### PR TITLE
feat: add Uncloud multi-machine container orchestration integration (t016)

### DIFF
--- a/.agents/scripts/uncloud-helper.sh
+++ b/.agents/scripts/uncloud-helper.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2034
+set -euo pipefail
+
+# Uncloud Helper Script
+# CLI wrapper for common Uncloud (uc) operations
+# Docs: https://uncloud.run/docs
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+readonly HELP_USAGE_INFO="Use '$0 help' for usage information"
+
+# Check if uc CLI is installed
+check_uc() {
+    if ! command -v uc >/dev/null 2>&1; then
+        print_error "Uncloud CLI (uc) is not installed"
+        print_info "Install via Homebrew: brew install psviderski/tap/uncloud"
+        print_info "Install via curl: curl -fsS https://get.uncloud.run/install.sh | sh"
+        return 1
+    fi
+    return 0
+}
+
+# Show cluster status (machines + services)
+cmd_status() {
+    check_uc || return 1
+
+    print_info "Cluster machines:"
+    uc machine ls 2>&1 || print_warning "No cluster configured or machines unreachable"
+
+    echo ""
+    print_info "Services:"
+    uc ls 2>&1 || print_warning "No services running"
+
+    echo ""
+    print_info "Containers:"
+    uc ps 2>&1 || print_warning "No containers running"
+
+    return 0
+}
+
+# List machines
+cmd_machines() {
+    check_uc || return 1
+    uc machine ls
+    return 0
+}
+
+# List services
+cmd_services() {
+    check_uc || return 1
+    uc ls
+    return 0
+}
+
+# Deploy from compose.yaml
+cmd_deploy() {
+    local compose_file="${1:-}"
+    check_uc || return 1
+
+    local args=()
+    if [[ -n "$compose_file" ]]; then
+        args+=("-f" "$compose_file")
+    fi
+
+    print_info "Deploying services..."
+    uc deploy "${args[@]}"
+    return 0
+}
+
+# Run a service from an image
+cmd_run() {
+    check_uc || return 1
+
+    if [[ $# -eq 0 ]]; then
+        print_error "Usage: run <image> [uc run flags]"
+        print_info "Example: run my-app:latest -p app.example.com:8000/https"
+        return 1
+    fi
+
+    uc run "$@"
+    return 0
+}
+
+# Scale a service
+cmd_scale() {
+    local service="${1:-}"
+    local replicas="${2:-}"
+    check_uc || return 1
+
+    if [[ -z "$service" || -z "$replicas" ]]; then
+        print_error "Usage: scale <service> <replicas>"
+        return 1
+    fi
+
+    print_info "Scaling $service to $replicas replicas..."
+    uc scale "$service" "$replicas"
+    return 0
+}
+
+# View service logs
+cmd_logs() {
+    local service="${1:-}"
+    check_uc || return 1
+
+    if [[ -z "$service" ]]; then
+        print_error "Usage: logs <service> [--follow]"
+        return 1
+    fi
+
+    shift
+    uc logs "$service" "$@"
+    return 0
+}
+
+# Execute command in a service container
+cmd_exec() {
+    local service="${1:-}"
+    check_uc || return 1
+
+    if [[ -z "$service" ]]; then
+        print_error "Usage: exec <service> [-- command]"
+        return 1
+    fi
+
+    shift
+    uc exec "$service" "$@"
+    return 0
+}
+
+# Inspect a service
+cmd_inspect() {
+    local service="${1:-}"
+    check_uc || return 1
+
+    if [[ -z "$service" ]]; then
+        print_error "Usage: inspect <service>"
+        return 1
+    fi
+
+    uc inspect "$service"
+    return 0
+}
+
+# Volume management
+cmd_volumes() {
+    check_uc || return 1
+    uc volume ls
+    return 0
+}
+
+# DNS management
+cmd_dns() {
+    check_uc || return 1
+    uc dns show
+    return 0
+}
+
+# Caddy management
+cmd_caddy() {
+    local subcmd="${1:-config}"
+    check_uc || return 1
+
+    case "$subcmd" in
+        config)
+            uc caddy config
+            ;;
+        deploy)
+            uc caddy deploy
+            ;;
+        *)
+            print_error "Unknown caddy subcommand: $subcmd"
+            print_info "Available: config, deploy"
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# Machine init (initialise new cluster)
+cmd_init() {
+    local ssh_target="${1:-}"
+    local name="${2:-}"
+    check_uc || return 1
+
+    if [[ -z "$ssh_target" ]]; then
+        print_error "Usage: init <user@host> [--name machine-name]"
+        return 1
+    fi
+
+    local args=("$ssh_target")
+    if [[ -n "$name" ]]; then
+        args=("--name" "$name" "$ssh_target")
+    fi
+
+    print_info "Initialising cluster with machine $ssh_target..."
+    uc machine init "${args[@]}"
+    return 0
+}
+
+# Add machine to cluster
+cmd_add_machine() {
+    local ssh_target="${1:-}"
+    local name="${2:-}"
+    check_uc || return 1
+
+    if [[ -z "$ssh_target" ]]; then
+        print_error "Usage: add-machine <user@host> [machine-name]"
+        return 1
+    fi
+
+    local args=("$ssh_target")
+    if [[ -n "$name" ]]; then
+        args=("--name" "$name" "$ssh_target")
+    fi
+
+    print_info "Adding machine $ssh_target to cluster..."
+    uc machine add "${args[@]}"
+    return 0
+}
+
+# Remove a service
+cmd_rm() {
+    local service="${1:-}"
+    check_uc || return 1
+
+    if [[ -z "$service" ]]; then
+        print_error "Usage: rm <service>"
+        return 1
+    fi
+
+    print_warning "Removing service: $service"
+    uc rm "$service"
+    return 0
+}
+
+# Stop a service
+cmd_stop() {
+    local service="${1:-}"
+    check_uc || return 1
+
+    if [[ -z "$service" ]]; then
+        print_error "Usage: stop <service>"
+        return 1
+    fi
+
+    uc stop "$service"
+    return 0
+}
+
+# Start a service
+cmd_start() {
+    local service="${1:-}"
+    check_uc || return 1
+
+    if [[ -z "$service" ]]; then
+        print_error "Usage: start <service>"
+        return 1
+    fi
+
+    uc start "$service"
+    return 0
+}
+
+# Push image to cluster
+cmd_push() {
+    local image="${1:-}"
+    check_uc || return 1
+
+    if [[ -z "$image" ]]; then
+        print_error "Usage: push <image:tag>"
+        return 1
+    fi
+
+    print_info "Pushing image $image to cluster..."
+    uc image push "$image"
+    return 0
+}
+
+# WireGuard network info
+cmd_network() {
+    check_uc || return 1
+    uc wg show
+    return 0
+}
+
+# Context management
+cmd_context() {
+    local subcmd="${1:-ls}"
+    check_uc || return 1
+
+    case "$subcmd" in
+        ls|list)
+            uc ctx ls
+            ;;
+        use)
+            local ctx="${2:-}"
+            if [[ -z "$ctx" ]]; then
+                print_error "Usage: context use <context-name>"
+                return 1
+            fi
+            uc ctx use "$ctx"
+            ;;
+        *)
+            print_error "Unknown context subcommand: $subcmd"
+            print_info "Available: ls, use"
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# Show help
+cmd_help() {
+    echo "Uncloud Helper Script"
+    echo "${HELP_LABEL_USAGE} $0 [command] [args]"
+    echo ""
+    echo "Cluster Management:"
+    echo "  status                          - Show cluster status (machines, services, containers)"
+    echo "  init <user@host> [name]         - Initialise a new cluster with first machine"
+    echo "  add-machine <user@host> [name]  - Add a machine to the cluster"
+    echo "  machines                        - List machines in the cluster"
+    echo "  network                         - Show WireGuard network info"
+    echo "  context [ls|use <name>]         - Manage cluster contexts"
+    echo ""
+    echo "Service Management:"
+    echo "  services                        - List services"
+    echo "  deploy [compose-file]           - Deploy services from compose.yaml"
+    echo "  run <image> [flags]             - Run a service from a Docker image"
+    echo "  scale <service> <replicas>      - Scale a service"
+    echo "  start <service>                 - Start a service"
+    echo "  stop <service>                  - Stop a service"
+    echo "  rm <service>                    - Remove a service"
+    echo "  logs <service> [--follow]       - View service logs"
+    echo "  exec <service> [-- cmd]         - Execute command in service container"
+    echo "  inspect <service>               - Show service details"
+    echo ""
+    echo "Infrastructure:"
+    echo "  push <image:tag>                - Push Docker image to cluster (Unregistry)"
+    echo "  volumes                         - List volumes"
+    echo "  dns                             - Show cluster DNS domain"
+    echo "  caddy [config|deploy]           - Manage Caddy reverse proxy"
+    echo ""
+    echo "${HELP_LABEL_EXAMPLES}"
+    echo "  $0 status"
+    echo "  $0 init root@server.example.com my-server"
+    echo "  $0 deploy"
+    echo "  $0 run my-app:latest -p app.example.com:8000/https"
+    echo "  $0 scale my-service 3"
+    echo "  $0 logs my-service --follow"
+    echo ""
+    echo "Requirements:"
+    echo "  - uc CLI (brew install psviderski/tap/uncloud)"
+    echo "  - SSH access to target machines"
+    echo "  - Docs: https://uncloud.run/docs"
+    return 0
+}
+
+# Main function
+main() {
+    local command="${1:-help}"
+    shift 2>/dev/null || true
+
+    case "$command" in
+        status)         cmd_status ;;
+        machines)       cmd_machines ;;
+        services)       cmd_services ;;
+        deploy)         cmd_deploy "$@" ;;
+        run)            cmd_run "$@" ;;
+        scale)          cmd_scale "$@" ;;
+        logs)           cmd_logs "$@" ;;
+        exec)           cmd_exec "$@" ;;
+        inspect)        cmd_inspect "$@" ;;
+        volumes)        cmd_volumes ;;
+        dns)            cmd_dns ;;
+        caddy)          cmd_caddy "$@" ;;
+        init)           cmd_init "$@" ;;
+        add-machine)    cmd_add_machine "$@" ;;
+        rm)             cmd_rm "$@" ;;
+        stop)           cmd_stop "$@" ;;
+        start)          cmd_start "$@" ;;
+        push)           cmd_push "$@" ;;
+        network)        cmd_network ;;
+        context)        cmd_context "$@" ;;
+        help|-h|--help) cmd_help ;;
+        *)
+            print_error "${ERROR_UNKNOWN_COMMAND} ${command}"
+            print_info "Run '$0 help' for usage information"
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+main "$@"

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -45,7 +45,7 @@ tools/ocr/,OCR and text extraction - local document processing via Ollama,glm-oc
 tools/video/,Video creation and downloading - programmatic generation and YouTube downloads,remotion|higgsfield|yt-dlp|video-prompt-design
 tools/voice/,Voice AI - voice bridge and Pipecat pipeline for talking to AI agents,speech-to-speech|voice-bridge|hyprwhspr|pipecat-opencode|transcription|voice-models|buzz
 tools/data-extraction/,Data extraction - scraping business data,outscraper
