### PR TITLE
fix: remove 2>/dev/null from cmd_add calls in auto-pickup (t279)

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -12779,7 +12779,7 @@ cmd_auto_pickup() {
             fi
 
             # Add to supervisor
-            if cmd_add "$task_id" --repo "$repo" 2>/dev/null; then
+            if cmd_add "$task_id" --repo "$repo"; then
                 picked_up=$((picked_up + 1))
                 log_success "  Auto-picked: $task_id (tagged #auto-dispatch)"
             fi
@@ -12837,7 +12837,7 @@ cmd_auto_pickup() {
                 continue
             fi
 
-            if cmd_add "$task_id" --repo "$repo" 2>/dev/null; then
+            if cmd_add "$task_id" --repo "$repo"; then
                 picked_up=$((picked_up + 1))
                 log_success "  Auto-picked: $task_id (Dispatch Queue section)"
             fi
@@ -12893,7 +12893,7 @@ cmd_auto_pickup() {
             fi
 
             # Add to supervisor (plan_anchor passed directly to dispatch_decomposition_worker)
-            if cmd_add "$task_id" --repo "$repo" 2>/dev/null; then
+            if cmd_add "$task_id" --repo "$repo"; then
                 picked_up=$((picked_up + 1))
                 log_success "  Auto-picked: $task_id (#plan task for decomposition)"
                 


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from 3 `cmd_add` call sites in `auto_pickup_tasks()` (lines 12782, 12840, 12896)
- `cmd_add()` already has proper unknown option logging via `log_error "Unknown option: $1"` at line 1831
- The stderr suppression made the `--metadata` flag bug (PR #1071) invisible — unknown options were silently swallowed
- Pattern: never suppress stderr on internal function calls during development

## Testing

- `bash -n` syntax check: pass
- `shellcheck -S warning`: no new warnings (only pre-existing SC2034 unused vars)
- Change is minimal (3 lines) and only removes stderr redirection

Closes #1090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in automated task dispatch operations to ensure errors are properly surfaced during task auto-pickup instead of being silenced, enabling earlier error detection and better visibility of failures in the dispatch pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->