### PR TITLE
feat: add Maestro for mobile and web E2E testing (t096)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -262,6 +262,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | Git/PRs | `workflows/git-workflow.md`, `tools/git/github-cli.md`, `tools/git/conflict-resolution.md` |
 | Releases | `workflows/release.md`, `workflows/version-bump.md` |
 | Browser | `tools/browser/browser-automation.md` (decision tree, then tool-specific subagent) |
+| Mobile/E2E | `tools/mobile/maestro.md`, `tools/mobile/ios-simulator-mcp.md`, `tools/mobile/minisim.md` |
 | WordPress | `tools/wordpress/wp-dev.md`, `tools/wordpress/mainwp.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |
 | Video | `tools/video/video-prompt-design.md`, `tools/video/remotion.md`, `tools/video/higgsfield.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -34,7 +34,7 @@ tools/build-mcp/,MCP development - creating MCP servers,build-mcp|server-pattern
 tools/ai-assistants/,AI tool integration - OpenCode and headless dispatch,agno|capsolver|claude-code|overview|openclaw|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
 tools/browser/,Browser automation - scraping and testing,agent-browser|stagehand|playwright|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy
-tools/mobile/,Mobile development - iOS/Android emulators,minisim
+tools/mobile/,Mobile development - iOS/Android testing and emulators,maestro|minisim|ios-simulator-mcp|xcodebuild-mcp|axe-cli
 tools/pdf/,PDF processing - form filling and digital signatures,overview|libpdf
 tools/performance/,Web performance - Core Web Vitals and network analysis,performance|webpagetest
 tools/ui/,UI components - design systems and debugging,shadcn|ui-skills|frontend-debugging

--- a/.agents/tools/browser/browser-automation.md
+++ b/.agents/tools/browser/browser-automation.md
@@ -96,6 +96,9 @@ What do you need?
     |
     +-> TEST your own app (dev server)?
             |
+            +-> Mobile E2E (Android/iOS/React Native/Flutter)?
+            |       --> Maestro (YAML flows, no compilation, built-in flakiness tolerance)
+            |       --> See tools/mobile/maestro.md
             +-> Need to stay logged in across restarts? --> dev-browser (profile)
             +-> Need parallel test contexts? --> Playwright (isolated contexts)
             +-> Need visual debugging? --> dev-browser (headed) + DevTools MCP


### PR DESCRIPTION
## Summary

- Integrates Maestro (10.6k stars, Apache-2.0) YAML-based E2E testing framework for Android, iOS, React Native, Flutter, and web apps into the aidevops agent ecosystem
- Expands `tools/mobile/` subagent index to surface all 5 mobile tools (maestro, minisim, ios-simulator-mcp, xcodebuild-mcp, axe-cli)
- Adds Mobile E2E branch to browser-automation.md decision tree and Mobile/E2E row to AGENTS.md progressive disclosure table

## Changes

| File | Change |
|------|--------|
| `.agents/subagent-index.toon` | Expand `tools/mobile/` key_files from `minisim` to `maestro\|minisim\|ios-simulator-mcp\|xcodebuild-mcp\|axe-cli` |
| `.agents/tools/browser/browser-automation.md` | Add Mobile E2E decision branch pointing to Maestro |
| `.agents/AGENTS.md` | Add `Mobile/E2E` row to progressive disclosure table |

## Notes

- `maestro.md` subagent already existed with full content (133 lines covering install, YAML syntax, selectors, cross-platform support, Studio/Cloud, and integration patterns)
- This PR focuses on framework integration: making Maestro discoverable via the subagent index, decision tree, and progressive disclosure
- Zero markdown lint violations across all changed files

Closes #517