### PR TITLE
feat: integrate email accessibility checks into email-health-check + email-design-test (t215.6)

### DIFF
--- a/.agents/scripts/commands/email-health-check.md
+++ b/.agents/scripts/commands/email-health-check.md
@@ -56,6 +56,7 @@ Actions:
 | `/email-health-check example.com spf` | SPF only |
 | `/email-health-check example.com dkim google` | DKIM with selector |
 | `/email-health-check example.com dmarc` | DMARC only |
+| `/email-health-check accessibility newsletter.html` | Email accessibility audit |
 
 ## Examples
 
@@ -97,8 +98,31 @@ AI: Checking DKIM for selector 'k1' on example.com...
     This is a Mailchimp DKIM selector.
 ```
 
+**Email accessibility check:**
+
+```text
+User: /email-health-check accessibility newsletter.html
+AI: Running email accessibility audit on newsletter.html...
+
+    Email Accessibility Report
+    Standard: WCAG 2.1 AA (email-applicable subset)
+
+    PASS: All images have alt attributes (5 images)
+    FAIL: Missing lang attribute on <html> tag
+    WARN: 3 table(s) without role attribute
+    PASS: No excessively small font sizes detected
+    PASS: No generic link text detected
+
+    Summary: 1 error(s), 1 warning(s)
+
+    Recommendations:
+    1. Add lang="en" to the <html> tag
+    2. Add role="presentation" to layout tables
+```
+
 ## Related
 
 - `services/email/email-health-check.md` - Full documentation
 - `services/email/ses.md` - Amazon SES integration
 - `services/hosting/dns.md` - DNS management
+- `tools/accessibility/accessibility.md` - WCAG accessibility reference

--- a/.agents/scripts/commands/email-test-suite.md
+++ b/.agents/scripts/commands/email-test-suite.md
@@ -63,8 +63,9 @@ Actions:
 
 | Command | Purpose |
 |---------|---------|
-| `/email-test-suite newsletter.html` | Design rendering tests |
+| `/email-test-suite newsletter.html` | Design rendering tests (includes accessibility) |
 | `/email-test-suite example.com` | Inbox placement analysis |
+| `/email-test-suite accessibility newsletter.html` | Email accessibility check only |
 | `/email-test-suite smtp mail.example.com 587` | SMTP connectivity test |
 | `/email-test-suite headers headers.txt` | Header analysis |
 | `/email-test-suite generate` | Generate test email template |
@@ -87,10 +88,16 @@ AI: Running design rendering tests on newsletter.html...
     2. Missing color-scheme meta for dark mode
     3. CSS animations not supported in most clients
 
+    Accessibility:
+    - PASS: All images have alt text
+    - WARN: 2 tables without role="presentation"
+    - PASS: lang attribute present
+
     Recommendations:
     1. Replace flexbox with table-based layout
     2. Add dark mode meta tags and media queries
     3. Remove CSS animations or use as progressive enhancement
+    4. Add role="presentation" to layout tables
 ```
 
 **Inbox placement check:**
@@ -121,3 +128,4 @@ AI: Checking inbox placement factors for example.com...
 - `services/email/email-testing.md` - Full documentation
 - `services/email/email-health-check.md` - DNS authentication checks
 - `services/email/ses.md` - Amazon SES integration
+- `tools/accessibility/accessibility.md` - WCAG accessibility reference

--- a/.agents/services/email/email-health-check.md
+++ b/.agents/services/email/email-health-check.md
@@ -35,6 +35,9 @@ email-health-check-helper.sh dkim example.com selector1
 email-health-check-helper.sh dmarc example.com
 email-health-check-helper.sh mx example.com
 email-health-check-helper.sh blacklist example.com
+
+# Email accessibility audit (WCAG 2.1)
+email-health-check-helper.sh accessibility newsletter.html
 ```
 
 <!-- AI-CONTEXT-END -->
@@ -342,9 +345,31 @@ email-health-check-helper.sh check example.com
 # Score: 12/15 (80%) - Grade: B
 ```
 
+## Email Accessibility
+
+The health check now includes an `accessibility` command for auditing HTML email templates against WCAG 2.1 AA (email-applicable subset):
+
+```bash
+email-health-check-helper.sh accessibility newsletter.html
+```
+
+This delegates to `accessibility-helper.sh email` and checks:
+
+- Images without `alt` attributes (WCAG 1.1.1)
+- Missing `lang` attribute on `<html>` (WCAG 3.1.1)
+- Layout tables without `role="presentation"` (WCAG 1.3.1)
+- Small font sizes below 12px (WCAG 1.4.4)
+- Generic link text like "click here" (WCAG 2.4.4)
+- Heading structure (WCAG 1.3.1)
+- Colour-only information indicators (WCAG 1.4.1)
+
+For contrast ratio checks, use: `accessibility-helper.sh contrast '#fg' '#bg'`
+
 ## Related
 
 - `services/email/email-testing.md` - Design rendering and delivery testing
 - `services/email/ses.md` - Amazon SES integration
 - `services/hosting/dns.md` - DNS management
