### PR TITLE
feat: compaction-resilient session state (t187)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -206,6 +206,22 @@ Run `/session-review` before ending. Suggest new sessions after PR merge, domain
 
 **Full docs**: `workflows/session-manager.md`
 
+## Context Compaction Resilience
+
+When context is compacted (long sessions, autonomous loops), operational state is lost unless persisted to disk. Use `/checkpoint` to save and restore session state.
+
+**Commands**:
+
+- `/checkpoint` or `session-checkpoint-helper.sh save --task <id> --next <ids>` — save current state
+- `session-checkpoint-helper.sh load` — reload state after compaction
+- `session-checkpoint-helper.sh continuation` — generate a full continuation prompt for new sessions
+
+**When to checkpoint**: After each task completion, before large operations, after PR creation/merge.
+
+**Compaction survival rule**: When summarizing this conversation for compaction, ALWAYS preserve: current task IDs and states, active batch ID, worktree path, open PR numbers, and the next 3 action items. This operational state is more important than conversation history details.
+
+**Full docs**: `workflows/session-manager.md` "Compaction Resilience" section
+
 ## Agents & Subagents
 
 See `subagent-index.toon` for complete listing of agents, subagents, workflows, and scripts.

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -116,6 +116,19 @@ claiming Docker image versions don't exist, flagging correct file paths as wrong
 suggesting fixes that break working code. Always verify factual claims against runtime,
 documentation, or project conventions before acting on them.
 
+# Context Compaction Survival
+# When summarizing this conversation for context compaction, ALWAYS preserve:
+# 1. Current task ID(s) and their states (e.g., "working on t187.2, t187.1 done")
+# 2. Active batch ID (if any) and its concurrency/status
+# 3. Active worktree path and branch name
+# 4. Open PR numbers and their states
+# 5. The next 3 action items in priority order
+# 6. Any blocking issues or decisions pending user input
+# 7. Key file paths being modified in this session
+# This operational state is MORE important than conversation history details.
+# Without it, the agent can operate the framework but doesn't know what to work on.
+# If a checkpoint file exists, reference: ~/.aidevops/.agent-workspace/tmp/session-checkpoint.md
+
 # Model-Specific Reinforcements
 These apply to all models but reinforce behaviours some need more than others:
 - NEVER end your turn without completing the task. Keep working until fully resolved.

--- a/.agents/scripts/session-checkpoint-helper.sh
+++ b/.agents/scripts/session-checkpoint-helper.sh
@@ -8,6 +8,8 @@
 # Commands:
 #   save              Save current session checkpoint
 #   load              Load and display current checkpoint
+#   continuation      Generate structured continuation prompt for new sessions
+#   auto-save         Auto-detect state and save (no manual flags needed)
 #   clear             Remove checkpoint file
 #   status            Show checkpoint age and summary
 #   help              Show this help
@@ -190,6 +192,165 @@ cmd_status() {
     return 0
 }
 
