### PR TITLE
fix(supervisor): prevent worker death on cron exit and fix dispatch deadlock

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 ## Backlog
 
 - [ ] t140 setup.sh: Cisco Skill Scanner install fails on PEP 668 systems (Ubuntu 24.04+) #bugfix #setup #linux ~1h (ai:45m test:15m) logged:2026-02-07
-  - Notes: GH#415. pip3 install --user blocked by PEP 668 on modern Ubuntu/Debian. Fix fallback chain: uv -> pipx -> venv+symlink -> pip3 --user (legacy). Affects setup.sh lines ~2408-2432. Workaround: manual venv at ~/.aidevops/.agent-workspace/work/cisco-scanner-env/. BLOCKED: Re-prompt dispatch failed: backend_infrastructure_error
+  - Notes: GH#415. pip3 install --user blocked by PEP 668 on modern Ubuntu/Debian. Fix fallback chain: uv -> pipx -> venv+symlink -> pip3 --user (legacy). Affects setup.sh lines ~2408-2432. Workaround: manual venv at ~/.aidevops/.agent-workspace/work/cisco-scanner-env/. BLOCKED: Re-prompt dispatch failed: backend_infrastructure_error BLOCKED: Re-prompt dispatch failed: ambiguous_ai_unavailable
 - [ ] t139 bug: memory-helper.sh recall fails on hyphenated queries #bugfix #memory ~30m (ai:20m test:10m) logged:2026-02-07 started:2026-02-07
   - Notes: GH#414. Hyphens in FTS5 queries interpreted as NOT operator. "qs-agency" becomes "qs NOT agency" causing column resolution error. Fix: quote hyphenated terms before passing to FTS5 MATCH clause.
 - [x] t138 aidevops update output overwhelms tool buffer on large updates #bugfix #setup ~30m (ai:20m test:10m) logged:2026-02-07 completed:2026-02-07


### PR DESCRIPTION
## Summary

- Workers launched by cron pulse were dying after ~1-2 minutes because background subshells get killed when the parent cron script exits. Fixed with `nohup` + `disown`.
- Dispatch loop had SC2319 bug: `$?` after `if cmd_dispatch` captured the if-condition exit code, not the actual dispatch exit code. Refactored to `cmd || exit=$?` pattern.
- Added pulse-level health check flag so the 8-second health probe only runs once per pulse invocation, not once per task.
- Dispatch failures are now logged instead of swallowed by `2>/dev/null`.

**Before**: 23 queued, 0 running, 0 dispatched (complete deadlock)
**After**: 21 queued, 3 running, 8 deployed

Resolves dispatch deadlock in batch `quality-hardening-8h`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure optimizations to improve system reliability and performance under scheduled execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->