### PR TITLE
feat: provider-agnostic task claiming via TODO.md (t165)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -201,6 +201,11 @@ worktree-helper.sh add feature/x  # Fallback
 supervisor-helper.sh add t001 --repo "$(pwd)" --description "Task description"
 supervisor-helper.sh batch "my-batch" --concurrency 3 --tasks "t001,t002,t003"
 
+# Task claiming (t165 — provider-agnostic, TODO.md primary)
+supervisor-helper.sh claim t001     # Adds assignee: to TODO.md, optional GH sync
+supervisor-helper.sh unclaim t001   # Releases claim (removes assignee:)
+# Claiming is automatic during dispatch. Manual claim/unclaim for coordination.
+
 # Install cron pulse (REQUIRED for autonomous operation)
 supervisor-helper.sh cron install
 
@@ -211,6 +216,8 @@ supervisor-helper.sh pulse --batch <batch-id>
 supervisor-helper.sh dashboard --batch <batch-id>
 supervisor-helper.sh status <batch-id>
 ```
+
+**Task claiming** (t165): TODO.md `assignee:` field is the authoritative claim source. Works offline, with any git host. GitHub Issue sync is optional best-effort (requires `gh` CLI + `ref:GH#` in TODO.md). GH Issue creation is opt-in: use `--with-issue` flag or `SUPERVISOR_AUTO_ISSUE=true`.
 
 **Cron pulse is mandatory** for autonomous operation. Without it, the supervisor is passive and requires manual `pulse` calls. The pulse cycle: check workers -> evaluate outcomes -> dispatch next -> cleanup.
 


### PR DESCRIPTION
## Summary

- Replace GH Issue-based claiming with TODO.md `assignee:` field as the authoritative claim source
- Make GitHub Issue creation opt-in (`--with-issue` flag) instead of default, with `SUPERVISOR_AUTO_ISSUE=true` for backward compat
- Fix latent bug: `find_project_root()` and `detect_repo_slug()` were called but never defined in supervisor-helper.sh

## Changes

### supervisor-helper.sh
- **Added** `find_project_root()` — walks up directory tree to find TODO.md (was called but undefined)
- **Added** `detect_repo_slug()` — parses HTTPS/SSH git remotes to `owner/repo` (was called but undefined)
- **Changed** `cmd_add`: GH Issue creation is now opt-in via `--with-issue` flag (was opt-out via `--no-issue`)
  - `SUPERVISOR_AUTO_ISSUE=true` env var restores old default for backward compat
  - `--no-issue` kept as alias for default (no-op, backward compat)
- **Changed** `create_github_issue()`: removed internal `SUPERVISOR_AUTO_ISSUE` guard (callers now gate)
- **Changed** `sync_claim_to_github()`: added `gh auth status` check (skip if unauthenticated)
- **Added** claiming architecture documentation in header comments and help text

### AGENTS.md
- Added `claim`/`unclaim` commands to supervisor quick reference
- Documented TODO.md-primary claiming model

### tests/test-supervisor-state-machine.sh
- **Added** 14 new tests for the claiming system (all pass):
  - `get_task_assignee` for unclaimed and pre-claimed tasks
  - `cmd_add --no-issue` and `--with-issue` flag acceptance
  - `find_project_root` directory traversal
  - Claiming/unclaiming sed operations on TODO.md
  - `check_task_claimed` free vs claimed-by-other detection
  - `SUPERVISOR_AUTO_ISSUE` default verification
  - `detect_repo_slug` HTTPS and SSH parsing

## Architecture

```
TODO.md assignee: field  ← PRIMARY (instant, offline, any git host)
        ↓ (optional sync)
GitHub Issue assignee    ← SECONDARY (best-effort, requires gh CLI + ref:GH#)
```

Claiming flow:
1. `cmd_claim` adds `assignee:<identity> started:<ISO>` to TODO.md task line
2. Commits and pushes TODO.md (optimistic lock — push failure = race lost)
3. Optionally syncs to GitHub Issue assignee if `ref:GH#` exists

## Test Results

- 14 new tests: all PASS
- 0 regressions (pre-existing 10 failures in Evaluate Worker section unchanged)
- ShellCheck: no new warnings