### PR TITLE
t317.3: Update AGENTS.md task completion rules

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -118,10 +118,12 @@ Use `/save-todo` after planning. Auto-detects complexity:
 **Task completion rules** (CRITICAL - prevents false completion cascade):
 - NEVER mark a task `[x]` unless a merged PR exists with real deliverables for that task
 - The supervisor `update_todo_on_complete()` is the ONLY path to mark tasks done - it requires a merged PR URL or `verified:YYYY-MM-DD` field
+- **Interactive sessions**: Use `complete_task()` or manually add `pr:#NNN` or `verified:YYYY-MM-DD` to the task line BEFORE marking `[x]`. The pre-commit hook (`validate_todo_completions()`) will warn if completion evidence is missing.
 - Checking that a file exists is NOT sufficient - verify the PR was merged and contains substantive changes
 - If a worker completes with `no_pr` or `task_only`, the task stays `[ ]` until a human or the supervisor verifies the deliverable
 - The `issue-sync` GitHub Action auto-closes issues when tasks are marked `[x]` - false completions cascade into closed issues
 - NEVER close GitHub issues manually with `gh issue close` — let the issue-sync pipeline verify deliverables (`pr:` or `verified:` field) before closing. Manual closure bypasses the proof-log safety check
+- **Pre-commit enforcement**: The pre-commit hook checks TODO.md for newly completed tasks (`[ ]` → `[x]`) and warns if no `verified:` field or merged PR evidence exists. This is a warning only (commit proceeds) but serves as a reminder to add completion evidence.
 
 **After ANY TODO/planning edit** (interactive sessions only, NOT workers): Commit and push immediately. Planning-only files (TODO.md, todo/) go directly to main -- no branch, no PR. Mixed changes (planning + non-exception files) use a worktree. NEVER `git checkout -b` in the main repo.
 


### PR DESCRIPTION
## Summary
- Add instruction for interactive sessions to use `complete_task()` or manually add `pr:#NNN`/`verified:YYYY-MM-DD` before marking tasks `[x]`
- Document pre-commit hook enforcement via `validate_todo_completions()`
- Clarify that pre-commit warning is non-blocking but serves as a reminder to add completion evidence

## Changes
- Updated "Task completion rules" section in `.agents/AGENTS.md`
- Added two new bullet points explaining interactive session requirements and pre-commit enforcement

## Testing
- Verified markdown formatting with markdownlint
- Reviewed diff to ensure clarity and accuracy

Ref #1231