### PR TITLE
docs: add OpenCode Anthropic OAuth plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,37 @@ opencode auth login
 
 **Multi-account load balancing:** Add multiple Google accounts for automatic rate limit distribution and failover. See the [plugin documentation](https://github.com/NoeFabris/opencode-antigravity-auth) for model configuration.
 
+### OpenCode Anthropic OAuth Plugin
+
+The setup automatically installs the [opencode-anthropic-auth](https://github.com/anomalyco/opencode-anthropic-auth) plugin, enabling OAuth authentication for Claude Pro/Max accounts. This allows Claude subscribers to use OpenCode with zero API costs.
+
+**After setup, authenticate:**
+
+```bash
+opencode auth login
+# Select: Anthropic → Claude Pro/Max
+# Follow OAuth flow in browser
+```
+
+**Benefits:**
+
+- **Zero cost** for Claude Pro/Max subscribers (covered by subscription)
+- **Automatic token refresh** - No manual re-authentication needed
+- **Beta features enabled** - Extended thinking modes and latest features
+- **Three authentication methods:**
+  - Claude Pro/Max OAuth (recommended for subscribers)
+  - Create API Key via OAuth
+  - Manual API key entry
+
+**Available models:**
+
+All Anthropic models available to Pro/Max subscribers, including:
+- `claude-sonnet-4-20250514`
+- `claude-opus-4-5`
+- Extended thinking modes
+
+See the [plugin documentation](https://github.com/anomalyco/opencode-anthropic-auth) and `.agent/tools/opencode/opencode-anthropic-auth.md` for complete setup and troubleshooting.
+
 ### Oh-My-OpenCode Plugin (Optional)
 
 The setup offers to install [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode) - a complementary plugin that adds **coding productivity features**:


### PR DESCRIPTION
## Summary

Documents the opencode-anthropic-auth plugin in the README alongside the existing Antigravity OAuth plugin documentation.

## Changes

- Added new section "OpenCode Anthropic OAuth Plugin" after the Antigravity section
- Documented authentication methods (Claude Pro/Max OAuth, Create API Key, Manual)
- Highlighted zero-cost benefit for Claude subscribers
- Listed available models and beta features
- Linked to plugin repository and internal documentation

## Context

The setup.sh script already installs this plugin (v0.0.8), but it wasn't documented in the README. This brings the README up to date with the actual installation.

## Related

- Plugin repository: https://github.com/anomalyco/opencode-anthropic-auth
- Internal docs: `.agent/tools/opencode/opencode-anthropic-auth.md`
- Previous PR: #21 (updated plugin to v0.0.8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for OpenCode Anthropic OAuth Plugin, including setup instructions and authentication flow for Claude Pro/Max users, along with supported model information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->