### PR TITLE
t318.1: Add PR task ID check GitHub Action

### DIFF
--- a/.github/PR-TASK-ID-CHECK-README.md
+++ b/.github/PR-TASK-ID-CHECK-README.md
@@ -1,0 +1,11 @@
+# PR Task ID Check - Implementation Notes
+
+## File: .github/workflows/pr-task-id-check.yml
+
+This workflow enforces that every PR references a valid task ID from TODO.md.
+The implementation is complete in the local worktree but requires manual push
+due to GitHub OAuth token scope limitations.
+
+See PR body for push instructions.
+
+This file can be deleted after the workflow file is pushed.


### PR DESCRIPTION
## Summary

- Adds new standalone GitHub Action workflow `.github/workflows/pr-task-id-check.yml`
- Enforces that every PR references a valid task ID (`tNNN`) from `TODO.md`
- Creates the first enforcement point of the t318 audit trail system

Ref #1235

## What it does

1. **Extracts task ID** from PR title (preferred) or branch name (fallback)
   - Matches patterns: `t123`, `t123.1`, `t123.1.1`
2. **Validates task exists** in `TODO.md` on the base branch
   - Subtasks inherit validity from parent (e.g., `t318.1` valid if `t318` exists)
   - Declined tasks `[-]` are rejected
3. **Posts a PR comment** with clear fix instructions on failure
   - Updates existing comment instead of creating duplicates
4. **Exempts** automated branches: `dependabot/*`, `auto-fix/*`, `release/*`, `hotfix/*-emergency-*`

## Security

- All user-controlled inputs (PR title, branch name) passed via `env:` to prevent shell injection
- Sparse checkout of only `TODO.md` to minimize attack surface
- Read-only `contents` permission, write only for `pull-requests` (comments)

## Action Required: Push workflow file

The workflow file is implemented and committed locally but **cannot be pushed** via the Claude Code OAuth token (lacks `workflow` scope). GitHub blocks all `.github/workflows/` modifications without this scope.

**To complete this PR**, push from the worktree:

```bash
cd ~/Git/aidevops.feature-t318.1
git push origin feature/t318.1
```

Then delete the placeholder `.github/PR-TASK-ID-CHECK-README.md` file (it was added to create the PR diff).

## Testing

Once the workflow file is pushed, test by:
1. Creating a PR without task ID in title/branch -> should fail
2. Creating a PR with valid task ID -> should pass
3. Creating a PR from `dependabot/*` branch -> should be exempt
4. Creating a PR referencing a declined `[-]` task -> should fail