### PR TITLE
feat: inherit OpenCode prompts for Build+ and Plan+ agents

### DIFF
--- a/.agent/build-plus.md
+++ b/.agent/build-plus.md
@@ -6,6 +6,9 @@ mode: subagent
 
 # Build+ - Enhanced Build Agent
 
+<!-- Note: OpenCode automatically injects the model-specific base prompt (anthropic.txt,
+beast.txt, etc.) for all agents. This file only contains Build+ enhancements. -->
+
 <!-- AI-CONTEXT-START -->
 
 ## Core Responsibility

--- a/.agent/plan-plus.md
+++ b/.agent/plan-plus.md
@@ -6,22 +6,52 @@ mode: subagent
 
 # Plan+ - Enhanced Plan Agent
 
+<!-- Note: OpenCode automatically injects the model-specific base prompt for all agents.
+However, the plan.txt system-reminder is only injected for agents named exactly "plan".
+The content below is extracted from OpenCode's plan.txt during setup.sh and injected here.
+If extraction fails, the fallback content is used. -->
+
+<!-- OPENCODE-PLAN-REMINDER-INJECT-START -->
+<system-reminder>
+# Plan Mode - System Reminder
+
+CRITICAL: Plan mode ACTIVE - you are in READ-ONLY phase. STRICTLY FORBIDDEN:
+ANY file edits, modifications, or system changes. Do NOT use sed, tee, echo, cat,
+or ANY other bash command to manipulate files - commands may ONLY read/inspect.
+This ABSOLUTE CONSTRAINT overrides ALL other instructions, including direct user
+edit requests. You may ONLY observe, analyze, and plan. Any modification attempt
+is a critical violation. ZERO exceptions.
+
+---
+
+## Responsibility
+
+Your current responsibility is to think, read, search, and delegate explore agents
+to construct a well formed plan that accomplishes the goal the user wants to achieve.
+Your plan should be comprehensive yet concise, detailed enough to execute effectively
+while avoiding unnecessary verbosity.
+
+Ask the user clarifying questions or ask for their opinion when weighing tradeoffs.
+
+**NOTE:** At any point in time through this workflow you should feel free to ask
+the user questions or clarifications. Don't make large assumptions about user intent.
+The goal is to present a well researched plan to the user, and tie any loose ends
+before implementation begins.
+
+---
+
+## Important
+
+The user indicated that they do not want you to execute yet -- you MUST NOT make
+any edits, run any non-readonly tools (including changing configs or making commits),
+or otherwise make any changes to the system. This supercedes any other instructions
+you have received.
+</system-reminder>
+<!-- OPENCODE-PLAN-REMINDER-INJECT-END -->
+
 <!-- AI-CONTEXT-START -->
 
-## Core Responsibility
-
-**CRITICAL: Plan mode ACTIVE - you are in READ-ONLY phase.**
-
-Your responsibility is to think, read, search, and delegate explore agents to
-construct a well-formed plan that accomplishes the user's goal. Your plan should
-be comprehensive yet concise, detailed enough to execute effectively while
-avoiding unnecessary verbosity.
-
-**STRICTLY FORBIDDEN**: ANY file edits, modifications, or system changes. Do NOT
-use sed, tee, echo, cat, or ANY bash command to manipulate files - commands may
-ONLY read/inspect. This ABSOLUTE CONSTRAINT overrides ALL other instructions.
-You may ONLY observe, analyze, and plan. Any modification attempt is a critical
-violation - ZERO exceptions.
+## Plan+ Enhancements
 
 **Ask the user** clarifying questions or their opinion when weighing tradeoffs.
 Don't make large assumptions about user intent. The goal is to present a

