### PR TITLE
feat(browser): add sweet-cookie documentation for cookie extraction

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -380,7 +380,7 @@ Subagents provide specialized capabilities. Read them when tasks require domain 
 | `tools/build-mcp/` | MCP development - creating Model Context Protocol servers and tools | build-mcp, api-wrapper, server-patterns, transports, deployment |
 | `tools/ai-assistants/` | AI tool integration - configuring assistants, CAPTCHA solving, multi-modal agents | agno, capsolver, windsurf, configuration, status |
 | `tools/ai-orchestration/` | AI orchestration frameworks - visual builders, multi-agent teams, workflow automation, DSL orchestration | overview, langflow, crewai, autogen, openprose, packaging |
-| `tools/browser/` | Browser automation - web scraping, testing, screenshots, form filling | agent-browser, stagehand, playwright, playwriter, crawl4ai, dev-browser, pagespeed, chrome-devtools |
+| `tools/browser/` | Browser automation - web scraping, testing, screenshots, form filling, cookie extraction | agent-browser, stagehand, playwright, playwriter, crawl4ai, dev-browser, pagespeed, chrome-devtools, sweet-cookie |
 | `tools/ui/` | UI components - component libraries, design systems, frontend debugging, hydration errors | shadcn, ui-skills, frontend-debugging |
 | `tools/code-review/` | Code quality - linting, security scanning, style enforcement, PR reviews | code-standards, code-simplifier, codacy, coderabbit, qlty, snyk, secretlint, auditing |
 | `tools/context/` | Context optimization - semantic search, codebase indexing, token efficiency | osgrep, augment-context-engine, context-builder, context7, toon, dspy, llm-tldr |

--- a/.agent/tools/browser/browser-automation.md
+++ b/.agent/tools/browser/browser-automation.md
@@ -81,6 +81,8 @@ Need browser automation?
     │
     ├─► Need existing browser session/cookies? ──► Playwriter
     │
+    ├─► Need cookies for API calls (no browser)? ──► sweet-cookie
+    │
     ├─► Need natural language control? ──► Stagehand
     │
     └─► Need web crawling/extraction? ──► Crawl4AI
@@ -93,11 +95,12 @@ Need browser automation?
 | **agent-browser** (DEFAULT) | CLI automation, AI agents, CI/CD, multi-session | `agent-browser-helper.sh setup` |
 | **dev-browser** | TypeScript API, stateful pages, dev testing | `dev-browser-helper.sh setup` |
 | **playwriter** | Existing sessions, bypass detection | Chrome extension + MCP |
+| **sweet-cookie** | Cookie extraction for API calls, session reuse | `npm i @steipete/sweet-cookie` |
 | **stagehand** | Natural language automation | `stagehand-helper.sh setup` |
 | **crawl4ai** | Web scraping, content extraction | `crawl4ai-helper.sh setup` |
 | **playwright** | Cross-browser testing | MCP integration |
 
-**Full docs**: `tools/browser/agent-browser.md` (default), `tools/browser/dev-browser.md`, `tools/browser/playwriter.md`, etc.
+**Full docs**: `tools/browser/agent-browser.md` (default), `tools/browser/dev-browser.md`, `tools/browser/sweet-cookie.md`, etc.
 
 **Ethical Rules**: Respect ToS, rate limit (2-5s delays), no spam, legitimate use only
 <!-- AI-CONTEXT-END -->

