### PR TITLE
t1044.9: Generate _index.toon collection manifest after batch import

### DIFF
--- a/.agents/scripts/document-creation-helper.sh
+++ b/.agents/scripts/document-creation-helper.sh
@@ -2771,12 +2771,12 @@ def parse_frontmatter(md_path):
         return fields
 
     fm_block = content[4:end]
-    for line in fm_block.split('\n'):
-        line = line.strip()
-        if not line or line.startswith('#'):
+    for raw_line in fm_block.split('\n'):
+        # Skip indented lines (nested YAML: list items, sub-keys)
+        if raw_line.startswith(' ') or raw_line.startswith('\t'):
             continue
-        # Handle top-level key: value pairs (skip nested/list items)
-        if line.startswith('- ') or line.startswith('  '):
+        line = raw_line.strip()
+        if not line or line.startswith('#') or line.startswith('- '):
             continue
         colon_pos = line.find(':')
         if colon_pos > 0:


### PR DESCRIPTION
## Summary

- Add `generate-manifest` command to `document-creation-helper.sh` that generates `_index.toon` collection manifest after batch email import
- Manifest includes three TOON indexes: documents (all converted .md files with metadata), threads (conversation groups from in_reply_to chains), contacts (all .toon records with email counts)
- Automatically called at end of `import-emails` flow; also available standalone

## Dependencies
- Merges `feature/t1044.5` (batch import command)
- Gracefully handles absent t1044.8 thread_id fields by reconstructing threads from in_reply_to chains

Ref #1428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `generate-manifest` command to automatically generate collection manifests on demand
  * Consolidates collection data including documents, threads, and contacts into organized manifest files
  * Available as a top-level CLI command with complete help documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->