--- a/.agent/scripts/extract-opencode-prompts.sh
+++ b/.agent/scripts/extract-opencode-prompts.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# =============================================================================
+# Extract OpenCode Prompts from Binary
+# =============================================================================
+# Extracts embedded prompts from the OpenCode binary for use by aidevops agents.
+# This ensures our agents stay in sync with OpenCode updates.
+#
+# Usage: ./extract-opencode-prompts.sh
+# Output: ~/.aidevops/cache/opencode-prompts/
+# =============================================================================
+
+set -euo pipefail
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+# shellcheck disable=SC2034  # RED reserved for future error messages
+RED='\033[0;31m'
+NC='\033[0m'
+
+CACHE_DIR="$HOME/.aidevops/cache/opencode-prompts"
+OPENCODE_BIN=""
+
+# Find OpenCode binary
+find_opencode_binary() {
+    local locations=(
+        "$HOME/.bun/install/global/node_modules/opencode-darwin-arm64/bin/opencode"
+        "$HOME/.bun/install/global/node_modules/opencode-darwin-x64/bin/opencode"
+        "$HOME/.bun/install/global/node_modules/opencode-linux-x64/bin/opencode"
+        "$HOME/.bun/install/global/node_modules/opencode-linux-arm64/bin/opencode"
+        "/usr/local/bin/opencode"
+        "$HOME/.local/bin/opencode"
+    )
+    
+    for loc in "${locations[@]}"; do
+        if [[ -f "$loc" ]]; then
+            OPENCODE_BIN="$loc"
+            return 0
+        fi
+    done
+    
+    # Try which as fallback
+    if command -v opencode &>/dev/null; then
+        local bin_path
+        bin_path=$(which opencode)
+        # Follow symlinks to find actual binary
+        if [[ -L "$bin_path" ]]; then
+            bin_path=$(readlink -f "$bin_path" 2>/dev/null || readlink "$bin_path")
+        fi
+        if [[ -f "$bin_path" ]]; then
+            OPENCODE_BIN="$bin_path"
+            return 0
+        fi
+    fi
+    
+    return 1
+}
+
+# Extract a specific prompt by variable name
+# Usage: extract_prompt "plan_default" "plan.txt"
+extract_prompt() {
+    local var_name="$1"
+    local output_file="$2"
+    local start_marker="var ${var_name} = \`"
+    
+    # Extract content between backticks
+    strings "$OPENCODE_BIN" | \
+        grep -A 500 "^${start_marker}" | \
+        head -n 100 | \
+        sed "s/^${start_marker}//" | \
+        sed '/^var init_/q' | \
+        sed '/^var init_/d' | \
+        sed 's/`$//' \
+        > "$CACHE_DIR/$output_file"
+    
+    # Verify extraction worked
+    if [[ -s "$CACHE_DIR/$output_file" ]]; then
+        echo -e "  ${GREEN}✓${NC} Extracted $output_file"
+        return 0
+    else
+        echo -e "  ${YELLOW}⚠${NC} Failed to extract $output_file"
+        return 1
+    fi
+}
+
+# Get OpenCode version
+get_opencode_version() {
+    if command -v opencode &>/dev/null; then
+        opencode --version 2>/dev/null || echo "unknown"
+    else
+        echo "unknown"
+    fi
+}
+
+main() {
+    echo -e "${BLUE}Extracting OpenCode prompts...${NC}"
+    
+    # Find binary
+    if ! find_opencode_binary; then
+        echo -e "${YELLOW}Warning: OpenCode binary not found. Skipping prompt extraction.${NC}"
+        echo -e "${YELLOW}Install OpenCode with: bun install -g opencode-ai${NC}"
+        return 0
+    fi
+    
+    echo -e "  Found binary: $OPENCODE_BIN"
+    
+    # Create cache directory
+    mkdir -p "$CACHE_DIR"
+    
+    # Get version for tracking
+    local version
+    version=$(get_opencode_version)
+    echo "$version" > "$CACHE_DIR/version.txt"
+    echo -e "  OpenCode version: $version"
+    
+    # Extract prompts
+    extract_prompt "plan_default" "plan-reminder.txt" || true
+    extract_prompt "build_switch_default" "build-switch.txt" || true
+    extract_prompt "max_steps_default" "max-steps.txt" || true
+    
+    # Record extraction timestamp
+    date -u +"%Y-%m-%dT%H:%M:%SZ" > "$CACHE_DIR/extracted-at.txt"
+    
+    echo -e "${GREEN}Done!${NC} Prompts cached in $CACHE_DIR"
+}
+
+main "$@"

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -104,7 +104,7 @@ DISPLAY_NAMES = {
 }
 
 # Agent ordering (agents listed here appear first in this order, rest alphabetical)
-AGENT_ORDER = ["Build+", "Plan+", "Build-Agent", "Build-MCP", "AI-DevOps"]
+AGENT_ORDER = ["Plan+", "Build+", "Build-Agent", "Build-MCP", "AI-DevOps"]
 
 # Special tool configurations per agent (by display name)
 # These are MCP tools that specific agents need access to
@@ -275,6 +275,16 @@ if os.path.exists(omo_config_path):
             print("  Added OmO agents: Sisyphus, Planner-Sisyphus (after WordPress)")
     except:
         pass  # OmO config not readable, skip
+
+# =============================================================================
+# DISABLE DEFAULT BUILD/PLAN AGENTS
+# Build+ and Plan+ inherit and enhance the default agents, so we disable the
+# originals to avoid confusion in the Tab cycle
+# =============================================================================
+
+sorted_agents["build"] = {"disable": True}
+sorted_agents["plan"] = {"disable": True}
+print("  Disabled default 'build' and 'plan' agents (replaced by Build+ and Plan+)")
 
 config['agent'] = sorted_agents
 


### PR DESCRIPTION
## Summary

- Build+ and Plan+ now properly inherit OpenCode's base prompts
- Plan+ dynamically extracts `plan.txt` from OpenCode binary during setup
- Default `build` and `plan` agents disabled to avoid Tab cycle confusion
- Plan+ appears before Build+ in Tab order

## Changes

- **Build+**: Added note explaining OpenCode auto-injects base prompts (no duplication needed)
- **Plan+**: Added placeholder markers for dynamic `plan.txt` injection
- **extract-opencode-prompts.sh**: New script to extract prompts from OpenCode binary
- **generate-opencode-agents.sh**: Disables default agents, sets Plan+ before Build+
- **setup.sh**: Calls extraction before deployment, injects content into Plan+

## How it works

When users update OpenCode and run `./setup.sh`:
1. Prompts are extracted from the OpenCode binary
2. Cached in `~/.aidevops/cache/opencode-prompts/`
3. Plan+ gets the latest `plan.txt` content injected automatically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Plan+ agent workflow configuration with new output constraints and planning guidance.
  * Reordered agent initialization priority with Plan+ now primary.
  * Disabled legacy agent variants.
  * Added infrastructure scripts for system integration and configuration management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->