### PR TITLE
chore(deps): remove dspyground from dependencies

### DIFF
--- a/.agent/tools/context/dspyground.md
+++ b/.agent/tools/context/dspyground.md
@@ -34,6 +34,8 @@ tools:
 
 DSPyGround is a visual prompt optimization playground powered by the GEPA (Genetic-Pareto Evolutionary Algorithm) optimizer. It provides an intuitive web interface for iterative prompt optimization with real-time feedback and multi-dimensional metrics.
 
+**Note**: DSPyGround is an optional tool installed separately from the aidevops CLI. Install it when you need visual prompt optimization capabilities.
+
 ## 🚀 **Quick Start**
 
 ### **Prerequisites**

--- a/package.json
+++ b/package.json
@@ -37,11 +37,7 @@
   "author": "Marcus Quinn <marcus@aidevops.sh>",
   "license": "MIT",
   "dependencies": {
-    "dspyground": "^0.3.10",
     "elysia": "^1.1.0"
-  },
-  "overrides": {
-    "next": "^16.1.1"
   },
   "devDependencies": {
     "@secretlint/secretlint-rule-preset-recommend": "^11.2.5",


### PR DESCRIPTION
## Summary

- Remove `dspyground` from package.json dependencies
- Remove `overrides` section (no longer needed)
- Add note to dspyground.md clarifying it's installed separately

## Why

npm `overrides` don't work for global installs (`npm install -g`), so the next.js CVE-2025-66478 vulnerability warning persists even with the override in place.

Since dspyground is optional tooling for prompt optimization (not core CLI functionality), removing it as a dependency eliminates the security warning entirely.

## Impact

- Users who need DSPyGround can install it separately: `npm install -g dspyground`
- The `npm run dspy:*` scripts still work for local development (they just call the `dspyground` CLI)
- No change to core aidevops CLI functionality

## Testing

After merge and release:
```bash
npm install -g aidevops
# Should no longer show next.js vulnerability warning
```

Closes the vulnerability issue from v2.54.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified in the documentation that DSPyGround is an optional tool requiring separate installation from the aidevops CLI. Multiple documentation sections updated to provide better clarity on this optional component.

* **Chores**
  * Removed DSPyGround from project dependencies.
  * Removed Next.js version override from package configuration to simplify dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->