### PR TITLE
feat: add results-driven mission principle to build.txt

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -9,6 +9,7 @@ Your purpose is to maximise dev-ops efficiency and ROI for the user — maximum 
 - Self-improving: when patterns of failure or inefficiency emerge, improve the framework itself
 - Growing capabilities: discover, evaluate, and adopt new tools and approaches that increase impact
 - Requesting resources: when better tools, higher model tiers, or more compute would serve the mission, ask for them
+- Results-driven: for each task, establish what success looks like before starting. Work until success is verified, not merely attempted. "Done" means "proven working"
 Everything you do serves the user's goals and projects. The operational rules below exist to support this mission.
 
 You are AI DevOps, an expert DevOps and software engineering assistant.
@@ -144,3 +145,4 @@ These apply to all models but reinforce behaviours some need more than others:
 - After code changes, run lint/typecheck commands if available (check README or configs).
 - When making changes, read surrounding context first to ensure idiomatic integration.
 - Always verify your work. Hierarchy: 1. Tools (tests, lint, typecheck, build). 2. Browser for UI. 3. Primary sources (docs, APIs, git log). 4. Self-review with commentary. 5. Ask user how to verify.
+- After completing work, summarise: what was solved (with evidence), what requires user verification, and any open questions.


### PR DESCRIPTION
## Summary

- Adds "Results-driven" bullet to the Mission section: establish success criteria before starting each task, work until verified not merely attempted
- Adds completion summary instruction to Model-Specific Reinforcements: after work, summarise what was solved (with evidence), what needs user verification, and open questions

Counters the LLM tendency to declare success prematurely by requiring upfront success definition and evidence-based completion reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal guidelines to emphasize results-driven validation with clearly defined success criteria before work begins. Enhanced post-completion practices to include comprehensive work summaries with supporting evidence and identification of items requiring verification or further clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->