### PR TITLE
t243: Higgsfield execSync shell injection hardening — execFileSync

### DIFF
--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -4,7 +4,7 @@
 //   node render.mjs --brief <path> --videos <v1.mp4,v2.mp4,...> --output <path>
 //   node render.mjs --still --text "Title" --aspect 9:16 --output title.png
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { readFileSync, existsSync, copyFileSync, mkdirSync } from "node:fs";
 import { resolve, dirname, join, basename } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -115,20 +115,19 @@ function renderVideo(opts) {
   const [width, height] = dims[props.aspect] || dims["9:16"];
 
   const propsJson = JSON.stringify(props);
-  const propsArg = `--props='${propsJson.replace(/'/g, "'\\''")}'`;
 
-  const cmd = [
-    "npx remotion render",
-    `src/index.ts`,
+  const renderArgs = [
+    "remotion", "render",
+    "src/index.ts",
     "FullVideo",
-    `"${output}"`,
-    propsArg,
+    output,
+    `--props=${propsJson}`,
     `--width=${width}`,
     `--height=${height}`,
     `--frames=0-${totalFrames - 1}`,
     "--codec=h264",
     "--log=verbose",
-  ].join(" ");
+  ];
 
   console.log(`Rendering ${sceneVideoFilenames.length} scenes -> ${output}`);
   console.log(`  Aspect: ${props.aspect} (${width}x${height})`);
@@ -137,7 +136,7 @@ function renderVideo(opts) {
   console.log(`  Captions: ${props.captions.length}`);
 
   try {
-    execSync(cmd, {
+    execFileSync("npx", renderArgs, {
       cwd: __dirname,
       stdio: "inherit",
       timeout: 600000, // 10 min
@@ -170,21 +169,22 @@ function renderStill(opts) {
   };
 
   const propsJson = JSON.stringify(props);
-  const cmd = [
-    "npx remotion still",
-    `src/index.ts`,
+
+  const stillArgs = [
+    "remotion", "still",
+    "src/index.ts",
     "SceneGraphic",
-    `"${output}"`,
-    `--props='${propsJson.replace(/'/g, "'\\''")}'`,
+    output,
+    `--props=${propsJson}`,
     `--width=${width}`,
     `--height=${height}`,
     "--log=verbose",
-  ].join(" ");
+  ];
 
   console.log(`Rendering still: "${props.text}" -> ${output}`);
 
   try {
-    execSync(cmd, {
+    execFileSync("npx", stillArgs, {
       cwd: __dirname,
       stdio: "inherit",
       timeout: 120000,


### PR DESCRIPTION
## Summary

Replace all execSync calls with execFileSync + argument arrays in Higgsfield scripts to prevent shell injection vulnerabilities.

## Changes

### render.mjs (2 calls)
- npx remotion render — props JSON and output path were interpolated into shell string with quote escaping. Now passed as discrete array elements to execFileSync("npx", [...args]).
- npx remotion still — same pattern.

### playwright-automator.mjs (10 calls)
- **6 curl calls** — URLs from page scraping (CloudFront CDN) and file paths were template-literal interpolated. Now execFileSync("curl", ["-sL", "-o", savePath, url]).
- **3 ffmpeg calls** — concat, re-encode, and music overlay commands with file paths. Now execFileSync("ffmpeg", [...args]).
- **1 npx remotion call** — same pattern as render.mjs.

### index.mjs (intentionally unchanged)
The run() helper in the OpenCode plugin executes shell pipelines (git, bash scripts with 2>/dev/null) where shell interpretation is required and all inputs are framework-controlled paths. Converting this would break redirections and pipe semantics.

## Why execFileSync?

execSync(string) spawns a shell (/bin/sh -c) which interprets metacharacters ($, backtick, |, ;, etc.) in the command string. If any interpolated value (URL, file path, JSON) contains these characters, it could execute arbitrary commands.

execFileSync(file, args) bypasses the shell entirely — arguments are passed directly to the process via execve(), making shell injection impossible regardless of argument content.

## Verification

- All 3 .mjs files pass node --check syntax validation
- execFileSync confirmed as valid child_process export
- Zero remaining execSync calls in Higgsfield scripts (verified via rg)