### PR TITLE
t1033: Add label propagation to claim-task-id.sh

### DIFF
--- a/.agents/scripts/audit-task-creator-helper.sh
+++ b/.agents/scripts/audit-task-creator-helper.sh
@@ -1184,7 +1184,7 @@ cmd_create() {
 			local tag="${BASH_REMATCH[1]}"
 			tag_list+=("$tag")
 			# Remove matched tag to find next one
-			task_desc_tmp="${task_desc#*#${tag}}"
+			task_desc_tmp="${task_desc#*#"${tag}"}"
 			task_desc="$task_desc_tmp"
 		done
 		# Rebuild task_desc (it was consumed by the loop)

--- a/.agents/scripts/audit-task-creator-helper.sh
+++ b/.agents/scripts/audit-task-creator-helper.sh
@@ -1174,6 +1174,29 @@ cmd_create() {
 			source_tag=" #${source_tool}"
 		fi
 
+		# Build task description first (needed for label extraction)
+		local task_desc="Fix ${category} issue (${severity}): ${description}${location}${pr_ref} ${priority_tag}${source_tag} #quality #auto-review #auto-dispatch ~30m"
+
+		# Extract labels from task description hashtags
+		local labels=""
+		local tag_list=()
+		while [[ "$task_desc" =~ \#([a-zA-Z0-9_-]+) ]]; do
+			local tag="${BASH_REMATCH[1]}"
+			tag_list+=("$tag")
+			# Remove matched tag to find next one
+			task_desc_tmp="${task_desc#*#${tag}}"
+			task_desc="$task_desc_tmp"
+		done
+		# Rebuild task_desc (it was consumed by the loop)
+		task_desc="Fix ${category} issue (${severity}): ${description}${location}${pr_ref} ${priority_tag}${source_tag} #quality #auto-review #auto-dispatch ~30m"
+		# Join tags with commas
+		if [[ ${#tag_list[@]} -gt 0 ]]; then
+			labels=$(
+				IFS=,
+				echo "${tag_list[*]}"
+			)
+		fi
+
 		# Allocate task ID via claim-task-id.sh
 		local task_id=""
 		local gh_ref=""
@@ -1181,7 +1204,7 @@ cmd_create() {
 
 		local task_title="Fix ${category} issue (${severity}): ${description:0:80}"
 
-		if claim_output=$("${SCRIPT_DIR}/claim-task-id.sh" --title "$task_title" --description "Auto-created from ${source_tool} finding #${finding_id}" --labels "quality,auto-review" 2>&1); then
+		if claim_output=$("${SCRIPT_DIR}/claim-task-id.sh" --title "$task_title" --description "Auto-created from ${source_tool} finding #${finding_id}" --labels "$labels" 2>&1); then
 			task_id=$(echo "$claim_output" | grep "^task_id=" | cut -d= -f2)
 			gh_ref=$(echo "$claim_output" | grep "^ref=" | cut -d= -f2)
 
@@ -1194,9 +1217,6 @@ cmd_create() {
 			log_info "Skipping this finding (will retry on next run)"
 			continue
 		fi
-
-		# Build task description
-		local task_desc="Fix ${category} issue (${severity}): ${description}${location}${pr_ref} ${priority_tag}${source_tag} #quality #auto-review #auto-dispatch ~30m"
 
 		# Add GitHub issue reference if available
 		if [[ -n "$gh_ref" && "$gh_ref" != "offline" ]]; then

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -71,7 +71,7 @@ extract_hashtags() {
 			tags="$tag"
 		fi
 		# Remove matched tag to find next one
-		text="${text#*#${tag}}"
+		text="${text#*#"${tag}"}"
 	done
 
 	echo "$tags"

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -57,6 +57,26 @@ log_success() { echo -e "${GREEN}[OK]${NC} $*" >&2; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
+# Extract hashtags from text and convert to comma-separated labels
+extract_hashtags() {
+	local text="$1"
+	local tags=""
+
+	# Extract all #hashtags (word characters after #)
+	while [[ "$text" =~ \#([a-zA-Z0-9_-]+) ]]; do
+		local tag="${BASH_REMATCH[1]}"
+		if [[ -n "$tags" ]]; then
+			tags="${tags},${tag}"
+		else
+			tags="$tag"
+		fi
+		# Remove matched tag to find next one
+		text="${text#*#${tag}}"
+	done
+
+	echo "$tags"
+}
+
 # Parse arguments
 parse_args() {
 	while [[ $# -gt 0 ]]; do
@@ -99,6 +119,16 @@ parse_args() {
 	if [[ -z "$TASK_TITLE" ]]; then
 		log_error "Missing required argument: --title"
 		exit 1
+	fi
+
+	# Auto-extract hashtags from title if no labels provided
+	if [[ -z "$TASK_LABELS" ]]; then
+		local extracted_tags
+		extracted_tags=$(extract_hashtags "$TASK_TITLE")
+		if [[ -n "$extracted_tags" ]]; then
+			TASK_LABELS="$extracted_tags"
+			log_info "Auto-extracted labels from title: $TASK_LABELS"
+		fi
 	fi
 }
 

--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -1229,7 +1229,7 @@ cmd_pulse() {
 									while [[ "$task_desc_copy" =~ \#([a-zA-Z0-9_-]+) ]]; do
 										local tag="${BASH_REMATCH[1]}"
 										tag_list+=("$tag")
-										task_desc_copy="${task_desc_copy#*#${tag}}"
+										task_desc_copy="${task_desc_copy#*#"${tag}"}"
 									done
 									if [[ ${#tag_list[@]} -gt 0 ]]; then
 										labels=$(


### PR DESCRIPTION
## Summary

This PR implements label propagation from TODO.md hashtags to GitHub issues created via claim-task-id.sh.

## Changes

1. **claim-task-id.sh**: Added  function to auto-extract #hashtags from --title and use them as labels when --labels is not explicitly provided
2. **coderabbit-task-creator-helper.sh**: Extract all hashtags from task description and pass them to claim-task-id.sh via --labels flag
3. **supervisor/pulse.sh Phase 10b**: Extract hashtags from task descriptions and pass them to claim-task-id.sh when allocating task IDs

## Impact

- GitHub issues created during task allocation now automatically receive all relevant labels (#auto-dispatch, #quality, #critical, #high, etc.)
- Eliminates the window where issues exist without labels before the issue-sync pipeline runs
- Enables the supervisor to filter tasks by label immediately after creation

## Testing

- ShellCheck passed on all modified .sh files (pre-existing warnings in pulse.sh are unrelated to these changes)
- Changes follow existing patterns in the codebase
- Backward compatible: explicit --labels still override auto-extraction

Ref #1371