### PR TITLE
hotfix: restore t314 timeout values overwritten by concurrent PR merges

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -10508,11 +10508,11 @@ cmd_pulse() {
 	fi
 
 	# Phase 4: Worker health checks - detect dead, hung, and orphaned workers
-	local worker_timeout_seconds="${SUPERVISOR_WORKER_TIMEOUT:-1800}" # 30 min default
+	local worker_timeout_seconds="${SUPERVISOR_WORKER_TIMEOUT:-3600}" # 1 hour default (t314: restored after merge overwrite)
 	# Absolute max runtime: kill workers regardless of log activity.
 	# Prevents runaway workers (e.g., shellcheck on huge files) from accumulating
 	# and exhausting system memory. Default 2 hours.
-	local worker_max_runtime_seconds="${SUPERVISOR_WORKER_MAX_RUNTIME:-7200}" # 2 hour default
+	local worker_max_runtime_seconds="${SUPERVISOR_WORKER_MAX_RUNTIME:-14400}" # 4 hour default (t314: restored after merge overwrite)
 
 	if [[ -d "$SUPERVISOR_DIR/pids" ]]; then
 		for pid_file in "$SUPERVISOR_DIR/pids"/*.pid; do


### PR DESCRIPTION
## Summary

- Restores worker timeout values from t314 that were overwritten by concurrent PR merges
- `SUPERVISOR_WORKER_TIMEOUT`: 1800s → 3600s (1h)
- `SUPERVISOR_WORKER_MAX_RUNTIME`: 7200s → 14400s (4h)

## Root Cause

PRs #1216 (t303) and #1218 (t311.2) were branched before #1215 (t314) merged. Their squash-merges overwrote the timeout changes because they touched the same file. t311.2 then failed again at 1825s with the old 1800s timeout.

Ref #1215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended worker health check timeouts: increased inactivity timeout from 30 minutes to 1 hour and maximum runtime from 2 hours to 4 hours, allowing longer-running operations to complete without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->