### PR TITLE
feat: separate --force from security scan bypass in skill imports

### DIFF
--- a/.agents/scripts/commands/add-skill.md
+++ b/.agents/scripts/commands/add-skill.md
@@ -91,7 +91,13 @@ If the skill conflicts with existing files, the helper will prompt:
 3. **Separate** - Use a different name for the imported skill
 4. **Skip** - Cancel the import
 
-### Step 4: Post-Import
+### Step 4: Security Scan
+
+Before registration, the skill is scanned using [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner) (if installed). CRITICAL/HIGH findings block the import. Use `--skip-security` to bypass (not recommended). The `--force` flag only controls file overwrite, not security bypass.
+
+Security scanning also runs on updates (`aidevops skill update`) -- pulling a new version triggers the same checks as the initial import.
+
+### Step 5: Post-Import
 
 After successful import:
 

--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -255,7 +255,7 @@ cmd_check() {
             echo -e "${YELLOW}UPDATE AVAILABLE${NC}: $name"
             echo "  Current: ${current_commit:0:7}"
             echo "  Latest:  ${latest_commit:0:7}"
-            echo "  Run: add-skill-helper.sh add $upstream_url --force"
+            echo "  Run: aidevops skill update $name"
             echo ""
             ((updates_available++)) || true
             results+=("{\"name\":\"$name\",\"status\":\"update_available\",\"current\":\"$current_commit\",\"latest\":\"$latest_commit\"}")

--- a/README.md
+++ b/README.md
@@ -472,7 +472,21 @@ aidevops skill scan [name]         # Security scan skills (Cisco Skill Scanner)
 aidevops skill remove <name>       # Remove an imported skill
 ```
 
-Skills are registered in `~/.aidevops/agents/configs/skill-sources.json` with upstream tracking for update detection. Imported skills are automatically security-scanned using [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner) when installed (CRITICAL/HIGH findings block import). Telemetry is disabled - no data is sent to third parties.
+Skills are registered in `~/.aidevops/agents/configs/skill-sources.json` with upstream tracking for update detection.
+
+**Security Scanning:**
+
+Imported skills are automatically security-scanned using [Cisco Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner) when installed. Scanning runs on both initial import and updates -- pulling a new version of a skill triggers the same security checks as the first import. CRITICAL/HIGH findings block the operation; MEDIUM/LOW findings warn but allow. Telemetry is disabled - no data is sent to third parties.
+
+| Scenario | Security scan runs? | CRITICAL/HIGH blocks? |
+|----------|--------------------|-----------------------|
+| `aidevops skill add <source>` | Yes | Yes |
+| `aidevops skill update [name]` | Yes | Yes |
+| `aidevops skill add <source> --force` | Yes | Yes |
+| `aidevops skill add <source> --skip-security` | Yes (reports only) | No (warns) |
+| `aidevops skill scan [name]` | Yes (standalone) | Report only |
+
+The `--force` flag only controls file overwrite behavior (replacing an existing skill without prompting). To bypass security blocking, use `--skip-security` explicitly -- this separation ensures that routine updates and re-imports never silently skip security checks.
 
 **Browse community skills:** [skills.sh](https://skills.sh) | [ClawdHub](https://clawdhub.com) | **Specification:** [agentskills.io](https://agentskills.io)
 


### PR DESCRIPTION
## Summary

- Separates `--force` (file overwrite) from `--skip-security` (security scan bypass) in skill import/update pipeline
- Ensures `aidevops skill update` always runs security scans on updated skills (previously `--force` silently bypassed CRITICAL/HIGH findings)
- Updates README with comprehensive security scanning documentation including behavior matrix table

## Changes

**`add-skill-helper.sh`**: New `--skip-security` flag for explicit security bypass. `--force` now only controls file overwrite. Updated help text, user-facing messages, and both GitHub and ClawdHub import paths.

**`skill-update-helper.sh`**: Updated user-facing "update available" message to suggest `aidevops skill update` instead of raw `--force` commands.

**`add-skill.md`**: Added Step 4 (Security Scan) to the workflow documentation explaining scan behavior on import and update.

**`README.md`**: Expanded Imported Skills section with security scanning details, behavior matrix table, and explanation of `--force` vs `--skip-security` separation.

## Why

Previously `--force` served dual purpose: overwriting existing files AND bypassing CRITICAL/HIGH security scan findings. Since `skill-update-helper.sh` passes `--force` to handle file overwrite during updates, this meant all skill updates silently skipped security checks. Now the concerns are separated so updates are always scanned.