### PR TITLE
refactor: remove serper MCP, use curl subagent instead

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -154,7 +154,7 @@ AGENT_TOOLS = {
     },
     "SEO": {
         "write": True, "read": True, "bash": True, "webfetch": True,
-        "gsc_*": True, "ahrefs_*": True, "dataforseo_*": True, "serper_*": True,
+        "gsc_*": True, "ahrefs_*": True, "dataforseo_*": True,
         "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True
     },
     "WordPress": {
@@ -534,18 +534,8 @@ if 'dataforseo_*' not in config['tools']:
     config['tools']['dataforseo_*'] = False
     print("  Added dataforseo_* to tools (disabled globally, enabled for SEO agent)")
 
-# Serper MCP - for Google Search API
-if 'serper' not in config['mcp']:
-    config['mcp']['serper'] = {
-        "type": "local",
-        "command": ["/bin/bash", "-c", f"source ~/.config/aidevops/mcp-env.sh && SERPER_API_KEY=$SERPER_API_KEY {pkg_runner} serper-mcp-server"],
-        "enabled": True
-    }
-    print("  Added serper MCP server")
-
-if 'serper_*' not in config['tools']:
-    config['tools']['serper_*'] = False
-    print("  Added serper_* to tools (disabled globally, enabled for SEO agent)")
+# Serper - REMOVED: Now uses curl-based subagent (.agent/seo/serper.md)
+# No MCP overhead, same functionality via direct API calls
 
 # Playwriter MCP - browser automation via Chrome extension
 # Requires: Chrome extension from https://chromewebstore.google.com/detail/playwriter-mcp/jfeammnjpkecdekppnclgkkffahnhfhe
@@ -653,9 +643,7 @@ while IFS= read -r f; do
         dataforseo)
             extra_tools=$'  dataforseo_*: true\n  webfetch: true'
             ;;
-        serper)
-            extra_tools=$'  serper_*: true\n  webfetch: true'
-            ;;
+        # serper - REMOVED: Uses curl subagent now, no MCP tools
         playwriter)
             extra_tools=$'  playwriter_*: true'
             ;;

--- a/.agent/scripts/setup-mcp-integrations.sh
+++ b/.agent/scripts/setup-mcp-integrations.sh
@@ -41,14 +41,14 @@ get_mcp_command() {
         "stagehand-python") echo "${HOME}/.aidevops/stagehand-python/.venv/bin/python ${HOME}/.aidevops/stagehand-python/examples/basic_example.py" ;;
         "stagehand-both") echo "both" ;;
         "dataforseo") echo "npx dataforseo-mcp-server" ;;
-        "serper") echo "uv tool run serper-mcp-server" ;;
+        # serper - REMOVED: Uses curl subagent (.agent/seo/serper.md), no MCP needed
         *) echo "" ;;
     esac
     return 0
 }
 
 # Available integrations list
-MCP_LIST="chrome-devtools playwright cloudflare-browser ahrefs perplexity nextjs-devtools google-search-console pagespeed-insights grep-vercel claude-code-mcp stagehand stagehand-python stagehand-both dataforseo serper"
+MCP_LIST="chrome-devtools playwright cloudflare-browser ahrefs perplexity nextjs-devtools google-search-console pagespeed-insights grep-vercel claude-code-mcp stagehand stagehand-python stagehand-both dataforseo"
 
 # Check prerequisites
 check_prerequisites() {
@@ -278,34 +278,8 @@ install_mcp() {
             print_info "Available modules: SERP, KEYWORDS_DATA, BACKLINKS, ONPAGE, DATAFORSEO_LABS, BUSINESS_DATA, DOMAIN_ANALYTICS, CONTENT_ANALYSIS, AI_OPTIMIZATION"
             print_info "Docs: https://docs.dataforseo.com/v3/"
             ;;
-        "serper")
-            print_info "Setting up Serper MCP for Google Search API..."
-            print_warning "Serper MCP requires API key"
-            print_info "Get API key from: https://serper.dev/"
-            print_info ""
-            print_info "Store in ~/.config/aidevops/mcp-env.sh:"
-            print_info "  export SERPER_API_KEY=\"your_api_key\""
-            print_info ""
-            print_info "Or use the helper script:"
-            print_info "  bash ~/.aidevops/agents/scripts/setup-local-api-keys.sh set SERPER_API_KEY your_key"
-            print_info ""
-            print_info "For OpenCode, use bash wrapper pattern in opencode.json:"
-            print_info '  "serper": {'
-            print_info '    "type": "local",'
-            print_info '    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && SERPER_API_KEY=\$SERPER_API_KEY uv tool run serper-mcp-server"],'
-            print_info '    "enabled": true'
-            print_info '  }'
-            print_info ""
-            print_info "Available tools: google_search, google_search_images, google_search_videos, google_search_places, google_search_maps, google_search_reviews, google_search_news, google_search_shopping, google_search_lens, google_search_scholar, google_search_patents, google_search_autocomplete, webpage_scrape"
-            print_info "GitHub: https://github.com/garylab/serper-mcp-server"
-            
-            # Check if uv is installed and supports 'tool' subcommand
-            if ! command -v uv &> /dev/null || ! uv tool --help &> /dev/null; then
-                print_warning "uv (Python package manager) not found or too old"
-                print_info "Install/update with: curl -LsSf https://astral.sh/uv/install.sh | sh"
-                print_info "Alternative: pip install serper-mcp-server"
-            fi
-            ;;
+        # "serper" - REMOVED: Uses curl subagent (.agent/seo/serper.md), no MCP needed
+        # Get API key from https://serper.dev/ and set SERPER_API_KEY in mcp-env.sh
         *)
             print_error "Unknown MCP integration: $mcp_name"
             print_info "Available integrations: $MCP_LIST"


### PR DESCRIPTION
## Summary

- Remove serper MCP server from aidevops - replaced by curl-based subagent
- The `.agent/seo/serper.md` subagent provides the same functionality using direct curl API calls
- No MCP server overhead, simpler setup, same capabilities

## Changes

- `generate-opencode-agents.sh`: Remove code that was re-adding serper MCP
- `setup-mcp-integrations.sh`: Remove serper from MCP list and install function
- Keep serper in `setup.sh` deprecated list so existing configs get cleaned up

## Migration

Users with existing serper MCP configs will have them removed on next `./setup.sh` run. The serper subagent (`.agent/seo/serper.md`) provides equivalent functionality via curl.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Serper integration from agent configurations and MCP server setup. Serper search tools and functionality are no longer available for use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->