### PR TITLE
fix: harden cron scripts for secure remote use

### DIFF
--- a/.agent/tools/automation/cron-agent.md
+++ b/.agent/tools/automation/cron-agent.md
@@ -381,11 +381,39 @@ ls -la ~/.aidevops/.agent-workspace/cron/
 
 ## Security Considerations
 
-1. **Server authentication**: Always use `OPENCODE_SERVER_PASSWORD` for network-exposed servers
-2. **Task validation**: Jobs only execute pre-defined tasks from `cron-jobs.json`
-3. **Timeout limits**: All jobs have configurable timeouts to prevent runaway sessions
-4. **Log rotation**: Old logs are automatically pruned (configurable retention)
-5. **Credential isolation**: Tasks inherit environment from cron, not from config files
+1. **HTTPS by default**: Remote hosts (non-localhost) automatically use HTTPS
+2. **Server authentication**: Always use `OPENCODE_SERVER_PASSWORD` for network-exposed servers
+3. **SSL verification**: Enabled by default; use `OPENCODE_INSECURE=1` only for self-signed certs
+4. **Task validation**: Jobs only execute pre-defined tasks from `cron-jobs.json`
+5. **Timeout limits**: All jobs have configurable timeouts to prevent runaway sessions
+6. **Log rotation**: Old logs are automatically pruned (configurable retention)
+7. **Credential isolation**: Tasks inherit environment from cron, not from config files
+
+### Remote Server Configuration
+
+For connecting to a remote OpenCode server:
+
+```bash
+# Required: Set server host and authentication
+export OPENCODE_HOST="opencode.example.com"
+export OPENCODE_PORT="4096"
+export OPENCODE_SERVER_PASSWORD="your-secure-password"
+
+# Optional: For self-signed certificates (not recommended for production)
+export OPENCODE_INSECURE=1
+
+# Test connection
+cron-helper.sh status
+```
+
+### Protocol Selection
+
+| Host | Protocol | Notes |
+|------|----------|-------|
+| `localhost` | HTTP | Safe for local development |
+| `127.0.0.1` | HTTP | Safe for local development |
+| `::1` | HTTP | IPv6 localhost |
+| Any other host | HTTPS | Encrypted connection required |
 
 ## Related Documentation
 


### PR DESCRIPTION
## Summary

Security hardening for cron agent scripts to support secure remote OpenCode server connections.

## Changes

### Security Improvements

1. **HTTPS by default** - Non-localhost hosts automatically use HTTPS
2. **Proper array expansion** - Replace unquoted `$auth_header` with `"${CURL_ARGS[@]}"` array
3. **SSL verification** - Enabled by default, `OPENCODE_INSECURE=1` for self-signed certs
4. **Protocol auto-detection** - `get_protocol()` returns `http` for localhost, `https` for remote

### Files Changed

| File | Changes |
|------|---------|
| `cron-dispatch.sh` | Add `get_protocol()`, `build_curl_args()`, use array for curl |
| `cron-helper.sh` | Same security functions, add `OPENCODE_INSECURE` config |
| `cron-agent.md` | Document remote server configuration and protocol selection |

## Protocol Selection Logic

| Host | Protocol |
|------|----------|
| `localhost` | HTTP |
| `127.0.0.1` | HTTP |
| `::1` | HTTP |
| Any other | HTTPS |

## Remote Usage Example

```bash
export OPENCODE_HOST="opencode.example.com"
export OPENCODE_SERVER_PASSWORD="secure-password"
cron-helper.sh status
```

## Addresses

- SonarCloud S5332 (Using HTTP instead of HTTPS)
- SonarCloud S6506 (Unquoted variable expansion)

## Testing

```bash
# Local (HTTP)
OPENCODE_HOST=localhost cron-helper.sh status

# Remote (HTTPS)
OPENCODE_HOST=remote.example.com cron-helper.sh status
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protocol-aware request handling that automatically selects HTTP for localhost and HTTPS for remote servers.
  * Added OPENCODE_INSECURE environment variable to optionally disable SSL verification for HTTPS connections.

* **Documentation**
  * Expanded security considerations guide with HTTPS defaults and authentication best practices.
  * Added remote server configuration section with environment variable guidance.
  * Added protocol selection reference table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->