### PR TITLE
t1071: Fix GIT_EDITOR for headless rebase --continue

### DIFF
--- a/.agents/scripts/supervisor/deploy.sh
+++ b/.agents/scripts/supervisor/deploy.sh
@@ -2169,6 +2169,11 @@ rebase_sibling_pr() {
 
 	log_info "rebase_sibling_pr: rebasing $task_id ($tbranch) onto main..."
 
+	# Prevent git rebase --continue from opening an editor (nano/vim) for
+	# commit messages — in cron/headless environments TERM is unset, causing
+	# "error: there was a problem with the editor 'nano'" and aborting the rebase.
+	export GIT_EDITOR=true
+
 	# Fetch latest main
 	if ! git -C "$trepo" fetch origin main 2>>"$SUPERVISOR_LOG"; then
 		log_warn "rebase_sibling_pr: failed to fetch origin main for $task_id"

--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -587,8 +587,8 @@ cmd_pulse() {
 				fi
 
 				local pr_state pr_merged_at
-				pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4)
-				pr_merged_at=$(echo "$pr_json" | grep -o '"mergedAt":"[^"]*"' | cut -d'"' -f4)
+				pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4 || echo "")
+				pr_merged_at=$(echo "$pr_json" | grep -o '"mergedAt":"[^"]*"' | cut -d'"' -f4 || echo "")
 
 				if [[ "$pr_state" == "MERGED" ]]; then
 					local escaped_stale_id
@@ -1985,7 +1985,7 @@ cmd_triage() {
 		fi
 
 		local pr_state
-		pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4)
+		pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4 || echo "")
 
 		case "$pr_state" in
 		MERGED)


### PR DESCRIPTION
## Summary

- Fix `git rebase --continue` failing in cron/headless environments because `TERM` is unset and git tries to open `nano` for commit message editing
- Set `GIT_EDITOR=true` at the top of `rebase_sibling_pr()` to accept default commit messages without an editor
- This was the second bug preventing merge-conflict rebases — the first (mergedAt:null crash, PR #1553) prevented reaching Phase 3.5, and this one prevented the actual rebase from completing

## Root Cause

```
TERM environment variable not set.
error: there was a problem with the editor 'nano'
Please supply the message using either -m or -F option.
error: could not commit staged changes.
```

## Impact

Unblocks: t1063, t1063.1, t1064, t1065, t1068 — all had successful AI conflict resolution but failed at `git rebase --continue`

Related: #1553 (first fix in this chain)
Closes #1552