### PR TITLE
feat: add video-prompt-design subagent for Veo 3 meta prompt framework

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -492,7 +492,7 @@ Subagents provide specialized capabilities. Read them when tasks require domain 
 | `tools/code-review/` | Code quality - linting, security scanning, style enforcement, PR reviews | code-standards, code-simplifier, codacy, coderabbit, qlty, snyk, secretlint, auditing |
 | `tools/context/` | Context optimization - semantic search, codebase indexing, token efficiency | osgrep, augment-context-engine, context-builder, context7, toon, dspy, llm-tldr |
 | `tools/conversion/` | Format conversion - document transformation between formats | pandoc |
-| `tools/video/` | Video creation - programmatic video generation, AI image/video generation, animations | remotion, higgsfield |
+| `tools/video/` | Video creation - programmatic video generation, AI image/video generation, animations, prompt design | remotion, higgsfield, video-prompt-design |
 | `tools/data-extraction/` | Data extraction - scraping business data, Google Maps, reviews | outscraper |
 | `tools/deployment/` | Deployment automation - self-hosted PaaS, serverless, CI/CD | coolify, coolify-cli, vercel |
 | `tools/git/` | Git operations - GitHub/GitLab/Gitea CLIs, Actions, worktrees, AI PR automation | github-cli, gitlab-cli, gitea-cli, github-actions, worktrunk, opencode-github, opencode-gitlab |
@@ -600,6 +600,7 @@ For AI-assisted setup guidance, see `aidevops/setup.md`.
 | macOS automation | `tools/automation/mac.md` (AppleScript, JXA, app control) |
 | Programmatic video | `tools/video/remotion.md` (React video creation, animations) |
 | AI image/video generation | `tools/video/higgsfield.md` (100+ generative models via unified API) |
+| Video prompt engineering | `tools/video/video-prompt-design.md` (Veo 3 meta prompts, 7-component framework) |
 | Mobile emulators | `tools/mobile/minisim.md` (iOS simulator, Android emulator launcher) |
 | Importing skills | `scripts/commands/add-skill.md` (import, naming, update tracking) |
 

