### PR TITLE
feat: add MiniSim iOS/Android emulator launcher support

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -487,6 +487,7 @@ Subagents provide specialized capabilities. Read them when tasks require domain 
 | `tools/ai-assistants/` | AI tool integration - configuring assistants, CAPTCHA solving, multi-modal agents | agno, capsolver, windsurf, configuration, status |
 | `tools/ai-orchestration/` | AI orchestration frameworks - visual builders, multi-agent teams, workflow automation, DSL orchestration | overview, langflow, crewai, autogen, openprose, packaging |
 | `tools/browser/` | Browser automation - web scraping, testing, screenshots, form filling, cookie extraction, macOS GUI automation | agent-browser, stagehand, playwright, playwriter, crawl4ai, dev-browser, pagespeed, chrome-devtools, sweet-cookie, peekaboo |
+| `tools/mobile/` | Mobile development - iOS simulator and Android emulator management | minisim |
 | `tools/ui/` | UI components - component libraries, design systems, frontend debugging, hydration errors | shadcn, ui-skills, frontend-debugging |
 | `tools/code-review/` | Code quality - linting, security scanning, style enforcement, PR reviews | code-standards, code-simplifier, codacy, coderabbit, qlty, snyk, secretlint, auditing |
 | `tools/context/` | Context optimization - semantic search, codebase indexing, token efficiency | osgrep, augment-context-engine, context-builder, context7, toon, dspy, llm-tldr |
@@ -598,6 +599,7 @@ For AI-assisted setup guidance, see `aidevops/setup.md`.
 | macOS automation | `tools/automation/mac.md` (AppleScript, JXA, app control) |
 | Programmatic video | `tools/video/remotion.md` (React video creation, animations) |
 | AI image/video generation | `tools/video/higgsfield.md` (100+ generative models via unified API) |
+| Mobile emulators | `tools/mobile/minisim.md` (iOS simulator, Android emulator launcher) |
 
 ## Security
 

