### PR TITLE
Fix secretlint performance

### DIFF
--- a/.agent/scripts/linters-local.sh
+++ b/.agent/scripts/linters-local.sh
@@ -308,13 +308,18 @@ check_secrets() {
         fi
     elif command -v docker &> /dev/null; then
         local timeout_sec=60
-        print_info "Secretlint: Using Docker for scan (${timeout_sec}s timeout)..."
         # Use gtimeout (macOS) or timeout (Linux) to prevent Docker from hanging
         local timeout_cmd=""
         if command -v gtimeout &> /dev/null; then
             timeout_cmd="gtimeout $timeout_sec"
         elif command -v timeout &> /dev/null; then
             timeout_cmd="timeout $timeout_sec"
+        fi
+        
+        if [[ -n "$timeout_cmd" ]]; then
+            print_info "Secretlint: Using Docker for scan (${timeout_sec}s timeout)..."
+        else
+            print_info "Secretlint: Using Docker for scan (no timeout available)..."
         fi
         
         local docker_result

--- a/.secretlintignore
+++ b/.secretlintignore
@@ -114,5 +114,3 @@
 **/.osgrep/
 **/.scannerwork/
 
-# Lock files
-**/bun.lock

--- a/.secretlintignore
+++ b/.secretlintignore
@@ -107,6 +107,8 @@
 **/templates/**
 
 # Python virtual environments (mirror .gitignore)
+# Note: **/env/ is broad but matches .gitignore convention for venvs
+# venv/.venv already in Dependencies section above
 **/python-env/
 **/env/
 

--- a/.secretlintignore
+++ b/.secretlintignore
@@ -105,3 +105,14 @@
 
 # Template files (contain example configurations)
 **/templates/**
+
+# Python virtual environments (mirror .gitignore)
+**/python-env/
+**/env/
+
+# Tool caches and indexes (mirror .gitignore)
+**/.osgrep/
+**/.scannerwork/
+
+# Lock files
+**/bun.lock

--- a/TODO.md
+++ b/TODO.md
@@ -281,3 +281,4 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 <!--TOON:summary{total,pending,in_progress,in_review,done,declined,total_est,total_actual,blocked_count,ready_count}:
 56,45,0,0,26,0,28d3h,16h50m,0,45
+-->

--- a/TODO.md
+++ b/TODO.md
@@ -135,6 +135,8 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
   - Notes: Inspired by opengraphdebug.com. Two subagents: 1) debug-opengraph.md - validate Open Graph meta tags (og:title, og:description, og:image, og:url, twitter:card), preview social sharing appearance, check image dimensions/accessibility. 2) debug-favicon.md - validate favicon setup across platforms (favicon.ico, apple-touch-icon, manifest icons), check sizes/formats, verify PWA manifest. Could use browser automation (Stagehand/Playwright) or direct HTML parsing. Add to tools/seo/ or tools/browser/.
 - [ ] t062 Research vercel-labs/agent-skills for inclusion in aidevops #research #tools #deployment ~2h (ai:1h read:1h) logged:2026-01-14 ref:https://github.com/vercel-labs/agent-skills
   - Notes: Vercel's Agent Skills collection (332 stars, MIT). Currently includes vercel-deploy skill for instant deployment without auth. Auto-detects 40+ frameworks, returns preview URL + claim URL. Follows agentskills.io format (SKILL.md structure). Evaluate: 1) Add vercel-deploy as aidevops skill 2) Adopt Agent Skills format for aidevops skills 3) Contribute aidevops skills back to ecosystem.
+- [ ] t063 Fix secretlint scanning performance #bugfix #secretlint #performance ~30m (ai:15m test:10m read:5m) logged:2026-01-14
+  - Notes: Secretlint scans 19,790 files (572MB) including python-env binaries, causing 60+ min hangs. Fix: 1) Add missing patterns to .secretlintignore (python-env, .osgrep, .scannerwork) - must mirror .gitignore to avoid security gaps. 2) Add --init flag to docker run for proper timeout handling. 3) Increase timeout from 30s to 60s. Result: Scans ~230 files in seconds, timeout now properly stops container. Principle: .secretlintignore must be subset of .gitignore.
 
 <!--TOON:backlog[40]{id,desc,owner,tags,est,est_ai,est_test,est_read,logged,status,blocked_by,blocks,parent}:
 t010,Evaluate Merging build-agent and build-mcp into aidevops,,plan|architecture|agents,4h,2h,1h,1h,2025-12-21T14:00Z,pending,,,
@@ -279,4 +281,3 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 <!--TOON:summary{total,pending,in_progress,in_review,done,declined,total_est,total_actual,blocked_count,ready_count}:
 56,45,0,0,26,0,28d3h,16h50m,0,45
--->


### PR DESCRIPTION
## Summary

Fixes secretlint scanning 19,790 files (572MB) including python-env binaries, causing 60+ minute hangs.

## Changes

### .secretlintignore
- Add `python-env/` - Python virtual environments (mirrors .gitignore)
- Add `.osgrep/` - Tool cache (mirrors .gitignore)
- Add `.scannerwork/` - SonarCloud cache (mirrors .gitignore)
- Add `bun.lock` - Lock file

### linters-local.sh
- Increase Docker timeout from 30s to 60s (allows for cold starts)

## Result
- Scans ~230 files instead of 19,790
- Completes in seconds instead of 60+ minutes

## Task Reference
- t063: Fix secretlint scanning performance

## Principle
`.secretlintignore` patterns must be subset of `.gitignore` to avoid security gaps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased Docker-based Secretlint scan timeout to 60s and updated user messaging to reflect longer scans when applicable.
  * Ensure Docker runs include init processing to improve signal handling.
  * Expanded Secretlint ignore patterns to skip common Python virtual environments and tool caches/indexes.
  * Updated backlog: replaced the prior research task with a new task focused on improving Secretlint scanning performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->