### PR TITLE
feat: add aidevops skill CLI command with telemetry disabled

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -511,7 +511,7 @@ Subagents provide specialized capabilities. Read them when tasks require domain 
 | `workflows/` | Development processes - branching, releases, PR reviews, quality gates | git-workflow, plans, release, version-bump, pr, review-issue-pr, preflight, postflight, ralph-loop, session-review |
 | `templates/` | Document templates - PRDs, task lists, planning documents | prd-template, tasks-template, plans-template, todo-template |
 | `workflows/branch/` | Branch conventions - naming, purpose, merge strategies per branch type | feature, bugfix, hotfix, refactor, chore, experiment, release |
-| `scripts/commands/` | Slash commands - save-todo, remember, recall, code-simplifier, humanise and other interactive commands | save-todo, remember, recall, code-simplifier, humanise |
+| `scripts/commands/` | Slash commands - save-todo, remember, recall, code-simplifier, humanise, add-skill and other interactive commands | save-todo, remember, recall, code-simplifier, humanise, add-skill |
 
 <!-- AI-CONTEXT-END -->
 
@@ -554,6 +554,7 @@ aidevops features                # List available features
 | `aidevops upgrade` | Alias for update |
 | `aidevops repos` | List registered projects |
 | `aidevops repos add` | Register current project |
+| `aidevops skill <cmd>` | Manage imported skills (add/list/check/update/remove/generate) |
 | `aidevops detect` | Find unregistered aidevops projects |
 | `aidevops update-tools` | Check for outdated tools |
 | `aidevops uninstall` | Remove aidevops |
@@ -600,6 +601,7 @@ For AI-assisted setup guidance, see `aidevops/setup.md`.
 | Programmatic video | `tools/video/remotion.md` (React video creation, animations) |
 | AI image/video generation | `tools/video/higgsfield.md` (100+ generative models via unified API) |
 | Mobile emulators | `tools/mobile/minisim.md` (iOS simulator, Android emulator launcher) |
+| Importing skills | `scripts/commands/add-skill.md` (import, naming, update tracking) |
 
 ## Security
 
@@ -644,6 +646,47 @@ Never create files in `~/` root for files needed only with the current task.
 | `full-loop-helper.sh` | End-to-end development loop (task → PR → deploy) |
 | `session-review-helper.sh` | Gather session context for completeness review |
 | `humanise-update-helper.sh` | Check for upstream updates to humanise subagent |
