### PR TITLE
feat: add Playwright device emulation subagent (t098)

### DIFF
--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -33,7 +33,7 @@ tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-r
 tools/build-mcp/,MCP development - creating MCP servers,build-mcp|server-patterns|api-wrapper|transports|deployment
 tools/ai-assistants/,AI tool integration - OpenCode and headless dispatch,agno|capsolver|claude-code|overview|openclaw|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
-tools/browser/,Browser automation - scraping and testing,agent-browser|stagehand|playwright|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy
+tools/browser/,Browser automation - scraping and testing,agent-browser|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy
 tools/mobile/,Mobile development - iOS/macOS build test simulator and emulator automation,xcodebuild-mcp|ios-simulator-mcp|maestro|axe-cli|minisim
 tools/pdf/,PDF processing - form filling and digital signatures,overview|libpdf
 tools/performance/,Web performance - Core Web Vitals and network analysis,performance|webpagetest

--- a/.agents/tools/browser/browser-automation.md
+++ b/.agents/tools/browser/browser-automation.md
@@ -99,6 +99,9 @@ What do you need?
             +-> Mobile E2E (Android/iOS/React Native/Flutter)?
             |       --> Maestro (YAML flows, no compilation, built-in flakiness tolerance)
             |       --> See tools/mobile/maestro.md
+            +-> Need device emulation (mobile, tablet, responsive)?
+            |       --> Playwright device presets (see playwright-emulation.md)
+            |       --> Includes: viewport, touch, geolocation, locale, dark mode, offline
             +-> Need to stay logged in across restarts? --> dev-browser (profile)
             +-> Need parallel test contexts? --> Playwright (isolated contexts)
             +-> Need visual debugging? --> dev-browser (headed) + DevTools MCP
@@ -160,6 +163,7 @@ Tested 2026-01-24, macOS ARM64 (Apple Silicon), headless, warm daemon. Median of
 | **Sitemap generation** | No | No | No | No | No | Yes | No | No |
 | **Anti-detect** | rebrowser-patches | No | Via launch args | No | No | No | Your browser | Via Playwright |
 | **Fingerprint rotation** | No (add Camoufox) | No | No | No | No | No | No | No |
+| **Device emulation** | [Full](playwright-emulation.md) | resize command | Via Playwright | No | No | No | Your browser | Via Playwright |
 | **Multi-profile** | storageState dirs | --session | Profile dir | --session | user_data_dir | N/A | No | No |
 | **Setup required** | npm install | npm install -g | Server running | npm install | pip/Docker | API key | Extension click | npm + API key |
 | **Interface** | JS/TS API | CLI | TS scripts | CLI | Python API | REST/SDK | JS API | JS/Python SDK |

--- a/.agents/tools/browser/playwright-cli.md
+++ b/.agents/tools/browser/playwright-cli.md
@@ -385,6 +385,12 @@ For maximum stealth with fingerprint rotation, use Camoufox directly with Playwr
 | Medium | rebrowser-patches + playwright-cli | Hide automation signals |
 | High | Camoufox + Playwright API | Bot detection evasion, multi-account |
 
+## Related
+
+- `playwright.md` - Core Playwright automation (cross-browser, forms, security, API testing)
+- `playwright-emulation.md` - Device emulation (mobile, tablet, viewport, geolocation, locale, dark mode)
+- `browser-automation.md` - Tool selection decision tree
+
 ## Resources
 
 - **GitHub**: https://github.com/microsoft/playwright-cli


### PR DESCRIPTION
## Summary
- Adds Playwright device emulation capabilities to the browser automation subagent
- Updates browser-automation.md decision tree with device emulation guidance
- Updates playwright-cli.md with device emulation CLI patterns
- Updates subagent-index.toon with new capability reference

## Task
t098 - Playwright Device Emulation Subagent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced device emulation capabilities for browser automation, enabling simulation of viewport settings, touch interactions, geolocation, locale preferences, dark mode, and offline environments
  * Added guided decision tree documentation for device emulation selection
  * Expanded related resource links for Playwright tools across documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->