### PR TITLE
t1031: Restore missing supervisor globals + add globals test

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -196,7 +196,13 @@ readonly SESSION_DISTILL_HELPER="${SCRIPT_DIR}/session-distill-helper.sh"       
 readonly MEMORY_AUDIT_HELPER="${SCRIPT_DIR}/memory-audit-pulse.sh"              # Used by pulse Phase 9 (t185)
 readonly SESSION_CHECKPOINT_HELPER="${SCRIPT_DIR}/session-checkpoint-helper.sh" # Used by respawn (t264.1)
 readonly RESPAWN_LOG="${HOME}/.aidevops/logs/respawn-history.log"               # Persistent respawn log (t264.1)
+SUPERVISOR_LOG_DIR="${HOME}/.aidevops/logs"
+mkdir -p "$SUPERVISOR_LOG_DIR" 2>/dev/null || true
+SUPERVISOR_LOG="${SUPERVISOR_LOG_DIR}/supervisor.log"
+readonly PULSE_LOCK_DIR="${SUPERVISOR_DIR}/pulse.lock"
+readonly PULSE_LOCK_TIMEOUT="${SUPERVISOR_PULSE_LOCK_TIMEOUT:-600}"
 export MAIL_HELPER MEMORY_HELPER SESSION_REVIEW_HELPER SESSION_DISTILL_HELPER MEMORY_AUDIT_HELPER SESSION_CHECKPOINT_HELPER
+export SUPERVISOR_LOG SUPERVISOR_LOG_DIR PULSE_LOCK_DIR PULSE_LOCK_TIMEOUT
 
 # Valid states for the state machine
 readonly VALID_STATES="queued dispatched running evaluating retrying complete pr_review review_triage merging merged deploying deployed verifying verified verify_failed blocked failed cancelled"
@@ -260,12 +266,10 @@ readonly DIM='\033[2m'
 # log_info, log_success, log_warn, log_error, log_verbose, sql_escape, db, log_cmd
 # are defined in supervisor/_common.sh (sourced above)
 
-
 # ============================================================
 # Functions below are kept in the monolith as glue/router/UI.
 # All domain functions have been moved to supervisor/ modules.
 # ============================================================
-
 
 #######################################
 # Show usage

--- a/tests/test-supervisor-globals.sh
+++ b/tests/test-supervisor-globals.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# test-supervisor-globals.sh
+#
+# Verify all supervisor modules can be sourced without unbound variable errors.
+# This catches the class of bug where modularization moves functions but drops
+# the global variable definitions they depend on.
+#
+# How it works:
+# 1. Sources supervisor-helper.sh (which sources all modules) with set -u
+# 2. Runs `supervisor-helper.sh help` to exercise the main code path
+# 3. Checks that key globals are defined and non-empty
+#
+# Usage: bash tests/test-supervisor-globals.sh
+# Exit codes: 0 = pass, 1 = failure
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUPERVISOR="$REPO_DIR/.agents/scripts/supervisor-helper.sh"
+
+PASS=0
+FAIL=0
+
+pass() {
+	PASS=$((PASS + 1))
+	echo "  PASS: $1"
+}
+fail() {
+	FAIL=$((FAIL + 1))
+	echo "  FAIL: $1"
+}
+
+echo "=== Supervisor Globals Test ==="
+echo ""
+
+# Test 1: supervisor-helper.sh sources without errors under set -u
+echo "Test 1: Source all modules (set -u)"
+if bash -u "$SUPERVISOR" help >/dev/null 2>&1; then
+	pass "supervisor-helper.sh help runs without unbound variable errors"
+else
+	fail "supervisor-helper.sh help failed — likely unbound variable"
+	# Show the actual error
+	bash -u "$SUPERVISOR" help 2>&1 | head -5
+fi
+
+# Test 2: bash -n syntax check on all module files
+echo "Test 2: Syntax check all modules"
+syntax_ok=true
+for module in "$REPO_DIR/.agents/scripts/supervisor/"*.sh; do
+	if ! bash -n "$module" 2>/dev/null; then
+		fail "syntax error in $(basename "$module")"
+		syntax_ok=false
+	fi
+done
+if [[ "$syntax_ok" == "true" ]]; then
+	pass "all module files pass bash -n"
+fi
+
+# Test 3: Key globals are defined after sourcing
+echo "Test 3: Key globals defined"
+# We can't source directly (readonly conflicts), so check via grep
+required_globals=(
+	"SUPERVISOR_DIR"
+	"SUPERVISOR_DB"
+	"SUPERVISOR_LOG"
+	"PULSE_LOCK_DIR"
+	"PULSE_LOCK_TIMEOUT"
+	"VALID_STATES"
+	"VALID_TRANSITIONS"
+)
+
+all_files="$SUPERVISOR $(echo "$REPO_DIR/.agents/scripts/supervisor/"*.sh)"
+for var in "${required_globals[@]}"; do
+	# Check if the variable is assigned (not just referenced) in any file
+	# Handles: VAR=, readonly VAR=, readonly -a VAR=(
+	# shellcheck disable=SC2086
+	if grep -qE "^[[:space:]]*(readonly( -a)? )?${var}=" $all_files 2>/dev/null; then
+		pass "$var is defined"
+	else
+		fail "$var is NOT defined in any supervisor file"
+	fi
+done
+
+# Test 4: No module references a variable that isn't defined anywhere
+echo "Test 4: Cross-reference module variables"
+# Extract variables used in modules (excluding env vars with :- defaults)
+module_dir="$REPO_DIR/.agents/scripts/supervisor"
+# Find bare $VAR references (no :- default) that look like supervisor globals
+missing_count=0
+for var in SUPERVISOR_DIR SUPERVISOR_DB SUPERVISOR_LOG PULSE_LOCK_DIR PULSE_LOCK_TIMEOUT SCRIPT_DIR SUPERVISOR_MODULE_DIR; do
+	# Check if used in modules
+	if grep -rq "\$${var}\b\|\${${var}}" "$module_dir/" 2>/dev/null; then
+		# Check if defined in monolith or _common.sh
+		# shellcheck disable=SC2086
+		if ! grep -q "^[[:space:]]*\(readonly \)\{0,1\}${var}=" $all_files 2>/dev/null; then
+			fail "$var used in modules but not defined anywhere"
+			missing_count=$((missing_count + 1))
+		fi
+	fi
+done
+if [[ "$missing_count" -eq 0 ]]; then
+	pass "all module-referenced globals are defined"
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/todo/VERIFY.md
+++ b/todo/VERIFY.md
@@ -497,3 +497,34 @@
   files: .agents/scripts/claim-task-id.sh
   check: shellcheck .agents/scripts/claim-task-id.sh
   check: file-exists .agents/scripts/claim-task-id.sh
