### PR TITLE
feat: add Unstract MCP integration for document processing

### DIFF
--- a/.agent/aidevops/mcp-integrations.md
+++ b/.agent/aidevops/mcp-integrations.md
@@ -31,7 +31,7 @@ tools:
 - Google Search Console: `GOOGLE_APPLICATION_CREDENTIALS` (service account JSON)
 
 **Document Processing**:
-- Unstract MCP: `UNSTRACT_API_KEY` + `UNSTRACT_API_BASE_URL` required (Docker-based)
+- Unstract MCP: `UNSTRACT_API_KEY` + `API_BASE_URL` required (Docker-based, self-hosted default)
 
 **Development**:
 - Claude Code MCP: Claude Code automation (forked server)
@@ -212,12 +212,16 @@ See `services/crm/fluentcrm.md` for detailed documentation.
 ### **Unstract MCP**
 
 ```bash
-# 1. Sign up at https://unstract.com/start-for-free/ (14-day free trial)
-# 2. Create a Prompt Studio project, define schema, deploy as API
-# 3. Store credentials in ~/.config/aidevops/mcp-env.sh:
+# 1. Self-hosted (recommended): unstract-helper.sh install
+# 2. Or cloud: Sign up at https://unstract.com/start-for-free/
+# 3. Create a Prompt Studio project, define schema, deploy as API
+# 4. Store credentials in ~/.config/aidevops/mcp-env.sh:
 export UNSTRACT_API_KEY="your_api_key_here"
-export UNSTRACT_API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
+export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
+chmod 600 ~/.config/aidevops/mcp-env.sh
 ```
+
+**Note**: The MCP expects `API_BASE_URL` (not prefixed) - this matches the official Unstract spec.
 
 **For OpenCode** - Docker-based, disabled globally, enabled on-demand:
 
@@ -225,7 +229,7 @@ export UNSTRACT_API_BASE_URL="https://us-central.unstract.com/deployment/api/you
 {
   "unstract": {
     "type": "local",
-    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL=\"$UNSTRACT_API_BASE_URL\" unstract/mcp-server unstract"],
+    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL -e DISABLE_TELEMETRY=true unstract/mcp-server:${UNSTRACT_IMAGE_TAG:-latest} unstract"],
     "enabled": false
   }
 }
@@ -243,11 +247,12 @@ export UNSTRACT_API_BASE_URL="https://us-central.unstract.com/deployment/api/you
         "-v", "/tmp:/tmp",
         "-e", "UNSTRACT_API_KEY",
         "-e", "API_BASE_URL",
+        "-e", "DISABLE_TELEMETRY=true",
         "unstract/mcp-server", "unstract"
       ],
       "env": {
         "UNSTRACT_API_KEY": "your_api_key",
-        "API_BASE_URL": "https://us-central.unstract.com/deployment/api/.../"
+        "API_BASE_URL": "http://backend.unstract.localhost/deployment/api/.../"
       }
     }
   }
@@ -257,6 +262,8 @@ export UNSTRACT_API_BASE_URL="https://us-central.unstract.com/deployment/api/you
 **Per-Agent Enablement**: The `services/document-processing/unstract.md` subagent has `unstract_tool: true` in its tools section. Agents needing document extraction reference this subagent.
 
 **Available Tools**: `unstract_tool` - submits files, polls for completion, returns structured JSON. Supports optional metadata and metrics.
+
+**Image Pinning**: Set `UNSTRACT_IMAGE_TAG` env var to pin a specific version for reproducibility.
 
 See `services/document-processing/unstract.md` for detailed documentation.
 
@@ -335,6 +342,12 @@ export AHREFS_API_KEY="your_40_char_ahrefs_key"
 export PERPLEXITY_API_KEY="your_perplexity_key"
 export CLOUDFLARE_ACCOUNT_ID="your_account_id"
 export CLOUDFLARE_API_TOKEN="your_api_token"
