### PR TITLE
fix: add Homebrew PATH detection early in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -413,6 +413,16 @@ install_packages() {
 check_requirements() {
     print_info "Checking system requirements..."
     
+    # Ensure Homebrew is in PATH (macOS Apple Silicon)
+    if [[ -x "/opt/homebrew/bin/brew" ]] && ! echo "$PATH" | grep -q "/opt/homebrew/bin"; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+        print_warning "Homebrew not in PATH - added for this session"
+        echo ""
+        echo "  To fix permanently, add to ~/.bash_profile or ~/.zshrc:"
+        echo "    eval \"\$(/opt/homebrew/bin/brew shellenv)\""
+        echo ""
+    fi
+    
     local missing_deps=()
     
     # Check for required commands


### PR DESCRIPTION
## Summary

- Detects missing Homebrew PATH at the start of `check_requirements()` and adds it for the session
- Ensures all subsequent `command -v` calls find Homebrew tools (fd, rg, node, bun, python3, etc.)
- Advises user on the permanent fix (`eval "$(brew shellenv)"` in shell profile)
- Complements the `find_python3()` helper from PR #167 — this fixes the root cause for all tools