### PR TITLE
feat(email): add email-health-check command and subagent

### DIFF
--- a/.agent/scripts/commands/email-health-check.md
+++ b/.agent/scripts/commands/email-health-check.md
@@ -1,0 +1,104 @@
+---
+description: Check email deliverability health for a domain (SPF, DKIM, DMARC, MX, blacklists)
+agent: Build+
+mode: subagent
+---
+
+Check email authentication and deliverability configuration for a domain.
+
+Domain: $ARGUMENTS
+
+## Workflow
+
+### Step 1: Run Health Check
+
+```bash
+~/.aidevops/agents/scripts/email-health-check-helper.sh check "$ARGUMENTS"
+```
+
+### Step 2: Present Results
+
+Format the output as a clear report:
+
+```text
+Email Health Check: {domain}
+
+SPF:       {status} - {details}
+DKIM:      {status} - {selectors found}
+DMARC:     {status} - {policy}
+MX:        {status} - {record count}
+Blacklist: {status} - {listed/clean}
+
+Issues Found:
+- {issue 1}
+- {issue 2}
+
+Recommendations:
+1. {recommendation 1}
+2. {recommendation 2}
+```
+
+### Step 3: Offer Follow-up Actions
+
+```text
+Actions:
+1. Check specific DKIM selector
+2. View detailed blacklist report
+3. Get mail-tester.com instructions
+4. Show DNS records to add/fix
+```
+
+## Options
+
+| Command | Purpose |
+|---------|---------|
+| `/email-health-check example.com` | Full health check |
+| `/email-health-check example.com spf` | SPF only |
+| `/email-health-check example.com dkim google` | DKIM with selector |
+| `/email-health-check example.com dmarc` | DMARC only |
+
+## Examples
+
+**Basic check:**
+
+```text
+User: /email-health-check example.com
+AI: Running email health check for example.com...
+
+    Email Health Check: example.com
+    
+    SPF:       OK - v=spf1 include:_spf.google.com ~all
+    DKIM:      OK - Found: google, selector1
+    DMARC:     WARN - p=none (monitoring only)
+    MX:        OK - 2 records (redundant)
+    Blacklist: OK - Not listed
+    
+    Recommendations:
+    1. Upgrade DMARC policy from p=none to p=quarantine
+    2. Consider adding rua= for DMARC reports
+    
+    Would you like to:
+    1. See the recommended DMARC record
+    2. Run a mail-tester.com deliverability test
+    3. Check another domain
+```
+
+**DKIM with specific selector:**
+
+```text
+User: /email-health-check example.com dkim k1
+AI: Checking DKIM for selector 'k1' on example.com...
+
+    DKIM Record Found:
+    Selector: k1._domainkey.example.com
+    Key Type: RSA
+    Status: Valid
+    
+    This is a Mailchimp DKIM selector.
+```
+
+## Related
+
+- `services/email/email-health-check.md` - Full documentation
+- `services/email/ses.md` - Amazon SES integration
+- `services/hosting/dns.md` - DNS management

