### PR TITLE
feat: add WAVE API integration for comprehensive accessibility analysis (t215.4)

### DIFF
--- a/.agents/scripts/accessibility-helper.sh
+++ b/.agents/scripts/accessibility-helper.sh
@@ -146,7 +146,7 @@ run_wave_audit() {
     local report_file="${A11Y_REPORTS_DIR}/wave_${timestamp}.json"
 
     local encoded_url
-    encoded_url=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$url', safe=''))" 2>/dev/null || echo "$url")
+    encoded_url=$(python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=''))" "$url" 2>/dev/null || echo "$url")
 
     local api_url="${WAVE_API_ENDPOINT}?key=${WAVE_API_KEY}&url=${encoded_url}&reporttype=${report_type}&viewportwidth=${viewport_width}&format=json"
 

--- a/.agents/scripts/accessibility-helper.sh
+++ b/.agents/scripts/accessibility-helper.sh
@@ -3,7 +3,7 @@
 
 # Accessibility & Contrast Testing Helper Script
 # WCAG compliance auditing for websites and HTML emails
-# Uses: Lighthouse (accessibility category), pa11y (WCAG runner), contrast checks
+# Uses: Lighthouse (accessibility category), pa11y (WCAG runner), WAVE API, contrast checks
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
@@ -15,6 +15,9 @@ init_log_file
 # Configuration
 readonly A11Y_REPORTS_DIR="$HOME/.aidevops/reports/accessibility"
 readonly A11Y_WCAG_LEVEL="${A11Y_WCAG_LEVEL:-WCAG2AA}"
+readonly WAVE_API_ENDPOINT="https://wave.webaim.org/api/request"
+readonly WAVE_DOCS_ENDPOINT="https://wave.webaim.org/api/docs"
+# Note: WAVE API limits to 2 simultaneous requests per account
 
 # Ensure reports directory exists
 mkdir -p "$A11Y_REPORTS_DIR"
