### PR TITLE
feat: add --count flag to download command (t268)

### DIFF
--- a/.agents/scripts/higgsfield-helper.sh
+++ b/.agents/scripts/higgsfield-helper.sh
@@ -338,7 +338,7 @@ Commands:
   assets             List recent generations
   credits            Check account credits/plan
   screenshot [url]   Take screenshot of a page
-  download           Download latest generation
+  download           Download latest generation (default: 4 most recent images)
   help               Show this help
 
 Options (pass after command):
@@ -359,6 +359,7 @@ Options (pass after command):
   --unlimited        Prefer unlimited models only
   --no-sidecar       Disable JSON sidecar metadata files
   --no-dedup         Disable SHA-256 duplicate detection
+  --count, -c        Number of images to download (default: 4, use 0 for all)
   --concurrency, -C  Max concurrent jobs for batch operations (default varies)
   --resume           Resume a previous batch run (skip completed jobs)
 


### PR DESCRIPTION
## Summary

Fixes issue where the Higgsfield `download` command downloaded the entire history (19-24 images from all previous sessions) instead of just the latest generation.

## Changes

- Added `--count/-c` flag to control number of images to download (default: 4)
- Added `--concurrency/-C` flag to FLAG_DEFS for batch operations
- Modified `downloadFromHistory()` to pass count parameter to `downloadLatestResult()`
- Updated `downloadLatestResult()` to respect count parameter (0 = download all)
- Updated help text in both `higgsfield-helper.sh` and `playwright-automator.mjs`
- Added usage examples for the new `--count` flag

## Usage

```bash
# Download 4 most recent images (default)
higgsfield-helper.sh download

# Download specific number of images
higgsfield-helper.sh download --count 2

# Download all images on the page
higgsfield-helper.sh download --count 0
```

## Testing

- ✅ JavaScript syntax validated with `node --check`
- ✅ ShellCheck passes with zero violations
- ✅ Logic verified: count defaults to 4, 0 means all, respects min(count, available)

Closes #1042