### PR TITLE
feat: support multiple AI code reviewers in PR loop

### DIFF
--- a/.agent/scripts/quality-loop-helper.sh
+++ b/.agent/scripts/quality-loop-helper.sh
@@ -608,14 +608,15 @@ check_pr_status() {
     check_count=$(echo "$pr_info" | jq '.statusCheckRollup | length')
     
     if [[ "$check_count" -gt 0 ]]; then
-        local pending_count failed_count
-        pending_count=$(echo "$pr_info" | jq '[.statusCheckRollup[] | select(.status == "PENDING" or .status == "IN_PROGRESS")] | length')
-        failed_count=$(echo "$pr_info" | jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE")] | length')
+        local pending_count failed_count action_required_count
+        pending_count=$(printf '%s' "$pr_info" | jq '[.statusCheckRollup[] | select(.status == "PENDING" or .status == "IN_PROGRESS")] | length')
+        failed_count=$(printf '%s' "$pr_info" | jq '[.statusCheckRollup[] | select(.conclusion == "FAILURE")] | length')
+        action_required_count=$(printf '%s' "$pr_info" | jq '[.statusCheckRollup[] | select(.conclusion == "ACTION_REQUIRED")] | length')
         
-        print_info "  CI Checks: $check_count total, $pending_count pending, $failed_count failed"
+        print_info "  CI Checks: $check_count total, $pending_count pending, $failed_count failed, $action_required_count action required"
         
         [[ "$pending_count" -gt 0 ]] && checks_pending=true
-        [[ "$failed_count" -gt 0 ]] && checks_failed=true
+        [[ "$failed_count" -gt 0 || "$action_required_count" -gt 0 ]] && checks_failed=true
     fi
     
     # Determine overall status

--- a/.agent/scripts/quality-loop-helper.sh
+++ b/.agent/scripts/quality-loop-helper.sh
@@ -762,6 +762,7 @@ check_unresolved_review_comments() {
         return 2
     fi
     
+    # shellcheck disable=SC2016 # GraphQL variables, not shell - single quotes intentional
     api_response=$(gh api graphql -f query='
       query($owner:String!, $repo:String!, $number:Int!) {
         repository(owner:$owner, name:$repo) {

--- a/.agent/workflows/pr.md
+++ b/.agent/workflows/pr.md
@@ -97,6 +97,19 @@ Calls remote quality services via APIs:
 - Codacy - Code quality analysis
 - SonarCloud - Security and maintainability
 
+### Supported AI Code Reviewers
+
+The PR loop monitors comments from multiple AI code review services:
+
+| Reviewer | Bot Username Pattern | Purpose |
+|----------|---------------------|---------|
+| CodeRabbit | `coderabbit*` | AI-powered code review with suggestions |
+| Gemini Code Assist | `gemini-code-assist[bot]` | Google's AI code review |
+| Augment Code | `augment-code[bot]` | Augment AI code review |
+| GitHub Copilot | `copilot[bot]` | GitHub's AI assistant |
+
+The `/pr-loop` command automatically detects and surfaces comments from all these reviewers, ensuring no feedback is missed regardless of which AI services are configured on the repository.
+
 ### 3. Standards Compliance (`/code-standards`)
 
 Checks against our documented quality standards:

--- a/.agent/workflows/pr.md
+++ b/.agent/workflows/pr.md
@@ -105,7 +105,7 @@ The PR loop monitors comments from multiple AI code review services:
 |----------|---------------------|---------|
 | CodeRabbit | `coderabbit*` | AI-powered code review with suggestions |
 | Gemini Code Assist | `gemini-code-assist[bot]` | Google's AI code review |
-| Augment Code | `augment-code[bot]` | Augment AI code review |
+| Augment Code | `augment-code[bot]` | AI-powered code review and improvement |
 | GitHub Copilot | `copilot[bot]` | GitHub's AI assistant |
 
 The `/pr-loop` command automatically detects and surfaces comments from all these reviewers, ensuring no feedback is missed regardless of which AI services are configured on the repository.

--- a/.agent/workflows/pr.md
+++ b/.agent/workflows/pr.md
@@ -105,7 +105,7 @@ The PR loop monitors comments from multiple AI code review services:
 |----------|---------------------|---------|
 | CodeRabbit | `coderabbit*` | AI-powered code review with suggestions |
 | Gemini Code Assist | `gemini-code-assist[bot]` | Google's AI code review |
-| Augment Code | `augment-code[bot]` | AI-powered code review and improvement |
+| Augment Code | `augment-code[bot]`, `augmentcode[bot]` | AI-powered code review and improvement |
 | GitHub Copilot | `copilot[bot]` | GitHub's AI assistant |
 
 The `/pr-loop` command automatically detects and surfaces comments from all these reviewers, ensuring no feedback is missed regardless of which AI services are configured on the repository.


### PR DESCRIPTION
## Summary

- Add regex-based detection for multiple AI code reviewers (CodeRabbit, Gemini Code Assist, Augment Code, GitHub Copilot)
- Update PR loop to monitor comments from all supported AI reviewers
- Add function to check for unresolved AI review comments

## Problem

`quality-loop-helper.sh` only monitored CodeRabbit reviews, ignoring feedback from other AI code review services. This caused `/pr-loop` to miss review comments and declare "Ready to Merge" prematurely.

**Evidence**: In a managed project PR #2, Gemini Code Assist left comments that were not detected by the PR loop.

## Changes

| File | Change |
|------|--------|
| `quality-loop-helper.sh` | Add `AI_REVIEWERS` constant with regex pattern |
| `quality-loop-helper.sh` | Update `get_pr_feedback()` to detect all AI reviewer comments |
| `quality-loop-helper.sh` | Update `check_and_trigger_review()` to check all AI reviewer times |
| `quality-loop-helper.sh` | Add `check_unresolved_review_comments()` function |
| `workflows/pr.md` | Document supported AI reviewers |

## Supported AI Reviewers

| Reviewer | Bot Username Pattern |
|----------|---------------------|
| CodeRabbit | `coderabbit*` |
| Gemini Code Assist | `gemini-code-assist[bot]` |
| Augment Code | `augment-code[bot]` |
| GitHub Copilot | `copilot[bot]` |

Closes #294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR review loop now monitors feedback from multiple AI code reviewers (CodeRabbit, Gemini Code Assist, Augment Code, GitHub Copilot) and surfaces their comments.
  * Detects unresolved AI reviewer comments and prevents auto-approval until feedback is addressed; will still warn if reviewer APIs cannot be reached.

* **Documentation**
  * Added documentation describing supported AI reviewers and how the PR loop integrates their feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->