### PR TITLE
t271: Higgsfield Trinity UGC Windows template

### DIFF
--- a/.agents/scripts/higgsfield-helper.sh
+++ b/.agents/scripts/higgsfield-helper.sh
@@ -218,6 +218,21 @@ cmd_seed_bracket() {
     run_automator seed-bracket --prompt "${prompt}" "$@"
 }
 
+# Trinity UGC Windows template
+cmd_trinity_ugc_windows() {
+    local first_arg="${1:-}"
+
+    # If first arg doesn't start with --, treat it as a prompt
+    if [[ -n "${first_arg}" && "${first_arg}" != --* ]]; then
+        shift
+        print_info "Trinity UGC Windows: ${first_arg}"
+        run_automator trinity-ugc-windows --prompt "${first_arg}" "$@"
+    else
+        print_info "Running Trinity UGC Windows template..."
+        run_automator trinity-ugc-windows "$@"
+    fi
+}
+
 # Download latest
 cmd_download() {
     print_info "Downloading latest generation..."
@@ -333,6 +348,7 @@ Commands:
   batch-video <file> Batch video generation from JSON manifest
   batch-lipsync <file> Batch lipsync generation from JSON manifest
   pipeline           Full production: image -> video -> lipsync -> assembly
+  trinity-ugc-windows  Pre-built: image -> Windows preset -> UGC video
   seed-bracket       Test seed range to find best seeds for a prompt
   app <effect>       Use a Higgsfield app/effect
   assets             List recent generations
@@ -356,6 +372,8 @@ Options (pass after command):
   --seed-range       Seed range for bracketing (e.g., "1000-1010")
   --brief            Path to pipeline brief JSON file
   --character-image  Character face image for pipeline
+  --video-model      Video model for trinity/pipeline (e.g., kling-2.6)
+  --video-prompt     Video animation prompt for trinity/pipeline
   --dialogue         Dialogue text for lipsync
   --unlimited        Prefer unlimited models only
   --no-sidecar       Disable JSON sidecar metadata files
@@ -376,6 +394,8 @@ Examples:
   higgsfield-helper.sh pipeline --brief brief.json
   higgsfield-helper.sh pipeline "Person reviews product" --character-image face.png
   higgsfield-helper.sh seed-bracket "Elegant woman, golden hour" --seed-range 1000-1010
+  higgsfield-helper.sh trinity-ugc-windows "Product on marble table, clean aesthetic"
+  higgsfield-helper.sh trinity-ugc-windows --image-file product.jpg --video-model kling-2.6
   higgsfield-helper.sh app face-swap --image-file face.jpg
   higgsfield-helper.sh credits
   higgsfield-helper.sh batch-image prompts.json --concurrency 2 -o ./output
@@ -413,6 +433,7 @@ main() {
         batch-video)  cmd_batch_video "$@" ;;
         batch-lipsync) cmd_batch_lipsync "$@" ;;
         pipeline)   cmd_pipeline "$@" ;;
+        trinity-ugc-windows|trinity-windows|ugc-windows) cmd_trinity_ugc_windows "$@" ;;
         seed-bracket) cmd_seed_bracket "$@" ;;
         app)        cmd_app "$@" ;;
         assets)     cmd_assets "$@" ;;

--- a/.agents/tools/video/higgsfield-ui.md
+++ b/.agents/tools/video/higgsfield-ui.md
@@ -781,6 +781,71 @@ Output goes to `{default-output}/pipeline-{timestamp}/` with all intermediate fi
 
 Video generation time is dominated by Higgsfield's server-side processing (~3-4 min per video). Parallel submission means all videos process concurrently.
 
