### PR TITLE
fix(docs): resolve Codacy markdown style issues and add markdown standards

### DIFF
--- a/.agent/seo/seo-audit-skill.md
+++ b/.agent/seo/seo-audit-skill.md
@@ -3,7 +3,6 @@ description: "When the user wants to audit, review, or diagnose SEO issues on th
 mode: subagent
 imported_from: external
 ---
-# seo-audit
 
 # SEO Audit
 

--- a/.agent/tools/build-agent/build-agent.md
+++ b/.agent/tools/build-agent/build-agent.md
@@ -474,6 +474,13 @@ Before adding content to any agent file:
    - Facts cross-referenced?
    - Biases acknowledged?
 
+9. **Does the markdown pass linting?**
+   - Single H1 heading per file (MD025)
+   - Blank lines around headings (MD022)
+   - Blank lines around code blocks (MD031)
+   - No multiple consecutive blank lines (MD012)
+   - Run `npx markdownlint-cli2 "path/to/file.md"` to verify
+
 ### Progressive Disclosure Pattern
 
 Instead of putting everything in AGENTS.md:

--- a/.agent/tools/code-review/code-standards.md
+++ b/.agent/tools/code-review/code-standards.md
@@ -261,6 +261,98 @@ bash /tmp/install.sh
 | Security Issues | 0 |
 | Error Prone | 0 |
 
+## Markdown Standards
+
+All markdown files must pass markdownlint with zero violations.
+
+### MD022 - Headings Surrounded by Blank Lines
+
+Headings MUST have blank lines before AND after them.
+
+```markdown
+<!-- CORRECT - Blank lines around headings -->
+Some content here.
+
+### Heading Title
+
+Content after heading.
+
+<!-- INCORRECT - Missing blank line after heading -->
+Some content here.
+
+### Heading Title
+Content after heading.  <!-- This causes MD022 violation -->
+```
+
+### MD025 - Single Top-Level Heading
+
+Each document should have only ONE H1 (`#`) heading.
+
+```markdown
+<!-- CORRECT - Single H1 -->
+# Document Title
+
+## Section One
+
+## Section Two
+
+<!-- INCORRECT - Multiple H1s -->
+# First Title
+
+# Second Title  <!-- This causes MD025 violation -->
+```
+
+### MD012 - No Multiple Blank Lines
+
+Use only single blank lines between elements.
+
+```markdown
+<!-- CORRECT - Single blank lines -->
+Paragraph one.
+
+Paragraph two.
+
+<!-- INCORRECT - Multiple blank lines -->
+Paragraph one.
+
+
+Paragraph two.  <!-- This causes MD012 violation -->
+```
+
+### MD031 - Fenced Code Blocks Surrounded by Blank Lines
+
+Code blocks MUST have blank lines before AND after them.
+
+````markdown
+<!-- CORRECT - Blank lines around code blocks -->
+Some text.
+
+```bash
+echo "hello"
+```
+
+More text.
+
+<!-- INCORRECT - Missing blank line -->
+Some text.
+```bash
+echo "hello"
+```
+````
+
+**Validation**:
+
+```bash
+# Lint all markdown files
+npx markdownlint-cli2 "**/*.md" --ignore node_modules
+
+# Lint specific file
+npx markdownlint-cli2 "path/to/file.md"
+
+# Auto-fix issues
+npx markdownlint-cli2 "**/*.md" --fix
+```
+
 ## Pre-Commit Checklist
 
 Before committing, verify:
@@ -280,6 +372,9 @@ find .agent/scripts/ -name "*.sh" -exec shellcheck {} \;
 
 # 5. Check for secrets
 ~/.aidevops/agents/scripts/secretlint-helper.sh scan
+
+# 6. Lint markdown files
+npx markdownlint-cli2 "**/*.md" --ignore node_modules
 ```
 
 ## Quality Scripts


### PR DESCRIPTION
## Summary

- Fixes remaining Codacy markdown style issue (MD025 - multiple H1 headings)
- Adds comprehensive markdown standards documentation to prevent future issues

## Changes

### Bug Fix
- **seo-audit-skill.md**: Removed duplicate `# seo-audit` H1 heading that was causing MD025 violation

### Documentation
- **code-standards.md**: Added new "Markdown Standards" section documenting:
  - MD022: Headings must be surrounded by blank lines
  - MD025: Only one H1 heading per document
  - MD012: No multiple consecutive blank lines
  - MD031: Code blocks must be surrounded by blank lines
  - Added markdown linting to pre-commit checklist

- **build-agent.md**: Added markdown linting check to agent design checklist

## Context

The Codacy issues shown were from commit 97a9374. Most were already auto-fixed by the GitHub Actions workflow. This PR addresses the remaining MD025 violation and adds documentation to prevent future markdown style issues.

## Testing

```bash
npx markdownlint-cli2 ".agent/seo/seo-audit-skill.md" ".agent/tools/build-agent/build-agent.md" ".agent/tools/code-review/code-standards.md"
# Summary: 0 error(s)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved SEO audit documentation formatting and consistency.
  * Added markdown linting verification requirements to build agent documentation with specific lint rules and validation commands.
  * Enhanced code standards documentation with comprehensive markdown quality guidelines including markdown standards section and pre-commit linting checklist.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->