### PR TITLE
fix: update deprecated Plan+ agent references to Build+

### DIFF
--- a/.agent/aidevops/add-new-mcp-to-aidevops.md
+++ b/.agent/aidevops/add-new-mcp-to-aidevops.md
@@ -148,14 +148,14 @@ Before proceeding, ask:
 > "Which main agents and subagents should have this MCP enabled?
 >
 > **Main Agents Available**:
-> Plan+, Build+, Accounts, AI-DevOps, Content, Health, Legal, Marketing,
+> Build+, Accounts, AI-DevOps, Content, Health, Legal, Marketing,
 > Research, Sales, SEO, WordPress
 >
 > **Recommendation**: Enable globally disabled, then enable per-agent only
 > where needed for context efficiency.
 >
 > **Common patterns**:
-> - Codebase/context tools → Plan+, Build+, AI-DevOps, WordPress, Research
+> - Codebase/context tools → Build+, AI-DevOps, WordPress, Research
 > - Documentation tools → All development agents
 > - Domain-specific → Only relevant domain agents
 >
@@ -170,7 +170,7 @@ Record which agents and why:
 
 | Agent | Enabled | Rationale |
 |-------|---------|-----------|
-| Plan+ | Yes | Needs codebase context for planning |
+| @plan-plus | Optional | Subagent for planning-only mode (Build+ handles planning by default) |
 | Build+ | Yes | Primary development agent |
 | AI-DevOps | Yes | Infrastructure development |
 | WordPress | No | Not relevant to WordPress tasks |
@@ -246,12 +246,6 @@ Edit `.agent/scripts/generate-opencode-agents.sh`:
 Based on the agent enablement decision from Step 2:
 
 ```python
-"Plan+": {
-    "tools": {
-        # ... existing tools ...
-        "{mcp-name}_*": True  # Only if enabled for this agent
-    }
-},
 "Build+": {
     "tools": {
         # ... existing tools ...

--- a/.agent/aidevops/troubleshooting.md
+++ b/.agent/aidevops/troubleshooting.md
@@ -248,7 +248,7 @@ opencode run "/new-command arg1" --agent Build+
 
 ```bash
 ~/.aidevops/agents/scripts/opencode-test-helper.sh test-mcp dataforseo SEO
-~/.aidevops/agents/scripts/opencode-test-helper.sh test-agent Plan+
+~/.aidevops/agents/scripts/opencode-test-helper.sh test-agent Build+
 ```
 
 ## Performance Optimization

--- a/.agent/scripts/commands/list-todo.md
+++ b/.agent/scripts/commands/list-todo.md
@@ -1,6 +1,6 @@
 ---
 description: List tasks from TODO.md with sorting and filtering options
-agent: Plan+
+agent: Build+
 mode: subagent
 ---
 

--- a/.agent/scripts/commands/save-todo.md
+++ b/.agent/scripts/commands/save-todo.md
@@ -1,6 +1,6 @@
 ---
 description: Save current discussion as task or plan (auto-detects complexity)
-agent: Plan+
+agent: Build+
 mode: subagent
 ---
 

--- a/.agent/scripts/commands/show-plan.md
+++ b/.agent/scripts/commands/show-plan.md
@@ -1,6 +1,6 @@
 ---
 description: Show detailed information about a specific plan from PLANS.md
-agent: Plan+
+agent: Build+
 mode: subagent
 ---
 

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -418,13 +418,15 @@ if os.path.exists(omo_config_path):
 # Build+ is now the unified coding agent (Plan+ and AI-DevOps consolidated)
 # =============================================================================
 
+# Disable OpenCode's built-in default agents so only our custom agents appear
 sorted_agents["build"] = {"disable": True}
 sorted_agents["plan"] = {"disable": True}
-# Disable Plan+ and AI-DevOps as primary agents (now subagents)
-sorted_agents["Plan+"] = {"disable": True}
-sorted_agents["AI-DevOps"] = {"disable": True}
+# Note: Plan+ and AI-DevOps are no longer emitted as disabled primary agents.
+# They were consolidated into Build+ (v2.50.0) and exist only as subagents
+# (@plan-plus, @aidevops). Emitting {"disable": True} without a model caused
+# OpenCode TypeError on input.model.providerID.
 print("  Disabled default 'build' and 'plan' agents")
-print("  Disabled 'Plan+' and 'AI-DevOps' (consolidated into Build+, available as @subagents)")
+print("  Plan+ and AI-DevOps available as @subagents (not in primary agent list)")
 
 config['agent'] = sorted_agents
 

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -418,15 +418,13 @@ if os.path.exists(omo_config_path):
 # Build+ is now the unified coding agent (Plan+ and AI-DevOps consolidated)
 # =============================================================================
 
-# Disable OpenCode's built-in default agents so only our custom agents appear
 sorted_agents["build"] = {"disable": True}
 sorted_agents["plan"] = {"disable": True}
-# Note: Plan+ and AI-DevOps are no longer emitted as disabled primary agents.
-# They were consolidated into Build+ (v2.50.0) and exist only as subagents
-# (@plan-plus, @aidevops). Emitting {"disable": True} without a model caused
-# OpenCode TypeError on input.model.providerID.
+# Disable Plan+ and AI-DevOps as primary agents (now subagents)
+sorted_agents["Plan+"] = {"disable": True}
+sorted_agents["AI-DevOps"] = {"disable": True}
 print("  Disabled default 'build' and 'plan' agents")
-print("  Plan+ and AI-DevOps available as @subagents (not in primary agent list)")
+print("  Disabled 'Plan+' and 'AI-DevOps' (consolidated into Build+, available as @subagents)")
 
 config['agent'] = sorted_agents
 

--- a/.agent/tools/context/context-guardrails.md
+++ b/.agent/tools/context/context-guardrails.md
@@ -160,7 +160,7 @@ Before attempting edits, verify you have the required tools:
 ```text
 Self-check: "Do I have Edit/Write/Bash tools for this task?"
 
