### PR TITLE
feat: create supervisor module skeleton (t311.2)

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -163,6 +163,27 @@ unset _gh_token_cache
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
+# Source all supervisor module files
+SUPERVISOR_MODULE_DIR="${SCRIPT_DIR}/supervisor"
+source "${SUPERVISOR_MODULE_DIR}/_common.sh"
+source "${SUPERVISOR_MODULE_DIR}/database.sh"
+source "${SUPERVISOR_MODULE_DIR}/state.sh"
+source "${SUPERVISOR_MODULE_DIR}/batch.sh"
+source "${SUPERVISOR_MODULE_DIR}/dispatch.sh"
+source "${SUPERVISOR_MODULE_DIR}/evaluate.sh"
+source "${SUPERVISOR_MODULE_DIR}/pulse.sh"
+source "${SUPERVISOR_MODULE_DIR}/cleanup.sh"
+source "${SUPERVISOR_MODULE_DIR}/cron.sh"
+source "${SUPERVISOR_MODULE_DIR}/lifecycle.sh"
+source "${SUPERVISOR_MODULE_DIR}/deploy.sh"
+source "${SUPERVISOR_MODULE_DIR}/self-heal.sh"
+source "${SUPERVISOR_MODULE_DIR}/release.sh"
+source "${SUPERVISOR_MODULE_DIR}/utility.sh"
+source "${SUPERVISOR_MODULE_DIR}/git-ops.sh"
+source "${SUPERVISOR_MODULE_DIR}/issue-sync.sh"
+source "${SUPERVISOR_MODULE_DIR}/memory-integration.sh"
+source "${SUPERVISOR_MODULE_DIR}/todo-sync.sh"
+
 readonly SCRIPT_DIR
 readonly SUPERVISOR_DIR="${AIDEVOPS_SUPERVISOR_DIR:-$HOME/.aidevops/.agent-workspace/supervisor}"
 readonly SUPERVISOR_DB="$SUPERVISOR_DIR/supervisor.db"

--- a/.agents/scripts/supervisor/_common.sh
+++ b/.agents/scripts/supervisor/_common.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# _common.sh - Shared helpers for supervisor modules
+#
+# Provides common functions used across all supervisor modules:
+# - db(): SQLite wrapper with busy_timeout
+# - log_*(): Structured logging functions
+# - sql_escape(): SQL string escaping
+# - log_cmd(): Command execution with stderr logging
+
+set -euo pipefail
+
+#######################################
+# SQLite wrapper: sets busy_timeout on every connection
+# busy_timeout is per-connection and must be set each time
+# Arguments:
+#   $1 - database path
+#   $2+ - SQL commands or options
+#######################################
+db() {
+	sqlite3 -cmd ".timeout 5000" "$@"
+}
+
+#######################################
+# Structured logging functions
+# All output to stderr with color-coded prefixes
+#######################################
+log_info() {
+	echo -e "${BLUE}[SUPERVISOR]${NC} $*" >&2
+}
+
+log_success() {
+	echo -e "${GREEN}[SUPERVISOR]${NC} $*" >&2
+}
+
+log_warn() {
+	echo -e "${YELLOW}[SUPERVISOR]${NC} $*" >&2
+}
+
+log_error() {
+	echo -e "${RED}[SUPERVISOR]${NC} $*" >&2
+}
+
+log_verbose() {
+	[[ "${SUPERVISOR_VERBOSE:-}" == "true" ]] && echo -e "${BLUE}[SUPERVISOR]${NC} $*" >&2 || true
+}
+
+#######################################
+# Escape single quotes for SQL
+# Arguments:
+#   $1 - input string
+# Returns:
+#   Escaped string on stdout
+#######################################
+sql_escape() {
+	local input="$1"
+	echo "${input//\'/\'\'}"
+}
+
+#######################################
+# Log stderr from a command to the supervisor log file
+# Preserves exit code. Use for DB writes, API calls, state transitions.
+# Arguments:
+#   $1 - context label
+#   $2+ - command and arguments
+# Returns:
+#   Exit code from the command
+#######################################
+log_cmd() {
+	local context="$1"
+	shift
+	local ts
+	ts="$(date '+%H:%M:%S' 2>/dev/null || echo "?")"
+	echo "[$ts] [$context] $*" >>"${SUPERVISOR_LOG:-/dev/null}" 2>/dev/null || true
+	"$@" 2>>"${SUPERVISOR_LOG:-/dev/null}"
+	local rc=$?
+	[[ $rc -ne 0 ]] && echo "[$ts] [$context] exit=$rc" >>"${SUPERVISOR_LOG:-/dev/null}" 2>/dev/null || true
+	return $rc
+}

