### PR TITLE
refactor: remove gh_grep MCP entirely

### DIFF
--- a/.agent/scripts/generate-opencode-agents.sh
+++ b/.agent/scripts/generate-opencode-agents.sh
@@ -522,8 +522,9 @@ EAGER_MCPS = {'osgrep'}
 LAZY_MCPS = {'claude-code-mcp', 'outscraper', 'dataforseo', 'shadcn', 'macos-automator', 
              'gsc', 'localwp', 'chrome-devtools', 'quickfile', 'amazon-order-history', 
              'google-analytics-mcp', 'MCP_DOCKER', 'ahrefs',
-             'playwriter', 'augment-context-engine', 'gh_grep', 'context7',
+             'playwriter', 'augment-context-engine', 'context7',
              'sentry', 'socket'}
+# Note: gh_grep removed entirely - @github-search subagent uses CLI tools instead
 
 # Apply loading policy to existing MCPs and warn about uncategorized ones
 uncategorized = []
@@ -585,21 +586,9 @@ if 'playwriter' not in config['mcp']:
 # playwriter_* enabled globally (used by all main agents)
 config['tools']['playwriter_*'] = True
 
-# gh_grep MCP - GitHub code search (lazy load - @github-search subagent only)
-# This is a remote MCP, no local process to start
-# Disabled globally to save ~600 tokens, enabled when @github-search is called
-if 'gh_grep' not in config['mcp']:
-    config['mcp']['gh_grep'] = {
-        "type": "remote",
-        "url": "https://mcp.grep.app",
-        "enabled": False
-    }
-    print("  Added gh_grep MCP (lazy load - @github-search subagent only)")
-
-# gh_grep tools disabled globally, enabled via @github-search subagent
-if 'gh_grep_*' not in config['tools']:
-    config['tools']['gh_grep_*'] = False
-    print("  Set gh_grep_* disabled globally (@github-search enables on-demand)")
+# gh_grep MCP removed - @github-search subagent uses CLI tools (rg, gh) instead
+# This saves ~600 tokens per session with equivalent functionality
+# See: tools/context/github-search.md
 
 # -----------------------------------------------------------------------------
 # LAZY-LOADED MCPs (enabled: False) - Subagent-only, start on-demand

--- a/.agent/scripts/setup-mcp-integrations.sh
+++ b/.agent/scripts/setup-mcp-integrations.sh
@@ -35,7 +35,8 @@ get_mcp_command() {
         "nextjs-devtools") echo "npx next-devtools-mcp@latest" ;;
         "google-search-console") echo "npx mcp-server-gsc@latest" ;;
         "pagespeed-insights") echo "npx mcp-pagespeed-server@latest" ;;
-        "grep-vercel") echo "remote:https://mcp.grep.app" ;;
+        # grep-vercel - REMOVED: Use @github-search subagent (CLI-based, zero tokens)
+        "grep-vercel") echo "" ;;
         "claude-code-mcp") echo "npx -y github:marcusquinn/claude-code-mcp" ;;
         "stagehand") echo "node ${HOME}/.aidevops/stagehand/examples/basic-example.js" ;;
         "stagehand-python") echo "${HOME}/.aidevops/stagehand-python/.venv/bin/python ${HOME}/.aidevops/stagehand-python/examples/basic_example.py" ;;
@@ -175,18 +176,12 @@ install_mcp() {
             print_info "Use: ./.agent/scripts/pagespeed-helper.sh for CLI access"
             ;;
         "grep-vercel")
-            print_info "Setting up Grep by Vercel MCP for GitHub code search..."
-            print_info "This is a remote MCP server - no local installation required"
-            print_info "URL: https://mcp.grep.app"
-            
-            # Add to Claude MCP if available
-            if command -v claude &> /dev/null; then
-                claude mcp add gh_grep --url "https://mcp.grep.app"
-            fi
-            
-            print_success "Grep by Vercel MCP setup complete!"
-            print_info "Use 'gh_grep' tool in prompts to search GitHub code"
-            print_info "Example: 'use gh_grep to find examples of SST Astro components'"
+            print_info "Grep by Vercel MCP (grep.app) is no longer installed by aidevops"
+            print_info "Use @github-search subagent instead (CLI-based, zero token overhead)"
+            print_info "If you have Oh-My-OpenCode, it provides grep_app MCP"
+            print_info ""
+            print_info "Usage: @github-search 'search pattern'"
+            print_info "Or directly: gh search code 'pattern' --language typescript"
             ;;
         "claude-code-mcp")
             print_info "Setting up Claude Code MCP (forked) for Claude Code automation..."

