### PR TITLE
docs: add worktree path re-read instruction

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -117,6 +117,8 @@ wt switch -c feature/my-feature   # Worktrunk (preferred)
 worktree-helper.sh add feature/x  # Fallback
 ```
 
+**After switching to a worktree**: Re-read any file at its worktree path before editing. The Edit tool tracks reads by exact absolute path — a read from the main repo path does NOT satisfy the worktree path.
+
 **After completing changes**, offer: 1) Preflight checks 2) Skip preflight 3) Continue editing
 
 **Branch types**: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`


### PR DESCRIPTION
## Summary

- Adds one-line instruction after worktree commands in AGENTS.md
- Prevents the "must read file before editing" error when switching from main repo to worktree path
- The Edit tool tracks reads by exact absolute path — reading `~/Git/repo/file` doesn't satisfy `~/Git/repo.branch/file`