### PR TITLE
fix: Remotion staticFile path handling, Seedance video download matching, caption normalization

### DIFF
--- a/.agents/scripts/higgsfield/remotion/.gitignore
+++ b/.agents/scripts/higgsfield/remotion/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 out/
+public/*.mp4


### PR DESCRIPTION
## Summary

- **Remotion render.mjs**: Fix `staticFile()` rejecting absolute paths by copying videos to `public/` and passing only filenames in props
- **Remotion render.mjs**: Normalize brief captions from `startFrame/endFrame` format to scene-indexed `{ scene, text, position, style }` format expected by `FullVideo.tsx`
- **playwright-automator.mjs**: Add order-based fallback matching for video download when API returns empty prompts (affects Seedance 1.5 Pro and similar models)
- **gitignore**: Exclude runtime video copies from `public/`

## Testing

- Remotion render verified: 6-scene Notion ad rendered successfully at 1080x1920 (9:16), 27.6s, with fade transitions and 6 caption overlays (bold-white, minimal, impact styles)
- JS syntax checks pass for both `render.mjs` and `playwright-automator.mjs`

## Context

These fixes were discovered during a full E2E production run of a 30-second Notion influencer ad using Nano Banana Pro (images) and Seedance 1.5 Pro (video) on Higgsfield.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable image-generation completion detection (handles missing queue indicators, button/spinner state, and adds automatic reload after long inactivity).
  * Improved video download matching with prompt-based and order-based fallback strategies; download logs now indicate match method.

* **New Features**
  * Video rendering now uses deterministic scene filenames and normalizes captions for consistent playback.

* **Chores**
  * Added ignore rule to exclude generated MP4s from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->