### PR TITLE
fix: replace ls with find in review-pulse-helper.sh (SC2012) (t196)

### DIFF
--- a/.agents/scripts/review-pulse-helper.sh
+++ b/.agents/scripts/review-pulse-helper.sh
@@ -375,7 +375,7 @@ create_tasks_from_findings() {
     ensure_dirs
 
     local latest_findings
-    latest_findings=$(ls -t "$FINDINGS_DIR"/*-findings.json 2>/dev/null | head -1)
+    latest_findings=$(find "$FINDINGS_DIR" -maxdepth 1 -name '*-findings.json' -printf '%T@\t%p\n' 2>/dev/null | sort -rn | head -1 | cut -f2-)
 
     if [[ -z "$latest_findings" || ! -f "$latest_findings" ]]; then
         print_warning "No findings files found. Run 'review-pulse-helper.sh run' first."
@@ -448,7 +448,7 @@ show_findings() {
     ensure_dirs
 
     local latest_findings
-    latest_findings=$(ls -t "$FINDINGS_DIR"/*-findings.json 2>/dev/null | head -1)
+    latest_findings=$(find "$FINDINGS_DIR" -maxdepth 1 -name '*-findings.json' -printf '%T@\t%p\n' 2>/dev/null | sort -rn | head -1 | cut -f2-)
 
     if [[ -z "$latest_findings" || ! -f "$latest_findings" ]]; then
         print_warning "No findings files found. Run 'review-pulse-helper.sh run' first."
@@ -552,7 +552,7 @@ show_status() {
     # Check data directory
     if [[ -d "$FINDINGS_DIR" ]]; then
         local findings_count
-        findings_count=$(ls "$FINDINGS_DIR"/*-findings.json 2>/dev/null | wc -l | tr -d ' ')
+        findings_count=$(find "$FINDINGS_DIR" -maxdepth 1 -name '*-findings.json' 2>/dev/null | wc -l | tr -d ' ')
         print_info "Findings files: $findings_count"
     else
         print_info "Findings directory: not created yet"


### PR DESCRIPTION
## Summary

- Replace 3 instances of `ls` with `find` in `review-pulse-helper.sh` to fix ShellCheck SC2012 warnings
- Lines 378, 451: `ls -t` for finding latest findings file → `find -printf '%T@' | sort -rn`
- Line 555: `ls | wc -l` for counting files → `find | wc -l`

## Context

Found by CodeRabbit daily pulse review (issue #753). Other findings from the same report (SC2086 in wp-helper.sh, SC2034 unused colors) were verified as false positives.

## Verification

- `shellcheck -e SC1091` passes with zero SC2012 violations
- `bash -n` syntax check passes
- Zero remaining `ls` usage in the file
- No behavior change — same file discovery logic, just POSIX-compliant

Closes t196.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of findings file selection to better handle special characters and spaces in filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->