### PR TITLE
fix: sed portability, speech-to-speech reliability (t145, t141)

### DIFF
--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -99,6 +99,9 @@ log_fail() { echo -e "${RED}[FAIL]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_header() { echo -e "${PURPLE}${BOLD}$*${NC}"; }
 
+# Cross-platform sed in-place edit (macOS vs GNU/Linux)
+sed_inplace() { if [[ "$(uname)" == "Darwin" ]]; then sed -i '' "$@"; else sed -i "$@"; fi; }
+
 #######################################
 # Ensure workspace directories exist
 #######################################
@@ -864,8 +867,7 @@ TEMPLATE
     # Replace placeholder with actual name
     local safe_name
     safe_name="${name//[^a-zA-Z0-9_-]/-}"
-    sed -i '' "s/SUITE_NAME/${safe_name}/" "$suite_file" 2>/dev/null || \
-        sed -i "s/SUITE_NAME/${safe_name}/" "$suite_file"
+    sed_inplace "s/SUITE_NAME/${safe_name}/" "$suite_file"
 
     log_pass "Created test suite: $suite_file"
     log_info "Edit the file to add your test cases, then run:"

--- a/.agents/scripts/privacy-filter-helper.sh
+++ b/.agents/scripts/privacy-filter-helper.sh
@@ -116,6 +116,9 @@ print_error() {
     return 0
 }
 
+# Cross-platform sed in-place edit (macOS vs GNU/Linux)
+sed_inplace() { if [[ "$(uname)" == "Darwin" ]]; then sed -i '' "$@"; else sed -i "$@"; fi; }
+
 print_header() {
     local message="$1"
     echo -e "${PURPLE}$message${NC}"
@@ -371,7 +374,7 @@ apply_redactions() {
                 
                 # Apply redaction
                 if [[ "$(uname)" == "Darwin" ]]; then
-                    sed -i '' -E "s/$pattern/[REDACTED]/g" "$file"
+                    sed_inplace -E "s/$pattern/[REDACTED]/g" "$file"
                 else
                     sed -i -E "s/$pattern/[REDACTED]/g" "$file"
                 fi

--- a/.agents/scripts/privacy-filter-helper.sh
+++ b/.agents/scripts/privacy-filter-helper.sh
@@ -373,11 +373,7 @@ apply_redactions() {
                 cp "$file" "${file}.privacy-backup"
                 
                 # Apply redaction
-                if [[ "$(uname)" == "Darwin" ]]; then
-                    sed_inplace -E "s/$pattern/[REDACTED]/g" "$file"
-                else
-                    sed -i -E "s/$pattern/[REDACTED]/g" "$file"
-                fi
+                sed_inplace -E "s/$pattern/[REDACTED]/g" "$file"
                 
                 print_success "Redacted: $file"
                 changes=$((changes + 1))

--- a/.agents/scripts/quality-fix.sh
+++ b/.agents/scripts/quality-fix.sh
@@ -42,6 +42,9 @@ print_info() {
     return 0
 }
 
+# Cross-platform sed in-place edit (macOS vs GNU/Linux)
+sed_inplace() { if [[ "$(uname)" == "Darwin" ]]; then sed -i '' "$@"; else sed -i "$@"; fi; }
+
 backup_files() {
     print_info "Creating backup of provider files..."
 
@@ -102,7 +105,7 @@ fix_return_statements() {
                         
                         if [[ ! $last_line =~ return[[:space:]]+[01] ]]; then
                             # Remove the closing brace and add return statement
-                            sed -i '' '$ d' "$temp_file"
+                            sed_inplace '$ d' "$temp_file"
                             echo "    return 0" >> "$temp_file"
                             echo "}" >> "$temp_file"
                             ((fixed_functions++))
@@ -153,7 +156,7 @@ fix_positional_parameters() {
                 }' "$file" > "$temp_file"
                 
                 # Replace direct positional parameter usage in case statements
-                sed -i '' 's/\$_arg1/$command/g; s/\$2/$account_name/g; s/\$3/$target/g; s/\$4/$options/g' "$temp_file"
+                sed_inplace 's/\$_arg1/$command/g; s/\$2/$account_name/g; s/\$3/$target/g; s/\$4/$options/g' "$temp_file"
                 
                 if ! diff -q "$file" "$temp_file" > /dev/null; then
                     mv "$temp_file" "$file"

--- a/.agents/scripts/security-helper.sh
+++ b/.agents/scripts/security-helper.sh
@@ -22,6 +22,9 @@ readonly BLUE='\033[0;34m'
 readonly CYAN='\033[0;36m'
 readonly NC='\033[0m'
 
+# Cross-platform sed in-place edit (macOS vs GNU/Linux)
+sed_inplace() { if [[ "$(uname)" == "Darwin" ]]; then sed -i '' "$@"; else sed -i "$@"; fi; }
+
 print_header() {
     echo -e "${CYAN}"
     echo "╔═══════════════════════════════════════════════════════════╗"
@@ -418,9 +421,9 @@ update_scan_results_log() {
     scan_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
     
     # Update the "Latest Full Scan" date
-    sed -i '' "s/^\*\*Date\*\*: .*/**Date**: ${scan_timestamp}/" "$results_file" 2>/dev/null || true
-    sed -i '' "s/^\*\*Skills scanned\*\*: .*/**Skills scanned**: ${skills_scanned}/" "$results_file" 2>/dev/null || true
-    sed -i '' "s/^\*\*Safe\*\*: .*/**Safe**: ${safe_count}/" "$results_file" 2>/dev/null || true
+    sed_inplace "s/^\*\*Date\*\*: .*/**Date**: ${scan_timestamp}/" "$results_file" 2>/dev/null || true
+    sed_inplace "s/^\*\*Skills scanned\*\*: .*/**Skills scanned**: ${skills_scanned}/" "$results_file" 2>/dev/null || true
+    sed_inplace "s/^\*\*Safe\*\*: .*/**Safe**: ${safe_count}/" "$results_file" 2>/dev/null || true
     
     # Append to scan history table
     local history_row="| ${scan_date} | ${skills_scanned} | ${safe_count} | ${critical_count} | ${high_count} | ${medium_count} | ${notes} |"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -229,6 +229,22 @@ validate_command_exists() {
 }
 
 # =============================================================================
+# Portable sed -i wrapper (macOS vs GNU/Linux)
+# macOS sed requires -i '' while GNU sed requires -i (no argument)
+# Usage: sed_inplace 'pattern' file
+#        sed_inplace -E 'pattern' file
+# =============================================================================
+
+sed_inplace() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+    return $?
+}
+
+# =============================================================================
 # Export all constants for use in other scripts
 # =============================================================================
 

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -3884,11 +3884,12 @@ update_todo_on_blocked() {
     else
         # Insert a new Notes line after the task
         local notes_line="${indent}  - Notes: BLOCKED by supervisor: ${safe_reason}"
+        # sed append syntax differs between BSD and GNU - sed_inplace can't abstract this
         if [[ "$(uname)" == "Darwin" ]]; then
-            sed_inplace "${line_num}a\\
+            sed -i '' "${line_num}a\\
 ${notes_line}" "$todo_file"
         else
-            sed_inplace "${line_num}a\\${notes_line}" "$todo_file"
+            sed -i "${line_num}a\\${notes_line}" "$todo_file"
         fi
     fi
 

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -132,6 +132,9 @@ log_success() { echo -e "${GREEN}[SUPERVISOR]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[SUPERVISOR]${NC} $*"; }
 log_error() { echo -e "${RED}[SUPERVISOR]${NC} $*" >&2; }
 
+# Cross-platform sed in-place edit (macOS vs GNU/Linux)
+sed_inplace() { if [[ "$(uname)" == "Darwin" ]]; then sed -i '' "$@"; else sed -i "$@"; fi; }
+
 #######################################
 # Get the number of CPU cores on this system
 # Returns integer count on stdout
@@ -3788,11 +3791,7 @@ update_todo_on_complete() {
     # Use sed to match the line and transform it
     local sed_pattern="s/^([[:space:]]*- )\[ \] (${task_id} .*)$/\1[x] \2 completed:${today}/"
 
-    if [[ "$(uname)" == "Darwin" ]]; then
-        sed -i '' -E "$sed_pattern" "$todo_file"
-    else
-        sed -i -E "$sed_pattern" "$todo_file"
-    fi
+    sed_inplace -E "$sed_pattern" "$todo_file"
 
     # Verify the change was made
     if ! grep -qE "^[[:space:]]*- \[x\] ${task_id} " "$todo_file"; then
@@ -3881,19 +3880,15 @@ update_todo_on_blocked() {
     if echo "$next_line" | grep -qE "^[[:space:]]*- Notes:"; then
         # Append to existing Notes line
         local append_text=" BLOCKED: ${safe_reason}"
-        if [[ "$(uname)" == "Darwin" ]]; then
-            sed -i '' "${next_line_num}s/$/${append_text}/" "$todo_file"
-        else
-            sed -i "${next_line_num}s/$/${append_text}/" "$todo_file"
-        fi
+        sed_inplace "${next_line_num}s/$/${append_text}/" "$todo_file"
     else
         # Insert a new Notes line after the task
         local notes_line="${indent}  - Notes: BLOCKED by supervisor: ${safe_reason}"
         if [[ "$(uname)" == "Darwin" ]]; then
-            sed -i '' "${line_num}a\\
+            sed_inplace "${line_num}a\\
 ${notes_line}" "$todo_file"
         else
-            sed -i "${line_num}a\\${notes_line}" "$todo_file"
+            sed_inplace "${line_num}a\\${notes_line}" "$todo_file"
         fi
     fi
 

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -714,10 +714,10 @@ auto_mark_tasks_complete() {
             # Check if line already has completed: field
             if grep -E "$sed_unchecked_pattern" "$todo_file" | grep -q "completed:"; then
                 # Just change checkbox
-                sed -i '' "s/^\\([[:space:]]*\\)- \\[ \\] \\(${escaped_id}[[:space:]]\\)/\\1- [x] \\2/" "$todo_file"
+                sed_inplace "s/^\\([[:space:]]*\\)- \\[ \\] \\(${escaped_id}[[:space:]]\\)/\\1- [x] \\2/" "$todo_file"
             else
                 # Change checkbox and add completed: timestamp
-                sed -i '' "s/^\\([[:space:]]*\\)- \\[ \\] \\(${escaped_id}[[:space:]].*\\)\$/\\1- [x] \\2 completed:$today_short/" "$todo_file"
+                sed_inplace "s/^\\([[:space:]]*\\)- \\[ \\] \\(${escaped_id}[[:space:]].*\\)\$/\\1- [x] \\2 completed:$today_short/" "$todo_file"
             fi
             
             count=$((count + 1))


### PR DESCRIPTION
## Summary

- **t145**: Make `sed -i` portable across macOS and Linux. Added `sed_inplace()` wrapper function to `shared-constants.sh` and 6 active scripts. macOS requires `sed -i ''` while GNU/Linux requires `sed -i` (no argument).
- **t141**: Improve `speech-to-speech-helper.sh` stop reliability (polling loop instead of fixed sleep) and NLTK download error handling (visible warnings instead of silent suppression).

## Changes

| Commit | Scope | Description |
|--------|-------|-------------|
| `34c7899` | scripts | `sed_inplace()` in 7 scripts, replace all `sed -i ''` calls |
| `5b4eaef` | speech-to-speech | Graceful stop polling, NLTK error handling |

## Scripts Modified (t145)

- `shared-constants.sh` - canonical `sed_inplace()` definition
- `agent-test-helper.sh` - replaced fallback pattern
- `privacy-filter-helper.sh` - replaced direct call
- `quality-fix.sh` - replaced 2 direct calls
- `security-helper.sh` - replaced 3 direct calls
- `supervisor-helper.sh` - replaced 3 platform-specific blocks
- `version-manager.sh` - replaced 2 direct calls (function already existed)

## Quality

- ShellCheck: zero violations on all modified files
- Archived scripts (`_archive/`) left as-is

Closes #440, closes #445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for speech module initialization with graceful failure recovery.
  * Improved shutdown sequence with extended timeout to allow graceful process termination before force-kill.

* **Chores**
  * Improved cross-platform compatibility across build and helper scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->