### PR TITLE
fix: use detect_repo_slug() for GitHub API calls — fixes PR validation failures

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -4771,7 +4771,7 @@ evaluate_worker() {
     task_branch=$(sqlite3 "$SUPERVISOR_DB" "SELECT branch FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "")
     repo_slug_detect=""
     if [[ -n "$task_repo" ]]; then
-        repo_slug_detect=$(git -C "$task_repo" remote get-url origin 2>/dev/null | grep -oE '[^/:]+/[^/.]+' | tail -1 || echo "")
+        repo_slug_detect=$(detect_repo_slug "$task_repo" 2>/dev/null || echo "")
     fi
 
     # Validate DB-seeded PR URL belongs to this task (t195): a previous pulse
@@ -5751,7 +5751,7 @@ check_pr_status() {
         task_repo_check=$(sqlite3 "$SUPERVISOR_DB" "SELECT repo FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "")
         if [[ -n "$task_repo_check" ]]; then
             local repo_slug_check
-            repo_slug_check=$(git -C "$task_repo_check" remote get-url origin 2>/dev/null | grep -oE '[^/:]+/[^/.]+' | tail -1 || echo "")
+            repo_slug_check=$(detect_repo_slug "$task_repo_check" 2>/dev/null || echo "")
             if [[ -n "$repo_slug_check" ]]; then
                 local found_pr_url=""
                 # Try DB branch first (actual worktree branch name)
@@ -5957,7 +5957,7 @@ scan_orphaned_prs() {
         [[ -n "$repo_path" && -d "$repo_path" ]] || continue
 
         local repo_slug
-        repo_slug=$(git -C "$repo_path" remote get-url origin 2>/dev/null | grep -oE '[^/:]+/[^/.]+' | tail -1 || echo "")
+        repo_slug=$(detect_repo_slug "$repo_path" 2>/dev/null || echo "")
         if [[ -z "$repo_slug" ]]; then
             log_verbose "  Phase 6: Cannot determine repo slug for $repo_path — skipping"
             continue
@@ -6402,7 +6402,7 @@ cmd_pr_lifecycle() {
             local found_pr=""
             if [[ -n "$trepo" ]]; then
                 local repo_slug_lifecycle
-                repo_slug_lifecycle=$(git -C "$trepo" remote get-url origin 2>/dev/null | grep -oE '[^/:]+/[^/.]+' | tail -1 || echo "")
+                repo_slug_lifecycle=$(detect_repo_slug "$trepo" 2>/dev/null || echo "")
                 if [[ -n "$repo_slug_lifecycle" ]]; then
                     found_pr=$(gh pr list --repo "$repo_slug_lifecycle" --head "feature/${task_id}" --json url --jq '.[0].url' 2>>"$SUPERVISOR_LOG" || echo "")
                 fi


### PR DESCRIPTION
## Summary

- Replaces 4 instances of broken inline regex `grep -oE '[^/:]+/[^/.]+' | tail -1` with the existing `detect_repo_slug()` function
- The regex extracted `github.com/marcusquinn` instead of `marcusquinn/aidevops` from HTTPS `.git` URLs
- This caused `validate_pr_belongs_to_task()` to fail on every call, making the supervisor unable to link PRs to tasks

## Impact

**Root cause** of all PR validation failures in backlog-12:
- Workers created PRs successfully but supervisor evaluated them as `task_only` / `no_pr`
- Triggered unnecessary retries (wasting Opus compute)
- Retry workers closed existing PRs and created new ones (PR churn)
- Affected: t204 (#886), t206 (#887), t207 (#896→#899), t208 (#897), t209 (#898)

## Fix

4 call sites in `supervisor-helper.sh` (lines 4774, 5754, 5960, 6405) now use `detect_repo_slug()` which correctly strips `.git` suffix before extraction.

## Testing

- Verified `detect_repo_slug()` returns `marcusquinn/aidevops` (correct)
- Verified broken regex returns `github.com/marcusquinn` (incorrect)
- ShellCheck: zero new violations