### PR TITLE
t1056: Fix Intel brew shellenv breaking Homebrew on Apple Silicon

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -367,6 +367,7 @@ check_requirements() {
 			# Only modify rc files during interactive setup (not updates)
 			if [[ "$NON_INTERACTIVE" != "true" ]]; then
 				local intel_brew_line='eval "$(/usr/local/bin/brew shellenv)"'
+				local intel_fixed_rc=false
 				local intel_rc
 				while IFS= read -r intel_rc; do
 					[[ -z "$intel_rc" ]] && continue
@@ -375,8 +376,16 @@ check_requirements() {
 						echo "# Homebrew Intel Mac (added by aidevops setup)" >>"$intel_rc"
 						echo "$intel_brew_line" >>"$intel_rc"
 						print_success "Added Homebrew to PATH in $intel_rc"
+						intel_fixed_rc=true
 					fi
 				done < <(get_all_shell_rcs)
+
+				if [[ "$intel_fixed_rc" == "false" ]]; then
+					echo ""
+					echo "  To fix permanently, add to your shell rc file:"
+					echo "    $intel_brew_line"
+					echo ""
+				fi
 			fi
 		fi
 	fi


### PR DESCRIPTION
## Summary

- **Skip Intel brew entirely on Apple Silicon**: When ARM Homebrew (`/opt/homebrew/bin/brew`) exists, the Intel brew block is skipped — no `eval`, no rc file writes. This prevents `/usr/local/bin` from being prepended to PATH and shadowing ARM binaries.
- **Skip rc file writes during non-interactive updates**: Both ARM and Intel brew blocks now only modify shell rc files during interactive `setup.sh` runs, not during `aidevops update` (`--non-interactive`). Users who intentionally remove these lines won't have them re-added on every update.
- **Preserve session-level eval for Intel-only Macs**: On genuine Intel Macs (no ARM brew), the ephemeral `eval` and interactive rc writes still work as before.

## Root Cause

`check_requirements()` in `setup-modules/core.sh` detected `/usr/local/bin/brew` (Intel Homebrew via Rosetta) on Apple Silicon Macs and unconditionally appended `eval "$(/usr/local/bin/brew shellenv)"` to all shell rc files on every `aidevops update`. This prepended `/usr/local/bin` to PATH, causing x86 binaries to shadow the correct ARM ones from `/opt/homebrew/bin`.

Closes #1510
Refs: GH#1511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer will no longer modify shell configuration files during non-interactive installs and now only updates them in interactive sessions.
  * Homebrew detection improved to prefer Apple Silicon brew when present and avoid inappropriate Intel-path changes.

* **Documentation**
  * Clearer on-screen guidance and notices about when RC files were updated or when manual action is needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->