### PR TITLE
feat: add upgrade-planning command

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -431,6 +431,7 @@ aidevops features                # List available features
 | Command | Purpose |
 |---------|---------|
 | `aidevops init [features]` | Initialize aidevops in current project |
+| `aidevops upgrade-planning` | Upgrade TODO.md/PLANS.md to latest templates |
 | `aidevops features` | List available features |
 | `aidevops status` | Check installation status |
 | `aidevops update` | Update to latest version |

--- a/README.md
+++ b/README.md
@@ -143,6 +143,18 @@ This creates:
 
 **Available features:** `planning`, `git-workflow`, `code-quality`, `time-tracking`, `beads`
 
+### Upgrade Planning Files
+
+When aidevops templates evolve, upgrade existing projects to the latest format:
+
+```bash
+aidevops upgrade-planning           # Interactive upgrade with backup
+aidevops upgrade-planning --dry-run # Preview changes without modifying
+aidevops upgrade-planning --force   # Skip confirmation prompt
+```
+
+This preserves your existing tasks while adding TOON-enhanced parsing, dependency tracking, and better structure.
+
 ### Task Graph Visualization with Beads
 
 [Beads](https://github.com/steveyegge/beads) provides task dependency tracking and graph visualization:


### PR DESCRIPTION
## Summary

- Add `aidevops upgrade-planning` command to upgrade existing TODO.md/PLANS.md files to latest TOON-enhanced templates
- Preserves existing tasks by extracting and merging into new structure
- Creates backups before modification

## Problem

When aidevops templates evolve (e.g., adding TOON markers for machine parsing), existing projects initialized with older templates don't automatically get the improvements. Users had to manually recreate their planning files.

## Solution

New CLI command with options:
- `aidevops upgrade-planning` - Interactive upgrade with backup
- `aidevops upgrade-planning --dry-run` - Preview changes
- `aidevops upgrade-planning --force` - Skip confirmation
- `aidevops upgrade-planning --no-backup` - Skip backup creation

## Testing

Tested with dry-run on a managed private repo repo which was initialized with minimal templates:

```
$ aidevops upgrade-planning --dry-run
Upgrade Planning Files

[WARN] TODO.md uses minimal template (missing TOON markers)
[WARN] todo/PLANS.md uses minimal template (missing TOON markers)

[INFO] Dry run - no changes will be made

  Would upgrade: TODO.md
  Would upgrade: todo/PLANS.md
```

## Checklist

- [x] ShellCheck passes on aidevops.sh
- [x] Help command updated
- [x] AGENTS.md documentation updated
- [x] README.md updated with usage examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an upgrade-planning command to migrate TODO/PLANS to updated templates with --dry-run, --force, and backup controls; preserves and merges existing tasks and provides post-upgrade restore hints.
* **Behavior**
  * Interactive protected-branch handling: prompts to create/use a worktree or cancel when on main branches (skipped during dry-run).
* **Documentation**
  * Help/examples and a new Upgrade Planning Files section were added (guidance appears in two locations).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->