### PR TITLE
feat: integrate email accessibility checks into email-health-check + email-design-test (t215.6)

### DIFF
--- a/.agents/scripts/commands/email-health-check.md
+++ b/.agents/scripts/commands/email-health-check.md
@@ -87,6 +87,7 @@ Actions:
 | `/email-health-check example.com dkim google` | DKIM with selector |
 | `/email-health-check newsletter.html check-links` | Link validation only |
 | `/email-health-check newsletter.html check-subject` | Subject line check only |
+| `/email-health-check accessibility newsletter.html` | Email accessibility audit |
 
 ## Examples
 
@@ -144,9 +145,32 @@ AI: Running full precheck...
     Combined:      20/25 (80%) - Grade: B
 ```
 
+**Email accessibility check:**
+
+```text
+User: /email-health-check accessibility newsletter.html
+AI: Running email accessibility audit on newsletter.html...
+
+    Email Accessibility Report
+    Standard: WCAG 2.1 AA (email-applicable subset)
+
+    PASS: All images have alt attributes (5 images)
+    FAIL: Missing lang attribute on <html> tag
+    WARN: 3 table(s) without role attribute
+    PASS: No excessively small font sizes detected
+    PASS: No generic link text detected
+
+    Summary: 1 error(s), 1 warning(s)
+
+    Recommendations:
+    1. Add lang="en" to the <html> tag
+    2. Add role="presentation" to layout tables
+```
+
 ## Related
 
 - `services/email/email-health-check.md` - Full documentation
 - `services/email/email-testing.md` - Design rendering and delivery testing
 - `content/distribution/email.md` - Email content strategy
 - `services/email/ses.md` - Amazon SES integration
+- `tools/accessibility/accessibility.md` - WCAG accessibility reference

--- a/.agents/scripts/commands/email-test-suite.md
+++ b/.agents/scripts/commands/email-test-suite.md
@@ -63,8 +63,9 @@ Actions:
 
 | Command | Purpose |
 |---------|---------|
-| `/email-test-suite newsletter.html` | Design rendering tests |
+| `/email-test-suite newsletter.html` | Design rendering tests (includes accessibility) |
 | `/email-test-suite example.com` | Inbox placement analysis |
+| `/email-test-suite accessibility newsletter.html` | Email accessibility check only |
 | `/email-test-suite smtp mail.example.com 587` | SMTP connectivity test |
 | `/email-test-suite headers headers.txt` | Header analysis |
 | `/email-test-suite generate` | Generate test email template |
@@ -82,6 +83,11 @@ AI: Running design rendering tests on newsletter.html...
     Dark Mode: 2 warnings (hardcoded colors)
     Responsive: OK
 
+    Accessibility:
+    - PASS: All images have alt text
+    - WARN: 2 tables without role="presentation"
+    - PASS: lang attribute present
+
     Top Issues:
     1. Flexbox layout will break in Outlook
     2. Missing color-scheme meta for dark mode
@@ -91,6 +97,7 @@ AI: Running design rendering tests on newsletter.html...
     1. Replace flexbox with table-based layout
     2. Add dark mode meta tags and media queries
     3. Remove CSS animations or use as progressive enhancement
+    4. Add role="presentation" to layout tables
 ```
 
 **Inbox placement check:**
@@ -121,3 +128,4 @@ AI: Checking inbox placement factors for example.com...
 - `services/email/email-testing.md` - Full documentation
 - `services/email/email-health-check.md` - DNS authentication checks
 - `services/email/ses.md` - Amazon SES integration
+- `tools/accessibility/accessibility.md` - WCAG accessibility reference

--- a/.agents/services/email/email-health-check.md
+++ b/.agents/services/email/email-health-check.md
@@ -50,6 +50,9 @@ email-health-check-helper.sh check-accessibility newsletter.html
 email-health-check-helper.sh check-links newsletter.html
 email-health-check-helper.sh check-images newsletter.html
 email-health-check-helper.sh check-spam-words newsletter.html
+
+# Email accessibility audit (WCAG 2.1)
+email-health-check-helper.sh accessibility newsletter.html
 ```
 
 <!-- AI-CONTEXT-END -->
@@ -460,10 +463,32 @@ email-health-check-helper.sh precheck example.com newsletter.html
 # Combined:      20/25 (80%) - Grade: B
 ```
 
+## Email Accessibility
+
+The health check includes an `accessibility` command for auditing HTML email templates against WCAG 2.1 AA (email-applicable subset):
+
+```bash
+email-health-check-helper.sh accessibility newsletter.html
+```
+
+This delegates to `accessibility-helper.sh email` and checks:
+
+- Images without `alt` attributes (WCAG 1.1.1)
+- Missing `lang` attribute on `<html>` (WCAG 3.1.1)
+- Layout tables without `role="presentation"` (WCAG 1.3.1)
+- Small font sizes below 14px (WCAG 1.4.4)
+- Generic link text like "click here" (WCAG 2.4.4)
+- Heading structure (WCAG 1.3.1)
+- Colour-only information indicators (WCAG 1.4.1)
+
+For contrast ratio checks, use: `accessibility-helper.sh contrast '#fg' '#bg'`
+
 ## Related
 
 - `services/email/email-testing.md` - Design rendering and delivery testing
 - `services/email/ses.md` - Amazon SES integration
 - `services/hosting/dns.md` - DNS management
 - `content/distribution/email.md` - Email content strategy and best practices
