### PR TITLE
t1065: CRFT Lookup provider agent and tech-stack-helper.sh

### DIFF
--- a/.agents/scripts/tech-stack-helper.sh
+++ b/.agents/scripts/tech-stack-helper.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 # Tech Stack Discovery Helper Script
 # Multi-provider website technology detection with common schema output.
-# Providers: openexplorer (free, open-source), unbuilt (Unbuilt.app CLI)
+# Providers: openexplorer (free, open-source), unbuilt (Unbuilt.app CLI), crft (CRFT Lookup)
 #
 # Usage: tech-stack-helper.sh <provider> <command> [options]
 #        tech-stack-helper.sh providers
@@ -18,11 +18,20 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # Configuration
 readonly CACHE_DIR="$HOME/.aidevops/.agent-workspace/tmp/tech-stack-cache"
 readonly CACHE_TTL=3600 # 1 hour cache
+readonly REPORTS_DIR="${HOME}/.aidevops/.agent-workspace/work/tech-stack/reports"
 SCRIPT_NAME="$(basename "$0")" || true
 readonly SCRIPT_NAME
 readonly UNBUILT_PKG="@unbuilt/cli"
 readonly UNBUILT_TIMEOUT="${UNBUILT_TIMEOUT:-120}"
-mkdir -p "$CACHE_DIR"
+
+# CRFT Lookup Configuration
+readonly CRFT_BASE_URL="https://crft.studio"
+readonly CRFT_LOOKUP_URL="${CRFT_BASE_URL}/lookup"
+readonly CRFT_GALLERY_URL="${CRFT_BASE_URL}/lookup/gallery"
+readonly CRFT_SCAN_TIMEOUT=60
+
+# Ensure directories exist
+mkdir -p "$CACHE_DIR" "$REPORTS_DIR" 2>/dev/null || true
 
 # =============================================================================
 # Utility Functions
@@ -62,6 +71,23 @@ normalise_url() {
 	url="${url#www.}"
 	url="${url%/}"
 	echo "$url"
+	return 0
+}
+
+# Normalize domain: strip protocol, trailing slash, www prefix
+normalize_domain() {
+	local url="$1"
+	local domain
+
+	# Strip protocol
+	domain="${url#http://}"
+	domain="${domain#https://}"
+	# Strip trailing slash and path
+	domain="${domain%%/*}"
+	# Strip port
+	domain="${domain%%:*}"
+
+	echo "$domain"
 	return 0
 }
 
@@ -631,6 +657,407 @@ normalise_unbuilt() {
 }
 
 # =============================================================================
