### PR TITLE
fix: prevent RETURN trap clobbering with cleanup stack (t196)

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -436,7 +436,8 @@ register_skill() {
         log_info "Updating existing skill registration: $name"
         local tmp_file
         tmp_file=$(mktemp)
-        trap 'rm -f "${tmp_file:-}"' RETURN
+        _save_cleanup_scope; trap '_run_cleanups' RETURN
+        push_cleanup "rm -f '${tmp_file}'"
         jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" > "$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
         rm -f "$tmp_file"
     fi
@@ -1274,7 +1275,8 @@ cmd_remove() {
     # Remove from registry
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "${tmp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${tmp_file}'"
     jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" > "$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
     
     log_success "Skill '$name' removed"

--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -343,7 +343,9 @@ run_prompt_opencode_cli() {
     local stderr_file raw_output
     stderr_file=$(mktemp)
     raw_output=$(mktemp)
-    trap 'rm -f "${stderr_file:-}" "${raw_output:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${stderr_file}'"
+    push_cleanup "rm -f '${raw_output}'"
 
     local exit_code=0
     portable_timeout "${timeout}" "${cmd[@]}" "$prompt" >"$raw_output" 2>"$stderr_file" || {

--- a/.agents/scripts/clawdhub-helper.sh
+++ b/.agents/scripts/clawdhub-helper.sh
@@ -157,7 +157,8 @@ fetch_skill_content_playwright() {
     # Create a temporary Node.js project with Playwright to extract SKILL.md
     local pw_dir
     pw_dir=$(mktemp -d "${TMPDIR:-/tmp}/clawdhub-pw-XXXXXX")
-    trap 'rm -rf "$pw_dir"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -rf '${pw_dir}'"
 
     # Create package.json for the temporary project
     cat > "$pw_dir/package.json" << 'PKGJSON'

--- a/.agents/scripts/coderabbit-collector-helper.sh
+++ b/.agents/scripts/coderabbit-collector-helper.sh
@@ -384,7 +384,9 @@ collect_reviews() {
     local jq_filter_file sql_file
     jq_filter_file=$(mktemp)
     sql_file=$(mktemp)
-    trap 'rm -f "${jq_filter_file:-}" "${sql_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${jq_filter_file}'"
+    push_cleanup "rm -f '${sql_file}'"
 
     cat > "$jq_filter_file" << 'JQ_EOF'
 def sql_str: gsub("'"; "''") | "'" + . + "'";
@@ -452,7 +454,9 @@ collect_comments() {
     local jq_filter_file sql_file
     jq_filter_file=$(mktemp)
     sql_file=$(mktemp)
-    trap 'rm -f "${jq_filter_file:-}" "${sql_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${jq_filter_file}'"
+    push_cleanup "rm -f '${sql_file}'"
 
     cat > "$jq_filter_file" << 'JQ_EOF'
 def sql_str: gsub("'"; "''") | "'" + . + "'";

--- a/.agents/scripts/coderabbit-task-creator-helper.sh
+++ b/.agents/scripts/coderabbit-task-creator-helper.sh
@@ -370,7 +370,8 @@ scan_db_findings() {
     # Write comments to temp file for process substitution (avoids subshell)
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "${tmp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${tmp_file}'"
     echo "$comments_json" | jq -c '.[]' > "$tmp_file"
 
     local total=0
@@ -505,7 +506,8 @@ scan_pulse_findings() {
     # Write findings to temp file to avoid subshell variable loss
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "${tmp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${tmp_file}'"
     jq -c '.findings[]' "$latest_findings" > "$tmp_file"
 
     while IFS= read -r finding; do
@@ -707,7 +709,8 @@ cmd_create() {
     # Write findings to temp file to avoid subshell variable loss
     local tmp_create
     tmp_create=$(mktemp)
-    trap 'rm -f "${tmp_create:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${tmp_create}'"
     echo "$findings_json" | jq -c '.[]' > "$tmp_create"
 
     while IFS= read -r finding; do

--- a/.agents/scripts/cron-dispatch.sh
+++ b/.agents/scripts/cron-dispatch.sh
@@ -118,7 +118,8 @@ update_job_status() {
     
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     jq --arg id "$job_id" \
        --arg status "$status" \
        --arg timestamp "$timestamp" \

--- a/.agents/scripts/cron-helper.sh
+++ b/.agents/scripts/cron-helper.sh
@@ -152,7 +152,8 @@ get_job() {
 sync_crontab() {
     local temp_cron
     temp_cron=$(mktemp)
-    trap 'rm -f "${temp_cron:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_cron}'"
     
     # Get existing crontab (excluding our managed entries)
     crontab -l 2>/dev/null | grep -v "cron-dispatch.sh" > "$temp_cron" || true
@@ -271,7 +272,8 @@ cmd_add() {
     # Add job to config
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     jq --arg id "$job_id" \
        --arg name "$name" \
        --arg schedule "$schedule" \
@@ -360,7 +362,8 @@ cmd_remove() {
     # Remove from config
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     jq --arg id "$job_id" '.jobs = [.jobs[] | select(.id != $id)]' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     
@@ -395,7 +398,8 @@ cmd_pause() {
     # Update status
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     jq --arg id "$job_id" '(.jobs[] | select(.id == $id)).status = "paused"' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     
@@ -432,7 +436,8 @@ cmd_resume() {
     # Update status
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     jq --arg id "$job_id" '(.jobs[] | select(.id == $id)).status = "active"' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -160,7 +160,8 @@ remove_headless_todo_guard() {
         # Use sed to remove the guard block
         local tmp_file
         tmp_file=$(mktemp)
-        trap 'rm -f "${tmp_file:-}"' RETURN
+        _save_cleanup_scope; trap '_run_cleanups' RETURN
+        push_cleanup "rm -f '${tmp_file}'"
         awk '/# t173-headless-todo-guard/{skip=1} /^fi$/ && skip{skip=0; next} !skip' "$hook_file" > "$tmp_file"
         mv "$tmp_file" "$hook_file"
         chmod +x "$hook_file"

--- a/.agents/scripts/keyword-research-helper.sh
+++ b/.agents/scripts/keyword-research-helper.sh
@@ -789,7 +789,8 @@ do_webmaster_research() {
     # Combine and deduplicate keywords
     local combined_keywords
     combined_keywords=$(mktemp)
-    trap 'rm -f "${combined_keywords:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${combined_keywords}'"
     
     # Process GSC data
     if [[ -n "$gsc_data" ]]; then

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -134,7 +134,8 @@ check_positional_parameters() {
     # Exclude: heredocs (<<), awk scripts, main script body, and local assignments
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "${tmp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${tmp_file}'"
 
     # Only check inside function bodies, exclude heredocs, awk/sed patterns, and comments
     for file in .agents/scripts/*.sh; do

--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -26,6 +26,11 @@ set -euo pipefail
 # Resolve script directory for sibling script references
 LOOP_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 readonly LOOP_COMMON_DIR
+
+# Source shared constants for cleanup stack utilities (t196)
+# shellcheck source=shared-constants.sh
+source "${LOOP_COMMON_DIR}/shared-constants.sh"
+
 readonly LOOP_MAIL_HELPER="${LOOP_COMMON_DIR}/mail-helper.sh"
 readonly LOOP_MEMORY_HELPER="${LOOP_COMMON_DIR}/memory-helper.sh"
 
@@ -175,7 +180,8 @@ loop_set_state() {
     
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     
     # Determine value type and update
     if [[ "$value" =~ ^[0-9]+$ ]]; then

--- a/.agents/scripts/markdown-formatter.sh
+++ b/.agents/scripts/markdown-formatter.sh
@@ -37,7 +37,8 @@ fix_markdown_file() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     local changes_made=0
     
     print_info "Processing: $file"
@@ -123,7 +124,8 @@ apply_advanced_fixes() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
 
     print_info "Applying advanced fixes to: $file"
 

--- a/.agents/scripts/markdown-lint-fix.sh
+++ b/.agents/scripts/markdown-lint-fix.sh
@@ -151,7 +151,8 @@ apply_manual_fixes() {
     local file="$1"
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     local changes_made=0
     
     print_info "Applying manual fixes to: $file"

--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -120,7 +120,8 @@ config_set() {
 
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     jq --arg key "$key" --arg value "$value" '.[$key] = $value' "$CONFIG_FILE" > "$temp_file" && mv "$temp_file" "$CONFIG_FILE"
     chmod 600 "$CONFIG_FILE"
 }
@@ -253,7 +254,8 @@ cmd_setup() {
     # Save config
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     jq -n \
         --arg homeserverUrl "$homeserver" \
         --arg accessToken "$access_token" \
@@ -769,7 +771,8 @@ cmd_map() {
 
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     jq --arg room "$room_id" --arg runner "$runner_name" \
         '.roomMappings[$room] = $runner' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
@@ -801,7 +804,8 @@ cmd_unmap() {
 
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     jq --arg room "$room_id" 'del(.roomMappings[$room])' "$CONFIG_FILE" > "$temp_file"
     mv "$temp_file" "$CONFIG_FILE"
     chmod 600 "$CONFIG_FILE"

--- a/.agents/scripts/objective-runner-helper.sh
+++ b/.agents/scripts/objective-runner-helper.sh
@@ -172,7 +172,8 @@ update_state() {
 
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
 
     # Build jq expression from key=value pairs
     local jq_expr="."

--- a/.agents/scripts/ralph-loop-helper.sh
+++ b/.agents/scripts/ralph-loop-helper.sh
@@ -234,7 +234,8 @@ run_v2_loop() {
 
     local iteration=1
     output_file="$(mktemp)"
-    trap 'rm -f "${output_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${output_file}'"
 
     while [[ $iteration -le $max_iterations ]]; do
         print_step "=== Iteration $iteration/$max_iterations ==="

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -500,7 +500,8 @@ $full_prompt"
     # Update config with run metadata
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     local status="success"
     if [[ $exit_code -ne 0 ]]; then
         status="failed"

--- a/.agents/scripts/schema-validator-helper.sh
+++ b/.agents/scripts/schema-validator-helper.sh
@@ -57,18 +57,19 @@ install_deps() {
     fi
 
     # Ensure type: module for ESM imports
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
     if ! grep -q '"type": "module"' "$TOOL_DIR/package.json" 2>/dev/null; then
         if command_exists jq; then
             local tmp
             tmp=$(mktemp)
-            trap 'rm -f "${tmp:-}"' RETURN
+            push_cleanup "rm -f '${tmp}'"
             jq '. + {"type": "module"}' "$TOOL_DIR/package.json" > "$tmp" && mv "$tmp" "$TOOL_DIR/package.json"
             rm -f "$tmp"
         else
             # Fallback: write "type": "module" into package.json without jq
             local tmp
             tmp=$(mktemp)
-            trap 'rm -f "${tmp:-}"' RETURN
+            push_cleanup "rm -f '${tmp}'"
             printf '{\n  "type": "module",\n' > "$tmp"
             # Append everything after the opening brace
             tail -n +2 "$TOOL_DIR/package.json" >> "$tmp" && mv "$tmp" "$TOOL_DIR/package.json"

--- a/.agents/scripts/secretlint-helper.sh
+++ b/.agents/scripts/secretlint-helper.sh
@@ -888,7 +888,8 @@ setup_husky_integration() {
     if command -v jq &> /dev/null; then
         local tmp_file
         tmp_file=$(mktemp)
-        trap 'rm -f "${tmp_file:-}"' RETURN
+        _save_cleanup_scope; trap '_run_cleanups' RETURN
+        push_cleanup "rm -f '${tmp_file}'"
         jq '. + {"lint-staged": {"*": ["secretlint"]}}' package.json > "$tmp_file" && mv "$tmp_file" package.json
         print_success "Added lint-staged configuration"
     else

--- a/.agents/scripts/seo-analysis-helper.sh
+++ b/.agents/scripts/seo-analysis-helper.sh
@@ -97,7 +97,8 @@ analyze_quick_wins() {
     # Collect data from all sources
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     
     for toon_file in "$domain_dir"/*.toon; do
         [[ -f "$toon_file" ]] || continue
@@ -159,7 +160,8 @@ analyze_striking_distance() {
     
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     
     for toon_file in "$domain_dir"/*.toon; do
         [[ -f "$toon_file" ]] || continue
@@ -224,7 +226,8 @@ analyze_low_ctr() {
     
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     
     for toon_file in "$domain_dir"/*.toon; do
         [[ -f "$toon_file" ]] || continue
@@ -284,7 +287,9 @@ analyze_cannibalization() {
     temp_file=$(mktemp)
     local query_pages
     query_pages=$(mktemp)
-    trap 'rm -f "${temp_file:-}" "${query_pages:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
+    push_cleanup "rm -f '${query_pages}'"
     
     # Collect all query-page pairs
     for toon_file in "$domain_dir"/*.toon; do

--- a/.agents/scripts/site-crawler-helper.sh
+++ b/.agents/scripts/site-crawler-helper.sh
@@ -734,7 +734,8 @@ EOF
     if find_python && "$PYTHON_CMD" -c "import openpyxl" 2>/dev/null; then
         local xlsx_script
         xlsx_script=$(mktemp /tmp/xlsx_gen_XXXXXX.py)
-        trap 'rm -f "${xlsx_script:-}"' RETURN
+        _save_cleanup_scope; trap '_run_cleanups' RETURN
+        push_cleanup "rm -f '${xlsx_script}'"
         cat > "$xlsx_script" << 'PYXLSX'
 import sys
 import csv
@@ -1183,7 +1184,8 @@ do_crawl() {
     # Generate and run crawler
     local crawler_script
     crawler_script=$(mktemp /tmp/site_crawler_XXXXXX.py)
-    trap 'rm -f "${crawler_script:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${crawler_script}'"
     generate_fallback_crawler > "$crawler_script"
     
     "$PYTHON_CMD" "$crawler_script" "$url" "$output_dir" "$max_urls" "$depth" "$format"

--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -180,7 +180,8 @@ update_last_checked() {
     
     local tmp_file
     tmp_file=$(mktemp)
-    trap 'rm -f "${tmp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${tmp_file}'"
     
     jq --arg name "$skill_name" --arg ts "$timestamp" \
         '.skills = [.skills[] | if .name == $name then .last_checked = $ts else . end]' \

--- a/.agents/scripts/sonarcloud-autofix.sh
+++ b/.agents/scripts/sonarcloud-autofix.sh
@@ -35,7 +35,8 @@ fix_missing_returns() {
     # This is a basic implementation - would need more sophisticated logic for production
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     
     awk '
     /^[a-zA-Z_][a-zA-Z0-9_]*\(\)/ { in_function = 1 }

--- a/.agents/scripts/sonarscanner-cli.sh
+++ b/.agents/scripts/sonarscanner-cli.sh
@@ -95,7 +95,8 @@ install_sonar_scanner() {
     # Create temporary directory with trap cleanup for early returns
     local temp_dir
     temp_dir=$(mktemp -d)
-    trap 'rm -rf "$temp_dir"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -rf '${temp_dir}'"
     local zip_file="$temp_dir/sonar-scanner.zip"
     
     # Download

--- a/.agents/scripts/sops-helper.sh
+++ b/.agents/scripts/sops-helper.sh
@@ -104,7 +104,8 @@ cmd_install() {
         local latest_url="https://github.com/getsops/sops/releases/latest/download/sops_3.9.4_${arch}.deb"
         local tmp_deb
         tmp_deb=$(mktemp /tmp/sops-XXXXXX.deb)
-        trap 'rm -f "${tmp_deb:-}"' RETURN
+        _save_cleanup_scope; trap '_run_cleanups' RETURN
+        push_cleanup "rm -f '${tmp_deb}'"
         curl -fsSL "$latest_url" -o "$tmp_deb"
         sudo dpkg -i "$tmp_deb"
         rm -f "$tmp_deb"

--- a/.agents/scripts/terminal-title-setup.sh
+++ b/.agents/scripts/terminal-title-setup.sh
@@ -105,7 +105,8 @@ tabby_enable_dynamic_titles() {
     # Replace all instances (cross-platform: works on both macOS and Linux)
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     sed 's/disableDynamicTitle: true/disableDynamicTitle: false/g' "$TABBY_CONFIG_FILE" > "$temp_file" && mv "$temp_file" "$TABBY_CONFIG_FILE"
     
     local count
@@ -304,7 +305,8 @@ remove_integration() {
     # Remove our integration block (cross-platform: works on both macOS and Linux)
     local temp_file
     temp_file=$(mktemp)
-    trap 'rm -f "${temp_file:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_file}'"
     sed "/$MARKER_START/,/$MARKER_END/d" "$rc_file" > "$temp_file" && mv "$temp_file" "$rc_file"
     
     log_success "Removed integration from $rc_file (backup: ${rc_file}.aidevops-backup)"

--- a/.agents/scripts/watercrawl-helper.sh
+++ b/.agents/scripts/watercrawl-helper.sh
@@ -579,7 +579,8 @@ scrape_url() {
     # Create Node.js script for scraping
     local temp_script
     temp_script=$(mktemp /tmp/watercrawl_scrape_XXXXXX.mjs)
-    trap 'rm -f "${temp_script:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_script}'"
     
     cat > "$temp_script" << 'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';
@@ -660,7 +661,8 @@ crawl_website() {
     # Create Node.js script for crawling
     local temp_script
     temp_script=$(mktemp /tmp/watercrawl_crawl_XXXXXX.mjs)
-    trap 'rm -f "${temp_script:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_script}'"
     
     cat > "$temp_script" << 'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';
@@ -773,7 +775,8 @@ search_web() {
     # Create Node.js script for searching
     local temp_script
     temp_script=$(mktemp /tmp/watercrawl_search_XXXXXX.mjs)
-    trap 'rm -f "${temp_script:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_script}'"
     
     cat > "$temp_script" << 'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';
@@ -862,7 +865,8 @@ generate_sitemap() {
     # Create Node.js script for sitemap
     local temp_script
     temp_script=$(mktemp /tmp/watercrawl_sitemap_XXXXXX.mjs)
-    trap 'rm -f "${temp_script:-}"' RETURN
+    _save_cleanup_scope; trap '_run_cleanups' RETURN
+    push_cleanup "rm -f '${temp_script}'"
     
     cat > "$temp_script" << 'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';


### PR DESCRIPTION
## Summary

- Add `push_cleanup`/`_run_cleanups`/`_save_cleanup_scope` utilities to `shared-constants.sh` that accumulate cleanup commands in a stack, preventing the silent clobbering that occurs when a bash function sets `trap ... RETURN` more than once
- Migrate all 49 `trap ... RETURN` instances across 28 scripts to use the new pattern
- Add `shared-constants.sh` source to `loop-common.sh` (only script missing it)

## Problem

In bash, setting `trap 'cmd' RETURN` twice in the same function silently replaces the first trap. If a function creates two temp files with separate traps, the first file leaks:

```bash
# BUG: only $b gets cleaned up, $a leaks
my_func() {
    local a; a=$(mktemp); trap "rm -f '$a'" RETURN
    local b; b=$(mktemp); trap "rm -f '$b'" RETURN  # clobbers first trap!
}
```

## Solution

A cleanup stack pattern where functions accumulate cleanup commands:

```bash
my_func() {
    _save_cleanup_scope; trap '_run_cleanups' RETURN
    local a; a=$(mktemp); push_cleanup "rm -f '${a}'"
    local b; b=$(mktemp); push_cleanup "rm -f '${b}'"
    # Both files cleaned up on return (LIFO order)
}
```

Key properties:
- **LIFO execution** — last pushed = first cleaned (matches resource acquisition order)
- **Nesting-safe** — `_save_cleanup_scope` preserves parent function's cleanup list
- **Backward compatible** — single-trap functions work identically to before
- **Zero new shellcheck warnings**

## Testing

All 13 unit tests pass:
1. Single cleanup removes file
2. Multiple cleanups all execute
3. Nested functions don't clobber each other
4. LIFO cleanup order verified
5. Directory cleanup with rm -rf
6. Empty cleanup stack is safe
7. Cleanup after early return

Regression test confirms old pattern leaks file `a` while new pattern cleans both.

## Files Changed

- `shared-constants.sh` — new cleanup stack utilities (+103 lines)
- 28 scripts — migrated from raw `trap ... RETURN` to `push_cleanup` pattern