### PR TITLE
feat: add iOS Simulator MCP integration for AI-driven simulator interaction (t097)

### DIFF
--- a/.agents/aidevops/mcp-integrations.md
+++ b/.agents/aidevops/mcp-integrations.md
@@ -33,6 +33,9 @@ tools:
 **Document Processing**:
 - Unstract MCP: `UNSTRACT_API_KEY` + `API_BASE_URL` required (Docker-based, self-hosted default)
 
+**Mobile Testing**:
+- iOS Simulator MCP: AI-driven iOS simulator interaction (tap, swipe, screenshot)
+
 **Development**:
 - Claude Code MCP: Claude Code automation (forked server)
 - Next.js DevTools MCP
@@ -57,6 +60,10 @@ This document provides comprehensive setup and usage instructions for advanced M
 - **Ahrefs MCP**: SEO analysis, backlink research, keyword data
 - **Perplexity MCP**: AI-powered web search and research
 - **Google Search Console MCP**: Search performance data and insights
+
+### **📱 Mobile Testing**
+
+- **iOS Simulator MCP**: AI-driven iOS simulator interaction (tap, swipe, type, screenshot, accessibility)
 
 ### **⚡ Development Tools**
 
@@ -101,6 +108,24 @@ playwright-mcp --install-browsers
 # Add to MCP client
 claude mcp add playwright npx playwright-mcp@latest
 ```
+
+### **iOS Simulator MCP**
+
+```bash
+# Prerequisites: macOS, Xcode with iOS simulators, Facebook IDB
+brew tap facebook/fb && brew install idb-companion
+
+# Add to Claude Code
+claude mcp add ios-simulator npx ios-simulator-mcp
+```
+
+**Tools**: `ui_tap`, `ui_swipe`, `ui_type`, `ui_view`, `screenshot`, `record_video`, `ui_describe_all`, `install_app`, `launch_app`, `get_booted_sim_id`.
+
+**Env vars**: `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR` (output dir), `IOS_SIMULATOR_MCP_FILTERED_TOOLS` (disable tools), `IOS_SIMULATOR_MCP_IDB_PATH` (custom IDB path).
+
+**Per-Agent Enablement**: The `tools/mobile/ios-simulator-mcp.md` subagent has `ios-simulator_*: true` in its tools section. Disabled globally, enabled on-demand.
+
+See `tools/mobile/ios-simulator-mcp.md` for detailed documentation.
 
 ### **Claude Code MCP (Fork)**
 

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -472,7 +472,7 @@ LAZY_MCPS = {'claude-code-mcp', 'outscraper', 'dataforseo', 'shadcn', 'macos-aut
              'gsc', 'localwp', 'chrome-devtools', 'quickfile', 'amazon-order-history', 
              'google-analytics-mcp', 'MCP_DOCKER', 'ahrefs',
              'playwriter', 'augment-context-engine', 'context7',
-             'sentry', 'socket',
+             'sentry', 'socket', 'ios-simulator',
              # Oh-My-OpenCode MCPs - disable globally, use @github-search/@context7 subagents
              'grep_app', 'websearch', 'gh_grep'}
 # Note: gh_grep removed from aidevops but may exist from old configs or OmO
@@ -621,6 +621,22 @@ if platform.system() == 'Darwin':
         config['tools']['macos-automator_*'] = False
         print("  Set macos-automator_* disabled globally")
 
+# iOS Simulator MCP - simulator interaction (macOS only, subagent only)
+# Docs: https://github.com/joshuayoes/ios-simulator-mcp
+# Note: enabled state is set by MCP loading policy above
+if platform.system() == 'Darwin':
+    if 'ios-simulator' not in config['mcp']:
+        config['mcp']['ios-simulator'] = {
+            "type": "local",
+            "command": ["npx", "-y", "ios-simulator-mcp"],
+            "enabled": False
+        }
+        print("  Added ios-simulator MCP (lazy load - @ios-simulator-mcp subagent only)")
+
+    if 'ios-simulator_*' not in config['tools']:
+        config['tools']['ios-simulator_*'] = False
+        print("  Set ios-simulator_* disabled globally")
+
 # Disable Oh-My-OpenCode MCP tools globally
 # OmO installs: grep_app (GitHub search), context7 (docs), websearch (Exa)
 # MCPs are disabled via LAZY_MCPS above, but we also need to disable tools
@@ -689,6 +705,12 @@ while IFS= read -r f; do
             # Only enable macos-automator tools on macOS
             if [[ "$(uname -s)" == "Darwin" ]]; then
                 extra_tools=$'  macos-automator_*: true\n  webfetch: true'
+            fi
+            ;;
+        ios-simulator-mcp)
+            # Only enable ios-simulator tools on macOS
+            if [[ "$(uname -s)" == "Darwin" ]]; then
+                extra_tools=$'  ios-simulator_*: true'
             fi
             ;;
         *)

--- a/.agents/tools/mobile/ios-simulator-mcp.md
+++ b/.agents/tools/mobile/ios-simulator-mcp.md
@@ -26,6 +26,10 @@ tools:
 
 **Requirements**: macOS, Xcode with iOS simulators, Node.js, Facebook [IDB](https://fbidb.io/) (`brew tap facebook/fb && brew install idb-companion`)
 
+**Verification prompt**: "Get the booted simulator ID and describe all accessibility elements on screen"
+
+**Enabled for agents**: Disabled globally, enabled via `@ios-simulator-mcp` subagent (`ios-simulator_*: true`)
+
 <!-- AI-CONTEXT-END -->
 
 ## MCP Tools
@@ -48,13 +52,29 @@ tools:
 
 ## Configuration
 
+### Claude Code
+
 ```bash
