### PR TITLE
t275: Fix version-manager.sh unbound variable bugs

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -895,7 +895,7 @@ EOF
 # Main function
 main() {
     local action="$1"
-    local bump_type="$2"
+    local bump_type="${2:-}"
     
     case "$action" in
         "get")

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -894,7 +894,7 @@ EOF
 
 # Main function
 main() {
-    local action="$1"
+    local action="${1:-}"
     local bump_type="${2:-}"
     
     case "$action" in


### PR DESCRIPTION
## Summary
Fixed unbound variable bugs in version-manager.sh main() function when using `set -u`.

## Changes
1. **Line 898**: Changed `local bump_type="$2"` to `local bump_type="${2:-}"`
   - Prevents crash when only one arg is passed (e.g., `version-manager.sh get`)
2. **Line 897**: Changed `local action="$1"` to `local action="${1:-}"`
   - Prevents crash when script is called with no arguments

## Testing
- ✅ Tested `version-manager.sh get` - works without errors
- ✅ Tested `version-manager.sh` (no args) - shows help without crashing
- ✅ ShellCheck passes with zero violations

## Related
Same class of bug as SCRIPTS_DIR typo fixed in PR #1037.

Fixes #t275