### PR TITLE
feat: add critical thinking directive and Socratic pre-flight questions

### DIFF
--- a/.agents/accounts.md
+++ b/.agents/accounts.md
@@ -29,6 +29,16 @@ subagents:
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-flight Questions
+
+Before generating financial or accounting output, work through:
+
+1. How would this look to a tax inspector, investor, or lender reviewing the books?
+2. What is the tax treatment — and in which jurisdiction(s)?
+3. Are we recording substance or just form — does this reflect economic reality?
+4. What audit trail exists to support every figure?
+5. What would change if the business were investigated, sold, or seeking funding tomorrow?
+
 ## Accounting Workflows
 
 ### QuickFile Integration

--- a/.agents/content/production/writing.md
+++ b/.agents/content/production/writing.md
@@ -26,6 +26,15 @@ model: sonnet
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-flight Questions
+
+Before generating copy, scripts, or long-form content, work through:
+
+1. What is the one thing the reader should do after reading this?
+2. Is the value front-loaded — would someone get something useful from the first paragraph alone?
+3. Is every section earning its place, or am I padding to fill a word count?
+4. Does the tone match the context — and am I matching it deliberately or defaulting?
+
 ## Output Formats
 
 ### Long-Form Script (YouTube, Podcast)

--- a/.agents/content/research.md
+++ b/.agents/content/research.md
@@ -28,6 +28,17 @@ Pre-writing research to validate niches, understand audiences, and analyse compe
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-flight Questions
+
+Before generating audience or market research, work through:
+
+1. What are the first principles here — what is actually true vs commonly assumed?
+2. What is the root cause, not the symptom?
+3. What biases could be distorting this — confirmation, anchoring, availability, survivorship?
+4. What is the evidence — and how reliable is the source?
+5. Are there physics, psychology, or reliability constraints that limit what's possible?
+6. What would disprove this conclusion?
+
 ## Workflow
 
 ### 1. Audience Research

--- a/.agents/content/story.md
+++ b/.agents/content/story.md
@@ -26,6 +26,15 @@ model: sonnet
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-flight Questions
+
+Before committing to a narrative angle or hook, work through:
+
+1. What is the theme — the universal truth this content explores?
+2. What is the single takeaway — what should the audience think, feel, or do differently?
+3. Does this tell a story — is there tension, transformation, and resolution?
+4. Who is the protagonist — the audience, a character, or the brand — and is that the right choice?
+
 ## 7 Hook Formulas
 
 Every piece of content starts with a hook. Use these formulas to generate variants:

--- a/.agents/health.md
+++ b/.agents/health.md
@@ -31,6 +31,16 @@ Always consult healthcare professionals for medical advice.
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-flight Questions
+
+Before generating health-related output, work through:
+
+1. What does the peer-reviewed evidence say? Cite studies, not opinions.
+2. What is the mechanism of action — can it be explained physiologically?
+3. What biases could be influencing this conclusion — confirmation, survivorship, selection, funding?
+4. What would a controlled experiment look like to test this claim?
+5. What are the risks of acting on this vs doing nothing — and for whom?
+
 ## Health Workflows
 
 ### Developer Wellness

--- a/.agents/legal.md
+++ b/.agents/legal.md
@@ -34,6 +34,16 @@ Always consult qualified legal professionals for binding advice.
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-flight Questions
+
+Before generating legal-adjacent output, work through:
+
+1. What does the actual law say — statute, regulation, case law? Cite it.
+2. What jurisdiction(s) apply, and where do they conflict or overlap?
+3. What are the consequences of getting this wrong — financial, criminal, reputational?
+4. What would a competent opposing counsel argue against this position?
+5. Is the proposed approach proportionate to the risk, or over/under-engineered?
+
 ## Legal Workflows
 
 ### Document Review

--- a/.agents/marketing.md
+++ b/.agents/marketing.md
@@ -78,6 +78,18 @@ subagents:
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-flight Questions
+
+Before generating marketing strategy or campaign output, work through:
+
+1. Is the offer valuable? What specific problem does it solve, and is that problem real and painful?
+2. What is unique about our solution — what do we offer that alternatives don't?
+3. What are the benefits (outcomes the buyer gets) before the features (how it works)?
+4. How does our pricing and value compare to alternatives — including doing nothing?
+5. How can we guarantee results or satisfaction — and are our claims realistic and provable?
+6. Who specifically are we addressing — named personas with real constraints, not demographics?
+7. What would make someone say "this isn't for me" — and is that the right person to lose?
+
 ## Email Marketing
 
 ### FluentCRM Setup

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -26,6 +26,12 @@ IMPORTANT: You must NEVER generate or guess URLs for the user unless you are con
 # Professional objectivity
 Prioritize technical accuracy and truthfulness over validating the user's beliefs. Focus on facts and problem-solving, providing direct, objective technical info without any unnecessary superlatives, praise, or emotional validation. Objective guidance and respectful correction are more valuable than false agreement. Whenever there is uncertainty, investigate to find the truth first rather than instinctively confirming the user's beliefs.
 
+# Critical thinking
+For all non-trivial output: Is this a good idea? Compared to what? At what cost? Based on
+what evidence? Evaluate whether action is necessary — doing nothing is a valid option.
+Ensure objective understanding, distinguish nuance, and consider unintended consequences
+or third-order effects. Weigh value against cost and effort before proceeding.
+
 # Task Management
 You have access to the TodoWrite tools to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
 These tools are also EXTREMELY helpful for planning tasks, and for breaking down larger complex tasks into smaller steps. If you do not use this tool when planning, you may forget to do important tasks - and that is unacceptable.

