### PR TITLE
feat: add AI bot review verification to pr-loop and full-loop workflows (t129)

### DIFF
--- a/.agent/AGENTS.md
+++ b/.agent/AGENTS.md
@@ -258,6 +258,10 @@ aidevops features                # List available features
 
 **CLI**: `aidevops [init|update|status|repos|skill|detect|features|uninstall]`
 
+## Bot Reviewer Feedback
+
+AI code review bots (Gemini, CodeRabbit, Copilot) can provide incorrect suggestions. **Never blindly implement bot feedback.** Verify factual claims (versions, paths, APIs) against runtime/docs/project conventions before acting. Dismiss incorrect suggestions with evidence; address valid ones.
+
 ## Quality Workflow
 
 ```text

--- a/.agent/prompts/build.txt
+++ b/.agent/prompts/build.txt
@@ -97,6 +97,13 @@ For loop mode: `pre-edit-check.sh --loop-mode --task "description"`
 - Use GitHub-flavored markdown
 - Use numbered options for user prompts (never "[Enter] to confirm")
 
+# AI Suggestion Verification
+Never apply AI tool suggestions (from code review bots, linters with AI explanations, or
+automated PR reviewers) without independent verification. AI reviewers can hallucinate —
+claiming Docker image versions don't exist, flagging correct file paths as wrong, or
+suggesting fixes that break working code. Always verify factual claims against runtime,
+documentation, or project conventions before acting on them.
+
 # Model-Specific Reinforcements
 These apply to all models but reinforce behaviours some need more than others:
 - NEVER end your turn without completing the task. Keep working until fully resolved.

--- a/.agent/scripts/commands/full-loop.md
+++ b/.agent/scripts/commands/full-loop.md
@@ -334,7 +334,7 @@ loop until **PR is merged** (max: 20):
     session "Fix CI issues and push"
   
   if **changes requested**:
-    session "Address review feedback and push"
+    session "Evaluate review feedback: verify factual claims against runtime/docs/project conventions, dismiss incorrect suggestions with evidence, address valid ones, then push"
 
 # Phase 5: Postflight
 session "Verify release health"

--- a/.agent/scripts/commands/pr-loop.md
+++ b/.agent/scripts/commands/pr-loop.md
@@ -51,8 +51,19 @@ The script performs these checks each iteration:
 
 If issues are found:
 - CI failures: Report and wait for fixes
-- Changes requested: Report feedback for addressing
+- Changes requested: **Verify before acting** (see below), then address valid feedback
 - Stale review: Auto-trigger re-review (unless `--no-auto-trigger`)
+
+### AI Bot Review Verification
+
+When a review bot (Gemini, CodeRabbit, Copilot, etc.) requests changes, **verify factual claims before implementing**. AI reviewers can hallucinate - e.g., claiming a Docker image version doesn't exist when it does, or flagging correct file paths as wrong.
+
+**Verification steps:**
+
+1. **Check factual claims** - Verify version numbers, file paths, API signatures against runtime/docs/project conventions
+2. **Dismiss incorrect suggestions** - Reply with evidence (e.g., "Image exists: `docker manifest inspect image:tag`")
+3. **Address valid feedback** - Implement suggestions that are technically correct
+4. **Re-request review** - Push fixes and trigger re-review for remaining items
 
 ## Completion Promises
 

--- a/.agent/scripts/commands/pr-loop.md
+++ b/.agent/scripts/commands/pr-loop.md
@@ -60,7 +60,7 @@ When a review bot (Gemini, CodeRabbit, Copilot, etc.) requests changes, **verify
 
 **Verification steps:**
 
-1. **Check factual claims** - Verify version numbers, file paths, API signatures against runtime/docs/project conventions
+1. **Check factual claims** - Verify version numbers, file paths, API signatures against runtime, documentation, or project conventions
 2. **Dismiss incorrect suggestions** - Reply with evidence (e.g., "Image exists: `docker manifest inspect image:tag`")
 3. **Address valid feedback** - Implement suggestions that are technically correct
 4. **Re-request review** - Push fixes and trigger re-review for remaining items

--- a/.agent/scripts/quality-loop-helper.sh
+++ b/.agent/scripts/quality-loop-helper.sh
@@ -908,7 +908,8 @@ pr_review_loop() {
             CHANGES_REQUESTED)
                 print_warning "Changes requested. Getting feedback..."
                 get_pr_feedback "$pr_number"
-                print_info "Address the feedback and push updates."
+                print_warning "IMPORTANT: Verify bot suggestions before implementing — AI reviewers can hallucinate (wrong versions, non-existent issues, incorrect paths). Check claims against runtime/docs first."
+                print_info "Address verified feedback and push updates."
                 ;;
             WAITING)
                 print_info "Waiting for review..."

--- a/.agent/scripts/quality-loop-helper.sh
+++ b/.agent/scripts/quality-loop-helper.sh
@@ -908,7 +908,7 @@ pr_review_loop() {
             CHANGES_REQUESTED)
                 print_warning "Changes requested. Getting feedback..."
                 get_pr_feedback "$pr_number"
-                print_warning "IMPORTANT: Verify bot suggestions before implementing — AI reviewers can hallucinate (wrong versions, non-existent issues, incorrect paths). Check claims against runtime/docs first."
+                print_warning "IMPORTANT: Verify AI bot suggestions before implementing — reviewers can hallucinate. Check claims against runtime/docs first."
                 print_info "Address verified feedback and push updates."
                 ;;
             WAITING)


### PR DESCRIPTION
## Summary

- Add verification steps before acting on AI bot review feedback (CHANGES_REQUESTED) across pr-loop, full-loop, and quality-loop workflows
- AI code review bots (Gemini, CodeRabbit, Copilot) can hallucinate — claiming Docker image versions don't exist, flagging correct file paths as wrong, or suggesting fixes that break working code
- This ensures agents verify factual claims against runtime/docs/project conventions before implementing bot suggestions

## Changes

| File | Change |
|------|--------|
| `pr-loop.md` | Added "AI Bot Review Verification" section with 4-step verification workflow |
| `full-loop.md` | Updated OpenProse example to include evaluation step for review feedback |
| `quality-loop-helper.sh` | Added warning message in CHANGES_REQUESTED handler |
| `build.txt` | Added "AI Suggestion Verification" rule |
| `AGENTS.md` | Added "Bot Reviewer Feedback" guidance section |

## Task

Closes t129 from TODO.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance to always verify AI code-review suggestions against runtime, docs, and project conventions before applying.
  * Introduced a clear verification workflow: check factual claims, dismiss incorrect suggestions with evidence, and address valid feedback.
  * Inserted explicit reminders in PR and review guidance to validate AI recommendations and re-run lint/type checks after changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->