### PR TITLE
feat: auto-install Cisco Skill Scanner during setup

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -499,7 +499,7 @@ scan_skill_security() {
         scanner_cmd="pipx run cisco-ai-skill-scanner"
     else
         log_info "Skill Scanner not installed (skipping security scan)"
-        log_info "Install with: uv pip install cisco-ai-skill-scanner"
+        log_info "Install with: uv tool install cisco-ai-skill-scanner"
         return 0
     fi
     

--- a/.agents/scripts/security-helper.sh
+++ b/.agents/scripts/security-helper.sh
@@ -396,11 +396,11 @@ cmd_skill_scan() {
         echo -e "${YELLOW}Cisco Skill Scanner not installed.${NC}"
         echo ""
         echo "Install with:"
-        echo "  uv pip install cisco-ai-skill-scanner"
-        echo "  # or run without installing"
-        echo "  uvx cisco-ai-skill-scanner scan /path/to/skill"
+        echo "  uv tool install cisco-ai-skill-scanner"
         echo "  # or via pip"
-        echo "  pip install cisco-ai-skill-scanner"
+        echo "  pip3 install --user cisco-ai-skill-scanner"
+        echo "  # or run setup.sh to auto-install"
+        echo "  aidevops update"
         echo ""
         return 1
     fi
@@ -677,11 +677,11 @@ cmd_install() {
         skill-scanner|cisco-ai-skill-scanner)
             echo "Installing Cisco Skill Scanner..."
             if check_command uv; then
-                uv pip install cisco-ai-skill-scanner
-            elif check_command pip; then
-                pip install cisco-ai-skill-scanner
+                uv tool install cisco-ai-skill-scanner
+            elif check_command pip3; then
+                pip3 install --user cisco-ai-skill-scanner
             else
-                echo -e "${RED}Please install uv or pip first${NC}"
+                echo -e "${RED}Please install uv or pip3 first${NC}"
                 return 1
             fi
             ;;
@@ -711,9 +711,9 @@ cmd_install() {
             if ! check_command skill-scanner; then
                 echo -e "${CYAN}Installing Cisco Skill Scanner...${NC}"
                 if check_command uv; then
-                    uv pip install cisco-ai-skill-scanner || true
-                elif check_command pip; then
-                    pip install cisco-ai-skill-scanner || true
+                    uv tool install cisco-ai-skill-scanner || true
+                elif check_command pip3; then
+                    pip3 install --user cisco-ai-skill-scanner || true
                 fi
             fi
             

--- a/.agents/tools/code-review/skill-scanner.md
+++ b/.agents/tools/code-review/skill-scanner.md
@@ -20,7 +20,7 @@ tools:
 
 - **Type**: Security scanner for AI Agent Skills (SKILL.md, AGENTS.md, scripts)
 - **Source**: [cisco-ai-defense/skill-scanner](https://github.com/cisco-ai-defense/skill-scanner) (Apache 2.0)
-- **Install**: `uv pip install cisco-ai-skill-scanner` or `pip install cisco-ai-skill-scanner`
+- **Install**: `uv tool install cisco-ai-skill-scanner` (auto-installed by `setup.sh`)
 - **Run without install**: `uvx cisco-ai-skill-scanner scan /path/to/skill`
 - **aidevops integration**: `aidevops skill scan` or `security-helper.sh skill-scan`
 - **Formats**: summary, json, markdown, table, sarif


### PR DESCRIPTION
## Summary

- `setup.sh` now auto-installs `cisco-ai-skill-scanner` via `uv tool install` during the `scan_imported_skills` step
- Falls back to `pip3 install --user` if `uv` is not available
- Updated all install hints across the codebase from `uv pip install` to `uv tool install` (creates isolated env with binary on PATH)
- Verified: scanner installs successfully and scans all 8 imported skills (all pass)

## Why

The previous PR (#400) integrated the scanner but relied on it being pre-installed or available via `uvx`. In practice, `uvx` had a broken Python interpreter path, so the scanner was silently not running. This ensures it's actually installed and functional.

## Changes

- **`setup.sh`**: `scan_imported_skills()` now installs the scanner if missing, using `run_with_spinner` for consistent UX
- **`security-helper.sh`**: Updated install commands and hints to use `uv tool install`
- **`add-skill-helper.sh`**: Updated install hint
- **`skill-scanner.md`**: Updated install docs

## Testing

- `uv tool install cisco-ai-skill-scanner` -- installs 91 packages including yara-python (C extension compiles successfully)
- `skill-scanner scan` -- produces real JSON output with findings
- `security-helper.sh skill-scan all` -- scans all 8 imported skills, all pass
- ShellCheck: zero violations