### PR TITLE
feat(seo): add Rich Results Test subagent (t084)

### DIFF
--- a/.agent/seo.md
+++ b/.agent/seo.md
@@ -18,6 +18,9 @@ subagents:
   - data-export
   - ranking-opportunities
   - analytics-tracking
+  - rich-results
+  - debug-opengraph
+  - debug-favicon
   - general
   - explore
 ---
@@ -49,6 +52,9 @@ subagents:
 | `data-export.md` | Export SEO data from GSC, Bing, Ahrefs, DataForSEO to TOON format |
 | `ranking-opportunities.md` | Analyze data for quick wins, striking distance, cannibalization |
 | `analytics-tracking.md` | GA4 setup, event tracking, conversions, UTM parameters, attribution |
+| `rich-results.md` | Google Rich Results Test via browser automation (API deprecated) |
+| `debug-opengraph.md` | Validate Open Graph meta tags for social sharing |
+| `debug-favicon.md` | Validate favicon setup across platforms |
 
 **Key Operations**:
 - Keyword research with weakness detection (`/keyword-research-extended`)

--- a/.agent/seo/rich-results.md
+++ b/.agent/seo/rich-results.md
@@ -1,0 +1,149 @@
+---
+description: Google Rich Results Test via browser automation (API deprecated)
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+---
+
+# Google Rich Results Test
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Validate structured data and preview rich snippets
+- **URL**: `https://search.google.com/test/rich-results`
+- **API Status**: **Deprecated** (standalone API no longer available)
+- **Method**: Browser automation (Playwright) or manual testing
+- **Alternatives**: Schema.org Validator (`https://validator.schema.org/`)
+
+## Manual Testing
+
+1. Go to [Google Rich Results Test](https://search.google.com/test/rich-results)
+2. Enter the URL to test or paste the code snippet
+3. Select "Smartphone" or "Desktop" user agent
+4. Click "Test URL" or "Test Code"
+5. Review critical errors, non-critical issues, and preview the result
+
+## Browser Automation (Playwright)
+
+Since the API is deprecated, use Playwright to automate the testing process.
+
+### Test a URL
+
+```javascript
+// rich-results-test.js
+import { chromium } from 'playwright';
+
+const TEST_URL = process.argv[2];
+
+if (!TEST_URL) {
+  console.error('Usage: node rich-results-test.js <url>');
+  process.exit(1);
+}
+
+async function main() {
+  const browser = await chromium.launch({ headless: false });
+  const page = await browser.newPage();
+
+  console.log(`Testing: ${TEST_URL}`);
+
+  await page.goto('https://search.google.com/test/rich-results');
+
+  // Wait for input field and enter URL
+  const input = await page.waitForSelector(
+    'input[type="url"], input[type="text"]',
+    { timeout: 10000 }
+  );
+  await input.fill(TEST_URL);
+  await page.keyboard.press('Enter');
+
+  console.log('Test started... waiting for results (up to 60s)');
+  console.log('Complete CAPTCHA if prompted.');
+
+  try {
+    await page.waitForSelector('.result-card, .error-card, [data-result]', {
+      timeout: 60000,
+    });
+    console.log('Results loaded.');
+
+    await page.screenshot({ path: 'rich-results.png', fullPage: true });
+    console.log('Screenshot saved to rich-results.png');
+  } catch {
+    console.log('Timed out waiting for results or CAPTCHA encountered.');
+    await page.screenshot({ path: 'rich-results-timeout.png', fullPage: true });
+  }
+
+  // Keep open for manual inspection
+  // await browser.close();
+}
+
+main().catch(console.error);
+```
+
+Run with:
+
+```bash
+node rich-results-test.js https://example.com
+```
+
+### Batch Testing
+
+```bash
+# Test multiple URLs
+for url in https://example.com https://example.com/article https://example.com/product; do
+  echo "--- Testing: $url ---"
+  node rich-results-test.js "$url"
+  sleep 5
+done
+```
+
+<!-- AI-CONTEXT-END -->
+
+## Schema Validation (Alternative)
+
+For pure syntax validation without Google's rendering context, use the Schema.org Validator.
+
+- **URL**: `https://validator.schema.org/`
+- **Advantage**: Faster, no CAPTCHA, API-friendly
+- **Disadvantage**: Does not show Google-specific eligibility (e.g., Merchant Center requirements)
+
+### Quick JSON-LD Extraction
+
+```bash
+# Extract JSON-LD from a page
+curl -sL "https://example.com" \
+  | grep -oE '<script type="application/ld\+json">[^<]+</script>' \
+  | sed 's/<[^>]*>//g' \
+  | jq . 2>/dev/null || echo "No valid JSON-LD found"
+```
+
+## Rich Result Types
+
+Google supports rich results for these structured data types:
+
+| Type | Schema | Common Use |
+|------|--------|------------|
+| Article | `Article`, `NewsArticle` | Blog posts, news |
+| Product | `Product` | E-commerce listings |
+| FAQ | `FAQPage` | Question/answer pages |
+| HowTo | `HowTo` | Step-by-step guides |
+| Recipe | `Recipe` | Cooking instructions |
+| Review | `Review` | Product/service reviews |
+| Event | `Event` | Upcoming events |
+| LocalBusiness | `LocalBusiness` | Business listings |
+| BreadcrumbList | `BreadcrumbList` | Navigation breadcrumbs |
+| VideoObject | `VideoObject` | Video content |
+| JobPosting | `JobPosting` | Job listings |
+| Course | `Course` | Educational content |
+
+## Related
+
+- `seo/debug-opengraph.md` - Open Graph meta tag validation
+- `seo/site-crawler.md` - Bulk structured data auditing
+- `tools/browser/playwright.md` - Browser automation for JS-rendered pages

--- a/.agent/subagent-index.toon
+++ b/.agent/subagent-index.toon
@@ -25,7 +25,7 @@ pro,gemini-2.5-pro,Capable large context
 <!--TOON:subagents[39]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison
 memory/,Cross-session memory - SQLite FTS5 storage,README
-seo/,Search optimization - keywords and rankings,dataforseo|serper|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog
+seo/,Search optimization - keywords and rankings,dataforseo|serper|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon
 content/,Content creation - copywriting and editorial,guidelines|humanise
 tools/content/,Content tools - summarization and extraction,summarize
 tools/social-media/,Social media tools - X/Twitter CLI,bird

--- a/TODO.md
+++ b/TODO.md
@@ -201,8 +201,8 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 - [x] t083 Create Bing Webmaster Tools subagent #seo #tools ~15m actual:10m (ai:10m test:3m read:2m) logged:2026-01-29 completed:2026-02-06 related:seo-audit-skill
   - Notes: Created .agent/seo/bing-webmaster-tools.md with curl-based API integration. Added to subagent-index.toon.
   - Notes: API integration for Bing Webmaster Tools. Features: submit URLs, check indexation status, view search analytics, manage sitemaps. Ref: https://www.bing.com/webmasters/help/webmaster-api-5f3c5e1e
-- [ ] t084 Create Rich Results Test subagent #seo #tools #schema ~10m (ai:8m test:1m read:1m) logged:2026-01-29 related:seo-audit-skill
-  - Notes: Google Rich Results Test API integration. Validate structured data, preview rich snippets, check eligibility for rich results. Add to tools/seo/ or seo/. Ref: https://search.google.com/test/rich-results BLOCKED: auth_error BLOCKED: Max retries exceeded: clean_exit_no_signal
+- [x] t084 Create Rich Results Test subagent #seo #tools #schema ~10m (ai:8m test:1m read:1m) logged:2026-01-29 related:seo-audit-skill completed:2026-02-06
+  - Notes: Created seo/rich-results.md. Google deprecated the standalone API, so the subagent documents manual testing and provides a Playwright script for browser automation. Also references Schema.org Validator as an alternative.
 - [x] t085 Create Schema Validator subagent #seo #tools #schema ~10m (ai:8m test:1m read:1m) logged:2026-01-29 related:seo-audit-skill completed:2026-02-06
   - Notes: Schema.org validator integration. Validate JSON-LD, Microdata, RDFa structured data. Add to tools/seo/ or seo/. Ref: https://validator.schema.org/
 - [x] t086 Create Screaming Frog subagent #seo #tools #crawler ~15m (ai:10m test:3m read:2m) logged:2026-01-29 related:seo-audit-skill completed:2026-02-06

--- a/todo/tasks/t084-rich-results.md
+++ b/todo/tasks/t084-rich-results.md
@@ -1,0 +1,13 @@
+# Task: Create Rich Results Test subagent (t084)
+
+- [x] t084 Create Rich Results Test subagent #seo #tools #schema ~10m (ai:8m test:1m read:1m) logged:2026-01-29 related:seo-audit-skill completed:2026-02-06
+  - Notes: Google Rich Results Test API integration. Validate structured data, preview rich snippets, check eligibility for rich results. Add to tools/seo/ or seo/. Ref: https://search.google.com/test/rich-results
+  - Update: Google deprecated the standalone API. Use URL-based testing only; document browser automation approach.
+
+## Plan
+
+1.  [x] Create `~/.aidevops/agents/seo/rich-results.md` with instructions for Rich Results testing.
+2.  [x] Include instructions for manual testing via URL.
+3.  [x] Include instructions/script for browser-based automation (opening the URL).
+4.  [x] Update `~/.aidevops/agents/seo.md` to index the new subagent.
+5.  [x] Verify the subagent content.


### PR DESCRIPTION
## Summary

- Create `seo/rich-results.md` subagent for Google Rich Results Test validation
- Google deprecated the standalone API, so the subagent documents manual testing and provides a Playwright script for browser automation
- References Schema.org Validator as an alternative for syntax-only validation
- Includes rich result types reference table (Article, Product, FAQ, HowTo, etc.)

## Changes

- **New**: `.agent/seo/rich-results.md` - Rich Results Test subagent
- **Updated**: `.agent/seo.md` - Added rich-results, debug-opengraph, debug-favicon to subagents list and table
- **Updated**: `.agent/subagent-index.toon` - Added rich-results, debug-opengraph, debug-favicon to seo/ key_files
- **Updated**: `TODO.md` - Marked t084 complete
- **New**: `todo/tasks/t084-rich-results.md` - Task tracking file

Closes t084.