### PR TITLE
fix: use placeholder versions in AGENTS.md example

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -47,7 +47,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 3. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message
 
-If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|2.41.1|2.41.2`), inform user: "Update available (current → latest). Run `aidevops update` to update."
+If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest`), inform user: "Update available (current → latest). Run `aidevops update` to update."
 
 ## Pre-Edit Git Check
 


### PR DESCRIPTION
The model was seeing version numbers in the example and using those instead of running the script. Changed to generic placeholders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated example tokens in update notices from concrete version numbers to dynamic placeholder tokens (current|latest) for more flexible messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->