### PR TITLE
fix: correct path case in Docker test environment (t135.6.1)

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache bash curl git jq sudo coreutils grep sed && \
 
 USER testuser
 WORKDIR /home/testuser
-RUN mkdir -p ~/git ~/.config/aidevops ~/.agents/{tmp,work,memory}
+RUN mkdir -p ~/Git ~/.config/aidevops ~/.aidevops/.agent-workspace/{tmp,work,memory}
 
 ENV HOME=/home/testuser
 CMD ["/bin/bash"]

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -3,12 +3,12 @@ services:
   test:
     build: .
     volumes:
-      - ../../:/home/testuser/git/aidevops:ro
-    command: ["/home/testuser/git/aidevops/tests/docker/run-tests.sh"]
+      - ../../:/home/testuser/Git/aidevops:ro
+    command: ["/home/testuser/Git/aidevops/tests/docker/run-tests.sh"]
 
   shell:
     build: .
     volumes:
-      - ../../:/home/testuser/git/aidevops
+      - ../../:/home/testuser/Git/aidevops
     stdin_open: true
     tty: true


### PR DESCRIPTION
## Summary

- Fix Docker test environment paths to match actual project conventions (`~/Git/` not `~/git/`)
- Fix workspace directory structure (`~/.aidevops/.agent-workspace/` not `~/.agents/`)

## Changes

| File | Change |
|------|--------|
| `tests/docker/Dockerfile` | `~/git` → `~/Git`, `~/.agents/{tmp,work,memory}` → `~/.aidevops/.agent-workspace/{tmp,work,memory}` |
| `tests/docker/docker-compose.yml` | Volume mount and command paths: `git/aidevops` → `Git/aidevops` |

## Context

Part of t135.6 (fix broken references). The Docker test environment used lowercase `git` and an outdated `.agents/` workspace path that no longer exists.

Closes #441