### PR TITLE
docs: add feature branch scenario guidance to pre-edit workflow

### DIFF
--- a/.agent/scripts/pre-edit-check.sh
+++ b/.agent/scripts/pre-edit-check.sh
@@ -10,12 +10,15 @@
 #   ~/.aidevops/agents/scripts/pre-edit-check.sh --loop-mode --task "description"
 #
 # Exit codes:
-#   0 - OK to proceed (on feature branch, or docs-only on main in loop mode)
-#   1 - STOP (on protected branch, interactive mode)
+#   0 - OK to proceed (on feature branch in worktree, or docs-only on main)
+#   1 - STOP (on protected branch main/master, interactive mode)
 #   2 - Create worktree (loop mode detected code task on main)
+#   3 - WARNING (on feature branch in main repo - should use worktree instead)
 #
-# AI assistants should call this before any Edit/Write tool and STOP if it
-# returns a warning about being on main branch.
+# AI assistants should call this before any Edit/Write tool and:
+# - Exit 1: STOP and present branch creation options
+# - Exit 3: Present options to user (continue, create worktree, or switch main back)
+# - Exit 0: Proceed with edits
 # =============================================================================
 
 set -euo pipefail
@@ -159,20 +162,47 @@ else
         is_main_worktree=true
     fi
     
-    if [[ "$is_main_worktree" == "true" ]]; then
-        echo -e "${YELLOW}WARNING${NC} - Main repo is on feature branch: ${BOLD}$current_branch${NC}"
-        echo -e "${YELLOW}The main repo directory should stay on 'main' for parallel safety.${NC}"
-        echo -e "${YELLOW}Consider using a worktree instead, or switch back to main when done.${NC}"
-        echo ""
-    else
-        echo -e "${GREEN}OK${NC} - On branch: ${BOLD}$current_branch${NC}"
-    fi
-    
     # Sync terminal tab title with repo/branch (silent, non-blocking)
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
     if [[ -x "$SCRIPT_DIR/terminal-title-helper.sh" ]]; then
         "$SCRIPT_DIR/terminal-title-helper.sh" sync 2>/dev/null || true
     fi
     
-    exit 0
+    if [[ "$is_main_worktree" == "true" ]]; then
+        # Loop mode: auto-decide for feature branch in main repo
+        if [[ "$LOOP_MODE" == "true" ]]; then
+            if is_docs_only "$TASK_DESC"; then
+                echo -e "${YELLOW}LOOP-AUTO${NC}: Docs-only task on feature branch, continuing"
+                echo "LOOP_DECISION=continue"
+                exit 0
+            else
+                # For code tasks, warn but continue (already on feature branch)
+                echo -e "${YELLOW}LOOP-AUTO${NC}: On feature branch in main repo (not ideal but continuing)"
+                echo "LOOP_DECISION=continue_warning"
+                exit 0
+            fi
+        fi
+        
+        # Interactive mode: show warning with options
+        echo ""
+        echo -e "${YELLOW}${BOLD}======================================================${NC}"
+        echo -e "${YELLOW}${BOLD}  WARNING - MAIN REPO ON FEATURE BRANCH${NC}"
+        echo -e "${YELLOW}${BOLD}======================================================${NC}"
+        echo ""
+        echo -e "Current branch: ${BOLD}$current_branch${NC}"
+        echo ""
+        echo -e "${YELLOW}The main repo directory should stay on 'main' for parallel safety.${NC}"
+        echo -e "${YELLOW}Working directly here can cause issues with parallel sessions.${NC}"
+        echo ""
+        echo "Options:"
+        echo "  1. Create worktree for this task (recommended)"
+        echo "  2. Continue on current branch (not recommended for code)"
+        echo "  3. Switch main repo back to main, then create worktree"
+        echo ""
+        echo "FEATURE_BRANCH_WARNING=$current_branch"
+        exit 3
+    else
+        echo -e "${GREEN}OK${NC} - On branch: ${BOLD}$current_branch${NC} (in worktree)"
+        exit 0
+    fi
 fi


### PR DESCRIPTION
## Summary

- Add exit code 3 for 'on feature branch in main repo' scenario
- Update AGENTS.md with table of exit codes and required actions
- Add guidance for when already on a feature branch (not just main → feature)

## Problem

The agent review identified that the workflow documentation didn't clearly address:
- What to do when already on a feature branch
- Whether personal development branches should be treated differently
- Whether small tasks warrant their own worktree/branch

## Solution

1. **New exit code 3**: Distinguishes "on feature branch in main repo" from "on main" (exit 1)
2. **AGENTS.md updates**:
   - Table of all exit codes with required actions
   - Feature branch scenarios section explaining when warnings appear
   - Small tasks exception for quick fixes on current branch
3. **Script updates**:
   - Loop mode handles feature branch scenarios
   - Interactive mode presents numbered options for feature branch warnings

## Testing

- ShellCheck passes on modified script
- Script correctly identifies worktree vs main repo
- Exit codes work as documented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded pre-edit git check guidelines with detailed exit code handling and comprehensive scenario-based workflows
  * Added interactive prompts and user options for branch validation
  * Introduced manual fallback procedures and self-verification guidance

* **Enhancement**
  * Improved branch validation workflow with clearer error handling and explicit user decision points

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->