### PR TITLE
feat: multi-channel content fan-out orchestration (t206)

### DIFF
--- a/.agents/content.md
+++ b/.agents/content.md
@@ -138,6 +138,55 @@ subagents:
 
 <!-- AI-CONTEXT-END -->
 
+## Fan-Out Orchestration (t206)
+
+The `content-fanout-helper.sh` script automates the diamond pipeline from brief to channel-specific outputs.
+
+**Quick start**:
+
+```bash
+# 1. Generate a story brief template
+content-fanout-helper.sh template default
+
+# 2. Edit the brief with your topic, audience, and channels
+# 3. Generate a fan-out plan
+content-fanout-helper.sh plan ~/my-story-brief.md
+
+# 4. Execute the plan (generates channel-specific prompts)
+content-fanout-helper.sh run <plan-file>
+
+# 5. Process each channel's prompt with AI
+# Each channel directory contains a prompt.md ready for AI processing
+```
+
+**Commands**:
+
+| Command | Purpose |
+|---------|---------|
+| `plan <brief>` | Generate fan-out plan from story brief |
+| `run <plan>` | Execute plan, create channel-specific prompts |
+| `channels` | List available distribution channels (8 channels) |
+| `formats` | List media formats and channel requirements |
+| `status <plan>` | Show progress of a fan-out run |
+| `template [type]` | Generate brief template (default, video, blog, social) |
+| `estimate <brief>` | Estimate time and token cost |
+
+**Available channels**: youtube, short-form, social-x, social-linkedin, social-reddit, blog, email, podcast
+
+**Brief format** (simple key: value):
+
+```text
+topic: Why 95% of AI influencers fail
+angle: contrarian
+audience: aspiring AI content creators
+channels: youtube, short-form, social-x, social-linkedin, blog, email
+tone: direct, data-backed, slightly provocative
+cta: Subscribe for weekly AI creator breakdowns
+notes: Include specific failure stats, name no names
+```
+
+**Pipeline flow**: Brief -> Plan -> Run -> AI Processing -> 10+ Outputs
+
 ## The Multi-Media Multiplier
 
 The core insight: **one story → 10+ outputs**.

