### PR TITLE
feat(plan+): allow version check script for initial greeting

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -345,6 +345,9 @@ def get_agent_config(display_name, filename, subagents=None, model_tier=None):
                 "fd -e *": "allow",
                 "fd -g *": "allow",
                 "rg --files*": "allow",
+                # Version check for initial greeting
+                "~/.aidevops/agents/scripts/aidevops-update-check.sh": "allow",
+                "bash ~/.aidevops/agents/scripts/aidevops-update-check.sh": "allow",
                 # Deny everything else
                 "*": "deny"
             },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "2.85.0"
+    "version": "2.86.0"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 2.85.0
+# Version: 2.86.0
 
 set -euo pipefail
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "2.85.0",
+  "version": "2.86.0",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "main": "index.js",

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 2.85.0
+# Version: 2.86.0
 #
 # Quick Install (one-liner):
 #   bash <(curl -fsSL https://aidevops.dev/install)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=2.85.0
+sonar.projectVersion=2.86.0
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agent,configs,templates


### PR DESCRIPTION
## Summary

- Plan+ agent now has bash permission to run `aidevops-update-check.sh`
- Enables Plan+ to display the version greeting on conversation start
- Added both direct path and `bash` prefixed variants to handle different invocation patterns

## Changes

- `.agent/scripts/generate-opencode-agents.sh`: Added version check script to Plan+ bash permissions

## Testing

- Ran `generate-opencode-agents.sh` successfully
- Verified the permission appears in generated `opencode.json`
- ShellCheck passes with no issues