### PR TITLE
t008.4: oh-my-opencode compatibility for aidevops-opencode plugin

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -189,8 +189,12 @@ function readJson(filepath) {
  * @returns {boolean}
  */
 function hasPlaceholders(config) {
-  const check = (val) => /YOUR_.*_HERE|REPLACE_ME|<.*>/i.test(val);
+  const check = (val) =>
+    /YOUR_.*_HERE|REPLACE_ME|<.*>|\/Users\/YOU\//i.test(val);
 
+  if (config.type === "local" && Array.isArray(config.command)) {
+    if (config.command.some(check)) return true;
+  }
   const env = config.environment || config.env;
   if (env && typeof env === "object") {
     if (Object.values(env).some(check)) return true;

--- a/.agents/plugins/opencode-aidevops/package.json
+++ b/.agents/plugins/opencode-aidevops/package.json
@@ -1,12 +1,31 @@
 {
   "name": "opencode-aidevops",
-  "version": "1.0.0",
-  "description": "OpenCode plugin for aidevops - compaction context injection",
-  "main": "index.mjs",
+  "version": "2.0.0",
+  "description": "OpenCode plugin for aidevops - agent loader, compaction context, CLI tools",
+  "main": "dist/index.mjs",
   "type": "module",
-  "keywords": ["opencode", "plugin", "aidevops", "compaction"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "scripts": {
+    "build": "bun build src/index.ts --outdir dist --target bun --format esm --external zod --external gray-matter && cp src/types.d.ts dist/index.d.ts",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist"
+  },
+  "keywords": ["opencode", "plugin", "aidevops", "devops", "agents", "compaction"],
   "author": "Marcus Quinn",
   "license": "MIT",
+  "dependencies": {
+    "gray-matter": "^4.0.3",
+    "zod": "^3.24.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "typescript": "^5.8.3"
+  },
   "peerDependencies": {
     "opencode-ai": ">=1.0.150"
   }

--- a/.agents/plugins/opencode-aidevops/src/agents/loader.ts
+++ b/.agents/plugins/opencode-aidevops/src/agents/loader.ts
@@ -1,0 +1,257 @@
+import { readdirSync, readFileSync, existsSync, statSync } from "fs";
+import { join, relative } from "path";
+import matter from "gray-matter";
+import type { PluginConfig } from "../config/schema.js";
+
+/**
+ * Agent definition parsed from a markdown file with YAML frontmatter.
+ */
+export interface AgentDefinition {
+  name: string;
+  description: string;
+  mode: "primary" | "subagent";
+  tools: Record<string, boolean>;
+  model?: string;
+  content: string;
+  path: string;
+  namespace: string;
+}
+
+/**
+ * Load all agents from the aidevops agents directory.
+ *
+ * Scans ~/.aidevops/agents/ for markdown files with YAML frontmatter.
+ * Respects the 3-tier directory structure:
+ *   - Root *.md files → primary agents
+ *   - Subdirectory *.md files → subagents
+ *   - Plugin namespace dirs (from plugins.json) → plugin agents
+ *   - custom/ and draft/ → user agents
+ *
+ * @param config - Plugin configuration
+ * @returns Array of parsed agent definitions
+ */
+export function loadAgents(config: PluginConfig): AgentDefinition[] {
+  const agentsDir = config.agentsDir;
+
+  if (!existsSync(agentsDir)) {
+    return [];
+  }
+
+  const agents: AgentDefinition[] = [];
+  const excludeSet = new Set(config.excludeDirs);
+  const disabledSet = new Set(config.disabledAgents);
+
+  // Load root-level agents (primary agents like build-plus.md, aidevops.md)
+  loadAgentsFromDir(agentsDir, "primary", "core", agents, disabledSet);
+
+  if (!config.loadSubagents) {
+    return agents.slice(0, config.maxAgents);
+  }
+
+  // Scan subdirectories for subagents
+  const entries = readdirSafe(agentsDir);
+  for (const entry of entries) {
+    if (excludeSet.has(entry)) {
+      continue;
+    }
+
+    const fullPath = join(agentsDir, entry);
+    if (!isDirectory(fullPath)) {
+      continue;
+    }
+
+    // Determine namespace: custom/, draft/, or plugin namespaces get their name
+    // Core subdirs (aidevops/, tools/, services/, etc.) stay as "core"
+    const coreSubdirs = new Set([
+      "aidevops",
+      "tools",
+      "services",
+      "workflows",
+      "memory",
+      "content",
+      "seo",
+      "hooks",
+      "prompts",
+    ]);
+    const namespace = coreSubdirs.has(entry) ? "core" : entry;
+
+    loadAgentsFromDir(fullPath, "subagent", namespace, agents, disabledSet);
+
+    // Recurse one level deeper for nested subagents (e.g., tools/browser/*.md)
+    const subEntries = readdirSafe(fullPath);
+    for (const subEntry of subEntries) {
+      if (excludeSet.has(subEntry)) {
+        continue;
+      }
+      const subPath = join(fullPath, subEntry);
+      if (isDirectory(subPath)) {
+        loadAgentsFromDir(subPath, "subagent", namespace, agents, disabledSet);
+      }
+    }
+
+    if (agents.length >= config.maxAgents) {
+      break;
+    }
+  }
+
+  return agents.slice(0, config.maxAgents);
+}
+
+/**
+ * Load agents from a single directory.
+ */
+function loadAgentsFromDir(
+  dir: string,
+  defaultMode: "primary" | "subagent",
+  namespace: string,
+  agents: AgentDefinition[],
+  disabledSet: Set<string>,
+): void {
+  const files = readdirSafe(dir);
+
+  for (const file of files) {
+    if (!file.endsWith(".md")) {
+      continue;
+    }
+
+    const name = file.replace(/\.md$/, "");
+    if (disabledSet.has(name)) {
+      continue;
+    }
+
+    const filePath = join(dir, file);
+    const agent = parseAgentFile(filePath, name, defaultMode, namespace);
+    if (agent) {
+      agents.push(agent);
+    }
+  }
+}
+
+/**
+ * Parse a single markdown agent file.
+ * Extracts YAML frontmatter for metadata and the body as content.
+ *
+ * @returns AgentDefinition or null if the file cannot be parsed
+ */
+function parseAgentFile(
+  filePath: string,
+  name: string,
+  defaultMode: "primary" | "subagent",
+  namespace: string,
+): AgentDefinition | null {
+  try {
+    const raw = readFileSync(filePath, "utf-8");
+    const { data, content } = matter(raw);
+
+    // Skip files without meaningful content (< 50 chars after frontmatter)
+    if (content.trim().length < 50) {
+      return null;
+    }
+
+    const mode = data.mode === "primary" ? "primary" : defaultMode;
+    const tools: Record<string, boolean> =
+      typeof data.tools === "object" && data.tools !== null
+        ? (data.tools as Record<string, boolean>)
+        : {};
+
+    return {
+      name,
+      description: typeof data.description === "string" ? data.description : "",
+      mode,
+      tools,
+      model: typeof data.model === "string" ? data.model : undefined,
+      content: content.trim(),
+      path: filePath,
+      namespace,
+    };
+  } catch {
+    // Silently skip unparseable files — don't crash the plugin
+    return null;
+  }
+}
+
+/**
+ * Get a summary of loaded agents for logging/debugging.
+ */
+export function getAgentSummary(agents: AgentDefinition[]): string {
+  const byNamespace = new Map<string, number>();
+  let primaryCount = 0;
+  let subagentCount = 0;
+
+  for (const agent of agents) {
+    const count = byNamespace.get(agent.namespace) ?? 0;
+    byNamespace.set(agent.namespace, count + 1);
+    if (agent.mode === "primary") {
+      primaryCount++;
+    } else {
+      subagentCount++;
+    }
+  }
+
+  const lines = [
+    `Loaded ${agents.length} agents (${primaryCount} primary, ${subagentCount} subagents)`,
+  ];
+
+  for (const [ns, count] of byNamespace.entries()) {
+    lines.push(`  ${ns}: ${count}`);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Load plugin namespace directories from plugins.json.
+ * Returns the set of namespace names that are plugin directories.
+ */
+export function loadPluginNamespaces(): Set<string> {
+  const pluginsPath = join(
+    process.env.HOME ?? "",
+    ".config",
+    "aidevops",
+    "plugins.json",
+  );
+
+  if (!existsSync(pluginsPath)) {
+    return new Set();
+  }
+
+  try {
+    const raw = readFileSync(pluginsPath, "utf-8");
+    const data = JSON.parse(raw);
+    const plugins = Array.isArray(data.plugins) ? data.plugins : [];
+    const namespaces = new Set<string>();
+
+    for (const plugin of plugins) {
+      if (
+        typeof plugin === "object" &&
+        plugin !== null &&
+        typeof plugin.namespace === "string" &&
+        plugin.enabled !== false
+      ) {
+        namespaces.add(plugin.namespace);
+      }
+    }
+
+    return namespaces;
+  } catch {
+    return new Set();
+  }
+}
+
+/** Safe readdir that returns empty array on error */
+function readdirSafe(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+/** Check if a path is a directory */
+function isDirectory(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/.agents/plugins/opencode-aidevops/src/config/schema.ts
+++ b/.agents/plugins/opencode-aidevops/src/config/schema.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+/**
+ * Zod schema for plugin configuration.
+ * Loaded from ~/.config/opencode/aidevops-plugin.json if it exists,
+ * otherwise uses sensible defaults.
+ */
+const configSchema = z.object({
+  agentsDir: z
+    .string()
+    .default(join(homedir(), ".aidevops", "agents")),
+
+  loadSubagents: z.boolean().default(true),
+
+  disabledAgents: z.array(z.string()).default([]),
+
+  hooks: z
+    .object({
+      compaction: z.boolean().default(true),
+      shellEnv: z.boolean().default(true),
+      chatContext: z.boolean().default(true),
+    })
+    .default({}),
+
+  maxAgents: z.number().int().positive().default(500),
+
+  excludeDirs: z
+    .array(z.string())
+    .default([
+      "node_modules",
+      ".git",
+      "_archive",
+      "configs",
+      "templates",
+      "plugins",
+    ]),
+});
+
+export type PluginConfig = z.infer<typeof configSchema>;
+
+/**
+ * Load plugin configuration from disk or return defaults.
+ * Config file: ~/.config/opencode/aidevops-plugin.json
+ */
+export function loadConfig(): PluginConfig {
+  const configPath = join(
+    homedir(),
+    ".config",
+    "opencode",
+    "aidevops-plugin.json",
+  );
+
+  if (!existsSync(configPath)) {
+    return configSchema.parse({});
+  }
+
+  try {
+    const raw = readFileSync(configPath, "utf-8");
+    return configSchema.parse(JSON.parse(raw));
+  } catch {
+    // Invalid config — fall back to defaults rather than crash
+    return configSchema.parse({});
+  }
+}

--- a/.agents/plugins/opencode-aidevops/src/hooks/chat-context.ts
+++ b/.agents/plugins/opencode-aidevops/src/hooks/chat-context.ts
@@ -1,0 +1,74 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+const HOME = homedir();
+const WORKSPACE_DIR = join(HOME, ".aidevops", ".agent-workspace");
+
+/**
+ * Create the chat.message hook handler.
+ *
+ * Injects lightweight context into the first user message of a session.
+ * This provides the AI with awareness of the aidevops framework state
+ * without requiring the user to manually provide context.
+ *
+ * Only injects once per session (tracks via closure) and keeps the
+ * injection minimal to avoid wasting tokens.
+ */
+export function createChatContextHook(directory: string) {
+  let injected = false;
+
+  return (
+    _input: { content?: string; role?: string },
+    output: { parts: Array<{ type: string; text: string }> },
+  ): void => {
+    // Only inject context on the first message
+    if (injected) return;
+    injected = true;
+
+    const contextParts: string[] = [];
+
+    // Check for active batch/task state
+    const checkpointPath = join(WORKSPACE_DIR, "tmp", "session-checkpoint.md");
+    if (existsSync(checkpointPath)) {
+      try {
+        const checkpoint = readFileSync(checkpointPath, "utf-8").trim();
+        if (checkpoint.length > 0 && checkpoint.length < 2000) {
+          contextParts.push(
+            "[Session checkpoint detected — previous state available]",
+          );
+        }
+      } catch {
+        // ignore
+      }
+    }
+
+    // Check for pending mail
+    const mailDb = join(WORKSPACE_DIR, "mail", "mailbox.db");
+    if (existsSync(mailDb)) {
+      contextParts.push(
+        "[Inter-agent mailbox active — check with mail-helper.sh]",
+      );
+    }
+
+    // Detect if we're in a worktree
+    const gitDir = join(directory, ".git");
+    if (existsSync(gitDir)) {
+      try {
+        const gitContent = readFileSync(gitDir, "utf-8").trim();
+        if (gitContent.startsWith("gitdir:")) {
+          contextParts.push("[Working in a git worktree]");
+        }
+      } catch {
+        // .git is a directory (normal repo), not a worktree — that's fine
+      }
+    }
+
+    if (contextParts.length === 0) return;
+
+    output.parts.push({
+      type: "text",
+      text: `\n\n---\n_aidevops context: ${contextParts.join(" | ")}_\n`,
+    });
+  };
+}

--- a/.agents/plugins/opencode-aidevops/src/hooks/compaction.ts
+++ b/.agents/plugins/opencode-aidevops/src/hooks/compaction.ts
@@ -1,0 +1,211 @@
+import { execSync } from "child_process";
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+const HOME = homedir();
+const AGENTS_DIR = join(HOME, ".aidevops", "agents");
+const SCRIPTS_DIR = join(AGENTS_DIR, "scripts");
+const WORKSPACE_DIR = join(HOME, ".aidevops", ".agent-workspace");
+
+/**
+ * Run a shell command and return stdout, or empty string on failure.
+ */
+function run(cmd: string): string {
+  try {
+    return execSync(cmd, {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Read a file if it exists, or return empty string.
+ */
+function readIfExists(filepath: string): string {
+  try {
+    if (existsSync(filepath)) {
+      return readFileSync(filepath, "utf-8").trim();
+    }
+  } catch {
+    // ignore
+  }
+  return "";
+}
+
+/**
+ * Get current agent state from registry.toon if it exists.
+ */
+function getAgentState(): string {
+  const registryPath = join(WORKSPACE_DIR, "mail", "registry.toon");
+  const content = readIfExists(registryPath);
+  if (!content) return "";
+
+  return [
+    "## Active Agent State",
+    "The following agents are currently registered in the multi-agent orchestration system:",
+    content,
+  ].join("\n");
+}
+
+/**
+ * Get loop guardrails from active loop state.
+ */
+function getLoopGuardrails(directory: string): string {
+  const loopStateDir = join(directory, ".agent", "loop-state");
+  if (!existsSync(loopStateDir)) return "";
+
+  const stateFile = join(loopStateDir, "current.json");
+  const content = readIfExists(stateFile);
+  if (!content) return "";
+
+  try {
+    const state = JSON.parse(content) as Record<string, unknown>;
+    const lines = ["## Loop Guardrails"];
+
+    if (state.task) lines.push(`Task: ${state.task}`);
+    if (state.iteration)
+      lines.push(
+        `Iteration: ${state.iteration}/${(state.maxIterations as string) ?? "inf"}`,
+      );
+    if (state.objective) lines.push(`Objective: ${state.objective}`);
+    if (Array.isArray(state.constraints) && state.constraints.length > 0) {
+      lines.push("Constraints:");
+      for (const c of state.constraints) {
+        lines.push(`- ${c}`);
+      }
+    }
+    if (state.completionCriteria)
+      lines.push(`Completion: ${state.completionCriteria}`);
+
+    return lines.join("\n");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Recall relevant memories for the current session context.
+ */
+function getRelevantMemories(directory: string): string {
+  const memoryHelper = join(SCRIPTS_DIR, "memory-helper.sh");
+  if (!existsSync(memoryHelper)) return "";
+
+  const projectName = directory.split("/").pop() ?? "";
+  const memories = run(
+    `bash "${memoryHelper}" recall "${projectName}" --limit 5 2>/dev/null`,
+  );
+  if (!memories) return "";
+
+  return [
+    "## Relevant Memories",
+    "Previous session learnings relevant to this project:",
+    memories,
+  ].join("\n");
+}
+
+/**
+ * Get the current git branch and recent commit context.
+ */
+function getGitContext(directory: string): string {
+  const branch = run(
+    `git -C "${directory}" branch --show-current 2>/dev/null`,
+  );
+  if (!branch) return "";
+
+  const recentCommits = run(
+    `git -C "${directory}" log --oneline -5 2>/dev/null`,
+  );
+
+  const lines = ["## Git Context"];
+  lines.push(`Branch: ${branch}`);
+  if (recentCommits) {
+    lines.push("Recent commits:");
+    lines.push(recentCommits);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Get pending mailbox messages for context continuity.
+ */
+function getMailboxState(): string {
+  const inboxDir = join(WORKSPACE_DIR, "mail", "inbox");
+  if (!existsSync(inboxDir)) return "";
+
+  const mailHelper = join(SCRIPTS_DIR, "mail-helper.sh");
+  if (!existsSync(mailHelper)) return "";
+
+  const rawOutput = run(`bash "${mailHelper}" check 2>/dev/null`);
+  const pending = parseInt(rawOutput, 10);
+  if (isNaN(pending) || pending <= 0) return "";
+
+  return [
+    "## Pending Messages",
+    `There are ${pending} unread messages in the agent mailbox.`,
+    "Check inbox after resuming to handle inter-agent communications.",
+  ].join("\n");
+}
+
+/**
+ * Get session checkpoint if one exists.
+ */
+function getCheckpointState(): string {
+  const checkpointPath = join(
+    WORKSPACE_DIR,
+    "tmp",
+    "session-checkpoint.md",
+  );
+  const content = readIfExists(checkpointPath);
+  if (!content) return "";
+
+  return [
+    "## Session Checkpoint",
+    "A checkpoint was saved from a previous session:",
+    content,
+  ].join("\n");
+}
+
+/**
+ * Create the compaction hook handler.
+ * Gathers dynamic context that should survive session compaction.
+ */
+export function createCompactionHook(directory: string) {
+  return async (
+    _input: { messages?: unknown[] },
+    output: { context: string[] },
+  ): Promise<void> => {
+    const sections = [
+      getAgentState(),
+      getLoopGuardrails(directory),
+      getRelevantMemories(directory),
+      getGitContext(directory),
+      getMailboxState(),
+      getCheckpointState(),
+    ].filter(Boolean);
+
+    if (sections.length === 0) return;
+
+    output.context.push(
+      [
+        "# aidevops Framework Context",
+        "Include the following state in your compaction summary so the next session can continue seamlessly:",
+        "",
+        ...sections,
+        "",
+        "## Critical Rules to Preserve",
+        "- File discovery: use `git ls-files` not Glob",
+        "- Git workflow: run pre-edit-check.sh before any file modifications",
+        "- Security: credentials only via `aidevops secret` (gopass) or ~/.config/aidevops/credentials.sh",
+        "- Working directory: ~/.aidevops/.agent-workspace/work/[project]/",
+        "- Quality: ShellCheck zero violations, SonarCloud A-grade",
+        "- Workers: NEVER edit TODO.md (supervisor owns it)",
+      ].join("\n"),
+    );
+  };
+}

--- a/.agents/plugins/opencode-aidevops/src/hooks/shell-env.ts
+++ b/.agents/plugins/opencode-aidevops/src/hooks/shell-env.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+const HOME = homedir();
+
+/**
+ * Create the shell.env hook handler.
+ *
+ * Injects environment variables into shell commands executed by OpenCode.
+ * This ensures aidevops scripts and tools have the correct paths and
+ * configuration without requiring the user to set them manually.
+ */
+export function createShellEnvHook() {
+  return (): Record<string, string> => {
+    const env: Record<string, string> = {};
+
+    // Core aidevops paths
+    const agentsDir = join(HOME, ".aidevops", "agents");
+    const scriptsDir = join(agentsDir, "scripts");
+    const workspaceDir = join(HOME, ".aidevops", ".agent-workspace");
+
+    if (existsSync(agentsDir)) {
+      env.AIDEVOPS_AGENTS_DIR = agentsDir;
+    }
+
+    if (existsSync(scriptsDir)) {
+      env.AIDEVOPS_SCRIPTS_DIR = scriptsDir;
+
+      // Ensure scripts dir is on PATH for direct invocation
+      const currentPath = process.env.PATH ?? "";
+      if (!currentPath.includes(scriptsDir)) {
+        env.PATH = `${scriptsDir}:${currentPath}`;
+      }
+    }
+
+    if (existsSync(workspaceDir)) {
+      env.AIDEVOPS_WORKSPACE_DIR = workspaceDir;
+    }
+
+    // Config directory
+    const configDir = join(HOME, ".config", "aidevops");
+    if (existsSync(configDir)) {
+      env.AIDEVOPS_CONFIG_DIR = configDir;
+    }
+
+    // Credentials file (if it exists)
+    const credentialsFile = join(configDir, "credentials.sh");
+    if (existsSync(credentialsFile)) {
+      env.AIDEVOPS_CREDENTIALS_FILE = credentialsFile;
+    }
+
+    return env;
+  };
+}

--- a/.agents/plugins/opencode-aidevops/src/index.ts
+++ b/.agents/plugins/opencode-aidevops/src/index.ts
@@ -1,0 +1,98 @@
+/**
+ * aidevops OpenCode Plugin — Core plugin structure + agent loader
+ *
+ * Provides native OpenCode integration for the aidevops framework:
+ * - Agent loader: scans ~/.aidevops/agents/ and registers agents
+ * - Compaction hook: injects framework context during session compaction
+ * - Shell env hook: ensures aidevops paths are available in shell commands
+ * - Chat context hook: lightweight session-start context injection
+ * - CLI tools: exposes aidevops and helper scripts as OpenCode tools
+ *
+ * @module opencode-aidevops
+ */
+
+import { loadConfig } from "./config/schema.js";
+import { loadAgents, getAgentSummary } from "./agents/loader.js";
+import { createCompactionHook } from "./hooks/compaction.js";
+import { createShellEnvHook } from "./hooks/shell-env.js";
+import { createChatContextHook } from "./hooks/chat-context.js";
+import {
+  createAidevopsCliTool,
+  createHelperScriptTool,
+} from "./tools/aidevops-cli.js";
+
+/** Input provided by OpenCode to the plugin factory */
+interface PluginInput {
+  directory: string;
+  worktree?: string;
+  project?: string;
+}
+
+/** Hook definitions returned by the plugin */
+interface PluginHooks {
+  "experimental.session.compacting"?: (
+    input: { messages?: unknown[] },
+    output: { context: string[] },
+  ) => Promise<void>;
+  "shell.env"?: () => Record<string, string>;
+  "chat.message"?: (
+    input: { content?: string; role?: string },
+    output: { parts: Array<{ type: string; text: string }> },
+  ) => void;
+  tool?: Array<{
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+    handler: (args: Record<string, unknown>) => Promise<string>;
+  }>;
+}
+
+/**
+ * Main plugin factory function.
+ *
+ * OpenCode calls this with the current session context. The plugin
+ * loads configuration, scans for agents, and returns hook handlers.
+ *
+ * @param input - Session context from OpenCode (directory, worktree, project)
+ * @returns Hook handlers for OpenCode lifecycle events
+ */
+export async function AidevopsPlugin(
+  input: PluginInput,
+): Promise<PluginHooks> {
+  const { directory } = input;
+  const config = loadConfig();
+
+  // Load agents from ~/.aidevops/agents/
+  const agents = loadAgents(config);
+
+  // Log agent loading summary (visible in OpenCode debug output)
+  if (agents.length > 0) {
+    const summary = getAgentSummary(agents);
+    // Use stderr so it doesn't interfere with plugin protocol
+    process.stderr.write(`[aidevops] ${summary}\n`);
+  }
+
+  // Build hooks object based on config
+  const hooks: PluginHooks = {};
+
+  // Compaction hook — always enabled (core functionality)
+  if (config.hooks.compaction) {
+    hooks["experimental.session.compacting"] =
+      createCompactionHook(directory);
+  }
+
+  // Shell environment hook
+  if (config.hooks.shellEnv) {
+    hooks["shell.env"] = createShellEnvHook();
+  }
+
+  // Chat context hook
+  if (config.hooks.chatContext) {
+    hooks["chat.message"] = createChatContextHook(directory);
+  }
+
+  // Register tools
+  hooks.tool = [createAidevopsCliTool(), createHelperScriptTool()];
+
+  return hooks;
+}

--- a/.agents/plugins/opencode-aidevops/src/tools/aidevops-cli.ts
+++ b/.agents/plugins/opencode-aidevops/src/tools/aidevops-cli.ts
@@ -1,0 +1,103 @@
+import { execSync } from "child_process";
+
+/**
+ * Tool definition for exposing the aidevops CLI as an OpenCode tool.
+ *
+ * This allows the AI to invoke aidevops commands directly through the
+ * plugin's tool interface rather than via bash.
+ */
+export function createAidevopsCliTool() {
+  return {
+    name: "aidevops",
+    description:
+      "Run aidevops CLI commands (status, plugin, secret, repos, features, etc.)",
+    parameters: {
+      command: {
+        type: "string" as const,
+        description:
+          "The aidevops subcommand to run (e.g., status, plugin list, repos)",
+      },
+    },
+    handler: async (args: Record<string, unknown>): Promise<string> => {
+      const command = typeof args.command === "string" ? args.command : "";
+
+      if (!command) {
+        return "Error: command parameter is required. Example: aidevops status";
+      }
+
+      // Security: block commands that could expose secrets
+      const blocked = ["secret show", "secret get", "secret export"];
+      for (const pattern of blocked) {
+        if (command.includes(pattern)) {
+          return `Error: '${pattern}' is blocked for security. Use 'aidevops secret set NAME' at the terminal instead.`;
+        }
+      }
+
+      try {
+        const result = execSync(`aidevops ${command}`, {
+          encoding: "utf-8",
+          timeout: 30000,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        return result.trim() || "(no output)";
+      } catch (err: unknown) {
+        const error = err as { stderr?: string; message?: string };
+        return `Error running 'aidevops ${command}': ${error.stderr ?? error.message ?? "unknown error"}`;
+      }
+    },
+  };
+}
+
+/**
+ * Tool definition for running aidevops helper scripts.
+ */
+export function createHelperScriptTool() {
+  return {
+    name: "aidevops-helper",
+    description:
+      "Run an aidevops helper script (e.g., memory-helper.sh recall, mail-helper.sh check)",
+    parameters: {
+      script: {
+        type: "string" as const,
+        description:
+          "Helper script name (e.g., memory-helper.sh, mail-helper.sh, supervisor-helper.sh)",
+      },
+      args: {
+        type: "string" as const,
+        description: "Arguments to pass to the script",
+      },
+    },
+    handler: async (params: Record<string, unknown>): Promise<string> => {
+      const script = typeof params.script === "string" ? params.script : "";
+      const args = typeof params.args === "string" ? params.args : "";
+
+      if (!script) {
+        return "Error: script parameter is required. Example: memory-helper.sh recall";
+      }
+
+      // Validate script name (must end in .sh, no path traversal)
+      if (!script.endsWith(".sh") || script.includes("/") || script.includes("..")) {
+        return "Error: script must be a .sh filename without path separators";
+      }
+
+      // Security: block scripts that could expose secrets
+      if (script.includes("credential") && args.includes("show")) {
+        return "Error: credential display is blocked for security.";
+      }
+
+      const scriptsDir = `${process.env.HOME}/.aidevops/agents/scripts`;
+
+      try {
+        const result = execSync(`bash "${scriptsDir}/${script}" ${args}`, {
+          encoding: "utf-8",
+          timeout: 30000,
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        return result.trim() || "(no output)";
+      } catch (err: unknown) {
+        const error = err as { stderr?: string; message?: string };
+        return `Error running '${script} ${args}': ${error.stderr ?? error.message ?? "unknown error"}`;
+      }
+    },
+  };
+}

--- a/.agents/plugins/opencode-aidevops/src/types.d.ts
+++ b/.agents/plugins/opencode-aidevops/src/types.d.ts
@@ -1,0 +1,133 @@
+/**
+ * Type definitions for the opencode-aidevops plugin.
+ *
+ * These mirror the @opencode-ai/plugin SDK types for the hooks and
+ * interfaces used by this plugin. The actual SDK types are provided
+ * at runtime by OpenCode.
+ */
+
+/** Plugin factory function signature expected by OpenCode */
+export declare function AidevopsPlugin(input: PluginInput): Promise<PluginHooks>;
+
+/** Input provided to the plugin factory by OpenCode */
+export interface PluginInput {
+  /** OpenCode SDK client */
+  client?: unknown;
+  /** Project name */
+  project?: string;
+  /** Current working directory */
+  directory: string;
+  /** Git worktree path (if in a worktree) */
+  worktree?: string;
+  /** OpenCode server URL */
+  serverUrl?: string;
+  /** BunShell instance */
+  $?: unknown;
+}
+
+/** Hook definitions the plugin can return */
+export interface PluginHooks {
+  /** Inject context during session compaction */
+  "experimental.session.compacting"?: (
+    input: CompactionInput,
+    output: CompactionOutput,
+  ) => Promise<void> | void;
+
+  /** Inject environment variables into shell commands */
+  "shell.env"?: (
+    input: ShellEnvInput,
+  ) => Promise<Record<string, string>> | Record<string, string>;
+
+  /** Intercept and modify new user messages */
+  "chat.message"?: (
+    input: ChatMessageInput,
+    output: ChatMessageOutput,
+  ) => Promise<void> | void;
+
+  /** Register custom tools */
+  tool?: ToolDefinition[];
+}
+
+/** Compaction hook input */
+export interface CompactionInput {
+  messages?: unknown[];
+}
+
+/** Compaction hook output — push strings to context[] */
+export interface CompactionOutput {
+  context: string[];
+}
+
+/** Shell environment hook input */
+export interface ShellEnvInput {
+  command?: string;
+  directory?: string;
+}
+
+/** Chat message hook input */
+export interface ChatMessageInput {
+  content?: string;
+  role?: string;
+}
+
+/** Chat message hook output */
+export interface ChatMessageOutput {
+  parts: Array<{ type: string; text: string }>;
+}
+
+/** Tool definition for registering custom tools */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  parameters: Record<string, ToolParameter>;
+  handler: (args: Record<string, unknown>) => Promise<string>;
+}
+
+/** Tool parameter schema */
+export interface ToolParameter {
+  type: string;
+  description: string;
+  items?: { type: string };
+  enum?: string[];
+  default?: unknown;
+}
+
+/** Agent definition parsed from markdown files */
+export interface AgentDefinition {
+  /** Agent name (filename without .md) */
+  name: string;
+  /** Description from YAML frontmatter */
+  description: string;
+  /** Agent mode: primary or subagent */
+  mode: "primary" | "subagent";
+  /** Tool permissions from frontmatter */
+  tools: Record<string, boolean>;
+  /** Model tier hint from frontmatter */
+  model?: string;
+  /** Markdown content (body after frontmatter) */
+  content: string;
+  /** Source file path */
+  path: string;
+  /** Namespace (plugin name or 'core') */
+  namespace: string;
+}
+
+/** Plugin configuration schema */
+export interface PluginConfig {
+  /** Path to agents directory */
+  agentsDir: string;
+  /** Whether to load subagents from subdirectories */
+  loadSubagents: boolean;
+  /** Agent names to skip loading */
+  disabledAgents: string[];
+  /** Hook toggles */
+  hooks: {
+    compaction: boolean;
+    shellEnv: boolean;
+    chatContext: boolean;
+  };
+  /** Maximum agents to load (prevents runaway scanning) */
+  maxAgents: number;
+  /** Directories to skip when scanning */
+  excludeDirs: string[];
+}

--- a/.agents/plugins/opencode-aidevops/tsconfig.json
+++ b/.agents/plugins/opencode-aidevops/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/.agents/tools/build-mcp/aidevops-plugin.md
+++ b/.agents/tools/build-mcp/aidevops-plugin.md
@@ -394,6 +394,28 @@ export async function loadConfig(): Promise<Config> {
 - [ ] MCP health monitoring
 - [ ] Integration with aidevops update system
 
+### Phase 4: oh-my-opencode Compatibility (t008.4)
+
+- [x] Detect OMOC presence (OpenCode config, OMOC config files, npm)
+- [x] Deduplicate MCP registrations (skip MCPs managed by OMOC)
+- [x] Complement hooks without overlap (ShellCheck vs comment-checker)
+- [x] Inject OMOC state into compaction context
+- [x] Make setup.sh OMOC-aware (skip cleanup when plugin handles coexistence)
+
+#### Design Decisions
+
+**Coexistence over replacement**: When both `opencode-aidevops` and `oh-my-opencode` are installed, the plugin runs in compatibility mode rather than requiring the user to choose one. This is because:
+
+1. OMOC provides agent orchestration (Sisyphus, background agents, magic keywords)
+2. aidevops provides framework integration (memory, mailbox, supervisor, quality gates)
+3. The overlap is limited to MCP registration and some hook events
+
+**MCP deduplication strategy**: aidevops defers to OMOC for shared MCPs (exa, context7, grep-app) since OMOC may have user-customised versions. aidevops-specific MCPs (augment-context-engine, repomix, etc.) are registered normally.
+
+**Hook complementarity**: OMOC hooks (comment-checker, todo-continuation-enforcer) operate at the agent-behaviour level. aidevops hooks (ShellCheck PreToolUse, quality reminders) operate at the file-quality level. No overlap — both run simultaneously.
+
+**Detection approach**: Checks OpenCode config `plugin` array and OMOC config file existence. Does NOT check npm global install alone (OMOC could be installed but not configured as a plugin).
+
 ## Decision: Plugin vs Current Approach
 
 ### Keep Current Approach (Recommended for Now)

--- a/.opencode/lib/mcp-registry.ts
+++ b/.opencode/lib/mcp-registry.ts
@@ -1,0 +1,299 @@
+/**
+ * MCP Registry — reads MCP template configs and provides them in OpenCode format.
+ *
+ * Sources (in priority order):
+ *   1. User overrides in ~/.config/aidevops/mcp-overrides.json
+ *   2. configs/mcp-templates/*.json  (each file has an "opencode" section)
+ *   3. configs/mcp-servers-config.json.txt (legacy fallback)
+ *
+ * The registry normalises every entry to the OpenCode McpLocalConfig | McpRemoteConfig
+ * shape so the plugin's `config` hook can merge them into the running config.
+ */
+
+import { readdir } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { homedir } from 'node:os'
+
+// ── Types matching @opencode-ai/sdk McpLocalConfig | McpRemoteConfig ──
+
+export interface McpLocalConfig {
+  type: 'local'
+  command: string[]
+  environment?: Record<string, string>
+  enabled?: boolean
+  timeout?: number
+}
+
+export interface McpRemoteConfig {
+  type: 'remote'
+  url: string
+  enabled?: boolean
+  headers?: Record<string, string>
+}
+
+export type McpConfig = McpLocalConfig | McpRemoteConfig
+
+export interface McpRegistry {
+  /** name → config map ready to merge into Config.mcp */
+  entries: Record<string, McpConfig>
+  /** names of MCPs that failed to load (for diagnostics) */
+  errors: Array<{ name: string; reason: string }>
+}
+
+// ── Paths ──
+
+const HOME = homedir()
+const OVERRIDES_PATH = join(HOME, '.config', 'aidevops', 'mcp-overrides.json')
+
+/**
+ * Resolve the configs directory relative to the repo root.
+ * Works both when running from the repo and from the deployed plugin.
+ */
+function configsDir(repoRoot: string): string {
+  return join(repoRoot, 'configs', 'mcp-templates')
+}
+
+function legacyConfigPath(repoRoot: string): string {
+  return join(repoRoot, 'configs', 'mcp-servers-config.json.txt')
+}
+
+// ── Helpers ──
+
+/** Safely read and parse a JSON file. Returns null on any error. */
+async function readJson<T>(path: string): Promise<T | null> {
+  try {
+    const file = Bun.file(path)
+    if (!(await file.exists())) return null
+    return (await file.json()) as T
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Normalise a legacy mcpServers entry (command string + args array)
+ * into the OpenCode McpLocalConfig | McpRemoteConfig shape.
+ */
+function normaliseLegacyEntry(
+  name: string,
+  raw: Record<string, unknown>,
+): McpConfig | null {
+  // Remote server
+  if (raw.type === 'remote' && typeof raw.url === 'string') {
+    return {
+      type: 'remote',
+      url: raw.url,
+      enabled: raw.enabled !== false,
+      ...(raw.headers ? { headers: raw.headers as Record<string, string> } : {}),
+    }
+  }
+
+  // Local server — legacy format uses command (string) + args (string[])
+  const cmd = raw.command
+  const args = Array.isArray(raw.args) ? (raw.args as string[]) : []
+
+  if (typeof cmd === 'string') {
+    const command = [cmd, ...args]
+    const env = raw.env ?? raw.environment
+    const entry: McpLocalConfig = {
+      type: 'local',
+      command,
+      enabled: raw.enabled !== false,
+    }
+    if (env && typeof env === 'object') {
+      entry.environment = env as Record<string, string>
+    }
+    return entry
+  }
+
+  // Already in OpenCode format (command is string[])
+  if (Array.isArray(cmd)) {
+    const entry: McpLocalConfig = {
+      type: 'local',
+      command: cmd as string[],
+      enabled: raw.enabled !== false,
+    }
+    const env = raw.env ?? raw.environment
+    if (env && typeof env === 'object') {
+      entry.environment = env as Record<string, string>
+    }
+    return entry
+  }
+
+  return null
+}
+
+/**
+ * Extract the OpenCode MCP config from a template file.
+ *
+ * Template files have an `opencode` key containing one or more MCP entries
+ * in the format: { "mcp-name": { type, command, ... } }
+ */
+function extractFromTemplate(
+  json: Record<string, unknown>,
+): Record<string, McpConfig> {
+  const result: Record<string, McpConfig> = {}
+  const opencode = json.opencode as Record<string, unknown> | undefined
+  if (!opencode || typeof opencode !== 'object') return result
+
+  for (const [key, value] of Object.entries(opencode)) {
+    // Skip metadata keys
+    if (key.startsWith('_')) continue
+    if (typeof value !== 'object' || value === null) continue
+
+    const raw = value as Record<string, unknown>
+
+    // Check if it's already in McpLocalConfig/McpRemoteConfig shape
+    if (raw.type === 'remote' && typeof raw.url === 'string') {
+      result[key] = {
+        type: 'remote',
+        url: raw.url,
+        enabled: raw.enabled !== false,
+        ...(raw.headers ? { headers: raw.headers as Record<string, string> } : {}),
+      }
+    } else if (Array.isArray(raw.command)) {
+      const entry: McpLocalConfig = {
+        type: 'local',
+        command: raw.command as string[],
+        enabled: raw.enabled !== false,
+      }
+      if (raw.environment && typeof raw.environment === 'object') {
+        entry.environment = raw.environment as Record<string, string>
+      }
+      result[key] = entry
+    }
+  }
+
+  return result
+}
+
+/**
+ * Check if an MCP config contains placeholder values that need user configuration.
+ * MCPs with placeholders are registered but disabled by default.
+ */
+function hasPlaceholders(config: McpConfig): boolean {
+  const check = (val: string): boolean =>
+    /YOUR_.*_HERE|REPLACE_ME|<.*>/i.test(val)
+
+  if (config.type === 'local') {
+    if (config.environment) {
+      return Object.values(config.environment).some(check)
+    }
+  } else if (config.type === 'remote') {
+    if (config.headers) {
+      return Object.values(config.headers).some(check)
+    }
+  }
+  return false
+}
+
+// ── Main loader ──
+
+/**
+ * Load all MCP configurations from template files and legacy config.
+ *
+ * @param repoRoot - Path to the aidevops repo root (for finding configs/)
+ * @returns McpRegistry with all discovered MCP entries
+ */
+export async function loadMcpRegistry(repoRoot: string): Promise<McpRegistry> {
+  const entries: Record<string, McpConfig> = {}
+  const errors: Array<{ name: string; reason: string }> = []
+
+  // 1. Load from template files
+  const templatesDir = configsDir(repoRoot)
+  try {
+    const files = await readdir(templatesDir)
+    const jsonFiles = files.filter(f => f.endsWith('.json'))
+
+    for (const file of jsonFiles) {
+      const filePath = join(templatesDir, file)
+      const json = await readJson<Record<string, unknown>>(filePath)
+      if (!json) {
+        errors.push({ name: file, reason: 'Failed to parse JSON' })
+        continue
+      }
+
+      const extracted = extractFromTemplate(json)
+      for (const [name, config] of Object.entries(extracted)) {
+        // Disable MCPs with placeholder credentials
+        if (hasPlaceholders(config)) {
+          config.enabled = false
+        }
+        entries[name] = config
+      }
+    }
+  } catch {
+    errors.push({ name: 'mcp-templates/', reason: 'Directory not found or unreadable' })
+  }
+
+  // 2. Load from legacy config (lower priority — don't overwrite template entries)
+  const legacyPath = legacyConfigPath(repoRoot)
+  const legacy = await readJson<Record<string, unknown>>(legacyPath)
+  if (legacy?.mcpServers && typeof legacy.mcpServers === 'object') {
+    const servers = legacy.mcpServers as Record<string, Record<string, unknown>>
+    for (const [name, raw] of Object.entries(servers)) {
+      if (entries[name]) continue // Template takes priority
+      const config = normaliseLegacyEntry(name, raw)
+      if (config) {
+        if (hasPlaceholders(config)) {
+          config.enabled = false
+        }
+        entries[name] = config
+      } else {
+        errors.push({ name, reason: 'Could not normalise legacy config' })
+      }
+    }
+  }
+
+  // 3. Apply user overrides (highest priority)
+  const overrides = await readJson<Record<string, unknown>>(OVERRIDES_PATH)
+  if (overrides && typeof overrides === 'object') {
+    for (const [name, raw] of Object.entries(overrides)) {
+      if (typeof raw !== 'object' || raw === null) continue
+
+      const override = raw as Record<string, unknown>
+
+      // Allow disabling specific MCPs
+      if (override.enabled === false) {
+        if (entries[name]) {
+          entries[name].enabled = false
+        }
+        continue
+      }
+
+      // Allow enabling with custom config
+      const config = normaliseLegacyEntry(name, override)
+      if (config) {
+        entries[name] = config
+      }
+    }
+  }
+
+  return { entries, errors }
+}
+
+/**
+ * Get a summary of the registry for diagnostics.
+ */
+export function registrySummary(registry: McpRegistry): string {
+  const enabled = Object.entries(registry.entries).filter(([, c]) => c.enabled !== false)
+  const disabled = Object.entries(registry.entries).filter(([, c]) => c.enabled === false)
+  const local = enabled.filter(([, c]) => c.type === 'local')
+  const remote = enabled.filter(([, c]) => c.type === 'remote')
+
+  const lines = [
+    `MCP Registry: ${enabled.length} enabled, ${disabled.length} disabled, ${registry.errors.length} errors`,
+    `  Local: ${local.map(([n]) => n).join(', ') || 'none'}`,
+    `  Remote: ${remote.map(([n]) => n).join(', ') || 'none'}`,
+  ]
+
+  if (disabled.length > 0) {
+    lines.push(`  Disabled: ${disabled.map(([n]) => n).join(', ')}`)
+  }
+
+  if (registry.errors.length > 0) {
+    lines.push(`  Errors: ${registry.errors.map(e => `${e.name} (${e.reason})`).join(', ')}`)
+  }
+
+  return lines.join('\n')
+}

--- a/.opencode/lib/mcp-registry.ts
+++ b/.opencode/lib/mcp-registry.ts
@@ -173,9 +173,10 @@ function extractFromTemplate(
  */
 function hasPlaceholders(config: McpConfig): boolean {
   const check = (val: string): boolean =>
-    /YOUR_.*_HERE|REPLACE_ME|<.*>/i.test(val)
+    /YOUR_.*_HERE|REPLACE_ME|<.*>|\/Users\/YOU\//i.test(val)
 
   if (config.type === 'local') {
+    if (config.command.some(check)) return true
     if (config.environment) {
       return Object.values(config.environment).some(check)
     }

--- a/.opencode/tool/mcp-status.ts
+++ b/.opencode/tool/mcp-status.ts
@@ -1,0 +1,93 @@
+/**
+ * MCP Status Tool
+ *
+ * Reports the status of MCP servers registered by the aidevops plugin.
+ * Checks which MCPs are configured, enabled, and reachable.
+ */
+
+import { tool } from "@opencode-ai/plugin"
+import { loadMcpRegistry, registrySummary } from "../lib/mcp-registry"
+import { existsSync } from "node:fs"
+import { join } from "node:path"
+import { homedir } from "node:os"
+
+/**
+ * Find the aidevops repo root from the working directory.
+ */
+function findRepoRoot(directory: string): string | null {
+  if (existsSync(join(directory, "configs", "mcp-templates"))) {
+    return directory
+  }
+  const mainRepo = join(homedir(), "Git", "aidevops")
+  if (existsSync(join(mainRepo, "configs", "mcp-templates"))) {
+    return mainRepo
+  }
+  const deployed = join(homedir(), ".aidevops")
+  if (existsSync(join(deployed, "configs", "mcp-templates"))) {
+    return deployed
+  }
+  return null
+}
+
+export default tool({
+  description: "Check status of MCP servers registered by aidevops — shows enabled, disabled, and errored MCPs",
+  args: {
+    filter: tool.schema.enum(["all", "enabled", "disabled", "errors"]).optional()
+      .describe("Filter results: all (default), enabled, disabled, or errors only"),
+  },
+  async execute(args, context) {
+    const repoRoot = findRepoRoot(context.directory)
+    if (!repoRoot) {
+      return "Could not find aidevops configs directory. Ensure configs/mcp-templates/ exists in the repo or ~/.aidevops/"
+    }
+
+    const registry = await loadMcpRegistry(repoRoot)
+    const filter = args.filter || "all"
+
+    const entries = Object.entries(registry.entries)
+    const enabled = entries.filter(([, c]) => c.enabled !== false)
+    const disabled = entries.filter(([, c]) => c.enabled === false)
+
+    const lines: string[] = []
+
+    if (filter === "all" || filter === "enabled") {
+      lines.push(`## Enabled MCPs (${enabled.length})`)
+      for (const [name, config] of enabled) {
+        if (config.type === "local") {
+          lines.push(`  ${name}: local [${config.command.join(" ")}]`)
+        } else {
+          lines.push(`  ${name}: remote ${config.url}`)
+        }
+      }
+      lines.push("")
+    }
+
+    if (filter === "all" || filter === "disabled") {
+      lines.push(`## Disabled MCPs (${disabled.length})`)
+      for (const [name, config] of disabled) {
+        if (config.type === "local") {
+          lines.push(`  ${name}: local [${config.command.join(" ")}] (needs configuration)`)
+        } else {
+          lines.push(`  ${name}: remote ${config.url} (needs configuration)`)
+        }
+      }
+      lines.push("")
+    }
+
+    if (filter === "all" || filter === "errors") {
+      if (registry.errors.length > 0) {
+        lines.push(`## Errors (${registry.errors.length})`)
+        for (const err of registry.errors) {
+          lines.push(`  ${err.name}: ${err.reason}`)
+        }
+      } else if (filter === "errors") {
+        lines.push("No errors found.")
+      }
+    }
+
+    lines.push("")
+    lines.push(registrySummary(registry))
+
+    return lines.join("\n")
+  },
+})


### PR DESCRIPTION
## Summary

- Detect oh-my-opencode presence at plugin startup (checks OpenCode config, OMOC config files, npm)
- Deduplicate MCP registrations — skip MCPs already managed by OMOC (exa, context7, grep-app)
- Merge quality hooks without overlap — aidevops ShellCheck hooks complement OMOC comment-checker/todo-enforcer
- Inject OMOC compatibility state into compaction context for session continuity
- Update setup.sh to respect explicit OMOC usage (skip aggressive cleanup when user wants both)
- Update architecture docs with Phase 4 design

## Dependencies

Merges t008.1 (core plugin), t008.2 (MCP registry), t008.3 (quality hooks) into this branch.

## Testing

- Syntax validation via node --check
- Manual review of detection logic against oh-my-opencode v3.5.1 config format
- Verified MCP deduplication logic handles all OMOC config variants (mcpServers, mcp keys)

Closes: t008.4