### PR TITLE
fix: stat -f unbound variable on Linux blocks supervisor dispatch

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -460,7 +460,7 @@ check_gh_auth() {
 	if [[ -f "$cache_file" ]]; then
 		local cache_age
 		local cache_mtime
-		cache_mtime=$(stat -f '%m' "$cache_file" 2>/dev/null || stat -c '%Y' "$cache_file" 2>/dev/null || echo "0")
+		cache_mtime=$(stat -c '%Y' "$cache_file" 2>/dev/null || stat -f '%m' "$cache_file" 2>/dev/null || echo "0")
 		cache_age=$(($(date +%s) - cache_mtime))
 		if [[ "$cache_age" -lt "$cache_ttl" ]]; then
 			local cached_result
@@ -10462,7 +10462,7 @@ cmd_pulse() {
 						if [[ -n "$log_file" && -f "$log_file" ]]; then
 							local log_age_seconds=0
 							local log_mtime
-							log_mtime=$(stat -f %m "$log_file" 2>/dev/null || stat -c %Y "$log_file" 2>/dev/null || echo "0")
+							log_mtime=$(stat -c %Y "$log_file" 2>/dev/null || stat -f %m "$log_file" 2>/dev/null || echo "0")
 							local now_epoch
 							now_epoch=$(date +%s)
 							log_age_seconds=$((now_epoch - log_mtime))


### PR DESCRIPTION
## Summary

- On Linux, `stat -f '%m'` is filesystem mode (not file modification time) and succeeds with exit 0, outputting `File: "..."` to stdout
- The `||` fallback to `stat -c '%Y'` never triggers because the first command succeeds
- The captured output contains `File:` which bash evaluates as an unbound variable in arithmetic context (`set -u`)
- This blocks ALL supervisor dispatch on Linux — the pulse crashes before spawning any workers

## Fix

Swap the order: try `stat -c` (Linux) first, fall through to `stat -f` (macOS) on failure. Two occurrences fixed (lines 463 and 10465). Line 554 already had a proper `uname` guard.

## Testing

- `bash -n` syntax check passes
- Verified `stat -c '%Y'` works on Linux and fails on macOS (triggering the fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal script optimization with no user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->