### PR TITLE
fix(loop-state): change state files from .md to .state extension

### DIFF
--- a/.agent/scripts/full-loop-helper.sh
+++ b/.agent/scripts/full-loop-helper.sh
@@ -41,13 +41,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 readonly SCRIPT_DIR
 readonly STATE_DIR=".agent/loop-state"
-readonly STATE_FILE="${STATE_DIR}/full-loop.local.md"
+readonly STATE_FILE="${STATE_DIR}/full-loop.local.state"
 
 # Legacy state directory (for backward compatibility during migration)
 # shellcheck disable=SC2034  # Defined for documentation, used in cancel checks
 readonly LEGACY_STATE_DIR=".claude"
 # shellcheck disable=SC2034  # Defined for backward compatibility path reference
-readonly LEGACY_STATE_FILE="${LEGACY_STATE_DIR}/full-loop.local.md"
+readonly LEGACY_STATE_FILE="${LEGACY_STATE_DIR}/full-loop.local.state"
 
 # Default settings
 readonly DEFAULT_MAX_TASK_ITERATIONS=50
@@ -562,7 +562,7 @@ cmd_resume() {
     case "$CURRENT_PHASE" in
         "$PHASE_TASK")
             # Check if task is complete (check both new and legacy locations)
-            if [[ -f ".agent/loop-state/ralph-loop.local.md" ]] || [[ -f ".claude/ralph-loop.local.md" ]]; then
+            if [[ -f ".agent/loop-state/ralph-loop.local.state" ]] || [[ -f ".claude/ralph-loop.local.state" ]]; then
                 print_info "Task loop still active. Complete it first."
                 return 0
             fi
