### PR TITLE
t316.2: Create module skeleton for setup.sh

### DIFF
--- a/.agents/scripts/setup/_backup.sh
+++ b/.agents/scripts/setup/_backup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Backup and rotation functions for setup.sh
+
+# Backup rotation settings
+BACKUP_KEEP_COUNT=10
+
+# Create a backup with rotation (keeps last N backups)
+# Usage: create_backup_with_rotation <source_path> <backup_name>
+# Example: create_backup_with_rotation "$target_dir" "agents"
+# Creates: ~/.aidevops/agents-backups/20251221_123456/
+create_backup_with_rotation() {
+	# TODO: Extract from setup.sh lines 246-283
+	:
+}

--- a/.agents/scripts/setup/_bootstrap.sh
+++ b/.agents/scripts/setup/_bootstrap.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Bootstrap and entry point functions for setup.sh
+
+# Bootstrap: Clone or update repo if running remotely (via curl)
+bootstrap_repo() {
+	# TODO: Extract from setup.sh lines 1049-1230
+	:
+}
+
+# Set permissions on scripts
+set_permissions() {
+	# TODO: Extract from setup.sh lines 2735-2750
+	:
+}
+
+# Install aidevops CLI
+install_aidevops_cli() {
+	# TODO: Extract from setup.sh lines 2803-2843
+	:
+}
+
+# Parse command line arguments
+parse_args() {
+	# TODO: Extract from setup.sh lines 5403-5447
+	:
+}
+
+# Main entry point
+main() {
+	# TODO: Extract from setup.sh lines 5450-5696
+	:
+}

