### PR TITLE
feat: add cron integration and auto-pickup to supervisor (t128.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ Coordinator (pulse loop)
 |-----------|--------|---------|
 | Mailbox | `mail-helper.sh` | SQLite-backed inter-agent messaging (send, check, broadcast, archive) |
 | Coordinator | `coordinator-helper.sh` | Stateless pulse loop: collect reports, dispatch tasks, track idle workers |
-| Supervisor | `supervisor-helper.sh` | Autonomous multi-task orchestration with SQLite state machine, batches, retry cycles |
+| Supervisor | `supervisor-helper.sh` | Autonomous multi-task orchestration with SQLite state machine, batches, retry cycles, cron scheduling, auto-pickup from TODO.md |
 | Registry | `mail-helper.sh register` | Agent registration with role, branch, worktree, heartbeat |
 | Model routing | `model-routing.md`, `/route` | Cost-aware 5-tier routing guidance (haiku/flash/sonnet/pro/opus) |
 


### PR DESCRIPTION
## Summary

- Add `auto-pickup` command: scans TODO.md for `#auto-dispatch` tagged tasks and tasks in a `## Dispatch Queue` section, auto-adds them to supervisor
- Add `cron` command: install/uninstall/status for cron-based pulse scheduling (default `*/5 * * * *`)
- Add `watch` command: fswatch-based TODO.md watcher as real-time alternative to cron
- Integrate auto-pickup into pulse cycle as Phase 0 (runs before worker checks and dispatch)

## Task

Closes t128.5 from the Autonomous Supervisor Loop plan (t128).

## Changes

| File | Change |
|------|--------|
| `.agent/scripts/supervisor-helper.sh` | +3 commands (`auto-pickup`, `cron`, `watch`), Phase 0 in pulse, updated help text |
| `README.md` | Updated supervisor description to mention cron/auto-pickup |

## Testing

- Bash syntax check: PASS
- ShellCheck: zero violations
- `auto-pickup` tested with mock TODO.md: correctly picks up 2 tagged + 2 queued tasks, skips untagged and completed
- `cron install/uninstall/status` cycle tested: installs, shows status, uninstalls cleanly
- `watch` tested: correctly reports fswatch not found with install instructions

## Auto-Pickup Strategies

1. **Tag-based**: Tasks with `#auto-dispatch` anywhere in the line
2. **Section-based**: All open tasks under a `## Dispatch Queue` header (until next section)

Both skip tasks already tracked by the supervisor (any state except complete/cancelled).