### PR TITLE
feat: supervisor session memory monitoring with respawn detection (t264)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -259,6 +259,8 @@ supervisor-helper.sh status <batch-id>
 
 **Cron pulse is mandatory** for autonomous operation. Without it, the supervisor is passive and requires manual `pulse` calls. The pulse cycle: check workers -> evaluate outcomes -> dispatch next -> cleanup.
 
+**Session memory monitoring** (t264): Long-running OpenCode/Bun sessions accumulate WebKit malloc dirty pages that are never returned to the OS (25GB+ observed). Phase 11 of the pulse cycle checks the parent OpenCode session's `phys_footprint` and writes a respawn marker when it exceeds `SUPERVISOR_SELF_MEM_LIMIT` (default: 8192MB). Cron-based pulses are already fresh processes. Use `supervisor-helper.sh mem-check` to inspect session memory.
+
 **Full docs**: `tools/ai-assistants/headless-dispatch.md`, `supervisor-helper.sh help`
 
 ## Session Completion


### PR DESCRIPTION
## Summary

- Add per-process memory footprint measurement using macOS `footprint(1)` / Linux `/proc/PID/status`
- Add Phase 11 to supervisor pulse cycle: detects when the parent OpenCode session exceeds memory threshold and writes a respawn marker
- Add `supervisor-helper.sh mem-check` CLI command for manual inspection
- Document in AGENTS.md

## Problem

OpenCode/Bun processes accumulate WebKit malloc dirty pages that are never returned to the OS. A single session observed at 25GB+ `phys_footprint` (30GB total). Workers are short-lived and already cleaned up by Phase 4, but the long-running supervisor session needs monitoring.

## Design Decisions

- **Workers are NOT killed for memory** — they may legitimately need more for large tasks, and Phase 4 already handles dead/hung workers
- **Concurrency is NOT throttled by worker memory** — existing system-wide `memory_pressure` detection already handles this
- **Focus is solely on the supervisor session** — the one long-lived process that accumulates WebKit malloc over hours
- **Respawn marker file** (`respawn-recommended`) enables external tooling to detect and act on the recommendation
- **`SUPERVISOR_SELF_MEM_LIMIT`** env var (default 8192MB) controls the threshold

## Testing

- `get_process_footprint_mb` verified against known 29GB OpenCode process (returned 30406MB, matching Activity Monitor)
- `mem-check` command tested — correctly detects parent OpenCode session, shows footprint and uptime
- ShellCheck clean (zero new warnings)

Closes t264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic memory monitoring for long-running sessions to detect when memory usage exceeds thresholds
  * New memory inspection capability to check session memory footprint and receive respawn recommendations
  * Configurable memory limit threshold for supervisor sessions

* **Documentation**
  * Added documentation explaining session memory behavior, monitoring mechanisms, and how to use memory inspection utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->