### PR TITLE
feat: prevent false task completion cascade (t163)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -110,6 +110,8 @@ Use `/save-todo` after planning. Auto-detects complexity:
 - Before marking `[x]`, verify: deliverable file exists AND content is substantive (not a stub/placeholder)
 - Marking `[x]` triggers `issue-sync` to auto-close the linked GitHub Issue — false completions cascade
 
+_See `workflows/plans.md` "Task Completion Rules" for detailed guidance._
+
 **After ANY TODO/planning edit** (interactive sessions only, NOT workers): Commit and push immediately. Planning-only files (TODO.md, todo/) go directly to main -- no branch, no PR. Mixed changes (planning + non-exception files) use a worktree. NEVER `git checkout -b` in the main repo. Workers must NOT edit TODO.md -- see `workflows/plans.md` "Worker TODO.md Restriction".
 
 **Full docs**: `workflows/plans.md`, `tools/task-management/beads.md`

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -104,6 +104,12 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **Dependencies**: `blocked-by:t001`, `blocks:t002`, `t001.1` (subtask)
 
+**Task completion rules:**
+- NEVER mark a task `[x]` unless YOU wrote code/content for it in THIS session
+- If a worker branch or merged PR completed the task, leave it `[ ]` — the repo owner or reviewer marks it done
+- Before marking `[x]`, verify: deliverable file exists AND content is substantive (not a stub/placeholder)
+- Marking `[x]` triggers `issue-sync` to auto-close the linked GitHub Issue — false completions cascade
+
 **After ANY TODO/planning edit** (interactive sessions only, NOT workers): Commit and push immediately. Planning-only files (TODO.md, todo/) go directly to main -- no branch, no PR. Mixed changes (planning + non-exception files) use a worktree. NEVER `git checkout -b` in the main repo. Workers must NOT edit TODO.md -- see `workflows/plans.md` "Worker TODO.md Restriction".
 
 **Full docs**: `workflows/plans.md`, `tools/task-management/beads.md`

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1029,7 +1029,13 @@ cmd_close() {
             continue
         fi
 
-        if gh issue close "$issue_number" --repo "$repo_slug" --comment "Completed. Task $task_id marked done in TODO.md (verified)." 2>/dev/null; then
+        local close_comment
+        if [[ "$force" == "true" ]]; then
+            close_comment="Completed. Task $task_id marked done in TODO.md (force-closed, verified: field not checked)."
+        else
+            close_comment="Completed. Task $task_id marked done in TODO.md (verified)."
+        fi
+        if gh issue close "$issue_number" --repo "$repo_slug" --comment "$close_comment" 2>/dev/null; then
             print_success "Closed #$issue_number ($task_id)"
             closed=$((closed + 1))
         else

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -693,6 +693,7 @@ An "always switch branches for TODO.md" rule fails the 80% universal applicabili
 1. **YOU wrote code/content** for it in THIS session (not just verified a file exists)
 2. **Deliverable is substantive** — file exists, content is complete (not a stub/placeholder), passes quality checks
 3. **You can cite what you did** — specific files created/modified, lines changed
+4. **Add `verified:YYYY-MM-DD`** to the task line — `issue-sync close` requires this field to auto-close the linked GitHub Issue
 
 **If someone else did the work** (worker branch, merged PR, another session): leave it `[ ]`. The repo owner or reviewer marks it done after verification.
 

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -686,6 +686,20 @@ An "always switch branches for TODO.md" rule fails the 80% universal applicabili
 
 **Bottom line**: Use judgment. Related work stays together; unrelated TODO-only backlog goes directly to main; mixed changes use a worktree.
 
+## MANDATORY: Task Completion Rules
+
+**NEVER mark a task `[x]` unless ALL of these are true:**
+
+1. **YOU wrote code/content** for it in THIS session (not just verified a file exists)
+2. **Deliverable is substantive** — file exists, content is complete (not a stub/placeholder), passes quality checks
+3. **You can cite what you did** — specific files created/modified, lines changed
+
+**If someone else did the work** (worker branch, merged PR, another session): leave it `[ ]`. The repo owner or reviewer marks it done after verification.
+
+**Why this matters**: Marking `[x]` triggers `issue-sync` GitHub Action which auto-closes the linked GitHub Issue. False completions cascade — 38 issues were incorrectly closed in a single incident (PR #616).
+
+**The `actual:` field** should only appear on completed `[x]` tasks. Remove it when reverting a task to `[ ]`.
+
 ## MANDATORY: Worker TODO.md Restriction
 
 **Workers (headless dispatch runners) must NEVER edit TODO.md directly.** This is the primary cause of merge conflicts when multiple workers + supervisor all push to TODO.md on main simultaneously.

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -148,9 +148,10 @@ jobs:
         HEAD="${{ github.event.pull_request.head.sha }}"
 
         # Get tasks that changed from [ ] to [x] in this PR
-        NEW_COMPLETIONS=$(diff <(git show "$BASE":TODO.md 2>/dev/null | grep -E '^\- \[ \] t[0-9]+' | grep -oE 't[0-9]+' | sort) \
-                               <(git show "$HEAD":TODO.md 2>/dev/null | grep -E '^\- \[x\] t[0-9]+' | grep -oE 't[0-9]+' | sort) \
-                          2>/dev/null | grep '^>' | sed 's/^> //' || true)
+        # comm -12 finds the intersection: IDs that were [ ] in BASE AND [x] in HEAD
+        BASE_OPEN=$(git show "$BASE":TODO.md 2>/dev/null | grep -E '^\- \[ \] t[0-9]+' | grep -oE 't[0-9]+' | sort || true)
+        HEAD_DONE=$(git show "$HEAD":TODO.md 2>/dev/null | grep -E '^\- \[x\] t[0-9]+' | grep -oE 't[0-9]+' | sort || true)
+        NEW_COMPLETIONS=$(comm -12 <(echo "$BASE_OPEN") <(echo "$HEAD_DONE") || true)
 
         if [[ -z "$NEW_COMPLETIONS" ]]; then
           echo "No new task completions in this PR"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -130,6 +130,58 @@ jobs:
         echo ""
         echo "All shell scripts passed ShellCheck"
 
+  todo-validation:
+    name: TODO.md Task Completion Validation
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Check for unverified task completions
+      run: |
+        # Compare TODO.md between base and head to find new [x] transitions
+        BASE="${{ github.event.pull_request.base.sha }}"
+        HEAD="${{ github.event.pull_request.head.sha }}"
+
+        # Get tasks that changed from [ ] to [x] in this PR
+        NEW_COMPLETIONS=$(diff <(git show "$BASE":TODO.md 2>/dev/null | grep -E '^\- \[ \] t[0-9]+' | grep -oE 't[0-9]+' | sort) \
+                               <(git show "$HEAD":TODO.md 2>/dev/null | grep -E '^\- \[x\] t[0-9]+' | grep -oE 't[0-9]+' | sort) \
+                          2>/dev/null | grep '^>' | sed 's/^> //' || true)
+
+        if [[ -z "$NEW_COMPLETIONS" ]]; then
+          echo "No new task completions in this PR"
+          exit 0
+        fi
+
+        echo "New task completions found:"
+        echo "$NEW_COMPLETIONS"
+        echo ""
+
+        WARNINGS=0
+        while IFS= read -r task_id; do
+          [[ -z "$task_id" ]] && continue
+          TASK_LINE=$(git show "$HEAD":TODO.md | grep -E "^\- \[x\] ${task_id} " | head -1 || true)
+
+          # Check for verified: field
+          if ! echo "$TASK_LINE" | grep -qE 'verified:[0-9]{4}-[0-9]{2}-[0-9]{2}'; then
+            echo "WARNING: $task_id marked [x] without verified: field"
+            WARNINGS=$((WARNINGS + 1))
+          else
+            echo "OK: $task_id has verified: field"
+          fi
+        done <<< "$NEW_COMPLETIONS"
+
+        if [[ "$WARNINGS" -gt 0 ]]; then
+          echo ""
+          echo "WARNING: $WARNINGS task(s) marked complete without verified: field."
+          echo "Add 'verified:YYYY-MM-DD' to confirm completion, or issue-sync will skip auto-closing the linked GitHub Issue."
+          echo "This is a warning only — the PR can still merge."
+        fi
+
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add task completion rules to AGENTS.md and plans.md — agents must never mark `[x]` unless they wrote the code
- `issue-sync-helper.sh cmd_close()` now requires `verified:` field before closing GitHub Issues (--force to override)
- Supervisor Phase 6: verify deliverables by checking PR merge status before marking verified
- CI: new TODO.md validation step warns on PRs when tasks marked `[x]` without `verified:` field

Addresses root cause of 38 issues being falsely auto-closed (PR #616). ref:GH#618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated verification of deployed deliverables to confirm PR merges before marking task completion.
  * Added CI/CD validation step to check verified dates on all task completions.
  * Introduced --force flag to override verification requirements when closing tasks.

* **Documentation**
  * Codified task completion rules, approval criteria, and ownership/reporting model for the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->