### PR TITLE
fix: add external_directory permission to Plan+ agent

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -337,6 +337,9 @@ def get_agent_config(display_name, filename, subagents=None, model_tier=None):
         # Bash has granular permissions for read-only file discovery commands
         # Path-based permissions: deny by default, allow specific paths
         config["permission"] = {
+            # Allow reading from external directories (e.g., ~/.aidevops/agents/)
+            # Required for version check greeting and reading agent documentation
+            "external_directory": "allow",
             "bash": {
                 # File discovery commands (fast alternatives to mcp_glob)
                 "git ls-files*": "allow",


### PR DESCRIPTION
## Summary

Plan+ was prompting for permission to access `~/.aidevops/agents/` when reading the VERSION file for the greeting message.

## Fix

Added `'external_directory': 'allow'` to Plan+ permissions while maintaining the restricted write/edit permissions for planning files only.

## Testing

After this fix, Plan+ will no longer prompt for external directory access on startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan+ agent now has permission to access external directories, enabling it to perform version checks and retrieve agent documentation from external sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->