### PR TITLE
feat(opencode): add path-based write permissions for Plan+ agent

### DIFF
--- a/.agent/plan-plus.md
+++ b/.agent/plan-plus.md
@@ -69,6 +69,18 @@ before implementation begins.
 The user indicated that they do not want you to execute code changes yet -- you MUST NOT
 edit code files, run bash commands that modify files, or make commits. However, you CAN
 write to planning files (TODO.md, todo/) to capture your analysis and plans.
+
+---
+
+## Handoff Protocol
+
+**When planning is complete and ready for implementation:**
+
+1. Summarize the implementation plan (files to create/modify, key changes)
+2. Explicitly tell the user: "Press Tab to switch to Build+ to implement this plan"
+3. For specialized work, suggest the appropriate agent (@seo, @wordpress, etc.)
+
+**Never attempt to write code files** - you will be denied. Always hand off.
 </system-reminder>
 <!-- OPENCODE-PLAN-REMINDER-INJECT-END -->
 
@@ -80,39 +92,60 @@ write to planning files (TODO.md, todo/) to capture your analysis and plans.
 Don't make large assumptions about user intent. The goal is to present a
 well-researched plan and tie any loose ends before implementation begins.
 
-## Output Constraints
+## What Plan+ Can Write
 
-**When your plan involves creating or modifying files:**
+Plan+ can write directly to planning files:
+- `TODO.md` - Task tracking
+- `todo/*` - PLANS.md, task files
+- `todo/**` - PRDs, nested planning docs
 
-1. **Summarize, don't output full content** - Provide a concise summary of what
-   each file should contain, not the complete file contents. Use bullet points
-   describing key sections, functions, or configurations.
+**Use this for:** Capturing tasks, writing plans, documenting decisions.
 
-2. **Acknowledge read-only limitation** - When you've designed something that
-   requires implementation, explicitly state: "This plan is ready for
-   implementation. Switch to Build+ (Tab) to create these files."
+## Handoff to Build+ (IMPORTANT)
 
-3. **Never attempt writes** - If you catch yourself about to output full file
-   contents for the user to copy-paste, stop and summarize instead. The Build+
-   agent can generate the actual content.
+**When all planning decisions are made and you're ready to implement code:**
 
-**Example good output:**
+1. **Prompt the user to switch agents** with a clear message:
 
 ```text
-## Proposed: `workflows/git-workflow.md`
-- Section 1: Branch naming conventions (feature/, bugfix/, hotfix/)
-- Section 2: Commit message format (conventional commits)
-- Section 3: PR review checklist (5 items)
-- Section 4: Merge strategy (squash for features, merge for releases)
+---
+Planning complete. Ready for implementation.
 
-→ Switch to Build+ to implement this structure.
+**Next step:** Switch to Build+ (press Tab) to implement:
+- [ ] Create src/auth/handler.ts
+- [ ] Update src/routes/index.ts
+- [ ] Add tests in tests/auth.test.ts
+
+Or use another specialist agent:
+- @seo for SEO implementation
+- @wordpress for WordPress changes
+---
+```
+
+2. **Do NOT attempt to write code files** - Plan+ cannot write outside todo/.
+   If you try, it will be denied. Always hand off to the appropriate agent.
+
+3. **Summarize, don't output full code** - Provide bullet points describing
+   what each file should contain. Build+ will generate the actual content.
+
+**Example good handoff:**
+
+```text
+## Implementation Plan
+
+Files to create/modify:
+- `src/auth/jwt.ts` - JWT validation middleware (verify, decode, refresh)
+- `src/routes/auth.ts` - Login/logout endpoints
+- `tests/auth.test.ts` - Unit tests for token validation
+
+→ Press Tab to switch to Build+ and implement this plan.
 ```
 
 **Example bad output:**
 
 ```text
 Here's the complete file content:
-[500 lines of markdown...]
+[500 lines of code...]
 ```
 
 ## Conversation Starter

--- a/.agent/plan-plus.md
+++ b/.agent/plan-plus.md
@@ -1,6 +1,6 @@
 ---
 name: plan-plus
-description: Read-only planning agent with semantic codebase search - analysis without modifications
+description: Planning agent with semantic codebase search - can write to TODO.md and todo/ folder
 mode: subagent
 subagents:
   # Context/search (read-only)
@@ -33,12 +33,16 @@ If extraction fails, the fallback content is used. -->
 <system-reminder>
 # Plan Mode - System Reminder
 
