### PR TITLE
fix(memory): improve secret detection regex to catch hyphenated API keys

### DIFF
--- a/.agent/scripts/memory-helper.sh
+++ b/.agent/scripts/memory-helper.sh
@@ -333,7 +333,7 @@ cmd_store() {
     content=$(echo "$content" | sed 's/<private>[^<]*<\/private>//g' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
     
     # Privacy filter: reject content that looks like secrets
-    if echo "$content" | grep -qE '(sk-[a-zA-Z0-9]{20,}|AKIA[0-9A-Z]{16}|ghp_[a-zA-Z0-9]{36}|api[_-]?key["\s:=]+[a-zA-Z0-9_-]{16,})'; then
+    if echo "$content" | grep -qE '(sk-[a-zA-Z0-9_-]{20,}|AKIA[0-9A-Z]{16}|ghp_[a-zA-Z0-9]{36}|gho_[a-zA-Z0-9]{36}|xoxb-[a-zA-Z0-9-]{20,}|api[_-]?key[[:space:]"'"'"':=]+[a-zA-Z0-9_-]{16,})'; then
         log_error "Content appears to contain secrets (API keys, tokens). Refusing to store."
         log_error "Remove sensitive data or wrap in <private>...</private> tags to exclude."
         return 1


### PR DESCRIPTION
## Summary

- Fixes secret detection regex in memory-helper.sh privacy filter that missed `sk-proj-*` style API keys
- Found during testing of t058 Memory Auto-Capture feature

## Changes

The `sk-` pattern `sk-[a-zA-Z0-9]{20,}` didn't match keys with hyphens like `sk-proj-abcdef...`. Updated to `sk-[a-zA-Z0-9_-]{20,}`.

Also added patterns for:
- `gho_*` (GitHub OAuth tokens)
- `xoxb-*` (Slack bot tokens)
- Fixed `api_key` pattern quoting for shell compatibility

## Testing

```bash
# These are now correctly rejected:
memory-helper.sh store --auto --content "sk-proj-abcdefghijklmnopqrstuvwxyz1234" --type TOOL_CONFIG
# → ERROR: Content appears to contain secrets

# Safe content still passes:
memory-helper.sh store --auto --content "Use skip-worktree flag" --type WORKING_SOLUTION
# → OK
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced detection of sensitive credentials to prevent accidental storage of API keys, authentication tokens, and other secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->