+
+# Unstract - document processing (see services/document-processing/unstract.md)
+export UNSTRACT_API_KEY="your_unstract_api_key"
+export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
+# Optional: pin image version for reproducibility
+export UNSTRACT_IMAGE_TAG="latest"
 ```
 
 ## 🚀 **Getting Started**

--- a/.agent/aidevops/mcp-integrations.md
+++ b/.agent/aidevops/mcp-integrations.md
@@ -30,6 +30,9 @@ tools:
 - Perplexity MCP: `PERPLEXITY_API_KEY` required
 - Google Search Console: `GOOGLE_APPLICATION_CREDENTIALS` (service account JSON)
 
+**Document Processing**:
+- Unstract MCP: `UNSTRACT_API_KEY` + `UNSTRACT_API_BASE_URL` required (Docker-based)
+
 **Development**:
 - Claude Code MCP: Claude Code automation (forked server)
 - Next.js DevTools MCP
@@ -59,6 +62,10 @@ This document provides comprehensive setup and usage instructions for advanced M
 
 - **Claude Code MCP**: Run Claude Code as an MCP server for automation
 - **Next.js DevTools MCP**: Next.js development and debugging assistance
+
+### **📄 Document Processing**
+
+- **Unstract MCP**: LLM-powered structured data extraction from unstructured documents (PDF, images, DOCX)
 
 ### **📧 CRM & Marketing**
 
@@ -201,6 +208,57 @@ export FLUENTCRM_API_PASSWORD="your_application_password"
 **Available Tools**: Contacts, Tags, Lists, Campaigns, Email Templates, Automations, Webhooks, Smart Links, Dashboard Stats.
 
 See `services/crm/fluentcrm.md` for detailed documentation.
+
+### **Unstract MCP**
+
+```bash
+# 1. Sign up at https://unstract.com/start-for-free/ (14-day free trial)
+# 2. Create a Prompt Studio project, define schema, deploy as API
+# 3. Store credentials in ~/.config/aidevops/mcp-env.sh:
+export UNSTRACT_API_KEY="your_api_key_here"
+export UNSTRACT_API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
+```
+
+**For OpenCode** - Docker-based, disabled globally, enabled on-demand:
+
+```json
+{
+  "unstract": {
+    "type": "local",
+    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL=\"$UNSTRACT_API_BASE_URL\" unstract/mcp-server unstract"],
+    "enabled": false
+  }
+}
+```
+
+**For Claude Desktop** (Docker):
+
+```json
+{
+  "mcpServers": {
+    "unstract_tool": {
+      "command": "/usr/local/bin/docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-v", "/tmp:/tmp",
+        "-e", "UNSTRACT_API_KEY",
+        "-e", "API_BASE_URL",
+        "unstract/mcp-server", "unstract"
+      ],
+      "env": {
+        "UNSTRACT_API_KEY": "your_api_key",
+        "API_BASE_URL": "https://us-central.unstract.com/deployment/api/.../"
+      }
+    }
+  }
+}
+```
+
+**Per-Agent Enablement**: The `services/document-processing/unstract.md` subagent has `unstract_tool: true` in its tools section. Agents needing document extraction reference this subagent.
+
+**Available Tools**: `unstract_tool` - submits files, polls for completion, returns structured JSON. Supports optional metadata and metrics.
+
+See `services/document-processing/unstract.md` for detailed documentation.
 
 ## 🔧 **Configuration Examples**
 

--- a/.agent/scripts/setup-mcp-integrations.sh
+++ b/.agent/scripts/setup-mcp-integrations.sh
@@ -42,13 +42,14 @@ get_mcp_command() {
         "stagehand-both") echo "both" ;;
         "dataforseo") echo "npx dataforseo-mcp-server" ;;
         "serper") echo "uvx serper-mcp-server" ;;
+        "unstract") echo "docker:unstract/mcp-server" ;;
         *) echo "" ;;
     esac
     return 0
 }
 
 # Available integrations list
-MCP_LIST="chrome-devtools playwright cloudflare-browser ahrefs perplexity nextjs-devtools google-search-console pagespeed-insights grep-vercel claude-code-mcp stagehand stagehand-python stagehand-both dataforseo serper"
+MCP_LIST="chrome-devtools playwright cloudflare-browser ahrefs perplexity nextjs-devtools google-search-console pagespeed-insights grep-vercel claude-code-mcp stagehand stagehand-python stagehand-both dataforseo serper unstract"
 
 # Check prerequisites
 check_prerequisites() {
@@ -305,6 +306,31 @@ install_mcp() {
                 print_info "Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"
                 print_info "Alternative: pip install serper-mcp-server"
             fi
+            ;;
+        "unstract")
+            print_info "Setting up Unstract self-hosted document processing platform..."
+            print_info "This installs the full Unstract platform locally via Docker Compose"
+            print_info "Requirements: Docker, Docker Compose, Git, 8GB RAM"
+            echo
+
+            # Run the helper script for installation
+            local helper_script="${SCRIPT_DIR}/unstract-helper.sh"
+            if [[ -f "$helper_script" ]]; then
+                bash "$helper_script" install
+            else
+                print_error "unstract-helper.sh not found at ${helper_script}"
+                print_info "Manual install:"
+                print_info "  git clone https://github.com/Zipstack/unstract.git ~/.aidevops/unstract"
+                print_info "  cd ~/.aidevops/unstract && ./run-platform.sh"
+                return 1
+            fi
+
+            echo
+            print_info "Your existing LLM API keys can be used as Unstract adapters:"
+            print_info "  Run: unstract-helper.sh configure-llm"
+            print_info ""
+            print_info "The MCP connects to your local instance by default."
+            print_info "Config template: configs/mcp-templates/unstract.json"
             ;;
         *)
             print_error "Unknown MCP integration: $mcp_name"

--- a/.agent/scripts/unstract-helper.sh
+++ b/.agent/scripts/unstract-helper.sh
@@ -186,9 +186,9 @@ do_status() {
     fi
 
     # Check MCP env
-    if [[ -f "$MCP_ENV_FILE" ]] && grep -q "UNSTRACT_API_BASE_URL" "$MCP_ENV_FILE"; then
+    if [[ -f "$MCP_ENV_FILE" ]] && grep -q "API_BASE_URL" "$MCP_ENV_FILE"; then
         local url
-        url=$(grep "UNSTRACT_API_BASE_URL" "$MCP_ENV_FILE" | sed 's/.*=//' | tr -d '"' | tr -d "'")
+        url=$(grep "^export API_BASE_URL" "$MCP_ENV_FILE" | sed 's/.*=//' | tr -d '"' | tr -d "'")
         print_info "MCP configured: ${url}"
     else
         print_warning "MCP not configured. Run 'unstract-helper.sh configure-llm'"
@@ -238,7 +238,7 @@ do_uninstall() {
     # Remove MCP env entries
     if [[ -f "$MCP_ENV_FILE" ]]; then
         sed -i.bak '/UNSTRACT_API_KEY/d' "$MCP_ENV_FILE"
-        sed -i.bak '/UNSTRACT_API_BASE_URL/d' "$MCP_ENV_FILE"
+        sed -i.bak '/^export API_BASE_URL.*unstract/d' "$MCP_ENV_FILE"
         rm -f "${MCP_ENV_FILE}.bak"
     fi
 
@@ -253,8 +253,8 @@ configure_local_mcp_env() {
     # Set default local URL (user will update deployment ID after creating a project)
     local needs_update=0
 
-    if ! grep -q "UNSTRACT_API_BASE_URL" "$MCP_ENV_FILE" 2>/dev/null; then
-        echo 'export UNSTRACT_API_BASE_URL="http://backend.unstract.localhost/deployment/api/YOUR_DEPLOYMENT_ID/"' >> "$MCP_ENV_FILE"
+    if ! grep -q "^export API_BASE_URL" "$MCP_ENV_FILE" 2>/dev/null; then
+        echo 'export API_BASE_URL="http://backend.unstract.localhost/deployment/api/YOUR_DEPLOYMENT_ID/"' >> "$MCP_ENV_FILE"
         needs_update=1
     fi
 
@@ -265,7 +265,7 @@ configure_local_mcp_env() {
 
     if [[ "$needs_update" -eq 1 ]]; then
         chmod 600 "$MCP_ENV_FILE"
-        print_info "Added UNSTRACT_API_KEY and UNSTRACT_API_BASE_URL to ${MCP_ENV_FILE}"
+        print_info "Added UNSTRACT_API_KEY and API_BASE_URL to ${MCP_ENV_FILE}"
         print_warning "Update these after creating your first API deployment in Prompt Studio"
     fi
 

--- a/.agent/scripts/unstract-helper.sh
+++ b/.agent/scripts/unstract-helper.sh
@@ -1,0 +1,373 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2155
+
+# Unstract Helper - Self-hosted document processing platform
+# Manages local Unstract instance via Docker Compose
+#
+# Usage: unstract-helper.sh [install|start|stop|status|logs|uninstall|configure-llm]
+
+set -euo pipefail
+
+# Constants
+readonly UNSTRACT_DIR="${HOME}/.aidevops/unstract"
+readonly UNSTRACT_REPO="https://github.com/Zipstack/unstract.git"
+readonly MCP_ENV_FILE="${HOME}/.config/aidevops/mcp-env.sh"
+readonly FRONTEND_URL="http://frontend.unstract.localhost"
+readonly BACKEND_URL="http://backend.unstract.localhost"
+
+# Colors
+readonly GREEN='\033[0;32m'
+readonly BLUE='\033[0;34m'
+readonly YELLOW='\033[1;33m'
+readonly RED='\033[0;31m'
+readonly NC='\033[0m'
+
+print_success() { local msg="$1"; echo -e "${GREEN}[OK] ${msg}${NC}"; return 0; }
+print_info() { local msg="$1"; echo -e "${BLUE}[INFO] ${msg}${NC}"; return 0; }
+print_warning() { local msg="$1"; echo -e "${YELLOW}[WARN] ${msg}${NC}"; return 0; }
+print_error() { local msg="$1"; echo -e "${RED}[ERROR] ${msg}${NC}" >&2; return 0; }
+
+# Check prerequisites
+check_prerequisites() {
+    local missing=0
+
+    if ! command -v docker &>/dev/null; then
+        print_error "Docker is required but not installed"
+        print_info "Install from: https://docs.docker.com/get-docker/"
+        missing=1
+    fi
+
+    if ! command -v docker compose &>/dev/null && ! command -v docker-compose &>/dev/null; then
+        print_error "Docker Compose is required but not installed"
+        missing=1
+    fi
+
+    if ! command -v git &>/dev/null; then
+        print_error "Git is required but not installed"
+        missing=1
+    fi
+
+    if [[ "$missing" -eq 1 ]]; then
+        return 1
+    fi
+
+    # Check available RAM (minimum 8GB)
+    local ram_gb
+    if [[ "$(uname)" == "Darwin" ]]; then
+        ram_gb=$(( $(sysctl -n hw.memsize) / 1073741824 ))
+    else
+        ram_gb=$(( $(grep MemTotal /proc/meminfo | awk '{print $2}') / 1048576 ))
+    fi
+
+    if [[ "$ram_gb" -lt 8 ]]; then
+        print_warning "System has ${ram_gb}GB RAM. Unstract recommends 8GB minimum."
+    else
+        print_info "System RAM: ${ram_gb}GB (meets 8GB minimum)"
+    fi
+
+    return 0
+}
+
+# Install Unstract self-hosted
+do_install() {
+    print_info "Installing Unstract self-hosted platform..."
+
+    if [[ -d "$UNSTRACT_DIR" ]]; then
+        print_warning "Unstract already installed at ${UNSTRACT_DIR}"
+        print_info "Use 'unstract-helper.sh start' to start, or 'unstract-helper.sh uninstall' first"
+        return 0
+    fi
+
+    check_prerequisites || return 1
+
+    # Clone repository
+    print_info "Cloning Unstract repository..."
+    git clone "$UNSTRACT_REPO" "$UNSTRACT_DIR"
+
+    # Disable analytics in frontend
+    local frontend_env="${UNSTRACT_DIR}/frontend/.env"
+    if [[ -f "$frontend_env" ]]; then
+        if grep -q "REACT_APP_ENABLE_POSTHOG" "$frontend_env"; then
+            sed -i.bak 's/REACT_APP_ENABLE_POSTHOG=.*/REACT_APP_ENABLE_POSTHOG=false/' "$frontend_env"
+        else
+            echo "REACT_APP_ENABLE_POSTHOG=false" >> "$frontend_env"
+        fi
+    else
+        echo "REACT_APP_ENABLE_POSTHOG=false" > "$frontend_env"
+    fi
+    print_success "Analytics disabled (REACT_APP_ENABLE_POSTHOG=false)"
+
+    # Start the platform
+    do_start
+
+    # Configure MCP env to point to local instance
+    configure_local_mcp_env
+
+    print_success "Unstract self-hosted installation complete!"
+    echo
+    print_info "Next steps:"
+    print_info "1. Visit ${FRONTEND_URL} (login: unstract/unstract)"
+    print_info "2. Add LLM adapters (Settings > Adapters) using your existing API keys"
+    print_info "3. Create a Prompt Studio project and deploy as API"
+    print_info "4. The MCP will automatically connect to your local instance"
+    echo
+    print_info "Run 'unstract-helper.sh configure-llm' for help adding LLM keys"
+
+    return 0
+}
+
+# Start Unstract
+do_start() {
+    if [[ ! -d "$UNSTRACT_DIR" ]]; then
+        print_error "Unstract not installed. Run 'unstract-helper.sh install' first"
+        return 1
+    fi
+
+    print_info "Starting Unstract platform..."
+    cd "$UNSTRACT_DIR"
+
+    if [[ -f "run-platform.sh" ]]; then
+        bash run-platform.sh
+    else
+        docker compose up -d
+    fi
+
+    # Wait for services to be ready
+    print_info "Waiting for services to start..."
+    local attempts=0
+    while [[ $attempts -lt 30 ]]; do
+        if curl -s -o /dev/null -w "%{http_code}" "$FRONTEND_URL" 2>/dev/null | grep -q "200\|301\|302"; then
+            print_success "Unstract is running at ${FRONTEND_URL}"
+            return 0
+        fi
+        sleep 2
+        attempts=$((attempts + 1))
+    done
+
+    print_warning "Services may still be starting. Check: unstract-helper.sh status"
+    return 0
+}
+
+# Stop Unstract
+do_stop() {
+    if [[ ! -d "$UNSTRACT_DIR" ]]; then
+        print_error "Unstract not installed"
+        return 1
+    fi
+
+    print_info "Stopping Unstract platform..."
+    cd "$UNSTRACT_DIR"
+    docker compose down
+    print_success "Unstract stopped"
+    return 0
+}
+
+# Check status
+do_status() {
+    if [[ ! -d "$UNSTRACT_DIR" ]]; then
+        print_info "Unstract: Not installed"
+        print_info "Run 'unstract-helper.sh install' to set up"
+        return 0
+    fi
+
+    print_info "Unstract installation: ${UNSTRACT_DIR}"
+
+    cd "$UNSTRACT_DIR"
+    local running
+    running=$(docker compose ps --format json 2>/dev/null | grep -c '"running"' 2>/dev/null || echo "0")
+
+    if [[ "$running" -gt 0 ]]; then
+        print_success "Unstract: Running (${running} containers)"
+        print_info "Frontend: ${FRONTEND_URL}"
+        print_info "Backend: ${BACKEND_URL}"
+    else
+        print_warning "Unstract: Installed but not running"
+        print_info "Run 'unstract-helper.sh start' to start"
+    fi
+
+    # Check MCP env
+    if [[ -f "$MCP_ENV_FILE" ]] && grep -q "UNSTRACT_API_BASE_URL" "$MCP_ENV_FILE"; then
+        local url
+        url=$(grep "UNSTRACT_API_BASE_URL" "$MCP_ENV_FILE" | sed 's/.*=//' | tr -d '"' | tr -d "'")
+        print_info "MCP configured: ${url}"
+    else
+        print_warning "MCP not configured. Run 'unstract-helper.sh configure-llm'"
+    fi
+
+    return 0
+}
+
+# Show logs
+do_logs() {
+    if [[ ! -d "$UNSTRACT_DIR" ]]; then
+        print_error "Unstract not installed"
+        return 1
+    fi
+
+    cd "$UNSTRACT_DIR"
+    local service="${1:-}"
+    if [[ -n "$service" ]]; then
+        docker compose logs -f "$service"
+    else
+        docker compose logs -f --tail=50
+    fi
+    return 0
+}
+
+# Uninstall
+do_uninstall() {
+    if [[ ! -d "$UNSTRACT_DIR" ]]; then
+        print_info "Unstract not installed, nothing to remove"
+        return 0
+    fi
+
+    print_warning "This will stop and remove the Unstract installation"
+    print_warning "Location: ${UNSTRACT_DIR}"
+    echo -n "Continue? [y/N] "
+    read -r confirm
+    if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+        print_info "Cancelled"
+        return 0
+    fi
+
+    cd "$UNSTRACT_DIR"
+    docker compose down -v 2>/dev/null || true
+    cd "$HOME"
+    rm -rf "$UNSTRACT_DIR"
+
+    # Remove MCP env entries
+    if [[ -f "$MCP_ENV_FILE" ]]; then
+        sed -i.bak '/UNSTRACT_API_KEY/d' "$MCP_ENV_FILE"
+        sed -i.bak '/UNSTRACT_API_BASE_URL/d' "$MCP_ENV_FILE"
+        rm -f "${MCP_ENV_FILE}.bak"
+    fi
+
+    print_success "Unstract uninstalled"
+    return 0
+}
+
+# Configure local MCP environment
+configure_local_mcp_env() {
+    mkdir -p "$(dirname "$MCP_ENV_FILE")"
+
+    # Set default local URL (user will update deployment ID after creating a project)
+    local needs_update=0
+
+    if ! grep -q "UNSTRACT_API_BASE_URL" "$MCP_ENV_FILE" 2>/dev/null; then
+        echo 'export UNSTRACT_API_BASE_URL="http://backend.unstract.localhost/deployment/api/YOUR_DEPLOYMENT_ID/"' >> "$MCP_ENV_FILE"
+        needs_update=1
+    fi
+
+    if ! grep -q "UNSTRACT_API_KEY" "$MCP_ENV_FILE" 2>/dev/null; then
+        echo 'export UNSTRACT_API_KEY="YOUR_LOCAL_API_KEY"' >> "$MCP_ENV_FILE"
+        needs_update=1
+    fi
+
+    if [[ "$needs_update" -eq 1 ]]; then
+        chmod 600 "$MCP_ENV_FILE"
+        print_info "Added UNSTRACT_API_KEY and UNSTRACT_API_BASE_URL to ${MCP_ENV_FILE}"
+        print_warning "Update these after creating your first API deployment in Prompt Studio"
+    fi
+
+    return 0
+}
+
+# Help with LLM adapter configuration
+do_configure_llm() {
+    print_info "Unstract LLM Adapter Configuration"
+    echo
+    print_info "Unstract uses 'Adapters' to connect to LLM providers."
+    print_info "Add these in the Unstract UI: Settings > Adapters > Add Adapter"
+    echo
+    print_info "Your existing API keys from ~/.config/aidevops/mcp-env.sh can be used:"
+    echo
+
+    # Check which keys the user already has
+    local found_keys=0
+    if [[ -f "$MCP_ENV_FILE" ]]; then
+        if grep -q "OPENAI_API_KEY" "$MCP_ENV_FILE" 2>/dev/null; then
+            print_success "OpenAI API key found - add as 'OpenAI' adapter in Unstract"
+            found_keys=$((found_keys + 1))
+        fi
+        if grep -q "ANTHROPIC_API_KEY" "$MCP_ENV_FILE" 2>/dev/null; then
+            print_success "Anthropic API key found - add as 'Anthropic' adapter in Unstract"
+            found_keys=$((found_keys + 1))
+        fi
+        if grep -q "GOOGLE_API_KEY\|GOOGLE_APPLICATION_CREDENTIALS\|VERTEX" "$MCP_ENV_FILE" 2>/dev/null; then
+            print_success "Google/Vertex AI key found - add as 'Google VertexAI' adapter"
+            found_keys=$((found_keys + 1))
+        fi
+        if grep -q "AZURE_OPENAI" "$MCP_ENV_FILE" 2>/dev/null; then
+            print_success "Azure OpenAI key found - add as 'Azure OpenAI' adapter"
+            found_keys=$((found_keys + 1))
+        fi
+        if grep -q "AWS_ACCESS_KEY\|AWS_SECRET" "$MCP_ENV_FILE" 2>/dev/null; then
+            print_success "AWS credentials found - add as 'Bedrock' adapter"
+            found_keys=$((found_keys + 1))
+        fi
+    fi
+
+    if [[ "$found_keys" -eq 0 ]]; then
+        print_warning "No LLM API keys found in ${MCP_ENV_FILE}"
+        print_info "Add at least one LLM key to use Unstract:"
+        echo
+    fi
+
+    echo
+    print_info "Supported LLM providers in Unstract:"
+    print_info "  - OpenAI (GPT-4, GPT-4o)"
+    print_info "  - Anthropic (Claude)"
+    print_info "  - Google VertexAI / Gemini"
+    print_info "  - Azure OpenAI"
+    print_info "  - AWS Bedrock"
+    print_info "  - Ollama (local, no API key needed)"
+    print_info "  - Mistral AI"
+    echo
+    print_info "For Ollama (fully local, no cloud):"
+    print_info "  1. Install Ollama: https://ollama.ai"
+    print_info "  2. Pull a model: ollama pull llama3"
+    print_info "  3. Add as 'Ollama' adapter in Unstract (URL: http://host.docker.internal:11434)"
+    echo
+    print_info "Visit ${FRONTEND_URL} > Settings > Adapters to configure"
+
+    return 0
+}
+
+# Main
+main() {
+    local command="${1:-help}"
+
+    case "$command" in
+        install)    do_install ;;
+        start)      do_start ;;
+        stop)       do_stop ;;
+        status)     do_status ;;
+        logs)       shift; do_logs "${1:-}" ;;
+        uninstall)  do_uninstall ;;
+        configure-llm) do_configure_llm ;;
+        help|--help|-h)
+            echo "Usage: unstract-helper.sh [command]"
+            echo
+            echo "Commands:"
+            echo "  install        Clone and start Unstract self-hosted (analytics disabled)"
+            echo "  start          Start Unstract containers"
+            echo "  stop           Stop Unstract containers"
+            echo "  status         Show installation and running status"
+            echo "  logs [svc]     Show container logs (optionally for specific service)"
+            echo "  uninstall      Remove Unstract installation and data"
+            echo "  configure-llm  Show how to add LLM adapters using your existing API keys"
+            echo
+            echo "Prerequisites: Docker, Docker Compose, Git, 8GB RAM"
+            echo "Install location: ${UNSTRACT_DIR}"
+            ;;
+        *)
+            print_error "Unknown command: ${command}"
+            echo "Run 'unstract-helper.sh help' for usage"
+            return 1
+            ;;
+    esac
+
+    return 0
+}
+
+main "$@"

--- a/.agent/services/document-processing/unstract.md
+++ b/.agent/services/document-processing/unstract.md
@@ -64,19 +64,49 @@ Submits a file to the Unstract API, polls for completion, and returns structured
 
 ## Setup
 
-### 1. Get API Credentials
+The MCP server is a thin client that connects to any Unstract API endpoint - cloud or self-hosted.
+
+### Option A: Cloud (Quick Start)
 
 1. Sign up at https://unstract.com/start-for-free/ (14-day free trial)
 2. Create a Prompt Studio project and define your extraction schema
 3. Deploy as an API endpoint
 4. Copy the API key and deployment URL
 
-### 2. Store Credentials
-
 ```bash
 # Add to ~/.config/aidevops/mcp-env.sh:
 export UNSTRACT_API_KEY="your_api_key_here"
 export UNSTRACT_API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
