### PR TITLE
feat: improve session titles to include task descriptions

### DIFF
--- a/.agent/scripts/commands/full-loop.md
+++ b/.agent/scripts/commands/full-loop.md
@@ -10,27 +10,37 @@ Task/Prompt: $ARGUMENTS
 
 ## Step 0: Resolve Task ID and Set Session Title
 
-**IMPORTANT**: Before proceeding, extract the first positional argument (ignoring flags like `--max-task-iterations`) and check if it's a task ID (matches pattern `t\d+` like `t061`).
+**IMPORTANT**: Before proceeding, extract the first positional argument from `$ARGUMENTS` (ignoring flags like `--max-task-iterations`). Check if it matches the task ID pattern `t\d+` (e.g., `t061`).
 
-If the first argument is a task ID:
+If the first argument is a task ID (e.g., `t061`):
 
-1. Look up the task description from TODO.md (matches open, completed, or declined tasks):
+1. Extract the task ID and look up its description from TODO.md:
 
    ```bash
-   grep -E "^- \[( |x|-)\] $TASK_ID " TODO.md 2>/dev/null | head -1 | sed -E 's/^- \[( |x|-)\] [^ ]* //'
+   # Extract first argument (the task ID)
+   TASK_ID=$(echo "$ARGUMENTS" | awk '{print $1}')
+   
+   # Look up description (matches open, completed, or declined tasks)
+   TASK_DESC=$(grep -E "^- \[( |x|-)\] $TASK_ID " TODO.md 2>/dev/null | head -1 | sed -E 's/^- \[( |x|-)\] [^ ]* //')
    ```
 
-2. Use the task description (not just the ID) for the session title. Call the `session-rename` tool with a descriptive title like:
+2. Set the session title using the `session-rename` MCP tool:
+
+   ```text
+   # Call the session-rename tool with the title parameter
+   session-rename(title: "t061: Improve session title to include task description")
+   ```
+
    - Good: `"t061: Improve session title to include task description"`
    - Bad: `"Full loop development for t061"`
 
