### PR TITLE
t306: Fix namespace validation in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -282,6 +282,24 @@ create_backup_with_rotation() {
     return 0
 }
 
+# Validate namespace string for safe use in paths and shell commands
+# Returns 0 if valid, 1 if invalid
+# Valid: alphanumeric, dash, underscore, forward slash (no .., no shell metacharacters)
+validate_namespace() {
+    local ns="$1"
+    # Reject empty
+    [[ -z "$ns" ]] && return 1
+    # Reject path traversal
+    [[ "$ns" == *".."* ]] && return 1
+    # Reject shell metacharacters and dangerous characters
+    [[ "$ns" =~ [^a-zA-Z0-9/_-] ]] && return 1
+    # Reject absolute paths
+    [[ "$ns" == /* ]] && return 1
+    # Reject trailing slash (causes issues with rsync/tar exclusions)
+    [[ "$ns" == */ ]] && return 1
+    return 0
+}
+
 # Remove deprecated agent paths that have been moved
 # This ensures clean upgrades when agents are reorganized
 cleanup_deprecated_paths() {
@@ -3052,7 +3070,13 @@ deploy_aidevops_agents() {
     local -a plugin_namespaces=()
     if [[ -f "$plugins_file" ]] && command -v jq &>/dev/null; then
         while IFS= read -r ns; do
-            [[ -n "$ns" ]] && plugin_namespaces+=("$ns")
+            if [[ -n "$ns" ]]; then
+                if validate_namespace "$ns"; then
+                    plugin_namespaces+=("$ns")
+                else
+                    print_warning "Skipping invalid plugin namespace: '$ns' (contains unsafe characters or path traversal)"
+                fi
+            fi
         done < <(jq -r '.plugins[].namespace // empty' "$plugins_file" 2>/dev/null)
     fi
     
@@ -3249,6 +3273,10 @@ deploy_plugins() {
     local disabled_ns
     while IFS= read -r disabled_ns; do
         [[ -z "$disabled_ns" ]] && continue
+        if ! validate_namespace "$disabled_ns"; then
+            print_warning "Skipping invalid disabled plugin namespace: '$disabled_ns' (contains unsafe characters or path traversal)"
+            continue
+        fi
         if [[ -d "$target_dir/$disabled_ns" ]]; then
             rm -rf "${target_dir:?}/${disabled_ns:?}"
             print_info "  Removed disabled plugin directory: $disabled_ns"
@@ -3264,6 +3292,14 @@ deploy_plugins() {
     # Process each enabled plugin
     while IFS=$'\t' read -r pname prepo pns pbranch; do
         [[ -z "$pname" ]] && continue
+
+        # Validate namespace before use in paths
+        if ! validate_namespace "$pns"; then
+            print_warning "Skipping plugin '$pname' with invalid namespace: '$pns' (contains unsafe characters or path traversal)"
+            failed=$((failed + 1))
+            continue
+        fi
+
         pbranch="${pbranch:-main}"
         local clone_dir="$target_dir/$pns"
         


### PR DESCRIPTION
## Summary

- Add `validate_namespace()` function to reject path traversal, shell metacharacters, absolute paths, and empty/trailing-slash namespaces
- Validate all three unvalidated namespace entry points in `setup.sh`:
  1. `deploy_aidevops_agents()` — namespace collection for rsync exclusions and preserve lists
  2. `deploy_plugins()` — disabled plugin cleanup (`rm -rf`)
  3. `deploy_plugins()` — enabled plugin processing (path construction + `git clone`)
- Single top-level function avoids duplication across both functions

## Security Impact

Without validation, a malicious `plugins.json` namespace like `../../../etc` could:
- Escape the target directory via rsync exclusion manipulation
- Delete arbitrary directories via `rm -rf "$target_dir/$disabled_ns"`
- Clone repos to arbitrary paths via `git clone ... "$target_dir/$pns"`

## Testing

- `bash -n setup.sh` — syntax OK
- `shellcheck -x -S warning setup.sh` — zero violations
- 19/19 unit test cases pass (valid + invalid namespace patterns)

Fixes: t306 Ref #1179