+| `add-skill-helper.sh` | Import external skills from GitHub repos |
+| `skill-update-helper.sh` | Check/update imported skills from upstream |
+| `generate-skills.sh` | Generate SKILL.md stubs for cross-tool discovery |
+
+## Imported Skills
+
+Import community [Agent Skills](https://agentskills.io) into aidevops with upstream tracking.
+
+**Naming convention**: Imported skills use a `-skill` suffix to distinguish from native subagents:
+
+| Type | Pattern | Example | Managed by |
+|------|---------|---------|------------|
+| Native subagent | `{name}.md` | `playwright.md` | aidevops team |
+| Imported skill | `{name}-skill.md` | `playwright-skill.md` | Upstream repo |
+
+**CLI commands:**
+
+```bash
+aidevops skill add <source>       # Import from GitHub (→ *-skill.md)
+aidevops skill list                # List imported skills
+aidevops skill check               # Check for upstream updates
+aidevops skill update [name]       # Pull upstream changes
+aidevops skill remove <name>       # Remove imported skill
+aidevops skill generate            # Generate SKILL.md stubs for cross-tool discovery
+aidevops skill clean               # Remove generated SKILL.md stubs
+```
+
+**How it works:**
+1. Clones the source repo, detects format (SKILL.md, AGENTS.md, .cursorrules)
+2. Converts to aidevops subagent format with `-skill.md` suffix
+3. Places in appropriate category folder (auto-detected from content)
+4. Registers in `.agent/configs/skill-sources.json` for update tracking
+5. Telemetry disabled - no data sent to skills.sh or third parties
+
+**When issues arise with a subagent:**
+- `*-skill.md` → Check upstream for updates: `aidevops skill check`
+- Native `.md` → Evolve locally, submit PR to aidevops
+
+**Cross-tool discovery**: `aidevops skill generate` creates lightweight SKILL.md stubs so other tools (Cursor, VS Code Copilot, OpenCode) can discover aidevops subagents without changing our file structure.
+
+**Related scripts:** `add-skill-helper.sh`, `skill-update-helper.sh`, `generate-skills.sh`
 
 ## Quality Workflow
 

--- a/.agent/scripts/add-skill-helper.sh
+++ b/.agent/scripts/add-skill-helper.sh
@@ -785,7 +785,7 @@ cmd_check_updates() {
         # Get latest commit from GitHub API
         local api_url="https://api.github.com/repos/$owner/$repo/commits?per_page=1"
         local latest_commit
-        latest_commit=$(curl -s "$api_url" | jq -r '.[0].sha // empty' 2>/dev/null)
+        latest_commit=$(curl -s --connect-timeout 10 --max-time 30 "$api_url" | jq -r '.[0].sha // empty' 2>/dev/null)
         
         if [[ -z "$latest_commit" ]]; then
             log_warning "Could not fetch latest commit for $name"

--- a/.agent/scripts/commands/add-skill.md
+++ b/.agent/scripts/commands/add-skill.md
@@ -11,14 +11,17 @@ URL/Repo: $ARGUMENTS
 ## Quick Reference
 
 ```bash
-# Import skill from GitHub
+# Import skill from GitHub (saved as *-skill.md)
 /add-skill dmmulroy/cloudflare-skill
+# → .agent/services/hosting/cloudflare-skill.md
 
 # Import specific skill from multi-skill repo
 /add-skill anthropics/skills/pdf
+# → .agent/tools/pdf-skill.md
 
 # Import with custom name
 /add-skill vercel-labs/agent-skills --name vercel-deploy
+# → .agent/tools/deployment/vercel-deploy-skill.md
 
 # List imported skills
 /add-skill list
@@ -26,6 +29,21 @@ URL/Repo: $ARGUMENTS
 # Check for updates
 /add-skill check-updates
 ```
+
+## Naming Convention
+
+Imported skills are saved with a `-skill` suffix to distinguish them from native aidevops subagents:
+
+| Type | Example | Managed by |
+|------|---------|------------|
+| Native subagent | `playwright.md` | aidevops team, evolves with framework |
+| Imported skill | `playwright-skill.md` | Upstream repo, checked for updates |
+
+This means:
+- No name clashes between imports and native subagents
+- `*-skill.md` glob finds all imports instantly
+- `aidevops skill check` knows which files to check for upstream updates
+- Issues with imported skills → check upstream; issues with native → evolve locally
 
 ## Workflow
 
@@ -111,7 +129,7 @@ Imported skills are tracked in `.agent/configs/skill-sources.json`:
       "name": "cloudflare",
       "upstream_url": "https://github.com/dmmulroy/cloudflare-skill",
       "upstream_commit": "abc123...",
-      "local_path": ".agent/services/hosting/cloudflare.md",
+      "local_path": ".agent/services/hosting/cloudflare-skill.md",
       "format_detected": "skill-md",
       "imported_at": "2026-01-21T00:00:00Z",
       "last_checked": "2026-01-21T00:00:00Z",

--- a/.agent/tools/browser/playwriter.md
+++ b/.agent/tools/browser/playwriter.md
@@ -59,12 +59,14 @@ Add to your MCP client configuration:
   "mcp": {
     "playwriter": {
       "type": "local",
-      "command": ["npx", "playwriter@latest"],
+      "command": ["/opt/homebrew/bin/npx", "-y", "playwriter@latest"],
       "enabled": true
     }
   }
 }
-```text
+```
+
+> **Note**: Use full path to `npx` (e.g., `/opt/homebrew/bin/npx` on macOS with Homebrew) for reliability. The `-y` flag auto-confirms package installation.
 
 **Claude Desktop** (`claude_desktop_config.json`):
 
@@ -73,11 +75,30 @@ Add to your MCP client configuration:
   "mcpServers": {
     "playwriter": {
       "command": "npx",
-      "args": ["playwriter@latest"]
+      "args": ["-y", "playwriter@latest"]
     }
   }
 }
