### PR TITLE
docs: add model routing and scoring to AGENTS.md and subagent-index (t102.4)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -281,6 +281,8 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | Encryption | `tools/credentials/encryption-stack.md` (decision tree), `tools/credentials/sops.md`, `tools/credentials/gocryptfs.md`, `tools/credentials/gopass.md` |
 | Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting) |
 | Cloud GPU | `tools/infrastructure/cloud-gpu.md` |
+| Model routing | `tools/context/model-routing.md`, `model-registry-helper.sh`, `fallback-chain-helper.sh`, `model-availability-helper.sh` |
+| Model comparison | `tools/ai-assistants/compare-models.md`, `tools/ai-assistants/response-scoring.md`, `aidevops/claude-flow-comparison.md` |
 | Parallel agents | `tools/ai-assistants/headless-dispatch.md`, `tools/ai-assistants/runners/` |
 | Orchestration | `supervisor-helper.sh` (batch dispatch, cron pulse, self-healing), `/runners-check` (quick queue status) |
 | MCP dev | `tools/build-mcp/build-mcp.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -22,7 +22,7 @@ grok,grok-3,Research and real-time web knowledge
 -->
 
 <!--TOON:subagents[41]{folder,purpose,key_files}:
-aidevops/,Framework internals - extending aidevops and architecture,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison
+aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings and UX/CRO,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper|mom-test-ux
 content/,Content creation - copywriting and editorial,guidelines|platform-personas|humanise|seo-writer|meta-creator|editor|internal-linker|context-templates
@@ -30,7 +30,7 @@ tools/content/,Content tools - calendar planning summarization and extraction,co
 tools/social-media/,Social media tools - X/Twitter LinkedIn and Reddit,bird|linkedin|reddit
 tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-review|agent-testing
 tools/build-mcp/,MCP development - creating MCP servers,build-mcp|server-patterns|api-wrapper|transports|deployment
-tools/ai-assistants/,AI tool integration - OpenCode headless dispatch and model comparison,agno|capsolver|claude-code|compare-models|overview|openclaw|opencode-server|headless-dispatch
+tools/ai-assistants/,AI tool integration - OpenCode headless dispatch model comparison and response scoring,agno|capsolver|claude-code|compare-models|response-scoring|overview|openclaw|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
 tools/browser/,Browser automation - scraping and testing,agent-browser|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy
 tools/mobile/,Mobile development - iOS/macOS build test simulator and emulator automation,agent-device|xcodebuild-mcp|ios-simulator-mcp|maestro|axe-cli|minisim
@@ -80,7 +80,7 @@ bug-fixing,workflows/bug-fixing.md,Bug fix workflow
 feature-development,workflows/feature-development.md,Feature development workflow
 -->
 
-<!--TOON:scripts[52]{name,purpose}:
+<!--TOON:scripts[57]{name,purpose}:
 list-keys-helper.sh,List all API keys with storage locations
 list-verify-helper.sh,List verification queue entries with filtering (pending passed failed)
 verify-run-helper.sh,Execute verification checks with proof logging to verify-proof-log.md
@@ -132,6 +132,10 @@ voice-bridge.py,Voice bridge Python script (VAD STT LLM TTS with session handbac
 seo-content-analyzer.py,SEO content analysis (readability keywords intent quality scoring)
 compare-models-helper.sh,AI model capability comparison (list compare recommend pricing context capabilities providers)
 model-registry-helper.sh,Provider/model registry with periodic sync (sync list status check suggest deprecations diff export)
+model-availability-helper.sh,Model availability checker - probe before dispatch (check probe status cache clear)
+fallback-chain-helper.sh,Fallback chain configuration - per-agent and global model fallbacks (list get set test status validate)
+response-scoring-helper.sh,Response scoring - evaluate AI model responses side-by-side (prompt record score compare leaderboard export)
+coderabbit-task-creator-helper.sh,Auto-create tasks from CodeRabbit findings with false positive filtering (scan create filter status)
 sops-helper.sh,SOPS encrypted config file management (init encrypt decrypt edit rotate status install)
 gocryptfs-helper.sh,gocryptfs encrypted filesystem overlay (init mount unmount create open close list status install)
 -->


### PR DESCRIPTION
## Summary

- Add 4 missing helper scripts to `subagent-index.toon`: `model-availability-helper.sh`, `fallback-chain-helper.sh`, `response-scoring-helper.sh`, `coderabbit-task-creator-helper.sh`
- Add **Model routing** and **Model comparison** rows to AGENTS.md progressive disclosure table
- Fix script count (was declared 52, actual 53, now 57 with 4 new entries)

All t102.1-t102.3 deliverables (cost-aware routing, semantic memory, success patterns) were already documented in their respective subagent files and `memory/README.md`. This PR completes the integration by ensuring discoverability via the index and AGENTS.md.

Fixes: t102.4 ref:GH#744