### PR TITLE
t1043: Align verify ShellCheck with CI and fix Phase 7b reconciliation

### DIFF
--- a/.agents/scripts/supervisor/deploy.sh
+++ b/.agents/scripts/supervisor/deploy.sh
@@ -2644,7 +2644,11 @@ run_verify_checks() {
 			;;
 		shellcheck)
 			if command -v shellcheck &>/dev/null; then
-				if shellcheck "$repo/$check_arg" 2>>"$SUPERVISOR_LOG"; then
+				# t1041: Use -S warning -x to match CI severity threshold.
+				# CI uses -S error; verify uses -S warning (catches warnings+errors
+				# but not info/style like SC2016/SC1091 which are pre-existing noise).
+				# -x follows source directives so sourced files don't cause SC1091.
+				if shellcheck -S warning -x "$repo/$check_arg" 2>>"$SUPERVISOR_LOG"; then
 					log_success "    PASS: shellcheck $check_arg"
 				else
 					log_error "    FAIL: shellcheck $check_arg"

--- a/.agents/scripts/supervisor/todo-sync.sh
+++ b/.agents/scripts/supervisor/todo-sync.sh
@@ -1038,13 +1038,15 @@ cmd_reconcile_db_todo() {
 	fi
 
 	# --- Gap 2: TODO.md [x] but DB still in non-terminal state ---
-	# Terminal states: complete, deployed, verified, failed, blocked, cancelled
+	# Terminal states: complete, deployed, verified, failed, blocked, cancelled, verify_failed
 	# Non-terminal: queued, dispatched, running, evaluating, retrying,
-	#   pr_review, review_triage, merging, merged, deploying, verifying, verify_failed
+	#   pr_review, review_triage, merging, merged, deploying, verifying
+	# t1041: verify_failed is excluded — it's a meaningful state (PR merged+deployed
+	# but post-merge checks failed). Re-verification handles these, not reconciliation.
 	local all_db_tasks
 	all_db_tasks=$(db -separator '|' "$SUPERVISOR_DB" "
 		SELECT t.id, t.status FROM tasks t
-		WHERE t.status NOT IN ('complete', 'deployed', 'verified', 'failed', 'blocked', 'cancelled')
+		WHERE t.status NOT IN ('complete', 'deployed', 'verified', 'verify_failed', 'failed', 'blocked', 'cancelled')
 		$batch_filter
 		ORDER BY t.id;
 	")


### PR DESCRIPTION
## Summary

- **Fix 1**: Post-merge ShellCheck verification used bare `shellcheck` (all severities) while CI uses `-S error`. This caused false `verify_failed` on pre-existing SC2016/SC1091 info-level violations. Now uses `-S warning -x` — catches real issues, skips info/style noise, follows source directives.
- **Fix 2**: Phase 7b reconciliation tried to transition `verify_failed → complete` when TODO.md showed `[x]`, but the state machine doesn't allow that. Now excludes `verify_failed` from Gap 2 reconciliation — it's a meaningful state, not a stale inconsistency.

## Impact

- All 8 `verify_failed` tasks failed due to ShellCheck severity mismatch (false positives)
- Phase 7b was logging "Failed to transition" errors every pulse cycle for these tasks
- After deploy, re-running verify on these tasks should pass with the relaxed severity

## Files Changed

- `.agents/scripts/supervisor/deploy.sh` — `run_verify_checks()` shellcheck case: add `-S warning -x`
- `.agents/scripts/supervisor/todo-sync.sh` — `reconcile_db_todo()` Gap 2: exclude `verify_failed`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated task reconciliation logic to properly handle post-deployment verification state, preventing unnecessary task reprocessing.
  * Enhanced shell script validation settings to align verification severity levels and source directive handling between local and CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->