### PR TITLE
feat: create Screaming Frog subagent (t086)

### DIFF
--- a/.agent/seo.md
+++ b/.agent/seo.md
@@ -10,6 +10,7 @@ subagents:
   - serper
   - ahrefs
   - site-crawler
+  - screaming-frog
   - eeat-score
   - domain-research
   - pagespeed
@@ -42,6 +43,7 @@ subagents:
 | `dataforseo.md` | Comprehensive SEO data APIs (SERP, keywords, backlinks) |
 | `serper.md` | Google Search API (web, images, news, places) |
 | `site-crawler.md` | SEO site auditing (Screaming Frog-like capabilities) |
+| `screaming-frog.md` | Screaming Frog SEO Spider CLI integration |
 | `eeat-score.md` | E-E-A-T content quality scoring and analysis |
 | `google-analytics.md` | GA4 reporting, traffic analysis, and user behavior (see `services/analytics/`) |
 | `data-export.md` | Export SEO data from GSC, Bing, Ahrefs, DataForSEO to TOON format |

--- a/.agent/seo/screaming-frog.md
+++ b/.agent/seo/screaming-frog.md
@@ -1,0 +1,69 @@
+---
+description: Screaming Frog SEO Spider CLI integration for site auditing and crawling
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+---
+
+# Screaming Frog SEO Spider Integration
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Advanced site crawling and SEO auditing via CLI
+- **License**: **Paid license required** for CLI automation ($259/yr)
+- **Free Tier**: GUI only, limited to 500 URLs (CLI not supported in free mode)
+- **Command**: `screamingfrogseospider` (requires alias/path setup)
+- **Output**: Headless mode supports CSV, PDF, and Google Sheets exports
+
+## Prerequisites
+
+1. **Installation**: Download from [screamingfrog.co.uk](https://www.screamingfrog.co.uk/seo-spider/)
+2. **License**: Enter license key in GUI first (`Help > Enter License`)
+3. **CLI Setup**:
+   - **macOS**: Alias required (see below)
+   - **Linux**: Standard package install
+   - **Windows**: Path configuration required
+
+## Setup
+
+### macOS Alias
+Add to `~/.zshrc` or `~/.bashrc`:
+```bash
+alias screamingfrogseospider="/Applications/Screaming\ Frog\ SEO\ Spider.app/Contents/MacOS/ScreamingFrogSEOSpiderLauncher"
+```
+
+### Verification
+```bash
+screamingfrogseospider --help
+```
+
+## Usage
+
+### Basic Crawl
+```bash
+screamingfrogseospider --crawl https://example.com --headless --output-folder ./reports
+```
+
+### Configuration
+- **Save Config**: Configure in GUI, save as `profile.seospiderconfig`
+- **Load Config**: Use `--config profile.seospiderconfig`
+
+### Export Options
+- `--export-tabs "Internal:All,Response Codes:All"`
+- `--save-crawl` (saves .seospider file)
+- `--bulk-export "All Inlinks"`
+
+## Integration with AI DevOps
+
+- **Audit**: Use for deep technical audits when `site-crawler` is insufficient
+- **Validation**: Verify fixes by re-crawling specific paths
+- **Reporting**: Generate CSVs for analysis by other agents
+
+<!-- AI-CONTEXT-END -->

--- a/.agent/subagent-index.toon
+++ b/.agent/subagent-index.toon
@@ -25,7 +25,7 @@ pro,gemini-2.5-pro,Capable large context
 <!--TOON:subagents[39]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison
 memory/,Cross-session memory - SQLite FTS5 storage,README
-seo/,Search optimization - keywords and rankings,dataforseo|serper|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools
+seo/,Search optimization - keywords and rankings,dataforseo|serper|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog
 content/,Content creation - copywriting and editorial,guidelines|humanise
 tools/content/,Content tools - summarization and extraction,summarize
 tools/social-media/,Social media tools - X/Twitter CLI,bird


### PR DESCRIPTION
## Summary
- Created `.agent/seo/screaming-frog.md` subagent for Screaming Frog SEO Spider CLI integration
- Updated `.agent/seo.md` to include the new subagent
- Updated `.agent/subagent-index.toon` to include the new subagent
- Marked task t086 as completed in `TODO.md`

## Context
Task t086: Create Screaming Frog subagent #seo #tools #crawler
This subagent documents the CLI usage for Screaming Frog, including license requirements and free tier limits.