### PR TITLE
docs(playwriter): fix OpenCode MCP configuration

### DIFF
--- a/.agent/tools/browser/playwriter.md
+++ b/.agent/tools/browser/playwriter.md
@@ -59,12 +59,14 @@ Add to your MCP client configuration:
   "mcp": {
     "playwriter": {
       "type": "local",
-      "command": ["npx", "playwriter@latest"],
+      "command": ["/opt/homebrew/bin/npx", "-y", "playwriter@latest"],
       "enabled": true
     }
   }
 }
-```text
+```
+
+> **Note**: Use full path to `npx` (e.g., `/opt/homebrew/bin/npx` on macOS with Homebrew) for reliability. The `-y` flag auto-confirms package installation.
 
 **Claude Desktop** (`claude_desktop_config.json`):
 
@@ -73,11 +75,30 @@ Add to your MCP client configuration:
   "mcpServers": {
     "playwriter": {
       "command": "npx",
-      "args": ["playwriter@latest"]
+      "args": ["-y", "playwriter@latest"]
     }
   }
 }
-```text
+```
+
+**Enable per-agent** (OpenCode tools section):
+
+```json
+{
+  "tools": {
+    "playwriter_*": false
+  },
+  "agent": {
+    "Build+": {
+      "tools": {
+        "playwriter_*": true
+      }
+    }
+  }
+}
+```
+
+> **Tip**: Disable globally with `"playwriter_*": false` in `tools`, then enable per-agent to reduce context token usage.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Update Playwriter MCP documentation with correct OpenCode configuration format
- Add `-y` flag to npx command for auto-confirmation
- Document full path usage for reliability
- Add per-agent tool enabling example for token optimization

## Changes

### Documentation (`playwriter.md`)
- Fixed OpenCode config example: `["npx", "playwriter@latest"]` → `["/opt/homebrew/bin/npx", "-y", "playwriter@latest"]`
- Added note about using full path to npx
- Added Claude Desktop config with `-y` flag
- Added per-agent tool enabling example with explanation

## Testing

The user's OpenCode config was also updated (outside this repo) to:
1. Use correct npx command format
2. Enable `playwriter_*` tools for Build+ and Research agents

## Related

- Playwriter GitHub: https://github.com/remorses/playwriter
- Latest version: 0.0.50 (Jan 19, 2026)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Playwriter tool configuration guidance with clearer setup instructions
  * Added user-facing notes clarifying proper command usage and automatic confirmation behavior
  * Enhanced configuration examples for OpenCode and Claude Desktop environments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->