### PR TITLE
t260: Fix missing PR URL when monitoring session merges PRs

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -7125,7 +7125,8 @@ scan_orphaned_prs() {
     # Find tasks that might have orphaned PRs:
     # - Status indicates work was done but no PR linked
     # - pr_url is NULL, empty, 'no_pr', 'task_only', or 'task_obsolete'
-    local where_clause="status IN ('failed', 'blocked', 'retrying', 'complete', 'running', 'evaluating')
+    # - Includes terminal states (deployed, merged, verified) to catch manually merged PRs (t260)
+    local where_clause="status IN ('failed', 'blocked', 'retrying', 'complete', 'running', 'evaluating', 'deployed', 'merged', 'verified')
         AND (pr_url IS NULL OR pr_url = '' OR pr_url = 'no_pr' OR pr_url = 'task_only' OR pr_url = 'task_obsolete')"
     if [[ -n "$batch_id" ]]; then
         where_clause="$where_clause AND id IN (SELECT task_id FROM batch_tasks WHERE batch_id = '$(sql_escape "$batch_id")')"
@@ -11677,6 +11678,13 @@ cmd_reconcile_todo() {
                 log_warn "[dry-run] $tid: deployed in DB but open in TODO.md"
             else
                 log_info "Reconciling $tid..."
+                
+                # t260: Attempt PR discovery if pr_url is missing before calling update_todo_on_complete
+                if [[ -z "$tpr_url" || "$tpr_url" == "no_pr" || "$tpr_url" == "task_only" || "$tpr_url" == "task_obsolete" ]]; then
+                    log_verbose "  $tid: Attempting PR discovery before reconciliation"
+                    link_pr_to_task "$tid" --caller "reconcile_todo" 2>>"${SUPERVISOR_LOG:-/dev/null}" || true
+                fi
+                
                 if update_todo_on_complete "$tid"; then
                     updated_count=$((updated_count + 1))
                 else


### PR DESCRIPTION
## Summary

Fixes missing PR URL in supervisor DB when a human or monitoring session manually merges a PR (bypassing the supervisor's PR lifecycle).

## Changes

1. **Phase 6 (Orphaned PR Scan)**: Extended to include terminal-state tasks (deployed, merged, verified) with empty pr_url fields
2. **Phase 7 (TODO Reconciliation)**: Added PR discovery attempt via link_pr_to_task() before calling update_todo_on_complete() for tasks with missing PR URLs

## Problem

When a monitoring session or human manually merges a PR outside the supervisor's control:
- The task transitions to a terminal state (deployed/verified)
- The supervisor DB pr_url field stays empty
- Phase 6 orphaned PR scan skipped terminal states
- Phase 7 reconciliation didn't attempt PR discovery

This resulted in completed tasks with missing PR URLs in the database.

## Solution

**Phase 6 Enhancement**: Now scans tasks in all states including deployed, merged, and verified to catch manually merged PRs.

**Phase 7 Enhancement**: Before marking a task complete in TODO.md, attempts to discover and link any missing PR URL using the existing link_pr_to_task() function.

## Testing

- Bash syntax validation: Passed
- Logic tests: Passed (empty pr_url triggers discovery, valid pr_url skips)
- ShellCheck: No new violations introduced

## Related

- Fixes issue described in t260
- Complements existing PR discovery mechanisms (eager scan in Phase 1, throttled scan in Phase 6)
- Uses existing link_pr_to_task() infrastructure for validation and persistence