### PR TITLE
feat(t021): auto-mark tasks complete from commit messages in release

### DIFF
--- a/.agent/workflows/release.md
+++ b/.agent/workflows/release.md
@@ -332,14 +332,30 @@ cd ~/Git/aidevops && ./setup.sh
 
 This ensures `~/.aidevops/agents/` has the latest release with updated version references.
 
-### Task Completion
+### Task Completion (Automatic)
 
-Mark all tasks included in this release as completed:
+The release script **automatically marks tasks complete** based on commit messages:
 
-1. **Move tasks** from `## In Progress` or `## In Review` to `## Done`
-2. **Add timestamps**: `completed:` with current date
-3. **Add actual time**: `actual:` if known (calculate from `started:`)
-4. **Sync with Beads**
+1. **Scans commits** since last release for task IDs (t001, t001.1, etc.)
+2. **Updates TODO.md** - changes `- [ ]` to `- [x]` and adds `completed:` timestamp
+3. **Commits changes** as part of the release commit
+
+**Supported commit patterns:**
+- Direct reference: `chore: mark t001 as complete`
+- Conventional commits: `feat(t001): add user dashboard`
+- Any mention: `fix: resolve issue in t002 validation`
+
+**Manual commands:**
+
+```bash
+# Preview which tasks would be marked complete
+.agent/scripts/version-manager.sh list-task-ids
+
+# Manually run auto-mark (without release)
+.agent/scripts/version-manager.sh auto-mark-tasks
+```
+
+**Manual completion** (if needed):
 
 ```markdown
 # Before (in ## In Progress or ## In Review)
@@ -350,13 +366,9 @@ Mark all tasks included in this release as completed:
 ```
 
 ```bash
-# Sync with Beads after updating TODO.md
+# Sync with Beads after manual updates
 ~/.aidevops/agents/scripts/beads-sync-helper.sh push
 ```
-
-**Task identification**: The release script can parse commit messages for task IDs:
-- Conventional commits: `feat(t001): add user dashboard`
-- Issue references: `Closes #123` (if linked to task)
 
 ### Time Summary
 


### PR DESCRIPTION
## Summary

Implements automatic task completion marking during the release workflow. When running `version-manager.sh release`, the script now:

1. Scans commits since the last release tag for task IDs (t001, t001.1, etc.)
2. Updates TODO.md to mark those tasks as complete (`- [ ]` → `- [x]`)
3. Adds `completed:` timestamp to each marked task
4. Includes TODO.md in the release commit

## Changes

- **version-manager.sh**: Added `extract_task_ids_from_commits()` and `auto_mark_tasks_complete()` functions
- **release.md**: Updated documentation to reflect automatic task completion behavior

## New Commands

```bash
# Preview which tasks would be marked complete
.agent/scripts/version-manager.sh list-task-ids

# Manually run auto-mark (without release)
.agent/scripts/version-manager.sh auto-mark-tasks
```

## Supported Patterns

Task IDs are extracted from commit messages matching:
- Direct reference: `chore: mark t001 as complete`
- Conventional commits: `feat(t001): add user dashboard`
- Subtasks: `fix: resolve t002.1 validation issue`
- Any mention: `docs: update t003 documentation`

## Testing

- [x] ShellCheck passes
- [x] `list-task-ids` correctly extracts task IDs from commits
- [x] `auto-mark-tasks` correctly identifies already-complete tasks
- [x] Regex handles all task ID formats (t001, t001.1, t001.1.1)

Closes #t021

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated task completion during releases: task IDs in commit messages are now automatically marked as complete in TODO.md with timestamps.
  * Added CLI commands to preview and trigger automatic task completion during the release workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->