### PR TITLE
chore: mark t146 complete - no_pr retry bug already fixed by t147.1 (#450)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -81,8 +81,8 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
   - Notes: PR #462 merged. Self-healing auto-creates diagnostic subtasks on failure/block.
 - [x] t149 feat: auto-create GitHub issues when supervisor adds tasks #enhancement #supervisor #sync ~2h actual:30m (ai:30m) logged:2026-02-07 ref:GH#455 completed:2026-02-07
   - Notes: PR #469 merged. create_github_issue() + update_todo_with_issue_ref() + --no-issue flag + SUPERVISOR_AUTO_ISSUE env.
-- [ ] t146 bug: supervisor no_pr retry counter non-functional (missing $SUPERVISOR_DB) #bugfix #supervisor ~15m (ai:10m test:5m) logged:2026-02-07 ref:GH#439
-  - Notes: Lines 3165 and 3183 of supervisor-helper.sh missing $SUPERVISOR_DB as first arg to db(). Every other db call (20+) passes it. Retry counter never persists. Also remove unused no_pr_key variable on line 3163. From CodeRabbit review on PR #435.
+- [x] t146 bug: supervisor no_pr retry counter non-functional (missing $SUPERVISOR_DB) #bugfix #supervisor ~15m actual:0m (ai:0m) logged:2026-02-07 ref:GH#439 completed:2026-02-07
+  - Notes: Already fixed by t147.1 (PR #450). Both db() calls now have $SUPERVISOR_DB, unused no_pr_key removed. Verified all 117 db() calls pass $SUPERVISOR_DB.
 - [ ] t145 bug: sed -i '' is macOS-only, breaks on Linux/CI #bugfix #portability ~1h (ai:30m test:30m) logged:2026-02-07 ref:GH#440
   - Notes: Multiple scripts use BSD sed -i '' syntax. Need portable wrapper in shared-constants.sh. Audit all scripts for sed -i usage. From reviews on PR #406.
 - [x] t144 quality: excessive 2>/dev/null suppresses real errors #quality #debugging ~3h actual:1h (ai:1h) logged:2026-02-07 ref:GH#441 completed:2026-02-07


### PR DESCRIPTION
## Summary

- Marks t146 as complete in TODO.md - the bug (missing `$SUPERVISOR_DB` arg in `db()` calls for no_pr retry counter) was already fixed by t147.1 (PR #450, commit 3430dcb)
- Verified all 117 `db()` calls in supervisor-helper.sh correctly pass `$SUPERVISOR_DB`
- No code changes needed; TODO-only update

## Verification

All three issues from the original CodeRabbit review on PR #435 were addressed by t147.1:
1. `$SUPERVISOR_DB` added to `db()` SELECT call (line ~3483)
2. `$SUPERVISOR_DB` added to `db()` UPDATE call (line ~3501)
3. Unused `no_pr_key` variable removed

Refs: GH#439, t146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a retry counter issue where database configuration was not being properly applied across all database operations. Database settings are now consistently passed throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->