### PR TITLE
feat: add agent testing framework with isolated AI sessions (t118)

### DIFF
--- a/.agent/subagent-index.toon
+++ b/.agent/subagent-index.toon
@@ -29,7 +29,7 @@ seo/,Search optimization - keywords and rankings,dataforseo|serper|neuronwriter|
 content/,Content creation - copywriting and editorial,guidelines|humanise
 tools/content/,Content tools - summarization and extraction,summarize
 tools/social-media/,Social media tools - X/Twitter CLI,bird
-tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-review
+tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-review|agent-testing
 tools/build-mcp/,MCP development - creating MCP servers,build-mcp|server-patterns|api-wrapper|transports|deployment
 tools/ai-assistants/,AI tool integration - configuring assistants and headless dispatch,agno|capsolver|windsurf|claude-code|configuration|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
@@ -77,7 +77,7 @@ bug-fixing,workflows/bug-fixing.md,Bug fix workflow
 feature-development,workflows/feature-development.md,Feature development workflow
 -->
 
-<!--TOON:scripts[35]{name,purpose}:
+<!--TOON:scripts[36]{name,purpose}:
 list-keys-helper.sh,List all API keys with storage locations
 linters-local.sh,Run local linting (ShellCheck secretlint patterns)
 code-audit-helper.sh,Run remote auditing (CodeRabbit Codacy SonarCloud)
