### PR TITLE
fix: remove eval-based patterns from credential-helper.sh (t107)

### DIFF
--- a/.agent/tools/credentials/multi-tenant.md
+++ b/.agent/tools/credentials/multi-tenant.md
@@ -179,11 +179,11 @@ exec $SHELL              # Restart shell
 ### Script Integration
 
 ```bash
-# Load specific tenant in a script
-eval $(credential-helper.sh export --tenant client-acme)
+# Load specific tenant in a script (preferred: source)
+source <(credential-helper.sh export --tenant client-acme)
 
 # Check active tenant
-echo $AIDEVOPS_ACTIVE_TENANT
+echo "$AIDEVOPS_ACTIVE_TENANT"
 ```
 
 ### CI/CD Integration

--- a/README.md
+++ b/README.md
@@ -2060,7 +2060,7 @@ credential-helper.sh set GITHUB_TOKEN ghp_xxx
 echo "client-acme" > .aidevops-tenant
 
 # Export for scripts
-eval $(credential-helper.sh export)
+source <(credential-helper.sh export)
 ```
 
 **Resolution priority:** Project `.aidevops-tenant` → Global active tenant → Default


### PR DESCRIPTION
## Summary

- **Removed `bash -c` execution** in `cmd_get` that evaluated raw lines from env files, replacing with safe string parsing using parameter expansion
- **Changed value storage format** from `printf %q` (requires eval to decode) to double-quoted values with explicit character escaping (trivial to parse without eval)
- **Added strict validation** in `cmd_export` to only emit lines matching `^export [A-Z_][A-Z0-9_]*=` pattern, rejecting any tampered content
- **Updated docs** (README.md, multi-tenant.md, help text) to recommend `source <()` over `eval $()`

## Security Issues Fixed

| Location | Before (unsafe) | After (safe) |
|----------|-----------------|--------------|
| `cmd_get` L419 | `bash -c "$line; echo \"\$$env_var\""` | Parameter expansion + quote stripping |
| `cmd_set` L343 | `printf '%q'` (needs eval to decode) | Double-quoted with `\", \\, \$, \`` escaping |
| `cmd_export` L797 | Raw `grep "^export "` passthrough | Regex-validated line-by-line output |

## Testing

- Roundtrip test: `set` + `get` with spaces, `$`, `"`, `` ` ``, `\` all pass
- ShellCheck: zero violations
- Backward compatible: existing double-quoted and single-quoted values still parse correctly

Closes t107