### PR TITLE
fix: surface AI reviewer feedback posted as COMMENTED in pr-loop WAITING state

### DIFF
--- a/.agents/scripts/commands/pr-loop.md
+++ b/.agents/scripts/commands/pr-loop.md
@@ -52,6 +52,7 @@ The script performs these checks each iteration:
 If issues are found:
 - CI failures: Report and wait for fixes
 - Changes requested: **Verify before acting** (see below), then address valid feedback
+- Unresolved AI feedback (COMMENTED): Some bots (e.g., Gemini Code Assist) post as `COMMENTED` rather than `CHANGES_REQUESTED`, so GitHub's `reviewDecision` stays `NONE`. The loop detects unresolved review threads and surfaces this feedback for action.
 - Stale review: Auto-trigger re-review (unless `--no-auto-trigger`)
 
 ### AI Bot Review Verification

--- a/.agents/scripts/quality-loop-helper.sh
+++ b/.agents/scripts/quality-loop-helper.sh
@@ -919,7 +919,9 @@ pr_review_loop() {
                 check_unresolved_review_comments "$pr_number"
                 waiting_unresolved_result=$?
                 
-                if [[ $waiting_unresolved_result -eq 1 ]]; then
+                if [[ $waiting_unresolved_result -eq 2 ]]; then
+                    print_warning "Could not verify AI review status (API error) - proceeding with caution"
+                elif [[ $waiting_unresolved_result -eq 1 ]]; then
                     print_warning "AI reviewers left unresolved feedback (review posted as COMMENTED, not CHANGES_REQUESTED)"
                     get_pr_feedback "$pr_number"
                     print_warning "IMPORTANT: Verify AI bot suggestions before implementing — reviewers can hallucinate. Check claims against runtime/docs first."


### PR DESCRIPTION
## Summary

- PR review loop's `WAITING` path now detects unresolved review threads from AI bots (Gemini Code Assist, etc.) that post as `COMMENTED` rather than `CHANGES_REQUESTED`
- Previously, these reviews were invisible to the loop because GitHub's `reviewDecision` stayed `NONE`
- Uses the existing `check_unresolved_review_comments()` GraphQL function, consistent with how the `READY` path already handles this

## Problem

Bots like Gemini Code Assist submit reviews with state `COMMENTED` (not `CHANGES_REQUESTED`), so:
1. GitHub's `reviewDecision` remains `NONE`
2. The pr-loop enters the `WAITING` branch
3. Feedback is never surfaced for the agent to act on
4. The loop just waits and eventually triggers a CodeRabbit re-review

## Fix

The `WAITING` branch now calls `check_unresolved_review_comments()` first. If unresolved threads exist, it surfaces the feedback via `get_pr_feedback()` with the standard AI verification warning. Only falls through to stale-review logic if no unresolved threads are found.

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/quality-loop-helper.sh` | Add unresolved thread check to WAITING path |
| `.agents/scripts/commands/pr-loop.md` | Document new COMMENTED feedback detection |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and surfacing of unresolved AI feedback in pull request reviews, ensuring previously missed commented reviews are flagged for action.

* **Improvements**
  * Review workflow now checks for unresolved review threads and API errors before auto-triggering re-reviews, adds warnings, and prompts verification of AI suggestions prior to proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->