### PR TITLE
feat: add trap cleanup for all mktemp temp files (t135.9)

### DIFF
--- a/.agents/scripts/_archive/add-missing-returns.sh
+++ b/.agents/scripts/_archive/add-missing-returns.sh
@@ -15,6 +15,7 @@ add_returns_to_file() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     local changes_made=0
     
     print_info "Processing: $file"

--- a/.agents/scripts/_archive/fix-common-strings.sh
+++ b/.agents/scripts/_archive/fix-common-strings.sh
@@ -26,6 +26,7 @@ fix_common_strings_in_file() {
     local backup_file="${file}.backup"
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     local changes_made=0
     
     print_info "Processing: $file"

--- a/.agents/scripts/_archive/fix-s131-default-cases.sh
+++ b/.agents/scripts/_archive/fix-s131-default-cases.sh
@@ -144,6 +144,7 @@ add_default_case() {
         # Create temp file and insert default case
         local temp_file
         temp_file=$(mktemp)
+        trap 'rm -f "$temp_file"' RETURN
         
         head -n $((esac_line - 1)) "$file" > "$temp_file"
         {

--- a/.agents/scripts/_archive/fix-sc2155-simple.sh
+++ b/.agents/scripts/_archive/fix-sc2155-simple.sh
@@ -15,6 +15,7 @@ fix_sc2155_simple() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     local changes_made=0
     
     print_info "Processing: $file"

--- a/.agents/scripts/_archive/fix-shellcheck-critical.sh
+++ b/.agents/scripts/_archive/fix-shellcheck-critical.sh
@@ -15,6 +15,7 @@ fix_sc2155_in_file() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     local changes_made=0
     
     # Create backup
@@ -70,6 +71,7 @@ fix_sc2181_in_file() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     local changes_made=0
     
     # Fix common SC2181 patterns

--- a/.agents/scripts/_archive/fix-string-literals.sh
+++ b/.agents/scripts/_archive/fix-string-literals.sh
@@ -44,6 +44,7 @@ analyze_repeated_strings() {
     
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     
     # Find all shell files and extract string literals
     find "$target_dir" -name "*.sh" -type f | while read -r file; do
@@ -89,6 +90,7 @@ create_string_constants() {
     
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     local constants_added=0
     local replacements_made=0
     

--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -436,6 +436,7 @@ register_skill() {
         log_info "Updating existing skill registration: $name"
         local tmp_file
         tmp_file=$(mktemp)
+        trap 'rm -f "$tmp_file"' RETURN
         jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" > "$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
         rm -f "$tmp_file"
     fi

--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -343,6 +343,7 @@ run_prompt_opencode_cli() {
     local stderr_file raw_output
     stderr_file=$(mktemp)
     raw_output=$(mktemp)
+    trap 'rm -f "$stderr_file" "$raw_output"' RETURN
 
     local exit_code=0
     portable_timeout "${timeout}" "${cmd[@]}" "$prompt" >"$raw_output" 2>"$stderr_file" || {

--- a/.agents/scripts/coderabbit-collector-helper.sh
+++ b/.agents/scripts/coderabbit-collector-helper.sh
@@ -384,6 +384,7 @@ collect_reviews() {
     local jq_filter_file sql_file
     jq_filter_file=$(mktemp)
     sql_file=$(mktemp)
+    trap 'rm -f "$jq_filter_file" "$sql_file"' RETURN
 
     cat > "$jq_filter_file" << 'JQ_EOF'
 def sql_str: gsub("'"; "''") | "'" + . + "'";
@@ -451,6 +452,7 @@ collect_comments() {
     local jq_filter_file sql_file
     jq_filter_file=$(mktemp)
     sql_file=$(mktemp)
+    trap 'rm -f "$jq_filter_file" "$sql_file"' RETURN
 
     cat > "$jq_filter_file" << 'JQ_EOF'
 def sql_str: gsub("'"; "''") | "'" + . + "'";

--- a/.agents/scripts/coderabbit-task-creator-helper.sh
+++ b/.agents/scripts/coderabbit-task-creator-helper.sh
@@ -370,6 +370,7 @@ scan_db_findings() {
     # Write comments to temp file for process substitution (avoids subshell)
     local tmp_file
     tmp_file=$(mktemp)
+    trap 'rm -f "$tmp_file"' RETURN
     echo "$comments_json" | jq -c '.[]' > "$tmp_file"
 
     local total=0
@@ -504,6 +505,7 @@ scan_pulse_findings() {
     # Write findings to temp file to avoid subshell variable loss
     local tmp_file
     tmp_file=$(mktemp)
+    trap 'rm -f "$tmp_file"' RETURN
     jq -c '.findings[]' "$latest_findings" > "$tmp_file"
 
     while IFS= read -r finding; do
@@ -705,6 +707,7 @@ cmd_create() {
     # Write findings to temp file to avoid subshell variable loss
     local tmp_create
     tmp_create=$(mktemp)
+    trap 'rm -f "$tmp_create"' RETURN
     echo "$findings_json" | jq -c '.[]' > "$tmp_create"
 
     while IFS= read -r finding; do

--- a/.agents/scripts/cron-helper.sh
+++ b/.agents/scripts/cron-helper.sh
@@ -271,6 +271,7 @@ cmd_add() {
     # Add job to config
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq --arg id "$job_id" \
        --arg name "$name" \
        --arg schedule "$schedule" \
@@ -359,6 +360,7 @@ cmd_remove() {
     # Remove from config
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq --arg id "$job_id" '.jobs = [.jobs[] | select(.id != $id)]' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     
@@ -393,6 +395,7 @@ cmd_pause() {
     # Update status
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq --arg id "$job_id" '(.jobs[] | select(.id == $id)).status = "paused"' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     
@@ -429,6 +432,7 @@ cmd_resume() {
     # Update status
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq --arg id "$job_id" '(.jobs[] | select(.id == $id)).status = "active"' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -160,6 +160,7 @@ remove_headless_todo_guard() {
         # Use sed to remove the guard block
         local tmp_file
         tmp_file=$(mktemp)
+        trap 'rm -f "$tmp_file"' RETURN
         awk '/# t173-headless-todo-guard/{skip=1} /^fi$/ && skip{skip=0; next} !skip' "$hook_file" > "$tmp_file"
         mv "$tmp_file" "$hook_file"
         chmod +x "$hook_file"

--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -175,6 +175,7 @@ loop_set_state() {
     
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     
     # Determine value type and update
     if [[ "$value" =~ ^[0-9]+$ ]]; then

--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -523,6 +523,7 @@ EOF
     
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq ".receipts += [\"$(basename "$receipt_file")\"]" "$LOOP_STATE_FILE" > "$temp_file"
     mv "$temp_file" "$LOOP_STATE_FILE"
     
@@ -643,6 +644,7 @@ loop_track_attempt() {
     
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq ".attempts[\"$task_id\"] = $new_attempts" "$LOOP_STATE_FILE" > "$temp_file"
     mv "$temp_file" "$LOOP_STATE_FILE"
     
@@ -686,6 +688,7 @@ loop_block_task() {
     
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq ".blocked_tasks += [{\"id\": \"$task_id\", \"reason\": \"$reason\", \"blocked_at\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}]" "$LOOP_STATE_FILE" > "$temp_file"
     mv "$temp_file" "$LOOP_STATE_FILE"
     

--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -253,6 +253,7 @@ cmd_setup() {
     # Save config
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq -n \
         --arg homeserverUrl "$homeserver" \
         --arg accessToken "$access_token" \
@@ -768,6 +769,7 @@ cmd_map() {
 
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq --arg room "$room_id" --arg runner "$runner_name" \
         '.roomMappings[$room] = $runner' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
@@ -799,6 +801,7 @@ cmd_unmap() {
 
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     jq --arg room "$room_id" 'del(.roomMappings[$room])' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     chmod 600 "$CONFIG_FILE"

--- a/.agents/scripts/objective-runner-helper.sh
+++ b/.agents/scripts/objective-runner-helper.sh
@@ -172,6 +172,7 @@ update_state() {
 
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
 
     # Build jq expression from key=value pairs
     local jq_expr="."

--- a/.agents/scripts/quality-fix.sh
+++ b/.agents/scripts/quality-fix.sh
@@ -66,6 +66,7 @@ fix_return_statements() {
             # Find functions that don't end with return statement
             local temp_file
             temp_file=$(mktemp)
+            trap 'rm -f "$temp_file"' RETURN
             local in_function=false
             local function_name=""
             local brace_count=0
@@ -141,6 +142,7 @@ fix_positional_parameters() {
         if [[ -f "$file" ]]; then
             local temp_file
             temp_file=$(mktemp)
+            trap 'rm -f "$temp_file"' RETURN
 
             
             # Process main() functions specifically
@@ -178,6 +180,7 @@ analyze_string_literals() {
     
     local constants_file
     constants_file=$(mktemp)
+    trap 'rm -f "$constants_file"' RETURN
     
     for file in .agents/scripts/*.sh; do
         if [[ -f "$file" ]]; then

--- a/.agents/scripts/ralph-loop-helper.sh
+++ b/.agents/scripts/ralph-loop-helper.sh
@@ -727,6 +727,7 @@ increment_iteration() {
 
     local temp_file
     temp_file=$(mktemp)
+    trap 'rm -f "$temp_file"' RETURN
     sed "s/^iteration: .*/iteration: $next_iteration/" "$RALPH_STATE_FILE" > "$temp_file"
     mv "$temp_file" "$RALPH_STATE_FILE"
 

--- a/.agents/scripts/schema-validator-helper.sh
+++ b/.agents/scripts/schema-validator-helper.sh
@@ -61,12 +61,14 @@ install_deps() {
         if command_exists jq; then
             local tmp
             tmp=$(mktemp)
+            trap 'rm -f "$tmp"' RETURN
             jq '. + {"type": "module"}' "$TOOL_DIR/package.json" > "$tmp" && mv "$tmp" "$TOOL_DIR/package.json"
             rm -f "$tmp"
         else
             # Fallback: write "type": "module" into package.json without jq
             local tmp
             tmp=$(mktemp)
+            trap 'rm -f "$tmp"' RETURN
             printf '{\n  "type": "module",\n' > "$tmp"
             # Append everything after the opening brace
             tail -n +2 "$TOOL_DIR/package.json" >> "$tmp" && mv "$tmp" "$TOOL_DIR/package.json"

--- a/.agents/scripts/site-crawler-helper.sh
+++ b/.agents/scripts/site-crawler-helper.sh
@@ -477,6 +477,7 @@ crawl_with_crawl4ai() {
         if [[ ${#batch_urls[@]} -gt 0 ]]; then
             local new_queue
             new_queue=$(mktemp)
+            trap 'rm -f "$new_queue"' RETURN
             while IFS= read -r queue_url; do
                 if ! grep -qxF "$queue_url" "$visited_file" 2>/dev/null; then
                     echo "$queue_url"

--- a/.agents/scripts/sops-helper.sh
+++ b/.agents/scripts/sops-helper.sh
@@ -104,6 +104,7 @@ cmd_install() {
         local latest_url="https://github.com/getsops/sops/releases/latest/download/sops_3.9.4_${arch}.deb"
         local tmp_deb
         tmp_deb=$(mktemp /tmp/sops-XXXXXX.deb)
+        trap 'rm -f "$tmp_deb"' RETURN
         curl -fsSL "$latest_url" -o "$tmp_deb"
         sudo dpkg -i "$tmp_deb"
         rm -f "$tmp_deb"

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -3365,6 +3365,7 @@ check_model_health() {
         else
             local probe_pid probe_tmpfile
             probe_tmpfile=$(mktemp)
+            trap 'rm -f "$probe_tmpfile"' RETURN
             ("${probe_cmd[@]}" > "$probe_tmpfile" 2>&1) &
             probe_pid=$!
             local waited=0
@@ -3394,6 +3395,7 @@ check_model_health() {
         else
             local probe_pid probe_tmpfile
             probe_tmpfile=$(mktemp)
+            trap 'rm -f "$probe_tmpfile"' RETURN
             ("${probe_cmd[@]}" > "$probe_tmpfile" 2>&1) &
             probe_pid=$!
             local waited=0
@@ -4370,6 +4372,7 @@ extract_log_metadata() {
     # Only the final lines contain actual execution status/errors.
     local log_tail_file
     log_tail_file=$(mktemp)
+    trap 'rm -f "$log_tail_file"' RETURN
     tail -20 "$log_file" > "$log_tail_file" 2>/dev/null || true
 
     local rate_limit_count=0 auth_error_count=0 conflict_count=0 timeout_count=0 oom_count=0
@@ -7407,6 +7410,7 @@ populate_verify_queue() {
         # Insert before the end marker
         local temp_file
         temp_file=$(mktemp)
+        trap 'rm -f "$temp_file"' RETURN
         awk -v entry="$entry" '
             /<!-- VERIFY-QUEUE-END -->/ {
                 print entry
@@ -7942,6 +7946,7 @@ generate_verify_entry() {
     # Insert before marker using temp file (portable across macOS/Linux)
     local tmp_file
     tmp_file=$(mktemp)
+    trap 'rm -f "$tmp_file"' RETURN
     awk -v entry="$full_entry" -v mark="$marker" '{
         if (index($0, mark) > 0) { print entry; }
         print;

--- a/.agents/scripts/verify-run-helper.sh
+++ b/.agents/scripts/verify-run-helper.sh
@@ -301,6 +301,7 @@ update_verify_status() {
     # Write the replacement using awk (sed delimiters conflict with | in content)
     local tmp_file
     tmp_file=$(mktemp)
+    trap 'rm -f "$tmp_file"' RETURN
     awk -v ln="$line_num" -v rep="$new_line" 'NR==ln{print rep; next}{print}' "$verify_file" > "$tmp_file"
     mv "$tmp_file" "$verify_file"
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -597,6 +597,7 @@ cmd_update() {
             print_error "Failed to create temp file for setup script"
             return 1
         }
+        trap 'rm -f "$tmp_setup"' RETURN
         if curl -fsSL "https://raw.githubusercontent.com/marcusquinn/aidevops/main/setup.sh" -o "$tmp_setup" 2>/dev/null && [[ -s "$tmp_setup" ]]; then
             chmod +x "$tmp_setup"
             bash "$tmp_setup"
@@ -1484,6 +1485,7 @@ cmd_upgrade_planning() {
                 local temp_file="${todo_file}.merge"
                 local tasks_file
                 tasks_file=$(mktemp)
+                trap 'rm -f "$tasks_file"' RETURN
                 printf '%s\n' "$existing_tasks" > "$tasks_file"
                 # Use while-read to avoid BSD awk "newline in string" warning with -v
                 local in_backlog=false
@@ -1548,6 +1550,7 @@ cmd_upgrade_planning() {
                 local temp_file="${plans_file}.merge"
                 local plans_content_file
                 plans_content_file=$(mktemp)
+                trap 'rm -f "$plans_content_file"' RETURN
                 printf '%s\n' "$existing_plans" > "$plans_content_file"
                 # Use while-read to avoid BSD awk "newline in string" warning with -v
                 local in_active=false

--- a/setup.sh
+++ b/setup.sh
@@ -334,6 +334,7 @@ cleanup_deprecated_paths() {
         if jq -e '.plugin | index("oh-my-opencode")' "$opencode_config" >/dev/null 2>&1; then
             local tmp_file
             tmp_file=$(mktemp)
+            trap 'rm -f "$tmp_file"' RETURN
             jq '.plugin = [.plugin[] | select(. != "oh-my-opencode")]' "$opencode_config" > "$tmp_file" && mv "$tmp_file" "$opencode_config"
             print_info "Removed oh-my-opencode from OpenCode plugin list"
         fi
@@ -514,6 +515,7 @@ cleanup_deprecated_mcps() {
     local cleaned=0
     local tmp_config
     tmp_config=$(mktemp)
+    trap 'rm -f "$tmp_config"' RETURN
     
     cp "$opencode_config" "$tmp_config"
     
@@ -637,6 +639,7 @@ disable_ondemand_mcps() {
     local disabled=0
     local tmp_config
     tmp_config=$(mktemp)
+    trap 'rm -f "$tmp_config"' RETURN
     
     cp "$opencode_config" "$tmp_config"
     
@@ -714,6 +717,7 @@ validate_opencode_config() {
         if jq -e ".[\"$key\"]" "$opencode_config" > /dev/null 2>&1; then
             local tmp_fix
             tmp_fix=$(mktemp)
+            trap 'rm -f "$tmp_fix"' RETURN
             if jq "del(.[\"$key\"])" "$opencode_config" > "$tmp_fix" 2>/dev/null; then
                 create_backup_with_rotation "$opencode_config" "opencode"
                 mv "$tmp_fix" "$opencode_config"
@@ -2583,6 +2587,7 @@ deploy_aidevops_agents() {
         print_info "Clean mode: removing stale files from $target_dir (preserving ${preserved_dirs[*]})"
         local tmp_preserve
         tmp_preserve="$(mktemp -d)"
+        trap 'rm -rf "$tmp_preserve"' RETURN
         if [[ -z "$tmp_preserve" || ! -d "$tmp_preserve" ]]; then
             print_error "Failed to create temp dir for preserving agents"
             return 1
@@ -2675,6 +2680,7 @@ deploy_aidevops_agents() {
                 # (awk -v doesn't handle multi-line content with special chars well)
                 local tmp_file
                 tmp_file=$(mktemp)
+                trap 'rm -f "$tmp_file"' RETURN
                 local in_placeholder=false
                 while IFS= read -r line || [[ -n "$line" ]]; do
                     if [[ "$line" == *"OPENCODE-PLAN-REMINDER-INJECT-START"* ]]; then
@@ -3105,6 +3111,7 @@ inject_agents_reference() {
                     # Prepend reference to existing file
                     local temp_file
                     temp_file=$(mktemp)
+                    trap 'rm -f "$temp_file"' RETURN
                     echo "$reference_line" > "$temp_file"
                     echo "" >> "$temp_file"
                     cat "$agents_file" >> "$temp_file"
@@ -3434,6 +3441,7 @@ update_mcp_paths_in_opencode() {
 
     local tmp_config
     tmp_config=$(mktemp)
+    trap 'rm -f "$tmp_config"' RETURN
     cp "$opencode_config" "$tmp_config"
 
     local updated=0
@@ -4277,6 +4285,7 @@ add_opencode_plugin() {
             # Update existing plugin to latest version
             local temp_file
             temp_file=$(mktemp)
+            trap 'rm -f "$temp_file"' RETURN
             jq --arg old "$plugin_name" --arg new "$plugin_spec" \
                 '.plugin = [.plugin[] | if startswith($old) then $new else . end]' \
                 "$opencode_config" > "$temp_file" && mv "$temp_file" "$opencode_config"
@@ -4285,6 +4294,7 @@ add_opencode_plugin() {
             # Add plugin to existing array
             local temp_file
             temp_file=$(mktemp)
+            trap 'rm -f "$temp_file"' RETURN
             jq --arg p "$plugin_spec" '.plugin += [$p]' "$opencode_config" > "$temp_file" && mv "$temp_file" "$opencode_config"
             print_success "Added $plugin_name plugin to OpenCode config"
         fi
@@ -4292,6 +4302,7 @@ add_opencode_plugin() {
         # Create plugin array with the plugin
         local temp_file
         temp_file=$(mktemp)
+        trap 'rm -f "$temp_file"' RETURN
         jq --arg p "$plugin_spec" '. + {plugin: [$p]}' "$opencode_config" > "$temp_file" && mv "$temp_file" "$opencode_config"
         print_success "Created plugin array with $plugin_name"
     fi
@@ -4434,6 +4445,7 @@ setup_google_analytics_mcp() {
         if [[ "$enable_mcp" == "true" ]]; then
             local tmp_config
             tmp_config=$(mktemp)
+            trap 'rm -f "$tmp_config"' RETURN
             if jq --arg creds "$creds_path" --arg proj "$project_id" \
                 '.mcp["google-analytics-mcp"].environment.GOOGLE_APPLICATION_CREDENTIALS = $creds |
                  .mcp["google-analytics-mcp"].environment.GOOGLE_PROJECT_ID = $proj |
@@ -4454,6 +4466,7 @@ setup_google_analytics_mcp() {
     # Add google-analytics-mcp to opencode.json
     local tmp_config
     tmp_config=$(mktemp)
+    trap 'rm -f "$tmp_config"' RETURN
     
     if jq --arg creds "$creds_path" --arg proj "$project_id" --argjson enabled "$enable_mcp" \
         '.mcp["google-analytics-mcp"] = {

--- a/tests/test-supervisor-state-machine.sh
+++ b/tests/test-supervisor-state-machine.sh
@@ -1209,6 +1209,7 @@ fi
 
 # Test: run_verify_checks with a real VERIFY.md
 VERIFY_TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$WORKTREE_TEST_DIR" "$TEST_DIR" "$VERIFY_TEST_DIR" "$CLAIM_TEST_DIR"' EXIT
 mkdir -p "$VERIFY_TEST_DIR/todo"
 mkdir -p "$VERIFY_TEST_DIR/.agents/scripts"
 


### PR DESCRIPTION
## Summary

- Add `trap 'rm -f "$var"' RETURN` cleanup for all remaining mktemp usages that lacked trap protection
- Prevents temp file leaks on unexpected exits, early returns, or errors
- Covers 12 additional files missed by the initial pass (loop-common.sh, quality-fix.sh, ralph-loop-helper.sh, site-crawler-helper.sh, verify-run-helper.sh, test-supervisor-state-machine.sh, and 6 archive scripts)
- Combined with the first commit, all ~90 mktemp usages across the codebase now have trap cleanup

## Changes

**Active scripts** (7 files):
- `loop-common.sh` — 3 locations (receipt tracking, attempt tracking, task blocking)
- `quality-fix.sh` — 3 locations (return statement fixer, positional params, string analysis)
- `ralph-loop-helper.sh` — 1 location (iteration increment)
- `site-crawler-helper.sh` — 1 location (queue processing)
- `verify-run-helper.sh` — 1 location (verify status update)

**Test files** (1 file):
- `test-supervisor-state-machine.sh` — consolidated EXIT trap to cover all 4 mktemp -d dirs

**Archive scripts** (6 files):
- `_archive/add-missing-returns.sh`, `fix-common-strings.sh`, `fix-s131-default-cases.sh`, `fix-sc2155-simple.sh`, `fix-shellcheck-critical.sh`, `fix-string-literals.sh`

## Verification

- All modified files pass `bash -n` syntax check
- Trap pattern uses single quotes (avoids SC2064 shellcheck warning)
- Uses `RETURN` for function-scoped cleanup, `EXIT` for script-level cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved resource cleanup in shell scripts by adding automatic temporary file removal on function exit across multiple scripts, ensuring no leftover temporary files and reducing potential resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->