--- a/.agent/tools/mobile/minisim.md
+++ b/.agent/tools/mobile/minisim.md
@@ -1,0 +1,146 @@
+---
+description: MiniSim - macOS menu bar app for iOS/Android emulator management
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# MiniSim - iOS and Android Emulator Launcher
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: macOS menu bar app for launching iOS simulators and Android emulators
+- **Install**: `brew install --cask minisim`
+- **Global Shortcut**: Option + Shift + E
+- **Requirements**: Xcode (iOS) and/or Android Studio (Android)
+- **Website**: https://www.minisim.app/
+- **GitHub**: https://github.com/okwasniewski/MiniSim
+
+**Key Features**:
+- Launch iOS simulators and Android emulators from menu bar
+- Copy device UDID/ADB ID
+- Cold boot Android emulators
+- Run Android emulators without audio (saves Bluetooth headphone battery)
+- Toggle accessibility on Android emulators
+- Focus running devices via accessibility API
+- Set default launch flags
+
+**Why MiniSim**: Native Swift/AppKit app - lightweight, fast, no Electron overhead
+
+<!-- AI-CONTEXT-END -->
+
+## Installation
+
+```bash
+# Install via Homebrew (recommended)
+brew install --cask minisim
+
+# Or download from GitHub releases
+# https://github.com/okwasniewski/MiniSim/releases
+```
+
+## Requirements
+
+MiniSim uses `xcrun` and Android SDK's `emulator` command to discover devices:
+
+- **iOS Simulators**: Requires Xcode with iOS Simulator installed
+- **Android Emulators**: Requires Android Studio with emulator configured
+
+## Usage
+
+### Global Shortcut
+
+Press **Option + Shift + E** to open the MiniSim menu from anywhere.
+
+### iOS Simulator Features
+
+| Action | Description |
+|--------|-------------|
+| Launch | Click simulator name to boot |
+| Copy UDID | Right-click > Copy UDID |
+| Copy Name | Right-click > Copy Name |
+| Delete | Right-click > Delete Simulator |
+
+### Android Emulator Features
+
+| Action | Description |
+|--------|-------------|
+| Launch | Click emulator name to boot |
+| Cold Boot | Right-click > Cold Boot |
+| No Audio | Right-click > Launch without audio |
+| Toggle A11y | Right-click > Toggle Accessibility |
+| Copy ADB ID | Right-click > Copy ADB ID |
+| Copy Name | Right-click > Copy Name |
+
+### Default Launch Flags
+
+Configure default flags in MiniSim preferences:
+
+- **Android**: Add flags like `-no-audio`, `-no-boot-anim`
+- **iOS**: Configure simulator options
+
+## Integration with AI Workflows
+
+### Launching Simulators from Scripts
+
+```bash
+# List iOS simulators
+xcrun simctl list devices
+
+# Boot specific iOS simulator
+xcrun simctl boot "iPhone 15 Pro"
+
+# List Android emulators
+emulator -list-avds
+
+# Launch Android emulator
+emulator -avd Pixel_7_API_34
+
+# Launch without audio (saves Bluetooth battery)
+emulator -avd Pixel_7_API_34 -no-audio
+```
+
+### Raycast Extension
+
+MiniSim has a Raycast extension for keyboard-driven workflows:
+
+1. Install Raycast: https://www.raycast.com
+2. Install MiniSim extension from Raycast Store
+3. Use Raycast to search and launch emulators
+
+## Troubleshooting
+
+### Simulators Not Showing
+
+1. Verify Xcode is installed: `xcode-select -p`
+2. Check simulators exist: `xcrun simctl list devices`
+3. Restart MiniSim after installing new simulators
+
+### Android Emulators Not Showing
+
+1. Verify Android SDK path is configured
+2. Check emulators exist: `emulator -list-avds`
+3. Ensure `ANDROID_HOME` or `ANDROID_SDK_ROOT` is set
+
+### Permission Issues
+
+MiniSim may need accessibility permissions to focus devices:
+
+1. Open System Preferences > Security & Privacy > Privacy
+2. Select Accessibility
+3. Add MiniSim to the list
+
+## Related Tools
+
+- `tools/browser/stagehand.md` - Browser automation (web testing)
+- `tools/browser/playwright.md` - Cross-browser testing
+- `services/hosting/localhost.md` - Local development setup

--- a/setup.sh
+++ b/setup.sh
@@ -1003,6 +1003,89 @@ setup_recommended_tools() {
     return 0
 }
 
