### PR TITLE
fix: osgrep installation and beads_viewer pipx handling

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -545,17 +545,25 @@ print(f"  Applied MCP loading policy: {len(EAGER_MCPS)} eager, {len(LAZY_MCPS)} 
 # -----------------------------------------------------------------------------
 
 # osgrep MCP - local semantic search (primary, try first)
-# Install: npm install -g osgrep && osgrep install-opencode
-if 'osgrep' not in config['mcp']:
-    config['mcp']['osgrep'] = {
-        "type": "local",
-        "command": ["osgrep", "mcp"],
-        "enabled": True
-    }
-    print("  Added osgrep MCP (eager load - used by all agents)")
-
-# osgrep_* enabled globally (used by all main agents)
-config['tools']['osgrep_*'] = True
+# Install: npm install -g osgrep && osgrep setup
+# Only enable if osgrep CLI is installed (avoids "Executable not found" errors)
+osgrep_installed = shutil.which('osgrep') is not None
+if osgrep_installed:
+    if 'osgrep' not in config['mcp']:
+        config['mcp']['osgrep'] = {
+            "type": "local",
+            "command": ["osgrep", "mcp"],
+            "enabled": True
+        }
+        print("  Added osgrep MCP (eager load - used by all agents)")
+    # osgrep_* enabled globally (used by all main agents)
+    config['tools']['osgrep_*'] = True
+else:
+    # Disable osgrep if not installed to avoid MCP errors
+    if 'osgrep' in config['mcp']:
+        config['mcp']['osgrep']['enabled'] = False
+    config['tools']['osgrep_*'] = False
+    print("  osgrep not installed - MCP disabled (install: npm install -g osgrep && osgrep setup)")
 
 # Playwriter MCP - browser automation via Chrome extension (used by all main agents)
 # Requires: Chrome extension from https://chromewebstore.google.com/detail/playwriter-mcp/jfeammnjpkecdekppnclgkkffahnhfhe


### PR DESCRIPTION
## Summary

Fixes two setup issues:

### 1. osgrep MCP shows "Executable not found" error

**Problem**: osgrep MCP was configured in opencode.json even when osgrep CLI wasn't installed, causing OpenCode to show error on startup.

**Fix**:
- `setup.sh`: Now offers to install osgrep CLI (`npm install -g osgrep`) and download models
- `generate-opencode-agents.sh`: Checks if osgrep is installed before enabling MCP
- If not installed, MCP is disabled to prevent errors

### 2. beads_viewer installation fails on macOS

**Problem**: `pip install --user beads-viewer` fails on macOS due to PEP 668 (externally-managed-environment).

**Fix**:
- Prefer pipx for isolated Python environments
- On macOS with Homebrew: offer to install pipx first
- Better error messages explaining the issue
- Only fall back to pip as last resort

## Testing

Run `aidevops update` and verify:
1. osgrep: Offers to install if not found, MCP disabled if declined
2. beads_viewer: Offers to install pipx first on macOS