### PR TITLE
fix: correct path to agent-review.md

### DIFF
--- a/.agent/scripts/generate-opencode-commands.sh
+++ b/.agent/scripts/generate-opencode-commands.sh
@@ -41,7 +41,7 @@ agent: Build-Agent
 subtask: true
 ---
 
-Read ~/.aidevops/agents/build-agent/agent-review.md and follow its instructions.
+Read ~/.aidevops/agents/tools/build-agent/agent-review.md and follow its instructions.
 
 Review the agent file(s) specified: $ARGUMENTS
 


### PR DESCRIPTION
## Summary

- Fixed incorrect path in `generate-opencode-commands.sh`
- Changed `~/.aidevops/agents/build-agent/agent-review.md` to `~/.aidevops/agents/tools/build-agent/agent-review.md`
- The `tools/` directory was missing from the path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build agent instruction source location to reflect new directory structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->