--- a/.agent/tools/browser/sweet-cookie.md
+++ b/.agent/tools/browser/sweet-cookie.md
@@ -1,0 +1,361 @@
+---
+description: Browser cookie extraction for automation and session reuse
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Sweet Cookie - Browser Cookie Extraction
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Extract browser cookies for automation, session reuse, and authenticated scraping
+- **Two Libraries**: TypeScript (cross-platform) and Swift (macOS native)
+- **Use Case**: When you need real browser session cookies for API calls or automation
+
+**When to Use Sweet Cookie**:
+- Reusing existing browser sessions (already logged in)
+- Authenticated API calls without re-login
+- Bypassing automation detection with real cookies
+- CI/CD pipelines needing browser auth state
+
+**When NOT to Use**:
+- Fresh browser automation (use agent-browser, stagehand)
+- Sites with app-bound encryption (use Chrome extension)
+- Simple scraping without auth (use crawl4ai)
+
+**Quick Decision**:
+
+```text
+Need cookies from existing browser session?
+    |
+    +-> TypeScript/Node.js project? --> @steipete/sweet-cookie
+    |
+    +-> Swift/macOS native app? --> SweetCookieKit
+    |
+    +-> App-bound cookies (Chrome 127+)? --> Use Chrome extension
+```
+<!-- AI-CONTEXT-END -->
+
+## Overview
+
+Sweet Cookie provides two complementary libraries for extracting browser cookies:
+
+| Library | Language | Platforms | Best For |
+|---------|----------|-----------|----------|
+| `@steipete/sweet-cookie` | TypeScript | macOS, Windows, Linux | Node.js/Bun automation, CI/CD |
+| `SweetCookieKit` | Swift | macOS only | Native macOS apps, Swift tooling |
+
+Both libraries read cookies directly from browser profile databases, avoiding the need for manual cookie export or browser extensions in most cases.
+
+## @steipete/sweet-cookie (TypeScript)
+
+Cross-platform cookie extraction for Node.js and Bun.
+
+### Installation
+
+```bash
+npm install @steipete/sweet-cookie
+# or
+pnpm add @steipete/sweet-cookie
+# or
+bun add @steipete/sweet-cookie
+```
+
+**Requirements**: Node.js >= 22 (for `node:sqlite`) or Bun (for `bun:sqlite`)
+
+### Basic Usage
+
+```typescript
+import { getCookies, toCookieHeader } from '@steipete/sweet-cookie';
+
+// Extract cookies for a URL
+const { cookies, warnings } = await getCookies({
+  url: 'https://example.com/',
+  names: ['session', 'csrf'],
+  browsers: ['chrome', 'edge', 'firefox', 'safari'],
+});
+
+// Log any warnings (e.g., browser locked, keychain prompt)
+for (const warning of warnings) console.warn(warning);
+
+// Convert to Cookie header string
+const cookieHeader = toCookieHeader(cookies, { dedupeByName: true });
+
+// Use in fetch request
+const response = await fetch('https://api.example.com/data', {
+  headers: { Cookie: cookieHeader }
+});
+```
+
+### Multiple Origins (OAuth/SSO)
+
+```typescript
+// Handle OAuth redirects across domains
+const { cookies } = await getCookies({
+  url: 'https://app.example.com/',
+  origins: ['https://accounts.example.com/', 'https://login.example.com/'],
+  names: ['session', 'xsrf'],
+  browsers: ['chrome'],
+  mode: 'merge',
+});
+```
+
+### Specific Browser Profile
+
+```typescript
+// Chrome with specific profile
+await getCookies({
+  url: 'https://example.com/',
+  browsers: ['chrome'],
+  chromeProfile: 'Default', // or full path to Cookies DB
+});
+
+// Edge with specific profile
+await getCookies({
+  url: 'https://example.com/',
+  browsers: ['edge'],
+  edgeProfile: 'Profile 1',
+});
+```
+
+### Inline Cookies (CI/CD)
+
+For environments where browser DB access isn't possible:
+
+```typescript
+// From file (exported via Chrome extension)
+await getCookies({
+  url: 'https://example.com/',
+  browsers: ['chrome'],
+  inlineCookiesFile: '/path/to/cookies.json',
+});
+
+// From JSON string
+await getCookies({
+  url: 'https://example.com/',
+  inlineCookiesJson: '{"cookies": [...]}',
+});
+
+// From base64
+await getCookies({
+  url: 'https://example.com/',
+  inlineCookiesBase64: 'eyJjb29raWVzIjogWy4uLl19',
+});
+```
+
+### Environment Variables
+
+```bash
+# Browser selection
+SWEET_COOKIE_BROWSERS=chrome,safari,firefox
+SWEET_COOKIE_MODE=merge  # or 'first'
+
+# Profile selection
+SWEET_COOKIE_CHROME_PROFILE=Default
+SWEET_COOKIE_EDGE_PROFILE=Default
+SWEET_COOKIE_FIREFOX_PROFILE=default-release
+
+# Linux keyring (if needed)
+SWEET_COOKIE_LINUX_KEYRING=gnome  # or kwallet, basic
+SWEET_COOKIE_CHROME_SAFE_STORAGE_PASSWORD=...
+```
+
+### Supported Browsers
+
+| Browser | macOS | Windows | Linux |
+|---------|-------|---------|-------|
+| Chrome | Yes | Yes | Yes |
+| Edge | Yes | Yes | Yes |
+| Firefox | Yes | Yes | Yes |
+| Safari | Yes | - | - |
+
+### Chrome Extension (App-Bound Cookies)
+
+For Chrome 127+ with app-bound encryption, use the included Chrome extension:
+
+1. Install from `apps/extension` in the sweet-cookie repo
+2. Export cookies as JSON/base64/file
+3. Use `inlineCookiesFile` or `inlineCookiesJson` option
+
+## SweetCookieKit (Swift)
+
+Native macOS cookie extraction for Swift applications.
+
+### Installation
+
+```swift
+// Package.swift
+.package(url: "https://github.com/steipete/SweetCookieKit.git", from: "0.2.0")
+```
+
+**Requirements**: macOS 13+, Swift 6
+
+### Basic Usage
+
+```swift
+import SweetCookieKit
+
+let client = BrowserCookieClient()
+
+// List available browser profiles
+let stores = client.stores(for: .chrome)
+
+// Get cookies from specific profile
+let store = stores.first { $0.profile.name == "Default" }
+let query = BrowserCookieQuery(domains: ["example.com"])
+let records = try client.records(matching: query, in: store!)
+
+// Convert to HTTPCookie
+let cookies = try client.cookies(matching: query, in: store!)
+```
+
+### Query Options
+
+```swift
+let query = BrowserCookieQuery(
+    domains: ["example.com"],
+    domainMatch: .suffix,      // Match subdomains
+    includeExpired: false
+)
+```
+
+### Browser Import Order
+
+```swift
+// Try all supported browsers in order
+let order = Browser.defaultImportOrder
+for browser in order {
+    let results = try client.records(matching: query, in: browser)
+    // Results grouped by profile/store
+}
+```
+
+### Chromium Local Storage
+
+```swift
+// Read localStorage entries
+let entries = ChromiumLocalStorageReader.readEntries(
+    for: "https://example.com",
+    in: levelDBURL
+)
+```
+
+### Chromium LevelDB Helpers
+
+```swift
+// Raw text entries
+let entries = ChromiumLevelDBReader.readTextEntries(in: levelDBURL)
+
+// Token candidates (for auth tokens)
+let tokens = ChromiumLevelDBReader.readTokenCandidates(
+    in: levelDBURL,
+    minimumLength: 80
+)
+```
+
+### CLI Tool
+
+```bash
+cd Examples/CookieCLI
+swift run SweetCookieCLI --help
+
+# List stores
+swift run SweetCookieCLI stores
+
+# Export cookies as JSON
+swift run SweetCookieCLI export --domain example.com --format json
+```
+
+## Comparison: When to Use Each
+
+| Scenario | Recommended Tool |
+|----------|------------------|
+| Node.js/Bun automation | `@steipete/sweet-cookie` |
+| Swift/macOS native app | `SweetCookieKit` |
+| CI/CD pipeline | `@steipete/sweet-cookie` + inline cookies |
+| Cross-platform script | `@steipete/sweet-cookie` |
+| macOS-only CLI tool | Either (Swift for native, TS for npm ecosystem) |
+| Browser extension needed | `@steipete/sweet-cookie` Chrome extension |
+
+## Integration with aidevops
+
+### With Bird (X/Twitter CLI)
+
+Bird uses sweet-cookie for automatic authentication:
+
+```bash
+# Bird auto-extracts X/Twitter cookies
+bird whoami  # Shows logged-in account
+bird tweet "Hello from CLI"
+```
+
+### With Browser Automation
+
+Combine with agent-browser or stagehand for authenticated sessions:
+
+```typescript
+import { getCookies, toCookieHeader } from '@steipete/sweet-cookie';
+
+// Get existing session cookies
+const { cookies } = await getCookies({
+  url: 'https://app.example.com/',
+  browsers: ['chrome'],
+});
+
+// Inject into automation
+const cookieHeader = toCookieHeader(cookies);
+// Use with fetch, playwright, or other tools
+```
+
+### With Crawl4AI
+
+For authenticated crawling:
+
+```bash
+# Export cookies to file
+# Then use with crawl4ai
+crawl4ai https://app.example.com --cookies /path/to/cookies.json
+```
+
+## Security Notes
+
+- **Keychain prompts**: Chrome/Edge may trigger Keychain access prompts on macOS
+- **Full Disk Access**: Safari requires Full Disk Access permission
+- **Browser must be closed**: Some browsers lock their cookie DB while running
+- **Encrypted cookies**: Chromium cookies are encrypted; sweet-cookie handles decryption via OS keychain
+
+### Keychain Prompt Handler (Swift)
+
+```swift
+import SweetCookieKit
+
+// Show custom UI before system keychain prompt
+BrowserCookieKeychainPromptHandler.shared.handler = { context in
+    // context.kind = .chromiumSafeStorage
+    // Show blocking alert or custom UI
+}
+```
+
+## Resources
+
+- **sweet-cookie (TypeScript)**: https://github.com/steipete/sweet-cookie
+- **SweetCookieKit (Swift)**: https://github.com/steipete/SweetCookieKit
+- **Documentation**: https://sweetcookie.dev
+- **Chrome Extension**: `apps/extension` in sweet-cookie repo
+
+## Related Tools
+
+- `tools/browser/agent-browser.md` - CLI browser automation (default)
+- `tools/browser/stagehand.md` - AI-powered browser automation
+- `tools/browser/playwriter.md` - Chrome extension MCP for existing sessions
+- `tools/social-media/bird.md` - X/Twitter CLI (uses sweet-cookie)


### PR DESCRIPTION
## Summary

- Add comprehensive documentation for sweet-cookie (TypeScript) and SweetCookieKit (Swift) browser cookie extraction libraries
- Update browser-automation.md tool selection guide to include sweet-cookie
- Add sweet-cookie to AGENTS.md subagent table

## What are these tools?

**sweet-cookie** (`@steipete/sweet-cookie`) - TypeScript library for cross-platform cookie extraction:
- Works on macOS, Windows, Linux
- Supports Chrome, Edge, Firefox, Safari
- No native Node addons (uses built-in SQLite)
- Inline cookie support for CI/CD pipelines

**SweetCookieKit** - Swift library for native macOS cookie extraction:
- Swift 6 package for macOS 13+
- Safari, Chromium, Firefox support
- HTTPCookie conversion
- Chromium LevelDB helpers

## When to use

- Reusing existing browser sessions (already logged in)
- Authenticated API calls without re-login
- Bypassing automation detection with real cookies
- CI/CD pipelines needing browser auth state

## Links

- https://github.com/steipete/sweet-cookie
- https://github.com/steipete/SweetCookieKit
- https://sweetcookie.dev