### PR TITLE
feat(browser): add Mullvad Browser support for privacy-focused automation

### DIFF
--- a/.agent/scripts/anti-detect-helper.sh
+++ b/.agent/scripts/anti-detect-helper.sh
@@ -41,7 +41,7 @@ SETUP OPTIONS:
 
 LAUNCH OPTIONS:
     --profile <name>    Profile to launch (required unless --disposable)
-    --engine <type>     Browser engine: chromium|firefox|random (default: firefox)
+    --engine <type>     Browser engine: chromium|firefox|mullvad|random (default: firefox)
     --headless          Run headless (default: headed)
     --disposable        Single-use profile (auto-deleted)
     --url <url>         URL to navigate to after launch
@@ -470,7 +470,7 @@ launch_browser() {
     fi
 
     if [[ "$engine" == "random" ]]; then
-        engine=$(python3 -c "import random; print(random.choice(['chromium','firefox']))")
+        engine=$(python3 -c "import random; print(random.choice(['chromium','firefox','mullvad']))")
     fi
 
     # Update last_used timestamp
@@ -492,6 +492,8 @@ with open('$profile_dir/metadata.json', 'r+') as f:
 
     if [[ "$engine" == "firefox" ]]; then
         launch_camoufox "$profile_name" "$headless" "$url" "$disposable"
+    elif [[ "$engine" == "mullvad" ]]; then
+        launch_mullvad "$profile_name" "$headless" "$url" "$disposable"
     else
         launch_chromium_stealth "$profile_name" "$headless" "$url" "$disposable"
     fi
@@ -596,6 +598,102 @@ with Camoufox(**kwargs) as browser:
 " 2>&1
 
     deactivate 2>/dev/null || true
+    return 0
+}
+
+launch_mullvad() {
+    local profile_name="$1"
+    local headless="$2"
+    local url="$3"
+    local disposable="$4"
+
+    # Find Mullvad Browser executable
+    local mullvad_path=""
+    if [[ -f "/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser" ]]; then
+        mullvad_path="/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser"
+    elif [[ -f "/usr/bin/mullvad-browser" ]]; then
+        mullvad_path="/usr/bin/mullvad-browser"
+    elif [[ -f "$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser" ]]; then
+        mullvad_path="$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser"
+    elif [[ -f "/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe" ]]; then
+        mullvad_path="/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe"
+    else
+        echo -e "${RED}Error: Mullvad Browser not found. Install from https://mullvad.net/browser${NC}" >&2
+        return 1
+    fi
+
+    local profile_dir=""
+    local user_data_dir=""
+    local proxy_server=""
+
+    if [[ -n "$profile_name" ]]; then
+        profile_dir=$(find_profile_dir "$profile_name")
+        if [[ -n "$profile_dir" ]]; then
+            user_data_dir="$profile_dir/mullvad-data"
+            mkdir -p "$user_data_dir"
+        fi
+        if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
+            proxy_server=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('server',''))" 2>/dev/null)
+        fi
+    fi
+
+    local headless_flag="true"
+    [[ "$headless" != "true" ]] && headless_flag="false"
+
+    local target_url="${url:-https://www.browserscan.net/bot-detection}"
+
+    echo -e "${BLUE}Launching Mullvad Browser (headless=$headless_flag)...${NC}"
+    echo -e "${YELLOW}Note: Mullvad Browser uses Tor Browser's uniform fingerprint (no rotation).${NC}"
+    echo -e "${YELLOW}For fingerprint rotation, use --engine firefox (Camoufox) instead.${NC}"
+
+    # Use Node.js with Playwright Firefox driver
+    node -e "
+const { firefox } = require('playwright');
+
+(async () => {
+    const launchOpts = {
+        executablePath: '$mullvad_path',
+        headless: $headless_flag,
+    };
+
+    const contextOpts = {
+        viewport: { width: 1280, height: 800 },  // Mullvad default
+    };
+
+    const proxyServer = '$proxy_server';
+    if (proxyServer) {
+        launchOpts.proxy = { server: proxyServer };
+    }
+
+    const userDataDir = '$user_data_dir';
+    let browser, context, page;
+
+    if (userDataDir && '$disposable' !== 'true') {
+        // Persistent context for Mullvad
+        browser = await firefox.launchPersistentContext(userDataDir, {
+            ...launchOpts,
+            ...contextOpts,
+        });
+        page = browser.pages()[0] || await browser.newPage();
+    } else {
+        browser = await firefox.launch(launchOpts);
+        context = await browser.newContext(contextOpts);
+        page = await context.newPage();
+    }
+
+    console.log('Mullvad Browser launched');
+    await page.goto('$target_url', { timeout: 30000 });
+    console.log('Navigated to:', page.url());
+    console.log('Title:', await page.title());
+
+    if (!$headless_flag) {
+        await new Promise(r => setTimeout(r, 60000));
+    }
+
+    await browser.close();
+})().catch(e => { console.error(e.message); process.exit(1); });
+" 2>&1
+
     return 0
 }
 
