### PR TITLE
fix: deploy greeting template via setup.sh and include app name in greeting

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2707,8 +2707,11 @@ inject_agents_reference() {
     local template_source="$SCRIPT_DIR/templates/opencode-config-agents.md"
     
     if [[ -d "$opencode_config_dir" && -f "$template_source" ]]; then
-        cp "$template_source" "$opencode_config_agents"
-        print_success "Deployed greeting template to $opencode_config_agents"
+        if cp "$template_source" "$opencode_config_agents"; then
+            print_success "Deployed greeting template to $opencode_config_agents"
+        else
+            print_error "Failed to deploy greeting template to $opencode_config_agents"
+        fi
     fi
     
     return 0

--- a/setup.sh
+++ b/setup.sh
@@ -2704,9 +2704,15 @@ inject_agents_reference() {
     # This controls the session greeting (auto-loaded by OpenCode from config root)
     local opencode_config_dir="$HOME/.config/opencode"
     local opencode_config_agents="$opencode_config_dir/AGENTS.md"
-    local template_source="$SCRIPT_DIR/templates/opencode-config-agents.md"
+    local template_source="$INSTALL_DIR/templates/opencode-config-agents.md"
     
     if [[ -d "$opencode_config_dir" && -f "$template_source" ]]; then
+        # Backup if file exists and differs from template
+        if [[ -f "$opencode_config_agents" ]]; then
+            if ! diff -q "$template_source" "$opencode_config_agents" &>/dev/null; then
+                create_backup_with_rotation "$opencode_config_agents" "opencode-agents"
+            fi
+        fi
         if cp "$template_source" "$opencode_config_agents"; then
             print_success "Deployed greeting template to $opencode_config_agents"
         else

--- a/setup.sh
+++ b/setup.sh
@@ -2700,6 +2700,17 @@ inject_agents_reference() {
         print_success "Updated $updated_count AI assistant configuration(s)"
     fi
     
+    # Deploy OpenCode config-level AGENTS.md from managed template
+    # This controls the session greeting (auto-loaded by OpenCode from config root)
+    local opencode_config_dir="$HOME/.config/opencode"
+    local opencode_config_agents="$opencode_config_dir/AGENTS.md"
+    local template_source="$SCRIPT_DIR/templates/opencode-config-agents.md"
+    
+    if [[ -d "$opencode_config_dir" && -f "$template_source" ]]; then
+        cp "$template_source" "$opencode_config_agents"
+        print_success "Deployed greeting template to $opencode_config_agents"
+    fi
+    
     return 0
 }
 

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -5,7 +5,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 **On conversation start**:
 1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh`
 2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash)
-3. Relay ALL lines from the output in your greeting. The first line is the version string, subsequent lines are runtime context. Format: "Hi!\n\nWe're running https://aidevops.sh v{version}. {runtime context}\n\nWhat would you like to work on?"
+3. Parse the first line of output (format: `aidevops v{version} running in {app} v{app_version} | {repo}`). Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version} in {app} v{app_version}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message
 
 If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest|AppName`), inform user: "Update available (current → latest). Run `aidevops update` to update."


### PR DESCRIPTION
## Summary

- Session greeting was missing the app name (e.g., "in OpenCode v1.1.53") because the template instruction was too vague and setup.sh never deployed the managed template
- Makes greeting parse instruction explicit with named fields (`{app}`, `{app_version}`) matching the script output format
- Adds template deploy step to `inject_agents_reference()` in setup.sh so `~/.config/opencode/AGENTS.md` stays in sync with the repo template on every `aidevops update`

**Before:** "We're running https://aidevops.sh v2.105.0."
**After:** "We're running https://aidevops.sh v2.105.0 in OpenCode v1.1.53."

Resolves t137.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration-level greeting initialization for improved onboarding
  * Restructured welcome message to display version and environment information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->