### PR TITLE
fix: add grep_app and websearch to disable_ondemand_mcps

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -375,12 +375,16 @@ disable_ondemand_mcps() {
     
     # MCPs to disable globally (enabled on-demand via subagents)
     # Note: use exact MCP key names from opencode.json
+    # Includes Oh-My-OpenCode MCPs (grep_app, websearch) that we replace with subagents
     local -a ondemand_mcps=(
         "playwriter"
         "augment-context-engine"
         "gh_grep"
         "google-analytics-mcp"
         "context7"
+        # Oh-My-OpenCode MCPs - use @github-search subagent instead
+        "grep_app"
+        "websearch"
     )
     
     local disabled=0
@@ -3590,8 +3594,8 @@ main() {
     confirm_step "Setup AI orchestration frameworks info" && setup_ai_orchestration
     confirm_step "Setup OpenCode plugins" && setup_opencode_plugins
     confirm_step "Setup Oh-My-OpenCode" && setup_oh_my_opencode
-    # Run AFTER all MCP setup functions to ensure disabled state persists
-    confirm_step "Disable on-demand MCPs globally (playwriter, augment, gh_grep)" && disable_ondemand_mcps
+    # Run AFTER all MCP setup functions (including OmO) to ensure disabled state persists
+    confirm_step "Disable on-demand MCPs globally (incl. OmO: grep_app, websearch)" && disable_ondemand_mcps
 
     echo ""
     print_success "🎉 Setup complete!"


### PR DESCRIPTION
## Problem

Oh-My-OpenCode MCPs (`grep_app`, `websearch`) still showing as 'Connected' after update.

## Root Cause

The previous fixes added these MCPs to `generate-opencode-agents.sh`, but that script runs BEFORE Oh-My-OpenCode setup. OmO adds its MCPs when configured.

The `disable_ondemand_mcps()` function in `setup.sh` runs AFTER OmO setup and is the correct place to disable these MCPs.

## Fix

Add `grep_app` and `websearch` to the `ondemand_mcps` array in `disable_ondemand_mcps()`.

## Execution Order

1. `generate-opencode-agents.sh` - configures agents
2. `setup_oh_my_opencode()` - OmO adds its MCPs
3. `disable_ondemand_mcps()` - disables MCPs including OmO's ← **this is where the fix is**