--- a/.agent/scripts/email-health-check-helper.sh
+++ b/.agent/scripts/email-health-check-helper.sh
@@ -1,0 +1,453 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+
+# Email Health Check Helper Script
+# Validates email authentication and deliverability for domains
+# Checks: SPF, DKIM, DMARC, MX records, blacklist status
+
+set -euo pipefail
+
+# Source shared constants if available
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
+
+# Colors for output
+readonly GREEN='\033[0;32m'
+readonly BLUE='\033[0;34m'
+readonly YELLOW='\033[1;33m'
+readonly RED='\033[0;31m'
+readonly NC='\033[0m'
+
+# Common message constants
+readonly HELP_SHOW_MESSAGE="Show this help"
+readonly USAGE_COMMAND_OPTIONS="Usage: $0 [command] [domain] [options]"
+readonly HELP_USAGE_INFO="Use '$0 help' for usage information"
+
+# Common DKIM selectors by provider
+readonly DKIM_SELECTORS="google google1 google2 selector1 selector2 k1 k2 s1 s2 pm smtp zoho default dkim"
+
+print_info() {
+    local msg="$1"
+    echo -e "${BLUE}[INFO]${NC} $msg"
+    return 0
+}
+
+print_success() {
+    local msg="$1"
+    echo -e "${GREEN}[OK]${NC} $msg"
+    return 0
+}
+
+print_warning() {
+    local msg="$1"
+    echo -e "${YELLOW}[WARN]${NC} $msg"
+    return 0
+}
+
+print_error() {
+    local msg="$1"
+    echo -e "${RED}[FAIL]${NC} $msg" >&2
+    return 0
+}
+
+print_header() {
+    local msg="$1"
+    echo ""
+    echo -e "${BLUE}=== $msg ===${NC}"
+    return 0
+}
+
+# Check if a command exists
+command_exists() {
+    local cmd="$1"
+    command -v "$cmd" >/dev/null 2>&1
+    return $?
+}
+
+# Check if checkdmarc is installed
+check_checkdmarc() {
+    if command_exists checkdmarc; then
+        return 0
+    else
+        print_warning "checkdmarc not installed. Using dig for DNS queries."
+        print_info "Install with: pip install checkdmarc"
+        return 1
+    fi
+}
+
+# Check SPF record
+check_spf() {
+    local domain="$1"
+    
+    print_header "SPF Check for $domain"
+    
+    local spf_record
+    spf_record=$(dig TXT "$domain" +short 2>/dev/null | grep -i "v=spf1" | tr -d '"' || true)
+    
+    if [[ -z "$spf_record" ]]; then
+        print_error "No SPF record found for $domain"
+        print_info "Recommendation: Add SPF record to authorize mail servers"
+        return 1
+    fi
+    
+    print_success "SPF record found:"
+    echo "  $spf_record"
+    
+    # Analyze SPF record
+    if [[ "$spf_record" == *"+all"* ]]; then
+        print_error "CRITICAL: SPF uses +all (allows anyone to send)"
+    elif [[ "$spf_record" == *"-all"* ]]; then
+        print_success "SPF uses -all (hard fail - strict)"
+    elif [[ "$spf_record" == *"~all"* ]]; then
+        print_success "SPF uses ~all (soft fail - recommended)"
+    elif [[ "$spf_record" == *"?all"* ]]; then
+        print_warning "SPF uses ?all (neutral - not recommended)"
+    fi
+    
+    # Count includes (rough DNS lookup estimate)
+    local include_count
+    include_count=$(echo "$spf_record" | grep -o "include:" | wc -l | tr -d ' ')
+    if [[ "$include_count" -gt 8 ]]; then
+        print_warning "SPF has $include_count includes - may exceed 10 DNS lookup limit"
+    fi
+    
+    return 0
+}
+
+# Check DKIM record
+check_dkim() {
+    local domain="$1"
+    local selector="${2:-}"
+    
+    print_header "DKIM Check for $domain"
+    
+    local found_dkim=false
+    local selectors_to_check
+    
+    if [[ -n "$selector" ]]; then
+        selectors_to_check="$selector"
+    else
+        selectors_to_check="$DKIM_SELECTORS"
+    fi
+    
+    for sel in $selectors_to_check; do
+        local dkim_record
+        dkim_record=$(dig TXT "${sel}._domainkey.${domain}" +short 2>/dev/null | tr -d '"' || true)
+        
+        if [[ -n "$dkim_record" && "$dkim_record" != *"NXDOMAIN"* ]]; then
+            found_dkim=true
+            print_success "DKIM found for selector '$sel':"
+            echo "  ${dkim_record:0:80}..."
+            
+            # Check key type and length
+            if [[ "$dkim_record" == *"k=rsa"* ]]; then
+                print_info "Key type: RSA"
+            fi
+        fi
+    done
+    
+    if [[ "$found_dkim" == false ]]; then
+        print_error "No DKIM records found for common selectors"
+        print_info "Specify selector with: $0 dkim $domain <selector>"
+        print_info "Find selector in email headers: DKIM-Signature: s=<selector>"
+        return 1
+    fi
+    
+    return 0
+}
+
+# Check DMARC record
+check_dmarc() {
+    local domain="$1"
+    
+    print_header "DMARC Check for $domain"
+    
+    local dmarc_record
+    dmarc_record=$(dig TXT "_dmarc.${domain}" +short 2>/dev/null | tr -d '"' || true)
+    
+    if [[ -z "$dmarc_record" ]]; then
+        print_error "No DMARC record found for $domain"
+        print_info "Recommendation: Add DMARC record for email authentication policy"
+        print_info "Example: v=DMARC1; p=none; rua=mailto:dmarc@$domain"
+        return 1
+    fi
+    
+    print_success "DMARC record found:"
+    echo "  $dmarc_record"
+    
+    # Analyze DMARC policy
+    if [[ "$dmarc_record" == *"p=reject"* ]]; then
+        print_success "Policy: reject (strongest protection)"
+    elif [[ "$dmarc_record" == *"p=quarantine"* ]]; then
+        print_success "Policy: quarantine (good protection)"
+    elif [[ "$dmarc_record" == *"p=none"* ]]; then
+        print_warning "Policy: none (monitoring only - no protection)"
+    fi
+    
+    # Check for reporting
+    if [[ "$dmarc_record" == *"rua="* ]]; then
+        print_success "Aggregate reporting enabled"
+    else
+        print_warning "No aggregate reporting (rua=) configured"
+    fi
+    
+    if [[ "$dmarc_record" == *"ruf="* ]]; then
+        print_info "Forensic reporting enabled"
+    fi
+    
+    return 0
+}
+
+# Check MX records
+check_mx() {
+    local domain="$1"
+    
+    print_header "MX Check for $domain"
+    
+    local mx_records
+    mx_records=$(dig MX "$domain" +short 2>/dev/null || true)
+    
+    if [[ -z "$mx_records" ]]; then
+        print_error "No MX records found for $domain"
+        print_info "Domain cannot receive email without MX records"
+        return 1
+    fi
+    
+    print_success "MX records found:"
+    echo "$mx_records" | while read -r line; do
+        echo "  $line"
+    done
+    
+    # Count MX records
+    local mx_count
+    mx_count=$(echo "$mx_records" | wc -l | tr -d ' ')
+    if [[ "$mx_count" -eq 1 ]]; then
+        print_warning "Only 1 MX record - no redundancy"
+    else
+        print_success "$mx_count MX records provide redundancy"
+    fi
+    
+    return 0
+}
+
+# Check blacklist status
+check_blacklist() {
+    local domain="$1"
+    
+    print_header "Blacklist Check for $domain"
+    
+    # Get IP addresses for domain
+    local ips
+    ips=$(dig A "$domain" +short 2>/dev/null || true)
+    
+    if [[ -z "$ips" ]]; then
+        # Try MX records
+        local mx_host
+        mx_host=$(dig MX "$domain" +short 2>/dev/null | head -1 | awk '{print $2}' | sed 's/\.$//' || true)
+        if [[ -n "$mx_host" ]]; then
+            ips=$(dig A "$mx_host" +short 2>/dev/null || true)
+        fi
+    fi
+    
+    if [[ -z "$ips" ]]; then
+        print_warning "Could not resolve IP addresses for blacklist check"
+        return 1
+    fi
+    
+    print_info "Checking IPs: $ips"
+    
+    # Common blacklists to check
+    local blacklists="zen.spamhaus.org bl.spamcop.net b.barracudacentral.org"
+    local listed=false
+    
+    for ip in $ips; do
+        # Reverse IP for DNSBL lookup
+        local reversed_ip
+        reversed_ip=$(echo "$ip" | awk -F. '{print $4"."$3"."$2"."$1}')
+        
+        for bl in $blacklists; do
+            local result
+            result=$(dig A "${reversed_ip}.${bl}" +short 2>/dev/null || true)
+            
+            if [[ -n "$result" && "$result" != *"NXDOMAIN"* ]]; then
+                print_error "$ip is listed on $bl"
+                listed=true
+            fi
+        done
+    done
+    
+    if [[ "$listed" == false ]]; then
+        print_success "No blacklist entries found for checked IPs"
+    else
+        print_warning "Some IPs are blacklisted - investigate and request delisting"
+    fi
+    
+    print_info "For comprehensive check, visit: https://mxtoolbox.com/blacklists.aspx"
+    
+    return 0
+}
+
+# Full health check using checkdmarc if available
+check_full() {
+    local domain="$1"
+    
+    print_header "Full Email Health Check for $domain"
+    echo ""
+    
+    if check_checkdmarc; then
+        print_info "Using checkdmarc for comprehensive analysis..."
+        echo ""
+        checkdmarc "$domain" 2>/dev/null || true
+        echo ""
+    fi
+    
+    # Run individual checks for detailed output
+    check_spf "$domain" || true
+    check_dkim "$domain" || true
+    check_dmarc "$domain" || true
+    check_mx "$domain" || true
+    check_blacklist "$domain" || true
+    
+    print_header "Summary"
+    print_info "For detailed deliverability testing, send a test email to mail-tester.com"
+    print_info "For MX diagnostics: https://mxtoolbox.com/SuperTool.aspx?action=mx:$domain"
+    
+    return 0
+}
+
+# Guide for mail-tester.com
+mail_tester_guide() {
+    print_header "Mail-Tester.com Guide"
+    
+    print_info "Mail-Tester provides comprehensive deliverability scoring (1-10)"
+    echo ""
+    echo "Steps:"
+    echo "  1. Visit https://mail-tester.com"
+    echo "  2. Copy the unique test email address shown"
+    echo "  3. Send a test email from your domain to that address"
+    echo "  4. Click 'Then check your score' on the website"
+    echo "  5. Review the detailed report"
+    echo ""
+    print_info "Aim for a score of 9/10 or higher"
+    echo ""
+    echo "Common issues that reduce score:"
+    echo "  - Missing or invalid SPF record"
+    echo "  - Missing DKIM signature"
+    echo "  - No DMARC policy"
+    echo "  - Blacklisted IP"
+    echo "  - Spam-like content"
+    echo "  - Missing unsubscribe header"
+    
+    return 0
+}
+
+# Show help
+show_help() {
+    echo "Email Health Check Helper Script"
+    echo "$USAGE_COMMAND_OPTIONS"
+    echo ""
+    echo "Commands:"
+    echo "  check [domain]              Full health check (SPF, DKIM, DMARC, MX, blacklist)"
+    echo "  spf [domain]                Check SPF record only"
+    echo "  dkim [domain] [selector]    Check DKIM record (optional: specific selector)"
+    echo "  dmarc [domain]              Check DMARC record only"
+    echo "  mx [domain]                 Check MX records only"
+    echo "  blacklist [domain]          Check blacklist status"
+    echo "  mail-tester                 Guide for using mail-tester.com"
+    echo "  help                        $HELP_SHOW_MESSAGE"
+    echo ""
+    echo "Examples:"
+    echo "  $0 check example.com"
+    echo "  $0 spf example.com"
+    echo "  $0 dkim example.com google"
+    echo "  $0 dmarc example.com"
+    echo "  $0 mx example.com"
+    echo "  $0 blacklist example.com"
+    echo ""
+    echo "Dependencies:"
+    echo "  Required: dig (usually pre-installed)"
+    echo "  Optional: checkdmarc (pip install checkdmarc)"
+    echo ""
+    echo "Common DKIM selectors by provider:"
+    echo "  Google Workspace: google, google1, google2"
+    echo "  Microsoft 365:    selector1, selector2"
+    echo "  Mailchimp:        k1, k2, k3"
+    echo "  SendGrid:         s1, s2, smtpapi"
+    echo "  Postmark:         pm, pm2"
+    
+    return 0
+}
+
+# Main function
+main() {
+    local command="${1:-help}"
+    local domain="${2:-}"
+    local selector="${3:-}"
+    
+    case "$command" in
+        "check"|"full")
+            if [[ -z "$domain" ]]; then
+                print_error "Domain required"
+                echo "$HELP_USAGE_INFO"
+                exit 1
+            fi
+            check_full "$domain"
+            ;;
+        "spf")
+            if [[ -z "$domain" ]]; then
+                print_error "Domain required"
+                exit 1
+            fi
+            check_spf "$domain"
+            ;;
+        "dkim")
+            if [[ -z "$domain" ]]; then
+                print_error "Domain required"
+                exit 1
+            fi
+            check_dkim "$domain" "$selector"
+            ;;
+        "dmarc")
+            if [[ -z "$domain" ]]; then
+                print_error "Domain required"
+                exit 1
+            fi
+            check_dmarc "$domain"
+            ;;
+        "mx")
+            if [[ -z "$domain" ]]; then
+                print_error "Domain required"
+                exit 1
+            fi
+            check_mx "$domain"
+            ;;
+        "blacklist"|"bl")
+            if [[ -z "$domain" ]]; then
+                print_error "Domain required"
+                exit 1
+            fi
+            check_blacklist "$domain"
+            ;;
+        "mail-tester"|"mailtester")
+            mail_tester_guide
+            ;;
+        "help"|"-h"|"--help"|"")
+            show_help
+            ;;
+        *)
+            # Assume first arg is domain if it looks like one
+            if [[ "$command" == *"."* ]]; then
+                check_full "$command"
+            else
+                print_error "Unknown command: $command"
+                echo "$HELP_USAGE_INFO"
+                exit 1
+            fi
+            ;;
+    esac
+    
+    return 0
+}
+
+main "$@"

