### PR TITLE
t1010: Track model usage per task via action:model issue labels

### DIFF
--- a/.agents/scripts/pattern-tracker-helper.sh
+++ b/.agents/scripts/pattern-tracker-helper.sh
@@ -33,10 +33,22 @@ readonly MEMORY_DB="${AIDEVOPS_MEMORY_DIR:-$HOME/.aidevops/.agent-workspace/memo
 PATTERN_TYPES="'SUCCESS_PATTERN','FAILURE_PATTERN','WORKING_SOLUTION','FAILED_APPROACH','ERROR_FIX'"
 readonly PATTERN_TYPES
 
-log_info() { echo -e "${BLUE}[INFO]${NC} $*"; return 0; }
-log_success() { echo -e "${GREEN}[OK]${NC} $*"; return 0; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; return 0; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; return 0; }
+log_info() {
+	echo -e "${BLUE}[INFO]${NC} $*"
+	return 0
+}
+log_success() {
+	echo -e "${GREEN}[OK]${NC} $*"
+	return 0
+}
+log_warn() {
+	echo -e "${YELLOW}[WARN]${NC} $*"
+	return 0
+}
+log_error() {
+	echo -e "${RED}[ERROR]${NC} $*" >&2
+	return 0
+}
 
 # Valid task types for pattern tracking
 readonly VALID_TASK_TYPES="code-review refactor bugfix feature docs testing deployment security architecture planning research content seo"
@@ -49,120 +61,144 @@ readonly VALID_MODELS="haiku flash sonnet pro opus"
 # Returns 0 if DB exists, 1 if not
 #######################################
 ensure_db() {
-    if [[ ! -f "$MEMORY_DB" ]]; then
-        log_warn "No memory database found at: $MEMORY_DB"
-        log_info "Run 'memory-helper.sh store' to initialize the database."
-        return 1
-    fi
-    return 0
+	if [[ ! -f "$MEMORY_DB" ]]; then
+		log_warn "No memory database found at: $MEMORY_DB"
+		log_info "Run 'memory-helper.sh store' to initialize the database."
+		return 1
+	fi
+	return 0
 }
 
 #######################################
 # SQL-escape a value (double single quotes)
 #######################################
 sql_escape() {
-    local val="$1"
-    echo "${val//\'/\'\'}"
+	local val="$1"
+	echo "${val//\'/\'\'}"
 }
 
 #######################################
 # Record a success or failure pattern
 #######################################
 cmd_record() {
-    local outcome=""
-    local task_type=""
-    local model=""
-    local description=""
-    local tags=""
-    local task_id=""
-    local duration=""
-    local retries=""
+	local outcome=""
+	local task_type=""
+	local model=""
+	local description=""
+	local tags=""
+	local task_id=""
+	local duration=""
+	local retries=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --outcome) outcome="$2"; shift 2 ;;
-            --task-type) task_type="$2"; shift 2 ;;
-            --model) model="$2"; shift 2 ;;
-            --description|--desc) description="$2"; shift 2 ;;
-            --tags) tags="$2"; shift 2 ;;
-            --task-id) task_id="$2"; shift 2 ;;
-            --duration) duration="$2"; shift 2 ;;
-            --retries) retries="$2"; shift 2 ;;
-            *)
-                if [[ -z "$description" ]]; then
-                    description="$1"
-                fi
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--outcome)
+			outcome="$2"
+			shift 2
+			;;
+		--task-type)
+			task_type="$2"
+			shift 2
+			;;
+		--model)
+			model="$2"
+			shift 2
+			;;
+		--description | --desc)
+			description="$2"
+			shift 2
+			;;
+		--tags)
+			tags="$2"
+			shift 2
+			;;
+		--task-id)
+			task_id="$2"
+			shift 2
+			;;
+		--duration)
+			duration="$2"
+			shift 2
+			;;
+		--retries)
+			retries="$2"
+			shift 2
+			;;
+		*)
+			if [[ -z "$description" ]]; then
+				description="$1"
+			fi
+			shift
+			;;
+		esac
+	done
 
-    # Validate required fields
-    if [[ -z "$outcome" ]]; then
-        log_error "Outcome required: --outcome success|failure"
-        return 1
-    fi
+	# Validate required fields
+	if [[ -z "$outcome" ]]; then
+		log_error "Outcome required: --outcome success|failure"
+		return 1
+	fi
 
-    if [[ "$outcome" != "success" && "$outcome" != "failure" ]]; then
-        log_error "Outcome must be 'success' or 'failure'"
-        return 1
-    fi
+	if [[ "$outcome" != "success" && "$outcome" != "failure" ]]; then
+		log_error "Outcome must be 'success' or 'failure'"
+		return 1
+	fi
 
-    if [[ -z "$description" ]]; then
-        log_error "Description required: --description \"what happened\""
-        return 1
-    fi
+	if [[ -z "$description" ]]; then
+		log_error "Description required: --description \"what happened\""
+		return 1
+	fi
 
-    # Validate task type if provided
-    if [[ -n "$task_type" ]]; then
-        local type_check=" $task_type "
-        if [[ ! " $VALID_TASK_TYPES " =~ $type_check ]]; then
-            log_warn "Non-standard task type: $task_type (standard: $VALID_TASK_TYPES)"
-        fi
-    fi
+	# Validate task type if provided
+	if [[ -n "$task_type" ]]; then
+		local type_check=" $task_type "
+		if [[ ! " $VALID_TASK_TYPES " =~ $type_check ]]; then
+			log_warn "Non-standard task type: $task_type (standard: $VALID_TASK_TYPES)"
+		fi
+	fi
 
-    # Validate model if provided
-    if [[ -n "$model" ]]; then
-        local model_check=" $model "
-        if [[ ! " $VALID_MODELS " =~ $model_check ]]; then
-            log_warn "Non-standard model: $model (standard: $VALID_MODELS)"
-        fi
-    fi
+	# Validate model if provided
+	if [[ -n "$model" ]]; then
+		local model_check=" $model "
+		if [[ ! " $VALID_MODELS " =~ $model_check ]]; then
+			log_warn "Non-standard model: $model (standard: $VALID_MODELS)"
+		fi
+	fi
 
-    # Build memory type
-    local memory_type
-    if [[ "$outcome" == "success" ]]; then
-        memory_type="SUCCESS_PATTERN"
-    else
-        memory_type="FAILURE_PATTERN"
-    fi
+	# Build memory type
+	local memory_type
+	if [[ "$outcome" == "success" ]]; then
+		memory_type="SUCCESS_PATTERN"
+	else
+		memory_type="FAILURE_PATTERN"
+	fi
 
-    # Build tags
-    local all_tags="pattern"
-    [[ -n "$task_type" ]] && all_tags="$all_tags,$task_type"
-    [[ -n "$model" ]] && all_tags="$all_tags,model:$model"
-    [[ -n "$task_id" ]] && all_tags="$all_tags,$task_id"
-    [[ -n "$duration" ]] && all_tags="$all_tags,duration:$duration"
-    [[ -n "$retries" ]] && all_tags="$all_tags,retries:$retries"
-    [[ -n "$tags" ]] && all_tags="$all_tags,$tags"
+	# Build tags
+	local all_tags="pattern"
+	[[ -n "$task_type" ]] && all_tags="$all_tags,$task_type"
+	[[ -n "$model" ]] && all_tags="$all_tags,model:$model"
+	[[ -n "$task_id" ]] && all_tags="$all_tags,$task_id"
+	[[ -n "$duration" ]] && all_tags="$all_tags,duration:$duration"
+	[[ -n "$retries" ]] && all_tags="$all_tags,retries:$retries"
+	[[ -n "$tags" ]] && all_tags="$all_tags,$tags"
 
-    # Build content with structured metadata
-    local content="$description"
-    [[ -n "$task_type" ]] && content="[task:$task_type] $content"
-    [[ -n "$model" ]] && content="$content [model:$model]"
-    [[ -n "$task_id" ]] && content="$content [id:$task_id]"
-    [[ -n "$duration" ]] && content="$content [duration:${duration}s]"
-    [[ -n "$retries" && "$retries" != "0" ]] && content="$content [retries:$retries]"
+	# Build content with structured metadata
+	local content="$description"
+	[[ -n "$task_type" ]] && content="[task:$task_type] $content"
+	[[ -n "$model" ]] && content="$content [model:$model]"
+	[[ -n "$task_id" ]] && content="$content [id:$task_id]"
+	[[ -n "$duration" ]] && content="$content [duration:${duration}s]"
+	[[ -n "$retries" && "$retries" != "0" ]] && content="$content [retries:$retries]"
 
-    # Store via memory-helper.sh
-    "$MEMORY_HELPER" store \
-        --content "$content" \
-        --type "$memory_type" \
-        --tags "$all_tags" \
-        --confidence "high"
+	# Store via memory-helper.sh
+	"$MEMORY_HELPER" store \
+		--content "$content" \
+		--type "$memory_type" \
+		--tags "$all_tags" \
+		--confidence "high"
 
-    log_success "Recorded $outcome pattern: $description"
-    return 0
+	log_success "Recorded $outcome pattern: $description"
+	return 0
 }
 
 #######################################
@@ -170,163 +206,172 @@ cmd_record() {
 # Uses direct SQLite for reliability
 #######################################
 cmd_analyze() {
-    local task_type=""
-    local model=""
-    local limit=20
+	local task_type=""
+	local model=""
+	local limit=20
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --task-type) task_type="$2"; shift 2 ;;
-            --model) model="$2"; shift 2 ;;
-            --limit|-l) limit="$2"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--task-type)
+			task_type="$2"
+			shift 2
+			;;
+		--model)
+			model="$2"
+			shift 2
+			;;
+		--limit | -l)
+			limit="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    ensure_db || return 0
+	ensure_db || return 0
 