--- a/.agents/content/production/writing.md
+++ b/.agents/content/production/writing.md
@@ -1,0 +1,287 @@
+---
+name: writing
+description: Scripts, copy, captions, and text content production across all formats
+mode: subagent
+model: sonnet
+---
+
+# Writing - Multi-Format Text Production
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Transform story packages into platform-ready scripts, copy, and text content
+- **Input**: Story package (from `content/story.md`) or direct brief
+- **Output**: Long-form scripts, short-form scripts, social copy, blog drafts, email copy, captions
+- **Key Principle**: Same narrative, different delivery -- adapt voice, length, and structure per format
+
+**Critical Rules**:
+
+- **Hook-first in every format** -- First line/sentence/second must hook
+- **8-second dialogue chunks** for AI video -- Longer blocks cause unnatural pacing
+- **Platform-native voice** -- No cross-posting smell (each platform has distinct expectations)
+- **One CTA per piece** -- Clarity beats comprehensiveness
+- **Scene-by-scene for video** -- Include B-roll directions, not just dialogue
+
+<!-- AI-CONTEXT-END -->
+
+## Output Formats
+
+### Long-Form Script (YouTube, Podcast)
+
+Target: 8-15 minutes (1,200-2,200 words spoken)
+
+**Structure**:
+
+```text
+# [Title]
+
+## HOOK (0:00-0:15)
+[Opening line — pattern interrupt or bold claim]
+[Visual: B-roll description or camera direction]
+
+## SCENE 1: [Setup] (0:15-2:00)
+[Narration — 8-second chunks max]
+[Visual: B-roll / screen recording / graphic]
+[Transition: bridge sentence to next scene]
+
+## SCENE 2: [Problem/Story] (2:00-5:00)
+[Narration]
+[Visual: ...]
+
+## SCENE 3: [Solution/Insight] (5:00-8:00)
+[Narration]
+[Visual: ...]
+
+## SCENE 4: [Proof/Examples] (8:00-10:00)
+[Narration]
+[Visual: ...]
+
+## CTA (10:00-10:30)
+[Soft sell — natural transition from content]
+[Visual: end screen, subscribe animation]
+
+## END SCREEN (10:30-11:00)
+[Suggested video tease]
+```
+
+**Rules**:
+
+- Every scene has narration + visual direction
+- B-roll directions are specific ("show screen recording of tool X dashboard", not "show relevant footage")
+- Dialogue pacing: 8-second maximum chunks for AI voice generation
+- Include timestamp estimates for each scene
+- Mark emotional beats: [PAUSE], [EMPHASIS], [LOWER VOICE]
+
+### Short-Form Script (TikTok, Reels, Shorts)
+
+Target: 30-60 seconds (75-150 words spoken)
+
+**Structure**:
+
+```text
+# [Hook — first 1-3 seconds]
+
+[Setup — 5 seconds]
+[Payoff — 10-15 seconds]
+[Twist or reinforcement — 5 seconds]
+[CTA — 3 seconds]
+
+CAPTION: [Full text for silent viewers]
+SOUND: [Mood/genre suggestion]
+CUTS: [Cut timing — e.g., "cut every 1.5s"]
+```
+
+**Rules**:
+
+- Hook must work in first 1-3 seconds (before scroll)
+- Fast cuts: 1-3 seconds per shot
+- Captions are mandatory (80%+ watch without sound)
+- Single idea only -- no tangents
+- End with loop potential (last frame connects to first)
+
+### Social Copy
+
+#### X (Twitter)
+
+**Thread format**:
+
+```text
+POST 1 (HOOK): [Under 280 chars, standalone value]
+POST 2: [Expand on the hook]
+POST 3-7: [One point per post, each standalone]
+POST 8 (CTA): [Soft ask — follow, bookmark, reply]
+```
+
+**Single post**: Under 280 chars. Front-load value. Personality-forward.
+
+#### LinkedIn
+
+**Post format**:
+
+```text
+[Hook line — bold or surprising]
+
+[2-3 short paragraphs — insight, story, or data]
+
+[Key takeaway — one sentence]
+
+[CTA — question or invitation to discuss]
+
+#hashtag1 #hashtag2 #hashtag3
+```
+
+Target: 1,200-1,500 characters. Professional but not corporate.
+
+#### Reddit
+
+**Post format**:
+
+```text
+Title: [Curiosity-driven, not clickbait]
+
+Body:
+[Context — why you're posting, what you found]
+[Value — the insight, data, or resource]
+[Discussion prompt — genuine question for the community]
+```
+
+Rules: No self-promotion. Value-first. Community-native tone.
+
+### Blog Draft
+
+**Structure**:
+
+```text
+# [H1 — Target keyword, under 60 chars]
+
+[Intro paragraph — hook + promise + what they'll learn]
+
+## [H2 — Section 1]
+[Content — 200-400 words]
+
+## [H2 — Section 2]
+[Content — 200-400 words]
+
+### [H3 — Subsection if needed]
+[Content]
+
+## [H2 — Section 3]
+[Content]
+
+## Key Takeaways
+- [Bullet 1]
+- [Bullet 2]
+- [Bullet 3]
+
+## [CTA Section]
+[Natural transition to offer/next step]
+```
+
+**SEO rules**:
+
+- Target keyword in H1, first paragraph, and 1-2 H2s
+- 1,500-2,500 words for comprehensive coverage
+- Internal links: 3-5 to related content
+- Meta title: under 60 chars, keyword-front-loaded
+- Meta description: under 155 chars, includes CTA
+
+### Email Copy
+
+**Newsletter format**:
+
+```text
+SUBJECT: [5 variants for A/B testing]
+PREVIEW: [Under 90 chars — extends the subject line]
+
+[Opening hook — personal, story-driven]
+
+[Body — single narrative thread, 300-500 words]
+
+[CTA — one clear action, button or link]
+
+P.S. [Secondary hook or bonus value]
+```
+
+**Sequence email format**:
+
+```text
+EMAIL 1 (Day 0): Welcome + immediate value
+EMAIL 2 (Day 1): Story + pain point
+EMAIL 3 (Day 3): Solution + social proof
+EMAIL 4 (Day 5): Offer + urgency
+EMAIL 5 (Day 7): Last chance + FAQ
+```
+
+### Podcast Script
+
+**Talking points format**:
+
+```text
+# Episode: [Title]
+
+## INTRO (0:00-1:00)
+- [Hook — why this matters today]
+- [What they'll learn]
+- [Sponsor read if applicable]
+
+## SEGMENT 1: [Topic] (1:00-5:00)
+- [Talking point 1]
+- [Talking point 2]
+- [Anecdote or example]
+
+## SEGMENT 2: [Topic] (5:00-10:00)
+- [Talking point 1]
+- [Talking point 2]
+
+## SEGMENT 3: [Topic] (10:00-15:00)
+- [Talking point 1]
+- [Key insight]
+
+## OUTRO (15:00-16:00)
+- [Summary — one sentence]
+- [CTA — subscribe, review, share]
+- [Next episode tease]
+
+## SHOW NOTES
+- [Timestamps]
+- [Links mentioned]
+- [Resources]
+```
+
+## Voice and Tone Adaptation
+
+| Platform | Voice | Pacing | Formality |
+|----------|-------|--------|-----------|
+| YouTube | Conversational, energetic | Medium (150 wpm) | Low-medium |
+| Short-form | Punchy, direct | Fast (170 wpm) | Low |
+| X | Sharp, opinionated | Rapid | Low |
+| LinkedIn | Thoughtful, professional | Measured | Medium-high |
+| Reddit | Authentic, helpful | Natural | Low |
+| Blog | Authoritative, clear | Steady | Medium |
+| Email | Personal, direct | Conversational | Low-medium |
+| Podcast | Warm, storytelling | Natural (140 wpm) | Low |
+
+## Quality Checklist
+
+Before delivering any written output:
+
+- [ ] Hook is in the first line/sentence
+- [ ] Voice matches platform expectations
+- [ ] CTA is clear and singular
+- [ ] No cross-posting smell (platform-native language)
+- [ ] Dialogue chunks are under 8 seconds (for video)
+- [ ] Captions included (for video/short-form)
+- [ ] SEO elements present (for blog)
+- [ ] Subject line variants included (for email)
+- [ ] B-roll directions included (for video scripts)
+
+## Related
+
+- `content/story.md` -- Provides the narrative framework and hook variants
+- `content/production/image.md` -- Visual assets referenced in scripts
+- `content/production/video.md` -- Video production specs for script adaptation
+- `content/production/audio.md` -- Voice pipeline for script delivery
+- `content/distribution/` -- Channel-specific conventions for final adaptation
+- `content.md` -- Parent orchestrator (diamond pipeline)

