### PR TITLE
refactor: optimize MCP loading with lazy-load strategy

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -639,10 +639,12 @@ if 'shadcn_*' not in config['tools']:
 # Claude Code MCP - spawn Claude as sub-agent (subagent only)
 # Source: https://github.com/steipete/claude-code-mcp
 # Use @claude-code subagent to invoke this MCP
-# Note: Always overwrite to ensure correct upstream package is used
+# Fork: https://github.com/marcusquinn/claude-code-mcp (until PR #40 merged upstream)
+# Upstream: https://github.com/steipete/claude-code-mcp
+# Note: Always overwrite to ensure correct fork is used
 config['mcp']['claude-code-mcp'] = {
     "type": "local",
-    "command": ["npx", "-y", "@steipete/claude-code-mcp"],
+    "command": ["npx", "-y", "github:marcusquinn/claude-code-mcp"],
     "enabled": False
 }
 print("  Set claude-code-mcp to lazy load (@claude-code subagent only)")

--- a/.agent/subagent-index.toon
+++ b/.agent/subagent-index.toon
@@ -31,7 +31,7 @@ tools/content/,Content tools - summarization and extraction,summarize
 tools/social-media/,Social media tools - X/Twitter CLI,bird
 tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-review
 tools/build-mcp/,MCP development - creating MCP servers,build-mcp|server-patterns|api-wrapper|transports|deployment
-tools/ai-assistants/,AI tool integration - configuring assistants,agno|capsolver|windsurf|configuration
+tools/ai-assistants/,AI tool integration - configuring assistants,agno|capsolver|windsurf|claude-code|configuration
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
 tools/browser/,Browser automation - scraping and testing,agent-browser|stagehand|playwright|playwriter|crawl4ai|pagespeed|peekaboo
 tools/mobile/,Mobile development - iOS/Android emulators,minisim

--- a/.agent/tools/ai-assistants/claude-code.md
+++ b/.agent/tools/ai-assistants/claude-code.md
@@ -1,0 +1,112 @@
+---
+description: Claude Code MCP - spawn Claude as a sub-agent for complex tasks
+mode: subagent
+tools:
+  read: true
+  bash: true
+  claude-code-mcp_*: true
+---
+
+# Claude Code MCP
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Spawn Claude Code as a sub-agent for complex, multi-step tasks
+- **MCP**: `claude-code-mcp` (loaded on-demand when this subagent is invoked)
+- **Source**: https://github.com/steipete/claude-code-mcp
+- **Install**: `npm install -g @steipete/claude-code-mcp`
+
+**When to use**:
+- Complex multi-file refactoring that benefits from fresh context
+- Tasks requiring extended thinking or different model capabilities
+- Parallel execution of independent subtasks
+- Second opinion on complex architectural decisions
+
+**When NOT to use**:
+- Simple file edits (use native Edit tool)
+- Quick searches (use grep/osgrep)
+- Single-file changes (overhead not worth it)
+
+<!-- AI-CONTEXT-END -->
+
+## Overview
+
+The Claude Code MCP allows spawning Claude Code as a sub-agent. This is useful for:
+
+1. **Context isolation**: Sub-agent gets fresh context, avoiding token bloat
+2. **Parallel execution**: Multiple sub-agents can work on independent tasks
+3. **Model flexibility**: Sub-agent can use different model/settings
+4. **Complex workflows**: Multi-step tasks that benefit from dedicated focus
+
+## Usage
+
+Invoke this subagent when you need Claude Code capabilities:
+
+```text
+@claude-code Refactor the authentication module to use JWT tokens
+```
+
+The subagent will:
+1. Load the `claude-code-mcp` tools
+2. Execute the task using Claude Code
+3. Return results to the parent agent
+
+## Available Tools
+
+When this subagent is invoked, these tools become available:
+
+| Tool | Description |
+|------|-------------|
+| `claude_code` | Execute a prompt via Claude Code CLI |
+
+## Example Prompts
+
+```text
+# Complex refactoring
+@claude-code Refactor src/auth/ to use the new token validation library
+
+# Multi-file analysis
+@claude-code Analyze all API endpoints and create a comprehensive test suite
+
+# Architecture review
+@claude-code Review the database schema and suggest optimizations
+
+# Parallel tasks (invoke multiple times)
+@claude-code Update all React components to use the new design system
+@claude-code Migrate all API routes to the new error handling pattern
+```
+
+## Configuration
+
+The MCP is configured in `opencode.json`:
+
+```json
+{
+  "mcp": {
+    "claude-code-mcp": {
+      "type": "local",
+      "command": ["npx", "-y", "@steipete/claude-code-mcp"],
+      "enabled": false
+    }
+  },
+  "tools": {
+    "claude-code-mcp_*": false
+  }
+}
+```
+
+The MCP starts on-demand when this subagent is invoked, avoiding startup overhead.
+
+## Best Practices
+
+1. **Be specific**: Provide clear, detailed prompts for best results
+2. **Scope appropriately**: Don't use for trivial tasks
+3. **Check results**: Review sub-agent output before proceeding
+4. **Avoid loops**: Don't have sub-agents spawn more sub-agents
+
+## Related
+
+- `tools/ai-assistants/overview.md` - AI assistant comparison
+- `tools/ai-orchestration/openprose.md` - Multi-agent orchestration DSL

