### PR TITLE
t1003: Block parent task completion when any subtask is open

### DIFF
--- a/.agents/scripts/supervisor/todo-sync.sh
+++ b/.agents/scripts/supervisor/todo-sync.sh
@@ -372,13 +372,12 @@ update_todo_on_complete() {
 		return 1
 	fi
 
-	# t278: Guard against marking #plan tasks complete when subtasks are still open.
-	# A #plan task is a parent that was decomposed into subtasks. It should only be
-	# marked [x] when ALL its subtasks are [x]. This prevents decomposition workers
-	# from prematurely completing the parent.
+	# t278, t1003: Guard against marking parent tasks complete when subtasks are open.
+	# Any task with subtasks (indented lines below it) should only be marked [x]
+	# when ALL its subtasks are [x]. This applies to all parents, not just #plan tasks.
 	local task_line
 	task_line=$(grep -E "^[[:space:]]*- \[[ x-]\] ${task_id}( |$)" "$todo_file" | head -1 || true)
-	if [[ -n "$task_line" && "$task_line" == *"#plan"* ]]; then
+	if [[ -n "$task_line" ]]; then
 		# Get the indentation level of this task
 		local task_indent
 		task_indent=$(echo "$task_line" | sed -E 's/^([[:space:]]*).*/\1/' | wc -c)
@@ -404,8 +403,8 @@ update_todo_on_complete() {
 		if [[ -n "$open_subtasks" ]]; then
 			local open_count
 			open_count=$(echo "$open_subtasks" | wc -l | tr -d ' ')
-			log_warn "Task $task_id is a #plan task with $open_count open subtask(s) — NOT marking [x]"
-			log_warn "  Parent #plan tasks should only be completed when all subtasks are done"
+			log_warn "Task $task_id has $open_count open subtask(s) — NOT marking [x]"
+			log_warn "  Parent tasks can only be completed when all subtasks are done"
 			return 1
 		fi
 	fi


### PR DESCRIPTION
## Summary

- Remove `#plan` tag requirement from subtask completion guard — now ALL parent tasks are blocked from `[x]` if any subtask is still `[ ]`
- Add the same guard to `task-complete-helper.sh` (interactive path) — previously only the supervisor path had this check
- Clear error messages listing which subtasks are still open

## Root Cause

The original guard (t278) only checked tasks tagged with `#plan`. But any parent task with subtasks should follow the same rule: a parent can't be resolved until all subtasks are resolved. Without the `#plan` tag, parents could be marked complete while subtasks were still open.

## Changes

1. **`supervisor/todo-sync.sh`** (`update_todo_on_complete()`): Removed `&& "$task_line" == *"#plan"*` condition. Now checks all tasks for open subtasks.
2. **`task-complete-helper.sh`** (`complete_task()`): Added the same awk-based subtask scan. Blocks with clear error listing open subtasks.

## Testing

- `bash -n` syntax check: pass on both files
- ShellCheck: clean (only SC1091 info)
- Functional tests:
  - Parent with open subtask: **blocked** (exit 1, lists open subtask)
  - Simple task (no subtasks): **completes** (exit 0)
  - Parent with all subtasks done: **completes** (exit 0)

Closes #1279