### PR TITLE
fix: auto-install fd and ripgrep in non-interactive mode

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -638,7 +638,10 @@ setup_file_discovery_tools() {
         pkg_manager=$(detect_package_manager)
         
         if [[ "$pkg_manager" != "unknown" ]]; then
-            read -r -p "Install file discovery tools (${missing_packages[*]}) using $pkg_manager? (y/n): " install_fd_tools
+            local install_fd_tools="y"
+            if [[ "$INTERACTIVE_MODE" == "true" ]]; then
+                read -r -p "Install file discovery tools (${missing_packages[*]}) using $pkg_manager? (y/n): " install_fd_tools
+            fi
             
             if [[ "$install_fd_tools" == "y" ]]; then
                 print_info "Installing ${missing_packages[*]}..."


### PR DESCRIPTION
## Summary

- In non-interactive mode, auto-install fd and ripgrep instead of skipping
- Interactive mode still prompts y/n as before
- These tools are required by the framework for efficient file discovery