--- a/configs/mcp-templates/claude-code-mcp.json
+++ b/configs/mcp-templates/claude-code-mcp.json
@@ -1,28 +1,27 @@
 {
-  "_comment": "Claude Code MCP (fork) configuration snippets for various AI tools",
-  "_documentation": "https://github.com/marcusquinn/claude-code-mcp",
-  "_upstream": "https://github.com/steipete/claude-code-mcp (revert if merged)",
+  "_comment": "Claude Code MCP configuration snippets for various AI tools",
+  "_documentation": "https://github.com/steipete/claude-code-mcp",
   "_note": "Requires Claude CLI with --dangerously-skip-permissions accepted (swap to ./start.sh for local dev)",
-  "_install": "npx -y github:marcusquinn/claude-code-mcp",
+  "_install": "npx -y @steipete/claude-code-mcp",
 
   "opencode": {
     "_file": "~/.config/opencode/opencode.json",
     "_section": "mcp",
     "claude-code-mcp": {
       "type": "local",
-      "command": ["npx", "-y", "github:marcusquinn/claude-code-mcp"],
-      "enabled": true
+      "command": ["npx", "-y", "@steipete/claude-code-mcp"],
+      "enabled": false
     }
   },
 
-  "claude_code_command": "claude mcp add claude-code-mcp \"npx -y github:marcusquinn/claude-code-mcp\"",
+  "claude_code_command": "claude mcp add claude-code-mcp \"npx -y @steipete/claude-code-mcp\"",
 
   "cursor": {
     "_file": "~/.cursor/mcp.json",
     "mcpServers": {
       "claude-code-mcp": {
         "command": "npx",
-        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
+        "args": ["-y", "@steipete/claude-code-mcp"]
       }
     }
   },
@@ -32,7 +31,7 @@
     "mcpServers": {
       "claude-code-mcp": {
         "command": "npx",
-        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
+        "args": ["-y", "@steipete/claude-code-mcp"]
       }
     }
   },
@@ -42,7 +41,7 @@
     "mcpServers": {
       "claude-code-mcp": {
         "command": "npx",
-        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
+        "args": ["-y", "@steipete/claude-code-mcp"]
       }
     }
   },
@@ -53,7 +52,7 @@
       "claude-code-mcp": {
         "type": "stdio",
         "command": "npx",
-        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
+        "args": ["-y", "@steipete/claude-code-mcp"]
       }
     }
   }

