### PR TITLE
fix: refresh version cache after setup.sh completes

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4210,6 +4210,13 @@ main() {
         confirm_step "Disable on-demand MCPs globally" && disable_ondemand_mcps
     fi
 
+    # Refresh version cache so session greeting shows correct version
+    # This ensures `setup.sh` alone (without `aidevops update`) updates the cached version
+    local update_check_script="$HOME/.aidevops/agents/scripts/aidevops-update-check.sh"
+    if [[ -x "$update_check_script" ]]; then
+        "$update_check_script" > /dev/null 2>&1 || true
+    fi
+
     echo ""
     print_success "🎉 Setup complete!"
     echo ""


### PR DESCRIPTION
## Summary
- `setup.sh` deploys the VERSION file to `~/.aidevops/agents/VERSION` but never refreshes the session greeting cache (`~/.aidevops/cache/session-greeting.txt`)
- This causes stale version reporting when running `setup.sh` directly (e.g. after a manual `git pull`) without going through `aidevops update`
- Fix: run `aidevops-update-check.sh` at the end of setup to sync the cached version

## Testing
1. Run `./setup.sh` directly (not via `aidevops update`)
2. Check `~/.aidevops/cache/session-greeting.txt` shows correct version
3. New AI sessions should report the correct version immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic version and cache refresh during the setup process to ensure the installation reflects the current state. This executes silently as part of the standard setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->