### PR TITLE
feat(skills): import cloudflare-platform skill and add update checking

### DIFF
--- a/.agent/configs/skill-sources.json
+++ b/.agent/configs/skill-sources.json
@@ -27,6 +27,17 @@
       "merge_strategy": "added",
       "notes": "Includes 29 rule files in .agent/tools/video/remotion/",
       "context7_id": "/remotion-dev/remotion"
+    },
+    {
+      "name": "cloudflare-platform",
+      "upstream_url": "https://github.com/dmmulroy/cloudflare-skill",
+      "upstream_commit": "c4696d5389f95e9546b075759ff8326deac1fba7",
+      "local_path": ".agent/services/hosting/cloudflare-platform.md",
+      "format_detected": "skill-md-nested",
+      "imported_at": "2026-01-21T05:12:00Z",
+      "last_checked": "2026-01-21T05:12:00Z",
+      "merge_strategy": "added",
+      "notes": "Includes 60 product reference directories in .agent/services/hosting/cloudflare-platform/references/"
     }
   ]
 }

--- a/.agent/services/hosting/cloudflare-platform.md
+++ b/.agent/services/hosting/cloudflare-platform.md
@@ -1,0 +1,230 @@
+---
+description: "Comprehensive Cloudflare platform skill covering Workers, Pages, storage (KV, D1, R2), AI (Workers AI, Vectorize, Agents SDK), networking (Tunnel, Spectrum), security (WAF, DDoS), and infrastructure-as-code (Terraform, Pulumi). Use for any Cloudflare development task."
+mode: subagent
+imported_from: external
+---
+# cloudflare
+
+
+# Cloudflare Platform Skill
+
+Consolidated skill for building on the Cloudflare platform. Use decision trees below to find the right product, then load detailed references.
+
+## How to Use This Skill
+
+### Reference File Structure
+
+Each product in `./references/<product>/` contains a `README.md` as the entry point, which may be structured in one of two ways:
+
+**Multi-file format (5 files):**
+| File | Purpose | When to Read |
+|------|---------|--------------|
+| `README.md` | Overview, when to use, getting started | **Always read first** |
+| `api.md` | Runtime API, types, method signatures | Writing code |
+| `configuration.md` | wrangler.toml, bindings, setup | Configuring a project |
+| `patterns.md` | Common patterns, best practices | Implementation guidance |
+| `gotchas.md` | Pitfalls, limitations, edge cases | Debugging, avoiding mistakes |
+
+**Single-file format:** All information consolidated in `README.md`.
+
+### Reading Order
+
+1. Start with `README.md`
+2. Then read additional files relevant to your task (if multi-file format):
+   - Building feature → `api.md` + `patterns.md`
+   - Setting up project → `configuration.md`
+   - Troubleshooting → `gotchas.md`
+
+### Example Paths
+
+```
+./references/workflows/README.md         # Start here for Workflows
+./references/workflows/api.md            # Workflow class, step methods
+./references/durable-objects/gotchas.md  # DO limitations
+./references/workers-ai/README.md        # Single-file - all Workers AI docs
+```
+
+## Quick Decision Trees
+
+### "I need to run code"
+
+```
+Need to run code?
+├─ Serverless functions at the edge → workers/
+├─ Full-stack web app with Git deploys → pages/
+├─ Stateful coordination/real-time → durable-objects/
+├─ Long-running multi-step jobs → workflows/
+├─ Run containers → containers/
+├─ Multi-tenant (customers deploy code) → workers-for-platforms/
+└─ Scheduled tasks (cron) → cron-triggers/
+```
+
+### "I need to store data"
+
+```
+Need storage?
+├─ Key-value (config, sessions, cache) → kv/
+├─ Relational SQL → d1/ (SQLite) or hyperdrive/ (existing Postgres/MySQL)
+├─ Object/file storage (S3-compatible) → r2/
+├─ Message queue (async processing) → queues/
+├─ Vector embeddings (AI/semantic search) → vectorize/
+├─ Strongly-consistent per-entity state → durable-objects/ (DO storage)
+├─ Secrets management → secrets-store/
+└─ Streaming ETL to R2 → pipelines/
+```
+
+### "I need AI/ML"
+
+```
+Need AI?
+├─ Run inference (LLMs, embeddings, images) → workers-ai/
+├─ Vector database for RAG/search → vectorize/
+├─ Build stateful AI agents → agents-sdk/
+├─ Gateway for any AI provider (caching, routing) → ai-gateway/
+└─ AI-powered search widget → ai-search/
+```
+
+### "I need networking/connectivity"
+
+```
+Need networking?
+├─ Expose local service to internet → tunnel/
+├─ TCP/UDP proxy (non-HTTP) → spectrum/
+├─ WebRTC TURN server → turn/
+├─ Private network connectivity → network-interconnect/
+├─ Optimize routing → argo-smart-routing/
+└─ Real-time video/audio → realtimekit/ or realtime-sfu/
+```
+
+### "I need security"
+
+```
+Need security?
+├─ Web Application Firewall → waf/
+├─ DDoS protection → ddos/
+├─ Bot detection/management → bot-management/
+├─ API protection → api-shield/
+├─ CAPTCHA alternative → turnstile/
+└─ Credential leak detection → waf/ (managed ruleset)
+```
+
+### "I need media/content"
+
+```
+Need media?
+├─ Image optimization/transformation → images/
+├─ Video streaming/encoding → stream/
+├─ Browser automation/screenshots → browser-rendering/
+└─ Third-party script management → zaraz/
+```
+
+### "I need infrastructure-as-code"
+
+```
+Need IaC?
+├─ Pulumi → pulumi/
+├─ Terraform → terraform/
+└─ Direct API → api/
+```
+
+## Product Index
+
+### Compute & Runtime
+| Product | Entry File |
+|---------|------------|
+| Workers | `./references/workers/README.md` |
+| Pages | `./references/pages/README.md` |
+| Pages Functions | `./references/pages-functions/README.md` |
+| Durable Objects | `./references/durable-objects/README.md` |
+| Workflows | `./references/workflows/README.md` |
+| Containers | `./references/containers/README.md` |
+| Workers for Platforms | `./references/workers-for-platforms/README.md` |
+| Cron Triggers | `./references/cron-triggers/README.md` |
+| Tail Workers | `./references/tail-workers/README.md` |
+| Snippets | `./references/snippets/README.md` |
+| Smart Placement | `./references/smart-placement/README.md` |
+
+### Storage & Data
+| Product | Entry File |
+|---------|------------|
+| KV | `./references/kv/README.md` |
+| D1 | `./references/d1/README.md` |
+| R2 | `./references/r2/README.md` |
+| Queues | `./references/queues/README.md` |
+| Hyperdrive | `./references/hyperdrive/README.md` |
+| DO Storage | `./references/do-storage/README.md` |
+| Secrets Store | `./references/secrets-store/README.md` |
+| Pipelines | `./references/pipelines/README.md` |
+| R2 Data Catalog | `./references/r2-data-catalog/README.md` |
+| R2 SQL | `./references/r2-sql/README.md` |
+
+### AI & Machine Learning
+| Product | Entry File |
+|---------|------------|
+| Workers AI | `./references/workers-ai/README.md` |
+| Vectorize | `./references/vectorize/README.md` |
+| Agents SDK | `./references/agents-sdk/README.md` |
+| AI Gateway | `./references/ai-gateway/README.md` |
+| AI Search | `./references/ai-search/README.md` |
+
+### Networking & Connectivity
+| Product | Entry File |
+|---------|------------|
+| Tunnel | `./references/tunnel/README.md` |
+| Spectrum | `./references/spectrum/README.md` |
+| TURN | `./references/turn/README.md` |
+| Network Interconnect | `./references/network-interconnect/README.md` |
+| Argo Smart Routing | `./references/argo-smart-routing/README.md` |
+| Workers VPC | `./references/workers-vpc/README.md` |
+
+### Security
+| Product | Entry File |
+|---------|------------|
+| WAF | `./references/waf/README.md` |
+| DDoS Protection | `./references/ddos/README.md` |
+| Bot Management | `./references/bot-management/README.md` |
+| API Shield | `./references/api-shield/README.md` |
+| Turnstile | `./references/turnstile/README.md` |
+
+### Media & Content
+| Product | Entry File |
+|---------|------------|
+| Images | `./references/images/README.md` |
+| Stream | `./references/stream/README.md` |
+| Browser Rendering | `./references/browser-rendering/README.md` |
+| Zaraz | `./references/zaraz/README.md` |
+
+### Real-Time Communication
+| Product | Entry File |
+|---------|------------|
+| RealtimeKit | `./references/realtimekit/README.md` |
+| Realtime SFU | `./references/realtime-sfu/README.md` |
+
+### Developer Tools
+| Product | Entry File |
+|---------|------------|
+| Wrangler | `./references/wrangler/README.md` |
+| Miniflare | `./references/miniflare/README.md` |
+| C3 | `./references/c3/README.md` |
+| Observability | `./references/observability/README.md` |
+| Analytics Engine | `./references/analytics-engine/README.md` |
+| Web Analytics | `./references/web-analytics/README.md` |
+| Sandbox | `./references/sandbox/README.md` |
+| Workerd | `./references/workerd/README.md` |
+| Workers Playground | `./references/workers-playground/README.md` |
+
+### Infrastructure as Code
+| Product | Entry File |
+|---------|------------|
+| Pulumi | `./references/pulumi/README.md` |
+| Terraform | `./references/terraform/README.md` |
+| API | `./references/api/README.md` |
+
+### Other Services
+| Product | Entry File |
+|---------|------------|
+| Email Routing | `./references/email-routing/README.md` |
+| Email Workers | `./references/email-workers/README.md` |
+| Static Assets | `./references/static-assets/README.md` |
+| Bindings | `./references/bindings/README.md` |
+| Cache Reserve | `./references/cache-reserve/README.md` |

--- a/.agent/services/hosting/cloudflare-platform/references/agents-sdk/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/agents-sdk/README.md
@@ -1,0 +1,35 @@
+# Cloudflare Agents SDK
+
+Cloudflare Agents SDK enables building AI-powered agents on Durable Objects with state, WebSockets, SQL, scheduling, and AI integration.
+
+## Core Value
+Build stateful, globally distributed AI agents with persistent memory, real-time connections, scheduled tasks, and async workflows.
+
+## When to Use
+- Persistent state + memory required
+- Real-time WebSocket connections
+- Long-running workflows (minutes/hours)
+- Chat interfaces with AI models
+- Scheduled/recurring tasks with state
+- DB queries with agent state
+
+## Quick Start
+```typescript
+import { Agent } from "agents";
+
+export class MyAgent extends Agent<Env> {
+  onStart() {
+    this.sql`CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY)`;
+  }
+  
+  async onRequest(request: Request) {
+    return Response.json({ state: this.state });
+  }
+}
+```
+
+## See Also
+- durable-objects - Agent infrastructure
+- d1 - External database integration
+- workers-ai - AI model integration
+- vectorize - Vector search for RAG patterns

--- a/.agent/services/hosting/cloudflare-platform/references/agents-sdk/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/agents-sdk/api.md
@@ -1,0 +1,100 @@
+# API Reference
+
+## Lifecycle
+
+**onStart()** - Init/hibernation restart:
+```ts
+onStart() {
+  this.sql`CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT)`;
+  if (!this.state.initialized) this.setState({initialized: true, messages: []});
+}
+```
+
+**onRequest(req)** - HTTP:
+```ts
+async onRequest(req: Request) {
+  const {pathname} = new URL(req.url);
+  if (pathname === "/users") return Response.json(this.sql<{id,name}>`SELECT * FROM users`);
+  return new Response("Not found", {status: 404});
+}
+```
+
+**onConnect(conn, ctx)** - WebSocket:
+```ts
+async onConnect(conn: Connection, ctx: ConnectionContext) {
+  conn.accept();
+  conn.setState({userId: ctx.request.headers.get("X-User-ID")});
+  conn.send(JSON.stringify({type: "connected", state: this.state}));
+}
+```
+
+**onMessage(conn, msg)** - WS messages:
+```ts
+async onMessage(conn: Connection, msg: WSMessage) {
+  const m = JSON.parse(msg as string);
+  if (m.type === "chat") {
+    this.setState({messages: [...this.state.messages, m]});
+    this.connections.forEach(c => c.send(JSON.stringify(m)));
+  }
+}
+```
+
+**onEmail(email)** - Email routing:
+```ts
+async onEmail(email: AgentEmail) {
+  const text = await email.text();
+  this.sql`INSERT INTO emails (from_addr,subject,body) VALUES (${email.from},${email.headers.get("subject")},${text})`;
+}
+```
+
+## State
+
+```ts
+this.setState({count: 42, users: []}); // Auto-syncs
+this.setState({...this.state, count: this.state.count + 1});
+const s = this.state;
+```
+
+## SQL
+
+```ts
+this.sql`CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY, name TEXT)`;
+this.sql`INSERT INTO users (id,name) VALUES (${userId},${name})`;
+const users = this.sql<{id,name}>`SELECT * FROM users`;
+const user = this.sql<{name}>`SELECT name FROM users WHERE id = ${userId}`; // Prevents injection
+```
+
+## Scheduling
+
+```ts
+await this.schedule(new Date("2026-12-25T00:00:00Z"), "sendGreeting", {msg:"Hi"}); // Time
+await this.schedule(60, "checkStatus", {}); // Delay (sec)
+await this.schedule("0 0 * * *", "dailyCleanup", {}); // Cron
+await this.schedule("*/5 * * * *", "syncData", {}); // Every 5min
+const schedules = await this.getSchedules();
+await this.cancelSchedule(scheduleId);
+```
+
+## Connections
+
+```ts
+this.connections.forEach(c => c.send(JSON.stringify(msg))); // Broadcast
+conn.send(JSON.stringify({type:"update",data})); // Specific
+conn.close(1000, "Goodbye");
+conn.setState({userId:"123",role:"admin"});
+const uid = conn.state.userId;
+```
+
+## AI
+
+```ts
+const r = await this.env.AI.run("@cf/meta/llama-3.1-8b-instruct", {prompt});
+
+const stream = await client.chat.completions.create({
+  model: "gpt-4", messages: [{role:"user",content:prompt}], stream: true
+});
+for await (const chunk of stream) {
+  const content = chunk.choices[0]?.delta?.content;
+  if (content) conn.send(JSON.stringify({type:"chunk",content}));
+}
+```

--- a/.agent/services/hosting/cloudflare-platform/references/agents-sdk/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/agents-sdk/configuration.md
@@ -1,0 +1,99 @@
+# Configuration
+
+## Wrangler Setup
+
+```toml
+name = "my-agents-app"
+
+[[durable_objects.bindings]]
+name = "MyAgent"
+class_name = "MyAgent"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyAgent"]
+
+[ai]
+binding = "AI"
+```
+
+```jsonc
+{
+  "durable_objects": {
+    "bindings": [
+      {"name": "MyAgent", "class_name": "MyAgent"}
+    ]
+  },
+  "migrations": [
+    {"tag": "v1", "new_sqlite_classes": ["MyAgent"]}
+  ],
+  "ai": {
+    "binding": "AI"
+  }
+}
+```
+
+## Environment Bindings
+
+```typescript
+interface Env {
+  AI?: Ai;                              // Workers AI
+  MyAgent?: DurableObjectNamespace<MyAgent>;
+  DB?: D1Database;                      // D1 database
+  KV?: KVNamespace;                     // KV storage
+  R2?: R2Bucket;                        // R2 bucket
+  OPENAI_API_KEY?: string;              // Secrets
+  QUEUE?: Queue;                        // Queues
+}
+```
+
+## Deployment
+
+```bash
+# Local dev
+npx wrangler dev
+
+# Deploy production
+npx wrangler deploy
+
+# Set secrets
+npx wrangler secret put OPENAI_API_KEY
+```
+
+## Agent Routing
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env) {
+    const id = env.MyAgent.idFromName("user-123");
+    const stub = env.MyAgent.get(id);
+    return stub.fetch(request);
+  }
+}
+```
+
+## Email Routing
+
+Configure email routing in dashboard to deliver emails to agent:
+
+```
+Destination: Workers with Durable Objects
+Worker: my-agents-app
+```
+
+## AI Gateway (Optional)
+
+```typescript
+// Enable caching/routing through AI Gateway
+const response = await this.env.AI.run(
+  "@cf/meta/llama-3.1-8b-instruct",
+  { prompt },
+  {
+    gateway: {
+      id: "my-gateway-id",
+      skipCache: false,
+      cacheTtl: 3600
+    }
+  }
+);
+```

--- a/.agent/services/hosting/cloudflare-platform/references/agents-sdk/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/agents-sdk/gotchas.md
@@ -1,0 +1,59 @@
+# Gotchas & Best Practices
+
+## State
+DO: `setState()` (auto-syncs), serializable, limit size | DON'T: Mutate directly, large objects (SQL), functions/circular
+```ts
+// ❌ this.state.count++ | ✅ this.setState({...this.state, count: this.state.count + 1})
+```
+
+## SQL
+DO: Parameterized, create in `onStart()`, types | DON'T: Direct interpolation, assume exists
+```ts
+// ❌ this.sql`...WHERE id = '${userId}'` | ✅ this.sql`...WHERE id = ${userId}`
+```
+
+## WebSocket
+DO: `conn.accept()`, errors, cleanup | DON'T: Forget accept (timeout), assume persist, sensitive in state
+```ts
+async onConnect(conn: Connection, ctx: ConnectionContext) { conn.accept(); conn.setState({userId: "123"}); }
+```
+
+## Scheduling
+1000 tasks/agent, 1min min, persist. Clean old, descriptive names, handle failures
+```ts
+async checkSchedules() { if ((await this.getSchedules()).length > 800) console.warn("Near limit!"); }
+```
+
+## AI
+Optimize: AI Gateway cache, rate limit, stream | Error: try/catch, fallback, quota/timeout
+```ts
+try { return await this.env.AI.run(model, {prompt}); } catch (e) { return {error: "Unavailable"}; }
+```
+
+## Perf
+State: Batch `setState()`, low-freq, SQL for large | Conns: Limit broadcast, selective, backpressure
+
+## Debug
+`npx wrangler dev` (local), `npx wrangler tail` (remote)
+Issues: "Agent not found" (DO binding), State not sync (`setState()`), Timeout (`conn.accept()`), SQL (create in `onStart()`)
+
+## Security
+DO: Validate, sanitize, auth WS, env secrets | DON'T: Trust headers, expose sensitive, unauth
+```ts
+async onConnect(conn: Connection, ctx: ConnectionContext) {
+  const token = ctx.request.headers.get("Authorization");
+  if (!await this.validateToken(token)) { conn.close(4001, "Unauthorized"); return; }
+  conn.accept();
+}
+```
+
+## Limits
+CPU: 30s/req, Mem: 128MB/inst, Storage: SQL shares DO quota, Conns: no limit (watch mem), Schedules: 1000/agent
+
+## Migration
+`new_sqlite_classes`, test staging, no downgrade w/SQL, careful state
+```toml
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyAgent"]
+```

--- a/.agent/services/hosting/cloudflare-platform/references/agents-sdk/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/agents-sdk/patterns.md
@@ -1,0 +1,89 @@
+# Patterns & Use Cases
+
+## Chat
+
+```ts
+export class ChatAgent extends Agent<Env, ChatState> {
+  initialState = {messages: [], participants: []};
+  async onConnect(conn: Connection, ctx: ConnectionContext) {
+    conn.accept();
+    const userId = ctx.request.headers.get("X-User-ID");
+    conn.setState({userId});
+    this.setState({...this.state, participants: [...this.state.participants, userId]});
+    conn.send(JSON.stringify({type: "history", messages: this.state.messages}));
+  }
+  async onMessage(conn: Connection, msg: WSMessage) {
+    const m = JSON.parse(msg as string);
+    if (m.type === "chat")
+      this.setState({...this.state, messages: [...this.state.messages, {userId: conn.state.userId, text: m.text, timestamp: Date.now()}]});
+  }
+}
+```
+
+## AI w/Tools
+
+```ts
+import {tool} from "ai"; import {z} from "zod";
+const weatherTool = tool({description: "Get weather", inputSchema: z.object({city: z.string()}), execute: async ({city}) => `Weather: ${city} Sunny 72°F`});
+export class AIAgent extends Agent<Env> {
+  tools = {getWeather: weatherTool};
+  async onMessage(conn: Connection, msg: WSMessage) {
+    const m = JSON.parse(msg as string);
+    conn.send(JSON.stringify({response: await this.env.AI.run("@cf/meta/llama-3.1-8b-instruct", {prompt: m.prompt, tools: this.tools})}));
+  }
+}
+```
+
+## Streaming
+
+```ts
+import {OpenAI} from "openai";
+export class StreamingAgent extends Agent<Env> {
+  async onMessage(conn: Connection, msg: WSMessage) {
+    const m = JSON.parse(msg as string);
+    const stream = await new OpenAI({apiKey: this.env.OPENAI_API_KEY}).chat.completions.create({model: "gpt-4", messages: [{role: "user", content: m.prompt}], stream: true});
+    for await (const chunk of stream) { const c = chunk.choices[0]?.delta?.content || ""; if (c) conn.send(JSON.stringify({type: "chunk", content: c})); }
+    conn.send(JSON.stringify({type: "done"}));
+  }
+}
+```
+
+## Cron/Scheduled
+
+```ts
+export class TaskAgent extends Agent<Env> {
+  onStart() { this.schedule("0 0 * * *", "dailyCleanup", {}); this.schedule("0 * * * *", "syncData", {}); }
+  async dailyCleanup() { this.sql`DELETE FROM logs WHERE created_at < ${Date.now() - 86400000}`; }
+  async syncData() { const data = await (await fetch(this.env.API_URL)).json(); this.sql`INSERT INTO cache (data,updated_at) VALUES (${JSON.stringify(data)},${Date.now()})`; }
+}
+```
+
+## Email+AI
+
+```ts
+export class EmailAgent extends Agent<Env> {
+  async onEmail(email: AgentEmail) {
+    const [text, from, subject] = [await email.text(), email.from, email.headers.get("subject")];
+    this.sql`INSERT INTO emails (from_addr,subject,body,received_at) VALUES (${from},${subject},${text},${Date.now()})`;
+    const r = await this.env.AI.run("@cf/meta/llama-3.1-8b-instruct", {prompt: `Summarize: ${text}`});
+    this.setState({...this.state, lastEmail: {from, subject, summary: r}});
+    this.connections.forEach(c => c.send(JSON.stringify({type: "new_email", from, subject})));
+  }
+}
+```
+
+## Game
+
+```ts
+export class GameAgent extends Agent<Env, GameState> {
+  initialState = {players: [], score: 0, round: 1};
+  async onConnect(conn: Connection, ctx: ConnectionContext) {
+    conn.accept(); const playerId = ctx.request.headers.get("X-Player-ID"); conn.setState({playerId});
+    this.setState({...this.state, players: [...this.state.players, {id: playerId, score: 0}]});
+  }
+  async onMessage(conn: Connection, msg: WSMessage) {
+    const m = JSON.parse(msg as string);
+    if (m.type === "move") this.setState({...this.state, players: this.state.players.map(p => p.id === conn.state.playerId ? {...p, score: p.score + m.points} : p)});
+  }
+}
+```

--- a/.agent/services/hosting/cloudflare-platform/references/ai-gateway/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ai-gateway/README.md
@@ -1,0 +1,695 @@
+# Cloudflare AI Gateway Skill
+
+Expert guidance for implementing and configuring Cloudflare AI Gateway - a universal gateway for AI model providers with analytics, caching, rate limiting, and routing capabilities.
+
+## When to Use This Skill
+
+- Setting up AI Gateway for any AI provider (OpenAI, Anthropic, Workers AI, etc.)
+- Implementing caching, rate limiting, or request retry/fallback
+- Configuring dynamic routing with A/B testing or model fallbacks
+- Managing provider API keys securely with BYOK
+- Setting up observability with logging and custom metadata
+- Integrating AI Gateway with Cloudflare Workers or external applications
+- Debugging AI Gateway requests or optimizing configurations
+
+## Core Concepts
+
+### Gateway Architecture
+
+AI Gateway acts as a proxy between your application and AI providers:
+
+```
+Your App → AI Gateway → AI Provider (OpenAI, Anthropic, etc.)
+         ↓
+    Analytics, Caching, Rate Limiting, Logging
+```
+
+**Key URL patterns:**
+- Unified API (OpenAI-compatible): `https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/compat/chat/completions`
+- Provider-specific: `https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/{provider}/{endpoint}`
+- Dynamic routes: Use route name instead of model: `dynamic/{route-name}`
+
+### Gateway Types
+
+1. **Unauthenticated Gateway**: Open access (not recommended for production)
+2. **Authenticated Gateway**: Requires `cf-aig-authorization` header with Cloudflare API token (recommended)
+
+### Provider Authentication Options
+
+1. **Unified Billing**: Use AI Gateway billing to pay for inference
+2. **BYOK (Store Keys)**: Store provider API keys in Cloudflare dashboard
+3. **Request Headers**: Include provider API key in each request
+
+## Common Patterns
+
+### Pattern 1: OpenAI SDK with Unified API Endpoint
+
+Most common pattern - drop-in replacement for OpenAI API with multi-provider support.
+
+```typescript
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY, // or any provider's key
+  baseURL: `https://gateway.ai.cloudflare.com/v1/${accountId}/${gatewayId}/compat`,
+  defaultHeaders: {
+    // Only needed for authenticated gateways
+    'cf-aig-authorization': `Bearer ${cfToken}`
+  }
+});
+
+// Switch providers by changing model format: {provider}/{model}
+const response = await client.chat.completions.create({
+  model: 'openai/gpt-4o-mini', // or 'anthropic/claude-sonnet-4-5'
+  messages: [{ role: 'user', content: 'Hello!' }]
+});
+```
+
+**Benefits:**
+- Works with existing OpenAI SDK tooling
+- Switch providers without code changes (just change model param)
+- Compatible with most OpenAI-compatible tools
+
+### Pattern 2: Provider-Specific Endpoints
+
+Use when you need the original provider's API schema.
+
+```typescript
+import OpenAI from 'openai';
+
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY,
+  baseURL: `https://gateway.ai.cloudflare.com/v1/${accountId}/${gatewayId}/openai`
+});
+
+// Standard OpenAI request - AI Gateway features still apply
+const response = await client.chat.completions.create({
+  model: 'gpt-4o-mini',
+  messages: [{ role: 'user', content: 'Hello!' }]
+});
+```
+
+### Pattern 3: Workers AI Binding with Gateway
+
+For Cloudflare Workers using Workers AI.
+
+```typescript
+export default {
+  async fetch(request, env, ctx) {
+    const response = await env.AI.run(
+      '@cf/meta/llama-3-8b-instruct',
+      { 
+        messages: [{ role: 'user', content: 'Hello!' }]
+      },
+      { 
+        gateway: { 
+          id: 'my-gateway',
+          metadata: { userId: '123', team: 'engineering' }
+        } 
+      }
+    );
+    
+    return new Response(JSON.stringify(response));
+  }
+};
+```
+
+### Pattern 4: Custom Metadata for Tracking
+
+Tag requests with user IDs, teams, or other identifiers (max 5 metadata entries).
+
+```typescript
+const response = await openai.chat.completions.create(
+  {
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: 'Hello!' }]
+  },
+  {
+    headers: {
+      'cf-aig-metadata': JSON.stringify({
+        userId: 'user123',
+        team: 'engineering',
+        environment: 'production',
+        requestType: 'chat',
+        internal: true
+      })
+    }
+  }
+);
+```
+
+### Pattern 5: Per-Request Caching Control
+
+Override default gateway caching settings per request.
+
+```bash
+# Skip cache for this request
+curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/chat/completions \
+  --header 'Authorization: Bearer $TOKEN' \
+  --header 'cf-aig-skip-cache: true' \
+  --data '{"model": "gpt-4o-mini", "messages": [...]}'
+
+# Custom cache TTL (1 hour)
+curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/chat/completions \
+  --header 'Authorization: Bearer $TOKEN' \
+  --header 'cf-aig-cache-ttl: 3600' \
+  --data '{"model": "gpt-4o-mini", "messages": [...]}'
+
+# Custom cache key for deterministic caching
+curl https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai/chat/completions \
+  --header 'Authorization: Bearer $TOKEN' \
+  --header 'cf-aig-cache-key: greeting-response' \
+  --data '{"model": "gpt-4o-mini", "messages": [...]}'
+```
+
+**Cache headers:**
+- `cf-aig-skip-cache: true` - Bypass cache
+- `cf-aig-cache-ttl: <seconds>` - Custom TTL (min: 60s, max: 1 month)
+- `cf-aig-cache-key: <key>` - Custom cache key
+- Response header `cf-aig-cache-status: HIT|MISS` indicates cache status
+
+### Pattern 6: BYOK (Bring Your Own Keys)
+
+Store provider keys in dashboard, remove from code.
+
+**Setup:**
+1. Enable authentication on gateway
+2. Dashboard → AI Gateway → Select gateway → Provider Keys → Add API Key
+3. Remove provider API keys from code:
+
+```typescript
+// Before BYOK: Include provider key in every request
+const client = new OpenAI({
+  apiKey: process.env.OPENAI_API_KEY, // Provider key
+  baseURL: `https://gateway.ai.cloudflare.com/v1/${accountId}/${gatewayId}/openai`,
+  defaultHeaders: {
+    'cf-aig-authorization': `Bearer ${cfToken}` // Gateway auth
+  }
+});
+
+// After BYOK: Only gateway auth needed
+const client = new OpenAI({
+  // No apiKey needed - stored in dashboard
+  baseURL: `https://gateway.ai.cloudflare.com/v1/${accountId}/${gatewayId}/openai`,
+  defaultHeaders: {
+    'cf-aig-authorization': `Bearer ${cfToken}` // Only gateway auth
+  }
+});
+```
+
+### Pattern 7: Dynamic Routing with Fallbacks
+
+Configure routing logic in dashboard, not code.
+
+```typescript
+// Use route name instead of model
+const response = await client.chat.completions.create({
+  model: 'dynamic/support', // Route name from dashboard
+  messages: [{ role: 'user', content: 'Hello!' }]
+});
+```
+
+**Dynamic routing use cases:**
+- A/B testing between models
+- Rate/budget limits per user/team
+- Model fallbacks on errors
+- Conditional routing (paid vs free users)
+
+**Route configuration (in dashboard):**
+1. Create route: Dashboard → Gateway → Dynamic Routes → Add Route
+2. Define flow with nodes:
+   - **Conditional**: Branch on metadata (e.g., `user.plan == "paid"`)
+   - **Percentage**: A/B split (e.g., 80% model A, 20% model B)
+   - **Rate Limit**: Quota enforcement, fallback when exceeded
+   - **Budget Limit**: Cost quota enforcement
+   - **Model**: Call specific provider/model
+3. Save & deploy version
+
+### Pattern 8: Error Handling
+
+```typescript
+try {
+  const response = await client.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: 'Hello!' }]
+  });
+} catch (error) {
+  // Rate limit exceeded
+  if (error.status === 429) {
+    console.error('Rate limit exceeded:', error.message);
+    // Implement backoff or use dynamic routing with fallback
+  }
+  
+  // Gateway authentication failed
+  if (error.status === 401) {
+    console.error('Gateway authentication failed - check cf-aig-authorization token');
+  }
+  
+  // Provider authentication failed
+  if (error.status === 403) {
+    console.error('Provider authentication failed - check API key or BYOK setup');
+  }
+  
+  throw error;
+}
+```
+
+## Configuration Reference
+
+### Dashboard Setup
+
+**Create gateway:**
+```bash
+# Via Dashboard: AI > AI Gateway > Create Gateway
+# Or via API:
+curl https://api.cloudflare.com/client/v4/accounts/{account_id}/ai-gateway/gateways \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "id": "my-gateway",
+    "cache_ttl": 3600,
+    "cache_invalidate_on_update": true,
+    "rate_limiting_interval": 60,
+    "rate_limiting_limit": 100,
+    "rate_limiting_technique": "sliding",
+    "collect_logs": true
+  }'
+```
+
+### Feature Configuration
+
+**Caching:**
+- Dashboard: Settings → Cache Responses → Enable
+- Default TTL: Set in gateway settings
+- Cache behavior: Only for identical requests (text & image responses)
+- Use case: Support bots with limited prompt options
+
+**Rate Limiting:**
+- Dashboard: Settings → Rate-limiting → Enable
+- Parameters:
+  - Limit: Number of requests
+  - Interval: Time period (seconds)
+  - Technique: `fixed` or `sliding` window
+- Response: `429 Too Many Requests` when exceeded
+
+**Logging:**
+- Dashboard: Settings → Logs
+- Default: Enabled (up to 10M logs per gateway)
+- Per-request: `cf-aig-collect-log: false` to skip
+- Auto-delete: Enable to remove oldest logs when limit reached
+- Filter logs by: status, cache, provider, model, cost, tokens, duration, metadata
+
+### Wrangler Integration
+
+**Gateway with Workers AI:**
+
+```toml
+# wrangler.toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[ai]
+binding = "AI"
+
+[[ai.gateway]]
+id = "my-gateway"
+```
+
+```typescript
+// src/index.ts
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const response = await env.AI.run(
+      '@cf/meta/llama-3-8b-instruct',
+      { prompt: 'Hello!' },
+      { gateway: { id: 'my-gateway' } }
+    );
+    
+    return Response.json(response);
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+**Environment variables for gateways:**
+
+```toml
+# wrangler.toml
+[vars]
+CF_ACCOUNT_ID = "your-account-id"
+GATEWAY_ID = "my-gateway"
+
+# Secrets (use wrangler secret put)
+# CF_API_TOKEN - for authenticated gateways
+# OPENAI_API_KEY - if not using BYOK
+```
+
+```bash
+# Set secrets
+wrangler secret put CF_API_TOKEN
+wrangler secret put OPENAI_API_KEY
+```
+
+### API Token Permissions
+
+**For gateway management:**
+- AI Gateway - Read
+- AI Gateway - Edit
+
+**For authenticated gateway access:**
+- Create API token with appropriate permissions
+- Pass in `cf-aig-authorization: Bearer {token}` header
+
+## Supported Providers
+
+AI Gateway works with 15+ providers via unified API or provider-specific endpoints:
+
+| Provider | Unified API | Provider Endpoint | Notes |
+|----------|-------------|-------------------|-------|
+| OpenAI | ✅ `openai/gpt-4o` | `/openai/*` | Full support |
+| Anthropic | ✅ `anthropic/claude-3-5-sonnet` | `/anthropic/*` | Full support |
+| Google AI Studio | ✅ `google-ai-studio/gemini-2.0-flash` | `/google-ai-studio/*` | Full support |
+| Workers AI | ✅ `workersai/@cf/meta/llama-3` | `/workers-ai/*` | Native integration |
+| Azure OpenAI | ✅ `azure-openai/*` | `/azure-openai/*` | Deployment names |
+| AWS Bedrock | ❌ | `/bedrock/*` | Provider endpoint only |
+| Groq | ✅ `groq/*` | `/groq/*` | Fast inference |
+| Mistral | ✅ `mistral/*` | `/mistral/*` | Full support |
+| Cohere | ✅ `cohere/*` | `/cohere/*` | Full support |
+| Perplexity | ✅ `perplexity/*` | `/perplexity/*` | Full support |
+| xAI (Grok) | ✅ `grok/*` | `/grok/*` | Full support |
+| DeepSeek | ✅ `deepseek/*` | `/deepseek/*` | Full support |
+| Cerebras | ✅ `cerebras/*` | `/cerebras/*` | Fast inference |
+| Replicate | ❌ | `/replicate/*` | Provider endpoint only |
+| HuggingFace | ❌ | `/huggingface/*` | Provider endpoint only |
+
+See [full provider list](https://developers.cloudflare.com/ai-gateway/usage/providers/)
+
+## Observability
+
+### Analytics Dashboard
+
+View in Dashboard → AI Gateway → Select gateway:
+- Request count over time
+- Token usage (input/output)
+- Cost tracking (estimated or custom)
+- Cache hit rate
+- Error rates by provider/model
+- Latency percentiles
+
+### Log Structure
+
+Each log entry contains:
+- User prompt & model response
+- Provider & model
+- Timestamp
+- Request status (success/error)
+- Token usage (input/output/total)
+- Cost
+- Duration (ms)
+- Cache status (HIT/MISS)
+- Custom metadata
+- Request/Event ID
+
+### Custom Cost Tracking
+
+For custom models or providers not in Cloudflare's pricing database:
+
+```bash
+# Dashboard: Gateway → Settings → Custom Costs
+# Or via API:
+curl https://api.cloudflare.com/client/v4/accounts/{account_id}/ai-gateway/gateways/{gateway_id}/custom-costs \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -d '{
+    "model": "custom-model-v1",
+    "input_cost": 0.01,
+    "output_cost": 0.03
+  }'
+```
+
+## Advanced Use Cases
+
+### Multi-Model Chat with Fallbacks
+
+```typescript
+// Configure in dashboard:
+// Route: dynamic/smart-chat
+// - Try GPT-4 first
+// - Fallback to Claude if error
+// - Fallback to Llama if both fail
+
+const response = await client.chat.completions.create({
+  model: 'dynamic/smart-chat',
+  messages: [{ role: 'user', content: 'Complex reasoning task' }]
+});
+```
+
+### A/B Testing Models
+
+```typescript
+// Dashboard: Create route with Percentage node
+// - 50% to gpt-4o-mini
+// - 50% to claude-sonnet-4-5
+// Analyze logs to compare quality/cost/latency
+
+const response = await client.chat.completions.create({
+  model: 'dynamic/ab-test',
+  messages: [{ role: 'user', content: prompt }],
+  // Add metadata to track experiments
+  headers: {
+    'cf-aig-metadata': JSON.stringify({ experiment: 'model-comparison-v1' })
+  }
+});
+```
+
+### User-Based Rate Limiting
+
+```typescript
+// Dashboard: Create route with Rate Limit node
+// - Condition: Check metadata.userId
+// - Limit: 100 requests/hour per user
+// - Fallback: Return error or use cheaper model
+
+const response = await client.chat.completions.create(
+  {
+    model: 'dynamic/user-limited',
+    messages: [{ role: 'user', content: prompt }]
+  },
+  {
+    headers: {
+      'cf-aig-metadata': JSON.stringify({ userId })
+    }
+  }
+);
+```
+
+### Semantic Caching (Future)
+
+Currently, caching requires identical requests. Semantic caching (similar but not identical requests) is planned.
+
+**Current workaround:**
+```typescript
+// Use cf-aig-cache-key for grouped responses
+const normalizedPrompt = normalizePrompt(userInput); // Your logic
+const cacheKey = hashPrompt(normalizedPrompt);
+
+const response = await fetch(gatewayUrl, {
+  headers: {
+    'cf-aig-cache-key': cacheKey,
+    'cf-aig-cache-ttl': '3600'
+  },
+  // ... rest of request
+});
+```
+
+## Debugging & Troubleshooting
+
+### Check Gateway Status
+
+```bash
+# List all gateways
+curl https://api.cloudflare.com/client/v4/accounts/{account_id}/ai-gateway/gateways \
+  -H "Authorization: Bearer $CF_API_TOKEN"
+
+# Get specific gateway
+curl https://api.cloudflare.com/client/v4/accounts/{account_id}/ai-gateway/gateways/{gateway_id} \
+  -H "Authorization: Bearer $CF_API_TOKEN"
+```
+
+### Inspect Request Logs
+
+Dashboard → Gateway → Logs
+
+**Filter examples:**
+- `status: error` - All failed requests
+- `provider: openai` - OpenAI requests only
+- `metadata.userId: user123` - Specific user
+- `cache: not cached` - Cache misses only
+- `cost > 0.01` - Expensive requests
+
+### Common Issues
+
+**401 Unauthorized:**
+- Authenticated gateway without `cf-aig-authorization` header
+- Invalid/expired CF API token
+- Check token permissions (AI Gateway - Read)
+
+**403 Forbidden:**
+- Provider API key invalid/missing
+- BYOK key not configured or expired
+- Provider quota exceeded
+
+**429 Rate Limited:**
+- Gateway rate limit exceeded
+- Check settings: Dashboard → Gateway → Settings → Rate-limiting
+- Implement backoff or use dynamic routing
+
+**Cache not working:**
+- Requests must be identical (body, model, parameters)
+- Caching only supports text/image responses
+- Check `cf-aig-cache-status` header in response
+- Verify caching enabled: Dashboard → Settings → Cache Responses
+
+**Logs not appearing:**
+- Check log limit (default: 10M per gateway)
+- Verify logs enabled: Dashboard → Settings → Logs
+- Per-request `cf-aig-collect-log: false` bypasses logging
+- Wait 30-60s for logs to appear
+
+## API Reference
+
+### Gateway Management
+
+```bash
+# Create gateway
+POST /accounts/{account_id}/ai-gateway/gateways
+
+# Update gateway
+PUT /accounts/{account_id}/ai-gateway/gateways/{gateway_id}
+
+# Delete gateway
+DELETE /accounts/{account_id}/ai-gateway/gateways/{gateway_id}
+
+# List gateways
+GET /accounts/{account_id}/ai-gateway/gateways
+```
+
+### Log Management
+
+```bash
+# Get logs
+GET /accounts/{account_id}/ai-gateway/gateways/{gateway_id}/logs
+
+# Delete logs
+DELETE /accounts/{account_id}/ai-gateway/gateways/{gateway_id}/logs
+
+# Filter logs (query params)
+?status=error&provider=openai&cache=not_cached
+```
+
+### Headers Reference
+
+**Gateway authentication:**
+- `cf-aig-authorization: Bearer {token}` - Required for authenticated gateways
+
+**Caching:**
+- `cf-aig-cache-ttl: {seconds}` - Cache duration (60s - 1 month)
+- `cf-aig-skip-cache: true` - Bypass cache
+- `cf-aig-cache-key: {key}` - Custom cache key
+- Response: `cf-aig-cache-status: HIT|MISS`
+
+**Logging:**
+- `cf-aig-collect-log: false` - Skip logging for this request
+
+**Metadata:**
+- `cf-aig-metadata: {json}` - Custom tracking data (max 5 entries, string/number/boolean values)
+
+## Best Practices
+
+1. **Always use authenticated gateways in production**
+   - Prevents unauthorized access
+   - Protects against log storage abuse
+   - Required for BYOK
+
+2. **Use BYOK for provider keys**
+   - Removes keys from codebase
+   - Easier key rotation
+   - Centralized management
+
+3. **Add custom metadata to all requests**
+   - Track users, teams, environments
+   - Filter logs effectively
+   - Debug production issues faster
+
+4. **Configure appropriate rate limits**
+   - Prevent runaway costs
+   - Use dynamic routing for per-user limits
+   - Combine with budget limits
+
+5. **Enable caching for deterministic prompts**
+   - Support bots with fixed options
+   - Static content generation
+   - Reduces costs & latency
+
+6. **Use dynamic routing for resilience**
+   - Model fallbacks on errors
+   - A/B testing without code changes
+   - Gradual rollouts
+
+7. **Monitor logs regularly**
+   - Set up automatic log deletion
+   - Export logs for long-term analysis
+   - Track cost trends
+
+8. **Test with provider-specific endpoints first**
+   - Validates provider integration
+   - Easier debugging
+   - Migrate to unified API after validation
+
+## Examples Repository
+
+See real-world usage:
+- [NextChat](https://github.com/ChatGPTNextWeb/NextChat/blob/main/app/utils/cloudflare.ts) - URL parsing utilities
+- [LibreChat](https://github.com/danny-avila/LibreChat) - Multi-provider chat with AI Gateway
+- [Continue.dev](https://github.com/continuedev/continue/blob/main/core/llm/llms/Cloudflare.ts) - IDE integration
+- [Big-AGI](https://github.com/enricoros/big-AGI) - Complex gateway path handling
+
+## Resources
+
+- [Official Docs](https://developers.cloudflare.com/ai-gateway/)
+- [API Reference](https://developers.cloudflare.com/api/resources/ai_gateway/)
+- [Provider Guides](https://developers.cloudflare.com/ai-gateway/usage/providers/)
+- [Workers AI Integration](https://developers.cloudflare.com/workers-ai/)
+- [Discord Community](https://discord.cloudflare.com)
+
+## Quick Reference
+
+**Create gateway:**
+```bash
+Dashboard → AI → AI Gateway → Create Gateway
+```
+
+**Basic request:**
+```typescript
+const client = new OpenAI({
+  baseURL: `https://gateway.ai.cloudflare.com/v1/${accountId}/${gatewayId}/compat`
+});
+```
+
+**Check cache status:**
+```bash
+# Response header: cf-aig-cache-status: HIT|MISS
+```
+
+**Get account/gateway IDs:**
+```bash
+# Account ID: Dashboard → Overview → Account ID
+# Gateway ID: Dashboard → AI Gateway → Gateway name/ID
+```
+
+**Required env vars:**
+```bash
+CF_ACCOUNT_ID=xxx
+GATEWAY_ID=xxx
+CF_API_TOKEN=xxx  # For authenticated gateways
+PROVIDER_API_KEY=xxx  # If not using BYOK
+```

--- a/.agent/services/hosting/cloudflare-platform/references/ai-search/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ai-search/README.md
@@ -1,0 +1,14 @@
+# Cloudflare AI Search Skill Reference
+
+Expert guidance for implementing Cloudflare AI Search (formerly AutoRAG), Cloudflare's managed semantic search and RAG service....
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/ai-search/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ai-search/api.md
@@ -1,0 +1,38 @@
+## REST API
+
+**Base URL:** `https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/autorag/rags/{AUTORAG_NAME}`
+
+**Note:** API endpoints still use `autorag` naming; functionality identical to AI Search
+
+### Authentication
+
+Create API token with permissions:
+- `AI Search - Read`
+- `AI Search Edit`
+
+```bash
+curl -H "Authorization: Bearer {API_TOKEN}" \
+  -H "Content-Type: application/json"
+```
+
+### AI Search Endpoint
+
+```bash
+curl https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/autorag/rags/{AUTORAG_NAME}/ai-search \
+-H "Authorization: Bearer {API_TOKEN}" \
+-H "Content-Type: application/json" \
+-d '{
+  "query": "How do I configure caching?",
+  "model": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+  "system_prompt": "You are a technical documentation assistant.",
+  "rewrite_query": true,
+  "max_num_results": 10,
+  "ranking_options": {
+    "score_threshold": 0.3
+  },
+  "reranking": {
+    "enabled": true,
+    "model": "@cf/baai/bge-reranker-base"
+  },
+  "stream": false,
+  "fil

--- a/.agent/services/hosting/cloudflare-platform/references/ai-search/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ai-search/configuration.md
@@ -1,0 +1,52 @@
+### Configuration
+
+**wrangler.toml:**
+```toml
+[ai]
+binding = "AI"
+```
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "ai": {
+    "binding": "AI"
+  }
+}
+```
+
+### Code Patterns
+
+#### AI Search with Generation
+```typescript
+// Generate AI response with retrieved context
+const answer = await env.AI.autorag("my-autorag").aiSearch({
+  query: "How do I configure rate limits?",
+  model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+  rewrite_query: true,
+  max_num_results: 10,
+  ranking_options: {
+    score_threshold: 0.3
+  },
+  reranking: {
+    enabled: true,
+    model: "@cf/baai/bge-reranker-base"
+  },
+  stream: true
+});
+
+// Response includes: search_query, response, data[], has_more, next_page
+```
+
+#### Search Only (No Generation)
+```typescript
+// Retrieve relevant chunks without generation
+const results = await env.AI.autorag("my-autorag").search({
+  query: "rate limiting configuration",
+  rewrite_query: true,
+  max_num_results: 5,
+  ranking_options: {
+    score_threshold: 0.4
+  },
+  reranking: {
+    enab

--- a/.agent/services/hosting/cloudflare-platform/references/ai-search/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ai-search/gotchas.md
@@ -1,0 +1,41 @@
+### Best Practices
+- Keep files under size limits
+- Use supported formats
+- Maintain valid Service API token
+- Clean up outdated content regularly
+- Monitor Vectorize index limits
+
+## Configuration via Dashboard
+
+### 1. Create Instance
+```
+Dashboard → AI Search → Create
+→ Choose data source (R2 bucket or Website)
+→ Configure settings
+→ Create
+```
+
+### 2. Monitor Indexing
+```
+AI Search → Select instance → Overview
+View: indexing status, progress, stats
+```
+
+### 3. Test Queries
+```
+AI Search → Select instance → Playground
+→ "Search with AI" or "Search"
+→ Enter query
+```
+
+### 4. Get API Token
+```
+AI Search → Select instance → Use AI Search → API
+→ Create API Token
+→ Permissions: "AI Search - Read", "AI Search Edit"
+```
+
+### 5. Connect to Application
+```
+AI Search → Select instance → Connect
+C

--- a/.agent/services/hosting/cloudflare-platform/references/ai-search/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ai-search/patterns.md
@@ -1,0 +1,45 @@
+## Common Use Cases
+
+1. **Enterprise search**: Natural language search over company docs
+2. **Customer support**: AI-powered chat with product documentation
+3. **Knowledge bases**: Semantic search over technical content
+4. **Multitenancy SaaS**: Per-tenant data isolation with folder filters
+5. **Content discovery**: Finding relevant content across large datasets
+
+## Workers Binding (Recommended)
+
+### Configuration
+
+**wrangler.toml:**
+```toml
+[ai]
+binding = "AI"
+```
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "ai": {
+    "binding": "AI"
+  }
+}
+```
+
+### Code Patterns
+
+#### AI Search with Generation
+```typescript
+// Generate AI response with retrieved context
+const answer = await env.AI.autorag("my-autorag").aiSearch({
+  query: "How do I configure rate limits?",
+  model: "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+  rewrite_query: true,
+  max_num_results: 10,
+  ranking_options: {
+    score_threshold: 0.3
+  },
+  reranking: {
+    enabled: true,
+    model: "@cf/baai/bge-reranker-base"
+  },
+  stream: tr

--- a/.agent/services/hosting/cloudflare-platform/references/analytics-engine/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/analytics-engine/README.md
@@ -1,0 +1,14 @@
+# Cloudflare Workers Analytics Engine Reference
+
+Expert guidance for implementing unlimited-cardinality analytics at scale using Cloudflare Workers Analytics Engine. This skill covers ONLY Analytics Engine - NOT the broader Cloudflare platform....
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/analytics-engine/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/analytics-engine/api.md
@@ -1,0 +1,27 @@
+#### API Usage Tracking
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const customerId = request.headers.get("X-Customer-Id");
+    const startTime = Date.now();
+    
+    // Handle request...
+    const response = await handleRequest(request);
+    const duration = Date.now() - startTime;
+    
+    // Track API usage
+    env.API_USAGE.writeDataPoint({
+      blobs: [
+        url.pathname,                      // blob1: endpoint
+        request.method,                    // blob2: HTTP method  
+        response.status.toString(),        // blob3: status code
+        request.cf?.colo as string,        // blob4: datacenter
+        request.cf?.country as string      // blob5: country
+      ],
+      doubles: [
+        duration,                          // double1: latency ms
+        1                                  // double2: request count (for summing)
+      ],
+      indexes: [customerId || "anonymous"

--- a/.agent/services/hosting/cloudflare-platform/references/analytics-engine/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/analytics-engine/configuration.md
@@ -1,0 +1,45 @@
+## Configuration
+
+### Wrangler Setup
+
+**wrangler.toml:**
+```toml
+[[analytics_engine_datasets]]
+binding = "WEATHER"
+dataset = "weather_data"
+```
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "analytics_engine_datasets": [
+    {
+      "binding": "WEATHER",
+      "dataset": "weather_data"
+    }
+  ]
+}
+```
+
+**Key Points:**
+- Datasets are created automatically on first write - no manual dashboard setup needed
+- `binding` = variable name accessible in Worker env
+- `dataset` = logical table name (like SQL table - rows/columns should have consistent meaning)
+- Multiple datasets can be defined per Worker
+
+### TypeScript Types
+
+```typescript
+interface Env {
+  WEATHER: AnalyticsEngineDataset;
+}
+
+// The binding exposes this interface
+interface AnalyticsEngineDataset {
+  writeDataPoint(data: AnalyticsEngineDataPoint): void;
+}
+
+interface AnalyticsEngineDataPoint {
+  blobs?: string[];      // Up to 20 strings (dimensions for grouping/filtering)
+  doubles?

--- a/.agent/services/hosting/cloudflare-platform/references/analytics-engine/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/analytics-engine/gotchas.md
@@ -1,0 +1,3 @@
+# Gotchas
+
+See main documentation.

--- a/.agent/services/hosting/cloudflare-platform/references/analytics-engine/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/analytics-engine/patterns.md
@@ -1,0 +1,36 @@
+### Common Use Cases
+
+1. **Custom customer-facing analytics** - Expose analytics dashboards to your users
+2. **Usage-based billing** - Track per-customer/per-feature usage for metered billing
+3. **Service health monitoring** - Per-customer/per-user health metrics
+4. **High-frequency instrumentation** - Add telemetry to hot code paths without performance impact
+5. **Event tracking** - User actions, API calls, errors, performance metrics
+
+## Configuration
+
+### Wrangler Setup
+
+**wrangler.toml:**
+```toml
+[[analytics_engine_datasets]]
+binding = "WEATHER"
+dataset = "weather_data"
+```
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "analytics_engine_datasets": [
+    {
+      "binding": "WEATHER",
+      "dataset": "weather_data"
+    }
+  ]
+}
+```
+
+**Key Points:**
+- Datasets are created automatically on first write - no manual dashboard setup needed
+- `binding` = variable name accessible in Worker env
+- `dataset` = logical table name (like SQL table - r

--- a/.agent/services/hosting/cloudflare-platform/references/api-shield/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api-shield/README.md
@@ -1,0 +1,20 @@
+# Cloudflare API Shield Reference
+
+Expert guidance for API Shield - comprehensive API security suite for discovery, protection, and monitoring.
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, session identifiers, rules, token/mTLS configs
+- **[api.md](./api.md)** - Endpoint management, discovery, validation APIs, GraphQL operations
+- **[patterns.md](./patterns.md)** - Common patterns, progressive rollout, OWASP mappings, workflows
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, false positives, performance, best practices
+
+## Quick Start
+
+API Shield: Enterprise-grade API security (Discovery, Schema Validation, JWT, mTLS, Sequence Enforcement). Available as Enterprise add-on with preview access.
+
+## See Also
+
+- [API Shield Docs](https://developers.cloudflare.com/api-shield/)
+- [API Reference](https://developers.cloudflare.com/api/resources/api_gateway/)
+- [OWASP API Security Top 10](https://owasp.org/www-project-api-security/)

--- a/.agent/services/hosting/cloudflare-platform/references/api-shield/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api-shield/api.md
@@ -1,0 +1,78 @@
+# API Reference
+
+Base: `/zones/{zone_id}/api_gateway`
+
+## Endpoints
+
+```bash
+GET /operations                    # List
+GET /operations/{op_id}            # Get single
+POST /operations/item              # Create: {endpoint,host,method}
+POST /operations                   # Bulk: {operations:[{endpoint,host,method}]}
+DELETE /operations/{op_id}         # Delete
+DELETE /operations                 # Bulk delete: {operation_ids:[...]}
+```
+
+## Discovery
+
+```bash
+GET /discovery/operations                    # List discovered
+PATCH /discovery/operations/{op_id}          # Update: {state:"saved"|"ignored"}
+PATCH /discovery/operations                  # Bulk: {operation_ids:{id:{state}}}
+GET /discovery                               # OpenAPI export
+```
+
+## Config
+
+```bash
+GET /configuration        # Get session ID config
+PUT /configuration        # Update: {auth_id_characteristics:[{name,type:"header"|"cookie"}]}
+```
+
+## Token Validation
+
+```bash
+GET /token_validation                  # List
+POST /token_validation                 # Create: {name,location:{header:"..."},jwks:"..."}
+POST /jwt_validation_rules             # Rule: {name,hostname,token_validation_id,action:"block"}
+```
+
+## Workers
+
+API client:
+```js
+export default {
+  async fetch(req, env) {
+    const jwt = await generateJWT(env.JWT_SECRET);
+    return fetch('https://api.example.com/data', {
+      headers: {'Authorization': `Bearer ${jwt}`, 'Content-Type': 'application/json'}
+    });
+  }
+}
+```
+
+Dynamic JWKS:
+```js
+export default {
+  async scheduled(event, env) {
+    const jwks = await (await fetch('https://auth.example.com/.well-known/jwks.json')).json();
+    await fetch(`https://api.cloudflare.com/client/v4/zones/${env.ZONE_ID}/api_gateway/token_validation/${env.CONFIG_ID}`, {
+      method: 'PATCH',
+      headers: {'Authorization': `Bearer ${env.CF_API_TOKEN}`, 'Content-Type': 'application/json'},
+      body: JSON.stringify({jwks: JSON.stringify(jwks)})
+    });
+  }
+}
+```
+
+## Firewall Fields
+
+```js
+cf.api_gateway.auth_id_present           // Session ID present
+cf.api_gateway.request_violates_schema   // Schema violation
+cf.api_gateway.fallthrough_triggered     // No endpoint match
+cf.api_gateway.jwt_claims_valid          // JWT valid
+lookup_json_string(http.request.jwt.claims["{config_id}"][0], "claim_name")
+cf.tls_client_auth.cert_verified         // mTLS cert valid
+cf.tls_client_auth.cert_fingerprint_sha256
+```

--- a/.agent/services/hosting/cloudflare-platform/references/api-shield/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api-shield/configuration.md
@@ -1,0 +1,128 @@
+# Configuration
+
+## Schema Validation Setup
+
+**Upload schema (Dashboard):**
+```
+Security > API Shield > Schema validation > Add validation
+- Upload .yml/.yaml/.json (OpenAPI v3.0)
+- Endpoints auto-added to Endpoint Management
+- Action: Log/Block/None
+```
+
+**Change default action:**
+```
+Security > API Shield > Settings > Schema validation
+Per-endpoint: Filter → ellipses → Change action
+```
+
+**Fallthrough rule** (catch-all unknown endpoints):
+```
+Security > API Shield > Settings > Fallthrough > Use Template
+- Select hostnames
+- Create rule with cf.api_gateway.fallthrough_triggered
+```
+
+**Body inspection:** Supports `application/json`, `*/*`, `application/*`. Disable origin MIME sniffing to prevent bypasses.
+
+## JWT Validation
+
+**Setup token config:**
+```
+Security > API Shield > Settings > JWT Settings > Add configuration
+- Name: "Auth0 JWT Config"
+- Location: Header/Cookie + name (e.g., "Authorization")
+- JWKS: Paste public keys from IdP
+```
+
+**Create validation rule:**
+```
+Security > API Shield > API Rules > Add rule
+- Hostname: api.example.com
+- Deselect endpoints to ignore
+- Token config: Select config
+- Enforce presence: Ignore or Mark as non-compliant
+- Action: Log/Block/Challenge
+```
+
+**Rate limit by JWT claim:**
+```wirefilter
+lookup_json_string(http.request.jwt.claims["{config_id}"][0], "sub")
+```
+
+**Special cases:**
+- Two JWTs, different IdPs: Create 2 configs, select both, "Validate all"
+- IdP migration: 2 configs + 2 rules, adjust actions per state
+- Bearer prefix: API Shield handles with/without
+- Nested claims: Dot notation `user.email`
+
+## Mutual TLS (mTLS)
+
+**Setup:**
+```
+SSL/TLS > Client Certificates > Create Certificate
+- Generate CF-managed CA (all plans)
+- Upload custom CA (Enterprise, max 5)
+```
+
+**Configure mTLS rule:**
+```
+Security > API Shield > mTLS
+- Select hostname(s)
+- Choose certificate(s)
+- Action: Block/Log/Challenge
+```
+
+**Test:**
+```bash
+openssl req -x509 -newkey rsa:4096 -keyout client-key.pem -out client-cert.pem -days 365
+curl https://api.example.com/endpoint --cert client-cert.pem --key client-key.pem
+```
+
+## Session Identifiers
+
+Critical for Sequence Mitigation + analytics. Configure header/cookie that uniquely IDs API users.
+
+**Examples:** JWT sub claim, session token, API key, custom user ID header
+
+**Configure:**
+```
+Security > API Shield > Settings > Session Identifiers
+- Type: Header/Cookie
+- Name: "X-User-ID" or "Authorization"
+```
+
+## Terraform
+
+```hcl
+# Session identifier
+resource "cloudflare_api_shield" "main" {
+  zone_id = var.zone_id
+  auth_id_characteristics {
+    type = "header"
+    name = "Authorization"
+  }
+}
+
+# Add endpoint
+resource "cloudflare_api_shield_operation" "users_get" {
+  zone_id  = var.zone_id
+  method   = "GET"
+  host     = "api.example.com"
+  endpoint = "/api/users/{id}"
+}
+
+# JWT validation rule
+resource "cloudflare_ruleset" "jwt_validation" {
+  zone_id = var.zone_id
+  name    = "API JWT Validation"
+  kind    = "zone"
+  phase   = "http_request_firewall_custom"
+
+  rules {
+    action = "block"
+    expression = "(http.host eq \"api.example.com\" and not cf.api_gateway.jwt_claims_valid)"
+    description = "Block invalid JWTs"
+  }
+}
+```

--- a/.agent/services/hosting/cloudflare-platform/references/api-shield/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api-shield/gotchas.md
@@ -1,0 +1,51 @@
+# Gotchas & Troubleshooting
+
+## Schema Blocking Valid Reqs
+
+Firewall Events show violations? 1) Check details 2) Review schema (Settings) 3) Test Swagger Editor 4) Log mode 5) Update schema
+
+Validated: date-time,time,date,email,hostname,ipv4/6,uri(-reference),iri(-reference),int32/64,float,double,password,uuid,byte,uint64
+
+oneOf: Zero matches (missing discriminator), Multiple (ambiguous)
+
+## JWT Failing
+
+1) JWKS match IdP? 2) `exp` valid? 3) Header/cookie name? 4) Test jwt.io 5) Clock skew?
+
+## Discovery Missing
+
+Needs 500+ reqs/10d, 2xx from edge, not Workers direct. Check threshold, codes, session ID config. ML updates daily. Path norm: `/profile/238` → `/profile/{var1}`
+
+## Sequence False Positives
+
+Lookback: 10 reqs to managed endpoints, 10min (contact for adjust). Check session ID uniqueness, neg vs pos model
+
+## Perf
+
+Schema: ~1-2ms, JWT: ~0.5-1ms, mTLS: ~2-5ms, Sequence: ~0.5ms
+
+## Best Practices
+
+1. Discovery first (map before enforce)
+2. Progressive: Log → Block critical → Full
+3. Session IDs unique per user
+4. Validate schema (Swagger Editor)
+5. Automate JWKS rotation (Worker cron)
+6. Fallthrough rules (zombie APIs)
+7. Logpush + alerts
+8. Rate limit w/JWT claims
+9. Layer Bot Management
+10. Test staging
+
+## Limits
+
+Schema: OpenAPI v3.0.x only, no ext refs/non-basic paths, 10K ops, need `type`+`schema`, default `style`/`explode`, no `content` in params, no obj param validation, no `anyOf` in params
+JWT: Headers/cookies only, validates managed endpoints only
+Sequence (Beta): Needs endpoints+session ID, contact team
+
+## Errors
+
+"Token invalid": Config wrong, JWKS mismatch, expired
+"Schema violation": Missing fields, wrong types, spec mismatch
+"Fallthrough": Unknown endpoint, pattern mismatch
+"mTLS failed": Cert untrusted/expired, wrong CA

--- a/.agent/services/hosting/cloudflare-platform/references/api-shield/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api-shield/patterns.md
@@ -1,0 +1,145 @@
+# Patterns & Use Cases
+
+## Protect API with Schema + JWT
+
+```bash
+# 1. Upload OpenAPI schema
+POST /zones/{zone_id}/api_gateway/user_schemas
+
+# 2. Configure JWT validation
+POST /zones/{zone_id}/api_gateway/token_validation
+{
+  "name": "Auth0",
+  "location": {"header": "Authorization"},
+  "jwks": "{...}"
+}
+
+# 3. Create JWT rule
+POST /zones/{zone_id}/api_gateway/jwt_validation_rules
+
+# 4. Set schema validation action
+PUT /zones/{zone_id}/api_gateway/settings/schema_validation
+{"validation_default_mitigation_action": "block"}
+```
+
+## Progressive Rollout
+
+```
+1. Log mode: Observe false positives
+   - Schema: Action = Log
+   - JWT: Action = Log
+
+2. Block subset: Protect critical endpoints
+   - Change specific endpoint actions to Block
+   - Monitor firewall events
+
+3. Full enforcement: Block all violations
+   - Change default action to Block
+   - Handle fallthrough with custom rule
+```
+
+## Fallthrough Detection (Zombie APIs)
+
+```javascript
+// WAF Custom Rule
+(cf.api_gateway.fallthrough_triggered and http.host eq "api.example.com")
+// Action: Log (discover unknown) or Block (strict)
+```
+
+## Rate Limiting by User
+
+```javascript
+// Rate Limiting Rule
+(http.host eq "api.example.com" and
+ lookup_json_string(http.request.jwt.claims["{config_id}"][0], "sub") ne "")
+
+// Rate: 100 req/60s
+// Counting: lookup_json_string(http.request.jwt.claims["{config_id}"][0], "sub")
+```
+
+## Architecture Patterns
+
+### Public API (High Security)
+```
+Cloudflare Edge
+├── API Discovery (identify endpoints)
+├── Schema Validation (enforce OpenAPI)
+├── JWT Validation (verify tokens)
+├── Rate Limiting (per-user)
+├── Bot Management (filter abuse)
+└── Origin → API server
+```
+
+### Partner API (mTLS + Schema)
+```
+Cloudflare Edge
+├── mTLS (verify client certs)
+├── Schema Validation (validate payloads)
+├── Sequence Mitigation (enforce order)
+└── Origin → API server
+```
+
+### Internal API (Discovery + Monitoring)
+```
+Cloudflare Edge
+├── API Discovery (map shadow APIs)
+├── Schema Learning (auto-generate specs)
+├── Authentication Posture (audit coverage)
+└── Origin → API server
+```
+
+## OWASP API Security Top 10 Mapping
+
+| OWASP Issue | API Shield Solutions |
+|-------------|---------------------|
+| Broken Object Level Authorization | BOLA detection, Sequence mitigation, Schema, JWT, Rate Limiting |
+| Broken Authentication | Auth Posture, mTLS, JWT, Credential Checks, Bot Management |
+| Broken Object Property Auth | Schema validation, JWT validation |
+| Unrestricted Resource | Rate Limiting, Sequence, Bot Management, GraphQL protection |
+| Broken Function Level Auth | Schema validation, JWT validation |
+| Unrestricted Business Flows | Sequence mitigation, Bot Management, GraphQL |
+| SSRF | Schema, WAF managed rules, WAF custom |
+| Security Misconfiguration | Sequence, Schema, WAF managed, GraphQL |
+| Improper Inventory | Discovery, Schema learning |
+| Unsafe API Consumption | JWT validation, WAF managed |
+
+## Monitoring
+
+**Security Events:**
+```
+Security > Events
+Filter: Action = block, Service = API Shield
+```
+
+**Firewall Analytics:**
+```
+Analytics > Security
+Filter by cf.api_gateway.* fields
+```
+
+**Logpush fields:**
+```json
+{
+  "APIGatewayAuthIDPresent": true,
+  "APIGatewayRequestViolatesSchema": false,
+  "APIGatewayFallthroughDetected": false,
+  "JWTValidationResult": "valid",
+  "ClientCertFingerprint": "abc123..."
+}
+```
+
+## Availability
+
+| Feature | Availability |
+|---------|-------------|
+| mTLS (CF-managed CA) | All plans |
+| Endpoint Management | All plans (limited ops) |
+| Schema Validation | All plans (limited ops) |
+| API Discovery | Enterprise only |
+| JWT Validation | Enterprise (add-on) |
+| Sequence Mitigation | Enterprise (closed beta) |
+| BOLA Detection | Enterprise (add-on) |
+| Volumetric Abuse | Enterprise (add-on) |
+| Full Suite | Enterprise add-on |
+
+Enterprise: 10K ops (contact for higher), non-contract preview available.

--- a/.agent/services/hosting/cloudflare-platform/references/api/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api/README.md
@@ -1,0 +1,21 @@
+# Cloudflare API Integration Skill Reference
+
+Guide for working with Cloudflare's REST API - covering authentication, SDK usage, common patterns, and API categories.
+
+## When to Use This Skill
+
+Use when working with:
+- Cloudflare API authentication and tokens
+- Official Cloudflare SDKs (TypeScript, Python, Go)
+- Zone management, DNS, Workers, o...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/api/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api/api.md
@@ -1,0 +1,31 @@
+### API Token (Recommended)
+
+**Create token**: Dashboard → My Profile → API Tokens → Create Token
+
+```bash
+# Environment variable
+export CLOUDFLARE_API_TOKEN='your-token-here'
+
+# curl
+curl "https://api.cloudflare.com/client/v4/zones" \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+**Token scopes**: Always use minimal permissions
+- Zone-specific vs account-level
+- Read vs edit permissions
+- Time-limited tokens for CI/CD
+
+### API Key (Legacy - Not Recommended)
+
+```bash
+curl "https://api.cloudflare.com/client/v4/zones" \
+  --header "X-Auth-Email: user@example.com" \
+  --header "X-Auth-Key: $CLOUDFLARE_API_KEY"
+```
+
+**Limitations**:
+- Full account access (insecure)
+- Cannot scope permissions
+- No expiration
+- Use tokens instead

--- a/.agent/services/hosting/cloudflare-platform/references/api/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api/configuration.md
@@ -1,0 +1,20 @@
+## Wrangler CLI Integration
+
+Wrangler uses Cloudflare API internally:
+
+```bash
+# Configure authentication
+wrangler login
+# Or
+export CLOUDFLARE_API_TOKEN='token'
+
+# Common commands that use API
+wrangler deploy              # Uploads worker via API
+wrangler kv:key put          # KV operations
+wrangler r2 bucket create    # R2 operations
+wrangler d1 execute          # D1 operations
+wrangler pages deploy        # Pages operations
+
+# Get API configuration
+wrangler whoami              # Shows authenticated user
+```

--- a/.agent/services/hosting/cloudflare-platform/references/api/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api/gotchas.md
@@ -1,0 +1,28 @@
+## Best Practices
+
+### Security
+
+- **Never commit tokens**: Use environment variables
+- **Minimal permissions**: Create scoped API tokens
+- **Rotate tokens**: Regularly refresh tokens
+- **Use token expiration**: Set expiry dates
+- **Audit token usage**: Monitor API logs
+
+### Performance
+
+- **Batch operations**: Group related API calls
+- **Use pagination wisely**: Don't fetch all data if unnecessary
+- **Cache responses**: Store rarely-changing data locally
+- **Parallel requests**: Use `Promise.all()` for independent operations
+- **Handle rate limits**: Implement exponential backoff
+
+### Code organization
+
+```typescript
+// Create reusable client instance
+export const cfClient = new Cloudflare({
+  apiToken: process.env.CLOUDFLARE_API_TOKEN,
+});
+
+// Wrap common operations
+export async function

--- a/.agent/services/hosting/cloudflare-platform/references/api/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/api/patterns.md
@@ -1,0 +1,47 @@
+## Common API Categories
+
+### Zone Management
+
+```typescript
+// List zones (with filtering)
+const zones = await client.zones.list({
+  account: { id: 'account-id' },
+  status: 'active',
+});
+
+// Create zone
+const zone = await client.zones.create({
+  account: { id: 'account-id' },
+  name: 'example.com',
+  type: 'full', // or 'partial'
+});
+
+// Update zone
+await client.zones.edit('zone-id', {
+  paused: false,
+  vanity_name_servers: ['ns1.example.com', 'ns2.example.com'],
+});
+
+// Delete zone
+await client.zones.delete('zone-id');
+```
+
+### DNS Management
+
+```typescript
+// Create record
+await client.dns.records.create({
+  zone_id: 'zone-id',
+  type: 'A' | 'AAAA' | 'CNAME' | 'TXT' | 'MX' | 'SRV',
+  name: 'subdomain.example.com',
+  content: '192.0.2.1',
+  ttl: 1, // 1 = auto, or specific seconds
+  proxied: true, // Orange cloud
+  priority: 10, // For MX/SRV records
+});
+
+// List records (with filtering)
+const records = await client.dns.records.list({
+  zone_id: 'zone-id',
+  type: 'A',
+  name: 'exa

--- a/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/README.md
@@ -1,0 +1,16 @@
+# Cloudflare Argo Smart Routing Skill Reference
+
+## Overview
+
+Cloudflare Argo Smart Routing is a performance optimization service that detects real-time network issues and routes web traffic across the most efficient network path. This skill provides comprehensive guidance for implementing, configuring, and managing Argo Smart Routing via API, CLI...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/api.md
@@ -1,0 +1,50 @@
+## API Reference
+
+### Base Endpoint
+```
+https://api.cloudflare.com/client/v4
+```
+
+### Authentication
+Use API tokens with Zone:Argo Smart Routing:Edit permissions:
+
+```bash
+# Headers required
+X-Auth-Email: user@example.com
+Authorization: Bearer YOUR_API_TOKEN
+```
+
+### Get Argo Smart Routing Status
+
+**Endpoint:** `GET /zones/{zone_id}/argo/smart_routing`
+
+**Description:** Retrieves current Argo Smart Routing enablement status.
+
+**cURL Example:**
+```bash
+curl -X GET "https://api.cloudflare.com/client/v4/zones/{zone_id}/argo/smart_routing" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+**Response:**
+```json
+{
+  "result": {
+    "id": "smart_routing",
+    "value": "on",
+    "editable": true,
+    "modified_on": "2024-01-11T12:00:00Z"
+  },
+  "success": true,
+  "errors": [],
+  "messages": []
+}
+```
+
+**TypeScript SDK Example:**
+```typescript
+import Cloudflare from 'cloudflare';
+
+const client = new Cloudflare({
+  apiToken: process.env.CLOUDFLARE_API_TOKE

--- a/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/configuration.md
@@ -1,0 +1,53 @@
+## Configuration Management
+
+### Infrastructure as Code (Terraform)
+
+```hcl
+# terraform/argo.tf
+# Note: Use Cloudflare Terraform provider
+
+resource "cloudflare_argo" "example" {
+  zone_id        = var.zone_id
+  smart_routing  = "on"
+  tiered_caching = "on"
+}
+
+variable "zone_id" {
+  description = "Cloudflare Zone ID"
+  type        = string
+}
+
+output "argo_enabled" {
+  value       = cloudflare_argo.example.smart_routing
+  description = "Argo Smart Routing status"
+}
+```
+
+### Environment-Based Configuration
+
+```typescript
+// config/argo.ts
+interface ArgoEnvironmentConfig {
+  enabled: boolean;
+  tieredCache: boolean;
+  monitoring: {
+    usageAlerts: boolean;
+    threshold: number;
+  };
+}
+
+const configs: Record<string, ArgoEnvironmentConfig> = {
+  production: {
+    enabled: true,
+    tieredCache: true,
+    monitoring: {
+      usageAlerts: true,
+      threshold: 1000, // GB
+    },
+  },
+  staging: {
+    enabled: true,
+    tieredCache: false,
+    monitoring: {
+      usageAlerts: false,
+      th

--- a/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/gotchas.md
@@ -1,0 +1,16 @@
+## Best Practices Summary
+
+1. **Always check editability** before attempting to enable/disable Argo
+2. **Set up billing notifications** to avoid unexpected costs
+3. **Combine with Tiered Cache** for maximum performance benefit
+4. **Use in production only** - disable for dev/staging to control costs
+5. **Monitor analytics** - require 500+ requests in 48h for detailed metrics
+6. **Handle errors gracefully** - check for billing, permissions, zone compatibility
+7. **Test configuration changes** in staging before production
+8. **Use TypeScript SDK** for type safety and better developer experience
+9. **Implement retry logic** for API calls in production systems
+10. **Document zone-specific settings** for team visibility
+
+## Additional Resources
+
+- [Official Argo Smart Routing Docs](https://devel

--- a/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/argo-smart-routing/patterns.md
@@ -1,0 +1,45 @@
+## Integration with Tiered Cache
+
+Combine Argo Smart Routing with Tiered Cache for maximum performance:
+
+**Endpoint:** `PATCH /zones/{zone_id}/argo/tiered_caching`
+
+**Benefits:**
+- Argo optimizes routing between edge and origin
+- Tiered Cache reduces origin requests via cache hierarchy
+- Combined: optimal network path + reduced origin load
+
+**Enable Both Services:**
+```typescript
+async function enableArgoWithTieredCache(
+  client: Cloudflare,
+  zoneId: string
+) {
+  // Enable Argo Smart Routing
+  await client.argo.smartRouting.edit({
+    zone_id: zoneId,
+    value: 'on',
+  });
+
+  // Enable Tiered Caching
+  await client.argo.tieredCaching.edit({
+    zone_id: zoneId,
+    value: 'on',
+  });
+
+  console.log('Argo Smart Routing and Tiered Cache enabled');
+}
+```
+
+**Architecture Flow:**
+```
+Visitor → Edge Data Center (Lower-Tier)
+         ↓ [Cache Miss]
+         Upper-Tier Data Center
+         ↓ [Cache Miss + Argo Smart Route]
+         Origin Server
+```
+
+## Usage-Based Billing Management
+
+### S

--- a/.agent/services/hosting/cloudflare-platform/references/bindings/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bindings/README.md
@@ -1,0 +1,14 @@
+# Cloudflare Bindings Skill Reference
+
+Expert guidance on Cloudflare Workers Bindings - the runtime APIs that connect Workers to Cloudflare platform resources....
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/bindings/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bindings/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+See main documentation.

--- a/.agent/services/hosting/cloudflare-platform/references/bindings/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bindings/configuration.md
@@ -1,0 +1,58 @@
+## Wrangler Configuration Patterns
+
+### JSON vs TOML
+
+**JSON (Recommended for new projects):**
+```jsonc
+// wrangler.jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2024-01-01",
+  "vars": {
+    "API_URL": "https://api.example.com"
+  }
+}
+```
+
+**TOML (Legacy):**
+```toml
+# wrangler.toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[vars]
+API_URL = "https://api.example.com"
+```
+
+### Environment-Specific Configuration
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2024-01-01",
+  
+  // Production bindings
+  "vars": {
+    "ENV": "production"
+  },
+  "kv_namespaces": [
+    {
+      "binding": "CACHE",
+      "id": "prod-kv-id"
+    }
+  ],
+  
+  // Environment overrides
+  "env": {
+    "staging": {
+      "vars": {
+        "ENV": "staging"
+      },
+      "kv_namespaces": [
+        {
+          "binding": "CACHE",
+          "id": "staging-kv-id

--- a/.agent/services/hosting/cloudflare-platform/references/bindings/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bindings/gotchas.md
@@ -1,0 +1,35 @@
+## Troubleshooting
+
+### Binding Not Found
+```
+Error: env.MY_KV is undefined
+```
+**Solutions:**
+1. Check binding name matches config
+2. Run `npx wrangler types` to regenerate types
+3. Verify binding exists in current environment
+4. Check for typos in `wrangler.jsonc`
+
+### Type Errors
+```
+Property 'MY_KV' does not exist on type 'Env'
+```
+**Solution:** Run `npx wrangler types`
+
+### Preview Binding Required
+```
+Error: preview_id is required for --remote
+```
+**Solution:** Add preview_id to config or use local mode
+
+### Stale Binding Values
+```
+Secret updated but Worker still uses old value
+```
+**Solution:** Avoid caching `env` values in global scope
+
+## Security Best Practices
+
+1. **Never commit secrets to config files**
+   - Use `npx wrangler secret put` for sensitive values
+   - Secrets are e

--- a/.agent/services/hosting/cloudflare-platform/references/bindings/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bindings/patterns.md
@@ -1,0 +1,37 @@
+## Common Anti-Patterns
+
+### ❌ Hardcoding Credentials
+```typescript
+// DON'T
+const apiKey = 'sk_live_abc123';
+```
+**✅ Use secrets:**
+```bash
+npx wrangler secret put API_KEY
+```
+
+### ❌ Using REST API from Worker
+```typescript
+// DON'T
+await fetch('https://api.cloudflare.com/client/v4/accounts/.../kv/...');
+```
+**✅ Use bindings:**
+```typescript
+await env.MY_KV.get('key');
+```
+
+### ❌ Polling KV/D1 for Changes
+```typescript
+// DON'T
+setInterval(() => {
+  const config = await env.KV.get('config');
+}, 1000);
+```
+**✅ Use Durable Objects for real-time state**
+
+### ❌ Storing Large Data in env.vars
+```typescript
+// DON'T
+{ "vars": { "HUGE_CONFIG": "..." } } // Max 5KB per var
+```
+**✅ Use KV/R2 for large data**

--- a/.agent/services/hosting/cloudflare-platform/references/bot-management/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bot-management/README.md
@@ -1,0 +1,71 @@
+# Cloudflare Bot Management
+
+Enterprise-grade bot detection, protection, and mitigation using ML/heuristics, bot scores, JavaScript detections, and verified bot handling.
+
+## Overview
+
+Bot Management provides multi-tier protection:
+- **Free (Bot Fight Mode)**: Auto-blocks definite bots, no config
+- **Pro/Business (Super Bot Fight Mode)**: Configurable actions, static resource protection, analytics groupings
+- **Enterprise (Bot Management)**: Granular 1-99 scores, WAF integration, JA3/JA4 fingerprinting, Workers API, Advanced Analytics
+
+## Quick Start
+
+```txt
+# Dashboard: Security > Bots
+# Enterprise: Deploy rule template
+(cf.bot_management.score eq 1 and not cf.bot_management.verified_bot) → Block
+(cf.bot_management.score le 29 and not cf.bot_management.verified_bot) → Managed Challenge
+```
+
+## Core Concepts
+
+**Bot Scores**: 1-99 (1 = definitely automated, 99 = definitely human). Threshold: <30 indicates bot traffic. Enterprise gets granular 1-99; Pro/Business get groupings only.
+
+**Detection Engines**: Heuristics (known fingerprints, assigns score=1), ML (majority of detections, supervised learning on billions of requests), Anomaly Detection (optional, baseline traffic analysis), JavaScript Detections (headless browser detection).
+
+**Verified Bots**: Allowlisted good bots (search engines, AI crawlers) verified via reverse DNS or Web Bot Auth. Access via `cf.bot_management.verified_bot` or `cf.verified_bot_category`.
+
+## Platform Limits
+
+| Plan | Bot Scores | JA3/JA4 | Custom Rules | Analytics Retention |
+|------|------------|---------|--------------|---------------------|
+| Free | No (auto-block only) | No | 5 | N/A (no analytics) |
+| Pro/Business | Groupings only | No | 20/100 | 30 days (72h at a time) |
+| Enterprise | 1-99 granular | Yes | 1,000+ | 30 days (1 week at a time) |
+
+## Basic Patterns
+
+```typescript
+// Workers: Check bot score
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const botScore = request.cf?.botManagement?.score;
+    if (botScore && botScore < 30 && !request.cf?.botManagement?.verifiedBot) {
+      return new Response('Bot detected', { status: 403 });
+    }
+    return fetch(request);
+  }
+};
+```
+
+```txt
+# WAF: Block definite bots
+(cf.bot_management.score eq 1 and not cf.bot_management.verified_bot)
+
+# WAF: Protect sensitive endpoints
+(cf.bot_management.score lt 50 and http.request.uri.path in {"/login" "/checkout"} and not cf.bot_management.verified_bot)
+```
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - Product tiers, WAF rule setup, JavaScript Detections, ML auto-updates
+- [api.md](./api.md) - Workers BotManagement interface, WAF fields, JA4 Signals
+- [patterns.md](./patterns.md) - E-commerce, API protection, mobile app allowlisting, SEO-friendly handling
+- [gotchas.md](./gotchas.md) - False positives/negatives, score=0 issues, JSD limitations, CSP requirements
+
+## See Also
+
+- [waf](../waf/) - WAF custom rules for bot enforcement
+- [workers](../workers/) - Workers request.cf.botManagement API
+- [api-shield](../api-shield/) - API-specific bot protection

--- a/.agent/services/hosting/cloudflare-platform/references/bot-management/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bot-management/api.md
@@ -1,0 +1,168 @@
+# Bot Management API
+
+## Workers: BotManagement Interface
+
+```typescript
+interface BotManagement {
+  score: number;              // 1-99 (Enterprise), 0 if not computed
+  verifiedBot: boolean;       // Is verified bot
+  staticResource: boolean;    // Serves static resource
+  ja3Hash: string;            // JA3 fingerprint (Enterprise, HTTPS only)
+  ja4: string;                // JA4 fingerprint (Enterprise, HTTPS only)
+  jsDetection?: {
+    passed: boolean;          // Passed JS detection (if enabled)
+  };
+  detectionIds: number[];     // Heuristic detection IDs
+  corporateProxy?: boolean;   // From corporate proxy (Enterprise)
+}
+
+// Access via request.cf
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const cf = request.cf as any;
+    const botMgmt = cf?.botManagement;
+    
+    if (!botMgmt) return fetch(request);
+    if (botMgmt.verifiedBot) return fetch(request); // Allow verified bots
+    if (botMgmt.score === 1) return new Response('Blocked', { status: 403 });
+    if (botMgmt.score < 30) return new Response('Challenge required', { status: 429 });
+    
+    return fetch(request);
+  }
+};
+```
+
+## WAF Fields Reference
+
+```txt
+# Score fields
+cf.bot_management.score                    # 0-99 (0 = not computed)
+cf.bot_management.verified_bot             # boolean
+cf.bot_management.static_resource          # boolean
+cf.bot_management.ja3_hash                 # string (Enterprise)
+cf.bot_management.ja4                      # string (Enterprise)
+cf.bot_management.detection_ids            # array
+cf.bot_management.js_detection.passed      # boolean
+cf.bot_management.corporate_proxy          # boolean (Enterprise)
+cf.verified_bot_category                   # string
+
+# Workers equivalent
+request.cf.botManagement.score
+request.cf.botManagement.verifiedBot
+request.cf.botManagement.ja3Hash
+request.cf.botManagement.ja4
+request.cf.botManagement.jsDetection.passed
+request.cf.verifiedBotCategory
+```
+
+## JA4 Signals (Enterprise)
+
+```typescript
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const cf = request.cf as any;
+    const ja4Signals = cf?.ja4Signals;
+    
+    if (!ja4Signals) return fetch(request); // Not available for HTTP or Worker routing
+    
+    // Check for anomalous behavior
+    const heuristicRatio = ja4Signals.heuristic_ratio_1h ?? 0;
+    const browserRatio = ja4Signals.browser_ratio_1h ?? 0;
+    
+    if (heuristicRatio > 0.5 || browserRatio < 0.3) {
+      return new Response('Suspicious traffic', { status: 403 });
+    }
+    
+    return fetch(request);
+  }
+};
+```
+
+## Common Patterns
+
+### Mobile App Pattern
+```typescript
+const MOBILE_APP_JA4 = 'your_mobile_app_ja4_fingerprint';
+
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const cf = request.cf as any;
+    const botMgmt = cf?.botManagement;
+    
+    if (botMgmt?.ja4 === MOBILE_APP_JA4) return fetch(request); // Allow mobile app
+    if (botMgmt?.score && botMgmt.score < 30) return new Response('Bot detected', { status: 403 });
+    
+    return fetch(request);
+  }
+};
+```
+
+### Corporate Proxy Exemption
+```typescript
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const cf = request.cf as any;
+    const botMgmt = cf?.botManagement;
+    
+    if (botMgmt?.corporateProxy) return fetch(request); // Exempt corporate proxy traffic
+    if (botMgmt?.score && botMgmt.score < 30 && !botMgmt.verifiedBot) {
+      return new Response('Bot detected', { status: 403 });
+    }
+    
+    return fetch(request);
+  }
+};
+```
+
+### Log Bot Data
+```typescript
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const cf = request.cf as any;
+    const botMgmt = cf?.botManagement;
+    
+    console.log({
+      score: botMgmt?.score,
+      verifiedBot: botMgmt?.verifiedBot,
+      ja3Hash: botMgmt?.ja3Hash,
+      ja4: botMgmt?.ja4,
+      detectionIds: botMgmt?.detectionIds,
+      jsDetection: botMgmt?.jsDetection?.passed,
+      corporateProxy: botMgmt?.corporateProxy,
+    });
+    
+    return fetch(request);
+  }
+};
+```
+
+## Bot Analytics
+
+### Access Locations
+- Dashboard: Security > Bots (old) or Security > Analytics > Bot analysis (new)
+- GraphQL API for programmatic access
+- Security Events & Security Analytics
+- Logpush/Logpull
+
+### Available Data
+- **Enterprise BM**: Bot scores (1-99), bot score source, distribution
+- **Pro/Business**: Bot groupings (automated, likely automated, likely human)
+- Top attributes: IPs, paths, user agents, countries
+- Detection sources: Heuristics, ML, AD, JSD
+- Verified bot categories
+
+### Time Ranges
+- **Enterprise BM**: Up to 1 week at a time, 30 days history
+- **Pro/Business**: Up to 72 hours at a time, 30 days history
+- Real-time in most cases, adaptive sampling (1-10% depending on volume)
+
+## Logpush Fields
+
+```txt
+BotScore              # 1-99 or 0 if not computed
+BotScoreSrc           # Detection engine (ML, Heuristics, etc.)
+BotTags               # Classification tags
+BotDetectionIDs       # Heuristic detection IDs
+```
+
+Access via Logpush (stream to cloud storage/SIEM), Logpull (API to fetch logs), or GraphQL API (query analytics data).

--- a/.agent/services/hosting/cloudflare-platform/references/bot-management/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bot-management/configuration.md
@@ -1,0 +1,114 @@
+# Bot Management Configuration
+
+## Product Tiers
+
+### Bot Fight Mode (Free)
+- Auto-blocks definite bots (score=1), excludes verified bots by default
+- JavaScript Detections always enabled, no configuration options
+
+### Super Bot Fight Mode (Pro/Business)
+```txt
+Dashboard: Security > Bots > Configure
+- Definitely automated: Block/Challenge
+- Likely automated: Challenge/Allow  
+- Verified bots: Allow (recommended)
+- Static resource protection: ON (may block mail clients)
+- JavaScript Detections: Optional
+```
+
+### Bot Management for Enterprise
+```txt
+Dashboard: Security > Bots > Configure > Auto-updates: ON (recommended)
+
+# Template 1: Block definite bots
+(cf.bot_management.score eq 1 and not cf.bot_management.verified_bot and not cf.bot_management.static_resource)
+Action: Block
+
+# Template 2: Challenge likely bots
+(cf.bot_management.score ge 2 and cf.bot_management.score le 29 and not cf.bot_management.verified_bot and not cf.bot_management.static_resource)
+Action: Managed Challenge
+```
+
+## JavaScript Detections Setup
+
+### Enable via Dashboard
+```txt
+Security > Bots > Configure Bot Management > JS Detections: ON
+
+Update CSP: script-src 'self' /cdn-cgi/challenge-platform/;
+```
+
+### Manual JS Injection (API)
+```html
+<script>
+function jsdOnload() {
+  window.cloudflare.jsd.executeOnce({ callback: function(result) { console.log('JSD:', result); } });
+}
+</script>
+<script src="/cdn-cgi/challenge-platform/scripts/jsd/api.js?onload=jsdOnload" async></script>
+```
+
+**Use API for**: Selective deployment on specific pages  
+**Don't combine**: Zone-wide toggle + manual injection
+
+### WAF Rules for JSD
+```txt
+# NEVER use on first page visit (needs HTML page first)
+(not cf.bot_management.js_detection.passed and http.request.uri.path eq "/api/user/create" and http.request.method eq "POST" and not cf.bot_management.verified_bot)
+Action: Managed Challenge (always use Managed Challenge, not Block)
+```
+
+### Limitations
+- First request won't have JSD data (needs HTML page first)
+- Strips ETags from HTML responses
+- Not supported with CSP via `<meta>` tags
+- Websocket endpoints not supported
+- Native mobile apps won't pass
+- cf_clearance cookie: 15-minute lifespan, max 4096 bytes
+
+## Static Resource Protection
+
+**File Extensions**: ico, jpg, png, jpeg, gif, css, js, tif, tiff, bmp, pict, webp, svg, svgz, class, jar, txt, csv, doc, docx, xls, xlsx, pdf, ps, pls, ppt, pptx, ttf, otf, woff, woff2, eot, eps, ejs, swf, torrent, midi, mid, m3u8, m4a, mp3, ogg, ts  
+**Plus**: `/.well-known/` path (all files)
+
+```txt
+# Exclude static resources from bot rules
+(cf.bot_management.score lt 30 and not cf.bot_management.static_resource)
+```
+
+**WARNING**: May block mail clients fetching static images
+
+## JA3/JA4 Fingerprinting (Enterprise)
+
+```txt
+# Block specific attack fingerprint
+(cf.bot_management.ja3_hash eq "8b8e3d5e3e8b3d5e")
+
+# Allow mobile app by fingerprint
+(cf.bot_management.ja4 eq "your_mobile_app_fingerprint")
+```
+
+Only available for HTTPS/TLS traffic. Missing for Worker-routed traffic or HTTP requests.
+
+## Verified Bot Categories
+
+```txt
+# Allow search engines only
+(cf.verified_bot_category eq "Search Engine Crawler")
+
+# Block AI crawlers
+(cf.verified_bot_category eq "AI Crawler")
+Action: Block
+
+# Or use dashboard: Security > Settings > Bot Management > Block AI Bots
+```
+
+Categories: Search Engine Crawler, AI Crawler, Monitoring & Analytics, Aggregator, Security Intelligence, Academic Research
+
+## Best Practices
+
+- **ML Auto-Updates**: Enable on Enterprise for latest models
+- **Start with Managed Challenge**: Test before blocking
+- **Always exclude verified bots**: Use `not cf.bot_management.verified_bot`
+- **Exempt corporate proxies**: For B2B traffic via `cf.bot_management.corporate_proxy`
+- **Use static resource exception**: Improves performance, reduces overhead

--- a/.agent/services/hosting/cloudflare-platform/references/bot-management/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bot-management/gotchas.md
@@ -1,0 +1,99 @@
+# Bot Management Gotchas
+
+## Bot Score = 0
+
+**Cause**: Bot Management didn't run  
+**Reasons**: Internal Cloudflare request, Worker routing to zone (Orange-to-Orange), Request handled before BM (Redirect Rules, etc.)  
+**Solution**: Check request flow, ensure BM runs in request lifecycle
+
+## JavaScript Detections Not Working
+
+**Issue**: `js_detection.passed` always false or undefined  
+**Causes**:
+1. CSP headers don't allow `/cdn-cgi/challenge-platform/`
+2. Using on first page visit (needs HTML page first)
+3. Ad blockers or disabled JS
+4. JSD not enabled in dashboard
+5. Using Block action (must use Managed Challenge)
+
+**CSP Fix**:
+```txt
+Content-Security-Policy: script-src 'self' /cdn-cgi/challenge-platform/;
+```
+
+## False Positives
+
+**Issue**: Legitimate users blocked  
+**Solutions**:
+1. Check Bot Analytics for affected IPs/paths
+2. Identify detection source (ML, Heuristics, etc.)
+3. Create exception rule:
+```txt
+(cf.bot_management.score lt 30 and http.request.uri.path eq "/problematic-path")
+Action: Skip (Bot Management)
+```
+4. Or allowlist by IP/ASN/country
+
+## False Negatives (Bots Not Caught)
+
+**Issue**: Bots bypassing detection  
+**Solutions**:
+1. Lower score threshold (30 → 50)
+2. Enable JavaScript Detections
+3. Add JA3/JA4 fingerprinting rules
+4. Use rate limiting as fallback
+
+## Verified Bot Blocked
+
+**Issue**: Search engine bot blocked  
+**Causes**: WAF Managed Rules (not just Bot Management), Yandex bot during IP update (48h)  
+**Solution**: Create WAF exception for specific rule ID, verify bot via reverse DNS
+
+## JA3/JA4 Missing
+
+**Issue**: `ja3Hash` or `ja4` is undefined  
+**Causes**: Non-HTTPS traffic, Worker routing traffic, Orange-to-Orange traffic via Worker, Bot Management skipped  
+**Solution**: Only available for HTTPS/TLS traffic; check request routing
+
+## Bot Score Limitations
+
+- Score = 0 means **not computed** (not score = 100)
+- First request may not have JSD data
+- Score doesn't guarantee 100% accuracy
+- False positives/negatives possible
+
+## JavaScript Detections Limitations
+
+- Doesn't work on first HTML page visit
+- Requires JavaScript-enabled browser
+- Strips ETags from HTML responses
+- Not compatible with some CSP configurations
+- Not supported via `<meta>` CSP tags
+- Websocket endpoints not supported
+- Native mobile apps won't pass
+
+## JA3/JA4 Fingerprint Limitations
+
+- Only available for HTTPS/TLS traffic
+- Missing for Worker-routed traffic
+- Not unique per user (shared by clients with same browser/library)
+- Can change with browser/library updates
+
+## Plan Restrictions
+
+| Feature | Free | Pro/Business | Enterprise |
+|---------|------|--------------|------------|
+| Granular scores (1-99) | No | No | Yes |
+| JA3/JA4 | No | No | Yes |
+| Anomaly Detection | No | No | Yes |
+| Corporate Proxy detection | No | No | Yes |
+| Verified bot categories | Limited | Limited | Full |
+| Custom WAF rules | 5 | 20/100 | 1,000+ |
+
+## Technical Constraints
+
+- Max 25 WAF custom rules on Free (varies by plan)
+- Workers CPU time limits apply to bot logic
+- Bot Analytics sampling (1-10%)
+- 30-day maximum history
+- CSP requirements for JSD (must allow `/cdn-cgi/challenge-platform/`)

--- a/.agent/services/hosting/cloudflare-platform/references/bot-management/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/bot-management/patterns.md
@@ -1,0 +1,125 @@
+# Bot Management Patterns
+
+## E-commerce Protection
+
+```txt
+# High security for checkout
+(cf.bot_management.score lt 50 and http.request.uri.path in {"/checkout" "/cart/add"} and not cf.bot_management.verified_bot and not cf.bot_management.corporate_proxy)
+Action: Managed Challenge
+```
+
+## API Protection
+
+```txt
+# Protect API with JS detection + score
+(http.request.uri.path matches "^/api/" and (cf.bot_management.score lt 30 or not cf.bot_management.js_detection.passed) and not cf.bot_management.verified_bot)
+Action: Block
+```
+
+## SEO-Friendly Bot Handling
+
+```txt
+# Allow search engine crawlers
+(cf.bot_management.score lt 30 and not cf.verified_bot_category in {"Search Engine Crawler"})
+Action: Managed Challenge
+```
+
+## Block AI Scrapers
+
+```txt
+# Block AI training bots
+(cf.verified_bot_category eq "AI Crawler")
+Action: Block
+
+# Or use dashboard: Security > Settings > Bot Management > Block AI Bots
+```
+
+## Rate Limiting by Bot Score
+
+```txt
+# Stricter limits for suspicious traffic
+(cf.bot_management.score lt 50)
+Rate: 10 requests per 10 seconds
+
+(cf.bot_management.score ge 50)
+Rate: 100 requests per 10 seconds
+```
+
+## Mobile App Allowlisting
+
+```txt
+# Identify mobile app by JA3/JA4
+(cf.bot_management.ja4 in {"fingerprint1" "fingerprint2"})
+Action: Skip (all remaining rules)
+```
+
+## Layered Defense
+
+```txt
+1. Bot Management (score-based)
+2. JavaScript Detections (for JS-capable clients)
+3. Rate Limiting (fallback protection)
+4. WAF Managed Rules (OWASP, etc.)
+```
+
+## Progressive Enhancement
+
+```txt
+Public content: High threshold (score < 10)
+Authenticated: Medium threshold (score < 30)
+Sensitive: Low threshold (score < 50) + JSD
+```
+
+## Zero Trust for Bots
+
+```txt
+1. Default deny (all scores < 30)
+2. Allowlist verified bots
+3. Allowlist mobile apps (JA3/JA4)
+4. Allowlist corporate proxies
+5. Allowlist static resources
+```
+
+## Workers: Score + JS Detection
+
+```typescript
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const cf = request.cf as any;
+    const botMgmt = cf?.botManagement;
+    const url = new URL(request.url);
+    
+    if (botMgmt?.staticResource) return fetch(request); // Skip static
+    
+    // API endpoints: require JS detection + good score
+    if (url.pathname.startsWith('/api/')) {
+      const jsDetectionPassed = botMgmt?.jsDetection?.passed ?? false;
+      const score = botMgmt?.score ?? 100;
+      
+      if (!jsDetectionPassed || score < 30) {
+        return new Response('Unauthorized', { status: 401 });
+      }
+    }
+    
+    return fetch(request);
+  }
+};
+```
+
+## Rate Limiting by JWT Claim + Bot Score
+
+```txt
+# Enterprise: Combine bot score with JWT validation
+Rate limiting > Custom rules
+- Field: lookup_json_string(http.request.jwt.claims["{config_id}"][0], "sub")
+- Matches: user ID claim
+- Additional condition: cf.bot_management.score lt 50
+```
+
+## WAF Integration Points
+
+- **WAF Custom Rules**: Primary enforcement mechanism
+- **Rate Limiting Rules**: Bot score as dimension, stricter limits for low scores
+- **Transform Rules**: Pass score to origin via custom header
+- **Workers**: Programmatic bot logic, custom scoring algorithms
+- **Page Rules / Configuration Rules**: Zone-level overrides, path-specific settings

--- a/.agent/services/hosting/cloudflare-platform/references/browser-rendering/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/browser-rendering/README.md
@@ -1,0 +1,16 @@
+# Cloudflare Browser Rendering Skill Reference
+
+**Description**: Expert knowledge for Cloudflare Browser Rendering - control headless Chrome on Cloudflare's global network for browser automation, screenshots, PDFs, web scraping, testing, and content generation.
+
+**When to use**: Any task involving Cloudflare Browser Rendering including: taking sc...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/browser-rendering/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/browser-rendering/api.md
@@ -1,0 +1,54 @@
+## API Quick Reference
+
+### Puppeteer
+```typescript
+// Browser
+puppeteer.launch(env.MYBROWSER, opts?)
+puppeteer.connect(env.MYBROWSER, sessionId)
+puppeteer.sessions() // List open
+puppeteer.history()  // View closed
+puppeteer.limits()   // Check quotas
+
+browser.newPage()
+browser.close()
+browser.createIncognitoBrowserContext()
+
+// Page
+page.goto(url)
+page.content()
+page.screenshot()
+page.pdf()
+page.evaluate(fn)
+page.metrics()
+page.setUserAgent(ua)
+page.type(selector, text)
+page.click(selector)
+page.select(selector, value)
+```
+
+### Playwright
+```typescript
+// Browser
+launch(env.MYBROWSER, opts?)
+connect(env.MYBROWSER, sessionId)
+acquire(env.MYBROWSER) // Get new sessionId
+playwright.sessions()
+playwright.history()
+playwright.limits()
+
+browser.newPage()
+browser.newContext(opts?)
+browser.close()
+
+// Page
+page.goto(url)
+page.content()
+page.screenshot()
+page.getByTestId(id)
+page.getByPlaceholder(text)
+page.locator(selector)
+page.fill(selector, value)
+page.press(selector, key)
+
+// Context
+con

--- a/.agent/services/hosting/cloudflare-platform/references/browser-rendering/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/browser-rendering/configuration.md
@@ -1,0 +1,47 @@
+### Wrangler Configuration
+```jsonc
+{
+  "name": "browser-worker",
+  "main": "src/index.js",
+  "compatibility_date": "2023-03-14",
+  "compatibility_flags": ["nodejs_compat"],
+  "browser": {
+    "binding": "MYBROWSER"
+  }
+}
+```
+
+### Basic Pattern
+```typescript
+import puppeteer from "@cloudflare/puppeteer";
+
+interface Env {
+  MYBROWSER: Fetcher;
+}
+
+export default {
+  async fetch(request, env): Promise<Response> {
+    const browser = await puppeteer.launch(env.MYBROWSER);
+    const page = await browser.newPage();
+    
+    try {
+      await page.goto("https://example.com");
+      const metrics = await page.metrics();
+      return Response.json(metrics);
+    } finally {
+      await browser.close(); // ALWAYS close in finally block
+    }
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+### Keep-Alive Sessions
+```javascript
+// Default: 60 seconds idle timeout
+// Max: 10 minutes (600000 ms)
+const browser = await puppeteer.launch(env.MYBROWSER, { 
+  keep_alive: 600000 
+});
+```
+
+### Session Reuse Patt

--- a/.agent/services/hosting/cloudflare-platform/references/browser-rendering/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/browser-rendering/gotchas.md
@@ -1,0 +1,29 @@
+## Best Practices
+
+### Always Close Browsers
+```typescript
+// ❌ BAD - Session stays open until timeout
+const browser = await puppeteer.launch(env.MYBROWSER);
+const page = await browser.newPage();
+await page.goto("https://example.com");
+return new Response(await page.content());
+
+// ✅ GOOD - Always use try/finally
+const browser = await puppeteer.launch(env.MYBROWSER);
+try {
+  const page = await browser.newPage();
+  await page.goto("https://example.com");
+  return new Response(await page.content());
+} finally {
+  await browser.close(); // Ensures cleanup even on errors
+}
+```
+
+### Optimize Concurrency
+Instead of launching multiple browsers:
+- Use multiple tabs in single browser
+- Reuse sessions with session IDs
+- Use incognito contexts for isolation without new browsers
+
+```typescript
+// ❌ BA

--- a/.agent/services/hosting/cloudflare-platform/references/browser-rendering/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/browser-rendering/patterns.md
@@ -1,0 +1,29 @@
+## Integration Methods
+
+### 1. REST API
+**Best for**: Simple, stateless, one-off tasks
+
+**Authentication**: Requires API Token with `Browser Rendering - Edit` permissions
+
+**Base URL**: `https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/`
+
+**Available endpoints**:
+- `/content` - Fetch rendered HTML
+- `/screenshot` - Capture screenshots (PNG/JPEG)
+- `/pdf` - Generate PDFs
+- `/snapshot` - Webpage snapshots
+- `/scrape` - Extract HTML elements with selectors
+- `/json` - Extract structured data using AI
+- `/links` - Retrieve all links from page
+- `/markdown` - Convert page to markdown
+
+**Usage monitoring**: Response header `X-Browser-Ms-Used` reports browser time (milliseconds)
+
+**Example - Take screenshot**:
+```bash
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<accountId>/browser-rendering/screenshot' \
+  -H 'Authorization: Bearer <apiToken>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "url": "https://example.com",
+    "screenshotOptions":

--- a/.agent/services/hosting/cloudflare-platform/references/c3/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/c3/README.md
@@ -1,0 +1,264 @@
+# Cloudflare C3 (create-cloudflare) Skill
+
+Expert guidance for using C3, the official CLI tool for scaffolding Cloudflare projects.
+
+## What is C3?
+
+C3 (`create-cloudflare`) is Cloudflare's CLI for project initialization. Creates Workers, Pages, and full-stack applications with templates, TypeScript, and instant deployment.
+
+## Installation & Usage
+
+```bash
+# NPM
+npm create cloudflare@latest
+
+# Yarn
+yarn create cloudflare
+
+# PNPM
+pnpm create cloudflare@latest
+
+# With project name
+npm create cloudflare@latest my-app
+
+# With template
+npm create cloudflare@latest -- --template=cloudflare/templates/workers-template
+```
+
+## Common Templates
+
+### Workers
+
+```bash
+# Basic Worker
+npm create cloudflare@latest -- --template=worker
+
+# TypeScript Worker
+npm create cloudflare@latest -- --template=worker-typescript
+
+# Durable Objects
+npm create cloudflare@latest -- --template=hello-world-do-template
+```
+
+### Full-Stack Apps
+
+```bash
+# Next.js
+npm create cloudflare@latest -- --template=next-starter-template
+
+# React Router
+npm create cloudflare@latest -- --template=react-router-starter-template
+
+# Remix
+npm create cloudflare@latest -- --template=remix-starter-template
+
+# Astro
+npm create cloudflare@latest -- --template=astro-blog-starter-template
+```
+
+### Database & Storage
+
+```bash
+# D1 SQLite
+npm create cloudflare@latest -- --template=d1-template
+
+# R2 Explorer
+npm create cloudflare@latest -- --template=r2-explorer-template
+
+# Postgres + Hyperdrive
+npm create cloudflare@latest -- --template=postgres-hyperdrive-template
+```
+
+### AI & ML
+
+```bash
+# Workers AI Chat
+npm create cloudflare@latest -- --template=llm-chat-app-template
+
+# Text-to-Image
+npm create cloudflare@latest -- --template=text-to-image-template
+```
+
+### Real-time & Multiplayer
+
+```bash
+# Chat with Durable Objects
+npm create cloudflare@latest -- --template=durable-chat-template
+
+# Multiplayer Globe
+npm create cloudflare@latest -- --template=multiplayer-globe-template
+```
+
+## Interactive Mode
+
+```bash
+npm create cloudflare@latest my-app
+```
+
+C3 prompts for:
+1. Application type (Website/API/scheduled worker/etc.)
+2. Framework choice (if applicable)
+3. TypeScript preference
+4. Git initialization
+5. Deployment option
+
+## Non-Interactive Mode
+
+```bash
+npm create cloudflare@latest my-worker \
+  --type=web-app \
+  --framework=next \
+  --ts \
+  --git \
+  --deploy
+```
+
+### Flags
+
+- `--type` - Application type: `web-app`, `hello-world`, `pre-existing`, `remote-template`
+- `--framework` - Framework: `next`, `remix`, `astro`, `react-router`, `solid`, `svelte`, etc.
+- `--template` - GitHub template URL or path
+- `--ts` / `--no-ts` - TypeScript
+- `--git` / `--no-git` - Initialize git repo
+- `--deploy` / `--no-deploy` - Deploy after creation
+- `--open` - Open in browser after deploy
+- `--existing-script` - Path to existing Worker script
+
+## CI/CD Usage
+
+```yaml
+# GitHub Actions
+- name: Create Cloudflare Project
+  run: |
+    npm create cloudflare@latest my-app -- \
+      --type=web-app \
+      --framework=next \
+      --ts \
+      --no-git \
+      --no-deploy
+```
+
+## Custom Templates
+
+```bash
+# From GitHub repo
+npm create cloudflare@latest -- --template=user/repo
+
+# From local path
+npm create cloudflare@latest -- --template=../my-template
+
+# From Cloudflare official templates
+npm create cloudflare@latest -- --template=cloudflare/templates/workers-template
+```
+
+## Project Structure Created
+
+```
+my-app/
+├── src/
+│   └── index.ts       # Worker entry point
+├── wrangler.toml      # Configuration
+├── package.json
+├── tsconfig.json
+└── README.md
+```
+
+## Post-Creation
+
+```bash
+cd my-app
+
+# Local development
+npm run dev
+
+# Deploy
+npm run deploy
+
+# Type check
+npm run cf-typegen
+```
+
+## wrangler.toml Configuration
+
+C3 generates:
+
+```toml
+name = "my-app"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+# Bindings added based on template
+[[kv_namespaces]]
+binding = "MY_KV"
+id = "..."
+
+[[d1_databases]]
+binding = "DB"
+database_id = "..."
+```
+
+## Best Practices
+
+1. **Use latest C3:** `npm create cloudflare@latest`
+2. **Choose TypeScript** for type safety
+3. **Enable git** for version control
+4. **Review generated wrangler.toml** before first deploy
+5. **Update dependencies** post-creation: `npm update`
+
+## Common Workflows
+
+### Quick Worker
+
+```bash
+npm create cloudflare@latest my-worker -- --type=hello-world --ts --deploy
+```
+
+### Full-Stack App with D1
+
+```bash
+npm create cloudflare@latest my-app -- \
+  --template=react-router-starter-template \
+  --ts \
+  --git
+cd my-app
+npx wrangler d1 create my-db
+# Add to wrangler.toml, then:
+npm run deploy
+```
+
+### Convert Existing Project
+
+```bash
+cd existing-project
+npm create cloudflare@latest . -- --existing-script=./dist/index.js
+```
+
+## Troubleshooting
+
+### `npm create cloudflare failed`
+
+- Ensure Node.js 16.13+
+- Clear npm cache: `npm cache clean --force`
+- Try with `npx`: `npx create-cloudflare@latest`
+
+### Template not found
+
+- Verify template name/path
+- Check network connection
+- Use full GitHub URL: `https://github.com/user/repo`
+
+### Deployment fails
+
+- Check Cloudflare account authentication: `wrangler login`
+- Verify `wrangler.toml` configuration
+- Check for naming conflicts in dashboard
+
+## Reference
+
+- [C3 GitHub](https://github.com/cloudflare/workers-sdk/tree/main/packages/create-cloudflare)
+- [Templates Repository](https://github.com/cloudflare/templates)
+- [Workers Docs](https://developers.cloudflare.com/workers/)
+
+---
+
+This skill focuses exclusively on C3 CLI tool usage. For Workers development, see `cloudflare-workers` skill.

--- a/.agent/services/hosting/cloudflare-platform/references/cache-reserve/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cache-reserve/README.md
@@ -1,0 +1,93 @@
+# Cloudflare Cache Reserve
+
+**Persistent cache storage built on R2 for long-term content retention**
+
+## Overview
+
+Cache Reserve is Cloudflare's persistent, large-scale cache storage layer built on R2. It acts as the ultimate upper-tier cache, storing cacheable content for extended periods (30+ days) to maximize cache hits, reduce origin egress fees, and shield origins from repeated requests for long-tail content.
+
+## Core Concepts
+
+### What is Cache Reserve?
+
+- **Persistent storage layer**: Built on R2, sits above tiered cache hierarchy
+- **Long-term retention**: 30-day default retention, extended on each access
+- **Automatic operation**: Works seamlessly with existing CDN, no code changes required
+- **Origin shielding**: Dramatically reduces origin egress by serving cached content longer
+- **Usage-based pricing**: Pay only for storage + read/write operations
+
+### Cache Hierarchy
+
+```
+Visitor Request
+    ↓
+Lower-Tier Cache (closest to visitor)
+    ↓ (on miss)
+Upper-Tier Cache (closest to origin)
+    ↓ (on miss)
+Cache Reserve (R2 persistent storage)
+    ↓ (on miss)
+Origin Server
+```
+
+### How It Works
+
+1. **On cache miss**: Content fetched from origin �� written to Cache Reserve + edge caches simultaneously
+2. **On edge eviction**: Content may be evicted from edge cache but remains in Cache Reserve
+3. **On subsequent request**: If edge cache misses but Cache Reserve hits → content restored to edge caches
+4. **Retention**: Assets remain in Cache Reserve for 30 days since last access (configurable via TTL)
+
+## Asset Eligibility
+
+Cache Reserve only stores assets meeting **ALL** criteria:
+
+- Cacheable per Cloudflare's standard rules
+- Minimum 10-hour TTL (36000 seconds)
+- `Content-Length` header present
+- Original files only (not transformed images)
+
+### Not Eligible
+
+- Assets with TTL < 10 hours
+- Responses without `Content-Length` header
+- Image transformation variants (original images are eligible)
+- Responses with `Set-Cookie` headers
+- Responses with `Vary: *` header
+- Assets from R2 public buckets on same zone
+- O2O (Orange-to-Orange) setup requests
+
+## Quick Start
+
+```bash
+# Enable via Dashboard
+https://dash.cloudflare.com/caching/cache-reserve
+# Click "Enable Storage Sync" or "Purchase" button
+```
+
+**Prerequisites:**
+- Paid Cache Reserve plan required
+- Tiered Cache strongly recommended
+
+## Essential Commands
+
+```bash
+# Check Cache Reserve status
+curl -X GET "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/cache/cache_reserve" \
+  -H "Authorization: Bearer $API_TOKEN"
+
+# Enable Cache Reserve
+curl -X PATCH "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/cache/cache_reserve" \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"value": "on"}'
+
+# Check asset cache status
+curl -I https://example.com/asset.jpg | grep -i cache
+```
+
+## See Also
+
+- [Configuration](./configuration.md) - Setup, API, and Cache Rules
+- [API Reference](./api.md) - Purging, monitoring, and management APIs
+- [Patterns](./patterns.md) - Best practices and architecture patterns
+- [Gotchas](./gotchas.md) - Common issues, troubleshooting, limits

--- a/.agent/services/hosting/cloudflare-platform/references/cache-reserve/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cache-reserve/api.md
@@ -1,0 +1,176 @@
+# Cache Reserve API
+
+## Workers Integration
+
+Cache Reserve works automatically with Workers Cache API, but requires specific patterns:
+
+### Standard Fetch (Recommended)
+
+```typescript
+// Cache Reserve works automatically via standard fetch
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // Standard fetch uses Cache Reserve automatically
+    return await fetch(request);
+  }
+};
+```
+
+### Cache API Limitations
+
+**IMPORTANT**: `cache.put()` is **NOT compatible** with Cache Reserve or Tiered Cache.
+
+```typescript
+// ❌ WRONG: cache.put() bypasses Cache Reserve
+const cache = caches.default;
+let response = await cache.match(request);
+if (!response) {
+  response = await fetch(request);
+  await cache.put(request, response.clone()); // Bypasses Cache Reserve!
+}
+
+// ✅ CORRECT: Use standard fetch for Cache Reserve compatibility
+return await fetch(request);
+
+// ✅ CORRECT: Use Cache API only for custom cache namespaces
+const customCache = await caches.open('my-custom-cache');
+let response = await customCache.match(request);
+if (!response) {
+  response = await fetch(request);
+  await customCache.put(request, response.clone()); // Custom cache OK
+}
+```
+
+## Purging and Cache Management
+
+### Purge by URL (Instant)
+
+```typescript
+// Purge specific URL from Cache Reserve immediately
+const purgeCacheReserveByURL = async (
+  zoneId: string,
+  apiToken: string,
+  urls: string[]
+) => {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ files: urls })
+    }
+  );
+  return await response.json();
+};
+
+// Example usage
+await purgeCacheReserveByURL('zone123', 'token456', [
+  'https://example.com/image.jpg',
+  'https://example.com/video.mp4'
+]);
+```
+
+### Purge by Tag/Host/Prefix (Revalidation)
+
+```typescript
+// Purge by cache tag - forces revalidation, not immediate removal
+const purgeCacheReserveByTag = async (
+  zoneId: string,
+  apiToken: string,
+  tags: string[]
+) => {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ tags })
+    }
+  );
+  return await response.json();
+};
+
+// Note: Assets remain in Cache Reserve but will revalidate on next request
+// Storage costs continue until retention TTL expires
+```
+
+**Important purge behavior differences:**
+
+- **Purge by URL**: Immediately removes from Cache Reserve + edge cache
+- **Purge by tag/host/prefix**: Forces revalidation but assets remain in storage
+- **Storage costs**: Continue for tag/host/prefix purges until TTL expiry
+
+### Clear All Cache Reserve Data
+
+```typescript
+// Clear ALL Cache Reserve data (requires Cache Reserve to be OFF)
+const clearAllCacheReserve = async (zoneId: string, apiToken: string) => {
+  // Step 1: Verify Cache Reserve is off
+  const statusResponse = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${zoneId}/cache/cache_reserve`,
+    { method: 'GET', headers: { 'Authorization': `Bearer ${apiToken}` } }
+  );
+  const status = await statusResponse.json();
+  
+  if (status.result.value !== 'off') {
+    throw new Error('Cache Reserve must be OFF before clearing data');
+  }
+  
+  // Step 2: Clear Cache Reserve data
+  const clearResponse = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${zoneId}/cache/cache_reserve_clear`,
+    { method: 'POST', headers: { 'Authorization': `Bearer ${apiToken}` } }
+  );
+  return await clearResponse.json();
+};
+
+// Check clear status
+const getClearStatus = async (zoneId: string, apiToken: string) => {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${zoneId}/cache/cache_reserve_clear`,
+    { method: 'GET', headers: { 'Authorization': `Bearer ${apiToken}` } }
+  );
+  return await response.json();
+  // Returns: { state: "In-progress" | "Completed", start_ts: "..." }
+};
+```
+
+**Clear process:**
+1. Disable Cache Reserve (`value: 'off'`)
+2. Call cache_reserve_clear endpoint
+3. Deletion takes up to 24 hours
+4. Re-enable Cache Reserve when ready
+
+## Monitoring and Analytics
+
+```typescript
+// Dashboard: egress savings, requests served (hits/misses), storage, operations (A/B)
+// Logpush field: CacheReserveUsed (boolean) - filter for Cache Reserve hits
+
+// Query Cache Reserve hits
+const query = `
+  SELECT ClientRequestHost, COUNT(*) as requests, SUM(EdgeResponseBytes) as bytes
+  FROM http_requests WHERE CacheReserveUsed = true
+  GROUP BY ClientRequestHost ORDER BY requests DESC
+`;
+```
+
+## Pricing
+
+```typescript
+// Storage: $0.015/GB-month | Class A (writes): $4.50/M | Class B (reads): $0.36/M
+// Cache miss: 1A + 1B | Cache hit: 1B | Assets >1GB: proportionally more ops
+```
+
+## See Also
+
+- [README](./README.md) - Overview and core concepts
+- [Configuration](./configuration.md) - Setup and Cache Rules
+- [Patterns](./patterns.md) - Best practices and optimization
+- [Gotchas](./gotchas.md) - Common issues and troubleshooting

--- a/.agent/services/hosting/cloudflare-platform/references/cache-reserve/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cache-reserve/configuration.md
@@ -1,0 +1,164 @@
+# Cache Reserve Configuration
+
+## Dashboard Setup
+
+**Minimum steps to enable:**
+
+```bash
+# Navigate to dashboard
+https://dash.cloudflare.com/caching/cache-reserve
+
+# Click "Enable Storage Sync" or "Purchase" button
+```
+
+**Prerequisites:**
+- Paid Cache Reserve plan required
+- Tiered Cache strongly recommended (Cache Reserve checks for this)
+
+## API Configuration
+
+```typescript
+// Enable Cache Reserve
+const enableCacheReserve = async (zoneId: string, apiToken: string) => {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${zoneId}/cache/cache_reserve`,
+    {
+      method: 'PATCH',
+      headers: {
+        'Authorization': `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ value: 'on' })
+    }
+  );
+  return await response.json();
+};
+
+// Check Cache Reserve status
+const getCacheReserveStatus = async (zoneId: string, apiToken: string) => {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${zoneId}/cache/cache_reserve`,
+    {
+      method: 'GET',
+      headers: { 'Authorization': `Bearer ${apiToken}` }
+    }
+  );
+  return await response.json();
+};
+```
+
+### Required API Token Permissions
+
+- `Zone Settings Read`
+- `Zone Settings Write`
+- `Zone Read`
+- `Zone Write`
+
+## Cache Rules Integration
+
+Control Cache Reserve eligibility via Cache Rules:
+
+```typescript
+// Enable Cache Reserve for static assets with long TTL
+const staticAssetRule = {
+  action: 'set_cache_settings',
+  action_parameters: {
+    cache_reserve: {
+      eligible: true,
+      minimum_file_ttl: 86400 // 24 hours
+    },
+    edge_ttl: {
+      mode: 'override_origin',
+      default: 86400
+    },
+    cache: true
+  },
+  expression: '(http.request.uri.path matches "\\.(jpg|jpeg|png|gif|webp|pdf|zip)$")'
+};
+
+// Disable Cache Reserve for frequently updated content
+const dynamicContentRule = {
+  action: 'set_cache_settings',
+  action_parameters: {
+    cache_reserve: { eligible: false }
+  },
+  expression: '(http.request.uri.path matches "^/api/")'
+};
+
+// Cache Reserve for specific origin with minimum 12-hour TTL
+const specificOriginRule = {
+  action: 'set_cache_settings',
+  action_parameters: {
+    cache_reserve: {
+      eligible: true,
+      minimum_file_ttl: 43200 // 12 hours
+    },
+    edge_ttl: { mode: 'override_origin', default: 43200 },
+    cache: true
+  },
+  expression: '(http.host eq "cdn.example.com")'
+};
+```
+
+### Creating Rules via API
+
+```typescript
+const createCacheRule = async (
+  zoneId: string,
+  apiToken: string,
+  rule: CacheRuleWithReserve
+) => {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/zones/${zoneId}/rulesets/phases/http_request_cache_settings/entrypoint`,
+    {
+      method: 'PUT',
+      headers: {
+        'Authorization': `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ rules: [rule] })
+    }
+  );
+  return await response.json();
+};
+```
+
+## Wrangler Integration
+
+Cache Reserve works automatically with Workers deployed via Wrangler. No special configuration needed.
+
+```jsonc
+// wrangler.jsonc
+{
+  "name": "cache-reserve-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-01-11", // Use current date for new projects
+  
+  // Cache Reserve works automatically with standard routes
+  "routes": [
+    { "pattern": "example.com/*", "zone_name": "example.com" }
+  ]
+  // No special Cache Reserve configuration needed
+  // Enable via Dashboard or API
+}
+```
+
+### Development and Testing
+
+```bash
+# Local development (Cache Reserve not active locally)
+npx wrangler dev
+
+# Deploy to production (Cache Reserve active if enabled for zone)
+npx wrangler deploy
+
+# View logs (including cache behavior)
+npx wrangler tail
+```
+
+## See Also
+
+- [README](./README.md) - Overview and core concepts
+- [API Reference](./api.md) - Purging and monitoring APIs
+- [Patterns](./patterns.md) - Best practices and optimization
+- [Gotchas](./gotchas.md) - Common issues and troubleshooting

--- a/.agent/services/hosting/cloudflare-platform/references/cache-reserve/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cache-reserve/gotchas.md
@@ -1,0 +1,203 @@
+# Cache Reserve Gotchas
+
+## Common Issues and Solutions
+
+### Issue: Assets Not Being Cached in Cache Reserve
+
+**Diagnostics:**
+
+```typescript
+const debugEligibility = {
+  checks: [
+    'Verify asset is cacheable (cf-cache-status header)',
+    'Check TTL >= 10 hours',
+    'Confirm Content-Length header present',
+    'Review Cache Rules configuration',
+    'Check for Set-Cookie or Vary: * headers'
+  ],
+  
+  tools: [
+    'curl -I https://example.com/asset.jpg',
+    'Check cf-cache-status header',
+    'Review Cloudflare Trace output',
+    'Check Logpush CacheReserveUsed field'
+  ]
+};
+```
+
+**Solutions:**
+
+```typescript
+// 1. Ensure minimum TTL (10+ hours)
+response.headers.set('Cache-Control', 'public, max-age=36000');
+
+// Or via Cache Rule:
+const rule = {
+  action_parameters: {
+    edge_ttl: { mode: 'override_origin', default: 36000 }
+  }
+};
+
+// 2. Add Content-Length
+response.headers.set('Content-Length', bodySize.toString());
+
+// 3. Remove blocking headers
+response.headers.delete('Set-Cookie');
+response.headers.set('Vary', 'Accept-Encoding'); // Not *
+```
+
+### Issue: High Class A Operations Costs
+
+**Cause**: Frequent cache misses, short TTLs, or frequent revalidation
+
+**Solutions:**
+
+```typescript
+// 1. Increase TTL for stable content
+const optimizedTTL = {
+  before: 3600,  // 1 hour (not eligible)
+  after: 86400   // 24 hours (eligible + fewer rewrites)
+};
+
+// 2. Enable Tiered Cache (reduces direct Cache Reserve misses)
+
+// 3. Use stale-while-revalidate (via fetch, not cache.put)
+response.headers.set(
+  'Cache-Control',
+  'public, max-age=86400, stale-while-revalidate=86400'
+);
+```
+
+### Issue: Purge Not Working as Expected
+
+**Understanding purge behavior:**
+
+```typescript
+const purgeBehavior = {
+  byURL: {
+    cacheReserve: 'Immediately removed',
+    edgeCache: 'Immediately removed',
+    cost: 'Free'
+  },
+  
+  byTag: {
+    cacheReserve: 'Revalidation triggered, NOT removed',
+    edgeCache: 'Immediately removed',
+    storage: 'Continues until TTL expires',
+    cost: 'Storage costs continue'
+  }
+};
+
+// Solution: Use purge by URL for immediate removal
+await purgeByURL(['https://example.com/asset.jpg']);
+
+// Or: Disable + clear for complete removal
+await disableCacheReserve(zoneId, token);
+await clearAllCacheReserve(zoneId, token);
+```
+
+### Issue: Cache Reserve Disabled But Can't Clear
+
+**Error**: "Cache Reserve must be OFF before clearing data"
+
+**Solution:**
+
+```typescript
+const clearProcess = async (zoneId: string, token: string) => {
+  // Step 1: Check current state
+  const status = await getCacheReserveStatus(zoneId, token);
+  
+  // Step 2: Disable if enabled
+  if (status.result.value !== 'off') {
+    await disableCacheReserve(zoneId, token);
+  }
+  
+  // Step 3: Wait briefly for propagation
+  await new Promise(resolve => setTimeout(resolve, 5000));
+  
+  // Step 4: Clear data
+  const clearResult = await clearAllCacheReserve(zoneId, token);
+  
+  // Step 5: Monitor clear progress (can take up to 24 hours)
+  let clearStatus;
+  do {
+    await new Promise(resolve => setTimeout(resolve, 60000));
+    clearStatus = await getClearStatus(zoneId, token);
+  } while (clearStatus.result.state === 'In-progress');
+};
+```
+
+## Troubleshooting
+
+### Diagnostic Commands
+
+```bash
+# Check Cache Reserve status
+curl -X GET "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/cache/cache_reserve" \
+  -H "Authorization: Bearer $API_TOKEN" | jq
+
+# Check asset cache status
+curl -I https://example.com/asset.jpg | grep -i cache
+```
+
+### Common Header Patterns
+
+```typescript
+// Successful: HIT + max-age >= 36000 + content-length present
+// Not eligible: TTL < 10hrs | missing content-length | has set-cookie | vary: *
+```
+
+## Limits
+
+### Minimum Requirements Checklist
+
+- [ ] Paid Cache Reserve plan active
+- [ ] Tiered Cache enabled (strongly recommended)
+- [ ] Assets cacheable per standard rules
+- [ ] TTL >= 10 hours (36000 seconds)
+- [ ] Content-Length header present
+- [ ] No Set-Cookie header (or using private directive)
+- [ ] No Vary: * header
+- [ ] Not an image transformation variant
+
+### Key Limits
+
+```typescript
+const limits = {
+  minTTL: 36000,              // 10 hours in seconds
+  retentionDefault: 2592000,  // 30 days in seconds
+  maxFileSize: Infinity,      // Same as R2 limits
+  purgeClearTime: 86400000,   // Up to 24 hours in milliseconds
+};
+```
+
+### API Endpoints
+
+```typescript
+const endpoints = {
+  status: 'GET /zones/:zone_id/cache/cache_reserve',
+  enable: 'PATCH /zones/:zone_id/cache/cache_reserve',
+  disable: 'PATCH /zones/:zone_id/cache/cache_reserve',
+  clear: 'POST /zones/:zone_id/cache/cache_reserve_clear',
+  clearStatus: 'GET /zones/:zone_id/cache/cache_reserve_clear',
+  purge: 'POST /zones/:zone_id/purge_cache',
+  cacheRules: 'PUT /zones/:zone_id/rulesets/phases/http_request_cache_settings/entrypoint'
+};
+```
+
+## Additional Resources
+
+- **Official Docs**: https://developers.cloudflare.com/cache/advanced-configuration/cache-reserve/
+- **API Reference**: https://developers.cloudflare.com/api/resources/cache/subresources/cache_reserve/
+- **Cache Rules**: https://developers.cloudflare.com/cache/how-to/cache-rules/
+- **Workers Cache API**: https://developers.cloudflare.com/workers/runtime-apis/cache/
+- **R2 Documentation**: https://developers.cloudflare.com/r2/
+- **Smart Shield**: https://developers.cloudflare.com/smart-shield/
+- **Tiered Cache**: https://developers.cloudflare.com/cache/how-to/tiered-cache/
+
+## See Also
+
+- [README](./README.md) - Overview and core concepts
+- [Configuration](./configuration.md) - Setup and Cache Rules
+- [API Reference](./api.md) - Purging and monitoring
+- [Patterns](./patterns.md) - Best practices and optimization

--- a/.agent/services/hosting/cloudflare-platform/references/cache-reserve/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cache-reserve/patterns.md
@@ -1,0 +1,180 @@
+# Cache Reserve Patterns
+
+## Best Practices
+
+### 1. Always Enable Tiered Cache
+
+```typescript
+// Cache Reserve is designed for use WITH Tiered Cache
+const configuration = {
+  tieredCache: 'enabled',    // Required for optimal performance
+  cacheReserve: 'enabled',   // Works best with Tiered Cache
+  
+  hierarchy: [
+    'Lower-Tier Cache (visitor)',
+    'Upper-Tier Cache (origin region)',
+    'Cache Reserve (persistent)',
+    'Origin'
+  ]
+};
+```
+
+### 2. Set Appropriate Cache-Control Headers
+
+```typescript
+// Origin response headers for Cache Reserve eligibility
+const originHeaders = {
+  'Cache-Control': 'public, max-age=86400', // 24 hours minimum 10 hours
+  'Content-Length': '1024000', // Required for eligibility
+  'Cache-Tag': 'images,product-123', // Optional: For purging
+  'ETag': '"abc123"', // Optional: Support revalidation
+  'Last-Modified': 'Wed, 21 Oct 2025 07:28:00 GMT',
+  
+  // Avoid: Prevents caching
+  // 'Set-Cookie': 'session=xyz',  // Remove or use private directive
+  // 'Vary': '*',                  // Not compatible
+};
+```
+
+### 3. Use Cache Rules for Fine-Grained Control
+
+```typescript
+// Different TTLs for different content types
+const cacheRules = [
+  {
+    description: 'Long-term cache for immutable assets',
+    expression: '(http.request.uri.path matches "^/static/.*\\.[a-f0-9]{8}\\.")',
+    action_parameters: {
+      cache_reserve: { eligible: true },
+      edge_ttl: { mode: 'override_origin', default: 2592000 }, // 30 days
+      cache: true
+    }
+  },
+  {
+    description: 'Moderate cache for regular images',
+    expression: '(http.request.uri.path matches "\\.(jpg|png|webp)$")',
+    action_parameters: {
+      cache_reserve: { eligible: true },
+      edge_ttl: { mode: 'override_origin', default: 86400 }, // 24 hours
+      cache: true
+    }
+  },
+  {
+    description: 'Exclude API from Cache Reserve',
+    expression: '(http.request.uri.path matches "^/api/")',
+    action_parameters: { cache_reserve: { eligible: false }, cache: false }
+  }
+];
+```
+
+### 4. Ensuring Cache Reserve Eligibility in Workers
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const response = await fetch(request);
+    
+    if (response.ok) {
+      const headers = new Headers(response.headers);
+      
+      // Set minimum 10-hour cache
+      headers.set('Cache-Control', 'public, max-age=36000');
+      
+      // Remove Set-Cookie if present (prevents caching)
+      headers.delete('Set-Cookie');
+      
+      // Ensure Content-Length is present
+      if (!headers.has('Content-Length')) {
+        const blob = await response.blob();
+        headers.set('Content-Length', blob.size.toString());
+        
+        return new Response(blob, {
+          status: response.status,
+          statusText: response.statusText,
+          headers
+        });
+      }
+      
+      return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers
+      });
+    }
+    
+    return response;
+  }
+};
+```
+
+### 5. Hostname Best Practices
+
+```typescript
+// ✅ CORRECT: Use Worker's hostname for efficient caching
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return await fetch(request); // Keep the Worker's hostname
+  }
+};
+
+// ❌ WRONG: Overriding hostname causes unnecessary DNS lookups
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    url.hostname = 'different-host.com'; // Avoid this!
+    return await fetch(url.toString());
+  }
+};
+```
+
+## Architecture Patterns
+
+### Multi-Tier Caching + Immutable Assets
+
+```typescript
+// Optimal: L1 (visitor) → L2 (region) → L3 (Cache Reserve) → Origin
+// Each miss backfills all upstream layers
+
+// Immutable asset optimization with content hashing
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const isImmutable = /\.[a-f0-9]{8,}\.(js|css|jpg|png|woff2)$/.test(url.pathname);
+    
+    const response = await fetch(request);
+    
+    if (isImmutable) {
+      const headers = new Headers(response.headers);
+      headers.set('Cache-Control', 'public, max-age=31536000, immutable'); // 1 year
+      return new Response(response.body, { status: response.status, headers });
+    }
+    
+    return response;
+  }
+};
+```
+
+## Cost Optimization
+
+```typescript
+// Typical savings: 50-80% reduction in origin egress
+// Origin cost (AWS: $0.09/GB) vs Cache Reserve ($0.015/GB-month + $0.36/M reads)
+
+// 1. Set appropriate TTLs
+const optimizeTTL = {
+  tooShort: 3600,    // 1 hour - not eligible
+  optimal: 86400,    // 24 hours - reduces rewrites
+  tooLong: 2592000   // 30 days - use cautiously
+};
+
+// 2. Cache high-value, stable assets: images, media, fonts, archives
+// 3. Exclude frequently changing: /api/, user-specific, JSON data
+// 4. Note: Cache Reserve requests uncompressed from origin, compresses for visitors
+```
+
+## See Also
+
+- [README](./README.md) - Overview and core concepts
+- [Configuration](./configuration.md) - Setup and Cache Rules
+- [API Reference](./api.md) - Purging and monitoring
+- [Gotchas](./gotchas.md) - Common issues and troubleshooting

--- a/.agent/services/hosting/cloudflare-platform/references/containers/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/containers/README.md
@@ -1,0 +1,16 @@
+# Cloudflare Containers Skill Reference
+
+**APPLIES TO: Cloudflare Containers ONLY - NOT general Cloudflare Workers**
+
+Use when working with Cloudflare Containers: deploying containerized apps on Workers platform, configuring container-enabled Durable Objects, managing container lifecycle, or implementing stateful/stateless container patter...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/containers/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/containers/api.md
@@ -1,0 +1,43 @@
+### HTTP Requests
+
+**Default port (recommended):**
+```typescript
+// Uses defaultPort from Container class
+const container = env.MY_CONTAINER.getByName("id");
+const response = await container.fetch(request);
+```
+
+**Specific port:**
+```typescript
+const port = this.ctx.container.getTcpPort(8080);
+const response = await port.fetch("http://container/api", {
+  method: "POST",
+  body: JSON.stringify(data)
+});
+```
+
+### TCP Connections
+
+```typescript
+const port = this.ctx.container.getTcpPort(8080);
+const conn = port.connect('10.0.0.1:8080');
+await conn.opened;
+
+try {
+  if (request.body) {
+    await request.body.pipeTo(conn.writable);
+  }
+  return new Response(conn.readable);
+} catch (err) {
+  return new Response("Failed to proxy", { status: 502 });
+}
+```
+
+### WebSocket Forwarding
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env) {
+    const upgradeHeader = request.headers.get("Upgrade");
+    if (upgradeHeader === "websocket") {
+      const container = env.MY_CONTAINER.g

--- a/.agent/services/hosting/cloudflare-platform/references/containers/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/containers/configuration.md
@@ -1,0 +1,56 @@
+## Wrangler Configuration
+
+### Basic Container Config
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-01-10",
+  "containers": [
+    {
+      "class_name": "MyContainer",
+      "image": "./Dockerfile",  // or path to directory with Dockerfile
+      "max_instances": 10
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "MY_CONTAINER",
+        "class_name": "MyContainer"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["MyContainer"]  // Must use new_sqlite_classes
+    }
+  ]
+}
+```
+
+### TOML Format
+
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2026-01-10"
+
+[[containers]]
+class_name = "MyContainer"
+image = "./Dockerfile"
+max_instances = 10
+
+[[durable_objects.bindings]]
+name = "MY_CONTAINER"
+class_name = "MyContainer"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["MyContainer"]
+```
+
+Key config requirements:
+- `image` - Path to Dockerfile or directory conta

--- a/.agent/services/hosting/cloudflare-platform/references/containers/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/containers/gotchas.md
@@ -1,0 +1,21 @@
+## Best Practices
+
+1. **Use `@cloudflare/containers` package** - Cleaner API than raw Durable Object methods
+
+2. **Set appropriate `sleepAfter`** - Balance resource usage vs cold start latency
+   - Short-lived jobs: "5m"
+   - Session-based: "30m" - "2h"
+   - Long-running services: "2h" or longer
+
+3. **Choose routing pattern based on use case:**
+   - Stateless services → `getRandom()` load balancing
+   - Stateful sessions → `getByName()` with session/user ID
+   - Short-lived jobs → Unique IDs with explicit lifecycle control
+
+4. **Pass secrets securely:**
+   - Use Worker Secrets or Secret Store, not hard-coded values
+   - Read KV/secrets asynchronously when starting containers
+   - Don't log sensitive environment variables
+
+5. **Design for container restarts:**
+   - Containers can stop after

--- a/.agent/services/hosting/cloudflare-platform/references/containers/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/containers/patterns.md
@@ -1,0 +1,40 @@
+## Common Use Cases
+
+### Stateful Backend (Session-based)
+
+```typescript
+import { Container } from "@cloudflare/containers";
+
+export class SessionBackend extends Container {
+  defaultPort = 3000;
+  sleepAfter = "30m";
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    const { sessionId } = await request.json();
+    // Each session gets dedicated container instance
+    const container = env.SESSION_BACKEND.getByName(sessionId);
+    return container.fetch(request);
+  }
+}
+```
+
+### Short-Lived Code Execution
+
+```typescript
+export class CodeSandbox extends Container {
+  defaultPort = 8080;
+  sleepAfter = "5m";  // Quick cleanup
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    const { code, executionId } = await request.json();
+    
+    const container = env.CODE_SANDBOX.getByName(executionId);
+    await container.startAndWaitForPorts({
+      startOptions: {
+        envVars: {
+          USER_CODE: Buffer.from(code).toString('base64'),
+          TIMEOUT: "3

--- a/.agent/services/hosting/cloudflare-platform/references/cron-triggers/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cron-triggers/README.md
@@ -1,0 +1,85 @@
+# Cloudflare Cron Triggers
+
+Schedule Workers execution using cron expressions. Runs on Cloudflare's global network during underutilized periods.
+
+## Key Features
+
+- **UTC-only execution** - All schedules run on UTC time
+- **5-field cron syntax** - Quartz scheduler extensions (L, W, #)
+- **Global propagation** - 15min deployment delay
+- **At-least-once delivery** - Rare duplicate executions possible
+- **Workflow integration** - Trigger long-running multi-step tasks
+
+## Cron Syntax
+
+```
+ ┌─────────── minute (0-59)
+ │ ┌───────── hour (0-23)
+ │ │ ┌─────── day of month (1-31)
+ │ │ │ ┌───── month (1-12, JAN-DEC)
+ │ │ │ │ ┌─── day of week (1-7, SUN-SAT, 1=Sunday)
+ * * * * *
+```
+
+**Special chars:** `*` (any), `,` (list), `-` (range), `/` (step), `L` (last), `W` (weekday), `#` (nth)
+
+## Common Schedules
+
+```bash
+*/5 * * * *        # Every 5 minutes
+0 * * * *          # Hourly
+0 2 * * *          # Daily 2am UTC (off-peak)
+0 9 * * MON-FRI    # Weekdays 9am UTC
+0 0 1 * *          # Monthly 1st midnight UTC
+0 9 L * *          # Last day of month 9am UTC
+0 10 * * MON#2     # 2nd Monday 10am UTC
+*/10 9-17 * * MON-FRI  # Every 10min, 9am-5pm weekdays
+```
+
+## Quick Start
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "name": "my-cron-worker",
+  "triggers": {
+    "crons": ["*/5 * * * *", "0 2 * * *"]
+  }
+}
+```
+
+**Handler:**
+```typescript
+export default {
+  async scheduled(
+    controller: ScheduledController,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    console.log("Cron:", controller.cron);
+    console.log("Time:", new Date(controller.scheduledTime));
+    
+    ctx.waitUntil(asyncTask(env)); // Non-blocking
+  },
+};
+```
+
+**Test locally:**
+```bash
+npx wrangler dev
+curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*"
+```
+
+## Limits
+
+- **Free:** 3 triggers/worker, 10ms CPU
+- **Paid:** Unlimited triggers, 50ms CPU
+- **Propagation:** 15min global deployment
+- **Timezone:** UTC only
+
+## See Also
+
+- [configuration.md](./configuration.md) - wrangler config, env-specific schedules
+- [api.md](./api.md) - ScheduledController, handler params
+- [patterns.md](./patterns.md) - Use cases, batch processing, monitoring
+- [gotchas.md](./gotchas.md) - Timezone issues, debugging, limits

--- a/.agent/services/hosting/cloudflare-platform/references/cron-triggers/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cron-triggers/api.md
@@ -1,0 +1,198 @@
+# Cron Triggers API
+
+## Basic Handler
+
+```typescript
+interface Env {
+  // Bindings (KV, R2, D1, secrets, etc.)
+}
+
+export default {
+  async scheduled(
+    controller: ScheduledController,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<void> {
+    console.log("Cron executed:", new Date(controller.scheduledTime));
+  },
+};
+```
+
+```javascript
+export default {
+  async scheduled(controller, env, ctx) {
+    console.log("Cron executed:", new Date(controller.scheduledTime));
+  },
+};
+```
+
+```python
+from workers import WorkerEntrypoint
+
+class Default(WorkerEntrypoint):
+    async def scheduled(self, controller, env, ctx):
+        print(f"Cron executed: {controller.scheduledTime}")
+```
+
+## ScheduledController
+
+```typescript
+interface ScheduledController {
+  scheduledTime: number;  // Unix ms when scheduled to run
+  cron: string;           // Expression that triggered (e.g., "*/5 * * * *")
+  type: string;           // Always "scheduled"
+}
+```
+
+**Parse time:**
+```typescript
+const date = new Date(controller.scheduledTime);
+console.log(date.toISOString());
+```
+
+## Handler Parameters
+
+**`controller: ScheduledController`**
+- Access cron expression and scheduled time
+
+**`env: Env`**
+- All bindings: KV, R2, D1, secrets, service bindings
+
+**`ctx: ExecutionContext`**
+- `ctx.waitUntil(promise)` - Extend execution for async tasks (logging, cleanup, external APIs)
+- First `waitUntil` failure recorded in Cron Events
+
+## Multiple Schedules Pattern
+
+```typescript
+import { Hono } from "hono";
+
+interface Env {
+  MY_KV: KVNamespace;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+app.get("/", (c) => c.text("API Running"));
+
+export default {
+  fetch: app.fetch,
+
+  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext) {
+    switch (controller.cron) {
+      case "*/3 * * * *":
+        ctx.waitUntil(updateRecentData(env));
+        break;
+      
+      case "0 * * * *":
+        ctx.waitUntil(processHourlyAggregation(env));
+        break;
+      
+      case "0 2 * * *":
+        ctx.waitUntil(performDailyMaintenance(env));
+        break;
+      
+      default:
+        console.warn(`Unhandled cron: ${controller.cron}`);
+    }
+  },
+};
+```
+
+## ctx.waitUntil Usage
+
+Non-blocking async tasks:
+
+```typescript
+export default {
+  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext) {
+    // Critical path - runs immediately
+    const data = await fetchCriticalData();
+    
+    // Non-blocking background tasks
+    ctx.waitUntil(
+      Promise.all([
+        logToAnalytics(data),
+        cleanupOldRecords(env.DB),
+        notifyWebhook(env.WEBHOOK_URL, data),
+      ])
+    );
+    
+    // Handler returns while waitUntil tasks complete
+  },
+};
+```
+
+## Workflow Integration
+
+Trigger long-running workflows on schedule:
+
+```typescript
+import { WorkflowEntrypoint } from "cloudflare:workers";
+
+interface Env {
+  MY_WORKFLOW: Workflow;
+}
+
+export class DataProcessingWorkflow extends WorkflowEntrypoint {
+  async run(event: any, step: any) {
+    const data = await step.do("fetch-data", async () => {
+      return await fetchLargeDataset();
+    });
+    
+    const processed = await step.do("process-data", async () => {
+      return await processDataset(data);
+    });
+    
+    await step.do("store-results", async () => {
+      return await storeResults(processed);
+    });
+  }
+}
+
+export default {
+  async scheduled(controller: ScheduledController, env: Env, ctx: ExecutionContext) {
+    const instance = await env.MY_WORKFLOW.create({
+      params: {
+        scheduledTime: controller.scheduledTime,
+        cron: controller.cron,
+      },
+    });
+    
+    console.log(`Started workflow: ${instance.id}`);
+  },
+};
+```
+
+## Testing Handler
+
+```typescript
+// test/scheduled.test.ts
+import { describe, it, expect } from "vitest";
+import worker from "../src/index";
+
+describe("Scheduled Handler", () => {
+  it("processes scheduled event", async () => {
+    const env = getMiniflareBindings();
+    const ctx = {
+      waitUntil: (promise: Promise<any>) => promise,
+      passThroughOnException: () => {},
+    };
+    
+    const controller = {
+      scheduledTime: Date.now(),
+      cron: "*/5 * * * *",
+      type: "scheduled" as const,
+    };
+    
+    await worker.scheduled(controller, env, ctx);
+    
+    const result = await env.MY_KV.get("last_run");
+    expect(result).toBeDefined();
+  });
+});
+```
+
+## See Also
+
+- [README.md](./README.md) - Overview
+- [patterns.md](./patterns.md) - Use cases, examples

--- a/.agent/services/hosting/cloudflare-platform/references/cron-triggers/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cron-triggers/configuration.md
@@ -1,0 +1,151 @@
+# Cron Triggers Configuration
+
+## wrangler.jsonc
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-cron-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2024-01-01",
+  
+  "triggers": {
+    "crons": [
+      "*/5 * * * *",     // Every 5 minutes
+      "0 */2 * * *",     // Every 2 hours
+      "0 9 * * MON-FRI", // Weekdays at 9am UTC
+      "0 2 1 * *"        // Monthly on 1st at 2am UTC
+    ]
+  }
+}
+```
+
+## wrangler.toml
+
+```toml
+name = "my-cron-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[triggers]
+crons = [
+  "*/5 * * * *",     # Every 5 minutes
+  "0 */2 * * *",     # Every 2 hours
+  "0 9 * * MON-FRI", # Weekdays at 9am UTC
+  "0 2 1 * *"        # Monthly on 1st at 2am UTC
+]
+```
+
+## Environment-Specific Schedules
+
+```jsonc
+{
+  "name": "my-cron-worker",
+  "triggers": {
+    "crons": ["0 */6 * * *"]  // Prod: every 6 hours
+  },
+  "env": {
+    "staging": {
+      "triggers": {
+        "crons": ["*/15 * * * *"]  // Staging: every 15min
+      }
+    },
+    "dev": {
+      "triggers": {
+        "crons": ["*/5 * * * *"]  // Dev: every 5min
+      }
+    }
+  }
+}
+```
+
+```toml
+name = "my-cron-worker"
+
+[triggers]
+crons = ["0 */6 * * *"]  # Prod: every 6 hours
+
+[env.staging.triggers]
+crons = ["*/15 * * * *"]  # Staging: every 15min
+
+[env.dev.triggers]
+crons = ["*/5 * * * *"]  # Dev: every 5min
+```
+
+## Schedule Format
+
+**5-field structure:**
+```
+minute hour day-of-month month day-of-week
+```
+
+**Special characters:**
+- `*` - Any value
+- `,` - List: `1,15,30 * * * *` (minutes 1, 15, 30)
+- `-` - Range: `0 9-17 * * *` (9am-5pm)
+- `/` - Step: `*/10 * * * *` (every 10 minutes)
+- `L` - Last: `0 0 L * *` (last day of month), `0 18 * * FRI-L` (last Friday)
+- `W` - Weekday: `0 9 15W * *` (weekday nearest 15th)
+- `#` - Nth: `0 10 * * MON#1` (1st Monday)
+
+## Managing Triggers
+
+**Remove all:**
+```jsonc
+{
+  "triggers": {
+    "crons": []  // Empty array removes all
+  }
+}
+```
+
+**Preserve existing:**
+```jsonc
+{
+  // Omit "triggers" entirely to keep existing crons
+}
+```
+
+## Deployment
+
+```bash
+# Deploy with config crons
+npx wrangler deploy
+
+# Deploy specific environment
+npx wrangler deploy --env production
+
+# View deployments
+npx wrangler deployments list
+```
+
+**⚠️ Changes take up to 15 minutes to propagate globally**
+
+## API Management
+
+**Get triggers:**
+```bash
+curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/workers/scripts/{script_name}/schedules" \
+  -H "Authorization: Bearer {api_token}"
+```
+
+**Update triggers:**
+```bash
+curl -X PUT "https://api.cloudflare.com/client/v4/accounts/{account_id}/workers/scripts/{script_name}/schedules" \
+  -H "Authorization: Bearer {api_token}" \
+  -H "Content-Type: application/json" \
+  -d '{"crons": ["*/5 * * * *", "0 2 * * *"]}'
+```
+
+**Delete all:**
+```bash
+curl -X PUT "https://api.cloudflare.com/client/v4/accounts/{account_id}/workers/scripts/{script_name}/schedules" \
+  -H "Authorization: Bearer {api_token}" \
+  -H "Content-Type: application/json" \
+  -d '{"crons": []}'
+```
+
+## See Also
+
+- [README.md](./README.md) - Overview, quick start
+- [api.md](./api.md) - Handler implementation

--- a/.agent/services/hosting/cloudflare-platform/references/cron-triggers/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cron-triggers/gotchas.md
@@ -1,0 +1,129 @@
+# Cron Triggers Gotchas
+
+## Timezone Issues
+
+**⚠️ UTC ONLY** - No timezone configuration
+
+```typescript
+// ❌ Wrong: "0 9 * * *" // 9am UTC, not local
+// ✅ Right: "0 17 * * *" // 9am PST (UTC-8) = 17:00 UTC
+// Calculate: utcHour = (localHour - utcOffset + 24) % 24
+```
+
+## Propagation Delay
+
+**Changes take up to 15 minutes**. Verify: Dashboard → Workers → Select Worker → Settings → Triggers
+
+## Limits
+
+| Plan | Triggers/Worker | CPU Time | Execution |
+|------|----------------|----------|-----------|
+| Free | 3 | 10ms | At-least-once |
+| Paid | Unlimited | 50ms | At-least-once |
+
+```typescript
+// ❌ BAD: await processLargeDataset(); // May exceed CPU
+// ✅ GOOD: ctx.waitUntil(processLargeDataset(env));
+// ✅ OR: await env.WORKFLOW.create({});
+```
+
+## Duplicate Executions
+
+**At-least-once delivery** - duplicates possible. Make idempotent:
+
+```typescript
+export default {
+  async scheduled(controller, env, ctx) {
+    const execId = `${controller.scheduledTime}-${controller.cron}`;
+    if (await env.KV.get(`exec:${execId}`)) return;
+    await env.KV.put(`exec:${execId}`, "processing", { expirationTtl: 3600 });
+    await performTask(env);
+    await env.KV.put(`exec:${execId}`, "complete", { expirationTtl: 86400 });
+  },
+};
+```
+
+## Debugging Not Executing
+
+**Check:** `scheduled()` exported, recent deploy, 15min wait, valid cron ([crontab.guru](https://crontab.guru/)), plan limits
+
+```typescript
+export default {
+  async scheduled(controller, env, ctx) {
+    console.log("EXECUTED", {time: new Date().toISOString(), scheduledTime: new Date(controller.scheduledTime).toISOString(), cron: controller.cron});
+    ctx.waitUntil(env.KV.put("last_execution", Date.now().toString()));
+  },
+};
+```
+
+## Execution Failures
+
+**Common:** CPU exceeded, unhandled exceptions, network timeouts, binding misconfiguration
+
+```typescript
+export default {
+  async scheduled(controller, env, ctx) {
+    try {
+      const abortCtrl = new AbortController();
+      const timeout = setTimeout(() => abortCtrl.abort(), 5000);
+      const response = await fetch("https://api.example.com/data", {signal: abortCtrl.signal});
+      clearTimeout(timeout);
+      if (!response.ok) throw new Error(`API: ${response.status}`);
+      await processData(await response.json(), env);
+    } catch (error) {
+      console.error("Failed", {error: error.message, cron: controller.cron});
+      // Don't re-throw to mark success despite errors
+    }
+  },
+};
+```
+
+## Local Testing Issues
+
+Ensure `wrangler dev` runs, `scheduled()` exists, update Wrangler: `npm i -g wrangler@latest`
+
+```bash
+curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*" # URL encode spaces
+curl "http://localhost:8787/__scheduled" # No params = default
+# Python: curl "http://localhost:8787/cdn-cgi/handler/scheduled?cron=*/5+*+*+*+*"
+```
+
+## Security
+
+```typescript
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    if (url.pathname === "/__scheduled") {
+      if (env.ENVIRONMENT === "production") return new Response("Not found", { status: 404 });
+      await this.scheduled({scheduledTime: Date.now(), cron: url.searchParams.get("cron") || "* * * * *", type: "scheduled"}, env, ctx);
+      return new Response("OK");
+    }
+    return new Response("Hello");
+  },
+  async scheduled(controller, env, ctx) {},
+};
+```
+
+## Secrets Management
+
+```typescript
+// ❌ BAD: headers: { "Authorization": "Bearer sk_live_abc123..." }
+// ✅ GOOD: headers: { "Authorization": `Bearer ${env.API_KEY}` }
+```
+
+```bash
+npx wrangler secret put API_KEY
+```
+
+## Green Compute
+
+Dashboard: Workers & Pages → Account details → Compute Setting → Green Compute. Tradeoffs: fewer locations, higher latency, ideal for non-time-critical jobs
+
+## Resources
+
+- [Cron Triggers Docs](https://developers.cloudflare.com/workers/configuration/cron-triggers/)
+- [Scheduled Handler API](https://developers.cloudflare.com/workers/runtime-apis/handlers/scheduled/)
+- [Cloudflare Workflows](https://developers.cloudflare.com/workflows/)
+- [Workers Limits](https://developers.cloudflare.com/workers/platform/limits/)
+- [Crontab Guru](https://crontab.guru/) - Validator

--- a/.agent/services/hosting/cloudflare-platform/references/cron-triggers/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/cron-triggers/patterns.md
@@ -1,0 +1,122 @@
+# Cron Triggers Patterns
+
+## API Data Sync
+
+```typescript
+export default {
+  async scheduled(controller, env, ctx) {
+    const response = await fetch("https://api.example.com/data", {headers: { "Authorization": `Bearer ${env.API_KEY}` }});
+    if (!response.ok) throw new Error(`API error: ${response.status}`);
+    ctx.waitUntil(env.MY_KV.put("cached_data", JSON.stringify(await response.json()), {expirationTtl: 3600}));
+  },
+};
+```
+
+## Database Cleanup
+
+```typescript
+export default {
+  async scheduled(controller, env, ctx) {
+    const result = await env.DB.prepare(`DELETE FROM sessions WHERE expires_at < datetime('now')`).run();
+    console.log(`Deleted ${result.meta.changes} expired sessions`);
+    ctx.waitUntil(env.DB.prepare("VACUUM").run());
+  },
+};
+```
+
+## Report Generation
+
+```typescript
+export default {
+  async scheduled(controller, env, ctx) {
+    const startOfWeek = new Date(); startOfWeek.setDate(startOfWeek.getDate() - 7);
+    const { results } = await env.DB.prepare(`SELECT date, revenue, orders FROM daily_stats WHERE date >= ? ORDER BY date`).bind(startOfWeek.toISOString()).all();
+    const report = {period: "weekly", totalRevenue: results.reduce((sum, d) => sum + d.revenue, 0), totalOrders: results.reduce((sum, d) => sum + d.orders, 0), dailyBreakdown: results};
+    const reportKey = `reports/weekly-${Date.now()}.json`;
+    await env.REPORTS_BUCKET.put(reportKey, JSON.stringify(report));
+    ctx.waitUntil(env.SEND_EMAIL.fetch("https://example.com/send", {method: "POST", body: JSON.stringify({to: "team@example.com", subject: "Weekly Report", reportUrl: `https://reports.example.com/${reportKey}`})}));
+  },
+};
+```
+
+## Health Checks
+
+```typescript
+export default {
+  async scheduled(controller, env, ctx) {
+    const services = [{name: "API", url: "https://api.example.com/health"}, {name: "CDN", url: "https://cdn.example.com/health"}];
+    const checks = await Promise.all(services.map(async (service) => {
+      const start = Date.now();
+      try {
+        const response = await fetch(service.url, { signal: AbortSignal.timeout(5000) });
+        return {name: service.name, status: response.ok ? "up" : "down", responseTime: Date.now() - start};
+      } catch (error) {
+        return {name: service.name, status: "down", responseTime: Date.now() - start, error: error.message};
+      }
+    }));
+    ctx.waitUntil(env.STATUS_KV.put("health_status", JSON.stringify(checks)));
+    const failures = checks.filter(c => c.status === "down");
+    if (failures.length > 0) ctx.waitUntil(fetch(env.ALERT_WEBHOOK, {method: "POST", body: JSON.stringify({text: `${failures.length} service(s) down: ${failures.map(f => f.name).join(", ")}`})}));
+  },
+};
+```
+
+## Batch Processing (Rate-Limited)
+
+```typescript
+export default {
+  async scheduled(controller, env, ctx) {
+    const queueData = await env.QUEUE_KV.get("pending_items", "json");
+    if (!queueData || queueData.length === 0) return;
+    const batch = queueData.slice(0, 100);
+    const results = await Promise.allSettled(batch.map(item => fetch("https://api.example.com/process", {method: "POST", headers: {"Authorization": `Bearer ${env.API_KEY}`, "Content-Type": "application/json"}, body: JSON.stringify(item)})));
+    console.log(`Processed ${results.filter(r => r.status === "fulfilled").length}/${batch.length} items`);
+    ctx.waitUntil(env.QUEUE_KV.put("pending_items", JSON.stringify(queueData.slice(100))));
+  },
+};
+```
+
+## Monitoring & Logging
+
+```typescript
+export default {
+  async scheduled(controller, env, ctx) {
+    const startTime = Date.now();
+    console.log(`[START] Cron ${controller.cron} at ${new Date(controller.scheduledTime).toISOString()}`);
+    try {
+      const result = await performTask(env);
+      const duration = Date.now() - startTime;
+      console.log(`[SUCCESS] Completed in ${duration}ms`, {cron: controller.cron, recordsProcessed: result.count});
+      ctx.waitUntil(logToExternal(env.ANALYTICS_ENDPOINT, {event: "cron_success", duration, cron: controller.cron}));
+    } catch (error) {
+      const duration = Date.now() - startTime;
+      console.error(`[ERROR] Failed after ${duration}ms`, {cron: controller.cron, error: error.message});
+      ctx.waitUntil(notifyFailure(env.ALERT_WEBHOOK, {cron: controller.cron, error: error.message}));
+      throw error;
+    }
+  },
+};
+```
+
+## View Past Events
+
+**Dashboard:** Workers & Pages → Select Worker → Settings → Triggers → Cron Events
+
+**Wrangler:**
+```bash
+npx wrangler tail
+npx wrangler tail --format json | jq 'select(.event.cron != null)'
+```
+
+**GraphQL:**
+```graphql
+query CronMetrics($accountTag: string!, $workerName: string!) {
+  viewer { accounts(filter: { accountTag: $accountTag }) { workersInvocationsAdaptive(filter: {scriptName: $workerName, eventType: "scheduled"}, limit: 100) { dimensions { datetime, status }, sum { requests, errors } } } }
+}
+```
+
+## See Also
+
+- [README.md](./README.md) - Overview
+- [api.md](./api.md) - Handler implementation
+- [gotchas.md](./gotchas.md) - Troubleshooting

--- a/.agent/services/hosting/cloudflare-platform/references/d1/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/d1/README.md
@@ -1,0 +1,92 @@
+# Cloudflare D1 Database
+
+Expert guidance for Cloudflare D1, a serverless SQLite database designed for horizontal scale-out across multiple databases.
+
+## Overview
+
+D1 is Cloudflare's managed, serverless database with:
+- SQLite SQL semantics and compatibility
+- Built-in disaster recovery via Time Travel (30-day point-in-time recovery)
+- Horizontal scale-out architecture (10 GB per database)
+- Worker and HTTP API access
+- Pricing based on query and storage costs only
+
+**Architecture Philosophy**: D1 is optimized for per-user, per-tenant, or per-entity database patterns rather than single large databases.
+
+## Quick Start
+
+```bash
+# Create database
+wrangler d1 create <database-name>
+
+# Execute migration
+wrangler d1 execute <db-name> --remote --file=./migrations/0001_schema.sql
+
+# Local development
+wrangler dev
+```
+
+## Core Query Methods
+
+```typescript
+// .all() - Returns all rows; .first() - First row or null; .first(col) - Single column value
+// .run() - INSERT/UPDATE/DELETE; .raw() - Array of arrays (efficient)
+const { results, success, meta } = await env.DB.prepare('SELECT * FROM users WHERE active = ?').bind(true).all();
+const user = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId).first();
+```
+
+## Batch Operations
+
+```typescript
+// Multiple queries in single round trip (atomic transaction)
+const results = await env.DB.batch([
+  env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(1),
+  env.DB.prepare('SELECT * FROM posts WHERE author_id = ?').bind(1),
+  env.DB.prepare('UPDATE users SET last_access = ? WHERE id = ?').bind(Date.now(), 1)
+]);
+```
+
+## Platform Limits
+
+| Limit | Value |
+|-------|-------|
+| Database size | 10 GB per database |
+| Row size | 1 MB maximum |
+| Query timeout | 30 seconds |
+| Batch size | 10,000 statements |
+| Time Travel retention | 30 days |
+
+## CLI Commands
+
+```bash
+# Database management
+wrangler d1 create <db-name>
+wrangler d1 list
+wrangler d1 delete <db-name>
+
+# Execute queries
+wrangler d1 execute <db-name> --remote --command="SELECT * FROM users"
+wrangler d1 execute <db-name> --local --file=./migrations/0001_schema.sql
+
+# Backups
+wrangler d1 export <db-name> --remote --output=./backup.sql
+wrangler d1 time-travel restore <db-name> --timestamp="2024-01-15T14:30:00Z"
+
+# Development
+wrangler dev --persist-to=./.wrangler/state
+```
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - wrangler.toml setup, TypeScript types, binding configuration
+- [api.md](./api.md) - D1Database API, prepared statements, batch operations, testing
+- [patterns.md](./patterns.md) - Pagination, bulk operations, caching, multi-tenant patterns
+- [gotchas.md](./gotchas.md) - SQL injection prevention, error handling, performance pitfalls
+
+## See Also
+
+- [workers](../workers/) - Worker runtime and fetch handler patterns
+- [kv](../kv/) - Workers KV for caching D1 results
+- [r2](../r2/) - R2 for storing binary data instead of D1 BLOBs
+- [queues](../queues/) - Queue writes to D1 for high-throughput scenarios
+- [durable-objects](../durable-objects/) - Coordinate D1 writes with strong consistency

--- a/.agent/services/hosting/cloudflare-platform/references/d1/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/d1/api.md
@@ -1,0 +1,141 @@
+# D1 API Reference
+
+## Prepared Statements (Required for Security)
+
+```typescript
+// ❌ NEVER: Direct string interpolation (SQL injection risk)
+const result = await env.DB.prepare(`SELECT * FROM users WHERE id = ${userId}`).all();
+
+// ✅ CORRECT: Prepared statements with bind()
+const result = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId).all();
+
+// Multiple parameters
+const result = await env.DB.prepare('SELECT * FROM users WHERE email = ? AND active = ?').bind(email, true).all();
+```
+
+## Query Execution Methods
+
+```typescript
+// .all() - Returns all rows
+const { results, success, meta } = await env.DB.prepare('SELECT * FROM users WHERE active = ?').bind(true).all();
+// results: Array of row objects; success: boolean
+// meta: { duration: number, rows_read: number, rows_written: number }
+
+// .first() - Returns first row or null
+const user = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId).first();
+
+// .first(columnName) - Returns single column value
+const email = await env.DB.prepare('SELECT email FROM users WHERE id = ?').bind(userId).first('email');
+// Returns string | number | null
+
+// .run() - For INSERT/UPDATE/DELETE (no row data returned)
+const result = await env.DB.prepare('UPDATE users SET last_login = ? WHERE id = ?').bind(Date.now(), userId).run();
+// result.meta: { duration, rows_read, rows_written, last_row_id, changes }
+
+// .raw() - Returns array of arrays (efficient for large datasets)
+const rawResults = await env.DB.prepare('SELECT id, name FROM users').raw();
+// [[1, 'Alice'], [2, 'Bob']]
+```
+
+## Batch Operations
+
+```typescript
+// Execute multiple queries in single round trip (atomic transaction)
+const results = await env.DB.batch([
+  env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(1),
+  env.DB.prepare('SELECT * FROM posts WHERE author_id = ?').bind(1),
+  env.DB.prepare('UPDATE users SET last_access = ? WHERE id = ?').bind(Date.now(), 1)
+]);
+// results is array: [result1, result2, result3]
+
+// Batch with same prepared statement, different params
+const userIds = [1, 2, 3];
+const stmt = env.DB.prepare('SELECT * FROM users WHERE id = ?');
+const results = await env.DB.batch(userIds.map(id => stmt.bind(id)));
+```
+
+## Transactions (via batch)
+
+```typescript
+// D1 executes batch() as atomic transaction - all succeed or all fail
+const results = await env.DB.batch([
+  env.DB.prepare('INSERT INTO accounts (id, balance) VALUES (?, ?)').bind(1, 100),
+  env.DB.prepare('INSERT INTO accounts (id, balance) VALUES (?, ?)').bind(2, 200),
+  env.DB.prepare('UPDATE accounts SET balance = balance - ? WHERE id = ?').bind(50, 1),
+  env.DB.prepare('UPDATE accounts SET balance = balance + ? WHERE id = ?').bind(50, 2)
+]);
+```
+
+## Error Handling
+
+```typescript
+async function getUser(userId: number, env: Env): Promise<Response> {
+  try {
+    const result = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId).all();
+    if (!result.success) return new Response('Database error', { status: 500 });
+    if (result.results.length === 0) return new Response('User not found', { status: 404 });
+    return Response.json(result.results[0]);
+  } catch (error) {
+    return new Response('Internal error', { status: 500 });
+  }
+}
+
+// Constraint violations
+try {
+  await env.DB.prepare('INSERT INTO users (email, name) VALUES (?, ?)').bind(email, name).run();
+} catch (error) {
+  if (error.message?.includes('UNIQUE constraint failed')) return new Response('Email exists', { status: 409 });
+  throw error;
+}
+```
+
+## REST API (HTTP) Access
+
+```typescript
+// Access D1 via Cloudflare REST API (external to Workers)
+const response = await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/d1/database/${DATABASE_ID}/query`,
+  {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${CLOUDFLARE_API_TOKEN}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      sql: 'SELECT * FROM users WHERE id = ?',
+      params: [userId]
+    })
+  }
+);
+
+const data = await response.json();
+```
+
+## Testing
+
+```typescript
+import { unstable_dev } from 'wrangler';
+
+describe('D1 Tests', () => {
+  let worker: Awaited<ReturnType<typeof unstable_dev>>;
+  beforeAll(async () => { worker = await unstable_dev('src/index.ts', { experimental: { disableExperimentalWarning: true } }); });
+  afterAll(async () => { await worker.stop(); });
+  it('should query users', async () => { expect((await worker.fetch('/api/users')).status).toBe(200); });
+});
+```
+
+## Debugging
+
+```typescript
+// Log query metadata
+const result = await env.DB.prepare('SELECT * FROM users').all();
+console.log('Duration:', result.meta.duration, 'ms', 'Rows:', result.meta.rows_read);
+
+// EXPLAIN for query plans
+const plan = await env.DB.prepare('EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?').bind(email).all();
+```
+
+```bash
+sqlite3 .wrangler/state/v3/d1/<database-id>.sqlite  # Inspect local DB
+.tables; .schema users; .indexes users; PRAGMA table_info(users);
+```

--- a/.agent/services/hosting/cloudflare-platform/references/d1/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/d1/configuration.md
@@ -1,0 +1,127 @@
+# D1 Configuration
+
+## wrangler.toml Setup
+
+```toml
+name = "your-worker-name"; main = "src/index.ts"; compatibility_date = "2024-01-01"
+
+[[d1_databases]]
+binding = "DB"                    # Env variable name
+database_name = "your-db-name"    # Human-readable name
+database_id = "your-database-id"  # UUID from dashboard/CLI
+migrations_dir = "migrations"     # Optional
+
+# Multiple databases
+[[d1_databases]]
+binding = "ANALYTICS_DB"; database_name = "analytics-db"; database_id = "yyy-yyy-yyy"
+```
+
+## TypeScript Types
+
+```typescript
+interface Env { DB: D1Database; ANALYTICS_DB?: D1Database; }
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const result = await env.DB.prepare('SELECT * FROM users').all();
+    return Response.json(result.results);
+  }
+}
+```
+
+## Migrations
+
+File structure: `migrations/0001_initial_schema.sql`, `0002_add_posts.sql`, etc.
+
+### Example Migration
+
+```sql
+-- migrations/0001_initial_schema.sql
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_users_email ON users(email);
+
+CREATE TABLE IF NOT EXISTS posts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL,
+  title TEXT NOT NULL,
+  content TEXT,
+  published BOOLEAN DEFAULT 0,
+  created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_posts_user_id ON posts(user_id);
+CREATE INDEX idx_posts_published ON posts(published);
+```
+
+### Running Migrations
+
+```bash
+wrangler d1 execute <db-name> --local --file=./migrations/0001_schema.sql    # Local
+wrangler d1 execute <db-name> --remote --file=./migrations/0001_schema.sql   # Production
+wrangler d1 execute <db-name> --remote --command="SELECT * FROM users"      # Direct
+
+# Track migrations: CREATE TABLE schema_version (version INT PRIMARY KEY, name TEXT, applied_at INT)
+```
+
+## Indexing Strategy
+
+```sql
+-- Index frequently queried columns
+CREATE INDEX idx_users_email ON users(email);
+
+-- Composite indexes for multi-column queries
+CREATE INDEX idx_posts_user_published ON posts(user_id, published);
+
+-- Covering indexes (include queried columns)
+CREATE INDEX idx_users_email_name ON users(email, name);
+
+-- Partial indexes for filtered queries
+CREATE INDEX idx_active_users ON users(email) WHERE active = 1;
+
+-- Check if query uses index
+EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?;
+```
+
+## Drizzle ORM
+
+```typescript
+// drizzle.config.ts
+export default {
+  schema: './src/schema.ts', out: './migrations', dialect: 'sqlite', driver: 'd1-http',
+  dbCredentials: { accountId: process.env.CLOUDFLARE_ACCOUNT_ID!, databaseId: process.env.D1_DATABASE_ID!, token: process.env.CLOUDFLARE_API_TOKEN! }
+} satisfies Config;
+
+// schema.ts
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+export const users = sqliteTable('users', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  email: text('email').notNull().unique(),
+  name: text('name').notNull()
+});
+
+// worker.ts
+import { drizzle } from 'drizzle-orm/d1';
+import { users } from './schema';
+export default {
+  async fetch(request: Request, env: Env) {
+    const db = drizzle(env.DB);
+    return Response.json(await db.select().from(users));
+  }
+}
+```
+
+## Local Development
+
+```bash
+wrangler dev --persist-to=./.wrangler/state  # Persist across restarts
+# Local DB: .wrangler/state/v3/d1/<database-id>.sqlite
+sqlite3 .wrangler/state/v3/d1/<database-id>.sqlite  # Inspect
+```

--- a/.agent/services/hosting/cloudflare-platform/references/d1/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/d1/gotchas.md
@@ -1,0 +1,70 @@
+# D1 Gotchas & Troubleshooting
+
+## SQL Injection Prevention (CRITICAL)
+
+```typescript
+// ❌ NEVER: String interpolation - SQL injection vulnerability
+await env.DB.prepare(`SELECT * FROM users WHERE id = ${userId}`).all(); // DANGEROUS!
+
+// ✅ ALWAYS: Prepared statements with bind()
+await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId).all();
+```
+
+Attacker could pass `1 OR 1=1` to dump table or `1; DROP TABLE users;--` to delete data.
+
+## Common Errors
+
+**Missing Table:** "no such table" → Run migrations first  
+**Unique Constraint:** "UNIQUE constraint failed" → Catch and return 409  
+**Query Timeout:** 30s exceeded → Break into smaller queries or add indexes
+
+## N+1 Query Problem
+
+```typescript
+// ❌ BAD: N+1 queries (multiple round trips)
+for (const post of posts.results) {
+  const author = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(post.user_id).first();
+}
+
+// ✅ GOOD: Single JOIN or batch()
+const postsWithAuthors = await env.DB.prepare(`
+  SELECT posts.*, users.name FROM posts JOIN users ON posts.user_id = users.id
+`).all();
+```
+
+## Missing Indexes
+
+```sql
+EXPLAIN QUERY PLAN SELECT * FROM users WHERE email = ?;  -- Check for "USING INDEX"
+CREATE INDEX idx_users_email ON users(email);  -- Add if missing
+```
+
+## Limits to Watch
+
+| Limit | Value | Impact |
+|-------|-------|--------|
+| Database size | 10 GB | Design for multiple DBs per tenant |
+| Row size | 1 MB | Store large files in R2, not D1 |
+| Query timeout | 30s | Break long queries into smaller chunks |
+| Batch size | 10,000 statements | Split large batches |
+
+## Local vs Remote
+
+Local uses `.wrangler/state/v3/d1/<database-id>.sqlite`. Always test migrations locally before remote.
+
+## Data Types
+
+**Boolean:** SQLite uses INTEGER (0/1) not boolean - bind 1 or 0, not true/false  
+**Date/Time:** Use TEXT (ISO 8601) or INTEGER (unix timestamp), not native DATE/TIME
+
+## Best Practices
+
+- ✅ Use prepared statements with bind() - ALWAYS
+- ✅ Create indexes on frequently queried columns
+- ✅ Use batch() for multiple queries (reduces latency)
+- ✅ Design for horizontal scaling (multiple small DBs vs single large DB)
+- ✅ Test migrations locally before applying remotely
+- ✅ Monitor query performance via meta.duration
+- ❌ Don't store binary data directly (use R2 for blobs)
+- ❌ Don't use single large database (scale horizontally instead)
+- ❌ Don't run long transactions (30s timeout)

--- a/.agent/services/hosting/cloudflare-platform/references/d1/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/d1/patterns.md
@@ -1,0 +1,144 @@
+# D1 Patterns & Best Practices
+
+## Pagination
+
+```typescript
+async function getUsers({ page, pageSize }: { page: number; pageSize: number }, env: Env) {
+  const offset = (page - 1) * pageSize;
+  const [countResult, dataResult] = await env.DB.batch([
+    env.DB.prepare('SELECT COUNT(*) as total FROM users'),
+    env.DB.prepare('SELECT * FROM users ORDER BY created_at DESC LIMIT ? OFFSET ?').bind(pageSize, offset)
+  ]);
+  return { data: dataResult.results, total: countResult.results[0].total, page, pageSize, totalPages: Math.ceil(countResult.results[0].total / pageSize) };
+}
+```
+
+## Conditional Queries
+
+```typescript
+async function searchUsers(filters: { name?: string; email?: string; active?: boolean }, env: Env) {
+  const conditions: string[] = [], params: any[] = [];
+  if (filters.name) { conditions.push('name LIKE ?'); params.push(`%${filters.name}%`); }
+  if (filters.email) { conditions.push('email = ?'); params.push(filters.email); }
+  if (filters.active !== undefined) { conditions.push('active = ?'); params.push(filters.active ? 1 : 0); }
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+  return await env.DB.prepare(`SELECT * FROM users ${whereClause}`).bind(...params).all();
+}
+```
+
+## Bulk Insert
+
+```typescript
+async function bulkInsertUsers(users: Array<{ name: string; email: string }>, env: Env) {
+  const stmt = env.DB.prepare('INSERT INTO users (name, email) VALUES (?, ?)');
+  const batch = users.map(user => stmt.bind(user.name, user.email));
+  return await env.DB.batch(batch);
+}
+```
+
+## Caching with KV
+
+```typescript
+async function getCachedUser(userId: number, env: { DB: D1Database; CACHE: KVNamespace }) {
+  const cacheKey = `user:${userId}`;
+  const cached = await env.CACHE?.get(cacheKey, 'json');
+  if (cached) return cached;
+  const user = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId).first();
+  if (user) await env.CACHE?.put(cacheKey, JSON.stringify(user), { expirationTtl: 300 });
+  return user;
+}
+```
+
+## Query Optimization
+
+```typescript
+// ✅ Use indexes in WHERE clauses
+const users = await env.DB.prepare('SELECT * FROM users WHERE email = ?').bind(email).all();
+
+// ✅ Limit result sets
+const recentPosts = await env.DB.prepare('SELECT * FROM posts ORDER BY created_at DESC LIMIT 100').all();
+
+// ✅ Use batch() for multiple independent queries
+const [user, posts, comments] = await env.DB.batch([
+  env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(userId),
+  env.DB.prepare('SELECT * FROM posts WHERE user_id = ?').bind(userId),
+  env.DB.prepare('SELECT * FROM comments WHERE user_id = ?').bind(userId)
+]);
+
+// ❌ Avoid N+1 queries
+for (const post of posts) {
+  const author = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(post.user_id).first(); // Bad: multiple round trips
+}
+
+// ✅ Use JOINs instead
+const postsWithAuthors = await env.DB.prepare(`
+  SELECT posts.*, users.name as author_name
+  FROM posts
+  JOIN users ON posts.user_id = users.id
+`).all();
+```
+
+## Multi-Tenant SaaS
+
+```typescript
+// Each tenant gets own database
+export default {
+  async fetch(request: Request, env: { [key: `TENANT_${string}`]: D1Database }) {
+    const tenantId = request.headers.get('X-Tenant-ID');
+    const data = await env[`TENANT_${tenantId}`].prepare('SELECT * FROM records').all();
+    return Response.json(data.results);
+  }
+}
+```
+
+## Session Storage
+
+```typescript
+async function createSession(userId: number, token: string, env: Env) {
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+  return await env.DB.prepare(`
+    INSERT INTO sessions (user_id, token, expires_at, created_at)
+    VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+  `).bind(userId, token, expiresAt).run();
+}
+
+async function validateSession(token: string, env: Env) {
+  return await env.DB.prepare(`
+    SELECT s.*, u.email, u.name
+    FROM sessions s
+    JOIN users u ON s.user_id = u.id
+    WHERE s.token = ? AND s.expires_at > CURRENT_TIMESTAMP
+  `).bind(token).first();
+}
+```
+
+## Analytics/Events
+
+```typescript
+async function logEvent(event: { type: string; userId?: number; metadata: any }, env: Env) {
+  return await env.DB.prepare(`
+    INSERT INTO events (type, user_id, metadata, timestamp)
+    VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+  `).bind(event.type, event.userId || null, JSON.stringify(event.metadata)).run();
+}
+
+async function getEventStats(startDate: string, endDate: string, env: Env) {
+  return await env.DB.prepare(`
+    SELECT type, COUNT(*) as count
+    FROM events
+    WHERE timestamp BETWEEN ? AND ?
+    GROUP BY type
+    ORDER BY count DESC
+  `).bind(startDate, endDate).all();
+}
+```
+
+## Time Travel & Backups
+
+```bash
+wrangler d1 time-travel restore <db-name> --timestamp="2024-01-15T14:30:00Z"  # Point-in-time
+wrangler d1 time-travel info <db-name>  # List restore points (30-day window)
+wrangler d1 export <db-name> --remote --output=./backup.sql  # Full export
+wrangler d1 export <db-name> --remote --no-schema --output=./data.sql  # Data only
+wrangler d1 execute <db-name> --remote --file=./backup.sql  # Import
+```

--- a/.agent/services/hosting/cloudflare-platform/references/ddos/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ddos/README.md
@@ -1,0 +1,34 @@
+# Cloudflare DDoS Protection
+
+Autonomous, always-on protection against DDoS attacks across L3/4 and L7.
+
+## Protection Types
+
+- **HTTP DDoS (L7)**: Protects HTTP/HTTPS traffic, phase `ddos_l7`, zone/account level
+- **Network DDoS (L3/4)**: UDP/SYN/DNS floods, phase `ddos_l4`, account level only
+- **Adaptive DDoS**: Learns 7-day baseline, detects deviations (Enterprise)
+
+## Key Features
+
+- Always-on managed rulesets (cannot disable)
+- Sensitivity levels: `default` (high), `medium`, `low`, `eoff` (essentially off)
+- Actions: `block`, `managed_challenge`, `challenge`, `log` (Enterprise Advanced only)
+- Override by category/tag or individual rule ID
+- Custom expressions for traffic filtering (Enterprise Advanced)
+- Alert configuration for attack notifications
+
+## Rule Limits
+
+- Free/Pro/Business: 1 override rule
+- Enterprise Advanced: Up to 10 rules
+
+## Scope Hierarchy
+
+Zone overrides take precedence over account overrides.
+
+## See Also
+
+- [configuration.md](./configuration.md) - Dashboard & rule setup
+- [api.md](./api.md) - API endpoints & management
+- [patterns.md](./patterns.md) - Protection strategies
+- [gotchas.md](./gotchas.md) - False positives & tuning

--- a/.agent/services/hosting/cloudflare-platform/references/ddos/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ddos/api.md
@@ -1,0 +1,136 @@
+# DDoS API
+
+## Endpoints
+
+### HTTP DDoS (L7)
+
+```typescript
+// Zone-level
+PUT /zones/{zoneId}/rulesets/phases/ddos_l7/entrypoint
+GET /zones/{zoneId}/rulesets/phases/ddos_l7/entrypoint
+
+// Account-level (Enterprise Advanced)
+PUT /accounts/{accountId}/rulesets/phases/ddos_l7/entrypoint
+GET /accounts/{accountId}/rulesets/phases/ddos_l7/entrypoint
+```
+
+### Network DDoS (L3/4)
+
+```typescript
+// Account-level only
+PUT /accounts/{accountId}/rulesets/phases/ddos_l4/entrypoint
+GET /accounts/{accountId}/rulesets/phases/ddos_l4/entrypoint
+```
+
+## TypeScript SDK
+
+```typescript
+import Cloudflare from "cloudflare";
+
+const client = new Cloudflare({ apiToken: process.env.CLOUDFLARE_API_TOKEN });
+
+// Get HTTP DDoS ruleset
+const ruleset = await client.zones.rulesets.phases.entrypoint.get("ddos_l7", {
+  zone_id: zoneId,
+});
+
+// Update HTTP DDoS ruleset
+await client.zones.rulesets.phases.entrypoint.update("ddos_l7", {
+  zone_id: zoneId,
+  rules: [
+    {
+      action: "execute",
+      expression: "true",
+      action_parameters: {
+        id: managedRulesetId,
+        overrides: {
+          sensitivity_level: "medium",
+          action: "managed_challenge",
+        },
+      },
+    },
+  ],
+});
+
+// Network DDoS (account level)
+const l4Ruleset = await client.accounts.rulesets.phases.entrypoint.get("ddos_l4", {
+  account_id: accountId,
+});
+```
+
+## Alert Configuration
+
+```typescript
+interface DDoSAlertConfig {
+  name: string;
+  enabled: boolean;
+  alert_type: "http_ddos_attack_alert" | "layer_3_4_ddos_attack_alert" 
+    | "advanced_http_ddos_attack_alert" | "advanced_layer_3_4_ddos_attack_alert";
+  filters?: {
+    zones?: string[];
+    hostnames?: string[];
+    requests_per_second?: number;
+    packets_per_second?: number;
+    megabits_per_second?: number;
+    ip_prefixes?: string[]; // CIDR
+    ip_addresses?: string[];
+    protocols?: string[];
+  };
+  mechanisms: {
+    email?: Array<{ id: string }>;
+    webhooks?: Array<{ id: string }>;
+    pagerduty?: Array<{ id: string }>;
+  };
+}
+
+// Create alert
+await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${accountId}/alerting/v3/policies`,
+  {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(alertConfig),
+  }
+);
+```
+
+## Worker Integration
+
+```typescript
+// DDoS config management worker
+interface Env {
+  CLOUDFLARE_API_TOKEN: string;
+  ZONE_ID: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/configure") {
+      const response = await fetch(
+        `https://api.cloudflare.com/client/v4/zones/${env.ZONE_ID}/rulesets/phases/ddos_l7/entrypoint`,
+        {
+          method: "PUT",
+          headers: {
+            Authorization: `Bearer ${env.CLOUDFLARE_API_TOKEN}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            description: "Dynamic DDoS config",
+            rules: [/* ... */],
+          }),
+        }
+      );
+      return response;
+    }
+
+    return new Response("Not found", { status: 404 });
+  },
+};
+```
+
+See [patterns.md](./patterns.md) for complete worker examples.

--- a/.agent/services/hosting/cloudflare-platform/references/ddos/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ddos/configuration.md
@@ -1,0 +1,67 @@
+# DDoS Configuration
+
+## Dashboard Setup
+
+1. Navigate to Security > DDoS
+2. Select HTTP DDoS or Network-layer DDoS
+3. Configure sensitivity & action per ruleset/category/rule
+4. Apply overrides with optional expressions (Enterprise Advanced)
+
+## Rule Structure
+
+```typescript
+interface DDoSOverride {
+  description: string;
+  rules: Array<{
+    action: "execute";
+    expression: string; // Filter traffic, "true" for all
+    action_parameters: {
+      id: string; // Managed ruleset ID
+      overrides: {
+        sensitivity_level?: "default" | "medium" | "low" | "eoff";
+        action?: "block" | "managed_challenge" | "challenge" | "log";
+        categories?: Array<{ // Override by category
+          category: string; // e.g., "http-flood", "udp-flood"
+          sensitivity_level?: string;
+        }>;
+        rules?: Array<{ // Override by rule ID
+          id: string;
+          action?: string;
+          sensitivity_level?: string;
+        }>;
+      };
+    };
+  }>;
+}
+```
+
+## Sensitivity Mapping
+
+| UI | API | Threshold |
+|----|-----|-----------|
+| High | `default` | Most aggressive |
+| Medium | `medium` | Balanced |
+| Low | `low` | Less aggressive |
+| Essentially Off | `eoff` | Minimal mitigation |
+
+## Common Categories
+
+- `http-flood`, `http-anomaly` (L7)
+- `udp-flood`, `syn-flood`, `dns-flood` (L3/4)
+
+## Adaptive Rules
+
+Configure by targeting specific rule IDs. Check dashboard for IDs:
+- HTTP: origins, user-agents, locations
+- L4: protocols
+
+Requires 7 days of traffic history to learn baseline.
+
+## Alerting
+
+Configure via Notifications:
+- Alert types: `http_ddos_attack_alert`, `layer_3_4_ddos_attack_alert`, `advanced_*` variants
+- Filters: zones, hostnames, RPS/PPS/Mbps thresholds, IPs, protocols
+- Mechanisms: email, webhooks, PagerDuty
+
+See [api.md](./api.md#alert-configuration) for API examples.

--- a/.agent/services/hosting/cloudflare-platform/references/ddos/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ddos/gotchas.md
@@ -1,0 +1,114 @@
+# DDoS Gotchas
+
+## False Positives
+
+**Symptom**: Legitimate traffic blocked/challenged
+
+**Diagnosis**:
+```typescript
+// Query GraphQL API for flagged requests
+const query = `
+  query {
+    viewer {
+      zones(filter: { zoneTag: "${zoneId}" }) {
+        httpRequestsAdaptiveGroups(
+          filter: { ruleId: "${ruleId}", action: "log" }
+          limit: 100
+          orderBy: [datetime_DESC]
+        ) {
+          dimensions {
+            clientCountryName
+            clientRequestHTTPHost
+            clientRequestPath
+            userAgent
+          }
+          count
+        }
+      }
+    }
+  }
+`;
+```
+
+**Fix**:
+1. Lower sensitivity for specific rule/category
+2. Use `log` action first to validate (Enterprise Advanced)
+3. Add exception with custom expression (e.g., allowlist IPs)
+4. Reduce category sensitivity: `{ category: "http-flood", sensitivity_level: "low" }`
+
+## Attacks Getting Through
+
+**Cause**: Sensitivity too low, wrong action
+
+**Fix**:
+```typescript
+// Increase to default (high) sensitivity
+const config = {
+  rules: [{
+    expression: "true",
+    action: "execute",
+    action_parameters: {
+      id: managedRulesetId,
+      overrides: { sensitivity_level: "default", action: "block" },
+    },
+  }],
+};
+```
+
+## Adaptive Rules Not Working
+
+**Cause**: Insufficient traffic history (needs 7 days)
+
+**Fix**: Wait for baseline to establish, check dashboard for adaptive rule status
+
+## Zone vs Account Override Conflict
+
+**Issue**: Account overrides ignored when zone has overrides
+
+**Solution**: Configure at zone level OR remove zone overrides to use account-level
+
+## Log Action Not Available
+
+**Cause**: Not on Enterprise Advanced DDoS plan
+
+**Workaround**: Use `managed_challenge` with low sensitivity for testing
+
+## Rule Limit Exceeded
+
+**Plans**:
+- Free/Pro/Business: 1 override rule only
+- Enterprise Advanced: Up to 10 rules
+
+**Workaround**: Combine conditions in single expression using `and`/`or`
+
+## Read-only Managed Rules
+
+**Issue**: Some rules cannot be overridden
+
+**Check**: API response indicates if rule is read-only
+
+## Always-on Protection
+
+**Reality**: DDoS managed rulesets cannot be fully disabled
+
+**Minimum**: Set `sensitivity_level: "eoff"` for minimal mitigation
+
+## Tuning Strategy
+
+1. Start with `log` action + `medium` sensitivity
+2. Monitor for 24-48 hours
+3. Identify false positives, add exceptions
+4. Gradually increase to `default` sensitivity
+5. Change action from `log` → `managed_challenge` → `block`
+6. Document all adjustments
+
+## Best Practices
+
+- Test during low-traffic periods
+- Use zone-level for per-site tuning
+- Reference IP lists for easier management
+- Set appropriate alert thresholds (avoid noise)
+- Combine with WAF for layered defense
+- Avoid over-tuning (keep config simple)
+
+See [patterns.md](./patterns.md) for progressive rollout examples.

--- a/.agent/services/hosting/cloudflare-platform/references/ddos/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/ddos/patterns.md
@@ -1,0 +1,158 @@
+# DDoS Protection Patterns
+
+## Allowlist Trusted IPs
+
+```typescript
+// Account-level override with custom expression
+const config = {
+  description: "Allowlist trusted IPs",
+  rules: [{
+    expression: "ip.src in { 203.0.113.0/24 192.0.2.1 }",
+    action: "execute",
+    action_parameters: {
+      id: managedRulesetId,
+      overrides: { sensitivity_level: "eoff" }, // Effectively off
+    },
+  }],
+};
+
+await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${accountId}/rulesets/phases/ddos_l7/entrypoint`,
+  { method: "PUT", headers: { Authorization: `Bearer ${apiToken}`, "Content-Type": "application/json" }, body: JSON.stringify(config) }
+);
+```
+
+## Route-specific Sensitivity
+
+```typescript
+// Lower sensitivity for bursty API endpoints
+const config = {
+  description: "Route-specific protection",
+  rules: [
+    {
+      expression: "not http.request.uri.path matches \"^/api/\"",
+      action: "execute",
+      action_parameters: {
+        id: managedRulesetId,
+        overrides: { sensitivity_level: "default", action: "block" },
+      },
+    },
+    {
+      expression: "http.request.uri.path matches \"^/api/\"",
+      action: "execute",
+      action_parameters: {
+        id: managedRulesetId,
+        overrides: { sensitivity_level: "low", action: "managed_challenge" },
+      },
+    },
+  ],
+};
+```
+
+## Progressive Enhancement
+
+```typescript
+enum ProtectionLevel { MONITORING = "monitoring", LOW = "low", MEDIUM = "medium", HIGH = "high" }
+
+async function setProtectionLevel(zoneId: string, level: ProtectionLevel, managedRulesetId: string, apiToken: string) {
+  const levelConfig = {
+    [ProtectionLevel.MONITORING]: { action: "log", sensitivity: "eoff" },
+    [ProtectionLevel.LOW]: { action: "managed_challenge", sensitivity: "low" },
+    [ProtectionLevel.MEDIUM]: { action: "managed_challenge", sensitivity: "medium" },
+    [ProtectionLevel.HIGH]: { action: "block", sensitivity: "default" },
+  } as const;
+
+  const settings = levelConfig[level];
+  const config = {
+    description: `DDoS protection level: ${level}`,
+    rules: [{
+      expression: "true",
+      action: "execute",
+      action_parameters: {
+        id: managedRulesetId,
+        overrides: { action: settings.action, sensitivity_level: settings.sensitivity },
+      },
+    }],
+  };
+
+  return fetch(/* ... */);
+}
+
+// Gradual rollout: Week 1 MONITORING → Week 2 LOW → Week 3 MEDIUM → Week 4 HIGH
+```
+
+## Dynamic Response to Attacks
+
+```typescript
+// Worker adjusts settings based on attack patterns
+interface Env {
+  CLOUDFLARE_API_TOKEN: string;
+  ZONE_ID: string;
+  KV_NAMESPACE: KVNamespace;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.url.includes("/attack-detected")) {
+      const attackData = await request.json();
+      await env.KV_NAMESPACE.put(`attack:${Date.now()}`, JSON.stringify(attackData), { expirationTtl: 86400 });
+
+      const recentAttacks = await getRecentAttacks(env.KV_NAMESPACE);
+      if (recentAttacks.length > 5) {
+        await increaseProtection(env.ZONE_ID, "managed-ruleset-id", env.CLOUDFLARE_API_TOKEN);
+        return new Response("Protection increased", { status: 200 });
+      }
+    }
+    return new Response("OK");
+  },
+
+  // Cron: auto-decrease after quiet period
+  async scheduled(event: ScheduledEvent, env: Env): Promise<void> {
+    const recentAttacks = await getRecentAttacks(env.KV_NAMESPACE);
+    if (recentAttacks.length === 0) {
+      await normalizeProtection(env.ZONE_ID, "managed-ruleset-id", env.CLOUDFLARE_API_TOKEN);
+    }
+  },
+};
+```
+
+## Multi-rule Tiered Protection (Enterprise Advanced)
+
+```typescript
+// Up to 10 rules with different conditions
+const config = {
+  description: "Multi-tier DDoS protection",
+  rules: [
+    { // Strictest for unknown traffic
+      expression: "not ip.src in $known_ips and not cf.bot_management.score gt 30",
+      action: "execute",
+      action_parameters: {
+        id: managedRulesetId,
+        overrides: { sensitivity_level: "default", action: "block" },
+      },
+    },
+    { // Medium for verified bots
+      expression: "cf.bot_management.verified_bot",
+      action: "execute",
+      action_parameters: {
+        id: managedRulesetId,
+        overrides: { sensitivity_level: "medium", action: "managed_challenge" },
+      },
+    },
+    { // Low for trusted IPs
+      expression: "ip.src in $trusted_ips",
+      action: "execute",
+      action_parameters: {
+        id: managedRulesetId,
+        overrides: { sensitivity_level: "low" },
+      },
+    },
+  ],
+};
+```
+
+## Defense in Depth
+
+Combine DDoS with WAF, Rate Limiting, Bot Management. Layer protections at different levels.
+
+See [configuration.md](./configuration.md) for rule structure details.

--- a/.agent/services/hosting/cloudflare-platform/references/do-storage/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/do-storage/README.md
@@ -1,0 +1,62 @@
+# Cloudflare Durable Objects Storage
+
+Persistent storage API for Durable Objects with SQLite and KV backends, PITR, and automatic concurrency control.
+
+## Overview
+
+DO Storage provides:
+- SQLite-backed (recommended) or KV-backed
+- SQL API + synchronous/async KV APIs
+- Automatic input/output gates (race-free)
+- 30-day point-in-time recovery (PITR)
+- Transactions and alarms
+
+**Use cases:** Stateful coordination, real-time collaboration, counters, sessions, rate limiters
+
+## Quick Start
+
+```typescript
+export class Counter extends DurableObject {
+  sql: SqlStorage;
+  
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+    this.sql.exec('CREATE TABLE IF NOT EXISTS data(key TEXT PRIMARY KEY, value INTEGER)');
+  }
+  
+  async increment(): Promise<number> {
+    this.sql.exec('INSERT OR REPLACE INTO data VALUES (?, ?) RETURNING value', 'counter', 
+      (this.sql.exec('SELECT value FROM data WHERE key = ?', 'counter').one()?.value || 0) + 1);
+  }
+}
+```
+
+## Storage Backends
+
+| Backend | Create Method | APIs | PITR |
+|---------|---------------|------|------|
+| SQLite (recommended) | `new_sqlite_classes` | SQL + sync KV + async KV | ✅ |
+| KV (legacy) | `new_classes` | async KV only | ❌ |
+
+## Core APIs
+
+- **SQL API** (`ctx.storage.sql`): Full SQLite with extensions (FTS5, JSON, math)
+- **Sync KV** (`ctx.storage.kv`): Synchronous key-value (SQLite only)
+- **Async KV** (`ctx.storage`): Asynchronous key-value (both backends)
+- **Transactions** (`transactionSync()`, `transaction()`)
+- **PITR** (`getBookmarkForTime()`, `onNextSessionRestoreBookmark()`)
+- **Alarms** (`setAlarm()`, `alarm()` handler)
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - wrangler.jsonc migrations, SQLite vs KV setup
+- [api.md](./api.md) - SQL exec/cursors, KV methods, transactions, alarms, PITR
+- [patterns.md](./patterns.md) - Schema migrations, caching, rate limiting, batch processing
+- [gotchas.md](./gotchas.md) - Concurrency gates, transaction rules, SQL limits, async pitfalls
+
+## See Also
+
+- [durable-objects](../durable-objects/) - DO fundamentals and coordination patterns
+- [workers](../workers/) - Worker runtime for DO stubs
+- [d1](../d1/) - Shared database alternative to per-DO storage

--- a/.agent/services/hosting/cloudflare-platform/references/do-storage/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/do-storage/api.md
@@ -1,0 +1,89 @@
+# DO Storage API Reference
+
+## SQL API
+
+```typescript
+const cursor = this.sql.exec('SELECT * FROM users WHERE email = ?', email);
+for (let row of cursor) {} // Objects: { id, name, email }
+cursor.toArray(); cursor.one(); // Single row (throws if != 1)
+for (let row of cursor.raw()) {} // Arrays: [1, "Alice", "..."]
+cursor.columnNames; // ["id", "name", "email"]
+cursor.rowsRead; cursor.rowsWritten; // Billing
+
+type User = { id: number; name: string; email: string };
+const user = this.sql.exec<User>('...', userId).one();
+```
+
+## Sync KV API (SQLite only)
+
+```typescript
+this.ctx.storage.kv.get("counter"); // undefined if missing
+this.ctx.storage.kv.put("counter", 42);
+this.ctx.storage.kv.put("user", { name: "Alice", age: 30 });
+this.ctx.storage.kv.delete("counter"); // true if existed
+
+for (let [key, value] of this.ctx.storage.kv.list()) {}
+
+// List options: start, prefix, reverse, limit
+this.ctx.storage.kv.list({ start: "user:", prefix: "user:", reverse: true, limit: 100 });
+```
+
+## Async KV API (Both backends)
+
+```typescript
+await this.ctx.storage.get("key"); // Single
+await this.ctx.storage.get(["key1", "key2"]); // Multiple (max 128)
+await this.ctx.storage.put("key", value); // Single
+await this.ctx.storage.put({ "key1": "v1", "key2": { nested: true } }); // Multiple (max 128)
+await this.ctx.storage.delete("key");
+await this.ctx.storage.delete(["key1", "key2"]);
+await this.ctx.storage.list({ prefix: "user:", limit: 100 });
+
+// Options: allowConcurrency, noCache, allowUnconfirmed
+await this.ctx.storage.get("key", { allowConcurrency: true, noCache: true });
+await this.ctx.storage.put("key", value, { allowUnconfirmed: true, noCache: true });
+```
+
+## Transactions
+
+```typescript
+// Sync (SQL/sync KV only)
+this.ctx.storage.transactionSync(() => {
+  this.sql.exec('UPDATE accounts SET balance = balance - ? WHERE id = ?', 100, 1);
+  this.sql.exec('UPDATE accounts SET balance = balance + ? WHERE id = ?', 100, 2);
+  return "result";
+});
+
+// Async
+await this.ctx.storage.transaction(async () => {
+  const value = await this.ctx.storage.get("counter");
+  await this.ctx.storage.put("counter", value + 1);
+  if (value > 100) this.ctx.storage.rollback(); // Explicit rollback
+});
+```
+
+## Point-in-Time Recovery
+
+```typescript
+await this.ctx.storage.getCurrentBookmark();
+await this.ctx.storage.getBookmarkForTime(Date.now() - 2 * 24 * 60 * 60 * 1000);
+await this.ctx.storage.onNextSessionRestoreBookmark(bookmark);
+this.ctx.abort(); // Restart to apply; bookmarks lexically comparable (earlier < later)
+```
+
+## Alarms
+
+```typescript
+await this.ctx.storage.setAlarm(Date.now() + 60000); // Timestamp or Date
+await this.ctx.storage.getAlarm();
+await this.ctx.storage.deleteAlarm();
+
+async alarm() { await this.doScheduledWork(); }
+```
+
+## Misc
+
+```typescript
+await this.ctx.storage.deleteAll(); // Atomic for SQLite; alarm NOT included
+this.ctx.storage.sql.databaseSize; // Bytes
+```

--- a/.agent/services/hosting/cloudflare-platform/references/do-storage/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/do-storage/configuration.md
@@ -1,0 +1,116 @@
+# DO Storage Configuration
+
+## SQLite-backed (Recommended)
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["Counter", "Session", "RateLimiter"]
+    }
+  ]
+}
+```
+
+**wrangler.toml:**
+```toml
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["Counter", "Session"]
+```
+
+## KV-backed (Legacy)
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_classes": ["OldCounter"]
+    }
+  ]
+}
+```
+
+## TypeScript Setup
+
+```typescript
+export class MyDurableObject extends DurableObject {
+  sql: SqlStorage;
+  
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+    
+    // Initialize schema
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS users(
+        id INTEGER PRIMARY KEY,
+        name TEXT NOT NULL,
+        email TEXT UNIQUE
+      );
+    `);
+  }
+}
+
+// Binding
+interface Env {
+  MY_DO: DurableObjectNamespace;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const id = env.MY_DO.idFromName('singleton');
+    const stub = env.MY_DO.get(id);
+    return stub.fetch(request);
+  }
+}
+```
+
+## CPU Limits
+
+```jsonc
+{
+  "limits": {
+    "cpu_ms": 300000  // 5 minutes (default 30s)
+  }
+}
+```
+
+```toml
+[limits]
+cpu_ms = 300_000
+```
+
+## Location Control
+
+```typescript
+// Jurisdiction (GDPR/FedRAMP)
+const euNamespace = env.MY_DO.jurisdiction("eu");
+const id = euNamespace.newUniqueId();
+const stub = euNamespace.get(id);
+
+// Location hint (best effort)
+const stub = env.MY_DO.get(id, { locationHint: "enam" });
+// Hints: wnam, enam, sam, weur, eeur, apac, oc, afr, me
+```
+
+## Initialization
+
+```typescript
+export class Counter extends DurableObject {
+  value: number;
+  
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    
+    // Block concurrent requests during init
+    ctx.blockConcurrencyWhile(async () => {
+      this.value = (await ctx.storage.get("value")) || 0;
+    });
+  }
+}
+```

--- a/.agent/services/hosting/cloudflare-platform/references/do-storage/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/do-storage/gotchas.md
@@ -1,0 +1,93 @@
+# DO Storage Gotchas & Troubleshooting
+
+## Concurrency Gates
+
+**Input gate:** No new events while storage op pending (except storage completions)
+**Output gate:** Network messages held until storage writes confirm
+
+```typescript
+// ✅ NO RACE: Auto serialization
+async getUniqueNumber() {
+  let val = await this.ctx.storage.get("counter"); // Other requests blocked
+  await this.ctx.storage.put("counter", val + 1);
+  return val;
+}
+
+// ❌ RACE: Concurrent calls from same event
+async handler() {
+  const [v1, v2] = await Promise.all([this.getUniqueNumber(), this.getUniqueNumber()]); // v1 === v2!
+}
+
+// ✅ SAFE: Response waits for write confirm; if write fails, response discarded & restart
+async increment() {
+  let val = await this.ctx.storage.get("counter");
+  this.ctx.storage.put("counter", val + 1); // Don't await
+  return new Response(String(val));
+}
+```
+
+## Transaction Rules
+
+```typescript
+// ❌ WRONG: Direct SQL statements
+this.sql.exec('BEGIN TRANSACTION');
+
+// ✅ CORRECT: Use transactionSync() or async transaction()
+this.ctx.storage.transactionSync(() => { this.sql.exec('UPDATE ...'); });
+await this.ctx.storage.transaction(async () => { await this.ctx.storage.put("key", value); });
+
+// ❌ WRONG: Async in transactionSync
+this.ctx.storage.transactionSync(async () => { await fetch(...); }); // Error!
+```
+
+## Limits
+
+**SQL:** Max cols/table: 100; string/BLOB/row: 2MB; statement: 100KB; params: 100; LIKE/GLOB: 50B
+**Storage:** SQLite: 10GB/object, 2MB key+value; KV: Unlimited storage, key 2KiB, value 128KiB
+
+## TypeScript Type Safety
+
+```typescript
+// ❌ Types don't validate at runtime
+type User = { id: number; name: string };
+const user = this.sql.exec<User>('SELECT id FROM users WHERE id = ?', id).one(); // Only has { id }!
+
+// ✅ Query must match type
+const user = this.sql.exec<User>('SELECT id, name FROM users WHERE id = ?', id).one();
+```
+
+## Alarm Persistence
+
+```typescript
+// ❌ deleteAll() doesn't delete alarms
+await this.ctx.storage.deleteAll(); // Alarm remains!
+
+// ✅ Delete alarm explicitly
+await this.ctx.storage.deleteAlarm();
+await this.ctx.storage.deleteAll();
+```
+
+## Auto Caching & Bypass
+
+```typescript
+// Built-in cache makes simple code fast
+async getUniqueNumber() {
+  let val = await this.ctx.storage.get("counter"); // Cached after first
+  await this.ctx.storage.put("counter", val + 1);  // Instant cache write
+  return val;
+}
+
+// Bypass opts: allowConcurrency, noCache, allowUnconfirmed
+await this.ctx.storage.get("key", { allowConcurrency: true, noCache: true });
+```
+
+## Common Errors & Best Practices
+
+**Slow perf:** Use sync KV API (`ctx.storage.kv`) vs async  
+**Races:** Check concurrent calls from same event (not protected)  
+**High billing:** Check `rowsRead`/`rowsWritten`; verify unused objects call `deleteAll()`  
+**Overload:** Single DO soft limit ~1K req/sec; shard
+
+**Do:** Use SQLite-backed; sync KV for simple key-value; don't await writes unnecessarily (output gate protects); use `blockConcurrencyWhile()` for init; delete alarms AND storage when cleaning
+
+**Don't:** Use SQL transaction statements directly; initiate concurrent storage ops from same event; assume TypeScript types validate at runtime

--- a/.agent/services/hosting/cloudflare-platform/references/do-storage/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/do-storage/patterns.md
@@ -1,0 +1,112 @@
+# DO Storage Patterns & Best Practices
+
+## Schema Migration
+
+```typescript
+export class MyDurableObject extends DurableObject {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+    this.sql.exec(`CREATE TABLE IF NOT EXISTS _meta(key TEXT PRIMARY KEY, value TEXT)`);
+    const ver = this.sql.exec("SELECT value FROM _meta WHERE key = 'schema_version'").toArray()[0]?.value || "0";
+    if (ver === "0") this.sql.exec(`CREATE TABLE users(id INTEGER PRIMARY KEY, name TEXT); INSERT OR REPLACE INTO _meta VALUES ('schema_version', '1')`);
+    if (ver === "1") this.sql.exec(`ALTER TABLE users ADD COLUMN email TEXT; UPDATE _meta SET value = '2' WHERE key = 'schema_version'`);
+  }
+}
+```
+
+## In-Memory Caching
+
+```typescript
+export class UserCache extends DurableObject {
+  cache = new Map<string, User>();
+  async getUser(id: string): Promise<User> {
+    if (this.cache.has(id)) return this.cache.get(id)!;
+    const user = await this.ctx.storage.get<User>(`user:${id}`);
+    if (user) this.cache.set(id, user);
+    return user;
+  }
+  async updateUser(id: string, data: Partial<User>) {
+    const updated = { ...await this.getUser(id), ...data };
+    this.cache.set(id, updated);
+    await this.ctx.storage.put(`user:${id}`, updated);
+    return updated;
+  }
+}
+```
+
+## Rate Limiting
+
+```typescript
+export class RateLimiter extends DurableObject {
+  async checkLimit(key: string, limit: number, window: number): Promise<boolean> {
+    const now = Date.now();
+    this.sql.exec('DELETE FROM requests WHERE key = ? AND timestamp < ?', key, now - window);
+    const count = this.sql.exec('SELECT COUNT(*) as count FROM requests WHERE key = ?', key).one().count;
+    if (count >= limit) return false;
+    this.sql.exec('INSERT INTO requests (key, timestamp) VALUES (?, ?)', key, now);
+    return true;
+  }
+}
+```
+
+## Batch Processing with Alarms
+
+```typescript
+export class BatchProcessor extends DurableObject {
+  pending: string[] = [];
+  async addItem(item: string) {
+    this.pending.push(item);
+    if (!await this.ctx.storage.getAlarm()) await this.ctx.storage.setAlarm(Date.now() + 5000);
+  }
+  async alarm() {
+    const items = [...this.pending];
+    this.pending = [];
+    this.sql.exec(`INSERT INTO processed_items (item, timestamp) VALUES ${items.map(() => "(?, ?)").join(", ")}`, ...items.flatMap(item => [item, Date.now()]));
+  }
+}
+```
+
+## Initialization Pattern
+
+```typescript
+export class Counter extends DurableObject {
+  value: number;
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    ctx.blockConcurrencyWhile(async () => { this.value = (await ctx.storage.get("value")) || 0; });
+  }
+  async increment() {
+    this.value++;
+    this.ctx.storage.put("value", this.value); // Don't await (output gate protects)
+    return this.value;
+  }
+}
+```
+
+## Safe Counter / Optimized Write
+
+```typescript
+// Input gate blocks other requests
+async getUniqueNumber(): Promise<number> {
+  let val = await this.ctx.storage.get("counter");
+  await this.ctx.storage.put("counter", val + 1);
+  return val;
+}
+
+// No await on write - output gate delays response until write confirms
+async increment(): Promise<Response> {
+  let val = await this.ctx.storage.get("counter");
+  this.ctx.storage.put("counter", val + 1);
+  return new Response(String(val));
+}
+```
+
+## Cleanup
+
+```typescript
+async cleanup() {
+  await this.ctx.storage.deleteAlarm(); // Separate from deleteAll
+  await this.ctx.storage.deleteAll();
+}
+```

--- a/.agent/services/hosting/cloudflare-platform/references/durable-objects/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/durable-objects/README.md
@@ -1,0 +1,125 @@
+# Cloudflare Durable Objects
+
+Expert guidance for building stateful applications with Cloudflare Durable Objects.
+
+## Overview
+
+Durable Objects combine compute with storage in globally-unique, strongly-consistent packages:
+- **Globally unique instances**: Each DO has unique ID for multi-client coordination
+- **Co-located storage**: Fast, strongly-consistent storage with compute
+- **Automatic placement**: Objects spawn near first request location
+- **Stateful serverless**: In-memory state + persistent storage
+- **Single-threaded**: Serial request processing (no race conditions)
+
+## When to Use DOs
+
+Use DOs for **stateful coordination**, not stateless request handling:
+- **Coordination**: Multiple clients interacting with shared state (chat rooms, multiplayer games)
+- **Strong consistency**: Operations must serialize to avoid races (booking systems, inventory)
+- **Per-entity storage**: Each user/tenant/resource needs isolated database (multi-tenant SaaS)
+- **Persistent connections**: Long-lived WebSockets that survive across requests
+- **Per-entity scheduled work**: Each entity needs its own timer (subscription renewals, game timeouts)
+
+## When NOT to Use DOs
+
+| Scenario | Use Instead |
+|----------|-------------|
+| Stateless request handling | Workers |
+| Maximum global distribution | Workers |
+| High fan-out (independent requests) | Workers |
+| Global singleton handling all traffic | Shard across multiple DOs |
+| High-frequency pub/sub | Queues |
+| Long-running continuous processes | Workers + Alarms |
+| Chatty microservice (every request) | Reconsider architecture |
+| Eventual consistency OK, read-heavy | KV |
+| Relational queries across entities | D1 |
+
+## Design Heuristics
+
+Model each DO around your **atom of coordination**—the logical unit needing serialized access (user, room, document, session).
+
+| Characteristic | Feels Right | Question It | Reconsider |
+|----------------|-------------|-------------|------------|
+| Requests/sec (sustained) | < 100 | 100-500 | > 500 |
+| Storage keys | < 100 | 100-1000 | > 1000 |
+| Total state size | < 10MB | 10MB-100MB | > 1GB |
+| Alarm frequency | Minutes-hours | Every 30s | Every few seconds |
+| WebSocket duration | Short bursts | Hours (hibernating) | Days always-on |
+| Fan-out from this DO | Never/rarely | To < 10 DOs | To 100+ DOs |
+
+## Core Concepts
+
+### Class Structure
+All DOs extend `DurableObject` base class with constructor receiving `DurableObjectState` (storage, WebSockets, alarms) and `Env` (bindings).
+
+### Accessing from Workers
+Workers use bindings to get stubs, then call RPC methods directly (recommended) or use fetch handler (legacy).
+
+### ID Generation
+- `idFromName()`: Deterministic, named coordination
+- `newUniqueId()`: Random IDs for sharding
+- `idFromString()`: Derive from existing IDs
+- Jurisdiction option: Data locality
+
+### Storage Options
+- **SQLite** (recommended): Structured data, transactions, 10GB/DO
+- **Synchronous KV API**: Simple key-value on SQLite objects
+- **Asynchronous KV API**: Legacy/advanced use cases
+
+### Special Features
+- **Alarms**: Schedule future execution per-DO
+- **WebSocket Hibernation**: Zero-cost idle connections
+- **Point-in-Time Recovery**: Restore to any point in 30 days
+
+## Quick Start
+
+```typescript
+import { DurableObject } from "cloudflare:workers";
+
+export class Counter extends DurableObject<Env> {
+  async increment(): Promise<number> {
+    const result = this.ctx.storage.sql.exec(
+      `INSERT INTO counters (id, value) VALUES (1, 1)
+       ON CONFLICT(id) DO UPDATE SET value = value + 1
+       RETURNING value`
+    ).one();
+    return result.value;
+  }
+}
+
+// Worker access
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const id = env.COUNTER.idFromName("global");
+    const stub = env.COUNTER.get(id);
+    const count = await stub.increment();
+    return new Response(`Count: ${count}`);
+  }
+};
+```
+
+## Essential Commands
+
+```bash
+npx wrangler dev              # Local dev with DOs
+npx wrangler dev --remote     # Test against prod DOs
+npx wrangler deploy           # Deploy + auto-apply migrations
+```
+
+## Resources
+
+**Docs**: https://developers.cloudflare.com/durable-objects/  
+**API Reference**: https://developers.cloudflare.com/durable-objects/api/  
+**Examples**: https://developers.cloudflare.com/durable-objects/examples/
+
+## In This Reference
+
+- [Configuration](./configuration.md) - wrangler.jsonc setup, migrations, bindings
+- [API](./api.md) - Class structure, storage APIs, alarms, WebSockets
+- [Patterns](./patterns.md) - Rate limiting, locks, real-time collab, sessions
+- [Gotchas](./gotchas.md) - Limits, common issues, troubleshooting
+
+## See Also
+
+- [Workers](../workers/README.md) - Core Workers runtime
+- [DO Storage](../do-storage/README.md) - Deep dive on storage APIs

--- a/.agent/services/hosting/cloudflare-platform/references/durable-objects/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/durable-objects/api.md
@@ -1,0 +1,152 @@
+# Durable Objects API
+
+## Class Structure
+
+```typescript
+import { DurableObject } from "cloudflare:workers";
+
+export class MyDO extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    // Initialize storage/run migrations before any requests
+    ctx.blockConcurrencyWhile(async () => {
+      await this.migrate();
+    });
+  }
+  async myMethod(arg: string): Promise<string> { return arg; }
+  async alarm() { }
+  async webSocketMessage(ws: WebSocket, msg: string | ArrayBuffer) { }
+}
+```
+
+## Concurrency Model
+
+### Input/Output Gates
+
+DOs are single-threaded but async/await allows request interleaving. The runtime uses **gates** to prevent data races:
+
+**Input gates** block new events while synchronous JS executes. Awaiting async ops opens the gate, allowing interleaving. Storage operations provide special protection.
+
+**Output gates** hold outgoing network messages until pending storage writes complete—clients never see confirmation of unpersisted data.
+
+### Write Coalescing
+
+Multiple storage writes without intervening `await` are automatically batched into a single atomic transaction:
+
+```typescript
+async transfer(fromId: string, toId: string, amount: number) {
+  // All three writes commit together atomically
+  this.ctx.storage.sql.exec("UPDATE accounts SET balance = balance - ? WHERE id = ?", amount, fromId);
+  this.ctx.storage.sql.exec("UPDATE accounts SET balance = balance + ? WHERE id = ?", amount, toId);
+  this.ctx.storage.sql.exec("INSERT INTO transfers (from_id, to_id, amount) VALUES (?, ?, ?)", fromId, toId, amount);
+}
+```
+
+### blockConcurrencyWhile()
+
+Guarantees no other events process until callback completes. **Use sparingly**—only for initialization/migrations.
+
+```typescript
+constructor(ctx: DurableObjectState, env: Env) {
+  super(ctx, env);
+  ctx.blockConcurrencyWhile(async () => {
+    const version = this.ctx.storage.sql.exec<{ version: number }>("PRAGMA user_version").one()?.version ?? 0;
+    if (version < 1) {
+      this.ctx.storage.sql.exec(`CREATE TABLE IF NOT EXISTS data (...); PRAGMA user_version = 1;`);
+    }
+  });
+}
+```
+
+**Anti-pattern**: Using `blockConcurrencyWhile()` on every request or across I/O (fetch, KV, R2) severely degrades throughput. For regular requests, rely on input/output gates and write coalescing.
+
+### Optimistic Locking (Non-Storage I/O)
+
+Input gates only protect during storage ops. External I/O like `fetch()` allows interleaving. Use check-and-set:
+
+```typescript
+async updateFromExternal(key: string) {
+  const version = this.ctx.storage.sql.exec<{ v: number }>("SELECT version as v FROM data WHERE key = ?", key).one()?.v;
+  const externalData = await fetch("https://api.example.com/data");  // Other requests can interleave here
+  const newVersion = this.ctx.storage.sql.exec<{ v: number }>("SELECT version as v FROM data WHERE key = ?", key).one()?.v;
+  
+  if (version !== newVersion) throw new Error("Concurrent modification");
+  this.ctx.storage.sql.exec("UPDATE data SET value = ?, version = version + 1 WHERE key = ?", await externalData.text(), key);
+}
+```
+
+## SQLite Storage
+
+```typescript
+// Query
+const cursor = this.ctx.storage.sql.exec("SELECT * FROM users WHERE age > ?", 18);
+cursor.toArray()          // All rows
+cursor.one()              // 1 row or throw
+cursor.raw().toArray()    // [[1, 'Alice']]
+cursor.rowsRead, cursor.rowsWritten, cursor.columnNames
+this.ctx.storage.sql.databaseSize
+
+// Schema
+this.ctx.storage.sql.exec("CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, name TEXT)");
+```
+
+## KV Storage
+
+```typescript
+// Sync (SQLite only)
+this.ctx.storage.kv.get/put/delete("key", value)
+this.ctx.storage.kv.list({ prefix: "user:" })
+
+// Async
+await this.ctx.storage.get/put/delete("key", value)
+await this.ctx.storage.put({ k1: "a", k2: "b" })  // Batch 128 max
+await this.ctx.storage.list({ prefix: "user:", start: "user:100", limit: 50 })
+await this.ctx.storage.deleteAll()
+```
+
+## Transactions
+
+```typescript
+// Sync
+this.ctx.storage.transactionSync(() => { /* SQL ops */ });
+
+// Async
+await this.ctx.storage.transaction(async (txn) => {
+  await txn.get/put/delete("key", value);  // Throw to rollback
+});
+```
+
+## Point-in-Time Recovery
+
+```typescript
+await this.ctx.storage.getCurrentBookmark()
+await this.ctx.storage.getBookmarkForTime(Date.now() - 86400000)
+await this.ctx.storage.onNextSessionRestoreBookmark(bookmark)  // Call ctx.abort() after
+```
+
+## Alarms
+
+```typescript
+await this.ctx.storage.setAlarm(Date.now() + 3600000)
+await this.ctx.storage.getAlarm()
+await this.ctx.storage.deleteAlarm()
+async alarm() { /* runs when fires */ }
+```
+
+## WebSockets
+
+```typescript
+async fetch(req: Request): Promise<Response> {
+  const [client, server] = Object.values(new WebSocketPair());
+  this.ctx.acceptWebSocket(server, ["room:123"]);
+  server.serializeAttachment({ userId: "abc" });
+  return new Response(null, { status: 101, webSocket: client });
+}
+
+async webSocketMessage(ws: WebSocket, msg: string | ArrayBuffer) {
+  const data = ws.deserializeAttachment();
+  for (const c of this.ctx.getWebSockets()) c.send(msg);
+}
+
+// Management: getWebSockets(), getTags(ws), ws.send/close()
+```

--- a/.agent/services/hosting/cloudflare-platform/references/durable-objects/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/durable-objects/configuration.md
@@ -1,0 +1,148 @@
+# Durable Objects Configuration
+
+## Basic Setup
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2024-04-03",
+  "durable_objects": {
+    "bindings": [
+      { "name": "MY_DO", "class_name": "MyDO" },
+      { "name": "EXTERNAL", "class_name": "ExternalDO", "script_name": "other-worker" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["MyDO"] }
+  ]
+}
+```
+
+## Migrations
+
+```jsonc
+{
+  "migrations": [
+    // Create new SQLite-backed class (recommended for new classes)
+    { "tag": "v1", "new_sqlite_classes": ["MyDO"] },
+    
+    // Create new KV-backed class (legacy, paid only)
+    // { "tag": "v1", "new_classes": ["MyDO"] },
+    
+    // Rename class - preserves all data and object IDs
+    { "tag": "v2", "renamed_classes": [{ "from": "OldName", "to": "NewName" }] },
+    
+    // Transfer between scripts - requires coordination
+    { "tag": "v3", "transferred_classes": [{ "from": "Src", "from_script": "old-worker", "to": "Dest" }] },
+    
+    // DELETE - DESTROYS ALL DATA PERMANENTLY, NO RECOVERY
+    { "tag": "v4", "deleted_classes": ["Obsolete"] }
+  ]
+}
+```
+
+**Migration rules:**
+- Tags must be unique and sequential
+- No rollback mechanism—test with `--dry-run` first
+- Auto-applied on deploy
+- `renamed_classes` preserves data and IDs
+- `deleted_classes` is irreversible—all storage gone
+- Transfers between scripts require both scripts deployed with coordinated migrations
+
+## Advanced
+
+```jsonc
+{
+  "limits": { "cpu_ms": 300000 },  // Default 30s, max 300s
+  "env": {
+    "production": {
+      "durable_objects": {
+        "bindings": [{ "name": "MY_DO", "class_name": "MyDO", "environment": "production" }]
+      }
+    }
+  }
+}
+```
+
+## Types
+
+```typescript
+import { DurableObject } from "cloudflare:workers";
+
+interface Env {
+  MY_DO: DurableObjectNamespace<MyDO>;
+}
+
+export class MyDO extends DurableObject<Env> {}
+
+type DurableObjectNamespace<T> = {
+  newUniqueId(options?: { jurisdiction?: string }): DurableObjectId;
+  idFromName(name: string): DurableObjectId;
+  idFromString(id: string): DurableObjectId;
+  get(id: DurableObjectId): DurableObjectStub<T>;
+};
+```
+
+## Testing with Vitest
+
+```typescript
+// vitest.config.ts
+import { defineWorkersConfig } from "@cloudflare/vitest-pool-workers/config";
+
+export default defineWorkersConfig({
+  test: {
+    poolOptions: {
+      workers: { wrangler: { configPath: "./wrangler.toml" } },
+    },
+  },
+});
+```
+
+```typescript
+// test/my-do.test.ts
+import { env, runInDurableObject, runDurableObjectAlarm } from "cloudflare:test";
+import { describe, it, expect } from "vitest";
+
+describe("MyDO", () => {
+  it("handles RPC methods", async () => {
+    const id = env.MY_DO.idFromName("test");
+    const stub = env.MY_DO.get(id);
+    
+    const result = await stub.myMethod("test-arg");
+    expect(result).toBe("test-arg");
+  });
+
+  it("can access storage directly", async () => {
+    const id = env.MY_DO.idFromName("test");
+    const stub = env.MY_DO.get(id);
+    
+    await runInDurableObject(stub, async (instance, state) => {
+      const count = state.storage.sql
+        .exec<{ count: number }>("SELECT COUNT(*) as count FROM data")
+        .one();
+      expect(count.count).toBe(0);
+    });
+  });
+
+  it("can trigger alarms", async () => {
+    const id = env.MY_DO.idFromName("test");
+    const stub = env.MY_DO.get(id);
+    
+    const alarmRan = await runDurableObjectAlarm(stub);
+    expect(alarmRan).toBe(false); // No alarm scheduled
+  });
+});
+```
+
+## Commands
+
+```bash
+npx wrangler dev                                       # Local dev
+npx wrangler dev --remote                              # Test prod DOs
+npx wrangler deploy                                    # Deploy + migrations
+npx wrangler deploy --dry-run                          # Validate only
+npx wrangler durable-objects list                      # List namespaces
+npx wrangler durable-objects info <namespace> <id>     # Object info
+npx wrangler durable-objects delete <namespace> <id>   # Delete object
+```

--- a/.agent/services/hosting/cloudflare-platform/references/durable-objects/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/durable-objects/gotchas.md
@@ -1,0 +1,158 @@
+# Durable Objects Gotchas
+
+## Limits
+
+| Resource | Free | Paid |
+|----------|------|------|
+| Storage per DO | 10GB (SQLite) | 10GB (SQLite) |
+| Total storage | 5GB | Unlimited |
+| DO classes | 100 | 500 |
+| Requests/sec/DO | ~1000 | ~1000 |
+| CPU time | 30s default, 300s max | 30s default, 300s max |
+| WebSocket message | 32MiB | 32MiB |
+| SQL columns | 100 | 100 |
+| SQL statement | 100KB | 100KB |
+| Key+value size | 2MB | 2MB |
+
+## Billing Gotchas
+
+### Duration Billing Trap
+DOs bill for **wall-clock time** while active, not CPU time. WebSocket open 8 hours = 8 hours duration billing, even if DO processed 50 small messages.
+
+**Fix**: Use Hibernatable WebSockets API. DO sleeps while maintaining connections, only wakes (and bills) when messages arrive.
+
+### storage.list() on Every Request
+Storage reads are cheap but not free. Calling `storage.list()` or multiple `storage.get()` on every request adds up.
+
+**Fix**: Profile actual usage. Options:
+- `storage.get(['key1', 'key2', 'key3'])` - cheapest if only need specific keys
+- `storage.list()` once on wake, cache in memory - cheapest if serving many requests per wake cycle
+- Single `storage.get('allData')` with combined object - cheapest if often need multiple keys together
+
+### Alarm Recursion
+Scheduling `setAlarm()` every 5 minutes = 288 wake-ups/day × minimum billable duration. Across thousands of DOs, you're waking them all whether work exists or not.
+
+**Fix**: Only schedule alarms when actual work is pending. Check if alarm is needed before setting.
+
+### WebSocket Never Closes
+If users close browser tabs without proper disconnect and you don't handle it, connection stays "open" from DO's perspective, preventing hibernation.
+
+**Fix**:
+1. Handle `webSocketClose` and `webSocketError` events
+2. Implement heartbeat/ping-pong to detect dead connections
+3. Use Hibernatable WebSockets API properly
+
+### Singleton vs Sharding
+Global singleton DO handling all traffic = bottleneck + continuous duration billing (never hibernates).
+
+| Design | Cost Pattern |
+|--------|--------------|
+| One global DO | Never hibernates, continuous billing |
+| Per-user DO | Each only wakes for their requests, most hibernate |
+| Per-user-per-hour | Many cold starts, many minimum durations |
+
+**Fix**: Use per-entity DOs (per-user, per-room, per-document). They hibernate between activity.
+
+### Batching Reads
+Five separate `storage.get()` calls > one `storage.get(['k1','k2','k3','k4','k5'])`. Each operation has overhead.
+
+**Fix**: Batch reads/writes. Writes without intervening `await` are automatically coalesced into single atomic transaction.
+
+### Hibernation State Loss
+In-memory state is **lost** when DO hibernates or evicts. Waking DO reconstructs from storage.
+
+**Fix**:
+1. Store all important state in SQLite storage
+2. Use `blockConcurrencyWhile()` in constructor to load state on wake
+3. Cache in memory for current wake cycle only
+4. Accept every wake is potentially "cold"
+
+### Fan-Out Tax
+Event notifying 1,000 DOs = 1,000 DO invocations billed immediately. Queue pattern doesn't reduce invocations but provides retries and batching.
+
+**Fix**: For time-sensitive, accept cost. For deferrable, use Queues for retry/dead-letter handling.
+
+### Idempotency Key Explosion
+Creating one DO per idempotency key (used once) = millions of single-use DOs that persist until deleted.
+
+**Fix**:
+1. Hash idempotency keys into N sharded buckets
+2. Store records as rows in single DO's SQLite table
+3. Implement TTL cleanup via alarms
+4. Consider if KV is sufficient (if strong consistency not needed)
+
+### Storage Compaction
+Individual writes billed per-operation. Writing 100 events individually = 100× the write operations vs batching.
+
+**Fix**: Batch writes. Multiple `INSERT` statements without intervening `await` coalesce into single transaction.
+
+### waitUntil() Behavior
+`ctx.waitUntil()` keeps DO alive (billed) until promises resolve. Waiting for slow external calls = paying for wait time.
+
+**Fix**: For true background work, use alarms or Queues instead of `waitUntil()`.
+
+### KV vs DO Storage
+For read-heavy, write-rare, eventually-consistent-OK data: **KV is cheaper**.
+
+| | KV | DO Storage |
+|-|----|----|
+| Reads | Global edge cache, cheap | Every read hits DO compute |
+| Writes | ~60s propagation | Immediate consistency |
+| Use case | Config, sessions, cache | Read-modify-write, coordination |
+
+## Common Issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| DO overloaded (503) | Single DO bottleneck | Shard across DOs with random/deterministic IDs |
+| Storage quota exceeded | Write failures | Upgrade plan or cleanup via alarms |
+| CPU exceeded | Terminated mid-request | Increase `limits.cpu_ms` or chunk work |
+| WebSockets disconnect | Eviction | Use hibernation + reconnection logic |
+| Migration failed | Deploy error | Check tag uniqueness, class names, use `--dry-run` |
+| RPC not found | Old compatibility_date | Update to >= 2024-04-03 or use fetch |
+| One alarm limit | Need multiple timers | Use event queue pattern (store events, single alarm) |
+| Constructor expensive | Slow cold starts | Lazy load in methods, cache after first load |
+
+## RPC vs Fetch
+
+| | RPC | Fetch |
+|-|-----|-------|
+| Type safety | Full TypeScript support | Manual parsing |
+| Simplicity | Direct method calls | HTTP request/response |
+| Performance | Slightly faster | HTTP overhead |
+| Requirement | compatibility_date >= 2024-04-03 | Always works |
+| Use case | **Default choice** | Legacy, proxying |
+
+```typescript
+// RPC (recommended)
+const result = await stub.myMethod(arg);
+
+// Fetch (legacy)
+const response = await stub.fetch(new Request("http://do/endpoint"));
+```
+
+## Migration Gotchas
+
+- Tags must be unique and sequential
+- No rollback mechanism
+- `deleted_classes` **destroys ALL data** permanently
+- Test with `--dry-run` before production deploy
+- Transfers between scripts need coordination
+- Renames preserve data and IDs
+
+## Debugging
+
+```bash
+npx wrangler dev              # Local development
+npx wrangler dev --remote     # Test against production DOs
+npx wrangler tail             # Stream logs
+npx wrangler durable-objects list
+npx wrangler durable-objects info <namespace> <id>
+```
+
+```typescript
+// Storage diagnostics
+this.ctx.storage.sql.databaseSize  // Current storage usage
+cursor.rowsRead                    // Rows scanned
+cursor.rowsWritten                 // Rows modified
+```

--- a/.agent/services/hosting/cloudflare-platform/references/durable-objects/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/durable-objects/patterns.md
@@ -1,0 +1,255 @@
+# Durable Objects Patterns
+
+## Parent-Child Relationships
+
+Don't put all data in a single DO. For hierarchical data (workspaces → projects, game servers → matches), create separate child DOs. Parent coordinates and tracks children; children handle own state independently.
+
+```typescript
+export class GameServer extends DurableObject<Env> {
+  async createMatch(matchId: string): Promise<string> {
+    // Store child reference in parent
+    this.ctx.storage.sql.exec(
+      "INSERT INTO matches (id, created_at, status) VALUES (?, ?, ?)",
+      matchId, Date.now(), "active"
+    );
+    return matchId;
+  }
+
+  async routeToMatch(matchId: string, playerId: string, action: string) {
+    // Route to child DO - operations on different children run in parallel
+    const childId = this.env.MATCH.idFromName(matchId);
+    const child = this.env.MATCH.get(childId);
+    return await child.handleAction(playerId, action);
+  }
+
+  async listMatches(): Promise<string[]> {
+    // Query parent only - children stay hibernated
+    return this.ctx.storage.sql
+      .exec<{ id: string }>("SELECT id FROM matches WHERE status = ?", "active")
+      .toArray()
+      .map(r => r.id);
+  }
+}
+```
+
+Benefits: parallelism across children, each child has own SQLite database, listing doesn't wake children.
+
+## Fleet Pattern (Hierarchical DOs)
+
+URL-based hierarchy creates infinite nesting of manager/agent relationships. Each path segment (`/team/project/task`) maps to a unique DO via `idFromName()`.
+
+```typescript
+// Worker: Route all requests based on URL path
+app.all('*', async (c) => {
+  const path = new URL(c.req.url).pathname;
+  const parts = path.split('/').filter(Boolean);
+  const doName = parts.length === 0 ? '/' : `/${parts.join('/')}`;
+  
+  const id = c.env.FLEET_DO.idFromName(doName);
+  return c.env.FLEET_DO.get(id).fetch(c.req.raw);
+});
+
+// Single unified DO class handles both manager and agent roles
+export class FleetDO extends DurableObject<Env> {
+  async deleteWithCascade() {
+    const data = await this.ctx.storage.get<{ agents: string[] }>('data');
+    const myPath = /* derive from context */;
+    
+    // Cascade delete to all children
+    for (const agent of data?.agents || []) {
+      const childPath = myPath === '/' ? `/${agent}` : `${myPath}/${agent}`;
+      const child = this.env.FLEET_DO.get(this.env.FLEET_DO.idFromName(childPath));
+      await child.fetch(new Request('https://internal' + childPath, { method: 'DELETE' }));
+    }
+    
+    await this.ctx.storage.deleteAll();
+  }
+}
+```
+
+Use cases: collaborative IDEs (file per DO), distributed task runners, IoT device management, game server infrastructure.
+
+## Per-User DO Pattern
+
+One DO per user for settings, presence, inbox, profile data. Deterministic routing via `idFromName(userId)`.
+
+```typescript
+export class UserDO extends DurableObject<Env> {
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    ctx.blockConcurrencyWhile(async () => {
+      this.ctx.storage.sql.exec(`
+        CREATE TABLE IF NOT EXISTS profile (key TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE IF NOT EXISTS inbox (id TEXT PRIMARY KEY, data TEXT, created_at INTEGER);
+      `);
+    });
+  }
+
+  async getProfile(): Promise<Record<string, string>> {
+    return Object.fromEntries(
+      this.ctx.storage.sql.exec<{ key: string; value: string }>("SELECT * FROM profile").toArray()
+        .map(r => [r.key, r.value])
+    );
+  }
+
+  async updateProfile(updates: Record<string, string>) {
+    for (const [key, value] of Object.entries(updates)) {
+      this.ctx.storage.sql.exec(
+        "INSERT OR REPLACE INTO profile (key, value) VALUES (?, ?)", key, value
+      );
+    }
+    this.broadcast({ type: 'profile_updated', data: updates });
+  }
+
+  private broadcast(msg: object) {
+    const payload = JSON.stringify(msg);
+    for (const ws of this.ctx.getWebSockets()) ws.send(payload);
+  }
+}
+
+// Worker
+const id = env.USER_DO.idFromName(userId); // deterministic per-user routing
+const user = env.USER_DO.get(id);
+```
+
+Benefits: natural ownership boundary, hibernates between user activity, WebSocket for real-time updates.
+
+## Colo-Aware Sharding
+
+Use `request.cf.colo` for geographic distribution. Rate limit per-colo before hitting DO.
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const userId = new URL(request.url).searchParams.get("userId") || "unknown";
+    const colo = request.cf?.colo || "unknown";
+    const shardKey = `${colo}:${userId}`;
+    
+    // Rate limit per-colo (counters not shared across datacenters)
+    const { success } = await env.RATE_LIMITER.limit({ key: shardKey });
+    if (!success) return new Response("Rate limited", { status: 429 });
+    
+    // Route to colo-aware DO shard
+    const stub = env.MY_DO.get(env.MY_DO.idFromName(shardKey));
+    return await stub.fetch(request);
+  }
+}
+```
+
+`request.cf.colo` returns IATA airport code (e.g., "SFO", "LHR"). Useful for high-throughput systems needing geographic awareness.
+
+## Rate Limiting
+
+```typescript
+async checkLimit(key: string, limit: number, windowMs: number): Promise<boolean> {
+  const req = await this.ctx.storage.sql.exec(
+    "SELECT COUNT(*) as count FROM requests WHERE key = ? AND timestamp > ?",
+    key, Date.now() - windowMs
+  ).one();
+  if (req.count >= limit) return false;
+  this.ctx.storage.sql.exec("INSERT INTO requests (key, timestamp) VALUES (?, ?)", key, Date.now());
+  return true;
+}
+```
+
+## Distributed Lock
+
+```typescript
+private held = false;
+async acquire(timeoutMs = 5000): Promise<boolean> {
+  if (this.held) return false;
+  this.held = true;
+  await this.ctx.storage.setAlarm(Date.now() + timeoutMs);
+  return true;
+}
+async release() { this.held = false; await this.ctx.storage.deleteAlarm(); }
+async alarm() { this.held = false; }
+```
+
+## Real-time Collaboration
+
+```typescript
+async fetch(req: Request): Promise<Response> {
+  const [client, server] = Object.values(new WebSocketPair());
+  this.ctx.acceptWebSocket(server);
+  server.send(JSON.stringify({ type: "init", content: this.ctx.storage.kv.get("doc") || "" }));
+  return new Response(null, { status: 101, webSocket: client });
+}
+
+async webSocketMessage(ws: WebSocket, msg: string) {
+  const data = JSON.parse(msg);
+  if (data.type === "edit") {
+    this.ctx.storage.kv.put("doc", data.content);
+    for (const c of this.ctx.getWebSockets()) if (c !== ws) c.send(msg);
+  }
+}
+```
+
+## Session Management
+
+```typescript
+async createSession(userId: string, data: object): Promise<string> {
+  const id = crypto.randomUUID(), exp = Date.now() + 86400000;
+  this.ctx.storage.sql.exec("INSERT INTO sessions VALUES (?, ?, ?, ?)", id, userId, JSON.stringify(data), exp);
+  await this.ctx.storage.setAlarm(exp);
+  return id;
+}
+
+async getSession(id: string): Promise<object | null> {
+  const row = this.ctx.storage.sql.exec("SELECT data FROM sessions WHERE id = ? AND expires_at > ?", id, Date.now()).one();
+  return row ? JSON.parse(row.data) : null;
+}
+
+async alarm() { this.ctx.storage.sql.exec("DELETE FROM sessions WHERE expires_at <= ?", Date.now()); }
+```
+
+## Deduplication
+
+```typescript
+private pending = new Map<string, Promise<Response>>();
+async deduplicatedFetch(url: string): Promise<Response> {
+  if (this.pending.has(url)) return this.pending.get(url)!;
+  const p = fetch(url).finally(() => this.pending.delete(url));
+  this.pending.set(url, p);
+  return p;
+}
+```
+
+## Multiple Events (Single Alarm)
+
+```typescript
+async scheduleEvent(id: string, runAt: number, repeatMs?: number) {
+  await this.ctx.storage.put(`event:${id}`, { id, runAt, repeatMs });
+  const curr = await this.ctx.storage.getAlarm();
+  if (!curr || runAt < curr) await this.ctx.storage.setAlarm(runAt);
+}
+
+async alarm() {
+  const now = Date.now(), events = await this.ctx.storage.list({ prefix: "event:" });
+  let next: number | null = null;
+  for (const [key, ev] of events) {
+    if (ev.runAt <= now) {
+      await this.processEvent(ev);
+      ev.repeatMs ? await this.ctx.storage.put(key, { ...ev, runAt: now + ev.repeatMs }) : await this.ctx.storage.delete(key);
+    }
+    if (ev.runAt > now && (!next || ev.runAt < next)) next = ev.runAt;
+  }
+  if (next) await this.ctx.storage.setAlarm(next);
+}
+```
+
+## Best Practices
+
+**Design for Hibernation**: DOs should sleep by default, wake for meaningful work, then sleep again. All important state must persist to storage—in-memory state is lost on eviction. Use `blockConcurrencyWhile()` in constructor to reload state on wake. Design so any instance could disappear and reconstruct from storage.
+
+**Atom of Coordination**: Each DO should own ONE logical unit (user, room, document, session). If data spans multiple boundaries or doesn't have natural ownership, DO may be wrong choice.
+
+**Design**: Keep objects focused, use `idFromName()` for coordination, `newUniqueId()` for sharding, minimize constructor work, leverage WebSocket hibernation
+
+**Storage**: Prefer SQLite, create indexes judiciously, batch with transactions, set alarms for cleanup, use PITR before risky ops
+
+**Performance**: One DO ~1000 req/s max - shard for more, cache in memory, avoid long ops, use alarms for deferred work
+
+**Reliability**: Handle 503 with retry+backoff, design for cold starts, test migrations, monitor alarm retries
+
+**Security**: Validate inputs in Workers, don't trust user names, rate limit DO creation, use jurisdiction tags, encrypt sensitive data

--- a/.agent/services/hosting/cloudflare-platform/references/email-routing/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/email-routing/README.md
@@ -1,0 +1,18 @@
+# Cloudflare Email Routing Skill Reference
+
+## Overview
+
+Cloudflare Email Routing enables custom email addresses for your domain that route to verified destination addresses. It's free, privacy-focused (no storage/access), and includes Email Workers for programmatic email processing.
+
+**Available to all Cloudflare customers using Cloudflare a...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/email-routing/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/email-routing/api.md
@@ -1,0 +1,46 @@
+## REST API Operations
+
+### Authentication
+
+Use API tokens (preferred) or API keys:
+
+```bash
+# API Token (recommended)
+curl -H "Authorization: Bearer $API_TOKEN" \
+  https://api.cloudflare.com/client/v4/...
+
+# API Key (legacy)
+curl -H "X-Auth-Email: $EMAIL" \
+     -H "X-Auth-Key: $API_KEY" \
+  https://api.cloudflare.com/client/v4/...
+```
+
+### Enable Email Routing
+
+```bash
+POST /zones/{zone_id}/email/routing/dns
+
+curl -X POST "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/email/routing/dns" \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Content-Type: application/json"
+```
+
+### Disable Email Routing
+
+```bash
+DELETE /zones/{zone_id}/email/routing/dns
+
+curl -X DELETE "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/email/routing/dns" \
+  -H "Authorization: Bearer $API_TOKEN"
+```
+
+### Get Email Routing Settings
+
+```bash
+GET /zones/{zone_id}/email/routing
+
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/email/routing" \
+  -H "Authorization: Bearer $API_TOKEN"
+```
+
+Resp

--- a/.agent/services/hosting/cloudflare-platform/references/email-routing/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/email-routing/configuration.md
@@ -1,0 +1,63 @@
+## Wrangler Configuration
+
+### Basic Email Worker
+
+```toml
+name = "email-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[[send_email]]
+name = "EMAIL"
+```
+
+Or in JSON:
+
+```jsonc
+{
+  "name": "email-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2024-01-01",
+  "send_email": [
+    {
+      "name": "EMAIL"
+    }
+  ]
+}
+```
+
+### With KV/R2 Bindings
+
+```toml
+name = "email-processor"
+main = "src/index.ts"
+
+[[send_email]]
+name = "EMAIL"
+
+[[kv_namespaces]]
+binding = "EMAIL_METADATA"
+id = "your-kv-namespace-id"
+
+[[r2_buckets]]
+binding = "EMAIL_BUCKET"
+bucket_name = "email-archive"
+```
+
+### Local Development
+
+Run locally with `wrangler dev`:
+
+```bash
+npx wrangler dev
+```
+
+Test receiving email via curl:
+
+```bash
+curl --request POST 'http://localhost:8787/cdn-cgi/handler/email' \
+  --url-query 'from=sender@example.com' \
+  --url-query 'to=recipient@example.com' \
+  --header 'Content-Type: application/json' \
+  --data-raw 'From: sender@example.com
+To: recipient@example.co

--- a/.agent/services/hosting/cloudflare-platform/references/email-routing/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/email-routing/gotchas.md
@@ -1,0 +1,16 @@
+## Best Practices
+
+1. **Verify destinations first**: Rules auto-disabled until destination verified
+2. **Use Email Workers for complex logic**: Don't create dozens of rules; use Workers
+3. **Monitor spam scores**: Check `X-Cf-Spamh-Score` header for filtering
+4. **Handle auth failures**: Enforce SPF/DKIM/DMARC at sender domain
+5. **Use subaddressing strategically**: Track where emails come from (`user+service@`)
+6. **Consider Worker limits**: Upgrade to Paid plan for heavy processing
+7. **Store raw emails carefully**: R2 for archival, KV for metadata
+8. **Implement proper error handling**: Always handle `setReject` cases
+9. **Test locally with wrangler dev**: Use curl to simulate email delivery
+10. **Use priority for rule ordering**: Lower priority = evaluated first
+
+## Debugging
+
+### Chec

--- a/.agent/services/hosting/cloudflare-platform/references/email-routing/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/email-routing/patterns.md
@@ -1,0 +1,46 @@
+## Common Patterns
+
+### 1. Allowlist Email Worker
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    const allowList = ["friend@example.com", "coworker@example.com"];
+    if (allowList.indexOf(message.from) == -1) {
+      message.setReject("Address not allowed");
+    } else {
+      await message.forward("inbox@corp");
+    }
+  },
+};
+```
+
+### 2. Parse Email with postal-mime
+
+```typescript
+import * as PostalMime from 'postal-mime';
+
+export default {
+  async email(message, env, ctx) {
+    const parser = new PostalMime.default();
+    const rawEmail = new Response(message.raw);
+    const email = await parser.parse(await rawEmail.arrayBuffer());
+    
+    console.log({
+      from: email.from,
+      to: email.to,
+      subject: email.subject,
+      html: email.html,
+      attachments: email.attachments
+    });
+    
+    await message.forward("destination@example.com");
+  },
+};
+```
+
+### 3. Forward with Custom Headers
+
+```typescript
+export default {
+  async email(message, env, 

--- a/.agent/services/hosting/cloudflare-platform/references/email-workers/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/email-workers/README.md
@@ -1,0 +1,598 @@
+# Cloudflare Email Workers Skill
+
+Expert guidance for building, configuring, and deploying Cloudflare Email Workers.
+
+## Overview
+
+Email Workers let you programmatically process incoming emails using Cloudflare Workers runtime. Use them to build custom email routing logic, spam filters, auto-responders, ticket systems, notification handlers, and more.
+
+## Core Architecture
+
+### Event Handler (ES Modules)
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    // Process email
+    await message.forward("destination@example.com");
+  },
+};
+```
+
+### Event Handler (Service Worker - Deprecated)
+
+```typescript
+addEventListener("email", async (event) => {
+  await event.message.forward("destination@example.com");
+});
+```
+
+**Use ES modules format for all new projects.**
+
+## ForwardableEmailMessage API
+
+### Properties
+
+```typescript
+interface ForwardableEmailMessage {
+  readonly from: string;        // Envelope From
+  readonly to: string;          // Envelope To
+  readonly headers: Headers;    // Message headers
+  readonly raw: ReadableStream; // Raw message stream
+  readonly rawSize: number;     // Message size in bytes
+  
+  setReject(reason: string): void;
+  forward(rcptTo: string, headers?: Headers): Promise<void>;
+  reply(message: EmailMessage): Promise<void>;
+}
+```
+
+### Key Methods
+
+- **`setReject(reason)`**: Reject with permanent SMTP error
+- **`forward(rcptTo, headers?)`**: Forward to verified destination (only `X-*` headers allowed)
+- **`reply(message)`**: Reply to sender with new EmailMessage
+
+### EmailMessage for Sending
+
+```typescript
+interface EmailMessage {
+  readonly from: string;
+  readonly to: string;
+}
+
+// Usage
+import { EmailMessage } from "cloudflare:email";
+const msg = new EmailMessage(from, to, rawMimeContent);
+```
+
+## Common Patterns
+
+### 1. Allowlist
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    const allowList = ["friend@example.com", "coworker@example.com"];
+    if (!allowList.includes(message.from)) {
+      message.setReject("Address not allowed");
+    } else {
+      await message.forward("inbox@corp.example.com");
+    }
+  },
+};
+```
+
+### 2. Blocklist
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    const blockList = ["spam@example.com", "badactor@example.com"];
+    if (blockList.includes(message.from)) {
+      message.setReject("Blocked sender");
+    } else {
+      await message.forward("inbox@corp.example.com");
+    }
+  },
+};
+```
+
+### 3. Parse Email with postal-mime
+
+```typescript
+import * as PostalMime from 'postal-mime';
+
+export default {
+  async email(message, env, ctx) {
+    const parser = new PostalMime.default();
+    const rawEmail = new Response(message.raw);
+    const email = await parser.parse(await rawEmail.arrayBuffer());
+    
+    // email contains: headers, from, to, subject, html, text, attachments
+    console.log(email.subject, email.from);
+    
+    await message.forward("inbox@example.com");
+  },
+};
+```
+
+### 4. Auto-Reply
+
+```typescript
+import { EmailMessage } from "cloudflare:email";
+import { createMimeMessage } from 'mimetext';
+
+export default {
+  async email(message, env, ctx) {
+    const msg = createMimeMessage();
+    msg.setSender({ name: 'Support Team', addr: 'support@example.com' });
+    msg.setRecipient(message.from);
+    msg.setHeader('In-Reply-To', message.headers.get('Message-ID'));
+    msg.setSubject('Re: Your inquiry');
+    msg.addMessage({
+      contentType: 'text/plain',
+      data: 'Thank you for contacting us. We will respond within 24 hours.',
+    });
+
+    const replyMessage = new EmailMessage(
+      'support@example.com',
+      message.from,
+      msg.asRaw()
+    );
+
+    await message.reply(replyMessage);
+    await message.forward("team@example.com");
+  },
+};
+```
+
+### 5. Conditional Routing by Subject
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    const subject = message.headers.get('Subject') || '';
+    
+    if (subject.toLowerCase().includes('billing')) {
+      await message.forward("billing@example.com");
+    } else if (subject.toLowerCase().includes('support')) {
+      await message.forward("support@example.com");
+    } else {
+      await message.forward("general@example.com");
+    }
+  },
+};
+```
+
+### 6. Store Email in KV/R2
+
+```typescript
+import * as PostalMime from 'postal-mime';
+
+export default {
+  async email(message, env, ctx) {
+    const parser = new PostalMime.default();
+    const rawEmail = new Response(message.raw);
+    const email = await parser.parse(await rawEmail.arrayBuffer());
+    
+    // Store in KV
+    const key = `email:${Date.now()}:${message.from}`;
+    await env.EMAIL_ARCHIVE.put(key, JSON.stringify({
+      from: email.from,
+      subject: email.subject,
+      receivedAt: new Date().toISOString(),
+    }));
+    
+    await message.forward("inbox@example.com");
+  },
+};
+```
+
+### 7. Webhook Notification
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    const subject = message.headers.get('Subject');
+    
+    // Notify via webhook
+    ctx.waitUntil(
+      fetch('https://hooks.slack.com/services/YOUR/WEBHOOK/URL', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text: `New email from ${message.from}: ${subject}`,
+        }),
+      })
+    );
+    
+    await message.forward("inbox@example.com");
+  },
+};
+```
+
+### 8. Size-Based Filtering
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+    
+    if (message.rawSize > MAX_SIZE) {
+      message.setReject("Message too large");
+    } else {
+      await message.forward("inbox@example.com");
+    }
+  },
+};
+```
+
+## Wrangler Configuration
+
+### Minimal Config (Local Dev)
+
+```jsonc
+// wrangler.jsonc
+{
+  "send_email": [
+    {
+      "name": "EMAIL"
+    }
+  ]
+}
+```
+
+```toml
+# wrangler.toml
+[[send_email]]
+name = "EMAIL"
+```
+
+### Full Production Config
+
+```toml
+name = "email-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+# Email binding
+[[send_email]]
+name = "EMAIL"
+
+# Add KV for email archival
+[[kv_namespaces]]
+binding = "EMAIL_ARCHIVE"
+id = "your-kv-namespace-id"
+
+# Add secrets for API keys
+[vars]
+WEBHOOK_URL = "https://example.com/webhook"
+```
+
+## Local Development
+
+### Test Receiving Email
+
+```bash
+npx wrangler dev
+```
+
+```bash
+curl --request POST 'http://localhost:8787/cdn-cgi/handler/email' \
+  --url-query 'from=sender@example.com' \
+  --url-query 'to=recipient@example.com' \
+  --header 'Content-Type: application/json' \
+  --data-raw 'From: sender@example.com
+To: recipient@example.com
+Subject: Test Email
+
+Hello world'
+```
+
+### Test Sending Email
+
+Wrangler writes sent emails to local `.eml` files:
+
+```typescript
+import { EmailMessage } from "cloudflare:email";
+import { createMimeMessage } from 'mimetext';
+
+export default {
+  async fetch(request, env, ctx) {
+    const msg = createMimeMessage();
+    msg.setSender({ name: 'Test', addr: 'sender@example.com' });
+    msg.setRecipient('recipient@example.com');
+    msg.setSubject('Test from Worker');
+    msg.addMessage({
+      contentType: 'text/plain',
+      data: 'Hello from Email Worker',
+    });
+
+    const message = new EmailMessage(
+      'sender@example.com',
+      'recipient@example.com',
+      msg.asRaw()
+    );
+    await env.EMAIL.send(message);
+    
+    return Response.json({ ok: true });
+  }
+};
+```
+
+Visit `http://localhost:8787/` to trigger. Check terminal for `.eml` file path.
+
+## Deployment
+
+### Prerequisites
+
+1. Enable Email Routing in Cloudflare dashboard
+2. Add verified destination address
+3. Configure wrangler.toml
+
+### Deploy
+
+```bash
+npx wrangler deploy
+```
+
+### Bind to Route
+
+In Cloudflare dashboard:
+1. Go to Email Routing → Email Workers
+2. Create route (e.g., `hello@yourdomain.com`)
+3. Bind route to your deployed Worker
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Max message size | 25 MiB |
+| Max rules | 200 |
+| Max destination addresses | 200 |
+| Workers CPU (free tier) | Limited (upgrade for more) |
+
+### CPU Limit Errors
+
+Monitor with `wrangler tail`:
+
+```bash
+npx wrangler tail
+```
+
+Look for `EXCEEDED_CPU` errors. Consider:
+- Upgrading to Workers Paid plan
+- Optimizing email parsing logic
+- Using `ctx.waitUntil()` for non-critical operations
+
+## Best Practices
+
+### 1. Use Verified Destinations Only
+
+`forward()` only works with verified destination addresses in your Cloudflare account.
+
+### 2. Handle Large Emails
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    if (message.rawSize > 20 * 1024 * 1024) {
+      // Don't parse huge emails synchronously
+      ctx.waitUntil(processLargeEmail(message, env));
+      await message.forward("inbox@example.com");
+      return;
+    }
+    
+    // Normal processing
+  },
+};
+```
+
+### 3. Use ctx.waitUntil for Async Operations
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    // Forward immediately
+    await message.forward("inbox@example.com");
+    
+    // Non-blocking operations
+    ctx.waitUntil(
+      Promise.all([
+        logToAnalytics(message),
+        notifySlack(message),
+        updateDatabase(message),
+      ])
+    );
+  },
+};
+```
+
+### 4. Add Custom Headers When Forwarding
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    const customHeaders = new Headers();
+    customHeaders.set('X-Processed-By', 'Email-Worker');
+    customHeaders.set('X-Original-To', message.to);
+    
+    await message.forward("inbox@example.com", customHeaders);
+  },
+};
+```
+
+### 5. Parse Headers Safely
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    const subject = message.headers.get('Subject') || '(no subject)';
+    const messageId = message.headers.get('Message-ID') || '';
+    
+    // Avoid throwing on missing headers
+  },
+};
+```
+
+### 6. Type Safety
+
+```typescript
+interface Env {
+  EMAIL: SendEmail;
+  EMAIL_ARCHIVE: KVNamespace;
+  WEBHOOK_URL: string;
+}
+
+export default {
+  async email(message: ForwardableEmailMessage, env: Env, ctx: ExecutionContext) {
+    // Fully typed
+  },
+};
+```
+
+## Common Use Cases
+
+1. **Spam/Allowlist Filtering**: Block/allow senders
+2. **Auto-Responders**: Reply with canned responses
+3. **Ticket Creation**: Parse email, create support ticket
+4. **Email Archival**: Store emails in KV/R2/D1
+5. **Notification Routing**: Forward to Slack/Discord/webhooks
+6. **Size Filtering**: Reject oversized attachments
+7. **Domain Routing**: Route by sender domain
+8. **Subject-Based Routing**: Route by keywords in subject
+9. **Attachment Handling**: Extract and store attachments
+10. **Email Analytics**: Track email metrics
+
+## Dependencies
+
+### Recommended npm Packages
+
+```json
+{
+  "dependencies": {
+    "postal-mime": "^2.3.3",    // Parse incoming emails
+    "mimetext": "^4.0.0"         // Compose outgoing emails
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.0.0",
+    "wrangler": "^3.0.0"
+  }
+}
+```
+
+## Troubleshooting
+
+### Email Not Forwarding
+
+- Verify destination address in Cloudflare dashboard
+- Check Email Routing is enabled
+- Verify route binding in dashboard
+- Check `wrangler tail` for errors
+
+### CPU Limit Errors
+
+- Upgrade to Workers Paid plan
+- Use `ctx.waitUntil()` for heavy operations
+- Avoid synchronous parsing of large emails
+
+### Local Dev Not Working
+
+- Ensure `send_email` binding in wrangler config
+- Use correct curl format with `--data-raw`
+- Check wrangler version (`npx wrangler --version`)
+
+## Advanced Patterns
+
+### Multi-Tenant Email Processing
+
+```typescript
+export default {
+  async email(message, env, ctx) {
+    const [localPart, domain] = message.to.split('@');
+    
+    // Route based on subdomain or local part
+    const tenantId = extractTenantId(localPart);
+    const config = await env.TENANT_CONFIG.get(tenantId, 'json');
+    
+    if (config?.forwardTo) {
+      await message.forward(config.forwardTo);
+    } else {
+      message.setReject("Unknown recipient");
+    }
+  },
+};
+```
+
+### Attachment Extraction
+
+```typescript
+import * as PostalMime from 'postal-mime';
+
+export default {
+  async email(message, env, ctx) {
+    const parser = new PostalMime.default();
+    const rawEmail = new Response(message.raw);
+    const email = await parser.parse(await rawEmail.arrayBuffer());
+    
+    // Process attachments
+    for (const attachment of email.attachments) {
+      const key = `attachments/${Date.now()}-${attachment.filename}`;
+      ctx.waitUntil(
+        env.ATTACHMENTS.put(key, attachment.content, {
+          metadata: {
+            contentType: attachment.mimeType,
+            from: email.from.address,
+          },
+        })
+      );
+    }
+    
+    await message.forward("inbox@example.com");
+  },
+};
+```
+
+### Conditional Auto-Reply with Rate Limiting
+
+```typescript
+import { EmailMessage } from "cloudflare:email";
+import { createMimeMessage } from 'mimetext';
+
+export default {
+  async email(message, env, ctx) {
+    const rateKey = `rate:${message.from}`;
+    const lastReply = await env.RATE_LIMIT.get(rateKey);
+    
+    if (!lastReply) {
+      // Send auto-reply
+      const msg = createMimeMessage();
+      msg.setSender({ name: 'Auto Reply', addr: 'noreply@example.com' });
+      msg.setRecipient(message.from);
+      msg.setSubject('Received your message');
+      msg.addMessage({
+        contentType: 'text/plain',
+        data: 'Thank you for contacting us.',
+      });
+      
+      const reply = new EmailMessage('noreply@example.com', message.from, msg.asRaw());
+      await message.reply(reply);
+      
+      // Rate limit: 1 reply per hour
+      ctx.waitUntil(
+        env.RATE_LIMIT.put(rateKey, Date.now().toString(), { expirationTtl: 3600 })
+      );
+    }
+    
+    await message.forward("inbox@example.com");
+  },
+};
+```
+
+## Related Documentation
+
+- [Email Routing Setup](https://developers.cloudflare.com/email-routing/get-started/enable-email-routing/)
+- [Workers Platform](https://developers.cloudflare.com/workers/)
+- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/)
+- [Workers Limits](https://developers.cloudflare.com/workers/platform/limits/)

--- a/.agent/services/hosting/cloudflare-platform/references/hyperdrive/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/hyperdrive/README.md
@@ -1,0 +1,62 @@
+# Hyperdrive
+
+Accelerates database queries from Workers via connection pooling, edge setup, query caching.
+
+## Key Features
+
+- **Connection Pooling**: Persistent connections eliminate TCP/TLS/auth handshakes (~7 round-trips)
+- **Edge Setup**: Connection negotiation at edge, pooling near origin
+- **Query Caching**: Auto-cache non-mutating queries (default 60s TTL)
+- **Support**: PostgreSQL, MySQL + compatibles (CockroachDB, Timescale, PlanetScale, Neon, Supabase)
+
+## Architecture
+
+```
+Worker → Edge (setup) → Pool (near DB) → Origin
+         ↓ cached reads
+         Cache
+```
+
+## Quick Start
+
+```bash
+# Create config
+npx wrangler hyperdrive create my-db \
+  --connection-string="postgres://user:pass@host:5432/db"
+
+# wrangler.jsonc
+{
+  "compatibility_flags": ["nodejs_compat"],
+  "hyperdrive": [{"binding": "HYPERDRIVE", "id": "<ID>"}]
+}
+```
+
+```typescript
+import { Client } from "pg";
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const client = new Client({
+      connectionString: env.HYPERDRIVE.connectionString,
+    });
+    await client.connect();
+    const result = await client.query("SELECT * FROM users WHERE id = $1", [123]);
+    await client.end();
+    return Response.json(result.rows);
+  },
+};
+```
+
+## When to Use
+
+✅ Global access to single-region DBs, high read ratios, popular queries, connection-heavy loads
+❌ Write-heavy, real-time data (<1s), single-region apps close to DB
+
+## See Also
+
+- [configuration.md](./configuration.md) - Setup, wrangler config
+- [api.md](./api.md) - Binding APIs, query patterns
+- [patterns.md](./patterns.md) - Use cases, ORMs
+- [gotchas.md](./gotchas.md) - Limits, troubleshooting
+
+[Docs](https://developers.cloudflare.com/hyperdrive/) | [Discord #hyperdrive](https://discord.cloudflare.com)

--- a/.agent/services/hosting/cloudflare-platform/references/hyperdrive/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/hyperdrive/api.md
@@ -1,0 +1,137 @@
+# API Reference
+
+See [README.md](./README.md) for overview, [configuration.md](./configuration.md) for setup.
+
+## Binding Interface
+
+```typescript
+interface Hyperdrive {
+  connectionString: string;  // PostgreSQL
+  // MySQL properties:
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+}
+
+interface Env {
+  HYPERDRIVE: Hyperdrive;
+}
+```
+
+## PostgreSQL (node-postgres) - RECOMMENDED
+
+```typescript
+import { Client } from "pg";  // pg@^8.16.3, @types/pg
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const client = new Client({connectionString: env.HYPERDRIVE.connectionString});
+    try {
+      await client.connect();
+      const result = await client.query("SELECT * FROM users WHERE id = $1", [123]);
+      return Response.json(result.rows);
+    } finally {
+      await client.end();
+    }
+  },
+};
+```
+
+## PostgreSQL (postgres.js)
+
+```typescript
+import postgres from "postgres";  // postgres@^3.4.5
+
+const sql = postgres(env.HYPERDRIVE.connectionString, {
+  max: 5,             // Limit per Worker
+  prepare: true,      // ⚠️ CRITICAL for caching
+  fetch_types: false, // Reduce latency if not using arrays
+});
+
+const users = await sql`SELECT * FROM users WHERE active = ${true} LIMIT 10`;
+```
+
+**⚠️ `prepare: true` required for Hyperdrive caching.** `false` disables prepared statements + cache.
+
+## MySQL (mysql2)
+
+```typescript
+import { createConnection } from "mysql2/promise";  // mysql2@^3.13.0
+
+const conn = await createConnection({
+  host: env.HYPERDRIVE.host,
+  user: env.HYPERDRIVE.user,
+  password: env.HYPERDRIVE.password,
+  database: env.HYPERDRIVE.database,
+  port: env.HYPERDRIVE.port,
+  disableEval: true,  // ⚠️ REQUIRED for Workers
+});
+
+const [results] = await conn.query("SELECT * FROM users WHERE active = ? LIMIT ?", [true, 10]);
+ctx.waitUntil(conn.end());
+```
+
+## Query Caching
+
+**Cacheable:**
+```sql
+SELECT * FROM posts WHERE published = true;
+SELECT COUNT(*) FROM users;
+```
+
+**NOT cacheable:**
+```sql
+-- Writes
+INSERT/UPDATE/DELETE
+
+-- Volatile functions
+SELECT NOW();
+SELECT random();
+SELECT LASTVAL();  -- PostgreSQL
+SELECT UUID();     -- MySQL
+```
+
+**Cache config:**
+- Default: `max_age=60s`, `swr=15s`
+- Max `max_age`: 3600s
+- Disable: `--caching-disabled=true`
+
+**Multiple configs pattern:**
+```typescript
+// Reads: cached
+const sqlCached = postgres(env.HYPERDRIVE_CACHED.connectionString);
+const posts = await sqlCached`SELECT * FROM posts ORDER BY views DESC LIMIT 10`;
+
+// Writes/time-sensitive: no cache
+const sqlNoCache = postgres(env.HYPERDRIVE_NO_CACHE.connectionString);
+const orders = await sqlNoCache`SELECT * FROM orders WHERE created_at > NOW() - INTERVAL 5 MINUTE`;
+```
+
+## ORMs
+
+**Drizzle:**
+```typescript
+import { drizzle } from "drizzle-orm/postgres-js";  // drizzle-orm@^0.26.2
+import postgres from "postgres";
+
+const client = postgres(env.HYPERDRIVE.connectionString, {max: 5, prepare: true});
+const db = drizzle(client);
+const users = await db.select().from(users).where(eq(users.active, true)).limit(10);
+```
+
+**Kysely:**
+```typescript
+import { Kysely, PostgresDialect } from "kysely";  // kysely@^0.26.3
+import postgres from "postgres";
+
+const db = new Kysely({
+  dialect: new PostgresDialect({
+    postgres: postgres(env.HYPERDRIVE.connectionString, {max: 5, prepare: true}),
+  }),
+});
+const users = await db.selectFrom("users").selectAll().where("active", "=", true).execute();
+```
+
+See [patterns.md](./patterns.md) for use cases, [gotchas.md](./gotchas.md) for limits.

--- a/.agent/services/hosting/cloudflare-platform/references/hyperdrive/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/hyperdrive/configuration.md
@@ -1,0 +1,133 @@
+# Configuration
+
+See [README.md](./README.md) for overview.
+
+## Create Config
+
+**PostgreSQL:**
+```bash
+# Basic
+npx wrangler hyperdrive create my-db \
+  --connection-string="postgres://user:pass@host:5432/db"
+
+# Custom cache
+npx wrangler hyperdrive create my-db \
+  --connection-string="postgres://..." \
+  --max-age=120 --swr=30
+
+# No cache
+npx wrangler hyperdrive create my-db \
+  --connection-string="postgres://..." \
+  --caching-disabled=true
+```
+
+**MySQL:**
+```bash
+npx wrangler hyperdrive create my-db \
+  --connection-string="mysql://user:pass@host:3306/db"
+```
+
+## wrangler.jsonc
+
+```jsonc
+{
+  "compatibility_date": "2024-09-23",
+  "compatibility_flags": ["nodejs_compat"],
+  "hyperdrive": [
+    {
+      "binding": "HYPERDRIVE",
+      "id": "<HYPERDRIVE_ID>",
+      "localConnectionString": "postgres://user:pass@localhost:5432/dev"
+    }
+  ]
+}
+```
+
+**Multiple configs:**
+```jsonc
+{
+  "hyperdrive": [
+    {"binding": "HYPERDRIVE_CACHED", "id": "<ID1>"},
+    {"binding": "HYPERDRIVE_NO_CACHE", "id": "<ID2>"}
+  ]
+}
+```
+
+## Management
+
+```bash
+npx wrangler hyperdrive list
+npx wrangler hyperdrive get <ID>
+npx wrangler hyperdrive update <ID> --max-age=180
+npx wrangler hyperdrive delete <ID>
+```
+
+## Config Options
+
+| Option | Default | Notes |
+|--------|---------|-------|
+| `--caching-disabled` | `false` | Disable caching |
+| `--max-age` | `60` | Cache TTL (max 3600s) |
+| `--swr` | `15` | Stale-while-revalidate |
+| `--origin-connection-limit` | 20/100 | Free/paid |
+| `--access-client-id` | - | Tunnel auth |
+| `--access-client-secret` | - | Tunnel auth |
+| `--sslmode` | `require` | PostgreSQL only |
+
+## Private DB via Tunnel
+
+```
+Worker → Hyperdrive → Access → Tunnel → Private Network → DB
+```
+
+**Setup:**
+```bash
+# 1. Create tunnel
+cloudflared tunnel create my-db-tunnel
+
+# 2. Configure hostname in Zero Trust dashboard
+#    Domain: db-tunnel.example.com
+#    Service: TCP -> localhost:5432
+
+# 3. Create service token (Zero Trust > Service Auth)
+#    Save Client ID/Secret
+
+# 4. Create Access app (db-tunnel.example.com)
+#    Policy: Service Auth token from step 3
+
+# 5. Create Hyperdrive
+npx wrangler hyperdrive create my-private-db \
+  --host=db-tunnel.example.com \
+  --user=dbuser --password=dbpass --database=prod \
+  --access-client-id=<ID> --access-client-secret=<SECRET>
+```
+
+**⚠️ Don't specify `--port` with Tunnel** - port configured in tunnel service settings.
+
+## Local Dev
+
+**Option 1: Local (RECOMMENDED):**
+```bash
+# Env var (takes precedence)
+export CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE="postgres://user:pass@localhost:5432/dev"
+npx wrangler dev
+
+# wrangler.jsonc
+{"hyperdrive": [{"binding": "HYPERDRIVE", "localConnectionString": "postgres://..."}]}
+```
+
+**Remote DB locally:**
+```bash
+# PostgreSQL
+export CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE="postgres://user:pass@remote:5432/db?sslmode=require"
+
+# MySQL
+export CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE="mysql://user:pass@remote:3306/db?sslMode=REQUIRED"
+```
+
+**Option 2: Remote execution:**
+```bash
+npx wrangler dev --remote  # Uses deployed config, affects production
+```
+
+See [api.md](./api.md), [patterns.md](./patterns.md), [gotchas.md](./gotchas.md).

--- a/.agent/services/hosting/cloudflare-platform/references/hyperdrive/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/hyperdrive/gotchas.md
@@ -1,0 +1,184 @@
+# Gotchas
+
+See [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md).
+
+## Limits
+
+**Config:**
+| Limit | Free | Paid |
+|-------|------|------|
+| Max configs | 10 | 25 |
+| Username/DB name | 63 bytes | 63 bytes |
+
+**Connections:**
+| Limit | Free | Paid |
+|-------|------|------|
+| Connection timeout | 15s | 15s |
+| Idle timeout | 10min | 10min |
+| Max origin connections | ~20 | ~100 |
+
+**Queries:**
+| Limit | Value |
+|-------|-------|
+| Max duration | 60s |
+| Max cached response | 50MB |
+
+**Note:** Queries >60s terminated. Responses >50MB returned but not cached.
+
+## Common Errors
+
+```typescript
+try {
+  const result = await client.query("SELECT * FROM users");
+} catch (error: any) {
+  const msg = error.message || "";
+
+  // Pool exhausted
+  if (msg.includes("Failed to acquire a connection")) {
+    console.error("Pool exhausted - long transactions?");
+    return new Response("Service busy", {status: 503});
+  }
+
+  // Connection refused
+  if (msg.includes("connection_refused")) {
+    console.error("DB refusing - firewall/limits?");
+    return new Response("DB unavailable", {status: 503});
+  }
+
+  // Timeout
+  if (msg.includes("timeout") || msg.includes("deadline exceeded")) {
+    console.error("Query timeout - exceeded 60s");
+    return new Response("Query timeout", {status: 504});
+  }
+
+  // Auth failure
+  if (msg.includes("password authentication failed")) {
+    console.error("Auth failed - check credentials");
+    return new Response("Config error", {status: 500});
+  }
+
+  // SSL/TLS
+  if (msg.includes("SSL") || msg.includes("TLS")) {
+    console.error("TLS issue - check sslmode");
+    return new Response("Connection security error", {status: 500});
+  }
+
+  console.error("Unknown DB error:", error);
+  return new Response("Internal error", {status: 500});
+}
+```
+
+## Monitor Connections
+
+**PostgreSQL:**
+```sql
+-- Show Hyperdrive connections
+SELECT usename, application_name, client_addr, state
+FROM pg_stat_activity 
+WHERE application_name = 'Cloudflare Hyperdrive';
+
+-- Count active
+SELECT COUNT(*) FROM pg_stat_activity WHERE application_name = 'Cloudflare Hyperdrive';
+```
+
+## Troubleshooting
+
+**Connection refused:**
+1. Check firewall allows Cloudflare IPs
+2. Verify DB listening on port
+3. Confirm service running
+4. Check credentials
+
+**Pool exhausted:**
+1. Reduce transaction duration
+2. Avoid long queries (>60s)
+3. Don't hold connections during external calls
+4. Upgrade to paid plan
+
+**SSL/TLS failed:**
+1. Add `sslmode=require` (Postgres) or `sslMode=REQUIRED` (MySQL)
+2. Upload CA cert if self-signed
+3. Verify DB has SSL enabled
+4. Check cert expiry
+
+**Queries not cached:**
+1. Verify non-mutating (SELECT)
+2. Check for volatile functions (NOW(), RANDOM())
+3. Confirm caching not disabled
+4. Use `wrangler dev --remote` to test
+5. Check `prepare=true` for postgres.js
+
+**Query timeout (>60s):**
+1. Optimize with indexes
+2. Reduce dataset (LIMIT)
+3. Break into smaller queries
+4. Use async processing
+
+**Local DB connection:**
+1. Verify `localConnectionString` correct
+2. Check DB running
+3. Confirm env var name matches binding
+4. Test with psql/mysql client
+
+**Env var not working:**
+1. Format: `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_<BINDING>`
+2. Binding matches wrangler.jsonc
+3. Variable exported in shell
+4. Restart wrangler dev
+
+## Migration Checklist
+
+- [ ] Create config via Wrangler
+- [ ] Add binding to wrangler.jsonc
+- [ ] Enable `nodejs_compat` flag
+- [ ] Set `compatibility_date` >= `2024-09-23`
+- [ ] Update code to `env.HYPERDRIVE.connectionString` (Postgres) or properties (MySQL)
+- [ ] Configure `localConnectionString`
+- [ ] Set `prepare: true` (postgres.js) or `disableEval: true` (mysql2)
+- [ ] Test locally with `wrangler dev`
+- [ ] Deploy + monitor pool usage
+- [ ] Validate cache with `wrangler dev --remote`
+- [ ] Update firewall (Cloudflare IPs)
+- [ ] Configure observability
+
+## Supported Databases
+
+**PostgreSQL:**
+- PostgreSQL 11+
+- CockroachDB, Timescale, Materialize
+- Neon, Supabase
+
+Recommended: `pg` >= 8.16.3
+
+**MySQL:**
+- MySQL 5.7+
+- PlanetScale
+
+Recommended: `mysql2` >= 3.13.0
+
+**SSL/TLS:**
+- PostgreSQL `sslmode`: `require`, `verify-ca`, `verify-full`
+- MySQL `sslMode`: `REQUIRED`, `VERIFY_CA`, `VERIFY_IDENTITY`
+
+## When NOT to Use
+
+❌ Write-heavy workloads (limited cache benefit)
+❌ Real-time data requirements (<1s freshness)
+❌ Single-region apps close to DB
+❌ Very simple apps (overhead unjustified)
+❌ DB with strict connection limits already exceeded
+
+**Alternatives:**
+- D1 - Cloudflare native distributed SQL
+- Durable Objects - Stateful Workers
+- KV - Global key-value
+- R2 - Object storage
+
+## Resources
+
+- [Docs](https://developers.cloudflare.com/hyperdrive/)
+- [Getting Started](https://developers.cloudflare.com/hyperdrive/get-started/)
+- [Wrangler Reference](https://developers.cloudflare.com/hyperdrive/reference/wrangler-commands/)
+- [Supported DBs](https://developers.cloudflare.com/hyperdrive/reference/supported-databases-and-features/)
+- [Discord #hyperdrive](https://discord.cloudflare.com)
+- [Limit Increase Form](https://forms.gle/ukpeZVLWLnKeixDu7)

--- a/.agent/services/hosting/cloudflare-platform/references/hyperdrive/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/hyperdrive/patterns.md
@@ -1,0 +1,176 @@
+# Patterns
+
+See [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md).
+
+## High-Traffic Read-Heavy
+
+```typescript
+const sql = postgres(env.HYPERDRIVE.connectionString, {max: 5, prepare: true});
+
+// Cacheable: popular content
+const posts = await sql`SELECT * FROM posts WHERE published = true ORDER BY views DESC LIMIT 20`;
+
+// Cacheable: user profiles
+const [user] = await sql`SELECT id, username, bio FROM users WHERE id = ${userId}`;
+```
+
+**Benefits:** Trending/profiles cached (60s), connection pooling handles spikes.
+
+## Mixed Read/Write
+
+```typescript
+interface Env {
+  HYPERDRIVE_CACHED: Hyperdrive;    // max_age=120
+  HYPERDRIVE_REALTIME: Hyperdrive;  // caching disabled
+}
+
+// Reads: cached
+if (req.method === "GET") {
+  const sql = postgres(env.HYPERDRIVE_CACHED.connectionString, {prepare: true});
+  const products = await sql`SELECT * FROM products WHERE category = ${cat}`;
+}
+
+// Writes: no cache (immediate consistency)
+if (req.method === "POST") {
+  const sql = postgres(env.HYPERDRIVE_REALTIME.connectionString, {prepare: true});
+  await sql`INSERT INTO orders ${sql(data)}`;
+}
+```
+
+## Analytics Dashboard
+
+```typescript
+const client = new Client({connectionString: env.HYPERDRIVE.connectionString});
+await client.connect();
+
+// Aggregate queries cached
+const dailyStats = await client.query(`
+  SELECT DATE(created_at) as date, COUNT(*) as orders, SUM(amount) as revenue
+  FROM orders WHERE created_at >= NOW() - INTERVAL '30 days'
+  GROUP BY DATE(created_at) ORDER BY date DESC
+`);
+
+const topProducts = await client.query(`
+  SELECT p.name, COUNT(oi.id) as count, SUM(oi.quantity * oi.price) as revenue
+  FROM order_items oi JOIN products p ON oi.product_id = p.id
+  WHERE oi.created_at >= NOW() - INTERVAL '7 days'
+  GROUP BY p.id, p.name ORDER BY revenue DESC LIMIT 10
+`);
+```
+
+**Benefits:** Expensive aggregations cached, dashboard instant, reduced DB load.
+
+## Multi-Tenant
+
+```typescript
+const tenantId = req.headers.get("X-Tenant-ID");
+const sql = postgres(env.HYPERDRIVE.connectionString, {prepare: true});
+
+// Tenant-scoped queries cached separately
+const docs = await sql`
+  SELECT * FROM documents 
+  WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+  ORDER BY updated_at DESC LIMIT 50
+`;
+```
+
+**Benefits:** Per-tenant caching, shared connection pool, protects DB from multi-tenant load.
+
+## Geographically Distributed
+
+```typescript
+// Worker runs at edge nearest user
+// Connection setup at edge (fast), pooling near DB (efficient)
+const sql = postgres(env.HYPERDRIVE.connectionString, {prepare: true});
+const [user] = await sql`SELECT * FROM users WHERE id = ${userId}`;
+
+return Response.json({
+  user,
+  serverRegion: req.cf?.colo,  // Edge location
+});
+```
+
+**Benefits:** Edge setup + DB pooling = global → single-region DB without replication.
+
+## Connection Pooling
+
+Operates in **transaction mode**: connection acquired per transaction, `RESET` on return.
+
+**SET statements:**
+```typescript
+// ✅ Within transaction
+await client.query("BEGIN");
+await client.query("SET work_mem = '256MB'");
+await client.query("SELECT * FROM large_table");  // Uses SET
+await client.query("COMMIT");  // RESET after
+
+// ✅ Single statement
+await client.query("SET work_mem = '256MB'; SELECT * FROM large_table");
+
+// ❌ Across queries (may get different connection)
+await client.query("SET work_mem = '256MB'");
+await client.query("SELECT * FROM large_table");  // SET not applied
+```
+
+**Best practices:**
+```typescript
+// ❌ Long transactions block pooling
+await client.query("BEGIN");
+await processThousands();  // Connection held entire time
+await client.query("COMMIT");
+
+// ✅ Short transactions
+await client.query("BEGIN");
+await client.query("UPDATE users SET status = $1 WHERE id = $2", [status, id]);
+await client.query("COMMIT");
+
+// ✅ SET LOCAL within transaction
+await client.query("BEGIN");
+await client.query("SET LOCAL work_mem = '256MB'");
+await client.query("SELECT * FROM large_table");
+await client.query("COMMIT");
+```
+
+## Performance Tips
+
+**1. Enable prepared statements:**
+```typescript
+// ✅ Best
+const sql = postgres(connectionString, {prepare: true});  // Caching enabled
+
+// ❌ Slower
+const sql = postgres(connectionString, {prepare: false}); // Extra round-trips
+```
+
+**2. Optimize settings:**
+```typescript
+const sql = postgres(connectionString, {
+  max: 5,             // Limit per Worker
+  fetch_types: false, // Skip if not using arrays
+  prepare: true,
+  idle_timeout: 60,   // Match Worker lifetime
+});
+```
+
+**3. Cache-friendly queries:**
+```typescript
+// ✅ Cacheable (deterministic)
+await sql`SELECT * FROM products WHERE category = 'electronics' LIMIT 10`;
+
+// ❌ Not cacheable (volatile)
+await sql`SELECT * FROM logs WHERE created_at > NOW()`;
+
+// ✅ Make cacheable (parameterize)
+const ts = Date.now();
+await sql`SELECT * FROM logs WHERE created_at > ${ts}`;
+```
+
+**4. Monitor cache hits:**
+```typescript
+const start = Date.now();
+const result = await sql`SELECT * FROM users LIMIT 10`;
+const duration = Date.now() - start;
+console.log({duration, likelyCached: duration < 10});  // <10ms = cache hit
+```
+
+See [gotchas.md](./gotchas.md) for limits, troubleshooting.

--- a/.agent/services/hosting/cloudflare-platform/references/images/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/images/README.md
@@ -1,0 +1,14 @@
+# Cloudflare Images Skill Reference
+
+**Cloudflare Images** is an end-to-end image management solution providing storage, transformation, optimization, and delivery at scale via Cloudflare's global network....
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/images/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/images/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+See main documentation.

--- a/.agent/services/hosting/cloudflare-platform/references/images/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/images/configuration.md
@@ -1,0 +1,45 @@
+## Wrangler Integration
+
+### Upload via Wrangler
+
+Wrangler doesn't have built-in Cloudflare Images commands, but you can use the API:
+
+```typescript
+// scripts/upload-image.ts
+import fs from 'fs';
+import FormData from 'form-data';
+import fetch from 'node-fetch';
+
+async function uploadImage(filePath: string) {
+  const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+  const apiToken = process.env.CLOUDFLARE_API_TOKEN;
+  
+  const formData = new FormData();
+  formData.append('file', fs.createReadStream(filePath));
+  
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/images/v1`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiToken}`,
+      },
+      body: formData,
+    }
+  );
+  
+  const result = await response.json();
+  console.log('Uploaded:', result);
+}
+
+uploadImage('./photo.jpg');
+```
+
+### Access Images from Workers
+
+Store account hash as an environment variable:
+
+```toml
+# wrangler.toml
+[vars]
+IMAGES_ACCOUNT

--- a/.agent/services/hosting/cloudflare-platform/references/images/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/images/gotchas.md
@@ -1,0 +1,23 @@
+## Best Practices
+
+### 1. Use Appropriate Fit Modes
+- `cover`: Hero images, thumbnails, avatars (fills space, crops)
+- `contain`: Product images, artwork (preserves full image)
+- `scale-down`: Ensure images aren't unnecessarily enlarged
+
+### 2. Format Selection
+- Use `format=auto` for automatic AVIF/WebP/JPEG selection
+- For Workers, parse `Accept` header for format negotiation
+- AVIF: Best compression, use for modern browsers
+- WebP: Wide support, good compression
+- JPEG: Fallback for older browsers
+
+### 3. Quality Settings
+- `85`: Good default balance
+- `90-95`: High-quality images (portfolios, product photos)
+- `75-80`: Acceptable quality for faster loading
+- WebP lossless: `quality=100`
+
+### 4. Responsive Images
+- Use `srcset` with multiple widths (400w, 800w, 1200w)
+- Set appropriate 

--- a/.agent/services/hosting/cloudflare-platform/references/images/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/images/patterns.md
@@ -1,0 +1,31 @@
+#### Common Options
+
+```
+width=<PIXELS>         # w=<PIXELS> (alias)
+height=<PIXELS>        # h=<PIXELS> (alias)
+fit=scale-down         # scale-down|contain|cover|crop|pad|squeeze
+quality=85             # q=85 (1-100)
+format=auto            # f=auto (auto|webp|avif|jpeg|png)
+dpr=2                  # Device Pixel Ratio (1-3)
+gravity=auto           # auto|left|right|top|bottom|face|0.5x0.5
+sharpen=2              # 0-10
+blur=10                # 1-250
+rotate=90              # 90|180|270
+background=white       # CSS color for pad fit mode
+metadata=none          # none|copyright|keep
+```
+
+### Transform via Workers
+
+Use Cloudflare Workers for programmatic control:
+
+```typescript
+export default {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    
+    // Parse Accept header for format negotiation
+    const accept = request.headers.get('Accept') || '';
+    let format: 'avif' | 'webp' | undefined;
+    if (/image\/avif/.test(accept)) {
+      format = 'a

--- a/.agent/services/hosting/cloudflare-platform/references/kv/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/kv/README.md
@@ -1,0 +1,60 @@
+# Cloudflare Workers KV
+
+Globally-distributed, eventually-consistent key-value store optimized for high read volume and low latency.
+
+## Overview
+
+KV provides:
+- Eventual consistency (60s global propagation)
+- Read-optimized performance
+- 25 MiB value limit per key
+- Auto-replication to Cloudflare edge
+- Metadata support (1024 bytes)
+
+**Use cases:** Config storage, user sessions, feature flags, caching, A/B testing
+
+## Quick Start
+
+```bash
+wrangler kv namespace create MY_NAMESPACE
+# Add binding to wrangler.jsonc
+```
+
+```typescript
+// Write
+await env.MY_KV.put("key", "value", { expirationTtl: 300 });
+
+// Read
+const value = await env.MY_KV.get("key");
+const json = await env.MY_KV.get<Config>("config", "json");
+```
+
+## Core Operations
+
+| Method | Purpose | Returns |
+|--------|---------|---------|
+| `get(key, type?)` | Single read | `string \| null` |
+| `get(keys, type?)` | Bulk read (≤100) | `Map<string, T \| null>` |
+| `put(key, value, options?)` | Write | `Promise<void>` |
+| `delete(key)` | Delete | `Promise<void>` |
+| `list(options?)` | List keys | `{ keys, list_complete, cursor? }` |
+| `getWithMetadata(key)` | Get + metadata | `{ value, metadata }` |
+
+## Consistency Model
+
+- **Write visibility:** Immediate in same location, ≤60s globally
+- **Read path:** Eventually consistent
+- **Write rate:** 1 write/second per key (429 on exceed)
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - wrangler.jsonc setup, namespace creation, TypeScript types
+- [api.md](./api.md) - KV methods, bulk operations, cacheTtl, content types
+- [patterns.md](./patterns.md) - Caching, sessions, rate limiting, A/B testing
+- [gotchas.md](./gotchas.md) - Eventual consistency, concurrent writes, value limits
+
+## See Also
+
+- [workers](../workers/) - Worker runtime for KV access
+- [d1](../d1/) - Use D1 for strong consistency needs
+- [durable-objects](../durable-objects/) - Strongly consistent alternative

--- a/.agent/services/hosting/cloudflare-platform/references/kv/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/kv/api.md
@@ -1,0 +1,114 @@
+# KV API Reference
+
+## Read Operations
+
+```typescript
+// Single key (string)
+const value = await env.MY_KV.get("user:123");
+
+// JSON type (auto-parsed)
+const config = await env.MY_KV.get<AppConfig>("config", "json");
+
+// ArrayBuffer for binary
+const buffer = await env.MY_KV.get("image", "arrayBuffer");
+
+// Stream for large values
+const stream = await env.MY_KV.get("large-file", "stream");
+
+// With cache TTL (min 60s)
+const value = await env.MY_KV.get("key", { type: "text", cacheTtl: 300 });
+
+// Bulk get (max 100 keys, counts as 1 operation)
+const values = await env.MY_KV.get(["user:1", "user:2", "user:3"]);
+// Returns Map<string, string | null>
+
+const configs = await env.MY_KV.get<Config>(["config:app", "config:feature"], "json");
+```
+
+## Write Operations
+
+```typescript
+// Basic put
+await env.MY_KV.put("key", "value");
+await env.MY_KV.put("config", JSON.stringify({ theme: "dark" }));
+
+// With expiration (UNIX timestamp)
+await env.MY_KV.put("session", token, {
+  expiration: Math.floor(Date.now() / 1000) + 3600
+});
+
+// With TTL (seconds from now, min 60)
+await env.MY_KV.put("cache", data, { expirationTtl: 300 });
+
+// With metadata (max 1024 bytes)
+await env.MY_KV.put("user:profile", userData, {
+  metadata: { version: 2, lastUpdated: Date.now() }
+});
+
+// Combined
+await env.MY_KV.put("temp", value, {
+  expirationTtl: 3600,
+  metadata: { temporary: true }
+});
+```
+
+## Get with Metadata
+
+```typescript
+// Single key
+const result = await env.MY_KV.getWithMetadata("user:profile");
+// { value: string | null, metadata: any | null }
+
+if (result.value && result.metadata) {
+  const { version, lastUpdated } = result.metadata;
+}
+
+// Multiple keys
+const results = await env.MY_KV.getWithMetadata(["key1", "key2"]);
+// Returns Map<string, { value, metadata }>
+
+// With type
+const result = await env.MY_KV.getWithMetadata<UserData>("user:123", "json");
+```
+
+## Delete Operations
+
+```typescript
+await env.MY_KV.delete("key"); // Always succeeds (even if key missing)
+```
+
+## List Operations
+
+```typescript
+// List all
+const keys = await env.MY_KV.list();
+// { keys: [...], list_complete: boolean, cursor?: string }
+
+// With prefix
+const userKeys = await env.MY_KV.list({ prefix: "user:" });
+
+// Pagination
+let cursor: string | undefined;
+let allKeys = [];
+do {
+  const result = await env.MY_KV.list({ cursor, limit: 1000 });
+  allKeys.push(...result.keys);
+  cursor = result.cursor;
+} while (!result.list_complete);
+```
+
+## Limits
+
+| Limit | Free | Paid |
+|-------|------|------|
+| Reads/day | 100,000 | Unlimited |
+| Writes/day | 1,000 | Unlimited |
+| Writes/second per key | 1 | 1 |
+| Operations per Worker | 1,000 | 1,000 |
+| Key size | 512 bytes | 512 bytes |
+| Value size | 25 MiB | 25 MiB |
+| Metadata size | 1024 bytes | 1024 bytes |
+| Min cacheTtl | 60s | 60s |
+| Bulk get max | 100 keys | 100 keys |
+
+**Note:** Bulk requests count as 1 operation against 1,000 limit.

--- a/.agent/services/hosting/cloudflare-platform/references/kv/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/kv/configuration.md
@@ -1,0 +1,92 @@
+# KV Configuration
+
+## Create Namespace
+
+```bash
+wrangler kv namespace create MY_NAMESPACE
+# Output: { binding = "MY_NAMESPACE", id = "abc123..." }
+
+wrangler kv namespace create MY_NAMESPACE --preview  # For local dev
+```
+
+## Workers Binding
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "kv_namespaces": [
+    {
+      "binding": "MY_KV",
+      "id": "abc123xyz789"
+    }
+  ]
+}
+```
+
+**wrangler.toml:**
+```toml
+[[kv_namespaces]]
+binding = "MY_KV"
+id = "abc123xyz789"
+```
+
+## TypeScript Types
+
+```typescript
+interface Env { MY_KV: KVNamespace; }
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const value = await env.MY_KV.get("key");
+    return new Response(value || "Not found");
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+## CLI Operations
+
+```bash
+# Put
+wrangler kv key put --binding=MY_KV "key" "value"
+wrangler kv key put --binding=MY_KV "key" --path=./file.json --ttl=3600
+
+# Get
+wrangler kv key get --binding=MY_KV "key"
+
+# Delete
+wrangler kv key delete --binding=MY_KV "key"
+
+# List
+wrangler kv key list --binding=MY_KV --prefix="user:"
+
+# Bulk operations (max 10,000 keys per file)
+wrangler kv bulk put data.json --binding=MY_KV
+wrangler kv bulk get keys.json --binding=MY_KV
+wrangler kv bulk delete keys.json --binding=MY_KV --force
+```
+
+## Local Development
+
+```bash
+wrangler dev                # Local KV (isolated)
+wrangler dev --remote       # Remote KV (production)
+
+# Or in wrangler.jsonc:
+# "kv_namespaces": [{ "binding": "MY_KV", "id": "...", "remote": true }]
+```
+
+## REST API
+
+```typescript
+import Cloudflare from 'cloudflare';
+
+const client = new Cloudflare({
+  apiEmail: process.env.CLOUDFLARE_EMAIL,
+  apiKey: process.env.CLOUDFLARE_API_KEY
+});
+
+await client.kv.namespaces.values.update(namespaceId, 'key', {
+  account_id: accountId,
+  value: 'value'
+});
+```

--- a/.agent/services/hosting/cloudflare-platform/references/kv/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/kv/gotchas.md
@@ -1,0 +1,117 @@
+# KV Gotchas & Troubleshooting
+
+## Eventual Consistency
+
+```typescript
+// ❌ BAD: Read immediately after write (may see stale globally)
+await env.MY_KV.put("key", "value");
+const value = await env.MY_KV.get("key"); // May be null in other regions
+
+// ✅ GOOD: Return confirmation without reading
+await env.MY_KV.put("key", "value");
+return new Response("Updated", { status: 200 });
+
+// ✅ GOOD: Use local value
+const newValue = "updated";
+await env.MY_KV.put("key", newValue);
+return new Response(newValue);
+```
+
+**Propagation:** Writes visible immediately in same location, ≤60s globally.
+
+## Concurrent Writes
+
+```typescript
+// ❌ BAD: Concurrent writes to same key (429 rate limit)
+await Promise.all([
+  env.MY_KV.put("counter", "1"),
+  env.MY_KV.put("counter", "2")
+]); // 429 error
+
+// ✅ GOOD: Sequential writes
+await env.MY_KV.put("counter", "3");
+
+// ✅ GOOD: Unique keys for concurrent writes
+await Promise.all([
+  env.MY_KV.put("counter:1", "1"),
+  env.MY_KV.put("counter:2", "2")
+]);
+
+// ✅ GOOD: Retry with backoff
+async function putWithRetry(kv: KVNamespace, key: string, value: string) {
+  let delay = 1000;
+  for (let i = 0; i < 5; i++) {
+    try {
+      await kv.put(key, value);
+      return;
+    } catch (err) {
+      if (err.message.includes("429") && i < 4) {
+        await new Promise(resolve => setTimeout(resolve, delay));
+        delay *= 2;
+      } else throw err;
+    }
+  }
+}
+```
+
+**Limit:** 1 write/second per key (all plans).
+
+## Bulk Operations
+
+```typescript
+// ❌ BAD: Multiple individual gets (uses 3 operations)
+const user1 = await env.USERS.get("user:1");
+const user2 = await env.USERS.get("user:2");
+const user3 = await env.USERS.get("user:3");
+
+// ✅ GOOD: Single bulk get (uses 1 operation)
+const users = await env.USERS.get(["user:1", "user:2", "user:3"]);
+```
+
+**Note:** Bulk write NOT available in Workers (only via CLI/API).
+
+## Null Handling
+
+```typescript
+// ❌ BAD: No null check
+const value = await env.MY_KV.get("key");
+const result = value.toUpperCase(); // Error if null
+
+// ✅ GOOD: Check for null
+const value = await env.MY_KV.get("key");
+if (value === null) return new Response("Not found", { status: 404 });
+return new Response(value);
+
+// ✅ GOOD: Provide default
+const value = (await env.MY_KV.get("config")) ?? "default-config";
+```
+
+## Value Limits
+
+- Key size: 512 bytes max
+- Value size: 25 MiB max
+- Metadata: 1024 bytes max
+- cacheTtl: 60s minimum
+
+## Pricing
+
+- **Reads:** $0.50 per 10M
+- **Writes:** $5.00 per 1M
+- **Deletes:** $5.00 per 1M
+- **Storage:** $0.50 per GB-month
+
+## When NOT to Use
+
+- ❌ Strong consistency required → Durable Objects
+- ❌ Write-heavy workloads → D1 or Durable Objects
+- ❌ Relational queries → D1
+- ❌ Large files (>25 MiB) → R2
+- ❌ Atomic operations → Durable Objects
+
+## When TO Use
+
+- ✅ Read-heavy workloads
+- ✅ Global distribution needed
+- ✅ Eventually consistent acceptable
+- ✅ Key-value access patterns
+- ✅ Low-latency reads critical

--- a/.agent/services/hosting/cloudflare-platform/references/kv/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/kv/patterns.md
@@ -1,0 +1,139 @@
+# KV Patterns & Best Practices
+
+## API Response Caching
+
+```typescript
+async function getCachedData(env: Env, key: string, fetcher: () => Promise<any>): Promise<any> {
+  const cached = await env.MY_KV.get(key, "json");
+  if (cached) return cached;
+  
+  const data = await fetcher();
+  await env.MY_KV.put(key, JSON.stringify(data), { expirationTtl: 300 });
+  return data;
+}
+
+const apiData = await getCachedData(
+  env,
+  "cache:users",
+  () => fetch("https://api.example.com/users").then(r => r.json())
+);
+```
+
+## Session Management
+
+```typescript
+interface Session { userId: string; expiresAt: number; }
+
+async function createSession(env: Env, userId: string): Promise<string> {
+  const sessionId = crypto.randomUUID();
+  const expiresAt = Date.now() + (24 * 60 * 60 * 1000);
+  
+  await env.SESSIONS.put(
+    `session:${sessionId}`,
+    JSON.stringify({ userId, expiresAt }),
+    { expirationTtl: 86400, metadata: { createdAt: Date.now() } }
+  );
+  
+  return sessionId;
+}
+
+async function getSession(env: Env, sessionId: string): Promise<Session | null> {
+  const data = await env.SESSIONS.get<Session>(`session:${sessionId}`, "json");
+  if (!data || data.expiresAt < Date.now()) return null;
+  return data;
+}
+```
+
+## Feature Flags
+
+```typescript
+async function getFeatureFlags(env: Env): Promise<Record<string, boolean>> {
+  return await env.CONFIG.get<Record<string, boolean>>(
+    "features:flags",
+    { type: "json", cacheTtl: 600 }
+  ) || {};
+}
+
+export default {
+  async fetch(request, env): Promise<Response> {
+    const flags = await getFeatureFlags(env);
+    if (flags.beta_feature) return handleBetaFeature(request);
+    return handleStandardFlow(request);
+  }
+};
+```
+
+## Rate Limiting
+
+```typescript
+async function rateLimit(env: Env, identifier: string, limit: number, windowSeconds: number): Promise<boolean> {
+  const key = `ratelimit:${identifier}`;
+  const now = Date.now();
+  const data = await env.MY_KV.get<{ count: number, resetAt: number }>(key, "json");
+  
+  if (!data || data.resetAt < now) {
+    await env.MY_KV.put(key, JSON.stringify({ count: 1, resetAt: now + windowSeconds * 1000 }), { expirationTtl: windowSeconds });
+    return true;
+  }
+  
+  if (data.count >= limit) return false;
+  
+  await env.MY_KV.put(key, JSON.stringify({ count: data.count + 1, resetAt: data.resetAt }), { expirationTtl: Math.ceil((data.resetAt - now) / 1000) });
+  return true;
+}
+```
+
+## A/B Testing
+
+```typescript
+async function getVariant(env: Env, userId: string, testName: string): Promise<string> {
+  const assigned = await env.AB_TESTS.get(`test:${testName}:user:${userId}`);
+  if (assigned) return assigned;
+  
+  const test = await env.AB_TESTS.get<{ variants: string[], weights: number[] }>(`test:${testName}:config`, { type: "json", cacheTtl: 3600 });
+  if (!test) return "control";
+  
+  const hash = await hashString(userId);
+  const random = (hash % 100) / 100;
+  let cumulative = 0, variant = test.variants[0];
+  
+  for (let i = 0; i < test.variants.length; i++) {
+    cumulative += test.weights[i];
+    if (random < cumulative) { variant = test.variants[i]; break; }
+  }
+  
+  await env.AB_TESTS.put(`test:${testName}:user:${userId}`, variant, { expirationTtl: 2592000 });
+  return variant;
+}
+```
+
+## Coalesce Cold Keys
+
+```typescript
+// ❌ BAD: Many individual keys
+await env.KV.put("user:123:name", "John");
+await env.KV.put("user:123:email", "john@example.com");
+
+// ✅ GOOD: Single coalesced object
+await env.USERS.put("user:123:profile", JSON.stringify({
+  name: "John",
+  email: "john@example.com",
+  role: "admin"
+}));
+
+// Benefits: Hot key cache, single read, reduced operations
+// Trade-off: Harder to update individual fields
+```
+
+## Hierarchical Keys
+
+```typescript
+// Use prefixes for organization
+"user:123:profile"
+"user:123:settings"
+"cache:api:users"
+"session:abc-def"
+"feature:flags:beta"
+
+const userKeys = await env.MY_KV.list({ prefix: "user:123:" });
+```

--- a/.agent/services/hosting/cloudflare-platform/references/miniflare/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/miniflare/README.md
@@ -1,0 +1,64 @@
+# Miniflare
+
+Local simulator for Cloudflare Workers development/testing. Runs Workers in workerd sandbox implementing runtime APIs - no internet required.
+
+## Features
+
+- Full-featured: KV, Durable Objects, R2, D1, WebSockets, Queues
+- Fully-local: test without internet, instant reload
+- TypeScript-native: detailed logging, source maps
+- Advanced testing: dispatch events without HTTP, simulate Worker connections
+
+## When to Use
+
+- Integration tests for Workers
+- Advanced use cases requiring fine-grained control
+- Testing bindings/storage locally
+- Multiple Workers with service bindings
+
+**Note:** Most users should use Wrangler. Miniflare for advanced testing.
+
+## Setup
+
+```bash
+npm i -D miniflare
+```
+
+Requires ES modules in `package.json`:
+```json
+{"type": "module"}
+```
+
+## Quick Start
+
+```js
+import { Miniflare } from "miniflare";
+
+const mf = new Miniflare({
+  modules: true,
+  script: `
+    export default {
+      async fetch(request, env, ctx) {
+        return new Response("Hello Miniflare!");
+      }
+    }
+  `,
+});
+
+const res = await mf.dispatchFetch("http://localhost:8787/");
+console.log(await res.text()); // Hello Miniflare!
+await mf.dispose();
+```
+
+## See Also
+
+- [configuration.md](./configuration.md) - Config options, bindings, wrangler.toml
+- [api.md](./api.md) - Programmatic API, methods, event dispatching
+- [patterns.md](./patterns.md) - Testing patterns, CI, mocking
+- [gotchas.md](./gotchas.md) - Compatibility issues, limits, debugging
+
+## Resources
+
+- [Miniflare Docs](https://developers.cloudflare.com/workers/testing/miniflare/)
+- [Miniflare GitHub](https://github.com/cloudflare/workers-sdk/tree/main/packages/miniflare)
+- [Vitest Integration](https://developers.cloudflare.com/workers/testing/vitest-integration/) (recommended)

--- a/.agent/services/hosting/cloudflare-platform/references/miniflare/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/miniflare/api.md
@@ -1,0 +1,144 @@
+# Programmatic API
+
+## Miniflare Class
+
+```typescript
+class Miniflare {
+  constructor(options: MiniflareOptions);
+  ready: Promise<void>;
+  dispose(): Promise<void>;
+  setOptions(options: MiniflareOptions): Promise<void>;
+  
+  // Event dispatching
+  dispatchFetch(url: string, init?: RequestInit): Promise<Response>;
+  getWorker(): Promise<Worker>;
+  
+  // Bindings access
+  getBindings(): Promise<Record<string, any>>;
+  getKVNamespace(name: string): Promise<KVNamespace>;
+  getR2Bucket(name: string): Promise<R2Bucket>;
+  getDurableObjectNamespace(name: string): Promise<DurableObjectNamespace>;
+  getDurableObjectStorage(id: DurableObjectId): Promise<DurableObjectStorage>;
+  getD1Database(name: string): Promise<D1Database>;
+  getCaches(): Promise<CacheStorage>;
+  getQueueProducer(name: string): Promise<QueueProducer>;
+}
+```
+
+## Event Dispatching
+
+**Fetch (no HTTP server):**
+```js
+const res = await mf.dispatchFetch("http://localhost:8787/path", {
+  method: "POST",
+  headers: { "Authorization": "Bearer token" },
+  body: JSON.stringify({ data: "value" }),
+});
+```
+
+**Custom Host routing:**
+```js
+const res = await mf.dispatchFetch("http://localhost:8787/", {
+  headers: { "Host": "api.example.com" },
+});
+```
+
+**Scheduled:**
+```js
+const worker = await mf.getWorker();
+const result = await worker.scheduled({ cron: "30 * * * *" });
+// result: { outcome: "ok", noRetry: false }
+```
+
+**Queue:**
+```js
+const worker = await mf.getWorker();
+const result = await worker.queue("queue-name", [
+  { id: "msg1", timestamp: new Date(), body: "data", attempts: 1 },
+]);
+// result: { outcome: "ok", retryAll: false, ackAll: false, ... }
+```
+
+## Bindings Access
+
+**Environment variables:**
+```js
+const bindings = await mf.getBindings();
+console.log(bindings.SECRET_KEY);
+```
+
+**KV:**
+```js
+const ns = await mf.getKVNamespace("TEST_NAMESPACE");
+await ns.put("key", "value");
+const value = await ns.get("key");
+```
+
+**R2:**
+```js
+const bucket = await mf.getR2Bucket("BUCKET");
+await bucket.put("file.txt", "content");
+const object = await bucket.get("file.txt");
+```
+
+**Durable Objects:**
+```js
+const ns = await mf.getDurableObjectNamespace("COUNTER");
+const id = ns.idFromName("test");
+const stub = ns.get(id);
+const res = await stub.fetch("http://localhost/");
+
+// Access storage directly:
+const storage = await mf.getDurableObjectStorage(id);
+await storage.put("key", "value");
+```
+
+**D1:**
+```js
+const db = await mf.getD1Database("DB");
+await db.exec(`CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)`);
+await db.prepare("INSERT INTO users (name) VALUES (?)").bind("Alice").run();
+```
+
+**Cache:**
+```js
+const caches = await mf.getCaches();
+const defaultCache = caches.default;
+await defaultCache.put("http://example.com", new Response("cached"));
+```
+
+**Queue producer:**
+```js
+const producer = await mf.getQueueProducer("QUEUE");
+await producer.send({ body: "message data" });
+```
+
+## Lifecycle
+
+**Reload:**
+```js
+await mf.setOptions({
+  scriptPath: "worker.js",
+  bindings: { VERSION: "2.0" },
+});
+```
+
+**Watch (manual):**
+```js
+import { watch } from "fs";
+
+const config = { scriptPath: "worker.js" };
+const mf = new Miniflare(config);
+
+watch("worker.js", async () => {
+  console.log("Reloading...");
+  await mf.setOptions(config);
+});
+```
+
+**Cleanup:**
+```js
+await mf.dispose();
+```
+
+See [configuration.md](./configuration.md) for all constructor options.

--- a/.agent/services/hosting/cloudflare-platform/references/miniflare/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/miniflare/configuration.md
@@ -1,0 +1,203 @@
+# Configuration
+
+## Script Loading
+
+**Inline:**
+```js
+new Miniflare({ modules: true, script: `export default { ... }` });
+```
+
+**File-based:**
+```js
+new Miniflare({ scriptPath: "worker.js" });
+```
+
+**Multi-module auto-crawl:**
+```js
+new Miniflare({
+  scriptPath: "src/index.js",
+  modules: true,
+  modulesRules: [
+    { type: "ESModule", include: ["**/*.js"] },
+    { type: "Text", include: ["**/*.txt"] },
+  ],
+});
+```
+
+**Explicit modules:**
+```js
+new Miniflare({
+  modules: [
+    { type: "ESModule", path: "src/index.js" },
+    { type: "Text", path: "data.txt" },
+  ],
+});
+```
+
+## Compatibility
+
+```js
+new Miniflare({
+  compatibilityDate: "2021-11-23",
+  compatibilityFlags: ["formdata_parser_supports_files"],
+  upstream: "https://example.com",
+});
+```
+
+## Server Options
+
+```js
+new Miniflare({
+  port: 8787,
+  host: "127.0.0.1",
+  https: true, // Self-signed cert
+  httpsKeyPath: "./key.pem",
+  httpsCertPath: "./cert.pem",
+});
+```
+
+**Request.cf:**
+```js
+cf: true,        // Fetch from Cloudflare
+cf: "cf.json",   // Load from file
+cf: false,       // Disable
+```
+
+## Storage Bindings
+
+**KV:**
+```js
+kvNamespaces: ["TEST_NAMESPACE", "CACHE"],
+kvPersist: "./kv-data", // Optional: persist to disk
+```
+
+**R2:**
+```js
+r2Buckets: ["BUCKET", "IMAGES"],
+r2Persist: "./r2-data",
+```
+
+**Durable Objects:**
+```js
+modules: true,
+durableObjects: {
+  COUNTER: "Counter", // className
+  API_OBJECT: { className: "ApiObject", scriptName: "api-worker" },
+},
+durableObjectsPersist: "./do-data",
+```
+
+**D1:**
+```js
+d1Databases: ["DB"],
+d1Persist: "./d1-data",
+```
+
+**Cache:**
+```js
+cache: true, // Default
+cachePersist: "./cache-data",
+cacheWarnUsage: true,
+```
+
+## Bindings
+
+**Environment variables:**
+```js
+bindings: {
+  SECRET_KEY: "my-secret-value",
+  API_URL: "https://api.example.com",
+  DEBUG: true,
+},
+```
+
+**WASM:**
+```js
+wasmBindings: { ADD_MODULE: "./add.wasm" },
+```
+
+**Text/Data blobs:**
+```js
+textBlobBindings: { TEXT: "./data.txt" },
+dataBlobBindings: { DATA: "./data.bin" },
+```
+
+**Queue producers:**
+```js
+queueProducers: ["QUEUE"],
+```
+
+## Multiple Workers
+
+```js
+new Miniflare({
+  host: "0.0.0.0",
+  port: 8787,
+  kvPersist: true,
+  
+  workers: [
+    {
+      name: "main-worker",
+      kvNamespaces: { DATA: "shared-data" },
+      serviceBindings: {
+        API: "api-worker",
+        async EXTERNAL(request) {
+          return new Response("External response");
+        },
+      },
+      modules: true,
+      script: `export default { ... }`,
+    },
+    {
+      name: "api-worker",
+      kvNamespaces: { DATA: "shared-data" }, // Shared
+      script: `addEventListener("fetch", ...)`,
+    },
+  ],
+});
+```
+
+## Routing
+
+```js
+workers: [
+  {
+    name: "api",
+    scriptPath: "./api/worker.js",
+    routes: ["http://127.0.0.1/api/*", "api.example.com/*"],
+  },
+  {
+    name: "web",
+    scriptPath: "./web/worker.js",
+    routes: ["example.com/*"],
+  },
+],
+```
+
+Update `/etc/hosts`: `127.0.0.1 api.example.com`
+
+## Advanced
+
+**Logging:**
+```js
+import { Log, LogLevel } from "miniflare";
+new Miniflare({ log: new Log(LogLevel.DEBUG) }); // DEBUG, INFO, WARN, ERROR
+```
+
+**Live reload:**
+```js
+liveReload: true, // Auto-reload HTML on worker reload
+```
+
+**Workers Site:**
+```js
+sitePath: "./public",
+siteInclude: ["**/*.html", "**/*.css"],
+siteExclude: ["node_modules/**"],
+```
+
+## CLI Options
+
+Miniflare doesn't read `wrangler.toml` - configure via API. For wrangler.toml configs, manually translate to Miniflare options.
+
+See [api.md](./api.md) for full API reference.

--- a/.agent/services/hosting/cloudflare-platform/references/miniflare/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/miniflare/gotchas.md
@@ -1,0 +1,187 @@
+# Gotchas & Debugging
+
+## Compatibility Issues
+
+### Not Supported in Miniflare
+
+- Cloudflare Analytics Engine
+- Cloudflare Images
+- Live production data
+- True global distribution
+- Some advanced Workers features
+
+### Behavior Differences from Production
+
+1. **No actual edge:** Runs in workerd locally, not Cloudflare's global network
+2. **Persistence:** Local filesystem/in-memory, not distributed
+3. **Request.cf:** Fetched from cached endpoint or mocked, not real edge metadata
+4. **Performance:** Local performance ≠ edge performance
+5. **Caching:** May differ slightly from production
+
+## Common Issues
+
+### Module Resolution Errors
+
+**Problem:** `Cannot find module`
+
+**Fix:**
+```js
+// Use absolute paths or modulesRules
+new Miniflare({
+  scriptPath: "./src/index.js",
+  modules: true,
+  modulesRules: [
+    { type: "ESModule", include: ["**/*.js"], fallthrough: true },
+  ],
+});
+```
+
+### Persistence Not Working
+
+**Problem:** Data not persisting between runs
+
+**Fix:**
+```js
+// Ensure persist paths are directories, not files
+new Miniflare({
+  kvPersist: "./data/kv",           // Directory
+  r2Persist: "./data/r2",
+  durableObjectsPersist: "./data/do",
+});
+```
+
+### TypeScript Workers
+
+**Problem:** Cannot directly run TypeScript
+
+**Fix:**
+```js
+// Build before running
+import { spawnSync } from "node:child_process";
+
+before(() => {
+  const result = spawnSync("npm run build", { shell: true });
+  if (result.error) throw result.error;
+});
+
+new Miniflare({ scriptPath: "dist/worker.js" });
+```
+
+### Request.cf Undefined
+
+**Problem:** `request.cf` is undefined in worker
+
+**Fix:**
+```js
+new Miniflare({
+  cf: true, // Fetch from Cloudflare
+  // Or provide custom
+  cf: "./cf.json",
+});
+```
+
+### Port Already in Use
+
+**Problem:** `EADDRINUSE` error
+
+**Fix:**
+```js
+// Don't specify port for testing - use dispatchFetch
+new Miniflare({
+  scriptPath: "worker.js",
+  // No port/host
+});
+
+const res = await mf.dispatchFetch("http://localhost/");
+```
+
+### Durable Object Not Found
+
+**Problem:** `ReferenceError: Counter is not defined`
+
+**Fix:**
+```js
+// Ensure DO class is exported
+new Miniflare({
+  modules: true, // Required for DOs
+  script: `
+    export class Counter { /* ... */ } // Must export
+    export default { /* ... */ }
+  `,
+  durableObjects: {
+    COUNTER: "Counter", // Must match export name
+  },
+});
+```
+
+## Debugging Tips
+
+**Enable debug logging:**
+```js
+import { Log, LogLevel } from "miniflare";
+new Miniflare({ log: new Log(LogLevel.DEBUG) });
+```
+
+**Check binding names match:**
+```js
+const bindings = await mf.getBindings();
+console.log(Object.keys(bindings));
+```
+
+**Verify storage directly:**
+```js
+const ns = await mf.getKVNamespace("TEST");
+const keys = await ns.list();
+console.log(keys);
+```
+
+**Test HTTP server separately:**
+```js
+// Use dispatchFetch for tests, not HTTP server
+const res = await mf.dispatchFetch("http://localhost/");
+```
+
+## Migration Notes
+
+### From Wrangler Dev to Miniflare
+
+**Wrangler:**
+```bash
+wrangler dev
+```
+
+**Miniflare:**
+```js
+new Miniflare({
+  scriptPath: "dist/worker.js",
+  // Manually configure bindings (doesn't read wrangler.toml)
+  kvNamespaces: ["KV"],
+  bindings: { API_KEY: "..." },
+});
+```
+
+**Note:** Miniflare doesn't read `wrangler.toml` - configure everything via API.
+
+### From Miniflare 2 to 3
+
+Major changes:
+- Different API surface
+- Better workerd integration
+- Changed persistence options
+- See [official migration guide](https://developers.cloudflare.com/workers/testing/vitest-integration/migration-guides/migrate-from-miniflare-2/)
+
+## When to Use
+
+**Use Miniflare when:**
+- Writing integration tests for Workers
+- Testing Worker bindings/storage locally
+- Testing multiple Workers with service bindings
+- Need direct access to bindings in tests
+- Dispatch events without HTTP
+
+**Use Wrangler instead for:**
+- Standard development workflow
+- Quick local dev server
+- Production deployments
+
+See [patterns.md](./patterns.md) for testing examples.

--- a/.agent/services/hosting/cloudflare-platform/references/miniflare/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/miniflare/patterns.md
@@ -1,0 +1,211 @@
+# Testing Patterns
+
+## Basic Test Setup (node:test)
+
+```js
+import assert from "node:assert";
+import test, { after, before } from "node:test";
+import { Miniflare } from "miniflare";
+
+let mf;
+
+before(async () => {
+  mf = new Miniflare({
+    modules: true,
+    scriptPath: "src/index.js",
+    kvNamespaces: ["TEST_KV"],
+    bindings: { API_KEY: "test-key" },
+  });
+  await mf.ready;
+});
+
+test("fetch returns hello", async () => {
+  const res = await mf.dispatchFetch("http://localhost/");
+  assert.strictEqual(await res.text(), "Hello World");
+});
+
+test("kv operations", async () => {
+  const kv = await mf.getKVNamespace("TEST_KV");
+  await kv.put("key", "value");
+  
+  const res = await mf.dispatchFetch("http://localhost/kv");
+  assert.strictEqual(await res.text(), "value");
+});
+
+after(async () => {
+  await mf.dispose();
+});
+```
+
+## Build Before Tests
+
+```js
+import { spawnSync } from "node:child_process";
+
+before(() => {
+  spawnSync("npx wrangler build", { shell: true, stdio: "pipe" });
+});
+```
+
+## Testing Durable Objects
+
+```js
+test("durable object state", async () => {
+  const ns = await mf.getDurableObjectNamespace("COUNTER");
+  const id = ns.idFromName("test-counter");
+  const stub = ns.get(id);
+  
+  const res1 = await stub.fetch("http://localhost/increment");
+  assert.strictEqual(await res1.text(), "1");
+  
+  const res2 = await stub.fetch("http://localhost/increment");
+  assert.strictEqual(await res2.text(), "2");
+  
+  // Direct storage access
+  const storage = await mf.getDurableObjectStorage(id);
+  const count = await storage.get("count");
+  assert.strictEqual(count, 2);
+});
+```
+
+## Testing Queue Handlers
+
+```js
+test("queue message processing", async () => {
+  const worker = await mf.getWorker();
+  
+  const result = await worker.queue("my-queue", [
+    { id: "msg1", timestamp: new Date(), body: { userId: 123 }, attempts: 1 },
+  ]);
+  
+  assert.strictEqual(result.outcome, "ok");
+  
+  // Verify side effects
+  const kv = await mf.getKVNamespace("QUEUE_LOG");
+  const log = await kv.get("msg1");
+  assert.ok(log);
+});
+```
+
+## Testing Scheduled Events
+
+```js
+test("scheduled cron handler", async () => {
+  const worker = await mf.getWorker();
+  
+  const result = await worker.scheduled({
+    scheduledTime: new Date("2024-01-01T00:00:00Z"),
+    cron: "0 0 * * *",
+  });
+  
+  assert.strictEqual(result.outcome, "ok");
+});
+```
+
+## Isolated Test Data
+
+```js
+describe("user tests", () => {
+  let mf;
+  
+  beforeEach(async () => {
+    mf = new Miniflare({
+      scriptPath: "worker.js",
+      kvNamespaces: ["USERS"],
+      // In-memory: no persist
+    });
+  });
+  
+  afterEach(async () => {
+    await mf.dispose();
+  });
+  
+  test("create user", async () => {
+    // Fresh KV per test
+  });
+});
+```
+
+## Mock External Services
+
+```js
+new Miniflare({
+  workers: [
+    {
+      name: "main",
+      serviceBindings: { EXTERNAL_API: "mock-api" },
+      script: `/* main worker */`,
+    },
+    {
+      name: "mock-api",
+      script: `
+        addEventListener("fetch", (event) => {
+          event.respondWith(Response.json({ mocked: true }));
+        })
+      `,
+    },
+  ],
+});
+```
+
+## Shared Storage Between Workers
+
+```js
+new Miniflare({
+  kvPersist: "./data",
+  workers: [
+    { name: "writer", kvNamespaces: { DATA: "shared" }, script: `...` },
+    { name: "reader", kvNamespaces: { DATA: "shared" }, script: `...` },
+  ],
+});
+```
+
+## Test Utils Pattern
+
+```js
+// test-utils.js
+export async function createTestWorker(overrides = {}) {
+  const mf = new Miniflare({
+    scriptPath: "dist/worker.js",
+    kvNamespaces: ["TEST_KV"],
+    bindings: { ENVIRONMENT: "test", ...overrides.bindings },
+    ...overrides,
+  });
+  await mf.ready;
+  return mf;
+}
+
+// test.js
+test("my test", async () => {
+  const mf = await createTestWorker({ bindings: { CUSTOM: "value" } });
+  try {
+    const res = await mf.dispatchFetch("http://localhost/");
+    assert.ok(res.ok);
+  } finally {
+    await mf.dispose();
+  }
+});
+```
+
+## Error Handling Tests
+
+```js
+test("handles 404", async () => {
+  const res = await mf.dispatchFetch("http://localhost/not-found");
+  assert.strictEqual(res.status, 404);
+});
+
+test("handles invalid input", async () => {
+  const res = await mf.dispatchFetch("http://localhost/api", {
+    method: "POST",
+    body: "invalid json",
+  });
+  assert.strictEqual(res.status, 400);
+});
+```
+
+## CI Integration
+
+Use in-memory storage (omit persist options) for CI speed. Use `dispatchFetch` instead of HTTP server to avoid port conflicts.
+
+See [gotchas.md](./gotchas.md) for troubleshooting common issues.

--- a/.agent/services/hosting/cloudflare-platform/references/network-interconnect/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/network-interconnect/README.md
@@ -1,0 +1,60 @@
+# Cloudflare Network Interconnect (CNI)
+
+Private, high-performance connectivity to Cloudflare's network. **Enterprise-only**.
+
+## Connection Types
+
+**Direct**: Physical fiber in shared datacenter. 10/100 Gbps. You order cross-connect.
+
+**Partner**: Virtual via Console Connect, Equinix, Megaport, etc. Managed via partner SDN.
+
+**Cloud**: AWS Direct Connect or GCP Cloud Interconnect. Magic WAN only.
+
+## Dataplane Versions
+
+**v1 (Classic)**: GRE tunnel support, VLAN/BFD/LACP, asymmetric MTU (1500↓/1476↑), peering support.
+
+**v2 (Beta)**: No GRE, 1500 MTU both ways, no VLAN/BFD/LACP yet, ECMP instead.
+
+## Use Cases
+
+- **Magic Transit DSR**: DDoS protection, egress via ISP (v1/v2)
+- **Magic Transit + Egress**: DDoS + egress via CF (v1/v2)
+- **Magic WAN + Zero Trust**: Private backbone (v1 needs GRE, v2 native)
+- **Peering**: Public routes at PoP (v1 only)
+- **App Security**: WAF/Cache/LB (v1/v2 over Magic Transit)
+
+## Prerequisites
+
+- Enterprise plan
+- IPv4 /24+ or IPv6 /48+ prefixes
+- BGP ASN for v1
+- See [locations PDF](https://developers.cloudflare.com/network-interconnect/static/cni-locations-30-10-2025.pdf)
+
+## Specs
+
+- /31 point-to-point subnets
+- 10km max optical distance
+- 10G: 10GBASE-LR single-mode
+- 100G: 100GBASE-LR4 single-mode
+- **No SLA** (free service)
+- Backup Internet required
+
+## Throughput
+
+| Direction | 10G | 100G |
+|-----------|-----|------|
+| CF → Customer | 10 Gbps | 100 Gbps |
+| Customer → CF (peering) | 10 Gbps | 100 Gbps |
+| Customer → CF (Magic) | 1 Gbps/tunnel or CNI | 1 Gbps/tunnel or CNI |
+
+## Timeline
+
+2-4 weeks typical. Steps: request → config review → order connection → configure → test → enable health checks → activate → monitor.
+
+## See Also
+
+- [configuration.md](./configuration.md) - BGP, routing, setup
+- [api.md](./api.md) - API endpoints, SDKs
+- [patterns.md](./patterns.md) - HA, hybrid cloud, failover
+- [gotchas.md](./gotchas.md) - Troubleshooting, limits

--- a/.agent/services/hosting/cloudflare-platform/references/network-interconnect/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/network-interconnect/api.md
@@ -1,0 +1,240 @@
+# CNI API Reference
+
+See [README.md](./README.md) for overview.
+
+## Base
+
+```
+https://api.cloudflare.com/client/v4
+Auth: Authorization: Bearer <token>
+```
+
+## Interconnects
+
+### List
+```http
+GET /accounts/{account_id}/cni/interconnects
+```
+Query: `page`, `per_page`
+
+### Create
+```http
+POST /accounts/{account_id}/cni/interconnects
+```
+Body: `account`, `slot_id`, `type`, `facility`, `speed`, `name`, `description`
+
+### Get
+```http
+GET /accounts/{account_id}/cni/interconnects/{icon}
+```
+
+### Status
+```http
+GET /accounts/{account_id}/cni/interconnects/{icon}/status
+```
+Returns: `active` | `unhealthy` | `pending`
+
+### LOA
+```http
+GET /accounts/{account_id}/cni/interconnects/{icon}/loa
+```
+Returns PDF.
+
+### Delete
+```http
+DELETE /accounts/{account_id}/cni/interconnects/{icon}
+```
+
+## CNI Objects (BGP config)
+
+### List
+```http
+GET /accounts/{account_id}/cni/cnis
+```
+
+### Create
+```http
+POST /accounts/{account_id}/cni/cnis
+```
+Body: `account`, `cust_ip`, `cf_ip`, `bgp_asn`, `bgp_password`, `vlan`
+
+### Get/Update/Delete
+```http
+GET /accounts/{account_id}/cni/cnis/{cni}
+PUT /accounts/{account_id}/cni/cnis/{cni}
+DELETE /accounts/{account_id}/cni/cnis/{cni}
+```
+
+## Slots
+
+### List
+```http
+GET /accounts/{account_id}/cni/slots
+```
+Query: `facility`, `occupied`
+
+### Get
+```http
+GET /accounts/{account_id}/cni/slots/{slot}
+```
+
+## Settings
+
+### Get/Update
+```http
+GET /accounts/{account_id}/cni/settings
+PUT /accounts/{account_id}/cni/settings
+```
+Body: `default_asn`
+
+## TypeScript SDK
+
+```typescript
+import Cloudflare from 'cloudflare';
+
+const client = new Cloudflare({ apiToken: process.env.CF_TOKEN });
+
+// List
+await client.networkInterconnects.interconnects.list({ account_id: id });
+
+// Create
+await client.networkInterconnects.interconnects.create({
+  account_id: id,
+  account: id,
+  slot_id: 'slot_abc',
+  type: 'direct',
+  facility: 'EWR1',
+  speed: '10G',
+  name: 'prod-interconnect',
+});
+
+// Status
+await client.networkInterconnects.interconnects.get(accountId, iconId);
+
+// LOA (use fetch)
+const res = await fetch(`https://api.cloudflare.com/client/v4/accounts/${id}/cni/interconnects/${iconId}/loa`, {
+  headers: { Authorization: `Bearer ${token}` },
+});
+await fs.writeFile('loa.pdf', Buffer.from(await res.arrayBuffer()));
+
+// CNI object
+await client.networkInterconnects.cnis.create({
+  account_id: id,
+  account: id,
+  cust_ip: '192.0.2.1/31',
+  cf_ip: '192.0.2.0/31',
+  bgp_asn: 65000,
+  vlan: 100,
+});
+
+// Slots
+await client.networkInterconnects.slots.list({
+  account_id: id,
+  occupied: false,
+});
+```
+
+## Python SDK
+
+```python
+from cloudflare import Cloudflare
+
+client = Cloudflare(api_token=os.environ["CF_TOKEN"])
+
+# List
+client.network_interconnects.interconnects.list(account_id=id)
+
+# Create
+client.network_interconnects.interconnects.create(
+    account_id=id,
+    account=id,
+    slot_id="slot_abc",
+    type="direct",
+    facility="EWR1",
+    speed="10G",
+    name="prod-interconnect",
+)
+
+# Status
+client.network_interconnects.interconnects.get(account_id=id, icon=icon_id)
+
+# LOA
+import requests
+res = requests.get(
+    f"https://api.cloudflare.com/client/v4/accounts/{id}/cni/interconnects/{icon_id}/loa",
+    headers={"Authorization": f"Bearer {token}"}
+)
+with open("loa.pdf", "wb") as f:
+    f.write(res.content)
+
+# CNI object
+client.network_interconnects.cnis.create(
+    account_id=id,
+    account=id,
+    cust_ip="192.0.2.1/31",
+    cf_ip="192.0.2.0/31",
+    bgp_asn=65000,
+    vlan=100,
+)
+
+# Slots
+client.network_interconnects.slots.list(
+    account_id=id,
+    occupied=False,
+)
+```
+
+## cURL
+
+```bash
+export CF_TOKEN="token"
+export ACCOUNT_ID="id"
+
+# List
+curl "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/cni/interconnects" \
+  -H "Authorization: Bearer ${CF_TOKEN}"
+
+# Create
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/cni/interconnects" \
+  -H "Authorization: Bearer ${CF_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account": "'${ACCOUNT_ID}'",
+    "slot_id": "slot_abc",
+    "type": "direct",
+    "facility": "EWR1",
+    "speed": "10G",
+    "name": "prod-interconnect"
+  }'
+
+# Status
+curl "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/cni/interconnects/${ICON_ID}/status" \
+  -H "Authorization: Bearer ${CF_TOKEN}"
+
+# LOA
+curl "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/cni/interconnects/${ICON_ID}/loa" \
+  -H "Authorization: Bearer ${CF_TOKEN}" \
+  --output loa.pdf
+
+# CNI object
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/cni/cnis" \
+  -H "Authorization: Bearer ${CF_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "account": "'${ACCOUNT_ID}'",
+    "cust_ip": "192.0.2.1/31",
+    "cf_ip": "192.0.2.0/31",
+    "bgp_asn": 65000,
+    "vlan": 100
+  }'
+
+# Slots
+curl "https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/cni/slots?occupied=false" \
+  -H "Authorization: Bearer ${CF_TOKEN}"
+```
+
+## Resources
+
+- [API Docs](https://developers.cloudflare.com/api/resources/network_interconnects/)
+- [TypeScript SDK](https://github.com/cloudflare/cloudflare-typescript)
+- [Python SDK](https://github.com/cloudflare/cloudflare-python)

--- a/.agent/services/hosting/cloudflare-platform/references/network-interconnect/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/network-interconnect/configuration.md
@@ -1,0 +1,127 @@
+# CNI Configuration
+
+See [README.md](./README.md) for overview.
+
+## Workflow (2-4 weeks)
+
+1. **Submit request** (Week 1): Contact account team, provide type/location/use case
+2. **Review config** (Week 1-2, v1 only): Approve IP/VLAN/spec doc
+3. **Order connection** (Week 2-3):
+   - **Direct**: Get LOA, order cross-connect from facility
+   - **Partner**: Order virtual circuit in partner portal
+   - **Cloud**: Order Direct Connect/Cloud Interconnect, send LOA+VLAN to CF
+4. **Configure** (Week 3): Both sides configure per doc
+5. **Test** (Week 3-4): Ping, verify BGP, check routes
+6. **Health checks** (Week 4): Configure [Magic Transit](https://developers.cloudflare.com/magic-transit/how-to/configure-tunnel-endpoints/#add-tunnels) or [Magic WAN](https://developers.cloudflare.com/magic-wan/configuration/manually/how-to/configure-tunnel-endpoints/#add-tunnels) health checks
+7. **Activate** (Week 4): Route traffic, verify flow
+8. **Monitor**: Enable [maintenance notifications](https://developers.cloudflare.com/network-interconnect/monitoring-and-alerts/#enable-cloudflare-status-maintenance-notification)
+
+## BGP Configuration
+
+**v1 Requirements:**
+- BGP ASN (provide during setup)
+- /31 subnet for peering
+- Optional: BGP password
+
+**v2:** Simplified, less BGP config needed.
+
+**Example v1 BGP:**
+```
+Router ID: 192.0.2.1
+Peer IP: 192.0.2.0
+Remote ASN: 13335
+Local ASN: 65000
+Password: [optional]
+VLAN: 100
+```
+
+## Cloud Interconnect Setup
+
+### AWS Direct Connect (Beta)
+
+**Requirements:** Magic WAN, AWS Dedicated Direct Connect 1/10 Gbps.
+
+**Process:**
+1. Contact CF account team
+2. Choose location
+3. Order in AWS portal
+4. AWS provides LOA + VLAN ID
+5. Send to CF account team
+6. Wait ~4 weeks
+
+**Post-setup:** Add [static routes](https://developers.cloudflare.com/magic-wan/configuration/manually/how-to/configure-routes/#configure-static-routes) to Magic WAN. Enable [bidirectional health checks](https://developers.cloudflare.com/magic-wan/configuration/manually/how-to/configure-tunnel-endpoints/#legacy-bidirectional-health-checks).
+
+### GCP Cloud Interconnect (Beta)
+
+**Setup via Dashboard:**
+1. Interconnects → Create → Cloud Interconnect → Google
+2. Provide name, MTU (match GCP VLAN attachment), speed
+3. Enter VLAN attachment pairing key
+4. Confirm order
+
+**Routing to GCP:** Add [static routes](https://developers.cloudflare.com/magic-wan/configuration/manually/how-to/configure-routes/#configure-static-routes). BGP routes from GCP Cloud Router **ignored**.
+
+**Routing to CF:** Configure [custom learned routes](https://cloud.google.com/network-connectivity/docs/router/how-to/configure-custom-learned-routes) in Cloud Router. Request prefixes from CF account team.
+
+## Monitoring
+
+**Dashboard Status:**
+- **Active**: Link up, sufficient light, Ethernet negotiated
+- **Unhealthy**: Link down, no/low light (<-20 dBm), can't negotiate
+- **Pending**: Cross-connect incomplete, device unresponsive, RX/TX swapped
+
+**Alerts:**
+
+**CNI Connection Maintenance** (Magic Networking only):
+```
+Dashboard → Notifications → Add
+Product: Cloudflare Network Interconnect
+Type: Connection Maintenance Alert
+```
+Warnings up to 2 weeks advance. 6hr delay for new additions.
+
+**Cloudflare Status Maintenance** (entire PoP):
+```
+Dashboard → Notifications → Add
+Product: Cloudflare Status
+Filter PoPs: gru,fra,lhr
+```
+
+**Find PoP code:**
+```
+Dashboard → Magic Transit/WAN → Configuration → Interconnects
+Select CNI → Note Data Center (e.g., "gru-b")
+Use first 3 letters: "gru"
+```
+
+## Best Practices
+
+**Design:**
+- Choose locations with device diversity
+- Plan redundancy from start
+- Select appropriate dataplane for use case
+- Document capacity + growth
+
+**Ordering:**
+- Verify facility codes match LOA
+- Confirm single-mode fiber
+- Check optic types (10GBASE-LR/100GBASE-LR4)
+
+**Config:**
+- /31 subnets
+- BGP passwords
+- BFD for v1
+- Test ping before BGP
+
+**Production:**
+- Enable maintenance notifications immediately
+- Monitor status programmatically
+- Test backup connectivity regularly
+- Document escalation paths
+
+**Security:**
+- Minimum API token permissions
+- Rotate BGP passwords
+- BGP route filtering
+- Monitor unexpected advertisements
+- Use Magic Firewall

--- a/.agent/services/hosting/cloudflare-platform/references/network-interconnect/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/network-interconnect/gotchas.md
@@ -1,0 +1,171 @@
+# CNI Gotchas & Troubleshooting
+
+See [README.md](./README.md) for overview.
+
+## Limitations
+
+**General:**
+- No formal SLA (free service)
+- No dashboard config visibility
+- Recovery may take days
+- 10km max optical distance
+- Backup Internet required
+
+**v1:**
+- Asymmetric MTU (1500↓/1476↑)
+- GRE overhead for Magic Transit/WAN
+- 1 Gbps/GRE tunnel limit
+
+**v2:**
+- No VLAN (yet)
+- No BFD (yet)
+- No LACP (use ECMP)
+- No peering support
+- Beta status
+
+**Cloud:**
+- AWS Hosted Direct Connect unsupported
+- Magic WAN only
+- GCP BGP routes ignored
+- AWS requires manual coordination
+
+## Troubleshooting
+
+### Status: Pending
+
+**Symptoms:** Stuck in pending.
+
+**Causes:**
+- Cross-connect not installed
+- RX/TX fibers reversed
+- Wrong fiber type
+- Low light levels
+
+**Fix:**
+1. Verify cross-connect installed
+2. Check fiber at patch panel
+3. Swap RX/TX
+4. Check light with optical power meter
+5. Contact account team
+
+### Status: Unhealthy
+
+**Symptoms:** Shows unhealthy.
+
+**Causes:**
+- Physical issue
+- Light <-20 dBm
+- Optic mismatch
+- Dirty connectors
+
+**Fix:**
+1. Check physical connections
+2. Clean fiber connectors
+3. Verify optic types (10GBASE-LR/100GBASE-LR4)
+4. Test with known-good optics
+5. Check patch panel
+6. Contact account team
+
+### BGP Session Down
+
+**Symptoms:** Link up, BGP down.
+
+**Causes:**
+- Wrong IP addressing
+- Wrong ASN
+- Password mismatch
+- Firewall blocking TCP/179
+
+**Fix:**
+1. Verify IPs match CNI object
+2. Confirm ASN correct
+3. Check BGP password
+4. Verify no firewall on TCP/179
+5. Check BGP logs
+6. Review BGP timers
+
+### Low Throughput
+
+**Symptoms:** Traffic flows, below expected.
+
+**Causes:**
+- MTU mismatch
+- Fragmentation
+- Single GRE tunnel (v1)
+- Routing inefficiency
+
+**Fix:**
+1. Check MTU (1500↓/1476↑ for v1, 1500 both for v2)
+2. Test various packet sizes
+3. Add more GRE tunnels (v1)
+4. Consider upgrading to v2
+5. Review routing tables
+6. Use LACP for bundling (v1)
+
+## Common Mistakes
+
+**Ordering:**
+- ❌ Wrong facility code on LOA
+- ❌ Multi-mode fiber (need single-mode)
+- ❌ Wrong optic type
+- ❌ Forgetting to track cross-connect order
+
+**Configuration:**
+- ❌ Not using /31 subnets
+- ❌ Skipping BGP passwords
+- ❌ Wrong ASN
+- ❌ Firewall blocking BGP (TCP/179)
+
+**Production:**
+- ❌ No maintenance notifications
+- ❌ Not testing backup connectivity
+- ❌ Missing runbooks
+- ❌ No failover testing
+- ❌ Ignoring capacity planning
+
+## Quick Reference
+
+**Status Guide:**
+- **Active**: Working normally → Monitor
+- **Unhealthy**: Down → Check physical
+- **Pending**: In progress → Complete cross-connect
+
+**Contact Account Team For:**
+- CNI eligibility
+- Config assistance
+- LOA generation
+- Unhealthy interconnects
+- Location availability
+- Device diversity options
+
+**Key Commands:**
+```bash
+# List interconnects
+curl "https://api.cloudflare.com/client/v4/accounts/${ID}/cni/interconnects" \
+  -H "Authorization: Bearer ${TOKEN}"
+
+# Get status
+curl "https://api.cloudflare.com/client/v4/accounts/${ID}/cni/interconnects/${ICON}/status" \
+  -H "Authorization: Bearer ${TOKEN}"
+
+# Download LOA
+curl "https://api.cloudflare.com/client/v4/accounts/${ID}/cni/interconnects/${ICON}/loa" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  --output loa.pdf
+
+# List CNI objects
+curl "https://api.cloudflare.com/client/v4/accounts/${ID}/cni/cnis" \
+  -H "Authorization: Bearer ${TOKEN}"
+
+# List available slots
+curl "https://api.cloudflare.com/client/v4/accounts/${ID}/cni/slots?occupied=false" \
+  -H "Authorization: Bearer ${TOKEN}"
+```
+
+## Resources
+
+- [CNI Overview](https://developers.cloudflare.com/network-interconnect/)
+- [Get Started](https://developers.cloudflare.com/network-interconnect/get-started/)
+- [Monitoring](https://developers.cloudflare.com/network-interconnect/monitoring-and-alerts/)
+- [Locations PDF](https://developers.cloudflare.com/network-interconnect/static/cni-locations-30-10-2025.pdf)
+- [API Docs](https://developers.cloudflare.com/api/resources/network_interconnects/)

--- a/.agent/services/hosting/cloudflare-platform/references/network-interconnect/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/network-interconnect/patterns.md
@@ -1,0 +1,171 @@
+# CNI Patterns
+
+See [README.md](./README.md) for overview.
+
+## High Availability
+
+**Critical:** Design for resilience from day one.
+
+**Requirements:**
+- Device-level diversity (separate hardware)
+- Backup Internet connectivity (no SLA on CNI)
+- Network-resilient locations preferred
+- Regular failover testing
+
+**Architecture:**
+```
+Your Network A ──10G CNI v2──> CF CCR Device 1
+                                     │
+Your Network B ──10G CNI v2──> CF CCR Device 2
+                                     │
+                            CF Global Network (AS13335)
+```
+
+**Capacity Planning:**
+- Plan across all links
+- Account for failover scenarios
+- Your responsibility
+
+## Pattern: Magic Transit + CNI v2
+
+**Use Case:** DDoS protection, private connectivity, no GRE overhead.
+
+```typescript
+// 1. Create interconnect
+const ic = await client.networkInterconnects.interconnects.create({
+  account_id: id,
+  type: 'direct',
+  facility: 'EWR1',
+  speed: '10G',
+  name: 'magic-transit-primary',
+});
+
+// 2. Poll until active
+const status = await pollUntilActive(id, ic.id);
+
+// 3. Configure Magic Transit tunnel via Dashboard/API
+```
+
+**Benefits:** 1500 MTU both ways, simplified routing.
+
+## Pattern: Multi-Cloud Hybrid
+
+**Use Case:** AWS/GCP workloads with Cloudflare.
+
+**AWS Direct Connect:**
+```typescript
+// 1. Order Direct Connect in AWS Console
+// 2. Get LOA + VLAN from AWS
+// 3. Send to CF account team (no API)
+// 4. Configure static routes in Magic WAN
+
+await configureStaticRoutes(id, {
+  prefix: '10.0.0.0/8',
+  nexthop: 'aws-direct-connect',
+});
+```
+
+**GCP Cloud Interconnect:**
+```typescript
+// 1. Get VLAN pairing key from GCP
+// 2. Create via Dashboard (no SDK yet)
+// 3. Configure static routes in Magic WAN
+// 4. Configure BGP in GCP Cloud Router
+
+const ic = await client.networkInterconnects.interconnects.create({
+  account_id: id,
+  type: 'cloud',
+  cloud_provider: 'gcp',
+  pairing_key: 'gcp_key',
+  name: 'gcp-interconnect',
+});
+```
+
+## Pattern: Multi-Location HA
+
+**Use Case:** 99.99%+ uptime.
+
+```typescript
+// Primary (NY)
+const primary = await client.networkInterconnects.interconnects.create({
+  account_id: id,
+  type: 'direct',
+  facility: 'EWR1',
+  speed: '10G',
+  name: 'primary-ewr1',
+});
+
+// Secondary (NY, different hardware)
+const secondary = await client.networkInterconnects.interconnects.create({
+  account_id: id,
+  type: 'direct',
+  facility: 'EWR2',
+  speed: '10G',
+  name: 'secondary-ewr2',
+});
+
+// Tertiary (LA, different geography)
+const tertiary = await client.networkInterconnects.interconnects.create({
+  account_id: id,
+  type: 'partner',
+  facility: 'LAX1',
+  speed: '10G',
+  name: 'tertiary-lax1',
+});
+
+// BGP local preferences:
+// Primary: 200
+// Secondary: 150
+// Tertiary: 100
+// Internet: Last resort
+```
+
+## Pattern: Partner Interconnect (Equinix)
+
+**Use Case:** Quick deployment, no colocation.
+
+**Setup:**
+1. Order virtual circuit in Equinix Fabric Portal
+2. Select Cloudflare as destination
+3. Choose facility
+4. Send details to CF account team
+5. CF accepts in portal
+6. Configure BGP
+
+**No API automation** – partner portals managed separately.
+
+## Failover & Security
+
+**Failover Best Practices:**
+- Use BGP local preferences for priority
+- Configure BFD for fast detection (v1)
+- Test regularly with traffic shift
+- Document runbooks
+
+**Security:**
+- BGP password authentication
+- BGP route filtering
+- Monitor unexpected routes
+- Magic Firewall for DDoS/threats
+- Minimum API token permissions
+- Rotate credentials periodically
+
+## Decision Matrix
+
+| Requirement | Recommended |
+|-------------|-------------|
+| Collocated with CF | Direct |
+| Not collocated | Partner |
+| AWS/GCP workloads | Cloud |
+| 1500 MTU both ways | v2 |
+| VLAN tagging | v1 |
+| Public peering | v1 |
+| Simplest config | v2 |
+| BFD fast failover | v1 |
+| LACP bundling | v1 |
+
+## Resources
+
+- [Magic Transit Docs](https://developers.cloudflare.com/magic-transit/)
+- [Magic WAN Docs](https://developers.cloudflare.com/magic-wan/)
+- [Argo Smart Routing](https://developers.cloudflare.com/argo/)

--- a/.agent/services/hosting/cloudflare-platform/references/observability/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/observability/README.md
@@ -1,0 +1,18 @@
+# Cloudflare Observability Skill Reference
+
+**Purpose**: Comprehensive guidance for implementing observability in Cloudflare Workers, covering traces, logs, metrics, and analytics.
+
+**Scope**: Cloudflare Observability features ONLY - Workers Logs, Traces, Analytics Engine, Logpush, Metrics & Analytics, and OpenTelemetry exports.
+
+---...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/observability/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/observability/api.md
@@ -1,0 +1,51 @@
+## API Reference
+
+### GraphQL Analytics API
+
+**Endpoint**: `https://api.cloudflare.com/client/v4/graphql`
+
+**Query Workers Metrics**:
+```graphql
+query {
+  viewer {
+    accounts(filter: { accountTag: $accountId }) {
+      workersInvocationsAdaptive(
+        limit: 100
+        filter: {
+          datetime_geq: "2025-01-01T00:00:00Z"
+          datetime_leq: "2025-01-31T23:59:59Z"
+          scriptName: "my-worker"
+        }
+      ) {
+        sum {
+          requests
+          errors
+          subrequests
+        }
+        quantiles {
+          cpuTimeP50
+          cpuTimeP99
+          wallTimeP50
+          wallTimeP99
+        }
+      }
+    }
+  }
+}
+```
+
+### Analytics Engine SQL API
+
+**Endpoint**: `https://api.cloudflare.com/client/v4/accounts/{account_id}/analytics_engine/sql`
+
+**Authentication**: `Authorization: Bearer <API_TOKEN>` (Account Analytics Read permission)
+
+**Common Queries**:
+
+```sql
+-- List all datasets
+SHOW TABLES;
+
+-- Time-series aggregation (5-minute buckets)
+SELECT
+  intDi

--- a/.agent/services/hosting/cloudflare-platform/references/observability/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/observability/configuration.md
@@ -1,0 +1,60 @@
+## Configuration Patterns
+
+### Enable Workers Logs
+
+```jsonc
+// wrangler.jsonc
+{
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1  // 100% sampling (default)
+  }
+}
+```
+
+```toml
+# wrangler.toml
+[observability]
+enabled = true
+head_sampling_rate = 1  # 100% sampling
+```
+
+**Best Practice**: Use structured JSON logging for better indexing
+
+```typescript
+// Good - structured logging
+console.log({ 
+  user_id: 123, 
+  action: "login", 
+  status: "success",
+  duration_ms: 45
+});
+
+// Avoid - unstructured string
+console.log("user_id: 123 logged in successfully in 45ms");
+```
+
+### Enable Workers Traces
+
+```jsonc
+// wrangler.jsonc
+{
+  "observability": {
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 0.05  // 5% sampling
+    }
+  }
+}
+```
+
+```toml
+# wrangler.toml
+[observability.traces]
+enabled = true
+head_sampling_rate = 0.05  # 5% sampling
+```
+
+**Note**: Default sampling is 100%. For high-traffic Workers, use lower sampling (0.01-0.1).
+
+### Configure Analytics

--- a/.agent/services/hosting/cloudflare-platform/references/observability/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/observability/gotchas.md
@@ -1,0 +1,36 @@
+## Troubleshooting
+
+### Logs not appearing
+
+**Check**:
+1. `observability.enabled = true` in wrangler config
+2. Worker has been redeployed after config change
+3. Worker is receiving traffic
+4. Sampling rate is not too low (check `head_sampling_rate`)
+5. Log size under 256 KB limit
+
+**Solution**:
+```bash
+# Verify config
+cat wrangler.toml | grep -A 5 observability
+
+# Check deployment
+wrangler deployments list <WORKER_NAME>
+
+# Test with curl
+curl https://your-worker.workers.dev
+```
+
+### Traces not being captured
+
+**Check**:
+1. `observability.traces.enabled = true`
+2. `head_sampling_rate` is appropriate (1.0 for testing)
+3. Worker deployed after traces enabled
+4. Check destination status in dashboard
+
+**Solution**:
+```jsonc
+// Temporarily set to 100% sampling for debugging
+{
+  "observability": 

--- a/.agent/services/hosting/cloudflare-platform/references/observability/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/observability/patterns.md
@@ -1,0 +1,42 @@
+## Common Use Cases
+
+### 1. Usage-Based Billing
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const customerId = request.headers.get('X-Customer-ID');
+    const apiKey = request.headers.get('X-API-Key');
+    
+    if (!customerId || !apiKey) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+    
+    // Track API usage per customer
+    env.ANALYTICS.writeDataPoint({
+      'blobs': [customerId, request.url, request.method],
+      'doubles': [1], // request_count
+      'indexes': [customerId]
+    });
+    
+    return processRequest(request);
+  }
+}
+```
+
+**Query for billing**:
+```sql
+SELECT
+  blob1 AS customer_id,
+  SUM(_sample_interval * double1) AS total_api_calls
+FROM api_usage
+WHERE timestamp >= DATE_TRUNC('month', NOW())
+GROUP BY customer_id
+ORDER BY total_api_calls DESC
+```
+
+### 2. Performance Monitoring
+
+```typescript
+async function monitoredFetch(url: string, env: Env): Promise<Response> {
+  const start = Date.now(

--- a/.agent/services/hosting/cloudflare-platform/references/pages-functions/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages-functions/README.md
@@ -1,0 +1,57 @@
+# Cloudflare Pages Functions
+
+Serverless functions on Cloudflare Pages using Workers runtime. Full-stack dev with file-based routing.
+
+## File-Based Routing
+
+```
+/functions
+  ├── index.js              → /
+  ├── api.js                → /api
+  ├── users/
+  │   ├── index.js          → /users/
+  │   ├── [user].js         → /users/:user
+  │   └── [[catchall]].js   → /users/*
+  └── _middleware.js        → runs on all routes
+```
+
+**Rules:**
+- `index.js` → directory root
+- Trailing slash optional
+- Specific routes precede catch-alls
+- Falls back to static if no match
+
+## Dynamic Routes
+
+**Single segment** `[param]` → string:
+```js
+// /functions/users/[user].js
+export function onRequest(context) {
+  return new Response(`Hello ${context.params.user}`);
+}
+// Matches: /users/nevi
+```
+
+**Multi-segment** `[[param]]` → array:
+```js
+// /functions/users/[[catchall]].js
+export function onRequest(context) {
+  return new Response(JSON.stringify(context.params.catchall));
+}
+// Matches: /users/nevi/foobar → ["nevi", "foobar"]
+```
+
+## Key Features
+
+- **Method handlers:** `onRequestGet`, `onRequestPost`, etc.
+- **Middleware:** `_middleware.js` for cross-cutting concerns
+- **Bindings:** KV, D1, R2, Durable Objects, Workers AI, Service bindings
+- **TypeScript:** Full type support via `@cloudflare/workers-types`
+- **Advanced mode:** Use `_worker.js` for custom routing logic
+
+## See Also
+
+- [configuration.md](./configuration.md) - Routes, headers, redirects, wrangler config
+- [api.md](./api.md) - EventContext, handlers, bindings
+- [patterns.md](./patterns.md) - Auth, CORS, rate limiting, forms, caching
+- [gotchas.md](./gotchas.md) - Common issues, debugging, limits

--- a/.agent/services/hosting/cloudflare-platform/references/pages-functions/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages-functions/api.md
@@ -1,0 +1,201 @@
+# Function API
+
+## EventContext
+
+```typescript
+interface EventContext<Env = any> {
+  request: Request;              // Incoming request
+  functionPath: string;          // Request path
+  waitUntil(promise: Promise<any>): void;  // Background work
+  passThroughOnException(): void;          // Fallback on error
+  next(input?: Request | string, init?: RequestInit): Promise<Response>;
+  env: Env;                      // Bindings, vars, secrets
+  params: Record<string, string | string[]>;  // Route params
+  data: any;                     // Middleware shared data
+}
+```
+
+## Handlers
+
+```typescript
+// Generic (fallback)
+export async function onRequest(context: EventContext): Promise<Response> {
+  return new Response('Any method');
+}
+
+// Method-specific (takes precedence)
+export async function onRequestGet(context: EventContext): Promise<Response> {
+  return new Response('GET request');
+}
+
+export async function onRequestPost(context: EventContext): Promise<Response> {
+  const body = await context.request.json();
+  return Response.json({ received: body });
+}
+
+// Also: onRequestPut, onRequestPatch, onRequestDelete, onRequestHead, onRequestOptions
+```
+
+## Bindings
+
+### KV
+
+```typescript
+interface Env { TODO_LIST: KVNamespace; }
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  await context.env.TODO_LIST.put('Task:123', 'Buy milk');
+  const task = await context.env.TODO_LIST.get('Task:123');
+  await context.env.TODO_LIST.delete('Task:123');
+  const keys = await context.env.TODO_LIST.list({ prefix: 'Task:' });
+  
+  // With options
+  await context.env.TODO_LIST.put('session', data, { expirationTtl: 3600 });
+  const value = await context.env.TODO_LIST.get('key', { type: 'json' });
+  
+  return new Response(task);
+};
+```
+
+### D1
+
+```typescript
+interface Env { DB: D1Database; }
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  // Prepared statements
+  const result = await context.env.DB.prepare('SELECT * FROM users WHERE id = ?')
+    .bind(123)
+    .first();
+  
+  // Batch
+  const data = await context.env.DB.batch([
+    context.env.DB.prepare('SELECT * FROM users'),
+    context.env.DB.prepare('SELECT * FROM posts')
+  ]);
+  
+  return Response.json(result);
+};
+```
+
+### R2
+
+```typescript
+interface Env { BUCKET: R2Bucket; }
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const url = new URL(context.request.url);
+  const key = url.pathname.slice(1);
+  
+  // GET
+  const obj = await context.env.BUCKET.get(key);
+  if (!obj) return new Response('Not found', { status: 404 });
+  
+  // PUT
+  await context.env.BUCKET.put(key, context.request.body, {
+    httpMetadata: { contentType: 'application/octet-stream' }
+  });
+  
+  // DELETE
+  await context.env.BUCKET.delete(key);
+  
+  return new Response(obj.body);
+};
+```
+
+### Durable Objects
+
+```typescript
+interface Env { COUNTER: DurableObjectNamespace; }
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const id = context.env.COUNTER.idFromName('global-counter');
+  const stub = context.env.COUNTER.get(id);
+  return stub.fetch(context.request);
+};
+```
+
+### Workers AI
+
+```typescript
+interface Env { AI: Ai; }
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const answer = await context.env.AI.run(
+    '@cf/meta/llama-3.1-8b-instruct',
+    { prompt: 'Hello, World?' }
+  );
+  return Response.json(answer);
+};
+```
+
+### Service Bindings
+
+```typescript
+interface Env { AUTH_SERVICE: Fetcher; }
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  // Forward request
+  return context.env.AUTH_SERVICE.fetch(context.request);
+  
+  // Custom request
+  const req = new Request('https://internal/verify', {
+    method: 'POST',
+    body: JSON.stringify({ token: 'xyz' })
+  });
+  return context.env.AUTH_SERVICE.fetch(req);
+};
+```
+
+### Environment Variables
+
+```typescript
+interface Env {
+  API_KEY: string;
+  ENVIRONMENT: string;
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const apiKey = context.env.API_KEY;
+  const isProd = context.env.ENVIRONMENT === 'production';
+  return new Response('OK');
+};
+```
+
+## TypeScript
+
+```bash
+npm install -D @cloudflare/workers-types
+```
+
+```json
+// tsconfig.json
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ES2022",
+    "lib": ["ES2021"],
+    "types": ["@cloudflare/workers-types"]
+  }
+}
+```
+
+```typescript
+import type { PagesFunction, EventContext } from '@cloudflare/workers-types';
+
+interface Env {
+  KV: KVNamespace;
+  DB: D1Database;
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  // context.env fully typed
+  return new Response('OK');
+};
+```
+
+## See Also
+
+- [README.md](./README.md) - Overview
+- [configuration.md](./configuration.md) - wrangler.json
+- [patterns.md](./patterns.md) - Common patterns

--- a/.agent/services/hosting/cloudflare-platform/references/pages-functions/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages-functions/configuration.md
@@ -1,0 +1,159 @@
+# Configuration
+
+## wrangler.json / wrangler.toml
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-pages-app",
+  "pages_build_output_dir": "./dist",
+  "compatibility_date": "2024-01-15",
+  "compatibility_flags": ["nodejs_compat"],
+  
+  "vars": { "API_URL": "https://api.example.com" },
+  
+  "kv_namespaces": [
+    { "binding": "KV", "id": "abc123" }
+  ],
+  
+  "d1_databases": [{
+    "binding": "DB",
+    "database_name": "production-db",
+    "database_id": "xyz789"
+  }],
+  
+  "r2_buckets": [
+    { "binding": "BUCKET", "bucket_name": "my-bucket" }
+  ],
+  
+  "durable_objects": {
+    "bindings": [{
+      "name": "COUNTER",
+      "class_name": "Counter",
+      "script_name": "counter-worker"
+    }]
+  },
+  
+  "services": [
+    { "binding": "AUTH", "service": "auth-worker" }
+  ],
+  
+  "ai": { "binding": "AI" },
+  
+  "vectorize": [{
+    "binding": "VECTORIZE",
+    "index_name": "my-index"
+  }],
+  
+  "hyperdrive": [{
+    "binding": "HYPERDRIVE",
+    "id": "hyperdrive-id"
+  }],
+  
+  "analytics_engine_datasets": [{ "binding": "ANALYTICS" }]
+}
+```
+
+## Environment Overrides
+
+```jsonc
+{
+  "name": "my-app",
+  "vars": { "API_URL": "http://localhost:8787" },
+  
+  "env": {
+    "preview": {
+      "vars": { "API_URL": "https://preview.example.com" }
+    },
+    "production": {
+      "vars": { "API_URL": "https://api.example.com" }
+    }
+  }
+}
+```
+
+**Rules:**
+- Top-level → local dev
+- `env.preview` → preview deployments
+- `env.production` → production
+- **Non-inheritable keys:** If overriding `vars`, `kv_namespaces`, `d1_databases`, etc., ALL must be redefined
+
+## Local Secrets (.dev.vars)
+
+```bash
+# .dev.vars (DO NOT COMMIT)
+SECRET_KEY="my-secret-value"
+API_TOKEN="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+```
+
+- Add `.dev.vars*` to `.gitignore`
+- Use `vars` for non-sensitive config
+- Environment-specific: `.dev.vars.preview`, `.dev.vars.production`
+
+## _routes.json (Advanced)
+
+Custom routing rules in build output:
+
+```json
+{
+  "version": 1,
+  "include": ["/api/*"],
+  "exclude": ["/static/*"]
+}
+```
+
+## _headers (Static)
+
+```
+/static/*
+  Cache-Control: public, max-age=31536000
+  X-Custom: value
+
+/api/*
+  Access-Control-Allow-Origin: *
+```
+
+## _redirects (Static)
+
+```
+/old-page  /new-page  301
+/docs/*    https://docs.example.com/:splat  302
+```
+
+## Local Dev
+
+```bash
+# Start dev server
+npx wrangler pages dev ./dist
+
+# With bindings
+npx wrangler pages dev ./dist \
+  --kv=KV \
+  --d1=DB=database-id \
+  --r2=BUCKET \
+  --binding=API_KEY=secret123
+
+# Durable Objects (2 terminals)
+cd do-worker && npx wrangler dev
+cd pages-project && npx wrangler pages dev ./dist \
+  --do COUNTER=CounterClass@do-worker
+```
+
+## Deployment
+
+```bash
+# Git push (auto-deploys)
+git push origin main
+
+# CLI
+npx wrangler pages deploy ./dist
+npx wrangler pages deploy ./dist --branch preview
+
+# Download config from dashboard
+npx wrangler pages download config my-project-name
+```
+
+## See Also
+
+- [README.md](./README.md) - Overview
+- [api.md](./api.md) - EventContext, bindings

--- a/.agent/services/hosting/cloudflare-platform/references/pages-functions/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages-functions/gotchas.md
@@ -1,0 +1,151 @@
+# Gotchas & Debugging
+
+## Common Issues
+
+### Functions Not Invoking
+
+All requests serve static, functions never run.
+
+**Fix:**
+- `/functions` in correct location (project root)
+- Check `pages_build_output_dir` in wrangler.json
+- Files have `.js` or `.ts` extension
+- `_routes.json` not excluding paths
+
+### Binding Not Available
+
+`context.env.MY_BINDING is undefined`
+
+**Fix:**
+- Binding in wrangler.json or dashboard
+- Name matches exactly (case-sensitive)
+- Local dev: pass flags OR configure wrangler.json
+- Redeploy after changes
+
+### TypeScript Errors
+
+Type errors for `context.env`
+
+**Fix:**
+```typescript
+interface Env { MY_BINDING: KVNamespace; }
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  // context.env.MY_BINDING now typed
+};
+```
+
+### Middleware Not Running
+
+`_middleware.js` not executing
+
+**Fix:**
+- Named exactly `_middleware.js`
+- In correct directory for route scope
+- `onRequest` or method handler exported
+- Use `context.next()` to pass control
+
+### Environment Variables Missing
+
+`context.env.VAR_NAME is undefined`
+
+**Fix:**
+- `vars` in wrangler.json
+- Secrets: `.dev.vars` locally, dashboard/wrangler.json for prod
+- Redeploy after changes
+
+## Debugging
+
+### Console Logging
+
+```typescript
+export async function onRequest(context) {
+  console.log('Request:', context.request.method, context.request.url);
+  console.log('Headers:', Object.fromEntries(context.request.headers));
+  
+  const response = await context.next();
+  console.log('Response status:', response.status);
+  return response;
+}
+```
+
+### Wrangler Tail
+
+```bash
+# Stream real-time logs
+npx wrangler pages deployment tail
+
+# Filter
+npx wrangler pages deployment tail --status error
+```
+
+### Source Maps
+
+```jsonc
+// wrangler.json
+{ "upload_source_maps": true }
+```
+
+## Limits
+
+- **CPU:** 10ms (Free), 50ms (Paid)
+- **Memory:** 128 MB
+- **Script size:** 10 MB compressed
+- **Env vars:** 5 KB per var, 64 max
+- **Requests:** 100k free/day, $0.50/million after
+
+## Best Practices
+
+**Performance:**
+- Minimize deps for cold starts
+- KV for infrequent reads, D1 for relational, R2 for large files
+- Set `Cache-Control` headers
+- Use prepared statements, batch operations
+- Handle errors gracefully
+
+**Security:**
+- Never commit secrets
+- Use secrets (encrypted) not vars for sensitive data
+- Validate all input
+- Sanitize before DB ops
+- Implement auth middleware
+- Set appropriate CORS headers
+- Rate limit per-IP
+
+## Migration
+
+### From Workers
+
+```typescript
+// Worker
+export default {
+  fetch(request, env) { }
+}
+
+// Pages Function
+export function onRequest(context) {
+  const { request, env } = context;
+}
+```
+
+In `_worker.js`: `return env.ASSETS.fetch(request)` for static assets.
+
+### From Other Platforms
+
+- `/functions/api/users.js` → `/api/users`
+- Dynamic routes: `[param]` not `:param`
+- Replace deps with Workers APIs or `nodejs_compat` flag
+
+## Resources
+
+- [Docs](https://developers.cloudflare.com/pages/functions/)
+- [Workers APIs](https://developers.cloudflare.com/workers/runtime-apis/)
+- [Examples](https://github.com/cloudflare/pages-example-projects)
+- [Discord](https://discord.gg/cloudflaredev)
+
+## See Also
+
+- [README.md](./README.md) - Overview
+- [configuration.md](./configuration.md) - wrangler.json
+- [api.md](./api.md) - EventContext, bindings
+- [patterns.md](./patterns.md) - Common patterns

--- a/.agent/services/hosting/cloudflare-platform/references/pages-functions/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages-functions/patterns.md
@@ -1,0 +1,190 @@
+# Common Patterns
+
+## Middleware
+
+```javascript
+// functions/_middleware.js - global
+// functions/users/_middleware.js - scoped to /users/*
+
+// Single
+export async function onRequest(context) {
+  try {
+    return await context.next();
+  } catch (err) {
+    return new Response(`${err.message}\n${err.stack}`, { status: 500 });
+  }
+}
+
+// Chained (runs in array order)
+export const onRequest = [errorHandling, authentication, logging];
+```
+
+**Best practices:**
+- First middleware = error handler (wraps others)
+- Use `context.next()` to pass control
+- Share state via `context.data`
+
+## Authentication
+
+```typescript
+async function authMiddleware(context: EventContext<Env>) {
+  const token = context.request.headers.get('authorization')?.replace('Bearer ', '');
+  if (!token) return new Response('Unauthorized', { status: 401 });
+  
+  const session = await context.env.KV.get(`session:${token}`);
+  if (!session) return new Response('Invalid token', { status: 401 });
+  
+  context.data.user = JSON.parse(session);
+  return context.next();
+}
+
+export const onRequest = [authMiddleware];
+```
+
+## CORS
+
+```typescript
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Access-Control-Max-Age': '86400',
+};
+
+export async function onRequestOptions(context) {
+  return new Response(null, { headers: corsHeaders });
+}
+
+export async function onRequest(context) {
+  const response = await context.next();
+  Object.entries(corsHeaders).forEach(([k, v]) => response.headers.set(k, v));
+  return response;
+}
+```
+
+## Rate Limiting
+
+```typescript
+interface Env { RATE_LIMIT: KVNamespace; }
+
+async function rateLimitMiddleware(context: EventContext<Env>) {
+  const clientIP = context.request.headers.get('CF-Connecting-IP') || 'unknown';
+  const key = `ratelimit:${clientIP}`;
+  const count = parseInt(await context.env.RATE_LIMIT.get(key) || '0');
+  
+  if (count >= 100) return new Response('Rate limit exceeded', { status: 429 });
+  
+  await context.env.RATE_LIMIT.put(key, (count + 1).toString(), { expirationTtl: 3600 });
+  return context.next();
+}
+```
+
+## Forms
+
+```typescript
+export async function onRequestPost(context) {
+  const contentType = context.request.headers.get('content-type') || '';
+  
+  if (contentType.includes('application/json')) {
+    const data = await context.request.json();
+    return Response.json({ received: data });
+  }
+  
+  if (contentType.includes('application/x-www-form-urlencoded')) {
+    const formData = await context.request.formData();
+    return Response.json({ received: Object.fromEntries(formData) });
+  }
+  
+  if (contentType.includes('multipart/form-data')) {
+    const formData = await context.request.formData();
+    const file = formData.get('file') as File;
+    if (file) {
+      await context.env.BUCKET.put(file.name, file.stream());
+      return Response.json({ uploaded: file.name });
+    }
+  }
+  
+  return new Response('Unsupported content type', { status: 400 });
+}
+```
+
+## Caching
+
+```typescript
+export async function onRequest(context) {
+  const cache = caches.default;
+  const cacheKey = new Request(context.request.url, context.request);
+  
+  let response = await cache.match(cacheKey);
+  if (!response) {
+    response = new Response('Hello World');
+    response.headers.set('Cache-Control', 'public, max-age=3600');
+    context.waitUntil(cache.put(cacheKey, response.clone()));
+  }
+  
+  return response;
+}
+```
+
+## Redirects
+
+```typescript
+export async function onRequest(context) {
+  const url = new URL(context.request.url);
+  
+  // Old paths
+  if (url.pathname === '/old-page') {
+    return Response.redirect(`${url.origin}/new-page`, 301);
+  }
+  
+  // Force HTTPS
+  if (url.protocol === 'http:') {
+    url.protocol = 'https:';
+    return Response.redirect(url.toString(), 301);
+  }
+  
+  return context.next();
+}
+```
+
+## Advanced Mode (_worker.js)
+
+For complex routing, replace `/functions` with `_worker.js`:
+
+```typescript
+interface Env {
+  ASSETS: Fetcher;
+  KV: KVNamespace;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    
+    // Custom API
+    if (url.pathname.startsWith('/api/')) {
+      return new Response('API response');
+    }
+    
+    // Static assets
+    return env.ASSETS.fetch(request);
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+**When to use:**
+- Existing Worker too complex for file-based routing
+- Need full routing control
+- Framework-generated Workers (Next.js, SvelteKit)
+
+**Important:**
+- Module Worker syntax required
+- `/functions` ignored
+- Manually call `env.ASSETS.fetch()` for static files
+- `passThroughOnException()` unavailable
+
+## See Also
+
+- [README.md](./README.md) - Overview
+- [api.md](./api.md) - EventContext, bindings
+- [gotchas.md](./gotchas.md) - Common issues

--- a/.agent/services/hosting/cloudflare-platform/references/pages/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages/README.md
@@ -1,0 +1,76 @@
+# Cloudflare Pages
+
+JAMstack platform for full-stack apps on Cloudflare's global network.
+
+## Key Features
+
+- **Git-based deploys**: Auto-deploy from GitHub/GitLab
+- **Preview deployments**: Unique URL per branch/PR
+- **Pages Functions**: File-based serverless routing (Workers runtime)
+- **Static + dynamic**: Smart asset caching + edge compute
+- **Framework optimized**: Next.js, SvelteKit, Remix, Astro, Nuxt, Qwik
+
+## Deployment Methods
+
+### 1. Git Integration (Production)
+Dashboard → Workers & Pages → Create → Connect to Git → Configure build
+
+### 2. Direct Upload
+```bash
+npx wrangler pages deploy ./dist --project-name=my-project
+npx wrangler pages deploy ./dist --project-name=my-project --branch=staging
+```
+
+### 3. C3 CLI
+```bash
+npm create cloudflare@latest my-app
+# Select framework → auto-setup + deploy
+```
+
+## vs Workers
+
+- **Pages**: Static sites, JAMstack, frameworks, git workflow, file-based routing
+- **Workers**: Pure APIs, complex routing, WebSockets, scheduled tasks, email handlers
+- **Combine**: Pages Functions use Workers runtime, can bind to Workers
+
+## Quick Start
+
+```bash
+# Create
+npm create cloudflare@latest
+
+# Local dev
+npx wrangler pages dev ./dist
+
+# Deploy
+npx wrangler pages deploy ./dist --project-name=my-project
+
+# Types
+npx wrangler types --path='./functions/types.d.ts'
+
+# Secrets
+echo "value" | npx wrangler pages secret put KEY --project-name=my-project
+
+# Logs
+npx wrangler pages deployment tail --project-name=my-project
+```
+
+## Resources
+
+- [Pages Docs](https://developers.cloudflare.com/pages/)
+- [Functions API](https://developers.cloudflare.com/pages/functions/api-reference/)
+- [Framework Guides](https://developers.cloudflare.com/pages/framework-guides/)
+- [Discord #functions](https://discord.com/channels/595317990191398933/910978223968518144)
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - wrangler.jsonc, build, env vars
+- [api.md](./api.md) - Functions API, bindings, context
+- [patterns.md](./patterns.md) - Full-stack patterns, frameworks
+- [gotchas.md](./gotchas.md) - Build issues, limits, debugging
+
+## See Also
+
+- [pages-functions](../pages-functions/) - File-based routing, middleware
+- [d1](../d1/) - SQL database for Pages Functions
+- [kv](../kv/) - Key-value storage for caching/state

--- a/.agent/services/hosting/cloudflare-platform/references/pages/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages/api.md
@@ -1,0 +1,200 @@
+# Functions API
+
+## File-Based Routing
+
+```
+/functions
+  /index.ts                    → example.com/
+  /api
+    /users.ts                  → example.com/api/users
+    /users
+      /[id].ts                 → example.com/api/users/:id
+      /[[catchall]].ts         → example.com/api/users/*
+  /_middleware.ts              → Runs before all routes
+```
+
+**Rules**: `[param]` = single segment, `[[param]]` = multi-segment wildcard, more specific wins, falls back to static assets.
+
+## Request Handlers
+
+```typescript
+import type { PagesFunction } from '@cloudflare/workers-types';
+
+interface Env {
+  DB: D1Database;
+  KV: KVNamespace;
+}
+
+// All methods
+export const onRequest: PagesFunction<Env> = async (context) => {
+  return new Response('All methods');
+};
+
+// Method-specific
+export const onRequestGet: PagesFunction<Env> = async (context) => {
+  const { request, env, params, data } = context;
+  
+  const user = await env.DB.prepare(
+    'SELECT * FROM users WHERE id = ?'
+  ).bind(params.id).first();
+  
+  return Response.json(user);
+};
+
+export const onRequestPost: PagesFunction<Env> = async (context) => {
+  const body = await context.request.json();
+  return Response.json({ success: true });
+};
+
+// Also: onRequestPut, onRequestPatch, onRequestDelete, onRequestHead, onRequestOptions
+```
+
+## Context Object
+
+```typescript
+interface EventContext<Env, Params, Data> {
+  request: Request;              // Incoming HTTP request
+  env: Env;                      // Bindings (KV, D1, R2, etc.)
+  params: Params;                // Dynamic route parameters
+  data: Data;                    // Shared data from middleware
+  functionPath: string;          // Current function path
+  waitUntil: (promise: Promise<any>) => void;  // Background tasks
+  next: (input?: RequestInfo, init?: RequestInit) => Promise<Response>;
+  passThroughOnException: () => void;  // Fallback on error (not in advanced mode)
+}
+```
+
+## Dynamic Routes
+
+### Single Segment
+```typescript
+// functions/users/[id].ts
+export const onRequestGet: PagesFunction = async ({ params }) => {
+  // /users/123 → params.id = "123"
+  return Response.json({ userId: params.id });
+};
+```
+
+### Multi-Segment
+```typescript
+// functions/files/[[path]].ts
+export const onRequestGet: PagesFunction = async ({ params }) => {
+  // /files/docs/api/v1.md → params.path = ["docs", "api", "v1.md"]
+  const filePath = (params.path as string[]).join('/');
+  return new Response(filePath);
+};
+```
+
+## Middleware
+
+```typescript
+// functions/_middleware.ts
+import type { PagesFunction } from '@cloudflare/workers-types';
+
+// Single
+export const onRequest: PagesFunction = async (context) => {
+  const response = await context.next();
+  response.headers.set('X-Custom-Header', 'value');
+  return response;
+};
+
+// Chained (runs in order)
+const errorHandler: PagesFunction = async (context) => {
+  try {
+    return await context.next();
+  } catch (err) {
+    return new Response(err.message, { status: 500 });
+  }
+};
+
+const auth: PagesFunction = async (context) => {
+  const token = context.request.headers.get('Authorization');
+  if (!token) return new Response('Unauthorized', { status: 401 });
+  
+  context.data.userId = await verifyToken(token);
+  return context.next();
+};
+
+export const onRequest = [errorHandler, auth];
+```
+
+**Scope**:
+- `functions/_middleware.ts` → ALL requests (including static)
+- `functions/api/_middleware.ts` → `/api/*` only
+
+## Bindings Usage
+
+```typescript
+export const onRequestGet: PagesFunction<Env> = async ({ env, request }) => {
+  // KV
+  const cached = await env.KV.get('key', 'json');
+  await env.KV.put('key', JSON.stringify({ data: 'value' }), {
+    expirationTtl: 3600
+  });
+  
+  // D1
+  const result = await env.DB.prepare(
+    'SELECT * FROM users WHERE id = ?'
+  ).bind(userId).first();
+  
+  // R2
+  const object = await env.BUCKET.get('file.txt');
+  const content = await object?.text();
+  
+  // Queue
+  await env.QUEUE.send({ event: 'user.signup', userId: 123 });
+  
+  // AI
+  const aiResponse = await env.AI.run('@cf/meta/llama-2-7b-chat-int8', {
+    prompt: 'Hello world'
+  });
+  
+  return Response.json({ success: true });
+};
+```
+
+## Advanced Mode
+
+Full Workers API, bypasses file-based routing:
+
+```javascript
+// functions/_worker.js
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    
+    // Custom routing
+    if (url.pathname.startsWith('/api/')) {
+      return new Response('API response');
+    }
+    
+    // REQUIRED: Serve static assets
+    return env.ASSETS.fetch(request);
+  }
+};
+```
+
+**When to use**: WebSockets, complex routing, scheduled handlers, email handlers.
+
+## getRequestContext (Framework SSR)
+
+Access bindings in framework code (Next.js, SvelteKit, etc.):
+
+```typescript
+import { getRequestContext } from '@cloudflare/next-on-pages';
+
+export async function GET(request: Request) {
+  const { env, cf, ctx } = getRequestContext();
+  
+  const data = await env.DB.prepare(
+    'SELECT * FROM users'
+  ).all();
+  
+  return Response.json(data);
+}
+```
+
+**Note**: Adapter-specific. Check framework docs:
+- Next.js: `@cloudflare/next-on-pages`
+- SvelteKit: `@sveltejs/adapter-cloudflare`
+- Remix: `@remix-run/cloudflare-pages`

--- a/.agent/services/hosting/cloudflare-platform/references/pages/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages/configuration.md
@@ -1,0 +1,228 @@
+# Configuration
+
+## wrangler.toml
+
+```toml
+name = "my-pages-project"
+pages_build_output_dir = "./dist"
+compatibility_date = "2024-01-01"
+compatibility_flags = ["nodejs_compat"]
+
+# Bindings
+[[kv_namespaces]]
+binding = "KV"
+id = "abcd1234..."
+
+[[d1_databases]]
+binding = "DB"
+database_id = "xxxx-xxxx-xxxx-xxxx"
+database_name = "production-db"
+
+[[r2_buckets]]
+binding = "BUCKET"
+bucket_name = "my-bucket"
+
+[[durable_objects.bindings]]
+name = "COUNTER"
+class_name = "Counter"
+script_name = "counter-worker"
+
+[[services]]
+binding = "API"
+service = "api-worker"
+
+[[queues.producers]]
+binding = "QUEUE"
+queue = "my-queue"
+
+[[vectorize]]
+binding = "VECTORIZE"
+index_name = "my-index"
+
+[ai]
+binding = "AI"
+
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+
+# Vars (non-sensitive)
+[vars]
+API_URL = "https://api.example.com"
+ENVIRONMENT = "production"
+
+# Environment overrides
+[env.preview]
+[env.preview.vars]
+API_URL = "https://staging-api.example.com"
+
+[[env.preview.kv_namespaces]]
+binding = "KV"
+id = "preview-namespace-id"
+```
+
+## Build Config
+
+**Git deployment**: Dashboard → Project → Settings → Build settings
+- Build command: `npm run build`
+- Output directory: `dist` / `out` / `build`
+- Environment variables: Set per environment (preview/production)
+
+**Framework detection**: Auto-configures build command + output dir for common frameworks
+
+## Environment Variables
+
+### Local Secrets (.dev.vars)
+```bash
+# .dev.vars (never commit)
+SECRET_KEY="local-secret-key"
+API_TOKEN="dev-token-123"
+DATABASE_URL="http://localhost:5432"
+```
+
+### Production Secrets
+```bash
+# Interactive
+echo "super-secret-value" | npx wrangler pages secret put SECRET_KEY --project-name=my-project
+
+# Per environment
+echo "prod-secret" | npx wrangler pages secret put SECRET_KEY --project-name=my-project --env=production
+
+# List
+npx wrangler pages secret list --project-name=my-project
+
+# Delete
+npx wrangler pages secret delete SECRET_KEY --project-name=my-project
+```
+
+Access like bindings: `env.SECRET_KEY`
+
+## Static Config Files
+
+### _redirects
+Place in build output (e.g., `dist/_redirects`):
+
+```txt
+# Simple (302)
+/old-page /new-page
+
+# Permanent (301)
+/old-page /new-page 301
+
+# External
+/blog https://blog.example.com
+
+# Splat wildcard
+/blog/* /news/:splat 301
+
+# Placeholders
+/users/:id /members/:id 301
+
+# Proxying (200)
+/api/* /api-v2/:splat 200
+
+# Limits: 2,100 total (2,000 static + 100 dynamic), 1,000 char/line
+```
+
+**Important**: Redirects don't apply to Functions routes. Functions take precedence.
+
+### _headers
+```txt
+# Security
+/secure/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: no-referrer
+
+# CORS
+/api/*
+  Access-Control-Allow-Origin: *
+  Access-Control-Allow-Methods: GET, POST, PUT, DELETE, OPTIONS
+
+# Cache
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Prevent indexing previews
+https://:project.pages.dev/*
+  X-Robots-Tag: noindex
+
+# Remove header
+/special-page
+  ! X-Frame-Options
+
+# Limits: 100 rules, 2,000 char/line
+```
+
+**Important**: Headers don't apply to Functions responses. Set in Response object.
+
+### _routes.json
+Controls which requests invoke Functions (auto-generated for most frameworks):
+
+```json
+{
+  "version": 1,
+  "include": ["/*"],
+  "exclude": [
+    "/build/*",
+    "/static/*",
+    "/assets/*",
+    "/*.ico",
+    "/*.png",
+    "/*.jpg",
+    "/*.css",
+    "/*.js"
+  ]
+}
+```
+
+**Purpose**: Functions are metered; static requests are free. `exclude` takes precedence. Max 100 rules, 100 char/rule.
+
+## TypeScript
+
+Generate types:
+```bash
+npx wrangler types --path='./functions/types.d.ts'
+```
+
+```json
+// functions/tsconfig.json
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "lib": ["esnext"],
+    "types": ["./types.d.ts"]
+  }
+}
+```
+
+## Local Dev
+
+```bash
+# Basic
+npx wrangler pages dev ./dist
+
+# With bindings
+npx wrangler pages dev ./dist --kv KV --d1 DB=local-db-id --r2 BUCKET
+
+# Persistence
+npx wrangler pages dev ./dist --persist-to=./.wrangler/state/v3
+
+# Custom port
+npx wrangler pages dev ./dist --port=3000
+
+# Live reload
+npx wrangler pages dev ./dist --live-reload
+
+# Proxy mode (SSR frameworks)
+npx wrangler pages dev -- npm run dev
+```
+
+## Limits
+
+- **Functions**: 100k req/day (Free), 10ms CPU, 128MB memory, 1MB script
+- **Deployments**: 500/month (Free), 20k files, 25MB/file
+- **Config**: 2,100 redirects, 100 header rules, 100 route rules
+- **Build**: 20min timeout, no Docker
+
+[Full limits](https://developers.cloudflare.com/pages/platform/limits/)

--- a/.agent/services/hosting/cloudflare-platform/references/pages/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages/gotchas.md
@@ -1,0 +1,161 @@
+# Gotchas
+
+## Functions Not Running
+
+1. **Check `_routes.json`**: May be excluding Function routes
+2. **Verify file naming**: Must be `.js` or `.ts`, NOT `.jsx` or `.tsx`
+3. **Check build output**: Functions dir must be at root of output dir
+4. **Functions precedence**: Functions always override redirects/static
+
+## 404 on Static Assets
+
+1. **Build output dir**: Verify setting matches actual build output
+2. **Functions catching requests**: Use `_routes.json` to exclude static paths
+3. **Advanced mode**: Must call `env.ASSETS.fetch()` or static won't serve
+
+## Bindings Not Working
+
+1. **wrangler.toml syntax**: Check for TOML errors
+2. **Binding IDs**: Verify correct (especially for KV/D1/R2)
+3. **Local dev**: Check `.dev.vars` exists and has correct values
+4. **Regenerate types**: `npx wrangler types --path='./functions/types.d.ts'`
+5. **Environment**: Production bindings ≠ preview bindings (set separately)
+
+## Build Failures
+
+1. **Build logs**: Check in Dashboard → Deployments → Build log
+2. **Build command**: Verify correct for framework
+3. **Output directory**: Must match actual build output
+4. **Node version**: Check compatibility (set via `.nvmrc` or env var)
+5. **Environment variables**: Review in Settings → Environment variables
+6. **Timeout**: 20min max. Long builds may fail.
+7. **Memory**: Build can OOM on large projects
+
+## Deployment Fails
+
+1. **File count**: Max 20,000 files per deployment
+2. **File size**: Max 25MB per file
+3. **Build errors**: Check build output in logs
+4. **wrangler.toml validation**: `npx wrangler pages project validate`
+5. **Bindings**: Verify all referenced bindings exist
+
+## Middleware Not Running
+
+1. **File location**: Must be `_middleware.ts` (underscore prefix)
+2. **Export**: Must export `onRequest` or method-specific handlers
+3. **Must call `next()`**: Or return Response directly
+4. **Scope**: `functions/_middleware.ts` applies to ALL (including static)
+5. **Order**: Array order matters: `[errorHandler, auth, logging]`
+
+## Headers Not Applied
+
+1. **Functions responses**: `_headers` only applies to static assets
+2. **Set in code**: Functions must set headers via Response object
+3. **Syntax**: Check `_headers` file syntax (path, then indented headers)
+4. **Limits**: Max 100 header rules
+
+## Redirects Not Working
+
+1. **Functions take precedence**: Redirects don't apply to Function routes
+2. **Syntax**: Check `_redirects` file format
+3. **Limits**: Max 2,100 redirects (2,000 static + 100 dynamic)
+4. **Query strings**: Preserved automatically
+5. **Testing**: Preview deployments to test before production
+
+## TypeScript Errors
+
+1. **Generate types**: `npx wrangler types` before dev
+2. **tsconfig**: Point `types` to generated file
+3. **Env interface**: Must match wrangler.toml bindings
+4. **Type imports**: `import type { PagesFunction } from '@cloudflare/workers-types'`
+
+## Local Dev Issues
+
+1. **Port conflicts**: Use `--port=3000` to change
+2. **Bindings**: Must pass via CLI flags or wrangler.toml
+3. **Persistence**: Use `--persist-to` to keep data between restarts
+4. **Hot reload**: May need manual restart for some changes
+5. **HTTPS**: Local dev uses HTTP, production uses HTTPS (affects cookies, etc.)
+
+## Preview vs Production
+
+1. **Different bindings**: Set separately in Dashboard
+2. **Different env vars**: Configure per environment
+3. **Branch deploys**: Every branch gets preview deployment
+4. **URLs**: `https://branch.project.pages.dev` vs `https://project.pages.dev`
+
+## Performance Issues
+
+1. **Function invocations**: Exclude static assets via `_routes.json`
+2. **Cold starts**: First request after deploy may be slower
+3. **CPU time**: 10ms limit per request (can hit on complex operations)
+4. **Memory**: 128MB limit (watch for large JSON parsing)
+5. **Bundle size**: Keep Functions < 1MB compressed
+
+## Framework-Specific
+
+### Next.js
+- Use `@cloudflare/next-on-pages` adapter
+- Some features unsupported (ISR, Middleware with waitUntil in body)
+- Check [compatibility](https://github.com/cloudflare/next-on-pages/blob/main/docs/compatibility.md)
+
+### SvelteKit
+- Use `@sveltejs/adapter-cloudflare`
+- Set `platform: 'cloudflare'` in svelte.config.js
+
+### Remix
+- Use `@remix-run/cloudflare-pages`
+- Check server context for bindings
+
+## Debugging
+
+```typescript
+// Log everything
+console.log('Request:', {
+  method: request.method,
+  url: request.url,
+  headers: Object.fromEntries(request.headers),
+});
+console.log('Env:', Object.keys(env));
+console.log('Params:', params);
+console.log('Data:', data);
+```
+
+**View logs**:
+```bash
+npx wrangler pages deployment tail --project-name=my-project
+```
+
+## Common Errors
+
+**"Module not found"**: Check build output, ensure dependencies bundled
+
+**"Binding not found"**: Verify wrangler.toml and regenerate types
+
+**"Request exceeded CPU limit"**: Optimize hot paths, use Workers for heavy compute
+
+**"Script too large"**: Tree-shake, dynamic imports, code-split
+
+**"Too many subrequests"**: Max 50 subreqs per request, batch where possible
+
+**"KV key not found"**: Check namespaces match (production vs preview)
+
+**"D1 error"**: Verify database_id, check migrations applied
+
+## Limits Reference
+
+- **Functions**: 100k req/day (Free), 10ms CPU, 128MB memory, 1MB script
+- **Deployments**: 500/month (Free), 20k files, 25MB/file
+- **Config**: 2,100 redirects, 100 headers, 100 routes
+- **Build**: 20min timeout
+- **Subrequests**: 50/request
+- **Request size**: 100MB
+
+[Full limits](https://developers.cloudflare.com/pages/platform/limits/)
+
+## Getting Help
+
+1. Check [Pages Docs](https://developers.cloudflare.com/pages/)
+2. Search [Discord #functions](https://discord.com/channels/595317990191398933/910978223968518144)
+3. Review [Workers Examples](https://developers.cloudflare.com/workers/examples/)
+4. Check framework-specific docs/adapters

--- a/.agent/services/hosting/cloudflare-platform/references/pages/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pages/patterns.md
@@ -1,0 +1,145 @@
+# Patterns
+
+## API Routes
+
+```typescript
+// functions/api/todos/[id].ts
+export const onRequestGet: PagesFunction<Env> = async ({ env, params }) => {
+  const todo = await env.DB.prepare('SELECT * FROM todos WHERE id = ?').bind(params.id).first();
+  if (!todo) return new Response('Not found', { status: 404 });
+  return Response.json(todo);
+};
+
+export const onRequestPut: PagesFunction<Env> = async ({ env, params, request }) => {
+  const body = await request.json();
+  await env.DB.prepare('UPDATE todos SET title = ?, completed = ? WHERE id = ?')
+    .bind(body.title, body.completed, params.id).run();
+  return Response.json({ success: true });
+};
+
+export const onRequestDelete: PagesFunction<Env> = async ({ env, params }) => {
+  await env.DB.prepare('DELETE FROM todos WHERE id = ?').bind(params.id).run();
+  return new Response(null, { status: 204 });
+};
+```
+
+## Auth Middleware
+
+```typescript
+// functions/_middleware.ts
+const auth: PagesFunction<Env> = async (context) => {
+  if (context.request.url.includes('/public/')) return context.next();
+  const authHeader = context.request.headers.get('Authorization');
+  if (!authHeader?.startsWith('Bearer ')) return new Response('Unauthorized', { status: 401 });
+  
+  try {
+    const payload = await verifyJWT(authHeader.substring(7), context.env.JWT_SECRET);
+    context.data.user = payload;
+    return context.next();
+  } catch (err) {
+    return new Response('Invalid token', { status: 401 });
+  }
+};
+export const onRequest = [auth];
+```
+
+## CORS
+
+```typescript
+// functions/api/_middleware.ts
+const corsHeaders = {'Access-Control-Allow-Origin': '*', 'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS', 'Access-Control-Allow-Headers': 'Content-Type, Authorization'};
+const cors: PagesFunction = async (context) => {
+  if (context.request.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+  const response = await context.next();
+  Object.entries(corsHeaders).forEach(([k, v]) => response.headers.set(k, v));
+  return response;
+};
+export const onRequest = [cors];
+```
+
+## Form Handling
+
+```typescript
+// functions/api/contact.ts
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  const formData = await request.formData();
+  await env.QUEUE.send({name: formData.get('name'), email: formData.get('email'), message: formData.get('message')});
+  return new Response('<h1>Thanks!</h1>', { headers: { 'Content-Type': 'text/html' } });
+};
+```
+
+## Background Tasks
+
+```typescript
+export const onRequestPost: PagesFunction = async ({ request, waitUntil }) => {
+  const data = await request.json();
+  waitUntil(fetch('https://api.example.com/webhook', {method: 'POST', body: JSON.stringify(data)}));
+  return Response.json({ queued: true });
+};
+```
+
+## Error Handling
+
+```typescript
+// functions/_middleware.ts
+const errorHandler: PagesFunction = async (context) => {
+  try {
+    return await context.next();
+  } catch (error) {
+    console.error('Error:', error);
+    if (context.request.url.includes('/api/')) return Response.json({ error: error.message }, { status: 500 });
+    return new Response(`<html><body><h1>Error</h1><p>${error.message}</p></body></html>`, { status: 500, headers: { 'Content-Type': 'text/html' } });
+  }
+};
+export const onRequest = [errorHandler];
+```
+
+## Caching
+
+```typescript
+// functions/api/data.ts
+export const onRequestGet: PagesFunction<Env> = async ({ env, request }) => {
+  const url = new URL(request.url);
+  const cacheKey = `data:${url.pathname}`;
+  const cached = await env.KV.get(cacheKey, 'json');
+  if (cached) return Response.json(cached, { headers: { 'X-Cache': 'HIT' } });
+  
+  const data = await env.DB.prepare('SELECT * FROM data WHERE path = ?').bind(url.pathname).first();
+  await env.KV.put(cacheKey, JSON.stringify(data), {expirationTtl: 3600});
+  return Response.json(data, {headers: {'X-Cache': 'MISS', 'Cache-Control': 'public, max-age=3600'}});
+};
+```
+
+## Framework Integration
+
+```bash
+npm create cloudflare@latest my-app -- --framework=<framework>
+# next, svelte, remix, nuxt, astro, qwik
+```
+[Framework Guides](https://developers.cloudflare.com/pages/framework-guides/)
+
+## Monorepo
+
+Dashboard → Project → Settings → Build settings → Root directory
+
+Set to subproject path (e.g., `apps/web`). Only builds when files in that dir change.
+
+## Best Practices
+
+### Performance
+1. Exclude static from Functions via `_routes.json`
+2. Cache with KV (API responses, rendered content)
+3. Use Cache API: `await caches.default.match(request)`
+4. Minimize Function size: tree-shake, dynamic imports, keep < 1MB
+
+### Security
+1. Set security headers in `_headers` for static
+2. Use secrets, never commit to wrangler.toml
+3. Validate all inputs
+4. Rate limit with KV/DO
+
+### Workflow
+1. Preview deployments per branch/PR
+2. Local dev: `npx wrangler pages dev ./dist`
+3. Environment-specific configs in `wrangler.toml`
+4. Rollbacks: Dashboard → Deployments → Rollback (instant)

--- a/.agent/services/hosting/cloudflare-platform/references/pipelines/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pipelines/README.md
@@ -1,0 +1,664 @@
+# Cloudflare Pipelines Skill
+
+Expert guidance for working with Cloudflare Pipelines - ETL streaming data platform for ingesting, transforming, and loading data into R2.
+
+## Overview
+
+Cloudflare Pipelines ingests events, transforms them with SQL, and delivers to R2 as Apache Iceberg tables or Parquet/JSON files. It provides:
+
+- **Streams**: Durable, buffered queues for event ingestion via HTTP or Workers
+- **Pipelines**: SQL-based transformations between streams and sinks
+- **Sinks**: Destinations for processed data (R2 Data Catalog or R2 storage)
+
+**Status**: Open beta (Workers Paid plan required)
+**Pricing**: Currently no charge beyond standard R2 storage/operations
+
+## Architecture
+
+```
+Data Sources → Streams → Pipelines (SQL) → Sinks → R2
+                 ↑          ↓                 ↓
+            HTTP/Workers   Transform      Iceberg/Parquet
+```
+
+### Core Components
+
+1. **Streams**: Buffer and store incoming events
+   - Structured (with schema validation) or unstructured (raw JSON)
+   - HTTP endpoints and Worker bindings
+   - Can be read by multiple pipelines
+
+2. **Pipelines**: Execute SQL transformations
+   - Filter, transform, enrich data
+   - Cannot be modified after creation (delete/recreate required)
+   - SQL reference: SELECT, INSERT, scalar functions
+
+3. **Sinks**: Write to destinations
+   - **R2 Data Catalog**: Apache Iceberg tables with ACID guarantees
+   - **R2 Storage**: Parquet or JSON files
+   - Exactly-once delivery guarantee
+
+## Common Use Cases
+
+- **Analytics pipelines**: Server logs, clickstream, telemetry
+- **Data warehousing**: ETL into queryable Iceberg tables
+- **Event processing**: Mobile/IoT events with enrichment
+- **Ecommerce analytics**: User events, purchases, product views
+- **Log aggregation**: Application/server logs with filtering
+
+## Setup & Configuration
+
+### Quick Start
+
+```bash
+# Interactive setup (recommended)
+npx wrangler pipelines setup
+
+# Manual setup
+npx wrangler r2 bucket create my-bucket
+npx wrangler r2 bucket catalog enable my-bucket
+npx wrangler pipelines streams create my-stream --schema-file schema.json
+npx wrangler pipelines sinks create my-sink --type r2-data-catalog \
+  --bucket my-bucket --namespace default --table my_table \
+  --catalog-token YOUR_TOKEN
+npx wrangler pipelines create my-pipeline \
+  --sql "INSERT INTO my_sink SELECT * FROM my_stream"
+```
+
+### Schema Definition
+
+**Structured streams** (recommended for validation):
+
+```json
+{
+  "fields": [
+    {
+      "name": "user_id",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "event_type",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "amount",
+      "type": "float64",
+      "required": false
+    },
+    {
+      "name": "tags",
+      "type": "list",
+      "required": false,
+      "items": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "metadata",
+      "type": "struct",
+      "required": false,
+      "fields": [
+        {
+          "name": "source",
+          "type": "string",
+          "required": false
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Supported types**: `string`, `int32`, `int64`, `float32`, `float64`, `bool`, `timestamp`, `json`, `binary`, `list`, `struct`
+
+**Unstructured streams** (no validation, single `value` column):
+```bash
+npx wrangler pipelines streams create my-stream
+```
+
+## Writing Data to Streams
+
+### Via Workers (Recommended)
+
+**Configuration** (`wrangler.toml`):
+```toml
+[[pipelines]]
+pipeline = "<STREAM_ID>"
+binding = "STREAM"
+```
+
+**Or JSON** (`wrangler.jsonc`):
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "pipelines": [
+    {
+      "pipeline": "<STREAM_ID>",
+      "binding": "STREAM"
+    }
+  ]
+}
+```
+
+**Worker code**:
+```typescript
+export default {
+  async fetch(request, env, ctx): Promise<Response> {
+    const event = {
+      user_id: "12345",
+      event_type: "purchase",
+      product_id: "widget-001",
+      amount: 29.99
+    };
+    
+    // Send single or multiple events
+    await env.STREAM.send([event]);
+    
+    return new Response('Event sent');
+  },
+} satisfies ExportedHandler<Env>;
+```
+
+**Batch sending**:
+```typescript
+const events = [
+  { user_id: "user1", event_type: "view" },
+  { user_id: "user2", event_type: "purchase", amount: 50 }
+];
+await env.STREAM.send(events);
+```
+
+### Via HTTP
+
+**Endpoint format**: `https://{stream-id}.ingest.cloudflare.com`
+
+**Without auth** (for testing):
+```bash
+curl -X POST https://{stream-id}.ingest.cloudflare.com \
+  -H "Content-Type: application/json" \
+  -d '[
+    {
+      "user_id": "user_12345",
+      "event_type": "purchase",
+      "product_id": "widget-001",
+      "amount": 29.99
+    }
+  ]'
+```
+
+**With authentication**:
+```bash
+curl -X POST https://{stream-id}.ingest.cloudflare.com \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -d '[{"event": "data"}]'
+```
+
+**Required permission**: Workers Pipeline Send
+
+## SQL Transformations
+
+### Basic Patterns
+
+**Pass-through**:
+```sql
+INSERT INTO my_sink SELECT * FROM my_stream
+```
+
+**Filtering**:
+```sql
+INSERT INTO my_sink
+SELECT * FROM my_stream
+WHERE event_type = 'purchase' AND amount > 100
+```
+
+**Field selection**:
+```sql
+INSERT INTO my_sink
+SELECT user_id, event_type, timestamp, amount
+FROM my_stream
+```
+
+**Field transformation**:
+```sql
+INSERT INTO my_sink
+SELECT
+  user_id,
+  UPPER(event_type) as event_type,
+  timestamp,
+  amount * 1.1 as amount_with_tax,
+  CONCAT(user_id, '_', product_id) as unique_key
+FROM my_stream
+```
+
+**Conditional logic**:
+```sql
+INSERT INTO my_sink
+SELECT
+  user_id,
+  event_type,
+  CASE
+    WHEN amount > 1000 THEN 'high_value'
+    WHEN amount > 100 THEN 'medium_value'
+    ELSE 'low_value'
+  END as customer_tier
+FROM my_stream
+WHERE event_type IN ('purchase', 'refund')
+```
+
+## Sink Configuration
+
+### R2 Data Catalog (Iceberg Tables)
+
+**Create sink**:
+```bash
+npx wrangler pipelines sinks create my-sink \
+  --type r2-data-catalog \
+  --bucket my-bucket \
+  --namespace my_namespace \
+  --table my_table \
+  --catalog-token YOUR_CATALOG_TOKEN \
+  --compression zstd \
+  --roll-interval 60 \
+  --roll-size 100
+```
+
+**Options**:
+- `--compression`: `zstd` (default), `snappy`, `gzip`, `lz4`, `uncompressed`
+- `--roll-interval`: Seconds between writes (default: 300)
+- `--roll-size`: Max file size in MB before rolling
+- `--target-row-group-size`: Parquet row group size in MB (default: 256)
+
+**Querying with R2 SQL**:
+```bash
+export WRANGLER_R2_SQL_AUTH_TOKEN=YOUR_API_TOKEN
+
+npx wrangler r2 sql query "warehouse_name" "
+SELECT user_id, event_type, COUNT(*) as event_count
+FROM default.my_table
+WHERE event_type = 'purchase'
+GROUP BY user_id, event_type
+LIMIT 100"
+```
+
+### R2 Storage (Raw Files)
+
+**JSON format**:
+```bash
+npx wrangler pipelines sinks create my-sink \
+  --type r2 \
+  --bucket my-bucket \
+  --format json \
+  --path analytics/events \
+  --partitioning "year=%Y/month=%m/day=%d" \
+  --roll-interval 60 \
+  --roll-size 100 \
+  --access-key-id YOUR_KEY \
+  --secret-access-key YOUR_SECRET
+```
+
+**Parquet format** (better compression/performance):
+```bash
+npx wrangler pipelines sinks create my-sink \
+  --type r2 \
+  --bucket my-bucket \
+  --format parquet \
+  --compression zstd \
+  --path analytics/events \
+  --partitioning "year=%Y/month=%m/day=%d/hour=%H" \
+  --target-row-group-size 256 \
+  --roll-interval 300 \
+  --roll-size 100 \
+  --access-key-id YOUR_KEY \
+  --secret-access-key YOUR_SECRET
+```
+
+**File organization**:
+```
+bucket/analytics/events/
+  year=2025/
+    month=01/
+      day=11/
+        uuid-1.parquet
+        uuid-2.parquet
+```
+
+## Wrangler Commands Reference
+
+### Setup & Management
+
+```bash
+# Interactive setup (creates stream, sink, pipeline)
+npx wrangler pipelines setup
+
+# List all pipelines
+npx wrangler pipelines list
+
+# Get pipeline details
+npx wrangler pipelines get <PIPELINE_ID>
+
+# Delete pipeline
+npx wrangler pipelines delete <PIPELINE_ID>
+```
+
+### Streams
+
+```bash
+# Create stream with schema
+npx wrangler pipelines streams create my-stream --schema-file schema.json
+
+# Create unstructured stream
+npx wrangler pipelines streams create my-stream
+
+# List streams
+npx wrangler pipelines streams list
+
+# Get stream details
+npx wrangler pipelines streams get <STREAM_ID>
+
+# Delete stream (deletes dependent pipelines and buffered events!)
+npx wrangler pipelines streams delete <STREAM_ID>
+```
+
+### Sinks
+
+```bash
+# Create R2 Data Catalog sink
+npx wrangler pipelines sinks create my-sink \
+  --type r2-data-catalog \
+  --bucket my-bucket \
+  --namespace default \
+  --table my_table \
+  --catalog-token TOKEN
+
+# Create R2 storage sink
+npx wrangler pipelines sinks create my-sink \
+  --type r2 \
+  --bucket my-bucket \
+  --format parquet \
+  --compression zstd
+
+# List sinks
+npx wrangler pipelines sinks list
+
+# Get sink details
+npx wrangler pipelines sinks get <SINK_ID>
+
+# Delete sink
+npx wrangler pipelines sinks delete <SINK_ID>
+```
+
+### Pipelines
+
+```bash
+# Create with inline SQL
+npx wrangler pipelines create my-pipeline \
+  --sql "INSERT INTO my_sink SELECT * FROM my_stream"
+
+# Create with SQL file
+npx wrangler pipelines create my-pipeline \
+  --sql-file transform.sql
+
+# View pipeline
+npx wrangler pipelines get <PIPELINE_ID>
+
+# List all pipelines
+npx wrangler pipelines list
+
+# Delete pipeline
+npx wrangler pipelines delete <PIPELINE_ID>
+```
+
+## Authentication & Permissions
+
+### R2 Data Catalog Token
+
+Required permissions: **R2 Admin Read & Write**
+
+Create in dashboard:
+1. Go to R2 > Manage API tokens
+2. Create Account API Token
+3. Select "Admin Read & Write" permission
+4. Save token value
+
+### R2 Storage Credentials
+
+Required permissions: **Object Read & Write**
+
+Create via Wrangler or dashboard for access key ID and secret access key.
+
+### HTTP Ingest Token
+
+Required permissions: **Workers Pipeline Send**
+
+For authenticated HTTP ingestion endpoints.
+
+## Best Practices
+
+### Schema Design
+- ✅ Use structured streams for validation
+- ✅ Mark critical fields as `required: true`
+- ✅ Use appropriate types (`int64` for timestamps, `float64` for decimals)
+- ❌ Avoid overly nested structs (query performance)
+- ❌ Don't change schemas after creation (recreate stream)
+
+### Performance
+- **Low latency**: Set `--roll-interval 10` (smaller files, more frequent)
+- **Query performance**: Set `--roll-interval 300` and `--roll-size 100` (larger files, less frequent)
+- Use `zstd` compression for best ratio, `snappy` for speed
+- Increase `--target-row-group-size` for analytical workloads
+
+### SQL Transformations
+- ✅ Filter early (`WHERE` clauses reduce data volume)
+- ✅ Select only needed fields (reduces storage costs)
+- ✅ Use functions for enrichment (CONCAT, UPPER, CASE)
+- ❌ Cannot modify pipelines after creation (plan carefully)
+- ❌ No JOINs across streams (single stream per pipeline)
+
+### Workers Integration
+- ✅ Use Worker bindings (no token management)
+- ✅ Batch events when possible (`send([event1, event2, ...])`)
+- ✅ Handle send errors gracefully
+- ❌ Don't await send in critical path if latency matters (use `ctx.waitUntil()`)
+
+```typescript
+// Fire-and-forget pattern
+export default {
+  async fetch(request, env, ctx) {
+    const event = { /* ... */ };
+    
+    // Don't block response on send
+    ctx.waitUntil(env.STREAM.send([event]));
+    
+    return new Response('OK');
+  }
+};
+```
+
+### HTTP Ingestion
+- ✅ Enable auth for production endpoints
+- ✅ Configure CORS if sending from browsers
+- ✅ Send arrays (not single objects) for batch efficiency
+- ✅ Handle 4xx/5xx responses with retries
+
+### Monitoring
+- Check stream buffer status (dashboard or API)
+- Monitor pipeline processing rate
+- Review R2 storage growth
+- Query data regularly to verify pipeline health
+
+## Limits (Open Beta)
+
+| Resource | Limit |
+|----------|-------|
+| Streams per account | 20 |
+| Sinks per account | 20 |
+| Pipelines per account | 20 |
+| Payload size per request | 1 MB |
+| Ingest rate per stream | 5 MB/s |
+
+Request increases: [Limit Increase Form](https://forms.gle/ukpeZVLWLnKeixDu7)
+
+## Troubleshooting
+
+### Events not appearing in R2
+- Wait 10-300 seconds (depends on `--roll-interval`)
+- Check pipeline status: `npx wrangler pipelines get <ID>`
+- Verify stream has data (check dashboard metrics)
+- Confirm sink credentials are valid
+
+### Schema validation failures
+- Events accepted but dropped if invalid
+- Check event structure matches schema exactly
+- Verify required fields are present
+- Check data types (e.g., strings not numbers)
+
+### Worker binding not found
+- Verify `wrangler.toml`/`wrangler.jsonc` has correct `pipeline` ID
+- Redeploy Worker after adding binding
+- Check binding name matches code (`env.STREAM`)
+
+### SQL errors
+- SQL cannot be modified after creation
+- Recreate pipeline with corrected SQL
+- Verify stream and sink names in SQL match actual resources
+- Check SQL syntax against reference docs
+
+## Complete Example: Ecommerce Analytics
+
+**1. Create schema** (`ecommerce-schema.json`):
+```json
+{
+  "fields": [
+    {
+      "name": "user_id",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "event_type",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "product_id",
+      "type": "string",
+      "required": false
+    },
+    {
+      "name": "amount",
+      "type": "float64",
+      "required": false
+    },
+    {
+      "name": "timestamp",
+      "type": "timestamp",
+      "required": true
+    }
+  ]
+}
+```
+
+**2. Setup infrastructure**:
+```bash
+# Create bucket and enable catalog
+npx wrangler r2 bucket create ecommerce-data
+npx wrangler r2 bucket catalog enable ecommerce-data
+
+# Create stream
+npx wrangler pipelines streams create ecommerce-stream \
+  --schema-file ecommerce-schema.json
+
+# Create sink
+npx wrangler pipelines sinks create ecommerce-sink \
+  --type r2-data-catalog \
+  --bucket ecommerce-data \
+  --namespace default \
+  --table events \
+  --catalog-token $CATALOG_TOKEN \
+  --roll-interval 60
+
+# Create pipeline with transformation
+npx wrangler pipelines create ecommerce-pipeline \
+  --sql "INSERT INTO ecommerce_sink 
+         SELECT 
+           user_id,
+           UPPER(event_type) as event_type,
+           product_id,
+           amount,
+           timestamp,
+           CASE 
+             WHEN amount > 100 THEN 'high_value'
+             ELSE 'standard'
+           END as transaction_tier
+         FROM ecommerce_stream
+         WHERE event_type IN ('purchase', 'add_to_cart', 'view_product')"
+```
+
+**3. Configure Worker** (`wrangler.toml`):
+```toml
+name = "ecommerce-api"
+main = "src/index.ts"
+
+[[pipelines]]
+pipeline = "<STREAM_ID>"
+binding = "EVENTS"
+```
+
+**4. Send events** (`src/index.ts`):
+```typescript
+interface Env {
+  EVENTS: Pipeline;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (request.method === 'POST') {
+      const data = await request.json();
+      
+      const event = {
+        user_id: data.userId,
+        event_type: data.eventType,
+        product_id: data.productId,
+        amount: data.amount,
+        timestamp: new Date().toISOString()
+      };
+      
+      try {
+        await env.EVENTS.send([event]);
+        return new Response('Event tracked', { status: 200 });
+      } catch (error) {
+        return new Response('Failed to track event', { status: 500 });
+      }
+    }
+    
+    return new Response('Method not allowed', { status: 405 });
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+**5. Query results**:
+```bash
+export WRANGLER_R2_SQL_AUTH_TOKEN=$CATALOG_TOKEN
+
+npx wrangler r2 sql query "ecommerce-warehouse" "
+SELECT 
+  event_type,
+  transaction_tier,
+  COUNT(*) as event_count,
+  SUM(amount) as total_revenue
+FROM default.events
+WHERE event_type = 'PURCHASE'
+GROUP BY event_type, transaction_tier
+ORDER BY total_revenue DESC"
+```
+
+## Additional Resources
+
+- [Pipelines Documentation](https://developers.cloudflare.com/pipelines/)
+- [SQL Reference](https://developers.cloudflare.com/pipelines/sql-reference/)
+- [R2 Data Catalog](https://developers.cloudflare.com/r2/data-catalog/)
+- [Wrangler Commands](https://developers.cloudflare.com/workers/wrangler/commands/#pipelines)
+- [Apache Iceberg](https://iceberg.apache.org/)

--- a/.agent/services/hosting/cloudflare-platform/references/pulumi/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pulumi/README.md
@@ -1,0 +1,107 @@
+# Cloudflare Pulumi Provider
+
+Expert guidance for Cloudflare Pulumi Provider (@pulumi/cloudflare).
+
+## Overview
+
+Programmatic management of Cloudflare resources: Workers, Pages, D1, KV, R2, DNS, Queues, etc.
+
+**Packages:**
+- TypeScript/JS: `@pulumi/cloudflare`
+- Python: `pulumi-cloudflare`
+- Go: `github.com/pulumi/pulumi-cloudflare/sdk/v6/go/cloudflare`
+- .NET: `Pulumi.Cloudflare`
+
+**Version:** v6.x
+
+## Core Principles
+
+1. Use API tokens (not legacy API keys)
+2. Store accountId in stack config
+3. Match binding names across code/config
+4. Use `module: true` for ES modules
+5. Set `compatibilityDate` to lock behavior
+
+## Authentication
+
+Three methods (mutually exclusive):
+
+**1. API Token (Recommended)**
+```typescript
+import * as cloudflare from "@pulumi/cloudflare";
+
+const provider = new cloudflare.Provider("cf", {
+    apiToken: process.env.CLOUDFLARE_API_TOKEN,
+});
+```
+Env: `CLOUDFLARE_API_TOKEN`
+
+**2. API Key (Legacy)**
+```typescript
+const provider = new cloudflare.Provider("cf", {
+    apiKey: process.env.CLOUDFLARE_API_KEY,
+    email: process.env.CLOUDFLARE_EMAIL,
+});
+```
+Env: `CLOUDFLARE_API_KEY`, `CLOUDFLARE_EMAIL`
+
+**3. API User Service Key**
+```typescript
+const provider = new cloudflare.Provider("cf", {
+    apiUserServiceKey: process.env.CLOUDFLARE_API_USER_SERVICE_KEY,
+});
+```
+Env: `CLOUDFLARE_API_USER_SERVICE_KEY`
+
+## Setup
+
+**Pulumi.yaml:**
+```yaml
+name: my-cloudflare-app
+runtime: nodejs
+config:
+  cloudflare:apiToken:
+    value: ${CLOUDFLARE_API_TOKEN}
+```
+
+**Pulumi.<stack>.yaml:**
+```yaml
+config:
+  cloudflare:accountId: "abc123..."
+```
+
+**index.ts:**
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as cloudflare from "@pulumi/cloudflare";
+
+const config = new pulumi.Config("cloudflare");
+const accountId = config.require("accountId");
+```
+
+## Essential Imports
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as cloudflare from "@pulumi/cloudflare";
+```
+
+## Common Resource Types
+- `Provider` - Provider config
+- `WorkerScript` - Worker
+- `WorkersKvNamespace` - KV
+- `R2Bucket` - R2
+- `D1Database` - D1
+- `Queue` - Queue
+- `PagesProject` - Pages
+- `DnsRecord` - DNS
+- `WorkerRoute` - Worker route
+- `WorkersDomain` - Custom domain
+
+## Key Properties
+- `accountId` - Required for most resources
+- `zoneId` - Required for DNS/domain
+- `name`/`title` - Resource identifier
+- `*Bindings` - Connect resources to Workers
+
+---
+See: [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)

--- a/.agent/services/hosting/cloudflare-platform/references/pulumi/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pulumi/api.md
@@ -1,0 +1,194 @@
+# API & Data Sources
+
+## Outputs and Exports
+
+Export resource identifiers:
+
+```typescript
+export const kvId = kv.id;
+export const bucketName = bucket.name;
+export const workerUrl = worker.subdomain;
+export const dbId = db.id;
+```
+
+## Resource Dependencies
+
+Implicit dependencies via outputs:
+
+```typescript
+const kv = new cloudflare.WorkersKvNamespace("kv", {
+    accountId: accountId,
+    title: "my-kv",
+});
+
+// Worker depends on KV (implicit via kv.id)
+const worker = new cloudflare.WorkerScript("worker", {
+    accountId: accountId,
+    name: "my-worker",
+    content: code,
+    kvNamespaceBindings: [{name: "MY_KV", namespaceId: kv.id}], // Creates dependency
+});
+```
+
+Explicit dependencies:
+
+```typescript
+const migration = new command.local.Command("migration", {
+    create: pulumi.interpolate`wrangler d1 execute ${db.name} --file ./schema.sql`,
+}, {dependsOn: [db]});
+
+const worker = new cloudflare.WorkerScript("worker", {
+    accountId: accountId,
+    name: "worker",
+    content: code,
+    d1DatabaseBindings: [{name: "DB", databaseId: db.id}],
+}, {dependsOn: [migration]}); // Ensure migrations run first
+```
+
+## Using Outputs with API Calls
+
+```typescript
+const db = new cloudflare.D1Database("db", {
+    accountId: accountId,
+    name: "my-db",
+});
+
+db.id.apply(async (dbId) => {
+    const response = await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/d1/database/${dbId}/query`,
+        {
+            method: "POST",
+            headers: {
+                "Authorization": `Bearer ${apiToken}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({sql: "CREATE TABLE users (id INT PRIMARY KEY, name TEXT)"}),
+        }
+    );
+    return response.json();
+});
+```
+
+## Custom Dynamic Providers
+
+For resources not in provider:
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+
+class D1MigrationProvider implements pulumi.dynamic.ResourceProvider {
+    async create(inputs: any): Promise<pulumi.dynamic.CreateResult> {
+        const response = await fetch(
+            `https://api.cloudflare.com/client/v4/accounts/${inputs.accountId}/d1/database/${inputs.databaseId}/query`,
+            {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${inputs.apiToken}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify({sql: inputs.sql}),
+            }
+        );
+        const result = await response.json();
+        return {id: `${inputs.databaseId}-${Date.now()}`, outs: result};
+    }
+
+    async update(id: string, olds: any, news: any): Promise<pulumi.dynamic.UpdateResult> {
+        if (olds.sql !== news.sql) await this.create(news);
+        return {};
+    }
+
+    async delete(id: string, props: any): Promise<void> {}
+}
+
+class D1Migration extends pulumi.dynamic.Resource {
+    constructor(name: string, args: any, opts?: pulumi.CustomResourceOptions) {
+        super(new D1MigrationProvider(), name, args, opts);
+    }
+}
+
+// Usage
+const migration = new D1Migration("migration", {
+    accountId: accountId,
+    databaseId: db.id,
+    apiToken: apiToken,
+    sql: "CREATE TABLE users (id INT PRIMARY KEY, name TEXT)",
+}, {dependsOn: [db]});
+```
+
+## Data Sources
+
+**Get Zone:**
+```typescript
+const zone = cloudflare.getZone({name: "example.com"});
+const zoneId = zone.then(z => z.id);
+```
+
+**Get Accounts (via API):**
+Use Cloudflare API directly or custom dynamic resources.
+
+## Import Existing Resources
+
+```bash
+# Import worker
+pulumi import cloudflare:index/workerScript:WorkerScript my-worker <account_id>/<worker_name>
+
+# Import KV namespace
+pulumi import cloudflare:index/workersKvNamespace:WorkersKvNamespace my-kv <namespace_id>
+
+# Import R2 bucket
+pulumi import cloudflare:index/r2Bucket:R2Bucket my-bucket <account_id>/<bucket_name>
+
+# Import D1 database
+pulumi import cloudflare:index/d1Database:D1Database my-db <account_id>/<database_id>
+
+# Import DNS record
+pulumi import cloudflare:index/dnsRecord:DnsRecord my-record <zone_id>/<record_id>
+```
+
+## Secrets Management
+
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config();
+const apiKey = config.requireSecret("apiKey"); // Encrypted in state
+
+const worker = new cloudflare.WorkerScript("worker", {
+    accountId: accountId,
+    name: "my-worker",
+    content: code,
+    secretTextBindings: [{name: "API_KEY", text: apiKey}],
+});
+```
+
+Store secrets:
+```bash
+pulumi config set --secret apiKey "secret-value"
+```
+
+## Transform Pattern
+
+Modify resource args before creation:
+
+```typescript
+import {Transform} from "@pulumi/pulumi";
+
+interface BucketArgs {
+    accountId: pulumi.Input<string>;
+    transform?: {bucket?: Transform<cloudflare.R2BucketArgs>};
+}
+
+function createBucket(name: string, args: BucketArgs) {
+    const bucketArgs: cloudflare.R2BucketArgs = {
+        accountId: args.accountId,
+        name: name,
+        location: "auto",
+    };
+    const finalArgs = args.transform?.bucket?.(bucketArgs) ?? bucketArgs;
+    return new cloudflare.R2Bucket(name, finalArgs);
+}
+```
+
+---
+See: [README.md](./README.md), [configuration.md](./configuration.md), [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)

--- a/.agent/services/hosting/cloudflare-platform/references/pulumi/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pulumi/configuration.md
@@ -1,0 +1,216 @@
+# Resource Configuration
+
+## Workers (cloudflare.WorkerScript)
+
+```typescript
+import * as cloudflare from "@pulumi/cloudflare";
+import * as fs from "fs";
+
+const worker = new cloudflare.WorkerScript("my-worker", {
+    accountId: accountId,
+    name: "my-worker",
+    content: fs.readFileSync("./dist/worker.js", "utf8"),
+    module: true, // ES modules
+    compatibilityDate: "2024-01-01",
+    compatibilityFlags: ["nodejs_compat"],
+    
+    // Bindings
+    kvNamespaceBindings: [{name: "MY_KV", namespaceId: kv.id}],
+    r2BucketBindings: [{name: "MY_BUCKET", bucketName: bucket.name}],
+    d1DatabaseBindings: [{name: "DB", databaseId: db.id}],
+    queueBindings: [{name: "MY_QUEUE", queue: queue.id}],
+    serviceBindings: [{name: "OTHER_SERVICE", service: other.name}],
+    plainTextBindings: [{name: "ENV_VAR", text: "value"}],
+    secretTextBindings: [{name: "API_KEY", text: secret}],
+});
+```
+
+## Workers KV (cloudflare.WorkersKvNamespace)
+
+```typescript
+const kv = new cloudflare.WorkersKvNamespace("my-kv", {
+    accountId: accountId,
+    title: "my-kv-namespace",
+});
+
+// Write values
+const kvValue = new cloudflare.WorkersKvValue("config", {
+    accountId: accountId,
+    namespaceId: kv.id,
+    key: "config",
+    value: JSON.stringify({foo: "bar"}),
+});
+```
+
+## R2 Buckets (cloudflare.R2Bucket)
+
+```typescript
+const bucket = new cloudflare.R2Bucket("my-bucket", {
+    accountId: accountId,
+    name: "my-bucket",
+    location: "auto", // or "wnam", etc.
+});
+```
+
+## D1 Databases (cloudflare.D1Database)
+
+```typescript
+const db = new cloudflare.D1Database("my-db", {
+    accountId: accountId,
+    name: "my-database",
+});
+
+// Migrations: use command or wrangler
+import * as command from "@pulumi/command";
+
+const migration = new command.local.Command("d1-migration", {
+    create: pulumi.interpolate`wrangler d1 execute ${db.name} --command "CREATE TABLE users (id INT PRIMARY KEY, name TEXT)"`,
+}, {dependsOn: [db]});
+```
+
+## Queues (cloudflare.Queue)
+
+```typescript
+const queue = new cloudflare.Queue("my-queue", {
+    accountId: accountId,
+    name: "my-queue",
+});
+
+// Producer
+const producer = new cloudflare.WorkerScript("producer", {
+    accountId: accountId,
+    name: "producer",
+    content: code,
+    queueBindings: [{name: "MY_QUEUE", queue: queue.id}],
+});
+
+// Consumer
+const consumer = new cloudflare.WorkerScript("consumer", {
+    accountId: accountId,
+    name: "consumer",
+    content: code,
+    queueConsumers: [{
+        queue: queue.name,
+        maxBatchSize: 10,
+        maxRetries: 3,
+        maxWaitTimeMs: 5000,
+    }],
+});
+```
+
+## Pages Projects (cloudflare.PagesProject)
+
+```typescript
+const pages = new cloudflare.PagesProject("my-site", {
+    accountId: accountId,
+    name: "my-site",
+    productionBranch: "main",
+    buildConfig: {
+        buildCommand: "npm run build",
+        destinationDir: "dist",
+        rootDir: "",
+    },
+    source: {
+        type: "github",
+        config: {
+            owner: "my-org",
+            repoName: "my-repo",
+            productionBranch: "main",
+            prCommentsEnabled: true,
+            deploymentsEnabled: true,
+        },
+    },
+    deploymentConfigs: {
+        production: {
+            environmentVariables: {NODE_VERSION: "18"},
+            kvNamespaces: {MY_KV: kv.id},
+            d1Databases: {DB: db.id},
+            r2Buckets: {MY_BUCKET: bucket.name},
+        },
+    },
+});
+```
+
+## DNS Records (cloudflare.DnsRecord)
+
+```typescript
+const zone = cloudflare.getZone({name: "example.com"});
+
+const record = new cloudflare.DnsRecord("www", {
+    zoneId: zone.then(z => z.id),
+    name: "www",
+    type: "A",
+    content: "192.0.2.1",
+    ttl: 3600,
+    proxied: true,
+});
+
+// CNAME
+const cname = new cloudflare.DnsRecord("api", {
+    zoneId: zone.then(z => z.id),
+    name: "api",
+    type: "CNAME",
+    content: worker.subdomain,
+    proxied: true,
+});
+```
+
+## Workers Domains/Routes
+
+```typescript
+// Route (pattern-based)
+const route = new cloudflare.WorkerRoute("my-route", {
+    zoneId: zoneId,
+    pattern: "example.com/api/*",
+    scriptName: worker.name,
+});
+
+// Domain (dedicated subdomain)
+const domain = new cloudflare.WorkersDomain("my-domain", {
+    accountId: accountId,
+    hostname: "api.example.com",
+    service: worker.name,
+    zoneId: zoneId,
+});
+```
+
+## Multi-Language Examples
+
+**Python:**
+```python
+import pulumi
+import pulumi_cloudflare as cloudflare
+
+config = pulumi.Config()
+account_id = config.require("accountId")
+
+kv = cloudflare.WorkersKvNamespace("my-kv", account_id=account_id, title="my-kv")
+worker = cloudflare.WorkerScript("my-worker", account_id=account_id, name="my-worker", 
+    content=open("./dist/worker.js").read(), module=True,
+    kv_namespace_bindings=[cloudflare.WorkerScriptKvNamespaceBindingArgs(name="MY_KV", namespace_id=kv.id)])
+```
+
+**Go:**
+```go
+import (
+    "github.com/pulumi/pulumi-cloudflare/sdk/v6/go/cloudflare"
+    "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+    "github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
+)
+
+func main() {
+    pulumi.Run(func(ctx *pulumi.Context) error {
+        cfg := config.New(ctx, "")
+        accountId := cfg.Require("accountId")
+        
+        kv, _ := cloudflare.NewWorkersKvNamespace(ctx, "my-kv", &cloudflare.WorkersKvNamespaceArgs{
+            AccountId: pulumi.String(accountId),
+            Title: pulumi.String("my-kv"),
+        })
+        return nil
+    })
+}
+```
+
+---
+See: [README.md](./README.md), [api.md](./api.md), [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)

--- a/.agent/services/hosting/cloudflare-platform/references/pulumi/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pulumi/gotchas.md
@@ -1,0 +1,223 @@
+# Troubleshooting & Best Practices
+
+## Common Errors
+
+**1. Account ID Missing**
+```
+error: Missing required property 'accountId'
+```
+Solution: Add to config or pass explicitly.
+
+**2. Binding Name Mismatch**
+Worker expects `MY_KV` but binding uses different name.
+Solution: Match binding names in Pulumi and worker code.
+
+**3. Resource Not Found**
+```
+error: resource 'abc123' not found
+```
+Solution: Ensure resources exist in correct account/zone.
+
+**4. API Token Permissions**
+Solution: Verify token has required permissions (Workers, KV, R2, etc.).
+
+## Debugging
+
+**Enable verbose logging:**
+```bash
+pulumi up --logtostderr -v=9
+```
+
+**Preview changes:**
+```bash
+pulumi preview
+```
+
+**View resource state:**
+```bash
+pulumi stack export
+```
+
+**Inspect specific resource:**
+```bash
+pulumi stack --show-urns
+pulumi state delete <urn> # Use with caution
+```
+
+## Best Practices
+
+### 1. Use Stack Configuration
+```yaml
+# Pulumi.<stack>.yaml
+config:
+  cloudflare:accountId: "abc123"
+  cloudflare:apiToken:
+    secure: "encrypted-value"
+  app:domain: "example.com"
+  app:zoneId: "xyz789"
+```
+
+### 2. Explicit Provider Configuration
+```typescript
+const devProvider = new cloudflare.Provider("dev", {apiToken: devToken});
+const prodProvider = new cloudflare.Provider("prod", {apiToken: prodToken});
+
+const devWorker = new cloudflare.WorkerScript("dev-worker", {
+    accountId: devAccountId, name: "worker", content: code,
+}, {provider: devProvider});
+
+const prodWorker = new cloudflare.WorkerScript("prod-worker", {
+    accountId: prodAccountId, name: "worker", content: code,
+}, {provider: prodProvider});
+```
+
+### 3. Resource Naming Conventions
+```typescript
+const stack = pulumi.getStack();
+const kv = new cloudflare.WorkersKvNamespace(`${stack}-kv`, {accountId, title: `${stack}-my-kv`});
+```
+
+### 4. Protect Production Resources
+```typescript
+const prodDb = new cloudflare.D1Database("prod-db", {accountId, name: "production-database"}, 
+    {protect: true}); // Cannot delete without removing protect
+```
+
+### 5. Use dependsOn for Ordering
+```typescript
+const migration = new command.local.Command("migration", {
+    create: pulumi.interpolate`wrangler d1 execute ${db.name} --file ./schema.sql`,
+}, {dependsOn: [db]});
+
+const worker = new cloudflare.WorkerScript("worker", {
+    accountId, name: "worker", content: code,
+    d1DatabaseBindings: [{name: "DB", databaseId: db.id}],
+}, {dependsOn: [migration]}); // Ensure migrations run first
+```
+
+### 6. Resource Tagging Pattern
+```typescript
+function createResource(name: string, type: string) {
+    const stack = pulumi.getStack();
+    const fullName = `${stack}-${type}-${name}`;
+    return new cloudflare.WorkersKvNamespace(fullName, {accountId, title: fullName});
+}
+
+const userCache = createResource("user-cache", "kv");
+const sessionCache = createResource("session-cache", "kv");
+```
+
+## Security
+
+### Secrets Management
+```typescript
+const config = new pulumi.Config();
+const apiKey = config.requireSecret("apiKey"); // Encrypted in state
+
+const worker = new cloudflare.WorkerScript("worker", {
+    accountId, name: "my-worker", content: code,
+    secretTextBindings: [{name: "API_KEY", text: apiKey}],
+});
+```
+
+**Store secrets:**
+```bash
+pulumi config set --secret apiKey "secret-value"
+```
+
+**Use environment variables:**
+```bash
+export CLOUDFLARE_API_TOKEN="..."
+pulumi up
+```
+
+### API Token Scopes
+Create tokens with minimal permissions:
+- Workers: `Workers Routes:Edit`, `Workers Scripts:Edit`
+- KV: `Workers KV Storage:Edit`
+- R2: `R2:Edit`
+- D1: `D1:Edit`
+- DNS: `Zone:Edit`, `DNS:Edit`
+- Pages: `Pages:Edit`
+
+### State Security
+- Use Pulumi Cloud or S3 backend with encryption
+- Never commit state files to VCS
+- Use RBAC to control stack access
+
+## Performance
+
+### Reduce State Size
+- Avoid storing large files in state
+- Use `ignoreChanges` for frequently changing properties
+- Use external build processes
+
+### Parallel Updates
+Pulumi automatically parallelizes independent resource updates.
+
+### Refresh Strategy
+```bash
+pulumi refresh --yes # Sync state with actual infrastructure
+```
+
+## Migration
+
+### Import Existing Resources
+```bash
+pulumi import cloudflare:index/workerScript:WorkerScript my-worker <account_id>/<worker_name>
+pulumi import cloudflare:index/workersKvNamespace:WorkersKvNamespace my-kv <namespace_id>
+pulumi import cloudflare:index/r2Bucket:R2Bucket my-bucket <account_id>/<bucket_name>
+```
+
+### From Terraform
+Use `pulumi import` and rewrite configs in Pulumi DSL.
+
+### From Wrangler
+1. Create Pulumi resources matching wrangler.toml
+2. Import existing resources
+3. Verify with `pulumi preview`
+4. Switch to Pulumi for deployments
+
+## CI/CD
+
+**GitHub Actions:**
+```yaml
+name: Deploy
+on: [push]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pulumi/actions@v4
+        with:
+          command: up
+          stack-name: prod
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+```
+
+**GitLab CI:**
+```yaml
+deploy:
+  image: pulumi/pulumi:latest
+  script:
+    - pulumi stack select prod
+    - pulumi up --yes
+  only:
+    - main
+  variables:
+    CLOUDFLARE_API_TOKEN: $CLOUDFLARE_API_TOKEN
+```
+
+## Resources
+
+- **Pulumi Registry:** https://www.pulumi.com/registry/packages/cloudflare/
+- **API Docs:** https://www.pulumi.com/registry/packages/cloudflare/api-docs/
+- **GitHub:** https://github.com/pulumi/pulumi-cloudflare
+- **Cloudflare Docs:** https://developers.cloudflare.com/
+- **Workers Docs:** https://developers.cloudflare.com/workers/
+
+---
+See: [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md)

--- a/.agent/services/hosting/cloudflare-platform/references/pulumi/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/pulumi/patterns.md
@@ -1,0 +1,139 @@
+# Architecture Patterns
+
+## Component Resources
+
+```typescript
+class WorkerApp extends pulumi.ComponentResource {
+    constructor(name: string, args: WorkerAppArgs, opts?) {
+        super("custom:cloudflare:WorkerApp", name, {}, opts);
+        const defaultOpts = {parent: this};
+
+        this.kv = new cloudflare.WorkersKvNamespace(`${name}-kv`, {accountId: args.accountId, title: `${name}-kv`}, defaultOpts);
+        this.worker = new cloudflare.WorkerScript(`${name}-worker`, {
+            accountId: args.accountId, name: `${name}-worker`, content: args.workerCode,
+            module: true, kvNamespaceBindings: [{name: "KV", namespaceId: this.kv.id}],
+        }, defaultOpts);
+        this.domain = new cloudflare.WorkersDomain(`${name}-domain`, {
+            accountId: args.accountId, hostname: args.domain, service: this.worker.name,
+        }, defaultOpts);
+    }
+}
+```
+
+## Full-Stack Worker App
+
+```typescript
+const kv = new cloudflare.WorkersKvNamespace("cache", {accountId, title: "api-cache"});
+const db = new cloudflare.D1Database("db", {accountId, name: "app-database"});
+const bucket = new cloudflare.R2Bucket("assets", {accountId, name: "app-assets"});
+
+const apiWorker = new cloudflare.WorkerScript("api", {
+    accountId, name: "api-worker", content: fs.readFileSync("./dist/api.js", "utf8"),
+    module: true, kvNamespaceBindings: [{name: "CACHE", namespaceId: kv.id}],
+    d1DatabaseBindings: [{name: "DB", databaseId: db.id}],
+    r2BucketBindings: [{name: "ASSETS", bucketName: bucket.name}],
+});
+```
+
+## Multi-Environment Setup
+
+```typescript
+const stack = pulumi.getStack();
+const worker = new cloudflare.WorkerScript(`worker-${stack}`, {
+    accountId, name: `my-worker-${stack}`, content: code,
+    plainTextBindings: [{name: "ENVIRONMENT", text: stack}],
+});
+```
+
+## Queue-Based Processing
+
+```typescript
+const queue = new cloudflare.Queue("processing-queue", {accountId, name: "image-processing"});
+
+// Producer: API receives requests
+const apiWorker = new cloudflare.WorkerScript("api", {
+    accountId, name: "api-worker", content: apiCode,
+    queueBindings: [{name: "PROCESSING_QUEUE", queue: queue.id}],
+});
+
+// Consumer: Process async
+const processorWorker = new cloudflare.WorkerScript("processor", {
+    accountId, name: "processor-worker", content: processorCode,
+    queueConsumers: [{queue: queue.name, maxBatchSize: 10, maxRetries: 3, maxWaitTimeMs: 5000}],
+    r2BucketBindings: [{name: "OUTPUT_BUCKET", bucketName: outputBucket.name}],
+});
+```
+
+## Microservices with Service Bindings
+
+```typescript
+const authWorker = new cloudflare.WorkerScript("auth", {accountId, name: "auth-service", content: authCode});
+const apiWorker = new cloudflare.WorkerScript("api", {
+    accountId, name: "api-service", content: apiCode,
+    serviceBindings: [{name: "AUTH", service: authWorker.name}],
+});
+// In worker: await env.AUTH.fetch("/verify", {...});
+```
+
+## Event-Driven Architecture
+
+```typescript
+const eventQueue = new cloudflare.Queue("events", {accountId, name: "event-bus"});
+const producers = ["api", "webhook"].map(name =>
+    new cloudflare.WorkerScript(`${name}-producer`, {
+        accountId, name: `${name}-producer`, content: producerCode,
+        queueBindings: [{name: "EVENTS", queue: eventQueue.id}],
+    })
+);
+const consumers = ["email", "analytics"].map(name =>
+    new cloudflare.WorkerScript(`${name}-consumer`, {
+        accountId, name: `${name}-consumer`, content: consumerCode,
+        queueConsumers: [{queue: eventQueue.name, maxBatchSize: 10}],
+    })
+);
+```
+
+## CDN with Dynamic Content
+
+```typescript
+const staticBucket = new cloudflare.R2Bucket("static", {accountId, name: "static-assets"});
+const appWorker = new cloudflare.WorkerScript("app", {
+    accountId, name: "app-worker", content: appCode,
+    r2BucketBindings: [{name: "STATIC", bucketName: staticBucket.name}],
+});
+const route = new cloudflare.WorkerRoute("route", {zoneId, pattern: `${domain}/*`, scriptName: appWorker.name});
+```
+
+## Wrangler Integration
+
+```typescript
+// Match wrangler.toml bindings in Pulumi
+const worker = new cloudflare.WorkerScript("worker", {
+    accountId, name: "my-worker", content: code,
+    compatibilityDate: "2024-01-01", compatibilityFlags: ["nodejs_compat"],
+    kvNamespaceBindings: [{name: "MY_KV", namespaceId: kv.id}], // Must match wrangler.toml
+});
+```
+
+## Dynamic Worker Content
+
+```typescript
+import * as command from "@pulumi/command";
+const build = new command.local.Command("build-worker", {create: "npm run build", dir: "./worker"});
+const workerContent = build.stdout.apply(() => fs.readFileSync("./worker/dist/index.js", "utf8"));
+const worker = new cloudflare.WorkerScript("worker", {accountId, name: "my-worker", content: workerContent}, {dependsOn: [build]});
+```
+
+## Conditional Resources
+
+```typescript
+const isProd = pulumi.getStack() === "prod";
+const analytics = isProd ? new cloudflare.WorkersKvNamespace("analytics", {accountId, title: "analytics"}) : undefined;
+const worker = new cloudflare.WorkerScript("worker", {
+    accountId, name: "worker", content: code,
+    kvNamespaceBindings: analytics ? [{name: "ANALYTICS", namespaceId: analytics.id}] : [],
+});
+```
+
+---
+See: [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [gotchas.md](./gotchas.md)

--- a/.agent/services/hosting/cloudflare-platform/references/queues/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/queues/README.md
@@ -1,0 +1,69 @@
+# Cloudflare Queues
+
+Flexible message queuing for async task processing with guaranteed at-least-once delivery and configurable batching.
+
+## Overview
+
+Queues provide:
+- At-least-once delivery guarantee
+- Push-based (Worker) and pull-based (HTTP) consumers
+- Configurable batching and retries
+- Dead Letter Queues (DLQ)
+- Delays up to 12 hours
+
+**Use cases:** Async processing, API buffering, rate limiting, event workflows, deferred jobs
+
+## Quick Start
+
+```bash
+wrangler queues create my-queue
+wrangler queues consumer add my-queue my-worker
+```
+
+```typescript
+// Producer
+await env.MY_QUEUE.send({ userId: 123, action: 'notify' });
+
+// Consumer
+export default {
+  async queue(batch: MessageBatch, env: Env): Promise<void> {
+    for (const msg of batch.messages) {
+      await process(msg.body);
+      msg.ack();
+    }
+  }
+};
+```
+
+## Core Operations
+
+| Operation | Purpose | Limit |
+|-----------|---------|-------|
+| `send(body, options?)` | Publish message | 128 KB |
+| `sendBatch(messages)` | Bulk publish | 100 msgs/256 KB |
+| `message.ack()` | Acknowledge success | - |
+| `message.retry(options?)` | Retry with delay | - |
+| `batch.ackAll()` | Ack entire batch | - |
+
+## Architecture
+
+```
+[Producer Worker] → [Queue] → [Consumer Worker/HTTP] → [Processing]
+```
+
+- Max 10,000 queues per account
+- 5,000 msgs/second per queue
+- 4-14 day retention (configurable)
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - wrangler.jsonc setup, producer/consumer config, DLQ
+- [api.md](./api.md) - Send/batch methods, queue handler, ack/retry, pull API
+- [patterns.md](./patterns.md) - Async tasks, buffering, rate limiting, event workflows
+- [gotchas.md](./gotchas.md) - Idempotency, retry limits, content types, cost optimization
+
+## See Also
+
+- [workers](../workers/) - Worker runtime for producers/consumers
+- [r2](../r2/) - Process R2 event notifications via queues
+- [d1](../d1/) - Batch write to D1 from queue consumers

--- a/.agent/services/hosting/cloudflare-platform/references/queues/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/queues/api.md
@@ -1,0 +1,138 @@
+# Queues API Reference
+
+## Producer: Send Messages
+
+```typescript
+// Basic send
+await env.MY_QUEUE.send({ url: request.url, timestamp: Date.now() });
+
+// Options: delay (max 43200s), contentType (json|text|bytes|v8)
+await env.MY_QUEUE.send(message, { delaySeconds: 600 });
+await env.MY_QUEUE.send(message, { delaySeconds: 0 }); // Override queue default
+
+// Batch (up to 100 msgs or 256 KB)
+await env.MY_QUEUE.sendBatch([
+  { body: 'msg1' },
+  { body: 'msg2' },
+  { body: 'msg3', options: { delaySeconds: 300 } }
+]);
+
+// Non-blocking
+ctx.waitUntil(env.MY_QUEUE.send({ data: 'async' }));
+```
+
+## Consumer: Push-based (Worker)
+
+```typescript
+export default {
+  async queue(batch: MessageBatch, env: Env, ctx: ExecutionContext): Promise<void> {
+    // batch.queue, batch.messages.length
+    for (const msg of batch.messages) {
+      // msg.id, msg.body, msg.timestamp, msg.attempts
+      try {
+        await processMessage(msg.body);
+        msg.ack();
+      } catch (error) {
+        msg.retry({ delaySeconds: 600 });
+      }
+    }
+  }
+};
+```
+
+## Batch Operations
+
+```typescript
+// Acknowledge entire batch
+try {
+  await bulkProcess(batch.messages);
+  batch.ackAll();
+} catch (error) {
+  batch.retryAll({ delaySeconds: 300 });
+}
+```
+
+## Exponential Backoff
+
+```typescript
+async queue(batch: MessageBatch, env: Env): Promise<void> {
+  for (const msg of batch.messages) {
+    try {
+      await processMessage(msg.body);
+      msg.ack();
+    } catch (error) {
+      const delay = Math.min(30 ** msg.attempts, 43200);
+      msg.retry({ delaySeconds: delay });
+    }
+  }
+}
+```
+
+## Multiple Queues, Single Consumer
+
+```typescript
+export default {
+  async queue(batch: MessageBatch, env: Env): Promise<void> {
+    switch (batch.queue) {
+      case 'high-priority': await processUrgent(batch.messages); break;
+      case 'low-priority': await processDeferred(batch.messages); break;
+      case 'email': await sendEmails(batch.messages); break;
+      default: batch.retryAll();
+    }
+  }
+};
+```
+
+## Consumer: Pull-based (HTTP)
+
+```typescript
+// Pull messages
+const response = await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/queues/${QUEUE_ID}/messages/pull`,
+  {
+    method: 'POST',
+    headers: { 'authorization': `Bearer ${API_TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify({ visibility_timeout_ms: 6000, batch_size: 50 })
+  }
+);
+
+const data = await response.json();
+
+// Acknowledge
+await fetch(
+  `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/queues/${QUEUE_ID}/messages/ack`,
+  {
+    method: 'POST',
+    headers: { 'authorization': `Bearer ${API_TOKEN}`, 'content-type': 'application/json' },
+    body: JSON.stringify({
+      acks: [{ lease_id: msg.lease_id }],
+      retries: [{ lease_id: msg2.lease_id, delay_seconds: 600 }]
+    })
+  }
+);
+```
+
+## Interfaces
+
+```typescript
+interface MessageBatch<Body = unknown> {
+  readonly queue: string;
+  readonly messages: Message<Body>[];
+  ackAll(): void;
+  retryAll(options?: QueueRetryOptions): void;
+}
+
+interface Message<Body = unknown> {
+  readonly id: string;
+  readonly timestamp: Date;
+  readonly body: Body;
+  readonly attempts: number;
+  ack(): void;
+  retry(options?: QueueRetryOptions): void;
+}
+
+interface QueueSendOptions {
+  contentType?: 'text' | 'bytes' | 'json' | 'v8';
+  delaySeconds?: number; // 0-43200
+}
+```

--- a/.agent/services/hosting/cloudflare-platform/references/queues/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/queues/configuration.md
@@ -1,0 +1,125 @@
+# Queues Configuration
+
+## Create Queue
+
+```bash
+wrangler queues create my-queue
+wrangler queues create my-queue --retention-period-hours=336  # 14 days
+wrangler queues create my-queue --delivery-delay-secs=300
+```
+
+## Producer Binding
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "queues": {
+    "producers": [
+      {
+        "queue": "my-queue-name",
+        "binding": "MY_QUEUE",
+        "delivery_delay": 60  // Optional: default delay in seconds
+      }
+    ]
+  }
+}
+```
+
+**wrangler.toml:**
+```toml
+[[queues.producers]]
+queue = "my-queue-name"
+binding = "MY_QUEUE"
+delivery_delay = 60
+```
+
+## Consumer Configuration (Push-based)
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "queues": {
+    "consumers": [
+      {
+        "queue": "my-queue-name",
+        "max_batch_size": 10,           // 1-100, default 10
+        "max_batch_timeout": 5,         // 0-60s, default 5
+        "max_retries": 3,               // default 3, max 100
+        "dead_letter_queue": "my-dlq",  // optional
+        "retry_delay": 300              // optional: delay retries in seconds
+      }
+    ]
+  }
+}
+```
+
+**wrangler.toml:**
+```toml
+[[queues.consumers]]
+queue = "my-queue-name"
+max_batch_size = 10
+max_batch_timeout = 5
+max_retries = 3
+dead_letter_queue = "my-dlq"
+retry_delay = 300
+```
+
+## Consumer Configuration (Pull-based)
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "queues": {
+    "consumers": [
+      {
+        "queue": "my-queue-name",
+        "type": "http_pull",
+        "visibility_timeout_ms": 5000,  // default 30000, max 12h
+        "max_retries": 5,
+        "dead_letter_queue": "my-dlq"
+      }
+    ]
+  }
+}
+```
+
+## TypeScript Types
+
+```typescript
+interface Env {
+  MY_QUEUE: Queue<MessageBody>;
+  ANALYTICS_QUEUE: Queue<AnalyticsEvent>;
+}
+
+interface MessageBody {
+  id: string;
+  action: 'create' | 'update' | 'delete';
+  data: Record<string, any>;
+}
+
+export default {
+  async queue(batch: MessageBatch<MessageBody>, env: Env): Promise<void> {
+    for (const msg of batch.messages) {
+      console.log(msg.body.action);
+      msg.ack();
+    }
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+## CLI Commands
+
+```bash
+# Consumer management
+wrangler queues consumer add my-queue my-worker --batch-size=50 --max-retries=5
+wrangler queues consumer http add my-queue
+wrangler queues consumer worker remove my-queue my-worker
+wrangler queues consumer http remove my-queue
+
+# Queue operations
+wrangler queues list
+wrangler queues pause my-queue
+wrangler queues resume my-queue
+wrangler queues purge my-queue
+wrangler queues delete my-queue
+```

--- a/.agent/services/hosting/cloudflare-platform/references/queues/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/queues/gotchas.md
@@ -1,0 +1,112 @@
+# Queues Gotchas & Troubleshooting
+
+## Idempotency Required
+
+At-least-once delivery means duplicates possible. Design consumers to handle duplicates:
+
+```typescript
+// ✅ GOOD: Track processed messages
+const processed = await env.PROCESSED_KV.get(msg.id);
+if (processed) { msg.ack(); continue; }
+await processMessage(msg.body);
+await env.PROCESSED_KV.put(msg.id, '1', { expirationTtl: 86400 });
+msg.ack();
+```
+
+## Content Type Visibility
+
+- `json`: Visible in dashboard, works with pull consumers
+- `v8`: NOT decodable by pull consumers or dashboard
+- Use `json` for pull consumers
+
+```typescript
+// ✅ For pull consumers
+await env.MY_QUEUE.send(data, { contentType: 'json' });
+
+// ❌ Avoid v8 with pull
+await env.MY_QUEUE.send(new Date(), { contentType: 'v8' }); // Can't decode
+```
+
+## Retry Behavior
+
+```typescript
+// If you DON'T call ack() or retry(), message retries automatically
+async queue(batch: MessageBatch): Promise<void> {
+  for (const msg of batch.messages) {
+    try {
+      await processMessage(msg.body);
+      msg.ack(); // Explicit success
+    } catch (error) {
+      // Don't call retry() - auto-retries with configured delay
+      // OR call retry() with custom delay
+      msg.retry({ delaySeconds: 600 });
+    }
+  }
+}
+```
+
+## CPU Time Limits
+
+Default: 30s per consumer invocation. Increase if needed:
+
+```jsonc
+{ "limits": { "cpu_ms": 300000 } } // 5 minutes
+```
+
+## Cost Optimization
+
+Operations: write + read + delete = 3 ops per message  
+Retries add read ops  
+Formula: `((messages × 3) - 1M) / 1M × $0.40` per month
+
+```typescript
+// Keep messages <64 KB (charged per 64 KB chunk)
+// Batch aggressively to reduce frequency
+{ "max_batch_size": 100, "max_batch_timeout": 30 }
+```
+
+## Message Not Delivered
+
+```bash
+# Check queue paused
+wrangler queues list
+
+# Verify consumer configured
+wrangler queues consumer worker remove my-queue my-worker
+wrangler queues consumer add my-queue my-worker
+
+# Check logs for errors
+wrangler tail my-worker
+```
+
+## High DLQ Rate
+
+- Review consumer error logs
+- Check external dependency availability
+- Verify message format matches expectations
+- Increase retry delay: `"retry_delay": 300`
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Max queues | 10,000 |
+| Message size | 128 KB |
+| Batch size (consumer) | 100 messages |
+| Batch size (sendBatch) | 100 msgs/256 KB |
+| Throughput | 5,000 msgs/sec/queue |
+| Retention | 4-14 days |
+| Max backlog | 25 GB |
+| Max delay | 12 hours (43,200s) |
+| Max retries | 100 |
+
+## Best Practices
+
+- ✅ Design for idempotency (at-least-once delivery)
+- ✅ Use `json` content type for visibility
+- ✅ Log failures with context
+- ✅ Configure DLQ for permanent failures
+- ✅ Use `waitUntil()` for non-blocking sends
+- ✅ Batch sends when possible
+- ❌ Don't use v8 with pull consumers
+- ❌ Don't rely on message ordering

--- a/.agent/services/hosting/cloudflare-platform/references/queues/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/queues/patterns.md
@@ -1,0 +1,155 @@
+# Queues Patterns & Best Practices
+
+## Async Task Processing
+
+```typescript
+// Producer: Accept request, queue work
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { userId, reportType } = await request.json();
+    await env.REPORT_QUEUE.send({ userId, reportType, requestedAt: Date.now() });
+    return Response.json({ message: 'Report queued', status: 'pending' });
+  }
+};
+
+// Consumer: Process reports
+export default {
+  async queue(batch: MessageBatch, env: Env): Promise<void> {
+    for (const msg of batch.messages) {
+      const { userId, reportType } = msg.body;
+      const report = await generateReport(userId, reportType, env);
+      await env.REPORTS_BUCKET.put(`${userId}/${reportType}.pdf`, report);
+      msg.ack();
+    }
+  }
+};
+```
+
+## Buffering API Calls
+
+```typescript
+// Producer: Queue log entries
+ctx.waitUntil(env.LOGS_QUEUE.send({
+  method: request.method,
+  url: request.url,
+  timestamp: Date.now()
+}));
+
+// Consumer: Batch write to external API
+async queue(batch: MessageBatch, env: Env): Promise<void> {
+  const logs = batch.messages.map(m => m.body);
+  await fetch(env.LOG_ENDPOINT, { method: 'POST', body: JSON.stringify({ logs }) });
+  batch.ackAll();
+}
+```
+
+## Rate Limiting Upstream
+
+```typescript
+async queue(batch: MessageBatch, env: Env): Promise<void> {
+  for (const msg of batch.messages) {
+    try {
+      await callRateLimitedAPI(msg.body);
+      msg.ack();
+    } catch (error) {
+      if (error.status === 429) {
+        const retryAfter = parseInt(error.headers.get('Retry-After') || '60');
+        msg.retry({ delaySeconds: retryAfter });
+      } else throw error;
+    }
+  }
+}
+```
+
+## Event-Driven Workflows
+
+```typescript
+// R2 event → Queue → Worker
+export default {
+  async queue(batch: MessageBatch, env: Env): Promise<void> {
+    for (const msg of batch.messages) {
+      const event = msg.body;
+      if (event.action === 'PutObject') {
+        await processNewFile(event.object.key, env);
+      } else if (event.action === 'DeleteObject') {
+        await cleanupReferences(event.object.key, env);
+      }
+      msg.ack();
+    }
+  }
+};
+```
+
+## Dead Letter Queue Pattern
+
+```typescript
+// Main queue: After max_retries, goes to DLQ automatically
+export default {
+  async queue(batch: MessageBatch, env: Env): Promise<void> {
+    for (const msg of batch.messages) {
+      try {
+        await riskyOperation(msg.body);
+        msg.ack();
+      } catch (error) {
+        console.error(`Failed after ${msg.attempts} attempts:`, error);
+      }
+    }
+  }
+};
+
+// DLQ consumer: Log and store failed messages
+export default {
+  async queue(batch: MessageBatch, env: Env): Promise<void> {
+    for (const msg of batch.messages) {
+      await env.FAILED_KV.put(msg.id, JSON.stringify(msg.body));
+      msg.ack();
+    }
+  }
+};
+```
+
+## Priority Queues
+
+High priority: `max_batch_size: 5, max_batch_timeout: 1`. Low priority: `max_batch_size: 100, max_batch_timeout: 30`.
+
+## Delayed Job Processing
+
+```typescript
+await env.EMAIL_QUEUE.send({ to, template, userId }, { delaySeconds: 3600 });
+```
+
+## Fan-out Pattern
+
+```typescript
+async fetch(request: Request, env: Env): Promise<Response> {
+  const event = await request.json();
+  
+  // Send to multiple queues for parallel processing
+  await Promise.all([
+    env.ANALYTICS_QUEUE.send(event),
+    env.NOTIFICATIONS_QUEUE.send(event),
+    env.AUDIT_LOG_QUEUE.send(event)
+  ]);
+  
+  return Response.json({ status: 'processed' });
+}
+```
+
+## Idempotency Pattern
+
+```typescript
+async queue(batch: MessageBatch, env: Env): Promise<void> {
+  for (const msg of batch.messages) {
+    // Check if already processed
+    const processed = await env.PROCESSED_KV.get(msg.id);
+    if (processed) {
+      msg.ack();
+      continue;
+    }
+    
+    await processMessage(msg.body);
+    await env.PROCESSED_KV.put(msg.id, '1', { expirationTtl: 86400 });
+    msg.ack();
+  }
+}
+```

--- a/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/README.md
@@ -1,0 +1,18 @@
+# Cloudflare R2 Data Catalog Skill Reference
+
+Expert guidance for Cloudflare R2 Data Catalog - Apache Iceberg catalog built into R2 buckets.
+
+## Overview
+
+R2 Data Catalog is a managed Apache Iceberg REST catalog built directly into R2 buckets. It enables analytical workloads like log analytics, BI, and data pipelines with zero egress fees. Curr...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/api.md
@@ -1,0 +1,29 @@
+### API Token Creation
+
+**Dashboard Method (Recommended):**
+1. R2 → Manage API tokens → Create API token
+2. Select **Admin Read & Write** or **Admin Read only**
+   - Includes both R2 Data Catalog + R2 Storage permissions
+3. Copy token value
+
+**API Method (Programmatic):**
+```json
+{
+  "policies": [{
+    "effect": "allow",
+    "resources": {
+      "com.cloudflare.edge.r2.bucket.<account-id>_<jurisdiction>_<bucket-name>": "*"
+    },
+    "permission_groups": [
+      {
+        "id": "d229766a2f7f4d299f20eaa8c9b1fde9",
+        "name": "Workers R2 Data Catalog Write"
+      },
+      {
+        "id": "2efd5506f9c8494dacb1fa10a3e7d5b6",
+        "name": "Workers R2 Storage Bucket Item Write"
+      }
+    ]
+  }]
+}
+```

--- a/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/configuration.md
@@ -1,0 +1,39 @@
+## Configuration
+
+### Prerequisites
+- Cloudflare account with R2 subscription
+- R2 bucket created
+- API token with both R2 Storage and R2 Data Catalog permissions
+
+### Enable Catalog on Bucket
+
+**Via Wrangler:**
+```bash
+npx wrangler r2 bucket catalog enable <BUCKET_NAME>
+```
+
+**Via Dashboard:**
+1. Go to R2 → Select bucket → Settings tab
+2. Scroll to "R2 Data Catalog" → Click "Enable"
+3. Note the **Catalog URI** and **Warehouse name**
+
+**Output:**
+- Catalog URI: `https://<account-id>.r2.cloudflarestorage.com/iceberg/<bucket-name>`
+- Warehouse: `<bucket-name>`
+
+### API Token Creation
+
+**Dashboard Method (Recommended):**
+1. R2 → Manage API tokens → Create API token
+2. Select **Admin Read & Write** or **Admin Read only**
+   - Includes both R2 Data Catalog + R2 Storage permissions
+3. Copy token value
+
+**API Method (Programmatic):**
+```json
+{
+  "policies": [{
+    "effect": "allow",
+    "resources": {
+      "com.cloudflare.edge.r2.bucket.<account-id>_<jurisdiction>_<bucket-name>": "*"
+    },

--- a/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/gotchas.md
@@ -1,0 +1,20 @@
+## Best Practices
+
+### Authentication & Security
+1. **Use Admin Read & Write tokens** for read/write operations
+2. **Use Admin Read only tokens** for read-only query engines
+3. **Store tokens securely** in environment variables, not code
+4. **Rotate tokens regularly** via dashboard
+5. **Use catalog-level maintenance** with service tokens for automation
+
+### Performance Optimization
+1. **Enable compaction** for all production tables
+2. **Choose appropriate target file sizes**:
+   - Start with 128 MB for most workloads
+   - Tune based on query patterns
+3. **Configure snapshot expiration** to match retention requirements
+4. **Use partitioning** in table schema for large datasets
+5. **Monitor query performance** and adjust compaction settings
+
+### Data Modeling
+1. **Use namespaces** to organiz

--- a/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2-data-catalog/patterns.md
@@ -1,0 +1,46 @@
+## Common Use Cases
+
+### 1. Log Analytics Pipeline
+
+**Scenario:** Ingest and query application logs
+
+```python
+from pyiceberg.catalog.rest import RestCatalog
+import pyarrow as pa
+import pandas as pd
+
+# Setup catalog
+catalog = RestCatalog(
+    name="logs_catalog",
+    warehouse=WAREHOUSE,
+    uri=CATALOG_URI,
+    token=TOKEN,
+)
+
+catalog.create_namespace_if_not_exists("logs")
+
+# Create schema for logs
+log_schema = pa.schema([
+    ("timestamp", pa.timestamp("ms")),
+    ("level", pa.string()),
+    ("service", pa.string()),
+    ("message", pa.string()),
+    ("user_id", pa.int64()),
+])
+
+# Create table
+logs_table = catalog.create_table(
+    ("logs", "application_logs"),
+    schema=log_schema,
+)
+
+# Append logs incrementally
+log_data = pa.table({
+    "timestamp": [pd.Timestamp.now(), pd.Timestamp.now()],
+    "level": ["ERROR", "INFO"],
+    "service": ["auth-service", "api-gateway"],
+    "message": ["Failed login attempt", "Request processed"],
+    "user_id": [12345, 67890],
+})
+
+logs_table.appen

--- a/.agent/services/hosting/cloudflare-platform/references/r2-sql/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2-sql/README.md
@@ -1,0 +1,512 @@
+# Cloudflare R2 SQL Skill
+
+Guide for using Cloudflare R2 SQL - serverless distributed query engine for Apache Iceberg tables in R2 Data Catalog.
+
+## Overview
+
+R2 SQL is Cloudflare's serverless distributed analytics query engine for querying Apache Iceberg tables in R2 Data Catalog. Features:
+- Serverless - no clusters to manage
+- Distributed - leverages Cloudflare's global network
+- Zero egress fees - query from any cloud/region
+- Open beta - free during beta (standard R2 storage costs apply)
+
+## Core Concepts
+
+### Apache Iceberg Table Format
+- Open table format for large-scale analytics datasets
+- ACID transactions for reliable concurrent reads/writes
+- Schema evolution - add/rename/drop columns without rewriting data
+- Optimized metadata - avoids full table scans via indexed metadata
+- Supported by Spark, Trino, Snowflake, DuckDB, ClickHouse, PyIceberg
+
+### R2 Data Catalog
+- Managed Apache Iceberg catalog built into R2 bucket
+- Exposes standard Iceberg REST catalog interface
+- Single source of truth for table metadata
+- Tracks table state via immutable snapshots
+- Supports multiple query engines safely accessing same tables
+
+### Architecture
+**Query Planner**:
+- Top-down metadata investigation
+- Multi-layer pruning (partition-level, column-level, row-group level)
+- Streaming pipeline - execution starts before planning completes
+- Early termination - stops when result complete without full scan
+- Uses partition stats and column stats (min/max, null counts)
+
+**Query Execution**:
+- Coordinator distributes work to workers across Cloudflare network
+- Workers run Apache DataFusion for parallel query execution
+- Arrow IPC format for inter-process communication
+- Parquet column pruning - reads only required columns
+- Ranged reads from R2 for efficiency
+
+**Aggregation Strategies**:
+- Scatter-gather - for simple aggregations (sum, count, avg)
+- Shuffling - for ORDER BY/HAVING on aggregates via hash partitioning
+
+## Setup & Configuration
+
+### 1. Enable R2 Data Catalog
+
+CLI:
+```bash
+npx wrangler r2 bucket catalog enable <bucket-name>
+```
+
+Note the Warehouse name and Catalog URI from output.
+
+Dashboard:
+1. R2 Object Storage → Select bucket
+2. Settings tab → R2 Data Catalog → Enable
+3. Note Catalog URI and Warehouse name
+
+### 2. Create API Token
+
+Required permissions: R2 Admin Read & Write (includes R2 SQL Read)
+
+Dashboard:
+1. R2 Object Storage → Manage API tokens
+2. Create API token → Admin Read & Write
+3. Save token value
+
+### 3. Configure Environment
+
+```bash
+export WRANGLER_R2_SQL_AUTH_TOKEN=<your-token>
+```
+
+Or `.env` file:
+```
+WRANGLER_R2_SQL_AUTH_TOKEN=<your-token>
+```
+
+## Common Code Patterns
+
+### Wrangler CLI Query
+
+```bash
+npx wrangler r2 sql query "<warehouse-name>" "
+  SELECT * 
+  FROM namespace.table_name 
+  WHERE condition 
+  LIMIT 10"
+```
+
+### PyIceberg Setup
+
+```python
+from pyiceberg.catalog.rest import RestCatalog
+
+catalog = RestCatalog(
+    name="my_catalog",
+    warehouse="<WAREHOUSE>",
+    uri="<CATALOG_URI>",
+    token="<TOKEN>",
+)
+
+# Create namespace
+catalog.create_namespace_if_not_exists("default")
+```
+
+### Create Table
+
+```python
+import pyarrow as pa
+
+# Define schema
+df = pa.table({
+    "id": [1, 2, 3],
+    "name": ["Alice", "Bob", "Charlie"],
+    "score": [80.0, 92.5, 88.0],
+})
+
+# Create table
+table = catalog.create_table(
+    ("default", "people"),
+    schema=df.schema,
+)
+```
+
+### Append Data
+
+```python
+table.append(df)
+```
+
+### Query Table
+
+```python
+# Scan and convert to Pandas
+scanned = table.scan().to_arrow()
+print(scanned.to_pandas())
+```
+
+## SQL Reference
+
+### Query Structure
+
+```sql
+SELECT column_list | aggregation_function
+FROM table_name
+WHERE conditions
+[GROUP BY column_list]
+[HAVING conditions]
+[ORDER BY partition_key [DESC | ASC]]
+[LIMIT number]
+```
+
+### Schema Discovery
+
+```sql
+-- List namespaces
+SHOW DATABASES;
+SHOW NAMESPACES;
+
+-- List tables
+SHOW TABLES IN namespace_name;
+
+-- Describe table
+DESCRIBE namespace_name.table_name;
+```
+
+### SELECT Patterns
+
+```sql
+-- All columns
+SELECT * FROM ns.table;
+
+-- Specific columns
+SELECT user_id, timestamp, status FROM ns.table;
+
+-- With conditions
+SELECT * FROM ns.table 
+WHERE timestamp BETWEEN '2025-01-01T00:00:00Z' AND '2025-01-31T23:59:59Z'
+  AND status = 200
+LIMIT 100;
+
+-- Complex conditions
+SELECT * FROM ns.table 
+WHERE (status = 404 OR status = 500) 
+  AND method = 'POST'
+  AND user_agent IS NOT NULL
+ORDER BY timestamp DESC;
+```
+
+### Aggregations
+
+Supported functions: COUNT(*), SUM(col), AVG(col), MIN(col), MAX(col)
+
+```sql
+-- Count by group
+SELECT department, COUNT(*)
+FROM ns.sales_data
+GROUP BY department;
+
+-- Multiple aggregates
+SELECT region, MIN(price), MAX(price), AVG(price)
+FROM ns.products
+GROUP BY region
+ORDER BY AVG(price) DESC;
+
+-- With HAVING filter
+SELECT category, SUM(amount)
+FROM ns.sales
+WHERE sale_date >= '2024-01-01'
+GROUP BY category
+HAVING SUM(amount) > 10000
+LIMIT 10;
+```
+
+### Data Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| integer | Whole numbers | 1, 42, -10 |
+| float | Decimals | 1.5, 3.14 |
+| string | Text (quoted) | 'hello', 'GET' |
+| boolean | true/false | true, false |
+| timestamp | RFC3339 | '2025-01-01T00:00:00Z' |
+| date | YYYY-MM-DD | '2025-01-01' |
+
+### Operators
+
+Comparison: =, !=, <, <=, >, >=, LIKE, BETWEEN, IS NULL, IS NOT NULL
+Logical: AND (higher precedence), OR (lower precedence)
+
+### ORDER BY Limitations
+
+**CRITICAL**: ORDER BY only supports partition key columns
+
+```sql
+-- Valid if timestamp is partition key
+SELECT * FROM ns.logs ORDER BY timestamp DESC LIMIT 100;
+
+-- Invalid if column not in partition key
+SELECT * FROM ns.logs ORDER BY user_id;  -- ERROR
+```
+
+### LIMIT Defaults
+
+- Range: 1 to 10,000
+- Default: 500 if not specified
+
+## Pipelines Integration
+
+### Create Pipeline with Data Catalog Sink
+
+Schema file (`schema.json`):
+```json
+{
+  "fields": [
+    {"name": "user_id", "type": "string", "required": true},
+    {"name": "event_type", "type": "string", "required": true},
+    {"name": "amount", "type": "float64", "required": false}
+  ]
+}
+```
+
+Setup:
+```bash
+npx wrangler pipelines setup
+```
+
+Configuration:
+- Pipeline name: ecommerce
+- Enable HTTP endpoint: yes
+- Schema: Load from file → schema.json
+- Destination: Data Catalog Table
+- R2 bucket: your-bucket
+- Namespace: default
+- Table name: events
+- Catalog token: <your-token>
+- Compression: zstd
+- Roll file time: 10 seconds (dev), 300+ (prod)
+
+### Send Data to Pipeline
+
+```bash
+curl -X POST https://{stream-id}.ingest.cloudflare.com \
+  -H "Content-Type: application/json" \
+  -d '[
+    {
+      "user_id": "user_123",
+      "event_type": "purchase",
+      "amount": 29.99
+    }
+  ]'
+```
+
+## Common Use Cases
+
+### Log Analytics
+- Ingest logs via Pipelines to Iceberg table
+- Partition by day(timestamp) for efficient queries
+- Query specific time ranges with automatic pruning
+- Aggregate by status codes, endpoints, user agents
+
+```sql
+SELECT status, COUNT(*)
+FROM logs.http_requests
+WHERE timestamp BETWEEN '2025-01-01T00:00:00Z' AND '2025-01-31T23:59:59Z'
+  AND method = 'GET'
+GROUP BY status
+ORDER BY COUNT(*) DESC;
+```
+
+### Fraud Detection
+- Stream transaction events to catalog
+- Query suspicious patterns with WHERE filters
+- Aggregate by location, merchant, time windows
+
+```sql
+SELECT location, COUNT(*), AVG(amount)
+FROM fraud.transactions
+WHERE is_fraud = true
+  AND transaction_timestamp >= '2025-01-01'
+GROUP BY location
+HAVING COUNT(*) > 10;
+```
+
+### Business Intelligence
+- ETL data into partitioned Iceberg tables
+- Run analytical queries across large datasets
+- Generate reports with GROUP BY aggregations
+- No egress fees when querying from BI tools
+
+```sql
+SELECT 
+  department, 
+  SUM(revenue) as total_revenue,
+  AVG(revenue) as avg_revenue
+FROM sales.transactions
+WHERE sale_date >= '2024-01-01'
+GROUP BY department
+ORDER BY SUM(revenue) DESC
+LIMIT 10;
+```
+
+## Performance Optimization
+
+### Partitioning Strategy
+- Choose partition key based on common query patterns
+- Typical: day(timestamp), hour(timestamp), region, category
+- Enables metadata pruning to skip entire partitions
+- Required for ORDER BY optimization
+
+### Query Optimization
+- Use WHERE filters to leverage partition/column stats
+- Specify LIMIT to enable early termination
+- ORDER BY partition key columns only
+- Filter on high-selectivity columns first
+
+### Data Organization
+- Smaller files → slower queries (overhead)
+- Larger files → better compression, fewer metadata ops
+- Recommended: 100-500MB Parquet files after compression
+- Use appropriate roll intervals in Pipelines (300+ seconds for prod)
+
+### File Pruning
+Automatic at three levels:
+1. Partition-level: Skip manifests not matching query
+2. File-level: Skip Parquet files via column stats
+3. Row-group level: Skip row groups within files
+
+## Iceberg Metadata Structure
+
+```
+bucket/
+  metadata/
+    snap-{id}.avro          # Snapshot (points to manifest list)
+    {uuid}-m0.avro          # Manifest file (lists data files + stats)
+    version-hint.text       # Current metadata version
+    v{n}.metadata.json      # Table metadata (schema, snapshots)
+  data/
+    00000-0-{uuid}.parquet  # Data files
+```
+
+**Metadata hierarchy**:
+1. Table metadata JSON - schema, partition spec, snapshot log
+2. Snapshot - points to manifest list
+3. Manifest list - partition stats for each manifest
+4. Manifest files - column stats for each data file
+5. Parquet files - row group stats in footer
+
+## Limitations & Best Practices
+
+### Current Limitations (Open Beta)
+- ORDER BY only on partition key columns
+- COUNT(*) only - COUNT(column) not supported
+- No aliases in SELECT
+- No subqueries, joins, or CTEs
+- No nested column access
+- LIMIT max 10,000
+
+### Best Practices
+- Partition by time dimension for time-series data
+- Use BETWEEN for time ranges (leverages partition pruning)
+- Combine filters with AND for better pruning
+- Set appropriate LIMIT based on use case
+- Use compression (zstd recommended)
+- Monitor query performance and adjust partitioning
+
+### Type Safety
+- Quote string values: 'value'
+- Use RFC3339 for timestamps: '2025-01-01T00:00:00Z'
+- Use YYYY-MM-DD for dates: '2025-01-01'
+- No implicit type conversions
+
+## Connecting Other Engines
+
+R2 Data Catalog supports standard Iceberg REST catalog API.
+
+### Spark (Scala)
+```scala
+val spark = SparkSession.builder()
+  .config("spark.sql.catalog.my_catalog", "org.apache.iceberg.spark.SparkCatalog")
+  .config("spark.sql.catalog.my_catalog.catalog-impl", "org.apache.iceberg.rest.RESTCatalog")
+  .config("spark.sql.catalog.my_catalog.uri", catalogUri)
+  .config("spark.sql.catalog.my_catalog.token", token)
+  .config("spark.sql.catalog.my_catalog.warehouse", warehouse)
+  .getOrCreate()
+```
+
+### Snowflake
+- Create external Iceberg catalog connection
+- Configure with Catalog URI and R2 credentials
+- Query tables via SQL interface
+
+### DuckDB, Trino, ClickHouse
+- Supported via Iceberg REST catalog protocol
+- Refer to engine-specific documentation for configuration
+
+## Pricing (Future)
+
+Currently in open beta - no charges beyond standard R2 costs.
+
+Planned future pricing:
+- R2 storage: $0.015/GB-month
+- Class A operations: $4.50/million
+- Class B operations: $0.36/million
+- Catalog operations: $9.00/million (create table, get metadata, etc)
+- Compaction: $0.05/GB + $4.00/million objects processed
+- Egress: $0 (always free)
+
+30+ days notice before billing begins.
+
+## Troubleshooting
+
+### Common Errors
+
+**"ORDER BY column not in partition key"**
+- Only partition key columns can be used in ORDER BY
+- Check table partition spec with DESCRIBE
+- Remove ORDER BY or adjust table partitioning
+
+**"Token authentication failed"**
+- Verify WRANGLER_R2_SQL_AUTH_TOKEN is set
+- Ensure token has R2 Admin Read & Write + SQL Read permissions
+- Token may be expired - create new one
+
+**"Table not found"**
+- Verify namespace exists: SHOW DATABASES
+- Check table name: SHOW TABLES IN namespace
+- Ensure catalog enabled on bucket
+
+**"No data returned"**
+- Check WHERE conditions match data
+- Verify time range in BETWEEN clause
+- Try removing filters to confirm data exists
+
+### Performance Issues
+
+**Slow queries**:
+- Check partition pruning effectiveness
+- Reduce LIMIT if scanning too much data
+- Ensure filters on partition key columns
+- Review Parquet file sizes (aim for 100-500MB)
+
+**Query timeout**:
+- Add more restrictive WHERE filters
+- Reduce LIMIT
+- Consider better partitioning strategy
+
+## Resources
+
+- Docs: https://developers.cloudflare.com/r2-sql/
+- Data Catalog: https://developers.cloudflare.com/r2/data-catalog/
+- Blog: https://blog.cloudflare.com/r2-sql-deep-dive/
+- Discord: https://discord.cloudflare.com/
+
+## Key Reminders
+
+1. R2 SQL queries ONLY Apache Iceberg tables in R2 Data Catalog
+2. Enable catalog on bucket before use
+3. Create API token with R2 + catalog permissions
+4. Partition by time for time-series data
+5. ORDER BY limited to partition key columns
+6. Use LIMIT and WHERE for optimal performance
+7. Zero egress fees - query from anywhere
+8. Open beta - free during testing phase
+9. Serverless - no infrastructure management
+10. Leverage Cloudflare's global network for distributed execution

--- a/.agent/services/hosting/cloudflare-platform/references/r2/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2/README.md
@@ -1,0 +1,61 @@
+# Cloudflare R2 Object Storage
+
+S3-compatible object storage with zero egress fees, optimized for large file storage and delivery.
+
+## Overview
+
+R2 provides:
+- S3-compatible API (Workers API + S3 REST)
+- Zero egress fees globally
+- Strong consistency for writes/deletes
+- Storage classes (Standard/Infrequent Access)
+- SSE-C encryption support
+
+**Use cases:** Media storage, backups, static assets, user uploads, data lakes
+
+## Quick Start
+
+```bash
+wrangler r2 bucket create my-bucket --location=enam
+wrangler r2 object put my-bucket/file.txt --file=./local.txt
+```
+
+```typescript
+// Upload
+await env.MY_BUCKET.put(key, data, {
+  httpMetadata: { contentType: 'image/jpeg' }
+});
+
+// Download
+const object = await env.MY_BUCKET.get(key);
+if (object) return new Response(object.body);
+```
+
+## Core Operations
+
+| Method | Purpose | Returns |
+|--------|---------|---------|
+| `put(key, value, options?)` | Upload object | `R2Object \| null` |
+| `get(key, options?)` | Download object | `R2ObjectBody \| R2Object \| null` |
+| `head(key)` | Get metadata only | `R2Object \| null` |
+| `delete(keys)` | Delete object(s) | `Promise<void>` |
+| `list(options?)` | List objects | `R2Objects` |
+
+## Storage Classes
+
+- **Standard**: Frequent access, low latency reads
+- **InfrequentAccess**: 30-day minimum storage, retrieval fees, lower storage cost
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - wrangler.jsonc bindings, S3 SDK setup, location hints
+- [api.md](./api.md) - Workers API methods, multipart uploads, conditional requests
+- [patterns.md](./patterns.md) - Streaming, caching, presigned URLs, storage transitions
+- [gotchas.md](./gotchas.md) - List truncation, etag format, checksum limits, multipart pitfalls
+
+## See Also
+
+- [workers](../workers/) - Worker runtime and fetch handlers
+- [kv](../kv/) - Metadata storage for R2 objects
+- [d1](../d1/) - Store R2 URLs in relational database
+- [queues](../queues/) - Process R2 uploads asynchronously

--- a/.agent/services/hosting/cloudflare-platform/references/r2/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2/api.md
@@ -1,0 +1,127 @@
+# R2 API Reference
+
+## PUT (Upload)
+
+```typescript
+// Basic
+await env.MY_BUCKET.put(key, value);
+
+// With metadata
+await env.MY_BUCKET.put(key, value, {
+  httpMetadata: {
+    contentType: 'image/jpeg',
+    contentDisposition: 'attachment; filename="photo.jpg"',
+    cacheControl: 'max-age=3600'
+  },
+  customMetadata: { userId: '123', version: '2' },
+  storageClass: 'Standard', // or 'InfrequentAccess'
+  sha256: arrayBufferOrHex, // Integrity check
+  ssecKey: arrayBuffer32bytes // SSE-C encryption
+});
+
+// Value types: ReadableStream | ArrayBuffer | string | Blob
+```
+
+## GET (Download)
+
+```typescript
+const object = await env.MY_BUCKET.get(key);
+if (!object) return new Response('Not found', { status: 404 });
+
+// Body formats
+const buffer = await object.arrayBuffer();
+const text = await object.text();
+const json = await object.json();
+const stream = object.body; // ReadableStream
+
+// Ranged reads
+const object = await env.MY_BUCKET.get(key, {
+  range: { offset: 0, length: 1024 }
+});
+
+// Conditional GET
+const object = await env.MY_BUCKET.get(key, {
+  onlyIf: { etagMatches: '"abc123"' }
+});
+```
+
+## HEAD (Metadata Only)
+
+```typescript
+const object = await env.MY_BUCKET.head(key);
+console.log(object?.size, object?.etag, object?.storageClass);
+```
+
+## DELETE
+
+```typescript
+await env.MY_BUCKET.delete(key);
+await env.MY_BUCKET.delete([key1, key2, key3]); // Batch (max 1000)
+```
+
+## LIST
+
+```typescript
+const listed = await env.MY_BUCKET.list({
+  limit: 1000,
+  prefix: 'photos/',
+  cursor: cursorFromPrevious,
+  delimiter: '/',
+  include: ['httpMetadata', 'customMetadata']
+});
+
+// Pagination (always use truncated flag)
+while (listed.truncated) {
+  const next = await env.MY_BUCKET.list({ cursor: listed.cursor });
+  listed.objects.push(...next.objects);
+  listed.truncated = next.truncated;
+  listed.cursor = next.cursor;
+}
+```
+
+## Multipart Uploads
+
+```typescript
+const multipart = await env.MY_BUCKET.createMultipartUpload(key, {
+  httpMetadata: { contentType: 'video/mp4' }
+});
+
+const uploadedParts: R2UploadedPart[] = [];
+for (let i = 0; i < partCount; i++) {
+  const part = await multipart.uploadPart(i + 1, partData);
+  uploadedParts.push(part);
+}
+
+const object = await multipart.complete(uploadedParts);
+// OR: await multipart.abort();
+
+// Resume
+const multipart = env.MY_BUCKET.resumeMultipartUpload(key, uploadId);
+```
+
+## R2Object Interface
+
+```typescript
+interface R2Object {
+  key: string;
+  version: string;
+  size: number;
+  etag: string; // Unquoted
+  httpEtag: string; // Quoted (use for headers)
+  uploaded: Date;
+  httpMetadata: R2HTTPMetadata;
+  customMetadata: Record<string, string>;
+  storageClass: 'Standard' | 'InfrequentAccess';
+  checksums: R2Checksums;
+  writeHttpMetadata(headers: Headers): void;
+}
+```
+
+## CLI Operations
+
+```bash
+wrangler r2 object put my-bucket/file.txt --file=./local.txt --content-type=text/plain
+wrangler r2 object get my-bucket/file.txt --file=./download.txt
+wrangler r2 object delete my-bucket/file.txt
+wrangler r2 object list my-bucket --prefix=photos/ --delimiter=/
+```

--- a/.agent/services/hosting/cloudflare-platform/references/r2/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2/configuration.md
@@ -1,0 +1,76 @@
+# R2 Configuration
+
+## Workers Binding
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "r2_buckets": [
+    {
+      "binding": "MY_BUCKET",
+      "bucket_name": "my-bucket-name"
+    }
+  ]
+}
+```
+
+**wrangler.toml:**
+```toml
+[[r2_buckets]]
+binding = 'MY_BUCKET'
+bucket_name = 'my-bucket-name'
+```
+
+## TypeScript Types
+
+```typescript
+interface Env { MY_BUCKET: R2Bucket; }
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const object = await env.MY_BUCKET.get('file.txt');
+    return new Response(object?.body);
+  }
+}
+```
+
+## S3 SDK Setup
+
+```typescript
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+  credentials: {
+    accessKeyId: env.R2_ACCESS_KEY_ID,
+    secretAccessKey: env.R2_SECRET_ACCESS_KEY
+  }
+});
+
+await s3.send(new PutObjectCommand({
+  Bucket: 'my-bucket',
+  Key: 'file.txt',
+  Body: data,
+  StorageClass: 'STANDARD' // or 'STANDARD_IA'
+}));
+```
+
+## Location Hints
+
+```bash
+wrangler r2 bucket create my-bucket --location=enam
+
+# Hints: wnam, enam, weur, eeur, apac, oc
+# Jurisdictions (override hint): --jurisdiction=eu (or fedramp)
+```
+
+## Bucket Management
+
+```bash
+wrangler r2 bucket create my-bucket --location=enam --storage-class=Standard
+wrangler r2 bucket list
+wrangler r2 bucket info my-bucket
+wrangler r2 bucket delete my-bucket  # Must be empty
+wrangler r2 bucket update-storage-class my-bucket --storage-class=InfrequentAccess
+```

--- a/.agent/services/hosting/cloudflare-platform/references/r2/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2/gotchas.md
@@ -1,0 +1,94 @@
+# R2 Gotchas & Troubleshooting
+
+## List Truncation
+
+```typescript
+// ❌ WRONG: Don't compare object count when using include
+while (listed.objects.length < options.limit) { ... }
+
+// ✅ CORRECT: Always use truncated property
+while (listed.truncated) {
+  const next = await env.MY_BUCKET.list({ cursor: listed.cursor });
+  // ...
+}
+```
+
+**Reason:** `include` with metadata may return fewer objects per page to fit metadata.
+
+## ETag Format
+
+```typescript
+// ❌ WRONG: Using etag (unquoted) in headers
+headers.set('etag', object.etag); // Missing quotes
+
+// ✅ CORRECT: Use httpEtag (quoted)
+headers.set('etag', object.httpEtag);
+```
+
+## Checksum Limits
+
+Only ONE checksum algorithm allowed per PUT:
+
+```typescript
+// ❌ WRONG: Multiple checksums
+await env.MY_BUCKET.put(key, data, { md5: hash1, sha256: hash2 }); // Error
+
+// ✅ CORRECT: Pick one
+await env.MY_BUCKET.put(key, data, { sha256: hash });
+```
+
+## Multipart Requirements
+
+- All parts must be uniform size (except last part)
+- Part numbers start at 1 (not 0)
+- Uncompleted uploads auto-abort after 7 days
+- `resumeMultipartUpload` doesn't validate uploadId existence
+
+## Conditional Operations
+
+```typescript
+// Precondition failure returns object WITHOUT body
+const object = await env.MY_BUCKET.get(key, {
+  onlyIf: { etagMatches: '"wrong"' }
+});
+
+// Check for body, not just null
+if (!object) return new Response('Not found', { status: 404 });
+if (!object.body) return new Response(null, { status: 304 }); // Precondition failed
+```
+
+## Key Validation
+
+```typescript
+// ❌ DANGEROUS: Path traversal
+const key = url.pathname.slice(1); // Could be ../../../etc/passwd
+await env.MY_BUCKET.get(key);
+
+// ✅ SAFE: Validate keys
+if (!key || key.includes('..') || key.startsWith('/')) {
+  return new Response('Invalid key', { status: 400 });
+}
+```
+
+## Storage Class Pitfalls
+
+- InfrequentAccess: 30-day minimum billing (even if deleted early)
+- Can't transition IA → Standard via lifecycle (use S3 CopyObject)
+- Retrieval fees apply for IA reads
+
+## Limits
+
+| Limit | Value |
+|-------|-------|
+| Object size | 5 TB |
+| Multipart part count | 10,000 |
+| Batch delete | 1,000 keys |
+| List limit | 1,000 per request |
+| Key size | 1024 bytes |
+| Custom metadata | 2 KB per object |
+
+## Common Errors
+
+**"oldString not found"**: Object key doesn't exist  
+**List compatibility_date**: Set `compatibility_date >= 2022-08-04` or enable `r2_list_honor_include` flag  
+**Multipart part size**: Ensure uniform size except final part

--- a/.agent/services/hosting/cloudflare-platform/references/r2/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/r2/patterns.md
@@ -1,0 +1,127 @@
+# R2 Patterns & Best Practices
+
+## Streaming Large Files
+
+```typescript
+const object = await env.MY_BUCKET.get(key);
+if (!object) return new Response('Not found', { status: 404 });
+
+const headers = new Headers();
+object.writeHttpMetadata(headers);
+headers.set('etag', object.httpEtag);
+
+return new Response(object.body, { headers });
+```
+
+## Conditional GET (304 Not Modified)
+
+```typescript
+const ifNoneMatch = request.headers.get('if-none-match');
+const object = await env.MY_BUCKET.get(key, {
+  onlyIf: { etagDoesNotMatch: ifNoneMatch?.replace(/"/g, '') || '' }
+});
+
+if (!object) return new Response('Not found', { status: 404 });
+if (!object.body) return new Response(null, { status: 304, headers: { 'etag': object.httpEtag } });
+
+return new Response(object.body, { headers: { 'etag': object.httpEtag } });
+```
+
+## Upload with Validation
+
+```typescript
+const key = url.pathname.slice(1);
+if (!key || key.includes('..')) return new Response('Invalid key', { status: 400 });
+
+const object = await env.MY_BUCKET.put(key, request.body, {
+  httpMetadata: { contentType: request.headers.get('content-type') || 'application/octet-stream' },
+  customMetadata: { uploadedAt: new Date().toISOString(), ip: request.headers.get('cf-connecting-ip') || 'unknown' }
+});
+
+return Response.json({ key: object.key, size: object.size, etag: object.httpEtag });
+```
+
+## Multipart with Progress
+
+```typescript
+const PART_SIZE = 5 * 1024 * 1024; // 5MB
+const partCount = Math.ceil(file.size / PART_SIZE);
+const multipart = await env.MY_BUCKET.createMultipartUpload(key, { httpMetadata: { contentType: file.type } });
+
+const uploadedParts: R2UploadedPart[] = [];
+try {
+  for (let i = 0; i < partCount; i++) {
+    const start = i * PART_SIZE;
+    const part = await multipart.uploadPart(i + 1, file.slice(start, start + PART_SIZE));
+    uploadedParts.push(part);
+    onProgress?.(Math.round(((i + 1) / partCount) * 100));
+  }
+  return await multipart.complete(uploadedParts);
+} catch (error) {
+  await multipart.abort();
+  throw error;
+}
+```
+
+## Batch Delete
+
+```typescript
+async function deletePrefix(prefix: string, env: Env) {
+  let cursor: string | undefined;
+  let truncated = true;
+
+  while (truncated) {
+    const listed = await env.MY_BUCKET.list({ prefix, limit: 1000, cursor });
+    if (listed.objects.length > 0) {
+      await env.MY_BUCKET.delete(listed.objects.map(o => o.key));
+    }
+    truncated = listed.truncated;
+    cursor = listed.cursor;
+  }
+}
+```
+
+## Checksum Validation
+
+```typescript
+const hash = await crypto.subtle.digest('SHA-256', data);
+await env.MY_BUCKET.put(key, data, { sha256: hash });
+
+// Verify on retrieval
+const object = await env.MY_BUCKET.get(key);
+const retrievedHash = await crypto.subtle.digest('SHA-256', await object.arrayBuffer());
+const valid = object.checksums.sha256 && arrayBuffersEqual(retrievedHash, object.checksums.sha256);
+```
+
+## Storage Class Transitions
+
+```typescript
+// Use S3 SDK CopyObject to transition
+const s3 = new S3Client({...});
+await s3.send(new CopyObjectCommand({
+  Bucket: 'my-bucket',
+  Key: key,
+  CopySource: `/my-bucket/${key}`,
+  StorageClass: 'STANDARD_IA'
+}));
+```
+
+## Public Bucket with Custom Domain
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const key = new URL(request.url).pathname.slice(1);
+    const object = await env.MY_BUCKET.get(key);
+    if (!object) return new Response('Not found', { status: 404 });
+
+    const headers = new Headers();
+    object.writeHttpMetadata(headers);
+    headers.set('etag', object.httpEtag);
+    headers.set('access-control-allow-origin', '*');
+    headers.set('cache-control', 'public, max-age=31536000, immutable');
+
+    return new Response(object.body, { headers });
+  }
+};
+```

--- a/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/README.md
@@ -1,0 +1,21 @@
+# Cloudflare Realtime SFU Reference
+
+Expert guidance for building real-time audio/video/data applications using Cloudflare Realtime SFU (Selective Forwarding Unit).
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, environment variables, Wrangler config
+- **[api.md](./api.md)** - Sessions, tracks, endpoints, request/response patterns
+- **[patterns.md](./patterns.md)** - Architecture patterns, use cases, integration examples
+- **[gotchas.md](./gotchas.md)** - Common issues, debugging, performance, security
+
+## Quick Start
+
+Cloudflare Realtime SFU: WebRTC infrastructure on global network (310+ cities). Anycast routing, no regional constraints, pub/sub model.
+
+## See Also
+
+- [Orange Meets Demo](https://demo.orange.cloudflare.dev/)
+- [Orange Source](https://github.com/cloudflare/orange)
+- [Calls Examples](https://github.com/cloudflare/calls-examples)
+- [API Reference](https://developers.cloudflare.com/api/resources/calls/)

--- a/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/api.md
@@ -1,0 +1,135 @@
+# API Reference
+
+## Authentication
+
+```bash
+curl -X POST 'https://rtc.live/v1/apps/${CALLS_APP_ID}/sessions/new' \
+  -H "Authorization: Bearer ${CALLS_APP_SECRET}"
+```
+
+## Core Concepts
+
+**Sessions:** PeerConnection to Cloudflare edge  
+**Tracks:** Media/data channels (audio/video/datachannel)  
+**No rooms:** Build presence via track sharing
+
+## Endpoints
+
+### Create Session
+```http
+POST /v1/apps/{appId}/sessions/new
+→ {sessionId, sessionDescription}
+```
+
+### Add Track (Publish)
+```http
+POST /v1/apps/{appId}/sessions/{sessionId}/tracks/new
+Body: {
+  sessionDescription: {sdp, type: "offer"},
+  tracks: [{location: "local", trackName: "my-video"}]
+}
+→ {sessionDescription, tracks: [{trackName}]}
+```
+
+### Add Track (Subscribe)
+```http
+POST /v1/apps/{appId}/sessions/{sessionId}/tracks/new
+Body: {
+  tracks: [{
+    location: "remote",
+    trackName: "remote-track-id",
+    sessionId: "other-session-id"
+  }]
+}
+→ {sessionDescription} (server offer)
+```
+
+### Renegotiate
+```http
+PUT /v1/apps/{appId}/sessions/{sessionId}/renegotiate
+Body: {sessionDescription: {sdp, type: "answer"}}
+```
+
+### Close Tracks
+```http
+PUT /v1/apps/{appId}/sessions/{sessionId}/tracks/close
+Body: {tracks: [{trackName}]}
+```
+
+### Get Session
+```http
+GET /v1/apps/{appId}/sessions/{sessionId}
+```
+
+## WebRTC Flow
+
+```typescript
+// 1. Create PeerConnection
+const pc = new RTCPeerConnection({
+  iceServers: [{urls: 'stun:stun.cloudflare.com:3478'}]
+});
+
+// 2. Add tracks
+const stream = await navigator.mediaDevices.getUserMedia({video: true, audio: true});
+stream.getTracks().forEach(track => pc.addTrack(track, stream));
+
+// 3. Create offer
+const offer = await pc.createOffer();
+await pc.setLocalDescription(offer);
+
+// 4. Send to backend → Cloudflare API
+const response = await fetch('/api/new-session', {
+  method: 'POST',
+  body: JSON.stringify({sdp: offer.sdp})
+});
+
+// 5. Set remote answer
+const {sessionDescription} = await response.json();
+await pc.setRemoteDescription(sessionDescription);
+```
+
+## Publishing
+
+```typescript
+const offer = await pc.createOffer();
+await pc.setLocalDescription(offer);
+
+const res = await fetch(`/api/sessions/${sessionId}/tracks`, {
+  method: 'POST',
+  body: JSON.stringify({
+    sdp: offer.sdp,
+    tracks: [{location: 'local', trackName: 'my-video'}]
+  })
+});
+
+const {sessionDescription, tracks} = await res.json();
+await pc.setRemoteDescription(sessionDescription);
+const publishedTrackId = tracks[0].trackName; // Share with others
+```
+
+## Subscribing
+
+```typescript
+const res = await fetch(`/api/sessions/${sessionId}/tracks`, {
+  method: 'POST',
+  body: JSON.stringify({
+    tracks: [{location: 'remote', trackName: remoteTrackId, sessionId: remoteSessionId}]
+  })
+});
+
+const {sessionDescription} = await res.json();
+await pc.setRemoteDescription(sessionDescription);
+
+const answer = await pc.createAnswer();
+await pc.setLocalDescription(answer);
+
+await fetch(`/api/sessions/${sessionId}/renegotiate`, {
+  method: 'PUT',
+  body: JSON.stringify({sdp: answer.sdp})
+});
+
+pc.ontrack = (event) => {
+  const [remoteStream] = event.streams;
+  videoElement.srcObject = remoteStream;
+};
+```

--- a/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/configuration.md
@@ -1,0 +1,63 @@
+# Configuration & Deployment
+
+## Wrangler Setup
+
+```toml
+name = "my-calls-app"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[vars]
+CALLS_APP_ID = "your-app-id"
+MAX_WEBCAM_BITRATE = "1200000"
+MAX_WEBCAM_FRAMERATE = "24"
+MAX_WEBCAM_QUALITY_LEVEL = "1080"
+
+# Set secret: wrangler secret put CALLS_APP_SECRET
+
+[[durable_objects.bindings]]
+name = "ROOM"
+class_name = "Room"
+```
+
+## Deploy
+
+```bash
+wrangler login
+wrangler secret put CALLS_APP_SECRET
+wrangler deploy
+```
+
+## Environment Variables
+
+**Required:**
+- `CALLS_APP_ID`: From dashboard
+- `CALLS_APP_SECRET`: From dashboard (secret)
+
+**Optional:**
+- `MAX_WEBCAM_BITRATE` (default: 1200000)
+- `MAX_WEBCAM_FRAMERATE` (default: 24)
+- `MAX_WEBCAM_QUALITY_LEVEL` (default: 1080)
+- `TURN_SERVICE_ID`: TURN service
+- `TURN_SERVICE_TOKEN`: TURN auth (secret)
+
+## TURN Configuration
+
+```javascript
+const pc = new RTCPeerConnection({
+  iceServers: [
+    { urls: 'stun:stun.cloudflare.com:3478' },
+    {
+      urls: [
+        'turn:turn.cloudflare.com:3478?transport=udp',
+        'turn:turn.cloudflare.com:3478?transport=tcp',
+        'turns:turn.cloudflare.com:5349?transport=tcp'
+      ],
+      username: turnUsername,
+      credential: turnCredential
+    }
+  ]
+});
+```
+
+**Ports:** 3478 (UDP/TCP), 53 (UDP), 80 (TCP), 443 (TLS), 5349 (TLS)

--- a/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/gotchas.md
@@ -1,0 +1,75 @@
+# Gotchas & Troubleshooting
+
+## Common Issues
+
+**Slow connect (~1.8s):** First STUN delayed (consensus forming), normal, subsequent faster
+**USE-CANDIDATE delay (Chrome):** CF detects DTLS ClientHello early to compensate
+
+**No media flow checklist:**
+1. SDP exchange done? 2. `pc.connectionState === 'connected'`? 3. Tracks added before offer? 4. Browser perms? 5. `chrome://webrtc-internals`
+
+**Track not RX checklist:**
+1. Published OK? 2. Track ID shared? 3. Session IDs match? 4. `pc.ontrack` before answer? 5. Renegotiation done?
+
+## Debug
+
+`chrome://webrtc-internals`: ICE pairs, DTLS, media stats, bandwidth
+
+Logging:
+```ts
+pc.addEventListener('icecandidateerror', (e) => console.error('ICE err:', e));
+pc.addEventListener('connectionstatechange', () => console.log('Conn:', pc.connectionState));
+pc.addEventListener('iceconnectionstatechange', () => console.log('ICE:', pc.iceConnectionState));
+```
+
+Quality:
+```ts
+setInterval(async () => {
+  const stats = await pc.getStats();
+  stats.forEach(r => {
+    if (r.type === 'inbound-rtp' && r.kind === 'video')
+      console.log('Loss:', r.packetsLost, 'Jitter:', r.jitter, 'Bytes:', r.bytesReceived);
+  });
+}, 1000);
+```
+
+## Security
+
+❌ Never expose App Secret client-side (use backend env vars, Wrangler secrets)
+Track IDs = capabilities, authz required:
+```ts
+app.post('/api/sessions/:sid/tracks', async (req, res) => {
+  for (const t of req.body.tracks)
+    if (!await canAccessTrack(req.user.id, t.trackName)) return res.status(403).json({error: 'Unauth'});
+  // CF API call
+});
+```
+Validate session ownership, timeouts, cleanup abandoned
+
+## Pricing & Limits
+
+Free: 1TB/mo egress. Paid: $0.05/GB. Inbound free. TURN free w/SFU. No participant/track limits (client bandwidth/CPU bound). Optimize: bitrates, simulcast, adaptive, cleanup
+
+## vs Traditional SFUs
+
+| Aspect | Traditional | Cloudflare |
+|--------|------------|------------|
+| Deploy | Single region | 310+ DCs |
+| Route | Manual | Anycast |
+| SDK | Often required | Pure WebRTC |
+| Arch | Rooms | Sessions/tracks |
+| Scale | Vertical/horiz | Auto global |
+| TURN | Separate | Integrated |
+| State | Centralized | Distributed |
+
+## Quick Ref
+
+```bash
+POST /v1/apps/{appId}/sessions/new  # Create
+POST .../sessions/{sid}/tracks/new  # Pub: {sessionDescription, tracks: [{location:'local',trackName}]}
+POST .../sessions/{sid}/tracks/new  # Sub: {tracks:[{location:'remote',trackName,sessionId}]}
+PUT .../sessions/{sid}/renegotiate  # Renegotiate
+PUT .../sessions/{sid}/tracks/close # Close
+```
+
+CF SFU: unopinionated, full WebRTC control, max flexibility, needs fundamentals

--- a/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtime-sfu/patterns.md
@@ -1,0 +1,102 @@
+# Patterns & Use Cases
+
+## Architecture
+
+```
+Client (WebRTC) <---> CF Edge <---> Backend (HTTP)
+                           |
+                    CF Backbone (310+ DCs)
+                           |
+                    Other Edges <---> Other Clients
+```
+
+Anycast: Last-mile <50ms (95%), no region select, NACK shield, distributed consensus
+
+Cascading trees auto-scale to millions:
+```
+Publisher -> Edge A -> Edge B -> Sub1
+                    \-> Edge C -> Sub2,3
+```
+
+## Use Cases
+
+**1:1:** A creates session+publishes, B creates+subscribes to A+publishes, A subscribes to B
+**N:N:** All create session+publish, backend broadcasts track IDs, all subscribe to others
+**1:N:** Publisher creates+publishes, viewers each create+subscribe (no fan-out limit)
+**Breakout:** Same PeerConnection! Backend closes/adds tracks, no recreation
+
+## Backend
+
+Express:
+```js
+app.post('/api/new-session', async (req, res) => {
+  const r = await fetch(`${CALLS_API}/apps/${process.env.CALLS_APP_ID}/sessions/new`,
+    {method: 'POST', headers: {'Authorization': `Bearer ${process.env.CALLS_APP_SECRET}`}});
+  res.json(await r.json());
+});
+```
+
+Workers:
+```ts
+export default {
+  async fetch(req: Request, env: Env) {
+    return fetch(`https://rtc.live/v1/apps/${env.CALLS_APP_ID}/sessions/new`,
+      {method: 'POST', headers: {'Authorization': `Bearer ${env.CALLS_APP_SECRET}`}});
+  }
+};
+```
+
+DO Presence:
+```ts
+export class Room {
+  sessions = new Map(); // sessionId -> {userId, tracks: [{trackName, kind}]}
+
+  async fetch(req: Request) {
+    const {pathname} = new URL(req.url);
+    if (pathname === '/join') {
+      const {sessionId, userId} = await req.json();
+      this.sessions.set(sessionId, {userId, tracks: []});
+      const existingTracks = Array.from(this.sessions.entries())
+        .filter(([id]) => id !== sessionId)
+        .flatMap(([id, data]) => data.tracks.map(t => ({...t, sessionId: id})));
+      return Response.json({existingTracks});
+    }
+    if (pathname === '/publish') {
+      const {sessionId, tracks} = await req.json();
+      this.sessions.get(sessionId)?.tracks.push(...tracks); // Notify others via WS
+      return new Response('OK');
+    }
+  }
+}
+```
+
+## Advanced
+
+Bandwidth mgmt:
+```ts
+const s = pc.getSenders().find(s => s.track?.kind === 'video');
+const p = s.getParameters();
+if (!p.encodings) p.encodings = [{}];
+p.encodings[0].maxBitrate = 1200000; p.encodings[0].maxFramerate = 24;
+await s.setParameters(p);
+```
+
+Simulcast (CF auto-forwards best layer):
+```ts
+pc.addTransceiver('video', {direction: 'sendonly', sendEncodings: [
+  {rid: 'high', maxBitrate: 1200000},
+  {rid: 'med', maxBitrate: 600000, scaleResolutionDownBy: 2},
+  {rid: 'low', maxBitrate: 200000, scaleResolutionDownBy: 4}
+]});
+```
+
+DataChannel:
+```ts
+const dc = pc.createDataChannel('chat', {ordered: true, maxRetransmits: 3});
+dc.onopen = () => dc.send(JSON.stringify({type: 'chat', text: 'Hi'}));
+dc.onmessage = (e) => console.log('RX:', JSON.parse(e.data));
+```
+
+Integrations: R2 for recording `env.R2_BUCKET.put(...)`, Queues for analytics
+
+Perf: 100-250ms connect, ~50ms latency (95%), 200-400ms glass-to-glass, no participant limit (client: 10-50 tracks)

--- a/.agent/services/hosting/cloudflare-platform/references/realtimekit/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtimekit/README.md
@@ -1,0 +1,81 @@
+# Cloudflare RealtimeKit
+
+Expert guidance for building real-time video and audio applications using **Cloudflare RealtimeKit** - a comprehensive SDK suite for adding customizable live video and voice to web or mobile applications.
+
+## Overview
+
+RealtimeKit is Cloudflare's SDK suite built on Realtime SFU, abstracting WebRTC complexity with fast integration, pre-built UI components, global performance (300+ cities), and production features (recording, transcription, chat, polls).
+
+**Use cases**: Team meetings, webinars, social video, audio calls, interactive plugins
+
+## Core Concepts
+
+- **App**: Workspace grouping meetings, participants, presets, recordings. Use separate Apps for staging/production
+- **Meeting**: Re-usable virtual room. Each join creates new **Session**
+- **Session**: Live meeting instance. Created on first join, ends after last leave
+- **Participant**: User added via REST API. Returns `authToken` for client SDK. **Do not reuse tokens**
+- **Preset**: Reusable permission/UI template (permissions, meeting type, theme). Applied at participant creation
+- **Peer ID** (`id`): Unique per session, changes on rejoin
+- **Participant ID** (`userId`): Persistent across sessions
+
+## Quick Start
+
+### 1. Create App & Meeting (Backend)
+
+```bash
+# Create app
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtime/kit/apps' \
+  -H 'Authorization: Bearer <api_token>' \
+  -d '{"name": "My RealtimeKit App"}'
+
+# Create meeting
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtime/kit/<app_id>/meetings' \
+  -H 'Authorization: Bearer <api_token>' \
+  -d '{"title": "Team Standup"}'
+
+# Add participant
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtime/kit/<app_id>/meetings/<meeting_id>/participants' \
+  -H 'Authorization: Bearer <api_token>' \
+  -d '{"name": "Alice", "preset_name": "host"}'
+# Returns: { authToken }
+```
+
+### 2. Client Integration
+
+**React**:
+```tsx
+import { RtkMeeting } from '@cloudflare/realtimekit-react-ui';
+
+function App() {
+  return <RtkMeeting authToken="<participant_auth_token>" onLeave={() => {}} />;
+}
+```
+
+**Core SDK**:
+```typescript
+import RealtimeKitClient from '@cloudflare/realtimekit';
+
+const meeting = new RealtimeKitClient({ authToken: '<token>', video: true, audio: true });
+await meeting.join();
+```
+
+## In This Reference
+
+- [Configuration](./configuration.md) - Setup, installation, wrangler config
+- [API](./api.md) - Meeting object, REST API, SDK methods
+- [Patterns](./patterns.md) - Common workflows, code examples
+- [Gotchas](./gotchas.md) - Common issues, troubleshooting
+
+## See Also
+
+- [Workers](../workers/) - Backend integration
+- [D1](../d1/) - Meeting metadata storage
+- [R2](../r2/) - Recording storage
+- [KV](../kv/) - Session management
+
+## Reference Links
+
+- **Official Docs**: https://developers.cloudflare.com/realtime/realtimekit/
+- **API Reference**: https://developers.cloudflare.com/api/resources/realtime_kit/
+- **Examples**: https://github.com/cloudflare/realtimekit-web-examples
+- **Dashboard**: https://dash.cloudflare.com/?to=/:account/realtime/kit

--- a/.agent/services/hosting/cloudflare-platform/references/realtimekit/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtimekit/api.md
@@ -1,0 +1,164 @@
+# RealtimeKit API Reference
+
+Complete API reference for Meeting object, REST endpoints, and SDK methods.
+
+## Meeting Object API
+
+### `meeting.self` - Local Participant
+
+```typescript
+// Properties: id, userId, name, audioEnabled, videoEnabled, screenShareEnabled, audioTrack, videoTrack, screenShareTracks, roomJoined, roomState
+// Methods
+await meeting.self.enableAudio() / disableAudio() / enableVideo() / disableVideo() / enableScreenShare() / disableScreenShare()
+await meeting.self.setName("Name")  // Before join only
+await meeting.self.setDevice(device)
+const devices = await meeting.self.getAllDevices() / getAudioDevices() / getVideoDevices() / getSpeakerDevices()
+// Events: 'roomJoined', 'audioUpdate', 'videoUpdate', 'screenShareUpdate', 'deviceUpdate', 'deviceListUpdate'
+meeting.self.on('roomJoined', () => {})
+meeting.self.on('audioUpdate', ({ audioEnabled, audioTrack }) => {})
+```
+
+### `meeting.participants` - Remote Participants
+
+**Collections**:
+```typescript
+meeting.participants.joined / active / waitlisted / pinned  // Maps
+const participants = meeting.participants.joined.toArray()
+const count = meeting.participants.joined.size()
+const p = meeting.participants.joined.get('peer-id')
+```
+
+**Participant Properties**:
+```typescript
+participant.id / userId / name
+participant.audioEnabled / videoEnabled / screenShareEnabled
+participant.audioTrack / videoTrack / screenShareTracks
+```
+
+**Events**:
+```typescript
+meeting.participants.joined.on('participantJoined', (participant) => {})
+meeting.participants.joined.on('participantLeft', (participant) => {})
+```
+
+### `meeting.meta` - Metadata
+```typescript
+meeting.meta.meetingId / meetingTitle / meetingStartedTimestamp
+```
+
+### `meeting.chat` - Chat
+```typescript
+meeting.chat.messages  // Array
+await meeting.chat.sendTextMessage("Hello") / sendImageMessage(file)
+meeting.chat.on('chatUpdate', ({ message, messages }) => {})
+```
+
+### `meeting.polls` - Polling
+```typescript
+meeting.polls.items  // Array
+await meeting.polls.create(question, options, anonymous, hideVotes)
+await meeting.polls.vote(pollId, optionIndex)
+```
+
+### `meeting.plugins` - Collaborative Apps
+```typescript
+meeting.plugins.all  // Array
+await meeting.plugins.activate(pluginId) / deactivate()
+```
+
+### `meeting.ai` - AI Features
+```typescript
+meeting.ai.transcripts  // Live transcriptions (when enabled in Preset)
+```
+
+### Core Methods
+```typescript
+await meeting.join()   // Emits 'roomJoined' on meeting.self
+await meeting.leave()
+```
+
+## REST API
+
+Base: `https://api.cloudflare.com/client/v4/accounts/{account_id}/realtime/kit/{app_id}`
+
+### Meetings
+```bash
+GET    /meetings                                    # List all
+GET    /meetings/{meeting_id}                       # Get details
+POST   /meetings                                    # Create: {"title": "..."}
+PATCH  /meetings/{meeting_id}                       # Update: {"title": "...", "record_on_start": true}
+```
+
+### Participants
+```bash
+GET    /meetings/{meeting_id}/participants                          # List all
+GET    /meetings/{meeting_id}/participants/{participant_id}         # Get details
+POST   /meetings/{meeting_id}/participants                          # Add: {"name": "...", "preset_name": "...", "custom_participant_id": "..."}
+PATCH  /meetings/{meeting_id}/participants/{participant_id}         # Update: {"name": "...", "preset_name": "..."}
+DELETE /meetings/{meeting_id}/participants/{participant_id}         # Delete
+POST   /meetings/{meeting_id}/participants/{participant_id}/token   # Refresh token
+```
+
+### Active Session
+```bash
+GET  /meetings/{meeting_id}/active-session               # Get active session
+POST /meetings/{meeting_id}/active-session/kick          # Kick users: {"user_ids": ["id1", "id2"]}
+POST /meetings/{meeting_id}/active-session/kick-all      # Kick all
+POST /meetings/{meeting_id}/active-session/poll          # Create poll: {"question": "...", "options": [...], "anonymous": false}
+```
+
+### Recording
+```bash
+GET  /recordings?meeting_id={meeting_id}                 # List recordings
+GET  /recordings/active-recording/{meeting_id}           # Get active recording
+POST /recordings                                         # Start: {"meeting_id": "...", "type": "composite"} (or "track")
+PUT  /recordings/{recording_id}                          # Control: {"action": "pause"} (or "resume", "stop")
+POST /recordings/track                                   # Track recording: {"meeting_id": "...", "layers": [...]}
+```
+
+### Livestreaming
+```bash
+GET  /livestreams?exclude_meetings=false                                # List all
+GET  /livestreams/{livestream_id}                                       # Get details
+POST /meetings/{meeting_id}/livestreams                                 # Start for meeting
+POST /meetings/{meeting_id}/active-livestream/stop                      # Stop
+POST /livestreams                                                       # Create independent: returns {ingest_server, stream_key, playback_url}
+```
+
+### Sessions & Analytics
+```bash
+GET  /sessions                                                          # List all
+GET  /sessions/{session_id}                                             # Get details
+GET  /sessions/{session_id}/participants                                # List participants
+GET  /sessions/{session_id}/participants/{participant_id}               # Call stats
+GET  /sessions/{session_id}/chat                                        # Download chat CSV
+GET  /sessions/{session_id}/transcript                                  # Download transcript CSV
+GET  /sessions/{session_id}/summary                                     # Get summary
+POST /sessions/{session_id}/summary                                     # Generate summary
+GET  /analytics/daywise?start_date=YYYY-MM-DD&end_date=YYYY-MM-DD      # Day-wise analytics
+GET  /analytics/livestreams/overall                                     # Livestream analytics
+```
+
+### Webhooks
+```bash
+GET    /webhooks                    # List all
+POST   /webhooks                    # Create: {"url": "https://...", "events": ["session.started", "session.ended"]}
+PATCH  /webhooks/{webhook_id}       # Update
+DELETE /webhooks/{webhook_id}       # Delete
+```
+
+## Session Lifecycle
+
+```
+Initialization → Join Intent → [Waitlist?] → Meeting Screen (Stage) → Ended
+                                   ↓ Approved
+                               [Rejected → Ended]
+```
+
+UI Kit handles state transitions automatically.
+
+## See Also
+
+- [Configuration](./configuration.md) - Setup and installation
+- [Patterns](./patterns.md) - Usage examples
+- [README](./README.md) - Overview and quick start

--- a/.agent/services/hosting/cloudflare-platform/references/realtimekit/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtimekit/configuration.md
@@ -1,0 +1,147 @@
+# RealtimeKit Configuration
+
+Configuration guide for RealtimeKit setup, client SDKs, and wrangler integration.
+
+## Installation
+
+### React
+```bash
+npm install @cloudflare/realtimekit @cloudflare/realtimekit-react-ui
+```
+
+### Angular
+```bash
+npm install @cloudflare/realtimekit @cloudflare/realtimekit-angular-ui
+```
+
+### Web Components/HTML
+```bash
+npm install @cloudflare/realtimekit @cloudflare/realtimekit-ui
+```
+
+## Client SDK Configuration
+
+### React UI Kit
+```tsx
+import { RtkMeeting } from '@cloudflare/realtimekit-react-ui';
+<RtkMeeting authToken="<token>" onLeave={() => {}} />
+```
+
+### Angular UI Kit
+```typescript
+@Component({ template: `<rtk-meeting [authToken]="authToken" (rtkLeave)="onLeave($event)"></rtk-meeting>` })
+export class AppComponent { authToken = '<token>'; onLeave() {} }
+```
+
+### Web Components
+```html
+<script type="module" src="https://cdn.jsdelivr.net/npm/@cloudflare/realtimekit-ui/dist/realtimekit-ui/realtimekit-ui.esm.js"></script>
+<rtk-meeting id="meeting"></rtk-meeting>
+<script>
+  document.getElementById('meeting').authToken = '<token>';
+</script>
+```
+
+### Core SDK Configuration
+```typescript
+import RealtimeKitClient from '@cloudflare/realtimekit';
+
+const meeting = new RealtimeKitClient({
+  authToken: '<token>',
+  video: true, audio: true, autoSwitchAudioDevice: true,
+  mediaConfiguration: {
+    video: { width: { ideal: 1280 }, height: { ideal: 720 }, frameRate: { ideal: 30 } },
+    audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+    screenshare: { width: { max: 1920 }, height: { max: 1080 }, frameRate: { ideal: 15 } }
+  }
+});
+await meeting.join();
+```
+
+## Backend Setup
+
+### Create App & Credentials
+
+**Dashboard**: https://dash.cloudflare.com/?to=/:account/realtime/kit
+
+**API**:
+```bash
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtime/kit/apps' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <api_token>' \
+  -d '{"name": "My RealtimeKit App"}'
+```
+
+**Required Permissions**: API token with **Realtime / Realtime Admin** permissions
+
+### Create Presets
+
+```bash
+curl -X POST 'https://api.cloudflare.com/client/v4/accounts/<account_id>/realtime/kit/<app_id>/presets' \
+  -H 'Authorization: Bearer <api_token>' \
+  -d '{
+    "name": "host",
+    "permissions": {
+      "canShareAudio": true,
+      "canShareVideo": true,
+      "canRecord": true,
+      "canLivestream": true,
+      "canStartStopRecording": true
+    }
+  }'
+```
+
+## Wrangler Configuration
+
+### Basic Configuration
+```jsonc
+// wrangler.jsonc
+{
+  "name": "realtimekit-app",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-01-01",  // Use current date
+  "vars": {
+    "CLOUDFLARE_ACCOUNT_ID": "abc123",
+    "REALTIMEKIT_APP_ID": "xyz789"
+  }
+  // Secrets: wrangler secret put CLOUDFLARE_API_TOKEN
+}
+```
+
+### With Database & Storage
+```jsonc
+{
+  "d1_databases": [{ "binding": "DB", "database_name": "meetings", "database_id": "d1-id" }],
+  "r2_buckets": [{ "binding": "RECORDINGS", "bucket_name": "recordings" }],
+  "kv_namespaces": [{ "binding": "SESSIONS", "id": "kv-id" }]
+}
+```
+
+### Multi-Environment
+```bash
+# Deploy to environments
+wrangler deploy --env staging
+wrangler deploy --env production
+```
+
+## TURN Service Configuration
+
+RealtimeKit can use Cloudflare's TURN service for connectivity through restrictive networks:
+
+```jsonc
+// wrangler.jsonc
+{
+  "vars": {
+    "TURN_SERVICE_ID": "your_turn_service_id"
+  }
+  // Set secret: wrangler secret put TURN_SERVICE_TOKEN
+}
+```
+
+TURN automatically configured when enabled in account - no client-side changes needed.
+
+## See Also
+
+- [API](./api.md) - Meeting APIs, REST endpoints
+- [Patterns](./patterns.md) - Backend integration examples
+- [README](./README.md) - Overview and quick start

--- a/.agent/services/hosting/cloudflare-platform/references/realtimekit/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtimekit/gotchas.md
@@ -1,0 +1,172 @@
+# RealtimeKit Gotchas & Troubleshooting
+
+## Common Issues
+
+### Issue: Cannot connect to meeting
+**Causes**:
+- Auth token invalid or expired
+- API credentials lack correct permissions
+- Network blocks WebRTC traffic (firewall/proxy)
+
+**Solutions**:
+- Verify token validity
+- Check API token has **Realtime / Realtime Admin** permissions
+- Enable TURN service for restrictive networks
+
+### Issue: No video/audio tracks
+**Causes**:
+- Browser permissions not granted
+- `video: true, audio: true` not set in initialization
+- Device in use by another app
+- Device not available
+
+**Solutions**:
+- Request browser permissions explicitly
+- Verify initialization config
+- Use `meeting.self.getAllDevices()` to debug device availability
+- Close other apps using the device
+
+### Issue: Participant count mismatched
+**Cause**: `meeting.participants` doesn't include `meeting.self`
+
+**Solution**: Total count = `meeting.participants.joined.size() + 1`
+
+### Issue: Events not firing
+**Causes**:
+- Event listeners registered after actions occur
+- Incorrect event name spelling
+- Wrong namespace (e.g., `meeting.self` vs `meeting.participants`)
+
+**Solutions**:
+- Register listeners before calling `meeting.join()`
+- Check event names against API documentation
+- Verify correct namespace for events
+
+### Issue: CORS errors in API calls
+**Cause**: Making REST API calls from client-side
+
+**Solution**: All REST API calls **must** be server-side (Workers, backend). Never expose API tokens to clients.
+
+### Issue: Preset not applying
+**Causes**:
+- Preset doesn't exist in App
+- `preset_name` doesn't match exactly (case-sensitive)
+- Participant created before preset
+
+**Solutions**:
+- Verify preset exists via Dashboard or API
+- Check exact spelling and case
+- Create preset before adding participants
+
+### Issue: Token reuse errors
+**Cause**: Reusing participant tokens across sessions
+
+**Solution**: Generate fresh token per session. Use refresh endpoint if token expires during session.
+
+### Issue: Video quality poor
+**Causes**:
+- Network bandwidth insufficient
+- Resolution/bitrate too high for connection
+- CPU overload
+
+**Solutions**:
+- Lower `mediaConfiguration.video` resolution/frameRate
+- Monitor network conditions
+- Reduce participant count or grid size
+
+### Issue: Echo or audio feedback
+**Cause**: Multiple devices picking up same audio source
+
+**Solutions**:
+- Enable `echoCancellation: true` in `mediaConfiguration.audio`
+- Use headphones
+- Mute when not speaking
+
+### Issue: Screen share not working
+**Causes**:
+- Browser doesn't support screen sharing API
+- Permission denied by user
+- Wrong `displaySurface` configuration
+
+**Solutions**:
+- Use Chrome/Edge/Firefox (Safari limited support)
+- Check browser permissions
+- Try different `displaySurface` values ('window', 'monitor', 'browser')
+
+## Limits
+
+| Resource | Limit |
+|----------|-------|
+| Max participants per session | 100 |
+| Max concurrent sessions per App | 1000 |
+| Max recording duration | 6 hours |
+| Max meeting duration | 24 hours |
+| Max chat message length | 4000 characters |
+| Max preset name length | 64 characters |
+| Max meeting title length | 256 characters |
+| Max participant name length | 256 characters |
+| Token expiration | 24 hours (default) |
+| WebRTC ports required | UDP 1024-65535 |
+
+## Network Requirements
+
+### Firewall Rules
+Allow outbound UDP/TCP to:
+- `*.cloudflare.com` ports 443, 80
+- UDP ports 1024-65535 (WebRTC media)
+
+### TURN Service
+Enable for users behind restrictive firewalls/proxies:
+```jsonc
+// wrangler.jsonc
+{
+  "vars": {
+    "TURN_SERVICE_ID": "your_turn_service_id"
+  }
+  // Set secret: wrangler secret put TURN_SERVICE_TOKEN
+}
+```
+
+TURN automatically configured in SDK when enabled in account.
+
+## Debugging Tips
+
+```typescript
+// Check devices
+const devices = await meeting.self.getAllDevices();
+meeting.self.on('deviceListUpdate', ({ added, removed, devices }) => console.log('Devices:', { added, removed, devices }));
+
+// Monitor participants
+meeting.participants.joined.on('participantJoined', (p) => console.log(`${p.name} joined:`, { id: p.id, userId: p.userId, audioEnabled: p.audioEnabled, videoEnabled: p.videoEnabled }));
+
+// Check room state
+meeting.self.on('roomJoined', () => console.log('Room:', { meetingId: meeting.meta.meetingId, meetingTitle: meeting.meta.meetingTitle, participantCount: meeting.participants.joined.size() + 1, audioEnabled: meeting.self.audioEnabled, videoEnabled: meeting.self.videoEnabled }));
+
+// Log all events
+['roomJoined', 'audioUpdate', 'videoUpdate', 'screenShareUpdate', 'deviceUpdate', 'deviceListUpdate'].forEach(event => meeting.self.on(event, (data) => console.log(`[self] ${event}:`, data)));
+['participantJoined', 'participantLeft'].forEach(event => meeting.participants.joined.on(event, (data) => console.log(`[participants] ${event}:`, data)));
+meeting.chat.on('chatUpdate', (data) => console.log('[chat] chatUpdate:', data));
+```
+
+## Security & Performance
+
+### Security: Do NOT
+- Expose `CLOUDFLARE_API_TOKEN` in client code, hardcode credentials in frontend
+- Reuse participant tokens, store tokens in localStorage without encryption
+- Allow client-side meeting creation
+
+### Security: DO
+- Generate tokens server-side only, use HTTPS, implement rate limiting
+- Validate user auth before generating tokens, use `custom_participant_id` to map to your user system
+- Set appropriate preset permissions per user role, rotate API tokens regularly
+
+### Performance
+- **CPU**: Lower video resolution/frameRate, disable video for audio-only, use `meeting.participants.active` for large meetings, implement virtual scrolling
+- **Bandwidth**: Set max resolution in `mediaConfiguration`, disable screenshare audio if unneeded, use audio-only mode, implement adaptive bitrate
+- **Memory**: Clean up event listeners on unmount, call `meeting.leave()` when done, don't store large participant arrays
+
+## In This Reference
+- [README.md](./README.md) - Overview, core concepts, quick start
+- [configuration.md](./configuration.md) - SDK config, presets, wrangler setup
+- [api.md](./api.md) - Client SDK APIs, REST endpoints
+- [patterns.md](./patterns.md) - Common patterns, React hooks, backend integration

--- a/.agent/services/hosting/cloudflare-platform/references/realtimekit/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/realtimekit/patterns.md
@@ -1,0 +1,155 @@
+# RealtimeKit Patterns
+
+## UI Kit (Minimal Code)
+
+```tsx
+// React
+import { RtkMeeting } from '@cloudflare/realtimekit-react-ui';
+<RtkMeeting authToken="<token>" onLeave={() => console.log('Left')} />
+
+// Angular
+@Component({ template: `<rtk-meeting [authToken]="authToken" (rtkLeave)="onLeave($event)"></rtk-meeting>` })
+export class AppComponent { authToken = '<token>'; onLeave(event: unknown) {} }
+
+// HTML/Web Components
+<script type="module" src="https://cdn.jsdelivr.net/npm/@cloudflare/realtimekit-ui/dist/realtimekit-ui/realtimekit-ui.esm.js"></script>
+<rtk-meeting id="meeting"></rtk-meeting>
+<script>document.getElementById('meeting').authToken = '<token>';</script>
+```
+
+## Core SDK Patterns
+
+### Basic Setup
+```typescript
+import RealtimeKitClient from '@cloudflare/realtimekit';
+
+const meeting = new RealtimeKitClient({ authToken, video: true, audio: true });
+meeting.self.on('roomJoined', () => console.log('Joined:', meeting.meta.meetingTitle));
+meeting.participants.joined.on('participantJoined', (p) => console.log(`${p.name} joined`));
+await meeting.join();
+```
+
+### Video Grid (React)
+```typescript
+function VideoGrid({ meeting }) {
+  const [participants, setParticipants] = useState([]);
+  useEffect(() => {
+    const update = () => setParticipants(meeting.participants.joined.toArray());
+    meeting.participants.joined.on('participantJoined', update);
+    meeting.participants.joined.on('participantLeft', update);
+    update();
+    return () => { meeting.participants.joined.off('participantJoined', update); meeting.participants.joined.off('participantLeft', update); };
+  }, [meeting]);
+  return <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))' }}>
+    {participants.map(p => <VideoTile key={p.id} participant={p} />)}
+  </div>;
+}
+
+function VideoTile({ participant }) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  useEffect(() => {
+    if (videoRef.current && participant.videoTrack) videoRef.current.srcObject = new MediaStream([participant.videoTrack]);
+  }, [participant.videoTrack]);
+  return <div><video ref={videoRef} autoPlay playsInline muted /><div>{participant.name}</div></div>;
+}
+```
+
+### Device Selection & Chat
+```typescript
+// Device selection
+const devices = await meeting.self.getAllDevices();
+const audioInputs = devices.filter(d => d.kind === 'audioinput');
+const videoInputs = devices.filter(d => d.kind === 'videoinput');
+meeting.self.on('deviceListUpdate', ({ added, removed }) => console.log('Devices:', { added, removed }));
+const switchCamera = (deviceId: string) => { const d = devices.find(x => x.deviceId === deviceId); if (d) await meeting.self.setDevice(d); };
+
+// Chat component
+function ChatComponent({ meeting }) {
+  const [messages, setMessages] = useState(meeting.chat.messages);
+  const [input, setInput] = useState('');
+  useEffect(() => {
+    const handleUpdate = ({ messages }) => setMessages(messages);
+    meeting.chat.on('chatUpdate', handleUpdate);
+    return () => meeting.chat.off('chatUpdate', handleUpdate);
+  }, [meeting]);
+  const send = async () => { if (input.trim()) { await meeting.chat.sendTextMessage(input); setInput(''); } };
+  return <div><div>{messages.map((msg, i) => <div key={i}><strong>{msg.senderName}:</strong> {msg.text}</div>)}</div><input value={input} onChange={e => setInput(e.target.value)} onKeyPress={e => e.key === 'Enter' && send()} /><button onClick={send}>Send</button></div>;
+}
+
+// Custom hook
+export function useMeeting(authToken: string) {
+  const [meeting, setMeeting] = useState<RealtimeKitClient | null>(null);
+  const [joined, setJoined] = useState(false);
+  const [participants, setParticipants] = useState([]);
+  useEffect(() => {
+    const client = new RealtimeKitClient({ authToken });
+    client.self.on('roomJoined', () => setJoined(true));
+    const update = () => setParticipants(client.participants.joined.toArray());
+    client.participants.joined.on('participantJoined', update);
+    client.participants.joined.on('participantLeft', update);
+    setMeeting(client);
+    return () => { client.leave(); };
+  }, [authToken]);
+  return { meeting, joined, participants, join: async () => meeting?.join(), leave: async () => meeting?.leave() };
+}
+```
+
+## Backend Integration
+
+### Token Generation (Express)
+```typescript
+app.post('/api/join-meeting', async (req, res) => {
+  const { meetingId, userName, presetName } = req.body;
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${process.env.ACCOUNT_ID}/realtime/kit/${process.env.APP_ID}/meetings/${meetingId}/participants`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${process.env.CLOUDFLARE_API_TOKEN}` },
+      body: JSON.stringify({ name: userName, preset_name: presetName, custom_participant_id: req.user.id })
+    }
+  );
+  const data = await response.json();
+  res.json({ authToken: data.result.authToken });
+});
+```
+
+### Workers Integration
+```typescript
+export interface Env { CLOUDFLARE_API_TOKEN: string; CLOUDFLARE_ACCOUNT_ID: string; REALTIMEKIT_APP_ID: string; }
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (new URL(request.url).pathname === '/api/create-meeting') {
+      return fetch(`https://api.cloudflare.com/client/v4/accounts/${env.CLOUDFLARE_ACCOUNT_ID}/realtime/kit/${env.REALTIMEKIT_APP_ID}/meetings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${env.CLOUDFLARE_API_TOKEN}` },
+        body: JSON.stringify({ title: 'Team Meeting' })
+      });
+    }
+    return new Response('Not found', { status: 404 });
+  }
+};
+```
+
+## Best Practices
+
+### Security
+1. **Never expose API tokens client-side** - Generate participant tokens server-side only
+2. **Don't reuse participant tokens** - Generate fresh token per session, use refresh endpoint if expired
+3. **Use custom participant IDs** - Map to your user system for cross-session tracking
+
+### Performance
+1. **Event-driven updates** - Listen to events, don't poll. Use `toArray()` only when needed
+2. **Media quality constraints** - Set appropriate resolution/bitrate limits based on network conditions
+3. **Device management** - Enable `autoSwitchAudioDevice` for better UX, handle device list updates
+
+### Architecture
+1. **Separate Apps for environments** - staging vs production to prevent data mixing
+2. **Preset strategy** - Create presets at App level, reuse across meetings
+3. **Token management** - Backend generates tokens, frontend receives via authenticated endpoint
+
+## In This Reference
+- [README.md](./README.md) - Overview, core concepts, quick start
+- [configuration.md](./configuration.md) - SDK config, presets, wrangler setup
+- [api.md](./api.md) - Client SDK APIs, REST endpoints
+- [gotchas.md](./gotchas.md) - Common issues, troubleshooting, limits

--- a/.agent/services/hosting/cloudflare-platform/references/sandbox/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/sandbox/README.md
@@ -1,0 +1,90 @@
+# Cloudflare Sandbox SDK
+
+Secure isolated code execution in containers on Cloudflare's edge. Run untrusted code, manage files, expose services, integrate with AI agents.
+
+**Use cases**: AI code execution, interactive dev environments, data analysis, CI/CD, code interpreters, multi-tenant execution.
+
+## Architecture
+
+- Each sandbox = Durable Object + Container
+- Persistent across requests (same ID = same sandbox)
+- Isolated filesystem/processes/network
+- Configurable sleep/wake for cost optimization
+
+## Quick Start
+
+```typescript
+import { getSandbox, proxyToSandbox, type Sandbox } from '@cloudflare/sandbox';
+export { Sandbox } from '@cloudflare/sandbox';
+
+type Env = { Sandbox: DurableObjectNamespace<Sandbox>; };
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    // CRITICAL: proxyToSandbox MUST be called first for preview URLs
+    const proxyResponse = await proxyToSandbox(request, env);
+    if (proxyResponse) return proxyResponse;
+
+    const sandbox = getSandbox(env.Sandbox, 'my-sandbox');
+    const result = await sandbox.exec('python3 -c "print(2 + 2)"');
+    return Response.json({ output: result.stdout });
+  }
+};
+```
+
+**wrangler.jsonc**:
+```jsonc
+{
+  "name": "my-sandbox-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2024-01-01",
+  
+  "containers": [{
+    "class_name": "Sandbox",
+    "image": "./Dockerfile",
+    "instance_type": "lite",        // lite | standard | heavy
+    "max_instances": 5
+  }],
+  
+  "durable_objects": {
+    "bindings": [{ "class_name": "Sandbox", "name": "Sandbox" }]
+  },
+  
+  "migrations": [{
+    "tag": "v1",
+    "new_sqlite_classes": ["Sandbox"]
+  }]
+}
+```
+
+**Dockerfile**:
+```dockerfile
+FROM docker.io/cloudflare/sandbox:latest
+RUN pip3 install --no-cache-dir pandas numpy matplotlib
+EXPOSE 8080 3000  # Required for wrangler dev
+```
+
+## Core APIs
+
+- `getSandbox(namespace, id, options?)` → Get/create sandbox
+- `sandbox.exec(command, options?)` → Execute command
+- `sandbox.readFile(path)` / `writeFile(path, content)` → File ops
+- `sandbox.startProcess(command, options)` → Background process
+- `sandbox.exposePort(port, options)` → Get preview URL
+- `sandbox.createSession(options)` → Isolated session
+
+## Critical Rules
+
+- ALWAYS call `proxyToSandbox()` first
+- Same ID = reuse sandbox
+- Use `/workspace` for persistent files
+- `normalizeId: true` for preview URLs
+- Retry on `CONTAINER_NOT_READY`
+
+## Resources
+
+- [Configuration](./configuration.md) - Config, CLI, environment
+- [API Reference](./api.md) - Programmatic API, testing
+- [Patterns](./patterns.md) - Common workflows, CI/CD
+- [Gotchas](./gotchas.md) - Issues, limits, best practices
+- [Official Docs](https://developers.cloudflare.com/sandbox/)

--- a/.agent/services/hosting/cloudflare-platform/references/sandbox/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/sandbox/api.md
@@ -1,0 +1,178 @@
+# API Reference
+
+## Command Execution
+
+```typescript
+// Basic
+const result = await sandbox.exec('python3 script.py');
+// Returns: { stdout, stderr, exitCode, success, duration }
+
+// Streaming
+await sandbox.exec('npm install', {
+  stream: true,
+  onOutput: (stream, data) => console.log(`[${stream}]`, data),
+  onComplete: (result) => console.log('Exit:', result.exitCode),
+  onError: (error) => console.error(error)
+});
+
+// With env & cwd
+await sandbox.exec('python3 test.py', {
+  cwd: '/workspace/project',
+  env: { API_KEY: 'secret', DEBUG: 'true' }
+});
+```
+
+## File Operations
+
+```typescript
+// Read
+const file = await sandbox.readFile('/workspace/data.txt');
+// Returns: { content, path }
+
+// Write (creates dirs automatically)
+await sandbox.writeFile('/workspace/deep/nested/file.txt', 'content');
+
+// List
+const files = await sandbox.listFiles('/workspace');
+// Returns: [{ name, path, type: 'file'|'directory', size, modified }]
+
+// Delete
+await sandbox.deleteFile('/workspace/temp.txt');
+await sandbox.deleteFile('/workspace/temp-dir', { recursive: true });
+
+// Directory ops
+await sandbox.mkdir('/workspace/new-dir', { recursive: true });
+const exists = await sandbox.pathExists('/workspace/file.txt');
+```
+
+## Background Processes
+
+```typescript
+// Start
+const process = await sandbox.startProcess('python3 -m http.server 8080', {
+  processId: 'web-server',
+  cwd: '/workspace/public',
+  env: { PORT: '8080' }
+});
+// Returns: { id, pid, command }
+
+// Management
+const processes = await sandbox.listProcesses();
+const info = await sandbox.getProcess('web-server');
+await sandbox.stopProcess('web-server');
+const logs = await sandbox.getProcessLogs('web-server');
+```
+
+## Port Exposure
+
+```typescript
+// Expose
+const exposed = await sandbox.exposePort(8080, {
+  name: 'web-app',
+  hostname: request.hostname
+});
+// Returns: { url, port, name, status }
+
+// Check
+const isExposed = await sandbox.isPortExposed(8080);
+const portInfo = await sandbox.getExposedPort(8080);
+const allPorts = await sandbox.getExposedPorts(request.hostname);
+
+// Unexpose
+await sandbox.unexposePort(8080);
+```
+
+## Sessions (Isolated Contexts)
+
+Each session maintains own shell state, env vars, cwd, process namespace.
+
+```typescript
+// Create
+const session = await sandbox.createSession({
+  id: 'user-123',
+  name: 'User Workspace',
+  cwd: '/workspace/user123',
+  env: { USER_ID: '123', API_KEY: 'secret' }
+});
+
+// Use (full sandbox API bound to session context)
+await session.exec('echo $USER_ID');
+await session.writeFile('config.txt', 'data');
+await session.startProcess('python3 worker.py', { processId: 'worker-1' });
+
+// Retrieve
+const session = await sandbox.getSession('user-123');
+const sessions = await sandbox.listSessions();
+
+// Delete
+await sandbox.deleteSession('user-123');
+```
+
+## Code Interpreter
+
+```typescript
+const result = await sandbox.interpret('python', {
+  code: `
+import matplotlib.pyplot as plt
+plt.plot([1, 2, 3], [4, 5, 6])
+plt.savefig('plot.png')
+print("Chart created")
+  `,
+  files: {
+    'data.csv': 'name,value\nalice,10\nbob,20'
+  }
+});
+// Returns: { outputs: [{ type, content }], files, error }
+```
+
+## Error Handling
+
+```typescript
+// Command errors
+const result = await sandbox.exec('python3 invalid.py');
+if (!result.success) {
+  console.error('Exit code:', result.exitCode);
+  console.error('Stderr:', result.stderr);
+}
+
+// SDK errors
+try {
+  await sandbox.readFile('/nonexistent');
+} catch (error) {
+  if (error.code === 'FILE_NOT_FOUND') { /* ... */ }
+  else if (error.code === 'CONTAINER_NOT_READY') { /* retry */ }
+  else if (error.code === 'TIMEOUT') { /* ... */ }
+}
+
+// Retry pattern
+async function execWithRetry(sandbox, cmd, maxRetries = 3) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      return await sandbox.exec(cmd);
+    } catch (error) {
+      if (error.code === 'CONTAINER_NOT_READY' && i < maxRetries - 1) {
+        await new Promise(r => setTimeout(r, 2000));
+        continue;
+      }
+      throw error;
+    }
+  }
+}
+```
+
+## Client Architecture
+
+```
+SandboxClient (aggregator)
+├── CommandClient     → exec(), streaming
+├── FileClient        → read/write/list/delete
+├── ProcessClient     → background processes
+├── PortClient        → expose services, preview URLs
+├── GitClient         → clone repos
+├── UtilityClient     → health, sessions
+└── InterpreterClient → code execution (Python/JS)
+```
+
+**Execution Modes**:
+1. **Foreground** (exec): Blocking, captures output
+2. **Background** (execStream/startProcess): Non-blocking, uses FIFOs, concurrent

--- a/.agent/services/hosting/cloudflare-platform/references/sandbox/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/sandbox/configuration.md
@@ -1,0 +1,131 @@
+# Configuration
+
+## getSandbox Options
+
+```typescript
+const sandbox = getSandbox(env.Sandbox, 'sandbox-id', {
+  normalizeId: true,         // lowercase ID (required for preview URLs)
+  sleepAfter: '30m',         // sleep after inactivity: '5m', '1h', '2d'
+  keepAlive: false,          // false = auto-timeout, true = never sleep
+  
+  containerTimeouts: {
+    instanceGetTimeoutMS: 30000,  // 30s for provisioning
+    portReadyTimeoutMS: 90000     // 90s for container startup
+  }
+});
+```
+
+**Sleep Config**:
+- `sleepAfter`: Duration string (e.g., '5m', '30m', '1h')
+- `keepAlive: false`: Auto-sleep (default, cost-optimized)
+- `keepAlive: true`: Never sleep (higher cost, faster response)
+- Sleeping sandboxes wake automatically (cold start)
+
+## Instance Types
+
+wrangler.jsonc `instance_type`:
+- `lite`: 256MB RAM, 0.5 vCPU (default)
+- `standard`: 512MB RAM, 1 vCPU
+- `heavy`: 1GB RAM, 2 vCPU
+
+## Dockerfile Patterns
+
+**Basic**:
+```dockerfile
+FROM docker.io/cloudflare/sandbox:latest
+RUN pip3 install --no-cache-dir pandas numpy
+EXPOSE 8080  # Required for wrangler dev
+```
+
+**Scientific**:
+```dockerfile
+FROM docker.io/cloudflare/sandbox:latest
+RUN pip3 install --no-cache-dir \
+    jupyter-server ipykernel matplotlib \
+    pandas seaborn plotly scipy scikit-learn
+```
+
+**Node.js**:
+```dockerfile
+FROM docker.io/cloudflare/sandbox:latest
+RUN npm install -g typescript ts-node
+```
+
+**CRITICAL**: `EXPOSE` required for `wrangler dev` port access. Production auto-exposes all ports.
+
+## CLI Commands
+
+```bash
+# Dev
+wrangler dev                    # Start local dev server
+wrangler deploy                 # Deploy to production
+wrangler tail                   # Monitor logs
+wrangler containers list        # Check container status
+wrangler secret put KEY         # Set secret
+```
+
+## Environment & Secrets
+
+**wrangler.jsonc**:
+```jsonc
+{
+  "vars": {
+    "ENVIRONMENT": "production",
+    "API_URL": "https://api.example.com"
+  },
+  "r2_buckets": [{
+    "binding": "DATA_BUCKET",
+    "bucket_name": "my-data-bucket"
+  }]
+}
+```
+
+**Usage**:
+```typescript
+const token = env.GITHUB_TOKEN;  // From wrangler secret
+await sandbox.exec('git clone ...', {
+  env: { GIT_TOKEN: token }
+});
+```
+
+## Preview URL Setup
+
+**Prerequisites**:
+- Custom domain with wildcard DNS: `*.yourdomain.com → worker.yourdomain.com`
+- `.workers.dev` domains NOT supported
+- `normalizeId: true` in getSandbox
+- `proxyToSandbox()` called first in fetch handler
+
+## Cron Triggers (Pre-warming)
+
+```jsonc
+{
+  "triggers": {
+    "crons": ["*/5 * * * *"]  // Every 5 minutes
+  }
+}
+```
+
+```typescript
+export default {
+  async scheduled(event: ScheduledEvent, env: Env) {
+    const sandbox = getSandbox(env.Sandbox, 'main');
+    await sandbox.exec('echo "keepalive"');  // Wake sandbox
+  }
+};
+```
+
+## R2 Storage Integration
+
+```typescript
+await sandbox.mountStorage({
+  type: 'r2',
+  bucket: env.DATA_BUCKET,
+  mountPoint: '/data',
+  readOnly: false
+});
+
+// Access mounted storage
+await sandbox.exec('python3 process.py', { cwd: '/data/datasets' });
+await sandbox.writeFile('/data/output/results.csv', csvData);
+```

--- a/.agent/services/hosting/cloudflare-platform/references/sandbox/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/sandbox/gotchas.md
@@ -1,0 +1,156 @@
+# Gotchas & Best Practices
+
+## Common Issues
+
+### Container Not Ready
+**Error**: `CONTAINER_NOT_READY`  
+**Cause**: Container still provisioning (first request or after sleep)  
+**Fix**: Retry after 2-3s
+
+```typescript
+async function execWithRetry(sandbox, cmd) {
+  for (let i = 0; i < 3; i++) {
+    try {
+      return await sandbox.exec(cmd);
+    } catch (e) {
+      if (e.code === 'CONTAINER_NOT_READY') {
+        await new Promise(r => setTimeout(r, 2000));
+        continue;
+      }
+      throw e;
+    }
+  }
+}
+```
+
+### Port Exposure Fails in Dev
+**Error**: "Connection refused: container port not found"  
+**Cause**: Missing `EXPOSE` directive in Dockerfile  
+**Fix**: Add `EXPOSE <port>` to Dockerfile (only needed for `wrangler dev`, production auto-exposes)
+
+### Preview URLs Not Working
+**Checklist**:
+1. Custom domain configured? (not `.workers.dev`)
+2. Wildcard DNS set up? (`*.domain.com → worker.domain.com`)
+3. `normalizeId: true` in getSandbox?
+4. `proxyToSandbox()` called first in fetch?
+
+### Slow First Request
+**Cause**: Cold start (container provisioning)  
+**Solutions**:
+- Use `sleepAfter` instead of creating new sandboxes
+- Pre-warm with cron triggers
+- Set `keepAlive: true` for critical sandboxes
+
+### File Not Persisting
+**Cause**: Files in `/tmp` or other ephemeral paths  
+**Fix**: Use `/workspace` for persistent files
+
+## Performance Optimization
+
+### Sandbox ID Strategy
+
+```typescript
+// ❌ BAD: Creates new sandbox every time (slow, expensive)
+const sandbox = getSandbox(env.Sandbox, `user-${Date.now()}`);
+
+// ✅ GOOD: Reuse sandbox per user
+const sandbox = getSandbox(env.Sandbox, `user-${userId}`);
+
+// ✅ GOOD: Reuse for temporary tasks
+const sandbox = getSandbox(env.Sandbox, 'shared-runner');
+```
+
+### Sleep Configuration
+
+```typescript
+// Cost-optimized: Sleep after 30min inactivity
+const sandbox = getSandbox(env.Sandbox, 'id', {
+  sleepAfter: '30m',
+  keepAlive: false
+});
+
+// Always-on (higher cost, faster response)
+const sandbox = getSandbox(env.Sandbox, 'id', {
+  keepAlive: true
+});
+```
+
+### Increase max_instances for High Traffic
+
+```jsonc
+{
+  "containers": [{
+    "class_name": "Sandbox",
+    "max_instances": 50  // Allow 50 concurrent sandboxes
+  }]
+}
+```
+
+## Security Best Practices
+
+### Sandbox Isolation
+- Each sandbox = isolated container (filesystem, network, processes)
+- Use unique sandbox IDs per tenant for multi-tenant apps
+- Sandboxes cannot communicate directly
+
+### Input Validation
+
+```typescript
+// ❌ DANGEROUS: Command injection
+const result = await sandbox.exec(`python3 -c "${userCode}"`);
+
+// ✅ SAFE: Write to file, execute file
+await sandbox.writeFile('/workspace/user_code.py', userCode);
+const result = await sandbox.exec('python3 /workspace/user_code.py');
+```
+
+### Resource Limits
+
+```typescript
+// Timeout long-running commands
+const result = await sandbox.exec('python3 script.py', {
+  timeout: 30000  // 30 seconds
+});
+```
+
+### Secrets Management
+
+```typescript
+// ❌ NEVER hardcode secrets
+const token = 'ghp_abc123';
+
+// ✅ Use environment secrets
+const token = env.GITHUB_TOKEN;
+
+// Pass to sandbox via exec env
+const result = await sandbox.exec('git clone ...', {
+  env: { GIT_TOKEN: token }
+});
+```
+
+### Preview URL Security
+Preview URLs include auto-generated tokens:
+```
+https://8080-sandbox-abc123def456.yourdomain.com
+```
+Token changes on each expose operation, preventing unauthorized access.
+
+## Limits
+
+- **Instance types**: lite (256MB), standard (512MB), heavy (1GB)
+- **Default timeout**: 120s for exec operations
+- **First deploy**: 2-3 min for container provisioning
+- **Cold start**: 2-3s when waking from sleep
+
+## Production Guide
+
+See: https://developers.cloudflare.com/sandbox/guides/production-deployment/
+
+## Resources
+
+- [Official Docs](https://developers.cloudflare.com/sandbox/)
+- [API Reference](https://developers.cloudflare.com/sandbox/api/)
+- [Examples](https://github.com/cloudflare/sandbox-sdk/tree/main/examples)
+- [npm Package](https://www.npmjs.com/package/@cloudflare/sandbox)
+- [Discord Support](https://discord.cloudflare.com)

--- a/.agent/services/hosting/cloudflare-platform/references/sandbox/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/sandbox/patterns.md
@@ -1,0 +1,203 @@
+# Common Patterns
+
+## AI Code Execution Agent
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { code } = await request.json();
+    const sandbox = getSandbox(env.Sandbox, 'ai-agent');
+    
+    // Execute user code safely
+    await sandbox.writeFile('/workspace/user_code.py', code);
+    const result = await sandbox.exec('python3 /workspace/user_code.py');
+    
+    return Response.json({
+      output: result.stdout,
+      error: result.stderr,
+      success: result.success
+    });
+  }
+};
+```
+
+## Interactive Dev Environment
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const proxyResponse = await proxyToSandbox(request, env);
+    if (proxyResponse) return proxyResponse;
+    
+    const sandbox = getSandbox(env.Sandbox, 'ide', { normalizeId: true });
+    
+    if (request.url.endsWith('/start')) {
+      await sandbox.exec('curl -fsSL https://code-server.dev/install.sh | sh');
+      await sandbox.startProcess('code-server --bind-addr 0.0.0.0:8080', {
+        processId: 'vscode'
+      });
+      
+      const exposed = await sandbox.exposePort(8080);
+      return Response.json({ url: exposed.url });
+    }
+    
+    return new Response('Try /start');
+  }
+};
+```
+
+## CI/CD Pipeline
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { repo, branch } = await request.json();
+    const sandbox = getSandbox(env.Sandbox, `ci-${repo}-${Date.now()}`);
+    
+    await sandbox.exec(`git clone -b ${branch} ${repo} /workspace/repo`);
+    
+    const install = await sandbox.exec('npm install', {
+      cwd: '/workspace/repo',
+      stream: true,
+      onOutput: (stream, data) => console.log(data)
+    });
+    
+    if (!install.success) {
+      return Response.json({ success: false, error: 'Install failed' });
+    }
+    
+    const test = await sandbox.exec('npm test', { cwd: '/workspace/repo' });
+    
+    return Response.json({
+      success: test.success,
+      output: test.stdout,
+      exitCode: test.exitCode
+    });
+  }
+};
+```
+
+## Data Analysis Platform
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { notebook } = await request.json();
+    const sandbox = getSandbox(env.Sandbox, 'data-analysis');
+    
+    await sandbox.writeFile('/workspace/analysis.ipynb', JSON.stringify(notebook));
+    
+    const result = await sandbox.exec(
+      'jupyter nbconvert --to notebook --execute analysis.ipynb --output results.ipynb',
+      { cwd: '/workspace' }
+    );
+    
+    const output = await sandbox.readFile('/workspace/results.ipynb');
+    
+    return Response.json({
+      success: result.success,
+      notebook: JSON.parse(output.content)
+    });
+  }
+};
+```
+
+## Multi-Language Code Runner
+
+```typescript
+const languageConfigs = {
+  python: { cmd: 'python3', ext: 'py' },
+  javascript: { cmd: 'node', ext: 'js' },
+  typescript: { cmd: 'ts-node', ext: 'ts' },
+  bash: { cmd: 'bash', ext: 'sh' }
+};
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { language, code } = await request.json();
+    const config = languageConfigs[language];
+    
+    if (!config) {
+      return Response.json({ error: 'Unsupported language' }, { status: 400 });
+    }
+    
+    const sandbox = getSandbox(env.Sandbox, 'code-runner');
+    const filename = `/workspace/script.${config.ext}`;
+    
+    await sandbox.writeFile(filename, code);
+    const result = await sandbox.exec(`${config.cmd} ${filename}`);
+    
+    return Response.json({
+      output: result.stdout,
+      error: result.stderr,
+      exitCode: result.exitCode
+    });
+  }
+};
+```
+
+## Multi-Tenant Pattern
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const userId = request.headers.get('X-User-ID');
+    const sandbox = getSandbox(env.Sandbox, 'multi-tenant');
+    
+    // Each user gets isolated session
+    let session;
+    try {
+      session = await sandbox.getSession(userId);
+    } catch {
+      session = await sandbox.createSession({
+        id: userId,
+        cwd: `/workspace/users/${userId}`,
+        env: { USER_ID: userId }
+      });
+    }
+    
+    const code = await request.text();
+    const result = await session.exec(`python3 -c "${code}"`);
+    
+    return Response.json({ output: result.stdout });
+  }
+};
+```
+
+## Jupyter Integration
+
+**Dockerfile**:
+```dockerfile
+FROM docker.io/cloudflare/sandbox:latest
+RUN pip3 install --no-cache-dir jupyter-server ipykernel matplotlib pandas
+EXPOSE 8888
+```
+
+**Worker**:
+```typescript
+await sandbox.startProcess('jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser', {
+  processId: 'jupyter',
+  cwd: '/workspace'
+});
+
+const exposed = await sandbox.exposePort(8888, { name: 'jupyter' });
+return Response.json({ url: exposed.url });
+```
+
+## Git Operations
+
+```typescript
+// Clone
+await sandbox.exec('git clone https://github.com/user/repo.git /workspace/repo');
+
+// Clone specific branch
+await sandbox.exec('git clone -b main --single-branch https://github.com/user/repo.git /workspace/repo');
+
+// Authenticated clone
+const token = env.GITHUB_TOKEN;
+await sandbox.exec(`git clone https://${token}@github.com/user/private-repo.git`);
+
+// Git ops
+await sandbox.exec('git pull', { cwd: '/workspace/repo' });
+await sandbox.exec('git checkout -b feature', { cwd: '/workspace/repo' });
+```

--- a/.agent/services/hosting/cloudflare-platform/references/smart-placement/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/smart-placement/README.md
@@ -1,0 +1,91 @@
+# Cloudflare Workers Smart Placement
+
+Automatic workload placement optimization to minimize latency by running Workers closer to backend infrastructure rather than end users.
+
+## Core Concept
+
+Smart Placement automatically analyzes Worker request duration across Cloudflare's global network and intelligently routes requests to optimal data center locations. Instead of defaulting to the location closest to the end user, Smart Placement can forward requests to locations closer to backend infrastructure when this reduces overall request duration.
+
+### When to Use
+
+**Enable Smart Placement when:**
+- Worker makes multiple round trips to backend services/databases
+- Backend infrastructure is geographically concentrated
+- Request duration dominated by backend latency rather than network latency from user
+- Running backend logic in Workers (APIs, data aggregation, SSR with DB calls)
+
+**Do NOT enable for:**
+- Workers serving only static content or cached responses
+- Workers without significant backend communication
+- Pure edge logic (auth checks, redirects, simple transformations)
+- Workers without fetch event handlers
+
+### Key Architecture Pattern
+
+**Recommended:** Split full-stack applications into separate Workers:
+```
+User → Frontend Worker (at edge, close to user)
+         ↓ Service Binding
+       Backend Worker (Smart Placement enabled, close to DB/API)
+         ↓
+       Database/Backend Service
+```
+
+This maintains fast, reactive frontends while optimizing backend latency.
+
+## Quick Start
+
+```toml
+# wrangler.toml
+[placement]
+mode = "smart"
+hint = "wnam"  # Optional: West North America
+```
+
+Deploy and wait 15 minutes for analysis. Check status via API or dashboard metrics.
+
+## Requirements
+
+- Wrangler 2.20.0+
+- Analysis time: Up to 15 minutes after enabling
+- Traffic requirements: Consistent traffic from multiple global locations
+- Available on all Workers plans (Free, Paid, Enterprise)
+
+## Placement Status Values
+
+```typescript
+type PlacementStatus = 
+  | undefined  // Not yet analyzed
+  | 'SUCCESS'  // Successfully optimized
+  | 'INSUFFICIENT_INVOCATIONS'  // Not enough traffic
+  | 'UNSUPPORTED_APPLICATION';  // Made Worker slower (reverted)
+```
+
+## CLI Commands
+
+```bash
+# Deploy with Smart Placement
+wrangler deploy
+
+# Check placement status
+curl -H "Authorization: Bearer $TOKEN" \
+  https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/workers/services/$WORKER_NAME \
+  | jq .result.placement_status
+
+# Monitor
+wrangler tail your-worker-name --header cf-placement
+```
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - wrangler.toml setup, placement hints, dashboard config
+- [api.md](./api.md) - Placement Status API, cf-placement header, monitoring
+- [patterns.md](./patterns.md) - Frontend/backend split, database workers, SSR patterns
+- [gotchas.md](./gotchas.md) - Troubleshooting INSUFFICIENT_INVOCATIONS, performance issues
+
+## See Also
+
+- [workers](../workers/) - Worker runtime and fetch handlers
+- [d1](../d1/) - D1 database that benefits from Smart Placement
+- [durable-objects](../durable-objects/) - Durable Objects with backend logic
+- [bindings](../bindings/) - Service bindings for frontend/backend split

--- a/.agent/services/hosting/cloudflare-platform/references/smart-placement/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/smart-placement/api.md
@@ -1,0 +1,139 @@
+# Smart Placement API
+
+## Placement Status API
+
+Query Worker placement status via Cloudflare API:
+
+```bash
+curl -X GET "https://api.cloudflare.com/client/v4/accounts/{ACCOUNT_ID}/workers/services/{WORKER_NAME}" \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json"
+```
+
+Response includes `placement_status` field:
+
+```typescript
+type PlacementStatus = 
+  | undefined  // Not yet analyzed
+  | 'SUCCESS'  // Successfully optimized
+  | 'INSUFFICIENT_INVOCATIONS'  // Not enough traffic
+  | 'UNSUPPORTED_APPLICATION';  // Made Worker slower (reverted)
+```
+
+## Status Meanings
+
+**`undefined` (not present)**
+- Worker not yet analyzed
+- Always runs at default edge location closest to user
+
+**`SUCCESS`**
+- Analysis complete, Smart Placement active
+- Worker runs in optimal location (may be edge or remote)
+
+**`INSUFFICIENT_INVOCATIONS`**
+- Not enough requests to make placement decision
+- Requires consistent multi-region traffic
+- Always runs at default edge location
+
+**`UNSUPPORTED_APPLICATION`** (rare, <1% of Workers)
+- Smart Placement made Worker slower
+- Placement decision reverted
+- Always runs at edge location
+- Won't be re-analyzed until redeployed
+
+## cf-placement Header (Beta)
+
+Smart Placement adds response header indicating routing decision:
+
+```typescript
+// Remote placement (Smart Placement routed request)
+"cf-placement: remote-LHR"  // Routed to London
+
+// Local placement (default edge routing)  
+"cf-placement: local-EWR"   // Stayed at Newark edge
+```
+
+Format: `{placement-type}-{IATA-code}`
+- `remote-*` = Smart Placement routed to remote location
+- `local-*` = Stayed at default edge location
+- IATA code = nearest airport to data center
+
+**Warning:** Beta feature, may be removed before GA.
+
+## Detecting Smart Placement in Code
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const placementHeader = request.headers.get('cf-placement');
+    
+    if (placementHeader?.startsWith('remote-')) {
+      const location = placementHeader.split('-')[1];
+      console.log(`Smart Placement routed to ${location}`);
+    } else if (placementHeader?.startsWith('local-')) {
+      const location = placementHeader.split('-')[1];
+      console.log(`Running at edge location ${location}`);
+    }
+    
+    return new Response('OK');
+  }
+};
+```
+
+## Request Duration Metrics
+
+Available in Cloudflare dashboard when Smart Placement enabled:
+
+**Workers & Pages → [Your Worker] → Metrics → Request Duration**
+
+Shows histogram comparing:
+- Request duration WITH Smart Placement (99% of traffic)
+- Request duration WITHOUT Smart Placement (1% baseline)
+
+**Request Duration vs Execution Duration:**
+- **Request duration:** Total time from request arrival to response delivery (includes network latency)
+- **Execution duration:** Time Worker code actively executing (excludes network waits)
+
+Use request duration to measure Smart Placement impact.
+
+## Monitoring Commands
+
+```bash
+# Tail Worker logs
+wrangler tail your-worker-name
+
+# Tail with filters
+wrangler tail your-worker-name --status error
+wrangler tail your-worker-name --header cf-placement
+
+# Check placement status via API
+curl -H "Authorization: Bearer $TOKEN" \
+  https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/workers/services/$WORKER_NAME \
+  | jq .result.placement_status
+```
+
+## TypeScript Types
+
+```typescript
+type PlacementStatus = 
+  | 'SUCCESS'
+  | 'INSUFFICIENT_INVOCATIONS'
+  | 'UNSUPPORTED_APPLICATION'
+  | undefined;
+
+interface WorkerMetadata {
+  placement_mode?: 'smart';
+  placement_status?: PlacementStatus;
+}
+
+interface Env {
+  BACKEND_SERVICE: Fetcher;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const response = await env.BACKEND_SERVICE.fetch(request);
+    return response;
+  }
+} satisfies ExportedHandler<Env>;
+```

--- a/.agent/services/hosting/cloudflare-platform/references/smart-placement/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/smart-placement/configuration.md
@@ -1,0 +1,129 @@
+# Smart Placement Configuration
+
+## wrangler.toml Setup
+
+```toml
+# Basic Smart Placement
+[placement]
+mode = "smart"
+
+# With placement hint (preferred region)
+[placement]
+mode = "smart"
+hint = "wnam"  # West North America
+```
+
+## wrangler.json/wrangler.jsonc
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "placement": {
+    "mode": "smart",
+    "hint": "wnam"  // Optional region hint
+  }
+}
+```
+
+## Placement Mode Values
+
+- `"smart"` - Enable Smart Placement optimization
+- Not specified - Default behavior (run at edge closest to user)
+
+## Placement Hints
+
+Optional region hints guide Smart Placement decisions:
+- `"wnam"` - West North America
+- `"enam"` - East North America  
+- `"weur"` - Western Europe
+- `"eeur"` - Eastern Europe
+- `"apac"` - Asia Pacific
+
+**Note:** Hints are suggestions, not guarantees. Smart Placement makes final decision based on performance data.
+
+## Frontend + Backend Split Configuration
+
+### Frontend Worker (No Smart Placement)
+
+```toml
+# frontend-worker/wrangler.toml
+name = "frontend"
+main = "frontend-worker.ts"
+
+# No [placement] - runs at edge
+
+[[services]]
+binding = "BACKEND"
+service = "backend-api"
+```
+
+### Backend Worker (Smart Placement Enabled)
+
+```toml
+# backend-api/wrangler.toml
+name = "backend-api"
+main = "backend-worker.ts"
+
+[placement]
+mode = "smart"
+
+[[d1_databases]]
+binding = "DATABASE"
+database_id = "xxx"
+```
+
+## Requirements & Limitations
+
+### Requirements
+- **Wrangler version:** 2.20.0+
+- **Analysis time:** Up to 15 minutes
+- **Traffic requirements:** Consistent multi-location traffic
+- **Workers plan:** All plans (Free, Paid, Enterprise)
+
+### What Smart Placement Affects
+- ✅ **Affects:** `fetch` event handlers only
+- ❌ **Does NOT affect:** RPC methods, named entrypoints, Workers without fetch handlers
+
+### Baseline Traffic
+Smart Placement automatically routes 1% of requests WITHOUT optimization as baseline for performance comparison.
+
+## Dashboard Configuration
+
+**Enable via Dashboard:**
+1. Navigate to **Workers & Pages** in Cloudflare dashboard
+2. Select your Worker
+3. Go to **Settings** → **General**
+4. Under **Placement**, select **Smart**
+5. Wait 15 minutes for analysis
+6. Check **Metrics** tab for request duration charts
+
+## TypeScript Environment Types
+
+```typescript
+interface Env {
+  // Backend Worker binding (Smart Placement enabled)
+  BACKEND: Fetcher;
+  DATABASE: D1Database;
+  CACHE: KVNamespace;
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const data = await env.DATABASE.prepare('SELECT * FROM table').all();
+    return Response.json(data);
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+## Local Development
+
+```bash
+# Smart Placement does NOT affect local development
+wrangler dev
+
+# Local dev always runs in single location
+# Test Smart Placement by deploying to staging
+wrangler deploy --env staging
+```
+
+Smart Placement only activates in production deployments.

--- a/.agent/services/hosting/cloudflare-platform/references/smart-placement/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/smart-placement/gotchas.md
@@ -1,0 +1,87 @@
+# Smart Placement Gotchas
+
+## "INSUFFICIENT_INVOCATIONS" Status
+
+**Problem:** Not enough traffic for Smart Placement to analyze.
+
+**Solutions:**
+- Ensure Worker receives consistent global traffic
+- Wait longer (analysis takes up to 15 minutes)
+- Send test traffic from multiple global locations
+- Check Worker has fetch event handler
+
+## Smart Placement Making Things Slower
+
+**Problem:** `placement_status: "UNSUPPORTED_APPLICATION"`
+
+**Likely Causes:**
+- Worker doesn't make backend calls (runs faster at edge)
+- Backend calls are cached (network latency to user more important)
+- Backend service has poor global distribution
+
+**Solutions:**
+- Disable Smart Placement for this Worker
+- Review whether Worker actually benefits from Smart Placement
+- Consider caching strategy to reduce backend calls
+
+## No Request Duration Metrics
+
+**Problem:** Request duration chart not showing in dashboard.
+
+**Solutions:**
+- Ensure Smart Placement enabled in config
+- Wait 15+ minutes after deployment
+- Verify Worker has sufficient traffic
+- Check `placement_status` is `SUCCESS`
+
+## cf-placement Header Missing
+
+**Problem:** Header not present in responses.
+
+**Possible Causes:**
+- Smart Placement not enabled
+- Beta feature removed (check latest docs)
+- Worker hasn't been analyzed yet
+
+## Monolithic Full-Stack Worker
+
+**Problem:** Frontend and backend logic in single Worker with Smart Placement enabled.
+
+**Impact:** Smart Placement optimizes for backend latency but hurts frontend response time to users.
+
+**Solution:** Split into two Workers:
+- Frontend Worker (no Smart Placement) - runs at edge
+- Backend Worker (Smart Placement) - runs near database
+
+## Local Development Confusion
+
+**Issue:** Smart Placement doesn't work in `wrangler dev`.
+
+**Explanation:** Smart Placement only activates in production deployments, not local development.
+
+**Solution:** Test Smart Placement in staging environment: `wrangler deploy --env staging`
+
+## Baseline 1% Traffic
+
+**Note:** Smart Placement automatically routes 1% of requests WITHOUT optimization for performance comparison. This is expected behavior.
+
+## Analysis Time
+
+**Issue:** Smart Placement takes up to 15 minutes after enabling to complete analysis.
+
+**Impact:** During analysis, Worker runs at default edge location. Be patient and monitor `placement_status`.
+
+## Requirements
+
+- **Wrangler 2.20.0+** required
+- **Consistent multi-region traffic** needed for analysis
+- **Only affects fetch handlers** - RPC methods and named entrypoints not affected
+
+## When NOT to Use
+
+- Workers serving only static content or cached responses
+- Workers without significant backend communication
+- Pure edge logic (auth checks, redirects, simple transformations)
+- Workers without fetch event handlers
+
+These scenarios won't benefit and may perform worse with Smart Placement.

--- a/.agent/services/hosting/cloudflare-platform/references/smart-placement/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/smart-placement/patterns.md
@@ -1,0 +1,135 @@
+# Smart Placement Patterns
+
+## Backend Worker with Database Access
+
+```typescript
+// Smart Placement runs close to database - multiple round trips benefit
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const user = await env.DATABASE.prepare('SELECT * FROM users WHERE id = ?').bind(userId).first();
+    const orders = await env.DATABASE.prepare('SELECT * FROM orders WHERE user_id = ?').bind(userId).all();
+    return Response.json({ user, orders });
+  }
+};
+```
+
+```toml
+name = "backend-api"; [placement]; mode = "smart"; [[d1_databases]]; binding = "DATABASE"
+```
+
+## Frontend + Backend Split
+
+**Frontend (no Smart Placement):** Runs at edge for fast user response
+**Backend (Smart Placement):** Runs close to database
+
+```typescript
+// Frontend - forwards API requests to backend
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (new URL(request.url).pathname.startsWith('/api/')) return env.BACKEND.fetch(request);
+    return env.ASSETS.fetch(request);
+  }
+};
+
+// Backend - database operations
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return Response.json(await env.DATABASE.prepare('SELECT * FROM table').all());
+  }
+};
+```
+
+## External API Integration
+
+```typescript
+// Smart Placement runs closer to external API - multiple calls benefit
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const apiUrl = 'https://api.partner.com';
+    const headers = { 'Authorization': `Bearer ${env.API_KEY}` };
+    const [profile, transactions] = await Promise.all([
+      fetch(`${apiUrl}/profile`, { headers }),
+      fetch(`${apiUrl}/transactions`, { headers })
+    ]);
+    return Response.json({ profile: await profile.json(), transactions: await transactions.json() });
+  }
+};
+```
+
+```toml
+[placement]; mode = "smart"; hint = "enam"  # If API in East North America
+```
+
+## Multi-Service Aggregation
+
+```typescript
+// Aggregates data from multiple services in same region
+export default {
+  async fetch(request: Request, env: Env) {
+    const [orders, inventory, shipping] = await Promise.all([
+      fetch('https://orders.internal.api'), fetch('https://inventory.internal.api'), fetch('https://shipping.internal.api')
+    ]);
+    return Response.json({ orders: await orders.json(), inventory: await inventory.json(), shipping: await shipping.json() });
+  }
+};
+```
+
+## SSR with Backend Data
+
+```typescript
+// Frontend SSR (edge) - render close to user
+export default {
+  async fetch(request: Request, env: Env) {
+    const data = await env.BACKEND.fetch('/api/page-data');
+    return new Response(renderPage(await data.json()), { headers: { 'Content-Type': 'text/html' } });
+  }
+};
+
+// Backend (Smart Placement) - fetch data close to database
+export default {
+  async fetch(request: Request, env: Env) {
+    return Response.json(await env.DATABASE.prepare('SELECT * FROM pages WHERE id = ?').bind(pageId).first());
+  }
+};
+```
+
+## API Gateway
+
+```typescript
+// Gateway at edge - quick auth, forward to backend
+export default {
+  async fetch(request: Request, env: Env) {
+    if (!request.headers.get('Authorization')) return new Response('Unauthorized', { status: 401 });
+    return env.BACKEND_API.fetch(request);
+  }
+};
+
+// Backend with Smart Placement - heavy DB operations
+export default {
+  async fetch(request: Request, env: Env) {
+    return Response.json(await performDatabaseOperations(env.DATABASE));
+  }
+};
+```
+
+## Best Practices
+
+1. **Split Full-Stack Apps:** Frontend at edge, backend with Smart Placement
+2. **Use Service Bindings:** Connect frontend/backend Workers efficiently
+3. **Monitor Request Duration:** Compare before/after metrics
+4. **Enable for Backend Logic:** APIs, data aggregation, server-side processing
+5. **Don't Enable for Pure Edge:** Auth, redirects, static content
+6. **Test Before Production:** Deploy to staging, verify metrics
+7. **Consider Placement Hints:** Guide Smart Placement if you know backend location
+8. **Wait for Analysis:** 15+ minutes after enabling
+9. **Check Placement Status:** Verify `SUCCESS` via API
+10. **Combine with Caching:** Cache frequently accessed data
+
+## Anti-Patterns
+
+❌ **Enabling on static content Workers**
+❌ **Monolithic full-stack Worker with Smart Placement** (hurts frontend performance)
+❌ **Not monitoring placement status** after deploy
+
+✅ **Split architecture:** Frontend (edge) + Backend (Smart Placement)
+✅ **Verify status** via API and metrics

--- a/.agent/services/hosting/cloudflare-platform/references/snippets/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/snippets/README.md
@@ -1,0 +1,15 @@
+# Cloudflare Snippets Skill Reference
+
+## Description
+Expert guidance for **Cloudflare Snippets ONLY** - a lightweight JavaScript-based edge logic platform for modifying HTTP requests and responses. Snippets run as part of the Ruleset Engine and are included at no additional cost on paid plans (Pro, Business, Enterprise)....
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/snippets/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/snippets/api.md
@@ -1,0 +1,47 @@
+### HTTP Methods
+```javascript
+request.method // GET, POST, PUT, DELETE, etc.
+```
+
+### Response Constructors
+```javascript
+// Plain text
+new Response("Hello", { status: 200 })
+
+// JSON
+Response.json({ key: "value" })
+
+// HTML
+new Response("<h1>Hi</h1>", { 
+  headers: { "Content-Type": "text/html" }
+})
+
+// Redirect
+Response.redirect("https://example.com", 301)
+```
+
+### Header Operations
+```javascript
+// Request headers
+request.headers.get("X-Header")
+request.headers.has("X-Header")
+request.headers.set("X-Header", "value")
+request.headers.delete("X-Header")
+
+// Response headers (must clone first)
+const res = new Response(response.body, response);
+res.headers.set("X-Header", "value")
+res.headers.append("Set-Cookie", "value")
+res.headers.delete("X-Header")
+```
+
+### URL Operations
+```javascript
+const url = new URL(request.url);
+url.hostname    // "example.com"
+url.pathname    // "/path/to/page"
+url.search      // "?query=value"
+url.searchParams.get("query") // "value"
+```
+
+### Cloudflare Pr

--- a/.agent/services/hosting/cloudflare-platform/references/snippets/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/snippets/configuration.md
@@ -1,0 +1,33 @@
+## Configuration Methods
+
+### 1. Dashboard (GUI)
+```
+1. Go to zone → Rules → Snippets
+2. Create Snippet or select template
+3. Enter snippet name (a-z, 0-9, _ only, cannot change later)
+4. Write JavaScript code (32KB max)
+5. Configure snippet rule:
+   - Expression Builder or Expression Editor
+   - Use Ruleset Engine filter expressions
+6. Deploy or Save as Draft
+```
+
+### 2. API
+```bash
+# Create/update snippet
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/snippets/$SNIPPET_NAME" \
+  --request PUT \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --form "files=@example.js" \
+  --form "metadata={\"main_module\": \"example.js\"}"
+
+# Create snippet rule
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/snippets/snippet_rules" \
+  --request PUT \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --json '{
+    "rules": [
+      {
+        "description": "Trigger snippet on specific cookie",
+        "enabled": true,
+        "expression": "http.cookie eq 

--- a/.agent/services/hosting/cloudflare-platform/references/snippets/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/snippets/gotchas.md
@@ -1,0 +1,21 @@
+## Best Practices
+
+### Performance
+1. **Keep code minimal**: 32KB limit, but aim for <10KB
+2. **Avoid blocking operations**: 5ms execution limit
+3. **Clone only when needed**: `new Request(request)` creates copy
+4. **Cache strategically**: Use `caches.default` for repeated data
+5. **Limit subrequests**: Plan-based limits (2-5)
+
+### Security
+1. **Validate input**: Never trust user data
+2. **Use Web Crypto API**: For cryptographic operations
+3. **Sanitize headers**: Remove sensitive information
+4. **Check bot scores**: Use `request.cf.botManagement.score`
+5. **Rate limit carefully**: Snippets run on every matching request
+
+### Debugging
+1. **Test in dashboard**: Use HTTP/Preview tabs
+2. **Start simple**: Test with basic logic first
+3. **Use custom headers**: Add debug headers to responses
+4.

--- a/.agent/services/hosting/cloudflare-platform/references/snippets/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/snippets/patterns.md
@@ -1,0 +1,34 @@
+## Common Use Cases
+
+### 1. Header Manipulation
+**Use for**: Adding/removing/modifying request or response headers
+```javascript
+// Add timestamp header
+const timestamp = Date.now().toString(16);
+modifiedRequest.headers.set("X-Hex-Timestamp", timestamp);
+
+// Remove sensitive headers
+newResponse.headers.delete("X-Powered-By");
+newResponse.headers.delete("Server");
+
+// Set security headers
+newResponse.headers.set("X-Frame-Options", "DENY");
+newResponse.headers.set("X-Content-Type-Options", "nosniff");
+```
+
+### 2. Cookie Modification
+**Use for**: Setting dynamic cookies, expiry times, A/B testing
+```javascript
+const expiry = new Date(Date.now() + 7 * 86400000).toUTCString();
+const group = request.headers.get("userGroup") == "premium" ? "A" : "B";
+response.headers.append(
+  "Set-Cookie",
+  `testGroup=${group}; Expires=${expiry}; path=/`
+);
+```
+
+### 3. Bot Management
+**Use for**: Routing bots, honeypots, rate limiting
+```javascript
+// Access bot score from request.cf
+const botScore = reques

--- a/.agent/services/hosting/cloudflare-platform/references/spectrum/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/spectrum/README.md
@@ -1,0 +1,16 @@
+# Cloudflare Spectrum Skill Reference
+
+## Overview
+
+Cloudflare Spectrum provides security and acceleration for ANY TCP or UDP-based application. It's a global Layer 4 (L4) reverse proxy running on Cloudflare's edge nodes that routes MQTT, email, file transfer, version control, games, and more through Cloudflare to mask origins and protec...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/spectrum/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/spectrum/api.md
@@ -1,0 +1,24 @@
+### API Endpoints
+
+```
+GET    /zones/{zone_id}/spectrum/apps                    # List apps
+POST   /zones/{zone_id}/spectrum/apps                    # Create app
+GET    /zones/{zone_id}/spectrum/apps/{app_id}           # Get app
+PUT    /zones/{zone_id}/spectrum/apps/{app_id}           # Update app
+DELETE /zones/{zone_id}/spectrum/apps/{app_id}           # Delete app
+
+GET    /zones/{zone_id}/spectrum/analytics/aggregate/current
+GET    /zones/{zone_id}/spectrum/analytics/events/bytime
+GET    /zones/{zone_id}/spectrum/analytics/events/summary
+```
+
+### Supported Protocols
+
+**Pro/Business Plans:**
+- Selected protocols only (check Cloudflare docs for current list)
+
+**Enterprise Plans:**
+- All TCP ports (1-65535)
+- All UDP ports (1-65535)
+- Port ranges
+- Custom protocols

--- a/.agent/services/hosting/cloudflare-platform/references/spectrum/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/spectrum/configuration.md
@@ -1,0 +1,43 @@
+## Configuration Patterns
+
+### Basic TCP Application with Direct IP Origin
+
+```bash
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/spectrum/apps" \
+  --request POST \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --json '{
+    "protocol": "tcp/22",
+    "dns": {
+      "type": "CNAME",
+      "name": "ssh.example.com"
+    },
+    "origin_direct": ["tcp://192.0.2.1:22"],
+    "proxy_protocol": "off",
+    "ip_firewall": true,
+    "tls": "off",
+    "edge_ips": {
+      "type": "dynamic",
+      "connectivity": "all"
+    },
+    "traffic_type": "direct",
+    "argo_smart_routing": true
+  }'
+```
+
+### TCP Application with CNAME Origin
+
+```bash
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/spectrum/apps" \
+  --request POST \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --json '{
+    "dns": {
+      "type": "CNAME",
+      "name": "game.example.com"
+    },
+    "protocol": "tcp/27015",
+    "proxy_protocol": "v1",
+    "tls": "off",
+    "origin_dns": {
+ 

--- a/.agent/services/hosting/cloudflare-platform/references/spectrum/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/spectrum/gotchas.md
@@ -1,0 +1,42 @@
+## Troubleshooting
+
+### Issue: Connection timeouts
+
+**Diagnosis:**
+```bash
+# Test connectivity to Spectrum app
+nc -zv app.example.com 22
+
+# Check DNS resolution
+dig app.example.com
+
+# Verify origin accepts Cloudflare IPs
+curl -v telnet://origin-ip:port
+```
+
+**Solutions:**
+- Verify origin firewall allows Cloudflare IPs
+- Check origin service is running and listening on correct port
+- Ensure DNS record is CNAME (not A/AAAA unless using BYOIP)
+
+### Issue: Client IP showing Cloudflare IP
+
+**Solution:** Enable Proxy Protocol
+
+```json
+{
+  "proxy_protocol": "v1"  // TCP: v1 or v2; UDP: simple
+}
+```
+
+Ensure origin application parses proxy protocol headers.
+
+### Issue: TLS errors
+
+**Diagnosis:**
+```bash
+openssl s_client -connect app.example.com:443 -showcerts
+```
+
+**Solutions:**
+- `tls: "flexible"`

--- a/.agent/services/hosting/cloudflare-platform/references/spectrum/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/spectrum/patterns.md
@@ -1,0 +1,40 @@
+## Common Use Cases
+
+### 1. SSH Server Protection
+
+```bash
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/spectrum/apps" \
+  --request POST \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --json '{
+    "protocol": "tcp/22",
+    "dns": {"type": "CNAME", "name": "ssh.example.com"},
+    "origin_direct": ["tcp://10.0.1.5:22"],
+    "ip_firewall": true,
+    "argo_smart_routing": true
+  }'
+```
+
+**Benefits:**
+- Hide origin IP from attackers
+- DDoS protection at L3/L4
+- Argo reduces latency
+- IP firewall for additional access control
+
+### 2. Game Server (e.g., Minecraft)
+
+```bash
+curl "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/spectrum/apps" \
+  --request POST \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  --json '{
+    "protocol": "tcp/25565",
+    "dns": {"type": "CNAME", "name": "mc.example.com"},
+    "origin_direct": ["tcp://192.168.1.10:25565"],
+    "proxy_protocol": "v1",
+    "argo_smart_routing": true
+  }'
+```
+
+**Benefits:**
+- Protection

--- a/.agent/services/hosting/cloudflare-platform/references/static-assets/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/static-assets/README.md
@@ -1,0 +1,14 @@
+# Cloudflare Static Assets Skill Reference
+
+Expert guidance for deploying and configuring static assets with Cloudflare Workers. This skill covers configuration patterns, routing architectures, asset binding usage, and best practices for SPAs, SSG sites, and full-stack applications....
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/static-assets/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/static-assets/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+See main documentation.

--- a/.agent/services/hosting/cloudflare-platform/references/static-assets/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/static-assets/configuration.md
@@ -1,0 +1,47 @@
+## Configuration
+
+### Basic Setup
+
+Minimal configuration requires only `assets.directory`:
+
+```jsonc
+{
+  "name": "my-worker",
+  "compatibility_date": "2025-01-01",
+  "assets": {
+    "directory": "./dist"
+  }
+}
+```
+
+```toml
+name = "my-worker"
+compatibility_date = "2025-01-01"
+
+[assets]
+directory = "./dist"
+```
+
+### Full Configuration Options
+
+```jsonc
+{
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-01-01",
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "html_handling": "auto-trailing-slash",
+    "run_worker_first": ["/api/*", "!/api/docs/*"]
+  }
+}
+```
+
+**Configuration keys:**
+
+- `directory` (string, required): Path to assets folder (e.g. `./dist`, `./public`, `./build`)
+- `binding` (string, optional): Name to access assets in Worker code (e.g. `env.ASSETS`)
+- `not_found_handling` (string, optional): Behavior when asset not found
+  - `"single-page-application"`: Serve `/index.html

--- a/.agent/services/hosting/cloudflare-platform/references/static-assets/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/static-assets/gotchas.md
@@ -1,0 +1,44 @@
+## Best Practices
+
+### 1. Use Selective Worker-First Routing
+
+Instead of `run_worker_first = true`, use array patterns:
+
+```jsonc
+{
+  "assets": {
+    "run_worker_first": [
+      "/api/*",           // API routes
+      "/admin/*",         // Admin area
+      "!/admin/assets/*"  // Except admin assets
+    ]
+  }
+}
+```
+
+**Benefits:**
+- Reduces Worker invocations
+- Lowers costs
+- Improves asset delivery performance
+
+### 2. Leverage Navigation Request Optimization
+
+For SPAs, use `compatibility_date = "2025-04-01"` or later:
+
+```jsonc
+{
+  "compatibility_date": "2025-04-01",
+  "assets": {
+    "not_found_handling": "single-page-application"
+  }
+}
+```
+
+Navigation requests skip Worker invocation, reducing costs.
+
+### 3. Type Safety with Bindings
+
+Always type your environment:
+
+```typescript
+interface

--- a/.agent/services/hosting/cloudflare-platform/references/static-assets/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/static-assets/patterns.md
@@ -1,0 +1,42 @@
+### Common Patterns
+
+**1. Forward request to assets:**
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    return env.ASSETS.fetch(request);
+  }
+};
+```
+
+**2. Fetch specific asset by path:**
+
+```typescript
+const response = await env.ASSETS.fetch("https://assets.local/logo.png");
+```
+
+**3. Modify request before fetching asset:**
+
+```typescript
+const url = new URL(request.url);
+url.pathname = "/index.html";
+return env.ASSETS.fetch(new Request(url, request));
+```
+
+**4. Transform asset response:**
+
+```typescript
+const response = await env.ASSETS.fetch(request);
+const modifiedResponse = new Response(response.body, response);
+modifiedResponse.headers.set("X-Custom-Header", "value");
+modifiedResponse.headers.set("Cache-Control", "public, max-age=3600");
+return modifiedResponse;
+```
+
+**5. Conditional asset serving:**
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);

--- a/.agent/services/hosting/cloudflare-platform/references/stream/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/stream/README.md
@@ -1,0 +1,103 @@
+# Cloudflare Stream
+
+Serverless live and on-demand video streaming platform with one API.
+
+## Overview
+
+Cloudflare Stream provides video upload, storage, encoding, and delivery without managing infrastructure. Runs on Cloudflare's global network.
+
+### Key Features
+- **On-demand video**: Upload, encode, store, deliver
+- **Live streaming**: RTMPS/SRT ingestion with ABR
+- **Direct creator uploads**: End users upload without API keys
+- **Signed URLs**: Token-based access control
+- **Analytics**: Server-side metrics via GraphQL
+- **Webhooks**: Processing notifications
+- **Captions**: Upload or AI-generate subtitles
+- **Watermarks**: Apply branding to videos
+- **Downloads**: Enable MP4 offline viewing
+
+## Core Concepts
+
+### Video Upload Methods
+1. **API Upload (TUS protocol)**: Direct server upload
+2. **Upload from URL**: Import from external source
+3. **Direct Creator Uploads**: User-generated content (recommended)
+
+### Playback Options
+1. **Stream Player (iframe)**: Built-in, optimized player
+2. **Custom Player (HLS/DASH)**: Video.js, HLS.js integration
+3. **Thumbnails**: Static or animated previews
+
+### Access Control
+- **Public**: No restrictions
+- **requireSignedURLs**: Token-based access
+- **allowedOrigins**: Domain restrictions
+- **Access Rules**: Geo/IP restrictions in tokens
+
+### Live Streaming
+- RTMPS/SRT ingest from OBS, FFmpeg
+- Automatic recording to on-demand
+- Simulcast to YouTube, Twitch, etc.
+- WebRTC support for browser streaming
+
+## Quick Start
+
+**Upload video via API**
+```bash
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/copy" \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com/video.mp4"}'
+```
+
+**Embed player**
+```html
+<iframe
+  src="https://customer-<CODE>.cloudflarestream.com/<VIDEO_ID>/iframe"
+  style="border: none;"
+  height="720" width="1280"
+  allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+  allowfullscreen="true"
+></iframe>
+```
+
+**Create live input**
+```bash
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/live_inputs" \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"recording": {"mode": "automatic"}}'
+```
+
+## Limits
+
+- Max file size: 30 GB
+- Max frame rate: 60 fps (recommended)
+- Supported formats: MP4, MKV, MOV, AVI, FLV, MPEG-2 TS/PS, MXF, LXF, GXF, 3GP, WebM, MPG, QuickTime
+
+## Pricing
+
+- $5/1000 min stored
+- $1/1000 min delivered
+
+## Resources
+
+- Dashboard: https://dash.cloudflare.com/?to=/:account/stream
+- API Docs: https://developers.cloudflare.com/api/resources/stream/
+- Stream Docs: https://developers.cloudflare.com/stream/
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - Setup, environment variables, wrangler config
+- [api.md](./api.md) - Upload, playback, live streaming, management APIs
+- [patterns.md](./patterns.md) - Full-stack flows, state management, best practices
+- [gotchas.md](./gotchas.md) - Error codes, troubleshooting, limits
+
+## See Also
+
+- [workers](../workers/) - Deploy Stream APIs in Workers
+- [pages](../pages/) - Integrate Stream with Pages
+- [workers-ai](../workers-ai/) - AI-generate captions

--- a/.agent/services/hosting/cloudflare-platform/references/stream/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/stream/api.md
@@ -1,0 +1,204 @@
+# Stream API Reference
+
+Upload, playback, live streaming, and management APIs.
+
+## Upload APIs
+
+### Direct Creator Upload (Recommended)
+
+**Backend: Create upload URL**
+```typescript
+async function createUploadURL(accountId: string, apiToken: string) {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/direct_upload`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        maxDurationSeconds: 3600,
+        expiry: new Date(Date.now() + 3600000).toISOString(),
+        requireSignedURLs: true,
+        meta: { creator: 'user-123' }
+      })
+    }
+  );
+  const data = await response.json();
+  return { uploadURL: data.result.uploadURL, uid: data.result.uid };
+}
+```
+
+**Frontend: Upload to Stream**
+```typescript
+async function uploadVideo(file: File, uploadURL: string) {
+  const formData = new FormData();
+  formData.append('file', file);
+  return fetch(uploadURL, { method: 'POST', body: formData }).then(r => r.json());
+}
+```
+
+### Upload from URL
+
+```bash
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/copy" \
+  -H "Authorization: Bearer <TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com/video.mp4",
+    "meta": {"name": "My Video"},
+    "requireSignedURLs": false
+  }'
+```
+
+## Playback APIs
+
+### Embed Player (iframe)
+
+```html
+<iframe
+  src="https://customer-<CODE>.cloudflarestream.com/<VIDEO_ID>/iframe?autoplay=true&muted=true"
+  style="border: none;" height="720" width="1280"
+  allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+  allowfullscreen="true"
+></iframe>
+```
+
+### HLS/DASH Manifest URLs
+
+```typescript
+// HLS
+const hlsUrl = `https://customer-<CODE>.cloudflarestream.com/${videoId}/manifest/video.m3u8`;
+
+// DASH
+const dashUrl = `https://customer-<CODE>.cloudflarestream.com/${videoId}/manifest/video.mpd`;
+```
+
+### Thumbnails
+
+```typescript
+// At specific time (seconds)
+const thumb = `https://customer-<CODE>.cloudflarestream.com/${videoId}/thumbnails/thumbnail.jpg?time=10s`;
+
+// By percentage
+const thumbPct = `https://customer-<CODE>.cloudflarestream.com/${videoId}/thumbnails/thumbnail.jpg?time=50%`;
+
+// Animated GIF
+const gif = `https://customer-<CODE>.cloudflarestream.com/${videoId}/thumbnails/thumbnail.gif`;
+```
+
+## Signed URLs
+
+```typescript
+// Low volume (<1k/day): Use API
+async function getSignedToken(accountId: string, videoId: string, apiToken: string) {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/${videoId}/token`,
+    {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${apiToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        accessRules: [{ type: 'ip.geoip.country', action: 'allow', country: ['US'] }]
+      })
+    }
+  );
+  return (await response.json()).result.token;
+}
+
+// High volume: Self-sign with RS256 JWT using crypto.subtle (see patterns.md)
+```
+
+## Live Streaming APIs
+
+### Create Live Input
+
+```typescript
+async function createLiveInput(accountId: string, apiToken: string) {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/live_inputs`,
+    {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${apiToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        recording: { mode: 'automatic', timeoutSeconds: 30 },
+        deleteRecordingAfterDays: 30
+      })
+    }
+  );
+  const { result } = await response.json();
+  return {
+    uid: result.uid,
+    rtmps: { url: result.rtmps.url, streamKey: result.rtmps.streamKey },
+    srt: { url: result.srt.url, streamId: result.srt.streamId, passphrase: result.srt.passphrase }
+  };
+}
+```
+
+### Check Live Status
+
+```typescript
+async function getLiveStatus(accountId: string, liveInputId: string, apiToken: string) {
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/live_inputs/${liveInputId}`,
+    { headers: { 'Authorization': `Bearer ${apiToken}` } }
+  );
+  const { result } = await response.json();
+  return { isLive: result.status?.current?.state === 'connected', recording: result.recording };
+}
+```
+
+### Create Live Output (Simulcast)
+
+```typescript
+async function createLiveOutput(
+  accountId: string, liveInputId: string, apiToken: string,
+  outputUrl: string, streamKey: string
+) {
+  return fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/live_inputs/${liveInputId}/outputs`,
+    {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${apiToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: `${outputUrl}/${streamKey}`, enabled: true })
+    }
+  ).then(r => r.json());
+}
+```
+
+## Video Management APIs
+
+```typescript
+// List videos
+async function listVideos(accountId: string, apiToken: string, search?: string) {
+  const params = new URLSearchParams(search ? { search } : {});
+  return fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream?${params}`,
+    { headers: { 'Authorization': `Bearer ${apiToken}` } }
+  ).then(r => r.json());
+}
+
+// Update video
+async function updateVideo(accountId: string, videoId: string, apiToken: string, updates: unknown) {
+  return fetch(`https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/${videoId}`, {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${apiToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(updates)
+  }).then(r => r.json());
+}
+
+// Delete, clip: similar pattern with DELETE/POST
+```
+
+## In This Reference
+
+- [README.md](./README.md) - Overview and quick start
+- [configuration.md](./configuration.md) - Setup and config
+- [patterns.md](./patterns.md) - Full-stack flows, best practices
+- [gotchas.md](./gotchas.md) - Error codes, troubleshooting
+
+## See Also
+
+- [workers](../workers/) - Deploy Stream APIs in Workers

--- a/.agent/services/hosting/cloudflare-platform/references/stream/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/stream/configuration.md
@@ -1,0 +1,127 @@
+# Stream Configuration
+
+Setup, environment variables, and wrangler configuration.
+
+## Environment Variables
+
+```bash
+# Required
+CF_ACCOUNT_ID=your-account-id
+CF_API_TOKEN=your-api-token
+
+# For signed URLs (high volume)
+STREAM_KEY_ID=your-key-id
+STREAM_JWK=base64-encoded-jwk
+
+# For webhooks
+WEBHOOK_SECRET=your-webhook-secret
+
+# Customer subdomain (from dashboard)
+STREAM_CUSTOMER_CODE=your-customer-code
+```
+
+## Wrangler Configuration
+
+```jsonc
+{
+  "name": "stream-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-01-01", // Use current date for new projects
+  "vars": {
+    "CF_ACCOUNT_ID": "your-account-id"
+  }
+  // Store secrets: wrangler secret put CF_API_TOKEN
+  // wrangler secret put STREAM_KEY_ID
+  // wrangler secret put STREAM_JWK
+  // wrangler secret put WEBHOOK_SECRET
+}
+```
+
+## Signing Keys (High Volume)
+
+Create once for self-signing tokens (thousands of daily users).
+
+**Create key**
+```bash
+curl -X POST \
+  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/keys" \
+  -H "Authorization: Bearer <API_TOKEN>"
+
+# Save `id` and `jwk` (base64) from response
+```
+
+**Store in secrets**
+```bash
+wrangler secret put STREAM_KEY_ID
+wrangler secret put STREAM_JWK
+```
+
+## Webhooks
+
+**Setup webhook URL**
+```bash
+curl -X PUT \
+  "https://api.cloudflare.com/client/v4/accounts/{account_id}/stream/webhook" \
+  -H "Authorization: Bearer <API_TOKEN>" \
+  -H "Content-Type: application/json" \
+  -d '{"notificationUrl": "https://your-worker.workers.dev/webhook"}'
+
+# Save the returned `secret` for signature verification
+```
+
+**Store secret**
+```bash
+wrangler secret put WEBHOOK_SECRET
+```
+
+## Direct Upload / Live / Watermark Config
+
+```typescript
+// Direct upload
+const uploadConfig = {
+  maxDurationSeconds: 3600,
+  expiry: new Date(Date.now() + 3600000).toISOString(),
+  requireSignedURLs: true,
+  allowedOrigins: ['https://yourdomain.com'],
+  meta: { creator: 'user-123' }
+};
+
+// Live input
+const liveConfig = {
+  recording: { mode: 'automatic', timeoutSeconds: 30 },
+  deleteRecordingAfterDays: 30
+};
+
+// Watermark
+const watermark = {
+  name: 'Logo', opacity: 0.7, padding: 20,
+  position: 'lowerRight', scale: 0.15
+};
+```
+
+## Access Rules & Player Config
+
+```typescript
+// Access rules: allow US/CA, block CN/RU, or IP allowlist
+const geoRestrict = [
+  { type: 'ip.geoip.country', action: 'allow', country: ['US', 'CA'] },
+  { type: 'any', action: 'block' }
+];
+
+// Player params for iframe
+const playerParams = new URLSearchParams({
+  autoplay: 'true', muted: 'true', preload: 'auto', defaultTextTrack: 'en'
+});
+```
+
+## In This Reference
+
+- [README.md](./README.md) - Overview and quick start
+- [api.md](./api.md) - Upload, playback, live streaming APIs
+- [patterns.md](./patterns.md) - Full-stack flows, best practices
+- [gotchas.md](./gotchas.md) - Error codes, troubleshooting
+
+## See Also
+
+- [wrangler](../wrangler/) - Wrangler CLI and configuration
+- [workers](../workers/) - Deploy Stream APIs in Workers

--- a/.agent/services/hosting/cloudflare-platform/references/stream/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/stream/gotchas.md
@@ -1,0 +1,131 @@
+# Stream Gotchas
+
+Common issues, troubleshooting, and limits.
+
+## Common Errors
+
+### ERR_NON_VIDEO
+**Cause**: Uploaded file is not a valid video format
+
+**Solution**: Ensure file is in supported format (MP4, MKV, MOV, AVI, FLV, MPEG-2 TS/PS, MXF, LXF, GXF, 3GP, WebM, MPG, QuickTime)
+
+### ERR_DURATION_EXCEED_CONSTRAINT
+**Cause**: Video duration exceeds `maxDurationSeconds` constraint
+
+**Solution**: Increase `maxDurationSeconds` in direct upload config or trim video before upload
+
+### ERR_FETCH_ORIGIN_ERROR
+**Cause**: Failed to download video from URL (upload from URL)
+
+**Solution**: Ensure URL is publicly accessible, uses HTTPS, and video file is available
+
+### ERR_MALFORMED_VIDEO
+**Cause**: Video file is corrupted or improperly encoded
+
+**Solution**: Re-encode video using FFmpeg or check source file integrity
+
+### ERR_DURATION_TOO_SHORT
+**Cause**: Video must be at least 0.1 seconds long
+
+**Solution**: Ensure video has valid duration (not a single frame)
+
+## Troubleshooting
+
+### Video stuck in "inprogress" state
+- **Cause**: Processing large/complex video
+- **Solution**: Wait up to 5 minutes for processing; use webhooks instead of polling
+
+### Signed URL returns 403
+- **Cause**: Token expired or invalid signature
+- **Solution**: Check expiration timestamp, verify JWK is correct, ensure clock sync
+
+### Live stream not connecting
+- **Cause**: Invalid RTMPS URL or stream key
+- **Solution**: Use exact URL/key from API, ensure firewall allows outbound 443
+
+### Webhook signature verification fails
+- **Cause**: Incorrect secret or timestamp window
+- **Solution**: Use exact secret from webhook setup, allow 5-minute timestamp drift
+
+### Video uploads but isn't visible
+- **Cause**: `requireSignedURLs` enabled without providing token
+- **Solution**: Generate signed token or set `requireSignedURLs: false` for public videos
+
+### Player shows infinite loading
+- **Cause**: CORS issue with allowedOrigins
+- **Solution**: Add your domain to `allowedOrigins` array
+
+## Limits
+
+| Resource | Limit |
+|----------|-------|
+| Max file size | 30 GB |
+| Max frame rate | 60 fps (recommended) |
+| Max duration per direct upload | Configurable via `maxDurationSeconds` |
+| Token generation (API endpoint) | 1,000/day recommended (use signing keys for higher) |
+| Live input outputs (simulcast) | 5 per live input |
+| Webhook retry attempts | 5 (exponential backoff) |
+| Webhook timeout | 30 seconds |
+| Caption file size | 5 MB |
+| Watermark image size | 2 MB |
+| Metadata keys per video | Unlimited |
+| Search results per page | Max 1,000 |
+
+## Performance Issues
+
+### Upload is slow
+- **Cause**: Large file size or network constraints
+- **Solution**: Use TUS resumable upload, compress video before upload, check bandwidth
+
+### Playback buffering
+- **Cause**: Network congestion or low bandwidth
+- **Solution**: Use ABR (adaptive bitrate) with HLS/DASH, reduce max bitrate
+
+### High processing time
+- **Cause**: Complex video codec, high resolution
+- **Solution**: Pre-encode with H.264 (most efficient), reduce resolution
+
+## Type Safety
+
+```typescript
+// Error response type
+interface StreamError {
+  success: false;
+  errors: Array<{
+    code: number;
+    message: string;
+  }>;
+}
+
+// Handle errors
+async function uploadWithErrorHandling(url: string, file: File) {
+  const formData = new FormData();
+  formData.append('file', file);
+  const response = await fetch(url, { method: 'POST', body: formData });
+  const result = await response.json();
+  
+  if (!result.success) {
+    throw new Error(result.errors[0]?.message || 'Upload failed');
+  }
+  return result;
+}
+```
+
+## Security Gotchas
+
+1. **Never expose API token in frontend** - Use direct creator uploads
+2. **Always verify webhook signatures** - Prevent spoofed notifications
+3. **Set appropriate token expiration** - Short-lived for security
+4. **Use requireSignedURLs for private content** - Prevent unauthorized access
+5. **Whitelist allowedOrigins** - Prevent hotlinking/embedding on unauthorized sites
+
+## In This Reference
+
+- [README.md](./README.md) - Overview and quick start
+- [configuration.md](./configuration.md) - Setup and config
+- [api.md](./api.md) - Upload, playback, live streaming APIs
+- [patterns.md](./patterns.md) - Full-stack flows, best practices
+
+## See Also
+
+- [workers](../workers/) - Deploy Stream APIs securely

--- a/.agent/services/hosting/cloudflare-platform/references/stream/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/stream/patterns.md
@@ -1,0 +1,152 @@
+# Stream Patterns
+
+Common workflows, full-stack flows, and best practices.
+
+## Full-Stack Upload Flow
+
+**Backend API (Next.js route)**
+```typescript
+// app/api/upload-url/route.ts
+export async function POST(req: Request) {
+  const { userId, videoName } = await req.json();
+  
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${process.env.CF_ACCOUNT_ID}/stream/direct_upload`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${process.env.CF_API_TOKEN}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        maxDurationSeconds: 3600,
+        requireSignedURLs: true,
+        meta: { creator: userId, name: videoName }
+      })
+    }
+  );
+  const data = await response.json();
+  return Response.json({ uploadURL: data.result.uploadURL, uid: data.result.uid });
+}
+```
+
+**Frontend component**
+```tsx
+'use client';
+import { useState } from 'react';
+
+export function VideoUploader() {
+  const [uploading, setUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  
+  async function handleUpload(file: File) {
+    setUploading(true);
+    const { uploadURL, uid } = await fetch('/api/upload-url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ videoName: file.name })
+    }).then(r => r.json());
+    
+    const formData = new FormData();
+    formData.append('file', file);
+    
+    const xhr = new XMLHttpRequest();
+    xhr.upload.addEventListener('progress', (e) => {
+      if (e.lengthComputable) setProgress((e.loaded / e.total) * 100);
+    });
+    xhr.addEventListener('load', () => {
+      setUploading(false);
+      window.location.href = `/videos/${uid}`;
+    });
+    xhr.open('POST', uploadURL);
+    xhr.send(formData);
+  }
+  
+  return (
+    <div>
+      <input type="file" accept="video/*"
+        onChange={(e) => e.target.files?.[0] && handleUpload(e.target.files[0])}
+        disabled={uploading} />
+      {uploading && <progress value={progress} max={100} />}
+    </div>
+  );
+}
+```
+
+## Video State Management
+
+```typescript
+interface VideoState {
+  uid: string;
+  readyToStream: boolean;
+  status: { state: 'queued' | 'inprogress' | 'ready' | 'error'; pctComplete?: string };
+}
+
+async function waitForVideoReady(
+  accountId: string, videoId: string, apiToken: string,
+  maxAttempts = 60, intervalMs = 5000
+): Promise<VideoState> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/accounts/${accountId}/stream/${videoId}`,
+      { headers: { 'Authorization': `Bearer ${apiToken}` } }
+    );
+    const { result } = await response.json();
+    if (result.readyToStream || result.status.state === 'error') return result;
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+  throw new Error('Video processing timeout');
+}
+```
+
+## Webhook Handler (Workers)
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const signature = request.headers.get('Webhook-Signature');
+    if (!signature) return new Response('No signature', { status: 401 });
+    
+    const body = await request.text();
+    // Verify HMAC-SHA256: parse time/sig1, check 5min window, compare signature
+    const isValid = await verifySignature(signature, body, env.WEBHOOK_SECRET);
+    if (!isValid) return new Response('Invalid', { status: 401 });
+    
+    const payload = JSON.parse(body);
+    if (payload.readyToStream) console.log(`Video ${payload.uid} ready`);
+    return new Response('OK');
+  }
+};
+// Full verifySignature impl in gotchas.md
+```
+
+## Live Streaming Setup
+
+**OBS**: Server `rtmps://live.cloudflare.com:443/live/`, Stream Key from API
+
+**FFmpeg**: `ffmpeg -re -i input.mp4 -c:v libx264 -preset veryfast -b:v 3000k -c:a aac -f flv rtmps://live.cloudflare.com:443/live/<KEY>`
+
+## Best Practices
+
+1. **Use Direct Creator Uploads** - Avoid proxying video through servers
+2. **Enable requireSignedURLs** - Control access to private content
+3. **Use signing keys for high volume** - Self-sign tokens instead of API calls
+4. **Set allowedOrigins** - Prevent hotlinking
+5. **Use webhooks over polling** - Efficient status updates
+6. **Cache video metadata** - Reduce API calls
+7. **Set maxDurationSeconds** - Prevent abuse on direct uploads
+8. **Use creator metadata** - Enable per-user filtering/analytics
+9. **Enable recordings for live** - Automatic VOD after stream ends
+10. **Monitor with GraphQL analytics** - Track views, watch time, geo
+
+## In This Reference
+
+- [README.md](./README.md) - Overview and quick start
+- [configuration.md](./configuration.md) - Setup and config
+- [api.md](./api.md) - Upload, playback, live streaming APIs
+- [gotchas.md](./gotchas.md) - Error codes, troubleshooting
+
+## See Also
+
+- [workers](../workers/) - Deploy Stream APIs in Workers
+- [pages](../pages/) - Integrate Stream with Pages

--- a/.agent/services/hosting/cloudflare-platform/references/tail-workers/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/tail-workers/README.md
@@ -1,0 +1,640 @@
+# Cloudflare Tail Workers Skill
+
+## Purpose
+Expert guidance on Cloudflare Tail Workers—specialized Workers that consume execution events from producer Workers for logging, debugging, analytics, and observability.
+
+## When to Use
+- User implements observability/logging for Cloudflare Workers
+- User needs to process Worker execution events, logs, exceptions
+- User builds custom analytics or error tracking
+- User configures real-time event streaming
+- User mentions tail handlers, tail consumers, or producer Workers
+
+## Core Concepts
+
+### What Are Tail Workers?
+Tail Workers automatically process events from producer Workers (the Workers being monitored). They receive:
+- HTTP request/response info
+- Console logs (console.log/error/warn/debug)
+- Uncaught exceptions
+- Execution outcomes (ok, exception, exceededCpu, etc.)
+- Diagnostic channel events
+
+**Key characteristics:**
+- Invoked AFTER producer finishes executing
+- Capture entire request lifecycle including Service Bindings and Dynamic Dispatch sub-requests
+- Billed by CPU time, not request count
+- Available on Workers Paid and Enterprise tiers
+
+### Alternative: OpenTelemetry Export
+For batch exports to observability tools (Sentry, Grafana, Honeycomb):
+- Consider OTEL export instead of Tail Workers
+- OTEL sends logs/traces in batches (more efficient)
+- Tail Workers = advanced mode for custom processing
+
+## Implementation Patterns
+
+### Basic Tail Handler Structure
+
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    // Process events from producer Worker
+  }
+};
+```
+
+**Parameters:**
+- `events`: Array of `TailItem` objects (one per producer invocation)
+- `env`: Bindings (KV, D1, R2, env vars, etc.)
+- `ctx`: Context with `waitUntil()` for async work
+
+**CRITICAL:** Tail handlers don't return values. Use `ctx.waitUntil()` for async operations.
+
+### Event Structure (`TailItem`)
+
+```typescript
+interface TailItem {
+  scriptName: string;           // Producer Worker name
+  eventTimestamp: number;        // Epoch time
+  outcome: 'ok' | 'exception' | 'exceededCpu' | 'exceededMemory' 
+         | 'canceled' | 'scriptNotFound' | 'responseStreamDisconnected' | 'unknown';
+  
+  event: {
+    request?: {
+      url: string;               // Redacted by default
+      method: string;
+      headers: Record<string, string>;  // Sensitive headers redacted
+      cf: IncomingRequestCfProperties;
+      getUnredacted(): TailRequest;     // Bypass redaction (use carefully)
+    };
+    response?: {
+      status: number;
+    };
+  };
+  
+  logs: Array<{
+    timestamp: number;
+    level: 'debug' | 'info' | 'log' | 'warn' | 'error';
+    message: any[];              // Args passed to console function
+  }>;
+  
+  exceptions: Array<{
+    timestamp: number;
+    name: string;                // Error type (Error, TypeError, etc.)
+    message: string;             // Error description
+  }>;
+  
+  diagnosticsChannelEvents: Array<{
+    channel: string;
+    message: any;
+    timestamp: number;
+  }>;
+}
+```
+
+### Configuration
+
+**Producer Worker wrangler.toml:**
+```toml
+name = "my-producer-worker"
+tail_consumers = [{service = "my-tail-worker"}]
+```
+
+**Producer Worker wrangler.jsonc:**
+```json
+{
+  "name": "my-producer-worker",
+  "tail_consumers": [
+    {
+      "service": "my-tail-worker"
+    }
+  ]
+}
+```
+
+**Tail Worker wrangler.toml:**
+```toml
+name = "my-tail-worker"
+# No special config needed, just must have tail() handler
+```
+
+## Common Use Cases
+
+### 1. Send Logs to HTTP Endpoint
+
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    const payload = events.map(event => ({
+      script: event.scriptName,
+      timestamp: event.eventTimestamp,
+      outcome: event.outcome,
+      url: event.event?.request?.url,
+      status: event.event?.response?.status,
+      logs: event.logs,
+      exceptions: event.exceptions,
+    }));
+    
+    ctx.waitUntil(
+      fetch(env.LOG_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+    );
+  }
+};
+```
+
+### 2. Error Tracking to External Service
+
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    for (const event of events) {
+      // Only process errors
+      if (event.outcome === 'exception' || event.exceptions.length > 0) {
+        ctx.waitUntil(
+          fetch("https://error-tracker.example.com/errors", {
+            method: "POST",
+            headers: {
+              "Authorization": `Bearer ${env.ERROR_TRACKER_TOKEN}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              script: event.scriptName,
+              timestamp: event.eventTimestamp,
+              exceptions: event.exceptions,
+              request: event.event?.request?.getUnredacted?.(),  // If needed
+              logs: event.logs,
+            }),
+          })
+        );
+      }
+    }
+  }
+};
+```
+
+### 3. Store Logs in KV
+
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    const promises = events.map(event => {
+      const key = `log:${event.scriptName}:${event.eventTimestamp}`;
+      const value = JSON.stringify({
+        outcome: event.outcome,
+        logs: event.logs,
+        exceptions: event.exceptions,
+      });
+      
+      // TTL: 24 hours
+      return env.LOGS_KV.put(key, value, { expirationTtl: 86400 });
+    });
+    
+    ctx.waitUntil(Promise.all(promises));
+  }
+};
+```
+
+### 4. Analytics Engine for Aggregated Metrics
+
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    const writes = events.map(event => 
+      env.ANALYTICS.writeDataPoint({
+        // String dimensions
+        blobs: [
+          event.scriptName,
+          event.outcome,
+          event.event?.request?.method ?? 'unknown',
+        ],
+        // Numeric metrics
+        doubles: [
+          1,  // Count
+          event.event?.response?.status ?? 0,
+        ],
+        // Indexed fields for filtering
+        indexes: [
+          event.event?.request?.cf?.colo ?? 'unknown',
+        ],
+      })
+    );
+    
+    ctx.waitUntil(Promise.all(writes));
+  }
+};
+```
+
+### 5. Filter Specific Routes/Patterns
+
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    // Only process API routes
+    const apiEvents = events.filter(event => 
+      event.event?.request?.url?.includes('/api/')
+    );
+    
+    if (apiEvents.length === 0) return;
+    
+    ctx.waitUntil(
+      fetch(env.API_LOGS_ENDPOINT, {
+        method: "POST",
+        body: JSON.stringify(apiEvents),
+      })
+    );
+  }
+};
+```
+
+### 6. Multi-Destination Logging
+
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    // Send errors to one place, everything else to another
+    const errors = events.filter(e => e.outcome === 'exception');
+    const success = events.filter(e => e.outcome === 'ok');
+    
+    const tasks = [];
+    
+    if (errors.length > 0) {
+      tasks.push(
+        fetch(env.ERROR_ENDPOINT, {
+          method: "POST",
+          body: JSON.stringify(errors),
+        })
+      );
+    }
+    
+    if (success.length > 0) {
+      tasks.push(
+        fetch(env.SUCCESS_ENDPOINT, {
+          method: "POST",
+          body: JSON.stringify(success),
+        })
+      );
+    }
+    
+    ctx.waitUntil(Promise.all(tasks));
+  }
+};
+```
+
+### 7. Performance Monitoring
+
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    const metrics = events.map(event => ({
+      script: event.scriptName,
+      timestamp: event.eventTimestamp,
+      duration: calculateDuration(event),  // Custom logic
+      outcome: event.outcome,
+      status: event.event?.response?.status,
+      colo: event.event?.request?.cf?.colo,
+    }));
+    
+    ctx.waitUntil(
+      fetch(env.METRICS_ENDPOINT, {
+        method: "POST",
+        headers: { "X-API-Key": env.METRICS_API_KEY },
+        body: JSON.stringify(metrics),
+      })
+    );
+  }
+};
+```
+
+## Security & Privacy
+
+### Automatic Redaction
+By default, sensitive data is redacted from `TailRequest`:
+
+**Header redaction:**
+- Headers containing: `auth`, `key`, `secret`, `token`, `jwt` (case-insensitive)
+- `cookie` and `set-cookie` headers
+- Redacted values show as `"REDACTED"`
+
+**URL redaction:**
+- Hex IDs: 32+ hex digits → `"REDACTED"`
+- Base-64 IDs: 21+ chars with 2+ upper, 2+ lower, 2+ digits → `"REDACTED"`
+
+### Bypassing Redaction
+```typescript
+// Use with extreme caution
+const unredacted = event.event?.request?.getUnredacted();
+// unredacted.url and unredacted.headers contain raw values
+```
+
+**Best practices:**
+- Only call `getUnredacted()` when absolutely necessary
+- Never log unredacted sensitive data
+- Implement additional filtering before external transmission
+- Use environment variables for API keys, never hardcode
+
+## Wrangler CLI Usage
+
+### Deploy Tail Worker
+```bash
+wrangler deploy
+```
+
+### View Live Tail Locally (NOT Tail Workers)
+```bash
+# This streams logs to terminal, different from Tail Workers
+wrangler tail <producer-worker-name>
+```
+
+### Update Producer Configuration
+```bash
+# Edit wrangler.toml to add tail_consumers
+wrangler deploy
+```
+
+### Remove Tail Consumer
+```toml
+# Remove from wrangler.toml or set empty array
+tail_consumers = []
+```
+
+## TypeScript Types
+
+```typescript
+// Add to your Tail Worker
+export default {
+  async tail(
+    events: TailItem[],
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<void> {
+    // Implementation
+  }
+} satisfies ExportedHandler<Env>;
+
+interface Env {
+  // Your bindings
+  LOGS_KV: KVNamespace;
+  ANALYTICS: AnalyticsEngineDataset;
+  LOG_ENDPOINT: string;
+  API_TOKEN: string;
+}
+```
+
+## Testing & Development
+
+### Local Testing
+Tail Workers cannot be fully tested locally with `wrangler dev`. Deploy to staging environment for testing.
+
+### Testing Strategy
+1. Deploy producer Worker to staging
+2. Deploy Tail Worker to staging
+3. Configure `tail_consumers` in producer
+4. Trigger producer Worker requests
+5. Verify Tail Worker receives events (check destination logs/storage)
+
+### Debugging Tips
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    // Log to console for debugging (won't be captured by self)
+    console.log('Received events:', events.length);
+    
+    try {
+      // Your logic
+      await processEvents(events, env);
+    } catch (error) {
+      // Log errors
+      console.error('Tail Worker error:', error);
+      // Consider sending errors to monitoring service
+    }
+  }
+};
+```
+
+## Advanced Patterns
+
+### Batching Events
+```typescript
+// Use KV or Durable Objects to batch events before sending
+export default {
+  async tail(events, env, ctx) {
+    const batch = await env.BATCH_DO.get(env.BATCH_DO.idFromName("batch"));
+    ctx.waitUntil(batch.addEvents(events));
+  }
+};
+```
+
+### Sampling
+```typescript
+// Only process a percentage of events
+export default {
+  async tail(events, env, ctx) {
+    const sampleRate = 0.1;  // 10%
+    const sampledEvents = events.filter(() => Math.random() < sampleRate);
+    
+    if (sampledEvents.length > 0) {
+      ctx.waitUntil(sendToEndpoint(sampledEvents, env));
+    }
+  }
+};
+```
+
+### Workers for Platforms
+For dynamic dispatch Workers, `events` array contains TWO elements:
+1. Dynamic dispatch Worker event
+2. User Worker event
+
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    for (const event of events) {
+      // Distinguish between dispatch and user Worker
+      if (event.scriptName === 'dispatch-worker') {
+        // Handle dispatch Worker event
+      } else {
+        // Handle user Worker event
+      }
+    }
+  }
+};
+```
+
+## Common Pitfalls
+
+1. **Not using `ctx.waitUntil()`:**
+   ```typescript
+   // ❌ WRONG - async work may not complete
+   export default {
+     async tail(events) {
+       fetch(endpoint, { body: JSON.stringify(events) });
+     }
+   };
+   
+   // ✅ CORRECT
+   export default {
+     async tail(events, env, ctx) {
+       ctx.waitUntil(
+         fetch(endpoint, { body: JSON.stringify(events) })
+       );
+     }
+   };
+   ```
+
+2. **Missing tail() handler:**
+   Producer Worker deployment will fail if tail_consumers references a Worker without tail() handler.
+
+3. **Outcome vs HTTP Status:**
+   `outcome` is script execution status, NOT HTTP status. A Worker can return 500 but have outcome='ok' if script completed successfully.
+
+4. **Excessive logging:**
+   Tail Workers are invoked on EVERY producer invocation. Be mindful of volume and costs.
+
+5. **Blocking operations:**
+   Don't await in tail handler unless necessary. Use `ctx.waitUntil()` for fire-and-forget operations.
+
+## Integration Examples
+
+### Sentry
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    const errors = events.filter(e => 
+      e.outcome === 'exception' || e.exceptions.length > 0
+    );
+    
+    for (const event of errors) {
+      ctx.waitUntil(
+        fetch(`https://sentry.io/api/${env.SENTRY_PROJECT}/store/`, {
+          method: "POST",
+          headers: {
+            "X-Sentry-Auth": `Sentry sentry_key=${env.SENTRY_KEY}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            message: event.exceptions[0]?.message,
+            level: "error",
+            tags: { worker: event.scriptName },
+            extra: { event },
+          }),
+        })
+      );
+    }
+  }
+};
+```
+
+### Datadog
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    const logs = events.flatMap(event => 
+      event.logs.map(log => ({
+        ddsource: "cloudflare-worker",
+        ddtags: `worker:${event.scriptName},outcome:${event.outcome}`,
+        hostname: event.event?.request?.cf?.colo,
+        message: log.message.join(" "),
+        status: log.level,
+        timestamp: log.timestamp,
+      }))
+    );
+    
+    ctx.waitUntil(
+      fetch("https://http-intake.logs.datadoghq.com/v1/input", {
+        method: "POST",
+        headers: {
+          "DD-API-KEY": env.DATADOG_API_KEY,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(logs),
+      })
+    );
+  }
+};
+```
+
+## Related Resources
+- Tail Workers Docs: https://developers.cloudflare.com/workers/observability/logs/tail-workers/
+- Tail Handler API: https://developers.cloudflare.com/workers/runtime-apis/handlers/tail/
+- Analytics Engine: https://developers.cloudflare.com/analytics/analytics-engine/
+- OpenTelemetry Export: https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/
+
+## Decision Tree
+
+```
+Need observability for Workers?
+├─ Batch export to known tools (Sentry/Grafana/Honeycomb)?
+│  └─ Use OpenTelemetry export (not Tail Workers)
+├─ Custom real-time processing needed?
+│  ├─ Aggregated metrics?
+│  │  └─ Use Tail Worker + Analytics Engine
+│  ├─ Error tracking?
+│  │  └─ Use Tail Worker + external service
+│  ├─ Custom logging/debugging?
+│  │  └─ Use Tail Worker + KV/HTTP endpoint
+│  └─ Complex event processing?
+│     └─ Use Tail Worker + Durable Objects
+└─ Quick debugging?
+   └─ Use `wrangler tail` (different from Tail Workers)
+```
+
+## Code Quality Guidelines
+
+### Type Safety
+```typescript
+// ✅ Use proper types
+interface Env {
+  LOG_ENDPOINT: string;
+  API_TOKEN: string;
+}
+
+export default {
+  async tail(
+    events: TailItem[],
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<void> {
+    // Type-safe implementation
+  }
+} satisfies ExportedHandler<Env>;
+
+// ❌ Avoid any
+export default {
+  async tail(events: any, env: any, ctx: any) {
+    // Unsafe
+  }
+};
+```
+
+### Error Handling
+```typescript
+export default {
+  async tail(events, env, ctx) {
+    ctx.waitUntil(
+      (async () => {
+        try {
+          await fetch(env.ENDPOINT, {
+            method: "POST",
+            body: JSON.stringify(events),
+          });
+        } catch (error) {
+          // Log to console or send to fallback
+          console.error("Failed to send events:", error);
+        }
+      })()
+    );
+  }
+};
+```
+
+### Minimal, Surgical Changes
+- Process only necessary events (filter early)
+- Avoid unnecessary data transformations
+- Keep handlers focused and simple
+
+## Summary
+Tail Workers provide real-time, custom event processing for Cloudflare Workers. Use them when you need fine-grained control over logging, error tracking, or analytics that goes beyond standard OTEL export. Always use `ctx.waitUntil()` for async work, be mindful of sensitive data redaction, and consider Analytics Engine for aggregated metrics.

--- a/.agent/services/hosting/cloudflare-platform/references/terraform/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/terraform/README.md
@@ -1,0 +1,76 @@
+# Cloudflare Terraform Provider
+
+**Expert guidance for Cloudflare Terraform Provider - infrastructure as code for Cloudflare resources.**
+
+## Core Principles
+
+- **Provider-first**: Use Terraform provider for ALL infrastructure - never mix with wrangler.toml for the same resources
+- **State management**: Always use remote state (S3, Terraform Cloud, etc.) for team environments
+- **Modular architecture**: Create reusable modules for common patterns (zones, workers, pages)
+- **Version pinning**: Always pin provider version with `~>` for predictable upgrades
+- **Secret management**: Use variables + environment vars for sensitive data - never hardcode API tokens
+
+## Provider Setup
+
+### Basic Configuration
+
+```hcl
+terraform {
+  required_version = ">= 1.0"
+  
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.15.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token  # or CLOUDFLARE_API_TOKEN env var
+}
+```
+
+### Authentication Methods (priority order)
+
+1. **API Token** (RECOMMENDED): `api_token` or `CLOUDFLARE_API_TOKEN`
+   - Create: Dashboard → My Profile → API Tokens
+   - Scope to specific accounts/zones for security
+   
+2. **Global API Key** (LEGACY): `api_key` + `api_email` or `CLOUDFLARE_API_KEY` + `CLOUDFLARE_EMAIL`
+   - Less secure, use tokens instead
+   
+3. **User Service Key**: `user_service_key` for Origin CA certificates
+
+### Backend Configuration
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket = "terraform-state"
+    key    = "cloudflare/terraform.tfstate"
+    region = "us-east-1"
+  }
+}
+```
+
+## Quick Reference: Common Commands
+
+```bash
+terraform init          # Initialize provider
+terraform plan          # Plan changes
+terraform apply         # Apply changes
+terraform destroy       # Destroy resources
+terraform import cloudflare_zone.example <zone-id>  # Import existing
+terraform state list    # List resources in state
+terraform output        # Show outputs
+terraform fmt -recursive  # Format code
+terraform validate      # Validate configuration
+```
+
+## See Also
+
+- [Configuration Reference](./configuration.md) - Resources for zones, DNS, workers, KV, R2, D1, Pages, rulesets
+- [API Reference](./api.md) - Data sources for existing resources
+- [Patterns & Use Cases](./patterns.md) - Architecture patterns, multi-env setup, CI/CD integration
+- [Troubleshooting & Best Practices](./gotchas.md) - Common issues, security, best practices

--- a/.agent/services/hosting/cloudflare-platform/references/terraform/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/terraform/api.md
@@ -1,0 +1,159 @@
+# Terraform Data Sources Reference
+
+Query existing Cloudflare resources to reference in your configurations.
+
+## Zone Data Sources
+
+```hcl
+# Get zone by name
+data "cloudflare_zone" "example" {
+  name = "example.com"
+}
+
+# Use in resources
+resource "cloudflare_dns_record" "www" {
+  zone_id = data.cloudflare_zone.example.id
+  name = "www"
+  # ...
+}
+```
+
+## Account Data Sources
+
+```hcl
+# List all accounts
+data "cloudflare_accounts" "main" {
+  name = "My Account"
+}
+
+# Use account ID
+resource "cloudflare_worker_script" "api" {
+  account_id = data.cloudflare_accounts.main.accounts[0].id
+  # ...
+}
+```
+
+## Worker Data Sources
+
+```hcl
+# Get existing worker script
+data "cloudflare_worker_script" "existing" {
+  account_id = var.account_id
+  name = "existing-worker"
+}
+
+# Reference in service bindings
+resource "cloudflare_worker_script" "consumer" {
+  service_binding {
+    name = "UPSTREAM"
+    service = data.cloudflare_worker_script.existing.name
+  }
+}
+```
+
+## KV Data Sources
+
+```hcl
+# Get KV namespace
+data "cloudflare_workers_kv_namespace" "existing" {
+  account_id = var.account_id
+  namespace_id = "abc123"
+}
+
+# Use in worker binding
+resource "cloudflare_worker_script" "api" {
+  kv_namespace_binding {
+    name = "KV"
+    namespace_id = data.cloudflare_workers_kv_namespace.existing.id
+  }
+}
+```
+
+## IP Ranges Data Source
+
+```hcl
+# Get Cloudflare IP ranges (for firewall rules)
+data "cloudflare_ip_ranges" "cloudflare" {}
+
+output "ipv4_cidrs" {
+  value = data.cloudflare_ip_ranges.cloudflare.ipv4_cidr_blocks
+}
+
+output "ipv6_cidrs" {
+  value = data.cloudflare_ip_ranges.cloudflare.ipv6_cidr_blocks
+}
+
+# Use in security group rules (AWS example)
+resource "aws_security_group_rule" "allow_cloudflare" {
+  type = "ingress"
+  from_port = 443
+  to_port = 443
+  protocol = "tcp"
+  cidr_blocks = data.cloudflare_ip_ranges.cloudflare.ipv4_cidr_blocks
+  security_group_id = aws_security_group.web.id
+}
+```
+
+## Common Patterns
+
+### Import Existing Resources
+
+```bash
+# Find zone ID in dashboard
+terraform import cloudflare_zone.example <zone-id>
+
+# Import DNS record
+terraform import cloudflare_dns_record.example <zone-id>/<record-id>
+
+# Import worker script
+terraform import cloudflare_worker_script.api <account-id>/<script-name>
+
+# Import KV namespace
+terraform import cloudflare_workers_kv_namespace.cache <account-id>/<namespace-id>
+```
+
+### Reference Across Modules
+
+```hcl
+# modules/worker/main.tf
+data "cloudflare_zone" "main" {
+  name = var.domain
+}
+
+resource "cloudflare_worker_route" "api" {
+  zone_id = data.cloudflare_zone.main.id
+  pattern = "api.${var.domain}/*"
+  script_name = cloudflare_worker_script.api.name
+}
+```
+
+### Output Important Values
+
+```hcl
+output "zone_id" {
+  value = cloudflare_zone.main.id
+  description = "Zone ID for DNS management"
+}
+
+output "worker_url" {
+  value = "https://${cloudflare_worker_domain.api.hostname}"
+  description = "Worker API endpoint"
+}
+
+output "kv_namespace_id" {
+  value = cloudflare_workers_kv_namespace.app.id
+  sensitive = false
+}
+
+output "name_servers" {
+  value = cloudflare_zone.main.name_servers
+  description = "Name servers for domain registration"
+}
+```
+
+## See Also
+
+- [README](./README.md) - Provider setup
+- [Configuration Reference](./configuration.md) - All resource types
+- [Patterns](./patterns.md) - Architecture patterns
+- [Troubleshooting](./gotchas.md) - Common issues

--- a/.agent/services/hosting/cloudflare-platform/references/terraform/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/terraform/configuration.md
@@ -1,0 +1,156 @@
+# Terraform Configuration Reference
+
+Complete resource configurations for Cloudflare infrastructure.
+
+## Zone & DNS
+
+```hcl
+# Zone + settings
+resource "cloudflare_zone" "example" { account = { id = var.account_id }; name = "example.com"; type = "full" }
+resource "cloudflare_zone_settings_override" "example" {
+  zone_id = cloudflare_zone.example.id
+  settings { ssl = "strict"; always_use_https = "on"; min_tls_version = "1.2"; tls_1_3 = "on"; http3 = "on" }
+}
+
+# DNS records (A, CNAME, MX, TXT)
+resource "cloudflare_dns_record" "www" {
+  zone_id = cloudflare_zone.example.id; name = "www"; content = "192.0.2.1"; type = "A"; proxied = true
+}
+resource "cloudflare_dns_record" "mx" {
+  for_each = { "10" = "mail1.example.com", "20" = "mail2.example.com" }
+  zone_id = cloudflare_zone.example.id; name = "@"; content = each.value; type = "MX"; priority = each.key
+}
+```
+
+## Workers
+
+```hcl
+# Worker with bindings
+resource "cloudflare_worker_script" "api" {
+  account_id = var.account_id; name = "api-worker"; content = file("worker.js"); module = true
+  compatibility_date = "2025-01-01"
+  kv_namespace_binding { name = "KV"; namespace_id = cloudflare_workers_kv_namespace.cache.id }
+  r2_bucket_binding { name = "BUCKET"; bucket_name = cloudflare_r2_bucket.assets.name }
+  d1_database_binding { name = "DB"; database_id = cloudflare_d1_database.app.id }
+  service_binding { name = "AUTH"; service = "auth-worker" }
+  secret_text_binding { name = "SECRET"; text = var.secret }
+}
+
+# Routes & domains
+resource "cloudflare_worker_route" "api" {
+  zone_id = cloudflare_zone.example.id; pattern = "api.example.com/*"; script_name = cloudflare_worker_script.api.name
+}
+resource "cloudflare_worker_cron_trigger" "task" {
+  account_id = var.account_id; script_name = cloudflare_worker_script.api.name
+  schedules = ["*/5 * * * *"]  # Every 5min
+}
+```
+
+## Storage (KV, R2, D1)
+
+```hcl
+# KV
+resource "cloudflare_workers_kv_namespace" "cache" { account_id = var.account_id; title = "cache" }
+resource "cloudflare_workers_kv" "config" {
+  account_id = var.account_id; namespace_id = cloudflare_workers_kv_namespace.cache.id
+  key_name = "config"; value = jsonencode({ version = "1.0" })
+}
+
+# R2
+resource "cloudflare_r2_bucket" "assets" { account_id = var.account_id; name = "assets"; location = "WNAM" }
+
+# D1 (schema migrations via wrangler)
+resource "cloudflare_d1_database" "app" { account_id = var.account_id; name = "app-db" }
+```
+
+## Pages
+
+```hcl
+resource "cloudflare_pages_project" "site" {
+  account_id = var.account_id; name = "site"; production_branch = "main"
+  deployment_configs {
+    production {
+      compatibility_date = "2025-01-01"
+      environment_variables = { NODE_ENV = "production" }
+      kv_namespaces = { KV = cloudflare_workers_kv_namespace.cache.id }
+      d1_databases = { DB = cloudflare_d1_database.app.id }
+    }
+  }
+  build_config { build_command = "npm run build"; destination_dir = "dist" }
+  source { type = "github"; config { owner = "org"; repo_name = "site"; production_branch = "main" }}
+}
+
+resource "cloudflare_pages_domain" "custom" {
+  account_id = var.account_id; project_name = cloudflare_pages_project.site.name; domain = "site.example.com"
+}
+```
+
+## Rulesets (WAF, Redirects, Cache)
+
+```hcl
+# WAF
+resource "cloudflare_ruleset" "waf" {
+  zone_id = cloudflare_zone.example.id; name = "WAF"; kind = "zone"; phase = "http_request_firewall_custom"
+  rules { action = "block"; enabled = true; expression = "(cf.client.bot) and not (cf.verified_bot)" }
+}
+
+# Redirects
+resource "cloudflare_ruleset" "redirects" {
+  zone_id = cloudflare_zone.example.id; name = "Redirects"; kind = "zone"; phase = "http_request_dynamic_redirect"
+  rules {
+    action = "redirect"; enabled = true; expression = "(http.request.uri.path eq \"/old\")"
+    action_parameters { from_value { status_code = 301; target_url { value = "https://example.com/new" }}}
+  }
+}
+
+# Cache rules
+resource "cloudflare_ruleset" "cache" {
+  zone_id = cloudflare_zone.example.id; name = "Cache"; kind = "zone"; phase = "http_request_cache_settings"
+  rules {
+    action = "set_cache_settings"; enabled = true; expression = "(http.request.uri.path matches \"\\.(jpg|png|css|js)$\")"
+    action_parameters { cache = true; edge_ttl { mode = "override_origin"; default = 86400 }}
+  }
+}
+```
+
+## Load Balancers
+
+```hcl
+resource "cloudflare_load_balancer_monitor" "http" {
+  account_id = var.account_id; type = "http"; path = "/health"; interval = 60; timeout = 5
+}
+resource "cloudflare_load_balancer_pool" "api" {
+  account_id = var.account_id; name = "api-pool"; monitor = cloudflare_load_balancer_monitor.http.id
+  origins { name = "api-1"; address = "192.0.2.1" }
+  origins { name = "api-2"; address = "192.0.2.2" }
+}
+resource "cloudflare_load_balancer" "api" {
+  zone_id = cloudflare_zone.example.id; name = "api.example.com"
+  default_pool_ids = [cloudflare_load_balancer_pool.api.id]; steering_policy = "geo"
+}
+```
+
+## Access (Zero Trust)
+
+```hcl
+resource "cloudflare_access_application" "admin" {
+  account_id = var.account_id; name = "Admin"; domain = "admin.example.com"; type = "self_hosted"
+  session_duration = "24h"; allowed_idps = [cloudflare_access_identity_provider.github.id]
+}
+resource "cloudflare_access_policy" "allow" {
+  account_id = var.account_id; application_id = cloudflare_access_application.admin.id
+  name = "Allow"; decision = "allow"; precedence = 1
+  include { email = ["admin@example.com"] }
+}
+resource "cloudflare_access_identity_provider" "github" {
+  account_id = var.account_id; name = "GitHub"; type = "github"
+  config { client_id = var.github_id; client_secret = var.github_secret }
+}
+```
+
+## See Also
+
+- [README](./README.md) - Provider setup
+- [API](./api.md) - Data sources
+- [Patterns](./patterns.md) - Use cases
+- [Troubleshooting](./gotchas.md) - Issues

--- a/.agent/services/hosting/cloudflare-platform/references/terraform/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/terraform/gotchas.md
@@ -1,0 +1,207 @@
+# Terraform Troubleshooting & Best Practices
+
+Common issues, security considerations, and best practices.
+
+## Common Errors
+
+### "Error: couldn't find resource"
+
+**Cause**: Resource deleted outside Terraform  
+**Solution**:
+```bash
+terraform import cloudflare_zone.example <zone-id>
+# Or remove from state:
+terraform state rm cloudflare_zone.example
+```
+
+### "409 Conflict" on worker deployment
+
+**Cause**: Worker deployed by both Terraform and wrangler  
+**Solution**: Choose one deployment method. If using Terraform, remove wrangler deployments.
+
+### DNS record already exists
+
+**Cause**: Existing record not imported into Terraform  
+**Solution**:
+```bash
+# Find record ID in Cloudflare dashboard
+terraform import cloudflare_dns_record.example <zone-id>/<record-id>
+```
+
+### "Invalid provider configuration"
+
+**Cause**: API token missing or invalid  
+**Solution**:
+```bash
+export CLOUDFLARE_API_TOKEN="your-token"
+# Or check token permissions in dashboard
+```
+
+### State locking errors
+
+**Cause**: Multiple Terraform runs or stale lock  
+**Solution**:
+```bash
+# Remove stale lock (with caution!)
+terraform force-unlock <lock-id>
+```
+
+## Best Practices
+
+### 1. Resource Naming
+
+```hcl
+# Good: Consistent naming with environment
+locals { env_prefix = "${var.environment}-${var.project_name}" }
+
+resource "cloudflare_worker_script" "api" { name = "${local.env_prefix}-api" }
+resource "cloudflare_workers_kv_namespace" "cache" { title = "${local.env_prefix}-cache" }
+```
+
+### 2. Output Important Values
+
+```hcl
+output "zone_id" { value = cloudflare_zone.main.id; description = "Zone ID for DNS management" }
+output "worker_url" { value = "https://${cloudflare_worker_domain.api.hostname}"; description = "Worker API endpoint" }
+output "kv_namespace_id" { value = cloudflare_workers_kv_namespace.app.id; sensitive = false }
+```
+
+### 3. Use Data Sources for Existing Resources
+
+```hcl
+# Reference existing zone
+data "cloudflare_zone" "main" { name = var.domain }
+
+# Reference existing account
+data "cloudflare_accounts" "main" { name = var.account_name }
+
+# Use in resources
+resource "cloudflare_worker_route" "api" {
+  zone_id = data.cloudflare_zone.main.id
+  # ...
+}
+```
+
+### 4. Separate Secrets from Code
+
+```hcl
+# variables.tf
+variable "cloudflare_api_token" {
+  type = string; sensitive = true; description = "Cloudflare API token"
+}
+
+# terraform.tfvars (gitignored)
+cloudflare_api_token = "actual-token-here"
+
+# Or use environment variables
+# export TF_VAR_cloudflare_api_token="actual-token-here"
+```
+
+### 5. Use Separate Directories per Environment (RECOMMENDED)
+
+```
+environments/
+  production/    # Separate state, separate vars
+  staging/
+  development/
+```
+
+Better than workspaces for isolation and clarity.
+
+### 6. Version Control State Locking
+
+```hcl
+# S3 backend with DynamoDB locking
+terraform {
+  backend "s3" {
+    bucket = "terraform-state"; key = "cloudflare/terraform.tfstate"; region = "us-east-1"
+    dynamodb_table = "terraform-locks"; encrypt = true
+  }
+}
+```
+
+## Security Considerations
+
+1. **Never commit secrets**: Use variables + environment vars or secret management tools
+2. **Scope API tokens**: Create tokens with minimal required permissions
+3. **Enable state encryption**: Use encrypted S3 backend or Terraform Cloud
+4. **Use separate tokens per environment**: Different tokens for prod/staging
+5. **Rotate tokens regularly**: Update tokens in CI/CD systems
+6. **Review terraform plans**: Always review before applying
+7. **Use Access for sensitive applications**: Don't expose admin panels publicly
+
+## Common Commands Reference
+
+```bash
+terraform init                    # Initialize provider
+terraform plan                    # Plan changes
+terraform apply                   # Apply changes
+terraform apply -auto-approve     # Apply without confirmation
+terraform destroy                 # Destroy resources
+terraform import cloudflare_zone.example <zone-id>  # Import existing
+terraform show                    # Show current state
+terraform state list              # List resources in state
+terraform state rm cloudflare_zone.example  # Remove from state (no destroy)
+terraform refresh                 # Refresh state from infrastructure
+terraform fmt -recursive          # Format code
+terraform validate                # Validate configuration
+terraform output                  # Show outputs
+terraform output zone_id          # Show specific output
+```
+
+## Workspace Management
+
+```bash
+# Create workspace
+terraform workspace new production
+
+# List workspaces
+terraform workspace list
+
+# Switch workspace
+terraform workspace select staging
+
+# Note: Separate directories recommended over workspaces for production
+```
+
+## State Management
+
+```bash
+# List state resources
+terraform state list
+
+# Show resource details
+terraform state show cloudflare_zone.example
+
+# Move resource in state
+terraform state mv cloudflare_zone.old cloudflare_zone.new
+
+# Remove from state (no destroy)
+terraform state rm cloudflare_zone.example
+
+# Pull state to local file
+terraform state pull > terraform.tfstate.backup
+
+# Push state from local file
+terraform state push terraform.tfstate
+```
+
+## Limits
+
+| Resource | Limit | Notes |
+|----------|-------|-------|
+| API token rate limit | Varies by plan | Use `api_client_logging = true` to debug
+| Worker script size | 10 MB | Includes all dependencies
+| KV keys per namespace | Unlimited | Pay per operation
+| R2 storage | Unlimited | Pay per GB
+| D1 databases | 50,000 per account | Free tier: 10
+| Pages projects | 500 per account | 100 for free accounts
+| DNS records | 3,500 per zone | Free plan
+
+## See Also
+
+- [README](./README.md) - Provider setup
+- [Configuration](./configuration.md) - Resources
+- [API](./api.md) - Data sources
+- [Patterns](./patterns.md) - Use cases
+- Provider docs: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs

--- a/.agent/services/hosting/cloudflare-platform/references/terraform/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/terraform/patterns.md
@@ -1,0 +1,135 @@
+# Terraform Patterns & Use Cases
+
+Architecture patterns, multi-environment setups, and real-world use cases.
+
+## Multi-Environment Setup
+
+```hcl
+# Directory: environments/{production,staging}/main.tf + modules/{zone,worker,pages}
+module "zone" {
+  source = "../../modules/zone"; account_id = var.account_id; zone_name = "example.com"; environment = "production"
+}
+module "api_worker" {
+  source = "../../modules/worker"; account_id = var.account_id; zone_id = module.zone.zone_id
+  name = "api-worker-prod"; script = file("../../workers/api.js"); environment = "production"
+}
+```
+
+## Worker with All Bindings
+
+```hcl
+locals { worker_name = "full-stack-worker" }
+resource "cloudflare_workers_kv_namespace" "app" { account_id = var.account_id; title = "${local.worker_name}-kv" }
+resource "cloudflare_r2_bucket" "app" { account_id = var.account_id; name = "${local.worker_name}-bucket" }
+resource "cloudflare_d1_database" "app" { account_id = var.account_id; name = "${local.worker_name}-db" }
+
+resource "cloudflare_worker_script" "app" {
+  account_id = var.account_id; name = local.worker_name; content = file("worker.js"); module = true
+  compatibility_date = "2025-01-01"
+  kv_namespace_binding { name = "KV"; namespace_id = cloudflare_workers_kv_namespace.app.id }
+  r2_bucket_binding { name = "BUCKET"; bucket_name = cloudflare_r2_bucket.app.name }
+  d1_database_binding { name = "DB"; database_id = cloudflare_d1_database.app.id }
+  secret_text_binding { name = "API_KEY"; text = var.api_key }
+}
+```
+
+## Wrangler Integration
+
+**CRITICAL**: Wrangler and Terraform must NOT manage same resources.
+
+**Terraform**: Zones, DNS, security rules, Access, load balancers, worker deployments (CI/CD), KV/R2/D1 resource creation  
+**Wrangler**: Local dev (`wrangler dev`), manual deploys, D1 migrations, KV bulk ops, log streaming (`wrangler tail`)
+
+### CI/CD Pattern
+
+```hcl
+# Terraform creates infrastructure
+resource "cloudflare_workers_kv_namespace" "app" { account_id = var.account_id; title = "app-kv" }
+resource "cloudflare_d1_database" "app" { account_id = var.account_id; name = "app-db" }
+output "kv_namespace_id" { value = cloudflare_workers_kv_namespace.app.id }
+output "d1_database_id" { value = cloudflare_d1_database.app.id }
+```
+
+```yaml
+# GitHub Actions: terraform apply → envsubst wrangler.jsonc.template → wrangler deploy
+- run: terraform apply -auto-approve
+- run: |
+    export KV_NAMESPACE_ID=$(terraform output -raw kv_namespace_id)
+    envsubst < wrangler.jsonc.template > wrangler.jsonc
+- run: wrangler deploy
+```
+
+## Use Cases
+
+### Static Site + API Worker
+
+```hcl
+resource "cloudflare_pages_project" "frontend" {
+  account_id = var.account_id; name = "frontend"; production_branch = "main"
+  build_config { build_command = "npm run build"; destination_dir = "dist" }
+}
+resource "cloudflare_worker_script" "api" {
+  account_id = var.account_id; name = "api"; content = file("api-worker.js")
+  d1_database_binding { name = "DB"; database_id = cloudflare_d1_database.api_db.id }
+}
+resource "cloudflare_dns_record" "frontend" {
+  zone_id = cloudflare_zone.main.id; name = "app"; content = cloudflare_pages_project.frontend.subdomain; type = "CNAME"; proxied = true
+}
+resource "cloudflare_worker_route" "api" {
+  zone_id = cloudflare_zone.main.id; pattern = "api.example.com/*"; script_name = cloudflare_worker_script.api.name
+}
+```
+
+### Multi-Region Load Balancing
+
+```hcl
+resource "cloudflare_load_balancer_pool" "us" {
+  account_id = var.account_id; name = "us-pool"; monitor = cloudflare_load_balancer_monitor.http.id
+  origins { name = "us-east"; address = var.us_east_ip }
+}
+resource "cloudflare_load_balancer_pool" "eu" {
+  account_id = var.account_id; name = "eu-pool"; monitor = cloudflare_load_balancer_monitor.http.id
+  origins { name = "eu-west"; address = var.eu_west_ip }
+}
+resource "cloudflare_load_balancer" "global" {
+  zone_id = cloudflare_zone.main.id; name = "api.example.com"; steering_policy = "geo"
+  default_pool_ids = [cloudflare_load_balancer_pool.us.id]
+  region_pools { region = "WNAM"; pool_ids = [cloudflare_load_balancer_pool.us.id] }
+  region_pools { region = "WEU"; pool_ids = [cloudflare_load_balancer_pool.eu.id] }
+}
+```
+
+### Secure Admin with Access
+
+```hcl
+resource "cloudflare_pages_project" "admin" { account_id = var.account_id; name = "admin"; production_branch = "main" }
+resource "cloudflare_access_application" "admin" {
+  account_id = var.account_id; name = "Admin"; domain = "admin.example.com"; type = "self_hosted"; session_duration = "24h"
+  allowed_idps = [cloudflare_access_identity_provider.google.id]
+}
+resource "cloudflare_access_policy" "allow" {
+  account_id = var.account_id; application_id = cloudflare_access_application.admin.id
+  name = "Allow admins"; decision = "allow"; precedence = 1; include { email = var.admin_emails }
+}
+```
+
+### Reusable Module
+
+```hcl
+# modules/cloudflare-zone/main.tf
+variable "account_id" { type = string }; variable "domain" { type = string }; variable "ssl_mode" { default = "strict" }
+resource "cloudflare_zone" "main" { account = { id = var.account_id }; name = var.domain }
+resource "cloudflare_zone_settings_override" "main" {
+  zone_id = cloudflare_zone.main.id; settings { ssl = var.ssl_mode; always_use_https = "on" }
+}
+output "zone_id" { value = cloudflare_zone.main.id }
+
+# Usage: module "prod" { source = "./modules/cloudflare-zone"; account_id = var.account_id; domain = "example.com" }
+```
+
+## See Also
+
+- [README](./README.md) - Provider setup
+- [Configuration Reference](./configuration.md) - All resource types
+- [API Reference](./api.md) - Data sources
+- [Troubleshooting](./gotchas.md) - Best practices, common issues

--- a/.agent/services/hosting/cloudflare-platform/references/tunnel/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/tunnel/README.md
@@ -1,0 +1,82 @@
+# Cloudflare Tunnel
+
+Secure outbound-only connections between infrastructure and Cloudflare's global network.
+
+## Overview
+
+Cloudflare Tunnel (formerly Argo Tunnel) enables:
+- **Outbound-only connections** - No inbound ports or firewall changes
+- **Public hostname routing** - Expose local services to internet
+- **Private network access** - Connect internal networks via WARP
+- **Zero Trust integration** - Built-in access policies
+
+**Architecture**: Tunnel (persistent object) → Connector (`cloudflared` process) → Origin services
+
+## Quick Start
+
+```bash
+# Install cloudflared
+brew install cloudflared  # macOS
+
+# Authenticate
+cloudflared tunnel login
+
+# Create tunnel
+cloudflared tunnel create my-tunnel
+
+# Route DNS
+cloudflared tunnel route dns my-tunnel app.example.com
+
+# Run tunnel
+cloudflared tunnel run my-tunnel
+```
+
+## Core Commands
+
+```bash
+# Tunnel lifecycle
+cloudflared tunnel create <name>
+cloudflared tunnel list
+cloudflared tunnel info <name>
+cloudflared tunnel delete <name>
+
+# DNS routing
+cloudflared tunnel route dns <tunnel> <hostname>
+cloudflared tunnel route list
+
+# Private network
+cloudflared tunnel route ip add 10.0.0.0/8 <tunnel>
+
+# Run tunnel
+cloudflared tunnel run <name>
+```
+
+## Configuration Example
+
+```yaml
+# ~/.cloudflared/config.yml
+tunnel: 6ff42ae2-765d-4adf-8112-31c55c1551ef
+credentials-file: /root/.cloudflared/6ff42ae2-765d-4adf-8112-31c55c1551ef.json
+
+ingress:
+  - hostname: app.example.com
+    service: http://localhost:8000
+  - hostname: api.example.com
+    service: https://localhost:8443
+    originRequest:
+      noTLSVerify: true
+  - service: http_status:404
+```
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - Config file options, ingress rules, TLS settings
+- [api.md](./api.md) - Cloudflare API, remotely-managed tunnels, programmatic control
+- [patterns.md](./patterns.md) - Docker, Kubernetes, HA, service types, use cases
+- [gotchas.md](./gotchas.md) - Troubleshooting, limitations, best practices
+
+## See Also
+
+- [workers](../workers/) - Workers with Tunnel integration
+- [access](../access/) - Zero Trust access policies
+- [warp](../warp/) - WARP client for private networks

--- a/.agent/services/hosting/cloudflare-platform/references/tunnel/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/tunnel/api.md
@@ -1,0 +1,105 @@
+# Tunnel API
+
+## Cloudflare API Access
+
+**Base URL**: `https://api.cloudflare.com/client/v4`
+
+**Authentication**:
+```bash
+Authorization: Bearer ${CF_API_TOKEN}
+```
+
+## Create Tunnel
+
+```bash
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/tunnels" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "name": "my-tunnel",
+    "tunnel_secret": "<base64-secret>"
+  }'
+```
+
+## List Tunnels
+
+```bash
+curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/tunnels" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}"
+```
+
+## Get Tunnel Info
+
+```bash
+curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/tunnels/{tunnel_id}" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}"
+```
+
+## Update Tunnel Config
+
+```bash
+curl -X PUT "https://api.cloudflare.com/client/v4/accounts/{account_id}/tunnels/{tunnel_id}/configurations" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "config": {
+      "ingress": [
+        {"hostname": "app.example.com", "service": "http://localhost:8000"},
+        {"service": "http_status:404"}
+      ]
+    }
+  }'
+```
+
+## Delete Tunnel
+
+```bash
+curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/{account_id}/tunnels/{tunnel_id}" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}"
+```
+
+## Remotely-Managed Tunnels
+
+### Via Dashboard
+1. **Zero Trust** > **Networks** > **Tunnels**
+2. **Create a tunnel** > **Cloudflared**
+3. Copy install command with token
+4. Run on origin:
+```bash
+cloudflared service install <TOKEN>
+```
+
+### Via Token
+```bash
+# Run with token (no config file needed)
+cloudflared tunnel --no-autoupdate run --token ${TUNNEL_TOKEN}
+
+# Docker
+docker run cloudflare/cloudflared:latest tunnel --no-autoupdate run --token ${TUNNEL_TOKEN}
+```
+
+## DNS Routes API
+
+```bash
+# Create DNS route
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/tunnels/{tunnel_id}/connections" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  --data '{"hostname": "app.example.com"}'
+
+# Delete route
+curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/{account_id}/tunnels/{tunnel_id}/connections/{route_id}" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}"
+```
+
+## Private Network Routes API
+
+```bash
+# Add IP route
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/tunnels/{tunnel_id}/routes" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  --data '{"ip_network": "10.0.0.0/8"}'
+
+# List IP routes
+curl -X GET "https://api.cloudflare.com/client/v4/accounts/{account_id}/tunnels/{tunnel_id}/routes" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}"
+```

--- a/.agent/services/hosting/cloudflare-platform/references/tunnel/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/tunnel/configuration.md
@@ -1,0 +1,113 @@
+# Tunnel Configuration
+
+## Config File Location
+
+```
+~/.cloudflared/config.yml          # User config
+/etc/cloudflared/config.yml        # System-wide (Linux)
+```
+
+## Basic Structure
+
+```yaml
+tunnel: <UUID>
+credentials-file: /path/to/<UUID>.json
+
+ingress:
+  - hostname: app.example.com
+    service: http://localhost:8000
+  - service: http_status:404  # Required catch-all
+```
+
+## Ingress Rules
+
+Rules evaluated **top to bottom**, first match wins.
+
+```yaml
+ingress:
+  # Exact hostname + path regex
+  - hostname: static.example.com
+    path: \.(jpg|png|css|js)$
+    service: https://localhost:8001
+  
+  # Wildcard hostname
+  - hostname: "*.example.com"
+    service: https://localhost:8002
+  
+  # Path only (all hostnames)
+  - path: /api/.*
+    service: http://localhost:9000
+  
+  # Catch-all (required)
+  - service: http_status:404
+```
+
+**Validation**:
+```bash
+cloudflared tunnel ingress validate
+cloudflared tunnel ingress rule https://foo.example.com
+```
+
+## Service Types
+
+| Protocol | Format | Client Requirement |
+|----------|--------|-------------------|
+| HTTP | `http://localhost:8000` | Browser |
+| HTTPS | `https://localhost:8443` | Browser |
+| TCP | `tcp://localhost:2222` | `cloudflared access tcp` |
+| SSH | `ssh://localhost:22` | `cloudflared access ssh` |
+| RDP | `rdp://localhost:3389` | `cloudflared access rdp` |
+| Unix | `unix:/path/to/socket` | Browser |
+| Test | `hello_world` | Browser |
+
+## Origin Configuration
+
+### Connection Settings
+```yaml
+originRequest:
+  connectTimeout: 30s
+  tlsTimeout: 10s
+  tcpKeepAlive: 30s
+  keepAliveTimeout: 90s
+  keepAliveConnections: 100
+```
+
+### TLS Settings
+```yaml
+originRequest:
+  noTLSVerify: true                      # Disable cert verification
+  originServerName: "app.internal"       # Override SNI
+  caPool: /path/to/ca.pem                # Custom CA
+```
+
+### HTTP Settings
+```yaml
+originRequest:
+  disableChunkedEncoding: true
+  httpHostHeader: "app.internal"
+  http2Origin: true
+```
+
+## Private Network Mode
+
+```yaml
+tunnel: <UUID>
+credentials-file: /path/to/creds.json
+
+warp-routing:
+  enabled: true
+```
+
+```bash
+cloudflared tunnel route ip add 10.0.0.0/8 my-tunnel
+cloudflared tunnel route ip add 192.168.1.100/32 my-tunnel
+```
+
+## Environment Variables
+
+```bash
+TUNNEL_TOKEN=<token>                    # Remotely-managed token
+TUNNEL_ORIGIN_CERT=/path/to/cert.pem   # Override cert path
+NO_AUTOUPDATE=true                      # Disable auto-updates
+TUNNEL_LOGLEVEL=debug                   # Log level
+```

--- a/.agent/services/hosting/cloudflare-platform/references/tunnel/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/tunnel/gotchas.md
@@ -1,0 +1,115 @@
+# Tunnel Gotchas
+
+## Common Issues
+
+### Error 1016 (Origin DNS Error)
+
+**Cause**: Tunnel not running or not connected
+
+**Fix**:
+```bash
+cloudflared tunnel info my-tunnel     # Check status
+ps aux | grep cloudflared             # Verify running
+journalctl -u cloudflared -n 100      # Check logs
+```
+
+### Certificate Errors
+
+**Issue**: Self-signed certs rejected
+
+**Fix**:
+```yaml
+originRequest:
+  noTLSVerify: true      # Dev only
+  caPool: /path/to/ca.pem  # Custom CA
+```
+
+### Connection Timeouts
+
+**Issue**: Origin slow to respond
+
+**Fix**:
+```yaml
+originRequest:
+  connectTimeout: 60s
+  tlsTimeout: 20s
+  keepAliveTimeout: 120s
+```
+
+### Tunnel Not Starting
+
+**Check**:
+```bash
+cloudflared tunnel ingress validate  # Validate config
+ls -la ~/.cloudflared/*.json         # Verify credentials
+cloudflared tunnel list              # Verify tunnel exists
+```
+
+## Best Practices
+
+### Security
+1. Use remotely-managed tunnels for centralized control
+2. Enable Access policies for sensitive services
+3. Rotate tunnel credentials regularly
+4. Verify TLS certs (`noTLSVerify: false`)
+5. Restrict `bastion` service type
+
+### Performance
+1. Run multiple replicas for HA
+2. Place `cloudflared` close to origin (same network)
+3. Use HTTP/2 for gRPC (`http2Origin: true`)
+4. Tune keepalive for long-lived connections
+5. Monitor connection counts
+
+### Configuration
+1. Use environment variables for secrets
+2. Version control config files
+3. Validate before deploying (`cloudflared tunnel ingress validate`)
+4. Test rules (`cloudflared tunnel ingress rule <URL>`)
+5. Document rule order (first match wins)
+
+### Operations
+1. Monitor tunnel health in dashboard
+2. Set up disconnect alerts
+3. Graceful shutdown for config updates
+4. Keep `cloudflared` updated (1 year support)
+5. Use `--no-autoupdate` in prod; control updates manually
+
+## Limitations
+
+- **Free tier**: Unlimited tunnels and traffic
+- **Tunnel limit**: 1000 replicas per tunnel
+- **Connection duration**: No hard limit (hours to days)
+- **Long-lived connections**: Drop during replica updates (WebSocket, SSH, UDP)
+
+## Debug Mode
+
+```bash
+cloudflared tunnel --loglevel debug run my-tunnel
+cloudflared tunnel ingress rule https://app.example.com
+```
+
+## Migration Strategies
+
+### From Ngrok
+```yaml
+# Ngrok: ngrok http 8000
+# Cloudflare Tunnel:
+ingress:
+  - hostname: app.example.com
+    service: http://localhost:8000
+  - service: http_status:404
+```
+
+### From VPN
+```yaml
+# Replace VPN with private network routing
+warp-routing:
+  enabled: true
+```
+
+```bash
+cloudflared tunnel route ip add 10.0.0.0/8 my-tunnel
+```
+
+Users install WARP client instead of VPN.

--- a/.agent/services/hosting/cloudflare-platform/references/tunnel/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/tunnel/patterns.md
@@ -1,0 +1,157 @@
+# Tunnel Patterns
+
+## Docker Deployment
+
+### Quick Tunnel
+```dockerfile
+FROM cloudflare/cloudflared:latest
+CMD ["tunnel", "--url", "http://app:8080"]
+```
+
+### Named Tunnel
+```yaml
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    command: tunnel --no-autoupdate run --token ${TUNNEL_TOKEN}
+    restart: unless-stopped
+  app:
+    image: myapp:latest
+```
+
+### With Config File
+```yaml
+services:
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    volumes:
+      - ./config.yml:/etc/cloudflared/config.yml:ro
+      - ./credentials.json:/etc/cloudflared/credentials.json:ro
+    command: tunnel --config /etc/cloudflared/config.yml run
+```
+
+## Kubernetes Deployment
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cloudflared
+  template:
+    metadata:
+      labels:
+        app: cloudflared
+    spec:
+      containers:
+      - name: cloudflared
+        image: cloudflare/cloudflared:latest
+        args:
+        - tunnel
+        - --no-autoupdate
+        - run
+        - --token
+        - $(TUNNEL_TOKEN)
+        env:
+        - name: TUNNEL_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: tunnel-credentials
+              key: token
+```
+
+## High Availability
+
+```yaml
+# Same config on multiple servers
+tunnel: <UUID>
+credentials-file: /path/to/creds.json
+
+ingress:
+  - hostname: app.example.com
+    service: http://localhost:8000
+  - service: http_status:404
+```
+
+Run on multiple machines:
+```bash
+# Server 1
+cloudflared tunnel run my-tunnel
+
+# Server 2 (same config)
+cloudflared tunnel run my-tunnel
+```
+
+Cloudflare automatically load balances. Long-lived connections (WebSocket, SSH) will drop during updates.
+
+## Use Cases
+
+### Web Application
+```yaml
+ingress:
+  - hostname: myapp.example.com
+    service: http://localhost:3000
+  - service: http_status:404
+```
+
+### SSH Access
+```yaml
+ingress:
+  - hostname: ssh.example.com
+    service: ssh://localhost:22
+  - service: http_status:404
+```
+
+Client:
+```bash
+cloudflared access ssh --hostname ssh.example.com
+```
+
+### gRPC Service
+```yaml
+ingress:
+  - hostname: grpc.example.com
+    service: http://localhost:50051
+    originRequest:
+      http2Origin: true
+  - service: http_status:404
+```
+
+### Multiple Environments
+```yaml
+ingress:
+  - hostname: prod.example.com
+    service: http://localhost:8001
+  - hostname: staging.example.com
+    service: http://localhost:8002
+  - hostname: dev.example.com
+    service: http://localhost:8003
+  - service: http_status:404
+```
+
+## Service Installation
+
+### Linux systemd
+```bash
+cloudflared service install
+systemctl start cloudflared
+systemctl enable cloudflared
+systemctl status cloudflared
+
+# Logs
+journalctl -u cloudflared -f
+```
+
+### macOS launchd
+```bash
+sudo cloudflared service install
+sudo launchctl start com.cloudflare.cloudflared
+sudo launchctl load -w /Library/LaunchDaemons/com.cloudflare.cloudflared.plist
+
+# Logs
+tail -f /Library/Logs/com.cloudflare.cloudflared.err.log
+```

--- a/.agent/services/hosting/cloudflare-platform/references/turn/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/turn/README.md
@@ -1,0 +1,699 @@
+# Cloudflare TURN Service
+
+Expert guidance for implementing Cloudflare TURN Service in WebRTC applications.
+
+## Overview
+
+Cloudflare TURN (Traversal Using Relays around NAT) Service is a managed relay service for WebRTC applications. TURN acts as a relay point for traffic between WebRTC clients and SFUs, particularly when direct peer-to-peer communication is obstructed by NATs or firewalls. The service runs on Cloudflare's global anycast network across 310+ cities.
+
+## Key Characteristics
+
+- **Anycast Architecture**: Automatically connects clients to the closest Cloudflare location
+- **Global Network**: Available across Cloudflare's entire network (excluding China Network)
+- **Zero Configuration**: No need to manually select regions or servers
+- **Protocol Support**: STUN/TURN over UDP, TCP, and TLS
+- **Free Tier**: Free when used with Cloudflare Calls SFU, otherwise $0.05/GB outbound
+
+## Service Addresses and Ports
+
+### STUN over UDP
+- **Primary**: `stun.cloudflare.com:3478/udp`
+- **Alternate**: `stun.cloudflare.com:53/udp` (not recommended as primary, blocked by many ISPs/browsers)
+
+### TURN over UDP
+- **Primary**: `turn.cloudflare.com:3478/udp`
+- **Alternate**: `turn.cloudflare.com:53/udp`
+
+### TURN over TCP
+- **Primary**: `turn.cloudflare.com:3478/tcp`
+- **Alternate**: `turn.cloudflare.com:80/tcp`
+
+### TURN over TLS
+- **Primary**: `turn.cloudflare.com:5349/tcp`
+- **Alternate**: `turn.cloudflare.com:443/tcp`
+
+## API Endpoints
+
+All API endpoints require authentication with a Cloudflare API token with "Calls Write" permission.
+
+Base URL: `https://api.cloudflare.com/client/v4`
+
+### List TURN Keys
+```
+GET /accounts/{account_id}/calls/turn_keys
+```
+
+### Get TURN Key Details
+```
+GET /accounts/{account_id}/calls/turn_keys/{key_id}
+```
+
+### Create TURN Key
+```
+POST /accounts/{account_id}/calls/turn_keys
+Content-Type: application/json
+
+{
+  "name": "my-turn-key"
+}
+```
+
+**Response includes**:
+- `uid`: Key identifier
+- `key`: The actual secret key (only returned on creation)
+- `name`: Human-readable name
+- `created`: ISO 8601 timestamp
+- `modified`: ISO 8601 timestamp
+
+### Update TURN Key
+```
+PUT /accounts/{account_id}/calls/turn_keys/{key_id}
+Content-Type: application/json
+
+{
+  "name": "updated-name"
+}
+```
+
+### Delete TURN Key
+```
+DELETE /accounts/{account_id}/calls/turn_keys/{key_id}
+```
+
+## Generate Temporary Credentials
+
+To use TURN, clients need temporary credentials. Generate them via:
+
+```
+POST https://rtc.live.cloudflare.com/v1/turn/keys/{key_id}/credentials/generate
+Authorization: Bearer {key_secret}
+Content-Type: application/json
+
+{
+  "ttl": 86400  // optional, defaults to reasonable value
+}
+```
+
+**Response**:
+```json
+{
+  "iceServers": {
+    "urls": [
+      "stun:stun.cloudflare.com:3478",
+      "turn:turn.cloudflare.com:3478?transport=udp",
+      "turn:turn.cloudflare.com:3478?transport=tcp",
+      "turns:turn.cloudflare.com:5349?transport=tcp"
+    ],
+    "username": "generated-username",
+    "credential": "generated-credential"
+  }
+}
+```
+
+## Implementation Patterns
+
+### Basic TURN Configuration (Browser)
+
+```typescript
+interface RTCIceServer {
+  urls: string | string[];
+  username?: string;
+  credential?: string;
+  credentialType?: "password" | "oauth";
+}
+
+async function getTURNConfig(): Promise<RTCIceServer[]> {
+  const response = await fetch('/api/turn-credentials');
+  const data = await response.json();
+  
+  return [
+    {
+      urls: 'stun:stun.cloudflare.com:3478'
+    },
+    {
+      urls: [
+        'turn:turn.cloudflare.com:3478?transport=udp',
+        'turn:turn.cloudflare.com:3478?transport=tcp',
+        'turns:turn.cloudflare.com:5349?transport=tcp'
+      ],
+      username: data.username,
+      credential: data.credential,
+      credentialType: 'password'
+    }
+  ];
+}
+
+// Use in RTCPeerConnection
+const iceServers = await getTURNConfig();
+const peerConnection = new RTCPeerConnection({ iceServers });
+```
+
+### Credential Generation (Backend - Node.js/TypeScript)
+
+```typescript
+async function generateTURNCredentials(
+  turnKeyId: string,
+  turnKeySecret: string,
+  ttl: number = 86400
+): Promise<{ username: string; credential: string; urls: string[] }> {
+  const response = await fetch(
+    `https://rtc.live.cloudflare.com/v1/turn/keys/${turnKeyId}/credentials/generate`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${turnKeySecret}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ ttl })
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Failed to generate TURN credentials: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return {
+    username: data.iceServers.username,
+    credential: data.iceServers.credential,
+    urls: data.iceServers.urls
+  };
+}
+```
+
+### Cloudflare Worker Integration
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    
+    if (url.pathname !== '/turn-credentials') {
+      return new Response('Not found', { status: 404 });
+    }
+
+    // Validate client (implement your auth logic)
+    const authHeader = request.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    // Generate credentials
+    const response = await fetch(
+      `https://rtc.live.cloudflare.com/v1/turn/keys/${env.TURN_KEY_ID}/credentials/generate`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${env.TURN_KEY_SECRET}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ ttl: 3600 })
+      }
+    );
+
+    if (!response.ok) {
+      return new Response('Failed to generate credentials', { status: 500 });
+    }
+
+    const data = await response.json();
+    
+    return new Response(JSON.stringify({
+      iceServers: [
+        {
+          urls: 'stun:stun.cloudflare.com:3478'
+        },
+        {
+          urls: data.iceServers.urls,
+          username: data.iceServers.username,
+          credential: data.iceServers.credential
+        }
+      ]
+    }), {
+      headers: { 'Content-Type': 'application/json' }
+    });
+  }
+};
+```
+
+### Credentials Caching Pattern
+
+```typescript
+class TURNCredentialsManager {
+  private credentials: {
+    username: string;
+    credential: string;
+    urls: string[];
+    expiresAt: number;
+  } | null = null;
+
+  async getCredentials(
+    turnKeyId: string,
+    turnKeySecret: string
+  ): Promise<RTCIceServer[]> {
+    const now = Date.now();
+    
+    // Return cached credentials if still valid
+    if (this.credentials && this.credentials.expiresAt > now) {
+      return this.buildIceServers(this.credentials);
+    }
+
+    // Generate new credentials
+    const ttl = 3600; // 1 hour
+    const data = await this.generateCredentials(turnKeyId, turnKeySecret, ttl);
+    
+    this.credentials = {
+      username: data.username,
+      credential: data.credential,
+      urls: data.urls,
+      expiresAt: now + (ttl * 1000) - 60000 // Refresh 1 min early
+    };
+
+    return this.buildIceServers(this.credentials);
+  }
+
+  private async generateCredentials(
+    turnKeyId: string,
+    turnKeySecret: string,
+    ttl: number
+  ) {
+    const response = await fetch(
+      `https://rtc.live.cloudflare.com/v1/turn/keys/${turnKeyId}/credentials/generate`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${turnKeySecret}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ ttl })
+      }
+    );
+
+    const data = await response.json();
+    return {
+      username: data.iceServers.username,
+      credential: data.iceServers.credential,
+      urls: data.iceServers.urls
+    };
+  }
+
+  private buildIceServers(creds: {
+    username: string;
+    credential: string;
+    urls: string[];
+  }): RTCIceServer[] {
+    return [
+      { urls: 'stun:stun.cloudflare.com:3478' },
+      {
+        urls: creds.urls,
+        username: creds.username,
+        credential: creds.credential,
+        credentialType: 'password' as const
+      }
+    ];
+  }
+}
+```
+
+### Type-Safe Configuration
+
+```typescript
+interface CloudflareTURNConfig {
+  keyId: string;
+  keySecret: string;
+  ttl?: number;
+  protocols?: ('udp' | 'tcp' | 'tls')[];
+}
+
+interface TURNCredentials {
+  username: string;
+  credential: string;
+  urls: string[];
+  expiresAt: Date;
+}
+
+function validateRTCIceServer(obj: unknown): obj is RTCIceServer {
+  if (!obj || typeof obj !== 'object') {
+    return false;
+  }
+
+  const server = obj as Record<string, unknown>;
+
+  if (typeof server.urls !== 'string' && !Array.isArray(server.urls)) {
+    return false;
+  }
+
+  if (server.username && typeof server.username !== 'string') {
+    return false;
+  }
+
+  if (server.credential && typeof server.credential !== 'string') {
+    return false;
+  }
+
+  return true;
+}
+
+async function fetchTURNServers(
+  config: CloudflareTURNConfig
+): Promise<RTCIceServer[]> {
+  const response = await fetch(
+    `https://rtc.live.cloudflare.com/v1/turn/keys/${config.keyId}/credentials/generate`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${config.keySecret}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ ttl: config.ttl ?? 3600 })
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`TURN credential generation failed: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const iceServers = [
+    { urls: 'stun:stun.cloudflare.com:3478' },
+    {
+      urls: data.iceServers.urls,
+      username: data.iceServers.username,
+      credential: data.iceServers.credential,
+      credentialType: 'password' as const
+    }
+  ];
+
+  // Validate before returning
+  if (!iceServers.every(validateRTCIceServer)) {
+    throw new Error('Invalid ICE server configuration received');
+  }
+
+  return iceServers;
+}
+```
+
+## Common Use Cases
+
+### 1. Video Conferencing
+Use TURN as fallback when direct peer-to-peer fails due to restrictive NATs/firewalls.
+
+```typescript
+const config: RTCConfiguration = {
+  iceServers: await getTURNConfig(),
+  iceTransportPolicy: 'all' // Try direct connection first
+};
+```
+
+### 2. Screen Sharing Applications
+Ensure connectivity for high-bandwidth screen sharing streams.
+
+```typescript
+const iceServers = await getTURNConfig();
+const pc = new RTCPeerConnection({ 
+  iceServers,
+  bundlePolicy: 'max-bundle' // Reduce overhead
+});
+```
+
+### 3. IoT Device Communication
+Enable WebRTC for devices behind restrictive NATs.
+
+```typescript
+// Prefer relay for predictable connectivity
+const config: RTCConfiguration = {
+  iceServers: await getTURNConfig(),
+  iceTransportPolicy: 'relay' // Force TURN usage
+};
+```
+
+### 4. Live Streaming (WHIP/WHEP)
+Integrate with Cloudflare Stream for low-latency broadcasting.
+
+```typescript
+const turnServers = await getTURNConfig();
+// Use in WHIP/WHEP workflow with Cloudflare Stream
+```
+
+## Limits and Quotas
+
+Per TURN allocation (per user):
+- **IP addresses**: >5 new unique IPs per second
+- **Packet rate**: 5-10k packets per second (inbound/outbound)
+- **Data rate**: 50-100 Mbps (inbound/outbound)
+- **MTU**: No specific limit
+- **Burst rates**: Higher than documented limits
+
+Limits apply per allocation, not account-wide. Exceeding limits results in packet drops.
+
+## TLS Configuration
+
+### Supported TLS Versions
+- TLS 1.1
+- TLS 1.2
+- TLS 1.3
+
+### Recommended Ciphers (TLS 1.3)
+- AEAD-AES128-GCM-SHA256
+- AEAD-AES256-GCM-SHA384
+- AEAD-CHACHA20-POLY1305-SHA256
+
+### Recommended Ciphers (TLS 1.2)
+- ECDHE-ECDSA-AES128-GCM-SHA256
+- ECDHE-RSA-AES128-GCM-SHA256
+- ECDHE-RSA-AES128-SHA (also TLS 1.1)
+- AES128-GCM-SHA256
+
+## Environment Variables Pattern
+
+```bash
+# .env
+CLOUDFLARE_ACCOUNT_ID=your_account_id
+CLOUDFLARE_API_TOKEN=your_api_token
+TURN_KEY_ID=your_turn_key_id
+TURN_KEY_SECRET=your_turn_key_secret
+```
+
+```typescript
+// config.ts
+import { z } from 'zod';
+
+const envSchema = z.object({
+  CLOUDFLARE_ACCOUNT_ID: z.string().min(1),
+  CLOUDFLARE_API_TOKEN: z.string().min(1),
+  TURN_KEY_ID: z.string().min(1),
+  TURN_KEY_SECRET: z.string().min(1)
+});
+
+export const config = envSchema.parse(process.env);
+```
+
+## Wrangler Configuration
+
+```toml
+# wrangler.toml
+name = "turn-credentials-api"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+[vars]
+TURN_KEY_ID = "your-turn-key-id"
+
+[[env.production.kv_namespaces]]
+binding = "CREDENTIALS_CACHE"
+id = "your-kv-namespace-id"
+
+[env.production]
+vars = { ENVIRONMENT = "production" }
+
+# Store TURN_KEY_SECRET in secrets
+# wrangler secret put TURN_KEY_SECRET
+```
+
+## Security Best Practices
+
+1. **Never expose TURN key secrets client-side**
+   - Always generate credentials server-side
+   - Use a backend API endpoint
+
+2. **Implement rate limiting**
+   ```typescript
+   // Limit credential generation per client
+   const rateLimiter = new Map<string, number>();
+   
+   function checkRateLimit(clientId: string): boolean {
+     const lastRequest = rateLimiter.get(clientId) ?? 0;
+     const now = Date.now();
+     
+     if (now - lastRequest < 5000) { // 5 second cooldown
+       return false;
+     }
+     
+     rateLimiter.set(clientId, now);
+     return true;
+   }
+   ```
+
+3. **Set appropriate TTLs**
+   - Short-lived sessions: 1800-3600 seconds (30 min - 1 hour)
+   - Long-lived sessions: 86400 seconds (24 hours max recommended)
+
+4. **Validate client authentication**
+   ```typescript
+   async function validateClient(request: Request): Promise<boolean> {
+     const token = request.headers.get('Authorization')?.split(' ')[1];
+     if (!token) return false;
+     
+     // Implement JWT validation or session check
+     return validateToken(token);
+   }
+   ```
+
+5. **Monitor usage**
+   - Track credential generation requests
+   - Alert on unusual patterns
+   - Log failed authentication attempts
+
+## Troubleshooting
+
+### Issue: TURN credentials not working
+**Check:**
+- Key ID and secret are correct
+- Credentials haven't expired (check TTL)
+- Server can reach rtc.live.cloudflare.com
+- Network allows outbound HTTPS
+
+### Issue: Slow connection establishment
+**Solutions:**
+- Ensure proper ICE candidate gathering
+- Check network latency to Cloudflare edge
+- Verify firewall allows WebRTC ports
+- Consider using TURN over TLS (port 443)
+
+### Issue: High packet loss
+**Check:**
+- Not exceeding rate limits (5-10k pps)
+- Not exceeding bandwidth limits (50-100 Mbps)
+- Not connecting to too many unique IPs (>5/sec)
+- Client network quality
+
+### Debugging ICE Connectivity
+
+```typescript
+pc.addEventListener('icecandidate', (event) => {
+  if (event.candidate) {
+    console.log('ICE candidate:', {
+      type: event.candidate.type,
+      protocol: event.candidate.protocol,
+      address: event.candidate.address,
+      port: event.candidate.port
+    });
+  }
+});
+
+pc.addEventListener('iceconnectionstatechange', () => {
+  console.log('ICE connection state:', pc.iceConnectionState);
+});
+
+// Check which candidate pair was selected
+const stats = await pc.getStats();
+stats.forEach(report => {
+  if (report.type === 'candidate-pair' && report.selected) {
+    console.log('Selected candidate pair:', report);
+  }
+});
+```
+
+## Monitoring and Analytics
+
+```typescript
+interface TURNMetrics {
+  totalRequests: number;
+  failedRequests: number;
+  averageLatency: number;
+  activeConnections: number;
+}
+
+class TURNMonitor {
+  private metrics: TURNMetrics = {
+    totalRequests: 0,
+    failedRequests: 0,
+    averageLatency: 0,
+    activeConnections: 0
+  };
+
+  async trackRequest<T>(
+    operation: () => Promise<T>
+  ): Promise<T> {
+    const start = Date.now();
+    this.metrics.totalRequests++;
+
+    try {
+      const result = await operation();
+      this.updateLatency(Date.now() - start);
+      return result;
+    } catch (error) {
+      this.metrics.failedRequests++;
+      throw error;
+    }
+  }
+
+  private updateLatency(latency: number): void {
+    this.metrics.averageLatency = 
+      (this.metrics.averageLatency + latency) / 2;
+  }
+
+  getMetrics(): TURNMetrics {
+    return { ...this.metrics };
+  }
+}
+```
+
+## Architecture Considerations
+
+### Anycast Benefits
+- **Automatic routing**: Clients connect to nearest location
+- **No region selection**: BGP handles routing
+- **Low latency**: 95% of users within 50ms of edge
+- **Fault tolerance**: Network handles failover
+
+### When to Use TURN
+- **Restrictive NATs**: Symmetric NATs that block direct connections
+- **Corporate firewalls**: Environments blocking WebRTC ports
+- **Mobile networks**: Carrier-grade NAT scenarios
+- **Predictable connectivity**: When reliability > efficiency
+
+### Integration with Cloudflare Calls SFU
+```typescript
+// TURN is automatically used when needed
+// Cloudflare Calls handles TURN + SFU coordination
+const session = await callsClient.createSession({
+  appId: 'your-app-id',
+  sessionId: 'meeting-123'
+});
+```
+
+## Cost Optimization
+
+1. **Use appropriate TTLs**: Don't over-provision credential lifetime
+2. **Implement credential caching**: Reuse credentials when possible
+3. **Set iceTransportPolicy wisely**:
+   - `'all'`: Try direct first (recommended for most cases)
+   - `'relay'`: Force TURN (only when necessary)
+4. **Monitor usage**: Track bandwidth to avoid surprises
+5. **Use with Cloudflare Calls**: Free when used with SFU
+
+## Additional Resources
+
+- [Cloudflare Calls Documentation](https://developers.cloudflare.com/calls/)
+- [Cloudflare TURN Service Docs](https://developers.cloudflare.com/realtime/turn/)
+- [Cloudflare API Reference](https://developers.cloudflare.com/api/resources/calls/subresources/turn/)
+- [WebRTC for the Curious](https://webrtcforthecurious.com/)
+- [Orange Meets (Open Source Example)](https://github.com/cloudflare/orange)
+
+## Related Cloudflare Services
+
+- **Cloudflare Calls SFU**: Managed Selective Forwarding Unit
+- **Cloudflare Stream**: Video streaming with WHIP/WHEP support
+- **Cloudflare Workers**: Backend for credential generation
+- **Cloudflare KV**: Credential caching
+- **Cloudflare Durable Objects**: Session state management

--- a/.agent/services/hosting/cloudflare-platform/references/turnstile/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/turnstile/README.md
@@ -1,0 +1,14 @@
+# Cloudflare Turnstile Implementation Skill Reference
+
+Expert guidance for implementing Cloudflare Turnstile - a smart CAPTCHA alternative that protects websites from bots without showing traditional CAPTCHA puzzles....
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/turnstile/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/turnstile/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+See main documentation.

--- a/.agent/services/hosting/cloudflare-platform/references/turnstile/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/turnstile/configuration.md
@@ -1,0 +1,19 @@
+## Configuration Options
+
+### Widget Configurations
+```javascript
+{
+  sitekey: 'required',              // Your widget sitekey
+  action: 'optional-string',        // Custom action identifier for analytics
+  cData: 'optional-string',         // Custom data passed back in validation
+  callback: (token) => {},          // Success callback with token
+  'error-callback': (code) => {},   // Error callback
+  'expired-callback': () => {},     // Token expiry callback
+  'timeout-callback': () => {},     // Challenge timeout callback
+  'before-interactive-callback': () => {}, // Before showing checkbox
+  'after-interactive-callback': () => {},  // After checkbox interaction
+  theme: 'auto',                    // 'light', 'dark', 'auto'
+  size: 'normal',                   // 'normal', 'flexible', 'compact'
+  tabindex: 0,                      // Tab index for accessibility
+  'response-field': true,           // Create hidden input (default: true)
+  'response-field-name': 'cf-turnstile-response', /

--- a/.agent/services/hosting/cloudflare-platform/references/turnstile/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/turnstile/gotchas.md
@@ -1,0 +1,27 @@
+## Troubleshooting
+
+### Widget Not Rendering
+- Check browser console for errors
+- Verify sitekey is correct
+- Ensure JavaScript is enabled
+- Check for CSP (Content Security Policy) blocking script
+- Verify not using `file://` protocol (only `http://` and `https://` work)
+
+### Validation Failing
+- Check secret key is correct
+- Verify token not expired (>5 min old)
+- Ensure token not already validated (single-use)
+- Check server can reach Siteverify API
+- Verify not using test secret key in production
+
+### CSP Configuration
+```html
+<meta http-equiv="Content-Security-Policy" 
+      content="script-src 'self' https://challenges.cloudflare.com; 
+               frame-src https://challenges.cloudflare.com;">
+```
+
+## Reference
+
+### Official Docs
+- [Turnstile Overview](https://developers.cloudflare

--- a/.agent/services/hosting/cloudflare-platform/references/turnstile/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/turnstile/patterns.md
@@ -1,0 +1,41 @@
+## Common Pitfalls
+
+### ❌ Skipping Server-Side Validation
+```javascript
+// WRONG - Client-only, easily bypassed
+<form onsubmit="return window.turnstileToken ? true : false">
+```
+
+```javascript
+// CORRECT - Always validate server-side
+app.post('/submit', async (req, res) => {
+  const validation = await validateTurnstile(token, ip);
+  if (!validation.success) {
+    return res.status(400).json({ error: 'Invalid' });
+  }
+  // Process request
+});
+```
+
+### ❌ Exposing Secret Key
+```javascript
+// WRONG - Secret in client code
+const SECRET = 'your-secret-key';
+fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+  body: JSON.stringify({ secret: SECRET, response: token })
+});
+```
+
+```javascript
+// CORRECT - Validation on server only
+// Client sends token to your backend
+// Backend validates with secret key
+```
+
+### ❌ Not Handling Token Expiry
+```javascript
+// WRONG - No expiry handling
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  submitForm(turnstileToken);
+})

--- a/.agent/services/hosting/cloudflare-platform/references/vectorize/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/vectorize/README.md
@@ -1,0 +1,682 @@
+# Cloudflare Vectorize Skill
+
+Expert guidance for Cloudflare Vectorize - globally distributed vector database for AI applications.
+
+## Overview
+
+Vectorize is Cloudflare's vector database that enables building full-stack AI-powered applications with Workers. It stores and queries vector embeddings for semantic search, recommendations, classification, and anomaly detection.
+
+**Key Features:**
+- Globally distributed vector database
+- Seamless integration with Workers AI
+- Support for dimensions up to 1536 (32-bit float precision)
+- Metadata filtering (up to 10 indexes per Vectorize index)
+- Namespace support for index segmentation
+- Three distance metrics: euclidean, cosine, dot-product
+- Up to 5M vectors per index (V2)
+
+**Status:** Generally Available (GA)
+
+## Index Configuration
+
+### Creating Indexes
+
+Use `wrangler vectorize create` with required parameters:
+
+```bash
+# Wrangler 3.71.0+ required for V2 indexes
+npx wrangler@latest vectorize create <index-name> \
+  --dimensions=<number> \
+  --metric=<euclidean|cosine|dot-product>
+```
+
+**CRITICAL: Index configuration is immutable after creation. Cannot change dimensions or metric.**
+
+#### Distance Metrics
+
+| Metric | Best For | Score Interpretation |
+|--------|----------|---------------------|
+| `euclidean` | Absolute distance, spatial data | Lower = closer (0.0 = identical) |
+| `cosine` | Text embeddings, semantic similarity | Higher = closer (1.0 = identical) |
+| `dot-product` | Recommendation systems, normalized vectors | Higher = closer |
+
+**Metric Selection:**
+- Text/semantic search: `cosine` (most common)
+- Image similarity: `euclidean`
+- Pre-normalized vectors: `dot-product`
+
+#### Naming Conventions
+
+Index names must:
+- Be lowercase and/or numeric ASCII
+- Start with a letter
+- Use dashes (-) instead of spaces
+- Be < 32 characters
+- Be descriptive: `production-doc-search`, `dev-recommendation-engine`
+
+### Metadata Indexes
+
+Enable filtering on metadata properties (up to 10 per index):
+
+```bash
+# Create metadata index BEFORE inserting vectors
+npx wrangler vectorize create-metadata-index <index-name> \
+  --property-name=<field-name> \
+  --type=<string|number|boolean>
+```
+
+**Important:**
+- Create metadata indexes BEFORE inserting vectors
+- Existing vectors won't be indexed retroactively (must re-upsert)
+- String fields: first 64 bytes indexed (UTF-8 boundary)
+- Number fields: float64 precision
+- Max 10 metadata indexes per Vectorize index
+
+**Cardinality Considerations:**
+- **High cardinality** (UUIDs, millisecond timestamps): Good for `$eq`, poor for range queries
+- **Low cardinality** (enum values, status): Good for filters, less selective
+- **Best practice**: Bucket high-cardinality data (e.g., round timestamps to 5-min windows)
+
+### Management Commands
+
+```bash
+# List metadata indexes
+npx wrangler vectorize list-metadata-index <index-name>
+
+# Delete metadata index
+npx wrangler vectorize delete-metadata-index <index-name> --property-name=<field>
+
+# Get index info (vector count, processed mutations)
+npx wrangler vectorize info <index-name>
+
+# List vector IDs (paginated, 1-1000 per page)
+npx wrangler vectorize list-vectors <index-name> \
+  --count=100 \
+  --cursor=<pagination-cursor>
+```
+
+## Worker Binding
+
+### Configuration
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "vectorize": [
+    {
+      "binding": "VECTORIZE",
+      "index_name": "production-index"
+    }
+  ]
+}
+```
+
+**wrangler.toml:**
+```toml
+[[vectorize]]
+binding = "VECTORIZE"  # Available as env.VECTORIZE
+index_name = "production-index"
+```
+
+### TypeScript Types
+
+```typescript
+export interface Env {
+  VECTORIZE: Vectorize;
+}
+
+// Generate types after config changes
+// npx wrangler types
+```
+
+## Vector Operations
+
+### Vector Format
+
+```typescript
+interface VectorizeVector {
+  id: string;              // Unique identifier (max 64 bytes)
+  values: number[] | Float32Array | Float64Array;  // Match index dimensions
+  namespace?: string;      // Optional partition key (max 64 bytes)
+  metadata?: Record<string, string | number | boolean | null>;  // Max 10 KiB
+}
+```
+
+**Vector Values:**
+- Array of numbers, Float32Array, or Float64Array
+- Must match index dimensions exactly
+- Stored as Float32 (Float64 converted on insert)
+- Dense arrays only (no sparse vectors)
+
+### Insert vs Upsert
+
+```typescript
+// INSERT: Ignore duplicates (keeps first)
+const inserted = await env.VECTORIZE.insert([
+  {
+    id: "1",
+    values: [0.12, 0.45, 0.67, ...],
+    metadata: { url: "/products/sku/123", category: "electronics" }
+  }
+]);
+
+// UPSERT: Overwrite existing (keeps last)
+const upserted = await env.VECTORIZE.upsert([
+  {
+    id: "1",
+    values: [0.15, 0.48, 0.70, ...],
+    metadata: { url: "/products/sku/123", category: "electronics", updated: true }
+  }
+]);
+```
+
+**Key Differences:**
+- `insert()`: Duplicate IDs ignored, first insert wins
+- `upsert()`: Overwrites completely (no merge), last upsert wins
+- Both return `{ mutationId: string }`
+- Asynchronous: Takes a few seconds to be queryable
+
+**Batch Limits:**
+- Workers: 1000 vectors per batch
+- HTTP API: 5000 vectors per batch
+- File upload: 100 MB max
+
+### Querying
+
+#### Basic Query
+
+```typescript
+// Query vector: must match index dimensions
+const queryVector: number[] = [0.13, 0.25, 0.44, ...];
+
+const matches = await env.VECTORIZE.query(queryVector, {
+  topK: 5,                    // Default: 5, Max: 100 (or 20 with values/metadata)
+  returnValues: false,        // Default: false
+  returnMetadata: "none",     // "none" | "indexed" | "all"
+  namespace?: "user-123",     // Optional namespace filter
+  filter?: { category: "electronics" }  // Optional metadata filter
+});
+```
+
+**Response:**
+```typescript
+interface VectorizeMatches {
+  count: number;
+  matches: Array<{
+    id: string;
+    score: number;           // Distance score (interpretation depends on metric)
+    values?: number[];       // If returnValues: true
+    metadata?: Record<string, any>;  // If returnMetadata != "none"
+  }>;
+}
+```
+
+#### Query by ID
+
+```typescript
+// Query using existing vector in index
+const matches = await env.VECTORIZE.queryById("some-vector-id", {
+  topK: 5,
+  returnValues: true,
+  returnMetadata: "all"
+});
+```
+
+#### Get Vectors by ID
+
+```typescript
+// Retrieve specific vectors with values and metadata
+const ids = ["11", "22", "33"];
+const vectors = await env.VECTORIZE.getByIds(ids);
+```
+
+### Metadata Filtering
+
+```typescript
+// Implicit $eq
+const matches = await env.VECTORIZE.query(queryVector, {
+  topK: 10,
+  filter: { category: "electronics" }
+});
+
+// Explicit operators
+const matches = await env.VECTORIZE.query(queryVector, {
+  filter: {
+    category: { $ne: "deprecated" },
+    price: { $gte: 10, $lt: 100 },
+    tags: { $in: ["featured", "sale"] },
+    discontinued: { $ne: true }
+  }
+});
+
+// Nested metadata with dot notation
+const matches = await env.VECTORIZE.query(queryVector, {
+  filter: { "product.brand": "acme" }
+});
+
+// Range query for prefix search (strings)
+const matches = await env.VECTORIZE.query(queryVector, {
+  filter: { 
+    category: { $gte: "elec", $lt: "eled" }  // Matches "electronics"
+  }
+});
+```
+
+**Operators:**
+- `$eq`: Equals (implicit if no operator)
+- `$ne`: Not equals
+- `$in`: In array
+- `$nin`: Not in array
+- `$lt`, `$lte`: Less than (or equal)
+- `$gt`, `$gte`: Greater than (or equal)
+
+**Filter Constraints:**
+- Max 2048 bytes (compact JSON)
+- Keys: no empty, no dots, no `$` prefix, no double-quotes, max 512 chars
+- Values: string, number, boolean, null
+- Range queries: Can combine upper/lower bounds on same field
+- Namespaces filtered before metadata
+
+### Deletion
+
+```typescript
+// Delete by IDs (asynchronous)
+const deleted = await env.VECTORIZE.deleteByIds(["11", "22", "33"]);
+// Returns: { mutationId: string }
+```
+
+### Index Inspection
+
+```typescript
+// Get index configuration
+const details = await env.VECTORIZE.describe();
+// Returns: { dimensions: number, metric: string, vectorCount?: number }
+```
+
+## Namespaces
+
+Partition vectors within a single index by customer, tenant, or category.
+
+```typescript
+// Insert with namespace
+await env.VECTORIZE.insert([
+  { id: "1", values: [...], namespace: "customer-abc" },
+  { id: "2", values: [...], namespace: "customer-xyz" }
+]);
+
+// Query within namespace (applied before vector search)
+const matches = await env.VECTORIZE.query(queryVector, {
+  namespace: "customer-abc"
+});
+```
+
+**Limits:**
+- 50,000 namespaces (Paid) / 1,000 (Free)
+- Max 64 bytes per namespace name
+- Namespace filter applied before metadata filters
+
+## Integration Patterns
+
+### Workers AI Integration
+
+```typescript
+import { Ai } from '@cloudflare/ai';
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const ai = new Ai(env.AI);
+    
+    // Generate embedding
+    const userQuery = "what is a vector database";
+    const embeddings = await ai.run("@cf/baai/bge-base-en-v1.5", {
+      text: [userQuery]
+    });
+    
+    // embeddings.data is number[][]
+    // Pass embeddings.data[0], NOT embeddings or embeddings.data
+    const matches = await env.VECTORIZE.query(embeddings.data[0], {
+      topK: 3,
+      returnMetadata: "all"
+    });
+    
+    return Response.json({ matches });
+  }
+};
+```
+
+**Common Embedding Models:**
+- `@cf/baai/bge-base-en-v1.5`: 768 dimensions, English
+- `@cf/baai/bge-large-en-v1.5`: 1024 dimensions, English
+- `@cf/baai/bge-small-en-v1.5`: 384 dimensions, English
+
+### OpenAI Integration
+
+```typescript
+import OpenAI from 'openai';
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const openai = new OpenAI({ apiKey: env.OPENAI_KEY });
+    
+    const userQuery = "semantic search query";
+    const response = await openai.embeddings.create({
+      model: "text-embedding-ada-002",
+      input: userQuery
+    });
+    
+    // Pass response.data[0].embedding, NOT response
+    const matches = await env.VECTORIZE.query(response.data[0].embedding, {
+      topK: 5,
+      returnMetadata: "all"
+    });
+    
+    return Response.json({ matches });
+  }
+};
+```
+
+### RAG Pattern
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { query } = await request.json();
+    
+    // 1. Generate query embedding
+    const embeddings = await env.AI.run("@cf/baai/bge-base-en-v1.5", {
+      text: [query]
+    });
+    
+    // 2. Search Vectorize
+    const matches = await env.VECTORIZE.query(embeddings.data[0], {
+      topK: 5,
+      returnMetadata: "all"
+    });
+    
+    // 3. Fetch full documents from R2/D1/KV
+    const documents = await Promise.all(
+      matches.matches.map(async (match) => {
+        const key = match.metadata?.r2_key as string;
+        const obj = await env.R2_BUCKET.get(key);
+        return obj?.text();
+      })
+    );
+    
+    // 4. Build context for LLM
+    const context = documents.filter(Boolean).join("\n\n");
+    
+    // 5. Generate response with context
+    const llmResponse = await env.AI.run("@cf/meta/llama-3-8b-instruct", {
+      prompt: `Context: ${context}\n\nQuestion: ${query}\n\nAnswer:`
+    });
+    
+    return Response.json({ answer: llmResponse, sources: matches.matches });
+  }
+};
+```
+
+## CLI Operations
+
+### Bulk Upload (NDJSON)
+
+```bash
+# File: embeddings.ndjson
+# { "id": "1", "values": [0.1, 0.2, ...], "metadata": {"url": "/doc/1"}}
+# { "id": "2", "values": [0.3, 0.4, ...], "metadata": {"url": "/doc/2"}}
+
+npx wrangler vectorize insert <index-name> --file=embeddings.ndjson
+```
+
+**Rate Limits:**
+- Max 5000 vectors per file (Cloudflare API rate limit)
+- Use multiple files for larger batches
+
+### Python HTTP API Example
+
+```python
+import requests
+
+url = f"https://api.cloudflare.com/client/v4/accounts/{account_id}/vectorize/v2/indexes/{index_name}/insert"
+headers = {"Authorization": f"Bearer {api_token}"}
+
+with open('embeddings.ndjson', 'rb') as f:
+    resp = requests.post(url, headers=headers, files=dict(vectors=f))
+    print(resp.json())
+```
+
+## Performance Optimization
+
+### Write Throughput
+
+**Batching Strategy:**
+- Vectorize batches up to 200K vectors OR 1000 operations per job
+- Inserting 1 vector at a time = 1000 vectors per job = slow
+- Inserting 2500 vectors at a time = 200K+ vectors per job = fast
+
+**Example:**
+```typescript
+// BAD: 250,000 individual inserts = 250 jobs = ~1 hour
+for (const vector of vectors) {
+  await env.VECTORIZE.insert([vector]);
+}
+
+// GOOD: 100 batches of 2,500 = 2-3 jobs = minutes
+for (let i = 0; i < vectors.length; i += 2500) {
+  const batch = vectors.slice(i, i + 2500);
+  await env.VECTORIZE.insert(batch);
+}
+```
+
+### Query Performance
+
+**High-Precision vs. Approximate:**
+- Default: Approximate scoring (faster, good trade-off)
+- `returnValues: true`: High-precision scoring (slower, more accurate)
+
+**topK Limits:**
+- Default limit: 100 without values/metadata
+- With `returnValues: true` or `returnMetadata: "all"`: Max 20
+- Balance accuracy vs. latency
+
+**Metadata Filter Performance:**
+- Namespace filters applied first (fastest)
+- High-cardinality range queries degrade performance
+- Bucket high-cardinality values when possible
+
+### Mutation Tracking
+
+```bash
+# Check if mutations are processed
+npx wrangler vectorize info <index-name>
+
+# Returns processedUpToMutation and processedUpToDatetime
+# Compare with insert/upsert mutationId
+```
+
+## Limits (V2)
+
+| Resource | Limit |
+|----------|-------|
+| Indexes per account | 50,000 (Paid) / 100 (Free) |
+| Max dimensions | 1536 (32-bit float) |
+| Max vector ID length | 64 bytes |
+| Metadata per vector | 10 KiB |
+| Max topK (no values/metadata) | 100 |
+| Max topK (with values/metadata) | 20 |
+| Insert batch size (Workers) | 1000 |
+| Insert batch size (HTTP API) | 5000 |
+| List vectors page size | 1000 |
+| Max index name length | 64 bytes |
+| Max vectors per index | 5,000,000 |
+| Max namespaces | 50,000 (Paid) / 1000 (Free) |
+| Max namespace length | 64 bytes |
+| Max upload size | 100 MB |
+| Max metadata indexes | 10 |
+| Indexed metadata per field | 64 bytes (strings, UTF-8) |
+
+## Common Patterns
+
+### Multi-Tenant Architecture
+
+```typescript
+// Option 1: Separate indexes per tenant (if < 50K tenants)
+const tenantIndex = env[`VECTORIZE_${tenantId.toUpperCase()}`];
+
+// Option 2: Namespaces (up to 50K namespaces)
+await env.VECTORIZE.insert([
+  { id: "doc-1", values: [...], namespace: `tenant-${tenantId}` }
+]);
+
+const matches = await env.VECTORIZE.query(queryVector, {
+  namespace: `tenant-${tenantId}`
+});
+
+// Option 3: Metadata filtering (flexible but slower)
+const matches = await env.VECTORIZE.query(queryVector, {
+  filter: { tenantId: tenantId }
+});
+```
+
+### Semantic Search with Metadata
+
+```typescript
+// Index documents with rich metadata
+await env.VECTORIZE.upsert([
+  {
+    id: doc.id,
+    values: embedding,
+    metadata: {
+      title: doc.title,
+      category: doc.category,
+      published: Math.floor(doc.date / 1000), // Unix timestamp
+      tags: doc.tags.join(","),
+      url: doc.url
+    }
+  }
+]);
+
+// Search with filters
+const matches = await env.VECTORIZE.query(queryVector, {
+  topK: 10,
+  returnMetadata: "all",
+  filter: {
+    category: "tutorials",
+    published: { $gte: thirtyDaysAgo }
+  }
+});
+```
+
+### Hybrid Search (Vector + Metadata)
+
+```typescript
+// 1. Create metadata indexes for common filters
+// wrangler vectorize create-metadata-index my-index --property-name=category --type=string
+// wrangler vectorize create-metadata-index my-index --property-name=published --type=number
+
+// 2. Query with both semantic similarity and filters
+const results = await env.VECTORIZE.query(queryVector, {
+  topK: 20,
+  returnMetadata: "all",
+  filter: {
+    category: { $in: ["tech", "science"] },
+    published: { $gte: lastMonth },
+    status: "published"
+  }
+});
+```
+
+## Error Handling
+
+```typescript
+try {
+  const matches = await env.VECTORIZE.query(queryVector, { topK: 5 });
+} catch (error) {
+  // Common errors:
+  // - Dimension mismatch
+  // - Invalid filter syntax
+  // - topK exceeds limits
+  // - Index not found/not bound
+  console.error("Vectorize query failed:", error);
+  
+  // Fallback strategy
+  return Response.json({ 
+    error: "Search unavailable", 
+    matches: [] 
+  }, { status: 503 });
+}
+```
+
+## Best Practices
+
+1. **Create metadata indexes BEFORE inserting vectors** - existing vectors not retroactively indexed
+2. **Use upsert for updates** - insert ignores duplicates
+3. **Batch operations** - 1000-2500 vectors per batch for optimal throughput
+4. **Monitor mutations** - Use `wrangler vectorize info` to track processing
+5. **Choose appropriate metric** - cosine for text, euclidean for images
+6. **Design for cardinality** - Bucket high-cardinality metadata for better range queries
+7. **Namespace for tenant isolation** - Faster than metadata filters
+8. **Return metadata strategically** - Use "indexed" for speed, "all" when needed
+9. **Validate dimensions** - Must match index configuration exactly
+10. **Handle async operations** - Inserts/upserts take seconds to be queryable
+
+## Common Mistakes
+
+1. **Passing wrong data shape to query():**
+   - Workers AI: Pass `embeddings.data[0]`, not `embeddings`
+   - OpenAI: Pass `response.data[0].embedding`, not `response`
+
+2. **Creating metadata indexes after inserting vectors** - Won't index existing vectors
+
+3. **Using insert when upsert is needed** - Duplicates ignored with insert
+
+4. **Not batching operations** - 1 vector per request is extremely slow
+
+5. **Returning all values/metadata by default** - Impacts performance and topK limit
+
+6. **High-cardinality range queries** - Use bucketing or discrete values
+
+7. **Exceeding topK limits** - 20 with values/metadata, 100 without
+
+8. **Forgetting to run wrangler types** - Missing TypeScript types after config changes
+
+## Troubleshooting
+
+### Vectors not appearing in queries
+
+- Check mutation processed: `wrangler vectorize info <index>`
+- Wait 5-10 seconds after insert/upsert
+- Verify mutationId matches processedUpToMutation
+
+### Dimension mismatch errors
+
+- Ensure query vector length matches index dimensions exactly
+- Check embedding model output dimensions
+
+### Filter not working
+
+- Verify metadata index created: `wrangler vectorize list-metadata-index <index>`
+- Re-upsert vectors after creating metadata index
+- Check filter syntax and operator constraints
+
+### Performance issues
+
+- Reduce topK if using returnValues or returnMetadata="all"
+- Simplify metadata filters (avoid high-cardinality ranges)
+- Use namespace filtering instead of metadata when possible
+- Batch insert/upsert operations properly
+
+## Resources
+
+- [Official Docs](https://developers.cloudflare.com/vectorize/)
+- [Client API Reference](https://developers.cloudflare.com/vectorize/reference/client-api/)
+- [Metadata Filtering](https://developers.cloudflare.com/vectorize/reference/metadata-filtering/)
+- [Limits](https://developers.cloudflare.com/vectorize/platform/limits/)
+- [Workers AI Models](https://developers.cloudflare.com/workers-ai/models/#text-embeddings)
+- [Wrangler Commands](https://developers.cloudflare.com/workers/wrangler/commands/#vectorize)
+- [Discord: #vectorize](https://discord.cloudflare.com)
+
+---
+
+**Version:** V2 (GA) - Requires Wrangler 3.71.0+
+**Last Updated:** 2025-01-11

--- a/.agent/services/hosting/cloudflare-platform/references/waf/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/waf/README.md
@@ -1,0 +1,14 @@
+# Cloudflare WAF Expert Skill Reference
+
+**Expertise**: Cloudflare Web Application Firewall (WAF) configuration, custom rules, managed rulesets, rate limiting, attack detection, and API integration...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/waf/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/waf/api.md
@@ -1,0 +1,3 @@
+# API Reference
+
+See main documentation.

--- a/.agent/services/hosting/cloudflare-platform/references/waf/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/waf/configuration.md
@@ -1,0 +1,44 @@
+### Wrangler Integration
+
+While Wrangler primarily manages Workers, WAF configuration is typically done via:
+- Dashboard UI
+- Cloudflare API directly
+- Terraform provider
+- Pulumi provider
+
+**Related Wrangler Operations**:
+- Deploy Workers that benefit from WAF protection
+- Configure zone settings that complement WAF
+- Use `wrangler.toml` for environment-specific configurations
+
+**Example: Using Cloudflare API from Worker**:
+```typescript
+// Worker that calls WAF API
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const response = await fetch(
+      `https://api.cloudflare.com/client/v4/zones/${env.ZONE_ID}/rulesets`,
+      {
+        headers: {
+          'Authorization': `Bearer ${env.CF_API_TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+    return response;
+  },
+};
+```
+
+### TypeScript SDK Usage
+
+**Installation**:
+```bash
+npm install cloudflare
+# or
+pnpm add cloudflare
+```
+
+**Basic Setup**:
+```typescript
+import Cloud

--- a/.agent/services/hosting/cloudflare-platform/references/waf/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/waf/gotchas.md
@@ -1,0 +1,24 @@
+### Common Issues & Solutions
+
+**Issue**: False positives blocking legitimate traffic
+**Solution**: 
+- Start with `log` action to monitor
+- Use WAF exceptions for specific endpoints
+- Override managed ruleset rules to less aggressive actions
+- Combine attack score with path filters
+
+**Issue**: Rate limiting blocking legitimate users behind NAT
+**Solution**:
+- Use "IP with NAT support" characteristic (Business+)
+- Add additional characteristics (headers, cookies)
+- Increase rate limits for shared IPs
+- Use counting expressions to filter what counts
+
+**Issue**: Rules not applying as expected
+**Solution**:
+- Check rule order and priority
+- Verify expression syntax with Security Events
+- Ensure ruleset is deployed to correct phase
+- Check for conflicting skip or allow rules
+
+**Issue**: Managed

--- a/.agent/services/hosting/cloudflare-platform/references/waf/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/waf/patterns.md
@@ -1,0 +1,29 @@
+### Common Issues & Solutions
+
+**Issue**: False positives blocking legitimate traffic
+**Solution**: 
+- Start with `log` action to monitor
+- Use WAF exceptions for specific endpoints
+- Override managed ruleset rules to less aggressive actions
+- Combine attack score with path filters
+
+**Issue**: Rate limiting blocking legitimate users behind NAT
+**Solution**:
+- Use "IP with NAT support" characteristic (Business+)
+- Add additional characteristics (headers, cookies)
+- Increase rate limits for shared IPs
+- Use counting expressions to filter what counts
+
+**Issue**: Rules not applying as expected
+**Solution**:
+- Check rule order and priority
+- Verify expression syntax with Security Events
+- Ensure ruleset is deployed to correct phase
+- Check for conflicting skip or allow rules
+
+**Issue**: Managed ruleset causing performance issues
+**Solution**:
+- Use exceptions to skip ruleset for static assets
+- Override ruleset to disable unused rule categories
+- Consider using zone-specific configuration
+-

--- a/.agent/services/hosting/cloudflare-platform/references/web-analytics/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/web-analytics/README.md
@@ -1,0 +1,19 @@
+# Cloudflare Web Analytics Skill Reference
+
+Comprehensive guide for implementing Cloudflare Web Analytics - a privacy-first web analytics solution that provides performance metrics and user insights without compromising visitor privacy.
+
+## Overview
+
+Cloudflare Web Analytics is a free, privacy-focused analytics service that:
+- Measures Core W...
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/web-analytics/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/web-analytics/api.md
@@ -1,0 +1,52 @@
+## API Access (GraphQL)
+
+While Web Analytics is primarily dashboard-based, Cloudflare provides GraphQL API access for advanced queries.
+
+### Authentication
+
+```bash
+# API Token with "Web Analytics Read" permission
+curl -X POST https://api.cloudflare.com/client/v4/graphql \
+  -H "Authorization: Bearer YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{"query": "..."}'
+```
+
+### Example Queries
+
+**Get page views by path:**
+
+```graphql
+query {
+  viewer {
+    accounts(filter: {accountTag: "YOUR_ACCOUNT_ID"}) {
+      rumPageloadEventsAdaptiveGroups(
+        filter: {
+          date_geq: "2024-01-01"
+          date_lt: "2024-01-31"
+        }
+        limit: 100
+      ) {
+        dimensions {
+          blob1 # Page path
+        }
+        sum {
+          visits
+          pageViews
+        }
+        avg {
+          sampleInterval
+        }
+      }
+    }
+  }
+}
+```
+
+**Get Core Web Vitals:**
+
+```graphql
+query {
+  viewer {
+    accounts(filter: {accountTag: "YOUR_ACCOUNT_ID"}) {
+    

--- a/.agent/services/hosting/cloudflare-platform/references/web-analytics/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/web-analytics/configuration.md
@@ -1,0 +1,31 @@
+## Setup Methods
+
+### 1. Sites Proxied Through Cloudflare (Automatic)
+
+For sites already on Cloudflare's proxy:
+
+1. **Dashboard setup:**
+   - Navigate to Web Analytics in Cloudflare dashboard
+   - Click "Add a site"
+   - Select hostname from dropdown → "Done"
+   - Analytics enabled by default (beacon auto-injected)
+
+2. **Configuration options:**
+   - **Enable** - Full auto-injection for all visitors
+   - **Enable, excluding visitor data in the EU** - No injection for EU visitors
+   - **Enable with JS Snippet installation** - Manual snippet required
+   - **Disable** - Turn off analytics
+
+**Important:** If `Cache-Control: public, no-transform` header is set, auto-injection fails. Beacon must be added manually.
+
+### 2. Sites Not Proxied Through Cloudflare (Manual)
+
+For non-proxied sites (limit: 10 sites):
+
+1. Dashboard: Web Analytics → "Add a site"
+2. Enter hostname manually → "Done"
+3. Copy JS snippet from "Manage site"
+4. Add snippet before closing `</body>` tag:
+
+```html
+<!-- Cloudflar

--- a/.agent/services/hosting/cloudflare-platform/references/web-analytics/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/web-analytics/gotchas.md
@@ -1,0 +1,28 @@
+## Troubleshooting
+
+### Beacon Not Loading
+
+**Issue:** Script not appearing on page
+
+**Solutions:**
+1. Check `Cache-Control` header - remove `no-transform` if present
+2. Verify beacon placement before `</body>`
+3. Check CSP (Content Security Policy) allows `static.cloudflareinsights.com`
+4. For proxied sites: Ensure auto-injection enabled in dashboard
+
+**CSP Fix:**
+```html
+<meta http-equiv="Content-Security-Policy" 
+      content="script-src 'self' 'unsafe-inline' https://static.cloudflareinsights.com;">
+```
+
+### No Data Appearing
+
+**Issue:** Dashboard shows no analytics
+
+**Solutions:**
+1. Wait 5-10 minutes after setup (data ingestion delay)
+2. Verify token is correct in `data-cf-beacon`
+3. Check browser console for beacon errors
+4. Confirm site has real traffic (test by visiting pages)
+5.

--- a/.agent/services/hosting/cloudflare-platform/references/web-analytics/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/web-analytics/patterns.md
@@ -1,0 +1,52 @@
+## Common Use Cases
+
+### 1. Performance Monitoring
+
+Track Core Web Vitals to identify slow-loading elements:
+
+```typescript
+// Debug poor LCP scores
+// 1. Enable Web Analytics
+// 2. Dashboard → Core Web Vitals → LCP section
+// 3. Debug View shows top 5 problematic elements
+// 4. Use element CSS selector in browser console:
+document.querySelector('.hero-image') // Example element
+// 5. Optimize identified elements (lazy loading, compression, etc.)
+```
+
+### 2. Bot Traffic Filtering
+
+Exclude bots to see real user metrics:
+
+```
+Dashboard filters:
+- Exclude Bots: Yes
+→ Shows human traffic only
+```
+
+### 3. Multi-Site Analytics
+
+Track multiple properties under one account:
+
+```
+Proxied sites: Unlimited
+Non-proxied: Up to 10 sites
+
+View by dimension:
+- Site: example.com
+- Site: blog.example.com
+→ Compare traffic across properties
+```
+
+### 4. Geographic Analysis
+
+Understand visitor distribution:
+
+```
+Filter by:
+- Country: United States
+- Device type: Mobile
+→ Mobile traffic from US
+```
+
+### 5. 

--- a/.agent/services/hosting/cloudflare-platform/references/workerd/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workerd/README.md
@@ -1,0 +1,47 @@
+# Workerd Runtime
+
+V8-based JS/Wasm runtime powering Cloudflare Workers. Use as app server, dev tool, or HTTP proxy.
+
+## When to Use
+- Local Workers development (via Wrangler)
+- Self-hosted Workers runtime
+- Custom embedded runtime
+- Debugging runtime-specific issues
+
+## Key Features
+- **Standards-based**: Fetch API, Web Crypto, Streams, WebSocket
+- **Nanoservices**: Service bindings with local call performance
+- **Capability security**: Explicit bindings prevent SSRF
+- **Backwards compatible**: Version = max compat date supported
+
+## Architecture
+```
+Config (workerd.capnp)
+├── Services (workers/endpoints)
+├── Sockets (HTTP/HTTPS listeners)
+└── Extensions (global capabilities)
+```
+
+## Quick Start
+```bash
+workerd serve config.capnp
+workerd compile config.capnp myConfig -o binary
+workerd test config.capnp
+```
+
+## Core Concepts
+- **Service**: Named endpoint (worker/network/disk/external)
+- **Binding**: Capability-based resource access (KV/DO/R2/services)
+- **Compatibility date**: Feature gate (always set!)
+- **Modules**: ES modules (recommended) or service worker syntax
+
+## See Also
+- [configuration.md](./configuration.md) - Config format, services, bindings
+- [api.md](./api.md) - Runtime APIs, C++ embedding
+- [patterns.md](./patterns.md) - Multi-service, DO, proxies
+- [gotchas.md](./gotchas.md) - Common errors, debugging
+
+## References
+- [GitHub](https://github.com/cloudflare/workerd)
+- [Compat Dates](https://developers.cloudflare.com/workers/configuration/compatibility-dates/)
+- [workerd.capnp](https://github.com/cloudflare/workerd/blob/main/src/workerd/server/workerd.capnp)

--- a/.agent/services/hosting/cloudflare-platform/references/workerd/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workerd/api.md
@@ -1,0 +1,199 @@
+# Workerd APIs
+
+## Worker Code (JS/TS)
+
+### ES Modules (Recommended)
+```javascript
+export default {
+  async fetch(request, env, ctx) {
+    // env: bindings, ctx: ExecutionContext
+    const value = await env.KV.get("key");
+    const response = await env.API.fetch(request);
+    
+    ctx.waitUntil(logRequest(request));  // Background task
+    return new Response("OK");
+  },
+  
+  async adminApi(request, env, ctx) {   // Named entrypoint
+    return new Response("Admin");
+  },
+  
+  async queue(batch, env, ctx) {        // Queue consumer
+    for (const msg of batch.messages) {
+      await processMessage(msg.body);
+    }
+  },
+  
+  async scheduled(event, env, ctx) {    // Cron
+    ctx.waitUntil(runTask(env));
+  }
+};
+```
+
+### TypeScript Types
+```typescript
+interface Env {
+  API: Fetcher;
+  CACHE: KVNamespace;
+  STORAGE: R2Bucket;
+  ROOMS: DurableObjectNamespace;
+  API_KEY: string;
+  CONFIG: {apiUrl: string};
+}
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const data = await env.CACHE.get("key");
+    return new Response(data);
+  }
+};
+```
+
+### Service Worker Syntax
+```javascript
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request));
+});
+
+async function handleRequest(request) {
+  // Bindings as globals
+  const value = await KV.get("key");
+  return new Response("OK");
+}
+```
+
+### Durable Objects
+```javascript
+export class Room {
+  constructor(state, env) {
+    this.state = state;
+    this.env = env;
+  }
+  
+  async fetch(request) {
+    const url = new URL(request.url);
+    
+    if (url.pathname === "/state") {
+      const value = await this.state.storage.get("counter");
+      return new Response(value || "0");
+    }
+    
+    if (url.pathname === "/increment") {
+      const value = (await this.state.storage.get("counter")) || 0;
+      await this.state.storage.put("counter", value + 1);
+      return new Response(String(value + 1));
+    }
+    
+    return new Response("Not found", {status: 404});
+  }
+}
+```
+
+### RPC Between Services
+```javascript
+// Caller
+export default {
+  async fetch(request, env, ctx) {
+    const user = await env.AUTH.validateToken(request.headers.get("Authorization"));
+    return new Response(`Hello ${user.name}`);
+  }
+};
+
+// Callee
+export default {
+  async validateToken(token) {
+    return {id: 123, name: "Alice"};  // Return structured data
+  }
+};
+```
+
+## Web Platform APIs
+
+### Fetch
+- `fetch()`, `Request`, `Response`, `Headers`
+- `AbortController`, `AbortSignal`
+
+### Streams
+- `ReadableStream`, `WritableStream`, `TransformStream`
+- Byte streams, BYOB readers
+
+### Web Crypto
+- `crypto.subtle` (encrypt/decrypt/sign/verify)
+- `crypto.randomUUID()`, `crypto.getRandomValues()`
+
+### Encoding
+- `TextEncoder`, `TextDecoder`
+- `atob()`, `btoa()`
+
+### Web Standards
+- `URL`, `URLSearchParams`
+- `Blob`, `File`, `FormData`
+- `WebSocket`, `EventSource` (SSE)
+- `HTMLRewriter`
+
+### Performance
+- `performance.now()`, `performance.timeOrigin`
+- `setTimeout()`, `setInterval()`, `queueMicrotask()`
+
+### Console
+- `console.log()`, `console.error()`, `console.warn()`
+
+### Node.js Compat (`nodejs_compat` flag)
+- `node:*` imports
+- `process.env`, `Buffer`
+- Subset of Node.js APIs
+
+## CLI Commands
+
+### Serve
+```bash
+workerd serve config.capnp [constantName]
+workerd serve config.capnp --socket-addr http=*:3000
+workerd serve config.capnp --socket-fd http=3       # Systemd
+workerd serve config.capnp --verbose
+workerd serve config.capnp --compat-date=2024-01-15
+```
+
+### Compile
+```bash
+workerd compile config.capnp constantName -o binary
+./binary
+```
+
+### Test
+```bash
+workerd test config.capnp
+workerd test config.capnp --test-only=my-test.js
+```
+
+## Wrangler Integration
+```bash
+export MINIFLARE_WORKERD_PATH="/path/to/workerd"
+wrangler dev
+```
+
+**wrangler.toml**:
+```toml
+name = "my-worker"
+main = "src/index.js"
+compatibility_date = "2024-01-15"
+compatibility_flags = ["nodejs_compat"]
+
+[[kv_namespaces]]
+binding = "CACHE"
+id = "abc123"
+
+[[r2_buckets]]
+binding = "STORAGE"
+bucket_name = "my-bucket"
+
+[[durable_objects.bindings]]
+name = "ROOMS"
+class_name = "Room"
+script_name = "my-worker"
+```
+
+## C++ Embedder API
+Not covered here. See [workerd source](https://github.com/cloudflare/workerd) for embedding runtime in C++ applications.
+
+See [patterns.md](./patterns.md) for usage examples, [configuration.md](./configuration.md) for config details.

--- a/.agent/services/hosting/cloudflare-platform/references/workerd/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workerd/gotchas.md
@@ -1,0 +1,203 @@
+# Workerd Gotchas
+
+## Configuration Errors
+
+### Missing Compat Date
+❌ **Wrong**:
+```capnp
+const worker :Workerd.Worker = (
+  serviceWorkerScript = embed "worker.js"
+)
+```
+
+✅ **Correct**:
+```capnp
+const worker :Workerd.Worker = (
+  serviceWorkerScript = embed "worker.js",
+  compatibilityDate = "2024-01-15"  # Always set!
+)
+```
+
+### Wrong Binding Type
+❌ **Wrong** - text returns string:
+```capnp
+(name = "CONFIG", text = '{"key":"value"}')  # String, not parsed
+```
+
+✅ **Correct** - json returns object:
+```capnp
+(name = "CONFIG", json = '{"key":"value"}')  # Parsed object
+```
+
+### Service vs Namespace
+❌ **Wrong** - just a Fetcher:
+```capnp
+(name = "ROOM", service = "room-service")
+```
+
+✅ **Correct** - Durable Object namespace:
+```capnp
+(name = "ROOM", durableObjectNamespace = "Room")
+```
+
+### Module Name Mismatch
+❌ **Wrong** - import fails:
+```capnp
+modules = [(name = "src/index.js", esModule = embed "src/index.js")]
+```
+
+✅ **Correct** - use simple names:
+```capnp
+modules = [(name = "index.js", esModule = embed "src/index.js")]
+```
+
+## Network Access
+
+### No Global Outbound
+❌ **Wrong** - may fail without config:
+```javascript
+await fetch("https://api.example.com")
+```
+
+✅ **Correct** - configure network service:
+```capnp
+services = [
+  (name = "internet", network = (allow = ["public"])),
+  (name = "worker", worker = (
+    ...,
+    bindings = [(name = "API", service = "internet")]
+  ))
+]
+```
+
+Or use external service:
+```capnp
+bindings = [
+  (name = "API", service = (
+    name = "api-backend",
+    external = (address = "api.com:443", http = (style = tls))
+  ))
+]
+```
+
+## Debugging Issues
+
+### Worker Not Responding
+Check:
+1. Socket config: `address = "*:8080"`, service name matches
+2. Worker has `fetch()` handler
+3. Port available
+4. Service name in socket matches service definition
+
+### Binding Not Found
+Check:
+1. Binding name in config matches code (`env.BINDING` or global)
+2. Service exists in config
+3. ES module vs service worker syntax (env vs global)
+
+### Module Not Found
+Check:
+1. Module name in config matches import path
+2. `embed` path correct
+3. ES module syntax valid (no CommonJS in `.mjs`)
+
+### Compatibility Errors
+Check:
+1. `compatibilityDate` set
+2. API available on that date ([docs](https://developers.cloudflare.com/workers/configuration/compatibility-dates/))
+3. Required flags enabled (`compatibilityFlags`)
+
+## Performance Issues
+
+### High Memory Usage
+Try:
+1. V8 flags: `v8Flags = ["--max-old-space-size=2048"]`
+2. Reduce cache limits: `memoryCache.limits.maxTotalValueSize`
+3. Profile with `--verbose` logging
+
+### Slow Startup
+Try:
+1. Compile binary: `workerd compile config.capnp name -o binary`
+2. Check module count (many imports slow startup)
+3. Review compatibility flags (some have perf impact)
+
+### Request Timeouts
+Check:
+1. External service connectivity
+2. Network service DNS resolution
+3. TLS handshake issues (`tlsOptions`)
+
+## Build Issues
+
+### Cap'n Proto Errors
+- Install Cap'n Proto tools: `brew install capnp` / `apt install capnproto`
+- Check schema import path: `using Workerd = import "/workerd/workerd.capnp";`
+- Validate with: `capnp compile -I. config.capnp`
+
+### Embed Path Issues
+- Paths relative to config file location
+- Use absolute paths if needed: `embed "/full/path/file.js"`
+- Check file exists before running
+
+### V8 Flags Warning
+**Warning**: V8 flags (`v8Flags`) can break everything. Use only if necessary and test thoroughly. Not supported in production Cloudflare Workers.
+
+## Security Gotchas
+
+### Hardcoded Secrets
+❌ **Never** hardcode:
+```capnp
+(name = "API_KEY", text = "sk-1234567890")
+```
+
+✅ **Use env vars**:
+```capnp
+(name = "API_KEY", fromEnvironment = "API_KEY")
+```
+
+### Overly Broad Network Access
+❌ **Too permissive**:
+```capnp
+network = (allow = ["*"])  # Everything
+```
+
+✅ **Restrictive**:
+```capnp
+network = (allow = ["public"], deny = ["local"])
+```
+
+### Extractable Keys
+❌ **Extractable keys risky**:
+```capnp
+cryptoKey = (extractable = true, ...)
+```
+
+✅ **Non-extractable**:
+```capnp
+cryptoKey = (extractable = false, ...)
+```
+
+## Compatibility Changes
+
+### Breaking Change Migration
+When updating `compatibilityDate`:
+1. Review [compatibility dates docs](https://developers.cloudflare.com/workers/configuration/compatibility-dates/)
+2. Check flags enabled between old/new date
+3. Test locally with new date
+4. Update code for breaking changes
+5. Deploy with new date
+
+### Version Mismatch
+Workerd version = max compat date supported. If `compatibilityDate = "2025-01-01"` but workerd is v1.20241201.0, it fails. Update workerd binary.
+
+## Troubleshooting Steps
+
+1. **Enable verbose logging**: `workerd serve config.capnp --verbose`
+2. **Check logs**: Look for error messages, stack traces
+3. **Validate config**: `capnp compile -I. config.capnp`
+4. **Test bindings**: Log `Object.keys(env)` to verify
+5. **Check versions**: Workerd version vs compat date
+6. **Isolate issue**: Minimal repro config
+7. **Review schema**: [workerd.capnp](https://github.com/cloudflare/workerd/blob/main/src/workerd/server/workerd.capnp)
+
+See [configuration.md](./configuration.md) for config details, [patterns.md](./patterns.md) for working examples, [api.md](./api.md) for runtime APIs.

--- a/.agent/services/hosting/cloudflare-platform/references/workerd/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workerd/patterns.md
@@ -1,0 +1,216 @@
+# Workerd Patterns
+
+## Multi-Service Architecture
+```capnp
+const config :Workerd.Config = (
+  services = [
+    (name = "frontend", worker = (
+      modules = [(name = "index.js", esModule = embed "frontend/index.js")],
+      compatibilityDate = "2024-01-15",
+      bindings = [(name = "API", service = "api")]
+    )),
+    
+    (name = "api", worker = (
+      modules = [(name = "index.js", esModule = embed "api/index.js")],
+      compatibilityDate = "2024-01-15",
+      bindings = [
+        (name = "DB", service = "postgres"),
+        (name = "CACHE", kvNamespace = "kv"),
+      ]
+    )),
+    
+    (name = "postgres", external = (address = "db.internal:5432", http = ())),
+    (name = "kv", disk = (path = "/var/kv", writable = true)),
+  ],
+  
+  sockets = [(name = "http", address = "*:8080", http = (), service = "frontend")]
+);
+```
+
+## Durable Objects
+```capnp
+const config :Workerd.Config = (
+  services = [
+    (name = "app", worker = (
+      modules = [
+        (name = "index.js", esModule = embed "index.js"),
+        (name = "room.js", esModule = embed "room.js"),
+      ],
+      compatibilityDate = "2024-01-15",
+      bindings = [(name = "ROOMS", durableObjectNamespace = "Room")],
+      durableObjectNamespaces = [(className = "Room", uniqueKey = "v1")],
+      durableObjectStorage = (localDisk = "/var/do")
+    ))
+  ],
+  sockets = [(name = "http", address = "*:8080", http = (), service = "app")]
+);
+```
+
+## Dev vs Prod Configs
+```capnp
+const devWorker :Workerd.Worker = (
+  modules = [(name = "index.js", esModule = embed "src/index.js")],
+  compatibilityDate = "2024-01-15",
+  bindings = [
+    (name = "API_URL", text = "http://localhost:3000"),
+    (name = "DEBUG", text = "true"),
+  ]
+);
+
+const prodWorker :Workerd.Worker = (
+  inherit = "dev-service",
+  bindings = [
+    (name = "API_URL", text = "https://api.prod.com"),
+    (name = "DEBUG", text = "false"),
+  ]
+);
+```
+
+## HTTP Reverse Proxy
+```capnp
+const config :Workerd.Config = (
+  services = [
+    (name = "proxy", worker = (
+      serviceWorkerScript = embed "proxy.js",
+      compatibilityDate = "2024-01-15",
+      bindings = [(name = "BACKEND", service = "backend")]
+    )),
+    (name = "backend", external = (address = "internal:8080", http = ()))
+  ],
+  sockets = [(name = "http", address = "*:80", http = (), service = "proxy")]
+);
+```
+
+## Local Development
+
+### Using Wrangler
+```bash
+export MINIFLARE_WORKERD_PATH="/path/to/workerd"
+wrangler dev
+```
+
+### Direct Workerd
+```bash
+workerd serve config.capnp --socket-addr http=*:3000 --verbose
+```
+
+### Environment Variables
+```capnp
+bindings = [
+  (name = "DATABASE_URL", fromEnvironment = "DATABASE_URL"),
+  (name = "API_KEY", fromEnvironment = "API_KEY"),
+]
+```
+
+```bash
+export DATABASE_URL="postgres://..."
+export API_KEY="secret"
+workerd serve config.capnp
+```
+
+## Testing
+
+### Test Config
+```capnp
+const testWorker :Workerd.Worker = (
+  modules = [
+    (name = "index.js", esModule = embed "src/index.js"),
+    (name = "test.js", esModule = embed "tests/test.js"),
+  ],
+  compatibilityDate = "2024-01-15"
+);
+```
+
+```bash
+workerd test config.capnp
+workerd test config.capnp --test-only=test.js
+```
+
+## Production Deployment
+
+### Systemd
+```ini
+# /etc/systemd/system/workerd.service
+[Unit]
+Description=workerd runtime
+After=network-online.target
+Requires=workerd.socket
+
+[Service]
+Type=exec
+ExecStart=/usr/bin/workerd serve /etc/workerd/config.capnp --socket-fd http=3
+Restart=always
+User=nobody
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```ini
+# /etc/systemd/system/workerd.socket
+[Socket]
+ListenStream=0.0.0.0:80
+
+[Install]
+WantedBy=sockets.target
+```
+
+### Docker
+```dockerfile
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates
+COPY workerd /usr/local/bin/
+COPY config.capnp /etc/workerd/
+COPY src/ /etc/workerd/src/
+EXPOSE 8080
+CMD ["workerd", "serve", "/etc/workerd/config.capnp"]
+```
+
+### Compiled Binary
+```bash
+workerd compile config.capnp myConfig -o production-server
+./production-server
+```
+
+## Best Practices
+
+1. **Use ES modules** over service worker syntax
+2. **Explicit bindings** - no global namespace assumptions
+3. **Type safety** - define `Env` interfaces
+4. **Service isolation** - split concerns
+5. **Pin compat date** in production after testing
+6. **Use ctx.waitUntil()** for background tasks
+7. **Handle errors gracefully** with try/catch
+8. **Configure resource limits** on caches/storage
+
+## Error Handling Pattern
+```javascript
+export default {
+  async fetch(request, env, ctx) {
+    try {
+      return await handleRequest(request, env);
+    } catch (error) {
+      console.error("Request failed", error);
+      return new Response("Internal Error", {status: 500});
+    }
+  }
+};
+```
+
+## Logging Pattern
+```javascript
+export default {
+  async fetch(request, env, ctx) {
+    console.log("Request", {method: request.method, url: request.url});
+    
+    ctx.waitUntil(
+      logToAnalytics(request, env)
+    );
+    
+    return new Response("OK");
+  }
+};
+```
+
+See [configuration.md](./configuration.md) for config syntax, [api.md](./api.md) for runtime APIs, [gotchas.md](./gotchas.md) for common errors.

--- a/.agent/services/hosting/cloudflare-platform/references/workers-ai/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-ai/README.md
@@ -1,0 +1,116 @@
+# Cloudflare Workers AI Skill
+
+A comprehensive OpenCode skill for working with Cloudflare Workers AI.
+
+## What This Skill Covers
+
+This skill focuses **exclusively on Cloudflare Workers AI** - the serverless AI inference platform. It does NOT cover the broader Cloudflare platform (Workers, Pages, CDN, etc.) unless directly related to Workers AI usage.
+
+### Topics Included
+
+- **Core Concepts**: Bindings, model invocation patterns, naming conventions
+- **Task-Specific Implementations**: Text generation, embeddings, image generation, speech recognition, translation, etc.
+- **REST API Usage**: Authentication, endpoints, OpenAI compatibility
+- **Wrangler Integration**: Setup, configuration, deployment
+- **Pricing & Limits**: Neurons, rate limits, cost optimization
+- **Common Patterns**: RAG, streaming, batch processing, error handling
+- **AI Gateway**: Caching, rate limiting, analytics integration
+- **Function Calling**: Both traditional and embedded approaches
+- **Model Selection**: Guidelines for choosing the right model
+- **TypeScript Support**: Types, interfaces, best practices
+
+## How to Use This Skill
+
+### Installation
+
+1. Place `README.md` in your OpenCode skills directory
+2. Load the skill when working on Workers AI projects
+
+### When to Load This Skill
+
+Load this skill when:
+- Implementing AI inference in Cloudflare Workers
+- Building RAG systems with Workers AI + Vectorize
+- Optimizing Workers AI costs or performance
+- Debugging Workers AI integration issues
+- Setting up AI Gateway with Workers AI
+- Implementing function calling with LLMs
+
+### Example Usage
+
+```bash
+# In OpenCode CLI
+load-skill cloudflare-workers-ai
+
+# Then ask questions like:
+"How do I implement streaming with Workers AI?"
+"What's the best embedding model for semantic search?"
+"Show me how to do RAG with Vectorize"
+"How do I handle rate limits?"
+```
+
+## Skill Structure
+
+The skill is organized into these sections:
+
+1. **Overview** - What Workers AI is and when to use this skill
+2. **Core Concepts** - Bindings, invocation patterns, model naming
+3. **Task-Specific Patterns** - Code examples for each AI task type
+4. **REST API** - Using Workers AI via HTTP endpoints
+5. **Wrangler CLI** - Setup, config, deployment
+6. **Pricing & Neurons** - Cost model and optimization
+7. **Rate Limits** - Per-task and per-model limits
+8. **RAG Pattern** - Complete retrieval-augmented generation example
+9. **AI Gateway** - Integration patterns
+10. **Common Patterns** - Error handling, streaming, batching, etc.
+11. **Model Selection** - Choosing the right model
+12. **Debugging** - Monitoring and troubleshooting
+13. **Common Issues** - Known problems and solutions
+14. **Pages Integration** - Using Workers AI in Pages Functions
+15. **Advanced Topics** - LoRA adapters
+16. **Architecture Patterns** - System design approaches
+
+## Key Features
+
+- ✅ **Complete Code Examples**: Every pattern has working code
+- ✅ **TypeScript First**: Proper typing for all examples
+- ✅ **Real-World Patterns**: RAG, streaming, batch processing
+- ✅ **Cost Optimization**: Pricing info and model selection guidance
+- ✅ **Troubleshooting**: Common issues and solutions
+- ✅ **Best Practices**: Error handling, type safety, monitoring
+
+## What's NOT Covered
+
+This skill does NOT cover:
+- General Cloudflare Workers programming (use Workers skill)
+- Cloudflare Pages (unless specifically Workers AI integration)
+- Cloudflare CDN, DNS, security features
+- Vectorize (unless in context of Workers AI RAG)
+- D1, KV, R2, Durable Objects (unless AI-specific usage)
+
+## Maintenance
+
+To keep this skill up to date:
+- Check official docs: https://developers.cloudflare.com/workers-ai/
+- Monitor model catalog: https://developers.cloudflare.com/workers-ai/models/
+- Track pricing changes: https://developers.cloudflare.com/workers-ai/platform/pricing/
+
+## Contributing
+
+Found an issue or want to improve this skill?
+1. Test changes against official Cloudflare Workers AI docs
+2. Verify code examples work with latest Wrangler
+3. Update pricing/limits if changed
+4. Add new model examples as they're released
+
+## Version History
+
+- **v1.0** (2026-01-11): Initial comprehensive skill
+  - Full coverage of Workers AI API
+  - Code patterns for all task types
+  - Pricing, limits, troubleshooting
+  - RAG, streaming, function calling examples
+
+## License
+
+This skill documentation is provided as-is for use with OpenCode.

--- a/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/README.md
@@ -1,0 +1,48 @@
+# Cloudflare Workers for Platforms
+
+Multi-tenant platform with isolated customer code execution at scale.
+
+## Use Cases
+
+- Multi-tenant SaaS running customer code
+- AI-generated code execution in secure sandboxes
+- Programmable platforms with isolated compute
+- Edge functions/serverless platforms
+- Website builders with static + dynamic content
+- Unlimited app deployment at scale
+
+**NOT for general Workers** - only for Workers for Platforms architecture.
+
+## Architecture
+
+**4 Components:**
+1. **Dispatch Namespace** - Container for unlimited customer Workers, automatic isolation, untrusted mode
+2. **Dynamic Dispatch Worker** - Entry point, routes requests, enforces platform logic (auth, limits, validation)
+3. **User Workers** - Customer code in isolated sandboxes, API-deployed, optional bindings (KV/D1/R2/DO)
+4. **Outbound Worker** (optional) - Intercepts external fetch, controls egress, logs subrequests
+
+**Request Flow:**
+```
+Request → Dispatch Worker → Determines user Worker → env.DISPATCHER.get("customer") 
+→ User Worker executes (Outbound Worker for external fetch) → Response → Dispatch Worker → Client
+```
+
+## Key Features
+
+- Unlimited Workers per namespace (no script limits)
+- Automatic tenant isolation
+- Custom CPU/subrequest limits per customer
+- Hostname routing (subdomains/vanity domains)
+- Egress/ingress control
+- Static assets support
+- Tags for bulk operations
+
+## Quick Start
+
+See [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)
+
+## Refs
+
+- [Docs](https://developers.cloudflare.com/cloudflare-for-platforms/workers-for-platforms/)
+- [Starter Kit](https://github.com/cloudflare/templates/tree/main/worker-publisher-template)
+- [VibeSDK](https://github.com/cloudflare/vibesdk)

--- a/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/api.md
@@ -1,0 +1,169 @@
+# API Operations
+
+## Deploy User Worker
+
+```bash
+curl -X PUT \
+  "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/workers/dispatch/namespaces/$NAMESPACE/scripts/$SCRIPT_NAME" \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -F 'metadata={"main_module": "worker.mjs"};type=application/json' \
+  -F 'worker.mjs=@worker.mjs;type=application/javascript+module'
+```
+
+### TypeScript SDK
+```typescript
+import Cloudflare from "cloudflare";
+
+const client = new Cloudflare({ apiToken: process.env.API_TOKEN });
+
+const scriptFile = new File([scriptContent], `${scriptName}.mjs`, {
+  type: "application/javascript+module",
+});
+
+await client.workersForPlatforms.dispatch.namespaces.scripts.update(
+  namespace, scriptName,
+  {
+    account_id: accountId,
+    metadata: { main_module: `${scriptName}.mjs` },
+    files: [scriptFile],
+  }
+);
+```
+
+## Deploy with Bindings
+```bash
+curl -X PUT ".../scripts/$SCRIPT_NAME" \
+  -F 'metadata={
+    "main_module": "worker.mjs",
+    "bindings": [
+      {"type": "kv_namespace", "name": "MY_KV", "namespace_id": "'$KV_ID'"}
+    ],
+    "tags": ["customer-123", "production"],
+    "compatibility_date": "2024-01-01"
+  };type=application/json' \
+  -F 'worker.mjs=@worker.mjs;type=application/javascript+module'
+```
+
+## List/Delete Workers
+
+```bash
+# List
+curl "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/workers/dispatch/namespaces/$NAMESPACE/scripts" \
+  -H "Authorization: Bearer $API_TOKEN"
+
+# Delete by name
+curl -X DELETE ".../scripts/$SCRIPT_NAME" -H "Authorization: Bearer $API_TOKEN"
+
+# Delete by tag
+curl -X DELETE ".../scripts?tags=customer-123%3Ayes" -H "Authorization: Bearer $API_TOKEN"
+```
+
+## Static Assets
+
+**3-step process:** Create session → Upload files → Deploy Worker
+
+### 1. Create Upload Session
+```bash
+curl -X POST ".../scripts/$SCRIPT_NAME/assets-upload-session" \
+  -H "Authorization: Bearer $API_TOKEN" \
+  -d '{
+    "manifest": {
+      "/index.html": {"hash": "08f1dfda4574284ab3c21666d1ee8c7d4", "size": 1234}
+    }
+  }'
+# Returns: jwt, buckets
+```
+
+**Hash:** First 16 bytes (32 hex chars) of SHA-256
+
+### 2. Upload Files
+```bash
+curl -X POST ".../workers/assets/upload?base64=true" \
+  -H "Authorization: Bearer $UPLOAD_JWT" \
+  -F '08f1dfda4574284ab3c21666d1ee8c7d4=<BASE64_CONTENT>'
+# Returns: completion jwt
+```
+
+### 3. Deploy with Assets
+```bash
+curl -X PUT ".../scripts/$SCRIPT_NAME" \
+  -F 'metadata={
+    "main_module": "index.js",
+    "assets": {"jwt": "<COMPLETION_TOKEN>"},
+    "bindings": [{"type": "assets", "name": "ASSETS"}]
+  };type=application/json' \
+  -F 'index.js=export default {...};type=application/javascript+module'
+```
+
+**Asset Isolation:** Assets shared across namespace. For strict isolation, salt hash:
+```typescript
+const hash = sha256(accountId + fileContents).slice(0, 32);
+```
+
+## Dispatch Workers
+
+### Subdomain Routing
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const userWorkerName = new URL(request.url).hostname.split(".")[0];
+    const userWorker = env.DISPATCHER.get(userWorkerName);
+    return await userWorker.fetch(request);
+  },
+};
+```
+
+### Path Routing
+```typescript
+const pathParts = new URL(request.url).pathname.split("/").filter(Boolean);
+const userWorker = env.DISPATCHER.get(pathParts[0]);
+return await userWorker.fetch(request);
+```
+
+### KV Routing
+```typescript
+const hostname = new URL(request.url).hostname;
+const userWorkerName = await env.ROUTING_KV.get(hostname);
+const userWorker = env.DISPATCHER.get(userWorkerName);
+return await userWorker.fetch(request);
+```
+
+## Outbound Workers
+
+Control external fetch from user Workers:
+
+### Configure
+```typescript
+const userWorker = env.DISPATCHER.get(
+  workerName, {},
+  { outbound: { customer_context: { customer_name: workerName, url: request.url } } }
+);
+```
+
+### Implement
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const customerName = env.customer_name;
+    const url = new URL(request.url);
+    
+    // Block domains
+    if (["malicious.com"].some(d => url.hostname.includes(d))) {
+      return new Response("Blocked", { status: 403 });
+    }
+    
+    // Inject auth
+    if (url.hostname === "api.example.com") {
+      const headers = new Headers(request.headers);
+      headers.set("Authorization", `Bearer ${generateJWT(customerName)}`);
+      return fetch(new Request(request, { headers }));
+    }
+    
+    return fetch(request);
+  },
+};
+```
+
+**Note:** Doesn't intercept DO/mTLS fetch.
+
+See [README.md](./README.md), [configuration.md](./configuration.md), [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)

--- a/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/configuration.md
@@ -1,0 +1,136 @@
+# Configuration
+
+## Dispatch Namespace Binding
+
+### wrangler.jsonc
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "dispatch_namespaces": [{
+    "binding": "DISPATCHER",
+    "namespace": "production"
+  }]
+}
+```
+
+### wrangler.toml
+```toml
+[[dispatch_namespaces]]
+binding = "DISPATCHER"
+namespace = "production"
+```
+
+### With Outbound Worker
+```jsonc
+{
+  "dispatch_namespaces": [{
+    "binding": "DISPATCHER",
+    "namespace": "production",
+    "outbound": {
+      "service": "outbound-worker",
+      "parameters": ["customer_context"]
+    }
+  }]
+}
+```
+
+## Wrangler Commands
+
+```bash
+wrangler dispatch-namespace list
+wrangler dispatch-namespace get production
+wrangler dispatch-namespace create production
+wrangler dispatch-namespace delete staging
+wrangler dispatch-namespace rename old new
+```
+
+## Custom Limits
+
+Set CPU time and subrequest limits per invocation:
+
+```typescript
+const userWorker = env.DISPATCHER.get(
+  workerName,
+  {},
+  {
+    limits: { 
+      cpuMs: 10,        // Max CPU ms
+      subRequests: 5    // Max fetch() calls
+    }
+  }
+);
+```
+
+Handle limit violations:
+```typescript
+try {
+  return await userWorker.fetch(request);
+} catch (e) {
+  if (e.message.includes("CPU time limit")) {
+    return new Response("CPU limit exceeded", { status: 429 });
+  }
+  throw e;
+}
+```
+
+## Static Assets
+
+Deploy HTML/CSS/images with Workers. See [api.md](./api.md#static-assets) for upload process.
+
+### Wrangler
+```jsonc
+{
+  "name": "customer-site",
+  "main": "./src/index.js",
+  "assets": {
+    "directory": "./public",
+    "binding": "ASSETS"
+  }
+}
+```
+
+```bash
+npx wrangler deploy --name customer-site --dispatch-namespace production
+```
+
+## Bindings
+
+Supported: KV, D1, R2, Durable Objects, Analytics Engine, Service, Assets
+
+Add via API metadata (see [api.md](./api.md#deploy-with-bindings)):
+```json
+{
+  "bindings": [
+    {"type": "kv_namespace", "name": "USER_KV", "namespace_id": "..."},
+    {"type": "r2_bucket", "name": "STORAGE", "bucket_name": "..."},
+    {"type": "d1", "name": "DB", "id": "..."}
+  ]
+}
+```
+
+Preserve existing bindings:
+```json
+{
+  "bindings": [{"type": "r2_bucket", "name": "STORAGE", "bucket_name": "new"}],
+  "keep_bindings": ["kv_namespace", "d1"]
+}
+```
+
+## Tags
+
+Organize/search Workers (max 8/script):
+
+```bash
+# Set tags
+curl -X PUT ".../tags" -d '["customer-123", "pro", "production"]'
+
+# Filter by tag
+curl ".../scripts?tags=production%3Ayes"
+
+# Delete by tag
+curl -X DELETE ".../scripts?tags=customer-123%3Ayes"
+```
+
+Common patterns: `customer-123`, `free|pro|enterprise`, `production|staging`
+
+See [README.md](./README.md), [api.md](./api.md), [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)

--- a/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/gotchas.md
@@ -1,0 +1,130 @@
+# Gotchas & Limits
+
+## Limits
+
+- **Max 8 tags per Worker**
+- **Upload session JWT valid 1 hour**
+- **Completion token valid 1 hour**
+- **No limits on Workers per namespace** (unlike regular Workers)
+- **User Workers run in untrusted mode** (no `request.cf` access)
+- **Outbound Workers don't intercept DO/mTLS fetch**
+
+## Security
+
+### User Worker Restrictions
+- Run in untrusted mode
+- No access to `request.cf` object
+- Automatic isolation from other customers
+- Never share cache
+
+### Outbound Worker Gaps
+- Doesn't intercept Durable Object fetch
+- Doesn't intercept mTLS binding fetch
+- Plan accordingly for complete egress control
+
+### Asset Isolation
+Assets shared across namespace by hash. For strict isolation:
+```typescript
+const hash = sha256(accountId + fileContents).slice(0, 32);
+```
+
+Never expose upload JWTs to clients.
+
+## Error Handling
+
+### Worker Not Found
+```typescript
+try {
+  const userWorker = env.DISPATCHER.get(name);
+  return await userWorker.fetch(request);
+} catch (e) {
+  if (e.message.startsWith("Worker not found")) {
+    return new Response("Worker not found", { status: 404 });
+  }
+  return new Response(e.message, { status: 500 });
+}
+```
+
+### Limit Violations
+```typescript
+try {
+  return await userWorker.fetch(request);
+} catch (e) {
+  if (e.message.includes("CPU time limit")) {
+    env.ANALYTICS.writeDataPoint({
+      indexes: [workerName],
+      blobs: ["cpu_limit_exceeded"],
+    });
+    return new Response("CPU limit exceeded", { status: 429 });
+  }
+  throw e;
+}
+```
+
+## Troubleshooting
+
+### Hostname Routing Issues
+- Use `*/*` wildcard route to avoid DNS proxy issues
+- Orange-to-orange: Customer proxied through CF → your CF domain
+- Wildcard works regardless of proxy settings
+
+### Binding Preservation
+- Use `keep_bindings` to avoid losing existing bindings on update
+- Document which resources bound to which Workers
+
+### Tag Filtering
+- URL encode tags: `tags=production%3Ayes`
+- Avoid special chars: `,` and `&`
+
+### Deploy Failures
+- ES modules require multipart form upload
+- Must specify `main_module` in metadata
+- File type: `application/javascript+module`
+
+### Static Assets
+- Hash must be first 16 bytes (32 hex chars) of SHA-256
+- Upload must happen within 1 hour of session creation
+- Deploy must happen within 1 hour of upload completion
+- Base64 encode file contents for upload
+
+## TypeScript Types
+
+```typescript
+interface Env {
+  DISPATCHER: DispatchNamespace;
+  ROUTING_KV: KVNamespace;
+  CUSTOMERS_KV: KVNamespace;
+  ANALYTICS: AnalyticsEngineDataset;
+}
+
+interface DispatchNamespace {
+  get(
+    name: string,
+    options?: Record<string, unknown>,
+    config?: {
+      limits?: {
+        cpuMs?: number;
+        subRequests?: number;
+      };
+      outbound?: Record<string, unknown>;
+    }
+  ): Fetcher;
+}
+
+interface Fetcher {
+  fetch(request: Request): Promise<Response>;
+}
+```
+
+## Common Mistakes
+
+1. **Creating namespace per customer** → Use one namespace per environment
+2. **Not handling Worker not found** → Always catch and handle gracefully
+3. **Forgetting `keep_bindings`** → Existing bindings lost on update
+4. **Not tagging Workers** → Can't bulk delete/filter
+5. **Exposing upload JWTs** → Keep server-side only
+6. **No limit tracking** → Use Analytics Engine for violations
+7. **Not using wildcard routes** → Hit route limits, DNS issues
+8. **Assuming DO/mTLS interception** → Outbound Worker doesn't catch these
+
+See [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md)

--- a/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-for-platforms/patterns.md
@@ -1,0 +1,170 @@
+# Multi-Tenant Patterns
+
+## Billing by Plan
+
+```typescript
+interface Env {
+  DISPATCHER: DispatchNamespace;
+  CUSTOMERS_KV: KVNamespace;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const userWorkerName = new URL(request.url).hostname.split(".")[0];
+    const customerPlan = await env.CUSTOMERS_KV.get(userWorkerName);
+    
+    const plans = {
+      enterprise: { cpuMs: 50, subRequests: 50 },
+      pro: { cpuMs: 20, subRequests: 20 },
+      free: { cpuMs: 10, subRequests: 5 },
+    };
+    const limits = plans[customerPlan as keyof typeof plans] || plans.free;
+    
+    const userWorker = env.DISPATCHER.get(userWorkerName, {}, { limits });
+    return await userWorker.fetch(request);
+  },
+};
+```
+
+## Resource Isolation
+
+**Complete isolation:** Create unique resources per customer
+- KV namespace per customer
+- D1 database per customer
+- R2 bucket per customer
+
+```typescript
+const bindings = [{
+  type: "kv_namespace",
+  name: "USER_KV",
+  namespace_id: `customer-${customerId}-kv`
+}];
+```
+
+## Hostname Routing
+
+### Wildcard Route (Recommended)
+Configure `*/*` route on SaaS domain → dispatch Worker
+
+**Benefits:**
+- Supports subdomains + custom vanity domains
+- No route limits
+- Programmatic control
+- Works with any DNS proxy settings
+
+**Setup:**
+1. Cloudflare for SaaS custom hostnames
+2. Fallback origin (dummy `A 192.0.2.0` if Worker is origin)
+3. DNS CNAME to SaaS domain
+4. `*/*` route → dispatch Worker
+5. Routing logic in dispatch Worker
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const hostname = new URL(request.url).hostname;
+    const hostnameData = await env.ROUTING_KV.get(`hostname:${hostname}`, { type: "json" });
+    
+    if (!hostnameData?.workerName) {
+      return new Response("Hostname not configured", { status: 404 });
+    }
+    
+    const userWorker = env.DISPATCHER.get(hostnameData.workerName);
+    return await userWorker.fetch(request);
+  },
+};
+```
+
+### Subdomain-Only
+1. Wildcard DNS: `*.saas.com` → origin
+2. Route: `*.saas.com/*` → dispatch Worker
+3. Extract subdomain for routing
+
+**Orange-to-Orange:** When customers use Cloudflare and CNAME to your domain, use `*/*` wildcard for consistent behavior.
+
+## Observability
+
+### Logpush
+- Enable on dispatch Worker → captures all user Worker logs
+- Filter by `Outcome` or `Script Name`
+
+### Tail Workers
+- Real-time logs with custom formatting
+- Receives HTTP status, `console.log()`, exceptions, diagnostics
+
+### Analytics Engine
+```typescript
+// Track violations
+env.ANALYTICS.writeDataPoint({
+  indexes: [customerName],
+  blobs: ["cpu_limit_exceeded"],
+});
+```
+
+### GraphQL
+```graphql
+query {
+  viewer {
+    accounts(filter: {accountTag: $accountId}) {
+      workersInvocationsAdaptive(filter: {dispatchNamespaceName: "production"}) {
+        sum { requests errors cpuTime }
+      }
+    }
+  }
+}
+```
+
+## Use Case Implementations
+
+### AI Code Execution
+```typescript
+async function deployGeneratedCode(name: string, code: string) {
+  const file = new File([code], `${name}.mjs`, { type: "application/javascript+module" });
+  await client.workersForPlatforms.dispatch.namespaces.scripts.update("production", name, {
+    account_id: accountId,
+    metadata: { main_module: `${name}.mjs`, tags: [name, "ai-generated"] },
+    files: [file],
+  });
+}
+
+// Short limits for untrusted code
+const userWorker = env.DISPATCHER.get(sessionId, {}, { limits: { cpuMs: 5, subRequests: 3 } });
+```
+
+### Edge Functions Platform
+```typescript
+// Route: /customer-id/function-name
+const [customerId, functionName] = new URL(request.url).pathname.split("/").filter(Boolean);
+const workerName = `${customerId}-${functionName}`;
+const userWorker = env.DISPATCHER.get(workerName);
+```
+
+### Website Builder
+- Deploy static assets + Worker code
+- See [api.md](./api.md#static-assets) for full implementation
+- Salt hashes for asset isolation
+
+## Best Practices
+
+### Architecture
+- One namespace per environment (production, staging)
+- Platform logic in dispatch Worker (auth, rate limiting, validation)
+- Isolation automatic (no shared cache, untrusted mode)
+
+### Routing
+- Use `*/*` wildcard routes
+- Store mappings in KV
+- Handle missing Workers gracefully
+
+### Limits & Security
+- Set custom limits by plan
+- Track violations with Analytics Engine
+- Use outbound Workers for egress control
+- Sanitize responses
+
+### Tags
+- Tag all Workers: customer ID, plan, environment
+- Enable bulk operations
+- Filter efficiently
+
+See [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [gotchas.md](./gotchas.md)

--- a/.agent/services/hosting/cloudflare-platform/references/workers-playground/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-playground/README.md
@@ -1,0 +1,16 @@
+# Cloudflare Workers Playground Skill Reference
+
+## Overview
+
+Cloudflare Workers Playground is a browser-based sandbox for instantly experimenting with, testing, and deploying Cloudflare Workers without authentication or setup. This skill provides patterns, APIs, and best practices specifically for Workers Playground development....
+
+## In This Reference
+
+- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
+- **[api.md](./api.md)** - API endpoints, methods, interfaces
+- **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
+- **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
+
+## See Also
+
+- [Cloudflare Docs](https://developers.cloudflare.com/)

--- a/.agent/services/hosting/cloudflare-platform/references/workers-playground/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-playground/api.md
@@ -1,0 +1,20 @@
+### HTTP Test Panel
+
+Switch to **HTTP** tab to test raw HTTP requests:
+- Change HTTP method (GET, POST, PUT, DELETE, etc.)
+- Add/edit headers
+- Modify request body
+- Send request to Worker
+
+### Sharing Code
+
+Click **Copy Link** to generate shareable URL with embedded code. Links never expire and can be bookmarked.
+
+### Deploy from Playground
+
+Click **Deploy** button to:
+1. Log in to Cloudflare account (if not already)
+2. Review Worker code
+3. Deploy to Cloudflare's global network
+4. Get unique `*.workers.dev` URL
+5. Add custom domains, bindings, etc. from dashboard

--- a/.agent/services/hosting/cloudflare-platform/references/workers-playground/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-playground/configuration.md
@@ -1,0 +1,3 @@
+# Configuration
+
+See main documentation.

--- a/.agent/services/hosting/cloudflare-platform/references/workers-playground/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-playground/gotchas.md
@@ -1,0 +1,35 @@
+## Best Practices
+
+### 1. Use Async/Await
+Always use `async/await` for cleaner asynchronous code:
+
+```javascript
+// Good
+export default {
+  async fetch(request, env, ctx) {
+    const response = await fetch('https://api.example.com');
+    const data = await response.json();
+    return new Response(JSON.stringify(data));
+  },
+};
+
+// Avoid
+export default {
+  fetch(request, env, ctx) {
+    return fetch('https://api.example.com')
+      .then(response => response.json())
+      .then(data => new Response(JSON.stringify(data)));
+  },
+};
+```
+
+### 2. Clone Responses Before Reading
+Response bodies can only be read once:
+
+```javascript
+export default {
+  async fetch(request, env, ctx) {
+    const response = await fetch('https://api.example.com');
+    
+    // Clone before caching
+    ctx.waitUntil(cach

--- a/.agent/services/hosting/cloudflare-platform/references/workers-playground/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-playground/patterns.md
@@ -1,0 +1,42 @@
+## Common Use Cases
+
+### 1. API Gateway
+```javascript
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    
+    // Route based on path
+    if (url.pathname.startsWith('/v1/users')) {
+      return fetch('https://users-api.example.com' + url.pathname);
+    }
+    
+    if (url.pathname.startsWith('/v1/posts')) {
+      return fetch('https://posts-api.example.com' + url.pathname);
+    }
+    
+    return new Response('API Gateway', { status: 404 });
+  },
+};
+```
+
+### 2. A/B Testing
+```javascript
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const cookie = request.headers.get('Cookie');
+    
+    // Check existing variant
+    let variant = cookie?.includes('ab_test=B') ? 'B' : null;
+    
+    if (!variant) {
+      // Assign 50/50 split
+      variant = Math.random() < 0.5 ? 'A' : 'B';
+    }
+    
+    const targetUrl = variant === 'A' 
+      ? 'https://a.example.com' 
+      : 'https://b.example.com';
+    
+    con

--- a/.agent/services/hosting/cloudflare-platform/references/workers-vpc/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers-vpc/README.md
@@ -1,0 +1,579 @@
+# Cloudflare Workers VPC Skill
+
+Expert guidance for connecting Cloudflare Workers to private networks (AWS/Azure/GCP/on-prem) using TCP Sockets, Cloudflare Tunnel, and related technologies.
+
+## What is Workers VPC Connectivity?
+
+Workers VPC connectivity enables Workers to communicate with resources in private networks through:
+
+1. **TCP Sockets API** (`connect()`) - Direct outbound TCP connections from Workers
+2. **Cloudflare Tunnel** - Secure connections to private networks without exposing public IPs
+3. **Hyperdrive** - Optimized connections to external databases with pooling
+4. **Smart Placement** - Automatic Worker placement near backend services
+
+## Core APIs
+
+### TCP Sockets (`connect()`)
+
+Create outbound TCP connections to private resources:
+
+```typescript
+import { connect } from 'cloudflare:sockets';
+
+export default {
+  async fetch(req: Request): Promise<Response> {
+    const socket = connect({
+      hostname: "internal-db.private.com",
+      port: 5432
+    }, {
+      secureTransport: "starttls" // or "on" for immediate TLS
+    });
+
+    // Get readable/writable streams
+    const writer = socket.writable.getWriter();
+    const reader = socket.readable.getReader();
+
+    // Write data
+    const encoder = new TextEncoder();
+    await writer.write(encoder.encode("QUERY\r\n"));
+    await writer.close();
+
+    // Read response
+    const { value } = await reader.read();
+    
+    await socket.close();
+    return new Response(value);
+  }
+};
+```
+
+### SocketOptions
+
+```typescript
+interface SocketOptions {
+  secureTransport?: "off" | "on" | "starttls"; // Default: "off"
+  allowHalfOpen?: boolean; // Default: false
+}
+
+interface SocketAddress {
+  hostname: string; // e.g., "db.private.net"
+  port: number;     // e.g., 5432
+}
+```
+
+### Socket Interface
+
+```typescript
+interface Socket {
+  readable: ReadableStream<Uint8Array>;
+  writable: WritableStream<Uint8Array>;
+  opened: Promise<SocketInfo>;
+  closed: Promise<void>;
+  close(): Promise<void>;
+  startTls(): Socket; // Upgrade to TLS
+}
+```
+
+## Common Use Cases
+
+### 1. Connect to Internal Database
+
+```typescript
+import { connect } from 'cloudflare:sockets';
+
+export default {
+  async fetch(req: Request) {
+    const socket = connect(
+      { hostname: "10.0.1.50", port: 5432 },
+      { secureTransport: "on" }
+    );
+
+    try {
+      await socket.opened; // Wait for connection
+      
+      const writer = socket.writable.getWriter();
+      await writer.write(new TextEncoder().encode("SELECT 1\n"));
+      await writer.close();
+
+      return new Response(socket.readable);
+    } catch (error) {
+      return new Response(`Connection failed: ${error}`, { status: 500 });
+    } finally {
+      await socket.close();
+    }
+  }
+};
+```
+
+### 2. StartTLS Pattern (Opportunistic TLS)
+
+Many databases require starting insecure then upgrading:
+
+```typescript
+import { connect } from 'cloudflare:sockets';
+
+const socket = connect(
+  { hostname: "postgres.internal", port: 5432 },
+  { secureTransport: "starttls" }
+);
+
+// Initially insecure connection
+const writer = socket.writable.getWriter();
+await writer.write(new TextEncoder().encode("STARTTLS\n"));
+
+// Upgrade to TLS
+const secureSocket = socket.startTls();
+
+// Now use secureSocket for encrypted communication
+const secureWriter = secureSocket.writable.getWriter();
+await secureWriter.write(new TextEncoder().encode("AUTH\n"));
+```
+
+### 3. SSH/MQTT/SMTP Protocols
+
+```typescript
+// SSH connection example
+import { connect } from 'cloudflare:sockets';
+
+export default {
+  async fetch(req: Request) {
+    const socket = connect(
+      { hostname: "bastion.internal", port: 22 },
+      { secureTransport: "on" }
+    );
+
+    const writer = socket.writable.getWriter();
+    const reader = socket.readable.getReader();
+
+    // SSH handshake
+    await writer.write(new TextEncoder().encode("SSH-2.0-CloudflareWorker\r\n"));
+
+    // Read server response
+    const { value } = await reader.read();
+    const response = new TextDecoder().decode(value);
+
+    await socket.close();
+    return new Response(response);
+  }
+};
+```
+
+### 4. Connection with Error Handling
+
+```typescript
+import { connect } from 'cloudflare:sockets';
+
+async function connectToPrivateService(
+  host: string,
+  port: number,
+  data: string
+): Promise<string> {
+  let socket: ReturnType<typeof connect> | null = null;
+
+  try {
+    socket = connect({ hostname: host, port }, { secureTransport: "on" });
+    
+    await socket.opened; // Throws if connection fails
+
+    const writer = socket.writable.getWriter();
+    await writer.write(new TextEncoder().encode(data));
+    await writer.close();
+
+    const reader = socket.readable.getReader();
+    const chunks: Uint8Array[] = [];
+    
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+
+    const combined = new Uint8Array(
+      chunks.reduce((acc, chunk) => acc + chunk.length, 0)
+    );
+    let offset = 0;
+    chunks.forEach(chunk => {
+      combined.set(chunk, offset);
+      offset += chunk.length;
+    });
+
+    return new TextDecoder().decode(combined);
+  } catch (error) {
+    throw new Error(`Socket error: ${error}`);
+  } finally {
+    if (socket) await socket.close();
+  }
+}
+```
+
+## Integration with Cloudflare Tunnel
+
+Connect Workers to private networks via Cloudflare Tunnel:
+
+### Architecture Pattern
+
+```
+Worker → TCP Socket → Cloudflare Tunnel → Private Network
+```
+
+### Setup
+
+1. **Install cloudflared in your private network:**
+
+```bash
+# On private network server
+cloudflared tunnel create my-private-network
+cloudflared tunnel route ip add 10.0.0.0/24 my-private-network
+```
+
+2. **Configure tunnel:**
+
+```yaml
+# config.yml
+tunnel: <TUNNEL_ID>
+credentials-file: /path/to/credentials.json
+
+ingress:
+  - hostname: db.internal.example.com
+    service: tcp://10.0.1.50:5432
+  - hostname: api.internal.example.com
+    service: http://10.0.1.100:8080
+  - service: http_status:404
+```
+
+3. **Connect from Worker:**
+
+```typescript
+import { connect } from 'cloudflare:sockets';
+
+export default {
+  async fetch(req: Request) {
+    // Connect through Tunnel to private resource
+    const socket = connect({
+      hostname: "db.internal.example.com",
+      port: 5432
+    }, {
+      secureTransport: "on"
+    });
+
+    // Use socket...
+  }
+};
+```
+
+## Wrangler Configuration
+
+### Enable TCP Sockets
+
+```toml
+# wrangler.toml
+name = "private-network-worker"
+main = "src/index.ts"
+compatibility_date = "2024-01-01"
+
+# No special configuration needed - TCP sockets are available by default
+# in Workers runtime
+
+[env.production]
+routes = [
+  { pattern = "api.example.com/*", zone_name = "example.com" }
+]
+```
+
+### Environment Variables for Endpoints
+
+```toml
+[vars]
+DB_HOST = "10.0.1.50"
+DB_PORT = "5432"
+API_HOST = "internal-api.private.net"
+API_PORT = "8080"
+```
+
+```typescript
+interface Env {
+  DB_HOST: string;
+  DB_PORT: string;
+}
+
+export default {
+  async fetch(req: Request, env: Env) {
+    const socket = connect({
+      hostname: env.DB_HOST,
+      port: parseInt(env.DB_PORT)
+    });
+    // ...
+  }
+};
+```
+
+## Smart Placement
+
+Auto-locate Workers near backend services:
+
+```toml
+# wrangler.toml
+[placement]
+mode = "smart"
+```
+
+```typescript
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext) {
+    // Worker automatically runs closest to your backend
+    const socket = connect({ hostname: "backend.internal", port: 8080 });
+    // Minimized latency to private network
+  }
+};
+```
+
+## Hyperdrive for Databases
+
+For PostgreSQL/MySQL, use Hyperdrive instead of raw TCP sockets:
+
+```toml
+# wrangler.toml
+[[hyperdrive]]
+binding = "DB"
+id = "<HYPERDRIVE_ID>"
+```
+
+```typescript
+import { Client } from 'pg';
+
+interface Env {
+  DB: Hyperdrive;
+}
+
+export default {
+  async fetch(req: Request, env: Env) {
+    const client = new Client({
+      connectionString: env.DB.connectionString
+    });
+    
+    await client.connect();
+    const result = await client.query('SELECT * FROM users');
+    await client.end();
+
+    return Response.json(result.rows);
+  }
+};
+```
+
+## Limits and Considerations
+
+### TCP Socket Limits
+
+- **Max simultaneous connections:** 6 per Worker execution
+- **Blocked destinations:**
+  - Cloudflare IPs
+  - `localhost` / `127.0.0.1`
+  - Port 25 (SMTP - use Email Workers instead)
+  - Cannot connect back to the calling Worker (loop detection)
+- **Scope:** Sockets must be created in handlers (fetch/scheduled/queue), not global scope
+
+### Performance
+
+```typescript
+// ❌ BAD: Creating socket in global scope
+// import { connect } from 'cloudflare:sockets';
+// const globalSocket = connect({ hostname: "db", port: 5432 }); // ERROR
+
+// ✅ GOOD: Create in handler
+export default {
+  async fetch(req: Request) {
+    const socket = connect({ hostname: "db", port: 5432 });
+    // Use socket
+    await socket.close();
+  }
+};
+```
+
+### Security
+
+```typescript
+// Validate destinations
+function isAllowedHost(hostname: string): boolean {
+  const allowed = [
+    'internal-db.company.com',
+    'api.private.net',
+    /^10\.0\.1\.\d+$/ // Private subnet regex
+  ];
+  
+  return allowed.some(pattern => 
+    pattern instanceof RegExp 
+      ? pattern.test(hostname)
+      : pattern === hostname
+  );
+}
+
+export default {
+  async fetch(req: Request) {
+    const url = new URL(req.url);
+    const target = url.searchParams.get('target');
+    
+    if (!target || !isAllowedHost(target)) {
+      return new Response('Forbidden', { status: 403 });
+    }
+    
+    const socket = connect({ hostname: target, port: 443 });
+    // ...
+  }
+};
+```
+
+## Common Errors
+
+### `proxy request failed, cannot connect to the specified address`
+
+**Cause:** Attempting to connect to disallowed address (Cloudflare IPs, localhost, blocked IPs)
+
+**Solution:** Use public internet addresses or properly configured Tunnel endpoints
+
+### `TCP Loop detected`
+
+**Cause:** Worker connecting back to itself
+
+**Solution:** Ensure destination is external service, not the Worker's own URL
+
+### `Connections to port 25 are prohibited`
+
+**Cause:** Attempting SMTP on port 25
+
+**Solution:** Use [Email Workers](https://developers.cloudflare.com/email-routing/email-workers/)
+
+### `socket is not open`
+
+**Cause:** Trying to read/write after socket closed
+
+**Solution:** Check socket state, use try/finally with close()
+
+## Testing
+
+### Local Development with Wrangler
+
+```bash
+wrangler dev
+```
+
+### Test TCP Connection
+
+```typescript
+// test.ts
+import { connect } from 'cloudflare:sockets';
+
+export default {
+  async fetch(req: Request) {
+    const socket = connect({ hostname: "google.com", port: 80 });
+    
+    const writer = socket.writable.getWriter();
+    await writer.write(
+      new TextEncoder().encode("GET / HTTP/1.0\r\n\r\n")
+    );
+    await writer.close();
+
+    return new Response(socket.readable, {
+      headers: { "Content-Type": "text/plain" }
+    });
+  }
+};
+```
+
+## Best Practices
+
+1. **Always close sockets:**
+   ```typescript
+   const socket = connect(...);
+   try {
+     // Use socket
+   } finally {
+     await socket.close();
+   }
+   ```
+
+2. **Use Hyperdrive for databases** - Better performance, connection pooling
+
+3. **Validate destinations** - Prevent connections to unintended hosts
+
+4. **Handle errors gracefully:**
+   ```typescript
+   try {
+     const socket = connect(...);
+     await socket.opened;
+     // Use socket
+   } catch (error) {
+     console.error('Socket error:', error);
+     return new Response('Service unavailable', { status: 503 });
+   }
+   ```
+
+5. **Use Smart Placement** for latency-sensitive applications
+
+6. **Prefer fetch() for HTTP** - Use TCP sockets only when necessary
+
+## Real-World Patterns
+
+### Multi-Protocol Gateway
+
+```typescript
+import { connect } from 'cloudflare:sockets';
+
+interface Protocol {
+  connect(host: string, port: number): Promise<string>;
+}
+
+class SSHProtocol implements Protocol {
+  async connect(host: string, port: number): Promise<string> {
+    const socket = connect({ hostname: host, port }, { secureTransport: "on" });
+    // SSH implementation
+    await socket.close();
+    return "SSH connection established";
+  }
+}
+
+class PostgresProtocol implements Protocol {
+  async connect(host: string, port: number): Promise<string> {
+    const socket = connect(
+      { hostname: host, port },
+      { secureTransport: "starttls" }
+    );
+    
+    // Postgres wire protocol
+    const secureSocket = socket.startTls();
+    await secureSocket.close();
+    return "Postgres connection established";
+  }
+}
+
+export default {
+  async fetch(req: Request) {
+    const url = new URL(req.url);
+    const protocol = url.pathname.slice(1); // /ssh or /postgres
+    
+    const protocols: Record<string, Protocol> = {
+      ssh: new SSHProtocol(),
+      postgres: new PostgresProtocol()
+    };
+    
+    const handler = protocols[protocol];
+    if (!handler) {
+      return new Response('Unknown protocol', { status: 400 });
+    }
+    
+    const result = await handler.connect('internal.net', 22);
+    return new Response(result);
+  }
+};
+```
+
+## Reference
+
+- [TCP Sockets Documentation](https://developers.cloudflare.com/workers/runtime-apis/tcp-sockets/)
+- [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/)
+- [Hyperdrive](https://developers.cloudflare.com/hyperdrive/)
+- [Smart Placement](https://developers.cloudflare.com/workers/configuration/smart-placement/)
+- [Email Workers](https://developers.cloudflare.com/email-routing/email-workers/)
+
+---
+
+This skill focuses exclusively on connecting Workers to private networks and VPCs. For general Workers development, see the `cloudflare-workers` skill.

--- a/.agent/services/hosting/cloudflare-platform/references/workers/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers/README.md
@@ -1,0 +1,96 @@
+# Cloudflare Workers
+
+Expert guidance for building, deploying, and optimizing Cloudflare Workers applications.
+
+## Overview
+
+Cloudflare Workers run on V8 isolates (NOT containers/VMs):
+- Extremely fast cold starts (< 1ms)
+- Global deployment across 300+ locations
+- Web standards compliant (fetch, URL, Headers, Request, Response)
+- Support JS/TS, Python, Rust, and WebAssembly
+
+**Key principle**: Workers use web platform APIs wherever possible for portability.
+
+## Module Worker Pattern (Recommended)
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    return new Response('Hello World!');
+  },
+};
+```
+
+**Handler parameters**:
+- `request`: Incoming HTTP request (standard Request object)
+- `env`: Environment bindings (KV, D1, R2, secrets, vars)
+- `ctx`: Execution context (`waitUntil`, `passThroughOnException`)
+
+## Essential Commands
+
+```bash
+npx wrangler dev                    # Local dev
+npx wrangler dev --remote           # Remote dev (actual resources)
+npx wrangler deploy                 # Production
+npx wrangler deploy --env staging   # Specific environment
+npx wrangler tail                   # Stream logs
+npx wrangler secret put API_KEY     # Set secret
+```
+
+## When to Use Workers
+
+- API endpoints at the edge
+- Request/response transformation
+- Authentication/authorization layers
+- Static asset optimization
+- A/B testing and feature flags
+- Rate limiting and security
+- Proxy/routing logic
+- WebSocket applications
+
+## Quick Start
+
+```bash
+npm create cloudflare@latest my-worker -- --type hello-world
+cd my-worker
+npx wrangler dev
+```
+
+## Handler Signatures
+
+```typescript
+// HTTP requests
+async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response>
+
+// Cron triggers
+async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void>
+
+// Queue consumer
+async queue(batch: MessageBatch, env: Env, ctx: ExecutionContext): Promise<void>
+
+// Tail consumer
+async tail(events: TraceItem[], env: Env, ctx: ExecutionContext): Promise<void>
+```
+
+## Resources
+
+**Docs**: https://developers.cloudflare.com/workers/  
+**Examples**: https://developers.cloudflare.com/workers/examples/  
+**Runtime APIs**: https://developers.cloudflare.com/workers/runtime-apis/
+
+## In This Reference
+
+- [Configuration](./configuration.md) - wrangler.jsonc setup, bindings, environments
+- [API](./api.md) - Runtime APIs, bindings, execution context
+- [Patterns](./patterns.md) - Common workflows, testing, optimization
+- [Gotchas](./gotchas.md) - Common issues, limits, troubleshooting
+
+## See Also
+
+- [KV](../kv/README.md) - Key-value storage
+- [D1](../d1/README.md) - SQL database
+- [R2](../r2/README.md) - Object storage
+- [Durable Objects](../durable-objects/README.md) - Stateful coordination
+- [Queues](../queues/README.md) - Message queues
+- [Wrangler](../wrangler/README.md) - CLI tool reference

--- a/.agent/services/hosting/cloudflare-platform/references/workers/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers/api.md
@@ -1,0 +1,137 @@
+# Workers Runtime APIs
+
+## Fetch Handler
+
+```typescript
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    if (request.method === 'POST' && url.pathname === '/api') {
+      const body = await request.json();
+      return new Response(JSON.stringify({ id: 1 }), {
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+    return fetch(request);  // Subrequest to origin
+  },
+};
+```
+
+## Execution Context
+
+```typescript
+ctx.waitUntil(logAnalytics(request));  // Background work, don't block response
+ctx.passThroughOnException();  // Failover to origin on error
+```
+
+**Never** `await` background operations - use `ctx.waitUntil()`.
+
+## Bindings
+
+```typescript
+// KV
+await env.MY_KV.get('key');
+await env.MY_KV.put('key', 'value', { expirationTtl: 3600 });
+
+// R2
+const obj = await env.MY_BUCKET.get('file.txt');
+await env.MY_BUCKET.put('file.txt', 'content');
+
+// D1
+const result = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(1).first();
+
+// Queues
+await env.MY_QUEUE.send({ timestamp: Date.now() });
+
+// Secrets/vars
+const key = env.API_KEY;
+```
+
+## Cache API
+
+```typescript
+const cache = caches.default;
+let response = await cache.match(request);
+
+if (!response) {
+  response = await fetch(request);
+  response = new Response(response.body, response);
+  response.headers.set('Cache-Control', 'max-age=3600');
+  ctx.waitUntil(cache.put(request, response.clone()));  // Clone before caching
+}
+```
+
+## HTMLRewriter
+
+```typescript
+return new HTMLRewriter()
+  .on('a[href]', {
+    element(el) {
+      const href = el.getAttribute('href');
+      if (href?.startsWith('http://')) {
+        el.setAttribute('href', href.replace('http://', 'https://'));
+      }
+    }
+  })
+  .transform(response);
+```
+
+**Use cases**: A/B testing, analytics injection, link rewriting
+
+## WebSockets
+
+```typescript
+const [client, server] = Object.values(new WebSocketPair());
+
+server.accept();
+server.addEventListener('message', event => {
+  server.send(`Echo: ${event.data}`);
+});
+
+return new Response(null, { status: 101, webSocket: client });
+```
+
+## Durable Objects
+
+```typescript
+export class Counter {
+  private value = 0;
+  
+  constructor(private state: DurableObjectState) {
+    state.blockConcurrencyWhile(async () => {
+      this.value = (await state.storage.get('value')) || 0;
+    });
+  }
+  
+  async fetch(request: Request): Promise<Response> {
+    if (new URL(request.url).pathname === '/increment') {
+      await this.state.storage.put('value', ++this.value);
+    }
+    return new Response(String(this.value));
+  }
+}
+
+// Usage: const stub = env.COUNTER.get(env.COUNTER.idFromName('global'));
+```
+
+**When to use**: Real-time collaboration, rate limiting, strongly consistent state
+
+## Other Handlers
+
+```typescript
+// Cron: async scheduled(event, env, ctx) { ctx.waitUntil(doCleanup(env)); }
+// Queue: async queue(batch) { for (const msg of batch.messages) { await process(msg.body); msg.ack(); } }
+// Tail: async tail(events, env) { for (const e of events) if (e.outcome === 'exception') await log(e); }
+```
+
+## Service Bindings
+
+```typescript
+return env.SERVICE_B.fetch(request);  // Worker-to-worker RPC, zero latency
+```
+
+## See Also
+
+- [Configuration](./configuration.md) - Binding setup
+- [Patterns](./patterns.md) - Common workflows
+- [KV](../kv/README.md), [D1](../d1/README.md), [R2](../r2/README.md), [Durable Objects](../durable-objects/README.md), [Queues](../queues/README.md)

--- a/.agent/services/hosting/cloudflare-platform/references/workers/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers/configuration.md
@@ -1,0 +1,147 @@
+# Workers Configuration
+
+## wrangler.jsonc (Recommended)
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-01-01", // Use current date for new projects
+  
+  // Bindings (non-inheritable)
+  "vars": { "ENVIRONMENT": "production" },
+  "kv_namespaces": [{ "binding": "MY_KV", "id": "abc123" }],
+  "r2_buckets": [{ "binding": "MY_BUCKET", "bucket_name": "my-bucket" }],
+  "d1_databases": [{ "binding": "DB", "database_name": "my-db", "database_id": "xyz789" }],
+  
+  // Environments
+  "env": {
+    "staging": {
+      "vars": { "ENVIRONMENT": "staging" },
+      "kv_namespaces": [{ "binding": "MY_KV", "id": "staging-id" }]
+    }
+  }
+}
+```
+
+## Configuration Rules
+
+**Inheritable**: `name`, `main`, `compatibility_date`, `routes`, `workers_dev`  
+**Non-inheritable**: All bindings (`vars`, `kv_namespaces`, `r2_buckets`, etc.)  
+**Top-level only**: `migrations`, `keep_vars`, `send_metrics`
+
+**ALWAYS set `compatibility_date` to current date for new projects**
+
+## Bindings
+
+```jsonc
+{
+  // Environment variables - access via env.VAR_NAME
+  "vars": { "ENVIRONMENT": "production" },
+  
+  // KV (key-value storage)
+  "kv_namespaces": [{ "binding": "MY_KV", "id": "abc123" }],
+  
+  // R2 (object storage)
+  "r2_buckets": [{ "binding": "MY_BUCKET", "bucket_name": "my-bucket" }],
+  
+  // D1 (SQL database)
+  "d1_databases": [{ "binding": "DB", "database_name": "my-db", "database_id": "xyz789" }],
+  
+  // Durable Objects (stateful coordination)
+  "durable_objects": {
+    "bindings": [{ "name": "COUNTER", "class_name": "Counter" }]
+  },
+  
+  // Queues (message queues)
+  "queues": {
+    "producers": [{ "binding": "MY_QUEUE", "queue": "my-queue" }],
+    "consumers": [{ "queue": "my-queue", "max_batch_size": 10 }]
+  },
+  
+  // Service bindings (worker-to-worker RPC)
+  "services": [{ "binding": "SERVICE_B", "service": "service-b" }],
+  
+  // Analytics Engine
+  "analytics_engine_datasets": [{ "binding": "ANALYTICS" }]
+}
+```
+
+### Secrets
+
+Set via CLI (never in config):
+
+```bash
+npx wrangler secret put API_KEY
+```
+
+Access: `env.API_KEY`
+
+### Automatic Provisioning (Beta)
+
+Bindings without IDs are auto-created:
+
+```jsonc
+{ "kv_namespaces": [{ "binding": "MY_KV" }] }  // ID added on deploy
+```
+
+## Routes & Triggers
+
+```jsonc
+{
+  "routes": [
+    { "pattern": "example.com/*", "zone_name": "example.com" }
+  ],
+  "triggers": {
+    "crons": ["0 */6 * * *"]  // Every 6 hours
+  }
+}
+```
+
+## TypeScript Setup
+
+```bash
+npm install -D @cloudflare/workers-types
+```
+
+`tsconfig.json`: `{ "compilerOptions": { "target": "ES2022", "lib": ["ES2022"], "types": ["@cloudflare/workers-types"] } }`
+
+Define environment interface:
+
+```typescript
+interface Env {
+  MY_KV: KVNamespace;
+  DB: D1Database;
+  API_KEY: string;
+}
+```
+
+## Advanced Options
+
+```jsonc
+{
+  // Auto-locate compute near data sources
+  "placement": { "mode": "smart" },
+  
+  // Enable Node.js built-ins
+  "compatibility_flags": ["nodejs_compat_v2"],
+  
+  // Observability (10% sampling)
+  "observability": { "enabled": true, "head_sampling_rate": 0.1 }
+}
+```
+
+## Deployment Commands
+
+```bash
+npx wrangler deploy              # Production
+npx wrangler deploy --env staging
+npx wrangler deploy --dry-run    # Validate only
+```
+
+## See Also
+
+- [API](./api.md) - Runtime APIs and bindings usage
+- [Patterns](./patterns.md) - Deployment strategies
+- [Wrangler](../wrangler/README.md) - CLI reference

--- a/.agent/services/hosting/cloudflare-platform/references/workers/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers/gotchas.md
@@ -1,0 +1,99 @@
+# Workers Gotchas
+
+## CPU Time Limits
+
+**Standard**: 10ms CPU time  
+**Unbound**: 30ms CPU time
+
+**Solutions**:
+- Use `ctx.waitUntil()` for background work
+- Offload heavy compute to Durable Objects
+- Consider Workers AI for ML workloads
+
+## No Persistent State in Worker
+
+Workers are stateless between requests - module-level variables reset unpredictably.
+
+**Solution**: Use KV, D1, or Durable Objects for persistent state.
+
+## Response Bodies Are Streams
+
+```typescript
+// ❌ BAD
+const response = await fetch(url);
+await logBody(response.text());  // First read
+return response;  // Body already consumed!
+
+// ✅ GOOD
+const response = await fetch(url);
+const text = await response.text();
+await logBody(text);
+return new Response(text, response);
+```
+
+## No Node.js Built-ins (by default)
+
+```typescript
+// ❌ BAD
+import fs from 'fs';  // Not available
+
+// ✅ GOOD - use Workers APIs
+const data = await env.MY_BUCKET.get('file.txt');
+
+// OR enable Node.js compat
+{ "compatibility_flags": ["nodejs_compat_v2"] }
+```
+
+## Fetch in Global Scope Forbidden
+
+```typescript
+// ❌ BAD
+const config = await fetch('/config.json');  // Error!
+
+export default {
+  async fetch() { return new Response('OK'); },
+};
+
+// ✅ GOOD
+export default {
+  async fetch() {
+    const config = await fetch('/config.json');  // OK
+    return new Response('OK');
+  },
+};
+```
+
+## Limits
+
+| Resource | Limit |
+|----------|-------|
+| Request size | 100 MB |
+| Response size | Unlimited (streaming) |
+| CPU time | 10ms (standard) / 30ms (unbound) |
+| Subrequests | 1000 per request |
+| KV reads | 1000 per request |
+| KV write size | 25 MB |
+| Environment size | 5 MB |
+
+## Common Errors
+
+### "Error: Body has already been used"
+
+**Cause**: Response body read twice  
+**Solution**: Clone response before reading: `response.clone()`
+
+### "Error: Too much CPU time used"
+
+**Cause**: Exceeded CPU limit  
+**Solution**: Use `ctx.waitUntil()` for background work
+
+### "Error: Subrequest depth limit exceeded"
+
+**Cause**: Too many nested subrequests  
+**Solution**: Flatten request chain, use service bindings
+
+## See Also
+
+- [Patterns](./patterns.md) - Best practices
+- [API](./api.md) - Runtime APIs
+- [Configuration](./configuration.md) - Setup

--- a/.agent/services/hosting/cloudflare-platform/references/workers/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workers/patterns.md
@@ -1,0 +1,149 @@
+# Workers Patterns
+
+## Error Handling
+
+```typescript
+class HTTPError extends Error {
+  constructor(public status: number, message: string) { super(message); }
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    try {
+      return await handleRequest(request, env);
+    } catch (error) {
+      if (error instanceof HTTPError) {
+        return new Response(JSON.stringify({ error: error.message }), {
+          status: error.status, headers: { 'Content-Type': 'application/json' }
+        });
+      }
+      return new Response('Internal Server Error', { status: 500 });
+    }
+  },
+};
+```
+
+## CORS
+
+```typescript
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+if (request.method === 'OPTIONS') return new Response(null, { headers: corsHeaders });
+// Add corsHeaders to response
+```
+
+## Routing
+
+```typescript
+const router = { 'GET /api/users': handleGetUsers, 'POST /api/users': handleCreateUser };
+
+const handler = router[`${request.method} ${url.pathname}`];
+return handler ? handler(request, env) : new Response('Not Found', { status: 404 });
+```
+
+**Production**: Use Hono, itty-router, or Worktop
+
+## Performance
+
+```typescript
+// ❌ Sequential
+const user = await fetch('/api/user/1');
+const posts = await fetch('/api/posts?user=1');
+
+// ✅ Parallel
+const [user, posts] = await Promise.all([fetch('/api/user/1'), fetch('/api/posts?user=1')]);
+```
+
+## Streaming
+
+```typescript
+const stream = new ReadableStream({
+  async start(controller) {
+    for (let i = 0; i < 1000; i++) {
+      controller.enqueue(new TextEncoder().encode(`Item ${i}\n`));
+      if (i % 100 === 0) await new Promise(r => setTimeout(r, 0));
+    }
+    controller.close();
+  }
+});
+```
+
+## Transform Streams
+
+```typescript
+response.body.pipeThrough(new TextDecoderStream()).pipeThrough(
+  new TransformStream({ transform(chunk, c) { c.enqueue(chunk.toUpperCase()); } })
+).pipeThrough(new TextEncoderStream());
+```
+
+## Testing
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import worker from '../src/index';
+
+describe('Worker', () => {
+  it('returns 200', async () => {
+    const req = new Request('http://localhost/');
+    const env = { MY_VAR: 'test' };
+    const ctx = { waitUntil: () => {}, passThroughOnException: () => {} };
+    expect((await worker.fetch(req, env, ctx)).status).toBe(200);
+  });
+});
+```
+
+## Deployment
+
+```bash
+npx wrangler deploy              # production
+npx wrangler deploy --env staging
+npx wrangler versions upload --message "Add feature"
+npx wrangler rollback
+```
+
+## Monitoring
+
+```typescript
+const start = Date.now();
+const response = await handleRequest(request, env);
+ctx.waitUntil(env.ANALYTICS.writeDataPoint({
+  doubles: [Date.now() - start], blobs: [request.url, String(response.status)]
+}));
+```
+
+## Security
+
+```typescript
+// Headers
+const security = {
+  'X-Content-Type-Options': 'nosniff',
+  'X-Frame-Options': 'DENY',
+  'Content-Security-Policy': "default-src 'self'",
+};
+
+// Auth
+const auth = request.headers.get('Authorization');
+if (!auth?.startsWith('Bearer ')) return new Response('Unauthorized', { status: 401 });
+```
+
+## Rate Limiting
+
+See [Durable Objects](../durable-objects/README.md) for stateful rate limiting patterns.
+
+## Gradual Rollouts
+
+```typescript
+const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(userId));
+const bucket = new Uint8Array(hash)[0] % 100;
+if (bucket < rolloutPercent) return newFeature(request);
+```
+
+## See Also
+
+- [API](./api.md) - Runtime APIs
+- [Gotchas](./gotchas.md) - Common issues
+- [Configuration](./configuration.md) - Setup

--- a/.agent/services/hosting/cloudflare-platform/references/workflows/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workflows/README.md
@@ -1,0 +1,62 @@
+# Cloudflare Workflows
+
+Durable multi-step applications with automatic retries, state persistence, and long-running execution.
+
+## What It Does
+
+- Chain steps with automatic retry logic
+- Persist state between steps (minutes → weeks)
+- Handle failures without losing progress
+- Wait for external events/approvals
+- Sleep without consuming resources
+
+**Available:** Free & Paid Workers plans
+
+## Core Concepts
+
+**Workflow**: Class extending `WorkflowEntrypoint` with `run` method
+**Instance**: Single execution with unique ID & independent state
+**Steps**: Independently retriable units via `step.do()` - API calls, DB queries, AI invocations
+**State**: Persisted from step returns; step name = cache key
+
+## Quick Start
+
+```typescript
+import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent } from 'cloudflare:workers';
+
+type Env = { MY_WORKFLOW: Workflow; DB: D1Database };
+type Params = { userId: string };
+
+export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
+  async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
+    const user = await step.do('fetch user', async () => {
+      return await this.env.DB.prepare('SELECT * FROM users WHERE id = ?')
+        .bind(event.payload.userId).first();
+    });
+    
+    await step.sleep('wait 7 days', '7 days');
+    
+    await step.do('send reminder', async () => {
+      await sendEmail(user.email, 'Reminder!');
+    });
+  }
+}
+```
+
+## Key Features
+
+- **Durability**: Failed steps don't re-run successful ones
+- **Retries**: Configurable backoff (constant/linear/exponential)
+- **Events**: `waitForEvent()` for webhooks/approvals (timeout: 1h → 365d)
+- **Sleep**: `sleep()` / `sleepUntil()` for scheduling (max 365d)
+- **Parallel**: `Promise.all()` for concurrent steps
+- **Idempotency**: Check-then-execute patterns
+
+## Further Reading
+
+- [configuration.md](./configuration.md) - wrangler.toml, step config
+- [api.md](./api.md) - Step APIs, instance management
+- [patterns.md](./patterns.md) - Common workflows, orchestration
+- [gotchas.md](./gotchas.md) - Timeouts, limits, debugging
+
+[Official Docs](https://developers.cloudflare.com/workflows/)

--- a/.agent/services/hosting/cloudflare-platform/references/workflows/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workflows/api.md
@@ -1,0 +1,125 @@
+# Workflow APIs
+
+## Step APIs
+
+```typescript
+// step.do()
+const result = await step.do('step name', async () => { /* logic */ });
+const result = await step.do('step name', { retries, timeout }, async () => {});
+
+// step.sleep()
+await step.sleep('description', '1 hour');
+await step.sleep('description', 5000); // ms
+
+// step.sleepUntil()
+await step.sleepUntil('description', Date.parse('2024-12-31'));
+
+// step.waitForEvent()
+const data = await step.waitForEvent<PayloadType>('wait', {type: 'webhook-type', timeout: '24h'}); // Default 24h, max 365d
+try { const event = await step.waitForEvent('wait', { type: 'approval', timeout: '1h' }); } catch (e) { /* Timeout */ }
+```
+
+## Instance Management
+
+```typescript
+// Create single
+const instance = await env.MY_WORKFLOW.create({id: crypto.randomUUID(), params: { userId: 'user123' }}); // id optional, auto-generated if omitted
+
+// Batch (max 100, idempotent: skips existing IDs)
+const instances = await env.MY_WORKFLOW.createBatch([{id: 'user1', params: {name: 'John'}}, {id: 'user2', params: {name: 'Jane'}}]);
+
+// Get & Status
+const instance = await env.MY_WORKFLOW.get('instance-id');
+const status = await instance.status(); // {status: 'queued' | 'running' | 'paused' | 'errored' | 'terminated' | 'complete' | 'waiting' | 'waitingForPause' | 'unknown', error?, output?}
+
+// Control
+await instance.pause(); await instance.resume(); await instance.terminate(); await instance.restart();
+
+// Send Events
+await instance.sendEvent({type: 'approval', payload: { approved: true }}); // Must match waitForEvent type
+```
+
+## Triggering Workflows
+
+```typescript
+// From Worker
+export default { async fetch(req, env) { const instance = await env.MY_WORKFLOW.create({id: crypto.randomUUID(), params: { userId: 'user123' }}); return Response.json({ id: instance.id }); }};
+
+// From Queue
+export default { async queue(batch, env) { for (const msg of batch.messages) { await env.MY_WORKFLOW.create({id: `job-${msg.id}`, params: msg.body}); } }};
+
+// From Cron
+export default { async scheduled(event, env) { await env.CLEANUP_WORKFLOW.create({id: `cleanup-${Date.now()}`, params: { timestamp: event.scheduledTime }}); }};
+
+// From Another Workflow (non-blocking)
+export class ParentWorkflow extends WorkflowEntrypoint<Env, Params> {
+  async run(event, step) {
+    const child = await step.do('start child', async () => await this.env.CHILD_WORKFLOW.create({id: `child-${event.instanceId}`, params: {}}));
+  }
+}
+```
+
+## Error Handling
+
+```typescript
+import { NonRetryableError } from 'cloudflare:workflows';
+
+// NonRetryableError
+await step.do('validate', async () => {
+  if (!event.payload.paymentMethod) throw new NonRetryableError('Payment method required');
+  const res = await fetch('https://api.example.com/charge', { method: 'POST' });
+  if (res.status === 401) throw new NonRetryableError('Invalid credentials'); // Don't retry
+  if (!res.ok) throw new Error('Retryable failure'); // Will retry
+  return res.json();
+});
+
+// Catching Errors
+try { await step.do('risky op', async () => { throw new NonRetryableError('Failed'); }); } catch (e) { await step.do('cleanup', async () => {}); }
+
+// Idempotency
+await step.do('charge', async () => {
+  const sub = await fetch(`https://api/subscriptions/${id}`).then(r => r.json());
+  if (sub.charged) return sub; // Already done
+  return await fetch(`https://api/subscriptions/${id}`, {method: 'POST', body: JSON.stringify({ amount: 10.0 })}).then(r => r.json());
+});
+```
+
+## Wrangler CLI
+
+```bash
+npm create cloudflare@latest my-workflow -- --template "cloudflare/workflows-starter"
+npx wrangler deploy
+npx wrangler workflows list
+npx wrangler workflows trigger my-workflow '{"userId":"user123"}'
+npx wrangler workflows instances list my-workflow
+npx wrangler workflows instances describe my-workflow instance-id
+npx wrangler workflows instances pause/resume/terminate my-workflow instance-id
+```
+
+## REST API
+
+```bash
+# Create
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/workflows/{workflow_name}/instances" -H "Authorization: Bearer {token}" -d '{"id":"custom-id","params":{"userId":"user123"}}'
+
+# Status
+curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/workflows/{workflow_name}/instances/{instance_id}/status" -H "Authorization: Bearer {token}"
+
+# Send Event
+curl -X POST "https://api.cloudflare.com/client/v4/accounts/{account_id}/workflows/{workflow_name}/instances/{instance_id}/events" -H "Authorization: Bearer {token}" -d '{"type":"approval","payload":{"approved":true}}'
+```
+
+## Bindings
+
+```typescript
+type Env = {MY_WORKFLOW: Workflow; KV: KVNamespace; DB: D1Database; BUCKET: R2Bucket; AI: Ai; VECTORIZE: VectorizeIndex;};
+
+await step.do('use bindings', async () => {
+  const kv = await this.env.KV.get('key');
+  const db = await this.env.DB.prepare('SELECT * FROM users').first();
+  const file = await this.env.BUCKET.get('file.txt');
+  const ai = await this.env.AI.run('@cf/meta/llama-2-7b-chat-int8', { prompt: 'Hi' });
+});
+```
+
+See: [configuration.md](./configuration.md), [patterns.md](./patterns.md)

--- a/.agent/services/hosting/cloudflare-platform/references/workflows/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workflows/configuration.md
@@ -1,0 +1,177 @@
+# Workflow Configuration
+
+## Wrangler Setup
+
+**wrangler.toml:**
+```toml
+name = "my-worker"
+main = "src/index.ts"
+compatibility_date = "2024-10-22"
+
+[[workflows]]
+name = "my-workflow"           # Workflow name
+binding = "MY_WORKFLOW"        # Env binding
+class_name = "MyWorkflow"      # TS class name
+# script_name = "other-worker" # For cross-script calls
+
+[limits]
+cpu_ms = 300_000  # 5 min max (default 30s)
+```
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "name": "my-worker",
+  "workflows": [
+    { "name": "my-workflow", "binding": "MY_WORKFLOW", "class_name": "MyWorkflow" }
+  ],
+  "limits": { "cpu_ms": 300000 }
+}
+```
+
+## Step Configuration
+
+### Basic Step
+```typescript
+const data = await step.do('step name', async () => {
+  return { result: 'value' };
+});
+```
+
+### Retry Config
+```typescript
+await step.do('api call', {
+  retries: {
+    limit: 10,              // Default: 5, or Infinity
+    delay: '10 seconds',    // Default: 10000ms
+    backoff: 'exponential'  // constant | linear | exponential
+  },
+  timeout: '30 minutes'     // Per-attempt timeout (default: 10min)
+}, async () => {
+  const res = await fetch('https://api.example.com/data');
+  if (!res.ok) throw new Error('Failed');
+  return res.json();
+});
+```
+
+### Parallel Steps
+```typescript
+const [user, settings] = await Promise.all([
+  step.do('fetch user', async () => this.env.KV.get(`user:${id}`)),
+  step.do('fetch settings', async () => this.env.KV.get(`settings:${id}`))
+]);
+```
+
+### Conditional Steps
+```typescript
+const config = await step.do('fetch config', async () => 
+  this.env.KV.get('flags', { type: 'json' })
+);
+
+// ✅ Deterministic (based on step output)
+if (config.enableEmail) {
+  await step.do('send email', async () => sendEmail());
+}
+
+// ❌ Non-deterministic (Date.now outside step)
+if (Date.now() > deadline) { /* BAD */ }
+```
+
+### Dynamic Steps (Loops)
+```typescript
+const files = await step.do('list files', async () => 
+  this.env.BUCKET.list()
+);
+
+for (const file of files.objects) {
+  await step.do(`process ${file.key}`, async () => {
+    const obj = await this.env.BUCKET.get(file.key);
+    return processData(await obj.arrayBuffer());
+  });
+}
+```
+
+## Sleep & Scheduling
+
+```typescript
+// Relative
+await step.sleep('wait 1 hour', '1 hour');
+await step.sleep('wait 30 days', '30 days');
+await step.sleep('wait 5s', 5000); // ms
+
+// Absolute
+await step.sleepUntil('launch date', Date.parse('24 Oct 2024 13:00:00 UTC'));
+await step.sleepUntil('deadline', new Date('2024-12-31T23:59:59Z'));
+```
+
+Units: second, minute, hour, day, week, month, year. Max: 365 days.
+Sleeping instances don't count toward concurrency.
+
+## Parameters
+
+**Pass from Worker:**
+```typescript
+const instance = await env.MY_WORKFLOW.create({
+  id: crypto.randomUUID(),
+  params: { userId: 'user123', email: 'user@example.com' }
+});
+```
+
+**Access in Workflow:**
+```typescript
+async run(event: WorkflowEvent<Params>, step: WorkflowStep) {
+  const userId = event.payload.userId;
+  const instanceId = event.instanceId;
+  const createdAt = event.timestamp;
+}
+```
+
+**CLI Trigger:**
+```bash
+npx wrangler workflows trigger my-workflow '{"userId":"user123"}'
+```
+
+## Multiple Workflows
+
+```typescript
+export class UserOnboarding extends WorkflowEntrypoint<Env, UserParams> {
+  async run(event, step) { /* ... */ }
+}
+
+export class DataProcessing extends WorkflowEntrypoint<Env, DataParams> {
+  async run(event, step) { /* ... */ }
+}
+```
+
+```toml
+[[workflows]]
+name = "user-onboarding"
+binding = "USER_ONBOARDING"
+class_name = "UserOnboarding"
+
+[[workflows]]
+name = "data-processing"
+binding = "DATA_PROCESSING"
+class_name = "DataProcessing"
+```
+
+## Cross-Script Bindings
+
+**billing-worker** defines workflow:
+```toml
+[[workflows]]
+name = "billing-workflow"
+binding = "BILLING"
+class_name = "BillingWorkflow"
+```
+
+**web-api-worker** calls it:
+```toml
+[[workflows]]
+name = "billing-workflow"
+binding = "BILLING"
+class_name = "BillingWorkflow"
+script_name = "billing-worker"
+```
+
+See: [api.md](./api.md), [patterns.md](./patterns.md)

--- a/.agent/services/hosting/cloudflare-platform/references/workflows/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workflows/gotchas.md
@@ -1,0 +1,136 @@
+# Gotchas & Debugging
+
+## Timeout Issues
+
+### Step Timeout
+- **Default**: 10 min/attempt
+- **CPU Limit**: 30s default, max 5min (wrangler.toml `limits.cpu_ms = 300_000`)
+
+```typescript
+await step.do('long operation', {timeout: '30 minutes'}, async () => { /* ... */ });
+```
+
+### waitForEvent Timeout
+- **Default**: 24h, **Max**: 365d, **Throws on timeout**
+
+```typescript
+try {
+  const event = await step.waitForEvent('wait', { type: 'approval', timeout: '1h' });
+} catch (e) { /* Timeout - proceed with default */ }
+```
+
+## Limits
+
+| Limit | Free | Paid |
+|-------|------|------|
+| CPU per step | 10ms | 30s (default), 5min (max) |
+| Step state | 1 MiB | 1 MiB |
+| Instance state | 100 MB | 1 GB |
+| Steps per workflow | 1,024 | 1,024 |
+| Executions/day | 100k | Unlimited |
+| Concurrent instances | 25 | 10k |
+| State retention | 3d | 30d |
+
+Note: `step.sleep()` doesn't count toward step limit
+
+## Debugging
+
+### Logs
+```typescript
+await step.do('process', async () => {
+  console.log('Logged once per successful step'); // ✅
+  return result;
+});
+console.log('Outside step'); // ⚠️ May duplicate on restart
+```
+
+### Instance Status
+```bash
+npx wrangler workflows instances describe my-workflow instance-id
+```
+
+```typescript
+const instance = await env.MY_WORKFLOW.get('instance-id');
+const status = await instance.status();
+// status: queued | running | paused | errored | terminated | complete | waiting | waitingForPause | unknown
+```
+
+## Common Pitfalls
+
+### Non-Deterministic Step Names
+```typescript
+// ❌ BAD: await step.do(`step-${Date.now()}`, ...)
+// ✅ GOOD: await step.do(`step-${event.instanceId}`, ...)
+```
+
+### State in Variables
+```typescript
+// ❌ BAD: let total = 0; await step.do('step 1', async () => { total += 10; }); // Lost on hibernation
+// ✅ GOOD: const total = await step.do('step 1', async () => 10); // Persisted
+```
+
+### Non-Deterministic Conditionals
+```typescript
+// ❌ BAD: if (Date.now() > deadline) { await step.do(...) }
+// ✅ GOOD: const isLate = await step.do('check', async () => Date.now() > deadline); if (isLate) { await step.do(...) }
+```
+
+### Large Step Returns
+```typescript
+// ❌ BAD: return await fetchHugeDataset(); // 5 MiB
+// ✅ GOOD: Store in R2, return { key }
+```
+
+### Idempotency Ignored
+```typescript
+// ❌ BAD: await step.do('charge', async () => await chargeCustomer(...)); // Charges on retry
+// ✅ GOOD: Check if already charged first
+```
+
+### Instance ID Collision
+```typescript
+// ❌ BAD: await env.MY_WORKFLOW.create({ id: userId, params: {} }); // Reuses IDs
+// ✅ GOOD: await env.MY_WORKFLOW.create({ id: `${userId}-${Date.now()}`, params: {} });
+```
+
+### Missing await
+```typescript
+// ❌ BAD: step.do('task', ...); // Fire-and-forget
+// ✅ GOOD: await step.do('task', ...);
+```
+
+## Pricing
+
+| Metric | Free | Paid |
+|--------|------|------|
+| Requests | 100k/day | 10M/mo + $0.30/M |
+| CPU time | 10ms/invoke | 30M CPU-ms/mo + $0.02/M CPU-ms |
+| Storage | 1 GB | 1 GB/mo + $0.20/GB-mo |
+
+Storage: Includes all instances (running/errored/sleeping/completed). Retention: 3d (Free), 30d (Paid)
+
+## TypeScript Types
+
+```typescript
+import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent, NonRetryableError } from 'cloudflare:workers';
+
+interface Env { MY_WORKFLOW: Workflow<MyParams>; KV: KVNamespace; DB: D1Database; }
+
+export class MyWorkflow extends WorkflowEntrypoint<Env, MyParams> {
+  async run(event: WorkflowEvent<MyParams>, step: WorkflowStep) {
+    const user = await step.do('fetch', async () => await this.env.KV.get<User>(`user:${event.payload.userId}`, { type: 'json' }));
+  }
+}
+```
+
+## References
+
+- [Official Docs](https://developers.cloudflare.com/workflows/)
+- [Get Started Guide](https://developers.cloudflare.com/workflows/get-started/guide/)
+- [Workers API](https://developers.cloudflare.com/workflows/build/workers-api/)
+- [REST API](https://developers.cloudflare.com/api/resources/workflows/)
+- [Examples](https://developers.cloudflare.com/workflows/examples/)
+- [Limits](https://developers.cloudflare.com/workflows/reference/limits/)
+- [Pricing](https://developers.cloudflare.com/workflows/reference/pricing/)
+
+See: [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md)

--- a/.agent/services/hosting/cloudflare-platform/references/workflows/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/workflows/patterns.md
@@ -1,0 +1,132 @@
+# Workflow Patterns
+
+## Image Processing Pipeline
+
+```typescript
+export class ImageProcessingWorkflow extends WorkflowEntrypoint<Env, Params> {
+  async run(event, step) {
+    const imageData = await step.do('fetch', async () => (await this.env.BUCKET.get(event.payload.imageKey)).arrayBuffer());
+    const description = await step.do('generate description', async () => 
+      await this.env.AI.run('@cf/llava-hf/llava-1.5-7b-hf', {image: Array.from(new Uint8Array(imageData)), prompt: 'Describe this image', max_tokens: 50})
+    );
+    await step.waitForEvent('await approval', { type: 'approved', timeout: '24h' });
+    await step.do('publish', async () => await this.env.BUCKET.put(`public/${event.payload.imageKey}`, imageData));
+  }
+}
+```
+
+## User Lifecycle
+
+```typescript
+export class UserLifecycleWorkflow extends WorkflowEntrypoint<Env, Params> {
+  async run(event, step) {
+    await step.do('welcome email', async () => await sendEmail(event.payload.email, 'Welcome!'));
+    await step.sleep('trial period', '7 days');
+    const hasConverted = await step.do('check conversion', async () => {
+      const user = await this.env.DB.prepare('SELECT subscription_status FROM users WHERE id = ?').bind(event.payload.userId).first();
+      return user.subscription_status === 'active';
+    });
+    if (!hasConverted) await step.do('trial expiration email', async () => await sendEmail(event.payload.email, 'Trial ending'));
+  }
+}
+```
+
+## Data Pipeline
+
+```typescript
+export class DataPipelineWorkflow extends WorkflowEntrypoint<Env, Params> {
+  async run(event, step) {
+    const rawData = await step.do('extract', {retries: { limit: 10, delay: '30s', backoff: 'exponential' }, timeout: '5 minutes'}, async () => {
+      const res = await fetch(event.payload.sourceUrl);
+      if (!res.ok) throw new Error('Fetch failed');
+      return res.json();
+    });
+    const transformed = await step.do('transform', async () => rawData.map(item => ({ id: item.id, normalized: normalizeData(item) })));
+    const dataRef = await step.do('store', async () => {
+      const key = `processed/${Date.now()}.json`;
+      await this.env.BUCKET.put(key, JSON.stringify(transformed));
+      return { key };
+    });
+    await step.do('load', {retries: { limit: 5, delay: '1m', backoff: 'linear' }}, async () => {
+      const data = await (await this.env.BUCKET.get(dataRef.key)).json();
+      for (let i = 0; i < data.length; i += 100) {
+        await this.env.DB.batch(data.slice(i, i + 100).map(item => this.env.DB.prepare('INSERT INTO records VALUES (?, ?)').bind(item.id, item.normalized)));
+      }
+    });
+  }
+}
+```
+
+## Human-in-the-Loop Approval
+
+```typescript
+export class ApprovalWorkflow extends WorkflowEntrypoint<Env, Params> {
+  async run(event, step) {
+    await step.do('create approval', async () => await this.env.DB.prepare('INSERT INTO approvals (id, user_id, status) VALUES (?, ?, ?)').bind(event.instanceId, event.payload.userId, 'pending').run());
+    try {
+      const approval = await step.waitForEvent<{ approved: boolean }>('wait for approval', { type: 'approval-response', timeout: '48h' });
+      if (approval.approved) { await step.do('process approval', async () => {}); } 
+      else { await step.do('handle rejection', async () => {}); }
+    } catch (e) {
+      await step.do('auto reject', async () => await this.env.DB.prepare('UPDATE approvals SET status = ? WHERE id = ?').bind('auto-rejected', event.instanceId).run());
+    }
+  }
+}
+```
+
+## Best Practices
+
+### ✅ DO
+
+1. **Granular steps**: One API call per step (unless proving idempotency)
+2. **Idempotency**: Check-then-execute; use idempotency keys
+3. **Deterministic names**: Use static or step-output-based names
+4. **Return state**: Persist via step returns, not variables
+5. **Always await**: `await step.do()`, avoid dangling promises
+6. **Deterministic conditionals**: Base on `event.payload` or step outputs
+7. **Store large data externally**: R2/KV for >1 MiB, return refs
+8. **Batch creation**: `createBatch()` for multiple instances
+
+### ❌ DON'T
+
+1. **One giant step**: Breaks durability & retry control
+2. **State outside steps**: Lost on hibernation
+3. **Mutate events**: Events immutable, return new state
+4. **Non-deterministic logic outside steps**: `Math.random()`, `Date.now()` must be in steps
+5. **Side effects outside steps**: May duplicate on restart
+6. **Non-deterministic step names**: Prevents caching
+7. **Ignore timeouts**: `waitForEvent` throws, use try-catch
+8. **Reuse instance IDs**: Must be unique within retention
+
+## Orchestration Patterns
+
+### Fan-Out (Parallel Processing)
+```typescript
+const files = await step.do('list', async () => this.env.BUCKET.list());
+await Promise.all(files.objects.map((file, i) => step.do(`process ${i}`, async () => processFile(await (await this.env.BUCKET.get(file.key)).arrayBuffer()))));
+```
+
+### Parent-Child Workflows
+```typescript
+const child = await step.do('start child', async () => await this.env.CHILD_WORKFLOW.create({id: `child-${event.instanceId}`, params: { data: result.data }}));
+await step.do('other work', async () => console.log(`Child started: ${child.id}`));
+```
+
+### Promise.race
+```typescript
+const result = await step.do('race', async () => await Promise.race([step.do('option A', async () => { await sleep(1000); return 'A'; }), step.do('option B', async () => 'B')]));
+```
+
+### Scheduled Workflow Chain
+```typescript
+export default { async scheduled(event, env) { await env.DAILY_WORKFLOW.create({id: `daily-${event.scheduledTime}`, params: { timestamp: event.scheduledTime }}); }};
+export class DailyWorkflow extends WorkflowEntrypoint<Env, Params> {
+  async run(event, step) {
+    await step.do('daily task', async () => {});
+    await step.sleep('wait 7 days', '7 days');
+    await step.do('weekly followup', async () => {});
+  }
+}
+```
+
+See: [configuration.md](./configuration.md), [api.md](./api.md), [gotchas.md](./gotchas.md)

--- a/.agent/services/hosting/cloudflare-platform/references/wrangler/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/wrangler/README.md
@@ -1,0 +1,90 @@
+# Cloudflare Wrangler
+
+Official CLI for Cloudflare Workers - develop, manage, and deploy Workers from the command line.
+
+## What is Wrangler?
+
+Wrangler is the Cloudflare Developer Platform CLI that allows you to:
+- Create, develop, and deploy Workers
+- Manage bindings (KV, D1, R2, Durable Objects, etc.)
+- Configure routing and environments
+- Run local development servers
+- Execute migrations and manage resources
+- Perform integration testing
+
+## Installation
+
+```bash
+npm install wrangler --save-dev
+# or globally
+npm install -g wrangler
+```
+
+Run commands: `npx wrangler <command>` (or `pnpm`/`yarn wrangler`)
+
+## Essential Commands
+
+### Project & Development
+```bash
+wrangler init [name]              # Create new project
+wrangler dev                      # Local dev server
+wrangler dev --remote             # Dev with remote resources
+wrangler deploy                   # Deploy to production
+wrangler deploy --env staging     # Deploy to environment
+wrangler versions list            # List versions
+wrangler rollback [id]            # Rollback deployment
+wrangler login                    # OAuth login
+wrangler whoami                   # Check auth status
+```
+
+## Resource Management
+
+### KV
+```bash
+wrangler kv namespace create NAME
+wrangler kv key put "key" "value" --namespace-id=<id>
+wrangler kv key get "key" --namespace-id=<id>
+```
+
+### D1
+```bash
+wrangler d1 create NAME
+wrangler d1 execute NAME --command "SQL"
+wrangler d1 migrations create NAME "description"
+wrangler d1 migrations apply NAME
+```
+
+### R2
+```bash
+wrangler r2 bucket create NAME
+wrangler r2 object put BUCKET/key --file path
+wrangler r2 object get BUCKET/key
+```
+
+### Other Resources
+```bash
+wrangler queues create NAME
+wrangler vectorize create NAME --dimensions N --metric cosine
+wrangler hyperdrive create NAME --connection-string "..."
+```
+
+### Secrets
+```bash
+wrangler secret put NAME          # Set secret
+wrangler secret list              # List secrets
+wrangler secret delete NAME       # Delete secret
+```
+
+### Monitoring
+```bash
+wrangler tail                     # Real-time logs
+wrangler tail --env production    # Tail specific env
+wrangler tail --status error      # Filter by status
+```
+
+## In This Reference
+
+- [configuration.md](./configuration.md) - wrangler.jsonc setup, environments, bindings
+- [api.md](./api.md) - Programmatic API (`unstable_startWorker`, `getPlatformProxy`)
+- [patterns.md](./patterns.md) - Common workflows and development patterns
+- [gotchas.md](./gotchas.md) - Common pitfalls, limits, and troubleshooting

--- a/.agent/services/hosting/cloudflare-platform/references/wrangler/api.md
+++ b/.agent/services/hosting/cloudflare-platform/references/wrangler/api.md
@@ -1,0 +1,140 @@
+# Wrangler Programmatic API
+
+Node.js APIs for testing and development.
+
+## unstable_startWorker (Testing)
+
+Starts Worker with real local bindings for integration tests.
+
+```typescript
+import { unstable_startWorker } from "wrangler";
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+
+describe("worker", () => {
+  let worker;
+  
+  before(async () => {
+    worker = await unstable_startWorker({ config: "wrangler.jsonc" });
+  });
+  
+  after(async () => {
+    await worker.dispose();
+  });
+  
+  it("responds with 200", async () => {
+    const response = await worker.fetch("http://example.com");
+    assert.strictEqual(response.status, 200);
+  });
+});
+```
+
+Options: `config`, `environment`, `persist`, `bundle`
+
+## getPlatformProxy
+
+Emulate bindings in Node.js without starting Worker.
+
+```typescript
+import { getPlatformProxy } from "wrangler";
+
+const { env, dispose, caches } = await getPlatformProxy<Env>({
+  configPath: "wrangler.jsonc",
+  environment: "production",
+  persist: { path: ".wrangler/state" }
+});
+
+// Use bindings
+const value = await env.MY_KV.get("key");
+await env.DB.prepare("SELECT * FROM users").all();
+await env.ASSETS.put("file.txt", "content");
+
+// Platform APIs
+await caches.default.put("https://example.com", new Response("cached"));
+
+await dispose();
+```
+
+### Use Cases
+
+**Unit Tests**
+```typescript
+const { env, dispose } = await getPlatformProxy();
+
+describe("database", () => {
+  after(async () => await dispose());
+  
+  it("inserts user", async () => {
+    const result = await env.DB.prepare(
+      "INSERT INTO users (name) VALUES (?)"
+    ).bind("Alice").run();
+    assert.strictEqual(result.meta.changes, 1);
+  });
+});
+```
+
+**Scripts**
+```typescript
+const { env, dispose } = await getPlatformProxy({
+  persist: { path: ".wrangler/state" }
+});
+
+await env.DB.batch([
+  env.DB.prepare("CREATE TABLE users (id INTEGER PRIMARY KEY)"),
+  env.DB.prepare("INSERT INTO users (id) VALUES (1)")
+]);
+
+await dispose();
+```
+
+## Type Generation
+
+```bash
+wrangler types
+```
+
+Creates `worker-configuration.d.ts`:
+
+```typescript
+interface Env {
+  MY_KV: KVNamespace;
+  DB: D1Database;
+  API_KEY: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const value = await env.MY_KV.get("key");  // Type-safe
+    return Response.json({ value });
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+## unstable_dev (Legacy)
+
+Use `unstable_startWorker` instead.
+
+```typescript
+import { unstable_dev } from "wrangler";
+
+const worker = await unstable_dev("src/index.ts", {
+  config: "wrangler.jsonc"
+});
+
+const response = await worker.fetch();
+await worker.stop();
+```
+
+## Best Practices
+
+- Use `unstable_startWorker` for integration tests (tests full Worker)
+- Use `getPlatformProxy` for unit tests (tests individual functions)
+- Enable `persist: true` for debugging (state survives runs)
+- Run `wrangler types` after config changes
+- Always `dispose()` to prevent resource leaks
+
+## See Also
+
+- [README.md](./README.md) - CLI commands
+- [configuration.md](./configuration.md) - Config
+- [patterns.md](./patterns.md) - Testing patterns

--- a/.agent/services/hosting/cloudflare-platform/references/wrangler/configuration.md
+++ b/.agent/services/hosting/cloudflare-platform/references/wrangler/configuration.md
@@ -1,0 +1,128 @@
+# Wrangler Configuration
+
+Configuration reference for wrangler.jsonc (recommended) and wrangler.toml.
+
+## Config Format
+
+**wrangler.jsonc recommended** (v3.91.0+) - provides schema validation.
+
+```jsonc
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "my-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-01-01",  // Use current date
+  "vars": { "API_KEY": "dev-key" },
+  "kv_namespaces": [{ "binding": "MY_KV", "id": "abc123" }]
+}
+```
+
+## Field Categories
+
+### Top-Level Only
+- `keep_vars`, `migrations`, `send_metrics`
+
+### Inheritable (can override per env)
+- `name`, `main`, `compatibility_date`, `account_id`
+- `workers_dev`, `routes`, `triggers`, `minify`, `observability`
+
+### Non-Inheritable (per-env required)
+- `vars`, `kv_namespaces`, `d1_databases`, `r2_buckets`
+- `durable_objects`, `vectorize`, `hyperdrive`, `services`, `queues`
+
+## Environments
+
+```jsonc
+{
+  "name": "my-worker",
+  "vars": { "ENV": "dev" },
+  "env": {
+    "production": {
+      "name": "my-worker-prod",
+      "vars": { "ENV": "prod" },
+      "route": { "pattern": "example.com/*", "zone_name": "example.com" }
+    }
+  }
+}
+```
+
+Deploy: `wrangler deploy --env production`
+
+## Routing
+
+```jsonc
+// Custom domain (recommended)
+{ "routes": [{ "pattern": "api.example.com", "custom_domain": true }] }
+
+// Zone-based
+{ "routes": [{ "pattern": "api.example.com/*", "zone_name": "example.com" }] }
+
+// workers.dev
+{ "workers_dev": true }
+```
+
+## Bindings
+
+```jsonc
+// Variables
+{ "vars": { "API_URL": "https://api.example.com" } }
+
+// KV
+{ "kv_namespaces": [{ "binding": "CACHE", "id": "abc123" }] }
+
+// D1
+{ "d1_databases": [{ "binding": "DB", "database_id": "abc-123" }] }
+
+// R2
+{ "r2_buckets": [{ "binding": "ASSETS", "bucket_name": "my-assets" }] }
+
+{ "durable_objects": { "bindings": [{ "name": "COUNTER", "class_name": "Counter" }] } }
+{ "migrations": [{ "tag": "v1", "new_sqlite_classes": ["Counter"] }] }
+
+// Service Bindings
+{ "services": [{ "binding": "AUTH", "service": "auth-worker" }] }
+
+// Queues
+{ "queues": {
+  "producers": [{ "binding": "TASKS", "queue": "task-queue" }],
+  "consumers": [{ "queue": "task-queue", "max_batch_size": 10 }]
+} }
+
+// Vectorize
+{ "vectorize": [{ "binding": "VECTORS", "index_name": "embeddings" }] }
+
+// Hyperdrive (requires nodejs_compat_v2)
+{ "hyperdrive": [{ "binding": "HYPERDRIVE", "id": "hyper-id" }] }
+
+// Workers AI
+{ "ai": { "binding": "AI" } }
+```
+
+## Advanced
+
+```jsonc
+// Cron Triggers
+{ "triggers": { "crons": ["0 0 * * *"] } }
+
+// Observability
+{ "observability": { "enabled": true, "head_sampling_rate": 0.1 } }
+
+// Runtime Limits
+{ "limits": { "cpu_ms": 100 } }
+
+// Auto-Provisioning (Beta) - IDs written back on deploy
+{ "kv_namespaces": [{ "binding": "MY_KV" }] }
+
+// Static Assets
+{ "assets": { "directory": "./public", "binding": "ASSETS" } }
+
+// mTLS Certificates
+{ "mtls_certificates": [{ "binding": "CERT", "certificate_id": "cert-uuid" }] }
+```
+
+## See Also
+
+- [README.md](./README.md) - Overview and commands
+- [api.md](./api.md) - Programmatic API
+- [patterns.md](./patterns.md) - Workflows
+- [gotchas.md](./gotchas.md) - Common issues

--- a/.agent/services/hosting/cloudflare-platform/references/wrangler/gotchas.md
+++ b/.agent/services/hosting/cloudflare-platform/references/wrangler/gotchas.md
@@ -1,0 +1,93 @@
+# Wrangler Common Issues
+
+Pitfalls, limits, and troubleshooting.
+
+## Common Gotchas
+
+### Binding IDs vs Names
+- Bindings use `binding` (code name) and `id`/`database_id`/`bucket_name` (resource ID)
+- Preview bindings need separate IDs: `preview_id`, `preview_database_id`
+
+### Environment Inheritance
+- Non-inheritable keys (bindings, vars) must be redefined per environment
+- Inheritable keys (routes, compatibility_date) can be overridden
+
+### Local vs Remote Dev
+- `wrangler dev` (default): Local simulation, fast, limited accuracy
+- `wrangler dev --remote`: Remote execution, slower, production-accurate
+
+### Compatibility Dates
+Always set `compatibility_date` to avoid unexpected runtime changes:
+```jsonc
+{ "compatibility_date": "2025-01-01" }
+```
+
+### Durable Objects Need script_name
+With `getPlatformProxy`, always specify `script_name`:
+```jsonc
+{
+  "durable_objects": {
+    "bindings": [
+      { "name": "MY_DO", "class_name": "MyDO", "script_name": "my-worker" }
+    ]
+  }
+}
+```
+
+### Secrets in Local Dev
+Secrets set with `wrangler secret put` only work in deployed Workers. For local dev, use `.dev.vars`.
+
+### Node.js Compatibility
+Some bindings (Hyperdrive with `pg`) require Node.js compatibility:
+```jsonc
+{ "compatibility_flags": ["nodejs_compat_v2"] }
+```
+
+## Troubleshooting
+
+### Authentication Issues
+```bash
+wrangler logout
+wrangler login
+wrangler whoami
+```
+
+### Configuration Errors
+```bash
+wrangler check  # Validate config
+```
+Use wrangler.jsonc with `$schema` for validation.
+
+### Binding Not Available
+- Check binding exists in config
+- For environments, ensure binding defined for that env
+- Local dev: some bindings need `--remote`
+
+### Deployment Failures
+```bash
+wrangler tail              # Check logs
+wrangler deploy --dry-run  # Validate
+wrangler whoami            # Check account limits
+```
+
+### Local Development Issues
+```bash
+rm -rf .wrangler/state     # Clear local state
+wrangler dev --remote      # Use remote bindings
+wrangler dev --persist-to ./local-state  # Custom persist location
+```
+
+## Resources
+
+- Docs: https://developers.cloudflare.com/workers/wrangler/
+- Config: https://developers.cloudflare.com/workers/wrangler/configuration/
+- Commands: https://developers.cloudflare.com/workers/wrangler/commands/
+- Examples: https://github.com/cloudflare/workers-sdk/tree/main/templates
+- Discord: https://discord.gg/cloudflaredev
+
+## See Also
+
+- [README.md](./README.md) - Commands
+- [configuration.md](./configuration.md) - Config
+- [api.md](./api.md) - Programmatic API
+- [patterns.md](./patterns.md) - Workflows

--- a/.agent/services/hosting/cloudflare-platform/references/wrangler/patterns.md
+++ b/.agent/services/hosting/cloudflare-platform/references/wrangler/patterns.md
@@ -1,0 +1,150 @@
+# Wrangler Development Patterns
+
+Common workflows and best practices.
+
+## New Worker Project
+
+```bash
+wrangler init my-worker && cd my-worker
+wrangler dev              # Develop locally
+wrangler deploy           # Deploy
+```
+
+## Local Development
+
+```bash
+wrangler dev              # Local (fast, limited accuracy)
+wrangler dev --remote     # Remote (slower, production-accurate)
+wrangler dev --env staging
+wrangler dev --port 8787
+```
+
+## Secrets
+
+**Never commit secrets.** Use `wrangler secret put` for production, `.dev.vars` for local.
+
+```bash
+# Production
+echo "secret-value" | wrangler secret put SECRET_KEY
+wrangler secret list
+wrangler secret delete SECRET_KEY
+```
+
+`.dev.vars` (gitignored):
+```
+SECRET_KEY=local-dev-key
+```
+
+## Adding KV
+
+```bash
+wrangler kv namespace create MY_KV
+wrangler kv namespace create MY_KV --preview
+# Add to wrangler.jsonc: { "binding": "MY_KV", "id": "abc123" }
+wrangler deploy
+```
+
+## Adding D1
+
+```bash
+wrangler d1 create my-db
+wrangler d1 migrations create my-db "initial_schema"
+# Edit migration file, then:
+wrangler d1 migrations apply my-db --local
+wrangler deploy
+wrangler d1 migrations apply my-db --remote
+```
+
+## Multi-Environment
+
+```bash
+wrangler deploy --env staging
+wrangler deploy --env production
+```
+
+```jsonc
+{ "env": { "staging": { "vars": { "ENV": "staging" } } } }
+```
+
+## Testing
+
+```typescript
+import { unstable_startWorker } from "wrangler";
+
+const worker = await unstable_startWorker({ config: "wrangler.jsonc" });
+const response = await worker.fetch("/api/users");
+await worker.dispose();
+```
+
+## Monitoring
+
+```bash
+wrangler tail                 # Real-time logs
+wrangler tail --status error  # Filter errors
+wrangler tail --env production
+wrangler whoami               # Check auth
+```
+
+## Version Control
+
+```bash
+wrangler versions list
+wrangler deployments list
+wrangler rollback [id]
+```
+
+## TypeScript
+
+```bash
+wrangler types  # Generate types from config
+```
+
+```typescript
+interface Env {
+  MY_KV: KVNamespace;
+  DB: D1Database;
+  API_KEY: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const value = await env.MY_KV.get("key");
+    return Response.json({ value });
+  }
+} satisfies ExportedHandler<Env>;
+```
+
+## Durable Objects Migration
+
+```jsonc
+{ "migrations": [{ "tag": "v1", "new_sqlite_classes": ["Counter"] }] }
+```
+
+## Performance
+
+```jsonc
+{ "minify": true }
+```
+
+```typescript
+// KV caching
+const cached = await env.CACHE.get("key", { cacheTtl: 3600 });
+
+// Batch DB
+await env.DB.batch([
+  env.DB.prepare("SELECT * FROM users"),
+  env.DB.prepare("SELECT * FROM posts")
+]);
+
+// Edge caching
+return new Response(data, {
+  headers: { "Cache-Control": "public, max-age=3600" }
+});
+```
+
+## See Also
+
+- [README.md](./README.md) - Commands
+- [configuration.md](./configuration.md) - Config
+- [api.md](./api.md) - Programmatic API
+- [gotchas.md](./gotchas.md) - Issues

--- a/.agent/services/hosting/cloudflare-platform/references/zaraz/README.md
+++ b/.agent/services/hosting/cloudflare-platform/references/zaraz/README.md
@@ -1,0 +1,360 @@
+# Cloudflare Zaraz Skill
+
+Expert guidance for Cloudflare Zaraz - server-side tag manager for loading third-party tools at the edge.
+
+## What is Zaraz?
+
+Zaraz offloads third-party scripts (analytics, ads, chat, marketing) to Cloudflare's edge, improving site speed, privacy, and security. Zero client-side performance impact.
+
+## Core Concepts
+
+- **Server-side execution** - Scripts run on Cloudflare, not user's browser
+- **Single HTTP request** - All tools loaded via one endpoint
+- **Privacy-first** - Control data sent to third parties
+- **No client-side JS** - Minimal browser overhead
+
+## Zaraz Dashboard Setup
+
+1. Navigate to domain > Zaraz
+2. Click "Start setup"
+3. Add tools (Google Analytics, Facebook Pixel, etc.)
+4. Configure triggers and actions
+
+## Web API
+
+Zaraz provides `zaraz` object in browser:
+
+### Track Events
+
+```javascript
+// Basic event
+zaraz.track('button_click');
+
+// Event with properties
+zaraz.track('purchase', {
+  value: 99.99,
+  currency: 'USD',
+  item_id: '12345'
+});
+
+// E-commerce events
+zaraz.track('add_to_cart', {
+  product_name: 'Widget',
+  price: 29.99,
+  quantity: 1
+});
+```
+
+### Set User Properties
+
+```javascript
+zaraz.set('userId', 'user_12345');
+zaraz.set('plan', 'premium');
+zaraz.set({
+  email: '[email protected]',
+  country: 'US',
+  age: 30
+});
+```
+
+### E-commerce Tracking
+
+```javascript
+// Product view
+zaraz.ecommerce('Product Viewed', {
+  product_id: 'SKU123',
+  name: 'Blue Widget',
+  price: 49.99,
+  currency: 'USD'
+});
+
+// Add to cart
+zaraz.ecommerce('Product Added', {
+  product_id: 'SKU123',
+  quantity: 2,
+  price: 49.99
+});
+
+// Purchase
+zaraz.ecommerce('Order Completed', {
+  order_id: 'ORD-789',
+  total: 149.98,
+  revenue: 149.98,
+  shipping: 10.00,
+  tax: 12.50,
+  currency: 'USD',
+  products: [
+    { product_id: 'SKU123', quantity: 2, price: 49.99 }
+  ]
+});
+```
+
+## Consent Management
+
+```javascript
+// Check consent status
+if (zaraz.consent.getAll().analytics) {
+  zaraz.track('page_view');
+}
+
+// Request consent
+zaraz.consent.modal = true; // Show consent modal
+
+// Set consent programmatically
+zaraz.consent.setAll({
+  analytics: true,
+  marketing: false,
+  preferences: true
+});
+
+// Listen for consent changes
+zaraz.consent.addEventListener('consentChanged', () => {
+  console.log('Consent updated:', zaraz.consent.getAll());
+});
+```
+
+## Workers Integration
+
+Access Zaraz data in Workers:
+
+```typescript
+export default {
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    
+    // Inject Zaraz tracking
+    if (url.pathname === '/checkout') {
+      const response = await fetch(req);
+      const html = await response.text();
+      
+      const tracking = `
+        <script>
+          zaraz.track('checkout_started', {
+            cart_value: 99.99
+          });
+        </script>
+      `;
+      
+      const modified = html.replace('</body>', tracking + '</body>');
+      return new Response(modified, response);
+    }
+    
+    return fetch(req);
+  }
+};
+```
+
+## Triggers
+
+Configure when tools fire:
+
+### Page Rules
+
+- **Pageview** - On every page load
+- **DOM Ready** - When DOM is ready
+- **Click** - Element clicks (CSS selector)
+- **Form submission** - Form submits
+- **Scroll depth** - User scrolls percentage
+- **Timer** - After time elapsed
+- **Variable match** - Custom conditions
+
+### Example Trigger
+
+```
+Trigger: Button Click
+Match rule: CSS Selector = .buy-button
+Action: Track event "purchase_intent"
+```
+
+## Common Tools
+
+### Google Analytics 4
+
+```javascript
+// Track page view (automatic)
+zaraz.track('pageview');
+
+// Custom event
+zaraz.track('sign_up', {
+  method: 'email'
+});
+```
+
+### Facebook Pixel
+
+```javascript
+zaraz.track('PageView');
+zaraz.track('Purchase', {
+  value: 99.99,
+  currency: 'USD'
+});
+```
+
+### Google Ads Conversion
+
+```javascript
+zaraz.track('conversion', {
+  send_to: 'AW-XXXXXXXXX/YYYYYY',
+  value: 1.00,
+  currency: 'USD'
+});
+```
+
+## Custom Managed Components
+
+Build custom tools:
+
+```javascript
+// Example: Custom analytics tool
+export default class CustomAnalytics {
+  async handleEvent(event) {
+    const { type, payload } = event;
+    
+    await fetch('https://analytics.example.com/track', {
+      method: 'POST',
+      body: JSON.stringify({
+        event: type,
+        properties: payload,
+        timestamp: Date.now()
+      })
+    });
+  }
+}
+```
+
+## Data Layer
+
+Use `zaraz.dataLayer` for structured data:
+
+```javascript
+// Set data layer
+window.zaraz.dataLayer = {
+  user_id: '12345',
+  page_type: 'product',
+  category: 'electronics'
+};
+
+// Access in triggers
+// Variable: {{client.__zarazTrack.page_type}}
+```
+
+## Server-Side Configuration
+
+### zaraz.toml
+
+```toml
+[settings]
+auto_inject = true
+debug_mode = false
+
+[[tools]]
+type = "google-analytics"
+id = "G-XXXXXXXXXX"
+
+[[tools.triggers]]
+match_rule = "Pageview"
+```
+
+## Privacy Features
+
+1. **IP anonymization** - Automatic
+2. **Cookie control** - Consent-based
+3. **Data minimization** - Send only necessary data
+4. **Regional compliance** - GDPR, CCPA support
+
+## Performance
+
+```javascript
+// Zaraz automatically:
+// - Batches requests
+// - Defers non-critical scripts
+// - Proxies third-party requests
+// - Caches tool configurations
+
+// Result: ~0ms client-side overhead
+```
+
+## Debugging
+
+```javascript
+// Enable debug mode in dashboard, then:
+zaraz.debug = true;
+
+// View events in console
+zaraz.track('test_event', { debug: true });
+
+// Check loaded tools
+console.log(zaraz.tools);
+```
+
+## Best Practices
+
+1. **Use triggers** instead of inline `zaraz.track()` when possible
+2. **Batch events** for related actions
+3. **Test with debug mode** before production
+4. **Implement consent** for GDPR compliance
+5. **Monitor performance** in dashboard analytics
+6. **Use data layer** for structured data
+
+## Common Patterns
+
+### SPA Tracking
+
+```javascript
+// On route change
+router.afterEach((to, from) => {
+  zaraz.track('pageview', {
+    page_path: to.path,
+    page_title: to.meta.title
+  });
+});
+```
+
+### User Identification
+
+```javascript
+// On login
+zaraz.set('user_id', user.id);
+zaraz.set('user_email', user.email);
+zaraz.track('login', { method: 'password' });
+```
+
+### A/B Testing
+
+```javascript
+const variant = Math.random() < 0.5 ? 'A' : 'B';
+zaraz.set('ab_test_variant', variant);
+zaraz.track('ab_test_view', { variant });
+```
+
+## Limits
+
+- **Tools**: Unlimited
+- **Events**: Unlimited
+- **Data retention**: Per tool's policy
+- **Request size**: 100KB per request
+
+## Troubleshooting
+
+### Events not firing
+
+- Check trigger conditions in dashboard
+- Verify tool is enabled
+- Enable debug mode
+- Check browser console for errors
+
+### Consent issues
+
+- Verify consent modal configuration
+- Check `zaraz.consent.getAll()` status
+- Ensure tools respect consent settings
+
+## Reference
+
+- [Zaraz Docs](https://developers.cloudflare.com/zaraz/)
+- [Web API](https://developers.cloudflare.com/zaraz/web-api/)
+- [Managed Components](https://developers.cloudflare.com/zaraz/advanced/load-custom-managed-component/)
+
+---
+
+This skill focuses exclusively on Zaraz. For Workers development, see `cloudflare-workers` skill.


### PR DESCRIPTION
## Summary

- Import comprehensive Cloudflare platform skill from `dmmulroy/cloudflare-skill`
- Add skill update checking to `setup.sh`

## Changes

### Cloudflare Platform Skill
- 60 product reference directories covering Workers, Pages, D1, R2, KV, Durable Objects, AI, networking, security, and more
- Each product has structured docs: README, api.md, configuration.md, patterns.md, gotchas.md
- Registered in `skill-sources.json` for update tracking

### Setup.sh Enhancement
- New `check_skill_updates()` function checks GitHub API for upstream changes
- Runs during `./setup.sh` to notify users of available updates
- Shows which skills have updates and how to update them

## Skill Commands

```bash
# Import a skill
/add-skill dmmulroy/cloudflare-skill

# List imported skills  
/add-skill list

# Check for updates
/add-skill check-updates

# Update a skill
/add-skill <repo> --force
```

## Testing

- Verified skill import with nested structure detection
- Verified skill registry updated correctly
- Verified setup.sh runs without errors