### PR TITLE
perf: install MCP packages globally for instant startup

### DIFF
--- a/.agent/scripts/tool-version-check.sh
+++ b/.agent/scripts/tool-version-check.sh
@@ -73,12 +73,17 @@ done
 NPM_TOOLS=(
     "npm|osgrep|osgrep|--version|osgrep|npm update -g osgrep"
     "npm|Augment CLI|auggie|--version|@augmentcode/auggie@prerelease|npm update -g @augmentcode/auggie@prerelease"
-    "npm|Repomix|repomix|--version|repomix|npm update -g repomix"
+    "npm|Repomix|repomix|--version|repomix|bun install -g repomix@latest"
     "npm|DSPyGround|dspyground|--version|dspyground|npm update -g dspyground"
     "npm|LocalWP MCP|mcp-local-wp|--version|@verygoodplugins/mcp-local-wp|npm update -g @verygoodplugins/mcp-local-wp"
     "npm|Beads UI|beads-ui|--version|beads-ui|npm update -g beads-ui"
     "npm|BDUI|bdui|--version|bdui|npm update -g bdui"
-    "npm|OpenCode|opencode|--version|opencode|npm update -g opencode"
+    "npm|OpenCode|opencode|--version|opencode|bun install -g opencode-ai@latest"
+    "npm|Chrome DevTools MCP|chrome-devtools-mcp|--version|chrome-devtools-mcp|bun install -g chrome-devtools-mcp@latest"
+    "npm|GSC MCP|mcp-server-gsc|--version|mcp-server-gsc|bun install -g mcp-server-gsc@latest"
+    "npm|Playwriter MCP|playwriter|--version|playwriter|bun install -g playwriter@latest"
+    "npm|macOS Automator MCP|macos-automator-mcp|--version|@steipete/macos-automator-mcp|bun install -g @steipete/macos-automator-mcp@latest"
+    "npm|Claude Code MCP|claude-code-mcp|--version|@steipete/claude-code-mcp|bun install -g @steipete/claude-code-mcp@latest"
 )
 
 BREW_TOOLS=(
@@ -94,6 +99,8 @@ PIP_TOOLS=(
     "pip|Beads Viewer|beads_viewer|--version|beads-viewer|pip install --upgrade beads-viewer"
     "pip|DSPy|dspy|--version|dspy-ai|pip install --upgrade dspy-ai"
     "pip|Crawl4AI|crawl4ai|--version|crawl4ai|pip install --upgrade crawl4ai"
+    "pip|Analytics MCP|analytics-mcp|--version|analytics-mcp|pipx upgrade analytics-mcp"
+    "pip|Outscraper MCP|outscraper-mcp-server|--version|outscraper-mcp-server|uv tool upgrade outscraper-mcp-server"
 )
 
 # Counters


### PR DESCRIPTION
## Summary

- Eliminates ~6-18s startup delay caused by 6 `npx -y package@latest` registry lookups on every OpenCode launch
- MCP packages are now installed globally via `bun install -g` (or npm fallback) and referenced by bare binary name
- `aidevops update-tools` keeps them current

## Changes

### setup.sh
- **`install_mcp_packages()`** - New function installs 6 Node.js MCPs globally (bun preferred, npm fallback) + 2 Python MCPs (pipx/uv)
- **`cleanup_deprecated_mcps()`** - Extended to migrate existing `npx`/`pipx run`/`uv tool run` commands to bare binary names
- **`setup_google_analytics_mcp()`** - Uses `analytics-mcp` binary instead of `pipx run`

### tool-version-check.sh
- Added 5 Node.js MCP packages with `bun install -g pkg@latest` as update command
- Added 2 Python MCP packages with `pipx upgrade` / `uv tool upgrade`

## Before/After

| MCP | Before (per launch) | After |
|-----|---------------------|-------|
| chrome-devtools | `npx -y chrome-devtools-mcp@latest` (~2-3s) | `chrome-devtools-mcp` (~0.1s) |
| repomix | `npx -y repomix@latest --mcp` (~2-3s) | `repomix --mcp` (~0.1s) |
| playwriter | `npx -y playwriter@latest` (~2-3s) | `playwriter` (~0.1s) |
| macos-automator | `npx -y @steipete/macos-automator-mcp@latest` (~2-3s) | `macos-automator-mcp` (~0.1s) |
| claude-code-mcp | `npx -y @steipete/claude-code-mcp@latest` (~2-3s) | `claude-code-mcp` (~0.1s) |
| gsc | `npx -y mcp-server-gsc` (~2-3s) | `mcp-server-gsc` (~0.1s) |
| google-analytics | `pipx run analytics-mcp` (~1-2s) | `analytics-mcp` (~0.1s) |
| outscraper | `bash -c "source... uv tool run..."` (~1-2s) | `outscraper-mcp-server` (~0.1s) |

**Estimated total savings: 12-24 seconds per OpenCode launch**