### PR TITLE
fix(sonarcloud): add missing default cases to case statements

### DIFF
--- a/.agent/scripts/quality-loop-helper.sh
+++ b/.agent/scripts/quality-loop-helper.sh
@@ -816,6 +816,9 @@ pr_review_loop() {
                     fi
                 fi
                 ;;
+            *)
+                print_warning "Unknown PR status: $status"
+                ;;
         esac
         
         iteration=$(increment_iteration)

--- a/.agent/scripts/terminal-title-helper.sh
+++ b/.agent/scripts/terminal-title-helper.sh
@@ -99,6 +99,9 @@ detect_terminal() {
             echo "hyper"
             return 0
             ;;
+        *)
+            # Not a known TERM_PROGRAM, continue to TERM check
+            ;;
     esac
     
     # Check by TERM variable for other terminals
@@ -106,6 +109,9 @@ detect_terminal() {
         xterm*|rxvt*|screen*|tmux*|alacritty|kitty*)
             echo "compatible"
             return 0
+            ;;
+        *)
+            # Not a known TERM, continue to other checks
             ;;
     esac
     


### PR DESCRIPTION
## Summary

Add missing default cases to switch/case statements to fix SonarCloud warnings.

## Changes

- Add default cases to `quality-loop-helper.sh`
- Add default cases to `terminal-title-helper.sh`

## Related

Fixes SonarCloud rule violations for missing default cases.