### PR TITLE
t1064: Unbuilt.app provider agent and tech-stack-helper.sh

### DIFF
--- a/.agents/scripts/tech-stack-helper.sh
+++ b/.agents/scripts/tech-stack-helper.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Tech Stack Discovery Helper Script
 # Multi-provider website technology detection with common schema output.
-# Providers: openexplorer (free, open-source)
+# Providers: openexplorer (free, open-source), unbuilt (Unbuilt.app CLI)
 #
 # Usage: tech-stack-helper.sh <provider> <command> [options]
 #        tech-stack-helper.sh providers
@@ -16,6 +16,8 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # Configuration
 readonly CACHE_DIR="$HOME/.aidevops/.agent-workspace/tmp/tech-stack-cache"
 readonly CACHE_TTL=3600 # 1 hour cache
+readonly UNBUILT_PKG="@unbuilt/cli"
+readonly UNBUILT_TIMEOUT="${UNBUILT_TIMEOUT:-120}"
 mkdir -p "$CACHE_DIR"
 
 # =============================================================================
@@ -446,8 +448,205 @@ PLAYWRIGHT_SCRIPT
 }
 
 # =============================================================================
+# Unbuilt Provider
+# =============================================================================
+
+# Check if Node.js/npm is available
+check_node() {
+	if ! command -v node &>/dev/null; then
+		print_error "Node.js is not installed. Install Node.js 16+ first."
+		return 1
+	fi
+	return 0
+}
+
+# Check if the unbuilt CLI is installed
+check_unbuilt() {
+	if command -v unbuilt &>/dev/null; then
+		return 0
+	fi
+	# Check npx availability as fallback
+	if command -v npx &>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+# Check if Playwright Chromium is available for local analysis
+check_playwright() {
+	local pw_browsers
+	pw_browsers="${HOME}/Library/Caches/ms-playwright"
+	if [[ -d "$pw_browsers" ]] && ls "$pw_browsers"/chromium-* &>/dev/null; then
+		return 0
+	fi
+	# Linux path
+	pw_browsers="${HOME}/.cache/ms-playwright"
+	if [[ -d "$pw_browsers" ]] && ls "$pw_browsers"/chromium-* &>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+install_unbuilt() {
+	check_node || return 1
+
+	print_info "Installing ${UNBUILT_PKG} globally..."
+	if npm install -g "${UNBUILT_PKG}"; then
+		print_success "Installed ${UNBUILT_PKG}"
+	else
+		print_error "Failed to install ${UNBUILT_PKG}"
+		return 1
+	fi
+
+	# Install Playwright Chromium if not present
+	if ! check_playwright; then
+		print_info "Installing Playwright Chromium browser..."
+		if npx playwright install chromium; then
+			print_success "Playwright Chromium installed"
+		else
+			print_warning "Playwright install failed. Use --remote flag for server-side analysis."
+		fi
+	fi
+
+	return 0
+}
+
+# Run unbuilt analysis on a URL
+run_unbuilt() {
+	local url="$1"
+	shift
+
+	# Validate URL
+	if [[ -z "$url" ]]; then
+		print_error "URL is required. Usage: tech-stack-helper.sh unbuilt <url>"
+		return 1
+	fi
+
+	# Auto-install if missing
+	if ! check_unbuilt; then
+		print_warning "Unbuilt CLI not found. Installing..."
+		install_unbuilt || return 1
+	fi
+
+	# Build command args
+	local -a cmd_args=()
+	local use_json=false
+	local use_remote=false
+
+	# Parse passthrough flags
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json | -j)
+			use_json=true
+			cmd_args+=("--json")
+			;;
+		--remote | -r)
+			use_remote=true
+			cmd_args+=("--remote")
+			;;
+		--timeout | -t)
+			cmd_args+=("--timeout" "${2:-$UNBUILT_TIMEOUT}")
+			shift
+			;;
+		--session | --refresh | --async | -n)
+			cmd_args+=("$1")
+			;;
+		*)
+			cmd_args+=("$1")
+			;;
+		esac
+		shift
+	done
+
+	# Warn if no Playwright and not using remote
+	if [[ "$use_remote" == "false" ]] && ! check_playwright; then
+		print_warning "Playwright Chromium not found. Falling back to --remote mode."
+		cmd_args+=("--remote")
+	fi
+
+	# Run analysis
+	local unbuilt_cmd
+	if command -v unbuilt &>/dev/null; then
+		unbuilt_cmd="unbuilt"
+	else
+		unbuilt_cmd="npx ${UNBUILT_PKG}"
+	fi
+
+	if [[ "$use_json" == "true" ]]; then
+		# JSON mode: capture output for potential post-processing
+		local raw_output
+		raw_output=$($unbuilt_cmd "$url" "${cmd_args[@]}" 2>/dev/null) || {
+			print_error "Unbuilt analysis failed for: ${url}"
+			return 1
+		}
+		echo "$raw_output"
+	else
+		# Human-readable mode: stream output directly
+		print_info "Analysing: ${url}"
+		$unbuilt_cmd "$url" "${cmd_args[@]}" || {
+			print_error "Unbuilt analysis failed for: ${url}"
+			return 1
+		}
+	fi
+
+	return 0
+}
+
+# Normalise unbuilt JSON output to common tech-stack schema
+normalise_unbuilt() {
+	if ! command -v jq &>/dev/null; then
+		print_error "jq is required for JSON normalisation. Install with: brew install jq"
+		return 1
+	fi
+
+	jq '{
+        url: .url,
+        provider: "unbuilt",
+        detected: {
+            bundler:          ((.technologies.bundlers // []) | join(", ")),
+            ui_library:       ((.technologies.uiLibraries // []) | join(", ")),
+            framework:        ((.technologies.frameworks // []) | join(", ")),
+            css_framework:    (((.technologies.styling // []) + (.technologies.stylingLibraries // [])) | unique | join(", ")),
+            state_management: ((.technologies.stateManagement // []) | join(", ")),
+            http_client:      ((.technologies.httpClients // []) | join(", ")),
+            router:           ((.technologies.routers // []) | join(", ")),
+            i18n:             ((.technologies.translationLibraries // []) | join(", ")),
+            date_library:     ((.technologies.dateLibraries // []) | join(", ")),
+            analytics:        ((.technologies.analytics // []) | join(", ")),
+            monitoring:       ((.technologies.monitoring // []) | join(", ")),
+            platform:         ((.technologies.platforms // []) | join(", ")),
+            minifier:         ((.technologies.minifiers // []) | join(", ")),
+            transpiler:       ((.technologies.transpilers // []) | join(", ")),
+            module_system:    ((.technologies.moduleSystems // []) | join(", "))
+        }
+    } | .detected |= with_entries(select(.value != ""))' 2>/dev/null || {
+		print_error "Failed to normalise Unbuilt JSON output"
+		return 1
+	}
+
+	return 0
+}
+
+# =============================================================================
 # Provider Management
 # =============================================================================
+
+install_provider() {
+	local provider="$1"
+
+	case "$provider" in
+	unbuilt)
+		install_unbuilt
+		;;
+	*)
+		print_error "Unknown provider: ${provider}"
+		print_info "Available providers: openexplorer, unbuilt"
+		return 1
+		;;
+	esac
+
+	return $?
+}
 
 # List available providers
 list_providers() {
@@ -457,6 +656,25 @@ list_providers() {
 	echo "                https://openexplorer.tech"
 	echo "                Commands: search, tech, category, analyse"
 	echo ""
+	echo "  unbuilt       Unbuilt.app: real-time frontend JS analysis (MIT)"
+	echo "                Detects: bundlers, frameworks, UI libs, styling, state, analytics, monitoring"
+	echo "                CLI: npm install -g @unbuilt/cli"
+	echo "                Requires: Node.js 16+, Playwright Chromium (or --remote)"
+	echo ""
+
+	# Show installation status
+	echo -e "${CYAN}Installation Status${NC}"
+	echo ""
+	if check_unbuilt 2>/dev/null; then
+		local version
+		version=$(unbuilt --version 2>/dev/null || echo "unknown")
+		echo -e "  unbuilt: ${GREEN}installed${NC} (${version})"
+	else
+		echo -e "  unbuilt: ${RED}not installed${NC}"
+		echo "           Install: tech-stack-helper.sh install unbuilt"
+	fi
+	echo ""
+
 	print_info "Usage: tech-stack-helper.sh <provider> <command> [args]"
 	return 0
 }
@@ -475,9 +693,10 @@ compare_providers() {
 	openexplorer_search "$normalised"
 	echo ""
 
-	# Future: add more providers here
-	# echo "--- Wappalyzer ---"
-	# wappalyzer_search "$normalised"
+	# Unbuilt
+	echo "--- Unbuilt ---"
+	run_unbuilt "$normalised" --json 2>/dev/null || echo "Unbuilt analysis unavailable"
+	echo ""
 
 	print_info "Add more providers to tech-stack-helper.sh for cross-reference."
 	return 0
@@ -494,28 +713,40 @@ show_help() {
 	echo "  tech-stack-helper.sh <provider> <command> [options]"
 	echo "  tech-stack-helper.sh providers"
 	echo "  tech-stack-helper.sh compare <url>"
+	echo "  tech-stack-helper.sh install <provider>"
 	echo ""
 	echo "${HELP_LABEL_COMMANDS}"
 	echo "  providers                     List available providers"
 	echo "  compare <url>                 Compare results across all providers"
+	echo "  install <provider>            Install a provider CLI"
 	echo ""
 	echo "  openexplorer search <url>     Search by URL"
 	echo "  openexplorer tech <name>      Search by technology name"
 	echo "  openexplorer category <name>  Search by category"
 	echo "  openexplorer analyse <url>    Full analysis via Playwright"
 	echo ""
+	echo "  unbuilt <url> [flags]         Analyse a URL with Unbuilt.app CLI"
+	echo "  normalise                     Normalise unbuilt JSON (stdin) to common schema (stdout)"
+	echo ""
 	echo "${HELP_LABEL_OPTIONS}"
 	echo "  --page <n>                    Page number (default: 1)"
 	echo "  --limit <n>                   Results per page (default: 20)"
 	echo "  --no-cache                    Skip cache"
-	echo "  --json                        Output raw JSON (default)"
+	echo "  --json, -j                    Output results in JSON format"
+	echo "  --remote, -r                  Run analysis on unbuilt.app server"
+	echo "  --timeout, -t <secs>          Max wait time (default: 120)"
+	echo "  --session                     Use local Chrome profile for auth"
+	echo "  --refresh                     Force fresh analysis (bypass cache)"
 	echo ""
 	echo "${HELP_LABEL_EXAMPLES}"
 	echo "  tech-stack-helper.sh openexplorer search github.com"
 	echo "  tech-stack-helper.sh openexplorer tech React"
 	echo "  tech-stack-helper.sh openexplorer analyse https://example.com"
+	echo "  tech-stack-helper.sh unbuilt https://example.com"
+	echo "  tech-stack-helper.sh unbuilt https://example.com --json | tech-stack-helper.sh normalise"
 	echo "  tech-stack-helper.sh providers"
 	echo "  tech-stack-helper.sh compare github.com"
+	echo "  tech-stack-helper.sh install unbuilt"
 	return 0
 }
 
@@ -533,12 +764,23 @@ main() {
 	help | --help | -h)
 		show_help
 		;;
-	providers)
+	providers | list)
 		list_providers
 		;;
 	compare)
 		local url="${1:?URL required for compare}"
 		compare_providers "$url"
+		;;
+	install)
+		local install_provider_name="${1:-}"
+		if [[ -z "$install_provider_name" ]]; then
+			print_error "Provider name required. Usage: tech-stack-helper.sh install <provider>"
+			return 1
+		fi
+		install_provider "$install_provider_name"
+		;;
+	normalise | normalize)
+		normalise_unbuilt
 		;;
 	openexplorer)
 		local command="${1:-help}"
@@ -570,6 +812,9 @@ main() {
 			return 1
 			;;
 		esac
+		;;
+	unbuilt)
+		run_unbuilt "$@"
 		;;
 	*)
 		print_error "Unknown provider: $provider"

--- a/.agents/scripts/tech-stack-helper.sh
+++ b/.agents/scripts/tech-stack-helper.sh
@@ -16,6 +16,8 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # Configuration
 readonly CACHE_DIR="$HOME/.aidevops/.agent-workspace/tmp/tech-stack-cache"
 readonly CACHE_TTL=3600 # 1 hour cache
+SCRIPT_NAME="$(basename "$0")" || true
+readonly SCRIPT_NAME
 readonly UNBUILT_PKG="@unbuilt/cli"
 readonly UNBUILT_TIMEOUT="${UNBUILT_TIMEOUT:-120}"
 mkdir -p "$CACHE_DIR"

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -21,7 +21,7 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[47]{folder,purpose,key_files}:
+<!--TOON:subagents[48]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings and UX/CRO,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper|mom-test-ux
@@ -69,6 +69,7 @@ services/analytics/,Website analytics - GA4 reporting,google-analytics
 services/monitoring/,Error monitoring and debugging,sentry|socket
 services/accounting/,Accounting integration - invoicing,quickfile
 services/document-processing/,Document processing - LLM-powered extraction,unstract
+tools/research/,Tech stack research - frontend technology detection providers,providers/unbuilt
 -->
 
 <!--TOON:workflows[13]{name,file,purpose}:
@@ -87,7 +88,7 @@ feature-development,workflows/feature-development.md,Feature development workflo
 conversation-starter,workflows/conversation-starter.md,Session greeting and auto-recall
 -->
 
-<!--TOON:scripts[78]{name,purpose}:
+<!--TOON:scripts[79]{name,purpose}:
 accessibility-helper.sh,Accessibility and contrast testing (WCAG compliance WAVE API for websites and emails)
 accessibility-audit-helper.sh,Accessibility audit CLI wrapping axe-core WAVE API WebAIM contrast and Lighthouse a11y
 auto-update-helper.sh,Automatic update polling daemon (enable disable status check logs)
@@ -175,4 +176,5 @@ wavespeed-helper.sh,WaveSpeed AI REST API client - unified generation for 200+ m
 plugin-loader-helper.sh,Plugin agent loader - discover validate load unload agents hooks index status
 claim-task-id.sh,Distributed task ID allocation with collision prevention (online GH/GL issue lock or offline +100 offset)
 planning-commit-helper.sh,Planning file auto-commit helper (next-id complete commit check status)
+tech-stack-helper.sh,Frontend technology detection (unbuilt analyse normalise install providers)
 -->

--- a/.agents/tools/research/providers/unbuilt.md
+++ b/.agents/tools/research/providers/unbuilt.md
@@ -1,0 +1,167 @@
+---
+description: Unbuilt.app provider — real-time frontend technology detection via CLI
+mode: subagent
+model: sonnet
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: false
+---
+
+# Unbuilt.app Provider
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Detect frontend technologies on live websites via real-time JS analysis
+- **CLI**: `@unbuilt/cli` (npm), usage: `unbuilt <url>`
+- **Source**: [github.com/yavorsky/unbuilt.app](https://github.com/yavorsky/unbuilt.app) (MIT)
+- **Strengths**: Real-time code analysis of bundled/minified JS (not static signatures)
+- **Prerequisite**: Node.js 16+, Playwright Chromium (`npx playwright install chromium`)
+- **Helper**: `tech-stack-helper.sh unbuilt <url> [--json]`
+
+## What It Detects
+
+| Category | Examples |
+|----------|----------|
+| Bundlers | Webpack, Vite, Rollup, Parcel, esbuild, Turbopack |
+| UI Libraries | React, Vue, Angular, Svelte |
+| Frameworks | Next.js, Nuxt.js, Remix, VitePress, Storybook, SvelteKit |
+| Minifiers | Terser, UglifyJS |
+| Styling Processors | Sass, Less, PostCSS |
+| Module Systems | CommonJS, ES Modules, AMD |
+| Styling Libraries | Tailwind CSS, Material UI, Chakra UI, shadcn/ui, Lucide |
+| State Management | Redux, MobX, Zustand |
+| HTTP Clients | Axios, Fetch, SuperAgent |
+| Routers | React Router, Vue Router, Next.js internal router |
+| Translation (i18n) | i18next, react-intl |
+| Date Libraries | Moment.js, date-fns, Luxon |
+| Analytics | Google Analytics, Mixpanel, Umami, Microsoft Clarity |
+| Transpilers | Babel, SWC, TypeScript |
+| Monitoring | Sentry, Datadog, Rollbar, New Relic, OpenTelemetry, Vercel Speed Insights |
+| Platforms | Wix, Weebly, Webflow, Squarespace, Shopify |
+
+## CLI Installation
+
+```bash
+npm install -g @unbuilt/cli
+npx playwright install chromium
+```
+
+## CLI Usage
+
+```bash
+# Basic analysis (human-readable output)
+unbuilt https://example.com
+
+# JSON output (machine-readable, for integration)
+unbuilt https://example.com --json
+
+# Remote analysis (uses unbuilt.app server, no local Playwright needed)
+unbuilt https://example.com --remote --json
+
+# With authenticated session (uses local Chrome profile)
+unbuilt https://example.com --session
+
+# Custom timeout (default 120s)
+unbuilt https://example.com --timeout 60
+
+# Batch analysis from CSV
+unbuilt batch urls.csv --concurrent 4 --json --output results.json
+```
+
+## CLI Options
+
+| Flag | Description |
+|------|-------------|
+| `-j, --json` | Output results in JSON format |
+| `-r, --remote` | Run analysis on unbuilt.app server (no local browser needed) |
+| `-n, --async` | Async remote execution (returns job ID) |
+| `--refresh` | Force fresh analysis (bypass cache) |
+| `-t, --timeout <s>` | Max wait time in seconds (default: 120) |
+| `--session` | Use local Chrome profile for authenticated analysis |
+
+## Integration Pattern
+
+The `tech-stack-helper.sh` script wraps the CLI for the aidevops framework:
+
+```bash
+# Analyze a single URL
+tech-stack-helper.sh unbuilt https://example.com
+
+# JSON output for programmatic use
+tech-stack-helper.sh unbuilt https://example.com --json
+
+# Auto-install CLI if missing
+tech-stack-helper.sh install unbuilt
+```
+
+## Output Schema (JSON mode)
+
+The `--json` flag returns structured results grouped by detection category.
+Each detected technology includes the technology name, category, and evidence.
+
+Example structure:
+
+```json
+{
+  "url": "https://example.com",
+  "technologies": {
+    "bundlers": ["Webpack"],
+    "uiLibraries": ["React"],
+    "frameworks": ["Next.js"],
+    "styling": ["Tailwind CSS"],
+    "stateManagement": ["Redux"],
+    "monitoring": ["Sentry"],
+    "analytics": ["Google Analytics"]
+  }
+}
+```
+
+## Common Schema Mapping
+
+The helper normalises Unbuilt output into a common tech-stack schema:
+
+| Common Field | Unbuilt Category |
+|-------------|-----------------|
+| `bundler` | bundlers |
+| `ui_library` | uiLibraries |
+| `framework` | frameworks |
+| `css_framework` | styling / stylingLibraries |
+| `state_management` | stateManagement |
+| `http_client` | httpClients |
+| `router` | routers |
+| `i18n` | translationLibraries |
+| `date_library` | dateLibraries |
+| `analytics` | analytics |
+| `monitoring` | monitoring |
+| `platform` | platforms |
+| `minifier` | minifiers |
+| `transpiler` | transpilers |
+| `module_system` | moduleSystems |
+
+## Comparison with Alternatives
+
+| Feature | Unbuilt | Wappalyzer | BuiltWith |
+|---------|---------|------------|-----------|
+| Detection method | Real-time JS execution | Static signatures | Crawl + signatures |
+| Open source | MIT | Partially | No |
+| Cost | Free | Freemium | Paid |
+| Modern tech focus | Excellent | Good | Good |
+| Local CLI | Yes | Browser ext only | No |
+| Evidence-based | Yes (code proof) | No | No |
+
+## Limitations
+
+- Requires Playwright Chromium for local analysis (or use `--remote`)
+- Beta status: detection patterns are actively improving
+- Analysis takes 5-30 seconds per URL depending on site complexity
+- Some heavily obfuscated sites may yield incomplete results
+- Version detection is not yet available (planned feature)
+
+<!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

- Add `tools/research/providers/unbuilt.md` subagent documenting Unbuilt.app CLI capabilities, detection categories (bundlers, frameworks, UI libs, styling, state management, analytics, monitoring, platforms), and integration patterns
- Create `tech-stack-helper.sh` with unbuilt provider: auto-install, local/remote analysis, JSON output, normalise command (jq-based mapping to common tech-stack schema), and provider listing with installation status
- Register new subagent and script in `subagent-index.toon`

Ref #1525

## Details

**Unbuilt.app** ([github.com/yavorsky/unbuilt.app](https://github.com/yavorsky/unbuilt.app), MIT) does real-time code analysis of bundled/minified JS to detect frontend technologies. Unlike static signature tools, it executes JS in a headless browser for evidence-based detection.

**tech-stack-helper.sh** follows standard helper script patterns:
- Sources `shared-constants.sh` for consistent output formatting
- Auto-installs `@unbuilt/cli` and Playwright Chromium if missing
- Falls back to `--remote` mode when Playwright is unavailable
- Provides `normalise` command to map Unbuilt output to a common schema via jq
- ShellCheck clean (zero violations at warning level)

**Usage:**
```bash
tech-stack-helper.sh unbuilt https://example.com --json
tech-stack-helper.sh unbuilt https://example.com --json | tech-stack-helper.sh normalise
tech-stack-helper.sh providers
tech-stack-helper.sh install unbuilt
```