+- `tools/accessibility/accessibility.md` - WCAG accessibility reference
+- `services/accessibility/accessibility-audit.md` - Full accessibility audit service
 - `tools/browser/browser-automation.md` - For mail-tester automation

--- a/.agents/services/email/email-testing.md
+++ b/.agents/services/email/email-testing.md
@@ -26,10 +26,11 @@ tools:
 **Quick commands:**
 
 ```bash
-# Design rendering tests
+# Design rendering tests (includes accessibility)
 email-test-suite-helper.sh test-design newsletter.html
 email-test-suite-helper.sh check-dark-mode template.html
 email-test-suite-helper.sh check-responsive campaign.html
+email-test-suite-helper.sh check-accessibility newsletter.html
 
 # Delivery testing
 email-test-suite-helper.sh test-smtp smtp.gmail.com 587
@@ -57,6 +58,7 @@ Validate that HTML emails render correctly across email clients:
 - **CSS Compatibility** - Detects unsupported CSS (flexbox, grid, position, float, animations) that break in Outlook/Gmail/Yahoo
 - **Dark Mode** - color-scheme meta, prefers-color-scheme queries, hardcoded colors, transparent PNGs
 - **Responsive Design** - Viewport meta, fixed widths, media queries, MSO conditionals, font sizes, touch targets
+- **Accessibility** - WCAG 2.1 AA checks: alt text, lang attribute, table roles, font sizes, link text, headings, colour usage
 
 ### 2. Delivery Testing
 
@@ -73,7 +75,7 @@ Validate email delivery infrastructure:
 ### Design Rendering
 
 ```bash
-# Full design test suite (all checks)
+# Full design test suite (all checks including accessibility)
 email-test-suite-helper.sh test-design newsletter.html
 
 # Individual checks
@@ -81,6 +83,7 @@ email-test-suite-helper.sh validate-html newsletter.html
 email-test-suite-helper.sh check-css newsletter.html
 email-test-suite-helper.sh check-dark-mode newsletter.html
 email-test-suite-helper.sh check-responsive newsletter.html
+email-test-suite-helper.sh check-accessibility newsletter.html
 
 # Generate a test email template
 email-test-suite-helper.sh generate-test-email test.html
@@ -188,7 +191,7 @@ The email test suite complements `email-health-check-helper.sh`:
 # 1. Check DNS authentication
 email-health-check-helper.sh check example.com
 
-# 2. Test design rendering
+# 2. Test design rendering (includes accessibility)
 email-test-suite-helper.sh test-design newsletter.html
 
 # 3. Check delivery infrastructure
@@ -196,6 +199,9 @@ email-test-suite-helper.sh check-placement example.com
 
 # 4. Test SMTP connectivity
 email-test-suite-helper.sh test-smtp-domain example.com
+
+# 5. Standalone accessibility audit (if needed)
+email-health-check-helper.sh accessibility newsletter.html
 ```
 
 ## External Testing Services
@@ -217,4 +223,6 @@ For visual rendering tests across real email clients:
 - `services/email/email-health-check.md` - DNS authentication checks
 - `services/email/ses.md` - Amazon SES integration
 - `content/distribution/email.md` - Email content strategy
+- `tools/accessibility/accessibility.md` - WCAG accessibility reference
+- `services/accessibility/accessibility-audit.md` - Full accessibility audit service
 - `tools/browser/browser-automation.md` - For automated rendering tests


### PR DESCRIPTION
## Summary

- Add WCAG 2.1 AA email accessibility auditing to both `email-health-check-helper.sh` and `email-test-suite-helper.sh`
- New `accessibility` command in health-check delegates to `accessibility-helper.sh email`
- New `check-accessibility` command in test-suite with fallback inline checks when helper is unavailable
- Accessibility runs automatically as part of `test-design` full suite
- Updated all 4 documentation files with accessibility options, examples, and cross-references

## Changes

### email-health-check-helper.sh (+41 lines)
- New `check_email_accessibility()` function delegating to `accessibility-helper.sh email`
- New `accessibility|a11y` case in main command router
- Added accessibility to help text, examples, and "Next Steps" output
- Added `accessibility-helper.sh` to Related section

### email-test-suite-helper.sh (+128 lines)
- New `check_accessibility()` function with:
  - Primary: delegates to `accessibility-helper.sh email`
  - Fallback: 7 inline WCAG checks (alt text, lang, table roles, font sizes, link text, headings, colour-only indicators)
- Integrated into `test_design()` flow (runs automatically with full suite)
- New `check-accessibility|accessibility|a11y` case in main command router
- Updated help text with accessibility command and examples
- Added Related section

### Documentation (4 files)
- `commands/email-health-check.md`: Added accessibility option and example
- `commands/email-test-suite.md`: Added accessibility option, example output, and cross-reference
- `services/email/email-health-check.md`: Added accessibility command to quick reference, new "Email Accessibility" section
- `services/email/email-testing.md`: Added accessibility to design rendering overview, quick commands, usage, and workflow

## Design Decision

Delegated to existing `accessibility-helper.sh` rather than duplicating logic — matches project convention of single-responsibility helpers. Added inline fallback in `email-test-suite` for resilience when the helper is not available.

## Verification

- ShellCheck: zero violations on both scripts
- Bash syntax: valid on both scripts
- Purely additive: 241 insertions, 5 deletions (replaced help text lines only)
- No files deleted, no existing features removed