### PR TITLE
fix: guard ((var++)) with || true to prevent silent exit under set -e

### DIFF
--- a/.agents/scripts/anti-detect-helper.sh
+++ b/.agents/scripts/anti-detect-helper.sh
@@ -1096,7 +1096,7 @@ show_status() {
     # Profiles
     local profile_count=0
     for dir in "$PROFILES_DIR"/{persistent,clean,warmup}/*/; do
-        [[ -d "$dir" ]] && [[ "$(basename "$dir")" != "default" ]] && ((profile_count++)) || true
+        [[ -d "$dir" ]] && [[ "$(basename "$dir")" != "default" ]] && ((profile_count++)) || true || true
     done
     echo -e "  Profiles:          ${GREEN}$profile_count${NC} configured"
 

--- a/.agents/scripts/codacy-cli-chunked.sh
+++ b/.agents/scripts/codacy-cli-chunked.sh
@@ -188,7 +188,7 @@ run_quick_analysis() {
     # Count tools
     for tool in $fast_tools; do
         if get_configured_tools | grep -q "^$tool$"; then
-            ((total_tools++))
+            ((total_tools++)) || true
         fi
     done
 
@@ -205,7 +205,7 @@ run_quick_analysis() {
 
     for tool in $fast_tools; do
         if get_configured_tools | grep -q "^$tool$"; then
-            ((completed_tools++))
+            ((completed_tools++)) || true
             print_progress $completed_tools $total_tools "$tool"
             
             print_info "Running: $tool"
@@ -350,7 +350,7 @@ run_chunked_analysis() {
 
         # Update progress
         completed_tools=$chunk_end
-        ((chunk_num++))
+        ((chunk_num++)) || true
         
         # Brief pause between chunks
         if [[ $chunk_end -lt ${#tool_array[@]} ]]; then

--- a/.agents/scripts/crawl4ai-examples.sh
+++ b/.agents/scripts/crawl4ai-examples.sh
@@ -154,7 +154,7 @@ example_batch_processing() {
             print_warning "Failed to process: $url"
         fi
         
-        ((i++))
+        ((i++)) || true
         sleep 1  # Rate limiting
     done
     
@@ -263,7 +263,7 @@ example_captcha_demo() {
             print_warning "CAPTCHA demo $i failed - this may be due to site changes or API limits"
         fi
 
-        ((i++))
+        ((i++)) || true
 
         # Add delay between requests to respect rate limits
         if [[ $i -le ${#demo_configs[@]} ]]; then

--- a/.agents/scripts/linter-manager.sh
+++ b/.agents/scripts/linter-manager.sh
@@ -149,41 +149,41 @@ install_python_linters() {
     print_info "Installing pycodestyle..."
     if pip install pycodestyle &>/dev/null; then
         print_success "pycodestyle installed"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install pycodestyle"
     fi
-    ((total++))
+    ((total++)) || true
     
     # Pylint (comprehensive Python linter)
     print_info "Installing Pylint..."
     if pip install pylint &>/dev/null; then
         print_success "Pylint installed"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install Pylint"
     fi
-    ((total++))
+    ((total++)) || true
     
     # Bandit (security linter)
     print_info "Installing Bandit..."
     if pip install bandit &>/dev/null; then
         print_success "Bandit installed"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install Bandit"
     fi
-    ((total++))
+    ((total++)) || true
     
     # Ruff (fast Python linter)
     print_info "Installing Ruff..."
     if pip install ruff &>/dev/null; then
         print_success "Ruff installed"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install Ruff"
     fi
-    ((total++))
+    ((total++)) || true
     
     print_info "Python linters: $success/$total installed successfully"
     return $((total - success))
@@ -200,21 +200,21 @@ install_javascript_linters() {
     print_info "Installing ESLint..."
     if install_npm_global eslint; then
         print_success "ESLint installed"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install ESLint"
     fi
-    ((total++))
+    ((total++)) || true
 
     # TypeScript ESLint parser and plugin
     print_info "Installing TypeScript ESLint support..."
     if install_npm_global @typescript-eslint/parser @typescript-eslint/eslint-plugin; then
         print_success "TypeScript ESLint support installed"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install TypeScript ESLint support"
     fi
-    ((total++))
+    ((total++)) || true
 
     print_info "JavaScript/TypeScript linters: $success/$total installed successfully"
     return $((total - success))
@@ -231,11 +231,11 @@ install_css_linters() {
     print_info "Installing Stylelint..."
     if install_npm_global stylelint stylelint-config-standard; then
         print_success "Stylelint installed"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install Stylelint"
     fi
-    ((total++))
+    ((total++)) || true
 
     print_info "CSS linters: $success/$total installed successfully"
     return $((total - success))
@@ -252,17 +252,17 @@ install_shell_linters() {
     print_info "Installing ShellCheck..."
     if command -v shellcheck &>/dev/null; then
         print_success "ShellCheck already installed"
-        ((success++))
+        ((success++)) || true
     elif brew install shellcheck &>/dev/null; then
         print_success "ShellCheck installed via Homebrew"
-        ((success++))
+        ((success++)) || true
     elif apt-get install -y shellcheck &>/dev/null; then
         print_success "ShellCheck installed via apt"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install ShellCheck"
     fi
-    ((total++))
+    ((total++)) || true
 
     print_info "Shell linters: $success/$total installed successfully"
     return $((total - success))
@@ -279,14 +279,14 @@ install_docker_linters() {
     print_info "Installing Hadolint..."
     if command -v hadolint &>/dev/null; then
         print_success "Hadolint already installed"
-        ((success++))
+        ((success++)) || true
     elif brew install hadolint &>/dev/null; then
         print_success "Hadolint installed via Homebrew"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install Hadolint"
     fi
-    ((total++))
+    ((total++)) || true
 
     print_info "Docker linters: $success/$total installed successfully"
     return $((total - success))
@@ -303,11 +303,11 @@ install_yaml_linters() {
     print_info "Installing yamllint..."
     if pip install yamllint &>/dev/null; then
         print_success "yamllint installed"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install yamllint"
     fi
-    ((total++))
+    ((total++)) || true
 
     print_info "YAML linters: $success/$total installed successfully"
     return $((total - success))
@@ -324,27 +324,27 @@ install_security_linters() {
     print_info "Installing Trivy..."
     if command -v trivy &>/dev/null; then
         print_success "Trivy already installed"
-        ((success++))
+        ((success++)) || true
     elif brew install trivy &>/dev/null; then
         print_success "Trivy installed via Homebrew"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install Trivy"
     fi
-    ((total++))
+    ((total++)) || true
 
     # Secretlint (secret detection)
     print_info "Installing Secretlint..."
     if command -v secretlint &>/dev/null; then
         print_success "Secretlint already installed"
-        ((success++))
+        ((success++)) || true
     elif install_npm_global secretlint @secretlint/secretlint-rule-preset-recommend; then
         print_success "Secretlint installed"
-        ((success++))
+        ((success++)) || true
     else
         print_error "Failed to install Secretlint"
     fi
-    ((total++))
+    ((total++)) || true
 
     print_info "Security linters: $success/$total installed successfully"
     return $((total - success))

--- a/.agents/scripts/localhost-helper.sh
+++ b/.agents/scripts/localhost-helper.sh
@@ -67,7 +67,7 @@ find_available_port() {
             echo "$port"
             return 0
         fi
-        ((port++))
+        ((port++)) || true
     done
     
     print_error "No available ports found in range $start_port-$PORT_RANGE_END"

--- a/.agents/scripts/markdown-formatter.sh
+++ b/.agents/scripts/markdown-formatter.sh
@@ -98,9 +98,9 @@ process_directory() {
 
     # Find all markdown files
     while IFS= read -r -d '' file; do
-        ((total_files++))
+        ((total_files++)) || true
         if fix_markdown_file "$file"; then
-            ((changed_files++))
+            ((changed_files++)) || true
         fi
     done < <(find "$dir" -name "*.md" -type f -print0)
 

--- a/.agents/scripts/quality-cli-manager.sh
+++ b/.agents/scripts/quality-cli-manager.sh
@@ -100,54 +100,54 @@ install_clis() {
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
         print_info "Installing CodeRabbit CLI..."
         if execute_cli_command "$CLI_CODERABBIT" "install"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
     
     if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
         print_info "Installing Codacy CLI..."
         if execute_cli_command "codacy" "install"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
     
     if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
         print_info "Installing SonarScanner CLI..."
         if execute_cli_command "sonar" "install"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
         print_info "Installing Qlty CLI..."
         if execute_cli_command "qlty" "install"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
         print_info "Installing Snyk CLI..."
         if execute_cli_command "$CLI_SNYK" "install"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "linters" ]]; then
         print_info "Installing CodeFactor-inspired linters..."
         if bash "$(dirname "$0")/linter-manager.sh" install-detected; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
     
@@ -175,45 +175,45 @@ init_clis() {
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
         print_info "Initializing CodeRabbit CLI..."
         if execute_cli_command "$CLI_CODERABBIT" "setup"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
     
     if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
         print_info "Initializing Codacy CLI..."
         if execute_cli_command "codacy" "init"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
     
     if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
         print_info "Initializing SonarScanner CLI..."
         if execute_cli_command "sonar" "init"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
         print_info "Initializing Qlty CLI..."
         if execute_cli_command "qlty" "init"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
         print_info "Initializing Snyk CLI..."
         if execute_cli_command "$CLI_SNYK" "auth"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
     
@@ -243,18 +243,18 @@ analyze_with_clis() {
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
         print_info "Running CodeRabbit analysis..."
         if execute_cli_command "$CLI_CODERABBIT" "review" "$args"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
         print_info "Running Codacy analysis..."
         if execute_cli_command "codacy" "analyze" "$args"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
@@ -262,18 +262,18 @@ analyze_with_clis() {
     if [[ "$target_cli" == "codacy-fix" ]]; then
         print_info "Running Codacy analysis with auto-fix..."
         if execute_cli_command "codacy" "analyze" "--fix"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
         print_info "Running SonarQube analysis..."
         if execute_cli_command "sonar" "analyze" "$args"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
@@ -285,18 +285,18 @@ analyze_with_clis() {
             qlty_args="$args $QLTY_ORG"
         fi
         if execute_cli_command "qlty" "check" "$qlty_args"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
         print_info "Running Snyk security analysis..."
         if execute_cli_command "$CLI_SNYK" "full" "$args"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
@@ -304,27 +304,27 @@ analyze_with_clis() {
     if [[ "$target_cli" == "snyk-sca" ]]; then
         print_info "Running Snyk SCA (dependency) scan..."
         if execute_cli_command "$CLI_SNYK" "test" "$args"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "snyk-code" ]]; then
         print_info "Running Snyk Code (SAST) scan..."
         if execute_cli_command "$CLI_SNYK" "code" "$args"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "snyk-iac" ]]; then
         print_info "Running Snyk IaC scan..."
         if execute_cli_command "$CLI_SNYK" "iac" "$args"; then
-            ((success_count++))
+            ((success_count++)) || true
         fi
-        ((total_count++))
+        ((total_count++)) || true
         echo ""
     fi
 

--- a/.agents/scripts/setup-linters-wizard.sh
+++ b/.agents/scripts/setup-linters-wizard.sh
@@ -248,7 +248,7 @@ install_selected_linters() {
             print_success "$lang linters installed successfully"
         else
             print_warning "Some $lang linters failed to install"
-            ((total_failures++))
+            ((total_failures++)) || true
         fi
         echo ""
     done

--- a/.agents/scripts/setup-local-api-keys.sh
+++ b/.agents/scripts/setup-local-api-keys.sh
@@ -64,7 +64,7 @@ setup_shell_integration() {
             echo "# AI DevOps API Keys (single source of truth)" >> "$config"
             echo "$source_line" >> "$config"
             print_success "Added credentials.sh sourcing to $config"
-            ((updated++))
+            ((updated++)) || true
         fi
     done
     

--- a/.agents/scripts/toon-helper.sh
+++ b/.agents/scripts/toon-helper.sh
@@ -208,9 +208,9 @@ batch_convert() {
                     basename=$(basename "$file" .json)
                     local target_file="$target_dir/$basename.toon"
                     
-                    ((count++))
+                    ((count++)) || true
                     if json_to_toon "$file" "$target_file" "$delimiter" "false"; then
-                        ((success_count++))
+                        ((success_count++)) || true
                     fi
                 fi
             done
@@ -222,9 +222,9 @@ batch_convert() {
                     basename=$(basename "$file" .toon)
                     local target_file="$target_dir/$basename.json"
                     
-                    ((count++))
+                    ((count++)) || true
                     if toon_to_json "$file" "$target_file" "true"; then
-                        ((success_count++))
+                        ((success_count++)) || true
                     fi
                 fi
             done


### PR DESCRIPTION
## Summary

- Fix `((var++))` arithmetic expressions that silently abort scripts under `set -e` when the variable is 0
- In bash, `((0))` returns exit code 1, and `set -e` (errexit) treats this as a fatal error
- This caused `setup.sh --non-interactive` to abort at `cleanup_deprecated_mcps()` before reaching `deploy_aidevops_agents()`, leaving deployed agents at a stale version

## Changes

- **setup.sh**: Fixed 33 instances of `((var++))` → `((var++)) || true`
- **10 helper scripts**: Fixed the same pattern in scripts that use `set -e`:
  - `anti-detect-helper.sh`, `codacy-cli-chunked.sh`, `crawl4ai-examples.sh`
  - `linter-manager.sh`, `localhost-helper.sh`, `markdown-formatter.sh`
  - `quality-cli-manager.sh`, `setup-linters-wizard.sh`, `setup-local-api-keys.sh`
  - `toon-helper.sh`

## Testing

- `bash -n` syntax check passes on all 11 modified files
- `setup.sh --non-interactive` now runs to completion (previously silently aborted)
- Verified agents deploy correctly with VERSION file synced

## Root Cause

```bash
set -euo pipefail
local cleaned=0
# ... inside a loop when first match found:
((cleaned++))  # cleaned is 0, post-increment returns 0, (( 0 )) = exit 1 → script dies
```

Closes t152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling robustness across shell scripts to prevent unexpected termination during script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->