--- a/.agents/content/story.md
+++ b/.agents/content/story.md
@@ -1,0 +1,169 @@
+---
+name: story
+description: Narrative design, hooks, angles, and frameworks for platform-agnostic storytelling
+mode: subagent
+model: sonnet
+---
+
+# Story - Narrative Design and Hook Engineering
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Craft platform-agnostic narratives that adapt to any media format or distribution channel
+- **Input**: Research brief (from `content/research.md`) or topic + audience
+- **Output**: Story package: hook variants, narrative arc, transformation framework, angle selection
+- **Key Principle**: One story, many outputs -- design the narrative once, adapt everywhere
+
+**Critical Rules**:
+
+- **Hook-first always** -- Every output starts with the hook, regardless of platform
+- **6-12 word constraint** on hooks -- Forces clarity and punch
+- **Proven first, original second** -- 97% proven structure, 3% unique twist
+- **One transformation per story** -- Before state -> struggle -> after state
+- **Test 5-10 hook variants** before committing to any single angle
+
+<!-- AI-CONTEXT-END -->
+
+## 7 Hook Formulas
+
+Every piece of content starts with a hook. Use these formulas to generate variants:
+
+| # | Formula | Example | Best For |
+|---|---------|---------|----------|
+| 1 | **Bold Claim** | "95% of AI influencers will fail this year" | YouTube, blog, LinkedIn |
+| 2 | **Question** | "Why do most AI creators quit in 6 months?" | Social, email, podcast |
+| 3 | **Story** | "I spent $10K on AI tools and here's what happened" | YouTube, podcast, blog |
+| 4 | **Contrarian** | "The AI tool everyone recommends is actually terrible" | X, Reddit, short-form |
+| 5 | **Result** | "How I got 1M views using only free AI tools" | YouTube, short-form, social |
+| 6 | **Problem-Agitate** | "You're wasting 4 hours/day on content that nobody sees" | Email, LinkedIn, blog |
+| 7 | **Curiosity Gap** | "The one AI trick that changed everything (it's not what you think)" | Short-form, X, email |
+
+**Hook generation process**:
+
+1. Write 10 variants using different formulas
+2. Score each on: specificity (1-5), emotion (1-5), curiosity (1-5)
+3. Pick top 3 for A/B testing
+4. Use the winner, archive the rest for future repurposing
+
+## 4-Part Script Framework
+
+Universal structure that works across all formats:
+
+### 1. Hook (first 5-10 seconds / first sentence)
+
+- Pattern interrupt or immediate value promise
+- Use one of the 7 hook formulas
+- Must work standalone (visible in previews, thumbnails, subject lines)
+
+### 2. Storytelling (60-70% of content)
+
+- **Before state**: Where the audience is now (pain, frustration, confusion)
+- **Struggle**: The journey, failed attempts, common mistakes
+- **After state**: The transformation, result, insight
+
+Frameworks for the storytelling section:
+
+- **AIDA**: Attention -> Interest -> Desire -> Action
+- **Three-Act**: Setup -> Confrontation -> Resolution
+- **Hero's Journey**: Ordinary world -> Call to adventure -> Return with knowledge
+- **Problem-Solution-Result**: Pain -> Method -> Proof
+- **Listicle with Stakes**: "5 mistakes that cost creators $10K+"
+
+### 3. Soft Sell (15-20% of content)
+
+- Transition naturally from story to offer/CTA
+- Frame as logical next step, not sales pitch
+- Use social proof or scarcity only if genuine
+
+### 4. Visual Cues (embedded throughout)
+
+- B-roll directions for video
+- Image suggestions for blog/social
+- Tone shifts for audio/podcast
+- Formatting cues for text (bold, line breaks, emoji sparingly)
+
+## Angle Selection
+
+Choose the story angle based on audience state and platform:
+
+| Angle | When to Use | Platforms |
+|-------|-------------|-----------|
+| **Pain** | Audience is frustrated, searching for solutions | Blog, email, YouTube |
+| **Aspiration** | Audience wants to level up, inspired by results | Short-form, social, YouTube |
+| **Contrarian** | Audience follows conventional wisdom that's wrong | X, Reddit, podcast |
+| **Educational** | Audience needs to learn a skill or concept | Blog, YouTube, podcast |
+| **Hot take** | Audience is engaged in a trending conversation | X, short-form, Reddit |
+| **Behind the scenes** | Audience wants authenticity and process | YouTube, podcast, social |
+
+## Campaign Audit Process
+
+Before publishing, validate the story package with this 7-step audit:
+
+1. **Offer clarity** -- Can you explain the value in one sentence?
+2. **Urgency** -- Is there a reason to act now (not manufactured)?
+3. **Pain angle** -- Does it address a real, specific pain point?
+4. **Cosmetic vs life-changing** -- Is this a nice-to-have or a must-have?
+5. **Hook + visual alignment** -- Does the hook match the thumbnail/preview?
+6. **4 elements present** -- Hook, story, soft sell, visual cues all included?
+7. **Test readiness** -- Are there 3+ variants ready for A/B testing?
+
+## Pattern Interrupt Principle
+
+Hooks work by breaking the audience's scroll pattern. Three techniques:
+
+1. **Contrast** -- Juxtapose unexpected elements ("The $0 tool that beats $500/month software")
+2. **Extremes** -- Use specific, surprising numbers ("I analyzed 10,000 AI videos and found this")
+3. **Unexpected combinations** -- Pair unrelated concepts ("What chess taught me about AI prompting")
+
+## Story Package Output Format
+
+When generating a story package, produce:
+
+```text
+# Story Package: [Topic]
+
+## Hook Variants (scored)
+1. [Hook] — Formula: [name] — Score: specificity/emotion/curiosity = total
+2. ...
+(minimum 5 variants)
+
+## Narrative Arc
+- Before state: [audience's current pain]
+- Struggle: [common mistakes, failed approaches]
+- Transformation: [the insight/method/result]
+- After state: [where they'll be after consuming this content]
+
+## Angle
+- Primary: [angle name]
+- Rationale: [why this angle for this audience]
+
+## Script Skeleton (4-Part)
+### Hook
+[Winning hook variant]
+
+### Story
+[Scene-by-scene or section-by-section outline]
+
+### Soft Sell
+[CTA framing]
+
+### Visual Cues
+[B-roll / image / formatting directions]
+
+## Platform Adaptation Notes
+- YouTube: [specific adaptations]
+- Short-form: [specific adaptations]
+- Social: [specific adaptations]
+- Blog: [specific adaptations]
+- Email: [specific adaptations]
+- Podcast: [specific adaptations]
+```
+
+## Related
+
+- `content/research.md` -- Feeds into story design (audience data, pain points)
+- `content/production/writing.md` -- Expands story into full scripts and copy
+- `content/optimization.md` -- A/B tests hook variants and story angles
+- `content.md` -- Parent orchestrator (diamond pipeline)

