### PR TITLE
chore: remove opencode-anthropic-auth external plugin from setup

### DIFF
--- a/.agent/tools/opencode/opencode-anthropic-auth.md
+++ b/.agent/tools/opencode/opencode-anthropic-auth.md
@@ -9,14 +9,19 @@ tools:
 
 # OpenCode Anthropic Auth Plugin
 
+> **DEPRECATED**: As of OpenCode v1.1.36+, Anthropic OAuth is built into OpenCode natively.
+> The external `opencode-anthropic-auth` plugin is no longer needed and must NOT be added
+> to `opencode.json` plugins — doing so causes a TypeError due to double-loading.
+> Use `opencode auth login` directly. This document is retained for historical reference.
+
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
 
 - **Purpose**: OAuth authentication for Claude Pro/Max accounts in OpenCode
+- **Status**: **DEPRECATED** — built into OpenCode v1.1.36+, do not install as external plugin
 - **Repository**: https://github.com/anomalyco/opencode-anthropic-auth
-- **Installation**: `npm install -g opencode-anthropic-auth` (auto-installed by setup.sh)
-- **Alternative to**: Manual API key management, requires Claude subscription
+- **Installation**: Built-in to OpenCode v1.1.36+ (no installation needed)
 
 **Authentication Methods**:
 
@@ -55,24 +60,22 @@ The `opencode-anthropic-auth` plugin enables OAuth authentication for Anthropic'
 
 ## Installation
 
-### Automatic Installation (Recommended)
+### Built-in (OpenCode v1.1.36+)
 
-The aidevops `setup.sh` script automatically installs this plugin:
+Anthropic OAuth is built into OpenCode v1.1.36+. No installation needed — just run:
 
 ```bash
-cd ~/Git/aidevops
-./setup.sh
+opencode auth login
+# Select: Anthropic → Claude Pro/Max
 ```
 
-This installs the plugin globally and configures OpenCode to use it.
+### Legacy Installation (pre-v1.1.36 only)
 
-### Manual Installation
+> **Do not use on OpenCode v1.1.36+** — causes TypeError from double-loading.
 
 ```bash
-# Install via npm
+# Only for OpenCode versions before v1.1.36
 npm install -g opencode-anthropic-auth
-
-# Plugin is automatically discovered by OpenCode
 ```
 
 ## Authentication Methods
@@ -397,17 +400,11 @@ cat ~/.config/opencode/auth.json | jq '.anthropic'
 
 ### Automatic Setup
 
