### PR TITLE
feat: integrate Cisco Skill Scanner for security scanning of imported skills

### DIFF
--- a/.agents/tools/code-review/skill-scanner.md
+++ b/.agents/tools/code-review/skill-scanner.md
@@ -1,0 +1,142 @@
+---
+description: Cisco Skill Scanner for detecting threats in AI agent skills
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# Cisco Skill Scanner - Agent Skill Security
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Type**: Security scanner for AI Agent Skills (SKILL.md, AGENTS.md, scripts)
+- **Source**: [cisco-ai-defense/skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) (Apache 2.0)
+- **Install**: `uv pip install cisco-ai-skill-scanner` or `pip install cisco-ai-skill-scanner`
+- **Run without install**: `uvx cisco-ai-skill-scanner scan /path/to/skill`
+- **aidevops integration**: `aidevops skill scan` or `security-helper.sh skill-scan`
+- **Formats**: summary, json, markdown, table, sarif
+- **Exit codes**: 0=safe, 1=findings detected
+
+## Threat Detection
+
+| Category | AITech Code | Severity | Detection |
+|----------|-------------|----------|-----------|
+| Prompt injection | AITech-1.1/1.2 | HIGH-CRITICAL | YAML + YARA + LLM |
+| Command injection | AITech-9.1.4 | CRITICAL | YAML + YARA + LLM |
+| Data exfiltration | AITech-8.2 | CRITICAL | YAML + YARA + LLM |
+| Hardcoded secrets | AITech-8.2 | CRITICAL | YAML + YARA + LLM |
+| Tool/permission abuse | AITech-12.1 | MEDIUM-CRITICAL | Python + YARA |
+| Obfuscation | - | MEDIUM-CRITICAL | YAML + YARA + binary |
+| Capability inflation | AITech-4.3 | LOW-HIGH | YAML + YARA + Python |
+| Indirect prompt injection | AITech-1.2 | HIGH | YARA + LLM |
+| Autonomy abuse | AITech-13.1 | MEDIUM-HIGH | YAML + YARA + LLM |
+| Tool chaining | AITech-8.2.3 | HIGH | YARA + LLM |
+
+## Analysis Engines
+
+| Engine | Cost | Speed | Requirements |
+|--------|------|-------|-------------|
+| Static (YAML + YARA) | Free | ~150ms | None |
+| Behavioral (AST dataflow) | Free | ~150ms | None |
+| LLM-as-judge | API cost | ~2s | `SKILL_SCANNER_LLM_API_KEY` |
+| Meta-analyzer (FP filter) | API cost | ~1s | `SKILL_SCANNER_LLM_API_KEY` |
+| VirusTotal | Free tier | ~1s | `VIRUSTOTAL_API_KEY` |
+| Cisco AI Defense | Enterprise | ~1s | `AI_DEFENSE_API_KEY` |
+
+## aidevops Integration Points
+
+### Import-time scanning (automatic)
+
+When `skill-scanner` is installed, `add-skill-helper.sh` automatically scans
+skills during import. CRITICAL/HIGH findings block import unless `--force`.
+
+### Batch scanning
+
+```bash
+# Scan all imported skills
+aidevops skill scan
+
+# Scan specific skill
+aidevops skill scan cloudflare-platform
+
+# Via security-helper directly
+security-helper.sh skill-scan all
+security-helper.sh skill-scan cloudflare-platform
+```
+
+### Setup-time scanning
+
+`setup.sh` runs a security scan on all imported skills during `aidevops update`.
+Non-blocking: findings are reported but don't halt setup.
+
+### Update-time scanning
+
+`skill-update-helper.sh update` re-imports via `add-skill-helper.sh --force`,
+which triggers the security scan on the updated content.
+
+## CLI Usage
+
+```bash
+# Static-only scan (fast, no API key)
+skill-scanner scan /path/to/skill
+
+# With behavioral analysis
+skill-scanner scan /path/to/skill --use-behavioral
+
+# Full scan with LLM
+skill-scanner scan /path/to/skill --use-behavioral --use-llm
+
+# With false-positive filtering
+skill-scanner scan /path/to/skill --use-llm --enable-meta
+
+# Batch scan
+skill-scanner scan-all /path/to/skills --recursive
+
+# CI/CD mode
+skill-scanner scan-all ./skills --fail-on-findings --format sarif --output results.sarif
+
+# Custom YARA rules
+skill-scanner scan /path/to/skill --custom-rules /path/to/rules/
+
+# Disable noisy rules
+skill-scanner scan /path/to/skill --disable-rule YARA_script_injection
+
+# Permissive mode (fewer findings)
+skill-scanner scan /path/to/skill --yara-mode permissive
+```
+
+## Environment Variables
+
+```bash
+# LLM analyzer (optional)
+export SKILL_SCANNER_LLM_API_KEY="your_api_key"
+export SKILL_SCANNER_LLM_MODEL="claude-3-5-sonnet-20241022"
+
+# VirusTotal (optional)
+export VIRUSTOTAL_API_KEY="your_key"
+
+# Cisco AI Defense (optional)
+export AI_DEFENSE_API_KEY="your_key"
+```
+
+Store keys in `~/.config/aidevops/mcp-env.sh` (600 permissions).
+
+## Response Guidelines
+
+| Severity | Action |
+|----------|--------|
+| CRITICAL | Do not import. Remove if already imported. |
+| HIGH | Block import. Review before allowing with `--force`. |
+| MEDIUM | Warn. Review findings and plan fixes. |
+| LOW | Informational. Address in future. |
+
+<!-- AI-CONTEXT-END -->

