### PR TITLE
fix: correct model tier from sonnet to opus for primary agents

### DIFF
--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -1,15 +1,15 @@
 <!--TOON:agents[11]{name,file,purpose,model_tier}:
-Build+,build-plus.md,Enhanced Build with context tools,sonnet
-SEO,seo.md,SEO optimization and analysis,sonnet
-Content,content.md,Content creation workflows,sonnet
+Build+,build-plus.md,Enhanced Build with context tools,opus
+SEO,seo.md,SEO optimization and analysis,opus
+Content,content.md,Content creation workflows,opus
 Research,research.md,Research and analysis tasks,flash
-Marketing,marketing.md,Marketing strategy and email campaigns (FluentCRM),sonnet
-Sales,sales.md,Sales operations and CRM pipeline (FluentCRM),sonnet
-Legal,legal.md,Legal compliance,sonnet
-Accounts,accounts.md,Financial operations,sonnet
-Health,health.md,Health and wellness,sonnet
-Social-Media,social-media.md,Social media management,sonnet
-Video,video.md,AI video generation and prompt engineering,sonnet
+Marketing,marketing.md,Marketing strategy and email campaigns (FluentCRM),opus
+Sales,sales.md,Sales operations and CRM pipeline (FluentCRM),opus
+Legal,legal.md,Legal compliance,opus
+Accounts,accounts.md,Financial operations,opus
+Health,health.md,Health and wellness,opus
+Social-Media,social-media.md,Social media management,opus
+Video,video.md,AI video generation and prompt engineering,opus
 -->
 
 <!--TOON:model_tiers[5]{tier,model_id,use_case}:

--- a/README.md
+++ b/README.md
@@ -1476,17 +1476,17 @@ Primary agents as registered in `subagent-index.toon` (11 total). MCPs are loade
 
 | Name | File | Purpose | Model Tier |
 |------|------|---------|------------|
-| Build+ | `build-plus.md` | Enhanced Build with context tools (default agent) | sonnet |
-| SEO | `seo.md` | SEO optimization and analysis | sonnet |
-| Content | `content.md` | Content creation workflows | sonnet |
+| Build+ | `build-plus.md` | Enhanced Build with context tools (default agent) | opus |
+| SEO | `seo.md` | SEO optimization and analysis | opus |
+| Content | `content.md` | Content creation workflows | opus |
 | Research | `research.md` | Research and analysis tasks | flash |
-| Marketing | `marketing.md` | Marketing strategy and email campaigns | sonnet |
-| Sales | `sales.md` | Sales operations and CRM pipeline | sonnet |
-| Legal | `legal.md` | Legal compliance | sonnet |
-| Accounts | `accounts.md` | Financial operations | sonnet |
-| Health | `health.md` | Health and wellness | sonnet |
-| Social-Media | `social-media.md` | Social media management | sonnet |
-| Video | `video.md` | AI video generation and prompt engineering | sonnet |
+| Marketing | `marketing.md` | Marketing strategy and email campaigns | opus |
+| Sales | `sales.md` | Sales operations and CRM pipeline | opus |
+| Legal | `legal.md` | Legal compliance | opus |
+| Accounts | `accounts.md` | Financial operations | opus |
+| Health | `health.md` | Health and wellness | opus |
+| Social-Media | `social-media.md` | Social media management | opus |
+| Video | `video.md` | AI video generation and prompt engineering | opus |
 
 **Specialist subagents** (@plan-plus, @aidevops, @wordpress, Build-Agent, Build-MCP, etc.) live under `tools/` or as `mode: subagent` files and are invoked via @mention when domain expertise is needed. See `subagent-index.toon` for the full listing.
 


### PR DESCRIPTION
## Summary

- Fixes model tier in TOON index and README table: `sonnet` → `opus` for all primary agents
- Research agent stays on `flash` (intentional — fast/cheap for research tasks)
- Primary agents run on opus (claude-opus-4) as the interactive coding tier