### PR TITLE
docs: auto-dispatch tagging guidance + default-on policy for TODO creation (t273)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -113,6 +113,8 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **Dependencies**: `blocked-by:t001`, `blocks:t002`, `t001.1` (subtask)
 
+**Auto-dispatch**: Add `#auto-dispatch` to tasks that can run autonomously (clear spec, bounded scope, no user input needed). Default to including it — only omit when a specific exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria. The supervisor's Phase 0 picks these up automatically every 2 minutes.
+
 **Task completion rules** (CRITICAL - prevents false completion cascade):
 - NEVER mark a task `[x]` unless a merged PR exists with real deliverables for that task
 - The supervisor `update_todo_on_complete()` is the ONLY path to mark tasks done - it requires a merged PR URL or `verified:YYYY-MM-DD` field

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -115,6 +115,35 @@ When a task meets Ralph criteria, add the `#ralph` tag:
 - [ ] t044 Design new dashboard layout #feature ~3h  (NOT ralph-able)
 ```
 
+### Auto-Dispatch Tagging
+
+When creating TODO entries, assess whether the task can run autonomously without user monitoring. If yes, add `#auto-dispatch`. The supervisor's Phase 0 picks these up automatically on the next cron pulse.
+
+**Add `#auto-dispatch` when ALL of these are true:**
+- Clear fix/feature description with specific files or patterns to change
+- Bounded scope (~2h or less estimated)
+- No user credentials, accounts, or purchases needed
+- No design decisions requiring user preference
+- Verification is automatable (tests, ShellCheck, syntax check, browser test)
+
+**Do NOT add `#auto-dispatch` when ANY of these are true:**
+- Task requires user to provide credentials, top up accounts, or make purchases
+- Task is a `#plan` that needs decomposition into subtasks first
+- Task requires hardware setup or external service configuration
+- Task description says "investigate" or "evaluate" without a clear deliverable
+- Task has `blocked-by:` dependencies on incomplete tasks
+
+**Examples:**
+
+```markdown
+- [ ] t042 Fix ShellCheck violations in helper.sh #bugfix #auto-dispatch ~30m
+- [ ] t043 Add download --count flag to automator #enhancement #auto-dispatch ~1h
+- [ ] t044 Investigate API pricing tiers #investigation ~30m  (NOT auto-dispatch)
+- [ ] t045 Design new dashboard layout #plan ~3h  (NOT auto-dispatch — needs decomposition)
+```
+
+**AI agents MUST**: When creating a new TODO entry, always evaluate auto-dispatch eligibility and add the tag if criteria are met. Default to including `#auto-dispatch` — only omit when a specific exclusion criterion applies. The goal is to keep the autonomous pipeline moving.
+
 ### Ralph Task Requirements
 
 When tagging a task as `#ralph`, ensure it includes:


### PR DESCRIPTION
## Summary

- Adds auto-dispatch tagging criteria to `workflows/plans.md` so AI agents know when to tag tasks for autonomous processing
- Default policy: **include `#auto-dispatch` unless a specific exclusion applies** — keeps the pipeline moving
- Adds quick reference to `AGENTS.md` Planning & Tasks section

## Why

8 tasks were sitting idle in TODO.md that could have been running autonomously. The framework had the `#auto-dispatch` mechanism (Phase 0 auto-pickup) but no guidance telling agents to use it. This closes that gap.

## Auto-dispatch criteria (from the new docs)

**Add when**: clear spec, bounded scope (~2h), no user input needed, automatable verification
**Omit when**: needs credentials/purchases, is a `#plan` needing decomposition, needs hardware, or is investigative without clear deliverable