### PR TITLE
feat: add Homebrew install offer and Beads binary download fallback for Linux

### DIFF
--- a/.agents/scripts/beads-sync-helper.sh
+++ b/.agents/scripts/beads-sync-helper.sh
@@ -122,7 +122,8 @@ check_beads_installed() {
     if ! command -v bd &> /dev/null; then
         log_error "Beads CLI (bd) not found"
         log_info "Install with: brew install steveyegge/beads/bd"
-        log_info "Or: curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash"
+        log_info "Or download binary: https://github.com/steveyegge/beads/releases"
+        log_info "Or via Go: go install github.com/steveyegge/beads/cmd/bd@latest"
         return 1
     fi
     return 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1107,7 +1107,8 @@ EOF
         if ! command -v bd &> /dev/null; then
             print_warning "Beads CLI (bd) not installed"
             echo "  Install with: brew install steveyegge/beads/bd"
-            echo "  Or: go install github.com/steveyegge/beads/cmd/bd@latest"
+            echo "  Or download: https://github.com/steveyegge/beads/releases"
+            echo "  Or via Go:   go install github.com/steveyegge/beads/cmd/bd@latest"
         else
             # Initialize Beads in the project
             if [[ ! -d "$project_root/.beads" ]]; then


### PR DESCRIPTION
## Summary

- On fresh Linux servers (Ubuntu, etc.) without Homebrew or Go, `setup.sh` hit a dead end when installing the Beads CLI -- it could only print manual install instructions
- This was reported by a user who installed aidevops on a fresh Ubuntu server

## Changes

### New: `ensure_homebrew()` function (setup.sh)
- Offers to install Linuxbrew when `brew` is not available and a tool needs it
- Interactive prompt (Y/n) -- skipped in non-interactive mode
- Installs Linuxbrew prerequisites via apt/dnf/yum automatically
- Uses the existing `verified_install` pattern (download-verify-execute, not curl|sh)
- Adds Homebrew to PATH for the current session and persists to shell rc files

### New: `install_beads_binary()` function (setup.sh)
- Downloads prebuilt `bd` binary directly from GitHub releases
- Supports linux/darwin, amd64/arm64
- Queries GitHub API for latest version tag
- Installs to `/usr/local/bin` (with sudo) or `~/.local/bin` (fallback)
- This is the **primary fallback** -- faster and lighter than installing Homebrew

### New: `install_beads_go()` helper (setup.sh)
- Extracted from inline code for reuse in the fallback chain

### Updated: `setup_beads()` fallback chain
**Before:** brew → go → print manual instructions (dead end)
**After:** brew → go → binary download → offer Homebrew install → manual instructions

### Updated: install hints
- `beads-sync-helper.sh` and `aidevops.sh` now include the binary download URL alongside brew and go options

## Testing

- `bash -n` syntax check: all 3 files pass
- `shellcheck -x`: zero new findings (all pre-existing)
- Verified Beads publishes prebuilt binaries for linux_amd64 and linux_arm64