--- a/.agent/tools/build-mcp/aidevops-plugin.md
+++ b/.agent/tools/build-mcp/aidevops-plugin.md
@@ -408,11 +408,13 @@ async setup(input: PluginInput) {
   const omoLoaded = input.plugins?.includes('oh-my-opencode');
   
   if (omoLoaded && config.omoCompatibility) {
-    // Disable MCPs that OmO provides
-    config.disabledMcps.push('context7', 'websearch_exa', 'gh_grep');
+    // Disable MCPs that OmO provides (websearch_exa, context7, grep_app)
+    // aidevops doesn't add these - OmO handles them
+    // We just need to avoid conflicts with agent names
+    config.disabledMcps.push('context7', 'websearch_exa');
     
-    // Prefix agent names to avoid conflicts
-    // (though current agents don't conflict)
+    // Note: OmO provides grep_app for GitHub search
+    // aidevops uses @github-search subagent (CLI-based, zero token overhead)
   }
   
   // Continue with setup...

--- a/.agent/tools/context/github-search.md
+++ b/.agent/tools/context/github-search.md
@@ -148,14 +148,16 @@ rg '"scripts"' package.json -A 10
 
 5. **Look at tests**: Test files often show correct usage patterns.
 
-## Comparison with gh_grep MCP
+## Comparison with GitHub Search MCPs
 
-| Feature | github-search (this) | gh_grep MCP |
-|---------|---------------------|-------------|
+| Feature | github-search (this) | grep_app / gh_grep MCP |
+|---------|---------------------|------------------------|
 | Token cost | 0 (no MCP) | ~600 tokens |
 | Speed | Fast (local rg) | Network dependent |
 | Scope | Local + gh CLI | GitHub API |
 | Regex | Full ripgrep | Limited |
 | Offline | Partial (local) | No |
 
-This subagent provides the same functionality as `gh_grep` MCP without the token overhead.
+This subagent provides the same functionality as `grep_app` (Oh-My-OpenCode) or `gh_grep` MCPs without the token overhead.
+
+**Note**: aidevops does not install GitHub search MCPs. If you have Oh-My-OpenCode installed, it provides `grep_app`. Use this `@github-search` subagent instead for zero-overhead GitHub code search.

--- a/.agent/tools/context/mcp-discovery.md
+++ b/.agent/tools/context/mcp-discovery.md
@@ -52,9 +52,13 @@ mcp-index-helper.sh status
 |-----|--------|----------|----------------|
 | `playwriter` | ~3K | `@playwriter` | Browser automation needed |
 | `augment-context-engine` | ~1K | `@augment-context-engine` | osgrep insufficient |
-| `gh_grep` | ~600 | `@github-search` | (uses rg/bash instead) |
 | `google-analytics-mcp` | ~800 | `@google-analytics` | Analytics reporting |
 | `context7` | ~800 | `@context7` | Library docs lookup |
+
+**Not installed by aidevops** (use subagent instead):
+| MCP | Subagent | Notes |
+|-----|----------|-------|
+| `grep_app` / `gh_grep` | `@github-search` | CLI-based, zero tokens |
 
 **Always enabled**: `osgrep` (primary semantic search, local, no auth)
 

--- a/.agent/tools/opencode/opencode.md
+++ b/.agent/tools/opencode/opencode.md
@@ -152,7 +152,7 @@ Specialized agents invoked with `@agent-name`. MCPs are enabled only for relevan
 | `code-quality` | Quality scanning + learning loop | context7 |
 | `browser-automation` | Testing, scraping | chrome-devtools, context7 |
 | `context7-mcp-setup` | Documentation | context7 |
-| `git-platforms` | GitHub, GitLab, Gitea | gh_grep, context7 |
+| `git-platforms` | GitHub, GitLab, Gitea | context7 |
 | `crawl4ai-usage` | Web crawling | context7 |
 | `dns-providers` | DNS management | hostinger-api (DNS) |
 | `agent-review` | Session analysis, improvements | (read/write only) |


### PR DESCRIPTION
## Summary

Remove `gh_grep` MCP from aidevops - it's redundant:

1. **Oh-My-OpenCode provides `grep_app`** - same MCP, different name
2. **`@github-search` subagent** uses CLI tools (rg, gh) with zero token overhead

## Changes

- Remove gh_grep MCP from generate-opencode-agents.sh
- Update setup-mcp-integrations.sh to point to @github-search subagent
- Update documentation (github-search.md, mcp-discovery.md, opencode.md, aidevops-plugin.md)

## Token Savings

~600 tokens per session when not using GitHub code search (which is most sessions).

## For Users

- **With Oh-My-OpenCode**: You already have `grep_app` MCP
- **Without OmO**: Use `@github-search` subagent (CLI-based, works offline for local repos)