### PR TITLE
fix: enforce Anthropic-only model routing for all worker dispatch

### DIFF
--- a/.agents/configs/fallback-chain-config.json.txt
+++ b/.agents/configs/fallback-chain-config.json.txt
@@ -3,45 +3,36 @@
   "_docs": "See .agents/tools/ai-assistants/fallback-chains.md for full documentation",
 
   "chains": {
-    "_comment": "Per-tier fallback chains. Models tried in order. Only use providers configured in OpenCode (anthropic, google). Never use openrouter (expensive gateway).",
+    "_comment": "Per-tier fallback chains. Anthropic ONLY. Never use openrouter, openai, or google providers for worker dispatch.",
 
     "haiku": [
-      "anthropic/claude-haiku-4-5",
-      "google/gemini-2.5-flash"
+      "anthropic/claude-haiku-4-5"
     ],
     "flash": [
-      "google/gemini-2.5-flash",
       "anthropic/claude-haiku-4-5"
     ],
     "sonnet": [
-      "anthropic/claude-sonnet-4-5",
-      "google/gemini-2.5-pro"
+      "anthropic/claude-sonnet-4-5"
     ],
     "pro": [
-      "google/gemini-2.5-pro",
       "anthropic/claude-sonnet-4-5"
     ],
     "opus": [
-      "anthropic/claude-opus-4-6",
-      "google/gemini-2.5-pro"
+      "anthropic/claude-opus-4-6"
     ],
     "coding": [
       "anthropic/claude-opus-4-6",
-      "anthropic/claude-sonnet-4-5",
-      "google/gemini-2.5-pro"
+      "anthropic/claude-sonnet-4-5"
     ],
     "eval": [
-      "anthropic/claude-sonnet-4-5",
-      "google/gemini-2.5-flash"
+      "anthropic/claude-sonnet-4-5"
     ],
     "health": [
-      "anthropic/claude-sonnet-4-5",
-      "google/gemini-2.5-flash"
+      "anthropic/claude-sonnet-4-5"
     ],
 
     "default": [
-      "anthropic/claude-sonnet-4-5",
-      "google/gemini-2.5-pro"
+      "anthropic/claude-sonnet-4-5"
     ]
   },
 

--- a/.agents/scripts/fallback-chain-helper.sh
+++ b/.agents/scripts/fallback-chain-helper.sh
@@ -257,14 +257,14 @@ get_chain_for_tier() {
     # Use the existing model-availability-helper.sh tier mapping
     local tier_spec=""
     case "$tier" in
-        haiku)  tier_spec='["anthropic/claude-haiku-4-5","google/gemini-2.5-flash"]' ;;
-        flash)  tier_spec='["google/gemini-2.5-flash","anthropic/claude-haiku-4-5"]' ;;
-        sonnet) tier_spec='["anthropic/claude-sonnet-4-5","google/gemini-2.5-pro"]' ;;
-        pro)    tier_spec='["google/gemini-2.5-pro","anthropic/claude-sonnet-4-5"]' ;;
-        opus)   tier_spec='["anthropic/claude-opus-4-6","google/gemini-2.5-pro"]' ;;
-        coding) tier_spec='["anthropic/claude-opus-4-6","google/gemini-2.5-pro"]' ;;
-        eval)   tier_spec='["anthropic/claude-sonnet-4-5","google/gemini-2.5-flash"]' ;;
-        health) tier_spec='["anthropic/claude-sonnet-4-5","google/gemini-2.5-flash"]' ;;
+        haiku)  tier_spec='["anthropic/claude-haiku-4-5"]' ;;
+        flash)  tier_spec='["anthropic/claude-haiku-4-5"]' ;;
+        sonnet) tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
+        pro)    tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
+        opus)   tier_spec='["anthropic/claude-opus-4-6"]' ;;
+        coding) tier_spec='["anthropic/claude-opus-4-6","anthropic/claude-sonnet-4-5"]' ;;
+        eval)   tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
+        health) tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
         *)
             print_error "Unknown tier: $tier"
             return 1

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -2817,14 +2817,11 @@ resolve_model() {
         sonnet|eval|health)
             echo "anthropic/claude-sonnet-4-5"
             ;;
-        haiku)
+        haiku|flash)
             echo "anthropic/claude-haiku-4-5"
             ;;
-        flash)
-            echo "google/gemini-2.5-flash"
-            ;;
         pro)
-            echo "google/gemini-2.5-pro"
+            echo "anthropic/claude-sonnet-4-5"
             ;;
         *)
             # Unknown tier — treat as coding tier default


### PR DESCRIPTION
## Summary

- Removes ALL Google, OpenRouter, and OpenAI models from fallback chains and static defaults
- Every worker dispatch tier now resolves exclusively to Anthropic models
- Prevents accidental spend on non-Anthropic providers

## Tier Mapping (Anthropic Only)

| Tier | Model |
|------|-------|
| opus, coding | `anthropic/claude-opus-4-6` |
| sonnet, eval, health, pro | `anthropic/claude-sonnet-4-5` |
| haiku, flash | `anthropic/claude-haiku-4-5` |

## Files Changed

- `fallback-chain-config.json.txt` — config template (Priority 2, overrides hardcoded)
- `fallback-chain-helper.sh` — hardcoded fallback (Priority 4)
- `supervisor-helper.sh` — static fallback defaults

## Context

Workers were hitting Google Gemini quota errors because the fallback chain was falling through from Anthropic (availability check fails due to missing env var) to Google. User explicitly requires Anthropic-only dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated model provider configurations to consolidate all performance tiers to use only Anthropic Claude models (haiku, flash, sonnet, pro, opus, coding, eval, and health tiers)
* Simplified model selection and fallback chains by removing alternative providers and streamlining tier-to-model mappings across configuration and helper systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->