### PR TITLE
t242: fix Higgsfield retryAttempted flag bug — separate reloadAttempted flag

### DIFF
--- a/.agents/scripts/higgsfield/playwright-automator.mjs
+++ b/.agents/scripts/higgsfield/playwright-automator.mjs
@@ -1355,6 +1355,7 @@ async function generateImage(options = {}) {
     // This handles fast generations where queue resolves before first poll
     let peakQueue = Math.max(queueBefore, detectedQueueCount);
     let retryAttempted = false;
+    let reloadAttempted = false;
     let btnWasDisabled = false; // Track if Generate button was ever disabled/changed
 
     while (Date.now() - startTime < timeout) {
@@ -1429,7 +1430,7 @@ async function generateImage(options = {}) {
 
       // Completion condition 4: After 60s with no queue/button activity,
       // reload the page and check if new images appeared at the top
-      if (!retryAttempted && parseInt(elapsed, 10) >= 60 &&
+      if (!reloadAttempted && parseInt(elapsed, 10) >= 60 &&
           peakQueue === queueBefore && !btnWasDisabled) {
         console.log('No queue or button activity after 60s - reloading to check for new images...');
         await page.reload({ waitUntil: 'domcontentloaded', timeout: 30000 });
@@ -1442,7 +1443,7 @@ async function generateImage(options = {}) {
           generationComplete = true;
           break;
         }
-        retryAttempted = true;
+        reloadAttempted = true;
       }
     }
 


### PR DESCRIPTION
## Summary

- **Bug**: The `waitForGeneration` polling loop in `playwright-automator.mjs` used a single `retryAttempted` boolean for two independent recovery mechanisms: the 30s Generate re-click and the 60s page reload check. Once the 30s retry fired and set `retryAttempted = true`, the 60s reload could never execute.
- **Fix**: Introduced a separate `reloadAttempted` flag so both recovery paths operate independently. The 30s retry still uses `retryAttempted`; the 60s reload now uses `reloadAttempted`.
- **Impact**: 3-line change (1 addition, 2 modifications). No API surface changes. Syntax-verified with `node --check`.

## Changes

`playwright-automator.mjs:1357-1358` — Added `reloadAttempted` flag declaration
`playwright-automator.mjs:1433` — Changed 60s reload guard from `!retryAttempted` to `!reloadAttempted`
`playwright-automator.mjs:1446` — Changed 60s reload flag set from `retryAttempted` to `reloadAttempted`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image generation timeout handling by changing the system to reload the page when no activity is detected for 60 seconds, enhancing reliability and recovery during the generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->