+# Setup MiniSim - iOS/Android emulator launcher (macOS only)
+setup_minisim() {
+    # Only available on macOS
+    if [[ "$(uname)" != "Darwin" ]]; then
+        return 0
+    fi
+    
+    print_info "Setting up MiniSim (iOS/Android emulator launcher)..."
+    
+    # Check if MiniSim is already installed
+    if [[ -d "/Applications/MiniSim.app" ]]; then
+        print_success "MiniSim already installed"
+        print_info "Global shortcut: Option + Shift + E"
+        return 0
+    fi
+    
+    # Check if Xcode or Android Studio is installed (MiniSim needs at least one)
+    local has_xcode=false
+    local has_android=false
+    
+    if command -v xcrun >/dev/null 2>&1 && xcrun simctl list devices >/dev/null 2>&1; then
+        has_xcode=true
+    fi
+    
+    if [[ -n "${ANDROID_HOME:-}" ]] || [[ -n "${ANDROID_SDK_ROOT:-}" ]] || [[ -d "$HOME/Library/Android/sdk" ]]; then
+        has_android=true
+    fi
+    
+    if [[ "$has_xcode" == "false" && "$has_android" == "false" ]]; then
+        print_info "MiniSim requires Xcode (iOS) or Android Studio (Android)"
+        print_info "Install one of these first, then re-run setup to install MiniSim"
+        return 0
+    fi
+    
+    # Show what's available
+    local available_for=""
+    if [[ "$has_xcode" == "true" ]]; then
+        available_for="iOS simulators"
+    fi
+    if [[ "$has_android" == "true" ]]; then
+        if [[ -n "$available_for" ]]; then
+            available_for="$available_for and Android emulators"
+        else
+            available_for="Android emulators"
+        fi
+    fi
+    
+    print_info "MiniSim is a menu bar app for launching $available_for"
+    echo "  Features:"
+    echo "    - Global shortcut: Option + Shift + E"
+    echo "    - Launch/manage iOS simulators and Android emulators"
+    echo "    - Copy device UDID/ADB ID"
+    echo "    - Cold boot Android emulators"
+    echo "    - Run Android emulators without audio (saves Bluetooth battery)"
+    echo ""
+    
+    # Check if Homebrew is available
+    if ! command -v brew >/dev/null 2>&1; then
+        print_warning "Homebrew not found - cannot install MiniSim automatically"
+        echo "  Install manually: https://github.com/okwasniewski/MiniSim/releases"
+        return 0
+    fi
+    
+    read -r -p "Install MiniSim? (y/n): " install_minisim
+    
+    if [[ "$install_minisim" == "y" ]]; then
+        print_info "Installing MiniSim..."
+        if brew install --cask minisim; then
+            print_success "MiniSim installed successfully"
+            print_info "Global shortcut: Option + Shift + E"
+            print_info "Documentation: ~/.aidevops/agents/tools/mobile/minisim.md"
+        else
+            print_warning "Failed to install MiniSim via Homebrew"
+            echo "  Install manually: https://github.com/okwasniewski/MiniSim/releases"
+        fi
+    else
+        print_info "Skipped MiniSim installation"
+        print_info "Install later: brew install --cask minisim"
+    fi
+    
+    return 0
+}
+
 # Setup SSH key if needed
 setup_ssh_key() {
     print_info "Checking SSH key setup..."
@@ -2757,6 +2840,7 @@ main() {
     # Optional steps with confirmation in interactive mode
     confirm_step "Check optional dependencies (bun, node, python)" && check_optional_deps
     confirm_step "Setup recommended tools (Tabby, Zed, etc.)" && setup_recommended_tools
+    confirm_step "Setup MiniSim (iOS/Android emulator launcher)" && setup_minisim
     confirm_step "Setup Git CLIs (gh, glab, tea)" && setup_git_clis
     confirm_step "Setup file discovery tools (fd, ripgrep)" && setup_file_discovery_tools
     confirm_step "Setup Worktrunk (git worktree management)" && setup_worktrunk

--- a/setup.sh
+++ b/setup.sh
@@ -1066,6 +1066,7 @@ setup_minisim() {
         return 0
     fi
     
+    local install_minisim
     read -r -p "Install MiniSim? (y/n): " install_minisim
     
     if [[ "$install_minisim" == "y" ]]; then


### PR DESCRIPTION
## Summary

- Add MiniSim documentation in `tools/mobile/minisim.md`
- Add `setup_minisim` function to `setup.sh` for optional installation
- Update `AGENTS.md` with mobile tools folder and MiniSim reference

## What is MiniSim?

[MiniSim](https://github.com/okwasniewski/MiniSim) is a lightweight macOS menu bar app for launching iOS simulators and Android emulators. Key features:

- **Global shortcut**: Option + Shift + E
- **iOS Simulators**: Launch, copy UDID, copy name, delete
- **Android Emulators**: Launch, cold boot, no-audio mode, toggle a11y, copy ADB ID
- **Native Swift/AppKit**: Fast, no Electron overhead

## Installation

```bash
brew install --cask minisim
```

## Changes

| File | Change |
|------|--------|
| `.agent/tools/mobile/minisim.md` | New documentation for MiniSim |
| `.agent/AGENTS.md` | Added mobile tools folder to subagent table |
| `setup.sh` | Added `setup_minisim()` function with Homebrew installation |

## Testing

- [x] ShellCheck passes (no errors)
- [x] New function follows existing setup.sh patterns
- [x] Documentation follows agent markdown conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for a mobile emulator management tool: installation, requirements, usage examples (iOS/Android), integration notes, configuration, and troubleshooting; also added it to the tools index for improved discoverability.

* **Chores**
  * Integrated an interactive setup step to streamline installation and configuration of the macOS-based emulator launcher, including checks and prompts for required platform tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->