### PR TITLE
refactor: replace repomix MCP with CLI

### DIFF
--- a/.agent/aidevops/architecture.md
+++ b/.agent/aidevops/architecture.md
@@ -76,7 +76,7 @@ aidevops implements proven agent design patterns identified by Lance Martin (Lan
 GLOBAL_TOOLS = {"gsc_*": False, "outscraper_*": False, "osgrep_*": True, ...}
 AGENT_TOOLS = {
     "Plan+": {"write": False, "edit": False, "bash": False, ...},
-    "Build+": {"write": True, "context7_*": True, "repomix_*": True, ...},
+    "Build+": {"write": True, "context7_*": True, "bash": True, ...},
     "SEO": {"gsc_*": True, "google-analytics-mcp_*": True, ...},
 }
 ```

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -123,52 +123,52 @@ AGENT_TOOLS = {
         # Bash enabled with granular permissions for read-only file discovery commands
         "write": True, "edit": True, "bash": True,
         "read": True, "glob": True, "grep": True, "webfetch": True, "task": False,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True,
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True,
         "gh_grep_*": True, "playwriter_*": True
     },
     "Build+": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True, "todoread": True, "todowrite": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True,
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True,
         "gh_grep_*": True, "playwriter_*": True
     },
     "AI-DevOps": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True, "todoread": True, "todowrite": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True,
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True,
         "gh_grep_*": True, "playwriter_*": True
     },
     "Onboarding": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True,
-        "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "osgrep_*": True, "augment-context-engine_*": True, "playwriter_*": True
     },
     "Accounts": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True, "quickfile_*": True,
-        "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "osgrep_*": True, "augment-context-engine_*": True, "playwriter_*": True
     },
     "Social-Media": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True,
-        "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "osgrep_*": True, "augment-context-engine_*": True, "playwriter_*": True
     },
     "SEO": {
         "write": True, "read": True, "bash": True, "webfetch": True,
         "gsc_*": True, "ahrefs_*": True, "dataforseo_*": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "playwriter_*": True
     },
     "WordPress": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
-        "localwp_*": True, "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "localwp_*": True, "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "playwriter_*": True
     },
     "Content": {
         "write": True, "edit": True, "read": True, "webfetch": True,
-        "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "osgrep_*": True, "augment-context-engine_*": True, "playwriter_*": True
     },
     "Research": {
         "read": True, "webfetch": True, "bash": True,
-        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+        "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "playwriter_*": True
     },
 }
 
@@ -177,7 +177,7 @@ AGENT_TOOLS = {
 DEFAULT_TOOLS = {
     "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
     "webfetch": True, "task": True,
-    "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True, "playwriter_*": True
+    "osgrep_*": True, "augment-context-engine_*": True, "playwriter_*": True
 }
 
 # Temperature settings (by display name, default 0.2)
@@ -433,7 +433,7 @@ if os.path.exists(omo_config_path):
                 "tools": {
                     "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
                     "webfetch": True, "task": True, "todoread": True, "todowrite": True,
-                    "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True
+                    "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True
                 }
             }
             sorted_agents["Planner-Sisyphus"] = {
@@ -444,7 +444,7 @@ if os.path.exists(omo_config_path):
                 "tools": {
                     "write": False, "edit": False, "bash": False,
                     "read": True, "glob": True, "grep": True, "webfetch": True, "task": False,
-                    "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True, "repomix_*": True
+                    "context7_*": True, "osgrep_*": True, "augment-context-engine_*": True
                 }
             }
             print("  Added OmO agents: Sisyphus, Planner-Sisyphus (after WordPress)")
@@ -490,7 +490,7 @@ if model_count > 0:
 #   - enabled: False = Server starts on-demand when subagent invokes it (lazy loading)
 #
 # MCPs enabled at startup (used by main agents):
-#   - osgrep, augment-context-engine, context7, repomix, playwriter, gh_grep
+#   - osgrep, augment-context-engine, context7, playwriter, gh_grep
 #
 # MCPs lazy-loaded (subagent-only):
 #   - claude-code-mcp, outscraper, dataforseo, shadcn, macos-automator, gsc, localwp, etc.
@@ -515,7 +515,7 @@ pkg_runner = f"{bun_path} x" if bun_path else (npx_path or "npx")
 # MCP LOADING POLICY - Enforce enabled states for all MCPs
 # -----------------------------------------------------------------------------
 # Eager-loaded (enabled: True): Used by all main agents, start at launch
-EAGER_MCPS = {'osgrep', 'augment-context-engine', 'context7', 'repomix', 'playwriter', 'gh_grep', 'sentry', 'socket'}
+EAGER_MCPS = {'osgrep', 'augment-context-engine', 'context7', 'playwriter', 'gh_grep', 'sentry', 'socket'}
 
 # Lazy-loaded (enabled: False): Subagent-only, start on-demand
 LAZY_MCPS = {'claude-code-mcp', 'outscraper', 'dataforseo', 'shadcn', 'macos-automator', 
@@ -588,9 +588,6 @@ if 'gh_grep' not in config['mcp']:
 if 'gh_grep_*' not in config['tools']:
     config['tools']['gh_grep_*'] = False
     print("  Set gh_grep_* disabled globally (enabled for Plan+/Build+/AI-DevOps)")
-
-# repomix_* enabled globally (used by all main agents)
-config['tools']['repomix_*'] = True
 
 # -----------------------------------------------------------------------------
 # LAZY-LOADED MCPs (enabled: False) - Subagent-only, start on-demand

--- a/.agent/scripts/mcp-index-helper.sh
+++ b/.agent/scripts/mcp-index-helper.sh
@@ -201,7 +201,6 @@ for mcp_name, mcp_config in mcp_servers.items():
         'context7': ['query-docs', 'resolve-library-id'],
         'osgrep': ['search', 'trace', 'skeleton'],
         'augment-context-engine': ['codebase-retrieval'],
-        'repomix': ['pack_codebase', 'pack_remote_repository', 'generate_skill', 'attach_packed_output', 'read_repomix_output', 'grep_repomix_output', 'file_system_read_file', 'file_system_read_directory'],
         'dataforseo': ['serp', 'keywords', 'backlinks', 'domain-analytics'],
         # serper - REMOVED: Uses curl subagent (.agent/seo/serper.md)
         'gsc': ['query', 'sitemaps', 'inspect'],
@@ -224,7 +223,7 @@ for mcp_name, mcp_config in mcp_servers.items():
             # Derive category from MCP name
             if 'seo' in mcp_name.lower() or pattern in ['dataforseo', 'gsc']:
                 category = 'seo'
-            elif pattern in ['context7', 'osgrep', 'augment-context-engine', 'repomix']:
+            elif pattern in ['context7', 'osgrep', 'augment-context-engine']:
                 category = 'context'
             elif pattern in ['shadcn', 'playwriter']:
                 category = 'browser'

--- a/.agent/scripts/mcp-inspector-helper.sh
+++ b/.agent/scripts/mcp-inspector-helper.sh
@@ -385,7 +385,6 @@ Configuration:
     - mcp-dashboard    (HTTP)  - MCP Dashboard with WebSocket
     - crawl4ai         (stdio) - Web crawling
     - context7         (stdio) - Library documentation
-    - repomix          (stdio) - Repository packaging
     - filesystem       (stdio) - File system access
     - memory           (stdio) - Persistent memory
     - github           (stdio) - GitHub API

--- a/.agent/tools/build-agent/build-agent.md
+++ b/.agent/tools/build-agent/build-agent.md
@@ -647,7 +647,7 @@ Before using tools, verify you're using the optimal choice:
 | Read file contents | `mcp_read` | `cat` via bash | Better error handling |
 | Edit files | `mcp_edit` | `sed` via bash | Safer, atomic |
 | Web content | `mcp_webfetch` | `curl` via bash | Handles redirects |
-| Remote repo research | `mcp_webfetch` README first | `mcp_repomix_pack_remote_repository` | Prevents context overload |
+| Remote repo research | `mcp_webfetch` README first | `npx repomix --remote` | Prevents context overload |
 
 **Self-check prompt**: Before calling any MCP tool, ask:
 > "Is there a faster CLI alternative I should use via Bash?"

--- a/.agent/tools/context/context-builder-agent.md
+++ b/.agent/tools/context/context-builder-agent.md
@@ -7,8 +7,8 @@ tools:
   read: true
   write: true
   glob: true
-  repomix_*: true
   task: true
+note: Uses repomix CLI directly (not MCP) for better control and reliability
 ---
 
 # Context Builder Agent
@@ -17,18 +17,20 @@ Specialized agent for generating token-efficient context for AI coding assistant
 
 ## Purpose
 
-Generate optimized repository context using Repomix with Tree-sitter compression.
+Generate optimized repository context using Repomix CLI with Tree-sitter compression.
 Achieves ~80% token reduction while preserving code structure understanding.
 
 ## Reference Documentation
 
-Read `~/Git/aidevops/.agent/context-builder.md` for complete operational guidance.
+Read `tools/context/context-builder.md` for complete operational guidance.
 
 ## Available Commands
 
+**Helper Script** (preferred):
+
 ```bash
 # Helper script location
-~/Git/aidevops/.agent/scripts/context-builder-helper.sh
+~/.aidevops/agents/scripts/context-builder-helper.sh
 
 # Compress mode (recommended) - ~80% token reduction
 context-builder-helper.sh compress [path] [style]
@@ -49,18 +51,30 @@ context-builder-helper.sh remote user/repo [branch]
 context-builder-helper.sh compare [path]
 ```
 
-## Available MCP Tools (repomix_*)
+**Direct CLI** (when helper unavailable):
 
-When Repomix MCP is enabled:
-- `repomix_pack_repository` - Pack local or remote repository
-- `repomix_read_repomix_output` - Read generated context file
-- `repomix_file_system_tree` - Get directory structure
+```bash
+# Pack with compression (recommended)
+npx repomix@latest . --compress --output context.xml
+
+# Pack remote repository
+npx repomix@latest --remote user/repo --compress --output context.xml
+
+# Pack with patterns
+npx repomix@latest . --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Token analysis
+npx repomix@latest . --token-count-tree 100
+
+# Output to stdout
+npx repomix@latest . --stdout | pbcopy
+```
 
 ## When to Use
 
 | Scenario | Command | Token Impact |
 |----------|---------|--------------|
-| Architecture review | `compress` | ~80% reduction |
+| Architecture review | `compress` or `--compress` | ~80% reduction |
 | Full implementation details | `pack` | Full tokens |
 | Quick file subset | `quick . "**/*.ts"` | Minimal |
 | External repo analysis | `remote user/repo` | Compressed |

--- a/.agent/tools/context/context-builder.md
+++ b/.agent/tools/context/context-builder.md
@@ -10,6 +10,7 @@ tools:
   grep: true
   webfetch: true
   task: true
+note: Uses repomix CLI directly (not MCP) for better control and reliability
 ---
 
 # Context Builder - Token-Efficient AI Context Generation
@@ -19,43 +20,59 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Generate token-efficient context for AI coding assistants
-- **Tool**: Repomix wrapper with aidevops conventions
+- **Tool**: Repomix CLI via helper script or direct `npx repomix` commands
 - **Key Feature**: Tree-sitter compression (~80% token reduction)
 - **Output Dir**: `~/.aidevops/.agent-workspace/work/context/`
 
-**Commands**:
+**Helper Script Commands**:
 
 ```bash
 # Compress mode (recommended) - extracts code structure only
-.agent/scripts/context-builder-helper.sh compress [path]
+context-builder-helper.sh compress [path]
 
 # Full pack with smart defaults
-.agent/scripts/context-builder-helper.sh pack [path] [xml|markdown|json]
+context-builder-helper.sh pack [path] [xml|markdown|json]
 
 # Quick mode - auto-copies to clipboard
-.agent/scripts/context-builder-helper.sh quick [path] [pattern]
+context-builder-helper.sh quick [path] [pattern]
 
 # Analyze token usage per file
-.agent/scripts/context-builder-helper.sh analyze [path] [threshold]
+context-builder-helper.sh analyze [path] [threshold]
 
 # Pack remote GitHub repo
-.agent/scripts/context-builder-helper.sh remote user/repo [branch]
+context-builder-helper.sh remote user/repo [branch]
 
 # Compare full vs compressed
-.agent/scripts/context-builder-helper.sh compare [path]
+context-builder-helper.sh compare [path]
+```
 
-# Start MCP server
-.agent/scripts/context-builder-helper.sh mcp
-```text
+**Direct CLI Commands** (when helper unavailable):
+
+```bash
+# Pack local directory with compression
+npx repomix@latest . --compress --output context.xml
+
+# Pack remote repository
+npx repomix@latest --remote user/repo --compress --output context.xml
+
+# Pack with specific patterns
+npx repomix@latest . --include "src/**/*.ts" --ignore "**/*.test.ts"
+
+# Analyze token usage
+npx repomix@latest . --token-count-tree 100
+
+# Output to stdout (pipe to clipboard or other tools)
+npx repomix@latest . --stdout | pbcopy
+```
 
 **When to Use**:
 
 | Scenario | Command | Token Impact |
 |----------|---------|--------------|
-| Share full codebase with AI | `pack` | Full tokens |
-| Architecture understanding | `compress` | ~80% reduction |
+| Share full codebase with AI | `pack` or `npx repomix .` | Full tokens |
+| Architecture understanding | `compress` or `npx repomix . --compress` | ~80% reduction |
 | Quick file subset | `quick . "**/*.ts"` | Minimal |
-| External repo analysis | `remote user/repo` | Compressed |
+| External repo analysis | `remote user/repo` or `npx repomix --remote user/repo` | Compressed |
 
 **Code Maps (compress mode)** extracts:
 - Class names and signatures
@@ -75,15 +92,18 @@ tools:
 | Repo Size (KB) | Est. Tokens | Action |
 |----------------|-------------|--------|
 | < 500 | < 50K | Safe for compressed pack |
-| 500-2000 | 50-200K | Use `includePatterns` only |
+| 500-2000 | 50-200K | Use `--include` patterns only |
 | > 2000 | > 200K | **NEVER full pack** - targeted files only |
 
-4. **Use patterns** - `mcp_repomix_pack_remote_repository(..., includePatterns="README.md,src/**/*.ts")`
+4. **Use patterns**:
+```bash
+npx repomix@latest --remote user/repo --include "README.md,src/**/*.ts,docs/**" --compress
+```
 
 **What NOT to do:**
 ```bash
 # DANGEROUS - packs entire repo without size check
-mcp_repomix_pack_remote_repository(remote="https://github.com/some/large-repo")
+npx repomix@latest --remote https://github.com/some/large-repo
 ```
 
 See `tools/context/context-guardrails.md` for full workflow and recovery procedures.
@@ -258,37 +278,9 @@ Output:
 Size reduction: 80.4%
 ```text
 
-## MCP Server Integration
+## Note on MCP
 
-Context Builder can run as an MCP server for direct AI assistant integration:
-
-```bash
-# Start MCP server
-./context-builder-helper.sh mcp
-```text
-
-### OpenCode Configuration
-
-Add to `~/.config/opencode/opencode.json`:
-
-```json
-{
-  "mcp": {
-    "repomix": {
-      "type": "local",
-      "command": ["/opt/homebrew/bin/npx", "-y", "repomix@latest", "--mcp"],
-      "enabled": true
-    }
-  }
-}
-```text
-
-### Available MCP Tools
-
-When running as MCP server:
-- `pack_repository` - Pack local or remote repository
-- `read_repomix_output` - Read generated context file
-- `file_system_tree` - Get directory structure
+While Repomix supports MCP server mode (`npx repomix --mcp`), this framework uses the CLI directly for better control and reliability. The helper script and direct CLI commands provide all needed functionality.
 
 ## Output Files
 

--- a/configs/mcp-servers-config.json.txt
+++ b/configs/mcp-servers-config.json.txt
@@ -19,11 +19,6 @@
       "url": "https://mcp.context7.com/mcp",
       "description": "Context7 MCP server for accessing latest documentation of development tools and frameworks"
     },
-    "repomix": {
-      "command": "npx",
-      "args": ["-y", "repomix@latest", "--mcp"],
-      "description": "Repomix MCP server for AI-optimized codebase analysis"
-    },
     "augment-context-engine": {
       "command": "auggie",
       "args": ["--mcp"],

--- a/setup.sh
+++ b/setup.sh
@@ -192,6 +192,7 @@ cleanup_deprecated_mcps() {
         "dataforseo"
         "hostinger-api"
         "shadcn"
+        "repomix"
     )
     
     # Tool rules to remove (for MCPs that no longer exist)
@@ -202,6 +203,7 @@ cleanup_deprecated_mcps() {
         "dataforseo_*"
         "serper_*"
         "shadcn_*"
+        "repomix_*"
     )
     
     local cleaned=0
@@ -233,7 +235,6 @@ cleanup_deprecated_mcps() {
     local -a mcp_pkgs=(
         "chrome-devtools-mcp"
         "mcp-server-gsc"
-        "repomix"
         "playwriter"
         "@steipete/macos-automator-mcp"
         "@steipete/claude-code-mcp"
@@ -242,7 +243,6 @@ cleanup_deprecated_mcps() {
     local -a mcp_bins=(
         "chrome-devtools-mcp"
         "mcp-server-gsc"
-        "repomix"
         "playwriter"
         "macos-automator-mcp"
         "claude-code-mcp"
@@ -262,12 +262,7 @@ cleanup_deprecated_mcps() {
             local full_path
             full_path=$(resolve_mcp_binary_path "$bin_name")
             if [[ -n "$full_path" ]]; then
-                # Preserve --mcp flag for repomix
-                if [[ "$bin_name" == "repomix" ]]; then
-                    jq --arg k "$mcp_key" --arg p "$full_path" '.mcp[$k].command = [$p, "--mcp"]' "$tmp_config" > "${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-                else
-                    jq --arg k "$mcp_key" --arg p "$full_path" '.mcp[$k].command = [$p]' "$tmp_config" > "${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-                fi
+                jq --arg k "$mcp_key" --arg p "$full_path" '.mcp[$k].command = [$p]' "$tmp_config" > "${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
                 ((cleaned++))
             fi
         fi
@@ -2157,7 +2152,6 @@ install_mcp_packages() {
     local -a node_mcps=(
         "chrome-devtools-mcp"
         "mcp-server-gsc"
-        "repomix"
         "playwriter"
         "@steipete/macos-automator-mcp"
         "@steipete/claude-code-mcp"


### PR DESCRIPTION
## Summary

- Replace repomix MCP integration with direct CLI usage (`npx repomix`)
- Remove repomix from MCP server configs and setup.sh
- Add repomix to deprecated MCPs list for automatic cleanup of existing user configs

## Why

CLI provides equivalent functionality with:
- No MCP server startup overhead
- Works without MCP configuration
- Direct control over output location
- Easier to chain with other commands

## Changes

**Documentation** (commit 1):
- Update context-builder.md with CLI examples
- Update context-builder-agent.md to remove MCP tool references
- Update context-guardrails.md with CLI commands
- Update architecture.md and build-agent.md references

**MCP Removal** (commit 2):
- Remove from `configs/mcp-servers-config.json.txt`
- Remove from `setup.sh` MCP installation lists
- Remove `repomix_*` tool permissions from `generate-opencode-agents.sh`
- Remove from `mcp-index-helper.sh` and `mcp-inspector-helper.sh`
- Add to deprecated MCPs list for automatic cleanup