### PR TITLE
fix(memory): add blank lines before category headings in graduation output (MD022)

### DIFF
--- a/.agents/aidevops/graduated-learnings.md
+++ b/.agents/aidevops/graduated-learnings.md
@@ -40,6 +40,7 @@ candidates and appends them here. Each graduation batch is timestamped.
 
 - **[FAILURE_PATTERN]** [task:refactor] Haiku missed edge cases when refactoring complex shell scripts with many conditionals [model:haiku]
   *(confidence: high, validated: 3x)*
+
 ### Architecture Decisions
 
 - **[ARCHITECTURAL_DECISION]** YAML handoffs are more token-efficient than markdown (~400 vs ~2000 tokens)
@@ -50,10 +51,12 @@ candidates and appends them here. Each graduation batch is timestamped.
 
 - **[DECISION]** Agent lifecycle uses three tiers: draft/ (R&D, orchestration-created), custom/ (private, permanent), shared (.agents/ via PR). Both draft/ and custom/ survive setup.sh deployments. Orchestration agents (Build+, Ralph loop, runners) know they can create drafts for reusable parallel processing context and propose them for inclusion in aidevops.
   *(confidence: medium, validated: 3x)*
+
 ### Configuration & Preferences
 
 - **[USER_PREFERENCE]** Prefer conventional commits with scope: feat(memory): description
   *(confidence: medium, validated: 4x)*
+
 ### Patterns & Best Practices
 
 - **[SUCCESS_PATTERN]** [task:feature] Breaking task into 4 phases with separate commits worked well for Claude-Flow feature adoption [model:sonnet]
@@ -64,4 +67,3 @@ candidates and appends them here. Each graduation batch is timestamped.
 
 - **[CODEBASE_PATTERN]** Memory daemon should auto-extract learnings from thinking blocks when sessions end
   *(confidence: medium, validated: 5x)*
-

--- a/.agents/scripts/memory-graduate-helper.sh
+++ b/.agents/scripts/memory-graduate-helper.sh
@@ -408,11 +408,20 @@ EOF
 
 "
 
+    local first_category=true
     for entries_file in "$tmp_dir"/*.entries; do
         [[ -f "$entries_file" ]] || continue
         local base_name cat_name
         base_name=$(basename "$entries_file" .entries)
         cat_name=$(cat "$tmp_dir/${base_name}.name" 2>/dev/null || echo "$base_name")
+        # Add blank line before heading (MD022) - skip for first category
+        # (already has blank line from ## Graduated header above)
+        if [[ "$first_category" == true ]]; then
+            first_category=false
+        else
+            new_content+="
+"
+        fi
         new_content+="### $cat_name
 
 "


### PR DESCRIPTION
## Summary

- Fix 3 Codacy MD022 violations (missing blank line before `###` headings) in `graduated-learnings.md`
- Fix root cause in `memory-graduate-helper.sh`: bash `$(cat file)` strips trailing newlines, leaving insufficient spacing between category sections
- Remove trailing blank line (MD012)

## Root Cause

The graduation script builds markdown content by concatenating category entries from temp files:

```bash
new_content+=$(cat "$entries_file")   # $(…) strips trailing newlines
new_content+="### $cat_name           # heading follows immediately
```

This produces `entry\n### Heading` instead of `entry\n\n### Heading`.

## Fix

- Add `first_category` flag to insert a blank line before 2nd+ category headings
- Fix the existing `graduated-learnings.md` output
- Verified: `markdownlint` passes clean on both files

Closes #t190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated learning patterns documentation with a new success pattern for race condition identification.

* **Chores**
  * Improved internal script formatting to better organize category headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->