### PR TITLE
feat: add macos-automator MCP for AppleScript automation

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -392,6 +392,7 @@ Subagents provide specialized capabilities. Read them when tasks require domain 
 | `tools/opencode/` | OpenCode config - CLI setup, plugins, authentication, Oh-My-OpenCode extensions | opencode, opencode-anthropic-auth, oh-my-opencode |
 | `tools/task-management/` | Task tracking - dependency graphs, blocking relationships, visual planning | beads |
 | `tools/terminal/` | Terminal integration - tab titles, git context display | terminal-title |
+| `tools/automation/` | macOS automation - AppleScript, JXA, accessibility API, app control | mac, macos-automator |
 | `tools/wordpress/` | WordPress ecosystem - local dev, fleet management, plugin curation, custom fields | wp-dev, wp-admin, localwp, mainwp, wp-preferred, scf |
 | `services/hosting/` | Hosting providers - DNS, domains, cloud servers, managed WordPress | hostinger, hetzner, cloudflare, cloudron, closte, 101domains, spaceship |
 | `services/email/` | Email services - transactional email, deliverability | ses |
@@ -483,6 +484,7 @@ For AI-assisted setup guidance, see `aidevops/setup.md`.
 | Framework internals | `aidevops/architecture.md` (when working in `~/Git/aidevops/`) |
 | Content summarization | `tools/content/summarize.md` |
 | X/Twitter automation | `tools/social-media/bird.md` |
+| macOS automation | `tools/automation/mac.md` (AppleScript, JXA, app control) |
 
 ## Security
 

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -409,6 +409,7 @@ if 'outscraper_*' not in config['tools']:
 # DataForSEO MCP - for comprehensive SEO data
 # Uses bun x if available, falls back to npx
 import shutil
+import platform
 bun_path = shutil.which('bun')
 npx_path = shutil.which('npx') or '/opt/homebrew/bin/npx'
 pkg_runner = f"{bun_path} x" if bun_path else npx_path
@@ -471,12 +472,12 @@ if 'shadcn_*' not in config['tools']:
 
 # macOS Automator MCP - AppleScript and JXA automation (macOS only)
 # Docs: https://github.com/steipete/macos-automator-mcp
-import platform
+# Note: import platform is at line 412 with other imports
 if platform.system() == 'Darwin':
     if 'macos-automator' not in config['mcp']:
         config['mcp']['macos-automator'] = {
             "type": "local",
-            "command": ["npx", "-y", "@steipete/macos-automator-mcp@latest"],
+            "command": ["npx", "-y", "@steipete/macos-automator-mcp@0.2.0"],
             "enabled": True
         }
         print("  Added macos-automator MCP server (macOS only)")
@@ -540,7 +541,10 @@ while IFS= read -r f; do
             extra_tools=$'  shadcn_*: true\n  write: true\n  edit: true'
             ;;
         macos-automator|mac)
-            extra_tools=$'  macos-automator_*: true\n  webfetch: true'
+            # Only enable macos-automator tools on macOS
+            if [[ "$(uname -s)" == "Darwin" ]]; then
+                extra_tools=$'  macos-automator_*: true\n  webfetch: true'
+            fi
             ;;
         *)
             ;;  # No extra tools for other agents

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -469,6 +469,22 @@ if 'shadcn_*' not in config['tools']:
     config['tools']['shadcn_*'] = False
     print("  Added shadcn_* to tools (disabled globally, enabled for @shadcn subagent)")
 
+# macOS Automator MCP - AppleScript and JXA automation (macOS only)
+# Docs: https://github.com/steipete/macos-automator-mcp
+import platform
+if platform.system() == 'Darwin':
+    if 'macos-automator' not in config['mcp']:
+        config['mcp']['macos-automator'] = {
+            "type": "local",
+            "command": ["npx", "-y", "@steipete/macos-automator-mcp@latest"],
+            "enabled": True
+        }
+        print("  Added macos-automator MCP server (macOS only)")
+
+    if 'macos-automator_*' not in config['tools']:
+        config['tools']['macos-automator_*'] = False
+        print("  Added macos-automator_* to tools (disabled globally, enabled for @mac subagent)")
+
 with open(config_path, 'w') as f:
     json.dump(config, f, indent=2)
 
