### PR TITLE
feat: queue priority - fresh tasks before retries (t313)

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -3690,7 +3690,7 @@ cmd_next() {
             WHERE bt.batch_id = '$escaped_batch'
             AND t.status = 'queued'
             AND t.retries < t.max_retries
-            ORDER BY bt.position
+            ORDER BY t.retries ASC, bt.position
             LIMIT $limit;
         "
     else
@@ -3699,7 +3699,7 @@ cmd_next() {
             FROM tasks
             WHERE status = 'queued'
             AND retries < max_retries
-            ORDER BY created_at ASC
+            ORDER BY retries ASC, created_at ASC
             LIMIT $limit;
         "
     fi


### PR DESCRIPTION
## Summary

- Modifies `cmd_next()` dispatch ordering to sort by `retries ASC` first, ensuring fresh tasks (retries=0) always dispatch before retried tasks
- Only 2 queries changed — both in `cmd_next()` (batch dispatch and global dispatch)
- Informational queries (status, dashboard, release) left unchanged — retry ordering is irrelevant there

## Problem

When failed tasks get reset and re-queued, they could consume all dispatch slots, blocking fresh tasks that have a better chance of succeeding. This wastes worker tokens on tasks that already failed once.

## Changes

| Location | Before | After |
|----------|--------|-------|
| `cmd_next()` batch query (L3693) | `ORDER BY bt.position` | `ORDER BY t.retries ASC, bt.position` |
| `cmd_next()` global query (L3702) | `ORDER BY created_at ASC` | `ORDER BY retries ASC, created_at ASC` |

## Testing

- `bash -n` syntax check: PASS
- ShellCheck: no new warnings
- Diff is exactly 2 insertions, 2 deletions

Closes #313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined task dispatch logic to prioritize task execution based on retry history. Tasks with fewer previous retry attempts are now processed earlier in both batch and standalone task queues, improving overall dispatch efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->