### PR TITLE
fix(setup): .agent -> .agents migration handles directories and stale symlinks (t130)

### DIFF
--- a/.secretlintignore
+++ b/.secretlintignore
@@ -44,6 +44,7 @@
 # Documentation with example credentials
 # (These contain intentional example patterns for documentation)
 **/.agent/*.md
+**/.agents/*.md
 **/.ai/*.md
 **/.claude/**
 **/.continue/**

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -54,14 +54,14 @@ Create a plugin architecture for aidevops that allows private extension repos (`
        └── pro-*.sh        # Prefixed scripts
    ```
 
-2. **Plugin structure mirrors main** - Same `.agent/` pattern:
+2. **Plugin structure mirrors main** - Same `.agents/` pattern:
    ```
    ~/Git/aidevops-pro/
    ├── AGENTS.md           # Points to main framework
    ├── README.md
    ├── VERSION
    ├── .aidevops.json      # Plugin config with base_repo reference
-   └── .agent/
+   └── .agents/
        ├── pro.md          # Main plugin agent
        ├── pro/            # Subagents
        └── scripts/
@@ -108,7 +108,7 @@ Create a plugin architecture for aidevops that allows private extension repos (`
 
 **Symlink option for rapid iteration:**
 - `.plugin-dev/` in main repo (gitignored)
-- Symlinks to plugin `.agent/` directories
+- Symlinks to plugin `.agents/` directories
 - Useful when testing plugin content against main repo changes
 
 #### Decision Log


### PR DESCRIPTION
## Summary

- **Fixed**: `migrate_agent_to_agents_folder()` step 2 only scanned for `.agent` symlinks (`-type l`), missing `.agent` directories in `~/Git/` projects
- **Fixed**: Stale `.agent` symlinks not cleaned up when `.agents` already exists
- **Fixed**: `.agent/` references in `todo/PLANS.md` plugin system plan updated to `.agents/`
- **Fixed**: `.secretlintignore` now includes `**/.agents/*.md` pattern alongside legacy `**/.agent/*.md`

## Testing

Verified on local machine:
- 5 `.agent` directories migrated to `.agents` (amazon-order-history-csv-download-mcp, quickfile-mcp, mcp/*, quickfile-skill)
- 1 stale `.agent` symlink cleaned up (a managed project - had both `.agent` and `.agents`)
- `aidevops init` creates `.agents` symlink (not `.agent`) in fresh test project
- Zero remaining `.agent` entries in `~/Git/` after migration
- ShellCheck zero violations on setup.sh

## Regression Testing Checklist (t130)

- [x] t130.1 Fix .claude-plugin/marketplace.json (completed prior)
- [x] t130.2 Run setup.sh and verify migration function
- [x] t130.3 Verify `aidevops init` creates `.agents` symlink
- [x] t130.4 Verify setup.sh migrates existing `.agent` in `~/Git/`
- [x] t130.5 Stale worktrees assessed (200-300 commits behind, rebase deferred)