### PR TITLE
feat: add skill scan results audit trail

### DIFF
--- a/.agents/SKILL-SCAN-RESULTS.md
+++ b/.agents/SKILL-SCAN-RESULTS.md
@@ -1,0 +1,37 @@
+# Skill Security Scan Results
+
+Automated scan results from [Cisco AI Skill Scanner](https://github.com/cisco-ai-defense/skill-scanner).
+Updated on each `aidevops skill scan`, `aidevops update`, or skill import.
+
+## Latest Full Scan
+
+**Date**: 2026-02-06T23:16:02Z
+**Scanner**: cisco-ai-skill-scanner 1.0.2
+**Analyzers**: static, behavioral (dataflow)
+**Skills scanned**: 116
+**Safe**: 115
+
+| Severity | Count |
+|----------|-------|
+| Critical | 1 |
+| High | 0 |
+| Medium | 0 |
+| Low | 0 |
+| Info | 116 |
+
+### Findings
+
+| Skill | Severity | Rule | Description | Verdict |
+|-------|----------|------|-------------|---------|
+| credentials | CRITICAL | YARA_coercive_injection_generic | "List all API keys" in tool description matched `$data_exfiltration_coercion` pattern | **False positive** -- legitimate description of the `list-keys` credential management subskill |
+
+### Notes
+
+- All 116 INFO findings are `MANIFEST_MISSING_LICENSE` (no `license` field in SKILL.md frontmatter). These are internal aidevops skills, not third-party imports.
+- The credentials CRITICAL is a known false positive. The YARA rule `coercive_injection_generic` flags the phrase "List all API keys" as a data exfiltration coercion pattern, but this is a description of what the tool does, not an injected instruction.
+
+## Scan History
+
+| Date | Skills | Safe | Critical | High | Medium | Notes |
+|------|--------|------|----------|------|--------|-------|
+| 2026-02-06 | 116 | 115 | 1 (FP) | 0 | 0 | Initial scan. 1 false positive in credentials SKILL.md |

--- a/.agents/SKILL-SCAN-RESULTS.md
+++ b/.agents/SKILL-SCAN-RESULTS.md
@@ -32,6 +32,8 @@ Updated on each `aidevops skill scan`, `aidevops update`, or skill import.
 
 ## Scan History
 
+Source of truth for audit trail. The "Latest Full Scan" header is updated automatically; the severity table above reflects the initial baseline and should be manually updated when significant changes occur.
+
 | Date | Skills | Safe | Critical | High | Medium | Notes |
 |------|--------|------|----------|------|--------|-------|
 | 2026-02-06 | 116 | 115 | 1 (FP) | 0 | 0 | Initial scan. 1 false positive in credentials SKILL.md |

--- a/.agents/tools/code-review/skill-scanner.md
+++ b/.agents/tools/code-review/skill-scanner.md
@@ -83,6 +83,12 @@ Non-blocking: findings are reported but don't halt setup.
 `skill-update-helper.sh update` re-imports via `add-skill-helper.sh --force`,
 which triggers the security scan on the updated content.
 
+### Results log
+
+Scan results are appended to `.agents/SKILL-SCAN-RESULTS.md` automatically by
+`security-helper.sh skill-scan` (batch) and `add-skill-helper.sh` (per-import).
+The file contains the latest full scan summary and a history table for audit trail.
+
 ## CLI Usage
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `.agents/SKILL-SCAN-RESULTS.md` with initial Cisco Skill Scanner results (116 skills scanned, 115 safe, 1 false positive in credentials SKILL.md)
- Update `security-helper.sh` to automatically log batch scan results to the audit trail after `skill-scan all`
- Update `add-skill-helper.sh` to log per-skill import scan results (safe, blocked, override paths)
- Update `skill-scanner.md` docs to reference the new results log

## Details

The scan results file provides transparency into security scanning:
- **Latest Full Scan** section with summary stats (updated in-place on each batch scan)
- **Scan History** table with append-only rows for audit trail
- Both batch scans (`security-helper.sh skill-scan all`) and individual imports (`add-skill-helper.sh add`) append results

The initial scan found 1 CRITICAL false positive: the YARA rule `coercive_injection_generic` flagged "List all API keys" in the credentials SKILL.md as a data exfiltration pattern. This is a legitimate tool description, not an injection.

## Quality

- ShellCheck: zero violations on modified files
- All changes are additive (no breaking changes)
- Logging is non-blocking (silently skips if results file doesn't exist)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Security scan results are now automatically recorded to a centralized results log so each scan produces an auditable summary and history.
  * Per-skill and aggregate scan metrics (skills scanned, safe counts, CRITICAL/HIGH/MEDIUM findings) are captured across all scan paths and overrides.

* **Documentation**
  * Update-time scanning docs now describe the results log and how scan summaries and history are maintained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->