### PR TITLE
feat: add Oh My Zsh setup option and fix bash/zsh shell compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ git clone https://github.com/marcusquinn/aidevops.git ~/Git/aidevops
 - Deploy agents to `~/.aidevops/agents/`
 - Install the `aidevops` CLI command
 - Configure your AI assistants automatically
+- Offer to install Oh My Zsh (optional, opt-in) for enhanced shell experience
 - Guide you through recommended tools (Tabby, Zed, Git CLIs)
+- Ensure all PATH and alias changes work in both bash and zsh
 
 **New users: Start [OpenCode](https://opencode.ai/) and type `/onboarding`** to configure your services interactively. OpenCode is the recommended tool for aidevops - all features, agents, and workflows are designed and tested for it first. The onboarding wizard will:
 - Explain what **[aidevops](https://aidevops.sh)** can do


### PR DESCRIPTION
## Summary

- Add optional Oh My Zsh installation early in setup flow (opt-in with `y/N` default, not capital Y)
- Fix shell compatibility so all PATH changes, aliases, and tool configs work in both bash and zsh on fresh Mac installs

## Problem

On a fresh Mac, the default terminal runs bash but the system default shell is zsh (since macOS Catalina). When running `bash <(curl ...)` to install aidevops, PATH changes and aliases were only written to the running shell's rc file, leaving the other shell unconfigured. This meant tools installed during setup wouldn't be available when the user opened a new terminal with their default shell.

## Changes

### New: Oh My Zsh setup (opt-in)
- `setup_oh_my_zsh()` offered early in setup flow, before tools that benefit from zsh plugins
- Uses `[y/N]` prompt (lowercase y, not capital Y) since some users prefer plain zsh
- Installs with `--unattended` flag to avoid changing shell or starting zsh during setup
- Optionally offers to change default shell to zsh

### Shell compatibility helpers
- `detect_running_shell()` - detects bash vs zsh for the current process
- `detect_default_shell()` - detects the user's login shell ($SHELL)
- `get_shell_rc()` - maps shell name to rc file path
- `get_all_shell_rcs()` - returns ALL rc files that should be updated (both bash + zsh on macOS)

### Functions updated for cross-shell support
- `check_requirements()` - auto-fixes Homebrew PATH in all rc files, adds Intel Mac detection
- `add_local_bin_to_path()` - writes to all existing shell rc files
- `setup_aliases()` - writes to all existing shell rc files
- `setup_worktrunk()` - checks all rc files for shell integration
- `setup_terminal_title()` - checks all rc files for existing config
- `setup_browser_tools()` - ensures Bun PATH is in all rc files after install
- `migrate_mcp_env_to_credentials()` - adds sed -i fallback for Linux

### Quality
- Zero new ShellCheck warnings (3 pre-existing SC2155 warnings unchanged)
- `bash -n` syntax check passes
- README updated with new setup capabilities

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional Oh My Zsh installation during setup
  * Enhanced cross-shell compatibility for bash and zsh environments
  * PATH configuration now updates across all relevant shell configurations

* **Documentation**
  * Added informational notes for shell setup compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->