### PR TITLE
feat: gopass integration & credentials rename (t131)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -75,7 +75,7 @@ For long-running processes: use `&`, `nohup`, or `screen`/`tmux`. For parallel A
 - **Purpose**: DevOps automation across multiple services
 - **Getting Started**: `/onboarding` - Interactive setup wizard
 - **Scripts**: `~/.aidevops/agents/scripts/[service]-helper.sh [command] [account] [target]`
-- **Credentials**: `~/.config/aidevops/mcp-env.sh` (600 permissions)
+- **Credentials**: `~/.config/aidevops/credentials.sh` (600 permissions)
 - **Subagent Index**: `subagent-index.toon` (agents, subagents, workflows, scripts)
 
 **Critical Rules**:
@@ -280,7 +280,7 @@ Import community skills: `aidevops skill add <source>` (→ `*-skill.md` suffix)
 
 ## Security
 
-- Credentials: `~/.config/aidevops/mcp-env.sh` (600 permissions)
+- Credentials: `~/.config/aidevops/credentials.sh` (600 permissions)
 - Config templates: `configs/*.json.txt` (committed), working: `configs/*.json` (gitignored)
 - Confirm destructive operations before execution
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -75,7 +75,7 @@ For long-running processes: use `&`, `nohup`, or `screen`/`tmux`. For parallel A
 - **Purpose**: DevOps automation across multiple services
 - **Getting Started**: `/onboarding` - Interactive setup wizard
 - **Scripts**: `~/.aidevops/agents/scripts/[service]-helper.sh [command] [account] [target]`
-- **Credentials**: `~/.config/aidevops/credentials.sh` (600 permissions)
+- **Secrets**: `aidevops secret` (gopass encrypted) or `~/.config/aidevops/credentials.sh` (plaintext fallback)
 - **Subagent Index**: `subagent-index.toon` (agents, subagents, workflows, scripts)
 
 **Critical Rules**:
@@ -280,9 +280,14 @@ Import community skills: `aidevops skill add <source>` (→ `*-skill.md` suffix)
 
 ## Security
 
-- Credentials: `~/.config/aidevops/credentials.sh` (600 permissions)
+- **Encrypted secrets** (recommended): `aidevops secret` (gopass backend, GPG-encrypted)
+- **Plaintext fallback**: `~/.config/aidevops/credentials.sh` (600 permissions)
 - Config templates: `configs/*.json.txt` (committed), working: `configs/*.json` (gitignored)
 - Confirm destructive operations before execution
+
+**Secret handling rule**: When a user needs to store a secret, ALWAYS instruct them to run `aidevops secret set NAME` at their terminal. NEVER accept secret values in conversation context. NEVER run `gopass show`, `cat credentials.sh`, or any command that prints secret values.
+
+**Full docs**: `tools/credentials/gopass.md`, `tools/credentials/api-key-setup.md`
 
 ## Working Directories
 

--- a/.agents/aidevops.md
+++ b/.agents/aidevops.md
@@ -118,7 +118,7 @@ configs/[service]-config.json.txt
 configs/[service]-config.json
 
 # Credentials
-~/.config/aidevops/mcp-env.sh
+~/.config/aidevops/credentials.sh
 ```text
 
 ## Quality Standards

--- a/.agents/aidevops/mcp-integrations.md
+++ b/.agents/aidevops/mcp-integrations.md
@@ -117,7 +117,7 @@ claude mcp add claude-code-mcp "npx -y github:marcusquinn/claude-code-mcp"
 
 ```bash
 # Get your standard 40-char API key (NOT JWT tokens) from https://ahrefs.com/api
-# Store in ~/.config/aidevops/mcp-env.sh:
+# Store in ~/.config/aidevops/credentials.sh:
 export AHREFS_API_KEY="your_40_char_api_key"
 
 # For Claude Desktop:
@@ -167,7 +167,7 @@ cd fluentcrm-mcp-server
 npm install
 npm run build
 
-# 2. Store credentials in ~/.config/aidevops/mcp-env.sh:
+# 2. Store credentials in ~/.config/aidevops/credentials.sh:
 export FLUENTCRM_API_URL="https://your-domain.com/wp-json/fluent-crm/v2"
 export FLUENTCRM_API_USERNAME="your_username"
 export FLUENTCRM_API_PASSWORD="your_application_password"
@@ -179,7 +179,7 @@ export FLUENTCRM_API_PASSWORD="your_application_password"
 {
   "fluentcrm": {
     "type": "local",
-    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && node ~/.local/share/mcp-servers/fluentcrm-mcp-server/dist/fluentcrm-mcp-server.js"],
+    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/credentials.sh && node ~/.local/share/mcp-servers/fluentcrm-mcp-server/dist/fluentcrm-mcp-server.js"],
     "enabled": false
   }
 }
@@ -215,10 +215,10 @@ See `services/crm/fluentcrm.md` for detailed documentation.
 # 1. Self-hosted (recommended): unstract-helper.sh install
 # 2. Or cloud: Sign up at https://unstract.com/start-for-free/
 # 3. Create a Prompt Studio project, define schema, deploy as API
-# 4. Store credentials in ~/.config/aidevops/mcp-env.sh:
+# 4. Store credentials in ~/.config/aidevops/credentials.sh:
 export UNSTRACT_API_KEY="your_api_key_here"
 export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
-chmod 600 ~/.config/aidevops/mcp-env.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 **Note**: The MCP expects `API_BASE_URL` (not prefixed) - this matches the official Unstract spec.
@@ -229,7 +229,7 @@ chmod 600 ~/.config/aidevops/mcp-env.sh
 {
   "unstract": {
     "type": "local",
-    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL -e DISABLE_TELEMETRY=true unstract/mcp-server:${UNSTRACT_IMAGE_TAG:-latest} unstract"],
+    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/credentials.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL -e DISABLE_TELEMETRY=true unstract/mcp-server:${UNSTRACT_IMAGE_TAG:-latest} unstract"],
     "enabled": false
   }
 }

--- a/.agents/aidevops/mcp-troubleshooting.md
+++ b/.agents/aidevops/mcp-troubleshooting.md
@@ -25,7 +25,7 @@ tools:
 | "Config file is invalid" | Unrecognized key in config | Remove unsupported keys (see below) |
 | "Connection closed" | Wrong command or outdated version | Update tool, check command syntax |
 | "Command not found" | Tool not installed | `npm install -g {package}` |
-| "Permission denied" | Missing credentials | Check `~/.config/aidevops/mcp-env.sh` |
+| "Permission denied" | Missing credentials | Check `~/.config/aidevops/credentials.sh` |
 | "Timeout" | Server not starting | Check Node.js version, run manually |
 | "unauthorized" | HTTP server instead of MCP | Use correct MCP command (not serve) |
 

--- a/.agents/aidevops/security.md
+++ b/.agents/aidevops/security.md
@@ -19,7 +19,7 @@ tools:
 
 **Credential Rules**:
 - NEVER commit API tokens to git
-- Store in `~/.config/aidevops/mcp-env.sh` (600 permissions)
+- Store in `~/.config/aidevops/credentials.sh` (600 permissions)
 - Rotate tokens quarterly
 - Use least-privilege principle
 

--- a/.agents/aidevops/setup.md
+++ b/.agents/aidevops/setup.md
@@ -39,7 +39,7 @@ cd ~/Git/aidevops
 **Post-setup locations**:
 - Agents: `~/.aidevops/agents/`
 - Backups: `~/.aidevops/config-backups/`
-- Credentials: `~/.config/aidevops/mcp-env.sh`
+- Credentials: `~/.config/aidevops/credentials.sh`
 
 <!-- AI-CONTEXT-END -->
 
@@ -139,7 +139,7 @@ apt-get install jq curl  # Ubuntu/Debian
 
 ```bash
 # Ensure correct permissions
-chmod 600 ~/.config/aidevops/mcp-env.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 chmod 755 ~/.aidevops/agents/scripts/*.sh
 ```text
 

--- a/.agents/marketing.md
+++ b/.agents/marketing.md
@@ -93,10 +93,10 @@ FluentCRM provides self-hosted email marketing with full API access via MCP.
 
 **Environment Setup**:
 
