### PR TITLE
fix: strip verbose workflow from /onboarding command prompt

### DIFF
--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -61,7 +61,7 @@ If yes, provide a brief overview:
 ```text
 aidevops gives your AI assistant superpowers for DevOps and infrastructure management.
 
-**Recommended tool:** You should be running this in [Claude Code](https://Claude.ai/) - the recommended AI coding agent for aidevops. All features, agents, and workflows are designed and tested for Claude Code first. If you're using a different tool, most features will still work, but Claude Code provides the best experience.
+**Recommended tool:** You should be running this in [OpenCode](https://opencode.ai/) - the recommended AI coding agent for aidevops. All features, agents, and workflows are designed and tested for OpenCode first. OpenCode supports multiple AI providers (Zen, Anthropic, OpenAI, and more) so you can use whichever model you prefer.
 
 **Capabilities:**
 

--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -1017,43 +1017,7 @@ cat > "$OPENCODE_COMMAND_DIR/onboarding.md" << 'EOF'
 description: Interactive onboarding wizard - discover services, configure integrations
 ---
 
-Read ~/.aidevops/agents/aidevops/onboarding.md and follow its instructions.
-
-This is the recommended starting point for new aidevops users.
-
-**Workflow:**
-
-1. **Welcome**: Ask if user wants an explanation of aidevops capabilities
-
-2. **Understand needs**: Ask what kind of work they do:
-   - Web development (WordPress, React, Node.js)
-   - DevOps & infrastructure management
-   - SEO & content marketing
-   - Multiple client/site management
-   - Something else
-
-3. **Show status**: Run the status check and display results:
-   ```bash
-   ~/.aidevops/agents/scripts/onboarding-helper.sh status
-   ```
-
-4. **Personalized recommendations**: Based on their work type:
-   ```bash
-   ~/.aidevops/agents/scripts/onboarding-helper.sh recommend [type]
-   ```
-
-5. **Guide setup**: For each service they want to configure:
-   - Explain what it does
-   - Provide signup/API key link
-   - Show the setup command
-   - Verify it works
-
-6. **Next steps**: Suggest trying a simple task to verify everything works
-
-**Quick status check only:**
-```bash
-~/.aidevops/agents/scripts/onboarding-helper.sh status
-```
+Read ~/.aidevops/agents/aidevops/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions — go straight to the Welcome Flow conversation.
 
 Arguments: $ARGUMENTS
 EOF


### PR DESCRIPTION
## Summary

- Strips the verbose 6-step workflow summary from the `/onboarding` command file, leaving only a single read instruction
- The command file content is displayed by OpenCode as a visible prompt block — the old version dumped raw workflow instructions before the AI could process them
- Now the AI reads `onboarding.md` silently and presents the interactive Welcome Flow (numbered choices) directly

## Before (screenshot from user)

The `/onboarding` command showed a wall of raw workflow text (steps 1-6, bash code blocks) before the AI greeted the user with a simple yes/no question.

## After

The command prompt shows a single clean instruction. The AI reads `onboarding.md` and follows its Welcome Flow — presenting the proper numbered-choice interactive conversation.

## Related PRs

- #709 — Removed `agent: Onboarding` from frontmatter (third layer fix)
- #704 — Removed `--agent "Onboarding"` flag from launch command
- This PR cleans up the command content for a polished first-run experience

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified onboarding instructions to streamline setup by directing users to the Welcome Flow instead of a detailed multi-step workflow.
  * Updated recommended AI coding agent from Claude Code to OpenCode and noted that OpenCode supports multiple AI providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->