### PR TITLE
t239: Add missing local declarations in shell functions

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -147,6 +147,7 @@ parse_github_url() {
     fi
     
     # Split by /
+    local -a parts
     IFS='/' read -ra parts <<< "$input"
     
     if [[ ${#parts[@]} -ge 2 ]]; then

--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -718,7 +718,7 @@ cmd_add() {
     fi
     
     # Parse GitHub URL
-    local parsed
+    local parsed owner repo subpath
     parsed=$(parse_github_url "$url")
     IFS='|' read -r owner repo subpath <<< "$parsed"
     
@@ -856,6 +856,7 @@ cmd_add() {
             echo ""
             read -rp "Choose option [1-3]: " choice
             
+            local new_name
             case "$choice" in
                 1)
                     log_info "Replacing existing..."
@@ -1035,6 +1036,7 @@ cmd_add_clawdhub() {
             echo ""
             read -rp "Choose option [1-3]: " choice
             
+            local new_name
             case "$choice" in
                 1) log_info "Replacing existing..." ;;
                 2)
@@ -1183,6 +1185,7 @@ cmd_check_updates() {
     
     local updates_available=false
     
+    local name url commit owner repo subpath
     while IFS='|' read -r name url commit; do
         # Extract owner/repo from URL
         local parsed

--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -908,6 +908,7 @@ cmd_discover() {
         local active_key=""
 
         # Check each possible key name for this provider
+        local -a keys
         IFS=',' read -ra keys <<< "$key_names"
         for key_name in "${keys[@]}"; do
             if check_provider_key "$key_name"; then
@@ -1004,6 +1005,7 @@ cmd_discover() {
                 pname=$(echo "$pline" | cut -d'|' -f1)
                 pkeys=$(echo "$pline" | cut -d'|' -f2)
                 if [[ "$pname" == "$model_provider" ]]; then
+                    local -a pkey_arr
                     IFS=',' read -ra pkey_arr <<< "$pkeys"
                     for pk in "${pkey_arr[@]}"; do
                         if check_provider_key "$pk"; then
@@ -1044,6 +1046,7 @@ cmd_discover() {
                 pname=$(echo "$pline" | cut -d'|' -f1)
                 pkeys=$(echo "$pline" | cut -d'|' -f2)
                 if [[ "$pname" == "$model_provider" ]]; then
+                    local -a pkey_arr
                     IFS=',' read -ra pkey_arr <<< "$pkeys"
                     for pk in "${pkey_arr[@]}"; do
                         if check_provider_key "$pk"; then

--- a/.agents/scripts/content-calendar-helper.sh
+++ b/.agents/scripts/content-calendar-helper.sh
@@ -396,6 +396,7 @@ cmd_status() {
             return 1
         fi
 
+        local id title pillar cluster stage intent word_count tags author created updated notes
         IFS='|' read -r id title pillar cluster stage intent word_count tags author created updated notes <<< "$item_data"
 
         echo ""

--- a/.agents/scripts/coordinator-helper.sh
+++ b/.agents/scripts/coordinator-helper.sh
@@ -313,6 +313,7 @@ cmd_convoy() {
 
     log_info "Creating convoy: $name"
 
+    local -a task_array
     IFS=',' read -ra task_array <<< "$tasks"
     for task_id in "${task_array[@]}"; do
         local task_desc

--- a/.agents/scripts/crawl4ai-examples.sh
+++ b/.agents/scripts/crawl4ai-examples.sh
@@ -245,6 +245,7 @@ example_captcha_demo() {
     )
 
     local i=1
+    local url captcha_type site_key description
     for config in "${demo_configs[@]}"; do
         IFS='|' read -r url captcha_type site_key description <<< "$config"
 

--- a/.agents/scripts/hetzner-helper.sh
+++ b/.agents/scripts/hetzner-helper.sh
@@ -91,6 +91,7 @@ connect_server() {
         exit 1
     fi
     
+    local ip name project
     read -r ip name project <<< "$server_info"
     print_info "Connecting to $name ($ip) in project $project..."
     ssh "root@$ip"
@@ -115,6 +116,7 @@ exec_on_server() {
         exit 1
     fi
     
+    local ip name project
     read -r ip name project <<< "$server_info"
     print_info "Executing '$command' on $name..."
     ssh "root@$ip" "$command"

--- a/.agents/scripts/keyword-research-helper.sh
+++ b/.agents/scripts/keyword-research-helper.sh
@@ -195,6 +195,7 @@ prompt_locale() {
     echo "  7) Spain/Spanish"
     echo "  8) Custom (enter location code)"
     echo ""
+    local choice custom_code
     read -p "Select option [1]: " choice
     
     case "${choice:-1}" in
@@ -1382,6 +1383,7 @@ do_extended_research() {
             }]' 2>/dev/null || echo "[]")
             ;;
         "gap")
+            local -a domains
             IFS=',' read -ra domains <<< "$target"
             local your_domain="${domains[0]}"
             local competitor_domain="${domains[1]}"
@@ -1403,9 +1405,11 @@ do_extended_research() {
             ;;
         *)
             # Standard keyword research with SERP analysis
+            local -a keyword_array
             IFS=',' read -ra keyword_array <<< "$keywords"
             
             # For quick mode, just use keyword suggestions directly
+            local keyword
             if [[ "$quick_mode" == "true" ]]; then
                 for keyword in "${keyword_array[@]}"; do
                     keyword=$(echo "$keyword" | xargs)
@@ -1784,6 +1788,7 @@ main() {
         "set-config")
             local new_locale
             new_locale=$(prompt_locale)
+            local new_provider new_limit
             read -p "Default provider [dataforseo/serper/both] ($DEFAULT_PROVIDER): " new_provider
             new_provider="${new_provider:-$DEFAULT_PROVIDER}"
             read -p "Default limit ($DEFAULT_LIMIT): " new_limit

--- a/.agents/scripts/keyword-research-helper.sh
+++ b/.agents/scripts/keyword-research-helper.sh
@@ -1182,8 +1182,10 @@ do_keyword_research() {
     local results="[]"
     
     # Split keywords by comma and process each
+    local -a keyword_array
     IFS=',' read -ra keyword_array <<< "$keywords"
     
+    local keyword
     for keyword in "${keyword_array[@]}"; do
         keyword=$(echo "$keyword" | xargs)  # Trim whitespace
         print_info "Researching: $keyword"
@@ -1536,6 +1538,7 @@ apply_filters() {
     local result="$json_data"
     
     # Parse filters (format: min-volume:1000,max-difficulty:40,intent:commercial,contains:term,excludes:term)
+    local -a filter_array
     IFS=',' read -ra filter_array <<< "$filters"
     
     for filter in "${filter_array[@]}"; do

--- a/.agents/scripts/list-todo-helper.sh
+++ b/.agents/scripts/list-todo-helper.sh
@@ -329,6 +329,7 @@ parse_plans() {
 apply_filters() {
     local line="$1"
     
+    local status id desc est tags owner logged blocked_by is_plan
     IFS='|' read -r status id desc est tags owner logged blocked_by is_plan <<< "$line"
     
     # Status filter

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -295,6 +295,7 @@ resolve_api_key() {
     fi
 
     # Check each possible env var name
+    local -a var_names
     IFS=',' read -ra var_names <<< "$key_vars"
     for var_name in "${var_names[@]}"; do
         # Source 1: Environment variable
@@ -348,6 +349,7 @@ _get_key_value() {
         return 1
     fi
 
+    local -a var_names
     IFS=',' read -ra var_names <<< "$key_vars"
 
     # Try env vars first (may have been populated by resolve_api_key)

--- a/.agents/scripts/model-registry-helper.sh
+++ b/.agents/scripts/model-registry-helper.sh
@@ -510,6 +510,7 @@ DeepSeek|DEEPSEEK_API_KEY"
         key_names=$(echo "$pline" | cut -d'|' -f2)
 
         local key_value=""
+        local -a keys
         IFS=',' read -ra keys <<< "$key_names"
         for key_name in "${keys[@]}"; do
             if [[ -n "${!key_name:-}" ]]; then

--- a/.agents/scripts/secretlint-helper.sh
+++ b/.agents/scripts/secretlint-helper.sh
@@ -538,6 +538,7 @@ run_secretlint_scan() {
     fi
     
     # Handle extra_args safely by splitting on spaces (limited use case)
+    local -a extra_array
     if [[ -n "$extra_args" ]]; then
         read -ra extra_array <<< "$extra_args"
         cmd_array+=("${extra_array[@]}")
@@ -617,6 +618,7 @@ run_docker_scan() {
     )
     
     # Handle extra_args safely
+    local -a extra_array
     if [[ -n "$extra_args" ]]; then
         read -ra extra_array <<< "$extra_args"
         cmd_array+=("${extra_array[@]}")

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -1662,6 +1662,7 @@ cmd_batch() {
     # Add tasks to batch if provided
     if [[ -n "$tasks" ]]; then
         local position=0
+        local -a task_array
         IFS=',' read -ra task_array <<< "$tasks"
         for task_id in "${task_array[@]}"; do
             task_id=$(echo "$task_id" | tr -d ' ')
@@ -2204,7 +2205,7 @@ cmd_status() {
     ")
 
     if [[ -n "$batch_row" ]]; then
-        local brelease_flag brelease_type
+        local bid bname bconc bstatus bcreated brelease_flag brelease_type
         IFS='|' read -r bid bname bconc bstatus bcreated brelease_flag brelease_type <<< "$batch_row"
         local bmax_conc
         bmax_conc=$(db "$SUPERVISOR_DB" "SELECT COALESCE(max_concurrency, 0) FROM batches WHERE id = '$(sql_escape "$bid")';" 2>/dev/null || echo "0")

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -259,6 +259,7 @@ check_category() {
         echo -e "${BOLD}${CYAN}=== $cat_name Tools ===${NC}"
     fi
     
+    local category name cmd ver_flag pkg update_cmd
     for tool_spec in "${tools[@]}"; do
         IFS='|' read -r category name cmd ver_flag pkg update_cmd <<< "$tool_spec"
         check_tool "$category" "$name" "$cmd" "$ver_flag" "$pkg" "$update_cmd"

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -38,6 +38,7 @@ bump_version() {
     local current_version
     current_version=$(get_current_version)
     
+    local major minor patch
     IFS='.' read -r major minor patch <<< "$current_version"
     
     case "$bump_type" in

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -339,7 +339,7 @@ cmd_remove() {
     if is_worktree_owned_by_others "$path_to_remove"; then
         local owner_info
         owner_info=$(check_worktree_owner "$path_to_remove")
-        local owner_pid owner_session owner_batch owner_task
+        local owner_pid owner_session owner_batch owner_task _
         IFS='|' read -r owner_pid owner_session owner_batch owner_task _ <<< "$owner_info"
         echo -e "${RED}Error: Worktree is owned by another active session${NC}"
         echo -e "  Owner PID:     $owner_pid"


### PR DESCRIPTION
## Summary

Audit all shell functions for missing `local` declarations — specifically variables assigned in case/option-parsing blocks and IFS-read here-string patterns without `local` declarations.

## What was found

### Category 1: Variables in case/option-parsing blocks (5 violations, 3 files)

| File | Function | Variables |
|------|----------|-----------|
| `add-skill-helper.sh` | `cmd_add()` | `owner`, `repo`, `subpath`, `new_name` |
| `add-skill-helper.sh` | `cmd_add_clawdhub()` | `new_name` |
| `add-skill-helper.sh` | `cmd_check_updates()` | `name`, `url`, `commit`, `owner`, `repo`, `subpath` |
| `keyword-research-helper.sh` | `prompt_locale()` | `choice`, `custom_code` |
| `keyword-research-helper.sh` | `do_extended_research()` | `domains`, `keyword_array`, `keyword` |

### Category 2: IFS-read here-string variables (56 violations, 14 files)

Here-string reads (`IFS=x read -r var <<< "$data"`) execute in the current shell (not a subshell like pipe reads), so variables leak to global scope without `local`.

| File | Function | Variables |
|------|----------|-----------|
| `add-skill-helper.sh` | `parse_github_url()` | `parts` (array) |
| `compare-models-helper.sh` | `cmd_discover()` | `keys`, `pkey_arr` (arrays) |
| `content-calendar-helper.sh` | `cmd_status()` | `id`, `title`, `pillar`, `cluster`, `stage`, `intent`, `word_count`, `tags`, `author`, `created`, `updated`, `notes` |
| `coordinator-helper.sh` | `cmd_convoy()` | `task_array` (array) |
| `crawl4ai-examples.sh` | `example_captcha_demo()` | `url`, `captcha_type`, `site_key`, `description` |
| `hetzner-helper.sh` | `connect_server()`, `exec_on_server()` | `ip`, `name`, `project` |
| `keyword-research-helper.sh` | `do_keyword_research()`, `apply_filters()` | `keyword_array`, `keyword`, `filter_array` |
| `list-todo-helper.sh` | `apply_filters()` | `status`, `id`, `desc`, `est`, `tags`, `owner`, `logged`, `blocked_by`, `is_plan` |
| `model-availability-helper.sh` | `resolve_api_key()`, `_get_key_value()` | `var_names` (array) |
| `model-registry-helper.sh` | `sync_providers()` | `keys` (array) |
| `secretlint-helper.sh` | `run_secretlint_scan()`, `run_docker_scan()` | `extra_array` (array) |
| `supervisor-helper.sh` | `cmd_batch()`, `cmd_status()` | `task_array`, `bid`, `bname`, `bconc`, `bstatus`, `bcreated` |
| `tool-version-check.sh` | `check_category()` | `category`, `name`, `cmd`, `ver_flag`, `pkg`, `update_cmd` |
| `worktree-helper.sh` | `cmd_remove()` | `_` (throwaway) |

### Not bugs (confirmed by-design)

- **Pipe-subshell reads** (`command | while IFS='|' read -r var; do`): ~800+ instances across the codebase. Variables are scoped to the subshell and cannot leak. No fix needed.
- **Intentional globals**: Variables like `HEADLESS`, `DRY_RUN`, `VERBOSE` in option-parsing functions that are initialized at file scope and intentionally set globally (e.g., `full-loop-helper.sh`, `yt-dlp-helper.sh`, `transcription-helper.sh`).
- **supervisor-helper.sh `_render_frame()`**: `paused` and `scroll_offset` appear in a case block but are declared `local` in the parent `cmd_dashboard()` function — false positive from nested function tracking.

## Verification

- All 16 modified `.sh` files pass `bash -n` syntax check
- All modified files pass ShellCheck (`-x -S warning`) with zero new violations
- Pre-existing SC2178/SC2128 in `compare-models-helper.sh` (unrelated to this PR)
- Re-ran the audit scanner on all modified files: 0 remaining violations

## Task

Closes t239