### PR TITLE
feat: add YouTube slash commands — /youtube setup, /youtube research, /youtube script

### DIFF
--- a/.agents/scripts/commands/youtube-research.md
+++ b/.agents/scripts/commands/youtube-research.md
@@ -1,0 +1,227 @@
+---
+description: Research YouTube topics, competitors, and content opportunities
+agent: YouTube
+mode: subagent
+---
+
+Run YouTube research workflows -- competitor analysis, content gap detection, trend spotting, and topic validation.
+
+Arguments: $ARGUMENTS
+
+## Usage
+
+```text
+/youtube research                              # Full research cycle (intel + gaps + trends)
+/youtube research competitors                  # Scan all stored competitors
+/youtube research gaps                         # Content gap analysis
+/youtube research trending "niche topic"       # Find trending videos in a niche
+/youtube research topic "topic name"           # Validate a specific topic idea
+/youtube research outliers @handle             # Find outlier videos for a channel
+/youtube research recall                       # Show previous research findings
+```
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` to determine the research mode:
+
+| Argument | Action |
+|----------|--------|
+| (none) | Full research cycle |
+| `competitors` | Competitor intel scan |
+| `gaps` | Content gap analysis |
+| `trending "topic"` | Trending video search |
+| `topic "name"` | Single topic validation |
+| `outliers @handle` | Outlier detection for a channel |
+| `recall` | Show stored research findings |
+
+### Step 2: Load Context
+
+Before any research, recall stored configuration:
+
+```bash
+# Get channel profile
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "My channel"
+
+# Get competitor list
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "Competitor"
+
+# Get previous research (avoid duplicating work)
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube-topics --recent
+```
+
+If no channel profile exists, prompt:
+
+```text
+No YouTube channel configured. Run /youtube setup first.
+```
+
+### Step 3: Route to Research Mode
+
+**For `competitors` or full cycle:**
+
+Read `youtube/channel-intel.md` for the full workflow, then for each stored competitor:
+
+```bash
+# Get channel stats
+~/.aidevops/agents/scripts/youtube-helper.sh channel @handle
+
+# Get recent videos (last 50)
+~/.aidevops/agents/scripts/youtube-helper.sh videos @handle 50
+
+# Run comparison
+~/.aidevops/agents/scripts/youtube-helper.sh competitors @me @comp1 @comp2 @comp3
+```
+
+Analyze the data to identify:
+
+- New uploads since last scan
+- Outlier videos (3x+ median views)
+- Upload frequency changes
+- New topic clusters
+
+Store findings:
+
+```bash
+~/.aidevops/agents/scripts/memory-helper.sh store --type WORKING_SOLUTION --namespace youtube \
+  "Intel scan [date]: @handle - [findings summary]"
+```
+
+**For `gaps`:**
+
+Read `youtube/topic-research.md` for the full workflow:
+
+1. Extract topic clusters from competitor video titles
+2. Map your own coverage
+3. Identify topics where 2+ competitors have videos but you have none
+4. Filter by outlier presence (proven demand)
+5. Rank by opportunity score (demand / competition)
+
+Store each gap:
+
+```bash
+~/.aidevops/agents/scripts/memory-helper.sh store --type WORKING_SOLUTION --namespace youtube-topics \
+  "Content gap: [topic]. Covered by @comp1 ([views]), @comp2 ([views]). My coverage: none. Angle: [suggestion]."
+```
+
+**For `trending "topic"`:**
+
+```bash
+~/.aidevops/agents/scripts/youtube-helper.sh trending "topic" 20
+```
+
+Analyze results for:
+
+- View velocity (views per day since publish)
+- Channel diversity (many channels = broad trend, few = niche)
+- Recency (all recent = rising trend, mixed = established)
+
+**For `topic "name"`:**
+
+Validate a specific topic idea:
+
+```bash
+# Check existing coverage
+~/.aidevops/agents/scripts/youtube-helper.sh search "topic name" video 20
+
+# Check competition level
+~/.aidevops/agents/scripts/youtube-helper.sh search "topic name" video 50
+```
+
+Assess:
+
+- How many videos exist on this exact topic?
+- What are the view counts? (high = proven demand)
+- How recent are the top results? (old = opportunity to update)
+- What angles have been covered? (find the gap)
+
+Report using the topic opportunity format from `youtube/topic-research.md`.
+
+**For `outliers @handle`:**
+
+```bash
+~/.aidevops/agents/scripts/youtube-helper.sh videos @handle 200 json
+```
+
+Then calculate median views and identify videos at 3x+ threshold. For each outlier, note the title pattern, topic, and duration.
+
+**For `recall`:**
+
+```bash
+# Recent intel
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "Intel scan" --recent
+
+# Topic opportunities
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube-topics "Opportunity" --recent
+
+# Content gaps
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube-topics "Content gap" --recent
+```
+
+### Step 4: Full Research Cycle (no arguments)
+
+When no arguments are provided, run the complete cycle:
+
+1. **Competitor scan** -- profile all stored competitors
+2. **Outlier detection** -- find breakout videos across all competitors
+3. **Content gap analysis** -- compare topic coverage
+4. **Trend check** -- search for rising topics in the niche
+5. **Rank opportunities** -- score by demand, competition, and fit
+
+Present a ranked list:
+
+```text
+YouTube Research Results ([date]):
+
+Top Opportunities:
+1. [Topic] -- Demand: High, Competition: Low, Angle: [suggestion]
+   Covered by: @comp1 (50K views), @comp2 (30K views)
+   Your coverage: None
+
+2. [Topic] -- Demand: Medium, Competition: Medium, Angle: [suggestion]
+   Outlier: @comp3 "[title]" (200K views, 5x their median)
+   Your coverage: 1 video (underperforming)
+
+3. [Topic] -- Demand: Rising, Competition: Low, Angle: [suggestion]
+   Trend signal: 4 new videos in last 2 weeks across 3 channels
+
+Quota used: [X] / 10,000 units
+
+Next steps:
+  /youtube script "[topic]"    -- Generate a script for any topic above
+  /youtube research recall     -- Review these findings later
+```
+
+### Step 5: Store and Report
+
+After any research mode, store findings in memory and check quota:
+
+```bash
+~/.aidevops/agents/scripts/youtube-helper.sh quota
+```
+
+## Quota Budget
+
+| Research Mode | Estimated Cost |
+|---------------|---------------|
+| Single competitor scan | ~10 units |
+| Full competitor scan (5 channels) | ~50 units |
+| Content gap analysis | ~60 units (includes video enumeration) |
+| Trending search | ~100 units (uses search endpoint) |
+| Topic validation | ~100 units (uses search endpoint) |
+| Full research cycle | ~300 units |
+
+## Prerequisites
+
+- YouTube channel configured via `/youtube setup`
+- At least 1 competitor stored in memory
+- YouTube Data API authentication working
+
+## Related
+
+- `youtube.md` -- Main YouTube agent
+- `youtube/channel-intel.md` -- Detailed competitor profiling
+- `youtube/topic-research.md` -- Content gap and trend workflows
+- `youtube-helper.sh` -- YouTube Data API wrapper
+- `youtube-script.md` -- Generate scripts from research findings

--- a/.agents/scripts/commands/youtube-script.md
+++ b/.agents/scripts/commands/youtube-script.md
@@ -1,0 +1,267 @@
+---
+description: Generate YouTube video scripts with hooks, retention optimization, and metadata
+agent: YouTube
+mode: subagent
+---
+
+Generate YouTube video scripts from a topic, outline, or competitor video. Includes hook generation, retention curve optimization, and optional metadata (titles, tags, description).
+
+Arguments: $ARGUMENTS
+
+## Usage
+
+```text
+/youtube script "topic name"                   # Generate script from a topic
+/youtube script remix VIDEO_ID                 # Remix a competitor video into unique script
+/youtube script hook "topic name"              # Generate hook options only
+/youtube script outline "topic name"           # Generate outline only (no full script)
+/youtube script optimize                       # Optimize an existing script (paste or file)
+/youtube script list                           # List previously generated scripts
+```
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` to determine the script mode:
+
+| Argument | Action |
+|----------|--------|
+| `"topic"` | Full script generation from topic |
+| `remix VIDEO_ID` | Remix competitor video |
+| `hook "topic"` | Hook options only |
+| `outline "topic"` | Outline without full script |
+| `optimize` | Optimize existing script |
+| `list` | List generated scripts |
+
+### Step 2: Load Context
+
+Before generating any script, recall stored context:
+
+```bash
+# Channel voice and audience
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "My channel"
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "Channel voice"
+
+# Topic research for this topic (if available)
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube-topics "$TOPIC"
+
+# Previous script patterns
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube-scripts --recent
+
+# Successful patterns
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube-patterns "script"
+```
+
+If no channel profile exists, prompt:
+
+```text
+No YouTube channel configured. Run /youtube setup first to set your channel voice and audience.
+```
+
+### Step 3: Route to Script Mode
+
+**For `"topic"` (full script generation):**
+
+Read `youtube/script-writer.md` for the full workflow.
+
+1. **Check for existing research** on this topic in memory
+2. **Get competitor coverage** (if not already in memory):
+
+```bash
+~/.aidevops/agents/scripts/youtube-helper.sh search "topic" video 10
+```
+
+3. **Get competitor transcripts** for the top 2-3 results:
+
+```bash
+~/.aidevops/agents/scripts/youtube-helper.sh transcript VIDEO_ID
+```
+
+4. **Choose framework** based on content type:
+
+| Content Type | Framework |
+|-------------|-----------|
+| Product review | AIDA |
+| Tutorial / how-to | Problem-Solution-Result |
+| Documentary / explainer | Three-Act Structure |
+| Personal story | Hero's Journey |
+| List / roundup | Listicle with Stakes |
+
+5. **Generate the full script** following the structure from `youtube/script-writer.md`:
+   - HOOK (0-30s) -- pattern interrupt + promise + credibility
+   - INTRO (30-60s) -- context + roadmap + stakes
+   - BODY -- sections with pattern interrupts every 2-3 minutes
+   - CLIMAX -- payoff the hook's promise
+   - CTA -- subscribe + next video + comment prompt
+
+6. **Generate metadata** using `youtube/optimizer.md`:
+   - 3-5 title options with CTR signals
+   - 15-30 tags across categories
+   - SEO-optimized description with timestamps
+   - Thumbnail brief
+
+7. **Save to workspace**:
+
+```bash
+mkdir -p ~/.aidevops/.agent-workspace/work/youtube/scripts/$(date +%Y-%m-%d)-$(echo "$TOPIC" | tr ' ' '-' | tr '[:upper:]' '[:lower:]' | head -c 40)
+```
+
+Save files: `script.md`, `titles.md`, `tags.txt`, `description.md`, `thumbnail-brief.md`
+
+**For `remix VIDEO_ID`:**
+
+Read `youtube/script-writer.md` "Remix Mode" section.
+
+1. **Get the source video metadata and transcript**:
+
+```bash
+~/.aidevops/agents/scripts/youtube-helper.sh video VIDEO_ID
+~/.aidevops/agents/scripts/youtube-helper.sh transcript VIDEO_ID
+```
+
+2. **Analyze the source structure** -- extract hook formula, framework, key points, pattern interrupts, CTA approach
+3. **Choose remix mode**:
+   - Same topic, new angle (default)
+   - Same structure, new topic
+   - Update (cover what changed)
+   - Response (add your expertise)
+   - Deep dive (expand one point)
+
+4. **Generate remixed script** that keeps successful structural elements but uses your voice, angle, and new information
+5. **Generate metadata** and save to workspace
+
+**For `hook "topic"`:**
+
+Generate 5 hook options using formulas from `youtube/script-writer.md`:
+
+1. Bold claim hook
+2. Question hook
+3. Story hook
+4. Result hook
+5. Curiosity gap hook
+
+For each hook, include:
+
+- Spoken text (15-30 seconds when read aloud)
+- `[VISUAL]` cue for what appears on screen
+- Why this hook works for this specific topic
+
+**For `outline "topic"`:**
+
+Generate a structured outline without full script text:
+
+```text
+## [Working Title]
+
+**Framework**: [chosen framework]
+**Target length**: [X minutes]
+**Primary keyword**: [keyword]
+
+### [00:00] HOOK
+- Formula: [hook type]
+- Promise: [what viewer will learn]
+- Credibility: [why they should listen]
+
+### [00:30] INTRO
+- Context: [topic background]
+- Roadmap: [what the video covers]
+- Stakes: [why it matters]
+
+### [01:00] Section 1: [Title]
+- Key point: [main idea]
+- Evidence: [data/example/story]
+- Pattern interrupt: [type]
+
+### [04:00] Section 2: [Title]
+...
+
+### [XX:XX] CTA
+- Action: [specific ask]
+- Next video: [related content]
+```
+
+**For `optimize`:**
+
+Ask the user to paste their existing script or provide a file path. Then review against the retention checklist from `youtube/script-writer.md`:
+
+| Checkpoint | What to Verify |
+|-----------|---------------|
+| First 5 seconds | Does it stop the scroll? |
+| First 30 seconds | Is the hook complete? |
+| 60-second mark | Does the viewer know what they get? |
+| Every 2-3 minutes | Is there a pattern interrupt? |
+| Midpoint | Is there a re-engagement moment? |
+| Before CTA | Was the hook's promise fulfilled? |
+| CTA | Is it specific and content-related? |
+
+Provide specific suggestions for each checkpoint that fails.
+
+**For `list`:**
+
+```bash
+ls -la ~/.aidevops/.agent-workspace/work/youtube/scripts/ 2>/dev/null || echo "No scripts generated yet."
+
+# Also check memory for script metadata
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube-scripts --recent
+```
+
+### Step 4: Present Output
+
+After generating a script, present it with:
+
+```text
+Script Generated: "[Title]"
+
+Framework:  [framework name]
+Length:      ~[X] minutes ([Y] words)
+Hook:       [hook type] formula
+Sections:   [N] sections with [N] pattern interrupts
+
+Titles (pick one):
+1. [Title option 1] -- [CTR signals used]
+2. [Title option 2] -- [CTR signals used]
+3. [Title option 3] -- [CTR signals used]
+
+Saved to: ~/.aidevops/.agent-workspace/work/youtube/scripts/[date]-[topic]/
+
+Next steps:
+1. Review and refine the script
+2. /youtube script optimize -- check retention signals
+3. Record the video
+```
+
+### Step 5: Store in Memory
+
+```bash
+~/.aidevops/agents/scripts/memory-helper.sh store --type WORKING_SOLUTION --namespace youtube-scripts \
+  "Script: [topic]. Framework: [name]. Hook: [type]. Length: [X min]. \
+   Titles: [top 2 options]. Saved: [path]."
+```
+
+## Quota Budget
+
+| Script Mode | Estimated Cost |
+|-------------|---------------|
+| Full script (with research) | ~110 units (search + video lookups) |
+| Full script (topic pre-researched) | ~10 units (transcript only) |
+| Remix | ~2 units (video lookup + transcript via yt-dlp) |
+| Hook only | ~100 units (search for competitor hooks) |
+| Outline only | ~100 units (search for competitor coverage) |
+| Optimize | 0 units (AI analysis only) |
+
+## Prerequisites
+
+- YouTube channel configured via `/youtube setup`
+- For best results, run `/youtube research` first to identify validated topics
+- `yt-dlp` installed for transcript extraction (`/yt-dlp status`)
+
+## Related
+
+- `youtube.md` -- Main YouTube agent
+- `youtube/script-writer.md` -- Detailed script generation workflows
+- `youtube/optimizer.md` -- Title, tag, description optimization
+- `youtube/topic-research.md` -- Topic validation before scripting
+- `youtube-helper.sh` -- YouTube Data API wrapper
+- `youtube-research.md` -- Research command for topic discovery
+- `youtube-setup.md` -- Initial channel configuration

