### PR TITLE
docs: note OpenProse telemetry disabled by default

### DIFF
--- a/.agent/tools/ai-orchestration/openprose.md
+++ b/.agent/tools/ai-orchestration/openprose.md
@@ -22,6 +22,7 @@ tools:
 - **Key Feature**: Explicit control flow (`parallel:`, `loop until`, `try/catch`) for multi-agent workflows
 - **License**: MIT
 - **Repo**: https://github.com/openprose/prose
+- **Telemetry**: Disabled by default in aidevops (upstream enables by default)
 
 **When to Use OpenProse**:
 
@@ -42,6 +43,16 @@ git clone https://github.com/openprose/prose.git ~/.config/opencode/skill/open-p
 claude plugin marketplace add https://github.com/openprose/prose.git
 claude plugin install open-prose@prose
 ```
+
+**Telemetry**: OpenProse upstream enables telemetry by default. When using OpenProse via aidevops, telemetry is **disabled by default**. To explicitly disable when using upstream directly, add to `.prose/state.json`:
+
+```json
+{
+  "OPENPROSE_TELEMETRY": "disabled"
+}
+```
+
+Or pass `--no-telemetry` flag when running programs.
 
 <!-- AI-CONTEXT-END -->
 


### PR DESCRIPTION
## Summary

- Document that aidevops disables OpenProse telemetry by default
- Provide instructions for users installing upstream directly to disable telemetry

## Context

OpenProse upstream enables telemetry by default. This is a privacy concern for some users. When using OpenProse via aidevops, we disable telemetry by default.

## Changes

- Added telemetry note to Quick Reference section
- Added instructions for disabling telemetry when using upstream directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced OpenProse documentation with telemetry guidance, clarifying default settings between upstream and aidevops versions.
  * Added instructions for disabling telemetry using configuration entries or command-line flags.
  * Updated Core Concepts and Quick Reference sections with telemetry information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->