### PR TITLE
fix: correct ultimate-multisite plugin URL in wp-preferred.md

### DIFF
--- a/.agent/tools/wordpress/wp-preferred.md
+++ b/.agent/tools/wordpress/wp-preferred.md
@@ -316,7 +316,7 @@ These 5 plugins form the minimal recommended installation for any new WordPress 
 | Slug | Name | Source |
 |------|------|--------|
 | `network-plugin-auditor` | Network Plugin Auditor | https://wordpress.org/plugins/network-plugin-auditor/ |
-| `ultimate-multisite` | Ultimate Multisite | https://developer.developer.developer-developer-developer/ |
+| `ultimate-multisite` | Ultimate Multisite | https://wordpress.org/plugins/ultimate-multisite/ |
 
 ### Hosting-Specific
 


### PR DESCRIPTION
## Summary

- Fixes incorrect URL for the `ultimate-multisite` plugin in the Multisite section of wp-preferred.md
- Changed from placeholder/broken URL (`https://developer.developer.developer-developer-developer/`) to the correct WordPress.org plugin page (`https://wordpress.org/plugins/ultimate-multisite/`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected an invalid source URL reference to point to the official WordPress plugin page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->