### PR TITLE
feat: add Video main agent for AI video generation and prompt engineering

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -148,6 +148,7 @@ See `subagent-index.toon` for complete listing of agents, subagents, workflows, 
 | Browser | `tools/browser/stagehand.md` or `tools/browser/playwright.md` |
 | WordPress | `tools/wordpress/wp-dev.md`, `tools/wordpress/mainwp.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |
+| Video | `tools/video/video-prompt-design.md`, `tools/video/remotion.md`, `tools/video/higgsfield.md` |
 | MCP dev | `tools/build-mcp/build-mcp.md` |
 | Agent design | `tools/build-agent/build-agent.md` |
 | Framework | `aidevops/architecture.md` |

--- a/.agent/video.md
+++ b/.agent/video.md
@@ -1,0 +1,83 @@
+---
+name: video
+description: Video creation and AI generation - prompt engineering, programmatic video, generative models, editing workflows
+mode: subagent
+subagents:
+  # Video tools
+  - video-prompt-design
+  - remotion
+  - higgsfield
+  # Content integration
+  - guidelines
+  - summarize
+  # Research
+  - context7
+  - crawl4ai
+  # Built-in
+  - general
+  - explore
+---
+
+# Video - Main Agent
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: AI video generation and programmatic video creation
+- **Subagents**: `tools/video/` (prompt design, Remotion, Higgsfield)
+
+**Capabilities**:
+- AI video prompt engineering (Veo 3, Sora, Kling, Seedance)
+- Programmatic video creation with React (Remotion)
+- Multi-model AI generation via unified API (Higgsfield)
+- Character consistency across video series
+- Audio design and hallucination prevention
+
+**Typical Tasks**:
+- Craft structured prompts for AI video generation
+- Build programmatic video pipelines
+- Generate consistent character series
+- Design camera work, dialogue, and audio
+- Compare and select AI video models
+
+<!-- AI-CONTEXT-END -->
+
+## Subagent Reference
+
+| Subagent | Purpose |
+|----------|---------|
+| `video-prompt-design` | 7-component meta prompt framework for Veo 3 and similar models |
+| `remotion` | Programmatic video creation with React - animations, compositions, rendering |
+| `higgsfield` | Unified API for 100+ generative media models (image, video, voice, audio) |
+
+## Workflows
+
+### AI Video Prompt Engineering
+
+1. Define character with 15+ attributes for consistency
+2. Structure prompt using 7 components (Subject, Action, Scene, Style, Dialogue, Sounds, Technical)
+3. Include camera positioning syntax and negative prompts
+4. Specify environment audio explicitly to prevent hallucinations
+5. Keep dialogue to 12-15 words for 8-second generations
+
+### Programmatic Video (Remotion)
+
+1. Define compositions with `useCurrentFrame()` and `useVideoConfig()`
+2. Drive all animations via `interpolate()` or `spring()`
+3. Use `<Sequence>` for time-offset content
+4. Render via CLI or Lambda for production
+
+### AI Generation Pipeline (Higgsfield)
+
+1. Generate base image with text-to-image (Soul, FLUX)
+2. Create character for consistency across generations
+3. Convert to video with image-to-video (DOP, Kling, Seedance)
+4. Poll for completion via webhooks or status API
+
+## Integration Points
+
+- `content.md` - Script writing and content planning
+- `social-media.md` - Platform-specific video formatting
+- `marketing.md` - Campaign video production
+- `seo.md` - Video SEO (titles, descriptions, thumbnails)

--- a/README.md
+++ b/README.md
@@ -1033,7 +1033,7 @@ Call them in your AI assistant conversation with a simple @mention
 
 ### **Main Agents**
 
-Ordered as they appear in OpenCode Tab selector and other AI assistants (14 total):
+Ordered as they appear in OpenCode Tab selector and other AI assistants (15 total):
 
 | Name | File | Purpose | MCPs Enabled |
 |------|------|---------|--------------|
@@ -1050,6 +1050,7 @@ Ordered as they appear in OpenCode Tab selector and other AI assistants (14 tota
 | Research | `research.md` | Research and analysis tasks | context7, augment |
 | Sales | `sales.md` | Sales operations and CRM | augment |
 | SEO | `seo.md` | SEO optimization, Search Console, keyword research | gsc, ahrefs, dataforseo, serper, context7, augment |
+| Video | `video.md` | AI video generation, prompt engineering, programmatic video | augment |
 | WordPress | `wordpress.md` | WordPress ecosystem (dev, admin, MainWP, LocalWP) | localwp, context7, augment |
 
 ### **Example Subagents with MCP Integration**


### PR DESCRIPTION
## Summary

- Adds `video.md` as a new primary agent (Tab-switchable in OpenCode)
- Owns the `tools/video/` subagents: video-prompt-design, remotion, higgsfield
- Auto-discovered alphabetically by `generate-opencode-agents.sh` on next `setup.sh` run

## Changes

- **New**: `.agent/video.md` - Primary agent with subagent frontmatter, workflows, integration points
- **Updated**: `.agent/AGENTS.md` - Added Video to progressive disclosure table
- **Updated**: `README.md` - Added to primary agents table (15 total), alphabetical between SEO and WordPress

## Architecture

- Uses `DEFAULT_TOOLS` from generate-opencode-agents.sh (write, edit, bash, read, glob, grep, webfetch, task, osgrep, augment)
- No custom MCP tools needed (guidance/prompt-crafting agent)
- Subagents declared in frontmatter for OpenCode filtering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Video agent to the main agents list.

* **Documentation**
  * Created comprehensive Video agent specifications and workflow documentation.
  * Updated main agent registry and summary tables to include the Video agent.
  * Updated main agent count from 14 to 15.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->