### PR TITLE
docs: add terminal capabilities section

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -49,6 +49,23 @@ Exit 0 = proceed. Exit 1 = STOP (on main). Exit 2 = create worktree. Exit 3 = wa
 
 ---
 
+## Terminal Capabilities
+
+The Bash tool provides full PTY access. You can run any CLI autonomously:
+
+| Category | Examples |
+|----------|----------|
+| **Editors** | `vim`, `nano`, `emacs` |
+| **Database shells** | `psql`, `mysql`, `redis-cli`, `mongosh` |
+| **Remote sessions** | `ssh user@host`, `mosh` |
+| **Monitoring** | `htop`, `tail -f`, `watch`, `less` |
+| **Dev servers** | `npm run dev`, `cargo watch`, `flask run` |
+| **Nested AI** | `opencode -p "subtask"` (spawns subagent in same TUI) |
+
+For long-running processes: use `&`, `nohup`, or `screen`/`tmux`. For parallel AI dispatch: use OpenCode server API (`tools/ai-assistants/opencode-server.md`).
+
+---
+
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference

--- a/.agent/tools/build-agent/build-agent.md
+++ b/.agent/tools/build-agent/build-agent.md
@@ -655,6 +655,8 @@ Before using tools, verify you're using the optimal choice:
 | Edit files | `mcp_edit` | `sed` via bash | Safer, atomic |
 | Web content | `mcp_webfetch` | `curl` via bash | Handles redirects |
 | Remote repo research | `mcp_webfetch` README first | `npx repomix --remote` | Prevents context overload |
+| Interactive CLIs | Bash directly | N/A | Full PTY - run vim, psql, ssh, htop |
+| Parallel AI dispatch | OpenCode server API | Multiple TUI instances | Headless, programmatic |
 
 **Self-check prompt**: Before calling any MCP tool, ask:
 > "Is there a faster CLI alternative I should use via Bash?"


### PR DESCRIPTION
## Summary

Documents that the AI agent has full PTY access and can run interactive CLIs autonomously.

## Changes

### AGENTS.md
- Added 'Terminal Capabilities' section after File Discovery
- Lists interactive CLI categories: editors, database shells, remote sessions, monitoring, dev servers
- Documents nested AI capability (`opencode -p 'subtask'`)
- Guidance for long-running processes and parallel dispatch

### build-agent.md
- Added 'Interactive CLIs' row to Tool Selection Checklist
- Added 'Parallel AI dispatch' row pointing to OpenCode server API

## Why

The agent didn't know it could run interactive tools like vim, psql, ssh, htop. This was identified when evaluating pi-interactive-shell - we realized OpenCode already has this capability natively, but our agents weren't aware of it.

## Testing

- Markdown linting passes
- Content follows build-agent.md guidelines (concise, universally applicable)