### PR TITLE
t234: Add ShellCheck pre-push gate to worker prompt

### DIFF
--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -407,6 +407,7 @@ loop_generate_reanchor() {
 - Report status via exit code, log output, and PR creation only.
 - Put task notes in commit messages or PR body, never in TODO.md.
 - Work ONLY on the assigned task described above. Do not pick tasks from TODO.md.
+- **ShellCheck before push (t234)**: Before every \`git push\`, if any committed .sh files changed, run \`shellcheck -x -S warning\` on them. Fix violations before pushing. Skip if shellcheck is not installed.
 "
     fi
 


### PR DESCRIPTION
## Summary

- Workers are now instructed to run `shellcheck -x -S warning` on modified `.sh` files before every `git push`, catching CI failures 5-10 minutes earlier
- Added as step 3 in the Worker Efficiency Protocol (injected into every headless worker session via `build_dispatch_cmd()`)
- Added to the re-anchor prompt in `loop-common.sh` so the gate survives context compaction
- Updated `headless-dispatch.md` documentation with the new step and comparison table row

## Changes

| File | Change |
|------|--------|
| `supervisor-helper.sh` | New step 3 "ShellCheck gate before push" in `build_dispatch_cmd()`, renumbered 3-6 to 4-7 |
| `loop-common.sh` | Added ShellCheck bullet to headless worker restrictions in re-anchor prompt |
| `headless-dispatch.md` | Added step 3 docs, renumbered 3-7 to 4-8, added "Why This Matters" table row |

## How It Works

Before every `git push`, workers check for modified `.sh` files and run ShellCheck on them. If violations are found, the worker fixes them before pushing. If `shellcheck` is not installed, the gate is skipped with a note in the PR body.

## Testing

- `bash -n` syntax check passes on both modified shell scripts
- `shellcheck` passes on `loop-common.sh`
- Changes are in string literals (worker prompt text), so they do not affect script execution