### PR TITLE
fix: add blank line before fenced code block in remember.md

### DIFF
--- a/.agent/scripts/commands/remember.md
+++ b/.agent/scripts/commands/remember.md
@@ -139,6 +139,7 @@ That worked! Want me to remember this for future sessions?
 ### Examples
 
 **After fixing a bug:**
+
 ```text
 User: Adding --legacy-peer-deps fixed the npm install
 AI: That worked! Want me to remember this for future sessions?


### PR DESCRIPTION
Fixes Codacy markdown lint issue - fenced code blocks should be surrounded by blank lines.