### PR TITLE
fix: remove invalid syntax in clawdhub-helper.sh

### DIFF
--- a/.agent/scripts/clawdhub-helper.sh
+++ b/.agent/scripts/clawdhub-helper.sh
@@ -287,9 +287,9 @@ PLAYWRIGHT_SCRIPT
 
     # Install playwright and run the fetch script
     log_info "Installing Playwright (temporary)..."
-    if (cd "$pw_dir" && npm install --silent 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null); then || exit
+    if (cd "$pw_dir" && npm install --silent 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null); then
         log_info "Running browser extraction..."
-        if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file" 2>/dev/null); then || exit
+        if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file" 2>/dev/null); then
             rm -rf "$pw_dir"
             if [[ -f "$output_file" && -s "$output_file" ]]; then
                 log_success "Extracted SKILL.md ($(wc -c < "$output_file" | tr -d ' ') bytes)"
@@ -304,7 +304,7 @@ PLAYWRIGHT_SCRIPT
     # Fallback: try clawdhub CLI
     if command -v npx &>/dev/null; then
         log_info "Trying: npx clawdhub install $slug"
-        if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force 2>/dev/null); then || exit
+        if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force 2>/dev/null); then
             # clawdhub installs to ./skills/<slug>/SKILL.md
             local installed_skill
             installed_skill=$(find "$output_dir" -name "SKILL.md" -type f 2>/dev/null | head -1)


### PR DESCRIPTION
## Summary

- Fix ShellCheck SC1072/SC1073 syntax errors
- Remove invalid `|| exit` after `then` in if statements (3 occurrences)

## Issue

```bash
# Invalid syntax
if (command); then || exit

# Fixed
if (command); then
```

## Verification

```bash
shellcheck .agent/scripts/clawdhub-helper.sh
# No output = passes
```