--- a/.agents/sales.md
+++ b/.agents/sales.md
@@ -77,6 +77,19 @@ subagents:
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-flight Questions
+
+Before generating sales strategy or prospect-facing output, work through:
+
+1. What is the hook — what gets attention in the first 5 seconds?
+2. What is the need — what problem does the prospect have, in their words?
+3. What is the desire — what outcome do they want, and how emotionally invested are they?
+4. What is the price positioning — how does cost relate to the value of the problem solved?
+5. Can they pay — budget, authority, and timing?
+6. What is the reason to buy now — what changes if they wait?
+7. How do we close — what is the specific next action?
+8. How do we consolidate — what happens after the sale to prevent buyer's remorse and generate referrals?
+
 ## CRM Integration
 
 ### FluentCRM Setup

--- a/.agents/seo/eeat-score.md
+++ b/.agents/seo/eeat-score.md
@@ -54,6 +54,17 @@ eeat-score-helper.sh report ~/Downloads/example.com/_latest/eeat-scores.json
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-flight Questions
+
+Before assessing or generating E-E-A-T content, work through:
+
+1. Are brand name, expert name, and credentials cited with verifiable sources?
+2. Are there quality backlinks from authoritative domains supporting the claims?
+3. Is NAP (name, address, phone) consistent across all mentions and structured data?
+4. What is the entity density — are key entities mentioned with appropriate frequency and semantic weight?
+5. Does this demonstrate first-hand experience, or just restate what already ranks?
+6. Would a domain expert cite this — or dismiss it as surface-level?
+
 ## Overview
 
 The E-E-A-T Score agent evaluates content quality using Google's E-E-A-T framework

--- a/.agents/youtube/script-writer.md
+++ b/.agents/youtube/script-writer.md
@@ -17,6 +17,15 @@ tools:
 
 Generate YouTube video scripts optimized for audience retention. Supports structured outlines, full scripts with pattern interrupts, hook generation, and remix mode (transform competitor videos into unique content).
 
+## Pre-flight Questions
+
+Before writing a video script, work through:
+
+1. What is the single takeaway — and does every section of the script serve it?
+2. Why would someone watch past 30 seconds — what tension or promise holds them?
+3. What does the viewer already know — where does this video meet them?
+4. What would make this indistinguishable from the last 10 videos on this topic — and how do we avoid that?
+
 ## When to Use
 
 Read this subagent when the user wants to:


### PR DESCRIPTION
## Summary

- Add a **critical thinking** section to `build.txt` that applies to all non-trivial output: *Is this a good idea? Compared to what? At what cost? Based on what evidence?*
- Add domain-specific **pre-flight questions** to 10 Tier 1 agents that produce subjective, advisory, or creative output

## Evidence

Tested via the response-scoring framework with 18 responses across 3 models (Sonnet, Opus, Gemini) and 3 task types (research, story, legal):

| Task | Sonnet | Opus | Gemini |
|------|--------|------|--------|
| Research | 4.00 → 4.50 (+0.50) | 4.50 → 5.00 (+0.50) | 4.20 → 4.55 (+0.35) |
| Story | 4.00 → 4.75 (+0.75) | 4.20 → 5.00 (+0.80) | 3.70 → 4.00 (+0.30) |
| Legal | 3.65 → 4.80 (+1.15) | 3.65 → 5.00 (+1.35) | 3.65 → 4.55 (+0.90) |

**Average improvement: +0.73 points on a 5-point scale.** Legal saw the largest gain because all models missed jurisdiction awareness and disclaimers without the pre-flight prompt.

## Files Changed (11)

- `build.txt` — Critical thinking directive (4 lines)
- `legal.md` — Law citation, jurisdiction, consequences, opposing arguments
- `health.md` — Peer-reviewed evidence, mechanisms, bias types, experiments
- `accounts.md` — Tax inspector perspective, substance vs form, audit trail
- `marketing.md` — Offer value, unique solution, benefits > features, provable claims
- `sales.md` — Hook, need, desire, price, ability to pay, close, consolidation
- `content/research.md` — First principles, root cause, bias, evidence reliability
- `content/story.md` — Theme, takeaway, story tension, protagonist choice
- `content/production/writing.md` — Reader action, front-loaded value, tone
- `youtube/script-writer.md` — Single takeaway, 30s retention, differentiation
- `seo/eeat-score.md` — Citations, backlinks, NAP consistency, entity density

## Design Decisions

- **build.txt** gets the general principle (applies to all models/tasks)
- **Subagents** get domain-specific questions (only loaded when that agent is read)
- **No change to AGENTS.md** — would be redundant since subagents carry their own questions
- **Tier 2/3 agents skipped** — objective/procedural tasks have automated verification instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pre-flight question checklists across multiple agent guides (Accounts, Content, Health, Legal, Marketing, Sales, SEO, and YouTube) to help users prepare before generating output.
  * Expanded SEO E-E-A-T scoring framework with comprehensive evaluation criteria and detailed methodology guidance.
  * Enhanced marketing documentation with operational setup and management guidance.
  * Added critical thinking evaluation framework to help assess output quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->