+```
+
+### Option B: Self-Hosted (Local)
+
+Run the full Unstract platform locally via Docker Compose (requires 8GB RAM):
+
+```bash
+git clone https://github.com/Zipstack/unstract.git
+cd unstract
+./run-platform.sh
+# Visit http://frontend.unstract.localhost (login: unstract/unstract)
+```
+
+Then create your Prompt Studio project, deploy as API, and configure:
+
+```bash
+# Add to ~/.config/aidevops/mcp-env.sh:
+export UNSTRACT_API_KEY="your_local_api_key"
+export UNSTRACT_API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-deployment-id/"
+```
+
+Self-hosted gives full data privacy - no documents leave your machine.
+
+### 2. Store Credentials
+
+Whichever option you chose, ensure credentials are in `~/.config/aidevops/mcp-env.sh`:
+
+```bash
+export UNSTRACT_API_KEY="your_api_key_here"
+export UNSTRACT_API_BASE_URL="https://your-endpoint/deployment/api/your-id/"
 ```
 
 ### 3. OpenCode Configuration (On-Demand)
@@ -116,6 +146,19 @@ See `configs/mcp-templates/unstract.json` for the configuration template.
 - **Insurance claims**: Extract claim details from forms and supporting documents
 - **KYC/onboarding**: Parse identity documents and application forms
 - **Contract analysis**: Extract key terms, dates, parties from legal documents
+
+## Analytics / Telemetry
+
+The MCP server itself (`unstract/mcp-server` Docker image) contains **no analytics or telemetry code** - it is a clean API client that submits files and returns results.
+
+For **self-hosted** Unstract deployments, disable frontend analytics:
+
+```bash
+# In frontend/.env of your self-hosted Unstract instance:
+REACT_APP_ENABLE_POSTHOG=false
+```
+
+The **cloud API** (`us-central.unstract.com`) may collect server-side usage metrics as part of their platform. Use self-hosted if this is a concern.
 
 ## Integration with aidevops
 

--- a/.agent/services/document-processing/unstract.md
+++ b/.agent/services/document-processing/unstract.md
@@ -23,7 +23,7 @@ mcp:
 - **Purpose**: Extract structured data from unstructured documents (PDFs, images, DOCX, etc.)
 - **MCP Server**: `unstract/mcp-server` (Docker) or `@unstract/mcp-server` (npx)
 - **Tool**: `unstract_tool` - submits files to Unstract API, polls for completion, returns structured JSON
-- **Credentials**: `UNSTRACT_API_KEY` + `API_BASE_URL` in `~/.config/aidevops/mcp-env.sh`
+- **Credentials**: `UNSTRACT_API_KEY` + `API_BASE_URL` in `~/.config/aidevops/mcp-env.sh` (chmod 600)
 - **Docs**: https://docs.unstract.com/unstract/unstract_platform/mcp/unstract_platform_mcp_server/
 - **GitHub**: https://github.com/Zipstack/unstract
 
@@ -76,7 +76,8 @@ The MCP server is a thin client that connects to any Unstract API endpoint - clo
 ```bash
 # Add to ~/.config/aidevops/mcp-env.sh:
 export UNSTRACT_API_KEY="your_api_key_here"