+# CRFT Lookup Provider
+# =============================================================================
+
+# Convert domain to gallery slug (e.g., basecamp.com -> basecamp)
+domain_to_slug() {
+	local domain="$1"
+
+	# Strip www. prefix
+	domain="${domain#www.}"
+	# Take the part before the TLD for simple domains
+	# e.g., basecamp.com -> basecamp, linear.app -> linear
+	local slug="${domain%%.*}"
+
+	echo "$slug"
+	return 0
+}
+
+# Fetch a CRFT gallery report page and extract data
+fetch_gallery_report() {
+	local domain="$1"
+	local slug
+	slug=$(domain_to_slug "$domain")
+
+	local gallery_url="${CRFT_GALLERY_URL}/${slug}"
+	local response
+
+	print_info "Fetching report from: $gallery_url"
+
+	response=$(curl -sL \
+		-H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" \
+		-H "Accept: text/html" \
+		--max-time "$CRFT_SCAN_TIMEOUT" \
+		"$gallery_url" 2>/dev/null) || {
+		print_warning "Could not fetch gallery page for: $domain"
+		echo ""
+		return 1
+	}
+
+	# Check if we got a valid report page (not a 404)
+	if echo "$response" | grep -q "Technology Stack\|Performance\|Lighthouse" 2>/dev/null; then
+		echo "$response"
+		return 0
+	fi
+
+	print_warning "No existing report found for: $domain"
+	echo ""
+	return 1
+}
+
+# Parse technologies from HTML report
+parse_technologies() {
+	local html="$1"
+	local json_output="${2:-false}"
+
+	if [[ -z "$html" ]]; then
+		print_warning "No HTML content to parse"
+		return 1
+	fi
+
+	# Extract technology names from icon filenames in the gallery page HTML
+	# Icons appear as /icons/React.svg, /icons/Next.js.svg, etc.
+	local techs_raw
+	techs_raw=$(echo "$html" | grep -oE '/icons/[^."]+' 2>/dev/null |
+		sed 's|/icons/||' |
+		grep -v "Open Graph" |
+		sort -u) || true
+
+	if [[ "$json_output" == "true" ]]; then
+		local json_array="["
+		local first=true
+		while IFS= read -r tech; do
+			[[ -z "$tech" ]] && continue
+			if [[ "$first" == "true" ]]; then
+				first=false
+			else
+				json_array+=","
+			fi
+			local escaped_tech
+			escaped_tech=$(echo "$tech" | sed 's/"/\\"/g')
+			json_array+="{\"name\":\"$escaped_tech\"}"
+		done <<<"$techs_raw"
+		json_array+="]"
+		echo "$json_array"
+	else
+		if [[ -n "$techs_raw" ]]; then
+			echo "$techs_raw"
+		else
+			print_warning "Could not extract technologies from report"
+		fi
+	fi
+
+	return 0
+}
+
+# Parse Lighthouse scores from HTML report
+parse_lighthouse() {
+	local html="$1"
+	local json_output="${2:-false}"
+
+	if [[ -z "$html" ]]; then
+		print_warning "No HTML content to parse"
+		return 1
+	fi
+
+	# Extract Lighthouse scores from the HTML
+	# Scores appear near category labels as plain numbers (0-100)
+	# The page has Desktop scores first, then Mobile scores
+	local performance accessibility best_practices seo
+
+	# Helper: extract number following a label (portable, no grep -P)
+	_extract_score() {
+		local label="$1"
+		local occurrence="${2:-1}"
+		echo "$html" | sed -n "s/.*${label}[^0-9]*\([0-9]\{1,3\}\).*/\1/p" | sed -n "${occurrence}p"
+	}
+
+	# Desktop scores (first occurrence)
+	performance=$(_extract_score "Performance" 1) || performance=""
+	accessibility=$(_extract_score "Accessibility" 1) || accessibility=""
+	best_practices=$(_extract_score "Best Practices" 1) || best_practices=""
+	seo=$(_extract_score "SEO" 1) || seo=""
+
+	# Mobile scores (second occurrence)
+	local m_performance m_accessibility m_best_practices m_seo
+	m_performance=$(_extract_score "Performance" 2) || m_performance=""
+	m_accessibility=$(_extract_score "Accessibility" 2) || m_accessibility=""
+	m_best_practices=$(_extract_score "Best Practices" 2) || m_best_practices=""
+	m_seo=$(_extract_score "SEO" 2) || m_seo=""
+
+	if [[ "$json_output" == "true" ]]; then
+		cat <<ENDJSON
+{
+  "desktop": {
+    "performance": ${performance:-null},
+    "accessibility": ${accessibility:-null},
+    "best_practices": ${best_practices:-null},
+    "seo": ${seo:-null}
+  },
+  "mobile": {
+    "performance": ${m_performance:-null},
+    "accessibility": ${m_accessibility:-null},
+    "best_practices": ${m_best_practices:-null},
+    "seo": ${m_seo:-null}
+  }
+}
+ENDJSON
+	else
+		print_header "Lighthouse Scores"
+		echo ""
+		echo "  Desktop:"
+		echo "    Performance:    ${performance:-N/A}"
+		echo "    Accessibility:  ${accessibility:-N/A}"
+		echo "    Best Practices: ${best_practices:-N/A}"
+		echo "    SEO:            ${seo:-N/A}"
+		echo ""
+		echo "  Mobile:"
+		echo "    Performance:    ${m_performance:-N/A}"
+		echo "    Accessibility:  ${m_accessibility:-N/A}"
+		echo "    Best Practices: ${m_best_practices:-N/A}"
+		echo "    SEO:            ${m_seo:-N/A}"
+	fi
+
+	return 0
+}
+
+# Parse meta tags from HTML report
+parse_meta() {
+	local html="$1"
+	local json_output="${2:-false}"
+
+	if [[ -z "$html" ]]; then
+		print_warning "No HTML content to parse"
+		return 1
+	fi
+
+	# Extract meta information from the report page
+	local title description og_image
+
+	# The report page includes the scanned site's meta info (portable sed extraction)
+	title=$(echo "$html" | sed -n 's/.*<meta property="og:title" content="\([^"]*\)".*/\1/p' | head -1) || title=""
+	description=$(echo "$html" | sed -n 's/.*<meta property="og:description" content="\([^"]*\)".*/\1/p' | head -1) || description=""
+	og_image=$(echo "$html" | sed -n 's/.*<meta property="og:image" content="\([^"]*\)".*/\1/p' | head -1) || og_image=""
+
+	if [[ "$json_output" == "true" ]]; then
+		local escaped_title escaped_desc
+		escaped_title=$(echo "$title" | sed 's/"/\\"/g')
+		escaped_desc=$(echo "$description" | sed 's/"/\\"/g')
+		cat <<ENDJSON
+{
+  "title": "$escaped_title",
+  "description": "$escaped_desc",
+  "og_image": "$og_image"
+}
+ENDJSON
+	else
+		print_header "Meta Tags"
+		echo ""
+		echo "  Title:       ${title:-N/A}"
+		echo "  Description: ${description:-N/A}"
+		echo "  OG Image:    ${og_image:-N/A}"
+	fi
+
+	return 0
+}
+
+# Full scan: tech stack + Lighthouse + meta tags
+crft_scan() {
+	local domain="$1"
+	local json_output="${2:-false}"
+
+	domain=$(normalize_domain "$domain")
+	local slug
+	slug=$(domain_to_slug "$domain")
+	local report_url="${CRFT_GALLERY_URL}/${slug}"
+
+	print_header "CRFT Lookup: $domain"
+	print_info "Report URL: $report_url"
+	echo ""
+
+	local html
+	html=$(fetch_gallery_report "$domain") || {
+		print_error "Could not fetch report for: $domain"
+		print_info "Try scanning manually at: ${CRFT_LOOKUP_URL}"
+		print_info "Then re-run this command after the report generates (~20s)"
+		return 1
+	}
+
+	if [[ -z "$html" ]]; then
+		print_error "Empty report for: $domain"
+		print_info "The site may not have been scanned yet."
+		print_info "Visit ${CRFT_LOOKUP_URL} and submit the URL first."
+		return 1
+	fi
+
+	if [[ "$json_output" == "true" ]]; then
+		local techs_json lighthouse_json meta_json
+		techs_json=$(parse_technologies "$html" "true")
+		lighthouse_json=$(parse_lighthouse "$html" "true")
+		meta_json=$(parse_meta "$html" "true")
+
+		jq -n \
+			--arg url "$domain" \
+			--arg report_url "$report_url" \
+			--argjson technologies "$techs_json" \
+			--argjson lighthouse "$lighthouse_json" \
+			--argjson meta "$meta_json" \
+			'{url: $url, report_url: $report_url, technologies: $technologies, lighthouse: $lighthouse, meta: $meta}'
+	else
+		parse_technologies "$html" "false"
+		echo ""
+		parse_lighthouse "$html" "false"
+		echo ""
+		parse_meta "$html" "false"
+		echo ""
+		print_info "Full report: $report_url"
+	fi
+
+	# Cache the report
+	local cache_file
+	cache_file="${REPORTS_DIR}/${slug}-$(date -u +%Y%m%d).html"
+	echo "$html" >"$cache_file" 2>/dev/null || true
+
+	return 0
+}
+
+# Technology detection only
+crft_techs() {
+	local domain="$1"
+	local json_output="${2:-false}"
+
+	domain=$(normalize_domain "$domain")
+
+	print_header "Tech Stack: $domain"
+	echo ""
+
+	local html
+	html=$(fetch_gallery_report "$domain") || {
+		print_error "Could not fetch report for: $domain"
+		return 1
+	}
+
+	if [[ -z "$html" ]]; then
+		print_error "Empty report for: $domain"
+		return 1
+	fi
+
+	parse_technologies "$html" "$json_output"
+	return 0
+}
+
+# Lighthouse scores only
+crft_lighthouse() {
+	local domain="$1"
+	local json_output="${2:-false}"
+
+	domain=$(normalize_domain "$domain")
+
+	local html
+	html=$(fetch_gallery_report "$domain") || {
+		print_error "Could not fetch report for: $domain"
+		return 1
+	}
+
+	if [[ -z "$html" ]]; then
+		print_error "Empty report for: $domain"
+		return 1
+	fi
+
+	parse_lighthouse "$html" "$json_output"
+	return 0
+}
+
+# Meta tags only
+crft_meta() {
+	local domain="$1"
+	local json_output="${2:-false}"
+
+	domain=$(normalize_domain "$domain")
+
+	local html
+	html=$(fetch_gallery_report "$domain") || {
+		print_error "Could not fetch report for: $domain"
+		return 1
+	}
+
+	if [[ -z "$html" ]]; then
+		print_error "Empty report for: $domain"
+		return 1
+	fi
+
+	parse_meta "$html" "$json_output"
+	return 0
+}
+
+# Compare two sites
+crft_compare() {
+	local domain1="$1"
+	local domain2="$2"
+	local json_output="${3:-false}"
+
+	domain1=$(normalize_domain "$domain1")
+	domain2=$(normalize_domain "$domain2")
+
+	print_header "Comparing: $domain1 vs $domain2"
+	echo ""
+
+	local html1 html2
+	html1=$(fetch_gallery_report "$domain1") || true
+	html2=$(fetch_gallery_report "$domain2") || true
+
+	if [[ -z "$html1" ]]; then
+		print_error "Could not fetch report for: $domain1"
+		return 1
+	fi
+
+	if [[ -z "$html2" ]]; then
+		print_error "Could not fetch report for: $domain2"
+		return 1
+	fi
+
+	if [[ "$json_output" == "true" ]]; then
+		local techs1 techs2 lh1 lh2
+		techs1=$(parse_technologies "$html1" "true")
+		techs2=$(parse_technologies "$html2" "true")
+		lh1=$(parse_lighthouse "$html1" "true")
+		lh2=$(parse_lighthouse "$html2" "true")
+
+		jq -n \
+			--arg site1 "$domain1" \
+			--arg site2 "$domain2" \
+			--argjson techs1 "$techs1" \
+			--argjson techs2 "$techs2" \
+			--argjson lighthouse1 "$lh1" \
+			--argjson lighthouse2 "$lh2" \
+			'{site1: $site1, site2: $site2, technologies: {site1: $techs1, site2: $techs2}, lighthouse: {site1: $lighthouse1, site2: $lighthouse2}}'
+	else
+		echo "--- $domain1 ---"
+		parse_technologies "$html1" "false"
+		echo ""
+		parse_lighthouse "$html1" "false"
+		echo ""
+		echo "--- $domain2 ---"
+		parse_technologies "$html2" "false"
+		echo ""
+		parse_lighthouse "$html2" "false"
+	fi
+
+	return 0
+}
+
+# Show report URL for a domain
+crft_report_url() {
+	local domain="$1"
+	domain=$(normalize_domain "$domain")
+	local slug
+	slug=$(domain_to_slug "$domain")
+	echo "${CRFT_GALLERY_URL}/${slug}"
+	return 0
+}
+
+# =============================================================================
 # Provider Management
 # =============================================================================
 
