### PR TITLE
fix: update stale Plan+ and AI-DevOps agent refs to Build+ in command generator

### DIFF
--- a/.agent/scripts/generate-opencode-commands.sh
+++ b/.agent/scripts/generate-opencode-commands.sh
@@ -541,7 +541,7 @@ echo -e "  ${GREEN}✓${NC} Created /pr command (alias for /create-pr)"
 cat > "$OPENCODE_COMMAND_DIR/create-prd.md" << 'EOF'
 ---
 description: Generate a Product Requirements Document for a feature
-agent: Plan+
+agent: Build+
 ---
 
 Read ~/.aidevops/agents/workflows/plans.md and follow its PRD generation instructions.
@@ -579,7 +579,7 @@ echo -e "  ${GREEN}✓${NC} Created /create-prd command"
 cat > "$OPENCODE_COMMAND_DIR/generate-tasks.md" << 'EOF'
 ---
 description: Generate implementation tasks from a PRD
-agent: Plan+
+agent: Build+
 ---
 
 Read ~/.aidevops/agents/workflows/plans.md and follow its task generation instructions.
@@ -619,7 +619,7 @@ echo -e "  ${GREEN}✓${NC} Created /generate-tasks command"
 cat > "$OPENCODE_COMMAND_DIR/list-todo.md" << 'EOF'
 ---
 description: List tasks and plans with sorting, filtering, and grouping
-agent: Plan+
+agent: Build+
 ---
 
 Read TODO.md and todo/PLANS.md and display tasks based on arguments.
@@ -707,7 +707,7 @@ echo -e "  ${GREEN}✓${NC} Created /list-todo command"
 cat > "$OPENCODE_COMMAND_DIR/save-todo.md" << 'EOF'
 ---
 description: Save current discussion as task or plan (auto-detects complexity)
-agent: Plan+
+agent: Build+
 ---
 
 Analyze the current conversation and save appropriately based on complexity.
@@ -773,7 +773,7 @@ echo -e "  ${GREEN}✓${NC} Created /save-todo command"
 cat > "$OPENCODE_COMMAND_DIR/plan-status.md" << 'EOF'
 ---
 description: Show active plans and TODO.md status
-agent: Plan+
+agent: Build+
 ---
 
 Read TODO.md and todo/PLANS.md to show current planning status.
@@ -1017,7 +1017,7 @@ echo -e "  ${GREEN}✓${NC} Created /webmaster-keywords command"
 cat > "$OPENCODE_COMMAND_DIR/onboarding.md" << 'EOF'
 ---
 description: Interactive onboarding wizard - discover services, configure integrations
-agent: AI-DevOps
+agent: Build+
 ---
 
 Read ~/.aidevops/agents/onboarding.md and follow its instructions.


### PR DESCRIPTION
## Summary

- 7 slash commands were broken with "agent not found" because they referenced disabled agents `Plan+` and `AI-DevOps`
- Updated all 6 hardcoded agent references in `generate-opencode-commands.sh` to `Build+`

## Affected Commands

| Command | Old Agent | New Agent |
|---------|-----------|-----------|
| `/list-todo` | Plan+ (disabled) | Build+ |
| `/save-todo` | Plan+ (disabled) | Build+ |
| `/create-prd` | Plan+ (disabled) | Build+ |
| `/generate-tasks` | Plan+ (disabled) | Build+ |
| `/plan-status` | Plan+ (disabled) | Build+ |
| `/show-plan` | Plan+ (disabled) | Build+ |
| `/onboarding` | AI-DevOps (disabled) | Build+ |

## Root Cause

PR #226 consolidated Plan+ and AI-DevOps into Build+ and disabled the old agents, but the hardcoded heredoc templates in `generate-opencode-commands.sh` were not updated to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent assignments for command processing workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->