### PR TITLE
fix: detect fd-find as fdfind on Debian/Ubuntu

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -731,15 +731,14 @@ setup_file_discovery_tools() {
     local missing_packages=()
     local missing_names=()
     
-    # Check for fd (fd-find on Debian/Ubuntu installs as fdfind)
+    local fd_version
     if command -v fd >/dev/null 2>&1; then
-        local fd_version
         fd_version=$(fd --version 2>/dev/null | head -1 || echo "unknown")
         print_success "fd found: $fd_version"
     elif command -v fdfind >/dev/null 2>&1; then
-        local fd_version
         fd_version=$(fdfind --version 2>/dev/null | head -1 || echo "unknown")
         print_success "fd found (as fdfind): $fd_version"
+        print_warning "Note: 'fd' alias not active in current shell. Restart shell or run: alias fd=fdfind"
     else
         missing_tools+=("fd")
         missing_packages+=("fd")

--- a/setup.sh
+++ b/setup.sh
@@ -731,15 +731,19 @@ setup_file_discovery_tools() {
     local missing_packages=()
     local missing_names=()
     
-    # Check for fd (fd-find)
-    if ! command -v fd >/dev/null 2>&1; then
-        missing_tools+=("fd")
-        missing_packages+=("fd")
-        missing_names+=("fd (fast file finder)")
-    else
+    # Check for fd (fd-find on Debian/Ubuntu installs as fdfind)
+    if command -v fd >/dev/null 2>&1; then
         local fd_version
         fd_version=$(fd --version 2>/dev/null | head -1 || echo "unknown")
         print_success "fd found: $fd_version"
+    elif command -v fdfind >/dev/null 2>&1; then
+        local fd_version
+        fd_version=$(fdfind --version 2>/dev/null | head -1 || echo "unknown")
+        print_success "fd found (as fdfind): $fd_version"
+    else
+        missing_tools+=("fd")
+        missing_packages+=("fd")
+        missing_names+=("fd (fast file finder)")
     fi
     
     # Check for ripgrep


### PR DESCRIPTION
## Summary

- Fix fd detection on Debian/Ubuntu where fd-find package installs binary as `fdfind`, not `fd`
- Now checks for both `fd` and `fdfind` commands

## Problem

On Debian/Ubuntu, after installing `fd-find`:
- Binary is named `fdfind`, not `fd`
- Alias is added to shell rc files but not active until shell restart
- `setup.sh` incorrectly reports fd as not installed

## Solution

Check for both `command -v fd` and `command -v fdfind` in `setup_file_discovery_tools()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved setup script compatibility on Debian/Ubuntu: now detects alternative names for the file-search tool, reports the detected version, and suggests creating an alias if needed. Ripgrep checks and existing success/failure messaging remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->