--- a/.agent/configs/skill-sources.json
+++ b/.agent/configs/skill-sources.json
@@ -29,6 +29,17 @@
       "context7_id": "/remotion-dev/remotion"
     },
     {
+      "name": "video-prompt-design",
+      "upstream_url": "https://github.com/snubroot/Veo-3-Meta-Framework",
+      "upstream_commit": "",
+      "local_path": ".agent/tools/video/video-prompt-design.md",
+      "format_detected": "readme-distilled",
+      "imported_at": "2026-01-23T20:40:00Z",
+      "last_checked": "2026-01-23T20:40:00Z",
+      "merge_strategy": "added",
+      "notes": "Distilled from upstream README into 7-component meta prompt framework subagent"
+    },
+    {
       "name": "cloudflare-platform",
       "upstream_url": "https://github.com/dmmulroy/cloudflare-skill",
       "upstream_commit": "c4696d5389f95e9546b075759ff8326deac1fba7",

--- a/.agent/tools/video/video-prompt-design.md
+++ b/.agent/tools/video/video-prompt-design.md
@@ -1,0 +1,216 @@
+---
+description: "Video prompt design - AI video generation prompt engineering for Veo 3 and similar models using the 7-component meta prompt framework"
+mode: subagent
+upstream_url: https://github.com/snubroot/Veo-3-Meta-Framework
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: false
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Video Prompt Design
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Generate professional AI video prompts using structured meta prompt architecture
+- **Primary Model**: Google Veo 3 (8s max, 1080p, 24fps, 16:9)
+- **Framework**: 7-component format (Subject, Action, Scene, Style, Dialogue, Sounds, Technical)
+- **Source**: [Veo 3 Meta Framework](https://github.com/snubroot/Veo-3-Meta-Framework)
+
+**When to Use**: Read this when crafting prompts for AI video generation (Veo 3, Sora, Kling, etc.)
+
+**Core Format** (all 7 components required for professional quality):
+
+```text
+Subject:   [Character with 15+ physical attributes]
+Action:    [Movements, gestures, timing, micro-expressions]
+Scene:     [Environment, props, lighting, weather, time of day]
+Style:     [Camera shot, angle, movement, colour palette, depth of field]
+Dialogue:  [Character]: "Speech" (Tone: descriptor)
+Sounds:    [Ambient, effects, music, environmental audio]
+Technical: [Negative prompt - elements to exclude]
+```
+
+**Critical Techniques**:
+- Camera positioning: Include `(thats where the camera is)` for spatial anchoring
+- Dialogue format: Use colon syntax to prevent subtitle generation
+- Audio: Always specify environment audio to prevent hallucinations
+- Character consistency: Use identical descriptions across a series
+- Duration: 12-15 words / 20-25 syllables for 8-second dialogue
+
+<!-- AI-CONTEXT-END -->
+
+## Detailed Guidance
+
+### Character Development
+
+Build characters with 15+ specific attributes for consistency across generations:
+
+```text
+[NAME], a [AGE] [ETHNICITY] [GENDER] with [HAIR_DETAILS], [EYE_COLOUR] eyes,
+[FACIAL_FEATURES], [BUILD], wearing [CLOTHING], with [POSTURE],
+[EMOTIONAL_STATE], [ACCESSORIES], [VOICE_CHARACTERISTICS]
+```
+
+**Required attributes**: Age, ethnicity, gender, hair (colour/style/length/texture), eyes (colour/shape), facial features, build (height/weight/type), clothing (style/colour/fit/material), posture, mannerisms, emotional baseline, voice, distinctive features, professional indicators, personality markers.
+
+**Consistency rule**: Use the exact same character description wording across all prompts in a series.
+
+### Camera Work
+
+#### Shot Types
+
+| Shot | Framing | Use Case |
+|------|---------|----------|
+| EWS | Full environment | Scale, context |
+| WS | Full body | Character in environment |
+| MS | Waist up | Conversation, standard |
+| CU | Head/shoulders | Emotion, connection |
+| ECU | Eyes/mouth | Intense emotion |
+
+#### Movement Keywords
+
+| Movement | Effect |
+|----------|--------|
+| `static shot` | Stability, authority |
+| `dolly in/out` | Emotional intimacy control |
+| `pan left/right` | Scene revelation |
+| `tracking shot` | Subject following |
+| `handheld` | Authenticity, energy |
+| `crane shot` | Dramatic reveals |
+
+#### Camera Positioning Syntax
+
+Always include spatial context for the camera:
+
+```text
+"Close-up shot with camera positioned at counter level (thats where the camera is)
+as the character demonstrates the product"
+```
+
+### Dialogue Design
+
+**Colon format prevents subtitle generation**:
+
+```text
+CORRECT: The character looks at camera and says: 'This changes everything.'
+WRONG:   The character says 'This changes everything.'
+```
+
+**8-second rule**: 12-15 words, 20-25 syllables maximum per generation.
+
+Always specify tone and delivery:
+
+```text
+(Character Name): "Exact dialogue here"
+(Tone: warm confidence with professional authority)
+```
+
+### Audio Engineering
+
+**Always specify environment audio** to prevent hallucinations:
+
+```text
+Sounds: quiet office ambiance, keyboard typing, no audience sounds, professional atmosphere
+```
+
+**Domain-specific audio libraries**:
+
+| Setting | Audio Elements |
+|---------|---------------|
+| Kitchen | Sizzling, chopping, boiling, utensils, ambiance |
+| Office | Keyboard, fans, notifications, paper, professional |
+| Workshop | Tools, machinery, metal, equipment, industrial |
+| Outdoors | Wind, birds, traffic (distant), footsteps, natural |
+
+### Negative Prompts (Technical Component)
+
+**Universal quality negatives** (include in every prompt):
+
+```text
+subtitles, captions, watermark, text overlays, words on screen, logo, branding,
+poor lighting, blurry footage, low resolution, artifacts, unwanted objects,
+inconsistent character appearance, audio sync issues, amateur quality,
+distorted hands, oversaturation, compression noise, camera shake
+```
+
+**Domain-specific additions**:
+- Corporate: `no casual attire, no distracting backgrounds, no poor posture`
+- Educational: `no overly dramatic presentation, no artificial staging`
+- Social media: `no outdated trends, no poor mobile optimisation`
+
+### Physics-Aware Prompting
+
+Include physics keywords for realistic movement:
+
+```text
+"realistic physics governing all actions"
+"natural fluid dynamics"
+"authentic momentum conservation"
+"proper weight and balance"
+```
+
+**Movement quality modifiers**: `natural movement`, `energetic movement`, `slow and deliberate`, `graceful`, `confident`, `fluid`.
+
+### Selfie Video Formula
+
+```text
+A selfie video of [CHARACTER]. [He/She] holds the camera at arm's length.
+[His/Her] [arm] is clearly visible in the frame. [He/She] occasionally
+looks into the camera before [ACTION]. The image is slightly grainy,
+looks very film-like. [He/She] says: "[DIALOGUE_8S_MAX]"
+```
+
+### Quality Tiers
+
+| Tier | Components | Automation |
+|------|-----------|------------|
+| Advanced | All 7 + physics + meta prompt | Full |
+| Professional | 6-7 with detail | Partial |
+| Intermediate | 4-6 basic | Minimal |
+| Basic | 1-3 (poor results) | None |
+
+### Domain Templates
+
+**Corporate**: Executive presence, brand compliance, three-point lighting, authoritative framing, business formal attire, corporate environments.
+
+**Educational**: Visual-auditory sync, cognitive load management, clear progression, multi-sensory engagement, retention-focused design.
+
+**Social media**: Hook within 2 seconds, emotional engagement, platform-specific formatting, viral mechanics, demographic targeting.
+
+### Meta Prompt Generation
+
+When generating meta prompts (prompts that generate prompts), follow this cognitive architecture:
+
+1. **Identity layer**: Define role and expertise
+2. **Knowledge layer**: Technical specs and best practices
+3. **Analysis layer**: Parse requirements and optimise
+4. **Generation layer**: Apply 7-component format
+5. **Quality layer**: Validate against checklist
+6. **Output layer**: Structured response with alternatives
+
+### Success Metrics
+
+| Metric | Target |
+|--------|--------|
+| Generation success rate | >95% |
+| Character consistency | >98% |
+| Audio-visual sync | >97% |
+| Brand compliance | 100% |
+
+### Veo 3 Limitations
+
+- Maximum 8 seconds per generation
+- Complex multi-character scenes reduce consistency
+- Rapid camera movements cause motion blur
+- Background audio hallucinations without explicit specification
+- Text/subtitles appear unless negated
+- Hand/finger details need careful negative prompting
+- 16:9 landscape is the primary supported aspect ratio

--- a/.agent/tools/video/video-prompt-design.md
+++ b/.agent/tools/video/video-prompt-design.md
@@ -141,23 +141,15 @@ inconsistent character appearance, audio sync issues, amateur quality,
 distorted hands, oversaturation, compression noise, camera shake
 ```
 
-**Domain-specific additions**:
-- Corporate: `no casual attire, no distracting backgrounds, no poor posture`
-- Educational: `no overly dramatic presentation, no artificial staging`
-- Social media: `no outdated trends, no poor mobile optimisation`
+### Movement and Physics
 
-### Physics-Aware Prompting
+**Movement quality modifiers** (add to Action component):
 
-Include physics keywords for realistic movement:
+`natural movement`, `energetic movement`, `slow and deliberate`, `graceful`, `confident`, `fluid`
 
-```text
-"realistic physics governing all actions"
-"natural fluid dynamics"
-"authentic momentum conservation"
-"proper weight and balance"
-```
+**Physics keywords** (for realistic results):
 
-**Movement quality modifiers**: `natural movement`, `energetic movement`, `slow and deliberate`, `graceful`, `confident`, `fluid`.
+`realistic physics governing all actions`, `proper weight and balance`, `natural fluid dynamics`
 
 ### Selfie Video Formula
 
@@ -167,43 +159,6 @@ A selfie video of [CHARACTER]. [He/She] holds the camera at arm's length.
 looks into the camera before [ACTION]. The image is slightly grainy,
 looks very film-like. [He/She] says: "[DIALOGUE_8S_MAX]"
 ```
-
-### Quality Tiers
-
-| Tier | Components | Automation |
-|------|-----------|------------|
-| Advanced | All 7 + physics + meta prompt | Full |
-| Professional | 6-7 with detail | Partial |
-| Intermediate | 4-6 basic | Minimal |
-| Basic | 1-3 (poor results) | None |
-
-### Domain Templates
-
-**Corporate**: Executive presence, brand compliance, three-point lighting, authoritative framing, business formal attire, corporate environments.
-
-**Educational**: Visual-auditory sync, cognitive load management, clear progression, multi-sensory engagement, retention-focused design.
-
-**Social media**: Hook within 2 seconds, emotional engagement, platform-specific formatting, viral mechanics, demographic targeting.
-
-### Meta Prompt Generation
-
-When generating meta prompts (prompts that generate prompts), follow this cognitive architecture:
-
-1. **Identity layer**: Define role and expertise
-2. **Knowledge layer**: Technical specs and best practices
-3. **Analysis layer**: Parse requirements and optimise
-4. **Generation layer**: Apply 7-component format
-5. **Quality layer**: Validate against checklist
-6. **Output layer**: Structured response with alternatives
-
-### Success Metrics
-
-| Metric | Target |
-|--------|--------|
-| Generation success rate | >95% |
-| Character consistency | >98% |
-| Audio-visual sync | >97% |
-| Brand compliance | 100% |
 
 ### Veo 3 Limitations
 

--- a/.agent/tools/video/video-prompt-design.md
+++ b/.agent/tools/video/video-prompt-design.md
@@ -4,8 +4,8 @@ mode: subagent
 upstream_url: https://github.com/snubroot/Veo-3-Meta-Framework
 tools:
   read: true
-  write: true
-  edit: true
+  write: false
+  edit: false
   bash: false
   glob: true
   grep: true
@@ -33,7 +33,7 @@ Subject:   [Character with 15+ physical attributes]
 Action:    [Movements, gestures, timing, micro-expressions]
 Scene:     [Environment, props, lighting, weather, time of day]
 Style:     [Camera shot, angle, movement, colour palette, depth of field]
-Dialogue:  [Character]: "Speech" (Tone: descriptor)
+Dialogue:  (Character Name): "Speech" (Tone: descriptor)
 Sounds:    [Ambient, effects, music, environmental audio]
 Technical: [Negative prompt - elements to exclude]
 ```

--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@ aidevops includes curated skills imported from external repositories. Skills fro
 |-------|--------|-------------|
 | **cloudflare-platform** | [dmmulroy/cloudflare-skill](https://github.com/dmmulroy/cloudflare-skill) | 60 Cloudflare products: Workers, Pages, D1, R2, KV, Durable Objects, AI, networking, security |
 | **remotion** | [remotion-dev/skills](https://github.com/remotion-dev/skills) | Programmatic video creation with React, animations, rendering |
+| **video-prompt-design** | [snubroot/Veo-3-Meta-Framework](https://github.com/snubroot/Veo-3-Meta-Framework) | AI video prompt engineering - 7-component meta prompt framework for Veo 3 |
 | **animejs** | [animejs.com](https://animejs.com) | JavaScript animation library patterns and API (via Context7) |
 
 **CLI Commands:**
@@ -562,6 +563,7 @@ The setup script offers to install these tools automatically.
 ### **Video Creation**
 
 - **[Remotion](https://remotion.dev/)**: Programmatic video creation with React - animations, compositions, media handling, captions
+- **[Video Prompt Design](https://github.com/snubroot/Veo-3-Meta-Framework)**: AI video prompt engineering using the 7-component meta prompt framework for Veo 3 and similar models
 
 ### **WordPress Development**
 
@@ -602,6 +604,7 @@ The setup script offers to install these tools automatically.
 
 - **[Anime.js](https://animejs.com/)**: Lightweight JavaScript animation library for CSS, SVG, DOM attributes, and JS objects
 - **[Remotion](https://remotion.dev/)**: Programmatic video creation with React - create videos using code with 29 specialized rule files
+- **[Video Prompt Design](https://github.com/snubroot/Veo-3-Meta-Framework)**: Structured prompt engineering for AI video generation (Veo 3, 7-component framework, character consistency, audio design)
 
 ### **Performance & Monitoring**
 


### PR DESCRIPTION
## Summary

- Adds `video-prompt-design` subagent to `tools/video/` based on the [Veo 3 Meta Framework](https://github.com/snubroot/Veo-3-Meta-Framework)
- Provides structured 7-component prompt engineering for AI video generation (Subject, Action, Scene, Style, Dialogue, Sounds, Technical)
- Follows build-agent best practices: YAML frontmatter, AI-CONTEXT block, progressive disclosure, under 100 instructions

## Changes

- **New**: `.agent/tools/video/video-prompt-design.md` - Complete subagent with character consistency templates, camera positioning syntax, audio hallucination prevention, domain-specific templates, and Veo 3 limitations
- **Updated**: `.agent/AGENTS.md` - Added to subagent folder table and progressive disclosure section
- **Updated**: `README.md` - Added to imported skills table, Video Creation section, and Animation & Video section

## Design Decisions

- Kept model-agnostic where possible (techniques apply to Veo 3, Sora, Kling, etc.)
- Used `upstream_url` in frontmatter to track source repo
- Enabled `webfetch: true` for fetching latest model documentation
- All code blocks use `text` language specifier (no bare fences)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Video Prompt Design documentation with structured 7-component guidance for AI video generation, examples, and checklists.
  * New Video Prompt Design entry added across tools lists, README sections, and CLI/help references for video creation.
  * Registered Video Prompt Design as a new skill source so it appears in the imported skills catalog.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->