### PR TITLE
feat: add plugin template and 'aidevops plugin init' command (t136.4)

### DIFF
--- a/.agents/aidevops/plugins.md
+++ b/.agents/aidevops/plugins.md
@@ -101,6 +101,14 @@ Disabling removes the deployed directory but preserves the config entry.
 aidevops plugin remove pro       # Removes config entry and deployed files
 ```
 
+### Create a New Plugin
+
+```bash
+aidevops plugin init ./my-plugin my-plugin my-ns
+```
+
+Arguments: `[directory] [name] [namespace]`. Scaffolds a plugin from the built-in template with placeholder substitution. The generated structure includes AGENTS.md, a main agent file, an example subagent, and a scripts directory.
+
 ## Plugin Repository Structure
 
 A plugin repo should follow this structure:

--- a/.agents/templates/plugin-template/AGENTS.md
+++ b/.agents/templates/plugin-template/AGENTS.md
@@ -1,0 +1,26 @@
+# {{PLUGIN_NAME}} Plugin
+
+> This is an [aidevops](https://aidevops.sh) plugin. Install with:
+>
+> ```bash
+> aidevops plugin add {{REPO_URL}} --namespace {{NAMESPACE}}
+> ```
+
+## Agents
+
+| Agent | Purpose |
+|-------|---------|
+| `{{NAMESPACE}}.md` | Main agent for {{PLUGIN_NAME}} |
+
+## Setup
+
+1. Install the plugin: `aidevops plugin add {{REPO_URL}} --namespace {{NAMESPACE}}`
+2. Configure any required credentials: `aidevops secret set {{PLUGIN_NAME_UPPER}}_API_KEY`
+3. Use the agent: reference `{{NAMESPACE}}/` agents in your workflow
+
+## Configuration
+
+This plugin reads configuration from:
+
+- `~/.config/aidevops/credentials.sh` (API keys)
+- `.aidevops.json` in your project root (project-level settings)

--- a/.agents/templates/plugin-template/example-subagent.md
+++ b/.agents/templates/plugin-template/example-subagent.md
@@ -1,0 +1,25 @@
+---
+tools:
+  - bash
+  - read
+model: sonnet
+---
+
+# Example Subagent
+
+This is an example subagent for the {{PLUGIN_NAME}} plugin.
+
+## Purpose
+
+Describe what this subagent does.
+
+## Usage
+
+Reference this subagent from the main agent or invoke directly.
+
+## Commands
+
+```bash
+# Example command
+echo "Hello from {{NAMESPACE}}"
+```

--- a/.agents/templates/plugin-template/main-agent.md
+++ b/.agents/templates/plugin-template/main-agent.md
@@ -1,0 +1,44 @@
+---
+tools:
+  - bash
+  - read
+  - edit
+  - write
+model: sonnet
+---
+
+# {{PLUGIN_NAME}}
+
+{{PLUGIN_DESCRIPTION}}
+
+## Quick Reference
+
+- **Purpose**: {{PLUGIN_DESCRIPTION}}
+- **Namespace**: `{{NAMESPACE}}`
+- **Requires**: aidevops framework (`~/.aidevops/agents/` must exist)
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/{{NAMESPACE}}-help` | Show available commands |
+
+## Subagents
+
+| File | Purpose |
+|------|---------|
+| `{{NAMESPACE}}/example.md` | Example subagent |
+
+## Workflow
+
+1. Step one
+2. Step two
+3. Step three
+
+## Integration
+
+This plugin integrates with the aidevops framework:
+
+- Uses `~/.config/aidevops/credentials.sh` for API keys
+- Follows aidevops agent conventions (YAML frontmatter, progressive disclosure)
+- Compatible with supervisor dispatch and headless workers


### PR DESCRIPTION
## Summary

- Create `plugin-template/` in `.agents/templates/` with AGENTS.md, main-agent.md, and example-subagent.md
- Add `aidevops plugin init [dir] [name] [namespace]` subcommand that scaffolds a new plugin from the template
- Template uses `{{PLACEHOLDER}}` substitution for plugin name, namespace, repo URL, etc.
- Update `plugins.md` to document the `init` command

## Details

Part of the Plugin System plan (t136). Follows t136.3 (setup.sh deployment, PR #762).

### Template files

| File | Purpose |
|------|---------|
| `AGENTS.md` | Plugin documentation with install instructions |
| `main-agent.md` | Main agent with YAML frontmatter, commands table, workflow |
| `example-subagent.md` | Example subagent to demonstrate structure |

### Usage

```bash
aidevops plugin init ./my-plugin my-plugin my-ns
```

Generates:
```
./my-plugin/
├── AGENTS.md           # Plugin documentation
├── my-ns.md            # Main agent
├── my-ns/
│   └── example.md      # Example subagent
└── scripts/            # Helper scripts (empty)
```

### Testing

- `bash -n aidevops.sh` -- syntax OK
- `aidevops plugin help` -- shows `init` command
- `aidevops plugin init /tmp/test test-plugin test` -- scaffolds correctly with all placeholders substituted

Fixes: t136.4 ref:GH#731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `plugin init` [directory] [name] command to scaffold new plugins with auto-generated configuration, main agent files, example subagents, and scripts directory.

* **Documentation**
  * Added comprehensive Plugin System guidance describing the initialization command, generated scaffolding structure, and next steps for plugin development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->