### PR TITLE
feat(seo): add GSC sitemap submission via Playwright automation

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -372,7 +372,7 @@ Subagents provide specialized capabilities. Read them when tasks require domain 
 |--------|---------|---------------|
 | `aidevops/` | Framework internals - extending aidevops, adding MCPs, architecture decisions | setup, architecture, add-new-mcp-to-aidevops, troubleshooting, mcp-integrations |
 | `memory/` | Cross-session memory - SQLite FTS5 storage, /remember and /recall commands | README (system docs) |
-| `seo/` | Search optimization - keyword research, rankings, site audits, E-E-A-T scoring | dataforseo, serper, google-search-console, site-crawler, eeat-score, domain-research |
+| `seo/` | Search optimization - keyword research, rankings, site audits, E-E-A-T scoring, sitemap submission | dataforseo, serper, google-search-console, gsc-sitemaps, site-crawler, eeat-score, domain-research |
 | `content/` | Content creation - copywriting standards, editorial guidelines, tone of voice | guidelines |
 | `tools/content/` | Content tools - summarization, extraction, processing | summarize |
 | `tools/social-media/` | Social media tools - X/Twitter CLI, posting, reading | bird |
@@ -457,6 +457,7 @@ For AI-assisted setup guidance, see `aidevops/setup.md`.
 | Browser automation | `tools/browser/stagehand.md` or `tools/browser/playwright.md` |
 | WordPress work | `tools/wordpress/wp-dev.md`, `tools/wordpress/mainwp.md` |
 | SEO analysis | `seo/dataforseo.md`, `seo/google-search-console.md` |
+| Sitemap submission | `seo/gsc-sitemaps.md` |
 | MCP development | `tools/build-mcp/build-mcp.md`, `tools/build-mcp/server-patterns.md` |
 | Agent design | `tools/build-agent/build-agent.md`, `tools/build-agent/agent-review.md` |
 | Database migrations | `workflows/sql-migrations.md` |

--- a/.agent/seo.md
+++ b/.agent/seo.md
@@ -179,19 +179,19 @@ Use `seo/gsc-sitemaps.md` for automated sitemap submissions:
 
 ```bash
 # Submit sitemap for single domain
-gsc-sitemap-helper.sh submit example.com
+~/.aidevops/agents/scripts/gsc-sitemap-helper.sh submit example.com
 
 # Submit for multiple domains
-gsc-sitemap-helper.sh submit example.com example.net example.org
+~/.aidevops/agents/scripts/gsc-sitemap-helper.sh submit example.com example.net example.org
 
 # Submit from file
-gsc-sitemap-helper.sh submit --file domains.txt
+~/.aidevops/agents/scripts/gsc-sitemap-helper.sh submit --file domains.txt
 
 # Check status
-gsc-sitemap-helper.sh status example.com
+~/.aidevops/agents/scripts/gsc-sitemap-helper.sh status example.com
 ```
 
-Uses Playwright browser automation with persistent Chrome profile. First-time setup requires `gsc-sitemap-helper.sh login` to authenticate.
+Uses Playwright browser automation with persistent Chrome profile. First-time setup requires `~/.aidevops/agents/scripts/gsc-sitemap-helper.sh login` to authenticate.
 
 ### Content Optimization
 

--- a/.agent/seo.md
+++ b/.agent/seo.md
@@ -21,6 +21,7 @@ mode: subagent
 |----------|---------|
 | `keyword-research.md` | Comprehensive keyword research with SERP weakness detection |
 | `google-search-console.md` | GSC queries and search performance |
+| `gsc-sitemaps.md` | Sitemap submission via Playwright browser automation |
 | `dataforseo.md` | Comprehensive SEO data APIs (SERP, keywords, backlinks) |
 | `serper.md` | Google Search API (web, images, news, places) |
 | `site-crawler.md` | SEO site auditing (Screaming Frog-like capabilities) |
@@ -171,6 +172,26 @@ eeat-score-helper.sh score https://example.com/article
 
 Scores 7 criteria (1-10): Authorship, Citation, Effort, Originality, Intent, Subjective Quality, Writing.
 Output: `{domain}-eeat-score-{date}.xlsx` with scores and reasoning.
+
+### Sitemap Submission
+
+Use `seo/gsc-sitemaps.md` for automated sitemap submissions:
+
+```bash
+# Submit sitemap for single domain
+gsc-sitemap-helper.sh submit example.com
+
+# Submit for multiple domains
+gsc-sitemap-helper.sh submit example.com example.net example.org
+
+# Submit from file
+gsc-sitemap-helper.sh submit --file domains.txt
+
+# Check status
+gsc-sitemap-helper.sh status example.com
+```
+
+Uses Playwright browser automation with persistent Chrome profile. First-time setup requires `gsc-sitemap-helper.sh login` to authenticate.
 
 ### Content Optimization
 

