### PR TITLE
feat(agents): add subagent filtering via frontmatter

### DIFF
--- a/.agent/accounts.md
+++ b/.agent/accounts.md
@@ -2,6 +2,10 @@
 name: accounts
 description: Financial operations and accounting - QuickFile integration, invoicing, expense tracking
 mode: subagent
+subagents:
+  - quickfile
+  - general
+  - explore
 ---
 
 # Accounts - Main Agent

--- a/.agent/aidevops.md
+++ b/.agent/aidevops.md
@@ -2,6 +2,42 @@
 name: aidevops
 description: AI DevOps framework operations - setup, configuration, meta-agents, troubleshooting
 mode: subagent
+subagents:
+  # Framework internals
+  - setup
+  - troubleshooting
+  - architecture
+  - add-new-mcp-to-aidevops
+  - mcp-integrations
+  - mcp-troubleshooting
+  - configs
+  - providers
+  # Agent development
+  - build-agent
+  - agent-review
+  - build-mcp
+  - server-patterns
+  - api-wrapper
+  - transports
+  - deployment
+  # Workflows
+  - git-workflow
+  - release
+  - version-bump
+  - preflight
+  - postflight
+  # Code quality
+  - code-standards
+  - linters-local
+  - secretlint
+  # Credentials
+  - api-key-setup
+  - api-key-management
+  - vaultwarden
+  - list-keys
+  # Built-in
+  - general
+  - explore
 ---
 
 # AI DevOps - Framework Main Agent

--- a/.agent/build-plus.md
+++ b/.agent/build-plus.md
@@ -2,6 +2,44 @@
 name: build-plus
 description: Enhanced build agent with semantic codebase search and context tools
 mode: subagent
+subagents:
+  # Core workflows
+  - git-workflow
+  - branch
+  - preflight
+  - postflight
+  - release
+  - version-bump
+  - pr
+  - conversation-starter
+  - error-feedback
+  # Code quality
+  - code-standards
+  - code-simplifier
+  - best-practices
+  - auditing
+  - secretlint
+  - qlty
+  # Context tools
+  - osgrep
+  - augment-context-engine
+  - context-builder
+  - context7
+  - toon
+  # Browser/testing
+  - playwright
+  - stagehand
+  - pagespeed
+  # Git platforms
+  - github-cli
+  - gitlab-cli
+  - github-actions
+  # Deployment
+  - coolify
+  - vercel
+  # Built-in
+  - general
+  - explore
 ---
 
 # Build+ - Enhanced Build Agent

--- a/.agent/content.md
+++ b/.agent/content.md
@@ -2,6 +2,22 @@
 name: content
 description: Content creation and management - copywriting, guidelines, editorial workflows
 mode: subagent
+subagents:
+  # Content
+  - guidelines
+  - summarize
+  # SEO integration
+  - keyword-research
+  - eeat-score
+  # WordPress publishing
+  - wp-admin
+  - mainwp
+  # Research
+  - context7
+  - crawl4ai
+  # Built-in
+  - general
+  - explore
 ---
 
 # Content - Main Agent

--- a/.agent/health.md
+++ b/.agent/health.md
@@ -2,6 +2,13 @@
 name: health
 description: Health and wellness domain - medical information, fitness, nutrition guidance
 mode: subagent
+subagents:
+  # Research
+  - context7
+  - crawl4ai
+  # Built-in
+  - general
+  - explore
 ---
 
 # Health - Main Agent

--- a/.agent/health.md
+++ b/.agent/health.md
@@ -4,7 +4,6 @@ description: Health and wellness domain - medical information, fitness, nutritio
 mode: subagent
 subagents:
   # Research
-  - context7
   - crawl4ai
   # Built-in
   - general

--- a/.agent/legal.md
+++ b/.agent/legal.md
@@ -2,6 +2,15 @@
 name: legal
 description: Legal compliance and documentation - contracts, policies, regulatory guidance
 mode: subagent
+subagents:
+  # Research
+  - context7
+  - crawl4ai
+  # Content
+  - guidelines
+  # Built-in
+  - general
+  - explore
 ---
 
 # Legal - Main Agent

--- a/.agent/marketing.md
+++ b/.agent/marketing.md
@@ -10,6 +10,23 @@ tools:
   glob: true
   grep: true
   webfetch: true
+subagents:
+  # CRM
+  - fluentcrm
+  # Content
+  - guidelines
+  - summarize
+  # SEO
+  - keyword-research
+  - serper
+  - dataforseo
+  # Social
+  - bird
+  # Analytics
+  - google-search-console
+  # Built-in
+  - general
+  - explore
 ---
 
 # Marketing - Main Agent

--- a/.agent/onboarding.md
+++ b/.agent/onboarding.md
@@ -2,6 +2,19 @@
 name: onboarding
 description: Interactive onboarding wizard - discover services, check credentials, configure integrations
 mode: subagent
+subagents:
+  # Setup/config
+  - setup
+  - troubleshooting
+  - api-key-setup
+  - list-keys
+  - mcp-integrations
+  # Services overview
+  - services
+  - service-links
+  # Built-in
+  - general
+  - explore
 ---
 
 # Onboarding Wizard - aidevops Configuration

--- a/.agent/plan-plus.md
+++ b/.agent/plan-plus.md
@@ -2,6 +2,24 @@
 name: plan-plus
 description: Read-only planning agent with semantic codebase search - analysis without modifications
 mode: subagent