-    echo ""
-    echo -e "${CYAN}=== Pattern Analysis ===${NC}"
-    echo ""
+	echo ""
+	echo -e "${CYAN}=== Pattern Analysis ===${NC}"
+	echo ""
 
-    # Build WHERE clause for filtering
-    local where_success="type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION')"
-    local where_failure="type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX')"
+	# Build WHERE clause for filtering
+	local where_success="type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION')"
+	local where_failure="type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX')"
 
-    if [[ -n "$task_type" ]]; then
-        local escaped_type
-        escaped_type=$(sql_escape "$task_type")
-        where_success="$where_success AND (tags LIKE '%${escaped_type}%' OR content LIKE '%task:${escaped_type}%')"
-        where_failure="$where_failure AND (tags LIKE '%${escaped_type}%' OR content LIKE '%task:${escaped_type}%')"
-    fi
+	if [[ -n "$task_type" ]]; then
+		local escaped_type
+		escaped_type=$(sql_escape "$task_type")
+		where_success="$where_success AND (tags LIKE '%${escaped_type}%' OR content LIKE '%task:${escaped_type}%')"
+		where_failure="$where_failure AND (tags LIKE '%${escaped_type}%' OR content LIKE '%task:${escaped_type}%')"
+	fi
 
-    if [[ -n "$model" ]]; then
-        local escaped_model
-        escaped_model=$(sql_escape "$model")
-        where_success="$where_success AND (tags LIKE '%model:${escaped_model}%' OR content LIKE '%model:${escaped_model}%')"
-        where_failure="$where_failure AND (tags LIKE '%model:${escaped_model}%' OR content LIKE '%model:${escaped_model}%')"
-    fi
+	if [[ -n "$model" ]]; then
+		local escaped_model
+		escaped_model=$(sql_escape "$model")
+		where_success="$where_success AND (tags LIKE '%model:${escaped_model}%' OR content LIKE '%model:${escaped_model}%')"
+		where_failure="$where_failure AND (tags LIKE '%model:${escaped_model}%' OR content LIKE '%model:${escaped_model}%')"
+	fi
 
-    # Success patterns
-    echo -e "${GREEN}Success Patterns:${NC}"
-    local success_results
-    success_results=$(sqlite3 "$MEMORY_DB" "SELECT content FROM learnings WHERE $where_success ORDER BY created_at DESC LIMIT $limit;" 2>/dev/null || echo "")
+	# Success patterns
+	echo -e "${GREEN}Success Patterns:${NC}"
+	local success_results
+	success_results=$(sqlite3 "$MEMORY_DB" "SELECT content FROM learnings WHERE $where_success ORDER BY created_at DESC LIMIT $limit;" 2>/dev/null || echo "")
 
-    if [[ -n "$success_results" ]]; then
-        while IFS= read -r line; do
-            echo "  + $line"
-        done <<< "$success_results"
-    else
-        echo "  (none recorded)"
-    fi
+	if [[ -n "$success_results" ]]; then
+		while IFS= read -r line; do
+			echo "  + $line"
+		done <<<"$success_results"
+	else
+		echo "  (none recorded)"
+	fi
 
-    echo ""
+	echo ""
 
-    # Failure patterns
-    echo -e "${RED}Failure Patterns:${NC}"
-    local failure_results
-    failure_results=$(sqlite3 "$MEMORY_DB" "SELECT content FROM learnings WHERE $where_failure ORDER BY created_at DESC LIMIT $limit;" 2>/dev/null || echo "")
+	# Failure patterns
+	echo -e "${RED}Failure Patterns:${NC}"
+	local failure_results
+	failure_results=$(sqlite3 "$MEMORY_DB" "SELECT content FROM learnings WHERE $where_failure ORDER BY created_at DESC LIMIT $limit;" 2>/dev/null || echo "")
 
-    if [[ -n "$failure_results" ]]; then
-        while IFS= read -r line; do
-            echo "  - $line"
-        done <<< "$failure_results"
-    else
-        echo "  (none recorded)"
-    fi
+	if [[ -n "$failure_results" ]]; then
+		while IFS= read -r line; do
+			echo "  - $line"
+		done <<<"$failure_results"
+	else
+		echo "  (none recorded)"
+	fi
 
-    echo ""
+	echo ""
 
-    # Summary counts
-    local success_count failure_count
-    success_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE $where_success;" 2>/dev/null || echo "0")
-    failure_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE $where_failure;" 2>/dev/null || echo "0")
+	# Summary counts
+	local success_count failure_count
+	success_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE $where_success;" 2>/dev/null || echo "0")
+	failure_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE $where_failure;" 2>/dev/null || echo "0")
 
-    echo -e "${CYAN}Summary:${NC}"
-    echo "  Successes: $success_count"
-    echo "  Failures: $failure_count"
-    [[ -n "$task_type" ]] && echo "  Task type: $task_type"
-    [[ -n "$model" ]] && echo "  Model: $model"
-    echo ""
-    return 0
+	echo -e "${CYAN}Summary:${NC}"
+	echo "  Successes: $success_count"
+	echo "  Failures: $failure_count"
+	[[ -n "$task_type" ]] && echo "  Task type: $task_type"
+	[[ -n "$model" ]] && echo "  Model: $model"
+	echo ""
+	return 0
 }
 
 #######################################
 # Suggest approach based on patterns
 #######################################
 cmd_suggest() {
-    local task_desc="$*"
+	local task_desc="$*"
 
-    if [[ -z "$task_desc" ]]; then
-        log_error "Task description required: pattern-tracker-helper.sh suggest \"description\""
-        return 1
-    fi
+	if [[ -z "$task_desc" ]]; then
+		log_error "Task description required: pattern-tracker-helper.sh suggest \"description\""
+		return 1
+	fi
 
-    echo ""
-    echo -e "${CYAN}=== Pattern Suggestions for: \"$task_desc\" ===${NC}"
-    echo ""
+	echo ""
+	echo -e "${CYAN}=== Pattern Suggestions for: \"$task_desc\" ===${NC}"
+	echo ""
 
-    # Search for relevant success patterns via FTS5
-    echo -e "${GREEN}What has worked before:${NC}"
-    local success_results
-    success_results=$("$MEMORY_HELPER" recall --query "$task_desc" --type SUCCESS_PATTERN --limit 5 --json 2>/dev/null || echo "[]")
+	# Search for relevant success patterns via FTS5
+	echo -e "${GREEN}What has worked before:${NC}"
+	local success_results
+	success_results=$("$MEMORY_HELPER" recall --query "$task_desc" --type SUCCESS_PATTERN --limit 5 --json 2>/dev/null || echo "[]")
 
-    # Also search WORKING_SOLUTION (supervisor-generated)
-    local working_results
-    working_results=$("$MEMORY_HELPER" recall --query "$task_desc" --type WORKING_SOLUTION --limit 3 --json 2>/dev/null || echo "[]")
+	# Also search WORKING_SOLUTION (supervisor-generated)
+	local working_results
+	working_results=$("$MEMORY_HELPER" recall --query "$task_desc" --type WORKING_SOLUTION --limit 3 --json 2>/dev/null || echo "[]")
 
-    local found_success=false
-    if command -v jq &>/dev/null; then
-        local count
-        count=$(echo "$success_results" | jq 'length' 2>/dev/null || echo "0")
-        if [[ "$count" -gt 0 ]]; then
-            echo "$success_results" | jq -r '.[] | "  + \(.content)"' 2>/dev/null
-            found_success=true
-        fi
-        count=$(echo "$working_results" | jq 'length' 2>/dev/null || echo "0")
-        if [[ "$count" -gt 0 ]]; then
-            echo "$working_results" | jq -r '.[] | "  + \(.content)"' 2>/dev/null
-            found_success=true
-        fi
-    fi
-    if [[ "$found_success" == false ]]; then
-        echo "  (no matching success patterns)"
-    fi
+	local found_success=false
+	if command -v jq &>/dev/null; then
+		local count
+		count=$(echo "$success_results" | jq 'length' 2>/dev/null || echo "0")
+		if [[ "$count" -gt 0 ]]; then
+			echo "$success_results" | jq -r '.[] | "  + \(.content)"' 2>/dev/null
+			found_success=true
+		fi
+		count=$(echo "$working_results" | jq 'length' 2>/dev/null || echo "0")
+		if [[ "$count" -gt 0 ]]; then
+			echo "$working_results" | jq -r '.[] | "  + \(.content)"' 2>/dev/null
+			found_success=true
+		fi
+	fi
+	if [[ "$found_success" == false ]]; then
+		echo "  (no matching success patterns)"
+	fi
 
-    echo ""
+	echo ""
 
-    # Search for relevant failure patterns
-    echo -e "${RED}What to avoid:${NC}"
-    local failure_results
-    failure_results=$("$MEMORY_HELPER" recall --query "$task_desc" --type FAILURE_PATTERN --limit 5 --json 2>/dev/null || echo "[]")
+	# Search for relevant failure patterns
+	echo -e "${RED}What to avoid:${NC}"
+	local failure_results
+	failure_results=$("$MEMORY_HELPER" recall --query "$task_desc" --type FAILURE_PATTERN --limit 5 --json 2>/dev/null || echo "[]")
 
-    local failed_results
-    failed_results=$("$MEMORY_HELPER" recall --query "$task_desc" --type FAILED_APPROACH --limit 3 --json 2>/dev/null || echo "[]")
+	local failed_results
+	failed_results=$("$MEMORY_HELPER" recall --query "$task_desc" --type FAILED_APPROACH --limit 3 --json 2>/dev/null || echo "[]")
 
-    local found_failure=false
-    if command -v jq &>/dev/null; then
-        local count
-        count=$(echo "$failure_results" | jq 'length' 2>/dev/null || echo "0")
-        if [[ "$count" -gt 0 ]]; then
-            echo "$failure_results" | jq -r '.[] | "  - \(.content)"' 2>/dev/null
-            found_failure=true
-        fi
-        count=$(echo "$failed_results" | jq 'length' 2>/dev/null || echo "0")
-        if [[ "$count" -gt 0 ]]; then
-            echo "$failed_results" | jq -r '.[] | "  - \(.content)"' 2>/dev/null
-            found_failure=true
-        fi
-    fi
-    if [[ "$found_failure" == false ]]; then
-        echo "  (no matching failure patterns)"
-    fi
+	local found_failure=false
+	if command -v jq &>/dev/null; then
+		local count
+		count=$(echo "$failure_results" | jq 'length' 2>/dev/null || echo "0")
+		if [[ "$count" -gt 0 ]]; then
+			echo "$failure_results" | jq -r '.[] | "  - \(.content)"' 2>/dev/null
+			found_failure=true
+		fi
+		count=$(echo "$failed_results" | jq 'length' 2>/dev/null || echo "0")
+		if [[ "$count" -gt 0 ]]; then
+			echo "$failed_results" | jq -r '.[] | "  - \(.content)"' 2>/dev/null
+			found_failure=true
+		fi
+	fi
+	if [[ "$found_failure" == false ]]; then
+		echo "  (no matching failure patterns)"
+	fi
 
-    echo ""
+	echo ""
 
-    # Model recommendation based on patterns
-    _show_model_hint "$task_desc"
+	# Model recommendation based on patterns
+	_show_model_hint "$task_desc"
 
-    return 0
+	return 0
 }
 
 #######################################