--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# Common helper functions for setup.sh
+# Sourced by all setup modules
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Print functions
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
+print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# Spinner for long-running operations
+# Usage: run_with_spinner "Installing package..." command arg1 arg2
+run_with_spinner() {
+	local message="$1"
+	shift
+	local pid
+	local spin_chars='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
+	local i=0
+
+	# Start command in background
+	"$@" &>/dev/null &
+	pid=$!
+
+	# Show spinner while command runs
+	printf "${BLUE}[INFO]${NC} %s " "$message"
+	while kill -0 "$pid" 2>/dev/null; do
+		printf "\r${BLUE}[INFO]${NC} %s %s" "$message" "${spin_chars:i++%${#spin_chars}:1}"
+		sleep 0.1
+	done
+
+	# Check exit status
+	wait "$pid"
+	local exit_code=$?
+
+	# Clear spinner and show result
+	printf "\r"
+	if [[ $exit_code -eq 0 ]]; then
+		print_success "$message done"
+	else
+		print_error "$message failed"
+	fi
+
+	return $exit_code
+}
+
+# Verified install: download script to temp file, inspect, then execute
+# Replaces unsafe curl|sh patterns with download-verify-execute
+# Usage: verified_install "description" "url" [extra_args...]
+# Options (set before calling):
+#   VERIFIED_INSTALL_SUDO="true"  - run with sudo
+#   VERIFIED_INSTALL_SHELL="sh"  - use sh instead of bash (default: bash)
+# Returns: 0 on success, 1 on failure
+verified_install() {
+	local description="$1"
+	local url="$2"
+	shift 2
+	local extra_args=("$@")
+	local shell="${VERIFIED_INSTALL_SHELL:-bash}"
+	local use_sudo="${VERIFIED_INSTALL_SUDO:-false}"
+
+	# Reset options for next call
+	VERIFIED_INSTALL_SUDO="false"
+	VERIFIED_INSTALL_SHELL="bash"
+
+	# Create secure temp file
+	local tmp_script
+	tmp_script=$(mktemp "${TMPDIR:-/tmp}/aidevops-install-XXXXXX.sh") || {
+		print_error "Failed to create temp file for $description"
+		return 1
+	}
+
+	# Ensure cleanup on exit from this function
+	# shellcheck disable=SC2064
+	trap "rm -f '$tmp_script'" RETURN
+
+	# Download script to file (not piped to shell)
+	print_info "Downloading $description install script..."
+	if ! curl -fsSL "$url" -o "$tmp_script" 2>/dev/null; then
+		print_error "Failed to download $description install script from $url"
+		return 1
+	fi
+
+	# Verify download is non-empty and looks like a script
+	if [[ ! -s "$tmp_script" ]]; then
+		print_error "Downloaded $description script is empty"
+		return 1
+	fi
+
+	# Basic content safety check: reject binary content
+	if file "$tmp_script" 2>/dev/null | grep -qv 'text'; then
+		print_error "Downloaded $description script appears to be binary, not a shell script"
+		return 1
+	fi
+
+	# Make executable
+	chmod +x "$tmp_script"
+
+	# Execute from file
+	local cmd=("$shell" "$tmp_script" "${extra_args[@]}")
+	if [[ "$use_sudo" == "true" ]]; then
+		cmd=(sudo "$shell" "$tmp_script" "${extra_args[@]}")
+	fi
+
+	if "${cmd[@]}"; then
+		print_success "$description installed"
+		return 0
+	else
+		print_error "$description installation failed"
+		return 1
+	fi
+}
+
+# Confirm step in interactive mode
+# Usage: confirm_step "Step description" && function_to_run
+# Returns: 0 if confirmed or not interactive, 1 if skipped
+confirm_step() {
+	local step_name="$1"
+
+	# Skip confirmation in non-interactive mode
+	if [[ "$INTERACTIVE_MODE" != "true" ]]; then
+		return 0
+	fi
+
+	echo ""
+	echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+	echo -e "${BLUE}Step:${NC} $step_name"
+	echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+	while true; do
+		echo -n -e "${GREEN}Run this step? [Y]es / [n]o / [q]uit: ${NC}"
+		read -r response
+		# Convert to lowercase (bash 3.2 compatible)
+		response=$(echo "$response" | tr '[:upper:]' '[:lower:]')
+		case "$response" in
+		y | yes | "")
+			return 0
+			;;
+		n | no | s | skip)
+			print_warning "Skipped: $step_name"
+			return 1
+			;;
+		q | quit | exit)
+			echo ""
+			print_info "Setup cancelled by user"
+			exit 0
+			;;
+		*)
+			echo "Please answer: y (yes), n (no), or q (quit)"
+			;;
+		esac
+	done
+}
+
+# Detect package manager
+detect_package_manager() {
+	if command -v brew >/dev/null 2>&1; then
+		echo "brew"
+	elif command -v apt-get >/dev/null 2>&1; then
+		echo "apt"
+	elif command -v dnf >/dev/null 2>&1; then
+		echo "dnf"
+	elif command -v yum >/dev/null 2>&1; then
+		echo "yum"
+	elif command -v pacman >/dev/null 2>&1; then
+		echo "pacman"
+	elif command -v apk >/dev/null 2>&1; then
+		echo "apk"
+	else
+		echo "unknown"
+	fi
+}
+
+# Install packages using detected package manager
+install_packages() {
+	local pkg_manager="$1"
+	shift
+	local packages=("$@")
+
+	case "$pkg_manager" in
+	brew)
+		brew install "${packages[@]}"
+		;;
+	apt)
+		sudo apt-get update && sudo apt-get install -y "${packages[@]}"
+		;;
+	dnf)
+		sudo dnf install -y "${packages[@]}"
+		;;
+	yum)
+		sudo yum install -y "${packages[@]}"
+		;;
+	pacman)
+		sudo pacman -S --noconfirm "${packages[@]}"
+		;;
+	apk)
+		sudo apk add "${packages[@]}"
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+# Offer to install Homebrew (Linuxbrew) on Linux when brew is not available
+# Returns: 0 if brew is now available, 1 if user declined or install failed
+ensure_homebrew() {
+	# Already available
+	if command -v brew &>/dev/null; then
+		return 0
+	fi
+
+	# Only offer on Linux (macOS users should install Homebrew themselves)
+	if [[ "$(uname)" == "Darwin" ]]; then
+		print_warning "Homebrew not found. Install from https://brew.sh"
+		return 1
+	fi
+
+	# Non-interactive mode: skip
+	if [[ "$NON_INTERACTIVE" == "true" ]]; then
+		return 1
+	fi
+
+	echo ""
+	print_info "Homebrew (Linuxbrew) is not installed."
+	print_info "Several optional tools (Beads CLI, Worktrunk, bv) install via Homebrew taps."
+	echo ""
+	read -r -p "Install Homebrew for Linux? [Y/n]: " install_brew
+
+	if [[ ! "$install_brew" =~ ^[Yy]?$ ]]; then
+		print_info "Skipped Homebrew installation"
+		return 1
+	fi
+
+	print_info "Installing Homebrew (Linuxbrew)..."
+
+	# Prerequisites for Linuxbrew
+	if command -v apt-get &>/dev/null; then
+		sudo apt-get update -qq
+		sudo apt-get install -y -qq build-essential procps curl file git
+	elif command -v dnf &>/dev/null; then
+		sudo dnf groupinstall -y 'Development Tools'
+		sudo dnf install -y procps-ng curl file git
+	elif command -v yum &>/dev/null; then
+		sudo yum groupinstall -y 'Development Tools'
+		sudo yum install -y procps-ng curl file git
+	fi
+
+	# Install Homebrew using verified_install pattern
+	if verified_install "Homebrew" "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"; then
+		# Add Homebrew to PATH for this session
+		local brew_prefix="/home/linuxbrew/.linuxbrew"
+		if [[ -x "$brew_prefix/bin/brew" ]]; then
+			eval "$("$brew_prefix/bin/brew" shellenv)"
+		fi
+
+		# Persist to shell rc files
+		local brew_line="eval \"\$($brew_prefix/bin/brew shellenv)\""
+		local rc_file
+		while IFS= read -r rc_file; do
+			[[ -z "$rc_file" ]] && continue
+			if ! grep -q 'linuxbrew' "$rc_file" 2>/dev/null; then
+				{
+					echo ""
+					echo "# Homebrew (Linuxbrew) - added by aidevops setup"
+					echo "$brew_line"
+				} >>"$rc_file"
+			fi
+		done < <(get_all_shell_rcs)
+
+		if command -v brew &>/dev/null; then
+			print_success "Homebrew installed and added to PATH"
+			return 0
+		else
+			print_warning "Homebrew installed but not yet in PATH. Restart your shell or run:"
+			echo "  $brew_line"
+			return 1
+		fi
+	else
+		print_warning "Homebrew installation failed"
+		return 1
+	fi
+}
+
+# Find OpenCode config file (checks multiple possible locations)
+# Returns: path to config file, or empty string if not found
+find_opencode_config() {
+	local candidates=(
+		"$HOME/.config/opencode/opencode.json"                     # XDG standard (Linux, some macOS)
+		"$HOME/.opencode/opencode.json"                            # Alternative location
+		"$HOME/Library/Application Support/opencode/opencode.json" # macOS standard
+	)
+	for candidate in "${candidates[@]}"; do
+		if [[ -f "$candidate" ]]; then
+			echo "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Find best python3 binary (prefer Homebrew/pyenv over system)
+find_python3() {
+	local candidates=(
+		"/opt/homebrew/bin/python3"
+		"/usr/local/bin/python3"
+		"$HOME/.pyenv/shims/python3"
+	)
+	for candidate in "${candidates[@]}"; do
+		if [[ -x "$candidate" ]]; then
+			echo "$candidate"
+			return 0
+		fi
+	done
+	# Fallback to PATH
+	if command -v python3 &>/dev/null; then
+		command -v python3
+		return 0
+	fi
+	return 1
+}
+
+# Install a package globally via npm or bun, with sudo when needed on Linux.
+# Usage: npm_global_install "package-name" OR npm_global_install "package@version"
+# Uses bun if available (no sudo needed), falls back to npm.
+# On Linux with apt-installed npm, automatically prepends sudo.
+# Returns: 0 on success, 1 on failure
+npm_global_install() {
+	local pkg="$1"
+
+	if command -v bun >/dev/null 2>&1; then
+		bun install -g "$pkg"
+		return $?
+	elif command -v npm >/dev/null 2>&1; then
+		# npm global installs need sudo on Linux when prefix dir isn't writable
+		if [[ "$(uname)" != "Darwin" ]] && [[ ! -w "$(npm config get prefix 2>/dev/null)/lib" ]]; then
+			sudo npm install -g "$pkg"
+		else
+			npm install -g "$pkg"
+		fi
+		return $?
+	else
+		return 1
+	fi
+}
+
+# Validate namespace string for safe use in paths and shell commands
+# Returns 0 if valid, 1 if invalid
+# Valid: alphanumeric, dash, underscore, forward slash (no .., no shell metacharacters)
+validate_namespace() {
+	local ns="$1"
+	# Reject empty
+	[[ -z "$ns" ]] && return 1
+	# Reject path traversal
+	[[ "$ns" == *".."* ]] && return 1
+	# Reject shell metacharacters and dangerous characters
+	[[ "$ns" =~ [^a-zA-Z0-9/_-] ]] && return 1
+	# Reject absolute paths
+	[[ "$ns" == /* ]] && return 1
+	# Reject trailing slash (causes issues with rsync/tar exclusions)
+	[[ "$ns" == */ ]] && return 1
+	return 0
+}

--- a/.agents/scripts/setup/_deployment.sh
+++ b/.agents/scripts/setup/_deployment.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Agent deployment functions for setup.sh
+
+# Deploy aidevops agents to ~/.aidevops/agents/
+deploy_aidevops_agents() {
+	# TODO: Extract from setup.sh lines 3076-3268
+	:
+}
+
+# Deploy plugins to ~/.aidevops/agents/
+deploy_plugins() {
+	# TODO: Extract from setup.sh lines 3293-3391
+	:
+}
+
+# Generate agent skills from SKILL.md files
+generate_agent_skills() {
+	# TODO: Extract from setup.sh lines 3394-3410
+	:
+}
+
+# Create skill symlinks for imported skills
+create_skill_symlinks() {
+	# TODO: Extract from setup.sh lines 3413-3496
+	:
+}
+
+# Check for skill updates
+check_skill_updates() {
+	# TODO: Extract from setup.sh lines 3499-3581
+	:
+}
+
+# Scan imported skills
+scan_imported_skills() {
+	# TODO: Extract from setup.sh lines 3584-3658
+	:
+}
+
+# Inject agents reference into AI assistant configs
+inject_agents_reference() {
+	# TODO: Extract from setup.sh lines 3661-3743
+	:
+}
+
+# Deploy AI templates
+deploy_ai_templates() {
+	# TODO: Extract from setup.sh lines 3023-3037
+	:
+}
+
+# Extract OpenCode prompts
+extract_opencode_prompts() {
+	# TODO: Extract from setup.sh lines 3041-3051
+	:
+}
+
+# Check OpenCode prompt drift
+check_opencode_prompt_drift() {
+	# TODO: Extract from setup.sh lines 3054-3073
+	:
+}

--- a/.agents/scripts/setup/_installation.sh
+++ b/.agents/scripts/setup/_installation.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Installation functions for setup.sh
+
+# Check system requirements
+check_requirements() {
+	# TODO: Extract from setup.sh lines 1366-1465
+	:
+}
+
+# Check for quality/linting tools (shellcheck, shfmt)
+check_quality_tools() {
+	# TODO: Extract from setup.sh lines 1469-1532
+	:
+}
+
+# Check optional dependencies
+check_optional_deps() {
+	# TODO: Extract from setup.sh lines 1918-1952
+	:
+}
+
+# Resolve MCP binary path (find full path for npx/bunx/pipx packages)
+resolve_mcp_binary_path() {
+	# TODO: Extract from setup.sh lines 3981-4009
+	:
+}
+
+# Install MCP packages
+install_mcp_packages() {
+	# TODO: Extract from setup.sh lines 3909-3978
+	:
+}
+
+# Install Beads binary (Homebrew tap)
+install_beads_binary() {
+	# TODO: Extract from setup.sh lines 4266-4348
+	:
+}
+
+# Install Beads from Go source
+install_beads_go() {
+	# TODO: Extract from setup.sh lines 4351-4361
+	:
+}

--- a/.agents/scripts/setup/_migration.sh
+++ b/.agents/scripts/setup/_migration.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Migration functions for setup.sh
+
+# Remove deprecated agent paths that have been moved
+# This ensures clean upgrades when agents are reorganized
+cleanup_deprecated_paths() {
+	# TODO: Extract from setup.sh lines 305-390
+	:
+}
+
+# Migrate .agent -> .agents in user projects and local config
+migrate_agent_to_agents_folder() {
+	# TODO: Extract from setup.sh lines 400-520
+	:
+}
+
+# Remove deprecated MCP entries from opencode.json
+cleanup_deprecated_mcps() {
+	# TODO: Extract from setup.sh lines 524-652
+	:
+}
+
+# Disable MCPs globally that should only be enabled on-demand via subagents
+disable_ondemand_mcps() {
+	# TODO: Extract from setup.sh lines 661-737
+	:
+}
+
+# Validate and repair OpenCode config schema
+validate_opencode_config() {
+	# TODO: Extract from setup.sh lines 744-834
+	:
+}
+
+# Migrate mcp-env.sh to credentials.sh (v2.105.0)
+migrate_mcp_env_to_credentials() {
+	# TODO: Extract from setup.sh lines 838-895
+	:
+}
+
+# Migrate old config-backups to new per-type backup structure
+migrate_old_backups() {
+	# TODO: Extract from setup.sh lines 899-951
+	:
+}
+
+# Migrate loop state from .claude/ to .agents/loop-state/ in user projects
+migrate_loop_state_directories() {
+	# TODO: Extract from setup.sh lines 956-1046
+	:
+}

--- a/.agents/scripts/setup/_opencode.sh
+++ b/.agents/scripts/setup/_opencode.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# OpenCode configuration functions for setup.sh
+
+# Update OpenCode config with new settings
+update_opencode_config() {
+	# TODO: Extract from setup.sh lines 3746-3790
+	:
+}
+
+# Update MCP paths in OpenCode config to use full binary paths
+update_mcp_paths_in_opencode() {
+	# TODO: Extract from setup.sh lines 4012-4097
+	:
+}
+
+# Add OpenCode plugin
+add_opencode_plugin() {
+	# TODO: Extract from setup.sh lines 4959-4997
+	:
+}

--- a/.agents/scripts/setup/_services.sh
+++ b/.agents/scripts/setup/_services.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Service setup functions for setup.sh
+
+# Setup SSH key
+setup_ssh_key() {
+	# TODO: Extract from setup.sh lines 2690-2708
+	:
+}
+
+# Setup configs (credentials, repos, etc.)
+setup_configs() {
+	# TODO: Extract from setup.sh lines 2711-2732
+	:
+}
+
+# Setup terminal title
+setup_terminal_title() {
+	# TODO: Extract from setup.sh lines 2951-3020
+	:
+}
+
+# Setup Python environment
+setup_python_env() {
+	# TODO: Extract from setup.sh lines 3814-3870
+	:
+}
+
+# Setup Node.js environment
+setup_nodejs_env() {
+	# TODO: Extract from setup.sh lines 3873-3906
+	:
+}
+
+# Setup Node.js
+setup_nodejs() {
+	# TODO: Extract from setup.sh lines 4650-4768
+	:
+}
+
+# Setup OpenCode CLI
+setup_opencode_cli() {
+	# TODO: Extract from setup.sh lines 4771-4823
+	:
+}
+
+# Setup OrbStack VM
+setup_orbstack_vm() {
+	# TODO: Extract from setup.sh lines 4826-4863
+	:
+}
+
+# Setup AI orchestration
+setup_ai_orchestration() {
+	# TODO: Extract from setup.sh lines 4866-4924
+	:
+}
+
+# Setup safety hooks
+setup_safety_hooks() {
+	# TODO: Extract from setup.sh lines 4927-4956
+	:
+}
+
+# Setup OpenCode plugins
+setup_opencode_plugins() {
+	# TODO: Extract from setup.sh lines 5000-5037
+	:
+}
+
+# Setup SEO MCPs
+setup_seo_mcps() {
+	# TODO: Extract from setup.sh lines 5040-5075
+	:
+}
+
+# Setup Google Analytics MCP
+setup_google_analytics_mcp() {
+	# TODO: Extract from setup.sh lines 5078-5182
+	:
+}
+
+# Setup QuickFile MCP
+setup_quickfile_mcp() {
+	# TODO: Extract from setup.sh lines 5185-5280
+	:
+}
+
+# Setup multi-tenant credentials
+setup_multi_tenant_credentials() {
+	# TODO: Extract from setup.sh lines 5283-5344
+	:
+}
+
+# Setup LocalWP MCP
+setup_localwp_mcp() {
+	# TODO: Extract from setup.sh lines 4100-4147
+	:
+}
+
+# Setup Augment Context Engine
+setup_augment_context_engine() {
+	# TODO: Extract from setup.sh lines 4150-4191
+	:
+}
+
+# Setup osgrep (semantic code search)
+setup_osgrep() {
+	# TODO: Extract from setup.sh lines 4194-4263
+	:
+}
+
+# Setup Beads (task management)
+setup_beads() {
+	# TODO: Extract from setup.sh lines 4364-4419
+	:
+}
+
+# Setup Beads UI
+setup_beads_ui() {
+	# TODO: Extract from setup.sh lines 4422-4524
+	:
+}

--- a/.agents/scripts/setup/_shell.sh
+++ b/.agents/scripts/setup/_shell.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Shell environment functions for setup.sh
+
+# Detect the current running shell (not $SHELL which is the login default)
+# Returns: "bash" or "zsh" or the shell name
+detect_running_shell() {
+	# TODO: Extract from setup.sh lines 1537-1546
+	:
+}
+
+# Detect the user's preferred/default shell (what they'll use day-to-day)
+detect_default_shell() {
+	# TODO: Extract from setup.sh lines 1550-1553
+	:
+}
+
+# Get the appropriate shell rc file for a given shell
+# Usage: get_shell_rc "zsh" or get_shell_rc "bash"
+get_shell_rc() {
+	# TODO: Extract from setup.sh lines 1557-1590
+	:
+}
+
+# Get all shell rc files that exist on the system
+get_all_shell_rcs() {
+	# TODO: Extract from setup.sh lines 1595-1620
+	:
+}
+
+# Setup oh-my-zsh if not already installed
+setup_oh_my_zsh() {
+	# TODO: Extract from setup.sh lines 1626-1690
+	:
+}
+
+# Setup shell compatibility (bash 3.2 on macOS, etc.)
+setup_shell_compatibility() {
+	# TODO: Extract from setup.sh lines 1698-1915
+	:
+}
+
+# Add ~/.local/bin to PATH if not already present
+add_local_bin_to_path() {
+	# TODO: Extract from setup.sh lines 2754-2800
+	:
+}
+
+# Setup shell aliases for aidevops
+setup_aliases() {
+	# TODO: Extract from setup.sh lines 2847-2948
+	:
+}

--- a/.agents/scripts/setup/_tools.sh
+++ b/.agents/scripts/setup/_tools.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Tool setup functions for setup.sh
+
+# Setup git CLIs (gh, glab)
+setup_git_clis() {
+	# TODO: Extract from setup.sh lines 1955-2039
+	:
+}
+
+# Setup file discovery tools (fd, rg)
+setup_file_discovery_tools() {
+	# TODO: Extract from setup.sh lines 2042-2167
+	:
+}
+
+# Setup shell linting tools (shellcheck, shfmt)
+setup_shell_linting_tools() {
+	# TODO: Extract from setup.sh lines 2170-2236
+	:
+}
+
+# Setup Rosetta audit tool
+setup_rosetta_audit() {
+	# TODO: Extract from setup.sh lines 2239-2277
+	:
+}
+
+# Setup Worktrunk (git worktree manager)
+setup_worktrunk() {
+	# TODO: Extract from setup.sh lines 2279-2393
+	:
+}
+
+# Setup recommended tools
+setup_recommended_tools() {
+	# TODO: Extract from setup.sh lines 2396-2605
+	:
+}
+
+# Setup MiniSim (iOS simulator manager)
+setup_minisim() {
+	# TODO: Extract from setup.sh lines 2608-2687
+	:
+}
+
+# Setup browser tools (Playwright, Puppeteer, etc.)
+setup_browser_tools() {
+	# TODO: Extract from setup.sh lines 4527-4647
+	:
+}
+
+# Check for tool updates
+check_tool_updates() {
+	# TODO: Extract from setup.sh lines 5347-5400
+	:
+}

--- a/.agents/scripts/setup/_validation.sh
+++ b/.agents/scripts/setup/_validation.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Validation functions for setup.sh
+
+# Sanitize plugin namespace for safe use in paths
+# Usage: sanitize_plugin_namespace "namespace"
+sanitize_plugin_namespace() {
+	# TODO: Extract from setup.sh lines 3274-3289
+	:
+}
+
+# Verify location (check if running from correct directory)
+# Usage: verify_location
+verify_location() {
+	# TODO: Extract from setup.sh lines 3793-3812
+	:
+}

--- a/setup.sh
+++ b/setup.sh
@@ -26,6 +26,35 @@ UPDATE_TOOLS_MODE=false
 REPO_URL="https://github.com/marcusquinn/aidevops.git"
 INSTALL_DIR="$HOME/Git/aidevops"
 
+# Source modular setup functions (t316.2)
+# These modules are sourced only when setup.sh is run from the repo directory
+# (not during bootstrap from curl, which re-execs after cloning)
+SETUP_MODULES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.agents/scripts/setup" 2>/dev/null && pwd)"
+if [[ -d "$SETUP_MODULES_DIR" ]]; then
+	# shellcheck source=.agents/scripts/setup/_common.sh
+	source "$SETUP_MODULES_DIR/_common.sh"
+	# shellcheck source=.agents/scripts/setup/_backup.sh
+	source "$SETUP_MODULES_DIR/_backup.sh"
+	# shellcheck source=.agents/scripts/setup/_validation.sh
+	source "$SETUP_MODULES_DIR/_validation.sh"
+	# shellcheck source=.agents/scripts/setup/_migration.sh
+	source "$SETUP_MODULES_DIR/_migration.sh"
+	# shellcheck source=.agents/scripts/setup/_shell.sh
+	source "$SETUP_MODULES_DIR/_shell.sh"
+	# shellcheck source=.agents/scripts/setup/_installation.sh
+	source "$SETUP_MODULES_DIR/_installation.sh"
+	# shellcheck source=.agents/scripts/setup/_deployment.sh
+	source "$SETUP_MODULES_DIR/_deployment.sh"
+	# shellcheck source=.agents/scripts/setup/_opencode.sh
+	source "$SETUP_MODULES_DIR/_opencode.sh"
+	# shellcheck source=.agents/scripts/setup/_tools.sh
+	source "$SETUP_MODULES_DIR/_tools.sh"
+	# shellcheck source=.agents/scripts/setup/_services.sh
+	source "$SETUP_MODULES_DIR/_services.sh"
+	# shellcheck source=.agents/scripts/setup/_bootstrap.sh
+	source "$SETUP_MODULES_DIR/_bootstrap.sh"
+fi
+
 print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
 print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }


