### PR TITLE
fix(release): sync Homebrew formula version during release and add to version validator (t135.11)

### DIFF
--- a/.agents/scripts/validate-version-consistency.sh
+++ b/.agents/scripts/validate-version-consistency.sh
@@ -132,6 +132,18 @@ validate_version_consistency() {
         warnings=$((warnings + 1))
     fi
     
+    # Check homebrew/aidevops.rb (version URL only - SHA256 is updated by CI)
+    if [[ -f "$REPO_ROOT/homebrew/aidevops.rb" ]]; then
+        if grep -q "v${expected_version}.tar.gz" "$REPO_ROOT/homebrew/aidevops.rb"; then
+            print_success "homebrew/aidevops.rb: v$expected_version"
+        else
+            local current_formula_version
+            current_formula_version=$(grep -o 'v[0-9]\+\.[0-9]\+\.[0-9]\+\.tar\.gz' "$REPO_ROOT/homebrew/aidevops.rb" | head -1 || echo "not found")
+            print_error "homebrew/aidevops.rb shows '$current_formula_version', expected 'v${expected_version}.tar.gz'"
+            errors=$((errors + 1))
+        fi
+    fi
+    
     # Check .claude-plugin/marketplace.json (optional - only for repos with Claude plugin)
     if [[ -f "$REPO_ROOT/.claude-plugin/marketplace.json" ]]; then
         local marketplace_version

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -474,6 +474,19 @@ update_version_in_files() {
         print_warning "README.md not found, skipping version badge update"
     fi
     
+    # Update Homebrew formula version (SHA256 is updated by CI publish-packages.yml)
+    local formula_file="$REPO_ROOT/homebrew/aidevops.rb"
+    if [[ -f "$formula_file" ]]; then
+        sed_inplace "s|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.tar\.gz\"|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v${new_version}.tar.gz\"|" "$formula_file"
+        
+        if grep -q "v${new_version}.tar.gz" "$formula_file"; then
+            print_success "Updated homebrew/aidevops.rb version URL"
+        else
+            print_error "Failed to update homebrew/aidevops.rb"
+            errors=$((errors + 1))
+        fi
+    fi
+    
     # Update Claude Code plugin marketplace.json
     if [[ -f "$REPO_ROOT/.claude-plugin/marketplace.json" ]]; then
         sed_inplace "s/\"version\": \"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/\"version\": \"$new_version\"/" "$REPO_ROOT/.claude-plugin/marketplace.json"

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,8 +5,8 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v2.52.1.tar.gz"
-  sha256 "PLACEHOLDER_SHA256"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v2.105.6.tar.gz"
+  sha256 "0e8557216eb745e8aabebd482ae8cc4586f1ae869ce7b78901294a47db2d3494"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"
 


### PR DESCRIPTION
## Summary

- Adds Homebrew formula version URL update to `update_version_in_files()` in version-manager.sh so the local `homebrew/aidevops.rb` stays in sync during releases
- Adds formula version check to `validate-version-consistency.sh` (now validates 8 files)
- Updates the frozen local formula from v2.52.1/PLACEHOLDER_SHA256 to v2.105.6 with correct SHA256

## Context

The local `homebrew/aidevops.rb` was frozen at v2.52.1 with `PLACEHOLDER_SHA256` since the formula was first created. The CI workflow (`publish-packages.yml`) correctly updates the tap repo (`marcusquinn/homebrew-tap`) on each release, but the local copy was never updated by version-manager.sh.

Now the release flow updates the version URL locally (SHA256 is computed and applied by CI from the release tarball), and the version validator catches any drift.

## Testing

- `bash -n`: PASS (both files)
- `shellcheck -S error`: PASS (both files)
- `validate-version-consistency.sh`: All 8 files consistent at v2.105.6

Closes t135.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 2.105.6
  * Enhanced version consistency validation
  * Updated distribution configurations for improved release management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->