@@ -334,270 +379,276 @@ cmd_suggest() {
 # Queries patterns tagged with model info and calculates success rates
 #######################################
 cmd_recommend() {
-    local task_type=""
-    local task_desc=""
+	local task_type=""
+	local task_desc=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --task-type) task_type="$2"; shift 2 ;;
-            *)
-                if [[ -z "$task_desc" ]]; then
-                    task_desc="$1"
-                else
-                    task_desc="$task_desc $1"
-                fi
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--task-type)
+			task_type="$2"
+			shift 2
+			;;
+		*)
+			if [[ -z "$task_desc" ]]; then
+				task_desc="$1"
+			else
+				task_desc="$task_desc $1"
+			fi
+			shift
+			;;
+		esac
+	done
 
-    ensure_db || {
-        echo ""
-        echo -e "${CYAN}=== Model Recommendation ===${NC}"
-        echo ""
-        echo "  No pattern data available. Default recommendation: sonnet"
-        echo "  Record patterns to enable data-driven routing."
-        echo ""
-        return 0
-    }
+	ensure_db || {
+		echo ""
+		echo -e "${CYAN}=== Model Recommendation ===${NC}"
+		echo ""
+		echo "  No pattern data available. Default recommendation: sonnet"
+		echo "  Record patterns to enable data-driven routing."
+		echo ""
+		return 0
+	}
 
-    echo ""
-    echo -e "${CYAN}=== Model Recommendation ===${NC}"
-    echo ""
+	echo ""
+	echo -e "${CYAN}=== Model Recommendation ===${NC}"
+	echo ""
 
-    # Build filter clause
-    local filter=""
-    if [[ -n "$task_type" ]]; then
-        local escaped_type
-        escaped_type=$(sql_escape "$task_type")
-        filter="AND (tags LIKE '%${escaped_type}%' OR content LIKE '%task:${escaped_type}%')"
-        echo -e "  Task type: ${WHITE}$task_type${NC}"
-    fi
-    if [[ -n "$task_desc" ]]; then
-        echo -e "  Description: ${WHITE}$task_desc${NC}"
-    fi
-    echo ""
+	# Build filter clause
+	local filter=""
+	if [[ -n "$task_type" ]]; then
+		local escaped_type
+		escaped_type=$(sql_escape "$task_type")
+		filter="AND (tags LIKE '%${escaped_type}%' OR content LIKE '%task:${escaped_type}%')"
+		echo -e "  Task type: ${WHITE}$task_type${NC}"
+	fi
+	if [[ -n "$task_desc" ]]; then
+		echo -e "  Description: ${WHITE}$task_desc${NC}"
+	fi
+	echo ""
 
-    # Query success/failure counts per model tier
-    echo -e "${CYAN}Model Performance (from pattern history):${NC}"
-    echo ""
-    printf "  %-10s %8s %8s %10s\n" "Model" "Success" "Failure" "Rate"
-    printf "  %-10s %8s %8s %10s\n" "-----" "-------" "-------" "----"
+	# Query success/failure counts per model tier
+	echo -e "${CYAN}Model Performance (from pattern history):${NC}"
+	echo ""
+	printf "  %-10s %8s %8s %10s\n" "Model" "Success" "Failure" "Rate"
+	printf "  %-10s %8s %8s %10s\n" "-----" "-------" "-------" "----"
 
-    local best_model="" best_rate=0 has_data=false
+	local best_model="" best_rate=0 has_data=false
 
-    for model_tier in $VALID_MODELS; do
-        local model_filter="AND (tags LIKE '%model:${model_tier}%' OR content LIKE '%model:${model_tier}%')"
+	for model_tier in $VALID_MODELS; do
+		local model_filter="AND (tags LIKE '%model:${model_tier}%' OR content LIKE '%model:${model_tier}%')"
 
-        local successes failures
-        successes=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION') $model_filter $filter;" 2>/dev/null || echo "0")
-        failures=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX') $model_filter $filter;" 2>/dev/null || echo "0")
+		local successes failures
+		successes=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION') $model_filter $filter;" 2>/dev/null || echo "0")
+		failures=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX') $model_filter $filter;" 2>/dev/null || echo "0")
 
-        local total=$((successes + failures))
-        if [[ "$total" -gt 0 ]]; then
-            has_data=true
-            local rate
-            rate=$(( (successes * 100) / total ))
-            printf "  %-10s %8d %8d %9d%%\n" "$model_tier" "$successes" "$failures" "$rate"
+		local total=$((successes + failures))
+		if [[ "$total" -gt 0 ]]; then
+			has_data=true
+			local rate
+			rate=$(((successes * 100) / total))
+			printf "  %-10s %8d %8d %9d%%\n" "$model_tier" "$successes" "$failures" "$rate"
 
-            # Track best model (prefer higher success rate, break ties with more data)
-            if [[ "$rate" -gt "$best_rate" ]] || { [[ "$rate" -eq "$best_rate" ]] && [[ "$total" -gt 0 ]]; }; then
-                best_rate=$rate
-                best_model=$model_tier
-            fi
-        else
-            printf "  %-10s %8s %8s %10s\n" "$model_tier" "-" "-" "no data"
-        fi
-    done
+			# Track best model (prefer higher success rate, break ties with more data)
+			if [[ "$rate" -gt "$best_rate" ]] || { [[ "$rate" -eq "$best_rate" ]] && [[ "$total" -gt 0 ]]; }; then
+				best_rate=$rate
+				best_model=$model_tier
+			fi
+		else
+			printf "  %-10s %8s %8s %10s\n" "$model_tier" "-" "-" "no data"
+		fi
+	done
 
-    echo ""
+	echo ""
 
-    # Recommendation
-    if [[ "$has_data" == true && -n "$best_model" ]]; then
-        echo -e "  ${GREEN}Recommended: ${WHITE}$best_model${GREEN} (${best_rate}% success rate)${NC}"
+	# Recommendation
+	if [[ "$has_data" == true && -n "$best_model" ]]; then
+		echo -e "  ${GREEN}Recommended: ${WHITE}$best_model${GREEN} (${best_rate}% success rate)${NC}"
 
