### PR TITLE
feat: integrate Content Calendar Workflow subagent into framework (t075)

### DIFF
--- a/.agents/content.md
+++ b/.agents/content.md
@@ -12,6 +12,7 @@ subagents:
   - editor
   - internal-linker
   - context-templates
+  - content-calendar
   # SEO integration
   - keyword-research
   - eeat-score
@@ -47,6 +48,7 @@ subagents:
 | `editor.md` | Transform AI content into human-sounding articles |
 | `internal-linker.md` | Strategic internal linking recommendations |
 | `context-templates.md` | Per-project SEO context templates (brand voice, style, keywords) |
+| `content-calendar.md` | Content calendar planning with gap analysis and lifecycle tracking |
 
 **SEO Analysis** (via `seo/`):
 
@@ -75,12 +77,13 @@ python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py intent "search query"
 ```
 
 **Workflow**:
-1. Research (keywords, competitors, audience)
-2. Write (`content/seo-writer.md` with keyword targets)
-3. Analyze (`seo-content-analyzer.py analyze`)
-4. Optimize (address issues from analysis)
-5. Edit (`content/editor.md` for human voice)
-6. Publish (via WordPress or CMS)
+1. Plan (`tools/content/content-calendar.md` for gap analysis and scheduling)
+2. Research (keywords, competitors, audience)
+3. Write (`content/seo-writer.md` with keyword targets)
+4. Analyze (`seo-content-analyzer.py analyze`)
+5. Optimize (address issues from analysis)
+6. Edit (`content/editor.md` for human voice)
+7. Publish (via WordPress or CMS)
 
 <!-- AI-CONTEXT-END -->
 

--- a/.agents/seo.md
+++ b/.agents/seo.md
@@ -294,6 +294,7 @@ See `seo/image-seo.md` for the full workflow, `seo/moondream.md` for the vision 
 ### Content Optimization
 
 Integrate with `content.md` for:
+- Content calendar planning and gap analysis (`tools/content/content-calendar.md`)
 - SEO-optimized content writing (`content/seo-writer.md`)
 - Meta title/description generation (`content/meta-creator.md`)
 - Internal linking strategy (`content/internal-linker.md`)
@@ -301,12 +302,13 @@ Integrate with `content.md` for:
 
 **Content analysis workflow** (from SEO Machine integration):
 
-1. **Research**: `/keyword-research` + `/autocomplete-research`
-2. **Write**: Use `content/seo-writer.md` with keyword targets
-3. **Analyze**: `seo-content-analyzer.py analyze` for quality score
-4. **Optimize**: Address issues from `seo/seo-optimizer.md`
-5. **Edit**: `content/editor.md` for human voice
-6. **Publish**: Via WordPress or CMS
+1. **Plan**: Use `tools/content/content-calendar.md` for gap analysis and scheduling
+2. **Research**: `/keyword-research` + `/autocomplete-research`
+3. **Write**: Use `content/seo-writer.md` with keyword targets
+4. **Analyze**: `seo-content-analyzer.py analyze` for quality score
+5. **Optimize**: Address issues from `seo/seo-optimizer.md`
+6. **Edit**: `content/editor.md` for human voice
+7. **Publish**: Via WordPress or CMS
 
 **Context templates** for per-project SEO configuration:
 

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -27,7 +27,7 @@ aidevops/,Framework internals - extending aidevops and architecture,setup|archit
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper
 content/,Content creation - copywriting and editorial,guidelines|humanise|seo-writer|meta-creator|editor|internal-linker|context-templates
-tools/content/,Content tools - summarization and extraction,summarize
+tools/content/,Content tools - calendar planning summarization and extraction,content-calendar|summarize
 tools/social-media/,Social media tools - X/Twitter LinkedIn and Reddit,bird|linkedin|reddit
 tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-review|agent-testing
 tools/build-mcp/,MCP development - creating MCP servers,build-mcp|server-patterns|api-wrapper|transports|deployment


### PR DESCRIPTION
## Summary

- Wire existing `tools/content/content-calendar.md` subagent into framework cross-references
- Add content-calendar to `content.md` subagents list, table, and workflow (new "Plan" step 1)
- Add content-calendar to `seo.md` Content Optimization section and analysis workflow
- Update `subagent-index.toon` to include content-calendar in `tools/content/` entry

## Context

The content-calendar.md subagent already existed (132 lines) with comprehensive coverage of gap analysis, topic clustering, calendar structure, lifecycle tracking, platform scheduling, and content pillars. It was created as part of the ALwrity review (t037) but was not wired into the framework's discovery and workflow paths.

This PR completes the integration so the calendar is discoverable via:
- `content.md` agent subagent list and workflow
- `seo.md` Content Optimization workflow
- `subagent-index.toon` for programmatic discovery
- `tools/content/guidelines.md` (already had the reference)

Closes #533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new content calendar planning subagent to the content workflow
  * Reorganized content workflow to begin with an initial planning step
  * Updated content optimization documentation to include calendar planning capabilities
  * Enhanced subagent descriptions to reflect content calendar and summarization features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->