### PR TITLE
t1071: Fix pulse Phase 3b2 crash on mergedAt:null

### DIFF
--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -587,8 +587,8 @@ cmd_pulse() {
 				fi
 
 				local pr_state pr_merged_at
-				pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4)
-				pr_merged_at=$(echo "$pr_json" | grep -o '"mergedAt":"[^"]*"' | cut -d'"' -f4)
+				pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4 || echo "")
+				pr_merged_at=$(echo "$pr_json" | grep -o '"mergedAt":"[^"]*"' | cut -d'"' -f4 || echo "")
 
 				if [[ "$pr_state" == "MERGED" ]]; then
 					local escaped_stale_id
@@ -1985,7 +1985,7 @@ cmd_triage() {
 		fi
 
 		local pr_state
-		pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4)
+		pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4 || echo "")
 
 		case "$pr_state" in
 		MERGED)


### PR DESCRIPTION
## Summary

- Fix critical bug where `grep -o '"mergedAt":"[^"]*"'` returns exit code 1 when `mergedAt` is `null` (not a quoted string), killing the entire pulse under `set -euo pipefail`
- This prevented Phase 3.5 (rebase retry) and Phase 3.6 (opus escalation) from ever executing, causing 5+ merge-conflict blocked tasks to stall indefinitely
- Add `|| echo ""` fallback to all `grep -o` PR field extractions (lines 590, 591, 1988)

## Testing

```bash
# Verified under set -euo pipefail:
# mergedAt:null -> pr_merged_at="" (no crash)
# mergedAt:"2026-..." -> pr_merged_at="2026-..." (still works)
```

## Impact

Unblocks: t1063, t1063.1, t1064, t1065, t1068 (all stuck in `blocked` with merge conflicts because rebase retry phase never ran)

Closes #1552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved robustness in internal PR processing to better handle edge cases with missing or incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->