### PR TITLE
feat: add code-simplifier subagent and enforce worktree-first workflow

### DIFF
--- a/.agent/scripts/commands/code-simplifier.md
+++ b/.agent/scripts/commands/code-simplifier.md
@@ -1,0 +1,86 @@
+---
+description: Simplify and refine code for clarity, consistency, and maintainability
+agent: Build+
+mode: subagent
+---
+
+Simplify and refine code for clarity, consistency, and maintainability while preserving all functionality.
+
+Target: $ARGUMENTS
+
+## Quick Reference
+
+- **Purpose**: Simplify code without changing functionality
+- **Priority**: Clarity over brevity
+- **Scope**: Recently modified code unless target specified
+
+## Process
+
+1. **Identify scope**: Use $ARGUMENTS if provided, otherwise find recently modified files
+2. **Read the code-simplifier agent**: `tools/code-review/code-simplifier.md`
+3. **Apply refinements** following the agent's principles
+4. **Verify** functionality is preserved
+5. **Report** changes made
+
+## Scope Detection
+
+If no target specified ($ARGUMENTS is empty):
+
+```bash
+# Find recently modified files (last commit or staged)
+git diff --name-only HEAD~1
+git diff --name-only --staged
+```
+
+If target specified:
+- Directory path: Simplify all code files in directory
+- File path: Simplify specific file
+- `--all`: Review entire codebase (use sparingly)
+
+## Refinement Principles
+
+From `tools/code-review/code-simplifier.md`:
+
+1. **Preserve Functionality**: Never change what code does
+2. **Apply Project Standards**: Follow CLAUDE.md/AGENTS.md conventions
+3. **Enhance Clarity**: Reduce complexity, eliminate redundancy
+4. **Maintain Balance**: Avoid over-simplification
+5. **Focus Scope**: Only refine recently modified code unless instructed otherwise
+
+## Key Patterns to Fix
+
+- Nested ternaries -> switch/if-else chains
+- Dense one-liners -> readable multi-line
+- Redundant abstractions -> direct code
+- Obvious comments -> remove
+- Inconsistent naming -> standardize
+
+## Output Format
+
+```text
+Code Simplification Report
+==========================
+
+Files reviewed: {count}
+Changes made: {count}
+
+{file1}:
+  - Line {n}: {before} -> {after}
+  - Line {m}: Removed redundant {description}
+
+{file2}:
+  - Line {n}: Simplified nested ternary to if/else
+
+Functionality: Preserved
+```
+
+## Integration
+
+After simplification, suggest:
+
+```text
+Next steps:
+1. Run /linters-local to validate
+2. Review changes with git diff
+3. Commit if satisfied
+```

--- a/.agent/scripts/pre-edit-check.sh
+++ b/.agent/scripts/pre-edit-check.sh
@@ -51,20 +51,38 @@ if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
     echo "  hotfix/description   - Urgent production fixes"
     echo "  refactor/description - Code restructuring"
     echo ""
-    echo "To create a branch:"
+    echo -e "${BOLD}Create a worktree (keeps main repo on main):${NC}"
     echo ""
-    echo "  Option A - Worktree (recommended for parallel sessions):"
     echo "    ~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{description}"
     echo "    cd ../{repo}-{type}-{description}"
     echo ""
-    echo "  Option B - Traditional checkout:"
-    echo "    git checkout -b {type}/{description}"
+    echo -e "${YELLOW}Why worktrees? The main repo directory should ALWAYS stay on main.${NC}"
+    echo -e "${YELLOW}Using 'git checkout -b' here leaves the repo on a feature branch,${NC}"
+    echo -e "${YELLOW}which breaks parallel sessions and causes merge conflicts.${NC}"
     echo ""
     echo -e "${RED}DO NOT proceed with edits until on a feature branch.${NC}"
     echo ""
     exit 1
 else
-    echo -e "${GREEN}OK${NC} - On branch: ${BOLD}$current_branch${NC}"
+    # Check if this is the main repo directory (not a worktree) on a feature branch
+    # This is a warning - the main repo should stay on main
+    git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
+    git_dir=$(git rev-parse --git-dir 2>/dev/null)
+    
+    # If git-dir equals git-common-dir, this is the main worktree (not a linked worktree)
+    is_main_worktree=false
+    if [[ "$git_dir" == "$git_common_dir" ]] || [[ "$git_dir" == ".git" ]]; then
+        is_main_worktree=true
+    fi
+    
+    if [[ "$is_main_worktree" == "true" ]]; then
+        echo -e "${YELLOW}WARNING${NC} - Main repo is on feature branch: ${BOLD}$current_branch${NC}"
+        echo -e "${YELLOW}The main repo directory should stay on 'main' for parallel safety.${NC}"
+        echo -e "${YELLOW}Consider using a worktree instead, or switch back to main when done.${NC}"
+        echo ""
+    else
+        echo -e "${GREEN}OK${NC} - On branch: ${BOLD}$current_branch${NC}"
+    fi
     
     # Sync terminal tab title with repo/branch (silent, non-blocking)
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit

