### PR TITLE
fix: triage 17 PR review threads across 5 merged PRs (t147.7)

### DIFF
--- a/.agents/content.md
+++ b/.agents/content.md
@@ -90,5 +90,3 @@ Integrate with WordPress workflow:
 - Product descriptions
 - Technical documentation
 - Marketing copy
-
-

--- a/.agents/tools/build-mcp/aidevops-plugin.md
+++ b/.agents/tools/build-mcp/aidevops-plugin.md
@@ -415,7 +415,6 @@ Build the plugin when:
 1. OpenCode becomes dominant AI CLI tool
 2. Users request native plugin experience
 3. Hooks become essential (quality gates, etc.)
-4. Plugin hooks become essential (quality gates, etc.)
 
 ## References
 

--- a/setup.sh
+++ b/setup.sh
@@ -2041,8 +2041,9 @@ add_local_bin_to_path() {
     while IFS= read -r rc_file; do
         [[ -z "$rc_file" ]] && continue
         
-        # Create the rc file if it doesn't exist
+        # Create the rc file if it doesn't exist (ensure parent dir exists for fish etc.)
         if [[ ! -f "$rc_file" ]]; then
+            mkdir -p "$(dirname "$rc_file")"
             touch "$rc_file"
         fi
         
@@ -2160,7 +2161,7 @@ alias aws-helper './.agents/scripts/aws-helper.sh'
 ALIASES
 )
     
-    # Check if aliases already exist in any rc file
+    # Check if aliases already exist in any rc file (including fish config)
     local any_configured=false
     local rc_file
     while IFS= read -r rc_file; do
@@ -2170,6 +2171,13 @@ ALIASES
             break
         fi
     done < <(get_all_shell_rcs)
+    # Also check fish config (not included in get_all_shell_rcs on macOS)
+    if [[ "$any_configured" == "false" ]]; then
+        local fish_config="$HOME/.config/fish/config.fish"
+        if grep -q "# AI Assistant Server Access" "$fish_config" 2>/dev/null; then
+            any_configured=true
+        fi
+    fi
     
     if [[ "$any_configured" == "true" ]]; then
         print_info "Server Access aliases already configured - Skipping"
@@ -3787,14 +3795,6 @@ setup_opencode_plugins() {
     
     return 0
 }
-
-# Setup Oh-My-OpenCode Plugin (removed - no longer supported)
-# Kept as stub for backward compatibility with any callers
-setup_oh_my_opencode() {
-    # Removed - oh-my-opencode no longer supported
-    return 0
-}
-
 setup_seo_mcps() {
     print_info "Setting up SEO integrations..."
     


### PR DESCRIPTION
## Summary

- Triaged all 17 review threads across PRs #418, #413, #412, #399, #394
- Applied 5 valid fixes, confirmed 6 already-fixed, dismissed 6 as bot noise
- Replied to every thread on GitHub with disposition and evidence

## Changes

### Fixed (5 threads)
| PR | File | Fix |
|----|------|-----|
| #413 | `.agents/content.md` | Remove trailing blank lines |
| #413 | `.agents/tools/build-mcp/aidevops-plugin.md` | Remove duplicate list item |
| #413 | `setup.sh` | Remove dead `setup_oh_my_opencode` stub (no callers) |
| #418 | `setup.sh` | Add `mkdir -p` before `touch` in `add_local_bin_to_path` for fish dirs |
| #418 | `setup.sh` | Add fish config to alias duplicate detection in `setup_aliases` |

### Already Fixed (6 threads)
- PR #412: `setup_augment_context_engine` return 0, context7.md old tool refs, pointer file count tracking
- PR #399: `parse_args` return 0, mutual exclusion guard, non-interactive `check_requirements`

### Dismissed (6 threads)
- PR #418: Intel Homebrew path (code removed), Bun rc (code removed), lowercase-only y (intentional UX)
- PR #412: `-e` vs `-f` check (unrealistic edge case), AGENTS.md vs dir check (sufficient)
- PR #394: Shorten warning (intentional verbosity), pr-loop dedup (maintainer dismissed)

## Verification
- ShellCheck: no new violations
- `rg setup_oh_my_opencode`: zero callers confirmed before removal
- All 17 threads replied to on GitHub