### PR TITLE
feat: add 'aidevops plugin' CLI commands for plugin management (t136.2)

### DIFF
--- a/.agents/aidevops/plugins.md
+++ b/.agents/aidevops/plugins.md
@@ -123,11 +123,8 @@ Plugins occupy a distinct tier alongside existing tiers:
 | Plugin | `~/.aidevops/agents/<namespace>/` | Yes (managed separately) | Third-party git repos |
 | Shared | `.agents/` in repo | Overwritten on update | Open-source distribution |
 
-## Current Status
+## Configuration
 
-The plugin schema is defined in `.aidevops.json`. The `aidevops plugin` subcommand is planned for a future release (t136.2+). Until then, plugins can be managed manually:
+Plugin state is stored in `~/.config/aidevops/plugins.json` (global, not per-project). The file is auto-created on first use. Per-project `.aidevops.json` also has a `plugins` array for project-level plugin awareness.
 
-1. Add the entry to `.aidevops.json` `plugins` array
-2. Clone the repo: `git clone <repo> ~/.aidevops/agents/<namespace>/`
-3. To update: `git -C ~/.aidevops/agents/<namespace>/ pull`
-4. To remove: delete the directory and remove the config entry
+Run `aidevops plugin help` for full CLI documentation.


### PR DESCRIPTION
## Summary

- Add `cmd_plugin()` to `aidevops.sh` with 6 subcommands: `add`, `list`, `update`, `enable`, `disable`, `remove`
- Plugin state stored in `~/.config/aidevops/plugins.json` with namespace isolation
- Namespace validation prevents collisions with core directories (custom, draft, scripts, tools, etc.)
- Update `plugins.md` to reflect CLI availability

## Details

Part of the Plugin System plan (t136). Follows t136.1 (plugin schema in `.aidevops.json`, PR #755).

### Subcommands

| Command | Description |
|---------|-------------|
| `aidevops plugin add <repo-url> [--namespace <name>] [--branch <branch>]` | Clone plugin repo, register in plugins.json |
| `aidevops plugin list` | Show installed plugins with status |
| `aidevops plugin update [name]` | Update one or all enabled plugins |
| `aidevops plugin enable <name>` | Enable plugin, redeploy files |
| `aidevops plugin disable <name>` | Disable plugin, remove deployed files |
| `aidevops plugin remove <name>` | Delete plugin files and config entry |

### Testing

- `bash -n aidevops.sh` — syntax OK
- `aidevops plugin help` — displays correctly
- `aidevops plugin list` — shows "No plugins installed"
- `aidevops help` — includes plugin in commands list
- Reserved namespace rejection — correctly blocked
- Invalid namespace characters — correctly blocked

Fixes: t136.2 ref:GH#729

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin management command supporting add, list, update, enable, disable, and remove subcommands
  * Global plugin configuration now stored in `~/.config/aidevops/plugins.json` with per-project awareness via `.aidevops.json`
  * Access full plugin CLI documentation via `aidevops plugin help`

* **Documentation**
  * Updated plugin configuration guide with new storage structure and usage guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->