### PR TITLE
fix: Plan+ uses Read for version check (no Bash tool)

### DIFF
--- a/.agent/plan-plus.md
+++ b/.agent/plan-plus.md
@@ -27,7 +27,7 @@ subagents:
 
 # Plan+ - Enhanced Plan Agent
 
-**MANDATORY FIRST ACTION**: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh` and greet with the output. You have bash permission for this specific script.
+**MANDATORY FIRST ACTION**: Read `~/.aidevops/agents/VERSION` and greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
 
 <!-- Note: OpenCode automatically injects the model-specific base prompt for all agents.
 However, the plan.txt system-reminder is only injected for agents named exactly "plan".

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -42,9 +42,10 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 ## aidevops Framework Status
 
 **On conversation start**:
-1. Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh` (ALL agents have permission for this specific script)
-2. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
-3. Then respond to the user's actual message
+1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh`
+2. If no Bash tool: Read `~/.aidevops/agents/VERSION` file to get version
+3. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
+4. Then respond to the user's actual message
 
 If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest`), inform user: "Update available (current → latest). Run `aidevops update` to update."
 


### PR DESCRIPTION
OpenCode doesn't expose Bash to Plan+ despite config. Use Read tool as fallback.