### PR TITLE
t296: Auto-create batches on auto-pickup

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -113,7 +113,7 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **Dependencies**: `blocked-by:t001`, `blocks:t002`, `t001.1` (subtask)
 
-**Auto-dispatch**: Add `#auto-dispatch` to tasks that can run autonomously (clear spec, bounded scope, no user input needed). Default to including it — only omit when a specific exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria. The supervisor's Phase 0 picks these up automatically every 2 minutes.
+**Auto-dispatch**: Add `#auto-dispatch` to tasks that can run autonomously (clear spec, bounded scope, no user input needed). Default to including it — only omit when a specific exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria. The supervisor's Phase 0 picks these up automatically every 2 minutes and auto-creates batches (`auto-YYYYMMDD-HHMMSS`, concurrency 3) when no active batch exists.
 
 **Task completion rules** (CRITICAL - prevents false completion cascade):
 - NEVER mark a task `[x]` unless a merged PR exists with real deliverables for that task


### PR DESCRIPTION
## Summary

- When `cmd_auto_pickup` picks up `#auto-dispatch` tasks, they are now automatically assigned to a batch
- If an active batch exists (has non-terminal tasks), new tasks are added to it
- If no active batch exists, creates a new `auto-YYYYMMDD-HHMMSS` batch with concurrency 3
- Previously, auto-picked tasks were unbatched — dispatched globally without batch-level concurrency control, completion tracking, or auto-release

## Problem

The cron pulse runs `auto-pickup` every 2 minutes, which scans TODO.md for `#auto-dispatch` tasks and adds them to the supervisor DB. But `cmd_add` doesn't assign tasks to any batch. Phase 2 of the pulse dispatches unbatched tasks globally, bypassing batch concurrency limits and losing batch-level features (completion tracking, retrospectives, auto-release).

## Solution

Added auto-batching logic at the end of `cmd_auto_pickup`:
1. After picking up tasks, find unbatched queued tasks
2. Check for an active batch (any batch with non-terminal tasks)
3. If active batch exists → add tasks to it (appends at next position)
4. If no active batch → create `auto-YYYYMMDD-HHMMSS` with concurrency 3

## Testing

- Bash syntax check: pass
- ShellCheck (warning level): zero new violations (only pre-existing SC2034)
- Logic review: handles edge cases (empty pickup, existing batch, no batch)

## Files Changed

- `.agents/scripts/supervisor-helper.sh` — auto-batch logic in `cmd_auto_pickup`, updated help text
- `.agents/AGENTS.md` — updated auto-dispatch documentation

Ref #1155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-dispatch system now automatically creates batches (auto-YYYYMMDD-HHMMSS format with concurrency 3) when no active batch exists.
  * Auto-pickup process automatically batches unbatched tasks to existing active batches or creates new batches as needed.
  * Enhanced logging for batch creation and task batching operations.
  * Updated documentation for auto-pickup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->