### PR TITLE
docs: add playwright-cli integration with DevTools and anti-detect

### DIFF
--- a/.agent/tools/browser/anti-detect-browser.md
+++ b/.agent/tools/browser/anti-detect-browser.md
@@ -103,10 +103,34 @@ Need anti-detection?
 ~/.aidevops/agents/scripts/anti-detect-helper.sh profile clean "my-account"
 ```
 
+## Integration with playwright-cli
+
+playwright-cli uses Playwright's Chromium under the hood. For stealth:
+
+| Stealth Level | Setup | Use Case |
+|---------------|-------|----------|
+| **None** | `playwright-cli open <url>` | Dev testing, trusted sites |
+| **Medium** | Apply rebrowser-patches, then use playwright-cli | Hide automation signals |
+| **High** | Use Camoufox + Playwright API directly | Bot detection evasion |
+
+**Medium stealth with playwright-cli**:
+
+```bash
+# 1. Patch Playwright's Chromium (one-time)
+npx rebrowser-patches@latest patch
+
+# 2. Use playwright-cli normally - it uses patched browser
+playwright-cli open https://bot-detection-test.com
+playwright-cli snapshot
+```
+
+**High stealth** requires Camoufox with Playwright API (not playwright-cli) for fingerprint rotation. See `fingerprint-profiles.md`.
+
 ## Subagent Index
 
 | Subagent | Purpose | When to Read |
 |----------|---------|--------------|
+| `playwright-cli.md` | CLI automation (works with rebrowser-patches) | AI agent automation |
 | `stealth-patches.md` | Chromium automation signal removal | Quick stealth, existing Playwright code |
 | `fingerprint-profiles.md` | Camoufox fingerprint rotation & spoofing | Full anti-detect, unique identities |
 | `browser-profiles.md` | Multi-profile management (persistent/clean) | Account management, session persistence |

--- a/.agent/tools/browser/browser-automation.md
+++ b/.agent/tools/browser/browser-automation.md
@@ -320,6 +320,11 @@ playwright-cli tracing-stop
 
 **vs agent-browser**: Simpler ref syntax (`e5` vs `@e5`), built-in tracing, Microsoft-maintained. agent-browser has Rust CLI for faster cold starts and more commands.
 
+**Integrations**:
+- **Chrome DevTools MCP**: Connect to playwright-cli's browser for Lighthouse, network monitoring
+- **Anti-detect (rebrowser-patches)**: Apply patches to Playwright's Chromium, then use playwright-cli normally
+- See `playwright-cli.md` for detailed integration examples
+
 **Skill installation** (Claude Code):
 
 ```bash

--- a/.agent/tools/browser/chrome-devtools.md
+++ b/.agent/tools/browser/chrome-devtools.md
@@ -58,6 +58,7 @@ npx chrome-devtools-mcp@latest --autoConnect
 - Automation: `comprehensiveAnalysis()`, `comparePages()` (A/B testing)
 
 **Best pairings**:
+- **playwright-cli + DevTools**: CLI automation + performance profiling (AI agents)
 - **dev-browser + DevTools**: Persistent profile + deep inspection
 - **Playwright + DevTools**: Speed + performance profiling
 - **Playwriter + DevTools**: Your browser + debugging your extensions

--- a/.agent/tools/browser/playwright-cli.md
+++ b/.agent/tools/browser/playwright-cli.md
@@ -337,6 +337,54 @@ playwright-cli screenshot
 - **Stagehand** - Natural language automation, self-healing selectors
 - **Playwright direct** - Maximum speed, full API control, TypeScript projects
 
+## Integration with Other Tools
+
+### Chrome DevTools MCP
+
+playwright-cli exposes a CDP endpoint that Chrome DevTools MCP can connect to for debugging:
+
+```bash
+# Start playwright-cli with remote debugging
+playwright-cli open https://example.com --headed
+
+# In another terminal, connect DevTools MCP to the browser
+# (playwright-cli uses Chromium on port 9222 by default)
+npx chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:9222
+```
+
+**Use cases**:
+- Performance profiling with Lighthouse while automating
+- Network monitoring during form submissions
+- CSS coverage analysis
+- Console error capture
+
+See `tools/browser/chrome-devtools.md` for full DevTools capabilities.
+
+### Anti-Detect Browser Stack
+
+playwright-cli uses Playwright under the hood, so it works with the anti-detect stack:
+
+**Quick stealth (rebrowser-patches)**:
+
+```bash
+# Install rebrowser-patches for Chromium
+# See tools/browser/stealth-patches.md for setup
+
+# playwright-cli will use the patched Chromium automatically
+# if installed in the Playwright browsers directory
+playwright-cli open https://bot-detection-test.com
+```
+
+**Full anti-detect (Camoufox)**:
+
+For maximum stealth with fingerprint rotation, use Camoufox directly with Playwright API rather than playwright-cli. See `tools/browser/anti-detect-browser.md`.
+
+| Stealth Level | Tool | Use Case |
+|---------------|------|----------|
+| None | playwright-cli (default) | Dev testing, trusted sites |
+| Medium | rebrowser-patches + playwright-cli | Hide automation signals |
+| High | Camoufox + Playwright API | Bot detection evasion, multi-account |
+
 ## Resources
 
 - **GitHub**: https://github.com/microsoft/playwright-cli


### PR DESCRIPTION
## Summary

Documents how playwright-cli integrates with other browser tools:

### playwright-cli.md
- Added Chrome DevTools MCP integration section
- Added anti-detect browser stack integration section
- Stealth level comparison table

### chrome-devtools.md
- Added playwright-cli to "Best pairings" list

### anti-detect-browser.md
- Added "Integration with playwright-cli" section
- Added playwright-cli to subagent index
- Stealth level guide (none/medium/high)

### browser-automation.md
- Added integrations note to playwright-cli section

## Integration Summary

| Tool | Works with playwright-cli? | How |
|------|---------------------------|-----|
| Chrome DevTools MCP | Yes | Connect to CDP endpoint on port 9222 |
| rebrowser-patches | Yes | Patch Chromium, then use playwright-cli normally |
| Camoufox | No (use Playwright API) | Requires Python API for fingerprint rotation |

## Stealth Levels

| Level | Setup | Use Case |
|-------|-------|----------|
| None | `playwright-cli open <url>` | Dev testing |
| Medium | `npx rebrowser-patches patch` + playwright-cli | Hide automation signals |
| High | Camoufox + Playwright API | Full anti-detect |