--- a/.agent/services/email/email-health-check.md
+++ b/.agent/services/email/email-health-check.md
@@ -1,0 +1,330 @@
+---
+description: Check email deliverability health (SPF, DKIM, DMARC, MX, blacklists)
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+---
+
+# Email Health Check
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Validate email authentication and deliverability for domains
+- **Script**: `email-health-check-helper.sh [command] [domain]`
+- **Checks**: SPF, DKIM, DMARC, MX records, blacklist status
+- **Tools**: checkdmarc (Python CLI), dig/nslookup, mxtoolbox.com
+- **Install**: `pip install checkdmarc` or `pipx install checkdmarc`
+
+**Quick commands:**
+
+```bash
+# Full health check
+email-health-check-helper.sh check example.com
+
+# Individual checks
+email-health-check-helper.sh spf example.com
+email-health-check-helper.sh dkim example.com selector1
+email-health-check-helper.sh dmarc example.com
+email-health-check-helper.sh mx example.com
+email-health-check-helper.sh blacklist example.com
+```
+
+<!-- AI-CONTEXT-END -->
+
+## Overview
+
+Email health checks validate that a domain is properly configured for email deliverability. This includes:
+
+1. **SPF (Sender Policy Framework)** - Authorizes mail servers to send on behalf of domain
+2. **DKIM (DomainKeys Identified Mail)** - Cryptographic signature for email authenticity
+3. **DMARC (Domain-based Message Authentication)** - Policy for handling failed SPF/DKIM
+4. **MX Records** - Mail exchange servers for receiving email
+5. **Blacklist Status** - Check if domain/IP is on spam blacklists
+
+## Installation
+
+### checkdmarc (Recommended)
+
+```bash
+# Using pip
+pip install checkdmarc
+
+# Using pipx (isolated environment)
+pipx install checkdmarc
+
+# Verify installation
+checkdmarc --version
+```
+
+### Alternative: Manual DNS Queries
+
+If checkdmarc is not available, use dig/nslookup:
+
+```bash
+# SPF record
+dig TXT example.com +short | grep spf
+
+# DKIM record (requires selector)
+dig TXT selector1._domainkey.example.com +short
+
+# DMARC record
+dig TXT _dmarc.example.com +short
+
+# MX records
+dig MX example.com +short
+```
+
+## Usage
+
+### Full Health Check
+
+```bash
+# Run comprehensive check
+./.agent/scripts/email-health-check-helper.sh check example.com
+
+# Output includes:
+# - SPF record and validity
+# - DKIM status (common selectors)
+# - DMARC policy and settings
+# - MX records and priorities
+# - Blacklist status summary
+```
+
+### Individual Checks
+
+```bash
+# SPF only
+./.agent/scripts/email-health-check-helper.sh spf example.com
+
+# DKIM with specific selector
+./.agent/scripts/email-health-check-helper.sh dkim example.com google
+./.agent/scripts/email-health-check-helper.sh dkim example.com selector1
+./.agent/scripts/email-health-check-helper.sh dkim example.com k1  # Mailchimp
+
+# DMARC only
+./.agent/scripts/email-health-check-helper.sh dmarc example.com
+
+# MX records
+./.agent/scripts/email-health-check-helper.sh mx example.com
+
+# Blacklist check
+./.agent/scripts/email-health-check-helper.sh blacklist example.com
+```
+
+### Using checkdmarc Directly
+
+```bash
+# Basic check
+checkdmarc example.com
+
+# JSON output
+checkdmarc example.com --json
+
+# Check multiple domains
+checkdmarc example.com example.org example.net
+
+# Include DKIM check with selector
+checkdmarc example.com --dkim-selector google
+
+# Timeout settings
+checkdmarc example.com --timeout 10
+```
+
+## Common DKIM Selectors
+
+Different email providers use different DKIM selectors:
+
+| Provider | Selector(s) |
+|----------|-------------|
+| Google Workspace | `google`, `google1`, `google2` |
+| Microsoft 365 | `selector1`, `selector2` |
+| Amazon SES | `*._domainkey` (varies) |
+| Mailchimp | `k1`, `k2`, `k3` |
+| SendGrid | `s1`, `s2`, `smtpapi` |
+| Postmark | `pm`, `pm2` |
+| Mailgun | `smtp`, `mailo`, `k1` |
+| Zoho | `zoho`, `zmail` |
+
+## Interpreting Results
+
+### SPF Record
+
+```text
+v=spf1 include:_spf.google.com include:amazonses.com ~all
+```
+
+- `v=spf1` - SPF version (required)
+- `include:` - Authorized sending domains
+- `~all` - Soft fail (recommended)
+- `-all` - Hard fail (strict)
+- `?all` - Neutral (not recommended)
+
+**Issues:**
+- Missing SPF record = emails may be rejected
+- Too many DNS lookups (>10) = SPF permerror
+- `+all` = anyone can send (very bad)
+
+### DKIM Record
+
+```text
+v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQ...
+```
+
+- `v=DKIM1` - DKIM version
+- `k=rsa` - Key type
+- `p=` - Public key (base64)
+
+**Issues:**
+- Missing DKIM = reduced deliverability
+- Invalid key = signature verification fails
+- Key too short (<1024 bits) = security risk
+
+### DMARC Record
+
+```text
+v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com; pct=100
+```
+
+- `v=DMARC1` - DMARC version
+- `p=` - Policy: `none`, `quarantine`, `reject`
+- `rua=` - Aggregate report destination
+- `ruf=` - Forensic report destination
+- `pct=` - Percentage of messages to apply policy
+
+**Recommended progression:**
+1. Start with `p=none` to monitor
+2. Move to `p=quarantine` after review
+3. Eventually `p=reject` for full protection
+
+### MX Records
+
+```text
+10 mail.example.com
+20 backup.example.com
+```
+
+- Lower priority number = higher preference
+- Multiple MX records provide redundancy
+
+**Issues:**
+- Missing MX = cannot receive email
+- Unreachable MX servers = delivery failures
+- Misconfigured priorities = routing issues
+
+### Blacklist Status
+
+Common blacklists checked:
+- Spamhaus (ZEN, SBL, XBL, PBL)
+- Barracuda
+- SORBS
+- SpamCop
+- UCEPROTECT
+
+**If blacklisted:**
+1. Identify the cause (compromised account, spam complaints)
+2. Fix the underlying issue
+3. Request delisting from each blacklist
+
+## Troubleshooting
+
+### SPF Issues
+
+```bash
+# Check SPF record
+dig TXT example.com +short | grep spf
+
+# Count DNS lookups (must be ≤10)
+# Each include:, a:, mx:, ptr:, exists: counts as 1 lookup
+
+# Flatten SPF to reduce lookups
+# Use tools like spf-flattener or manually expand includes
+```
+
+### DKIM Issues
+
+```bash
+# Find DKIM selector from email headers
+# Look for: DKIM-Signature: ... s=selector; d=example.com
+
+# Test specific selector
+dig TXT selector._domainkey.example.com +short
+
+# Common issue: selector mismatch between DNS and email config
+```
+
+### DMARC Issues
+
+```bash
+# Check DMARC record
+dig TXT _dmarc.example.com +short
+
+# Common issues:
+# - Missing rua= means no reports
+# - p=none provides no protection
+# - Subdomain policy (sp=) may differ from main policy
+```
+
+## Integration with Other Tools
+
+### mail-tester.com
+
+For comprehensive deliverability testing:
+
+1. Get test address from mail-tester.com
+2. Send test email from your domain
+3. Check score and recommendations
+
+```bash
+# The helper script can guide you through this
+./.agent/scripts/email-health-check-helper.sh mail-tester
+```
+
+### mxtoolbox.com
+
+For detailed diagnostics:
+
+```bash
+# Open MX Toolbox for domain
+open "https://mxtoolbox.com/SuperTool.aspx?action=mx:example.com"
+
+# Or use their API (requires account)
+```
+
+## Best Practices
+
+### Minimum Requirements
+
+1. **SPF**: Valid record with appropriate includes
+2. **DKIM**: At least one valid DKIM key
+3. **DMARC**: Policy set (even if `p=none` initially)
+4. **MX**: At least one reachable mail server
+
+### Recommended Setup
+
+1. **SPF**: Include all legitimate senders, end with `~all` or `-all`
+2. **DKIM**: 2048-bit keys, rotate annually
+3. **DMARC**: `p=quarantine` or `p=reject` with reporting enabled
+4. **Monitoring**: Regular checks and DMARC report analysis
+
+### Monitoring Schedule
+
+| Check | Frequency |
+|-------|-----------|
+| Full health check | Weekly |
+| Blacklist status | Daily (automated) |
+| DMARC reports | Weekly review |
+| DKIM key rotation | Annually |
+
+## Related
+
+- `services/email/ses.md` - Amazon SES integration
+- `services/hosting/dns.md` - DNS management
+- `tools/browser/browser-automation.md` - For mail-tester automation