--- a/.agents/scripts/supervisor/batch.sh
+++ b/.agents/scripts/supervisor/batch.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# batch.sh - Batch management functions
+#
+# Functions for creating, managing, and querying batches
+
+set -euo pipefail
+
+#######################################
+# Create a new batch
+# TODO: Implementation
+#######################################
+create_batch() {
+	log_error "create_batch: not yet implemented"
+	return 1
+}
+
+#######################################
+# List batches
+# TODO: Implementation
+#######################################
+list_batches() {
+	log_error "list_batches: not yet implemented"
+	return 1
+}
+
+#######################################
+# Get batch status
+# TODO: Implementation
+#######################################
+get_batch_status() {
+	log_error "get_batch_status: not yet implemented"
+	return 1
+}
+
+#######################################
+# Cancel a batch
+# TODO: Implementation
+#######################################
+cancel_batch() {
+	log_error "cancel_batch: not yet implemented"
+	return 1
+}

--- a/.agents/scripts/supervisor/cleanup.sh
+++ b/.agents/scripts/supervisor/cleanup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# cleanup.sh - Cleanup and maintenance functions
+#
+# Functions for cleaning up completed worktrees, processes, and resources
+
+set -euo pipefail
+
+#######################################
+# Clean up completed worktrees
+# TODO: Implementation
+#######################################
+cleanup_worktrees() {
+	log_error "cleanup_worktrees: not yet implemented"
+	return 1
+}
+
+#######################################
+# Kill orphaned worker processes
+# TODO: Implementation
+#######################################
+kill_orphaned_workers() {
+	log_error "kill_orphaned_workers: not yet implemented"
+	return 1
+}
+
+#######################################
+# Clean up stale PID files
+# TODO: Implementation
+#######################################
+cleanup_pid_files() {
+	log_error "cleanup_pid_files: not yet implemented"
+	return 1
+}

--- a/.agents/scripts/supervisor/cron.sh
+++ b/.agents/scripts/supervisor/cron.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# cron.sh - Cron pulse management functions
+#
+# Functions for installing, managing, and monitoring cron-based pulse scheduling
+
+set -euo pipefail
+
+#######################################
+# Install cron pulse
+# TODO: Implementation
+#######################################
+install_cron_pulse() {
+	log_error "install_cron_pulse: not yet implemented"
+	return 1
+}
+
+#######################################
+# Uninstall cron pulse
+# TODO: Implementation
+#######################################
+uninstall_cron_pulse() {
+	log_error "uninstall_cron_pulse: not yet implemented"
+	return 1
+}
+
+#######################################
+# Get cron pulse status
+# TODO: Implementation
+#######################################
+get_cron_status() {
+	log_error "get_cron_status: not yet implemented"
+	return 1
+}

