### PR TITLE
t1062: Fix supervisor auto-pickup race condition with assignee/started fields

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -115,6 +115,8 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **Auto-dispatch**: Add `#auto-dispatch` to tasks that can run autonomously (clear spec, bounded scope, no user input needed). Default to including it — only omit when a specific exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria. The supervisor's Phase 0 picks these up automatically every 2 minutes and auto-creates batches (`auto-YYYYMMDD-HHMMSS`, concurrency = cores/2, min 2) when no active batch exists.
 
+**Working on #auto-dispatch tasks interactively** (t1062): When you start working on a task tagged with `#auto-dispatch`, immediately add `assignee:` to the TODO entry before pushing. This prevents the supervisor from racing and dispatching a worker for the same task. The supervisor's auto-pickup skips tasks with `assignee:` or `started:` fields.
+
 **Task completion rules** (CRITICAL - prevents false completion cascade):
 - NEVER mark a task `[x]` unless a merged PR exists with real deliverables for that task
 - Use `task-complete-helper.sh <task-id> --pr <number>` or `task-complete-helper.sh <task-id> --verified` to mark tasks complete in interactive sessions

--- a/.agents/scripts/supervisor/cron.sh
+++ b/.agents/scripts/supervisor/cron.sh
@@ -268,6 +268,13 @@ cmd_auto_pickup() {
 				continue
 			fi
 
+			# Skip tasks with assignee: or started: fields (t1062)
+			# These indicate someone is already working on the task
+			if echo "$line" | grep -qE '(assignee:|started:)'; then
+				log_info "  $task_id: already claimed or in progress — skipping auto-pickup"
+				continue
+			fi
+
 			# Check if already in supervisor
 			local existing
 			existing=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$task_id")';" 2>/dev/null || true)
@@ -324,6 +331,13 @@ cmd_auto_pickup() {
 			local task_id
 			task_id=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1)
 			if [[ -z "$task_id" ]]; then
+				continue
+			fi
+
+			# Skip tasks with assignee: or started: fields (t1062)
+			# These indicate someone is already working on the task
+			if echo "$line" | grep -qE '(assignee:|started:)'; then
+				log_info "  $task_id: already claimed or in progress — skipping auto-pickup"
 				continue
 			fi
 


### PR DESCRIPTION
## Summary

Fixes race condition where supervisor auto-pickup dispatches workers for tasks already being worked on interactively.

## Changes

1. **Supervisor auto-pickup skip logic** (`.agents/scripts/supervisor/cron.sh`):
   - Strategy 1 (#auto-dispatch tag): Skip tasks with `assignee:` or `started:` fields
   - Strategy 2 (Dispatch Queue section): Skip tasks with `assignee:` or `started:` fields
   
2. **Documentation update** (`.agents/AGENTS.md`):
   - Added guidance for interactive sessions: add `assignee:` field when starting work on #auto-dispatch tasks
   - Prevents supervisor from racing and dispatching duplicate workers

## Testing

- Verified grep pattern correctly identifies and skips tasks with `assignee:` or `started:` fields
- ShellCheck passed with zero violations
- Test cases covered: tasks with assignee only, started only, both fields, and neither field

## Impact

- Prevents false `status:blocked` on GitHub issues caused by worker collisions
- Interactive sessions can safely work on #auto-dispatch tasks without race conditions
- Supervisor respects task ownership indicated by `assignee:` or `started:` fields

Ref #1518