### PR TITLE
fix: pass --non-interactive to setup.sh in aidevops update (t169)

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -553,7 +553,7 @@ cmd_update() {
             if [[ "$repo_version" != "$deployed_version" ]]; then
                 print_warning "Deployed agents ($deployed_version) don't match repo ($repo_version)"
                 print_info "Re-running setup to sync agents..."
-                bash "$INSTALL_DIR/setup.sh"
+                bash "$INSTALL_DIR/setup.sh" --non-interactive
             fi
         else
             print_info "Pulling latest changes..."
@@ -582,7 +582,7 @@ cmd_update() {
                 
                 echo ""
                 print_info "Running setup to apply changes..."
-                bash "$INSTALL_DIR/setup.sh"
+                bash "$INSTALL_DIR/setup.sh" --non-interactive
             else
                 print_error "Failed to pull updates"
                 print_info "Try: cd $INSTALL_DIR && git pull"


### PR DESCRIPTION
## Summary

- Pass `--non-interactive` to `setup.sh` when called from `cmd_update()` in `aidevops.sh`
- Fixes agent deployment being skipped or hanging during `aidevops update` because `setup.sh` would enter its default mode with interactive prompts (tool install offers, etc.)
- The `--non-interactive` path in `setup.sh` runs `deploy_aidevops_agents` plus safe migrations -- exactly what `update` needs

## Changes

Two lines changed in `aidevops.sh`:
- Line 556: stale agent re-sync path now passes `--non-interactive`
- Line 585: post-git-pull path now passes `--non-interactive`

## Testing

- `bash -n aidevops.sh` -- syntax OK
- `shellcheck aidevops.sh` -- zero violations
- Verified `setup.sh --non-interactive` path includes `deploy_aidevops_agents` (line 4280)
- Fresh install path (curl) intentionally left without `--non-interactive` since first-time setup should be interactive

Closes #t169