### PR TITLE
docs: add MCP lifecycle pattern and fix GSC/identity docs

### DIFF
--- a/.agent/prompts/build.txt
+++ b/.agent/prompts/build.txt
@@ -1,7 +1,10 @@
 # Upstream base: anomalyco/opencode anthropic.txt @ 3c41e4e8f12b
 # Overrides: file discovery, code search, git workflow, security, agent framework
-# Note: "OpenCode" references are intentional - the opencode-anthropic-auth plugin
-# transforms these to "Claude Code" for Anthropic OAuth users automatically.
+#
+# INTENTIONAL DESIGN: "OpenCode" identity below is rewritten to "Claude Code" at runtime
+# by the opencode-anthropic-auth plugin. This is a FEATURE not a bug - it enables the
+# same prompt to work across both OpenCode (native) and Anthropic OAuth (Claude Code)
+# authentication paths. Do not "fix" the identity references.
 
 You are OpenCode, the best coding agent on the planet.
 

--- a/.agent/seo/google-search-console.md
+++ b/.agent/seo/google-search-console.md
@@ -1,5 +1,5 @@
 ---
-description: Google Search Console via REST API (no MCP needed)
+description: Google Search Console via MCP (gsc_* tools) with curl fallback
 mode: subagent
 tools:
   read: true
@@ -16,12 +16,13 @@ tools:
 
 ## Quick Reference
 
+- **Primary access**: MCP tools (`gsc_*`) - enabled for SEO agent
+- **Fallback**: curl with OAuth2 token from service account
 - **API**: REST at `https://searchconsole.googleapis.com/v1/`
 - **Auth**: Service account JSON at `~/.config/aidevops/gsc-credentials.json`
 - **Capabilities**: Search analytics, URL inspection, indexing requests, sitemap management
 - **Metrics**: clicks, impressions, ctr, position
 - **Dimensions**: query, page, country, device, searchAppearance
-- **No MCP required** - uses curl with OAuth2 token from service account
 
 ## Setup Steps
 
@@ -47,9 +48,51 @@ The service account email (e.g., `aidevops@project-id.iam.gserviceaccount.com`) 
 ### 3. Verify Access
 
 ```bash
-# Test GSC MCP connection
-opencode mcp list | grep -i search
+# Verify credentials file
+python3 -c "import json; d=json.load(open('$HOME/.config/aidevops/gsc-credentials.json')); print(f'Service account: {d[\"client_email\"]}')"
 ```
+
+## Direct API Access (curl fallback)
+
+When the MCP is unavailable, use curl with OAuth2 token exchange:
+
+```bash
+# Get OAuth2 access token from service account
+ACCESS_TOKEN=$(python3 -c "
+import json, time, jwt, requests
+creds = json.load(open('$HOME/.config/aidevops/gsc-credentials.json'))
+now = int(time.time())
+payload = {'iss': creds['client_email'], 'scope': 'https://www.googleapis.com/auth/webmasters.readonly',
+           'aud': creds['token_uri'], 'iat': now, 'exp': now + 3600}
+signed = jwt.encode(payload, creds['private_key'], algorithm='RS256')
+r = requests.post(creds['token_uri'], data={'grant_type': 'urn:ietf:params:oauth:grant-type:jwt-bearer', 'assertion': signed})
+print(r.json()['access_token'])
+")
+
+# List sites
+curl -s "https://searchconsole.googleapis.com/v1/sites" \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+
+# Search analytics query
+curl -s -X POST "https://searchconsole.googleapis.com/v1/sites/https%3A%2F%2Fexample.com/searchAnalytics/query" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "startDate": "2025-01-01",
+    "endDate": "2025-01-20",
+    "dimensions": ["query", "page"],
+    "rowLimit": 25
+  }'
+
+# Submit URL for indexing
+curl -s -X POST "https://searchconsole.googleapis.com/v1/urlInspection/index:inspect" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"inspectionUrl": "https://example.com/page", "siteUrl": "https://example.com"}'
+```
+
+**Requirements for curl fallback**: `pip install PyJWT requests`
+
 <!-- AI-CONTEXT-END -->
 
 ## Automated Bulk Setup with Playwright


### PR DESCRIPTION
## Summary

- Document the MCP lifecycle decision framework established during the MCP audit session
- Fix GSC subagent to reflect its actual usage (MCP primary, curl fallback)
- Clarify the OpenCode→Claude Code identity rewrite is intentional design

## Changes

| File | Change |
|------|--------|
| `.agent/aidevops/architecture.md` | Add MCP lifecycle pattern section with decision table and three-tier strategy |
| `.agent/seo/google-search-console.md` | Add curl OAuth2 fallback, update description to MCP-primary |
| `.agent/prompts/build.txt` | Expand identity rewrite comment to prevent future "fixes" |

## MCP Lifecycle Pattern (new)

Three-tier strategy:
1. **Globally enabled** (always loaded): osgrep, augment-context-engine, claude-code-mcp
2. **Enabled, tools disabled** (zero context until agent invokes): gsc, outscraper, etc.
3. **Replaced by curl subagent** (removed entirely): hetzner, serper, dataforseo, etc.

Decision factors: tool count, auth complexity, session frequency, context cost, statefulness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Google Search Console docs with MCP-first workflow, detailed direct API (curl) fallback, OAuth2 guidance, Playwright automation, troubleshooting, and richer SEO analytics examples.
  * Added architecture guidance describing tiered MCP lifecycle, tool gating patterns, and example configuration patterns.
  * Clarified agent identity messaging to support cross-platform prompt usage.

* **Chores**
  * Setup flow now includes a cleanup step for deprecated MCP entries and auto-detection to enable SEO/Analytics integrations when credentials are present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->