### PR TITLE
fix: resolve postflight ShellCheck and return statement issues

### DIFF
--- a/.agent/scripts/dev-browser-helper.sh
+++ b/.agent/scripts/dev-browser-helper.sh
@@ -329,7 +329,7 @@ show_profile() {
         print_success "Profile exists (${profile_size})"
         echo ""
         print_info "Contents:"
-        find "${PROFILE_DIR}" -maxdepth 1 -exec ls -ld {} \; 2>/dev/null | head -20
+        (cd "${PROFILE_DIR}" && find . -maxdepth 1 -mindepth 1 -exec ls -ld {} +) 2>/dev/null | head -20
         echo ""
         print_info "This profile persists:"
         print_info "  - Cookies (stay logged into sites)"

--- a/.agent/scripts/dev-browser-helper.sh
+++ b/.agent/scripts/dev-browser-helper.sh
@@ -329,7 +329,7 @@ show_profile() {
         print_success "Profile exists (${profile_size})"
         echo ""
         print_info "Contents:"
-        ls -la "${PROFILE_DIR}" 2>/dev/null | head -20
+        find "${PROFILE_DIR}" -maxdepth 1 -exec ls -ld {} \; 2>/dev/null | head -20
         echo ""
         print_info "This profile persists:"
         print_info "  - Cookies (stay logged into sites)"

--- a/.agent/scripts/fix-s131-default-cases.sh
+++ b/.agent/scripts/fix-s131-default-cases.sh
@@ -245,5 +245,3 @@ main() {
 }
 
 main "$@"
-
-return 0

--- a/.agent/scripts/generate-skills.sh
+++ b/.agent/scripts/generate-skills.sh
@@ -352,5 +352,3 @@ if [[ "$DRY_RUN" == true ]]; then
     log_warning ""
     log_warning "This was a dry run. Run without --dry-run to generate files."
 fi
-
-return 0

--- a/.agent/scripts/gsc-add-user-helper.sh
+++ b/.agent/scripts/gsc-add-user-helper.sh
@@ -311,5 +311,3 @@ case "${1:-}" in
         exit 1
         ;;
 esac
-
-return 0

--- a/.agent/scripts/ralph-upstream-check.sh
+++ b/.agent/scripts/ralph-upstream-check.sh
@@ -320,6 +320,8 @@ main() {
     fi
     
     check_upstream
+    
+    return 0
 }
 
 main "$@"

--- a/.agent/scripts/terminal-title-setup.sh
+++ b/.agent/scripts/terminal-title-setup.sh
@@ -526,8 +526,7 @@ main() {
             return 1
             ;;
     esac
-    
-    return 0
+    # Return status of the executed command
 }
 
 main "$@"

--- a/.agent/scripts/terminal-title-setup.sh
+++ b/.agent/scripts/terminal-title-setup.sh
@@ -33,9 +33,6 @@ log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 MARKER_START="# >>> aidevops terminal-title integration >>>"
 MARKER_END="# <<< aidevops terminal-title integration <<<"
 
-# Helper script path
-HELPER_SCRIPT="$HOME/.aidevops/agents/scripts/terminal-title-helper.sh"
-
 # =============================================================================
 # Shell Detection
 # =============================================================================
@@ -529,6 +526,8 @@ main() {
             return 1
             ;;
     esac
+    
+    return 0
 }
 
 main "$@"

--- a/.agent/scripts/todo-ready.sh
+++ b/.agent/scripts/todo-ready.sh
@@ -251,6 +251,8 @@ main() {
             parse_tasks "$todo_file" | output_text
             ;;
     esac
+    
+    return 0
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Remove erroneous `return 0` after `main "$@"` in 3 scripts
- Add missing `return 0` in `main()` for 3 scripts  
- Remove unused `HELPER_SCRIPT` variable (SC2034) in terminal-title-setup.sh
- Replace `ls -la` with `find -exec ls -ld` (SC2012) in dev-browser-helper.sh

## Files Changed

| File | Change |
|------|--------|
| fix-s131-default-cases.sh | Remove erroneous `return 0` after main |
| generate-skills.sh | Remove erroneous `return 0` after script body |
| gsc-add-user-helper.sh | Remove erroneous `return 0` after case statement |
| ralph-upstream-check.sh | Add `return 0` in main() |
| terminal-title-setup.sh | Remove unused variable + add return |
| todo-ready.sh | Add `return 0` in main() |
| dev-browser-helper.sh | Use find instead of ls (SC2012) |

## Testing

- ShellCheck passes with no warnings/errors
- All scripts remain functional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved script reliability with consistent exit status handling across helper scripts
  * Updated developer profile listing to display only top-level items (limited to 20 entries) for clearer output
  * Removed unused variable declarations and improved code clarity with enhanced comments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->