### PR TITLE
fix: correct SonarCloud rule prefix (shell: → shelldre:)

### DIFF
--- a/.agent/scripts/privacy-filter-helper.sh
+++ b/.agent/scripts/privacy-filter-helper.sh
@@ -229,15 +229,6 @@ scan_privacy() {
     print_info "Checking ${#patterns[@]} patterns"
     echo ""
     
-    # Find files to scan (respect .gitignore)
-    local -a files
-    if command -v rg &> /dev/null; then
-        # Use ripgrep for speed
-        mapfile -t files < <(rg --files "$target" 2>/dev/null || find "$target" -type f 2>/dev/null)
-    else
-        mapfile -t files < <(find "$target" -type f -not -path '*/\.*' -not -path '*/node_modules/*' 2>/dev/null)
-    fi
-    
     # Scan each pattern
     for pattern in "${patterns[@]}"; do
         local pattern_name="${pattern:0:40}..."

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -30,42 +30,42 @@ sonar.cpd.exclusions=configs/**/*.txt,.agent/**/*.md,templates/**/*.md
 # - curl|bash installers: Official installers from verified HTTPS sources
 sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17
 
-# Ignore "npm install without --ignore-scripts" (shell:S6505) - required for CLI tool installation
-sonar.issue.ignore.multicriteria.e1.ruleKey=shell:S6505
+# Ignore "npm install without --ignore-scripts" (shelldre:S6505) - required for CLI tool installation
+sonar.issue.ignore.multicriteria.e1.ruleKey=shelldre:S6505
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*-helper.sh
 
-sonar.issue.ignore.multicriteria.e2.ruleKey=shell:S6505
+sonar.issue.ignore.multicriteria.e2.ruleKey=shelldre:S6505
 sonar.issue.ignore.multicriteria.e2.resourceKey=**/*-setup.sh
 
-sonar.issue.ignore.multicriteria.e3.ruleKey=shell:S6505
+sonar.issue.ignore.multicriteria.e3.ruleKey=shelldre:S6505
 sonar.issue.ignore.multicriteria.e3.resourceKey=**/*-cli.sh
 
-# Ignore "clear-text protocol" (shell:S5332) - localhost dev servers, HTTP detection, installers
+# Ignore "clear-text protocol" (shelldre:S5332) - localhost dev servers, HTTP detection, installers
 # These scripts use http://localhost for local dev, detect http:// URLs, or use official installers
-sonar.issue.ignore.multicriteria.e4.ruleKey=shell:S5332
+sonar.issue.ignore.multicriteria.e4.ruleKey=shelldre:S5332
 sonar.issue.ignore.multicriteria.e4.resourceKey=**/*-helper.sh
 
-sonar.issue.ignore.multicriteria.e5.ruleKey=shell:S5332
+sonar.issue.ignore.multicriteria.e5.ruleKey=shelldre:S5332
 sonar.issue.ignore.multicriteria.e5.resourceKey=**/*-setup.sh
 
-sonar.issue.ignore.multicriteria.e6.ruleKey=shell:S5332
+sonar.issue.ignore.multicriteria.e6.ruleKey=shelldre:S5332
 sonar.issue.ignore.multicriteria.e6.resourceKey=**/*-cli.sh
 
-# Ignore "HTTPS not enforced" (shell:S6506) - curl|bash for official installers from verified sources
-sonar.issue.ignore.multicriteria.e7.ruleKey=shell:S6506
+# Ignore "HTTPS not enforced" (shelldre:S6506) - curl|bash for official installers from verified sources
+sonar.issue.ignore.multicriteria.e7.ruleKey=shelldre:S6506
 sonar.issue.ignore.multicriteria.e7.resourceKey=**/*-helper.sh
 
-sonar.issue.ignore.multicriteria.e8.ruleKey=shell:S6506
+sonar.issue.ignore.multicriteria.e8.ruleKey=shelldre:S6506
 sonar.issue.ignore.multicriteria.e8.resourceKey=**/*-setup.sh
 
-sonar.issue.ignore.multicriteria.e9.ruleKey=shell:S6506
+sonar.issue.ignore.multicriteria.e9.ruleKey=shelldre:S6506
 sonar.issue.ignore.multicriteria.e9.resourceKey=**/*-cli.sh
 
 # Ignore S5332/S6506 for verify scripts (HTTP redirect testing requires HTTP)
-sonar.issue.ignore.multicriteria.e10.ruleKey=shell:S5332
+sonar.issue.ignore.multicriteria.e10.ruleKey=shelldre:S5332
 sonar.issue.ignore.multicriteria.e10.resourceKey=**/*-verify.sh
 
-sonar.issue.ignore.multicriteria.e11.ruleKey=shell:S6506
+sonar.issue.ignore.multicriteria.e11.ruleKey=shelldre:S6506
 sonar.issue.ignore.multicriteria.e11.resourceKey=**/*-verify.sh
 
 # Code smell exclusions for shell scripts
@@ -74,21 +74,21 @@ sonar.issue.ignore.multicriteria.e11.resourceKey=**/*-verify.sh
 
 # S7679: Positional parameters - Standard shell argument parsing pattern used consistently
 # The while/case pattern for argument parsing is idiomatic and readable
-sonar.issue.ignore.multicriteria.e12.ruleKey=shell:S7679
+sonar.issue.ignore.multicriteria.e12.ruleKey=shelldre:S7679
 sonar.issue.ignore.multicriteria.e12.resourceKey=**/*.sh
 
 # S1192: String literals - Many repeated strings are intentional (color codes, log prefixes)
 # Extracting these to constants would reduce readability in shell scripts
-sonar.issue.ignore.multicriteria.e13.ruleKey=shell:S1192
+sonar.issue.ignore.multicriteria.e13.ruleKey=shelldre:S1192
 sonar.issue.ignore.multicriteria.e13.resourceKey=**/*.sh
 
 # S7677: Error messages to stderr - Many "errors" are actually user-facing status messages
 # The framework uses colored output for UX, not traditional stderr separation
-sonar.issue.ignore.multicriteria.e14.ruleKey=shell:S7677
+sonar.issue.ignore.multicriteria.e14.ruleKey=shelldre:S7677
 sonar.issue.ignore.multicriteria.e14.resourceKey=**/*.sh
 
 # S1135: TODO comments - These are tracked intentionally for future work
-sonar.issue.ignore.multicriteria.e15.ruleKey=shell:S1135
+sonar.issue.ignore.multicriteria.e15.ruleKey=shelldre:S1135
 sonar.issue.ignore.multicriteria.e15.resourceKey=**/*.sh
 
 # Note: S1481 (unused variables) and S1066 (collapsible ifs) are NOT excluded
@@ -96,12 +96,12 @@ sonar.issue.ignore.multicriteria.e15.resourceKey=**/*.sh
 
 # S131: Missing default case - Many case statements intentionally skip unknown options
 # The framework handles unknown commands at the main dispatch level
-sonar.issue.ignore.multicriteria.e16.ruleKey=shell:S131
+sonar.issue.ignore.multicriteria.e16.ruleKey=shelldre:S131
 sonar.issue.ignore.multicriteria.e16.resourceKey=**/*.sh
 
 # S7682: Explicit return statements - Functions use implicit returns where appropriate
 # Shell convention allows implicit return 0 for successful functions
-sonar.issue.ignore.multicriteria.e17.ruleKey=shell:S7682
+sonar.issue.ignore.multicriteria.e17.ruleKey=shelldre:S7682
 sonar.issue.ignore.multicriteria.e17.resourceKey=**/*.sh
 
 # Project metadata


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue exclusions not being applied.

## Problem

SonarCloud was reporting 421 issues despite having exclusions configured. The rule prefix changed from `shell:` to `shelldre:` in SonarCloud's shell analyzer, but our config still used the old prefix.

## Changes

- Update all rule prefixes from `shell:` to `shelldre:` in `sonar-project.properties`
- Remove unused `files` variable from `privacy-filter-helper.sh` (S1481)

## Expected Result

After merge, SonarCloud should respect the exclusions and report significantly fewer issues (mostly just S1481 unused variables which we intentionally don't exclude).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SonarQube rule configurations for improved code quality analysis.
  
* **Refactor**
  * Simplified privacy scanning logic to streamline file discovery process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->