### PR TITLE
feat: add WAVE API integration for comprehensive accessibility analysis (t215.4)

### DIFF
--- a/.agents/services/accessibility/accessibility-audit.md
+++ b/.agents/services/accessibility/accessibility-audit.md
@@ -27,8 +27,14 @@ tools:
 **Quick commands:**
 
 ```bash
-# Full web audit (Lighthouse + pa11y, desktop + mobile)
+# Full web audit (Lighthouse + pa11y + WAVE, desktop + mobile)
 accessibility-helper.sh audit https://example.com
+
+# WAVE API only (comprehensive, CSS/JS-rendered analysis)
+accessibility-helper.sh wave https://example.com
+
+# WAVE with XPath locations for precise element identification
+accessibility-helper.sh wave https://example.com 3
 
 # Email HTML accessibility check
 accessibility-helper.sh email ./newsletter.html
@@ -48,10 +54,10 @@ This agent orchestrates accessibility auditing across web and email channels. It
 
 | Channel | Tools | Coverage |
 |---------|-------|----------|
-| **Web (desktop)** | Lighthouse, pa11y | axe-core engine + HTML_CodeSniffer |
-| **Web (mobile)** | Lighthouse mobile, pa11y | Touch targets, viewport, zoom |
+| **Web (desktop)** | Lighthouse, pa11y, WAVE API | axe-core + HTML_CodeSniffer + WAVE engine |
+| **Web (mobile)** | Lighthouse mobile, pa11y, WAVE API (375px) | Touch targets, viewport, zoom |
 | **HTML email** | Built-in static analysis | Email-specific WCAG subset |
-| **Colour** | Built-in contrast calculator | WCAG AA + AAA ratios |
+| **Colour** | Built-in contrast calculator, WAVE contrast data | WCAG AA + AAA ratios |
 
 ## Audit Workflow
 
@@ -244,12 +250,16 @@ accessibility-helper.sh pa11y https://staging.example.com WCAG2AA
 |----------|------|---------|
 | Quick score check | Lighthouse | `accessibility-helper.sh lighthouse <url>` |
 | WCAG compliance audit | pa11y | `accessibility-helper.sh pa11y <url> WCAG2AA` |
-| Full web audit | Both | `accessibility-helper.sh audit <url>` |
+| Comprehensive analysis | WAVE API | `accessibility-helper.sh wave <url>` |
+| Element-level issues | WAVE API (type 3/4) | `accessibility-helper.sh wave <url> 3` |
+| Mobile accessibility | WAVE API | `accessibility-helper.sh wave-mobile <url>` |
+| Full web audit | All tools | `accessibility-helper.sh audit <url>` |
 | Email template check | Built-in | `accessibility-helper.sh email <file>` |
 | Colour pair validation | Built-in | `accessibility-helper.sh contrast <fg> <bg>` |
 | Multi-site monitoring | Bulk | `accessibility-helper.sh bulk <urls-file>` |
 | Dynamic SPA content | Playwright | Use `playwright` for JS-rendered pages |
 | Real device rendering | Browser tools | `pagespeed-helper.sh` or Litmus/Email on Acid |
+| Item documentation | WAVE docs | `accessibility-helper.sh wave-docs <item-id>` |
 
 ## Integration with Other Services
 

--- a/.agents/tools/accessibility/accessibility.md
+++ b/.agents/tools/accessibility/accessibility.md
@@ -19,11 +19,11 @@ tools:
 ## Quick Reference
 
 - **Helper**: `.agents/scripts/accessibility-helper.sh`
-- **Commands**: `audit [url]` | `lighthouse [url]` | `pa11y [url]` | `email [file]` | `contrast [fg] [bg]` | `bulk [file]`
+- **Commands**: `audit [url]` | `lighthouse [url]` | `pa11y [url]` | `wave [url]` | `email [file]` | `contrast [fg] [bg]` | `bulk [file]`
 - **Install**: `npm install -g lighthouse pa11y` or `.agents/scripts/accessibility-helper.sh install-deps`
 - **Standards**: WCAG 2.1 Level A, AA (default), AAA
 - **Reports**: `~/.aidevops/reports/accessibility/`
-- **Tools**: Lighthouse (accessibility category), pa11y (WCAG runner), built-in contrast calculator, email HTML checker
+- **Tools**: Lighthouse (accessibility category), pa11y (WCAG runner), WAVE API (comprehensive analysis), built-in contrast calculator, email HTML checker
 
 <!-- AI-CONTEXT-END -->
 
@@ -35,6 +35,7 @@ Comprehensive WCAG compliance testing for websites and HTML emails. Combines mul
 |------|---------|-------|-------|
 | **Lighthouse** | Accessibility score + audit failures | ~15s | Broad (axe-core engine) |
 | **pa11y** | WCAG-specific violation reporting | ~10s | Deep (HTML_CodeSniffer) |
+| **WAVE API** | Comprehensive accessibility analysis | ~2-5s | Deep (WAVE engine, CSS/JS-rendered) |
 | **Email checker** | HTML email accessibility (static analysis) | <1s | Email-specific rules |
 | **Contrast calculator** | WCAG contrast ratio for color pairs | Instant | AA + AAA levels |
 
@@ -94,6 +95,51 @@ Standards-based testing with HTML_CodeSniffer:
 ```
 
 Reports categorise issues as errors (must fix), warnings (should fix), and notices (advisory).
