### PR TITLE
refactor: disable Playwriter MCP globally, enable per-agent only

### DIFF
--- a/.agent/tools/browser/playwriter.md
+++ b/.agent/tools/browser/playwriter.md
@@ -50,6 +50,8 @@ Always headed (uses your visible browser). Proxy support via browser settings or
 
 **When to use**: When you need your existing logged-in sessions, browser extensions (especially password managers), or want to collaborate with AI on a page you're viewing.
 
+**vs playwright-cli**: Use `playwright-cli` for headless automation (no MCP needed, just CLI). Use Playwriter when you need your existing browser state, extensions, or passwords.
+
 <!-- AI-CONTEXT-END -->
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ MCP packages are installed globally via `bun install -g` for instant startup (no
 - **Global** - Tools always available (loaded into every session)
 - **Per-agent** - Tools disabled globally, enabled per-agent via config (zero context overhead when unused)
 
-**Performance optimization:** MCP packages are installed globally via `bun install -g` for instant startup (~0.1s vs 2-3s with `npx`). The framework uses a three-tier loading strategy: 8 MCPs load eagerly at startup, 12 MCPs load on-demand when their subagent is invoked. This reduces OpenCode startup time by 12-24 seconds.
+**Performance optimization:** MCP packages are installed globally via `bun install -g` for instant startup (~0.1s vs 2-3s with `npx`). The framework uses a three-tier loading strategy: 7 MCPs load eagerly at startup, 13 MCPs load on-demand when their subagent is invoked. This reduces OpenCode startup time by 12-24 seconds.
 
 ### **SEO Integrations (curl subagents - no MCP overhead)**
 


### PR DESCRIPTION
## Summary

- Move Playwriter from eager-loaded to lazy-loaded MCPs
- Disable `playwriter_*` tools globally (was enabled for all agents)
- Build+ agent retains `playwriter_*: true` for existing browser sessions
- Update README MCP counts (7 eager → 13 lazy)

## Why?

Playwriter MCP adds context overhead even when not needed. It should only be loaded when:
- Using existing browser sessions with extensions/passwords
- Collaborating with AI on a visible browser tab

For headless automation, use `playwright-cli` instead (CLI-based, no MCP needed).

## Changes

| Before | After |
|--------|-------|
| `playwriter` in EAGER_MCPS | `playwriter` in LAZY_MCPS |
| `playwriter_*: True` globally | `playwriter_*: False` globally |
| 8 eager MCPs | 7 eager MCPs |
| 12 lazy MCPs | 13 lazy MCPs |

## When to use each tool

| Need | Tool |
|------|------|
| Headless automation | `playwright-cli` (CLI, no MCP) |
| Existing browser sessions | Playwriter MCP (per-agent) |
| Extensions/passwords | Playwriter MCP (per-agent) |