@@ -522,6 +538,9 @@ while IFS= read -r f; do
             ;;
         shadcn)
             extra_tools=$'  shadcn_*: true\n  write: true\n  edit: true'
+            ;;
+        macos-automator|mac)
+            extra_tools=$'  macos-automator_*: true\n  webfetch: true'
             ;;
         *)
             ;;  # No extra tools for other agents

--- a/.agent/tools/automation/mac.md
+++ b/.agent/tools/automation/mac.md
@@ -1,0 +1,93 @@
+---
+description: macOS automation via AppleScript and JXA
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: true
+  macos-automator_*: true
+---
+
+# @mac - macOS Automation Subagent
+
+Use this subagent to enable macOS automation capabilities via AppleScript and JXA.
+
+## Quick Start
+
+Invoke with `@mac` to enable the macos-automator MCP tools:
+
+```text
+@mac Get the current Safari URL
+@mac Toggle dark mode
+@mac List files on the desktop
+@mac Send a notification saying "Task complete"
+```
+
+## Available Tools
+
+When `@mac` is invoked, you gain access to:
+
+| Tool | Purpose |
+|------|---------|
+| `execute_script` | Run AppleScript or JXA code |
+| `get_scripting_tips` | Search 200+ pre-built automation scripts |
+| `accessibility_query` | Query and interact with UI elements |
+
+## Common Tasks
+
+### Get Information
+
+```text
+@mac What's the current Safari URL?
+@mac What apps are currently running?
+@mac What's on my clipboard?
+```
+
+### Control Applications
+
+```text
+@mac Open Safari and navigate to github.com
+@mac Play the next track in Music
+@mac Create a new folder called "Projects" on my desktop
+```
+
+### System Control
+
+```text
+@mac Toggle dark mode
+@mac Set volume to 50%
+@mac Show a notification with title "Done" and message "Task complete"
+```
+
+### UI Automation
+
+```text
+@mac Click the "General" button in System Settings
+@mac Find all text fields in the current app
+@mac What buttons are visible in Finder?
+```
+
+## Knowledge Base
+
+The MCP includes 200+ pre-built scripts. Search them:
+
+```text
+@mac Search for clipboard scripts
+@mac List all Safari automation tips
+@mac Show me file system automation options
+```
+
+## Requirements
+
+- **macOS only** - AppleScript is macOS-specific
+- **Permissions required**:
+  - System Settings > Privacy & Security > Automation
+  - System Settings > Privacy & Security > Accessibility
+
+## Full Documentation
+
+See `tools/automation/macos-automator.md` for complete setup and configuration.