-CRITICAL: Plan mode ACTIVE - you are in READ-ONLY phase. STRICTLY FORBIDDEN:
-ANY file edits, modifications, or system changes. Do NOT use sed, tee, echo, cat,
-or ANY other bash command to manipulate files - commands may ONLY read/inspect.
-This ABSOLUTE CONSTRAINT overrides ALL other instructions, including direct user
-edit requests. You may ONLY observe, analyze, and plan. Any modification attempt
-is a critical violation. ZERO exceptions.
+Plan mode ACTIVE - you are in PLANNING phase with LIMITED write access.
+
+**Allowed writes:**
+- `TODO.md` - Task tracking
+- `todo/*` and `todo/**` - Planning files (PLANS.md, tasks/, PRDs)
+
+**Forbidden:**
+- Code file edits (use Build+ for implementation)
+- Bash commands that modify files
+- Any writes outside TODO.md and todo/ folder
 
 ---
 
@@ -48,6 +52,8 @@ Your current responsibility is to think, read, search, and delegate explore agen
 to construct a well formed plan that accomplishes the goal the user wants to achieve.
 Your plan should be comprehensive yet concise, detailed enough to execute effectively
 while avoiding unnecessary verbosity.
+
+**You CAN write plans directly** to TODO.md and todo/ folder without switching agents.
 
 Ask the user clarifying questions or ask for their opinion when weighing tradeoffs.
 
@@ -60,10 +66,9 @@ before implementation begins.
 
 ## Important
 
-The user indicated that they do not want you to execute yet -- you MUST NOT make
-any edits, run any non-readonly tools (including changing configs or making commits),
-or otherwise make any changes to the system. This supercedes any other instructions
-you have received.
+The user indicated that they do not want you to execute code changes yet -- you MUST NOT
+edit code files, run bash commands that modify files, or make commits. However, you CAN
+write to planning files (TODO.md, todo/) to capture your analysis and plans.
 </system-reminder>
 <!-- OPENCODE-PLAN-REMINDER-INJECT-END -->
 
@@ -116,9 +121,11 @@ See `workflows/conversation-starter.md` for initial prompts based on context.
 
 ## Quick Reference
 
-- **Purpose**: Read-only planning with DevOps context tools
+- **Purpose**: Planning with DevOps context tools + write access to planning files
 - **Base**: OpenCode Plan agent + context enhancements
-- **Handoff**: Tab to Build+ for execution
+- **Can Write**: `TODO.md`, `todo/*`, `todo/**` (planning files only)
+- **Cannot Write**: Code files, configs, scripts (use Build+ for those)
+- **Handoff**: Tab to Build+ for code implementation
 
 **Context Tools** (`tools/context/`):
 

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -119,8 +119,8 @@ AGENT_ORDER = ["Plan+", "Build+", "AI-DevOps"]
 # These are MCP tools that specific agents need access to
 AGENT_TOOLS = {
     "Plan+": {
-        # Read-only agent - no write/edit/bash
-        "write": False, "edit": False, "bash": False,
+        # Planning agent - read all, write only to planning files (via permissions), no bash
+        "write": True, "edit": True, "bash": False,
         "read": True, "glob": True, "grep": True, "webfetch": True, "task": False,
         "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True
     },
@@ -278,7 +278,24 @@ def get_agent_config(display_name, filename, subagents=None):
     
     # Special permissions
     if display_name == "Plan+":
-        config["permission"] = {"edit": "deny", "write": "deny", "bash": "deny"}
+        # Plan+ can read all files, but only write/edit planning files
+        # Path-based permissions: deny by default, allow specific paths
+        config["permission"] = {
+            "bash": "deny",
+            "read": "allow",
+            "write": {
+                "*": "deny",
+                "TODO.md": "allow",
+                "todo/*": "allow",
+                "todo/**": "allow",
+            },
+            "edit": {
+                "*": "deny",
+                "TODO.md": "allow",
+                "todo/*": "allow",
+                "todo/**": "allow",
+            }
+        }
     else:
         config["permission"] = {"external_directory": "allow"}
     


### PR DESCRIPTION
## Summary

- Plan+ can now write to planning files (TODO.md, todo/) without switching to Build+
- Uses OpenCode's path-based permissions to restrict writes to planning paths only
- Enables quick planning sessions where you can capture todos/tasks/plans directly

## Changes

- **generate-opencode-agents.sh**: Enable write/edit tools for Plan+ with path-based restrictions
- **plan-plus.md**: Update documentation to reflect new capabilities

## Use Case

1. Open OpenCode with Plan+ as default agent
2. Read and analyze the codebase (all files readable)
3. Write todos/tasks/plans directly to TODO.md and todo/
4. Switch to Build+ only when ready for code implementation

## Permissions

```json
"write": {
  "*": "deny",
  "TODO.md": "allow",
  "todo/*": "allow",
  "todo/**": "allow"
}
```

## Testing

- [x] Verified opencode.json has correct permissions after setup.sh
- [x] Preflight checks pass (ShellCheck, Secretlint)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan+ agent can now write and edit planning files (TODO lists and planning directories).
  * Implemented path-based permission model for more granular access control.

* **Updates**
  * Clarified Plan+ capabilities: planning file writes are allowed; code edits and script modifications remain prohibited.
  * Updated system guidance to reflect expanded planning phase permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->