### PR TITLE
fix: recognize pr:#NNN field as completion evidence in issue-sync close

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1168,7 +1168,12 @@ task_has_completion_evidence() {
         return 0
     fi
 
-    # Check 2: Has a merged PR reference in the task line (e.g., "PR #NNN merged" in Notes)
+    # Check 2a: Has pr:#NNN field in the task line (supervisor-written proof-log format)
+    if echo "$task_line" | grep -qE 'pr:#[0-9]+'; then
+        return 0
+    fi
+
+    # Check 2b: Has a merged PR reference in the task line (e.g., "PR #NNN merged" in Notes)
     # Look for the task and its Notes lines
     if echo "$task_line" | grep -qiE 'PR #[0-9]+ merged|PR.*merged'; then
         return 0


### PR DESCRIPTION
## Summary

- `task_has_completion_evidence()` didn't recognize the `pr:#NNN` format that the supervisor writes to TODO.md when marking tasks complete
- It only checked for: `verified:YYYY-MM-DD`, `PR #NNN merged` (literal text), and GitHub API search
- The GitHub API search (Check 3) appears to fail silently in the GHA environment, making all 30 completed-task issues stuck open
- Fix: add Check 2a that matches `pr:#[0-9]+` directly from the task line — fast, reliable, no API dependency

## Evidence

- Manual close run (21891570137) completed with 0 closures, 527 skips
- All skips logged: "no merged PR or verified: field found"
- Example: t274 has `pr:#1066` in TODO.md but was skipped
- Local test confirms `pr:#NNN` regex matches correctly