### PR TITLE
feat(mcp): point Claude Code MCP to fork

### DIFF
--- a/.agent/aidevops/mcp-integrations.md
+++ b/.agent/aidevops/mcp-integrations.md
@@ -31,6 +31,7 @@ tools:
 - Google Search Console: `GOOGLE_APPLICATION_CREDENTIALS` (service account JSON)
 
 **Development**:
+- Claude Code MCP: Claude Code automation (forked server)
 - Next.js DevTools MCP
 - Context7 MCP: Real-time library docs
 - LocalWP MCP: WordPress database access
@@ -56,6 +57,7 @@ This document provides comprehensive setup and usage instructions for advanced M
 
 ### **⚡ Development Tools**
 
+- **Claude Code MCP**: Run Claude Code as an MCP server for automation
 - **Next.js DevTools MCP**: Next.js development and debugging assistance
 
 ### **📧 CRM & Marketing**
@@ -92,6 +94,17 @@ playwright-mcp --install-browsers
 # Add to MCP client
 claude mcp add playwright npx playwright-mcp@latest
 ```
+
+### **Claude Code MCP (Fork)**
+
+```bash
+# Add forked MCP server via Claude CLI
+claude mcp add claude-code-mcp "npx -y github:marcusquinn/claude-code-mcp"
+```
+
+**One-time setup**: run `claude --dangerously-skip-permissions` and accept prompts.
+**Upstream**: https://github.com/steipete/claude-code-mcp (revert if merged).
+**Local dev (optional)**: clone the fork and swap the command to `./start.sh` for instant iteration.
 
 ### **Ahrefs MCP**
 

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -121,12 +121,14 @@ AGENT_TOOLS = {
     "Build+": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True, "todoread": True, "todowrite": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True,
+        "claude-code-mcp_*": True
     },
     "AI-DevOps": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True, "todoread": True, "todowrite": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True,
+        "claude-code-mcp_*": True
     },
     "Onboarding": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
@@ -166,7 +168,8 @@ AGENT_TOOLS = {
 DEFAULT_TOOLS = {
     "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
     "webfetch": True, "task": True,
-    "osgrep_*": True, "augment-context-engine_*": True
+    "osgrep_*": True, "augment-context-engine_*": True,
+    "claude-code-mcp_*": False
 }
 
 # Temperature settings (by display name, default 0.2)
@@ -469,6 +472,21 @@ if 'shadcn' not in config['mcp']:
 if 'shadcn_*' not in config['tools']:
     config['tools']['shadcn_*'] = False
     print("  Added shadcn_* to tools (disabled globally, enabled for @shadcn subagent)")
+
+# Claude Code MCP - forked for local automation
+# Source: https://github.com/marcusquinn/claude-code-mcp
+# Upstream: https://github.com/steipete/claude-code-mcp (revert if merged)
+config['mcp']['claude-code-mcp'] = {
+    "type": "local",
+    "command": ["npx", "-y", "github:marcusquinn/claude-code-mcp"],
+    "enabled": True
+}
+print("  Ensured claude-code-mcp MCP server (forked)")
+
+# Claude Code MCP tools disabled globally (enable per-agent if needed)
+if 'claude-code-mcp_*' not in config['tools']:
+    config['tools']['claude-code-mcp_*'] = False
+    print("  Added claude-code-mcp_* to tools (disabled globally, enabled for Build+/AI-DevOps)")
 
 # macOS Automator MCP - AppleScript and JXA automation (macOS only)
 # Docs: https://github.com/steipete/macos-automator-mcp

--- a/.agent/scripts/setup-mcp-integrations.sh
+++ b/.agent/scripts/setup-mcp-integrations.sh
@@ -36,6 +36,7 @@ get_mcp_command() {
         "google-search-console") echo "npx mcp-server-gsc@latest" ;;
         "pagespeed-insights") echo "npx mcp-pagespeed-server@latest" ;;
         "grep-vercel") echo "remote:https://mcp.grep.app" ;;
+        "claude-code-mcp") echo "npx -y github:marcusquinn/claude-code-mcp" ;;
         "stagehand") echo "node ${HOME}/.aidevops/stagehand/examples/basic-example.js" ;;
         "stagehand-python") echo "${HOME}/.aidevops/stagehand-python/.venv/bin/python ${HOME}/.aidevops/stagehand-python/examples/basic_example.py" ;;
         "stagehand-both") echo "both" ;;
@@ -47,7 +48,7 @@ get_mcp_command() {
 }
 
 # Available integrations list
-MCP_LIST="chrome-devtools playwright cloudflare-browser ahrefs perplexity nextjs-devtools google-search-console pagespeed-insights grep-vercel stagehand stagehand-python stagehand-both dataforseo serper"
+MCP_LIST="chrome-devtools playwright cloudflare-browser ahrefs perplexity nextjs-devtools google-search-console pagespeed-insights grep-vercel claude-code-mcp stagehand stagehand-python stagehand-both dataforseo serper"
 
 # Check prerequisites
 check_prerequisites() {
@@ -185,6 +186,18 @@ install_mcp() {
             print_success "Grep by Vercel MCP setup complete!"
             print_info "Use 'gh_grep' tool in prompts to search GitHub code"
             print_info "Example: 'use gh_grep to find examples of SST Astro components'"
+            ;;
+        "claude-code-mcp")
+            print_info "Setting up Claude Code MCP (forked) for Claude Code automation..."
+            print_info "Source: https://github.com/marcusquinn/claude-code-mcp"
+            print_info "Upstream: https://github.com/steipete/claude-code-mcp (revert if merged)"
+            print_warning "Requires Claude CLI and prior acceptance of --dangerously-skip-permissions"
+            print_info "One-time setup: claude --dangerously-skip-permissions"
+            if command -v claude &> /dev/null; then
+                claude mcp add claude-code-mcp "$mcp_command"
+            fi
+            print_success "Claude Code MCP setup complete!"
+            print_info "Use 'claude_code' tool to run Claude Code tasks"
             ;;
         "stagehand")
             print_info "Setting up Stagehand AI Browser Automation MCP integration..."

--- a/.wiki/MCP-Integrations.md
+++ b/.wiki/MCP-Integrations.md
@@ -242,7 +242,30 @@ bash .agent/scripts/setup-mcp-integrations.sh pagespeed
 
 ---
 
-### Development Tools (3 servers)
+### Development Tools (4 servers)
+
+#### Claude Code MCP (Fork)
+
+Run Claude Code as an MCP server for automation.
+
+**Installation**:
+
+```bash
+claude mcp add claude-code-mcp "npx -y github:marcusquinn/claude-code-mcp"
+```
+
+**Upstream**: https://github.com/steipete/claude-code-mcp (revert if merged).
+**Local dev (optional)**: clone the fork and point the MCP command to `./start.sh`.
+
+**One-time setup**: run `claude --dangerously-skip-permissions` and accept prompts.
+
+**Use Cases**:
+
+- Run Claude Code workflows from MCP clients
+- Multi-step code edits via Claude Code CLI
+- Reuse Claude Code toolchain in Cursor/Windsurf
+
+---
 
 #### Next.js DevTools MCP
 
@@ -331,6 +354,9 @@ bash .agent/scripts/setup-mcp-integrations.sh playwright
 
 # Ahrefs
 bash .agent/scripts/setup-mcp-integrations.sh ahrefs
+
+# Claude Code MCP (fork)
+bash .agent/scripts/setup-mcp-integrations.sh claude-code-mcp
 
 # Context7
 bash .agent/scripts/setup-mcp-integrations.sh context7

--- a/configs/mcp-templates/claude-code-mcp.json
+++ b/configs/mcp-templates/claude-code-mcp.json
@@ -1,0 +1,60 @@
+{
+  "_comment": "Claude Code MCP (fork) configuration snippets for various AI tools",
+  "_documentation": "https://github.com/marcusquinn/claude-code-mcp",
+  "_upstream": "https://github.com/steipete/claude-code-mcp (revert if merged)",
+  "_note": "Requires Claude CLI with --dangerously-skip-permissions accepted (swap to ./start.sh for local dev)",
+  "_install": "npx -y github:marcusquinn/claude-code-mcp",
+
+  "opencode": {
+    "_file": "~/.config/opencode/opencode.json",
+    "_section": "mcp",
+    "claude-code-mcp": {
+      "type": "local",
+      "command": ["npx", "-y", "github:marcusquinn/claude-code-mcp"],
+      "enabled": true
+    }
+  },
+
+  "claude_code_command": "claude mcp add claude-code-mcp \"npx -y github:marcusquinn/claude-code-mcp\"",
+
+  "cursor": {
+    "_file": "~/.cursor/mcp.json",
+    "mcpServers": {
+      "claude-code-mcp": {
+        "command": "npx",
+        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
+      }
+    }
+  },
+
+  "windsurf": {
+    "_file": "~/.codeium/windsurf/mcp_config.json",
+    "mcpServers": {
+      "claude-code-mcp": {
+        "command": "npx",
+        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
+      }
+    }
+  },
+
+  "gemini_cli": {
+    "_file": "~/.gemini/settings.json",
+    "mcpServers": {
+      "claude-code-mcp": {
+        "command": "npx",
+        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
+      }
+    }
+  },
+
+  "github_copilot": {
+    "_file": ".vscode/mcp.json (project root)",
+    "servers": {
+      "claude-code-mcp": {
+        "type": "stdio",
+        "command": "npx",
+        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- switch Claude Code MCP to forked repository via `npx`
- add fork documentation and local dev notes
- add MCP template for Claude Code fork

## Testing
- `bash .agent/scripts/linters-local.sh`

## Notes
- Upstream PR: https://github.com/steipete/claude-code-mcp/pull/40
- Branch merged with `origin/main` for audit trail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code MCP integration, a new development tool for code-related operations.

* **Documentation**
  * Added comprehensive setup instructions and configuration guidance for Claude Code MCP across multiple development environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->