### PR TITLE
fix(opencode): exclude loop-state from agent discovery and deployment

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -62,6 +62,12 @@ for f in Accounts.md Accounting.md accounting.md AI-DevOps.md Build+.md Content.
     rm -f "$OPENCODE_AGENT_DIR/$f"
 done
 
+# Remove loop-state files that were incorrectly created as agents
+# These are runtime state files, not agents
+for f in ralph-loop.local.md quality-loop.local.md full-loop.local.md loop-state.md re-anchor.md postflight-loop.md; do
+    rm -f "$OPENCODE_AGENT_DIR/$f"
+done
+
 # =============================================================================
 # PRIMARY AGENTS - Defined in opencode.json for Tab order control
 # =============================================================================
@@ -615,7 +621,7 @@ tools:
 EOF
     fi
     ((subagent_count++))
-done < <(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -type f | sort)
+done < <(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -type f -not -path "*/loop-state/*" | sort)
 
 echo -e "  ${GREEN}✓${NC} Generated $subagent_count subagent files"
 

--- a/setup.sh
+++ b/setup.sh
@@ -1266,9 +1266,16 @@ deploy_aidevops_agents() {
         rm -rf "${target_dir:?}"/*
     fi
     
-    # Copy all agent files and folders (excluding scripts which are large)
-    # We copy scripts separately to maintain structure
-    cp -R "$source_dir"/* "$target_dir/"
+    # Copy all agent files and folders, excluding:
+    # - loop-state/ (local runtime state, not agents)
+    # Use rsync for selective exclusion
+    if command -v rsync &>/dev/null; then
+        rsync -a --exclude='loop-state/' "$source_dir/" "$target_dir/"
+    else
+        # Fallback: copy then remove loop-state
+        cp -R "$source_dir"/* "$target_dir/"
+        rm -rf "$target_dir/loop-state" 2>/dev/null || true
+    fi
     
     if [[ $? -eq 0 ]]; then
         print_success "Deployed agents to $target_dir"


### PR DESCRIPTION
## Summary

- Fixes 'Loop-State/Quality-Loop.Local' appearing in OpenCode tab cycle
- Loop state files (`.agent/loop-state/*.md`) are runtime state, not agents

## Changes

1. **setup.sh**: Use rsync to exclude `loop-state/` from deployment to `~/.aidevops/agents/`
2. **generate-opencode-agents.sh**: Exclude `loop-state/` from subagent discovery with `-not -path "*/loop-state/*"`
3. **generate-opencode-agents.sh**: Remove incorrectly created loop-state agent files on regeneration

## Root Cause

When running Ralph/Quality loops locally in the aidevops repo, `.agent/loop-state/` directory is created with state files like `quality-loop.local.md`. These were being:
1. Deployed to `~/.aidevops/agents/loop-state/` by setup.sh
2. Discovered as subagents by generate-opencode-agents.sh
3. Appearing in OpenCode's Tab cycle as agents

## Testing

After merging, run `./setup.sh` to deploy the fix. The loop-state files will be excluded from deployment and removed from the OpenCode agent directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded runtime loop-state files from agent deployment and discovery processes to ensure proper isolation of temporary state data.
  * Enhanced setup script with selective file copying for more efficient and cleaner deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->