### PR TITLE
chore: strengthen pre-edit-check self-verification wording

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -23,7 +23,7 @@ Exit 0 = proceed. Exit 1 = STOP (on main). Exit 2 = create worktree. Exit 3 = wa
 
 **Full details**: Read `workflows/pre-edit.md` for interactive prompts, worktree creation, and edge cases.
 
-**Self-verification**: Your FIRST tool call before any Edit/Write MUST be this script. If you are about to edit a file and have not yet run pre-edit-check.sh in this session, STOP and run it now. No exceptions — including TODO.md and planning files (the script handles exception logic, not you).
+**Self-verification**: Your FIRST step before any Edit/Write MUST be to run this script. If you are about to edit a file and have not yet run pre-edit-check.sh in this session, STOP and run it now. No exceptions — including TODO.md and planning files (the script handles exception logic, not you).
 
 ---
 

--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -23,7 +23,7 @@ Exit 0 = proceed. Exit 1 = STOP (on main). Exit 2 = create worktree. Exit 3 = wa
 
 **Full details**: Read `workflows/pre-edit.md` for interactive prompts, worktree creation, and edge cases.
 
-**Self-verification**: Before ANY file operation, confirm you've run this check in this session.
+**Self-verification**: Your FIRST tool call before any Edit/Write MUST be this script. If you are about to edit a file and have not yet run pre-edit-check.sh in this session, STOP and run it now. No exceptions — including TODO.md and planning files (the script handles exception logic, not you).
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces passive "confirm you've run this check" with active imperative wording
- Makes clear the script handles exception logic (e.g. planning files on main), not the agent's judgement
- Prevents agents from skipping the mandatory pre-edit-check by reasoning "it's just a TODO edit"

## Context

During a session, an agent edited TODO.md directly on main without running `pre-edit-check.sh`. The agent reasoned the check wasn't needed because "it's just a planning file." While the outcome was correct (planning files are allowed on main), the process was wrong — the script should always run, and the script decides exceptions.

## Change

**Before:**
> Self-verification: Before ANY file operation, confirm you've run this check in this session.

**After:**
> Self-verification: Your FIRST tool call before any Edit/Write MUST be this script. If you are about to edit a file and have not yet run pre-edit-check.sh in this session, STOP and run it now. No exceptions — including TODO.md and planning files (the script handles exception logic, not you).

## Why this works

1. **Active voice** — "Your FIRST tool call MUST be" vs passive "confirm"
2. **Removes ambiguity** — Explicitly states the script handles exceptions, not the agent
3. **Interrupt pattern** — "STOP and run it now" triggers even mid-task
4. **Addresses root cause** — Agents won't skip by reasoning about file type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development guidance documentation to clarify verification procedures for development workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->