-tools/deployment/,Deployment automation - self-hosted PaaS,coolify|coolify-cli|vercel|cloudron-app-packaging
+tools/deployment/,Deployment automation - self-hosted PaaS and orchestration,coolify|coolify-cli|vercel|cloudron-app-packaging|uncloud
 tools/git/,Git operations - GitHub/GitLab/Gitea CLIs,github-cli|gitlab-cli|gitea-cli|github-actions|worktrunk
 tools/credentials/,Secret management - API keys and vaults,api-key-setup|api-key-management|vaultwarden|gopass|psst|multi-tenant|list-keys
 tools/security/,Security tools - privacy filtering and scanning,privacy-filter
@@ -79,7 +79,7 @@ bug-fixing,workflows/bug-fixing.md,Bug fix workflow
 feature-development,workflows/feature-development.md,Feature development workflow
 -->
 
-<!--TOON:scripts[42]{name,purpose}:
+<!--TOON:scripts[44]{name,purpose}:
 list-keys-helper.sh,List all API keys with storage locations
 linters-local.sh,Run local linting (ShellCheck secretlint patterns)
 code-audit-helper.sh,Run remote auditing (CodeRabbit Codacy SonarCloud)
@@ -87,6 +87,7 @@ version-manager.sh,Version bumps and releases
 linter-manager.sh,Install and manage linters
 github-cli-helper.sh,GitHub operations
 coolify-helper.sh,Coolify deployment management
