### PR TITLE
t262: Include task description in worker session titles

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -4238,7 +4238,18 @@ $memory_context"
             printf '%s\0' "$model"
         fi
         printf '%s\0' "--title"
-        printf '%s\0' "$task_id"
+        # t262: Include truncated description in session title for readability
+        local session_title="$task_id"
+        if [[ -n "$description" ]]; then
+            local short_desc="${description%% -- *}"  # strip notes after --
+            short_desc="${short_desc%% #*}"            # strip tags
+            short_desc="${short_desc%% ~*}"            # strip estimates
+            if [[ ${#short_desc} -gt 40 ]]; then
+                short_desc="${short_desc:0:37}..."
+            fi
+            session_title="${task_id}: ${short_desc}"
+        fi
+        printf '%s\0' "$session_title"
         printf '%s\0' "$prompt"
     else
         # claude CLI
@@ -6389,7 +6400,18 @@ Task description: ${tdesc:-$task_id}"
     # Dispatch the re-prompt
     local -a cmd_parts=()
     if [[ "$ai_cli" == "opencode" ]]; then
-        cmd_parts=(opencode run --format json --title "${task_id}-retry${tretries}" "$reprompt_msg")
+        # t262: Include truncated description in retry session title
+        local retry_title="${task_id}-retry${tretries}"
+        if [[ -n "$tdesc" ]]; then
+            local short_desc="${tdesc%% -- *}"
+            short_desc="${short_desc%% #*}"
+            short_desc="${short_desc%% ~*}"
+            if [[ ${#short_desc} -gt 30 ]]; then
+                short_desc="${short_desc:0:27}..."
+            fi
+            retry_title="${task_id}-r${tretries}: ${short_desc}"
+        fi
+        cmd_parts=(opencode run --format json --title "$retry_title" "$reprompt_msg")
     else
         cmd_parts=(claude -p "$reprompt_msg" --output-format json)
     fi
@@ -6697,7 +6719,7 @@ dispatch_review_fix_worker() {
     escaped_id=$(sql_escape "$task_id")
     local task_row
     task_row=$(db -separator '|' "$SUPERVISOR_DB" "
-        SELECT repo, worktree, branch, pr_url, model
+        SELECT repo, worktree, branch, pr_url, model, description
         FROM tasks WHERE id = '$escaped_id';
     ")
 
@@ -6706,8 +6728,8 @@ dispatch_review_fix_worker() {
         return 1
     fi
 
-    local trepo tworktree tbranch tpr tmodel
-    IFS='|' read -r trepo tworktree tbranch tpr tmodel <<< "$task_row"
+    local trepo tworktree tbranch tpr tmodel tdesc
+    IFS='|' read -r trepo tworktree tbranch tpr tmodel tdesc <<< "$task_row"
 
     # Extract actionable threads (high + medium, skip low/dismiss)
     local fix_threads
@@ -6810,7 +6832,18 @@ Instructions:
         if [[ -n "$tmodel" ]]; then
             cmd_parts+=(-m "$tmodel")
         fi
-        cmd_parts+=(--title "${task_id}-review-fix" "$fix_prompt")
+        # t262: Include truncated description in review-fix session title
+        local fix_title="${task_id}-review-fix"
+        if [[ -n "$tdesc" ]]; then
+            local short_desc="${tdesc%% -- *}"
+            short_desc="${short_desc%% #*}"
+            short_desc="${short_desc%% ~*}"
+            if [[ ${#short_desc} -gt 25 ]]; then
+                short_desc="${short_desc:0:22}..."
+            fi
+            fix_title="${task_id}-fix: ${short_desc}"
+        fi
+        cmd_parts+=(--title "$fix_title" "$fix_prompt")
     else
         cmd_parts=(claude -p "$fix_prompt" --output-format json)
     fi


### PR DESCRIPTION
## Summary

Worker sessions in OpenCode were titled just "tNNN" (e.g., "t253", "t254") which is unhelpful when browsing the session list. Now includes a truncated task description for context.

### Changes

**`.agents/scripts/supervisor-helper.sh`**
- `build_dispatch_cmd()`: Session title now `"t253: Kill orphaned child proc..."` instead of `"t253"`
- `reprompt_worker()`: Retry title now `"t253-r2: Kill orphaned child..."` instead of `"t253-retry2"`
- `dispatch_review_fix_worker()`: Fix title now `"t253-fix: Kill orphaned ch..."` instead of `"t253-review-fix"`, also added `description` to the DB query
- Eval sessions left as `"eval-tNNN"` (ephemeral 30s probes, not worth the overhead)

Description is cleaned before truncation: strips notes after `--`, tags (`#bugfix`), and estimates (`~30m`).

### Verification

- `bash -n`: syntax valid
- ShellCheck: zero new warnings (only pre-existing SC2034 unused vars)
- Manual title simulation tested with real task descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Session titles now include truncated task descriptions for better readability and identification
  * Enhanced labeling applied to initial sessions, retry sessions, and review-fix sessions
  * Task descriptions automatically integrated into worker prompts for improved context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->