### PR TITLE
feat: register Mom Test UX/CRO agent and fix cross-references (t101)

### DIFF
--- a/.agents/seo/seo-audit-skill.md
+++ b/.agents/seo/seo-audit-skill.md
@@ -376,5 +376,5 @@ Same format as above
 - **programmatic-seo**: For building SEO pages at scale
 - **schema-markup**: For implementing structured data
 - **schema-validator**: For validating Schema.org structured data (JSON-LD, Microdata, RDFa)
-- **page-cro**: For optimizing pages for conversion (not just ranking)
+- **[mom-test-ux](mom-test-ux.md)**: For UX evaluation and CRO ("Would this confuse my mom?" heuristic)
 - **analytics-tracking**: For measuring SEO performance

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -25,7 +25,7 @@ pro,gemini-2.5-pro,Capable large context
 <!--TOON:subagents[40]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison
 memory/,Cross-session memory - SQLite FTS5 storage,README
-seo/,Search optimization - keywords and rankings,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper
+seo/,Search optimization - keywords and rankings and UX/CRO,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper|mom-test-ux
 content/,Content creation - copywriting and editorial,guidelines|platform-personas|humanise|seo-writer|meta-creator|editor|internal-linker|context-templates
 tools/content/,Content tools - calendar planning summarization and extraction,content-calendar|summarize
 tools/social-media/,Social media tools - X/Twitter LinkedIn and Reddit,bird|linkedin|reddit


### PR DESCRIPTION
## Summary

- Registers the Mom Test UX/CRO agent (`mom-test-ux`) in `subagent-index.toon` (was missing from seo/ key_files)
- Fixes broken `page-cro` reference in `seo-audit-skill.md` to correctly point to `mom-test-ux.md`
- The agent file itself (`seo/mom-test-ux.md`) was already merged via PR #557

## Context

Task t101 was previously marked complete by the supervisor but reverted in PR #616 (false completion cascade). The agent content is solid and complete — the gaps were in registration and cross-referencing.

## Changes

| File | Change |
|------|--------|
| `.agents/subagent-index.toon` | Add `mom-test-ux` to seo/ key_files |
| `.agents/seo/seo-audit-skill.md` | Fix `page-cro` → `mom-test-ux` reference |

Closes #521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SEO auditing now includes UX and conversion rate optimization (CRO) evaluation alongside traditional page optimization.
  * Introduced a user-experience testing heuristic to evaluate content clarity and usability.

* **Documentation**
  * Updated agent descriptions to reflect expanded UX/CRO capabilities within SEO tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->