### PR TITLE
feat: add tools/vision/ category for visual AI models (t131)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -269,6 +269,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | WordPress | `tools/wordpress/wp-dev.md`, `tools/wordpress/mainwp.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |
 | Video | `tools/video/video-prompt-design.md`, `tools/video/remotion.md`, `tools/video/higgsfield.md` |
+| Vision | `tools/vision/overview.md` (decision tree, then `image-generation.md`, `image-understanding.md`, `image-editing.md`) |
 | Voice | `tools/voice/speech-to-speech.md`, `voice-helper.sh talk` (voice bridge) |
 | Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting) |
 | Cloud GPU | `tools/infrastructure/cloud-gpu.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -22,7 +22,7 @@ flash,gemini-2.5-flash,Fast cheap large context
 pro,gemini-2.5-pro,Capable large context
 -->
 
-<!--TOON:subagents[40]{folder,purpose,key_files}:
+<!--TOON:subagents[41]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings and UX/CRO,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper|mom-test-ux
@@ -44,6 +44,7 @@ tools/conversion/,Format conversion - document transformation,pandoc
 tools/document/,Document extraction - conversion structured data extraction and workflow orchestration,document-extraction|extraction-workflow|docstrange
 tools/ocr/,OCR and text extraction - local document processing via Ollama,glm-ocr
 tools/video/,Video creation and downloading - programmatic generation and YouTube downloads,remotion|higgsfield|yt-dlp|video-prompt-design
+tools/vision/,Vision AI - image generation understanding and editing with local and cloud models,overview|image-generation|image-understanding|image-editing
 tools/voice/,Voice AI - TTS/STT model catalog voice bridge and Pipecat pipeline for talking to AI agents,voice-models|speech-to-speech|voice-bridge|hyprwhspr|pipecat-opencode|transcription|buzz
 tools/data-extraction/,Data extraction - scraping business data,outscraper
 tools/deployment/,Deployment automation - self-hosted PaaS and orchestration,coolify|coolify-cli|vercel|cloudron-app-packaging|uncloud

--- a/.agents/tools/infrastructure/cloud-gpu.md
+++ b/.agents/tools/infrastructure/cloud-gpu.md
@@ -23,7 +23,7 @@ tools:
 - **Pattern**: SSH into instance, Docker deploy, expose API, connect from local machine
 - **Cost range**: $0.20/hr (consumer GPUs) to $8.64/hr (B200 SXM)
 
-**When to Use**: Read this when deploying any AI model that requires GPU acceleration and local hardware is insufficient. Referenced by `tools/voice/speech-to-speech.md` and future `tools/vision/` subagents.
+**When to Use**: Read this when deploying any AI model that requires GPU acceleration and local hardware is insufficient. Referenced by `tools/voice/speech-to-speech.md` and `tools/vision/` subagents.
 
 <!-- AI-CONTEXT-END -->
 