@@ -643,7 +1070,7 @@ install_provider() {
 		;;
 	*)
 		print_error "Unknown provider: ${provider}"
-		print_info "Available providers: openexplorer, unbuilt"
+		print_info "Available providers: openexplorer, unbuilt, crft"
 		return 1
 		;;
 	esac
@@ -663,6 +1090,10 @@ list_providers() {
 	echo "                Detects: bundlers, frameworks, UI libs, styling, state, analytics, monitoring"
 	echo "                CLI: npm install -g @unbuilt/cli"
 	echo "                Requires: Node.js 16+, Playwright Chromium (or --remote)"
+	echo ""
+	echo "  crft          CRFT Lookup - free, no API key required (2500+ techs)"
+	echo "                https://crft.studio/lookup"
+	echo "                Commands: scan, techs, lighthouse, meta, compare, report-url"
 	echo ""
 
 	# Show installation status
@@ -701,6 +1132,11 @@ compare_providers() {
 	run_unbuilt "$normalised" --json 2>/dev/null || echo "Unbuilt analysis unavailable"
 	echo ""
 
+	# CRFT Lookup
+	echo "--- CRFT Lookup ---"
+	crft_scan "$normalised" "false"
+	echo ""
+
 	print_info "Add more providers to tech-stack-helper.sh for cross-reference."
 	return 0
 }
@@ -723,13 +1159,23 @@ show_help() {
 	echo "  compare <url>                 Compare results across all providers"
 	echo "  install <provider>            Install a provider CLI"
 	echo ""
-	echo "  openexplorer search <url>     Search by URL"
-	echo "  openexplorer tech <name>      Search by technology name"
-	echo "  openexplorer category <name>  Search by category"
-	echo "  openexplorer analyse <url>    Full analysis via Playwright"
+	echo "  OpenExplorer Commands:"
+	echo "    openexplorer search <url>     Search by URL"
+	echo "    openexplorer tech <name>      Search by technology name"
+	echo "    openexplorer category <name>  Search by category"
+	echo "    openexplorer analyse <url>    Full analysis via Playwright"
 	echo ""
-	echo "  unbuilt <url> [flags]         Analyse a URL with Unbuilt.app CLI"
-	echo "  normalise                     Normalise unbuilt JSON (stdin) to common schema (stdout)"
+	echo "  Unbuilt Commands:"
+	echo "    unbuilt <url> [flags]         Analyse a URL with Unbuilt.app CLI"
+	echo "    normalise                     Normalise unbuilt JSON (stdin) to common schema (stdout)"
+	echo ""
+	echo "  CRFT Lookup Commands:"
+	echo "    crft scan <domain>            Full analysis (tech + Lighthouse + meta)"
+	echo "    crft techs <domain>           Technology detection only"
+	echo "    crft lighthouse <domain>      Lighthouse scores only"
+	echo "    crft meta <domain>            Meta tag preview only"
+	echo "    crft compare <domain1> <domain2>  Compare two sites"
+	echo "    crft report-url <domain>      Show report URL"
 	echo ""
 	echo "${HELP_LABEL_OPTIONS}"
 	echo "  --page <n>                    Page number (default: 1)"
@@ -740,6 +1186,7 @@ show_help() {
 	echo "  --timeout, -t <secs>          Max wait time (default: 120)"
 	echo "  --session                     Use local Chrome profile for auth"
 	echo "  --refresh                     Force fresh analysis (bypass cache)"
+	echo "  --category <cat>              Filter techs by category"
 	echo ""
 	echo "${HELP_LABEL_EXAMPLES}"
 	echo "  tech-stack-helper.sh openexplorer search github.com"
@@ -747,6 +1194,9 @@ show_help() {
 	echo "  tech-stack-helper.sh openexplorer analyse https://example.com"
 	echo "  tech-stack-helper.sh unbuilt https://example.com"
 	echo "  tech-stack-helper.sh unbuilt https://example.com --json | tech-stack-helper.sh normalise"
+	echo "  tech-stack-helper.sh crft scan basecamp.com"
+	echo "  tech-stack-helper.sh crft techs linear.app --json"
+	echo "  tech-stack-helper.sh crft compare basecamp.com notion.com"
 	echo "  tech-stack-helper.sh providers"
 	echo "  tech-stack-helper.sh compare github.com"
 	echo "  tech-stack-helper.sh install unbuilt"
@@ -818,6 +1268,102 @@ main() {
 		;;
 	unbuilt)
 		run_unbuilt "$@"
+		;;
+	crft)
+		local command="${1:-help}"
+		shift || true
+
+		# Parse arguments
+		local target=""
+		local target2=""
+		local json_output=false
+		local category=""
+
+		local opt
+		while [[ $# -gt 0 ]]; do
+			opt="$1"
+			case "$opt" in
+			--json | -j)
+				json_output=true
+				shift
+				;;
+			--category | -c)
+				category="${2:-}"
+				shift 2
+				;;
+			-*)
+				print_error "Unknown option: $opt"
+				return 1
+				;;
+			*)
+				if [[ -z "$target" ]]; then
+					target="$opt"
+				elif [[ -z "$target2" ]]; then
+					target2="$opt"
+				fi
+				shift
+				;;
+			esac
+		done
+
+		case "$command" in
+		"scan" | "analyze" | "check")
+			if [[ -z "$target" ]]; then
+				print_error "Domain required"
+				print_info "Usage: tech-stack-helper.sh crft scan <domain>"
+				return 1
+			fi
+			crft_scan "$target" "$json_output"
+			;;
+		"techs" | "technologies" | "tech" | "stack")
+			if [[ -z "$target" ]]; then
+				print_error "Domain required"
+				print_info "Usage: tech-stack-helper.sh crft techs <domain>"
+				return 1
+			fi
+			crft_techs "$target" "$json_output"
+			;;
+		"lighthouse" | "lh" | "scores" | "performance")
+			if [[ -z "$target" ]]; then
+				print_error "Domain required"
+				print_info "Usage: tech-stack-helper.sh crft lighthouse <domain>"
+				return 1
+			fi
+			crft_lighthouse "$target" "$json_output"
+			;;
+		"meta" | "metatags" | "og")
+			if [[ -z "$target" ]]; then
+				print_error "Domain required"
+				print_info "Usage: tech-stack-helper.sh crft meta <domain>"
+				return 1
+			fi
+			crft_meta "$target" "$json_output"
+			;;
+		"compare" | "diff" | "vs")
+			if [[ -z "$target" || -z "$target2" ]]; then
+				print_error "Two domains required"
+				print_info "Usage: tech-stack-helper.sh crft compare <domain1> <domain2>"
+				return 1
+			fi
+			crft_compare "$target" "$target2" "$json_output"
+			;;
+		"report-url" | "url" | "link")
+			if [[ -z "$target" ]]; then
+				print_error "Domain required"
+				print_info "Usage: tech-stack-helper.sh crft report-url <domain>"
+				return 1
+			fi
+			crft_report_url "$target"
+			;;
+		"help" | "-h" | "--help" | "")
+			show_help
+			;;
+		*)
+			print_error "Unknown crft command: $command"
+			print_info "Use 'tech-stack-helper.sh help' for usage information"
+			return 1
+			;;
+		esac
 		;;
 	*)
 		print_error "Unknown provider: $provider"

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -48,6 +48,7 @@ tools/ai-generation/,AI generation management - ComfyUI install nodes models wor
 tools/video/,Video creation and generation - programmatic editing and AI generation APIs,remotion|higgsfield|runway|wavespeed|yt-dlp|video-prompt-design|real-video-enhancer
 tools/vision/,Vision AI - image generation understanding and editing with local and cloud models,overview|image-generation|image-understanding|image-editing
 tools/voice/,Voice AI - TTS/STT/S2S model catalog voice bridge Pipecat pipeline and cloud voice agents,voice-models|voice-ai-models|speech-to-speech|cloud-voice-agents|voice-bridge|hyprwhspr|pipecat-opencode|transcription|buzz|qwen3-tts
