### PR TITLE
fix: sanitize supervisor arithmetic to prevent syntax errors

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -121,6 +121,7 @@ Use `/save-todo` after planning. Auto-detects complexity:
 - Checking that a file exists is NOT sufficient - verify the PR was merged and contains substantive changes
 - If a worker completes with `no_pr` or `task_only`, the task stays `[ ]` until a human or the supervisor verifies the deliverable
 - The `issue-sync` GitHub Action auto-closes issues when tasks are marked `[x]` - false completions cascade into closed issues
+- NEVER close GitHub issues manually with `gh issue close` — let the issue-sync pipeline verify deliverables (`pr:` or `verified:` field) before closing. Manual closure bypasses the proof-log safety check
 
 **After ANY TODO/planning edit** (interactive sessions only, NOT workers): Commit and push immediately. Planning-only files (TODO.md, todo/) go directly to main -- no branch, no PR. Mixed changes (planning + non-exception files) use a worktree. NEVER `git checkout -b` in the main repo.
 

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -5678,7 +5678,9 @@ extract_log_metadata() {
     # heuristic quality signal — workers that parallelise independent subtasks
     # are more efficient. Logged for pattern tracking and supervisor dashboards.
     local task_tool_count=0
-    task_tool_count=$(grep -c 'mcp_task\|"tool_name":"task"\|"name":"task"' "$log_file" 2>/dev/null || echo 0)
+    task_tool_count=$(grep -c 'mcp_task\|"tool_name":"task"\|"name":"task"' "$log_file" 2>/dev/null || true)
+    task_tool_count="${task_tool_count//[^0-9]/}"
+    task_tool_count="${task_tool_count:-0}"
     echo "task_tool_count=$task_tool_count"
 
     # Exit code
@@ -10506,6 +10508,7 @@ populate_verify_queue() {
     # Determine next verify ID
     local last_vnum
     last_vnum=$(grep -oE 'v[0-9]+' "$verify_file" | grep -oE '[0-9]+' | sort -n | tail -1 || echo "0")
+    last_vnum=$((10#$last_vnum))
     local next_vnum=$((last_vnum + 1))
     local verify_id
     verify_id=$(printf "v%03d" "$next_vnum")
@@ -11044,6 +11047,7 @@ generate_verify_entry() {
     # Get next vNNN number
     local last_v
     last_v=$(grep -oE '^- \[.\] v([0-9]+)' "$verify_file" | grep -oE '[0-9]+' | sort -n | tail -1 || echo "0")
+    last_v=$((10#$last_v))
     local next_v=$((last_v + 1))
     local vid
     vid=$(printf "v%03d" "$next_v")
@@ -11606,7 +11610,9 @@ store_success_pattern() {
     local log_file task_tool_count=0
     log_file=$(db "$SUPERVISOR_DB" "SELECT log_file FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "")
     if [[ -n "$log_file" && -f "$log_file" ]]; then
-        task_tool_count=$(grep -c 'mcp_task\|"tool_name":"task"\|"name":"task"' "$log_file" 2>/dev/null || echo 0)
+        task_tool_count=$(grep -c 'mcp_task\|"tool_name":"task"\|"name":"task"' "$log_file" 2>/dev/null || true)
+        task_tool_count="${task_tool_count//[^0-9]/}"
+        task_tool_count="${task_tool_count:-0}"
     fi
     if [[ "$task_tool_count" -gt 0 ]]; then
         content="$content [task_tool:$task_tool_count]"


### PR DESCRIPTION
## Summary

- Fix `task_tool_count` grep output containing non-numeric characters (newlines) causing `[[: 0\n0: syntax error` in pattern storage (lines 5681, 11609)
- Fix `printf "v%03d"` with leading-zero verify IDs (e.g., `039`) causing `value too great for base` octal parsing errors (lines 10511, 11049)

## Changes

- Strip non-digit characters from `task_tool_count` after `grep -c` and default to 0
- Use `$((10#$var))` to force decimal interpretation of verify ID numbers before arithmetic

## Root Cause

- `grep -c` with `|| echo 0` could produce multi-line output in edge cases
- Verify IDs like `v039` produce `039` from grep, which bash interprets as invalid octal