### PR TITLE
t1045: Fix SonarCloud regression detection + fix 24 findings + rate-limit Phase 10c

### DIFF
--- a/.agents/scripts/audit-task-creator-helper.sh
+++ b/.agents/scripts/audit-task-creator-helper.sh
@@ -172,12 +172,10 @@ detect_db_mode() {
 get_active_task_db() {
 	local mode
 	mode=$(detect_db_mode)
-	if [[ "$mode" == "legacy" ]]; then
+	if [[ "$mode" == "legacy" ]] && [[ -f "$LEGACY_TASK_DB" ]]; then
 		# Use legacy path if it exists, otherwise use new path
-		if [[ -f "$LEGACY_TASK_DB" ]]; then
-			echo "$LEGACY_TASK_DB"
-			return 0
-		fi
+		echo "$LEGACY_TASK_DB"
+		return 0
 	fi
 	echo "$TASK_CREATOR_DB"
 	return 0

--- a/.agents/scripts/code-audit-helper.sh
+++ b/.agents/scripts/code-audit-helper.sh
@@ -14,6 +14,7 @@ set -euo pipefail
 #   code-audit-helper.sh report [--format json|text|csv] [--severity LEVEL]
 #   code-audit-helper.sh summary [--pr NUMBER]
 #   code-audit-helper.sh status
+#   code-audit-helper.sh check-regression
 #   code-audit-helper.sh reset
 #   code-audit-helper.sh help
 #
@@ -199,7 +200,7 @@ sql_escape() {
 # Collect findings from CodeRabbit via its collector helper
 collect_coderabbit() {
 	local run_id="$1"
-	local repo="$2"
+	local _repo="$2" # reserved for future repo-scoped collection
 	local pr_number="$3"
 	local count=0
 
@@ -1197,6 +1198,105 @@ cmd_reset() {
 }
 
 # =============================================================================
+# Check Regression (t1045)
+# =============================================================================
+# Queries SonarCloud API for current open findings, compares against the last
+# stored snapshot. Returns exit 1 if findings increased >20%.
+# Stores current count in a regression-tracking table for next comparison.
+# Called by supervisor pulse Phase 10c.
+
+cmd_check_regression() {
+	ensure_db
+
+	# Ensure regression_snapshots table exists
+	db "$AUDIT_DB" <<'SQL' >/dev/null
+CREATE TABLE IF NOT EXISTS regression_snapshots (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    source       TEXT NOT NULL,
+    total        INTEGER NOT NULL DEFAULT 0,
+    critical     INTEGER NOT NULL DEFAULT 0,
+    high         INTEGER NOT NULL DEFAULT 0,
+    medium       INTEGER NOT NULL DEFAULT 0,
+    low          INTEGER NOT NULL DEFAULT 0,
+    checked_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+CREATE INDEX IF NOT EXISTS idx_regression_source ON regression_snapshots(source);
+SQL
+
+	local repo
+	repo=$(get_repo)
+	# SonarCloud project key: owner_repo format
+	local project_key
+	project_key=$(echo "$repo" | tr '/' '_')
+
+	# Query SonarCloud public API (no token needed for public repos)
+	local api_url="https://sonarcloud.io/api/issues/search"
+	local api_params="componentKeys=${project_key}&statuses=OPEN,CONFIRMED,REOPENED&ps=1&facets=severities"
+	local response
+	response=$(curl -sf "${api_url}?${api_params}" 2>/dev/null) || {
+		log_warn "check-regression: SonarCloud API unreachable, skipping"
+		return 0
+	}
+
+	# Parse totals from facets
+	local total critical high medium low
+	total=$(echo "$response" | jq -r '.total // 0' 2>/dev/null) || total=0
+	critical=$(echo "$response" | jq -r '[.facets[]? | select(.property=="severities") | .values[]? | select(.val=="BLOCKER" or .val=="CRITICAL") | .count] | add // 0' 2>/dev/null) || critical=0
+	high=$(echo "$response" | jq -r '[.facets[]? | select(.property=="severities") | .values[]? | select(.val=="MAJOR") | .count] | add // 0' 2>/dev/null) || high=0
+	medium=$(echo "$response" | jq -r '[.facets[]? | select(.property=="severities") | .values[]? | select(.val=="MINOR") | .count] | add // 0' 2>/dev/null) || medium=0
+	low=$(echo "$response" | jq -r '[.facets[]? | select(.property=="severities") | .values[]? | select(.val=="INFO") | .count] | add // 0' 2>/dev/null) || low=0
+
+	# Get previous snapshot
+	local prev_total prev_critical prev_high
+	prev_total=$(db "$AUDIT_DB" "SELECT total FROM regression_snapshots WHERE source='sonarcloud' ORDER BY id DESC LIMIT 1;" 2>/dev/null) || prev_total=""
+	prev_critical=$(db "$AUDIT_DB" "SELECT critical FROM regression_snapshots WHERE source='sonarcloud' ORDER BY id DESC LIMIT 1;" 2>/dev/null) || prev_critical=""
+	prev_high=$(db "$AUDIT_DB" "SELECT high FROM regression_snapshots WHERE source='sonarcloud' ORDER BY id DESC LIMIT 1;" 2>/dev/null) || prev_high=""
+
+	# Store current snapshot
+	db "$AUDIT_DB" "INSERT INTO regression_snapshots (source, total, critical, high, medium, low) VALUES ('sonarcloud', $total, $critical, $high, $medium, $low);" 2>/dev/null
+
+	# First run — no previous data to compare
+	if [[ -z "$prev_total" ]]; then
+		log_info "check-regression: First snapshot recorded (total=$total, critical=$critical, high=$high, medium=$medium, low=$low)"
+		return 0
+	fi
+
+	# Compare: any critical/high increase is a regression, >20% total increase is a regression
+	local regression_found=0
+
+	if [[ "$critical" -gt "${prev_critical:-0}" ]]; then
+		log_warn "REGRESSION DETECTED: sonarcloud - critical findings increased (${prev_critical} -> ${critical})"
+		regression_found=1
+	fi
+
+	if [[ "$high" -gt "${prev_high:-0}" ]]; then
+		log_warn "REGRESSION DETECTED: sonarcloud - high severity findings increased (${prev_high} -> ${high})"
+		regression_found=1
+	fi
+
+	if [[ "$prev_total" -gt 0 ]]; then
+		local increase_pct=$(((total - prev_total) * 100 / prev_total))
+		if [[ "$increase_pct" -gt 20 ]]; then
+			log_warn "REGRESSION DETECTED: sonarcloud - findings increased by ${increase_pct}% (${prev_total} -> ${total})"
+			regression_found=1
+		fi
+	fi
+
+	if [[ "$regression_found" -eq 1 ]]; then
+		return 1
+	fi
+
+	# Log improvement if findings decreased
+	if [[ "$total" -lt "$prev_total" ]]; then
+		log_success "check-regression: Findings improved (${prev_total} -> ${total})"
+	else
+		log_info "check-regression: No regression (total=$total, prev=$prev_total)"
+	fi
+
+	return 0
+}
+
+# =============================================================================
 # Help
 # =============================================================================
 
@@ -1208,12 +1308,13 @@ USAGE:
   code-audit-helper.sh <command> [options]
 
 COMMANDS:
-  audit       Run unified audit across all configured services
-  report      Output detailed findings from the latest audit run
-  summary     Show summary statistics for an audit run
-  status      Show orchestrator status, dependencies, and DB info
-  reset       Reset the audit database (creates backup first)
-  help        Show this help
+  audit            Run unified audit across all configured services
+  report           Output detailed findings from the latest audit run
+  summary          Show summary statistics for an audit run
+  status           Show orchestrator status, dependencies, and DB info
+  check-regression Compare current SonarCloud findings against last snapshot
+  reset            Reset the audit database (creates backup first)
+  help             Show this help
 
 AUDIT OPTIONS:
   --repo OWNER/REPO   Repository (default: auto-detect from git)
@@ -1287,6 +1388,7 @@ main() {
 	summary) cmd_summary "$@" ;;
 	status) cmd_status "$@" ;;
 	reset) cmd_reset "$@" ;;
+	check-regression) cmd_check_regression "$@" ;;
 	help | --help | -h) show_help ;;
 	*)
 		log_error "$ERROR_UNKNOWN_COMMAND $command"

