### PR TITLE
fix: pass --non-interactive to setup.sh in supervisor and full-loop deploy phases

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -647,7 +647,7 @@ run_deploy_phase() {
     print_info "Running setup.sh to deploy changes..."
     
     if [[ -x "$repo_root/setup.sh" ]]; then
-        (cd "$repo_root" && ./setup.sh)
+        (cd "$repo_root" && ./setup.sh --non-interactive)
         print_success "Deployment complete!"
         echo "<promise>DEPLOYED</promise>"
     else

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -5056,14 +5056,14 @@ run_deploy_for_task() {
     fi
 
     if [[ -n "$timeout_cmd" ]]; then
-        if ! deploy_output=$(cd "$repo" && $timeout_cmd ./setup.sh 2>&1); then
+        if ! deploy_output=$(cd "$repo" && $timeout_cmd ./setup.sh --non-interactive 2>&1); then
             log_warn "Deploy (setup.sh) returned non-zero for $task_id (see $deploy_log)"
             echo "$deploy_output" > "$deploy_log" 2>/dev/null || true
             return 1
         fi
     else
         # Fallback: background process with manual timeout
-        (cd "$repo" && ./setup.sh > "$deploy_log" 2>&1) &
+        (cd "$repo" && ./setup.sh --non-interactive > "$deploy_log" 2>&1) &
         local deploy_pid=$!
         local waited=0
         while kill -0 "$deploy_pid" 2>/dev/null && [[ "$waited" -lt 300 ]]; do


### PR DESCRIPTION
## Summary

- Fix `supervisor-helper.sh` `run_deploy_for_task()` calling `setup.sh` without `--non-interactive`, causing interactive prompts to hang in headless contexts
- Fix `full-loop-helper.sh` `run_deploy_phase()` with the same issue
- Both timeout and fallback code paths in supervisor now pass the flag

## Root Cause

When the supervisor runs `setup.sh` as a deploy step (pr-lifecycle deploying phase), it fails because `setup.sh` hits interactive prompts (e.g., "Install Worktrunk shell integration?") that require stdin. The `--non-interactive` flag already exists and correctly skips all optional installs, but neither the supervisor nor full-loop-helper were passing it.

`aidevops.sh` (the CLI) already passes `--non-interactive` correctly at lines 556 and 585 — this fix brings the supervisor and full-loop into alignment.

## Changes

| File | Change |
|------|--------|
| `supervisor-helper.sh:5059` | Add `--non-interactive` to timeout path |
| `supervisor-helper.sh:5066` | Add `--non-interactive` to fallback path |
| `full-loop-helper.sh:650` | Add `--non-interactive` to deploy phase |

## Testing

- `bash -n` syntax check: PASS (both files)
- Verified all 3 `./setup.sh` invocations now include `--non-interactive`
- Verified `aidevops.sh` already uses this pattern (consistency confirmed)

Fixes: t193 ref:GH#720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment automation to run setup operations in non-interactive mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->