### PR TITLE
fix: sync homebrew formula version and enable subtask GitHub Issues

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -738,8 +738,8 @@ commit_version_changes() {
     
     print_info "Committing version changes..."
     
-    # Stage all version-related files (including CHANGELOG.md, TODO.md, and Claude plugin)
-    git add VERSION package.json README.md setup.sh aidevops.sh sonar-project.properties CHANGELOG.md TODO.md .claude-plugin/marketplace.json 2>/dev/null
+    # Stage all version-related files (including CHANGELOG.md, TODO.md, Homebrew formula, and Claude plugin)
+    git add VERSION package.json README.md setup.sh aidevops.sh sonar-project.properties CHANGELOG.md TODO.md homebrew/aidevops.rb .claude-plugin/marketplace.json 2>/dev/null
     
     # Check if there are changes to commit
     if git diff --cached --quiet; then

--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -5,7 +5,7 @@
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"
   homepage "https://aidevops.sh"
-  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v2.107.0.tar.gz"
+  url "https://github.com/marcusquinn/aidevops/archive/refs/tags/v2.108.0.tar.gz"
   sha256 "e72f395b3a58b2739deccb782efb9010653897f84b8882c54b8ae6a4e882d58c"
   license "MIT"
   head "https://github.com/marcusquinn/aidevops.git", branch: "main"


### PR DESCRIPTION
## Summary

- Fix homebrew formula version drift that was failing CI on **all open PRs** (v2.107.0 → v2.108.0)
- Enable GitHub Issue creation for subtasks (t199.1-t199.11 etc.) in issue-sync-helper.sh
- Prevent future homebrew drift by adding `homebrew/aidevops.rb` to version-manager.sh commit step

## Root Causes

### 1. Homebrew Version Drift (blocking all PRs)
`version-manager.sh` `commit_version_changes()` staged all version files **except** `homebrew/aidevops.rb`. The `update_version_in_files()` function correctly updated the formula, but the commit step never staged it. Every release left the formula one version behind on `origin/main`, causing the Version Consistency Check to fail on every PR.

### 2. Subtasks Not Getting GitHub Issues
`issue-sync-helper.sh` `cmd_push()` explicitly skipped indented subtask lines (`^- \[` only matches unindented). All 11 subtasks of t199 (t199.1-t199.11) had no GitHub Issues. The same `^-` pattern was used across `cmd_push`, `cmd_pull`, `cmd_close`, `cmd_enrich`, `cmd_status`, `cmd_reconcile`, `add_gh_ref_to_todo`, and `fix_gh_ref_in_todo`.

## Changes

| File | Change |
|------|--------|
| `version-manager.sh` | Add `homebrew/aidevops.rb` to `git add` in `commit_version_changes()` |
| `homebrew/aidevops.rb` | Update URL from v2.107.0 to v2.108.0 |
| `issue-sync-helper.sh` | Change all `^-` grep/sed patterns to `^\s*-` across 8 functions |

## Verification

- ShellCheck: zero new violations
- Syntax check: both scripts pass `bash -n`
- The homebrew fix will make Version Consistency Check pass, unblocking PRs #835, #834, #842, #840, #845