@@ -80,6 +83,311 @@ install_deps() {
     fi
 
     print_success "Dependencies installed"
+    return 0
+}
+
+# ============================================================================
+# WAVE API Integration
+# ============================================================================
+
+# Load WAVE API key from gopass or credentials file
+load_wave_api_key() {
+    # Already set via environment
+    if [[ -n "${WAVE_API_KEY:-}" ]]; then
+        return 0
+    fi
+
+    # Try gopass (encrypted, preferred)
+    if command -v gopass &> /dev/null; then
+        WAVE_API_KEY=$(gopass show -o "aidevops/wave-api-key" 2>/dev/null || echo "")
+        if [[ -n "$WAVE_API_KEY" ]]; then
+            export WAVE_API_KEY
+            return 0
+        fi
+    fi
+
+    # Try credentials file (plaintext fallback)
+    local creds_file="$HOME/.config/aidevops/credentials.sh"
+    if [[ -f "$creds_file" ]]; then
+        # shellcheck source=/dev/null
+        source "$creds_file"
+        if [[ -n "${WAVE_API_KEY:-}" ]]; then
+            export WAVE_API_KEY
+            return 0
+        fi
+    fi
+
+    print_error "WAVE API key not found"
+    print_info "Set via: aidevops secret set wave-api-key"
+    print_info "Or set WAVE_API_KEY environment variable"
+    print_info "Register at: https://wave.webaim.org/api/register"
+    return 1
+}
+
+# Run WAVE API audit on a URL
+# Arguments:
+#   $1 - URL to audit (required)
+#   $2 - report type: 1=stats, 2=items, 3=items+xpath, 4=items+selectors (default: 2)
+#   $3 - viewport width (default: 1200)
+run_wave_audit() {
+    local url="$1"
+    local report_type="${2:-2}"
+    local viewport_width="${3:-1200}"
+
+    load_wave_api_key || return 1
+    check_jq || return 1
+
+    print_info "Running WAVE API audit..."
+    print_info "URL: $url"
+    print_info "Report type: $report_type (1=stats, 2=items, 3=xpath, 4=selectors)"
+
+    local timestamp
+    timestamp=$(date +"%Y%m%d_%H%M%S")
+    local report_file="${A11Y_REPORTS_DIR}/wave_${timestamp}.json"
+
+    local encoded_url
+    encoded_url=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$url', safe=''))" 2>/dev/null || echo "$url")
+
+    local api_url="${WAVE_API_ENDPOINT}?key=${WAVE_API_KEY}&url=${encoded_url}&reporttype=${report_type}&viewportwidth=${viewport_width}&format=json"
+
+    local http_code
+    http_code=$(curl -s -w "%{http_code}" -o "$report_file" \
+        --max-time "$LONG_TIMEOUT" \
+        "$api_url" 2>/dev/null) || {
+        print_error "WAVE API request failed (network error)"
+        return 1
+    }
+
+    if [[ "$http_code" -ne 200 ]]; then
+        print_error "WAVE API returned HTTP $http_code"
+        rm -f "$report_file" 2>/dev/null || true
+        return 1
+    fi
+
+    # Check API-level success
+    local api_success
+    api_success=$(jq -r '.status.success // false' "$report_file" 2>/dev/null || echo "false")
+    if [[ "$api_success" != "true" ]]; then
+        local api_error
+        api_error=$(jq -r '.status.error // "Unknown error"' "$report_file" 2>/dev/null || echo "Unknown error")
+        print_error "WAVE API error: $api_error"
+        return 1
+    fi
+
+    print_success "Report saved: $report_file"
+    parse_wave_report "$report_file" "$report_type"
+    return 0
+}
+
+# Parse and display WAVE API report
+parse_wave_report() {
+    local report_file="$1"
+    local report_type="${2:-2}"
+
+    echo ""
+    print_header_line "WAVE API Results"
+
+    # Statistics
+    local page_title page_url total_elements aim_score credits_remaining wave_url
+    page_title=$(jq -r '.statistics.pagetitle // "N/A"' "$report_file")
+    page_url=$(jq -r '.statistics.pageurl // "N/A"' "$report_file")
+    total_elements=$(jq -r '.statistics.totalelements // "N/A"' "$report_file")
+    aim_score=$(jq -r '.statistics.AIMscore // "N/A"' "$report_file")
+    credits_remaining=$(jq -r '.statistics.creditsremaining // "N/A"' "$report_file")
+    wave_url=$(jq -r '.statistics.waveurl // "N/A"' "$report_file")
+
+    echo "  Page: $page_title"
+    echo "  URL: $page_url"
+    echo "  Elements: $total_elements"
+    if [[ "$aim_score" != "N/A" ]]; then
+        echo "  AIM Score: $aim_score"
+    fi
+    echo "  Credits remaining: $credits_remaining"
+    echo ""
+
+    # Category counts
+    print_header_line "Category Summary"
+
+    local errors contrasts alerts features structures arias
+    errors=$(jq -r '.categories.error.count // 0' "$report_file")
+    contrasts=$(jq -r '.categories.contrast.count // 0' "$report_file")
+    alerts=$(jq -r '.categories.alert.count // 0' "$report_file")
+    features=$(jq -r '.categories.feature.count // 0' "$report_file")
+    structures=$(jq -r '.categories.structure.count // 0' "$report_file")
+    arias=$(jq -r '.categories.aria.count // 0' "$report_file")
+
+    if [[ "$errors" -gt 0 ]]; then
+        echo -e "  Errors:     ${RED}${errors}${NC}"
+    else
+        echo -e "  Errors:     ${GREEN}0${NC}"
+    fi
+
+    if [[ "$contrasts" -gt 0 ]]; then
+        echo -e "  Contrast:   ${RED}${contrasts}${NC}"
+    else
+        echo -e "  Contrast:   ${GREEN}0${NC}"
+    fi
+
+    if [[ "$alerts" -gt 0 ]]; then
+        echo -e "  Alerts:     ${YELLOW}${alerts}${NC}"
+    else
+        echo -e "  Alerts:     ${GREEN}0${NC}"
+    fi
+
+    echo "  Features:   $features"
+    echo "  Structure:  $structures"
+    echo "  ARIA:       $arias"
+    echo ""
+
+    # Item details (reporttype >= 2)
+    if [[ "$report_type" -ge 2 ]]; then
+        # Errors
+        if [[ "$errors" -gt 0 ]]; then
+            print_header_line "Errors (must fix)"
+            jq -r '
+                .categories.error.items // {} | to_entries[]
+                | "  \(.value.id): \(.value.description) (x\(.value.count))"
+            ' "$report_file" 2>/dev/null || true
+            echo ""
+        fi
+
+        # Contrast errors
+        if [[ "$contrasts" -gt 0 ]]; then
+            print_header_line "Contrast Errors"
+            jq -r '
+                .categories.contrast.items // {} | to_entries[]
+                | "  \(.value.id): \(.value.description) (x\(.value.count))"
+            ' "$report_file" 2>/dev/null || true
+
+            # Show contrast data if available (reporttype 3 or 4)
+            if [[ "$report_type" -ge 3 ]]; then
+                local contrast_data
+                contrast_data=$(jq -r '
+                    .categories.contrast.items.contrast.contrastdata // [] | .[]
+                    | "    Ratio: \(.[0]):1 | FG: \(.[1]) | BG: \(.[2]) | Large: \(.[3])"
+                ' "$report_file" 2>/dev/null || echo "")
+                if [[ -n "$contrast_data" ]]; then
+                    echo "$contrast_data"
+                fi
+            fi
+            echo ""
+        fi
+
+        # Alerts
+        if [[ "$alerts" -gt 0 ]]; then
+            print_header_line "Alerts (should review)"
+            jq -r '
+                .categories.alert.items // {} | to_entries[]
+                | "  \(.value.id): \(.value.description) (x\(.value.count))"
+            ' "$report_file" 2>/dev/null || true
+            echo ""
+        fi
+    fi
+
+    # Full WAVE report link
+    if [[ "$wave_url" != "N/A" ]]; then
+        print_info "Full WAVE report: $wave_url"
+    fi
+
+    echo ""
+    return 0
+}
+
+# Run WAVE audit at mobile viewport width
+run_wave_mobile() {
+    local url="$1"
+    local report_type="${2:-2}"
+
+    print_info "Running WAVE API audit (mobile viewport)..."
+    run_wave_audit "$url" "$report_type" "375"
+    return $?
+}
+
+# Query WAVE documentation for a specific item
+wave_docs() {
+    local item_id="${1:-}"
+
+    check_jq || return 1
+
+    if [[ -z "$item_id" ]]; then
+        print_error "Please provide a WAVE item ID"
+        print_info "Usage: $0 wave-docs <item-id>"
+        print_info "Example: $0 wave-docs alt_missing"
+        return 1
+    fi
+
+    local docs_url="${WAVE_DOCS_ENDPOINT}?id=${item_id}"
+    local result
+    result=$(curl -s --max-time "$DEFAULT_TIMEOUT" "$docs_url" 2>/dev/null) || {
+        print_error "Failed to fetch WAVE documentation"
+        return 1
+    }
+
+    echo ""
+    print_header_line "WAVE Documentation: $item_id"
+
+    local title type summary purpose actions details
+    title=$(echo "$result" | jq -r '.title // "N/A"')
+    type=$(echo "$result" | jq -r '.type // "N/A"')
+    summary=$(echo "$result" | jq -r '.summary // "N/A"')
+    purpose=$(echo "$result" | jq -r '.purpose // "N/A"')
+    actions=$(echo "$result" | jq -r '.actions // "N/A"')
+    details=$(echo "$result" | jq -r '.details // "N/A"')
+
+    echo "  Title: $title"
+    echo "  Type: $type"
+    echo "  Summary: $summary"
+    echo ""
+    echo "  Purpose: $purpose"
+    echo ""
+    echo "  Actions: $actions"
+    echo ""
+    echo "  Algorithm: $details"
+    echo ""
+
+    # WCAG guidelines
+    local guidelines
+    guidelines=$(echo "$result" | jq -r '
+        .guidelines // [] | .[]
+        | "  - \(.name)"
+    ' 2>/dev/null || echo "")
+    if [[ -n "$guidelines" ]]; then
+        print_header_line "WCAG Guidelines"
+        echo "$guidelines"
+    fi
+
+    echo ""
+    return 0
+}
+
+# Check WAVE API credits remaining
+wave_credits() {
+    load_wave_api_key || return 1
+    check_jq || return 1
+
+    # Use a lightweight request (reporttype=1, 1 credit) against a known URL
+    print_info "Checking WAVE API credits..."
+
+    local result
+    result=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+        "${WAVE_API_ENDPOINT}?key=${WAVE_API_KEY}&url=https://example.com&reporttype=1" \
+        2>/dev/null) || {
+        print_error "Failed to reach WAVE API"
+        return 1
+    }
+
+    local success
+    success=$(echo "$result" | jq -r '.status.success // false')
+    if [[ "$success" != "true" ]]; then
+        local error_msg
+        error_msg=$(echo "$result" | jq -r '.status.error // "Unknown error"')
+        print_error "WAVE API error: $error_msg"
+        return 1
+    fi
+
+    local credits
+    credits=$(echo "$result" | jq -r '.statistics.creditsremaining // "N/A"')
+    print_success "WAVE API credits remaining: $credits"
     return 0
 }
 
@@ -540,7 +848,7 @@ check_contrast() {
 }
 
 # ============================================================================
-# Full Audit (Lighthouse + pa11y combined)
+# Full Audit (Lighthouse + pa11y + WAVE combined)
 # ============================================================================
 
 run_full_audit() {
@@ -565,6 +873,15 @@ run_full_audit() {
         run_pa11y_audit "$url" "$A11Y_WCAG_LEVEL" || exit_code=1
     else
         print_warning "Skipping pa11y (not installed). Install: npm install -g pa11y"
+    fi
+
+    echo ""
+
+    # WAVE API (if key is available)
+    if load_wave_api_key 2>/dev/null; then
+        run_wave_audit "$url" "2" || exit_code=1
+    else
+        print_warning "Skipping WAVE API (no API key). Set via: aidevops secret set wave-api-key"
     fi
 
     echo ""
@@ -785,6 +1102,29 @@ main() {
             fi
             run_playwright_contrast "$account_name" "${3:-summary}" "${4:-AA}"
             ;;
+        "wave")
+            if [[ -z "$account_name" ]]; then
+                print_error "Please provide a URL"
+                print_info "Usage: $0 wave <url> [reporttype] [viewport-width]"
+                print_info "Report types: 1=stats, 2=items (default), 3=items+xpath, 4=items+selectors"
+                return 1
+            fi
+            run_wave_audit "$account_name" "${3:-2}" "${4:-1200}"
+            ;;
+        "wave-mobile")
+            if [[ -z "$account_name" ]]; then
+                print_error "Please provide a URL"
+                print_info "Usage: $0 wave-mobile <url> [reporttype]"
+                return 1
+            fi
+            run_wave_mobile "$account_name" "${3:-2}"
+            ;;
+        "wave-docs")
+            wave_docs "$account_name"
+            ;;
+        "wave-credits")
+            wave_credits
+            ;;
         "bulk")
             if [[ -z "$account_name" ]]; then
                 print_error "Please provide a file containing URLs"