--- a/.agent/subagent-index.toon
+++ b/.agent/subagent-index.toon
@@ -50,7 +50,7 @@ tools/terminal/,Terminal integration - tab titles,terminal-title
 tools/automation/,macOS automation - AppleScript and JXA,mac|macos-automator
 tools/wordpress/,WordPress ecosystem - local dev and fleet,wp-dev|wp-admin|localwp|mainwp|wp-preferred|scf
 services/hosting/,Hosting providers - DNS and cloud servers,hostinger|hetzner|cloudflare|cloudflare-platform|cloudron|closte
-services/email/,Email services - transactional email,ses
+services/email/,Email services - transactional email and deliverability,ses|email-health-check
 services/communications/,Communications - SMS and voice,twilio|telfon
 services/crm/,CRM integration - contact management,fluentcrm
 services/analytics/,Website analytics - GA4 reporting,google-analytics
@@ -73,7 +73,7 @@ bug-fixing,workflows/bug-fixing.md,Bug fix workflow
 feature-development,workflows/feature-development.md,Feature development workflow
 -->
 
-<!--TOON:scripts[24]{name,purpose}:
+<!--TOON:scripts[25]{name,purpose}:
 list-keys-helper.sh,List all API keys with storage locations
 linters-local.sh,Run local linting (ShellCheck secretlint patterns)
 code-audit-helper.sh,Run remote auditing (CodeRabbit Codacy SonarCloud)
