### PR TITLE
fix: remove --agent Onboarding flag from opencode launch

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -4840,23 +4840,12 @@ echo "  aidevops uninstall    - Remove aidevops"
         read -r -p "Launch OpenCode with /onboarding now? [Y/n]: " launch_onboarding
         if [[ "$launch_onboarding" =~ ^[Yy]?$ || "$launch_onboarding" == "Y" ]]; then
             echo ""
-            echo "Starting OpenCode with Onboarding agent..."
-            # Detect available auth provider and select appropriate model
-            # Prefer Anthropic (Claude) > Google (Gemini)
-            local onboarding_model=""
-            local auth_file="$HOME/.local/share/opencode/auth.json"
-            if [[ -f "$auth_file" ]]; then
-                if jq -e '.anthropic' "$auth_file" &>/dev/null; then
-                    onboarding_model="anthropic/claude-sonnet-4-5"
-                elif jq -e '.google' "$auth_file" &>/dev/null; then
-                    onboarding_model="google/gemini-2.5-flash"
-                fi
-            fi
-            local opencode_args=("--agent" "Onboarding" "--prompt" "/onboarding")
-            if [[ -n "$onboarding_model" ]]; then
-                opencode_args+=("--model" "$onboarding_model")
-            fi
-            opencode "${opencode_args[@]}"
+            echo "Starting OpenCode with onboarding wizard..."
+            # Launch with /onboarding prompt only — don't use --agent flag because
+            # the "Onboarding" agent only exists after generate-opencode-agents.sh
+            # writes to opencode.json, which requires opencode.json to already exist.
+            # On first run it won't, so --agent "Onboarding" causes a fatal error.
+            opencode --prompt "/onboarding"
         else
             echo ""
             echo "You can run /onboarding anytime in OpenCode to configure services."


### PR DESCRIPTION
## Summary

Fixes `Agent not found: "Onboarding"` error on first-run opencode launch after setup.

### Root cause

`setup.sh` launched opencode with `--agent "Onboarding" --prompt "/onboarding"`. The "Onboarding" agent only exists after `generate-opencode-agents.sh` writes it into `opencode.json`. But on first run, `opencode.json` doesn't exist yet (it's created on first `opencode` launch), so the agent generator skips agent config. Result: fatal error.

### Fix

Use `opencode --prompt "/onboarding"` only. The `/onboarding` command file exists (created by `generate-opencode-commands.sh` which doesn't need `opencode.json`) and works with whatever default agent is active. Also removes the model detection logic which depended on auth state — OpenCode picks its own default model.