### PR TITLE
feat(localhost): add port management and loop-mode auto-branch

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -42,6 +42,22 @@ If the script outputs "STOP - ON PROTECTED BRANCH", you MUST NOT proceed with ed
 
 3. **Do NOT proceed until user replies with 1, 2, or 3**
 
+**Loop mode (autonomous agents)**: Loop agents (`/full-loop`, `/ralph-loop`) use auto-decision to avoid stalling:
+
+```bash
+~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "task description"
+```
+
+Auto-decision rules:
+- **Docs-only tasks** (README, CHANGELOG, docs/, typos) -> Option 3 (stay on main)
+- **Code tasks** (feature, fix, implement, refactor, enhance) -> Option 1 (create worktree automatically)
+
+Exit codes: `0` = proceed, `1` = interactive stop, `2` = create worktree needed
+
+Detection keywords:
+- Docs-only: `readme`, `changelog`, `documentation`, `docs/`, `typo`, `spelling`
+- Code (overrides docs): `feature`, `fix`, `bug`, `implement`, `refactor`, `add`, `update`, `enhance`, `port`, `ssl`, `helper`
+
 **Why worktrees are the default**: The main repo directory (`~/Git/{repo}/`) should ALWAYS stay on `main`. This prevents:
 - Uncommitted changes blocking branch switches
 - Parallel sessions inheriting wrong branch state
@@ -92,6 +108,13 @@ Run pre-edit-check.sh in `~/Git/aidevops/` BEFORE any changes to either location
 - Re-read files immediately before editing (stale reads cause "file modified" errors)
 
 **Quality Standards**: SonarCloud A-grade, ShellCheck zero violations
+
+**Localhost Standards** (for any local service setup):
+- **Always check port first**: `localhost-helper.sh check-port <port>` before starting services
+- **Use .local domains**: `myapp.local` not `localhost:3000` (enables password manager autofill)
+- **Always use SSL**: Via Traefik proxy with mkcert certificates
+- **Auto-find ports**: `localhost-helper.sh find-port <start>` if preferred port is taken
+- See `services/hosting/localhost.md` for full setup guide
 
 **SonarCloud Hotspot Patterns** (auto-excluded via `sonar-project.properties`):
 - Scripts matching `*-helper.sh`, `*-setup.sh`, `*-cli.sh`, `*-verify.sh` are excluded from:

