### PR TITLE
t1044.8: Thread reconstruction from message-id chains

### DIFF
--- a/.agents/scripts/email-to-markdown.py
+++ b/.agents/scripts/email-to-markdown.py
@@ -3,14 +3,24 @@
 email-to-markdown.py - Convert .eml/.msg files to markdown with attachment extraction
 Part of aidevops framework: https://aidevops.sh
 
-Usage: email-to-markdown.py <input-file> [--output <file>] [--attachments-dir <dir>]
+Usage: 
+  Single file:  email-to-markdown.py <input-file> [--output <file>] [--attachments-dir <dir>]
+  Batch mode:   email-to-markdown.py <directory> --batch [--threads-index]
 
 Output format: YAML frontmatter with visible headers (from, to, cc, bcc, date_sent,
 date_received, subject, size, message_id, in_reply_to, attachment_count, attachments),
+thread reconstruction fields (thread_id, thread_position, thread_length),
 markdown.new convention fields (title, description), and tokens_estimate for LLM context.
 
 Auto-summary (t1052.7): With --auto-summary, the description field uses intelligent
 summarisation — heuristic extraction for short emails, LLM via Ollama for long ones.
+
+Thread reconstruction:
+- Parses message_id and in_reply_to headers to build conversation threads
+- thread_id: message-id of the root message (first in thread)
+- thread_position: 1-based position in thread (1 = root)
+- thread_length: total number of messages in thread
+- --threads-index: generates JSON index files per thread in threads/ directory
 """
 
 import sys


### PR DESCRIPTION
Thread reconstruction from message-id chains

## Implementation
- Added `build_thread_map()` to scan directories for all emails
- Added `reconstruct_thread()` to walk message-id/in-reply-to chains  
- Added `generate_thread_index()` to create per-thread JSON index files
- Added `thread_id`, `thread_position`, `thread_length` to frontmatter
- Support `--batch` mode for directory processing with thread reconstruction
- Support `--threads-index` flag to generate thread index files
- Thread reconstruction works in single-file mode if other emails exist in parent dir

## Testing
Creating test emails to verify thread reconstruction...

Ref #1427