### PR TITLE
t1057, t1058: Fix wp-helper.sh SSH stdin consumption and Cloudways template path

### DIFF
--- a/.agents/configs/wordpress-sites.json.txt
+++ b/.agents/configs/wordpress-sites.json.txt
@@ -41,7 +41,7 @@
       "ssh_host": "cloudways.example.com",
       "ssh_port": 22,
       "ssh_user": "master_user",
-      "wp_path": "/home/master_user/applications/app_name/public_html",
+      "wp_path": "/home/master/applications/app_name/public_html",
       "mainwp_connected": true,
       "mainwp_site_id": 456,
       "category": "lead-gen"
@@ -64,7 +64,7 @@
     "localwp": "Local by Flywheel - no SSH, direct path access",
     "hostinger": "Hostinger - sshpass with password file, custom port 65002",
     "hetzner": "Hetzner VPS - SSH key auth",
-    "cloudways": "Cloudways - SSH key auth, master_user pattern",
+    "cloudways": "Cloudways - SSH key auth, home dir is always /home/master/ regardless of ssh_user",
     "closte": "Closte - sshpass with password file",
     "cloudron": "Cloudron - SSH key auth or Cloudron CLI"
   },

--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -24,292 +24,292 @@ TEMPLATE_FILE="${HOME}/.aidevops/agents/configs/wordpress-sites.json.txt"
 
 # Check dependencies
 check_dependencies() {
-    if ! command -v jq &> /dev/null; then
-        print_error "$ERROR_JQ_REQUIRED"
-        echo "$INFO_JQ_INSTALL_MACOS"
-        echo "$INFO_JQ_INSTALL_UBUNTU"
-        exit 1
-    fi
-    
-    if ! command -v ssh &> /dev/null; then
-        print_error "ssh is required but not installed"
-        exit 1
-    fi
-    return 0
+	if ! command -v jq &>/dev/null; then
+		print_error "$ERROR_JQ_REQUIRED"
+		echo "$INFO_JQ_INSTALL_MACOS"
+		echo "$INFO_JQ_INSTALL_UBUNTU"
+		exit 1
+	fi
+
+	if ! command -v ssh &>/dev/null; then
+		print_error "ssh is required but not installed"
+		exit 1
+	fi
+	return 0
 }
 
 # Check sshpass for password-based SSH (called only when needed)
 check_sshpass() {
-    if ! command -v sshpass &> /dev/null; then
-        print_error "sshpass is required for Hostinger/Closte sites but not installed"
-        print_info "Install with: brew install hudochenkov/sshpass/sshpass (macOS)"
-        print_info "Install with: apt-get install sshpass (Ubuntu)"
-        exit 1
-    fi
-    return 0
+	if ! command -v sshpass &>/dev/null; then
+		print_error "sshpass is required for Hostinger/Closte sites but not installed"
+		print_info "Install with: brew install hudochenkov/sshpass/sshpass (macOS)"
+		print_info "Install with: apt-get install sshpass (Ubuntu)"
+		exit 1
+	fi
+	return 0
 }
 
 # Load configuration
 load_config() {
-    if [[ ! -f "$CONFIG_FILE" ]]; then
-        print_error "$ERROR_CONFIG_NOT_FOUND: $CONFIG_FILE"
-        print_info "Copy and customize the template:"
-        print_info "  mkdir -p ~/.config/aidevops"
-        print_info "  cp $TEMPLATE_FILE $CONFIG_FILE"
-        exit 1
-    fi
-    return 0
+	if [[ ! -f "$CONFIG_FILE" ]]; then
+		print_error "$ERROR_CONFIG_NOT_FOUND: $CONFIG_FILE"
+		print_info "Copy and customize the template:"
+		print_info "  mkdir -p ~/.config/aidevops"
+		print_info "  cp $TEMPLATE_FILE $CONFIG_FILE"
+		exit 1
+	fi
+	return 0
 }
 
 # Get site configuration
 get_site_config() {
-    local site_key="$1"
-    
-    load_config
-    
-    local site_config
-    site_config=$(jq -r --arg key "$site_key" '.sites[$key]' "$CONFIG_FILE")
-    if [[ "$site_config" == "null" ]]; then
-        print_error "$ERROR_SITE_NOT_FOUND: $site_key"
-        list_sites
-        exit 1
-    fi
-    
-    echo "$site_config"
-    return 0
+	local site_key="$1"
+
+	load_config
+
+	local site_config
+	site_config=$(jq -r --arg key "$site_key" '.sites[$key]' "$CONFIG_FILE")
+	if [[ "$site_config" == "null" ]]; then
+		print_error "$ERROR_SITE_NOT_FOUND: $site_key"
+		list_sites
+		exit 1
+	fi
+
+	echo "$site_config"
+	return 0
 }
 
 # List all configured sites
 list_sites() {
-    load_config
-    print_info "Configured WordPress sites:"
-    echo ""
-    jq -r '.sites | to_entries[] | "\(.key)|\(.value.name)|\(.value.type)|\(.value.url // .value.path)|\(.value.category // "uncategorized")"' "$CONFIG_FILE" | \
-    while IFS='|' read -r key name type url category; do
-        printf "  %-20s %-25s %-12s %-40s [%s]\n" "$key" "$name" "$type" "$url" "$category"
-    done
-    return 0
+	load_config
+	print_info "Configured WordPress sites:"
+	echo ""
+	jq -r '.sites | to_entries[] | "\(.key)|\(.value.name)|\(.value.type)|\(.value.url // .value.path)|\(.value.category // "uncategorized")"' "$CONFIG_FILE" |
+		while IFS='|' read -r key name type url category; do
+			printf "  %-20s %-25s %-12s %-40s [%s]\n" "$key" "$name" "$type" "$url" "$category"
+		done
+	return 0
 }
 
 # List sites by category
 list_sites_by_category() {
-    local category="$1"
-    
-    load_config
-    print_info "Sites in category: $category"
-    echo ""
-    jq -r --arg cat "$category" '.sites | to_entries[] | select(.value.category == $cat) | "\(.key)|\(.value.name)|\(.value.type)|\(.value.url // .value.path)"' "$CONFIG_FILE" | \
-    while IFS='|' read -r key name type url; do
-        printf "  %-20s %-25s %-12s %s\n" "$key" "$name" "$type" "$url"
-    done
-    return 0
+	local category="$1"
+
+	load_config
+	print_info "Sites in category: $category"
+	echo ""
+	jq -r --arg cat "$category" '.sites | to_entries[] | select(.value.category == $cat) | "\(.key)|\(.value.name)|\(.value.type)|\(.value.url // .value.path)"' "$CONFIG_FILE" |
+		while IFS='|' read -r key name type url; do
+			printf "  %-20s %-25s %-12s %s\n" "$key" "$name" "$type" "$url"
+		done
+	return 0
 }
 
 # Execute WP-CLI command via SSH based on hosting type
 # Directly executes instead of building a string for eval
 execute_wp_via_ssh() {
-    local site_config="$1"
-    local wp_command="$2"
-    
-    local site_type
-    site_type=$(echo "$site_config" | jq -r '.type')
-    local ssh_host
-    ssh_host=$(echo "$site_config" | jq -r '.ssh_host // empty')
-    local ssh_port
-    ssh_port=$(echo "$site_config" | jq -r '.ssh_port // 22')
-    local ssh_user
-    ssh_user=$(echo "$site_config" | jq -r '.ssh_user // empty')
-    local wp_path
-    wp_path=$(echo "$site_config" | jq -r '.wp_path // empty')
-    local local_path
-    local_path=$(echo "$site_config" | jq -r '.path // empty')
-    local password_file
-    password_file=$(echo "$site_config" | jq -r '.password_file // empty')
-    
-    case "$site_type" in
-        localwp)
-            # LocalWP - direct local access
-            local expanded_path="${local_path/#\~/$HOME}"
-            (cd "$expanded_path" && wp $wp_command)
-            return $?
-            ;;
-        hostinger|closte)
-            # Hostinger/Closte - sshpass with password file
-            check_sshpass
-            local expanded_password_file
-            if [[ -n "$password_file" ]]; then
-                expanded_password_file="${password_file/#\~/$HOME}"
-            else
-                if [[ "$site_type" == "hostinger" ]]; then
-                    expanded_password_file="${HOME}/.ssh/hostinger_password"
-                else
-                    expanded_password_file="${HOME}/.ssh/closte_password"
-                fi
-            fi
-            
-            if [[ ! -f "$expanded_password_file" ]]; then
-                print_error "Password file not found: $expanded_password_file"
-                print_info "Create the password file with your SSH password (chmod 600)"
-                return 1
-            fi
-            
-            # Use array for sshpass + ssh command
-            sshpass -f "$expanded_password_file" ssh -p "$ssh_port" "${ssh_user}@${ssh_host}" "cd $(printf %q "$wp_path") && wp $wp_command"
-            return $?
-            ;;
-        hetzner|cloudways|cloudron)
-            # SSH key-based authentication (preferred)
-            ssh -p "$ssh_port" "${ssh_user}@${ssh_host}" "cd $(printf %q "$wp_path") && wp $wp_command"
-            return $?
-            ;;
-        *)
-            print_error "Unknown hosting type: $site_type"
-            return 1
-            ;;
-    esac
+	local site_config="$1"
+	local wp_command="$2"
+
+	local site_type
+	site_type=$(echo "$site_config" | jq -r '.type')
+	local ssh_host
+	ssh_host=$(echo "$site_config" | jq -r '.ssh_host // empty')
+	local ssh_port
+	ssh_port=$(echo "$site_config" | jq -r '.ssh_port // 22')
+	local ssh_user
+	ssh_user=$(echo "$site_config" | jq -r '.ssh_user // empty')
+	local wp_path
+	wp_path=$(echo "$site_config" | jq -r '.wp_path // empty')
+	local local_path
+	local_path=$(echo "$site_config" | jq -r '.path // empty')
+	local password_file
+	password_file=$(echo "$site_config" | jq -r '.password_file // empty')
+
+	case "$site_type" in
+	localwp)
+		# LocalWP - direct local access
+		local expanded_path="${local_path/#\~/$HOME}"
+		(cd "$expanded_path" && wp $wp_command)
+		return $?
+		;;
+	hostinger | closte)
+		# Hostinger/Closte - sshpass with password file
+		check_sshpass
+		local expanded_password_file
+		if [[ -n "$password_file" ]]; then
+			expanded_password_file="${password_file/#\~/$HOME}"
+		else
+			if [[ "$site_type" == "hostinger" ]]; then
+				expanded_password_file="${HOME}/.ssh/hostinger_password"
+			else
+				expanded_password_file="${HOME}/.ssh/closte_password"
+			fi
+		fi
+
+		if [[ ! -f "$expanded_password_file" ]]; then
+			print_error "Password file not found: $expanded_password_file"
+			print_info "Create the password file with your SSH password (chmod 600)"
+			return 1
+		fi
+
+		# Use array for sshpass + ssh command (-n prevents stdin consumption in loops)
+		sshpass -f "$expanded_password_file" ssh -n -p "$ssh_port" "${ssh_user}@${ssh_host}" "cd $(printf %q "$wp_path") && wp $wp_command"
+		return $?
+		;;
+	hetzner | cloudways | cloudron)
+		# SSH key-based authentication (preferred, -n prevents stdin consumption in loops)
+		ssh -n -p "$ssh_port" "${ssh_user}@${ssh_host}" "cd $(printf %q "$wp_path") && wp $wp_command"
+		return $?
+		;;
+	*)
+		print_error "Unknown hosting type: $site_type"
+		return 1
+		;;
+	esac
 }
 
 # Run WP-CLI command on a site
 run_wp_command() {
-    local site_key="$1"
-    shift
-    local wp_command="$*"
-    
-    if [[ -z "$wp_command" ]]; then
-        print_error "$ERROR_COMMAND_REQUIRED"
-        exit 1
-    fi
-    
-    local site_config
-    site_config=$(get_site_config "$site_key")
-    
-    local site_name
-    site_name=$(echo "$site_config" | jq -r '.name')
-    local site_type
-    site_type=$(echo "$site_config" | jq -r '.type')
-    
-    print_info "Running on $site_name ($site_type): wp $wp_command"
-    
-    # Execute directly without eval
-    execute_wp_via_ssh "$site_config" "$wp_command"
-    return $?
+	local site_key="$1"
+	shift
+	local wp_command="$*"
+
+	if [[ -z "$wp_command" ]]; then
+		print_error "$ERROR_COMMAND_REQUIRED"
+		exit 1
+	fi
+
+	local site_config
+	site_config=$(get_site_config "$site_key")
+
+	local site_name
+	site_name=$(echo "$site_config" | jq -r '.name')
+	local site_type
+	site_type=$(echo "$site_config" | jq -r '.type')
+
+	print_info "Running on $site_name ($site_type): wp $wp_command"
+
+	# Execute directly without eval
+	execute_wp_via_ssh "$site_config" "$wp_command"
+	return $?
 }
 
 # Run WP-CLI command on all sites in a category
 run_on_category() {
-    local category="$1"
-    shift
-    local wp_command="$*"
-    
-    if [[ -z "$wp_command" ]]; then
-        print_error "$ERROR_COMMAND_REQUIRED"
-        exit 1
-    fi
-    
-    load_config
-    
-    print_info "Running on all sites in category: $category"
-    print_info "Command: wp $wp_command"
-    echo ""
-    
-    local site_keys
-    site_keys=$(jq -r --arg cat "$category" '.sites | to_entries[] | select(.value.category == $cat) | .key' "$CONFIG_FILE")
-    
-    if [[ -z "$site_keys" ]]; then
-        print_warning "No sites found in category: $category"
-        return 0
-    fi
-    
-    local success_count=0
-    local fail_count=0
-    
-    while IFS= read -r site_key; do
-        echo "----------------------------------------"
-        print_info "Site: $site_key"
-        if run_wp_command "$site_key" "$wp_command"; then
-            ((++success_count))
-        else
-            ((++fail_count))
-            print_error "Failed on site: $site_key"
-        fi
-        echo ""
-    done <<< "$site_keys"
-    
-    echo "========================================"
-    print_info "Summary: $success_count succeeded, $fail_count failed"
-    return 0
+	local category="$1"
+	shift
+	local wp_command="$*"
+
+	if [[ -z "$wp_command" ]]; then
+		print_error "$ERROR_COMMAND_REQUIRED"
+		exit 1
+	fi
+
+	load_config
+
+	print_info "Running on all sites in category: $category"
+	print_info "Command: wp $wp_command"
+	echo ""
+
+	local site_keys
+	site_keys=$(jq -r --arg cat "$category" '.sites | to_entries[] | select(.value.category == $cat) | .key' "$CONFIG_FILE")
+
+	if [[ -z "$site_keys" ]]; then
+		print_warning "No sites found in category: $category"
+		return 0
+	fi
+
+	local success_count=0
+	local fail_count=0
+
+	while IFS= read -r site_key; do
+		echo "----------------------------------------"
+		print_info "Site: $site_key"
+		if run_wp_command "$site_key" "$wp_command"; then
+			((++success_count))
+		else
+			((++fail_count))
+			print_error "Failed on site: $site_key"
+		fi
+		echo ""
+	done <<<"$site_keys"
+
+	echo "========================================"
+	print_info "Summary: $success_count succeeded, $fail_count failed"
+	return 0
 }
 
 # Run WP-CLI command on all sites
 run_on_all() {
-    local wp_command="$*"
-    
-    if [[ -z "$wp_command" ]]; then
-        print_error "$ERROR_COMMAND_REQUIRED"
-        exit 1
-    fi
-    
-    load_config
-    
-    print_info "Running on ALL sites"
-    print_info "Command: wp $wp_command"
-    echo ""
-    
-    local site_keys
-    site_keys=$(jq -r '.sites | keys[]' "$CONFIG_FILE")
-    
-    local success_count=0
-    local fail_count=0
-    
-    while IFS= read -r site_key; do
-        echo "----------------------------------------"
-        print_info "Site: $site_key"
-        if run_wp_command "$site_key" "$wp_command"; then
-            ((++success_count))
-        else
-            ((++fail_count))
-            print_error "Failed on site: $site_key"
-        fi
-        echo ""
-    done <<< "$site_keys"
-    
-    echo "========================================"
-    print_info "Summary: $success_count succeeded, $fail_count failed"
-    return 0
+	local wp_command="$*"
+
+	if [[ -z "$wp_command" ]]; then
+		print_error "$ERROR_COMMAND_REQUIRED"
+		exit 1
+	fi
+
+	load_config
+
+	print_info "Running on ALL sites"
+	print_info "Command: wp $wp_command"
+	echo ""
+
+	local site_keys
+	site_keys=$(jq -r '.sites | keys[]' "$CONFIG_FILE")
+
+	local success_count=0
+	local fail_count=0
+
+	while IFS= read -r site_key; do
+		echo "----------------------------------------"
+		print_info "Site: $site_key"
+		if run_wp_command "$site_key" "$wp_command"; then
+			((++success_count))
+		else
+			((++fail_count))
+			print_error "Failed on site: $site_key"
+		fi
+		echo ""
+	done <<<"$site_keys"
+
+	echo "========================================"
+	print_info "Summary: $success_count succeeded, $fail_count failed"
+	return 0
 }
 
 # Get site info
 get_site_info() {
-    local site_key="$1"
-    
-    local site_config
-    site_config=$(get_site_config "$site_key")
-    
-    print_info "Site: $site_key"
-    echo "$site_config" | jq '.'
-    return 0
+	local site_key="$1"
+
+	local site_config
+	site_config=$(get_site_config "$site_key")
+
+	print_info "Site: $site_key"
+	echo "$site_config" | jq '.'
+	return 0
 }
 
 # List available categories
 list_categories() {
-    load_config
-    print_info "Available categories:"
-    jq -r '.sites[].category // "uncategorized"' "$CONFIG_FILE" | sort -u | while read -r cat; do
-        local count
-        if [[ "$cat" == "uncategorized" ]]; then
-            # Count sites with null/missing category
-            count=$(jq -r '[.sites[] | select(.category == null or .category == "")] | length' "$CONFIG_FILE")
-        else
-            count=$(jq -r --arg c "$cat" '[.sites[] | select(.category == $c)] | length' "$CONFIG_FILE")
-        fi
-        echo "  - $cat ($count sites)"
-    done
-    return 0
+	load_config
+	print_info "Available categories:"
+	jq -r '.sites[].category // "uncategorized"' "$CONFIG_FILE" | sort -u | while read -r cat; do
+		local count
+		if [[ "$cat" == "uncategorized" ]]; then
+			# Count sites with null/missing category
+			count=$(jq -r '[.sites[] | select(.category == null or .category == "")] | length' "$CONFIG_FILE")
+		else
+			count=$(jq -r --arg c "$cat" '[.sites[] | select(.category == $c)] | length' "$CONFIG_FILE")
+		fi
+		echo "  - $cat ($count sites)"
+	done
+	return 0
 }
 
 # Show help
 show_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 WordPress CLI Helper Script
 
 Runs WP-CLI commands on sites configured in ~/.config/aidevops/wordpress-sites.json