--- a/.agent/seo/gsc-sitemaps.md
+++ b/.agent/seo/gsc-sitemaps.md
@@ -1,0 +1,280 @@
+---
+description: Google Search Console sitemap submission via Playwright browser automation
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Google Search Console Sitemap Submission
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Automate sitemap submissions to Google Search Console
+- **Method**: Playwright browser automation with persistent Chrome profile
+- **Script**: `~/.aidevops/agents/scripts/gsc-sitemap-helper.sh`
+- **Config**: `~/.config/aidevops/gsc-config.json`
+- **Profile**: `~/.aidevops/.agent-workspace/chrome-gsc-profile/`
+- **Screenshots**: `/tmp/gsc-screenshots/` (verification)
+
+**Commands**:
+
+```bash
+# Submit sitemap for single domain
+gsc-sitemap-helper.sh submit example.com
+
+# Submit sitemaps for multiple domains
+gsc-sitemap-helper.sh submit example.com example.net example.org
+
+# Submit from file (one domain per line)
+gsc-sitemap-helper.sh submit --file domains.txt
+
+# Check sitemap status
+gsc-sitemap-helper.sh status example.com
+
+# List all sitemaps for a domain
+gsc-sitemap-helper.sh list example.com
+```
+
+**Prerequisites**:
+- Domain verified in Google Search Console
+- Sitemap accessible at URL (test with `curl https://example.com/sitemap.xml`)
+- User logged into Google in the Chrome profile
+- Node.js and Playwright installed
+
+<!-- AI-CONTEXT-END -->
+
+## When to Use
+
+- After deploying a new site
+- After adding `sitemap.xml` to a domain
+- When setting up multiple domains (like a portfolio of sites)
+- After major site restructuring that changes sitemap content
+
+## How It Works
+
+1. Opens Chrome with persistent profile (preserves Google login)
+2. Navigates to GSC sitemaps page for each domain
+3. Fills sitemap URL in "Add a new sitemap" input
+4. Clicks SUBMIT button (finds it relative to input, not sidebar feedback button)
+5. Verifies success via screenshot
+6. Handles domains that already have sitemaps submitted
+
+## Technical Details
+
+### Chrome Profile Setup
+
+Uses `chromium.launchPersistentContext()` with a dedicated profile directory and stealth flags to avoid "browser isn't secure" warnings:
+
+```javascript
+{
+    ignoreDefaultArgs: ['--enable-automation'],
+    args: [
+        '--disable-blink-features=AutomationControlled',
+        '--disable-infobars',
+        '--no-first-run',
+        '--no-default-browser-check'
+    ]
+}
+```
+
+### GSC UI Specifics
+
+- **SUBMIT button**: A `div[role="button"]` not a `<button>` element
+- **Sidebar conflict**: There's also a "Submit feedback" link - must avoid clicking that
+- **Button location**: Found relative to input field (walk up DOM to find container)
+- **Input format**: Requires FULL URL: `https://www.domain.com/sitemap.xml` not just `sitemap.xml`
+- **Button state**: Disabled until input has valid content
+
+### Finding the Correct Submit Button
+
+```javascript
+const submitBtn = await input.evaluateHandle(el => {
+    let parent = el.parentElement;
+    for (let i = 0; i < 10; i++) {
+        if (!parent) break;
+        const btn = parent.querySelector('[role="button"]');
+        if (btn && btn.textContent.trim().toUpperCase() === 'SUBMIT') {
+            return btn;
+        }
+        parent = parent.parentElement;
+    }
+    return null;
+});
+```
+
+### Detecting Already Submitted
+
+Look for sitemap in table (not just page content, as "sitemap.xml" appears in input placeholder):
+
+```javascript
+const sitemapInTable = await page.$('table:has-text("sitemap.xml")') ||
+                       await page.$('tr:has-text("sitemap.xml")') ||
+                       await page.$('[role="row"]:has-text("sitemap.xml")');
+```
+
+## Configuration
+
+Store in `~/.config/aidevops/gsc-config.json`:
+
+```json
+{
+  "chrome_profile_dir": "~/.aidevops/.agent-workspace/chrome-gsc-profile",
+  "default_sitemap_path": "sitemap.xml",
+  "screenshot_dir": "/tmp/gsc-screenshots",
+  "timeout_ms": 60000,
+  "headless": false
+}
+```
+
+## First-Time Setup
+
+1. **Install dependencies**:
+
+   ```bash
+   gsc-sitemap-helper.sh setup
+   ```
+
+2. **Login to Google** (first run opens browser for manual login):
+
+   ```bash
+   gsc-sitemap-helper.sh login
+   ```
+
+3. **Verify access**:
+
+   ```bash
+   gsc-sitemap-helper.sh list example.com
+   ```
+
+## Usage Examples
+
+### Single Domain
+
+```bash
+# Submit sitemap for one domain
+gsc-sitemap-helper.sh submit example.com
+
+# With custom sitemap path
+gsc-sitemap-helper.sh submit example.com --sitemap news-sitemap.xml
+```
+
+### Multiple Domains
+
+```bash
+# Submit to multiple domains
+gsc-sitemap-helper.sh submit example.com example.net example.org
+
+# From file
+echo -e "example.com\nexample.net\nexample.org" > domains.txt
+gsc-sitemap-helper.sh submit --file domains.txt
+```
+
+### Status Checking
+
+```bash
+# Check if sitemap is submitted
+gsc-sitemap-helper.sh status example.com
+
+# List all sitemaps for a domain
+gsc-sitemap-helper.sh list example.com
+```
+
+### Batch Operations
+
+```bash
+# Dry run (show what would be done)
+gsc-sitemap-helper.sh submit --dry-run example.com example.net
+
+# Skip already-submitted domains
+gsc-sitemap-helper.sh submit --skip-existing example.com example.net
+```
+
+## Troubleshooting
+
+### "Browser isn't secure" Warning
+
+The script uses stealth flags to prevent this. If it still appears:
+
+1. Close all Chrome instances
+2. Delete the profile: `rm -rf ~/.aidevops/.agent-workspace/chrome-gsc-profile`
+3. Run `gsc-sitemap-helper.sh login` to create fresh profile
+
+### "No access" Error
+
+- Domain not verified in GSC for this Google account
+- Check GSC manually: https://search.google.com/search-console
+
+### Submit Button Not Clicking
+
+- Check screenshot in `/tmp/gsc-screenshots/`
+- May be clicking feedback button instead of submit
+- Script uses DOM traversal to find correct button
+
+### Session Expired
+
+```bash
+# Re-login to refresh session
+gsc-sitemap-helper.sh login
+```
+
+### Sitemap Not Accessible
+
+Before submitting, verify sitemap is accessible:
+
+```bash
+curl -I https://www.example.com/sitemap.xml
+# Should return 200 OK with Content-Type: application/xml
+```
+
+## Integration with Other Tools
+
+### With Site Crawler
+
+After crawling a site, submit its sitemap:
+
+```bash
+# Crawl site
+site-crawler-helper.sh crawl https://example.com
+
+# Submit sitemap
+gsc-sitemap-helper.sh submit example.com
+```
+
+### With MainWP (WordPress Fleet)
+
+Submit sitemaps for all managed WordPress sites:
+
+```bash
+# Get domains from MainWP
+mainwp-helper.sh list-sites | awk '{print $2}' > wp-domains.txt
+
+# Submit sitemaps
+gsc-sitemap-helper.sh submit --file wp-domains.txt
+```
+
+### With Coolify Deployments
+
+After deploying a new site:
+
+```bash
+# Deploy site
+coolify-helper.sh deploy my-app
+
+# Submit sitemap
+gsc-sitemap-helper.sh submit my-app.example.com
+```
+
+## Related
+
+- `seo/google-search-console.md` - GSC API integration (analytics, not sitemaps)
+- `tools/browser/playwright.md` - Playwright automation patterns
+- `seo/site-crawler.md` - Site auditing and crawling

