### PR TITLE
feat: detect app name in session greeting

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -7,7 +7,7 @@ mode: subagent
 
 **Recommended tool:** [OpenCode](https://opencode.ai/) is the recommended and primary-tested AI coding agent for aidevops. All features, agents, slash commands, and workflows are designed and tested for OpenCode first. Other AI assistants are supported as a courtesy for users evaluating aidevops capabilities.
 
-**Runtime identity**: You are an AI DevOps agent powered by the aidevops framework. When asked about your identity, check which application this session is running in (OpenCode, Claude Code, Cursor, etc.) and mention both the app and the aidevops framework. MCP tools like `claude-code-mcp` are auxiliary integrations, not your identity.
+**Runtime identity**: You are an AI DevOps agent powered by the aidevops framework. When asked about your identity, use the app name from the version check output (e.g., "running in OpenCode") - do not guess or assume based on system prompt content. MCP tools like `claude-code-mcp` are auxiliary integrations, not your identity.
 
 ## MANDATORY: Pre-Edit Git Check
 

--- a/.agent/scripts/aidevops-update-check.sh
+++ b/.agent/scripts/aidevops-update-check.sh
@@ -20,27 +20,65 @@ get_version() {
 
 detect_app() {
     # Detect which AI coding assistant is running this script
+    # Returns: "AppName|version" or "AppName" or "unknown"
+    local app_name="" app_version=""
+    
     # Check environment variables set by various tools
     if [[ "${OPENCODE:-}" == "1" ]]; then
-        echo "OpenCode"
+        app_name="OpenCode"
+        # OpenCode doesn't have --version flag, check package.json
+        app_version=$(jq -r '.version // empty' ~/.bun/install/global/node_modules/opencode-ai/package.json 2>/dev/null || echo "")
     elif [[ -n "${CLAUDE_CODE:-}" ]] || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
-        echo "Claude Code"
+        app_name="Claude Code"
+        app_version=$(claude --version 2>/dev/null | head -1 | sed 's/ (Claude Code)//' || echo "")
     elif [[ -n "${CURSOR_SESSION:-}" ]] || [[ "${TERM_PROGRAM:-}" == "cursor" ]]; then
-        echo "Cursor"
+        app_name="Cursor"
     elif [[ -n "${WINDSURF_SESSION:-}" ]]; then
-        echo "Windsurf"
+        app_name="Windsurf"
     elif [[ -n "${CONTINUE_SESSION:-}" ]]; then
-        echo "Continue"
+        app_name="Continue"
+    elif [[ -n "${AIDER_SESSION:-}" ]]; then
+        app_name="Aider"
+        app_version=$(aider --version 2>/dev/null | head -1 || echo "")
+    elif [[ -n "${FACTORY_DROID:-}" ]]; then
+        app_name="Factory Droid"
+    elif [[ -n "${AUGMENT_SESSION:-}" ]]; then
+        app_name="Augment"
+    elif [[ -n "${COPILOT_SESSION:-}" ]]; then
+        app_name="GitHub Copilot"
+    elif [[ -n "${CODY_SESSION:-}" ]]; then
+        app_name="Cody"
+    elif [[ -n "${KILO_SESSION:-}" ]]; then
+        app_name="Kilo Code"
+    elif [[ -n "${WARP_SESSION:-}" ]]; then
+        app_name="Warp"
     else
         # Fallback: check parent process name
         local parent
         parent=$(ps -o comm= -p "${PPID:-0}" 2>/dev/null || echo "")
         case "$parent" in
-            *opencode*) echo "OpenCode" ;;
-            *claude*) echo "Claude Code" ;;
-            *cursor*) echo "Cursor" ;;
-            *) echo "unknown" ;;
+            *opencode*)
+                app_name="OpenCode"
+                app_version=$(jq -r '.version // empty' ~/.bun/install/global/node_modules/opencode-ai/package.json 2>/dev/null || echo "")
+                ;;
+            *claude*)
+                app_name="Claude Code"
+                app_version=$(claude --version 2>/dev/null | head -1 | sed 's/ (Claude Code)//' || echo "")
+                ;;
+            *cursor*) app_name="Cursor" ;;
+            *aider*)
+                app_name="Aider"
+                app_version=$(aider --version 2>/dev/null | head -1 || echo "")
+                ;;
+            *) app_name="unknown" ;;
         esac
