### PR TITLE
feat: add WordPress config templates and wp-helper.sh script

### DIFF
--- a/.agent/configs/mainwp-config.json.txt
+++ b/.agent/configs/mainwp-config.json.txt
@@ -1,0 +1,22 @@
+{
+  "_description": "MainWP Dashboard Configuration",
+  "_docs": "See .agent/tools/wordpress/mainwp.md for usage",
+  "_setup": "Copy to mainwp-config.json and fill in your credentials",
+
+  "instances": {
+    "production": {
+      "base_url": "https://mainwp.yourdomain.com",
+      "consumer_key": "YOUR_MAINWP_CONSUMER_KEY_HERE",
+      "consumer_secret": "YOUR_MAINWP_CONSUMER_SECRET_HERE",
+      "description": "Production MainWP instance",
+      "managed_sites_count": 0
+    },
+    "staging": {
+      "base_url": "https://staging-mainwp.yourdomain.com",
+      "consumer_key": "YOUR_STAGING_MAINWP_CONSUMER_KEY_HERE",
+      "consumer_secret": "YOUR_STAGING_MAINWP_CONSUMER_SECRET_HERE",
+      "description": "Staging MainWP instance",
+      "managed_sites_count": 0
+    }
+  }
+}

--- a/.agent/configs/wordpress-sites.json.txt
+++ b/.agent/configs/wordpress-sites.json.txt
@@ -1,0 +1,79 @@
+{
+  "_description": "WordPress Sites Registry",
+  "_docs": "See .agent/tools/wordpress/wp-admin.md for usage",
+  "_setup": "Copy to ~/.config/aidevops/wordpress-sites.json and fill in your sites",
+
+  "sites": {
+    "local-dev": {
+      "name": "Local Development",
+      "type": "localwp",
+      "path": "~/Local Sites/my-site/app/public",
+      "multisite": false,
+      "mainwp_connected": false
+    },
+    "production": {
+      "name": "Production Site",
+      "type": "hostinger",
+      "url": "https://example.com",
+      "ssh_host": "ssh.example.com",
+      "ssh_port": 65002,
+      "ssh_user": "u123456789",
+      "wp_path": "/domains/example.com/public_html",
+      "mainwp_connected": true,
+      "mainwp_site_id": 123,
+      "category": "client"
+    },
+    "staging": {
+      "name": "Staging Site",
+      "type": "hetzner",
+      "url": "https://staging.example.com",
+      "ssh_host": "123.45.67.89",
+      "ssh_port": 22,
+      "ssh_user": "root",
+      "wp_path": "/var/www/staging/public",
+      "mainwp_connected": false,
+      "category": "internal"
+    },
+    "cloudways-site": {
+      "name": "Cloudways Site",
+      "type": "cloudways",
+      "url": "https://cloudways.example.com",
+      "ssh_host": "cloudways.example.com",
+      "ssh_port": 22,
+      "ssh_user": "master_user",
+      "wp_path": "/home/master_user/applications/app_name/public_html",
+      "mainwp_connected": true,
+      "mainwp_site_id": 456,
+      "category": "lead-gen"
+    },
+    "closte-site": {
+      "name": "Closte Site",
+      "type": "closte",
+      "url": "https://closte.example.com",
+      "ssh_host": "closte.example.com",
+      "ssh_port": 22,
+      "ssh_user": "closte_user",
+      "wp_path": "/var/www/html",
+      "password_file": "~/.ssh/closte_password",
+      "mainwp_connected": false,
+      "category": "client"
+    }
+  },
+
+  "_hosting_types": {
+    "localwp": "Local by Flywheel - no SSH, direct path access",
+    "hostinger": "Hostinger - sshpass with password file, custom port 65002",
+    "hetzner": "Hetzner VPS - SSH key auth",
+    "cloudways": "Cloudways - SSH key auth, master_user pattern",
+    "closte": "Closte - sshpass with password file",
+    "cloudron": "Cloudron - SSH key auth or Cloudron CLI"
+  },
+
+  "_categories": [
+    "client",
+    "internal",
+    "lead-gen",
+    "ecommerce",
+    "blog"
+  ]
+}

