### PR TITLE
t266: Graduate permanent learnings into docs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -412,6 +412,8 @@ Import community skills: `aidevops skill add <source>` (→ `*-skill.md` suffix)
 
 Proactively use a browser for: dev server verification, form testing, deployment checks, frontend debugging. Read `tools/browser/browser-automation.md` for tool selection. Quick default: Playwright for dev testing, dev-browser for persistent login.
 
+**CRITICAL: Never use curl/HTTP to verify frontend fixes.** Server returns 200 even when React crashes client-side because error boundaries render successfully. The crash happens during hydration which curl never executes. Always use browser screenshots (dev-browser agent, Playwright) to verify frontend fixes work.
+
 ## Localhost Standards
 
 `.local` domains + SSL via Traefik + mkcert. See `services/hosting/localhost.md`.

--- a/.agents/memory/README.md
+++ b/.agents/memory/README.md
@@ -37,6 +37,8 @@ sqlite3 --version
 - **Dual timestamps** - Distinguish when stored vs when event occurred
 - **Contextual disambiguation** - Self-contained, atomic memories
 
+**Architecture Decision: SQLite FTS5 over PostgreSQL** - SQLite was chosen for memory storage to minimize deployment complexity and eliminate external dependencies. No separate database server required, no connection management, and FTS5 provides fast full-text search out of the box. This aligns with the aidevops philosophy of self-contained, portable tooling.
+
 ## Quick Start
 
 ```bash

--- a/.agents/tools/browser/browser-automation.md
+++ b/.agents/tools/browser/browser-automation.md
@@ -687,6 +687,8 @@ await client.disconnect();
 EOF
 ```
 
+**NEVER use curl/HTTP to verify frontend fixes**: Server returns 200 even when React crashes client-side because error boundaries render successfully. The crash happens during hydration which curl never executes. Always use browser screenshots to verify frontend fixes work.
+
 **Self-diagnosis workflow**:
 1. Action fails or unexpected result
 2. Take screenshot


### PR DESCRIPTION
## Summary

Graduated two FAILED_APPROACH memories into permanent documentation:

1. **Browser verification learning**: Never use curl/HTTP to verify frontend fixes — React error boundaries return 200 even when hydration crashes. Always use browser screenshots.
   - Added to `.agents/AGENTS.md` Browser Automation section
   - Added to `.agents/tools/browser/browser-automation.md` Visual Debugging section

2. **SQLite FTS5 architectural decision**: SQLite chosen over PostgreSQL for memory storage to minimize deployment complexity and eliminate external dependencies.
   - Added to `.agents/memory/README.md` as architectural note

Both memories have been pruned from the memory database after graduation.

## Changes

- `.agents/AGENTS.md`: Added browser verification warning
- `.agents/tools/browser/browser-automation.md`: Added browser verification warning
- `.agents/memory/README.md`: Added SQLite FTS5 architectural decision note
- Memory database: Removed 2 graduated FAILED_APPROACH memories

## Verification

- Documentation changes reviewed for formatting consistency
- Memories successfully deleted from database (verified with recall query)
- All changes committed incrementally following worker efficiency protocol