### PR TITLE
fix: use custom system prompt for ALL primary agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "2.86.1"
+    "version": "2.87.0"
   },
   "plugins": [
     {

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ The result: AI agents that work *with* your development process, not around it.
 ### Agent Structure
 
 - 18 primary agents (Plan+, Build+, SEO, WordPress, etc.)
-- 560+ subagent markdown files organized by domain
-- 146+ helper scripts in `.agent/scripts/`
+- 500+ subagent markdown files organized by domain
+- 140+ helper scripts in `.agent/scripts/`
 - 41 slash commands for common workflows
 
 <!-- AI-CONTEXT-END -->
@@ -491,7 +491,7 @@ aidevops implements proven agent design patterns identified by [Lance Martin (La
 
 | Pattern | Description | aidevops Implementation |
 |---------|-------------|------------------------|
-| **Give Agents a Computer** | Filesystem + shell for persistent context | `~/.aidevops/.agent-workspace/`, 141+ helper scripts |
+| **Give Agents a Computer** | Filesystem + shell for persistent context | `~/.aidevops/.agent-workspace/`, 140+ helper scripts |
 | **Multi-Layer Action Space** | Few tools, push actions to computer | Per-agent MCP filtering (~12-20 tools each) |
 | **Progressive Disclosure** | Load context on-demand | Subagent routing with content summaries, YAML frontmatter, read-on-demand |
 | **Offload Context** | Write results to filesystem | `.agent-workspace/work/[project]/` for persistence |
@@ -1166,7 +1166,7 @@ aidevops is registered as a **Claude Code plugin marketplace**. Install with two
 /plugin install aidevops@aidevops
 ```
 
-This installs the complete framework: 18 primary agents, 536+ subagents, and 141+ helper scripts.
+This installs the complete framework: 18 primary agents, 500+ subagents, and 140+ helper scripts.
 
 ### Importing External Skills
 
@@ -1254,7 +1254,7 @@ Ordered as they appear in OpenCode Tab selector and other AI assistants (15 tota
 
 ### **Example Subagents with MCP Integration**
 
-These are examples of subagents that have supporting MCPs enabled. See `.agent/` for the full list of 536+ subagents organized by domain.
+These are examples of subagents that have supporting MCPs enabled. See `.agent/` for the full list of 500+ subagents organized by domain.
 
 | Agent | Purpose | MCPs Enabled |
 |-------|---------|--------------|
@@ -1807,7 +1807,7 @@ aidevops/
 ├── .agent/                        # Agents and documentation
 │   ├── AGENTS.md                  # User guide (deployed to ~/.aidevops/agents/)
 │   ├── *.md                       # 18 primary agents
-│   ├── scripts/                   # 141+ helper scripts
+│   ├── scripts/                   # 140+ helper scripts
 │   ├── tools/                     # Cross-domain utilities (video, browser, git, etc.)
 │   ├── services/                  # External service integrations
 │   └── workflows/                 # Development process guides

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 2.86.1
+# Version: 2.87.0
 
 set -euo pipefail
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "2.86.1",
+  "version": "2.87.0",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "main": "index.js",

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 2.86.1
+# Version: 2.87.0
 #
 # Quick Install (one-liner):
 #   bash <(curl -fsSL https://aidevops.dev/install)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=2.86.1
+sonar.projectVersion=2.87.0
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agent,configs,templates


### PR DESCRIPTION
## Summary

- Apply custom system prompt (`prompts/build.txt`) to ALL primary agents by default
- Fixes identity confusion when running in Claude Code vs OpenCode
- Previously only Build+, AI-DevOps, and Sisyphus had custom prompts

## Changes

- Replace `AGENT_PROMPTS` dict with `DEFAULT_PROMPT` + `SKIP_CUSTOM_PROMPT` set
- All primary agents now use the custom prompt unless explicitly excluded
- OmO agents (Sisyphus, Planner-Sisyphus) also get the custom prompt

## Problem

When running Plan+ in Claude Code, it inherited Claude Code's default system prompt which says "You are Claude Code". This caused identity confusion. Build+ worked correctly because it had an explicit custom prompt.

## Solution

All primary agents now use `~/.aidevops/agents/prompts/build.txt` by default, ensuring consistent identity ("You are OpenCode") and tool preferences across all agents.