### PR TITLE
feat: Auto-create fd alias on Debian/Ubuntu

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -635,7 +635,7 @@ setup_file_discovery_tools() {
                     
                     # On Debian/Ubuntu, fd is installed as fdfind - create alias in all existing shell rc files
                     if [[ "$pkg_manager" == "apt" ]] && command -v fdfind >/dev/null 2>&1 && ! command -v fd >/dev/null 2>&1; then
-                        local rc_files=("$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile")
+                        local rc_files=("$HOME/.bashrc" "$HOME/.zshrc")
                         local added_to=""
                         
                         for rc_file in "${rc_files[@]}"; do

--- a/setup.sh
+++ b/setup.sh
@@ -633,10 +633,19 @@ setup_file_discovery_tools() {
                 if install_packages "$pkg_manager" "${actual_packages[@]}"; then
                     print_success "File discovery tools installed"
                     
-                    # On Debian/Ubuntu, fd is installed as fdfind - create alias
+                    # On Debian/Ubuntu, fd is installed as fdfind - create alias in ~/.profile
                     if [[ "$pkg_manager" == "apt" ]] && command -v fdfind >/dev/null 2>&1 && ! command -v fd >/dev/null 2>&1; then
-                        print_info "Note: On Debian/Ubuntu, fd is installed as 'fdfind'"
-                        echo "  Consider adding to your shell config: alias fd=fdfind"
+                        local profile_file="$HOME/.profile"
+                        if ! grep -q "alias fd=" "$profile_file" 2>/dev/null; then
+                            print_info "Adding fd alias to $profile_file..."
+                            echo '' >> "$profile_file"
+                            echo '# fd-find alias for Debian/Ubuntu (added by aidevops)' >> "$profile_file"
+                            echo 'alias fd="fdfind"' >> "$profile_file"
+                            print_success "Added alias fd=fdfind to $profile_file"
+                            echo "  Run 'source ~/.profile' or restart your shell to activate"
+                        else
+                            print_success "fd alias already exists in $profile_file"
+                        fi
                     fi
                 else
                     print_warning "Failed to install some file discovery tools (non-critical)"


### PR DESCRIPTION
## Summary

- Automatically adds `alias fd="fdfind"` to `~/.profile` when installing fd-find on Debian/Ubuntu
- Replaces manual instruction with automatic setup
- Checks if alias already exists before adding (idempotent)

## Changes

- `setup.sh`: Enhanced `setup_file_discovery_tools()` to auto-create fd alias

## Task Reference

Closes #t066 - Add shell alias: fdfind as fd (Debian/Ubuntu)

## Testing

- Verified on Debian-based system
- Preflight checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Setup now creates a persistent alias for the file-finder on Debian/Ubuntu when needed, automatically updating shell rc files (bash/zsh), avoiding duplicate entries, appending a brief comment, and reporting which rc files were modified with instructions to restart or source the shell.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->