-3. **Fallback**: If no description is found in TODO.md, use the task ID alone: `"t061: (task not found in TODO.md)"`
+3. **Fallback**: If `$TASK_DESC` is empty (task not found in TODO.md), use: `"t061: (task not found in TODO.md)"`
 
 4. Store the full task description for use in subsequent steps.
 
 If the first argument is NOT a task ID (it's a description):
 - Use the description directly for the session title
-- Call `session-rename` with a concise version if the description is very long (truncate to ~60 chars)
+- Call `session-rename` tool with a concise version if the description is very long (truncate to ~60 chars)
 
 **Example session titles:**
 - Task ID `t061` with description "Improve session title format" → `"t061: Improve session title format"`

--- a/.agent/scripts/commands/full-loop.md
+++ b/.agent/scripts/commands/full-loop.md
@@ -8,6 +8,31 @@ Start a full development loop that chains all phases from task implementation to
 
 Task/Prompt: $ARGUMENTS
 
+## Step 0: Resolve Task ID and Set Session Title
+
+**IMPORTANT**: Before proceeding, check if the argument is a task ID (matches pattern `t\d+` like `t061`).
+
+If the argument is a task ID:
+
+1. Look up the task description from TODO.md:
+   ```bash
+   grep "^- \[ \] $ARGUMENTS " TODO.md 2>/dev/null | head -1 | sed 's/^- \[ \] [^ ]* //'
+   ```
+
+2. Use the task description (not just the ID) for the session title. Call the `session-rename` tool with a descriptive title like:
+   - Good: `"t061: Improve session title to include task description"`
+   - Bad: `"Full loop development for t061"`
+
+3. Store the full task description for use in subsequent steps.
+
+If the argument is NOT a task ID (it's a description):
+- Use the description directly for the session title
+- Call `session-rename` with a concise version if the description is very long (truncate to ~60 chars)
+
+**Example session titles:**
+- Task ID `t061` with description "Improve session title format" → `"t061: Improve session title format"`
+- Description "Add JWT authentication" → `"Add JWT authentication"`
+
 ## Full Loop Phases
 
 ```text

--- a/.agent/scripts/commands/full-loop.md
+++ b/.agent/scripts/commands/full-loop.md
@@ -10,27 +10,30 @@ Task/Prompt: $ARGUMENTS
 
 ## Step 0: Resolve Task ID and Set Session Title
 
-**IMPORTANT**: Before proceeding, check if the argument is a task ID (matches pattern `t\d+` like `t061`).
+**IMPORTANT**: Before proceeding, extract the first positional argument (ignoring flags like `--max-task-iterations`) and check if it's a task ID (matches pattern `t\d+` like `t061`).
 
-If the argument is a task ID:
+If the first argument is a task ID:
 
-1. Look up the task description from TODO.md:
+1. Look up the task description from TODO.md (matches open, completed, or declined tasks):
    ```bash
-   grep "^- \[ \] $ARGUMENTS " TODO.md 2>/dev/null | head -1 | sed 's/^- \[ \] [^ ]* //'
+   grep -E "^- \[( |x|-)\] $TASK_ID " TODO.md 2>/dev/null | head -1 | sed -E 's/^- \[( |x|-)\] [^ ]* //'
    ```
 
 2. Use the task description (not just the ID) for the session title. Call the `session-rename` tool with a descriptive title like:
    - Good: `"t061: Improve session title to include task description"`
    - Bad: `"Full loop development for t061"`
 
-3. Store the full task description for use in subsequent steps.
+3. **Fallback**: If no description is found in TODO.md, use the task ID alone: `"t061: (task not found in TODO.md)"`
 
-If the argument is NOT a task ID (it's a description):
+4. Store the full task description for use in subsequent steps.
+
+If the first argument is NOT a task ID (it's a description):
 - Use the description directly for the session title
 - Call `session-rename` with a concise version if the description is very long (truncate to ~60 chars)
 
 **Example session titles:**
 - Task ID `t061` with description "Improve session title format" → `"t061: Improve session title format"`
+- Task ID `t999` not found → `"t999: (task not found in TODO.md)"`
 - Description "Add JWT authentication" → `"Add JWT authentication"`
 
 ## Full Loop Phases

--- a/.agent/scripts/commands/full-loop.md
+++ b/.agent/scripts/commands/full-loop.md
@@ -15,6 +15,7 @@ Task/Prompt: $ARGUMENTS
 If the first argument is a task ID:
 
 1. Look up the task description from TODO.md (matches open, completed, or declined tasks):
+
    ```bash
    grep -E "^- \[( |x|-)\] $TASK_ID " TODO.md 2>/dev/null | head -1 | sed -E 's/^- \[( |x|-)\] [^ ]* //'
    ```

--- a/.agent/scripts/generate-opencode-commands.sh
+++ b/.agent/scripts/generate-opencode-commands.sh
@@ -1113,6 +1113,8 @@ Start a Ralph loop for iterative development.
 
 Arguments: $ARGUMENTS
 
+**Session Title**: Set a descriptive session title using `session-rename` tool. Use a concise version of the prompt (truncate to ~60 chars if needed).
+
 **Usage:**
 ```bash
 /ralph-loop "<prompt>" --max-iterations <n> --completion-promise "<text>"
@@ -1358,7 +1360,8 @@ Task ID: $ARGUMENTS
 **Workflow:**
 1. Find task in TODO.md by ID (e.g., t042)
 2. Extract ralph metadata (promise, verify command, max iterations)
-3. Start Ralph loop with extracted parameters
+3. **Set session title** using `session-rename` tool with format: `"t042: Task description here"`
+4. Start Ralph loop with extracted parameters
 
 **Task format in TODO.md:**
 ```markdown
@@ -1381,7 +1384,8 @@ Task ID: $ARGUMENTS
 This will:
 1. Read TODO.md and find task t042
 2. Extract the ralph-promise, ralph-verify, ralph-max values
-3. Start: `/ralph-loop "{task description}" --completion-promise "{promise}" --max-iterations {max}`
+3. Set session title to `"t042: {task description}"` using `session-rename` tool
+4. Start: `/ralph-loop "{task description}" --completion-promise "{promise}" --max-iterations {max}`
 
 **Requirements:**
 - Task must have `#ralph` tag
@@ -1405,6 +1409,8 @@ Read ~/.aidevops/agents/scripts/commands/full-loop.md and follow its instruction
 
 Start a full development loop for: $ARGUMENTS
 
+**IMPORTANT - Session Title**: If the argument is a task ID (like `t061`), look up the task description from TODO.md and use it for the session title. Call `session-rename` with format: `"t061: Task description here"` instead of just `"Full loop development for t061"`.
+
 **Full Loop Phases:**
 ```text
 Task Development → Preflight → PR Create → PR Review → Postflight → Deploy
@@ -1414,6 +1420,7 @@ Task Development → Preflight → PR Create → PR Review → Postflight → De
 ```bash
 /full-loop "Implement feature X with tests"
 /full-loop "Fix bug Y" --max-task-iterations 30
+/full-loop t061  # Will look up task description from TODO.md
 ```
 
 **Options:**

--- a/.agent/scripts/generate-opencode-commands.sh
+++ b/.agent/scripts/generate-opencode-commands.sh
@@ -1113,7 +1113,7 @@ Start a Ralph loop for iterative development.
 
 Arguments: $ARGUMENTS
 
-**Session Title**: Set a descriptive session title using `session-rename` tool. Use a concise version of the prompt (truncate to ~60 chars if needed).
+**Session Title**: Only set a session title if one hasn't been set already (e.g., by `/ralph-task` which sets `"t042: description"`). If no task-prefixed title exists, use `session-rename` with a concise version of the prompt (truncate to ~60 chars if needed).
 
 **Usage:**
 ```bash
@@ -1408,8 +1408,6 @@ agent: Build+
 Read ~/.aidevops/agents/scripts/commands/full-loop.md and follow its instructions.
 
 Start a full development loop for: $ARGUMENTS
-
-**IMPORTANT - Session Title**: If the argument is a task ID (like `t061`), look up the task description from TODO.md and use it for the session title. Call `session-rename` with format: `"t061: Task description here"` instead of just `"Full loop development for t061"`.
 
 **Full Loop Phases:**
 ```text


### PR DESCRIPTION
## Summary

When using `/full-loop`, `/ralph-task`, or `/ralph-loop` with a task ID (like `t061`), the session title now includes the actual task description instead of just the generic format.

**Before:** `Full loop development for t061`
**After:** `t061: Improve session title to include task description`

## Changes

- Add "Step 0: Resolve Task ID and Set Session Title" to `full-loop.md` command
- Update `generate-opencode-commands.sh` to include session title guidance for:
  - `/full-loop` - Look up task description from TODO.md when given a task ID
  - `/ralph-task` - Set session title with task ID and description
  - `/ralph-loop` - Set descriptive session title from prompt

## How It Works

1. When the argument matches a task ID pattern (`t\d+`), the AI looks up the task description from TODO.md
2. The `session-rename` tool is called with format: `"t061: Task description here"`
3. For non-task-ID arguments, the description itself is used as the session title

## Testing

Run `./setup.sh` to regenerate commands, then use `/full-loop t001` (or any task ID from your TODO.md) to verify the session title is descriptive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic task resolution: detect task IDs and fetch matching descriptions to create informative session titles.
  * Conditional session-title setting: if no title exists, a concise title (~60 chars) is auto-applied before starting loops.
  * Full-loop and loop entry points support task-ID invocation with automatic description lookup and sensible fallbacks when descriptions are missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->