### PR TITLE
chore(docs): auto-fix markdownlint violations (MD012, MD022, MD031, MD038)

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -382,5 +382,3 @@ Communicate clearly and concisely in a casual, friendly yet professional tone:
 - Re-read a file to refresh context before a second edit, or if you suspect another tool (e.g. Bash) has modified it.
 - If content has not changed since your last read, do NOT re-read it.
 - Use internal memory and previous context to avoid redundant reads.
-
-

--- a/.agents/plan-plus.md
+++ b/.agents/plan-plus.md
@@ -335,5 +335,3 @@ Focus on:
 - **Build+**: Execute plans with full file/bash permissions
 - **AI-DevOps**: Infrastructure and deployment planning
 - **Research**: Deep investigation and documentation
-
-

--- a/.agents/research.md
+++ b/.agents/research.md
@@ -81,5 +81,3 @@ Structure findings as:
 - Next steps
 
 Research informs implementation but doesn't perform it.
-
-

--- a/.agents/scripts/commands/runners-check.md
+++ b/.agents/scripts/commands/runners-check.md
@@ -33,10 +33,12 @@ git worktree list 2>/dev/null
 Present results as a concise dashboard:
 
 ### Batch Status
+
 - Batch name, total/completed/queued/running/failed counts
 - Any tasks stuck in retrying or evaluating for >10 minutes
 
 ### Action Items
+
 Flag these for the user (most important first):
 1. **PRs ready to merge** — all CI green, no review comments
 2. **PRs with CI failures** — need investigation
@@ -45,6 +47,7 @@ Flag these for the user (most important first):
 5. **Stale worktrees** — for tasks already deployed/merged
 
 ### System Health
+
 - Load, memory, worker count
 - Cron pulse status: `~/.aidevops/agents/scripts/supervisor-helper.sh cron status 2>&1`
 

--- a/.agents/seo/bing-webmaster-tools.md
+++ b/.agents/seo/bing-webmaster-tools.md
@@ -42,6 +42,7 @@ export BING_API_KEY="your_api_key_here"
 ```
 
 Reload the environment:
+
 ```bash
 source ~/.config/aidevops/credentials.sh
 ```
@@ -131,18 +132,22 @@ curl -s -G "https://ssl.bing.com/webmaster/api.svc/json/GetFeedStats" \
 ## Troubleshooting
 
 ### HTTP 400 Bad Request
+
 - Check JSON syntax in request body
 - Verify `siteUrl` matches exactly what is registered in Bing Webmaster Tools (including http/https and www/non-www)
 
 ### HTTP 401 Unauthorized
+
 - Verify `BING_API_KEY` is correct
 - Ensure the API key has not been revoked
 
 ### HTTP 500 Internal Server Error
+
 - Retry the request
 - Check Bing Webmaster Tools status
 
 ### Quota Limits
+
 - **SubmitUrl**: 10,000 URLs per day per site
 - **Crawl Rate**: Dependent on site authority and history
 

--- a/.agents/seo/screaming-frog.md
+++ b/.agents/seo/screaming-frog.md
@@ -34,12 +34,15 @@ tools:
 ## Setup
 
 ### macOS Alias
+
 Add to `~/.zshrc` or `~/.bashrc`:
+
 ```bash
 alias screamingfrogseospider="/Applications/Screaming\ Frog\ SEO\ Spider.app/Contents/MacOS/ScreamingFrogSEOSpiderLauncher"
 ```
 
 ### Verification
+
 ```bash
 screamingfrogseospider --help
 ```
@@ -47,15 +50,18 @@ screamingfrogseospider --help
 ## Usage
 
 ### Basic Crawl
+
 ```bash
 screamingfrogseospider --crawl https://example.com --headless --output-folder ./reports
 ```
 
 ### Configuration
+
 - **Save Config**: Configure in GUI, save as `profile.seospiderconfig`
 - **Load Config**: Use `--config profile.seospiderconfig`
 
 ### Export Options
+
 - `--export-tabs "Internal:All,Response Codes:All"`
 - `--save-crawl` (saves .seospider file)
 - `--bulk-export "All Inlinks"`

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -1061,5 +1061,3 @@ Monitor your API usage for cache hit rates. High cache hits indicate:
 ### Reviewing Existing Agents
 
 See `build-agent/agent-review.md` for systematic review sessions. It covers instruction budgets, universal applicability, duplicates, code examples, AI-CONTEXT blocks, stale content, and MCP configuration.
-
-

--- a/.agents/tools/build-mcp/build-mcp.md
+++ b/.agents/tools/build-mcp/build-mcp.md
@@ -207,5 +207,3 @@ Use Context7 MCP for current documentation:
 - MCP SDK: `resolve library-id for @modelcontextprotocol/sdk`
 - ElysiaJS: `resolve library-id for elysia`
 - Bun: `resolve library-id for bun`
-
-

--- a/.agents/tools/wordpress.md
+++ b/.agents/tools/wordpress.md
@@ -68,5 +68,3 @@ MainWP provides centralized WordPress management:
 - Backup, Staging, Development tools
 
 Always prefer curated plugins for reliability.
-
-

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -820,7 +820,7 @@ gh issue create --title "t146: bug: supervisor no_pr retry counter non-functiona
 ### When Creating Both Together
 
 1. Assign the next available t-number
-2. Create the GitHub issue with `t{NNN}: ` prefix in the title
+2. Create the GitHub issue with `t{NNN}:` prefix in the title
 3. Add the task to TODO.md with `ref:GH#{issue_number}`
 4. Commit and push TODO.md immediately
 
@@ -829,7 +829,7 @@ gh issue create --title "t146: bug: supervisor no_pr retry counter non-functiona
 The supervisor's `update_todo_on_complete()` and `send_task_notification()` functions should maintain this sync. When the supervisor creates issues or updates TODO.md, it must:
 
 1. Check if a matching GitHub issue exists (search by `t{NNN}` in title)
-2. If not, create one with the `t{NNN}: ` prefix
+2. If not, create one with the `t{NNN}:` prefix
 3. If the TODO.md task lacks `ref:GH#`, add it after issue creation
 4. When closing a task, close the matching GitHub issue with a comment
 

--- a/.agents/workflows/pr.md
+++ b/.agents/workflows/pr.md
@@ -550,6 +550,7 @@ Contradictory feedback patterns:
 ### Resolution Process
 
 1. **Verify actual behavior**: Test the code to confirm what works
+
    ```bash
    # Example: Verify application name works in AppleScript
    osascript -e 'tell application "iTerm" to get name'


### PR DESCRIPTION
## Summary

- Run `markdownlint --fix` on all `.agents/**/*.md` files
- Fixes 31 auto-fixable violations across 11 files

## Fixes by rule

| Rule | Count | Description |
|------|-------|-------------|
| MD012 | 6 | Multiple consecutive blank lines |
| MD022 | 12 | Missing blank lines around headings |
| MD031 | 5 | Missing blank lines around fenced code blocks |
| MD038 | 2 | Spaces inside code spans |

## Remaining (non-auto-fixable)

263 violations remain, mostly in imported skill files:
- MD040 (216): code blocks without language specifier
- MD025 (37): multiple H1 headings
- MD055 (8): table pipe style
- MD033 (2): inline HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced troubleshooting guides with additional error scenarios and resolution steps.
  * Expanded workflow examples, including macOS-specific usage guidance and AppleScript implementations.
  * Improved dashboard documentation with additional metrics and action items descriptions.

* **Style**
  * Cleaned up formatting across documentation files by removing excess whitespace and adjusting spacing in workflow prefixes for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->