### PR TITLE
fix(sonarcloud): add missing default cases to case statements

### DIFF
--- a/.agent/scripts/quality-loop-helper.sh
+++ b/.agent/scripts/quality-loop-helper.sh
@@ -816,6 +816,9 @@ pr_review_loop() {
                     fi
                 fi
                 ;;
+            *)
+                print_warning "Unknown PR status: $status"
+                ;;
         esac
         
         iteration=$(increment_iteration)

--- a/.agent/scripts/terminal-title-helper.sh
+++ b/.agent/scripts/terminal-title-helper.sh
@@ -99,6 +99,9 @@ detect_terminal() {
             echo "hyper"
             return 0
             ;;
+        *)
+            # Not a known TERM_PROGRAM, continue to TERM check
+            ;;
     esac
     
     # Check by TERM variable for other terminals
@@ -106,6 +109,9 @@ detect_terminal() {
         xterm*|rxvt*|screen*|tmux*|alacritty|kitty*)
             echo "compatible"
             return 0
+            ;;
+        *)
+            # Not a known TERM, continue to other checks
             ;;
     esac
     


### PR DESCRIPTION
## Summary

- Fix 3 critical SonarCloud S131 violations (missing default cases)

## Changes

| File | Fix |
|------|-----|
| `quality-loop-helper.sh` | Add default case for unknown PR status |
| `terminal-title-helper.sh` | Add 2 default cases for terminal detection |

## SonarCloud Rule

**S131**: Add a default case (*) to handle unexpected values.

All `case` statements in shell scripts should have a `*)` default handler to catch unexpected values.

## Testing

- Verified bash syntax passes
- Verified no remaining missing default cases in `.agent/scripts/`