-        # Add context about the recommendation
-        if [[ "$best_rate" -lt 50 ]]; then
-            echo -e "  ${YELLOW}Warning: Low success rate across all models. Consider reviewing task approach.${NC}"
-        elif [[ "$best_rate" -lt 75 ]]; then
-            echo -e "  ${YELLOW}Note: Moderate success rate. Consider using a higher-tier model for complex tasks.${NC}"
-        fi
-    else
-        echo -e "  ${YELLOW}No pattern data for model comparison. Default: sonnet${NC}"
-        echo "  Record patterns with --model flag to enable data-driven routing."
-    fi
+		# Add context about the recommendation
+		if [[ "$best_rate" -lt 50 ]]; then
+			echo -e "  ${YELLOW}Warning: Low success rate across all models. Consider reviewing task approach.${NC}"
+		elif [[ "$best_rate" -lt 75 ]]; then
+			echo -e "  ${YELLOW}Note: Moderate success rate. Consider using a higher-tier model for complex tasks.${NC}"
+		fi
+	else
+		echo -e "  ${YELLOW}No pattern data for model comparison. Default: sonnet${NC}"
+		echo "  Record patterns with --model flag to enable data-driven routing."
+	fi
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 #######################################
 # Show pattern statistics
 #######################################
 cmd_stats() {
-    echo ""
-    echo -e "${CYAN}=== Pattern Statistics ===${NC}"
-    echo ""
+	echo ""
+	echo -e "${CYAN}=== Pattern Statistics ===${NC}"
+	echo ""
 
-    ensure_db || return 0
+	ensure_db || return 0
 
-    # Count by dedicated pattern types
-    local success_count failure_count
-    success_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'SUCCESS_PATTERN';" 2>/dev/null || echo "0")
-    failure_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'FAILURE_PATTERN';" 2>/dev/null || echo "0")
+	# Count by dedicated pattern types
+	local success_count failure_count
+	success_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'SUCCESS_PATTERN';" 2>/dev/null || echo "0")
+	failure_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'FAILURE_PATTERN';" 2>/dev/null || echo "0")
 
-    # Count supervisor-generated patterns
-    local working_count failed_count error_count
-    working_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'WORKING_SOLUTION' AND tags LIKE '%supervisor%';" 2>/dev/null || echo "0")
-    failed_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'FAILED_APPROACH' AND tags LIKE '%supervisor%';" 2>/dev/null || echo "0")
-    error_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'ERROR_FIX' AND tags LIKE '%supervisor%';" 2>/dev/null || echo "0")
+	# Count supervisor-generated patterns
+	local working_count failed_count error_count
+	working_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'WORKING_SOLUTION' AND tags LIKE '%supervisor%';" 2>/dev/null || echo "0")
+	failed_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'FAILED_APPROACH' AND tags LIKE '%supervisor%';" 2>/dev/null || echo "0")
+	error_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type = 'ERROR_FIX' AND tags LIKE '%supervisor%';" 2>/dev/null || echo "0")
 
-    echo "  Dedicated patterns:"
-    echo "    SUCCESS_PATTERN: $success_count"
-    echo "    FAILURE_PATTERN: $failure_count"
-    echo ""
-    echo "  Supervisor-generated:"
-    echo "    WORKING_SOLUTION: $working_count"
-    echo "    FAILED_APPROACH: $failed_count"
-    echo "    ERROR_FIX: $error_count"
-    echo ""
+	echo "  Dedicated patterns:"
+	echo "    SUCCESS_PATTERN: $success_count"
+	echo "    FAILURE_PATTERN: $failure_count"
+	echo ""
+	echo "  Supervisor-generated:"
+	echo "    WORKING_SOLUTION: $working_count"
+	echo "    FAILED_APPROACH: $failed_count"
+	echo "    ERROR_FIX: $error_count"
+	echo ""
 
-    local total=$(( success_count + failure_count + working_count + failed_count + error_count ))
-    echo "  Total trackable patterns: $total"
-    echo ""
+	local total=$((success_count + failure_count + working_count + failed_count + error_count))
+	echo "  Total trackable patterns: $total"
+	echo ""
 
-    # Show task type breakdown
-    echo "  Task types with patterns:"
-    local found_any=false
-    for task_type in $VALID_TASK_TYPES; do
-        local type_count
-        type_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ($PATTERN_TYPES) AND (tags LIKE '%${task_type}%' OR content LIKE '%task:${task_type}%');" 2>/dev/null || echo "0")
-        if [[ "$type_count" -gt 0 ]]; then
-            echo "    $task_type: $type_count"
-            found_any=true
-        fi
-    done
-    if [[ "$found_any" == false ]]; then
-        echo "    (none recorded with task types)"
-    fi
-    echo ""
+	# Show task type breakdown
+	echo "  Task types with patterns:"
+	local found_any=false
+	for task_type in $VALID_TASK_TYPES; do
+		local type_count
+		type_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ($PATTERN_TYPES) AND (tags LIKE '%${task_type}%' OR content LIKE '%task:${task_type}%');" 2>/dev/null || echo "0")
+		if [[ "$type_count" -gt 0 ]]; then
+			echo "    $task_type: $type_count"
+			found_any=true
+		fi
+	done
+	if [[ "$found_any" == false ]]; then
+		echo "    (none recorded with task types)"
+	fi
+	echo ""
 
-    # Show model tier breakdown
-    echo "  Model tiers with patterns:"
-    local found_model=false
-    for model_tier in $VALID_MODELS; do
-        local model_count
-        model_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ($PATTERN_TYPES) AND (tags LIKE '%model:${model_tier}%' OR content LIKE '%model:${model_tier}%');" 2>/dev/null || echo "0")
-        if [[ "$model_count" -gt 0 ]]; then
-            echo "    $model_tier: $model_count"
-            found_model=true
-        fi
-    done
-    if [[ "$found_model" == false ]]; then
-        echo "    (none recorded with model tiers)"
-    fi
-    echo ""
+	# Show model tier breakdown
+	echo "  Model tiers with patterns:"
+	local found_model=false
+	for model_tier in $VALID_MODELS; do
+		local model_count
+		model_count=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ($PATTERN_TYPES) AND (tags LIKE '%model:${model_tier}%' OR content LIKE '%model:${model_tier}%');" 2>/dev/null || echo "0")
+		if [[ "$model_count" -gt 0 ]]; then
+			echo "    $model_tier: $model_count"
+			found_model=true
+		fi
+	done
+	if [[ "$found_model" == false ]]; then
+		echo "    (none recorded with model tiers)"
+	fi
+	echo ""
 
-    # Success rate
-    local total_success=$((success_count + working_count))
-    local total_failure=$((failure_count + failed_count + error_count))
-    local total_all=$((total_success + total_failure))
-    if [[ "$total_all" -gt 0 ]]; then
-        local overall_rate=$(( (total_success * 100) / total_all ))
-        echo "  Overall success rate: ${overall_rate}% ($total_success/$total_all)"
-    fi
-    echo ""
-    return 0
+	# Success rate
+	local total_success=$((success_count + working_count))
+	local total_failure=$((failure_count + failed_count + error_count))
+	local total_all=$((total_success + total_failure))
+	if [[ "$total_all" -gt 0 ]]; then
+		local overall_rate=$(((total_success * 100) / total_all))
+		echo "  Overall success rate: ${overall_rate}% ($total_success/$total_all)"
+	fi
+	echo ""
+	return 0
 }
 
 #######################################
 # Export patterns as JSON or CSV
 #######################################
 cmd_export() {
-    local format="json"
+	local format="json"
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --format|-f) format="$2"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--format | -f)
+			format="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    ensure_db || return 1
+	ensure_db || return 1
 
-    # SQL for pattern types (used in queries below)
-    local types_sql="'SUCCESS_PATTERN','FAILURE_PATTERN','WORKING_SOLUTION','FAILED_APPROACH','ERROR_FIX'"
+	# SQL for pattern types (used in queries below)
+	local types_sql="'SUCCESS_PATTERN','FAILURE_PATTERN','WORKING_SOLUTION','FAILED_APPROACH','ERROR_FIX'"
 