--- a/.agent/seo/gsc-sitemaps.md
+++ b/.agent/seo/gsc-sitemaps.md
@@ -29,20 +29,22 @@ tools:
 
 ```bash
 # Submit sitemap for single domain
-gsc-sitemap-helper.sh submit example.com
+~/.aidevops/agents/scripts/gsc-sitemap-helper.sh submit example.com
 
 # Submit sitemaps for multiple domains
-gsc-sitemap-helper.sh submit example.com example.net example.org
+~/.aidevops/agents/scripts/gsc-sitemap-helper.sh submit example.com example.net example.org
 
 # Submit from file (one domain per line)
-gsc-sitemap-helper.sh submit --file domains.txt
+~/.aidevops/agents/scripts/gsc-sitemap-helper.sh submit --file domains.txt
 
 # Check sitemap status
-gsc-sitemap-helper.sh status example.com
+~/.aidevops/agents/scripts/gsc-sitemap-helper.sh status example.com
 
 # List all sitemaps for a domain
-gsc-sitemap-helper.sh list example.com
+~/.aidevops/agents/scripts/gsc-sitemap-helper.sh list example.com
 ```
+
+**Note**: Add `~/.aidevops/agents/scripts` to your PATH for shorter commands, or use the full path as shown above.
 
 **Prerequisites**:
 - Domain verified in Google Search Console