--- a/.agent/tools/automation/macos-automator.md
+++ b/.agent/tools/automation/macos-automator.md
@@ -1,0 +1,470 @@
+---
+description: macOS Automator MCP for AppleScript and JXA automation
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: true
+  macos-automator_*: true
+---
+
+# macOS Automator MCP Setup
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Execute AppleScript and JXA (JavaScript for Automation) on macOS
+- **Install**: `npm install -g @steipete/macos-automator-mcp@latest`
+- **Auth**: None required (uses macOS permissions)
+- **MCP Tools**: `execute_script`, `get_scripting_tips`, `accessibility_query`
+- **Docs**: <https://github.com/steipete/macos-automator-mcp>
+
+**OpenCode Config**:
+
+```json
+"macos-automator": {
+  "type": "local",
+  "command": ["npx", "-y", "@steipete/macos-automator-mcp@latest"],
+  "enabled": true
+}
+```
+
+**Verification Prompt**:
+
+```text
+Use the macos-automator MCP to get the current Safari URL.
+```
+
+**Supported AI Tools**: OpenCode, Claude Code, Cursor, Windsurf, Zed, GitHub Copilot,
+Kilo Code, Kiro, AntiGravity, Gemini CLI, Droid (Factory.AI)
+
+**Enabled for Agents**: None by default. Enable via `@mac` subagent.
+
+**macOS Permissions Required**:
+- System Settings > Privacy & Security > Automation
+- System Settings > Privacy & Security > Accessibility
+
+<!-- AI-CONTEXT-END -->
+
+## What It Does
+
+The macOS Automator MCP provides **full macOS automation** via AppleScript and JXA:
+
+| Feature | Description |
+|---------|-------------|
+| AppleScript execution | Run any AppleScript code |
+| JXA execution | Run JavaScript for Automation |
+| Knowledge base | 200+ pre-built automation scripts |
+| Accessibility queries | Inspect and interact with UI elements |
+| App control | Control any macOS application |
+
+Use it to:
+
+- Control Safari, Finder, Mail, Calendar, and other apps
+- Automate file system operations
+- Send notifications and control system settings
+- Interact with UI elements via accessibility API
+- Execute complex multi-step automations
+
+## Prerequisites
+
+- **macOS** (required - AppleScript is macOS-only)
+- **Node.js 18+** required
+- **macOS Permissions** (see below)
+
+### Required Permissions
+
+The application running the MCP server needs explicit permissions:
+
+1. **Automation Permissions**:
+   - Go to: System Settings > Privacy & Security > Automation
+   - Find Terminal (or your AI tool) in the list
+   - Enable checkboxes for apps you want to control
+
+2. **Accessibility Permissions** (for UI scripting):
+   - Go to: System Settings > Privacy & Security > Accessibility
+   - Add Terminal (or your AI tool) to the list
+   - Ensure checkbox is enabled
+
+## Installation
+
+### 1. Install via npx (Recommended)
+
+No installation needed - runs directly via npx:
+
+```bash
+npx -y @steipete/macos-automator-mcp@latest
+```
+
+### 2. Or Install Globally
+
+```bash
+npm install -g @steipete/macos-automator-mcp@latest
+```
+
+### 3. Verify Installation
+
+```bash
+# Test that it runs
+npx -y @steipete/macos-automator-mcp@latest --help
+```
+
+## AI Tool Configurations
+
+### OpenCode
+
+Edit `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "mcp": {
+    "macos-automator": {
+      "type": "local",
+      "command": ["npx", "-y", "@steipete/macos-automator-mcp@latest"],
+      "enabled": true
+    }
+  },
+  "tools": {
+    "macos-automator_*": false
+  }
+}
+```
+
+Then enable via `@mac` subagent or per-agent in the `agent` section:
+
+```json
+"agent": {
+  "Build+": {
+    "tools": {
+      "macos-automator_*": true
+    }
+  }
+}
+```
+
+### Claude Code
+
+Add via CLI command:
+
+```bash
+# User scope (all projects)
+claude mcp add-json macos-automator --scope user '{"type":"stdio","command":"npx","args":["-y","@steipete/macos-automator-mcp@latest"]}'
+
+# Project scope (current project only)
+claude mcp add-json macos-automator --scope project '{"type":"stdio","command":"npx","args":["-y","@steipete/macos-automator-mcp@latest"]}'
+```
+
+### Cursor
+
+Go to Settings > Tools & MCP > New MCP Server:
+
+```json
+{
+  "mcpServers": {
+    "macos-automator": {
+      "command": "npx",
+      "args": ["-y", "@steipete/macos-automator-mcp@latest"]
+    }
+  }
+}
+```
+
+### Windsurf
+
+Edit `~/.codeium/windsurf/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "macos-automator": {
+      "command": "npx",
+      "args": ["-y", "@steipete/macos-automator-mcp@latest"]
+    }
+  }
+}
+```
+
+### Zed
+
+Click ... > Add Custom Server:
+
+```json
+{
+  "macos-automator": {
+    "command": "npx",
+    "args": ["-y", "@steipete/macos-automator-mcp@latest"],
+    "env": {}
+  }
+}
+```
+
+### GitHub Copilot
+
+Create `.vscode/mcp.json` in your project root:
+
+```json
+{
+  "servers": {
+    "macos-automator": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@steipete/macos-automator-mcp@latest"]
+    }
+  },
+  "inputs": []
+}
+```
+
+### Gemini CLI
+
+Edit `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "macos-automator": {
+      "command": "npx",
+      "args": ["-y", "@steipete/macos-automator-mcp@latest"]
+    }
+  }
+}
+```
+
+### Droid (Factory.AI)
+
+Add via CLI:
+
+```bash
+droid mcp add macos-automator "npx" -y @steipete/macos-automator-mcp@latest
+```
+
+## MCP Tools
+
+### execute_script
+
+Execute AppleScript or JXA code.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `script_content` | string | Raw script code (mutually exclusive with script_path, kb_script_id) |
+| `script_path` | string | Absolute path to script file |
+| `kb_script_id` | string | ID of pre-defined script from knowledge base |
+| `language` | enum | 'applescript' or 'javascript' (default: applescript) |
+| `arguments` | array | Arguments to pass to script |
+| `input_data` | object | Named inputs for knowledge base scripts |
+| `timeout_seconds` | integer | Max execution time (default: 60) |
+
+**Examples**:
+
+```json
+// Get Safari URL
+{
+  "script_content": "tell application \"Safari\" to get URL of front document",
+  "language": "applescript"
+}
+
+// Use knowledge base script
+{
+  "kb_script_id": "safari_get_active_tab_url"
+}
+
+// Toggle dark mode
+{
+  "kb_script_id": "systemsettings_toggle_dark_mode_ui"
+}
+```
+
+### get_scripting_tips
+
+Search the knowledge base of 200+ pre-built scripts.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `list_categories` | boolean | List available categories |
+| `category` | string | Filter by category (e.g., "finder", "safari") |
+| `search_term` | string | Search in titles, descriptions, content |
+| `limit` | integer | Max results (default: 10) |
+
+**Examples**:
+
+```json
+// List all categories
+{ "list_categories": true }
+
+// Search for clipboard scripts
+{ "search_term": "clipboard" }
+
+// Get Safari automation tips
+{ "category": "safari" }
+```
+
+### accessibility_query
+
+Query and interact with UI elements via accessibility API.
+
+**Parameters**:
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `command` | enum | 'query' or 'perform' |
+| `locator.app` | string | Target application (name or bundle ID) |
+| `locator.role` | string | Accessibility role (e.g., "AXButton") |
+| `locator.match` | object | Attributes to match |
+| `action_to_perform` | string | Action for 'perform' command (e.g., "AXPress") |
+
+**Examples**:
+
+```json
+// Find all buttons in System Settings
+{
+  "command": "query",
+  "return_all_matches": true,
+  "locator": {
+    "app": "System Settings",
+    "role": "AXButton",
+    "match": {}
+  }
+}
+
+// Click a specific button
+{
+  "command": "perform",
+  "locator": {
+    "app": "System Settings",
+    "role": "AXButton",
+    "match": {"AXTitle": "General"}
+  },
+  "action_to_perform": "AXPress"
+}
+```
+
+## Common Use Cases
+
+### Application Control
+
+```applescript
+-- Get Safari URL
+tell application "Safari" to get URL of front document
+
+-- Get unread email subjects
+tell application "Mail" to get subject of messages of inbox whose read status is false
+
+-- Play/pause Music
+tell application "Music" to playpause
+```
+
+### File System Operations
+
+```applescript
+-- List desktop files
+tell application "Finder" to get name of every item of desktop
+
+-- Create new folder
+tell application "Finder" to make new folder at desktop with properties {name:"New Folder"}
+```
+
+### System Control
+
+```applescript
+-- Display notification
+display notification "Task complete!" with title "Automation"
+
+-- Set volume
+set volume output volume 50
+
+-- Get clipboard
+the clipboard
+```
+
+## Verification
+
+After configuring, test with this prompt:
+
+```text
+Use the macos-automator MCP to get the current Safari URL.
+```
+
+The AI should:
+
+1. Confirm access to `execute_script` tool
+2. Execute AppleScript to get Safari URL
+3. Return the URL of the front Safari tab
+
+## Troubleshooting
+
+### "Permission denied" errors
+
+1. Open System Settings > Privacy & Security > Automation
+2. Find your terminal/AI tool
+3. Enable permissions for the apps you want to control
+
+### "Accessibility access required"
+
+1. Open System Settings > Privacy & Security > Accessibility
+2. Add your terminal/AI tool to the list
+3. Ensure checkbox is enabled
+
+### Script timeout
+
+Increase `timeout_seconds` parameter (default is 60):
+
+```json
+{
+  "script_content": "...",
+  "timeout_seconds": 120
+}
+```
+
+### "Application not found"
+
+Use exact application name or bundle ID:
+
+```applescript
+-- By name
+tell application "Safari" to ...
+
+-- By bundle ID
+tell application id "com.apple.Safari" to ...
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LOG_LEVEL` | Logging verbosity: DEBUG, INFO, WARN, ERROR |
+| `KB_PARSING` | Knowledge base loading: lazy (default) or eager |
+| `LOCAL_KB_PATH` | Custom knowledge base path (default: ~/.macos-automator/knowledge_base) |
+
+## Custom Knowledge Base
+
+Create custom automation scripts at `~/.macos-automator/knowledge_base/`:
+
+```text
+~/.macos-automator/knowledge_base/
+  01_applescript_core/
+    my_custom_script.md
+  05_web_browsers/
+    safari/
+      my_safari_script.md
+```
+
+Scripts with matching IDs override the built-in knowledge base.
+
+## Updates
+
+Check for updates at:
+<https://github.com/steipete/macos-automator-mcp>
+
+## Related Documentation
+
+- [Stagehand](../browser/stagehand.md) - Browser automation
+- [Playwright](../browser/playwright.md) - Cross-browser testing