--- a/.agents/scripts/supervisor/database.sh
+++ b/.agents/scripts/supervisor/database.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# database.sh - Database initialization and migration functions
+#
+# Functions for database schema management, migrations, and backups
+
+set -euo pipefail
+
+#######################################
+# Initialize supervisor database
+# TODO: Implementation
+#######################################
+init_db() {
+	log_error "init_db: not yet implemented"
+	return 1
+}
+
+#######################################
+# Run database migration
+# TODO: Implementation
+#######################################
+migrate_db() {
+	log_error "migrate_db: not yet implemented"
+	return 1
+}
+
+#######################################
+# Backup database
+# TODO: Implementation
+#######################################
+backup_db() {
+	log_error "backup_db: not yet implemented"
+	return 1
+}
+
+#######################################
+# Restore database from backup
+# TODO: Implementation
+#######################################
+restore_db() {
+	log_error "restore_db: not yet implemented"
+	return 1
+}

--- a/.agents/scripts/supervisor/deploy.sh
+++ b/.agents/scripts/supervisor/deploy.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# deploy.sh - Deployment functions
+#
+# Functions for deploying completed tasks
+
+set -euo pipefail
+
+#######################################
+# Deploy a completed task
+# TODO: Implementation
+#######################################
+deploy_task() {
+	log_error "deploy_task: not yet implemented"
+	return 1
+}
+
+#######################################
+# Check deployment status
+# TODO: Implementation
+#######################################
+check_deployment_status() {
+	log_error "check_deployment_status: not yet implemented"
+	return 1
+}
+
+#######################################
+# Rollback a deployment
+# TODO: Implementation
+#######################################
+rollback_deployment() {
+	log_error "rollback_deployment: not yet implemented"
+	return 1
+}

--- a/.agents/scripts/supervisor/dispatch.sh
+++ b/.agents/scripts/supervisor/dispatch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# dispatch.sh - Task dispatch functions
+#
+# Functions for dispatching tasks to workers
+
+set -euo pipefail
+
+#######################################
+# Dispatch a task to a worker
+# TODO: Implementation
+#######################################
+dispatch_task() {
+	log_error "dispatch_task: not yet implemented"
+	return 1
+}
+
+#######################################
+# Check if a task can be dispatched
+# TODO: Implementation
+#######################################
+can_dispatch() {
+	log_error "can_dispatch: not yet implemented"
+	return 1
+}
+
+#######################################
+# Get next task to dispatch
+# TODO: Implementation
+#######################################
+get_next_task() {
+	log_error "get_next_task: not yet implemented"
+	return 1
+}

--- a/.agents/scripts/supervisor/evaluate.sh
+++ b/.agents/scripts/supervisor/evaluate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# evaluate.sh - Task evaluation functions
+#
+# Functions for evaluating worker outcomes
+
+set -euo pipefail
+
+#######################################
+# Evaluate a worker's outcome
+# TODO: Implementation
+#######################################
+evaluate_task() {
+	log_error "evaluate_task: not yet implemented"
+	return 1
+}
+
+#######################################
+# Parse worker exit signals
+# TODO: Implementation
+#######################################
+parse_exit_signals() {
+	log_error "parse_exit_signals: not yet implemented"
+	return 1
+}
+
+#######################################
+# Run AI evaluation
+# TODO: Implementation
+#######################################
+run_ai_evaluation() {
+	log_error "run_ai_evaluation: not yet implemented"
+	return 1
+}
+
+#######################################
+# Check quality gate
+# TODO: Implementation
+#######################################
+check_quality_gate() {
+	log_error "check_quality_gate: not yet implemented"
+	return 1
+}

