### PR TITLE
chore(todo): add debug-opengraph and debug-favicon subagents task

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -131,8 +131,10 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
   - Notes: Automatic memory capture inspired by claude-mem but tool-agnostic. Agent instructions trigger capture after significant operations. Works with OpenCode, Cursor, Claude Code, Windsurf. PRD: todo/tasks/prd-memory-auto-capture.md
 - [ ] t060 Research jj (Jujutsu) VCS for aidevops advantages #research #git #tools ~2h (ai:1h read:1h) logged:2026-01-13 ref:https://github.com/jj-vcs/jj
   - Notes: Git-compatible VCS (24.7k stars) with unique features: working-copy-as-commit (no staging area), operation log with undo, conflicts as first-class objects, automatic rebase of descendants, anonymous branches. Could simplify worktree workflows, enable safer experimentation, and provide better conflict handling. Evaluate: 1) Integration with existing git workflows 2) Colocated mode compatibility 3) Benefits for AI-assisted development 4) Learning curve vs productivity gains.
+- [ ] t061 Create debug-opengraph and debug-favicon subagents #tools #seo #browser ~3h (ai:2h test:30m read:30m) logged:2026-01-14 ref:https://opengraphdebug.com/
+  - Notes: Inspired by opengraphdebug.com. Two subagents: 1) debug-opengraph.md - validate Open Graph meta tags (og:title, og:description, og:image, og:url, twitter:card), preview social sharing appearance, check image dimensions/accessibility. 2) debug-favicon.md - validate favicon setup across platforms (favicon.ico, apple-touch-icon, manifest icons), check sizes/formats, verify PWA manifest. Could use browser automation (Stagehand/Playwright) or direct HTML parsing. Add to tools/seo/ or tools/browser/.
 
-<!--TOON:backlog[39]{id,desc,owner,tags,est,est_ai,est_test,est_read,logged,status,blocked_by,blocks,parent}:
+<!--TOON:backlog[40]{id,desc,owner,tags,est,est_ai,est_test,est_read,logged,status,blocked_by,blocks,parent}:
 t010,Evaluate Merging build-agent and build-mcp into aidevops,,plan|architecture|agents,4h,2h,1h,1h,2025-12-21T14:00Z,pending,,,
 t009,Claude Code Destructive Command Hooks,,plan|claude|git|security,4h,2h,1h,1h,2025-12-21T12:00Z,pending,,,
 t008,aidevops-opencode Plugin,,plan,2d,1d,0.5d,0.5d,2025-12-21T01:50Z,pending,,,
@@ -186,6 +188,7 @@ t056,Tool description indexing for on-demand MCP discovery,,tools|context,3h,2h,
 t057,Memory consolidation and pruning,,memory|optimization,2h,1h,45m,15m,2025-01-11T00:00Z,pending,t052,,
 t058,Memory Auto-Capture,,plan|memory|automation|context,1d,6h,4h,2h,2026-01-11T12:00Z,pending,,,
 t060,Research jj (Jujutsu) VCS for aidevops advantages,,research|git|tools,2h,1h,,1h,2026-01-13T00:00Z,pending,,,
+t061,Create debug-opengraph and debug-favicon subagents,,tools|seo|browser,3h,2h,30m,30m,2026-01-14T00:00Z,pending,,,
 -->
 
 <!--TOON:subtasks[0]{id,desc,est,status,blocked_by,parent}:
@@ -272,5 +275,5 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 -->
 
 <!--TOON:summary{total,pending,in_progress,in_review,done,declined,total_est,total_actual,blocked_count,ready_count}:
-54,43,0,0,26,0,27d22h,16h50m,0,43
+55,44,0,0,26,0,28d1h,16h50m,0,44
 -->


### PR DESCRIPTION
## Summary

- Add t061 to backlog for creating two debugging subagents inspired by [opengraphdebug.com](https://opengraphdebug.com/)
- **debug-opengraph.md** - validate Open Graph meta tags (og:title, og:description, og:image, og:url, twitter:card), preview social sharing appearance, check image dimensions/accessibility
- **debug-favicon.md** - validate favicon setup across platforms (favicon.ico, apple-touch-icon, manifest icons), check sizes/formats, verify PWA manifest

## Reference

- https://opengraphdebug.com/ - OG tag checker
- https://opengraphdebug.com/favicon - Favicon checker