### PR TITLE
fix(security): harden dashboard token storage - replace localStorage with sessionStorage (t108)

### DIFF
--- a/.opencode/server/mcp-dashboard.ts
+++ b/.opencode/server/mcp-dashboard.ts
@@ -326,8 +326,9 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
   <h1>🎛️ MCP Server Dashboard</h1>
   
   <div class="auth-bar">
-    <input type="password" id="authToken" placeholder="Enter DASHBOARD_TOKEN for control access">
+    <input type="password" id="authToken" placeholder="Enter DASHBOARD_TOKEN for control access" onkeydown="if(event.key==='Enter')setToken()">
     <button onclick="setToken()">Set Token</button>
+    <button id="clearTokenBtn" onclick="clearToken()" style="display:none;background:#da3633;border-color:#da3633;">Clear Token</button>
     <span class="auth-status" id="authStatus">Not authenticated</span>
   </div>
   
@@ -338,23 +339,37 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
 
   <script>
     let ws;
-    let authToken = localStorage.getItem('dashboardToken') || '';
+    let authToken = sessionStorage.getItem('dashboardToken') || '';
     let authRequired = false;
     
     function setToken() {
-      authToken = document.getElementById('authToken').value;
-      localStorage.setItem('dashboardToken', authToken);
+      const input = document.getElementById('authToken');
+      authToken = input.value;
+      sessionStorage.setItem('dashboardToken', authToken);
+      input.value = '';
       updateAuthStatus();
+      refreshAll();
+    }
+    
+    function clearToken() {
+      authToken = '';
+      sessionStorage.removeItem('dashboardToken');
+      document.getElementById('authToken').value = '';
+      updateAuthStatus();
+      refreshAll();
     }
     
     function updateAuthStatus() {
       const status = document.getElementById('authStatus');
+      const clearBtn = document.getElementById('clearTokenBtn');
       if (authToken) {
-        status.textContent = 'Token set';
+        status.textContent = 'Token set (session only)';
         status.className = 'auth-status authenticated';
+        if (clearBtn) clearBtn.style.display = 'inline-block';
       } else {
         status.textContent = authRequired ? 'Token required' : 'No token set';
         status.className = 'auth-status';
+        if (clearBtn) clearBtn.style.display = 'none';
       }
     }
     
