### PR TITLE
feat: add runtime context hint to session greeting

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -190,10 +190,28 @@ main() {
     
     echo "$output"
     
+    # Output runtime context hint for the AI model
+    local runtime_hint=""
+    case "$app_name" in
+        OpenCode)
+            runtime_hint="You are running in OpenCode. Global config: ~/.config/opencode/opencode.json"
+            ;;
+        "Claude Code")
+            runtime_hint="You are running in Claude Code. Global config: ~/.config/Claude/Claude.json"
+            ;;
+    esac
+    if [[ -n "$runtime_hint" ]]; then
+        echo "$runtime_hint"
+    fi
+    
     # Cache output for agents without Bash (e.g., Plan+)
     local cache_dir="$HOME/.aidevops/cache"
     mkdir -p "$cache_dir"
-    echo "$output" > "$cache_dir/session-greeting.txt"
+    if [[ -n "$runtime_hint" ]]; then
+        printf '%s\n%s\n' "$output" "$runtime_hint" > "$cache_dir/session-greeting.txt"
+    else
+        echo "$output" > "$cache_dir/session-greeting.txt"
+    fi
     
     # Check ralph upstream when in aidevops repo
     check_ralph_upstream

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -1,0 +1,15 @@
+Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
+
+## aidevops Framework Status
+
+**On conversation start**:
+1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh`
+2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash)
+3. Relay ALL lines from the output in your greeting. The first line is the version string, subsequent lines are runtime context. Format: "Hi!\n\nWe're running https://aidevops.sh v{version}. {runtime context}\n\nWhat would you like to work on?"
+4. Then respond to the user's actual message
+
+If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest`), inform user: "Update available (current → latest). Run `aidevops update` to update."
+
+## Pre-Edit Git Check
+
+Only for agents with Edit/Write/Bash tools. See ~/.aidevops/agents/AGENTS.md for workflow.

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -8,7 +8,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 3. Relay ALL lines from the output in your greeting. The first line is the version string, subsequent lines are runtime context. Format: "Hi!\n\nWe're running https://aidevops.sh v{version}. {runtime context}\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message
 
-If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest`), inform user: "Update available (current → latest). Run `aidevops update` to update."
+If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest|AppName`), inform user: "Update available (current → latest). Run `aidevops update` to update."
 
 ## Pre-Edit Git Check
 


### PR DESCRIPTION
## Summary

- Adds app-specific runtime context (config path) to the session greeting output so the AI model knows where settings are stored without guessing
- Includes managed template (`templates/opencode-config-agents.md`) for the OpenCode config-level AGENTS.md greeting instructions
- Also updates the greeting cache for agents without Bash access

Tested: new sessions now show `You are running in OpenCode. Global config: ~/.config/opencode/opencode.json` in the greeting context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent initialization with improved runtime context detection
  * Enhanced caching mechanisms for developer tool configuration and session management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->