+
+### WAVE API Analysis
+
+Comprehensive accessibility analysis using the WAVE engine. Evaluates pages after CSS and JavaScript rendering for accurate results. Requires an API key (register at https://wave.webaim.org/api/register).
+
+```bash
+# Basic WAVE audit (report type 2 — item details, 2 credits)
+.agents/scripts/accessibility-helper.sh wave https://example.com
+
+# Detailed with XPath locations (report type 3, 3 credits)
+.agents/scripts/accessibility-helper.sh wave https://example.com 3
+
+# Detailed with CSS selectors (report type 4, 3 credits)
+.agents/scripts/accessibility-helper.sh wave https://example.com 4
+
+# Mobile viewport (375px)
+.agents/scripts/accessibility-helper.sh wave-mobile https://example.com
+
+# Look up a specific WAVE item
+.agents/scripts/accessibility-helper.sh wave-docs alt_missing
+
+# Check remaining API credits
+.agents/scripts/accessibility-helper.sh wave-credits
+```
+
+**Report types:**
+
+| Type | Cost | Data |
+|------|------|------|
+| 1 | 1 credit | Category counts only (errors, alerts, features, etc.) |
+| 2 | 2 credits | Category counts + item details (default) |
+| 3 | 3 credits | All above + XPath locations + contrast data |
+| 4 | 3 credits | All above + CSS selector locations + contrast data |
+
+**API key setup:**
+
+```bash
+# Encrypted (recommended)
+aidevops secret set wave-api-key
+
+# Or environment variable
+export WAVE_API_KEY="your-key-here"
+```
+
+WAVE categories: errors (must fix), contrast errors, alerts (should review), features (positive), structural elements, ARIA usage.
 
 ### Email HTML Accessibility
 
@@ -192,6 +238,7 @@ HTML emails have unique constraints because email clients strip most CSS and Jav
 
 | Tool | Integration |
 |------|-------------|
+| **WAVE API** | Comprehensive analysis with CSS/JS rendering, contrast data, XPath/CSS selectors |
 | **PageSpeed** | `pagespeed-helper.sh` includes Lighthouse accessibility score |
 | **Playwright** | Use for dynamic content testing (SPA accessibility) |
 | **Chrome DevTools MCP** | Real-time accessibility tree inspection |
@@ -202,6 +249,7 @@ HTML emails have unique constraints because email clients strip most CSS and Jav
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `A11Y_WCAG_LEVEL` | `WCAG2AA` | Default WCAG standard for pa11y |
+| `WAVE_API_KEY` | — | WAVE API key (or use `aidevops secret set wave-api-key`) |
 
 ## Report Storage
 
@@ -209,6 +257,7 @@ All reports are saved to `~/.aidevops/reports/accessibility/`:
 
 - `lighthouse_a11y_YYYYMMDD_HHMMSS.json` — Lighthouse accessibility audit
 - `pa11y_YYYYMMDD_HHMMSS.json` — pa11y WCAG violations
+- `wave_YYYYMMDD_HHMMSS.json` — WAVE API analysis results
 - `email_a11y_YYYYMMDD_HHMMSS.txt` — Email HTML check results
 
 ## Related


### PR DESCRIPTION
## Summary

- Integrate WAVE API v3.1 into `accessibility-helper.sh` with 4 new commands: `wave`, `wave-mobile`, `wave-docs`, `wave-credits`
- Support all 4 WAVE report types (stats, items, items+xpath, items+selectors) with configurable viewport width
- Secure API key loading via gopass (encrypted), environment variable, or credentials.sh fallback
- WAVE automatically included in full `audit` command when API key is available; gracefully skipped otherwise

## Changes

### `accessibility-helper.sh` (+357 lines)
- `load_wave_api_key()` — secure credential loading (gopass > env > credentials.sh)
- `run_wave_audit()` — core WAVE API integration with URL encoding, error handling, report parsing
- `parse_wave_report()` — formatted output with colour-coded categories, item details, contrast data
- `run_wave_mobile()` — mobile viewport (375px) convenience wrapper
- `wave_docs()` — query WAVE documentation API for item details (free, no API key needed)
- `wave_credits()` — check remaining API credits
- Updated `run_full_audit()` to include WAVE when API key available
- Updated help text with all new commands and examples

### `accessibility.md` (tool reference)
- Added WAVE API to tool overview table
- New "WAVE API Analysis" section with usage, report types, API key setup
- Updated environment variables and report storage sections

### `accessibility-audit.md` (service agent)
- Updated channel/tools table to include WAVE API
- Added WAVE commands to quick reference
- Updated tool selection guide with WAVE scenarios

## Testing
- ShellCheck: zero violations
- Syntax check: `bash -n` passes
- Help output: verified all new commands appear
- `wave-docs` command: verified against live WAVE documentation API
- Error handling: verified graceful failure when API key is missing

## Task
Closes t215.4 — WAVE API integration for comprehensive accessibility analysis
ref:GH#907