### PR TITLE
fix: replace bc version comparison with integer arithmetic in crawl4ai-helper

### DIFF
--- a/.agent/scripts/crawl4ai-helper.sh
+++ b/.agent/scripts/crawl4ai-helper.sh
@@ -105,10 +105,12 @@ check_python() {
         return 1
     fi
     
-    local python_version
+    local python_version python_major python_minor
     python_version=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+    python_major=$(python3 -c "import sys; print(sys.version_info.major)")
+    python_minor=$(python3 -c "import sys; print(sys.version_info.minor)")
     
-    if [[ $(echo "$python_version < 3.8" | bc -l) -eq 1 ]]; then
+    if [[ "$python_major" -lt 3 ]] || { [[ "$python_major" -eq 3 ]] && [[ "$python_minor" -lt 8 ]]; }; then
         print_error "Python 3.8+ is required. Current version: $python_version"
         return 1
     fi

--- a/.agent/scripts/crawl4ai-helper.sh
+++ b/.agent/scripts/crawl4ai-helper.sh
@@ -107,8 +107,8 @@ check_python() {
     
     local python_version python_major python_minor
     python_version=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-    python_major=$(python3 -c "import sys; print(sys.version_info.major)")
-    python_minor=$(python3 -c "import sys; print(sys.version_info.minor)")
+    python_major=${python_version%.*}
+    python_minor=${python_version#*.}
     
     if [[ "$python_major" -lt 3 ]] || { [[ "$python_major" -eq 3 ]] && [[ "$python_minor" -lt 8 ]]; }; then
         print_error "Python 3.8+ is required. Current version: $python_version"


### PR DESCRIPTION
## Summary

- Fixes version check bug where Python 3.14+ would be incorrectly rejected (bc treats `3.14 < 3.8` as true since `3.14 < 3.80` numerically)
- Replaces `bc -l` float comparison with integer major/minor comparison
- Removes `bc` as an implicit dependency

## Changes

`crawl4ai-helper.sh:check_python()` — compare `python_major`/`python_minor` integers instead of piping version string to `bc`.