### PR TITLE
feat: worktree ownership safety — prevent cross-session removal (t189)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -166,7 +166,7 @@ worktree-helper.sh add feature/x  # Fallback
 
 **Branch types**: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
 
-**Worktree ownership** (CRITICAL): NEVER remove a worktree unless (a) you created it in this session, (b) it belongs to a task in your active batch, AND the task is deployed/complete, or (c) the user explicitly asks. Worktrees may belong to parallel sessions — removing them destroys another agent's working directory mid-work. When cleaning up, only touch worktrees for tasks you personally merged. Use `git worktree list` to see all worktrees but do NOT assume unrecognized ones are safe to remove.
+**Worktree ownership** (CRITICAL): NEVER remove a worktree unless (a) you created it in this session, (b) it belongs to a task in your active batch, AND the task is deployed/complete, or (c) the user explicitly asks. Worktrees may belong to parallel sessions — removing them destroys another agent's working directory mid-work. When cleaning up, only touch worktrees for tasks you personally merged. Use `git worktree list` to see all worktrees but do NOT assume unrecognized ones are safe to remove. The ownership registry (`worktree-helper.sh registry list`) tracks which PID owns each worktree — `remove` and `clean` commands automatically refuse to touch worktrees owned by other live processes.
 
 **Safety hooks** (Claude Code only): Destructive commands (`git reset --hard`, `rm -rf`, etc.) are blocked by a PreToolUse hook. Run `install-hooks.sh --test` to verify. See `workflows/git-workflow.md` "Destructive Command Safety Hooks" section.
 

--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -382,7 +382,33 @@ git worktree remove --force ~/Git/myrepo-feature-old
 git branch -D feature/old
 ```
 
-### 4. Don't Checkout Same Branch in Multiple Worktrees
+### 4. Ownership Safety (t189)
+
+Worktrees are registered to the creating session's PID in a SQLite registry. This prevents cross-session worktree removal — the root cause of disrupted parallel sessions.
+
+**How it works**:
+
+- `worktree-helper.sh add` and `supervisor-helper.sh dispatch` register ownership
+- `worktree-helper.sh remove` and `clean` refuse to touch worktrees owned by other live processes
+- `supervisor-helper.sh cleanup` skips worktrees owned by other sessions
+- Stale entries (dead PIDs, missing directories) are auto-pruned
+
+**Commands**:
+
+```bash
+# View the ownership registry
+worktree-helper.sh registry list
+
+# Prune stale entries (dead PIDs, missing directories)
+worktree-helper.sh registry prune
+
+# Force remove despite ownership (use with caution)
+worktree-helper.sh remove feature/branch --force
+```
+
+**Registry location**: `~/.aidevops/.agent-workspace/worktree-registry.db`
+
+### 5. Don't Checkout Same Branch in Multiple Worktrees
 
 Git prevents this - each branch can only be checked out in one worktree:
 


### PR DESCRIPTION
## Summary

- Adds SQLite-backed worktree ownership registry that tracks which PID owns each worktree
- `worktree-helper.sh remove` and `clean` refuse to touch worktrees owned by other live processes
- `supervisor-helper.sh` registers ownership on dispatch and checks before cleanup
- Prevents the root cause from 2026-02-09: supervisor force-removed a worktree belonging to a parallel interactive session

## Changes

### shared-constants.sh (+170 lines)
- `_wt_sql_escape()` — SQL escape helper
- `register_worktree()` — register PID ownership with optional task/batch/session metadata
- `unregister_worktree()` — remove ownership entry
- `check_worktree_owner()` — query owner info
- `is_worktree_owned_by_others()` — returns 0 if owned by another live PID
- `prune_worktree_registry()` — clean stale entries (dead PIDs, missing dirs)

### worktree-helper.sh (+135 lines)
- `cmd_add` registers ownership on creation
- `cmd_remove` checks ownership before removal, supports `--force` override
- `cmd_clean` skips worktrees owned by other active sessions
- New `cmd_registry` command (`list`/`prune` subcommands)

### supervisor-helper.sh (+37 lines)
- `create_task_worktree` registers ownership with `--task` metadata
- `create_task_worktree` refuses to clean stale worktrees owned by others
- `cleanup_task_worktree` checks ownership before removal, unregisters after
- `cmd_cleanup` prunes stale registry entries

### AGENTS.md
- Updated worktree ownership rule with registry reference

### worktree.md
- Added "Ownership Safety (t189)" section with commands and explanation

## Testing

- All 295 smoke tests pass (0 failures)
- ShellCheck zero new violations
- Functional test: register → check → is_owned_by_others → unregister → prune all work correctly
- Pre-existing test failures in dispatch-worktree-evaluate unchanged (11 vs 12 on base)

## Subtasks

- [x] t189.1 Add worktree ownership registry
- [x] t189.2 Add "in use" detection to worktree cleanup
- [x] t189.3 Add AGENTS.md rule (already existed, enhanced with registry ref)
- [x] t189.4 Scope batch cleanup to batch-owned worktrees only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added worktree ownership registry to prevent accidental removal by other sessions; ownership is automatically tracked on creation and enforced during cleanup operations.
  * New registry command to view and prune ownership records with process status checks.
  * Added `--force` flag to override ownership checks when needed.

* **Documentation**
  * Updated worktree safety documentation with ownership registry details and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->