### PR TITLE
feat(plan+): add granular bash permissions for file discovery

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -135,11 +135,12 @@ Self-check: "Am I about to use `mcp_glob`?" If yes, use these instead:
 
 **Why this matters**: `mcp_glob` is CPU-intensive on large codebases and should only be used when Bash tools are unavailable. Always prefer the Bash alternatives above.
 
-**Plan+ agents without Bash**: If you're in Plan+ (or another read-only agent) and need file discovery, request one-time Bash access from the user:
+**Plan+ has granular bash permissions**: Plan+ can run read-only file discovery commands directly:
+- `git ls-files`, `git status`, `git log`, `git diff`, `git branch`, `git show`
+- `fd -e`, `fd -g` (file finder)
+- `rg --files` (ripgrep file listing)
 
-> "I need to list files but don't have Bash access. Can you grant one-time Bash permission for file discovery? I'll only use it for `git ls-files` or `fd`, not for any modifications."
-
-This keeps Plan+ read-only for code while enabling efficient file discovery. The user can approve the specific command without granting full Bash access.
+All other bash commands are denied, keeping Plan+ safe for planning without code modification risk.
 
 **Localhost Standards** (for any local service setup):
 - **Always check port first**: `localhost-helper.sh check-port <port>` before starting services

--- a/.agent/plan-plus.md
+++ b/.agent/plan-plus.md
@@ -92,20 +92,23 @@ write to planning files (TODO.md, todo/) to capture your analysis and plans.
 Don't make large assumptions about user intent. The goal is to present a
 well-researched plan and tie any loose ends before implementation begins.
 
-## File Discovery (No Bash by Default)
+## File Discovery (Granular Bash Permissions)
 
-Plan+ doesn't have Bash access to keep it read-only. For file discovery, request one-time access:
+Plan+ has **granular bash permissions** for read-only file discovery commands.
+Use these instead of `mcp_glob` (which is CPU-intensive):
 
-> "I need to list files for planning. Can you grant one-time Bash permission? I'll only use `git ls-files '*.md'` for file discovery, not modifications."
+| Command | Use Case |
+|---------|----------|
+| `git ls-files 'pattern'` | List tracked files (fastest) |
+| `fd -e ext` or `fd -g 'pattern'` | Find files (respects .gitignore) |
+| `rg --files -g 'pattern'` | List files matching pattern |
+| `git status` | Check repo state |
+| `git log` | View commit history |
+| `git diff` | View changes |
+| `git branch` | List/check branches |
+| `git show` | View commit details |
 
-**Why ask**: `mcp_glob` is CPU-intensive. `git ls-files` is instant. One-time Bash for read-only commands keeps Plan+ safe while enabling efficient exploration.
-
-**Approved commands** (read-only, safe for Plan+):
-- `git ls-files 'pattern'` - List tracked files
-- `fd -e ext` or `fd -g 'pattern'` - Find files
-- `rg --files -g 'pattern'` - List files matching pattern
-- `git status --short` - Check repo state
-- `git log --oneline -10` - Recent history
+**All other bash commands are denied** - Plan+ cannot modify files via bash.
 
 ## What Plan+ Can Write
 


### PR DESCRIPTION
## Summary

- Enable bash tool for Plan+ with **granular permissions** for read-only file discovery
- Set Plan+ as the **default agent** for OpenCode startup
- Update documentation to reflect new capabilities

## Changes

### Granular Bash Permissions for Plan+

Plan+ can now run these read-only commands directly (no more asking for one-time access):

| Command | Purpose |
|---------|---------|
| `git ls-files*` | List tracked files (fastest) |
| `git status*` | Check repo state |
| `git log*` | View commit history |
| `git diff*` | View changes |
| `git branch*` | List/check branches |
| `git show*` | View commit details |
| `fd *` / `fd -e *` / `fd -g *` | Find files |
| `rg --files*` | List files matching pattern |

All other bash commands remain **denied** - Plan+ cannot modify files via bash.

### Default Agent

- Set `default_agent: "Plan+"` in OpenCode config
- Plan+ is now auto-selected on startup (first in Tab cycle)

## Why

1. **Performance**: `git ls-files` and `fd` are 10x faster than `mcp_glob`
2. **UX**: No more asking users for one-time bash permission
3. **Safety**: Granular permissions maintain Plan+'s read-only nature for code

## Related

- Closes t018 (phases 3 & 4)
- t010 already complete (build-agent/build-mcp kept as subagents)