### PR TITLE
fix: anchor task ID grep to capture dotted subtask IDs

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -483,7 +483,7 @@ run_pr_create_phase() {
     
     # Build PR title and body from task context (t156/t158)
     local pr_title pr_body task_id_match
-    task_id_match=$(echo "$branch" | grep -oE 't[0-9]+' | head -1 || echo "")
+    task_id_match=$(echo "$branch" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
     
     if [[ -n "$task_id_match" ]]; then
         # Look up task description: TODO.md first, then supervisor DB fallback (t158)

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -681,7 +681,7 @@ cmd_push() {
         # Find all open tasks without GH refs (top-level only, not subtasks)
         while IFS= read -r line; do
             local tid
-            tid=$(echo "$line" | grep -oE 't[0-9]+' | head -1 || echo "")
+            tid=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
             if [[ -n "$tid" ]] && ! echo "$line" | grep -qE 'ref:GH#[0-9]+'; then
                 # Skip subtasks (indented with more than 0 spaces before the dash)
                 if echo "$line" | grep -qE '^- \['; then
@@ -796,7 +796,7 @@ cmd_enrich() {
         # Find all open tasks WITH GH refs
         while IFS= read -r line; do
             local tid
-            tid=$(echo "$line" | grep -oE 't[0-9]+' | head -1 || echo "")
+            tid=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
             if [[ -n "$tid" ]]; then
                 tasks+=("$tid")
             fi
@@ -1071,7 +1071,7 @@ cmd_close() {
     else
         while IFS= read -r line; do
             local tid
-            tid=$(echo "$line" | grep -oE 't[0-9]+' | head -1 || echo "")
+            tid=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
             if [[ -n "$tid" ]]; then
                 tasks+=("$tid")
             fi

--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -184,7 +184,7 @@ validate_todo_completions() {
     local warn_count=0
     while IFS= read -r line; do
         local task_id
-        task_id=$(echo "$line" | grep -oE 't[0-9]+' | head -1 || echo "")
+        task_id=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
         if [[ -z "$task_id" ]]; then
             continue
         fi

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -206,7 +206,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
         # Check if task is claimed by someone else via TODO.md assignee: field (t165)
         # Note: no 'local' — this runs at script top-level, not inside a function
         task_id_from_branch=""
-        task_id_from_branch=$(echo "$current_branch" | grep -oE 't[0-9]+' | head -1 || true)
+        task_id_from_branch=$(echo "$current_branch" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || true)
         if [[ -n "$task_id_from_branch" ]]; then
             project_root=""
             project_root=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")


### PR DESCRIPTION
## Summary

- Fixed `grep -oE 't[0-9]+'` patterns that truncate dotted task IDs (e.g. `t131.vision` extracted as `t131`) across 4 scripts, 6 call sites
- Changed to `t[0-9]+(\.[0-9]+)*` to preserve full subtask identifiers
- Prevents mismatched issue lookups where closing `t131` accidentally targets `t131.vision`

## Root Cause

Discovered when `cmd_close()` in issue-sync-helper.sh matched `t131` from a `t131.vision` line, causing incorrect issue closure (#538). The same unanchored pattern existed in pre-edit-check.sh, pre-commit-hook.sh, and full-loop-helper.sh.

## Files Changed

- `.agents/scripts/issue-sync-helper.sh` (3 sites: cmd_push, cmd_enrich, cmd_close)
- `.agents/scripts/pre-edit-check.sh` (1 site: branch task ID extraction)
- `.agents/scripts/pre-commit-hook.sh` (1 site: TODO.md task validation)
- `.agents/scripts/full-loop-helper.sh` (1 site: PR title from branch)

## Testing

- ShellCheck clean (all 4 files)
- Verified zero remaining `grep -oE 't[0-9]+'` patterns in `.agents/scripts/`