### PR TITLE
t321: Derive auto-batch concurrency from CPU cores

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -113,7 +113,7 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **Dependencies**: `blocked-by:t001`, `blocks:t002`, `t001.1` (subtask)
 
-**Auto-dispatch**: Add `#auto-dispatch` to tasks that can run autonomously (clear spec, bounded scope, no user input needed). Default to including it — only omit when a specific exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria. The supervisor's Phase 0 picks these up automatically every 2 minutes and auto-creates batches (`auto-YYYYMMDD-HHMMSS`, concurrency 3) when no active batch exists.
+**Auto-dispatch**: Add `#auto-dispatch` to tasks that can run autonomously (clear spec, bounded scope, no user input needed). Default to including it — only omit when a specific exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria. The supervisor's Phase 0 picks these up automatically every 2 minutes and auto-creates batches (`auto-YYYYMMDD-HHMMSS`, concurrency = cores/2, min 2) when no active batch exists.
 
 **Task completion rules** (CRITICAL - prevents false completion cascade):
 - NEVER mark a task `[x]` unless a merged PR exists with real deliverables for that task

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -13079,13 +13079,23 @@ cmd_auto_pickup() {
 					log_success "Auto-batch: added $added_count tasks to active batch $active_batch_id"
 				fi
 			else
-				# Create a new auto-batch
+				# Create a new auto-batch with resource-aware concurrency
 				local auto_batch_name
 				auto_batch_name="auto-$(date +%Y%m%d-%H%M%S)"
 				local task_csv
 				task_csv=$(echo "$unbatched_queued" | tr '\n' ',' | sed 's/,$//')
+				# Derive base concurrency from CPU cores (cores / 2, min 2)
+				# A 10-core Mac gets 5, a 32-core server gets 16, etc.
+				# The adaptive scaling in calculate_adaptive_concurrency() then
+				# adjusts up/down from this base depending on actual load.
+				local auto_cores auto_base_concurrency
+				auto_cores=$(get_cpu_cores)
+				auto_base_concurrency=$((auto_cores / 2))
+				if [[ "$auto_base_concurrency" -lt 2 ]]; then
+					auto_base_concurrency=2
+				fi
 				local auto_batch_id
-				auto_batch_id=$(cmd_batch "$auto_batch_name" --concurrency 3 --tasks "$task_csv" 2>/dev/null)
+				auto_batch_id=$(cmd_batch "$auto_batch_name" --concurrency "$auto_base_concurrency" --tasks "$task_csv" 2>/dev/null)
 				if [[ -n "$auto_batch_id" ]]; then
 					log_success "Auto-batch: created '$auto_batch_name' ($auto_batch_id) with $picked_up tasks"
 				fi
@@ -14264,10 +14274,13 @@ Cron Integration & Auto-Pickup (t128.5, t296):
     2. Tasks listed under a "## Dispatch Queue" section header
   Both strategies skip tasks already tracked by the supervisor.
 
-  Auto-batching (t296): When new tasks are picked up, they are automatically
+  Auto-batching (t296, t321): When new tasks are picked up, they are automatically
   assigned to a batch. If an active batch exists, tasks are added to it.
   Otherwise, a new batch named 'auto-YYYYMMDD-HHMMSS' is created with
-  concurrency 3. This ensures all auto-dispatched tasks get batch-level
+  base concurrency derived from CPU cores (cores / 2, min 2). A 10-core
+  machine gets base 5, a 32-core server gets 16, etc. The adaptive scaling
+  then adjusts up/down from this base depending on actual CPU load.
+  This ensures all auto-dispatched tasks get batch-level
   concurrency control, completion tracking, and lifecycle management.
 
   Cron scheduling runs pulse (which includes auto-pickup) every N minutes:

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -13088,9 +13088,8 @@ cmd_auto_pickup() {
 				# A 10-core Mac gets 5, a 32-core server gets 16, etc.
 				# The adaptive scaling in calculate_adaptive_concurrency() then
 				# adjusts up/down from this base depending on actual load.
-				local auto_cores auto_base_concurrency
-				auto_cores=$(get_cpu_cores)
-				auto_base_concurrency=$((auto_cores / 2))
+				local auto_cores="$(get_cpu_cores)"
+				local auto_base_concurrency=$((auto_cores / 2))
 				if [[ "$auto_base_concurrency" -lt 2 ]]; then
 					auto_base_concurrency=2
 				fi


### PR DESCRIPTION
## Summary

- Auto-batch creation now derives base concurrency from CPU cores (`cores / 2`, min 2) instead of hardcoding 3
- A 10-core Mac gets base 5, a 32-core server gets 16, a 64-core server gets 32
- The existing adaptive scaling (`calculate_adaptive_concurrency()`) continues to adjust up/down from this base depending on actual CPU load
- Updated AGENTS.md docs and supervisor help text to reflect the new behavior

## Motivation

The hardcoded `--concurrency 3` in `cmd_phase0_auto_dispatch()` meant machines with significant available CPU and RAM were underutilized. This was observed on a 10-core Mac with 64GB RAM and ~55% idle CPU still running only 2-3 workers.

## Scaling table

| Cores | Base | Adaptive range (light → heavy load) |
|-------|------|-------------------------------------|
| 2     | 2    | 4 → 1                              |
| 4     | 2    | 4 → 1                              |
| 8     | 4    | 8 → 2                              |
| 10    | 5    | 10 → 2                             |
| 16    | 8    | 16 → 4                             |
| 32    | 16   | 32 → 8                             |
| 64    | 32   | 64 → 16                            |

## Testing

- `bash -n` syntax check: passed
- ShellCheck on changed lines: no warnings
- Arithmetic verified for core counts 1-128
- Pre-existing secretlint warnings (proxy-integration.md) unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Auto-batch concurrency now adapts dynamically based on system CPU cores (cores/2, minimum 2) instead of a fixed value.

* **Documentation**
  * Updated documentation to reflect adaptive concurrency behavior in auto-batching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->