### PR TITLE
feat: add platform persona adaptations for content guidelines (t076)

### DIFF
--- a/.agents/content.md
+++ b/.agents/content.md
@@ -5,6 +5,7 @@ mode: subagent
 subagents:
   # Content creation
   - guidelines
+  - platform-personas
   - humanise
   - summarize
   - seo-writer
@@ -42,6 +43,7 @@ subagents:
 | Subagent | Purpose |
 |----------|---------|
 | `guidelines.md` | Content standards and style guide |
+| `platform-personas.md` | Platform-specific voice adaptations (LinkedIn, Instagram, YouTube, X, Facebook) |
 | `humanise.md` | Remove AI writing patterns, make text sound human |
 | `seo-writer.md` | SEO-optimized content writing with keyword integration |
 | `meta-creator.md` | Generate meta titles and descriptions for SEO |
@@ -103,6 +105,11 @@ See `content/guidelines.md` for:
 - Formatting standards
 - SEO requirements
 - Quality checklist
+
+See `content/platform-personas.md` for platform-specific adaptations:
+- LinkedIn, Instagram, YouTube, X, Facebook voice guidelines
+- Structure and length per platform
+- Cross-platform content repurposing
 
 ### Humanising Content
 

--- a/.agents/content/guidelines.md
+++ b/.agents/content/guidelines.md
@@ -107,3 +107,7 @@ For HTML content fields (especially WordPress content areas), use these HTML tag
 > We finish them with marine-grade coatings — ensuring they resist swelling, warping and weathering.
 
 **Follow these guidelines for all product page updates.**
+
+## Platform-Specific Adaptations
+
+These guidelines define the core voice for website and blog content. When writing for social media or video platforms, see `content/platform-personas.md` for channel-specific adaptations of this voice (LinkedIn, Instagram, YouTube, X, Facebook).

