### PR TITLE
fix(worktree): prevent removal of unpushed branches and uncommitted changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -125,8 +125,10 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
   - Notes: Cursor-style MCP description sync to .agent-workspace/mcp-descriptions/. Add search tool for on-demand discovery instead of loading all tool definitions upfront.
 - [ ] t057 Memory consolidation and pruning #memory #optimization ~2h (ai:1h test:45m read:15m) logged:2025-01-11 blocked-by:t052
   - Notes: Add memory-helper.sh consolidate command. Periodic reflection to merge similar memories and prune stale/superseded entries.
+- [ ] t058 Memory Auto-Capture #plan → [todo/PLANS.md#memory-auto-capture] ~1d (ai:6h test:4h read:2h) logged:2026-01-11
+  - Notes: Automatic memory capture inspired by claude-mem but tool-agnostic. Agent instructions trigger capture after significant operations. Works with OpenCode, Cursor, Claude Code, Windsurf. PRD: todo/tasks/prd-memory-auto-capture.md
 
-<!--TOON:backlog[38]{id,desc,owner,tags,est,est_ai,est_test,est_read,logged,status,blocked_by,blocks,parent}:
+<!--TOON:backlog[39]{id,desc,owner,tags,est,est_ai,est_test,est_read,logged,status,blocked_by,blocks,parent}:
 t010,Evaluate Merging build-agent and build-mcp into aidevops,,plan|architecture|agents,4h,2h,1h,1h,2025-12-21T14:00Z,pending,,,
 t009,Claude Code Destructive Command Hooks,,plan|claude|git|security,4h,2h,1h,1h,2025-12-21T12:00Z,pending,,,
 t008,aidevops-opencode Plugin,,plan,2d,1d,0.5d,0.5d,2025-12-21T01:50Z,pending,,,
@@ -177,6 +179,7 @@ t054,Automatic session reflection to memory,,workflow|memory,4h,2.5h,1h,30m,2025
 t055,Document cache-aware prompt patterns,,docs|optimization,1h,30m,15m,15m,2025-01-11T00:00Z,pending,t052,,
 t056,Tool description indexing for on-demand MCP discovery,,tools|context,3h,2h,45m,15m,2025-01-11T00:00Z,pending,t052,,
 t057,Memory consolidation and pruning,,memory|optimization,2h,1h,45m,15m,2025-01-11T00:00Z,pending,t052,,
+t058,Memory Auto-Capture,,plan|memory|automation|context,1d,6h,4h,2h,2026-01-11T12:00Z,pending,,,
 -->
 
 <!--TOON:subtasks[0]{id,desc,est,status,blocked_by,parent}:
@@ -263,5 +266,5 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 -->
 
 <!--TOON:summary{total,pending,in_progress,in_review,done,declined,total_est,total_actual,blocked_count,ready_count}:
-51,40,0,0,26,0,26d18h,16h50m,0,40
+52,41,0,0,26,0,27d18h,16h50m,0,41
 -->

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -800,7 +800,7 @@ disc001,p009,Implementation faster than estimated,All core functionality already
 p009,beads-sync-helper.sh; todo-ready.sh; beads.md subagent; blocked-by/blocks syntax; hierarchical IDs; TOON schema; setup.sh integration; AGENTS.md docs,Robust sync script; comprehensive docs; seamless integration,Add optional UI installation to setup.sh,2d,1.5d,-25,1
 -->
 
-<!--TOON:active_plans[8]{id,title,status,phase,total_phases,owner,tags,est,est_ai,est_test,est_read,logged,started}:
+<!--TOON:active_plans[9]{id,title,status,phase,total_phases,owner,tags,est,est_ai,est_test,est_read,logged,started}:
 p001,aidevops-opencode Plugin,planning,0,4,,opencode|plugin,2d,1d,0.5d,0.5d,2025-12-21T01:50Z,
 p002,Claude Code Destructive Command Hooks,planning,0,4,,claude|git|security,4h,2h,1h,1h,2025-12-21T12:00Z,
 p003,Evaluate Merging build-agent and build-mcp into aidevops,planning,0,3,,architecture|agents,4h,2h,1h,1h,2025-12-21T14:00Z,