--- a/README.md
+++ b/README.md
@@ -468,10 +468,11 @@ aidevops skill add clawdhub:<slug> # Import a skill from ClawdHub
 aidevops skill list                # List imported skills
 aidevops skill check               # Check for upstream updates
 aidevops skill update [name]       # Update specific or all skills
+aidevops skill scan [name]         # Security scan skills (Cisco Skill Scanner)
 aidevops skill remove <name>       # Remove an imported skill
 ```
 
-Skills are registered in `~/.aidevops/agents/configs/skill-sources.json` with upstream tracking for update detection. Telemetry is disabled - no data is sent to third parties.
+Skills are registered in `~/.aidevops/agents/configs/skill-sources.json` with upstream tracking for update detection. Imported skills are automatically security-scanned using [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner) when installed (CRITICAL/HIGH findings block import). Telemetry is disabled - no data is sent to third parties.
 
 **Browse community skills:** [skills.sh](https://skills.sh) | [ClawdHub](https://clawdhub.com) | **Specification:** [agentskills.io](https://agentskills.io)
 
@@ -775,6 +776,7 @@ The setup script offers to install these tools automatically.
 - **[Snyk](https://snyk.io/)**: Security vulnerability scanning
 - **[Socket](https://socket.dev/)**: Dependency security and supply chain protection
 - **[Sentry](https://sentry.io/)**: Error monitoring and performance tracking
+- **[Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner)**: Security scanner for AI agent skills (prompt injection, exfiltration, malicious code)
 - **[Secretlint](https://github.com/secretlint/secretlint)**: Detect exposed secrets in code
 - **[OSV Scanner](https://google.github.io/osv-scanner/)**: Google's vulnerability database scanner
 - **[Qlty](https://qlty.sh/)**: Universal code quality platform (70+ linters, auto-fixes)

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1872,6 +1872,15 @@ cmd_skill() {
             print_info "Generating SKILL.md stubs for cross-tool discovery..."
             bash "$generate_script" "$@"
             ;;
+        scan)
+            local security_script="$AGENTS_DIR/scripts/security-helper.sh"
+            if [[ ! -f "$security_script" ]]; then
+                print_error "security-helper.sh not found"
+                print_info "Run 'aidevops update' to get the latest scripts"
+                return 1
+            fi
+            bash "$security_script" skill-scan "$@"
+            ;;
         clean)
             local generate_script="$AGENTS_DIR/scripts/generate-skills.sh"
             if [[ ! -f "$generate_script" ]]; then
@@ -1895,6 +1904,7 @@ cmd_skill() {
             echo "  check            Check for upstream updates"
             echo "  update [name]    Update specific or all skills"
             echo "  remove <name>    Remove an imported skill"
+            echo "  scan [name]      Security scan imported skills (Cisco Skill Scanner)"
             echo "  status           Show detailed skill status"
             echo "  generate         Generate SKILL.md stubs for cross-tool discovery"
             echo "  clean            Remove generated SKILL.md stubs"
@@ -1910,6 +1920,8 @@ cmd_skill() {
             echo "  aidevops skill add expo/skills --name expo-dev"
             echo "  aidevops skill check"
             echo "  aidevops skill update"
+            echo "  aidevops skill scan"
+            echo "  aidevops skill scan cloudflare-platform"
             echo "  aidevops skill generate --dry-run"
             echo ""
             echo "Imported skills are saved with a -skill suffix to distinguish"


### PR DESCRIPTION
## Summary

- Integrates [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner) (Apache 2.0) to detect prompt injection, data exfiltration, command injection, hardcoded secrets, and other threats in imported AI agent skills
- Closes the security gap where imported skills underwent zero validation before being placed in `.agents/` and symlinked to AI assistant locations
- Scanner is optional -- gracefully degrades when not installed, never blocks setup or existing workflows

## Integration Points

| When | Where | Behavior |
|------|-------|----------|
| **Import-time** | `add-skill-helper.sh` | Scans before registration; CRITICAL/HIGH blocks import unless `--force` |
| **On-demand** | `aidevops skill scan [name]` | Batch scan all or specific imported skills |
| **Setup-time** | `setup.sh` | Scans during `aidevops update` (non-blocking) |
| **Update-time** | `skill-update-helper.sh` | Re-scans via import pipeline on skill update |

## Changes

- **`security-helper.sh`**: New `cmd_skill_scan` function, status/install/routing updates (+187 lines)
- **`add-skill-helper.sh`**: New `scan_skill_security` function wired into GitHub and ClawdHub import paths (+116 lines)
- **`aidevops.sh`**: New `scan` subcommand under `aidevops skill` (+12 lines)
- **`setup.sh`**: New `scan_imported_skills` step after `check_skill_updates` (+28 lines)
- **`skill-scanner.md`**: New subagent documentation for the tool
- **`README.md`**: Added skill scanner to Security & Code Quality section and skill commands

## Testing

- ShellCheck: zero violations on all modified scripts
- Tested `security-helper.sh skill-scan all` -- successfully scans all 8 imported skills
- Tested `security-helper.sh status` -- shows Skill Scanner availability
- Graceful degradation verified when scanner not installed