### PR TITLE
t300: Fix Phase 10b SUPERVISOR_STATE_DIR error

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -10216,7 +10216,7 @@ cmd_pulse() {
     # Converts CodeRabbit and quality-sweep findings into TODO.md tasks.
     # Self-throttles with 24h cooldown. Only runs if task creator script exists.
     local task_creator_script="${SCRIPT_DIR}/coderabbit-task-creator-helper.sh"
-    local task_creation_cooldown_file="${SUPERVISOR_STATE_DIR}/task-creation-last-run"
+    local task_creation_cooldown_file="${SUPERVISOR_DIR}/task-creation-last-run"
     local task_creation_cooldown=86400  # 24 hours
     if [[ -x "$task_creator_script" ]]; then
         local should_run_task_creation=true


### PR DESCRIPTION
Fix SUPERVISOR_STATE_DIR unbound variable error in Phase 10b

Phase 10b was failing with "SUPERVISOR_STATE_DIR: unbound variable" error, preventing the self-improvement loop from creating TODO tasks from quality findings.

Root cause: SUPERVISOR_STATE_DIR was never defined in supervisor-helper.sh
Fix: Replace SUPERVISOR_STATE_DIR with SUPERVISOR_DIR (defined on line 167)

This unblocks the Phase 10b self-improvement loop verification.

Ref #1172