### PR TITLE
fix: add concurrency to all GitHub workflows

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   framework-validation:
     name: Framework Validation

--- a/.github/workflows/code-review-monitoring.yml
+++ b/.github/workflows/code-review-monitoring.yml
@@ -10,6 +10,11 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+# Cancel in-progress runs when a new run is triggered
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   code-review-monitoring:
     name: 🤖 Monitor & Auto-Fix Code Quality

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -9,6 +9,10 @@ on:
         description: 'Tag to verify (leave empty for latest)'
         required: false
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   postflight:
     name: Verify Release Health

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -9,6 +9,10 @@ on:
         description: 'Version to publish (e.g., 2.52.1)'
         required: true
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-npm:
     name: Publish to npm

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -7,6 +7,10 @@ on:
     paths:
       - '.wiki/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sync-wiki:
     name: Sync Wiki to GitHub

--- a/.github/workflows/update-website-docs.yml
+++ b/.github/workflows/update-website-docs.yml
@@ -9,6 +9,10 @@ on:
       - 'README.md'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/version-validation.yml
+++ b/.github/workflows/version-validation.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   version-consistency:
     name: Version Consistency Check


### PR DESCRIPTION
## Summary

Adds concurrency settings to all GitHub workflows to prevent duplicate runs and reduce email notification noise.

## Problem

When pushing multiple commits in quick succession, each push triggers a new workflow run. The previous run gets cancelled, generating a "cancelled" email notification for each one.

## Solution

Added to all 7 workflows:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

This ensures only the latest run executes, and cancelled runs don't generate notifications.

## Workflows Updated

- `code-quality.yml`
- `code-review-monitoring.yml`
- `postflight.yml`
- `publish-packages.yml`
- `sync-wiki.yml`
- `update-website-docs.yml`
- `version-validation.yml`

Note: `opencode-agent.yml` already had concurrency configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations to implement concurrency control. This prevents duplicate concurrent runs for the same workflow and ref, improving CI/CD efficiency by automatically canceling redundant in-flight executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->