--- a/.agent/scripts/pre-edit-check.sh
+++ b/.agent/scripts/pre-edit-check.sh
@@ -49,8 +49,8 @@ done
 # Function to detect if task is docs-only
 is_docs_only() {
     local task="$1"
-    local task_lower
-    task_lower=$(echo "$task" | tr '[:upper:]' '[:lower:]')
+    # Use bash 4.0+ parameter expansion for lowercase (more efficient than tr)
+    local task_lower="${task,,}"
     
     # Code change indicators (negative match - if present, NOT docs-only)
     # These take precedence over docs patterns

--- a/.agent/services/hosting/localhost.md
+++ b/.agent/services/hosting/localhost.md
@@ -39,11 +39,11 @@ tools:
 # 1. Check port availability first
 localhost-helper.sh check-port 3000
 
-# 2. If conflict, find next available
-localhost-helper.sh find-port 3000
+# 2. If conflict, find next available (returns e.g., 3001)
+available_port=$(localhost-helper.sh find-port 3000)
 
-# 3. Create app with .local domain + SSL
-localhost-helper.sh create-app myapp myapp.local 3000 true docker
+# 3. Create app with .local domain + SSL using available port
+localhost-helper.sh create-app myapp myapp.local "$available_port" true docker
 ```
 
 <!-- AI-CONTEXT-END -->
@@ -82,11 +82,11 @@ Traditional local development uses URLs like `http://localhost:3000`. This cause
 ~/.aidevops/agents/scripts/localhost-helper.sh check-port 3000
 
 # 2. If in use, find next available
-~/.aidevops/agents/scripts/localhost-helper.sh find-port 3000
-# Output: 3001
+available_port=$(~/.aidevops/agents/scripts/localhost-helper.sh find-port 3000)
+echo "Using port: $available_port"
 
-# 3. Create app with .local domain + SSL
-~/.aidevops/agents/scripts/localhost-helper.sh create-app myapp myapp.local 3001 true docker
+# 3. Create app with .local domain + SSL using available port
+~/.aidevops/agents/scripts/localhost-helper.sh create-app myapp myapp.local "$available_port" true docker
 ```
 
 **Result:** Access your app at `https://myapp.local` with:

--- a/.agent/services/hosting/localhost.md
+++ b/.agent/services/hosting/localhost.md
@@ -19,15 +19,81 @@ tools:
 
 - **Type**: Local development environment management
 - **Config**: `configs/localhost-config.json`
-- **Commands**: `localhost-helper.sh [environments|start|stop|status|localwp-sites|start-site|stop-site|generate-ssl|list-ports|check-port|kill-port|start-mcp] [env] [args]`
-- **LocalWP**: Sites in `/Users/username/Local Sites`, MCP on port 3001
-- **SSL**: `generate-ssl`, `install-ssl`, `trust-cert` for local HTTPS
-- **Ports**: `list-ports`, `check-port`, `kill-port`, `forward-port`
-- **Docker**: `docker-up`, `docker-down`, `docker-logs`, `docker-exec`
-- **MCP query**: `mcp-query "SELECT * FROM wp_posts LIMIT 5"`
+- **Commands**: `localhost-helper.sh [check-port|find-port|list-ports|kill-port|generate-cert|setup-dns|setup-proxy|create-app|start-mcp] [args]`
+- **LocalWP**: Sites in `/Users/username/Local Sites`, MCP on port 8085
+- **SSL**: `generate-cert`, `setup-proxy` for local HTTPS via Traefik
+- **Ports**: `check-port`, `find-port`, `list-ports`, `kill-port`
+
+**CRITICAL: Why .local + SSL + Port Checking?**
+
+| Problem | Solution | Why It Matters |
+|---------|----------|----------------|
+| Port conflicts | `check-port`, `find-port` | Avoids "address already in use" errors |
+| Password managers don't work | SSL via Traefik proxy | 1Password, Bitwarden require HTTPS to autofill |
+| Inconsistent URLs | `.local` domains | `myapp.local` instead of `localhost:3847` |
+| Browser security warnings | `mkcert` trusted certs | No "proceed anyway" clicks |
+
+**Standard Setup Pattern:**
+
+```bash
+# 1. Check port availability first
+localhost-helper.sh check-port 3000
+
+# 2. If conflict, find next available
+localhost-helper.sh find-port 3000
+
+# 3. Create app with .local domain + SSL
+localhost-helper.sh create-app myapp myapp.local 3000 true docker
+```
+
 <!-- AI-CONTEXT-END -->
 
 Localhost development provides local development capabilities with .local domain support, perfect for development workflows and testing environments.
+
+## Why .local Domains + SSL + Port Management?
+
+### The Problem with `localhost:port`
+
+Traditional local development uses URLs like `http://localhost:3000`. This causes several issues:
+
+1. **Password managers don't work** - 1Password, Bitwarden, and other password managers require HTTPS to autofill credentials. They won't save or fill passwords on `http://` URLs for security reasons.
+
+2. **Port conflicts are common** - Multiple projects fighting for port 3000, 8080, etc. leads to "EADDRINUSE" errors and manual port hunting.
+
+3. **Inconsistent URLs** - Remembering which project is on which port is cognitive overhead. Was it 3000 or 3001?
+
+4. **No SSL testing** - Can't test SSL-specific features, secure cookies, or HSTS locally.
+
+### The Solution: .local + SSL + Port Checking
+
+| Component | Tool | Purpose |
+|-----------|------|---------|
+| `.local` domains | dnsmasq | Consistent, memorable URLs (`myapp.local`) |
+| SSL certificates | mkcert | Browser-trusted HTTPS locally |
+| Reverse proxy | Traefik | Routes `.local` domains to correct ports |
+| Port management | localhost-helper.sh | Avoids conflicts, finds available ports |
+
+### Standard Workflow
+
+**Before starting any local service:**
+
+```bash
+# 1. Check if desired port is available
+~/.aidevops/agents/scripts/localhost-helper.sh check-port 3000
+
+# 2. If in use, find next available
+~/.aidevops/agents/scripts/localhost-helper.sh find-port 3000
+# Output: 3001
+
+# 3. Create app with .local domain + SSL
+~/.aidevops/agents/scripts/localhost-helper.sh create-app myapp myapp.local 3001 true docker
+```
+
+**Result:** Access your app at `https://myapp.local` with:
+- Password manager autofill working
+- No port conflicts
+- Browser-trusted SSL
+- Consistent URL across sessions
 
 ## Provider Overview
 

--- a/.agent/workflows/ralph-loop.md
+++ b/.agent/workflows/ralph-loop.md
@@ -75,6 +75,29 @@ The loop creates a **self-referential feedback loop** where:
 ~/.aidevops/agents/scripts/ralph-loop-helper.sh cancel
 ```
 
+### Auto-Branch Handling (Loop Mode)
+
+When running in loop mode on main/master, Ralph automatically handles branch decisions:
+
+```bash
+# The helper script checks branch and auto-decides
+~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "Build a REST API for todos"
+```
+
+**Auto-decision rules:**
+
+| Task Type | Detection Keywords | Action |
+|-----------|-------------------|--------|
+| Docs-only | readme, changelog, docs/, documentation, typo, spelling | Stay on main (exit 0) |
+| Code | feature, fix, bug, implement, refactor, add, update, enhance | Create worktree (exit 2) |
+
+**Exit codes:**
+- `0` - Proceed (on feature branch or docs-only on main)
+- `2` - Create worktree (code task detected on main)
+- `1` - Error (shouldn't occur in loop mode)
+
+This eliminates the interactive prompt that previously stalled loop agents.
+
 ### Legacy: Same Session
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `--loop-mode` flag to `pre-edit-check.sh` for autonomous branch decisions in loop agents
- Add port management functions to `localhost-helper.sh` for conflict avoidance
- Document localhost standards (SSL, .local domains, port checking) for password manager compatibility

## Changes

### Loop Mode Auto-Branch (`pre-edit-check.sh`)

Loop agents (`/full-loop`, `/ralph-loop`) can now auto-decide branch handling:

```bash
~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "task description"
```

| Task Type | Detection | Exit Code | Action |
|-----------|-----------|-----------|--------|
| Docs-only | readme, changelog, docs/ | 0 | Stay on main |
| Code | feature, fix, implement | 2 | Create worktree |

This eliminates the interactive prompt that previously stalled autonomous loops.

### Port Management (`localhost-helper.sh`)

New commands:
- `check-port <port>` - Check availability, suggest alternative if in use
- `find-port <start>` - Find next available port
- `list-ports` - Show common dev ports in use
- `kill-port <port>` - Kill process on port

### Localhost Standards

Why `.local` domains + SSL + port checking:
1. **Password managers require HTTPS** - 1Password, Bitwarden won't autofill on `http://localhost:port`
2. **Port conflicts are common** - Multiple projects fighting for 3000, 8080
3. **Inconsistent URLs** - Remembering which port is cognitive overhead

Standard workflow:
```bash
localhost-helper.sh check-port 3000
localhost-helper.sh create-app myapp myapp.local 3000 true docker
# Access at https://myapp.local with password manager working
```

## Testing

```bash
# Test loop-mode (on main branch)
cd ~/Git/aidevops
~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "Update README"
# Output: LOOP_DECISION=stay, exit 0

~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "Implement feature"
# Output: LOOP_DECISION=worktree, exit 2

# Test port management
localhost-helper.sh check-port 3000
localhost-helper.sh find-port 3000
localhost-helper.sh list-ports
```

## Files Changed

| File | Purpose |
|------|---------|
| `pre-edit-check.sh` | Add `--loop-mode` flag with task detection |
| `localhost-helper.sh` | Add port management functions |
| `localhost.md` | Document rationale and standards |
| `AGENTS.md` | Add localhost standards to quick reference |
| `full-loop.md` | Document auto-branch handling |
| `ralph-loop.md` | Document auto-branch handling |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autonomous loop mode for agents with auto-decision flow: docs-only tasks remain on main; code tasks auto-create feature worktrees and explicit exit codes indicate proceed/stop/create-worktree.
  * Port management tools: check port availability, find free ports, list development ports, and terminate processes.
  * Local HTTPS via Traefik with .local domain support.

* **Documentation**
  * Expanded localhost standards, setup guide, and updated loop-mode workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->