### PR TITLE
chore: add Cloudron forum search guidance to app packaging agent

### DIFF
--- a/.agent/tools/deployment/cloudron-app-packaging.md
+++ b/.agent/tools/deployment/cloudron-app-packaging.md
@@ -59,6 +59,24 @@ cloudron logs -f --app testapp
 ```
 <!-- AI-CONTEXT-END -->
 
+## Pre-Packaging Research
+
+Before starting to package an app, search the Cloudron forum for existing knowledge:
+
+1. **Search by app name**: `https://forum.cloudron.io/search?term=APP_NAME&in=titles`
+   Forum threads with the app name in the title often contain:
+   - Community packaging attempts (partial or complete) you can build on
+   - Known gotchas, workarounds, and platform-specific quirks
+   - Addon requirements and configuration insights from real deployments
+   - User experience reports on complexity, stability, and resource usage
+   - Upstream compatibility issues with Cloudron's read-only filesystem or auth model
+
+2. **Check the packaging category**: [forum.cloudron.io/category/96](https://forum.cloudron.io/category/96/app-packaging-development) for active packaging discussions
+
+3. **Search the app store**: `cloudron appstore search APP_NAME` to check if an official or community package already exists
+
+This research often saves significant trial-and-error, especially for apps with non-standard storage, auth, or process models.
+
 ## Overview
 
 Cloudron app packaging creates Docker containers that integrate with Cloudron's platform features: automatic SSL, user management (LDAP/OIDC), backups, and addon services.


### PR DESCRIPTION
## Summary
- Adds a "Pre-Packaging Research" section to the Cloudron app packaging agent
- Advises searching the Cloudron forum by app name before starting to package
- Forum threads often contain community packaging attempts, gotchas, addon insights, and UX reports
- Also recommends checking the packaging category and app store for existing packages

## Motivation
The Cloudron forum is a rich source of packaging knowledge that can save significant trial-and-error. Community threads frequently contain partial implementations, known quirks with read-only filesystems or auth models, and real-world resource usage data. This guidance ensures the agent leverages this knowledge before starting from scratch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Pre-Packaging Research section to the App Packaging Guide with guidance on researching existing knowledge before packaging, including searching forums, checking packaging categories, and exploring the app store.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->