### PR TITLE
fix: remove agent: Onboarding from /onboarding command frontmatter

### DIFF
--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -1015,7 +1015,6 @@ echo -e "  ${GREEN}✓${NC} Created /webmaster-keywords command"
 cat > "$OPENCODE_COMMAND_DIR/onboarding.md" << 'EOF'
 ---
 description: Interactive onboarding wizard - discover services, configure integrations
-agent: Onboarding
 ---
 
 Read ~/.aidevops/agents/aidevops/onboarding.md and follow its instructions.


### PR DESCRIPTION
## Summary

- Removes `agent: Onboarding` from the `/onboarding` command YAML frontmatter in `generate-opencode-commands.sh`
- On fresh installs, the Onboarding agent doesn't exist yet (it's created by `generate-opencode-agents.sh` which writes to `opencode.json`), causing "Agent not found" errors when OpenCode processes the `/onboarding` command
- The command now runs on the current default agent (Build+), which is always available

## Root Cause

The `/onboarding` command file written to `~/.config/opencode/command/onboarding.md` contained:

```yaml
---
description: Interactive onboarding wizard
agent: Onboarding
---
```

When OpenCode reads this frontmatter, it tries to switch to the "Onboarding" agent — which only exists after `generate-opencode-agents.sh` has run and written agent config into `opencode.json`. On first run, that file doesn't exist.

## Related PRs

- #698 — Decoupled OpenCode commands from config guard
- #702 — Removed auth gate from onboarding launch
- #704 — Removed `--agent "Onboarding"` flag from opencode launch command
- This PR fixes the **third and final layer** where the Onboarding agent was referenced

## Testing

- ShellCheck clean (no new violations)
- VM self-test: `bash tests/test-vm-setup.sh --branch bugfix/onboarding-command-agent-frontmatter`