### PR TITLE
fix: cmd_close pre-fetches open issues to avoid 2000+ API calls (t283)

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
     concurrency:
       group: issue-sync-push-${{ github.ref }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     permissions:
       contents: write
       issues: write


### PR DESCRIPTION
## Summary

- `cmd_close` iterated all 533 completed tasks making 2-5 GitHub API calls each (2000+ total), taking 5+ minutes per run
- Combined with `cancel-in-progress: true` on the push job, every new push cancelled the running close step — issues never got closed
- Fix: pre-fetch all open issues in 1 API call, build a task_id lookup map, only process completed tasks with matching open issues (~20-30 vs 533)
- Changed push job concurrency to `cancel-in-progress: false` so the sync completes

## Changes

- `.agents/scripts/issue-sync-helper.sh`: Rewrote `cmd_close()` bulk mode to pre-fetch open issues; extracted `_close_single_task()` for targeted single-task mode
- `.github/workflows/issue-sync.yml`: Changed push job `cancel-in-progress: false`

## Performance

| Metric | Before | After |
|--------|--------|-------|
| API calls per run | ~2000+ | ~30-50 |
| Runtime | 5+ min (always cancelled) | <30s |
| Issues closed | 0 (never finished) | All eligible |