### PR TITLE
t1037: Fix state_log column names in fix-cycle count query

### DIFF
--- a/.agents/scripts/supervisor/deploy.sh
+++ b/.agents/scripts/supervisor/deploy.sh
@@ -590,8 +590,8 @@ cmd_pr_lifecycle() {
 					fix_cycle_count=$(db "$SUPERVISOR_DB" "
 						SELECT COUNT(*) FROM state_log
 						WHERE task_id = '$escaped_id'
-						  AND old_state = 'review_triage'
-						  AND new_state = 'dispatched';
+						  AND from_state = 'review_triage'
+						  AND to_state = 'dispatched';
 					" 2>/dev/null || echo "0")
 					local max_fix_cycles=3
 					if [[ "$fix_cycle_count" -ge "$max_fix_cycles" ]]; then


### PR DESCRIPTION
## Summary

- Fix-cycle limit query used `old_state`/`new_state` but the `state_log` table uses `from_state`/`to_state`
- The incorrect column names caused the query to silently fail (caught by `|| echo "0"`), making the 3-cycle guard ineffective
- Already hotfixed in deployed copy; this PR updates the repo

One-line fix. Follow-up to PR #1387.

Refs: t1037, GH#1386