### PR TITLE
t272: Add UGC brief storyboard template for multi-shot content generation

### DIFF
--- a/.agents/content/production/image.md
+++ b/.agents/content/production/image.md
@@ -604,6 +604,140 @@ Different platforms have different optimal image dimensions and aspect ratios.
 - **PNG**: Graphics with transparency, text overlays, logos
 - **WebP**: Modern format, smaller than JPG, use for web when supported
 
+## UGC Brief Image Template
+
+Generate keyframe images for each shot in a UGC storyboard (from `content/story.md` UGC Brief Storyboard). Each keyframe becomes either a standalone social image or a reference frame for video generation via the annotated frame-to-video workflow.
+
+### When to Use
+
+- Generating static keyframes before committing to video generation (cheaper iteration)
+- Creating social media stills from a storyboard (Instagram carousel, blog headers)
+- Producing reference frames for the annotated frame-to-video workflow (see above)
+- Building a visual shot list for a video editor or director
+
+### UGC Keyframe JSON Template
+
+This template extends the Street Photography Template (above) with UGC-specific defaults. Swap `subject`, `concept`, and `composition.focal_point` per shot while keeping the authentic UGC aesthetic constant.
+
+```json
+{
+  "subject": "[PRESENTER_DESCRIPTION — identical across all shots]",
+  "concept": "[SHOT_PURPOSE from storyboard — e.g., 'Hook: presenter reacts to bold claim']",
+  "composition": {
+    "framing": "[Per shot: CU for hook/emotion, MS for dialogue, WS for context]",
+    "angle": "eye-level",
+    "rule_of_thirds": true,
+    "focal_point": "[Per shot: eyes for hook, product for hero, presenter for CTA]",
+    "depth_of_field": "shallow"
+  },
+  "lighting": {
+    "type": "natural",
+    "direction": "available light",
+    "quality": "soft diffused",
+    "color_temperature": "warm (4000K)",
+    "mood": "authentic and approachable"
+  },
+  "color": {
+    "palette": ["[BRAND_PRIMARY]", "[BRAND_SECONDARY]", "[NEUTRAL]"],
+    "dominant": "[BRAND_PRIMARY]",
+    "accent": "[BRAND_SECONDARY]",
+    "saturation": "muted",
+    "harmony": "analogous"
+  },
+  "style": {
+    "aesthetic": "photorealistic",
+    "texture": "film grain",
+    "post_processing": "film emulation",
+    "reference": "iPhone 15 Pro casual photography"
+  },
+  "technical": {
+    "camera": "iPhone 15 Pro",
+    "lens": "24mm f/1.78",
+    "settings": "f/1.78, 1/120s, ISO 640",
+    "resolution": "4K",
+    "aspect_ratio": "[9:16 for TikTok/Reels | 16:9 for YouTube]"
+  },
+  "negative": "studio lighting, professional setup, staged, posed, oversaturated, digital artifacts, watermark, text overlays, perfect skin retouching"
+}
+```
+
+### Per-Shot Keyframe Variations
+
+Map each storyboard shot to specific JSON overrides:
+
+| Shot | Framing | Focal Point | Concept Override | Lighting Override |
+|------|---------|-------------|-----------------|-------------------|
+| 1: Hook | CU | Eyes | "Pattern interrupt — [hook text]" | Warm natural, slightly bright |
+| 2: Before State | MS | Presenter (frustrated) | "Pain point — [problem]" | Flat, slightly desaturated |
+| 3: Product Hero | CU → MS | Product in hands | "Product reveal — [product name]" | Warm golden, product lit |
+| 4: After State | CU | Face (satisfied) | "Transformation result — [outcome]" | Warm, rich, inviting |
+| 5: CTA | MS | Presenter (direct to camera) | "Call to action — [CTA text]" | Clean, warm, confident |
+
+### Worked Example: FreshBrew Shot 3 (Product Hero)
+
+Using the FreshBrew storyboard from `content/story.md`:
+
+```json
+{
+  "subject": "Maya, a 32-year-old South Asian woman with shoulder-length dark wavy hair, warm brown eyes, light olive skin, wearing a cream knit sweater over a white tee, relaxed posture, genuine warm smile, minimal gold stud earrings, natural makeup",
+  "concept": "Product reveal — Maya opens FreshBrew subscription box with visible excitement, colourful coffee bags inside",
+  "composition": {
+    "framing": "medium shot",
+    "angle": "eye-level",
+    "rule_of_thirds": true,
+    "focal_point": "FreshBrew box and coffee bags in hands",
+    "depth_of_field": "shallow"
+  },
+  "lighting": {
+    "type": "natural",
+    "direction": "side (window light from left)",
+    "quality": "golden hour",
+    "color_temperature": "warm (3500K)",
+    "mood": "warm and inviting"
+  },
+  "color": {
+    "palette": ["#F4E4C1", "#6B4226", "#D4A574"],
+    "dominant": "#F4E4C1",
+    "accent": "#6B4226",
+    "saturation": "muted",
+    "harmony": "analogous"
+  },
+  "style": {
+    "aesthetic": "photorealistic",
+    "texture": "film grain",
+    "post_processing": "film emulation",
+    "reference": "iPhone 15 Pro casual photography"
+  },
+  "technical": {
+    "camera": "iPhone 15 Pro",
+    "lens": "24mm f/1.78",
+    "settings": "f/1.78, 1/120s, ISO 640",
+    "resolution": "4K",
+    "aspect_ratio": "9:16"
+  },
+  "negative": "studio lighting, professional setup, staged, posed, oversaturated, digital artifacts, watermark, text overlays, perfect skin retouching, blurry product text"
+}
+```
+
+### Keyframe-to-Video Handoff
+
+After generating keyframe images:
+
+1. **Score keyframes** using the Thumbnail Scoring Rubric (above) — threshold 7.5+
+2. **Annotate with motion** — Add arrows and labels per the Annotated Frame-to-Video Workflow (above)
+3. **Feed to video model** — Use the corresponding 7-component prompt from the storyboard
+4. **Model selection**: Sora 2 Pro for UGC aesthetic, Veo 3.1 for cinematic (see `content/production/video.md`)
+
+### Batch Generation Workflow
+
+Generate all 5 keyframes in a single session:
+
+1. Create base JSON with presenter description and UGC defaults (template above)
+2. For each shot, override only: `concept`, `composition.framing`, `composition.focal_point`, and `lighting` per the Per-Shot Keyframe Variations table
+3. Batch generate via Nanobanana Pro API or sequential Midjourney prompts
+4. Score all outputs, regenerate any below 7.5
+5. Assemble into a visual shot list for review before committing to video generation
+
 ## Cross-References
 
 - **Model comparison**: `tools/vision/image-generation.md` — detailed comparison of DALL-E 3, Midjourney, FLUX, SD XL
