### PR TITLE
feat: migrate inter-agent mailbox from TOON files to SQLite

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -137,13 +137,17 @@ Want me to remember this? /remember {concise description}
 
 ## Inter-Agent Mailbox
 
-TOON-based async communication between parallel agent sessions.
+SQLite-backed async communication between parallel agent sessions.
 
-**CLI**: `mail-helper.sh [send|check|read|archive|prune|status|register|deregister|agents]`
+**CLI**: `mail-helper.sh [send|check|read|archive|prune|status|register|deregister|agents|migrate]`
 
 **Message types**: task_dispatch, status_report, discovery, request, broadcast
 
-**Lifecycle**: send → check → read → archive → prune (7-day, with memory capture)
+**Lifecycle**: send → check → read → auto-archive on prune (7-day, with memory capture)
+
+**Runner integration**: Runners automatically check inbox before work and send status reports after. Unread messages are prepended as context to the runner's prompt.
+
+**Migration**: Run `mail-helper.sh migrate` to migrate existing TOON files to SQLite (backs up originals).
 
 ## MCP On-Demand Loading
 
@@ -264,7 +268,7 @@ Import community skills: `aidevops skill add <source>` (→ `*-skill.md` suffix)
 ~/.aidevops/.agent-workspace/
 ├── work/[project]/    # Persistent project files
 ├── tmp/session-*/     # Temporary session files
