### PR TITLE
t294: ShellCheck warning sweep - fix SC2178/SC2128/SC2115/SC2155

### DIFF
--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -481,12 +481,12 @@ cmd_providers() {
 # Dispatches via runner-helper.sh in parallel, collects outputs, produces summary.
 #######################################
 cmd_cross_review() {
-    local prompt="" models="" workdir="" review_timeout="600" output_dir=""
+    local prompt="" models_str="" workdir="" review_timeout="600" output_dir=""
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --prompt) [[ $# -lt 2 ]] && { print_error "--prompt requires a value"; return 1; }; prompt="$2"; shift 2 ;;
-            --models) [[ $# -lt 2 ]] && { print_error "--models requires a value"; return 1; }; models="$2"; shift 2 ;;
+            --models) [[ $# -lt 2 ]] && { print_error "--models requires a value"; return 1; }; models_str="$2"; shift 2 ;;
             --workdir) [[ $# -lt 2 ]] && { print_error "--workdir requires a value"; return 1; }; workdir="$2"; shift 2 ;;
             --timeout) [[ $# -lt 2 ]] && { print_error "--timeout requires a value"; return 1; }; review_timeout="$2"; shift 2 ;;
             --output) [[ $# -lt 2 ]] && { print_error "--output requires a value"; return 1; }; output_dir="$2"; shift 2 ;;
@@ -501,8 +501,8 @@ cmd_cross_review() {
     fi
 
     # Default models: sonnet + opus (Anthropic second opinion)
-    if [[ -z "$models" ]]; then
-        models="sonnet,opus"
+    if [[ -z "$models_str" ]]; then
+        models_str="sonnet,opus"
     fi
 
     # Set up output directory
@@ -524,7 +524,7 @@ cmd_cross_review() {
 
     # Parse models list
     local -a model_array=()
-    IFS=',' read -ra model_array <<< "$models"
+    IFS=',' read -ra model_array <<< "$models_str"
 
     if [[ ${#model_array[@]} -lt 2 ]]; then
         print_error "At least 2 models required for cross-review (got ${#model_array[@]})"
@@ -534,7 +534,7 @@ cmd_cross_review() {
     echo ""
     echo "Cross-Model Review"
     echo "==================="
-    echo "Models: ${models}"
+    echo "Models: ${models_str}"
     echo "Output: ${output_dir}"
     echo "Timeout: ${review_timeout}s per model"
     echo ""
@@ -622,7 +622,7 @@ cmd_cross_review() {
     # Generate diff summary if we have 2+ results
     echo "=== DIFF SUMMARY ==="
     echo ""
-    echo "Models compared: ${models}"
+    echo "Models compared: ${models_str}"
     echo "Results: ${results_found}/${#model_names[@]} successful"
     echo ""
 

--- a/setup.sh
+++ b/setup.sh
@@ -2989,7 +2989,7 @@ deploy_plugins() {
     while IFS= read -r disabled_ns; do
         [[ -z "$disabled_ns" ]] && continue
         if [[ -d "$target_dir/$disabled_ns" ]]; then
-            rm -rf "$target_dir/$disabled_ns"
+            rm -rf "${target_dir:?}/${disabled_ns:?}"
             print_info "  Removed disabled plugin directory: $disabled_ns"
         fi
     done < <(jq -r '.plugins[] | select(.enabled == false) | .namespace // empty' "$plugins_file" 2>/dev/null)
@@ -3535,7 +3535,8 @@ setup_nodejs_env() {
         return
     fi
 
-    local node_version=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
+    local node_version
+    node_version=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
     if [[ $node_version -lt 18 ]]; then
         print_warning "Node.js 18+ required for DSPyGround, found v$node_version - DSPyGround setup skipped"
         return
@@ -3811,7 +3812,8 @@ setup_augment_context_engine() {
         return
     fi
 
-    local node_version=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
+    local node_version
+    node_version=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
     if [[ $node_version -lt 22 ]]; then
         print_warning "Node.js 22+ required for Augment Context Engine, found v$node_version"
         print_info "Install: brew install node@22 (macOS) or nvm install 22"


### PR DESCRIPTION
## Summary

Completed ShellCheck warning sweep across all .sh files (excluding SC2034 unused variables).

## Changes

### compare-models-helper.sh
- **SC2178/SC2128**: Renamed `models` variable to `models_str` in `cmd_cross_review` function
- Prevents ShellCheck confusion with `models` array in `cmd_compare` function
- Fixed 4 warnings related to array/string type conflicts

### setup.sh
- **SC2115**: Added `:?` parameter expansion to `rm -rf` command to prevent accidental `/` deletion
- **SC2155**: Split local declaration and assignment to avoid masking return values in Node.js version checks
- Fixed 3 warnings in plugin cleanup and version validation

## Scan Results

- Scanned 241 .sh files across the repository
- Found and fixed 7 warnings (excluding SC2034)
- All critical helper scripts (supervisor, runner, worktree, memory, mail, pre-edit-check, linters-local, version-manager, model-registry) are clean
- Focus areas: quoting issues, subshell variable scope, arithmetic context

## Testing

- All fixes verified with `shellcheck -x -S warning`
- No new warnings introduced
- Modified files pass ShellCheck validation

Ref #1145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced safety measures for file operations during cleanup to prevent accidental deletions.
  * Improved robustness of variable handling and initialization in setup processes to prevent issues with uninitialized variables.
  * Refined internal output consistency for model comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->