### PR TITLE
feat: add --headless flag to full-loop for autonomous worker operation (t174)

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -2540,9 +2540,10 @@ build_dispatch_cmd() {
 
     # Include task description in the prompt so the worker knows what to do
     # even if TODO.md doesn't have an entry for this task (t158)
-    local prompt="/full-loop $task_id"
+    # Always pass --headless for supervisor-dispatched workers (t174)
+    local prompt="/full-loop $task_id --headless"
     if [[ -n "$description" ]]; then
-        prompt="/full-loop $task_id -- $description"
+        prompt="/full-loop $task_id --headless -- $description"
     fi
     if [[ -n "$memory_context" ]]; then
         prompt="$prompt
@@ -3054,20 +3055,24 @@ cmd_dispatch() {
     # Ensure PID directory exists before dispatch
     mkdir -p "$SUPERVISOR_DIR/pids"
 
+    # Set FULL_LOOP_HEADLESS for all supervisor-dispatched workers (t174)
+    # This ensures headless mode even if the AI doesn't parse --headless from the prompt
+    local headless_env="FULL_LOOP_HEADLESS=true"
+
     if [[ "$dispatch_mode" == "tabby" ]]; then
         # Tabby: attempt to open in a new tab via OSC 1337 escape sequence
         log_info "Opening Tabby tab for $task_id..."
         local tab_cmd
-        tab_cmd="cd '${worktree_path}' && ${cmd_parts[*]} > '${log_file}' 2>&1; echo \"EXIT:\$?\" >> '${log_file}'"
+        tab_cmd="cd '${worktree_path}' && ${headless_env} ${cmd_parts[*]} > '${log_file}' 2>&1; echo \"EXIT:\$?\" >> '${log_file}'"
         printf '\e]1337;NewTab=%s\a' "$tab_cmd" 2>/dev/null || true
         # Also start background process as fallback (Tabby may not support OSC 1337)
         # Use nohup + disown to survive parent (cron) exit
-        nohup bash -c "cd '${worktree_path}' && $(printf '%q ' "${cmd_parts[@]}") > '${log_file}' 2>&1; echo \"EXIT:\$?\" >> '${log_file}'" &>/dev/null &
+        nohup bash -c "cd '${worktree_path}' && export ${headless_env} && $(printf '%q ' "${cmd_parts[@]}") > '${log_file}' 2>&1; echo \"EXIT:\$?\" >> '${log_file}'" &>/dev/null &
     else
         # Headless: background process
         # Use nohup + disown to survive parent (cron) exit — without this,
         # workers die after ~2 minutes when the cron pulse script exits
-        nohup bash -c "cd '${worktree_path}' && $(printf '%q ' "${cmd_parts[@]}") > '${log_file}' 2>&1; echo \"EXIT:\$?\" >> '${log_file}'" &>/dev/null &
+        nohup bash -c "cd '${worktree_path}' && export ${headless_env} && $(printf '%q ' "${cmd_parts[@]}") > '${log_file}' 2>&1; echo \"EXIT:\$?\" >> '${log_file}'" &>/dev/null &
     fi
 
     local worker_pid=$!


### PR DESCRIPTION
## Summary

- Adds `--headless` flag (and `FULL_LOOP_HEADLESS` env var) to `full-loop-helper.sh` for fully autonomous worker operation
- Supervisor dispatch now passes `--headless` and exports `FULL_LOOP_HEADLESS=true` to all workers
- Adds `git pull --rebase` before push in PR create phase
- Handles `gh auth` failures cleanly in headless mode (exit for supervisor evaluation)

## Changes

| File | Changes |
|------|---------|
| `full-loop-helper.sh` | `--headless` flag, `is_headless()` helper, state persistence, prompt suppression, README gate skip, auth failure handling, pull --rebase before push |
| `supervisor-helper.sh` | `--headless` in dispatch prompt, `FULL_LOOP_HEADLESS=true` env export in nohup command |
| `commands/full-loop.md` | Headless mode documentation, options table, supervisor dispatch notes |

## Context

Worker t174 implemented all these changes autonomously but failed to commit them (asked "Would you like me to commit?" and exited). The supervisor rescued the uncommitted work from the worktree. Ironically, the `--headless` flag this PR adds would have prevented that exact failure.

## Testing

- ShellCheck: zero new violations
- Rebased cleanly onto main (includes auth precheck from PR #640)
- State file persistence tested (headless flag survives resume)