-├── mail/              # Inter-agent mailbox (TOON)
+├── mail/              # Inter-agent mailbox (SQLite: mailbox.db)
 └── memory/            # Cross-session patterns (SQLite FTS5)
 ```
 

--- a/.agent/scripts/coordinator-helper.sh
+++ b/.agent/scripts/coordinator-helper.sh
@@ -2,9 +2,9 @@
 # coordinator-helper.sh - Stateless multi-agent coordinator (pulse pattern)
 #
 # Unlike Gas Town's persistent Mayor, this coordinator is STATELESS:
-# - Reads current state (registry, outbox, TODO.md)
+# - Reads current state from SQLite (agents, messages)
 # - Makes dispatch decisions
-# - Writes inbox messages
+# - Sends inbox messages via mail-helper.sh
 # - Exits immediately (~20K token budget per pulse)
 #
 # Usage:
@@ -12,12 +12,12 @@
 #   coordinator-helper.sh status             # Show current orchestration state
 #   coordinator-helper.sh dispatch --task "description" [--to <agent>] [--priority high]
 #   coordinator-helper.sh convoy --name "group" --tasks "t001,t002,t003"
-#   coordinator-helper.sh watch [--interval 30]  # Watch mode (fswatch on outbox)
+#   coordinator-helper.sh watch [--interval 30]  # Watch mode (poll or fswatch)
 #
 # Trigger methods:
 #   1. Manual: coordinator-helper.sh pulse
 #   2. Cron: */5 * * * * coordinator-helper.sh pulse
-#   3. Watch: coordinator-helper.sh watch (fswatch on outbox/)
+#   3. Watch: coordinator-helper.sh watch (uses fswatch if available)
 
 set -euo pipefail
 
@@ -27,7 +27,7 @@ readonly SCRIPT_DIR
 readonly MAIL_HELPER="${SCRIPT_DIR}/mail-helper.sh"
 readonly MEMORY_HELPER="${SCRIPT_DIR}/memory-helper.sh"
 readonly MAIL_DIR="${AIDEVOPS_MAIL_DIR:-$HOME/.aidevops/.agent-workspace/mail}"
-readonly REGISTRY_FILE="$MAIL_DIR/registry.toon"
+readonly MAIL_DB="$MAIL_DIR/mailbox.db"
 readonly COORDINATOR_ID="coordinator"
 
 # Colors
@@ -44,38 +44,51 @@ log_warn() { echo -e "${YELLOW}[COORD]${NC} $*"; }
 log_error() { echo -e "${RED}[COORD]${NC} $*" >&2; }
 
 #######################################
-# Read active agents from registry
-# Output: agent_id,role,branch,status lines
+# Ensure mailbox DB exists
 #######################################
-get_active_agents() {
-    if [[ ! -f "$REGISTRY_FILE" ]]; then
-        return 0
+ensure_db() {
+    if [[ ! -f "$MAIL_DB" ]]; then
+        "$MAIL_HELPER" status > /dev/null 2>&1
     fi
-    grep ',active,' "$REGISTRY_FILE" 2>/dev/null | grep -v '^<!--' | grep -v '^-->' || true
+    return 0
 }
 
 #######################################
-# Read unprocessed outbox messages (status reports from workers)
-# Output: TOON message content
+# Read active agents from SQLite
+# Output: id,role,branch,status lines
+#######################################
+get_active_agents() {
+    ensure_db
+    sqlite3 -separator ',' "$MAIL_DB" "
+        SELECT id, role, branch, worktree, status, registered, last_seen
+        FROM agents WHERE status = 'active';
+    " 2>/dev/null || true
+}
+
+#######################################
+# Read unprocessed status reports
+# Output: from: payload lines
 #######################################
 get_worker_reports() {
-    local outbox_dir="$MAIL_DIR/outbox"
-    if [[ ! -d "$outbox_dir" ]]; then
-        return 0
-    fi
-    
-    for msg_file in "$outbox_dir"/*.toon; do
-        [[ -f "$msg_file" ]] || continue
-        local msg_type
-        msg_type=$(grep -A1 'TOON:message{' "$msg_file" 2>/dev/null | tail -1 | cut -d',' -f4)
-        if [[ "$msg_type" == "status_report" ]]; then
-            local from
-            from=$(grep -A1 'TOON:message{' "$msg_file" 2>/dev/null | tail -1 | cut -d',' -f2)
-            local payload
-            payload=$(sed -n '/^-->$/,$ { /^-->$/d; p; }' "$msg_file" | sed '/^$/d')
-            echo "$from: $payload"
-        fi
+    ensure_db
+    sqlite3 -separator '|' "$MAIL_DB" "
+        SELECT from_agent, payload FROM messages
+        WHERE type = 'status_report' AND status = 'unread'
+        ORDER BY created_at ASC;
+    " 2>/dev/null | while IFS='|' read -r from payload; do
+        echo "$from: $payload"
     done
+}
+
+#######################################
+# Mark status reports as read and archive them
+#######################################
+process_reports() {
+    ensure_db
+    sqlite3 "$MAIL_DB" "
+        UPDATE messages SET status = 'archived', archived_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
+        WHERE type = 'status_report' AND status = 'unread';
+    " 2>/dev/null || true
 }
 
 #######################################
@@ -87,9 +100,23 @@ get_ready_tasks() {
     if [[ ! -f "$todo_file" ]]; then
         return 0
     fi
-    
-    # Find unchecked tasks without blocked-by (or with all blockers completed)
+
     grep '^- \[ \]' "$todo_file" | grep -v 'blocked-by:' | head -5 || true
+}
+
+#######################################
+# Get idle workers (active agents with no unread messages)
+#######################################
+get_idle_workers() {
+    ensure_db
+    sqlite3 "$MAIL_DB" "
+        SELECT a.id FROM agents a
+        WHERE a.status = 'active' AND a.role = 'worker'
+        AND NOT EXISTS (
+            SELECT 1 FROM messages m
+            WHERE m.to_agent = a.id AND m.status = 'unread'
+        );
+    " 2>/dev/null || true
 }
 
 #######################################
@@ -98,7 +125,9 @@ get_ready_tasks() {
 #######################################
 cmd_pulse() {
     log_info "Coordinator pulse starting..."
-    
+
+    ensure_db
+
     # 1. Read current state
     local active_agents
     active_agents=$(get_active_agents)
@@ -106,18 +135,20 @@ cmd_pulse() {
     if [[ -n "$active_agents" ]]; then
         agent_count=$(echo "$active_agents" | wc -l | tr -d ' ')
     fi
-    
+
     log_info "Active agents: $agent_count"
-    
-    # 2. Process worker reports (archive after reading)
+
+    # 2. Process worker reports
     local reports
     reports=$(get_worker_reports)
+    local report_count=0
     if [[ -n "$reports" ]]; then
-        log_info "Worker reports:"
+        report_count=$(echo "$reports" | wc -l | tr -d ' ')
+        log_info "Worker reports ($report_count):"
         echo "$reports" | while IFS= read -r report; do
             echo "  $report"
         done
-        
+
         # Store notable reports to memory
         if [[ -x "$MEMORY_HELPER" ]]; then
             echo "$reports" | while IFS= read -r report; do
@@ -129,51 +160,31 @@ cmd_pulse() {
                 fi
             done
         fi
-        
-        # Move processed outbox status_reports to archive directly
-        # (mail-helper archive only handles inbox, so we move outbox files manually)
-        local outbox_dir="$MAIL_DIR/outbox"
-        local archive_dir="$MAIL_DIR/archive"
-        if [[ -d "$outbox_dir" ]]; then
-            mkdir -p "$archive_dir"
-            for msg_file in "$outbox_dir"/*.toon; do
-                [[ -f "$msg_file" ]] || continue
-                local msg_type
-                msg_type=$(grep -A1 'TOON:message{' "$msg_file" 2>/dev/null | tail -1 | cut -d',' -f4)
-                if [[ "$msg_type" == "status_report" ]]; then
-                    mv "$msg_file" "$archive_dir/" 2>/dev/null || true
-                fi
-            done
-        fi
+
+        # Archive processed reports
+        process_reports
     fi
-    
-    # 3. Check for idle agents that could take new work
-    local idle_agents=""
-    if [[ -n "$active_agents" ]]; then
-        while IFS=',' read -r agent_id role _branch _worktree _status _registered _last_seen; do
-            # Check if agent has unread messages (busy) or not (idle)
-            local inbox_dir="$MAIL_DIR/inbox/$agent_id"
-            local unread=0
-            if [[ -d "$inbox_dir" ]]; then
-                unread=$(grep -rl ',unread$' "$inbox_dir" 2>/dev/null | wc -l | tr -d ' ')
-            fi
-            if [[ "$unread" -eq 0 && "$role" == "worker" ]]; then
-                idle_agents="${idle_agents}${agent_id},"
-            fi
-        done <<< "$active_agents"
-    fi
-    
+
+    # 3. Find idle workers
+    local idle_workers
+    idle_workers=$(get_idle_workers)
+
     # 4. Find ready tasks to dispatch
     local ready_tasks
     ready_tasks=$(get_ready_tasks)
-    
-    if [[ -n "$ready_tasks" && -n "$idle_agents" ]]; then
+    local ready_count=0
+    if [[ -n "$ready_tasks" ]]; then
+        ready_count=$(echo "$ready_tasks" | wc -l | tr -d ' ')
+    fi
+
+    local dispatch_count=0
+    if [[ -n "$ready_tasks" && -n "$idle_workers" ]]; then
         log_info "Dispatching tasks to idle workers..."
         local first_idle
-        first_idle=$(echo "$idle_agents" | cut -d',' -f1)
+        first_idle=$(echo "$idle_workers" | head -1)
         local first_task
         first_task=$(echo "$ready_tasks" | head -1)
-        
+
         if [[ -n "$first_idle" && -n "$first_task" ]]; then
             "$MAIL_HELPER" send \
                 --from "$COORDINATOR_ID" \
@@ -182,6 +193,7 @@ cmd_pulse() {
                 --payload "$first_task" \
                 --priority normal 2>/dev/null || true
             log_success "Dispatched to $first_idle: $(echo "$first_task" | head -c 80)"
+            dispatch_count=1
         fi
     elif [[ -z "$active_agents" ]]; then
         log_info "No active agents registered. Nothing to coordinate."
@@ -190,24 +202,13 @@ cmd_pulse() {
     else
         log_info "All agents busy. Waiting for reports."
     fi
-    
+
     # 5. Summary
-    local report_count=0 dispatch_count=0 ready_count=0
-    if [[ -n "$reports" ]]; then
-        report_count=$(echo "$reports" | grep -c '.' 2>/dev/null || echo 0)
-    fi
-    # Count actual dispatches (1 if we dispatched, 0 otherwise)
-    if [[ -n "$ready_tasks" && -n "$idle_agents" && -n "${first_idle:-}" && -n "${first_task:-}" ]]; then
-        dispatch_count=1
-    fi
-    if [[ -n "$ready_tasks" ]]; then
-        ready_count=$(echo "$ready_tasks" | grep -c '.' 2>/dev/null || echo 0)
-    fi
     echo ""
     echo "<!--TOON:pulse_summary{agents,reports,dispatched,ready_tasks,timestamp}:"
     echo "${agent_count},${report_count},${dispatch_count},${ready_count},$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     echo "-->"
-    
+
     log_success "Pulse complete."
 }
 
@@ -217,24 +218,36 @@ cmd_pulse() {
 cmd_status() {
     echo "=== Coordinator Status ==="
     echo ""
-    
-    # Agent registry
-    if [[ -f "$REGISTRY_FILE" ]]; then
+
+    ensure_db
+
+    # Agent registry with inbox counts from SQLite
+    local agents
+    agents=$(sqlite3 -separator '|' "$MAIL_DB" "
+        SELECT a.id, a.role, a.branch, a.status, a.last_seen,
+               COALESCE(m.inbox_count, 0), COALESCE(m.unread_count, 0)
+        FROM agents a
+        LEFT JOIN (
+            SELECT to_agent,
+                   count(*) as inbox_count,
+                   sum(CASE WHEN status = 'unread' THEN 1 ELSE 0 END) as unread_count
+            FROM messages WHERE status != 'archived'
+            GROUP BY to_agent
+        ) m ON a.id = m.to_agent
+        ORDER BY a.status DESC, a.last_seen DESC;
+    " 2>/dev/null)
+
+    if [[ -n "$agents" ]]; then
         echo "Registered Agents:"
-        while IFS=',' read -r agent_id role branch _worktree status _registered last_seen; do
-            [[ "$agent_id" == "<!--"* || "$agent_id" == "-->"* || -z "$agent_id" ]] && continue
-            local inbox_count=0
-            if [[ -d "$MAIL_DIR/inbox/$agent_id" ]]; then
-                inbox_count=$(find "$MAIL_DIR/inbox/$agent_id" -name "*.toon" 2>/dev/null | wc -l | tr -d ' ')
-            fi
-            echo -e "  ${CYAN}$agent_id${NC} ($role) [$status] branch:$branch inbox:$inbox_count last:$last_seen"
-        done < "$REGISTRY_FILE"
+        while IFS='|' read -r id role branch status last_seen inbox_count unread_count; do
+            echo -e "  ${CYAN}$id${NC} ($role) [$status] branch:$branch inbox:$inbox_count($unread_count unread) last:$last_seen"
+        done <<< "$agents"
     else
         echo "  No agents registered"
     fi
-    
+
     echo ""
-    
+
     # Mailbox status
     if [[ -x "$MAIL_HELPER" ]]; then
         "$MAIL_HELPER" status 2>/dev/null
@@ -246,7 +259,7 @@ cmd_status() {
 #######################################
 cmd_dispatch() {
     local task="" to="" priority="normal" convoy=""
-    
+
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --task) [[ $# -lt 2 ]] && { log_error "--task requires a value"; return 1; }; task="$2"; shift 2 ;;
@@ -256,53 +269,33 @@ cmd_dispatch() {
             *) log_error "Unknown option: $1"; return 1 ;;
         esac
     done
-    
+
     if [[ -z "$task" ]]; then
         log_error "Missing --task <description>"
         return 1
     fi
-    
+
     # If no target specified, find first idle worker
     if [[ -z "$to" ]]; then
-        local active_agents
-        active_agents=$(get_active_agents)
-        if [[ -n "$active_agents" ]]; then
-            # Find a worker with no unread messages (idle)
-            while IFS=',' read -r agent_id role _rest; do
-                [[ "$role" == "worker" ]] || continue
-                local inbox_dir="$MAIL_DIR/inbox/$agent_id"
-                local unread=0
-                if [[ -d "$inbox_dir" ]]; then
-                    unread=$(find "$inbox_dir" -name "*.toon" -type f 2>/dev/null | wc -l | tr -d ' ')
-                fi
-                if [[ "$unread" -eq 0 ]]; then
-                    to="$agent_id"
-                    break
-                fi
-            done <<< "$active_agents"
-        fi
+        to=$(get_idle_workers | head -1)
         if [[ -z "$to" ]]; then
             log_error "No idle workers available. Register agents first."
             return 1
         fi
     fi
-    
+
+    local -a send_args=(
+        --from "$COORDINATOR_ID"
+        --to "$to"
+        --type task_dispatch
+        --payload "$task"
+        --priority "$priority"
+    )
     if [[ -n "$convoy" ]]; then
-        "$MAIL_HELPER" send \
-            --from "$COORDINATOR_ID" \
-            --to "$to" \
-            --type task_dispatch \
-            --payload "$task" \
-            --priority "$priority" \
-            --convoy "$convoy"
-    else
-        "$MAIL_HELPER" send \
-            --from "$COORDINATOR_ID" \
-            --to "$to" \
-            --type task_dispatch \
-            --payload "$task" \
-            --priority "$priority"
+        send_args+=(--convoy "$convoy")
     fi
+
+    "$MAIL_HELPER" send "${send_args[@]}"
 }
 
 #######################################
@@ -310,7 +303,7 @@ cmd_dispatch() {
 #######################################
 cmd_convoy() {
     local name="" tasks=""
-    
+
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --name) [[ $# -lt 2 ]] && { log_error "--name requires a value"; return 1; }; name="$2"; shift 2 ;;
@@ -318,50 +311,44 @@ cmd_convoy() {
             *) log_error "Unknown option: $1"; return 1 ;;
         esac
     done
-    
+
     if [[ -z "$name" || -z "$tasks" ]]; then
         log_error "Usage: coordinator-helper.sh convoy --name <group> --tasks <t001,t002>"
         return 1
     fi
-    
+
     log_info "Creating convoy: $name"
-    
-    # Dispatch each task with convoy grouping
+
     IFS=',' read -ra task_array <<< "$tasks"
     for task_id in "${task_array[@]}"; do
-        # Look up task description from TODO.md
         local task_desc
         task_desc=$(grep "^- \[ \] $task_id " TODO.md 2>/dev/null | head -1 || echo "$task_id")
-        
+
         cmd_dispatch --task "$task_desc" --convoy "$name" --priority normal
     done
-    
+
     log_success "Convoy '$name' created with ${#task_array[@]} tasks"
 }
 
 #######################################
-# Watch mode: trigger pulse on outbox changes
+# Watch mode: trigger pulse on DB changes or interval
 #######################################
 cmd_watch() {
     local interval="${1:-30}"
-    
-    # Remove --interval flag if present
+
     if [[ "$interval" == "--interval" ]]; then
         interval="${2:-30}"
     fi
-    
+
     log_info "Watch mode: polling every ${interval}s (Ctrl+C to stop)"
-    log_info "Tip: Install fswatch for event-driven triggers"
-    
-    # Check if fswatch is available for event-driven mode
+
+    # fswatch on the DB file for near-instant triggers
     if command -v fswatch &>/dev/null; then
         log_info "Using fswatch for event-driven coordination"
-        mkdir -p "$MAIL_DIR/outbox"
-        fswatch -o "$MAIL_DIR/outbox" | while read -r _; do
+        fswatch -o "$MAIL_DB" "$MAIL_DB-wal" 2>/dev/null | while read -r _; do
             cmd_pulse
         done
     else
-        # Fallback: polling
         while true; do
             cmd_pulse
             sleep "$interval"
@@ -386,6 +373,8 @@ Usage:
 The coordinator is STATELESS - it reads state, dispatches, and exits.
 Each pulse uses ~20K tokens of context (reads files, no conversation history).
 
+Backend: SQLite (shared with mail-helper.sh via mailbox.db)
+
 Trigger methods:
   Manual:  coordinator-helper.sh pulse
   Cron:    */5 * * * * ~/.aidevops/agents/scripts/coordinator-helper.sh pulse
@@ -402,7 +391,7 @@ EOF
 main() {
     local command="${1:-help}"
     shift || true
-    
+
     case "$command" in
         pulse) cmd_pulse "$@" ;;
         status) cmd_status "$@" ;;

--- a/.agent/scripts/coordinator-helper.sh
+++ b/.agent/scripts/coordinator-helper.sh
@@ -88,7 +88,7 @@ process_reports() {
     sqlite3 "$MAIL_DB" "
         UPDATE messages SET status = 'archived', archived_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
         WHERE type = 'status_report' AND status = 'unread';
-    " 2>/dev/null || true
+    "
 }
 
 #######################################

--- a/.agent/scripts/mail-helper.sh
+++ b/.agent/scripts/mail-helper.sh
@@ -399,6 +399,11 @@ cmd_prune() {
         esac
     done
 
+    if ! [[ "$older_than_days" =~ ^[0-9]+$ ]]; then
+        log_error "Invalid value for --older-than-days: must be a positive integer"
+        return 1
+    fi
+
     ensure_db
 
     local cutoff_date

--- a/.agent/scripts/runner-helper.sh
+++ b/.agent/scripts/runner-helper.sh
@@ -80,7 +80,10 @@ mailbox_before_run() {
     unread_messages=$(AIDEVOPS_AGENT_ID="$name" "$MAIL_HELPER" check --unread-only 2>/dev/null)
 
     local unread_count
-    unread_count=$(echo "$unread_messages" | grep -o '[0-9]* unread' | grep -o '[0-9]*' || echo "0")
+    unread_count=$(echo "$unread_messages" | grep '^Total:' | sed -n 's/.*(\([0-9]*\) unread).*/\1/p' || echo "0")
+    if [[ -z "$unread_count" ]]; then
+        unread_count=0
+    fi
 
     if [[ "$unread_count" -gt 0 ]]; then
         log_info "Mailbox: $unread_count unread message(s) for $name"
@@ -425,7 +428,7 @@ $prompt"
     fi
 
     # Prepend mailbox context if there are unread messages
-    if [[ -n "$mailbox_context" ]] && echo "$mailbox_context" | grep -q '[1-9].* unread'; then
+    if [[ -n "$mailbox_context" ]] && echo "$mailbox_context" | grep -q '^Total:.*([1-9][0-9]* unread)'; then
         full_prompt="## Mailbox (unread messages from other agents)
 
 $mailbox_context


### PR DESCRIPTION
## Summary

- Migrate inter-agent mailbox from file-per-message TOON format to SQLite WAL-mode database
- Add runner bookend integration: agents automatically check inbox before work and report status after
- Benchmarked **79x faster**: 32ms vs 2,548ms for 100-message inbox check, scales to thousands/day

## Problem

The TOON file-based mailbox spawned 3 subprocesses per message (grep + cut + echo in a loop). At 1000 tasks/day with bookend checks, inbox scans would take ~50 seconds. Messages never auto-archived, outbox never cleaned, and the registry file had lock contention with concurrent runners.

## Solution

Single SQLite database (`mailbox.db`) with WAL mode and indexed queries. Same CLI interface - drop-in replacement.

| Operation | TOON files | SQLite | Speedup |
|-----------|-----------|--------|---------|
| Check 100 messages | 2,548ms | 32ms | **79x** |
| Global status (1000 msgs) | ~25s est. | 45ms | **~555x** |
| Send message | ~50ms | ~15ms | **3x** |

## Changes

### `mail-helper.sh` - Complete rewrite
- SQLite WAL mode + `busy_timeout=5000` for concurrent access
- Indexed queries on `(to_agent, status)`, `type`, `convoy`, `created_at`
- Auto-archive read messages during prune
- `mail-helper.sh migrate` command migrates existing TOON files (backs up originals)
- Priority-ordered inbox (high → normal → low)

### `coordinator-helper.sh` - SQLite queries
- `get_idle_workers()` uses `NOT EXISTS` subquery (instant vs file scanning)
- `process_reports()` archives in single `UPDATE` statement
- `fswatch` on `mailbox.db` instead of outbox directory
- Status shows inbox counts via `LEFT JOIN` (single query)

### `runner-helper.sh` - Bookend integration
- **Before work**: Register agent, check inbox, prepend unread messages as context to prompt
- **After work**: Send `status_report` to coordinator, deregister agent
- Non-blocking: all mailbox calls wrapped in `|| true`

### `AGENTS.md` - Documentation
- Updated mailbox section with SQLite details, runner integration, migration instructions

## Testing

- Functional: send, check, read, archive, broadcast, register/deregister all verified
- Migration: TOON files migrated correctly with backup of originals
- Scale: 1000 messages across 10 agents, 32ms inbox check
- ShellCheck: zero violations on all three scripts
- Markdown lint: zero errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added migration utility to convert existing mailbox data to the new database system.
  * Runners now check for incoming messages before execution and include unread messages as context in prompts.
  * Status reports now captured and processed through the database.

* **Refactor**
  * Migrated mailbox system from file-based to database-backed storage.
  * Updated coordinator workflow to query state from database instead of filesystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->