--- a/configs/mcp-templates/claude-code-mcp.json
+++ b/configs/mcp-templates/claude-code-mcp.json
@@ -1,27 +1,28 @@
 {
-  "_comment": "Claude Code MCP configuration snippets for various AI tools",
-  "_documentation": "https://github.com/steipete/claude-code-mcp",
+  "_comment": "Claude Code MCP (fork) configuration snippets for various AI tools",
+  "_documentation": "https://github.com/marcusquinn/claude-code-mcp",
+  "_upstream": "https://github.com/steipete/claude-code-mcp (revert when PR #40 merged)",
   "_note": "Requires Claude CLI with --dangerously-skip-permissions accepted (swap to ./start.sh for local dev)",
-  "_install": "npx -y @steipete/claude-code-mcp",
+  "_install": "npx -y github:marcusquinn/claude-code-mcp",
 
   "opencode": {
     "_file": "~/.config/opencode/opencode.json",
     "_section": "mcp",
     "claude-code-mcp": {
       "type": "local",
-      "command": ["npx", "-y", "@steipete/claude-code-mcp"],
+      "command": ["npx", "-y", "github:marcusquinn/claude-code-mcp"],
       "enabled": false
     }
   },
 
-  "claude_code_command": "claude mcp add claude-code-mcp \"npx -y @steipete/claude-code-mcp\"",
+  "claude_code_command": "claude mcp add claude-code-mcp \"npx -y github:marcusquinn/claude-code-mcp\"",
 
   "cursor": {
     "_file": "~/.cursor/mcp.json",
     "mcpServers": {
       "claude-code-mcp": {
         "command": "npx",
-        "args": ["-y", "@steipete/claude-code-mcp"]
+        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
       }
     }
   },
@@ -31,7 +32,7 @@
     "mcpServers": {
       "claude-code-mcp": {
         "command": "npx",
-        "args": ["-y", "@steipete/claude-code-mcp"]
+        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
       }
     }
   },
@@ -41,7 +42,7 @@
     "mcpServers": {
       "claude-code-mcp": {
         "command": "npx",
-        "args": ["-y", "@steipete/claude-code-mcp"]
+        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
       }
     }
   },
@@ -52,7 +53,7 @@
       "claude-code-mcp": {
         "type": "stdio",
         "command": "npx",
-        "args": ["-y", "@steipete/claude-code-mcp"]
+        "args": ["-y", "github:marcusquinn/claude-code-mcp"]
       }
     }
   }


### PR DESCRIPTION
## Summary

- Add `@claude-code` subagent for on-demand claude-code-mcp access (instead of loading in main agents)
- Implement lazy-loading strategy: 12 MCPs now start on-demand, 8 remain eager-loaded
- Enable `playwriter_*` and `repomix_*` globally for all main agents

## Changes

### MCP Loading Policy

**Eager-loaded (8)** - Start at OpenCode launch, used by all main agents:
- osgrep, augment-context-engine, context7, repomix, playwriter, gh_grep, sentry, socket

**Lazy-loaded (12)** - Start on-demand when subagent invokes them:
- claude-code-mcp, gsc, localwp, chrome-devtools, outscraper, amazon-order-history
- google-analytics-mcp, dataforseo, shadcn, macos-automator, quickfile, MCP_DOCKER

### Agent Tool Changes

- Removed `claude-code-mcp_*: true` from Build+ and AI-DevOps (use `@claude-code` subagent instead)
- Added `gh_grep_*: true` to Plan+, Build+, AI-DevOps
- Added `playwriter_*: true` and `repomix_*: true` to all main agents

### New Subagent

- `tools/ai-assistants/claude-code.md` - Invokes claude-code-mcp on-demand

## Impact

Reduces OpenCode startup time by deferring 12 MCP server initializations until actually needed.

## Testing

- [x] `generate-opencode-agents.sh` runs successfully
- [x] ShellCheck passes
- [x] MCP loading policy correctly applied to opencode.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new code analysis and automation tools with expanded availability across multiple assistants.
  * Implemented optimized tool loading: essential tools launch immediately, others activate on-demand for improved performance.
  * Expanded multiple assistants with extended tool permissions for enhanced functionality.

* **Documentation**
  * Added comprehensive guide for new Claude Code analysis tool.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->