### PR TITLE
fix: memory namespace maintenance - orphan cleanup, access tracking, migrate, embeddings (t109.3)

### DIFF
--- a/.agent/scripts/runner-helper.sh
+++ b/.agent/scripts/runner-helper.sh
@@ -759,6 +759,13 @@ cmd_destroy() {
     dir=$(runner_dir "$name")
     rm -rf "$dir"
 
+    # Clean up memory namespace if it exists
+    local ns_dir="$HOME/.aidevops/.agent-workspace/memory/namespaces/$name"
+    if [[ -d "$ns_dir" ]]; then
+        rm -rf "$ns_dir"
+        log_info "Removed memory namespace: $name"
+    fi
+
     log_success "Destroyed runner: $name"
     return 0
 }


### PR DESCRIPTION
## Summary

Follow-up to #351 addressing five hazards identified in the memory namespace implementation:

- **Runner destroy orphans namespace** - `runner-helper.sh destroy` now removes the memory namespace directory
- **No orphan cleanup** - `namespaces prune` removes namespaces with no matching runner
- **Shared recall staleness** - `--shared` recall now updates access tracking in the global DB
- **Embeddings not namespace-aware** - `memory-embeddings-helper.sh` supports `--namespace` flag
- **No migration path** - `namespaces migrate --from X --to Y` copies/moves entries between namespaces

## Changes

### memory-helper.sh (+230 lines)
- `cmd_namespaces_prune()` - removes orphaned namespaces (with `--dry-run`)
- `cmd_namespaces_migrate()` - copies/moves entries between namespaces using `ATTACH DATABASE`
- `--shared` recall now updates `learning_access` in global DB for returned results
- `--semantic` recall passes `--namespace` through to embeddings helper
- Help text updated with prune and migrate examples

### runner-helper.sh (+5 lines)
- `cmd_destroy()` removes `memory/namespaces/<name>/` after removing runner directory

### memory-embeddings-helper.sh (+40 lines)
- `--namespace/-n` flag parsed before command dispatch
- `resolve_embeddings_namespace()` sets correct DB paths per namespace
- Python script path stays in base dir (shared across namespaces)

## Testing (11/11 pass)

| # | Test | Result |
|---|------|--------|
| 1 | Setup runner + namespace | Pass |
| 2 | Create orphaned namespace | Pass |
| 3 | `namespaces prune --dry-run` | Pass - identifies orphan, keeps active |
| 4 | `namespaces prune` (actual) | Pass - removes orphan only |
| 5 | `--shared` updates global access | Pass - access_count incremented |
| 6 | `namespaces migrate --dry-run` | Pass |
| 7 | `namespaces migrate` (copy) | Pass - global +1, source unchanged |
| 8 | `namespaces migrate --move` | Pass - source cleared, target +1 |
| 9 | Runner destroy cleans namespace | Pass - directory removed |
| 10 | Embeddings namespace flag | Pass - resolves correct paths |
| 11 | Global recall unaffected | Pass |

ShellCheck: zero violations on all three files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added namespace support for memory embeddings to organize data by context using a new `--namespace` flag
  * Added `namespaces prune` command to remove orphaned namespaces
  * Added `namespaces migrate` command to move or copy memories between namespaces
  * Semantic search now respects active namespace context

* **Improvements**
  * Runner cleanup now properly removes associated memory namespace data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->