### PR TITLE
fix: setup.sh stale file cleanup + false-close audit (t285, t286)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -9,10 +9,10 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 **Human-readable:**
 
 ```markdown
-- [ ] t001 Task description @owner #tag ~4h (ai:2h test:1h read:30m) ref:GH#544 logged:2025-01-15
-  - [ ] t001.1 Subtask ~2h blocked-by:t002 ref:GH#851
-    - [ ] t001.1.1 Sub-subtask ~1h ref:GH#852
-  - [ ] t001.2 Another subtask ~1h blocks:t003 ref:GH#853
+- [ ] t001 Task description @owner #tag ~4h (ai:2h test:1h read:30m) logged:2025-01-15
+  - [ ] t001.1 Subtask ~2h blocked-by:t002
+    - [ ] t001.1.1 Sub-subtask ~1h
+  - [ ] t001.2 Another subtask ~1h blocks:t003
 - [x] t002 Completed task ~2h actual:1.5h logged:2025-01-10 completed:2025-01-15
 - [-] t003 Declined task
 ```
@@ -71,7 +71,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 - [x] t270 Higgsfield automator should output to ~/Downloads by default for user-facing assets — generated images and videos are saved to ~/.aidevops/.agent-workspace/work/higgsfield/ which is buried and invisible to the user. For interactive sessions, default --output to ~/Downloads/higgsfield/ (or a project-named subdirectory) so users can immediately review assets in Finder. Keep .agent-workspace as the default only for headless/pipeline runs. #enhancement #higgsfield #ux #auto-dispatch ~15m (ai:10m test:5m) ref:GH#1045 assignee:marcusquinn started:2026-02-11T02:06:11Z logged:2026-02-11 completed:2026-02-11 pr:#1054
 - [x] t271 Higgsfield pipeline command should produce assembled sequence — the `pipeline` command exists but doesn't stitch individual clips into a final video. Currently requires manual ffmpeg to concatenate shots with transitions. The pipeline should auto-detect ffmpeg and produce a single assembled output with crossfade transitions between shots. #enhancement #higgsfield #automation #auto-dispatch ~1h (ai:45m test:15m) ref:GH#1046 assignee:marcusquinn started:2026-02-11T03:14:18Z logged:2026-02-11 completed:2026-02-11 pr:#1069
 - [x] t272 Content storyboard quality — content/story.md hook framework and content/production/image.md templates need a "UGC brief" template that generates a complete multi-shot storyboard from a business description. Current workflow requires manual shot-by-shot prompt writing. Template should include: presenter introduction, business context, product hero shots, and CTA. Should also integrate with the video-prompt-design.md 7-component format for each shot. #enhancement #content #automation #auto-dispatch ~2h (ai:1.5h test:30m) ref:GH#1047 assignee:marcusquinn started:2026-02-11T02:08:40Z logged:2026-02-11 completed:2026-02-11 pr:#1055
