### PR TITLE
fix: supervisor claim/unclaim now matches indented subtasks in TODO.md

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -1173,7 +1173,7 @@ cmd_add() {
     if [[ -z "$description" ]]; then
         local todo_file="$repo/TODO.md"
         if [[ -f "$todo_file" ]]; then
-            description=$(grep -E "^- \[( |x|-)\] $task_id " "$todo_file" 2>/dev/null | head -1 | sed -E 's/^- \[( |x|-)\] [^ ]* //' || true)
+            description=$(grep -E "^[[:space:]]*- \[( |x|-)\] $task_id " "$todo_file" 2>/dev/null | head -1 | sed -E 's/^[[:space:]]*- \[( |x|-)\] [^ ]* //' || true)
         fi
     fi
 
@@ -2143,7 +2143,7 @@ find_task_issue_number() {
     local todo_file="$project_root/TODO.md"
     if [[ -f "$todo_file" ]]; then
         local task_line
-        task_line=$(grep -E "^- \[.\] ${task_id_escaped} " "$todo_file" | head -1 || echo "")
+        task_line=$(grep -E "^[[:space:]]*- \[.\] ${task_id_escaped} " "$todo_file" | head -1 || echo "")
         echo "$task_line" | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || echo ""
     fi
     return 0
@@ -2194,7 +2194,7 @@ get_task_assignee() {
     task_id_escaped=$(printf '%s' "$task_id" | sed 's/\./\\./g')
 
     local task_line
-    task_line=$(grep -E "^- \[.\] ${task_id_escaped} " "$todo_file" | head -1 || echo "")
+    task_line=$(grep -E "^[[:space:]]*- \[.\] ${task_id_escaped} " "$todo_file" | head -1 || echo "")
     if [[ -z "$task_line" ]]; then
         return 0
     fi
@@ -2248,11 +2248,11 @@ cmd_claim() {
         return 1
     fi
 
-    # Verify task exists and is open
+    # Verify task exists and is open (supports both top-level and indented subtasks)
     local task_id_escaped
     task_id_escaped=$(printf '%s' "$task_id" | sed 's/\./\\./g')
     local task_line
-    task_line=$(grep -E "^- \[ \] ${task_id_escaped} " "$todo_file" | head -1 || echo "")
+    task_line=$(grep -E "^[[:space:]]*- \[ \] ${task_id_escaped} " "$todo_file" | head -1 || echo "")
     if [[ -z "$task_line" ]]; then
         log_error "Task $task_id not found as open in $todo_file"
         return 1
@@ -2262,7 +2262,7 @@ cmd_claim() {
     local now
     now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     local line_num
-    line_num=$(grep -nE "^- \[ \] ${task_id_escaped} " "$todo_file" | head -1 | cut -d: -f1)
+    line_num=$(grep -nE "^[[:space:]]*- \[ \] ${task_id_escaped} " "$todo_file" | head -1 | cut -d: -f1)
     if [[ -z "$line_num" ]]; then
         log_error "Could not find line number for $task_id"
         return 1
@@ -2347,7 +2347,7 @@ cmd_unclaim() {
     local task_id_escaped
     task_id_escaped=$(printf '%s' "$task_id" | sed 's/\./\\./g')
     local line_num
-    line_num=$(grep -nE "^- \[.\] ${task_id_escaped} " "$todo_file" | head -1 | cut -d: -f1)
+    line_num=$(grep -nE "^[[:space:]]*- \[.\] ${task_id_escaped} " "$todo_file" | head -1 | cut -d: -f1)
     if [[ -z "$line_num" ]]; then
         log_error "Could not find line number for $task_id"
         return 1


### PR DESCRIPTION
## Summary

- Fix supervisor's inability to dispatch subtasks (e.g., t132.2, t168.2) from TODO.md
- Change grep patterns from `^- \[` to `^[[:space:]]*- \[` in claim/unclaim/lookup functions

## Problem

The supervisor's `claim`, `unclaim`, and task lookup functions used `^- \[ \]` regex which only matched top-level tasks. Subtasks in TODO.md are indented:

```markdown
- [ ] t132 Cross-Provider Model Routing  (top-level - matched)
  - [ ] t132.2 Provider/model registry   (subtask - NOT matched)
```

This caused all subtask dispatches to fail with "Task tXXX.X not found as open in TODO.md".

## Fix

Changed 7 grep patterns to use `^[[:space:]]*- \[` which matches both:
- `- [ ] t132 ...` (top-level, zero indent)
- `  - [ ] t132.2 ...` (subtask, 2+ space indent)

## Functions Fixed

- `cmd_claim()` — task existence check + line number lookup
- `cmd_unclaim()` — line number lookup
- `check_task_claimed()` — task line lookup
- `get_task_gh_issue()` — task line lookup
- Task description lookup in `add` command

Note: `mark_task_complete()` already handled indented subtasks correctly.

## Testing

- ShellCheck: no new violations
- Bash syntax: verified OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced task management to correctly handle indented tasks in documentation files, improving accuracy of task identification, assignment, and claiming operations.
  * Improved task processing to robustly support varied indentation formats, ensuring consistent behavior regardless of how tasks or subtasks are formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->