@@ -140,19 +142,19 @@ Store in `~/.config/aidevops/gsc-config.json`:
 1. **Install dependencies**:
 
    ```bash
-   gsc-sitemap-helper.sh setup
+   ~/.aidevops/agents/scripts/gsc-sitemap-helper.sh setup
    ```
 
 2. **Login to Google** (first run opens browser for manual login):
 
    ```bash
-   gsc-sitemap-helper.sh login
+   ~/.aidevops/agents/scripts/gsc-sitemap-helper.sh login
    ```
 
 3. **Verify access**:
 
    ```bash
-   gsc-sitemap-helper.sh list example.com
+   ~/.aidevops/agents/scripts/gsc-sitemap-helper.sh list example.com
    ```
 
 ## Usage Examples

--- a/configs/gsc-sitemap-config.json.txt
+++ b/configs/gsc-sitemap-config.json.txt
@@ -1,0 +1,20 @@
+{
+  "chrome_profile_dir": "~/.aidevops/.agent-workspace/chrome-gsc-profile",
+  "default_sitemap_path": "sitemap.xml",
+  "screenshot_dir": "/tmp/gsc-screenshots",
+  "timeout_ms": 60000,
+  "headless": false,
+  "notes": {
+    "chrome_profile": "Persistent Chrome profile preserves Google login between sessions",
+    "first_time_setup": "Run 'gsc-sitemap-helper.sh login' to authenticate with Google",
+    "sitemap_format": "Script uses full URL format: https://www.domain.com/sitemap.xml",
+    "screenshots": "Screenshots saved for verification at each step",
+    "headless_mode": "Set to true after initial login for automated runs",
+    "requirements": [
+      "Node.js and npm installed",
+      "Playwright: npm install playwright",
+      "Chrome browser installed",
+      "Domain verified in Google Search Console"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Add automated sitemap submission to Google Search Console using Playwright browser automation
- Create CLI wrapper script with setup, login, submit, and status commands
- Support batch submission for multiple domains

## Changes

### New Files
- `.agent/seo/gsc-sitemaps.md` - Agent instructions for sitemap submission workflow
- `.agent/scripts/gsc-sitemap-helper.sh` - CLI wrapper script (624 lines)
- `configs/gsc-sitemap-config.json.txt` - Configuration template

### Modified Files
- `.agent/seo.md` - Added gsc-sitemaps to subagent table and sitemap submission section
- `.agent/AGENTS.md` - Added gsc-sitemaps to SEO subagent list and "When to read" table

## Features

- **Single/batch submission**: Submit sitemaps for one or multiple domains
- **File input**: Read domains from a text file
- **Persistent Chrome profile**: Preserves Google login between sessions
- **Stealth mode**: Avoids "browser isn't secure" warnings
- **Screenshot verification**: Captures screenshots at each step
- **Skip existing**: Automatically skips domains with sitemaps already submitted
- **Dry-run mode**: Test without making changes
- **Graceful error handling**: Handles domains without GSC access

## Technical Details

Based on working Playwright script with key learnings:
- Uses DOM traversal to find correct SUBMIT button (not sidebar feedback button)
- Requires full URL format: `https://www.domain.com/sitemap.xml`
- Button is `div[role="button"]` not `<button>` element
- Detects already-submitted sitemaps via table content (not page content)

## Usage

```bash
# First-time setup
gsc-sitemap-helper.sh setup
gsc-sitemap-helper.sh login

# Submit sitemaps
gsc-sitemap-helper.sh submit example.com
gsc-sitemap-helper.sh submit example.com example.net example.org
gsc-sitemap-helper.sh submit --file domains.txt

# Check status
gsc-sitemap-helper.sh status example.com
```

## Testing Checklist

- [x] Single domain submission
- [x] Multiple domains in sequence
- [x] Skip already-submitted sitemaps
- [x] Handle domains without access (graceful skip)
- [x] Screenshots for verification
- [x] Full URL format
- [x] Find correct SUBMIT button (not feedback)
- [ ] Headless mode (after initial login)
- [ ] Login detection/prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated Google Search Console sitemap submission tool with single/multi-domain submission, status checks, batch operations, and a guided first-time login/setup flow.
* **Documentation**
  * Added comprehensive sitemap submission guide, configuration notes, troubleshooting, and quick-reference links; updated SEO navigation and help text to include sitemap submission.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->