-If NO (e.g., in Plan+ agent):
+If NO (e.g., in @plan-plus subagent or read-only mode):
   -> Suggest: "This task requires edits. Please switch to Build+ agent."
 
 If YES:

--- a/.agent/tools/opencode/opencode.md
+++ b/.agent/tools/opencode/opencode.md
@@ -358,7 +358,7 @@ opencode run --attach http://localhost:4096 "Another test" --agent SEO
 |----------|---------|
 | New MCP added | `opencode run "List tools from [mcp]_*" --agent [agent]` |
 | MCP auth issues | `opencode run "Call [mcp]_[tool]" --agent [agent] 2>&1` |
-| Agent permissions | `opencode run "Try to write a file" --agent Plan+` |
+| Agent permissions | `opencode run "Try to write a file" --agent Build+` |
 | Slash command | `opencode run "/new-command arg1 arg2" --agent Build+` |
 | Quick task | `opencode run "Do X quickly" --agent Build+` |
 
@@ -371,7 +371,7 @@ Use the helper script for common testing tasks:
 ~/.aidevops/agents/scripts/opencode-test-helper.sh test-mcp dataforseo SEO
 
 # Test agent permissions
-~/.aidevops/agents/scripts/opencode-test-helper.sh test-agent Plan+
+~/.aidevops/agents/scripts/opencode-test-helper.sh test-agent Build+
 
 # List tools available to agent
 ~/.aidevops/agents/scripts/opencode-test-helper.sh list-tools Build+
@@ -532,7 +532,7 @@ When a parent agent uses the `task` tool to spawn a subagent:
 | `write: false, edit: false, bash: true` | NO - bash can write files |
 | `write: false, edit: false, bash: false, task: false` | YES - truly read-only |
 
-**Example**: Plan+ with `task: true` could call a subagent that creates files, defeating its read-only purpose.
+**Example**: A read-only agent (like @plan-plus) with `task: true` could call a subagent that creates files, defeating its read-only purpose.
 
 ### Bash Escapes All Restrictions
 
@@ -543,12 +543,12 @@ When `bash: true`, the agent can execute ANY shell command, including:
 
 **For true read-only behavior**: Set both `bash: false` AND `task: false`
 
-### Plan+ Read-Only Configuration
+### @plan-plus Read-Only Configuration
 
