### PR TITLE
fix: consolidate version validation to single source of truth

### DIFF
--- a/.agent/scripts/auto-version-bump.sh
+++ b/.agent/scripts/auto-version-bump.sh
@@ -118,8 +118,8 @@ main() {
             print_success "Version bumped: $current_version → $new_version"
             update_version_badge "$new_version"
             
-            # Add updated files to git
-            git add VERSION README.md sonar-project.properties setup.sh 2>/dev/null
+            # Add updated files to git (all version-tracked files)
+            git add VERSION README.md sonar-project.properties setup.sh aidevops.sh package.json .claude-plugin/marketplace.json 2>/dev/null
             
             echo "$new_version"
         else


### PR DESCRIPTION
## Summary

- Consolidates version validation logic to a single source of truth (`validate-version-consistency.sh`)
- Adds checks for `aidevops.sh`, `package.json`, and `.claude-plugin/marketplace.json`
- Refactors `version-manager.sh` to call the standalone validator instead of maintaining duplicate logic
- Adds validation after `marketplace.json` sed update to catch silent failures
- Updates `auto-version-bump.sh` with complete file list

## Problem

During release v2.67.0, the release script failed because:
1. `version-manager.sh` had its own embedded validation logic
2. PR #130 updated `validate-version-consistency.sh` to accept dynamic GitHub release badges
3. The embedded version in `version-manager.sh` wasn't updated, causing validation to fail
4. `marketplace.json` update had no validation (silent failure)

## Solution

- **Single source of truth**: `version-manager.sh` now calls `validate-version-consistency.sh` instead of duplicating logic
- **Complete coverage**: Validator now checks all version files including `aidevops.sh`, `package.json`, `marketplace.json`
- **Fail-fast**: Added validation after `marketplace.json` sed update to catch issues immediately
- **Complete git add**: `auto-version-bump.sh` now includes all version files

## Testing

```bash
# Validator passes with all files
.agent/scripts/validate-version-consistency.sh
# ✅ VERSION file: 2.67.0
# ✅ README.md uses dynamic GitHub release badge (recommended)
# ✅ sonar-project.properties: 2.67.0
# ✅ setup.sh: 2.67.0
# ✅ aidevops.sh: 2.67.0
# ✅ package.json: 2.67.0
# ✅ .claude-plugin/marketplace.json: 2.67.0
```

## Files Changed

| File | Change |
|------|--------|
| `validate-version-consistency.sh` | Added checks for aidevops.sh, package.json, marketplace.json |
| `version-manager.sh` | Refactored to call standalone validator, added post-sed validation |
| `auto-version-bump.sh` | Updated git add with complete file list |