### PR TITLE
fix: swap stat -f %m to Linux-first order for cross-platform compat

### DIFF
--- a/.agents/scripts/higgsfield-helper.sh
+++ b/.agents/scripts/higgsfield-helper.sh
@@ -289,7 +289,7 @@ cmd_batch_lipsync() {
 cmd_status() {
     if [[ -f "${STATE_FILE}" ]]; then
         local age
-        age=$(( $(date +%s) - $(stat -f %m "${STATE_FILE}" 2>/dev/null || stat -c %Y "${STATE_FILE}" 2>/dev/null || echo 0) ))
+        age=$(( $(date +%s) - $(stat -c %Y "${STATE_FILE}" 2>/dev/null || stat -f %m "${STATE_FILE}" 2>/dev/null || echo 0) ))
         local hours=$(( age / 3600 ))
         print_success "Auth state exists (${hours}h old)"
         print_info "State file: ${STATE_FILE}"

--- a/.agents/scripts/humanise-update-helper.sh
+++ b/.agents/scripts/humanise-update-helper.sh
@@ -57,7 +57,7 @@ fetch_upstream() {
     # Check cache freshness
     if [[ -f "$CACHE_FILE" && -f "$CACHE_VERSION_FILE" ]]; then
         local cache_age
-        cache_age=$(( $(date +%s) - $(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0) ))
+        cache_age=$(( $(date +%s) - $(stat -c %Y "$CACHE_FILE" 2>/dev/null || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0) ))
         if [[ $cache_age -lt $CACHE_TTL ]]; then
             echo "Using cached upstream ($(( cache_age / 60 )) minutes old)"
             return 0

--- a/.agents/scripts/mcp-index-helper.sh
+++ b/.agents/scripts/mcp-index-helper.sh
@@ -120,7 +120,7 @@ needs_refresh() {
     # Check if opencode.json is newer than last sync
     if [[ -f "$OPENCODE_CONFIG" ]]; then
         local config_mtime
-        config_mtime=$(stat -f %m "$OPENCODE_CONFIG" 2>/dev/null || stat -c %Y "$OPENCODE_CONFIG" 2>/dev/null || echo "0")
+        config_mtime=$(stat -c %Y "$OPENCODE_CONFIG" 2>/dev/null || stat -f %m "$OPENCODE_CONFIG" 2>/dev/null || echo "0")
         local sync_epoch
         sync_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "$last_sync" +%s 2>/dev/null || date -d "$last_sync" +%s 2>/dev/null || echo "0")
         

--- a/.agents/scripts/memory-audit-pulse.sh
+++ b/.agents/scripts/memory-audit-pulse.sh
@@ -65,7 +65,7 @@ should_run() {
     fi
 
     local last_run
-    last_run=$(stat -f %m "$AUDIT_MARKER" 2>/dev/null || stat -c %Y "$AUDIT_MARKER" 2>/dev/null || echo "0")
+    last_run=$(stat -c %Y "$AUDIT_MARKER" 2>/dev/null || stat -f %m "$AUDIT_MARKER" 2>/dev/null || echo "0")
     local now
     now=$(date +%s)
     local elapsed=$((now - last_run))
@@ -447,7 +447,7 @@ cmd_status() {
     # Last audit
     if [[ -f "$AUDIT_MARKER" ]]; then
         local last_run
-        last_run=$(stat -f %m "$AUDIT_MARKER" 2>/dev/null || stat -c %Y "$AUDIT_MARKER" 2>/dev/null || echo "0")
+        last_run=$(stat -c %Y "$AUDIT_MARKER" 2>/dev/null || stat -f %m "$AUDIT_MARKER" 2>/dev/null || echo "0")
         local now
         now=$(date +%s)
         local elapsed=$(( (now - last_run) / 3600 ))

--- a/.agents/scripts/memory/_common.sh
+++ b/.agents/scripts/memory/_common.sh
@@ -358,7 +358,7 @@ auto_prune() {
 	# Check if we should run
 	if [[ -f "$prune_marker" ]]; then
 		local last_prune
-		last_prune=$(stat -f %m "$prune_marker" 2>/dev/null || stat -c %Y "$prune_marker" 2>/dev/null || echo "0")
+		last_prune=$(stat -c %Y "$prune_marker" 2>/dev/null || stat -f %m "$prune_marker" 2>/dev/null || echo "0")
 		local now
 		now=$(date +%s)
 		local elapsed=$((now - last_prune))

--- a/.agents/scripts/migrate-pr-backfill.sh
+++ b/.agents/scripts/migrate-pr-backfill.sh
@@ -191,7 +191,7 @@ fetch_merged_prs() {
     # Use cache if less than 5 minutes old
     if [[ -f "$cache_file" ]]; then
         local cache_age
-        cache_age=$(( $(date +%s) - $(stat -f %m "$cache_file" 2>/dev/null || stat -c %Y "$cache_file" 2>/dev/null || echo 0) ))
+        cache_age=$(( $(date +%s) - $(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo 0) ))
         if (( cache_age < 300 )); then
             log "Using cached PR list (${cache_age}s old)"
             cat "$cache_file"

--- a/.agents/scripts/ralph-upstream-check.sh
+++ b/.agents/scripts/ralph-upstream-check.sh
@@ -74,7 +74,7 @@ is_cache_valid() {
     fi
     
     local cache_time
-    cache_time=$(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE" 2>/dev/null || echo 0)
+    cache_time=$(stat -c %Y "$CACHE_FILE" 2>/dev/null || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)
     local current_time
     current_time=$(date +%s)
     local age=$((current_time - cache_time))

--- a/.agents/scripts/schema-validator-helper.sh
+++ b/.agents/scripts/schema-validator-helper.sh
@@ -240,7 +240,7 @@ cmd_status() {
 
     if [[ -f "$SCHEMA_CACHE" ]]; then
         local cache_age
-        cache_age=$(( ($(date +%s) - $(stat -f %m "$SCHEMA_CACHE" 2>/dev/null || stat -c %Y "$SCHEMA_CACHE" 2>/dev/null || echo 0)) / 3600 ))
+        cache_age=$(( ($(date +%s) - $(stat -c %Y "$SCHEMA_CACHE" 2>/dev/null || stat -f %m "$SCHEMA_CACHE" 2>/dev/null || echo 0)) / 3600 ))
         print_success "Schema cache: ${cache_age}h old (24h TTL)"
     else
         print_info "Schema cache: not yet fetched (will download on first run)"

--- a/.agents/scripts/subagent-index-helper.sh
+++ b/.agents/scripts/subagent-index-helper.sh
@@ -160,13 +160,9 @@ cmd_check() {
 		return 1
 	fi
 
-	# macOS stat vs GNU stat
+	# Cross-platform file mtime: Linux (stat -c) first, macOS (stat -f) fallback
 	local index_mtime
-	if stat -f %m "$INDEX_FILE" >/dev/null 2>&1; then
-		index_mtime=$(stat -f %m "$INDEX_FILE")
-	else
-		index_mtime=$(stat -c %Y "$INDEX_FILE")
-	fi
+	index_mtime=$(stat -c %Y "$INDEX_FILE" 2>/dev/null || stat -f %m "$INDEX_FILE" 2>/dev/null || echo "0")
 	local index_age=$(($(date +%s) - index_mtime))
 
 	echo "Index: ${INDEX_FILE}"

--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -813,7 +813,7 @@ cmd_pulse() {
 	if [[ -f "$escalation_lock" ]]; then
 		local lock_pid lock_age
 		lock_pid=$(head -1 "$escalation_lock" 2>/dev/null || echo "")
-		lock_age=$(($(date +%s) - $(stat -f %m "$escalation_lock" 2>/dev/null || stat -c %Y "$escalation_lock" 2>/dev/null || echo "0")))
+		lock_age=$(($(date +%s) - $(stat -c %Y "$escalation_lock" 2>/dev/null || stat -f %m "$escalation_lock" 2>/dev/null || echo "0")))
 		# Check if the lock holder is still alive
 		if [[ -n "$lock_pid" ]] && kill -0 "$lock_pid" 2>/dev/null; then
 			# Lock holder alive — respect cooldown


### PR DESCRIPTION
## Summary

Fixes #1491 — `stat -f %m` (macOS-first) breaks on Linux, causing stdout pollution and "unbound variable" errors.

## Root Cause

On Linux, `stat -f %m` interprets `-f` as "filesystem" mode and dumps multi-line filesystem metadata to **stdout** (not stderr). Since `2>/dev/null` only suppresses stderr, the garbage is captured by `$()`, corrupting the variable. Arithmetic evaluation then fails on the garbage text.

## Fix

Swap all 10 macOS-first `||` chains to Linux-first:

```bash
# Before (broken on Linux):
stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || echo "0"

# After (works on both):
stat -c %Y "$file" 2>/dev/null || stat -f %m "$file" 2>/dev/null || echo "0"
```

`stat -c` on macOS fails cleanly (no stdout, exit 1) so the fallback to `stat -f` works correctly.

Also simplified `subagent-index-helper.sh` from a 5-line if/else to the standard `||` chain.

## Files Changed (10)

All `||` chain patterns swapped to Linux-first. The 4 files using `uname` guards were already safe and left unchanged.

## Verification

Tested on Linux via OrbStack (Ubuntu 22.04):
- `stat -c %Y` returns clean numeric timestamp
- Arithmetic age calculation: PASS
- All 10 fixed scripts confirmed Linux-first pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized file timestamp retrieval methods across internal helper and supervisor scripts to improve cross-platform compatibility and consistency for cache freshness validation, system configuration checks, memory management operations, upstream data synchronization, event timing calculations, and various automated maintenance and coordination infrastructure tasks throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->