### PR TITLE
fix: resolve ShellCheck violations blocking release

### DIFF
--- a/.agent/scripts/clawdhub-helper.sh
+++ b/.agent/scripts/clawdhub-helper.sh
@@ -287,9 +287,9 @@ PLAYWRIGHT_SCRIPT
 
     # Install playwright and run the fetch script
     log_info "Installing Playwright (temporary)..."
-    if (cd "$pw_dir" && npm install --silent 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null); then || exit
+    if (cd "$pw_dir" && npm install --silent 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null); then
         log_info "Running browser extraction..."
-        if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file" 2>/dev/null); then || exit
+        if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file" 2>/dev/null); then
             rm -rf "$pw_dir"
             if [[ -f "$output_file" && -s "$output_file" ]]; then
                 log_success "Extracted SKILL.md ($(wc -c < "$output_file" | tr -d ' ') bytes)"
@@ -304,7 +304,7 @@ PLAYWRIGHT_SCRIPT
     # Fallback: try clawdhub CLI
     if command -v npx &>/dev/null; then
         log_info "Trying: npx clawdhub install $slug"
-        if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force 2>/dev/null); then || exit
+        if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force 2>/dev/null); then
             # clawdhub installs to ./skills/<slug>/SKILL.md
             local installed_skill
             installed_skill=$(find "$output_dir" -name "SKILL.md" -type f 2>/dev/null | head -1)

--- a/.agent/scripts/self-improve-helper.sh
+++ b/.agent/scripts/self-improve-helper.sh
@@ -23,7 +23,8 @@
 set -euo pipefail
 
 # Configuration
-readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+readonly SCRIPT_DIR
 readonly AIDEVOPS_DIR="${HOME}/.aidevops"
 readonly WORKSPACE_DIR="${AIDEVOPS_DIR}/.agent-workspace"
 readonly IMPROVE_DIR="${WORKSPACE_DIR}/self-improve"
@@ -42,7 +43,6 @@ readonly BLUE='\033[0;34m'
 readonly YELLOW='\033[1;33m'
 readonly RED='\033[0;31m'
 readonly PURPLE='\033[0;35m'
-readonly CYAN='\033[0;36m'
 readonly NC='\033[0m' # No Color
 
 # Print functions


### PR DESCRIPTION
## Summary

- Fix syntax errors in `clawdhub-helper.sh` (invalid `; then || exit` pattern)
- Fix SC2155 in `self-improve-helper.sh` (declare and assign separately)
- Remove unused CYAN variable (SC2034)

These fixes unblock the v2.100.15 release which was failing preflight checks.