### PR TITLE
fix: add missing closing brace for batchLipsync function

### DIFF
--- a/.agents/scripts/higgsfield/playwright-automator.mjs
+++ b/.agents/scripts/higgsfield/playwright-automator.mjs
@@ -6315,6 +6315,7 @@ async function batchLipsync(options = {}) {
   }
 
   return batchState;
+}
 
 // Main CLI handler
 async function main() {


### PR DESCRIPTION
## Summary

- Adds missing closing `}` for the `batchLipsync()` function in `playwright-automator.mjs`
- The function was introduced in t236.3 (PR #966) but was missing its closing brace before the `main()` function definition
- This caused `SyntaxError: Unexpected end of input` when running `node --check`

## Testing

- `node --input-type=module --check` passes (was failing before)
- Single character fix — no logic changes