### PR TITLE
chore: position OpenCode as recommended tool, add LSP config and TOON validation

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -5,6 +5,8 @@ mode: subagent
 
 **New to aidevops?** Type `/onboarding` to get started with an interactive setup wizard.
 
+**Recommended tool:** [OpenCode](https://opencode.ai/) is the recommended and primary-tested AI coding agent for aidevops. All features, agents, slash commands, and workflows are designed and tested for OpenCode first. Other AI assistants are supported as a courtesy for users evaluating aidevops capabilities.
+
 ## MANDATORY: Pre-Edit Git Check
 
 > **Skip if you don't have Edit/Write/Bash tools** (e.g., Plan+ agent).

--- a/.agent/aidevops/architecture.md
+++ b/.agent/aidevops/architecture.md
@@ -39,6 +39,17 @@ tools:
 
 This file provides comprehensive context for AI assistants to understand, manage, and extend the AI DevOps Framework.
 
+## Preferred Tool
+
+**[OpenCode](https://opencode.ai/)** is the recommended and primary-tested AI coding agent for aidevops. All features, agents, workflows, LSP configurations, and MCP integrations are designed and tested for OpenCode first. Other AI assistants (Cursor, Claude Code, Zed, etc.) are supported as a courtesy for users evaluating aidevops capabilities, but may not receive the same level of testing or integration depth.
+
+Key OpenCode integrations:
+- **Agents**: Generated via `generate-opencode-agents.sh` with per-agent MCP tool filtering
+- **Commands**: 41 slash commands deployed to `~/.config/opencode/commands/`
+- **Plugins**: Compaction plugin at `.agent/plugins/opencode-aidevops/`
+- **LSP**: Built-in support for 35+ languages, extensible via `opencode.json` for Markdown and TOON
+- **Prompts**: Custom system prompt at `.agent/prompts/build.txt`
+
 ## Agent Design Patterns
 
 aidevops implements proven agent design patterns identified by Lance Martin (LangChain) and validated across successful agents like Claude Code, Manus, and Cursor. These patterns optimize for context efficiency and long-running autonomous operation.

--- a/.agent/onboarding.md
+++ b/.agent/onboarding.md
@@ -53,7 +53,11 @@ Would you like me to explain what aidevops can help you with? (yes/no)
 If yes, provide a brief overview:
 
 ```text
-aidevops gives your AI assistant superpowers for DevOps and infrastructure management:
+aidevops gives your AI assistant superpowers for DevOps and infrastructure management.
+
+**Recommended tool:** You should be running this in [OpenCode](https://opencode.ai/) - the recommended AI coding agent for aidevops. All features, agents, and workflows are designed and tested for OpenCode first. If you're using a different tool, most features will still work, but OpenCode provides the best experience.
+
+**Capabilities:**
 
 - **Infrastructure**: Manage servers across Hetzner, Hostinger, Cloudron, Coolify
 - **Domains & DNS**: Purchase domains, manage DNS via Cloudflare, Spaceship, 101domains

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ git clone https://github.com/marcusquinn/aidevops.git ~/Git/aidevops
 - Configure your AI assistants automatically
 - Guide you through recommended tools (Tabby, Zed, Git CLIs)
 
-**New users: Start OpenCode and type `/onboarding`** to configure your services interactively. The onboarding wizard will:
+**New users: Start [OpenCode](https://opencode.ai/) and type `/onboarding`** to configure your services interactively. OpenCode is the recommended tool for aidevops - all features, agents, and workflows are designed and tested for it first. The onboarding wizard will:
 - Explain what **[aidevops](https://aidevops.sh)** can do
 - Ask about your work to give personalized recommendations
 - Show which services are configured vs need setup
@@ -374,13 +374,13 @@ The secure workflow is included at `.github/workflows/opencode-agent.yml`.
 
 See `.agent/tools/git/opencode-github-security.md` for the full security documentation.
 
-**Supported AI Assistants:** (OpenCode & Zed are our daily drivers and preferred tools, so will have the most continual testing. All 18 assistants below have MCP configuration support.)
+**Supported AI Assistants:** OpenCode is the recommended and primary-tested tool. All 18 assistants below have MCP configuration support, but only OpenCode receives continual testing and first-class integration. Other tools are supported as a courtesy for users evaluating aidevops capabilities.
 
-**Preferred:**
+**Recommended:**
 
-- **[Tabby](https://tabby.sh/)** - Modern terminal with colour-coded Profiles. Use different profile colours per project/repo to visually distinguish which codebase you're working in. **Auto-syncs tab title with git repo/branch.**
-- **[OpenCode](https://opencode.ai/)** - Primary choice. Powerful agentic TUI/CLI with native MCP support, Tab-based agent switching, and excellent DX.
-- **[Zed](https://zed.dev/)** - High-performance editor with AI (Preferred, with the OpenCode Agent Extension)
+- **[OpenCode](https://opencode.ai/)** - The recommended AI coding agent. Powerful agentic TUI/CLI with native MCP support, Tab-based agent switching, LSP integration, plugin ecosystem, and excellent DX. All aidevops features are designed and tested for OpenCode first.
+- **[Tabby](https://tabby.sh/)** - Recommended terminal. Colour-coded Profiles per project/repo, **auto-syncs tab title with git repo/branch.**
+- **[Zed](https://zed.dev/)** - Recommended editor. High-performance with AI integration (use with the OpenCode Agent Extension).
 
 ### Terminal Tab Title Sync
 
@@ -393,6 +393,8 @@ Your terminal tab/window title automatically shows `repo/branch` context when wo
 **Example format:** `{repo}/{branch-type}/{description}`
 
 See `.agent/tools/terminal/terminal-title.md` for customization options.
+
+**Also Supported (community-tested):**
 
 **IDE-Based:**
 
@@ -663,7 +665,7 @@ The setup script offers to install these tools automatically.
 
 ## **MCP Integrations**
 
-**Model Context Protocol servers for real-time AI assistant integration.** The framework helps configure these MCPs for **18 AI assistants** including OpenCode (preferred), Cursor, Claude Code/Desktop, Windsurf, Continue.dev, Cody, Zed, GitHub Copilot, Kilo Code, Kiro, AntiGravity, Gemini CLI, Droid, Warp AI, Aider, and Qwen.
+**Model Context Protocol servers for real-time AI assistant integration.** The framework configures these MCPs primarily for **[OpenCode](https://opencode.ai/)** (recommended). Configuration support is also available for 17 other AI assistants including Cursor, Claude Code/Desktop, Windsurf, Continue.dev, Cody, Zed, GitHub Copilot, Kilo Code, Kiro, AntiGravity, Gemini CLI, Droid, Warp AI, Aider, and Qwen.
 
 ### **All Supported MCPs**
 
@@ -755,6 +757,34 @@ bash .agent/scripts/setup-mcp-integrations.sh stagehand-python   # Python versio
 bash .agent/scripts/setup-mcp-integrations.sh stagehand-both     # Both versions
 bash .agent/scripts/setup-mcp-integrations.sh chrome-devtools
 ```
+
+### OpenCode LSP Configuration
+
+OpenCode includes [built-in LSP servers](https://opencode.ai/docs/lsp/) for 35+ languages. For aidevops projects that use Markdown and TOON extensively, add these optional LSP servers to your `opencode.json` for real-time diagnostics during editing:
+
+```json
+{
+  "lsp": {
+    "markdownlint": {
+      "command": ["markdownlint-language-server", "--stdio"],
+      "extensions": [".md"]
+    },
+    "toon-lsp": {
+      "command": ["toon-lsp"],
+      "extensions": [".toon"]
+    }
+  }
+}
+```
+
+**Install the servers:**
+
+```bash
+npm install -g markdownlint-language-server  # Markdown diagnostics
+cargo install toon-lsp                        # TOON syntax validation
+```
+
+These catch formatting and syntax issues during editing, reducing preflight/postflight fix cycles.
 
 ## **Browser Automation**
 

--- a/TODO.md
+++ b/TODO.md
@@ -65,6 +65,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 - [ ] t008 aidevops-opencode Plugin #plan → [todo/PLANS.md#aidevops-opencode-plugin] ~2d (ai:1d test:0.5d read:0.5d) logged:2025-12-21
 - [ ] t004 Add Ahrefs MCP server integration #seo ~2d (ai:1d test:0.5d read:0.5d) logged:2025-12-20
 - [ ] t005 Implement multi-tenant credential storage #security ~5d (ai:3d test:1.5d read:0.5d) logged:2025-12-20
+- [ ] t069 Fix toon-helper.sh validate command - positional args not passed to case statement #bugfix ~1h (ai:30m test:30m) logged:2026-01-24
 - [x] t006 Add Playwright MCP auto-setup to setup.sh #browser ~1d actual:15m (ai:0.5d test:0.5d) logged:2025-12-20 started:2026-01-22T01:30Z completed:2026-01-22
   - Notes: Added Playwright MCP installation to setup_browser_tools() in setup.sh. Checks for existing installation, prompts user, installs browsers (chromium, firefox, webkit) via `npx playwright install`.
 - [ ] t007 Create MCP server for QuickFile accounting API #accounting ~3d (ai:2d test:1d) logged:2025-12-20


### PR DESCRIPTION
## Summary

- Position OpenCode as the explicitly recommended and primary-tested AI coding agent across all key documentation (README, architecture, AGENTS.md, onboarding)
- Add OpenCode LSP configuration section with `markdownlint-language-server` and `toon-lsp` for real-time diagnostics during editing, reducing preflight/postflight fix cycles
- Add `check_toon_syntax` to `linters-local.sh` for `.toon` file validation in preflight checks
- Reframe other AI assistants (Cursor, Claude Code, etc.) as "supported as a courtesy for users evaluating aidevops capabilities"

## Files Changed

| File | Change |
|------|--------|
| `README.md` | OpenCode as recommended, LSP config section, MCP wording update |
| `.agent/aidevops/architecture.md` | New "Preferred Tool" section |
| `.agent/AGENTS.md` | Recommended tool notice at top |
| `.agent/onboarding.md` | OpenCode recommendation in welcome flow |
| `.agent/scripts/linters-local.sh` | New `check_toon_syntax` function |

## Context

User identified that 99% of usage is OpenCode, and docs should reflect this rather than maintaining tool-neutral positioning. Also adds LSP servers (markdownlint + toon-lsp) as optional OpenCode config to catch issues during editing rather than at preflight time.