+tools/research/,Website research - tech stack detection and analysis providers,providers/crft-lookup
 tools/data-extraction/,Data extraction - scraping business data,outscraper
 tools/deployment/,Deployment automation - self-hosted PaaS and orchestration,coolify|coolify-cli|vercel|cloudron-app-packaging|uncloud
 tools/git/,Git operations - GitHub/GitLab/Gitea CLIs and diff tools,github-cli|gitlab-cli|gitea-cli|github-actions|worktrunk|lumen|jujutsu|conflict-resolution
@@ -108,6 +109,7 @@ stagehand-helper.sh,Browser automation with Stagehand
 crawl4ai-helper.sh,Web crawling and extraction
 watercrawl-helper.sh,WaterCrawl cloud API for web crawling and search
 domain-research-helper.sh,DNS intelligence (rDNS subdomains CNAMEs)
+tech-stack-helper.sh,Website tech stack detection via CRFT Lookup (scan techs lighthouse meta compare)
 toon-helper.sh,TOON format conversion
 sonarcloud-cli.sh,SonarCloud analysis
 quality-sweep-helper.sh,Unified quality debt sweep (SonarCloud Codacy CodeFactor findings)

--- a/.agents/tools/research/providers/crft-lookup.md
+++ b/.agents/tools/research/providers/crft-lookup.md
@@ -1,0 +1,261 @@
+---
+description: CRFT Lookup tech stack detection, Lighthouse scores, meta tags, and sitemap visualization
+mode: subagent
+model: sonnet
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# CRFT Lookup - Tech Stack Detection Provider
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Detect website tech stacks, Lighthouse scores, meta tags, and sitemap structure
+- **Service**: [crft.studio/lookup](https://crft.studio/lookup) (free, no API key required)
+- **Helper**: `~/.aidevops/agents/scripts/tech-stack-helper.sh`
+- **Provider**: `crft` (default provider in tech-stack-helper.sh)
+
+**Capabilities**:
+
+| Feature | Details |
+|---------|---------|
+| Tech detection | 2500+ fingerprints (frameworks, CMS, analytics, hosting, CDN) |
+| Lighthouse | Performance, accessibility, SEO, best practices (desktop + mobile) |
+| Meta tags | OG tags, Twitter cards, search engine previews |
+| Sitemap | Interactive tree visualization, page hierarchy |
+| Reports | Shareable URLs, 30-day retention |
+
+**Quick Commands**:
+
+```bash
+# Full analysis (tech stack + Lighthouse + meta tags)
+tech-stack-helper.sh scan example.com
+
+# Tech stack detection only
+tech-stack-helper.sh techs example.com
+
+# Lighthouse scores only
+tech-stack-helper.sh lighthouse example.com
+
+# Meta tag preview
+tech-stack-helper.sh meta example.com
+
+# JSON output
+tech-stack-helper.sh scan example.com --json
+
+# Compare two sites
+tech-stack-helper.sh compare site1.com site2.com
+```
+
+**Complementary Tools**:
+
+| Tool | Strength | Use Together |
+|------|----------|-------------|
+| PageSpeed Insights | Detailed performance metrics | CRFT for overview, PSI for deep dive |
+| Wappalyzer | Browser extension, real-time | CRFT for batch/CLI analysis |
+| BuiltWith | Historical data, market share | CRFT for current snapshot |
+| Unbuilt | Broader but shallower detection | CRFT for deeper fingerprinting |
+
+<!-- AI-CONTEXT-END -->
+
+## Overview
+
+CRFT Lookup is a free website analysis tool from [CRFT Studio](https://crft.studio) that consolidates technology detection, performance scoring, meta tag previews, and sitemap visualization into a single report. It uses headless Chromium with a Wappalyzer-fork fingerprint database of 2500+ technologies.
+
+### How It Works
+
+1. Submit a URL to `crft.studio/lookup`
+2. CRFT spins up a headless Chromium instance
+3. Visits the website and analyzes HTML, JavaScript variables, response headers
+4. Compares against 2500+ technology fingerprints
+5. Runs Google Lighthouse for performance metrics
+6. Extracts meta tags and sitemap structure
+7. Generates a shareable report (retained 30 days)
+
+### Report URL Structure
+
+Reports are accessible at: `https://crft.studio/lookup/gallery/{domain-slug}`
+
+Example: `https://crft.studio/lookup/gallery/basecamp` for `basecamp.com`
+
+The gallery page shows pre-generated reports. For fresh scans, the tool submits the URL through the web interface and waits for the report to generate (~20 seconds).
+
+## Detection Categories
+
+### Technology Stack
+
+- **JavaScript frameworks**: React, Vue, Svelte, Angular, Next.js, Nuxt, Astro, Stimulus, etc.
+- **CMS platforms**: WordPress, Contentful, Sanity, Strapi, Ghost, etc.
+- **Analytics**: Google Analytics, Plausible, PostHog, Hotjar, Mixpanel, etc.
+- **Advertising**: Google Ads, Facebook Pixel, LinkedIn Insight Tag, etc.
+- **Marketing automation**: Mailchimp, HubSpot, Intercom, Drift, etc.
+- **CDN/Hosting**: Cloudflare, Vercel, Netlify, AWS, Akamai, Fastly, etc.
+- **E-commerce**: Shopify, WooCommerce, Stripe, etc.
+- **Email**: Mailchimp, SendGrid, Postmark, etc.
+- **Miscellaneous**: Open Graph, Schema.org, PWA, etc.
+
+### Lighthouse Scores
+
+Four categories scored 0-100 for both desktop and mobile:
+
+| Category | What It Measures |
+|----------|-----------------|
+| Performance | Loading speed, interactivity, visual stability |
+| Accessibility | WCAG compliance, screen reader support |
+| Best Practices | Security, modern APIs, console errors |
+| SEO | Meta tags, crawlability, mobile-friendliness |
+
+### Meta Tags
+
+- **Title**: Page title with character count
+- **Description**: Meta description with character count
+- **Open Graph**: Image, title, description for social sharing
+- **Twitter Cards**: Twitter-specific meta tags
+- **Favicon**: Site icon detection
+
+## Usage
+
+### Basic Scan
+
+```bash
+# Scan a website (returns tech stack + Lighthouse + meta)
+tech-stack-helper.sh scan example.com
+
+# Output includes:
+# - Detected technologies grouped by category
+# - Lighthouse scores (desktop + mobile)
+# - Meta tag summary
+# - Report URL for full details
+```
+
+### Technology Detection
+
+```bash
+# List detected technologies
+tech-stack-helper.sh techs example.com
+
+# Filter by category
+tech-stack-helper.sh techs example.com --category frameworks
+tech-stack-helper.sh techs example.com --category analytics
+tech-stack-helper.sh techs example.com --category cms
+```
+
+### Lighthouse Scores
+
+```bash
+# Get Lighthouse scores
+tech-stack-helper.sh lighthouse example.com
+
+# Desktop only
+tech-stack-helper.sh lighthouse example.com --strategy desktop
+
+# Mobile only
+tech-stack-helper.sh lighthouse example.com --strategy mobile
+```
+
+### Comparison
+
+```bash
+# Compare tech stacks of two sites
+tech-stack-helper.sh compare site1.com site2.com
+
+# Output shows:
+# - Technologies unique to each site
+# - Technologies in common
+# - Lighthouse score comparison
+```
+
+### JSON Output
+
+```bash
+# Machine-readable output
+tech-stack-helper.sh scan example.com --json
+
+# JSON schema:
+# {
+#   "url": "example.com",
+#   "report_url": "https://crft.studio/lookup/gallery/example",
+#   "technologies": [
+#     {"name": "React", "category": "JavaScript frameworks", "description": "..."}
+#   ],
+#   "lighthouse": {
+#     "desktop": {"performance": 98, "accessibility": 100, "best_practices": 100, "seo": 100},
+#     "mobile": {"performance": 74, "accessibility": 100, "best_practices": 100, "seo": 100}
+#   },
+#   "meta": {
+#     "title": "...",
+#     "description": "...",
+#     "og_image": "..."
+#   }
+# }
+```
+
+## Integration with Other Agents
+
+### With SEO Analysis
+
+```bash
+# Get tech stack and Lighthouse scores for SEO audit
+tech-stack-helper.sh scan client-site.com --json | jq '.lighthouse'
+
+# Cross-reference with PageSpeed for detailed metrics
+pagespeed-helper.sh run client-site.com
+```
+
+### With Competitor Research
+
+```bash
+# Analyze competitor tech stacks
+for site in competitor1.com competitor2.com competitor3.com; do
+  tech-stack-helper.sh techs "$site" --json
+done
+
+# Compare your site against a competitor
+tech-stack-helper.sh compare mysite.com competitor.com
+```
+
+### With Domain Research
+
+```bash
+# Discover subdomains, then check their tech stacks
+domain-research-helper.sh subdomains example.com | while read -r sub; do
+  tech-stack-helper.sh techs "$sub" 2>/dev/null
+done
+```
+
+## Limitations
+
+- **Public sites only**: Cannot scan localhost, intranet, or password-protected pages
+- **No API**: Web-only interface; helper script uses web scraping
+- **Report retention**: Reports expire after 30 days
+- **Rate limiting**: No documented rate limits, but be respectful (~5s between scans)
+- **Scan time**: ~20 seconds per scan (headless Chromium + Lighthouse)
+- **Gallery only**: Pre-scanned sites available instantly; new scans require submission
+
+## Alternatives Comparison
+
+| Feature | CRFT Lookup | Wappalyzer | BuiltWith | PageSpeed Insights |
+|---------|-------------|------------|-----------|-------------------|
+| Tech detection | 2500+ | 1000+ | 50000+ | No |
+| Lighthouse scores | Yes | No | No | Yes (detailed) |
+| Meta tag preview | Yes | No | No | No |
+| Sitemap visualization | Yes | No | No | No |
+| API | No (web only) | Yes (paid) | Yes (paid) | Yes (free) |
+| Price | Free | Freemium | Paid | Free |
+| CLI | Via helper | Browser ext | No | Via npm |
+
+## Related Agents
+
+- `tools/browser/pagespeed.md` - Detailed Lighthouse analysis
+- `seo/site-crawler.md` - Website crawling
+- `seo/domain-research.md` - DNS intelligence
+- `tools/browser/browser-automation.md` - Browser automation for scraping


### PR DESCRIPTION
## Summary

- Add CRFT Lookup provider subagent (`tools/research/providers/crft-lookup.md`) documenting the free tech stack detection service (2500+ fingerprints, Lighthouse scores, meta tags, sitemap visualization)
- Create `tech-stack-helper.sh` CLI for scanning websites via CRFT Lookup gallery reports — supports `scan`, `techs`, `lighthouse`, `meta`, `compare` commands with `--json` output
- Register new subagent and script in `subagent-index.toon`

## Details

CRFT Lookup (crft.studio/lookup) is a free Wappalyzer alternative that consolidates tech detection, Lighthouse scoring, meta tag previews, and sitemap visualization into shareable reports (30-day retention). The helper script fetches gallery report pages and parses technologies, scores, and meta tags using portable sed/grep (no grep -P, works on macOS).

Complementary to existing tools: PageSpeed Insights for deep performance metrics, domain-research-helper for DNS intelligence.

## Testing

- ShellCheck clean (zero violations)
- Portable parsing verified (no Perl regex, macOS-compatible)
- Script follows existing helper conventions (shared-constants.sh, standard help/error patterns)

Ref #1526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced CRFT Lookup provider for website tech stack detection and analysis
  * Added commands: `crft scan`, `techs`, `lighthouse`, `meta`, `compare`, and `report-url`
  * Detect technologies, Lighthouse scores, and meta tags from websites
  * Compare tech stacks across multiple domains
  * JSON output support for all commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->