### PR TITLE
feat(email): Email Testing Suite cross-references (t214)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -319,6 +319,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | YouTube | `content/distribution/youtube/` (migrated from root, see content.md) |
 | Vision | `tools/vision/overview.md` (decision tree, then `image-generation.md`, `image-understanding.md`, `image-editing.md`) |
 | Voice | `tools/voice/speech-to-speech.md`, `voice-helper.sh talk` (voice bridge) |
+| Email testing | `services/email/email-design-test.md`, `services/email/email-delivery-test.md`, `services/email/email-health-check.md`, `email-test-suite-helper.sh` |
 | Encryption | `tools/credentials/encryption-stack.md` (decision tree), `tools/credentials/sops.md`, `tools/credentials/gocryptfs.md`, `tools/credentials/gopass.md` |
 | Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting) |
 | Cloud GPU | `tools/infrastructure/cloud-gpu.md` |

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -319,7 +319,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | YouTube | `content/distribution/youtube/` (migrated from root, see content.md) |
 | Vision | `tools/vision/overview.md` (decision tree, then `image-generation.md`, `image-understanding.md`, `image-editing.md`) |
 | Voice | `tools/voice/speech-to-speech.md`, `voice-helper.sh talk` (voice bridge) |
-| Email testing | `services/email/email-design-test.md`, `services/email/email-delivery-test.md`, `services/email/email-health-check.md`, `email-test-suite-helper.sh` |
+| Email testing | `services/email/email-testing.md` (overview), `services/email/email-design-test.md`, `services/email/email-delivery-test.md`, `email-test-suite-helper.sh` |
 | Encryption | `tools/credentials/encryption-stack.md` (decision tree), `tools/credentials/sops.md`, `tools/credentials/gocryptfs.md`, `tools/credentials/gopass.md` |
 | Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting) |
 | Cloud GPU | `tools/infrastructure/cloud-gpu.md` |

--- a/.agents/content/distribution/email.md
+++ b/.agents/content/distribution/email.md
@@ -259,7 +259,15 @@ Tag subscribers based on:
 
 - `services/accessibility/accessibility-audit.md` - Email accessibility checks (WCAG compliance)
 - `services/email/email-health-check.md` - DNS authentication and deliverability
-- `services/email/email-testing.md` - Design rendering and delivery testing
+- `services/email/email-testing.md` - Design rendering and delivery testing overview
+- `services/email/email-design-test.md` - Cross-client rendering tests (Litmus, Email on Acid)
+- `services/email/email-delivery-test.md` - Inbox placement and spam scoring (GlockApps, Mail Tester)
+
+**Pre-Send Testing Checklist** (run via `email-test-suite-helper.sh full`):
+
+1. Content checks — subject line, preheader, accessibility, links, images, spam words (`email-health-check-helper.sh`)
+2. Design rendering — cross-client screenshots and compatibility (`email-design-test-helper.sh`)
+3. Delivery testing — inbox placement, spam score, authentication (`email-delivery-test-helper.sh`)
 
 **Distribution Channels**:
 

--- a/.agents/content/distribution/email.md
+++ b/.agents/content/distribution/email.md
@@ -263,7 +263,7 @@ Tag subscribers based on:
 - `services/email/email-design-test.md` - Cross-client rendering tests (Litmus, Email on Acid)
 - `services/email/email-delivery-test.md` - Inbox placement and spam scoring (GlockApps, Mail Tester)
 
-**Pre-Send Testing Checklist** (run via `email-test-suite-helper.sh full`):
+**Pre-Send Testing Checklist** (use `email-test-suite-helper.sh` subcommands):
 
 1. Content checks — subject line, preheader, accessibility, links, images, spam words (`email-health-check-helper.sh`)
 2. Design rendering — cross-client screenshots and compatibility (`email-design-test-helper.sh`)

--- a/.agents/marketing.md
+++ b/.agents/marketing.md
@@ -478,7 +478,7 @@ After each campaign:
 | Spam complaints | Better consent, relevant content |
 | Template rendering | Use `services/email/email-design-test.md` for cross-client testing |
 | Delivery issues | Use `services/email/email-delivery-test.md` for inbox placement and spam scoring |
-| Pre-send validation | Run `email-test-suite-helper.sh full` for comprehensive checks |
+| Pre-send validation | Run `email-test-suite-helper.sh test-design <file>` and `check-placement <domain>` for comprehensive checks |
 | Accessibility issues | Use `services/accessibility/accessibility-audit.md` for WCAG compliance |
 
 ### Getting Help

--- a/.agents/marketing.md
+++ b/.agents/marketing.md
@@ -476,7 +476,9 @@ After each campaign:
 | High unsubscribes | Review frequency, improve targeting |
 | Bounces | Clean list, validate emails |
 | Spam complaints | Better consent, relevant content |
-| Template rendering | Use `services/email/email-testing.md` for cross-client testing |
+| Template rendering | Use `services/email/email-design-test.md` for cross-client testing |
+| Delivery issues | Use `services/email/email-delivery-test.md` for inbox placement and spam scoring |
+| Pre-send validation | Run `email-test-suite-helper.sh full` for comprehensive checks |
 | Accessibility issues | Use `services/accessibility/accessibility-audit.md` for WCAG compliance |
 
 ### Getting Help


### PR DESCRIPTION
## Summary

- Adds **Email testing** row to the progressive disclosure table in `.agents/AGENTS.md`, linking to `email-design-test.md`, `email-delivery-test.md`, `email-health-check.md`, and `email-test-suite-helper.sh`
- Adds **Pre-Send Testing Checklist** section and new agent references to `.agents/content/distribution/email.md`
- Updates troubleshooting table in `.agents/marketing.md` with specific email testing tool references (design, delivery, pre-send validation)

## Context

Phases 1-3 of t214 (Email Testing Suite) were implemented by a previous worker — this PR completes **Phase 4: Cross-references** by integrating the new email testing tools into the framework's discovery paths.

## Changes

| File | Change |
|------|--------|
| `.agents/AGENTS.md` | +1 row in progressive disclosure table |
| `.agents/content/distribution/email.md` | +2 agent links, +pre-send checklist section |
| `.agents/marketing.md` | +2 troubleshooting rows, updated rendering reference |

## Testing

- `bash -n` syntax check: all 4 email helper scripts pass
- Preflight linters: only pre-existing issues (no new violations from these markdown changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized email testing docs into an overview plus separate guides for template rendering and delivery validation
  * Added a Pre‑Send Testing Checklist outlining content, design, and delivery validation steps
  * Introduced helper utilities and tooling guidance to automate design checks, cross‑client rendering, and inbox placement/spam analysis
<!-- end of auto-generated comment: release notes by coderabbit.ai -->