### PR TITLE
fix(supervisor): add cron PATH resolution and no_pr retry limit

### DIFF
--- a/.agents/scripts/clawdhub-helper.sh
+++ b/.agents/scripts/clawdhub-helper.sh
@@ -287,9 +287,9 @@ PLAYWRIGHT_SCRIPT
 
     # Install playwright and run the fetch script
     log_info "Installing Playwright (temporary)..."
-    if (cd "$pw_dir" && npm install --silent 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null); then || exit
+    if (cd "$pw_dir" && npm install --silent 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null); then
         log_info "Running browser extraction..."
-        if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file" 2>/dev/null); then || exit
+        if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file" 2>/dev/null); then
             rm -rf "$pw_dir"
             if [[ -f "$output_file" && -s "$output_file" ]]; then
                 log_success "Extracted SKILL.md ($(wc -c < "$output_file" | tr -d ' ') bytes)"
@@ -304,7 +304,7 @@ PLAYWRIGHT_SCRIPT
     # Fallback: try clawdhub CLI
     if command -v npx &>/dev/null; then
         log_info "Trying: npx clawdhub install $slug"
-        if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force 2>/dev/null); then || exit
+        if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force 2>/dev/null); then
             # clawdhub installs to ./skills/<slug>/SKILL.md
             local installed_skill
             installed_skill=$(find "$output_dir" -name "SKILL.md" -type f 2>/dev/null | head -1)

--- a/tests/test-batch-quality-hardening.sh
+++ b/tests/test-batch-quality-hardening.sh
@@ -175,18 +175,19 @@ else
     fail "pandoc-config.json.txt still has embedded newline in keys"
 fi
 
-# Test: All .json and .json.txt config files are valid
+# Test: All git-tracked .json and .json.txt config files are valid
+# Note: gitignored working copies (configs/*.json) are excluded -- only tracked files matter
 json_invalid=0
 while IFS= read -r f; do
-    if ! python3 -m json.tool "$f" > /dev/null 2>&1; then
+    if ! python3 -m json.tool "$REPO_DIR/$f" > /dev/null 2>&1; then
         json_invalid=$((json_invalid + 1))
         [[ "$VERBOSE" == "--verbose" ]] && echo "       Invalid: $f"
     fi
-done < <(find "$REPO_DIR/configs" -name "*.json" -o -name "*.json.txt" 2>/dev/null)
+done < <(git -C "$REPO_DIR" ls-files 'configs/*.json' 'configs/*.json.txt' 'configs/**/*.json' 'configs/**/*.json.txt' 2>/dev/null)
 if [[ "$json_invalid" -eq 0 ]]; then
-    pass "All JSON config files in configs/ are valid"
+    pass "All git-tracked JSON config files in configs/ are valid"
 else
-    fail "$json_invalid JSON config file(s) are invalid in configs/"
+    fail "$json_invalid git-tracked JSON config file(s) are invalid in configs/"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

- **Cron PATH fix**: Add PATH augmentation at supervisor-helper.sh startup for cron environments that lack `/opt/homebrew/bin`, `~/.local/bin`, etc. This fixes `gh`/`opencode`/`node` being unreachable from cron-triggered pulses, which caused all `pr_review` tasks to loop forever in a `no_pr` retry cycle.
- **no_pr retry limit**: Add retry counter (max 5) to the `no_pr` case in `cmd_pr_lifecycle` to prevent infinite loops. After 5 failures, task transitions to `blocked` with diagnostic info (whether `gh` is in PATH).
- **Test suite fix**: Use `git ls-files` instead of `find` to validate JSON configs in `test-batch-quality-hardening.sh`, excluding gitignored working copies that caused a false positive failure.

## Root Cause

Discovered during PR verification batch: cron jobs run with minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). The `gh` CLI at `/opt/homebrew/bin/gh` was unreachable, causing `check_pr_status()` to silently return `no_pr` for every task. The `no_pr` handler had no retry limit, creating an infinite loop across 69+ pulse cycles.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/supervisor-helper.sh` | PATH augmentation + no_pr retry limit (5 max) |
| `tests/test-batch-quality-hardening.sh` | Use `git ls-files` for JSON validation scope |

## Testing

- `shellcheck -S error supervisor-helper.sh` -- 0 errors
- `bash -n supervisor-helper.sh` -- syntax OK
- `test-batch-quality-hardening.sh` -- 55/56 pass (1 expected diff: deployed vs repo version)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling logic in automated workflows to allow proper fallback mechanisms.
  * Enhanced retry mechanism for PR lifecycle processes with configurable attempt limits.

* **Chores**
  * Improved test validation to focus on git-tracked configuration files only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->