### PR TITLE
perf: enable Anthropic prompt caching in setup

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -430,6 +430,28 @@ if model_count > 0:
     print(f"  Model routing: {model_count} agents have model tier assignments")
 
 # =============================================================================
+# PROVIDER OPTIONS - Prompt caching and performance
+# =============================================================================
+# Enable prompt caching for Anthropic models (setCacheKey: true)
+# This caches the system prompt prefix (AGENTS.md + build.txt + tool definitions)
+# across requests, reducing input token costs by ~90% on cache hits.
+# Cache auto-invalidates when file content changes (content-based hashing).
+# Works on all Anthropic models (min 1024-4096 tokens depending on model).
+# See: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+
+if 'provider' not in config:
+    config['provider'] = {}
+
+if 'anthropic' not in config['provider']:
+    config['provider']['anthropic'] = {}
+
+if 'options' not in config['provider']['anthropic']:
+    config['provider']['anthropic']['options'] = {}
+
+config['provider']['anthropic']['options']['setCacheKey'] = True
+print("  Enabled prompt caching for Anthropic (setCacheKey: true)")
+
+# =============================================================================
 # MCP SERVERS - Ensure required MCP servers are configured
 # =============================================================================
 # Loading strategy:


### PR DESCRIPTION
## Summary

- Enables Anthropic prompt caching (`setCacheKey: true`) in the OpenCode config generator
- Caches the system prompt prefix (AGENTS.md + build.txt + tool definitions, ~8-10K tokens) across API requests
- Reduces input token costs by ~90% on cache hits (0.1x vs 1x base input price)

## How it works

- OpenCode's AI SDK sets `cache_control` breakpoints on the system prompt when `setCacheKey: true`
- Anthropic caches the prefix with a 5-minute TTL (auto-refreshed on use)
- Cache auto-invalidates when file content changes (content-based hashing)
- Works on all Anthropic models (min 1024-4096 tokens depending on model)
- No manual invalidation needed -- `aidevops update` / `setup.sh` naturally refreshes on next session

## Changes

- `.agents/scripts/generate-opencode-agents.sh`: Added PROVIDER OPTIONS section that sets `setCacheKey: true` for Anthropic
- Also applied to live config (`~/.config/opencode/opencode.json`) for immediate effect

## Cost impact

Over a 50-message session, ~85% savings on input tokens for the instruction prefix (~8-10K tokens cached).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled prompt caching for Anthropic models to improve response performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->