### PR TITLE
docs: add email testing cross-references

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -314,6 +314,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | Mobile/E2E | `tools/mobile/agent-device.md`, `tools/mobile/xcodebuild-mcp.md`, `tools/mobile/axe-cli.md`, `tools/mobile/maestro.md`, `tools/mobile/ios-simulator-mcp.md`, `tools/mobile/minisim.md` |
 | WordPress | `tools/wordpress/wp-dev.md`, `tools/wordpress/mainwp.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |
+| Email | `services/email/email-testing.md`, `services/email/email-health-check.md`, `email-test-suite-helper.sh`, `email-health-check-helper.sh` |
 | Content | `content.md` (orchestrator), `content/research.md`, `content/story.md`, `content/production/`, `content/distribution/`, `content/optimization.md` |
 | Video | `tools/video/video-prompt-design.md`, `tools/video/remotion.md`, `tools/video/higgsfield.md` |
 | YouTube | `content/distribution/youtube/` (migrated from root, see content.md) |

--- a/.agents/marketing.md
+++ b/.agents/marketing.md
@@ -179,6 +179,32 @@ fluentcrm_create_email_template with:
 - body: "<html>...</html>"
 ```
 
+### Email Testing
+
+Before sending campaigns, validate design rendering and deliverability:
+
+**Design Rendering Tests** (HTML validation, CSS compatibility, dark mode, responsive):
+
+```bash
+email-test-suite-helper.sh test-design newsletter.html
+email-test-suite-helper.sh check-dark-mode template.html
+email-test-suite-helper.sh check-responsive campaign.html
+```
+
+**Deliverability Health Check** (SPF, DKIM, DMARC, MX, blacklists):
+
+```bash
+email-health-check-helper.sh check example.com
+```
+
+**Inbox Placement Analysis** (comprehensive scoring):
+
+```bash
+email-test-suite-helper.sh check-placement example.com
+```
+
+See `services/email/email-testing.md` and `services/email/email-health-check.md` for full documentation.
+
 ## Marketing Automation
 
 ### Automation Triggers
@@ -431,6 +457,18 @@ After each campaign:
 - Use double opt-in
 - Monitor sender reputation
 - Authenticate with SPF, DKIM, DMARC
+
+**Testing deliverability:**
+
+```bash
+# Check DNS authentication
+email-health-check-helper.sh check your-domain.com
+
+# Test inbox placement factors
+email-test-suite-helper.sh check-placement your-domain.com
+```
+
+See `services/email/email-health-check.md` for detailed deliverability testing.
 
 ### List Hygiene
 

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -60,7 +60,7 @@ tools/containers/,Container runtimes - Docker and Linux VMs on macOS,orbstack
 tools/infrastructure/,Infrastructure - cloud GPU deployment and compute,cloud-gpu
 services/hosting/,Hosting providers - DNS and cloud servers,hostinger|hetzner|cloudflare|cloudflare-platform|cloudron|closte
 services/networking/,Networking - mesh VPN and secure device connectivity,tailscale
-services/email/,Email services - transactional email deliverability and testing,ses|email-health-check|email-testing
+services/email/,Email services - transactional email deliverability health checks and design/delivery testing,ses|email-health-check|email-testing
 services/communications/,Communications - SMS voice and Matrix bot dispatch,twilio|telfon|matrix-bot
 services/crm/,CRM integration - contact management,fluentcrm
 services/analytics/,Website analytics - GA4 reporting,google-analytics
@@ -119,8 +119,8 @@ pdf-helper.sh,PDF operations (info fields fill merge text)
 unstract-helper.sh,Unstract self-hosted document processing (install start stop)
 document-extraction-helper.sh,Document extraction with PII redaction (extract batch pii-scan pii-redact convert install status schemas)
 cloudron-package-helper.sh,Cloudron app packaging workflow (init scaffold build test)
-email-health-check-helper.sh,Email health check with scoring (SPF DKIM DMARC BIMI MTA-STS TLS-RPT DANE)
-email-test-suite-helper.sh,Email testing suite (design rendering delivery testing inbox placement)
+email-health-check-helper.sh,Email health check with scoring (SPF DKIM DMARC BIMI MTA-STS TLS-RPT DANE PTR blacklists)
+email-test-suite-helper.sh,Email testing suite (HTML validation CSS compatibility dark mode responsive design SMTP delivery inbox placement)
 yt-dlp-helper.sh,YouTube video/audio download and local file conversion
 privacy-filter-helper.sh,Privacy filter for public PR contributions
 self-improve-helper.sh,Self-improving agent system (analyze refine test pr)


### PR DESCRIPTION
## Summary

- Added Email domain to AGENTS.md progressive disclosure table
- Updated subagent-index.toon to detail email testing capabilities (HTML validation, CSS compatibility, dark mode, responsive design, SMTP, delivery, inbox placement)
- Added Email Testing section to marketing.md with practical examples
- Added deliverability testing commands to Best Practices section in marketing.md

## Changes

### AGENTS.md
- Added new row in Progressive disclosure table: `Email | services/email/email-testing.md, services/email/email-health-check.md, email-test-suite-helper.sh, email-health-check-helper.sh`

### subagent-index.toon
- Updated `services/email/` description to mention "health checks and design/delivery testing"
- Enhanced `email-health-check-helper.sh` description to include PTR and blacklists
- Enhanced `email-test-suite-helper.sh` description to detail all testing capabilities

### marketing.md
- Added "Email Testing" subsection after "Creating Templates" with examples for:
  - Design rendering tests (HTML, CSS, dark mode, responsive)
  - Deliverability health checks (SPF, DKIM, DMARC, MX, blacklists)
  - Inbox placement analysis
- Added deliverability testing commands to "Email Deliverability" best practices section
- Cross-referenced full documentation in `services/email/`

## Testing

- Verified TOON syntax structure is intact
- Checked git diff output for correctness
- All cross-references point to existing files

## Related

Closes #214 (t214.6)