### PR TITLE
fix: prevent shell injection and race conditions in issue-sync workflow

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -24,16 +24,15 @@ on:
           - reconcile
           - enrich
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   sync-on-push:
     name: Sync TODO.md → GitHub Issues
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: issue-sync-push-${{ github.ref }}
+      cancel-in-progress: true
     permissions:
       contents: write
       issues: write
@@ -41,10 +40,13 @@ jobs:
     steps:
       - name: Check commit author
         id: check-author
+        env:
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
         run: |
           # Prevent infinite loops: skip if this commit was made by GitHub Actions
-          AUTHOR="${{ github.event.head_commit.author.name }}"
-          if [[ "$AUTHOR" == "GitHub Actions" ]] || [[ "$AUTHOR" == "github-actions[bot]" ]]; then
+          # Note: COMMIT_AUTHOR passed via env to prevent shell injection from
+          # untrusted input (backticks, $() etc in author names)
+          if [[ "$COMMIT_AUTHOR" == "GitHub Actions" ]] || [[ "$COMMIT_AUTHOR" == "github-actions[bot]" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "Skipping: commit was made by GitHub Actions (loop prevention)"
           else
@@ -133,6 +135,9 @@ jobs:
     if: github.event_name == 'issues'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    concurrency:
+      group: issue-sync-issue-${{ github.event.issue.number }}
+      cancel-in-progress: true
     permissions:
       contents: write
       issues: read
@@ -140,17 +145,20 @@ jobs:
     steps:
       - name: Check issue title format
         id: check-issue
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          TITLE="${{ github.event.issue.title }}"
-          # Only sync issues with t-number prefix (our convention)
-          if echo "$TITLE" | grep -qE '^t[0-9]+'; then
+          # Note: ISSUE_TITLE passed via env to prevent shell injection from
+          # untrusted input (backticks in titles cause `command not found` errors)
+          if echo "$ISSUE_TITLE" | grep -qE '^t[0-9]+'; then
             echo "sync=true" >> "$GITHUB_OUTPUT"
-            TASK_ID=$(echo "$TITLE" | grep -oE '^t[0-9]+(\.[0-9]+)*')
+            TASK_ID=$(echo "$ISSUE_TITLE" | grep -oE '^t[0-9]+(\.[0-9]+)*')
             echo "task_id=$TASK_ID" >> "$GITHUB_OUTPUT"
-            echo "Issue #${{ github.event.issue.number }} matches task $TASK_ID"
+            echo "Issue #$ISSUE_NUMBER matches task $TASK_ID"
           else
             echo "sync=false" >> "$GITHUB_OUTPUT"
-            echo "Issue #${{ github.event.issue.number }} does not have t-number prefix, skipping"
+            echo "Issue #$ISSUE_NUMBER does not have t-number prefix, skipping"
           fi
 
       - name: Checkout
@@ -224,6 +232,9 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    concurrency:
+      group: issue-sync-manual
+      cancel-in-progress: false
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary

- **Shell injection fix**: Issue titles containing backticks (e.g. `` `pipeline` ``) were being executed as shell commands when interpolated via `${{ github.event.issue.title }}` in `run:` blocks. Moved untrusted inputs (issue title, commit author name) to `env:` variables. Confirmed failure: GH#1046 failed with `pipeline: command not found`.

- **Race condition fix**: Moved concurrency groups from workflow-level to job-level. Previously, supervisor claim pushes (every ~2 minutes) would cancel in-progress close runs, leaving 18+ completed-task issues stuck open. Now:
  - `push` events only cancel other `push` runs (latest wins)
  - `issue` events are grouped per issue number (don't interfere)
  - `workflow_dispatch` (manual) runs never get cancelled

## Evidence

- GH#1046 failure log: `pipeline: command not found` (exit 127)
- 18 issues with `pr:` fields still open because every close run was cancelled
- Last successful push-triggered close run was 40+ minutes before the latest attempt