-export UNSTRACT_API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
+export API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
+chmod 600 ~/.config/aidevops/mcp-env.sh
 ```
 
 ### Option B: Self-Hosted (Local) - Recommended
@@ -131,8 +132,11 @@ Whichever option you chose, ensure credentials are in `~/.config/aidevops/mcp-en
 
 ```bash
 export UNSTRACT_API_KEY="your_api_key_here"
-export UNSTRACT_API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
+export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
+chmod 600 ~/.config/aidevops/mcp-env.sh
 ```
+
+**Note**: The MCP expects `API_BASE_URL` (not prefixed). This matches the official Unstract spec.
 
 ### 3. OpenCode Configuration (On-Demand)
 

--- a/.agent/services/document-processing/unstract.md
+++ b/.agent/services/document-processing/unstract.md
@@ -1,0 +1,130 @@
+---
+description: Unstract - LLM-powered document data extraction via MCP
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: true
+  unstract_tool: true
+mcp:
+  unstract: true
+---
+
+# Unstract - Document Processing
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Extract structured data from unstructured documents (PDFs, images, DOCX, etc.)
+- **MCP Server**: `unstract/mcp-server` (Docker) or `@unstract/mcp-server` (npx)
+- **Tool**: `unstract_tool` - submits files to Unstract API, polls for completion, returns structured JSON
+- **Credentials**: `UNSTRACT_API_KEY` + `API_BASE_URL` in `~/.config/aidevops/mcp-env.sh`
+- **Docs**: https://docs.unstract.com/unstract/unstract_platform/mcp/unstract_platform_mcp_server/
+- **GitHub**: https://github.com/Zipstack/unstract
+
+**On-demand loading**: This MCP is disabled globally and enabled per-agent when document extraction is needed.
+
+<!-- AI-CONTEXT-END -->
+
+## What is Unstract?
+
+Unstract is a no-code LLM platform that structures unstructured documents. It provides:
+
+- **Prompt Studio**: Visual environment to define extraction schemas
+- **API Deployments**: Turn any document into JSON via REST API
+- **ETL Pipelines**: Batch process documents into databases
+- **MCP Server**: Integrate extraction into AI agent workflows
+
+## Supported File Types
+
+| Category | Formats |
+|----------|---------|
+| Documents | PDF, DOCX, DOC, ODT, TXT, CSV, JSON |
+| Spreadsheets | XLSX, XLS, ODS |
+| Presentations | PPTX, PPT, ODP |
+| Images | PNG, JPG, JPEG, TIFF, BMP, GIF, WEBP |
+
+## MCP Tool
+
+### `unstract_tool`
+
+Submits a file to the Unstract API, polls for completion, and returns structured extraction results.
+
+**Parameters**:
+- `file_path` (required): Path to the document to process
+- `include_metadata` (optional): Include extraction metadata in response
+- `include_metrics` (optional): Include processing metrics (tokens, cost)
+
+**Example prompt**: "Process the document /tmp/invoice.pdf"
+
+## Setup
+
+### 1. Get API Credentials
+
+1. Sign up at https://unstract.com/start-for-free/ (14-day free trial)
+2. Create a Prompt Studio project and define your extraction schema
+3. Deploy as an API endpoint
+4. Copy the API key and deployment URL
+
+### 2. Store Credentials
+
+```bash
+# Add to ~/.config/aidevops/mcp-env.sh:
+export UNSTRACT_API_KEY="your_api_key_here"
+export UNSTRACT_API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
+```
+
+### 3. OpenCode Configuration (On-Demand)
+
+The MCP is configured in OpenCode but disabled globally. It loads on-demand when this subagent is invoked.
+
+See `configs/mcp-templates/unstract.json` for the configuration template.
+
+### 4. Claude Desktop Configuration (Docker)
+
+```json
+{
+  "mcpServers": {
+    "unstract_tool": {
+      "command": "/usr/local/bin/docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-v", "/tmp:/tmp",
+        "-e", "UNSTRACT_API_KEY",
+        "-e", "API_BASE_URL",
+        "unstract/mcp-server",
+        "unstract"
+      ],
+      "env": {
+        "UNSTRACT_API_KEY": "",
+        "API_BASE_URL": "https://us-central.unstract.com/deployment/api/.../"
+      }
+    }
+  }
+}
+```
+
+## Use Cases
+
+- **Invoice processing**: Extract line items, totals, vendor info from invoices
+- **Bank statement parsing**: Structure transaction data from varied bank formats
+- **Insurance claims**: Extract claim details from forms and supporting documents
+- **KYC/onboarding**: Parse identity documents and application forms
+- **Contract analysis**: Extract key terms, dates, parties from legal documents
+
+## Integration with aidevops
+
+This subagent is referenced by agents that need document extraction capabilities. The MCP loads only when document processing tasks are detected.
+
+**Trigger keywords**: document, extract, parse, invoice, statement, PDF, OCR, unstructured
+
+## Related
+
+- `tools/context/mcp-discovery.md` - On-demand MCP loading pattern
+- `.agent/aidevops/mcp-integrations.md` - All MCP integrations
+- `configs/mcp-templates/unstract.json` - OpenCode config template

