### PR TITLE
docs: add update advice to README and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,16 @@ The result: AI agents that work *with* your development process, not around it.
 
 ```bash
 npm install -g aidevops
+aidevops update  # Deploy agents (required after npm install)
 ```
+
+> **Note**: npm suppresses postinstall output. Run `aidevops update` to deploy agents to `~/.aidevops/agents/`. The CLI will remind you if agents need updating.
 
 **Bun** (fast alternative):
 
 ```bash
 bun install -g aidevops
+aidevops update  # Deploy agents
 ```
 
 **Homebrew** (macOS/Linux):

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1702,6 +1702,26 @@ main() {
         echo ""
     fi
     
+    # Check if agents need updating (skip for update command itself)
+    if [[ "$command" != "update" && "$command" != "upgrade" && "$command" != "u" ]]; then
+        local cli_version agents_version
+        cli_version=$(get_version)
+        if [[ -f "$AGENTS_DIR/VERSION" ]]; then
+            agents_version=$(cat "$AGENTS_DIR/VERSION")
+        else
+            agents_version="not installed"
+        fi
+        
+        if [[ "$agents_version" == "not installed" ]]; then
+            echo -e "${YELLOW}[WARN]${NC} Agents not installed. Run: aidevops update"
+            echo ""
+        elif [[ "$cli_version" != "$agents_version" ]]; then
+            echo -e "${YELLOW}[WARN]${NC} Version mismatch - CLI: $cli_version, Agents: $agents_version"
+            echo -e "       Run: aidevops update"
+            echo ""
+        fi
+    fi
+    
     case "$command" in
         init|i)
             shift


### PR DESCRIPTION
## Summary

1. **README**: Add note that npm suppresses postinstall output, advise running `aidevops update`
2. **CLI**: Show warning when agents version doesn't match CLI version

## Why

npm v7+ suppresses lifecycle script output, so users don't see the postinstall message advising them to run `aidevops update`. This PR:

1. Documents the two-step install in README
2. Makes the CLI itself warn when versions are mismatched

## Example

```
$ aidevops status
[WARN] Version mismatch - CLI: 2.54.7, Agents: 2.54.4
       Run: aidevops update

AI DevOps Framework Status
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployment guidance reminding users to run update command after npm and Bun installations.

* **New Features**
  * Added automatic version consistency checks between CLI and agents, with informative warnings for out-of-sync or missing installations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->