### PR TITLE
refactor: disable gh_grep MCP globally (lazy load only)

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -585,20 +585,21 @@ if 'playwriter' not in config['mcp']:
 # playwriter_* enabled globally (used by all main agents)
 config['tools']['playwriter_*'] = True
 
-# gh_grep MCP - GitHub code search (used by Build+)
+# gh_grep MCP - GitHub code search (lazy load - @github-search subagent only)
 # This is a remote MCP, no local process to start
+# Disabled globally to save ~600 tokens, enabled when @github-search is called
 if 'gh_grep' not in config['mcp']:
     config['mcp']['gh_grep'] = {
         "type": "remote",
         "url": "https://mcp.grep.app",
-        "enabled": True
+        "enabled": False
     }
-    print("  Added gh_grep MCP (eager load - used by Build+)")
+    print("  Added gh_grep MCP (lazy load - @github-search subagent only)")
 
-# gh_grep tools disabled globally, enabled for specific agents
+# gh_grep tools disabled globally, enabled via @github-search subagent
 if 'gh_grep_*' not in config['tools']:
     config['tools']['gh_grep_*'] = False
-    print("  Set gh_grep_* disabled globally (enabled for Build+)")
+    print("  Set gh_grep_* disabled globally (@github-search enables on-demand)")
 
 # -----------------------------------------------------------------------------
 # LAZY-LOADED MCPs (enabled: False) - Subagent-only, start on-demand

--- a/.agent/tools/build-mcp/aidevops-plugin.md
+++ b/.agent/tools/build-mcp/aidevops-plugin.md
@@ -409,7 +409,7 @@ async setup(input: PluginInput) {
   
   if (omoLoaded && config.omoCompatibility) {
     // Disable MCPs that OmO provides
-    config.disabledMcps.push('context7', 'websearch_exa', 'grep_app');
+    config.disabledMcps.push('context7', 'websearch_exa', 'gh_grep');
     
     // Prefix agent names to avoid conflicts
     // (though current agents don't conflict)


### PR DESCRIPTION
## Summary

- Change `gh_grep` MCP from eager to lazy load (`enabled: false`)
- Saves ~600 tokens per session when not using GitHub code search
- The `@github-search` subagent uses CLI tools (rg, gh) instead - zero MCP overhead
- Fix `grep_app` -> `gh_grep` naming in aidevops-plugin.md for consistency

## Context

User noticed `grep_app` showing as Connected in MCP list alongside `osgrep`. These are different tools:

| Tool | Type | Purpose |
|------|------|---------|
| `osgrep` | Local CLI | Semantic search of local codebase (private, offline) |
| `gh_grep` | Remote MCP | Search public GitHub repos via grep.app |

Since `@github-search` subagent provides equivalent functionality without MCP overhead, `gh_grep` should be disabled by default.