@@ -965,6 +1063,21 @@ show_status() {
         echo -e "  Camoufox:          ${GREEN}installed${NC} (v$camoufox_version)"
     else
         echo -e "  Camoufox:          ${RED}not installed${NC}"
+    fi
+
+    # Mullvad Browser
+    local mullvad_path=""
+    if [[ -f "/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser" ]]; then
+        mullvad_path="/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser"
+    elif [[ -f "/usr/bin/mullvad-browser" ]]; then
+        mullvad_path="/usr/bin/mullvad-browser"
+    elif [[ -f "$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser" ]]; then
+        mullvad_path="$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser"
+    fi
+    if [[ -n "$mullvad_path" ]]; then
+        echo -e "  Mullvad Browser:   ${GREEN}installed${NC} ($mullvad_path)"
+    else
+        echo -e "  Mullvad Browser:   ${YELLOW}not installed${NC} (https://mullvad.net/browser)"
     fi
 
     # rebrowser-patches

--- a/.agent/scripts/anti-detect-helper.sh
+++ b/.agent/scripts/anti-detect-helper.sh
@@ -1073,6 +1073,8 @@ show_status() {
         mullvad_path="/usr/bin/mullvad-browser"
     elif [[ -f "$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser" ]]; then
         mullvad_path="$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser"
+    elif [[ -f "/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe" ]]; then
+        mullvad_path="/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe"
     fi
     if [[ -n "$mullvad_path" ]]; then
         echo -e "  Mullvad Browser:   ${GREEN}installed${NC} ($mullvad_path)"

--- a/.agent/tools/browser/anti-detect-browser.md
+++ b/.agent/tools/browser/anti-detect-browser.md
@@ -54,6 +54,7 @@ Need anti-detection?
     +-> Which browser engine?
     |       |
     |       +-> Maximum stealth (C++ level spoofing)? --> Camoufox (Firefox)
+    |       +-> Privacy-first (Tor Browser patches)? --> Mullvad Browser (--engine mullvad)
     |       +-> Speed + existing Playwright code? --> rebrowser-patches (Chromium)
     |       +-> Both (rotate engines)? --> anti-detect-helper.sh --engine random
     |
@@ -66,20 +67,24 @@ Need anti-detection?
 
 ## Tool Comparison
 
-| Feature | rebrowser-patches | Camoufox | AdsPower/GoLogin |
-|---------|------------------|----------|------------------|
-| **Engine** | Chromium (Playwright) | Firefox (Playwright) | Chromium |
-| **Stealth level** | Medium (CDP patches) | High (C++ level) | High (proprietary) |
-| **Fingerprint rotation** | No (add manually) | Yes (BrowserForge) | Yes |
-| **WebRTC spoofing** | No | Yes (protocol level) | Yes |
-| **Canvas/WebGL** | No | Yes (C++ intercept) | Yes |
-| **Font spoofing** | No | Yes (bundled fonts) | Yes |
-| **Human mouse** | No | Yes (C++ algorithm) | Yes |
-| **Profile management** | Manual | Python API | GUI |
-| **Proxy integration** | Playwright native | Python API | Built-in |
-| **Headless stealth** | Partial | Full (patched) | N/A |
-| **Cost** | Free (MIT) | Free (MPL-2.0) | $9-$299/mo |
-| **Setup** | `npx rebrowser-patches patch` | `pip install camoufox` | Download app |
+| Feature | rebrowser-patches | Camoufox | Mullvad Browser | AdsPower/GoLogin |
+|---------|------------------|----------|-----------------|------------------|
+| **Engine** | Chromium (Playwright) | Firefox (Playwright) | Firefox (Playwright) | Chromium |
+| **Stealth level** | Medium (CDP patches) | High (C++ level) | High (Tor patches) | High (proprietary) |
+| **Fingerprint rotation** | No (add manually) | Yes (BrowserForge) | No (fixed uniform) | Yes |
+| **WebRTC spoofing** | No | Yes (protocol level) | Yes (disabled) | Yes |
+| **Canvas/WebGL** | No | Yes (C++ intercept) | Yes (randomized) | Yes |
+| **Font spoofing** | No | Yes (bundled fonts) | Yes (limited set) | Yes |
+| **Human mouse** | No | Yes (C++ algorithm) | No | Yes |
+| **Profile management** | Manual | Python API | Manual | GUI |
+| **Proxy integration** | Playwright native | Python API | Manual/system | Built-in |
+| **Headless stealth** | Partial | Full (patched) | Partial | N/A |
+| **Cost** | Free (MIT) | Free (MPL-2.0) | Free (GPL) | $9-$299/mo |
+| **Setup** | `npx rebrowser-patches patch` | `pip install camoufox` | Download app | Download app |
+
+**Mullvad Browser vs Camoufox**:
+- **Mullvad Browser**: Best for manual browsing with privacy. Uses Tor Browser's uniform fingerprint approach (all users look identical). Limited automation support.
+- **Camoufox**: Best for automation. Generates unique, realistic fingerprints per profile. Full Playwright API support with C++ level spoofing.
 
 ## Quick Start
 
@@ -95,6 +100,9 @@ Need anti-detection?
 
 # Launch with stealth patches only (faster, Chromium)
 ~/.aidevops/agents/scripts/anti-detect-helper.sh launch --profile "my-account" --engine chromium
+
+# Launch with Mullvad Browser (Tor-based privacy, no fingerprint rotation)
+~/.aidevops/agents/scripts/anti-detect-helper.sh launch --profile "my-account" --engine mullvad
 
 # Test detection status
 ~/.aidevops/agents/scripts/anti-detect-helper.sh test --profile "my-account"

--- a/configs/browser-prefs.json.txt
+++ b/configs/browser-prefs.json.txt
@@ -1,0 +1,37 @@
+{
+  "preferred_browser": "chromium",
+  "preferred_firefox": "firefox",
+  "browser_paths": {
+    "chromium": null,
+    "brave": "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+    "edge": "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    "chrome": "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "firefox": "/Applications/Firefox.app/Contents/MacOS/firefox",
+    "mullvad": "/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser"
+  },
+  "browser_paths_linux": {
+    "chromium": null,
+    "brave": "/usr/bin/brave-browser",
+    "edge": "/usr/bin/microsoft-edge",
+    "chrome": "/usr/bin/google-chrome",
+    "firefox": "/usr/bin/firefox",
+    "mullvad": "/usr/bin/mullvad-browser"
+  },
+  "browser_paths_windows": {
+    "chromium": null,
+    "brave": "C:\\Program Files\\BraveSoftware\\Brave-Browser\\Application\\brave.exe",
+    "edge": "C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe",
+    "chrome": "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe",
+    "firefox": "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
+    "mullvad": "C:\\Program Files\\Mullvad Browser\\Browser\\mullvadbrowser.exe"
+  },
+  "extensions": {
+    "ublock_origin": null
+  },
+  "notes": {
+    "preferred_browser": "Default Chromium-based browser: chromium|brave|edge|chrome",
+    "preferred_firefox": "Default Firefox-based browser: firefox|mullvad",
+    "browser_paths": "Set to null to use Playwright's bundled browser",
+    "mullvad": "Mullvad Browser uses Tor Browser's uniform fingerprint (no rotation). Best for privacy, not multi-account."
+  }
+}


### PR DESCRIPTION
## Summary

- Add Mullvad Browser as a supported browser engine for privacy-focused automation
- Integrate with existing anti-detect browser stack alongside Camoufox and rebrowser-patches
- Create browser preferences template for storing custom browser paths

## Changes

### Documentation
- **browser-automation.md**: Add Mullvad Browser to custom browser engine table with paths for macOS/Linux/Windows
- **anti-detect-browser.md**: Add Mullvad vs Camoufox comparison, update decision tree and tool comparison table

### Scripts
- **anti-detect-helper.sh**: Add `--engine mullvad` option with `launch_mullvad()` function using Playwright's Firefox driver

### Configuration
- **browser-prefs.json.txt**: New template with browser paths for all supported browsers (Chromium, Brave, Edge, Chrome, Firefox, Mullvad)

## Usage

```bash
# Launch with Mullvad Browser
anti-detect-helper.sh launch --profile "my-account" --engine mullvad

# Check installation status
anti-detect-helper.sh status
```

## Notes

Mullvad Browser uses Tor Browser's uniform fingerprint approach (all users look identical), which is best for privacy but not multi-account automation. For fingerprint rotation, Camoufox remains the recommended option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mullvad Browser as a selectable engine (use --engine mullvad) with automatic executable discovery, headless support, proxy handling, and persistent/ephemeral profile options.
  * Status reporting now shows Mullvad availability and installation path when present.

* **Documentation**
  * Updated browser comparison, quick-starts, and examples to include Mullvad Browser.
  * Added a browser preferences config for platform-specific paths and defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->