--- a/.agent/tools/code-review/code-simplifier.md
+++ b/.agent/tools/code-review/code-simplifier.md
@@ -1,0 +1,174 @@
+---
+description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: true
+  grep: true
+  webfetch: false
+  task: true
+---
+
+# Code Simplifier
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Simplify and refine code for clarity, consistency, and maintainability
+- **Trigger**: `/code-simplifier` or after significant code changes
+- **Scope**: Recently modified code unless instructed otherwise
+- **Priority**: Clarity over brevity - explicit code beats compact code
+- **Rule**: Never change functionality - only improve how code is written
+
+**Key Principles**:
+- Preserve exact functionality
+- Apply project standards from CLAUDE.md/AGENTS.md
+- Reduce complexity and nesting
+- Eliminate redundancy
+- Avoid nested ternaries - use switch/if-else
+- Remove obvious comments
+
+<!-- AI-CONTEXT-END -->
+
+## What This Agent Does
+
+You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior.
+
+Based on the [Claude Code code-simplifier plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier).
+
+## Refinement Process
+
+1. **Identify** recently modified code sections
+2. **Analyze** for opportunities to improve elegance and consistency
+3. **Apply** project-specific best practices and coding standards
+4. **Ensure** all functionality remains unchanged
+5. **Verify** the refined code is simpler and more maintainable
+6. **Document** only significant changes that affect understanding
+
+## Core Principles
+
+### 1. Preserve Functionality
+
+Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
+
+### 2. Apply Project Standards
+
+Follow established coding standards including:
+
+- Use ES modules with proper import sorting and extensions
+- Prefer `function` keyword over arrow functions
+- Use explicit return type annotations for top-level functions
+- Follow proper React component patterns with explicit Props types
+- Use proper error handling patterns (avoid try/catch when possible)
+- Maintain consistent naming conventions
+
+For shell scripts, follow aidevops standards:
+
+- Use `local var="$1"` pattern for parameters
+- Explicit return statements
+- Constants for repeated strings (3+ occurrences)
+- SC2155 compliance: separate `local var` and `var=$(command)`
+
+### 3. Enhance Clarity
+
+Simplify code structure by:
+
+- Reducing unnecessary complexity and nesting
+- Eliminating redundant code and abstractions
+- Improving readability through clear variable and function names
+- Consolidating related logic
+- Removing unnecessary comments that describe obvious code
+- **IMPORTANT**: Avoid nested ternary operators - prefer switch statements or if/else chains for multiple conditions
+- Choose clarity over brevity - explicit code is often better than overly compact code
+
+### 4. Maintain Balance
+
+Avoid over-simplification that could:
+
+- Reduce code clarity or maintainability
+- Create overly clever solutions that are hard to understand
+- Combine too many concerns into single functions or components
+- Remove helpful abstractions that improve code organization
+- Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
+- Make the code harder to debug or extend
+
+### 5. Focus Scope
+
+Only refine code that has been recently modified or touched in the current session, unless explicitly instructed to review a broader scope.
+
+## Usage
+
+### Slash Command
+
+```bash
+/code-simplifier              # Simplify recently modified code
+/code-simplifier src/         # Simplify code in specific directory
+/code-simplifier --all        # Review entire codebase (use sparingly)
+```
+
+### Proactive Mode
+
+This agent can operate autonomously and proactively, refining code immediately after it's written or modified without requiring explicit requests. Enable by including in your workflow:
+
+```text
+After completing code changes, run @code-simplifier to refine.
+```
+
+## Examples
+
+### Before: Nested Ternaries
+
+```javascript
+const status = isLoading ? 'loading' : hasError ? 'error' : isComplete ? 'complete' : 'idle';
+```
+
+### After: Clear Switch Statement
+
+```javascript
+function getStatus(isLoading, hasError, isComplete) {
+  if (isLoading) return 'loading';
+  if (hasError) return 'error';
+  if (isComplete) return 'complete';
+  return 'idle';
+}
+```
+
+### Before: Dense One-Liner
+
+```javascript
+const result = data.filter(x => x.active).map(x => x.name).reduce((a, b) => a + ', ' + b, '').slice(2);
+```
+
+### After: Readable Steps
+
+```javascript
+const activeItems = data.filter(item => item.active);
+const names = activeItems.map(item => item.name);
+const result = names.join(', ');
+```
+
+## Integration with Quality Workflow
+
+Code simplification fits into the quality workflow:
+
+```text
+Development → @code-simplifier (refine)
+     ↓
+Pre-commit → /linters-local (validate)
+     ↓
+PR Review → /pr (full review)
+```
+
+Run code-simplifier before linting to catch style issues early.
+
+## Related Agents
+
+| Agent | Purpose |
+|-------|---------|
+| `code-standards.md` | Reference quality rules |
+| `best-practices.md` | AI-assisted coding patterns |
+| `auditing.md` | Security and quality audits |

