### PR TITLE
fix: make version scripts cross-platform and add validation

### DIFF
--- a/.agent/scripts/auto-version-bump.sh
+++ b/.agent/scripts/auto-version-bump.sh
@@ -19,6 +19,18 @@ print_success() { local msg="$1"; echo -e "${GREEN}[SUCCESS]${NC} $msg"; return 
 print_warning() { local msg="$1"; echo -e "${YELLOW}[WARNING]${NC} $msg"; return 0; }
 print_error() { local msg="$1"; echo -e "${RED}[ERROR]${NC} $msg" >&2; return 0; }
 
+# Cross-platform sed in-place edit (works on macOS and Linux)
+sed_inplace() {
+    local pattern="$1"
+    local file="$2"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "$pattern" "$file"
+    else
+        sed -i "$pattern" "$file"
+    fi
+    return $?
+}
+
 # Repository root directory
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)" || exit
 VERSION_MANAGER="$REPO_ROOT/.agent/scripts/version-manager.sh"
@@ -68,15 +80,20 @@ update_version_badge() {
     local readme_file="$REPO_ROOT/README.md"
 
     if [[ -f "$readme_file" ]]; then
-        # Use more robust regex pattern for version numbers (handles single and multi-digit)
-        # macOS sed requires different syntax for extended regex
-        sed -i '' "s/Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue/Version-$new_version-blue/" "$readme_file"
+        # Skip if using dynamic GitHub release badge
+        if grep -q "img.shields.io/github/v/release" "$readme_file"; then
+            print_success "README.md uses dynamic GitHub release badge (no update needed)"
+            return 0
+        fi
+        
+        # Use cross-platform sed for hardcoded badge
+        sed_inplace "s/Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue/Version-$new_version-blue/" "$readme_file"
 
         # Validate the update was successful
         if grep -q "Version-$new_version-blue" "$readme_file"; then
             print_success "Updated version badge in README.md to $new_version"
         else
-            print_error "Failed to update version badge in README.md"
+            print_warning "README.md has no version badge (consider adding dynamic GitHub release badge)"
         fi
     fi
     return 0

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "AI DevOps Framework - comprehensive DevOps automation with 25+ service integrations",
-    "version": "2.92.1"
+    "version": "2.92.2"
   },
   "plugins": [
     {

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3,7 +3,7 @@
 # AI DevOps Framework CLI
 # Usage: aidevops <command> [options]
 #
-# Version: 2.92.1
+# Version: 2.92.2
 
 set -euo pipefail
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aidevops",
-  "version": "2.92.1",
+  "version": "2.92.2",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
   "main": "index.js",

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,7 @@
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure
 #
-# Version: 2.92.1
+# Version: 2.92.2
 #
 # Quick Install (one-liner):
 #   bash <(curl -fsSL https://aidevops.dev/install)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,7 +5,7 @@ sonar.organization=marcusquinn
 
 # This is the name and version displayed in the SonarCloud UI
 sonar.projectName=AI DevOps Framework
-sonar.projectVersion=2.92.1
+sonar.projectVersion=2.92.2
 
 # Path is relative to the sonar-project.properties file
 sonar.sources=.agent,configs,templates


### PR DESCRIPTION
## Summary

- Add `sed_inplace()` helper function for macOS/Linux compatibility
- Add validation after each file update in `update_version_in_files()`
- Add error handling to abort release if file updates fail
- Sync all version files to 2.92.2 (fixing current inconsistency)

## Root Cause

The version-manager.sh script used `sed -i ''` syntax which only works on macOS. On Linux (GitHub Actions runners), GNU sed requires `sed -i` without the empty string argument. This caused file updates to fail silently, leaving files with stale versions while the VERSION file was updated.

## Changes

### version-manager.sh
- Added `sed_inplace()` helper that detects OS and uses correct sed syntax
- Added validation after each file update to verify the change was applied
- Added error counting and returns failure if any file fails to update
- Added error handling in `bump` and `release` actions to abort if updates fail

### auto-version-bump.sh
- Added same `sed_inplace()` helper for consistency
- Updated `update_version_badge()` to use cross-platform sed

### Version Files
- Synced all version files to 2.92.2:
  - package.json
  - sonar-project.properties
  - setup.sh
  - aidevops.sh
  - .claude-plugin/marketplace.json

## Testing

- Ran `validate-version-consistency.sh` - all files now show 2.92.2
- Ran `shellcheck` on modified scripts - no errors
- Ran `version-manager.sh validate` - passes

## Fixes

Resolves version inconsistency errors in GitHub Actions:
- Version Validation workflow failure
- Postflight Verification workflow failure