+    fi
+    
+    # Return with version if available
+    if [[ -n "$app_version" && "$app_version" != "unknown" ]]; then
+        echo "${app_name}|${app_version}"
+    else
+        echo "$app_name"
     fi
     return 0
 }
@@ -74,11 +112,37 @@ check_ralph_upstream() {
     return 0
 }
 
+get_git_context() {
+    # Get current repo and branch for context
+    local repo branch
+    repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "")
+    branch=$(git branch --show-current 2>/dev/null || echo "")
+    
+    if [[ -n "$repo" && -n "$branch" ]]; then
+        echo "${repo}/${branch}"
+    elif [[ -n "$repo" ]]; then
+        echo "$repo"
+    else
+        echo ""
+    fi
+    return 0
+}
+
 main() {
-    local current remote app
+    local current remote app_info app_name app_version git_context
     current=$(get_version)
     remote=$(get_remote_version)
-    app=$(detect_app)
+    app_info=$(detect_app)
+    git_context=$(get_git_context)
+    
+    # Parse app name and version
+    if [[ "$app_info" == *"|"* ]]; then
+        app_name="${app_info%%|*}"
+        app_version="${app_info##*|}"
+    else
+        app_name="$app_info"
+        app_version=""
+    fi
     
     # Build version string
     local version_str
@@ -88,19 +152,33 @@ main() {
         version_str="aidevops v$current (unable to check for updates)"
     elif [[ "$current" != "$remote" ]]; then
         # Special format for update available - parsed by AGENTS.md
-        echo "UPDATE_AVAILABLE|$current|$remote|$app"
+        echo "UPDATE_AVAILABLE|$current|$remote|$app_name"
         check_ralph_upstream
         return 0
     else
         version_str="aidevops v$current"
     fi
     
-    # Include app in output if detected
-    if [[ "$app" != "unknown" ]]; then
-        echo "$version_str running in $app"
-    else
-        echo "$version_str"
+    # Build app string with version if available
+    local app_str=""
+    if [[ "$app_name" != "unknown" ]]; then
+        if [[ -n "$app_version" ]]; then
+            app_str="$app_name v$app_version"
+        else
+            app_str="$app_name"
+        fi
     fi
+    
+    # Build final output
+    local output="$version_str"
+    if [[ -n "$app_str" ]]; then
+        output="$output running in $app_str"
+    fi
+    if [[ -n "$git_context" ]]; then
+        output="$output | $git_context"
+    fi
+    
+    echo "$output"
     
     # Check ralph upstream when in aidevops repo
     check_ralph_upstream


### PR DESCRIPTION
## Summary

Detect which AI coding assistant is running and include it in the session greeting.

## Changes

### aidevops-update-check.sh
- Add `detect_app()` function that checks:
  - `OPENCODE=1` environment variable → OpenCode
  - `CLAUDE_CODE` or `CLAUDE_SESSION_ID` → Claude Code
  - `CURSOR_SESSION` or `TERM_PROGRAM=cursor` → Cursor
  - `WINDSURF_SESSION` → Windsurf
  - `CONTINUE_SESSION` → Continue
  - Falls back to checking parent process name
- Output now includes "running in <app>" when detected

### AGENTS.md
- Updated runtime identity instruction to use the detected app name
- Explicitly says not to guess based on system prompt content

## Example Output

```
aidevops v2.88.0 running in OpenCode
```

## Why

The OAuth plugin rewrites "OpenCode" to "Claude Code" in the system prompt, causing the model to incorrectly identify as running in Claude Code. By detecting the app at the shell level and including it in the greeting output, the model gets accurate information about which app it's actually running in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved environment detection to identify the running app and include its name/version in version-check outputs.
  * Unified and clearer version/update output that can include repository/branch context.
  * Update-available messages now explicitly include app identification for clearer guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->