### PR TITLE
t1044.7: Auto-summary generation for email descriptions

### DIFF
--- a/tests/email-summary-test-fixtures/empty-body.eml
+++ b/tests/email-summary-test-fixtures/empty-body.eml
@@ -1,0 +1,8 @@
+From: noreply@example.com
+To: user@example.com
+Subject: Empty notification
+Date: Wed, 12 Feb 2026 08:00:00 +0000
+Message-ID: <empty-001@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+

--- a/tests/email-summary-test-fixtures/html-email.eml
+++ b/tests/email-summary-test-fixtures/html-email.eml
@@ -1,0 +1,19 @@
+From: marketing@example.com
+To: subscriber@example.com
+Subject: Your weekly digest
+Date: Thu, 13 Feb 2026 10:00:00 +0000
+Message-ID: <html-001@example.com>
+MIME-Version: 1.0
+Content-Type: text/html; charset="utf-8"
+
+<html>
+<body>
+<h1>Weekly Digest</h1>
+<p>Here are the <strong>top stories</strong> from this week:</p>
+<ul>
+<li>New product launch scheduled for March 15th.</li>
+<li>Customer satisfaction scores reached an all-time high of 94%.</li>
+</ul>
+<p>Visit <a href="https://example.com">our website</a> for more details.</p>
+</body>
+</html>

--- a/tests/email-summary-test-fixtures/long-email.eml
+++ b/tests/email-summary-test-fixtures/long-email.eml
@@ -1,0 +1,31 @@
+From: carol@example.com
+To: team@example.com
+Subject: Project Alpha - Phase 2 Status Update and Next Steps
+Date: Tue, 11 Feb 2026 14:30:00 +0000
+Message-ID: <long-001@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Dear Team,
+
+I wanted to provide a comprehensive update on Project Alpha Phase 2 progress and outline the next steps we need to take before the end of the quarter.
+
+First, regarding the backend migration: we have successfully completed the database schema changes and the new API endpoints are now deployed to the staging environment. The performance benchmarks show a 40% improvement in query response times compared to the previous architecture. However, we discovered an edge case in the pagination logic that affects queries with more than 10,000 results. David is working on a fix that should be ready by Thursday.
+
+On the frontend side, the new dashboard components are approximately 80% complete. The main remaining work involves the real-time data visualisation charts and the export functionality. Sarah has been coordinating with the design team to finalise the colour palette and accessibility requirements. We expect the frontend work to be completed by the end of next week.
+
+The QA team has been running automated regression tests against the staging environment. So far, they have identified 12 issues, of which 8 have been resolved. The remaining 4 are low-priority cosmetic issues that will not block the release. We are on track for the beta release scheduled for March 1st.
+
+Budget-wise, we are currently 5% under the allocated budget for Phase 2. This gives us some flexibility to bring in an additional contractor if needed to help with the documentation and training materials.
+
+Action items for this week:
+1. David to fix the pagination edge case by Thursday
+2. Sarah to complete the dashboard charts by Friday
+3. QA team to run the full regression suite on Monday
+4. I will schedule a stakeholder demo for next Wednesday
+
+Please let me know if you have any questions or concerns about the timeline.
+
+Best regards,
+Carol Henderson
+Project Manager, Engineering Division

--- a/tests/email-summary-test-fixtures/short-email.eml
+++ b/tests/email-summary-test-fixtures/short-email.eml
@@ -1,0 +1,14 @@
+From: alice@example.com
+To: bob@example.com
+Subject: Meeting tomorrow
+Date: Mon, 10 Feb 2026 09:15:00 +0000
+Message-ID: <short-001@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+
+Hi Bob,
+
+Can we meet at 3pm tomorrow to discuss the Q1 budget? I have the spreadsheet ready.
+
+Thanks,
+Alice

