### PR TITLE
feat: model availability checker - probe before dispatch (t132.3)

### DIFF
--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -180,6 +180,32 @@ Interactive commands: `/compare-models` (with live web fetch), `/compare-models-
 
 The model registry (`model-registry-helper.sh`) maintains a SQLite database tracking all known models across providers. It syncs from subagent frontmatter, embedded pricing data, and live provider APIs. Use `model-registry-helper.sh status` to check registry health and `model-registry-helper.sh check` to verify configured models are available.
 
+## Model Availability (Pre-Dispatch)
+
+The model availability checker (`model-availability-helper.sh`) provides lightweight, cached health probes for use before dispatch. Unlike the model registry (which tracks what models exist), the availability checker tests whether providers are currently responding and API keys are valid.
+
+```bash
+# Check if a provider is healthy (fast: direct HTTP, ~1-2s, cached 5min)
+model-availability-helper.sh check anthropic
+
+# Check a specific model
+model-availability-helper.sh check anthropic/claude-sonnet-4-20250514
+
+# Resolve best available model for a tier (with automatic fallback)
+model-availability-helper.sh resolve opus
+
+# Probe all configured providers
+model-availability-helper.sh probe
+
+# View cached status and rate limits
+model-availability-helper.sh status
+model-availability-helper.sh rate-limits
+```
+
+The supervisor uses this automatically during dispatch (t132.3). The availability helper is ~4-8x faster than the previous CLI-based health probe because it calls provider `/models` endpoints directly via HTTP instead of spawning a full AI CLI session.
+
+Exit codes: 0=available, 1=unavailable, 2=rate-limited, 3=API-key-invalid.
+
 <!-- AI-CONTEXT-END -->
 
 ## Decision Flowchart

--- a/tests/test-model-availability.sh
+++ b/tests/test-model-availability.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# test-model-availability.sh
+#
+# Tests for model-availability-helper.sh (t132.3)
+# Validates: syntax, help output, DB init, cache logic, tier resolution,
+# and integration with supervisor resolve_model/check_model_health.
+#
+# Usage: bash tests/test-model-availability.sh [--verbose]
+#
+# Exit codes: 0 = all pass, 1 = failures found
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$REPO_DIR/.agents/scripts/model-availability-helper.sh"
+SUPERVISOR="$REPO_DIR/.agents/scripts/supervisor-helper.sh"
+VERBOSE="${1:-}"
+
+# Portable timeout: gtimeout (macOS homebrew) > timeout (Linux) > none
+TIMEOUT_CMD=""
+if command -v gtimeout &>/dev/null; then
+    TIMEOUT_CMD="gtimeout"
+elif command -v timeout &>/dev/null; then
+    TIMEOUT_CMD="timeout"
+fi
+
+# Run a command with optional timeout
+run_with_timeout() {
+    local secs="$1"
+    shift
+    if [[ -n "$TIMEOUT_CMD" ]]; then
+        "$TIMEOUT_CMD" "$secs" "$@"
+    else
+        "$@"
+    fi
+}
+
+# --- Test Framework ---
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+TOTAL_COUNT=0
+
+pass() {
+    PASS_COUNT=$((PASS_COUNT + 1))
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
+    if [[ "$VERBOSE" == "--verbose" ]]; then
+        printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+    fi
+    return 0
+}
+
+fail() {
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
+    printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+    if [[ -n "${2:-}" ]]; then
+        printf "       %s\n" "$2"
+    fi
+    return 0
+}
+
+skip() {
+    SKIP_COUNT=$((SKIP_COUNT + 1))
+    TOTAL_COUNT=$((TOTAL_COUNT + 1))
+    if [[ "$VERBOSE" == "--verbose" ]]; then
+        printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+    fi
+    return 0
+}
+
+section() {
+    echo ""
+    printf "\033[1m=== %s ===\033[0m\n" "$1"
+}
+
+# Use a temp DB for testing to avoid polluting real cache
+TEST_DB_DIR=$(mktemp -d)
+export AVAILABILITY_DB_OVERRIDE="$TEST_DB_DIR/test-availability.db"
+trap 'rm -rf "$TEST_DB_DIR"' EXIT
+
+# ============================================================
+# SECTION 1: Basic validation
+# ============================================================
+section "Basic Validation"
+
+# Syntax check
+if bash -n "$HELPER" 2>/dev/null; then
+    pass "bash -n syntax check"
+else
+    fail "bash -n syntax check" "Script has syntax errors"
+fi
+
+# ShellCheck
+if command -v shellcheck &>/dev/null; then
+    sc_output=$(shellcheck "$HELPER" 2>&1 || true)
+    sc_errors=$(echo "$sc_output" | grep -c "error" 2>/dev/null || true)
+    if [[ "$sc_errors" -eq 0 ]]; then
+        pass "shellcheck (0 errors)"
+    else
+        fail "shellcheck ($sc_errors errors)" "$(echo "$sc_output" | head -5)"
+    fi
+else
+    skip "shellcheck not installed"
+fi
+
+# Help command
+help_output=$(run_with_timeout 5 bash "$HELPER" help 2>&1) || true
+if [[ -n "$help_output" ]]; then
+    pass "help command produces output"
+else
+    fail "help command produces output" "No output"
+fi
+
+# Help mentions key commands
+if echo "$help_output" | grep -qi "check"; then
+    pass "help mentions 'check' command"
+else
+    fail "help mentions 'check' command"
+fi
+
+if echo "$help_output" | grep -qi "probe"; then
+    pass "help mentions 'probe' command"
+else
+    fail "help mentions 'probe' command"
+fi
+
+if echo "$help_output" | grep -qi "resolve"; then
+    pass "help mentions 'resolve' command"
+else
+    fail "help mentions 'resolve' command"
+fi
+
+if echo "$help_output" | grep -qi "rate-limits"; then
+    pass "help mentions 'rate-limits' command"
+else
+    fail "help mentions 'rate-limits' command"
+fi
+
+# ============================================================
+# SECTION 2: Status command (no prior data)
+# ============================================================
+section "Status Command (Empty State)"
+
+status_output=$(run_with_timeout 5 bash "$HELPER" status 2>&1) || true
+if [[ -n "$status_output" ]]; then
+    pass "status command runs without error"
+else
+    fail "status command runs without error" "No output or error"
+fi
+
+# ============================================================
+# SECTION 3: Resolve command (tier resolution)
+# ============================================================
+section "Tier Resolution"
+
+# Test that resolve returns a model spec for known tiers
+for tier in haiku flash sonnet pro opus health eval coding; do
+    resolve_output=$(run_with_timeout 15 bash "$HELPER" resolve "$tier" --quiet 2>&1) || true
+    # Even without API keys, resolve should return the primary model
+    # (it falls through to the primary when no probe is possible)
+    if [[ -n "$resolve_output" && "$resolve_output" == *"/"* ]]; then
+        pass "resolve $tier -> $resolve_output"
+    else
+        # May fail if no API keys configured - that's OK for CI
+        skip "resolve $tier (no API keys or provider unavailable)"
+    fi
+done
+
+# Test unknown tier (use || true to prevent set -e from aborting on expected failure)
+if run_with_timeout 5 bash "$HELPER" resolve "nonexistent" --quiet >/dev/null 2>&1; then
+    fail "resolve unknown tier returns error" "Expected non-zero exit"
+else
+    pass "resolve unknown tier returns error"
+fi
+
+# ============================================================
+# SECTION 4: Check command
+# ============================================================
+section "Check Command"
+
+# Check with unknown provider (use if to prevent set -e from aborting on expected failure)
+if run_with_timeout 5 bash "$HELPER" check "nonexistent_provider_xyz" --quiet >/dev/null 2>&1; then
+    fail "check unknown target returns error" "Expected non-zero exit, got 0"
+else
+    pass "check unknown target returns error"
+fi
+
+# Check with known provider (may succeed or fail depending on keys)
+# Use || true to prevent set -e from aborting on non-zero exit
+for provider in anthropic openai google; do
+    check_exit=0
+    run_with_timeout 15 bash "$HELPER" check "$provider" --quiet >/dev/null 2>&1 || check_exit=$?
+    case "$check_exit" in
+        0) pass "check $provider: healthy" ;;
+        1) pass "check $provider: unhealthy (expected without key)" ;;
+        2) pass "check $provider: rate limited" ;;
+        3) pass "check $provider: no key (expected in CI)" ;;
+        *) fail "check $provider: unexpected exit code $check_exit" ;;
+    esac
+done
+
+# ============================================================
+# SECTION 5: Invalidate command
+# ============================================================
+section "Cache Invalidation"
+
+run_with_timeout 5 bash "$HELPER" invalidate >/dev/null 2>&1
+invalidate_exit=$?
+if [[ $invalidate_exit -eq 0 ]]; then
+    pass "invalidate all caches"
+else
+    fail "invalidate all caches" "Exit code: $invalidate_exit"
+fi
+
+run_with_timeout 5 bash "$HELPER" invalidate anthropic >/dev/null 2>&1
+invalidate_prov_exit=$?
+if [[ $invalidate_prov_exit -eq 0 ]]; then
+    pass "invalidate specific provider cache"
+else
+    fail "invalidate specific provider cache" "Exit code: $invalidate_prov_exit"
+fi
+
+# ============================================================
+# SECTION 6: Supervisor integration
+# ============================================================
+section "Supervisor Integration"
+
+# Verify supervisor references the availability helper
+if grep -q "model-availability-helper.sh" "$SUPERVISOR"; then
+    pass "supervisor references model-availability-helper.sh"
+else
+    fail "supervisor references model-availability-helper.sh"
+fi
+
+# Verify resolve_model() has availability helper fast path
+if grep -q "availability_helper.*resolve" "$SUPERVISOR"; then
+    pass "resolve_model() uses availability helper"
+else
+    fail "resolve_model() uses availability helper"
+fi
+
+# Verify check_model_health() has availability helper fast path
+if grep -q "availability_helper.*check" "$SUPERVISOR"; then
+    pass "check_model_health() uses availability helper fast path"
+else
+    fail "check_model_health() uses availability helper fast path"
+fi
+
+# Verify check_model_health() still has CLI fallback
+if grep -q 'health-check' "$SUPERVISOR"; then
+    pass "check_model_health() retains CLI fallback (slow path)"
+else
+    fail "check_model_health() retains CLI fallback (slow path)"
+fi
+
+# ============================================================
+# SECTION 7: JSON output
+# ============================================================
+section "JSON Output"
+
+# Status --json
+json_status=$(run_with_timeout 5 bash "$HELPER" status --json 2>&1) || true
+if echo "$json_status" | grep -q "{" 2>/dev/null; then
+    pass "status --json produces JSON"
+else
+    skip "status --json (no data to format)"
+fi
+
+# Resolve --json
+json_resolve=$(run_with_timeout 15 bash "$HELPER" resolve sonnet --json --quiet 2>&1) || true
+if echo "$json_resolve" | grep -q "tier" 2>/dev/null; then
+    pass "resolve --json produces JSON with tier field"
+else
+    skip "resolve --json (provider may be unavailable)"
+fi
+
+# ============================================================
+# SUMMARY
+# ============================================================
+echo ""
+echo "========================================"
+printf "  \033[1mResults: %d total, \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m, \033[0;33m%d skipped\033[0m\n" \
+    "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+echo "========================================"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+    echo ""
+    printf "\033[0;31mFAILURES DETECTED - review output above\033[0m\n"
+    exit 1
+else
+    echo ""
+    printf "\033[0;32mAll tests passed.\033[0m\n"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- **New `model-availability-helper.sh`**: Lightweight HTTP probes (~1-2s) to check provider health, API key validity, rate limits, and model availability before dispatch — replacing the slow CLI probe path (~8-15s that burns tokens)
- **Supervisor integration**: `resolve_model()` and `check_model_health()` now use the availability helper as a fast path, with the existing CLI probe retained as a slow-path fallback
- **Test suite**: 29 tests covering syntax, ShellCheck, help output, tier resolution, provider checks, cache invalidation, supervisor integration, and JSON output

## Details

### model-availability-helper.sh (~1150 lines)
- Commands: `check`, `probe`, `status`, `rate-limits`, `resolve`, `invalidate`, `help`
- SQLite cache at `~/.aidevops/.agent-workspace/model-availability.db` (5min health TTL, 60s rate limit TTL)
- API key resolution: env vars → gopass → credentials.sh
- Probes provider `/models` endpoints (free, fast)
- Parses rate limit headers (Anthropic, OpenAI, Groq specific + generic)
- Tier-to-model resolution with automatic cross-provider fallback
- Exit codes: 0=available, 1=unavailable, 2=rate-limited, 3=key-invalid
- Bash 3.2-compatible (no associative arrays — macOS ships bash 3.2)
- ShellCheck clean (0 warnings)

### Supervisor changes
- `resolve_model()`: Added availability-helper fast path before static defaults
- `check_model_health()`: Two-tier probe — fast HTTP path, slow CLI fallback

### Design decisions
- **Direct HTTP over CLI probes**: Existing `check_model_health()` spawned a full `opencode run` session (~8-15s, burns tokens). New helper calls `/models` endpoints directly via curl (~1-2s, free)
- **Bash 3.2 compatibility**: Used `case` statement functions instead of `declare -A` associative arrays
- **Two-tier fallback**: New helper is fast path; old CLI probe kept as slow-path fallback for environments without the helper

### Test results
```
Results: 29 total, 20 passed, 0 failed, 9 skipped
```
(9 skipped = tier resolution tests that require API keys, gracefully handled)

Smoke tests: 373 total, 309 passed, 0 failed — no regressions.