### PR DESCRIPTION
## Summary

Created modular structure for setup.sh to improve maintainability and enable parallel extraction work.

### Changes

1. **Created `.agents/scripts/setup/` directory** with module structure
2. **Extracted `_common.sh`** with 13 shared helper functions:
   - print_info/success/warning/error
   - run_with_spinner
   - verified_install
   - confirm_step
   - detect_package_manager
   - install_packages
   - ensure_homebrew
   - find_opencode_config
   - find_python3
   - npm_global_install
   - validate_namespace

3. **Created 10 empty module files** with function stubs:
   - `_backup.sh`: backup and rotation (1 function)
   - `_validation.sh`: validation (2 functions)
   - `_migration.sh`: migration (8 functions)
   - `_shell.sh`: shell environment (8 functions)
   - `_installation.sh`: installation (7 functions)
   - `_deployment.sh`: agent deployment (10 functions)
   - `_opencode.sh`: OpenCode config (3 functions)
   - `_tools.sh`: tool setup (9 functions)
   - `_services.sh`: service setup (18 functions)
   - `_bootstrap.sh`: bootstrap and entry point (5 functions)

4. **Wired module sourcing** into setup.sh entry point
   - Modules sourced in dependency order
   - Only sourced when running from repo directory
   - Added shellcheck source directives

### Verification

- ✅ `bash -n setup.sh` passes (no syntax errors)
- ✅ `./setup.sh --help` works correctly
- ✅ ShellCheck passes (1 expected warning for unused variable in stub)

### Next Steps

Future tasks will extract actual function implementations from setup.sh into these modules. This skeleton enables parallel work on different modules without conflicts.

Ref #1224