### PR TITLE
t1017: Protect assignee ownership in supervisor

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -284,6 +284,8 @@ supervisor-helper.sh status <batch-id>
 
 **Task claiming** (t165): TODO.md `assignee:` field is the authoritative claim source. Works offline, with any git host. GitHub Issue sync is optional best-effort (requires `gh` CLI + `ref:GH#` in TODO.md). GH Issue creation is opt-in: use `--with-issue` flag or `SUPERVISOR_AUTO_ISSUE=true`.
 
+**Assignee ownership** (t1017): NEVER remove or change `assignee:` on a task without explicit user confirmation. The assignee may be a contributor on another host whose work you cannot see. `unclaim` requires `--force` to release a task claimed by someone else. The full-loop claims the task automatically before starting work — if the task is already claimed by another, the loop stops.
+
 **Cron pulse is mandatory** for autonomous operation. Without it, the supervisor is passive and requires manual `pulse` calls. The pulse cycle: check workers -> evaluate outcomes -> dispatch next -> cleanup.
 
 **Session memory monitoring + respawn** (t264, t264.1): Long-running OpenCode/Bun sessions accumulate WebKit malloc dirty pages that are never returned to the OS (25GB+ observed). Phase 11 of the pulse cycle checks the parent session's `phys_footprint` when a batch wave completes (no running/queued tasks). If memory exceeds `SUPERVISOR_SELF_MEM_LIMIT` (default: 8192MB), it saves a checkpoint, logs the respawn event to `~/.aidevops/logs/respawn-history.log`, and exits cleanly for the next cron pulse to start fresh. Use `supervisor-helper.sh mem-check` to inspect memory and `supervisor-helper.sh respawn-history` to review respawn patterns.

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -64,10 +64,31 @@ If the first argument is NOT a task ID (it's a description):
 ## Full Loop Phases
 
 ```text
-Task Development → Preflight → PR Create → PR Review → Postflight → Deploy
+Claim → Branch Setup → Task Development → Preflight → PR Create → PR Review → Postflight → Deploy
 ```
 
 ## Workflow
+
+### Step 0.5: Claim Task (t1017)
+
+If the first argument is a task ID (`t\d+`), claim it before starting work. This prevents two agents (or a human and an agent) from working on the same task concurrently.
+
+```bash
+# Claim the task — adds assignee: to TODO.md
+~/.aidevops/agents/scripts/supervisor-helper.sh claim "$TASK_ID" "$(pwd)"
+```
+
+**Exit codes:**
+- `0` - Claimed successfully (or already claimed by you) — proceed
+- `1` - Claimed by someone else — **STOP, do not start work**
+
+**If claim fails** (task is claimed by another contributor):
+- In interactive mode: inform the user and stop
+- In headless mode: exit cleanly with `BLOCKED: task claimed by assignee:{name}`
+
+**Skip claim when:**
+- The first argument is not a task ID (it's a description)
+- The `--no-claim` flag is passed
 
 ### Step 1: Auto-Branch Setup
 


### PR DESCRIPTION
## Summary

- **cmd_unclaim()**: Add `--force` flag — rejects unclaim of foreign assignee without it
- **get_task_assignee()**: Fix false positive matching `assignee:` in description prose (t1019) — strips backtick segments, takes last match
- **full-loop.md**: Add Step 0.5 — claim task before branch setup, prevents concurrent work on same task
- **AGENTS.md**: Add assignee ownership rule

## Context

During supervisor session, I removed `assignee:marcusquinn` from t319.1 without checking if Marcus was working on it from another host. This exposed three gaps:
1. `unclaim` had no ownership check (already existed but no `--force` override)
2. `full-loop` didn't claim tasks before starting work
3. `get_task_assignee()` matched `assignee:someone-else` from task description text, causing `claim t1017` to fail

## Testing

- `bash -n` syntax check: pass
- Functional test: 4/4 cases pass (description text, simple, backtick, no assignee)