### PR TITLE
refactor: remove repomix/playwriter from default agent tools

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -117,67 +117,75 @@ AGENT_ORDER = ["Plan+", "Build+", "AI-DevOps"]
 
 # Special tool configurations per agent (by display name)
 # These are MCP tools that specific agents need access to
+# Note: repomix_* and playwriter_* are ONLY enabled for agents with browser/repomix subagents
+# to reduce context bloat from their verbose tool descriptions (~5,500 tokens saved)
 AGENT_TOOLS = {
     "Plan+": {
         # Planning agent - read all, write only to planning files (via permissions)
         # Bash enabled with granular permissions for read-only file discovery commands
+        # No repomix/playwriter - planning doesn't need browser or codebase packing
         "write": True, "edit": True, "bash": True,
         "read": True, "glob": True, "grep": True, "webfetch": True, "task": False,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True,
-        "gh_grep_*": True, "playwriter_*": True
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True,
+        "gh_grep_*": True
     },
     "Build+": {
+        # Build agent has browser subagents (playwright, stagehand) so needs playwriter
+        # Also needs repomix for codebase context operations
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True, "todoread": True, "todowrite": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True,
-        "gh_grep_*": True, "playwriter_*": True
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True,
+        "gh_grep_*": True, "repomix_*": True, "playwriter_*": True
     },
     "AI-DevOps": {
+        # Framework agent - needs repomix for skill generation, no browser needed
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True, "todoread": True, "todowrite": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True,
-        "gh_grep_*": True, "playwriter_*": True
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True,
+        "gh_grep_*": True, "repomix_*": True
     },
     "Onboarding": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True,
-        "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "osgrep_*": True, "augment-context-engine_*": True
     },
     "Accounts": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True, "quickfile_*": True,
-        "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "osgrep_*": True, "augment-context-engine_*": True
     },
     "Social-Media": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True,
-        "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "osgrep_*": True, "augment-context-engine_*": True
     },
     "SEO": {
         "write": True, "read": True, "bash": True, "webfetch": True,
         "gsc_*": True, "ahrefs_*": True, "dataforseo_*": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True
     },
     "WordPress": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
-        "localwp_*": True, "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "localwp_*": True, "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True
     },
     "Content": {
         "write": True, "edit": True, "read": True, "webfetch": True,
-        "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "osgrep_*": True, "augment-context-engine_*": True
     },
     "Research": {
         "read": True, "webfetch": True, "bash": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True
     },
 }
 
 # Default tools for agents not in AGENT_TOOLS
+# Note: repomix_* and playwriter_* NOT included by default - they add significant
+# context overhead from verbose tool descriptions. Enable per-agent as needed.
 # Note: claude-code-mcp_* NOT included - use @claude-code subagent instead
 DEFAULT_TOOLS = {
     "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
     "webfetch": True, "task": True,
-    "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+    "osgrep_*": True, "augment-context-engine_*": True
 }
 
 # Temperature settings (by display name, default 0.2)


### PR DESCRIPTION
## Summary

Remove `repomix_*` and `playwriter_*` MCP tools from `DEFAULT_TOOLS` and most `AGENT_TOOLS` entries to reduce context bloat on new sessions.

## Problem

These tools have verbose descriptions (~5,500 tokens combined) that were being loaded for every agent, even those that don't need browser automation or codebase packing. This was causing higher token usage on session start for Plan+ and other agents.

## Changes

| Agent | repomix_* | playwriter_* | Reason |
|-------|-----------|--------------|--------|
| Plan+ | Removed | Removed | Planning doesn't need browser/repomix |
| Build+ | **Kept** | **Kept** | Has browser subagents (playwright, stagehand) |
| AI-DevOps | **Kept** | Removed | Needs repomix for skill generation |
| All others | Removed | Removed | Not needed for their workflows |

## Expected Impact

- ~5,500 tokens saved per session for most agents
- Tools still available when needed via Build+ or AI-DevOps agents
- No functionality loss - just smarter tool loading