### PR TITLE
fix: clarify pre-edit check is only for agents with edit tools

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -7,6 +7,9 @@ mode: subagent
 
 ## 🛑 MANDATORY: Pre-Edit Git Check
 
+> **Skip this section if you don't have Edit/Write/Bash tools** (e.g., Plan+ agent).
+> Read-only agents should proceed directly to responding to the user.
+
 **CRITICAL**: This check MUST be performed BEFORE any edit/write tool call.
 Failure to follow this workflow is a bug in the AI assistant's behavior.
 


### PR DESCRIPTION
## Summary

Plan+ was attempting to run the pre-edit git check on conversation start, even though it's a read-only agent without Bash/Edit tools.

## Problem

When starting a new Plan+ session, the agent would:
1. See "MANDATORY: Pre-Edit Git Check" 
2. Try to run `pre-edit-check.sh`
3. Fail because it doesn't have Bash tool access
4. Output "Checking git branch..." error instead of greeting

## Fix

Added explicit skip instruction at the top of the Pre-Edit Git Check section:

> **Skip this section if you don't have Edit/Write/Bash tools** (e.g., Plan+ agent).
> Read-only agents should proceed directly to responding to the user.