### PR TITLE
docs: add Worktrunk as recommended worktree tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1144,17 +1144,30 @@ See `.agent/scripts/commands/full-loop.md` for complete documentation.
 
 Work on multiple branches simultaneously without stashing or switching. Each branch gets its own directory.
 
-**Quick usage:**
+**Recommended: [Worktrunk](https://worktrunk.dev)** (`wt`) - Git worktree management with shell integration, CI status, and PR links:
 
 ```bash
-# Create worktree for a new branch
+# Install (macOS/Linux)
+brew install max-sixty/worktrunk/wt && wt config shell install
+
+# Create worktree + cd into it
+wt switch -c feature/my-feature
+
+# Create worktree + start Claude Code
+wt switch -c -x claude feature/ai-task
+
+# List worktrees with CI status and PR links
+wt list
+
+# Merge + cleanup (squash/rebase options)
+wt merge
+```
+
+**Fallback** (no dependencies):
+
+```bash
 ~/.aidevops/agents/scripts/worktree-helper.sh add feature/my-feature
-# Creates: ~/Git/aidevops-feature-my-feature/
-
-# List all worktrees
 ~/.aidevops/agents/scripts/worktree-helper.sh list
-
-# Clean up after merge
 ~/.aidevops/agents/scripts/worktree-helper.sh clean
 ```
 
@@ -1162,11 +1175,11 @@ Work on multiple branches simultaneously without stashing or switching. Each bra
 - Run tests on one branch while coding on another
 - Compare implementations side-by-side
 - No context switching or stash management
-- Each OpenCode session can work on a different branch
+- Each AI session can work on a different branch
 
 **Worktree-first workflow:** The pre-edit check now **enforces** worktrees as the default when creating branches, keeping your main directory on `main`. This prevents uncommitted changes from blocking branch switches and ensures parallel sessions don't inherit wrong branch state.
 
-See `.agent/workflows/worktree.md` for the complete guide.
+See `.agent/workflows/worktree.md` for the complete guide and `.agent/tools/git/worktrunk.md` for Worktrunk documentation.
 
 ### Session Management - Parallel AI Sessions
 
@@ -1190,9 +1203,9 @@ opencode --non-interactive --prompt "Continue with feature X" &
 # New terminal tab (macOS)
 osascript -e 'tell application "Terminal" to do script "cd ~/Git/project && opencode"'
 
-# Worktree-based (isolated branch)
-~/.aidevops/agents/scripts/worktree-helper.sh add feature/next-feature
-cd ../project-feature-next-feature && opencode
+# Worktree-based (isolated branch) - recommended
+wt switch -c -x opencode feature/next-feature  # Worktrunk: create + start OpenCode
+# Or fallback: ~/.aidevops/agents/scripts/worktree-helper.sh add feature/next-feature
 ```
 
 **Session handoff pattern:**

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The result: AI agents that work *with* your development process, not around it.
 [![GitHub commits since latest release](https://img.shields.io/github/commits-since/marcusquinn/aidevops/latest)](https://github.com/marcusquinn/aidevops/commits/main)
 
 <!-- Repository Stats -->
-[![Version](https://img.shields.io/badge/Version-2.59.0-blue)](https://github.com/marcusquinn/aidevops/releases)
+[![Version](https://img.shields.io/badge/Version-2.60.0-blue)](https://github.com/marcusquinn/aidevops/releases)
 [![GitHub repo size](https://img.shields.io/github/repo-size/marcusquinn/aidevops?style=flat&color=blue)](https://github.com/marcusquinn/aidevops)
 [![Lines of code](https://img.shields.io/badge/Lines%20of%20Code-18%2C000%2B-brightgreen)](https://github.com/marcusquinn/aidevops)
 [![GitHub language count](https://img.shields.io/github/languages/count/marcusquinn/aidevops)](https://github.com/marcusquinn/aidevops)

--- a/README.md
+++ b/README.md
@@ -1149,11 +1149,12 @@ Work on multiple branches simultaneously without stashing or switching. Each bra
 ```bash
 # Install (macOS/Linux)
 brew install max-sixty/worktrunk/wt && wt config shell install
+# Restart your shell for shell integration to take effect
 
 # Create worktree + cd into it
 wt switch -c feature/my-feature
 
-# Create worktree + start Claude Code
+# Create worktree + start any AI CLI (-x runs command after switch)
 wt switch -c -x claude feature/ai-task
 
 # List worktrees with CI status and PR links
@@ -1167,6 +1168,7 @@ wt merge
 
 ```bash
 ~/.aidevops/agents/scripts/worktree-helper.sh add feature/my-feature
+# Creates: ~/Git/{repo}-feature-my-feature/ (cd there manually)
 ~/.aidevops/agents/scripts/worktree-helper.sh list
 ~/.aidevops/agents/scripts/worktree-helper.sh clean
 ```
@@ -1204,8 +1206,10 @@ opencode --non-interactive --prompt "Continue with feature X" &
 osascript -e 'tell application "Terminal" to do script "cd ~/Git/project && opencode"'
 
 # Worktree-based (isolated branch) - recommended
-wt switch -c -x opencode feature/next-feature  # Worktrunk: create + start OpenCode
-# Or fallback: ~/.aidevops/agents/scripts/worktree-helper.sh add feature/next-feature
+wt switch -c -x opencode feature/next-feature  # Worktrunk: create + start AI CLI
+# Or fallback:
+# ~/.aidevops/agents/scripts/worktree-helper.sh add feature/next-feature
+# cd ~/Git/{repo}-feature-next-feature && opencode
 ```
 
 **Session handoff pattern:**

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 2.59.0
+# Version: 2.60.0
 #
 # Quick Install (one-liner):
 #   bash <(curl -fsSL https://aidevops.dev/install)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=2.59.0
+sonar.projectVersion=2.60.0
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agent,configs,templates


### PR DESCRIPTION
## Summary

- Document [Worktrunk](https://worktrunk.dev) (`wt`) as the primary worktree management tool in README
- Show installation command and key usage patterns (switch, list, merge)
- Keep `worktree-helper.sh` as fallback for no-dependency environments
- Update session spawning example to use `wt switch -c -x`

## Changes

- **Git Worktrees section**: Restructured to show Worktrunk first with full command examples
- **Session Management section**: Updated worktree example to use Worktrunk

## Why

Worktrunk provides a better UX than raw git worktree commands:
- Shell integration (auto-cd into worktrees)
- CI status and PR links in `wt list`
- Integrated merge workflow with cleanup
- LLM commit message support

The framework already documents Worktrunk in `.agent/tools/git/worktrunk.md` and `.agent/workflows/worktree.md`, but the main README was missing this recommendation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced Git worktree guidance with a recommended Worktrunk-first workflow, added install and wt command examples (switch/list/merge), retained a non-dependency fallback, updated session-management guidance and related links, and adjusted wording/benefits to reflect AI sessions.
* **Chores**
  * Bumped project version metadata to 2.60.0 across documentation and setup/configuration artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->