### PR TITLE
docs: add explicit PR-required rule for all non-planning changes (t297)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -125,6 +125,8 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **After ANY TODO/planning edit** (interactive sessions only, NOT workers): Commit and push immediately. Planning-only files (TODO.md, todo/) go directly to main -- no branch, no PR. Mixed changes (planning + non-exception files) use a worktree. NEVER `git checkout -b` in the main repo.
 
+**PR required for ALL non-planning changes** (MANDATORY): Every change to scripts, agents, configs, workflows, or any file outside `TODO.md`, `todo/`, and `VERIFY.md` MUST go through a worktree + PR + CI pipeline — no matter how small. "It's just one line" is not a valid reason to skip CI. The pre-edit-check script enforces this; never bypass it by editing directly on main.
+
 **Task ID collision prevention**: When assigning a new task ID, if `git push` fails and you `git pull --rebase`, you MUST re-read TODO.md and verify your assigned ID is still unique before pushing again. Parallel sessions may have claimed the same ID. If a collision exists, renumber to the next available ID.
 
 **Full docs**: `workflows/plans.md`, `tools/task-management/beads.md`


### PR DESCRIPTION
## Summary

- Adds explicit instruction to AGENTS.md: all non-planning file changes MUST go through worktree + PR + CI, no matter how small
- Exception files (direct to main): `TODO.md`, `todo/`, `VERIFY.md`
- Everything else: worktree + PR + CI, no exceptions

## Context

The auto-dispatch label removal (issue-sync-helper.sh, 5 lines deleted) was pushed directly to main without PR/CI. The existing rule said "planning-only files go direct to main" but didn't explicitly state the inverse — that all other changes require a PR. This made it easy to rationalize skipping CI for "trivial" changes.

## Changes

| File | Change |
|------|--------|
| `.agents/AGENTS.md` | Add "PR required for ALL non-planning changes" paragraph |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidelines to clarify code change workflow requirements, specifying that all non-planning modifications must proceed through a standardized development pipeline rather than direct main branch edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->