### PR TITLE
fix: setup.sh cross-shell grep -c arithmetic error

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1547,12 +1547,14 @@ setup_shell_compatibility() {
     
     for src_file in "${bash_files[@]}"; do
         local n
-        n=$(grep -cE '^\s*export\s+[A-Z]' "$src_file" 2>/dev/null || echo "0")
-        total_exports=$((total_exports + n))
-        n=$(grep -cE '^\s*alias\s+' "$src_file" 2>/dev/null || echo "0")
-        total_aliases=$((total_aliases + n))
-        n=$(grep -cE 'PATH.*=' "$src_file" 2>/dev/null || echo "0")
-        total_paths=$((total_paths + n))
+        # grep -c outputs "0" on no match (exit 1); "|| true" prevents exit
+        # without appending a second "0" line (which breaks arithmetic)
+        n=$(grep -cE '^\s*export\s+[A-Z]' "$src_file" 2>/dev/null) || true
+        total_exports=$((total_exports + ${n:-0}))
+        n=$(grep -cE '^\s*alias\s+' "$src_file" 2>/dev/null) || true
+        total_aliases=$((total_aliases + ${n:-0}))
+        n=$(grep -cE 'PATH.*=' "$src_file" 2>/dev/null) || true
+        total_paths=$((total_paths + ${n:-0}))
     done
     
     if [[ $total_exports -eq 0 && $total_aliases -eq 0 && $total_paths -eq 0 ]]; then


### PR DESCRIPTION
## Summary

- Fixes arithmetic error in `setup_shell_compatibility()` at line ~1553 of setup.sh
- `grep -cE` outputs `0` on no match (exit code 1), then `|| echo "0"` appends a second `0` line, producing `"0\n0"` which breaks `$(( ))` arithmetic
- Fix: use `|| true` to suppress exit code without appending output, and `${n:-0}` as safety fallback

## Root Cause

```bash
# Before (broken): n becomes "0\n0" (two lines)
n=$(grep -cE '^\s*alias\s+' "$file" 2>/dev/null || echo "0")

# After (fixed): n becomes "0" (single line)
n=$(grep -cE '^\s*alias\s+' "$file" 2>/dev/null) || true
total=$((total + ${n:-0}))
```

## Impact

This bug was introduced by PR #900 and blocks all autonomous deploys via `run_deploy_for_task()` in the supervisor. The error is non-fatal (setup.sh continues) but produces confusing output and may cause incorrect cross-shell compatibility detection.

## Testing

- Verified fix produces clean single-line values for all bash config files
- Full `setup.sh --non-interactive` completes with zero errors
- ShellCheck clean (no new violations)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup script stability by enhancing error handling in shell compatibility checks, ensuring accurate configuration counts and preventing initialization errors when certain conditions are not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->