### PR TITLE
feat: disable google-analytics-mcp and context7 by default

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -124,22 +124,26 @@ SKIP_PRIMARY_AGENTS = {"plan-plus.md", "aidevops.md"}
 # These are MCP tools that specific agents need access to
 #
 # MCP On-Demand Loading Strategy:
-# The following MCPs are DISABLED globally to reduce context token usage (~4.6K saved):
+# The following MCPs are DISABLED globally to reduce context token usage:
 #   - playwriter_*: ~3K tokens - enable via @playwriter subagent
 #   - augment-context-engine_*: ~1K tokens - enable via @augment-context-engine subagent
 #   - gh_grep_*: ~600 tokens - replaced by @github-search subagent (uses rg/bash)
+#   - google-analytics-mcp_*: ~800 tokens - enable via @google-analytics subagent
+#   - context7_*: ~800 tokens - enable via @context7 subagent (library docs lookup)
 #
 # osgrep_* remains enabled as the primary semantic search tool (local, no auth).
 # Use @augment-context-engine subagent when osgrep returns insufficient results.
+# Use @context7 subagent when you need up-to-date library documentation.
 AGENT_TOOLS = {
     "Build+": {
         # Unified coding agent - planning, implementation, and DevOps
         # Browser automation: use @playwriter subagent (enables playwriter MCP on-demand)
         # Semantic search: osgrep primary, @augment-context-engine fallback
+        # Library docs: use @context7 subagent when needed
         # GitHub search: use @github-search subagent (rg/bash, no MCP needed)
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
         "webfetch": True, "task": True, "todoread": True, "todowrite": True,
-        "context7_*": True, "osgrep_*": True
+        "osgrep_*": True
     },
     "Onboarding": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
@@ -159,11 +163,11 @@ AGENT_TOOLS = {
     "SEO": {
         "write": True, "read": True, "bash": True, "webfetch": True,
         "gsc_*": True, "ahrefs_*": True, "dataforseo_*": True,
-        "context7_*": True, "osgrep_*": True
+        "osgrep_*": True
     },
     "WordPress": {
         "write": True, "edit": True, "bash": True, "read": True, "glob": True, "grep": True,
-        "localwp_*": True, "context7_*": True, "osgrep_*": True
+        "localwp_*": True, "osgrep_*": True
     },
     "Content": {
         "write": True, "edit": True, "read": True, "webfetch": True,
@@ -171,17 +175,19 @@ AGENT_TOOLS = {
     },
     "Research": {
         "read": True, "webfetch": True, "bash": True,
-        "context7_*": True, "osgrep_*": True
+        "osgrep_*": True
     },
 }
 
 # Default tools for agents not in AGENT_TOOLS
 #
-# MCP On-Demand Loading:
-# - playwriter_*: DISABLED - use @playwriter subagent (~3K tokens saved)
-# - augment-context-engine_*: DISABLED - use @augment-context-engine subagent (~1K saved)
-# - gh_grep_*: DISABLED - use @github-search subagent (~600 tokens saved)
-# - claude-code-mcp_*: DISABLED - use @claude-code subagent
+# MCP On-Demand Loading (all disabled globally, use subagents):
+# - playwriter_*: ~3K tokens - @playwriter subagent
+# - augment-context-engine_*: ~1K tokens - @augment-context-engine subagent
+# - gh_grep_*: ~600 tokens - @github-search subagent (uses rg/bash)
+# - google-analytics-mcp_*: ~800 tokens - @google-analytics subagent
+# - context7_*: ~800 tokens - @context7 subagent
+# - claude-code-mcp_*: use @claude-code subagent
 #
 # osgrep_* remains enabled as primary semantic search (local, fast, no auth)
 DEFAULT_TOOLS = {
@@ -507,12 +513,16 @@ pkg_runner = f"{bun_path} x" if bun_path else (npx_path or "npx")
 # MCP LOADING POLICY - Enforce enabled states for all MCPs
 # -----------------------------------------------------------------------------
 # Eager-loaded (enabled: True): Used by all main agents, start at launch
-EAGER_MCPS = {'osgrep', 'augment-context-engine', 'context7', 'playwriter', 'gh_grep', 'sentry', 'socket'}
+# Only osgrep remains eager - it's local, fast, no auth required
+EAGER_MCPS = {'osgrep', 'sentry', 'socket'}
 
 # Lazy-loaded (enabled: False): Subagent-only, start on-demand
+# Moved to lazy: playwriter, augment-context-engine, gh_grep, context7, google-analytics-mcp
+# These save ~6K+ tokens on session startup
 LAZY_MCPS = {'claude-code-mcp', 'outscraper', 'dataforseo', 'shadcn', 'macos-automator', 
              'gsc', 'localwp', 'chrome-devtools', 'quickfile', 'amazon-order-history', 
-             'google-analytics-mcp', 'MCP_DOCKER', 'ahrefs'}
+             'google-analytics-mcp', 'MCP_DOCKER', 'ahrefs',
+             'playwriter', 'augment-context-engine', 'gh_grep', 'context7'}
 
 # Apply loading policy to existing MCPs and warn about uncategorized ones
 uncategorized = []

--- a/.agent/tools/context/mcp-discovery.md
+++ b/.agent/tools/context/mcp-discovery.md
@@ -48,11 +48,13 @@ mcp-index-helper.sh status
 
 **Disabled MCPs** (enabled via subagents):
 
-| MCP | Tokens | Subagent |
-|-----|--------|----------|
-| `playwriter` | ~3K | `@playwriter` |
-| `augment-context-engine` | ~1K | `@augment-context-engine` |
-| `gh_grep` | ~600 | `@github-search` (uses rg/bash) |
+| MCP | Tokens | Subagent | When to enable |
+|-----|--------|----------|----------------|
+| `playwriter` | ~3K | `@playwriter` | Browser automation needed |
+| `augment-context-engine` | ~1K | `@augment-context-engine` | osgrep insufficient |
+| `gh_grep` | ~600 | `@github-search` | (uses rg/bash instead) |
+| `google-analytics-mcp` | ~800 | `@google-analytics` | Analytics reporting |
+| `context7` | ~800 | `@context7` | Library docs lookup |
 
 **Always enabled**: `osgrep` (primary semantic search, local, no auth)
 

--- a/setup.sh
+++ b/setup.sh
@@ -302,10 +302,12 @@ cleanup_deprecated_mcps() {
 }
 
 # Disable MCPs globally that should only be enabled on-demand via subagents
-# This reduces session startup context by ~4.6K tokens
+# This reduces session startup context by disabling rarely-used MCPs
 # - playwriter: ~3K tokens - enable via @playwriter subagent
 # - augment-context-engine: ~1K tokens - enable via @augment-context-engine subagent
 # - gh_grep: ~600 tokens - replaced by @github-search subagent (uses rg/bash)
+# - google-analytics-mcp: ~800 tokens - enable via @google-analytics subagent
+# - context7: ~800 tokens - enable via @context7 subagent (for library docs lookup)
 disable_ondemand_mcps() {
     local opencode_config="$HOME/.config/opencode/opencode.json"
     
@@ -318,11 +320,13 @@ disable_ondemand_mcps() {
     fi
     
     # MCPs to disable globally (enabled on-demand via subagents)
-    # Note: use exact MCP key names from opencode.json (underscore, not hyphen)
+    # Note: use exact MCP key names from opencode.json
     local -a ondemand_mcps=(
         "playwriter"
         "augment-context-engine"
         "gh_grep"
+        "google-analytics-mcp"
+        "context7"
     )
     
     local disabled=0


### PR DESCRIPTION
## Summary

Adds more MCPs to on-demand loading, saving additional ~1.6K tokens on startup.

## Changes

| MCP | Tokens | Subagent |
|-----|--------|----------|
| `google-analytics-mcp` | ~800 | `@google-analytics` |
| `context7` | ~800 | `@context7` |

**Total savings now: ~6K+ tokens** (was ~4.6K)

## Rationale

- **google-analytics-mcp**: Only needed occasionally for analytics reporting
- **context7**: Model knowledge is often sufficient; use subagent when library docs needed

## Files changed

- `setup.sh` - Add to `disable_ondemand_mcps` list
- `generate-opencode-agents.sh` - Move to LAZY_MCPS, remove from agent tools
- `mcp-discovery.md` - Document new disabled MCPs