@@ -98,4 +98,5 @@ memory-helper.sh,Cross-session memory (SQLite FTS5)
 pdf-helper.sh,PDF operations (info fields fill merge text)
 unstract-helper.sh,Unstract self-hosted document processing (install start stop)
 cloudron-package-helper.sh,Cloudron app packaging workflow (init scaffold build test)
+email-health-check-helper.sh,Email deliverability check (SPF DKIM DMARC MX blacklist)
 -->


### PR DESCRIPTION
## Summary

- Add comprehensive email deliverability checking for domains
- Check SPF, DKIM, DMARC, MX records, and blacklist status
- Support for checkdmarc CLI (optional) with dig fallback

## Changes

- `services/email/email-health-check.md` - Full subagent documentation
- `scripts/email-health-check-helper.sh` - CLI for email health checks
- `scripts/commands/email-health-check.md` - `/email-health-check` command
- `subagent-index.toon` - Updated with new entries

## Usage

```bash
# Full health check
email-health-check-helper.sh check example.com

# Individual checks
email-health-check-helper.sh spf example.com
email-health-check-helper.sh dkim example.com google
email-health-check-helper.sh dmarc example.com
email-health-check-helper.sh mx example.com
email-health-check-helper.sh blacklist example.com
```

## Testing

Tested with google.com - all checks pass:
- SPF: OK (v=spf1 include:_spf.google.com ~all)
- DMARC: OK (p=reject with reporting)
- MX: OK (smtp.google.com)
- Blacklist: Clean

Closes t042