### PR TITLE
fix: remove non-existent index.js from package.json main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.105.1",
   "description": "AI DevOps Framework - AI-assisted development workflows, code quality, and deployment automation",
   "type": "module",
-  "main": "index.js",
   "bin": {
     "aidevops": "./bin/aidevops"
   },


### PR DESCRIPTION
## Summary

- Removes the `"main": "index.js"` field from `package.json` since `index.js` does not exist
- This package is a CLI tool (entry point is `bin/aidevops`), not a library — the `main` field is unnecessary and misleading
- Resolves t135.10 from the Codebase Quality Hardening plan

## Changes

- `package.json`: Removed `"main": "index.js"` (1 line deletion)

## Verification

- `node -e "JSON.parse(...)"` confirms valid JSON
- `npm pack --dry-run` confirms package builds correctly without the field
- `bin` field (`"aidevops": "./bin/aidevops"`) remains intact as the CLI entry point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration by removing the main field entry. This may affect module resolution in certain environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->