### PR TITLE
t1046.5: PageIndex tree generation — .pageindex.json sidecar

### DIFF
--- a/.agents/scripts/document-creation-helper.sh
+++ b/.agents/scripts/document-creation-helper.sh
@@ -3,7 +3,7 @@
 # Part of aidevops framework: https://aidevops.sh
 #
 # Usage: document-creation-helper.sh <command> [options]
-# Commands: convert, create, template, install, formats, status, help
+# Commands: convert, create, template, normalise, install, formats, status, help
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Add `pageindex` subcommand to `document-creation-helper.sh` that generates `.pageindex.json` from markdown heading hierarchy
- Hierarchical tree built from H1-H6 levels with node summaries (LLM via Ollama when available, first-sentence fallback)
- Page references estimated from source PDF metadata via `--source-pdf` flag
- Integrates with `normalise` subcommand via `--pageindex` flag for combined normalisation + indexing
- Handles edge cases: no headings (single root node), deeply nested (5+ levels), flat text, missing frontmatter

## Test Results

- ShellCheck: zero violations
- Functional: tested with structured, flat, and deeply nested markdown — all produce valid JSON trees
- Integration: `normalise --pageindex` correctly chains both operations

Ref #1435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PageIndex generation from Markdown documents with configurable options
  * Introduced optional PDF source integration and AI model support for enhanced indexing
  * New `--pageindex` flag enables automatic index generation during document normalization
  * Expanded CLI with new `pageindex` command for standalone index creation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->