### PR TITLE
fix(release): include aidevops.sh in version updates

### DIFF
--- a/.agent/scripts/version-manager.sh
+++ b/.agent/scripts/version-manager.sh
@@ -395,6 +395,16 @@ validate_version_consistency() {
         fi
     fi
 
+    # Check aidevops.sh CLI
+    if [[ -f "$REPO_ROOT/aidevops.sh" ]]; then
+        if grep -q "# Version: $expected_version" "$REPO_ROOT/aidevops.sh"; then
+            print_success "aidevops.sh: $expected_version ✓"
+        else
+            print_error "aidevops.sh does not contain version $expected_version"
+            errors=$((errors + 1))
+        fi
+    fi
+
     # Check Claude Code plugin marketplace.json
     if [[ -f "$REPO_ROOT/.claude-plugin/marketplace.json" ]]; then
         if grep -q "\"version\": \"$expected_version\"" "$REPO_ROOT/.claude-plugin/marketplace.json"; then
@@ -443,6 +453,12 @@ update_version_in_files() {
     if [[ -f "$REPO_ROOT/setup.sh" ]]; then
         sed -i '' "s/# Version: .*/# Version: $new_version/" "$REPO_ROOT/setup.sh"
         print_success "Updated setup.sh"
+    fi
+    
+    # Update aidevops.sh CLI if it exists
+    if [[ -f "$REPO_ROOT/aidevops.sh" ]]; then
+        sed -i '' "s/# Version: .*/# Version: $new_version/" "$REPO_ROOT/aidevops.sh"
+        print_success "Updated aidevops.sh"
     fi
     
     # Update README version badge
@@ -498,7 +514,7 @@ commit_version_changes() {
     print_info "Committing version changes..."
     
     # Stage all version-related files (including CHANGELOG.md and Claude plugin)
-    git add VERSION package.json README.md setup.sh sonar-project.properties CHANGELOG.md .claude-plugin/marketplace.json 2>/dev/null
+    git add VERSION package.json README.md setup.sh aidevops.sh sonar-project.properties CHANGELOG.md .claude-plugin/marketplace.json 2>/dev/null
     
     # Check if there are changes to commit
     if git diff --cached --quiet; then

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 2.13.0
+# Version: 2.54.0
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

The `aidevops.sh` CLI script was not being updated during releases, causing npm installs to have outdated version strings (e.g., v2.13.0 instead of v2.54.0).

## Changes

- Add `aidevops.sh` to `update_version_in_files()` 
- Add `aidevops.sh` to `validate_version_consistency()`
- Add `aidevops.sh` to `git add` in `commit_version_changes()`
- Update `aidevops.sh` to current version 2.54.0

## Testing

After merge, the next release will automatically update `aidevops.sh` version string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version to 2.54.0.
  * Enhanced version consistency validation and tracking across components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->