--- a/.agent/scripts/wp-helper.sh
+++ b/.agent/scripts/wp-helper.sh
@@ -1,0 +1,445 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2155
+
+# WordPress CLI Helper Script
+# Runs WP-CLI commands on sites configured in wordpress-sites.json
+# Supports multiple hosting types: LocalWP, Hostinger, Hetzner, Cloudways, Closte
+
+set -euo pipefail
+
+# Colors for output
+readonly GREEN='\033[0;32m'
+readonly BLUE='\033[0;34m'
+readonly YELLOW='\033[1;33m'
+readonly RED='\033[0;31m'
+readonly NC='\033[0m' # No Color
+
+# String literal constants
+readonly ERROR_CONFIG_NOT_FOUND="Configuration file not found"
+readonly ERROR_JQ_REQUIRED="jq is required but not installed"
+readonly INFO_JQ_INSTALL_MACOS="Install with: brew install jq"
+readonly INFO_JQ_INSTALL_UBUNTU="Install with: apt-get install jq"
+readonly ERROR_SITE_NOT_FOUND="Site not found in configuration"
+readonly ERROR_SITE_REQUIRED="Site identifier is required"
+readonly ERROR_COMMAND_REQUIRED="WP-CLI command is required"
+readonly HELP_SHOW_MESSAGE="Show this help"
+
+# Configuration file location
+CONFIG_FILE="${HOME}/.config/aidevops/wordpress-sites.json"
+TEMPLATE_FILE="${HOME}/.aidevops/agents/configs/wordpress-sites.json.txt"
+
+print_info() {
+    local msg="$1"
+    echo -e "${BLUE}[INFO]${NC} $msg"
+    return 0
+}
+
+print_success() {
+    local msg="$1"
+    echo -e "${GREEN}[SUCCESS]${NC} $msg"
+    return 0
+}
+
+print_warning() {
+    local msg="$1"
+    echo -e "${YELLOW}[WARNING]${NC} $msg"
+    return 0
+}
+
+print_error() {
+    local msg="$1"
+    echo -e "${RED}[ERROR]${NC} $msg" >&2
+    return 0
+}
+
+# Check dependencies
+check_dependencies() {
+    if ! command -v jq &> /dev/null; then
+        print_error "$ERROR_JQ_REQUIRED"
+        echo "$INFO_JQ_INSTALL_MACOS"
+        echo "$INFO_JQ_INSTALL_UBUNTU"
+        exit 1
+    fi
+    return 0
+}
+
+# Load configuration
+load_config() {
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        print_error "$ERROR_CONFIG_NOT_FOUND: $CONFIG_FILE"
+        print_info "Copy and customize the template:"
+        print_info "  mkdir -p ~/.config/aidevops"
+        print_info "  cp $TEMPLATE_FILE $CONFIG_FILE"
+        exit 1
+    fi
+    return 0
+}
+
+# Get site configuration
+get_site_config() {
+    local site_key="$1"
+    
+    load_config
+    
+    local site_config
+    site_config=$(jq -r ".sites.\"$site_key\"" "$CONFIG_FILE")
+    if [[ "$site_config" == "null" ]]; then
+        print_error "$ERROR_SITE_NOT_FOUND: $site_key"
+        list_sites
+        exit 1
+    fi
+    
+    echo "$site_config"
+    return 0
+}
+
+# List all configured sites
+list_sites() {
+    load_config
+    print_info "Configured WordPress sites:"
+    echo ""
+    jq -r '.sites | to_entries[] | "\(.key)|\(.value.name)|\(.value.type)|\(.value.url // .value.path)|\(.value.category // "uncategorized")"' "$CONFIG_FILE" | \
+    while IFS='|' read -r key name type url category; do
+        printf "  %-20s %-25s %-12s %-40s [%s]\n" "$key" "$name" "$type" "$url" "$category"
+    done
+    return 0
+}
+
+# List sites by category
+list_sites_by_category() {
+    local category="$1"
+    
+    load_config
+    print_info "Sites in category: $category"
+    echo ""
+    jq -r ".sites | to_entries[] | select(.value.category == \"$category\") | \"\(.key)|\(.value.name)|\(.value.type)|\(.value.url // .value.path)\"" "$CONFIG_FILE" | \
+    while IFS='|' read -r key name type url; do
+        printf "  %-20s %-25s %-12s %s\n" "$key" "$name" "$type" "$url"
+    done
+    return 0
+}
+
+# Build SSH command based on hosting type
+build_ssh_command() {
+    local site_config="$1"
+    local wp_command="$2"
+    
+    local site_type
+    site_type=$(echo "$site_config" | jq -r '.type')
+    local ssh_host
+    ssh_host=$(echo "$site_config" | jq -r '.ssh_host // empty')
+    local ssh_port
+    ssh_port=$(echo "$site_config" | jq -r '.ssh_port // 22')
+    local ssh_user
+    ssh_user=$(echo "$site_config" | jq -r '.ssh_user // empty')
+    local wp_path
+    wp_path=$(echo "$site_config" | jq -r '.wp_path // empty')
+    local local_path
+    local_path=$(echo "$site_config" | jq -r '.path // empty')
+    local password_file
+    password_file=$(echo "$site_config" | jq -r '.password_file // empty')
+    
+    case "$site_type" in
+        localwp)
+            # LocalWP - direct local access
+            local expanded_path
+            expanded_path=$(eval echo "$local_path")
+            echo "cd \"$expanded_path\" && wp $wp_command"
+            ;;
+        hostinger|closte)
+            # Hostinger/Closte - sshpass with password file
+            local expanded_password_file
+            if [[ -n "$password_file" ]]; then
+                expanded_password_file=$(eval echo "$password_file")
+            else
+                # Default password file locations
+                if [[ "$site_type" == "hostinger" ]]; then
+                    expanded_password_file="${HOME}/.ssh/hostinger_password"
+                else
+                    expanded_password_file="${HOME}/.ssh/closte_password"
+                fi
+            fi
+            
+            if [[ ! -f "$expanded_password_file" ]]; then
+                print_error "Password file not found: $expanded_password_file"
+                print_info "Create the password file with your SSH password"
+                exit 1
+            fi
+            
+            echo "sshpass -f \"$expanded_password_file\" ssh -p $ssh_port $ssh_user@$ssh_host \"cd $wp_path && wp $wp_command\""
+            ;;
+        hetzner|cloudways|cloudron)
+            # SSH key-based authentication
+            echo "ssh -p $ssh_port $ssh_user@$ssh_host \"cd $wp_path && wp $wp_command\""
+            ;;
+        *)
+            print_error "Unknown hosting type: $site_type"
+            exit 1
+            ;;
+    esac
+    return 0
+}
+
+# Run WP-CLI command on a site
+run_wp_command() {
+    local site_key="$1"
+    shift
+    local wp_command="$*"
+    
+    if [[ -z "$wp_command" ]]; then
+        print_error "$ERROR_COMMAND_REQUIRED"
+        exit 1
+    fi
+    
+    local site_config
+    site_config=$(get_site_config "$site_key")
+    
+    local site_name
+    site_name=$(echo "$site_config" | jq -r '.name')
+    local site_type
+    site_type=$(echo "$site_config" | jq -r '.type')
+    
+    print_info "Running on $site_name ($site_type): wp $wp_command"
+    
+    local ssh_command
+    ssh_command=$(build_ssh_command "$site_config" "$wp_command")
+    
+    # Execute the command
+    eval "$ssh_command"
+    return $?
+}
+
+# Run WP-CLI command on all sites in a category
+run_on_category() {
+    local category="$1"
+    shift
+    local wp_command="$*"
+    
+    if [[ -z "$wp_command" ]]; then
+        print_error "$ERROR_COMMAND_REQUIRED"
+        exit 1
+    fi
+    
+    load_config
+    
+    print_info "Running on all sites in category: $category"
+    print_info "Command: wp $wp_command"
+    echo ""
+    
+    local site_keys
+    site_keys=$(jq -r ".sites | to_entries[] | select(.value.category == \"$category\") | .key" "$CONFIG_FILE")
+    
+    if [[ -z "$site_keys" ]]; then
+        print_warning "No sites found in category: $category"
+        return 0
+    fi
+    
+    local success_count=0
+    local fail_count=0
+    
+    while IFS= read -r site_key; do
+        echo "----------------------------------------"
+        print_info "Site: $site_key"
+        if run_wp_command "$site_key" "$wp_command"; then
+            ((success_count++))
+        else
+            ((fail_count++))
+            print_error "Failed on site: $site_key"
+        fi
+        echo ""
+    done <<< "$site_keys"
+    
+    echo "========================================"
+    print_info "Summary: $success_count succeeded, $fail_count failed"
+    return 0
+}
+
+# Run WP-CLI command on all sites
+run_on_all() {
+    local wp_command="$*"
+    
+    if [[ -z "$wp_command" ]]; then
+        print_error "$ERROR_COMMAND_REQUIRED"
+        exit 1
+    fi
+    
+    load_config
+    
+    print_info "Running on ALL sites"
+    print_info "Command: wp $wp_command"
+    echo ""
+    
+    local site_keys
+    site_keys=$(jq -r '.sites | keys[]' "$CONFIG_FILE")
+    
+    local success_count=0
+    local fail_count=0
+    
+    while IFS= read -r site_key; do
+        echo "----------------------------------------"
+        print_info "Site: $site_key"
+        if run_wp_command "$site_key" "$wp_command"; then
+            ((success_count++))
+        else
+            ((fail_count++))
+            print_error "Failed on site: $site_key"
+        fi
+        echo ""
+    done <<< "$site_keys"
+    
+    echo "========================================"
+    print_info "Summary: $success_count succeeded, $fail_count failed"
+    return 0
+}
+
+# Get site info
+get_site_info() {
+    local site_key="$1"
+    
+    local site_config
+    site_config=$(get_site_config "$site_key")
+    
+    print_info "Site: $site_key"
+    echo "$site_config" | jq '.'
+    return 0
+}
+
+# List available categories
+list_categories() {
+    load_config
+    print_info "Available categories:"
+    jq -r '.sites[].category // "uncategorized"' "$CONFIG_FILE" | sort -u | while read -r cat; do
+        local count
+        count=$(jq -r "[.sites[] | select(.category == \"$cat\")] | length" "$CONFIG_FILE")
+        echo "  - $cat ($count sites)"
+    done
+    return 0
+}
+
+# Show help
+show_help() {
+    cat << 'EOF'
+WordPress CLI Helper Script
+
+Runs WP-CLI commands on sites configured in ~/.config/aidevops/wordpress-sites.json
+
+Usage: wp-helper.sh [command] [options]
+
+Commands:
+  --list                              List all configured sites
+  --list-category <category>          List sites in a category
+  --categories                        List available categories
+  --info <site>                       Show site configuration
+  --all <wp-cli-command>              Run command on ALL sites
+  --category <cat> <wp-cli-command>   Run command on sites in category
+  <site> <wp-cli-command>             Run command on specific site
+  help                                Show this help
+
+Examples:
+  # List all sites
+  wp-helper.sh --list
+
+  # List sites by category
+  wp-helper.sh --list-category client
+
+  # Show site info
+  wp-helper.sh --info production
+
+  # Run WP-CLI on specific site
+  wp-helper.sh production plugin list
+  wp-helper.sh local-dev core version
+  wp-helper.sh staging user list --role=administrator
+
+  # Run on all sites in a category
+  wp-helper.sh --category client plugin update --all
+  wp-helper.sh --category lead-gen core version
+
+  # Run on ALL sites
+  wp-helper.sh --all core version
+  wp-helper.sh --all plugin list --status=active
+
+Configuration:
+  Config file: ~/.config/aidevops/wordpress-sites.json
+  Template: ~/.aidevops/agents/configs/wordpress-sites.json.txt
+
+Setup:
+  mkdir -p ~/.config/aidevops
+  cp ~/.aidevops/agents/configs/wordpress-sites.json.txt ~/.config/aidevops/wordpress-sites.json
+  # Edit the file with your site details
+
+Hosting Types:
+  localwp   - Local by Flywheel (direct path access)
+  hostinger - Hostinger (sshpass, port 65002)
+  closte    - Closte (sshpass)
+  hetzner   - Hetzner VPS (SSH key)
+  cloudways - Cloudways (SSH key)
+  cloudron  - Cloudron (SSH key)
+
+Related:
+  mainwp-helper.sh - For MainWP fleet management
+  wordpress-mcp-helper.sh - For WordPress MCP adapter
+EOF
+    return 0
+}
+
+# Main script logic
+main() {
+    local command="${1:-help}"
+    
+    check_dependencies
+    
+    case "$command" in
+        --list)
+            list_sites
+            ;;
+        --list-category)
+            local category="${2:-}"
+            if [[ -z "$category" ]]; then
+                print_error "Category is required"
+                exit 1
+            fi
+            list_sites_by_category "$category"
+            ;;
+        --categories)
+            list_categories
+            ;;
+        --info)
+            local site="${2:-}"
+            if [[ -z "$site" ]]; then
+                print_error "$ERROR_SITE_REQUIRED"
+                exit 1
+            fi
+            get_site_info "$site"
+            ;;
+        --all)
+            shift
+            run_on_all "$@"
+            ;;
+        --category)
+            local category="${2:-}"
+            if [[ -z "$category" ]]; then
+                print_error "Category is required"
+                exit 1
+            fi
+            shift 2
+            run_on_category "$category" "$@"
+            ;;
+        help|--help|-h)
+            show_help
+            ;;
+        *)
+            # Assume first arg is site key, rest is WP-CLI command
+            local site_key="$1"
+            shift
+            if [[ $# -eq 0 ]]; then
+                print_error "$ERROR_COMMAND_REQUIRED"
+                print_info "Usage: wp-helper.sh <site> <wp-cli-command>"
+                exit 1
+            fi
+            run_wp_command "$site_key" "$@"
+            ;;
+    esac
+    return 0
+}
+
+main "$@"

--- a/.agent/scripts/wp-helper.sh
+++ b/.agent/scripts/wp-helper.sh
@@ -154,6 +154,10 @@ build_ssh_command() {
     local password_file
     password_file=$(echo "$site_config" | jq -r '.password_file // empty')
     
+    # Quote wp_command for safe execution
+    local quoted_wp_command
+    quoted_wp_command=$(printf %q "$wp_command")
+    
     case "$site_type" in
         localwp)
             # LocalWP - direct local access
@@ -162,7 +166,7 @@ build_ssh_command() {
             # Quote path for safe execution
             local quoted_local_path
             quoted_local_path=$(printf %q "$expanded_path")
-            echo "cd $quoted_local_path && wp $wp_command"
+            echo "cd $quoted_local_path && wp $quoted_wp_command"
             ;;
         hostinger|closte)
             # Hostinger/Closte - sshpass with password file
@@ -191,14 +195,14 @@ build_ssh_command() {
             # Quote wp_path for safe remote execution
             local quoted_wp_path
             quoted_wp_path=$(printf %q "$wp_path")
-            echo "sshpass -f \"$expanded_password_file\" ssh -p $ssh_port $ssh_user@$ssh_host \"cd $quoted_wp_path && wp $wp_command\""
+            echo "sshpass -f \"$expanded_password_file\" ssh -p $ssh_port $ssh_user@$ssh_host \"cd $quoted_wp_path && wp $quoted_wp_command\""
             ;;
         hetzner|cloudways|cloudron)
             # SSH key-based authentication (preferred)
             # Quote wp_path for safe remote execution
             local quoted_wp_path
             quoted_wp_path=$(printf %q "$wp_path")
-            echo "ssh -p $ssh_port $ssh_user@$ssh_host \"cd $quoted_wp_path && wp $wp_command\""
+            echo "ssh -p $ssh_port $ssh_user@$ssh_host \"cd $quoted_wp_path && wp $quoted_wp_command\""
             ;;
         *)
             print_error "Unknown hosting type: $site_type"

