### PR TITLE
fix: supervisor self-healing -- macOS timeout, PR detection, model names, stale PID cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 ## Backlog
 
 - [ ] t140 setup.sh: Cisco Skill Scanner install fails on PEP 668 systems (Ubuntu 24.04+) #bugfix #setup #linux ~1h (ai:45m test:15m) logged:2026-02-07
-  - Notes: GH#415. pip3 install --user blocked by PEP 668 on modern Ubuntu/Debian. Fix fallback chain: uv -> pipx -> venv+symlink -> pip3 --user (legacy). Affects setup.sh lines ~2408-2432. Workaround: manual venv at ~/.aidevops/.agent-workspace/work/cisco-scanner-env/.
+  - Notes: GH#415. pip3 install --user blocked by PEP 668 on modern Ubuntu/Debian. Fix fallback chain: uv -> pipx -> venv+symlink -> pip3 --user (legacy). Affects setup.sh lines ~2408-2432. Workaround: manual venv at ~/.aidevops/.agent-workspace/work/cisco-scanner-env/. BLOCKED: Re-prompt dispatch failed: backend_infrastructure_error
 - [ ] t139 bug: memory-helper.sh recall fails on hyphenated queries #bugfix #memory ~30m (ai:20m test:10m) logged:2026-02-07 started:2026-02-07
   - Notes: GH#414. Hyphens in FTS5 queries interpreted as NOT operator. "qs-agency" becomes "qs NOT agency" causing column resolution error. Fix: quote hyphenated terms before passing to FTS5 MATCH clause.
 - [x] t138 aidevops update output overwhelms tool buffer on large updates #bugfix #setup ~30m (ai:20m test:10m) logged:2026-02-07 completed:2026-02-07


### PR DESCRIPTION
## Summary

Critical fixes for the supervisor batch orchestration system that was completely deadlocked:

- **macOS timeout fix**: `check_model_health` used `timeout` (coreutils) which doesn't exist on macOS. Added background-process-with-kill fallback so health probes work on all platforms.
- **Model name fix**: `resolve_model` returned `claude-sonnet-4` which OpenCode doesn't recognize (needs `claude-sonnet-4-5`). This caused health probes to error, blocking ALL dispatch indefinitely.
- **PR URL detection**: Added `gh pr list --head feature/tXXX` fallback in `evaluate_worker`, `check_pr_status`, and `cmd_pr_lifecycle` when log-grep finds no PR URL.
- **No-PR auto-deploy fix**: Stopped `cmd_pr_lifecycle` from marking code tasks as "deployed" when no PR exists. Now tries branch lookup first, leaves task in `pr_review` for retry.
- **Stale PID cleanup**: Extended cleanup to include `deployed`/`pr_review`/`merging`/`merged`/`deploying` states (was only cleaning terminal states).
- **SUPERVISOR_MODEL env var**: Added override for all model tiers.

### Impact

Before: 25 queued tasks, 0 dispatched, 0 running -- batch completely stalled.
After: Health check passes instantly, dispatch unblocked, cron resumes autonomous operation.

### Testing

- Verified `opencode run -m anthropic/claude-sonnet-4-5` responds in <1s
- ShellCheck clean (only 2 pre-existing SC2034 warnings for unused vars)
- Deployed to `~/.aidevops/` and confirmed `cmd_next` returns tasks correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model health probing with enhanced timeout handling and fallback recovery mechanisms
  * Enhanced PR detection with branch-based lookup recovery when PR URLs are missing or stale
  * Better PR lifecycle handling with improved deployment logic and error recovery paths

* **Chores**
  * Infrastructure improvements for model selection flexibility and worker cleanup logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->