+
+- [!] v062 t1031 Modularize supervisor-helper.sh — move functions from 1... | PR #1359 | merged:2026-02-13 failed:2026-02-13 reason:shellcheck: .agents/scripts/supervisor-helper.sh has violations; shellcheck: .agents/scripts/supervisor/cron.sh has violations; shellcheck: .agents/scripts/supervisor/deploy.sh has violations;
+  files: .agents/scripts/supervisor-helper.sh, .agents/scripts/supervisor/batch.sh, .agents/scripts/supervisor/cleanup.sh, .agents/scripts/supervisor/cron.sh, .agents/scripts/supervisor/database.sh, .agents/scripts/supervisor/deploy.sh, .agents/scripts/supervisor/dispatch.sh, .agents/scripts/supervisor/evaluate.sh, .agents/scripts/supervisor/issue-sync.sh, .agents/scripts/supervisor/memory-integration.sh, .agents/scripts/supervisor/pulse.sh, .agents/scripts/supervisor/self-heal.sh, .agents/scripts/supervisor/state.sh, .agents/scripts/supervisor/utility.sh
+  check: shellcheck .agents/scripts/supervisor-helper.sh
+  check: file-exists .agents/scripts/supervisor-helper.sh
+  check: shellcheck .agents/scripts/supervisor/batch.sh
+  check: file-exists .agents/scripts/supervisor/batch.sh
+  check: shellcheck .agents/scripts/supervisor/cleanup.sh
+  check: file-exists .agents/scripts/supervisor/cleanup.sh
+  check: shellcheck .agents/scripts/supervisor/cron.sh
+  check: file-exists .agents/scripts/supervisor/cron.sh
+  check: shellcheck .agents/scripts/supervisor/database.sh
+  check: file-exists .agents/scripts/supervisor/database.sh
+  check: shellcheck .agents/scripts/supervisor/deploy.sh
+  check: file-exists .agents/scripts/supervisor/deploy.sh
+  check: shellcheck .agents/scripts/supervisor/dispatch.sh
+  check: file-exists .agents/scripts/supervisor/dispatch.sh
+  check: shellcheck .agents/scripts/supervisor/evaluate.sh
+  check: file-exists .agents/scripts/supervisor/evaluate.sh
+  check: shellcheck .agents/scripts/supervisor/issue-sync.sh
+  check: file-exists .agents/scripts/supervisor/issue-sync.sh
+  check: shellcheck .agents/scripts/supervisor/memory-integration.sh
+  check: file-exists .agents/scripts/supervisor/memory-integration.sh
+  check: shellcheck .agents/scripts/supervisor/pulse.sh
+  check: file-exists .agents/scripts/supervisor/pulse.sh
+  check: shellcheck .agents/scripts/supervisor/self-heal.sh
+  check: file-exists .agents/scripts/supervisor/self-heal.sh
+  check: shellcheck .agents/scripts/supervisor/state.sh
+  check: file-exists .agents/scripts/supervisor/state.sh
+  check: shellcheck .agents/scripts/supervisor/utility.sh
+  check: file-exists .agents/scripts/supervisor/utility.sh


### PR DESCRIPTION
## Summary

- Restores `SUPERVISOR_LOG`, `SUPERVISOR_LOG_DIR`, `PULSE_LOCK_DIR`, and `PULSE_LOCK_TIMEOUT` globals that were dropped during t1031 modularization (PR #1359)
- These missing globals caused `unbound variable` errors when running `supervisor-helper.sh pulse`
- Adds `tests/test-supervisor-globals.sh` — a permanent guard that catches this class of bug:
  1. Sources all modules with `set -u` (catches unbound variables)
  2. Syntax-checks all module files
  3. Verifies key globals are defined
  4. Cross-references module variable usage against definitions

This is the **permanent solution**: any future modularization that drops a global will be caught by the test before merge.

Fixes the supervisor pulse failure introduced by #1359.