--- a/.agents/scripts/commands/youtube-setup.md
+++ b/.agents/scripts/commands/youtube-setup.md
@@ -1,0 +1,151 @@
+---
+description: Set up YouTube channel profile, competitors, and API authentication
+agent: YouTube
+mode: subagent
+---
+
+Configure your YouTube channel, competitors, and API access for research workflows.
+
+Arguments: $ARGUMENTS
+
+## Usage
+
+```text
+/youtube setup                          # Interactive guided setup
+/youtube setup auth                     # Test API authentication only
+/youtube setup channel @myhandle        # Store your channel profile
+/youtube setup competitor @handle       # Add a competitor
+/youtube setup competitors              # List stored competitors
+/youtube setup status                   # Show full configuration status
+```
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` to determine the setup mode:
+
+| Argument | Action |
+|----------|--------|
+| (none) | Run full interactive setup |
+| `auth` | Test YouTube Data API authentication |
+| `channel @handle` | Store channel profile in memory |
+| `competitor @handle` | Add a competitor to memory |
+| `competitors` | List all stored competitors |
+| `status` | Show configuration status |
+
+### Step 2: Route to Action
+
+**For `auth` or no arguments (start with auth test):**
+
+```bash
+~/.aidevops/agents/scripts/youtube-helper.sh auth-test
+```
+
+If auth fails, guide the user:
+
+1. They need a Google Cloud service account with YouTube Data API v3 enabled
+2. Store the key file: `cp <key.json> ~/.config/aidevops/keys/evergreen-je-sa.json && chmod 600 ~/.config/aidevops/keys/evergreen-je-sa.json`
+3. Add to credentials: `aidevops secret set GCP_SA_KEY_FILE`
+
+**For `channel @handle`:**
+
+```bash
+# Verify the channel exists
+~/.aidevops/agents/scripts/youtube-helper.sh channel @handle
+
+# Store in memory
+~/.aidevops/agents/scripts/memory-helper.sh store --type WORKING_SOLUTION --namespace youtube \
+  "My channel: @handle. Niche: [ask user]. Target audience: [ask user]. Channel voice: [ask user]."
+```
+
+**For `competitor @handle`:**
+
+```bash
+# Verify the channel exists and get stats
+~/.aidevops/agents/scripts/youtube-helper.sh channel @handle
+
+# Store in memory
+~/.aidevops/agents/scripts/memory-helper.sh store --type WORKING_SOLUTION --namespace youtube \
+  "Competitor: @handle - [subscriber count] subs, [video count] videos. Focus: [brief description]."
+```
+
+**For `competitors`:**
+
+```bash
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "Competitor"
+```
+
+**For `status`:**
+
+```bash
+# Check auth
+~/.aidevops/agents/scripts/youtube-helper.sh auth-test
+
+# Check quota
+~/.aidevops/agents/scripts/youtube-helper.sh quota
+
+# Recall channel config
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "My channel"
+
+# Recall competitors
+~/.aidevops/agents/scripts/memory-helper.sh recall --namespace youtube "Competitor"
+```
+
+### Step 3: Interactive Setup (no arguments)
+
+When no arguments are provided, run the full guided setup:
+
+1. **Test authentication** -- run `youtube-helper.sh auth-test`
+2. **Ask for channel handle** -- verify with `youtube-helper.sh channel @handle`
+3. **Ask for niche/topic** -- what the channel covers
+4. **Ask for target audience** -- who watches
+5. **Ask for channel voice** -- casual/formal, humor level, expertise positioning
+6. **Store channel profile** in memory namespace `youtube`
+7. **Ask for 3-5 competitors** -- verify each with `youtube-helper.sh channel @handle`
+8. **Store each competitor** in memory namespace `youtube`
+9. **Run initial comparison** -- `youtube-helper.sh competitors @me @comp1 @comp2 @comp3`
+10. **Show summary** of stored configuration
+
+Present each step with numbered options:
+
+```text
+YouTube Setup - Step 1/5: Authentication
+
+Testing YouTube Data API access...
+[OK] Authentication successful (service account: sa@project.iam.gserviceaccount.com)
+
+1. Continue to channel setup
+2. Reconfigure authentication
+```
+
+### Step 4: Report Configuration
+
+After setup, display:
+
+```text
+YouTube Configuration:
+  Channel:      @handle ([subscriber count] subscribers)
+  Niche:        [niche description]
+  Audience:     [audience description]
+  Voice:        [voice description]
+  Competitors:  @comp1, @comp2, @comp3
+  API Status:   Authenticated
+  Quota Today:  [X] / 10,000 units
+
+Ready to use:
+  /youtube research    -- Find topic opportunities
+  /youtube script      -- Generate video scripts
+```
+
+## Prerequisites
+
+- YouTube Data API v3 service account key
+- `youtube-helper.sh` accessible at `~/.aidevops/agents/scripts/`
+- `memory-helper.sh` for cross-session persistence
+
+## Related
+
+- `youtube.md` -- Main YouTube agent
+- `youtube/pipeline.md` -- Automated pipeline setup
+- `youtube-helper.sh` -- YouTube Data API wrapper


### PR DESCRIPTION
## Summary

- Add `/youtube setup` slash command for interactive channel profile, competitor, and API authentication configuration
- Add `/youtube research` slash command for competitor analysis, content gap detection, trend spotting, and topic validation
- Add `/youtube script` slash command for script generation from topics or competitor videos with retention optimization and metadata

## Details

Three new slash command files in `.agents/scripts/commands/`:

| Command | File | Purpose |
|---------|------|---------|
| `/youtube setup` | `youtube-setup.md` | Channel profile, competitors, API auth |
| `/youtube research` | `youtube-research.md` | Competitor intel, gaps, trends, topic validation |
| `/youtube script` | `youtube-script.md` | Script generation, remix, hooks, outlines |

All commands:
- Follow existing slash command conventions (YAML frontmatter, `$ARGUMENTS` pattern)
- Route to the `YouTube` agent
- Reference `youtube-helper.sh` for API access and `memory-helper.sh` for cross-session persistence
- Include quota budget estimates for API cost awareness
- Cross-reference the existing YouTube subagents (`channel-intel`, `topic-research`, `script-writer`, `optimizer`)

These commands were already referenced in `youtube.md` Quick Reference but had no implementation files.

Refs: t209