### PR TITLE
fix: add spinner to MCP package installs for visible progress

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3226,7 +3226,8 @@ install_mcp_packages() {
     local failed=0
     local pkg
     for pkg in "${node_mcps[@]}"; do
-        if npm_global_install "${pkg}@latest" > /dev/null 2>&1; then
+        local short_name="${pkg##*/}"  # Strip @scope/ prefix for display
+        if run_with_spinner "Installing $short_name" npm_global_install "${pkg}@latest"; then
             ((updated++)) || true
         else
             ((failed++)) || true


### PR DESCRIPTION
## Summary

- Wraps each `npm_global_install` call in the MCP packages loop with `run_with_spinner` so users see a spinner and package name during install instead of silent waiting
- Strips `@scope/` prefix from package names for cleaner display (e.g., "Installing context7-mcp" instead of "Installing @anthropic/context7-mcp")

### Before
```
[INFO] Using npm to install/update Node.js MCP packages...
                                    <-- silence for 1-2 minutes -->
[SUCCESS] 8 Node.js MCP packages installed/updated
```

### After
```
[INFO] Using npm to install/update Node.js MCP packages...
[INFO] Installing context7-mcp ⠹    <-- spinner with package name -->
[SUCCESS] Installing context7-mcp done
[INFO] Installing osgrep ⠼
...
```