--- a/.agents/scripts/content-fanout-helper.sh
+++ b/.agents/scripts/content-fanout-helper.sh
@@ -1,0 +1,825 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2155
+set -euo pipefail
+
+# Content Fan-Out Helper Script
+# Orchestrates the diamond pipeline: one story -> 10+ outputs across media and channels.
+#
+# Usage: ./content-fanout-helper.sh [command] [args] [options]
+# Commands:
+#   plan <brief-file>           - Generate a fan-out plan from a story brief
+#   run <plan-file>             - Execute a fan-out plan (generates all outputs)
+#   channels                    - List available distribution channels
+#   formats                     - List available media formats
+#   status <plan-file>          - Show progress of a fan-out run
+#   template [type]             - Generate a story brief template (default|video|blog|social)
+#   estimate <brief-file>       - Estimate time and token cost for a fan-out
+#   help                        - Show this help message
+#
+# The fan-out pipeline:
+#   1. Parse story brief (topic, angle, audience, channels)
+#   2. Generate channel-specific output specs
+#   3. Produce outputs per channel (scripts, copy, metadata)
+#   4. Write all outputs to a structured directory
+#
+# Author: AI DevOps Framework
+# Version: 1.0.0
+# License: MIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+# Constants
+readonly FANOUT_VERSION="1.0.0"
+readonly WORKSPACE_DIR="${HOME}/.aidevops/.agent-workspace/work/content-fanout"
+readonly TEMPLATES_DIR="${WORKSPACE_DIR}/templates"
+readonly PLANS_DIR="${WORKSPACE_DIR}/plans"
+readonly OUTPUTS_DIR="${WORKSPACE_DIR}/outputs"
+
+# All available channels (space-separated for iteration)
+readonly ALL_CHANNELS="blog email podcast short-form social-linkedin social-reddit social-x youtube"
+
+# ─── Channel/format lookup functions (bash 3.2 compatible) ───────────
+
+# Get subagent path for a channel
+channel_subagent() {
+    local ch="$1"
+    case "$ch" in
+        youtube)        echo "distribution/youtube" ;;
+        short-form)     echo "distribution/short-form" ;;
+        social-x)       echo "distribution/social" ;;
+        social-linkedin) echo "distribution/social" ;;
+        social-reddit)  echo "distribution/social" ;;
+        blog)           echo "distribution/blog" ;;
+        email)          echo "distribution/email" ;;
+        podcast)        echo "distribution/podcast" ;;
+        *) return 1 ;;
+    esac
+    return 0
+}
+
+# Get required formats for a channel
+channel_formats() {
+    local ch="$1"
+    case "$ch" in
+        youtube)        echo "script,image,video,audio" ;;
+        short-form)     echo "script,video,audio" ;;
+        social-x)       echo "script,image" ;;
+        social-linkedin) echo "script,image" ;;
+        social-reddit)  echo "script" ;;
+        blog)           echo "script,image" ;;
+        email)          echo "script,image" ;;
+        podcast)        echo "script,audio" ;;
+        *) return 1 ;;
+    esac
+    return 0
+}
+
+# Get output descriptions for a channel
+channel_outputs() {
+    local ch="$1"
+    case "$ch" in
+        youtube)        echo "Long-form script, thumbnail brief, description, tags, end screen CTA" ;;
+        short-form)     echo "60s vertical script (TikTok/Reels/Shorts), caption, trending sound note" ;;
+        social-x)       echo "Thread (3-10 posts) or single post, hook-first" ;;
+        social-linkedin) echo "Thought leadership post, professional framing" ;;
+        social-reddit)  echo "Community-native post, value-first, anti-promotional" ;;
+        blog)           echo "SEO-optimized article outline, meta title/description, internal link suggestions" ;;
+        email)          echo "Newsletter edition, subject line variants, preview text, CTA" ;;
+        podcast)        echo "Show notes, episode script/talking points, intro/outro" ;;
+        *) return 1 ;;
+    esac
+    return 0
+}
+
+# Get production subagent for a format
+format_subagent() {
+    local fmt="$1"
+    case "$fmt" in
+        script)    echo "production/writing" ;;
+        image)     echo "production/image" ;;
+        video)     echo "production/video" ;;
+        audio)     echo "production/audio" ;;
+        character) echo "production/characters" ;;
+        *) return 1 ;;
+    esac
+    return 0
+}
+
+# Check if a channel is valid
+is_valid_channel() {
+    local ch="$1"
+    channel_subagent "$ch" >/dev/null 2>&1
+    return $?
+}
+
+# ─── Utility functions ────────────────────────────────────────────────
+
+ensure_dirs() {
+    mkdir -p "${TEMPLATES_DIR}" "${PLANS_DIR}" "${OUTPUTS_DIR}"
+    return 0
+}
+
+timestamp() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+    return 0
+}
+
+slug() {
+    local input="$1"
+    echo "$input" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//' | sed 's/-$//'
+    return 0
+}
+
+# Parse a story brief YAML-like file into variables
+# Brief format:
+#   topic: Why 95% of AI influencers fail
+#   angle: contrarian
+#   audience: aspiring AI content creators
+#   channels: youtube, short-form, social-x, blog, email
+#   tone: direct, data-backed, slightly provocative
+#   cta: Subscribe for weekly AI creator breakdowns
+#   notes: Include specific failure stats, name no names
+parse_brief() {
+    local brief_file="$1"
+
+    if [[ ! -f "$brief_file" ]]; then
+        print_error "Brief file not found: $brief_file"
+        return 1
+    fi
+
+    # Extract fields (simple key: value parsing)
+    BRIEF_TOPIC=$(grep -i '^topic:' "$brief_file" | sed 's/^[^:]*: *//' | head -1)
+    BRIEF_ANGLE=$(grep -i '^angle:' "$brief_file" | sed 's/^[^:]*: *//' | head -1)
+    BRIEF_AUDIENCE=$(grep -i '^audience:' "$brief_file" | sed 's/^[^:]*: *//' | head -1)
+    BRIEF_CHANNELS=$(grep -i '^channels:' "$brief_file" | sed 's/^[^:]*: *//' | head -1)
+    BRIEF_TONE=$(grep -i '^tone:' "$brief_file" | sed 's/^[^:]*: *//' | head -1)
+    BRIEF_CTA=$(grep -i '^cta:' "$brief_file" | sed 's/^[^:]*: *//' | head -1)
+    BRIEF_NOTES=$(grep -i '^notes:' "$brief_file" | sed 's/^[^:]*: *//' | head -1)
+
+    # Defaults
+    BRIEF_ANGLE="${BRIEF_ANGLE:-contrarian}"
+    BRIEF_TONE="${BRIEF_TONE:-direct, conversational}"
+    BRIEF_CHANNELS="${BRIEF_CHANNELS:-youtube,short-form,social-x,social-linkedin,blog,email}"
+
+    # Validate required fields
+    if [[ -z "${BRIEF_TOPIC:-}" ]]; then
+        print_error "Brief must include 'topic:' field"
+        return 1
+    fi
+    if [[ -z "${BRIEF_AUDIENCE:-}" ]]; then
+        print_error "Brief must include 'audience:' field"
+        return 1
+    fi
+
+    return 0
+}
+
+# Parse comma-separated channel list, validate each
+# Outputs valid channels space-separated
+parse_channels() {
+    local channel_str="$1"
+    local valid_channels=""
+
+    # Normalize: remove spaces around commas
+    channel_str="${channel_str// , /,}"
+    channel_str="${channel_str//, /,}"
+    channel_str="${channel_str// ,/,}"
+
+    local IFS=','
+    for ch in $channel_str; do
+        # Trim whitespace
+        ch=$(echo "$ch" | tr -d ' ')
+        if [[ "$ch" == "all" ]]; then
+            echo "$ALL_CHANNELS"
+            return 0
+        elif is_valid_channel "$ch"; then
+            if [[ -n "$valid_channels" ]]; then
+                valid_channels="${valid_channels} ${ch}"
+            else
+                valid_channels="$ch"
+            fi
+        else
+            print_warning "Unknown channel: $ch (skipping)"
+        fi
+    done
+
+    if [[ -z "$valid_channels" ]]; then
+        print_error "No valid channels specified"
+        return 1
+    fi
+
+    echo "$valid_channels"
+    return 0
+}
+
+# ─── Commands ─────────────────────────────────────────────────────────
+
+cmd_plan() {
+    local brief_file="$1"
+    ensure_dirs
+
+    parse_brief "$brief_file" || return 1
+
+    local channels
+    channels=$(parse_channels "$BRIEF_CHANNELS") || return 1
+
+    local topic_slug
+    topic_slug=$(slug "$BRIEF_TOPIC")
+    local plan_id="${topic_slug}-$(date +%Y%m%d-%H%M%S)"
+    local plan_file="${PLANS_DIR}/${plan_id}.plan"
+
+    # Count channels
+    local channel_count=0
+    for _ch in $channels; do
+        channel_count=$((channel_count + 1))
+    done
+
+    print_info "Generating fan-out plan: ${plan_id}"
+    print_info "Topic: ${BRIEF_TOPIC}"
+    print_info "Channels: ${channel_count} (${channels})"
+
+    # Calculate total outputs and collect unique formats
+    local total_outputs=0
+    local all_formats=""
+
+    {
+        echo "# Content Fan-Out Plan"
+        echo "# Generated: $(timestamp)"
+        echo "# Version: ${FANOUT_VERSION}"
+        echo ""
+        echo "id: ${plan_id}"
+        echo "topic: ${BRIEF_TOPIC}"
+        echo "angle: ${BRIEF_ANGLE}"
+        echo "audience: ${BRIEF_AUDIENCE}"
+        echo "tone: ${BRIEF_TONE}"
+        echo "cta: ${BRIEF_CTA:-}"
+        echo "notes: ${BRIEF_NOTES:-}"
+        echo "status: planned"
+        echo ""
+        echo "# --- Channel Outputs ---"
+        echo ""
+
+        for ch in $channels; do
+            local formats
+            formats=$(channel_formats "$ch")
+            local outputs
+            outputs=$(channel_outputs "$ch")
+            local subagent
+            subagent=$(channel_subagent "$ch")
+
+            echo "channel: ${ch}"
+            echo "  subagent: ${subagent}"
+            echo "  formats: ${formats}"
+            echo "  outputs: ${outputs}"
+            echo "  status: pending"
+            echo ""
+
+            total_outputs=$((total_outputs + 1))
+
+            # Collect unique formats
+            local IFS=','
+            for fmt in $formats; do
+                case " ${all_formats} " in
+                    *" ${fmt} "*) ;;  # already present
+                    *) all_formats="${all_formats} ${fmt}" ;;
+                esac
+            done
+        done
+
+        # Count unique formats
+        local format_count=0
+        for _fmt in $all_formats; do
+            format_count=$((format_count + 1))
+        done
+
+        echo "# --- Summary ---"
+        echo ""
+        echo "total_channels: ${channel_count}"
+        echo "total_outputs: ${total_outputs}"
+        echo "unique_formats: ${format_count} (${all_formats})"
+        echo "estimated_tokens: $((total_outputs * 2000))"
+    } > "$plan_file"
+
+    # Count unique formats for display
+    local format_count=0
+    for _fmt in $all_formats; do
+        format_count=$((format_count + 1))
+    done
+
+    print_success "Plan written: ${plan_file}"
+    echo ""
+    echo "  Channels:  ${channel_count}"
+    echo "  Outputs:   ${total_outputs}"
+    echo "  Formats:   ${format_count} (${all_formats})"
+    echo ""
+    echo "Next: content-fanout-helper.sh run ${plan_file}"
+
+    return 0
+}
+
+cmd_run() {
+    local plan_file="$1"
+    ensure_dirs
+
+    if [[ ! -f "$plan_file" ]]; then
+        print_error "Plan file not found: $plan_file"
+        return 1
+    fi
+
+    local plan_id
+    plan_id=$(grep '^id:' "$plan_file" | sed 's/^id: *//')
+    local topic
+    topic=$(grep '^topic:' "$plan_file" | sed 's/^topic: *//')
+    local angle
+    angle=$(grep '^angle:' "$plan_file" | sed 's/^angle: *//')
+    local audience
+    audience=$(grep '^audience:' "$plan_file" | sed 's/^audience: *//')
+    local tone
+    tone=$(grep '^tone:' "$plan_file" | sed 's/^tone: *//')
+    local cta
+    cta=$(grep '^cta:' "$plan_file" | sed 's/^cta: *//' || echo "")
+    local notes
+    notes=$(grep '^notes:' "$plan_file" | sed 's/^notes: *//' || echo "")
+
+    local output_dir="${OUTPUTS_DIR}/${plan_id}"
+    mkdir -p "$output_dir"
+
+    print_info "Executing fan-out: ${plan_id}"
+    print_info "Output directory: ${output_dir}"
+
+    # Extract channels from plan
+    local channels=""
+    while IFS= read -r line; do
+        local ch="${line#channel: }"
+        if [[ -n "$channels" ]]; then
+            channels="${channels} ${ch}"
+        else
+            channels="$ch"
+        fi
+    done < <(grep '^channel:' "$plan_file")
+
+    local completed=0
+    local failed=0
+
+    for ch in $channels; do
+        local ch_dir="${output_dir}/${ch}"
+        mkdir -p "$ch_dir"
+
+        print_info "Generating: ${ch}..."
+
+        # Write the channel-specific prompt file for AI processing
+        local prompt_file="${ch_dir}/prompt.md"
+        local outputs
+        outputs=$(channel_outputs "$ch" 2>/dev/null || echo "Channel-specific content")
+        local formats
+        formats=$(channel_formats "$ch" 2>/dev/null || echo "script")
+
+        {
+            echo "# Fan-Out Prompt: ${ch}"
+            echo ""
+            echo "## Story Context"
+            echo ""
+            echo "- **Topic**: ${topic}"
+            echo "- **Angle**: ${angle}"
+            echo "- **Audience**: ${audience}"
+            echo "- **Tone**: ${tone}"
+            echo "- **CTA**: ${cta}"
+            echo "- **Notes**: ${notes}"
+            echo ""
+            echo "## Channel: ${ch}"
+            echo ""
+            echo "**Required outputs**: ${outputs}"
+            echo ""
+            echo "**Required formats**: ${formats}"
+            echo ""
+            echo "## Instructions"
+            echo ""
+
+            case "$ch" in
+                youtube)
+                    echo "Generate a complete YouTube video package:"
+                    echo "1. Long-form script (scene-by-scene with B-roll directions, 8-12 min target)"
+                    echo "2. Title (3 variants using hook formulas: Bold Claim, Question, Curiosity Gap)"
+                    echo "3. Description (SEO-optimized, timestamps, links, keywords)"
+                    echo "4. Tags (15-20 relevant tags)"
+                    echo "5. Thumbnail brief (text overlay, emotion, color scheme, 3 variants)"
+                    echo "6. End screen CTA script"
+                    echo ""
+                    echo "Reference: content/distribution/youtube/ for YouTube-specific conventions."
+                    ;;
+                short-form)
+                    echo "Generate vertical short-form video content:"
+                    echo "1. 60-second script (hook in first 1-3 seconds, fast cuts every 1-3s)"
+                    echo "2. Caption/subtitle text (for 80%+ silent viewers)"
+                    echo "3. Trending sound suggestion (describe mood/genre, not specific track)"
+                    echo "4. 3 hook variants (pattern interrupt openers)"
+                    echo ""
+                    echo "Format: 9:16 vertical. Platforms: TikTok, Reels, Shorts."
+                    echo "Reference: content/distribution/short-form.md"
+                    ;;
+                social-x)
+                    echo "Generate X (Twitter) content:"
+                    echo "1. Thread version (5-8 posts, hook-first, each post standalone value)"
+                    echo "2. Single post version (under 280 chars, punchy)"
+                    echo "3. Quote-post version (for sharing related content)"
+                    echo ""
+                    echo "Voice: Concise, opinionated, personality-forward."
+                    echo "Reference: content/distribution/social.md"
+                    ;;
+                social-linkedin)
+                    echo "Generate LinkedIn content:"
+                    echo "1. Long-form post (1200-1500 chars, thought leadership framing)"
+                    echo "2. Short-form post (under 300 chars, for quick engagement)"
+                    echo "3. Article outline (if topic warrants deeper treatment)"
+                    echo ""
+                    echo "Voice: Professional, insight-driven, no sales pitch."
+                    echo "Reference: content/distribution/social.md"
+                    ;;
+                social-reddit)
+                    echo "Generate Reddit content:"
+                    echo "1. Post title (curiosity-driven, not clickbait)"
+                    echo "2. Post body (value-first, community-native, anti-promotional)"
+                    echo "3. Suggested subreddits (3-5 relevant communities)"
+                    echo "4. Comment engagement strategy"
+                    echo ""
+                    echo "Voice: Authentic, helpful, never salesy."
+                    echo "Reference: content/distribution/social.md"
+                    ;;
+                blog)
+                    echo "Generate SEO-optimized blog content:"
+                    echo "1. Article outline (H2/H3 structure, 1500-2500 words target)"
+                    echo "2. Meta title (under 60 chars, keyword-front-loaded)"
+                    echo "3. Meta description (under 155 chars, includes CTA)"
+                    echo "4. Target keyword + 5 secondary keywords"
+                    echo "5. Internal link suggestions (3-5 related topics)"
+                    echo "6. Featured image brief"
+                    echo ""
+                    echo "Reference: content/distribution/blog.md, seo/"
+                    ;;
+                email)
+                    echo "Generate email/newsletter content:"
+                    echo "1. Subject line (5 variants, A/B test ready)"
+                    echo "2. Preview text (under 90 chars)"
+                    echo "3. Newsletter body (story-driven, single CTA)"
+                    echo "4. P.S. line (secondary hook)"
+                    echo ""
+                    echo "Reference: content/distribution/email.md"
+                    ;;
+                podcast)
+                    echo "Generate podcast content:"
+                    echo "1. Episode title (curiosity-driven)"
+                    echo "2. Talking points / script outline (15-20 min target)"
+                    echo "3. Intro script (30s hook)"
+                    echo "4. Outro script (CTA + next episode tease)"
+                    echo "5. Show notes (timestamps, links, resources)"
+                    echo ""
+                    echo "Reference: content/distribution/podcast.md"
+                    ;;
+                *)
+                    echo "Generate content adapted for: ${ch}"
+                    echo "Follow the conventions in the relevant distribution subagent."
+                    ;;
+            esac
+
+            echo ""
+            echo "## Quality Checklist"
+            echo ""
+            echo "- [ ] Hook is in the first line/sentence/second"
+            echo "- [ ] Tone matches platform expectations"
+            echo "- [ ] CTA is clear and singular"
+            echo "- [ ] No cross-posting smell (platform-native language)"
+            echo "- [ ] Story angle is consistent with brief"
+        } > "$prompt_file"
+
+        # Write a status marker
+        echo "pending" > "${ch_dir}/.status"
+        completed=$((completed + 1))
+    done
+
+    # Write run summary
+    {
+        echo "# Fan-Out Run Summary"
+        echo "# Executed: $(timestamp)"
+        echo ""
+        echo "plan: ${plan_file}"
+        echo "output_dir: ${output_dir}"
+        echo "channels_prepared: ${completed}"
+        echo "channels_failed: ${failed}"
+        echo "status: prompts_ready"
+        echo ""
+        echo "# Each channel directory contains a prompt.md file ready for AI processing."
+        echo "# Process with the content agent: @content run fan-out from ${output_dir}"
+    } > "${output_dir}/summary.md"
+
+    print_success "Fan-out prepared: ${completed} channels"
+    echo ""
+    echo "  Output dir: ${output_dir}"
+    echo "  Channels:   ${completed} prepared, ${failed} failed"
+    echo ""
+    echo "Each channel directory contains a prompt.md ready for AI processing."
+    echo "Process all channels: @content run fan-out from ${output_dir}"
+
+    return 0
+}
+
+cmd_channels() {
+    echo "Available distribution channels:"
+    echo ""
+    printf "  %-18s %-30s %s\n" "CHANNEL" "SUBAGENT" "OUTPUTS"
+    printf "  %-18s %-30s %s\n" "-------" "--------" "-------"
+    for ch in $ALL_CHANNELS; do
+        local subagent
+        subagent=$(channel_subagent "$ch")
+        local outputs
+        outputs=$(channel_outputs "$ch")
+        printf "  %-18s %-30s %s\n" "$ch" "$subagent" "$outputs"
+    done
+    echo ""
+    echo "Total: 8 channels"
+    return 0
+}
+
+cmd_formats() {
+    echo "Available media formats:"
+    echo ""
+    printf "  %-15s %s\n" "FORMAT" "PRODUCTION SUBAGENT"
+    printf "  %-15s %s\n" "------" "-------------------"
+    for fmt in audio character image script video; do
+        local subagent
+        subagent=$(format_subagent "$fmt")
+        printf "  %-15s %s\n" "$fmt" "$subagent"
+    done
+    echo ""
+    echo "Channel format requirements:"
+    echo ""
+    printf "  %-18s %s\n" "CHANNEL" "REQUIRED FORMATS"
+    printf "  %-18s %s\n" "-------" "----------------"
+    for ch in $ALL_CHANNELS; do
+        local formats
+        formats=$(channel_formats "$ch")
+        printf "  %-18s %s\n" "$ch" "$formats"
+    done
+    return 0
+}
+
+cmd_status() {
+    local plan_file="$1"
+
+    if [[ ! -f "$plan_file" ]]; then
+        print_error "Plan file not found: $plan_file"
+        return 1
+    fi
+
+    local plan_id
+    plan_id=$(grep '^id:' "$plan_file" | sed 's/^id: *//')
+    local output_dir="${OUTPUTS_DIR}/${plan_id}"
+
+    if [[ ! -d "$output_dir" ]]; then
+        print_info "Plan has not been executed yet"
+        print_info "Run: content-fanout-helper.sh run ${plan_file}"
+        return 0
+    fi
+
+    echo "Fan-out status: ${plan_id}"
+    echo ""
+
+    local total=0
+    local pending=0
+    local complete=0
+
+    for ch_dir in "${output_dir}"/*/; do
+        [[ -d "$ch_dir" ]] || continue
+        local ch
+        ch=$(basename "$ch_dir")
+        local status="unknown"
+
+        if [[ -f "${ch_dir}/.status" ]]; then
+            status=$(cat "${ch_dir}/.status")
+        fi
+
+        total=$((total + 1))
+        case "$status" in
+            pending) pending=$((pending + 1)); printf "  [ ] %s\n" "$ch" ;;
+            complete) complete=$((complete + 1)); printf "  [x] %s\n" "$ch" ;;
+            *) printf "  [?] %s (%s)\n" "$ch" "$status" ;;
+        esac
+    done
+
+    echo ""
+    echo "  Total: ${total} | Complete: ${complete} | Pending: ${pending}"
+
+    return 0
+}
+
+cmd_template() {
+    local template_type="${1:-default}"
+    ensure_dirs
+
+    local template_file="${TEMPLATES_DIR}/brief-${template_type}.md"
+
+    case "$template_type" in
+        default)
+            {
+                echo "# Story Brief"
+                echo ""
+                echo "topic: "
+                echo "angle: contrarian"
+                echo "audience: "
+                echo "channels: youtube, short-form, social-x, social-linkedin, social-reddit, blog, email, podcast"
+                echo "tone: direct, conversational, data-backed"
+                echo "cta: "
+                echo "notes: "
+            } > "$template_file"
+            ;;
+        video)
+            {
+                echo "# Story Brief (Video-First)"
+                echo ""
+                echo "topic: "
+                echo "angle: contrarian"
+                echo "audience: "
+                echo "channels: youtube, short-form"
+                echo "tone: energetic, visual, fast-paced"
+                echo "cta: "
+                echo "notes: Include B-roll directions and visual cues"
+            } > "$template_file"
+            ;;
+        blog)
+            {
+                echo "# Story Brief (Blog/SEO)"
+                echo ""
+                echo "topic: "
+                echo "angle: educational"
+                echo "audience: "
+                echo "channels: blog, email, social-linkedin"
+                echo "tone: authoritative, helpful, SEO-aware"
+                echo "cta: "
+                echo "notes: Target keyword: [keyword]. Include internal link opportunities."
+            } > "$template_file"
+            ;;
+        social)
+            {
+                echo "# Story Brief (Social-First)"
+                echo ""
+                echo "topic: "
+                echo "angle: hot-take"
+                echo "audience: "
+                echo "channels: social-x, social-linkedin, social-reddit, short-form"
+                echo "tone: punchy, opinionated, shareable"
+                echo "cta: "
+                echo "notes: Optimise for engagement and shares"
+            } > "$template_file"
+            ;;
+        *)
+            print_error "Unknown template type: $template_type"
+            print_info "Available: default, video, blog, social"
+            return 1
+            ;;
+    esac
+
+    print_success "Template written: ${template_file}"
+    echo ""
+    cat "$template_file"
+
+    return 0
+}
+
+cmd_estimate() {
+    local brief_file="$1"
+
+    parse_brief "$brief_file" || return 1
+
+    local channels
+    channels=$(parse_channels "$BRIEF_CHANNELS") || return 1
+
+    echo "Fan-out estimate for: ${BRIEF_TOPIC}"
+    echo ""
+
+    local total_tokens=0
+    local total_minutes=0
+    local channel_count=0
+
+    printf "  %-18s %-8s %-8s %s\n" "CHANNEL" "TOKENS" "MINUTES" "OUTPUTS"
+    printf "  %-18s %-8s %-8s %s\n" "-------" "------" "-------" "-------"
+
+    for ch in $channels; do
+        local tokens=0
+        local minutes=0
+
+        # Estimates based on typical output sizes
+        case "$ch" in
+            youtube)         tokens=4000; minutes=8 ;;
+            short-form)      tokens=1500; minutes=3 ;;
+            social-x)        tokens=1000; minutes=2 ;;
+            social-linkedin) tokens=1200; minutes=3 ;;
+            social-reddit)   tokens=800;  minutes=2 ;;
+            blog)            tokens=3000; minutes=6 ;;
+            email)           tokens=1500; minutes=3 ;;
+            podcast)         tokens=2500; minutes=5 ;;
+            *)               tokens=1500; minutes=3 ;;
+        esac
+
+        local outputs
+        outputs=$(channel_outputs "$ch" 2>/dev/null || echo "Channel-specific content")
+        printf "  %-18s %-8s %-8s %s\n" "$ch" "~${tokens}" "~${minutes}" "$outputs"
+        total_tokens=$((total_tokens + tokens))
+        total_minutes=$((total_minutes + minutes))
+        channel_count=$((channel_count + 1))
+    done
+
+    echo ""
+    echo "  Total estimated tokens:  ~${total_tokens}"
+    echo "  Total estimated time:    ~${total_minutes} minutes (sequential)"
+    echo "  Parallel time (3 slots): ~$(( (total_minutes + 2) / 3 )) minutes"
+    echo ""
+    echo "  Channels: ${channel_count}"
+    echo "  Story research (one-time): ~30 minutes"
+
+    return 0
+}
+
+cmd_help() {
+    echo "Content Fan-Out Helper v${FANOUT_VERSION}"
+    echo ""
+    echo "Orchestrates the diamond pipeline: one story -> 10+ outputs across channels."
+    echo ""
+    echo "${HELP_LABEL_USAGE}"
+    echo "  content-fanout-helper.sh [command] [args]"
+    echo ""
+    echo "${HELP_LABEL_COMMANDS}"
+    echo "  plan <brief-file>       Generate a fan-out plan from a story brief"
+    echo "  run <plan-file>         Execute a fan-out plan (generate all channel prompts)"
+    echo "  channels                List available distribution channels"
+    echo "  formats                 List available media formats and channel requirements"
+    echo "  status <plan-file>      Show progress of a fan-out run"
+    echo "  template [type]         Generate a story brief template (default|video|blog|social)"
+    echo "  estimate <brief-file>   Estimate time and token cost for a fan-out"
+    echo "  help                    Show this help message"
+    echo ""
+    echo "${HELP_LABEL_EXAMPLES}"
+    echo "  # Generate a brief template"
+    echo "  content-fanout-helper.sh template default"
+    echo ""
+    echo "  # Edit the brief, then plan"
+    echo "  content-fanout-helper.sh plan ~/my-story-brief.md"
+    echo ""
+    echo "  # Execute the plan"
+    echo "  content-fanout-helper.sh run ~/.aidevops/.agent-workspace/work/content-fanout/plans/my-topic.plan"
+    echo ""
+    echo "  # Check progress"
+    echo "  content-fanout-helper.sh status ~/.aidevops/.agent-workspace/work/content-fanout/plans/my-topic.plan"
+    echo ""
+    echo "  # Estimate before running"
+    echo "  content-fanout-helper.sh estimate ~/my-story-brief.md"
+    echo ""
+    echo "Pipeline: Brief -> Plan -> Run -> AI Processing -> Outputs"
+    echo "See: .agents/content.md for the full diamond pipeline architecture."
+
+    return 0
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────
+
+main() {
+    local command="${1:-help}"
+    shift || true
+
+    case "$command" in
+        plan)
+            [[ $# -lt 1 ]] && { print_error "Usage: content-fanout-helper.sh plan <brief-file>"; return 1; }
+            cmd_plan "$1"
+            ;;
+        run)
+            [[ $# -lt 1 ]] && { print_error "Usage: content-fanout-helper.sh run <plan-file>"; return 1; }
+            cmd_run "$1"
+            ;;
+        channels)
+            cmd_channels
+            ;;
+        formats)
+            cmd_formats
+            ;;
+        status)
+            [[ $# -lt 1 ]] && { print_error "Usage: content-fanout-helper.sh status <plan-file>"; return 1; }
+            cmd_status "$1"
+            ;;
+        template)
+            cmd_template "${1:-default}"
+            ;;
+        estimate)
+            [[ $# -lt 1 ]] && { print_error "Usage: content-fanout-helper.sh estimate <brief-file>"; return 1; }
+            cmd_estimate "$1"
+            ;;
+        help|--help|-h)
+            cmd_help
+            ;;
+        *)
+            print_error "${ERROR_UNKNOWN_COMMAND}: $command"
+            cmd_help
+            return 1
+            ;;
+    esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add `content-fanout-helper.sh` CLI orchestrator that automates the diamond pipeline: one story brief fans out to 8 distribution channels (YouTube, short-form, social-x, social-linkedin, social-reddit, blog, email, podcast) with channel-specific prompts ready for AI processing
- Create `content/story.md` subagent with 7 hook formulas, 4-part script framework, angle selection matrix, and campaign audit process
- Create `content/production/writing.md` subagent with multi-format text production templates (long-form scripts, short-form, social copy, blog drafts, email, podcast)
- Update `content.md` orchestrator with fan-out command reference and quick start guide

## Helper Commands

| Command | Purpose |
|---------|---------|
| `plan <brief>` | Generate fan-out plan from story brief |
| `run <plan>` | Execute plan, create channel-specific prompts |
| `channels` | List 8 available distribution channels |
| `formats` | List media formats and channel requirements |
| `status <plan>` | Show progress of a fan-out run |
| `template [type]` | Generate brief template (default/video/blog/social) |
| `estimate <brief>` | Estimate time and token cost |

## Testing

- ShellCheck: zero violations (SC1091 info-only for sourced file)
- All 7 commands tested end-to-end on macOS bash 3.2
- Full pipeline tested: template -> plan -> run -> status -> estimate

Closes #829