### PR TITLE
fix: revert qlty auto-fix that broke shell syntax

### DIFF
--- a/.agent/scripts/clawdhub-helper.sh
+++ b/.agent/scripts/clawdhub-helper.sh
@@ -287,9 +287,9 @@ PLAYWRIGHT_SCRIPT
 
     # Install playwright and run the fetch script
     log_info "Installing Playwright (temporary)..."
-    if (cd "$pw_dir" && npm install --silent 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null); then || exit
+    if (cd "$pw_dir" && npm install --silent 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null); then
         log_info "Running browser extraction..."
-        if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file" 2>/dev/null); then || exit
+        if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file" 2>/dev/null); then
             rm -rf "$pw_dir"
             if [[ -f "$output_file" && -s "$output_file" ]]; then
                 log_success "Extracted SKILL.md ($(wc -c < "$output_file" | tr -d ' ') bytes)"
@@ -304,7 +304,7 @@ PLAYWRIGHT_SCRIPT
     # Fallback: try clawdhub CLI
     if command -v npx &>/dev/null; then
         log_info "Trying: npx clawdhub install $slug"
-        if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force 2>/dev/null); then || exit
+        if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force 2>/dev/null); then
             # clawdhub installs to ./skills/<slug>/SKILL.md
             local installed_skill
             installed_skill=$(find "$output_dir" -name "SKILL.md" -type f 2>/dev/null | head -1)

--- a/.github/workflows/code-review-monitoring.yml
+++ b/.github/workflows/code-review-monitoring.yml
@@ -80,12 +80,11 @@ jobs:
     
     - name: 🔧 Apply Auto-Fixes
       run: |
-        # Run Qlty auto-formatting
-        if command -v qlty &> /dev/null; then
-          qlty fmt --all || echo "Qlty formatting completed with warnings"
-        fi
+        # NOTE: Qlty fmt disabled - it introduces invalid shell syntax
+        # (adds "|| exit" after "then" in if statements)
+        # See: https://github.com/marcusquinn/aidevops/issues/333
         
-        # Apply framework-specific fixes
+        # Apply framework-specific fixes only
         ./.agent/scripts/monitor-code-review.sh fix
     
     - name: 📊 Generate Quality Report


### PR DESCRIPTION
## Summary

- Remove invalid `; then || exit` syntax from clawdhub-helper.sh (lines 290, 292, 307)
- Disable `qlty fmt` in code-review-monitoring workflow

## Root Cause

The `qlty fmt --all` command in the GitHub Action was adding `|| exit` after `then` in if statements, which is invalid bash syntax:

```bash
# Invalid (what qlty produces)
if (cd "$dir" && command); then || exit

# Valid
if (cd "$dir" && command); then
```

This caused PR #331's fix to be immediately reverted by the auto-fix action.

## Fix

1. Manually fix the syntax errors (again)
2. Disable `qlty fmt` in the workflow to prevent recurrence

Unblocks v2.100.15 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling resilience in extraction processes by allowing fallback mechanisms to execute instead of terminating on failure.

* **Chores**
  * Temporarily disabled automatic code formatting due to a syntax issue; framework-specific fixes remain active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->