### PR TITLE
feat: add Playwright MCP auto-setup to setup.sh

### DIFF
--- a/.agent/scripts/onboarding-helper.sh
+++ b/.agent/scripts/onboarding-helper.sh
@@ -317,7 +317,7 @@ check_context_tools() {
 check_browser() {
     echo -e "${BLUE}Browser Automation${NC}"
     
-    if is_installed "npx" && npx playwright --version &>/dev/null 2>&1; then
+    if is_installed "npx" && npx --no-install playwright --version &>/dev/null 2>&1; then
         print_service "Playwright" "ready" "installed"
     else
         print_service "Playwright" "optional" "not installed"

--- a/.agent/tools/browser/browser-automation.md
+++ b/.agent/tools/browser/browser-automation.md
@@ -98,7 +98,7 @@ Need browser automation?
 | **sweet-cookie** | Cookie extraction for API calls, session reuse | `npm i @steipete/sweet-cookie` |
 | **stagehand** | Natural language automation | `stagehand-helper.sh setup` |
 | **crawl4ai** | Web scraping, content extraction | `crawl4ai-helper.sh setup` |
-| **playwright** | Cross-browser testing | MCP integration |
+| **playwright** | Cross-browser testing | `setup.sh` or `npx playwright install` |
 
 **Full docs**: `tools/browser/agent-browser.md` (default), `tools/browser/dev-browser.md`, `tools/browser/sweet-cookie.md`, etc.
 

--- a/.agent/tools/browser/playwright.md
+++ b/.agent/tools/browser/playwright.md
@@ -12,15 +12,18 @@ tools:
   task: true
 ---
 
-# Playwright MCP Usage Examples
+# Playwright MCP
 
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
 
-- Playwright examples for cross-browser testing automation
-- Browsers: chromium, firefox, webkit
-- Test types:
+- **Purpose**: Cross-browser testing automation via MCP
+- **MCP command**: `npx playwright-mcp@latest`
+- **Install**: `npx playwright install` (chromium, firefox, webkit)
+- **Setup**: Auto-installed via `setup.sh` → `setup_browser_tools()`
+- **Browsers**: chromium, firefox, webkit
+- **Test types**:
   - Cross-browser: `runTest()`, `testBrowserFeatures()`
   - User flows: `automateFlow()`, `testFormValidation()`
   - Mobile: `testOnDevice()`, `testOrientations()`
@@ -28,10 +31,42 @@ tools:
   - Visual: `visualRegressionSuite()`, `screenshotComponents()`
   - Security: `testXSS()`, `testAuthentication()`
   - API: `testAPIIntegration()`, `testRealTimeFeatures()`
-- Device emulation: iPhone, Samsung, iPad
-- Network throttling: Fast 3G, Slow 3G, Offline
-- Integration: Works with Chrome DevTools MCP
+- **Device emulation**: iPhone, Samsung, iPad
+- **Network throttling**: Fast 3G, Slow 3G, Offline
+- **Integration**: Works with Chrome DevTools MCP, dev-browser, Stagehand
+
 <!-- AI-CONTEXT-END -->
+
+## Installation
+
+Playwright MCP is auto-installed via `setup.sh` when running the browser tools setup:
+
+```bash
+# Via setup.sh (interactive)
+./setup.sh --interactive
+# Select: "Setup browser automation tools"
+
+# Manual installation
+npx playwright install              # Install browsers (chromium, firefox, webkit)
+npx playwright-mcp@latest           # Run MCP server
+```
+
+**Check if installed:**
+
+```bash
+npx --no-install playwright --version
+```
+
+**MCP configuration** (for Claude Code, OpenCode, etc.):
+
+```json
+{
+  "playwright": {
+    "command": "npx",
+    "args": ["playwright-mcp@latest"]
+  }
+}
+```
 
 ## Cross-Browser Testing
 

--- a/README.md
+++ b/README.md
@@ -625,7 +625,7 @@ The setup script offers to install these tools automatically.
 | [Outscraper](https://outscraper.com/) | Google Maps & business data extraction | Yes |
 | [PageSpeed Insights](https://developers.google.com/speed/docs/insights/v5/get-started) | Performance auditing | Yes (Google API) |
 | [Perplexity](https://docs.perplexity.ai/) | AI-powered research | Yes |
-| [Playwright](https://playwright.dev/) | Cross-browser testing | No |
+| [Playwright](https://playwright.dev/) | Cross-browser testing (auto-installed by setup.sh) | No |
 | [Repomix](https://github.com/yamadashy/repomix) | Codebase packing for AI context | No |
 | [Serper](https://serper.dev/) | Google Search API (web, images, news) | Yes |
 | [shadcn/ui](https://ui.shadcn.com/) | UI component library browsing & installation | No |
@@ -649,7 +649,7 @@ The setup script offers to install these tools automatically.
 - [Stagehand (JavaScript)](https://github.com/browserbase/stagehand) - AI-powered browser automation with natural language
 - [Stagehand (Python)](https://github.com/anthropics/stagehand-python) - Python version with Pydantic validation
 - [Chrome DevTools](https://chromedevtools.github.io/devtools-protocol/) - Browser automation, performance analysis, debugging
-- [Playwright](https://playwright.dev/) - Cross-browser testing and automation
+- [Playwright](https://playwright.dev/) - Cross-browser testing and automation (auto-installed via `setup.sh`)
 - [Crawl4AI](https://github.com/unclecode/crawl4ai) - Async web crawler optimized for AI
 - [Cloudflare Browser Rendering](https://developers.cloudflare.com/browser-rendering/) - Server-side web scraping
 

--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,8 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 - [ ] t008 aidevops-opencode Plugin #plan → [todo/PLANS.md#aidevops-opencode-plugin] ~2d (ai:1d test:0.5d read:0.5d) logged:2025-12-21
 - [ ] t004 Add Ahrefs MCP server integration #seo ~2d (ai:1d test:0.5d read:0.5d) logged:2025-12-20
 - [ ] t005 Implement multi-tenant credential storage #security ~5d (ai:3d test:1.5d read:0.5d) logged:2025-12-20
-- [ ] t006 Add Playwright MCP auto-setup to setup.sh #browser ~1d (ai:0.5d test:0.5d) logged:2025-12-20
+- [x] t006 Add Playwright MCP auto-setup to setup.sh #browser ~1d actual:15m (ai:0.5d test:0.5d) logged:2025-12-20 started:2026-01-22T01:30Z completed:2026-01-22
+  - Notes: Added Playwright MCP installation to setup_browser_tools() in setup.sh. Checks for existing installation, prompts user, installs browsers (chromium, firefox, webkit) via `npx playwright install`.
 - [ ] t007 Create MCP server for QuickFile accounting API #accounting ~3d (ai:2d test:1d) logged:2025-12-20
 - [ ] t012 OCR Invoice/Receipt Extraction Pipeline #plan → [todo/PLANS.md#ocr-invoicereceipt-extraction-pipeline] ~3d (ai:1.5d test:1d read:0.5d) logged:2025-12-21
 - [ ] t013 Image SEO Enhancement with AI Vision #plan → [todo/PLANS.md#image-seo-enhancement-with-ai-vision] ~6h (ai:3h test:2h read:1h) logged:2025-12-21
@@ -151,7 +152,7 @@ t009,Claude Code Destructive Command Hooks,,plan|claude|git|security,4h,2h,1h,1h
 t008,aidevops-opencode Plugin,,plan,2d,1d,0.5d,0.5d,2025-12-21T01:50Z,pending,,,
 t004,Add Ahrefs MCP server integration,,seo,2d,1d,0.5d,0.5d,2025-12-20T00:00Z,pending,,,
 t005,Implement multi-tenant credential storage,,security,5d,3d,1.5d,0.5d,2025-12-20T00:00Z,pending,,,
-t006,Add Playwright MCP auto-setup to setup.sh,,browser,1d,0.5d,0.5d,,2025-12-20T00:00Z,pending,,,
+t006,Add Playwright MCP auto-setup to setup.sh,,browser,1d,0.5d,0.5d,,2025-12-20T00:00Z,done,,,
 t007,Create MCP server for QuickFile accounting API,,accounting,3d,2d,1d,,2025-12-20T00:00Z,pending,,,
 t012,OCR Invoice/Receipt Extraction Pipeline,,plan|accounting|ocr|automation,3d,1.5d,1d,0.5d,2025-12-21T22:00Z,pending,,,
 t013,Image SEO Enhancement with AI Vision,,plan|seo|images|ai|accessibility,6h,3h,2h,1h,2025-12-21T23:30Z,pending,,,

--- a/setup.sh
+++ b/setup.sh
@@ -2220,10 +2220,11 @@ setup_browser_tools() {
     if [[ "$has_node" == "true" ]]; then
         print_info "Setting up Playwright MCP..."
         
-        # Check if Playwright browsers are installed
-        if npx playwright --version &> /dev/null 2>&1; then
+        # Check if Playwright browsers are installed (--no-install prevents auto-download)
+        if npx --no-install playwright --version &> /dev/null 2>&1; then
             print_success "Playwright already installed"
         else
+            local install_playwright
             read -r -p "Install Playwright MCP with browsers (chromium, firefox, webkit)? (y/n): " install_playwright
             
             if [[ "$install_playwright" == "y" ]]; then
@@ -2244,6 +2245,7 @@ setup_browser_tools() {
     fi
     
     print_info "Browser tools: dev-browser (stateful), Playwriter (extension), Playwright (testing), Stagehand (AI)"
+    return 0
 }
 
 # Setup AI Orchestration Frameworks (Langflow, CrewAI, AutoGen)

--- a/setup.sh
+++ b/setup.sh
@@ -2216,7 +2216,34 @@ setup_browser_tools() {
         print_warning "Node.js not found - Playwriter MCP unavailable"
     fi
     
-    print_info "Browser tools: dev-browser (stateful), Playwriter (extension), Stagehand (AI)"
+    # Playwright MCP (cross-browser testing automation)
+    if [[ "$has_node" == "true" ]]; then
+        print_info "Setting up Playwright MCP..."
+        
+        # Check if Playwright browsers are installed
+        if npx playwright --version &> /dev/null 2>&1; then
+            print_success "Playwright already installed"
+        else
+            read -r -p "Install Playwright MCP with browsers (chromium, firefox, webkit)? (y/n): " install_playwright
+            
+            if [[ "$install_playwright" == "y" ]]; then
+                print_info "Installing Playwright browsers..."
+                if npx playwright install 2>/dev/null; then
+                    print_success "Playwright browsers installed"
+                else
+                    print_warning "Playwright browser installation failed"
+                    print_info "Run manually: npx playwright install"
+                fi
+            else
+                print_info "Skipped Playwright installation"
+                print_info "Install later with: npx playwright install"
+            fi
+        fi
+        
+        print_info "Playwright MCP runs via: npx playwright-mcp@latest"
+    fi
+    
+    print_info "Browser tools: dev-browser (stateful), Playwriter (extension), Playwright (testing), Stagehand (AI)"
 }
 
 # Setup AI Orchestration Frameworks (Langflow, CrewAI, AutoGen)

--- a/setup.sh
+++ b/setup.sh
@@ -2229,7 +2229,7 @@ setup_browser_tools() {
             
             if [[ "$install_playwright" == "y" ]]; then
                 print_info "Installing Playwright browsers..."
-                if npx playwright install 2>/dev/null; then
+                if npx playwright install; then
                     print_success "Playwright browsers installed"
                 else
                     print_warning "Playwright browser installation failed"
@@ -2244,7 +2244,11 @@ setup_browser_tools() {
         print_info "Playwright MCP runs via: npx playwright-mcp@latest"
     fi
     
-    print_info "Browser tools: dev-browser (stateful), Playwriter (extension), Playwright (testing), Stagehand (AI)"
+    if [[ "$has_node" == "true" ]]; then
+        print_info "Browser tools: dev-browser (stateful), Playwriter (extension), Playwright (testing), Stagehand (AI)"
+    else
+        print_info "Browser tools: dev-browser (stateful), Stagehand (AI)"
+    fi
     return 0
 }
 


### PR DESCRIPTION
## Summary

- Add Playwright MCP installation to `setup_browser_tools()` function in setup.sh
- Check for existing Playwright installation before prompting user
- Install browsers (chromium, firefox, webkit) via `npx playwright install`
- Update browser tools summary to include Playwright

## Changes

- **setup.sh**: Added Playwright MCP setup section with:
  - Version check for existing installation
  - User prompt for installation
  - Browser installation via npx
  - Info about running via `npx playwright-mcp@latest`

- **TODO.md**: Marked t006 as complete

## Testing

The setup can be tested by running:
```bash
./setup.sh --interactive
```

And selecting "Setup browser automation tools" when prompted.

Closes t006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated conditional Playwright auto-setup into the installer with prompts to install browsers when prerequisites are present
  * Added checks for existing Playwright installation and guidance on installation failures
  * Updated displayed tooling list to include Playwright (testing)
  * Marked the related setup task as completed in project tracking

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->