### PR TITLE
t1077: Fix ShellCheck SC2034 warnings across 9 files

### DIFF
--- a/.agents/scripts/code-audit-helper.sh
+++ b/.agents/scripts/code-audit-helper.sh
@@ -1389,7 +1389,6 @@ main() {
 	check-regression) cmd_check_regression "$@" ;;
 	status) cmd_status "$@" ;;
 	reset) cmd_reset "$@" ;;
-	check-regression) cmd_check_regression "$@" ;;
 	help | --help | -h) show_help ;;
 	*)
 		log_error "$ERROR_UNKNOWN_COMMAND $command"

--- a/.agents/scripts/coderabbit-cli.sh
+++ b/.agents/scripts/coderabbit-cli.sh
@@ -33,8 +33,6 @@ source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
 # Colors for output
 readonly GREEN='\033[0;32m'
 readonly BLUE='\033[0;34m'
-readonly YELLOW='\033[1;33m'
-readonly RED='\033[0;31m'
 readonly PURPLE='\033[0;35m'
 readonly NC='\033[0m' # No Color
 

--- a/.agents/scripts/setup/_backup.sh
+++ b/.agents/scripts/setup/_backup.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 # Backup and rotation functions for setup.sh
 
-# Backup rotation settings
-BACKUP_KEEP_COUNT=10
-
 # Create a backup with rotation (keeps last N backups)
 # Usage: create_backup_with_rotation <source_path> <backup_name>
 # Example: create_backup_with_rotation "$target_dir" "agents"

--- a/.agents/scripts/sonarcloud-autofix.sh
+++ b/.agents/scripts/sonarcloud-autofix.sh
@@ -11,10 +11,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
 
 # Colors for output
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
-readonly BLUE='\033[0;34m'
-readonly YELLOW='\033[1;33m'
 readonly PURPLE='\033[0;35m'
 readonly NC='\033[0m'
 

--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -173,6 +173,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # but left the globals defined after the source block, causing
 # "PULSE_LOCK_DIR: unbound variable" errors in cron pulse (t1031 regression).
 readonly SUPERVISOR_DIR="${AIDEVOPS_SUPERVISOR_DIR:-$HOME/.aidevops/.agent-workspace/supervisor}"
+# shellcheck disable=SC2034 # Used by sourced supervisor/ modules
 readonly SUPERVISOR_DB="$SUPERVISOR_DIR/supervisor.db"
 readonly MAIL_HELPER="${SCRIPT_DIR}/mail-helper.sh"                             # Used by pulse command (t128.2)
 readonly MEMORY_HELPER="${SCRIPT_DIR}/memory-helper.sh"                         # Used by pulse command (t128.6)
@@ -180,7 +181,8 @@ readonly SESSION_REVIEW_HELPER="${SCRIPT_DIR}/session-review-helper.sh"         
 readonly SESSION_DISTILL_HELPER="${SCRIPT_DIR}/session-distill-helper.sh"       # Used by batch completion (t128.9)
 readonly MEMORY_AUDIT_HELPER="${SCRIPT_DIR}/memory-audit-pulse.sh"              # Used by pulse Phase 9 (t185)
 readonly SESSION_CHECKPOINT_HELPER="${SCRIPT_DIR}/session-checkpoint-helper.sh" # Used by respawn (t264.1)
-readonly RESPAWN_LOG="${HOME}/.aidevops/logs/respawn-history.log"               # Persistent respawn log (t264.1)
+# shellcheck disable=SC2034 # Used by supervisor/utility.sh
+readonly RESPAWN_LOG="${HOME}/.aidevops/logs/respawn-history.log" # Persistent respawn log (t264.1)
 SUPERVISOR_LOG_DIR="${HOME}/.aidevops/logs"
 mkdir -p "$SUPERVISOR_LOG_DIR" 2>/dev/null || true
 SUPERVISOR_LOG="${SUPERVISOR_LOG_DIR}/supervisor.log"
@@ -211,10 +213,12 @@ source "${SUPERVISOR_MODULE_DIR}/memory-integration.sh"
 source "${SUPERVISOR_MODULE_DIR}/todo-sync.sh"
 
 # Valid states for the state machine
