### PR TITLE
t318.3: Update interactive PR workflow to require task ID in PR title

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -233,6 +233,8 @@ worktree-helper.sh add feature/x  # Fallback
 
 **After completing changes**, offer: 1) Preflight checks 2) Skip preflight 3) Continue editing
 
+**PR title format** (MANDATORY): All PRs MUST include task ID from TODO.md: `{task-id}: {description}`. For unplanned work (hotfix, quick fix), create TODO entry first with `~15m` estimate, then create PR. No work should be untraceable. See `workflows/git-workflow.md` "PR Title Requirements" for full guidance.
+
 **Branch types**: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
 
 **Worktree ownership** (CRITICAL): NEVER remove a worktree unless (a) you created it in this session, (b) it belongs to a task in your active batch, AND the task is deployed/complete, or (c) the user explicitly asks. Worktrees may belong to parallel sessions — removing them destroys another agent's working directory mid-work. When cleaning up, only touch worktrees for tasks you personally merged. Use `git worktree list` to see all worktrees but do NOT assume unrecognized ones are safe to remove. The ownership registry (`worktree-helper.sh registry list`) tracks which PID owns each worktree — `remove` and `clean` commands automatically refuse to touch worktrees owned by other live processes.

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -587,6 +587,37 @@ After completing file changes, run preflight automatically:
 > 2. Continue working
 > 3. Done for now
 
+### PR Title Requirements
+
+**MANDATORY**: All PR titles MUST include the task ID from TODO.md for traceability.
+
+**Format**: `{task-id}: {description}`
+
+**Examples**:
+- `t318: Update PR workflow documentation`
+- `t042: Fix login timeout bug`
+- `t156: Add Ahrefs MCP server integration`
+
+**For unplanned work** (hotfixes, quick fixes discovered during development):
+
+1. **Create TODO entry first** with `~15m` estimate:
+   ```bash
+   # Add to TODO.md:
+   - [ ] t999 Fix typo in error message ~15m #hotfix
+   ```
+2. **Then create PR** with the task ID:
+   ```bash
+   gh pr create --title "t999: Fix typo in error message" --body "Quick fix"
+   ```
+
+**Rationale**: Every code change must be traceable to a task. This enables:
+- Accurate time tracking (compare estimate vs actual)
+- Work history and context for future reference
+- Linking PRs to GitHub issues via `ref:GH#` in TODO.md
+- Preventing untraceable "drive-by" changes
+
+**No exceptions**: Even 1-line fixes need a task ID. If the work wasn't planned, create the TODO entry first.
+
 **If changes include `.agents/` files** (in aidevops repo or repos with local agents):
 
 > Agent files modified. Run `./setup.sh` to deploy to `~/.aidevops/agents/`?


### PR DESCRIPTION
## Summary

- Added mandatory task ID requirement to PR titles in `workflows/git-workflow.md`
- Updated AGENTS.md Git Workflow section with PR title format guidance
- Added guidance for unplanned work: create TODO entry first with `~15m` estimate, then create PR
- Ensures all work is traceable through task IDs

## Changes

1. **workflows/git-workflow.md**: Added "PR Title Requirements" section after "Post-Change Workflow"
   - Mandatory format: `{task-id}: {description}`
   - Examples provided
   - Guidance for unplanned work (hotfixes, quick fixes)
   - Rationale for traceability

2. **AGENTS.md**: Added PR title requirement to Git Workflow section
   - Concise reference with link to full guidance in git-workflow.md
   - Emphasizes "no work should be untraceable"

## Rationale

Every code change must be traceable to a task for:
- Accurate time tracking (estimate vs actual)
- Work history and context
- Linking PRs to GitHub issues via `ref:GH#` in TODO.md
- Preventing untraceable "drive-by" changes

Ref #1237