+cmd_continuation() {
+    # Generate a structured continuation prompt that can be fed to a new session
+    # to fully reconstruct operational state. This is the single highest-impact
+    # factor for session continuity through context compaction.
+
+    local repo_root
+    repo_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "unknown")"
+    local branch
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
+    local repo_name
+    repo_name="$(basename "$repo_root")"
+
+    # Gather git state
+    local uncommitted
+    uncommitted="$(git status --short 2>/dev/null || echo "")"
+    local recent_commits
+    recent_commits="$(git log --oneline -5 2>/dev/null || echo "none")"
+    local worktrees
+    worktrees="$(git worktree list 2>/dev/null || echo "none")"
+
+    # Gather open PRs for this branch
+    local open_prs
+    open_prs="$(gh pr list --state open --json number,title,headRefName --jq '.[] | "#\(.number) [\(.headRefName)] \(.title)"' 2>/dev/null || echo "none")"
+
+    # Gather supervisor batch state (if supervisor DB exists)
+    local batch_state="none"
+    local supervisor_helper="${SCRIPT_DIR}/supervisor-helper.sh"
+    if [[ -x "$supervisor_helper" ]]; then
+        batch_state="$(bash "$supervisor_helper" list --active 2>/dev/null || echo "none")"
+    fi
+
+    # Gather TODO.md in-progress tasks
+    local todo_tasks="none"
+    local todo_file
+    for todo_file in "${repo_root}/TODO.md" "$(pwd)/TODO.md"; do
+        if [[ -f "$todo_file" ]]; then
+            todo_tasks="$(grep -E '^\s*- \[ \] ' "$todo_file" 2>/dev/null | head -10 || echo "none")"
+            break
+        fi
+    done
+
+    # Load existing checkpoint note if available
+    local checkpoint_note="none"
+    if [[ -f "$CHECKPOINT_FILE" ]]; then
+        checkpoint_note="$(awk '/^## Context Note$/,/^## /' "$CHECKPOINT_FILE" | sed '1d;/^## /d' | sed '/^$/d' || echo "none")"
+    fi
+
+    # Gather memory recall for recent session context
+    local recent_memories="none"
+    local memory_helper="${SCRIPT_DIR}/memory-helper.sh"
+    if [[ -x "$memory_helper" ]]; then
+        recent_memories="$(bash "$memory_helper" recall --recent --limit 3 2>/dev/null || echo "none")"
+    fi
+
+    # Output the continuation prompt
+    cat <<CONTINUATION_EOF
+## Session Continuation Prompt
+
+**Generated**: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+**Repository**: ${repo_name} (${repo_root})
+**Branch**: ${branch}
+
+### Operational State
+
+**Active tasks (from TODO.md)**:
+${todo_tasks}
+
+**Supervisor batch state**:
+${batch_state}
+
+**Open PRs**:
+${open_prs}
+
+### Git State
+
+**Uncommitted changes**:
+${uncommitted:-clean working tree}
+
+**Recent commits**:
+${recent_commits}
+
+**Active worktrees**:
+${worktrees}
+
+### Context
+
+**Last checkpoint note**:
+${checkpoint_note}
+
+**Recent memories**:
+${recent_memories}
+
+### Instructions
+
+Resume work from the state above. Read TODO.md for the full task list.
+Run \`session-checkpoint-helper.sh load\` for the last checkpoint.
+Run \`pre-edit-check.sh\` before any file modifications.
+CONTINUATION_EOF
+
+    # Note: output goes to stdout for piping/capture. Status messages go to stderr.
+    print_success "Continuation prompt generated" >&2
+    return 0
+}
+
+cmd_auto_save() {
+    # Auto-detect state and save checkpoint without requiring manual flags.
+    # Designed for use in autonomous loops where the agent calls this after
+    # each task completion without needing to know the exact flags.
+
+    local current_task=""
+    local next_tasks=""
+    local note=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --task) [[ $# -lt 2 ]] && { print_error "--task requires a value"; return 1; }; current_task="$2"; shift 2 ;;
+            --next) [[ $# -lt 2 ]] && { print_error "--next requires a value"; return 1; }; next_tasks="$2"; shift 2 ;;
+            --note) [[ $# -lt 2 ]] && { print_error "--note requires a value"; return 1; }; note="$2"; shift 2 ;;
+            *) print_error "Unknown option: $1"; return 1 ;;
+        esac
+    done
+
+    # Auto-detect branch and worktree
+    local branch
+    branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
+    local worktree
+    worktree="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+    # Auto-detect batch from supervisor if not provided
+    local batch=""
+    local supervisor_helper="${SCRIPT_DIR}/supervisor-helper.sh"
+    if [[ -x "$supervisor_helper" ]]; then
+        batch="$(bash "$supervisor_helper" list --active --format=id 2>/dev/null | head -1 || echo "")"
+    fi
+
+    # Auto-detect next tasks from TODO.md if not provided
+    if [[ -z "$next_tasks" ]]; then
+        local todo_file
+        for todo_file in "$(pwd)/TODO.md" "${worktree}/TODO.md"; do
+            if [[ -f "$todo_file" ]]; then
+                next_tasks="$(grep -E '^\s*- \[ \] t[0-9]' "$todo_file" 2>/dev/null | head -3 | sed 's/.*\(t[0-9][0-9]*[^ ]*\).*/\1/' | tr '\n' ',' | sed 's/,$//' || echo "")"
+                break
+            fi
+        done
+    fi
+
+    # Build save command args
+    local -a save_args=()
+    [[ -n "$current_task" ]] && save_args+=(--task "$current_task")
+    [[ -n "$next_tasks" ]] && save_args+=(--next "$next_tasks")
+    [[ -n "$worktree" ]] && save_args+=(--worktree "$worktree")
+    [[ -n "$branch" ]] && save_args+=(--branch "$branch")
+    [[ -n "$batch" ]] && save_args+=(--batch "$batch")
+    [[ -n "$note" ]] && save_args+=(--note "$note")
+
+    cmd_save "${save_args[@]}"
+    return $?
+}
+
 cmd_help() {
     # Extract header comment block as help text
     sed -n '2,/^$/p' "$0" | sed 's/^# \?//'
@@ -202,10 +363,12 @@ main() {
     shift 2>/dev/null || true
 
     case "$command" in
-        save)    cmd_save "$@" ;;
-        load)    cmd_load ;;
-        clear)   cmd_clear ;;
-        status)  cmd_status ;;
+        save)         cmd_save "$@" ;;
+        load)         cmd_load ;;
+        continuation) cmd_continuation ;;
+        auto-save)    cmd_auto_save "$@" ;;
+        clear)        cmd_clear ;;
+        status)       cmd_status ;;
         help|-h|--help) cmd_help ;;
         *)
             print_error "Unknown command: ${command}"

--- a/.agents/workflows/session-manager.md
+++ b/.agents/workflows/session-manager.md
@@ -291,7 +291,30 @@ This ensures the agent always has current state even if context was compacted be
 
 ### Continuation Prompt Generation
 
-If a session must be resumed manually (new conversation), the checkpoint file at `~/.aidevops/.agent-workspace/tmp/session-checkpoint.md` contains enough state to generate a continuation prompt. The user can paste it or the agent can read it on startup.
+Generate a structured continuation prompt that captures all operational state:
+
+```bash
+# Generate and display continuation prompt (for pasting into new session):
+session-checkpoint-helper.sh continuation
+
+# Auto-save checkpoint with state auto-detection (no manual flags):
+session-checkpoint-helper.sh auto-save --task "t135.9" --note "Completed X"
+
+# Include operational state in session distillation:
+session-distill-helper.sh auto    # Now includes checkpoint step
+session-distill-helper.sh checkpoint  # Just the operational state
+```
+
+The continuation prompt gathers state from multiple sources:
+
+- **Git**: branch, uncommitted changes, recent commits, worktrees
+- **GitHub**: open PRs for the repo
+- **Supervisor**: active batch state
+- **TODO.md**: in-progress tasks
+- **Checkpoint file**: last saved context note
+- **Memory**: recent session memories
+
+This is the single highest-impact factor for session continuity. AGENTS.md provides the "how" (conventions, tools), but the continuation prompt provides the "where we are" (task states, batch IDs, next steps).
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Add structured continuation prompt generation (`session-checkpoint-helper.sh continuation`) that captures all operational state (git, supervisor, PRs, TODO tasks, memories) into a single prompt for session recovery after context compaction
- Add compaction survival instruction to `build.txt` ensuring critical operational state (task IDs, batch ID, worktree path, PRs, next actions) is preserved through LLM context summaries
- Enhance `session-distill-helper.sh` to include operational state capture in the `auto` pipeline, complementing learnings (what we learned) with state (where we are)

## Changes

| File | Change |
|------|--------|
| `.agents/prompts/build.txt` | Add "Context Compaction Survival" instruction block |
| `.agents/AGENTS.md` | Add "Context Compaction Resilience" section |
| `.agents/scripts/session-checkpoint-helper.sh` | Add `continuation` and `auto-save` commands |
| `.agents/scripts/session-distill-helper.sh` | Add `checkpoint` command, integrate into `auto` pipeline |
| `.agents/workflows/session-manager.md` | Document continuation prompt generation workflow |

## Context

Lesson from 2026-02-09 session: the continuation prompt was the single biggest factor in surviving compaction. AGENTS.md provides the "how" (conventions, tools), but the continuation prompt provides the "where we are" (task states, batch IDs, next steps). Without it, the agent can operate the framework but doesn't know what to work on.

## Testing

- `session-checkpoint-helper.sh continuation` — generates full state dump
- `session-checkpoint-helper.sh auto-save --task t187` — auto-detects and saves
- `session-distill-helper.sh checkpoint` — captures operational state
- `session-distill-helper.sh auto` — now includes checkpoint step
- ShellCheck: zero new violations (SC2034 DIM unused is pre-existing)

Closes #686