### PR TITLE
t1028: Fix claim-task-id.sh to prefix issue titles with task ID

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -312,6 +312,25 @@ allocate_online() {
 	local next_id=$((highest_id + 1))
 	log_success "Allocated task ID: t${next_id}"
 
+	# Step 5: Update issue title with task ID prefix
+	local prefixed_title="t${next_id}: ${TASK_TITLE}"
+	case "$platform" in
+	github)
+		if gh issue edit "$issue_num" --title "$prefixed_title" --repo "$(cd "$repo_path" && gh repo view --json nameWithOwner -q .nameWithOwner)" 2>/dev/null; then
+			log_success "Updated issue title: ${prefixed_title}"
+		else
+			log_warn "Failed to update issue title (issue created without task ID prefix)"
+		fi
+		;;
+	gitlab)
+		if (cd "$repo_path" && glab issue update "$issue_num" --title "$prefixed_title") 2>/dev/null; then
+			log_success "Updated issue title: ${prefixed_title}"
+		else
+			log_warn "Failed to update issue title (issue created without task ID prefix)"
+		fi
+		;;
+	esac
+
 	# Output in machine-readable format
 	echo "task_id=t${next_id}"
 	echo "ref=${ref_prefix}#${issue_num}"


### PR DESCRIPTION
## Summary

- After `claim-task-id.sh` allocates a task ID (e.g., `t1028`), it now updates the GitHub/GitLab issue title to include the `tNNN:` prefix
- Previously, issues were created with the raw title before the task ID was known, so they lacked the prefix (e.g., GH#1347 was missing `t1027:`)
- Adds `gh issue edit` (GitHub) and `glab issue update` (GitLab) calls after ID allocation, with graceful fallback if the update fails

Fixes #1351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task ID allocation now includes automatic synchronization with remote issue titles. When a task ID is allocated in online mode, the remote issue title is updated to include the new task ID prefix. This enhancement supports both GitHub and GitLab platforms, with success logging and graceful handling if updates fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->