--- a/.agent/tools/automation/macos-automator.md
+++ b/.agent/tools/automation/macos-automator.md
@@ -19,7 +19,7 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Execute AppleScript and JXA (JavaScript for Automation) on macOS
-- **Install**: `npm install -g @steipete/macos-automator-mcp@latest`
+- **Install**: `npm install -g @steipete/macos-automator-mcp@0.2.0`
 - **Auth**: None required (uses macOS permissions)
 - **MCP Tools**: `execute_script`, `get_scripting_tips`, `accessibility_query`
 - **Docs**: <https://github.com/steipete/macos-automator-mcp>
@@ -29,7 +29,7 @@ tools:
 ```json
 "macos-automator": {
   "type": "local",
-  "command": ["npx", "-y", "@steipete/macos-automator-mcp@latest"],
+  "command": ["npx", "-y", "@steipete/macos-automator-mcp@0.2.0"],
   "enabled": true
 }
 ```
@@ -98,20 +98,20 @@ The application running the MCP server needs explicit permissions:
 No installation needed - runs directly via npx:
 
 ```bash
-npx -y @steipete/macos-automator-mcp@latest
+npx -y @steipete/macos-automator-mcp@0.2.0
 ```
 
 ### 2. Or Install Globally
 
 ```bash
-npm install -g @steipete/macos-automator-mcp@latest
+npm install -g @steipete/macos-automator-mcp@0.2.0
 ```
 
 ### 3. Verify Installation
 
 ```bash
 # Test that it runs
-npx -y @steipete/macos-automator-mcp@latest --help
+npx -y @steipete/macos-automator-mcp@0.2.0 --help
 ```
 
 ## AI Tool Configurations
