### PR TITLE
fix: correct bv (beads_viewer) installation method

### DIFF
--- a/.agent/tools/task-management/beads.md
+++ b/.agent/tools/task-management/beads.md
@@ -144,7 +144,7 @@ When both TODO.md and Beads have changes:
 | Tool | Type | Features | Install |
 |------|------|----------|---------|
 | `bd` | CLI | Core commands, MCP server | `brew install steveyegge/beads/bd` |
-| `beads_viewer` | TUI | PageRank, critical path, graph analytics | `pip install beads-viewer` |
+| `bv` | TUI | PageRank, critical path, graph analytics | `brew install dicklesworthstone/tap/bv` |
 | `beads-ui` | Web | Live updates, browser-based | `npm install -g beads-ui` |
 | `bdui` | TUI | React/Ink interface | `npm install -g bdui` |
 | `perles` | TUI | BQL query language | `cargo install perles` |
@@ -156,8 +156,10 @@ When both TODO.md and Beads have changes:
 brew install steveyegge/beads/bd
 # Or: go install github.com/steveyegge/beads/cmd/bd@latest
 
-# Advanced TUI with graph analytics (Python)
-pip install beads-viewer
+# Advanced TUI with graph analytics (Go)
+brew tap dicklesworthstone/tap && brew install dicklesworthstone/tap/bv
+# Or: go install github.com/Dicklesworthstone/beads_viewer/cmd/bv@latest
+# Or: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash
 # Repository: https://github.com/Dicklesworthstone/beads_viewer
 
 # Web UI with live updates (Node.js)
@@ -182,10 +184,10 @@ bd list
 bd ready
 bd graph <issue-id>
 
-# beads_viewer - Advanced TUI
-beads-viewer              # Interactive mode
-beads-viewer --pagerank   # Show PageRank scores
-beads-viewer --critical   # Show critical path
+# bv - Advanced TUI (beads_viewer)
+bv                        # Interactive mode
+bv --robot-triage         # Agent mode: triage overview
+bv --robot-next           # Agent mode: next task to work on
 
 # beads-ui - Web interface
 beads-ui                  # Starts on http://localhost:3000

