### PR TITLE
fix: resolve symlink in npm global install CLI wrapper

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -900,7 +900,7 @@ npm install -g aidevops && aidevops update
 brew install marcusquinn/tap/aidevops && aidevops update
 
 # curl
-bash <(curl -fsSL https://aidevops.sh)
+bash <(curl -fsSL https://aidevops.sh/install)
 \`\`\`
 
 ### What's New

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -2673,7 +2673,7 @@ cmd_help() {
 	echo "Installation:"
 	echo "  npm install -g aidevops && aidevops update      # via npm (recommended)"
 	echo "  brew install marcusquinn/tap/aidevops && aidevops update  # via Homebrew"
-	echo "  curl -fsSL https://aidevops.sh -o /tmp/aidevops-setup.sh && bash /tmp/aidevops-setup.sh  # manual"
+	echo "  bash <(curl -fsSL https://aidevops.sh/install)                     # manual"
 	echo ""
 	echo "Documentation: https://github.com/marcusquinn/aidevops"
 }

--- a/bin/aidevops
+++ b/bin/aidevops
@@ -4,8 +4,17 @@
 
 set -euo pipefail
 
-# Find the actual script location
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve symlinks to find the actual script location
+# npm install -g creates a symlink: /usr/local/bin/aidevops -> .../node_modules/aidevops/bin/aidevops
+# BASH_SOURCE[0] returns the symlink path, not the target, so we must resolve it
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    # If readlink returned a relative path, resolve it relative to the symlink's directory
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
 
 # Check if we're in an npm global install or local development
 if [[ -f "$SCRIPT_DIR/../aidevops.sh" ]]; then
@@ -16,6 +25,6 @@ elif [[ -f "$HOME/Git/aidevops/aidevops.sh" ]]; then
     exec bash "$HOME/Git/aidevops/aidevops.sh" "$@"
 else
     echo "Error: aidevops.sh not found"
-    echo "Please run: bash <(curl -fsSL https://aidevops.sh)"
+    echo "Please run: bash <(curl -fsSL https://aidevops.sh/install)"
     exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # Quick Install:
 #   npm install -g aidevops && aidevops update          (recommended)
 #   brew install marcusquinn/tap/aidevops && aidevops update  (Homebrew)
-#   curl -fsSL https://aidevops.sh -o /tmp/aidevops-setup.sh && bash /tmp/aidevops-setup.sh  (manual)
+#   bash <(curl -fsSL https://aidevops.sh/install)                     (manual)
 
 # Colors for output
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary

- Fix `bin/aidevops` symlink resolution so `npm install -g aidevops && aidevops update` works correctly
- Fix install URL references from `https://aidevops.sh` (serves HTML) to `https://aidevops.sh/install` (redirects to raw setup.sh)

## Problem

When users run `npm install -g aidevops`, npm creates a symlink:
```
/usr/local/bin/aidevops -> .../node_modules/aidevops/bin/aidevops
```

The wrapper used `BASH_SOURCE[0]` which returns the **symlink path** (`/usr/local/bin/`), not the resolved target. So `$SCRIPT_DIR/../aidevops.sh` resolved to `/usr/local/aidevops.sh` — which doesn't exist.

The error message then directed users to `bash <(curl -fsSL https://aidevops.sh)` which serves the HTML landing page, causing a `<!DOCTYPE html>` parse error.

## Fix

1. **Symlink resolution**: Added a `readlink` loop to resolve symlinks before deriving `SCRIPT_DIR`, following the standard bash pattern for this
2. **Install URL**: Updated all references from `https://aidevops.sh` to `https://aidevops.sh/install` which correctly 301-redirects to the raw `setup.sh`

## Files Changed

| File | Change |
|------|--------|
| `bin/aidevops` | Resolve symlinks via readlink loop; fix error message URL |
| `aidevops.sh` | Fix install URL in help text |
| `setup.sh` | Fix install URL in header comment |
| `.agents/scripts/version-manager.sh` | Fix install URL in release notes template |

## Testing

- ShellCheck clean on all 4 files
- Verified symlink resolution with a simulated npm global install layout (symlink -> package/bin/aidevops -> finds ../aidevops.sh correctly)
- Verified `https://aidevops.sh/install` returns valid shell script (301 -> raw.githubusercontent.com/setup.sh)