@@ -643,10 +643,10 @@ cmd_cancel() {
     clear_state
     
     # Also cancel any sub-loops (both new and legacy locations)
-    rm -f ".agent/loop-state/ralph-loop.local.md" 2>/dev/null
-    rm -f ".agent/loop-state/quality-loop.local.md" 2>/dev/null
-    rm -f ".claude/ralph-loop.local.md" 2>/dev/null
-    rm -f ".claude/quality-loop.local.md" 2>/dev/null
+    rm -f ".agent/loop-state/ralph-loop.local.state" 2>/dev/null
+    rm -f ".agent/loop-state/quality-loop.local.state" 2>/dev/null
+    rm -f ".claude/ralph-loop.local.state" 2>/dev/null
+    rm -f ".claude/quality-loop.local.state" 2>/dev/null
     
     print_success "Full loop cancelled"
     return 0

--- a/.agent/scripts/generate-opencode-commands.sh
+++ b/.agent/scripts/generate-opencode-commands.sh
@@ -1164,7 +1164,7 @@ Cancel the active Ralph loop.
 ~/.aidevops/agents/scripts/ralph-loop-helper.sh cancel
 ```
 
-This removes the state file at `.agent/loop-state/ralph-loop.local.md` and stops the loop.
+This removes the state file at `.agent/loop-state/ralph-loop.local.state` and stops the loop.
 
 If no loop is active, it will report "No active Ralph loop found."
 EOF

--- a/.agent/scripts/quality-loop-helper.sh
+++ b/.agent/scripts/quality-loop-helper.sh
@@ -32,7 +32,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 readonly SCRIPT_DIR
 readonly STATE_DIR=".agent/loop-state"
-readonly STATE_FILE="${STATE_DIR}/quality-loop.local.md"
+readonly STATE_FILE="${STATE_DIR}/quality-loop.local.state"
 
 # Legacy state directory (for backward compatibility during migration)
 # shellcheck disable=SC2034  # Defined for documentation
@@ -228,7 +228,7 @@ get_pending_checks() {
 #   $2 - Max iterations
 #   $3 - Options string (key=value pairs separated by commas)
 # Returns: 0
-# Side effects: Creates .agent/loop-state/quality-loop.local.md
+# Side effects: Creates .agent/loop-state/quality-loop.local.state
 create_state() {
     local loop_type="$1"
     local max_iterations="$2"

--- a/.agent/scripts/ralph-loop-helper.sh
+++ b/.agent/scripts/ralph-loop-helper.sh
@@ -44,12 +44,12 @@ fi
 
 # State directories
 readonly RALPH_STATE_DIR=".agent/loop-state"
-readonly RALPH_STATE_FILE="${RALPH_STATE_DIR}/ralph-loop.local.md"
+readonly RALPH_STATE_FILE="${RALPH_STATE_DIR}/ralph-loop.local.state"
 
 # Legacy state directory (for backward compatibility during migration)
 readonly RALPH_LEGACY_STATE_DIR=".claude"
 # shellcheck disable=SC2034  # Defined for documentation, used in status checks
-readonly RALPH_LEGACY_STATE_FILE="${RALPH_LEGACY_STATE_DIR}/ralph-loop.local.md"
+readonly RALPH_LEGACY_STATE_FILE="${RALPH_LEGACY_STATE_DIR}/ralph-loop.local.state"
 
 # Adaptive timing constants (evidence-based from PR #19 analysis)
 readonly RALPH_DELAY_BASE="${RALPH_DELAY_BASE:-2}"
@@ -599,8 +599,8 @@ show_status_all() {
             # Check for v2 state (new location first, then legacy)
             local v2_state="$worktree_path/.agent/loop-state/loop-state.json"
             local v2_state_legacy="$worktree_path/.claude/loop-state.json"
-            local legacy_state="$worktree_path/.agent/loop-state/ralph-loop.local.md"
-            local legacy_state_old="$worktree_path/.claude/ralph-loop.local.md"
+            local legacy_state="$worktree_path/.agent/loop-state/ralph-loop.local.state"
+            local legacy_state_old="$worktree_path/.claude/ralph-loop.local.state"
             
             # Check any of the state file locations
             if [[ -f "$v2_state" ]] || [[ -f "$v2_state_legacy" ]] || [[ -f "$legacy_state" ]] || [[ -f "$legacy_state_old" ]]; then
@@ -671,8 +671,8 @@ check_other_loops() {
             # Check all possible state file locations (new and legacy)
             local v2_state="$worktree_path/.agent/loop-state/loop-state.json"
             local v2_state_legacy="$worktree_path/.claude/loop-state.json"
-            local legacy_state="$worktree_path/.agent/loop-state/ralph-loop.local.md"
-            local legacy_state_old="$worktree_path/.claude/ralph-loop.local.md"
+            local legacy_state="$worktree_path/.agent/loop-state/ralph-loop.local.state"
+            local legacy_state_old="$worktree_path/.claude/ralph-loop.local.state"
 
             if [[ -f "$v2_state" ]] || [[ -f "$v2_state_legacy" ]] || [[ -f "$legacy_state" ]] || [[ -f "$legacy_state_old" ]]; then
                 local branch

--- a/.agent/scripts/session-review-helper.sh
+++ b/.agent/scripts/session-review-helper.sh
@@ -90,8 +90,8 @@ get_todo_status() {
 get_ralph_status() {
     local project_root="$1"
     # Check new location first, then legacy
-    local ralph_file="$project_root/.agent/loop-state/ralph-loop.local.md"
-    local ralph_file_legacy="$project_root/.claude/ralph-loop.local.md"
+    local ralph_file="$project_root/.agent/loop-state/ralph-loop.local.state"
+    local ralph_file_legacy="$project_root/.claude/ralph-loop.local.state"
     
     local active_file=""
     [[ -f "$ralph_file" ]] && active_file="$ralph_file"

--- a/.agent/scripts/worktree-sessions.sh
+++ b/.agent/scripts/worktree-sessions.sh
@@ -103,8 +103,8 @@ epoch_to_date() {
 get_ralph_loop_status() {
     local worktree_path="$1"
     # Check new location first, then legacy
-    local state_file="$worktree_path/.agent/loop-state/ralph-loop.local.md"
-    local state_file_legacy="$worktree_path/.claude/ralph-loop.local.md"
+    local state_file="$worktree_path/.agent/loop-state/ralph-loop.local.state"
+    local state_file_legacy="$worktree_path/.claude/ralph-loop.local.state"
     
     local active_file=""
     [[ -f "$state_file" ]] && active_file="$state_file"

--- a/setup.sh
+++ b/setup.sh
@@ -231,7 +231,7 @@ migrate_loop_state_directories() {
         
         # Check for loop state files in old location
         local has_loop_state=false
-        if [[ -f "$old_state_dir/ralph-loop.local.md" ]] || \
+        if [[ -f "$old_state_dir/ralph-loop.local.state" ]] || \
            [[ -f "$old_state_dir/loop-state.json" ]] || \
            [[ -d "$old_state_dir/receipts" ]]; then
             has_loop_state=true
@@ -245,7 +245,7 @@ migrate_loop_state_directories() {
         mkdir -p "$new_state_dir"
         
         # Move loop-related files
-        for file in ralph-loop.local.md loop-state.json re-anchor.md guardrails.md; do
+        for file in ralph-loop.local.state loop-state.json re-anchor.md guardrails.md; do
             if [[ -f "$old_state_dir/$file" ]]; then
                 mv "$old_state_dir/$file" "$new_state_dir/"
                 print_info "  Moved $file"


### PR DESCRIPTION
## Summary

Loop state files (`.local.md`) were being picked up as OpenCode agents because they're `.md` files in the `.agent/` directory tree (via the `.opencode/agent` symlink).

## Solution

Changed file extensions from `.md` to `.state`:
- `ralph-loop.local.md` -> `ralph-loop.local.state`
- `quality-loop.local.md` -> `quality-loop.local.state`  
- `full-loop.local.md` -> `full-loop.local.state`

This prevents OpenCode from discovering them as agents while keeping them in the logical `.agent/loop-state/` location.

## Files Updated

- `quality-loop-helper.sh` - STATE_FILE constant
- `ralph-loop-helper.sh` - RALPH_STATE_FILE and legacy paths
- `full-loop-helper.sh` - STATE_FILE and cleanup paths
- `worktree-sessions.sh` - state file paths
- `session-review-helper.sh` - ralph file paths
- `generate-opencode-commands.sh` - documentation
- `setup.sh` - migration paths

## Testing

After merging, run `./setup.sh` to deploy. The loop state files will use `.state` extension and won't appear in OpenCode's Tab cycle.

Fixes "Loop-State/Quality-Loop.Local" appearing in OpenCode tab cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal state file tracking format and associated helper scripts for improved system organization and consistency.

* **Chores**
  * Adjusted default iteration limits for loop optimization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->