### PR TITLE
fix: prefer Worktrunk (wt) over worktree-helper.sh

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -74,7 +74,7 @@ Detection keywords:
 
 Planning files are metadata about work, not the work itself - they don't need PR review.
 
-4. Create worktree: `~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{name}`
+4. Create worktree: `wt switch -c {type}/{name}` (preferred) or `worktree-helper.sh add {type}/{name}` (fallback)
 5. After creating branch, call `session-rename_sync_branch` tool
 
 **Legacy checkout workflow**: If user explicitly requests `git checkout -b` instead of worktrees, warn them:
@@ -254,12 +254,15 @@ Cross-session memory using SQLite FTS5 for fast full-text search.
 **Parallel branch work** (git worktrees): For multiple terminals/sessions on different branches:
 
 ```bash
-# Recommended: Worktrunk (install: brew install max-sixty/worktrunk/wt)
+# ALWAYS check for wt first, use it if available
+command -v wt &>/dev/null && wt switch -c feature/my-feature
+
+# Worktrunk commands (preferred - install: brew install max-sixty/worktrunk/wt)
 wt switch -c feature/my-feature   # Create worktree + cd into it
 wt list                           # List with CI status
 wt merge                          # Squash/rebase + cleanup
 
-# Fallback: worktree-helper.sh (no dependencies)
+# Fallback: worktree-helper.sh (only if wt not installed)
 ~/.aidevops/agents/scripts/worktree-helper.sh add feature/my-feature
 ~/.aidevops/agents/scripts/worktree-helper.sh list
 ~/.aidevops/agents/scripts/worktree-helper.sh clean
@@ -346,7 +349,7 @@ Session goals achieved:
 Suggestions:
 1. Run @agent-review to capture learnings
 2. Start new session for clean context
-3. For parallel work: worktree-helper.sh add {type}/{name}
+3. For parallel work: `wt switch -c {type}/{name}` (or worktree-helper.sh if wt unavailable)
 ---
 ```
 
@@ -360,14 +363,15 @@ Suggestions:
 1. Commit or stash uncommitted changes
 2. If in worktree: no action needed (worktree stays on its branch)
 3. If used `git checkout -b` in main repo: `git checkout main` before ending
-4. Run `worktree-helper.sh clean` to remove merged worktrees
+4. Run `wt list` then `wt merge` (or `worktree-helper.sh clean`) to remove merged worktrees
 
 **Spawning parallel sessions** (for related but separate work):
 
 ```bash
 # Create worktree + spawn new terminal (macOS)
-~/.aidevops/agents/scripts/worktree-helper.sh add feature/parallel-task
-osascript -e 'tell application "Terminal" to do script "cd ~/Git/{repo}-feature-parallel-task && opencode"'
+wt switch -c feature/parallel-task  # preferred
+# Or: ~/.aidevops/agents/scripts/worktree-helper.sh add feature/parallel-task
+osascript -e 'tell application "Terminal" to do script "cd ~/Git/{repo}.feature-parallel-task && opencode"'
 
 # Or background session
 opencode run "Continue with task X" --agent Build+ &

--- a/.agent/scripts/commands/full-loop.md
+++ b/.agent/scripts/commands/full-loop.md
@@ -43,6 +43,11 @@ The loop automatically handles branch setup when on main/master:
 ```bash
 # Generate branch name from task (sanitized, truncated to 40 chars)
 branch_name=$(echo "$ARGUMENTS" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-40)
+
+# Preferred: Use Worktrunk (wt) if installed
+wt switch -c "feature/$branch_name"
+
+# Fallback: Use worktree-helper.sh if wt not available
 ~/.aidevops/agents/scripts/worktree-helper.sh add "feature/$branch_name"
 # Continue in new worktree directory
 ```

--- a/.agent/scripts/pre-edit-check.sh
+++ b/.agent/scripts/pre-edit-check.sh
@@ -129,8 +129,16 @@ if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
     echo ""
     echo -e "${BOLD}Create a worktree (keeps main repo on main):${NC}"
     echo ""
-    echo "    ~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{description}"
-    echo "    cd ../{repo}-{type}-{description}"
+    if command -v wt &>/dev/null; then
+        echo "    wt switch -c {type}/{description}"
+        echo ""
+        echo "    (Using Worktrunk - recommended)"
+    else
+        echo "    ~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{description}"
+        echo "    cd ../{repo}-{type}-{description}"
+        echo ""
+        echo "    (Install Worktrunk for better experience: brew install max-sixty/worktrunk/wt)"
+    fi
     echo ""
     echo -e "${YELLOW}Why worktrees? The main repo directory should ALWAYS stay on main.${NC}"
     echo -e "${YELLOW}Using 'git checkout -b' here leaves the repo on a feature branch,${NC}"


### PR DESCRIPTION
## Summary

Ensures the AI uses Worktrunk (`wt`) when available, falling back to `worktree-helper.sh` only when necessary.

## Problem

AGENTS.md documented Worktrunk as "Recommended" and worktree-helper.sh as "Fallback", but:
1. `pre-edit-check.sh` always showed `worktree-helper.sh` command
2. The AI wasn't checking if `wt` was installed before using the fallback
3. Documentation didn't emphasize "check first, then use"

## Solution

### 1. `pre-edit-check.sh` - Dynamic tool selection

```bash
if command -v wt &>/dev/null; then
    echo "    wt switch -c {type}/{description}"
    echo "    (Using Worktrunk - recommended)"
else
    echo "    ~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{description}"
    echo "    (Install Worktrunk for better experience: brew install max-sixty/worktrunk/wt)"
fi
```

### 2. `AGENTS.md` - Emphasize check-first pattern

```bash
# ALWAYS check for wt first, use it if available
command -v wt &>/dev/null && wt switch -c feature/my-feature
```

### 3. `full-loop.md` - Show preferred option first

```bash
# Preferred: Use Worktrunk (wt) if installed
wt switch -c "feature/$branch_name"

# Fallback: Use worktree-helper.sh if wt not available
```

## Changes

| File | Change |
|------|--------|
| `.agent/scripts/pre-edit-check.sh` | Check for `wt`, show appropriate command |
| `.agent/AGENTS.md` | Add "check first" pattern, update examples |
| `.agent/scripts/commands/full-loop.md` | Show `wt` as preferred option |