-    case "$format" in
-        json)
-            # Use sqlite3 -json for proper JSON output
-            local query="SELECT l.id, l.type, l.content, l.tags, l.confidence, l.created_at, COALESCE(a.access_count, 0) as access_count FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.type IN ($types_sql) ORDER BY l.created_at DESC;"
-            sqlite3 -json "$MEMORY_DB" "$query" 2>/dev/null || echo "[]"
-            ;;
-        csv)
-            echo "id,type,content,tags,confidence,created_at,access_count"
-            local csv_query="SELECT l.id, l.type, l.content, l.tags, l.confidence, l.created_at, COALESCE(a.access_count, 0) FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.type IN ($types_sql) ORDER BY l.created_at DESC;"
-            sqlite3 -csv "$MEMORY_DB" "$csv_query" 2>/dev/null
-            ;;
-        *)
-            log_error "Unknown format: $format (use json or csv)"
-            return 1
-            ;;
-    esac
-    return 0
+	case "$format" in
+	json)
+		# Use sqlite3 -json for proper JSON output
+		local query="SELECT l.id, l.type, l.content, l.tags, l.confidence, l.created_at, COALESCE(a.access_count, 0) as access_count FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.type IN ($types_sql) ORDER BY l.created_at DESC;"
+		sqlite3 -json "$MEMORY_DB" "$query" 2>/dev/null || echo "[]"
+		;;
+	csv)
+		echo "id,type,content,tags,confidence,created_at,access_count"
+		local csv_query="SELECT l.id, l.type, l.content, l.tags, l.confidence, l.created_at, COALESCE(a.access_count, 0) FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.type IN ($types_sql) ORDER BY l.created_at DESC;"
+		sqlite3 -csv "$MEMORY_DB" "$csv_query" 2>/dev/null
+		;;
+	*)
+		log_error "Unknown format: $format (use json or csv)"
+		return 1
+		;;
+	esac
+	return 0
 }
 
 #######################################
 # Generate a summary report of patterns
 #######################################
 cmd_report() {
-    ensure_db || return 0
+	ensure_db || return 0
 
-    echo ""
-    echo -e "${CYAN}=== Pattern Tracking Report ===${NC}"
-    echo -e "  Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-    echo ""
+	echo ""
+	echo -e "${CYAN}=== Pattern Tracking Report ===${NC}"
+	echo -e "  Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+	echo ""
 
-    # Overall counts
-    local total_patterns
-    total_patterns=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ($PATTERN_TYPES);" 2>/dev/null || echo "0")
-    echo "  Total patterns tracked: $total_patterns"
+	# Overall counts
+	local total_patterns
+	total_patterns=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ($PATTERN_TYPES);" 2>/dev/null || echo "0")
+	echo "  Total patterns tracked: $total_patterns"
 
-    if [[ "$total_patterns" -eq 0 ]]; then
-        echo ""
-        echo "  No patterns recorded yet. Patterns are captured:"
-        echo "    - Automatically by the supervisor after task completion"
-        echo "    - Manually via: pattern-tracker-helper.sh record ..."
-        echo ""
-        return 0
-    fi
+	if [[ "$total_patterns" -eq 0 ]]; then
+		echo ""
+		echo "  No patterns recorded yet. Patterns are captured:"
+		echo "    - Automatically by the supervisor after task completion"
+		echo "    - Manually via: pattern-tracker-helper.sh record ..."
+		echo ""
+		return 0
+	fi
 
-    # Date range
-    local oldest newest
-    oldest=$(sqlite3 "$MEMORY_DB" "SELECT MIN(created_at) FROM learnings WHERE type IN ($PATTERN_TYPES);" 2>/dev/null || echo "unknown")
-    newest=$(sqlite3 "$MEMORY_DB" "SELECT MAX(created_at) FROM learnings WHERE type IN ($PATTERN_TYPES);" 2>/dev/null || echo "unknown")
-    echo "  Date range: $oldest to $newest"
-    echo ""
+	# Date range
+	local oldest newest
+	oldest=$(sqlite3 "$MEMORY_DB" "SELECT MIN(created_at) FROM learnings WHERE type IN ($PATTERN_TYPES);" 2>/dev/null || echo "unknown")
+	newest=$(sqlite3 "$MEMORY_DB" "SELECT MAX(created_at) FROM learnings WHERE type IN ($PATTERN_TYPES);" 2>/dev/null || echo "unknown")
+	echo "  Date range: $oldest to $newest"
+	echo ""
 
-    # Success vs failure breakdown
-    local success_total failure_total
-    success_total=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION');" 2>/dev/null || echo "0")
-    failure_total=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX');" 2>/dev/null || echo "0")
+	# Success vs failure breakdown
+	local success_total failure_total
+	success_total=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION');" 2>/dev/null || echo "0")
+	failure_total=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX');" 2>/dev/null || echo "0")
 
-    echo -e "  ${GREEN}Successes: $success_total${NC}"
-    echo -e "  ${RED}Failures: $failure_total${NC}"
+	echo -e "  ${GREEN}Successes: $success_total${NC}"
+	echo -e "  ${RED}Failures: $failure_total${NC}"
 
-    local total_sf=$((success_total + failure_total))
-    if [[ "$total_sf" -gt 0 ]]; then
-        local rate=$(( (success_total * 100) / total_sf ))
-        echo "  Success rate: ${rate}%"
-    fi
-    echo ""
+	local total_sf=$((success_total + failure_total))
+	if [[ "$total_sf" -gt 0 ]]; then
+		local rate=$(((success_total * 100) / total_sf))
+		echo "  Success rate: ${rate}%"
+	fi
+	echo ""
 
-    # Top failure reasons (most common failure content patterns)
-    echo -e "${RED}Most Common Failure Patterns:${NC}"
-    local top_failures
-    top_failures=$(sqlite3 "$MEMORY_DB" "
+	# Top failure reasons (most common failure content patterns)
+	echo -e "${RED}Most Common Failure Patterns:${NC}"
+	local top_failures
+	top_failures=$(sqlite3 "$MEMORY_DB" "
         SELECT content, COUNT(*) as cnt
         FROM learnings
         WHERE type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX')
@@ -606,42 +657,42 @@ cmd_report() {
         LIMIT 5;
     " 2>/dev/null || echo "")
 
-    if [[ -n "$top_failures" ]]; then
-        while IFS='|' read -r content cnt; do
-            # Truncate long content
-            if [[ ${#content} -gt 80 ]]; then
-                content="${content:0:77}..."
-            fi
-            echo "  ($cnt) $content"
-        done <<< "$top_failures"
-    else
-        echo "  (none)"
-    fi
-    echo ""
+	if [[ -n "$top_failures" ]]; then
+		while IFS='|' read -r content cnt; do
+			# Truncate long content
+			if [[ ${#content} -gt 80 ]]; then
+				content="${content:0:77}..."
+			fi
+			echo "  ($cnt) $content"
+		done <<<"$top_failures"
+	else
+		echo "  (none)"
+	fi
+	echo ""
 
-    # Model tier performance
-    echo -e "${CYAN}Model Tier Performance:${NC}"
-    printf "  %-10s %8s %8s %10s\n" "Model" "Success" "Failure" "Rate"
-    printf "  %-10s %8s %8s %10s\n" "-----" "-------" "-------" "----"
+	# Model tier performance
+	echo -e "${CYAN}Model Tier Performance:${NC}"
+	printf "  %-10s %8s %8s %10s\n" "Model" "Success" "Failure" "Rate"
+	printf "  %-10s %8s %8s %10s\n" "-----" "-------" "-------" "----"
 
-    for model_tier in $VALID_MODELS; do
-        local model_filter="AND (tags LIKE '%model:${model_tier}%' OR content LIKE '%model:${model_tier}%')"
-        local m_success m_failure
-        m_success=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION') $model_filter;" 2>/dev/null || echo "0")
-        m_failure=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX') $model_filter;" 2>/dev/null || echo "0")
+	for model_tier in $VALID_MODELS; do
+		local model_filter="AND (tags LIKE '%model:${model_tier}%' OR content LIKE '%model:${model_tier}%')"
+		local m_success m_failure
+		m_success=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION') $model_filter;" 2>/dev/null || echo "0")
+		m_failure=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX') $model_filter;" 2>/dev/null || echo "0")
 
-        local m_total=$((m_success + m_failure))
-        if [[ "$m_total" -gt 0 ]]; then
-            local m_rate=$(( (m_success * 100) / m_total ))
-            printf "  %-10s %8d %8d %9d%%\n" "$model_tier" "$m_success" "$m_failure" "$m_rate"
-        fi
-    done
-    echo ""
+		local m_total=$((m_success + m_failure))
+		if [[ "$m_total" -gt 0 ]]; then
+			local m_rate=$(((m_success * 100) / m_total))
+			printf "  %-10s %8d %8d %9d%%\n" "$model_tier" "$m_success" "$m_failure" "$m_rate"
+		fi
+	done
+	echo ""
 
-    # Recent patterns (last 5)
-    echo -e "${CYAN}Recent Patterns (last 5):${NC}"
-    local recent
-    recent=$(sqlite3 -separator '|' "$MEMORY_DB" "
+	# Recent patterns (last 5)
+	echo -e "${CYAN}Recent Patterns (last 5):${NC}"
+	local recent
+	recent=$(sqlite3 -separator '|' "$MEMORY_DB" "
         SELECT type, content, created_at
         FROM learnings
         WHERE type IN ($PATTERN_TYPES)
@@ -649,25 +700,25 @@ cmd_report() {
         LIMIT 5;
     " 2>/dev/null || echo "")
 
-    if [[ -n "$recent" ]]; then
-        while IFS='|' read -r type content created_at; do
-            local icon="?"
-            case "$type" in
-                SUCCESS_PATTERN|WORKING_SOLUTION) icon="${GREEN}+${NC}" ;;
-                FAILURE_PATTERN|FAILED_APPROACH|ERROR_FIX) icon="${RED}-${NC}" ;;
-            esac
-            # Truncate long content
-            if [[ ${#content} -gt 70 ]]; then
-                content="${content:0:67}..."
-            fi
-            echo -e "  $icon $content"
-            echo "    ($created_at)"
-        done <<< "$recent"
-    else
-        echo "  (none)"
-    fi
-    echo ""
-    return 0
+	if [[ -n "$recent" ]]; then
+		while IFS='|' read -r type content created_at; do
+			local icon="?"
+			case "$type" in
+			SUCCESS_PATTERN | WORKING_SOLUTION) icon="${GREEN}+${NC}" ;;
+			FAILURE_PATTERN | FAILED_APPROACH | ERROR_FIX) icon="${RED}-${NC}" ;;
+			esac
+			# Truncate long content
+			if [[ ${#content} -gt 70 ]]; then
+				content="${content:0:67}..."
+			fi
+			echo -e "  $icon $content"
+			echo "    ($created_at)"
+		done <<<"$recent"
+	else
+		echo "  (none)"
+	fi
+	echo ""
+	return 0
 }
 
 #######################################
@@ -675,49 +726,152 @@ cmd_report() {
 # Used by suggest command to add routing context
 #######################################
 _show_model_hint() {
-    if ! ensure_db 2>/dev/null; then
-        return 0
-    fi
+	if ! ensure_db 2>/dev/null; then
+		return 0
+	fi
 
-    # Check if any patterns have model data
-    local model_patterns
-    model_patterns=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ($PATTERN_TYPES) AND (tags LIKE '%model:%' OR content LIKE '%model:%');" 2>/dev/null || echo "0")
+	# Check if any patterns have model data
+	local model_patterns
+	model_patterns=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ($PATTERN_TYPES) AND (tags LIKE '%model:%' OR content LIKE '%model:%');" 2>/dev/null || echo "0")
 
-    if [[ "$model_patterns" -gt 0 ]]; then
-        echo -e "${CYAN}Model Routing Hint:${NC}"
+	if [[ "$model_patterns" -gt 0 ]]; then
+		echo -e "${CYAN}Model Routing Hint:${NC}"
 
-        local best_model="" best_rate=0
-        for model_tier in $VALID_MODELS; do
-            local model_filter="AND (tags LIKE '%model:${model_tier}%' OR content LIKE '%model:${model_tier}%')"
-            local m_success m_failure
-            m_success=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION') $model_filter;" 2>/dev/null || echo "0")
-            m_failure=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX') $model_filter;" 2>/dev/null || echo "0")
+		local best_model="" best_rate=0
+		for model_tier in $VALID_MODELS; do
+			local model_filter="AND (tags LIKE '%model:${model_tier}%' OR content LIKE '%model:${model_tier}%')"
+			local m_success m_failure
+			m_success=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('SUCCESS_PATTERN', 'WORKING_SOLUTION') $model_filter;" 2>/dev/null || echo "0")
+			m_failure=$(sqlite3 "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE type IN ('FAILURE_PATTERN', 'FAILED_APPROACH', 'ERROR_FIX') $model_filter;" 2>/dev/null || echo "0")
 
-            local m_total=$((m_success + m_failure))
-            if [[ "$m_total" -gt 2 ]]; then
-                local m_rate=$(( (m_success * 100) / m_total ))
-                if [[ "$m_rate" -gt "$best_rate" ]]; then
-                    best_rate=$m_rate
-                    best_model=$model_tier
-                fi
-            fi
-        done
+			local m_total=$((m_success + m_failure))
+			if [[ "$m_total" -gt 2 ]]; then
+				local m_rate=$(((m_success * 100) / m_total))
+				if [[ "$m_rate" -gt "$best_rate" ]]; then
+					best_rate=$m_rate
+					best_model=$model_tier
+				fi
+			fi
+		done
 
-        if [[ -n "$best_model" ]]; then
-            echo "  Based on pattern history, $best_model has the highest success rate (${best_rate}%)"
-        else
-            echo "  Not enough model-tagged patterns for a recommendation yet."
-        fi
-        echo ""
-    fi
-    return 0
+		if [[ -n "$best_model" ]]; then
+			echo "  Based on pattern history, $best_model has the highest success rate (${best_rate}%)"
+		else
+			echo "  Not enough model-tagged patterns for a recommendation yet."
+		fi
+		echo ""
+	fi
+	return 0
+}
+
+#######################################
+# Query model usage from GitHub issue labels (t1010)
+# Correlates label data with memory patterns for richer analysis.
+# Delegates to supervisor-helper.sh labels for the actual GitHub query,
+# then enriches with pattern-tracker success rate data.
+#######################################
+cmd_label_stats() {
+	local repo_slug="" action_filter="" model_filter=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo)
+			repo_slug="$2"
+			shift 2
+			;;
+		--action)
+			action_filter="$2"
+			shift 2
+			;;
+		--model)
+			model_filter="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	local supervisor_helper="${SCRIPT_DIR}/supervisor-helper.sh"
+	if [[ ! -x "$supervisor_helper" ]]; then
+		log_error "supervisor-helper.sh not found at: $supervisor_helper"
+		return 1
+	fi
+
+	echo -e "${BOLD}Model Usage Analysis${NC} (labels + patterns)"
+	echo "════════════════════════════════════════"
+
+	# Get label data from supervisor as JSON
+	local label_args=("labels" "--json")
+	[[ -n "$repo_slug" ]] && label_args+=("--repo" "$repo_slug")
+	[[ -n "$action_filter" ]] && label_args+=("--action" "$action_filter")
+	[[ -n "$model_filter" ]] && label_args+=("--model" "$model_filter")
+
+	local label_json
+	label_json=$("$supervisor_helper" "${label_args[@]}" 2>/dev/null || echo "[]")
+
+	if [[ "$label_json" == "[]" ]]; then
+		echo ""
+		echo "No model usage labels found on GitHub issues."
+		echo "Labels are added automatically during supervisor dispatch and evaluation."
+		echo ""
+		echo "Showing memory-based pattern data instead:"
+		echo ""
+		cmd_report
+		return 0
+	fi
+
+	# Display label summary
+	echo ""
+	echo -e "${BOLD}GitHub Issue Labels:${NC}"
+
+	# Parse JSON entries (simple line-by-line since format is known)
+	echo "$label_json" | tr ',' '\n' | tr -d '[]{}' | while IFS= read -r line; do
+		local label count
+		label=$(echo "$line" | grep -o '"label":"[^"]*"' | cut -d'"' -f4 || true)
+		count=$(echo "$line" | grep -o '"count":[0-9]*' | cut -d: -f2 || true)
+		if [[ -n "$label" && -n "$count" ]]; then
+			printf "  %-25s %d issues\n" "$label" "$count"
+		fi
+	done
+
+	# Enrich with pattern-tracker success rates
+	echo ""
+	echo -e "${BOLD}Memory Pattern Success Rates:${NC}"
+
+	if ! ensure_db; then
+		echo "  (no memory database — pattern data unavailable)"
+		return 0
+	fi
+
+	for tier in haiku flash sonnet pro opus; do
+		if [[ -n "$model_filter" && "$tier" != "$model_filter" ]]; then
+			continue
+		fi
+
+		local success_count failure_count total rate
+		success_count=$(sqlite3 "$MEMORY_DB" \
+			"SELECT COUNT(*) FROM learnings WHERE type IN ('SUCCESS_PATTERN','WORKING_SOLUTION') AND (tags LIKE '%model:${tier}%' OR content LIKE '%[model:${tier}]%');" \
+			2>/dev/null || echo "0")
+		failure_count=$(sqlite3 "$MEMORY_DB" \
+			"SELECT COUNT(*) FROM learnings WHERE type IN ('FAILURE_PATTERN','FAILED_APPROACH','ERROR_FIX') AND (tags LIKE '%model:${tier}%' OR content LIKE '%[model:${tier}]%');" \
+			2>/dev/null || echo "0")
+		total=$((success_count + failure_count))
+
+		if [[ "$total" -gt 0 ]]; then
+			rate=$((success_count * 100 / total))
+			printf "  %-10s %d/%d (%d%% success)\n" "$tier" "$success_count" "$total" "$rate"
+		fi
+	done
+
+	echo ""
+	return 0
 }
 
 #######################################
 # Show help
 #######################################
 cmd_help() {
-    cat <<'EOF'
+	cat <<'EOF'
 pattern-tracker-helper.sh - Track and analyze success/failure patterns
 
 USAGE:
@@ -731,6 +885,7 @@ COMMANDS:
     stats       Show pattern statistics (includes supervisor patterns)
     export      Export patterns as JSON or CSV
     report      Generate a comprehensive pattern report
+    label-stats Query model usage from GitHub issue labels (t1010)
     help        Show this help
 
 RECORD OPTIONS:
@@ -786,32 +941,37 @@ EXAMPLES:
 
     # View statistics
     pattern-tracker-helper.sh stats
+
+    # Query model usage from GitHub issue labels
+    pattern-tracker-helper.sh label-stats --model opus
+    pattern-tracker-helper.sh label-stats --action failed
 EOF
-    return 0
+	return 0
 }
 
 #######################################
 # Main entry point
 #######################################
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    case "$command" in
-        record) cmd_record "$@" ;;
-        analyze) cmd_analyze "$@" ;;
-        suggest) cmd_suggest "$@" ;;
-        recommend) cmd_recommend "$@" ;;
-        stats) cmd_stats ;;
-        export) cmd_export "$@" ;;
-        report) cmd_report ;;
-        help|--help|-h) cmd_help ;;
-        *)
-            log_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
+	case "$command" in
+	record) cmd_record "$@" ;;
+	analyze) cmd_analyze "$@" ;;
+	suggest) cmd_suggest "$@" ;;
+	recommend) cmd_recommend "$@" ;;
+	stats) cmd_stats ;;
+	export) cmd_export "$@" ;;
+	report) cmd_report ;;
+	label-stats) cmd_label_stats "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -2978,17 +2978,18 @@ model_to_tier() {
 	if [[ -z "$model_str" ]]; then
 		return 0
 	fi
