### PR TITLE
feat(content): add story.md narrative design subagent

### DIFF
--- a/.agents/content.md
+++ b/.agents/content.md
@@ -8,6 +8,7 @@ subagents:
   - platform-personas
   - humanise
   - summarize
+  - story
   - seo-writer
   - meta-creator
   - editor
@@ -45,6 +46,7 @@ subagents:
 | `guidelines.md` | Content standards and style guide |
 | `platform-personas.md` | Platform-specific voice adaptations (LinkedIn, Instagram, YouTube, X, Facebook) |
 | `humanise.md` | Remove AI writing patterns, make text sound human |
+| `story.md` | Narrative design -- hooks, angles, frameworks, emotional architecture |
 | `seo-writer.md` | SEO-optimized content writing with keyword integration |
 | `meta-creator.md` | Generate meta titles and descriptions for SEO |
 | `editor.md` | Transform AI content into human-sounding articles |
@@ -79,13 +81,14 @@ python3 ~/.aidevops/agents/scripts/seo-content-analyzer.py intent "search query"
 ```
 
 **Workflow**:
-1. Plan (`tools/content/content-calendar.md` for gap analysis and scheduling)
+1. Plan (`content/content-calendar.md` for gap analysis and scheduling)
 2. Research (keywords, competitors, audience)
-3. Write (`content/seo-writer.md` with keyword targets)
-4. Analyze (`seo-content-analyzer.py analyze`)
-5. Optimize (address issues from analysis)
-6. Edit (`content/editor.md` for human voice)
-7. Publish (via WordPress or CMS)
+3. Design narrative (`content/story.md` for hooks, angles, and structure)
+4. Write (`content/seo-writer.md` with keyword targets)
+5. Analyze (`seo-content-analyzer.py analyze`)
+6. Optimize (address issues from analysis)
+7. Edit (`content/editor.md` for human voice)
+8. Publish (via WordPress or CMS)
 
 <!-- AI-CONTEXT-END -->
 

--- a/.agents/content/story.md
+++ b/.agents/content/story.md
@@ -1,0 +1,415 @@
+---
+name: story
+description: Narrative design toolkit - story structures, hooks, angles, and emotional frameworks for any content format
+mode: subagent
+model: sonnet
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: false
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Narrative design
+
+<!-- AI-CONTEXT-START -->
+
+## Quick reference
+
+- **Purpose**: Design compelling narratives for any content format
+- **Input**: Topic, audience, goal, format constraints
+- **Output**: Narrative structure with hook, angle, emotional arc, and framework selection
+- **Complements**: `youtube/script-writer.md` (video-specific), `content/seo-writer.md` (SEO-specific), `content/editor.md` (editorial polish)
+
+**When to use**: Before writing. This subagent designs the narrative skeleton that other subagents flesh out. Use it when content needs to persuade, engage, or hold attention -- not just inform.
+
+<!-- AI-CONTEXT-END -->
+
+## When to use this vs other subagents
+
+| Need | Use |
+|------|-----|
+| Narrative structure before writing | **This subagent** |
+| YouTube-specific scripts with timestamps | `youtube/script-writer.md` |
+| SEO-optimized long-form articles | `content/seo-writer.md` |
+| Editorial polish on a draft | `content/editor.md` |
+| Removing AI writing patterns | `content/humanise.md` |
+| Platform-specific voice adaptation | `content/platform-personas.md` |
+
+## Core principle
+
+Every piece of content is a story. Even a product description has a protagonist (the reader), a problem, and a resolution. The difference between content that gets skipped and content that gets shared is narrative structure.
+
+## Hooks
+
+The hook determines whether anyone reads past the first line. Design it first, then build the narrative around it.
+
+### Hook types
+
+| Type | Mechanism | Best for |
+|------|-----------|----------|
+| **Bold claim** | Challenge an assumption | Opinion pieces, thought leadership |
+| **Question** | Open a curiosity gap | Educational content, how-to |
+| **Story drop** | Start mid-action | Case studies, personal narratives |
+| **Contrarian** | Oppose conventional wisdom | Industry commentary, hot takes |
+| **Result first** | Show the outcome, then explain | Tutorials, transformations |
+| **Problem-agitate** | Name a pain, then twist the knife | Sales pages, problem-solution content |
+| **Curiosity gap** | Reveal partial information | Lists, secrets, insider knowledge |
+| **Specificity** | Lead with an unexpected detail | Data-driven content, research |
+| **Tension** | Present two opposing forces | Comparisons, debates, analysis |
+| **Identity** | Speak directly to who the reader is | Community content, niche audiences |
+
+### Hook construction
+
+A strong hook has three components:
+
+1. **Pattern interrupt** -- break the reader's scroll. Say something unexpected, specific, or emotionally charged.
+2. **Promise** -- signal what the reader will gain by continuing. This can be implicit (a question they want answered) or explicit ("here's how").
+3. **Credibility** -- give a reason to trust this content. A specific number, a named source, a personal experience.
+
+Not every hook needs all three overtly, but the best ones have all three working.
+
+### Hook examples by format
+
+**Blog post**:
+> I deleted our highest-traffic page last month. Organic traffic went up 23%.
+
+**LinkedIn post**:
+> 90% of "thought leadership" on this platform is repackaged common sense with a personal photo attached. Here's what actual expertise looks like:
+
+**Email subject line**:
+> The metric you're tracking that's actively hurting your business
+
+**Product description**:
+> This window was designed for a climate that destroys most windows within 10 years.
+
+**Case study**:
+> They had 47 paying customers and were about to shut down. Eighteen months later, they crossed $2M ARR. One decision changed everything.
+
+### Hook testing
+
+Before committing to a hook, test it against these questions:
+
+1. Would I stop scrolling for this?
+2. Does it create a question the reader needs answered?
+3. Is it specific enough to feel real (not generic)?
+4. Does it match the content that follows (no bait-and-switch)?
+5. Could a competitor write the exact same hook? If yes, it's too generic.
+
+## Angles
+
+An angle is your unique perspective on a topic. The same topic can produce dozens of different pieces of content depending on the angle.
+
+### Angle discovery
+
+Ask these questions to find your angle:
+
+1. **What does everyone else say about this?** Your angle is probably the opposite, the exception, or the deeper layer.
+2. **What do I know that most people don't?** First-hand experience, proprietary data, unusual expertise.
+3. **Who is this really for?** Narrowing the audience sharpens the angle. "Marketing tips" is generic. "Marketing tips for solo founders who hate marketing" is an angle.
+4. **What's the uncomfortable truth?** The thing people in the industry know but don't say publicly.
+5. **What changed recently?** New data, new tools, new regulations that invalidate old advice.
+
+### Angle types
+
+| Angle | Description | Example |
+|-------|-------------|---------|
+| **Contrarian** | Opposite of consensus | "Why I stopped A/B testing" |
+| **Insider** | Behind-the-scenes knowledge | "What agencies won't tell you about SEO" |
+| **Data-driven** | Original research or analysis | "We analysed 10,000 landing pages. Here's what converts." |
+| **Personal failure** | Lessons from getting it wrong | "I wasted $50K on ads before learning this" |
+| **Synthesis** | Connect dots others haven't | "What poker strategy teaches about pricing" |
+| **Prediction** | Where things are heading | "3 trends that will kill traditional content marketing by 2027" |
+| **Beginner's mind** | Explain complex things simply | "I tried to understand blockchain. Here's what I actually learned." |
+| **Comparison** | Side-by-side with a verdict | "We ran the same campaign on TikTok and YouTube. The results were not close." |
+| **Process reveal** | Show exactly how something was done | "The exact 7-step process we use to write landing pages" |
+| **Curation** | Filter signal from noise | "I read 200 AI papers this year. These 5 actually matter." |
+
+### Angle validation
+
+A good angle passes these tests:
+
+- **Ownable**: Could only you (or very few people) write this from this perspective?
+- **Specific**: Does it narrow the topic enough to be interesting?
+- **Timely**: Is there a reason to read this now rather than later?
+- **Arguable**: Would a reasonable person disagree? If not, it might be too obvious.
+
+## Narrative frameworks
+
+Choose a framework based on your content goal. These are platform-agnostic -- adapt the pacing and length to your format.
+
+### Before-After-Bridge (BAB)
+
+**Goal**: Persuade. Show transformation.
+
+```text
+BEFORE: Paint the current painful reality
+AFTER:  Show what life looks like with the solution
+BRIDGE: Explain how to get from before to after
+```
+
+**Best for**: Sales pages, product descriptions, case studies, email sequences.
+
+**Example skeleton**:
+> You're spending 3 hours a day on manual deployments. [BEFORE]
+> Imagine pushing code and walking away -- it's live in 90 seconds, tested and monitored. [AFTER]
+> Here's the CI/CD pipeline that makes it happen. [BRIDGE]
+
+### Problem-Agitate-Solve (PAS)
+
+**Goal**: Create urgency. Make the reader feel the problem before offering relief.
+
+```text
+PROBLEM:  Name the specific pain
+AGITATE:  Make it worse -- show consequences, compound effects, what happens if ignored
+SOLVE:    Present the solution with proof
+```
+
+**Best for**: Landing pages, email marketing, ad copy, problem-focused blog posts.
+
+**Example skeleton**:
+> Your site loads in 4.2 seconds. [PROBLEM]
+> Every second costs you 7% in conversions. At your traffic, that's $12K/month in lost revenue. And Google is about to make Core Web Vitals a ranking factor. [AGITATE]
+> Here's a 30-minute performance audit that fixes the top 3 bottlenecks. [SOLVE]
+
+### SCQA (Situation-Complication-Question-Answer)
+
+**Goal**: Structure analytical or explanatory content. Originally from McKinsey's Pyramid Principle.
+
+```text
+SITUATION:     Establish shared context (what everyone agrees on)
+COMPLICATION:  Introduce the tension (what changed, what's wrong, what's at risk)
+QUESTION:      The question the reader now needs answered
+ANSWER:        Your thesis, supported by evidence
+```
+
+**Best for**: Business writing, strategy documents, thought leadership, presentations.
+
+**Example skeleton**:
+> Most SaaS companies use freemium to acquire users. [SITUATION]
+> But conversion rates from free to paid have dropped 40% in 3 years as the market saturated. [COMPLICATION]
+> So how do you build a sustainable acquisition engine without giving away the product? [QUESTION]
+> Reverse trials -- give full access for 14 days, then downgrade. Here's the data. [ANSWER]
+
+### Hero's Journey (simplified)
+
+**Goal**: Tell a transformation story. The reader or subject is the hero.
+
+```text
+ORDINARY WORLD:  Where the hero starts (relatable status quo)
+CALL:            The challenge or opportunity that disrupts the status quo
+TRIALS:          What was tried, what failed, what was learned
+TRANSFORMATION:  The breakthrough -- what changed and why
+RETURN:          What the hero knows now that they didn't before (and how the reader benefits)
+```
+
+**Best for**: Personal narratives, brand stories, case studies, keynote talks, documentary-style content.
+
+### Inverted Pyramid
+
+**Goal**: Deliver the most important information first. Let readers leave at any point having got the key message.
+
+```text
+LEAD:     The single most important fact or conclusion
+CONTEXT:  Supporting details and evidence
+BACKGROUND: Nice-to-know information for those who keep reading
+```
+
+**Best for**: News, announcements, executive summaries, email newsletters, social posts.
+
+### Nested Loops
+
+**Goal**: Maintain attention across long-form content by opening multiple story threads.
+
+```text
+OPEN LOOP 1:  Start a story, leave it unresolved
+OPEN LOOP 2:  Start a second story or question
+RESOLVE LOOP 2: Close the inner story
+RESOLVE LOOP 1: Return to and close the outer story
+```
+
+**Best for**: Podcasts, long-form video, keynotes, serialised content, email sequences.
+
+**Why it works**: The brain craves closure. An unresolved loop creates tension that keeps the audience engaged until it's resolved. Opening a new loop before closing the first compounds this effect.
+
+### Comparison Framework
+
+**Goal**: Help the reader make a decision by structuring a fair evaluation.
+
+```text
+CONTEXT:   Why this comparison matters now
+CRITERIA:  What dimensions matter (and why these, not others)
+ANALYSIS:  Side-by-side evaluation on each criterion
+VERDICT:   Clear recommendation with reasoning
+CAVEATS:   When the other option is actually better
+```
+
+**Best for**: Product comparisons, tool reviews, strategy evaluations, "X vs Y" content.
+
+## Emotional architecture
+
+Narrative structure is the skeleton. Emotional architecture is the nervous system -- it determines what the reader *feels* at each point.
+
+### Emotional arc design
+
+Map the intended emotion at each stage of your content:
+
+| Stage | Target emotion | Technique |
+|-------|---------------|-----------|
+| Hook | Curiosity or surprise | Unexpected claim, open question, tension |
+| Context | Recognition ("that's me") | Describe the reader's situation accurately |
+| Tension | Discomfort or urgency | Show consequences, raise stakes |
+| Insight | Relief or excitement | Deliver the "aha" moment |
+| Proof | Trust | Data, examples, social proof |
+| Close | Motivation or clarity | Clear next step, empowering conclusion |
+
+### Tension and release
+
+The fundamental rhythm of engaging content is tension followed by release. Tension without release is frustrating. Release without tension is boring.
+
+**Ways to create tension**:
+
+- Open a question and delay the answer
+- Present a problem and let it sit before solving it
+- Introduce conflict between two ideas
+- Show what's at stake if the reader does nothing
+- Reveal information that contradicts expectations
+
+**Ways to release tension**:
+
+- Answer the question
+- Deliver the solution
+- Resolve the conflict with a clear position
+- Provide the "how" after establishing the "why"
+- Confirm the reader's instinct with evidence
+
+### Pacing
+
+Vary the rhythm to maintain attention:
+
+- **Short sentences create urgency.** They punch.
+- Longer sentences allow the reader to settle into a thought, absorb a more complex idea, and feel the weight of what you're saying before you move on.
+- **Alternate between the two.**
+- After a dense section, give the reader a breather -- a one-line paragraph, a question, a concrete example.
+
+## Pattern interrupts
+
+Attention decays. In any format longer than a few sentences, you need pattern interrupts to reset the reader's engagement.
+
+| Interrupt type | How it works | Example |
+|---------------|-------------|---------|
+| **Direct address** | Speak to the reader | "Now, you might be thinking..." |
+| **Pivot** | Reverse direction | "But here's what nobody mentions..." |
+| **Story** | Drop into a micro-narrative | "Last Tuesday, I got an email that changed how I think about this." |
+| **Question** | Re-engage with curiosity | "So why does this keep happening?" |
+| **Data point** | Anchor with specificity | "The number is 73%. Not what you'd expect." |
+| **Format shift** | Change the visual pattern | Switch from prose to a list, quote, or example |
+| **Tease** | Promise something ahead | "The third reason is the one that matters most." |
+
+**Frequency**: Every 200-300 words in written content. Every 2-3 minutes in video/audio. Adjust based on format and audience attention span.
+
+## Workflow
+
+### Step 1: Define the brief
+
+Before designing the narrative, establish:
+
+- **Topic**: What is this about?
+- **Audience**: Who is reading/watching? What do they already know?
+- **Goal**: What should the reader think, feel, or do after consuming this?
+- **Format**: Blog, video, social post, email, landing page, presentation?
+- **Constraints**: Word count, tone requirements, brand guidelines?
+
+### Step 2: Choose your angle
+
+Use the angle discovery questions above. Pick the angle that is most ownable and timely.
+
+### Step 3: Design the hook
+
+Write 3-5 hook variations using different hook types. Test each against the hook testing questions. Pick the strongest.
+
+### Step 4: Select a framework
+
+Match the framework to your goal:
+
+| Goal | Framework |
+|------|-----------|
+| Persuade / sell | BAB or PAS |
+| Explain / analyse | SCQA or Inverted Pyramid |
+| Tell a story | Hero's Journey or Nested Loops |
+| Compare options | Comparison Framework |
+| Educate step-by-step | Problem-Solution-Result (see `youtube/script-writer.md`) |
+| Entertain / retain | Nested Loops with pattern interrupts |
+
+### Step 5: Map the emotional arc
+
+For each section of your chosen framework, note the target emotion and the technique you'll use to evoke it.
+
+### Step 6: Outline with interrupts
+
+Write the section-level outline. Mark where pattern interrupts will go. Ensure no section runs longer than 300 words without a reset.
+
+### Step 7: Hand off to a writing subagent
+
+Pass the completed narrative design to the appropriate writing subagent:
+
+- `content/seo-writer.md` for blog posts and articles
+- `youtube/script-writer.md` for video scripts
+- `content/platform-personas.md` for social media
+- `content/editor.md` for editorial review of the draft
+
+## Output format
+
+When designing a narrative, deliver:
+
+```markdown
+## Narrative design: [Topic]
+
+**Audience**: [Who]
+**Goal**: [What they should think/feel/do]
+**Format**: [Blog / video / email / etc.]
+
+### Angle
+
+[1-2 sentences describing the unique perspective]
+
+### Hook
+
+[The hook text]
+Type: [hook type from table above]
+
+### Framework
+
+[Framework name]
+
+### Outline
+
+1. [Section] -- [target emotion] -- [technique]
+2. [Section] -- [target emotion] -- [technique]
+   [INTERRUPT: type]
+3. [Section] -- [target emotion] -- [technique]
+...
+
+### Key tension points
+
+- [Where tension builds]
+- [Where it releases]
+
+### Notes for writer
+
+- [Anything the writing subagent needs to know]
+- [Specific examples, data points, or stories to include]
+```
+
+## Related
+
+- `content/guidelines.md` -- Voice, tone, and formatting standards
+- `content/humanise.md` -- Remove AI writing patterns from the final output
+- `content/editor.md` -- Editorial review and humanity scoring
+- `content/seo-writer.md` -- SEO-optimized article writing
+- `content/platform-personas.md` -- Platform-specific voice adaptation
+- `youtube/script-writer.md` -- Video-specific narrative (hooks, retention, timestamps)


### PR DESCRIPTION
## Summary

- Adds content/story.md -- a cross-platform narrative design toolkit for designing compelling content structures before writing
- Covers hooks (10 types with construction guide and testing criteria), angles (10 types with discovery and validation), 7 narrative frameworks (BAB, PAS, SCQA, Hero Journey, Inverted Pyramid, Nested Loops, Comparison), emotional architecture, and pattern interrupts
- Updates content.md to register the new subagent and insert narrative design as step 3 in the content workflow

## Design decisions

- Complements youtube/script-writer.md without duplicating it -- story.md is platform-agnostic, script-writer.md is YouTube-specific with timestamps and retention curves
- Positioned as a pre-writing tool: design the narrative skeleton, then hand off to seo-writer.md, script-writer.md, or platform-personas.md for format-specific execution
- Follows existing subagent conventions: YAML frontmatter, AI-CONTEXT markers, sentence-case headings, Related section with cross-references

## Task

Closes t199.2