### PR TITLE
fix: resolve setup onboarding errors (macOS head -z, model selection, agent routing)

### DIFF
--- a/.agent/scripts/generate-opencode-commands.sh
+++ b/.agent/scripts/generate-opencode-commands.sh
@@ -1017,7 +1017,7 @@ echo -e "  ${GREEN}✓${NC} Created /webmaster-keywords command"
 cat > "$OPENCODE_COMMAND_DIR/onboarding.md" << 'EOF'
 ---
 description: Interactive onboarding wizard - discover services, configure integrations
-agent: Build+
+agent: Onboarding
 ---
 
 Read ~/.aidevops/agents/onboarding.md and follow its instructions.

--- a/templates/deploy-templates.sh
+++ b/templates/deploy-templates.sh
@@ -63,7 +63,7 @@ create_backup_with_rotation() {
     if (( backup_count > BACKUP_KEEP_COUNT )); then
         local to_delete=$((backup_count - BACKUP_KEEP_COUNT))
         # Delete oldest backups (sorted by name = sorted by date)
-        find "$backup_type_dir" -maxdepth 1 -type d -name "20*" -print0 2>/dev/null | sort -z | head -z -n "$to_delete" | xargs -0 rm -rf
+        find "$backup_type_dir" -maxdepth 1 -type d -name "20*" 2>/dev/null | sort | head -n "$to_delete" | while read -r old_backup; do rm -rf "$old_backup"; done
         print_info "Rotated backups: removed $to_delete old backup(s)"
     fi
 


### PR DESCRIPTION
## Summary

Fixes three issues encountered during the setup/onboarding process:

- **macOS `head -z` error**: `deploy-templates.sh` used GNU-only `head -z` flag for null-delimited input, which fails on macOS with `head: invalid option -- z`. Replaced with macOS-compatible `while read -r` loop, matching the pattern already used in `setup.sh`.

- **Wrong model for onboarding**: When setup.sh launches OpenCode with the Onboarding agent, it used whatever model OpenCode defaults to (e.g., `gpt-5.2-chat-latest` for OpenAI). If the user doesn't have OpenAI credits, this causes `insufficient_quota` errors. Now auto-detects the user's authenticated providers from `auth.json` and selects an appropriate model (Anthropic Claude > Google Gemini > fallback).

- **Wrong agent routing**: The `/onboarding` command was configured with `agent: Build+` but there's a dedicated `Onboarding` primary agent. Updated to route to the correct agent.

## Changes

| File | Change |
|------|--------|
| `templates/deploy-templates.sh` | Replace `head -z` with macOS-compatible `while read` loop |
| `setup.sh` | Auto-detect auth provider and pass `--model` flag when launching onboarding |
| `.agent/scripts/generate-opencode-commands.sh` | Change `/onboarding` command agent from `Build+` to `Onboarding` |