### PR TITLE
fix: force-click all generate buttons to bypass Higgsfield overlay interception

### DIFF
--- a/.agents/scripts/higgsfield/playwright-automator.mjs
+++ b/.agents/scripts/higgsfield/playwright-automator.mjs
@@ -2366,7 +2366,7 @@ async function useApp(options = {}) {
     // Click generate/create
     const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Create"), button:has-text("Apply"), button[type="submit"]:visible');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked generate/apply button');
     }
 
@@ -3384,7 +3384,7 @@ async function cinemaStudio(options = {}) {
     // Click Generate
     const generateBtn = page.locator('button:has-text("Generate")');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked Generate in Cinema Studio');
     }
 
@@ -3475,7 +3475,7 @@ async function motionControl(options = {}) {
     // Click Generate
     const generateBtn = page.locator('button:has-text("Generate")');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked Generate in Motion Control');
     }
 
@@ -4202,7 +4202,7 @@ async function mixedMediaPreset(options = {}) {
     // Click Generate
     const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Apply"), button:has-text("Create")');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked Generate for mixed media preset');
     }
 
@@ -4325,7 +4325,7 @@ async function motionPreset(options = {}) {
     // Click Generate
     const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Apply"), button:has-text("Create")');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked Generate for motion preset');
     }
 
@@ -4407,7 +4407,7 @@ async function editVideo(options = {}) {
     // Click Generate
     const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Apply"), button:has-text("Edit")');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked Generate for video edit');
     }
 
@@ -4500,7 +4500,7 @@ async function storyboard(options = {}) {
     // Click Generate
     const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Create"), button:has-text("Build")');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked Generate for storyboard');
     }
 
@@ -4616,7 +4616,7 @@ async function vibeMotion(options = {}) {
     // Click Generate
     const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Create"), button:has-text("Build")');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked Generate for Vibe Motion');
     }
 
@@ -4692,7 +4692,7 @@ async function aiInfluencer(options = {}) {
     // Click Generate/Create
     const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Create"), button:has-text("Build")');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked Generate for AI Influencer');
     }
 
@@ -4875,7 +4875,7 @@ async function featurePage(options = {}) {
     // Click Generate/Create/Apply
     const generateBtn = page.locator('button:has-text("Generate"), button:has-text("Create"), button:has-text("Apply"), button[type="submit"]:visible');
     if (await generateBtn.count() > 0) {
-      await generateBtn.first().click();
+      await generateBtn.first().click({ force: true });
       console.log('Clicked Generate');
     }
 


### PR DESCRIPTION
## Summary

Adds `{ force: true }` to all 10 generate/create/build button clicks across the Higgsfield automator.

Higgsfield UI uses loading/transition overlays (`z-10 absolute inset-0` divs, `h1` elements) that persist and intercept pointer events. Playwright's default click waits for actionability, which times out when these overlays don't clear. `force: true` bypasses actionability checks, matching the pattern already established in the asset chain function from PR #956.

## Testing

Verified with live Higgsfield account:
- `vibe-motion --tab posters` — Previously timed out, now clicks Generate successfully
- `influencer` — Previously timed out on loading overlay, now clicks Generate successfully
- `storyboard` — Clicks Generate, downloads 3 videos
- `feature --feature fashion-factory` — Clicks Generate, downloads 32 assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of automated interactions across multiple pages including image, video, app, storyboard, vibe-motion, mixed-media, motion-preset, and feature pages.
  * Enhanced button click robustness to reduce sporadic interaction failures caused by UI overlays or obstructing elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->