### PR TITLE
refactor: use args array for opencode launch command

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3728,11 +3728,11 @@ echo "  aidevops uninstall    - Remove aidevops"
                     onboarding_model="google/gemini-2.5-flash"
                 fi
             fi
+            local opencode_args=("--agent" "Onboarding" "--prompt" "/onboarding")
             if [[ -n "$onboarding_model" ]]; then
-                opencode --agent Onboarding --prompt "/onboarding" --model "$onboarding_model"
-            else
-                opencode --agent Onboarding --prompt "/onboarding"
+                opencode_args+=("--model" "$onboarding_model")
             fi
+            opencode "${opencode_args[@]}"
         else
             echo ""
             echo "You can run /onboarding anytime in OpenCode to configure services."


### PR DESCRIPTION
## Summary

Addresses Gemini code review suggestion from PR #346. Builds the `opencode` command arguments dynamically using a bash array instead of duplicating the base command in an if/else block.

Before:
```bash
if [[ -n "$onboarding_model" ]]; then
    opencode --agent Onboarding --prompt "/onboarding" --model "$onboarding_model"
else
    opencode --agent Onboarding --prompt "/onboarding"
fi
```

After:
```bash
local opencode_args=("--agent" "Onboarding" "--prompt" "/onboarding")
if [[ -n "$onboarding_model" ]]; then
    opencode_args+=("--model" "$onboarding_model")
fi
opencode "${opencode_args[@]}"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal argument construction for OpenCode invocation, maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->