### PR TITLE
docs: runner templates and parallel vs sequential guide (t109.5)

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -203,6 +203,7 @@ See `subagent-index.toon` for complete listing of agents, subagents, workflows, 
 | WordPress | `tools/wordpress/wp-dev.md`, `tools/wordpress/mainwp.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |
 | Video | `tools/video/video-prompt-design.md`, `tools/video/remotion.md`, `tools/video/higgsfield.md` |
+| Parallel agents | `tools/ai-assistants/headless-dispatch.md`, `tools/ai-assistants/runners/` |
 | MCP dev | `tools/build-mcp/build-mcp.md` |
 | Agent design | `tools/build-agent/build-agent.md` |
 | Framework | `aidevops/architecture.md` |

--- a/.agent/tools/ai-assistants/runners/README.md
+++ b/.agent/tools/ai-assistants/runners/README.md
@@ -1,0 +1,45 @@
+---
+description: Example runner templates for parallel agent dispatch
+mode: reference
+---
+
+# Runner Templates
+
+Ready-to-use AGENTS.md templates for common runner types. Copy and customize for your needs.
+
+## Available Templates
+
+| Template | Use Case |
+|----------|----------|
+| [code-reviewer.md](code-reviewer.md) | Security and quality code review |
+| [seo-analyst.md](seo-analyst.md) | SEO analysis and recommendations |
+
+## Creating a Runner from a Template
+
+```bash
+# 1. Create the runner
+runner-helper.sh create my-runner --description "What it does"
+
+# 2. Open the AGENTS.md for editing
+runner-helper.sh edit my-runner
+
+# 3. Paste the template content from the files above
+
+# 4. Test it
+runner-helper.sh run my-runner "Your first task"
+```
+
+## Writing Your Own Runner Template
+
+A good runner AGENTS.md has four sections:
+
+1. **Identity** - One sentence: who is this agent and what does it do
+2. **Checklist** - Specific items to check/do (not vague guidance)
+3. **Output format** - Exact structure of the response (tables, sections)
+4. **Rules** - Hard constraints (what to never do, when to escalate)
+
+Keep it under 500 words. Runners get the full prompt on every dispatch, so brevity matters.
+
+## Parallel vs Sequential
+
+See the [decision guide](../headless-dispatch.md#parallel-vs-sequential) in headless-dispatch.md.

--- a/.agent/tools/ai-assistants/runners/code-reviewer.md
+++ b/.agent/tools/ai-assistants/runners/code-reviewer.md
@@ -1,0 +1,91 @@
+---
+description: Example runner template - security and quality code reviewer
+mode: reference
+---
+
+# Code Reviewer
+
+Example AGENTS.md for a code review runner. Copy to create your own:
+
+```bash
+runner-helper.sh create code-reviewer \
+  --description "Reviews code for security, quality, and maintainability"
+# Then paste the content below into the runner's AGENTS.md:
+runner-helper.sh edit code-reviewer
+```
+
+## Template
+
+```markdown
+# Code Reviewer
+
+You are a senior code reviewer focused on security, quality, and maintainability.
+You receive file paths or diffs and produce structured review output.
+
+## Review Checklist
+
+### Security
+- SQL injection (raw queries, string concatenation)
+- XSS (innerHTML, dangerouslySetInnerHTML, unescaped output)
+- Auth bypass (missing middleware, broken access control)
+- Secrets in code (API keys, passwords, tokens)
+- Path traversal (unsanitized file paths)
+- Dependency vulnerabilities (known CVEs)
+
+### Quality
+- Error handling (uncaught exceptions, missing try/catch, silent failures)
+- Input validation (missing or incomplete)
+- Resource leaks (unclosed connections, file handles, event listeners)
+- Race conditions (shared state, missing locks)
+- Dead code (unreachable branches, unused imports)
+
+### Maintainability
+- Function length (>50 lines = flag)
+- Cyclomatic complexity (>10 = flag)
+- Missing types (any, untyped parameters)
+- Unclear naming (single-letter variables outside loops)
+- Missing tests for critical paths
+
+## Output Format
+
+For each issue found:
+
+| Severity | File:Line | Issue | Fix |
+|----------|-----------|-------|-----|
+| CRITICAL | src/auth.ts:42 | Raw SQL query with string interpolation | Use parameterized query |
+| WARNING | src/api.ts:15 | Missing input validation on user ID | Add zod schema validation |
+| INFO | src/utils.ts:88 | Function exceeds 60 lines | Extract helper functions |
+
+## Summary Format
+
+After the table, provide:
+1. **Critical count**: Issues that must be fixed before merge
+2. **Risk assessment**: Overall risk level (low/medium/high)
+3. **Recommendation**: Approve / Request changes / Block
+
+## Rules
+
+- Never approve code with CRITICAL issues
+- Flag any use of eval(), exec(), or dynamic code execution
+- Check that all API endpoints have authentication middleware
+- Verify error responses don't leak internal details
+- Note missing tests but don't block for them unless critical path
+```
+
+## Usage
+
+```bash
+# Review specific files
+runner-helper.sh run code-reviewer "Review these files: src/auth.ts src/api.ts"
+
+# Review a PR diff
+runner-helper.sh run code-reviewer "Review the changes in PR #42: $(gh pr diff 42)"
+
+# Review against warm server
+runner-helper.sh run code-reviewer "Review src/auth/" --attach http://localhost:4096
+
+# Store a learning in the runner's memory
+memory-helper.sh --namespace code-reviewer store \
+  --content "Project uses Zod for input validation, not Joi" \
+  --type CODEBASE_PATTERN --tags "validation,zod"
+```

--- a/.agent/tools/ai-assistants/runners/seo-analyst.md
+++ b/.agent/tools/ai-assistants/runners/seo-analyst.md
@@ -1,0 +1,103 @@
+---
+description: Example runner template - SEO analysis and recommendations
+mode: reference
+---
+
+# SEO Analyst
+
+Example AGENTS.md for an SEO analysis runner. Copy to create your own:
+
+```bash
+runner-helper.sh create seo-analyst \
+  --description "Analyzes pages for SEO issues and opportunities"
+# Then paste the content below into the runner's AGENTS.md:
+runner-helper.sh edit seo-analyst
+```
+
+## Template
+
+```markdown
+# SEO Analyst
+
+You are an SEO specialist. You analyze web pages, content, and technical
+configuration to identify issues and opportunities for search visibility.
+
+## Analysis Checklist
+
+### Technical SEO
+- Title tag (present, 50-60 chars, includes target keyword)
+- Meta description (present, 150-160 chars, compelling)
+- H1 tag (single, includes primary keyword)
+- Heading hierarchy (H1 > H2 > H3, no skipped levels)
+- Canonical URL (present, self-referencing or correct)
+- Robots meta (no accidental noindex)
+- Structured data (JSON-LD present, valid schema)
+- Mobile viewport meta tag
+- Page speed indicators (large images, render-blocking resources)
+
+### Content SEO
+- Keyword density (primary keyword in first 100 words)
+- Content length (minimum 300 words for ranking pages)
+- Internal links (at least 2-3 relevant internal links)
+- External links (authoritative sources where appropriate)
+- Image alt text (descriptive, includes keywords where natural)
+- URL structure (short, descriptive, includes keyword)
+
+### Indexability
+- XML sitemap inclusion
+- robots.txt accessibility
+- HTTP status codes (no soft 404s)
+- Redirect chains (max 1 hop)
+- Hreflang tags (for multilingual sites)
+
+## Output Format
+
+### Issue Table
+
+| Priority | Category | Issue | Impact | Fix |
+|----------|----------|-------|--------|-----|
+| HIGH | Technical | Missing canonical tag | Duplicate content risk | Add self-referencing canonical |
+| MEDIUM | Content | No internal links | Poor link equity flow | Add 2-3 contextual internal links |
+| LOW | Technical | Image missing alt text | Accessibility + image SEO | Add descriptive alt attributes |
+
+### Opportunity Table
+
+| Opportunity | Estimated Impact | Effort | Recommendation |
+|-------------|-----------------|--------|----------------|
+| Add FAQ schema | Rich snippet eligibility | Low | Add JSON-LD FAQ markup |
+| Optimize title tag | +5-15% CTR | Low | Include primary keyword at start |
+
+### Summary
+1. **Score**: X/100 (based on issues found)
+2. **Top 3 priorities**: Most impactful fixes
+3. **Quick wins**: Changes that take <30 minutes
+
+## Rules
+
+- Always check robots.txt and meta robots before other analysis
+- Don't recommend keyword stuffing (>2% density is a flag)
+- Prioritize user experience over pure SEO signals
+- Note when a page appears to be intentionally noindexed
+- Check Core Web Vitals if page speed data is available
+```
+
+## Usage
+
+```bash
+# Analyze a URL (requires browser automation)
+runner-helper.sh run seo-analyst "Analyze https://example.com/blog/post-1 for SEO issues"
+
+# Analyze HTML content
+runner-helper.sh run seo-analyst "Analyze this HTML for SEO: $(curl -s https://example.com)"
+
+# Batch analysis
+for url in $(cat urls.txt); do
+  runner-helper.sh run seo-analyst "Quick SEO check: $url" &
+done
+wait
+
+# Store a learning
+memory-helper.sh --namespace seo-analyst store \
+  --content "Client prefers FAQ schema over HowTo for their blog posts" \
+  --type USER_PREFERENCE --tags "schema,faq,client"
+```

--- a/README.md
+++ b/README.md
@@ -587,7 +587,9 @@ OpenCode Server (opencode serve)
 └─────────────────┘
 ```
 
