### PR TITLE
docs: add one-time Bash guidance for Plan+ file discovery

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -135,6 +135,12 @@ Self-check: "Am I about to use `mcp_glob`?" If yes, use these instead:
 
 **Why this matters**: `mcp_glob` is CPU-intensive on large codebases and should only be used when Bash tools are unavailable. Always prefer the Bash alternatives above.
 
+**Plan+ agents without Bash**: If you're in Plan+ (or another read-only agent) and need file discovery, request one-time Bash access from the user:
+
+> "I need to list files but don't have Bash access. Can you grant one-time Bash permission for file discovery? I'll only use it for `git ls-files` or `fd`, not for any modifications."
+
+This keeps Plan+ read-only for code while enabling efficient file discovery. The user can approve the specific command without granting full Bash access.
+
 **Localhost Standards** (for any local service setup):
 - **Always check port first**: `localhost-helper.sh check-port <port>` before starting services
 - **Use .local domains**: `myapp.local` not `localhost:3000` (enables password manager autofill)

--- a/.agent/plan-plus.md
+++ b/.agent/plan-plus.md
@@ -92,6 +92,21 @@ write to planning files (TODO.md, todo/) to capture your analysis and plans.
 Don't make large assumptions about user intent. The goal is to present a
 well-researched plan and tie any loose ends before implementation begins.
 
+## File Discovery (No Bash by Default)
+
+Plan+ doesn't have Bash access to keep it read-only. For file discovery, request one-time access:
+
+> "I need to list files for planning. Can you grant one-time Bash permission? I'll only use `git ls-files '*.md'` for file discovery, not modifications."
+
+**Why ask**: `mcp_glob` is CPU-intensive. `git ls-files` is instant. One-time Bash for read-only commands keeps Plan+ safe while enabling efficient exploration.
+
+**Approved commands** (read-only, safe for Plan+):
+- `git ls-files 'pattern'` - List tracked files
+- `fd -e ext` or `fd -g 'pattern'` - Find files
+- `rg --files -g 'pattern'` - List files matching pattern
+- `git status --short` - Check repo state
+- `git log --oneline -10` - Recent history
+
 ## What Plan+ Can Write
 
 Plan+ can write directly to planning files:


### PR DESCRIPTION
## Summary

- Add guidance for Plan+ agents to request one-time Bash access for file discovery
- Prevents CPU-intensive `mcp_glob` usage when Bash alternatives exist
- Keeps Plan+ read-only for code while enabling efficient exploration

## Problem

Plan+ agents don't have Bash access by default (to keep them read-only). When they need to discover files, they fall back to `mcp_glob` which is CPU-intensive on large codebases.

## Solution

Add guidance for Plan+ to request **one-time Bash permission** specifically for read-only file discovery commands:

```text
"I need to list files for planning. Can you grant one-time Bash permission? 
I'll only use `git ls-files '*.md'` for file discovery, not modifications."
```

## Changes

| File | Change |
|------|--------|
| `.agent/AGENTS.md` | Added Plan+ one-time Bash guidance to File Discovery section |
| `.agent/plan-plus.md` | Added File Discovery section with approved read-only commands |

## Approved Read-Only Commands for Plan+

- `git ls-files 'pattern'` - List tracked files
- `fd -e ext` or `fd -g 'pattern'` - Find files  
- `rg --files -g 'pattern'` - List files matching pattern
- `git status --short` - Check repo state
- `git log --oneline -10` - Recent history

These are all read-only and safe for Plan+ to use without compromising its read-only nature for code files.