--- a/.agent/services/document-processing/unstract.md
+++ b/.agent/services/document-processing/unstract.md
@@ -79,26 +79,51 @@ export UNSTRACT_API_KEY="your_api_key_here"
 export UNSTRACT_API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
 ```
 
-### Option B: Self-Hosted (Local)
+### Option B: Self-Hosted (Local) - Recommended
 
-Run the full Unstract platform locally via Docker Compose (requires 8GB RAM):
+Install and run the full Unstract platform locally (requires Docker, 8GB RAM):
 
 ```bash
-git clone https://github.com/Zipstack/unstract.git
-cd unstract
-./run-platform.sh
-# Visit http://frontend.unstract.localhost (login: unstract/unstract)
+# One-command install via aidevops helper:
+~/.aidevops/agents/scripts/unstract-helper.sh install
+
+# Or via the MCP integrations setup:
+~/.aidevops/agents/scripts/setup-mcp-integrations.sh unstract
 ```
 
-Then create your Prompt Studio project, deploy as API, and configure:
+This clones Unstract to `~/.aidevops/unstract/`, disables analytics, starts Docker Compose, and configures the MCP to point at your local instance.
+
+Visit http://frontend.unstract.localhost (login: unstract/unstract)
+
+**Management commands:**
 
 ```bash