--- a/.agents/scripts/document-creation-helper.sh
+++ b/.agents/scripts/document-creation-helper.sh
@@ -982,7 +982,7 @@ convert_with_rolm_ocr() {
 convert_pdf_to_odt() {
 	local input="$1"
 	local output="$2"
-	local template="${3:-}"
+	local _template="${3:-}" # reserved for future template-based conversion
 
 	log_info "Converting PDF to ODT (programmatic pipeline)"
 

--- a/.agents/scripts/supervisor/cleanup.sh
+++ b/.agents/scripts/supervisor/cleanup.sh
@@ -4,7 +4,6 @@
 # Functions for creating/cleaning worktrees, killing workers,
 # and post-merge cleanup
 
-
 #######################################
 # Create a worktree for a task
 # Returns the worktree path on stdout
@@ -170,13 +169,11 @@ create_task_worktree() {
 	fi
 
 	# Try wt first (redirect its verbose output to stderr)
-	if command -v wt &>/dev/null; then
-		if wt switch -c "$branch_name" -C "$repo" >&2 2>&1; then
-			# Register ownership (t189)
-			register_worktree "$worktree_path" "$branch_name" --task "$task_id"
-			echo "$worktree_path"
-			return 0
-		fi
+	if command -v wt &>/dev/null && wt switch -c "$branch_name" -C "$repo" >&2 2>&1; then
+		# Register ownership (t189)
+		register_worktree "$worktree_path" "$branch_name" --task "$task_id"
+		echo "$worktree_path"
+		return 0
 	fi
 
 	# Fallback: raw git worktree add (quiet, reliable)
@@ -230,11 +227,9 @@ cleanup_task_worktree() {
 	rmdir "$worktree_path/.agents" 2>/dev/null || true
 
 	# Try wt remove first (worktrunk CLI)
-	if command -v wt &>/dev/null; then
-		if wt remove "$worktree_path" 2>>"$SUPERVISOR_LOG"; then
-			unregister_worktree "$worktree_path"
-			return 0
-		fi
+	if command -v wt &>/dev/null && wt remove "$worktree_path" 2>>"$SUPERVISOR_LOG"; then
+		unregister_worktree "$worktree_path"
+		return 0
 	fi
 
 	# Fallback: git worktree remove

--- a/.agents/scripts/supervisor/cron.sh
+++ b/.agents/scripts/supervisor/cron.sh
@@ -312,11 +312,9 @@ cmd_auto_pickup() {
 			fi
 		fi
 
-		if [[ "$in_dispatch_section" == "true" ]]; then
+		if [[ "$in_dispatch_section" == "true" ]] && echo "$line" | grep -qE '^[[:space:]]*- \[ \] t[0-9]+'; then
 			# Match open task lines
-			if echo "$line" | grep -qE '^[[:space:]]*- \[ \] t[0-9]+'; then
-				section_tasks+="$line"$'\n'
-			fi
+			section_tasks+="$line"$'\n'
 		fi
 	done <"$todo_file"
 

--- a/.agents/scripts/supervisor/evaluate.sh
+++ b/.agents/scripts/supervisor/evaluate.sh
@@ -4,7 +4,6 @@
 # Functions for evaluating worker outcomes, PR discovery,
 # and AI-assisted evaluation
 
-
 #######################################
 # Extract the last N lines from a log file (for AI eval context)
 # Avoids sending entire multi-MB logs to the evaluator
@@ -97,10 +96,8 @@ extract_log_metadata() {
 	# the supervisor retries them as clean_exit_no_signal, wasting retries.
 	# Only check the final text entry (authoritative, same as PR URL extraction).
 	local task_obsolete="false"
-	if [[ -n "$last_text_line" ]]; then
-		if echo "$last_text_line" | grep -qiE 'already done|already complete[d]?|task.*(obsolete|no longer needed)|no (changes|PR) needed|nothing to (change|fix|do)|no work (needed|required|to do)'; then
-			task_obsolete="true"
-		fi
+	if [[ -n "$last_text_line" ]] && echo "$last_text_line" | grep -qiE 'already done|already complete[d]?|task.*(obsolete|no longer needed)|no (changes|PR) needed|nothing to (change|fix|do)|no work (needed|required|to do)'; then
+		task_obsolete="true"
 	fi
 	echo "task_obsolete=$task_obsolete"
 
@@ -691,8 +688,8 @@ evaluate_worker() {
 		return 1
 	fi
 
-	local tstatus tlog tretries tmax_retries tsession tpr_url
-	IFS='|' read -r tstatus tlog tretries tmax_retries tsession tpr_url <<<"$task_row"
+	local _tstatus tlog tretries tmax_retries _tsession tpr_url
+	IFS='|' read -r _tstatus tlog tretries tmax_retries _tsession tpr_url <<<"$task_row"
 
 	# Enhanced no_log_file diagnostics (t183)
 	# Instead of a bare "failed:no_log_file", gather context about why the log

--- a/.agents/scripts/supervisor/memory-integration.sh
+++ b/.agents/scripts/supervisor/memory-integration.sh
@@ -4,7 +4,6 @@
 # Functions for task memory recall, failure/success pattern storage,
 # batch retrospectives, and session reviews
 
-
 #######################################
 # Recall relevant memories for a task before dispatch
 # Returns memory context as text (empty string if none found)
@@ -154,7 +153,7 @@ store_success_pattern() {
 	local escaped_id
 	escaped_id=$(sql_escape "$task_id")
 	local model_tier=""
-	local task_model duration_info retries
+	local task_model retries
 	task_model=$(db "$SUPERVISOR_DB" "SELECT model FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "")
 	retries=$(db "$SUPERVISOR_DB" "SELECT retries FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "0")
 

--- a/.agents/scripts/supervisor/self-heal.sh
+++ b/.agents/scripts/supervisor/self-heal.sh
@@ -4,7 +4,6 @@
 # Functions for automatic failure diagnosis, model escalation,
 # and diagnostic subtask creation
 
-
 #######################################
 # Self-healing: determine if a failed/blocked task is eligible for
 # automatic diagnostic subtask creation (t150)
@@ -161,7 +160,7 @@ create_diagnostic_subtask() {
 #######################################
 attempt_self_heal() {
 	local task_id="$1"
-	local outcome_type="$2"
+	local _outcome_type="$2" # kept for API compatibility (blocked/failed)
 	local failure_reason="$3"
 	local batch_id="${4:-}"
 


### PR DESCRIPTION
## Summary

Fixes three compounding stalling patterns that prevented the supervisor from self-healing quality regressions:

1. **Phantom `check-regression` subcommand** — `pulse.sh` Phase 10c called `code-audit-helper.sh check-regression` but that subcommand didn't exist. Every 2-minute pulse logged a false "regression detected" warning (189 times in the log). Now implemented: queries SonarCloud public API, stores snapshots in SQLite, compares against previous run.

2. **Phase 10c rate limiting** — Previously ran every 2-minute pulse (unnecessary API load, log spam). Now rate-limited to once per hour via a timestamp cache file.

3. **24 SonarCloud findings fixed** across 11 files:
   - **S1066** (13 MAJOR → 10 fixed): Merged nested `if` statements with `&&`
   - **S1481** (13 MINOR → 11 fixed): Removed/prefixed unused local variables
   - **S7684** (3 MAJOR → 3 fixed): Renamed `UPPER_CASE` locals to `lower_case`
   - 2 remaining are false positives (variables used in `for` loops)

## Stalling Pattern Analysis

These three issues compounded: workers introduce mechanical code smells → regression detection is broken (calls nonexistent function) → even if it worked, it only logs warnings without creating tasks → findings accumulate → user must manually intervene. This PR closes the loop on detection.

## Testing

- `check-regression` tested: first run records baseline, second run compares correctly
- ShellCheck `-S warning -x` passes on all 11 modified files (0 new warnings)
- All pre-existing ShellCheck warnings are from `read -r` unused variables in IFS splits (not our changes)

## Files Changed (11)

| File | Changes |
|------|---------|
| `code-audit-helper.sh` | Added `cmd_check_regression()`, `check-regression` case, updated help |
| `supervisor/pulse.sh` | Phase 10c: hourly rate limit, correct path |
| `audit-task-creator-helper.sh` | S1066: merged nested if |
| `supervisor/cleanup.sh` | S1066: merged 2 nested ifs |
| `supervisor/cron.sh` | S1066: merged nested if |
| `supervisor/evaluate.sh` | S1066 + S1481: merged if, prefixed unused vars |
| `supervisor/issue-sync.sh` | S1066 + S1481 + S7684: merged ifs, prefixed unused, renamed locals |
| `supervisor/memory-integration.sh` | S1481: removed unused `duration_info` |
| `supervisor/self-heal.sh` | S1481: prefixed unused `outcome_type` |
| `supervisor/utility.sh` | S1066 + S1481: merged if, removed/prefixed unused vars |
| `document-creation-helper.sh` | S1481: prefixed unused `template` |