### PR TITLE
feat: add sentry to Build+ allowed subagents

### DIFF
--- a/.agent/build-plus.md
+++ b/.agent/build-plus.md
@@ -42,6 +42,8 @@ subagents:
   # Deployment
   - coolify
   - vercel
+  # Monitoring
+  - sentry
   # Architecture review
   - architecture
   - build-agent


### PR DESCRIPTION
Enables @sentry task invocation for error monitoring MCP.