-# Claude Code
 claude mcp add ios-simulator npx ios-simulator-mcp
 ```
 
+### OpenCode
+
+Managed by `generate-opencode-agents.sh` (macOS only, lazy-loaded):
+
 ```json
-// OpenCode / Cursor (~/.config/opencode/mcp.json or ~/.cursor/mcp.json)
+{
+  "ios-simulator": {
+    "type": "local",
+    "command": ["npx", "-y", "ios-simulator-mcp"],
+    "enabled": false
+  }
+}
+```
+
+### Cursor / Windsurf / Claude Desktop
+
+```json
 {
   "mcpServers": {
     "ios-simulator": {
@@ -65,7 +85,13 @@ claude mcp add ios-simulator npx ios-simulator-mcp
 }
 ```
 
-**Environment variables**: `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR` (screenshot/video output, default `~/Downloads`), `IOS_SIMULATOR_MCP_FILTERED_TOOLS` (comma-separated tools to disable), `IOS_SIMULATOR_MCP_IDB_PATH` (custom IDB path).
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR` | Screenshot/video output directory | `~/Downloads` |
+| `IOS_SIMULATOR_MCP_FILTERED_TOOLS` | Comma-separated tool names to disable | None |
+| `IOS_SIMULATOR_MCP_IDB_PATH` | Custom path to IDB executable | `idb` (from PATH) |
 
 ## AI-Assisted QA Patterns
 
@@ -108,3 +134,6 @@ Both enable simulator interaction but take different approaches:
 ## Related Tools
 
 - `tools/mobile/minisim.md` - Simulator launcher and lifecycle management
+- `tools/mobile/xcodebuild-mcp.md` - Build iOS/macOS apps (build then install via this MCP)
+- `tools/mobile/maestro.md` - Scripted E2E mobile testing flows
+- `tools/mobile/axe-cli.md` - iOS simulator accessibility automation

--- a/configs/ios-simulator-mcp-config.json.txt
+++ b/configs/ios-simulator-mcp-config.json.txt
@@ -1,0 +1,101 @@
+{
+  "provider": "joshuayoes",
+  "description": "iOS Simulator MCP - AI-driven iOS simulator interaction (tap, swipe, type, screenshot)",
+  "documentation": "https://github.com/joshuayoes/ios-simulator-mcp",
+  "prerequisites": {
+    "platform": "macOS only",
+    "xcode": "Xcode with iOS simulators installed",
+    "node_version": "18+",
+    "idb_install": "brew tap facebook/fb && brew install idb-companion",
+    "verify_command": "npx -y ios-simulator-mcp --help"
+  },
+  "mcp_tools": [
+    "ui_tap",
+    "ui_swipe",
+    "ui_type",
+    "ui_view",
+    "screenshot",
+    "record_video",
+    "stop_recording",
+    "ui_describe_all",
+    "ui_describe_point",
+    "install_app",
+    "launch_app",
+    "get_booted_sim_id",
+    "open_simulator"
+  ],
+  "verification_prompt": "Get the booted simulator ID and describe all accessibility elements on screen",
+  "configurations": {
+    "opencode": {
+      "config_location": "~/.config/opencode/opencode.json",
+      "mcp_config": {
+        "ios-simulator": {
+          "type": "local",
+          "command": ["npx", "-y", "ios-simulator-mcp"],
+          "enabled": false
+        }
+      },
+      "tools_config": {
+        "ios-simulator_*": false
+      },
+      "agent_tools": {
+        "ios-simulator_*": true
+      },
+      "notes": "Disabled globally, enabled via @ios-simulator-mcp subagent"
+    },
+    "claude_code": {
+      "method": "cli",
+      "command": "claude mcp add ios-simulator npx ios-simulator-mcp"
+    },
+    "cursor": {
+      "config_location": "~/.cursor/mcp.json",
+      "mcp_config": {
+        "mcpServers": {
+          "ios-simulator": {
+            "command": "npx",
+            "args": ["-y", "ios-simulator-mcp"]
+          }
+        }
+      }
+    },
+    "claude_desktop": {
+      "config_location": "~/Library/Application Support/Claude/claude_desktop_config.json",
+      "mcp_config": {
+        "mcpServers": {
+          "ios-simulator": {
+            "command": "npx",
+            "args": ["-y", "ios-simulator-mcp"]
+          }
+        }
+      }
+    },
+    "windsurf": {
+      "config_location": "~/.codeium/windsurf/mcp_config.json",
+      "mcp_config": {
+        "mcpServers": {
+          "ios-simulator": {
+            "command": "npx",
+            "args": ["-y", "ios-simulator-mcp"]
+          }
+        }
+      }
+    },
+    "gemini_cli": {
+      "config_location": "~/.gemini/settings.json",
+      "mcp_config": {
+        "mcpServers": {
+          "ios-simulator": {
+            "command": "npx",
+            "args": ["-y", "ios-simulator-mcp"]
+          }
+        }
+      }
+    }
+  },
+  "environment_variables": {
+    "IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR": "Directory for screenshots/videos (default: ~/Downloads)",
+    "IOS_SIMULATOR_MCP_FILTERED_TOOLS": "Comma-separated tool names to disable",
+    "IOS_SIMULATOR_MCP_IDB_PATH": "Custom path to IDB executable"
+  },
+  "security_notes": "Use v1.3.3+ (command injection fix in earlier versions)"
+}

--- a/configs/mcp-templates/ios-simulator-mcp.json
+++ b/configs/mcp-templates/ios-simulator-mcp.json
@@ -1,0 +1,39 @@
+{
+  "opencode": {
+    "ios-simulator": {
+      "type": "local",
+      "command": ["npx", "-y", "ios-simulator-mcp"],
+      "enabled": false
+    }
+  },
+  "claude_code": "claude mcp add ios-simulator npx ios-simulator-mcp",
+  "cursor": {
+    "mcpServers": {
+      "ios-simulator": {
+        "command": "npx",
+        "args": ["-y", "ios-simulator-mcp"]
+      }
+    }
+  },
+  "claude_desktop": {
+    "mcpServers": {
+      "ios-simulator": {
+        "command": "npx",
+        "args": ["-y", "ios-simulator-mcp"]
+      }
+    }
+  },
+  "with_env_vars": {
+    "mcpServers": {
+      "ios-simulator": {
+        "command": "npx",
+        "args": ["-y", "ios-simulator-mcp"],
+        "env": {
+          "IOS_SIMULATOR_MCP_DEFAULT_OUTPUT_DIR": "~/Code/project/tmp",
+          "IOS_SIMULATOR_MCP_FILTERED_TOOLS": "screenshot,record_video,stop_recording",
+          "IOS_SIMULATOR_MCP_IDB_PATH": "~/bin/idb"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Integrates [ios-simulator-mcp](https://github.com/joshuayoes/ios-simulator-mcp) (1.6k stars, MIT) as a lazy-loaded MCP for AI-driven iOS simulator interaction
- Adds config templates, OpenCode agent generation support (macOS-only, subagent-gated), and documentation updates
- Enables AI assistants to tap, swipe, type, screenshot, record video, describe accessibility elements, install/launch apps on iOS simulators

## Changes

- **`.agents/tools/mobile/ios-simulator-mcp.md`**: Enhanced documentation with OpenCode config, environment variables table, verification prompt, agent enablement info, and related tools
- **`.agents/scripts/generate-opencode-agents.sh`**: Added `ios-simulator` to LAZY_MCPS, MCP config block (macOS-only), and subagent case for `ios-simulator-mcp` tool enablement
- **`.agents/subagent-index.toon`**: Updated mobile tools entry with ios-simulator-mcp and other mobile tool key_files
- **`.agents/aidevops/mcp-integrations.md`**: Added Mobile Testing section with iOS Simulator MCP setup instructions
- **`configs/mcp-templates/ios-simulator-mcp.json`**: MCP config snippets for OpenCode, Claude Code, Cursor, Claude Desktop
- **`configs/ios-simulator-mcp-config.json.txt`**: Comprehensive config template with all AI assistant configurations

## Testing

- ShellCheck: zero new violations on generate-opencode-agents.sh
- Markdown lint: zero violations on all modified .md files
- JSON validation: both config files pass
- Secretlint: no credential leaks detected

Closes #518