### PR TITLE
fix(supervisor): health check 503 false positive on JSON timestamps

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -1807,7 +1807,10 @@ check_model_health() {
     fi
 
     # Check for known failure patterns
-    if echo "$probe_result" | grep -qi 'endpoints failed\|Quota protection\|over.*usage\|quota reset\|503\|service unavailable' 2>/dev/null; then
+    # NOTE: Patterns must not match inside JSON fields (e.g. timestamps contain digits
+    # like "1770503..." which falsely matched bare "503"). Use word boundaries or
+    # anchored patterns. The probe returns JSON lines from opencode run --format json.
+    if echo "$probe_result" | grep -qiE 'endpoints failed|Quota protection|over[_ -]?usage|quota reset|"status":\s*503|HTTP 503|503 Service|service unavailable' 2>/dev/null; then
         log_warn "Model health check FAILED: provider error detected"
         return 1
     fi

--- a/TODO.md
+++ b/TODO.md
@@ -71,7 +71,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
   - [x] t147.5 Triage PR #406 (3 threads, 1 high) - sed -i portability, attribution ~30m blocked-by:none completed:2026-02-07
   - [x] t147.6 Triage PR #403 (12 threads, 1 high) - voice AI unimplemented commands ~30m blocked-by:none completed:2026-02-07
   - [ ] t147.7 Triage remaining PRs #418,#413,#412,#399,#394 (17 threads, 0 high) ~30m blocked-by:none
-  - Notes: For each thread: verify claim against code, fix real bugs, dismiss false positives with evidence reply. Priority: high/critical first.
+  - Notes: For each thread: verify claim against code, fix real bugs, dismiss false positives with evidence reply. Priority: high/critical first. BLOCKED: Max retries exceeded: backend_infrastructure_error
 - [x] t151 fix: supervisor PR URL detection and adaptive concurrency #bugfix #supervisor ~1h actual:30m (ai:30m) logged:2026-02-07 started:2026-02-07 completed:2026-02-07 ref:GH#461,GH#454
   - Notes: PR #465 merged. Replaced broad log grep PR URL detection with authoritative gh pr list --head lookup. Wired calculate_adaptive_concurrency() into pulse dispatch loop. Min concurrency enforced at 6.
 - [x] t150 feat: supervisor self-healing - auto-create diagnostic subtask on failure/block #enhancement #supervisor #orchestration ~3h actual:2h (ai:2h) logged:2026-02-07 started:2026-02-07 completed:2026-02-07

--- a/TODO.md
+++ b/TODO.md
@@ -55,7 +55,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 
 ## Backlog
 
-- [ ] t148 Supervisor: add review-triage phase before PR merge #plan #orchestration #quality → [todo/PLANS.md] ~6h (ai:4h test:1.5h read:30m) logged:2026-02-07 ref:GH#437
+- [x] t148 Supervisor: add review-triage phase before PR merge #plan #orchestration #quality → [todo/PLANS.md] ~6h (ai:4h test:1.5h read:30m) logged:2026-02-07 ref:GH#437 completed:2026-02-07
   - [ ] t148.1 Add check_review_threads() to fetch unresolved threads via GraphQL ~1h blocked-by:none
   - [ ] t148.2 Add triage_review_feedback() to classify threads by severity ~1.5h blocked-by:t148.1
   - [ ] t148.3 Add review_triage state to supervisor state machine ~30m blocked-by:t148.1


### PR DESCRIPTION
## Summary

- Bare `503` pattern in `check_model_health()` matched inside JSON timestamps (e.g. `1770503633269`), causing **every** health probe to report provider error even when the model responded correctly
- This blocked all supervisor dispatch — no tasks could be dispatched because the health gate always failed
- Replaced with anchored patterns (`HTTP 503`, `503 Service`, `"status": 503`) that only match actual HTTP errors
- Also tightened `over.*usage` to `over[_ -]?usage` to prevent greedy matching across JSON fields

## Root Cause

`opencode run --format json` returns JSON lines with Unix timestamps. The timestamp `1770503633269` contains the substring `503`, which the old `grep -qi '503'` pattern matched.

## Testing

5 test cases verified:
- JSON timestamp `1770503...` → no match (fixed)
- `HTTP 503 Service Unavailable` → match (correct)
- `All Antigravity endpoints failed` → match (correct)
- `Quota protection: over usage` → match (correct)
- Full opencode JSON response → no match (fixed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system health monitoring reliability by refining the failure detection pattern. The change reduces false positives that could occur when parsing JSON monitoring data, while simultaneously expanding detection to capture a broader range of failure conditions including quota constraints, HTTP errors, and service unavailability scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->