### PR TITLE
fix: PRs now cross-reference GitHub issues via Ref #NNN (t288)

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -4450,10 +4450,19 @@ exhaustion, crash, timeout), uncommitted work is LOST. Committed work survives.
 After your FIRST commit, push and create a draft PR immediately:
 \`\`\`bash
 git push -u origin HEAD
-gh pr create --draft --title '<task-id>: <description>' --body 'WIP - incremental commits'
+# t288: Include GitHub issue reference in PR body when task has ref:GH# in TODO.md
+# Look up: grep -oE 'ref:GH#[0-9]+' TODO.md for your task ID, extract the number
+# If found, add 'Ref #NNN' to the PR body so GitHub cross-links the issue
+gh_issue=\$(grep -E '^\s*- \[.\] <task-id> ' TODO.md 2>/dev/null | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
+pr_body='WIP - incremental commits'
+[[ -n \"\$gh_issue\" ]] && pr_body=\"\${pr_body}
+
+Ref #\${gh_issue}\"
+gh pr create --draft --title '<task-id>: <description>' --body \"\$pr_body\"
 \`\`\`
 Subsequent commits just need \`git push\`. The PR already exists.
 This ensures the supervisor can detect your PR even if you run out of context.
+The \`Ref #NNN\` line cross-links the PR to its GitHub issue for auditability.
 
 When ALL implementation is done, mark the PR as ready for review:
 \`\`\`bash
@@ -5963,6 +5972,22 @@ auto_create_pr_for_task() {
     local commit_log
     commit_log=$(git -C "$repo_path" log --oneline "${base_branch}..${branch_name}" 2>/dev/null | head -10 || echo "(no commits)")
 
+    # t288: Look up GitHub issue ref from TODO.md for cross-referencing
+    local gh_issue_ref=""
+    local todo_file="$repo_path/TODO.md"
+    if [[ -f "$todo_file" ]]; then
+        gh_issue_ref=$(grep -E "^\s*- \[.\] ${task_id} " "$todo_file" 2>/dev/null \
+            | head -1 | grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
+    fi
+
+    # Build issue reference line for PR body
+    local issue_ref_line=""
+    if [[ -n "$gh_issue_ref" ]]; then
+        issue_ref_line="
+
+Ref #${gh_issue_ref}"
+    fi
+
     # Create draft PR
     local pr_body
     pr_body="## Auto-created by supervisor (t247.2)
@@ -5978,7 +6003,7 @@ ${commit_log}
 
 ### Task
 
-${task_desc}"
+${task_desc}${issue_ref_line}"
 
     local pr_url
     pr_url=$(gh pr create \


### PR DESCRIPTION
## Summary

- **auto_create_pr_for_task()** now looks up `ref:GH#` from TODO.md and adds `Ref #NNN` to the PR body, so GitHub automatically cross-links the PR to its issue
- **Worker prompt template** updated to extract `ref:GH#` from TODO.md and include it in draft PR body when workers create PRs
- **Retroactive**: Added PR reference comments on 26 closed issues that were missing GitHub-linked PRs (8 already had them from prior issue-sync runs)

## Problem

34 closed issues with `status:done` had no GitHub-linked PR. The issue-sync `cmd_close()` already adds a closing comment with the PR reference, but the PRs themselves never referenced the issues. This made it impossible to navigate from an issue to its deliverable PR via GitHub's UI.

Root cause: Neither the worker prompt template nor `auto_create_pr_for_task()` included issue references in PR bodies.

## Changes

**`.agents/scripts/supervisor-helper.sh`** (+27/-2):
1. `auto_create_pr_for_task()`: Added TODO.md lookup for `ref:GH#NNN` and appends `Ref #NNN` to the auto-created PR body
2. Worker prompt template: Updated the draft PR creation example to extract `ref:GH#` from TODO.md and include it in the PR body

## Verification

- ShellCheck: zero new violations
- Retroactive comments verified on GitHub (e.g., [#907](https://github.com/marcusquinn/aidevops/issues/907#issuecomment-3882276933))
- All 34 orphaned issues now have auditable PR references

Ref #1108