### PR TITLE
fix: add remote sync verification to release script and tag rollback

### DIFF
--- a/.agent/scripts/full-loop-helper.sh
+++ b/.agent/scripts/full-loop-helper.sh
@@ -223,7 +223,18 @@ is_on_feature_branch() {
 run_task_phase() {
     local prompt="$1"
     local max_iterations="${MAX_TASK_ITERATIONS:-$DEFAULT_MAX_TASK_ITERATIONS}"
-    local tool="${RALPH_TOOL:-opencode}"
+    
+    # Auto-detect AI tool environment if RALPH_TOOL not explicitly set
+    local tool="${RALPH_TOOL:-}"
+    if [[ -z "$tool" ]]; then
+        if [[ -n "${CLAUDE_CODE:-}" ]] || command -v claude &>/dev/null; then
+            tool="claude"
+        elif command -v opencode &>/dev/null; then
+            tool="opencode"
+        else
+            tool="opencode"  # Default fallback name (will trigger legacy mode)
+        fi
+    fi
     
     print_phase "Task Development" "Running Ralph loop for task implementation"
     
@@ -247,8 +258,8 @@ run_task_phase() {
             --max-iterations "$max_iterations" \
             --completion-promise "TASK_COMPLETE"
     else
-        # Legacy: Same-session loop
-        print_warning "Using legacy mode (same session). Consider installing $tool for v2."
+        # Legacy: Same-session loop (tool not available or no v2 infrastructure)
+        print_warning "Using legacy mode (same session). $tool CLI not found for v2 external loop."
         "$SCRIPT_DIR/ralph-loop-helper.sh" setup "$prompt" \
             --max-iterations "$max_iterations" \
             --completion-promise "TASK_COMPLETE"


### PR DESCRIPTION
## Summary

- Add `verify_remote_sync()` to prevent release failures after squash merges
- Add tag rollback if push fails (prevents inconsistent local/remote state)
- Add AI tool auto-detection to `full-loop-helper.sh`

## Problem

After squash-merging a PR via GitHub, the local `main` branch diverges from `origin/main` (local has original commits, remote has squashed commit). Running `version-manager.sh release` would:
1. Create a local tag successfully
2. Fail to push (non-fast-forward)
3. Leave an inconsistent state (local tag exists, remote doesn't)

## Solution

### version-manager.sh
1. **New `verify_remote_sync()` function**: Fetches remote and compares SHA before releasing. Fails early with clear instructions if diverged.
2. **Tag rollback on push failure**: If `push_changes` fails, the local tag is deleted and the user gets actionable instructions.
3. **Bypassable with `--force`**: For edge cases where divergence is intentional.

### full-loop-helper.sh
4. **AI tool auto-detection**: Checks for `CLAUDE_CODE` env var or `claude` binary before defaulting to `opencode`. Prevents misleading "Consider installing opencode" warnings in Claude Code sessions.

## Testing

- [x] ShellCheck passes (no errors)
- [x] Follows existing code patterns (`local var`, explicit returns)
- [x] Graceful degradation (warns but proceeds if fetch fails)