### PR TITLE
feat: auto-migrate mailbox on update, replace auto-prune with storage report

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -143,11 +143,11 @@ SQLite-backed async communication between parallel agent sessions.
 
 **Message types**: task_dispatch, status_report, discovery, request, broadcast
 
-**Lifecycle**: send → check → read → auto-archive on prune (7-day, with memory capture)
+**Lifecycle**: send → check → read → archive (history preserved, prune is manual)
 
 **Runner integration**: Runners automatically check inbox before work and send status reports after. Unread messages are prepended as context to the runner's prompt.
 
-**Migration**: Run `mail-helper.sh migrate` to migrate existing TOON files to SQLite (backs up originals).
+**Storage**: `mail-helper.sh prune` shows storage report. Use `--force` to delete old archived messages. Migration from TOON files runs automatically on `aidevops update`.
 
 ## MCP On-Demand Loading
 

--- a/setup.sh
+++ b/setup.sh
@@ -1952,6 +1952,17 @@ deploy_aidevops_agents() {
                 print_info "Injected OpenCode plan-reminder into Plan+"
             fi
         fi
+        # Migrate mailbox from TOON files to SQLite (if old files exist)
+        local mail_dir="$HOME/.aidevops/.agent-workspace/mail"
+        local mail_script="$target_dir/scripts/mail-helper.sh"
+        if [[ -x "$mail_script" ]] && find "$mail_dir" -name "*.toon" 2>/dev/null | grep -q .; then
+            print_info "Migrating mailbox from TOON files to SQLite..."
+            if "$mail_script" migrate 2>/dev/null; then
+                print_success "Mailbox migration complete"
+            else
+                print_warning "Mailbox migration had issues (non-critical, old files preserved)"
+            fi
+        fi
     else
         print_error "Failed to deploy agents"
         return 1

--- a/setup.sh
+++ b/setup.sh
@@ -1953,11 +1953,11 @@ deploy_aidevops_agents() {
             fi
         fi
         # Migrate mailbox from TOON files to SQLite (if old files exist)
-        local mail_dir="$HOME/.aidevops/.agent-workspace/mail"
+        local aidevops_workspace_dir="${AIDEVOPS_WORKSPACE_DIR:-$HOME/.aidevops/.agent-workspace}"
+        local mail_dir="${AIDEVOPS_MAIL_DIR:-${aidevops_workspace_dir}/mail}"
         local mail_script="$target_dir/scripts/mail-helper.sh"
         if [[ -x "$mail_script" ]] && find "$mail_dir" -name "*.toon" 2>/dev/null | grep -q .; then
-            print_info "Migrating mailbox from TOON files to SQLite..."
-            if "$mail_script" migrate 2>/dev/null; then
+            if "$mail_script" migrate; then
                 print_success "Mailbox migration complete"
             else
                 print_warning "Mailbox migration had issues (non-critical, old files preserved)"


### PR DESCRIPTION
## Summary

- Auto-migrate TOON mailbox files to SQLite during `aidevops update` (setup.sh)
- Replace silent auto-prune with storage report - deletion now requires `--force`

## Changes

### `setup.sh`
- Added migration check in `deploy_aidevops_agents()`: detects `.toon` files in mail directory and runs `mail-helper.sh migrate` automatically
- Non-blocking: migration failure is a warning, not an error

### `mail-helper.sh` - prune redesign
- `prune` (default): Shows storage report with DB size, message counts by status/type, date range, prunable count
- `prune --force`: Actually deletes (captures discoveries to memory first, then VACUUMs)
- `prune --older-than-days N`: Adjustable threshold (default 7)
- `--dry-run`: Kept as backward-compatible alias for default report behavior

### `.agent/AGENTS.md`
- Updated lifecycle: "history preserved, prune is manual"
- Updated storage guidance with migration note

## User impact

| User type | What happens |
|-----------|-------------|
| New user | Fresh SQLite DB created on first mail-helper.sh call |
| Existing user (no TOON files) | No change |
| Existing user (has TOON files) | Auto-migrated on next `aidevops update`, originals backed up |
| Cron jobs calling `prune` | Now shows report instead of deleting - add `--force` to restore old behavior |

## Testing

- Storage report: verified with 11 messages, shows correct counts and type breakdown
- Force prune: verified deletion with memory capture and VACUUM
- Migration trigger: verified setup.sh detection of TOON files and successful migration
- SQL injection: validated integer check on `--older-than-days`
- Backward compat: `--dry-run` still works (alias for default)
- ShellCheck: zero new violations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mailbox now displays storage reports showing database size, message counts, and date ranges before any operations.
  * Automatic migration from legacy mailbox formats during system updates.

* **Documentation**
  * Updated mailbox lifecycle: archive and prune operations now require explicit user confirmation via command flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->