### PR TITLE
t1015: Fix AGENT_MCP_TOOLS lookup for path-based agent names

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -700,20 +700,29 @@ function applyAgentMcpTools(config) {
 
   let updated = 0;
 
-  for (const [agentName, toolPatterns] of Object.entries(AGENT_MCP_TOOLS)) {
-    if (!config.agent[agentName]) continue;
+  for (const [mcpAgentName, toolPatterns] of Object.entries(AGENT_MCP_TOOLS)) {
     if (toolPatterns.length === 0) continue;
 
-    // Ensure agent has a tools section
-    if (!config.agent[agentName].tools) {
-      config.agent[agentName].tools = {};
-    }
+    // Find matching agent(s) — check both exact name and path-based names
+    // ending with the basename (t1015: agents now use path-based names like
+    // "tools/wordpress/mainwp" instead of just "mainwp")
+    const matchingKeys = Object.keys(config.agent).filter(
+      (key) => key === mcpAgentName || key.endsWith("/" + mcpAgentName),
+    );
+    if (matchingKeys.length === 0) continue;
 
-    for (const pattern of toolPatterns) {
-      // Only set if not already configured (shell script takes precedence)
-      if (!(pattern in config.agent[agentName].tools)) {
-        config.agent[agentName].tools[pattern] = true;
-        updated++;
+    for (const matchKey of matchingKeys) {
+      // Ensure agent has a tools section
+      if (!config.agent[matchKey].tools) {
+        config.agent[matchKey].tools = {};
+      }
+
+      for (const pattern of toolPatterns) {
+        // Only set if not already configured (shell script takes precedence)
+        if (!(pattern in config.agent[matchKey].tools)) {
+          config.agent[matchKey].tools[pattern] = true;
+          updated++;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- Fix `applyAgentMcpTools()` to match path-based agent names after t1015 changed agent registration from basenames to relative paths
- Without this fix, MCP tool permissions (outscraper, mainwp, etc.) are never applied because the lookup key `outscraper` doesn't match the registered name `services/outscraper/outscraper`
- Uses `endsWith("/" + basename)` matching so both old basename keys and new path-based names work

Ref #1308