--- a/.agent/workflows/git-workflow.md
+++ b/.agent/workflows/git-workflow.md
@@ -61,9 +61,9 @@ When running multiple OpenCode sessions on the same repo:
 | Starting new work | Always create a new branch first |
 | **Multiple parallel sessions** | **Use git worktrees** (see below) |
 
-**Git Worktrees for Parallel Work** (RECOMMENDED):
+**Git Worktrees for Parallel Work** (DEFAULT):
 
-For true parallel development without branch conflicts, use git worktrees:
+**Core principle**: The main repo directory (`~/Git/{repo}/`) should ALWAYS stay on `main`. All feature work happens in worktree directories.
 
 ```bash
 # Create separate working directory for a branch
@@ -76,6 +76,8 @@ For true parallel development without branch conflicts, use git worktrees:
 # Each terminal/session works in its own directory
 # No branch switching affects other sessions
 ```
+
+**Why this matters**: If the main repo is left on a feature branch, the next session inherits that state. This causes "local changes would be overwritten" errors and breaks parallel workflows.
 
 See `workflows/worktree.md` for full worktree workflow.
 
@@ -277,16 +279,18 @@ grep -A 5 "^### \[" todo/PLANS.md | grep -i "{user_request_keywords}"
 
 **If on `main` branch**, auto-select best match and offer override:
 
-> On `main`. Creating `feature/{best-match-name}` (from {source}).
+> On `main`. Creating worktree for `feature/{best-match-name}` (from {source}).
 >
 > [Enter] to confirm, or:
 > 1. Use different name
-> 2. Continue on `main` (not recommended)
+> 2. Continue on `main` (docs-only, not recommended for code)
 
 Where `{source}` is one of:
 - "TODO.md" - matched a task
 - "PLANS.md" - matched an active plan
 - "your request" - derived from conversation
+
+**Note**: Always use worktrees, not `git checkout -b`. The main repo directory must stay on `main`.
 
 **If existing branch matches**, auto-select it:
 

--- a/.agent/workflows/worktree.md
+++ b/.agent/workflows/worktree.md
@@ -21,6 +21,7 @@ tools:
 - **Purpose**: Enable parallel work on multiple branches without conflicts
 - **Problem solved**: Branch switching affects all terminal tabs/sessions
 - **Solution**: Separate working directories, each on its own branch
+- **Core principle**: Main repo (`~/Git/{repo}/`) ALWAYS stays on `main`
 
 **Key Commands**:
 
@@ -318,15 +319,23 @@ Sessions are scored based on:
 
 ## Best Practices
 
-### 1. Keep Main Worktree on Main
+### 1. ALWAYS Keep Main Repo on Main (Critical)
 
 ```bash
-# Main repo directory stays on main branch
-~/Git/myrepo/  → main branch (reference, PRs, releases)
+# Main repo directory MUST stay on main branch
+~/Git/myrepo/  → main branch ONLY (never checkout feature branches here)
 
 # All feature work in linked worktrees
 ~/Git/myrepo-feature-*/  → feature branches
 ```
+
+**Why this is critical**: If the main repo is left on a feature branch:
+- Next session inherits wrong branch state
+- Uncommitted changes block branch switches
+- "Your local changes would be overwritten" errors occur
+- Parallel workflow assumptions break
+
+**Never use `git checkout -b` in the main repo directory.** Always use worktrees.
 
 ### 2. Name Worktrees Consistently
 


### PR DESCRIPTION
## Summary

- Add `/code-simplifier` slash command for code clarity improvements
- Add multi-worktree awareness to Ralph loop helper
- Enforce worktree-first workflow to prevent parallel session conflicts

## New Features

### Code Simplifier Subagent

Based on the [Claude Code code-simplifier plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier).

- `/code-simplifier [target]` - Simplify recently modified code
- Preserves functionality while improving clarity
- Applies project standards from CLAUDE.md/AGENTS.md

### Ralph Loop Multi-Worktree Awareness

- `ralph-loop-helper.sh status --all` - Scan all worktrees for active loops
- Warning when starting a loop if other worktrees have active loops
- `worktree-sessions.sh list` now shows Ralph loop status per worktree

### Workflow Improvements (from agent-review)

**Problem solved**: Main repo left on feature branch with uncommitted changes, blocking parallel sessions.

**Changes**:
- Remove checkout option from pre-edit prompt (worktrees only)
- Add warning when main repo is on feature branch
- Add "Main repo principle" - `~/Git/{repo}/` stays on `main`
- Add session cleanup checklist before ending
- Update git-workflow.md and worktree.md with enforcement

## Files Changed

| File | Change |
|------|--------|
| `scripts/commands/code-simplifier.md` | New slash command |
| `tools/code-review/code-simplifier.md` | New subagent |
| `scripts/ralph-loop-helper.sh` | Multi-worktree status, warnings |
| `scripts/worktree-sessions.sh` | Ralph loop status in list |
| `AGENTS.md` | Updated pre-edit check, quality workflow |
| `pre-edit-check.sh` | Warn on feature branch in main repo |
| `git-workflow.md` | Worktree as default |
| `worktree.md` | Main repo principle |