### PR TITLE
docs: add community standards documents

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Report a bug to help us improve
+title: ''
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear description of what the bug is.
+
+**To reproduce**
+Steps to reproduce:
+
+1. Run '...'
+2. See error
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+
+- OS: [e.g., macOS 14, Ubuntu 22.04]
+- aidevops version: [run `aidevops --version`]
+- Shell: [e.g., zsh, bash]
+
+**Additional context**
+Any other relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for aidevops
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+**Problem**
+What problem does this solve?
+
+**Proposed solution**
+How would you like it to work?
+
+**Alternatives considered**
+Any other approaches you've thought about.
+
+**Additional context**
+Any other relevant information.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+Brief description of changes.
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor
+
+## Checklist
+
+- [ ] I have tested my changes locally
+- [ ] I have followed the commit message conventions
+- [ ] I have updated documentation if needed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,60 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**aidevops@marcusquinn.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to aidevops
+
+Thanks for your interest in contributing! This guide will help you get started.
+
+## Quick Start
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/aidevops.git`
+3. Create a branch: `git checkout -b feature/your-feature`
+4. Make your changes
+5. Run tests: `./setup.sh` (installs locally for testing)
+6. Commit with conventional commits: `git commit -m "feat: add new feature"`
+7. Push and open a PR
+
+## Development Setup
+
+```bash
+# Clone and install
+git clone https://github.com/marcusquinn/aidevops.git
+cd aidevops
+./setup.sh
+
+# Run quality checks before committing
+.agent/scripts/linters-local.sh
+```
+
+## Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat:` - New feature
+- `fix:` - Bug fix
+- `docs:` - Documentation only
+- `refactor:` - Code change that neither fixes a bug nor adds a feature
+- `chore:` - Maintenance tasks
+
+## Code Standards
+
+- Shell scripts: ShellCheck compliant, use `local var="$1"` pattern
+- Markdown: Follow `.markdownlint.json` rules
+- Quality target: SonarCloud A-grade
+
+## Questions?
+
+Open an issue or start a discussion. We're happy to help!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately:
+
+**Email:** aidevops@marcusquinn.com
+
+**Please include:**
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fixes (optional)
+
+**Response timeline:**
+
+- Acknowledgment within 48 hours
+- Initial assessment within 7 days
+- Fix timeline communicated based on severity
+
+**Please do not:**
+
+- Open public issues for security vulnerabilities
+- Exploit vulnerabilities beyond proof-of-concept
+
+We appreciate responsible disclosure and will credit reporters in release notes
+(unless you prefer to remain anonymous).


### PR DESCRIPTION
## Summary

- Add CODE_OF_CONDUCT.md (Contributor Covenant 2.1)
- Add CONTRIBUTING.md (contribution guide)
- Add SECURITY.md (security policy)
- Add issue templates (bug report, feature request)
- Add pull request template

## Type of change

- [x] Documentation

## Checklist

- [x] I have tested my changes locally
- [x] I have followed the commit message conventions
- [x] I have updated documentation if needed

Closes the community standards checklist items at https://github.com/marcusquinn/aidevops/community