### PR TITLE
chore: clean up oh-my-opencode config on update

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -227,6 +227,25 @@ cleanup_deprecated_paths() {
         print_info "Cleaned up $cleaned deprecated agent path(s)"
     fi
     
+    # Remove oh-my-opencode config file if present
+    local omo_config="$HOME/.config/opencode/oh-my-opencode.json"
+    if [[ -f "$omo_config" ]]; then
+        rm -f "$omo_config"
+        print_info "Removed deprecated oh-my-opencode config"
+    fi
+    
+    # Remove oh-my-opencode from plugin array in opencode.json if present
+    local opencode_config
+    opencode_config=$(find_opencode_config 2>/dev/null) || true
+    if [[ -n "$opencode_config" ]] && [[ -f "$opencode_config" ]] && command -v jq &>/dev/null; then
+        if jq -e '.plugin | index("oh-my-opencode")' "$opencode_config" >/dev/null 2>&1; then
+            local tmp_file
+            tmp_file=$(mktemp)
+            jq '.plugin = [.plugin[] | select(. != "oh-my-opencode")]' "$opencode_config" > "$tmp_file" && mv "$tmp_file" "$opencode_config"
+            print_info "Removed oh-my-opencode from OpenCode plugin list"
+        fi
+    fi
+    
     return 0
 }
 


### PR DESCRIPTION
## Summary

- Remove `~/.config/opencode/oh-my-opencode.json` config file on update
- Remove `oh-my-opencode` from the `plugin` array in `opencode.json` on update

Ensures existing installs are fully cleaned of OmO artifacts when users run `aidevops update` or `setup.sh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved setup cleanup process to remove deprecated configuration files and legacy plugin references, ensuring a cleaner system state after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->