### PR TITLE
fix: replace excessive 2>/dev/null with log file redirects (t144)

### DIFF
--- a/.agents/scripts/mail-helper.sh
+++ b/.agents/scripts/mail-helper.sh
@@ -81,7 +81,7 @@ ensure_db() {
     local current_mode
     current_mode=$(db "$MAIL_DB" "PRAGMA journal_mode;" 2>/dev/null || echo "")
     if [[ "$current_mode" != "wal" ]]; then
-        db "$MAIL_DB" "PRAGMA journal_mode=WAL;" 2>/dev/null || true
+        db "$MAIL_DB" "PRAGMA journal_mode=WAL;" 2>/dev/null || echo "[WARN] Failed to enable WAL mode for mail DB" >&2
     fi
 
     return 0

--- a/.agents/scripts/memory-helper.sh
+++ b/.agents/scripts/memory-helper.sh
@@ -222,7 +222,7 @@ EOF
     local current_mode
     current_mode=$(db "$MEMORY_DB" "PRAGMA journal_mode;" 2>/dev/null || echo "")
     if [[ "$current_mode" != "wal" ]]; then
-        db "$MEMORY_DB" "PRAGMA journal_mode=WAL;" 2>/dev/null || true
+        db "$MEMORY_DB" "PRAGMA journal_mode=WAL;" 2>/dev/null || echo "[WARN] Failed to enable WAL mode for memory DB" >&2
     fi
 
     return 0
@@ -290,7 +290,7 @@ EOF
     local has_auto_captured
     has_auto_captured=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM pragma_table_info('learning_access') WHERE name='auto_captured';" 2>/dev/null || echo "0")
     if [[ "$has_auto_captured" == "0" ]]; then
-        db "$MEMORY_DB" "ALTER TABLE learning_access ADD COLUMN auto_captured INTEGER DEFAULT 0;" 2>/dev/null || true
+        db "$MEMORY_DB" "ALTER TABLE learning_access ADD COLUMN auto_captured INTEGER DEFAULT 0;" || echo "[WARN] Failed to add auto_captured column (may already exist)" >&2
     fi
     
     return 0
@@ -1194,7 +1194,7 @@ EOF
             fi
             
             # Transfer access history
-            db "$MEMORY_DB" "UPDATE learning_access SET id = '$older_id_esc' WHERE id = '$newer_id_esc' AND NOT EXISTS (SELECT 1 FROM learning_access WHERE id = '$older_id_esc');" 2>/dev/null || true
+            db "$MEMORY_DB" "UPDATE learning_access SET id = '$older_id_esc' WHERE id = '$newer_id_esc' AND NOT EXISTS (SELECT 1 FROM learning_access WHERE id = '$older_id_esc');" || echo "[WARN] Failed to transfer access history from $newer_id_esc to $older_id_esc" >&2
             
             # Re-point relations that referenced the deleted memory to the surviving one
             db "$MEMORY_DB" "UPDATE learning_relations SET supersedes_id = '$older_id_esc' WHERE supersedes_id = '$newer_id_esc';"

--- a/.agents/scripts/speech-to-speech-helper.sh
+++ b/.agents/scripts/speech-to-speech-helper.sh
@@ -131,8 +131,8 @@ cmd_setup() {
     # Clone or update repo
     if [[ -d "$S2S_DIR/.git" ]]; then
         print_info "Updating existing installation..."
-        git -C "$S2S_DIR" pull --ff-only 2>/dev/null || {
-            print_warning "Could not fast-forward, repo may have local changes"
+        git -C "$S2S_DIR" pull --ff-only 2>>"$S2S_LOG_FILE" || {
+            print_warning "Could not fast-forward, repo may have local changes (see $S2S_LOG_FILE)"
         }
     else
         print_info "Cloning speech-to-speech..."
@@ -393,7 +393,7 @@ cmd_stop() {
 
     # Stop Docker if running
     if command -v docker &>/dev/null && [[ -f "${S2S_DIR}/docker-compose.yml" ]]; then
-        if docker compose -f "${S2S_DIR}/docker-compose.yml" ps --quiet 2>/dev/null | grep -q .; then
+        if docker compose -f "${S2S_DIR}/docker-compose.yml" ps --quiet 2>>"$S2S_LOG_FILE" | grep -q .; then
             print_info "Stopping Docker containers..."
             (cd "$S2S_DIR" && docker compose down) || return 1
             print_success "Docker containers stopped"
@@ -444,7 +444,7 @@ cmd_status() {
     # Docker
     if command -v docker &>/dev/null && [[ -f "${S2S_DIR}/docker-compose.yml" ]]; then
         local docker_status
-        docker_status=$(docker compose -f "${S2S_DIR}/docker-compose.yml" ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null || echo "not running")
+        docker_status=$(docker compose -f "${S2S_DIR}/docker-compose.yml" ps --format "table {{.Name}}\t{{.Status}}" 2>>"$S2S_LOG_FILE" || echo "not running")
         if echo "$docker_status" | grep -qi "up"; then
             print_success "Docker: running"
             echo "$docker_status"


### PR DESCRIPTION
## Summary

- Add stderr logging infrastructure (`log_stderr`, `suppress_stderr`, `init_log_file`) to `shared-constants.sh` and supervisor-specific `log_cmd` + `SUPERVISOR_LOG` to `supervisor-helper.sh`
- Replace 67 blanket `2>/dev/null` suppressions with log file redirects across 6 scripts, making errors debuggable without cluttering terminal output
- Remaining ~1,209 occurrences are legitimate (command existence checks, process management, jq/DB reads with fallbacks)

## Changes by Script

| Script | Fixes | What Changed |
|--------|-------|-------------|
| `supervisor-helper.sh` | 62 | State transitions, DB writes, gh/git ops, notifications → `~/.aidevops/logs/supervisor.log` |
| `quality-loop-helper.sh` | 7 | `gh` API calls now show errors (callers already handle failures) |
| `speech-to-speech-helper.sh` | 3 | git pull, docker compose → existing S2S log file |
| `memory-helper.sh` | 3 | DB writes now warn on failure instead of silent |
| `mail-helper.sh` | 1 | WAL setup now warns on failure |
| `shared-constants.sh` | +53 lines | New `init_log_file()`, `log_stderr()`, `suppress_stderr()` utilities |

## Categorization of 2>/dev/null Usage

| Category | Count | Action |
|----------|-------|--------|
| **Keep**: `command -v`, `kill -0`, `pgrep`, `sysctl`, `/proc` reads | ~150 | Expected noise, suppression correct |
| **Keep**: `jq` parsing with `\|\| echo` fallback | ~250 | Fallback handles error |
| **Keep**: DB reads with `\|\| echo ""` fallback | ~100 | Fallback handles error |
| **Fixed**: DB writes, state transitions, git push/commit | 67 | → log file or stderr warning |
| **Keep**: `rm`, `mkdir` with `\|\| true` (race conditions) | ~20 | Suppression correct |

## Testing

- `bash -n` syntax check: all 6 files pass
- `shellcheck -S error`: zero violations
- `shellcheck -S warning`: only pre-existing SC2034 (unused vars, not from this PR)

Closes #441