### PR TITLE
fix: pre-dispatch check matched [x] in task description, not checkbox (t290)

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -3197,7 +3197,10 @@ check_task_already_done() {
         local first_match=""
         first_match=$(grep -E "^\s*- \[(x| |-)\] ${task_id}[[:space:]]" "$todo_file" 2>/dev/null | head -1) || true
         if [[ -n "$first_match" ]]; then
-            if [[ "$first_match" =~ \[x\] ]]; then
+            # Extract ONLY the checkbox at the start of the line, not [x] anywhere in description
+            local checkbox=""
+            checkbox=$(printf '%s' "$first_match" | sed -n 's/^[[:space:]]*- \[\(.\)\].*/\1/p')
+            if [[ "$checkbox" == "x" ]]; then
                 log_info "Pre-dispatch check: $task_id is marked [x] in TODO.md (first occurrence)" >&2
                 return 0
             else


### PR DESCRIPTION
## Summary

- `is_task_already_complete()` used `=~ \[x\]` which matched `[x]` anywhere in the TODO.md line
- Task descriptions containing literal `[x]` text (e.g., "catches `[x]` in TODO.md") were falsely detected as complete
- Now extracts only the checkbox character from the line-start position using `sed`
- This caused t290 itself to be un-dispatchable (its description mentions `[x]`)

## Task
t290

Ref #1124

## Testing
- `bash -n`: pass
- `shellcheck -S warning`: no new warnings
- Manual regex test: `[ ]` line with `[x]` in description correctly returns space, not x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of task completion detection by refining how the system identifies completed tasks, eliminating false positives that could occur when task descriptions contained completion markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->