### PR TITLE
fix: raise minimum concurrency to 6 and use tab separator for pipe-safe dispatch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -139,7 +139,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
     - [x] t135.7.2 Replace with array-based command construction ~2h blocked-by:t135.7.1 completed:2026-02-07
     - [x] t135.7.3 Test affected command paths ~30m blocked-by:t135.7.2 completed:2026-02-07
   - [ ] t135.8 P2-B: Increase shared-constants.sh adoption from 17% (29/170) to 80%+ ~4h blocked-by:none
-    - Notes: BLOCKED by supervisor: Re-prompt dispatch failed: backend_infrastructure_error    - [ ] t135.8.1 Audit shared-constants.sh vs what scripts duplicate ~30m
+    - Notes: BLOCKED by supervisor: Re-prompt dispatch failed: backend_infrastructure_error    - [ ] t135.8.1 Audit shared-constants.sh vs what scripts duplicate ~30m BLOCKED: Max retries exceeded: backend_infrastructure_error
     - [ ] t135.8.2 Create migration script to replace inline print_* with source shared-constants.sh ~1.5h blocked-by:t135.8.1
     - [ ] t135.8.3 Run migration in batches, testing each for regressions ~2h blocked-by:t135.8.2
   - [x] t135.9 P2-C: Add trap cleanup for temp files in setup.sh and mktemp scripts ~1h blocked-by:none started:2026-02-07 completed:2026-02-07


### PR DESCRIPTION
## Summary

- Raises adaptive concurrency minimum floor from 1 to 6 — macOS `vm.loadavg` inflates load averages by counting I/O-waiting threads, causing dispatch starvation at moderate CPU usage
- Switches `IFS` separator from `|` to `\t` (tab) in `cmd_dispatch()`, `cmd_next()`, and pulse dispatch loops — task descriptions containing pipe characters broke field parsing

## Changes

- `calculate_adaptive_concurrency()`: new `min_concurrency=6` local, applied as floor for overloaded, memory pressure, and moderate load cases
- `cmd_next()`: batch and global queries use tab separator
- `cmd_dispatch()`: task row query and read use tab separator  
- `cmd_pulse()`: both batch and global dispatch loops use tab separator

## Note

~20 other `IFS='|'` locations in the script still use pipe separator with description fields. Those are tracked as a separate systemic fix task.