### PR TITLE
fix: improve full-loop workflow reliability

### DIFF
--- a/.agent/scripts/commands/full-loop.md
+++ b/.agent/scripts/commands/full-loop.md
@@ -162,8 +162,22 @@ After task completion, the loop automatically:
 1. **Preflight**: Runs quality checks, auto-fixes issues
 2. **PR Create**: Creates pull request with `gh pr create --fill`
 3. **PR Review**: Monitors CI checks and review status
-4. **Postflight**: Verifies release health after merge
-5. **Deploy**: Runs `setup.sh` (aidevops repos only)
+4. **Merge**: Squash merge (without `--delete-branch` when in worktree)
+5. **Worktree Cleanup**: Return to main repo, pull, clean merged worktrees
+6. **Postflight**: Verifies release health after merge
+7. **Deploy**: Runs `setup.sh` (aidevops repos only)
+
+**Worktree cleanup after merge:**
+
+```bash
+# When in a worktree, merge without --delete-branch
+gh pr merge --squash
+
+# Then clean up from main repo
+cd ~/Git/$(basename "$PWD" | cut -d. -f1)  # Return to main repo
+git pull origin main                        # Get merged changes
+wt prune                                    # Clean merged worktrees
+```
 
 ### Step 5: Human Decision Points
 

--- a/.agent/scripts/version-manager.sh
+++ b/.agent/scripts/version-manager.sh
@@ -549,7 +549,7 @@ verify_remote_sync() {
     fi
     
     if [[ "$local_sha" != "$remote_sha" ]]; then
-        # Check if we're simply behind (can fast-forward) vs diverged
+        # Check relationship: behind, ahead, or diverged
         if git merge-base --is-ancestor "$local_sha" "$remote_sha" 2>/dev/null; then
             # Local is behind remote - auto-pull with rebase
             print_info "Local $branch is behind origin/$branch, pulling..."
@@ -561,6 +561,11 @@ verify_remote_sync() {
                 print_info "Fix with: git pull --rebase origin $branch"
                 return 1
             fi
+        elif git merge-base --is-ancestor "$remote_sha" "$local_sha" 2>/dev/null; then
+            # Local is ahead of remote - this is fine for release, just inform
+            print_info "Local $branch is ahead of origin/$branch (unpushed commits)"
+            print_info "This is expected if you have local commits ready to release."
+            return 0
         else
             # Truly diverged - cannot auto-fix
             print_error "Local $branch has diverged from origin/$branch"


### PR DESCRIPTION
- Fix version-manager.sh to detect repo root using git rev-parse (works from any location)
- Auto-pull when local is behind remote before release (handles CI race condition)
- Document worktree cleanup after PR merge (avoid --delete-branch failure)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced release workflow documentation with clearer merge, cleanup, and deployment steps
  * Improved repository synchronization handling with automatic recovery from common divergence issues
  * Better repository detection for more reliable script execution in various environments

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->