--- a/setup.sh
+++ b/setup.sh
@@ -2747,10 +2747,10 @@ setup_beads() {
 setup_beads_ui() {
     echo ""
     print_info "Beads UI tools provide enhanced visualization:"
-    echo "  • beads_viewer (Python) - PageRank, critical path, graph analytics"
-    echo "  • beads-ui (Node.js)    - Web dashboard with live updates"
-    echo "  • bdui (Node.js)        - React/Ink terminal UI"
-    echo "  • perles (Rust)         - BQL query language TUI"
+    echo "  • bv (Go)            - PageRank, critical path, graph analytics TUI"
+    echo "  • beads-ui (Node.js) - Web dashboard with live updates"
+    echo "  • bdui (Node.js)     - React/Ink terminal UI"
+    echo "  • perles (Rust)      - BQL query language TUI"
     echo ""
     
     read -r -p "Install optional Beads UI tools? [Y/n]: " install_beads_ui
@@ -2762,53 +2762,46 @@ setup_beads_ui() {
     
     local installed_count=0
     
-    # beads_viewer (Python) - use pipx for isolated install (recommended)
-    # pip install --user often fails on macOS due to PEP 668 (externally-managed-environment)
-    read -r -p "  Install beads_viewer (Python TUI with graph analytics)? [Y/n]: " install_viewer
+    # bv (beads_viewer) - Go TUI installed via Homebrew
+    # https://github.com/Dicklesworthstone/beads_viewer
+    read -r -p "  Install bv (TUI with PageRank, critical path, graph analytics)? [Y/n]: " install_viewer
     if [[ "$install_viewer" =~ ^[Yy]?$ ]]; then
-        if command -v pipx &> /dev/null; then
-            # pipx available - use it (best option)
-            if run_with_spinner "Installing beads_viewer via pipx" pipx install beads-viewer; then
-                print_info "Run: beads-viewer"
+        if command -v brew &> /dev/null; then
+            # Add the tap and install
+            if run_with_spinner "Installing bv via Homebrew" bash -c "brew tap dicklesworthstone/tap 2>/dev/null; brew install dicklesworthstone/tap/bv"; then
+                print_info "Run: bv (in a beads-enabled project)"
                 ((installed_count++))
             else
-                print_warning "pipx install failed - try manually: pipx install beads-viewer"
-            fi
-        elif command -v brew &> /dev/null; then
-            # macOS with Homebrew - offer to install pipx first
-            print_info "pipx recommended for Python CLI tools (isolated environments)"
-            read -r -p "  Install pipx first? [Y/n]: " install_pipx
-            if [[ "$install_pipx" =~ ^[Yy]?$ ]]; then
-                if run_with_spinner "Installing pipx" brew install pipx; then
-                    # Ensure pipx is in PATH
-                    pipx ensurepath > /dev/null 2>&1
-                    export PATH="$HOME/.local/bin:$PATH"
-                    if run_with_spinner "Installing beads_viewer via pipx" pipx install beads-viewer; then
-                        print_info "Run: beads-viewer"
-                        ((installed_count++))
-                    else
-                        print_warning "Installation failed - try manually: pipx install beads-viewer"
-                    fi
-                else
-                    print_warning "pipx installation failed"
-                fi
-            else
-                print_info "Skipped beads_viewer (requires pipx)"
-                print_info "Install later: brew install pipx && pipx install beads-viewer"
+                print_warning "Homebrew install failed - try manually:"
+                print_info "  brew tap dicklesworthstone/tap && brew install dicklesworthstone/tap/bv"
             fi
         else
-            # No pipx, no brew - try pip as last resort
-            print_warning "pipx not found - trying pip (may fail on macOS)"
-            if command -v pip3 &> /dev/null; then
-                if run_with_spinner "Installing beads_viewer" pip3 install --user beads-viewer; then
-                    print_info "Run: beads-viewer"
+            # No Homebrew - try install script or Go
+            print_warning "Homebrew not found"
+            if command -v go &> /dev/null; then
+                # Go available - use go install
+                if run_with_spinner "Installing bv via Go" go install github.com/Dicklesworthstone/beads_viewer/cmd/bv@latest; then
+                    print_info "Run: bv (in a beads-enabled project)"
                     ((installed_count++))
                 else
-                    print_warning "pip install failed - install pipx first"
-                    print_info "Linux: pip install pipx && pipx install beads-viewer"
+                    print_warning "Go install failed"
                 fi
             else
-                print_warning "Neither pipx nor pip3 found"
+                # Offer curl install script
+                read -r -p "  Install bv via install script? [Y/n]: " use_script
+                if [[ "$use_script" =~ ^[Yy]?$ ]]; then
+                    if run_with_spinner "Installing bv via script" bash -c 'curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh" | bash'; then
+                        print_info "Run: bv (in a beads-enabled project)"
+                        ((installed_count++))
+                    else
+                        print_warning "Install script failed - try manually:"
+                        print_info "  curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh | bash"
+                    fi
+                else
+                    print_info "Install later:"
+                    print_info "  Homebrew: brew tap dicklesworthstone/tap && brew install dicklesworthstone/tap/bv"
+                    print_info "  Go: go install github.com/Dicklesworthstone/beads_viewer/cmd/bv@latest"
+                fi
             fi
         fi
     fi

--- a/setup.sh
+++ b/setup.sh
@@ -2767,13 +2767,13 @@ setup_beads_ui() {
     read -r -p "  Install bv (TUI with PageRank, critical path, graph analytics)? [Y/n]: " install_viewer
     if [[ "$install_viewer" =~ ^[Yy]?$ ]]; then
         if command -v brew &> /dev/null; then
-            # Add the tap and install
-            if run_with_spinner "Installing bv via Homebrew" bash -c "brew tap dicklesworthstone/tap 2>/dev/null; brew install dicklesworthstone/tap/bv"; then
+            # brew install user/tap/formula auto-taps
+            if run_with_spinner "Installing bv via Homebrew" brew install dicklesworthstone/tap/bv; then
                 print_info "Run: bv (in a beads-enabled project)"
                 ((installed_count++))
             else
                 print_warning "Homebrew install failed - try manually:"
-                print_info "  brew tap dicklesworthstone/tap && brew install dicklesworthstone/tap/bv"
+                print_info "  brew install dicklesworthstone/tap/bv"
             fi
         else
             # No Homebrew - try install script or Go


### PR DESCRIPTION
## Summary

- Fix `bv` (beads_viewer) installation in setup.sh - was trying to install non-existent `beads-viewer` pip package
- `bv` is a Go tool installed via Homebrew, not a Python package
- Add fallbacks: Go install, curl script for systems without Homebrew
- Update beads.md documentation with correct install commands and usage

## Changes

| File | Change |
|------|--------|
| `setup.sh` | Replace pipx/pip install with Homebrew tap, Go, curl fallbacks |
| `.agent/tools/task-management/beads.md` | Update viewer table and install instructions |

## Testing

- [ ] ShellCheck passes on modified lines
- [ ] `brew tap dicklesworthstone/tap && brew install dicklesworthstone/tap/bv` works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Beads viewer tool renamed to bv with updated installation instructions and command examples.

* **Chores**
  * Simplified Beads UI installation flow to use Homebrew as the primary method with fallback options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->