### PR TITLE
t1062: Fix supervisor auto-pickup race with interactive sessions

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -113,7 +113,7 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **Dependencies**: `blocked-by:t001`, `blocks:t002`, `t001.1` (subtask)
 
-**Auto-dispatch**: Add `#auto-dispatch` to tasks that can run autonomously (clear spec, bounded scope, no user input needed). Default to including it — only omit when a specific exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria. The supervisor's Phase 0 picks these up automatically every 2 minutes and auto-creates batches (`auto-YYYYMMDD-HHMMSS`, concurrency = cores/2, min 2) when no active batch exists.
+**Auto-dispatch**: Add `#auto-dispatch` to tasks that can run autonomously (clear spec, bounded scope, no user input needed). Default to including it — only omit when a specific exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria. The supervisor's Phase 0 picks these up automatically every 2 minutes and auto-creates batches (`auto-YYYYMMDD-HHMMSS`, concurrency = cores/2, min 2) when no active batch exists. **Interactive claim guard** (t1062): When working interactively on a task tagged `#auto-dispatch`, always include `assignee:` or `started:` in the TODO entry before pushing — the supervisor skips tasks with these fields to prevent race conditions.
 
 **Task completion rules** (CRITICAL - prevents false completion cascade):
 - NEVER mark a task `[x]` unless a merged PR exists with real deliverables for that task

--- a/.agents/scripts/supervisor/cron.sh
+++ b/.agents/scripts/supervisor/cron.sh
@@ -286,6 +286,14 @@ cmd_auto_pickup() {
 				continue
 			fi
 
+			# Skip tasks already claimed or being worked on interactively (t1062).
+			# assignee: means someone claimed it; started: means work has begun.
+			# Without this check, the supervisor races with interactive sessions.
+			if echo "$line" | grep -qE ' (assignee|started):'; then
+				log_info "  $task_id: already claimed/started — skipping auto-pickup"
+				continue
+			fi
+
 			# Add to supervisor
 			if cmd_add "$task_id" --repo "$repo"; then
 				picked_up=$((picked_up + 1))
@@ -340,6 +348,12 @@ cmd_auto_pickup() {
 			# Pre-pickup check: skip tasks with merged PRs (t224).
 			if check_task_already_done "$task_id" "$repo"; then
 				log_info "  $task_id: already completed (merged PR) — skipping auto-pickup"
+				continue
+			fi
+
+			# Skip tasks already claimed or being worked on interactively (t1062).
+			if echo "$line" | grep -qE ' (assignee|started):'; then
+				log_info "  $task_id: already claimed/started — skipping auto-pickup"
 				continue
 			fi
 


### PR DESCRIPTION
## Summary

Prevents the supervisor from dispatching workers for tasks already being worked on interactively. This caused a race condition where:

1. Interactive session adds TODO entries with `#auto-dispatch` and starts working
2. Supervisor Phase 0 picks up the same tasks within 2 minutes
3. Supervisor dispatches workers that collide with the already-merged interactive fix
4. Workers can't find expected deliverables, set `status:blocked` on GitHub issues

**Root cause**: `cmd_auto_pickup()` checked for existing DB entries and merged PRs, but not for `assignee:` or `started:` metadata fields that indicate someone is already working on the task.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/supervisor/cron.sh:289-294` | Add claim guard to Strategy 1 (tagged `#auto-dispatch`) |
| `.agents/scripts/supervisor/cron.sh:354-359` | Add claim guard to Strategy 2 (Dispatch Queue section) |
| `.agents/AGENTS.md:116` | Add interactive claim guard guidance |

## Testing

- `bash -n cron.sh` — syntax OK
- `shellcheck -S warning cron.sh` — zero warnings
- Logic verified: `grep -qE ' (assignee|started):'` correctly matches TODO lines with these metadata fields

## Real-world scenario this fixes

This exact race happened with issues #1507/#1509 — we fixed them interactively and merged PR #1513, but the supervisor also dispatched workers. #1509 ended up with `status:blocked` because the supervisor's worker couldn't reconcile the already-merged fix.

Fixes #1518
Ref #1518