### PR TITLE
t1002: Fix octal parsing bug in claim-task-id.sh

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -152,7 +152,7 @@ get_highest_task_id() {
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^[[:space:]]*-[[:space:]]\[[[:space:]xX]\][[:space:]]t([0-9]+) ]]; then
 			local task_num="${BASH_REMATCH[1]}"
-			if [[ "$task_num" -gt "$highest" ]]; then
+			if ((10#$task_num > 10#$highest)); then
 				highest="$task_num"
 			fi
 		fi

--- a/.agents/scripts/test-task-id-collision.sh
+++ b/.agents/scripts/test-task-id-collision.sh
@@ -667,7 +667,7 @@ test_highest_task_id() {
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^[[:space:]]*-[[:space:]]\[[[:space:]xX]\][[:space:]]t([0-9]+) ]]; then
 			local task_num="${BASH_REMATCH[1]}"
-			if [[ "$task_num" -gt "$highest" ]]; then
+			if ((10#$task_num > 10#$highest)); then
 				highest="$task_num"
 			fi
 		fi
@@ -690,7 +690,7 @@ test_highest_task_id() {
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^[[:space:]]*-[[:space:]]\[[[:space:]xX]\][[:space:]]t([0-9]+) ]]; then
 			local task_num="${BASH_REMATCH[1]}"
-			if [[ "$task_num" -gt "$highest" ]]; then
+			if ((10#$task_num > 10#$highest)); then
 				highest="$task_num"
 			fi
 		fi
@@ -711,7 +711,7 @@ No tasks yet."
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^[[:space:]]*-[[:space:]]\[[[:space:]xX]\][[:space:]]t([0-9]+) ]]; then
 			local task_num="${BASH_REMATCH[1]}"
-			if [[ "$task_num" -gt "$highest" ]]; then
+			if ((10#$task_num > 10#$highest)); then
 				highest="$task_num"
 			fi
 		fi


### PR DESCRIPTION
## Summary

- Fix bash octal parsing error in `get_highest_task_id()` — numbers with leading zeros (008, 009, 018, 019, etc.) caused `value too great for base` errors
- Use `(( 10#$var ))` arithmetic instead of `[[ "$var" -gt ]]` to force base-10 interpretation
- Applied to both `claim-task-id.sh` and `test-task-id-collision.sh`

## Root Cause

Bash treats numbers with leading zeros as octal by default. Since octal only uses digits 0-7, any number containing 8 or 9 (like `008`, `009`, `018`, `019`, `028`, etc.) fails with `value too great for base`. This affected task ID scanning when TODO.md contained tasks like `t008`, `t009`, etc.

## Impact

The bug produced ~60 error lines on every `claim-task-id.sh` invocation but didn't prevent correct ID allocation (the comparison silently failed, but the highest ID was still found via other non-octal entries). With task IDs now in the 1000+ range, the bug is cosmetic but noisy.

## Testing

- `bash -n` syntax check: pass
- ShellCheck: clean (only SC1091 info for sourced file)
- Functional test: confirmed old code fails on `t008`/`t009`, new code handles all numbers correctly

Closes #1276