### PR TITLE
feat(opencode): auto-load aidevops AGENTS.md via instructions config

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -432,6 +432,18 @@ config['agent'] = sorted_agents
 config['default_agent'] = "Build+"
 print("  Set Build+ as default agent")
 
+# =============================================================================
+# INSTRUCTIONS - Auto-load aidevops AGENTS.md for full framework context
+# =============================================================================
+# OpenCode's 'instructions' config auto-includes files in every session.
+# This ensures the full aidevops framework docs are available without
+# relying on the LLM to follow "read this file" instructions.
+# See: https://opencode.ai/docs/rules/#using-opencodejson
+config['instructions'] = [
+    os.path.expanduser("~/.aidevops/agents/AGENTS.md")
+]
+print("  Added instructions: ~/.aidevops/agents/AGENTS.md (auto-loaded every session)")
+
 print(f"  Auto-discovered {len(sorted_agents)} primary agents from {agents_dir}")
 print(f"  Order: {', '.join(list(sorted_agents.keys())[:5])}...")
 if subagent_filtered_count > 0:
@@ -754,7 +766,8 @@ echo ""
 echo -e "${GREEN}Done!${NC}"
 echo "  Primary agents: Auto-discovered from ~/.aidevops/agents/*.md (Tab-switchable)"
 echo "  Subagents: $subagent_count auto-discovered from subfolders (@mentionable)"
-echo "  AGENTS.md: ~/.config/opencode/AGENTS.md"
+echo "  Instructions: ~/.aidevops/agents/AGENTS.md (auto-loaded every session)"
+echo "  Global rules: ~/.config/opencode/AGENTS.md (version check + pre-edit)"
 echo ""
 echo "Tab order: Build+ → (alphabetical)"
 echo "  Note: Plan+ and AI-DevOps consolidated into Build+ (available as @plan-plus, @aidevops)"

--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -439,10 +439,12 @@ print("  Set Build+ as default agent")
 # This ensures the full aidevops framework docs are available without
 # relying on the LLM to follow "read this file" instructions.
 # See: https://opencode.ai/docs/rules/#using-opencodejson
-config['instructions'] = [
-    os.path.expanduser("~/.aidevops/agents/AGENTS.md")
-]
-print("  Added instructions: ~/.aidevops/agents/AGENTS.md (auto-loaded every session)")
+instructions_path = os.path.expanduser("~/.aidevops/agents/AGENTS.md")
+if os.path.exists(instructions_path):
+    config['instructions'] = [instructions_path]
+    print("  Added instructions: ~/.aidevops/agents/AGENTS.md (auto-loaded every session)")
+else:
+    print("  Warning: ~/.aidevops/agents/AGENTS.md not found - run setup.sh first")
 
 print(f"  Auto-discovered {len(sorted_agents)} primary agents from {agents_dir}")
 print(f"  Order: {', '.join(list(sorted_agents.keys())[:5])}...")


### PR DESCRIPTION
## Summary

- Adds `instructions` config to `opencode.json` via `generate-opencode-agents.sh`
- OpenCode now auto-loads `~/.aidevops/agents/AGENTS.md` in every session
- Fixes unreliable "read this file" instruction in global AGENTS.md stub

## Problem

The global `~/.config/opencode/AGENTS.md` contained:
```
Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
```

This relied on the LLM using its Read tool to follow the instruction, which was unreliable.

## Solution

OpenCode's `instructions` field in `opencode.json` automatically includes specified files in every session context. Now both work together:

| File | Purpose |
|------|---------|
| `instructions: [~/.aidevops/agents/AGENTS.md]` | Full framework docs (auto-loaded) |
| `~/.config/opencode/AGENTS.md` | Version check + pre-edit instructions |

## Testing

- [x] `setup.sh` runs successfully
- [x] `opencode.json` contains `"instructions": ["/Users/.../AGENTS.md"]`
- [x] ShellCheck passes

## Ref

- https://opencode.ai/docs/rules/#using-opencodejson

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automatically load global instructions from user configuration at session start, with existence checks and clear user messages.
  * Startup and shutdown summaries now display Instructions and Global Rules distinctly and reflect the new loading behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->