### PR TITLE
t1007: Fix beads-sync-helper.sh rejecting positional arg from aidevops init

### DIFF
--- a/.agents/scripts/beads-sync-helper.sh
+++ b/.agents/scripts/beads-sync-helper.sh
@@ -576,7 +576,7 @@ main() {
             --force) force=true ;;
             --dry-run) dry_run=true ;;
             --verbose) verbose=true ;;
-            *) log_error "Unknown option: $opt"; show_help; return 1 ;;
+            *) break ;;  # Ignore positional args (project root discovered via git)
         esac
         shift
     done


### PR DESCRIPTION
Fix beads-sync-helper.sh to accept positional arguments from aidevops init.

The option parser was rejecting the project_root positional arg with "Unknown option" error.