-- [x] t274 Move wavespeed.md from services/ai-generation/ to tools/video/ — consolidate all video/media generation API agents under tools/video/ for simpler discovery. Update AGENTS.md, subagent-index.toon, content.md, and all cross-references. Remove empty services/ai-generation/ if no other files remain (comfy-cli is in tools/ai-generation/, not services/). #refactor #video #architecture #auto-dispatch ~30m (ai:20m test:10m) logged:2026-02-11 completed:2026-02-11
+- [x] t287 Move wavespeed.md from services/ai-generation/ to tools/video/ — consolidate all video/media generation API agents under tools/video/ for simpler discovery. Update AGENTS.md, subagent-index.toon, content.md, and all cross-references. Remove empty services/ai-generation/ if no other files remain (comfy-cli is in tools/ai-generation/, not services/). #refactor #video #architecture #auto-dispatch ~30m (ai:20m test:10m) logged:2026-02-11 completed:2026-02-11
 - [ ] t273 Auto-recall memories at session start and before task execution — memories are currently write-only unless someone manually runs `/recall`. No automatic recall at session start, no recall before tasks, no integration with Build+ workflow. Lessons stored in memory (e.g., "log TODOs immediately", "read domain subagents first") are never surfaced. Fix: (1) add `memory-helper.sh recall --recent --limit 5` to conversation-starter.md so recent lessons are shown at session start, (2) add a recall step to Build+ step 2 that queries memory for the task domain, (3) add recall to supervisor worker dispatch prompts so workers benefit from accumulated lessons. Without this, the memory system is a write-only log that never influences behaviour. #enhancement #memory #self-improvement #auto-dispatch ~1h (ai:45m test:15m) model:sonnet ref:GH#1065 logged:2026-02-11
 - [x] t264 Supervisor session memory monitoring with respawn detection — OpenCode/Bun processes accumulate 25GB+ WebKit malloc dirty pages over long sessions (never returned to OS). Added Phase 11 to supervisor pulse: checks phys_footprint of parent OpenCode session via macOS footprint(1) or Linux /proc/PID/status, writes respawn-recommended marker when exceeding SUPERVISOR_SELF_MEM_LIMIT (default 8192MB). Workers are NOT killed or throttled — they're short-lived and already managed by Phase 4. CLI: `supervisor-helper.sh mem-check`. Discovered via OpenCode issue #13041. #feature #supervisor #performance #memory ~2h (ai:1.5h test:30m) ref:GH#1048 logged:2026-02-11 completed:2026-02-11 pr:#1040
   - [x] t264.1 Respawn supervisor after batch completion when memory exceeds threshold — Phase 11 now actively respawns instead of passively warning. Triggers when batch wave completes (no running/queued tasks) AND parent session footprint > threshold. Saves checkpoint, logs respawn event to persistent history (~/.aidevops/logs/respawn-history.log), exits cleanly for next cron pulse. CLI: `supervisor-helper.sh respawn-history`. #feature #supervisor #memory ~1h (ai:45m test:15m) started:2026-02-11 completed:2026-02-11 pr:#1043
@@ -610,7 +610,7 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
   - [x] t068.8 TUI Dashboard (extend bdui or new Ink app) ~1h blocked-by:t068.4,t068.5 ref:GH#499 completed:2026-02-09 verified:2026-02-09 pr:#482
     - Notes: Already implemented as cmd_dashboard() in supervisor-helper.sh (lines 8989-9498). Full interactive TUI with: batch summary, progress bar, task table with status icons/colors, system resources (CPU/memory/processes), active worker PIDs, keyboard controls (q/p/r/j/k/?), scroll support, adaptive column widths.
 - [x] t009 Claude Code Destructive Command Hooks #plan → [todo/PLANS.md#claude-code-destructive-command-hooks] ~30m (ai:15m test:10m read:5m) ref:GH#500 logged:2025-12-21 completed:2026-02-08 verified:2026-02-08 PR #562 merged
-- [x] t008 aidevops-opencode Plugin #plan → [todo/PLANS.md#aidevops-opencode-plugin] ~1.5h (ai:45m test:30m read:15m) ref:GH#501 logged:2025-12-21 completed:2026-02-11
+- [ ] t008 aidevops-opencode Plugin #plan → [todo/PLANS.md#aidevops-opencode-plugin] ~1.5h (ai:45m test:30m read:15m) ref:GH#501 logged:2025-12-21
   - [ ] t008.1 Core plugin structure + agent loader ~4h #auto-dispatch ref:GH#1094 assignee:marcusquinn
   - [ ] t008.2 MCP registration ~2h #auto-dispatch blocked-by:t008.1 ref:GH#1095 assignee:marcusquinn
   - [ ] t008.3 Quality hooks (pre-commit) ~3h #auto-dispatch blocked-by:t008.1 ref:GH#1096 assignee:marcusquinn
@@ -632,9 +632,9 @@ Tasks with no open blockers - ready to work on. Use `/ready` to refresh this lis
 - [x] t006 Add Playwright MCP auto-setup to setup.sh #browser ~1d actual:15m (ai:0.5d test:0.5d) logged:2025-12-20 started:2026-01-22T01:30Z completed:2026-01-22
   - Notes: Added Playwright MCP installation to setup_browser_tools() in setup.sh. Checks for existing installation, prompts user, installs browsers (chromium, firefox, webkit) via `npx playwright install`.
 - [x] t007 Create MCP server for QuickFile accounting API #accounting ~2h (ai:1h test:40m read:20m) ref:GH#505 logged:2025-12-20 completed:2026-02-08 verified:2026-02-08 PR #585 merged
