### PR TITLE
feat: add WaveSpeed AI service agent with REST API helper (t258)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -318,6 +318,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | Video | `tools/video/video-prompt-design.md`, `tools/video/remotion.md`, `tools/video/higgsfield.md`, `tools/video/runway.md` |
 | YouTube | `content/distribution/youtube/` (migrated from root, see content.md) |
 | Vision | `tools/vision/overview.md` (decision tree, then `image-generation.md`, `image-understanding.md`, `image-editing.md`) |
+| AI generation | `services/ai-generation/wavespeed.md`, `wavespeed-helper.sh` (200+ models: image, video, audio, 3D) |
 | ComfyUI | `tools/ai-generation/comfy-cli.md`, `comfy-cli-helper.sh` |
 | Voice | `tools/voice/speech-to-speech.md`, `voice-helper.sh talk` (voice bridge) |
 | Email testing | `services/email/email-testing.md` (overview), `services/email/email-design-test.md`, `services/email/email-delivery-test.md`, `email-test-suite-helper.sh` |

--- a/.agents/scripts/wavespeed-helper.sh
+++ b/.agents/scripts/wavespeed-helper.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC1091
+
+# WaveSpeed Helper - REST API client for WaveSpeed AI
+# Part of AI DevOps Framework
+# Unified API for 200+ generative AI models (image, video, audio, 3D, LLM)
+
+set -euo pipefail
+
+# Source shared constants
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+    source "${SCRIPT_DIR}/shared-constants.sh"
+fi
+
+# Constants
+readonly WAVESPEED_API_BASE="https://api.wavespeed.ai/api/v3"
+readonly DEFAULT_MODEL="wavespeed-ai/flux-dev"
+readonly DEFAULT_POLL_INTERVAL=3
+readonly DEFAULT_TIMEOUT=300
+
+# Print helpers (fallback if shared-constants not loaded)
+if ! command -v print_info &>/dev/null; then
+    print_info() { echo "[INFO] $*"; }
+    print_success() { echo "[OK] $*"; }
+    print_error() { echo "[ERROR] $*" >&2; }
+    print_warning() { echo "[WARN] $*"; }
+fi
+
+# Load API key from credentials
+load_api_key() {
+    if [[ -n "${WAVESPEED_API_KEY:-}" ]]; then
+        return 0
+    fi
+
+    local cred_file="${HOME}/.config/aidevops/credentials.sh"
+    if [[ -f "${cred_file}" ]]; then
+        source "${cred_file}"
+    fi
+
+    # Try gopass
+    if [[ -z "${WAVESPEED_API_KEY:-}" ]] && command -v gopass &>/dev/null; then
+        WAVESPEED_API_KEY="$(gopass show -o "aidevops/WAVESPEED_API_KEY" 2>/dev/null)" || true
+    fi
+
+    if [[ -z "${WAVESPEED_API_KEY:-}" ]]; then
+        print_error "WAVESPEED_API_KEY not set"
+        print_info "Run: aidevops secret set WAVESPEED_API_KEY"
+        print_info "Or add to ~/.config/aidevops/credentials.sh"
+        return 1
+    fi
+
+    export WAVESPEED_API_KEY
+    return 0
+}
+
+# Make authenticated API request
+api_request() {
+    local method="$1"
+    local endpoint="$2"
+    shift 2
+
+    curl -s -X "${method}" \
+        "${WAVESPEED_API_BASE}${endpoint}" \
+        -H "Authorization: Bearer ${WAVESPEED_API_KEY}" \
+        -H "Content-Type: application/json" \
+        "$@"
+}
+
+# Submit a generation task
+cmd_generate() {
+    local prompt=""
+    local model="${DEFAULT_MODEL}"
+    local sync_mode="false"
+    local poll_interval="${DEFAULT_POLL_INTERVAL}"
+    local timeout="${DEFAULT_TIMEOUT}"
+    local extra_input=""
+    local output_file=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --model|-m)   model="$2"; shift 2 ;;
+            --sync)       sync_mode="true"; shift ;;
+            --poll)       poll_interval="$2"; shift 2 ;;
+            --timeout)    timeout="$2"; shift 2 ;;
+            --input)      extra_input="$2"; shift 2 ;;
+            --output|-o)  output_file="$2"; shift 2 ;;
+            --*)          print_error "Unknown option: $1"; return 1 ;;
+            *)
+                if [[ -z "${prompt}" ]]; then
+                    prompt="$1"
+                else
+                    print_error "Unexpected argument: $1"
+                    return 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "${prompt}" ]]; then
+        print_error "Prompt is required"
+        print_info "Usage: wavespeed-helper.sh generate \"your prompt\" [--model provider/model] [--sync]"
+        return 1
+    fi
+
+    load_api_key || return 1
+
+    # Build input JSON
+    local input_json
+    if [[ -n "${extra_input}" ]]; then
+        input_json=$(printf '{"prompt": %s, %s}' "$(jq -Rn --arg p "${prompt}" '$p')" "${extra_input}")
+    else
+        input_json=$(printf '{"prompt": %s}' "$(jq -Rn --arg p "${prompt}" '$p')")
+    fi
+
+    # Build request body
+    local body
+    if [[ "${sync_mode}" == "true" ]]; then
+        body=$(printf '{"input": %s, "enable_sync_mode": true}' "${input_json}")
+    else
+        body=$(printf '{"input": %s}' "${input_json}")
+    fi
+
+    print_info "Submitting to ${model}..."
+
+    local response
+    response=$(api_request POST "/predictions/${model}" -d "${body}")
+
+    # Check for errors
+    local error
+    error=$(echo "${response}" | jq -r '.error // empty' 2>/dev/null)
+    if [[ -n "${error}" ]]; then
+        print_error "API error: ${error}"
+        echo "${response}" | jq . 2>/dev/null || echo "${response}"
+        return 1
+    fi
+
+    # Sync mode returns result directly
+    if [[ "${sync_mode}" == "true" ]]; then
+        local status
+        status=$(echo "${response}" | jq -r '.status // empty' 2>/dev/null)
+        if [[ "${status}" == "completed" ]]; then
+            print_success "Generation complete"
+            echo "${response}" | jq -r '.outputs[]? // empty' 2>/dev/null
+            save_output "${response}" "${output_file}"
+            return 0
+        elif [[ "${status}" == "failed" ]]; then
+            print_error "Generation failed"
+            echo "${response}" | jq . 2>/dev/null || echo "${response}"
+            return 1
+        fi
+    fi
+
+    # Async mode — extract task ID and poll
+    local task_id
+    task_id=$(echo "${response}" | jq -r '.id // empty' 2>/dev/null)
+    if [[ -z "${task_id}" ]]; then
+        print_error "No task ID in response"
+        echo "${response}" | jq . 2>/dev/null || echo "${response}"
+        return 1
+    fi
+
+    print_info "Task ID: ${task_id}"
+    poll_task "${task_id}" "${poll_interval}" "${timeout}" "${output_file}"
+}
+
+# Poll task until completion
+poll_task() {
+    local task_id="$1"
+    local interval="$2"
+    local timeout="$3"
+    local output_file="${4:-}"
+    local elapsed=0
+
+    while [[ "${elapsed}" -lt "${timeout}" ]]; do
+        local response
+        response=$(api_request GET "/predictions/${task_id}/status")
+
+        local status
+        status=$(echo "${response}" | jq -r '.status // "unknown"' 2>/dev/null)
+
+        case "${status}" in
+            completed)
+                print_success "Generation complete (${elapsed}s)"
+                echo "${response}" | jq -r '.outputs[]? // empty' 2>/dev/null
+                save_output "${response}" "${output_file}"
+                return 0
+                ;;
+            failed)
+                print_error "Generation failed"
+                echo "${response}" | jq . 2>/dev/null || echo "${response}"
+                return 1
+                ;;
+            pending|processing)
+                printf "\r[INFO] Status: %s (%ds/%ds)" "${status}" "${elapsed}" "${timeout}"
+                sleep "${interval}"
+                elapsed=$((elapsed + interval))
+                ;;
+            *)
+                print_warning "Unknown status: ${status}"
+                sleep "${interval}"
+                elapsed=$((elapsed + interval))
+                ;;
+        esac
+    done
+
+    echo ""
+    print_error "Timeout after ${timeout}s. Task ${task_id} still ${status:-unknown}"
+    print_info "Check later: wavespeed-helper.sh status ${task_id}"
+    return 1
+}
+
+# Save output URLs to file
+save_output() {
+    local response="$1"
+    local output_file="$2"
+
+    if [[ -z "${output_file}" ]]; then
+        return 0
+    fi
+
+    mkdir -p "$(dirname "${output_file}")"
+    echo "${response}" | jq . > "${output_file}"
+    print_info "Response saved to: ${output_file}"
+    return 0
+}
+
+# Check task status
+cmd_status() {
+    local task_id="${1:-}"
+
+    if [[ -z "${task_id}" ]]; then
+        print_error "Task ID is required"
+        print_info "Usage: wavespeed-helper.sh status <task-id>"
+        return 1
+    fi
+
+    load_api_key || return 1
+
+    local response
+    response=$(api_request GET "/predictions/${task_id}/status")
+
+    echo "${response}" | jq . 2>/dev/null || echo "${response}"
+    return 0
+}
+
+# List available models
+cmd_models() {
+    load_api_key || return 1
+
+    local response
+    response=$(api_request GET "/models")
+
+    echo "${response}" | jq . 2>/dev/null || echo "${response}"
+    return 0
+}
+
+# Upload a file
+cmd_upload() {
+    local file_path="${1:-}"
+
+    if [[ -z "${file_path}" ]]; then
+        print_error "File path is required"
+        print_info "Usage: wavespeed-helper.sh upload <file>"
+        return 1
+    fi
+
+    if [[ ! -f "${file_path}" ]]; then
+        print_error "File not found: ${file_path}"
+        return 1
+    fi
+
+    load_api_key || return 1
+
+    print_info "Uploading: ${file_path}"
+
+    local response
+    response=$(curl -s -X POST \
+        "${WAVESPEED_API_BASE}/files/upload" \
+        -H "Authorization: Bearer ${WAVESPEED_API_KEY}" \
+        -F "file=@${file_path}")
+
+    local url
+    url=$(echo "${response}" | jq -r '.url // empty' 2>/dev/null)
+    if [[ -n "${url}" ]]; then
+        print_success "Upload complete"
+        echo "${url}"
+    else
+        print_error "Upload failed"
+        echo "${response}" | jq . 2>/dev/null || echo "${response}"
+        return 1
+    fi
+
+    return 0
+}
+
+# Check account balance
+cmd_balance() {
+    load_api_key || return 1
+
+    local response
+    response=$(api_request GET "/balance")
+
+    echo "${response}" | jq . 2>/dev/null || echo "${response}"
+    return 0
+}
+
+# Check usage stats
+cmd_usage() {
+    load_api_key || return 1
+
+    local response
+    response=$(api_request GET "/usage")
+
+    echo "${response}" | jq . 2>/dev/null || echo "${response}"
+    return 0
+}
+
+# Show help
+show_help() {
+    cat <<'EOF'
+WaveSpeed Helper - REST API client for WaveSpeed AI
+
+Usage: wavespeed-helper.sh <command> [arguments] [options]
+
+Commands:
+  generate <prompt>  Submit generation task to any model
+  status <task-id>   Check task status and get results
+  models             List available models
+  upload <file>      Upload file and get URL for use as input
+  balance            Check account balance
+  usage              Check usage statistics
+  help               Show this help
+
+Generate Options:
+  --model, -m <id>   Model ID (default: wavespeed-ai/flux-dev)
+  --sync             Use sync mode (blocks until result, no polling)
+  --poll <seconds>   Poll interval in seconds (default: 3)
+  --timeout <secs>   Timeout in seconds (default: 300)
+  --input <json>     Extra input fields as JSON fragment (e.g. '"seed": 42')
+  --output, -o <f>   Save full response JSON to file
+
+Examples:
+  # Image generation
+  wavespeed-helper.sh generate "A cyberpunk city at night" --model wavespeed-ai/flux-dev
+  wavespeed-helper.sh generate "A cat" --model wavespeed-ai/flux-schnell --sync
+
+  # Video generation
+  wavespeed-helper.sh generate "Camera pans across mountains" --model wavespeed-ai/wan-2.1
+
+  # With extra input parameters
+  wavespeed-helper.sh generate "Portrait" --model wavespeed-ai/flux-dev --input '"seed": 42, "width": 1024'
+
+  # Upload file for image-to-video
+  URL=$(wavespeed-helper.sh upload photo.jpg)
+  wavespeed-helper.sh generate "Person walks forward" --model wavespeed-ai/wan-2.1 --input "\"image_url\": \"${URL}\""
+
+  # Check status of a running task
+  wavespeed-helper.sh status abc123-def456
+
+  # Account info
+  wavespeed-helper.sh balance
+  wavespeed-helper.sh usage
+
+Environment:
+  WAVESPEED_API_KEY  API key (get from https://wavespeed.ai/accesskey)
+                     Store via: aidevops secret set WAVESPEED_API_KEY
+
+Model ID Format:
+  provider/model-name (e.g. wavespeed-ai/flux-dev, openai/dall-e-3)
+  Run 'wavespeed-helper.sh models' for the full list.
+EOF
+}
+
+# Main
+main() {
+    local command="${1:-help}"
+    shift 2>/dev/null || true
+
+    case "${command}" in
+        generate|gen)   cmd_generate "$@" ;;
+        status)         cmd_status "$@" ;;
+        models)         cmd_models "$@" ;;
+        upload)         cmd_upload "$@" ;;
+        balance)        cmd_balance "$@" ;;
+        usage)          cmd_usage "$@" ;;
+        help|--help|-h) show_help ;;
+        *)
+            print_error "Unknown command: ${command}"
+            show_help
+            return 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/.agents/services/ai-generation/wavespeed.md
+++ b/.agents/services/ai-generation/wavespeed.md
@@ -1,0 +1,276 @@
+---
+description: WaveSpeed AI - unified API for 200+ generative AI models
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: true
+  task: false
+---
+
+# WaveSpeed AI
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Unified API gateway for 200+ generative AI models (image, video, audio, 3D, LLM)
+- **API**: REST API at `https://api.wavespeed.ai/api/v3`
+- **Auth**: Bearer token via `WAVESPEED_API_KEY` env var
+- **CLI**: `wavespeed-helper.sh [generate|status|models|upload|balance|usage]`
+- **MCP**: Optional — `pip install wavespeed-mcp` for Claude Desktop integration
+- **SDKs**: Python (`pip install wavespeed`), JS (`npm install wavespeed`) — not used by helper
+
+**When to use**:
+
+- Generating images (Flux, DALL-E, Imagen, Z-Image, Recraft, etc.)
+- Generating video (Wan, Kling, Sora, Veo, Minimax, HunyuanVideo, etc.)
+- Audio generation (Ace Step music, TTS, voice cloning)
+- 3D model generation (Hunyuan3D, Meshy6)
+- Utility tasks (upscale, face swap, background removal, OCR, try-on)
+- Any task requiring access to multiple AI providers through a single API
+
+<!-- AI-CONTEXT-END -->
+
+## Setup
+
+### 1. Get API Key
+
+1. Sign up at [wavespeed.ai](https://wavespeed.ai)
+2. Go to [wavespeed.ai/accesskey](https://wavespeed.ai/accesskey)
+3. Create a new API key
+
+### 2. Store Credentials
+
+```bash
+aidevops secret set WAVESPEED_API_KEY
+# Or plaintext fallback:
+echo 'export WAVESPEED_API_KEY="wsk_..."' >> ~/.config/aidevops/credentials.sh
+chmod 600 ~/.config/aidevops/credentials.sh
+```
+
+### 3. Test Connection
+
+```bash
+wavespeed-helper.sh balance
+```
+
+## API Reference
+
+### Base URL
+
+```text
+https://api.wavespeed.ai/api/v3
+```
+
+All requests require `Authorization: Bearer $WAVESPEED_API_KEY` header.
+
+### Submit Task (Async)
+
+```bash
+curl -s -X POST "https://api.wavespeed.ai/api/v3/predictions/{model_id}" \
+  -H "Authorization: Bearer $WAVESPEED_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"prompt": "A cat wearing sunglasses"}}'
+```
+
+Response includes `id` for polling. Model ID format: `provider/model-name` (e.g., `wavespeed-ai/flux-dev`).
+
+### Submit Task (Sync Mode)
+
+Add `"enable_sync_mode": true` to skip polling — blocks until result is ready:
+
+```bash
+curl -s -X POST "https://api.wavespeed.ai/api/v3/predictions/{model_id}" \
+  -H "Authorization: Bearer $WAVESPEED_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"prompt": "A cat"}, "enable_sync_mode": true}'
+```
+
+### Poll Status
+
+```bash
+curl -s "https://api.wavespeed.ai/api/v3/predictions/{task_id}/status" \
+  -H "Authorization: Bearer $WAVESPEED_API_KEY"
+```
+
+Statuses: `pending` → `processing` → `completed` | `failed`
+
+Result on completion: `outputs` array containing URLs.
+
+### Upload File
+
+```bash
+curl -s -X POST "https://api.wavespeed.ai/api/v3/files/upload" \
+  -H "Authorization: Bearer $WAVESPEED_API_KEY" \
+  -F "file=@image.jpg"
+```
+
+Returns a URL to use as input for image-to-video, face swap, etc.
+
+### List Models
+
+```bash
+curl -s "https://api.wavespeed.ai/api/v3/models" \
+  -H "Authorization: Bearer $WAVESPEED_API_KEY"
+```
+
+### Check Balance
+
+```bash
+curl -s "https://api.wavespeed.ai/api/v3/balance" \
+  -H "Authorization: Bearer $WAVESPEED_API_KEY"
+```
+
+### Check Usage
+
+```bash
+curl -s "https://api.wavespeed.ai/api/v3/usage" \
+  -H "Authorization: Bearer $WAVESPEED_API_KEY"
+```
+
+### Delete Task
+
+```bash
+curl -s -X DELETE "https://api.wavespeed.ai/api/v3/predictions/{task_id}" \
+  -H "Authorization: Bearer $WAVESPEED_API_KEY"
+```
+
+## Model Categories
+
+### Image Generation
+
+| Model | Provider | Notes |
+|-------|----------|-------|
+| `wavespeed-ai/flux-dev` | WaveSpeed | Fast Flux variant |
+| `wavespeed-ai/flux-schnell` | WaveSpeed | Fastest Flux |
+| `wavespeed-ai/z-image` | WaveSpeed | High quality |
+| `openai/dall-e-3` | OpenAI | DALL-E 3 |
+| `google/imagen-4` | Google | Imagen 4 |
+| `recraft/recraft-v3` | Recraft | Design-focused |
+
+### Video Generation
+
+| Model | Provider | Notes |
+|-------|----------|-------|
+| `wavespeed-ai/wan-2.1` | WaveSpeed | Text/image to video |
+| `kling-ai/kling-2.0` | Kling | High quality video |
+| `openai/sora` | OpenAI | Sora |
+| `google/veo-3` | Google | Veo 3 |
+| `minimax/minimax-video-01` | Minimax | Fast video |
+| `bytedance/seedance-1.0` | ByteDance | Seedance |
+| `vidu/vidu-2.0` | Vidu | Vidu 2.0 |
+
+### Audio
+
+| Model | Provider | Notes |
+|-------|----------|-------|
+| `ace-step/ace-step` | Ace Step | Music generation |
+| Various TTS models | Multiple | Text-to-speech |
+
+### 3D Generation
+
+| Model | Provider | Notes |
+|-------|----------|-------|
+| `tencent/hunyuan3d-2.0` | Tencent | 3D model generation |
+| `meshy/meshy-6` | Meshy | 3D from text/image |
+
+### Utilities
+
+| Model | Notes |
+|-------|-------|
+| Upscaler | Image upscaling (2x, 4x) |
+| Face swap | Face replacement |
+| Background remover | Remove/replace backgrounds |
+| Try-on | Virtual clothing try-on |
+| OCR | Text extraction from images |
+
+Use `wavespeed-helper.sh models` to get the full current list.
+
+## CLI Helper
+
+```bash
+# Generate with any model (async with polling)
+wavespeed-helper.sh generate "A cyberpunk city" --model wavespeed-ai/flux-dev
+
+# Generate with sync mode (single request, blocks until done)
+wavespeed-helper.sh generate "A cat" --model wavespeed-ai/flux-schnell --sync
+
+# Check task status
+wavespeed-helper.sh status <task-id>
+
+# List available models
+wavespeed-helper.sh models
+
+# Upload a file (returns URL for use as input)
+wavespeed-helper.sh upload image.jpg
+
+# Check account balance
+wavespeed-helper.sh balance
+
+# Check usage stats
+wavespeed-helper.sh usage
+```
+
+## MCP Integration (Optional)
+
+WaveSpeed provides an official MCP server for Claude Desktop:
+
+```bash
+pip install wavespeed-mcp
+```
+
+Configure in Claude Desktop settings:
+
+```json
+{
+  "mcpServers": {
+    "wavespeed": {
+      "command": "wavespeed-mcp",
+      "env": {
+        "WAVESPEED_API_KEY": "wsk_..."
+      }
+    }
+  }
+}
+```
+
+Source: [github.com/WaveSpeedAI/wavespeed-mcp](https://github.com/WaveSpeedAI/wavespeed-mcp)
+
+## Integration with Content Pipeline
+
+WaveSpeed serves as a unified backend for content production:
+
+- **Image generation**: Use via `content/production/image.md` workflows
+- **Video generation**: Use via `content/production/video.md` workflows
+- **Audio generation**: Use via `content/production/audio.md` workflows
+
+The helper script can be called from other helpers and pipelines as a generation backend.
+
+## Troubleshooting
+
+### "Unauthorized" or 401
+
+1. Verify key is set: `echo "${WAVESPEED_API_KEY:+set}"`
+2. Verify key format starts with `wsk_`
+3. Check balance — expired accounts return 401
+
+### Task stuck in "processing"
+
+Some models (especially video) can take several minutes. The helper polls with configurable interval and timeout. For long tasks, use `--timeout 600` (10 minutes).
+
+### Model not found
+
+Model IDs use `provider/model-name` format. Use `wavespeed-helper.sh models` to get exact IDs. The model library updates frequently as new models are added.
+
+## Related
+
+- [WaveSpeed AI Documentation](https://wavespeed.ai/docs)
+- [WaveSpeed API Reference](https://wavespeed.ai/docs)
+- [WaveSpeed MCP Server](https://github.com/WaveSpeedAI/wavespeed-mcp)
+- `tools/video/video-prompt-design.md` — Prompt engineering for video models
+- `tools/vision/image-generation.md` — Image generation workflows

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -22,7 +22,7 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[46]{folder,purpose,key_files}:
+<!--TOON:subagents[48]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings and UX/CRO,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper|mom-test-ux
@@ -66,6 +66,7 @@ services/email/,Email services - transactional email deliverability and testing,
 services/communications/,Communications - SMS voice and Matrix bot dispatch,twilio|telfon|matrix-bot
 services/crm/,CRM integration - contact management,fluentcrm
 services/analytics/,Website analytics - GA4 reporting,google-analytics
+services/ai-generation/,AI generation API gateway - unified access to 200+ models (image video audio 3D),wavespeed
 services/monitoring/,Error monitoring and debugging,sentry|socket
 youtube/,YouTube competitor research - channel intel topic research script writing and optimization,channel-intel|topic-research|script-writer|optimizer|pipeline
 services/accounting/,Accounting integration - invoicing,quickfile
@@ -87,7 +88,7 @@ bug-fixing,workflows/bug-fixing.md,Bug fix workflow
 feature-development,workflows/feature-development.md,Feature development workflow
 -->
 
-<!--TOON:scripts[71]{name,purpose}:
+<!--TOON:scripts[72]{name,purpose}:
 accessibility-helper.sh,Accessibility and contrast testing (WCAG compliance WAVE API for websites and emails)
 accessibility-audit-helper.sh,Accessibility audit CLI wrapping axe-core WAVE API WebAIM contrast and Lighthouse a11y
 auto-update-helper.sh,Automatic update polling daemon (enable disable status check logs)
@@ -161,4 +162,5 @@ thumbnail-helper.sh,Thumbnail A/B testing pipeline (generate score batch-score u
 stale-pr-helper.sh,Stale PR detection and notification - scan for open PRs older than 24h not linked to active tasks (scan report help)
 comfy-cli-helper.sh,ComfyUI management via comfy-cli (status install setup launch node-install node-list model-download model-list snapshot-save snapshot-restore workflow-deps)
 runway-helper.sh,Runway API CLI for video image and audio generation (video image tts sts sfx dub isolate status wait cancel credits usage)
+wavespeed-helper.sh,WaveSpeed AI REST API client - unified generation for 200+ models (generate status models upload balance usage)
 -->


### PR DESCRIPTION
## Summary

- Add WaveSpeed AI as a new service agent under `services/ai-generation/` — a unified API gateway for 200+ generative AI models (image, video, audio, 3D, LLM)
- Add `wavespeed-helper.sh` CLI using curl+jq REST API (no SDK dependency) with commands: generate, status, models, upload, balance, usage
- Supports both sync mode (single blocking request) and async mode (submit + poll) with configurable timeout and poll interval

## Files Changed

| File | Change |
|------|--------|
| `.agents/services/ai-generation/wavespeed.md` | New service agent doc (API reference, model catalog, setup guide, MCP integration) |
| `.agents/scripts/wavespeed-helper.sh` | New CLI helper (ShellCheck clean, follows framework patterns) |
| `.agents/subagent-index.toon` | Register new subagent and script entries |
| `.agents/AGENTS.md` | Add "AI generation" row to progressive disclosure table |

## Task

Closes t258 in TODO.md

## Testing

- ShellCheck: zero violations
- Script follows existing helper patterns (shared-constants, gopass fallback, print helpers)
- README gate: no update needed (individual services not listed in README)