### PR TITLE
t274: Supervisor auto-decomposition of #plan tasks

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -12533,8 +12533,7 @@ dispatch_decomposition_worker() {
 
     # Build decomposition prompt with explicit TODO.md edit permission
     local decomposition_prompt
-    decomposition_prompt=$(cat <<'PROMPT_EOF'
-You are a task decomposition worker with SPECIAL PERMISSION to edit TODO.md.
+    decomposition_prompt="You are a task decomposition worker with SPECIAL PERMISSION to edit TODO.md.
 
 Your mission: Read a plan from PLANS.md and generate subtasks in TODO.md with #auto-dispatch tags.
 
@@ -12543,14 +12542,9 @@ You ARE allowed to edit TODO.md for this specific task because you are generatin
 subtasks for orchestration. This is the ONLY exception to the worker TODO.md restriction.
 
 ## Task Details
-PROMPT_EOF
-)
-    decomposition_prompt+="
 Task ID: $task_id
 Plan anchor: $plan_anchor
 Repository: $repo
-"
-    decomposition_prompt+=$(cat <<'PROMPT_EOF'
 
 ## Instructions
 
@@ -12577,25 +12571,25 @@ Create subtasks following this format:
 - Keep descriptions concise but actionable
 
 ### Step 4: Insert subtasks in TODO.md
-1. Find the parent task line (starts with "- [ ] ${task_id} ")
+1. Find the parent task line (starts with \"- [ ] ${task_id} \")
 2. Insert subtasks immediately after it (before any blank line or next task)
 3. Preserve all existing content
 4. DO NOT modify the parent task line
 
 ### Step 5: Commit and exit
 1. Run: git add TODO.md
-2. Run: git commit -m "feat: auto-decompose ${task_id} from PLANS.md (${plan_anchor})"
+2. Run: git commit -m \"feat: auto-decompose ${task_id} from PLANS.md (${plan_anchor})\"
 3. Run: git push origin main
 4. Exit with status 0
 
 ## Example output format
-```markdown
+\`\`\`markdown
 - [ ] t300 Email Testing Suite #plan → [todo/PLANS.md#2026-02-10-email-testing-suite] ~2h
   - [ ] t300.1 Email Design Test agent + helper script ~35m #auto-dispatch
   - [ ] t300.2 Email Delivery Test agent + helper script ~35m #auto-dispatch blocked-by:t300.1
   - [ ] t300.3 Email Health Check enhancements ~15m #auto-dispatch blocked-by:t300.2
   - [ ] t300.4 Cross-references + integration ~10m #auto-dispatch blocked-by:t300.3
-```
+\`\`\`
 
 ## CRITICAL Rules
 - DO NOT modify the parent task line
@@ -12613,9 +12607,7 @@ If the plan structure is unclear:
 - FLAG: Exit with error if plan anchor not found in PLANS.md
 - FLAG: Exit with error if plan has no actionable content
 
-Start now. Read todo/PLANS.md, find the anchor, generate subtasks, commit, push, exit 0.
-PROMPT_EOF
-)
+Start now. Read todo/PLANS.md, find the anchor, generate subtasks, commit, push, exit 0."
 
     # Create logs directory if it doesn't exist
     mkdir -p "$HOME/.aidevops/logs"

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -12533,7 +12533,8 @@ dispatch_decomposition_worker() {
 
     # Build decomposition prompt with explicit TODO.md edit permission
     local decomposition_prompt
-    decomposition_prompt="You are a task decomposition worker with SPECIAL PERMISSION to edit TODO.md.
+    read -r -d '' decomposition_prompt <<EOF || true
+You are a task decomposition worker with SPECIAL PERMISSION to edit TODO.md.
 
 Your mission: Read a plan from PLANS.md and generate subtasks in TODO.md with #auto-dispatch tags.
 
@@ -12571,14 +12572,14 @@ Create subtasks following this format:
 - Keep descriptions concise but actionable
 
 ### Step 4: Insert subtasks in TODO.md
-1. Find the parent task line (starts with \"- [ ] ${task_id} \")
+1. Find the parent task line (starts with "- [ ] ${task_id} ")
 2. Insert subtasks immediately after it (before any blank line or next task)
 3. Preserve all existing content
 4. DO NOT modify the parent task line
 
 ### Step 5: Commit and exit
 1. Run: git add TODO.md
-2. Run: git commit -m \"feat: auto-decompose ${task_id} from PLANS.md (${plan_anchor})\"
+2. Run: git commit -m "feat: auto-decompose ${task_id} from PLANS.md (${plan_anchor})"
 3. Run: git push origin main
 4. Exit with status 0
 
@@ -12607,7 +12608,8 @@ If the plan structure is unclear:
 - FLAG: Exit with error if plan anchor not found in PLANS.md
 - FLAG: Exit with error if plan has no actionable content
 
-Start now. Read todo/PLANS.md, find the anchor, generate subtasks, commit, push, exit 0."
+Start now. Read todo/PLANS.md, find the anchor, generate subtasks, commit, push, exit 0.
+EOF
 
     # Create logs directory if it doesn't exist
     mkdir -p "$HOME/.aidevops/logs"


### PR DESCRIPTION
## Summary

Implements supervisor auto-decomposition of #plan tasks in Phase 0. This closes the loop: plan → auto-decompose → auto-dispatch subtasks → workers execute → self-improving pipeline.

## Changes

### Strategy 3: #plan Task Detection (lines 12631-12691)
- Detects tasks with `#plan` tag AND `→ [todo/PLANS.md#anchor]` reference
- Checks if task already has subtasks (e.g., t001.1, t001.2)
- Skips tasks that are already decomposed
- Extracts PLANS.md anchor from task line
- Adds task to supervisor with metadata: `plan_anchor=...,needs_decomposition=true`
- Immediately dispatches decomposition worker

### dispatch_decomposition_worker Function (lines 12505-12591)
- Special worker with EXPLICIT permission to edit TODO.md
- Reads PLANS.md section using the extracted anchor
- Analyzes plan structure (phases, milestones, deliverables)
- Generates subtasks with:
  - Hierarchical IDs (t001.1, t001.2, etc.)
  - 2-space indentation
  - `#auto-dispatch` tags for autonomous execution
  - Estimates from plan
  - Dependencies (blocked-by:) for sequential phases
- Inserts subtasks immediately after parent task in TODO.md
- Commits directly to main (planning-only change)
- Logs to `~/.aidevops/logs/decomposition-worker-{task_id}.log`

## Integration with Existing Workflow

1. **Phase 0 (Auto-Pickup)**: Now has 3 strategies:
   - Strategy 1: `#auto-dispatch` tagged tasks
   - Strategy 2: "Dispatch Queue" section tasks
   - **Strategy 3 (NEW)**: `#plan` tasks without subtasks

2. **Decomposition Worker**: 
   - Runs in background (non-blocking)
   - Uses Claude CLI for AI-powered decomposition
   - Tracks worker PID in supervisor metadata
   - Exception to worker TODO.md restriction (documented in prompt)

3. **Auto-Dispatch Loop**:
   - Plan task detected → decomposed into subtasks
   - Subtasks have `#auto-dispatch` → picked up by Strategy 1
   - Workers execute subtasks autonomously
   - Self-improving pipeline completes the loop

## Testing

- ✅ Bash syntax validation (`bash -n`)
- ✅ ShellCheck validation (no violations)
- ✅ Verified detection patterns match existing TODO.md format
- ✅ Confirmed integration with existing Phase 0 strategies

## Example Workflow

**Before** (manual decomposition required):
```markdown
- [ ] t300 Email Testing Suite #plan → [todo/PLANS.md#2026-02-10-email-testing-suite] ~2h
```

**After** (automatic decomposition):
```markdown
- [ ] t300 Email Testing Suite #plan → [todo/PLANS.md#2026-02-10-email-testing-suite] ~2h
  - [ ] t300.1 Email Design Test agent + helper script ~35m #auto-dispatch
  - [ ] t300.2 Email Delivery Test agent + helper script ~35m #auto-dispatch blocked-by:t300.1
  - [ ] t300.3 Email Health Check enhancements ~15m #auto-dispatch blocked-by:t300.2
  - [ ] t300.4 Cross-references + integration ~10m #auto-dispatch blocked-by:t300.3
```

## Related

- Closes the loop described in t274
- Integrates with existing auto-dispatch (t128.5)
- Respects worker TODO.md restrictions (t173) with explicit exception
- Uses uncertainty decision framework (t176) in decomposition prompt