### PR TITLE
docs: add draft agent awareness to orchestration agents

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -155,6 +155,8 @@ opencode run "Test query" --agent Build+
 
 See `tools/opencode/opencode.md` for CLI testing patterns.
 
+**Draft Agents**: When you discover reusable patterns during orchestration (parallel Task tool calls, repeated prompts, domain-specific instructions), create a draft agent in `~/.aidevops/agents/draft/` instead of duplicating context. Include `status: draft` in frontmatter. Log a TODO for review. Useful drafts can be promoted to `custom/` (private) or `.agents/` (shared via PR). See `tools/build-agent/build-agent.md` "Agent Lifecycle Tiers".
+
 <!-- AI-CONTEXT-END -->
 
 ## Build Workflow

--- a/.agents/tools/ai-assistants/runners/README.md
+++ b/.agents/tools/ai-assistants/runners/README.md
@@ -40,6 +40,18 @@ A good runner AGENTS.md has four sections:
 
 Keep it under 500 words. Runners get the full prompt on every dispatch, so brevity matters.
 
+## Evolving Runners into Shared Agents
+
+When a runner proves valuable across multiple projects, consider promoting it:
+
+1. **Draft** -- Save to `~/.aidevops/agents/draft/` with `status: draft` in frontmatter
+2. **Custom** -- Move to `~/.aidevops/agents/custom/` for permanent private use
+3. **Shared** -- Refine to framework standards and submit a PR to `.agents/` in the aidevops repo
+
+Log a TODO item when a runner has reuse potential: `- [ ] tXXX Review runner {name} for promotion #agent-review`
+
+See `tools/build-agent/build-agent.md` "Agent Lifecycle Tiers" for the full promotion workflow.
+
 ## Parallel vs Sequential
 
 See the [decision guide](../headless-dispatch.md#parallel-vs-sequential) in headless-dispatch.md.

--- a/.agents/workflows/ralph-loop.md
+++ b/.agents/workflows/ralph-loop.md
@@ -56,6 +56,8 @@ The loop creates a **self-referential feedback loop** where:
 - Each iteration sees modified files and git history
 - Claude autonomously improves by reading its own past work
 
+**Evolving draft agents**: When a loop iteration discovers reusable domain patterns (validation rules, API conventions, testing strategies), capture them as a draft agent in `~/.aidevops/agents/draft/`. Subsequent iterations and future loops can reference the draft instead of rediscovering the pattern. After the loop completes, log a TODO to review the draft for promotion to `custom/` (private) or `.agents/` (shared via PR). See `tools/build-agent/build-agent.md` "Agent Lifecycle Tiers".
+
 ## Quick Start
 
 ### v2: Fresh Sessions (Recommended)


### PR DESCRIPTION
## Summary

- Build+, Ralph loop, and runners now know they can create and evolve draft agents
- Closes the gap where the lifecycle tiers existed in build-agent.md but orchestration agents had no awareness of them
- Agents can now propose useful drafts for inclusion in aidevops via PR

## Changes

### `build-plus.md`
- Added draft agent guidance to the AI-CONTEXT block (seen on every Build+ invocation)
- Tells Build+ to create drafts when it discovers reusable patterns during orchestration

### `ralph-loop.md`
- Added "Evolving draft agents" note after the "How It Works" section
- Loop iterations can capture domain patterns as drafts for future loops to reference

### `runners/README.md`
- Added "Evolving Runners into Shared Agents" section
- Documents the promotion path: runner -> draft -> custom/shared

## Context

Follow-up to #409 which added the three-tier agent lifecycle (draft, custom, shared) to build-agent.md and setup.sh. That PR added the *mechanism* but the orchestration agents that would *use* it had no awareness. This PR closes that gap.

## Testing

- markdownlint: zero errors across all 3 files
- No code changes, documentation only