### PR TITLE
t1030: Guard complete->deployed transition to require PR merge when pr_url exists

### DIFF
--- a/.agents/scripts/supervisor/deploy.sh
+++ b/.agents/scripts/supervisor/deploy.sh
@@ -4,7 +4,6 @@
 # Functions for PR review, merge, postflight, deployment,
 # verification, and rebase operations
 
-
 #######################################
 # Run postflight checks after merge
 # Lightweight: just verifies the merge landed on main
@@ -272,7 +271,7 @@ cmd_pr_lifecycle() {
 
 	# Step 1: Transition to pr_review if still in complete
 	if [[ "$tstatus" == "complete" ]]; then
-		if [[ -z "$tpr" || "$tpr" == "no_pr" || "$tpr" == "task_only" ]]; then
+		if [[ -z "$tpr" || "$tpr" == "no_pr" || "$tpr" == "task_only" || "$tpr" == "verified_complete" ]]; then
 			# Discover PR via centralized link_pr_to_task() (t232, t223)
 			local found_pr=""
 			if [[ "$dry_run" == "false" ]]; then


### PR DESCRIPTION
## Summary

- Adds a PR merge guard in `cmd_transition()` that blocks `complete->deployed` when a real PR URL exists but the PR is not MERGED
- Adds `verified_complete` to the no-PR fast-path whitelist in `process_post_pr_lifecycle` and `cmd_pr_lifecycle`
- Prevents the bug where tasks were marked deployed while their PR was still open (t1011 incident)

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/supervisor/state.sh` | Defense-in-depth guard in `cmd_transition()` — queries PR state via `gh pr view` before allowing `complete->deployed` |
| `.agents/scripts/supervisor/pulse.sh` | Added `verified_complete` to fast-path whitelist, documented defense-in-depth |
| `.agents/scripts/supervisor/deploy.sh` | Added `verified_complete` to `cmd_pr_lifecycle` no-PR check |
| `tests/test-supervisor-state-machine.sh` | 5 new tests: no-PR allowed, no_pr allowed, task_only allowed, verified_complete allowed, real URL blocked |

## Testing

- All 5 new t1030 tests pass
- 0 new test failures (12 pre-existing failures in evaluate worker section confirmed unchanged)
- ShellCheck: 0 new violations on all 3 modified scripts
- Bash syntax check: all 3 scripts pass