### PR TITLE
fix: route /agent-review command to Build+ instead of disabled Build-Agent

### DIFF
--- a/.agent/scripts/generate-opencode-commands.sh
+++ b/.agent/scripts/generate-opencode-commands.sh
@@ -37,7 +37,7 @@ command_count=0
 cat > "$OPENCODE_COMMAND_DIR/agent-review.md" << 'EOF'
 ---
 description: Systematic review and improvement of agent instructions
-agent: Build-Agent
+agent: Build+
 subtask: true
 ---
 


### PR DESCRIPTION
## Summary

- Fixed `/agent-review` slash command routing to disabled agent
- Changed `agent: Build-Agent` to `agent: Build+` in `generate-opencode-commands.sh`

## Problem

The `/agent-review` command was the only slash command routing to `Build-Agent`, which is disabled in OpenCode config (consolidated into `Build+`). This caused:

```
Agent not found: "Build-Agent"
```

## Solution

Updated the agent field to `Build+` to match all other 53 slash commands in the codebase.

## Testing

1. Ran `generate-opencode-commands.sh` from worktree
2. Verified `~/.config/opencode/command/agent-review.md` now shows `agent: Build+`
3. Pre-existing linter issues in imported skills unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent metadata configuration in generated command documentation to reflect current build system designation. No functional changes to command behavior or execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->