### PR TITLE
fix: make trap RETURN cleanup safe under set -u

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -436,7 +436,7 @@ register_skill() {
         log_info "Updating existing skill registration: $name"
         local tmp_file
         tmp_file=$(mktemp)
-        trap 'rm -f "$tmp_file"' RETURN
+        trap 'rm -f "${tmp_file:-}"' RETURN
         jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" > "$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
         rm -f "$tmp_file"
     fi
@@ -1274,7 +1274,7 @@ cmd_remove() {
     # Remove from registry
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' RETURN
+    trap 'rm -f "${tmp_file:-}"' RETURN
     jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" > "$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
     
     log_success "Skill '$name' removed"

--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -343,7 +343,7 @@ run_prompt_opencode_cli() {
     local stderr_file raw_output
     stderr_file=$(mktemp)
     raw_output=$(mktemp)
-    trap 'rm -f "$stderr_file" "$raw_output"' RETURN
+    trap 'rm -f "${stderr_file:-}" "${raw_output:-}"' RETURN
 
     local exit_code=0
     portable_timeout "${timeout}" "${cmd[@]}" "$prompt" >"$raw_output" 2>"$stderr_file" || {

--- a/.agents/scripts/coderabbit-collector-helper.sh
+++ b/.agents/scripts/coderabbit-collector-helper.sh
@@ -384,7 +384,7 @@ collect_reviews() {
     local jq_filter_file sql_file
     jq_filter_file=$(mktemp)
     sql_file=$(mktemp)
-    trap 'rm -f "$jq_filter_file" "$sql_file"' RETURN
+    trap 'rm -f "${jq_filter_file:-}" "${sql_file:-}"' RETURN
 
     cat > "$jq_filter_file" << 'JQ_EOF'
 def sql_str: gsub("'"; "''") | "'" + . + "'";
@@ -452,7 +452,7 @@ collect_comments() {
     local jq_filter_file sql_file
     jq_filter_file=$(mktemp)
     sql_file=$(mktemp)
-    trap 'rm -f "$jq_filter_file" "$sql_file"' RETURN
+    trap 'rm -f "${jq_filter_file:-}" "${sql_file:-}"' RETURN
 
     cat > "$jq_filter_file" << 'JQ_EOF'
 def sql_str: gsub("'"; "''") | "'" + . + "'";

--- a/.agents/scripts/coderabbit-task-creator-helper.sh
+++ b/.agents/scripts/coderabbit-task-creator-helper.sh
@@ -370,7 +370,7 @@ scan_db_findings() {
     # Write comments to temp file for process substitution (avoids subshell)
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' RETURN
+    trap 'rm -f "${tmp_file:-}"' RETURN
     echo "$comments_json" | jq -c '.[]' > "$tmp_file"
 
     local total=0
@@ -505,7 +505,7 @@ scan_pulse_findings() {
     # Write findings to temp file to avoid subshell variable loss
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' RETURN
+    trap 'rm -f "${tmp_file:-}"' RETURN
     jq -c '.findings[]' "$latest_findings" > "$tmp_file"
 
     while IFS= read -r finding; do
@@ -707,7 +707,7 @@ cmd_create() {
     # Write findings to temp file to avoid subshell variable loss
     local tmp_create
     tmp_create=$(mktemp)
-    trap 'rm -f "$tmp_create"' RETURN
+    trap 'rm -f "${tmp_create:-}"' RETURN
     echo "$findings_json" | jq -c '.[]' > "$tmp_create"
 
     while IFS= read -r finding; do

--- a/.agents/scripts/cron-dispatch.sh
+++ b/.agents/scripts/cron-dispatch.sh
@@ -118,7 +118,7 @@ update_job_status() {
     
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     jq --arg id "$job_id" \
        --arg status "$status" \
        --arg timestamp "$timestamp" \

--- a/.agents/scripts/cron-helper.sh
+++ b/.agents/scripts/cron-helper.sh
@@ -152,7 +152,7 @@ get_job() {
 sync_crontab() {
     local temp_cron
     temp_cron=$(mktemp)
-    trap 'rm -f "$temp_cron"' RETURN
+    trap 'rm -f "${temp_cron:-}"' RETURN
     
     # Get existing crontab (excluding our managed entries)
     crontab -l 2>/dev/null | grep -v "cron-dispatch.sh" > "$temp_cron" || true
@@ -271,7 +271,7 @@ cmd_add() {
     # Add job to config
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     jq --arg id "$job_id" \
        --arg name "$name" \
        --arg schedule "$schedule" \
@@ -360,7 +360,7 @@ cmd_remove() {
     # Remove from config
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     jq --arg id "$job_id" '.jobs = [.jobs[] | select(.id != $id)]' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     
@@ -395,7 +395,7 @@ cmd_pause() {
     # Update status
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     jq --arg id "$job_id" '(.jobs[] | select(.id == $id)).status = "paused"' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     
@@ -432,7 +432,7 @@ cmd_resume() {
     # Update status
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     jq --arg id "$job_id" '(.jobs[] | select(.id == $id)).status = "active"' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -160,7 +160,7 @@ remove_headless_todo_guard() {
         # Use sed to remove the guard block
         local tmp_file
         tmp_file=$(mktemp)
-        trap 'rm -f "$tmp_file"' RETURN
+        trap 'rm -f "${tmp_file:-}"' RETURN
         awk '/# t173-headless-todo-guard/{skip=1} /^fi$/ && skip{skip=0; next} !skip' "$hook_file" > "$tmp_file"
         mv "$tmp_file" "$hook_file"
         chmod +x "$hook_file"

--- a/.agents/scripts/keyword-research-helper.sh
+++ b/.agents/scripts/keyword-research-helper.sh
@@ -789,7 +789,7 @@ do_webmaster_research() {
     # Combine and deduplicate keywords
     local combined_keywords
     combined_keywords=$(mktemp)
-    trap 'rm -f "$combined_keywords"' RETURN
+    trap 'rm -f "${combined_keywords:-}"' RETURN
     
     # Process GSC data
     if [[ -n "$gsc_data" ]]; then

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -134,7 +134,7 @@ check_positional_parameters() {
     # Exclude: heredocs (<<), awk scripts, main script body, and local assignments
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' RETURN
+    trap 'rm -f "${tmp_file:-}"' RETURN
 
     # Only check inside function bodies, exclude heredocs, awk/sed patterns, and comments
     for file in .agents/scripts/*.sh; do

--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -175,7 +175,7 @@ loop_set_state() {
     
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     
     # Determine value type and update
     if [[ "$value" =~ ^[0-9]+$ ]]; then

--- a/.agents/scripts/markdown-formatter.sh
+++ b/.agents/scripts/markdown-formatter.sh
@@ -37,7 +37,7 @@ fix_markdown_file() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     local changes_made=0
     
     print_info "Processing: $file"
@@ -123,7 +123,7 @@ apply_advanced_fixes() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
 
     print_info "Applying advanced fixes to: $file"
 

--- a/.agents/scripts/markdown-lint-fix.sh
+++ b/.agents/scripts/markdown-lint-fix.sh
@@ -151,7 +151,7 @@ apply_manual_fixes() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     local changes_made=0
     
     print_info "Applying manual fixes to: $file"

--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -120,7 +120,7 @@ config_set() {
 
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     jq --arg key "$key" --arg value "$value" '.[$key] = $value' "$CONFIG_FILE" > "$temp_file" && mv "$temp_file" "$CONFIG_FILE"
     chmod 600 "$CONFIG_FILE"
 }
@@ -253,7 +253,7 @@ cmd_setup() {
     # Save config
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     jq -n \
         --arg homeserverUrl "$homeserver" \
         --arg accessToken "$access_token" \
@@ -769,7 +769,7 @@ cmd_map() {
 
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     jq --arg room "$room_id" --arg runner "$runner_name" \
         '.roomMappings[$room] = $runner' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
@@ -801,7 +801,7 @@ cmd_unmap() {
 
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     jq --arg room "$room_id" 'del(.roomMappings[$room])' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     chmod 600 "$CONFIG_FILE"

--- a/.agents/scripts/objective-runner-helper.sh
+++ b/.agents/scripts/objective-runner-helper.sh
@@ -172,7 +172,7 @@ update_state() {
 
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
 
     # Build jq expression from key=value pairs
     local jq_expr="."

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -500,7 +500,7 @@ $full_prompt"
     # Update config with run metadata
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     local status="success"
     if [[ $exit_code -ne 0 ]]; then
         status="failed"

--- a/.agents/scripts/schema-validator-helper.sh
+++ b/.agents/scripts/schema-validator-helper.sh
@@ -61,14 +61,14 @@ install_deps() {
         if command_exists jq; then
             local tmp
             tmp=$(mktemp)
-            trap 'rm -f "$tmp"' RETURN
+            trap 'rm -f "${tmp:-}"' RETURN
             jq '. + {"type": "module"}' "$TOOL_DIR/package.json" > "$tmp" && mv "$tmp" "$TOOL_DIR/package.json"
             rm -f "$tmp"
         else
             # Fallback: write "type": "module" into package.json without jq
             local tmp
             tmp=$(mktemp)
-            trap 'rm -f "$tmp"' RETURN
+            trap 'rm -f "${tmp:-}"' RETURN
             printf '{\n  "type": "module",\n' > "$tmp"
             # Append everything after the opening brace
             tail -n +2 "$TOOL_DIR/package.json" >> "$tmp" && mv "$tmp" "$TOOL_DIR/package.json"

--- a/.agents/scripts/secretlint-helper.sh
+++ b/.agents/scripts/secretlint-helper.sh
@@ -888,7 +888,7 @@ setup_husky_integration() {
     if command -v jq &> /dev/null; then
         local tmp_file
         tmp_file=$(mktemp)
-        trap 'rm -f "$tmp_file"' RETURN
+        trap 'rm -f "${tmp_file:-}"' RETURN
         jq '. + {"lint-staged": {"*": ["secretlint"]}}' package.json > "$tmp_file" && mv "$tmp_file" package.json
         print_success "Added lint-staged configuration"
     else

--- a/.agents/scripts/seo-analysis-helper.sh
+++ b/.agents/scripts/seo-analysis-helper.sh
@@ -97,7 +97,7 @@ analyze_quick_wins() {
     # Collect data from all sources
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     
     for toon_file in "$domain_dir"/*.toon; do
         [[ -f "$toon_file" ]] || continue
@@ -159,7 +159,7 @@ analyze_striking_distance() {
     
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     
     for toon_file in "$domain_dir"/*.toon; do
         [[ -f "$toon_file" ]] || continue
@@ -224,7 +224,7 @@ analyze_low_ctr() {
     
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     
     for toon_file in "$domain_dir"/*.toon; do
         [[ -f "$toon_file" ]] || continue
@@ -284,7 +284,7 @@ analyze_cannibalization() {
     temp_file=$(mktemp)
     local query_pages
     query_pages=$(mktemp)
-    trap 'rm -f "$temp_file" "$query_pages"' RETURN
+    trap 'rm -f "${temp_file:-}" "${query_pages:-}"' RETURN
     
     # Collect all query-page pairs
     for toon_file in "$domain_dir"/*.toon; do

--- a/.agents/scripts/site-crawler-helper.sh
+++ b/.agents/scripts/site-crawler-helper.sh
@@ -734,7 +734,7 @@ EOF
     if find_python && "$PYTHON_CMD" -c "import openpyxl" 2>/dev/null; then
         local xlsx_script
         xlsx_script=$(mktemp /tmp/xlsx_gen_XXXXXX.py)
-        trap 'rm -f "$xlsx_script"' RETURN
+        trap 'rm -f "${xlsx_script:-}"' RETURN
         cat > "$xlsx_script" << 'PYXLSX'
 import sys
 import csv
@@ -1183,7 +1183,7 @@ do_crawl() {
     # Generate and run crawler
     local crawler_script
     crawler_script=$(mktemp /tmp/site_crawler_XXXXXX.py)
-    trap 'rm -f "$crawler_script"' RETURN
+    trap 'rm -f "${crawler_script:-}"' RETURN
     generate_fallback_crawler > "$crawler_script"
     
     "$PYTHON_CMD" "$crawler_script" "$url" "$output_dir" "$max_urls" "$depth" "$format"

--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -180,7 +180,7 @@ update_last_checked() {
     
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' RETURN
+    trap 'rm -f "${tmp_file:-}"' RETURN
     
     jq --arg name "$skill_name" --arg ts "$timestamp" \
         '.skills = [.skills[] | if .name == $name then .last_checked = $ts else . end]' \

--- a/.agents/scripts/sonarcloud-autofix.sh
+++ b/.agents/scripts/sonarcloud-autofix.sh
@@ -35,7 +35,7 @@ fix_missing_returns() {
     # This is a basic implementation - would need more sophisticated logic for production
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     
     awk '
     /^[a-zA-Z_][a-zA-Z0-9_]*\(\)/ { in_function = 1 }

--- a/.agents/scripts/sops-helper.sh
+++ b/.agents/scripts/sops-helper.sh
@@ -104,7 +104,7 @@ cmd_install() {
         local latest_url="https://github.com/getsops/sops/releases/latest/download/sops_3.9.4_${arch}.deb"
         local tmp_deb
         tmp_deb=$(mktemp /tmp/sops-XXXXXX.deb)
-        trap 'rm -f "$tmp_deb"' RETURN
+        trap 'rm -f "${tmp_deb:-}"' RETURN
         curl -fsSL "$latest_url" -o "$tmp_deb"
         sudo dpkg -i "$tmp_deb"
         rm -f "$tmp_deb"

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -3365,7 +3365,7 @@ check_model_health() {
         else
             local probe_pid probe_tmpfile
             probe_tmpfile=$(mktemp)
-            trap 'rm -f "$probe_tmpfile"' RETURN
+            trap 'rm -f "${probe_tmpfile:-}"' RETURN
             ("${probe_cmd[@]}" > "$probe_tmpfile" 2>&1) &
             probe_pid=$!
             local waited=0
@@ -3395,7 +3395,7 @@ check_model_health() {
         else
             local probe_pid probe_tmpfile
             probe_tmpfile=$(mktemp)
-            trap 'rm -f "$probe_tmpfile"' RETURN
+            trap 'rm -f "${probe_tmpfile:-}"' RETURN
             ("${probe_cmd[@]}" > "$probe_tmpfile" 2>&1) &
             probe_pid=$!
             local waited=0
@@ -4372,7 +4372,7 @@ extract_log_metadata() {
     # Only the final lines contain actual execution status/errors.
     local log_tail_file
     log_tail_file=$(mktemp)
-    trap 'rm -f "$log_tail_file"' RETURN
+    trap 'rm -f "${log_tail_file:-}"' RETURN
     tail -20 "$log_file" > "$log_tail_file" 2>/dev/null || true
 
     local rate_limit_count=0 auth_error_count=0 conflict_count=0 timeout_count=0 oom_count=0
@@ -7410,7 +7410,7 @@ populate_verify_queue() {
         # Insert before the end marker
         local temp_file
         temp_file=$(mktemp)
-        trap 'rm -f "$temp_file"' RETURN
+        trap 'rm -f "${temp_file:-}"' RETURN
         awk -v entry="$entry" '
             /<!-- VERIFY-QUEUE-END -->/ {
                 print entry
@@ -7946,7 +7946,7 @@ generate_verify_entry() {
     # Insert before marker using temp file (portable across macOS/Linux)
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "$tmp_file"' RETURN
+    trap 'rm -f "${tmp_file:-}"' RETURN
     awk -v entry="$full_entry" -v mark="$marker" '{
         if (index($0, mark) > 0) { print entry; }
         print;

--- a/.agents/scripts/terminal-title-setup.sh
+++ b/.agents/scripts/terminal-title-setup.sh
@@ -105,7 +105,7 @@ tabby_enable_dynamic_titles() {
     # Replace all instances (cross-platform: works on both macOS and Linux)
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     sed 's/disableDynamicTitle: true/disableDynamicTitle: false/g' "$TABBY_CONFIG_FILE" > "$temp_file" && mv "$temp_file" "$TABBY_CONFIG_FILE"
     
     local count
@@ -304,7 +304,7 @@ remove_integration() {
     # Remove our integration block (cross-platform: works on both macOS and Linux)
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "$temp_file"' RETURN
+    trap 'rm -f "${temp_file:-}"' RETURN
     sed "/$MARKER_START/,/$MARKER_END/d" "$rc_file" > "$temp_file" && mv "$temp_file" "$rc_file"
     
     log_success "Removed integration from $rc_file (backup: ${rc_file}.aidevops-backup)"

--- a/.agents/scripts/watercrawl-helper.sh
+++ b/.agents/scripts/watercrawl-helper.sh
@@ -579,7 +579,7 @@ scrape_url() {
     # Create Node.js script for scraping
     local temp_script
     temp_script=$(mktemp /tmp/watercrawl_scrape_XXXXXX.mjs)
-    trap 'rm -f "$temp_script"' RETURN
+    trap 'rm -f "${temp_script:-}"' RETURN
     
     cat > "$temp_script" << 'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';
@@ -660,7 +660,7 @@ crawl_website() {
     # Create Node.js script for crawling
     local temp_script
     temp_script=$(mktemp /tmp/watercrawl_crawl_XXXXXX.mjs)
-    trap 'rm -f "$temp_script"' RETURN
+    trap 'rm -f "${temp_script:-}"' RETURN
     
     cat > "$temp_script" << 'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';
@@ -773,7 +773,7 @@ search_web() {
     # Create Node.js script for searching
     local temp_script
     temp_script=$(mktemp /tmp/watercrawl_search_XXXXXX.mjs)
-    trap 'rm -f "$temp_script"' RETURN
+    trap 'rm -f "${temp_script:-}"' RETURN
     
     cat > "$temp_script" << 'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';
@@ -862,7 +862,7 @@ generate_sitemap() {
     # Create Node.js script for sitemap
     local temp_script
     temp_script=$(mktemp /tmp/watercrawl_sitemap_XXXXXX.mjs)
-    trap 'rm -f "$temp_script"' RETURN
+    trap 'rm -f "${temp_script:-}"' RETURN
     
     cat > "$temp_script" << 'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -597,7 +597,7 @@ cmd_update() {
             print_error "Failed to create temp file for setup script"
             return 1
         }
-        trap 'rm -f "$tmp_setup"' RETURN
+        trap 'rm -f "${tmp_setup:-}"' RETURN
         if curl -fsSL "https://raw.githubusercontent.com/marcusquinn/aidevops/main/setup.sh" -o "$tmp_setup" 2>/dev/null && [[ -s "$tmp_setup" ]]; then
             chmod +x "$tmp_setup"
             bash "$tmp_setup"
@@ -1485,7 +1485,7 @@ cmd_upgrade_planning() {
                 local temp_file="${todo_file}.merge"
                 local tasks_file
                 tasks_file=$(mktemp)
-                trap 'rm -f "$tasks_file"' RETURN
+                trap 'rm -f "${tasks_file:-}"' RETURN
                 printf '%s\n' "$existing_tasks" > "$tasks_file"
                 # Use while-read to avoid BSD awk "newline in string" warning with -v
                 local in_backlog=false
@@ -1550,7 +1550,7 @@ cmd_upgrade_planning() {
                 local temp_file="${plans_file}.merge"
                 local plans_content_file
                 plans_content_file=$(mktemp)
-                trap 'rm -f "$plans_content_file"' RETURN
+                trap 'rm -f "${plans_content_file:-}"' RETURN
                 printf '%s\n' "$existing_plans" > "$plans_content_file"
                 # Use while-read to avoid BSD awk "newline in string" warning with -v
                 local in_active=false

--- a/setup.sh
+++ b/setup.sh
@@ -334,7 +334,7 @@ cleanup_deprecated_paths() {
         if jq -e '.plugin | index("oh-my-opencode")' "$opencode_config" >/dev/null 2>&1; then
             local tmp_file
             tmp_file=$(mktemp)
-            trap 'rm -f "$tmp_file"' RETURN
+            trap 'rm -f "${tmp_file:-}"' RETURN
             jq '.plugin = [.plugin[] | select(. != "oh-my-opencode")]' "$opencode_config" > "$tmp_file" && mv "$tmp_file" "$opencode_config"
             print_info "Removed oh-my-opencode from OpenCode plugin list"
         fi
@@ -515,7 +515,7 @@ cleanup_deprecated_mcps() {
     local cleaned=0
     local tmp_config
     tmp_config=$(mktemp)
-    trap 'rm -f "$tmp_config"' RETURN
+    trap 'rm -f "${tmp_config:-}"' RETURN
     
     cp "$opencode_config" "$tmp_config"
     
@@ -639,7 +639,7 @@ disable_ondemand_mcps() {
     local disabled=0
     local tmp_config
     tmp_config=$(mktemp)
-    trap 'rm -f "$tmp_config"' RETURN
+    trap 'rm -f "${tmp_config:-}"' RETURN
     
     cp "$opencode_config" "$tmp_config"
     
@@ -717,7 +717,7 @@ validate_opencode_config() {
         if jq -e ".[\"$key\"]" "$opencode_config" > /dev/null 2>&1; then
             local tmp_fix
             tmp_fix=$(mktemp)
-            trap 'rm -f "$tmp_fix"' RETURN
+            trap 'rm -f "${tmp_fix:-}"' RETURN
             if jq "del(.[\"$key\"])" "$opencode_config" > "$tmp_fix" 2>/dev/null; then
                 create_backup_with_rotation "$opencode_config" "opencode"
                 mv "$tmp_fix" "$opencode_config"
@@ -2587,7 +2587,7 @@ deploy_aidevops_agents() {
         print_info "Clean mode: removing stale files from $target_dir (preserving ${preserved_dirs[*]})"
         local tmp_preserve
         tmp_preserve="$(mktemp -d)"
-        trap 'rm -rf "$tmp_preserve"' RETURN
+        trap 'rm -rf "${tmp_preserve:-}"' RETURN
         if [[ -z "$tmp_preserve" || ! -d "$tmp_preserve" ]]; then
             print_error "Failed to create temp dir for preserving agents"
             return 1
@@ -2680,7 +2680,7 @@ deploy_aidevops_agents() {
                 # (awk -v doesn't handle multi-line content with special chars well)
                 local tmp_file
                 tmp_file=$(mktemp)
-                trap 'rm -f "$tmp_file"' RETURN
+                trap 'rm -f "${tmp_file:-}"' RETURN
                 local in_placeholder=false
                 while IFS= read -r line || [[ -n "$line" ]]; do
                     if [[ "$line" == *"OPENCODE-PLAN-REMINDER-INJECT-START"* ]]; then
@@ -3111,7 +3111,7 @@ inject_agents_reference() {
                     # Prepend reference to existing file
                     local temp_file
                     temp_file=$(mktemp)
-                    trap 'rm -f "$temp_file"' RETURN
+                    trap 'rm -f "${temp_file:-}"' RETURN
                     echo "$reference_line" > "$temp_file"
                     echo "" >> "$temp_file"
                     cat "$agents_file" >> "$temp_file"
@@ -3441,7 +3441,7 @@ update_mcp_paths_in_opencode() {
 
     local tmp_config
     tmp_config=$(mktemp)
-    trap 'rm -f "$tmp_config"' RETURN
+    trap 'rm -f "${tmp_config:-}"' RETURN
     cp "$opencode_config" "$tmp_config"
 
     local updated=0
@@ -4285,7 +4285,7 @@ add_opencode_plugin() {
             # Update existing plugin to latest version
             local temp_file
             temp_file=$(mktemp)
-            trap 'rm -f "$temp_file"' RETURN
+            trap 'rm -f "${temp_file:-}"' RETURN
             jq --arg old "$plugin_name" --arg new "$plugin_spec" \
                 '.plugin = [.plugin[] | if startswith($old) then $new else . end]' \
                 "$opencode_config" > "$temp_file" && mv "$temp_file" "$opencode_config"
@@ -4294,7 +4294,7 @@ add_opencode_plugin() {
             # Add plugin to existing array
             local temp_file
             temp_file=$(mktemp)
-            trap 'rm -f "$temp_file"' RETURN
+            trap 'rm -f "${temp_file:-}"' RETURN
             jq --arg p "$plugin_spec" '.plugin += [$p]' "$opencode_config" > "$temp_file" && mv "$temp_file" "$opencode_config"
             print_success "Added $plugin_name plugin to OpenCode config"
         fi
@@ -4302,7 +4302,7 @@ add_opencode_plugin() {
         # Create plugin array with the plugin
         local temp_file
         temp_file=$(mktemp)
-        trap 'rm -f "$temp_file"' RETURN
+        trap 'rm -f "${temp_file:-}"' RETURN
         jq --arg p "$plugin_spec" '. + {plugin: [$p]}' "$opencode_config" > "$temp_file" && mv "$temp_file" "$opencode_config"
         print_success "Created plugin array with $plugin_name"
     fi
@@ -4445,7 +4445,7 @@ setup_google_analytics_mcp() {
         if [[ "$enable_mcp" == "true" ]]; then
             local tmp_config
             tmp_config=$(mktemp)
-            trap 'rm -f "$tmp_config"' RETURN
+            trap 'rm -f "${tmp_config:-}"' RETURN
             if jq --arg creds "$creds_path" --arg proj "$project_id" \
                 '.mcp["google-analytics-mcp"].environment.GOOGLE_APPLICATION_CREDENTIALS = $creds |
                  .mcp["google-analytics-mcp"].environment.GOOGLE_PROJECT_ID = $proj |
@@ -4466,7 +4466,7 @@ setup_google_analytics_mcp() {
     # Add google-analytics-mcp to opencode.json
     local tmp_config
     tmp_config=$(mktemp)
-    trap 'rm -f "$tmp_config"' RETURN
+    trap 'rm -f "${tmp_config:-}"' RETURN
     
     if jq --arg creds "$creds_path" --arg proj "$project_id" --argjson enabled "$enable_mcp" \
         '.mcp["google-analytics-mcp"] = {
@@ -4579,7 +4579,7 @@ setup_quickfile_mcp() {
 
             local tmp_config
             tmp_config=$(mktemp)
-            trap 'rm -f "$tmp_config"' RETURN
+            trap 'rm -f "${tmp_config:-}"' RETURN
 
             if jq --arg np "$node_path" --arg dp "$quickfile_dir/dist/index.js" \
                 '.mcp.quickfile = {"type": "local", "command": [$np, $dp], "enabled": true}' \


### PR DESCRIPTION
Fixes unbound variable crash in setup.sh from PR #800. Uses ${var:-} default in all RETURN traps across 27 files.