### PR TITLE
t316.4: Fix deploy_aidevops_agents BASH_SOURCE path after modularization

### DIFF
--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -42,13 +42,24 @@ print_header() {
 }
 
 # Collect all shell scripts to lint, including modularised subdirectories
-# (e.g. memory/, supervisor-modules/) but excluding _archive/.
+# (e.g. memory/, supervisor-modules/, setup/) but excluding _archive/.
+# Also includes setup-modules/ and setup.sh from the repo root.
 # Populates the ALL_SH_FILES array for use by check functions.
 collect_shell_files() {
 	ALL_SH_FILES=()
 	while IFS= read -r -d '' f; do
 		ALL_SH_FILES+=("$f")
 	done < <(find .agents/scripts -name "*.sh" -not -path "*/_archive/*" -print0 2>/dev/null | sort -z)
+
+	# Include setup-modules/ (extracted setup.sh modules) if present
+	while IFS= read -r -d '' f; do
+		ALL_SH_FILES+=("$f")
+	done < <(find setup-modules -name "*.sh" -print0 2>/dev/null | sort -z)
+
+	# Include setup.sh entry point itself
+	if [[ -f "setup.sh" ]]; then
+		ALL_SH_FILES+=("setup.sh")
+	fi
 	return 0
 }
 

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -54,9 +54,10 @@ check_opencode_prompt_drift() {
 deploy_aidevops_agents() {
 	print_info "Deploying aidevops agents to ~/.aidevops/agents/..."
 
-	local script_dir
-	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-	local source_dir="$script_dir/.agents"
+	# Use INSTALL_DIR (set by setup.sh) — BASH_SOURCE[0] points to setup-modules/
+	# which is not the repo root, so we can't derive .agents/ from it
+	local repo_dir="${INSTALL_DIR:?INSTALL_DIR must be set by setup.sh}"
+	local source_dir="$repo_dir/.agents"
 	local target_dir="$HOME/.aidevops/agents"
 	local plugins_file="$HOME/.config/aidevops/plugins.json"
 
@@ -177,8 +178,8 @@ deploy_aidevops_agents() {
 		print_info "Deployed $agent_count agent files and $script_count scripts"
 
 		# Copy VERSION file from repo root to deployed agents
-		if [[ -f "$script_dir/VERSION" ]]; then
-			if cp "$script_dir/VERSION" "$target_dir/VERSION"; then
+		if [[ -f "$repo_dir/VERSION" ]]; then
+			if cp "$repo_dir/VERSION" "$target_dir/VERSION"; then
 				print_info "Copied VERSION file to deployed agents"
 			else
 				print_warning "Failed to copy VERSION file (Plan+ may not read version correctly)"
@@ -596,10 +597,8 @@ setup_safety_hooks() {
 
 	local helper_script="$HOME/.aidevops/agents/scripts/install-hooks-helper.sh"
 	if [[ ! -f "$helper_script" ]]; then
-		# Fall back to repo copy
-		local script_dir
-		script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-		helper_script="$script_dir/.agents/scripts/install-hooks-helper.sh"
+		# Fall back to repo copy (INSTALL_DIR set by setup.sh)
+		helper_script="${INSTALL_DIR:-.}/.agents/scripts/install-hooks-helper.sh"
 	fi
 
 	if [[ ! -f "$helper_script" ]]; then


### PR DESCRIPTION
## Summary

After t316.3 extracted `deploy_aidevops_agents()` from monolithic `setup.sh` into `setup-modules/agent-deploy.sh`, the `BASH_SOURCE[0]`-based path computation broke:

- `BASH_SOURCE[0]` now resolves to `setup-modules/agent-deploy.sh` instead of `setup.sh`
- `$script_dir/.agents` resolved to `setup-modules/.agents` which does not exist
- VERSION file copy looked for `setup-modules/VERSION` — also wrong

### Changes

1. **`setup-modules/agent-deploy.sh`**: Replace `BASH_SOURCE[0]`-derived `$script_dir` with `$INSTALL_DIR` (global set by `setup.sh` at line 27). Affects:
   - `deploy_aidevops_agents()`: source_dir and VERSION file path
   - `setup_safety_hooks()`: fallback helper script path

2. **`.agents/scripts/linters-local.sh`**: Extend `collect_shell_files()` to also include `setup-modules/*.sh` and `setup.sh` in the ShellCheck/shfmt file collection — these were previously unlinted.

Ref #1226

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed path resolution in deployment scripts to correctly reference VERSION files and helper utilities.

* **Chores**
  * Extended shell script linting coverage to include additional setup scripts in the validation pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->