### PR TITLE
t1054: Import chrome-webstore-release-blueprint skill into aidevops

### DIFF
--- a/.agents/scripts/chrome-webstore-helper.sh
+++ b/.agents/scripts/chrome-webstore-helper.sh
@@ -1,0 +1,750 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2034
+
+# Chrome Web Store Helper Script
+# Automate Chrome extension publishing via Chrome Web Store API
+# Managed by AI DevOps Framework
+
+# Set strict mode
+set -euo pipefail
+
+# ------------------------------------------------------------------------------
+# CONFIGURATION & CONSTANTS
+# ------------------------------------------------------------------------------
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${script_dir}/shared-constants.sh"
+
+readonly SCRIPT_DIR="$script_dir"
+
+repo_root="$(dirname "$SCRIPT_DIR")"
+readonly REPO_ROOT="$repo_root"
+
+# API Endpoints
+readonly CWS_TOKEN_URL="https://oauth2.googleapis.com/token"
+readonly CWS_API_BASE="https://chromewebstore.googleapis.com"
+
+# Error Messages
+readonly ERROR_MANIFEST_NOT_FOUND="Manifest file not found"
+readonly ERROR_MANIFEST_REQUIRED="Manifest path is required"
+readonly ERROR_CREDENTIALS_MISSING="Required credentials are missing"
+readonly ERROR_JQ_NOT_INSTALLED="jq is required but not installed"
+readonly ERROR_ZIP_NOT_INSTALLED="zip is required but not installed"
+readonly ERROR_BUILD_FAILED="Build command failed"
+readonly ERROR_ZIP_FAILED="Zip command failed"
+readonly ERROR_UPLOAD_FAILED="Upload to Chrome Web Store failed"
+readonly ERROR_PUBLISH_FAILED="Publish to Chrome Web Store failed"
+readonly ERROR_STATUS_FAILED="Failed to fetch status from Chrome Web Store"
+readonly ERROR_TOKEN_EXCHANGE_FAILED="Failed to exchange refresh token for access token"
+readonly ERROR_GH_NOT_INSTALLED="GitHub CLI (gh) is required but not installed"
+readonly ERROR_GH_NOT_AUTHENTICATED="GitHub CLI is not authenticated"
+
+# Success Messages
+readonly SUCCESS_SETUP_COMPLETE="Chrome Web Store credentials configured successfully"
+readonly SUCCESS_PUBLISH_COMPLETE="Extension published successfully"
+readonly SUCCESS_UPLOAD_COMPLETE="Extension uploaded successfully"
+readonly SUCCESS_SECRETS_UPLOADED="Secrets uploaded to GitHub successfully"
+
+# Required credential keys
+readonly REQUIRED_CREDENTIALS=(
+	"CWS_CLIENT_ID"
+	"CWS_CLIENT_SECRET"
+	"CWS_REFRESH_TOKEN"
+	"CWS_PUBLISHER_ID"
+	"CWS_EXTENSION_ID"
+)
+
+# ------------------------------------------------------------------------------
+# UTILITY FUNCTIONS
+# ------------------------------------------------------------------------------
+
+print_error() {
+	local message="$1"
+	echo -e "\033[1;31m[ERROR]\033[0m $message" >&2
+	return 0
+}
+
+print_success() {
+	local message="$1"
+	echo -e "\033[0;32m[OK]\033[0m $message"
+	return 0
+}
+
+print_info() {
+	local message="$1"
+	echo -e "\033[1;33m[INFO]\033[0m $message"
+	return 0
+}
+
+print_warning() {
+	local message="$1"
+	echo -e "\033[1;33m[WARN]\033[0m $message"
+	return 0
+}
+
+# ------------------------------------------------------------------------------
+# DEPENDENCY CHECKING
+# ------------------------------------------------------------------------------
+
+check_dependencies() {
+	local missing_deps=()
+
+	if ! command -v jq &>/dev/null; then
+		missing_deps+=("jq")
+	fi
+
+	if ! command -v zip &>/dev/null; then
+		missing_deps+=("zip")
+	fi
+
+	if [[ ${#missing_deps[@]} -gt 0 ]]; then
+		print_error "Missing required dependencies: ${missing_deps[*]}"
+		print_info "Install missing dependencies:"
+		for dep in "${missing_deps[@]}"; do
+			case "$dep" in
+			jq)
+				print_info "  macOS: brew install jq"
+				print_info "  Ubuntu: sudo apt install jq"
+				;;
+			zip)
+				print_info "  macOS: brew install zip"
+				print_info "  Ubuntu: sudo apt install zip"
+				;;
+			esac
+		done
+		return 1
+	fi
+	return 0
+}
+
+# ------------------------------------------------------------------------------
+# CREDENTIAL MANAGEMENT
+# ------------------------------------------------------------------------------
+
+load_credentials() {
+	local env_file="${1:-.env}"
+
+	# Try to load from env file if it exists
+	if [[ -f "$env_file" ]]; then
+		# shellcheck disable=SC1090
+		source "$env_file"
+	fi
+
+	# Try to load from aidevops secret storage
+	if command -v aidevops &>/dev/null; then
+		for key in "${REQUIRED_CREDENTIALS[@]}"; do
+			if [[ -z "${!key:-}" ]]; then
+				local value
+				value=$(aidevops secret get "$key" 2>/dev/null || echo "")
+				if [[ -n "$value" ]]; then
+					export "$key=$value"
+				fi
+			fi
+		done
+	fi
+
+	# Validate all required credentials are present
+	local missing_creds=()
+	for key in "${REQUIRED_CREDENTIALS[@]}"; do
+		if [[ -z "${!key:-}" ]]; then
+			missing_creds+=("$key")
+		fi
+	done
+
+	if [[ ${#missing_creds[@]} -gt 0 ]]; then
+		print_error "$ERROR_CREDENTIALS_MISSING"
+		print_info "Missing credentials: ${missing_creds[*]}"
+		print_info "Run 'chrome-webstore-helper.sh setup' to configure credentials"
+		return 1
+	fi
+
+	return 0
+}
+
+validate_credentials() {
+	local missing_creds=()
+
+	for key in "${REQUIRED_CREDENTIALS[@]}"; do
+		if [[ -z "${!key:-}" ]]; then
+			missing_creds+=("$key")
+		fi
+	done
+
+	if [[ ${#missing_creds[@]} -gt 0 ]]; then
+		print_error "$ERROR_CREDENTIALS_MISSING"
+		print_info "Missing credentials: ${missing_creds[*]}"
+		return 1
+	fi
+
+	return 0
+}
+
+# ------------------------------------------------------------------------------
+# SETUP COMMAND
+# ------------------------------------------------------------------------------
+
+cmd_setup() {
+	print_info "Chrome Web Store Credential Setup"
+	print_info "===================================="
+	echo ""
+
+	print_info "This wizard will guide you through setting up Chrome Web Store API credentials."
+	print_info "You will need to complete several manual steps in Google Cloud Console."
+	echo ""
+
+	# Step 1: Enable API
+	print_info "Step 1: Enable Chrome Web Store API"
+	print_info "1. Open: https://console.cloud.google.com/apis/library/chromewebstore.googleapis.com"
+	print_info "2. Select your Google Cloud project"
+	print_info "3. Click 'Enable' for Chrome Web Store API"
+	echo ""
+	read -rp "Press Enter when Chrome Web Store API is enabled..."
+	echo ""
+
+	# Step 2: OAuth Consent Screen
+	print_info "Step 2: Configure OAuth Consent Screen"
+	print_info "1. Open: https://console.cloud.google.com/apis/credentials/consent"
+	print_info "2. Choose 'External' user type"
+	print_info "3. Fill in app name, support email, developer contact email"
+	print_info "4. Save and continue through scopes"
+	print_info "5. Add your Google account as a test user if in Testing mode"
+	echo ""
+	read -rp "Press Enter when OAuth consent screen is configured..."
+	echo ""
+
+	# Step 3: Create OAuth Client
+	print_info "Step 3: Create OAuth Client"
+	print_info "1. Open: https://console.cloud.google.com/apis/credentials"
+	print_info "2. Click 'Create Credentials' -> 'OAuth client ID'"
+	print_info "3. Choose 'Web application'"
+	print_info "4. Add authorized redirect URI: https://developers.google.com/oauthplayground"
+	print_info "5. Create client and copy credentials"
+	echo ""
+
+	read -rp "Enter CWS_CLIENT_ID: " CWS_CLIENT_ID
+	read -rsp "Enter CWS_CLIENT_SECRET: " CWS_CLIENT_SECRET
+	echo ""
+	echo ""
+
+	# Step 4: Generate Refresh Token
+	print_info "Step 4: Generate Refresh Token"
+	print_info "1. Open: https://developers.google.com/oauthplayground/"
+	print_info "2. Click settings gear icon"
+	print_info "3. Enable 'Use your own OAuth credentials'"
+	print_info "4. Paste your Client ID and Client Secret"
+	print_info "5. In Step 1, enter scope: https://www.googleapis.com/auth/chromewebstore"
+	print_info "6. Click 'Authorize APIs' and sign in"
+	print_info "7. Click 'Exchange authorization code for tokens'"
+	print_info "8. Copy the refresh token"
+	echo ""
+
+	read -rsp "Enter CWS_REFRESH_TOKEN: " CWS_REFRESH_TOKEN
+	echo ""
+	echo ""
+
+	# Step 5: Capture Store IDs
+	print_info "Step 5: Capture Store IDs"
+	print_info "1. Open Chrome Web Store Developer Dashboard"
+	print_info "2. Copy extension item ID from URL or item details"
+	print_info "3. Copy publisher ID from account details or URL"
+	echo ""
+
+	read -rp "Enter CWS_EXTENSION_ID: " CWS_EXTENSION_ID
+	read -rp "Enter CWS_PUBLISHER_ID: " CWS_PUBLISHER_ID
+	echo ""
+
+	# Save credentials
+	print_info "Saving credentials..."
+
+	if command -v aidevops &>/dev/null; then
+		print_info "Using aidevops secret storage (encrypted)"
+		echo "$CWS_CLIENT_ID" | aidevops secret set CWS_CLIENT_ID
+		echo "$CWS_CLIENT_SECRET" | aidevops secret set CWS_CLIENT_SECRET
+		echo "$CWS_REFRESH_TOKEN" | aidevops secret set CWS_REFRESH_TOKEN
+		echo "$CWS_EXTENSION_ID" | aidevops secret set CWS_EXTENSION_ID
+		echo "$CWS_PUBLISHER_ID" | aidevops secret set CWS_PUBLISHER_ID
+	else
+		print_warning "aidevops not found, saving to .env file (plaintext)"
+		local env_file=".env.cws"
+		{
+			echo "CWS_CLIENT_ID=$CWS_CLIENT_ID"
+			echo "CWS_CLIENT_SECRET=$CWS_CLIENT_SECRET"
+			echo "CWS_REFRESH_TOKEN=$CWS_REFRESH_TOKEN"
+			echo "CWS_EXTENSION_ID=$CWS_EXTENSION_ID"
+			echo "CWS_PUBLISHER_ID=$CWS_PUBLISHER_ID"
+		} >"$env_file"
+		chmod 600 "$env_file"
+		print_info "Credentials saved to $env_file (600 permissions)"
+		print_warning "Add $env_file to .gitignore to prevent committing secrets"
+	fi
+
+	print_success "$SUCCESS_SETUP_COMPLETE"
+	return 0
+}
+
+# ------------------------------------------------------------------------------
+# TOKEN EXCHANGE
+# ------------------------------------------------------------------------------
+
+exchange_token() {
+	local client_id="$1"
+	local client_secret="$2"
+	local refresh_token="$3"
+
+	local response
+	response=$(curl -s -X POST "$CWS_TOKEN_URL" \
+		-d "client_id=$client_id" \
+		-d "client_secret=$client_secret" \
+		-d "refresh_token=$refresh_token" \
+		-d "grant_type=refresh_token")
+
+	local access_token
+	access_token=$(echo "$response" | jq -r '.access_token // empty')
+
+	if [[ -z "$access_token" ]]; then
+		print_error "$ERROR_TOKEN_EXCHANGE_FAILED"
+		print_error "Response: $response"
+		return 1
+	fi
+
+	echo "$access_token"
+	return 0
+}
+
+# ------------------------------------------------------------------------------
+# STATUS COMMAND
+# ------------------------------------------------------------------------------
+
+cmd_status() {
+	local manifest_path=""
+	local json_output=false
+
+	# Parse arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--manifest)
+			manifest_path="$2"
+			shift 2
+			;;
+		--json)
+			json_output=true
+			shift
+			;;
+		*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	check_dependencies || return 1
+	load_credentials || return 1
+
+	# Exchange refresh token for access token
+	local access_token
+	access_token=$(exchange_token "$CWS_CLIENT_ID" "$CWS_CLIENT_SECRET" "$CWS_REFRESH_TOKEN") || return 1
+
+	# Fetch status
+	local status_url="${CWS_API_BASE}/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_EXTENSION_ID}:fetchStatus"
+	local response
+	response=$(curl -s -X GET "$status_url" \
+		-H "Authorization: Bearer $access_token")
+
+	if [[ -z "$response" ]]; then
+		print_error "$ERROR_STATUS_FAILED"
+		return 1
+	fi
+
+	# Extract published version
+	local published_version
+	published_version=$(echo "$response" | jq -r '.publishedItemRevisionStatus.distributionChannels[0].crxVersion // "unknown"')
+
+	local published_state
+	published_state=$(echo "$response" | jq -r '.publishedItemRevisionStatus.distributionChannels[0].state // "unknown"')
+
+	# Extract local version if manifest provided
+	local local_version="unknown"
+	if [[ -n "$manifest_path" && -f "$manifest_path" ]]; then
+		local_version=$(jq -r '.version // "unknown"' "$manifest_path")
+	fi
+
+	# Determine if up to date
+	local up_to_date=false
+	if [[ "$local_version" == "$published_version" ]]; then
+		up_to_date=true
+	fi
+
+	# Output
+	if [[ "$json_output" == true ]]; then
+		jq -n \
+			--arg item_id "$CWS_EXTENSION_ID" \
+			--arg local_version "$local_version" \
+			--arg published_version "$published_version" \
+			--arg published_state "$published_state" \
+			--argjson up_to_date "$up_to_date" \
+			'{
+                itemId: $item_id,
+                localVersion: $local_version,
+                publishedVersion: $published_version,
+                publishedState: $published_state,
+                upToDate: $up_to_date
+            }'
+	else
+		print_info "Chrome Web Store Status"
+		print_info "======================="
+		echo "Extension ID: $CWS_EXTENSION_ID"
+		echo "Local Version: $local_version"
+		echo "Published Version: $published_version"
+		echo "Published State: $published_state"
+		echo "Up to Date: $up_to_date"
+	fi
+
+	return 0
+}
+
+# ------------------------------------------------------------------------------
+# PUBLISH COMMAND
+# ------------------------------------------------------------------------------
+
+cmd_publish() {
+	local manifest_path=""
+	local build_cmd=""
+	local zip_cmd=""
+	local output_path=""
+	local dry_run=false
+
+	# Parse arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--manifest)
+			manifest_path="$2"
+			shift 2
+			;;
+		--build)
+			build_cmd="$2"
+			shift 2
+			;;
+		--zip)
+			zip_cmd="$2"
+			shift 2
+			;;
+		--output)
+			output_path="$2"
+			shift 2
+			;;
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$manifest_path" ]]; then
+		print_error "$ERROR_MANIFEST_REQUIRED"
+		return 1
+	fi
+
+	if [[ ! -f "$manifest_path" ]]; then
+		print_error "$ERROR_MANIFEST_NOT_FOUND: $manifest_path"
+		return 1
+	fi
+
+	check_dependencies || return 1
+	load_credentials || return 1
+
+	# Read local version
+	local local_version
+	local_version=$(jq -r '.version // empty' "$manifest_path")
+
+	if [[ -z "$local_version" ]]; then
+		print_error "Failed to read version from manifest"
+		return 1
+	fi
+
+	print_info "Local version: $local_version"
+
+	# Exchange refresh token for access token
+	local access_token
+	access_token=$(exchange_token "$CWS_CLIENT_ID" "$CWS_CLIENT_SECRET" "$CWS_REFRESH_TOKEN") || return 1
+
+	# Fetch current published version
+	local status_url="${CWS_API_BASE}/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_EXTENSION_ID}:fetchStatus"
+	local response
+	response=$(curl -s -X GET "$status_url" \
+		-H "Authorization: Bearer $access_token")
+
+	local published_version
+	published_version=$(echo "$response" | jq -r '.publishedItemRevisionStatus.distributionChannels[0].crxVersion // "unknown"')
+
+	print_info "Published version: $published_version"
+
+	# Compare versions
+	if [[ "$local_version" == "$published_version" ]]; then
+		print_info "Local version matches published version. Skipping publish (no-op)."
+		return 0
+	fi
+
+	print_info "Version changed. Proceeding with publish..."
+
+	if [[ "$dry_run" == true ]]; then
+		print_info "[DRY RUN] Would publish version $local_version"
+		return 0
+	fi
+
+	# Build extension if build command provided
+	if [[ -n "$build_cmd" ]]; then
+		print_info "Running build command: $build_cmd"
+		if ! eval "$build_cmd"; then
+			print_error "$ERROR_BUILD_FAILED"
+			return 1
+		fi
+	fi
+
+	# Zip extension
+	local zip_file="${output_path:-extension.zip}"
+
+	if [[ -n "$zip_cmd" ]]; then
+		print_info "Running zip command: $zip_cmd"
+		if ! eval "$zip_cmd"; then
+			print_error "$ERROR_ZIP_FAILED"
+			return 1
+		fi
+	else
+		# Default zip command (assumes dist/ directory)
+		local manifest_dir
+		manifest_dir=$(dirname "$manifest_path")
+		print_info "Creating zip from $manifest_dir"
+		if ! (cd "$manifest_dir" && zip -r "$zip_file" .); then
+			print_error "$ERROR_ZIP_FAILED"
+			return 1
+		fi
+	fi
+
+	if [[ ! -f "$zip_file" ]]; then
+		print_error "Zip file not found: $zip_file"
+		return 1
+	fi
+
+	print_info "Uploading extension..."
+
+	# Upload extension
+	local upload_url="${CWS_API_BASE}/upload/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_EXTENSION_ID}:upload"
+	local upload_response
+	upload_response=$(curl -s -X POST "$upload_url" \
+		-H "Authorization: Bearer $access_token" \
+		-H "Content-Type: application/zip" \
+		--data-binary "@$zip_file")
+
+	local upload_state
+	upload_state=$(echo "$upload_response" | jq -r '.uploadState // empty')
+
+	if [[ "$upload_state" != "SUCCESS" ]]; then
+		print_error "$ERROR_UPLOAD_FAILED"
+		print_error "Response: $upload_response"
+		return 1
+	fi
+
+	print_success "$SUCCESS_UPLOAD_COMPLETE"
+
+	# Publish extension
+	print_info "Publishing extension..."
+
+	local publish_url="${CWS_API_BASE}/v2/publishers/${CWS_PUBLISHER_ID}/items/${CWS_EXTENSION_ID}:publish"
+	local publish_response
+	publish_response=$(curl -s -X POST "$publish_url" \
+		-H "Authorization: Bearer $access_token")
+
+	local publish_state
+	publish_state=$(echo "$publish_response" | jq -r '.status // empty')
+
+	# Successful states
+	case "$publish_state" in
+	PENDING_REVIEW | PUBLISHED | PUBLISHED_TO_TESTERS | STAGED)
+		print_success "$SUCCESS_PUBLISH_COMPLETE"
+		print_info "Status: $publish_state"
+		return 0
+		;;
+	*)
+		print_error "$ERROR_PUBLISH_FAILED"
+		print_error "Response: $publish_response"
+		return 1
+		;;
+	esac
+}
+
+# ------------------------------------------------------------------------------
+# UPLOAD SECRETS COMMAND
+# ------------------------------------------------------------------------------
+
+cmd_upload_secrets() {
+	local dry_run=false
+	local repo=""
+
+	# Parse arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		--repo)
+			repo="$2"
+			shift 2
+			;;
+		*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	# Check gh CLI
+	if ! command -v gh &>/dev/null; then
+		print_error "$ERROR_GH_NOT_INSTALLED"
+		print_info "Install GitHub CLI: https://cli.github.com/"
+		return 1
+	fi
+
+	if ! gh auth status &>/dev/null; then
+		print_error "$ERROR_GH_NOT_AUTHENTICATED"
+		print_info "Authenticate with: gh auth login"
+		return 1
+	fi
+
+	load_credentials || return 1
+
+	# Determine repo
+	if [[ -z "$repo" ]]; then
+		repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+		if [[ -z "$repo" ]]; then
+			print_error "Failed to determine repository. Use --repo owner/repo"
+			return 1
+		fi
+	fi
+
+	print_info "Uploading secrets to repository: $repo"
+
+	if [[ "$dry_run" == true ]]; then
+		print_info "[DRY RUN] Would upload the following secrets:"
+		for key in "${REQUIRED_CREDENTIALS[@]}"; do
+			print_info "  $key: ***MASKED***"
+		done
+		return 0
+	fi
+
+	# Upload secrets
+	for key in "${REQUIRED_CREDENTIALS[@]}"; do
+		local value="${!key}"
+		print_info "Uploading $key..."
+		if ! echo "$value" | gh secret set "$key" --repo "$repo"; then
+			print_error "Failed to upload $key"
+			return 1
+		fi
+	done
+
+	print_success "$SUCCESS_SECRETS_UPLOADED"
+	return 0
+}
+
+# ------------------------------------------------------------------------------
+# HELP COMMAND
+# ------------------------------------------------------------------------------
+
+cmd_help() {
+	cat <<EOF
+Chrome Web Store Helper Script
+
+Usage: chrome-webstore-helper.sh [command] [options]
+
+Commands:
+  setup              Interactive credential setup wizard
+  publish            Build, zip, upload, and publish extension
+  status             Fetch submission status
+  upload-secrets     Upload secrets to GitHub via gh CLI
+  help               Show this help message
+
+Options (publish):
+  --manifest PATH    Path to manifest.json (required)
+  --build CMD        Build command to run before packaging
+  --zip CMD          Zip command to create package
+  --output PATH      Output path for zip file (default: extension.zip)
+  --dry-run          Preview actions without executing
+
+Options (status):
+  --manifest PATH    Path to manifest.json for version comparison
+  --json             Output in JSON format
+
+Options (upload-secrets):
+  --repo OWNER/REPO  Target repository (default: current repo)
+  --dry-run          Preview actions without uploading
+
+Examples:
+  # Interactive setup
+  chrome-webstore-helper.sh setup
+
+  # Publish extension
+  chrome-webstore-helper.sh publish --manifest src/manifest.json --build "npm run build"
+
+  # Check status
+  chrome-webstore-helper.sh status --manifest src/manifest.json
+
+  # Upload secrets to GitHub
+  chrome-webstore-helper.sh upload-secrets --repo owner/repo
+
+Environment Variables:
+  CWS_CLIENT_ID       OAuth client ID
+  CWS_CLIENT_SECRET   OAuth client secret
+  CWS_REFRESH_TOKEN   OAuth refresh token
+  CWS_PUBLISHER_ID    Chrome Web Store publisher ID
+  CWS_EXTENSION_ID    Chrome Web Store extension ID
+
+Credentials can be stored via:
+  - aidevops secret storage (encrypted, recommended)
+  - .env file (plaintext, ensure gitignored)
+
+For more information, see:
+  .agents/tools/browser/chrome-webstore-release.md
+EOF
+	return 0
+}
+
+# ------------------------------------------------------------------------------
+# MAIN COMMAND DISPATCHER
+# ------------------------------------------------------------------------------
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	setup)
+		cmd_setup "$@"
+		;;
+	publish)
+		cmd_publish "$@"
+		;;
+	status)
+		cmd_status "$@"
+		;;
+	upload-secrets)
+		cmd_upload_secrets "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+# Run main if executed directly
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -32,7 +32,7 @@ tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-r
 tools/build-mcp/,MCP development - creating MCP servers and plugins,build-mcp|server-patterns|api-wrapper|transports|deployment|aidevops-plugin
 tools/ai-assistants/,AI tool integration - OpenCode headless dispatch model comparison and response scoring,agno|capsolver|claude-code|compare-models|response-scoring|overview|openclaw|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
