### PR TITLE
feat: distributed task claiming via GitHub Issue assignees (t164)

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -745,11 +745,13 @@ cmd_push() {
             continue
         fi
 
-        # Create the issue
+        # Create the issue with status:available label (t164)
         local gh_args=("issue" "create" "--repo" "$repo_slug" "--title" "$title")
         gh_args+=("--body" "$body")
         if [[ -n "$labels" ]]; then
-            gh_args+=("--label" "$labels")
+            gh_args+=("--label" "${labels},status:available")
+        else
+            gh_args+=("--label" "status:available")
         fi
 
         local issue_url

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -697,6 +697,9 @@ cmd_push() {
 
     print_info "Processing ${#tasks[@]} task(s) for push to $repo_slug"
 
+    # Ensure status:available label exists (t164 — label may not exist in new repos)
+    gh label create "status:available" --repo "$repo_slug" --color "0E8A16" --description "Task is available for claiming" --force 2>/dev/null || true
+
     local created=0
     local skipped=0
     for task_id in "${tasks[@]}"; do

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -204,31 +204,29 @@ source "${SCRIPT_DIR}/shared-constants.sh"
         exit 3
     else
         # Check if task is claimed by someone else on GitHub (t164)
-        local task_id_from_branch=""
+        # Note: no 'local' — this runs at script top-level, not inside a function
+        task_id_from_branch=""
         task_id_from_branch=$(echo "$current_branch" | grep -oE 't[0-9]+' | head -1 || true)
         if [[ -n "$task_id_from_branch" ]]; then
-            local supervisor_script="$SCRIPT_DIR/supervisor-helper.sh"
+            supervisor_script="$SCRIPT_DIR/supervisor-helper.sh"
             if [[ -x "$supervisor_script" ]]; then
-                local claimed_by=""
-                claimed_by=$("$supervisor_script" 2>/dev/null <<< "" || true)  # avoid sourcing
-                # Use check_task_claimed directly via the helper
-                local project_root
+                project_root=""
                 project_root=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
-                local todo_file="$project_root/TODO.md"
-                local issue_number=""
+                todo_file="$project_root/TODO.md"
+                issue_number=""
                 if [[ -f "$todo_file" ]]; then
-                    local task_line
+                    task_line=""
                     task_line=$(grep -E "^\- \[.\] ${task_id_from_branch} " "$todo_file" | head -1 || true)
                     issue_number=$(echo "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
                 fi
                 if [[ -n "$issue_number" ]] && command -v gh &>/dev/null; then
-                    local repo_slug
+                    repo_slug=""
                     repo_slug=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||;s|\.git$||' || true)
                     if [[ -n "$repo_slug" ]]; then
-                        local current_assignee
+                        current_assignee=""
                         current_assignee=$(gh api "repos/$repo_slug/issues/$issue_number" --jq '.assignee.login // empty' 2>/dev/null || true)
                         if [[ -n "$current_assignee" ]]; then
-                            local my_login
+                            my_login=""
                             my_login=$(gh api user --jq '.login' 2>/dev/null || true)
                             if [[ "$current_assignee" != "$my_login" ]]; then
                                 echo -e "${YELLOW}WARNING${NC}: Task $task_id_from_branch is claimed by @$current_assignee (GH#$issue_number)"

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -1836,6 +1836,159 @@ cmd_cancel() {
 }
 
 #######################################
+# Claim a task via GitHub Issue assignee (t164)
+# Uses GitHub as distributed lock — works across machines
+#######################################
+cmd_claim() {
+    local task_id="${1:-}"
+
+    if [[ -z "$task_id" ]]; then
+        log_error "Usage: supervisor-helper.sh claim <task_id>"
+        return 1
+    fi
+
+    # Find the GitHub issue number from TODO.md
+    local project_root
+    project_root=$(find_project_root 2>/dev/null || echo ".")
+    local todo_file="$project_root/TODO.md"
+    local issue_number=""
+
+    if [[ -f "$todo_file" ]]; then
+        local task_line
+        task_line=$(grep -E "^\- \[.\] ${task_id} " "$todo_file" | head -1 || echo "")
+        issue_number=$(echo "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
+    fi
+
+    if [[ -z "$issue_number" ]]; then
+        log_error "No GitHub issue found for $task_id (missing ref:GH# in TODO.md)"
+        return 1
+    fi
+
+    local repo_slug
+    repo_slug=$(detect_repo_slug "$project_root" 2>/dev/null || echo "")
+    if [[ -z "$repo_slug" ]]; then
+        log_error "Cannot detect repo slug"
+        return 1
+    fi
+
+    # Check current assignee
+    local current_assignee
+    current_assignee=$(gh api "repos/$repo_slug/issues/$issue_number" --jq '.assignee.login // empty' 2>/dev/null || echo "")
+
+    if [[ -n "$current_assignee" ]]; then
+        local my_login
+        my_login=$(gh api user --jq '.login' 2>/dev/null || echo "")
+        if [[ "$current_assignee" == "$my_login" ]]; then
+            log_info "$task_id already claimed by you (GH#$issue_number)"
+            return 0
+        fi
+        log_error "$task_id is claimed by @$current_assignee (GH#$issue_number)"
+        return 1
+    fi
+
+    # Assign to self
+    if gh issue edit "$issue_number" --repo "$repo_slug" --add-assignee "@me" 2>/dev/null; then
+        log_success "Claimed $task_id (GH#$issue_number assigned to you)"
+
+        # Add status label if it exists
+        gh issue edit "$issue_number" --repo "$repo_slug" --add-label "status:claimed" --remove-label "status:available" 2>/dev/null || true
+
+        return 0
+    else
+        log_error "Failed to claim $task_id (GH#$issue_number)"
+        return 1
+    fi
+}
+
+#######################################
+# Release a claimed task (t164)
+#######################################
+cmd_unclaim() {
+    local task_id="${1:-}"
+
+    if [[ -z "$task_id" ]]; then
+        log_error "Usage: supervisor-helper.sh unclaim <task_id>"
+        return 1
+    fi
+
+    local project_root
+    project_root=$(find_project_root 2>/dev/null || echo ".")
+    local todo_file="$project_root/TODO.md"
+    local issue_number=""
+
+    if [[ -f "$todo_file" ]]; then
+        local task_line
+        task_line=$(grep -E "^\- \[.\] ${task_id} " "$todo_file" | head -1 || echo "")
+        issue_number=$(echo "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
+    fi
+
+    if [[ -z "$issue_number" ]]; then
+        log_error "No GitHub issue found for $task_id"
+        return 1
+    fi
+
+    local repo_slug
+    repo_slug=$(detect_repo_slug "$project_root" 2>/dev/null || echo "")
+
+    local my_login
+    my_login=$(gh api user --jq '.login' 2>/dev/null || echo "")
+
+    if gh issue edit "$issue_number" --repo "$repo_slug" --remove-assignee "$my_login" 2>/dev/null; then
+        log_success "Released $task_id (GH#$issue_number unassigned)"
+        gh issue edit "$issue_number" --repo "$repo_slug" --add-label "status:available" --remove-label "status:claimed" 2>/dev/null || true
+        return 0
+    else
+        log_error "Failed to release $task_id"
+        return 1
+    fi
+}
+
+#######################################
+# Check if a task is claimed by someone else (t164)
+# Returns 0 if free or claimed by self, 1 if claimed by another
+#######################################
+check_task_claimed() {
+    local task_id="${1:-}"
+    local project_root="${2:-.}"
+    local todo_file="$project_root/TODO.md"
+    local issue_number=""
+
+    if [[ -f "$todo_file" ]]; then
+        local task_line
+        task_line=$(grep -E "^\- \[.\] ${task_id} " "$todo_file" | head -1 || echo "")
+        issue_number=$(echo "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo "")
+    fi
+
+    # No issue = no claim mechanism = free
+    if [[ -z "$issue_number" ]]; then
+        return 0
+    fi
+
+    local repo_slug
+    repo_slug=$(detect_repo_slug "$project_root" 2>/dev/null || echo "")
+    if [[ -z "$repo_slug" ]]; then
+        return 0
+    fi
+
+    local current_assignee
+    current_assignee=$(gh api "repos/$repo_slug/issues/$issue_number" --jq '.assignee.login // empty' 2>/dev/null || echo "")
+
+    if [[ -z "$current_assignee" ]]; then
+        return 0
+    fi
+
+    local my_login
+    my_login=$(gh api user --jq '.login' 2>/dev/null || echo "")
+
+    if [[ "$current_assignee" == "$my_login" ]]; then
+        return 0
+    fi
+
+    echo "$current_assignee"
+    return 1
+}
+
+#######################################
 # Direct SQLite access for debugging
 #######################################
 cmd_db() {
@@ -2484,6 +2637,17 @@ cmd_dispatch() {
         log_error "Task $task_id is in '$tstatus' state, must be 'queued' to dispatch"
         return 1
     fi
+
+    # Check if task is claimed by someone else on GitHub (t164)
+    local claimed_by=""
+    claimed_by=$(check_task_claimed "$task_id" "${trepo:-.}" 2>/dev/null) || true
+    if [[ -n "$claimed_by" ]]; then
+        log_warn "Task $task_id is claimed by @$claimed_by on GitHub — skipping dispatch"
+        return 2
+    fi
+
+    # Claim the task on GitHub before dispatching (t164)
+    cmd_claim "$task_id" 2>/dev/null || log_verbose "Could not claim $task_id on GitHub (no issue ref or gh unavailable)"
 
     # Check concurrency limit with adaptive load awareness (t151)
     if [[ -n "$batch_id" ]]; then
@@ -7588,6 +7752,8 @@ main() {
         running-count) cmd_running_count "$@" ;;
         reset) cmd_reset "$@" ;;
         cancel) cmd_cancel "$@" ;;
+        claim) cmd_claim "$@" ;;
+        unclaim) cmd_unclaim "$@" ;;
         backup) cmd_backup "$@" ;;
         restore) cmd_restore "$@" ;;
         db) cmd_db "$@" ;;

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -686,6 +686,29 @@ An "always switch branches for TODO.md" rule fails the 80% universal applicabili
 
 **Bottom line**: Use judgment. Related work stays together; unrelated TODO-only backlog goes directly to main; mixed changes use a worktree.
 
+## Distributed Task Claiming (t164)
+
+When multiple machines or agents work on the same repo, **GitHub Issue assignees** are the single source of truth for task ownership. The supervisor DB is a local cache only.
+
+**Claim flow:**
+
+```bash
+supervisor-helper.sh claim tNNN    # Assign GH issue to yourself
+supervisor-helper.sh unclaim tNNN  # Release the claim
+```
+
+**How it works:**
+
+| Actor | Before work | During work | After work |
+|-------|-------------|-------------|------------|
+| **Supervisor** | `claim` before dispatch (auto) | Worker runs | `unclaim` on completion |
+| **Human** | `claim` or assign on GitHub | Edit code | PR merge closes issue |
+| **Pre-edit check** | Warns if claimed by another | — | — |
+
+**Status labels** on GitHub Issues: `status:available` → `status:claimed` → `status:in-review` → `status:done`
+
+**Why GitHub, not local DB?** The supervisor DB is per-machine (SQLite). GitHub Issues are visible to all machines, all agents, and all humans. No sync needed.
+
 ## MANDATORY: Worker TODO.md Restriction
 
 **Workers (headless dispatch runners) must NEVER edit TODO.md directly.** This is the primary cause of merge conflicts when multiple workers + supervisor all push to TODO.md on main simultaneously.

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -701,9 +701,11 @@ supervisor-helper.sh unclaim tNNN  # Release the claim
 
 | Actor | Before work | During work | After work |
 |-------|-------------|-------------|------------|
-| **Supervisor** | `claim` before dispatch (auto) | Worker runs | `unclaim` on completion |
+| **Supervisor** | `claim` before dispatch (auto) | Worker runs | Manual `unclaim` or PR merge closes issue |
 | **Human** | `claim` or assign on GitHub | Edit code | PR merge closes issue |
 | **Pre-edit check** | Warns if claimed by another | — | — |
+
+> **Note:** Auto-unclaim on task completion is planned for a future iteration. Currently, claims are released manually or when the GitHub Issue is closed.
 
 **Status labels** on GitHub Issues: `status:available` → `status:claimed` → `status:in-review` → `status:done`
 


### PR DESCRIPTION
## Summary

- Add `claim`/`unclaim` commands to supervisor-helper.sh — uses GitHub Issue assignees as distributed lock across machines
- Supervisor dispatch checks GH assignee before dispatching, auto-claims, skips if claimed by another user
- Pre-edit check warns if task (extracted from branch name) is claimed by another user
- New issues created by issue-sync get `status:available` label
- Document distributed claiming workflow in plans.md

GitHub Issues are the single source of truth for task ownership. Supervisor DB is local cache only. ref:GH#619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Implemented distributed task claiming workflow to prevent concurrent task assignments across team members
  * Automatically applied "status:available" label to newly created issues for task visibility
  * Added pre-work validation that warns users if attempting to work on an already-claimed task

* **Documentation**
  * Added comprehensive documentation detailing the distributed task claiming workflow and multi-machine ownership model

<!-- end of auto-generated comment: release notes by coderabbit.ai -->