### PR TITLE
fix: correct onboarding command path to root agent location

### DIFF
--- a/.agent/scripts/generate-opencode-commands.sh
+++ b/.agent/scripts/generate-opencode-commands.sh
@@ -991,7 +991,7 @@ description: Interactive onboarding wizard - discover services, configure integr
 agent: AI-DevOps
 ---
 
-Read ~/.aidevops/agents/aidevops/onboarding.md and follow its instructions.
+Read ~/.aidevops/agents/onboarding.md and follow its instructions.
 
 This is the recommended starting point for new aidevops users.
 


### PR DESCRIPTION
## Summary

- Fix `/onboarding` command path from `aidevops/onboarding.md` to `onboarding.md`
- Closes the incorrect approach in PR #71

## Problem

The `/onboarding` command failed with:
```
Error: File not found: ~/.aidevops/agents/aidevops/onboarding.md
```

The command generator was pointing to the wrong path. `onboarding.md` is a **main agent** (located in root `.agent/` directory), not a subagent.

## Solution

Fix the path in `generate-opencode-commands.sh`:
```diff
-Read ~/.aidevops/agents/aidevops/onboarding.md
+Read ~/.aidevops/agents/onboarding.md
```

## Why this is correct

1. **Main agents** live in `.agent/*.md` (root level)
2. **Subagents** live in `.agent/{domain}/*.md` (subdirectories)
3. `onboarding.md` is listed in the "Main Agents" table in AGENTS.md
4. Moving the file (PR #71's approach) was architecturally wrong

## Testing

- [x] ShellCheck passes on changed file
- [x] Path now matches actual file location

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated onboarding configuration path reference to the correct location.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->