### PR TITLE
feat: auto-verification pipeline for supervisor batch tasks (t180.4)

### DIFF
--- a/.agents/scripts/verify-run-helper.sh
+++ b/.agents/scripts/verify-run-helper.sh
@@ -63,7 +63,7 @@ parse_entry() {
 
     while IFS= read -r line; do
         # Match entry header
-        if [[ "$line" =~ ^-\ \[(.)\]\ (v[0-9]+)\ (t[0-9]+)\ (.+) ]]; then
+        if [[ "$line" =~ ^-\ \[(.)\]\ (v[0-9]+)\ (t[0-9.]+)\ (.+) ]]; then
             if $in_entry; then
                 break
             fi


### PR DESCRIPTION
## Summary

Closes the verification gap in the supervisor batch pipeline. Previously, tasks went from `deployed` to done without any proof that deliverables actually work. Now:

- **Auto-generates VERIFY.md entries** when tasks transition to `deployed` state
  - Inspects PR file diffs via `gh` CLI
  - Creates appropriate check directives: `shellcheck` for `.sh`, `file-exists` for `.md`, `bash` for test files
- **Runs pending verifications** in pulse Phase 3b via `verify-run-helper.sh`
  - Transitions tasks: `deployed` -> `verified` (checks pass) or `verify_failed` (checks fail)
  - Results logged to `todo/verify-proof-log.md` as auditable evidence
- **Fixes subtask ID parsing** in `verify-run-helper.sh` (regex `t[0-9]+` -> `t[0-9.]+`)

## Pipeline Flow

```
worker completes -> PR merged -> deployed -> verify entry generated -> checks run -> verified/verify_failed
```

## Testing

- `bash -n` syntax check: pass on both files
- ShellCheck: no new violations
- Existing v001-v029 entries unaffected (backward compatible)