@@ -125,7 +125,7 @@ Edit `~/.config/opencode/opencode.json`:
   "mcp": {
     "macos-automator": {
       "type": "local",
-      "command": ["npx", "-y", "@steipete/macos-automator-mcp@latest"],
+      "command": ["npx", "-y", "@steipete/macos-automator-mcp@0.2.0"],
       "enabled": true
     }
   },
@@ -153,10 +153,10 @@ Add via CLI command:
 
 ```bash
 # User scope (all projects)
-claude mcp add-json macos-automator --scope user '{"type":"stdio","command":"npx","args":["-y","@steipete/macos-automator-mcp@latest"]}'
+claude mcp add-json macos-automator --scope user '{"type":"stdio","command":"npx","args":["-y","@steipete/macos-automator-mcp@0.2.0"]}'
 
 # Project scope (current project only)
-claude mcp add-json macos-automator --scope project '{"type":"stdio","command":"npx","args":["-y","@steipete/macos-automator-mcp@latest"]}'
+claude mcp add-json macos-automator --scope project '{"type":"stdio","command":"npx","args":["-y","@steipete/macos-automator-mcp@0.2.0"]}'
 ```
 
 ### Cursor
@@ -168,7 +168,7 @@ Go to Settings > Tools & MCP > New MCP Server:
   "mcpServers": {
     "macos-automator": {
       "command": "npx",
-      "args": ["-y", "@steipete/macos-automator-mcp@latest"]
+      "args": ["-y", "@steipete/macos-automator-mcp@0.2.0"]
     }
   }
 }
@@ -183,7 +183,7 @@ Edit `~/.codeium/windsurf/mcp.json`:
   "mcpServers": {
     "macos-automator": {
       "command": "npx",
-      "args": ["-y", "@steipete/macos-automator-mcp@latest"]
+      "args": ["-y", "@steipete/macos-automator-mcp@0.2.0"]
     }
   }
 }