@@ -810,6 +810,7 @@ p006,Uncloud Integration for aidevops,planning,0,4,,deployment|docker|orchestrat
 p007,SEO Machine Integration for aidevops,planning,0,5,,seo|content|agents,2d,1d,0.5d,0.5d,2025-12-21T15:00Z,
 p008,Enhance Plan+ and Build+ with OpenCode's Latest Features,planning,0,4,,opencode|agents|enhancement,3h,1.5h,1h,30m,2025-12-21T04:30Z,
 p010,Agent Design Pattern Improvements,planning,0,5,,architecture|agents|context|optimization,1d,6h,4h,2h,2025-01-11T00:00Z,
+p011,Memory Auto-Capture,planning,0,5,,memory|automation|context,1d,6h,4h,2h,2026-01-11T12:00Z,
 -->
 
 ### [2025-01-11] Agent Design Pattern Improvements
@@ -887,6 +888,100 @@ m052,p010,Phase 5: Memory consolidation,2h,,2025-01-11T00:00Z,,pending
 <!--TOON:decisions[2]{id,plan_id,decision,rationale,date,impact}:
 d017,p010,Document patterns before implementing improvements,Establishes baseline and validates alignment,2025-01-11,None
 d018,p010,Prioritize automatic session reflection,Highest impact for continual learning,2025-01-11,None
