### PR TITLE
feat: add status:needs-testing label for issue-sync

### DIFF
--- a/.agents/scripts/supervisor/issue-sync.sh
+++ b/.agents/scripts/supervisor/issue-sync.sh
@@ -6,7 +6,7 @@
 
 #######################################
 # Ensure status labels exist in the repo (t164)
-# Creates status:available, status:claimed, status:in-review, status:done
+# Creates status:available, status:claimed, status:in-review, status:needs-testing, status:done
 # if they don't already exist. Idempotent — safe to call repeatedly.
 # $1: repo_slug (e.g. "owner/repo")
 #######################################
@@ -24,6 +24,7 @@ ensure_status_labels() {
 	gh label create "status:in-review" --repo "$repo_slug" --color "FBCA04" --description "Task PR is in review" --force 2>/dev/null || true
 	gh label create "status:blocked" --repo "$repo_slug" --color "B60205" --description "Task is blocked" --force 2>/dev/null || true
 	gh label create "status:verify-failed" --repo "$repo_slug" --color "E4E669" --description "Task verification failed" --force 2>/dev/null || true
+	gh label create "status:needs-testing" --repo "$repo_slug" --color "FBCA04" --description "Code merged, needs manual or integration testing" --force 2>/dev/null || true
 	gh label create "status:done" --repo "$repo_slug" --color "6F42C1" --description "Task is complete" --force 2>/dev/null || true
 	return 0
 }
@@ -340,7 +341,7 @@ state_to_status_label() {
 # Used to remove stale labels before applying the new one.
 # Restored from pre-modularisation supervisor-helper.sh (t1035).
 #######################################
-ALL_STATUS_LABELS="status:available,status:queued,status:claimed,status:in-review,status:blocked,status:verify-failed,status:done"
+ALL_STATUS_LABELS="status:available,status:queued,status:claimed,status:in-review,status:blocked,status:verify-failed,status:needs-testing,status:done"
 
 #######################################
 # Sync GitHub issue status label on state transition (t1009)


### PR DESCRIPTION
## Summary

- Adds `status:needs-testing` label for tasks where code is merged but needs manual/integration testing against real infrastructure
- Label is created by `ensure_status_labels()` and preserved in `ALL_STATUS_LABELS` during reconciliation
- Applied manually (not auto-assigned by state machine) since it's a human workflow signal

## Use case

Tasks like t1056 (Matrix+Cloudron auto-setup) have all subtasks merged but need end-to-end testing against a live Cloudron server. Without this label they'd either sit as generic "open" issues or get auto-closed by issue-sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "needs-testing" status label to the repository's issue tracking system. This status is fully integrated into the standard workflow and managed alongside existing status labels during state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->