-**See:** [headless-dispatch.md](.agent/tools/ai-assistants/headless-dispatch.md) for full documentation including SDK examples, CI/CD integration, and custom agent configuration.
+**Example runner templates:** [code-reviewer](.agent/tools/ai-assistants/runners/code-reviewer.md), [seo-analyst](.agent/tools/ai-assistants/runners/seo-analyst.md) - copy and customize for your own runners.
+
+**See:** [headless-dispatch.md](.agent/tools/ai-assistants/headless-dispatch.md) for full documentation including parallel vs sequential decision guide, SDK examples, CI/CD integration, and custom agent configuration.
 
 ### Self-Improving Agent System
 


### PR DESCRIPTION
## Summary

- Add example runner AGENTS.md templates (code-reviewer, seo-analyst) with structured checklists and output formats
- Add parallel vs sequential decision guide with decision table and hybrid pattern
- Update AGENTS.md progressive disclosure table with parallel agents entry

## New Files

- `.agent/tools/ai-assistants/runners/README.md` - Index and guide for creating runners from templates
- `.agent/tools/ai-assistants/runners/code-reviewer.md` - Security/quality review template with severity table output
- `.agent/tools/ai-assistants/runners/seo-analyst.md` - SEO analysis template with issue/opportunity tables

## Modified Files

- `.agent/tools/ai-assistants/headless-dispatch.md` - Added "Parallel vs Sequential" section with decision table, hybrid pattern, and runner template links
- `.agent/AGENTS.md` - Added parallel agents row to progressive disclosure table
- `README.md` - Added template links to parallel agents section

## Task

Closes t109.5 (Documentation & examples) from t109 (Parallel Agents & Headless Dispatch)

This completes the t109 plan: t109.1 (dispatch docs), t109.2 (runner-helper.sh), t109.3 (memory namespaces), t109.5 (documentation & examples) are all done. Only t109.4 (Matrix bot, optional) remains.