+-->
+
+#### Surprises & Discoveries
+
+(To be populated during implementation)
+
+<!--TOON:discoveries[0]{id,plan_id,observation,evidence,impact,date}:
+-->
+
+### [2026-01-11] Memory Auto-Capture
+
+**Status:** Planning
+**Estimate:** ~1d (ai:6h test:4h read:2h)
+**PRD:** [todo/tasks/prd-memory-auto-capture.md](tasks/prd-memory-auto-capture.md)
+**Source:** [claude-mem](https://github.com/thedotmack/claude-mem) - inspiration for auto-capture patterns
+
+<!--TOON:plan{id,title,status,phase,total_phases,owner,tags,est,est_ai,est_test,est_read,logged,started}:
+p011,Memory Auto-Capture,planning,0,5,,memory|automation|context,1d,6h,4h,2h,2026-01-11T12:00Z,
+-->
+
+#### Purpose
+
+Add automatic memory capture to aidevops, inspired by claude-mem but tool-agnostic. Currently, memory requires manual `/remember` invocation. Auto-capture will:
+- Capture working solutions, failed approaches, and decisions automatically
+- Work across all AI tools (OpenCode, Cursor, Claude Code, Windsurf)
+- Use progressive disclosure to minimize token usage
+- Maintain minimal dependencies (bash + sqlite3)
+
+#### Context from Discussion
+
+**Why not use claude-mem as dependency:**
+- Claude Code only (plugin architecture)
+- Heavy dependencies (Bun, uv, Chroma, Node.js worker)
+- AGPL license (viral, requires source disclosure)
+- aidevops needs tool-agnostic solution
+
+**What we'll implement:**
+- Agent instructions for auto-capture (not lifecycle hooks)
+- Semantic classification into memory types
+- Deduplication via FTS5 similarity
+- Privacy controls (`<private>` tags, .gitignore patterns)
+- `/memory-log` command for reviewing captures
+
+**Architecture decision:** Use agent instructions (Option A) rather than shell wrappers or file watchers. This works with any AI tool that reads AGENTS.md.
+
+#### Progress
+
+- [ ] (2026-01-11) Phase 1: Research & Design ~2h
+  - Finalize capture triggers and thresholds
+  - Design classification rules
+  - Document privacy patterns
+- [ ] (2026-01-11) Phase 2: memory-helper.sh updates ~3.5h
+  - Add `--auto-captured` flag
+  - Add deduplication logic
+  - Add capture statistics
+- [ ] (2026-01-11) Phase 3: AGENTS.md instructions ~2h
+  - Add auto-capture instructions to AGENTS.md
+  - Define when to capture (success, failure, decisions)
+  - Add privacy exclusion patterns
+- [ ] (2026-01-11) Phase 4: /memory-log command ~2h
+  - Create `scripts/commands/memory-log.md`
+  - Show recent auto-captures with filtering
+  - Add prune command for cleanup
+- [ ] (2026-01-11) Phase 5: Privacy filters ~2.5h
+  - Integrate with .gitignore patterns
+  - Add `<private>` tag support
+  - Add secretlint pattern exclusions
+
+<!--TOON:milestones[5]{id,plan_id,desc,est,actual,scheduled,completed,status}:
+m053,p011,Phase 1: Research & Design,2h,,2026-01-11T12:00Z,,pending
+m054,p011,Phase 2: memory-helper.sh updates,3.5h,,2026-01-11T12:00Z,,pending
+m055,p011,Phase 3: AGENTS.md instructions,2h,,2026-01-11T12:00Z,,pending
+m056,p011,Phase 4: /memory-log command,2h,,2026-01-11T12:00Z,,pending
+m057,p011,Phase 5: Privacy filters,2.5h,,2026-01-11T12:00Z,,pending
+-->
+
+#### Decision Log
+
+- **Decision:** Use agent instructions instead of lifecycle hooks
+  **Rationale:** Tool-agnostic; works with OpenCode, Cursor, Claude Code, Windsurf without plugins
+  **Date:** 2026-01-11
+
+- **Decision:** Keep FTS5 for search, no vector embeddings
+  **Rationale:** Minimal dependencies; FTS5 is sufficient for keyword search; semantic search adds complexity
+  **Date:** 2026-01-11
+
+- **Decision:** Implement ourselves rather than depend on claude-mem
+  **Rationale:** claude-mem is Claude Code-only; aidevops needs multi-tool support
+  **Date:** 2026-01-11
+
+<!--TOON:decisions[3]{id,plan_id,decision,rationale,date,impact}:
+d019,p011,Use agent instructions instead of lifecycle hooks,Tool-agnostic; works with all AI tools,2026-01-11,None
+d020,p011,Keep FTS5 for search no vector embeddings,Minimal dependencies; FTS5 sufficient,2026-01-11,None
+d021,p011,Implement ourselves rather than depend on claude-mem,claude-mem is Claude Code-only,2026-01-11,None
 -->
 
 #### Surprises & Discoveries

--- a/todo/tasks/prd-memory-auto-capture.md
+++ b/todo/tasks/prd-memory-auto-capture.md
@@ -1,0 +1,245 @@
+---
+mode: subagent
+---
+# Product Requirements Document: Memory Auto-Capture
+
+Based on [ai-dev-tasks](https://github.com/snarktank/ai-dev-tasks) PRD format, with time tracking.
+
+<!--TOON:prd{id,feature,author,status,est,est_ai,est_test,est_read,logged}:
+prd-memory-auto-capture,Memory Auto-Capture,aidevops,draft,1d,6h,4h,2h,2026-01-11T12:00Z
+-->
+
+## Overview
+
+**Feature:** Memory Auto-Capture
+**Author:** aidevops
+**Date:** 2026-01-11
+**Status:** Draft
+**Estimate:** ~1d (ai:6h test:4h read:2h)
+**Reference:** [claude-mem](https://github.com/thedotmack/claude-mem) - 13k+ stars, inspiration for auto-capture patterns
+
+### Problem Statement
+
+Currently, aidevops memory requires manual `/remember` invocation. Users must consciously decide what to store, leading to:
+- Forgotten solutions that worked
+- Repeated debugging of the same issues
+- Lost context between sessions
+- Inconsistent memory capture across users
+
+claude-mem solves this with automatic capture via lifecycle hooks, but is Claude Code-only. aidevops needs a tool-agnostic solution.
+
+### Goal
+
+Implement automatic memory capture that:
+1. Works across all AI tools (OpenCode, Cursor, Claude Code, Windsurf)
+2. Captures working solutions, failed approaches, and decisions automatically
+3. Uses progressive disclosure to minimize token usage
+4. Maintains our minimal dependency philosophy (bash + sqlite3)
+
+## User Stories
+
+### Primary User Story
+
+As a developer using AI assistants, I want my working solutions and failed approaches automatically captured so that future sessions can learn from past work without manual intervention.
+
+### Additional User Stories
+
+- As a developer, I want to see what was auto-captured so I can verify quality and prune noise.
+- As a developer, I want to control what gets captured so sensitive information stays private.
+- As a developer, I want auto-captured memories to be searchable so I can find relevant context quickly.
+
+## Functional Requirements
+
+### Core Requirements
+
+1. **Post-Tool Capture Hook**: Automatically capture observations after significant tool operations (file edits, bash commands, git operations)
+2. **Semantic Classification**: Auto-classify captures into memory types (WORKING_SOLUTION, FAILED_APPROACH, CODEBASE_PATTERN, etc.)
+3. **Deduplication**: Prevent storing duplicate or near-duplicate observations
+4. **Privacy Controls**: Support `<private>` tags or patterns to exclude sensitive content
+
+### Secondary Requirements
+
+5. **Capture Summary View**: `/memory-log` command to show recent auto-captures
+6. **Capture Pruning**: Automatic cleanup of low-value captures after N days
+7. **Progressive Disclosure**: Index-first retrieval pattern (like claude-mem's 3-layer workflow)
+
+## Non-Goals (Out of Scope)
+
+- Vector embeddings / semantic search (keep FTS5 for simplicity)
+- Web UI for memory browsing (CLI-only for now)
+- AI-powered compression of observations (store raw, let retrieval filter)
+- Real-time sync across machines (local SQLite only)
+- Claude Code plugin architecture (we're tool-agnostic)
+
+## Design Considerations
+
+### Capture Triggers
+
+| Trigger | What to Capture | Memory Type |
+|---------|-----------------|-------------|
+| File edit succeeds | File path, change summary | CODEBASE_PATTERN |
+| Bash command succeeds | Command, output summary | WORKING_SOLUTION |
+| Bash command fails | Command, error message | FAILED_APPROACH |
+| Git commit | Commit message, files changed | DECISION |
+| Error resolved | Error message, fix applied | WORKING_SOLUTION |
+
+### Capture Format
+
+```json
+{
+  "timestamp": "2026-01-11T12:00:00Z",
+  "type": "WORKING_SOLUTION",
+  "trigger": "bash_success",
+  "content": "Fixed CORS with nginx: add_header 'Access-Control-Allow-Origin' '*';",
+  "context": {
+    "project": "myapp",
+    "file": "nginx.conf",
+    "command": "nginx -t && nginx -s reload"
+  },
+  "auto_captured": true
+}
+```
+
+### User Experience
+
+1. **Transparent**: Auto-capture happens silently, no interruption
+2. **Reviewable**: `/memory-log` shows what was captured
+3. **Controllable**: `<private>` tags exclude content
+4. **Searchable**: `/recall` finds both manual and auto-captured memories
+
+## Technical Considerations
+
+### Architecture
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                     AI Assistant Session                     │
+├─────────────────────────────────────────────────────────────┤
+│  Tool Call (Edit/Bash/Git)                                  │
+│         │                                                    │
+│         ▼                                                    │
+│  ┌─────────────────┐                                        │
+│  │ Capture Filter  │ ← Checks: success? significant? private?│
+│  └────────┬────────┘                                        │
+│           │                                                  │
+│           ▼                                                  │
+│  ┌─────────────────┐                                        │
+│  │ Auto-Classifier │ ← Determines memory type               │
+│  └────────┬────────┘                                        │
+│           │                                                  │
+│           ▼                                                  │
+│  ┌─────────────────┐                                        │
+│  │ Deduplicator    │ ← FTS5 similarity check                │
+│  └────────┬────────┘                                        │
+│           │                                                  │
+│           ▼                                                  │
+│  ┌─────────────────┐                                        │
+│  │ memory-helper.sh│ ← store --auto-captured                │
+│  └────────┬────────┘                                        │
+│           │                                                  │
+│           ▼                                                  │
+│  ┌─────────────────┐                                        │
+│  │   memory.db     │ ← SQLite FTS5                          │
+│  └─────────────────┘                                        │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Implementation Options
+
+**Option A: Agent Instructions (Recommended)**
+- Add auto-capture instructions to AGENTS.md
+- AI assistant calls `memory-helper.sh store --auto` after significant operations
+- Works with any AI tool that reads AGENTS.md
+- No external dependencies
+
+**Option B: Shell Wrapper**
+- Wrap common commands (git, npm, etc.) with capture hooks
+- More automatic but requires shell configuration
+- May conflict with user's existing aliases
+
+**Option C: File Watcher**
+- Watch for file changes and git operations
+- Most automatic but requires background daemon
+- Adds complexity, may miss context
+
+**Recommendation:** Option A - Agent instructions are tool-agnostic and require no additional infrastructure.
+
+### Dependencies
+
+- `memory-helper.sh`: Existing script, needs `--auto-captured` flag
+- `sqlite3`: Already required for memory system
+- No new dependencies
+
+### Constraints
+
+- Must work without background processes
+- Must not slow down normal operations
+- Must respect `.gitignore` patterns for privacy
+- Must work offline (no API calls for classification)
+
+### Security Considerations
+
+- Never auto-capture content matching `.gitignore` patterns
+- Never auto-capture content in `<private>` tags
+- Never auto-capture credentials, API keys, or secrets
+- Respect `secretlint` patterns for exclusion
+
+## Time Estimate Breakdown
+
+| Phase | AI Time | Test Time | Read Time | Total |
+|-------|---------|-----------|-----------|-------|
+| Research & Design | 1h | - | 1h | 2h |
+| memory-helper.sh updates | 2h | 1h | 30m | 3.5h |
+| AGENTS.md instructions | 1h | 30m | 30m | 2h |
+| /memory-log command | 1h | 1h | - | 2h |
+| Privacy filters | 1h | 1.5h | - | 2.5h |
+| **Total** | **6h** | **4h** | **2h** | **12h** |
+
+<!--TOON:time_breakdown[5]{phase,ai,test,read,total}:
+research,1h,,1h,2h
+memory-helper,2h,1h,30m,3.5h
+agents-md,1h,30m,30m,2h
+memory-log,1h,1h,,2h
+privacy,1h,1.5h,,2.5h
+-->
+
+## Success Metrics
+
+| Metric | Target | Measurement Method |
+|--------|--------|-------------------|
+| Auto-captures per session | 5-20 | Count in memory.db |
+| Duplicate rate | <10% | Dedup filter stats |
+| Retrieval relevance | >80% useful | User feedback |
+| Performance impact | <100ms per capture | Timing logs |
+
+## Open Questions
+
+- [x] Should we use agent instructions or shell wrappers? → Agent instructions (Option A)
+- [ ] What's the right threshold for "significant" operations?
+- [ ] Should auto-captures have lower priority in search results?
+- [ ] How long to retain auto-captures before pruning?
+
+## Appendix
+
+### Related Documents
+
+- [memory/README.md](../../.agent/memory/README.md) - Current memory system docs
+- [claude-mem](https://github.com/thedotmack/claude-mem) - Reference implementation
+- [scripts/commands/remember.md](../../.agent/scripts/commands/remember.md) - Manual memory command
+
+### Comparison with claude-mem
+
+| Feature | claude-mem | aidevops (proposed) |
+|---------|------------|---------------------|
+| Auto-capture | Lifecycle hooks | Agent instructions |
+| Storage | SQLite + Chroma | SQLite FTS5 only |
+| Search | Semantic + keyword | FTS5 keyword |
+| Dependencies | Bun, uv, Chroma | bash, sqlite3 |
+| Tool support | Claude Code only | All AI tools |
+| Token efficiency | 3-layer progressive | Index-first retrieval |
+
+### Revision History
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-01-11 | aidevops | Initial draft |


### PR DESCRIPTION
## Summary

- **Critical bug fix** for `worktree-helper.sh clean` command that was incorrectly removing worktrees with unpushed branches
- Adds Memory Auto-Capture plan (t058) inspired by claude-mem but tool-agnostic

## Bug Fix Details

The `cmd_clean()` function had a dangerous false positive in its "remote deleted" check:

```bash
# OLD (buggy): Assumed missing remote = merged
elif ! git show-ref --verify --quiet "refs/remotes/origin/$worktree_branch" 2>/dev/null; then
    is_merged=true
    merge_type="remote deleted"
fi
```

This incorrectly flagged **unpushed branches** for removal because they have no remote tracking branch yet.

### Changes

1. **`branch_was_pushed()` helper** - Checks if branch was ever pushed to remote
2. **`worktree_has_changes()` helper** - Detects uncommitted work in worktree
3. **Fixed "remote deleted" check** - Only applies if branch was previously pushed
4. **Added uncommitted changes safety** - Skips worktrees with uncommitted work
5. **Removed `--force` fallback** - Prevented bypassing safety checks

## Memory Auto-Capture Plan

Added planning documents for automatic memory capture feature:
- PRD: `todo/tasks/prd-memory-auto-capture.md`
- Plan: `todo/PLANS.md` (p011)
- Task: `TODO.md` (t058)

Inspired by [claude-mem](https://github.com/thedotmack/claude-mem) but designed to be tool-agnostic (works with OpenCode, Cursor, Claude Code, Windsurf).

## Testing

The fix can be verified by:
1. Creating a worktree with an unpushed branch
2. Running `worktree-helper.sh clean`
3. Confirming the unpushed branch is NOT flagged for removal