### PR TITLE
feat: add Ollama GLM-OCR support for local document OCR

### DIFF
--- a/.agent/subagent-index.toon
+++ b/.agent/subagent-index.toon
@@ -22,7 +22,7 @@ flash,gemini-2.5-flash,Fast cheap large context
 pro,gemini-2.5-pro,Capable large context
 -->
 
-<!--TOON:subagents[36]{folder,purpose,key_files}:
+<!--TOON:subagents[37]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture,setup|architecture|troubleshooting|self-improving-agents
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings,dataforseo|serper|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score
@@ -41,6 +41,7 @@ tools/ui/,UI components - design systems and debugging,shadcn|ui-skills|frontend
 tools/code-review/,Code quality - linting and security scanning,code-standards|code-simplifier|codacy|coderabbit|qlty|snyk|secretlint|security-analysis
 tools/context/,Context optimization - semantic search and indexing,osgrep|augment-context-engine|context-builder|context7|toon|mcp-discovery|github-search
 tools/conversion/,Format conversion - document transformation,pandoc
+tools/ocr/,OCR and text extraction - local document processing via Ollama,glm-ocr
 tools/video/,Video creation and downloading - programmatic generation and YouTube downloads,remotion|higgsfield|yt-dlp|video-prompt-design
 tools/data-extraction/,Data extraction - scraping business data,outscraper
 tools/deployment/,Deployment automation - self-hosted PaaS,coolify|coolify-cli|vercel|cloudron-app-packaging

--- a/.agent/tools/browser/peekaboo.md
+++ b/.agent/tools/browser/peekaboo.md
@@ -476,7 +476,15 @@ Peekaboo supports multiple AI providers for vision analysis:
 | Anthropic | Claude 4.x | `ANTHROPIC_API_KEY` |
 | xAI | Grok 4-fast | `XAI_API_KEY` |
 | Google | Gemini 2.5 (pro/flash) | `GOOGLE_API_KEY` |
-| Ollama | llama3.3, llava, etc. | Local (no key needed) |
+| Ollama | llama3.3, llava, glm-ocr, etc. | Local (no key needed) |
+
+### Recommended Models by Task
+
+| Task | Recommended Model | Why |
+|------|-------------------|-----|
+| **OCR / Document text extraction** | `ollama/glm-ocr` | Purpose-built for OCR, handles complex layouts, tables, forms |
+| **General screen understanding** | `ollama/llava` or cloud models | Good balance of speed and accuracy |
+| **UI element detection** | Cloud models (GPT-4o, Claude) | Better at identifying interactive elements |
 
 ### Configure Providers
 
@@ -495,12 +503,18 @@ export PEEKABOO_AI_PROVIDERS="openai/gpt-5.1,anthropic/claude-opus-4"
 # Install Ollama
 brew install ollama
 
-# Pull a vision model
-ollama pull llava
+# Pull vision models
+ollama pull llava      # General vision
+ollama pull glm-ocr    # OCR-optimized (recommended for document/text extraction)
 
-# Use with Peekaboo
+# Use with Peekaboo - general vision
 peekaboo image --mode screen --analyze "What's on screen?" --model ollama/llava