--- a/.agents/content/platform-personas.md
+++ b/.agents/content/platform-personas.md
@@ -1,0 +1,241 @@
+---
+name: platform-personas
+description: Platform-specific content adaptations - voice, tone, structure, and best practices per channel
+mode: subagent
+model: haiku
+---
+
+# Platform Persona Adaptations
+
+Adapt your core brand voice for each platform. The base voice comes from `content/guidelines.md` and project-level `context/brand-voice.md` -- this subagent defines how to shift that voice per channel.
+
+## How to Use
+
+1. Establish your core voice in `content/guidelines.md` or `context/brand-voice.md`
+2. When writing for a specific platform, apply the adaptations below
+3. The core identity stays consistent -- only delivery changes
+
+## LinkedIn
+
+### Voice Adaptation
+
+- **Register**: Professional, authoritative, thought-leadership
+- **Perspective**: First-person ("I" for personal brands, "We" for company pages)
+- **Tone shift**: More formal than blog, less formal than whitepaper
+- **Reader**: Decision-makers, peers, potential clients
+
+### Structure
+
+| Format | Length | Best For |
+|--------|--------|----------|
+| **Text post** | 150-300 words | Opinions, lessons, quick insights |
+| **Article** | 800-2,000 words | Deep dives, case studies |
+| **Carousel** | 8-12 slides, 20-40 words each | Frameworks, step-by-step guides |
+| **Document** | 5-15 pages | Reports, playbooks |
+
+### Best Practices
+
+- Open with a hook line (question, bold claim, or surprising stat)
+- Use line breaks liberally -- one thought per line
+- End with a question or clear CTA to drive engagement
+- Hashtags: 3-5 relevant ones, placed at the end
+- Avoid: corporate jargon, "excited to announce", empty self-promotion
+- Optimal posting: Tuesday-Thursday, 8-10am local time
+
+### Example Adaptation
+
+**Core voice**: "We build custom timber windows that last decades."
+
+**LinkedIn**: "Most replacement windows fail within 15 years.\n\nWe engineered ours to last 30+.\n\nHere's what makes the difference (thread):"
+
+## Instagram
+
+### Voice Adaptation
+
+- **Register**: Casual, visual-first, aspirational
+- **Perspective**: "We" for brands, authentic and behind-the-scenes
+- **Tone shift**: Warmer, more personal than other channels
+- **Reader**: Visual browsers, lifestyle-oriented audience
+
+### Structure
+
+| Format | Caption Length | Best For |
+|--------|---------------|----------|
+| **Feed post** | 50-150 words | Portfolio, finished work, tips |
+| **Carousel** | 30-80 words + slide text | Tutorials, before/after, lists |
+| **Story** | 1-2 sentences overlay | Daily updates, polls, BTS |
+| **Reel** | 30-80 words caption | Process videos, quick tips |
+
+### Best Practices
+
+- Lead with the visual -- caption supports, not replaces
+- First line is the hook (visible before "more" truncation)
+- Use emoji sparingly as visual breaks, not decoration
+- Hashtags: 5-15 relevant ones (mix niche + broad)
+- Alt text on every image (accessibility + SEO)
+- Avoid: walls of text, hard-sell language, stock photo aesthetics
+- Optimal posting: Monday-Friday, 11am-1pm and 7-9pm local time
+
+### Example Adaptation
+
+**Core voice**: "We build custom timber windows that last decades."
+
+**Instagram**: "From raw Accoya to finished frame. Swipe to see the process. [arrow emoji]\n\nBuilt for Jersey's salt air. Built to last."
+
+## YouTube
+
+### Voice Adaptation
+
+- **Register**: Educational, conversational, expert-but-approachable
+- **Perspective**: Direct address ("you"), presenter-led
+- **Tone shift**: More conversational than written content, explain as you go
+- **Reader**: Learners, researchers, how-to seekers
+
+### Structure
+
+| Format | Length | Best For |
+|--------|--------|----------|
+| **Short** | 30-60 seconds | Quick tips, single concepts |
+| **Tutorial** | 8-15 minutes | How-to, walkthroughs |
+| **Deep dive** | 15-30 minutes | Case studies, comparisons |
+| **Vlog** | 5-10 minutes | Behind-the-scenes, day-in-life |
+
+### Best Practices
+
+- Title: keyword-front, under 60 characters, curiosity or value hook
+- Description: first 2 lines visible -- include keyword and value prop
+- Thumbnail: high contrast, readable text, expressive face or clear subject
+- Chapters: add timestamps for videos over 5 minutes
+- CTA: subscribe prompt at natural break, not forced intro
+- Avoid: clickbait that doesn't deliver, long intros, "don't forget to like and subscribe" as opener
+- Tags: 5-10 relevant keywords
+
+### Script Tone Guide
+
+```text
+Written: "Marine-grade coatings provide superior weather resistance."
+YouTube: "So we coat these with marine-grade finish -- the same stuff
+         they use on boats. And that's what stops them warping in
+         the salt air."
+```
+
+## X (Twitter)
+
+### Voice Adaptation
+
+- **Register**: Concise, opinionated, conversational
+- **Perspective**: Direct, personality-forward
+- **Tone shift**: Sharpest and most direct of all platforms
+- **Reader**: Fast scrollers, industry peers, news followers
+
+### Structure
+
+| Format | Length | Best For |
+|--------|--------|----------|
+| **Single post** | 1-2 sentences (under 280 chars) | Hot takes, links, announcements |
+| **Thread** | 3-10 posts | Breakdowns, stories, tutorials |
+| **Quote post** | 1 sentence + context | Commentary, amplification |
+
+### Best Practices
+
+- Front-load the value -- no preamble
+- Threads: number them (1/7) or use a hook post + replies
+- One idea per post
+- Avoid: hashtag spam, @-mention chains, "RT if you agree"
+- Optimal posting: weekdays, 9-11am and 1-3pm local time
+
+### Example Adaptation
+
+**Core voice**: "We build custom timber windows that last decades."
+
+**X**: "Most window companies warranty 10 years. We warranty 30. Here's why that matters:"
+
+## Facebook
+
+### Voice Adaptation
+
+- **Register**: Community-oriented, warm, local
+- **Perspective**: "We" as a neighbour, not a corporation
+- **Tone shift**: Most personal and community-focused
+- **Reader**: Local community, existing customers, referral network
+
+### Structure
+
+| Format | Length | Best For |
+|--------|--------|----------|
+| **Post** | 40-100 words | Updates, photos, community |
+| **Event** | Brief description + details | Workshops, open days |
+| **Album** | 5-20 photos + captions | Project showcases |
+
+### Best Practices
+
+- Write like you're talking to a neighbour
+- Photos of real work outperform polished graphics
+- Ask questions to drive comments
+- Respond to every comment
+- Avoid: corporate tone, link-only posts, engagement bait
+- Optimal posting: Wednesday-Friday, 1-4pm local time
+
+## Blog / Website
+
+### Voice Adaptation
+
+- **Register**: Expert, thorough, SEO-aware
+- **Perspective**: "We" for company, "you" for reader
+- **Tone shift**: Most detailed and structured of all channels
+- **Reader**: Search visitors, researchers, potential customers
+
+### Structure
+
+See `content/guidelines.md` for full blog formatting standards. Key differences from social:
+
+- Longer form (1,500-3,000 words for pillar content)
+- H2/H3 hierarchy for scannability
+- Internal links (3-5 per article)
+- Meta title and description optimised for search
+- One sentence per paragraph (per guidelines.md)
+
+## Adapting Your Core Voice
+
+### The Adaptation Framework
+
+When writing for any platform, apply this checklist:
+
+1. **Start with core voice** from `guidelines.md` or `context/brand-voice.md`
+2. **Adjust register** (formal <-> casual) per platform table above
+3. **Adjust length** to platform norms
+4. **Adjust structure** (visual-first, text-first, video script)
+5. **Keep identity consistent** -- same values, different delivery
+
+### What Stays Constant
+
+- Brand values and positioning
+- Key messages and differentiators
+- Spelling conventions (British English if set in guidelines)
+- Honesty and authenticity
+- Expertise and authority
+
+### What Changes
+
+- Sentence length and complexity
+- Formality level
+- Use of emoji and hashtags
+- Content structure and formatting
+- Call-to-action style
+- Level of detail
+
+## Cross-Platform Content Repurposing
+
+One piece of content can feed multiple platforms:
+
+```text
+Blog post (2,000 words)
+  -> LinkedIn article (800 words, key insights)
+  -> LinkedIn carousel (8 slides, framework extract)
+  -> Instagram carousel (before/after or tips)
+  -> X thread (5 posts, main takeaways)
+  -> YouTube script (10 min tutorial version)
+  -> Facebook post (community angle + link)
+```
+
+Use `content/seo-writer.md` for the blog original, then adapt using the platform guidelines above.