-```text
+```
+
+**Enable per-agent** (OpenCode tools section):
+
+```json
+{
+  "tools": {
+    "playwriter_*": false
+  },
+  "agent": {
+    "Build+": {
+      "tools": {
+        "playwriter_*": true
+      }
+    }
+  }
+}
+```
+
+> **Tip**: Disable globally with `"playwriter_*": false` in `tools`, then enable per-agent to reduce context token usage.
 
 ## Usage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add MiniSim iOS/Android emulator launcher support (#151)
+
 ## [2.71.0] - 2026-01-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- add `aidevops skill` CLI command for managing agent skills with telemetry disabled (#154)
+- add `-skill` suffix convention for imported skills to distinguish from native subagents
+- add `generate`/`clean` subcommands for SKILL.md cross-tool discovery stubs
+
 ## [2.72.0] - 2026-01-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -453,16 +453,26 @@ aidevops includes curated skills imported from external repositories. Skills fro
 | **remotion** | [remotion-dev/skills](https://github.com/remotion-dev/skills) | Programmatic video creation with React, animations, rendering |
 | **animejs** | [animejs.com](https://animejs.com) | JavaScript animation library patterns and API (via Context7) |
 
-**Skill Commands:**
+**CLI Commands:**
 
 ```bash
-/add-skill <owner/repo>        # Import a skill from GitHub
-/add-skill list                # List imported skills
-/add-skill check-updates       # Check for upstream updates
-/add-skill <owner/repo> --force  # Update an existing skill
+aidevops skill add <owner/repo>    # Import a skill from GitHub
+aidevops skill list                # List imported skills
+aidevops skill check               # Check for upstream updates
+aidevops skill update [name]       # Update specific or all skills
+aidevops skill remove <name>       # Remove an imported skill
 ```
 
-Skills are registered in `~/.aidevops/agents/configs/skill-sources.json` and checked for updates during `./setup.sh`.
+Skills are registered in `~/.aidevops/agents/configs/skill-sources.json` with upstream commit tracking for update detection. Telemetry is disabled - no data is sent to third parties.
+
+**Browse community skills:** [skills.sh](https://skills.sh) | **Specification:** [agentskills.io](https://agentskills.io)
+
+**Reference:**
+- [Agent Skills Specification](https://agentskills.io/specification) - The open format for SKILL.md files
+- [skills.sh Leaderboard](https://skills.sh) - Discover popular community skills
+- [vercel-labs/add-skill](https://github.com/vercel-labs/add-skill) - The upstream CLI tool (aidevops uses its own implementation)
+- [anthropics/skills](https://github.com/anthropics/skills) - Official Anthropic example skills
+- [agentskills/agentskills](https://github.com/agentskills/agentskills) - Specification source and reference library
 
 ## **Agent Design Patterns**
 
@@ -923,30 +933,43 @@ This installs the complete framework: 13 domain agents, 225+ subagents, and 130+
 
 ### Importing External Skills
 
-Import skills from any GitHub repository using `/add-skill`:
+Import skills from any GitHub repository using the `aidevops skill` CLI:
 
 ```bash
 # Import from GitHub (auto-detects format)
-/add-skill owner/repo
+aidevops skill add owner/repo
 
 # Examples
-/add-skill anthropics/courses           # SKILL.md format
-/add-skill PatrickJS/awesome-cursorrules # .cursorrules format
-/add-skill someone/agents-repo          # AGENTS.md format
+aidevops skill add anthropics/skills/pdf           # Specific skill from multi-skill repo
+aidevops skill add vercel-labs/agent-skills         # All skills from a repo
+aidevops skill add expo/skills --name expo-dev      # Custom name
+aidevops skill add owner/repo --dry-run             # Preview without changes
 ```
 
 **Supported formats:**
-- `SKILL.md` - Agent Skills standard (preferred)
+- `SKILL.md` - [Agent Skills standard](https://agentskills.io/specification) (preferred)
 - `AGENTS.md` - Claude Code agents format
-- `.cursorrules` - Cursor rules (auto-converted to SKILL.md)
+- `.cursorrules` - Cursor rules (auto-converted)
 
 **Features:**
-- Conflict detection with existing skills
-- Version tracking for updates (`/add-skill --check-updates`)
-- Symlinks created for Claude Code, Cursor, Amp, and other tools
+- Auto-detection of skill format and category placement
+- Conflict detection with merge/replace/rename options
+- Upstream commit tracking for update detection (`aidevops skill check`)
+- Conversion to aidevops subagent format with YAML frontmatter
 - Registry stored in `.agent/configs/skill-sources.json`
+- Telemetry disabled (no data sent to skills.sh or other services)
 
-See `.agent/tools/build-agent/add-skill.md` for full documentation.
+**How it differs from `npx add-skill`:**
+
+| | `aidevops skill add` | `npx add-skill` |
+|---|---|---|
+| **Target** | Converts to aidevops format in `.agent/` | Copies SKILL.md to agent-specific dirs |
+| **Tracking** | Git commit-based upstream tracking | Lock file with content hashes |
+| **Telemetry** | Disabled | Sends anonymous install counts |
+| **Scope** | OpenCode-first | 22+ agents |
+| **Updates** | `aidevops skill check` (GitHub API) | `npx skills check` (Vercel API) |
+
+See `.agent/scripts/add-skill-helper.sh` for implementation details.
 
 ## **AI Agents & Subagents**
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1731,7 +1731,7 @@ cmd_skill() {
             fi
             bash "$generate_script" --clean "$@"
             ;;
-        help|--help|-h|*)
+        help|--help|-h)
             print_header "Agent Skills Management"
             echo ""
             echo "Import and manage reusable AI agent skills from the community."
@@ -1768,6 +1768,11 @@ cmd_skill() {
             echo ""
             echo "Browse community skills: https://skills.sh"
             echo "Agent Skills specification: https://agentskills.io"
+            ;;
+        *)
+            print_error "Unknown skill command: $action"
+            echo "Run 'aidevops skill help' for usage information."
+            return 1
             ;;
     esac
 }

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1631,6 +1631,123 @@ cmd_detect() {
     return 0
 }
 
+# Skill command - manage agent skills
+cmd_skill() {
+    local action="${1:-help}"
+    shift || true
+
+    # Disable telemetry for any downstream tools (add-skill, skills CLI)
+    export DISABLE_TELEMETRY=1
+    export DO_NOT_TRACK=1
+    export SKILLS_NO_TELEMETRY=1
+
+    local add_skill_script="$AGENTS_DIR/scripts/add-skill-helper.sh"
+    local update_skill_script="$AGENTS_DIR/scripts/skill-update-helper.sh"
+
+    case "$action" in
+        add|a)
+            if [[ $# -lt 1 ]]; then
+                print_error "Source required (owner/repo or URL)"
+                echo ""
+                echo "Usage: aidevops skill add <source> [options]"
+                echo ""
+                echo "Examples:"
+                echo "  aidevops skill add vercel-labs/agent-skills"
+                echo "  aidevops skill add anthropics/skills/pdf"
+                echo "  aidevops skill add https://github.com/owner/repo"
+                echo ""
+                echo "Options:"
+                echo "  --name <name>   Override the skill name"
+                echo "  --force         Overwrite existing skill"
+                echo "  --dry-run       Preview without making changes"
+                echo ""
+                echo "Browse skills: https://skills.sh"
+                return 1
+            fi
+
+            if [[ ! -f "$add_skill_script" ]]; then
+                print_error "add-skill-helper.sh not found"
+                print_info "Run 'aidevops update' to get the latest scripts"
+                return 1
+            fi
+
+            bash "$add_skill_script" add "$@"
+            ;;
+        list|ls|l)
+            if [[ ! -f "$add_skill_script" ]]; then
+                print_error "add-skill-helper.sh not found"
+                return 1
+            fi
+            bash "$add_skill_script" list
+            ;;
+        check|c)
+            if [[ ! -f "$update_skill_script" ]]; then
+                print_error "skill-update-helper.sh not found"
+                return 1
+            fi
+            bash "$update_skill_script" check "$@"
+            ;;
+        update|u)
+            if [[ ! -f "$update_skill_script" ]]; then
+                print_error "skill-update-helper.sh not found"
+                return 1
+            fi
+            bash "$update_skill_script" update "$@"
+            ;;
+        remove|rm)
+            if [[ $# -lt 1 ]]; then
+                print_error "Skill name required"
+                echo "Usage: aidevops skill remove <name>"
+                return 1
+            fi
+            if [[ ! -f "$add_skill_script" ]]; then
+                print_error "add-skill-helper.sh not found"
+                return 1
+            fi
+            bash "$add_skill_script" remove "$@"
+            ;;
+        status|s)
+            if [[ ! -f "$update_skill_script" ]]; then
+                print_error "skill-update-helper.sh not found"
+                return 1
+            fi
+            bash "$update_skill_script" status "$@"
+            ;;
+        help|--help|-h|*)
+            print_header "Agent Skills Management"
+            echo ""
+            echo "Import and manage reusable AI agent skills from the community."
+            echo "Skills are converted to aidevops format with upstream tracking."
+            echo "Telemetry is disabled - no data sent to third parties."
+            echo ""
+            echo "Usage: aidevops skill <command> [options]"
+            echo ""
+            echo "Commands:"
+            echo "  add <source>     Import a skill from GitHub"
+            echo "  list             List all imported skills"
+            echo "  check            Check for upstream updates"
+            echo "  update [name]    Update specific or all skills"
+            echo "  remove <name>    Remove an imported skill"
+            echo "  status           Show detailed skill status"
+            echo ""
+            echo "Source formats:"
+            echo "  owner/repo                    GitHub shorthand"
+            echo "  owner/repo/path/to/skill      Specific skill in multi-skill repo"
+            echo "  https://github.com/owner/repo Full URL"
+            echo ""
+            echo "Examples:"
+            echo "  aidevops skill add vercel-labs/agent-skills"
+            echo "  aidevops skill add anthropics/skills/pdf"
+            echo "  aidevops skill add expo/skills --name expo-dev"
+            echo "  aidevops skill check"
+            echo "  aidevops skill update"
+            echo ""
+            echo "Browse community skills: https://skills.sh"
+            echo "Agent Skills specification: https://agentskills.io"
+            ;;
+    esac
+}
+
 # Help command
 cmd_help() {
     local version
@@ -1644,6 +1761,7 @@ cmd_help() {
     echo "  init [features]    Initialize aidevops in current project"
     echo "  upgrade-planning   Upgrade TODO.md/PLANS.md to latest templates"
     echo "  features           List available features for init"
+    echo "  skill <cmd>        Manage agent skills (add/list/check/update/remove)"
     echo "  status             Check installation status of all components"
     echo "  update             Update aidevops to the latest version (alias: upgrade)"
     echo "  upgrade            Alias for update"
@@ -1667,6 +1785,13 @@ cmd_help() {
     echo "  aidevops update-tools        # Check for outdated tools"
     echo "  aidevops update-tools -u     # Update all outdated tools"
     echo "  aidevops uninstall           # Remove aidevops"
+    echo ""
+    echo "Skills:"
+    echo "  aidevops skill add <source>  # Import a skill from GitHub"
+    echo "  aidevops skill list          # List imported skills"
+    echo "  aidevops skill check         # Check for upstream updates"
+    echo "  aidevops skill update [name] # Update skills to latest"
+    echo "  aidevops skill remove <name> # Remove an imported skill"
     echo ""
     echo "Installation:"
     echo "  npm install -g aidevops && aidevops update      # via npm"
@@ -1747,6 +1872,10 @@ main() {
         repos|projects)
             shift
             cmd_repos "$@"
+            ;;
+        skill|skills)
+            shift
+            cmd_skill "$@"
             ;;
         detect|scan)
             cmd_detect

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1713,6 +1713,24 @@ cmd_skill() {
             fi
             bash "$update_skill_script" status "$@"
             ;;
+        generate|gen|g)
+            local generate_script="$AGENTS_DIR/scripts/generate-skills.sh"
+            if [[ ! -f "$generate_script" ]]; then
+                print_error "generate-skills.sh not found"
+                print_info "Run 'aidevops update' to get the latest scripts"
+                return 1
+            fi
+            print_info "Generating SKILL.md stubs for cross-tool discovery..."
+            bash "$generate_script" "$@"
+            ;;
+        clean)
+            local generate_script="$AGENTS_DIR/scripts/generate-skills.sh"
+            if [[ ! -f "$generate_script" ]]; then
+                print_error "generate-skills.sh not found"
+                return 1
+            fi
+            bash "$generate_script" --clean "$@"
+            ;;
         help|--help|-h|*)
             print_header "Agent Skills Management"
             echo ""
@@ -1723,12 +1741,14 @@ cmd_skill() {
             echo "Usage: aidevops skill <command> [options]"
             echo ""
             echo "Commands:"
-            echo "  add <source>     Import a skill from GitHub"
+            echo "  add <source>     Import a skill from GitHub (saved as *-skill.md)"
             echo "  list             List all imported skills"
             echo "  check            Check for upstream updates"
             echo "  update [name]    Update specific or all skills"
             echo "  remove <name>    Remove an imported skill"
             echo "  status           Show detailed skill status"
+            echo "  generate         Generate SKILL.md stubs for cross-tool discovery"
+            echo "  clean            Remove generated SKILL.md stubs"
             echo ""
             echo "Source formats:"
             echo "  owner/repo                    GitHub shorthand"
@@ -1741,6 +1761,10 @@ cmd_skill() {
             echo "  aidevops skill add expo/skills --name expo-dev"
             echo "  aidevops skill check"
             echo "  aidevops skill update"
+            echo "  aidevops skill generate --dry-run"
+            echo ""
+            echo "Imported skills are saved with a -skill suffix to distinguish"
+            echo "from native aidevops subagents (e.g., playwright-skill.md vs playwright.md)."
             echo ""
             echo "Browse community skills: https://skills.sh"
             echo "Agent Skills specification: https://agentskills.io"


### PR DESCRIPTION
## Summary

- Adds `aidevops skill` CLI command as a unified interface for managing [Agent Skills](https://agentskills.io) (the open standard for AI agent instructions)
- Disables telemetry by default (`DISABLE_TELEMETRY=1`, `DO_NOT_TRACK=1`, `SKILLS_NO_TELEMETRY=1`) to prevent usage data being sent to skills.sh leaderboard
- Delegates to existing `add-skill-helper.sh` (add/list/remove) and `skill-update-helper.sh` (check/update/status)

## Changes

### `aidevops.sh`
- Added `cmd_skill()` function (~100 lines) with subcommands: `add`, `list`, `remove`, `check`, `update`, `status`
- Added `skill|skills` case to main dispatch
- Updated `cmd_help()` with skill command documentation and examples section

### `README.md`
- Updated "Imported Skills" section with new `aidevops skill add` syntax
- Updated "Importing External Skills" section with comparison table vs `npx add-skill`
- Added reference links to agentskills.io, skills.sh, vercel-labs/add-skill, anthropics/skills

## Why

The `npx add-skill` / `npx skills` packages from Vercel send anonymous telemetry to power the skills.sh leaderboard. By wrapping through `aidevops skill`, we:
1. Provide a consistent CLI interface (`aidevops skill add` vs remembering `npx add-skill`)
2. Disable telemetry without users needing to know about it
3. Use our own implementation (git clone + SKILL.md conversion) rather than depending on npx

## References

- [Agent Skills Specification](https://agentskills.io/specification)
- [skills.sh Leaderboard](https://skills.sh)
- [vercel-labs/add-skill](https://github.com/vercel-labs/add-skill)
- [anthropics/skills](https://github.com/anthropics/skills)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "aidevops skill" command for managing external skills (add/list/check/update/remove/generate/clean/status).
  * Added per-agent tool enablement toggles for finer control.

* **Documentation**
  * Updated CLI examples, guides, and README to the new skill workflow and command syntax.
  * Added community-skills browsing, reference material, telemetry/upstream tracking guidance, and a user note recommending a stable npx invocation with auto-confirm.

* **Refactor**
  * Imported skills now use a clear "-skill" naming convention and improved conflict-resolution messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->