@@ -611,11 +745,13 @@ Different platforms have different optimal image dimensions and aspect ratios.
 - **Character consistency**: `content/production/characters.md` — Facial Engineering Framework, character bibles
 - **A/B testing**: `content/optimization.md` — thumbnail variant testing, scoring, analytics
 - **Distribution**: `content/distribution/` — platform-specific formatting for YouTube, social, blog
+- **UGC storyboard**: `content/story.md` — UGC Brief Storyboard template (generates the shot list this template visualises)
+- **Video prompts**: `tools/video/video-prompt-design.md` — 7-component format for video generation from keyframes
 
 ## See Also
 
 - `tools/vision/overview.md` — Vision AI decision tree
 - `tools/vision/image-editing.md` — Modify existing images
 - `tools/vision/image-understanding.md` — Analyze images
-- `content/story.md` — Hook formulas and visual storytelling frameworks
+- `content/story.md` — Hook formulas, visual storytelling frameworks, and UGC Brief Storyboard
 - `content/research.md` — Audience research to inform visual style

--- a/.agents/content/story.md
+++ b/.agents/content/story.md
@@ -170,9 +170,186 @@ When generating a story package, produce:
 - Podcast: [specific adaptations]
 ```
 
+## UGC Brief Storyboard
+
+Generate a complete multi-shot storyboard from a business description. This template eliminates manual shot-by-shot prompt writing by combining the 4-Part Script Framework (above) with the 7-component video prompt format (`tools/video/video-prompt-design.md`).
+
+### Input: Business Brief
+
+Provide a single business description and the template generates all shots:
+
+```text
+# UGC Brief
+
+Business:     [Company name and what they do]
+Product:      [Specific product/service being featured]
+Audience:     [Target customer — demographics, pain points]
+Presenter:    [Character description — 15+ attributes per video-prompt-design.md]
+Tone:         [warm | energetic | authoritative | casual | inspirational]
+Platform:     [TikTok/Reels (9:16) | YouTube (16:9) | both]
+Duration:     [15s | 30s | 60s]
+CTA:          [What the viewer should do — visit site, sign up, buy, etc.]
+```
+
+### Output: 5-Shot Storyboard
+
+The template produces a 5-shot storyboard. Each shot maps to the 4-Part Script Framework and includes all 7 components from `video-prompt-design.md`.
+
+| Shot | Framework Role | Duration | Purpose |
+|------|---------------|----------|---------|
+| 1 | **Hook** | 2-3s | Pattern interrupt — bold claim or question from the 7 Hook Formulas |
+| 2 | **Story: Before State** | 3-5s | Presenter shows the pain/frustration the audience knows |
+| 3 | **Story: Transformation** | 5-8s | Product hero — demonstrate the solution in action |
+| 4 | **Story: After State** | 3-5s | Result proof — show the outcome or transformation |
+| 5 | **Soft Sell + CTA** | 2-3s | Direct call to action with presenter addressing camera |
+
+### Per-Shot 7-Component Format
+
+Each shot in the storyboard uses this structure (from `tools/video/video-prompt-design.md`):
+
+```text
+## Shot [N]: [FRAMEWORK_ROLE]
+
+Subject:   [Presenter description — identical across all shots for consistency]
+Action:    [Specific movements, gestures, micro-expressions for this shot]
+Scene:     [Environment, props, lighting — matches business context]
+Style:     [Camera: shot type, angle, movement | Colour palette | DOF]
+Dialogue:  (Presenter): "[8s-rule: 12-15 words max]" (Tone: [from brief])
+Sounds:    [Diegetic audio only for UGC — no score, no stock music]
+Technical: [Negatives: subtitles, watermark, text overlays, amateur quality]
+```
+
+### Worked Example
+
+**Brief**: "FreshBrew, a specialty coffee subscription. Product: monthly curated coffee box. Audience: 25-40 remote workers who drink 3+ cups/day but are bored of supermarket coffee. Presenter: Maya, a 32-year-old South Asian woman with shoulder-length dark hair, warm brown eyes, wearing a cream knit sweater, relaxed posture, genuine smile. Tone: warm. Platform: TikTok/Reels (9:16). Duration: 30s. CTA: Link in bio for first box 50% off."
+
+---
+
+**Shot 1: Hook** (3s) — Bold Claim formula
+
+```text
+Subject:   Maya, a 32-year-old South Asian woman with shoulder-length dark wavy
+           hair, warm brown eyes, light olive skin, wearing a cream knit sweater
+           over a white tee, relaxed posture, genuine warm smile, minimal gold
+           stud earrings, natural makeup, confident and approachable demeanour
+Action:    Holds coffee mug close to face, inhales deeply, eyes widen with
+           surprise, looks directly into camera with eyebrows raised
+Scene:     Modern kitchen counter, morning light from window, coffee equipment
+           visible in background, warm wood tones, steam rising from mug
+Style:     CU (head and shoulders), eye-level, handheld with subtle movement,
+           warm colour palette (#F4E4C1, #6B4226, #FFFFFF), shallow DOF
+Dialogue:  (Maya): "Your morning coffee is lying to you." (Tone: warm playfulness
+           with a hint of conspiracy)
+Sounds:    Coffee pouring, gentle morning kitchen ambiance, no music
+Technical: subtitles, captions, watermark, text overlays, logo, amateur quality,
+           distorted hands, oversaturation
+```
+
+**Shot 2: Before State** (5s) — Pain angle
+
+```text
+Subject:   [Identical Maya description]
+Action:    Grimaces while sipping from a generic mug, sets it down with
+           disappointment, shakes head slightly, shoulders slump
+Scene:     Same kitchen, harsh overhead fluorescent light, generic supermarket
+           coffee bag visible on counter, dull morning atmosphere
+Style:     MS (waist up), slightly high angle (looking down = diminished),
+           static shot, desaturated warm tones, medium DOF
+Dialogue:  (Maya): "Same bland bag every week. Three cups a day of... nothing."
+           (Tone: genuine frustration, relatable)
+Sounds:    Mug clinking on counter, quiet kitchen hum, no music
+Technical: subtitles, captions, watermark, text overlays, logo, amateur quality
+```
+
+**Shot 3: Transformation — Product Hero** (8s)
+
+```text
+Subject:   [Identical Maya description]
+Action:    Opens FreshBrew box with visible excitement, lifts out a coffee bag,
+           reads the label with curiosity, scoops beans into grinder, presses
+           brew — movements are deliberate and tactile
+Scene:     Same kitchen, now warm natural window light, FreshBrew branded box
+           centre-frame, colourful coffee bags inside, steam rising from fresh
+           pour, warm golden atmosphere
+Style:     Sequence: CU on hands opening box → MS of Maya reading label → CU
+           tracking shot following pour into mug, warm saturated palette
+           (#F4E4C1, #6B4226, #D4A574), shallow DOF on product
+Dialogue:  (Maya): "Every month, beans I'd never find myself. Single origin,
+           roasted last week." (Tone: warm discovery, genuine enthusiasm)
+Sounds:    Box opening, beans rustling, grinder whirring, coffee pouring,
+           no music
+Technical: subtitles, captions, watermark, text overlays, logo, amateur quality,
+           blurry product text
+```
+
+**Shot 4: After State — Result Proof** (5s)
+
+```text
+Subject:   [Identical Maya description]
+Action:    Takes first sip of new coffee, eyes close in satisfaction, opens
+           eyes with a genuine smile, nods slowly, holds mug with both hands
+Scene:     Same kitchen, warm morning light, laptop open in background
+           suggesting remote work, cosy and elevated atmosphere
+Style:     CU (face and mug), eye-level, slow dolly in (building intimacy),
+           warm rich palette, shallow DOF — face sharp, background soft
+Dialogue:  (Maya): "This is what three cups a day should taste like."
+           (Tone: quiet satisfaction, contentment)
+Sounds:    Gentle sip, quiet morning ambiance, distant birdsong, no music
+Technical: subtitles, captions, watermark, text overlays, logo, amateur quality
+```
+
+**Shot 5: CTA** (3s)
+
+```text
+Subject:   [Identical Maya description]
+Action:    Looks directly into camera, points down (toward link), warm
+           confident smile, slight head tilt
+Scene:     Same kitchen, FreshBrew box visible beside her, warm natural light,
+           clean and inviting frame
+Style:     MS (waist up), eye-level, static shot, warm palette, medium DOF
+Dialogue:  (Maya): "Link in bio — first box is half off." (Tone: friendly
+           invitation, no pressure)
+Sounds:    Quiet kitchen ambiance, no music
+Technical: subtitles, captions, watermark, text overlays, logo, amateur quality
+```
+
+---
+
+### Storyboard Generation Process
+
+1. **Fill the brief** — Business, product, audience, presenter, tone, platform, duration, CTA
+2. **Select hook formula** — Pick from the 7 Hook Formulas based on audience state and platform
+3. **Generate 5 shots** — Use the per-shot 7-component format above
+4. **Score hooks** — Generate 5+ hook variants for Shot 1, score on specificity/emotion/curiosity
+5. **Generate image frames** — Feed each shot to `content/production/image.md` UGC Brief Image Template for static keyframes
+6. **Generate video** — Feed shots to video model (Sora 2 Pro for UGC, Veo 3.1 for cinematic)
+7. **Assemble** — Stitch shots in editing tool, add text overlays in post (not in generation)
+
+### Adapting Shot Count
+
+| Duration | Shots | Adjustment |
+|----------|-------|------------|
+| 15s | 3 | Merge: Hook + Before State, Transformation, CTA |
+| 30s | 5 | Standard template above |
+| 60s | 7-8 | Split Transformation into 2-3 product demo shots, add testimonial shot |
+
+### Integration Points
+
+- **Hook formulas**: Shot 1 uses the 7 Hook Formulas from this document
+- **4-Part Framework**: Shots map directly to Hook → Story → Soft Sell → Visual Cues
+- **Video prompts**: Each shot follows `tools/video/video-prompt-design.md` 7-component format
+- **Image keyframes**: Feed shots to `content/production/image.md` UGC Brief Image Template
+- **Character consistency**: Presenter description stays identical across all shots per `content/production/characters.md`
+- **Audio design**: UGC = all diegetic, no score per `content/production/audio.md`
+- **Distribution**: Output adapts to platform specs in `content/distribution/short-form.md`
+
 ## Related
 
 - `content/research.md` -- Feeds into story design (audience data, pain points)
 - `content/production/writing.md` -- Expands story into full scripts and copy
+- `content/production/image.md` -- UGC Brief Image Template for per-shot keyframes
 - `content/optimization.md` -- A/B tests hook variants and story angles
 - `content.md` -- Parent orchestrator (diamond pipeline)
+- `tools/video/video-prompt-design.md` -- 7-component format used in each shot
+- `content/production/video.md` -- Video generation (Sora 2 Pro for UGC)
+- `content/production/audio.md` -- UGC audio design (diegetic only)


### PR DESCRIPTION
## Summary

- Adds a **UGC Brief Storyboard** template to `content/story.md` that generates a complete 5-shot storyboard from a single business description, eliminating manual shot-by-shot prompt writing
- Adds a **UGC Brief Image Template** to `content/production/image.md` with per-shot Nanobanana JSON keyframe prompts that match the storyboard structure
- Each shot integrates the `video-prompt-design.md` 7-component format (Subject, Action, Scene, Style, Dialogue, Sounds, Technical) and maps to the existing 4-Part Script Framework (Hook → Story → Soft Sell → CTA)

## Changes

### `content/story.md`
- UGC Brief input format (business, product, audience, presenter, tone, platform, duration, CTA)
- 5-shot storyboard structure with framework role mapping
- Per-shot 7-component format template
- Worked example: FreshBrew coffee subscription (all 5 shots fully specified)
- Shot count adaptation table (15s → 3 shots, 30s → 5 shots, 60s → 7-8 shots)
- Integration points linking to existing pipeline (hooks, characters, audio, distribution)

### `content/production/image.md`
- UGC Keyframe JSON Template extending Street Photography with UGC defaults (iPhone 15 Pro, film grain, diegetic-only)
- Per-shot keyframe variation table (framing, focal point, concept, lighting overrides)
- Worked example: FreshBrew Shot 3 (Product Hero) with complete JSON
- Keyframe-to-video handoff workflow (score → annotate → generate → model selection)
- Batch generation workflow for producing all 5 keyframes efficiently

## Testing

- [ ] Markdown lint (MD031 blank lines around code blocks)
- [ ] Cross-reference validation (all linked files exist)
- [ ] Template completeness (7-component format in every shot)

Closes #1047