+
+# Use with Peekaboo - OCR tasks
+peekaboo image --mode window --app Preview --analyze "Extract all text from this document" --model ollama/glm-ocr
 ```
+
+**GLM-OCR** is recommended for OCR-heavy tasks (documents, forms, tables, receipts). See `tools/ocr/glm-ocr.md` for standalone OCR workflows without Peekaboo.
 
 ## Workflow Patterns
 

--- a/.agent/tools/ocr/glm-ocr.md
+++ b/.agent/tools/ocr/glm-ocr.md
@@ -1,0 +1,196 @@
+---
+description: GLM-OCR - Local OCR via Ollama for document text extraction
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: false
+  task: false
+---
+
+# GLM-OCR - Local Document OCR
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Extract text from documents, images, screenshots using local AI
+- **Model**: `glm-ocr` via Ollama (no API keys required)
+- **Install**: `ollama pull glm-ocr`
+- **Source**: THUDM (Tsinghua University) GLM-V architecture
+- **Ollama**: <https://ollama.com/library/glm-ocr>
+
+**When to use GLM-OCR**:
+
+- Quick text extraction from screenshots, photos, scanned documents
+- Processing receipts, invoices, forms locally (no cloud)
+- Batch OCR of image files
+- Privacy-sensitive documents that cannot leave your machine
+
+**When to use alternatives**:
+
+- Complex structured extraction (tables, nested forms) - Use Unstract
+- Screen capture + GUI automation - Use Peekaboo with `--model ollama/glm-ocr`
+- Cloud-based with higher accuracy - Use GPT-4o or Claude vision APIs
+
+<!-- AI-CONTEXT-END -->
+
+## Installation
+
+```bash
+# Install Ollama (if not already installed)
+brew install ollama
+
+# Pull GLM-OCR model (~2GB)
+ollama pull glm-ocr
+
+# Verify installation
+ollama list | grep glm-ocr
+```
+
+## Basic Usage
+
+### Extract Text from Image
+
+```bash
+# Single image OCR
+ollama run glm-ocr "Extract all text from this image" --images /path/to/document.png
+
+# With base64 encoding (for scripts)
+base64 -i document.png | ollama run glm-ocr "Extract all text" --images -
+```
+
+### Common Prompts
+
+| Task | Prompt |
+|------|--------|
+| Full text extraction | `"Extract all text from this image exactly as written"` |
+| Table extraction | `"Extract the table data as markdown"` |
+| Form fields | `"List all form fields and their values"` |
+| Receipt parsing | `"Extract merchant, date, items, and total from this receipt"` |
+| Handwriting | `"Transcribe the handwritten text"` |
+
+## Workflow Patterns
+
+### Screenshot OCR
+
+```bash
+# macOS: Capture screen region and OCR
+screencapture -i /tmp/capture.png && ollama run glm-ocr "Extract all text" --images /tmp/capture.png
+```
+
+### Batch Processing
+
+```bash
+# Process all images in a directory
+for img in ~/Documents/scans/*.png; do
+  echo "=== $img ==="
+  ollama run glm-ocr "Extract all text" --images "$img"
+done > extracted_text.txt
+```
+
+### PDF to Text (via ImageMagick)
+
+```bash
+# Convert PDF pages to images, then OCR
+convert -density 300 document.pdf -quality 90 /tmp/page-%03d.png
+
+for page in /tmp/page-*.png; do
+  ollama run glm-ocr "Extract all text" --images "$page"
+done
+```
+
+### With Peekaboo (Screen Capture)
+
+```bash
+# Capture window and OCR in one command
+peekaboo image --mode window --app Preview --analyze "Extract all text from this document" --model ollama/glm-ocr
+```
+
+## Model Comparison
+
+| Model | Best For | Size | Speed | Local |
+|-------|----------|------|-------|-------|
+| **glm-ocr** | Document OCR, forms, tables | ~2GB | Fast | Yes |
+| llava | General vision, scene understanding | ~4GB | Medium | Yes |
+| GPT-4o | Complex reasoning + vision | Cloud | Fast | No |
+| Claude 4 | Nuanced text understanding | Cloud | Fast | No |
+
+**GLM-OCR advantages**:
+
+- Purpose-built for OCR (not general vision)
+- Handles complex document layouts
+- Works with tables, forms, multi-column text
+- Fully local - no data leaves your machine
+- No API costs
+
+**GLM-OCR limitations**:
+
+- Less capable at general image understanding
+- May struggle with very low quality images
+- No structured JSON output (use Unstract for that)
+
+## Integration with aidevops
+
+### With Unstract (Structured Extraction)
+
+For complex documents requiring structured JSON output:
+
+```bash
+# GLM-OCR: Quick text dump
+ollama run glm-ocr "Extract all text" --images invoice.png
+
+# Unstract: Structured extraction with schema
+# See services/document-processing/unstract.md
+```
+
+### With Peekaboo (GUI Automation)
+
+GLM-OCR is available as a Peekaboo vision provider:
+
+```bash
+# Screen capture + OCR
+peekaboo image --mode screen --analyze "What text is visible?" --model ollama/glm-ocr
+
+# Window capture + OCR
+peekaboo image --mode window --app "Preview" --analyze "Extract document text" --model ollama/glm-ocr
+```
+
+## Troubleshooting
+
+### Model Not Found
+
+```bash
+# Re-pull the model
+ollama pull glm-ocr
+
+# Check Ollama is running
+ollama list
+```
+
+### Slow Performance
+
+```bash
+# Check available memory (model needs ~4GB RAM)
+vm_stat | head -5
+
+# For large batches, process sequentially to avoid memory pressure
+```
+
+### Poor OCR Quality
+
+- Ensure image resolution is at least 150 DPI
+- For scanned documents, use 300 DPI
+- Crop to relevant area before OCR
+- Try different prompts (be specific about expected content)
+
+## Resources
+
+- **Ollama Model**: <https://ollama.com/library/glm-ocr>
+- **THUDM (creators)**: <https://github.com/THUDM>
+- **Peekaboo integration**: `tools/browser/peekaboo.md`
+- **Structured extraction**: `services/document-processing/unstract.md`


### PR DESCRIPTION
## Summary

- Add GLM-OCR as recommended model in Peekaboo docs for OCR tasks
- Create dedicated `tools/ocr/glm-ocr.md` subagent
- Update subagent-index.toon with new OCR subagent entry

## Changes

### Peekaboo docs (`tools/browser/peekaboo.md`)
- Added "Recommended Models by Task" table highlighting GLM-OCR for OCR tasks
- Updated Ollama section with GLM-OCR pull command and usage example
- Added cross-reference to new OCR subagent

### New OCR subagent (`tools/ocr/glm-ocr.md`)
- Installation and basic usage via Ollama
- Workflow patterns: screenshot OCR, batch processing, PDF conversion
- Model comparison table (glm-ocr vs llava vs cloud models)
- Integration guidance with Peekaboo and Unstract
- Troubleshooting section

### Subagent index
- Added `tools/ocr/` entry with GLM-OCR subagent

## Why GLM-OCR?

GLM-OCR is a purpose-built OCR model from THUDM (Tsinghua University) that:
- Runs fully local via Ollama (no API keys, no cloud)
- Is optimized for document understanding (tables, forms, complex layouts)
- Complements existing tools (Peekaboo for GUI, Unstract for structured extraction)

## Testing

```bash
ollama pull glm-ocr
ollama run glm-ocr "Extract all text" --images /path/to/document.png
```