### PR TITLE
fix: make markdown lint blocking for changed files

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -69,7 +69,7 @@ Exit 0 = proceed. Exit 1 = STOP (on main). Exit 2 = create worktree. Exit 3 = wa
 - NEVER expose credentials in output/logs
 - Confirm destructive operations before execution
 
-**Quality**: SonarCloud A-grade, ShellCheck zero violations, `local var="$1"` pattern, explicit returns.
+**Quality**: SonarCloud A-grade, ShellCheck zero violations, `local var="$1"` pattern, explicit returns, blank lines around code blocks (MD031).
 
 ## Planning & Tasks
 

--- a/.agent/scripts/linters-local.sh
+++ b/.agent/scripts/linters-local.sh
@@ -363,9 +363,10 @@ check_markdown_lint() {
     fi
 
     # Get markdown files to check:
-    # 1. Uncommitted changes (staged + unstaged)
-    # 2. If no uncommitted, check files changed in current branch vs main
-    # 3. Fallback to all tracked .md files in .agent/
+    # 1. Uncommitted changes (staged + unstaged) - BLOCKING
+    # 2. If no uncommitted, check files changed in current branch vs main - BLOCKING
+    # 3. Fallback to all tracked .md files in .agent/ - NON-BLOCKING (advisory)
+    local check_mode="changed"  # "changed" = blocking, "all" = advisory
     if git rev-parse --git-dir > /dev/null 2>&1; then
         # First try uncommitted changes
         md_files=$(git diff --name-only --diff-filter=ACMR HEAD -- '*.md' 2>/dev/null)
@@ -379,12 +380,14 @@ check_markdown_lint() {
             fi
         fi
         
-        # Fallback: check all .agent/*.md files
+        # Fallback: check all .agent/*.md files (advisory only)
         if [[ -z "$md_files" ]]; then
             md_files=$(git ls-files '.agent/**/*.md' 2>/dev/null)
+            check_mode="all"
         fi
     else
         md_files=$(find . -name "*.md" -type f 2>/dev/null | grep -v node_modules)
+        check_mode="all"
     fi
 
     if [[ -z "$md_files" ]]; then
@@ -402,44 +405,34 @@ check_markdown_lint() {
             violations=$(echo "$lint_output" | grep -c "MD[0-9]" || echo "0")
             
             if [[ $violations -gt 0 ]]; then
-                print_warning "Markdown: $violations style issues found"
+                if [[ "$check_mode" == "changed" ]]; then
+                    print_error "Markdown: $violations style issues in changed files (BLOCKING)"
+                else
+                    print_warning "Markdown: $violations style issues found (advisory)"
+                fi
                 echo "$lint_output" | head -10
                 if [[ $violations -gt 10 ]]; then
                     echo "... and $((violations - 10)) more"
                 fi
-                print_info "Run: markdownlint --fix .agent/**/*.md to auto-fix"
-                # Non-blocking for now - many pre-existing issues
-                # TODO: Make blocking after fixing existing issues
+                print_info "Run: markdownlint --fix <file> to auto-fix"
+                # Blocking for changed files, advisory for all files
+                if [[ "$check_mode" == "changed" ]]; then
+                    return 1
+                fi
                 return 0
             fi
         fi
         print_success "Markdown: No style issues found"
     else
         # Fallback: basic checks without markdownlint
-        local issues=0
-        
-        # Check for fenced code blocks without language (MD040)
-        # Pattern: line starts with optional whitespace, then ``` with nothing after (or just whitespace)
-        for file in $md_files; do
-            local count
-            # Use grep -E for extended regex (portable across macOS/Linux)
-            count=$(grep -cE '^[[:space:]]*```[[:space:]]*$' "$file" 2>/dev/null || echo "0")
-            if [[ $count -gt 0 ]]; then
-                print_warning "$file: $count fenced code blocks without language specifier"
-                grep -nE '^[[:space:]]*```[[:space:]]*$' "$file" 2>/dev/null | head -3
-                issues=$((issues + count))
-            fi
-        done
-        
-        if [[ $issues -gt 0 ]]; then
-            print_warning "Markdown: $issues issues found (install markdownlint for full checks)"
-            print_info "Install: npm install -g markdownlint-cli"
-            # Non-blocking for now - many pre-existing issues
-            # TODO: Make blocking after fixing existing issues
-            return 0
-        fi
-        
-        print_success "Markdown: Basic checks passed (install markdownlint for full checks)"
+        # NOTE: Without markdownlint, we can't reliably detect MD031/MD040 violations
+        # because we can't distinguish opening fences (need language) from closing fences (always bare)
+        # So fallback is always advisory-only and recommends installing markdownlint
+        print_warning "Markdown: markdownlint not installed - cannot perform full lint checks"
+        print_info "Install: npm install -g markdownlint-cli"
+        print_info "Then re-run to get blocking checks for changed files"
+        # Advisory only - don't block without proper tooling
+        return 0
     fi
 
     return 0


### PR DESCRIPTION
## Summary

Makes markdown lint checks blocking for changed files while keeping them advisory for the full codebase. This prevents markdown formatting issues (like MD031 - blank lines around code blocks) from being merged.

## Changes

- **linters-local.sh**: Modified `check_markdown_lint()` to:
  - Track `check_mode` ("changed" vs "all")
  - Return exit 1 (blocking) when violations found in changed files
  - Keep advisory mode (exit 0) for full codebase scan
  - Simplified fallback when markdownlint not installed

- **AGENTS.md**: Added "blank lines around code blocks (MD031)" to Quality line as a reminder

## Why

PR #269 introduced an MD031 violation that was caught by Codacy post-merge, requiring a follow-up fix PR #270. This change ensures such issues are caught during preflight checks.

## Testing

1. With markdownlint installed: Changed files with violations → blocking (exit 1)
2. With markdownlint installed: No violations → pass (exit 0)
3. Without markdownlint: Advisory warning only (exit 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated quality criteria to include new formatting requirements for code blocks in markdown documentation.

**Chores**
- Enhanced markdown linting workflow with improved error detection and violation counting, introducing blocking versus advisory check modes, better fallback handling when tools are unavailable, and improved behavior in non-repository environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->