### PR TITLE
fix: add SUPERVISOR_SKIP_STALENESS env var for create-task false positives

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -3283,6 +3283,11 @@ check_task_already_done() {
 # Output (stdout): staleness reason if stale/uncertain, empty if current
 #######################################
 check_task_staleness() {
+    # Allow bypassing staleness check via env var (t314: for create tasks that reference non-existent files)
+    if [[ "${SUPERVISOR_SKIP_STALENESS:-false}" == "true" ]]; then
+        return 1  # Assume current
+    fi
+
 	local task_id="${1:-}"
 	local task_description="${2:-}"
 	local project_root="${3:-.}"
@@ -15064,6 +15069,7 @@ Environment:
   SUPERVISOR_SELF_HEAL        Enable/disable self-healing (default: true)
   SUPERVISOR_AUTO_ISSUE       Enable/disable GitHub issue creation (default: false)
   SUPERVISOR_SKIP_REVIEW_TRIAGE Skip review triage before merge (default: false)
+  SUPERVISOR_SKIP_STALENESS    Skip pre-dispatch staleness check (default: false)
   SUPERVISOR_WORKER_TIMEOUT   Seconds before a hung worker is killed (default: 3600)
   SUPERVISOR_SELF_MEM_LIMIT   MB before supervisor respawns after batch (default: 8192)
   AIDEVOPS_SUPERVISOR_DIR     Override supervisor data directory


### PR DESCRIPTION
## Summary

- Adds `SUPERVISOR_SKIP_STALENESS=true` env var to bypass the pre-dispatch staleness check (t312)
- Needed for tasks that CREATE new files/directories — the staleness check flags them as MISSING_FILES because the referenced paths don't exist yet (that's the whole point of the task)

## Problem

t311.2 ("Create module skeleton for supervisor-helper.sh") and t311.3 ("Extract supervisor modules") were repeatedly cancelled by the staleness check because they reference `supervisor/` directory and module files that don't exist yet. The `PARENT_REMOVED` signal also false-triggered because the staleness handler's own commit (removing `#auto-dispatch`) was interpreted as a removal commit.

## Usage

```bash
SUPERVISOR_SKIP_STALENESS=true supervisor-helper.sh dispatch t311.2
```

A proper fix (teaching the staleness check to recognize "Create" tasks) is a separate improvement.

Ref #1210