### PR TITLE
chore: implement agent-review session improvements

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -31,9 +31,12 @@ If the script outputs "STOP - ON PROTECTED BRANCH", you MUST NOT proceed with ed
 > 1. Create worktree for suggested branch (recommended for parallel sessions)
 > 2. Create branch with checkout (switches current directory's branch)
 > 3. Use different branch name
-> 4. Stay on `main` (not recommended)
+> 4. Stay on `main` (docs-only acceptable, otherwise not recommended)
 
 3. **Do NOT proceed until user replies with 1, 2, 3, or 4**
+
+**When option 4 is acceptable**: Documentation-only changes (README, CHANGELOG, docs/), typo fixes, version bumps via release script.
+**When option 4 is NOT acceptable**: Any code changes, configuration files, scripts.
 4. If worktree (option 1): `~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{name}`
 5. If checkout (option 2): `git checkout -b {type}/{name}`
 6. After creating branch, call `session-rename_sync_branch` tool

--- a/.agent/workflows/postflight.md
+++ b/.agent/workflows/postflight.md
@@ -581,9 +581,24 @@ gh run list --workflow=postflight.yml --limit=1 --json conclusion,status -q '.[0
 
 If the postflight.yml workflow is still running or failed, the local postflight should NOT report success.
 
+## Worktree Cleanup
+
+After PR merge, clean up any worktrees used for the merged branch:
+
+```bash
+# Check for stale worktrees
+~/.aidevops/agents/scripts/worktree-helper.sh list
+
+# Auto-clean merged worktrees (detects squash merges too)
+~/.aidevops/agents/scripts/worktree-helper.sh clean
+```
+
+The `clean` command detects both traditional merges and squash merges (by checking for deleted remote branches).
+
 ## Related Workflows
 
 - `release.md` - Pre-release and release process
 - `code-review.md` - Code review guidelines
 - `changelog.md` - Changelog management
 - `version-bump.md` - Version management
+- `worktree.md` - Parallel branch development

--- a/.agent/workflows/pr.md
+++ b/.agent/workflows/pr.md
@@ -485,6 +485,47 @@ git add . && git commit -m "fix: Resolve merge conflicts"
 git push
 ```text
 
+## Handling Contradictory AI Feedback
+
+AI code reviewers (CodeRabbit, Codacy, etc.) may occasionally provide contradictory feedback. When this occurs:
+
+### Detection
+
+Contradictory feedback patterns:
+- Reviewer suggests change A → B, then later suggests B → A
+- Different reviewers suggest opposite changes
+- Feedback contradicts documented standards or actual runtime behavior
+
+### Resolution Process
+
+1. **Verify actual behavior**: Test the code to confirm what works
+   ```bash
+   # Example: Verify application name works in AppleScript
+   osascript -e 'tell application "iTerm" to get name'
+   osascript -e 'tell application "iTerm2" to get name'
+   ```
+
+2. **Check authoritative sources**: Documentation, official APIs, standards
+
+3. **Document your decision**: In PR comments, explain:
+   - What the contradictory feedback was
+   - How you verified the correct behavior
+   - Why you're dismissing the feedback
+
+4. **Proceed with merge**: If feedback is demonstrably incorrect, merge despite CHANGES_REQUESTED
+   ```bash
+   gh pr merge 123 --squash --delete-branch
+   ```
+
+### Example Comment
+
+```markdown
+Regarding the iTerm/iTerm2 naming: Both work in AppleScript. 
+The app bundle is `/Applications/iTerm.app` but responds to both 
+`tell application "iTerm"` and `tell application "iTerm2"`. 
+Keeping current code - no change needed.
+```
+
 ## Related Workflows
 
 - **Branch creation**: `workflows/branch.md`

--- a/.agent/workflows/worktree.md
+++ b/.agent/workflows/worktree.md
@@ -322,6 +322,25 @@ git branch -d feature/completed
 worktree-helper.sh clean
 ```
 
+### Squash Merge Detection
+
+The `clean` command detects merged branches two ways:
+
+1. **Traditional merges**: Uses `git branch --merged`
+2. **Squash merges**: Checks if remote branch was deleted after PR merge
+
+The command runs `git fetch --prune` automatically to detect deleted remote branches.
+
+**Manual cleanup** if needed:
+
+```bash
+# Force remove worktree
+git worktree remove --force ~/Git/myrepo-feature-old
+
+# Delete local branch
+git branch -D feature/old
+```
+
 ### 4. Don't Checkout Same Branch in Multiple Worktrees
 
 Git prevents this - each branch can only be checked out in one worktree:


### PR DESCRIPTION
## Summary

Improvements identified from @agent-review session analysis:

- **worktree-helper.sh**: Detect squash-merged branches by checking for deleted remote branches
- **pr.md**: Add "Handling Contradictory AI Feedback" section
- **worktree.md**: Document squash merge detection and manual cleanup
- **postflight.md**: Add worktree cleanup reminder after PR merge
- **AGENTS.md**: Clarify when direct-to-main is acceptable

## Changes

| File | Change |
|------|--------|
| `worktree-helper.sh` | Enhanced `cmd_clean()` to detect squash merges via `git show-ref` |
| `pr.md` | New section for handling contradictory AI reviewer feedback |
| `worktree.md` | Documented squash merge detection behavior |
| `postflight.md` | Added worktree cleanup reminder section |
| `AGENTS.md` | Clarified option 4 (docs-only acceptable) |

## Problem Solved

The `worktree-helper.sh clean` command previously only detected traditional merges via `git branch --merged`. Squash merges (common in GitHub PRs) weren't detected because they create new commits. Now the script also checks if the remote branch was deleted, which reliably indicates the PR was merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for branch selection criteria with conditional rules for documentation-only changes.
  * Added sections on worktree cleanup workflows, squash merge detection, and handling contradictory feedback in pull request processes.

* **Improvements**
  * Enhanced worktree cleanup logic to detect both traditional and squash merges, with automatic local branch deletion during cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->