--- a/tests/test-email-summary.sh
+++ b/tests/test-email-summary.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# test-email-summary.sh - Test auto-summary generation for email-to-markdown (t1044.7)
+# Tests: heuristic summary for short emails, LLM routing for long emails,
+#        empty body handling, HTML email handling, --summary-mode flag
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+CONVERTER="${REPO_DIR}/.agents/scripts/email-to-markdown.py"
+FIXTURES="${SCRIPT_DIR}/email-summary-test-fixtures"
+TMPDIR_BASE="${TMPDIR:-/tmp}/email-summary-test-$$"
+
+pass_count=0
+fail_count=0
+total_count=0
+
+cleanup() {
+	rm -rf "${TMPDIR_BASE}"
+}
+trap cleanup EXIT
+
+mkdir -p "${TMPDIR_BASE}"
+
+log_pass() {
+	local test_name="$1"
+	pass_count=$((pass_count + 1))
+	total_count=$((total_count + 1))
+	echo "  PASS: ${test_name}"
+}
+
+log_fail() {
+	local test_name="$1"
+	local detail="${2:-}"
+	fail_count=$((fail_count + 1))
+	total_count=$((total_count + 1))
+	echo "  FAIL: ${test_name}"
+	if [[ -n "${detail}" ]]; then
+		echo "        ${detail}"
+	fi
+}
+
+# Helper: extract a frontmatter field value from a markdown file
+get_frontmatter_field() {
+	local file="$1"
+	local field="$2"
+	# Extract value between --- markers
+	sed -n '/^---$/,/^---$/p' "$file" | grep "^${field}:" | head -1 | sed "s/^${field}: *//" | sed 's/^"//;s/"$//'
+}
+
+echo "=== Email Auto-Summary Tests (t1044.7) ==="
+echo ""
+
+# --- Test 1: Short email uses heuristic ---
+echo "Test 1: Short email (<=100 words) uses heuristic summary"
+outfile="${TMPDIR_BASE}/short.md"
+python3 "${CONVERTER}" "${FIXTURES}/short-email.eml" -o "${outfile}" --summary-mode auto 2>/dev/null
+
+description=$(get_frontmatter_field "${outfile}" "description")
+summary_method=$(get_frontmatter_field "${outfile}" "summary_method")
+
+if [[ "${summary_method}" == "heuristic" ]]; then
+	log_pass "summary_method is 'heuristic' for short email"
+else
+	log_fail "summary_method is 'heuristic' for short email" "got: ${summary_method}"
+fi
+
+if [[ -n "${description}" ]]; then
+	log_pass "description is non-empty for short email"
+else
+	log_fail "description is non-empty for short email" "got empty description"
+fi
+
+# Check it contains meaningful content (not just truncation)
+if echo "${description}" | grep -qi "meet\|3pm\|budget"; then
+	log_pass "short email description contains key content"
+else
+	log_fail "short email description contains key content" "got: ${description}"
+fi
+
+# --- Test 2: Long email routing ---
+echo ""
+echo "Test 2: Long email (>100 words) attempts LLM, falls back to heuristic"
+outfile="${TMPDIR_BASE}/long.md"
+python3 "${CONVERTER}" "${FIXTURES}/long-email.eml" -o "${outfile}" --summary-mode auto 2>/dev/null
+
+description=$(get_frontmatter_field "${outfile}" "description")
+summary_method=$(get_frontmatter_field "${outfile}" "summary_method")
+
+# In CI/test environment, LLM is likely unavailable — should fall back to heuristic
+if [[ "${summary_method}" == "heuristic" || "${summary_method}" == "ollama" || "${summary_method}" == "anthropic" ]]; then
+	log_pass "summary_method is valid for long email (${summary_method})"
+else
+	log_fail "summary_method is valid for long email" "got: ${summary_method}"
+fi
+
+if [[ -n "${description}" ]]; then
+	log_pass "description is non-empty for long email"
+else
+	log_fail "description is non-empty for long email" "got empty description"
+fi
+
+# --- Test 3: Empty body ---
+echo ""
+echo "Test 3: Empty body email"
+outfile="${TMPDIR_BASE}/empty.md"
+python3 "${CONVERTER}" "${FIXTURES}/empty-body.eml" -o "${outfile}" --summary-mode auto 2>/dev/null
+
+description=$(get_frontmatter_field "${outfile}" "description")
+summary_method=$(get_frontmatter_field "${outfile}" "summary_method")
+
+if [[ "${summary_method}" == "heuristic" ]]; then
+	log_pass "empty body uses heuristic method"
+else
+	log_fail "empty body uses heuristic method" "got: ${summary_method}"
+fi
+
+# Empty body should produce empty or minimal description
+# (the body may contain just whitespace which gets stripped)
+log_pass "empty body handled without error"
+
+# --- Test 4: HTML email ---
+echo ""
+echo "Test 4: HTML email with markdown conversion"
+outfile="${TMPDIR_BASE}/html.md"
+python3 "${CONVERTER}" "${FIXTURES}/html-email.eml" -o "${outfile}" --summary-mode auto 2>/dev/null
+
+description=$(get_frontmatter_field "${outfile}" "description")
+summary_method=$(get_frontmatter_field "${outfile}" "summary_method")
+
+if [[ -n "${description}" ]]; then
+	log_pass "HTML email produces non-empty description"
+else
+	log_fail "HTML email produces non-empty description" "got empty description"
+fi
+
+if [[ "${summary_method}" == "heuristic" ]]; then
+	log_pass "HTML short email uses heuristic"
+else
+	log_fail "HTML short email uses heuristic" "got: ${summary_method}"
+fi
+
+# --- Test 5: --summary-mode heuristic forces heuristic ---
+echo ""
+echo "Test 5: --summary-mode heuristic forces heuristic for long email"
+outfile="${TMPDIR_BASE}/forced-heuristic.md"
+python3 "${CONVERTER}" "${FIXTURES}/long-email.eml" -o "${outfile}" --summary-mode heuristic 2>/dev/null
+
+summary_method=$(get_frontmatter_field "${outfile}" "summary_method")
+
+if [[ "${summary_method}" == "heuristic" ]]; then
+	log_pass "--summary-mode heuristic forces heuristic method"
+else
+	log_fail "--summary-mode heuristic forces heuristic method" "got: ${summary_method}"
+fi
+
+# --- Test 6: --summary-mode off uses truncation ---
+echo ""
+echo "Test 6: --summary-mode off uses truncation fallback"
+outfile="${TMPDIR_BASE}/off.md"
+python3 "${CONVERTER}" "${FIXTURES}/short-email.eml" -o "${outfile}" --summary-mode off 2>/dev/null
+
+summary_method=$(get_frontmatter_field "${outfile}" "summary_method")
+
+if [[ "${summary_method}" == "off" ]]; then
+	log_pass "--summary-mode off sets method to 'off'"
+else
+	log_fail "--summary-mode off sets method to 'off'" "got: ${summary_method}"
+fi
+
+# --- Test 7: summary_method field exists in frontmatter ---
+echo ""
+echo "Test 7: summary_method field present in all outputs"
+for f in "${TMPDIR_BASE}"/*.md; do
+	method=$(get_frontmatter_field "${f}" "summary_method")
+	basename_f=$(basename "${f}")
+	if [[ -n "${method}" ]]; then
+		log_pass "summary_method present in ${basename_f}"
+	else
+		log_fail "summary_method present in ${basename_f}" "field missing"
+	fi
+done
+
+# --- Summary ---
+echo ""
+echo "=== Results: ${pass_count}/${total_count} passed, ${fail_count} failed ==="
+
+if [[ "${fail_count}" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Add auto-summary generation for email `description:` frontmatter field
- Short emails (<=100 words): sentence extraction heuristic (first 1-2 complete sentences)
- Long emails (>100 words): LLM summarisation via Ollama (local) → Anthropic API (cloud fallback) → heuristic (last resort)
- New `--summary-mode` CLI flag: `auto` (default), `heuristic`, `llm`, `off`
- New `summary_method` frontmatter field tracks which method generated the description
- 17 test assertions across 4 fixture types (short, long, empty, HTML emails)

## Design Decisions

- **100-word threshold** chosen as boundary between short/long — emails under 100 words are typically 1-3 sentences where extraction is sufficient
- **Sentence extraction** uses regex sentence-boundary detection rather than simple truncation — produces more meaningful descriptions
- **Ollama first** for privacy-first local processing, Anthropic API as cloud fallback (matches t1044.3 pattern)
- **Graceful degradation** — always produces a description even without LLM availability
- **No new dependencies** — uses stdlib `urllib.request` for HTTP calls, no pip packages required

Ref #1426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unified summary mode selector (auto, heuristic, LLM, off) replacing previous flag combinations
  * Intelligent email processing: fast extraction for short emails; advanced summarization for long emails
  * Summary method metadata now included with each converted email for transparency
  * Improved fallback behavior when services are unavailable

* **Tests**
  * Added comprehensive test suite covering various email formats and summary modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->