### PR TITLE
fix: add missing log_verbose function to supervisor-helper.sh

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -180,6 +180,7 @@ log_info() { echo -e "${BLUE}[SUPERVISOR]${NC} $*"; }
 log_success() { echo -e "${GREEN}[SUPERVISOR]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[SUPERVISOR]${NC} $*"; }
 log_error() { echo -e "${RED}[SUPERVISOR]${NC} $*" >&2; }
+log_verbose() { [[ "${SUPERVISOR_VERBOSE:-}" == "true" ]] && echo -e "${BLUE}[SUPERVISOR]${NC} $*" || true; }
 
 # Supervisor stderr log file - captures stderr from commands that previously
 # used 2>/dev/null, making errors debuggable without cluttering terminal output.


### PR DESCRIPTION
## Summary

- Adds the missing `log_verbose()` function to `supervisor-helper.sh`
- The pulse function called `log_verbose()` in phases 8-10 (issue-sync skip, memory audit, CodeRabbit pulse) but the function was never defined
- This caused `command not found` errors on every cron pulse execution
- `log_verbose` is a conditional debug logger that only outputs when `SUPERVISOR_VERBOSE=true`, keeping normal pulse output clean

## Testing

- ShellCheck: no new violations
- Verified the function definition follows the same pattern as `log_info`, `log_success`, `log_warn`, `log_error`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for verbose logging output that can be enabled via configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->