### PR TITLE
t179: Issue-sync reconciliation — close stale issues, fix ref:GH# drift, wire into supervisor pulse

### DIFF
--- a/.agents/workflows/session-review.md
+++ b/.agents/workflows/session-review.md
@@ -117,6 +117,7 @@ Verify aidevops best practices were followed:
 | TODO tracking | Tasks logged in TODO.md | Recommended |
 | Commit hygiene | Atomic commits, clear messages | Required |
 | Quality checks | Linters run before commit | Recommended |
+| Issue-sync | `issue-sync-helper.sh status` after PR merge | Recommended |
 | Documentation | Changes documented where needed | Situational |
 
 **Check commands**:
@@ -294,6 +295,7 @@ Run `/session-review` before creating a PR to ensure:
 Run `/session-review` to:
 - Capture learnings via `@agent-review`
 - Update TODO.md with any discovered tasks
+- Check issue-sync drift: `issue-sync-helper.sh status` (t179.4)
 - Ensure clean handoff for future sessions
 
 ### After Ralph Loop Completion

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -21,6 +21,7 @@ on:
           - pull
           - push
           - close
+          - reconcile
           - enrich
 
 concurrency:


### PR DESCRIPTION
## Summary

- **t179.1**: `cmd_close()` fallback — searches by task ID in issue title when `ref:GH#` is missing or stale, auto-fixes mismatched refs in TODO.md
- **t179.2**: New `reconcile` command — scans all `ref:GH#` values, verifies each matches the correct issue, fixes mismatches, reports stale/orphan issues
- **t179.3**: Supervisor pulse Phase 8 — runs `reconcile` + `close` periodically (~50 min) when no workers active, throttled via timestamp file
- **t179.4**: Session-review integration — added issue-sync drift check to workflow adherence and recommendations

## Problem

12 GitHub issues were open for completed tasks because `ref:GH#` values in TODO.md didn't match actual issue numbers (issues recreated with new numbers by push command). The GHA workflow runs `close` on push but uses `ref:GH#` for lookup, missing the mismatched issues.

## Verification

Dry-run of `reconcile` found real drift in the repo:
- 8 mismatched refs (e.g., t171 had `ref:GH#580` which belongs to t161, correct issue is #632)
- 1 stale open issue (t131 completed but GH#538 still open)
- 1 orphan issue (t068.8 has no TODO.md entry)

All 3 modified scripts pass ShellCheck with zero errors at `-S error` level.

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/issue-sync-helper.sh` | `fix_gh_ref_in_todo()`, enhanced `cmd_close()` with fallback, new `cmd_reconcile()` |
| `.agents/scripts/supervisor-helper.sh` | Phase 8 in `cmd_pulse()` — periodic issue-sync |
| `.agents/scripts/session-review-helper.sh` | Issue-sync drift check in workflow adherence |
| `.agents/workflows/session-review.md` | Added issue-sync to checklist |
| `.github/workflows/issue-sync.yml` | Added `reconcile` to workflow dispatch options |