--- a/.agents/tools/vision/image-editing.md
+++ b/.agents/tools/vision/image-editing.md
@@ -1,0 +1,245 @@
+---
+description: "Image editing - AI-powered inpainting, outpainting, upscaling, and style transfer"
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: true
+  task: true
+---
+
+# Image Editing
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Modify existing images using AI - inpainting, outpainting, upscaling, style transfer, background removal
+- **Cloud**: DALL-E 2 edit API, Google Imagen edit, Adobe Firefly
+- **Local**: Stable Diffusion inpaint, FLUX fill, Real-ESRGAN (upscaling), ControlNet
+- **Workflow tool**: ComfyUI (node-based pipelines for complex edits)
+
+**When to use**: Removing objects from images, extending image boundaries, changing styles, upscaling low-resolution images, removing backgrounds, or applying consistent edits across batches.
+
+**Quick start** (cloud):
+
+```bash
+# DALL-E 2 image edit (inpainting)
+curl https://api.openai.com/v1/images/edits \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -F image="@original.png" \
+  -F mask="@mask.png" \
+  -F prompt="A sunlit garden with flowers" \
+  -F size="1024x1024"
+```
+
+<!-- AI-CONTEXT-END -->
+
+## Editing Capabilities
+
+| Capability | Description | Best Tool |
+|------------|-------------|-----------|
+| **Inpainting** | Replace selected region with AI-generated content | SD inpaint, DALL-E 2 edit |
+| **Outpainting** | Extend image beyond original boundaries | SD outpaint, FLUX fill |
+| **Upscaling** | Increase resolution with AI enhancement | Real-ESRGAN, Topaz |
+| **Background removal** | Remove or replace backgrounds | rembg, Segment Anything |
+| **Style transfer** | Apply artistic style to existing image | SD img2img, ControlNet |
+| **ControlNet** | Guide generation with edge/depth/pose maps | SD XL + ControlNet |
+| **Face restoration** | Enhance/restore faces in images | GFPGAN, CodeFormer |
+
+## Cloud APIs
+
+### DALL-E 2 Edit (OpenAI)
+
+The edit endpoint uses DALL-E 2 (not DALL-E 3). Requires a source image and a mask indicating the area to edit.
+
+```bash
+# Inpainting: replace masked area
+curl https://api.openai.com/v1/images/edits \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -F image="@photo.png" \
+  -F mask="@mask.png" \
+  -F prompt="A red sports car" \
+  -F size="1024x1024" \
+  -F n=1
+
+# Variation: generate similar images
+curl https://api.openai.com/v1/images/variations \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -F image="@photo.png" \
+  -F size="1024x1024" \
+  -F n=3
+```
+
+**Requirements**: Image and mask must be square PNG files, same dimensions, under 4MB. Mask transparent areas indicate where to edit.
+
+### Google Imagen Edit (Vertex AI)
+
+```bash
+# Inpainting via Vertex AI
+curl -X POST \
+  "https://us-central1-aiplatform.googleapis.com/v1/projects/$PROJECT_ID/locations/us-central1/publishers/google/models/imagen-3.0-capability-001:predict" \
+  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "instances": [{
+      "prompt": "Replace with a modern office",
+      "image": {"bytesBase64Encoded": "<base64-image>"},
+      "mask": {"image": {"bytesBase64Encoded": "<base64-mask>"}}
+    }],
+    "parameters": {"sampleCount": 1}
+  }'
+```
+
+## Local Tools
+
+### Stable Diffusion Inpainting (ComfyUI)
+
+```bash
+# Install ComfyUI (if not already)
+git clone https://github.com/comfyanonymous/ComfyUI.git
+cd ComfyUI && pip install -r requirements.txt
+
+# Download inpainting model
+# Place SD XL inpaint model in ComfyUI/models/checkpoints/
+# Available from https://huggingface.co/diffusers/stable-diffusion-xl-1.0-inpainting-0.1
+
+# Start ComfyUI
+python main.py --listen 0.0.0.0 --port 8188
+```
+
+Use the ComfyUI web interface to build inpainting workflows with mask painting tools.
+
+### Real-ESRGAN (Upscaling)
+
+```bash
+# Install
+pip install realesrgan
+
+# Upscale 4x
+python -m realesrgan -i input.jpg -o output.jpg -s 4
+
+# Upscale with face enhancement
+python -m realesrgan -i input.jpg -o output.jpg -s 4 --face_enhance
+```
+
+| Scale | Use Case | Notes |
+|-------|----------|-------|
+| 2x | Moderate enhancement | Fast, subtle |
+| 4x | Standard upscaling | Good balance |
+| 8x | Maximum enlargement | Slower, may introduce artifacts |
+
+### rembg (Background Removal)
+
+```bash
+# Install
+pip install rembg[gpu]  # GPU accelerated
+# or
+pip install rembg        # CPU only
+
+# Remove background
+rembg i input.jpg output.png
+
+# Batch process
+rembg p input_dir/ output_dir/
+
+# With alpha matting (better edges)
+rembg i -a input.jpg output.png
+```
+
+### GFPGAN (Face Restoration)
+
+```bash
+# Install
+pip install gfpgan
+
+# Restore faces
+python -m gfpgan.inference -i input.jpg -o output/ -v 1.4 -s 2
+```
+
+### ControlNet (Guided Generation)
+
+ControlNet allows precise control over image generation using structural guides:
+
+| Control Type | Input | Use Case |
+|-------------|-------|----------|
+| **Canny edge** | Edge map | Preserve structure, change style |
+| **Depth** | Depth map | Maintain spatial layout |
+| **OpenPose** | Pose skeleton | Control character poses |
+| **Scribble** | Hand-drawn sketch | Sketch to image |
+| **Segmentation** | Semantic map | Control scene composition |
+| **Tile** | Low-res image | Upscale with detail generation |
+
+ControlNet models are used within ComfyUI or Automatic1111 workflows.
+
+## Common Workflows
+
+### Product Photo Enhancement
+
+```text
+1. Remove background (rembg)
+2. Upscale if needed (Real-ESRGAN 2x)
+3. Generate new background (SD inpaint or DALL-E)
+4. Colour correct and adjust (ImageMagick or Pillow)
+```
+
+### Batch Background Removal
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+local input_dir="$1"
+local output_dir="$2"
+
+mkdir -p "$output_dir"
+
+for img in "$input_dir"/*.{jpg,png,webp}; do
+  [ -f "$img" ] || continue
+  local basename
+  basename="$(basename "${img%.*}")"
+  echo "Processing: $basename"
+  rembg i "$img" "$output_dir/${basename}.png"
+done
+
+echo "Done. Output in: $output_dir"
+```
+
+### Image Resize and Optimise
+
+```bash
+# Using ImageMagick (non-AI but commonly needed alongside AI editing)
+# Resize to max 1920px width, maintain aspect ratio
+magick input.jpg -resize 1920x\> -quality 85 output.jpg
+
+# Convert to WebP for web
+magick input.jpg -resize 1920x\> -quality 80 output.webp
+
+# Batch convert directory
+magick mogrify -resize 1920x\> -quality 85 -path output/ input/*.jpg
+```
+
+## VRAM Requirements
+
+| Tool | Min VRAM | Recommended | Notes |
+|------|----------|-------------|-------|
+| SD XL inpaint | 6GB | 8GB+ | Standard inpainting |
+| FLUX fill | 12GB | 16GB+ | Higher quality |
+| ControlNet | 8GB | 12GB+ | Adds ~2GB to base model |
+| Real-ESRGAN | 2GB | 4GB+ | Lightweight |
+| rembg (GPU) | 2GB | 4GB+ | Fast with GPU |
+| GFPGAN | 2GB | 4GB+ | Face-specific |
+
+For cloud GPU deployment of these tools, see `tools/infrastructure/cloud-gpu.md`.
+
+## See Also
+
+- `overview.md` - Vision AI category overview
+- `image-generation.md` - Create new images from text
+- `image-understanding.md` - Analyse existing images
+- `tools/infrastructure/cloud-gpu.md` - GPU deployment for local models
+- `tools/video/` - Image-to-video pipelines

--- a/.agents/tools/vision/image-generation.md
+++ b/.agents/tools/vision/image-generation.md
@@ -1,0 +1,247 @@
+---
+description: "Image generation - text-to-image models for creating visuals from prompts"
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: true
+  task: true
+---
+
+# Image Generation
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Generate images from text prompts using AI models
+- **Cloud**: DALL-E 3 (OpenAI), Midjourney, Google Imagen 3, Ideogram
+- **Local**: FLUX (Black Forest Labs), Stable Diffusion XL (Stability AI)
+- **Workflow tool**: ComfyUI (node-based, local), Automatic1111 (web UI, local)
+
+**When to use**: Creating product images, concept art, marketing visuals, UI mockups, social media graphics, or any task requiring new images from text descriptions.
+
+**Quick start** (cloud):
+
+```bash
+# DALL-E 3 via OpenAI API
+curl https://api.openai.com/v1/images/generations \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "dall-e-3",
+    "prompt": "A professional product photo of a laptop on a clean desk",
+    "size": "1024x1024",
+    "quality": "hd"
+  }'
+```
+
+**Quick start** (local):
+
+```bash
+# FLUX via ComfyUI (requires GPU with 12GB+ VRAM)
+# See ComfyUI setup section below
+```
+
+<!-- AI-CONTEXT-END -->
+
+## Model Comparison
+
+| Model | Provider | Quality | Speed | Cost | Local | Best For |
+|-------|----------|---------|-------|------|-------|----------|
+| **DALL-E 3** | OpenAI | High | Fast | $0.04-0.12/img | No | General purpose, text rendering |
+| **Midjourney v6** | Midjourney | Very high | Medium | $10-60/mo | No | Artistic, photorealistic |
+| **Imagen 3** | Google | High | Fast | API pricing | No | Photorealism, Google ecosystem |
+| **Ideogram 2.0** | Ideogram | High | Fast | Free tier + paid | No | Text in images, logos |
+| **FLUX.1 [dev]** | Black Forest Labs | High | Medium | Free (local) | Yes | Open-source, customisable |
+| **FLUX.1 [schnell]** | Black Forest Labs | Good | Fast | Free (local) | Yes | Fast local generation |
+| **SD XL** | Stability AI | Good | Fast | Free (local) | Yes | Established ecosystem, ControlNet |
+| **SD 3.5** | Stability AI | High | Medium | Free (local) | Yes | Latest Stability model |
+
+### Choosing a Model
+
+```text
+Need text rendered in images?     → DALL-E 3 or Ideogram
+Need photorealistic quality?      → Midjourney or Imagen 3
+Need full local control?          → FLUX.1 [dev] or SD XL
+Need fast iteration (local)?      → FLUX.1 [schnell]
+Need ControlNet / img2img?        → SD XL (most mature ecosystem)
+Need API integration?             → DALL-E 3 (simplest API)
+Budget-conscious?                 → FLUX or SD locally (GPU cost only)
+```
+
+## Cloud APIs
+
+### DALL-E 3 (OpenAI)
+
+```bash
+# Store API key
+aidevops secret set OPENAI_API_KEY
+
+# Generate image
+curl https://api.openai.com/v1/images/generations \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "dall-e-3",
+    "prompt": "A minimalist logo for a tech startup called Nexus",
+    "size": "1024x1024",
+    "quality": "hd",
+    "style": "natural"
+  }'
+```
+
+| Parameter | Options | Notes |
+|-----------|---------|-------|
+| `size` | 1024x1024, 1024x1792, 1792x1024 | Square, portrait, landscape |
+| `quality` | standard, hd | HD costs 2x but significantly better |
+| `style` | natural, vivid | Natural = photorealistic, vivid = artistic |
+| `n` | 1 | DALL-E 3 only supports 1 image per request |
+
+**Pricing**: Standard $0.04/img, HD $0.08/img (1024x1024). Larger sizes cost more.
+
+**Strengths**: Excellent text rendering, good prompt adherence, simple API.
+
+**Limitations**: No inpainting in v3 API (use v2 for edits), 1 image per request, no negative prompts.
+
+### Midjourney
+
+Midjourney operates via Discord bot or web interface (no REST API at time of writing).
+
+**Access**: Subscribe at [midjourney.com](https://www.midjourney.com/), use via Discord `/imagine` command or web UI.
+
+**Prompt tips**:
+
+- Use `--ar 16:9` for aspect ratio
+- Use `--v 6` for latest model
+- Use `--style raw` for less stylised output
+- Use `--no text, watermark` for negative prompts
+
+### Google Imagen 3
+
+Available via Vertex AI API or Google AI Studio.
+
+```bash
+# Via Vertex AI (requires Google Cloud project)
+curl -X POST \
+  "https://us-central1-aiplatform.googleapis.com/v1/projects/$PROJECT_ID/locations/us-central1/publishers/google/models/imagen-3.0-generate-002:predict" \
+  -H "Authorization: Bearer $(gcloud auth print-access-token)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "instances": [{"prompt": "A serene mountain landscape at sunset"}],
+    "parameters": {"sampleCount": 1, "aspectRatio": "16:9"}
+  }'
+```
+
+## Local Generation
+
+### ComfyUI (Recommended)
+
+Node-based workflow tool for local image generation. Supports FLUX, SD XL, ControlNet, and custom pipelines.
+
+```bash
+# Install ComfyUI
+git clone https://github.com/comfyanonymous/ComfyUI.git
+cd ComfyUI
+pip install -r requirements.txt
+
+# Download FLUX model (~12GB)
+# Place in ComfyUI/models/checkpoints/
+# Download from https://huggingface.co/black-forest-labs/FLUX.1-dev
+
+# Start ComfyUI
+python main.py --listen 0.0.0.0 --port 8188
+
+# Access at http://localhost:8188
+```
+
+**VRAM requirements**:
+
+| Model | Min VRAM | Recommended |
+|-------|----------|-------------|
+| FLUX.1 [schnell] | 8GB | 12GB+ |
+| FLUX.1 [dev] | 12GB | 16GB+ |
+| SD XL | 6GB | 8GB+ |
+| SD 3.5 | 8GB | 12GB+ |
+
+### ComfyUI API (Headless)
+
+```bash
+# Queue a prompt via API (headless generation)
+curl -X POST http://localhost:8188/prompt \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": <workflow-json>}'
+
+# Check queue status
+curl http://localhost:8188/queue
+
+# Get generated image
+curl http://localhost:8188/view?filename=<output-filename>
+```
+
+### Ollama (Simple Local)
+
+Some vision models in Ollama can generate image descriptions but not images. For generation, use ComfyUI or Automatic1111.
+
+## Prompt Engineering
+
+### General Principles
+
+1. **Be specific**: "A golden retriever puppy sitting on a red velvet cushion" > "a dog"
+2. **Include style**: "oil painting style", "photorealistic", "minimalist vector"
+3. **Specify lighting**: "soft natural light", "dramatic side lighting", "studio lighting"
+4. **Add composition**: "close-up", "wide angle", "bird's eye view", "rule of thirds"
+5. **Set mood**: "warm and inviting", "dark and moody", "bright and cheerful"
+
+### Negative Prompts (SD/FLUX)
+
+```text
+Useful negatives for quality:
+blurry, low quality, distorted, deformed, ugly, duplicate, watermark,
+text, signature, oversaturated, underexposed, overexposed
+```
+
+### Batch Generation Script
+
+```bash
+#!/usr/bin/env bash
+# Generate multiple variations via DALL-E 3
+set -euo pipefail
+
+local prompt="$1"
+local count="${2:-4}"
+local output_dir="${3:-.}"
+
+for i in $(seq 1 "$count"); do
+  echo "Generating image $i/$count..."
+  curl -s https://api.openai.com/v1/images/generations \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\": \"dall-e-3\", \"prompt\": \"$prompt\", \"size\": \"1024x1024\", \"quality\": \"hd\"}" \
+    | python3 -c "import json,sys,urllib.request; url=json.load(sys.stdin)['data'][0]['url']; urllib.request.urlretrieve(url, '$output_dir/gen_$i.png')"
+  echo "Saved: $output_dir/gen_$i.png"
+done
+```
+
+## Cost Comparison
+
+| Model | Per Image | Monthly (100 imgs) | Notes |
+|-------|-----------|---------------------|-------|
+| DALL-E 3 HD | $0.08 | $8 | Pay per image |
+| Midjourney Basic | $0.10 | $10/mo (200 imgs) | Subscription |
+| Imagen 3 | ~$0.04 | ~$4 | Vertex AI pricing |
+| FLUX (local) | ~$0.01 | GPU electricity only | Requires 12GB+ VRAM |
+| SD XL (local) | ~$0.005 | GPU electricity only | Requires 8GB+ VRAM |
+| FLUX (cloud GPU) | ~$0.02 | ~$2 + GPU rental | RunPod/Vast.ai |
+
+## See Also
+
+- `overview.md` - Vision AI category overview
+- `image-editing.md` - Modify existing images
+- `image-understanding.md` - Analyse existing images
+- `tools/video/video-prompt-design.md` - Video prompt engineering (related techniques)
+- `tools/infrastructure/cloud-gpu.md` - GPU deployment for local models

--- a/.agents/tools/vision/image-understanding.md
+++ b/.agents/tools/vision/image-understanding.md
@@ -1,0 +1,273 @@
+---
+description: "Image understanding - multimodal vision models for analysing and describing images"
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: true
+  task: true
+---
+
+# Image Understanding
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Analyse, describe, and extract information from images using vision-capable AI models
+- **Cloud**: GPT-4o vision, Claude vision (Sonnet/Opus), Gemini 2.5 Pro/Flash
+- **Local**: LLaVA, MiniCPM-o, Qwen-VL, InternVL (via Ollama)
+- **Dedicated OCR**: `tools/ocr/glm-ocr.md` (prefer for pure text extraction)
+
+**When to use**: Analysing screenshots, describing images for alt text, visual Q&A, diagram interpretation, UI review, accessibility audits, or any task requiring understanding of image content.
+
+**Quick start** (cloud):
+
+```bash
+# GPT-4o vision via OpenAI API
+curl https://api.openai.com/v1/chat/completions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Describe this image in detail"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}
+      ]
+    }]
+  }'
+```
+
+**Quick start** (local):
+
+```bash
+# LLaVA via Ollama (no API key needed)
+ollama pull llava
+ollama run llava "Describe this image" --images /path/to/image.png
+```
+
+<!-- AI-CONTEXT-END -->
+
+## Model Comparison
+
+| Model | Provider | Context | Speed | Cost | Local | Best For |
+|-------|----------|---------|-------|------|-------|----------|
+| **GPT-4o** | OpenAI | 128K | Fast | $2.50/$10 per 1M tokens | No | General analysis, reasoning |
+| **Claude Sonnet** | Anthropic | 200K | Fast | $3/$15 per 1M tokens | No | Nuanced descriptions, code review |
+| **Claude Opus** | Anthropic | 200K | Medium | $15/$75 per 1M tokens | No | Complex reasoning about images |
+| **Gemini 2.5 Pro** | Google | 1M | Fast | $1.25/$10 per 1M tokens | No | Large images, long documents |
+| **Gemini 2.5 Flash** | Google | 1M | Very fast | $0.15/$0.60 per 1M tokens | No | Fast analysis, cost-effective |
+| **LLaVA** | Open source | 4K | Medium | Free | Yes | General vision, ~4GB VRAM |
+| **MiniCPM-o** | OpenBMB | 8K | Fast | Free | Yes | Efficient local vision, ~4GB |
+| **Qwen-VL** | Alibaba | 32K | Medium | Free | Yes | Multilingual, detailed, ~8GB |
+| **InternVL 2.5** | Shanghai AI Lab | 8K | Medium | Free | Yes | Strong reasoning, ~8GB |
+
+### Choosing a Model
+
+```text
+Need best accuracy?               → GPT-4o or Claude Opus
+Need cost-effective cloud?         → Gemini 2.5 Flash
+Need large image/document?         → Gemini 2.5 Pro (1M context)
+Need nuanced text descriptions?    → Claude Sonnet
+Need fully local/private?          → LLaVA or MiniCPM-o (Ollama)
+Need multilingual understanding?   → Qwen-VL
+Need pure text extraction (OCR)?   → tools/ocr/glm-ocr.md (dedicated)
+Need screen capture + analysis?    → tools/browser/peekaboo.md
+```
+
+## Cloud APIs
+
+### OpenAI (GPT-4o Vision)
+
+```bash
+# Analyse image from URL
+curl https://api.openai.com/v1/chat/completions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4o",
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "What UI issues do you see in this screenshot?"},
+        {"type": "image_url", "image_url": {"url": "https://example.com/screenshot.png"}}
+      ]
+    }],
+    "max_tokens": 1000
+  }'
+
+# Analyse local image (base64)
+base64 -i screenshot.png | \
+  jq -Rs '{model: "gpt-4o", messages: [{role: "user", content: [{type: "text", text: "Describe this"}, {type: "image_url", image_url: {url: ("data:image/png;base64," + .)}}]}]}' | \
+  curl -s https://api.openai.com/v1/chat/completions \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d @-
+```
+
+**Image token costs**: Images are resized and tiled. A 1024x1024 image uses ~765 tokens. Larger images use more tiles. Use `detail: "low"` for cheaper analysis (~85 tokens per image).
+
+### Anthropic (Claude Vision)
+
+```bash
+# Claude vision via Messages API
+curl https://api.anthropic.com/v1/messages \
+  -H "x-api-key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [{
+      "role": "user",
+      "content": [
+        {"type": "image", "source": {"type": "base64", "media_type": "image/png", "data": "<base64-data>"}},
+        {"type": "text", "text": "Describe the architecture shown in this diagram"}
+      ]
+    }]
+  }'
+```
+
+**Supported formats**: JPEG, PNG, GIF, WebP. Max 5MB per image (API), 10MB (Claude.ai).
+
+### Google (Gemini Vision)
+
+```bash
+# Gemini via Google AI Studio API
+curl "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GOOGLE_AI_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contents": [{
+      "parts": [
+        {"text": "Analyse this chart and summarise the key trends"},
+        {"inline_data": {"mime_type": "image/png", "data": "<base64-data>"}}
+      ]
+    }]
+  }'
+```
+
+**Advantage**: 1M token context allows analysing very large images or multiple images in a single request.
+
+## Local Models (Ollama)
+
+### Setup
+
+```bash
+# Install Ollama
+brew install ollama
+
+# Pull vision models
+ollama pull llava           # General vision (~4GB)
+ollama pull minicpm-v       # Efficient vision (~4GB)
+ollama pull qwen2-vl        # Multilingual vision (~8GB)
+```
+
+### Usage
+
+```bash
+# Basic image analysis
+ollama run llava "What objects are in this image?" --images photo.jpg
+
+# Detailed description for alt text
+ollama run llava "Write a detailed alt text description for accessibility" --images hero-image.png
+
+# UI review
+ollama run minicpm-v "List all UI elements and their approximate positions" --images screenshot.png
+
+# Diagram interpretation
+ollama run qwen2-vl "Explain the architecture shown in this diagram" --images architecture.png
+```
+
+### Ollama API (Programmatic)
+
+```bash
+# Via Ollama REST API
+curl http://localhost:11434/api/generate \
+  -d '{
+    "model": "llava",
+    "prompt": "Describe this image",
+    "images": ["<base64-encoded-image>"]
+  }'
+```
+
+## Common Use Cases
+
+### Alt Text Generation
+
+```bash
+# Generate accessible alt text for web images
+ollama run llava "Write a concise, descriptive alt text for this image suitable for screen readers. Focus on the key visual content and purpose." --images hero.jpg
+```
+
+### UI/UX Review
+
+```bash
+# Analyse a screenshot for UI issues
+ollama run minicpm-v "Review this UI screenshot. Identify: 1) Alignment issues 2) Contrast problems 3) Missing elements 4) Accessibility concerns" --images app-screenshot.png
+```
+
+### Diagram to Code
+
+```bash
+# Convert a wireframe/diagram to code description
+ollama run qwen2-vl "Describe this wireframe as a structured layout specification I can implement in HTML/CSS. List each component, its position, and approximate dimensions." --images wireframe.png
+```
+
+### Batch Image Analysis
+
+```bash
+#!/usr/bin/env bash
+# Analyse all images in a directory
+set -euo pipefail
+
+local dir="${1:-.}"
+local model="${2:-llava}"
+local prompt="${3:-Describe this image in one sentence}"
+
+for img in "$dir"/*.{jpg,png,webp}; do
+  [ -f "$img" ] || continue
+  echo "=== $(basename "$img") ==="
+  ollama run "$model" "$prompt" --images "$img"
+  echo
+done
+```
+
+### Compare with Peekaboo
+
+For screen capture + vision analysis in a single command:
+
+```bash
+# Capture and analyse (uses Peekaboo's built-in vision)
+peekaboo image --mode screen --analyze "What application is shown and what is the user doing?" --model ollama/llava
+
+# Capture specific window
+peekaboo image --mode window --app Safari --analyze "Summarise the web page content" --model openai/gpt-4o
+```
+
+See `tools/browser/peekaboo.md` for full Peekaboo integration.
+
+## Token Cost Estimation
+
+| Provider | Low Detail | High Detail (1024x1024) | High Detail (2048x2048) |
+|----------|-----------|------------------------|------------------------|
+| OpenAI | ~85 tokens | ~765 tokens | ~1,105 tokens |
+| Anthropic | ~1,000 tokens | ~1,600 tokens | ~3,200 tokens |
+| Google | ~258 tokens | ~258 tokens | ~516 tokens |
+| Local (Ollama) | Free | Free | Free |
+
+**Cost tip**: Use `detail: "low"` in OpenAI API for quick classification tasks. Use high detail only when fine visual details matter.
+
+## See Also
+
+- `overview.md` - Vision AI category overview
+- `image-generation.md` - Create new images from text
+- `image-editing.md` - Modify existing images
+- `tools/ocr/glm-ocr.md` - Dedicated OCR for text extraction
+- `tools/browser/peekaboo.md` - Screen capture + vision analysis
+- `tools/infrastructure/cloud-gpu.md` - GPU deployment for local models

--- a/.agents/tools/vision/overview.md
+++ b/.agents/tools/vision/overview.md
@@ -1,0 +1,95 @@
+---
+description: "Vision AI tools overview - image generation, understanding, and editing model selection"
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Vision AI Tools
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Select and use visual AI models for image generation, understanding, and editing
+- **Categories**: Generation (text-to-image), Understanding (image analysis), Editing (inpainting/outpainting)
+- **Local options**: Stable Diffusion, FLUX, LLaVA, MiniCPM-o (via Ollama or ComfyUI)
+- **Cloud options**: DALL-E 3, Midjourney, GPT-4o vision, Claude vision, Gemini vision
+
+**Decision tree**:
+
+```text
+Need to CREATE images from text?
+  → See image-generation.md
+
+Need to UNDERSTAND/ANALYZE existing images?
+  → See image-understanding.md
+
+Need to EDIT/MODIFY existing images?
+  → See image-editing.md
+
+Need GPU deployment for local models?
+  → See tools/infrastructure/cloud-gpu.md
+```
+
+<!-- AI-CONTEXT-END -->
+
+## Category Overview
+
+| Category | Use Case | Key Models | Subagent |
+|----------|----------|------------|----------|
+| **Generation** | Text-to-image, concept art, marketing assets | DALL-E 3, Midjourney, FLUX, Stable Diffusion | `image-generation.md` |
+| **Understanding** | Image analysis, captioning, visual Q&A, OCR | GPT-4o, Claude vision, Gemini, LLaVA, Qwen-VL | `image-understanding.md` |
+| **Editing** | Inpainting, outpainting, style transfer, upscaling | DALL-E 3 edit, Stable Diffusion inpaint, FLUX fill | `image-editing.md` |
+
+## Model Selection Quick Guide
+
+### By Deployment
+
+| Deployment | Models | Best For |
+|------------|--------|----------|
+| **Cloud API** | DALL-E 3, GPT-4o vision, Claude vision, Gemini | Quick integration, no GPU needed |
+| **Local (Ollama)** | LLaVA, MiniCPM-o, Qwen-VL | Privacy, no API costs, understanding tasks |
+| **Local (ComfyUI)** | FLUX, Stable Diffusion XL, ControlNet | Generation, editing, full control |
+| **Cloud GPU** | Any model via vLLM/ComfyUI | Scale, large models, batch processing |
+
+### By Task
+
+```text
+Product photos / marketing    → DALL-E 3 (cloud) or FLUX (local)
+Code screenshot analysis      → Claude vision or GPT-4o vision
+Document/receipt OCR          → tools/ocr/glm-ocr.md (dedicated OCR)
+GUI automation screenshots    → tools/browser/peekaboo.md (screen capture + vision)
+Architectural diagrams        → GPT-4o vision or Gemini (large context)
+Image captioning / alt text   → Claude vision or LLaVA (local)
+Background removal / editing  → Stable Diffusion inpaint or DALL-E 3 edit
+Upscaling / enhancement       → Real-ESRGAN or Topaz (local)
+```
+
+## Integration with aidevops
+
+Vision tools integrate with existing subagents:
+
+| Integration | Description |
+|-------------|-------------|
+| `tools/ocr/glm-ocr.md` | Dedicated OCR (prefer over general vision for text extraction) |
+| `tools/browser/peekaboo.md` | Screen capture + vision analysis for GUI automation |
+| `tools/video/` | Image-to-video pipelines (Kling, Seedance via Higgsfield) |
+| `tools/infrastructure/cloud-gpu.md` | GPU deployment for local vision models |
+| `content/` | AI-generated images for content workflows |
+
+## See Also
+
+- `image-generation.md` - Text-to-image model guide
+- `image-understanding.md` - Image analysis and multimodal models
+- `image-editing.md` - Image modification and enhancement
+- `tools/ocr/glm-ocr.md` - Dedicated OCR (text extraction from images)
+- `tools/browser/peekaboo.md` - Screen capture with AI vision
+- `tools/infrastructure/cloud-gpu.md` - GPU deployment for local models


### PR DESCRIPTION
## Summary

- Add new `tools/vision/` category with 4 subagent files covering image generation, understanding, and editing
- Register vision category in `subagent-index.toon` (40 → 41 subagents) and AGENTS.md progressive disclosure table
- Update `cloud-gpu.md` to reference the now-existing vision subagents instead of "future"

## Files

### New
- `.agents/tools/vision/overview.md` — Category overview with decision tree routing to generation/understanding/editing
- `.agents/tools/vision/image-generation.md` — Text-to-image models (DALL-E 3, Midjourney, FLUX, SD XL, Imagen 3, Ideogram) with cloud APIs, ComfyUI local setup, prompt engineering, and cost comparison
- `.agents/tools/vision/image-understanding.md` — Multimodal vision analysis (GPT-4o, Claude, Gemini, LLaVA, MiniCPM-o, Qwen-VL) with cloud/local usage, token cost estimation, and Peekaboo integration
- `.agents/tools/vision/image-editing.md` — AI-powered editing (inpainting, outpainting, upscaling, background removal, ControlNet, face restoration) with DALL-E 2 edit API, ComfyUI, Real-ESRGAN, rembg

### Modified
- `.agents/subagent-index.toon` — Added vision entry, updated count 40 → 41
- `.agents/AGENTS.md` — Added Vision row to progressive disclosure table
- `.agents/tools/infrastructure/cloud-gpu.md` — Changed "future `tools/vision/`" to direct reference

## Integration Points

Cross-references existing subagents: `tools/ocr/glm-ocr.md` (dedicated OCR), `tools/browser/peekaboo.md` (screen capture + vision), `tools/video/` (image-to-video pipelines), `tools/infrastructure/cloud-gpu.md` (GPU deployment), `content/` (AI-generated images for content workflows).

## Verification

- `markdownlint` — zero violations on all new and modified markdown files
- TOON count verified: 41 entries match `subagents[41]` header
- All YAML frontmatter follows existing subagent conventions