### PR TITLE
feat: add Examples & Inspiration section to Remotion agent

### DIFF
--- a/.agent/tools/video/remotion.md
+++ b/.agent/tools/video/remotion.md
@@ -245,6 +245,25 @@ npx remotion still src/index.ts MyStill out/thumbnail.png
 npx remotion render src/index.ts MyComposition out/video.mp4 --props='{"title":"Custom"}'
 ```
 
+## Examples & Inspiration
+
+Open-source Remotion projects to study for patterns and ideas:
+
+| Repository | Description | Key Patterns |
+|-----------|-------------|--------------|
+| [trycua/launchpad](https://github.com/trycua/launchpad) | Product launch video monorepo (Turborepo + Next.js + Tailwind) | Scene-based architecture, shared packages, scaffolding CLI, word-by-word text animations, code editor scenes, spring physics, sound effects, blur transitions |
+| [remotion-dev/trailer](https://github.com/remotion-dev/trailer) | Official Remotion trailer | Advanced compositions, transitions, brand animation |
+| [remotion-dev/github-unwrapped](https://github.com/remotion-dev/github-unwrapped) | GitHub Wrapped annual recap videos | Data-driven video, dynamic props, SSR rendering at scale |
+| [remotion-dev/template-helloworld](https://github.com/remotion-dev/template-helloworld) | Official starter template | Minimal project structure, basic patterns |
+
+**Architectural patterns from examples:**
+
+- **Scene composition**: Break videos into scene components, each exporting a duration constant (e.g. `INTRO_DURATION = 90`)
+- **Shared packages**: Monorepo with reusable animations (`FadeIn`, `SlideUp`, `TextReveal`) and brand assets (colors, fonts, sounds)
+- **Constants file**: Centralize `VIDEO_WIDTH`, `VIDEO_HEIGHT`, `VIDEO_FPS` in `types/constants.ts`
+- **Scaffolding CLI**: Script to generate new video projects from a template with dimension presets
+- **Series composition**: Use `<Series>` to chain scenes sequentially in a `FullVideo` component
+
 ## Related
 
 - [Remotion Docs](https://www.remotion.dev/docs)


### PR DESCRIPTION
## Summary

- Adds curated list of open-source Remotion projects (trycua/launchpad, remotion-dev/trailer, github-unwrapped, template-helloworld) with key patterns for each
- Documents architectural patterns extracted from real-world examples: scene composition, shared packages, constants files, scaffolding CLIs, Series composition
- Placed in the existing `remotion.md` agent file for discoverability without adding a separate subagent

## Context

Found [trycua/launchpad](https://github.com/trycua/launchpad) - a well-structured Remotion monorepo (Turborepo + Next.js + Tailwind) demonstrating scene-based video architecture, shared component packages, and a video scaffolding CLI. Added it alongside other notable Remotion examples as an inspiration reference.

## Changes

- `.agent/tools/video/remotion.md` - Added "Examples & Inspiration" section before the existing "Related" section (+19 lines)