### PR TITLE
feat(accessibility): update AGENTS.md and cross-references for accessibility

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -306,7 +306,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | Domain | Read |
 |--------|------|
 | Planning | `workflows/plans.md`, `tools/task-management/beads.md` |
-| Accessibility | `tools/accessibility/accessibility.md`, `accessibility-helper.sh` |
+| Accessibility | `services/accessibility/accessibility-audit.md`, `tools/accessibility/accessibility.md`, `accessibility-helper.sh` |
 | Code quality | `tools/code-review/code-standards.md` |
 | Git/PRs | `workflows/git-workflow.md`, `tools/git/github-cli.md`, `tools/git/conflict-resolution.md`, `tools/git/lumen.md` |
 | Releases | `workflows/release.md`, `workflows/version-bump.md` |

--- a/.agents/content/distribution/email.md
+++ b/.agents/content/distribution/email.md
@@ -255,6 +255,12 @@ Tag subscribers based on:
 - `marketing.md` - Marketing orchestrator with FluentCRM integration
 - `services/crm/fluentcrm.md` - CRM operations and automation
 
+**Email Services**:
+
+- `services/accessibility/accessibility-audit.md` - Email accessibility checks (WCAG compliance)
+- `services/email/email-health-check.md` - DNS authentication and deliverability
+- `services/email/email-testing.md` - Design rendering and delivery testing
+
 **Distribution Channels**:
 
 - `content/distribution/youtube/` - Long-form YouTube content

--- a/.agents/marketing.md
+++ b/.agents/marketing.md
@@ -476,7 +476,8 @@ After each campaign:
 | High unsubscribes | Review frequency, improve targeting |
 | Bounces | Clean list, validate emails |
 | Spam complaints | Better consent, relevant content |
-| Template rendering | Test across email clients |
+| Template rendering | Use `services/email/email-testing.md` for cross-client testing |
+| Accessibility issues | Use `services/accessibility/accessibility-audit.md` for WCAG compliance |
 
 ### Getting Help
 

--- a/.agents/services/email/email-health-check.md
+++ b/.agents/services/email/email-health-check.md
@@ -462,6 +462,7 @@ email-health-check-helper.sh precheck example.com newsletter.html
 
 ## Related
 
+- `services/accessibility/accessibility-audit.md` - Email accessibility checks (WCAG compliance)
 - `services/email/email-testing.md` - Design rendering and delivery testing
 - `services/email/ses.md` - Amazon SES integration
 - `services/hosting/dns.md` - DNS management

--- a/.agents/services/email/email-testing.md
+++ b/.agents/services/email/email-testing.md
@@ -215,6 +215,7 @@ For visual rendering tests across real email clients:
 ## Related
 
 - `services/email/email-design-test.md` - Local Playwright rendering + Email on Acid API integration
+- `services/accessibility/accessibility-audit.md` - Email accessibility checks (WCAG compliance)
 - `services/email/email-health-check.md` - DNS authentication checks
 - `services/email/ses.md` - Amazon SES integration
 - `content/distribution/email.md` - Email content strategy

--- a/.agents/tools/browser/pagespeed.md
+++ b/.agents/tools/browser/pagespeed.md
@@ -297,6 +297,7 @@ lighthouse https://example.com \
 - **[WCAG 2.1 Guidelines](https://www.w3.org/TR/WCAG21/)**
 - **[WordPress Performance Guide](https://wordpress.org/support/article/optimization/)**
 - `tools/accessibility/accessibility.md` — Dedicated accessibility subagent (pa11y, contrast, email)
+- `services/accessibility/accessibility-audit.md` — Lighthouse accessibility category is included in performance audits
 
 ## MCP Integration
 


### PR DESCRIPTION
## Summary

Updates AGENTS.md and cross-references for the new accessibility audit service (t215.7).

## Changes

1. **AGENTS.md**: Added `services/accessibility/accessibility-audit.md` to the Accessibility row in the progressive disclosure table
2. **pagespeed.md**: Added reference to accessibility audit service in Related Resources section
3. **email-health-check.md**: Added accessibility audit reference in Related section
4. **email-testing.md**: Added accessibility audit reference in Related section
5. **content/distribution/email.md**: Added new "Email Services" section with accessibility, health check, and testing references
6. **marketing.md**: Updated troubleshooting table to reference specific agents for template rendering and accessibility

## Verification

- ✅ All markdown files pass markdownlint-cli2 with 0 errors
- ✅ Cross-references point to correct file paths
- ✅ Follows existing documentation patterns

## Related

- Closes #910 (t215.7)
- Part of t215 (Accessibility & contrast testing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added accessibility audit documentation references across multiple service guides.
  * Expanded email services documentation to include health checks and testing resources.
  * Enhanced troubleshooting sections with accessibility compliance and email testing guidance.
  * Improved cross-references between related service documentation for easier navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->