--- a/.agent/tools/wordpress/wp-admin.md
+++ b/.agent/tools/wordpress/wp-admin.md
@@ -19,7 +19,9 @@ tools:
 ## Quick Reference
 
 - **Sites Config**: `~/.config/aidevops/wordpress-sites.json`
+- **Sites Template**: `configs/wordpress-sites.json.txt`
 - **MainWP Config**: `configs/mainwp-config.json`
+- **MainWP Template**: `configs/mainwp-config.json.txt`
 - **Working Dir**: `~/.aidevops/.agent-workspace/work/wordpress/`
 - **Preferred Plugins**: See `wp-preferred.md` for curated recommendations
 
@@ -27,9 +29,19 @@ tools:
 
 | Method | When to Use |
 |--------|-------------|
+| wp-helper.sh | Multi-site WP-CLI via wordpress-sites.json |
 | WP-CLI (SSH) | Direct access, any site |
 | MainWP | Fleet operations, connected sites |
 | WordPress MCP | AI-powered admin actions |
+
+**wp-helper.sh Commands**:
+
+```bash
+wp-helper.sh --list                          # List all sites
+wp-helper.sh production plugin list          # Run on specific site
+wp-helper.sh --category client core version  # Run on category
+wp-helper.sh --all plugin update --all       # Run on ALL sites
+```
 
 **Common WP-CLI Commands**:
 
