### PR TITLE
feat: add domain expertise check to Build+ workflow (step 2b)

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -174,6 +174,39 @@ See `tools/opencode/opencode.md` for CLI testing patterns.
 - How does this fit into the larger context of the codebase?
 - What are the dependencies and interactions with other parts?
 
+### 2b. Domain Expertise Check (CRITICAL)
+
+Before implementing, check whether the work touches a domain that has specialist
+subagents. These contain prompt templates, best practices, tool routing, and
+testing strategies that dramatically improve output quality.
+
+**How to check**: Scan the AGENTS.md progressive disclosure table for matching
+domains. If the task involves content generation, video, images, SEO, WordPress,
+voice, accessibility, or any other listed domain — read the relevant subagent(s)
+BEFORE writing code or generating assets.
+
+**Examples**:
+
+| Task involves... | Read first |
+|------------------|------------|
+| Image generation, thumbnails, visual assets | `content/production/image.md` (structured prompt templates) |
+| Video generation, animation | `content/production/video.md` + `tools/video/video-prompt-design.md` |
+| UGC, ads, social content | `content.md` (orchestrator) -> `content/story.md` -> `content/production/` |
+| Audio, voice, narration | `content/production/audio.md` + `tools/voice/speech-to-speech.md` |
+| SEO content, blog posts | `seo/` + `content/distribution/` |
+| WordPress changes | `tools/wordpress/wp-dev.md` |
+| Browser automation | `tools/browser/browser-automation.md` (decision tree) |
+| Accessibility | `services/accessibility/accessibility-audit.md` |
+
+**Why this matters**: Domain subagents contain tested prompt schemas (e.g.,
+Nanobanana Pro JSON templates for images), model routing decisions (which AI
+model for which task), and quality criteria. Using freehand prompts when
+structured templates exist wastes credits and produces inferior results.
+
+**For testing**: Domain subagents also document how to verify output quality
+(scoring rubrics, A/B testing patterns, platform-specific requirements). Read
+them before declaring work complete.
+
 ### 3. Codebase Investigation
 
 - Explore relevant files and directories


### PR DESCRIPTION
## Summary

- Adds step 2b "Domain Expertise Check" to Build+ Build Workflow, between "Deeply Understand the Problem" and "Codebase Investigation"
- When a task touches a domain with specialist subagents (content, video, images, SEO, WordPress, etc.), Build+ now reads those subagents BEFORE implementing
- Includes lookup table mapping task types to relevant subagents (e.g., image generation -> `content/production/image.md` for Nanobanana Pro JSON templates)

## Why

Discovered during a Higgsfield UGC generation task: Build+ went straight to the automator with freehand prompts instead of reading `content/production/image.md` (which has tested Nanobanana Pro JSON prompt schemas), `content/story.md` (hook frameworks), and `tools/video/video-prompt-design.md` (7-component video prompt format). The domain subagents existed but Build+ had no instruction to check for them.

## Impact

- Better prompt quality for content generation tasks (structured templates vs freehand)
- Better model routing (domain subagents document which AI model for which task)
- Better testing (domain subagents include scoring rubrics and quality criteria)
- Applies to all domains, not just content — WordPress, SEO, accessibility, etc.