@@ -370,67 +370,67 @@ Related:
   mainwp-helper.sh - For MainWP fleet management
   wordpress-mcp-helper.sh - For WordPress MCP adapter
 EOF
-    return 0
+	return 0
 }
 
 # Main script logic
 main() {
-    local command="${1:-help}"
-    
-    check_dependencies
-    
-    case "$command" in
-        --list)
-            list_sites
-            ;;
-        --list-category)
-            local category="${2:-}"
-            if [[ -z "$category" ]]; then
-                print_error "Category is required"
-                exit 1
-            fi
-            list_sites_by_category "$category"
-            ;;
-        --categories)
-            list_categories
-            ;;
-        --info)
-            local site="${2:-}"
-            if [[ -z "$site" ]]; then
-                print_error "$ERROR_SITE_REQUIRED"
-                exit 1
-            fi
-            get_site_info "$site"
-            ;;
-        --all)
-            shift
-            run_on_all "$@"
-            ;;
-        --category)
-            local category="${2:-}"
-            if [[ -z "$category" ]]; then
-                print_error "Category is required"
-                exit 1
-            fi
-            shift 2
-            run_on_category "$category" "$@"
-            ;;
-        help|--help|-h)
-            show_help
-            ;;
-        *)
-            # Assume first arg is site key, rest is WP-CLI command
-            local site_key="$1"
-            shift
-            if [[ $# -eq 0 ]]; then
-                print_error "$ERROR_COMMAND_REQUIRED"
-                print_info "Usage: wp-helper.sh <site> <wp-cli-command>"
-                exit 1
-            fi
-            run_wp_command "$site_key" "$@"
-            ;;
-    esac
-    return 0
+	local command="${1:-help}"
+
+	check_dependencies
+
+	case "$command" in
+	--list)
+		list_sites
+		;;
+	--list-category)
+		local category="${2:-}"
+		if [[ -z "$category" ]]; then
+			print_error "Category is required"
+			exit 1
+		fi
+		list_sites_by_category "$category"
+		;;
+	--categories)
+		list_categories
+		;;
+	--info)
+		local site="${2:-}"
+		if [[ -z "$site" ]]; then
+			print_error "$ERROR_SITE_REQUIRED"
+			exit 1
+		fi
+		get_site_info "$site"
+		;;
+	--all)
+		shift
+		run_on_all "$@"
+		;;
+	--category)
+		local category="${2:-}"
+		if [[ -z "$category" ]]; then
+			print_error "Category is required"
+			exit 1
+		fi
+		shift 2
+		run_on_category "$category" "$@"
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		# Assume first arg is site key, rest is WP-CLI command
+		local site_key="$1"
+		shift
+		if [[ $# -eq 0 ]]; then
+			print_error "$ERROR_COMMAND_REQUIRED"
+			print_info "Usage: wp-helper.sh <site> <wp-cli-command>"
+			exit 1
+		fi
+		run_wp_command "$site_key" "$@"
+		;;
+	esac
+	return 0
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- **t1057 / #1507**: Add `ssh -n` flag to both SSH invocations in `execute_wp_via_ssh()` to prevent stdin consumption when iterating sites in `--all`/`--category` loops. Without `-n`, `ssh` reads from stdin and consumes the remaining input from the `while read` loop, causing only the first site to be processed.
- **t1058 / #1509**: Correct Cloudways template `wp_path` from `/home/master_user/applications/...` to `/home/master/applications/...`. On Cloudways, the home directory is always `/home/master/` regardless of the SSH username. Updated the `_hosting_types` comment to document this behavior.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/wp-helper.sh:157` | Add `ssh -n` to sshpass+ssh invocation |
| `.agents/scripts/wp-helper.sh:162` | Add `ssh -n` to key-based ssh invocation |
| `.agents/configs/wordpress-sites.json.txt:44` | Fix Cloudways `wp_path` template |
| `.agents/configs/wordpress-sites.json.txt:67` | Update Cloudways hosting type description |

## Testing

- `bash -n wp-helper.sh` - syntax check passes
- `shellcheck wp-helper.sh` - no new warnings (pre-existing SC1091, SC2086 only)
- `python3 -m json.tool wordpress-sites.json.txt` - JSON valid

Fixes #1507, Fixes #1509
Ref #1507, Ref #1509