-The aidevops `setup.sh` installs and configures this plugin:
-
-```bash
-cd ~/Git/aidevops
-./setup.sh
-```
+As of aidevops v2.90.0, `setup.sh` no longer installs this plugin (it's built into OpenCode v1.1.36+).
 
 After setup:
-1. Plugin is installed globally via npm
-2. OpenCode automatically discovers it
-3. Authentication is ready to use with `opencode auth login`
+1. OpenCode's built-in Anthropic OAuth is ready to use
+2. Authenticate with `opencode auth login`
 
 ### Recommended Configuration
 

--- a/.agent/tools/opencode/opencode.md
+++ b/.agent/tools/opencode/opencode.md
@@ -77,9 +77,9 @@ opencode auth login
 
 **Multi-account load balancing:** Add multiple Google accounts for automatic rate limit distribution. Run `opencode auth login` again to add more accounts.
 
-## Anthropic OAuth Plugin
+## Anthropic OAuth (Built-in)
 
-The aidevops setup automatically installs the [opencode-anthropic-auth](https://github.com/anomalyco/opencode-anthropic-auth) plugin, enabling OAuth authentication for Claude Pro/Max accounts.
+OpenCode v1.1.36+ includes Anthropic OAuth authentication natively. No external plugin is needed.
 
 **Authenticate after setup:**
 
@@ -104,7 +104,7 @@ opencode auth login
 - Zero cost for Pro/Max subscribers
 - No manual API key management
 
-**See also:** `tools/opencode/opencode-anthropic-auth.md` for detailed setup and troubleshooting.
+> **Note:** The external `opencode-anthropic-auth` plugin is no longer needed and should be removed from `opencode.json` plugins if present. Adding it alongside the built-in version causes a TypeError due to double-loading.
 
 ## Installation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- remove opencode-anthropic-auth external plugin from setup.sh — built into OpenCode v1.1.36+, external plugin causes TypeError from double-loading (#230)
+
 ## [2.89.1] - 2026-01-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -273,9 +273,9 @@ opencode auth login
 
 **Multi-account load balancing:** Add multiple Google accounts for automatic rate limit distribution and failover. See the [plugin documentation](https://github.com/NoeFabris/opencode-antigravity-auth) for model configuration.
 
-### OpenCode Anthropic OAuth Plugin
+### OpenCode Anthropic OAuth (Built-in)
 
-The setup automatically installs the [opencode-anthropic-auth](https://github.com/anomalyco/opencode-anthropic-auth) plugin, enabling OAuth authentication for Claude Pro/Max accounts. This allows Claude subscribers to use OpenCode with zero API costs.
+OpenCode v1.1.36+ includes Anthropic OAuth authentication natively. No external plugin is needed.
 
 **After setup, authenticate:**
 
@@ -290,19 +290,6 @@ opencode auth login
 - **Zero cost** for Claude Pro/Max subscribers (covered by subscription)
 - **Automatic token refresh** - No manual re-authentication needed
 - **Beta features enabled** - Extended thinking modes and latest features
-- **Three authentication methods:**
-  - Claude Pro/Max OAuth (recommended for subscribers)
-  - Create API Key via OAuth
-  - Manual API key entry
-
-**Available models:**
-
-All Anthropic models available to Pro/Max subscribers, including:
-- `claude-sonnet-4-20250514`
-- `claude-opus-4-5`
-- Extended thinking modes
-
-See the [plugin documentation](https://github.com/anomalyco/opencode-anthropic-auth) and `.agent/tools/opencode/opencode-anthropic-auth.md` for complete setup and troubleshooting.
 
 ### Oh-My-OpenCode Plugin (Optional)
 

--- a/setup.sh
+++ b/setup.sh
@@ -2862,18 +2862,13 @@ setup_opencode_plugins() {
     print_info "See: https://github.com/NoeFabris/opencode-antigravity-auth"
     echo ""
     
-    # Setup Anthropic OAuth plugin (Claude OAuth)
-    print_info "Setting up Anthropic OAuth plugin..."
-    add_opencode_plugin "opencode-anthropic-auth" "opencode-anthropic-auth@latest" "$opencode_config"
-    
-    print_info "Anthropic OAuth plugin enables Claude Pro/Max authentication"
-    print_info "Zero cost for Claude subscribers, auto token refresh, beta features"
-    print_info "See: https://github.com/anomalyco/opencode-anthropic-auth"
-    echo ""
+    # Note: opencode-anthropic-auth is built into OpenCode v1.1.36+
+    # Adding it as an external plugin causes TypeError due to double-loading.
+    # Removed in v2.90.0 - see PR #230.
     
     print_info "After setup, authenticate with: opencode auth login"
     print_info "  • For Google OAuth: Select 'Google' → 'OAuth with Google (Antigravity)'"
-    print_info "  • For Claude OAuth: Select 'Anthropic' → 'Claude Pro/Max'"
+    print_info "  • For Claude OAuth: Select 'Anthropic' → 'Claude Pro/Max' (built-in)"
     
     return 0
 }


### PR DESCRIPTION
## Summary

- Remove `opencode-anthropic-auth` external plugin installation from `setup.sh` — it's built into OpenCode v1.1.36+ and adding it externally causes a `TypeError: undefined is not an object (evaluating 'input.model.providerID')` from double-loading
- Update README.md, opencode.md, and opencode-anthropic-auth.md to reflect built-in status
- Mark opencode-anthropic-auth.md as deprecated with clear warnings against external installation

## Root Cause

OpenCode v1.1.36 bundles `opencode-anthropic-auth@0.0.10` internally. When `setup.sh` also added `opencode-anthropic-auth@latest` to the plugin array in `opencode.json`, both copies loaded simultaneously, causing the TypeError on every new session.

## Files Changed

| File | Change |
|------|--------|
| `setup.sh` | Remove `add_opencode_plugin` call for anthropic-auth |
| `README.md` | Replace plugin section with built-in note |
| `.agent/tools/opencode/opencode.md` | Update Anthropic OAuth section |
| `.agent/tools/opencode/opencode-anthropic-auth.md` | Add deprecation notice, update installation docs |
| `CHANGELOG.md` | Add removal entry |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Anthropic OAuth is now built-in in OpenCode v1.1.36+, eliminating the need for external plugin installation.
  * Updated authentication guidance to reflect built-in support via `opencode auth login`.
  * Users should remove the external Anthropic OAuth plugin from their configuration to avoid errors.

* **Removed**
  * Deprecated external Anthropic OAuth plugin; built-in functionality replaces external setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->