### PR TITLE
t1003: Block parent task completion when any subtask is open

### DIFF
--- a/.agents/scripts/supervisor/todo-sync.sh
+++ b/.agents/scripts/supervisor/todo-sync.sh
@@ -372,13 +372,25 @@ update_todo_on_complete() {
 		return 1
 	fi
 
-	# t278: Guard against marking #plan tasks complete when subtasks are still open.
-	# A #plan task is a parent that was decomposed into subtasks. It should only be
-	# marked [x] when ALL its subtasks are [x]. This prevents decomposition workers
-	# from prematurely completing the parent.
+	# t1003: Guard against marking parent tasks complete when subtasks are still open.
+	# Any task with subtasks (indented children OR explicit tNNN.M IDs) should only be
+	# marked [x] when ALL its subtasks are [x]. This prevents workers from prematurely
+	# completing parents, regardless of #plan tag.
 	local task_line
 	task_line=$(grep -E "^[[:space:]]*- \[[ x-]\] ${task_id}( |$)" "$todo_file" | head -1 || true)
-	if [[ -n "$task_line" && "$task_line" == *"#plan"* ]]; then
+	if [[ -n "$task_line" ]]; then
+		# Check for explicit subtask IDs (e.g., t123.1, t123.2 are children of t123)
+		local explicit_subtasks
+		explicit_subtasks=$(grep -E "^[[:space:]]*- \[ \] ${task_id}\.[0-9]+( |$)" "$todo_file" || true)
+
+		if [[ -n "$explicit_subtasks" ]]; then
+			local open_count
+			open_count=$(echo "$explicit_subtasks" | wc -l | tr -d ' ')
+			log_warn "Task $task_id has $open_count open subtask(s) by ID — NOT marking [x]"
+			log_warn "  Parent tasks should only be completed when all subtasks are done"
+			return 1
+		fi
+
 		# Get the indentation level of this task
 		local task_indent
 		task_indent=$(echo "$task_line" | sed -E 's/^([[:space:]]*).*/\1/' | wc -c)
@@ -404,8 +416,8 @@ update_todo_on_complete() {
 		if [[ -n "$open_subtasks" ]]; then
 			local open_count
 			open_count=$(echo "$open_subtasks" | wc -l | tr -d ' ')
-			log_warn "Task $task_id is a #plan task with $open_count open subtask(s) — NOT marking [x]"
-			log_warn "  Parent #plan tasks should only be completed when all subtasks are done"
+			log_warn "Task $task_id has $open_count open subtask(s) by indentation — NOT marking [x]"
+			log_warn "  Parent tasks should only be completed when all subtasks are done"
 			return 1
 		fi
 	fi


### PR DESCRIPTION
WIP - incremental commits

## Summary
- Remove #plan tag requirement from update_todo_on_complete() subtask blocking
- Add subtask blocking guard to task-complete-helper.sh
- Add subtask blocking validation to pre-commit hook

## Testing
- [ ] Verify blocking logic for parent tasks with explicit subtask IDs (t123.1, t123.2)
- [ ] Verify blocking logic for parent tasks with indented subtasks
- [ ] Run ShellCheck on modified scripts

Ref #1279