-tools/browser/,Browser automation - scraping and testing,agent-browser|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy
+tools/browser/,Browser automation - scraping and testing,agent-browser|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy|chrome-webstore-release
 tools/mobile/,Mobile development - iOS/macOS build test simulator and emulator automation,agent-device|xcodebuild-mcp|ios-simulator-mcp|maestro|axe-cli|minisim
 tools/pdf/,PDF processing - form filling and digital signatures,overview|libpdf
 tools/accessibility/,Accessibility and contrast testing - WCAG compliance for websites and emails,accessibility
@@ -97,6 +97,7 @@ verify-run-helper.sh,Execute verification checks with proof logging to verify-pr
 linters-local.sh,Run local linting (shfmt ShellCheck secretlint patterns)
 rosetta-audit-helper.sh,Detect and migrate x86 Homebrew packages on Apple Silicon
 code-audit-helper.sh,Run remote auditing (CodeRabbit Codacy SonarCloud)
+chrome-webstore-helper.sh,Chrome Web Store release automation (setup publish status upload-secrets)
 version-manager.sh,Version bumps and releases
 linter-manager.sh,Install and manage linters
 github-cli-helper.sh,GitHub operations

--- a/.agents/tools/browser/chrome-webstore-release.md
+++ b/.agents/tools/browser/chrome-webstore-release.md
@@ -1,0 +1,453 @@
+---
+name: chrome-webstore-release
+description: Chrome Web Store release automation - OAuth setup, API publish workflow, version-triggered CI, status checking
+model: sonnet
+tools: [bash, read, write]
+---
+
+# Chrome Web Store Release Automation
+
+This subagent guides you through setting up Chrome Web Store (CWS) release automation for Chrome extensions. It covers OAuth credential setup, API-based publishing, version-triggered CI workflows, and submission status checking.
+
+## When to Use
+
+- Setting up automated Chrome extension releases from scratch
+- Implementing version-triggered publish workflows to avoid accidental publishes
+- Configuring OAuth and refresh token for CWS API access
+- Creating status-checker scripts to verify PUBLISHED/PENDING_REVIEW states
+- Wiring secrets into local environment and CI (with optional `gh` automation)
+
+## Quick Start
+
+```bash
+# Interactive credential setup
+chrome-webstore-helper.sh setup
+
+# Publish extension (build + zip + upload + publish)
+chrome-webstore-helper.sh publish --manifest path/to/manifest.json
+
+# Check submission status
+chrome-webstore-helper.sh status
+
+# Upload secrets to GitHub (requires gh CLI)
+chrome-webstore-helper.sh upload-secrets
+```
+
+## Prerequisites
+
+- Chrome extension with `manifest.json`
+- Google Cloud project with Chrome Web Store API enabled
+- Publisher account on Chrome Web Store Developer Dashboard
+- `gh` CLI (optional, for automated secret upload)
+- `jq` for JSON parsing
+
+## Step 1: Project Discovery
+
+Before credential setup, collect these inputs:
+
+- **Manifest path**: Location of `manifest.json` containing extension version
+- **Build command**: Command to build the extension (e.g., `npm run build`)
+- **Zip command**: Command to package extension (e.g., `zip -r extension.zip dist/`)
+- **Output path**: Path to packaged zip file
+- **CI platform**: GitHub Actions (default), GitLab CI, etc.
+- **Release policy**: Publish on version change, tags, or manual dispatch
+- **Secret storage**: `.env`, `.env.local`, or other convention
+
+Ask the user:
+
+- "Do you want CI to publish only when version changes?" (recommended: yes)
+- "Do you want me to wire GitHub secret upload via `gh`?" (if GitHub Actions)
+
+## Step 2: Credential Walkthrough
+
+### 2.1 Enable Chrome Web Store API
+
+**User action** (manual):
+
+1. Open: `https://console.cloud.google.com/apis/library/chromewebstore.googleapis.com`
+2. Select your Google Cloud project
+3. Click **Enable** for Chrome Web Store API
+
+**Agent prompt**: "When Chrome Web Store API shows as Enabled, confirm and I will move to OAuth setup."
+
+### 2.2 Configure OAuth Consent Screen
+
+**User action** (manual):
+
+1. Open: `https://console.cloud.google.com/apis/credentials/consent`
+2. Choose **External** user type (for non-Workspace apps)
+3. Fill in:
+   - App name
+   - Support email
+   - Developer contact email
+4. Save and continue through scopes (no custom scopes needed)
+5. Add your Google account as a test user if app is in Testing mode
+6. Save
+
+**Agent guidance**: If user wants stable long-lived refresh token behavior, recommend moving consent screen to Production when ready.
+
+### 2.3 Create OAuth Client
+
+**User action** (manual):
+
+1. Open: `https://console.cloud.google.com/apis/credentials`
+2. Click **Create Credentials** → **OAuth client ID**
+3. Choose application type: **Web application**
+4. Add authorized redirect URI exactly:
+   - `https://developers.google.com/oauthplayground`
+5. Create client
+
+**Capture values**:
+
+- `CWS_CLIENT_ID`
+- `CWS_CLIENT_SECRET`
+
+**Agent prompt**: "Paste `CWS_CLIENT_ID` and `CWS_CLIENT_SECRET` when ready (I will treat them as secrets)."
+
+### 2.4 Generate Refresh Token (OAuth Playground)
+
+**User action** (manual):
+
+1. Open: `https://developers.google.com/oauthplayground/`
+2. Click the settings gear icon
+3. Enable **Use your own OAuth credentials**
+4. Paste `CWS_CLIENT_ID` and `CWS_CLIENT_SECRET`
+5. In Step 1, enter scope:
+   - `https://www.googleapis.com/auth/chromewebstore`
+6. Click **Authorize APIs**
+7. Sign in with the Google account that owns/publishes the extension
+8. Click **Exchange authorization code for tokens**
+9. Copy refresh token
+
+**Capture value**:
+
+- `CWS_REFRESH_TOKEN`
+
+**Agent prompt**: "Paste `CWS_REFRESH_TOKEN` now. I will only place it in local secret storage/CI secrets."
+
+### 2.5 Capture Store IDs
+
+**User action** (manual):
+
+1. Open Chrome Web Store Developer Dashboard
+2. Copy extension item ID from URL or item details
+3. Copy publisher ID from account details or URL
+
+**Capture values**:
+
+- `CWS_EXTENSION_ID` (extension item ID from store listing URL)
+- `CWS_PUBLISHER_ID` (developer/publisher ID from account)
+
+**Agent instruction**: If user is unsure, ask them to open the Chrome Web Store Developer Dashboard and copy IDs from item/account URLs or account details.
+
+### 2.6 Credential Checklist
+
+Do not proceed until all five exist:
+
+- `CWS_CLIENT_ID`
+- `CWS_CLIENT_SECRET`
+- `CWS_REFRESH_TOKEN`
+- `CWS_PUBLISHER_ID`
+- `CWS_EXTENSION_ID`
+
+## Step 3: Local Secret File and CI Secret Setup
+
+### Local Secret Template
+
+Create a local template file (no real values committed):
+
+```env
+CWS_CLIENT_ID=
+CWS_CLIENT_SECRET=
+CWS_REFRESH_TOKEN=
+CWS_PUBLISHER_ID=
+CWS_EXTENSION_ID=
+```
+
+Ensure real secret file path is gitignored (e.g., `.env`, `.env.local`).
+
+### Recommended: aidevops Secret Storage
+
+For encrypted secret storage:
+
+```bash
+aidevops secret set CWS_CLIENT_ID
+aidevops secret set CWS_CLIENT_SECRET
+aidevops secret set CWS_REFRESH_TOKEN
+aidevops secret set CWS_PUBLISHER_ID
+aidevops secret set CWS_EXTENSION_ID
+```
+
+Secrets are stored in gopass (GPG-encrypted) or `~/.config/aidevops/credentials.sh` (plaintext fallback, 600 permissions).
+
+### GitHub Actions Secret Upload
+
+If using GitHub Actions, ask user if `gh` automation is desired.
+
+**Verify `gh` CLI**:
+
+```bash
+gh --version
+gh auth status
+```
+
+If `gh` auth is missing, tell user to run: `gh auth login`
+
+**Upload secrets**:
+
+```bash
+chrome-webstore-helper.sh upload-secrets
+```
+
+This command:
+
+- Reads secret values from local env file or aidevops secret storage
+- Validates all required keys are present
+- Supports `--dry-run` to preview without uploading
+- Masks values in dry-run output
+- Uploads with `gh secret set ... --repo ...`
+- Fails fast on missing keys/auth
+
+**Manual fallback**: If user declines `gh`, provide manual secret entry checklist for repository settings.
+
+## Step 4: Release Workflow Blueprint (Version-Triggered)
+
+Design the CI workflow around this logic:
+
+1. **Read local manifest version** from `manifest.json`
+2. **Optionally compare** with a secondary version file and fail on mismatch
+3. **Exchange refresh token for access token**:
+   - `POST https://oauth2.googleapis.com/token`
+4. **Fetch CWS status**:
+   - `GET https://chromewebstore.googleapis.com/v2/publishers/<publisherId>/items/<extensionId>:fetchStatus`
+5. **Extract current published version** from:
+   - `publishedItemRevisionStatus.distributionChannels[0].crxVersion`
+6. **If local version == published version**, skip publish (no-op)
+7. **If version changed**:
+   - Build package zip
+   - Upload zip:
+     - `POST https://chromewebstore.googleapis.com/upload/v2/publishers/<publisherId>/items/<extensionId>:upload`
+   - Handle async upload state with polling when needed
+   - Publish:
+     - `POST https://chromewebstore.googleapis.com/v2/publishers/<publisherId>/items/<extensionId>:publish`
+
+**Successful submission states**:
+
+- `PENDING_REVIEW`
+- `PUBLISHED`
+- `PUBLISHED_TO_TESTERS`
+- `STAGED`
+
+### Example GitHub Actions Workflow
+
+```yaml
+name: Chrome Web Store Release
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build extension
+        run: npm run build
+
+      - name: Publish to Chrome Web Store
+        env:
+          CWS_CLIENT_ID: ${{ secrets.CWS_CLIENT_ID }}
+          CWS_CLIENT_SECRET: ${{ secrets.CWS_CLIENT_SECRET }}
+          CWS_REFRESH_TOKEN: ${{ secrets.CWS_REFRESH_TOKEN }}
+          CWS_PUBLISHER_ID: ${{ secrets.CWS_PUBLISHER_ID }}
+          CWS_EXTENSION_ID: ${{ secrets.CWS_EXTENSION_ID }}
+        run: |
+          chrome-webstore-helper.sh publish --manifest src/manifest.json
+```
+
+## Step 5: Submission Status Checker
+
+Create a script dedicated to "what is the latest submission state?".
+
+**Required behavior**:
+
+- Accepts env values (and optional `--env-file`)
+- Optionally accepts `--manifest` for local version comparison
+- Supports `--json` for machine-readable output
+- Calls token endpoint + `fetchStatus`
+- Outputs normalized fields:
+  - `itemId`
+  - `localVersion`
+  - `publishedVersion`
+  - `publishedState`
+  - `submittedVersion`
+  - `submittedState`
+  - `upToDate`
+  - `pendingReview`
+- Exits non-zero on auth/API/input errors
+
+**Helpful checks to include**:
+
+- Flag version mismatch between manifest and package metadata
+- Show whether uploaded version is pending review but not yet published
+- Print concise human summary when `--json` is not used
+
+**Example usage**:
+
+```bash
+# Check status with local manifest comparison
+chrome-webstore-helper.sh status --manifest src/manifest.json
+
+# JSON output for CI
+chrome-webstore-helper.sh status --json
+```
+
+## Step 6: Guided Verification Flow
+
+Run this with the user:
+
+1. **Confirm status checker runs successfully** before release
+2. **Bump extension version** (patch) in all version sources
+3. **Push branch and trigger workflow**
+4. **Confirm workflow** either:
+   - Skips (if no version change), or
+   - Uploads and submits publish
+5. **Re-run status checker**:
+   - Expect `PENDING_REVIEW` first in many cases
+   - Later expect published channel to match local version
+
+## Troubleshooting
+
+### `invalid_grant` Error
+
+**Cause**: Wrong/expired refresh token, wrong OAuth client, or wrong account
+
+**Fix**:
+
+- Regenerate refresh token via OAuth Playground
+- Verify OAuth client ID and secret match
+- Ensure refresh token was generated with the correct Google account
+
+### `403` from CWS Endpoint
+
+**Cause**: Account lacks publisher permissions for that extension
+
+**Fix**:
+
+- Verify publisher ID matches the account that owns the extension
+- Check that the Google account has publisher access in Chrome Web Store Developer Dashboard
+
+### Workflow No-Op
+
+**Cause**: Local version equals published version by design
+
+**Fix**: This is expected behavior. Bump version in `manifest.json` to trigger publish.
+
+### Upload Failure
+
+**Cause**: Invalid zip structure or manifest
+
+**Fix**:
+
+- Inspect API response for specific error
+- Verify packaged zip structure matches Chrome extension requirements
+- Validate `manifest.json` syntax and required fields
+
+### Version Mismatch Guard Failure
+
+**Cause**: Multiple version files out of sync
+
+**Fix**: Align all declared version files (e.g., `manifest.json`, `package.json`) before publishing.
+
+## API Reference
+
+### Token Exchange
+
+```bash
+curl -X POST https://oauth2.googleapis.com/token \
+  -d "client_id=$CWS_CLIENT_ID" \
+  -d "client_secret=$CWS_CLIENT_SECRET" \
+  -d "refresh_token=$CWS_REFRESH_TOKEN" \
+  -d "grant_type=refresh_token"
+```
+
+### Fetch Status
+
+```bash
+curl -X GET \
+  "https://chromewebstore.googleapis.com/v2/publishers/$CWS_PUBLISHER_ID/items/$CWS_EXTENSION_ID:fetchStatus" \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+### Upload Extension
+
+```bash
+curl -X POST \
+  "https://chromewebstore.googleapis.com/upload/v2/publishers/$CWS_PUBLISHER_ID/items/$CWS_EXTENSION_ID:upload" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/zip" \
+  --data-binary @extension.zip
+```
+
+### Publish Extension
+
+```bash
+curl -X POST \
+  "https://chromewebstore.googleapis.com/v2/publishers/$CWS_PUBLISHER_ID/items/$CWS_EXTENSION_ID:publish" \
+  -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+## Useful Links
+
+- Chrome Web Store API overview: `https://developer.chrome.com/docs/webstore/using-api`
+- Publish endpoint: `https://developer.chrome.com/docs/webstore/publish`
+- OAuth Playground: `https://developers.google.com/oauthplayground/`
+- API enablement: `https://console.cloud.google.com/apis/library/chromewebstore.googleapis.com`
+- Credentials page: `https://console.cloud.google.com/apis/credentials`
+
+## Security Guardrails
+
+- **Never commit credentials** to git
+- **Never hardcode secrets** in workflow YAML
+- **Never auto-publish every push** without version comparison
+- **Keep setup instructions explicit** and user-confirmed at each manual step
+- **Prefer repeatable helper scripts** over ad-hoc one-off commands
+- **Use aidevops secret storage** for encrypted credential management
+
+## Helper Script Reference
+
+See `chrome-webstore-helper.sh` for implementation:
+
+- `setup` - Interactive credential walkthrough
+- `publish` - Build + zip + upload + publish via CWS API
+- `status` - Fetch submission state
+- `upload-secrets` - Upload secrets to GitHub via `gh` CLI
+
+## Integration with aidevops
+
+This subagent integrates with the aidevops framework:
+
+- **Secret storage**: `aidevops secret set CWS_*` for encrypted credentials
+- **CI integration**: GitHub Actions workflow templates
+- **Helper script**: `chrome-webstore-helper.sh` in `.agents/scripts/`
+- **Subagent index**: Entry in `subagent-index.toon` under `tools/browser/`
+
+## Best Practices
+
+1. **Version comparison**: Always compare local vs published version to avoid no-op publishes
+2. **Dry-run first**: Test with `--dry-run` before actual publish
+3. **Status checking**: Verify status before and after publish
+4. **Secret masking**: Never log secret values in CI output
+5. **Fail fast**: Exit early on missing credentials or API errors
+6. **Idempotent**: Design workflows to be safely re-runnable


### PR DESCRIPTION
## Summary

- Adapted the Playbooks chrome-webstore-release-blueprint skill into aidevops agent/skill architecture
- Created `.agents/tools/browser/chrome-webstore-release.md` subagent covering OAuth setup walkthrough, CWS API publish workflow, version-triggered CI, status checker, and secret management
- Created `chrome-webstore-helper.sh` with commands: `setup`, `publish`, `status`, `upload-secrets`
- Added subagent-index entry for chrome-webstore-release
- Wired secrets via `aidevops secret set CWS_*`
- Adapted the 6-step guided flow to interactive session style

## Changes

- `.agents/tools/browser/chrome-webstore-release.md` - Comprehensive subagent documentation
- `.agents/scripts/chrome-webstore-helper.sh` - Helper script with all required commands
- `.agents/subagent-index.toon` - Added chrome-webstore-release to browser tools and scripts

## Testing

- ShellCheck passes with zero violations
- Bash syntax validation passes
- Help command verified working

Ref #1499