### PR TITLE
feat: add memory namespace support for per-runner isolation (t109.3)

### DIFF
--- a/.agent/memory/README.md
+++ b/.agent/memory/README.md
@@ -148,12 +148,43 @@ pattern-tracker-helper.sh stats
 
 See `scripts/pattern-tracker-helper.sh` for full documentation.
 
+## Namespaces (Per-Runner Memory Isolation)
+
+Runners can have isolated memory namespaces. Each namespace gets its own SQLite DB,
+preventing cross-contamination between parallel agents while allowing shared access
+to global memories when needed.
+
+```bash
+# Store in a runner-specific namespace
+memory-helper.sh --namespace code-reviewer store --content "Prefer explicit error handling"
+
+# Recall from namespace only
+memory-helper.sh --namespace code-reviewer recall "error handling"
+
+# Recall from namespace + global (shared access)
+memory-helper.sh --namespace code-reviewer recall "error handling" --shared
+
+# View namespace stats
+memory-helper.sh --namespace code-reviewer stats
+
+# List all namespaces
+memory-helper.sh namespaces
+```
+
+Namespace DBs are stored at `memory/namespaces/<name>/memory.db`. The global DB
+remains at `memory/memory.db` and is always accessible without `--namespace`.
+
 ## Storage Location
 
 ```text
 ~/.aidevops/.agent-workspace/memory/
-├── memory.db           # SQLite database with FTS5
+├── memory.db           # Global SQLite database with FTS5
 ├── embeddings.db       # Optional: vector embeddings for semantic search
+├── namespaces/         # Per-runner isolated memory
+│   ├── code-reviewer/
+│   │   └── memory.db
+│   └── seo-analyst/
+│       └── memory.db
 └── preferences/        # Optional: markdown preference files
 ```
 
@@ -190,6 +221,11 @@ memory-helper.sh prune             # Remove stale entries
 # Export
 memory-helper.sh export --format json   # Export as JSON
 memory-helper.sh export --format toon   # Export as TOON (token-efficient)
+
+# Namespaces (per-runner isolation)
+memory-helper.sh --namespace my-runner store --content "Runner-specific learning"
+memory-helper.sh --namespace my-runner recall "query" --shared  # Also search global
+memory-helper.sh namespaces            # List all namespaces
 ```
 
 ## Legacy: File-Based Preferences

--- a/.agent/scripts/runner-helper.sh
+++ b/.agent/scripts/runner-helper.sh
@@ -505,7 +505,7 @@ cmd_status() {
     # Check for memory namespace
     if [[ -x "$MEMORY_HELPER" ]]; then
         local mem_count
-        mem_count=$("$MEMORY_HELPER" stats --namespace "$name" 2>/dev/null | grep -c "Total" || echo "0")
+        mem_count=$("$MEMORY_HELPER" --namespace "$name" stats 2>/dev/null | grep -c "Total" || echo "0")
         if [[ "$mem_count" -gt 0 ]]; then
             echo "Memory entries: $mem_count"
         fi

--- a/README.md
+++ b/README.md
@@ -1810,9 +1810,14 @@ pattern-tracker-helper.sh suggest "refactor the auth middleware"
 # Maintenance
 ~/.aidevops/agents/scripts/memory-helper.sh validate   # Check for stale entries
 ~/.aidevops/agents/scripts/memory-helper.sh prune      # Remove stale memories
+
+# Namespaces (per-runner memory isolation)
+~/.aidevops/agents/scripts/memory-helper.sh --namespace my-runner store --content "Runner learning"
+~/.aidevops/agents/scripts/memory-helper.sh --namespace my-runner recall "query" --shared
+~/.aidevops/agents/scripts/memory-helper.sh namespaces  # List all namespaces
 ```
 
-**Storage:** `~/.aidevops/.agent-workspace/memory/memory.db` (+ optional `embeddings.db` for semantic search)
+**Storage:** `~/.aidevops/.agent-workspace/memory/memory.db` (+ optional `embeddings.db` for semantic search, `namespaces/` for per-runner isolation)
 
 See `.agent/memory/README.md` for complete documentation.
 


### PR DESCRIPTION
## Summary

- Add `--namespace` flag to `memory-helper.sh` enabling isolated memory databases per runner
- Add `--shared` flag on `recall` to search both namespace and global DB simultaneously
- Add `namespaces` command to list all configured memory namespaces with entry counts

## Changes

### memory-helper.sh
- Global `--namespace/-n` flag parsed before command dispatch
- `resolve_namespace()` validates name and sets `MEMORY_DIR`/`MEMORY_DB` to `memory/namespaces/<name>/memory.db`
- `--shared` flag on `recall` queries global DB in addition to namespace DB, merges results
- `cmd_namespaces()` lists all namespaces with entry counts (table and JSON formats)
- Stats and recall headers show active namespace context
- Help text updated with namespace documentation and examples

### runner-helper.sh
- Fix `cmd_status()` to pass `--namespace` before the command (was incorrectly after)

### Documentation
- `.agent/memory/README.md`: New "Namespaces" section with usage examples and updated storage layout
- `README.md`: Added namespace CLI examples to memory section

## Testing

All manually verified:
1. Store in namespace creates isolated DB at `memory/namespaces/<name>/memory.db`
2. Recall from namespace returns only namespace results
3. Recall with `--shared` returns namespace + global results
4. Stats shows namespace context in header
5. `namespaces` command lists all namespaces with counts
6. Invalid namespace names rejected with clear error
7. Global (no namespace) operations unchanged
8. ShellCheck: zero violations on both modified scripts

## Task

Closes t109.3 (Memory namespace integration) from t109 (Parallel Agents & Headless Dispatch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Memory namespace support enabling isolated memory storage per runner via --namespace flag
  * Shared memory recall to search both namespace-specific and global memory entries
  * New namespaces command to list all available memory namespaces with entry counts

* **Documentation**
  * Updated documentation to reflect memory namespace capabilities and usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->