### PR TITLE
t258: Exclude skill reference files from subagent stub generation

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -779,7 +779,7 @@ tools:
 EOF
     fi
     subagent_count=$((subagent_count + 1))
-done < <(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -type f -not -path "*/loop-state/*" | sort)
+done < <(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -type f -not -path "*/loop-state/*" -not -name "*-skill.md" | sort)
 
 echo -e "  ${GREEN}✓${NC} Generated $subagent_count subagent files"
 


### PR DESCRIPTION
## Summary

- Add `-not -name '*-skill.md'` filter to find command in generate-opencode-agents.sh
- Prevents skill reference files from being processed as OpenCode subagents
- Skill files are documentation/reference only, not executable agents

## Changes

- Modified `.agents/scripts/generate-opencode-agents.sh` line 782
- Added filter alongside existing `-not -path '*/loop-state/*'` exclusion

## Testing

- [x] Run generate-opencode-agents.sh
- [x] Verify skill files are excluded from subagent generation (12 skill files excluded, 893 subagents processed)
- [x] Run shellcheck validation (passes with no violations)

## Verification

```bash
# Before: Would process all .md files including skills
find ~/.aidevops/agents -mindepth 2 -name '*.md' -type f -not -path '*/loop-state/*' | wc -l
# 905 files

# After: Excludes skill files
find ~/.aidevops/agents -mindepth 2 -name '*.md' -type f -not -path '*/loop-state/*' -not -name '*-skill.md' | wc -l
# 893 files (12 skill files excluded)
```

Related: t258

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build script to refine file discovery and processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->