### PR TITLE
fix: inject mandatory read instruction into subagent stubs (t249)

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -752,6 +752,8 @@ tools:
   bash: true
 $extra_tools
 ---
+
+**MANDATORY**: Your first action MUST be to read ~/.aidevops/agents/${rel_path} and follow ALL rules within it.
 EOF
     else
         cat > "$OPENCODE_AGENT_DIR/$name.md" << EOF
@@ -765,6 +767,8 @@ tools:
   read: true
   bash: true
 ---
+
+**MANDATORY**: Your first action MUST be to read ~/.aidevops/agents/${rel_path} and follow ALL rules within it.
 EOF
     fi
     subagent_count=$((subagent_count + 1))


### PR DESCRIPTION
## Summary

- Generated subagent stubs had empty markdown body — OpenCode uses body as `agent.prompt`, so subagents never loaded their specific rules
- The `description: "Read <path>"` field is metadata shown in the Task tool listing, not an instruction that gets executed
- Fix: add one-line MANDATORY instruction to stub body telling the subagent to read its source `.md` file as first action

## Root Cause

`generate-opencode-agents.sh` created stubs like:

```yaml
---
description: Read ~/.aidevops/agents/tools/git/conflict-resolution.md
mode: subagent
tools:
  read: true
  bash: true
---
```

Empty body = OpenCode uses default provider prompt = subagent never sees its rules.

## Fix

Add body instruction after the YAML frontmatter:

```markdown
**MANDATORY**: Your first action MUST be to read ~/.aidevops/agents/{rel_path} and follow ALL rules within it.
```

## Testing

Verified by invoking `@git-workflow` via Task tool after regenerating stubs:
- **Before**: subagent returned global AGENTS.md rules, did not read git-workflow.md
- **After**: subagent read `~/.aidevops/agents/workflows/git-workflow.md` as first action and returned git-workflow-specific rules

## Changes

- `.agents/scripts/generate-opencode-agents.sh` — 2 lines added in each stub generation branch (4 insertions total)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced agent initialization process by introducing a mandatory instruction that ensures all agents read and follow configuration rules on startup. This improvement applies uniformly across all generated agent instances, regardless of tool configuration settings, promoting consistent rule compliance and standardized behavior across deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->