### PR TITLE
feat: add Phase 10b to auto-create TODO tasks from quality findings (t299)

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -10270,12 +10270,12 @@ cmd_pulse() {
             fi
         fi
         
-        # Create tasks from quality-sweep findings
-        local quality_sweep="${SCRIPT_DIR}/quality-sweep-helper.sh"
-        if [[ -x "$quality_sweep" ]]; then
+        # Create tasks from quality-sweep findings (SonarCloud, Codacy)
+        local finding_to_task="${SCRIPT_DIR}/finding-to-task-helper.sh"
+        if [[ -x "$finding_to_task" ]]; then
             log_verbose "    Converting quality-sweep findings to tasks..."
             local sweep_output
-            sweep_output=$("$quality_sweep" tasks 2>>"$SUPERVISOR_LOG" || true)
+            sweep_output=$("$finding_to_task" create --min-severity medium --limit 10 2>>"$SUPERVISOR_LOG" || true)
             
             if [[ -n "$sweep_output" ]] && echo "$sweep_output" | grep -q "^- \[ \]"; then
                 # Append tasks to TODO.md

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -10213,91 +10213,102 @@ cmd_pulse() {
     fi
 
     # Phase 10b: Auto-create TODO tasks from quality findings (t299)
-    # Converts CodeRabbit and quality-sweep findings into TODO.md tasks.
-    # Self-throttles with 24h cooldown. Only runs if task creator script exists.
-    local task_creator_script="${SCRIPT_DIR}/coderabbit-task-creator-helper.sh"
-    local task_creation_cooldown_file="${SUPERVISOR_DIR}/task-creation-last-run"
-    local task_creation_cooldown=86400  # 24 hours
-    if [[ -x "$task_creator_script" ]]; then
-        local should_run_task_creation=true
-        if [[ -f "$task_creation_cooldown_file" ]]; then
-            local last_run
-            last_run=$(cat "$task_creation_cooldown_file" 2>/dev/null || echo "0")
-            local now
-            now=$(date +%s)
-            local elapsed=$((now - last_run))
-            if [[ $elapsed -lt $task_creation_cooldown ]]; then
-                should_run_task_creation=false
-                local remaining=$(( (task_creation_cooldown - elapsed) / 3600 ))
-                log_verbose "  Phase 10b: Task creation skipped (${remaining}h until next run)"
+    # Converts CodeRabbit and quality-sweep findings into actionable TODO tasks with #auto-dispatch.
+    # Self-throttles with 24h cooldown to avoid task spam.
+    local task_creation_cooldown=86400  # 24 hours in seconds
+    local task_creation_state_file="${SUPERVISOR_DIR}/last-task-creation.json"
+    local should_create_tasks=false
+    
+    # Check cooldown
+    if [[ -f "$task_creation_state_file" ]]; then
+        local last_run
+        last_run=$(jq -r '.timestamp // 0' "$task_creation_state_file" 2>/dev/null || echo "0")
+        local now
+        now=$(date +%s)
+        local age=$((now - last_run))
+        
+        if [[ "$age" -ge "$task_creation_cooldown" ]]; then
+            should_create_tasks=true
+            log_verbose "  Phase 10b: Task creation cooldown expired (${age}s >= ${task_creation_cooldown}s)"
+        else
+            local remaining=$((task_creation_cooldown - age))
+            log_verbose "  Phase 10b: Task creation cooldown active (${remaining}s remaining)"
+        fi
+    else
+        should_create_tasks=true
+        log_verbose "  Phase 10b: First task creation run"
+    fi
+    
+    if [[ "$should_create_tasks" == "true" ]]; then
+        log_verbose "  Phase 10b: Creating tasks from quality findings"
+        
+        # Get repo path for TODO.md
+        local pulse_repo=""
+        pulse_repo=$(db "$SUPERVISOR_DB" "SELECT DISTINCT repo FROM tasks LIMIT 1;" 2>/dev/null || echo "")
+        if [[ -z "$pulse_repo" ]]; then
+            pulse_repo="$(pwd)"
+        fi
+        
+        local todo_file="${pulse_repo}/TODO.md"
+        local tasks_created=false
+        
+        # Create tasks from CodeRabbit findings
+        local coderabbit_creator="${SCRIPT_DIR}/coderabbit-task-creator-helper.sh"
+        if [[ -x "$coderabbit_creator" ]]; then
+            log_verbose "    Converting CodeRabbit findings to tasks..."
+            local coderabbit_output
+            coderabbit_output=$("$coderabbit_creator" create 2>>"$SUPERVISOR_LOG" || true)
+            
+            if [[ -n "$coderabbit_output" ]] && echo "$coderabbit_output" | grep -q "^- \[ \]"; then
+                # Append tasks to TODO.md
+                echo "" >> "$todo_file"
+                echo "$coderabbit_output" >> "$todo_file"
+                tasks_created=true
+                local task_count
+                task_count=$(echo "$coderabbit_output" | grep -c "^- \[ \]" || echo "0")
+                log_verbose "    Created $task_count tasks from CodeRabbit findings"
             fi
         fi
-
-        if [[ "$should_run_task_creation" == "true" ]]; then
-            log_info "  Phase 10b: Auto-creating tasks from quality findings"
-            date +%s > "$task_creation_cooldown_file"
-
-            # Determine repo for TODO.md
-            local task_repo=""
-            task_repo=$(db "$SUPERVISOR_DB" "SELECT DISTINCT repo FROM tasks LIMIT 1;" 2>/dev/null || echo "")
-            if [[ -z "$task_repo" ]]; then
-                task_repo="$(pwd)"
-            fi
-            local todo_file="$task_repo/TODO.md"
-
-            if [[ -f "$todo_file" ]]; then
-                local tasks_added=0
-
-                # 1. CodeRabbit findings → tasks
-                local cr_output
-                cr_output=$(bash "$task_creator_script" create 2>>"$SUPERVISOR_LOG" || echo "")
-                if [[ -n "$cr_output" ]]; then
-                    # Extract task lines between the markers
-                    local cr_tasks
-                    cr_tasks=$(echo "$cr_output" | sed -n '/=== Task Lines/,/===$/p' | grep -E '^\s*- \[ \]' || true)
-                    if [[ -n "$cr_tasks" ]]; then
-                        # Find next task ID
-                        local max_id
-                        max_id=$(grep -oE 't[0-9]+' "$todo_file" | grep -oE '[0-9]+' | sort -n | tail -1 || echo "0")
-                        max_id=$((10#$max_id))
-
-                        # Append each task with a unique ID
-                        while IFS= read -r task_line; do
-                            max_id=$((max_id + 1))
-                            # Replace placeholder or add task ID
-                            local new_line
-                            new_line=$(echo "$task_line" | sed -E "s/^(\s*- \[ \] )/\1t${max_id} /")
-                            # Ensure #auto-dispatch tag and source tag
-                            if ! echo "$new_line" | grep -q '#auto-dispatch'; then
-                                new_line="$new_line #auto-dispatch"
-                            fi
-                            if ! echo "$new_line" | grep -q '#auto-review'; then
-                                new_line="$new_line #auto-review"
-                            fi
-                            new_line="$new_line logged:$(date +%Y-%m-%d)"
-                            # Append after the last open task line
-                            echo "$new_line" >> "$todo_file"
-                            tasks_added=$((tasks_added + 1))
-                            log_info "    Created t${max_id} from CodeRabbit finding"
-                        done <<< "$cr_tasks"
-                    fi
-                fi
-
-                # 2. Commit and push if tasks were added
-                if [[ $tasks_added -gt 0 ]]; then
-                    log_info "  Phase 10b: Added $tasks_added task(s) to TODO.md"
-                    if git -C "$task_repo" add TODO.md 2>>"$SUPERVISOR_LOG" && \
-                       git -C "$task_repo" commit -m "chore: auto-create $tasks_added task(s) from quality findings (Phase 10b)" 2>>"$SUPERVISOR_LOG" && \
-                       git -C "$task_repo" push 2>>"$SUPERVISOR_LOG"; then
-                        log_success "  Phase 10b: Committed and pushed $tasks_added new task(s)"
-                    else
-                        log_warn "  Phase 10b: Failed to commit/push TODO.md changes"
-                    fi
-                else
-                    log_verbose "  Phase 10b: No new tasks to create"
-                fi
+        
+        # Create tasks from quality-sweep findings
+        local quality_sweep="${SCRIPT_DIR}/quality-sweep-helper.sh"
+        if [[ -x "$quality_sweep" ]]; then
+            log_verbose "    Converting quality-sweep findings to tasks..."
+            local sweep_output
+            sweep_output=$("$quality_sweep" tasks 2>>"$SUPERVISOR_LOG" || true)
+            
+            if [[ -n "$sweep_output" ]] && echo "$sweep_output" | grep -q "^- \[ \]"; then
+                # Append tasks to TODO.md
+                echo "" >> "$todo_file"
+                echo "$sweep_output" >> "$todo_file"
+                tasks_created=true
+                local task_count
+                task_count=$(echo "$sweep_output" | grep -c "^- \[ \]" || echo "0")
+                log_verbose "    Created $task_count tasks from quality-sweep findings"
             fi
         fi
+        
+        # Commit and push TODO.md if tasks were created
+        if [[ "$tasks_created" == "true" ]]; then
+            log_verbose "    Committing and pushing TODO.md updates..."
+            (
+                cd "$pulse_repo" || exit 1
+                git add TODO.md 2>>"$SUPERVISOR_LOG" || true
+                git commit -m "chore: auto-create tasks from quality findings (t299)" 2>>"$SUPERVISOR_LOG" || true
+                git push 2>>"$SUPERVISOR_LOG" || true
+            )
+        fi
+        
+        # Update cooldown state
+        mkdir -p "$SUPERVISOR_DIR"
+        cat > "$task_creation_state_file" << EOF
+{
+  "timestamp": $(date +%s),
+  "date": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "tasks_created": $tasks_created
+}
+EOF
+        log_verbose "  Phase 10b: Task creation complete"
     fi
 
     # Phase 11: Supervisor session memory monitoring + respawn (t264, t264.1)


### PR DESCRIPTION
## Summary

- Adds Phase 10b to the supervisor pulse cycle: auto-creates TODO tasks from CodeRabbit/quality findings
- Uses `finding-to-task-helper.sh` for task creation instead of inline logic
- Closes the self-improvement loop: quality findings -> TODO tasks -> auto-dispatch -> PRs

Replaces closed PR #1171 (was closed during blocked state, couldn't reopen after force-push).

Closes #1172