-# Add to ~/.config/aidevops/mcp-env.sh:
-export UNSTRACT_API_KEY="your_local_api_key"
-export UNSTRACT_API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-deployment-id/"
+unstract-helper.sh start          # Start containers
+unstract-helper.sh stop           # Stop containers
+unstract-helper.sh status         # Check status
+unstract-helper.sh logs           # View logs
+unstract-helper.sh configure-llm  # Help adding LLM adapters
+unstract-helper.sh uninstall      # Remove everything
 ```
 
 Self-hosted gives full data privacy - no documents leave your machine.
+
+### Using Your Existing LLM API Keys
+
+Unstract uses "Adapters" to connect to LLM providers. Your existing API keys from `~/.config/aidevops/mcp-env.sh` work directly - just add them as adapters in the Unstract UI (Settings > Adapters):
+
+| Your Key | Unstract Adapter |
+|----------|-----------------|
+| `OPENAI_API_KEY` | OpenAI (GPT-4, GPT-4o) |
+| `ANTHROPIC_API_KEY` | Anthropic (Claude) |
+| `GOOGLE_API_KEY` / Vertex credentials | Google VertexAI / Gemini |
+| `AZURE_OPENAI_API_KEY` | Azure OpenAI |
+| AWS credentials | AWS Bedrock |
+| Ollama (local, no key) | Ollama (http://host.docker.internal:11434) |
+
+Run `unstract-helper.sh configure-llm` to see which keys you already have configured.
+
+For fully local/offline operation, use **Ollama** as the LLM adapter - no cloud API keys needed.
 
 ### 2. Store Credentials
 
@@ -106,7 +131,7 @@ Whichever option you chose, ensure credentials are in `~/.config/aidevops/mcp-en
 
 ```bash
 export UNSTRACT_API_KEY="your_api_key_here"
-export UNSTRACT_API_BASE_URL="https://your-endpoint/deployment/api/your-id/"
+export UNSTRACT_API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
 ```
 
 ### 3. OpenCode Configuration (On-Demand)

