### PR TITLE
feat: extend setup.sh to deploy plugins during aidevops update (t136.3)

### DIFF
--- a/.agents/aidevops/plugins.md
+++ b/.agents/aidevops/plugins.md
@@ -76,6 +76,16 @@ aidevops plugin update pro       # Update a specific plugin
 
 Pulls the latest from the tracked branch and redeploys.
 
+### Automatic Deployment
+
+Running `aidevops update` automatically deploys any enabled plugins that are not yet installed. Existing plugin directories are preserved (not re-cloned). Disabled plugin directories are cleaned up. Plugin namespaces are protected during clean mode deployments.
+
+To force a refresh of all plugins after update:
+
+```bash
+aidevops plugin update
+```
+
 ### Disable / Enable
 
 ```bash


### PR DESCRIPTION
## Summary

- Add `deploy_plugins()` function to `setup.sh` that deploys enabled plugins from `~/.config/aidevops/plugins.json` after core agent deployment
- Preserve plugin namespace directories during clean mode (alongside custom/ and draft/)
- Exclude plugin namespaces from rsync/tar to prevent core deployment from overwriting them
- Clean up disabled plugin directories automatically
- Update `plugins.md` to document automatic deployment behavior

## Details

Part of the Plugin System plan (t136). Follows t136.2 (plugin CLI commands, PR #759).

### How it works

1. `deploy_aidevops_agents()` reads `plugins.json` to collect plugin namespaces
2. Plugin directories are added to the preserve list (clean mode) and exclude list (rsync/tar)
3. After core deployment, `deploy_plugins()` is called:
   - Removes directories for disabled plugins
   - Installs missing enabled plugins via shallow clone
   - Skips already-deployed plugins (use `aidevops plugin update` to refresh)
   - Reports summary (deployed/skipped/failed counts)

### Edge cases handled

- No `plugins.json` file: silently skips
- No `jq` available: warns and skips
- Empty plugins array: silently skips
- All plugins disabled: reports and skips
- Clone failure (network/auth): warns but continues (non-blocking)
- Plugin already deployed: skips re-clone

### Testing

- `bash -n setup.sh` -- syntax OK
- Functional test with empty plugins.json -- correctly returns early
- No regressions in core agent deployment flow

Fixes: t136.3 ref:GH#730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins are now automatically deployed during setup—enabled plugins are installed, disabled ones are removed, and existing directories are preserved.
  * Plugin namespaces are protected and maintained during agent deployments.

* **Documentation**
  * Added documentation detailing automatic plugin deployment behavior and procedures for refreshing plugins after updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->