+	# Order matters: specific patterns before generic ones (ShellCheck SC2221/SC2222)
 	case "$model_str" in
+	*gpt-4.1-mini*) echo "flash" ;;
+	*gpt-4.1*) echo "sonnet" ;;
+	*gemini-2.5-flash*) echo "flash" ;;
+	*gemini-2.5-pro*) echo "pro" ;;
 	*haiku*) echo "haiku" ;;
 	*flash*) echo "flash" ;;
 	*sonnet*) echo "sonnet" ;;
 	*opus*) echo "opus" ;;
 	*pro*) echo "pro" ;;
 	*o3*) echo "opus" ;;
-	*gpt-4.1-mini*) echo "flash" ;;
-	*gpt-4.1*) echo "sonnet" ;;
-	*gemini-2.5-flash*) echo "flash" ;;
-	*gemini-2.5-pro*) echo "pro" ;;
 	*) echo "" ;;
 	esac
 	return 0

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -2968,6 +2968,289 @@ ensure_status_labels() {
 }
 
 #######################################
+# Extract model tier name from a full model string (t1010)
+# Maps provider/model strings to tier names (haiku, flash, sonnet, pro, opus).
+# $1: model string (e.g. "anthropic/claude-opus-4-6")
+# Outputs tier name on stdout, empty if unrecognised.
+#######################################
+model_to_tier() {
+	local model_str="${1:-}"
+	if [[ -z "$model_str" ]]; then
+		return 0
+	fi
+	case "$model_str" in
+	*haiku*) echo "haiku" ;;
+	*flash*) echo "flash" ;;
+	*sonnet*) echo "sonnet" ;;
+	*opus*) echo "opus" ;;
+	*pro*) echo "pro" ;;
+	*o3*) echo "opus" ;;
+	*gpt-4.1-mini*) echo "flash" ;;
+	*gpt-4.1*) echo "sonnet" ;;
+	*gemini-2.5-flash*) echo "flash" ;;
+	*gemini-2.5-pro*) echo "pro" ;;
+	*) echo "" ;;
+	esac
+	return 0
+}
+
+#######################################
+# Add an action:model label to a GitHub issue (t1010)
+# Labels track which model was used for each lifecycle action.
+# Format: "action:tier" (e.g. "implemented:opus", "failed:sonnet")
+# Labels are append-only (history, not state) — never removed.
+# Created on-demand via gh label create --force (idempotent).
+#
+# Valid actions: dispatched, implemented, reviewed, verified,
+#   documented, failed, retried, escalated, planned, researched
+#
+# $1: task_id
+# $2: action (e.g. "implemented", "failed", "retried")
+# $3: model_tier (e.g. "opus", "sonnet") — or full model string (auto-extracted)
+# $4: project_root (optional)
+#
+# Fails silently if: gh not available, no auth, no issue ref, or API error.
+# This is best-effort — label failures must never block task processing.
+#######################################
+add_model_label() {
+	local task_id="${1:-}"
+	local action="${2:-}"
+	local model_input="${3:-}"
+	local project_root="${4:-}"
+
+	# Validate required params
+	if [[ -z "$task_id" || -z "$action" || -z "$model_input" ]]; then
+		return 0
+	fi
+
+	# Skip if gh CLI not available or not authenticated
+	command -v gh &>/dev/null || return 0
+	check_gh_auth || return 0
+
+	# Resolve model tier from full model string if needed
+	local tier="$model_input"
+	case "$model_input" in
+	haiku | flash | sonnet | pro | opus) ;; # Already a tier name
+	*)
+		tier=$(model_to_tier "$model_input")
+		if [[ -z "$tier" ]]; then
+			return 0
+		fi
+		;;
+	esac
+
+	# Find the GitHub issue number
+	local issue_number
+	issue_number=$(find_task_issue_number "$task_id" "$project_root")
+	if [[ -z "$issue_number" ]]; then
+		return 0
+	fi
+
+	# Detect repo slug
+	if [[ -z "$project_root" ]]; then
+		project_root=$(find_project_root 2>/dev/null || echo ".")
+	fi
+	local repo_slug
+	repo_slug=$(detect_repo_slug "$project_root" 2>/dev/null || echo "")
+	if [[ -z "$repo_slug" ]]; then
+		return 0
+	fi
+
+	local label_name="${action}:${tier}"
+
+	# Color scheme by action category:
+	#   dispatch/implement = blue shades (productive work)
+	#   review/verify/document = green shades (quality work)
+	#   fail/retry/escalate = red/orange shades (problems)
+	#   plan/research = purple shades (preparation)
+	local label_color label_desc
+	case "$action" in
+	dispatched)
+		label_color="1D76DB"
+		label_desc="Task dispatched to $tier model"
+		;;
+	implemented)
+		label_color="0075CA"
+		label_desc="Task implemented by $tier model"
+		;;
+	reviewed)
+		label_color="0E8A16"
+		label_desc="Task reviewed by $tier model"
+		;;
+	verified)
+		label_color="2EA44F"
+		label_desc="Task verified by $tier model"
+		;;
+	documented)
+		label_color="A2EEEF"
+		label_desc="Task documented by $tier model"
+		;;
+	failed)
+		label_color="D93F0B"
+		label_desc="Task failed with $tier model"
+		;;
+	retried)
+		label_color="E4E669"
+		label_desc="Task retried with $tier model"
+		;;
+	escalated)
+		label_color="FBCA04"
+		label_desc="Task escalated from $tier model"
+		;;
+	planned)
+		label_color="D4C5F9"
+		label_desc="Task planned with $tier model"
+		;;
+	researched)
+		label_color="C5DEF5"
+		label_desc="Task researched with $tier model"
+		;;
+	*)
+		label_color="BFDADC"
+		label_desc="Model $tier used for $action"
+		;;
+	esac
+
+	# Create label on-demand (idempotent — --force updates if exists)
+	gh label create "$label_name" --repo "$repo_slug" \
+		--color "$label_color" --description "$label_desc" \
+		--force 2>/dev/null || true
+
+	# Add label to issue (append-only — never remove model labels)
+	gh issue edit "$issue_number" --repo "$repo_slug" \
+		--add-label "$label_name" 2>/dev/null || true
+
+	log_info "Added label '$label_name' to issue #$issue_number for $task_id (t1010)"
+	return 0
+}
+
+#######################################
+# Query model usage labels for analysis (t1010)
+# Lists all action:model labels on issues in the repo.
+# Supports filtering by action, model tier, or both.
+#
+# Usage: cmd_labels [--action ACTION] [--model TIER] [--repo SLUG] [--json]
+#######################################
+cmd_labels() {
+	local action_filter="" model_filter="" repo_slug="" json_output="false"
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--action)
+			action_filter="$2"
+			shift 2
+			;;
+		--model)
+			model_filter="$2"
+			shift 2
+			;;
+		--repo)
+			repo_slug="$2"
+			shift 2
+			;;
+		--json)
+			json_output="true"
+			shift
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	# Detect repo if not provided
+	if [[ -z "$repo_slug" ]]; then
+		local project_root
+		project_root=$(find_project_root 2>/dev/null || echo ".")
+		repo_slug=$(detect_repo_slug "$project_root" 2>/dev/null || echo "")
+	fi
+
+	if [[ -z "$repo_slug" ]]; then
+		log_error "Cannot detect repo slug. Use --repo owner/repo"
+		return 1
+	fi
+
+	# Skip if gh CLI not available
+	if ! command -v gh &>/dev/null; then
+		log_error "gh CLI not available"
+		return 1
+	fi
+
+	# Build label search pattern
+	local label_pattern=""
+	if [[ -n "$action_filter" && -n "$model_filter" ]]; then
+		label_pattern="${action_filter}:${model_filter}"
+	elif [[ -n "$action_filter" ]]; then
+		label_pattern="${action_filter}:"
+	elif [[ -n "$model_filter" ]]; then
+		label_pattern=":${model_filter}"
+	fi
+
+	# Valid actions for model tracking
+	local valid_actions="dispatched implemented reviewed verified documented failed retried escalated planned researched"
+
+	if [[ "$json_output" == "true" ]]; then
+		# JSON output: list all model labels with issue counts
+		local first_entry="true"
+		printf '['
+		for act in $valid_actions; do
+			for tier in haiku flash sonnet pro opus; do
+				local lbl="${act}:${tier}"
+				# Skip if doesn't match filter
+				if [[ -n "$label_pattern" && "$lbl" != *"$label_pattern"* ]]; then
+					continue
+				fi
+				local count
+				count=$(gh issue list --repo "$repo_slug" --label "$lbl" --state all --json number --jq 'length' 2>/dev/null || echo "0")
+				if [[ "$count" -gt 0 ]]; then
+					if [[ "$first_entry" == "true" ]]; then
+						first_entry="false"
+					else
+						printf ','
+					fi
+					printf '{"label":"%s","action":"%s","model":"%s","count":%d}' "$lbl" "$act" "$tier" "$count"
+				fi
+			done
+		done
+		printf ']\n'
+	else
+		# Human-readable output
+		echo -e "${BOLD}Model Usage Labels${NC} ($repo_slug)"
+		echo "─────────────────────────────────────"
+
+		local found=0
+		for act in $valid_actions; do
+			local act_found=0
+			for tier in haiku flash sonnet pro opus; do
+				local lbl="${act}:${tier}"
+				if [[ -n "$label_pattern" && "$lbl" != *"$label_pattern"* ]]; then
+					continue
+				fi
+				local count
+				count=$(gh issue list --repo "$repo_slug" --label "$lbl" --state all --json number --jq 'length' 2>/dev/null || echo "0")
+				if [[ "$count" -gt 0 ]]; then
+					if [[ "$act_found" -eq 0 ]]; then
+						echo ""
+						echo -e "${BOLD}${act}${NC}:"
+						act_found=1
+					fi
+					printf "  %-10s %d issues\n" "$tier" "$count"
+					found=1
+				fi
+			done
+		done
+
+		if [[ "$found" -eq 0 ]]; then
+			echo ""
+			echo "No model usage labels found."
+			echo "Labels are added automatically during supervisor dispatch and evaluation."
+		fi
+		echo ""
+	fi
+	return 0
+}
+
+#######################################
 # Find GitHub issue number for a task from TODO.md (t164)
 # Outputs the issue number on stdout, empty if not found.
 # $1: task_id
