### PR TITLE
fix: add missing local declarations in cmd_transition to prevent cross-contamination

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -1693,6 +1693,7 @@ cmd_batch() {
 #######################################
 cmd_transition() {
     local task_id="" new_state="" error_msg=""
+    local session_id="" worktree="" branch="" log_file="" pr_url=""
 
     # Positional args
     if [[ $# -gt 0 && ! "$1" =~ ^-- ]]; then


### PR DESCRIPTION
## Summary

- Adds `local` declarations for `session_id`, `worktree`, `branch`, `log_file`, and `pr_url` in `cmd_transition()`
- These 5 variables were assigned in the `case` block without `local`, causing them to leak into the shell's global scope
- When the pulse cycle calls `cmd_transition()` in a loop for multiple tasks, stale values from a previous call would be picked up by `${branch:-}` / `${pr_url:-}` checks and written to unrelated tasks' DB rows

## Root Cause

This was the root cause of **all PR cross-contamination** we've been tracking:
- 6 historical duplicate PR links (PRs #657, #761, #805, #810, #922, #925)
- Ongoing backlog-19 contamination where PR #962 (t236.1) was linked to t236.2-5 and t238
- t236.1's branch column was overwritten from `feature/t236.1` to `feature/t236.5` (the last dispatched task)

## Why t232 didn't catch it

The centralized `link_pr_to_task()` (t232) validates PR ownership when called explicitly. But `cmd_transition()` has its own `--pr-url` flag that writes directly to the DB — and the stale global variable caused it to silently pass a wrong PR URL without going through validation.

## One-line fix

```bash
# Before (line 1695):
local task_id="" new_state="" error_msg=""

# After (lines 1695-1696):
local task_id="" new_state="" error_msg=""
local session_id="" worktree="" branch="" log_file="" pr_url=""
```

## Verification

- ShellCheck passes (no new violations)
- The `local` keyword ensures variables are scoped to the function and reset to empty on each call
- Subsequent calls without `--branch`/`--pr-url` will correctly see empty values and skip the DB update