@@ -197,7 +197,7 @@ Click ... > Add Custom Server:
 {
   "macos-automator": {
     "command": "npx",
-    "args": ["-y", "@steipete/macos-automator-mcp@latest"],
+    "args": ["-y", "@steipete/macos-automator-mcp@0.2.0"],
     "env": {}
   }
 }
@@ -213,7 +213,7 @@ Create `.vscode/mcp.json` in your project root:
     "macos-automator": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@steipete/macos-automator-mcp@latest"]
+      "args": ["-y", "@steipete/macos-automator-mcp@0.2.0"]
     }
   },
   "inputs": []
@@ -229,7 +229,7 @@ Edit `~/.gemini/settings.json`:
   "mcpServers": {
     "macos-automator": {
       "command": "npx",
-      "args": ["-y", "@steipete/macos-automator-mcp@latest"]
+      "args": ["-y", "@steipete/macos-automator-mcp@0.2.0"]
     }
   }
 }
@@ -240,7 +240,7 @@ Edit `~/.gemini/settings.json`:
 Add via CLI:
 
 ```bash
-droid mcp add macos-automator "npx" -y @steipete/macos-automator-mcp@latest
+droid mcp add macos-automator "npx" -y @steipete/macos-automator-mcp@0.2.0
 ```
 
 ## MCP Tools
@@ -263,19 +263,26 @@ Execute AppleScript or JXA code.
 
 **Examples**:
 
+Get Safari URL:
+
 ```json
-// Get Safari URL
 {
   "script_content": "tell application \"Safari\" to get URL of front document",
   "language": "applescript"
 }
+```
 
-// Use knowledge base script
+Use knowledge base script:
+
+```json
 {
   "kb_script_id": "safari_get_active_tab_url"
 }
+```
 
-// Toggle dark mode
+Toggle dark mode:
+
+```json
 {
   "kb_script_id": "systemsettings_toggle_dark_mode_ui"
 }
@@ -296,14 +303,21 @@ Search the knowledge base of 200+ pre-built scripts.
 
 **Examples**:
 
+List all categories:
+
 ```json
-// List all categories
 { "list_categories": true }
+```
 
-// Search for clipboard scripts
+Search for clipboard scripts:
+
+```json
 { "search_term": "clipboard" }
+```
 
-// Get Safari automation tips
+Get Safari automation tips:
+
+```json
 { "category": "safari" }
 ```
 


### PR DESCRIPTION
## Summary

- Add macos-automator MCP server (steipete/macos-automator-mcp) for AppleScript and JXA automation on macOS
- Create `@mac` subagent to enable MCP tools on demand (context-efficient pattern)
- MCP disabled globally, enabled via `@mac` subagent invocation

## Changes

### New Files
- `.agent/tools/automation/mac.md` - `@mac` subagent documentation
- `.agent/tools/automation/macos-automator.md` - Full MCP setup guide

### Modified Files
- `.agent/AGENTS.md` - Added `tools/automation/` to subagent folders table
- `.agent/scripts/generate-opencode-agents.sh` - Added macos-automator MCP config (macOS-only)

## MCP Tools Available via @mac

| Tool | Purpose |
|------|---------|
| `execute_script` | Run AppleScript or JXA code |
| `get_scripting_tips` | Search 200+ pre-built automation scripts |
| `accessibility_query` | Query and interact with UI elements |

## Usage

```text
@mac Get the current Safari URL
@mac Toggle dark mode
@mac List files on the desktop
```

## Requirements

- macOS only (platform check in generate-opencode-agents.sh)
- System Settings > Privacy & Security > Automation permissions
- System Settings > Privacy & Security > Accessibility permissions

## Testing

- [x] ShellCheck passes on modified script
- [x] `./setup.sh` deploys successfully
- [x] `@mac` subagent generated with `macos-automator_*: true`
- [x] MCP config added to opencode.json (disabled globally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS automation support enabling script execution, application & system control, UI automation, and automation-focused tools when running on macOS.

* **Documentation**
  * Added comprehensive macOS automation docs and a dedicated subagent guide with quick start, tool catalog, usage examples, requirements, troubleshooting, and verification steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->