@@ -801,9 +1141,13 @@ main() {
             echo "Usage: $0 [command] [options]"
             echo ""
             echo "Commands:"
-            echo "  audit <url>                    Full accessibility audit (Lighthouse + pa11y)"
+            echo "  audit <url>                    Full accessibility audit (Lighthouse + pa11y + WAVE)"
             echo "  lighthouse <url> [strategy]    Lighthouse accessibility-only audit"
             echo "  pa11y <url> [standard]         pa11y WCAG compliance test"
+            echo "  wave <url> [type] [width]      WAVE API accessibility analysis"
+            echo "  wave-mobile <url> [type]       WAVE API audit at mobile viewport (375px)"
+            echo "  wave-docs <item-id>            Look up WAVE item documentation"
+            echo "  wave-credits                   Check WAVE API credits remaining"
             echo "  email <file.html>              Check HTML email accessibility"
             echo "  contrast <fg-hex> <bg-hex>     Calculate WCAG contrast ratio"
             echo "  playwright-contrast <url> [fmt] [level]"
@@ -814,16 +1158,23 @@ main() {
             echo "  install-deps                   Install required dependencies"
             echo "  help                           Show this help"
             echo ""
+            echo "WAVE Report Types: 1=stats (1 credit), 2=items (2 credits),"
+            echo "  3=items+xpath (3 credits), 4=items+selectors (3 credits)"
+            echo ""
             echo "Standards: WCAG2A, WCAG2AA (default), WCAG2AAA"
             echo "Strategies: desktop (default), mobile"
             echo ""
             echo "Environment Variables:"
             echo "  A11Y_WCAG_LEVEL    Default WCAG level (default: WCAG2AA)"
+            echo "  WAVE_API_KEY       WAVE API key (or use: aidevops secret set wave-api-key)"
             echo ""
             echo "Examples:"
             echo "  $0 audit https://example.com"
             echo "  $0 lighthouse https://example.com mobile"
             echo "  $0 pa11y https://example.com WCAG2AAA"
+            echo "  $0 wave https://example.com 3"
+            echo "  $0 wave-mobile https://example.com"
+            echo "  $0 wave-docs alt_missing"
             echo "  $0 email ./newsletter.html"
             echo "  $0 contrast '#333333' '#ffffff'"
             echo "  $0 playwright-contrast https://example.com json AAA"

--- a/.agents/services/accessibility/accessibility-audit.md
+++ b/.agents/services/accessibility/accessibility-audit.md
@@ -27,8 +27,14 @@ tools:
 **Quick commands:**
 
 ```bash
-# Full web audit (Lighthouse + pa11y, desktop + mobile)
+# Full web audit (Lighthouse + pa11y + WAVE, desktop + mobile)
 accessibility-helper.sh audit https://example.com
+
+# WAVE API only (comprehensive, CSS/JS-rendered analysis)
+accessibility-helper.sh wave https://example.com
+
+# WAVE with XPath locations for precise element identification
+accessibility-helper.sh wave https://example.com 3
 
 # Email HTML accessibility check
 accessibility-helper.sh email ./newsletter.html
@@ -48,10 +54,10 @@ This agent orchestrates accessibility auditing across web and email channels. It
 
 | Channel | Tools | Coverage |
 |---------|-------|----------|
-| **Web (desktop)** | Lighthouse, pa11y | axe-core engine + HTML_CodeSniffer |
-| **Web (mobile)** | Lighthouse mobile, pa11y | Touch targets, viewport, zoom |
+| **Web (desktop)** | Lighthouse, pa11y, WAVE API | axe-core + HTML_CodeSniffer + WAVE engine |
+| **Web (mobile)** | Lighthouse mobile, pa11y, WAVE API (375px) | Touch targets, viewport, zoom |
 | **HTML email** | Built-in static analysis | Email-specific WCAG subset |
-| **Colour** | Built-in contrast calculator | WCAG AA + AAA ratios |
+| **Colour** | Built-in contrast calculator, WAVE contrast data | WCAG AA + AAA ratios |
 
 ## Audit Workflow
 
@@ -244,12 +250,16 @@ accessibility-helper.sh pa11y https://staging.example.com WCAG2AA
 |----------|------|---------|
 | Quick score check | Lighthouse | `accessibility-helper.sh lighthouse <url>` |
 | WCAG compliance audit | pa11y | `accessibility-helper.sh pa11y <url> WCAG2AA` |
-| Full web audit | Both | `accessibility-helper.sh audit <url>` |
+| Comprehensive analysis | WAVE API | `accessibility-helper.sh wave <url>` |
+| Element-level issues | WAVE API (type 3/4) | `accessibility-helper.sh wave <url> 3` |
+| Mobile accessibility | WAVE API | `accessibility-helper.sh wave-mobile <url>` |
+| Full web audit | All tools | `accessibility-helper.sh audit <url>` |
 | Email template check | Built-in | `accessibility-helper.sh email <file>` |
 | Colour pair validation | Built-in | `accessibility-helper.sh contrast <fg> <bg>` |
 | Multi-site monitoring | Bulk | `accessibility-helper.sh bulk <urls-file>` |
 | Dynamic SPA content | Playwright | Use `playwright` for JS-rendered pages |
 | Real device rendering | Browser tools | `pagespeed-helper.sh` or Litmus/Email on Acid |
+| Item documentation | WAVE docs | `accessibility-helper.sh wave-docs <item-id>` |
 
 ## Integration with Other Services
 

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -87,7 +87,7 @@ feature-development,workflows/feature-development.md,Feature development workflo
 -->
 
 <!--TOON:scripts[62]{name,purpose}:
-accessibility-helper.sh,Accessibility and contrast testing (WCAG compliance for websites and emails)
+accessibility-helper.sh,Accessibility and contrast testing (WCAG compliance WAVE API for websites and emails)
 accessibility-audit-helper.sh,Accessibility audit CLI wrapping axe-core WAVE API WebAIM contrast and Lighthouse a11y
 list-keys-helper.sh,List all API keys with storage locations
 list-verify-helper.sh,List verification queue entries with filtering (pending passed failed)
@@ -123,11 +123,8 @@ document-extraction-helper.sh,Document extraction with PII redaction (extract ba
 cloudron-package-helper.sh,Cloudron app packaging workflow (init scaffold build test)
 email-health-check-helper.sh,Email health check with scoring (SPF DKIM DMARC BIMI MTA-STS TLS-RPT DANE)
 email-test-suite-helper.sh,Email testing suite (design rendering delivery testing inbox placement)
-<<<<<<< HEAD
 email-delivery-test-helper.sh,Email delivery testing (spam content analysis provider deliverability inbox placement warm-up)
-=======
 email-design-test-helper.sh,Email design testing CLI (local validation and Email on Acid API real-client rendering)
->>>>>>> 69d3859a (feat: add email-design-test-helper.sh — CLI for local + EOA API email design testing)
 yt-dlp-helper.sh,YouTube video/audio download and local file conversion
 privacy-filter-helper.sh,Privacy filter for public PR contributions
 self-improve-helper.sh,Self-improving agent system (analyze refine test pr)

--- a/.agents/tools/accessibility/accessibility.md
+++ b/.agents/tools/accessibility/accessibility.md
@@ -18,14 +18,14 @@ tools:
 
 ## Quick Reference
 
-- **Helper**: `.agents/scripts/accessibility-helper.sh` (Lighthouse, pa11y, Playwright contrast, email, contrast calc)
+- **Helper**: `.agents/scripts/accessibility-helper.sh` (Lighthouse, pa11y, Playwright contrast, WAVE API, email, contrast calc)
 - **Audit Helper**: `.agents/scripts/accessibility-audit-helper.sh` (axe-core, WAVE API, WebAIM contrast, Lighthouse)
-- **Commands**: `audit [url]` | `lighthouse [url]` | `pa11y [url]` | `playwright-contrast [url]` | `email [file]` | `contrast [fg] [bg]` | `bulk [file]`
+- **Commands**: `audit [url]` | `lighthouse [url]` | `pa11y [url]` | `playwright-contrast [url]` | `wave [url]` | `email [file]` | `contrast [fg] [bg]` | `bulk [file]`
 - **Audit Commands**: `audit [url]` | `axe [url]` | `wave [url]` | `contrast [fg] [bg]` | `compare [url]` | `status`
 - **Install**: `npm install -g lighthouse pa11y @axe-core/cli` and `npm install playwright && npx playwright install chromium` or `accessibility-audit-helper.sh install-deps`
 - **Standards**: WCAG 2.1 Level A, AA (default), AAA
 - **Reports**: `~/.aidevops/reports/accessibility/` and `~/.aidevops/reports/accessibility-audit/`
-- **Tools**: Lighthouse (accessibility category), pa11y (WCAG runner), Playwright contrast extraction, axe-core (standalone axe scanner), WAVE API (visual evaluator), WebAIM contrast API, built-in contrast calculator, email HTML checker
+- **Tools**: Lighthouse (accessibility category), pa11y (WCAG runner), Playwright contrast extraction, WAVE API (comprehensive analysis), axe-core (standalone axe scanner), WebAIM contrast API, built-in contrast calculator, email HTML checker
 
 <!-- AI-CONTEXT-END -->
 
@@ -40,6 +40,7 @@ Comprehensive WCAG compliance testing for websites and HTML emails. Two helper s
 | **Lighthouse** | Accessibility score + audit failures | ~15s | Broad (axe-core engine) |
 | **pa11y** | WCAG-specific violation reporting | ~10s | Deep (HTML_CodeSniffer) |
 | **Playwright contrast** | Computed style analysis for all visible elements | ~5-15s | Every text element on page |
+| **WAVE API** | Comprehensive accessibility analysis | ~2-5s | Deep (WAVE engine, CSS/JS-rendered) |
 | **Email checker** | HTML email accessibility (static analysis) | <1s | Email-specific rules |
 | **Contrast calculator** | WCAG contrast ratio for color pairs | Instant | AA + AAA levels |
 
@@ -115,6 +116,51 @@ Standards-based testing with HTML_CodeSniffer:
 ```
 
 Reports categorise issues as errors (must fix), warnings (should fix), and notices (advisory).
+
+### WAVE API Analysis
+
+Comprehensive accessibility analysis using the WAVE engine. Evaluates pages after CSS and JavaScript rendering for accurate results. Requires an API key (register at https://wave.webaim.org/api/register).
+
+```bash
+# Basic WAVE audit (report type 2 — item details, 2 credits)
+.agents/scripts/accessibility-helper.sh wave https://example.com
+
+# Detailed with XPath locations (report type 3, 3 credits)
+.agents/scripts/accessibility-helper.sh wave https://example.com 3
+
+# Detailed with CSS selectors (report type 4, 3 credits)
+.agents/scripts/accessibility-helper.sh wave https://example.com 4
+
+# Mobile viewport (375px)
+.agents/scripts/accessibility-helper.sh wave-mobile https://example.com
+
+# Look up a specific WAVE item
+.agents/scripts/accessibility-helper.sh wave-docs alt_missing
+
+# Check remaining API credits
+.agents/scripts/accessibility-helper.sh wave-credits
+```
+
+**Report types:**
+
+| Type | Cost | Data |
+|------|------|------|
+| 1 | 1 credit | Category counts only (errors, alerts, features, etc.) |
+| 2 | 2 credits | Category counts + item details (default) |
+| 3 | 3 credits | All above + XPath locations + contrast data |
+| 4 | 3 credits | All above + CSS selector locations + contrast data |
+
+**API key setup:**
+
+```bash
+# Encrypted (recommended)
+aidevops secret set wave-api-key
+
+# Or environment variable
+export WAVE_API_KEY="your-key-here"
+```
+
+WAVE categories: errors (must fix), contrast errors, alerts (should review), features (positive), structural elements, ARIA usage.
 
 ### Email HTML Accessibility
 
@@ -294,6 +340,7 @@ Check which engines are installed and configured:
 
 | Tool | Integration |
 |------|-------------|
+| **WAVE API** | Comprehensive analysis with CSS/JS rendering, contrast data, XPath/CSS selectors |
 | **PageSpeed** | `pagespeed-helper.sh` includes Lighthouse accessibility score |
 | **Playwright** | Contrast extraction for all visible elements (`playwright-contrast` command) + dynamic SPA testing |
 | **Chrome DevTools MCP** | Real-time accessibility tree inspection |
@@ -305,7 +352,7 @@ Check which engines are installed and configured:
 |----------|---------|-------------|
 | `A11Y_WCAG_LEVEL` | `WCAG2AA` | Default WCAG standard for pa11y |
 | `AUDIT_WCAG_LEVEL` | `WCAG2AA` | Default WCAG level for audit helper |
-| `WAVE_API_KEY` | (none) | WAVE API key for `wave` command |
+| `WAVE_API_KEY` | — | WAVE API key (or use `aidevops secret set wave-api-key`) |
 
 ## Report Storage
 
@@ -314,6 +361,7 @@ Reports from `accessibility-helper.sh` are saved to `~/.aidevops/reports/accessi
 - `lighthouse_a11y_YYYYMMDD_HHMMSS.json` — Lighthouse accessibility audit
 - `pa11y_YYYYMMDD_HHMMSS.json` — pa11y WCAG violations
 - `playwright_contrast_YYYYMMDD_HHMMSS.{json,md,txt}` — Playwright contrast extraction
+- `wave_YYYYMMDD_HHMMSS.json` — WAVE API analysis results
 - `email_a11y_YYYYMMDD_HHMMSS.txt` — Email HTML check results
 
 Reports from `accessibility-audit-helper.sh` are saved to `~/.aidevops/reports/accessibility-audit/`:


### PR DESCRIPTION
## Summary

- Adds WAVE API integration to `accessibility-helper.sh` for comprehensive CSS/JS-rendered accessibility analysis
- New commands: `wave`, `wave-mobile`, `wave-docs`, `wave-credits` — covering all 4 WAVE report types with desktop and mobile viewport support
- Integrates WAVE into the existing `audit` command alongside Lighthouse and pa11y (gracefully skips if no API key)
- Secure API key loading via gopass (encrypted) or credentials.sh (plaintext fallback)
- Hardened URL encoding (passes URL via `sys.argv` to avoid shell injection)
- Updated documentation in both `accessibility-audit.md` and `accessibility.md` with usage examples, report type reference, and API key setup instructions
- Updated `subagent-index.toon` to reflect WAVE API capability

## Quality

- ShellCheck: zero violations
- Bash syntax: valid
- Follows existing patterns: `local var="$1"`, explicit returns, shared-constants integration
- All WAVE functions follow the same error handling pattern as existing Lighthouse/pa11y functions

## Testing

- `bash -n` syntax validation passes
- `shellcheck` passes clean
- WAVE API integration follows documented API at https://wave.webaim.org/api/
- URL encoding hardened against shell injection (sys.argv instead of string interpolation)

## Task

Closes t215.4