### PR TITLE
t1015: Fix agent name collisions in OpenCode plugin

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -309,7 +309,7 @@ function loadAgentDefinitions() {
 
       const { data } = parseFrontmatter(content);
       agents.push({
-        name: basename(file, ".md"),
+        name: basename(file, ".md"), // Root files keep simple names (no collision risk)
         description: data.description || "",
         mode: data.mode || "primary",
         relPath: file,
@@ -330,6 +330,8 @@ function loadAgentDefinitions() {
     "memory",
     "custom",
     "draft",
+    "scripts",
+    "templates",
   ];
 
   for (const subdir of subdirs) {
@@ -379,11 +381,15 @@ function loadAgentsRecursive(dirPath, relBase, agents) {
       if (!content) continue;
 
       const { data } = parseFrontmatter(content);
+      // Use relative path without .md extension to avoid collisions
+      // e.g., tools/git/github-cli.md → tools/git/github-cli
+      const relPath = join(relBase, entry.name);
+      const agentName = relPath.replace(/\.md$/, "");
       agents.push({
-        name: basename(entry.name, ".md"),
+        name: agentName,
         description: data.description || "",
         mode: data.mode || "subagent",
-        relPath: join(relBase, entry.name),
+        relPath: relPath,
       });
     }
   }

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -381,8 +381,10 @@ function loadAgentsRecursive(dirPath, relBase, agents) {
       if (!content) continue;
 
       const { data } = parseFrontmatter(content);
-      // Use relative path without .md extension to avoid collisions
+      // Use relative path without .md extension to avoid name collisions (t1015)
       // e.g., tools/git/github-cli.md → tools/git/github-cli
+      //       services/git/github-cli.md → services/git/github-cli
+      // This ensures agents with the same filename in different directories don't collide
       const relPath = join(relBase, entry.name);
       const agentName = relPath.replace(/\.md$/, "");
       agents.push({


### PR DESCRIPTION
Fix agent name collisions in OpenCode plugin by using relative paths instead of basename.

**Problem**: 204 agents were silently lost because `loadAgentDefinitions()` uses `basename(file, ".md")` as the agent name. Files like `tools/git/github-cli.md` and `services/git/github-cli.md` both register as `github-cli`, with the second one being dropped.

**Solution**:
- Changed `loadAgentsRecursive()` to use full relative path without `.md` extension as agent name
- Example: `tools/git/github-cli.md` → `tools/git/github-cli` (not `github-cli`)
- Added `scripts/` (65 md files) and `templates/` (8 md files) to scanned subdirs list

**Testing**: Will verify all agents load without collisions after this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended agent plugin loading system to include scripts and templates directories alongside existing plugins
  * Improved agent naming convention by using relative path identifiers instead of filenames
  * Enhanced data flow for loaded subagents with consistent path representation to prevent naming collisions between similarly named files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->