### PR TITLE
fix: resolve SonarCloud security hotspots for clear-text protocols and npm ignore-scripts

### DIFF
--- a/.agent/scripts/agent-test-helper.sh
+++ b/.agent/scripts/agent-test-helper.sh
@@ -77,10 +77,10 @@ AI_CLI="$(detect_cli)"
 readonly AI_CLI
 readonly DEFAULT_TIMEOUT="${AGENT_TEST_TIMEOUT:-120}"
 
-# OpenCode server defaults
+# OpenCode server defaults (localhost-only, HTTP is intentional for local dev server)
 readonly OPENCODE_HOST="${OPENCODE_HOST:-localhost}"
 readonly OPENCODE_PORT="${OPENCODE_PORT:-4096}"
-readonly OPENCODE_URL="http://${OPENCODE_HOST}:${OPENCODE_PORT}"
+readonly OPENCODE_URL="http://${OPENCODE_HOST}:${OPENCODE_PORT}" # NOSONAR - localhost dev server, no TLS needed
 
 # Colors
 readonly GREEN='\033[0;32m'
@@ -111,6 +111,7 @@ ensure_dirs() {
 # Check if OpenCode server is running
 #######################################
 check_opencode_server() {
+    # NOSONAR - localhost dev server health check, HTTP is intentional
     if curl -s --max-time 3 "${OPENCODE_URL}/global/health" > /dev/null 2>&1; then
         return 0
     fi
@@ -213,6 +214,7 @@ run_prompt_opencode_server() {
     local session_payload
     session_payload=$(jq -n --arg title "agent-test-$(date +%s)" '{"title": $title}')
     local session_response
+    # NOSONAR - localhost dev server API call, HTTP is intentional
     session_response=$(curl -s --max-time 10 -X POST "${OPENCODE_URL}/session" \
         -H "Content-Type: application/json" \
         -d "$session_payload")
@@ -231,6 +233,7 @@ run_prompt_opencode_server() {
     prompt_json=$(jq -n --arg text "$prompt" '{"parts": [{"type": "text", "text": $text}]}')
 
     local response
+    # NOSONAR - localhost dev server API call, HTTP is intentional
     response=$(curl -s --max-time "$timeout" -X POST \
         "${OPENCODE_URL}/session/${session_id}/message" \
         -H "Content-Type: application/json" \
@@ -244,7 +247,7 @@ run_prompt_opencode_server() {
         result=$(echo "$response" | jq -r '.content // .text // .message // empty' 2>/dev/null)
     fi
 
-    # Clean up session
+    # Clean up session (NOSONAR - localhost dev server, HTTP is intentional)
     curl -s -X DELETE "${OPENCODE_URL}/session/${session_id}" > /dev/null 2>&1 || true
 
     echo "$result"

--- a/.agent/scripts/schema-validator-helper.sh
+++ b/.agent/scripts/schema-validator-helper.sh
@@ -105,8 +105,7 @@ install_deps() {
     # Install packages if missing
     if [[ ! -d "$TOOL_DIR/node_modules/@adobe/structured-data-validator" ]]; then
         print_info "Installing @adobe/structured-data-validator, @marbec/web-auto-extractor, node-fetch..."
-        # NOSONAR - npm scripts required for schema validation dependencies
-        (cd "$TOOL_DIR" && npm install @adobe/structured-data-validator @marbec/web-auto-extractor node-fetch --silent) || {
+        (cd "$TOOL_DIR" && npm install --ignore-scripts @adobe/structured-data-validator @marbec/web-auto-extractor node-fetch --silent) || {
             print_error "Failed to install npm dependencies"
             return 1
         }


### PR DESCRIPTION
## Summary

Resolves all 9 open SonarCloud security hotspots on the `main` branch (new code period):

- **8x `shell:S5332`** ("Make sure that using clear-text protocols is safe here.") in `agent-test-helper.sh` - Added NOSONAR comments documenting that HTTP is intentional for localhost-only OpenCode dev server communication (loopback, no TLS needed)
- **1x `shell:S6505`** ("Omitting --ignore-scripts can lead to execution of shell scripts.") in `schema-validator-helper.sh` - Added `--ignore-scripts` flag to `npm install` to prevent arbitrary script execution from npm packages

## Changes

### `agent-test-helper.sh`
- Added descriptive comment explaining localhost-only HTTP usage
- Added `# NOSONAR` suppression on URL construction and each `curl` call to the local OpenCode server API
- No functional changes - all HTTP calls remain to `localhost:4096` (loopback only)

### `schema-validator-helper.sh`
- Added `--ignore-scripts` to `npm install` command for `@adobe/structured-data-validator`, `@marbec/web-auto-extractor`, and `node-fetch` (pure JS packages that don't require post-install scripts)
- Removed now-unnecessary `# NOSONAR` comment that was insufficient to suppress the hotspot

## SonarCloud Reference

https://sonarcloud.io/project/security_hotspots?id=marcusquinn_aidevops&branch=main&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation process to skip npm lifecycle scripts during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->