### PR TITLE
Fix OpenCode plugin array overwrite bug

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1836,12 +1836,12 @@ add_opencode_plugin() {
     
     # Check if plugin array exists and if plugin is already configured
     local has_plugin_array
-    has_plugin_array=$(jq -e '.plugin' "$opencode_config" 2>/dev/null && echo "true" || echo "false")
+    has_plugin_array=$(jq -e '.plugin' "$opencode_config" >/dev/null 2>&1 && echo "true" || echo "false")
     
     if [[ "$has_plugin_array" == "true" ]]; then
         # Check if plugin is already in the array
         local plugin_exists
-        plugin_exists=$(jq -e --arg p "$plugin_name" '.plugin | map(select(startswith($p))) | length > 0' "$opencode_config" 2>/dev/null && echo "true" || echo "false")
+        plugin_exists=$(jq -e --arg p "$plugin_name" '.plugin | map(select(startswith($p))) | length > 0' "$opencode_config" >/dev/null 2>&1 && echo "true" || echo "false")
         
         if [[ "$plugin_exists" == "true" ]]; then
             # Update existing plugin to latest version
@@ -1965,12 +1965,12 @@ setup_oh_my_opencode() {
     
     # Check if plugin array exists
     local has_plugin_array
-    has_plugin_array=$(jq -e '.plugin' "$opencode_config" 2>/dev/null && echo "true" || echo "false")
+    has_plugin_array=$(jq -e '.plugin' "$opencode_config" >/dev/null 2>&1 && echo "true" || echo "false")
     
     if [[ "$has_plugin_array" == "true" ]]; then
         # Check if plugin is already in the array
         local plugin_exists
-        plugin_exists=$(jq -e --arg p "$plugin_name" '.plugin | map(select(. == $p or startswith($p + "@"))) | length > 0' "$opencode_config" 2>/dev/null && echo "true" || echo "false")
+        plugin_exists=$(jq -e --arg p "$plugin_name" '.plugin | map(select(. == $p or startswith($p + "@"))) | length > 0' "$opencode_config" >/dev/null 2>&1 && echo "true" || echo "false")
         
         if [[ "$plugin_exists" == "true" ]]; then
             print_info "Oh-My-OpenCode already configured"


### PR DESCRIPTION
## Summary

- Fix bug where `setup_opencode_plugins` overwrites the plugin array instead of appending to it
- The `jq -e` command outputs JSON to stdout, which concatenates with `echo "true"`, causing the condition to fail

## Problem

When running `setup.sh` with existing plugins in `opencode.json`:

```json
"plugin": ["oh-my-opencode"]
```

After `setup_opencode_plugins`, only the last plugin remained:

```json
"plugin": ["opencode-anthropic-auth@latest"]
```

## Root Cause

```bash
# Bug: jq outputs JSON before && runs
has_plugin_array=$(jq -e '.plugin' "$config" 2>/dev/null && echo "true" || echo "false")
# Result: '["oh-my-opencode"]\ntrue' — not equal to "true"
```

The condition `[[ "$has_plugin_array" == "true" ]]` failed, falling through to the `else` branch which creates a new array.

## Fix

Added `>/dev/null` to suppress jq stdout while preserving exit code:

```bash
has_plugin_array=$(jq -e '.plugin' "$config" >/dev/null 2>&1 && echo "true" || echo "false")
# Result: 'true' — correct
```

## Changes

- `setup.sh`: Fixed 4 occurrences in `add_opencode_plugin()` and `setup_oh_my_opencode()` functions

## Testing

After fix, running `setup_opencode_plugins` correctly appends plugins:

```json
"plugin": [
  "oh-my-opencode",
  "opencode-antigravity-auth@latest",
  "opencode-anthropic-auth@latest"
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced error output handling in the setup script to reduce console noise during plugin installation checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->