### PR TITLE
fix: use stderr in postinstall so npm shows output

### DIFF
--- a/scripts/npm-postinstall.cjs
+++ b/scripts/npm-postinstall.cjs
@@ -3,6 +3,8 @@
  * 
  * The npm package contains only the CLI wrapper. The full agent files
  * are deployed from ~/Git/aidevops via `aidevops update`.
+ * 
+ * Note: Uses stderr so output is visible (npm suppresses stdout for lifecycle scripts)
  */
 
 const fs = require('fs');
@@ -11,6 +13,9 @@ const path = require('path');
 
 const agentsDir = path.join(os.homedir(), '.aidevops', 'agents');
 const versionFile = path.join(agentsDir, 'VERSION');
+
+// Use stderr so npm doesn't suppress the output
+const log = (msg = '') => process.stderr.write(msg + '\n');
 
 // Check current installed version
 let installedVersion = 'not installed';
@@ -22,30 +27,30 @@ if (fs.existsSync(versionFile)) {
 const packageJson = require('../package.json');
 const packageVersion = packageJson.version;
 
-console.log('');
-console.log('aidevops CLI installed successfully!');
-console.log('');
-console.log(`  CLI version:    ${packageVersion}`);
-console.log(`  Agents version: ${installedVersion}`);
-console.log('');
+log('');
+log('aidevops CLI installed successfully!');
+log('');
+log(`  CLI version:    ${packageVersion}`);
+log(`  Agents version: ${installedVersion}`);
+log('');
 
 if (installedVersion === 'not installed') {
-    console.log('To complete installation, run:');
-    console.log('');
-    console.log('  aidevops update');
-    console.log('');
-    console.log('This will clone the repository and deploy agents to ~/.aidevops/agents/');
+    log('To complete installation, run:');
+    log('');
+    log('  aidevops update');
+    log('');
+    log('This will clone the repository and deploy agents to ~/.aidevops/agents/');
 } else if (installedVersion !== packageVersion) {
-    console.log('To update agents to match CLI version, run:');
-    console.log('');
-    console.log('  aidevops update');
-    console.log('');
+    log('To update agents to match CLI version, run:');
+    log('');
+    log('  aidevops update');
+    log('');
 } else {
-    console.log('CLI and agents are in sync. Ready to use!');
-    console.log('');
-    console.log('Quick start:');
-    console.log('  aidevops status    # Check installation');
-    console.log('  aidevops init      # Initialize in a project');
-    console.log('  aidevops help      # Show all commands');
+    log('CLI and agents are in sync. Ready to use!');
+    log('');
+    log('Quick start:');
+    log('  aidevops status    # Check installation');
+    log('  aidevops init      # Initialize in a project');
+    log('  aidevops help      # Show all commands');
 }
-console.log('');
+log('');


### PR DESCRIPTION
## Summary

- Switch from `console.log()` to `process.stderr.write()` in postinstall script

## Why

npm v7+ suppresses stdout from lifecycle scripts by default. Using stderr ensures the version info and update advice is always visible:

```
$ npm install -g aidevops

aidevops CLI installed successfully!

  CLI version:    2.54.5
  Agents version: 2.54.4

To update agents to match CLI version, run:

  aidevops update
```

Without this fix, users see no output and don't know to run `aidevops update`.