+- `tools/accessibility/accessibility.md` - WCAG accessibility reference
+- `services/accessibility/accessibility-audit.md` - Full accessibility audit service
 - `tools/browser/browser-automation.md` - For mail-tester automation

--- a/.agents/services/email/email-testing.md
+++ b/.agents/services/email/email-testing.md
@@ -26,10 +26,11 @@ tools:
 **Quick commands:**
 
 ```bash
-# Design rendering tests
+# Design rendering tests (includes accessibility)
 email-test-suite-helper.sh test-design newsletter.html
 email-test-suite-helper.sh check-dark-mode template.html
 email-test-suite-helper.sh check-responsive campaign.html
+email-test-suite-helper.sh check-accessibility newsletter.html
 
 # Delivery testing
 email-test-suite-helper.sh test-smtp smtp.gmail.com 587
@@ -57,6 +58,7 @@ Validate that HTML emails render correctly across email clients:
 - **CSS Compatibility** - Detects unsupported CSS (flexbox, grid, position, float, animations) that break in Outlook/Gmail/Yahoo
 - **Dark Mode** - color-scheme meta, prefers-color-scheme queries, hardcoded colors, transparent PNGs
 - **Responsive Design** - Viewport meta, fixed widths, media queries, MSO conditionals, font sizes, touch targets
+- **Accessibility** - WCAG 2.1 AA checks: alt text, lang attribute, table roles, font sizes, link text, headings, colour usage
 
 ### 2. Delivery Testing
 
@@ -73,7 +75,7 @@ Validate email delivery infrastructure:
 ### Design Rendering
 
 ```bash
-# Full design test suite (all checks)
+# Full design test suite (all checks including accessibility)
 email-test-suite-helper.sh test-design newsletter.html
 
 # Individual checks
@@ -81,6 +83,7 @@ email-test-suite-helper.sh validate-html newsletter.html
 email-test-suite-helper.sh check-css newsletter.html
 email-test-suite-helper.sh check-dark-mode newsletter.html
 email-test-suite-helper.sh check-responsive newsletter.html
+email-test-suite-helper.sh check-accessibility newsletter.html
 
 # Generate a test email template
 email-test-suite-helper.sh generate-test-email test.html
@@ -188,7 +191,7 @@ The email test suite complements `email-health-check-helper.sh`:
 # 1. Check DNS authentication
 email-health-check-helper.sh check example.com
 
-# 2. Test design rendering
+# 2. Test design rendering (includes accessibility)
 email-test-suite-helper.sh test-design newsletter.html
 
 # 3. Check delivery infrastructure
@@ -196,6 +199,9 @@ email-test-suite-helper.sh check-placement example.com
 
 # 4. Test SMTP connectivity
 email-test-suite-helper.sh test-smtp-domain example.com
+
+# 5. Standalone accessibility audit (if needed)
+email-health-check-helper.sh accessibility newsletter.html
 ```
 
 ## External Testing Services
@@ -217,4 +223,6 @@ For visual rendering tests across real email clients:
 - `services/email/email-health-check.md` - DNS authentication checks
 - `services/email/ses.md` - Amazon SES integration
 - `content/distribution/email.md` - Email content strategy
+- `tools/accessibility/accessibility.md` - WCAG accessibility reference
+- `services/accessibility/accessibility-audit.md` - Full accessibility audit service
 - `tools/browser/browser-automation.md` - For automated rendering tests


### PR DESCRIPTION
## Summary

- Adds WCAG 2.1 AA email accessibility auditing to `email-health-check-helper.sh` (new `accessibility` command) and `email-test-suite-helper.sh` (new `check-accessibility` command + integrated into `test-design` flow)
- Delegates to existing `accessibility-helper.sh email` for consistency; includes inline fallback checks for resilience when the helper is unavailable
- Updates all 4 related documentation files (command docs + service docs) with accessibility options, examples, and cross-references

## Changes

### Scripts
- **`email-health-check-helper.sh`**: Added `check_email_accessibility()` function and `accessibility|a11y` command in main case. Updated help text and "Next Steps" output to reference accessibility.
- **`email-test-suite-helper.sh`**: Added `check_accessibility()` function with full inline fallback (7 WCAG checks: alt text, lang, table roles, font sizes, link text, headings, colour indicators). Integrated into `test_design()` flow. Added `check-accessibility|accessibility|a11y` command.

### Documentation
- **`commands/email-health-check.md`**: Added accessibility command to options table and example output
- **`commands/email-test-suite.md`**: Added accessibility to options table and design rendering example output
- **`services/email/email-health-check.md`**: Added "Email Accessibility" section with usage and WCAG criteria list
- **`services/email/email-testing.md`**: Updated quick commands, feature list, design rendering usage, recommended workflow, and related links

## Verification
- ShellCheck: zero violations on both scripts
- Bash syntax check: both scripts pass `bash -n`

## Task
Closes t215.6