### PR TITLE
chore: rename /pr to /create-pr, improve /postflight for PR feedback

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -128,6 +128,7 @@ User confirms with numbered options to override if needed.
 3. Create branch and call `session-rename_sync_branch` tool to sync session name
 4. Record `started:` timestamp in TODO.md if matching task exists
 5. Read `workflows/git-workflow.md` for full workflow guidance
+6. **Monitor scope**: If work diverges from branch purpose, suggest new branch
 
 **Session tools** (OpenCode):
 - `session-rename_sync_branch` - Auto-sync session name with current git branch (preferred)

--- a/.agent/workflows/git-workflow.md
+++ b/.agent/workflows/git-workflow.md
@@ -81,6 +81,36 @@ OpenCode auto-generates session titles from the first prompt. To sync session na
 
 **Best Practice**: After creating a branch, call `session-rename_sync_branch` tool to sync session name.
 
+**Scope Monitoring** (during session):
+
+When work evolves significantly from the branch name/purpose:
+
+| Signal | Example | Action |
+|--------|---------|--------|
+| Different feature area | Branch is `chore/update-deps`, now adding new API endpoint | Suggest new branch |
+| Unrelated bug fix | Branch is `feature/user-auth`, found unrelated CSS bug | Suggest separate branch |
+| Scope expansion | Branch is `bugfix/login-timeout`, now refactoring entire auth system | Suggest `refactor/` branch |
+| Command/API rename | Branch is `chore/optimize-X`, now renaming unrelated commands | Suggest new branch |
+
+**When detected**, proactively offer:
+
+> This work (`{description}`) seems outside the scope of `{current-branch}` ({original-purpose}).
+>
+> 1. Create new branch `{suggested-type}/{suggested-name}` (recommended)
+> 2. Continue on current branch (if intentionally expanding scope)
+> 3. Stash changes and switch to existing branch
+
+**Stash workflow** (if user chooses option 1 or 3):
+
+```bash
+git stash --include-untracked -m "WIP: {description}"
+git checkout main && git pull origin main
+git checkout -b {type}/{description}
+git stash pop
+```
+
+**Self-check trigger**: Before each file edit, briefly consider: "Does this change align with `{branch-name}`?"
+
 **Decision Tree**:
 
 | Situation | Action |


### PR DESCRIPTION
## Summary

- Rename `/pr` → `/create-pr` for intuitive "don't make me think" UX
- Change `/postflight` to check code audit feedback on latest push (not just release verification)
- Add scope monitoring guidance so agents detect when work diverges from branch purpose

## Command Changes

| Before | After | Purpose |
|--------|-------|---------|
| `/pr` | `/create-pr` | Create PR with auto-generated title/description |
| `/pr` | (alias) | Still works, points to `/create-pr` |
| `/postflight` (release only) | `/postflight` (any push) | Check CodeRabbit, Codacy, SonarCloud feedback |

## Agent Improvements

- **Scope monitoring**: Agents now detect when work diverges from branch purpose
- **Proactive suggestions**: Offer to create new branch when scope creep detected
- **Stash workflow**: Guidance for safely switching branches mid-work

## Files Changed

- `.agent/scripts/generate-opencode-commands.sh` - Command definitions
- `.agent/workflows/git-workflow.md` - Scope monitoring guidance
- `.agent/AGENTS.md` - Pointer to scope monitoring

## Context

This PR was created after recognizing that work on `chore/optimize-mcp-token-usage` had evolved into command renaming - demonstrating the exact problem this PR solves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

**New Features**
- Added `/create-pr` command for creating pull requests from the current branch with auto-generated descriptions
- Added scope monitoring step to Git Workflow to detect scope divergence and suggest branch re-evaluation
- Enhanced workflow guidance with expanded steps for handling scope expansion scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->