### PR TITLE
chore: implement agent-review improvements

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -118,7 +118,7 @@ User confirms with numbered options to override if needed.
 | `todo/tasks/prd-*.md` | Product requirement documents |
 | `todo/tasks/tasks-*.md` | Implementation task lists |
 
-**Slash commands:** `/save-todo`, `/plan-status`, `/create-prd`, `/generate-tasks`, `/log-time-spent`, `/ready`, `/sync-beads`, `/remember`, `/recall`, `/session-review`, `/full-loop`
+**Slash commands:** `/save-todo`, `/plan-status`, `/create-prd`, `/generate-tasks`, `/log-time-spent`, `/ready`, `/sync-beads`, `/remember`, `/recall`, `/session-review`, `/full-loop`, `/code-simplifier`
 
 **Time tracking format:**
 

--- a/.agent/scripts/generate-opencode-commands.sh
+++ b/.agent/scripts/generate-opencode-commands.sh
@@ -1525,6 +1525,36 @@ EOF
 echo -e "  ${GREEN}✓${NC} Created /recall command"
 
 # =============================================================================
+# AUTO-DISCOVERED COMMANDS FROM scripts/commands/
+# =============================================================================
+# Commands in .agent/scripts/commands/*.md are auto-generated
+# Each file should have frontmatter with description and agent
+# This prevents needing to manually add new commands to this script
+
+COMMANDS_DIR="$HOME/.aidevops/agents/scripts/commands"
+
+if [[ -d "$COMMANDS_DIR" ]]; then
+    for cmd_file in "$COMMANDS_DIR"/*.md; do
+        [[ -f "$cmd_file" ]] || continue
+        
+        cmd_name=$(basename "$cmd_file" .md)
+        
+        # Skip SKILL.md (not a command)
+        [[ "$cmd_name" == "SKILL" ]] && continue
+        
+        # Skip if already manually defined (avoid duplicates)
+        if [[ -f "$OPENCODE_COMMAND_DIR/$cmd_name.md" ]]; then
+            continue
+        fi
+        
+        # Copy command file directly (it already has proper frontmatter)
+        cp "$cmd_file" "$OPENCODE_COMMAND_DIR/$cmd_name.md"
+        ((command_count++))
+        echo -e "  ${GREEN}✓${NC} Auto-discovered /$cmd_name command"
+    done
+fi
+
+# =============================================================================
 # SUMMARY
 # =============================================================================
 

--- a/.agent/workflows/ralph-loop.md
+++ b/.agent/workflows/ralph-loop.md
@@ -272,6 +272,46 @@ head -10 .claude/ralph-loop.local.md
 test -f .claude/ralph-loop.local.md && echo "Active" || echo "Not active"
 ```
 
+## Multi-Worktree Awareness
+
+When working with git worktrees, Ralph loops are aware of parallel sessions.
+
+### Check All Worktrees
+
+```bash
+# Show loops across all worktrees
+~/.aidevops/agents/scripts/ralph-loop-helper.sh status --all
+```
+
+Output shows:
+- Branch name for each active loop
+- Current iteration and max
+- Which worktree is current
+
+### Parallel Loop Warnings
+
+When starting a new loop, the helper automatically checks for other active loops:
+
+```text
+Other active Ralph loops detected:
+  - feature/other-task (iteration 5)
+
+Use 'ralph-loop-helper.sh status --all' to see details
+```
+
+This helps prevent confusion when multiple AI sessions are running in parallel.
+
+### Integration with worktree-sessions.sh
+
+The worktree session mapper shows Ralph loop status:
+
+```bash
+# List all worktrees with their sessions and loop status
+~/.aidevops/agents/scripts/worktree-sessions.sh list
+```
+
+Output includes a "Ralph loop: iteration X/Y" line for worktrees with active loops.
+
 ## CI/CD Wait Time Optimization
 
 When using Ralph loops with PR review workflows, the loop uses adaptive timing based on observed CI/CD service completion times.


### PR DESCRIPTION
## Summary

Implements improvements identified by `/agent-review` from the previous session.

## Changes

### 1. Auto-Discovery for OpenCode Commands (High Priority)

Commands in `.agent/scripts/commands/*.md` are now auto-discovered by the generator script. This prevents needing to manually add new commands.

```bash
# New commands just need a file in scripts/commands/
# They'll be auto-discovered on next setup.sh run
```

### 2. Multi-Worktree Documentation (Medium Priority)

Added documentation to `ralph-loop.md` for:
- `status --all` - Check loops across all worktrees
- Parallel loop warnings when starting new loops
- Integration with `worktree-sessions.sh`

### 3. Slash Commands List (Low Priority)

Added `/code-simplifier` to the slash commands list in AGENTS.md.

## Files Changed

| File | Change |
|------|--------|
| `generate-opencode-commands.sh` | Auto-discovery loop for `scripts/commands/*.md` |
| `workflows/ralph-loop.md` | Multi-worktree awareness section |
| `AGENTS.md` | Added `/code-simplifier` to slash commands |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "/code-simplifier" slash command.
  * Enabled auto-discovery of commands from a dedicated directory to prevent duplicates and streamline command management.

* **Documentation**
  * Added Multi-Worktree Awareness documentation covering monitoring commands, parallel loop scenarios, and worktree integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->