### PR TITLE
fix: remove unsupported --metadata flag from auto-decomposition cmd_add

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -12892,8 +12892,8 @@ cmd_auto_pickup() {
                 continue
             fi
 
-            # Add to supervisor with special metadata for decomposition
-            if cmd_add "$task_id" --repo "$repo" --metadata "plan_anchor=$plan_anchor,needs_decomposition=true" 2>/dev/null; then
+            # Add to supervisor (plan_anchor passed directly to dispatch_decomposition_worker)
+            if cmd_add "$task_id" --repo "$repo" 2>/dev/null; then
                 picked_up=$((picked_up + 1))
                 log_success "  Auto-picked: $task_id (#plan task for decomposition)"
                 


### PR DESCRIPTION
## Summary

- `cmd_add()` does not accept `--metadata` — it has a `*) log_error "Unknown option: $1"; return 1 ;;` catch-all
- The t274 auto-decomposition code passed `--metadata "plan_anchor=..."` to `cmd_add`, which silently failed (error suppressed by `2>/dev/null`)
- This prevented all `#plan` tasks without subtasks (t008, t012) from being added to the supervisor DB for decomposition dispatch
- Fix: remove `--metadata` from the `cmd_add` call — the `plan_anchor` is already passed directly to `dispatch_decomposition_worker()` as a function argument

## Evidence

- `rg "^cmd_add" supervisor-helper.sh` shows line 1810 with no `--metadata` option
- Line 1831: `*) log_error "Unknown option: $1"; return 1 ;;`
- Supervisor logs show t008/t012 hitting `check_task_already_done` but never reaching "Auto-picked" log
- Manual `cmd_add t008 --repo $(pwd)` succeeds; with `--metadata` it fails