### PR TITLE
feat: use source file description in generated subagent stubs (t255)

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -695,6 +695,13 @@ while IFS= read -r f; do
     
     rel_path="${f#"$AGENTS_DIR"/}"
     
+    # Extract description from source file frontmatter (t255)
+    # Falls back to "Read <path>" if no description found
+    src_desc=$(sed -n '/^---$/,/^---$/{ /^description:/{s/^description: *//p; q} }' "$f" 2>/dev/null)
+    if [[ -z "$src_desc" ]]; then
+        src_desc="Read ~/.aidevops/agents/${rel_path}"
+    fi
+    
     # Determine additional tools based on subagent name/path
     extra_tools=""
     case "$name" in
@@ -742,7 +749,7 @@ while IFS= read -r f; do
     if [[ -n "$extra_tools" ]]; then
         cat > "$OPENCODE_AGENT_DIR/$name.md" << EOF
 ---
-description: Read ~/.aidevops/agents/${rel_path}
+description: ${src_desc}
 mode: subagent
 temperature: 0.2
 permission:
@@ -758,7 +765,7 @@ EOF
     else
         cat > "$OPENCODE_AGENT_DIR/$name.md" << EOF
 ---
-description: Read ~/.aidevops/agents/${rel_path}
+description: ${src_desc}
 mode: subagent
 temperature: 0.2
 permission:


### PR DESCRIPTION
## Summary

- Extract `description:` field from each source `.md` frontmatter and use it as the generated stub description
- Falls back to `"Read <path>"` for files without a description field (53 of 479)
- 426/479 stubs now have meaningful descriptions in the Task tool listing

## Before

All stubs had: `description: Read ~/.aidevops/agents/tools/git/conflict-resolution.md`

## After

Stubs now have: `description: Git merge, rebase, and cherry-pick conflict resolution strategies and workflows`

This gives the LLM meaningful context about what each subagent does when browsing the Task tool listing, improving subagent selection accuracy.

## Changes

- `.agents/scripts/generate-opencode-agents.sh` — 9 insertions, 2 deletions: add `sed` extraction of `description:` from source frontmatter before stub generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the agent generation process to automatically extract and apply custom descriptions from source files. Agents now display meaningful, context-specific descriptions instead of generic fallback messages, providing clearer and more consistent documentation across all generated agent files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->