### PR TITLE
t1035: Fix ALL_STATUS_LABELS unbound variable — t1031 modularisation regression

### DIFF
--- a/.agents/scripts/supervisor/issue-sync.sh
+++ b/.agents/scripts/supervisor/issue-sync.sh
@@ -336,6 +336,13 @@ state_to_status_label() {
 }
 
 #######################################
+# All status labels that can be set on an issue (t1009)
+# Used to remove stale labels before applying the new one.
+# Restored from pre-modularisation supervisor-helper.sh (t1035).
+#######################################
+ALL_STATUS_LABELS="status:available,status:queued,status:claimed,status:in-review,status:blocked,status:verify-failed,status:done"
+
+#######################################
 # Sync GitHub issue status label on state transition (t1009)
 # Called from cmd_transition() after each state change.
 # Removes all status:* labels, then adds the one matching the new state.


### PR DESCRIPTION
## Summary

- Restores `ALL_STATUS_LABELS` constant that was dropped during t1031 supervisor modularisation
- This constant is used by `sync_issue_status_label()` in `issue-sync.sh` and Phase 8b reconciliation in `pulse.sh`
- Under `set -euo pipefail`, the unbound variable crashed `sync_issue_status_label()`, which blocked `cmd_dispatch()` from completing — the dispatch function wrote metadata to the log but crashed before creating the dispatch script and launching the worker process
- This was the **root cause** of all workers showing `worker_never_started:no_sentinel` after t1031 merged

## Testing

- Deployed fix live to `~/.aidevops/agents/scripts/supervisor/issue-sync.sh`
- Ran `supervisor-helper.sh dispatch t1032.1` — worker started successfully (WORKER_STARTED sentinel present)
- ShellCheck: no new violations
- Previous dispatch attempts (without fix) all failed with dispatch hanging at `sync_issue_status_label`

## Related

- t1034 (PR #1373): Fixed PULSE_LOCK_DIR unbound variable — same class of bug
- t1031 (PR #1359): Original modularisation that introduced the regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GitHub issue status label management by centralizing the label sync process. Issue status updates now properly handle removal of outdated labels and state transitions across all status categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->