### PR TITLE
fix: add missing default cases in tool-version-check.sh (S131)

### DIFF
--- a/.agent/scripts/tool-version-check.sh
+++ b/.agent/scripts/tool-version-check.sh
@@ -181,6 +181,7 @@ check_tool() {
         npm) latest=$(get_npm_latest "$pkg") ;;
         brew) latest=$(get_brew_latest "$pkg") ;;
         pip) latest=$(get_pip_latest "$pkg") ;;
+        *) latest="unknown" ;;
     esac
     
     local status="up_to_date"
@@ -236,6 +237,9 @@ check_tool() {
                 ;;
             up_to_date)
                 echo -e "${color}${icon}  $name: $installed${NC}"
+                ;;
+            *)
+                echo -e "${color}${icon}  $name: $installed (status: $status)${NC}"
                 ;;
         esac
     fi


### PR DESCRIPTION
## Summary

Fixes 2 real S131 (missing default case) issues in `tool-version-check.sh`.

## Changes

Added default case (`*`) to two case statements:
- **Line 180**: category switch (npm/brew/pip) - defaults to `'unknown'`
- **Line 225**: status switch - outputs status for unexpected values

## Note on Other S131 Issues

SonarCloud shows 10 critical S131 issues, but 8 are **stale**:
- `todo-ready.sh` (5 issues) - already has default cases
- `terminal-title-helper.sh` (2 issues) - already has default cases  
- `quality-loop-helper.sh` (1 issue) - already has default case

These stale issues should clear on the next SonarCloud analysis. The S131 rule is also excluded in `sonar-project.properties` (rule e16) for all `*.sh` files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of tool version check script by adding proper handling for unrecognized tool categories and unhandled status states, ensuring consistent and defined behavior in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->