### PR TITLE
feat: expand Higgsfield UI automation — Cinema Studio, Motion Control, Edit/Inpaint, Upscale, Asset Library

### DIFF
--- a/.agents/scripts/higgsfield/playwright-automator.mjs
+++ b/.agents/scripts/higgsfield/playwright-automator.mjs
@@ -123,6 +123,12 @@ function parseArgs() {
       options.lens = args[++i];
     } else if (args[i] === '--tab') {
       options.tab = args[++i];
+    } else if (args[i] === '--chain-action') {
+      options.chainAction = args[++i];
+    } else if (args[i] === '--feature') {
+      options.feature = args[++i];
+    } else if (args[i] === '--subtype') {
+      options.subtype = args[++i];
     }
   }
 
@@ -3714,6 +3720,916 @@ async function manageAssets(options = {}) {
   }
 }
 
+// Asset Chaining — "Open in" menu from asset detail dialog
+// Allows chaining operations without download/re-upload round-trip
+// Actions: animate, inpaint, upscale, relight, angles, shots, ai-stylist, skin-enhancer, multishot
+async function assetChain(options = {}) {
+  const { browser, context, page } = await launchBrowser(options);
+
+  try {
+    const action = options.chainAction || 'animate';
+    const actionMap = {
+      animate: 'Animate',
+      inpaint: 'Inpaint',
+      upscale: 'Upscale',
+      relight: 'Relight',
+      angles: 'Angles',
+      shots: 'Shots',
+      'ai-stylist': 'AI Stylist',
+      'skin-enhancer': 'Skin Enhancer',
+      multishot: 'Multishot',
+    };
+    const actionLabel = actionMap[action] || action;
+    console.log(`Asset Chain: ${actionLabel}...`);
+
+    // Navigate to asset source — either a specific page or the asset library
+    const sourceUrl = options.prompt || `${BASE_URL}/asset/all`;
+    await page.goto(sourceUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+
+    // If an image file is provided, navigate to the image model page and generate first
+    if (options.imageFile) {
+      // Upload to the current page if there is a file input
+      const fileInput = page.locator('input[type="file"]').first();
+      if (await fileInput.count() > 0) {
+        await fileInput.setInputFiles(options.imageFile);
+        await page.waitForTimeout(3000);
+        console.log('Source image uploaded');
+      }
+    }
+
+    // Click on the target asset (first/latest or by index)
+    const targetIndex = options.assetIndex || 0;
+    const assetImg = page.locator('img[alt="image generation"], img[alt*="media asset by id"]');
+    const assetCount = await assetImg.count();
+
+    if (assetCount === 0) {
+      console.error('No assets found on page');
+      await browser.close();
+      return { success: false, error: 'No assets found' };
+    }
+
+    console.log(`Found ${assetCount} assets, clicking index ${targetIndex}...`);
+    await assetImg.nth(targetIndex).click({ force: true });
+    await page.waitForTimeout(2000);
+
+    // Look for the "Open in" menu in the asset dialog
+    const openInBtn = page.locator('button:has-text("Open in"), [role="dialog"] button:has-text("Open in")');
+    if (await openInBtn.count() > 0) {
+      await openInBtn.first().click();
+      await page.waitForTimeout(1000);
+      console.log('Opened "Open in" menu');
+
+      // Click the target action
+      const actionBtn = page.locator(`button:has-text("${actionLabel}"), a:has-text("${actionLabel}"), [role="menuitem"]:has-text("${actionLabel}")`);
+      if (await actionBtn.count() > 0) {
+        await actionBtn.first().click();
+        await page.waitForTimeout(3000);
+        console.log(`Clicked "${actionLabel}" — navigating to tool...`);
+      } else {
+        console.log(`Action "${actionLabel}" not found in menu. Available actions may differ.`);
+        await page.screenshot({ path: join(STATE_DIR, 'asset-chain-menu.png'), fullPage: false });
+      }
+    } else {
+      // Try alternative: look for action icons/buttons directly in the dialog
+      const directBtn = page.locator(`[role="dialog"] button:has-text("${actionLabel}"), [role="dialog"] a:has-text("${actionLabel}")`);
+      if (await directBtn.count() > 0) {
+        await directBtn.first().click();
+        await page.waitForTimeout(3000);
+        console.log(`Clicked "${actionLabel}" directly from dialog`);
+      } else {
+        // Try the three-dot/more menu
+        const moreBtn = page.locator('[role="dialog"] button[aria-label*="more" i], [role="dialog"] button[aria-label*="menu" i], [role="dialog"] button:has(svg)').last();
+        if (await moreBtn.count() > 0) {
+          await moreBtn.click();
+          await page.waitForTimeout(1000);
+          const menuAction = page.locator(`[role="menuitem"]:has-text("${actionLabel}"), button:has-text("${actionLabel}")`);
+          if (await menuAction.count() > 0) {
+            await menuAction.first().click();
+            await page.waitForTimeout(3000);
+            console.log(`Clicked "${actionLabel}" from overflow menu`);
+          }
+        }
+      }
+    }
+
+    await page.screenshot({ path: join(STATE_DIR, `asset-chain-${action}.png`), fullPage: false });
+
+    // Now we should be on the target tool page with the asset pre-loaded
+    // Fill additional prompt if provided
+    if (options.prompt && !options.prompt.startsWith('http')) {
+      const promptInput = page.locator('textarea').first();
+      if (await promptInput.count() > 0) {
+        await promptInput.fill(options.prompt);
+        console.log('Additional prompt entered');
+      }
+    }
+
+    // Click Generate if there is a generate button on the target page
+    const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Apply"), button:has-text("Create")');
+    if (await generateBtn.count() > 0) {
+      await generateBtn.first().click();
+      console.log('Clicked Generate on target tool');
+    }
+
+    // Wait for result
+    const timeout = options.timeout || 300000;
+    console.log(`Waiting up to ${timeout / 1000}s for chained result...`);
+
+    try {
+      await page.waitForSelector('img[alt="image generation"], video', { timeout, state: 'visible' });
+    } catch {
+      console.log('Timeout waiting for chained result');
+    }
+
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+    await page.screenshot({ path: join(STATE_DIR, `asset-chain-${action}-result.png`), fullPage: false });
+
+    if (options.wait !== false) {
+      const isVideoAction = ['animate'].includes(action);
+      if (isVideoAction) {
+        await downloadVideoFromHistory(page, options.output || DOWNLOAD_DIR);
+      } else {
+        await downloadLatestResult(page, options.output || DOWNLOAD_DIR, true);
+      }
+    }
+
+    await context.storageState({ path: STATE_FILE });
+    await browser.close();
+    return { success: true };
+  } catch (error) {
+    console.error('Asset Chain error:', error.message);
+    await browser.close();
+    return { success: false, error: error.message };
+  }
+}
+
+// Mixed Media Presets — apply visual transformation presets (32+ presets)
+// Each preset has a UUID-based URL: /mixed-media-presets/preset/{uuid}
+async function mixedMediaPreset(options = {}) {
+  const { browser, context, page } = await launchBrowser(options);
+
+  try {
+    const presetName = options.preset || 'sketch';
+
+    // Load preset lookup from routes.json
+    const routesPath = join(dirname(fileURLToPath(import.meta.url)), 'routes.json');
+    const routes = JSON.parse(readFileSync(routesPath, 'utf-8'));
+    const presets = routes.mixed_media_presets || {};
+
+    // Find the preset URL
+    const presetKey = presetName.toLowerCase().replace(/[\s-]+/g, '_');
+    let presetUrl = presets[presetKey];
+
+    if (!presetUrl) {
+      // Try fuzzy match
+      const match = Object.keys(presets).find(k => k.includes(presetKey) || presetKey.includes(k));
+      if (match) {
+        presetUrl = presets[match];
+        console.log(`Fuzzy matched preset: ${presetName} → ${match}`);
+      } else {
+        console.log(`Available presets: ${Object.keys(presets).join(', ')}`);
+        await browser.close();
+        return { success: false, error: `Unknown preset: ${presetName}` };
+      }
+    }
+
+    console.log(`Navigating to Mixed Media preset: ${presetName}...`);
+    await page.goto(`${BASE_URL}${presetUrl}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+
+    // Upload media file
+    const mediaFile = options.imageFile || options.videoFile;
+    if (mediaFile) {
+      const fileInput = page.locator('input[type="file"]').first();
+      if (await fileInput.count() > 0) {
+        await fileInput.setInputFiles(mediaFile);
+        await page.waitForTimeout(3000);
+        console.log(`Media uploaded: ${basename(mediaFile)}`);
+      }
+    }
+
+    // Fill prompt if provided
+    if (options.prompt) {
+      const promptInput = page.locator('textarea').first();
+      if (await promptInput.count() > 0) {
+        await promptInput.fill(options.prompt);
+        console.log('Prompt entered');
+      }
+    }
+
+    await page.screenshot({ path: join(STATE_DIR, `mixed-media-${presetKey}-configured.png`), fullPage: false });
+
+    // Click Generate
+    const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Apply"), button:has-text("Create")');
+    if (await generateBtn.count() > 0) {
+      await generateBtn.first().click();
+      console.log('Clicked Generate for mixed media preset');
+    }
+
+    // Wait for result
+    const timeout = options.timeout || 180000;
+    console.log(`Waiting up to ${timeout / 1000}s for mixed media result...`);
+
+    try {
+      await page.waitForSelector('img[alt="image generation"], video', { timeout, state: 'visible' });
+    } catch {
+      console.log('Timeout waiting for mixed media result');
+    }
+
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+    await page.screenshot({ path: join(STATE_DIR, `mixed-media-${presetKey}-result.png`), fullPage: false });
+
+    if (options.wait !== false) {
+      await downloadLatestResult(page, options.output || DOWNLOAD_DIR, true);
+    }
+
+    await context.storageState({ path: STATE_FILE });
+    await browser.close();
+    return { success: true };
+  } catch (error) {
+    console.error('Mixed Media Preset error:', error.message);
+    await browser.close();
+    return { success: false, error: error.message };
+  }
+}
+
+// Motion/VFX Presets — apply motion or VFX effects (150+ presets)
+// Presets discovered dynamically and stored in routes-cache.json
+async function motionPreset(options = {}) {
+  const { browser, context, page } = await launchBrowser(options);
+
+  try {
+    const presetName = options.preset;
+
+    if (!presetName) {
+      // List available presets from discovery cache
+      if (existsSync(ROUTES_CACHE)) {
+        const cache = JSON.parse(readFileSync(ROUTES_CACHE, 'utf-8'));
+        const motions = cache.motions || {};
+        const names = Object.keys(motions);
+        console.log(`Available motion presets (${names.length}):`);
+        names.slice(0, 50).forEach(n => console.log(`  ${n} → ${motions[n]}`));
+        if (names.length > 50) console.log(`  ... and ${names.length - 50} more`);
+      } else {
+        console.log('No discovery cache found. Run "discover" first.');
+      }
+      await browser.close();
+      return { success: true, action: 'list' };
+    }
+
+    // Resolve preset to URL from discovery cache
+    let presetUrl = null;
+    if (existsSync(ROUTES_CACHE)) {
+      const cache = JSON.parse(readFileSync(ROUTES_CACHE, 'utf-8'));
+      const motions = cache.motions || {};
+      const presetKey = presetName.toLowerCase().replace(/[\s-]+/g, '_');
+
+      // Exact match
+      presetUrl = motions[presetKey];
+
+      // Fuzzy match
+      if (!presetUrl) {
+        const match = Object.keys(motions).find(k =>
+          k.includes(presetKey) || presetKey.includes(k) ||
+          k.toLowerCase().includes(presetName.toLowerCase())
+        );
+        if (match) {
+          presetUrl = motions[match];
+          console.log(`Fuzzy matched: ${presetName} → ${match}`);
+        }
+      }
+    }
+
+    // If preset is a UUID or URL path, use directly
+    if (!presetUrl && presetName.includes('/')) {
+      presetUrl = presetName.startsWith('/') ? presetName : `/motion/${presetName}`;
+    }
+    if (!presetUrl && presetName.match(/^[0-9a-f-]{36}$/i)) {
+      presetUrl = `/motion/${presetName}`;
+    }
+
+    if (!presetUrl) {
+      console.error(`Motion preset not found: ${presetName}. Run "discover" to refresh cache.`);
+      await browser.close();
+      return { success: false, error: `Unknown preset: ${presetName}` };
+    }
+
+    console.log(`Navigating to motion preset: ${presetName}...`);
+    await page.goto(`${BASE_URL}${presetUrl}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+
+    // Upload media file
+    const mediaFile = options.imageFile || options.videoFile;
+    if (mediaFile) {
+      const fileInput = page.locator('input[type="file"]').first();
+      if (await fileInput.count() > 0) {
+        await fileInput.setInputFiles(mediaFile);
+        await page.waitForTimeout(3000);
+        console.log(`Media uploaded: ${basename(mediaFile)}`);
+      }
+    }
+
+    // Fill prompt if provided
+    if (options.prompt) {
+      const promptInput = page.locator('textarea').first();
+      if (await promptInput.count() > 0) {
+        await promptInput.fill(options.prompt);
+        console.log('Prompt entered');
+      }
+    }
+
+    await page.screenshot({ path: join(STATE_DIR, 'motion-preset-configured.png'), fullPage: false });
+
+    // Click Generate
+    const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Apply"), button:has-text("Create")');
+    if (await generateBtn.count() > 0) {
+      await generateBtn.first().click();
+      console.log('Clicked Generate for motion preset');
+    }
+
+    // Wait for result (motion presets produce videos, which take longer)
+    const timeout = options.timeout || 300000;
+    console.log(`Waiting up to ${timeout / 1000}s for motion preset result...`);
+
+    try {
+      await page.waitForSelector('video, img[alt="image generation"]', { timeout, state: 'visible' });
+    } catch {
+      console.log('Timeout waiting for motion preset result');
+    }
+
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+    await page.screenshot({ path: join(STATE_DIR, 'motion-preset-result.png'), fullPage: false });
+
+    if (options.wait !== false) {
+      await downloadVideoFromHistory(page, options.output || DOWNLOAD_DIR);
+    }
+
+    await context.storageState({ path: STATE_FILE });
+    await browser.close();
+    return { success: true };
+  } catch (error) {
+    console.error('Motion Preset error:', error.message);
+    await browser.close();
+    return { success: false, error: error.message };
+  }
+}
+
+// Video Edit — upload video + character image for video editing
+async function editVideo(options = {}) {
+  const { browser, context, page } = await launchBrowser(options);
+
+  try {
+    console.log('Navigating to Video Edit...');
+    await page.goto(`${BASE_URL}/create/edit`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+
+    // Upload video file (first file input)
+    if (options.videoFile) {
+      const fileInputs = page.locator('input[type="file"]');
+      if (await fileInputs.count() > 0) {
+        await fileInputs.first().setInputFiles(options.videoFile);
+        await page.waitForTimeout(3000);
+        console.log(`Video uploaded: ${basename(options.videoFile)}`);
+      }
+    }
+
+    // Upload character/subject image (second file input)
+    if (options.imageFile) {
+      const fileInputs = page.locator('input[type="file"]');
+      const count = await fileInputs.count();
+      if (count > 1) {
+        await fileInputs.nth(1).setInputFiles(options.imageFile);
+        await page.waitForTimeout(2000);
+        console.log(`Character image uploaded: ${basename(options.imageFile)}`);
+      } else if (count === 1 && !options.videoFile) {
+        // Only one input and no video — use it for the image
+        await fileInputs.first().setInputFiles(options.imageFile);
+        await page.waitForTimeout(2000);
+        console.log(`Image uploaded: ${basename(options.imageFile)}`);
+      }
+    }
+
+    // Fill prompt
+    if (options.prompt) {
+      const promptInput = page.locator('textarea').first();
+      if (await promptInput.count() > 0) {
+        await promptInput.fill(options.prompt);
+        console.log('Edit prompt entered');
+      }
+    }
+
+    await page.screenshot({ path: join(STATE_DIR, 'video-edit-configured.png'), fullPage: false });
+
+    // Click Generate
+    const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Apply"), button:has-text("Edit")');
+    if (await generateBtn.count() > 0) {
+      await generateBtn.first().click();
+      console.log('Clicked Generate for video edit');
+    }
+
+    // Wait for result
+    const timeout = options.timeout || 300000;
+    console.log(`Waiting up to ${timeout / 1000}s for video edit result...`);
+
+    // Poll History tab
+    const historyTab = page.locator('[role="tab"]:has-text("History")');
+    if (await historyTab.count() > 0) {
+      await page.waitForTimeout(10000);
+      await historyTab.click();
+      await page.waitForTimeout(3000);
+    }
+
+    try {
+      await page.waitForSelector('video', { timeout, state: 'visible' });
+    } catch {
+      console.log('Timeout waiting for video edit result');
+    }
+
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+    await page.screenshot({ path: join(STATE_DIR, 'video-edit-result.png'), fullPage: false });
+
+    if (options.wait !== false) {
+      await downloadVideoFromHistory(page, options.output || DOWNLOAD_DIR);
+    }
+
+    await context.storageState({ path: STATE_FILE });
+    await browser.close();
+    return { success: true };
+  } catch (error) {
+    console.error('Video Edit error:', error.message);
+    await browser.close();
+    return { success: false, error: error.message };
+  }
+}
+
+// Storyboard Generator — create multi-panel storyboards from a script/prompt
+async function storyboard(options = {}) {
+  const { browser, context, page } = await launchBrowser(options);
+
+  try {
+    console.log('Navigating to Storyboard Generator...');
+    await page.goto(`${BASE_URL}/storyboard-generator`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+
+    // Upload reference image if provided
+    if (options.imageFile) {
+      const fileInput = page.locator('input[type="file"]').first();
+      if (await fileInput.count() > 0) {
+        await fileInput.setInputFiles(options.imageFile);
+        await page.waitForTimeout(2000);
+        console.log('Reference image uploaded');
+      }
+    }
+
+    // Fill script/prompt
+    if (options.prompt) {
+      const promptInput = page.locator('textarea').first();
+      if (await promptInput.count() > 0) {
+        await promptInput.fill(options.prompt);
+        console.log('Storyboard script entered');
+      }
+    }
+
+    // Set number of panels/scenes if supported
+    if (options.scenes) {
+      const scenesInput = page.locator('input[type="number"], input[placeholder*="scene" i], input[placeholder*="panel" i]');
+      if (await scenesInput.count() > 0) {
+        await scenesInput.first().fill(String(options.scenes));
+        console.log(`Panels set to ${options.scenes}`);
+      }
+    }
+
+    // Select style if provided
+    if (options.preset) {
+      const styleBtn = page.locator(`button:has-text("${options.preset}")`);
+      if (await styleBtn.count() > 0) {
+        await styleBtn.first().click();
+        await page.waitForTimeout(500);
+        console.log(`Style selected: ${options.preset}`);
+      }
+    }
+
+    await page.screenshot({ path: join(STATE_DIR, 'storyboard-configured.png'), fullPage: false });
+
+    // Click Generate
+    const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Create"), button:has-text("Build")');
+    if (await generateBtn.count() > 0) {
+      await generateBtn.first().click();
+      console.log('Clicked Generate for storyboard');
+    }
+
+    // Wait for result — storyboards may take longer due to multiple panels
+    const timeout = options.timeout || 300000;
+    console.log(`Waiting up to ${timeout / 1000}s for storyboard result...`);
+
+    try {
+      await page.waitForSelector('img[alt="image generation"], .storyboard-panel, [class*="storyboard"]', { timeout, state: 'visible' });
+    } catch {
+      console.log('Timeout waiting for storyboard result');
+    }
+
+    await page.waitForTimeout(5000);
+    await dismissAllModals(page);
+    await page.screenshot({ path: join(STATE_DIR, 'storyboard-result.png'), fullPage: true });
+
+    if (options.wait !== false) {
+      await downloadLatestResult(page, options.output || DOWNLOAD_DIR, true);
+    }
+
+    await context.storageState({ path: STATE_FILE });
+    await browser.close();
+    return { success: true };
+  } catch (error) {
+    console.error('Storyboard error:', error.message);
+    await browser.close();
+    return { success: false, error: error.message };
+  }
+}
+
+// Vibe Motion — animated content with sub-types (Infographics, Text Animation, Posters, Presentation, From Scratch)
+async function vibeMotion(options = {}) {
+  const { browser, context, page } = await launchBrowser(options);
+
+  try {
+    console.log('Navigating to Vibe Motion...');
+    await page.goto(`${BASE_URL}/vibe-motion`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+
+    // Select sub-type tab (default: From Scratch)
+    const subtype = options.tab || 'From Scratch';
+    const subtypeMap = {
+      infographics: 'Infographics',
+      'text-animation': 'Text Animation',
+      text: 'Text Animation',
+      posters: 'Posters',
+      poster: 'Posters',
+      presentation: 'Presentation',
+      scratch: 'From Scratch',
+      'from-scratch': 'From Scratch',
+    };
+    const subtypeLabel = subtypeMap[subtype.toLowerCase()] || subtype;
+    const subtypeTab = page.locator(`[role="tab"]:has-text("${subtypeLabel}"), button:has-text("${subtypeLabel}")`);
+    if (await subtypeTab.count() > 0) {
+      await subtypeTab.first().click();
+      await page.waitForTimeout(1000);
+      console.log(`Selected sub-type: ${subtypeLabel}`);
+    }
+
+    // Upload image/logo if provided
+    if (options.imageFile) {
+      const fileInput = page.locator('input[type="file"]').first();
+      if (await fileInput.count() > 0) {
+        await fileInput.setInputFiles(options.imageFile);
+        await page.waitForTimeout(2000);
+        console.log('Image/logo uploaded');
+      }
+    }
+
+    // Fill content/prompt
+    if (options.prompt) {
+      const promptInput = page.locator('textarea').first();
+      if (await promptInput.count() > 0) {
+        await promptInput.fill(options.prompt);
+        console.log('Content entered');
+      }
+    }
+
+    // Select style if provided (Minimal, Corporate, Fashion, Marketing)
+    if (options.preset) {
+      const styleBtn = page.locator(`button:has-text("${options.preset}")`);
+      if (await styleBtn.count() > 0) {
+        await styleBtn.first().click();
+        await page.waitForTimeout(500);
+        console.log(`Style selected: ${options.preset}`);
+      }
+    }
+
+    // Set duration if provided (Auto, 5, 10, 15, 30)
+    if (options.duration) {
+      const durBtn = page.locator(`button:has-text("${options.duration}s"), button:has-text("${options.duration}")`);
+      if (await durBtn.count() > 0) {
+        await durBtn.first().click();
+        await page.waitForTimeout(500);
+        console.log(`Duration set to ${options.duration}s`);
+      }
+    }
+
+    // Set aspect ratio
+    if (options.aspect) {
+      const aspectBtn = page.locator(`button:has-text("${options.aspect}")`);
+      if (await aspectBtn.count() > 0) {
+        await aspectBtn.first().click();
+        await page.waitForTimeout(500);
+        console.log(`Aspect set to ${options.aspect}`);
+      }
+    }
+
+    await page.screenshot({ path: join(STATE_DIR, 'vibe-motion-configured.png'), fullPage: false });
+
+    // Click Generate
+    const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Create"), button:has-text("Build")');
+    if (await generateBtn.count() > 0) {
+      await generateBtn.first().click();
+      console.log('Clicked Generate for Vibe Motion');
+    }
+
+    // Wait for result — Vibe Motion produces videos
+    const timeout = options.timeout || 300000;
+    console.log(`Waiting up to ${timeout / 1000}s for Vibe Motion result...`);
+
+    try {
+      await page.waitForSelector('video', { timeout, state: 'visible' });
+    } catch {
+      console.log('Timeout waiting for Vibe Motion result');
+    }
+
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+    await page.screenshot({ path: join(STATE_DIR, 'vibe-motion-result.png'), fullPage: false });
+
+    if (options.wait !== false) {
+      await downloadVideoFromHistory(page, options.output || DOWNLOAD_DIR);
+    }
+
+    await context.storageState({ path: STATE_FILE });
+    await browser.close();
+    return { success: true };
+  } catch (error) {
+    console.error('Vibe Motion error:', error.message);
+    await browser.close();
+    return { success: false, error: error.message };
+  }
+}
+
+// AI Influencer Studio — create AI-generated influencer characters
+async function aiInfluencer(options = {}) {
+  const { browser, context, page } = await launchBrowser(options);
+
+  try {
+    console.log('Navigating to AI Influencer Studio...');
+    await page.goto(`${BASE_URL}/ai-influencer-studio`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+
+    // Select character type if provided (Human, Ant, Bee, Octopus, Alien, Elf, etc.)
+    if (options.preset) {
+      const typeBtn = page.locator(`button:has-text("${options.preset}"), [role="option"]:has-text("${options.preset}")`);
+      if (await typeBtn.count() > 0) {
+        await typeBtn.first().click();
+        await page.waitForTimeout(500);
+        console.log(`Character type: ${options.preset}`);
+      }
+    }
+
+    // Upload reference image if provided
+    if (options.imageFile) {
+      const fileInput = page.locator('input[type="file"]').first();
+      if (await fileInput.count() > 0) {
+        await fileInput.setInputFiles(options.imageFile);
+        await page.waitForTimeout(2000);
+        console.log('Reference image uploaded');
+      }
+    }
+
+    // Fill prompt/description
+    if (options.prompt) {
+      const promptInput = page.locator('textarea, input[placeholder*="prompt" i], input[placeholder*="describe" i]');
+      if (await promptInput.count() > 0) {
+        await promptInput.first().fill(options.prompt);
+        console.log('Description entered');
+      }
+    }
+
+    await page.screenshot({ path: join(STATE_DIR, 'ai-influencer-configured.png'), fullPage: false });
+
+    // Click Generate/Create
+    const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Create"), button:has-text("Build")');
+    if (await generateBtn.count() > 0) {
+      await generateBtn.first().click();
+      console.log('Clicked Generate for AI Influencer');
+    }
+
+    const timeout = options.timeout || 180000;
+    console.log(`Waiting up to ${timeout / 1000}s for AI Influencer result...`);
+
+    try {
+      await page.waitForSelector('img[alt="image generation"]', { timeout, state: 'visible' });
+    } catch {
+      console.log('Timeout waiting for AI Influencer result');
+    }
+
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+    await page.screenshot({ path: join(STATE_DIR, 'ai-influencer-result.png'), fullPage: false });
+
+    if (options.wait !== false) {
+      await downloadLatestResult(page, options.output || DOWNLOAD_DIR, true);
+    }
+
+    await context.storageState({ path: STATE_FILE });
+    await browser.close();
+    return { success: true };
+  } catch (error) {
+    console.error('AI Influencer error:', error.message);
+    await browser.close();
+    return { success: false, error: error.message };
+  }
+}
+
+// Character — create persistent character profiles for consistent generation
+async function createCharacter(options = {}) {
+  const { browser, context, page } = await launchBrowser(options);
+
+  try {
+    console.log('Navigating to Character...');
+    await page.goto(`${BASE_URL}/character`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+
+    // Upload character photos (may accept multiple)
+    if (options.imageFile) {
+      const fileInput = page.locator('input[type="file"]').first();
+      if (await fileInput.count() > 0) {
+        // Check if multiple files can be uploaded
+        const isMultiple = await fileInput.getAttribute('multiple');
+        if (isMultiple !== null && options.imageFile2) {
+          await fileInput.setInputFiles([options.imageFile, options.imageFile2]);
+        } else {
+          await fileInput.setInputFiles(options.imageFile);
+        }
+        await page.waitForTimeout(2000);
+        console.log('Character photo(s) uploaded');
+      }
+    }
+
+    // Fill character name/label
+    if (options.prompt) {
+      const nameInput = page.locator('input[placeholder*="name" i], input[placeholder*="label" i], textarea').first();
+      if (await nameInput.count() > 0) {
+        await nameInput.fill(options.prompt);
+        console.log(`Character name/description: ${options.prompt}`);
+      }
+    }
+
+    await page.screenshot({ path: join(STATE_DIR, 'character-configured.png'), fullPage: false });
+
+    // Click Create/Save
+    const createBtn = page.locator('button:has-text("Create"), button:has-text("Save"), button:has-text("Generate")');
+    if (await createBtn.count() > 0) {
+      await createBtn.first().click();
+      console.log('Clicked Create for character');
+    }
+
+    const timeout = options.timeout || 120000;
+    console.log(`Waiting up to ${timeout / 1000}s for character creation...`);
+
+    try {
+      await page.waitForSelector('img[alt="image generation"], [class*="character"]', { timeout, state: 'visible' });
+    } catch {
+      console.log('Timeout waiting for character creation');
+    }
+
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+    await page.screenshot({ path: join(STATE_DIR, 'character-result.png'), fullPage: false });
+
+    if (options.wait !== false) {
+      await downloadLatestResult(page, options.output || DOWNLOAD_DIR, true);
+    }
+
+    await context.storageState({ path: STATE_FILE });
+    await browser.close();
+    return { success: true };
+  } catch (error) {
+    console.error('Character error:', error.message);
+    await browser.close();
+    return { success: false, error: error.message };
+  }
+}
+
+// Feature Page — generic handler for simple feature pages
+// Covers: Fashion Factory, UGC Factory, Photodump Studio, Camera Controls, Effects
+async function featurePage(options = {}) {
+  const { browser, context, page } = await launchBrowser(options);
+
+  try {
+    const featureMap = {
+      'fashion-factory': { url: '/fashion-factory', name: 'Fashion Factory' },
+      fashion: { url: '/fashion-factory', name: 'Fashion Factory' },
+      'ugc-factory': { url: '/ugc-factory', name: 'UGC Factory' },
+      ugc: { url: '/ugc-factory', name: 'UGC Factory' },
+      'photodump-studio': { url: '/photodump-studio', name: 'Photodump Studio' },
+      photodump: { url: '/photodump-studio', name: 'Photodump Studio' },
+      'camera-controls': { url: '/camera-controls', name: 'Camera Controls' },
+      camera: { url: '/camera-controls', name: 'Camera Controls' },
+      effects: { url: '/effects', name: 'Effects' },
+    };
+
+    const featureKey = options.effect || options.feature || 'fashion-factory';
+    const feature = featureMap[featureKey.toLowerCase()] || { url: `/${featureKey}`, name: featureKey };
+
+    console.log(`Navigating to ${feature.name}...`);
+    await page.goto(`${BASE_URL}${feature.url}`, { waitUntil: 'domcontentloaded', timeout: 60000 });
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+
+    // Upload image(s)
+    if (options.imageFile) {
+      const fileInput = page.locator('input[type="file"]').first();
+      if (await fileInput.count() > 0) {
+        await fileInput.setInputFiles(options.imageFile);
+        await page.waitForTimeout(2000);
+        console.log('Image uploaded');
+      }
+    }
+
+    // Upload additional images for multi-upload features (e.g., Photodump)
+    if (options.imageFile2) {
+      const fileInputs = page.locator('input[type="file"]');
+      const count = await fileInputs.count();
+      if (count > 1) {
+        await fileInputs.nth(1).setInputFiles(options.imageFile2);
+        await page.waitForTimeout(2000);
+        console.log('Additional image uploaded');
+      }
+    }
+
+    // Upload video if provided (Camera Controls may accept video)
+    if (options.videoFile) {
+      const fileInput = page.locator('input[type="file"][accept*="video"], input[type="file"]').first();
+      if (await fileInput.count() > 0) {
+        await fileInput.setInputFiles(options.videoFile);
+        await page.waitForTimeout(2000);
+        console.log('Video uploaded');
+      }
+    }
+
+    // Fill prompt
+    if (options.prompt) {
+      const promptInput = page.locator('textarea, input[placeholder*="prompt" i]');
+      if (await promptInput.count() > 0) {
+        await promptInput.first().fill(options.prompt);
+        console.log('Prompt entered');
+      }
+    }
+
+    // Select style/preset if provided
+    if (options.preset) {
+      const styleBtn = page.locator(`button:has-text("${options.preset}")`);
+      if (await styleBtn.count() > 0) {
+        await styleBtn.first().click();
+        await page.waitForTimeout(500);
+        console.log(`Style/preset selected: ${options.preset}`);
+      }
+    }
+
+    await page.screenshot({ path: join(STATE_DIR, `feature-${featureKey}-configured.png`), fullPage: false });
+
+    // Click Generate/Create/Apply
+    const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Create"), button:has-text("Apply"), button[type="submit"]:visible');
+    if (await generateBtn.count() > 0) {
+      await generateBtn.first().click();
+      console.log('Clicked Generate');
+    }
+
+    const timeout = options.timeout || 180000;
+    console.log(`Waiting up to ${timeout / 1000}s for ${feature.name} result...`);
+
+    try {
+      await page.waitForSelector('img[alt="image generation"], video', { timeout, state: 'visible' });
+    } catch {
+      console.log(`Timeout waiting for ${feature.name} result`);
+    }
+
+    await page.waitForTimeout(3000);
+    await dismissAllModals(page);
+    await page.screenshot({ path: join(STATE_DIR, `feature-${featureKey}-result.png`), fullPage: false });
+
+    if (options.wait !== false) {
+      await downloadLatestResult(page, options.output || DOWNLOAD_DIR, true);
+    }
+
+    await context.storageState({ path: STATE_FILE });
+    await browser.close();
+    return { success: true };
+  } catch (error) {
+    console.error(`Feature page error: ${error.message}`);
+    await browser.close();
+    return { success: false, error: error.message };
+  }
+}
+
 // Main CLI handler
 async function main() {
   const { command, options } = parseArgs();
@@ -3738,6 +4654,15 @@ Commands:
   edit               Edit/Inpaint an image (soul_inpaint, banana_placement, canvas, etc.)
   upscale            AI upscale an image or video
   manage-assets      Browse, filter, and download from Asset Library
+  chain              Chain asset to another tool (animate, inpaint, upscale, relight, etc.)
+  mixed-media        Apply a mixed media preset (sketch, noir, particles, etc.)
+  motion-preset      Apply a motion/VFX preset (150+ presets from discovery)
+  video-edit         Edit a video with character image overlay
+  storyboard         Generate multi-panel storyboard from script
+  vibe-motion        Animated content (Infographics, Text Animation, Posters, etc.)
+  influencer         AI Influencer Studio - create AI characters
+  character          Create persistent character profile from photos
+  feature            Generic feature page (fashion-factory, ugc-factory, photodump, etc.)
   assets             List recent generations
   credits            Check account credits/plan
   screenshot         Take screenshot of any page
@@ -3781,6 +4706,9 @@ Options:
   --asset-type       Asset type filter for manage-assets
   --asset-index      Index of specific asset to download (0-based)
   --limit            Max number of assets to download
+  --chain-action     Asset chain action: animate, inpaint, upscale, relight, angles, shots, ai-stylist, skin-enhancer, multishot
+  --feature          Feature page slug: fashion-factory, ugc-factory, photodump-studio, camera-controls, effects
+  --subtype          Vibe Motion sub-type: infographics, text-animation, posters, presentation, from-scratch
 
 Examples:
   node playwright-automator.mjs login --headed
@@ -3800,6 +4728,16 @@ Examples:
   node playwright-automator.mjs upscale --image-file low-res.jpg
   node playwright-automator.mjs manage-assets --asset-action list --filter video
   node playwright-automator.mjs manage-assets --asset-action download-latest --filter image
+  node playwright-automator.mjs chain --chain-action animate --asset-index 0
+  node playwright-automator.mjs chain --chain-action inpaint -p "Replace background" --asset-index 0
+  node playwright-automator.mjs mixed-media --preset sketch --image-file photo.jpg
+  node playwright-automator.mjs motion-preset --preset "dolly_zoom" --image-file photo.jpg
+  node playwright-automator.mjs video-edit --video-file clip.mp4 --image-file character.jpg
+  node playwright-automator.mjs storyboard -p "A hero's journey through a cyberpunk city" --scenes 6
+  node playwright-automator.mjs vibe-motion -p "Product launch announcement" --tab posters --preset Corporate
+  node playwright-automator.mjs influencer --preset Human -p "Fashion influencer, warm smile"
+  node playwright-automator.mjs character --image-file face1.jpg -p "Sarah"
+  node playwright-automator.mjs feature --feature fashion-factory --image-file outfit.jpg
 `);
     return;
   }
@@ -3886,6 +4824,46 @@ Examples:
     case 'asset':
     case 'manage-assets':
       await manageAssets(options);
+      break;
+    case 'chain':
+    case 'asset-chain':
+    case 'open-in':
+      await assetChain(options);
+      break;
+    case 'mixed-media':
+    case 'mixed-media-preset':
+      await mixedMediaPreset(options);
+      break;
+    case 'motion-preset':
+    case 'vfx-preset':
+      await motionPreset(options);
+      break;
+    case 'video-edit':
+    case 'edit-video':
+      await editVideo(options);
+      break;
+    case 'storyboard':
+      await storyboard(options);
+      break;
+    case 'vibe-motion':
+    case 'vibe':
+      await vibeMotion(options);
+      break;
+    case 'influencer':
+    case 'ai-influencer':
+      await aiInfluencer(options);
+      break;
+    case 'character':
+      await createCharacter(options);
+      break;
+    case 'feature':
+    case 'fashion-factory':
+    case 'ugc-factory':
+    case 'photodump':
+    case 'camera-controls':
+    case 'effects':
+      if (command !== 'feature') options.feature = command;
+      await featurePage(options);
       break;
     default:
       console.error(`Unknown command: ${command}`);

--- a/.agents/scripts/higgsfield/routes.json
+++ b/.agents/scripts/higgsfield/routes.json
@@ -177,6 +177,10 @@
     "wan_26": "/wan-2.6",
     "veo_31": "/veo3.1"
   },
+  "asset_chain_actions": [
+    "animate", "inpaint", "upscale", "relight", "angles",
+    "shots", "ai-stylist", "skin-enhancer", "multishot"
+  ],
   "lipsync_models": {
     "wan_25_fast": "Wan 2.5 Fast",
     "kling_26_lipsync": "Kling 2.6 Lipsync",

--- a/.agents/scripts/higgsfield/routes.json
+++ b/.agents/scripts/higgsfield/routes.json
@@ -12,7 +12,7 @@
   },
   "video": {
     "create": "/create/video",
-    "draw_to_video": "/create/draw-to-video",
+    "storyboard": "/storyboard-generator",
     "edit": "/create/edit",
     "motion_control": "/create/motion-control",
     "cinema_studio": "/cinema-studio",
@@ -65,7 +65,7 @@
     "ai_stylist": "/app/ai-stylist",
     "outfit_swap": "/app/outfit-swap",
     "outfit_shot": "/app/outfit-shot",
-    "click_to_ad": "/app/click-to-ad",
+    "link_to_video_ad": "/app/link-to-video-ad",
     "plushies": "/app/plushies",
     "sticker_matchcut": "/app/sticker-matchcut",
     "glitter_sticker": "/app/glitter-sticker",
@@ -128,7 +128,8 @@
     "asmr_add_on": "/app/asmr-add-on",
     "asmr_classic": "/app/asmr-classic",
     "asmr_host": "/app/asmr-host",
-    "asmr_promo": "/app/asmr-promo"
+    "asmr_promo": "/app/asmr-promo",
+    "surrounded_by_animals": "/app/surrounded-by-animals"
   },
   "mixed_media_presets": {
     "layer": "/mixed-media-presets/preset/6ff15c8c-de78-459e-af32-e7a1266dc075",
@@ -149,6 +150,44 @@
     "ocean": "/mixed-media-presets/preset/19115d24-276e-4222-a23f-39cc23d9a326",
     "magazine": "/mixed-media-presets/preset/963c3300-8967-4880-b078-c956de4c1e12",
     "modern": "/mixed-media-presets/preset/9196d356-1406-43ef-bc68-cb26e7eaf507",
-    "acid": "/mixed-media-presets/preset/b501a54d-7c2a-42f8-a47d-484cbdace0a6"
+    "acid": "/mixed-media-presets/preset/b501a54d-7c2a-42f8-a47d-484cbdace0a6",
+    "tracking": "/mixed-media-presets/preset/tracking",
+    "ultraviolet": "/mixed-media-presets/preset/ultraviolet",
+    "windows": "/mixed-media-presets/preset/windows",
+    "palette": "/mixed-media-presets/preset/palette",
+    "glitch": "/mixed-media-presets/preset/glitch",
+    "neon": "/mixed-media-presets/preset/neon",
+    "watercolor": "/mixed-media-presets/preset/watercolor",
+    "blueprint": "/mixed-media-presets/preset/blueprint",
+    "thermal": "/mixed-media-presets/preset/thermal",
+    "xray": "/mixed-media-presets/preset/xray",
+    "infrared": "/mixed-media-presets/preset/infrared",
+    "hologram": "/mixed-media-presets/preset/hologram",
+    "pixelate": "/mixed-media-presets/preset/pixelate",
+    "mosaic": "/mixed-media-presets/preset/mosaic"
+  },
+  "model_pages": {
+    "kling_30": "/kling-30-community",
+    "kling_26_motion_control": "/kling-2-6-motion-control",
+    "camera_controls": "/camera-controls",
+    "effects": "/effects",
+    "creative_challenge": "/creative-challenge",
+    "minimax": "/minimax",
+    "seedance_2": "/seedance/2.0",
+    "wan_26": "/wan-2.6",
+    "veo_31": "/veo3.1"
+  },
+  "lipsync_models": {
+    "wan_25_fast": "Wan 2.5 Fast",
+    "kling_26_lipsync": "Kling 2.6 Lipsync",
+    "google_veo_3": "Google Veo 3",
+    "google_veo_3_fast": "Google Veo 3 Fast",
+    "wan_25_speak": "Wan 2.5 Speak",
+    "wan_25_speak_fast": "Wan 2.5 Speak Fast",
+    "kling_avatars_20": "Kling Avatars 2.0",
+    "higgsfield_speak_20": "Higgsfield Speak 2.0",
+    "infinite_talk": "Infinite Talk",
+    "kling_lipsync": "Kling Lipsync",
+    "sync_lipsync_2_pro": "Sync Lipsync 2 Pro"
   }
 }

--- a/.agents/tools/video/higgsfield-ui.md
+++ b/.agents/tools/video/higgsfield-ui.md
@@ -16,6 +16,8 @@ tools:
 
 Browser-based automation for Higgsfield AI using Playwright. This subagent drives the Higgsfield web UI to generate images, videos, lipsync, and effects using **subscription credits** (which are only available through the UI, not the API).
 
+**Automation Coverage**: Image generation (10/10 models), Video creation (2/4 workflows), Cinema Studio, Motion Control, Edit/Inpaint (5 models), Upscale, Lipsync (11 models), Apps (38 via generic handler), Asset Library, Pipeline with Remotion post-production, Seed Bracketing.
+
 ## When to Use
 
 Use this subagent instead of the API subagent (`higgsfield.md`) when:
@@ -46,6 +48,21 @@ Use this subagent instead of the API subagent (`higgsfield.md`) when:
 # Use an app/effect
 ~/.aidevops/agents/scripts/higgsfield-helper.sh app face-swap --image-file photo.jpg
 
+# Cinema Studio (cinematic image/video with camera+lens presets)
+~/.aidevops/agents/scripts/higgsfield-helper.sh cinema-studio "Epic landscape" --tab image --camera "Dolly Zoom"
+
+# Motion Control (animate character with motion reference video)
+~/.aidevops/agents/scripts/higgsfield-helper.sh motion-control --video-file dance.mp4 --image-file character.jpg
+
+# Edit/Inpaint (5 models: soul_inpaint, banana_placement, canvas, multi, nano_banana_pro_inpaint)
+~/.aidevops/agents/scripts/higgsfield-helper.sh edit "Replace background with beach" --image-file photo.jpg -m soul_inpaint
+
+# Upscale (AI upscale image or video)
+~/.aidevops/agents/scripts/higgsfield-helper.sh upscale --image-file low-res.jpg
+
+# Asset Library (browse, filter, download)
+~/.aidevops/agents/scripts/higgsfield-helper.sh manage-assets --asset-action list --filter video
+
 # Check credits and unlimited models
 ~/.aidevops/agents/scripts/higgsfield-helper.sh credits
 
@@ -57,7 +74,7 @@ Use this subagent instead of the API subagent (`higgsfield.md`) when:
 
 ```text
 higgsfield-helper.sh (shell wrapper)
-  └── higgsfield/playwright-automator.mjs (Playwright automation, ~3400 lines)
+  └── higgsfield/playwright-automator.mjs (Playwright automation, ~3900 lines)
         ├── Persistent auth state (~/.aidevops/.agent-workspace/work/higgsfield/auth-state.json)
         ├── Site discovery cache (~/.aidevops/.agent-workspace/work/higgsfield/routes-cache.json)
         ├── Credentials from ~/.config/aidevops/credentials.sh
@@ -147,7 +164,7 @@ higgsfield-helper.sh lipsync "Breaking news today..." --image-file anchor.jpg --
 
 ### Apps and Effects
 
-Higgsfield has 86+ apps for one-click content creation:
+Higgsfield has 38+ apps for one-click content creation (visible on /apps page):
 
 ```bash
 # Face swap
@@ -163,7 +180,100 @@ higgsfield-helper.sh app comic-book --image-file photo.jpg
 higgsfield-helper.sh app sketch-to-real --image-file sketch.jpg
 ```
 
-**Popular apps**: face-swap, 3d-render, comic-book, transitions, recast, skin-enhancer, angles, relight, shots, zooms, poster, sketch-to-real, renaissance, mugshot, character-swap, outfit-swap, click-to-ad, plushies, sticker-matchcut
+**Popular apps**: face-swap, 3d-render, comic-book, transitions, recast, skin-enhancer, angles, relight, shots, zooms, poster, sketch-to-real, renaissance, mugshot, character-swap, outfit-swap, link-to-video-ad, plushies, sticker-matchcut, surrounded-by-animals
+
+### Cinema Studio
+
+Professional cinematic image/video with camera and lens simulation presets.
+
+```bash
+# Cinematic image with camera preset
+higgsfield-helper.sh cinema-studio "Epic mountain landscape at golden hour" --tab image --camera "Dolly Zoom"
+
+# Cinematic video
+higgsfield-helper.sh cinema-studio "Dramatic reveal of ancient temple" --duration 10 --lens "Anamorphic"
+
+# With quality and aspect
+higgsfield-helper.sh cinema-studio "Product hero shot" --tab image --quality 4K --aspect 16:9
+```
+
+Controls: Image/Video tab, camera presets (Dolly Zoom, Tracking, etc.), lens presets (Anamorphic, etc.), quality (1K/2K/4K), aspect ratio, batch count. Cost: 20 credits (has free generations).
+
+### Motion Control
+
+Animate a character image using a motion reference video.
+
+```bash
+# Upload dance video as motion reference + character image
+higgsfield-helper.sh motion-control --video-file dance.mp4 --image-file character.jpg
+
+# With prompt guidance
+higgsfield-helper.sh motion-control --motion-ref walk.mp4 --image-file person.jpg -p "Walking through park"
+
+# Unlimited mode (Kling)
+higgsfield-helper.sh motion-control --video-file ref.mp4 --image-file face.jpg --unlimited
+```
+
+Accepts `--video-file` or `--motion-ref` for the reference video (3-30s), `--image-file` for the character. Cost: UNLIMITED with Kling.
+
+### Edit/Inpaint
+
+Upload an image and edit/inpaint specific regions with 5 available models.
+
+```bash
+# Soul Inpaint (default)
+higgsfield-helper.sh edit "Replace background with tropical beach" --image-file photo.jpg
+
+# Product placement (Banana Placement model)
+higgsfield-helper.sh edit "Place product on marble table" --image-file product.jpg -m banana_placement
+
+# Multi-reference (two images)
+higgsfield-helper.sh edit "Combine styles" --image-file base.jpg --image-file2 reference.jpg -m multi
+
+# Canvas model
+higgsfield-helper.sh edit "Extend the scene" --image-file photo.jpg -m canvas
+```
+
+Models: `soul_inpaint` (default), `nano_banana_pro_inpaint`, `banana_placement`, `canvas`, `multi`. The `--image-file2` flag provides a second reference image for multi-reference and product placement models.
+
+### Upscale
+
+AI upscale an image or video to higher resolution.
+
+```bash
+# Upscale an image
+higgsfield-helper.sh upscale --image-file low-res.jpg
+
+# Upscale a video
+higgsfield-helper.sh upscale --video-file clip.mp4
+
+# Custom output
+higgsfield-helper.sh upscale --image-file photo.jpg --output ~/Projects/hires/
+```
+
+### Asset Library
+
+Browse, filter, and download from the Higgsfield asset library.
+
+```bash
+# List all assets
+higgsfield-helper.sh manage-assets --asset-action list
+
+# List filtered by type
+higgsfield-helper.sh manage-assets --asset-action list --filter video
+higgsfield-helper.sh manage-assets --asset-action list --filter lipsync
+
+# Download latest asset
+higgsfield-helper.sh manage-assets --asset-action download-latest --filter image
+
+# Download specific asset by index
+higgsfield-helper.sh manage-assets --asset-action download --asset-index 3
+
+# Bulk download (up to N assets)
+higgsfield-helper.sh manage-assets --asset-action download-all --limit 20
+```
+
+Filters: `image`, `video`, `lipsync`, `upscaled`, `liked`. Actions: `list`, `download`, `download-latest`, `download-all`.
 
 ### Account Management
 
@@ -221,6 +331,7 @@ higgsfield-helper.sh download --model video # videos from History
 
 | Model | Resolution | Duration | Cost |
 |-------|-----------|----------|------|
+| Wan 2.5 Fast | varies | varies | varies |
 | Kling 2.6 Lipsync | 1080p | 10s | varies |
 | Google Veo 3 | 720p | 8s | varies |
 | Veo 3 Fast | 720p | 8s | varies |
@@ -460,6 +571,17 @@ Results saved to `~/Downloads/seed-bracket-{timestamp}/` with `bracket-results.j
 --character-image  Character face image for pipeline
 --dialogue         Dialogue text for lipsync in pipeline
 --scenes           Number of scenes to generate
+--video-file       Path to video file (motion reference for motion-control)
+--motion-ref       Alias for --video-file (motion reference video)
+--image-file2      Second image file (multi-reference edit, product placement)
+--camera           Camera preset for cinema-studio (e.g., "Dolly Zoom")
+--lens             Lens preset for cinema-studio (e.g., "Anamorphic")
+--tab              Tab selection: "image" or "video" (cinema-studio)
+--filter           Asset filter: image, video, lipsync, upscaled, liked
+--asset-action     Asset action: list, download, download-latest, download-all
+--asset-type       Asset type filter for manage-assets
+--asset-index      Index of specific asset to download (0-based)
+--limit            Max number of assets to download
 ```
 
 ## Prompt Engineering Tips

--- a/.agents/tools/video/higgsfield-ui.md
+++ b/.agents/tools/video/higgsfield-ui.md
@@ -16,7 +16,7 @@ tools:
 
 Browser-based automation for Higgsfield AI using Playwright. This subagent drives the Higgsfield web UI to generate images, videos, lipsync, and effects using **subscription credits** (which are only available through the UI, not the API).
 
-**Automation Coverage**: Image generation (10/10 models), Video creation (2/4 workflows), Cinema Studio, Motion Control, Edit/Inpaint (5 models), Upscale, Lipsync (11 models), Apps (38 via generic handler), Asset Library, Pipeline with Remotion post-production, Seed Bracketing.
+**Automation Coverage**: Full UI coverage -- Image generation (10/10 models), Video creation (4/4 workflows), Cinema Studio, Motion Control, Video Edit, Edit/Inpaint (5 models), Upscale, Lipsync (11 models), Apps (38+ via generic handler), Asset Library + Asset Chaining (9 actions), Mixed Media Presets (32), Motion/VFX Presets (150+), Vibe Motion (5 sub-types), Storyboard Generator, AI Influencer Studio, Character profiles, Feature pages (Fashion Factory, UGC Factory, Photodump Studio, Camera Controls, Effects), Pipeline with Remotion post-production, Seed Bracketing. **27 CLI commands total.**
 
 ## When to Use
 
@@ -74,7 +74,7 @@ Use this subagent instead of the API subagent (`higgsfield.md`) when:
 
 ```text
 higgsfield-helper.sh (shell wrapper)
-  └── higgsfield/playwright-automator.mjs (Playwright automation, ~3900 lines)
+  └── higgsfield/playwright-automator.mjs (Playwright automation, ~4900 lines)
         ├── Persistent auth state (~/.aidevops/.agent-workspace/work/higgsfield/auth-state.json)
         ├── Site discovery cache (~/.aidevops/.agent-workspace/work/higgsfield/routes-cache.json)
         ├── Credentials from ~/.config/aidevops/credentials.sh
@@ -274,6 +274,164 @@ higgsfield-helper.sh manage-assets --asset-action download-all --limit 20
 ```
 
 Filters: `image`, `video`, `lipsync`, `upscaled`, `liked`. Actions: `list`, `download`, `download-latest`, `download-all`.
+
+### Asset Chaining ("Open in")
+
+Chain an existing asset directly to another tool without downloading and re-uploading. Uses the "Open in" menu from the asset detail dialog.
+
+```bash
+# Animate an asset (send to video generation)
+higgsfield-helper.sh chain --chain-action animate --asset-index 0
+
+# Inpaint an asset with a prompt
+higgsfield-helper.sh chain --chain-action inpaint -p "Replace background with sunset" --asset-index 0
+
+# Upscale the latest asset
+higgsfield-helper.sh chain --chain-action upscale --asset-index 0
+
+# Relight, change angles, or apply AI styling
+higgsfield-helper.sh chain --chain-action relight --asset-index 2
+higgsfield-helper.sh chain --chain-action angles --asset-index 0
+higgsfield-helper.sh chain --chain-action ai-stylist --asset-index 0
+```
+
+Available actions: `animate`, `inpaint`, `upscale`, `relight`, `angles`, `shots`, `ai-stylist`, `skin-enhancer`, `multishot`. The `--asset-index` selects which asset to chain (0 = latest).
+
+### Mixed Media Presets
+
+Apply visual transformation presets (32+ presets with UUID-based URLs).
+
+```bash
+# Apply sketch preset
+higgsfield-helper.sh mixed-media --preset sketch --image-file photo.jpg
+
+# Apply noir preset
+higgsfield-helper.sh mixed-media --preset noir --image-file photo.jpg
+
+# Other presets: layer, canvas, flash_comic, overexposed, paper, particles,
+# hand_paint, toxic, vintage, comic, origami, marble, lava, ocean, magazine,
+# modern, acid, tracking, ultraviolet, glitch, neon, watercolor, blueprint,
+# thermal, xray, infrared, hologram, pixelate, mosaic
+```
+
+### Motion/VFX Presets
+
+Apply motion or VFX effects from 150+ presets discovered dynamically.
+
+```bash
+# List available presets
+higgsfield-helper.sh motion-preset
+
+# Apply a preset by name
+higgsfield-helper.sh motion-preset --preset dolly_zoom --image-file photo.jpg
+
+# Apply by UUID directly
+higgsfield-helper.sh motion-preset --preset "a1b2c3d4-..." --image-file photo.jpg
+```
+
+Presets are discovered by `discover` and cached in `routes-cache.json`. Run `discover` to refresh.
+
+### Video Edit
+
+Edit an existing video with a character image overlay.
+
+```bash
+# Edit video with character
+higgsfield-helper.sh video-edit --video-file clip.mp4 --image-file character.jpg -p "Character walks through scene"
+```
+
+### Storyboard Generator
+
+Create multi-panel storyboards from a script or prompt.
+
+```bash
+# Generate storyboard
+higgsfield-helper.sh storyboard -p "A hero's journey through a cyberpunk city" --scenes 6
+
+# With style preset
+higgsfield-helper.sh storyboard -p "Product launch story" --scenes 4 --preset "Cinematic"
+
+# With reference image
+higgsfield-helper.sh storyboard -p "Day in the life" --image-file reference.jpg
+```
+
+### Vibe Motion
+
+Animated content creation with 5 sub-types.
+
+```bash
+# Poster animation
+higgsfield-helper.sh vibe-motion -p "Product launch announcement" --tab posters --preset Corporate
+
+# Text animation
+higgsfield-helper.sh vibe-motion -p "Breaking News: AI Revolution" --tab text-animation --duration 10
+
+# Infographics
+higgsfield-helper.sh vibe-motion -p "Q4 Revenue Growth 45%" --tab infographics --preset Minimal
+
+# Presentation
+higgsfield-helper.sh vibe-motion -p "Company overview slides" --tab presentation --duration 30
+
+# From scratch (default)
+higgsfield-helper.sh vibe-motion -p "Abstract motion graphics" --image-file logo.png
+```
+
+Sub-types: `infographics`, `text-animation`, `posters`, `presentation`, `from-scratch`. Styles: Minimal, Corporate, Fashion, Marketing. Duration: Auto/5/10/15/30s. Cost: 8-60 credits.
+
+### AI Influencer Studio
+
+Create AI-generated influencer characters.
+
+```bash
+# Create human influencer
+higgsfield-helper.sh influencer --preset Human -p "Fashion influencer, warm smile, studio lighting"
+
+# Create fantasy character
+higgsfield-helper.sh influencer --preset Elf -p "Ethereal forest guardian"
+
+# With reference image
+higgsfield-helper.sh influencer --image-file reference.jpg -p "Similar style influencer"
+```
+
+Character types: Human, Ant, Bee, Octopus, Alien, Elf, and more. Cost: 30 free generations.
+
+### Character Profiles
+
+Create persistent character profiles for consistent generation across sessions.
+
+```bash
+# Create character from photo
+higgsfield-helper.sh character --image-file face.jpg -p "Sarah"
+
+# With multiple reference photos
+higgsfield-helper.sh character --image-file face1.jpg --image-file2 face2.jpg -p "Alex"
+```
+
+### Feature Pages
+
+Generic handler for feature pages that follow the standard upload + generate pattern.
+
+```bash
+# Fashion Factory
+higgsfield-helper.sh feature --feature fashion-factory --image-file outfit.jpg -p "Summer collection"
+
+# UGC Factory
+higgsfield-helper.sh feature --feature ugc-factory --image-file product.jpg -p "Unboxing review script"
+
+# Photodump Studio
+higgsfield-helper.sh feature --feature photodump-studio --image-file photo1.jpg
+
+# Camera Controls
+higgsfield-helper.sh feature --feature camera-controls --image-file scene.jpg
+
+# Effects
+higgsfield-helper.sh feature --feature effects --image-file photo.jpg
+
+# Shorthand (command name = feature name)
+higgsfield-helper.sh fashion-factory --image-file outfit.jpg
+higgsfield-helper.sh ugc-factory --image-file product.jpg
+higgsfield-helper.sh effects --image-file photo.jpg
+```
 
 ### Account Management
 
@@ -582,6 +740,9 @@ Results saved to `~/Downloads/seed-bracket-{timestamp}/` with `bracket-results.j
 --asset-type       Asset type filter for manage-assets
 --asset-index      Index of specific asset to download (0-based)
 --limit            Max number of assets to download
+--chain-action     Asset chain action: animate, inpaint, upscale, relight, angles, shots, ai-stylist, skin-enhancer, multishot
+--feature          Feature page slug: fashion-factory, ugc-factory, photodump-studio, camera-controls, effects
+--subtype          Vibe Motion sub-type: infographics, text-animation, posters, presentation, from-scratch
 ```
 
 ## Prompt Engineering Tips


### PR DESCRIPTION
## Summary

- Add 5 new Playwright automation functions (~490 lines) for previously unautomated Higgsfield features: Cinema Studio, Motion Control, Edit/Inpaint (5 models), Upscale, and Asset Library management
- Update routes.json with audit findings: remove deprecated draw-to-video (404), fix click-to-ad URL, add new apps/presets/model pages/lipsync registry
- Update higgsfield-ui.md documentation with new command sections, CLI options, coverage summary

## Changes

### playwright-automator.mjs (+489 lines)

| Function | Feature | URL |
|----------|---------|-----|
| `cinemaStudio()` | Cinematic image/video with camera+lens presets | `/cinema-studio` |
| `motionControl()` | Animate character with motion reference video | `/create/motion-control` |
| `editImage()` | Edit/Inpaint with 5 models | `/edit?model=X` |
| `upscale()` | AI upscale image or video | `/upscale` |
| `manageAssets()` | Asset Library browse, filter, download | `/asset/all` |

All functions fully wired to CLI (switch/case, help text, parseArgs) with new flags: `--video-file`, `--motion-ref`, `--image-file2`, `--camera`, `--lens`, `--tab`, `--filter`, `--asset-action`, `--asset-index`, `--limit`.

### routes.json (+47/-7)

- Removed deprecated `/create/draw-to-video` (returns 404)
- Fixed `/app/click-to-ad` → `/app/link-to-video-ad`
- Added `/app/surrounded-by-animals` (Micro-Beasts)
- Added 14 new mixed media presets (tracking, ultraviolet, windows, palette, etc.)
- Added `model_pages` section (Kling 3.0, Seedance 2.0, WAN 2.6, Veo 3.1, etc.)
- Added `lipsync_models` registry (11 models including new Wan 2.5 Fast)

### higgsfield-ui.md (+128 lines)

- Added command sections: Cinema Studio, Motion Control, Edit/Inpaint, Upscale, Asset Library
- Added coverage summary to intro
- Updated CLI options reference with all new flags
- Added Wan 2.5 Fast to lipsync models table
- Fixed app count (38 visible on /apps page, not 86+)

## Verification

- `node --check playwright-automator.mjs` — passes
- `JSON.parse(routes.json)` — valid
- `markdownlint` — 0 errors
- Based on comprehensive UI audit of all Higgsfield pages (screenshots in `~/.aidevops/.agent-workspace/work/higgsfield/audit/`)