### PR TITLE
docs: add task ID collision prevention rule to AGENTS.md (t201)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -122,6 +122,8 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **After ANY TODO/planning edit** (interactive sessions only, NOT workers): Commit and push immediately. Planning-only files (TODO.md, todo/) go directly to main -- no branch, no PR. Mixed changes (planning + non-exception files) use a worktree. NEVER `git checkout -b` in the main repo.
 
+**Task ID collision prevention**: When assigning a new task ID, if `git push` fails and you `git pull --rebase`, you MUST re-read TODO.md and verify your assigned ID is still unique before pushing again. Parallel sessions may have claimed the same ID. If a collision exists, renumber to the next available ID.
+
 **Full docs**: `workflows/plans.md`, `tools/task-management/beads.md`
 
 ## Model Routing


### PR DESCRIPTION
## Summary

- Add one-paragraph rule to `.agents/AGENTS.md` Planning & Tasks section
- Rule: after `git pull --rebase` on TODO.md, re-verify assigned task ID is still unique before pushing

## Context

Hit this race condition twice in one session — parallel sessions created t195 and t196 simultaneously, causing duplicate IDs in TODO.md. Root cause: agent assigns next ID, commits, push rejected (remote ahead), does `pull --rebase`, pushes again WITHOUT checking if the ID was taken by the parallel session.

The fix is an instruction-level guard: re-read TODO.md after rebase, renumber if collision detected.

Closes t201.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains no user-facing changes. Internal documentation updates have been made to improve development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->