@@ -65,6 +77,16 @@ This subagent handles WordPress administration tasks:
 - User management
 
 ## Site Configuration
+
+### Setup
+
+```bash
+# Copy template to config location
+mkdir -p ~/.config/aidevops
+cp ~/.aidevops/agents/configs/wordpress-sites.json.txt ~/.config/aidevops/wordpress-sites.json
+
+# Edit with your site details
+```
 
 ### WordPress Sites Registry
 


### PR DESCRIPTION
## Summary

- Add `mainwp-config.json.txt` template (fixes #260)
- Add `wordpress-sites.json.txt` template (fixes #261)
- Add `wp-helper.sh` script for multi-site WP-CLI operations (fixes #262)
- Update `wp-admin.md` with setup instructions and wp-helper.sh reference

## Changes

### New Files

| File | Purpose |
|------|---------|
| `.agent/configs/mainwp-config.json.txt` | Template for MainWP API configuration |
| `.agent/configs/wordpress-sites.json.txt` | Template for WordPress sites registry |
| `.agent/scripts/wp-helper.sh` | WP-CLI helper for multi-site operations |

### Modified Files

| File | Changes |
|------|---------|
| `.agent/tools/wordpress/wp-admin.md` | Added setup instructions, wp-helper.sh reference |

## wp-helper.sh Features

The new script reads from `~/.config/aidevops/wordpress-sites.json` and supports:

- **Multiple hosting types**: LocalWP, Hostinger, Hetzner, Cloudways, Closte, Cloudron
- **Site categories**: Run commands on sites by category
- **Bulk operations**: Run WP-CLI commands on all configured sites

### Usage Examples

```bash
# List all sites
wp-helper.sh --list

# Run on specific site
wp-helper.sh production plugin list

# Run on category
wp-helper.sh --category client core version

# Run on ALL sites
wp-helper.sh --all plugin update --all
```

## Testing

- [x] ShellCheck passes on wp-helper.sh
- [x] JSON templates validate with jq
- [x] Documentation updated

Closes #260, #261, #262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MainWP Dashboard configuration templates for production and staging.
  * Added a centralized WordPress Sites registry with hosting-type descriptors and site categories.
  * Added a command-line helper to list sites and run WP-CLI commands per-site, by category, or across all sites.

* **Documentation**
  * Updated admin guides with setup steps, usage examples, and configuration templates for the new tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->