@@ -472,9 +487,8 @@ const DASHBOARD_HTML = `<!DOCTYPE html>
     connectWebSocket();
     setInterval(fetchServers, 30000);
     
-    // Restore token from localStorage
+    // Restore token display from sessionStorage
     if (authToken) {
-      document.getElementById('authToken').value = '••••••••';
       updateAuthStatus();
     }
   </script>

--- a/TODO.md
+++ b/TODO.md
@@ -192,7 +192,8 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
   - Notes: Replaced all 4 eval usages with bash arrays. Added ALLOWED_OUTPUT_FORMATS whitelist. Fixed broken JSON heredoc. Removed 5 unreachable returns. Reduced shellcheck disables from 23 to 2. PR #375 merged.
 - [x] t106 Replace eval in system-cleanup.sh find command construction with safe args #security #shell ~1h actual:15m (ai:15m) logged:2026-02-03 completed:2026-02-06
 - [x] t107 Avoid eval-based export in credential-helper.sh; use safe output/quoting #security #shell ~1h actual:20m (ai:20m) logged:2026-02-03 completed:2026-02-06
-- [ ] t108 Dashboard token storage hardening (avoid localStorage; add reset/clear flow) #security #dashboard #plan → [todo/PLANS.md#2026-02-03-dashboard-token-storage-hardening] ~1h (ai:30m test:20m read:10m) logged:2026-02-03
+- [x] t108 Dashboard token storage hardening (avoid localStorage; add reset/clear flow) #security #dashboard #plan → [todo/PLANS.md#2026-02-03-dashboard-token-storage-hardening] ~1h actual:20m (ai:20m) logged:2026-02-03 started:2026-02-07 completed:2026-02-07
+  - Notes: Replaced all 3 localStorage calls with sessionStorage (auto-clears on tab close). Added Clear Token button with red styling. Input cleared after token set. Status shows "session only" indicator. Enter key support on input.
 - [x] t121 Fix template deploy head usage error (invalid option -z) #setup #deploy #bugfix ~30m actual:0m (ai:0m) logged:2026-02-03 completed:2026-02-06
   - Notes: Already fixed in PR #346. deploy-templates.sh replaced GNU-only `head -z` with macOS-compatible `while read -r` loop. No remaining `head -z` usage in codebase.
 - [x] t122 Resolve awk newline warnings during setup deploy (system-reminder) #setup #deploy #bugfix ~45m actual:15m (ai:15m) logged:2026-02-03 completed:2026-02-06
@@ -493,7 +494,7 @@ t104,Install script integrity hardening (replace curl|sh with verified downloads
 t105,Remove eval in ampcode-cli.sh (use arrays + whitelist formats),,security|shell,15m,10m,5m,2026-02-03T00:00Z,pending,,,
 t106,Replace eval in system-cleanup.sh find command construction with safe args,,security|shell,1h,45m,15m,2026-02-03T00:00Z,pending,,,
 t107,Avoid eval-based export in credential-helper.sh; use safe output/quoting,,security|shell,1h,45m,15m,2026-02-03T00:00Z,pending,,,
-t108,Dashboard token storage hardening (avoid localStorage; add reset/clear flow),,security|dashboard|plan,1h,30m,20m,2026-02-03T00:00Z,pending,,,
+t108,Dashboard token storage hardening (avoid localStorage; add reset/clear flow),,security|dashboard|plan,1h,20m,0m,2026-02-03T00:00Z,completed,2026-02-07T00:00Z,,
 t121,Fix template deploy head usage error (invalid option -z),,setup|deploy|bugfix,30m,0m,0m,2026-02-03T00:00Z,completed,2026-02-06T00:00Z,,
 t122,Resolve awk newline warnings during setup deploy (system-reminder),,setup|deploy|bugfix,45m,30m,15m,2026-02-03T00:00Z,pending,,,
 t123,Resolve DSPy dependency conflict (gepa) in setup flow,,python|dspy|deps,45m,0m,0m,2026-02-03T00:00Z,completed,,,

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -625,7 +625,7 @@ s020,p018,opencode run --format json streams structured events,Captured step_sta
 **Estimate:** ~3h (ai:1.5h test:1h read:30m)
 
 <!--TOON:plan{id,title,status,phase,total_phases,owner,tags,est,est_ai,est_test,est_read,logged,started}:
-p017,Dashboard Token Storage Hardening,planning,0,3,,security|auth|dashboard,3h,1.5h,1h,30m,2026-02-03T00:00Z,
+p017,Dashboard Token Storage Hardening,completed,3,3,,security|auth|dashboard,3h,1.5h,1h,30m,2026-02-03T00:00Z,2026-02-07T00:00Z
 -->
 
 #### Purpose
@@ -638,14 +638,14 @@ Current usage persists `dashboardToken` in `localStorage` in the MCP dashboard U
 
 #### Progress
 
-- [ ] (2026-02-03) Phase 1: Trace token flow and identify all storage/read paths ~45m
-- [ ] (2026-02-03) Phase 2: Migrate to session/memory storage and update auth flow ~1.5h
-- [ ] (2026-02-03) Phase 3: Add reset/clear UI flow and verify behavior ~45m
+- [x] (2026-02-07) Phase 1: Trace token flow and identify all storage/read paths ~45m actual:5m
+- [x] (2026-02-07) Phase 2: Migrate to session/memory storage and update auth flow ~1.5h actual:10m
+- [x] (2026-02-07) Phase 3: Add reset/clear UI flow and verify behavior ~45m actual:5m
 
 <!--TOON:milestones[3]{id,plan_id,desc,est,actual,scheduled,completed,status}:
-m088,p017,Phase 1: Trace token flow and storage paths,45m,,2026-02-03T00:00Z,,pending
-m089,p017,Phase 2: Migrate to session/memory storage and update auth flow,1.5h,,2026-02-03T00:00Z,,pending
-m090,p017,Phase 3: Add reset/clear UI flow and verify behavior,45m,,2026-02-03T00:00Z,,pending
+m088,p017,Phase 1: Trace token flow and storage paths,45m,5m,2026-02-03T00:00Z,2026-02-07T00:00Z,completed
+m089,p017,Phase 2: Migrate to session/memory storage and update auth flow,1.5h,10m,2026-02-03T00:00Z,2026-02-07T00:00Z,completed
+m090,p017,Phase 3: Add reset/clear UI flow and verify behavior,45m,5m,2026-02-03T00:00Z,2026-02-07T00:00Z,completed
 -->
 
 #### Decision Log
@@ -850,9 +850,12 @@ m011,p003,Phase 3: Implement chosen approach and test,1.5h,,2025-12-21T14:00Z,,p
 
 #### Decision Log
 
-(To be populated during analysis)
+- **d001**: Use `sessionStorage` over in-memory variable. Rationale: sessionStorage auto-clears on tab close (matching security goal) while surviving in-page navigation/refresh (better UX than pure in-memory). Still scoped to same-origin, not accessible cross-tab.
+- **d002**: Clear input field after token submission. Rationale: prevents token from sitting in a visible/inspectable input field. Status indicator shows "Token set (session only)" instead.
 
-<!--TOON:decisions[0]{id,plan_id,decision,rationale,date,impact}:
+<!--TOON:decisions[2]{id,plan_id,decision,rationale,date,impact}:
+d001,p017,sessionStorage over in-memory variable,Auto-clears on tab close while surviving refresh; same-origin scoped,2026-02-07,security+ux
+d002,p017,Clear input after token set,Prevents token sitting in inspectable input field,2026-02-07,security
 -->
 
 #### Surprises & Discoveries


### PR DESCRIPTION
## Summary

- Replaces all 3 `localStorage` calls with `sessionStorage` in mcp-dashboard.ts (token auto-clears on tab close)
- Adds Clear Token button for manual reset
- Clears input field after token submission (prevents inspection)
- Shows "session only" indicator in auth status
- Adds Enter key support on token input

Reduces XSS attack window from "indefinite" to "current tab session".