### PR TITLE
docs(readme): update Plan+ description to reflect write permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -870,7 +870,7 @@ Ordered as they appear in OpenCode Tab selector and other AI assistants (14 tota
 
 | Name | File | Purpose | MCPs Enabled |
 |------|------|---------|--------------|
-| Plan+ | `plan-plus.md` | Read-only planning with semantic codebase search | context7, augment, repomix |
+| Plan+ | `plan-plus.md` | Planning with semantic search, writes to TODO.md/todo/ | context7, augment, repomix |
 | Build+ | `build-plus.md` | Enhanced Build with context tools | context7, augment, repomix |
 | Build-Agent | `build-agent.md` | Design and improve AI agents | context7, augment, repomix |
 | Build-MCP | `build-mcp.md` | Build MCP servers with TS+Bun+ElysiaJS | context7, augment, repomix |


### PR DESCRIPTION
Updates the Plan+ description in the Main Agents table to reflect that it can now write to TODO.md and todo/ folder (per PR #112).

**Before:** Read-only planning with semantic codebase search
**After:** Planning with semantic search, writes to TODO.md/todo/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Plan+ agent description to reflect new capabilities: now supports writing to planning files (TODO.md/todo/) in addition to semantic codebase search functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->