### PR TITLE
fix: enforce README gate as mandatory step in loop workflows

### DIFF
--- a/.agent/scripts/commands/full-loop.md
+++ b/.agent/scripts/commands/full-loop.md
@@ -141,19 +141,34 @@ The AI will iterate on the task until outputting:
 <promise>TASK_COMPLETE</promise>
 ```
 
-**Completion criteria:**
-- All requirements implemented
-- Tests passing (if applicable)
-- Code quality acceptable
-- README.md updated (if adding features/APIs) - use `/readme --sections` for targeted updates
-- Conventional commits used (for auto-changelog)
+**Completion criteria (ALL must be satisfied before emitting TASK_COMPLETE):**
 
-**README check (aidevops repo only):**
+1. All requirements implemented
+2. Tests passing (if applicable)
+3. Code quality acceptable
+4. **README gate passed** (see below)
+5. Conventional commits used (for auto-changelog)
+
+**README gate (MANDATORY - do NOT skip):**
+
+Before emitting `TASK_COMPLETE`, answer this decision tree:
+
+1. Did this task add a new feature, tool, API, command, or config option? → **Update README.md**
+2. Did this task change existing user-facing behavior? → **Update README.md**
+3. Is this a pure refactor, bugfix with no behavior change, or internal-only change? → **SKIP**
+
+If README update is needed:
 
 ```bash
-# Check if README counts are stale after adding agents/scripts
+# For any repo: use targeted section updates
+/readme --sections "usage"  # or relevant section
+
+# For aidevops repo: also check if counts are stale
 ~/.aidevops/agents/scripts/readme-helper.sh check
+# If stale, run: readme-helper.sh update --apply
 ```
+
+**Do NOT emit TASK_COMPLETE until README is current.** This is a gate, not a suggestion. The t099 Neural-Chromium task was merged without a README update because this gate was advisory - it is now mandatory.
 
 ### Step 4: Automatic Phase Progression
 
@@ -258,13 +273,9 @@ Pass options after the prompt:
 
 ### README Updates
 
-When implementing features or APIs, include README updates in your task:
+README updates are enforced by the **README gate** in Step 3 completion criteria. You do NOT need to include "and update README" in your prompt - the gate catches it automatically.
 
-```bash
-/full-loop "Add user authentication with JWT tokens and update README"
-```
-
-The task development phase should update README.md with:
+When the gate triggers, update README.md with:
 - New feature documentation
 - Usage examples
 - API endpoint descriptions

--- a/.agent/scripts/full-loop-helper.sh
+++ b/.agent/scripts/full-loop-helper.sh
@@ -632,6 +632,11 @@ cmd_resume() {
                 print_info "Task loop still active. Complete it first."
                 return 0
             fi
+            # README gate reminder before preflight transition
+            print_warning "README GATE: Did this task add/change user-facing features?"
+            print_info "If yes, ensure README.md is updated before proceeding."
+            print_info "For aidevops repo:"
+            print_info "  Run: readme-helper.sh check"
             save_state "$PHASE_PREFLIGHT" "$SAVED_PROMPT" "" "$STARTED_AT"
             run_preflight_phase
             save_state "$PHASE_PR_CREATE" "$SAVED_PROMPT" "" "$STARTED_AT"

--- a/.agent/workflows/ralph-loop.md
+++ b/.agent/workflows/ralph-loop.md
@@ -250,9 +250,13 @@ Implement feature X following TDD:
 7. Output: <promise>COMPLETE</promise>
 ```
 
-### 4. Documentation Updates
+### 4. Documentation Updates (MANDATORY gate)
 
-Include documentation requirements in your completion criteria:
+**Before emitting COMPLETE**, check the README gate (enforced in full-loop Step 3):
+
+1. Did this task add a new feature, tool, API, command, or config option? → **Update README.md**
+2. Did this task change existing user-facing behavior? → **Update README.md**
+3. Pure refactor, bugfix with no behavior change, or internal-only? → **SKIP**
 
 **README updates** - When adding features, APIs, or changing behavior:
 
@@ -261,7 +265,8 @@ Implement feature X.
 
 When complete:
 - Feature working with tests
-- README.md updated with usage examples
+- README.md updated with usage examples (MANDATORY if user-facing)
+- For aidevops: readme-helper.sh check passes
 - Output: <promise>COMPLETE</promise>
 ```
 
@@ -651,7 +656,13 @@ The loop is designed for maximum AI autonomy while preserving human control at s
 
 ### Documentation in Loops
 
-**README updates**: Include in task development phase when adding features/APIs.
+**README gate (MANDATORY)**: Before declaring task complete, the AI MUST check:
+
+1. Did this task add/change user-facing features, tools, APIs, or commands?
+2. If YES → Update README.md before proceeding (use `/readme --sections` for targeted updates)
+3. For aidevops repo → Also run `readme-helper.sh check` for stale counts
+
+This is a gate between task development and preflight, not a suggestion. See `scripts/commands/full-loop.md` Step 3 completion criteria.
 
 **Changelog**: Auto-generated from conventional commits during release. Use proper prefixes:
 - `feat:` → Added section


### PR DESCRIPTION
## Summary

- Upgrade README update check from advisory bullet to mandatory gate in full-loop and ralph-loop workflows
- Add shell script safety net (print_warning) at task-to-preflight transition

## Problem

During the t099 full-loop (Neural-Chromium), the README was not updated despite adding a new browser tool. The README check existed as advisory text in a bullet list of completion criteria, which the AI agent skipped because it wasn't positioned as a gate in the phase progression.

## Changes

| File | Change |
|------|--------|
| `full-loop.md` | Replace advisory bullet with numbered mandatory gate including decision tree, directly in Step 3 completion criteria |
| `full-loop.md` | Update Documentation section to reference the gate instead of suggesting users add "and update README" to prompts |
| `ralph-loop.md` | Upgrade "Documentation Updates" heading to MANDATORY gate with decision tree and cross-reference |
| `ralph-loop.md` | Upgrade "Documentation in Loops" from advisory to mandatory checklist |
| `full-loop-helper.sh` | Add `print_warning` README gate reminder at task-to-preflight transition |

## How it prevents the t099 scenario

The AI would now hit the mandatory gate before emitting `TASK_COMPLETE`:
1. "Did this task add a new feature, tool, API, command, or config option?" -> YES (new browser subagent)
2. -> Update README.md's Browser Automation section
3. -> Run `readme-helper.sh check` (aidevops repo)
4. -> Only then proceed to preflight

The shell script also prints a warning when transitioning phases, providing a second safety net.