### PR TITLE
feat: supervisor respawn on batch completion when memory exceeds threshold (t264.1)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -259,7 +259,7 @@ supervisor-helper.sh status <batch-id>
 
 **Cron pulse is mandatory** for autonomous operation. Without it, the supervisor is passive and requires manual `pulse` calls. The pulse cycle: check workers -> evaluate outcomes -> dispatch next -> cleanup.
 
-**Session memory monitoring** (t264): Long-running OpenCode/Bun sessions accumulate WebKit malloc dirty pages that are never returned to the OS (25GB+ observed). Phase 11 of the pulse cycle checks the parent OpenCode session's `phys_footprint` and writes a respawn marker when it exceeds `SUPERVISOR_SELF_MEM_LIMIT` (default: 8192MB). Cron-based pulses are already fresh processes. Use `supervisor-helper.sh mem-check` to inspect session memory.
+**Session memory monitoring + respawn** (t264, t264.1): Long-running OpenCode/Bun sessions accumulate WebKit malloc dirty pages that are never returned to the OS (25GB+ observed). Phase 11 of the pulse cycle checks the parent session's `phys_footprint` when a batch wave completes (no running/queued tasks). If memory exceeds `SUPERVISOR_SELF_MEM_LIMIT` (default: 8192MB), it saves a checkpoint, logs the respawn event to `~/.aidevops/logs/respawn-history.log`, and exits cleanly for the next cron pulse to start fresh. Use `supervisor-helper.sh mem-check` to inspect memory and `supervisor-helper.sh respawn-history` to review respawn patterns.
 
 **Full docs**: `tools/ai-assistants/headless-dispatch.md`, `supervisor-helper.sh help`
 


### PR DESCRIPTION
## Summary

- Supervisor now actively respawns after a batch wave completes if the parent OpenCode/Bun session's memory exceeds `SUPERVISOR_SELF_MEM_LIMIT` (default 8192MB)
- All respawn events are logged to `~/.aidevops/logs/respawn-history.log` with timestamp, PID, footprint, reason, batch ID, and session uptime — enabling pattern analysis for sessions that chronically hit the threshold without compacting
- Checkpoint is saved before respawn so the next cron pulse (2 min) starts fresh with zero accumulated WebKit malloc and full context

## Changes

**`.agents/scripts/supervisor-helper.sh`**:
- `attempt_respawn_after_batch()`: checks batch-complete condition (no running/queued tasks) + memory threshold, saves checkpoint, logs event, writes respawn marker
- `log_respawn_event()`: appends structured line to persistent respawn history log
- `cmd_respawn_history`: new CLI command (`supervisor-helper.sh respawn-history [N]`)
- Phase 11 upgraded from passive warning to active respawn trigger
- `cmd_mem_check` enhanced to show last 3 respawn events inline

**`.agents/AGENTS.md`**: Updated session memory monitoring docs

## Design

Respawn triggers at a natural lifecycle boundary — after all workers finish and self-improvement TODOs are logged — not at arbitrary memory thresholds mid-work. Workers are never killed or throttled. The persistent log answers: "are sessions chronically hitting 8GB without ever reaching compaction?"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session memory monitoring now includes automatic respawn capability that saves checkpoints and restarts cleanly when memory limits are exceeded
  * Added `respawn-history` command to display recent respawn events and monitor system restarts

* **Documentation**
  * Updated documentation to reflect new memory monitoring and respawn behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->