+# shellcheck disable=SC2034 # Used by supervisor/state.sh
 readonly VALID_STATES="queued dispatched running evaluating retrying complete pr_review review_triage merging merged deploying deployed verifying verified verify_failed blocked failed cancelled"
 
 # Valid state transitions (from:to pairs)
 # Format: "from_state:to_state" - checked by validate_transition()
+# shellcheck disable=SC2034 # Used by supervisor/state.sh
 readonly -a VALID_TRANSITIONS=(
 	"queued:dispatched"
 	"queued:cancelled"
@@ -266,7 +270,9 @@ readonly -a VALID_TRANSITIONS=(
 	"verified:cancelled"
 )
 
+# shellcheck disable=SC2034 # Used by sourced supervisor/ modules
 readonly BOLD='\033[1m'
+# shellcheck disable=SC2034 # Used by supervisor/utility.sh
 readonly DIM='\033[2m'
 
 # log_info, log_success, log_warn, log_error, log_verbose, sql_escape, db, log_cmd

--- a/.agents/scripts/supervisor/deploy.sh
+++ b/.agents/scripts/supervisor/deploy.sh
@@ -2318,7 +2318,7 @@ rebase_sibling_prs_after_merge() {
 	local fail_count=0
 	local skip_count=0
 
-	while IFS='|' read -r sid sstatus spr sbranch sworktree srepo; do
+	while IFS='|' read -r sid sstatus _spr sbranch _sworktree _srepo; do
 		# Only rebase siblings that have open PRs and are in states where
 		# their branch is still active (not yet merged/deployed/cancelled)
 		case "$sstatus" in

--- a/.agents/scripts/supervisor/dispatch.sh
+++ b/.agents/scripts/supervisor/dispatch.sh
@@ -4,7 +4,6 @@
 # Functions for dispatching tasks to workers, resolving models,
 # quality gates, and building dispatch commands
 
-
 #######################################
 # Detect terminal environment for dispatch mode
 # Returns: "tabby", "headless", or "interactive"
@@ -584,8 +583,8 @@ check_output_quality() {
 		return 0
 	fi
 
-	local tlog tworktree tbranch trepo tpr_url
-	IFS='|' read -r tlog tworktree tbranch trepo tpr_url <<<"$task_row"
+	local tlog tworktree _tbranch trepo tpr_url
+	IFS='|' read -r tlog tworktree _tbranch trepo tpr_url <<<"$task_row"
 
 	# Check 1: Log file size — very small logs suggest trivial/empty output
 	if [[ -n "$tlog" && -f "$tlog" ]]; then
@@ -1431,8 +1430,8 @@ cmd_dispatch() {
 		return 1
 	fi
 
-	local tid trepo tdesc tstatus tmodel tretries tmax_retries
-	IFS=$'\t' read -r tid trepo tdesc tstatus tmodel tretries tmax_retries <<<"$task_row"
+	local _tid trepo tdesc tstatus tmodel tretries tmax_retries
+	IFS=$'\t' read -r _tid trepo tdesc tstatus tmodel tretries tmax_retries <<<"$task_row"
 
 	# Validate task is in dispatchable state
 	if [[ "$tstatus" != "queued" ]]; then
@@ -2050,8 +2049,8 @@ cmd_reprompt() {
 		return 1
 	fi
 
-	local tid trepo tdesc tstatus tsession tworktree tlog tretries tmax_retries terror
-	IFS='|' read -r tid trepo tdesc tstatus tsession tworktree tlog tretries tmax_retries terror <<<"$task_row"
+	local _tid trepo tdesc tstatus tsession tworktree tlog tretries tmax_retries terror
+	IFS='|' read -r _tid trepo tdesc tstatus tsession tworktree tlog tretries tmax_retries terror <<<"$task_row"
 
 	# Validate state - must be in retrying state
 	if [[ "$tstatus" != "retrying" ]]; then

--- a/.agents/scripts/tech-stack-helper.sh
+++ b/.agents/scripts/tech-stack-helper.sh
@@ -64,9 +64,6 @@ readonly DEFAULT_LIMIT=25
 readonly MAX_LIMIT=1000
 readonly DEFAULT_CLIENT="desktop"
 readonly REPORTS_DIR="${HOME}/.aidevops/.agent-workspace/work/tech-stack/reports"
-SCRIPT_NAME="$(basename "$0")" || true
-readonly SCRIPT_NAME
-readonly UNBUILT_PKG="@unbuilt/cli"
 readonly UNBUILT_TIMEOUT="${UNBUILT_TIMEOUT:-120}"
 
 # BigQuery configuration
@@ -80,18 +77,9 @@ readonly BQ_TABLE_CATEGORIES="categories"
 
 # BuiltWith configuration
 readonly BUILTWITH_API_BASE="https://api.builtwith.com"
-readonly BUILTWITH_FREE_BASE="https://trends.builtwith.com"
-
-# CRFT Lookup Configuration
-readonly CRFT_BASE_URL="https://crft.studio"
-readonly CRFT_LOOKUP_URL="${CRFT_BASE_URL}/lookup"
-readonly CRFT_GALLERY_URL="${CRFT_BASE_URL}/lookup/gallery"
-readonly CRFT_SCAN_TIMEOUT=60
 
 # Common message constants
 readonly HELP_SHOW_MESSAGE="Show this help"
-readonly USAGE_COMMAND_OPTIONS="Usage: $0 <command> [options]"
-readonly HELP_USAGE_INFO="Use '$0 help' for usage information"
 
 # Technology categories for structured output (referenced by provider helpers)
 # shellcheck disable=SC2034 # exported for provider helper scripts
@@ -2414,7 +2402,7 @@ main() {
 			log_error "Technology name is required. Usage: tech-stack-helper.sh info <technology>"
 			return 1
 		fi
-		cmd_info "$technology" ${positional[@]:1+"${positional[@]:1}"}
+		cmd_info "$technology" "${positional[@]:1}"
 		;;
 	help | -h | --help)
 		print_usage

--- a/.agents/scripts/test-orphan-cleanup.sh
+++ b/.agents/scripts/test-orphan-cleanup.sh
@@ -4,7 +4,6 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEST_DIR="/tmp/t253-test-$$"
 
 cleanup_test() {


### PR DESCRIPTION
## Summary

Fix ShellCheck SC2034 (unused variable), SC2068 (unquoted array), and SC2221/SC2222 (duplicate case pattern) warnings across 9 shell scripts.

Ref #1571

## Changes

| File | Findings | Fix |
|------|----------|-----|
| `tech-stack-helper.sh` | 8 SC2034 + 1 SC2068 | Remove 9 unused constants, quote array expansion |
| `supervisor-helper.sh` | 6 SC2034 | Add `# shellcheck disable=SC2034` — vars used by sourced modules |
| `sonarcloud-autofix.sh` | 4 SC2034 | Remove unused color constants (RED, GREEN, BLUE, YELLOW) |
| `supervisor/deploy.sh` | 3 SC2034 | Prefix unused IFS-read vars with `_` |
| `supervisor/dispatch.sh` | 3 SC2034 | Prefix unused IFS-read vars with `_` |
| `coderabbit-cli.sh` | 2 SC2034 | Remove unused color constants (YELLOW, RED) |
| `code-audit-helper.sh` | 1 SC2221 + 1 SC2222 | Remove duplicate `check-regression` case pattern |
| `setup/_backup.sh` | 1 SC2034 | Remove unused `BACKUP_KEEP_COUNT` |
| `test-orphan-cleanup.sh` | 1 SC2034 | Remove unused `SCRIPT_DIR` |

**Total**: 30 findings resolved across 9 files.

## Fix strategy

- **Truly unused variables**: Removed (constants defined but never referenced)
- **Used by sourced modules**: Added `# shellcheck disable=SC2034` with comment explaining which module uses them (supervisor-helper.sh defines globals consumed by supervisor/*.sh modules)
- **IFS read destructuring**: Prefixed unused positional vars with `_` (standard convention for intentionally unused variables)
- **Duplicate case pattern**: Removed the shadowed duplicate
- **SC2068**: Properly double-quoted array expansion

## Verification

All 9 files pass `shellcheck -x -S warning` with zero SC2034/SC2068/SC2221/SC2222 findings.