-- [x] t012 OCR Invoice/Receipt Extraction Pipeline #plan → [todo/PLANS.md#ocr-invoicereceipt-extraction-pipeline] ~3h (ai:1.5h test:1h read:30m) ref:GH#506 logged:2025-12-21 completed:2026-02-11
+- [ ] t012 OCR Invoice/Receipt Extraction Pipeline #plan → [todo/PLANS.md#ocr-invoicereceipt-extraction-pipeline] ~3h (ai:1.5h test:1h read:30m) ref:GH#506 logged:2025-12-21
   - [ ] t012.1 Research OCR approaches and @pontusab's implementation ~4h #auto-dispatch ref:GH#1098
-  - [x] t012.2 Design extraction schema (vendor, amount, date, VAT, items) ~4h #auto-dispatch blocked-by:t012.1 ref:GH#1099 completed:2026-02-11
+  - [ ] t012.2 Design extraction schema (vendor, amount, date, VAT, items) ~4h #auto-dispatch blocked-by:t012.1
   - [ ] t012.3 Implement OCR extraction pipeline ~8h #auto-dispatch blocked-by:t012.2 ref:GH#1099 assignee:marcusquinn
   - [ ] t012.4 QuickFile integration (purchases/expenses) ~4h #auto-dispatch blocked-by:t012.3 ref:GH#1100 assignee:marcusquinn
   - [ ] t012.5 Testing with various invoice/receipt formats ~4h #auto-dispatch blocked-by:t012.4 ref:GH#1101 assignee:marcusquinn

--- a/setup.sh
+++ b/setup.sh
@@ -307,6 +307,9 @@ cleanup_deprecated_paths() {
         "$agents_dir/tools/ai-assistants/status.md"
         # Removed oh-my-opencode integration (no longer supported)
         "$agents_dir/tools/opencode/oh-my-opencode.md"
+        # t199.8: youtube moved from root to content/distribution/youtube/
+        "$agents_dir/youtube.md"
+        "$agents_dir/youtube"
     )
     
     for path in "${deprecated_paths[@]}"; do