--- a/.agents/scripts/supervisor/git-ops.sh
+++ b/.agents/scripts/supervisor/git-ops.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# git-ops.sh - Git operations for supervisor
+#
+# Provides git-related functions for the supervisor:
+# - Branch creation and switching
+# - Commit and push operations
+# - Worktree management
+# - Git state queries
+
+set -euo pipefail
+
+#######################################
+# Create a new branch for a task
+# Arguments:
+#   $1 - task ID
+#   $2 - branch name
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+create_task_branch() {
+	:
+}
+
+#######################################
+# Commit changes for a task
+# Arguments:
+#   $1 - task ID
+#   $2 - commit message
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+commit_task_changes() {
+	:
+}
+
+#######################################
+# Push branch to remote
+# Arguments:
+#   $1 - branch name
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+push_branch() {
+	:
+}
+
+#######################################
+# Check if working directory is clean
+# Returns:
+#   0 if clean, 1 if dirty
+#######################################
+is_working_directory_clean() {
+	:
+}
+
+#######################################
+# Get current branch name
+# Returns:
+#   Branch name on stdout
+#######################################
+get_current_branch() {
+	:
+}
+
+#######################################
+# Create or switch to worktree
+# Arguments:
+#   $1 - task ID
+#   $2 - branch name
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+manage_worktree() {
+	:
+}
+
+#######################################
+# Clean up merged worktrees
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+cleanup_merged_worktrees() {
+	:
+}

--- a/.agents/scripts/supervisor/issue-sync.sh
+++ b/.agents/scripts/supervisor/issue-sync.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# issue-sync.sh - GitHub issue synchronization for supervisor
+#
+# Provides GitHub issue integration functions:
+# - Create issues from tasks
+# - Update issue status
+# - Sync task state with issues
+# - Link PRs to issues
+
+set -euo pipefail
+
+#######################################
+# Create GitHub issue for a task
+# Arguments:
+#   $1 - task ID
+#   $2 - task description
+# Returns:
+#   Issue number on stdout, 0 on success, 1 on failure
+#######################################
+create_issue_for_task() {
+	:
+}
+
+#######################################
+# Update issue status based on task state
+# Arguments:
+#   $1 - task ID
+#   $2 - issue number
+#   $3 - new state
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+update_issue_status() {
+	:
+}
+
+#######################################
+# Link PR to issue
+# Arguments:
+#   $1 - issue number
+#   $2 - PR number
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+link_pr_to_issue() {
+	:
+}
+
+#######################################
+# Sync task assignee to issue
+# Arguments:
+#   $1 - task ID
+#   $2 - issue number
+#   $3 - assignee
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+sync_assignee_to_issue() {
+	:
+}
+
+#######################################
+# Close issue when task is completed
+# Arguments:
+#   $1 - issue number
+#   $2 - completion message
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+close_completed_issue() {
+	:
+}
+
+#######################################
+# Get issue number from task ID
+# Arguments:
+#   $1 - task ID
+# Returns:
+#   Issue number on stdout, empty if not found
+#######################################
+get_issue_for_task() {
+	:
+}

--- a/.agents/scripts/supervisor/lifecycle.sh
+++ b/.agents/scripts/supervisor/lifecycle.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# lifecycle.sh - Task lifecycle management for supervisor
+#
+# Provides task state transition functions:
+# - State validation and transitions
+# - Lifecycle hooks
+# - State persistence
+# - Lifecycle event logging
+
+set -euo pipefail
+
+#######################################
+# Validate state transition
+# Arguments:
+#   $1 - current state
+#   $2 - target state
+# Returns:
+#   0 if valid, 1 if invalid
+#######################################
+validate_state_transition() {
+	:
+}
+
+#######################################
+# Transition task to new state
+# Arguments:
+#   $1 - task ID
+#   $2 - new state
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+transition_task_state() {
+	:
+}
+
+#######################################
+# Execute pre-transition hook
+# Arguments:
+#   $1 - task ID
+#   $2 - current state
+#   $3 - target state
+# Returns:
+#   0 to proceed, 1 to abort transition
+#######################################
+pre_transition_hook() {
+	:
+}
+
+#######################################
+# Execute post-transition hook
+# Arguments:
+#   $1 - task ID
+#   $2 - previous state
+#   $3 - current state
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+post_transition_hook() {
+	:
+}
+
+#######################################
+# Get valid next states for current state
+# Arguments:
+#   $1 - current state
+# Returns:
+#   Space-separated list of valid next states on stdout
+#######################################
+get_valid_next_states() {
+	:
+}
+
+#######################################
+# Log lifecycle event
+# Arguments:
+#   $1 - task ID
+#   $2 - event type
+#   $3 - event details
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+log_lifecycle_event() {
+	:
+}
+
+#######################################
+# Get task lifecycle history
+# Arguments:
+#   $1 - task ID
+# Returns:
+#   Lifecycle history on stdout
+#######################################
+get_lifecycle_history() {
+	:
+}