+subagents:
+  # Context/search (read-only)
+  - osgrep
+  - augment-context-engine
+  - context-builder
+  - context7
+  # Planning workflows
+  - plans
+  - plans-quick
+  - prd-template
+  - tasks-template
+  # Architecture review
+  - architecture
+  - code-standards
+  - best-practices
+  # Built-in
+  - general
+  - explore
 ---
 
 # Plan+ - Enhanced Plan Agent

--- a/.agent/research.md
+++ b/.agent/research.md
@@ -2,6 +2,20 @@
 name: research
 description: Research and analysis - data gathering, competitive analysis, market research
 mode: subagent
+subagents:
+  # Context/docs
+  - context7
+  - augment-context-engine
+  - osgrep
+  # Web research
+  - crawl4ai
+  - serper
+  - outscraper
+  # Summarization
+  - summarize
+  # Built-in
+  - general
+  - explore
 ---
 
 # Research - Main Agent

--- a/.agent/sales.md
+++ b/.agent/sales.md
@@ -10,6 +10,19 @@ tools:
   glob: true
   grep: true
   webfetch: true
+subagents:
+  # CRM
+  - fluentcrm
+  # Accounting
+  - quickfile
+  # Content for proposals
+  - guidelines
+  # Research
+  - outscraper
+  - crawl4ai
+  # Built-in
+  - general
+  - explore
 ---
 
 # Sales - Main Agent

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -185,7 +185,7 @@ SKIP_FILES = {"AGENTS.md", "README.md"}
 def parse_frontmatter(filepath):
     """Parse YAML frontmatter from markdown file."""
     try:
-        with open(filepath, 'r') as f:
+        with open(filepath, 'r', encoding='utf-8') as f:
             content = f.read()
         
         # Check for frontmatter
@@ -207,6 +207,10 @@ def parse_frontmatter(filepath):
         
         for line in lines:
             stripped = line.strip()
+            # Ignore comments and empty lines
+            if not stripped or stripped.startswith('#'):
+                continue
+            
             if stripped.startswith('- ') and current_key:
                 # List item
                 current_list.append(stripped[2:].strip())
@@ -229,7 +233,9 @@ def parse_frontmatter(filepath):
             result[current_key] = current_list
         
         return result
-    except:
+    except (IOError, OSError, UnicodeDecodeError) as e:
+        import sys
+        print(f"Warning: Failed to parse frontmatter for {filepath}: {e}", file=sys.stderr)
         return {}
 
 def filename_to_display(filename):

--- a/.agent/seo.md
+++ b/.agent/seo.md
@@ -2,6 +2,18 @@
 name: seo
 description: SEO optimization and analysis - keyword research, Search Console, DataForSEO, site crawling
 mode: subagent
+subagents:
+  - keyword-research
+  - google-search-console
+  - gsc-sitemaps
+  - dataforseo
+  - serper
+  - site-crawler
+  - eeat-score
+  - domain-research
+  - pagespeed
+  - general
+  - explore
 ---
 
 # SEO - Main Agent

--- a/.agent/social-media.md
+++ b/.agent/social-media.md
@@ -2,6 +2,18 @@
 name: social-media
 description: Social media management - content scheduling, analytics, engagement, multi-platform strategy
 mode: subagent
+subagents:
+  # Social tools
+  - bird
+  # Content
+  - guidelines
+  - summarize
+  # Research
+  - crawl4ai
+  - serper
+  # Built-in
+  - general
+  - explore
 ---
 
 # Social Media - Main Agent


### PR DESCRIPTION
## Summary

Add `subagents:` frontmatter to primary agents that specifies which subagents should appear in the Task tool description. This reduces token overhead by filtering 220 subagents down to 3-30 per agent.

## Changes

- Add `parse_frontmatter()` to `generate-opencode-agents.sh`
- Generate `permission.task` deny-list rules from subagents list
- Add `subagents:` frontmatter to all 13 primary agents

## How It Works

In agent frontmatter (e.g., `.agent/seo.md`):
```yaml
---
name: seo
subagents:
  - keyword-research
  - google-search-console
  - dataforseo
  - general
  - explore
---
```

`setup.sh` generates (in `~/.config/opencode/opencode.json`):
```json
"SEO": {
  "permission": {
    "task": {
      "*": "deny",
      "keyword-research": "allow",
      "google-search-console": "allow",
      ...
    }
  }
}
```

## Token Savings

| Agent | Subagents | Reduction |
|-------|-----------|-----------|
| Accounts | 3 | 220 → 3 (98.6%) |
| Health | 4 | 220 → 4 (98.2%) |
| Build+ | 30 | 220 → 30 (86.4%) |

**Average reduction**: ~94% fewer subagents in Task tool description per agent.

## Related

- OpenCode PR: anomalyco/opencode#7271 (proposing native `subagents` config)
- If that PR is accepted, this can be simplified to use native config instead of generating deny-lists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added subagents configuration for 13 agents, enabling grouped subagent lists across accounts, content, marketing, research, SEO, sales, onboarding, health, legal, plan-plus, build-plus, aidevops, and social-media.

* **Chores**
  * Updated discovery process to consume subagent configuration, apply subagent-based permission filtering, and emit runtime reporting/logging during agent discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->