### PR TITLE
feat(worktree): add session mapping and improve pre-edit check

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -10,10 +10,18 @@ mode: subagent
 > **Skip this section if you don't have Edit/Write/Bash tools** (e.g., Plan+ agent).
 > Read-only agents should proceed directly to responding to the user.
 
-**CRITICAL**: This check MUST be performed BEFORE any edit/write tool call.
+**CRITICAL**: This check MUST be performed BEFORE:
+- **Creating** new files
+- **Editing** existing files
+- **Writing** any content to disk
+- Using Edit, Write, or Bash tools that modify files
+
 Failure to follow this workflow is a bug in the AI assistant's behavior.
 
-**Self-check before editing**: Say "Checking git branch..." and run:
+**Trigger words requiring this check**: create, add, write, update, modify, change, fix, implement, refactor.
+If the user's request contains ANY of these, run the check FIRST.
+
+**Self-check before any file operation**: Say "Checking git branch..." and run:
 
 ```bash
 ~/.aidevops/agents/scripts/pre-edit-check.sh
@@ -39,6 +47,15 @@ If the script outputs "STOP - ON PROTECTED BRANCH", you MUST NOT proceed with ed
 6. After creating branch, call `session-rename_sync_branch` tool
 
 **Why this matters**: Skipping this check causes direct commits to `main`, bypassing PR review.
+
+**Self-verification**: Before ANY file operation, ask yourself:
+"Have I run pre-edit-check.sh in this session?" If unsure, run it NOW.
+
+**Working in aidevops framework**: When modifying aidevops agents, you work in TWO locations:
+- **Source**: `~/Git/aidevops/.agent/` - THIS is the git repo, check branch HERE
+- **Deployed**: `~/.aidevops/agents/` - copy of source, not a git repo
+
+Run pre-edit-check.sh in `~/Git/aidevops/` BEFORE any changes to either location.
 
 ---
 
@@ -153,6 +170,9 @@ User confirms with numbered options to override if needed.
 
 # List all worktrees
 ~/.aidevops/agents/scripts/worktree-helper.sh list
+
+# Find sessions for open worktrees
+~/.aidevops/agents/scripts/worktree-sessions.sh list
 
 # Clean up after merge
 ~/.aidevops/agents/scripts/worktree-helper.sh clean

--- a/.agent/scripts/worktree-sessions.sh
+++ b/.agent/scripts/worktree-sessions.sh
@@ -68,11 +68,10 @@ get_project_id() {
     echo ""
 }
 
-# Convert epoch milliseconds to readable date (portable)
-epoch_to_date() {
-    local epoch_ms="$1"
-    if [[ -n "$epoch_ms" ]] && [[ "$epoch_ms" != "null" ]]; then
-        local epoch_sec=$((epoch_ms/1000))
+# Convert epoch seconds to readable date (portable)
+epoch_sec_to_date() {
+    local epoch_sec="$1"
+    if [[ -n "$epoch_sec" ]] && [[ "$epoch_sec" != "0" ]]; then
         # Portable date formatting (BSD: -r, GNU: -d @)
         if date --version &>/dev/null 2>&1; then
             # GNU date
@@ -81,6 +80,16 @@ epoch_to_date() {
             # BSD date (macOS)
             date -r "$epoch_sec" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "unknown"
         fi
+    else
+        echo "unknown"
+    fi
+}
+
+# Convert epoch milliseconds to readable date (portable)
+epoch_to_date() {
+    local epoch_ms="$1"
+    if [[ -n "$epoch_ms" ]] && [[ "$epoch_ms" != "null" ]]; then
+        epoch_sec_to_date "$((epoch_ms/1000))"
     else
         echo "unknown"
     fi
@@ -290,7 +299,7 @@ cmd_list() {
                 
                 if [[ -n "$branch_start" ]]; then
                     local start_date
-                    start_date=$(date -r "$branch_start" "+%Y-%m-%d %H:%M" 2>/dev/null || echo "unknown")
+                    start_date=$(epoch_sec_to_date "$branch_start")
                     echo -e "    ${DIM}Branch started: $start_date${NC}"
                 fi
                 

--- a/.agent/workflows/worktree.md
+++ b/.agent/workflows/worktree.md
@@ -287,6 +287,35 @@ Tab 2: myrepo/feature/auth
 Tab 3: myrepo/bugfix/login
 ```
 
+### Session Recovery
+
+Find OpenCode sessions associated with worktrees:
+
+```bash
+# List worktrees with likely matching sessions
+~/.aidevops/agents/scripts/worktree-sessions.sh list
+
+# Interactive: select worktree and open in OpenCode
+~/.aidevops/agents/scripts/worktree-sessions.sh open
+```
+
+**How session matching works**:
+
+Sessions are scored based on:
+- **+100 pts**: Exact branch name in session title
+- **+80 pts**: Branch slug (e.g., `feature-auth`) in title
+- **+60 pts**: Branch name without type prefix in title
+- **+20 pts**: Each key term from branch name found in title
+- **+40 pts**: Session created within 1 hour of branch creation
+- **+20 pts**: Session created within 4 hours of branch creation
+
+**Confidence levels**:
+- **High (80+)**: Very likely the correct session
+- **Medium (40-79)**: Probably related
+- **Low (<40)**: Possible match
+
+**Best practice**: Always use `session-rename_sync_branch` tool after creating branches. This syncs the session name with the branch name, making future lookups reliable.
+
 ## Best Practices
 
 ### 1. Keep Main Worktree on Main


### PR DESCRIPTION
## Summary

- Add `worktree-sessions.sh` script to map git worktrees to likely OpenCode sessions
- Strengthen pre-edit git check based on agent-review feedback
- Document session recovery workflow

## Changes

### New: `worktree-sessions.sh`
Maps worktrees to OpenCode sessions using scoring based on:
- Session title matching branch names (+100 exact, +80 slug, +60 name)
- Temporal proximity to branch creation (+40 within 1hr, +20 within 4hr)
- Keyword matching from branch name (+20 per term)

Commands:
- `list` - Show worktrees with likely matching sessions
- `open` - Interactive selection to open worktree in OpenCode

### Improved: Pre-Edit Git Check (AGENTS.md)
Based on agent-review analysis of why the check was skipped:

1. **Expanded triggers** - Now explicitly lists "Creating new files" alongside editing
2. **Trigger words** - Added: create, add, write, update, modify, change, fix, implement, refactor
3. **Self-verification** - Added prompt: "Have I run pre-edit-check.sh in this session?"
4. **Dual-location clarity** - Explains source (`~/Git/aidevops/`) vs deployed (`~/.aidevops/agents/`)

### Updated: `workflows/worktree.md`
Added "Session Recovery" section documenting how to find and resume sessions for worktrees.

## Testing
- Created test worktree, verified session matching works
- Script correctly identifies sessions by title and temporal proximity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded pre-edit workflow with a detailed checklist, trigger-word guidance, self-check and self-verification steps, and manual/fallback branch workflow.
  * Clarified two-location (Source vs Deployed) workflow and added session-recovery guidance with confidence-based matching and best practices.
* **New Features**
  * Added a utility for discovering, scoring, listing, and opening git worktree sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->