### PR TITLE
fix: make oh-my-opencode removal optional, default to keeping it

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -372,7 +372,7 @@ cleanup_deprecated_paths() {
 				rm -f "$omo_config"
 				print_info "Removed oh-my-opencode config"
 			fi
-			if [[ "$has_omo_plugin" == "true" ]] && [[ -n "$opencode_config" ]]; then
+			if [[ "$has_omo_plugin" == "true" ]]; then
 				local tmp_file
 				tmp_file=$(mktemp)
 				trap 'rm -f "${tmp_file:-}"' RETURN


### PR DESCRIPTION
## Summary

- Makes the oh-my-opencode config cleanup in `setup.sh` opt-in instead of automatic
- In interactive mode: prompts with `[y/N]` (default: keep)
- In non-interactive mode: always skips (safe default)
- The deprecated agent doc cleanup (`tools/opencode/oh-my-opencode.md`) is unchanged — it only removes aidevops's own deployed file

## Problem

`setup.sh` unconditionally deleted `~/.config/opencode/oh-my-opencode.json` and removed the OmO plugin entry from `opencode.json` on every install/update. This broke users who independently installed oh-my-opencode alongside aidevops.

## Changes

- `setup.sh`: Refactored OmO cleanup in `cleanup_deprecated_paths()` to detect OmO presence first, then prompt the user (default N) before removing

## Testing

- `bash -n setup.sh` — syntax OK
- `shellcheck -S style setup.sh` — zero new warnings
- Verified logic: non-interactive skips, interactive defaults to N, explicit Y removes

Closes #1142
Task: t315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Setup now asks for user confirmation before removing deprecated configuration and related entries; in non-interactive runs it preserves existing config instead of deleting it automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->