### PR TITLE
t257: Fix batch release failing on empty CHANGELOG

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -1940,9 +1940,10 @@ trigger_batch_release() {
     }
 
     # Run the release (--skip-preflight: batch tasks already passed CI individually)
+    # Use --force to bypass empty CHANGELOG check (auto-generates from commits)
     local release_output=""
     local release_exit=0
-    release_output=$(cd "$repo" && bash "$version_manager" release "$release_type" --skip-preflight 2>&1) || release_exit=$?
+    release_output=$(cd "$repo" && bash "$version_manager" release "$release_type" --skip-preflight --force 2>&1) || release_exit=$?
 
     echo "$release_output" > "$release_log" 2>/dev/null || true
 


### PR DESCRIPTION
## Summary

Fixes batch release failures when CHANGELOG [Unreleased] section is empty.

## Changes

- Added `--force` flag to batch release call in `trigger_batch_release()`
- This bypasses the empty CHANGELOG check and allows auto-generation from commits
- Appropriate for automated batch releases where manual changelog curation is not expected

## Testing

- [x] ShellCheck validation pending
- [ ] Manual test with empty CHANGELOG scenario pending

## Related

- Task: t257
- Issue: Batch releases were failing when CHANGELOG [Unreleased] was empty
- Root cause: version-manager.sh release command requires --force to bypass empty changelog check