### PR TITLE
feat: auto-recall memories in Build+ workflow and session start (t273)

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -173,6 +173,7 @@ See `tools/opencode/opencode.md` for CLI testing patterns.
 - Consider: expected behavior, edge cases, potential pitfalls
 - How does this fit into the larger context of the codebase?
 - What are the dependencies and interactions with other parts?
+- **Recall prior lessons**: Run `~/.aidevops/agents/scripts/memory-helper.sh recall --query "<keywords from the task>" --limit 5` to surface relevant decisions, failure patterns, and working solutions from previous sessions. Extract 2-3 keywords from the user's request (e.g., "higgsfield video generation" or "supervisor worker dispatch"). If results are returned, read them and apply any relevant lessons before proceeding. This is how the framework learns across sessions.
 
 ### 2b. Domain Expertise Check (CRITICAL)
 

--- a/.agents/workflows/conversation-starter.md
+++ b/.agents/workflows/conversation-starter.md
@@ -7,14 +7,21 @@ Shared prompts for Build+ agent to ensure consistent UX.
 
 ## Inside Git Repository
 
-**First**: Check git context before offering options:
+**First**: Check git context and recall recent lessons:
 
 ```bash
 BRANCH=$(git branch --show-current)
 if [[ "$BRANCH" == "main" ]]; then
     echo "Currently on main branch - will suggest work branch for coding tasks"
 fi
+
+# Surface recent lessons from memory (silent if no results)
+~/.aidevops/agents/scripts/memory-helper.sh recall --recent --limit 3 2>/dev/null
 ```
+
+If memory recall returns results, briefly note any relevant lessons (e.g.,
+"Recent lesson: always read domain subagents before content generation tasks").
+Do not dump raw memory output — summarize actionable items only.
 
 If on `main` branch, include this note in the prompt:
 


### PR DESCRIPTION
## Summary

- Build+ step 2 ("Deeply Understand the Problem") now includes a memory recall command that queries prior lessons using task keywords before implementation begins
- Conversation starter now recalls the 3 most recent memories at session start, briefly noting actionable lessons
- Closes the learning loop: memories are stored during sessions but were never automatically surfaced — making the memory system write-only

## Why

Discovered during Trinity Windows UGC test session: 5 behavioural lessons were stored in memory (log TODOs immediately, read domain subagents, output to ~/Downloads, deliver assembled sequences, don't mention issues without logging them). But nothing in the framework would ever read them back. The memory system had no integration with Build+ or session startup.

## Changes

| File | Change |
|------|--------|
| `.agents/build-plus.md` | Added recall command to step 2 with keyword extraction guidance |
| `.agents/workflows/conversation-starter.md` | Added `memory-helper.sh recall --recent` at session start |