### PR TITLE
fix: add missing DIM color constant for respawn-history output (t264.1)

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -231,6 +231,7 @@ readonly -a VALID_TRANSITIONS=(
 )
 
 readonly BOLD='\033[1m'
+readonly DIM='\033[2m'
 
 log_info() { echo -e "${BLUE}[SUPERVISOR]${NC} $*" >&2; }
 log_success() { echo -e "${GREEN}[SUPERVISOR]${NC} $*" >&2; }


### PR DESCRIPTION
## Summary

- Adds missing `DIM` ANSI escape constant (`\033[2m`) to supervisor-helper.sh
- Fixes `unbound variable` error when running `supervisor-helper.sh respawn-history`
- Found during testing of t264.1 respawn feature