--- a/.agents/marketing.md
+++ b/.agents/marketing.md
@@ -313,14 +313,19 @@ Returns: <a href="{{fc_smart_link slug='demo-cta'}}">Request a Demo</a>
 
 ## Content Marketing Integration
 
+### Platform Voice Guidelines
+
+When creating content for social media or multi-channel campaigns, see `content/platform-personas.md` for platform-specific voice adaptations (LinkedIn, Instagram, YouTube, X, Facebook). This ensures consistent brand voice adapted to each channel's norms.
+
 ### Content to Campaign Workflow
 
 1. **Create content** using `content.md` agent
-2. **Optimize for SEO** using `seo.md` agent
-3. **Create email** promoting content
-4. **Segment audience** by interest
-5. **Send campaign** to relevant segments
-6. **Track engagement** and conversions
+2. **Adapt for platforms** using `content/platform-personas.md` guidelines
+3. **Optimize for SEO** using `seo.md` agent
+4. **Create email** promoting content
+5. **Segment audience** by interest
+6. **Send campaign** to relevant segments
+7. **Track engagement** and conversions
 
 ### Content Promotion Campaigns
 

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -26,7 +26,7 @@ pro,gemini-2.5-pro,Capable large context
 aidevops/,Framework internals - extending aidevops and architecture,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper
-content/,Content creation - copywriting and editorial,guidelines|humanise|seo-writer|meta-creator|editor|internal-linker|context-templates
+content/,Content creation - copywriting and editorial,guidelines|platform-personas|humanise|seo-writer|meta-creator|editor|internal-linker|context-templates
 tools/content/,Content tools - calendar planning summarization and extraction,content-calendar|summarize
 tools/social-media/,Social media tools - X/Twitter LinkedIn and Reddit,bird|linkedin|reddit
 tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-review|agent-testing


### PR DESCRIPTION
## Summary

- Adds `content/platform-personas.md` subagent with platform-specific voice, tone, structure, and best practices for LinkedIn, Instagram, YouTube, X (Twitter), Facebook, and Blog/Website
- Cross-references from `content/guidelines.md`, `content.md`, and `marketing.md`
- Registered in `subagent-index.toon`

## Details

Inspired by ALwrity persona system (t037 research). The core brand voice stays in `guidelines.md` -- this subagent defines how to adapt delivery per channel while keeping identity consistent.

Covers per platform: voice register, content structure/length tables, best practices, posting times, example adaptations, and a cross-platform repurposing framework.

## Changes

| File | Change |
|------|--------|
| `.agents/content/platform-personas.md` | New subagent (241 lines) |
| `.agents/content/guidelines.md` | Added platform adaptations reference |
| `.agents/content.md` | Registered subagent + added content standards reference |
| `.agents/marketing.md` | Added platform voice section + updated workflow |
| `.agents/subagent-index.toon` | Added platform-personas to content/ entry |

## Verification

- markdownlint: 0 errors across all changed files
- Follows existing subagent patterns (YAML frontmatter, model: haiku)
- Cross-references verified bidirectionally

Closes #534