### PR TITLE
docs: add Bitwarden cloud vs Vaultwarden detection documentation

### DIFF
--- a/.agent/tools/credentials/vaultwarden.md
+++ b/.agent/tools/credentials/vaultwarden.md
@@ -52,6 +52,99 @@ Vaultwarden is a self-hosted, lightweight implementation of the Bitwarden server
 - **Secure note storage** for configuration and documentation
 - **API key management** with audit trails and access control
 
+## Bitwarden Cloud vs Vaultwarden Self-Hosted
+
+### Service Detection
+
+The same `bw` CLI works for both Bitwarden cloud and Vaultwarden self-hosted. Detect which service you're using by the server URL:
+
+| Server URL | Service | Description |
+|------------|---------|-------------|
+| `vault.bitwarden.com` (default) | Bitwarden Cloud | Official hosted service |
+| `bitwarden.com` | Bitwarden Cloud | Official hosted service |
+| Any other domain | Vaultwarden | Self-hosted instance |
+
+```bash
+# Check current server configuration
+bw config server
+
+# Default (Bitwarden cloud) shows:
+# https://vault.bitwarden.com
+
+# Self-hosted shows your custom domain:
+# https://vault.yourdomain.com
+```
+
+### CLI Compatibility
+
+The official Bitwarden CLI (`bw`) works identically with both services:
+
+```bash
+# Install once, use for both
+npm install -g @bitwarden/cli
+
+# Configure for Bitwarden cloud (default, no config needed)
+bw config server https://vault.bitwarden.com
+
+# Configure for Vaultwarden self-hosted
+bw config server https://vault.yourdomain.com
+
+# All commands work the same after configuration
+bw login user@example.com
+bw unlock
+bw list items
+```
+
+### Behavioral Differences
+
+| Feature | Bitwarden Cloud | Vaultwarden Self-Hosted |
+|---------|-----------------|-------------------------|
+| **Hosting** | Managed by Bitwarden Inc. | Self-managed infrastructure |
+| **Pricing** | Free tier + paid plans | Free (open source) |
+| **Premium features** | Require paid subscription | All features unlocked |
+| **TOTP/2FA storage** | Premium only | Always available |
+| **File attachments** | Premium only | Always available |
+| **Emergency access** | Premium only | Always available |
+| **API rate limits** | Enforced by Bitwarden | Configurable (or none) |
+| **Data location** | Bitwarden's servers (US/EU) | Your infrastructure |
+| **Uptime/SLA** | 99.9% SLA on paid plans | Depends on your setup |
+| **Support** | Official support channels | Community support |
+| **Updates** | Automatic | Manual (Docker pull) |
+| **Admin panel** | Web vault only | `/admin` endpoint available |
+
+### When to Use Each
+
+**Choose Bitwarden Cloud when:**
+- You want zero infrastructure management
+- You need official support and SLA guarantees
+- Compliance requires a certified vendor
+- Team size justifies the subscription cost
+
+**Choose Vaultwarden when:**
+- You need all premium features without subscription
+- Data sovereignty requires self-hosting
+- You want full control over your infrastructure
+- You're comfortable with Docker/server management
+
+### Configuration Examples
+
+```json
+{
+  "instances": {
+    "bitwarden-cloud": {
+      "server_url": "https://vault.bitwarden.com",
+      "description": "Official Bitwarden cloud service",
+      "type": "cloud"
+    },
+    "vaultwarden-prod": {
+      "server_url": "https://vault.yourdomain.com",
+      "description": "Self-hosted Vaultwarden instance",
+      "type": "self-hosted"
+    }
+  }
+}
+```
+
 ## 🔧 **Configuration**
 
 ### **Setup Configuration:**


### PR DESCRIPTION
## Summary

- Add service detection section explaining URL-based identification (vault.bitwarden.com = cloud, custom domain = self-hosted)
- Document that the official `bw` CLI works identically for both services
- Add behavioral differences table covering pricing, features, hosting, and support
- Include guidance on when to choose each service
- Add configuration examples for multi-instance setups

## Changes

Added new section "Bitwarden Cloud vs Vaultwarden Self-Hosted" to `.agent/tools/credentials/vaultwarden.md` covering:

1. **Service Detection** - How to identify which service you're connected to by URL
2. **CLI Compatibility** - Confirmation that `bw` CLI works for both
3. **Behavioral Differences** - Table comparing features, pricing, hosting, etc.
4. **When to Use Each** - Decision guidance for cloud vs self-hosted
5. **Configuration Examples** - Multi-instance JSON config with type field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for integrating with Bitwarden Cloud and Vaultwarden Self-Hosted, including comparison information, CLI compatibility details, behavioral differences, configuration examples, and decision criteria for choosing between cloud and self-hosted deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->