### PR TITLE
chore: update README counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ The result: AI agents that work *with* your development process, not around it.
 ### Agent Structure
 
 - 18 primary agents (Plan+, Build+, SEO, WordPress, etc.)
-- 500+ subagent markdown files organized by domain
-- 140+ helper scripts in `.agent/scripts/`
+- 540+ subagent markdown files organized by domain
+- 145+ helper scripts in `.agent/scripts/`
 - 41 slash commands for common workflows
 
 <!-- AI-CONTEXT-END -->
@@ -491,7 +491,7 @@ aidevops implements proven agent design patterns identified by [Lance Martin (La
 
 | Pattern | Description | aidevops Implementation |
 |---------|-------------|------------------------|
-| **Give Agents a Computer** | Filesystem + shell for persistent context | `~/.aidevops/.agent-workspace/`, 140+ helper scripts |
+| **Give Agents a Computer** | Filesystem + shell for persistent context | `~/.aidevops/.agent-workspace/`, 145+ helper scripts |
 | **Multi-Layer Action Space** | Few tools, push actions to computer | Per-agent MCP filtering (~12-20 tools each) |
 | **Progressive Disclosure** | Load context on-demand | Subagent routing with content summaries, YAML frontmatter, read-on-demand |
 | **Offload Context** | Write results to filesystem | `.agent-workspace/work/[project]/` for persistence |
@@ -1166,7 +1166,7 @@ aidevops is registered as a **Claude Code plugin marketplace**. Install with two
 /plugin install aidevops@aidevops
 ```
 
-This installs the complete framework: 18 primary agents, 500+ subagents, and 140+ helper scripts.
+This installs the complete framework: 18 primary agents, 540+ subagents, and 145+ helper scripts.
 
 ### Importing External Skills
 
@@ -1254,7 +1254,7 @@ Ordered as they appear in OpenCode Tab selector and other AI assistants (15 tota
 
 ### **Example Subagents with MCP Integration**
 
-These are examples of subagents that have supporting MCPs enabled. See `.agent/` for the full list of 500+ subagents organized by domain.
+These are examples of subagents that have supporting MCPs enabled. See `.agent/` for the full list of 540+ subagents organized by domain.
 
 | Agent | Purpose | MCPs Enabled |
 |-------|---------|--------------|
@@ -1807,7 +1807,7 @@ aidevops/
 ├── .agent/                        # Agents and documentation
 │   ├── AGENTS.md                  # User guide (deployed to ~/.aidevops/agents/)
 │   ├── *.md                       # 18 primary agents
-│   ├── scripts/                   # 140+ helper scripts
+│   ├── scripts/                   # 145+ helper scripts
 │   ├── tools/                     # Cross-domain utilities (video, browser, git, etc.)
 │   ├── services/                  # External service integrations
 │   └── workflows/                 # Development process guides


### PR DESCRIPTION
Update subagent and script counts in README to reflect recent additions.

- Subagents: 500+ → 540+ (actual: 547)
- Scripts: 140+ → 145+ (actual: 146)

Includes recent additions like debug-opengraph and debug-favicon subagents.