### PR TITLE
fix: enforce worker TODO.md restriction with multi-layer guards (t173)

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -2574,10 +2574,21 @@ build_dispatch_cmd() {
     # Include task description in the prompt so the worker knows what to do
     # even if TODO.md doesn't have an entry for this task (t158)
     # Always pass --headless for supervisor-dispatched workers (t174)
+    # Inject explicit TODO.md restriction into worker prompt (t173)
     local prompt="/full-loop $task_id --headless"
     if [[ -n "$description" ]]; then
         prompt="/full-loop $task_id --headless -- $description"
     fi
+
+    # t173: Explicit worker restriction — prevents TODO.md race condition
+    prompt="$prompt
+
+## MANDATORY Worker Restrictions (t173)
+- Do NOT edit, commit, or push TODO.md — the supervisor owns all TODO.md updates.
+- Do NOT edit todo/PLANS.md or todo/tasks/* — these are supervisor-managed.
+- Report status via exit code, log output, and PR creation only.
+- Put task notes in commit messages or PR body, never in TODO.md."
+
     if [[ -n "$memory_context" ]]; then
         prompt="$prompt
 


### PR DESCRIPTION
## Summary

- Prevents TODO.md race condition where multiple workers + supervisor push to TODO.md on main simultaneously, causing merge conflicts
- Adds three layers of enforcement: prompt injection, context isolation, and git pre-commit hook
- Fixes ref:GH#564

## Changes

### `supervisor-helper.sh` — Prompt-level guard
- `build_dispatch_cmd()` now injects explicit "DO NOT EDIT TODO.md" restriction into every worker prompt

### `loop-common.sh` — Context-level guard
- Skips TODO.md reads in headless mode (workers never see TODO.md tasks in re-anchor context)
- Adds MANDATORY Worker Restrictions block to re-anchor prompt when `FULL_LOOP_HEADLESS=true`
- Workers only work on their assigned task, not tasks picked from TODO.md

### `full-loop-helper.sh` — Git-level guard
- `install_headless_todo_guard()` installs a pre-commit hook in the worker worktree that rejects any commit containing `TODO.md` or `todo/` changes when `FULL_LOOP_HEADLESS=true`
- `remove_headless_todo_guard()` cleans up the hook on loop cancel/complete
- Guard is installed at `cmd_start()` when `--headless` is active

## Testing

- `bash -n` syntax check: all 3 files pass
- `shellcheck -S error`: zero violations on all 3 files
- `test-smoke-help.sh`: 284 passed, 0 failed
- `test-batch-quality-hardening.sh`: 55/56 passed (1 expected diff: deployed vs repo version)