### PR TITLE
fix: remove non-existent npm package breaking CI

### DIFF
--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -76,18 +76,6 @@
           }
         }
       ]
-    },
-    {
-      "id": "@secretlint/secretlint-rule-regexp",
-      "options": {
-        "patterns": [
-          {
-            "name": "api-key-field",
-            "pattern": "\"(?:api_key|apiKey|API_KEY)\"\\s*:\\s*\"[A-Za-z0-9_\\-]{16,}\"",
-            "message": "Detected a likely API key value in an api_key field."
-          }
-        ]
-      }
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "@secretlint/secretlint-rule-preset-recommend": "^11.2.5",
-    "@secretlint/secretlint-rule-regexp": "^11.2.5",
     "@types/bun": "latest",
     "secretlint": "^11.2.5",
     "typescript": "^5.0.0"


### PR DESCRIPTION
## Summary

Remove `@secretlint/secretlint-rule-regexp` - this package doesn't exist on npm.

## Root Cause

PR #291 (Feb 3) attempted to add custom regex detection for generic API keys (like Updown.io keys) that don't match specific provider patterns. The implementation:

1. Added `@secretlint/secretlint-rule-regexp` to `package.json`
2. Added a custom rule in `.secretlintrc.json` to catch patterns like `"api_key": "ro-abc123..."`

**The problem**: The package `@secretlint/secretlint-rule-regexp` doesn't exist on npm. It was likely assumed to exist based on the naming pattern of other secretlint rules (like `secretlint-rule-aws`, `secretlint-rule-github`, etc.).

## Impact

The "Update Website Docs" workflow has been failing on every push/release with:

```
error: GET https://registry.npmjs.org/@secretlint%2fsecretlint-rule-regexp - 404
```

This also causes "Postflight Verification" to fail (it checks all CI status).

## Fix

- Remove the non-existent package from `package.json`
- Remove the unused rule from `.secretlintrc.json`

## Future Consideration

If we want custom regex detection for generic API keys, we'd need to either:
1. Write a custom secretlint rule package
2. Use a different tool that supports custom regex patterns
3. Check if secretlint has added this capability in newer versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a pattern-matching secret linting rule from the configuration.
  * Removed the associated development dependency from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->