-Plan+ is configured as strictly read-only:
+The @plan-plus subagent is configured as strictly read-only:
 
 ```json
-"Plan+": {
+"@plan-plus": {
   "permission": {
     "edit": "deny",
     "write": "deny",

--- a/.agent/workflows/conversation-starter.md
+++ b/.agent/workflows/conversation-starter.md
@@ -3,7 +3,7 @@ mode: subagent
 ---
 # Conversation Starter Prompts
 
-Shared prompts for Plan+ and Build+ agents to ensure consistent UX.
+Shared prompts for Build+ agent to ensure consistent UX.
 
 ## Inside Git Repository
 
@@ -22,7 +22,7 @@ If on `main` branch, include this note in the prompt:
 
 What are you working on?
 
-**Planning & Analysis** (Plan+):
+**Planning & Analysis** (Build+ deliberation mode):
 >
 > 1. Architecture Analysis
 > 2. Code Review (`workflows/code-audit-remote.md`)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The result: AI agents that work *with* your development process, not around it.
 
 ### Agent Structure
 
-- 15 primary agents (Build+, SEO, Marketing, etc.) with @plan-plus subagent for planning-only mode
+- Primary agents (Build+, SEO, Marketing, etc.) with @plan-plus subagent for planning-only mode
 - 552+ subagent markdown files organized by domain
 - 147 helper scripts in `.agent/scripts/`
 - 14 slash commands for common workflows

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ The result: AI agents that work *with* your development process, not around it.
 
 ### Agent Structure
 
-- 15 primary agents (Plan+, Build+, SEO, Marketing, etc.)
+- 15 primary agents (Build+, SEO, Marketing, etc.) with @plan-plus subagent for planning-only mode
 - 552+ subagent markdown files organized by domain
 - 147 helper scripts in `.agent/scripts/`
 - 14 slash commands for common workflows
@@ -1238,7 +1238,7 @@ Ordered as they appear in OpenCode Tab selector and other AI assistants (15 tota
 
 | Name | File | Purpose | MCPs Enabled |
 |------|------|---------|--------------|
-| Plan+ | `plan-plus.md` | Planning with semantic search, writes to TODO.md/todo/ | context7, augment, repomix |
+| @plan-plus | `plan-plus.md` | Planning-only subagent (Build+ handles planning by default) | context7, augment, repomix |
 | Build+ | `build-plus.md` | Enhanced Build with context tools | context7, augment, repomix |
 | Build-Agent | `build-agent.md` | Design and improve AI agents | context7, augment, repomix |
 | Build-MCP | `build-mcp.md` | Build MCP servers with TS+Bun+ElysiaJS | context7, augment, repomix |


### PR DESCRIPTION
## Summary

- Fix list-todo, save-todo, and show-plan commands that were broken because they referenced the deprecated `Plan+` primary agent in their frontmatter
- Update all remaining stale `Plan+` references across 9 files to use `Build+` (the unified agent) or `@plan-plus` (the subagent) as appropriate
- Preserve historical references in TODO.md, PLANS.md, and CHANGELOG.md

## Context

PR #226 consolidated Plan+ and AI-DevOps into Build+ as the unified coding agent. However, several files still referenced `Plan+` as a primary agent, causing the `/list-todo` command (and other planning commands) to error out when trying to route to a non-existent primary agent.

## Changes

| File | Change |
|------|--------|
| `list-todo.md` | `agent: Plan+` → `agent: Build+` |
| `save-todo.md` | `agent: Plan+` → `agent: Build+` |
| `show-plan.md` | `agent: Plan+` → `agent: Build+` |
| `conversation-starter.md` | Updated section headers and agent references |
| `add-new-mcp-to-aidevops.md` | Removed Plan+ from primary agent lists |
| `troubleshooting.md` | Updated test examples |
| `context-guardrails.md` | Reference @plan-plus subagent |
| `opencode.md` | Updated examples and config references |
| `README.md` | Updated agent structure description |

## Not Changed (Intentionally)

- `plan-plus.md` - Already correctly describes itself as a subagent
- `architecture.md` - Historical context ("consolidates the former Plan+") is accurate
- `onboarding.md` - Already uses correct `@plan-plus` subagent reference
- `TODO.md`, `PLANS.md`, `CHANGELOG.md` - Historical records preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated agent listings, examples, and guides to present @plan-plus as a planning-only subagent and Build+ as the default planner/implementer; expanded implementation task guidance and added Documentation Review.

* **Configuration**
  * Swapped examples and templates to use Build+ in command/testing scenarios; @plan-plus shown as optional/read-only.

* **Troubleshooting & Commands**
  * Updated test invocation examples and command metadata to reference Build+ instead of Plan+.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->