### PR TITLE
fix(security): remove eval in ampcode-cli.sh, use arrays + format whitelist

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -53,7 +53,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 ## Backlog
 
 - [ ] t104 Install script integrity hardening (replace curl|sh with verified downloads) #security #supply-chain #plan → [todo/PLANS.md#2026-02-03-install-script-integrity-hardening] ~1.5h (ai:45m test:30m read:15m) logged:2026-02-03
-- [ ] t105 Remove eval in ampcode-cli.sh (use arrays + whitelist formats) #security #shell ~15m (ai:10m test:5m) logged:2026-02-03
+- [ ] t105 Remove eval in ampcode-cli.sh (use arrays + whitelist formats) #security #shell ~15m (ai:10m test:5m) logged:2026-02-03 started:2026-02-06T12:00Z
 - [x] t106 Replace eval in system-cleanup.sh find command construction with safe args #security #shell ~1h actual:15m (ai:15m) logged:2026-02-03 completed:2026-02-06
 - [x] t107 Avoid eval-based export in credential-helper.sh; use safe output/quoting #security #shell ~1h actual:20m (ai:20m) logged:2026-02-03 completed:2026-02-06
 - [ ] t108 Dashboard token storage hardening (avoid localStorage; add reset/clear flow) #security #dashboard #plan → [todo/PLANS.md#2026-02-03-dashboard-token-storage-hardening] ~1h (ai:30m test:20m read:10m) logged:2026-02-03


### PR DESCRIPTION
## Summary

- Replace all 4 `eval` usages in ampcode-cli.sh with bash arrays (`local -a cmd=(...)` + `"${cmd[@]}"`) to prevent shell injection
- Add `ALLOWED_OUTPUT_FORMATS` whitelist to validate user-supplied format parameter
- Fix broken JSON heredoc in `setup_ampcode_config()` (stray `return 0` inside JSON body)
- Remove 5 unreachable `return 0` statements (ShellCheck SC2317)
- Reduce shellcheck disable list from 23 codes to 2

## Task

Closes t105 from TODO.md

## Testing

- `shellcheck -x ampcode-cli.sh` passes with zero violations
- `bash -n ampcode-cli.sh` syntax check passes
- `rg 'eval ' ampcode-cli.sh` returns no matches