### PR TITLE
fix: subagent generation silently fails due to bash arithmetic exit code

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -727,7 +727,7 @@ tools:
 ---
 EOF
     fi
-    ((subagent_count++))
+    subagent_count=$((subagent_count + 1))
 done < <(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -type f -not -path "*/loop-state/*" | sort)
 
 echo -e "  ${GREEN}✓${NC} Generated $subagent_count subagent files"


### PR DESCRIPTION
## Summary

- **Bug**: `generate-opencode-agents.sh` silently exits at the subagent generation step, producing 0 subagent files in `~/.config/opencode/agent/`
- **Root cause**: `((subagent_count++))` with `set -euo pipefail` — post-increment evaluates the current value (0) first, which is falsy (exit code 1), killing the script
- **Fix**: Replace with `subagent_count=$((subagent_count + 1))` which always returns exit code 0

## Impact

All 596 subagent `@mention` files were not being generated. This means `@cloudron-app-packaging`, `@hostinger`, `@hetzner`, and all other subagents were unavailable in OpenCode after running the generation script.

Primary agents (Build+, SEO, WordPress, etc.) were unaffected as they are configured earlier in the script via Python.

## Testing

Before fix:
```
Generating subagent markdown files...
(silent exit - no output, 0 files generated)
```

After fix:
```
Generating subagent markdown files...
  ✓ Generated 596 subagent files
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal script syntax for enhanced portability and consistency.

---

**Note:** This release contains primarily internal maintenance improvements with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->