+## Trinity UGC Windows Template
+
+Pre-built 3-step pipeline for creating Windows-style UGC (user-generated content) videos. Combines image generation, the Windows mixed-media preset, and video animation into a single command.
+
+### Steps
+
+1. **Image generation** - Generate a product/character image (or use `--image-file`)
+2. **Windows preset** - Apply the Windows mixed-media visual effect (retro Windows aesthetic)
+3. **Video animation** - Animate the result into a UGC-style video
+
+### Usage
+
+```bash
+# Generate image + apply Windows preset + animate to video
+higgsfield-helper.sh trinity-ugc-windows "Product on marble table, clean aesthetic"
+
+# Use an existing image (skip step 1)
+higgsfield-helper.sh trinity-ugc-windows --image-file product.jpg
+
+# With video model and prompt overrides
+higgsfield-helper.sh trinity-ugc-windows -p "Fashion model, studio lighting" \
+  --video-model kling-2.6 --video-prompt "Smooth zoom in, product showcase"
+
+# With aspect ratio and output directory
+higgsfield-helper.sh trinity-ugc-windows -p "Sneakers on display" --aspect 9:16 -o ~/Projects/ugc/
+
+# Dry run (configure but don't generate — no credits used)
+higgsfield-helper.sh trinity-ugc-windows -p "Product shot" --dry-run
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `--prompt, -p` | Image generation prompt (required unless `--image-file` provided) |
+| `--image-file` | Skip image generation, use this file as source |
+| `--model, -m` | Image model override (default: best unlimited or soul) |
+| `--video-model` | Video model override (default: best unlimited or kling-2.6) |
+| `--video-prompt` | Video animation prompt (default: derived from image prompt) |
+| `--aspect, -a` | Aspect ratio (default: 9:16 for vertical UGC) |
+| `--output, -o` | Output directory |
+| `--project` | Project name for organized output dirs |
+| `--dry-run` | Configure but don't generate |
+
+### Aliases
+
+All three aliases route to the same command:
+
+- `trinity-ugc-windows` (full name)
+- `trinity-windows` (short)
+- `ugc-windows` (shortest)
+
+### Output
+
+Output goes to `{default-output}/trinity-ugc-windows/` (or `{project}/trinity-ugc-windows/` with `--project`). Includes:
+
+- Source image (step 1)
+- Windows-preset image/video (step 2)
+- Final animated video (step 3)
+- `trinity-state.json` manifest with timing and step results
+
+### Cost
+
+~30 credits total (image: ~2 + Windows preset: ~10 + video: ~20). Zero credits if all models are unlimited.
+
 ## Seed Bracketing
 
 Based on the technique from "How I Cut AI Video Costs By 60%". Test a range of seeds with the same prompt to find which produce the best results, then reuse winning seeds.
@@ -846,6 +911,8 @@ Results saved to `{default-output}/seed-bracket-{timestamp}/` with `bracket-resu
 --seed-range       Seed range for bracketing (e.g., "1000-1010")
 --brief            Path to pipeline brief JSON file
 --character-image  Character face image for pipeline
+--video-model      Video model override for trinity/pipeline (e.g., kling-2.6)
+--video-prompt     Video animation prompt override for trinity/pipeline
 --dialogue         Dialogue text for lipsync in pipeline
 --scenes           Number of scenes to generate
 --video-file       Path to video file (motion reference for motion-control)


### PR DESCRIPTION
## Summary

- Adds pre-built Playwright script for Windows-style UGC video generation
- 3-step "Trinity" pipeline: image generation → Windows mixed-media preset → UGC video animation
- New commands: `trinity-ugc-windows`, `trinity-windows`, `ugc-windows`
- New CLI flags: `--video-model`, `--video-prompt` for step-specific overrides
- Integrated into shell helper with full CLI documentation

## Changes

- `.agents/scripts/higgsfield/playwright-automator.mjs` — `trinityUgcWindows()` function, command registry, flag defs, help text
- `.agents/scripts/higgsfield-helper.sh` — `trinity-ugc-windows` command routing
- `.agents/tools/video/higgsfield-ui.md` — Documentation for the new template

## Usage

```bash
# Generate image + apply Windows preset + animate to video
higgsfield-helper.sh trinity-ugc-windows "Product on marble table, clean aesthetic"

# Use existing image
higgsfield-helper.sh trinity-ugc-windows --image-file product.jpg

# With video model override
higgsfield-helper.sh trinity-ugc-windows -p "Fashion model" --video-model kling-2.6
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Trinity UGC Windows workflow: Generate images, apply Windows preset, and create UGC-style videos in a single pipeline.
  * Added CLI options `--video-model` and `--video-prompt` for customizing video generation within the workflow.
  * Added command aliases for streamlined access to the Trinity UGC Windows workflow.
  * Updated documentation with Trinity UGC Windows template guidance and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->