### PR TITLE
t1071: Fix pulse Phase 3b2 crash on mergedAt:null

### DIFF
--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -588,7 +588,7 @@ cmd_pulse() {
 
 				local pr_state pr_merged_at
 				pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4)
-				pr_merged_at=$(echo "$pr_json" | grep -o '"mergedAt":"[^"]*"' | cut -d'"' -f4)
+				pr_merged_at=$(echo "$pr_json" | grep -o '"mergedAt":"[^"]*"' | cut -d'"' -f4 || true)
 
 				if [[ "$pr_state" == "MERGED" ]]; then
 					local escaped_stale_id


### PR DESCRIPTION
## Summary

- Fix crash in supervisor pulse Phase 3b2 when `gh pr view` returns `"mergedAt":null` for unmerged PRs
- The `grep` pipeline extracting `mergedAt` failed with exit 1 (no match), which propagated through `set -o pipefail` and triggered `set -e`, crashing the entire pulse cycle
- Added `|| true` to the pipeline so an empty `pr_merged_at` is returned gracefully — downstream code already handles empty values (used only in log messages and proof-log evidence)

## Root Cause

`pulse.sh:591` used `grep -o '"mergedAt":"[^"]*"'` to extract the merge timestamp. When GitHub returns `"mergedAt":null` (unquoted null, not a string), the regex has no match, grep exits 1, pipefail propagates it, and `set -e` aborts the function.

## Verification

Tested all three scenarios under `set -eo pipefail`:
- `mergedAt:null` (OPEN/CLOSED PR) — returns empty string, no crash
- `mergedAt:"2025-..."` (MERGED PR) — returns timestamp correctly
- ShellCheck passes clean

Ref #1552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system reliability by fixing a potential script failure when certain pull request metadata fields are unavailable, ensuring more stable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->