### PR TITLE
chore: ban Antigravity - remove all references from codebase

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -5,7 +5,7 @@ mode: subagent
 
 **New to aidevops?** Type `/onboarding` to get started with an interactive setup wizard.
 
-**Supported tools:** [OpenCode](https://opencode.ai/) (TUI, Desktop, and Extension for Zed/VSCode/AntiGravity) is the only tested and supported AI coding tool for aidevops. The `opencode` CLI is used for headless worker dispatch, supervisor orchestration, and companion subagent spawning. aidevops is also available in the Claude marketplace.
+**Supported tools:** [OpenCode](https://opencode.ai/) (TUI, Desktop, and Extension for Zed/VSCode) is the only tested and supported AI coding tool for aidevops. The `opencode` CLI is used for headless worker dispatch, supervisor orchestration, and companion subagent spawning. aidevops is also available in the Claude marketplace.
 
 **Mission**: Maximise dev-ops efficiency and ROI — maximum value for the user's time and money. Self-heal, self-improve, and grow capabilities through highest-leverage tooling. See `prompts/build.txt` for the full mission statement.
 

--- a/.agents/aidevops.md
+++ b/.agents/aidevops.md
@@ -148,17 +148,10 @@ Port 3002: Vaultwarden credentials
 
 ## OpenCode Plugins
 
-**Antigravity OAuth** (`opencode-antigravity-auth`): Enables Google OAuth for OpenCode,
-providing access to Antigravity rate limits and premium models.
+**Anthropic OAuth** (built-in since OpenCode v1.1.36+): Enables Claude Pro/Max authentication.
 
 ```bash
 # Authenticate after setup
 opencode auth login
-# Select: Google → OAuth with Google (Antigravity)
+# Select: Anthropic → Claude Pro/Max
 ```text
-
-**Available models**: gemini-3-pro-high, claude-opus-4-5-thinking, claude-sonnet-4-5-thinking
-
-**Multi-account**: Add multiple Google accounts for load balancing and failover.
-
-See: https://github.com/NoeFabris/opencode-antigravity-auth

--- a/.agents/aidevops/add-new-mcp-to-aidevops.md
+++ b/.agents/aidevops/add-new-mcp-to-aidevops.md
@@ -25,7 +25,7 @@ tools:
 
 - OpenCode, Cursor, Claude Code/Desktop, Gemini CLI
 - Windsurf, Continue.dev, Cody, Zed
-- GitHub Copilot, Kilo Code, Kiro, AntiGravity
+- GitHub Copilot, Kilo Code, Kiro
 - Droid (Factory.AI), Warp AI, Aider, Qwen
 
 **Checklist**:
@@ -216,7 +216,7 @@ Use `.agents/tools/context/augment-context-engine.md` as a reference template.
 5. **AI Assistant Configurations** - One section per assistant:
    - OpenCode, Claude Code, Cursor, Windsurf
    - Continue.dev, Cody, Zed, GitHub Copilot
-   - Kilo Code, Kiro, AntiGravity, Gemini CLI
+   - Kilo Code, Kiro, Gemini CLI
    - Droid (Factory.AI), Warp AI, Aider, Qwen
 
 6. **Verification** - Test prompt and expected results
@@ -304,7 +304,7 @@ configure_{mcp_name}_mcp() {
 | Zed | Custom server UI | Document only |
 | GitHub Copilot | `.vscode/mcp.json` | Per-project |
 | Kilo/Kiro | Global MCP config | JSON merge |
-| AntiGravity | `~/.gemini/antigravity/` | JSON merge |
+
 
 ## Step 7: Update setup.sh (If Prerequisites Needed)
 

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -4387,7 +4387,7 @@ extract_log_metadata() {
     # discusses errors, APIs, status codes as documentation content.
     # Anchored patterns prevent substring matches (e.g., 503 in timestamps).
     local backend_error_count=0
-    backend_error_count=$(grep -ci 'endpoints failed\|Antigravity\|gateway[[:space:]].*error\|service unavailable\|HTTP 503\|503 Service\|"status":[[:space:]]*503\|Quota protection\|over[_ -]\{0,1\}usage\|quota reset' "$log_tail_file" 2>/dev/null || echo 0)
+    backend_error_count=$(grep -ci 'endpoints failed\|gateway[[:space:]].*error\|service unavailable\|HTTP 503\|503 Service\|"status":[[:space:]]*503\|Quota protection\|over[_ -]\{0,1\}usage\|quota reset' "$log_tail_file" 2>/dev/null || echo 0)
 
     rm -f "$log_tail_file"
 
@@ -4590,7 +4590,7 @@ evaluate_worker() {
 
     # Backend infrastructure error with EXIT:0 (t095-diag-1): CLI wrappers like
     # OpenCode exit 0 even when the backend rejects the request (quota exceeded,
-    # Antigravity down). A short log (< 10 lines) with backend errors means the
+    # backend down). A short log (< 10 lines) with backend errors means the
     # worker never started - this is NOT content discussion, it's a real failure.
     # Must be checked BEFORE clean_exit_no_signal to avoid wasting retries.
     if [[ "$meta_exit_code" == "0" && "$meta_signal" == "none" ]]; then
@@ -4618,7 +4618,7 @@ evaluate_worker() {
     # are content (e.g., subagents documenting auth flows), not real failures.
 
     if [[ "$meta_exit_code" != "0" ]]; then
-        # Backend infrastructure error (Antigravity, quota, API gateway) = transient retry
+        # Backend infrastructure error (quota, API gateway) = transient retry
         # Only checked on non-zero exit: a clean exit with backend error strings in
         # the log is content discussion, not a real infrastructure failure.
         if [[ "$meta_backend_error_count" -gt 0 ]]; then
@@ -4898,9 +4898,9 @@ cmd_reprompt() {
     ai_cli=$(resolve_ai_cli) || return 1
 
     # Pre-reprompt health check: avoid wasting retry attempts on dead backends
-    # (t153-pre-diag-1: retries 1+2 failed instantly with "All Antigravity
-    # endpoints failed" because reprompt skipped the health check that
-    # cmd_dispatch performs)
+    # (t153-pre-diag-1: retries 1+2 failed instantly with backend endpoint
+    # errors because reprompt skipped the health check that cmd_dispatch
+    # performs)
     local health_model
     health_model=$(resolve_model "health" "$ai_cli")
     if ! check_model_health "$ai_cli" "$health_model"; then

--- a/.agents/services/accounting/quickfile.md
+++ b/.agents/services/accounting/quickfile.md
@@ -197,7 +197,7 @@ Add to `.vscode/mcp.json` in project root:
 ```
 
 See `configs/mcp-templates/quickfile.json` for all AI assistant configurations
-(Zed, Kilo Code, Kiro, AntiGravity, Droid).
+(Zed, Kilo Code, Kiro, Droid).
 
 ## Available Tools (37 tools)
 

--- a/.agents/tools/ai-assistants/overview.md
+++ b/.agents/tools/ai-assistants/overview.md
@@ -18,7 +18,7 @@ tools:
 
 ## Quick Reference
 
-- Primary: OpenCode TUI, OpenCode Desktop, OpenCode extension (Zed/VSCode/AntiGravity/forks)
+- Primary: OpenCode TUI, OpenCode Desktop, OpenCode extension (Zed/VSCode/forks)
 - Companion: claude-code CLI (called from within OpenCode for sub-tasks)
 - Config: `~/.config/opencode/opencode.json`, `~/.claude/`
 - Setup: `aidevops update` deploys agents, configures OpenCode MCPs
@@ -35,7 +35,7 @@ aidevops is developed, tested, and supported exclusively with OpenCode and the c
 |---------|-------------|
 | **OpenCode TUI** | Terminal UI - keyboard-driven, full MCP support |
 | **OpenCode Desktop** | Desktop app with the same capabilities |
-| **OpenCode Extension** | Extension for Zed, VSCode, AntiGravity, and other VSCode forks |
+| **OpenCode Extension** | Extension for Zed, VSCode, and other VSCode forks |
 
 - **Installation**: `curl -fsSL https://opencode.ai/install | bash`
 - **Configuration**: `~/.config/opencode/opencode.json` or project `.opencode/`

--- a/.agents/tools/automation/macos-automator.md
+++ b/.agents/tools/automation/macos-automator.md
@@ -41,7 +41,7 @@ Use the macos-automator MCP to get the current Safari URL.
 ```
 
 **Supported AI Tools**: OpenCode, Claude Code, Cursor, Windsurf, Zed, GitHub Copilot,
-Kilo Code, Kiro, AntiGravity, Gemini CLI, Droid (Factory.AI)
+Kilo Code, Kiro, Gemini CLI, Droid (Factory.AI)
 
 **Enabled for Agents**: None by default. Enable via `@mac` subagent.
 

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -27,7 +27,7 @@ mcp:
 - **Single Tool**: `execute` - runs Playwright code snippets
 
 **Key Advantages**:
-- **1 tool vs 17+** - Less context bloat than BrowserMCP/Antigravity
+- **1 tool vs 17+** - Less context bloat than BrowserMCP
 - **Full Playwright API** - LLMs already know it from training
 - **Your existing browser** - Reuse extensions, sessions, cookies
 - **Works with Brave, Edge, Chrome** - Any Chromium-based browser with extension support

--- a/.agents/tools/build-mcp/deployment.md
+++ b/.agents/tools/build-mcp/deployment.md
@@ -25,7 +25,7 @@ tools:
 
 | Format | Assistants |
 |--------|------------|
-| JSON (mcpServers) | OpenCode, Claude Desktop, Cursor, Windsurf, Kilo Code, Kiro, AntiGravity, Gemini CLI |
+| JSON (mcpServers) | OpenCode, Claude Desktop, Cursor, Windsurf, Kilo Code, Kiro, Gemini CLI |
 | CLI command | Claude Code, Droid |
 | VS Code MCP | GitHub Copilot, Continue.dev, Cody |
 | Custom | Zed, Aider |
@@ -255,21 +255,6 @@ Open command palette (Cmd+Shift+P):
       "args": ["run", "/path/to/my-mcp/src/index.ts"],
       "disabled": false,
       "autoApprove": ["tool_name"]
-    }
-  }
-}
-```
-
-## AntiGravity
-
-Click MCP server icon → Manage MCP server → View raw config:
-
-```json
-{
-  "mcpServers": {
-    "my-mcp": {
-      "command": "bun",
-      "args": ["run", "/path/to/my-mcp/src/index.ts"]
     }
   }
 }

--- a/.agents/tools/context/augment-context-engine.md
+++ b/.agents/tools/context/augment-context-engine.md
@@ -272,23 +272,6 @@ Open command palette (Cmd+Shift+P / Ctrl+Shift+P):
 }
 ```
 
-### AntiGravity
-
-Click MCP server icon → Manage MCP server → View raw config:
-
-```json
-{
-  "mcpServers": {
-    "augment-context-engine": {
-      "command": "auggie",
-      "args": ["--mcp", "-m", "default", "-w", "/path/to/your/project"]
-    }
-  }
-}
-```
-
-**Note**: Update `/path/to/your/project` with your actual project path.
-
 ### Gemini CLI
 
 Edit `~/.gemini/settings.json` (user level) or `.gemini/settings.json` (project):

--- a/.agents/tools/context/osgrep.md
+++ b/.agents/tools/context/osgrep.md
@@ -327,21 +327,6 @@ Open command palette (Cmd+Shift+P / Ctrl+Shift+P):
 }
 ```
 
-### AntiGravity
-
-Click MCP server icon → Manage MCP server → View raw config:
-
-```json
-{
-  "mcpServers": {
-    "osgrep": {
-      "command": "osgrep",
-      "args": ["serve"]
-    }
-  }
-}
-```
-
 ### Gemini CLI
 
 Edit `~/.gemini/settings.json` (user level) or `.gemini/settings.json` (project):

--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -321,15 +321,13 @@ opencode run "Hello, Claude!" --model anthropic/claude-sonnet-4-20250514
 
 ## Comparison with Other Auth Methods
 
-| Feature | Anthropic OAuth (this plugin) | Antigravity OAuth | Manual API Key |
-|---------|-------------------------------|-------------------|----------------|
-| **Claude Pro/Max cost** | $0 (subscription) | N/A | Standard rates |
-| **Google OAuth** | No | Yes | No |
-| **Multi-account rotation** | No | Yes | No |
-| **Auto token refresh** | Yes | Yes | N/A |
-| **Beta features** | Auto-enabled | Manual | Manual |
-| **Setup complexity** | Low (OAuth flow) | Low (OAuth flow) | Lowest (paste key) |
-| **Best for** | Claude subscribers | Gemini/Claude users | API-only users |
+| Feature | Anthropic OAuth (built-in) | Manual API Key |
+|---------|---------------------------|----------------|
+| **Claude Pro/Max cost** | $0 (subscription) | Standard rates |
+| **Auto token refresh** | Yes | N/A |
+| **Beta features** | Auto-enabled | Manual |
+| **Setup complexity** | Low (OAuth flow) | Lowest (paste key) |
+| **Best for** | Claude subscribers | API-only users |
 
 ## Security Considerations
 
@@ -364,7 +362,7 @@ For teams or multi-account scenarios:
 2. **Account switching**: Use `opencode auth logout && opencode auth login`
 3. **Organization accounts**: Ensure organization members have API access enabled
 
-**Note**: Unlike Antigravity, this plugin does not support automatic multi-account load balancing. Use separate OpenCode profiles or environments for true multi-account rotation.
+**Note**: This plugin does not support automatic multi-account load balancing. Use separate OpenCode profiles or environments for true multi-account rotation.
 
 ### Beta Feature Customization
 
@@ -437,7 +435,7 @@ aidevops follows OpenCode's credential storage:
 
 ## Related Documentation
 
-- `tools/opencode/opencode.md` - OpenCode integration overview (includes Antigravity)
+- `tools/opencode/opencode.md` - OpenCode integration overview
 - `tools/ai-assistants/configuration.md` - AI assistant configuration
 - `tools/credentials/api-key-management.md` - API key management
 - `aidevops/setup.md` - Setup script details

--- a/.agents/tools/opencode/opencode.md
+++ b/.agents/tools/opencode/opencode.md
@@ -43,7 +43,7 @@ tools:
 
 # Authenticate (OAuth plugins)
 opencode auth login
-# - Google → Antigravity (Gemini/Claude via Google)
+# - Anthropic → Claude Pro/Max (direct Claude access)
 # - Anthropic → Claude Pro/Max (direct Claude access)
 
 # In OpenCode:
@@ -56,26 +56,6 @@ opencode auth login
 ## Overview
 
 OpenCode is a CLI AI assistant that supports specialized agents and MCP (Model Context Protocol) servers. This integration configures OpenCode with aidevops-specific agents and MCPs.
-
-## Antigravity OAuth Plugin
-
-The aidevops setup automatically installs the [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth) plugin, enabling Google OAuth authentication for premium model access.
-
-**Authenticate after setup:**
-
-```bash
-opencode auth login
-# Select: Google → OAuth with Google (Antigravity)
-# Press Enter to skip Project ID prompt
-```text
-
-**Available models via Antigravity:**
-
-- `gemini-3-pro-high` / `gemini-3-pro-low` / `gemini-3-flash`
-- `claude-sonnet-4-5` / `claude-sonnet-4-5-thinking` / `claude-opus-4-5-thinking`
-- `gpt-oss-120b-medium`
-
-**Multi-account load balancing:** Add multiple Google accounts for automatic rate limit distribution. Run `opencode auth login` again to add more accounts.
 
 ## Anthropic OAuth (Built-in)
 

--- a/README.md
+++ b/README.md
@@ -257,26 +257,6 @@ See `.agents/tools/task-management/beads.md` for complete documentation and inst
 
 **Your AI assistant now has agentic access to 30+ service integrations.**
 
-### OpenCode Antigravity OAuth Plugin
-
-The setup automatically installs the [opencode-antigravity-auth](https://github.com/NoeFabris/opencode-antigravity-auth) plugin, enabling Google OAuth authentication for OpenCode. This gives you access to Antigravity rate limits and premium models.
-
-**After setup, authenticate:**
-
-```bash
-opencode auth login
-# Select: Google → OAuth with Google (Antigravity)
-# Press Enter to skip Project ID prompt
-```
-
-**Available models via Antigravity:**
-
-- `gemini-3-pro-high` / `gemini-3-pro-low` / `gemini-3-flash`
-- `claude-sonnet-4-5` / `claude-sonnet-4-5-thinking` / `claude-opus-4-5-thinking`
-- `gpt-oss-120b-medium`
-
-**Multi-account load balancing:** Add multiple Google accounts for automatic rate limit distribution and failover. See the [plugin documentation](https://github.com/NoeFabris/opencode-antigravity-auth) for model configuration.
-
 ### OpenCode Anthropic OAuth (Built-in)
 
 OpenCode v1.1.36+ includes Anthropic OAuth authentication natively. No external plugin is needed.
@@ -888,7 +868,7 @@ See `.agents/tools/ocr/glm-ocr.md` for batch processing, PDF workflows, and Peek
 
 ## **MCP Integrations**
 
-**Model Context Protocol servers for real-time AI assistant integration.** The framework configures these MCPs for **[OpenCode](https://opencode.ai/)** (TUI, Desktop, and Extension for Zed/VSCode/AntiGravity).
+**Model Context Protocol servers for real-time AI assistant integration.** The framework configures these MCPs for **[OpenCode](https://opencode.ai/)** (TUI, Desktop, and Extension for Zed/VSCode).
 
 ### **All Supported MCPs (19 available)**
 

--- a/configs/augment-context-engine-config.json.txt
+++ b/configs/augment-context-engine-config.json.txt
@@ -116,19 +116,6 @@
         }
       }
     },
-    "antigravity": {
-      "method": "raw_config",
-      "path": "MCP server icon → Manage MCP server → View raw config",
-      "config": {
-        "mcpServers": {
-          "augment-context-engine": {
-            "command": "auggie",
-            "args": ["--mcp", "-m", "default", "-w", "/path/to/your/project"]
-          }
-        }
-      },
-      "notes": "Update /path/to/your/project with actual project path"
-    },
     "gemini_cli": {
       "config_locations": {
         "user": "~/.gemini/settings.json",

--- a/configs/mcp-templates/augment-context-engine.json
+++ b/configs/mcp-templates/augment-context-engine.json
@@ -81,16 +81,6 @@
     }
   },
 
-  "antigravity": {
-    "_method": "MCP server icon → Manage → View raw config",
-    "mcpServers": {
-      "augment-context-engine": {
-        "command": "auggie",
-        "args": ["--mcp", "-m", "default", "-w", "/path/to/your/project"]
-      }
-    }
-  },
-
   "gemini_cli": {
     "_file": "~/.gemini/settings.json",
     "mcpServers": {

--- a/configs/mcp-templates/osgrep.json
+++ b/configs/mcp-templates/osgrep.json
@@ -73,16 +73,6 @@
     }
   },
 
-  "antigravity": {
-    "_method": "MCP server icon → Manage → View raw config",
-    "mcpServers": {
-      "osgrep": {
-        "command": "osgrep",
-        "args": ["serve"]
-      }
-    }
-  },
-
   "gemini_cli": {
     "_file": "~/.gemini/settings.json",
     "mcpServers": {

--- a/configs/mcp-templates/quickfile.json
+++ b/configs/mcp-templates/quickfile.json
@@ -82,16 +82,6 @@
     }
   },
 
-  "antigravity": {
-    "_method": "MCP server icon > Manage > View raw config",
-    "mcpServers": {
-      "quickfile": {
-        "command": "node",
-        "args": ["/path/to/quickfile-mcp/dist/index.js"]
-      }
-    }
-  },
-
   "gemini_cli": {
     "_file": "~/.gemini/settings.json",
     "mcpServers": {

--- a/configs/osgrep-config.json.txt
+++ b/configs/osgrep-config.json.txt
@@ -102,18 +102,6 @@
         }
       }
     },
-    "antigravity": {
-      "method": "raw_config",
-      "path": "MCP server icon → Manage MCP server → View raw config",
-      "config": {
-        "mcpServers": {
-          "osgrep": {
-            "command": "osgrep",
-            "args": ["serve"]
-          }
-        }
-      }
-    },
     "gemini_cli": {
       "config_locations": {
         "user": "~/.gemini/settings.json",

--- a/configs/quickfile-mcp-config.json.txt
+++ b/configs/quickfile-mcp-config.json.txt
@@ -161,18 +161,6 @@
         }
       }
     },
-    "antigravity": {
-      "method": "raw_config",
-      "path": "MCP server icon > Manage MCP server > View raw config",
-      "config": {
-        "mcpServers": {
-          "quickfile": {
-            "command": "node",
-            "args": ["/path/to/quickfile-mcp/dist/index.js"]
-          }
-        }
-      }
-    },
     "gemini_cli": {
       "config_locations": {
         "user": "~/.gemini/settings.json",

--- a/setup.sh
+++ b/setup.sh
@@ -4265,7 +4265,7 @@ setup_safety_hooks() {
     return 0
 }
 
-# Setup OpenCode Plugins (Antigravity OAuth)
+# Setup OpenCode Plugins
 # Helper function to add/update a single plugin in OpenCode config
 add_opencode_plugin() {
     local plugin_name="$1"
@@ -4339,21 +4339,11 @@ setup_opencode_plugins() {
         print_success "aidevops compaction plugin registered (preserves context across compaction)"
     fi
 
-    # Setup Antigravity OAuth plugin (Google OAuth)
-    print_info "Setting up Antigravity OAuth plugin..."
-    add_opencode_plugin "opencode-antigravity-auth" "opencode-antigravity-auth@latest" "$opencode_config"
-    
-    print_info "Antigravity OAuth plugin enables Google OAuth for OpenCode"
-    print_info "Models available: gemini-3-pro-high, claude-opus-4-5-thinking, etc."
-    print_info "See: https://github.com/NoeFabris/opencode-antigravity-auth"
-    echo ""
-    
     # Note: opencode-anthropic-auth is built into OpenCode v1.1.36+
     # Adding it as an external plugin causes TypeError due to double-loading.
     # Removed in v2.90.0 - see PR #230.
     
     print_info "After setup, authenticate with: opencode auth login"
-    print_info "  • For Google OAuth: Select 'Google' → 'OAuth with Google (Antigravity)'"
     print_info "  • For Claude OAuth: Select 'Anthropic' → 'Claude Pro/Max' (built-in)"
     
     return 0


### PR DESCRIPTION
## Summary

- Remove Antigravity OAuth plugin installation from `setup.sh`
- Remove all AntiGravity MCP config sections from 6 config templates
- Remove AntiGravity from supported tool lists across 8 documentation files
- Clean up supervisor error detection patterns (remove Antigravity-specific matching)
- Update auth comparison table in `opencode-anthropic-auth.md`

**Antigravity is permanently banned.** It does not work. Anthropic OAuth (built-in to OpenCode v1.1.36+) is the only supported auth method.

21 files changed, 203 lines removed. CHANGELOG.md left intact as historical record.