### PR TITLE
fix: add main-branch write restrictions for subagents

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -34,6 +34,8 @@ Exit 0 = proceed. Exit 1 = STOP (on main). Exit 2 = create worktree. Exit 3 = wa
 
 **Self-verification**: Your FIRST step before any Edit/Write MUST be to run this script. If you are about to edit a file and have not yet run pre-edit-check.sh in this session, STOP and run it now. No exceptions — including TODO.md and planning files (the script handles exception logic, not you).
 
+**Subagent write restrictions**: Subagents invoked via the Task tool cannot run `pre-edit-check.sh` (many lack `bash: true`). When on `main`/`master`, subagents with `write: true` may ONLY write to: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. All other writes must be returned as proposed edits for the calling agent to apply in a worktree.
+
 ---
 
 ## MANDATORY: File Discovery

--- a/.agent/tools/build-agent/agent-review.md
+++ b/.agent/tools/build-agent/agent-review.md
@@ -37,6 +37,12 @@ tools:
 
 **Process**: Complete task first, cite evidence, check duplicates, propose specific fix, ask permission
 
+**Write Restrictions (MANDATORY)**: This subagent has `write: true` but MUST respect branch protection. When the working directory is on `main`/`master`:
+
+- **ALLOWED writes**: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`
+- **BLOCKED writes**: All other files (agent definitions, scripts, configs, code)
+- **For code changes**: Return proposed edits to the calling agent; do NOT write directly. The calling agent will apply them in a worktree.
+
 **Testing**: Use OpenCode CLI to test agent/config changes without restarting TUI:
 
 ```bash

--- a/.agent/tools/build-agent/build-agent.md
+++ b/.agent/tools/build-agent/build-agent.md
@@ -241,10 +241,19 @@ tools:
 
 **Note on permissions**: Path-based permissions (e.g., restricting which files can be edited) are configured in `opencode.json` for OpenCode, not in markdown frontmatter. The frontmatter defines which tools are available; the JSON config defines granular restrictions.
 
+**Main-branch write restrictions**: Subagents with `write: true` / `edit: true` that are invoked via the Task tool MUST respect the same branch protection as the primary agent. When the working directory is on `main`/`master`:
+
+- **ALLOWED**: `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*` (planning and documentation files)
+- **BLOCKED**: All other files (code, scripts, configs, agent definitions)
+- **WORKTREE**: If a worktree is active, writes to the worktree path are unrestricted
+
+Subagents cannot run `pre-edit-check.sh` (many lack `bash: true`), so this rule must be stated explicitly in the subagent's markdown. Add a "Write Restrictions" section to any subagent that has `write: true` and may be invoked on the main repo path.
+
 **Why this matters:**
 - Prevents confusion when agents recommend actions they cannot perform
 - Makes agent capabilities explicit and predictable
 - Enables safer parallel execution (read-only agents can't conflict)
+- Prevents subagents from bypassing branch protection when invoked via Task tool
 - Documents intent for both humans and AI systems
 
 #### Agent Directory Architecture


### PR DESCRIPTION
## Summary

- Add main-branch write restriction rule for subagents with `write: true`
- Prevent subagents invoked via Task tool from bypassing branch protection

## Problem

During the t099 session, the `agent-review` subagent (invoked via Task tool) wrote directly to files in the main repo on the `main` branch. It has `write: true` / `edit: true` in its YAML frontmatter but no `bash: true`, so it cannot run `pre-edit-check.sh`. This bypassed branch protection.

## Rule

On `main`/`master`, subagents may ONLY write to:
- `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`

All other writes must be returned as proposed edits for the calling agent to apply in a worktree.

## Files Changed

| File | Change |
|------|--------|
| `.agent/tools/build-agent/build-agent.md` | Added main-branch write restriction rule to subagent design guidance |
| `.agent/tools/build-agent/agent-review.md` | Added Write Restrictions section (exemplar for other subagents) |
| `.agent/AGENTS.md` | Added universal subagent write restriction to pre-edit section |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added policies clarifying write restrictions for subagents invoked via the Task tool
  * Documented which files can be modified and when proposed edits are required instead of direct writes
  * Updated guidance on subagent capabilities and limitations when operating on primary branches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->