--- a/.agent/subagent-index.toon
+++ b/.agent/subagent-index.toon
@@ -72,7 +72,7 @@ bug-fixing,workflows/bug-fixing.md,Bug fix workflow
 feature-development,workflows/feature-development.md,Feature development workflow
 -->
 
-<!--TOON:scripts[20]{name,purpose}:
+<!--TOON:scripts[21]{name,purpose}:
 list-keys-helper.sh,List all API keys with storage locations
 linters-local.sh,Run local linting (ShellCheck secretlint patterns)
 code-audit-helper.sh,Run remote auditing (CodeRabbit Codacy SonarCloud)
@@ -93,4 +93,5 @@ full-loop-helper.sh,End-to-end development loop (task to PR to deploy)
 session-review-helper.sh,Gather session context for review
 mail-helper.sh,TOON-based inter-agent mailbox system
 memory-helper.sh,Cross-session memory (SQLite FTS5)
+unstract-helper.sh,Unstract self-hosted document processing (install start stop)
 -->

--- a/.agent/subagent-index.toon
+++ b/.agent/subagent-index.toon
@@ -22,7 +22,7 @@ flash,gemini-2.5-flash,Fast cheap large context
 pro,gemini-2.5-pro,Capable large context
 -->
 
-<!--TOON:subagents[31]{folder,purpose,key_files}:
+<!--TOON:subagents[32]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture,setup|architecture|troubleshooting
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings,dataforseo|serper|google-search-console|gsc-sitemaps|site-crawler|eeat-score
@@ -54,6 +54,7 @@ services/communications/,Communications - SMS and voice,twilio|telfon
 services/crm/,CRM integration - contact management,fluentcrm
 services/analytics/,Website analytics - GA4 reporting,google-analytics
 services/accounting/,Accounting integration - invoicing,quickfile
