### PR TITLE
feat(loops): implement v2 architecture with fresh context per iteration

### DIFF
--- a/.agent/scripts/loop-common.sh
+++ b/.agent/scripts/loop-common.sh
@@ -1,0 +1,702 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Loop Common - Shared Infrastructure for All Loop Components
+# =============================================================================
+# Provides shared functions for ralph-loop, quality-loop, and full-loop:
+# - State management (JSON-based, survives session restart)
+# - Re-anchor prompt generation
+# - Receipt verification
+# - Memory integration
+#
+# Based on flow-next architecture: fresh context per iteration, file I/O as state
+# Reference: https://github.com/gmickel/gmickel-claude-marketplace/tree/main/plugins/flow-next
+#
+# Usage:
+#   source ~/.aidevops/agents/scripts/loop-common.sh
+#
+# Author: AI DevOps Framework
+# =============================================================================
+
+set -euo pipefail
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+readonly LOOP_STATE_DIR="${LOOP_STATE_DIR:-.claude}"
+readonly LOOP_STATE_FILE="${LOOP_STATE_DIR}/loop-state.json"
+readonly LOOP_RECEIPTS_DIR="${LOOP_STATE_DIR}/receipts"
+readonly LOOP_REANCHOR_FILE="${LOOP_STATE_DIR}/re-anchor.md"
+
+# Colors (exported for use by sourcing scripts)
+export LC_RED='\033[0;31m'
+export LC_GREEN='\033[0;32m'
+export LC_YELLOW='\033[1;33m'
+export LC_BLUE='\033[0;34m'
+export LC_CYAN='\033[0;36m'
+export LC_BOLD='\033[1m'
+export LC_NC='\033[0m'
+
+# =============================================================================
+# Logging Functions
+# =============================================================================
+
+loop_log_error() {
+    local message="$1"
+    echo -e "${LC_RED}[loop] Error:${LC_NC} ${message}" >&2
+    return 0
+}
+
+loop_log_success() {
+    local message="$1"
+    echo -e "${LC_GREEN}[loop]${LC_NC} ${message}"
+    return 0
+}
+
+loop_log_warn() {
+    local message="$1"
+    echo -e "${LC_YELLOW}[loop]${LC_NC} ${message}"
+    return 0
+}
+
+loop_log_info() {
+    local message="$1"
+    echo -e "${LC_BLUE}[loop]${LC_NC} ${message}"
+    return 0
+}
+
+loop_log_step() {
+    local message="$1"
+    echo -e "${LC_CYAN}[loop]${LC_NC} ${message}"
+    return 0
+}
+
+# =============================================================================
+# State Management (JSON-based)
+# =============================================================================
+
+# Initialize loop state directory
+# Arguments: none
+# Returns: 0
+loop_init_state_dir() {
+    mkdir -p "$LOOP_STATE_DIR"
+    mkdir -p "$LOOP_RECEIPTS_DIR"
+    return 0
+}
+
+# Create new loop state
+# Arguments:
+#   $1 - loop_type (ralph|preflight|pr-review|postflight|full)
+#   $2 - prompt/task description
+#   $3 - max_iterations (default: 50)
+#   $4 - completion_promise (default: TASK_COMPLETE)
+#   $5 - task_id (optional)
+# Returns: 0 on success, 1 on error
+loop_create_state() {
+    local loop_type="$1"
+    local prompt="$2"
+    local max_iterations="${3:-50}"
+    local completion_promise="${4:-TASK_COMPLETE}"
+    local task_id="${5:-}"
+    
+    loop_init_state_dir
+    
+    # Generate task_id if not provided
+    if [[ -z "$task_id" ]]; then
+        task_id="loop_$(date +%Y%m%d%H%M%S)"
+    fi
+    
+    local started_at
+    started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    
+    # Create JSON state file
+    cat > "$LOOP_STATE_FILE" << EOF
+{
+  "loop_type": "$loop_type",
+  "prompt": $(echo "$prompt" | jq -Rs .),
+  "iteration": 1,
+  "max_iterations": $max_iterations,
+  "phase": "task",
+  "task_id": "$task_id",
+  "started_at": "$started_at",
+  "last_iteration_at": "$started_at",
+  "completion_promise": "$completion_promise",
+  "attempts": {},
+  "receipts": [],
+  "blocked_tasks": [],
+  "active": true
+}
+EOF
+    
+    loop_log_success "Loop state created: $LOOP_STATE_FILE"
+    return 0
+}
+
+# Read loop state value
+# Arguments:
+#   $1 - JSON key path (e.g., ".iteration", ".task_id")
+# Returns: 0
+# Output: Value to stdout
+loop_get_state() {
+    local key="$1"
+    
+    if [[ ! -f "$LOOP_STATE_FILE" ]]; then
+        echo ""
+        return 0
+    fi
+    
+    jq -r "$key // empty" "$LOOP_STATE_FILE" 2>/dev/null || echo ""
+    return 0
+}
+
+# Update loop state value
+# Arguments:
+#   $1 - JSON key path (e.g., ".iteration")
+#   $2 - New value (will be auto-typed: number, string, bool)
+# Returns: 0 on success, 1 on error
+loop_set_state() {
+    local key="$1"
+    local value="$2"
+    
+    if [[ ! -f "$LOOP_STATE_FILE" ]]; then
+        loop_log_error "No active loop state"
+        return 1
+    fi
+    
+    local temp_file
+    temp_file=$(mktemp)
+    
+    # Determine value type and update
+    if [[ "$value" =~ ^[0-9]+$ ]]; then
+        # Integer
+        jq "$key = $value" "$LOOP_STATE_FILE" > "$temp_file"
+    elif [[ "$value" == "true" || "$value" == "false" ]]; then
+        # Boolean
+        jq "$key = $value" "$LOOP_STATE_FILE" > "$temp_file"
+    elif [[ "$value" == "null" ]]; then
+        # Null
+        jq "$key = null" "$LOOP_STATE_FILE" > "$temp_file"
+    else
+        # String
+        jq "$key = \"$value\"" "$LOOP_STATE_FILE" > "$temp_file"
+    fi
+    
+    mv "$temp_file" "$LOOP_STATE_FILE"
+    return 0
+}
+
+# Increment iteration counter
+# Arguments: none
+# Returns: 0
+# Output: New iteration number
+loop_increment_iteration() {
+    local current
+    current=$(loop_get_state ".iteration")
+    local next=$((current + 1))
+    
+    loop_set_state ".iteration" "$next"
+    loop_set_state ".last_iteration_at" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+    
+    echo "$next"
+    return 0
+}
+
+# Check if loop is active
+# Arguments: none
+# Returns: 0 if active, 1 if not
+loop_is_active() {
+    if [[ ! -f "$LOOP_STATE_FILE" ]]; then
+        return 1
+    fi
+    
+    local active
+    active=$(loop_get_state ".active")
+    [[ "$active" == "true" ]]
+}
+
+# Cancel loop
+# Arguments: none
+# Returns: 0
+loop_cancel() {
+    if [[ -f "$LOOP_STATE_FILE" ]]; then
+        loop_set_state ".active" "false"
+        loop_log_success "Loop cancelled"
+    else
+        loop_log_warn "No active loop to cancel"
+    fi
+    return 0
+}
+
+# Clean up loop state
+# Arguments: none
+# Returns: 0
+loop_cleanup() {
+    rm -f "$LOOP_STATE_FILE"
+    rm -f "$LOOP_REANCHOR_FILE"
+    # Keep receipts for audit trail
+    loop_log_info "Loop state cleaned up (receipts preserved)"
+    return 0
+}
+
+# =============================================================================
+# Re-Anchor System
+# =============================================================================
+
+# Generate re-anchor prompt for fresh context
+# Arguments:
+#   $1 - task_keywords (for memory recall)
+# Returns: 0
+# Output: Re-anchor prompt to stdout and file
+loop_generate_reanchor() {
+    local task_keywords="${1:-}"
+    local task_id
+    task_id=$(loop_get_state ".task_id")
+    local iteration
+    iteration=$(loop_get_state ".iteration")
+    local prompt
+    prompt=$(loop_get_state ".prompt")
+    
+    loop_init_state_dir
+    
+    # Get git state
+    local git_status
+    git_status=$(git status --short 2>/dev/null || echo "Not a git repo")
+    local git_log
+    git_log=$(git log -5 --oneline 2>/dev/null || echo "No git history")
+    local git_branch
+    git_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+    
+    # Get TODO.md in-progress tasks
+    local todo_in_progress=""
+    if [[ -f "TODO.md" ]]; then
+        todo_in_progress=$(grep -A10 "## In Progress" TODO.md 2>/dev/null | head -15 || echo "No tasks in progress")
+    fi
+    
+    # Get relevant memories
+    local memories=""
+    if [[ -n "$task_keywords" ]] && command -v ~/.aidevops/agents/scripts/memory-helper.sh &>/dev/null; then
+        memories=$(~/.aidevops/agents/scripts/memory-helper.sh recall "$task_keywords" --limit 5 --format text 2>/dev/null || echo "No relevant memories")
+    fi
+    
+    # Get latest receipt
+    local latest_receipt=""
+    local latest_receipt_file
+    latest_receipt_file=$(find "$LOOP_RECEIPTS_DIR" -name "*.json" -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || echo "")
+    if [[ -n "$latest_receipt_file" && -f "$latest_receipt_file" ]]; then
+        latest_receipt=$(cat "$latest_receipt_file")
+    fi
+    
+    # Generate re-anchor prompt
+    cat > "$LOOP_REANCHOR_FILE" << EOF
+# Re-Anchor Context (MANDATORY - Read Before Any Work)
+
+**Loop:** $task_id | **Iteration:** $iteration | **Branch:** $git_branch
+
+## Original Task
+
+$prompt
+
+## Current State
+
+### Git Status
+\`\`\`
+$git_status
+\`\`\`
+
+### Recent Commits
+\`\`\`
+$git_log
+\`\`\`
+
+### TODO.md In Progress
+\`\`\`
+$todo_in_progress
+\`\`\`
+
+## Relevant Memories
+
+$memories
+
+## Previous Iteration Receipt
+
+\`\`\`json
+${latest_receipt:-"First iteration - no previous receipt"}
+\`\`\`
+
+---
+
+**IMPORTANT:** Re-read this context before proceeding. Do NOT rely on conversation history.
+Continue working on the task. When complete, output: <promise>$(loop_get_state ".completion_promise")</promise>
+EOF
+    
+    cat "$LOOP_REANCHOR_FILE"
+    return 0
+}
+
+# =============================================================================
+# Receipt System
+# =============================================================================
+
+# Create a receipt for completed work
+# Arguments:
+#   $1 - type (task|preflight|pr-review|postflight)
+#   $2 - outcome (success|retry|blocked)
+#   $3 - evidence (JSON object as string, optional)
+# Returns: 0
+# Output: Receipt file path
+loop_create_receipt() {
+    local receipt_type="$1"
+    local outcome="$2"
+    local evidence="${3:-{}}"
+    
+    local task_id
+    task_id=$(loop_get_state ".task_id")
+    local iteration
+    iteration=$(loop_get_state ".iteration")
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    
+    loop_init_state_dir
+    
+    local receipt_file="${LOOP_RECEIPTS_DIR}/${receipt_type}-${task_id}-iter${iteration}.json"
+    
+    # Get commit hash if available
+    local commit_hash
+    commit_hash=$(git rev-parse --short HEAD 2>/dev/null || echo "none")
+    
+    cat > "$receipt_file" << EOF
+{
+  "type": "$receipt_type",
+  "id": "$task_id",
+  "iteration": $iteration,
+  "timestamp": "$timestamp",
+  "outcome": "$outcome",
+  "commit_hash": "$commit_hash",
+  "evidence": $evidence
+}
+EOF
+    
+    # Add receipt to state
+    local receipts
+    receipts=$(loop_get_state ".receipts")
+    if [[ -z "$receipts" || "$receipts" == "null" ]]; then
+        receipts="[]"
+    fi
+    
+    local temp_file
+    temp_file=$(mktemp)
+    jq ".receipts += [\"$(basename "$receipt_file")\"]" "$LOOP_STATE_FILE" > "$temp_file"
+    mv "$temp_file" "$LOOP_STATE_FILE"
+    
+    loop_log_success "Receipt created: $receipt_file"
+    echo "$receipt_file"
+    return 0
+}
+
+# Verify receipt exists for current iteration
+# Arguments:
+#   $1 - type (task|preflight|pr-review|postflight)
+# Returns: 0 if receipt exists, 1 if not
+loop_verify_receipt() {
+    local receipt_type="$1"
+    local task_id
+    task_id=$(loop_get_state ".task_id")
+    local iteration
+    iteration=$(loop_get_state ".iteration")
+    
+    local receipt_file="${LOOP_RECEIPTS_DIR}/${receipt_type}-${task_id}-iter${iteration}.json"
+    
+    if [[ -f "$receipt_file" ]]; then
+        loop_log_success "Receipt verified: $receipt_file"
+        return 0
+    else
+        loop_log_warn "Missing receipt: $receipt_file"
+        return 1
+    fi
+}
+
+# Get latest receipt for a type
+# Arguments:
+#   $1 - type (task|preflight|pr-review|postflight)
+# Returns: 0
+# Output: Receipt JSON to stdout
+loop_get_latest_receipt() {
+    local receipt_type="$1"
+    
+    local latest
+    latest=$(find "$LOOP_RECEIPTS_DIR" -name "${receipt_type}-*.json" -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || echo "")
+    
+    if [[ -n "$latest" && -f "$latest" ]]; then
+        cat "$latest"
+    else
+        echo "{}"
+    fi
+    return 0
+}
+
+# =============================================================================
+# Memory Integration
+# =============================================================================
+
+# Store learning from loop iteration
+# Arguments:
+#   $1 - type (WORKING_SOLUTION|FAILED_APPROACH|CODEBASE_PATTERN)
+#   $2 - content
+#   $3 - tags (comma-separated)
+# Returns: 0
+loop_store_memory() {
+    local memory_type="$1"
+    local content="$2"
+    local tags="${3:-loop}"
+    
+    local task_id
+    task_id=$(loop_get_state ".task_id")
+    
+    if command -v ~/.aidevops/agents/scripts/memory-helper.sh &>/dev/null; then
+        ~/.aidevops/agents/scripts/memory-helper.sh store \
+            --type "$memory_type" \
+            --content "$content" \
+            --tags "$tags,loop,$task_id" \
+            --session-id "$task_id" 2>/dev/null || true
+        loop_log_info "Memory stored: $memory_type"
+    fi
+    return 0
+}
+
+# Store failed approach (called on retry)
+# Arguments:
+#   $1 - what failed
+#   $2 - why it failed (optional)
+# Returns: 0
+loop_store_failure() {
+    local what_failed="$1"
+    local why="${2:-Unknown reason}"
+    
+    loop_store_memory "FAILED_APPROACH" "Failed: $what_failed. Reason: $why" "failure,retry"
+    return 0
+}
+
+# Store successful solution (called on completion)
+# Arguments:
+#   $1 - what worked
+# Returns: 0
+loop_store_success() {
+    local what_worked="$1"
+    
+    loop_store_memory "WORKING_SOLUTION" "Success: $what_worked" "success,solution"
+    return 0
+}
+
+# =============================================================================
+# Task Blocking
+# =============================================================================
+
+# Track attempt for a task
+# Arguments:
+#   $1 - task_id (optional, uses current if not provided)
+# Returns: 0
+# Output: New attempt count
+loop_track_attempt() {
+    local task_id="${1:-$(loop_get_state ".task_id")}"
+    
+    local attempts
+    attempts=$(jq -r ".attempts[\"$task_id\"] // 0" "$LOOP_STATE_FILE" 2>/dev/null || echo "0")
+    local new_attempts=$((attempts + 1))
+    
+    local temp_file
+    temp_file=$(mktemp)
+    jq ".attempts[\"$task_id\"] = $new_attempts" "$LOOP_STATE_FILE" > "$temp_file"
+    mv "$temp_file" "$LOOP_STATE_FILE"
+    
+    echo "$new_attempts"
+    return 0
+}
+
+# Check if task should be blocked
+# Arguments:
+#   $1 - max_attempts (default: 5)
+#   $2 - task_id (optional)
+# Returns: 0 if should block, 1 if not
+loop_should_block() {
+    local max_attempts="${1:-5}"
+    local task_id="${2:-$(loop_get_state ".task_id")}"
+    
+    local attempts
+    attempts=$(jq -r ".attempts[\"$task_id\"] // 0" "$LOOP_STATE_FILE" 2>/dev/null || echo "0")
+    
+    [[ "$attempts" -ge "$max_attempts" ]]
+}
+
+# Block a task
+# Arguments:
+#   $1 - reason
+#   $2 - task_id (optional)
+# Returns: 0
+loop_block_task() {
+    local reason="$1"
+    local task_id="${2:-$(loop_get_state ".task_id")}"
+    
+    local temp_file
+    temp_file=$(mktemp)
+    jq ".blocked_tasks += [{\"id\": \"$task_id\", \"reason\": \"$reason\", \"blocked_at\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}]" "$LOOP_STATE_FILE" > "$temp_file"
+    mv "$temp_file" "$LOOP_STATE_FILE"
+    
+    loop_store_failure "Task blocked after multiple attempts" "$reason"
+    loop_log_warn "Task $task_id blocked: $reason"
+    return 0
+}
+
+# =============================================================================
+# External Loop Runner
+# =============================================================================
+
+# Run external loop with fresh sessions
+# Arguments:
+#   $1 - tool (opencode|claude|aider)
+#   $2 - prompt
+#   $3 - max_iterations
+#   $4 - completion_promise
+# Returns: 0 on completion, 1 on max iterations
+loop_run_external() {
+    local tool="$1"
+    local prompt="$2"
+    local max_iterations="${3:-50}"
+    local completion_promise="${4:-TASK_COMPLETE}"
+    
+    # Validate tool
+    if ! command -v "$tool" &>/dev/null; then
+        loop_log_error "Tool not found: $tool"
+        return 1
+    fi
+    
+    loop_log_info "Starting external loop with $tool"
+    loop_log_info "Max iterations: $max_iterations"
+    loop_log_info "Completion promise: $completion_promise"
+    
+    local iteration=1
+    local output_file
+    output_file=$(mktemp)
+    trap 'rm -f "$output_file"' EXIT
+    
+    while [[ $iteration -le $max_iterations ]]; do
+        loop_log_step "=== Iteration $iteration/$max_iterations ==="
+        
+        # Update state
+        loop_set_state ".iteration" "$iteration"
+        loop_set_state ".last_iteration_at" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+        
+        # Generate re-anchor prompt
+        local reanchor
+        reanchor=$(loop_generate_reanchor "$prompt")
+        
+        # Build full prompt with re-anchor
+        local full_prompt="$reanchor"
+        
+        # Run tool (fresh session each time)
+        local exit_code=0
+        case "$tool" in
+            opencode)
+                echo "$full_prompt" | opencode --print > "$output_file" 2>&1 || exit_code=$?
+                ;;
+            claude)
+                echo "$full_prompt" | claude --print > "$output_file" 2>&1 || exit_code=$?
+                ;;
+            aider)
+                aider --yes --message "$full_prompt" > "$output_file" 2>&1 || exit_code=$?
+                ;;
+            *)
+                loop_log_error "Unknown tool: $tool"
+                return 1
+                ;;
+        esac
+        
+        # Check for completion promise
+        if grep -q "<promise>$completion_promise</promise>" "$output_file" 2>/dev/null; then
+            loop_log_success "Completion promise detected!"
+            loop_create_receipt "task" "success" '{"promise_fulfilled": true}'
+            loop_store_success "Task completed after $iteration iterations"
+            return 0
+        fi
+        
+        # Track attempt and check for blocking
+        local attempts
+        attempts=$(loop_track_attempt)
+        if loop_should_block 5; then
+            loop_block_task "Max attempts reached after $attempts tries"
+            return 1
+        fi
+        
+        # Create retry receipt
+        loop_create_receipt "task" "retry" "{\"iteration\": $iteration, \"exit_code\": $exit_code}"
+        
+        iteration=$((iteration + 1))
+        
+        # Brief delay between iterations
+        sleep 2
+    done
+    
+    loop_log_warn "Max iterations ($max_iterations) reached without completion"
+    loop_block_task "Max iterations reached"
+    return 1
+}
+
+# =============================================================================
+# Status Display
+# =============================================================================
+
+# Show loop status
+# Arguments: none
+# Returns: 0
+loop_show_status() {
+    if [[ ! -f "$LOOP_STATE_FILE" ]]; then
+        echo "No active loop"
+        return 0
+    fi
+    
+    echo ""
+    echo "=== Loop Status ==="
+    echo ""
+    
+    local loop_type
+    loop_type=$(loop_get_state ".loop_type")
+    local task_id
+    task_id=$(loop_get_state ".task_id")
+    local iteration
+    iteration=$(loop_get_state ".iteration")
+    local max_iterations
+    max_iterations=$(loop_get_state ".max_iterations")
+    local phase
+    phase=$(loop_get_state ".phase")
+    local started_at
+    started_at=$(loop_get_state ".started_at")
+    local active
+    active=$(loop_get_state ".active")
+    local completion_promise
+    completion_promise=$(loop_get_state ".completion_promise")
+    
+    echo "Type: $loop_type"
+    echo "Task ID: $task_id"
+    echo "Phase: $phase"
+    echo "Iteration: $iteration / $max_iterations"
+    echo "Active: $active"
+    echo "Started: $started_at"
+    echo "Promise: $completion_promise"
+    echo ""
+    
+    # Show receipts
+    local receipt_count
+    receipt_count=$(find "$LOOP_RECEIPTS_DIR" -name "*.json" -type f 2>/dev/null | wc -l | tr -d ' ')
+    echo "Receipts: $receipt_count"
+    
+    # Show blocked tasks
+    local blocked
+    blocked=$(jq -r '.blocked_tasks | length' "$LOOP_STATE_FILE" 2>/dev/null || echo "0")
+    if [[ "$blocked" -gt 0 ]]; then
+        echo ""
+        echo "Blocked tasks:"
+        jq -r '.blocked_tasks[] | "  - \(.id): \(.reason)"' "$LOOP_STATE_FILE" 2>/dev/null
+    fi
+    
+    echo ""
+    return 0
+}

--- a/.agent/scripts/ralph-loop-helper.sh
+++ b/.agent/scripts/ralph-loop-helper.sh
@@ -1,17 +1,27 @@
 #!/bin/bash
 # =============================================================================
-# Ralph Loop Helper - Cross-Tool Iterative AI Development
+# Ralph Loop Helper v2 - Cross-Tool Iterative AI Development
 # =============================================================================
 # Implementation of the Ralph Wiggum technique for iterative AI development.
 # Works with Claude Code, OpenCode, and other AI CLI tools.
 #
+# v2 Architecture (based on flow-next):
+# - Fresh context per iteration (external bash loop)
+# - File I/O as state (JSON-based, not transcript)
+# - Re-anchor from source of truth every iteration
+# - Receipt-based verification
+# - Memory integration for cross-session learning
+#
 # Usage:
 #   ralph-loop-helper.sh setup "<prompt>" [--max-iterations N] [--completion-promise "TEXT"]
+#   ralph-loop-helper.sh run "<prompt>" [options] --tool <tool>  # v2: fresh sessions
+#   ralph-loop-helper.sh external "<prompt>" [options] --tool <tool>  # legacy alias
 #   ralph-loop-helper.sh cancel
-#   ralph-loop-helper.sh status
-#   ralph-loop-helper.sh check-completion "<output>"
-#   ralph-loop-helper.sh increment
-#   ralph-loop-helper.sh external "<prompt>" [options] --tool <tool>
+#   ralph-loop-helper.sh status [--all]
+#   ralph-loop-helper.sh reanchor  # Generate re-anchor prompt
+#
+# Reference: https://github.com/gmickel/gmickel-claude-marketplace/tree/main/plugins/flow-next
+# Original: https://ghuntley.com/ralph/
 #
 # Author: AI DevOps Framework
 # =============================================================================
@@ -22,130 +32,127 @@ set -euo pipefail
 # Constants
 # =============================================================================
 
-readonly RALPH_STATE_DIR=".claude"
-readonly RALPH_STATE_FILE="${RALPH_STATE_DIR}/ralph-loop.local.md"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
 readonly SCRIPT_NAME="ralph-loop-helper.sh"
 
-# Adaptive timing constants (evidence-based from PR #19 analysis)
-# These can be overridden by environment variables
-readonly RALPH_DELAY_BASE="${RALPH_DELAY_BASE:-2}"      # Initial delay between iterations
-readonly RALPH_DELAY_MAX="${RALPH_DELAY_MAX:-30}"       # Maximum delay between iterations
-readonly RALPH_DELAY_MULTIPLIER="${RALPH_DELAY_MULTIPLIER:-1.5}"  # Backoff multiplier
+# Source shared loop infrastructure
+# shellcheck source=loop-common.sh
+if [[ -f "$SCRIPT_DIR/loop-common.sh" ]]; then
+    source "$SCRIPT_DIR/loop-common.sh"
+fi
 
-# Colors
+# Legacy state file (for backward compatibility)
+readonly RALPH_STATE_DIR=".claude"
+readonly RALPH_STATE_FILE="${RALPH_STATE_DIR}/ralph-loop.local.md"
+
+# Adaptive timing constants (evidence-based from PR #19 analysis)
+readonly RALPH_DELAY_BASE="${RALPH_DELAY_BASE:-2}"
+readonly RALPH_DELAY_MAX="${RALPH_DELAY_MAX:-30}"
+readonly RALPH_DELAY_MULTIPLIER="${RALPH_DELAY_MULTIPLIER:-1.5}"
+
+# v2 defaults
+readonly DEFAULT_MAX_ITERATIONS=50
+readonly DEFAULT_MAX_ATTEMPTS=5
+
+# Colors (fallback if loop-common.sh not loaded)
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'
 readonly YELLOW='\033[1;33m'
 readonly BLUE='\033[0;34m'
+readonly CYAN='\033[0;36m'
 readonly BOLD='\033[1m'
-readonly NC='\033[0m' # No Color
+readonly NC='\033[0m'
 
 # =============================================================================
 # Helper Functions
 # =============================================================================
 
-# Print error message to stderr
-# Arguments:
-#   $1 - Error message to display
-# Returns: 0
 print_error() {
     local message="$1"
-    echo -e "${RED}Error:${NC} ${message}" >&2
+    echo -e "${RED}[ralph] Error:${NC} ${message}" >&2
     return 0
 }
 
-# Print success message in green
-# Arguments:
-#   $1 - Success message to display
-# Returns: 0
 print_success() {
     local message="$1"
-    echo -e "${GREEN}${message}${NC}"
+    echo -e "${GREEN}[ralph]${NC} ${message}"
     return 0
 }
 
-# Print warning message in yellow
-# Arguments:
-#   $1 - Warning message to display
-# Returns: 0
 print_warning() {
     local message="$1"
-    echo -e "${YELLOW}${message}${NC}"
+    echo -e "${YELLOW}[ralph]${NC} ${message}"
     return 0
 }
 
-# Print info message in blue
-# Arguments:
-#   $1 - Info message to display
-# Returns: 0
 print_info() {
     local message="$1"
-    echo -e "${BLUE}${message}${NC}"
+    echo -e "${BLUE}[ralph]${NC} ${message}"
+    return 0
+}
+
+print_step() {
+    local message="$1"
+    echo -e "${CYAN}[ralph]${NC} ${message}"
     return 0
 }
 
 show_help() {
     cat << 'EOF'
-Ralph Loop Helper - Cross-Tool Iterative AI Development
+Ralph Loop Helper v2 - Cross-Tool Iterative AI Development
 
 USAGE:
   ralph-loop-helper.sh <command> [options]
 
 COMMANDS:
-  setup     Create state file to start a Ralph loop
-  cancel    Cancel the active Ralph loop
-  status    Show current loop status (use --all for all worktrees)
-  check     Check if output contains completion promise
-  increment Increment iteration counter
-  external  Run external bash loop (for tools without hook support)
-  help      Show this help message
+  setup       Create state file to start a Ralph loop (legacy mode)
+  run         Run external loop with fresh sessions per iteration (v2)
+  external    Alias for 'run' (backward compatibility)
+  cancel      Cancel the active Ralph loop
+  status      Show current loop status (use --all for all worktrees)
+  reanchor    Generate re-anchor prompt for current state
+  check       Check if output contains completion promise
+  increment   Increment iteration counter (legacy)
+  help        Show this help message
 
-SETUP OPTIONS:
+RUN OPTIONS (v2 - Recommended):
+  --tool <name>                  AI CLI tool (opencode, claude, aider)
+  --max-iterations <n>           Maximum iterations (default: 50)
+  --completion-promise '<text>'  Promise phrase to detect completion
+  --max-attempts <n>             Block task after N failed attempts (default: 5)
+  --task-id <id>                 Task ID for tracking (auto-generated if omitted)
+
+SETUP OPTIONS (Legacy):
   --max-iterations <n>           Maximum iterations (default: 0 = unlimited)
   --completion-promise '<text>'  Promise phrase to detect completion
 
 STATUS OPTIONS:
   --all, -a                      Show loops across all git worktrees
 
-EXTERNAL OPTIONS:
-  --tool <name>                  AI CLI tool to use (opencode, claude, aider)
-  --max-iterations <n>           Maximum iterations
-  --completion-promise '<text>'  Promise phrase
-
 EXAMPLES:
-  # Start a loop (for tools with hook support)
-  ralph-loop-helper.sh setup "Build a REST API" --max-iterations 20 --completion-promise "DONE"
+  # v2: Fresh sessions per iteration (recommended)
+  ralph-loop-helper.sh run "Build a REST API" --tool opencode --max-iterations 20
 
-  # Check status in current directory
-  ralph-loop-helper.sh status
+  # Legacy: Same-session loop (for tools with hook support)
+  ralph-loop-helper.sh setup "Build a REST API" --max-iterations 20
 
-  # Check status across all worktrees
+  # Check status
   ralph-loop-helper.sh status --all
 
-  # Cancel loop
-  ralph-loop-helper.sh cancel
+  # Generate re-anchor prompt
+  ralph-loop-helper.sh reanchor
 
-  # External loop (for tools without hook support)
-  ralph-loop-helper.sh external "Fix all tests" --tool opencode --max-iterations 10
-
-DESCRIPTION:
-  Ralph is a development methodology based on continuous AI agent loops.
-  The AI works on a task, and when it tries to exit, the same prompt is
-  fed back, allowing it to see its previous work and iterate until done.
-
-  For tools with hook support (Claude Code), use 'setup' to create state.
-  For tools without hooks, use 'external' to run a bash loop wrapper.
+v2 ARCHITECTURE:
+  - Fresh context per iteration (no transcript accumulation)
+  - Re-anchor from files at start of every iteration
+  - Receipt-based verification (proof of work)
+  - Memory integration (stores learnings across sessions)
+  - Auto-block after N failed attempts
 
 COMPLETION:
   To signal completion, the AI must output: <promise>YOUR_PHRASE</promise>
   The promise must be TRUE - do not output false promises to escape.
-
-MONITORING:
-  # View current iteration
-  grep '^iteration:' .claude/ralph-loop.local.md
-
-  # View full state
-  head -10 .claude/ralph-loop.local.md
 
 ENVIRONMENT VARIABLES:
   RALPH_DELAY_BASE        Initial delay between iterations (default: 2s)
@@ -154,46 +161,256 @@ ENVIRONMENT VARIABLES:
 
 LEARN MORE:
   Original technique: https://ghuntley.com/ralph/
+  flow-next reference: https://github.com/gmickel/gmickel-claude-marketplace
   Documentation: ~/.aidevops/agents/workflows/ralph-loop.md
 EOF
     return 0
 }
 
 # =============================================================================
-# Core Functions
+# v2 Functions (Fresh Context Architecture)
 # =============================================================================
 
-# Setup a new Ralph loop by creating state file
+# Run v2 loop with fresh sessions per iteration
 # Arguments:
-#   $@ - Prompt text and options (--max-iterations N, --completion-promise "TEXT")
-# Returns: 0 on success, 1 on error
-# Side effects: Creates .claude/ralph-loop.local.md state file
-setup_loop() {
+#   $@ - Prompt and options
+# Returns: 0 on completion, 1 on error/max iterations
+run_v2_loop() {
     local prompt=""
-    local max_iterations=0
-    local completion_promise="null"
+    local max_iterations=$DEFAULT_MAX_ITERATIONS
+    local completion_promise="TASK_COMPLETE"
+    local tool="opencode"
+    local max_attempts=$DEFAULT_MAX_ATTEMPTS
+    local task_id=""
     local prompt_parts=()
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
             --max-iterations)
-                if [[ -z "${2:-}" ]]; then
-                    print_error "--max-iterations requires a number argument"
-                    return 1
-                fi
-                if ! [[ "$2" =~ ^[0-9]+$ ]]; then
-                    print_error "--max-iterations must be a positive integer, got: $2"
-                    return 1
-                fi
                 max_iterations="$2"
                 shift 2
                 ;;
             --completion-promise)
-                if [[ -z "${2:-}" ]]; then
-                    print_error "--completion-promise requires a text argument"
-                    return 1
+                completion_promise="$2"
+                shift 2
+                ;;
+            --tool)
+                tool="$2"
+                shift 2
+                ;;
+            --max-attempts)
+                max_attempts="$2"
+                shift 2
+                ;;
+            --task-id)
+                task_id="$2"
+                shift 2
+                ;;
+            *)
+                prompt_parts+=("$1")
+                shift
+                ;;
+        esac
+    done
+
+    prompt="${prompt_parts[*]}"
+
+    if [[ -z "$prompt" ]]; then
+        print_error "No prompt provided"
+        echo "Usage: $SCRIPT_NAME run \"<prompt>\" --tool <tool> [options]"
+        return 1
+    fi
+
+    # Validate tool
+    if ! command -v "$tool" &>/dev/null; then
+        print_error "Tool '$tool' not found. Install it or use --tool to specify another."
+        print_info "Available tools: opencode, claude, aider"
+        return 1
+    fi
+
+    # Check for jq (required for v2)
+    if ! command -v jq &>/dev/null; then
+        print_error "jq is required for v2 loops. Install with: brew install jq"
+        return 1
+    fi
+
+    # Initialize state using shared infrastructure
+    if type loop_create_state &>/dev/null; then
+        loop_create_state "ralph" "$prompt" "$max_iterations" "$completion_promise" "$task_id"
+    else
+        print_warning "loop-common.sh not loaded, using basic state"
+        mkdir -p "$RALPH_STATE_DIR"
+    fi
+
+    print_info "Starting Ralph loop v2 with $tool"
+    print_info "Architecture: Fresh context per iteration"
+    echo ""
+    echo "Prompt: $prompt"
+    echo "Max iterations: $max_iterations"
+    echo "Completion promise: $completion_promise"
+    echo "Max attempts before block: $max_attempts"
+    echo ""
+
+    local iteration=1
+    local output_file
+    output_file=$(mktemp)
+    trap 'rm -f "$output_file"' EXIT
+
+    while [[ $iteration -le $max_iterations ]]; do
+        print_step "=== Iteration $iteration/$max_iterations ==="
+
+        # Update state
+        if type loop_set_state &>/dev/null; then
+            loop_set_state ".iteration" "$iteration"
+            loop_set_state ".last_iteration_at" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+        fi
+
+        # Generate re-anchor prompt (key v2 feature)
+        local reanchor_prompt=""
+        if type loop_generate_reanchor &>/dev/null; then
+            print_info "Generating re-anchor context..."
+            reanchor_prompt=$(loop_generate_reanchor "$prompt")
+        else
+            # Fallback: basic prompt with iteration
+            reanchor_prompt="[Ralph iteration $iteration/$max_iterations]
+
+$prompt
+
+To complete, output: <promise>$completion_promise</promise> (ONLY when TRUE)"
+        fi
+
+        # Run tool with fresh session
+        local exit_code=0
+        print_info "Spawning fresh $tool session..."
+        
+        case "$tool" in
+            opencode)
+                echo "$reanchor_prompt" | opencode --print > "$output_file" 2>&1 || exit_code=$?
+                ;;
+            claude)
+                echo "$reanchor_prompt" | claude --print > "$output_file" 2>&1 || exit_code=$?
+                ;;
+            aider)
+                aider --yes --message "$reanchor_prompt" > "$output_file" 2>&1 || exit_code=$?
+                ;;
+            *)
+                print_error "Unknown tool: $tool"
+                return 1
+                ;;
+        esac
+
+        if [[ $exit_code -ne 0 ]]; then
+            print_warning "Tool exited with code $exit_code (continuing)"
+        fi
+
+        # Check for completion promise
+        if grep -q "<promise>$completion_promise</promise>" "$output_file" 2>/dev/null; then
+            print_success "Completion promise detected!"
+            
+            # Create success receipt
+            if type loop_create_receipt &>/dev/null; then
+                loop_create_receipt "task" "success" '{"promise_fulfilled": true}'
+            fi
+            
+            # Store success in memory
+            if type loop_store_success &>/dev/null; then
+                loop_store_success "Task completed after $iteration iterations"
+            fi
+            
+            print_success "Ralph loop completed successfully after $iteration iterations"
+            return 0
+        fi
+
+        # Track attempt and check for blocking
+        if type loop_track_attempt &>/dev/null; then
+            local attempts
+            attempts=$(loop_track_attempt)
+            
+            if type loop_should_block &>/dev/null && loop_should_block "$max_attempts"; then
+                print_error "Task blocked after $attempts failed attempts"
+                
+                if type loop_block_task &>/dev/null; then
+                    loop_block_task "Max attempts ($max_attempts) reached without completion"
                 fi
+                
+                if type loop_store_failure &>/dev/null; then
+                    loop_store_failure "Task blocked" "Exceeded $max_attempts attempts"
+                fi
+                
+                return 1
+            fi
+        fi
+
+        # Create retry receipt
+        if type loop_create_receipt &>/dev/null; then
+            loop_create_receipt "task" "retry" "{\"iteration\": $iteration, \"exit_code\": $exit_code}"
+        fi
+
+        iteration=$((iteration + 1))
+
+        # Adaptive delay
+        local delay
+        delay=$(calculate_delay "$iteration")
+        print_info "Waiting ${delay}s before next iteration..."
+        sleep "$delay"
+    done
+
+    print_warning "Max iterations ($max_iterations) reached without completion"
+    
+    if type loop_block_task &>/dev/null; then
+        loop_block_task "Max iterations reached"
+    fi
+    
+    return 1
+}
+
+# Calculate adaptive delay with exponential backoff
+# Arguments:
+#   $1 - iteration number
+# Returns: 0
+# Output: delay in seconds
+calculate_delay() {
+    local iteration="$1"
+    local delay
+
+    if command -v bc &>/dev/null; then
+        delay=$(echo "scale=0; $RALPH_DELAY_BASE * ($RALPH_DELAY_MULTIPLIER ^ ($iteration - 1))" | bc 2>/dev/null || echo "$RALPH_DELAY_BASE")
+        if [[ $(echo "$delay > $RALPH_DELAY_MAX" | bc 2>/dev/null || echo "0") -eq 1 ]]; then
+            delay=$RALPH_DELAY_MAX
+        fi
+    else
+        delay=$RALPH_DELAY_BASE
+        local i=1
+        while [[ $i -lt $iteration ]] && [[ $delay -lt $RALPH_DELAY_MAX ]]; do
+            delay=$((delay * 2))
+            ((i++))
+        done
+        [[ $delay -gt $RALPH_DELAY_MAX ]] && delay=$RALPH_DELAY_MAX
+    fi
+
+    echo "$delay"
+    return 0
+}
+
+# =============================================================================
+# Legacy Functions (Backward Compatibility)
+# =============================================================================
+
+# Setup a new Ralph loop (legacy mode - same session)
+setup_loop() {
+    local prompt=""
+    local max_iterations=0
+    local completion_promise="null"
+    local prompt_parts=()
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --max-iterations)
+                max_iterations="$2"
+                shift 2
+                ;;
+            --completion-promise)
                 completion_promise="$2"
                 shift 2
                 ;;
@@ -204,20 +421,16 @@ setup_loop() {
         esac
     done
 
-    # Join prompt parts
     prompt="${prompt_parts[*]}"
 
     if [[ -z "$prompt" ]]; then
         print_error "No prompt provided"
-        echo ""
         echo "Usage: $SCRIPT_NAME setup \"<prompt>\" [--max-iterations N] [--completion-promise \"TEXT\"]"
         return 1
     fi
 
-    # Create state directory
     mkdir -p "$RALPH_STATE_DIR"
 
-    # Quote completion promise for YAML if needed
     local completion_promise_yaml
     if [[ -n "$completion_promise" ]] && [[ "$completion_promise" != "null" ]]; then
         completion_promise_yaml="\"$completion_promise\""
@@ -225,7 +438,6 @@ setup_loop() {
         completion_promise_yaml="null"
     fi
 
-    # Create state file
     cat > "$RALPH_STATE_FILE" << EOF
 ---
 active: true
@@ -233,38 +445,28 @@ iteration: 1
 max_iterations: $max_iterations
 completion_promise: $completion_promise_yaml
 started_at: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+mode: legacy
 ---
 
 $prompt
 EOF
 
-    # Check for other active loops in parallel worktrees
     check_other_loops
 
-    # Output setup message
     echo ""
-    print_success "Ralph loop activated!"
+    print_success "Ralph loop activated (legacy mode)"
+    print_warning "Note: Consider using 'run' command for v2 fresh-context architecture"
     echo ""
     echo "Iteration: 1"
     echo "Max iterations: $(if [[ $max_iterations -gt 0 ]]; then echo "$max_iterations"; else echo "unlimited"; fi)"
-    echo "Completion promise: $(if [[ "$completion_promise" != "null" ]]; then echo "${completion_promise} (ONLY output when TRUE)"; else echo "none (runs forever)"; fi)"
+    echo "Completion promise: $(if [[ "$completion_promise" != "null" ]]; then echo "$completion_promise"; else echo "none"; fi)"
     echo ""
     echo "State file: $RALPH_STATE_FILE"
-    echo ""
 
-    # Display completion promise requirements if set
     if [[ "$completion_promise" != "null" ]]; then
-        echo "================================================================"
-        echo "CRITICAL - Ralph Loop Completion Promise"
-        echo "================================================================"
         echo ""
-        echo "To complete this loop, output this EXACT text:"
-        echo "  <promise>$completion_promise</promise>"
-        echo ""
-        echo "STRICT REQUIREMENTS:"
-        echo "  - Use <promise> XML tags EXACTLY as shown"
-        echo "  - The statement MUST be completely TRUE"
-        echo "  - Do NOT output false statements to exit"
+        echo "================================================================"
+        echo "To complete this loop, output: <promise>$completion_promise</promise>"
         echo "================================================================"
     fi
 
@@ -275,33 +477,35 @@ EOF
 }
 
 # Cancel the active Ralph loop
-# Arguments: none
-# Returns: 0 (always succeeds)
-# Side effects: Removes state file if it exists
 cancel_loop() {
-    if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-        print_warning "No active Ralph loop found."
-        return 0
+    local cancelled=false
+
+    # Cancel v2 state
+    if type loop_cancel &>/dev/null && [[ -f "${RALPH_STATE_DIR}/loop-state.json" ]]; then
+        loop_cancel
+        cancelled=true
     fi
 
-    # Get iteration count before removing
-    local iteration
-    iteration=$(grep '^iteration:' "$RALPH_STATE_FILE" | sed 's/iteration: *//' || echo "unknown")
+    # Cancel legacy state
+    if [[ -f "$RALPH_STATE_FILE" ]]; then
+        local iteration
+        iteration=$(grep '^iteration:' "$RALPH_STATE_FILE" | sed 's/iteration: *//' || echo "unknown")
+        rm "$RALPH_STATE_FILE"
+        print_success "Cancelled legacy Ralph loop (was at iteration $iteration)"
+        cancelled=true
+    fi
 
-    rm "$RALPH_STATE_FILE"
-    print_success "Cancelled Ralph loop (was at iteration $iteration)"
+    if [[ "$cancelled" == "false" ]]; then
+        print_warning "No active Ralph loop found"
+    fi
+
     return 0
 }
 
-# Display current Ralph loop status
-# Arguments:
-#   --all: Show status across all worktrees
-# Returns: 0 (always succeeds)
-# Output: Status information to stdout
+# Show status
 show_status() {
     local show_all=false
-    
-    # Parse arguments
+
     while [[ $# -gt 0 ]]; do
         case $1 in
             --all|-a)
@@ -313,96 +517,79 @@ show_status() {
                 ;;
         esac
     done
-    
+
     if [[ "$show_all" == "true" ]]; then
         show_status_all
         return 0
     fi
-    
-    if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-        echo "No active Ralph loop in current directory."
-        echo ""
-        echo "Tip: Use 'status --all' to check all worktrees"
+
+    # Check v2 state first
+    if type loop_show_status &>/dev/null && [[ -f "${RALPH_STATE_DIR}/loop-state.json" ]]; then
+        echo "=== Ralph Loop v2 Status ==="
+        loop_show_status
         return 0
     fi
 
-    echo "Ralph Loop Status"
-    echo "================="
+    # Fall back to legacy state
+    if [[ -f "$RALPH_STATE_FILE" ]]; then
+        echo "=== Ralph Loop Status (Legacy) ==="
+        echo ""
+
+        local frontmatter
+        frontmatter=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
+
+        local iteration max_iterations completion_promise started_at
+        iteration=$(echo "$frontmatter" | grep '^iteration:' | sed 's/iteration: *//')
+        max_iterations=$(echo "$frontmatter" | grep '^max_iterations:' | sed 's/max_iterations: *//')
+        completion_promise=$(echo "$frontmatter" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
+        started_at=$(echo "$frontmatter" | grep '^started_at:' | sed 's/started_at: *//' | sed 's/^"\(.*\)"$/\1/')
+
+        echo "Mode: legacy (same-session)"
+        echo "Active: yes"
+        echo "Iteration: $iteration"
+        echo "Max iterations: $(if [[ "$max_iterations" == "0" ]]; then echo "unlimited"; else echo "$max_iterations"; fi)"
+        echo "Completion promise: $(if [[ "$completion_promise" == "null" ]]; then echo "none"; else echo "$completion_promise"; fi)"
+        echo "Started: $started_at"
+        echo ""
+        print_warning "Consider migrating to v2: ralph-loop-helper.sh run ..."
+        return 0
+    fi
+
+    echo "No active Ralph loop in current directory."
     echo ""
-
-    # Parse frontmatter
-    local frontmatter
-    frontmatter=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
-
-    local iteration
-    local max_iterations
-    local completion_promise
-    local started_at
-
-    iteration=$(echo "$frontmatter" | grep '^iteration:' | sed 's/iteration: *//')
-    max_iterations=$(echo "$frontmatter" | grep '^max_iterations:' | sed 's/max_iterations: *//')
-    completion_promise=$(echo "$frontmatter" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
-    started_at=$(echo "$frontmatter" | grep '^started_at:' | sed 's/started_at: *//' | sed 's/^"\(.*\)"$/\1/')
-
-    echo "Active: yes"
-    echo "Iteration: $iteration"
-    echo "Max iterations: $(if [[ "$max_iterations" == "0" ]]; then echo "unlimited"; else echo "$max_iterations"; fi)"
-    echo "Completion promise: $(if [[ "$completion_promise" == "null" ]]; then echo "none"; else echo "$completion_promise"; fi)"
-    echo "Started: $started_at"
-    echo ""
-    echo "State file: $RALPH_STATE_FILE"
-
+    echo "Tip: Use 'status --all' to check all worktrees"
     return 0
 }
 
-# Display Ralph loop status across all worktrees
-# Arguments: none
-# Returns: 0 (always succeeds)
-# Output: Status table for all worktrees with active loops
+# Show status across all worktrees
 show_status_all() {
     echo "Ralph Loop Status - All Worktrees"
     echo "=================================="
     echo ""
-    
-    # Check if we're in a git repo
+
     if ! git rev-parse --git-dir &>/dev/null; then
         print_error "Not in a git repository"
         return 1
     fi
-    
+
     local found_any=false
     local current_dir
     current_dir=$(pwd)
-    
-    # Get all worktrees
+
     while IFS= read -r line; do
         if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
             local worktree_path="${BASH_REMATCH[1]}"
-            local state_file="$worktree_path/$RALPH_STATE_DIR/$RALPH_STATE_FILE"
             
-            # Normalize path for comparison
-            state_file="$worktree_path/.claude/ralph-loop.local.md"
+            # Check for v2 state
+            local v2_state="$worktree_path/.claude/loop-state.json"
+            local legacy_state="$worktree_path/.claude/ralph-loop.local.md"
             
-            if [[ -f "$state_file" ]]; then
+            if [[ -f "$v2_state" ]] || [[ -f "$legacy_state" ]]; then
                 found_any=true
                 
-                # Parse state file
-                local frontmatter
-                frontmatter=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$state_file")
-                
-                local iteration
-                local max_iterations
-                local started_at
                 local branch
-                
-                iteration=$(echo "$frontmatter" | grep '^iteration:' | sed 's/iteration: *//')
-                max_iterations=$(echo "$frontmatter" | grep '^max_iterations:' | sed 's/max_iterations: *//')
-                started_at=$(echo "$frontmatter" | grep '^started_at:' | sed 's/started_at: *//' | sed 's/^"\(.*\)"$/\1/')
-                
-                # Get branch name
                 branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || echo "unknown")
                 
-                # Mark current directory
                 local marker=""
                 if [[ "$worktree_path" == "$current_dir" ]]; then
                     marker=" ${GREEN}(current)${NC}"
@@ -410,56 +597,69 @@ show_status_all() {
                 
                 echo -e "${BOLD}$branch${NC}$marker"
                 echo "  Path: $worktree_path"
-                echo "  Iteration: $iteration / $(if [[ "$max_iterations" == "0" ]]; then echo "unlimited"; else echo "$max_iterations"; fi)"
-                echo "  Started: $started_at"
+                
+                if [[ -f "$v2_state" ]]; then
+                    local iteration max_iterations
+                    iteration=$(jq -r '.iteration // 0' "$v2_state" 2>/dev/null || echo "?")
+                    max_iterations=$(jq -r '.max_iterations // 0' "$v2_state" 2>/dev/null || echo "?")
+                    echo "  Mode: v2 (fresh context)"
+                    echo "  Iteration: $iteration / $max_iterations"
+                elif [[ -f "$legacy_state" ]]; then
+                    local iteration max_iterations
+                    iteration=$(grep '^iteration:' "$legacy_state" | sed 's/iteration: *//')
+                    max_iterations=$(grep '^max_iterations:' "$legacy_state" | sed 's/max_iterations: *//')
+                    echo "  Mode: legacy (same session)"
+                    echo "  Iteration: $iteration / $(if [[ "$max_iterations" == "0" ]]; then echo "unlimited"; else echo "$max_iterations"; fi)"
+                fi
                 echo ""
             fi
         fi
     done < <(git worktree list --porcelain)
-    
+
     if [[ "$found_any" == "false" ]]; then
         echo -e "${GREEN}No active Ralph loops in any worktree${NC}"
     fi
-    
+
     return 0
 }
 
-# Check for active loops in other worktrees and warn
-# Arguments: none
-# Returns: 0 (always succeeds)
-# Output: Warning message if other loops are active
+# Check for other active loops
 check_other_loops() {
-    # Check if we're in a git repo
     if ! git rev-parse --git-dir &>/dev/null; then
         return 0
     fi
-    
+
     local current_dir
     current_dir=$(pwd)
     local other_loops=()
-    
-    # Get all worktrees
+
     while IFS= read -r line; do
         if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
             local worktree_path="${BASH_REMATCH[1]}"
             
-            # Skip current directory
             if [[ "$worktree_path" == "$current_dir" ]]; then
                 continue
             fi
-            
-            local state_file="$worktree_path/.claude/ralph-loop.local.md"
-            
-            if [[ -f "$state_file" ]]; then
+
+            local v2_state="$worktree_path/.claude/loop-state.json"
+            local legacy_state="$worktree_path/.claude/ralph-loop.local.md"
+
+            if [[ -f "$v2_state" ]] || [[ -f "$legacy_state" ]]; then
                 local branch
                 branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || echo "unknown")
-                local iteration
-                iteration=$(grep '^iteration:' "$state_file" | sed 's/iteration: *//')
+                local iteration="?"
+                
+                if [[ -f "$v2_state" ]]; then
+                    iteration=$(jq -r '.iteration // 0' "$v2_state" 2>/dev/null || echo "?")
+                elif [[ -f "$legacy_state" ]]; then
+                    iteration=$(grep '^iteration:' "$legacy_state" | sed 's/iteration: *//')
+                fi
+                
                 other_loops+=("$branch (iteration $iteration)")
             fi
         fi
     done < <(git worktree list --porcelain)
-    
+
     if [[ ${#other_loops[@]} -gt 0 ]]; then
         echo ""
         print_warning "Other active Ralph loops detected:"
@@ -467,42 +667,33 @@ check_other_loops() {
             echo "  - $loop"
         done
         echo ""
-        echo "Use 'ralph-loop-helper.sh status --all' to see details"
-        echo ""
     fi
-    
+
     return 0
 }
 
-# Check if output contains the completion promise
-# Arguments:
-#   $1 - Output text to check
-#   $2 - Completion promise phrase to look for
-# Returns: 0 (always succeeds)
-# Output: "COMPLETE", "NOT_COMPLETE", or "NO_PROMISE" to stdout
+# Generate re-anchor prompt
+generate_reanchor() {
+    if type loop_generate_reanchor &>/dev/null; then
+        local keywords="${1:-}"
+        loop_generate_reanchor "$keywords"
+    else
+        print_error "loop-common.sh not loaded"
+        return 1
+    fi
+}
+
+# Check completion (legacy)
 check_completion() {
     local output="$1"
     local completion_promise="${2:-}"
 
-    # If no completion promise, can't complete
     if [[ -z "$completion_promise" ]] || [[ "$completion_promise" == "null" ]]; then
         echo "NO_PROMISE"
         return 0
     fi
 
-    # Check for Perl dependency (required for multiline promise extraction)
-    if ! command -v perl &>/dev/null; then
-        print_warning "Perl not found - promise extraction may fail. Install perl for reliable completion detection."
-        echo "NOT_COMPLETE"
-        return 0
-    fi
-
-    # Extract text from <promise> tags using Perl for multiline support
-    local promise_text
-    promise_text=$(echo "$output" | perl -0777 -pe 's/.*?<promise>(.*?)<\/promise>.*/$1/s; s/^\s+|\s+$//g; s/\s+/ /g' 2>/dev/null || echo "")
-
-    # Use = for literal string comparison
-    if [[ -n "$promise_text" ]] && [[ "$promise_text" = "$completion_promise" ]]; then
+    if grep -q "<promise>$completion_promise</promise>" <<< "$output" 2>/dev/null; then
         echo "COMPLETE"
         return 0
     fi
@@ -511,30 +702,25 @@ check_completion() {
     return 0
 }
 
-# Increment the iteration counter in state file
-# Arguments: none
-# Returns: 0 on success, 1 if no active loop or corrupted state
-# Output: New iteration number to stdout
+# Increment iteration (legacy)
 increment_iteration() {
     if [[ ! -f "$RALPH_STATE_FILE" ]]; then
         print_error "No active Ralph loop to increment"
         return 1
     fi
 
-    # Get current iteration
     local current_iteration
     current_iteration=$(grep '^iteration:' "$RALPH_STATE_FILE" | sed 's/iteration: *//')
 
     if [[ ! "$current_iteration" =~ ^[0-9]+$ ]]; then
-        print_error "State file corrupted - iteration is not a number"
+        print_error "State file corrupted"
         return 1
     fi
 
     local next_iteration=$((current_iteration + 1))
 
-    # Update iteration in frontmatter (portable across macOS and Linux)
     local temp_file
-    temp_file=$(mktemp) || { print_error "Failed to create temp file"; return 1; }
+    temp_file=$(mktemp)
     sed "s/^iteration: .*/iteration: $next_iteration/" "$RALPH_STATE_FILE" > "$temp_file"
     mv "$temp_file" "$RALPH_STATE_FILE"
 
@@ -542,41 +728,18 @@ increment_iteration() {
     return 0
 }
 
-# Get the prompt from the state file
-# Arguments: none
-# Returns: 0 on success, 1 if no active loop
-# Output: Prompt text to stdout
+# Get prompt (legacy)
 get_prompt() {
     if [[ ! -f "$RALPH_STATE_FILE" ]]; then
         print_error "No active Ralph loop"
         return 1
     fi
 
-    # Extract prompt (everything after the closing ---)
     awk '/^---$/{i++; next} i>=2' "$RALPH_STATE_FILE"
     return 0
 }
 
-# Get max iterations setting from state file
-# Arguments: none
-# Returns: 0 (always succeeds)
-# Output: Max iterations number to stdout (0 if no active loop)
-get_max_iterations() {
-    if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-        echo "0"
-        return 0
-    fi
-
-    local frontmatter
-    frontmatter=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
-    echo "$frontmatter" | grep '^max_iterations:' | sed 's/max_iterations: *//'
-    return 0
-}
-
-# Get completion promise from state file
-# Arguments: none
-# Returns: 0 (always succeeds)
-# Output: Completion promise to stdout ("null" if no active loop or not set)
+# Get completion promise (legacy)
 get_completion_promise() {
     if [[ ! -f "$RALPH_STATE_FILE" ]]; then
         echo "null"
@@ -589,168 +752,6 @@ get_completion_promise() {
     return 0
 }
 
-# Run an external Ralph loop for tools without hook support
-# Arguments:
-#   $@ - Prompt and options (--tool NAME, --max-iterations N, --completion-promise "TEXT")
-# Returns: 0 on completion, 1 on error
-# Side effects: Runs AI tool repeatedly until completion or max iterations
-run_external_loop() {
-    local prompt=""
-    local max_iterations=0
-    local completion_promise="null"
-    local tool="opencode"
-    local prompt_parts=()
-
-    # Parse arguments
-    while [[ $# -gt 0 ]]; do
-        case $1 in
-            --max-iterations)
-                if [[ -z "${2:-}" ]]; then
-                    print_error "--max-iterations requires a number argument"
-                    return 1
-                fi
-                if ! [[ "$2" =~ ^[0-9]+$ ]]; then
-                    print_error "--max-iterations must be a positive integer, got: $2"
-                    return 1
-                fi
-                max_iterations="$2"
-                shift 2
-                ;;
-            --completion-promise)
-                if [[ -z "${2:-}" ]]; then
-                    print_error "--completion-promise requires a text argument"
-                    return 1
-                fi
-                completion_promise="$2"
-                shift 2
-                ;;
-            --tool)
-                if [[ -z "${2:-}" ]]; then
-                    print_error "--tool requires a tool name argument"
-                    return 1
-                fi
-                tool="$2"
-                shift 2
-                ;;
-            *)
-                prompt_parts+=("$1")
-                shift
-                ;;
-        esac
-    done
-
-    prompt="${prompt_parts[*]}"
-
-    if [[ -z "$prompt" ]]; then
-        print_error "No prompt provided for external loop"
-        return 1
-    fi
-
-    # Validate tool availability before starting loop
-    if ! command -v "$tool" &>/dev/null; then
-        print_error "Tool '$tool' not found. Please install it or use --tool to specify a different tool."
-        print_info "Available tools: opencode, claude, aider"
-        return 1
-    fi
-
-    print_info "Starting external Ralph loop with $tool"
-    echo "Prompt: $prompt"
-    echo "Max iterations: $(if [[ $max_iterations -gt 0 ]]; then echo "$max_iterations"; else echo "unlimited"; fi)"
-    echo "Completion promise: $(if [[ "$completion_promise" != "null" ]]; then echo "$completion_promise"; else echo "none"; fi)"
-    echo ""
-
-    local iteration=1
-    local output_file
-    output_file=$(mktemp)
-
-    # Cleanup on exit
-    trap 'rm -f "$output_file"' EXIT
-
-    while true; do
-        print_info "Ralph iteration $iteration"
-
-        # Check max iterations
-        if [[ $max_iterations -gt 0 ]] && [[ $iteration -gt $max_iterations ]]; then
-            print_warning "Max iterations ($max_iterations) reached. Stopping."
-            break
-        fi
-
-        # Build the full prompt with iteration info
-        local full_prompt
-        if [[ "$completion_promise" != "null" ]]; then
-            full_prompt="[Ralph iteration $iteration] $prompt
-
-To complete, output: <promise>$completion_promise</promise> (ONLY when TRUE)"
-        else
-            full_prompt="[Ralph iteration $iteration] $prompt"
-        fi
-
-        # Run the AI tool (capture exit code, log failures but continue loop)
-        local tool_exit_code=0
-        case "$tool" in
-            opencode)
-                echo "$full_prompt" | opencode --print > "$output_file" 2>&1 || tool_exit_code=$?
-                ;;
-            claude)
-                echo "$full_prompt" | claude --print > "$output_file" 2>&1 || tool_exit_code=$?
-                ;;
-            aider)
-                # Aider uses --message flag only (not stdin) to avoid duplicate prompts
-                aider --yes --message "$full_prompt" > "$output_file" 2>&1 || tool_exit_code=$?
-                ;;
-            *)
-                print_error "Unknown tool: $tool"
-                return 1
-                ;;
-        esac
-
-        # Log tool failures but continue (AI tools may exit non-zero for various reasons)
-        if [[ $tool_exit_code -ne 0 ]]; then
-            print_warning "Tool '$tool' exited with code $tool_exit_code (continuing loop)"
-        fi
-
-        # Check for completion
-        if [[ "$completion_promise" != "null" ]]; then
-            local result
-            result=$(check_completion "$(cat "$output_file")" "$completion_promise")
-            if [[ "$result" == "COMPLETE" ]]; then
-                print_success "Completion promise detected! Loop finished."
-                break
-            fi
-        fi
-
-        iteration=$((iteration + 1))
-
-        # Adaptive delay with exponential backoff
-        # Starts at RALPH_DELAY_BASE, increases by RALPH_DELAY_MULTIPLIER each iteration
-        # Capped at RALPH_DELAY_MAX
-        local delay
-        # Calculate: base * multiplier^(iteration-1), using bc for floating point
-        if command -v bc &>/dev/null; then
-            delay=$(echo "scale=0; $RALPH_DELAY_BASE * ($RALPH_DELAY_MULTIPLIER ^ ($iteration - 1))" | bc 2>/dev/null || echo "$RALPH_DELAY_BASE")
-            # Cap at max
-            if [[ $(echo "$delay > $RALPH_DELAY_MAX" | bc 2>/dev/null || echo "0") -eq 1 ]]; then
-                delay=$RALPH_DELAY_MAX
-            fi
-        else
-            # Fallback: simple doubling without bc
-            delay=$RALPH_DELAY_BASE
-            local i=1
-            while [[ $i -lt $iteration ]] && [[ $delay -lt $RALPH_DELAY_MAX ]]; do
-                delay=$((delay * 2))
-                ((i++))
-            done
-            [[ $delay -gt $RALPH_DELAY_MAX ]] && delay=$RALPH_DELAY_MAX
-        fi
-        
-        print_info "Waiting ${delay}s before next iteration (backoff: iteration $iteration)"
-        sleep "$delay"
-    done
-
-    print_success "Ralph loop completed after $iteration iterations"
-    return 0
-}
-
 # =============================================================================
 # Main
 # =============================================================================
@@ -760,6 +761,13 @@ main() {
     shift || true
 
     case "$command" in
+        run)
+            run_v2_loop "$@"
+            ;;
+        external)
+            # Legacy alias for 'run'
+            run_v2_loop "$@"
+            ;;
         setup)
             setup_loop "$@"
             ;;
@@ -768,6 +776,9 @@ main() {
             ;;
         status)
             show_status "$@"
+            ;;
+        reanchor)
+            generate_reanchor "$@"
             ;;
         check|check-completion)
             if [[ $# -lt 1 ]]; then
@@ -784,14 +795,8 @@ main() {
         get-prompt)
             get_prompt
             ;;
-        get-max-iterations)
-            get_max_iterations
-            ;;
         get-completion-promise)
             get_completion_promise
-            ;;
-        external)
-            run_external_loop "$@"
             ;;
         help|--help|-h)
             show_help


### PR DESCRIPTION
## Summary

Implements Ralph Loop v2 architecture based on [flow-next](https://github.com/gmickel/gmickel-claude-marketplace/tree/main/plugins/flow-next), addressing the core issue identified by @gmickel:

> "Single session, accumulating context, no re-anchoring. This really defeats the purpose."

### Key Changes

- **Fresh context per iteration** - External bash loop spawns new AI sessions
- **File I/O as state** - JSON-based state files, not conversation transcript
- **Re-anchor every iteration** - Re-read TODO.md, git state, memories
- **Receipt-based verification** - Proof of work for each iteration
- **Memory integration** - SQLite FTS5 for cross-session learning

### Files Changed

| File | Change |
|------|--------|
| `loop-common.sh` | NEW - Shared infrastructure for all loop components |
| `ralph-loop-helper.sh` | v2 `run` command with fresh sessions, legacy `setup` preserved |
| `full-loop-helper.sh` | Auto-detects v2 infrastructure |
| `ralph-loop.md` | Updated documentation |

### Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│  ralph-loop-helper.sh v2 (external loop)                        │
│  ┌───────────────────────────────────────────────────────────┐  │
│  │ while true; do                                            │  │
│  │   1. Generate re-anchor prompt (TODO.md, git, memories)   │  │
│  │   2. opencode run "$PROMPT" --print  # Fresh session!     │  │
│  │   3. Check for completion promise                         │  │
│  │   4. Create receipt (proof of work)                       │  │
│  │   5. If complete → break                                  │  │
│  │   6. If stuck N times → block task                        │  │
│  │ done                                                      │  │
│  └───────────────────────────────────────────────────────────┘  │
└─────────────────────────────────────────────────────────────────┘
```

### Usage

```bash
# v2: Fresh sessions per iteration (recommended)
ralph-loop-helper.sh run "Build a REST API" --tool opencode --max-iterations 20

# Legacy: Same-session loop (backward compatible)
ralph-loop-helper.sh setup "Build a REST API" --max-iterations 20
```

### References

- Original critique: https://x.com/gmickel/status/2009939771171434867
- flow-next implementation: https://github.com/gmickel/gmickel-claude-marketplace
- Original Ralph technique: https://ghuntley.com/ralph/