### PR TITLE
fix(quality-loop): output options as YAML object instead of string

### DIFF
--- a/.agent/scripts/quality-loop-helper.sh
+++ b/.agent/scripts/quality-loop-helper.sh
@@ -226,16 +226,31 @@ get_pending_checks() {
 # Arguments:
 #   $1 - Loop type (preflight, pr-review, postflight)
 #   $2 - Max iterations
-#   $3 - Options string
+#   $3 - Options string (key=value pairs separated by commas)
 # Returns: 0
-# Side effects: Creates .claude/quality-loop.local.md
+# Side effects: Creates .agent/loop-state/quality-loop.local.md
 create_state() {
     local loop_type="$1"
     local max_iterations="$2"
-    local options="$3"
-    
+    local options_str="$3"
+
     mkdir -p "$STATE_DIR"
-    
+
+    # Convert options string to YAML object format
+    # Input: "auto_fix=true,wait_for_ci=false" -> "  auto_fix: true\n  wait_for_ci: false"
+    local options_yaml=""
+    if [[ -n "$options_str" ]]; then
+        options_yaml=$(echo "$options_str" | tr ',' '\n' | while IFS='=' read -r key value; do
+            [[ -z "$key" ]] && continue
+            # Handle boolean and numeric values without quotes
+            if [[ "$value" == "true" || "$value" == "false" || "$value" =~ ^[0-9]+$ ]]; then
+                echo "  $key: $value"
+            else
+                echo "  $key: \"$value\""
+            fi
+        done)
+    fi
+
     cat > "$STATE_FILE" << EOF
 ---
 type: $loop_type
@@ -243,7 +258,8 @@ iteration: 1
 max_iterations: $max_iterations
 status: running
 started_at: "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-options: "$options"
+options:
+$options_yaml
 checks_passed: []
 checks_failed: []
 fixes_applied: 0


### PR DESCRIPTION
## Summary
- Fix YAML frontmatter parsing error in quality-loop state files
- The `options` field was output as a string `"auto_fix=true"` but OpenCode expects a YAML object
- Now properly converts comma-separated key=value pairs to YAML object format

## Problem
OpenCode failed to launch with error:
```
Configuration is invalid at .opencode/agent/loop-state/quality-loop.local.md
Invalid input: expected record, received string options
```

## Solution
Changed `create_state()` function to output:
```yaml
options:
  auto_fix: true
```
Instead of:
```yaml
options: "auto_fix=true"
```

## Test plan
- [x] Verified OpenCode launches successfully after fix
- [x] Preflight linters pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal configuration handling with enhanced type support for boolean, numeric, and string values.
  * Updated state file generation for better compatibility with structured configuration formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->