@@ -109,6 +109,7 @@ email-health-check-helper.sh,Email deliverability check (SPF DKIM DMARC MX black
 yt-dlp-helper.sh,YouTube video/audio download and local file conversion
 privacy-filter-helper.sh,Privacy filter for public PR contributions
 self-improve-helper.sh,Self-improving agent system (analyze refine test pr)
+agent-test-helper.sh,Agent testing framework (run run-one compare baseline list create results)
 cron-helper.sh,Cron job management for scheduled AI agent dispatch
 cron-dispatch.sh,Execute cron jobs via OpenCode server API
 runner-helper.sh,Named headless AI agent instances (create run status list edit logs stop destroy)

--- a/.agent/tools/build-agent/agent-testing.md
+++ b/.agent/tools/build-agent/agent-testing.md
@@ -1,0 +1,285 @@
+---
+name: agent-testing
+description: Agent testing framework - validate agent behavior with isolated AI sessions
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# Agent Testing Framework
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Script**: `agent-test-helper.sh [run|run-one|compare|baseline|list|create|results|help]`
+- **Test suites**: JSON files in `~/.aidevops/.agent-workspace/agent-tests/suites/`
+- **Results**: `~/.aidevops/.agent-workspace/agent-tests/results/`
+- **Baselines**: `~/.aidevops/.agent-workspace/agent-tests/baselines/`
+- **CLI support**: Auto-detects `claude` or `opencode` (override with `AGENT_TEST_CLI`)
+
+**When to use**:
+
+- Validating agent changes before merging
+- Regression testing after modifying AGENTS.md or subagents
+- Comparing agent behavior across models
+- Smoke testing after framework updates
+
+<!-- AI-CONTEXT-END -->
+
+## Architecture
+
+```text
+                    ┌──────────────────────────────┐
+                    │     agent-test-helper.sh      │
+                    ├──────────────────────────────┤
+                    │  Test Suite (JSON)            │
+                    │  ├── Prompt definitions       │
+                    │  ├── Expected patterns        │
+                    │  └── Pass/fail criteria       │
+                    └──────────┬───────────────────┘
+                               │
+              ┌────────────────┼────────────────┐
+              │                │                │
+     Claude Code CLI    OpenCode CLI     OpenCode Server
+     (claude -p)        (opencode run)   (HTTP API)
+              │                │                │
+              └────────────────┼────────────────┘
+                               │
+                    ┌──────────┴───────────────┐
+                    │  Validation Engine        │
+                    │  ├── expect_contains      │
+                    │  ├── expect_not_contains  │
+                    │  ├── expect_regex         │
+                    │  ├── min/max_length       │
+                    │  └── Pass/Fail verdict    │
+                    └──────────────────────────┘
+```
+
+## Test Suite Format
+
+Test suites are JSON files defining prompts and expected response patterns:
+
+```json
+{
+  "name": "build-agent-tests",
+  "description": "Validates build-agent subagent knowledge",
+  "agent": "Build+",
+  "model": "anthropic/claude-sonnet-4-20250514",
+  "timeout": 120,
+  "tests": [
+    {
+      "id": "instruction-budget",
+      "prompt": "What is the recommended instruction budget for agents?",
+      "expect_contains": ["50", "100"],
+      "expect_not_contains": ["unlimited"],
+      "min_length": 50
+    },
+    {
+      "id": "progressive-disclosure",
+      "prompt": "Explain the progressive disclosure pattern for agents",
+      "expect_contains": ["subagent", "on-demand"],
+      "expect_regex": "read.*when.*needed",
+      "min_length": 100
+    }
+  ]
+}
+```
+
+### Validation Options
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `expect_contains` | `string[]` | Response must contain each string (case-insensitive) |
+| `expect_not_contains` | `string[]` | Response must NOT contain any of these |
+| `expect_regex` | `string` | Response must match this regex (case-insensitive) |
+| `expect_not_regex` | `string` | Response must NOT match this regex |
+| `min_length` | `number` | Minimum response length in characters |
+| `max_length` | `number` | Maximum response length in characters |
+| `skip` | `boolean` | Skip this test (useful for temporarily disabling) |
+
+### Per-Test Overrides
+
+Each test can override suite-level defaults:
+
+```json
+{
+  "id": "slow-test",
+  "prompt": "Generate a comprehensive analysis...",
+  "agent": "plan",
+  "model": "anthropic/claude-opus-4-20250514",
+  "timeout": 300,
+  "expect_contains": ["analysis"]
+}
+```
+
+## Commands
+
+### Run a Test Suite
+
+```bash
+# By file path
+agent-test-helper.sh run path/to/suite.json
+
+# By name (looks in suites/ directory)
+agent-test-helper.sh run build-agent-tests
+```
+
+### Quick Single-Prompt Test
+
+```bash
+# Basic test
+agent-test-helper.sh run-one "What is your primary purpose?"
+
+# With expected pattern
+agent-test-helper.sh run-one "List your tools" --expect "bash"
+
+# With specific agent and model
+agent-test-helper.sh run-one "Explain git workflow" \
+  --agent "Build+" \
+  --model "anthropic/claude-sonnet-4-20250514" \
+  --timeout 60
+```
+
+### Before/After Comparison
+
+The comparison workflow validates that agent changes don't cause regressions:
+
+```bash
+# 1. Save current behavior as baseline
+agent-test-helper.sh baseline my-tests
+
+# 2. Make agent changes (edit AGENTS.md, subagents, etc.)
+
+# 3. Compare against baseline
+agent-test-helper.sh compare my-tests
+```
+
+The comparison reports:
+
+- Per-test status changes (pass -> fail = regression, fail -> pass = fix)
+- Overall pass/fail count changes
+- Non-zero exit code if regressions detected
+
+### Manage Test Suites
+
+```bash
+# Create a template
+agent-test-helper.sh create my-new-tests
+
+# List available suites
+agent-test-helper.sh list
+
+# View recent results
+agent-test-helper.sh results
+agent-test-helper.sh results my-tests  # Filter by name
+```
+
+## CLI Detection
+
+The framework auto-detects the available AI CLI:
+
+1. **Claude Code** (`claude -p`): Preferred when available
+2. **OpenCode server** (`curl` to HTTP API): Used when OpenCode server is running
+3. **OpenCode CLI** (`opencode run`): Fallback for OpenCode without server
+
+Override with `AGENT_TEST_CLI=claude` or `AGENT_TEST_CLI=opencode`.
+
+## Example Test Suites
+
+### AGENTS.md Knowledge Test
+
+Tests that the agent has absorbed key instructions from AGENTS.md:
+
+```json
+{
+  "name": "agents-md-knowledge",
+  "description": "Validates core AGENTS.md instruction absorption",
+  "timeout": 90,
+  "tests": [
+    {
+      "id": "pre-edit-check",
+      "prompt": "What must you run before editing any file?",
+      "expect_contains": ["pre-edit-check"],
+      "expect_regex": "pre-edit-check\\.sh"
+    },
+    {
+      "id": "file-discovery",
+      "prompt": "How should you find git-tracked files?",
+      "expect_contains": ["git ls-files"],
+      "expect_not_contains": ["mcp_glob", "Glob"]
+    },
+    {
+      "id": "security-credentials",
+      "prompt": "Where should credentials be stored?",
+      "expect_contains": ["mcp-env.sh"],
+      "expect_regex": "600"
+    }
+  ]
+}
+```
+
+### Subagent Behavior Test
+
+Tests that a specific subagent provides correct guidance:
+
+```json
+{
+  "name": "git-workflow-tests",
+  "description": "Validates git workflow subagent behavior",
+  "agent": "Build+",
+  "tests": [
+    {
+      "id": "branch-naming",
+      "prompt": "What branch naming conventions should I use?",
+      "expect_contains": ["feature/", "bugfix/"],
+      "min_length": 100
+    },
+    {
+      "id": "worktree-usage",
+      "prompt": "When should I use git worktrees?",
+      "expect_contains": ["worktree", "parallel"],
+      "min_length": 50
+    }
+  ]
+}
+```
+
+## Integration with CI/CD
+
+Run agent tests in CI pipelines:
+
+```bash
+# In GitHub Actions or similar
+agent-test-helper.sh run agents-md-knowledge || {
+  echo "Agent tests failed - check for regressions"
+  exit 1
+}
+```
+
+Requires an AI CLI available in the CI environment (e.g., `claude` with API key or `opencode` with server).
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AGENT_TEST_CLI` | auto-detect | Force `claude` or `opencode` |
+| `AGENT_TEST_MODEL` | (suite default) | Override model for all tests |
+| `AGENT_TEST_TIMEOUT` | `120` | Default timeout in seconds |
+| `OPENCODE_HOST` | `localhost` | OpenCode server host |
+| `OPENCODE_PORT` | `4096` | OpenCode server port |
+
+## Related
+
+- `build-agent.md` - Agent design and composition
+- `agent-review.md` - Reviewing and improving agents
+- `tools/ai-assistants/headless-dispatch.md` - Headless AI dispatch patterns
+- `tools/ai-assistants/opencode-server.md` - OpenCode server API
+- `scripts/self-improve-helper.sh` - Self-improving agent system (uses similar session patterns)

--- a/.agent/tools/build-agent/build-agent.md
+++ b/.agent/tools/build-agent/build-agent.md
@@ -34,6 +34,7 @@ mode: subagent
 | Subagent | When to Read |
 |----------|--------------|
 | `agent-review.md` | Reviewing and improving existing agents |
+| `agent-testing.md` | Testing agent behavior with isolated AI sessions |
 
 **Related Agents**:
 - `@code-standards` for linting agent markdown
@@ -44,13 +45,18 @@ mode: subagent
 - Branch strategy: `workflows/branch.md`
 - Git operations: `tools/git.md`
 
-**Testing**: Use OpenCode CLI to test config changes without restarting TUI:
+**Testing**: Use `agent-test-helper.sh` for automated testing, or OpenCode/Claude CLI for quick manual tests:
 
 ```bash
-opencode run "Test query" --agent Build+
-```text
+# Automated test suite
+agent-test-helper.sh run my-tests
 
-See `tools/opencode/opencode.md` for CLI testing patterns.
+# Quick manual test
+claude -p "Test query"
+opencode run "Test query" --agent Build+
+```
+
+See `agent-testing.md` for the full testing framework.
 
 <!-- AI-CONTEXT-END -->
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The result: AI agents that work *with* your development process, not around it.
 
 - Primary agents (Build+, SEO, Marketing, etc.) with @plan-plus subagent for planning-only mode
 - 614+ subagent markdown files organized by domain
-- 164 helper scripts in `.agent/scripts/`
+- 165 helper scripts in `.agent/scripts/`
 - 28 slash commands for common workflows
 
 <!-- AI-CONTEXT-END -->
@@ -480,7 +480,7 @@ aidevops implements proven agent design patterns identified by [Lance Martin (La
 
 | Pattern | Description | aidevops Implementation |
 |---------|-------------|------------------------|
-| **Give Agents a Computer** | Filesystem + shell for persistent context | `~/.aidevops/.agent-workspace/`, 164 helper scripts |
+| **Give Agents a Computer** | Filesystem + shell for persistent context | `~/.aidevops/.agent-workspace/`, 165 helper scripts |
 | **Multi-Layer Action Space** | Few tools, push actions to computer | Per-agent MCP filtering (~12-20 tools each) |
 | **Progressive Disclosure** | Load context on-demand | Subagent routing with content summaries, YAML frontmatter, read-on-demand |
 | **Offload Context** | Write results to filesystem | `.agent-workspace/work/[project]/` for persistence |


### PR DESCRIPTION
## Summary

- Add `agent-test-helper.sh` for testing agent behavior through isolated Claude Code or OpenCode sessions
- Add `agent-testing.md` subagent documentation with test suite format, examples, and CI/CD guidance
- Auto-detects `claude` or `opencode` CLI, with OpenCode server API fallback

## What's New

### agent-test-helper.sh (~600 lines)
- **Commands**: `run`, `run-one`, `compare`, `baseline`, `list`, `create`, `results`
- **Test suites**: JSON format with prompts and validation rules
- **Validation**: `expect_contains`, `expect_not_contains`, `expect_regex`, `min_length`, `max_length`
- **Before/after comparison**: Save baselines, detect regressions after agent changes
- **Multi-CLI**: Auto-detects Claude Code (`claude -p`) or OpenCode (`opencode run` / server API)

### agent-testing.md
- Full documentation with architecture diagram, test suite format, examples
- Example test suites for AGENTS.md knowledge testing and subagent behavior validation
- CI/CD integration guidance

### Updates
- `build-agent.md`: Added agent-testing.md to subagents table, updated Testing section
- `subagent-index.toon`: Added agent-testing to build-agent folder, added script entry (36 scripts)
- `README.md`: Updated helper script count (164 → 165)

## Quality
- ShellCheck: 0 violations
- Markdown lint: 0 errors
- No secrets in new files

## Task
Closes t118: Agent testing framework with OpenCode sessions