### PR TITLE
fix: handle bash -n syntax check directive in verify-run-helper.sh (t192)

### DIFF
--- a/.agents/scripts/verify-run-helper.sh
+++ b/.agents/scripts/verify-run-helper.sh
@@ -182,6 +182,19 @@ execute_check() {
         fi
     fi
 
+    # bash -n <path> (syntax check)
+    if [[ "$directive" =~ ^bash\ -n\ (.+) ]]; then
+        local script_path="${BASH_REMATCH[1]}"
+        local full_path="$project_root/$script_path"
+        output=$(bash -n "$full_path" 2>&1) && exit_code=0 || exit_code=$?
+        if [[ $exit_code -eq 0 ]]; then
+            RESULT_SUMMARY="syntax OK"
+        else
+            RESULT_SUMMARY="syntax error | ${output:0:80}"
+        fi
+        [[ $exit_code -eq 0 ]] && return 0 || return 1
+    fi
+
     # bash <path> (test scripts)
     if [[ "$directive" =~ ^bash\ (.+) ]]; then
         local script_path="${BASH_REMATCH[1]}"
@@ -438,6 +451,7 @@ Check directives (in VERIFY.md):
   file-exists <path>           Test file exists, report size
   rg "pattern" <path>          Ripgrep match count
   shellcheck <path>            ShellCheck analysis
+  bash -n <path>               Syntax check (bash -n), no execution
   bash <path>                  Run test script, capture pass/fail
 
 Proof log:


### PR DESCRIPTION
## Summary

- Adds dedicated `bash -n` (syntax check) handler in `verify-run-helper.sh` before the generic `bash` handler
- Previously, `bash -n script.sh` was parsed as `bash "/path/-n script.sh"` because the regex `^bash (.+)` captured `-n` as part of the file path
- Now correctly runs `bash -n "/path/script.sh"` and reports "syntax OK" or the syntax error

## Testing

- Tested with a temporary v999 VERIFY entry containing `check: bash -n .agents/scripts/verify-run-helper.sh`
- Proof log shows: `PASS | check 1: bash -n .agents/scripts/verify-run-helper.sh | exit: 0 | syntax OK`
- ShellCheck clean, bash -n clean

## Impact

Unblocks future VERIFY entries that use `bash -n` for syntax validation. Previously all such entries would fail with exit 127.