### PR TITLE
feat: integrate LinkedIn and Reddit subagents into framework cross-references (t077)

### DIFF
--- a/.agents/social-media.md
+++ b/.agents/social-media.md
@@ -5,6 +5,8 @@ mode: subagent
 subagents:
   # Social tools
   - bird
+  - linkedin
+  - reddit
   # Content
   - guidelines
   - summarize
@@ -75,6 +77,9 @@ subagents:
 
 ### Integration Points
 
+- `tools/social-media/bird.md` - X/Twitter CLI (read, post, reply, search)
+- `tools/social-media/linkedin.md` - LinkedIn API (posts, articles, carousels, analytics)
+- `tools/social-media/reddit.md` - Reddit API via PRAW (read, post, reply)
 - `content.md` - Content creation workflows
 - `marketing.md` - Campaign coordination
 - `seo.md` - Keyword and hashtag research

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -28,7 +28,7 @@ memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper
 content/,Content creation - copywriting and editorial,guidelines|humanise|seo-writer|meta-creator|editor|internal-linker|context-templates
 tools/content/,Content tools - summarization and extraction,summarize
-tools/social-media/,Social media tools - X/Twitter CLI,bird
+tools/social-media/,Social media tools - X/Twitter LinkedIn and Reddit,bird|linkedin|reddit
 tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-review|agent-testing
 tools/build-mcp/,MCP development - creating MCP servers,build-mcp|server-patterns|api-wrapper|transports|deployment
 tools/ai-assistants/,AI tool integration - OpenCode and headless dispatch,agno|capsolver|claude-code|overview|openclaw|opencode-server|headless-dispatch


### PR DESCRIPTION
## Summary

- Wire existing `linkedin.md` and `reddit.md` subagents into framework cross-references
- Update `subagent-index.toon` to list all three social media tools (bird, linkedin, reddit)
- Update `social-media.md` subagent list and integration points with descriptions

## Context

The LinkedIn content subagent (`tools/social-media/linkedin.md`, 128 lines) and Reddit subagent (`tools/social-media/reddit.md`, 92 lines) already existed but were not referenced in the subagent index or the social-media main agent. Only `bird` (X/Twitter) was listed.

This is a cross-reference integration fix, not new content creation.

## Changes

| File | Change |
|------|--------|
| `.agents/subagent-index.toon` | Add `linkedin\|reddit` to social-media key_files |
| `.agents/social-media.md` | Add `linkedin` and `reddit` to subagents YAML + integration points |

## Testing

- Verified TOON format has single social-media entry (no duplicates)
- Verified all three `.md` files exist at expected paths
- README gate: SKIP (internal cross-reference fix, no user-facing behavior change)