### PR TITLE
feat: add 'aidevops init sops' and document encryption stack cross-references

### DIFF
--- a/.agents/tools/credentials/api-key-setup.md
+++ b/.agents/tools/credentials/api-key-setup.md
@@ -264,3 +264,12 @@ aidevops secret init              # One-time setup
 aidevops secret set API_KEY       # Store (hidden input)
 aidevops secret run some-command  # Use (injected + redacted)
 ```
+
+## Beyond API Keys
+
+For config files and directories with secrets, see the full encryption stack:
+
+- **Config files in git** (YAML/JSON with encrypted values): `tools/credentials/sops.md`
+- **Directory encryption at rest**: `tools/credentials/gocryptfs.md`
+- **Decision guide**: `tools/credentials/encryption-stack.md`
+- **Project setup**: `aidevops init sops` to add SOPS support to a project

--- a/.agents/tools/credentials/encryption-stack.md
+++ b/.agents/tools/credentials/encryption-stack.md
@@ -73,8 +73,9 @@ aidevops secret init
 aidevops secret set DATABASE_URL
 aidevops secret set API_KEY
 
-# 2. Initialize SOPS for config files
-sops-helper.sh init
+# 2. Initialize SOPS for config files (two options)
+aidevops init sops                    # Project-level: creates .sops.yaml + age key
+sops-helper.sh init                   # Standalone: init without aidevops project config
 # Create and encrypt config files
 sops-helper.sh encrypt config.enc.yaml
 

--- a/.agents/tools/credentials/gopass.md
+++ b/.agents/tools/credentials/gopass.md
@@ -180,8 +180,19 @@ See `tools/credentials/psst.md` for psst documentation.
               5. Return exit code
 ```
 
+## Encryption Stack
+
+gopass handles **individual secrets** (API keys, tokens, passwords). For other encryption needs:
+
+- **Config files in git** (YAML/JSON with encrypted values): Use SOPS -- `tools/credentials/sops.md`
+- **Directory encryption at rest** (sensitive folders): Use gocryptfs -- `tools/credentials/gocryptfs.md`
+- **Decision guide**: `tools/credentials/encryption-stack.md`
+
 ## Related
 
+- `tools/credentials/encryption-stack.md` -- Full encryption stack overview and decision tree
+- `tools/credentials/sops.md` -- SOPS config file encryption (age backend)
+- `tools/credentials/gocryptfs.md` -- gocryptfs directory encryption
 - `tools/credentials/api-key-setup.md` -- Plaintext credential setup
 - `tools/credentials/multi-tenant.md` -- Multi-tenant credential storage
 - `tools/credentials/psst.md` -- psst alternative for solo devs


### PR DESCRIPTION
## Summary

- **t134.3**: Add `sops` as an `aidevops init` feature flag — generates age key, creates `.sops.yaml` with encryption patterns for `*.secret.yaml` and `configs/*.enc.json`
- **t134.4**: Add encryption stack cross-references to `gopass.md` and `api-key-setup.md` so users discover SOPS and gocryptfs from existing credential workflows

## Changes

| File | Change |
|------|--------|
| `aidevops.sh` | Add `sops` feature to init command (parsing, config, age key gen, .sops.yaml creation, features list) |
| `.agents/tools/credentials/gopass.md` | Add "Encryption Stack" section with SOPS/gocryptfs cross-refs |
| `.agents/tools/credentials/api-key-setup.md` | Add "Beyond API Keys" section pointing to encryption stack |
| `.agents/tools/credentials/encryption-stack.md` | Add `aidevops init sops` to project setup workflow |

## Testing

- ShellCheck clean (zero warnings)
- Bash syntax validation passes
- SOPS is opt-in only (`aidevops init sops`) — not included in `all` to avoid surprising users

Closes #747, closes #748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SOPS encryption feature for secure config file management with age-based encryption backend
  * Automatic age key generation and configuration during project initialization

* **Documentation**
  * Enhanced encryption documentation with improved cross-references between API key setup, encryption stack decision guide, and authentication tools
  * Documented multiple initialization workflows for flexible SOPS setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->