--- a/.agents/scripts/supervisor/memory-integration.sh
+++ b/.agents/scripts/supervisor/memory-integration.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# memory-integration.sh - Memory system integration for supervisor
+#
+# Provides memory and pattern tracking integration:
+# - Store task outcomes as memories
+# - Record success/failure patterns
+# - Query relevant memories for tasks
+# - Pattern-based recommendations
+
+set -euo pipefail
+
+#######################################
+# Store task outcome as memory
+# Arguments:
+#   $1 - task ID
+#   $2 - outcome (success/failure)
+#   $3 - details
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+store_task_memory() {
+	:
+}
+
+#######################################
+# Record success pattern
+# Arguments:
+#   $1 - task ID
+#   $2 - task type
+#   $3 - approach used
+#   $4 - model tier
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+record_success_pattern() {
+	:
+}
+
+#######################################
+# Record failure pattern
+# Arguments:
+#   $1 - task ID
+#   $2 - task type
+#   $3 - failure reason
+#   $4 - model tier
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+record_failure_pattern() {
+	:
+}
+
+#######################################
+# Query relevant memories for task
+# Arguments:
+#   $1 - task ID
+#   $2 - task description
+# Returns:
+#   Relevant memories on stdout
+#######################################
+query_task_memories() {
+	:
+}
+
+#######################################
+# Get pattern-based recommendations
+# Arguments:
+#   $1 - task type
+# Returns:
+#   Recommendations on stdout
+#######################################
+get_pattern_recommendations() {
+	:
+}
+
+#######################################
+# Store worker session learnings
+# Arguments:
+#   $1 - task ID
+#   $2 - session output
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+store_session_learnings() {
+	:
+}

--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# pulse.sh - Supervisor pulse cycle orchestration
+#
+# Provides pulse cycle management functions:
+# - Phase execution
+# - Worker health checks
+# - Outcome evaluation
+# - Next task dispatch
+# - Cleanup operations
+
+set -euo pipefail
+
+#######################################
+# Execute full pulse cycle
+# Arguments:
+#   $1 - batch ID (optional)
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+execute_pulse_cycle() {
+	:
+}
+
+#######################################
+# Phase 0: Auto-dispatch check
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+phase_auto_dispatch() {
+	:
+}
+
+#######################################
+# Phase 1: Check worker health
+# Arguments:
+#   $1 - batch ID
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+phase_check_workers() {
+	:
+}
+
+#######################################
+# Phase 2: Evaluate completed tasks
+# Arguments:
+#   $1 - batch ID
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+phase_evaluate_outcomes() {
+	:
+}
+
+#######################################
+# Phase 3: Dispatch next tasks
+# Arguments:
+#   $1 - batch ID
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+phase_dispatch_next() {
+	:
+}
+
+#######################################
+# Phase 4: Cleanup completed workers
+# Arguments:
+#   $1 - batch ID
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+phase_cleanup() {
+	:
+}
+
+#######################################
+# Phase 9: Memory audit
+# Returns:
+#   0 on success, 1 on failure
+#######################################
+phase_memory_audit() {
+	:
+}
+
+#######################################
+# Phase 11: Self memory check and respawn
+# Arguments:
+#   $1 - batch ID
+# Returns:
+#   0 to continue, exits if respawn needed
+#######################################
+phase_self_memory_check() {
+	:
+}
+
+#######################################
+# Check if pulse should run
+# Returns:
+#   0 if should run, 1 if should skip
+#######################################
+should_run_pulse() {
+	:
+}

