### PR TITLE
fix: add include guard to shared-constants.sh and remove duplicate source lines

### DIFF
--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -47,12 +47,12 @@
 set -euo pipefail
 
 # Configuration
+# Source shared constants (provides sed_inplace, print_*, color constants)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 # shellcheck disable=SC2034
 readonly SCRIPT_DIR
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
 readonly AIDEVOPS_DIR="${HOME}/.aidevops"
 readonly WORKSPACE_DIR="${AIDEVOPS_DIR}/.agent-workspace"
 readonly TEST_DIR="${WORKSPACE_DIR}/agent-tests"

--- a/.agents/scripts/auto-version-bump.sh
+++ b/.agents/scripts/auto-version-bump.sh
@@ -7,12 +7,9 @@
 # Author: AI DevOps Framework
 # Version: 1.1.1
 
+# Source shared constants (provides sed_inplace, print_*, color constants)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
-
-# Source shared constants (provides sed_inplace and other utilities)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
 
 # Repository root directory
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)" || exit

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -10,6 +10,10 @@
 # Author: AI DevOps Framework
 # Version: 1.6.0
 
+# Include guard: prevent readonly errors when sourced multiple times
+[[ -n "${_SHARED_CONSTANTS_LOADED:-}" ]] && return 0
+_SHARED_CONSTANTS_LOADED=1
+
 # =============================================================================
 # HTTP and API Constants
 # =============================================================================

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -81,7 +81,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 readonly SCRIPT_DIR
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
 readonly SUPERVISOR_DIR="${AIDEVOPS_SUPERVISOR_DIR:-$HOME/.aidevops/.agent-workspace/supervisor}"
 readonly SUPERVISOR_DB="$SUPERVISOR_DIR/supervisor.db"
 readonly MAIL_HELPER="${SCRIPT_DIR}/mail-helper.sh"       # Used by pulse command (t128.2)

--- a/.agents/scripts/unstract-helper.sh
+++ b/.agents/scripts/unstract-helper.sh
@@ -6,14 +6,11 @@
 #
 # Usage: unstract-helper.sh [install|start|stop|status|logs|uninstall|configure-llm]
 
+# Source shared constants (provides sed_inplace, print_*, color constants)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
-
-# Source shared constants (provides sed_inplace and other utilities)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
 
 # Constants
 readonly UNSTRACT_DIR="${HOME}/.aidevops/unstract"

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -7,12 +7,9 @@
 # Author: AI DevOps Framework
 # Version: 1.1.0
 
+# Source shared constants (provides sed_inplace, print_*, color constants)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
-
-# Source shared constants (provides sed_inplace and other utilities)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
 
 # Repository root directory
 # First try git (works when called from any location within a repo)


### PR DESCRIPTION
## Summary

- Add include guard to `shared-constants.sh` so it's safe to source multiple times
- Remove 5 duplicate `source shared-constants.sh` lines introduced by PR #480 merging on top of PR #479

## Problem

PR #479 (sed portability) added `source shared-constants.sh` to 7 scripts. PR #480 (shared-constants adoption) independently added the same line to 155 scripts. When both merged, 5 scripts ended up with two source lines. Under `set -euo pipefail`, the second source fails on `readonly` re-declaration, causing **all supervisor-helper.sh commands to silently exit 1** (batch, help, status, pulse — everything broken).

## Root Cause

`shared-constants.sh` declares 81 `readonly` variables. Sourcing it twice triggers `readonly variable` errors. With `set -e`, this kills the script even when the second source has `|| true` (bash propagates errors from within sourced files).

## Fix

1. **Include guard** in `shared-constants.sh`: `[[ -n "${_SHARED_CONSTANTS_LOADED:-}" ]] && return 0` — makes it idempotent
2. **Remove duplicates** from 5 scripts: supervisor-helper.sh, version-manager.sh, auto-version-bump.sh, unstract-helper.sh, agent-test-helper.sh

## Testing

```bash
# Before fix: exits silently
supervisor-helper.sh help  # no output, exit 1

# After fix: works correctly
supervisor-helper.sh help  # shows usage, exit 0
supervisor-helper.sh batch "test" --tasks "t146"  # creates batch
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal script initialization and dependency loading to enhance reliability and prevent duplicate source issues in development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->