+services/document-processing/,Document processing - LLM-powered extraction,unstract
 -->
 
 <!--TOON:workflows[12]{name,file,purpose}:

--- a/configs/mcp-templates/unstract.json
+++ b/configs/mcp-templates/unstract.json
@@ -7,6 +7,6 @@
       "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL=\"$UNSTRACT_API_BASE_URL\" -e DISABLE_TELEMETRY=true unstract/mcp-server unstract"
     ],
     "enabled": false,
-    "_comment": "Disabled globally. Enabled on-demand via services/document-processing/unstract.md subagent. Requires UNSTRACT_API_KEY and UNSTRACT_API_BASE_URL in ~/.config/aidevops/mcp-env.sh"
+    "_comment": "Disabled globally. Enabled on-demand via services/document-processing/unstract.md subagent. Defaults to local self-hosted instance (install: unstract-helper.sh install). Set UNSTRACT_API_BASE_URL to cloud endpoint if preferred."
   }
 }

--- a/configs/mcp-templates/unstract.json
+++ b/configs/mcp-templates/unstract.json
@@ -4,7 +4,7 @@
     "command": [
       "/bin/bash",
       "-c",
-      "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL=\"$UNSTRACT_API_BASE_URL\" unstract/mcp-server unstract"
+      "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL=\"$UNSTRACT_API_BASE_URL\" -e DISABLE_TELEMETRY=true unstract/mcp-server unstract"
     ],
     "enabled": false,
     "_comment": "Disabled globally. Enabled on-demand via services/document-processing/unstract.md subagent. Requires UNSTRACT_API_KEY and UNSTRACT_API_BASE_URL in ~/.config/aidevops/mcp-env.sh"

--- a/configs/mcp-templates/unstract.json
+++ b/configs/mcp-templates/unstract.json
@@ -4,9 +4,9 @@
     "command": [
       "/bin/bash",
       "-c",
-      "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL=\"$UNSTRACT_API_BASE_URL\" -e DISABLE_TELEMETRY=true unstract/mcp-server unstract"
+      "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL -e DISABLE_TELEMETRY=true unstract/mcp-server:${UNSTRACT_IMAGE_TAG:-latest} unstract"
     ],
     "enabled": false,
-    "_comment": "Disabled globally. Enabled on-demand via services/document-processing/unstract.md subagent. Defaults to local self-hosted instance (install: unstract-helper.sh install). Set UNSTRACT_API_BASE_URL to cloud endpoint if preferred."
+    "_comment": "Disabled globally. Enabled on-demand via services/document-processing/unstract.md. Requires UNSTRACT_API_KEY and API_BASE_URL in mcp-env.sh. Pin image with UNSTRACT_IMAGE_TAG env var for reproducibility."
   }
 }

--- a/configs/mcp-templates/unstract.json
+++ b/configs/mcp-templates/unstract.json
@@ -1,0 +1,12 @@
+{
+  "unstract": {
+    "type": "local",
+    "command": [
+      "/bin/bash",
+      "-c",
+      "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL=\"$UNSTRACT_API_BASE_URL\" unstract/mcp-server unstract"
+    ],
+    "enabled": false,
+    "_comment": "Disabled globally. Enabled on-demand via services/document-processing/unstract.md subagent. Requires UNSTRACT_API_KEY and UNSTRACT_API_BASE_URL in ~/.config/aidevops/mcp-env.sh"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds [Unstract](https://github.com/Zipstack/unstract) as an on-demand MCP server for LLM-powered structured data extraction from unstructured documents (PDF, images, DOCX, etc.)
- MCP is disabled globally in OpenCode and loads only when document processing tasks are detected (on-demand pattern)
- Docker-based execution via `unstract/mcp-server` container

## Changes

| File | Purpose |
|------|---------|
| `.agent/services/document-processing/unstract.md` | New subagent with full setup docs, tool reference, and use cases |
| `configs/mcp-templates/unstract.json` | OpenCode MCP config template (disabled by default) |
| `.agent/aidevops/mcp-integrations.md` | Added Unstract to integrations list and quick reference |
| `.agent/subagent-index.toon` | Added document-processing service entry |

## Design Decisions

- **On-demand only**: Follows the established pattern (like FluentCRM) where MCP is `enabled: false` globally and activated per-agent via subagent frontmatter
- **Docker-based**: Uses official `unstract/mcp-server` Docker image for isolation and easy updates
- **Credential pattern**: `UNSTRACT_API_KEY` + `UNSTRACT_API_BASE_URL` stored in `~/.config/aidevops/mcp-env.sh`
- **New service category**: Created `services/document-processing/` for document extraction tools

## Testing

- Preflight linters pass (pre-existing ShellCheck/secretlint issues unrelated)
- TOON syntax validation passes
- Config follows established JSON template pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Unstract MCP integration for document processing with support for invoices, statements, claims, KYC, and contract analysis.

* **Documentation**
  * Added comprehensive setup guides, configuration templates, and deployment instructions for the new document processing integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->