### PR TITLE
docs: add troubleshooting section with support links to QuickFile agent

### DIFF
--- a/.agent/services/accounting/quickfile.md
+++ b/.agent/services/accounting/quickfile.md
@@ -148,6 +148,21 @@ This agent provides access to QuickFile UK accounting software through the MCP s
 - API calls are authenticated via MD5 hash
 - Default rate limit: 1000 calls/day
 
+## Troubleshooting
+
+If you encounter issues with QuickFile operations, check these resources:
+
+| Resource | URL | Purpose |
+|----------|-----|---------|
+| Support Portal | https://support.quickfile.co.uk/ | Official help articles and FAQs |
+| Community Forum | https://community.quickfile.co.uk/ | User discussions and solutions |
+| API Documentation | https://api.quickfile.co.uk/ | Technical API reference |
+
+**Common issues:**
+- **Authentication errors**: Verify credentials in `~/.config/.quickfile-mcp/credentials.json`
+- **Rate limiting**: Default 1000 calls/day - check usage in QuickFile dashboard
+- **API changes**: Check API docs for deprecations or new endpoints
+
 ## Related Agents
 
 - `@aidevops` - For infrastructure operations
@@ -155,5 +170,7 @@ This agent provides access to QuickFile UK accounting software through the MCP s
 
 ## Reference
 
+- [QuickFile Support Portal](https://support.quickfile.co.uk/)
+- [QuickFile Community Forum](https://community.quickfile.co.uk/)
 - [QuickFile API Documentation](https://api.quickfile.co.uk/)
 - [AGENTS.md](../AGENTS.md) - Full documentation


### PR DESCRIPTION
## Summary

- Add troubleshooting section to QuickFile agent with links to official support resources
- Direct users to Support Portal, Community Forum, and API Documentation when encountering issues
- Include common issues guidance for authentication, rate limiting, and API changes

## Changes

- Added new "Troubleshooting" section with resource table
- Updated "Reference" section with all three support URLs
- Added common issues bullet points for quick diagnosis

## Resources Added

| Resource | URL | Purpose |
|----------|-----|---------|
| Support Portal | https://support.quickfile.co.uk/ | Official help articles and FAQs |
| Community Forum | https://community.quickfile.co.uk/ | User discussions and solutions |
| API Documentation | https://api.quickfile.co.uk/ | Technical API reference |