### PR TITLE
chore: advise removing empty x86 Homebrew in setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2220,7 +2220,9 @@ setup_rosetta_audit() {
     local total=$((x86_only_count + dup_count))
 
     if [[ "$total" -eq 0 ]]; then
-        print_success "No x86 Homebrew packages found — clean ARM setup"
+        print_success "No x86 Homebrew packages remaining"
+        echo "  x86 Homebrew is empty. You can remove it to reclaim disk space:"
+        echo "    sudo rm -rf /usr/local/Homebrew /usr/local/bin/brew /usr/local/Cellar"
         return 0
     fi
 


### PR DESCRIPTION
## Summary

- When `setup_rosetta_audit` detects x86 Homebrew with zero packages, it now advises the user to remove it with `sudo rm -rf /usr/local/Homebrew /usr/local/bin/brew /usr/local/Cellar`
- Previously it just said "clean ARM setup" which didn't tell the user they could reclaim disk space
- Does not auto-remove (requires sudo, destructive) — advisory only