### PR TITLE
fix: verify_gh_cli accepts GH_TOKEN/GITHUB_TOKEN env vars

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -87,6 +87,11 @@ verify_gh_cli() {
         print_error "gh CLI not installed. Install with: brew install gh"
         return 1
     fi
+    # Accept GH_TOKEN or GITHUB_TOKEN env vars (used in GitHub Actions)
+    # gh auth status checks the credential store but doesn't recognize env tokens
+    if [[ -n "${GH_TOKEN:-}" || -n "${GITHUB_TOKEN:-}" ]]; then
+        return 0
+    fi
     if ! gh auth status &>/dev/null 2>&1; then
         print_error "gh CLI not authenticated. Run: gh auth login"
         return 1


### PR DESCRIPTION
## Summary

- Push-triggered issue-sync runs fail with "gh CLI not authenticated" because `verify_gh_cli()` uses `gh auth status` which checks the credential store but doesn't recognize `GH_TOKEN`/`GITHUB_TOKEN` env vars that GitHub Actions provides
- Fix: accept these env vars as valid authentication before falling back to `gh auth status`
- This unblocks automatic issue-sync on every push to main

## Changes

- `.agents/scripts/issue-sync-helper.sh`: Added early return in `verify_gh_cli()` when `GH_TOKEN` or `GITHUB_TOKEN` env vars are set

## Testing

- ShellCheck passes
- Logic: if env token is set, skip credential store check and return 0