### PR TITLE
fix: SCRIPTS_DIR typo breaks quality gate model escalation

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -3493,7 +3493,7 @@ resolve_task_model() {
     # 3) Pattern-tracker recommendation (t246: data-driven routing)
     #    If we have 3+ samples for a task type with >75% success rate on a
     #    cheaper tier, use that tier. This learns from actual dispatch outcomes.
-    local pattern_helper="${SCRIPTS_DIR}/pattern-tracker-helper.sh"
+    local pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
     if [[ -n "$task_desc" && -x "$pattern_helper" ]]; then
         local pattern_json
         pattern_json=$("$pattern_helper" recommend --json 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

- Fixes `SCRIPTS_DIR: unbound variable` error at line 3496 of supervisor-helper.sh
- The variable is defined as `SCRIPT_DIR` (singular) at line 161, but line 3496 used `SCRIPTS_DIR` (plural)
- With `set -euo pipefail`, this crashes the pattern-tracker recommendation step during quality gate model escalation
- Result: escalated tasks dispatch with an empty model string instead of the intended `anthropic/claude-opus-4-6`

One-character fix: `SCRIPTS_DIR` → `SCRIPT_DIR`