### PR TITLE
docs(agents): add slash command placement guidance

### DIFF
--- a/.agent/tools/build-agent/agent-review.md
+++ b/.agent/tools/build-agent/agent-review.md
@@ -128,6 +128,12 @@ For each code example:
 - Is it readable without the detailed section?
 - Would an AI get stuck with only the AI-CONTEXT?
 
+#### 6. Slash Command Audit
+
+- Are any commands defined inline in main agents?
+- Should inline commands move to `scripts/commands/` or domain subagent?
+- Do main agents only reference commands (not implement them)?
+
 ### Improvement Proposal Format
 
 When proposing changes:

--- a/.agent/tools/build-agent/build-agent.md
+++ b/.agent/tools/build-agent/build-agent.md
@@ -704,8 +704,36 @@ See "Subagent YAML Frontmatter" section for full permission options.
 │   ├── {category}/           # Grouped by function
 ├── services/                 # External integrations
 │   ├── {category}/           # Grouped by type
-└── workflows/                # Process guides
+├── workflows/                # Process guides
+└── scripts/
+    └── commands/             # Slash command definitions
 ```text
+
+### Slash Command Placement
+
+**CRITICAL**: Never define slash commands inline in main agents.
+
+| Command Type | Location | Example |
+|--------------|----------|---------|
+| Generic (cross-domain) | `scripts/commands/{command}.md` | `/save-todo`, `/remember`, `/code-simplifier` |
+| Domain-specific | `{domain}/{subagent}.md` | `/keyword-research` in `seo/keyword-research.md` |
+
+**Main agents only reference commands** - they list available commands but never contain the implementation:
+
+```markdown
+# Good: Reference in main agent (seo.md)
+**Commands**: `/keyword-research`, `/autocomplete-research`
+
+# Bad: Implementation in main agent
+## /keyword-research Command
+[50 lines of command implementation...]
+```text
+
+**Why this matters:**
+- Keeps main agents under instruction budget
+- Enables command reuse across agents
+- Allows targeted reading (only load command when invoked)
+- Prevents duplication when multiple agents use same command
 
 **Naming conventions:**
 


### PR DESCRIPTION
## Summary

- Add guidance to `build-agent.md` ensuring slash commands are never defined inline in main agents
- Add slash command audit to `agent-review.md` checklist

## Changes

### `tools/build-agent/build-agent.md`
- Added `scripts/commands/` to folder organization diagram
- Added new "Slash Command Placement" section with:
  - Table showing where generic vs domain-specific commands should go
  - Example of good (reference) vs bad (inline implementation) patterns
  - Rationale for the pattern (instruction budget, reuse, targeted loading)

### `tools/build-agent/agent-review.md`
- Added "Slash Command Audit" to the review checklist (item 6)
- Checks for inline commands in main agents that should be extracted

## Context

Analysis found the framework already follows this pattern consistently, but there was no explicit guidance to prevent AI assistants from creating inline command implementations when adding new commands.

## Testing

- [x] Preflight checks passed
- [x] ShellCheck: No violations
- [x] Secretlint: No secrets detected