### PR TITLE
t1040: Fix sql_escape apostrophe bug blocking task queuing

### DIFF
--- a/.agents/scripts/supervisor/_common.sh
+++ b/.agents/scripts/supervisor/_common.sh
@@ -53,7 +53,11 @@ log_verbose() {
 #######################################
 sql_escape() {
 	local input="$1"
-	echo "${input//\'/\'\'}"
+	# t1040: Use printf+sed for reliable single-quote escaping.
+	# Bash parameter expansion ${input//\'/\'\'} fails in some quoting
+	# contexts, causing SQLite INSERT errors for task descriptions
+	# containing apostrophes (e.g. "supervisor's", "don't").
+	printf '%s' "$input" | sed "s/'/''/g"
 }
 
 #######################################

--- a/.agents/scripts/supervisor/_common.sh
+++ b/.agents/scripts/supervisor/_common.sh
@@ -58,6 +58,7 @@ sql_escape() {
 	# contexts, causing SQLite INSERT errors for task descriptions
 	# containing apostrophes (e.g. "supervisor's", "don't").
 	printf '%s' "$input" | sed "s/'/''/g"
+	return 0
 }
 
 #######################################


### PR DESCRIPTION
## Summary

- **Root cause fix**: `sql_escape()` in `_common.sh` used bash parameter expansion `${input//\'/\'\'}` which silently fails in some quoting contexts, causing SQLite INSERT errors for task descriptions containing apostrophes (e.g. "supervisor's", "don't")
- **Impact**: Tasks t1032.7 and t1033 were never queued despite `cmd_auto_pickup` logging "Added task" — the task ID row was created but the description INSERT failed silently
- **Fix**: Replace bash parameter expansion with `printf '%s' "$input" | sed "s/'/''/g"` which works reliably in all quoting contexts

## Testing

- ShellCheck passes on `_common.sh`
- After deploy, verify with `supervisor-helper.sh auto-pickup` that tasks with apostrophes in descriptions are correctly inserted into the DB

## Related

- Blocked: t1032.7, t1033 (will be unblocked after deploy)
- Part of supervisor reliability improvements (t1037-t1040 series)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal SQL string escaping mechanism for enhanced reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->