### PR TITLE
feat: wire up /compare-models and /compare-models-free slash commands (t168.4)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -318,7 +318,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting) |
 | Cloud GPU | `tools/infrastructure/cloud-gpu.md` |
 | Model routing | `tools/context/model-routing.md`, `model-registry-helper.sh`, `fallback-chain-helper.sh`, `model-availability-helper.sh` |
-| Model comparison | `tools/ai-assistants/compare-models.md`, `tools/ai-assistants/response-scoring.md`, `aidevops/claude-flow-comparison.md` |
+| Model comparison | `tools/ai-assistants/compare-models.md`, `tools/ai-assistants/response-scoring.md`, `/compare-models`, `/compare-models-free`, `/score-responses` |
 | Pattern tracking | `memory/README.md` "Pattern Tracking", `pattern-tracker-helper.sh`, `scripts/commands/patterns.md` |
 | Self-improvement | `aidevops/self-improving-agents.md`, `self-improve-helper.sh` (analyze → refine → test → pr) |
 | Parallel agents | `tools/ai-assistants/headless-dispatch.md`, `tools/ai-assistants/runners/` |

--- a/.agents/tools/ai-assistants/compare-models.md
+++ b/.agents/tools/ai-assistants/compare-models.md
@@ -151,6 +151,9 @@ Use discovery output to filter `/compare-models` to only show models the user ca
 
 ## Related
 
+- `scripts/commands/compare-models.md` - `/compare-models` slash command handler
+- `scripts/commands/compare-models-free.md` - `/compare-models-free` slash command handler
+- `scripts/commands/score-responses.md` - `/score-responses` slash command handler
 - `tools/ai-assistants/response-scoring.md` - Evaluate actual model response quality
 - `tools/context/model-routing.md` - Cost-aware model routing within aidevops
 - `tools/voice/voice-ai-models.md` - Voice-specific model comparison

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The result: AI agents that work *with* your development process, not around it.
 - 11 primary agents (Build+, SEO, Marketing, etc.) with specialist @subagents on demand
 - 735+ subagent markdown files organized by domain
 - 194 helper scripts in `.agents/scripts/`
-- 39 slash commands for common workflows
+- 53 slash commands for common workflows
 
 <!-- AI-CONTEXT-END -->
 
@@ -465,6 +465,8 @@ aidevops implements proven agent design patterns identified by [Lance Martin (La
 | **Evolve Context** | Learn from sessions | `/remember`, `/recall` with SQLite FTS5 + opt-in semantic search |
 | **Pattern Tracking** | Learn what works/fails | `pattern-tracker-helper.sh`, `/patterns` command |
 | **Cost-Aware Routing** | Match model to task complexity | `model-routing.md` with 5-tier guidance, `/route` command |
+| **Model Comparison** | Compare models side-by-side | `/compare-models` (live data), `/compare-models-free` (offline) |
+| **Response Scoring** | Evaluate actual model outputs | `/score-responses` with structured criteria |
 
 **Key insight**: Context is a finite resource with diminishing returns. aidevops treats every token as precious - loading only what's needed, when it's needed.
 
@@ -1709,6 +1711,15 @@ Configure time tracking per-repo via `.aidevops.json`.
 | `/preflight-loop` | Run preflight checks iteratively until all pass |
 | `/runners` | Batch dispatch tasks to parallel agents (task IDs, PR URLs, or descriptions) |
 | `/log-issue-aidevops` | Report issues with aidevops (gathers diagnostics, checks duplicates, creates GitHub issue) |
+
+**AI Model Comparison**:
+
+| Command | Purpose |
+|---------|---------|
+| `/compare-models` | Compare AI models by pricing, context, capabilities (with live web data) |
+| `/compare-models-free` | Compare AI models using offline embedded data only (no web fetches) |
+| `/score-responses` | Score and compare actual model responses with structured criteria |
+| `/route` | Suggest optimal model tier for a task description |
 
 ### Ralph Loop - Iterative AI Development
 


### PR DESCRIPTION
## Summary

- Add `/compare-models`, `/compare-models-free`, `/score-responses`, and `/route` to README.md as a new "AI Model Comparison" slash commands section
- Add "Model comparison" row to AGENTS.md progressive disclosure table with links to `compare-models.md` subagent and slash commands
- Add command handler cross-references to `compare-models.md` Related section
- Update README slash command count from 39 to 53 (reflects actual unique commands)
- Update README architecture table with Model Comparison and Response Scoring capabilities

## Task

Closes #724 (t168.4)

Blocked-by: t168.3 (PR #773, merged)

## What Changed

The command handler `.md` files for `/compare-models` and `/compare-models-free` already existed in `.agents/scripts/commands/` (created in t168/PR #660), and the `compare-models-helper.sh` backend was fully functional. This PR "wires them up" by:

1. **README.md**: Added "AI Model Comparison" section to the slash commands reference so users can discover these commands
2. **AGENTS.md**: Added "Model comparison" to the progressive disclosure table so the AI agent loads `compare-models.md` when model comparison tasks are detected
3. **compare-models.md**: Added cross-references to the command handler files in the Related section
4. **Slash command count**: Updated from stale "39" to accurate "53" based on actual unique commands in README

## Testing

- All command handler files verified to exist
- ShellCheck clean on `compare-models-helper.sh` (only SC1091 info-level for sourced file)
- Markdown formatting verified (blank lines around tables, consistent table structure)