### PR TITLE
fix: supervisor identity matching — prefer GitHub username, fuzzy compare

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,7 +104,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
   - Notes: PR #548 merged. Guard arithmetic with `|| true` to prevent silent exit under `set -e`.
 
 - [ ] t169 Fix `aidevops update` skipping agent deployment — pass `--non-interactive` to setup.sh #bug #setup ~15m (ai:10m) ref:GH#550 assignee:marcusquinn@Marcus-MacBook-Pro started:2026-02-08T17:33:28Z logged:2026-02-08
-  - Notes: `cmd_update()` in aidevops.sh calls `bash setup.sh` without `--non-interactive`, so interactive prompts silently skip in non-TTY contexts and agents never deploy.
+  - Notes: `cmd_update()` in aidevops.sh calls `bash setup.sh` without `--non-interactive`, so interactive prompts silently skip in non-TTY contexts and agents never deploy. BLOCKED: Re-prompt dispatch failed: ambiguous_skipped_ai
 
 - [ ] t170 Fix `import-credentials` ignoring multi-tenant credential files #bug #credentials ~30m (ai:20m) ref:GH#553 logged:2026-02-08
   - Notes: `cmd_import_credentials()` in secret-helper.sh reads credentials.sh directly but with multi-tenant active, that file is a loader script. Actual credentials are in `tenants/{tenant}/credentials.sh`.


### PR DESCRIPTION
## Summary

- `get_aidevops_identity()` now prefers GitHub username (via `gh api user`, cached per session) over `user@host` format
- `check_task_claimed()` now does fuzzy matching: compares against full identity, username portion (before `@`), local `whoami`, and GitHub username
- `cmd_claim()` and `cmd_unclaim()` delegate to `check_task_claimed()` for consistent matching

## Root Cause

The supervisor was skipping t166 and t167 during dispatch because:
- TODO.md had `assignee:marcusquinn` (GitHub username, set manually)
- `get_aidevops_identity()` returned `marcusquinn@Marcus-MacBook-Pro` (user@host)
- Exact string comparison failed, so the supervisor treated them as "claimed by someone else"

This is a single-user system where the repo owner, the GitHub user, and the supervisor are all the same person. The identity system needs to recognize that.

## Changes

| Function | Before | After |
|----------|--------|-------|
| `get_aidevops_identity()` | Always `user@host` | GitHub username (cached) > `user@host` |
| `check_task_claimed()` | Exact match only | Fuzzy: full identity, username portion, whoami, gh username |
| `cmd_claim()` | Inline comparison | Delegates to `check_task_claimed()` |
| `cmd_unclaim()` | Inline comparison | Delegates to `check_task_claimed()` |

## Testing

- ShellCheck: zero new violations
- GitHub username cached via `_CACHED_GH_USERNAME` to avoid repeated API calls
- Falls back gracefully when `gh` is unavailable (uses `user@host`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved task claiming and unclaiming to support multiple identity formats and reduce redundant API calls through session caching.
  * Enhanced identity resolution with fuzzy matching to handle username variations more reliably.

* **Chores**
  * Updated internal task status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->