### PR TITLE
fix: replace broken uvx command with uv tool run for serper MCP

### DIFF
--- a/.agent/scripts/setup-mcp-integrations.sh
+++ b/.agent/scripts/setup-mcp-integrations.sh
@@ -41,7 +41,7 @@ get_mcp_command() {
         "stagehand-python") echo "${HOME}/.aidevops/stagehand-python/.venv/bin/python ${HOME}/.aidevops/stagehand-python/examples/basic_example.py" ;;
         "stagehand-both") echo "both" ;;
         "dataforseo") echo "npx dataforseo-mcp-server" ;;
-        "serper") echo "uvx serper-mcp-server" ;;
+        "serper") echo "uv tool run serper-mcp-server" ;;
         *) echo "" ;;
     esac
     return 0
@@ -292,7 +292,7 @@ install_mcp() {
             print_info "For OpenCode, use bash wrapper pattern in opencode.json:"
             print_info '  "serper": {'
             print_info '    "type": "local",'
-            print_info '    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && SERPER_API_KEY=\$SERPER_API_KEY uvx serper-mcp-server"],'
+            print_info '    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && SERPER_API_KEY=\$SERPER_API_KEY uv tool run serper-mcp-server"],'
             print_info '    "enabled": true'
             print_info '  }'
             print_info ""
@@ -300,7 +300,7 @@ install_mcp() {
             print_info "GitHub: https://github.com/garylab/serper-mcp-server"
             
             # Check if uv is installed
-            if ! command -v uvx &> /dev/null && ! command -v uv &> /dev/null; then
+            if ! command -v uv &> /dev/null; then
                 print_warning "uv (Python package manager) not found"
                 print_info "Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"
                 print_info "Alternative: pip install serper-mcp-server"

--- a/.agent/scripts/setup-mcp-integrations.sh
+++ b/.agent/scripts/setup-mcp-integrations.sh
@@ -299,10 +299,10 @@ install_mcp() {
             print_info "Available tools: google_search, google_search_images, google_search_videos, google_search_places, google_search_maps, google_search_reviews, google_search_news, google_search_shopping, google_search_lens, google_search_scholar, google_search_patents, google_search_autocomplete, webpage_scrape"
             print_info "GitHub: https://github.com/garylab/serper-mcp-server"
             
-            # Check if uv is installed
-            if ! command -v uv &> /dev/null; then
-                print_warning "uv (Python package manager) not found"
-                print_info "Install with: curl -LsSf https://astral.sh/uv/install.sh | sh"
+            # Check if uv is installed and supports 'tool' subcommand
+            if ! command -v uv &> /dev/null || ! uv tool --help &> /dev/null; then
+                print_warning "uv (Python package manager) not found or too old"
+                print_info "Install/update with: curl -LsSf https://astral.sh/uv/install.sh | sh"
                 print_info "Alternative: pip install serper-mcp-server"
             fi
             ;;

--- a/configs/serper-config.json.txt
+++ b/configs/serper-config.json.txt
@@ -12,7 +12,7 @@
       "command": [
         "/bin/bash",
         "-c",
-        "source ~/.config/aidevops/mcp-env.sh && SERPER_API_KEY=$SERPER_API_KEY uvx serper-mcp-server"
+        "source ~/.config/aidevops/mcp-env.sh && SERPER_API_KEY=$SERPER_API_KEY uv tool run serper-mcp-server"
       ],
       "enabled": true
     }
@@ -21,8 +21,8 @@
     "_note": "Add to ~/Library/Application Support/Claude/claude_desktop_config.json",
     "mcpServers": {
       "serper": {
-        "command": "uvx",
-        "args": ["serper-mcp-server"],
+        "command": "uv",
+        "args": ["tool", "run", "serper-mcp-server"],
         "env": {
           "SERPER_API_KEY": "YOUR_SERPER_API_KEY"
         }
@@ -33,8 +33,8 @@
     "_note": "Add to ~/.cursor/mcp.json",
     "mcpServers": {
       "serper": {
-        "command": "uvx",
-        "args": ["serper-mcp-server"],
+        "command": "uv",
+        "args": ["tool", "run", "serper-mcp-server"],
         "env": {
           "SERPER_API_KEY": "YOUR_SERPER_API_KEY"
         }
@@ -45,8 +45,8 @@
     "_note": "Add to ~/.codeium/windsurf/mcp_config.json",
     "mcpServers": {
       "serper": {
-        "command": "uvx",
-        "args": ["serper-mcp-server"],
+        "command": "uv",
+        "args": ["tool", "run", "serper-mcp-server"],
         "env": {
           "SERPER_API_KEY": "YOUR_SERPER_API_KEY"
         }
@@ -54,7 +54,7 @@
     }
   },
   "pip_alternative": {
-    "_note": "Use this if you prefer pip over uv",
+    "_note": "Use this if you prefer pip over uv (fallback if uv not installed)",
     "mcpServers": {
       "serper": {
         "command": "python3",


### PR DESCRIPTION
## Summary

- Replace `uvx` with `uv tool run` in serper MCP config and setup script
- The `uvx` binary at `/opt/homebrew/bin/uvx` is a stale pip-installed Python wrapper pointing to a non-existent Python 3.11 interpreter, causing `bad interpreter` errors
- `uv tool run` is the correct, reliable way to invoke Python tools via uv (equivalent to the intended `uvx` alias)

## Changes

- `configs/serper-config.json.txt`: Updated all `uvx` references to `uv tool run` across OpenCode, Claude Desktop, Cursor, and Windsurf configs
- `.agent/scripts/setup-mcp-integrations.sh`: Updated command definition and prerequisite check to use `uv` directly

## Root Cause

The `/opt/homebrew/bin/uvx` file is a 232-byte Python script from a different `uvx` pip package (not uv's built-in alias), with shebang `#!/opt/homebrew/opt/python@3.11/bin/python3.11` which no longer exists. The real `uv` binary (32MB native) provides `uvx` functionality via `uv tool run`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Serper MCP integration to use revised tooling for server invocation.
  * Simplified setup prerequisites by removing redundant dependency checks.
  * Updated configuration files for Claude Desktop, Cursor, and Windsurf to align with new invocation method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->