--- a/todo/t286-false-close-audit.md
+++ b/todo/t286-false-close-audit.md
@@ -1,0 +1,78 @@
+# t286: False Close Audit Report
+
+**Date**: 2026-02-11
+**Auditor**: AI DevOps (claude-opus-4-6)
+**Scope**: All closed GitHub issues with `status:done` label vs TODO.md task status
+
+## Methodology
+
+1. Exported all 52 closed issues with `status:done` label
+2. Cross-referenced each issue's task ID against TODO.md `[x]` status
+3. Checked for parent tasks marked `[x]` with open subtasks
+4. Checked for tasks marked `[x]` without `pr:` or `verified:` fields
+5. Checked for task ID collisions
+
+## Findings
+
+### 1. False Closures (GitHub issue closed but task is `[ ]` in TODO.md)
+
+| Issue | Task ID | Description | Action |
+|-------|---------|-------------|--------|
+| GH#851 | t001.1 | Example subtask in TODO.md format section | Reopen issue or remove `ref:GH#` from example |
+| GH#852 | t001.1.1 | Example sub-subtask in TODO.md format section | Reopen issue or remove `ref:GH#` from example |
+| GH#853 | t001.2 | Example subtask in TODO.md format section | Reopen issue or remove `ref:GH#` from example |
+
+**Root cause**: The TODO.md format section contains example tasks with real `ref:GH#` links. The issue-sync pipeline created GitHub issues for these examples and then closed them when the format section was processed. These are not real tasks.
+
+**Fix**: Remove `ref:GH#` from the example tasks in the format section, or use clearly fake refs like `ref:GH#000`.
+
+### 2. Parent Tasks Marked `[x]` With Open Subtasks
+
+| Task | GitHub Issue | Open Subtasks | Action |
+|------|-------------|---------------|--------|
+| t008 | GH#501 (CLOSED) | t008.1, t008.2, t008.3, t008.4 (all `[ ]`) | Revert t008 to `[ ]`, reopen GH#501 |
+| t012 | GH#506 (CLOSED) | t012.1, t012.3, t012.4, t012.5 (all `[ ]`) | Revert t012 to `[ ]`, reopen GH#506 |
+
+**Root cause**: The supervisor's auto-decomposition (t274) marked parent `#plan` tasks as `[x]` after generating subtasks, but the subtasks themselves are incomplete. The issue-sync pipeline then closed the GitHub issues.
+
+**Fix**: Revert parent tasks to `[ ]` and reopen their GitHub issues.
+
+### 3. Task ID Collision
+
+| Task ID | Instance 1 | Instance 2 |
+|---------|-----------|-----------|
+| t274 | Supervisor auto-decomposition of #plan tasks (pr:#1066, GH#1064) | Move wavespeed.md from services/ai-generation/ to tools/video/ (no pr:, no ref:) |
+
+**Root cause**: Parallel sessions assigned the same task ID. The collision prevention rule (re-read TODO.md after failed push) was not followed.
+
+**Fix**: Renumber the wavespeed move task to the next available ID (t287).
+
+### 4. Subtask With Wrong `ref:GH#`
+
+| Task | Issue Ref | Actual Issue | Action |
+|------|-----------|-------------|--------|
+| t012.2 | ref:GH#1099 | GH#1099 is actually for t012.3 | Fix ref to correct issue |
+
+### 5. Previously Fixed
+
+| Task | Issue | Problem | Resolution |
+|------|-------|---------|------------|
+| t199.8 | GH#861 | Worker failed with `clean_exit_no_signal`, stub created instead of migration | Fixed in PR #1104 (this session) |
+
+## Summary
+
+| Category | Count | Severity |
+|----------|-------|----------|
+| False closures (example tasks) | 3 | Low (not real tasks) |
+| Parent tasks with open subtasks | 2 | Medium (misleading completion) |
+| Task ID collisions | 1 | Medium (data integrity) |
+| Wrong issue refs | 1 | Low (cross-reference error) |
+| Previously fixed | 1 | Resolved |
+
+## Recommended Actions
+
+1. Remove `ref:GH#` from TODO.md format examples (t001.x)
+2. Revert t008 and t012 to `[ ]` in TODO.md
+3. Reopen GH#501 and GH#506
+4. Renumber duplicate t274 (wavespeed) to t287
+5. Fix t012.2 ref to correct issue number


### PR DESCRIPTION
## Summary

- **t285**: Adds YouTube migration entries to `cleanup_deprecated_paths()` in setup.sh so stale `~/.aidevops/agents/youtube.md` and `youtube/` are removed on update
- **t286**: Audits all closed GitHub issues for false completions and fixes the data

## t285: Setup.sh Stale File Cleanup

Added two entries to the existing `cleanup_deprecated_paths()` function:
- `$agents_dir/youtube.md` (moved to `content/distribution/youtube/youtube.md`)
- `$agents_dir/youtube` (moved to `content/distribution/youtube/`)

This is the generalised pattern — future migrations just add entries to the same array.

## t286: False Close Audit

Audited all 52 closed issues with `status:done` label. Findings:

| Category | Count | Action Taken |
|----------|-------|-------------|
| Parent tasks marked [x] with open subtasks | 2 (t008, t012) | Reverted to [ ], reopened GH#501, GH#506 |
| Example tasks with real GH refs | 3 (t001.x) | Removed refs, closed issues as not-planned |
| Task ID collision | 1 (t274 duplicate) | Renumbered wavespeed move to t287 |
| Subtask with wrong ref | 1 (t012.2) | Reverted to [ ], removed wrong ref |

Full audit report: `todo/t286-false-close-audit.md`

## Files Changed

- `setup.sh` — 2 new deprecated path entries
- `TODO.md` — Fixed false completions, removed example refs, renumbered collision
- `todo/t286-false-close-audit.md` — New audit report