@@ -5928,6 +6211,9 @@ cmd_dispatch() {
 
 	# Transition to running
 	cmd_transition "$task_id" "running" --session "pid:$worker_pid"
+
+	# Add dispatched:model label to GitHub issue (t1010)
+	add_model_label "$task_id" "dispatched" "$resolved_model" "${trepo:-.}" 2>>"$SUPERVISOR_LOG" || true
 
 	log_success "Dispatched $task_id (PID: $worker_pid)"
 	echo "$worker_pid"
@@ -10120,6 +10406,11 @@ cmd_pulse() {
 			local tid_desc
 			tid_desc=$(db "$SUPERVISOR_DB" "SELECT description FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo "")
 
+			# Get task model and repo for model label tracking (t1010)
+			local tid_model tid_repo
+			tid_model=$(db "$SUPERVISOR_DB" "SELECT model FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo "")
+			tid_repo=$(db "$SUPERVISOR_DB" "SELECT repo FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo "")
+
 			# Skip AI eval for stuck tasks (it already timed out once)
 			local skip_ai="false"
 			if [[ "$current_task_state" == "evaluating" ]]; then
@@ -10180,6 +10471,8 @@ cmd_pulse() {
 					# Clean up worker process tree before re-dispatch (t128.7)
 					cleanup_worker_processes "$tid"
 					store_failure_pattern "$tid" "escalated" "Quality gate -> $escalated_model" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
+					# Add escalated:model label (original model that failed quality gate) (t1010)
+					add_model_label "$tid" "escalated" "$tid_model" "${tid_repo:-.}" 2>>"$SUPERVISOR_LOG" || true
 					send_task_notification "$tid" "escalated" "Re-queued with $escalated_model" 2>>"$SUPERVISOR_LOG" || true
 					continue
 				fi
@@ -10200,6 +10493,8 @@ cmd_pulse() {
 				send_task_notification "$tid" "complete" "$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 				# Store success pattern in memory (t128.6)
 				store_success_pattern "$tid" "$outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
+				# Add implemented:model label to GitHub issue (t1010)
+				add_model_label "$tid" "implemented" "$tid_model" "${tid_repo:-.}" 2>>"$SUPERVISOR_LOG" || true
 				# Self-heal: if this was a diagnostic task, re-queue the parent (t150)
 				handle_diagnostic_completion "$tid" 2>>"$SUPERVISOR_LOG" || true
 				;;
@@ -10214,6 +10509,8 @@ cmd_pulse() {
 				cleanup_worker_processes "$tid"
 				# Store failure pattern in memory (t128.6)
 				store_failure_pattern "$tid" "retry" "$outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
+				# Add retried:model label to GitHub issue (t1010)
+				add_model_label "$tid" "retried" "$tid_model" "${tid_repo:-.}" 2>>"$SUPERVISOR_LOG" || true
 				# Auto-escalate model on retry so re-prompt uses stronger model (t314 wiring)
 				escalate_model_on_failure "$tid" 2>>"$SUPERVISOR_LOG" || true
 				# Backend quota errors: defer re-prompt to next pulse (t095-diag-1).
@@ -10247,6 +10544,8 @@ cmd_pulse() {
 						send_task_notification "$tid" "blocked" "Max retries exceeded: $outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 						# Store failure pattern in memory (t128.6)
 						store_failure_pattern "$tid" "blocked" "Max retries exceeded: $outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
+						# Add failed:model label to GitHub issue (t1010)
+						add_model_label "$tid" "failed" "$tid_model" "${tid_repo:-.}" 2>>"$SUPERVISOR_LOG" || true
 						# Self-heal: attempt diagnostic subtask (t150)
 						attempt_self_heal "$tid" "blocked" "$outcome_detail" "${batch_id:-}" 2>>"$SUPERVISOR_LOG" || true
 					else
@@ -10258,6 +10557,8 @@ cmd_pulse() {
 						send_task_notification "$tid" "failed" "Re-prompt dispatch failed: $outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 						# Store failure pattern in memory (t128.6)
 						store_failure_pattern "$tid" "failed" "Re-prompt dispatch failed: $outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
+						# Add failed:model label to GitHub issue (t1010)
+						add_model_label "$tid" "failed" "$tid_model" "${tid_repo:-.}" 2>>"$SUPERVISOR_LOG" || true
 						# Self-heal: attempt diagnostic subtask (t150)
 						attempt_self_heal "$tid" "failed" "$outcome_detail" "${batch_id:-}" 2>>"$SUPERVISOR_LOG" || true
 					fi
@@ -10277,6 +10578,8 @@ cmd_pulse() {
 				send_task_notification "$tid" "blocked" "$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 				# Store failure pattern in memory (t128.6)
 				store_failure_pattern "$tid" "blocked" "$outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
+				# Add failed:model label to GitHub issue (t1010)
+				add_model_label "$tid" "failed" "$tid_model" "${tid_repo:-.}" 2>>"$SUPERVISOR_LOG" || true
 				# Self-heal: attempt diagnostic subtask (t150)
 				attempt_self_heal "$tid" "blocked" "$outcome_detail" "${batch_id:-}" 2>>"$SUPERVISOR_LOG" || true
 				;;
@@ -10295,6 +10598,8 @@ cmd_pulse() {
 				send_task_notification "$tid" "failed" "$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 				# Store failure pattern in memory (t128.6)
 				store_failure_pattern "$tid" "failed" "$outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
+				# Add failed:model label to GitHub issue (t1010)
+				add_model_label "$tid" "failed" "$tid_model" "${tid_repo:-.}" 2>>"$SUPERVISOR_LOG" || true
 				# Self-heal: attempt diagnostic subtask (t150)
 				attempt_self_heal "$tid" "failed" "$outcome_detail" "${batch_id:-}" 2>>"$SUPERVISOR_LOG" || true
 				;;
@@ -11849,19 +12154,12 @@ store_failure_pattern() {
 		return 0
 	fi
 
-	# Look up model tier from task record for pattern routing (t102.3)
+	# Look up model tier from task record for pattern routing (t102.3, t1010)
 	local model_tier=""
 	local task_model
 	task_model=$(db "$SUPERVISOR_DB" "SELECT model FROM tasks WHERE id = '$(sql_escape "$task_id")';" 2>/dev/null || echo "")
 	if [[ -n "$task_model" ]]; then
-		# Extract tier name from model string (e.g., "anthropic/claude-opus-4-6" -> "opus")
-		case "$task_model" in
-		*haiku*) model_tier="haiku" ;;
-		*flash*) model_tier="flash" ;;
-		*sonnet*) model_tier="sonnet" ;;
-		*opus*) model_tier="opus" ;;
-		*pro*) model_tier="pro" ;;
-		esac
+		model_tier=$(model_to_tier "$task_model")
 	fi
 
 	# Build structured content for pattern-tracker compatibility
@@ -11921,15 +12219,9 @@ store_success_pattern() {
 		fi
 	fi
 
-	# Extract tier name from model string
+	# Extract tier name from model string (t1010: use shared model_to_tier)
 	if [[ -n "$task_model" ]]; then
-		case "$task_model" in
-		*haiku*) model_tier="haiku" ;;
-		*flash*) model_tier="flash" ;;
-		*sonnet*) model_tier="sonnet" ;;
-		*opus*) model_tier="opus" ;;
-		*pro*) model_tier="pro" ;;
-		esac
+		model_tier=$(model_to_tier "$task_model")
 	fi
 
 	# Build structured content for pattern-tracker compatibility
@@ -13190,16 +13482,16 @@ cmd_cron() {
 	local script_path
 	script_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/supervisor-helper.sh"
 	local cron_marker="# aidevops-supervisor-pulse"
-	
+
 	# Detect current PATH for cron environment (t1006)
 	local user_path="${PATH}"
-	
+
 	# Detect GH_TOKEN from gh CLI if available (t1006)
 	local gh_token=""
 	if command -v gh &>/dev/null; then
 		gh_token=$(gh auth token 2>/dev/null || true)
 	fi
-	
+
 	# Build cron command with environment variables
 	local env_vars=""
 	if [[ -n "$user_path" ]]; then
@@ -13208,7 +13500,7 @@ cmd_cron() {
 	if [[ -n "$gh_token" ]]; then
 		env_vars="${env_vars:+${env_vars} }GH_TOKEN=${gh_token}"
 	fi
-	
+
 	local cron_cmd="*/${interval} * * * * ${env_vars:+${env_vars} }${script_path} pulse ${batch_arg} >> ${SUPERVISOR_DIR}/cron.log 2>&1 ${cron_marker}"
 
 	case "$action" in
@@ -14193,6 +14485,7 @@ Usage:
   supervisor-helper.sh cron [install|uninstall|status] Manage cron-based pulse scheduling
   supervisor-helper.sh watch [--repo path]            Watch TODO.md for changes (fswatch)
   supervisor-helper.sh dashboard [--batch id] [--interval N] Live TUI dashboard
+  supervisor-helper.sh labels [--action X] [--model Y] [--json]  Query model usage labels (t1010)
   supervisor-helper.sh db [sql]                      Direct SQLite access
   supervisor-helper.sh help                          Show this help
 
@@ -14527,6 +14820,7 @@ main() {
 	backup) cmd_backup "$@" ;;
 	restore) cmd_restore "$@" ;;
 	db) cmd_db "$@" ;;
+	labels) cmd_labels "$@" ;;
 	help | --help | -h) show_usage ;;
 	*)
 		log_error "Unknown command: $command"


### PR DESCRIPTION
## Summary

Adds `action:model` label tracking to GitHub issues, enabling data-driven model selection by recording which model tier was used for each lifecycle action on a task.

### Changes

**supervisor-helper.sh:**
- `model_to_tier()` — shared helper to extract tier name from full model strings (DRY refactor, replaces 2 inline case blocks)
- `add_model_label()` — adds `action:tier` labels to GitHub issues (e.g. `implemented:opus`, `failed:sonnet`). Best-effort, fails silently, never blocks task processing. Labels created on-demand via `gh label create --force`
- `cmd_labels` — new subcommand to query model usage labels (`--action`, `--model`, `--json` filters)
- Wired into supervisor lifecycle:
  - Dispatch → `dispatched:{tier}`
  - Evaluate complete → `implemented:{tier}`
  - Evaluate retry → `retried:{tier}`
  - Quality gate escalation → `escalated:{tier}`
  - Blocked/failed → `failed:{tier}`

**pattern-tracker-helper.sh:**
- `cmd_label_stats` — correlates GitHub issue labels with memory-based pattern data for enriched model analysis

### Design Decisions

- Labels are **append-only** (history, not state) — never removed, enabling full lifecycle audit
- Color scheme groups by action category: blue (productive), green (quality), red/orange (problems), purple (preparation)
- Uses `gh label create --force` for idempotent on-demand label creation
- All label operations wrapped in `|| true` — label failures never block task processing
- JSON output uses pure bash `printf` (no python3 dependency)
- Reordered `model_to_tier()` case patterns: specific (gpt-4.1-mini, gemini-2.5-*) before generic (*flash*, *pro*) for ShellCheck SC2221/SC2222 compliance

### Verification

- `bash -n` syntax check: PASS on both files
- ShellCheck `-S warning`: zero violations on new code
- Pattern-tracker ShellCheck: zero violations

Ref #1300