--- a/.agents/scripts/supervisor/release.sh
+++ b/.agents/scripts/supervisor/release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# release.sh - Supervisor release management functions
+# Part of the AI DevOps Framework supervisor module
+
+# Check if a release is needed based on merged PRs
+check_release_needed() {
+    :
+}
+
+# Determine release type (major/minor/patch) from commits
+determine_release_type() {
+    :
+}
+
+# Create release PR
+create_release_pr() {
+    :
+}
+
+# Execute release workflow
+execute_release() {
+    :
+}

--- a/.agents/scripts/supervisor/self-heal.sh
+++ b/.agents/scripts/supervisor/self-heal.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# self-heal.sh - Supervisor self-healing functions
+# Part of the AI DevOps Framework supervisor module
+
+# Detect stuck workers
+detect_stuck_workers() {
+    :
+}
+
+# Recover failed tasks
+recover_failed_tasks() {
+    :
+}
+
+# Clean up orphaned resources
+cleanup_orphaned_resources() {
+    :
+}
+
+# Restart failed batch
+restart_failed_batch() {
+    :
+}

--- a/.agents/scripts/supervisor/state.sh
+++ b/.agents/scripts/supervisor/state.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# state.sh - Supervisor state management functions
+# Part of the AI DevOps Framework supervisor module
+
+# Get current batch state
+get_batch_state() {
+    :
+}
+
+# Update task state
+update_task_state() {
+    :
+}
+
+# Get worker state
+get_worker_state() {
+    :
+}
+
+# Persist state to database
+persist_state() {
+    :
+}
+
+# Load state from database
+load_state() {
+    :
+}

--- a/.agents/scripts/supervisor/todo-sync.sh
+++ b/.agents/scripts/supervisor/todo-sync.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# todo-sync.sh - Supervisor TODO.md synchronization functions
+# Part of the AI DevOps Framework supervisor module
+
+# Sync task state to TODO.md
+sync_task_to_todo() {
+    :
+}
+
+# Update TODO.md with batch progress
+update_todo_batch_progress() {
+    :
+}
+
+# Mark task complete in TODO.md
+mark_todo_complete() {
+    :
+}
+
+# Add task to TODO.md
+add_task_to_todo() {
+    :
+}
+
+# Parse TODO.md for task metadata
+parse_todo_metadata() {
+    :
+}

--- a/.agents/scripts/supervisor/utility.sh
+++ b/.agents/scripts/supervisor/utility.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# utility.sh - Supervisor utility functions
+# Part of the AI DevOps Framework supervisor module
+
+# Format duration for display
+format_duration() {
+    :
+}
+
+# Calculate task priority
+calculate_priority() {
+    :
+}
+
+# Validate task dependencies
+validate_dependencies() {
+    :
+}
+
+# Generate batch ID
+generate_batch_id() {
+    :
+}
+
+# Send notification
+send_notification() {
+    :
+}


### PR DESCRIPTION
## Summary

Creates `.agents/scripts/supervisor/` directory with 18 module files containing function stubs, wired into `supervisor-helper.sh` via source statements.

Part of t311 modularisation plan. Ref #1199

### Files created
- `_common.sh` — shared helpers (db, logging)
- `batch.sh`, `cleanup.sh`, `cron.sh`, `database.sh`, `deploy.sh`, `dispatch.sh`, `evaluate.sh`, `git-ops.sh`, `issue-sync.sh`, `lifecycle.sh`, `memory-integration.sh`, `pulse.sh`, `release.sh`, `self-heal.sh`, `state.sh`, `todo-sync.sh`, `utility.sh`

### Verification
- `bash -n supervisor-helper.sh` passes (syntax check)
- 19 files changed, 939 insertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established foundational supervisor module architecture with placeholder stubs for task lifecycle management, batch processing, deployment, state management, Git operations, and worker coordination.
  * Added common utilities including logging, database operations, and SQL escaping for the supervisor framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->