### PR TITLE
feat: scaffold aidevops-pro and aidevops-anon plugin repos (t136.5)

### DIFF
--- a/.agents/aidevops/plugins.md
+++ b/.agents/aidevops/plugins.md
@@ -11,7 +11,7 @@ Plugins are configured in `.aidevops.json` under the `plugins` array:
   "plugins": [
     {
       "name": "pro",
-      "repo": "https://github.com/user/aidevops-pro.git",
+      "repo": "https://github.com/marcusquinn/aidevops-pro.git",
       "branch": "main",
       "namespace": "pro",
       "enabled": true
@@ -57,7 +57,7 @@ Plugins deploy to `~/.aidevops/agents/<namespace>/`:
 ### Add a Plugin
 
 ```bash
-aidevops plugin add https://github.com/user/aidevops-pro.git --namespace pro
+aidevops plugin add https://github.com/marcusquinn/aidevops-pro.git --namespace pro
 ```
 
 This:
@@ -146,3 +146,38 @@ Plugins occupy a distinct tier alongside existing tiers:
 Plugin state is stored in `~/.config/aidevops/plugins.json` (global, not per-project). The file is auto-created on first use. Per-project `.aidevops.json` also has a `plugins` array for project-level plugin awareness.
 
 Run `aidevops plugin help` for full CLI documentation.
+
+## Official Plugins
+
+The following plugins are maintained alongside the core aidevops framework:
+
+| Plugin | Namespace | Repo | Description |
+|--------|-----------|------|-------------|
+| **aidevops-pro** | `pro` | `https://github.com/marcusquinn/aidevops-pro.git` | Premium agents: advanced deployment, monitoring, cost optimisation |
+| **aidevops-anon** | `anon` | `https://github.com/marcusquinn/aidevops-anon.git` | Privacy agents: browser fingerprints, proxy rotation, identity isolation |
+
+### Quick Install
+
+```bash
+# Install pro plugin
+aidevops plugin add https://github.com/marcusquinn/aidevops-pro.git --namespace pro
+
+# Install anon plugin
+aidevops plugin add https://github.com/marcusquinn/aidevops-anon.git --namespace anon
+```
+
+### aidevops-pro Agents
+
+| Agent | Purpose |
+|-------|---------|
+| `pro/advanced-deployment.md` | Blue-green, canary, and rolling deployment strategies |
+| `pro/monitoring.md` | Prometheus/Grafana observability stack setup |
+| `pro/cost-optimisation.md` | Cloud spend analysis and right-sizing recommendations |
+
+### aidevops-anon Agents
+
+| Agent | Purpose |
+|-------|---------|
+| `anon/browser-profiles.md` | Browser fingerprint profile creation and management |
+| `anon/proxy-rotation.md` | Proxy pool management and rotation strategies |
+| `anon/identity-isolation.md` | Session isolation and identity separation |

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -2156,8 +2156,8 @@ cmd_plugin() {
                 echo "  --name <name>        Human-readable name (default: derived from repo)"
                 echo ""
                 echo "Examples:"
-                echo "  aidevops plugin add https://github.com/user/aidevops-pro.git --namespace pro"
-                echo "  aidevops plugin add git@github.com:user/aidevops-anon.git --namespace anon"
+                echo "  aidevops plugin add https://github.com/marcusquinn/aidevops-pro.git --namespace pro"
+                echo "  aidevops plugin add https://github.com/marcusquinn/aidevops-anon.git --namespace anon"
                 return 1
             fi
 
@@ -2508,8 +2508,8 @@ cmd_plugin() {
             echo "  --name <name>        Human-readable plugin name"
             echo ""
             echo "Examples:"
-            echo "  aidevops plugin add https://github.com/user/aidevops-pro.git --namespace pro"
-            echo "  aidevops plugin add git@gitea.example.com:user/aidevops-anon.git --namespace anon"
+            echo "  aidevops plugin add https://github.com/marcusquinn/aidevops-pro.git --namespace pro"
+            echo "  aidevops plugin add https://github.com/marcusquinn/aidevops-anon.git --namespace anon"
             echo "  aidevops plugin list"
             echo "  aidevops plugin update"
             echo "  aidevops plugin update pro"


### PR DESCRIPTION
## Summary

- Created `aidevops-pro` and `aidevops-anon` as private GitHub repos with proper plugin structure
- Updated `plugins.md` with Official Plugins section documenting both repos
- Updated `aidevops.sh` CLI examples to reference real repo URLs instead of placeholders

## What was done

### New GitHub Repos

**[aidevops-pro](https://github.com/marcusquinn/aidevops-pro)** (private):
- `pro.md` — Main agent with command reference
- `pro/advanced-deployment.md` — Blue-green, canary, rolling deployment strategies
- `pro/monitoring.md` — Prometheus/Grafana observability stack
- `pro/cost-optimisation.md` — Cloud spend analysis and right-sizing
- `scripts/pro-{deploy,monitor,cost}-helper.sh` — ShellCheck-clean helper stubs

**[aidevops-anon](https://github.com/marcusquinn/aidevops-anon)** (private):
- `anon.md` — Main agent with command reference
- `anon/browser-profiles.md` — Fingerprint profile creation and management
- `anon/proxy-rotation.md` — Proxy pool and rotation strategies
- `anon/identity-isolation.md` — Session isolation and identity separation
- `scripts/anon-{profile,proxy,session}-helper.sh` — ShellCheck-clean helper stubs

### Changes to this repo

- `.agents/aidevops/plugins.md` — Added Official Plugins section with install instructions and agent tables
- `aidevops.sh` — Updated 4 example URLs from `user/` placeholder to `marcusquinn/` real repos

## Verification

- ShellCheck: All 6 helper scripts pass with zero violations
- Full plugin lifecycle tested: `plugin add` → deploy → `plugin update` → `plugin list` → `plugin remove`
- Both plugins install to correct namespaces (`~/.aidevops/agents/pro/`, `~/.aidevops/agents/anon/`)
- Helper scripts execute correctly from deployed location

## Notes

- Gitea mirror not created (no Gitea access verified) — can be added as follow-up
- Plugin repos created as private (premium/sensitive capabilities)
- All scripts are stubs with proper structure — implementation is future work

Closes #732