+uncloud-helper.sh,Uncloud multi-machine container orchestration
 stagehand-helper.sh,Browser automation with Stagehand
 crawl4ai-helper.sh,Web crawling and extraction
 watercrawl-helper.sh,WaterCrawl cloud API for web crawling and search

--- a/.agents/tools/deployment/uncloud.md
+++ b/.agents/tools/deployment/uncloud.md
@@ -1,0 +1,388 @@
+---
+description: Lightweight multi-machine container orchestration with Uncloud
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Uncloud Provider Guide
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Type**: Multi-machine container orchestration (Docker-based, decentralised)
+- **CLI**: `uc` (install: `brew install psviderski/tap/uncloud` or `curl -fsS https://get.uncloud.run/install.sh | sh`)
+- **Config**: `configs/uncloud-config.json`
+- **Script**: `.agents/scripts/uncloud-helper.sh`
+- **Docs**: https://uncloud.run/docs
+- **Source**: https://github.com/psviderski/uncloud (Apache-2.0, 4.6k stars, Go)
+- **Status**: Active development, not yet production-ready (v0.16.0 as of Jan 2026)
+- **Commands**: `status|machines|services|deploy|run|scale|logs|exec|inspect|volumes|dns|caddy|help`
+- **Usage**: `./.agents/scripts/uncloud-helper.sh [command] [args]`
+
+**Key features**: WireGuard mesh networking, Docker Compose format, no control plane, Caddy reverse proxy with auto HTTPS, Unregistry (registryless image push), managed DNS (*.uncld.dev), rolling deployments.
+
+<!-- AI-CONTEXT-END -->
+
+Uncloud is a lightweight clustering and container orchestration tool that deploys and manages containerised applications across a network of Docker hosts. It bridges the gap between Docker Compose and Kubernetes.
+
+## Provider Overview
+
+### Characteristics
+
+- **Deployment Type**: Multi-machine container orchestration
+- **Technology**: Docker containers + WireGuard mesh + distributed SQLite (Corrosion)
+- **Format**: Docker Compose files (compose.yaml)
+- **Networking**: Automatic WireGuard mesh with peer discovery and NAT traversal
+- **Proxy**: Built-in Caddy reverse proxy with auto HTTPS (Let's Encrypt)
+- **Architecture**: Decentralised, no control plane, no quorum
+- **DNS**: Managed `*.uncld.dev` subdomains or custom domains
+- **Images**: Direct push via Unregistry (no external registry needed)
+- **Footprint**: ~150 MB RAM per machine daemon
+
+### Best Use Cases
+
+- **Multi-machine deployments** across cloud VMs, bare metal, hybrid setups
+- **Outgrowing Docker Compose** with zero-downtime deployments and replicas
+- **Self-hosting and homelabs** with simple scaling
+- **Edge computing** with machines in different locations/providers
+- **Dev/staging environments** mirroring production
+- **Agencies** hosting multiple client projects on shared infrastructure
+
+### Comparison with Other Providers
+
+| Provider | Type | Best For |
+|----------|------|----------|
+| Coolify | Self-hosted PaaS | Single-server apps, managed UI experience |
+| Vercel | Serverless | Static sites, JAMstack, Next.js |
+| Cloudron | Self-hosted PaaS | App store experience, managed updates |
+| **Uncloud** | **Multi-machine orchestration** | **Cross-server deployments, Docker clusters** |
+
+## Configuration
+
+### Setup Configuration
+
+```bash
+# Copy template
+cp configs/uncloud-config.json.txt configs/uncloud-config.json
+
+# Edit with your cluster details
+```
+
+### Cluster Configuration
+
+```json
+{
+  "clusters": {
+    "production": {
+      "name": "Production Cluster",
+      "context": "default",
+      "machines": [
+        {
+          "name": "web-1",
+          "ssh": "root@web1.example.com",
+          "role": "general"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Installation
+
+### CLI Installation
+
+```bash
+# macOS/Linux via Homebrew
+brew install psviderski/tap/uncloud
+
+# macOS/Linux via curl
+curl -fsS https://get.uncloud.run/install.sh | sh
+```
+
+### Cluster Initialisation
+
+```bash
+# Initialise first machine (installs Docker, uncloudd, WireGuard)
+uc machine init root@your-server-ip
+
+# Add more machines
+uc machine add --name web-2 root@second-server-ip
+
+# List machines
+uc machine ls
+```
+
+## Usage Examples
+
+### Service Management
+
+```bash
+# Run a service from a Docker image
+uc run -p app.example.com:8000/https image/my-app
+
+# Deploy from a compose.yaml file
+uc deploy
+
+# List services
+uc ls
+
+# View service logs
+uc logs my-service
+
+# Execute command in a service container
+uc exec my-service -- sh
+
+# Scale a service
+uc scale my-service 3
+
+# Stop/start services
+uc stop my-service
+uc start my-service
+
+# Remove a service
+uc rm my-service
+```
+
+### Machine Management
+
+```bash
+# List machines in cluster
+uc machine ls
+
+# Add a machine
+uc machine add --name node-3 root@third-server-ip
+
+# Rename a machine
+uc machine rename old-name new-name
+
+# Remove a machine
+uc machine rm node-3
+
+# Update machine configuration
+uc machine update node-1 --ssh root@new-ip
+```
+
+### Image Management (Unregistry)
+
+```bash
+# Push a local Docker image directly to cluster machines (no registry needed)
+uc image push my-app:latest
+
+# List images on cluster machines
+uc image ls
+```
+
+### DNS Management
+
+```bash
+# Show cluster domain
+uc dns show
+
+# Reserve a cluster domain
+uc dns reserve
+
+# Release a cluster domain
+uc dns release
+```
+
+### Caddy Reverse Proxy
+
+```bash
+# Show current Caddy configuration
+uc caddy config
+
+# Deploy/upgrade Caddy across all machines
+uc caddy deploy
+```
+
+### Volume Management
+
+```bash
+# Create a volume on a specific machine
+uc volume create my-data --machine web-1
+
+# List volumes
+uc volume ls
+
+# Inspect a volume
+uc volume inspect my-data
+
+# Remove a volume
+uc volume rm my-data
+```
+
+### Context Management (Multi-Cluster)
+
+```bash
+# List cluster contexts
+uc ctx ls
+
+# Switch to a different cluster
+uc ctx use staging
+
+# Change default connection for current context
+uc ctx connection
+```
+
+## Compose File
+
+Uncloud uses standard Docker Compose format with deployment extensions:
+
+```yaml
+services:
+  web:
+    image: my-app:latest
+    ports:
+      - "app.example.com:8000/https"
+    deploy:
+      replicas: 2
+      update_config:
+        parallelism: 1
+        order: start-first
+    volumes:
+      - app-data:/data
+
+volumes:
+  app-data:
+```
+
+### Port Publishing Formats
+
+```yaml
+ports:
+  # HTTPS with custom domain
+  - "app.example.com:8000/https"
+  # HTTP only
+  - "app.example.com:8000/http"
+  # TCP port (host:container)
+  - "8080:8000/tcp"
+  # UDP port
+  - "53:53/udp"
+```
+
+## Helper Script
+
+The `uncloud-helper.sh` script wraps common `uc` CLI operations:
+
+```bash
+# Check cluster status
+./.agents/scripts/uncloud-helper.sh status
+
+# List machines
+./.agents/scripts/uncloud-helper.sh machines
+
+# List services
+./.agents/scripts/uncloud-helper.sh services
+
+# Deploy from compose.yaml
+./.agents/scripts/uncloud-helper.sh deploy
+
+# Run a service
+./.agents/scripts/uncloud-helper.sh run my-app:latest -p app.example.com:8000/https
+
+# View logs
+./.agents/scripts/uncloud-helper.sh logs my-service
+
+# Scale a service
+./.agents/scripts/uncloud-helper.sh scale my-service 3
+```
+
+## Troubleshooting
+
+### Common Issues
+
+**Machine init fails:**
+
+```bash
+# Verify SSH access
+ssh root@your-server-ip 'echo ok'
+
+# Check Docker is running
+ssh root@your-server-ip 'docker info'
+
+# Check uncloudd service
+ssh root@your-server-ip 'systemctl status uncloud'
+```
+
+**Services not accessible:**
+
+```bash
+# Check service status
+uc ls
+uc inspect my-service
+
+# Check Caddy config
+uc caddy config
+
+# Check WireGuard connectivity
+uc wg show
+
+# Verify DNS
+dig app.example.com
+```
+
+**Container networking issues:**
+
+```bash
+# Check WireGuard mesh
+uc wg show
+
+# Verify machine connectivity
+uc machine ls
+
+# Check container IPs
+uc ps
+```
+
+### Uninstalling
+
+```bash
+# Uninstall Uncloud from a machine (run on the machine)
+uncloud-uninstall
+```
+
+## Security
+
+- **WireGuard encryption**: All inter-machine traffic encrypted
+- **SSH-based management**: CLI communicates via SSH tunnels
+- **No exposed ports**: Only SSH (22), HTTP (80), HTTPS (443), WireGuard (51820) needed
+- **Container isolation**: Standard Docker container isolation
+- **Auto HTTPS**: Let's Encrypt certificates via Caddy
+
+## Architecture
+
+```text
+Local Machine                    Remote Machines
++------------------+             +------------------+
+| uc CLI           |---SSH--->   | uncloudd daemon  |
++------------------+             | corrosion (CRDT) |
+                                 | Docker           |
+                                 | WireGuard        |
+                                 | Caddy proxy      |
+                                 +------------------+
+                                        |
+                                   WireGuard mesh
+                                        |
+                                 +------------------+
+                                 | uncloudd daemon  |
+                                 | corrosion (CRDT) |
+                                 | Docker           |
+                                 | WireGuard        |
+                                 | Caddy proxy      |
+                                 +------------------+
+```
+
+- **uncloudd**: Machine daemon (Go binary) managing containers and cluster state
+- **corrosion**: CRDT-based distributed SQLite for peer-to-peer state sync (by Fly.io)
+- **WireGuard**: Encrypted mesh network with automatic peer discovery
+- **Caddy**: Reverse proxy running globally on all machines, auto-configures from cluster state

--- a/TODO.md
+++ b/TODO.md
@@ -289,7 +289,8 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 - [x] t014 Document RapidFuzz library for fuzzy string matching #tools #context ~5m (ai:4m read:1m) logged:2025-12-21 completed:2026-02-07
   - Notes: tools/context/rapidfuzz.md created (122 lines). Covers core functions, process module, distance functions, performance tips, and aidevops integration patterns.
 - [x] t015 Add MinerU subagent as alternative to Pandoc for PDF conversion #tools #conversion ~15m actual:15m (ai:10m read:5m) logged:2025-12-21 completed:2026-02-06
-- [ ] t016 Uncloud Integration for aidevops #plan → [todo/PLANS.md#uncloud-integration-for-aidevops] ~45m (ai:25m test:10m read:10m) ref:GH#508 logged:2025-12-21
+- [x] t016 Uncloud Integration for aidevops #plan → [todo/PLANS.md#uncloud-integration-for-aidevops] ~45m actual:45m (ai:25m test:10m read:10m) ref:GH#508 logged:2025-12-21 started:2026-02-08 completed:2026-02-08
+  - Notes: Created uncloud.md subagent (deployment provider guide with Quick Reference, CLI examples, Compose format, architecture diagram), uncloud-helper.sh (CLI wrapper with 20 commands, zero ShellCheck violations), uncloud-config.json.txt (cluster config template). Updated subagent-index.toon. Uncloud v0.16.0, 4.6k stars, Apache-2.0, active development.
 - [ ] t017 SEO Machine Integration for aidevops #plan → [todo/PLANS.md#seo-machine-integration-for-aidevops] ~1.5h (ai:45m test:30m read:15m) ref:GH#509 logged:2025-12-21
 - [x] t020 Git Issues Bi-directional Sync (GitHub, GitLab, Gitea) #plan #git #sync → [todo/PLANS.md#2026-02-08-git-issues-bi-directional-sync] ~3h (ai:1.5h test:1h read:30m) logged:2025-12-21 ref:GH#510 started:2026-02-08 completed:2026-02-08
   - [x] t020.1 Build issue-sync-helper.sh core: TODO.md parser + rich issue body composer ~45m blocked-by:none completed:2026-02-08

--- a/configs/uncloud-config.json.txt
+++ b/configs/uncloud-config.json.txt
@@ -1,0 +1,83 @@
+{
+  "clusters": {
+    "production": {
+      "name": "Production Cluster",
+      "context": "default",
+      "description": "Primary production cluster",
+      "machines": [
+        {
+          "name": "web-1",
+          "ssh": "root@web1.example.com",
+          "role": "general",
+          "provider": "hetzner",
+          "region": "eu-central"
+        },
+        {
+          "name": "web-2",
+          "ssh": "root@web2.example.com",
+          "role": "general",
+          "provider": "hetzner",
+          "region": "eu-central"
+        }
+      ],
+      "services": [
+        {
+          "name": "my-app",
+          "image": "my-app:latest",
+          "domain": "app.example.com",
+          "port": 8000,
+          "protocol": "https",
+          "replicas": 2,
+          "compose_file": "compose.yaml"
+        }
+      ]
+    },
+    "staging": {
+      "name": "Staging Cluster",
+      "context": "staging",
+      "description": "Staging environment for testing",
+      "machines": [
+        {
+          "name": "staging-1",
+          "ssh": "root@staging.example.com",
+          "role": "general",
+          "provider": "hetzner",
+          "region": "eu-central"
+        }
+      ],
+      "services": [
+        {
+          "name": "my-app-staging",
+          "image": "my-app:staging",
+          "domain": "staging.example.com",
+          "port": 8000,
+          "protocol": "https",
+          "replicas": 1,
+          "compose_file": "compose.yaml"
+        }
+      ]
+    }
+  },
+  "defaults": {
+    "ssh_key": "~/.ssh/id_ed25519",
+    "ssh_user": "root",
+    "compose_file": "compose.yaml"
+  },
+  "dns": {
+    "provider": "uncloud",
+    "custom_domains": [
+      {
+        "domain": "app.example.com",
+        "service": "my-app",
+        "cluster": "production"
+      }
+    ]
+  },
+  "notes": {
+    "uncloud_version": "v0.16.0",
+    "documentation": "https://uncloud.run/docs",
+    "source": "https://github.com/psviderski/uncloud",
+    "cli_install": "brew install psviderski/tap/uncloud",
+    "status": "Active development, not yet production-ready"
+  }
+}

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -1035,12 +1035,13 @@ p005,Image SEO Enhancement with AI Vision,complete,4,4,,seo|images|ai|accessibil
 
 ### [2025-12-21] Uncloud Integration for aidevops
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~1d (ai:4h test:4h read:2h)
+**Actual:** ~45m (ai:25m test:10m read:10m)
 **Source:** [psviderski/uncloud](https://github.com/psviderski/uncloud)
 
-<!--TOON:plan{id,title,status,phase,total_phases,owner,tags,est,est_ai,est_test,est_read,logged,started}:
-p006,Uncloud Integration for aidevops,planning,0,4,,deployment|docker|orchestration,1d,4h,4h,2h,2025-12-21T04:00Z,
+<!--TOON:plan{id,title,status,phase,total_phases,owner,tags,est,est_ai,est_test,est_read,logged,started,completed}:
+p006,Uncloud Integration for aidevops,completed,4,4,,deployment|docker|orchestration,1d,4h,4h,2h,2025-12-21T04:00Z,2026-02-08T00:00Z,2026-02-08T00:00Z
 -->
 
 #### Purpose
@@ -1081,16 +1082,16 @@ Add Uncloud as a deployment provider option in aidevops. Uncloud is a lightweigh
 
 #### Progress
 
-- [ ] (2025-12-21) Phase 1: Create uncloud.md subagent with Quick Reference ~2h
-- [ ] (2025-12-21) Phase 2: Create uncloud-helper.sh script ~2h
-- [ ] (2025-12-21) Phase 3: Create uncloud-config.json.txt template ~1h
-- [ ] (2025-12-21) Phase 4: Update deployment docs and test workflows ~3h
+- [x] (2026-02-08) Phase 1: Create uncloud.md subagent with Quick Reference ~2h actual:10m
+- [x] (2026-02-08) Phase 2: Create uncloud-helper.sh script ~2h actual:10m
+- [x] (2026-02-08) Phase 3: Create uncloud-config.json.txt template ~1h actual:5m
+- [x] (2026-02-08) Phase 4: Update deployment docs and test workflows ~3h actual:10m
 
 <!--TOON:milestones[4]{id,plan_id,desc,est,actual,scheduled,completed,status}:
-m021,p006,Phase 1: Create uncloud.md subagent with Quick Reference,2h,,2025-12-21T04:00Z,,pending
-m022,p006,Phase 2: Create uncloud-helper.sh script,2h,,2025-12-21T04:00Z,,pending
-m023,p006,Phase 3: Create uncloud-config.json.txt template,1h,,2025-12-21T04:00Z,,pending
-m024,p006,Phase 4: Update deployment docs and test workflows,3h,,2025-12-21T04:00Z,,pending
+m021,p006,Phase 1: Create uncloud.md subagent with Quick Reference,2h,10m,2025-12-21T04:00Z,2026-02-08T00:00Z,completed
+m022,p006,Phase 2: Create uncloud-helper.sh script,2h,10m,2025-12-21T04:00Z,2026-02-08T00:00Z,completed
+m023,p006,Phase 3: Create uncloud-config.json.txt template,1h,5m,2025-12-21T04:00Z,2026-02-08T00:00Z,completed
+m024,p006,Phase 4: Update deployment docs and test workflows,3h,10m,2025-12-21T04:00Z,2026-02-08T00:00Z,completed
 -->
 
 #### Decision Log
@@ -1110,7 +1111,19 @@ d007,p006,Focus on CLI integration not MCP server initially,Uncloud is pre-produ
 
 #### Surprises & Discoveries
 
-(To be populated during implementation)
+- Uncloud has grown significantly since initial planning (4.6k stars, v0.16.0, 900 commits, 14 contributors). Still marked "not ready for production use" but actively developed.
+- CLI is `uc` (not `uncloud`). Install via Homebrew tap or curl script.
+- Unregistry feature allows pushing images directly to machines without an external Docker registry.
+- Decided to skip separate `uncloud-setup.md` file -- the main `uncloud.md` subagent covers installation and setup inline, matching the pattern of `vercel.md` (single file) rather than `coolify.md` + `coolify-setup.md` (split). Uncloud's setup is simpler (single `uc machine init` command vs Coolify's multi-step server provisioning).
+
+#### Outcomes & Retrospective
+
+- Created 3 files: `uncloud.md` (subagent), `uncloud-helper.sh` (CLI wrapper), `uncloud-config.json.txt` (config template)
+- Updated `subagent-index.toon` with uncloud entries
+- Zero ShellCheck violations, valid JSON config, help command tested
+- Actual time ~45m vs estimated ~1d -- plan was over-scoped for what turned out to be a straightforward integration following established patterns
+
+---
 
 #### Purpose
 
@@ -1580,7 +1593,7 @@ p002,Claude Code Destructive Command Hooks,planning,0,4,,claude|git|security,4h,
 p003,Evaluate Merging build-agent and build-mcp into aidevops,planning,0,3,,architecture|agents,4h,2h,1h,1h,2025-12-21T14:00Z,
 p004,OCR Invoice/Receipt Extraction Pipeline,planning,0,5,,accounting|ocr|automation,3d,1.5d,1d,0.5d,2025-12-21T22:00Z,
 p005,Image SEO Enhancement with AI Vision,planning,0,4,,seo|images|ai|accessibility,6h,3h,2h,1h,2025-12-21T23:30Z,
-p006,Uncloud Integration for aidevops,planning,0,4,,deployment|docker|orchestration,1d,4h,4h,2h,2025-12-21T04:00Z,
+p006,Uncloud Integration for aidevops,completed,4,4,,deployment|docker|orchestration,1d,4h,4h,2h,2025-12-21T04:00Z,2026-02-08T00:00Z
 p007,SEO Machine Integration for aidevops,planning,0,5,,seo|content|agents,2d,1d,0.5d,0.5d,2025-12-21T15:00Z,
 p008,Enhance Plan+ and Build+ with OpenCode's Latest Features,planning,0,4,,opencode|agents|enhancement,3h,1.5h,1h,30m,2025-12-21T04:30Z,
 p010,Agent Design Pattern Improvements,planning,0,5,,architecture|agents|context|optimization,1d,6h,4h,2h,2025-01-11T00:00Z,


### PR DESCRIPTION
## Summary

- Add Uncloud integration for multi-machine container orchestration without Kubernetes
- Create helper script `uncloud-helper.sh` with deploy, status, logs, scale, and config commands
- Add comprehensive subagent documentation at `tools/deployment/uncloud.md`
- Add config template at `configs/uncloud-config.json.txt`

## Files Changed

| File | Purpose |
|------|---------|
| `.agents/scripts/uncloud-helper.sh` | CLI helper for Uncloud operations |
| `.agents/tools/deployment/uncloud.md` | Uncloud integration subagent |
| `configs/uncloud-config.json.txt` | Config template for Uncloud |
| `.agents/subagent-index.toon` | Updated index with Uncloud entries |
| `todo/PLANS.md` | Updated plan status |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Uncloud integration for self-hosted infrastructure and cluster management
  * Added CLI wrapper with 20+ commands for deployments, services, machines, logs, and orchestration

* **Documentation**
  * Added comprehensive Uncloud provider guide with configuration, usage examples, and troubleshooting

* **Chores**
  * Updated tooling catalog and configuration indices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->