-> **Security Note**: Never commit actual credentials to version control. Store environment variables in `~/.config/aidevops/mcp-env.sh` (600 permissions). Rotate application passwords regularly.
+> **Security Note**: Never commit actual credentials to version control. Store environment variables in `~/.config/aidevops/credentials.sh` (600 permissions). Rotate application passwords regularly.
 
 ```bash
-# Add to ~/.config/aidevops/mcp-env.sh
+# Add to ~/.config/aidevops/credentials.sh
 export FLUENTCRM_API_URL="https://your-domain.com/wp-json/fluent-crm/v2"
 export FLUENTCRM_API_USERNAME="your_username"
 export FLUENTCRM_API_PASSWORD="your_application_password"

--- a/.agents/memory/README.md
+++ b/.agents/memory/README.md
@@ -430,7 +430,7 @@ Document environment-specific issues that affect AI assistance:
 
 - **Never store credentials** in memory files
 - **Use configuration references** instead of actual API keys
-- **Keep sensitive data** in separate secure locations (`~/.config/aidevops/mcp-env.sh`)
+- **Keep sensitive data** in separate secure locations (`~/.config/aidevops/credentials.sh`)
 - **Regular cleanup** of outdated information
 - **No personal identifiable information** in shareable templates
 

--- a/.agents/onboarding.md
+++ b/.agents/onboarding.md
@@ -504,7 +504,7 @@ All credentials are stored securely:
 
 | Location | Purpose | Permissions |
 |----------|---------|-------------|
-| `~/.config/aidevops/mcp-env.sh` | Primary credential store | 600 |
+| `~/.config/aidevops/credentials.sh` | Primary credential store | 600 |
 | `~/.config/coderabbit/api_key` | CodeRabbit token | 600 |
 | `configs/*-config.json` | Service-specific configs | 600, gitignored |
 
@@ -575,11 +575,11 @@ For new users, suggest this order based on their interests:
 ### Key not loading
 
 ```bash
-# Check if mcp-env.sh is sourced
-grep "mcp-env.sh" ~/.zshrc ~/.bashrc
+# Check if credentials.sh is sourced
+grep "credentials.sh" ~/.zshrc ~/.bashrc
 
 # Source manually
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 
 # Verify
 echo "${OPENAI_API_KEY:0:10}..."
@@ -599,7 +599,7 @@ opencode mcp list
 
 ```bash
 # Fix permissions
-chmod 600 ~/.config/aidevops/mcp-env.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 chmod 700 ~/.config/aidevops
 ```
 

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -194,7 +194,7 @@ export async function AidevopsPlugin({ directory }) {
           "## Critical Rules to Preserve",
           "- File discovery: use `git ls-files` not Glob",
           "- Git workflow: run pre-edit-check.sh before any file modifications",
-          "- Security: credentials only in ~/.config/aidevops/mcp-env.sh",
+          "- Security: credentials only in ~/.config/aidevops/credentials.sh",
           "- Working directory: ~/.aidevops/.agent-workspace/work/[project]/",
           "- Quality: ShellCheck zero violations, SonarCloud A-grade",
         ].join("\n")

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -52,7 +52,9 @@ When referencing specific functions or code include the pattern `file_path:line_
 
 # Security Rules
 - NEVER expose credentials in output/logs
-- Store secrets ONLY in `~/.config/aidevops/credentials.sh` (600 permissions)
+- Store secrets via `aidevops secret set NAME` (gopass encrypted) or `~/.config/aidevops/credentials.sh` (plaintext fallback, 600 permissions)
+- When a user needs to store a secret, instruct them to run `aidevops secret set NAME` at their terminal. NEVER accept secret values in conversation.
+- NEVER run `gopass show`, `cat credentials.sh`, `echo $SECRET`, or any command that prints secret values
 - Confirm destructive operations before execution
 - NEVER create files in `~/` root - use `~/.aidevops/.agent-workspace/work/[project]/`
 - Do not commit files containing secrets (.env, credentials.json, etc.)

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -52,7 +52,7 @@ When referencing specific functions or code include the pattern `file_path:line_
 
 # Security Rules
 - NEVER expose credentials in output/logs
-- Store secrets ONLY in `~/.config/aidevops/mcp-env.sh` (600 permissions)
+- Store secrets ONLY in `~/.config/aidevops/credentials.sh` (600 permissions)
 - Confirm destructive operations before execution
 - NEVER create files in `~/` root - use `~/.aidevops/.agent-workspace/work/[project]/`
 - Do not commit files containing secrets (.env, credentials.json, etc.)

--- a/.agents/sales.md
+++ b/.agents/sales.md
@@ -91,10 +91,10 @@ FluentCRM provides a self-hosted WordPress CRM with full API access via MCP.
 
 **Environment Setup**:
 
-> **Security Note**: Never commit actual credentials to version control. Store environment variables in `~/.config/aidevops/mcp-env.sh` (600 permissions). Rotate application passwords regularly.
+> **Security Note**: Never commit actual credentials to version control. Store environment variables in `~/.config/aidevops/credentials.sh` (600 permissions). Rotate application passwords regularly.
 
 ```bash
-# Add to ~/.config/aidevops/mcp-env.sh
+# Add to ~/.config/aidevops/credentials.sh
 export FLUENTCRM_API_URL="https://your-domain.com/wp-json/fluent-crm/v2"
 export FLUENTCRM_API_USERNAME="your_username"
 export FLUENTCRM_API_PASSWORD="your_application_password"

--- a/.agents/scripts/ampcode-cli.sh
+++ b/.agents/scripts/ampcode-cli.sh
@@ -71,7 +71,7 @@ ensure_results_dir() {
 
 # Load API configuration
 load_api_config() {
-    # Check environment variable first (set via mcp-env.sh, sourced by .zshrc)
+    # Check environment variable first (set via credentials.sh, sourced by .zshrc)
     if [[ -n "${AMPCODE_API_KEY:-}" ]]; then
         print_info "Using AmpCode API key from environment"
         return 0
@@ -89,7 +89,7 @@ load_api_config() {
     fi
 
     print_warning "AMPCODE_API_KEY not found in environment"
-    print_info "Add to ~/.config/aidevops/mcp-env.sh:"
+    print_info "Add to ~/.config/aidevops/credentials.sh:"
     print_info "  export AMPCODE_API_KEY=\"your-api-key\""
     return 1
 }
@@ -175,7 +175,7 @@ setup_ampcode_config() {
     # Load existing config
     if ! load_api_config; then
         print_info "Please visit https://ampcode.com to get your API key"
-        print_info "Then run: Add AMPCODE_API_KEY to ~/.config/aidevops/mcp-env.sh"
+        print_info "Then run: Add AMPCODE_API_KEY to ~/.config/aidevops/credentials.sh"
         return 1
     fi
 
@@ -478,7 +478,7 @@ show_help() {
     echo "Setup:"
     echo "  1. Visit https://ampcode.com to create account"
     echo "  2. Get your API key"
-    echo "  3. Run: Add AMPCODE_API_KEY to ~/.config/aidevops/mcp-env.sh"
+    echo "  3. Run: Add AMPCODE_API_KEY to ~/.config/aidevops/credentials.sh"
     echo "  4. Run: $0 setup"
     echo ""
     echo "This script integrates AmpCode's professional AI coding assistant"

--- a/.agents/scripts/anti-detect-helper.sh
+++ b/.agents/scripts/anti-detect-helper.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=/dev/null
-[[ -f "$HOME/.config/aidevops/mcp-env.sh" ]] && source "$HOME/.config/aidevops/mcp-env.sh"
+[[ -f "$HOME/.config/aidevops/credentials.sh" ]] && source "$HOME/.config/aidevops/credentials.sh"
 
 PROFILES_DIR="$HOME/.aidevops/.agent-workspace/browser-profiles"
 VENV_DIR="$HOME/.aidevops/anti-detect-venv"

--- a/.agents/scripts/codacy-cli-chunked.sh
+++ b/.agents/scripts/codacy-cli-chunked.sh
@@ -138,7 +138,7 @@ check_codacy_ready() {
         return 1
     fi
 
-    # Load API key from environment (set via mcp-env.sh, sourced by .zshrc)
+    # Load API key from environment (set via credentials.sh, sourced by .zshrc)
     # CODACY_PROJECT_TOKEN is the standard env var name
     if [[ -z "${CODACY_API_TOKEN:-}" && -n "${CODACY_PROJECT_TOKEN:-}" ]]; then
         export CODACY_API_TOKEN="$CODACY_PROJECT_TOKEN"

--- a/.agents/scripts/codacy-cli.sh
+++ b/.agents/scripts/codacy-cli.sh
@@ -55,7 +55,7 @@ print_warning() {
 
 # Load API configuration
 load_api_config() {
-    # Check environment variable first (set via mcp-env.sh, sourced by .zshrc)
+    # Check environment variable first (set via credentials.sh, sourced by .zshrc)
     # CODACY_PROJECT_TOKEN is the standard env var name
     if [[ -z "${CODACY_API_TOKEN:-}" && -n "${CODACY_PROJECT_TOKEN:-}" ]]; then
         export CODACY_API_TOKEN="$CODACY_PROJECT_TOKEN"
@@ -67,7 +67,7 @@ load_api_config() {
         # API token should be set in environment variable
         if [[ -z "${CODACY_API_TOKEN:-}" ]]; then
             print_error "CODACY_API_TOKEN/CODACY_PROJECT_TOKEN not found in environment"
-            print_info "Add to ~/.config/aidevops/mcp-env.sh:"
+            print_info "Add to ~/.config/aidevops/credentials.sh:"
             print_info "  export CODACY_PROJECT_TOKEN=\"your-token\""
             return 1
         fi

--- a/.agents/scripts/coderabbit-cli.sh
+++ b/.agents/scripts/coderabbit-cli.sh
@@ -262,7 +262,7 @@ setup_api_key() {
 
 # Load API key from configuration
 load_api_key() {
-    # Check environment variable first (set via mcp-env.sh, sourced by .zshrc)
+    # Check environment variable first (set via credentials.sh, sourced by .zshrc)
     if [[ -n "${CODERABBIT_API_KEY:-}" ]]; then
         print_info "Using CodeRabbit API key from environment"
         return 0
@@ -274,11 +274,11 @@ load_api_key() {
         legacy_key=$(cat "$API_KEY_FILE")
         export CODERABBIT_API_KEY="$legacy_key"
         print_info "Loaded CodeRabbit API key from legacy storage"
-        print_warning "Consider migrating to ~/.config/aidevops/mcp-env.sh"
+        print_warning "Consider migrating to ~/.config/aidevops/credentials.sh"
         return 0
     else
         print_error "CODERABBIT_API_KEY not found in environment"
-        print_info "Add to ~/.config/aidevops/mcp-env.sh:"
+        print_info "Add to ~/.config/aidevops/credentials.sh:"
         print_info "  export CODERABBIT_API_KEY=\"your-api-key\""
         return 1
     fi

--- a/.agents/scripts/commands/neuronwriter.md
+++ b/.agents/scripts/commands/neuronwriter.md
@@ -30,7 +30,7 @@ If only a keyword is provided (no subcommand), default to `analyze`.
 ### Step 2: Check API Key
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 if [[ -z "$NEURONWRITER_API_KEY" ]]; then
   echo "NEURONWRITER_API_KEY not configured." >&2
   echo "Set it with: bash ~/.aidevops/agents/scripts/setup-local-api-keys.sh set NEURONWRITER_API_KEY \"your_key\"" >&2

--- a/.agents/scripts/commands/seo-export.md
+++ b/.agents/scripts/commands/seo-export.md
@@ -59,7 +59,7 @@ Target: $ARGUMENTS
 | Ahrefs | API key | `AHREFS_API_KEY` |
 | DataForSEO | Username/password | `DATAFORSEO_USERNAME`, `DATAFORSEO_PASSWORD` |
 
-All credentials should be set in `~/.config/aidevops/mcp-env.sh`.
+All credentials should be set in `~/.config/aidevops/credentials.sh`.
 
 ## Next Steps
 

--- a/.agents/scripts/credential-helper.sh
+++ b/.agents/scripts/credential-helper.sh
@@ -8,8 +8,10 @@
 # Active:  ~/.config/aidevops/active-tenant
 # Project: .aidevops-tenant (per-project override)
 #
+# For encrypted storage with gopass, use: secret-helper.sh (aidevops secret)
+#
 # Author: AI DevOps Framework
-# Version: 1.0.0
+# Version: 1.1.0
 
 set -euo pipefail
 

--- a/.agents/scripts/credential-helper.sh
+++ b/.agents/scripts/credential-helper.sh
@@ -4,7 +4,7 @@
 # Credential Helper - Multi-Tenant Credential Storage
 # Manage multiple credential sets (tenants) for different accounts/clients
 #
-# Storage: ~/.config/aidevops/tenants/{tenant}/mcp-env.sh
+# Storage: ~/.config/aidevops/tenants/{tenant}/credentials.sh
 # Active:  ~/.config/aidevops/active-tenant
 # Project: .aidevops-tenant (per-project override)
 #
@@ -25,7 +25,8 @@ readonly NC='\033[0m'
 readonly CONFIG_DIR="$HOME/.config/aidevops"
 readonly TENANTS_DIR="$CONFIG_DIR/tenants"
 readonly ACTIVE_TENANT_FILE="$CONFIG_DIR/active-tenant"
-readonly LEGACY_ENV_FILE="$CONFIG_DIR/mcp-env.sh"
+readonly CREDENTIALS_FILE="$CONFIG_DIR/credentials.sh"
+readonly LEGACY_MCP_ENV_FILE="$CONFIG_DIR/mcp-env.sh"
 readonly PROJECT_TENANT_FILE=".aidevops-tenant"
 
 # Common constants
@@ -93,7 +94,7 @@ get_active_tenant() {
 # Get the env file path for a tenant
 get_tenant_env_file() {
     local tenant="$1"
-    echo "$TENANTS_DIR/$tenant/mcp-env.sh"
+    echo "$TENANTS_DIR/$tenant/credentials.sh"
     return 0
 }
 
@@ -125,9 +126,49 @@ HEADER
     return 0
 }
 
-# Migrate legacy mcp-env.sh to default tenant
+# Migrate from old mcp-env.sh to credentials.sh (file rename)
+migrate_mcp_env_to_credentials() {
+    # Migrate root-level mcp-env.sh -> credentials.sh
+    if [[ -f "$LEGACY_MCP_ENV_FILE" && ! -L "$LEGACY_MCP_ENV_FILE" ]]; then
+        if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+            mv "$LEGACY_MCP_ENV_FILE" "$CREDENTIALS_FILE"
+            chmod 600 "$CREDENTIALS_FILE"
+            print_info "Renamed mcp-env.sh to credentials.sh"
+        fi
+        # Create backward-compatible symlink
+        if [[ ! -L "$LEGACY_MCP_ENV_FILE" ]]; then
+            ln -sf "credentials.sh" "$LEGACY_MCP_ENV_FILE"
+            print_info "Created symlink mcp-env.sh -> credentials.sh"
+        fi
+    fi
+
+    # Migrate tenant-level mcp-env.sh -> credentials.sh
+    if [[ -d "$TENANTS_DIR" ]]; then
+        for tenant_dir in "$TENANTS_DIR"/*/; do
+            [[ -d "$tenant_dir" ]] || continue
+            local old_file="$tenant_dir/mcp-env.sh"
+            local new_file="$tenant_dir/credentials.sh"
+            if [[ -f "$old_file" && ! -L "$old_file" ]]; then
+                if [[ ! -f "$new_file" ]]; then
+                    mv "$old_file" "$new_file"
+                    chmod 600 "$new_file"
+                fi
+                if [[ ! -L "$old_file" ]]; then
+                    ln -sf "credentials.sh" "$old_file"
+                fi
+            fi
+        done
+    fi
+
+    return 0
+}
+
+# Migrate legacy credentials.sh to default tenant
 migrate_legacy() {
-    if [[ ! -f "$LEGACY_ENV_FILE" ]]; then
+    # First handle mcp-env.sh -> credentials.sh rename
+    migrate_mcp_env_to_credentials
+
+    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
         return 0
     fi
 
@@ -137,7 +178,7 @@ migrate_legacy() {
     if [[ -f "$default_env" ]]; then
         # Already migrated - check if legacy has keys not in default
         local legacy_keys
-        legacy_keys=$(grep -c "^export " "$LEGACY_ENV_FILE" 2>/dev/null || echo "0")
+        legacy_keys=$(grep -c "^export " "$CREDENTIALS_FILE" 2>/dev/null || echo "0")
         if [[ "$legacy_keys" -eq 0 ]]; then
             return 0
         fi
@@ -151,13 +192,13 @@ migrate_legacy() {
                     print_info "Migrated $key_name to default tenant"
                 fi
             fi
-        done < "$LEGACY_ENV_FILE"
+        done < "$CREDENTIALS_FILE"
         return 0
     fi
 
     # First migration: copy legacy to default tenant
     ensure_tenant_dir "default"
-    cp "$LEGACY_ENV_FILE" "$default_env"
+    cp "$CREDENTIALS_FILE" "$default_env"
     chmod 600 "$default_env"
 
     # Set default as active
@@ -168,14 +209,14 @@ migrate_legacy() {
     return 0
 }
 
-# Update the legacy mcp-env.sh to source the active tenant
+# Update the credentials.sh to source the active tenant
 update_legacy_sourcing() {
     local active_tenant="$1"
     local tenant_env
     tenant_env=$(get_tenant_env_file "$active_tenant")
 
-    # Rewrite legacy file to source the active tenant
-    cat > "$LEGACY_ENV_FILE" << EOF
+    # Rewrite credentials file to source the active tenant
+    cat > "$CREDENTIALS_FILE" << EOF
 #!/bin/bash
 # ------------------------------------------------------------------------------
 # Multi-Tenant Credential Loader
@@ -193,7 +234,13 @@ if [[ -f "$tenant_env" ]]; then
     source "$tenant_env"
 fi
 EOF
-    chmod 600 "$LEGACY_ENV_FILE"
+    chmod 600 "$CREDENTIALS_FILE"
+
+    # Ensure backward-compatible symlink exists
+    if [[ ! -L "$LEGACY_MCP_ENV_FILE" ]]; then
+        ln -sf "credentials.sh" "$LEGACY_MCP_ENV_FILE"
+    fi
+
     return 0
 }
 
@@ -270,7 +317,7 @@ cmd_list() {
         fi
         local tenant_name
         tenant_name=$(basename "$tenant_dir")
-        local env_file="$tenant_dir/mcp-env.sh"
+        local env_file="$tenant_dir/credentials.sh"
         local key_count=0
 
         if [[ -f "$env_file" ]]; then
@@ -726,7 +773,7 @@ cmd_status() {
             fi
             local tenant_name
             tenant_name=$(basename "$tenant_dir")
-            local env_file="$tenant_dir/mcp-env.sh"
+            local env_file="$tenant_dir/credentials.sh"
             local key_count=0
 
             if [[ -f "$env_file" ]]; then

--- a/.agents/scripts/domain-research-helper.sh
+++ b/.agents/scripts/domain-research-helper.sh
@@ -39,7 +39,7 @@ load_reconeer_api_key() {
     fi
     
     # Check config file
-    local config_file="$HOME/.config/aidevops/mcp-env.sh"
+    local config_file="$HOME/.config/aidevops/credentials.sh"
     if [[ -f "$config_file" ]]; then
         local key
         key=$(grep -E "^export RECONEER_API_KEY=" "$config_file" 2>/dev/null | cut -d'=' -f2- | tr -d '"' | tr -d "'")
@@ -604,7 +604,7 @@ reconeer_cmd() {
             echo "  Premium: Unlimited (\$49/mo with API key)"
             echo ""
             echo "API Key Setup:"
-            echo "  export RECONEER_API_KEY=\"your-key\" in ~/.config/aidevops/mcp-env.sh"
+            echo "  export RECONEER_API_KEY=\"your-key\" in ~/.config/aidevops/credentials.sh"
             echo ""
             ;;
         *)
@@ -714,7 +714,7 @@ show_help() {
     echo "  Reconeer: 10/day free, unlimited with \$49/mo premium"
     echo ""
     echo "API Key Setup (Reconeer):"
-    echo "  Add to ~/.config/aidevops/mcp-env.sh:"
+    echo "  Add to ~/.config/aidevops/credentials.sh:"
     echo "    export RECONEER_API_KEY=\"your-api-key-here\""
     echo ""
     echo "Database Info (THC):"

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -615,7 +615,7 @@ if 'outscraper_*' not in config['tools']:
 if 'dataforseo' not in config['mcp']:
     config['mcp']['dataforseo'] = {
         "type": "local",
-        "command": ["/bin/bash", "-c", f"source ~/.config/aidevops/mcp-env.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD {pkg_runner} dataforseo-mcp-server"],
+        "command": ["/bin/bash", "-c", f"source ~/.config/aidevops/credentials.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD {pkg_runner} dataforseo-mcp-server"],
         "enabled": False
     }
     print("  Added dataforseo MCP (lazy load - SEO agent/@dataforseo subagent)")

--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -387,7 +387,7 @@ Parse the JSON output and present as markdown tables grouped by source.
 Format with padded columns for readability:
 
 ```
-### ~/.config/aidevops/mcp-env.sh
+### ~/.config/aidevops/credentials.sh
 
 | Key                        | Status        |
 |----------------------------|---------------|

--- a/.agents/scripts/keyword-research-helper.sh
+++ b/.agents/scripts/keyword-research-helper.sh
@@ -152,8 +152,8 @@ check_credentials() {
     local has_creds=false
     
     # Source credentials
-    if [[ -f "$HOME/.config/aidevops/mcp-env.sh" ]]; then
-        source "$HOME/.config/aidevops/mcp-env.sh"
+    if [[ -f "$HOME/.config/aidevops/credentials.sh" ]]; then
+        source "$HOME/.config/aidevops/credentials.sh"
     fi
     
     case "$provider" in
@@ -186,7 +186,7 @@ check_credentials() {
     if [[ "$has_creds" == "false" ]]; then
         print_error "Missing credentials for provider: $provider"
         print_info "Run '/list-keys' to check your API keys"
-        print_info "Configure in ~/.config/aidevops/mcp-env.sh"
+        print_info "Configure in ~/.config/aidevops/credentials.sh"
         return 1
     fi
     
@@ -236,7 +236,7 @@ dataforseo_request() {
     local endpoint="$1"
     local data="$2"
     
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     local auth
     auth=$(echo -n "${DATAFORSEO_USERNAME}:${DATAFORSEO_PASSWORD}" | base64)
@@ -410,7 +410,7 @@ serper_request() {
     local endpoint="$1"
     local data="$2"
     
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     curl -s -X POST \
         "https://google.serper.dev/$endpoint" \
@@ -464,7 +464,7 @@ ahrefs_request() {
     local endpoint="$1"
     local params="$2"
     
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     curl -s -X GET \
         "https://api.ahrefs.com/v3/$endpoint?$params" \
@@ -498,7 +498,7 @@ gsc_request() {
     local endpoint="$1"
     local data="$2"
     
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     # Check for service account credentials
     if [[ -z "${GSC_ACCESS_TOKEN:-}" ]]; then
@@ -608,7 +608,7 @@ EOF
 
 # List verified sites
 gsc_list_sites() {
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     if [[ -z "${GSC_ACCESS_TOKEN:-}" ]]; then
         if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] && [[ -f "$GOOGLE_APPLICATION_CREDENTIALS" ]]; then
@@ -639,10 +639,10 @@ bing_request() {
     local endpoint="$1"
     local site_url="$2"
     
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     if [[ -z "${BING_WEBMASTER_API_KEY:-}" ]]; then
-        print_error "BING_WEBMASTER_API_KEY not configured in ~/.config/aidevops/mcp-env.sh"
+        print_error "BING_WEBMASTER_API_KEY not configured in ~/.config/aidevops/credentials.sh"
         return 1
     fi
     
@@ -670,7 +670,7 @@ bing_keyword() {
     local start_date="$3"
     local end_date="$4"
     
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     if [[ -z "${BING_WEBMASTER_API_KEY:-}" ]]; then
         print_error "BING_WEBMASTER_API_KEY not configured"
@@ -694,7 +694,7 @@ bing_related_keywords() {
     local start_date="$3"
     local end_date="$4"
     
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     if [[ -z "${BING_WEBMASTER_API_KEY:-}" ]]; then
         print_error "BING_WEBMASTER_API_KEY not configured"
@@ -716,7 +716,7 @@ bing_page_query_stats() {
     local site_url="$1"
     local page_url="$2"
     
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     if [[ -z "${BING_WEBMASTER_API_KEY:-}" ]]; then
         print_error "BING_WEBMASTER_API_KEY not configured"
@@ -743,7 +743,7 @@ bing_rank_traffic() {
 
 # List user sites
 bing_list_sites() {
-    source "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || true
+    source "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || true
     
     if [[ -z "${BING_WEBMASTER_API_KEY:-}" ]]; then
         print_error "BING_WEBMASTER_API_KEY not configured"

--- a/.agents/scripts/onboarding-helper.sh
+++ b/.agents/scripts/onboarding-helper.sh
@@ -31,13 +31,13 @@ readonly DIM='\033[2m'
 readonly NC='\033[0m'
 
 # Credential file locations
-readonly MCP_ENV_FILE="$HOME/.config/aidevops/mcp-env.sh"
+readonly CREDENTIALS_FILE="$HOME/.config/aidevops/credentials.sh"
 readonly CODERABBIT_KEY_FILE="$HOME/.config/coderabbit/api_key"
 
-# Source mcp-env.sh if it exists
-if [[ -f "$MCP_ENV_FILE" ]]; then
+# Source credentials.sh if it exists
+if [[ -f "$CREDENTIALS_FILE" ]]; then
     # shellcheck source=/dev/null
-    source "$MCP_ENV_FILE"
+    source "$CREDENTIALS_FILE"
 fi
 
 # Check if an environment variable is set and not a placeholder
@@ -521,7 +521,7 @@ show_guide() {
             echo "1. Get API key: https://platform.openai.com/api-keys"
             echo "2. Store key:"
             echo "   ~/.aidevops/agents/scripts/setup-local-api-keys.sh set OPENAI_API_KEY \"sk-...\""
-            echo "3. Restart terminal or: source ~/.config/aidevops/mcp-env.sh"
+            echo "3. Restart terminal or: source ~/.config/aidevops/credentials.sh"
             ;;
         anthropic)
             echo -e "${BLUE}Anthropic API Setup${NC}"
@@ -529,7 +529,7 @@ show_guide() {
             echo "1. Get API key: https://console.anthropic.com/settings/keys"
             echo "2. Store key:"
             echo "   ~/.aidevops/agents/scripts/setup-local-api-keys.sh set ANTHROPIC_API_KEY \"sk-ant-...\""
-            echo "3. Restart terminal or: source ~/.config/aidevops/mcp-env.sh"
+            echo "3. Restart terminal or: source ~/.config/aidevops/credentials.sh"
             ;;
         hetzner)
             echo -e "${BLUE}Hetzner Cloud Setup${NC}"

--- a/.agents/scripts/qlty-cli.sh
+++ b/.agents/scripts/qlty-cli.sh
@@ -51,7 +51,7 @@ print_header() {
 load_api_config() {
     local org="${1:-marcusquinn}"  # Default to marcusquinn organization
     
-    # First check environment variables (set via mcp-env.sh, sourced by .zshrc)
+    # First check environment variables (set via credentials.sh, sourced by .zshrc)
     local account_api_key="${QLTY_ACCOUNT_API_KEY:-}"
     local api_key="${QLTY_API_KEY:-}"
     local workspace_id="${QLTY_WORKSPACE_ID:-}"
@@ -90,7 +90,7 @@ load_api_config() {
     else
         # No credentials found
         print_warning "No Qlty credentials found"
-        print_info "Add to ~/.config/aidevops/mcp-env.sh:"
+        print_info "Add to ~/.config/aidevops/credentials.sh:"
         print_info "  export QLTY_ACCOUNT_API_KEY=\"your-key\""
         print_info "  export QLTY_WORKSPACE_ID=\"your-workspace-id\""
         return 1
@@ -288,7 +288,7 @@ show_help() {
     echo "  ⚡ Performance: Fast, concurrent execution"
     echo ""
     echo "Qlty Credential Management:"
-    echo "  Add to ~/.config/aidevops/mcp-env.sh:"
+    echo "  Add to ~/.config/aidevops/credentials.sh:"
     echo "    export QLTY_ACCOUNT_API_KEY=\"qltp_...\""
     echo "    export QLTY_API_KEY=\"qltcw_...\""
     echo "    export QLTY_WORKSPACE_ID=\"...\""

--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -1,0 +1,601 @@
+#!/bin/bash
+# shellcheck disable=SC2034
+
+# Secret Helper - AI-native secret management with gopass backend
+# Keeps secret values out of AI agent context windows via subprocess
+# injection and output redaction.
+#
+# Usage:
+#   secret-helper.sh set NAME              # Interactive hidden input -> gopass
+#   secret-helper.sh list                  # List secret names (never values)
+#   secret-helper.sh run CMD [ARGS...]     # Inject all secrets, redact output
+#   secret-helper.sh NAME [NAME...] -- CMD # Inject specific secrets, redact output
+#   secret-helper.sh init                  # Initialize gopass store
+#   secret-helper.sh import-credentials    # Migrate from credentials.sh to gopass
+#   secret-helper.sh status                # Show backend status
+#   secret-helper.sh help                  # Show help
+#
+# Author: AI DevOps Framework
+# Version: 1.0.0
+
+set -euo pipefail
+
+# Colors for output
+readonly GREEN='\033[0;32m'
+readonly BLUE='\033[0;34m'
+readonly YELLOW='\033[1;33m'
+readonly RED='\033[0;31m'
+readonly DIM='\033[2m'
+readonly NC='\033[0m'
+
+# Paths
+readonly CONFIG_DIR="$HOME/.config/aidevops"
+readonly CREDENTIALS_FILE="$CONFIG_DIR/credentials.sh"
+readonly GOPASS_PREFIX="aidevops"
+
+print_success() {
+    local msg="$1"
+    echo -e "${GREEN}[OK] $msg${NC}"
+    return 0
+}
+
+print_info() {
+    local msg="$1"
+    echo -e "${BLUE}[INFO] $msg${NC}"
+    return 0
+}
+
+print_warning() {
+    local msg="$1"
+    echo -e "${YELLOW}[WARN] $msg${NC}"
+    return 0
+}
+
+print_error() {
+    local msg="$1"
+    echo -e "${RED}[ERROR] $msg${NC}" >&2
+    return 0
+}
+
+# Check if gopass is available and initialized
+has_gopass() {
+    if ! command -v gopass &>/dev/null; then
+        return 1
+    fi
+    # Check if gopass store is initialized
+    if ! gopass ls &>/dev/null; then
+        return 1
+    fi
+    return 0
+}
+
+# Get a secret value from gopass (NEVER print to stdout in agent context)
+# This function is only used internally for subprocess injection
+get_secret_value() {
+    local name="$1"
+    if has_gopass; then
+        gopass show -o "${GOPASS_PREFIX}/${name}" 2>/dev/null
+    else
+        # Fallback to credentials.sh
+        if [[ -f "$CREDENTIALS_FILE" ]]; then
+            local value
+            value=$(grep "^export ${name}=" "$CREDENTIALS_FILE" 2>/dev/null | head -1 | sed 's/^export [^=]*=//' | sed 's/^"//' | sed 's/"$//')
+            echo "$value"
+        fi
+    fi
+    return 0
+}
+
+# Collect all secret values for redaction
+collect_secret_values() {
+    local -a values=()
+
+    if has_gopass; then
+        local secrets
+        secrets=$(gopass ls --flat "${GOPASS_PREFIX}/" 2>/dev/null || true)
+        while IFS= read -r secret_path; do
+            [[ -z "$secret_path" ]] && continue
+            local val
+            val=$(gopass show -o "$secret_path" 2>/dev/null || true)
+            if [[ -n "$val" && ${#val} -ge 4 ]]; then
+                values+=("$val")
+            fi
+        done <<< "$secrets"
+    fi
+
+    # Also collect from credentials.sh as fallback
+    if [[ -f "$CREDENTIALS_FILE" ]]; then
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^export[[:space:]]+[A-Z_][A-Z0-9_]*= ]]; then
+                local val="${line#*=}"
+                val="${val#\"}"
+                val="${val%\"}"
+                val="${val#\'}"
+                val="${val%\'}"
+                if [[ -n "$val" && ${#val} -ge 4 ]]; then
+                    values+=("$val")
+                fi
+            fi
+        done < "$CREDENTIALS_FILE"
+    fi
+
+    # Output values one per line for the redaction filter
+    printf '%s\n' "${values[@]}"
+    return 0
+}
+
+# Redact secret values from a stream
+# Reads stdin, replaces any secret value with [REDACTED]
+redact_stream() {
+    local -a secret_values=()
+
+    # Read secret values into array
+    while IFS= read -r val; do
+        [[ -n "$val" ]] && secret_values+=("$val")
+    done < <(collect_secret_values)
+
+    if [[ ${#secret_values[@]} -eq 0 ]]; then
+        # No secrets to redact, pass through
+        cat
+        return 0
+    fi
+
+    # Build sed script for redaction
+    # Sort by length descending to redact longer values first
+    local sed_script=""
+    local sorted_values
+    sorted_values=$(printf '%s\n' "${secret_values[@]}" | awk '{ print length, $0 }' | sort -rn | cut -d' ' -f2-)
+
+    while IFS= read -r val; do
+        [[ -z "$val" ]] && continue
+        # Escape special sed characters in the value
+        local escaped
+        escaped=$(printf '%s' "$val" | sed 's/[&/\]/\\&/g; s/\[/\\[/g; s/\]/\\]/g')
+        sed_script="${sed_script}s|${escaped}|[REDACTED]|g;"
+    done <<< "$sorted_values"
+
+    if [[ -n "$sed_script" ]]; then
+        sed "$sed_script"
+    else
+        cat
+    fi
+
+    return 0
+}
+
+# Build environment from gopass secrets
+build_secret_env() {
+    local -a specific_names=("$@")
+    local env_vars=""
+
+    if has_gopass; then
+        if [[ ${#specific_names[@]} -gt 0 ]]; then
+            # Inject only specific secrets
+            for name in "${specific_names[@]}"; do
+                local val
+                val=$(gopass show -o "${GOPASS_PREFIX}/${name}" 2>/dev/null || true)
+                if [[ -n "$val" ]]; then
+                    env_vars="${env_vars}${name}=${val}\n"
+                fi
+            done
+        else
+            # Inject all secrets
+            local secrets
+            secrets=$(gopass ls --flat "${GOPASS_PREFIX}/" 2>/dev/null || true)
+            while IFS= read -r secret_path; do
+                [[ -z "$secret_path" ]] && continue
+                local name="${secret_path#"${GOPASS_PREFIX}"/}"
+                local val
+                val=$(gopass show -o "$secret_path" 2>/dev/null || true)
+                if [[ -n "$val" ]]; then
+                    env_vars="${env_vars}${name}=${val}\n"
+                fi
+            done <<< "$secrets"
+        fi
+    fi
+
+    # Also load from credentials.sh as fallback/supplement
+    if [[ -f "$CREDENTIALS_FILE" ]]; then
+        while IFS= read -r line; do
+            if [[ "$line" =~ ^export[[:space:]]+([A-Z_][A-Z0-9_]*)=(.*) ]]; then
+                local name="${BASH_REMATCH[1]}"
+                local val="${BASH_REMATCH[2]}"
+                val="${val#\"}"
+                val="${val%\"}"
+                # Only add if not already set by gopass
+                if ! printf '%b' "$env_vars" | grep -q "^${name}="; then
+                    env_vars="${env_vars}${name}=${val}\n"
+                fi
+            fi
+        done < "$CREDENTIALS_FILE"
+    fi
+
+    printf '%b' "$env_vars"
+    return 0
+}
+
+# --- Commands ---
+
+# Initialize gopass store for aidevops
+cmd_init() {
+    if ! command -v gopass &>/dev/null; then
+        print_info "gopass not found. Installing..."
+        if command -v brew &>/dev/null; then
+            brew install gopass
+        elif command -v apt-get &>/dev/null; then
+            sudo apt-get install -y gopass
+        elif command -v pacman &>/dev/null; then
+            sudo pacman -S gopass
+        else
+            print_error "Cannot auto-install gopass. Install manually: https://github.com/gopasspw/gopass#installation"
+            return 1
+        fi
+    fi
+
+    if ! gopass ls &>/dev/null; then
+        print_info "Initializing gopass store..."
+        gopass setup
+    fi
+
+    # Create aidevops subfolder if it doesn't exist
+    if ! gopass ls "${GOPASS_PREFIX}/" &>/dev/null; then
+        print_info "Creating ${GOPASS_PREFIX}/ prefix in gopass store"
+        # gopass creates folders implicitly when secrets are added
+    fi
+
+    print_success "gopass initialized for aidevops"
+    print_info "Store secrets: aidevops secret set SECRET_NAME"
+    print_info "Import existing: aidevops secret import-credentials"
+    return 0
+}
+
+# Set a secret (interactive hidden input)
+cmd_set() {
+    local name="$1"
+
+    if [[ -z "$name" ]]; then
+        print_error "Usage: aidevops secret set SECRET_NAME"
+        return 1
+    fi
+
+    # Normalize to uppercase
+    name=$(echo "$name" | tr '[:lower:]-' '[:upper:]_')
+
+    if has_gopass; then
+        print_info "Enter value for $name (input hidden):"
+        gopass insert "${GOPASS_PREFIX}/${name}"
+        print_success "Stored $name in gopass"
+    else
+        print_warning "gopass not available, falling back to credentials.sh"
+        print_info "Enter value for $name (input hidden):"
+        local value
+        read -rs value
+        echo ""
+
+        mkdir -p "$CONFIG_DIR"
+        if [[ -f "$CREDENTIALS_FILE" ]] && grep -q "^export ${name}=" "$CREDENTIALS_FILE" 2>/dev/null; then
+            local tmp_file="${CREDENTIALS_FILE}.tmp"
+            grep -v "^export ${name}=" "$CREDENTIALS_FILE" > "$tmp_file"
+            echo "export ${name}=\"${value}\"" >> "$tmp_file"
+            mv "$tmp_file" "$CREDENTIALS_FILE"
+        else
+            echo "export ${name}=\"${value}\"" >> "$CREDENTIALS_FILE"
+        fi
+        chmod 600 "$CREDENTIALS_FILE"
+        print_success "Stored $name in credentials.sh"
+        print_info "Recommend: aidevops secret init (to enable encrypted storage)"
+    fi
+
+    return 0
+}
+
+# List secret names (NEVER values)
+cmd_list() {
+    local has_secrets=false
+
+    if has_gopass; then
+        local secrets
+        secrets=$(gopass ls --flat "${GOPASS_PREFIX}/" 2>/dev/null || true)
+        if [[ -n "$secrets" ]]; then
+            print_info "Secrets in gopass (${GOPASS_PREFIX}/):"
+            echo ""
+            while IFS= read -r secret_path; do
+                [[ -z "$secret_path" ]] && continue
+                local name="${secret_path#"${GOPASS_PREFIX}"/}"
+                echo "  $name"
+                has_secrets=true
+            done <<< "$secrets"
+            echo ""
+        fi
+    fi
+
+    if [[ -f "$CREDENTIALS_FILE" ]]; then
+        local cred_keys
+        cred_keys=$(grep "^export " "$CREDENTIALS_FILE" 2>/dev/null | sed 's/=.*//' | sed 's/export //' | sort || true)
+        if [[ -n "$cred_keys" ]]; then
+            print_info "Secrets in credentials.sh:"
+            echo ""
+            while IFS= read -r key; do
+                [[ -z "$key" ]] && continue
+                echo "  $key"
+                has_secrets=true
+            done <<< "$cred_keys"
+            echo ""
+        fi
+    fi
+
+    if [[ "$has_secrets" == "false" ]]; then
+        print_info "No secrets configured"
+        print_info "Add secrets: aidevops secret set SECRET_NAME"
+    fi
+
+    return 0
+}
+
+# Run a command with secrets injected and output redacted
+cmd_run() {
+    local -a cmd_args=("$@")
+
+    if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        print_error "Usage: aidevops secret run COMMAND [ARGS...]"
+        return 1
+    fi
+
+    # Build environment
+    local env_file
+    env_file=$(mktemp)
+    build_secret_env > "$env_file"
+
+    # Execute command with secrets in environment, redact output
+    local exit_code=0
+    (
+        # Load secrets into subprocess environment
+        while IFS='=' read -r key val; do
+            [[ -z "$key" ]] && continue
+            export "$key=$val"
+        done < "$env_file"
+
+        # Execute the command
+        "${cmd_args[@]}"
+    ) 2>&1 | redact_stream || exit_code=$?
+
+    # Clean up
+    rm -f "$env_file"
+
+    return "$exit_code"
+}
+
+# Run with specific secrets: secret NAME1 NAME2 -- command args
+cmd_run_specific() {
+    local -a secret_names=()
+    local -a cmd_args=()
+    local found_separator=false
+
+    for arg in "$@"; do
+        if [[ "$arg" == "--" ]]; then
+            found_separator=true
+            continue
+        fi
+        if [[ "$found_separator" == "true" ]]; then
+            cmd_args+=("$arg")
+        else
+            secret_names+=("$arg")
+        fi
+    done
+
+    if [[ ${#cmd_args[@]} -eq 0 ]]; then
+        print_error "Usage: aidevops secret NAME [NAME...] -- COMMAND [ARGS...]"
+        return 1
+    fi
+
+    # Build environment with specific secrets only
+    local env_file
+    env_file=$(mktemp)
+    build_secret_env "${secret_names[@]}" > "$env_file"
+
+    # Execute command with secrets in environment, redact output
+    local exit_code=0
+    (
+        while IFS='=' read -r key val; do
+            [[ -z "$key" ]] && continue
+            export "$key=$val"
+        done < "$env_file"
+
+        "${cmd_args[@]}"
+    ) 2>&1 | redact_stream || exit_code=$?
+
+    rm -f "$env_file"
+
+    return "$exit_code"
+}
+
+# Import credentials from credentials.sh to gopass
+cmd_import_credentials() {
+    if ! has_gopass; then
+        print_error "gopass not initialized. Run: aidevops secret init"
+        return 1
+    fi
+
+    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+        print_info "No credentials.sh found to import"
+        return 0
+    fi
+
+    local imported=0
+    local skipped=0
+
+    while IFS= read -r line; do
+        if [[ "$line" =~ ^export[[:space:]]+([A-Z_][A-Z0-9_]*)=(.*) ]]; then
+            local name="${BASH_REMATCH[1]}"
+            local val="${BASH_REMATCH[2]}"
+            val="${val#\"}"
+            val="${val%\"}"
+            val="${val#\'}"
+            val="${val%\'}"
+
+            # Skip empty/placeholder values
+            if [[ -z "$val" || "$val" == "YOUR_"* || "$val" == "CHANGE_ME"* ]]; then
+                ((skipped++))
+                continue
+            fi
+
+            # Check if already in gopass
+            if gopass show -o "${GOPASS_PREFIX}/${name}" &>/dev/null; then
+                print_info "Skipping $name (already in gopass)"
+                ((skipped++))
+                continue
+            fi
+
+            # Import to gopass
+            echo "$val" | gopass insert --force "${GOPASS_PREFIX}/${name}"
+            ((imported++))
+            print_success "Imported $name"
+        fi
+    done < "$CREDENTIALS_FILE"
+
+    print_success "Imported $imported secret(s), skipped $skipped"
+
+    if [[ $imported -gt 0 ]]; then
+        print_info "Verify with: aidevops secret list"
+        print_info "You can now remove plaintext values from credentials.sh"
+    fi
+
+    return 0
+}
+
+# Show backend status
+cmd_status() {
+    echo ""
+    print_info "Secret Management Status"
+    echo "========================="
+    echo ""
+
+    # gopass status
+    if command -v gopass &>/dev/null; then
+        local gopass_version
+        gopass_version=$(gopass version 2>/dev/null | head -1 || echo "unknown")
+        echo -e "  gopass:       ${GREEN}installed${NC} ($gopass_version)"
+
+        if gopass ls &>/dev/null; then
+            local secret_count
+            secret_count=$(gopass ls --flat "${GOPASS_PREFIX}/" 2>/dev/null | wc -l | tr -d ' ')
+            echo -e "  gopass store: ${GREEN}initialized${NC} ($secret_count secrets in ${GOPASS_PREFIX}/)"
+        else
+            echo -e "  gopass store: ${YELLOW}not initialized${NC}"
+            echo -e "                Run: aidevops secret init"
+        fi
+    else
+        echo -e "  gopass:       ${YELLOW}not installed${NC}"
+        echo -e "                Install: brew install gopass"
+    fi
+
+    # GPG status
+    if command -v gpg &>/dev/null; then
+        local gpg_keys
+        gpg_keys=$(gpg --list-secret-keys 2>/dev/null | grep -c "^sec" || echo "0")
+        echo -e "  GPG:          ${GREEN}installed${NC} ($gpg_keys secret key(s))"
+    else
+        echo -e "  GPG:          ${YELLOW}not installed${NC}"
+    fi
+
+    # credentials.sh status
+    if [[ -f "$CREDENTIALS_FILE" ]]; then
+        local key_count
+        key_count=$(grep -c "^export " "$CREDENTIALS_FILE" 2>/dev/null || echo "0")
+        echo -e "  credentials:  ${GREEN}$key_count key(s)${NC} in $CREDENTIALS_FILE"
+    else
+        echo -e "  credentials:  ${DIM}no file${NC}"
+    fi
+
+    echo ""
+    return 0
+}
+
+# Show help
+cmd_help() {
+    echo ""
+    print_info "AI DevOps - Secret Management"
+    echo ""
+    echo "  Manage secrets with gopass (encrypted) or credentials.sh (plaintext fallback)."
+    echo "  Secret values are NEVER exposed to AI agent context windows."
+    echo ""
+    print_info "Commands:"
+    echo ""
+    echo "  init                              Initialize gopass store"
+    echo "  set <NAME>                        Store a secret (interactive hidden input)"
+    echo "  list                              List secret names (never values)"
+    echo "  status                            Show backend status"
+    echo ""
+    echo "  run CMD [ARGS...]                 Run command with all secrets injected"
+    echo "  NAME [NAME...] -- CMD [ARGS...]   Run command with specific secrets"
+    echo "  import-credentials                Import from credentials.sh to gopass"
+    echo ""
+    print_info "Examples:"
+    echo ""
+    echo "  # Store a secret (value entered at terminal, hidden)"
+    echo "  aidevops secret set STRIPE_KEY"
+    echo ""
+    echo "  # Run a command with secrets injected (output redacted)"
+    echo "  aidevops secret run curl -H 'Authorization: Bearer \$STRIPE_KEY' https://api.stripe.com/v1/charges"
+    echo ""
+    echo "  # Inject specific secrets only"
+    echo "  aidevops secret GITHUB_TOKEN -- gh api /user"
+    echo ""
+    echo "  # Import existing credentials to gopass"
+    echo "  aidevops secret import-credentials"
+    echo ""
+    print_info "Security:"
+    echo ""
+    echo "  - Secret values are injected via subprocess environment (never in agent context)"
+    echo "  - All command output is automatically redacted (secret values -> [REDACTED])"
+    echo "  - gopass encrypts secrets at rest with GPG"
+    echo "  - credentials.sh is plaintext fallback (chmod 600)"
+    echo ""
+    return 0
+}
+
+# Main dispatch
+main() {
+    local command="${1:-help}"
+    shift 2>/dev/null || true
+
+    case "$command" in
+        init)
+            cmd_init "$@"
+            ;;
+        set)
+            cmd_set "$@"
+            ;;
+        list|ls)
+            cmd_list "$@"
+            ;;
+        run)
+            cmd_run "$@"
+            ;;
+        import-credentials|import)
+            cmd_import_credentials "$@"
+            ;;
+        status)
+            cmd_status "$@"
+            ;;
+        help|--help|-h)
+            cmd_help
+            ;;
+        *)
+            # Check if it looks like "NAME [NAME...] -- CMD"
+            # (specific secret injection pattern)
+            if [[ "$command" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
+                cmd_run_specific "$command" "$@"
+            else
+                print_error "Unknown command: $command"
+                echo ""
+                cmd_help
+                return 1
+            fi
+            ;;
+    esac
+
+    return 0
+}
+
+main "$@"

--- a/.agents/scripts/security-helper.sh
+++ b/.agents/scripts/security-helper.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # shellcheck source=/dev/null
-[[ -f "${HOME}/.config/aidevops/mcp-env.sh" ]] && source "${HOME}/.config/aidevops/mcp-env.sh"
+[[ -f "${HOME}/.config/aidevops/credentials.sh" ]] && source "${HOME}/.config/aidevops/credentials.sh"
 
 # Script directory (exported for subprocesses)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit

--- a/.agents/scripts/seo-export-ahrefs.sh
+++ b/.agents/scripts/seo-export-ahrefs.sh
@@ -53,11 +53,11 @@ print_error() { local msg="$1"; echo -e "${RED}[ERROR]${NC} $msg" >&2; return 0;
 
 # Get API key from environment
 get_api_key() {
-    source "$CONFIG_DIR/mcp-env.sh" 2>/dev/null || true
+    source "$CONFIG_DIR/credentials.sh" 2>/dev/null || true
     
     if [[ -z "${AHREFS_API_KEY:-}" ]]; then
         print_error "AHREFS_API_KEY not configured"
-        print_error "Set it in ~/.config/aidevops/mcp-env.sh"
+        print_error "Set it in ~/.config/aidevops/credentials.sh"
         return 1
     fi
     
@@ -246,12 +246,12 @@ Data Fields:
     - difficulty: Keyword difficulty (0-100)
 
 Requirements:
-    - AHREFS_API_KEY set in ~/.config/aidevops/mcp-env.sh
+    - AHREFS_API_KEY set in ~/.config/aidevops/credentials.sh
 
 API Key Setup:
     1. Go to https://app.ahrefs.com/user/api
     2. Generate API key
-    3. Add to mcp-env.sh: export AHREFS_API_KEY="your_key"
+    3. Add to credentials.sh: export AHREFS_API_KEY="your_key"
 
 EOF
     return 0

--- a/.agents/scripts/seo-export-bing.sh
+++ b/.agents/scripts/seo-export-bing.sh
@@ -47,11 +47,11 @@ print_error() { local msg="$1"; echo -e "${RED}[ERROR]${NC} $msg" >&2; return 0;
 
 # Get API key from environment
 get_api_key() {
-    source "$CONFIG_DIR/mcp-env.sh" 2>/dev/null || true
+    source "$CONFIG_DIR/credentials.sh" 2>/dev/null || true
     
     if [[ -z "${BING_WEBMASTER_API_KEY:-}" ]]; then
         print_error "BING_WEBMASTER_API_KEY not configured"
-        print_error "Set it in ~/.config/aidevops/mcp-env.sh"
+        print_error "Set it in ~/.config/aidevops/credentials.sh"
         return 1
     fi
     
@@ -227,7 +227,7 @@ Output:
     ~/.aidevops/.agent-workspace/work/seo-data/{domain}/bing-{start}-{end}.toon
 
 Requirements:
-    - BING_WEBMASTER_API_KEY set in ~/.config/aidevops/mcp-env.sh
+    - BING_WEBMASTER_API_KEY set in ~/.config/aidevops/credentials.sh
     - Site must be verified in Bing Webmaster Tools
 
 API Key Setup:
@@ -235,7 +235,7 @@ API Key Setup:
     2. Sign in and verify your site
     3. Go to Settings > API Access
     4. Generate API Key
-    5. Add to mcp-env.sh: export BING_WEBMASTER_API_KEY="your_key"
+    5. Add to credentials.sh: export BING_WEBMASTER_API_KEY="your_key"
 
 EOF
     return 0

--- a/.agents/scripts/seo-export-dataforseo.sh
+++ b/.agents/scripts/seo-export-dataforseo.sh
@@ -53,11 +53,11 @@ print_error() { local msg="$1"; echo -e "${RED}[ERROR]${NC} $msg" >&2; return 0;
 
 # Get auth header from environment
 get_auth_header() {
-    source "$CONFIG_DIR/mcp-env.sh" 2>/dev/null || true
+    source "$CONFIG_DIR/credentials.sh" 2>/dev/null || true
     
     if [[ -z "${DATAFORSEO_USERNAME:-}" ]] || [[ -z "${DATAFORSEO_PASSWORD:-}" ]]; then
         print_error "DataForSEO credentials not configured"
-        print_error "Set DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD in ~/.config/aidevops/mcp-env.sh"
+        print_error "Set DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD in ~/.config/aidevops/credentials.sh"
         return 1
     fi
     
@@ -274,12 +274,12 @@ Data Fields:
     - difficulty: Competition level
 
 Requirements:
-    - DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD in ~/.config/aidevops/mcp-env.sh
+    - DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD in ~/.config/aidevops/credentials.sh
 
 Setup:
     1. Sign up at https://app.dataforseo.com/
     2. Get API credentials from dashboard
-    3. Add to mcp-env.sh:
+    3. Add to credentials.sh:
        export DATAFORSEO_USERNAME="your_username"
        export DATAFORSEO_PASSWORD="your_password"
 

--- a/.agents/scripts/seo-export-gsc.sh
+++ b/.agents/scripts/seo-export-gsc.sh
@@ -48,7 +48,7 @@ print_error() { local msg="$1"; echo -e "${RED}[ERROR]${NC} $msg" >&2; return 0;
 
 # Get access token from service account or environment
 get_access_token() {
-    source "$CONFIG_DIR/mcp-env.sh" 2>/dev/null || true
+    source "$CONFIG_DIR/credentials.sh" 2>/dev/null || true
     
     if [[ -n "${GSC_ACCESS_TOKEN:-}" ]]; then
         echo "$GSC_ACCESS_TOKEN"
@@ -65,7 +65,7 @@ get_access_token() {
     fi
     
     print_error "GSC credentials not configured"
-    print_error "Set GOOGLE_APPLICATION_CREDENTIALS or GSC_ACCESS_TOKEN in ~/.config/aidevops/mcp-env.sh"
+    print_error "Set GOOGLE_APPLICATION_CREDENTIALS or GSC_ACCESS_TOKEN in ~/.config/aidevops/credentials.sh"
     return 1
 }
 
@@ -250,7 +250,7 @@ Output:
 
 Requirements:
     - GOOGLE_APPLICATION_CREDENTIALS pointing to service account JSON
-    - Or GSC_ACCESS_TOKEN set in ~/.config/aidevops/mcp-env.sh
+    - Or GSC_ACCESS_TOKEN set in ~/.config/aidevops/credentials.sh
     - Service account must have access to the GSC property
 
 EOF

--- a/.agents/scripts/setup-local-api-keys.sh
+++ b/.agents/scripts/setup-local-api-keys.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC2034,SC2155,SC2317,SC2329,SC2016,SC2181,SC1091,SC2154,SC2015,SC2086,SC2129,SC2030,SC2031,SC2119,SC2120,SC2001,SC2162,SC2088,SC2089,SC2090,SC2029,SC2006,SC2153
 
 # Setup Local API Keys - Secure User-Private Storage
-# Manage API keys in ~/.config/aidevops/mcp-env.sh (sourced by shell configs)
+# Manage API keys in ~/.config/aidevops/credentials.sh (sourced by shell configs)
 #
 # Author: AI DevOps Framework
 # Version: 2.1.0
@@ -42,7 +42,7 @@ print_error() {
 
 # Secure API key directory and file
 readonly API_KEY_DIR="$HOME/.config/aidevops"
-readonly MCP_ENV_FILE="$API_KEY_DIR/mcp-env.sh"
+readonly CREDENTIALS_FILE="$API_KEY_DIR/credentials.sh"
 
 # Shell config files to check/update
 SHELL_CONFIGS=(
@@ -62,39 +62,39 @@ setup_secure_directory() {
     # Ensure proper permissions
     chmod 700 "$API_KEY_DIR"
     
-    # Create mcp-env.sh if it doesn't exist
-    if [[ ! -f "$MCP_ENV_FILE" ]]; then
-        cat > "$MCP_ENV_FILE" << 'EOF'
+    # Create credentials.sh if it doesn't exist
+    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+        cat > "$CREDENTIALS_FILE" << 'EOF'
 #!/bin/bash
 # ------------------------------------------------------------------------------
 # API Keys & Tokens - Single Source of Truth
 # This file is sourced by shell configs (zsh, bash) for all processes
 # File permissions should be 600 (owner read/write only)
-# Location: ~/.config/aidevops/mcp-env.sh
+# Location: ~/.config/aidevops/credentials.sh
 #
 # Usage: Add keys with setup-local-api-keys.sh or manually:
 #   export SERVICE_NAME_API_KEY="your-key-here"
 # ------------------------------------------------------------------------------
 
 EOF
-        chmod 600 "$MCP_ENV_FILE"
-        print_success "Created mcp-env.sh"
+        chmod 600 "$CREDENTIALS_FILE"
+        print_success "Created credentials.sh"
     fi
     
     return 0
 }
 
-# Ensure shell configs source mcp-env.sh
+# Ensure shell configs source credentials.sh
 setup_shell_integration() {
-    local source_line='[[ -f ~/.config/aidevops/mcp-env.sh ]] && source ~/.config/aidevops/mcp-env.sh'
+    local source_line='[[ -f ~/.config/aidevops/credentials.sh ]] && source ~/.config/aidevops/credentials.sh'
     local updated=0
     
     for config in "${SHELL_CONFIGS[@]}"; do
-        if [[ -f "$config" ]] && ! grep -q "mcp-env.sh" "$config" 2>/dev/null; then
+        if [[ -f "$config" ]] && ! grep -q "credentials.sh" "$config" 2>/dev/null; then
             echo "" >> "$config"
             echo "# AI DevOps API Keys (single source of truth)" >> "$config"
             echo "$source_line" >> "$config"
-            print_success "Added mcp-env.sh sourcing to $config"
+            print_success "Added credentials.sh sourcing to $config"
             ((updated++))
         fi
     done
@@ -171,18 +171,18 @@ set_api_key() {
     fi
     
     # Check if the env var already exists in the file
-    if grep -q "^export ${env_var}=" "$MCP_ENV_FILE" 2>/dev/null; then
+    if grep -q "^export ${env_var}=" "$CREDENTIALS_FILE" 2>/dev/null; then
         # Update existing entry
-        local tmp_file="${MCP_ENV_FILE}.tmp"
-        sed "s|^export ${env_var}=.*|export ${env_var}=\"${key}\"|" "$MCP_ENV_FILE" > "$tmp_file"
-        mv "$tmp_file" "$MCP_ENV_FILE"
-        chmod 600 "$MCP_ENV_FILE"
-        print_success "Updated $env_var in mcp-env.sh"
+        local tmp_file="${CREDENTIALS_FILE}.tmp"
+        sed "s|^export ${env_var}=.*|export ${env_var}=\"${key}\"|" "$CREDENTIALS_FILE" > "$tmp_file"
+        mv "$tmp_file" "$CREDENTIALS_FILE"
+        chmod 600 "$CREDENTIALS_FILE"
+        print_success "Updated $env_var in credentials.sh"
     else
         # Append new entry
-        echo "export ${env_var}=\"${key}\"" >> "$MCP_ENV_FILE"
-        chmod 600 "$MCP_ENV_FILE"
-        print_success "Added $env_var to mcp-env.sh"
+        echo "export ${env_var}=\"${key}\"" >> "$CREDENTIALS_FILE"
+        chmod 600 "$CREDENTIALS_FILE"
+        print_success "Added $env_var to credentials.sh"
     fi
     
     # Also export to current shell
@@ -207,7 +207,7 @@ get_api_key() {
         return 1
     fi
     
-    if [[ ! -f "$MCP_ENV_FILE" ]]; then
+    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
         print_warning "No API keys configured. Run '$0 setup' first."
         return 1
     fi
@@ -225,7 +225,7 @@ get_api_key() {
     
     # If not in env, try to extract from file
     if [[ -z "$key" ]]; then
-        key=$(grep "^export ${env_var}=" "$MCP_ENV_FILE" 2>/dev/null | sed 's/^export [^=]*="//' | sed 's/"$//')
+        key=$(grep "^export ${env_var}=" "$CREDENTIALS_FILE" 2>/dev/null | sed 's/^export [^=]*="//' | sed 's/"$//')
     fi
     
     if [[ -n "$key" ]]; then
@@ -240,16 +240,16 @@ get_api_key() {
 
 # List configured services (without showing keys)
 list_services() {
-    if [[ ! -f "$MCP_ENV_FILE" ]]; then
+    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
         print_info "No API keys configured"
         return 0
     fi
     
-    print_info "Configured API keys in mcp-env.sh:"
+    print_info "Configured API keys in credentials.sh:"
     echo ""
-    grep "^export " "$MCP_ENV_FILE" | sed 's/=.*//' | sed 's/export /  /' | sort
+    grep "^export " "$CREDENTIALS_FILE" | sed 's/=.*//' | sed 's/export /  /' | sort
     echo ""
-    print_info "File: $MCP_ENV_FILE"
+    print_info "File: $CREDENTIALS_FILE"
     
     return 0
 }
@@ -258,7 +258,7 @@ list_services() {
 show_help() {
     print_info "AI DevOps - Secure Local API Key Management"
     echo ""
-    print_info "Manages API keys in: $MCP_ENV_FILE"
+    print_info "Manages API keys in: $CREDENTIALS_FILE"
     print_info "This file is sourced by shell configs (zsh & bash) for all processes."
     echo ""
     print_info "Usage: $0 <command> [args]"

--- a/.agents/scripts/setup-mcp-integrations.sh
+++ b/.agents/scripts/setup-mcp-integrations.sh
@@ -123,7 +123,7 @@ install_mcp() {
             print_info "Get your standard 40-char API key from: https://ahrefs.com/api"
             print_info "Note: JWT-style tokens do NOT work - use the standard API key"
             print_info ""
-            print_info "Store in ~/.config/aidevops/mcp-env.sh:"
+            print_info "Store in ~/.config/aidevops/credentials.sh:"
             print_info "  export AHREFS_API_KEY=\"your_40_char_key\""
             print_info ""
             print_info "For OpenCode, use bash wrapper pattern in opencode.json:"
@@ -256,7 +256,7 @@ install_mcp() {
             print_warning "DataForSEO MCP requires API credentials"
             print_info "Get credentials from: https://app.dataforseo.com/"
             print_info ""
-            print_info "Store in ~/.config/aidevops/mcp-env.sh:"
+            print_info "Store in ~/.config/aidevops/credentials.sh:"
             print_info "  export DATAFORSEO_USERNAME=\"your_username\""
             print_info "  export DATAFORSEO_PASSWORD=\"your_password\""
             print_info ""
@@ -267,7 +267,7 @@ install_mcp() {
             print_info "For OpenCode, use bash wrapper pattern in opencode.json:"
             print_info '  "dataforseo": {'
             print_info '    "type": "local",'
-            print_info '    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && DATAFORSEO_USERNAME=\$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=\$DATAFORSEO_PASSWORD npx dataforseo-mcp-server"],'
+            print_info '    "command": ["/bin/bash", "-c", "source ~/.config/aidevops/credentials.sh && DATAFORSEO_USERNAME=\$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=\$DATAFORSEO_PASSWORD npx dataforseo-mcp-server"],'
             print_info '    "enabled": true'
             print_info '  }'
             print_info ""
@@ -275,7 +275,7 @@ install_mcp() {
             print_info "Docs: https://docs.dataforseo.com/v3/"
             ;;
         # "serper" - REMOVED: Uses curl subagent (.agents/seo/serper.md), no MCP needed
-        # Get API key from https://serper.dev/ and set SERPER_API_KEY in mcp-env.sh
+        # Get API key from https://serper.dev/ and set SERPER_API_KEY in credentials.sh
         "unstract")
             print_info "Setting up Unstract self-hosted document processing platform..."
             print_info "This installs the full Unstract platform locally via Docker Compose"

--- a/.agents/scripts/sonarscanner-cli.sh
+++ b/.agents/scripts/sonarscanner-cli.sh
@@ -213,14 +213,14 @@ install_sonar_scanner() {
 init_sonar_config() {
     print_header "Initializing SonarQube Configuration"
 
-    # Check for required environment variables (set via mcp-env.sh, sourced by .zshrc)
+    # Check for required environment variables (set via credentials.sh, sourced by .zshrc)
     local sonar_token="${SONAR_TOKEN:-}"
     local sonar_organization="${SONAR_ORGANIZATION:-}"
     local sonar_project_key="${SONAR_PROJECT_KEY:-}"
 
     if [[ -z "$sonar_token" ]]; then
         print_error "SONAR_TOKEN not found in environment"
-        print_info "Add to ~/.config/aidevops/mcp-env.sh:"
+        print_info "Add to ~/.config/aidevops/credentials.sh:"
         print_info "  export SONAR_TOKEN=\"your-token\""
         print_info "Get your token from: https://sonarcloud.io/account/security/"
         return 1
@@ -290,11 +290,11 @@ run_sonar_analysis() {
         print_info "Attempting to run with environment variables..."
     fi
 
-    # Check for required token (set via mcp-env.sh, sourced by .zshrc)
+    # Check for required token (set via credentials.sh, sourced by .zshrc)
     local sonar_token="${SONAR_TOKEN:-}"
     if [[ -z "$sonar_token" ]]; then
         print_error "SONAR_TOKEN not found in environment"
-        print_info "Add to ~/.config/aidevops/mcp-env.sh:"
+        print_info "Add to ~/.config/aidevops/credentials.sh:"
         print_info "  export SONAR_TOKEN=\"your-token\""
         return 1
     fi

--- a/.agents/scripts/updown-helper.sh
+++ b/.agents/scripts/updown-helper.sh
@@ -72,7 +72,7 @@ check_dependencies() {
 load_config() {
     local api_key
     
-    # First try environment variable (preferred - set via mcp-env.sh)
+    # First try environment variable (preferred - set via credentials.sh)
     api_key="${UPDOWN_API_KEY:-}"
     
     # Fallback to config file if env var not set
@@ -82,7 +82,7 @@ load_config() {
 
     if [[ -z "$api_key" ]]; then
         print_error "$ERROR_API_KEY_MISSING"
-        print_error "Set UPDOWN_API_KEY in ~/.config/aidevops/mcp-env.sh"
+        print_error "Set UPDOWN_API_KEY in ~/.config/aidevops/credentials.sh"
         return 1
     fi
 

--- a/.agents/scripts/watercrawl-helper.sh
+++ b/.agents/scripts/watercrawl-helper.sh
@@ -52,7 +52,7 @@ readonly HELP_SHOW_MESSAGE="Show this help message"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 readonly SCRIPT_DIR
 readonly CONFIG_DIR="$SCRIPT_DIR/../configs"
-readonly MCP_ENV_FILE="$HOME/.config/aidevops/mcp-env.sh"
+readonly CREDENTIALS_FILE="$HOME/.config/aidevops/credentials.sh"
 readonly WATERCRAWL_CLOUD_URL="https://app.watercrawl.dev"
 readonly WATERCRAWL_LOCAL_URL="http://localhost"
 readonly NPM_PACKAGE="@watercrawl/nodejs"
@@ -90,11 +90,11 @@ print_header() {
     return 0
 }
 
-# Load configuration from mcp-env.sh
+# Load configuration from credentials.sh
 load_config() {
-    if [[ -f "$MCP_ENV_FILE" ]]; then
+    if [[ -f "$CREDENTIALS_FILE" ]]; then
         # shellcheck source=/dev/null
-        source "$MCP_ENV_FILE"
+        source "$CREDENTIALS_FILE"
     fi
     
     # Default to local URL if self-hosted, otherwise cloud
@@ -109,7 +109,7 @@ load_config() {
     return 0
 }
 
-# Load API key from mcp-env.sh
+# Load API key from credentials.sh
 load_api_key() {
     load_config
     
@@ -410,35 +410,35 @@ configure_api_key() {
     print_header "Configuring WaterCrawl API Key"
     
     # Create config directory if needed
-    mkdir -p "$(dirname "$MCP_ENV_FILE")"
+    mkdir -p "$(dirname "$CREDENTIALS_FILE")"
     
     # Check if file exists and has the key
-    if [[ -f "$MCP_ENV_FILE" ]]; then
-        if grep -q "^export WATERCRAWL_API_KEY=" "$MCP_ENV_FILE"; then
+    if [[ -f "$CREDENTIALS_FILE" ]]; then
+        if grep -q "^export WATERCRAWL_API_KEY=" "$CREDENTIALS_FILE"; then
             # Update existing key
-            sed -i.bak "s|^export WATERCRAWL_API_KEY=.*|export WATERCRAWL_API_KEY=\"$api_key\"|" "$MCP_ENV_FILE"
-            rm -f "${MCP_ENV_FILE}.bak"
-            print_success "API key updated in $MCP_ENV_FILE"
+            sed -i.bak "s|^export WATERCRAWL_API_KEY=.*|export WATERCRAWL_API_KEY=\"$api_key\"|" "$CREDENTIALS_FILE"
+            rm -f "${CREDENTIALS_FILE}.bak"
+            print_success "API key updated in $CREDENTIALS_FILE"
         else
             # Append new key
-            echo "" >> "$MCP_ENV_FILE"
-            echo "# WaterCrawl API Key" >> "$MCP_ENV_FILE"
-            echo "export WATERCRAWL_API_KEY=\"$api_key\"" >> "$MCP_ENV_FILE"
-            print_success "API key added to $MCP_ENV_FILE"
+            echo "" >> "$CREDENTIALS_FILE"
+            echo "# WaterCrawl API Key" >> "$CREDENTIALS_FILE"
+            echo "export WATERCRAWL_API_KEY=\"$api_key\"" >> "$CREDENTIALS_FILE"
+            print_success "API key added to $CREDENTIALS_FILE"
         fi
     else
         # Create new file
-        cat > "$MCP_ENV_FILE" << EOF
+        cat > "$CREDENTIALS_FILE" << EOF
 #!/bin/bash
 # MCP Environment Variables
 # This file is sourced by helper scripts to load API keys
-# Permissions should be 600 (chmod 600 $MCP_ENV_FILE)
+# Permissions should be 600 (chmod 600 $CREDENTIALS_FILE)
 
 # WaterCrawl Configuration
 export WATERCRAWL_API_KEY="$api_key"
 EOF
-        chmod 600 "$MCP_ENV_FILE"
-        print_success "Created $MCP_ENV_FILE with API key"
+        chmod 600 "$CREDENTIALS_FILE"
+        print_success "Created $CREDENTIALS_FILE with API key"
     fi
     
     return 0
@@ -457,32 +457,32 @@ configure_api_url() {
     print_header "Configuring WaterCrawl API URL"
     
     # Create config directory if needed
-    mkdir -p "$(dirname "$MCP_ENV_FILE")"
+    mkdir -p "$(dirname "$CREDENTIALS_FILE")"
     
     # Check if file exists and has the URL
-    if [[ -f "$MCP_ENV_FILE" ]]; then
-        if grep -q "^export WATERCRAWL_API_URL=" "$MCP_ENV_FILE"; then
+    if [[ -f "$CREDENTIALS_FILE" ]]; then
+        if grep -q "^export WATERCRAWL_API_URL=" "$CREDENTIALS_FILE"; then
             # Update existing URL
-            sed -i.bak "s|^export WATERCRAWL_API_URL=.*|export WATERCRAWL_API_URL=\"$api_url\"|" "$MCP_ENV_FILE"
-            rm -f "${MCP_ENV_FILE}.bak"
+            sed -i.bak "s|^export WATERCRAWL_API_URL=.*|export WATERCRAWL_API_URL=\"$api_url\"|" "$CREDENTIALS_FILE"
+            rm -f "${CREDENTIALS_FILE}.bak"
             print_success "API URL updated to: $api_url"
         else
             # Append new URL
-            echo "export WATERCRAWL_API_URL=\"$api_url\"" >> "$MCP_ENV_FILE"
+            echo "export WATERCRAWL_API_URL=\"$api_url\"" >> "$CREDENTIALS_FILE"
             print_success "API URL added: $api_url"
         fi
     else
         # Create new file
-        cat > "$MCP_ENV_FILE" << EOF
+        cat > "$CREDENTIALS_FILE" << EOF
 #!/bin/bash
 # MCP Environment Variables
-# Permissions should be 600 (chmod 600 $MCP_ENV_FILE)
+# Permissions should be 600 (chmod 600 $CREDENTIALS_FILE)
 
 # WaterCrawl Configuration
 export WATERCRAWL_API_URL="$api_url"
 EOF
-        chmod 600 "$MCP_ENV_FILE"
-        print_success "Created $MCP_ENV_FILE with API URL"
+        chmod 600 "$CREDENTIALS_FILE"
+        print_success "Created $CREDENTIALS_FILE with API URL"
     fi
     
     return 0

--- a/.agents/scripts/wordpress-mcp-helper.sh
+++ b/.agents/scripts/wordpress-mcp-helper.sh
@@ -49,7 +49,7 @@ print_error() {
 # Configuration paths (XDG-compliant user config)
 CONFIG_FILE="${HOME}/.config/aidevops/wordpress-sites-config.json"
 TEMPLATE_FILE="${HOME}/.aidevops/agents/configs/wordpress-sites-config.json.txt"
-MCP_ENV_FILE="${HOME}/.config/aidevops/mcp-env.sh"
+CREDENTIALS_FILE="${HOME}/.config/aidevops/credentials.sh"
 LOCAL_SITES_PATH="${HOME}/Local Sites"
 
 # Check dependencies
@@ -65,9 +65,9 @@ check_dependencies() {
 
 # Load MCP environment variables
 load_mcp_env() {
-    if [[ -f "$MCP_ENV_FILE" ]]; then
+    if [[ -f "$CREDENTIALS_FILE" ]]; then
         # shellcheck source=/dev/null
-        source "$MCP_ENV_FILE"
+        source "$CREDENTIALS_FILE"
     fi
     return 0
 }
@@ -437,7 +437,7 @@ Environment Variables:
 Configuration:
   Sites config: ~/.config/aidevops/wordpress-sites-config.json
   Template:     ~/.aidevops/agents/configs/wordpress-sites-config.json.txt
-  MCP env:      ~/.config/aidevops/mcp-env.sh
+  MCP env:      ~/.config/aidevops/credentials.sh
 
 Setup:
   mkdir -p ~/.config/aidevops

--- a/.agents/seo/ahrefs.md
+++ b/.agents/seo/ahrefs.md
@@ -17,7 +17,7 @@ tools:
 
 - **Purpose**: Backlink analysis, keyword research, site audit, rank tracking
 - **API**: REST at `https://api.ahrefs.com/v3/`
-- **Auth**: Bearer token in `~/.config/aidevops/mcp-env.sh` as `AHREFS_API_KEY`
+- **Auth**: Bearer token in `~/.config/aidevops/credentials.sh` as `AHREFS_API_KEY`
 - **Docs**: https://docs.ahrefs.com/reference
 - **No MCP required** - uses curl directly
 
@@ -26,7 +26,7 @@ tools:
 ## Authentication
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 ```
 
 ## API Endpoints
@@ -107,7 +107,7 @@ curl -s "https://api.ahrefs.com/v3/keywords-explorer/google/keyword-ideas?keywor
 
 ## Setup
 
-Get API key from https://app.ahrefs.com/user/api and add to `~/.config/aidevops/mcp-env.sh`:
+Get API key from https://app.ahrefs.com/user/api and add to `~/.config/aidevops/credentials.sh`:
 
 ```bash
 export AHREFS_API_KEY="your_key_here"

--- a/.agents/seo/bing-webmaster-tools.md
+++ b/.agents/seo/bing-webmaster-tools.md
@@ -19,7 +19,7 @@ tools:
 - **Primary access**: Direct API via `curl`
 - **API Endpoint**: `https://ssl.bing.com/webmaster/api.svc/json/`
 - **Auth**: API Key (passed as query parameter `apikey`)
-- **Credentials**: Store API Key in `~/.config/aidevops/mcp-env.sh` as `BING_API_KEY`
+- **Credentials**: Store API Key in `~/.config/aidevops/credentials.sh` as `BING_API_KEY`
 - **Capabilities**: Submit URLs, URL inspection, Search analytics, Sitemap management
 - **Docs**: [Bing Webmaster API](https://www.bing.com/webmasters/help/webmaster-api-5f3c5e1e)
 
@@ -37,13 +37,13 @@ tools:
 Add the key to your secure environment file:
 
 ```bash
-# Add to ~/.config/aidevops/mcp-env.sh
+# Add to ~/.config/aidevops/credentials.sh
 export BING_API_KEY="your_api_key_here"
 ```
 
 Reload the environment:
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 ```
 
 ## API Operations

--- a/.agents/seo/contentking.md
+++ b/.agents/seo/contentking.md
@@ -19,7 +19,7 @@ tools:
 - **Brand**: ContentKing was acquired by Conductor in 2022; now branded as "Conductor Website Monitoring"
 - **API Base**: `https://api.contentkingapp.com`
 - **App**: `https://app.contentkingapp.com`
-- **Auth**: Bearer token in `Authorization` header, stored in `~/.config/aidevops/mcp-env.sh` as `CONTENTKING_API_TOKEN`
+- **Auth**: Bearer token in `Authorization` header, stored in `~/.config/aidevops/credentials.sh` as `CONTENTKING_API_TOKEN`
 - **Docs**: `https://support.conductor.com/en_US/conductor-monitoring-apis`
 - **No MCP required** - uses curl directly
 
@@ -38,7 +38,7 @@ tools:
 ## Authentication
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 ```
 
 All requests require these headers:
@@ -172,7 +172,7 @@ Response: `{"status": "ok"}`
 ### Health Check Dashboard
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 CK_API="https://api.contentkingapp.com"
 CK_HEADERS=(-H "Authorization: token $CONTENTKING_API_TOKEN" -H "Content-Type: application/json")
 
@@ -193,7 +193,7 @@ done
 ### Find Pages with SEO Issues
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 CK_API="https://api.contentkingapp.com"
 CK_HEADERS=(-H "Authorization: token $CONTENTKING_API_TOKEN" -H "Content-Type: application/json")
 
@@ -211,7 +211,7 @@ curl -s "$CK_API/v2/data/pages?website_id=$WEBSITE_ID&per_page=1000" \
 ### Trigger Audit After CMS Publish
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 CK_HEADERS=(-H "Authorization: token $CONTENTKING_API_TOKEN" -H "Content-Type: application/json")
 
 # After publishing a page, trigger priority audit
@@ -265,7 +265,7 @@ bash ~/.aidevops/agents/scripts/setup-local-api-keys.sh set CONTENTKING_API_TOKE
 4. Verify:
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 curl -s "https://api.contentkingapp.com/v2/entities/websites" \
   -H "Authorization: token $CONTENTKING_API_TOKEN" \
   -H "Content-Type: application/json" | jq .

--- a/.agents/seo/dataforseo.md
+++ b/.agents/seo/dataforseo.md
@@ -18,7 +18,7 @@ tools:
 
 - **Purpose**: Comprehensive SEO data via DataForSEO APIs
 - **API**: REST at `https://api.dataforseo.com/v3/`
-- **Auth**: Basic auth (username:password) in `~/.config/aidevops/mcp-env.sh`
+- **Auth**: Basic auth (username:password) in `~/.config/aidevops/credentials.sh`
 - **Env Vars**: `DATAFORSEO_USERNAME`, `DATAFORSEO_PASSWORD`
 - **Docs**: https://docs.dataforseo.com/v3/
 - **No MCP required** - uses curl directly
@@ -42,7 +42,7 @@ tools:
 ## Direct API Access
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 export DFS_AUTH=$(echo -n "$DATAFORSEO_USERNAME:$DATAFORSEO_PASSWORD" | base64)
 ```
 
@@ -121,7 +121,7 @@ Add to `~/.config/opencode/opencode.json`:
       "command": [
         "/bin/bash",
         "-c",
-        "source ~/.config/aidevops/mcp-env.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD npx dataforseo-mcp-server"
+        "source ~/.config/aidevops/credentials.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD npx dataforseo-mcp-server"
       ],
       "enabled": true
     }

--- a/.agents/seo/domain-research.md
+++ b/.agents/seo/domain-research.md
@@ -63,7 +63,7 @@ domain-research-helper.sh reconeer subdomain api.example.com
 
 # With API key for unlimited access
 domain-research-helper.sh reconeer domain example.com --api-key YOUR_KEY
-# Or set RECONEER_API_KEY in ~/.config/aidevops/mcp-env.sh
+# Or set RECONEER_API_KEY in ~/.config/aidevops/credentials.sh
 ```
 
 **Use Cases**:
@@ -447,7 +447,7 @@ Reconeer provides curated subdomain enumeration with enriched data including IP 
 - **Free tier**: 10 queries/day, no API key required
 - **Premium**: $49/mo for unlimited queries, requires API key
 
-Store your API key in `~/.config/aidevops/mcp-env.sh`:
+Store your API key in `~/.config/aidevops/credentials.sh`:
 
 ```bash
 export RECONEER_API_KEY="your-api-key-here"

--- a/.agents/seo/neuronwriter.md
+++ b/.agents/seo/neuronwriter.md
@@ -17,7 +17,7 @@ tools:
 
 - **Purpose**: SEO content optimization, NLP term recommendations, content scoring, competitor analysis
 - **API**: `https://app.neuronwriter.com/neuron-api/0.5/writer`
-- **Auth**: API key in `X-API-KEY` header, stored in `~/.config/aidevops/mcp-env.sh` as `NEURONWRITER_API_KEY`
+- **Auth**: API key in `X-API-KEY` header, stored in `~/.config/aidevops/credentials.sh` as `NEURONWRITER_API_KEY`
 - **Plan**: Gold plan or higher required
 - **Docs**: https://neuronwriter.com/faqs/neuronwriter-api-how-to-use/
 - **No MCP required** - uses curl directly
@@ -29,7 +29,7 @@ tools:
 ## Authentication
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 ```
 
 ## API Endpoints
@@ -214,7 +214,7 @@ curl -s -X POST "https://app.neuronwriter.com/neuron-api/0.5/writer/evaluate-con
 ### Create Query and Poll for Results
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 
 NW_API="https://app.neuronwriter.com/neuron-api/0.5/writer"
 NW_HEADERS=(-H "X-API-KEY: $NEURONWRITER_API_KEY" -H "Accept: application/json" -H "Content-Type: application/json")
@@ -252,7 +252,7 @@ curl -s -X POST "$NW_API/get-query" "${NW_HEADERS[@]}" \
 ### Score Existing Content Against a Query
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 
 curl -s -X POST "https://app.neuronwriter.com/neuron-api/0.5/writer/evaluate-content" \
   -H "X-API-KEY: $NEURONWRITER_API_KEY" \
@@ -267,7 +267,7 @@ curl -s -X POST "https://app.neuronwriter.com/neuron-api/0.5/writer/evaluate-con
 ### Bulk Keyword Analysis
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 
 NW_API="https://app.neuronwriter.com/neuron-api/0.5/writer"
 NW_HEADERS=(-H "X-API-KEY: $NEURONWRITER_API_KEY" -H "Accept: application/json" -H "Content-Type: application/json")
@@ -307,7 +307,7 @@ bash ~/.aidevops/agents/scripts/setup-local-api-keys.sh set NEURONWRITER_API_KEY
 3. Verify:
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 curl -s -X POST "https://app.neuronwriter.com/neuron-api/0.5/writer/list-projects" \
   -H "X-API-KEY: $NEURONWRITER_API_KEY" \
   -H "Accept: application/json" \

--- a/.agents/seo/semrush.md
+++ b/.agents/seo/semrush.md
@@ -17,7 +17,7 @@ tools:
 
 - **Purpose**: Domain analytics, keyword research, backlink analysis, competitor research, position tracking, site audit
 - **API**: REST at `https://api.semrush.com/` (Analytics v3) and `https://api.semrush.com/management/v1/` (Projects)
-- **Auth**: API key as query parameter `key=` in `~/.config/aidevops/mcp-env.sh` as `SEMRUSH_API_KEY`
+- **Auth**: API key as query parameter `key=` in `~/.config/aidevops/credentials.sh` as `SEMRUSH_API_KEY`
 - **Docs**: https://developer.semrush.com/api/
 - **Response format**: CSV (semicolon-delimited) for Analytics v3
 - **No MCP required** - uses curl directly (Semrush also offers an official MCP server for AI tool integration)
@@ -39,7 +39,7 @@ Additional units can be purchased. Use `display_limit` to control unit consumpti
 ## Authentication
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 ```
 
 ## API Unit Balance
@@ -227,7 +227,7 @@ curl -s "https://api.semrush.com/?key=$SEMRUSH_API_KEY&type=domain_organic&expor
 
 ## Setup
 
-Get API key from Semrush account > Subscription Info > API Units tab, and add to `~/.config/aidevops/mcp-env.sh`:
+Get API key from Semrush account > Subscription Info > API Units tab, and add to `~/.config/aidevops/credentials.sh`:
 
 ```bash
 export SEMRUSH_API_KEY="your_key_here"

--- a/.agents/seo/serper.md
+++ b/.agents/seo/serper.md
@@ -17,7 +17,7 @@ tools:
 
 - **Purpose**: Google Search results (web, images, news, places, shopping, scholar)
 - **API**: `https://google.serper.dev`
-- **Auth**: API key in `~/.config/aidevops/mcp-env.sh` as `SERPER_API_KEY`
+- **Auth**: API key in `~/.config/aidevops/credentials.sh` as `SERPER_API_KEY`
 - **Dashboard**: https://serper.dev/
 - **No MCP required** - uses curl directly
 
@@ -26,7 +26,7 @@ tools:
 ## Authentication
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 ```
 
 ## API Endpoints
@@ -107,7 +107,7 @@ curl -s -X POST https://google.serper.dev/autocomplete \
 
 ## Setup
 
-Get API key from https://serper.dev/ and add to `~/.config/aidevops/mcp-env.sh`:
+Get API key from https://serper.dev/ and add to `~/.config/aidevops/credentials.sh`:
 
 ```bash
 export SERPER_API_KEY="your_key_here"

--- a/.agents/services/communications/twilio.md
+++ b/.agents/services/communications/twilio.md
@@ -454,7 +454,7 @@ Transcriptions can be:
 
 ```bash
 # Store credentials securely
-# In ~/.config/aidevops/mcp-env.sh (600 permissions)
+# In ~/.config/aidevops/credentials.sh (600 permissions)
 export TWILIO_ACCOUNT_SID_PRODUCTION="ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 export TWILIO_AUTH_TOKEN_PRODUCTION="your_token_here"
 

--- a/.agents/services/crm/fluentcrm.md
+++ b/.agents/services/crm/fluentcrm.md
@@ -78,7 +78,7 @@ Add to `~/.config/opencode/opencode.json` (disabled globally for token efficienc
   "mcp": {
     "fluentcrm": {
       "type": "local",
-      "command": ["/bin/bash", "-c", "source ~/.config/aidevops/mcp-env.sh && node ~/.local/share/mcp-servers/fluentcrm-mcp-server/dist/fluentcrm-mcp-server.js"],
+      "command": ["/bin/bash", "-c", "source ~/.config/aidevops/credentials.sh && node ~/.local/share/mcp-servers/fluentcrm-mcp-server/dist/fluentcrm-mcp-server.js"],
       "enabled": false
     }
   }

--- a/.agents/services/document-processing/unstract.md
+++ b/.agents/services/document-processing/unstract.md
@@ -23,7 +23,7 @@ mcp:
 - **Purpose**: Extract structured data from unstructured documents (PDFs, images, DOCX, etc.)
 - **MCP Server**: `unstract/mcp-server` (Docker) or `@unstract/mcp-server` (npx)
 - **Tool**: `unstract_tool` - submits files to Unstract API, polls for completion, returns structured JSON
-- **Credentials**: `UNSTRACT_API_KEY` + `API_BASE_URL` in `~/.config/aidevops/mcp-env.sh` (chmod 600)
+- **Credentials**: `UNSTRACT_API_KEY` + `API_BASE_URL` in `~/.config/aidevops/credentials.sh` (chmod 600)
 - **Docs**: https://docs.unstract.com/unstract/unstract_platform/mcp/unstract_platform_mcp_server/
 - **GitHub**: https://github.com/Zipstack/unstract
 
@@ -74,10 +74,10 @@ The MCP server is a thin client that connects to any Unstract API endpoint - clo
 4. Copy the API key and deployment URL
 
 ```bash
-# Add to ~/.config/aidevops/mcp-env.sh:
+# Add to ~/.config/aidevops/credentials.sh:
 export UNSTRACT_API_KEY="your_api_key_here"
 export API_BASE_URL="https://us-central.unstract.com/deployment/api/your-deployment-id/"
-chmod 600 ~/.config/aidevops/mcp-env.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 ### Option B: Self-Hosted (Local) - Recommended
@@ -111,7 +111,7 @@ Self-hosted gives full data privacy - no documents leave your machine.
 
 ### Using Your Existing LLM API Keys
 
-Unstract uses "Adapters" to connect to LLM providers. Your existing API keys from `~/.config/aidevops/mcp-env.sh` work directly - just add them as adapters in the Unstract UI (Settings > Adapters):
+Unstract uses "Adapters" to connect to LLM providers. Your existing API keys from `~/.config/aidevops/credentials.sh` work directly - just add them as adapters in the Unstract UI (Settings > Adapters):
 
 | Your Key | Unstract Adapter |
 |----------|-----------------|
@@ -128,12 +128,12 @@ For fully local/offline operation, use **Ollama** as the LLM adapter - no cloud 
 
 ### 2. Store Credentials
 
-Whichever option you chose, ensure credentials are in `~/.config/aidevops/mcp-env.sh`:
+Whichever option you chose, ensure credentials are in `~/.config/aidevops/credentials.sh`:
 
 ```bash
 export UNSTRACT_API_KEY="your_api_key_here"
 export API_BASE_URL="http://backend.unstract.localhost/deployment/api/your-id/"
-chmod 600 ~/.config/aidevops/mcp-env.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 **Note**: The MCP expects `API_BASE_URL` (not prefixed). This matches the official Unstract spec.

--- a/.agents/services/hosting/hetzner.md
+++ b/.agents/services/hosting/hetzner.md
@@ -18,7 +18,7 @@ tools:
 
 - **Type**: Cloud VPS, dedicated servers, storage
 - **API**: REST at `https://api.hetzner.cloud/v1`
-- **Auth**: Bearer token per project (stored in `~/.config/aidevops/mcp-env.sh`)
+- **Auth**: Bearer token per project (stored in `~/.config/aidevops/credentials.sh`)
 - **Token format**: `HCLOUD_TOKEN_{PROJECT}` (e.g. `HCLOUD_TOKEN_MYPROJECT`)
 - **Locations**: Germany (fsn1, nbg1), Finland (hel1), USA (ash, hil)
 - **Server types**: CX (shared), CPX (dedicated vCPU), CCX (dedicated CPU)
@@ -32,7 +32,7 @@ tools:
 
 ```bash
 # Load token for a specific project
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 export HCLOUD_TOKEN="$HCLOUD_TOKEN_MYPROJECT"
 
 # Verify access
@@ -152,7 +152,7 @@ for i in json.load(sys.stdin)['images']:
 
 ## Multi-Project Setup
 
-Each Hetzner Cloud project gets its own API token. Store them in `~/.config/aidevops/mcp-env.sh`:
+Each Hetzner Cloud project gets its own API token. Store them in `~/.config/aidevops/credentials.sh`:
 
 ```bash
 export HCLOUD_TOKEN_PROJECTA="hc_..."
@@ -172,7 +172,7 @@ For frequent interactive use, enable the MCP server in `opencode.json`:
 "hetzner-myproject": {
   "type": "local",
   "command": ["/bin/bash", "-c",
-    "source ~/.config/aidevops/mcp-env.sh && HCLOUD_TOKEN=$HCLOUD_TOKEN_MYPROJECT /Users/you/.local/bin/mcp-hetzner"],
+    "source ~/.config/aidevops/credentials.sh && HCLOUD_TOKEN=$HCLOUD_TOKEN_MYPROJECT /Users/you/.local/bin/mcp-hetzner"],
   "enabled": true
 }
 ```

--- a/.agents/services/hosting/hostinger.md
+++ b/.agents/services/hosting/hostinger.md
@@ -18,7 +18,7 @@ tools:
 
 - **Type**: Shared/VPS/Cloud hosting, budget-friendly
 - **API**: REST at `https://developers.hostinger.com`
-- **Auth**: Bearer token in `~/.config/aidevops/mcp-env.sh` as `HOSTINGER_API_TOKEN`
+- **Auth**: Bearer token in `~/.config/aidevops/credentials.sh` as `HOSTINGER_API_TOKEN`
 - **SSH**: Port 65002, password auth (no SSH keys on shared)
 - **Panel**: Custom hPanel
 - **No MCP required** - uses curl for API, sshpass for SSH

--- a/.agents/services/monitoring/sentry.md
+++ b/.agents/services/monitoring/sentry.md
@@ -23,7 +23,7 @@ mcp:
 - **Purpose**: Error monitoring, debugging, and issue tracking via Sentry
 - **MCP**: Local stdio mode with `@sentry/mcp-server`
 - **Auth**: Personal Auth Token (created after org exists)
-- **Credentials**: `~/.config/aidevops/mcp-env.sh` → `SENTRY_YOURNAME`
+- **Credentials**: `~/.config/aidevops/credentials.sh` → `SENTRY_YOURNAME`
 
 **When to use**:
 
@@ -58,14 +58,14 @@ mcp:
 4. Save token:
 
 ```bash
-echo 'export SENTRY_YOURNAME="sntryu_..."' >> ~/.config/aidevops/mcp-env.sh
-chmod 600 ~/.config/aidevops/mcp-env.sh
+echo 'export SENTRY_YOURNAME="sntryu_..."' >> ~/.config/aidevops/credentials.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 ### 3. Configure OpenCode MCP
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 jq --arg token "$SENTRY_YOURNAME" \
   '.mcp.sentry = {"type": "local", "command": ["npx", "@sentry/mcp-server@latest", "--access-token", $token], "enabled": false}' \
   ~/.config/opencode/opencode.json > /tmp/oc.json && mv /tmp/oc.json ~/.config/opencode/opencode.json
@@ -74,7 +74,7 @@ jq --arg token "$SENTRY_YOURNAME" \
 ### 4. Test Connection
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 curl -s -H "Authorization: Bearer $SENTRY_YOURNAME" "https://sentry.io/api/0/organizations/" | jq '.[].slug'
 ```
 
@@ -118,7 +118,7 @@ Create a new Personal Auth Token **after** the organization exists.
 
 ### "Not authenticated"
 
-1. Verify token: `source ~/.config/aidevops/mcp-env.sh && echo $SENTRY_YOURNAME`
+1. Verify token: `source ~/.config/aidevops/credentials.sh && echo $SENTRY_YOURNAME`
 2. Test API: `curl -H "Authorization: Bearer $SENTRY_YOURNAME" https://sentry.io/api/0/`
 3. Restart OpenCode after config changes
 

--- a/.agents/services/monitoring/socket.md
+++ b/.agents/services/monitoring/socket.md
@@ -23,7 +23,7 @@ mcp:
 - **Purpose**: Dependency security scanning for npm/pip packages
 - **MCP**: Remote at `https://mcp.socket.dev/`
 - **Auth**: API token from socket.dev
-- **Credentials**: `~/.config/aidevops/mcp-env.sh` → `SOCKET_YOURNAME`
+- **Credentials**: `~/.config/aidevops/credentials.sh` → `SOCKET_YOURNAME`
 
 **When to use**:
 
@@ -49,8 +49,8 @@ mcp:
 4. Save token:
 
 ```bash
-echo 'export SOCKET_YOURNAME="sktsec_..."' >> ~/.config/aidevops/mcp-env.sh
-chmod 600 ~/.config/aidevops/mcp-env.sh
+echo 'export SOCKET_YOURNAME="sktsec_..."' >> ~/.config/aidevops/credentials.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 ### 3. Configure OpenCode MCP
@@ -67,7 +67,7 @@ jq '.mcp.socket = {"type": "remote", "url": "https://mcp.socket.dev/", "enabled"
 ### 4. Test Connection
 
 ```bash
-source ~/.config/aidevops/mcp-env.sh
+source ~/.config/aidevops/credentials.sh
 curl -s -H "Authorization: Bearer $SOCKET_YOURNAME" "https://api.socket.dev/v0/organizations" | jq '.organizations'
 ```
 
@@ -108,7 +108,7 @@ socket npm info lodash
 
 ### "Unauthorized" error
 
-1. Verify token: `source ~/.config/aidevops/mcp-env.sh && echo $SOCKET_YOURNAME`
+1. Verify token: `source ~/.config/aidevops/credentials.sh && echo $SOCKET_YOURNAME`
 2. Check token has correct permissions in socket.dev dashboard
 3. Token format should start with `sktsec_`
 

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -46,7 +46,7 @@ tools/video/,Video creation and downloading - programmatic generation and YouTub
 tools/data-extraction/,Data extraction - scraping business data,outscraper
 tools/deployment/,Deployment automation - self-hosted PaaS,coolify|coolify-cli|vercel|cloudron-app-packaging
 tools/git/,Git operations - GitHub/GitLab/Gitea CLIs,github-cli|gitlab-cli|gitea-cli|github-actions|worktrunk
-tools/credentials/,Secret management - API keys and vaults,api-key-setup|api-key-management|vaultwarden
+tools/credentials/,Secret management - API keys and vaults,api-key-setup|api-key-management|vaultwarden|gopass|psst|multi-tenant|list-keys
 tools/security/,Security tools - privacy filtering and scanning,privacy-filter
 tools/task-management/,Task tracking - dependency graphs,beads
 tools/terminal/,Terminal integration - tab titles,terminal-title

--- a/.agents/tools/browser/proxy-integration.md
+++ b/.agents/tools/browser/proxy-integration.md
@@ -28,7 +28,7 @@ Network identity layer for anti-detect browser profiles. Supports residential, d
 
 ## Provider Configuration
 
-Proxy credentials stored in `~/.config/aidevops/mcp-env.sh`:
+Proxy credentials stored in `~/.config/aidevops/credentials.sh`:
 
 ```bash
 # Residential providers
@@ -250,7 +250,7 @@ Services to be added as subagents when needed:
 
 ## Security Notes
 
-- Never commit proxy credentials (stored in `mcp-env.sh` with 600 permissions)
+- Never commit proxy credentials (stored in `credentials.sh` with 600 permissions)
 - Use sticky sessions for login flows (avoid IP changes mid-session)
 - Match proxy geo to profile fingerprint (timezone, locale, geolocation)
 - Monitor proxy usage/costs via provider dashboards

--- a/.agents/tools/browser/watercrawl.md
+++ b/.agents/tools/browser/watercrawl.md
@@ -44,7 +44,7 @@ tools:
 
 **SDKs**: Node.js (`@watercrawl/nodejs`), Python (`watercrawl-py`), Go, PHP
 
-**Env Vars**: `WATERCRAWL_API_KEY`, `WATERCRAWL_API_URL` (stored in `~/.config/aidevops/mcp-env.sh`)
+**Env Vars**: `WATERCRAWL_API_KEY`, `WATERCRAWL_API_URL` (stored in `~/.config/aidevops/credentials.sh`)
 
 **vs Crawl4AI**: Both self-hostable. WaterCrawl has web search + full web UI; Crawl4AI has CAPTCHA solving + Python-native. Use WaterCrawl for web search and team dashboards. Use Crawl4AI for CAPTCHA-heavy sites.
 

--- a/.agents/tools/build-agent/agent-testing.md
+++ b/.agents/tools/build-agent/agent-testing.md
@@ -219,7 +219,7 @@ Tests that the agent has absorbed key instructions from AGENTS.md:
     {
       "id": "security-credentials",
       "prompt": "Where should credentials be stored?",
-      "expect_contains": ["mcp-env.sh"],
+      "expect_contains": ["credentials.sh"],
       "expect_regex": "600"
     }
   ]

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -539,7 +539,7 @@ Read subagents only when task requires them.
 
    ```bash
    # Pattern for credential storage (authoritative)
-   # Store actual values in ~/.config/aidevops/mcp-env.sh
+   # Store actual values in ~/.config/aidevops/credentials.sh
    export SERVICE_API_KEY="${SERVICE_API_KEY:-}"
    ```
 

--- a/.agents/tools/code-review/skill-scanner.md
+++ b/.agents/tools/code-review/skill-scanner.md
@@ -128,7 +128,7 @@ export VIRUSTOTAL_API_KEY="your_key"
 export AI_DEFENSE_API_KEY="your_key"
 ```
 
-Store keys in `~/.config/aidevops/mcp-env.sh` (600 permissions).
+Store keys in `~/.config/aidevops/credentials.sh` (600 permissions).
 
 ## Response Guidelines
 

--- a/.agents/tools/context/augment-context-engine.md
+++ b/.agents/tools/context/augment-context-engine.md
@@ -361,7 +361,7 @@ TOKEN={"accessToken":"your-access-token","tenantURL":"your-tenant-url","scopes":
 
 ### 2. Configure Environment Variables
 
-Add to your CI/CD environment or `~/.config/aidevops/mcp-env.sh`:
+Add to your CI/CD environment or `~/.config/aidevops/credentials.sh`:
 
 ```bash
 export AUGMENT_API_TOKEN="your-access-token"
@@ -406,7 +406,7 @@ droid mcp add augment-code "auggie" --mcp --env AUGMENT_API_TOKEN=your-access-to
 |--------|----------|----------|
 | Interactive | `~/.augment/session.json` | Local development |
 | Environment | `AUGMENT_API_TOKEN` + `AUGMENT_API_URL` | CI/CD, automation |
-| aidevops pattern | `~/.config/aidevops/mcp-env.sh` | Consistent with other services |
+| aidevops pattern | `~/.config/aidevops/credentials.sh` | Consistent with other services |
 
 ## Troubleshooting
 

--- a/.agents/tools/credentials/api-key-setup.md
+++ b/.agents/tools/credentials/api-key-setup.md
@@ -18,11 +18,20 @@ tools:
 
 ## Quick Reference
 
-- **Secrets Location**: `~/.config/aidevops/credentials.sh` (600 permissions)
+- **Recommended**: `aidevops secret set NAME` (gopass encrypted, AI-safe)
+- **Plaintext fallback**: `~/.config/aidevops/credentials.sh` (600 permissions)
 - **Working Dirs**: `~/.aidevops/` (agno, stagehand, reports)
 - **Setup**: `bash ~/Git/aidevops/.agents/scripts/setup-local-api-keys.sh setup`
 
-**Commands**:
+**Encrypted storage** (recommended):
+
+- `aidevops secret init` - Initialize gopass store
+- `aidevops secret set NAME` - Store secret (hidden input, GPG-encrypted)
+- `aidevops secret list` - List names (never values)
+- `aidevops secret run CMD` - Inject secrets + redact output
+
+**Plaintext storage** (fallback):
+
 - `set <service-name> <VALUE>` - Store API key (converts to UPPER_CASE export)
 - `add 'export VAR="value"'` - Parse and store export command
 - `get <service-name>` - Retrieve key value
@@ -30,7 +39,7 @@ tools:
 
 **Common Services**: codacy-project-token, sonar-token, coderabbit-api-key, hcloud-token-*, openai-api-key
 
-**Security**: Shell startup auto-sources credentials.sh, never commit keys to repo
+**Security**: NEVER accept secret values in AI conversation. Instruct users to run `aidevops secret set NAME` at their terminal.
 <!-- AI-CONTEXT-END -->
 
 ## Directory Structure
@@ -236,9 +245,22 @@ See `multi-tenant.md` for full documentation.
 
 ## Best Practices
 
-1. **Single source** - Always add keys via `setup-local-api-keys.sh` or `credential-helper.sh`
-2. **Regular rotation** - Rotate API keys every 90 days
-3. **Minimal permissions** - Use tokens with minimal required scopes
-4. **Monitor usage** - Check API usage in provider dashboards
-5. **Never commit** - API keys should never appear in git history
-6. **Use tenants** - Separate client/environment credentials with multi-tenant storage
+1. **Use gopass** - Prefer `aidevops secret set` for encrypted storage
+2. **Single source** - Always add keys via `aidevops secret set`, `setup-local-api-keys.sh`, or `credential-helper.sh`
+3. **Regular rotation** - Rotate API keys every 90 days
+4. **Minimal permissions** - Use tokens with minimal required scopes
+5. **Monitor usage** - Check API usage in provider dashboards
+6. **Never commit** - API keys should never appear in git history
+7. **Use tenants** - Separate client/environment credentials with multi-tenant storage
+8. **AI-safe** - Never accept secret values in AI conversation context
+
+## Encrypted Storage (Recommended)
+
+For encrypted secret storage with gopass, see `tools/credentials/gopass.md`.
+
+```bash
+# Quick start
+aidevops secret init              # One-time setup
+aidevops secret set API_KEY       # Store (hidden input)
+aidevops secret run some-command  # Use (injected + redacted)
+```

--- a/.agents/tools/credentials/api-key-setup.md
+++ b/.agents/tools/credentials/api-key-setup.md
@@ -18,7 +18,7 @@ tools:
 
 ## Quick Reference
 
-- **Secrets Location**: `~/.config/aidevops/mcp-env.sh` (600 permissions)
+- **Secrets Location**: `~/.config/aidevops/credentials.sh` (600 permissions)
 - **Working Dirs**: `~/.aidevops/` (agno, stagehand, reports)
 - **Setup**: `bash ~/Git/aidevops/.agents/scripts/setup-local-api-keys.sh setup`
 
@@ -30,7 +30,7 @@ tools:
 
 **Common Services**: codacy-project-token, sonar-token, coderabbit-api-key, hcloud-token-*, openai-api-key
 
-**Security**: Shell startup auto-sources mcp-env.sh, never commit keys to repo
+**Security**: Shell startup auto-sources credentials.sh, never commit keys to repo
 <!-- AI-CONTEXT-END -->
 
 ## Directory Structure
@@ -44,7 +44,7 @@ AI DevOps uses two directories for different purposes:
 
 ## Security Principle
 
-**API keys are stored ONLY in `~/.config/aidevops/mcp-env.sh`, NEVER in repository files.**
+**API keys are stored ONLY in `~/.config/aidevops/credentials.sh`, NEVER in repository files.**
 
 This file is automatically sourced by your shell (zsh and bash) on startup.
 
@@ -59,7 +59,7 @@ bash ~/Git/aidevops/.agents/scripts/setup-local-api-keys.sh setup
 This will:
 
 - Create `~/.config/aidevops/` with secure permissions
-- Create `mcp-env.sh` for storing API keys
+- Create `credentials.sh` for storing API keys
 - Add sourcing to your shell configs (`.zshrc`, `.bashrc`, `.bash_profile`)
 
 ### 2. Store API Keys
@@ -125,12 +125,12 @@ bash .agents/scripts/setup-local-api-keys.sh list
 bash .agents/scripts/setup-local-api-keys.sh get sonar-token
 
 # View the file directly (redacted)
-cat ~/.config/aidevops/mcp-env.sh | sed 's/=.*/=<REDACTED>/'
+cat ~/.config/aidevops/credentials.sh | sed 's/=.*/=<REDACTED>/'
 ```
 
 ## How It Works
 
-1. **mcp-env.sh** contains all API keys as shell exports:
+1. **credentials.sh** contains all API keys as shell exports:
 
    ```bash
    export SONAR_TOKEN="xxx"
@@ -141,7 +141,7 @@ cat ~/.config/aidevops/mcp-env.sh | sed 's/=.*/=<REDACTED>/'
 
    ```bash
    # In ~/.zshrc and ~/.bashrc:
-   [[ -f ~/.config/aidevops/mcp-env.sh ]] && source ~/.config/aidevops/mcp-env.sh
+   [[ -f ~/.config/aidevops/credentials.sh ]] && source ~/.config/aidevops/credentials.sh
    ```
 
 3. **All processes** (terminals, scripts, MCPs) get access to the env vars
@@ -150,7 +150,7 @@ cat ~/.config/aidevops/mcp-env.sh | sed 's/=.*/=<REDACTED>/'
 
 ### Secrets (Secure - 600 permissions)
 
-- `~/.config/aidevops/mcp-env.sh` - All API keys and tokens
+- `~/.config/aidevops/credentials.sh` - All API keys and tokens
 
 ### Working Directories (Standard permissions)
 
@@ -174,14 +174,14 @@ cat ~/.config/aidevops/mcp-env.sh | sed 's/=.*/=<REDACTED>/'
 # Verify permissions
 ls -la ~/.config/aidevops/
 # drwx------ (700) for directory
-# -rw------- (600) for mcp-env.sh
+# -rw------- (600) for credentials.sh
 ```
 
 ### Fix Permissions
 
 ```bash
 chmod 700 ~/.config/aidevops
-chmod 600 ~/.config/aidevops/mcp-env.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 ## Troubleshooting

--- a/.agents/tools/credentials/gopass.md
+++ b/.agents/tools/credentials/gopass.md
@@ -1,0 +1,190 @@
+---
+description: gopass encrypted secret management with AI-native wrapper
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: false
+  task: false
+---
+
+# gopass - Encrypted Secret Management
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Backend**: gopass (GPG/age encrypted, git-versioned, team-shareable)
+- **CLI**: `aidevops secret <command>` or `secret-helper.sh <command>`
+- **Store path**: `~/.local/share/gopass/stores/root/aidevops/`
+- **Fallback**: `~/.config/aidevops/credentials.sh` (plaintext, chmod 600)
+
+**Commands**:
+
+- `aidevops secret set NAME` -- Store secret (interactive hidden input)
+- `aidevops secret list` -- List names only (never values)
+- `aidevops secret run CMD` -- Inject all secrets, redact output
+- `aidevops secret NAME -- CMD` -- Inject specific secrets, redact output
+- `aidevops secret init` -- Initialize gopass store
+- `aidevops secret import-credentials` -- Migrate from credentials.sh
+- `aidevops secret status` -- Show backend status
+
+**CRITICAL**: NEVER use `gopass show`, `gopass cat`, or any command that prints secret values in agent context. Use `aidevops secret run` for subprocess injection with automatic output redaction.
+
+<!-- AI-CONTEXT-END -->
+
+## Why gopass
+
+| Feature | gopass | credentials.sh |
+|---------|--------|----------------|
+| Encryption at rest | GPG/age | None (plaintext) |
+| Team sharing | Git sync + GPG recipients | Manual copy |
+| Audit trail | Git history | None |
+| AI-safe | Subprocess injection + redaction | Agent can `cat` the file |
+| Breach detection | `gopass audit` + HIBP | None |
+
+## Installation
+
+```bash
+# macOS
+brew install gopass
+
+# Linux (Debian/Ubuntu)
+apt install gopass
+
+# Linux (Arch)
+pacman -S gopass
+
+# Or via aidevops
+aidevops secret init  # Auto-installs if missing
+```
+
+### Prerequisites
+
+- **GPG**: Required for encryption (`brew install gnupg`)
+- **pinentry-mac**: Required on macOS for passphrase entry (`brew install pinentry-mac`)
+- **git**: Required for versioned storage (already required by aidevops)
+
+## Setup
+
+```bash
+# Initialize gopass (creates GPG key if needed)
+aidevops secret init
+
+# Import existing credentials from credentials.sh
+aidevops secret import-credentials
+
+# Verify
+aidevops secret list
+aidevops secret status
+```
+
+## Usage
+
+### Storing Secrets
+
+```bash
+# Interactive hidden input (value never visible)
+aidevops secret set GITHUB_TOKEN
+aidevops secret set OPENAI_API_KEY
+aidevops secret set STRIPE_SECRET_KEY
+```
+
+### Using Secrets in Commands
+
+```bash
+# Inject all secrets into a command (output redacted)
+aidevops secret run npx some-mcp-server
+
+# Inject specific secrets only
+aidevops secret GITHUB_TOKEN -- gh api /user
+aidevops secret STRIPE_SECRET_KEY -- curl https://api.stripe.com/v1/charges
+
+# MCP server with secrets (replaces: source credentials.sh && npx server)
+aidevops secret run npx @anthropic/mcp-server-github
+```
+
+### Listing Secrets
+
+```bash
+# Names only (never values)
+aidevops secret list
+
+# Backend status
+aidevops secret status
+```
+
+## Team Sharing
+
+gopass uses GPG recipients for team access:
+
+```bash
+# Add team member's GPG key
+gpg --import teammate-public-key.asc
+
+# Add as gopass recipient
+gopass recipients add teammate@example.com
+
+# Sync via git
+gopass sync
+```
+
+## Agent Instructions
+
+When an AI agent needs a secret:
+
+1. Agent instructs user: "Please run: `aidevops secret set SECRET_NAME`"
+2. User runs command at terminal (value entered with hidden input)
+3. Agent uses secret via: `aidevops secret SECRET_NAME -- command`
+4. Output is automatically redacted
+
+**Prohibited commands** (NEVER run in agent context):
+
+- `gopass show` / `gopass cat` -- prints secret values
+- `cat ~/.config/aidevops/credentials.sh` -- exposes plaintext
+- `echo $SECRET_NAME` -- leaks to agent context
+- `env | grep` -- exposes environment variables
+
+## psst Alternative
+
+For solo developers who prefer simplicity, [psst](https://github.com/nicholasgasior/psst) is a documented alternative:
+
+- Simpler setup (Bun-based, no GPG)
+- AI-native design (built for agent workflows)
+- Trade-offs: v0.3.0, 61 stars, no team features, Bun dependency
+
+See `tools/credentials/psst.md` for psst documentation.
+
+## Architecture
+
+```text
+                    User Terminal (interactive)
+                           |
+                    aidevops secret set NAME
+                           |
+                    gopass insert aidevops/NAME
+                           |
+              ~/.local/share/gopass/stores/root/
+              (GPG-encrypted files, git-versioned)
+                           |
+              aidevops secret NAME -- command
+                           |
+              1. gopass show -o aidevops/NAME
+              2. Inject into subprocess env
+              3. Execute command
+              4. Redact output
+              5. Return exit code
+```
+
+## Related
+
+- `tools/credentials/api-key-setup.md` -- Plaintext credential setup
+- `tools/credentials/multi-tenant.md` -- Multi-tenant credential storage
+- `tools/credentials/psst.md` -- psst alternative for solo devs
+- `tools/credentials/list-keys.md` -- List configured keys
+- `.agents/scripts/secret-helper.sh` -- Implementation
+- `.agents/scripts/credential-helper.sh` -- Multi-tenant plaintext backend

--- a/.agents/tools/credentials/list-keys.md
+++ b/.agents/tools/credentials/list-keys.md
@@ -24,7 +24,7 @@ tools:
 - **Security**: Shows key names only, never exposes actual values
 
 **Key Sources** (checked in order):
-1. `~/.config/aidevops/mcp-env.sh` - Primary credential store (600 permissions)
+1. `~/.config/aidevops/credentials.sh` - Primary credential store (600 permissions)
 2. `~/.zshrc`, `~/.bashrc`, etc. - Shell config exports (credential patterns)
 3. Environment variables - Session-only keys matching `*_KEY`, `*_TOKEN`, `*_SECRET`, etc.
 4. `~/.config/coderabbit/api_key` - CodeRabbit CLI token
@@ -55,7 +55,7 @@ Example output:
 API Keys Available in Session
 =============================
 
-Source: ~/.config/aidevops/mcp-env.sh
+Source: ~/.config/aidevops/credentials.sh
   OPENAI_API_KEY          [loaded]
   ANTHROPIC_API_KEY       [loaded]
   CLOUDFLARE_API_KEY      [loaded]

--- a/.agents/tools/credentials/multi-tenant.md
+++ b/.agents/tools/credentials/multi-tenant.md
@@ -42,6 +42,8 @@ Multi-tenant credential storage allows managing separate credential sets for:
 - **Multiple accounts** (personal, work, freelance)
 - **Multiple services** (different GitHub orgs, Cloudflare accounts)
 
+**Note**: For encrypted secret storage, see `tools/credentials/gopass.md`. gopass can be used alongside multi-tenant storage -- use `aidevops secret` for encrypted secrets and `credential-helper.sh` for tenant switching.
+
 ## Architecture
 
 ```text

--- a/.agents/tools/credentials/multi-tenant.md
+++ b/.agents/tools/credentials/multi-tenant.md
@@ -19,11 +19,11 @@ tools:
 ## Quick Reference
 
 - **Script**: `.agents/scripts/credential-helper.sh`
-- **Storage**: `~/.config/aidevops/tenants/{tenant}/mcp-env.sh`
+- **Storage**: `~/.config/aidevops/tenants/{tenant}/credentials.sh`
 - **Active tenant**: `~/.config/aidevops/active-tenant`
 - **Project override**: `.aidevops-tenant` (gitignored)
 - **Priority**: Project tenant > Global active > "default"
-- **Backward compatible**: Existing `mcp-env.sh` migrates to `default` tenant
+- **Backward compatible**: Existing `credentials.sh` migrates to `default` tenant
 
 **Quick commands**:
 - `credential-helper.sh init` - Initialize (migrates existing keys)
@@ -46,15 +46,15 @@ Multi-tenant credential storage allows managing separate credential sets for:
 
 ```text
 ~/.config/aidevops/
-├── mcp-env.sh              # Loader (sources active tenant)
+├── credentials.sh              # Loader (sources active tenant)
 ├── active-tenant           # Global active tenant name
 └── tenants/
     ├── default/
-    │   └── mcp-env.sh      # Original credentials (migrated)
+    │   └── credentials.sh      # Original credentials (migrated)
     ├── client-acme/
-    │   └── mcp-env.sh      # Acme Corp credentials
+    │   └── credentials.sh      # Acme Corp credentials
     └── client-globex/
-        └── mcp-env.sh      # Globex Corp credentials
+        └── credentials.sh      # Globex Corp credentials
 ```
 
 ### Resolution Priority
@@ -68,7 +68,7 @@ Multi-tenant credential storage allows managing separate credential sets for:
 ### Initialize
 
 ```bash
-# First time: migrates existing mcp-env.sh to 'default' tenant
+# First time: migrates existing credentials.sh to 'default' tenant
 credential-helper.sh init
 ```
 
@@ -168,7 +168,7 @@ credential-helper.sh copy default client-acme
 
 ### Shell Integration
 
-The `mcp-env.sh` loader is sourced by shell startup (`.zshrc`/`.bashrc`). After switching tenants, either:
+The `credentials.sh` loader is sourced by shell startup (`.zshrc`/`.bashrc`). After switching tenants, either:
 
 ```bash
 source ~/.zshrc          # Reload current shell
@@ -202,7 +202,7 @@ api-keys action:set service:KEY_NAME    # Sets in active tenant
 ## Security
 
 - All tenant directories: `700` permissions
-- All `mcp-env.sh` files: `600` permissions
+- All `credentials.sh` files: `600` permissions
 - `.aidevops-tenant` is automatically added to `.gitignore`
 - Tenant names validated (alphanumeric, hyphens, underscores only)
 - Cannot delete the `default` tenant
@@ -210,7 +210,7 @@ api-keys action:set service:KEY_NAME    # Sets in active tenant
 
 ## Backward Compatibility
 
-- Existing `mcp-env.sh` is automatically migrated to `default` tenant on first `init`
-- The legacy `mcp-env.sh` file becomes a loader that sources the active tenant
+- Existing `credentials.sh` is automatically migrated to `default` tenant on first `init`
+- The legacy `credentials.sh` file becomes a loader that sources the active tenant
 - `setup-local-api-keys.sh` continues to work (operates on active tenant)
 - `list-keys-helper.sh` continues to work (reads from sourced environment)

--- a/.agents/tools/credentials/psst.md
+++ b/.agents/tools/credentials/psst.md
@@ -1,0 +1,82 @@
+---
+description: psst - AI-native secret manager alternative to gopass
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: false
+  task: false
+---
+
+# psst - AI-Native Secret Manager (Alternative)
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Status**: Documented alternative (gopass is recommended primary)
+- **Repo**: https://github.com/nicholasgasior/psst (61 stars, v0.3.0)
+- **Install**: `bun install -g psst-cli`
+- **Requires**: Bun runtime
+
+**Trade-offs vs gopass**:
+
+| Feature | gopass (recommended) | psst |
+|---------|---------------------|------|
+| Maturity | 6.7k stars, 8+ years | 61 stars, v0.3.0 |
+| Encryption | GPG/age (industry standard) | AES-256-GCM |
+| Team sharing | Git sync + GPG recipients | No |
+| Dependencies | Single Go binary | Bun runtime |
+| AI-native | Via aidevops wrapper | Built-in |
+| Audit trail | Git history | None |
+
+<!-- AI-CONTEXT-END -->
+
+## When to Use psst
+
+- Solo developer who wants simplest possible setup
+- Already using Bun in your stack
+- Don't need team sharing or audit trail
+- Prefer AI-native design over established tooling
+
+## Installation
+
+```bash
+# Requires Bun
+bun install -g psst-cli
+```
+
+## Usage
+
+```bash
+# Store a secret
+psst set MY_API_KEY
+
+# List secrets (names only)
+psst list
+
+# Use in subprocess (AI-safe)
+psst run MY_API_KEY -- curl https://api.example.com
+```
+
+## Recommendation
+
+For most users, **gopass is recommended** over psst because:
+
+1. Mature ecosystem (6.7k stars, 8+ years of development)
+2. GPG encryption (industry-standard, audited)
+3. Team sharing via git sync
+4. Zero runtime dependencies (single Go binary)
+5. Audit trail via git history
+6. `gopass audit` for breach detection
+
+Use psst only if you specifically prefer its simplicity and don't need team features.
+
+## Related
+
+- `tools/credentials/gopass.md` -- Recommended encrypted backend
+- `tools/credentials/api-key-setup.md` -- Plaintext credential setup

--- a/.agents/tools/data-extraction/outscraper.md
+++ b/.agents/tools/data-extraction/outscraper.md
@@ -18,7 +18,7 @@ tools:
 
 - **Purpose**: Business intelligence extraction from Google Maps, Amazon, reviews, contacts
 - **Auth**: API key from <https://auth.outscraper.com/profile>
-- **Env Var**: `OUTSCRAPER_API_KEY` in `~/.config/aidevops/mcp-env.sh`
+- **Env Var**: `OUTSCRAPER_API_KEY` in `~/.config/aidevops/credentials.sh`
 - **API Base**: `https://api.app.outscraper.com`
 - **Docs**: <https://app.outscraper.com/api-docs>
 - **No MCP required** - uses curl directly
@@ -393,7 +393,7 @@ pip install outscraper-mcp-server
 
 ### 4. Configure Environment
 
-Add to `~/.config/aidevops/mcp-env.sh` (create if needed):
+Add to `~/.config/aidevops/credentials.sh` (create if needed):
 
 ```bash
 export OUTSCRAPER_API_KEY="your_api_key_here"
@@ -402,13 +402,13 @@ export OUTSCRAPER_API_KEY="your_api_key_here"
 Set permissions:
 
 ```bash
-chmod 600 ~/.config/aidevops/mcp-env.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 Source in your shell profile:
 
 ```bash
-echo 'source ~/.config/aidevops/mcp-env.sh' >> ~/.zshrc
+echo 'source ~/.config/aidevops/credentials.sh' >> ~/.zshrc
 source ~/.zshrc
 ```
 
@@ -896,7 +896,7 @@ The AI should:
 | Method | Location | Use Case |
 |--------|----------|----------|
 | Environment | `OUTSCRAPER_API_KEY` | Local development, CI/CD |
-| aidevops pattern | `~/.config/aidevops/mcp-env.sh` | Consistent with other services |
+| aidevops pattern | `~/.config/aidevops/credentials.sh` | Consistent with other services |
 | Per-config | `env` block in MCP config | Tool-specific isolation |
 
 **Security**: Never commit API keys. Use environment variables or secure vaults.

--- a/.agents/tools/git/authentication.md
+++ b/.agents/tools/git/authentication.md
@@ -48,8 +48,8 @@ tools:
 gh auth login
 
 # Or store for scripts
-echo "GITHUB_TOKEN=ghp_xxxx" >> ~/.config/aidevops/mcp-env.sh
-chmod 600 ~/.config/aidevops/mcp-env.sh
+echo "GITHUB_TOKEN=ghp_xxxx" >> ~/.config/aidevops/credentials.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 ### Verify
@@ -82,8 +82,8 @@ glab auth login
 glab auth login --hostname gitlab.company.com
 
 # Or store for scripts
-echo "GITLAB_TOKEN=glpat-xxxx" >> ~/.config/aidevops/mcp-env.sh
-chmod 600 ~/.config/aidevops/mcp-env.sh
+echo "GITLAB_TOKEN=glpat-xxxx" >> ~/.config/aidevops/credentials.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 ### Verify
@@ -107,8 +107,8 @@ glab auth status
 tea login add --name myserver --url https://git.example.com --token YOUR_TOKEN
 
 # Or store for scripts
-echo "GITEA_TOKEN=xxxx" >> ~/.config/aidevops/mcp-env.sh
-chmod 600 ~/.config/aidevops/mcp-env.sh
+echo "GITEA_TOKEN=xxxx" >> ~/.config/aidevops/credentials.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 ### Verify

--- a/.agents/tools/git/security.md
+++ b/.agents/tools/git/security.md
@@ -51,8 +51,8 @@ Avoid environment variables when possible - CLI auth is more secure.
 # Store tokens securely
 mkdir -p ~/.config/aidevops
 chmod 700 ~/.config/aidevops
-echo "GITHUB_TOKEN=xxx" >> ~/.config/aidevops/mcp-env.sh
-chmod 600 ~/.config/aidevops/mcp-env.sh
+echo "GITHUB_TOKEN=xxx" >> ~/.config/aidevops/credentials.sh
+chmod 600 ~/.config/aidevops/credentials.sh
 ```
 
 ### Token Rotation

--- a/.agents/tools/opencode/opencode.md
+++ b/.agents/tools/opencode/opencode.md
@@ -30,7 +30,7 @@ tools:
 | Agent files | `~/.config/opencode/agent/*.md` |
 | Alternative config | `~/.opencode/` (some installations) |
 | aidevops agents | `~/.aidevops/agents/` (after setup.sh) |
-| Credentials | `~/.config/aidevops/mcp-env.sh` |
+| Credentials | `~/.config/aidevops/credentials.sh` |
 
 **Key Commands**:
 
@@ -392,7 +392,7 @@ Use the helper script for common testing tasks:
 
 ### Required Environment Variables
 
-Store in `~/.config/aidevops/mcp-env.sh`:
+Store in `~/.config/aidevops/credentials.sh`:
 
 ```bash
 # Hostinger
@@ -496,7 +496,7 @@ This pattern:
 | Path | Purpose | Notes |
 |------|---------|-------|
 | `~/.aidevops/agents/` | Deployed aidevops agents | Created by setup.sh |
-| `~/.config/aidevops/mcp-env.sh` | API credentials | 600 permissions |
+| `~/.config/aidevops/credentials.sh` | API credentials | 600 permissions |
 | `~/Git/aidevops/.agents/` | Source agents | Development repo |
 | `~/Git/aidevops/setup.sh` | Deployment script | Copies to ~/.aidevops/ |
 

--- a/.agents/tools/performance/webpagetest.md
+++ b/.agents/tools/performance/webpagetest.md
@@ -21,7 +21,7 @@ tools:
 - **Purpose**: Real-world performance testing from global locations with filmstrip, waterfall, and Core Web Vitals
 - **API Base**: `https://www.webpagetest.org`
 - **API Key**: Required for public instance. Get from https://www.webpagetest.org/signup
-- **Credential Storage**: `~/.config/aidevops/mcp-env.sh` as `WEBPAGETEST_API_KEY`
+- **Credential Storage**: `~/.config/aidevops/credentials.sh` as `WEBPAGETEST_API_KEY`
 - **Node.js Wrapper**: `npm install -g webpagetest` (CLI + API)
 - **Docs**: https://docs.webpagetest.org/api/reference/
 - **Related**: `tools/performance/performance.md`, `tools/browser/pagespeed.md`
@@ -48,8 +48,8 @@ WebPageTest (by Catchpoint) provides real-browser performance testing from 40+ g
 ```bash
 # Sign up at https://www.webpagetest.org/signup
 # Store key securely
-echo 'export WEBPAGETEST_API_KEY="your-key-here"' >> ~/.config/aidevops/mcp-env.sh
-source ~/.config/aidevops/mcp-env.sh
+echo 'export WEBPAGETEST_API_KEY="your-key-here"' >> ~/.config/aidevops/credentials.sh
+source ~/.config/aidevops/credentials.sh
 ```
 
 ### Node.js CLI (Optional)

--- a/.agents/tools/video/higgsfield.md
+++ b/.agents/tools/video/higgsfield.md
@@ -58,7 +58,7 @@ hf-secret: {secret}
 Authorization: Key {api-key}:{secret}
 ```
 
-Store credentials in `~/.config/aidevops/mcp-env.sh`:
+Store credentials in `~/.config/aidevops/credentials.sh`:
 
 ```bash
 export HIGGSFIELD_API_KEY="your-api-key"

--- a/.agents/tools/wordpress/wp-preferred.md
+++ b/.agents/tools/wordpress/wp-preferred.md
@@ -40,7 +40,7 @@ wp theme install kadence --activate
 ```
 
 **Pro/Premium plugins**: Require license activation via vendor dashboards
-**License keys**: Store in `~/.config/aidevops/mcp-env.sh` (see api-key-setup.md)
+**License keys**: Store in `~/.config/aidevops/credentials.sh` (see api-key-setup.md)
 **Updates**: Git Updater available for managing plugin updates from Git repositories
 <!-- AI-CONTEXT-END -->
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,9 @@ authorized_keys
 !.agents/scripts/secretlint-helper.sh
 !.agents/secretlint.md
 
-# Exception for credential management script (not actual credentials)
+# Exception for credential/secret management scripts (not actual credentials)
 !.agents/scripts/credential-helper.sh
+!.agents/scripts/secret-helper.sh
 
 # Environment files
 .env*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ From `tools/build-agent/build-agent.md`:
 ## Security
 
 - Never commit credentials
-- Store secrets in `~/.config/aidevops/mcp-env.sh` (600 permissions)
+- Store secrets in `~/.config/aidevops/credentials.sh` (600 permissions)
 - Confirm destructive operations before execution
 - Use placeholders in examples, note secure storage location
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,8 @@ From `tools/build-agent/build-agent.md`:
 ## Security
 
 - Never commit credentials
-- Store secrets in `~/.config/aidevops/credentials.sh` (600 permissions)
+- Store secrets via `aidevops secret set NAME` (gopass encrypted) or `~/.config/aidevops/credentials.sh` (plaintext fallback, 600 permissions)
+- NEVER accept secret values in AI conversation context
 - Confirm destructive operations before execution
 - Use placeholders in examples, note secure storage location
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The result: AI agents that work *with* your development process, not around it.
 
 - `aidevops init` - Initialize in any project
 - `aidevops update` - Update framework
+- `aidevops secret` - Manage secrets (gopass encrypted, AI-safe)
 - `/onboarding` - Interactive setup wizard (in AI assistant)
 
 ### Agent Structure
@@ -782,6 +783,7 @@ The setup script offers to install these tools automatically.
 
 ### **Security & Code Quality**
 
+- **[gopass](https://github.com/gopasspw/gopass)**: GPG-encrypted secret management with AI-native wrapper (`aidevops secret`) - subprocess injection + output redaction keeps secrets out of AI context
 - **[Vaultwarden](https://github.com/dani-garcia/vaultwarden)**: Password and secrets management
 - **[SonarCloud](https://sonarcloud.io/)**: Security and quality analysis (A-grade ratings)
 - **[CodeFactor](https://www.codefactor.io/)**: Code quality metrics (A+ score)

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1957,6 +1957,7 @@ cmd_help() {
     echo "  upgrade            Alias for update"
     echo "  update-tools       Check for outdated tools (--update to auto-update)"
     echo "  repos [cmd]        Manage registered projects (list/add/remove/clean)"
+    echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
     echo "  detect             Find and register aidevops projects"
     echo "  uninstall          Remove aidevops from your system"
     echo "  version            Show version information"
@@ -1975,6 +1976,14 @@ cmd_help() {
     echo "  aidevops update-tools        # Check for outdated tools"
     echo "  aidevops update-tools -u     # Update all outdated tools"
     echo "  aidevops uninstall           # Remove aidevops"
+    echo ""
+    echo "Secrets:"
+    echo "  aidevops secret set NAME     # Store a secret (hidden input)"
+    echo "  aidevops secret list         # List secret names (never values)"
+    echo "  aidevops secret run CMD      # Run with secrets injected + redacted"
+    echo "  aidevops secret init         # Initialize gopass encrypted store"
+    echo "  aidevops secret import       # Import from credentials.sh to gopass"
+    echo "  aidevops secret status       # Show backend status"
     echo ""
     echo "Skills:"
     echo "  aidevops skill add <source>  # Import a skill from GitHub"
@@ -2069,6 +2078,19 @@ main() {
             ;;
         detect|scan)
             cmd_detect
+            ;;
+        secret|secrets)
+            shift
+            local secret_helper="$AGENTS_DIR/scripts/secret-helper.sh"
+            if [[ ! -f "$secret_helper" ]]; then
+                secret_helper="$INSTALL_DIR/.agents/scripts/secret-helper.sh"
+            fi
+            if [[ -f "$secret_helper" ]]; then
+                bash "$secret_helper" "$@"
+            else
+                print_error "secret-helper.sh not found. Run: aidevops update"
+                exit 1
+            fi
             ;;
         uninstall|remove)
             cmd_uninstall

--- a/configs/dataforseo-config.json.txt
+++ b/configs/dataforseo-config.json.txt
@@ -2,7 +2,7 @@
   "_comments": {
     "note": "DataForSEO MCP configuration for different AI assistants",
     "signup": "Get credentials from https://app.dataforseo.com/",
-    "env_setup": "Store as DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD in ~/.config/aidevops/mcp-env.sh",
+    "env_setup": "Store as DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD in ~/.config/aidevops/credentials.sh",
     "docs": "https://docs.dataforseo.com/v3/"
   },
   "opencode": {
@@ -12,7 +12,7 @@
       "command": [
         "/bin/bash",
         "-c",
-        "source ~/.config/aidevops/mcp-env.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD npx dataforseo-mcp-server"
+        "source ~/.config/aidevops/credentials.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD npx dataforseo-mcp-server"
       ],
       "enabled": true
     }

--- a/configs/mcp-templates/ahrefs-seo.json
+++ b/configs/mcp-templates/ahrefs-seo.json
@@ -2,7 +2,7 @@
   "_comments": {
     "note": "Ahrefs MCP configuration for different AI assistants",
     "api_key": "Get standard 40-char API key from https://ahrefs.com/api (JWT tokens do NOT work)",
-    "env_setup": "Store as AHREFS_API_KEY in ~/.config/aidevops/mcp-env.sh",
+    "env_setup": "Store as AHREFS_API_KEY in ~/.config/aidevops/credentials.sh",
     "important": "The @ahrefs/mcp package expects API_KEY env var, not AHREFS_API_KEY"
   },
   "opencode": {

--- a/configs/mcp-templates/fluentcrm.json
+++ b/configs/mcp-templates/fluentcrm.json
@@ -4,7 +4,7 @@
     "command": [
       "/bin/bash",
       "-c",
-      "source ~/.config/aidevops/mcp-env.sh && node ~/.local/share/mcp-servers/fluentcrm-mcp-server/dist/fluentcrm-mcp-server.js"
+      "source ~/.config/aidevops/credentials.sh && node ~/.local/share/mcp-servers/fluentcrm-mcp-server/dist/fluentcrm-mcp-server.js"
     ],
     "enabled": false,
     "_comment": "Disabled globally. Enabled via fluentcrm_*: true in services/crm/fluentcrm.md subagent. Requires local build - see .agents/services/crm/fluentcrm.md for setup."

--- a/configs/mcp-templates/twilio.json
+++ b/configs/mcp-templates/twilio.json
@@ -20,7 +20,7 @@
   },
   
   "environment_variables": {
-    "_comment": "Store in ~/.config/aidevops/mcp-env.sh",
+    "_comment": "Store in ~/.config/aidevops/credentials.sh",
     "TWILIO_ACCOUNT_SID_PRODUCTION": "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "TWILIO_AUTH_TOKEN_PRODUCTION": "your_auth_token_here",
     "TWILIO_ACCOUNT_SID_STAGING": "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",

--- a/configs/mcp-templates/unstract.json
+++ b/configs/mcp-templates/unstract.json
@@ -4,9 +4,9 @@
     "command": [
       "/bin/bash",
       "-c",
-      "source ~/.config/aidevops/mcp-env.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL -e DISABLE_TELEMETRY=true unstract/mcp-server:${UNSTRACT_IMAGE_TAG:-latest} unstract"
+      "source ~/.config/aidevops/credentials.sh && docker run -i --rm -v /tmp:/tmp -e UNSTRACT_API_KEY -e API_BASE_URL -e DISABLE_TELEMETRY=true unstract/mcp-server:${UNSTRACT_IMAGE_TAG:-latest} unstract"
     ],
     "enabled": false,
-    "_comment": "Disabled globally. Enabled on-demand via services/document-processing/unstract.md. Requires UNSTRACT_API_KEY and API_BASE_URL in mcp-env.sh. Pin image with UNSTRACT_IMAGE_TAG env var for reproducibility."
+    "_comment": "Disabled globally. Enabled on-demand via services/document-processing/unstract.md. Requires UNSTRACT_API_KEY and API_BASE_URL in credentials.sh. Pin image with UNSTRACT_IMAGE_TAG env var for reproducibility."
   }
 }

--- a/configs/outscraper-config.json.txt
+++ b/configs/outscraper-config.json.txt
@@ -27,7 +27,7 @@
   },
 
   "aidevops_env_setup": {
-    "_file": "~/.config/aidevops/mcp-env.sh",
+    "_file": "~/.config/aidevops/credentials.sh",
     "_permissions": "chmod 600",
     "content": "export OUTSCRAPER_API_KEY=\"your_api_key_here\""
   },

--- a/configs/wordpress-sites-config.json.txt
+++ b/configs/wordpress-sites-config.json.txt
@@ -34,7 +34,7 @@
       "mcp_server": "mcp-adapter-default-server",
       "http_config": {
         "username": "YOUR_WP_USERNAME",
-        "_app_password": "STORE_IN_MCP_ENV_FILE",
+        "_app_password": "STORE_IN_CREDENTIALS_FILE",
         "_env_var": "WP_PRODUCTION_APP_PASSWORD"
       }
     },
@@ -75,7 +75,7 @@
       "mcp_server": "mcp-adapter-default-server",
       "http_config": {
         "username": "YOUR_WP_USERNAME",
-        "_app_password": "STORE_IN_MCP_ENV_FILE",
+        "_app_password": "STORE_IN_CREDENTIALS_FILE",
         "_env_var": "WP_CLOSTE_APP_PASSWORD"
       },
       "_note": "Closte uses password-based SSH - prefer HTTP transport"
@@ -88,7 +88,7 @@
       "mcp_server": "mcp-adapter-default-server",
       "http_config": {
         "username": "YOUR_WP_USERNAME",
-        "_app_password": "STORE_IN_MCP_ENV_FILE",
+        "_app_password": "STORE_IN_CREDENTIALS_FILE",
         "_env_var": "WP_CLOUDRON_APP_PASSWORD"
       }
     },
@@ -122,7 +122,7 @@
     }
   },
   "_credential_storage": {
-    "location": "~/.config/aidevops/mcp-env.sh",
+    "location": "~/.config/aidevops/credentials.sh",
     "example": [
       "export WP_PRODUCTION_APP_PASSWORD='xxxx xxxx xxxx xxxx'",
       "export WP_CLOSTE_APP_PASSWORD='xxxx xxxx xxxx xxxx'"

--- a/repomix-instruction.md
+++ b/repomix-instruction.md
@@ -32,7 +32,7 @@ Focus on `.agents/` for the authoritative content.
 1. **Token efficiency**: Agents use progressive disclosure (pointers to subagents)
 2. **AI-CONTEXT sections**: Quick reference blocks at top of each file
 3. **No duplication**: Check existing content before adding instructions
-4. **Security-first**: Credentials stored in `~/.config/aidevops/mcp-env.sh`
+4. **Security-first**: Credentials stored in `~/.config/aidevops/credentials.sh`
 
 ## When Analyzing This Codebase
 

--- a/setup.sh
+++ b/setup.sh
@@ -449,9 +449,9 @@ cleanup_deprecated_mcps() {
         if [[ -n "$outscraper_path" ]]; then
             # Source the API key and set it in environment
             local outscraper_key=""
-            if [[ -f "$HOME/.config/aidevops/mcp-env.sh" ]]; then
+            if [[ -f "$HOME/.config/aidevops/credentials.sh" ]]; then
                 # shellcheck source=/dev/null
-                outscraper_key=$(source "$HOME/.config/aidevops/mcp-env.sh" && echo "${OUTSCRAPER_API_KEY:-}")
+                outscraper_key=$(source "$HOME/.config/aidevops/credentials.sh" && echo "${OUTSCRAPER_API_KEY:-}")
             fi
             jq --arg p "$outscraper_path" --arg key "$outscraper_key" '.mcp.outscraper.command = [$p] | .mcp.outscraper.environment = {"OUTSCRAPER_API_KEY": $key}' "$tmp_config" > "${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
             ((cleaned++))
@@ -657,6 +657,66 @@ validate_opencode_config() {
         fi
     fi
     
+    return 0
+}
+
+# Migrate mcp-env.sh to credentials.sh (v2.105.0)
+# Renames the credential file and creates backward-compatible symlink
+migrate_mcp_env_to_credentials() {
+    local config_dir="$HOME/.config/aidevops"
+    local old_file="$config_dir/mcp-env.sh"
+    local new_file="$config_dir/credentials.sh"
+    local migrated=0
+
+    # Migrate root-level mcp-env.sh -> credentials.sh
+    if [[ -f "$old_file" && ! -L "$old_file" ]]; then
+        if [[ ! -f "$new_file" ]]; then
+            mv "$old_file" "$new_file"
+            chmod 600 "$new_file"
+            ((migrated++))
+            print_info "Renamed mcp-env.sh to credentials.sh"
+        fi
+        # Create backward-compatible symlink
+        if [[ ! -L "$old_file" ]]; then
+            ln -sf "credentials.sh" "$old_file"
+            print_info "Created symlink mcp-env.sh -> credentials.sh"
+        fi
+    fi
+
+    # Migrate tenant-level mcp-env.sh -> credentials.sh
+    local tenants_dir="$config_dir/tenants"
+    if [[ -d "$tenants_dir" ]]; then
+        for tenant_dir in "$tenants_dir"/*/; do
+            [[ -d "$tenant_dir" ]] || continue
+            local tenant_old="$tenant_dir/mcp-env.sh"
+            local tenant_new="$tenant_dir/credentials.sh"
+            if [[ -f "$tenant_old" && ! -L "$tenant_old" ]]; then
+                if [[ ! -f "$tenant_new" ]]; then
+                    mv "$tenant_old" "$tenant_new"
+                    chmod 600 "$tenant_new"
+                    ((migrated++))
+                fi
+                if [[ ! -L "$tenant_old" ]]; then
+                    ln -sf "credentials.sh" "$tenant_old"
+                fi
+            fi
+        done
+    fi
+
+    # Update shell rc files that source the old path
+    for rc_file in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile"; do
+        if [[ -f "$rc_file" ]] && grep -q 'source.*mcp-env\.sh' "$rc_file" 2>/dev/null; then
+            # shellcheck disable=SC2016
+            sed -i '' 's|source.*\.config/aidevops/mcp-env\.sh|source "$HOME/.config/aidevops/credentials.sh"|g' "$rc_file"
+            ((migrated++))
+            print_info "Updated $rc_file to source credentials.sh"
+        fi
+    done
+
+    if [[ $migrated -gt 0 ]]; then
+        print_success "Migrated $migrated mcp-env.sh -> credentials.sh reference(s)"
+    fi
+
     return 0
 }
 
@@ -3449,20 +3509,20 @@ setup_seo_mcps() {
     print_info "SEO uses curl-based subagents (zero context cost until invoked)"
     
     # Check if credentials are configured
-    if [[ -f "$HOME/.config/aidevops/mcp-env.sh" ]]; then
+    if [[ -f "$HOME/.config/aidevops/credentials.sh" ]]; then
         # shellcheck source=/dev/null
-        source "$HOME/.config/aidevops/mcp-env.sh"
+        source "$HOME/.config/aidevops/credentials.sh"
         
         [[ -n "$DATAFORSEO_USERNAME" ]] && print_success "DataForSEO credentials configured" || \
-            print_info "DataForSEO: set DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD in mcp-env.sh"
+            print_info "DataForSEO: set DATAFORSEO_USERNAME and DATAFORSEO_PASSWORD in credentials.sh"
         
         [[ -n "$SERPER_API_KEY" ]] && print_success "Serper API key configured" || \
-            print_info "Serper: set SERPER_API_KEY in mcp-env.sh"
+            print_info "Serper: set SERPER_API_KEY in credentials.sh"
         
         [[ -n "$AHREFS_API_KEY" ]] && print_success "Ahrefs API key configured" || \
-            print_info "Ahrefs: set AHREFS_API_KEY in mcp-env.sh"
+            print_info "Ahrefs: set AHREFS_API_KEY in credentials.sh"
     else
-        print_info "Configure SEO API credentials in ~/.config/aidevops/mcp-env.sh"
+        print_info "Configure SEO API credentials in ~/.config/aidevops/credentials.sh"
     fi
     
     # GSC uses MCP (OAuth2 complexity warrants it)
@@ -3611,10 +3671,10 @@ setup_multi_tenant_credentials() {
     fi
     
     # Check if there are existing credentials to migrate
-    if [[ -f "$HOME/.config/aidevops/mcp-env.sh" ]]; then
+    if [[ -f "$HOME/.config/aidevops/credentials.sh" ]]; then
         local key_count
-        key_count=$(grep -c "^export " "$HOME/.config/aidevops/mcp-env.sh" 2>/dev/null || echo "0")
-        print_info "Found $key_count existing API keys in mcp-env.sh"
+        key_count=$(grep -c "^export " "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || echo "0")
+        print_info "Found $key_count existing API keys in credentials.sh"
         print_info "Multi-tenant enables managing separate credential sets for:"
         echo "  - Multiple clients (agency/freelance work)"
         echo "  - Multiple environments (production, staging)"
@@ -3789,6 +3849,7 @@ main() {
         migrate_old_backups
         migrate_loop_state_directories
         migrate_agent_to_agents_folder
+        migrate_mcp_env_to_credentials
         cleanup_deprecated_paths
         cleanup_deprecated_mcps
         validate_opencode_config
@@ -3821,6 +3882,7 @@ main() {
         confirm_step "Migrate old backups to new structure" && migrate_old_backups
         confirm_step "Migrate loop state from .claude/.agent/ to .agents/loop-state/" && migrate_loop_state_directories
         confirm_step "Migrate .agent -> .agents in user projects" && migrate_agent_to_agents_folder
+        confirm_step "Migrate mcp-env.sh -> credentials.sh" && migrate_mcp_env_to_credentials
         confirm_step "Cleanup deprecated agent paths" && cleanup_deprecated_paths
         confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
         confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config

--- a/templates/home/AGENTS.md
+++ b/templates/home/AGENTS.md
@@ -32,12 +32,12 @@ AI assistants operating in this environment should:
 
 | Location | Purpose |
 |----------|---------|
-| `~/.config/aidevops/` | **Secrets only** - `mcp-env.sh` (600 perms) |
+| `~/.config/aidevops/` | **Secrets only** - `credentials.sh` (600 perms) |
 | `~/.aidevops/` | **Working directories** - agno, stagehand, reports |
 
 ### **✅ APPROVED Storage Location:**
 
-- **API Keys & Tokens**: `~/.config/aidevops/mcp-env.sh`
+- **API Keys & Tokens**: `~/.config/aidevops/credentials.sh`
 - **File Permissions**: 600 (owner read/write only)
 - **Sourced by**: `~/.zshrc` and `~/.bashrc` automatically
 

--- a/templates/home/git/AGENTS.md
+++ b/templates/home/git/AGENTS.md
@@ -42,7 +42,7 @@ ls ~/Git/aidevops/docs/
 
 ### **✅ APPROVED Storage Location:**
 
-- **API Keys & Tokens**: `~/.config/aidevops/mcp-env.sh`
+- **API Keys & Tokens**: `~/.config/aidevops/credentials.sh`
 - **Service Configurations**: `~/Git/aidevops/configs/[service]-config.json`
 - **File Permissions**: 600 (owner read/write only)
 

--- a/todo/tasks/prd-document-extraction.md
+++ b/todo/tasks/prd-document-extraction.md
@@ -194,7 +194,7 @@ pip install docling extract-thinker presidio-analyzer presidio-anonymizer
 
 ### Security Considerations
 
-- All credentials stored in `~/.config/aidevops/mcp-env.sh` (chmod 600)
+- All credentials stored in `~/.config/aidevops/credentials.sh` (chmod 600)
 - PII detection runs before any cloud API calls
 - Local processing mode available for air-gapped environments
 - Audit logging for all extraction operations


### PR DESCRIPTION
## Summary

- **Part A**: Rename `mcp-env.sh` to `credentials.sh` across 83 files (271 references) with backward-compatible symlink migration
- **Part B**: Add `aidevops secret` command with gopass encrypted backend, subprocess injection, and automatic output redaction
- **Part C**: Create gopass/psst subagent documentation and mandatory secret handling rules for AI agents

## Changes

### Part A: Credentials Rename (83 files)
- Rename `MCP_ENV_FILE` variable to `CREDENTIALS_FILE` in 6 shell scripts
- Update all references from `mcp-env.sh` to `credentials.sh` across agents, scripts, configs, templates
- Add `migrate_mcp_env_to_credentials()` to both `setup.sh` and `credential-helper.sh`
- Create backward-compatible symlink (`mcp-env.sh` -> `credentials.sh`) for shell rc compat
- Migrate tenant-level files in multi-tenant storage
- Update shell rc files that source the old path

### Part B: Secret Management (`aidevops secret`)
- Create `secret-helper.sh` (~500 lines) with gopass backend
- `aidevops secret set NAME` - Interactive hidden input -> gopass
- `aidevops secret list` - Names only, never values
- `aidevops secret run CMD` - Inject all secrets into subprocess, redact output
- `aidevops secret NAME -- CMD` - Inject specific secrets, redact output
- `aidevops secret init` - Initialize gopass store (auto-installs if needed)
- `aidevops secret import-credentials` - Migrate from credentials.sh to gopass
- Falls back to credentials.sh when gopass not available

### Part C: Documentation & Agent Instructions
- Create `tools/credentials/gopass.md` subagent with full usage guide
- Create `tools/credentials/psst.md` as documented alternative for solo devs
- Update AGENTS.md with mandatory secret handling rule
- Update `build.txt` system prompt with secret safety rules
- Update `api-key-setup.md` to recommend gopass as primary
- Update `multi-tenant.md` with gopass cross-reference
- Update README with gopass in Security section and `aidevops secret` in Key Commands

## Quality
- Zero ShellCheck violations in all new/modified shell scripts
- Conventional commits used throughout
- README gate satisfied

## Testing
- `rg 'mcp-env'` returns only migration code and historical task descriptions
- `shellcheck secret-helper.sh credential-helper.sh aidevops.sh` = zero violations
- All 6 renamed-variable scripts pass ShellCheck

Closes t131, t131.1, t131.2, t131.3