### PR TITLE
feat(plan-plus): add agent design subagents for planning discussions

### DIFF
--- a/.agent/plan-plus.md
+++ b/.agent/plan-plus.md
@@ -17,6 +17,9 @@ subagents:
   - architecture
   - code-standards
   - best-practices
+  # Agent design
+  - build-agent
+  - agent-review
   # Built-in
   - general
   - explore


### PR DESCRIPTION
## Summary

- Add `build-agent` and `agent-review` to Plan+ subagents list
- Enables agent design discussions during planning mode before implementation

## Why

When users discuss agent design in Plan+ mode, they should have awareness of:
- `build-agent` - Agent design patterns, instruction budgets, MCP config, progressive disclosure
- `agent-review` - Systematic review checklist, improvement proposals, self-assessment triggers

Previously these subagents were only available in Build+ mode, but planning discussions often happen first.

## Changes

- `.agent/plan-plus.md`: Added new "Agent design" category with `build-agent` and `agent-review` subagents