### PR TITLE
chore: reduce CI notification noise from issue-sync workflow

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -8,7 +8,7 @@ on:
       - 'todo/PLANS.md'
       - 'todo/tasks/**'
   issues:
-    types: [opened, closed, reopened, edited, labeled]
+    types: [opened]
   workflow_dispatch:
     inputs:
       command:
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 10
     concurrency:
       group: issue-sync-push-${{ github.ref }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     permissions:
       contents: write
       issues: write
@@ -179,30 +179,8 @@ jobs:
         run: |
           chmod +x .agents/scripts/issue-sync-helper.sh
           chmod +x .agents/scripts/shared-constants.sh
-
-          TASK_ID="${{ steps.check-issue.outputs.task_id }}"
-          ISSUE_NUM="${{ github.event.issue.number }}"
-          ACTION="${{ github.event.action }}"
-
-          echo "=== Issue event: $ACTION for $TASK_ID (#$ISSUE_NUM) ==="
-
-          case "$ACTION" in
-            opened)
-              # Pull the new issue ref into TODO.md
-              bash .agents/scripts/issue-sync-helper.sh pull --verbose || true
-              ;;
-            closed)
-              # If issue was closed, check if TODO.md task should be marked done
-              echo "Issue #$ISSUE_NUM closed. Run 'issue-sync-helper.sh status' to check drift."
-              ;;
-            reopened)
-              echo "Issue #$ISSUE_NUM reopened. Manual TODO.md update may be needed."
-              ;;
-            edited|labeled)
-              # Re-enrich if the issue was edited (might need label sync)
-              echo "Issue #$ISSUE_NUM edited/labeled. No automatic TODO.md update."
-              ;;
-          esac
+          echo "=== New issue opened: ${{ steps.check-issue.outputs.task_id }} (#${{ github.event.issue.number }}) ==="
+          bash .agents/scripts/issue-sync-helper.sh pull --verbose || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Remove issue event types that generated no-op workflow runs (`closed`, `reopened`, `edited`, `labeled`) — only keep `opened` which actually syncs refs to TODO.md
- Enable `cancel-in-progress` on push job so rapid TODO.md pushes don't queue redundant runs
- Simplify issue job handler

### Problem

The `labeled` and `edited` events were the main noise source: every time the supervisor updated a status label or edited an issue title, it triggered a full workflow run that just logged a message and exited. With the supervisor pulsing every 2 minutes and updating multiple issues per pulse, this generated dozens of workflow runs (and cancellation emails) per hour.

### Impact

Eliminates ~80% of issue-sync workflow runs. The remaining triggers (push to TODO.md, new issue opened) are the only ones that do actual work.

### User action still needed

Go to https://github.com/marcusquinn/aidevops/settings/notifications and disable email notifications for "Actions" workflow runs — or set to "Only notify for failed workflows". This catches any remaining noise from other workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified issue synchronization workflow to trigger on new issue openings only, reducing event handling complexity.
  * Updated job cancellation settings to terminate concurrent workflow runs, improving resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->