### PR TITLE
hotfix: use NUL-delimited IPC for dispatch command builder

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -2595,29 +2595,30 @@ build_dispatch_cmd() {
 $memory_context"
     fi
 
+    # Use NUL-delimited output so multi-line prompts stay as single arguments
     if [[ "$ai_cli" == "opencode" ]]; then
-        echo "opencode"
-        echo "run"
-        echo "--format"
-        echo "json"
+        printf '%s\0' "opencode"
+        printf '%s\0' "run"
+        printf '%s\0' "--format"
+        printf '%s\0' "json"
         if [[ -n "$model" ]]; then
-            echo "-m"
-            echo "$model"
+            printf '%s\0' "-m"
+            printf '%s\0' "$model"
         fi
-        echo "--title"
-        echo "$task_id"
-        echo "$prompt"
+        printf '%s\0' "--title"
+        printf '%s\0' "$task_id"
+        printf '%s\0' "$prompt"
     else
         # claude CLI
-        echo "claude"
-        echo "-p"
-        echo "$prompt"
+        printf '%s\0' "claude"
+        printf '%s\0' "-p"
+        printf '%s\0' "$prompt"
         if [[ -n "$model" ]]; then
-            echo "--model"
-            echo "$model"
+            printf '%s\0' "--model"
+            printf '%s\0' "$model"
         fi
-        echo "--output-format"
-        echo "json"
+        printf '%s\0' "--output-format"
+        printf '%s\0' "json"
     fi
 
     return 0
@@ -3101,8 +3102,9 @@ cmd_dispatch() {
     log_info "Log: $log_file"
 
     # Build and execute dispatch command
+    # Use NUL-delimited read to preserve multi-line prompts as single arguments
     local -a cmd_parts=()
-    while IFS= read -r part; do
+    while IFS= read -r -d '' part; do
         cmd_parts+=("$part")
     done < <(build_dispatch_cmd "$task_id" "$worktree_path" "$log_file" "$ai_cli" "$memory_context" "$tmodel" "$tdesc")
 

--- a/TODO.md
+++ b/TODO.md
@@ -127,7 +127,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
   - Notes: PR #642 merged. Added `--headless` flag to full-loop for autonomous worker operation.
 
 - [ ] t175 Fix `ambiguous_skipped_ai` evaluation — add better heuristic signals #bug #supervisor ~1h (ai:40m) ref:GH#644 assignee:marcusquinn started:2026-02-08T19:38:50Z logged:2026-02-08
-  - Notes: Recurring evaluation outcome across batches. Evaluator can't determine success/failure, skips AI eval, defaults to retry. Add heuristics: check for commits on branch, check for uncommitted changes in worktree.
+  - Notes: Recurring evaluation outcome across batches. Evaluator can't determine success/failure, skips AI eval, defaults to retry. Add heuristics: check for commits on branch, check for uncommitted changes in worktree. BLOCKED: Re-prompt dispatch failed: ambiguous_skipped_ai
 
 - [ ] t176 Add uncertainty guidance to worker dispatch prompt #feature #supervisor ~30m (ai:20m) ref:GH#645 assignee:marcusquinn started:2026-02-08T19:38:55Z logged:2026-02-08
   - Notes: Workers don't know when to make autonomous decisions vs flag uncertainty. Add decision framework to dispatch prompt for headless workers.


### PR DESCRIPTION
## Summary

- Fixes the root cause of all supervisor-dispatched workers failing since PR #649 (t173 worker restrictions)
- Multi-line prompts were being split into separate positional arguments instead of staying as one argument
- Workers received malformed commands and exited immediately with help text (EXIT:1)

## Root Cause (deeper than #653)

PR #653 fixed the `bash -c` quoting issue but missed the upstream problem: `build_dispatch_cmd()` outputs arguments via `echo` (newline-delimited), and `cmd_dispatch()` reads them with `while IFS= read -r`. When the prompt contains newlines (from worker restrictions, memory context), `read -r` splits the single prompt argument into multiple array elements.

Example: a prompt like:
```
/full-loop t175 --headless -- Fix bug

## MANDATORY Worker Restrictions
- Do NOT edit TODO.md
```

Was being split into 4 separate arguments instead of 1, causing `opencode run` to misparse the command.

## Fix

- `build_dispatch_cmd()`: Replace `echo` with `printf '%s\0'` (NUL-delimited output)
- `cmd_dispatch()`: Replace `read -r` with `read -r -d ''` (NUL-delimited input)

NUL bytes cannot appear in shell strings, making them the only safe delimiter for arbitrary content including newlines.

## Verification

- Simulated dispatch with multi-line prompt: 7 parts (correct), prompt is single argument with 4 lines
- Generated dispatch script: valid bash syntax, prompt is single `$'...\n...'` quoted argument
- ShellCheck: zero violations
- All 78 supervisor state machine tests pass

## Impact

This unblocks the entire `self-improvement-02` batch (t175-t178, t166) which has been failing since the t173 worker restrictions were added.