### PR TITLE
t244: Higgsfield caption scene fallback — clamp to last scene

### DIFF
--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -64,11 +64,15 @@ function renderVideo(opts) {
   const fps = 30;
   const rawCaptions = brief.captions || [];
   const scenes = brief.scenes || [];
+  const lastSceneIndex = Math.max(0, scenes.length - 1);
   const normalizedCaptions = rawCaptions.map((cap) => {
-    if (typeof cap.scene === "number") return cap; // Already in correct format
+    if (typeof cap.scene === "number") {
+      // Clamp to last scene so out-of-range indices don't silently drop captions
+      return { ...cap, scene: Math.min(cap.scene, lastSceneIndex) };
+    }
     // Derive scene index from startFrame
     let frameOffset = 0;
-    let sceneIdx = 0;
+    let sceneIdx = scenes.length - 1; // Default to last scene (fallback for beyond-end frames)
     for (let s = 0; s < scenes.length; s++) {
       const sceneDur = (scenes[s].duration || 5) * fps;
       if ((cap.startFrame || 0) >= frameOffset && (cap.startFrame || 0) < frameOffset + sceneDur) {

--- a/.agents/scripts/higgsfield/remotion/src/FullVideo.tsx
+++ b/.agents/scripts/higgsfield/remotion/src/FullVideo.tsx
@@ -29,9 +29,15 @@ export const FullVideo: React.FC<BriefProps> = ({
   const { fps } = useVideoConfig();
   const useTransitions = transitionStyle !== "none" && sceneVideos.length > 1;
 
-  // Find caption for a given scene index
+  // Find caption for a given scene index.
+  // Captions whose scene index exceeds the available scenes are clamped to the
+  // last scene so they still render instead of being silently dropped.
+  const lastSceneIndex = Math.max(0, sceneVideos.length - 1);
   const getCaptionForScene = (sceneIndex: number): CaptionEntry | undefined => {
-    return captions?.find((c) => c.scene === sceneIndex);
+    return captions?.find((c) => {
+      const clampedScene = Math.min(c.scene, lastSceneIndex);
+      return clampedScene === sceneIndex;
+    });
   };
 
   if (useTransitions) {


### PR DESCRIPTION
## Summary

- Captions referencing a scene index beyond the available scenes were silently dropped during Remotion rendering
- Now both render.mjs (normalization at build time) and FullVideo.tsx (runtime lookup) clamp out-of-range scene indices to the last scene
- Captions derived from startFrame that fall beyond all scene boundaries now default to the last scene instead of scene 0

## Changes

**render.mjs** — Caption normalization:
- Captions with explicit scene number are now clamped to Math.min(cap.scene, lastSceneIndex)
- startFrame-derived captions default sceneIdx to last scene instead of 0, so frames beyond the total duration land on the final scene

**FullVideo.tsx** — Runtime caption lookup:
- getCaptionForScene() now clamps each caption's scene index before matching, so out-of-range captions render on the last scene instead of being dropped

## Design Decision

Chose clamping over error/warning — matches existing fallback patterns in the codebase (e.g., duration fallback to 5, style fallback to bold-white). Defence-in-depth: both the normalization layer and the rendering layer apply the clamp independently.