### PR TITLE
fix: prevent CLI from silently exiting

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1696,7 +1696,7 @@ main() {
     
     # Auto-detect unregistered repo on any command (silent check)
     local unregistered
-    unregistered=$(detect_unregistered_repo 2>/dev/null)
+    unregistered=$(detect_unregistered_repo 2>/dev/null) || true
     if [[ -n "$unregistered" && "$command" != "detect" && "$command" != "repos" ]]; then
         echo -e "${YELLOW}[TIP]${NC} This project uses aidevops but isn't registered. Run: aidevops repos add"
         echo ""


### PR DESCRIPTION
## Summary

Add `|| true` to `detect_unregistered_repo` call to prevent `set -e` from exiting.

## Problem

The CLI was silently exiting with code 1 because `detect_unregistered_repo` returns non-zero when not in a git repo, and `set -e` catches this.

## Fix

```bash
unregistered=$(detect_unregistered_repo 2>/dev/null) || true
```

## Testing

Before: `aidevops help` produces no output, exits 1
After: `aidevops help` shows help text correctly