### PR TITLE
fix: re-run setup.sh when deployed agent VERSION mismatches repo

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -545,6 +545,17 @@ cmd_update() {
         
         if [[ "$local_hash" == "$remote_hash" ]]; then
             print_success "Framework already up to date!"
+            
+            # Even when repo is current, deployed agents may be stale
+            # (e.g., previous setup.sh was interrupted or failed)
+            local repo_version deployed_version
+            repo_version=$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "unknown")
+            deployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
+            if [[ "$repo_version" != "$deployed_version" ]]; then
+                print_warning "Deployed agents ($deployed_version) don't match repo ($repo_version)"
+                print_info "Re-running setup to sync agents..."
+                bash "$INSTALL_DIR/setup.sh"
+            fi
         else
             print_info "Pulling latest changes..."
             if git pull --ff-only origin main; then


### PR DESCRIPTION
## Summary

- Fixes `aidevops update` skipping agent deployment when the git repo is already at the latest commit
- When repo is current but `~/.aidevops/agents/VERSION` doesn't match, re-runs `setup.sh` to sync

## Root Cause

`cmd_update` only ran `setup.sh` when new commits were pulled. If the repo was already up-to-date (e.g., previous `setup.sh` was interrupted, failed, or the repo was updated manually), the deployed agents remained stale with no way to fix them short of running `./setup.sh` manually.

## Changes

- `aidevops.sh`: Added VERSION mismatch check in the "already up to date" branch of `cmd_update`
- Compares `$INSTALL_DIR/VERSION` against `~/.aidevops/agents/VERSION`
- Re-runs `setup.sh` only when they differ (no unnecessary re-deploys)

## Testing

- ShellCheck: zero violations
- Bash syntax check: OK
- Manually verified the fix resolves the original issue (agents were at 2.100.20, repo at 2.101.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the update process to detect version mismatches between the repository and deployed agents.
  * When versions diverge, the system automatically re-synchronizes agents and displays a warning to inform users.
  * This ensures consistency between local and deployed components even when the repository is already current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->