### PR TITLE
t1083: Update sonnet tier to Claude Sonnet 4.6

### DIFF
--- a/.agents/configs/fallback-chain-config.json.txt
+++ b/.agents/configs/fallback-chain-config.json.txt
@@ -12,27 +12,27 @@
       "anthropic/claude-haiku-4-5"
     ],
     "sonnet": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
     "pro": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
     "opus": [
       "anthropic/claude-opus-4-6"
     ],
     "coding": [
       "anthropic/claude-opus-4-6",
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
     "eval": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
     "health": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
 
     "default": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ]
   },
 

--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -20,7 +20,7 @@
 #     "name": "build-agent-tests",
 #     "description": "Tests for build-agent subagent",
 #     "agent": "Build+",
-#     "model": "anthropic/claude-sonnet-4-20250514",
+#     "model": "anthropic/claude-sonnet-4-6",
 #     "timeout": 120,
 #     "tests": [
 #       {
@@ -279,7 +279,7 @@ run_prompt_opencode_server() {
     # Build prompt payload with optional model override
     local prompt_json
     if [[ -n "$model" ]]; then
-        # Parse provider/model format (e.g., "anthropic/claude-sonnet-4-20250514")
+        # Parse provider/model format (e.g., "anthropic/claude-sonnet-4-6")
         local provider_id model_id
         provider_id="${model%%/*}"
         model_id="${model#*/}"
@@ -1036,7 +1036,7 @@ TEST SUITE FORMAT (JSON):
     "name": "suite-name",
     "description": "What this tests",
     "agent": "Build+",
-    "model": "anthropic/claude-sonnet-4-20250514",
+    "model": "anthropic/claude-sonnet-4-6",
     "timeout": 120,
     "tests": [
       {

--- a/.agents/scripts/contest-helper.sh
+++ b/.agents/scripts/contest-helper.sh
@@ -35,7 +35,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Default contest models — top 3 from different providers for diversity
-DEFAULT_CONTEST_MODELS="anthropic/claude-opus-4-6,anthropic/claude-sonnet-4-5,google/gemini-2.5-pro"
+DEFAULT_CONTEST_MODELS="anthropic/claude-opus-4-6,anthropic/claude-sonnet-4-6,google/gemini-2.5-pro"
 
 # Scoring weights (match response-scoring-helper.sh)
 WEIGHT_CORRECTNESS=30

--- a/.agents/scripts/cron-dispatch.sh
+++ b/.agents/scripts/cron-dispatch.sh
@@ -273,7 +273,7 @@ main() {
 	task=$(echo "$job" | jq -r '.task')
 	workdir=$(echo "$job" | jq -r '.workdir')
 	timeout=$(echo "$job" | jq -r '.timeout // 600')
-	model=$(echo "$job" | jq -r '.model // "anthropic/claude-sonnet-4-20250514"')
+	model=$(echo "$job" | jq -r '.model // "anthropic/claude-sonnet-4-6"')
 	notify=$(echo "$job" | jq -r '.notify // "none"')
 
 	# Resolve tier names to full model strings (t132.7)

--- a/.agents/scripts/cron-helper.sh
+++ b/.agents/scripts/cron-helper.sh
@@ -34,7 +34,7 @@ readonly SCRIPTS_DIR="$HOME/.aidevops/agents/scripts"
 readonly OPENCODE_PORT="${OPENCODE_PORT:-4096}"
 readonly OPENCODE_HOST="${OPENCODE_HOST:-127.0.0.1}"
 readonly OPENCODE_INSECURE="${OPENCODE_INSECURE:-}"
-readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-20250514"
+readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
 
 # shellcheck disable=SC2034  # CYAN reserved for future use
 readonly BOLD='\033[1m'

--- a/.agents/scripts/document-extraction-helper.sh
+++ b/.agents/scripts/document-extraction-helper.sh
@@ -527,7 +527,7 @@ resolve_llm_backend() {
 		elif [[ -n "${OPENAI_API_KEY:-}" ]]; then
 			llm_backend="openai/gpt-4o"
 		elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-			llm_backend="anthropic/claude-sonnet-4-20250514"
+			llm_backend="anthropic/claude-sonnet-4-6"
 		else
 			print_warning "No cloud API key found, falling back to local"
 			if command -v ollama &>/dev/null; then

--- a/.agents/scripts/fallback-chain-helper.sh
+++ b/.agents/scripts/fallback-chain-helper.sh
@@ -259,12 +259,12 @@ get_chain_for_tier() {
     case "$tier" in
         haiku)  tier_spec='["anthropic/claude-haiku-4-5"]' ;;
         flash)  tier_spec='["anthropic/claude-haiku-4-5"]' ;;
-        sonnet) tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
-        pro)    tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
+        sonnet) tier_spec='["anthropic/claude-sonnet-4-6"]' ;;
+        pro)    tier_spec='["anthropic/claude-sonnet-4-6"]' ;;
         opus)   tier_spec='["anthropic/claude-opus-4-6"]' ;;
-        coding) tier_spec='["anthropic/claude-opus-4-6","anthropic/claude-sonnet-4-5"]' ;;
-        eval)   tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
-        health) tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
+        coding) tier_spec='["anthropic/claude-opus-4-6","anthropic/claude-sonnet-4-6"]' ;;
+        eval)   tier_spec='["anthropic/claude-sonnet-4-6"]' ;;
+        health) tier_spec='["anthropic/claude-sonnet-4-6"]' ;;
         *)
             print_error "Unknown tier: $tier"
             return 1

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -217,7 +217,7 @@ SKIP_CUSTOM_PROMPT = set()
 # Agents declare their tier; the coordinator uses this for cost-effective routing
 MODEL_TIERS = {
     "haiku": "claude-3-5-haiku-20241022",      # Triage, routing, simple tasks
-    "sonnet": "claude-sonnet-4-20250514",      # Code, review, implementation
+    "sonnet": "claude-sonnet-4-6",      # Code, review, implementation
     "opus": "claude-opus-4-20250514",          # Architecture, complex reasoning
     "flash": "gemini-2.5-flash",               # Fast, cheap, large context
     "pro": "gemini-2.5-pro",                   # Capable, large context

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -117,11 +117,11 @@ get_tier_models() {
         case "$tier" in
             haiku)  echo "opencode/claude-3-5-haiku|opencode/gemini-3-flash" ;;
             flash)  echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
-            sonnet) echo "opencode/claude-sonnet-4|anthropic/claude-sonnet-4-20250514" ;;
+            sonnet) echo "opencode/claude-sonnet-4|anthropic/claude-sonnet-4-6" ;;
             pro)    echo "google/gemini-2.5-pro|opencode/gemini-3-pro" ;;
             opus)   echo "opencode/claude-opus-4-6|anthropic/claude-opus-4-6" ;;
-            health) echo "opencode/claude-sonnet-4-5|google/gemini-2.5-flash" ;;
-            eval)   echo "opencode/claude-sonnet-4-5|google/gemini-2.5-flash" ;;
+            health) echo "opencode/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+            eval)   echo "opencode/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
             coding) echo "opencode/claude-opus-4-6|anthropic/claude-opus-4-6" ;;
             *) return 1 ;;
         esac
@@ -129,11 +129,11 @@ get_tier_models() {
         case "$tier" in
             haiku)  echo "anthropic/claude-3-5-haiku-20241022|google/gemini-2.5-flash" ;;
             flash)  echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
-            sonnet) echo "anthropic/claude-sonnet-4-20250514|openai/gpt-4.1" ;;
-            pro)    echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-20250514" ;;
+            sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-4.1" ;;
+            pro)    echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;
             opus)   echo "anthropic/claude-opus-4-6|openai/o3" ;;
-            health) echo "anthropic/claude-sonnet-4-5|google/gemini-2.5-flash" ;;
-            eval)   echo "anthropic/claude-sonnet-4-5|google/gemini-2.5-flash" ;;
+            health) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+            eval)   echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
             coding) echo "anthropic/claude-opus-4-6|openai/o3" ;;
             *) return 1 ;;
         esac
@@ -1378,7 +1378,7 @@ cmd_help() {
     echo "  model-availability-helper.sh check anthropic"
     echo "  model-availability-helper.sh check opencode"
     echo "  model-availability-helper.sh check opencode/claude-sonnet-4"
-    echo "  model-availability-helper.sh check anthropic/claude-sonnet-4-20250514"
+    echo "  model-availability-helper.sh check anthropic/claude-sonnet-4-6"
     echo "  model-availability-helper.sh check sonnet"
     echo "  model-availability-helper.sh probe --all"
     echo "  model-availability-helper.sh resolve opus --json"

--- a/.agents/scripts/model-label-helper.sh
+++ b/.agents/scripts/model-label-helper.sh
@@ -56,7 +56,7 @@ ACTIONS:
     planned, researched, implemented, reviewed, verified, documented, failed, retried
 
 MODELS:
-    haiku, flash, sonnet, pro, opus (or concrete model names like claude-sonnet-4-5)
+    haiku, flash, sonnet, pro, opus (or concrete model names like claude-sonnet-4-6)
 
 EXAMPLES:
     # Add label when dispatching a task
@@ -92,7 +92,7 @@ EOF
 #######################################
 # Normalize model name to tier
 # Arguments:
-#   $1 - Model name (e.g., claude-sonnet-4-5, sonnet, gpt-4)
+#   $1 - Model name (e.g., claude-sonnet-4-6, sonnet, gpt-4)
 # Returns:
 #   Normalized tier name (haiku, flash, sonnet, pro, opus)
 #######################################

--- a/.agents/scripts/model-registry-helper.sh
+++ b/.agents/scripts/model-registry-helper.sh
@@ -43,7 +43,7 @@ init_log_file
 
 readonly REGISTRY_DIR="${HOME}/.aidevops/.agent-workspace"
 readonly REGISTRY_DB="${REGISTRY_DIR}/model-registry.db"
-readonly SYNC_INTERVAL=86400  # 24 hours in seconds
+readonly SYNC_INTERVAL=86400 # 24 hours in seconds
 readonly AGENTS_DIR="${SCRIPT_DIR}/.."
 readonly MODELS_DIR="${AGENTS_DIR}/tools/ai-assistants/models"
 
@@ -52,9 +52,9 @@ readonly MODELS_DIR="${AGENTS_DIR}/tools/ai-assistants/models"
 # =============================================================================
 
 init_db() {
-    mkdir -p "$REGISTRY_DIR" 2>/dev/null || true
+	mkdir -p "$REGISTRY_DIR" 2>/dev/null || true
 
-    sqlite3 "$REGISTRY_DB" "
+	sqlite3 "$REGISTRY_DB" "
         CREATE TABLE IF NOT EXISTS models (
             model_id       TEXT NOT NULL,
             provider       TEXT NOT NULL,
@@ -106,10 +106,10 @@ init_db() {
             details        TEXT DEFAULT ''
         );
     " 2>/dev/null || {
-        print_error "Failed to initialize registry database"
-        return 1
-    }
-    return 0
+		print_error "Failed to initialize registry database"
+		return 1
+	}
+	return 0
 }
 
 # =============================================================================
@@ -119,18 +119,18 @@ init_db() {
 # e.g., "claude-3-5-haiku" and "claude-haiku-3.5" both normalize to "claude-haiku"
 
 normalize_model_name() {
-    local name="$1"
-    # Strip provider prefix
-    name="${name#*/}"
-    # Strip date suffixes (e.g., -20250514, -20241022)
-    name="${name%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
-    # Strip preview suffixes (e.g., -preview-05-20)
-    name=$(echo "$name" | sed -E 's/-preview-[0-9]{2}-[0-9]{2}$//')
-    # Strip version numbers (e.g., -3-5, -3.5, -4, -2.5, -2.0)
-    name=$(echo "$name" | sed -E 's/-[0-9]+(\.[0-9]+)?//g')
-    # Lowercase
-    echo "$name" | tr '[:upper:]' '[:lower:]'
-    return 0
+	local name="$1"
+	# Strip provider prefix
+	name="${name#*/}"
+	# Strip date suffixes (e.g., -20250514, -20241022)
+	name="${name%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
+	# Strip preview suffixes (e.g., -preview-05-20)
+	name=$(echo "$name" | sed -E 's/-preview-[0-9]{2}-[0-9]{2}$//')
+	# Strip version numbers (e.g., -3-5, -3.5, -4, -2.5, -2.0)
+	name=$(echo "$name" | sed -E 's/-[0-9]+(\.[0-9]+)?//g')
+	# Lowercase
+	echo "$name" | tr '[:upper:]' '[:lower:]'
+	return 0
 }
 
 # =============================================================================
@@ -138,27 +138,27 @@ normalize_model_name() {
 # =============================================================================
 
 sql_escape() {
-    local val="$1"
-    echo "${val//\'/\'\'}"
-    return 0
+	local val="$1"
+	echo "${val//\'/\'\'}"
+	return 0
 }
 
 db_query() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" "$REGISTRY_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" "$REGISTRY_DB" "$query" 2>/dev/null
+	return $?
 }
 
 db_query_csv() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" -csv -header "$REGISTRY_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" -csv -header "$REGISTRY_DB" "$query" 2>/dev/null
+	return $?
 }
 
 db_query_json() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" -json "$REGISTRY_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" -json "$REGISTRY_DB" "$query" 2>/dev/null
+	return $?
 }
 
 # =============================================================================
@@ -166,72 +166,72 @@ db_query_json() {
 # =============================================================================
 
 sync_subagents() {
-    local added=0
-    local updated=0
+	local added=0
+	local updated=0
 
-    if [[ ! -d "$MODELS_DIR" ]]; then
-        print_warning "Models directory not found: $MODELS_DIR"
-        return 0
-    fi
+	if [[ ! -d "$MODELS_DIR" ]]; then
+		print_warning "Models directory not found: $MODELS_DIR"
+		return 0
+	fi
 
-    local md_file
-    for md_file in "$MODELS_DIR"/*.md; do
-        [[ ! -f "$md_file" ]] && continue
-        local basename_file
-        basename_file=$(basename "$md_file")
+	local md_file
+	for md_file in "$MODELS_DIR"/*.md; do
+		[[ ! -f "$md_file" ]] && continue
+		local basename_file
+		basename_file=$(basename "$md_file")
 
-        # Skip README and non-model files
-        [[ "$basename_file" == "README.md" ]] && continue
-        [[ "$basename_file" == *"-reviewer.md" ]] && continue
+		# Skip README and non-model files
+		[[ "$basename_file" == "README.md" ]] && continue
+		[[ "$basename_file" == *"-reviewer.md" ]] && continue
 
-        # Extract frontmatter fields
-        local model_full="" model_tier="" model_fallback=""
-        local in_frontmatter=false
-        local line_num=0
+		# Extract frontmatter fields
+		local model_full="" model_tier="" model_fallback=""
+		local in_frontmatter=false
+		local line_num=0
 
-        while IFS= read -r line; do
-            line_num=$((line_num + 1))
-            if [[ $line_num -eq 1 && "$line" == "---" ]]; then
-                in_frontmatter=true
-                continue
-            fi
-            if [[ "$in_frontmatter" == "true" && "$line" == "---" ]]; then
-                break
-            fi
-            if [[ "$in_frontmatter" == "true" ]]; then
-                case "$line" in
-                    model:*)
-                        model_full="${line#model:}"
-                        model_full="${model_full#"${model_full%%[![:space:]]*}"}"
-                        ;;
-                    model-tier:*)
-                        model_tier="${line#model-tier:}"
-                        model_tier="${model_tier#"${model_tier%%[![:space:]]*}"}"
-                        ;;
-                    model-fallback:*)
-                        model_fallback="${line#model-fallback:}"
-                        model_fallback="${model_fallback#"${model_fallback%%[![:space:]]*}"}"
-                        ;;
-                esac
-            fi
-        done < "$md_file"
+		while IFS= read -r line; do
+			line_num=$((line_num + 1))
+			if [[ $line_num -eq 1 && "$line" == "---" ]]; then
+				in_frontmatter=true
+				continue
+			fi
+			if [[ "$in_frontmatter" == "true" && "$line" == "---" ]]; then
+				break
+			fi
+			if [[ "$in_frontmatter" == "true" ]]; then
+				case "$line" in
+				model:*)
+					model_full="${line#model:}"
+					model_full="${model_full#"${model_full%%[![:space:]]*}"}"
+					;;
+				model-tier:*)
+					model_tier="${line#model-tier:}"
+					model_tier="${model_tier#"${model_tier%%[![:space:]]*}"}"
+					;;
+				model-fallback:*)
+					model_fallback="${line#model-fallback:}"
+					model_fallback="${model_fallback#"${model_fallback%%[![:space:]]*}"}"
+					;;
+				esac
+			fi
+		done <"$md_file"
 
-        if [[ -z "$model_tier" || -z "$model_full" ]]; then
-            continue
-        fi
+		if [[ -z "$model_tier" || -z "$model_full" ]]; then
+			continue
+		fi
 
-        # Extract short model_id from full ID (e.g., anthropic/claude-sonnet-4-20250514 -> claude-sonnet-4)
-        local model_short
-        model_short="${model_full#*/}"
-        # Strip trailing date suffix (e.g., -20250514)
-        model_short="${model_short%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
+		# Extract short model_id from full ID (e.g., anthropic/claude-sonnet-4-6 -> claude-sonnet-4)
+		local model_short
+		model_short="${model_full#*/}"
+		# Strip trailing date suffix (e.g., -20250514)
+		model_short="${model_short%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
 
-        # Compute normalized name for fuzzy matching
-        local norm_name
-        norm_name=$(normalize_model_name "$model_full")
+		# Compute normalized name for fuzzy matching
+		local norm_name
+		norm_name=$(normalize_model_name "$model_full")
 
-        # Upsert into subagent_models
-        db_query "
+		# Upsert into subagent_models
+		db_query "
             INSERT INTO subagent_models (tier, model_id, model_full_id, normalized_name, fallback_id, subagent_file, last_synced)
             VALUES (
                 '$(sql_escape "$model_tier")',
@@ -250,16 +250,16 @@ sync_subagents() {
                 subagent_file = excluded.subagent_file,
                 last_synced = excluded.last_synced;
         " && updated=$((updated + 1))
-    done
+	done
 
-    # Log sync
-    db_query "
+	# Log sync
+	db_query "
         INSERT INTO sync_log (sync_type, source, models_added, models_updated, details)
         VALUES ('subagents', 'frontmatter', $added, $updated, 'Synced from $MODELS_DIR');
     "
 
-    print_info "Subagent sync: $updated tiers updated from frontmatter"
-    return 0
+	print_info "Subagent sync: $updated tiers updated from frontmatter"
+	return 0
 }
 
 # =============================================================================
@@ -267,71 +267,71 @@ sync_subagents() {
 # =============================================================================
 
 sync_embedded() {
-    local added=0
-    local updated=0
+	local added=0
+	local updated=0
 
-    # Source the model data from compare-models-helper.sh
-    local compare_helper="${SCRIPT_DIR}/compare-models-helper.sh"
-    if [[ ! -f "$compare_helper" ]]; then
-        print_warning "compare-models-helper.sh not found"
-        return 0
-    fi
+	# Source the model data from compare-models-helper.sh
+	local compare_helper="${SCRIPT_DIR}/compare-models-helper.sh"
+	if [[ ! -f "$compare_helper" ]]; then
+		print_warning "compare-models-helper.sh not found"
+		return 0
+	fi
 
-    # Extract MODEL_DATA from compare-models-helper.sh
-    local model_data=""
-    local in_model_data=false
-    while IFS= read -r line; do
-        if [[ "$line" == 'readonly MODEL_DATA="'* ]]; then
-            in_model_data=true
-            model_data="${line#*=\"}"
-            # Check if single-line
-            if [[ "$model_data" == *'"' ]]; then
-                model_data="${model_data%\"}"
-                break
-            fi
-            continue
-        fi
-        if [[ "$in_model_data" == "true" ]]; then
-            if [[ "$line" == *'"' ]]; then
-                model_data="${model_data}
+	# Extract MODEL_DATA from compare-models-helper.sh
+	local model_data=""
+	local in_model_data=false
+	while IFS= read -r line; do
+		if [[ "$line" == 'readonly MODEL_DATA="'* ]]; then
+			in_model_data=true
+			model_data="${line#*=\"}"
+			# Check if single-line
+			if [[ "$model_data" == *'"' ]]; then
+				model_data="${model_data%\"}"
+				break
+			fi
+			continue
+		fi
+		if [[ "$in_model_data" == "true" ]]; then
+			if [[ "$line" == *'"' ]]; then
+				model_data="${model_data}
 ${line%\"}"
-                break
-            fi
-            model_data="${model_data}
+				break
+			fi
+			model_data="${model_data}
 ${line}"
-        fi
-    done < "$compare_helper"
+		fi
+	done <"$compare_helper"
 
-    if [[ -z "$model_data" ]]; then
-        print_warning "Could not extract MODEL_DATA from compare-models-helper.sh"
-        return 0
-    fi
+	if [[ -z "$model_data" ]]; then
+		print_warning "Could not extract MODEL_DATA from compare-models-helper.sh"
+		return 0
+	fi
 
-    # Parse and upsert each model
-    while IFS= read -r line; do
-        [[ -z "$line" ]] && continue
+	# Parse and upsert each model
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
 
-        local model_id provider display_name ctx input output tier caps best_for
-        model_id=$(echo "$line" | cut -d'|' -f1)
-        provider=$(echo "$line" | cut -d'|' -f2)
-        display_name=$(echo "$line" | cut -d'|' -f3)
-        ctx=$(echo "$line" | cut -d'|' -f4)
-        input=$(echo "$line" | cut -d'|' -f5)
-        output=$(echo "$line" | cut -d'|' -f6)
-        tier=$(echo "$line" | cut -d'|' -f7)
-        caps=$(echo "$line" | cut -d'|' -f8)
-        best_for=$(echo "$line" | cut -d'|' -f9)
+		local model_id provider display_name ctx input output tier caps best_for
+		model_id=$(echo "$line" | cut -d'|' -f1)
+		provider=$(echo "$line" | cut -d'|' -f2)
+		display_name=$(echo "$line" | cut -d'|' -f3)
+		ctx=$(echo "$line" | cut -d'|' -f4)
+		input=$(echo "$line" | cut -d'|' -f5)
+		output=$(echo "$line" | cut -d'|' -f6)
+		tier=$(echo "$line" | cut -d'|' -f7)
+		caps=$(echo "$line" | cut -d'|' -f8)
+		best_for=$(echo "$line" | cut -d'|' -f9)
 
-        # Compute normalized name for fuzzy matching
-        local norm_name
-        norm_name=$(normalize_model_name "$model_id")
+		# Compute normalized name for fuzzy matching
+		local norm_name
+		norm_name=$(normalize_model_name "$model_id")
 
-        # Check if model already exists
-        local existing
-        existing=$(db_query "SELECT model_id FROM models WHERE model_id='$(sql_escape "$model_id")' AND provider='$(sql_escape "$provider")';")
+		# Check if model already exists
+		local existing
+		existing=$(db_query "SELECT model_id FROM models WHERE model_id='$(sql_escape "$model_id")' AND provider='$(sql_escape "$provider")';")
 
-        if [[ -n "$existing" ]]; then
-            db_query "
+		if [[ -n "$existing" ]]; then
+			db_query "
                 UPDATE models SET
                     display_name = '$(sql_escape "$display_name")',
                     normalized_name = '$(sql_escape "$norm_name")',
@@ -345,9 +345,9 @@ ${line}"
                     source = 'embedded'
                 WHERE model_id = '$(sql_escape "$model_id")' AND provider = '$(sql_escape "$provider")';
             "
-            updated=$((updated + 1))
-        else
-            db_query "
+			updated=$((updated + 1))
+		else
+			db_query "
                 INSERT INTO models (model_id, provider, display_name, normalized_name, context_window, input_price, output_price, tier, capabilities, best_for, source)
                 VALUES (
                     '$(sql_escape "$model_id")',
@@ -361,17 +361,17 @@ ${line}"
                     'embedded'
                 );
             "
-            added=$((added + 1))
-        fi
-    done <<< "$model_data"
+			added=$((added + 1))
+		fi
+	done <<<"$model_data"
 
-    db_query "
+	db_query "
         INSERT INTO sync_log (sync_type, source, models_added, models_updated, details)
         VALUES ('embedded', 'compare-models-helper.sh', $added, $updated, 'Parsed MODEL_DATA');
     "
 
-    print_info "Embedded sync: $added added, $updated updated from compare-models-helper.sh"
-    return 0
+	print_info "Embedded sync: $added added, $updated updated from compare-models-helper.sh"
+	return 0
 }
 
 # =============================================================================
@@ -383,24 +383,24 @@ ${line}"
 # API keys (OpenCode routes through its gateway for opencode/* models).
 
 sync_opencode() {
-    local added=0
+	local added=0
 
-    # Check if opencode CLI is available
-    if ! command -v opencode &>/dev/null; then
-        print_info "OpenCode CLI not found, skipping opencode model sync"
-        return 0
-    fi
+	# Check if opencode CLI is available
+	if ! command -v opencode &>/dev/null; then
+		print_info "OpenCode CLI not found, skipping opencode model sync"
+		return 0
+	fi
 
-    # Try the cached models file first (instant, no network)
-    local cache_file="${HOME}/.cache/opencode/models.json"
-    local model_ids=""
+	# Try the cached models file first (instant, no network)
+	local cache_file="${HOME}/.cache/opencode/models.json"
+	local model_ids=""
 
-    # Only extract models from providers we track (avoids processing 2500+ models
-    # from the full models.dev registry — we only need ~100 from relevant providers)
-    local relevant_providers='["anthropic","openai","google","openrouter","groq","deepseek","opencode"]'
+	# Only extract models from providers we track (avoids processing 2500+ models
+	# from the full models.dev registry — we only need ~100 from relevant providers)
+	local relevant_providers='["anthropic","openai","google","openrouter","groq","deepseek","opencode"]'
 
-    if [[ -f "$cache_file" && -s "$cache_file" ]]; then
-        model_ids=$(jq -r --argjson providers "$relevant_providers" '
+	if [[ -f "$cache_file" && -s "$cache_file" ]]; then
+		model_ids=$(jq -r --argjson providers "$relevant_providers" '
             to_entries[] |
             select(.key as $k | $providers | index($k)) |
             .key as $provider |
@@ -408,46 +408,46 @@ sync_opencode() {
             keys[] |
             "\($provider)/\(.)"
         ' "$cache_file" 2>/dev/null) || true
-    fi
+	fi
 
-    # Fallback: use opencode models CLI if cache is empty or missing
-    if [[ -z "$model_ids" ]]; then
-        print_info "  Cache miss, querying opencode models CLI..."
-        model_ids=$(timeout "$DEFAULT_TIMEOUT" opencode models 2>/dev/null \
-            | grep -E '^(anthropic|openai|google|openrouter|groq|deepseek|opencode)/' | sort) || true
-    fi
+	# Fallback: use opencode models CLI if cache is empty or missing
+	if [[ -z "$model_ids" ]]; then
+		print_info "  Cache miss, querying opencode models CLI..."
+		model_ids=$(timeout "$DEFAULT_TIMEOUT" opencode models 2>/dev/null |
+			grep -E '^(anthropic|openai|google|openrouter|groq|deepseek|opencode)/' | sort) || true
+	fi
 
-    if [[ -z "$model_ids" ]]; then
-        print_warning "No models discovered from OpenCode"
-        return 0
-    fi
+	if [[ -z "$model_ids" ]]; then
+		print_warning "No models discovered from OpenCode"
+		return 0
+	fi
 
-    # Build batch SQL for all models (much faster than individual queries)
-    local sql_batch="BEGIN TRANSACTION;"
-    while IFS= read -r full_id; do
-        [[ -z "$full_id" ]] && continue
-        # Skip non-text models (embeddings, tts, whisper, image-only)
-        case "$full_id" in
-            *embed*|*tts*|*whisper*|*dall-e*|*moderation*|*image*) continue ;;
-        esac
+	# Build batch SQL for all models (much faster than individual queries)
+	local sql_batch="BEGIN TRANSACTION;"
+	while IFS= read -r full_id; do
+		[[ -z "$full_id" ]] && continue
+		# Skip non-text models (embeddings, tts, whisper, image-only)
+		case "$full_id" in
+		*embed* | *tts* | *whisper* | *dall-e* | *moderation* | *image*) continue ;;
+		esac
 
-        local provider
-        provider="${full_id%%/*}"
+		local provider
+		provider="${full_id%%/*}"
 
-        # Normalize provider name to match our conventions
-        local norm_provider
-        case "$provider" in
-            anthropic)  norm_provider="Anthropic" ;;
-            openai)     norm_provider="OpenAI" ;;
-            google)     norm_provider="Google" ;;
-            openrouter) norm_provider="OpenRouter" ;;
-            groq)       norm_provider="Groq" ;;
-            deepseek)   norm_provider="DeepSeek" ;;
-            opencode)   norm_provider="OpenCode" ;;
-            *)          norm_provider="$provider" ;;
-        esac
+		# Normalize provider name to match our conventions
+		local norm_provider
+		case "$provider" in
+		anthropic) norm_provider="Anthropic" ;;
+		openai) norm_provider="OpenAI" ;;
+		google) norm_provider="Google" ;;
+		openrouter) norm_provider="OpenRouter" ;;
+		groq) norm_provider="Groq" ;;
+		deepseek) norm_provider="DeepSeek" ;;
+		opencode) norm_provider="OpenCode" ;;
+		*) norm_provider="$provider" ;;
+		esac
 
-        sql_batch="${sql_batch}
+		sql_batch="${sql_batch}
             INSERT INTO provider_models (model_id, provider, in_registry, in_subagents, discovered_at)
             VALUES (
                 '$(sql_escape "$full_id")',
@@ -457,20 +457,20 @@ sync_opencode() {
             )
             ON CONFLICT(model_id, provider) DO UPDATE SET
                 discovered_at = excluded.discovered_at;"
-        added=$((added + 1))
-    done <<< "$model_ids"
-    sql_batch="${sql_batch} COMMIT;"
+		added=$((added + 1))
+	done <<<"$model_ids"
+	sql_batch="${sql_batch} COMMIT;"
 
-    # Execute batch insert
-    db_query "$sql_batch"
+	# Execute batch insert
+	db_query "$sql_batch"
 
-    db_query "
+	db_query "
         INSERT INTO sync_log (sync_type, source, models_added, models_updated, details)
         VALUES ('opencode', 'opencode-models', $added, 0, 'Discovered from OpenCode model registry');
     "
 
-    print_info "OpenCode sync: $added models discovered"
-    return 0
+	print_info "OpenCode sync: $added models discovered"
+	return 0
 }
 
 # =============================================================================
@@ -480,120 +480,120 @@ sync_opencode() {
 # Requires individual provider API keys in environment.
 
 sync_providers() {
-    local added=0
+	local added=0
 
-    # Skip if opencode sync already ran successfully (check sync_log)
-    local opencode_synced
-    opencode_synced=$(db_query "
+	# Skip if opencode sync already ran successfully (check sync_log)
+	local opencode_synced
+	opencode_synced=$(db_query "
         SELECT models_added FROM sync_log
         WHERE sync_type = 'opencode'
         AND (julianday('now') - julianday(timestamp)) * 86400 < 60
         ORDER BY id DESC LIMIT 1;
     " 2>/dev/null || echo "")
-    
-    # If recent successful sync, skip
-    if [[ -n "$opencode_synced" && "$opencode_synced" != "0" ]]; then
-        return 0
-    fi
-    if [[ -n "$opencode_synced" && "$opencode_synced" -gt 0 ]]; then
-        print_info "Skipping direct API probing (OpenCode sync already discovered $opencode_synced models)"
-        return 0
-    fi
 
-    # Reuse provider key detection from compare-models-helper.sh
-    local provider_env_keys="Anthropic|ANTHROPIC_API_KEY
+	# If recent successful sync, skip
+	if [[ -n "$opencode_synced" && "$opencode_synced" != "0" ]]; then
+		return 0
+	fi
+	if [[ -n "$opencode_synced" && "$opencode_synced" -gt 0 ]]; then
+		print_info "Skipping direct API probing (OpenCode sync already discovered $opencode_synced models)"
+		return 0
+	fi
+
+	# Reuse provider key detection from compare-models-helper.sh
+	local provider_env_keys="Anthropic|ANTHROPIC_API_KEY
 OpenAI|OPENAI_API_KEY
 Google|GOOGLE_API_KEY,GEMINI_API_KEY
 OpenRouter|OPENROUTER_API_KEY
 Groq|GROQ_API_KEY
 DeepSeek|DEEPSEEK_API_KEY"
 
-    while IFS= read -r pline; do
-        local provider key_names
-        provider=$(echo "$pline" | cut -d'|' -f1)
-        key_names=$(echo "$pline" | cut -d'|' -f2)
+	while IFS= read -r pline; do
+		local provider key_names
+		provider=$(echo "$pline" | cut -d'|' -f1)
+		key_names=$(echo "$pline" | cut -d'|' -f2)
 
-        local key_value=""
-        local -a keys
-        IFS=',' read -ra keys <<< "$key_names"
-        for key_name in "${keys[@]}"; do
-            if [[ -n "${!key_name:-}" ]]; then
-                key_value="${!key_name}"
-                break
-            fi
-        done
+		local key_value=""
+		local -a keys
+		IFS=',' read -ra keys <<<"$key_names"
+		for key_name in "${keys[@]}"; do
+			if [[ -n "${!key_name:-}" ]]; then
+				key_value="${!key_name}"
+				break
+			fi
+		done
 
-        [[ -z "$key_value" ]] && continue
+		[[ -z "$key_value" ]] && continue
 
-        local models_json=""
-        case "$provider" in
-            Anthropic)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "x-api-key: ${key_value}" \
-                    -H "anthropic-version: 2023-06-01" \
-                    "https://api.anthropic.com/v1/models" 2>/dev/null) || continue
-                ;;
-            OpenAI)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "Authorization: Bearer ${key_value}" \
-                    "https://api.openai.com/v1/models" 2>/dev/null) || continue
-                ;;
-            Google)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    "https://generativelanguage.googleapis.com/v1beta/models?key=${key_value}" 2>/dev/null) || continue
-                ;;
-            OpenRouter)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "Authorization: Bearer ${key_value}" \
-                    "https://openrouter.ai/api/v1/models" 2>/dev/null) || continue
-                ;;
-            Groq)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "Authorization: Bearer ${key_value}" \
-                    "https://api.groq.com/openai/v1/models" 2>/dev/null) || continue
-                ;;
-            DeepSeek)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "Authorization: Bearer ${key_value}" \
-                    "https://api.deepseek.com/v1/models" 2>/dev/null) || continue
-                ;;
-            *)
-                continue
-                ;;
-        esac
+		local models_json=""
+		case "$provider" in
+		Anthropic)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "x-api-key: ${key_value}" \
+				-H "anthropic-version: 2023-06-01" \
+				"https://api.anthropic.com/v1/models" 2>/dev/null) || continue
+			;;
+		OpenAI)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "Authorization: Bearer ${key_value}" \
+				"https://api.openai.com/v1/models" 2>/dev/null) || continue
+			;;
+		Google)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				"https://generativelanguage.googleapis.com/v1beta/models?key=${key_value}" 2>/dev/null) || continue
+			;;
+		OpenRouter)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "Authorization: Bearer ${key_value}" \
+				"https://openrouter.ai/api/v1/models" 2>/dev/null) || continue
+			;;
+		Groq)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "Authorization: Bearer ${key_value}" \
+				"https://api.groq.com/openai/v1/models" 2>/dev/null) || continue
+			;;
+		DeepSeek)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "Authorization: Bearer ${key_value}" \
+				"https://api.deepseek.com/v1/models" 2>/dev/null) || continue
+			;;
+		*)
+			continue
+			;;
+		esac
 
-        [[ -z "$models_json" ]] && continue
+		[[ -z "$models_json" ]] && continue
 
-        # Extract model IDs
-        local model_ids=""
-        case "$provider" in
-            Google)
-                model_ids=$(echo "$models_json" | jq -r '.models[].name // empty' 2>/dev/null | sed 's|^models/||' | sort) || continue
-                ;;
-            *)
-                model_ids=$(echo "$models_json" | jq -r '.data[].id // empty' 2>/dev/null | sort) || continue
-                ;;
-        esac
+		# Extract model IDs
+		local model_ids=""
+		case "$provider" in
+		Google)
+			model_ids=$(echo "$models_json" | jq -r '.models[].name // empty' 2>/dev/null | sed 's|^models/||' | sort) || continue
+			;;
+		*)
+			model_ids=$(echo "$models_json" | jq -r '.data[].id // empty' 2>/dev/null | sort) || continue
+			;;
+		esac
 
-        [[ -z "$model_ids" ]] && continue
+		[[ -z "$model_ids" ]] && continue
 
-        local provider_count=0
-        while IFS= read -r mid; do
-            [[ -z "$mid" ]] && continue
+		local provider_count=0
+		while IFS= read -r mid; do
+			[[ -z "$mid" ]] && continue
 
-            # Check if this model is in our registry
-            local in_registry
-            in_registry=$(db_query "SELECT COUNT(*) FROM models WHERE model_id LIKE '%$(sql_escape "$mid")%' AND provider='$(sql_escape "$provider")';")
-            local in_reg_flag=0
-            [[ "$in_registry" -gt 0 ]] && in_reg_flag=1
+			# Check if this model is in our registry
+			local in_registry
+			in_registry=$(db_query "SELECT COUNT(*) FROM models WHERE model_id LIKE '%$(sql_escape "$mid")%' AND provider='$(sql_escape "$provider")';")
+			local in_reg_flag=0
+			[[ "$in_registry" -gt 0 ]] && in_reg_flag=1
 
-            # Check if referenced in subagents
-            local in_subagents
-            in_subagents=$(db_query "SELECT COUNT(*) FROM subagent_models WHERE model_full_id LIKE '%$(sql_escape "$mid")%';")
-            local in_sub_flag=0
-            [[ "$in_subagents" -gt 0 ]] && in_sub_flag=1
+			# Check if referenced in subagents
+			local in_subagents
+			in_subagents=$(db_query "SELECT COUNT(*) FROM subagent_models WHERE model_full_id LIKE '%$(sql_escape "$mid")%';")
+			local in_sub_flag=0
+			[[ "$in_subagents" -gt 0 ]] && in_sub_flag=1
 
-            db_query "
+			db_query "
                 INSERT INTO provider_models (model_id, provider, in_registry, in_subagents, discovered_at)
                 VALUES (
                     '$(sql_escape "$mid")',
@@ -607,20 +607,20 @@ DeepSeek|DEEPSEEK_API_KEY"
                     in_subagents = excluded.in_subagents,
                     discovered_at = excluded.discovered_at;
             "
-            provider_count=$((provider_count + 1))
-        done <<< "$model_ids"
+			provider_count=$((provider_count + 1))
+		done <<<"$model_ids"
 
-        added=$((added + provider_count))
-        print_info "  $provider: $provider_count models discovered"
-    done <<< "$provider_env_keys"
+		added=$((added + provider_count))
+		print_info "  $provider: $provider_count models discovered"
+	done <<<"$provider_env_keys"
 
-    db_query "
+	db_query "
         INSERT INTO sync_log (sync_type, source, models_added, models_updated, details)
         VALUES ('provider_api', 'live', $added, 0, 'Discovered from provider APIs');
     "
 
-    print_info "Provider sync: $added total models discovered from APIs"
-    return 0
+	print_info "Provider sync: $added total models discovered from APIs"
+	return 0
 }
 
 # =============================================================================
@@ -628,443 +628,473 @@ DeepSeek|DEEPSEEK_API_KEY"
 # =============================================================================
 
 cmd_sync() {
-    local force=false
-    local quiet=false
+	local force=false
+	local quiet=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --force) force=true; shift ;;
-            --quiet) quiet=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--force)
+			force=true
+			shift
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    # Check if sync is needed
-    if [[ "$force" != "true" ]]; then
-        local last_sync
-        last_sync=$(db_query "SELECT timestamp FROM sync_log ORDER BY id DESC LIMIT 1;" 2>/dev/null || echo "")
-        if [[ -n "$last_sync" ]]; then
-            local last_epoch now_epoch
-            if [[ "$(uname)" == "Darwin" ]]; then
-                last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
-            else
-                last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
-            fi
-            now_epoch=$(date "+%s")
-            local age=$((now_epoch - last_epoch))
-            if [[ $age -lt $SYNC_INTERVAL ]]; then
-                local hours_ago=$((age / 3600))
-                [[ "$quiet" != "true" ]] && print_info "Registry synced ${hours_ago}h ago (interval: $((SYNC_INTERVAL / 3600))h). Use --force to resync."
-                return 0
-            fi
-        fi
-    fi
+	# Check if sync is needed
+	if [[ "$force" != "true" ]]; then
+		local last_sync
+		last_sync=$(db_query "SELECT timestamp FROM sync_log ORDER BY id DESC LIMIT 1;" 2>/dev/null || echo "")
+		if [[ -n "$last_sync" ]]; then
+			local last_epoch now_epoch
+			if [[ "$(uname)" == "Darwin" ]]; then
+				last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
+			else
+				last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
+			fi
+			now_epoch=$(date "+%s")
+			local age=$((now_epoch - last_epoch))
+			if [[ $age -lt $SYNC_INTERVAL ]]; then
+				local hours_ago=$((age / 3600))
+				[[ "$quiet" != "true" ]] && print_info "Registry synced ${hours_ago}h ago (interval: $((SYNC_INTERVAL / 3600))h). Use --force to resync."
+				return 0
+			fi
+		fi
+	fi
 
-    [[ "$quiet" != "true" ]] && echo ""
-    [[ "$quiet" != "true" ]] && echo "Model Registry Sync"
-    [[ "$quiet" != "true" ]] && echo "==================="
-    [[ "$quiet" != "true" ]] && echo ""
+	[[ "$quiet" != "true" ]] && echo ""
+	[[ "$quiet" != "true" ]] && echo "Model Registry Sync"
+	[[ "$quiet" != "true" ]] && echo "==================="
+	[[ "$quiet" != "true" ]] && echo ""
 
-    # Backup before sync
-    if [[ -f "$REGISTRY_DB" ]]; then
-        backup_sqlite_db "$REGISTRY_DB" "pre-sync" >/dev/null 2>&1 || true
-    fi
+	# Backup before sync
+	if [[ -f "$REGISTRY_DB" ]]; then
+		backup_sqlite_db "$REGISTRY_DB" "pre-sync" >/dev/null 2>&1 || true
+	fi
 
-    # Phase 1: Sync subagent frontmatter
-    [[ "$quiet" != "true" ]] && print_info "Phase 1: Syncing subagent frontmatter..."
-    sync_subagents
+	# Phase 1: Sync subagent frontmatter
+	[[ "$quiet" != "true" ]] && print_info "Phase 1: Syncing subagent frontmatter..."
+	sync_subagents
 
-    # Phase 2: Sync embedded model data
-    [[ "$quiet" != "true" ]] && print_info "Phase 2: Syncing embedded model data..."
-    sync_embedded
+	# Phase 2: Sync embedded model data
+	[[ "$quiet" != "true" ]] && print_info "Phase 2: Syncing embedded model data..."
+	sync_embedded
 
-    # Phase 3: Sync from OpenCode model registry (preferred — fast, no API keys needed)
-    [[ "$quiet" != "true" ]] && print_info "Phase 3: Discovering models from OpenCode registry..."
-    sync_opencode
+	# Phase 3: Sync from OpenCode model registry (preferred — fast, no API keys needed)
+	[[ "$quiet" != "true" ]] && print_info "Phase 3: Discovering models from OpenCode registry..."
+	sync_opencode
 
-    # Phase 4: Fallback to direct provider API probing (skipped if Phase 3 succeeded)
-    [[ "$quiet" != "true" ]] && print_info "Phase 4: Direct provider API discovery (fallback)..."
-    sync_providers
+	# Phase 4: Fallback to direct provider API probing (skipped if Phase 3 succeeded)
+	[[ "$quiet" != "true" ]] && print_info "Phase 4: Direct provider API discovery (fallback)..."
+	sync_providers
 
-    # Cleanup old backups
-    cleanup_sqlite_backups "$REGISTRY_DB" 3
+	# Cleanup old backups
+	cleanup_sqlite_backups "$REGISTRY_DB" 3
 
-    [[ "$quiet" != "true" ]] && echo ""
-    [[ "$quiet" != "true" ]] && print_success "Registry sync complete"
-    return 0
+	[[ "$quiet" != "true" ]] && echo ""
+	[[ "$quiet" != "true" ]] && print_success "Registry sync complete"
+	return 0
 }
 
 cmd_list() {
-    local json_flag=false
-    local filter_provider=""
-    local filter_tier=""
+	local json_flag=false
+	local filter_provider=""
+	local filter_tier=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            --provider) filter_provider="${2:-}"; shift 2 ;;
-            --tier) filter_tier="${2:-}"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		--provider)
+			filter_provider="${2:-}"
+			shift 2
+			;;
+		--tier)
+			filter_tier="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    local where_clause="WHERE 1=1"
-    [[ -n "$filter_provider" ]] && where_clause="$where_clause AND provider='$(sql_escape "$filter_provider")'"
-    [[ -n "$filter_tier" ]] && where_clause="$where_clause AND tier='$(sql_escape "$filter_tier")'"
+	local where_clause="WHERE 1=1"
+	[[ -n "$filter_provider" ]] && where_clause="$where_clause AND provider='$(sql_escape "$filter_provider")'"
+	[[ -n "$filter_tier" ]] && where_clause="$where_clause AND tier='$(sql_escape "$filter_tier")'"
 
-    if [[ "$json_flag" == "true" ]]; then
-        db_query_json "
+	if [[ "$json_flag" == "true" ]]; then
+		db_query_json "
             SELECT model_id, provider, display_name, context_window, input_price, output_price,
                    tier, capabilities, status, deprecated, last_seen
             FROM models $where_clause
             ORDER BY provider, input_price;
         "
-        return $?
-    fi
+		return $?
+	fi
 
-    echo ""
-    echo "Model Registry"
-    echo "=============="
-    echo ""
+	echo ""
+	echo "Model Registry"
+	echo "=============="
+	echo ""
 
-    local count
-    count=$(db_query "SELECT COUNT(*) FROM models $where_clause;")
+	local count
+	count=$(db_query "SELECT COUNT(*) FROM models $where_clause;")
 
-    if [[ "$count" -eq 0 ]]; then
-        print_warning "Registry is empty. Run 'model-registry-helper.sh sync' first."
-        return 0
-    fi
+	if [[ "$count" -eq 0 ]]; then
+		print_warning "Registry is empty. Run 'model-registry-helper.sh sync' first."
+		return 0
+	fi
 
-    printf "%-24s %-10s %-8s %-10s %-10s %-7s %-8s\n" \
-        "Model" "Provider" "Context" "In/1M" "Out/1M" "Tier" "Status"
-    printf "%-24s %-10s %-8s %-10s %-10s %-7s %-8s\n" \
-        "-----" "--------" "-------" "-----" "------" "----" "------"
+	printf "%-24s %-10s %-8s %-10s %-10s %-7s %-8s\n" \
+		"Model" "Provider" "Context" "In/1M" "Out/1M" "Tier" "Status"
+	printf "%-24s %-10s %-8s %-10s %-10s %-7s %-8s\n" \
+		"-----" "--------" "-------" "-----" "------" "----" "------"
 
-    db_query "
+	db_query "
         SELECT model_id, provider, context_window, input_price, output_price, tier, status, deprecated
         FROM models $where_clause
         ORDER BY provider, input_price;
     " | while IFS='|' read -r mid prov ctx inp outp tier stat dep; do
-        local ctx_fmt
-        if [[ "$ctx" -ge 1000000 ]]; then
-            ctx_fmt="1M"
-        elif [[ "$ctx" -ge 500000 ]]; then
-            ctx_fmt="512K"
-        elif [[ "$ctx" -ge 200000 ]]; then
-            ctx_fmt="200K"
-        elif [[ "$ctx" -ge 128000 ]]; then
-            ctx_fmt="128K"
-        else
-            ctx_fmt="${ctx}"
-        fi
+		local ctx_fmt
+		if [[ "$ctx" -ge 1000000 ]]; then
+			ctx_fmt="1M"
+		elif [[ "$ctx" -ge 500000 ]]; then
+			ctx_fmt="512K"
+		elif [[ "$ctx" -ge 200000 ]]; then
+			ctx_fmt="200K"
+		elif [[ "$ctx" -ge 128000 ]]; then
+			ctx_fmt="128K"
+		else
+			ctx_fmt="${ctx}"
+		fi
 
-        local status_display="$stat"
-        [[ "$dep" == "1" ]] && status_display="DEPR"
+		local status_display="$stat"
+		[[ "$dep" == "1" ]] && status_display="DEPR"
 
-        printf "%-24s %-10s %-8s \$%-9s \$%-9s %-7s %-8s\n" \
-            "$mid" "$prov" "$ctx_fmt" "$inp" "$outp" "$tier" "$status_display"
-    done
+		printf "%-24s %-10s %-8s \$%-9s \$%-9s %-7s %-8s\n" \
+			"$mid" "$prov" "$ctx_fmt" "$inp" "$outp" "$tier" "$status_display"
+	done
 
-    echo ""
-    echo "Total: $count models"
-    return 0
+	echo ""
+	echo "Total: $count models"
+	return 0
 }
 
 cmd_status() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ ! -f "$REGISTRY_DB" ]]; then
-        print_warning "Registry not initialized. Run 'model-registry-helper.sh sync' first."
-        return 0
-    fi
+	if [[ ! -f "$REGISTRY_DB" ]]; then
+		print_warning "Registry not initialized. Run 'model-registry-helper.sh sync' first."
+		return 0
+	fi
 
-    local total_models total_providers total_subagents total_provider_models
-    local last_sync deprecated_count
+	local total_models total_providers total_subagents total_provider_models
+	local last_sync deprecated_count
 
-    total_models=$(db_query "SELECT COUNT(*) FROM models;")
-    total_providers=$(db_query "SELECT COUNT(DISTINCT provider) FROM models;")
-    total_subagents=$(db_query "SELECT COUNT(*) FROM subagent_models;")
-    total_provider_models=$(db_query "SELECT COUNT(*) FROM provider_models;")
-    deprecated_count=$(db_query "SELECT COUNT(*) FROM models WHERE deprecated=1;")
-    last_sync=$(db_query "SELECT timestamp FROM sync_log ORDER BY id DESC LIMIT 1;" || echo "never")
+	total_models=$(db_query "SELECT COUNT(*) FROM models;")
+	total_providers=$(db_query "SELECT COUNT(DISTINCT provider) FROM models;")
+	total_subagents=$(db_query "SELECT COUNT(*) FROM subagent_models;")
+	total_provider_models=$(db_query "SELECT COUNT(*) FROM provider_models;")
+	deprecated_count=$(db_query "SELECT COUNT(*) FROM models WHERE deprecated=1;")
+	last_sync=$(db_query "SELECT timestamp FROM sync_log ORDER BY id DESC LIMIT 1;" || echo "never")
 
-    # Calculate staleness
-    local staleness="unknown"
-    if [[ -n "$last_sync" && "$last_sync" != "never" ]]; then
-        local last_epoch now_epoch
-        if [[ "$(uname)" == "Darwin" ]]; then
-            last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
-        else
-            last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
-        fi
-        now_epoch=$(date "+%s")
-        local age=$((now_epoch - last_epoch))
-        if [[ $age -lt 3600 ]]; then
-            staleness="fresh ($((age / 60))m ago)"
-        elif [[ $age -lt 86400 ]]; then
-            staleness="recent ($((age / 3600))h ago)"
-        else
-            staleness="stale ($((age / 86400))d ago)"
-        fi
-    fi
+	# Calculate staleness
+	local staleness="unknown"
+	if [[ -n "$last_sync" && "$last_sync" != "never" ]]; then
+		local last_epoch now_epoch
+		if [[ "$(uname)" == "Darwin" ]]; then
+			last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
+		else
+			last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
+		fi
+		now_epoch=$(date "+%s")
+		local age=$((now_epoch - last_epoch))
+		if [[ $age -lt 3600 ]]; then
+			staleness="fresh ($((age / 60))m ago)"
+		elif [[ $age -lt 86400 ]]; then
+			staleness="recent ($((age / 3600))h ago)"
+		else
+			staleness="stale ($((age / 86400))d ago)"
+		fi
+	fi
 
-    if [[ "$json_flag" == "true" ]]; then
-        echo "{\"total_models\":$total_models,\"total_providers\":$total_providers,\"subagent_tiers\":$total_subagents,\"provider_models_discovered\":$total_provider_models,\"deprecated\":$deprecated_count,\"last_sync\":\"$last_sync\",\"staleness\":\"$staleness\"}"
-        return 0
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		echo "{\"total_models\":$total_models,\"total_providers\":$total_providers,\"subagent_tiers\":$total_subagents,\"provider_models_discovered\":$total_provider_models,\"deprecated\":$deprecated_count,\"last_sync\":\"$last_sync\",\"staleness\":\"$staleness\"}"
+		return 0
+	fi
 
-    echo ""
-    echo "Model Registry Status"
-    echo "====================="
-    echo ""
-    echo "  Registry models:     $total_models"
-    echo "  Providers:           $total_providers"
-    echo "  Subagent tiers:      $total_subagents"
-    echo "  API-discovered:      $total_provider_models"
-    echo "  Deprecated:          $deprecated_count"
-    echo "  Last sync:           ${last_sync:-never}"
-    echo "  Staleness:           $staleness"
-    echo ""
+	echo ""
+	echo "Model Registry Status"
+	echo "====================="
+	echo ""
+	echo "  Registry models:     $total_models"
+	echo "  Providers:           $total_providers"
+	echo "  Subagent tiers:      $total_subagents"
+	echo "  API-discovered:      $total_provider_models"
+	echo "  Deprecated:          $deprecated_count"
+	echo "  Last sync:           ${last_sync:-never}"
+	echo "  Staleness:           $staleness"
+	echo ""
 
-    # Show subagent tier mapping
-    echo "Subagent Tier Mapping:"
-    echo ""
-    printf "  %-8s %-24s %-36s %-24s\n" "Tier" "Model" "Full ID" "Fallback"
-    printf "  %-8s %-24s %-36s %-24s\n" "----" "-----" "-------" "--------"
+	# Show subagent tier mapping
+	echo "Subagent Tier Mapping:"
+	echo ""
+	printf "  %-8s %-24s %-36s %-24s\n" "Tier" "Model" "Full ID" "Fallback"
+	printf "  %-8s %-24s %-36s %-24s\n" "----" "-----" "-------" "--------"
 
-    db_query "SELECT tier, model_id, model_full_id, fallback_id FROM subagent_models ORDER BY tier;" | \
-    while IFS='|' read -r tier mid full_id fallback; do
-        printf "  %-8s %-24s %-36s %-24s\n" "$tier" "$mid" "$full_id" "$fallback"
-    done
+	db_query "SELECT tier, model_id, model_full_id, fallback_id FROM subagent_models ORDER BY tier;" |
+		while IFS='|' read -r tier mid full_id fallback; do
+			printf "  %-8s %-24s %-36s %-24s\n" "$tier" "$mid" "$full_id" "$fallback"
+		done
 
-    echo ""
+	echo ""
 
-    # Show recent sync log
-    echo "Recent Sync History:"
-    echo ""
-    db_query "
+	# Show recent sync log
+	echo "Recent Sync History:"
+	echo ""
+	db_query "
         SELECT timestamp, sync_type, source, models_added, models_updated
         FROM sync_log ORDER BY id DESC LIMIT 5;
     " | while IFS='|' read -r ts stype src added updated; do
-        echo "  $ts  $stype ($src): +$added ~$updated"
-    done
+		echo "  $ts  $stype ($src): +$added ~$updated"
+	done
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 cmd_check() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    echo ""
-    echo "Model Availability Check"
-    echo "========================"
-    echo ""
+	echo ""
+	echo "Model Availability Check"
+	echo "========================"
+	echo ""
 
-    # Check each subagent model against provider APIs
-    local issues=0
+	# Check each subagent model against provider APIs
+	local issues=0
 
-    db_query "SELECT tier, model_id, model_full_id, fallback_id FROM subagent_models;" | \
-    while IFS='|' read -r tier mid full_id fallback; do
-        local provider
-        provider=$(echo "$full_id" | cut -d'/' -f1)
+	db_query "SELECT tier, model_id, model_full_id, fallback_id FROM subagent_models;" |
+		while IFS='|' read -r tier mid full_id fallback; do
+			local provider
+			provider=$(echo "$full_id" | cut -d'/' -f1)
 
-        # Get normalized name for this subagent model
-        local norm_name
-        norm_name=$(db_query "SELECT normalized_name FROM subagent_models WHERE tier='$(sql_escape "$tier")';" 2>/dev/null || echo "")
-        [[ -z "$norm_name" ]] && norm_name=$(normalize_model_name "$full_id")
+			# Get normalized name for this subagent model
+			local norm_name
+			norm_name=$(db_query "SELECT normalized_name FROM subagent_models WHERE tier='$(sql_escape "$tier")';" 2>/dev/null || echo "")
+			[[ -z "$norm_name" ]] && norm_name=$(normalize_model_name "$full_id")
 
-        # Check if model exists in provider_models (try both directions for fuzzy match)
-        local found
-        found=$(db_query "
+			# Check if model exists in provider_models (try both directions for fuzzy match)
+			local found
+			found=$(db_query "
             SELECT COUNT(*) FROM provider_models
             WHERE (model_id LIKE '%$(sql_escape "$mid")%'
                    OR '$(sql_escape "$mid")' LIKE '%' || model_id || '%')
             AND provider LIKE '%$(sql_escape "$provider")%';
         " 2>/dev/null || echo "0")
 
-        local status_icon="Y"
-        local status_text="available"
+			local status_icon="Y"
+			local status_text="available"
 
-        if [[ "$found" -eq 0 ]]; then
-            # Not found in API discovery - check embedded registry via normalized name
-            local in_embedded
-            in_embedded=$(db_query "
+			if [[ "$found" -eq 0 ]]; then
+				# Not found in API discovery - check embedded registry via normalized name
+				local in_embedded
+				in_embedded=$(db_query "
                 SELECT COUNT(*) FROM models
                 WHERE normalized_name = '$(sql_escape "$norm_name")'
                    OR model_id LIKE '%$(sql_escape "$mid")%'
                    OR '$(sql_escape "$mid")' LIKE '%' || model_id || '%';
             " 2>/dev/null || echo "0")
 
-            if [[ "$in_embedded" -gt 0 ]]; then
-                status_icon="?"
-                status_text="in registry, not verified via API"
-            else
-                status_icon="!"
-                status_text="NOT FOUND in registry or API"
-                issues=$((issues + 1))
-            fi
-        fi
+				if [[ "$in_embedded" -gt 0 ]]; then
+					status_icon="?"
+					status_text="in registry, not verified via API"
+				else
+					status_icon="!"
+					status_text="NOT FOUND in registry or API"
+					issues=$((issues + 1))
+				fi
+			fi
 
-        printf "  %s %-8s %-36s %s\n" "$status_icon" "$tier" "$full_id" "$status_text"
-    done
+			printf "  %s %-8s %-36s %s\n" "$status_icon" "$tier" "$full_id" "$status_text"
+		done
 
-    echo ""
-    if [[ $issues -gt 0 ]]; then
-        print_warning "$issues model(s) have availability issues"
-    else
-        print_success "All configured models appear available"
-    fi
-    echo ""
-    return 0
+	echo ""
+	if [[ $issues -gt 0 ]]; then
+		print_warning "$issues model(s) have availability issues"
+	else
+		print_success "All configured models appear available"
+	fi
+	echo ""
+	return 0
 }
 
 cmd_suggest() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    echo ""
-    echo "Model Suggestions"
-    echo "================="
-    echo ""
-    echo "Models discovered from provider APIs but not in the registry:"
-    echo ""
+	echo ""
+	echo "Model Suggestions"
+	echo "================="
+	echo ""
+	echo "Models discovered from provider APIs but not in the registry:"
+	echo ""
 
-    local count=0
-    db_query "
+	local count=0
+	db_query "
         SELECT pm.model_id, pm.provider, pm.discovered_at
         FROM provider_models pm
         WHERE pm.in_registry = 0
         AND pm.in_subagents = 0
         ORDER BY pm.provider, pm.model_id;
     " | while IFS='|' read -r mid prov discovered; do
-        # Filter to interesting models (skip internal/deprecated-looking ones)
-        case "$mid" in
-            *embed*|*tts*|*whisper*|*dall-e*|*moderation*|*babbage*|*davinci-00*|*search*|*instruct*|*realtime*)
-                continue
-                ;;
-        esac
-        echo "  [$prov] $mid (discovered: $discovered)"
-        count=$((count + 1))
-    done
+		# Filter to interesting models (skip internal/deprecated-looking ones)
+		case "$mid" in
+		*embed* | *tts* | *whisper* | *dall-e* | *moderation* | *babbage* | *davinci-00* | *search* | *instruct* | *realtime*)
+			continue
+			;;
+		esac
+		echo "  [$prov] $mid (discovered: $discovered)"
+		count=$((count + 1))
+	done
 
-    echo ""
-    if [[ $count -eq 0 ]]; then
-        print_info "No new model suggestions. Registry is up to date."
-    else
-        echo "  $count potential models found."
-        echo "  Review and add relevant ones to compare-models-helper.sh MODEL_DATA"
-        echo "  and create subagent files in $MODELS_DIR/ as needed."
-    fi
-    echo ""
-    return 0
+	echo ""
+	if [[ $count -eq 0 ]]; then
+		print_info "No new model suggestions. Registry is up to date."
+	else
+		echo "  $count potential models found."
+		echo "  Review and add relevant ones to compare-models-helper.sh MODEL_DATA"
+		echo "  and create subagent files in $MODELS_DIR/ as needed."
+	fi
+	echo ""
+	return 0
 }
 
 cmd_deprecations() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    echo ""
-    echo "Deprecated/Unavailable Models"
-    echo "============================="
-    echo ""
+	echo ""
+	echo "Deprecated/Unavailable Models"
+	echo "============================="
+	echo ""
 
-    local dep_count
-    dep_count=$(db_query "SELECT COUNT(*) FROM models WHERE deprecated=1;")
+	local dep_count
+	dep_count=$(db_query "SELECT COUNT(*) FROM models WHERE deprecated=1;")
 
-    if [[ "$dep_count" -eq 0 ]]; then
-        print_info "No deprecated models found in registry."
-        echo ""
+	if [[ "$dep_count" -eq 0 ]]; then
+		print_info "No deprecated models found in registry."
+		echo ""
 
-        # Check for models in subagents that aren't in provider APIs
-        echo "Models in subagents not confirmed by provider APIs:"
-        echo ""
-        local unconfirmed=0
-        db_query "SELECT tier, model_id, model_full_id FROM subagent_models;" | \
-        while IFS='|' read -r tier mid full_id; do
-            local short_id
-            short_id="${full_id#*/}"
-            local api_found
-            api_found=$(db_query "
+		# Check for models in subagents that aren't in provider APIs
+		echo "Models in subagents not confirmed by provider APIs:"
+		echo ""
+		local unconfirmed=0
+		db_query "SELECT tier, model_id, model_full_id FROM subagent_models;" |
+			while IFS='|' read -r tier mid full_id; do
+				local short_id
+				short_id="${full_id#*/}"
+				local api_found
+				api_found=$(db_query "
                 SELECT COUNT(*) FROM provider_models
                 WHERE model_id = '$(sql_escape "$short_id")';
             " 2>/dev/null || echo "0")
 
-            if [[ "$api_found" -eq 0 ]]; then
-                echo "  ! [$tier] $full_id - not found in API discovery"
-                unconfirmed=$((unconfirmed + 1))
-            fi
-        done
+				if [[ "$api_found" -eq 0 ]]; then
+					echo "  ! [$tier] $full_id - not found in API discovery"
+					unconfirmed=$((unconfirmed + 1))
+				fi
+			done
 
-        if [[ $unconfirmed -eq 0 ]]; then
-            print_info "  All subagent models confirmed via API discovery."
-        fi
-    else
-        db_query "
+		if [[ $unconfirmed -eq 0 ]]; then
+			print_info "  All subagent models confirmed via API discovery."
+		fi
+	else
+		db_query "
             SELECT model_id, provider, deprecation_note, last_seen
             FROM models WHERE deprecated=1
             ORDER BY provider, model_id;
         " | while IFS='|' read -r mid prov note last; do
-            echo "  ! $mid ($prov)"
-            [[ -n "$note" ]] && echo "    Note: $note"
-            echo "    Last seen: $last"
-        done
-    fi
+			echo "  ! $mid ($prov)"
+			[[ -n "$note" ]] && echo "    Note: $note"
+			echo "    Last seen: $last"
+		done
+	fi
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 cmd_diff() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    echo ""
-    echo "Registry vs Local Config Diff"
-    echo "=============================="
-    echo ""
+	echo ""
+	echo "Registry vs Local Config Diff"
+	echo "=============================="
+	echo ""
 
-    # Compare subagent models with registry
-    echo "Subagent Models vs Registry:"
-    echo ""
+	# Compare subagent models with registry
+	echo "Subagent Models vs Registry:"
+	echo ""
 
-    db_query "SELECT tier, model_id, model_full_id, normalized_name FROM subagent_models;" | \
-    while IFS='|' read -r tier mid full_id norm_name; do
-        [[ -z "$norm_name" ]] && norm_name=$(normalize_model_name "$full_id")
-        local reg_match
-        reg_match=$(db_query "
+	db_query "SELECT tier, model_id, model_full_id, normalized_name FROM subagent_models;" |
+		while IFS='|' read -r tier mid full_id norm_name; do
+			[[ -z "$norm_name" ]] && norm_name=$(normalize_model_name "$full_id")
+			local reg_match
+			reg_match=$(db_query "
             SELECT model_id, input_price, output_price
             FROM models
             WHERE normalized_name = '$(sql_escape "$norm_name")'
@@ -1073,26 +1103,26 @@ cmd_diff() {
             LIMIT 1;
         " 2>/dev/null || echo "")
 
-        if [[ -n "$reg_match" ]]; then
-            local reg_id reg_input reg_output
-            reg_id=$(echo "$reg_match" | cut -d'|' -f1)
-            reg_input=$(echo "$reg_match" | cut -d'|' -f2)
-            reg_output=$(echo "$reg_match" | cut -d'|' -f3)
-            printf "  = %-8s %-24s (registry: %s, \$%s/\$%s)\n" \
-                "$tier" "$full_id" "$reg_id" "$reg_input" "$reg_output"
-        else
-            printf "  ! %-8s %-24s (NOT in registry)\n" "$tier" "$full_id"
-        fi
-    done
+			if [[ -n "$reg_match" ]]; then
+				local reg_id reg_input reg_output
+				reg_id=$(echo "$reg_match" | cut -d'|' -f1)
+				reg_input=$(echo "$reg_match" | cut -d'|' -f2)
+				reg_output=$(echo "$reg_match" | cut -d'|' -f3)
+				printf "  = %-8s %-24s (registry: %s, \$%s/\$%s)\n" \
+					"$tier" "$full_id" "$reg_id" "$reg_input" "$reg_output"
+			else
+				printf "  ! %-8s %-24s (NOT in registry)\n" "$tier" "$full_id"
+			fi
+		done
 
-    echo ""
+	echo ""
 
-    # Show registry models not in subagents
-    echo "Registry Models Not in Subagents:"
-    echo ""
+	# Show registry models not in subagents
+	echo "Registry Models Not in Subagents:"
+	echo ""
 
-    local orphan_count=0
-    db_query "
+	local orphan_count=0
+	db_query "
         SELECT m.model_id, m.provider, m.tier
         FROM models m
         WHERE NOT EXISTS (
@@ -1103,184 +1133,208 @@ cmd_diff() {
         )
         ORDER BY m.provider, m.model_id;
     " | while IFS='|' read -r mid prov tier; do
-        printf "  + %-24s %-10s %-7s\n" "$mid" "$prov" "$tier"
-        orphan_count=$((orphan_count + 1))
-    done
+		printf "  + %-24s %-10s %-7s\n" "$mid" "$prov" "$tier"
+		orphan_count=$((orphan_count + 1))
+	done
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 cmd_export() {
-    local format="json"
+	local format="json"
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --csv) format="csv"; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--csv)
+			format="csv"
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    case "$format" in
-        csv)
-            db_query_csv "
+	case "$format" in
+	csv)
+		db_query_csv "
                 SELECT model_id, provider, display_name, context_window,
                        input_price, output_price, tier, capabilities,
                        best_for, status, deprecated, last_seen
                 FROM models ORDER BY provider, model_id;
             "
-            ;;
-        *)
-            db_query_json "
+		;;
+	*)
+		db_query_json "
                 SELECT model_id, provider, display_name, context_window,
                        input_price, output_price, tier, capabilities,
                        best_for, status, deprecated, last_seen
                 FROM models ORDER BY provider, model_id;
             "
-            ;;
-    esac
-    return $?
+		;;
+	esac
+	return $?
 }
 
 cmd_route() {
-    local description="$*"
-    local json_flag=false
+	local description="$*"
+	local json_flag=false
 
-    # Parse flags
-    local args=()
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) args+=("$1"); shift ;;
-        esac
-    done
-    description="${args[*]}"
+	# Parse flags
+	local args=()
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*)
+			args+=("$1")
+			shift
+			;;
+		esac
+	done
+	description="${args[*]}"
 
-    if [[ -z "$description" ]]; then
-        echo ""
-        echo "Usage: model-registry-helper.sh route <task description>"
-        echo ""
-        echo "Examples:"
-        echo "  model-registry-helper.sh route 'rename variable X to Y'"
-        echo "  model-registry-helper.sh route 'design auth system architecture'"
-        echo "  model-registry-helper.sh route 'summarize this 200-page PDF'"
-        echo ""
-        return 1
-    fi
+	if [[ -z "$description" ]]; then
+		echo ""
+		echo "Usage: model-registry-helper.sh route <task description>"
+		echo ""
+		echo "Examples:"
+		echo "  model-registry-helper.sh route 'rename variable X to Y'"
+		echo "  model-registry-helper.sh route 'design auth system architecture'"
+		echo "  model-registry-helper.sh route 'summarize this 200-page PDF'"
+		echo ""
+		return 1
+	fi
 
-    local desc_lower
-    desc_lower=$(echo "$description" | tr '[:upper:]' '[:lower:]')
+	local desc_lower
+	desc_lower=$(echo "$description" | tr '[:upper:]' '[:lower:]')
 
-    local tier="sonnet"
-    local reason="Default tier for general development tasks"
-    local cost="1x"
+	local tier="sonnet"
+	local reason="Default tier for general development tasks"
+	local cost="1x"
 
-    # Opus indicators: architecture, design, security audit, novel, trade-off, evaluate
-    if echo "$desc_lower" | grep -qE 'architect|system.design|security.audit|novel|trade.?off|evaluat|complex.*(plan|design|decision)|from.scratch'; then
-        tier="opus"
-        reason="Complex reasoning, architecture, or novel problem-solving"
-        cost="3x"
-    # Haiku indicators: rename, format, classify, triage, commit message, simple
-    elif echo "$desc_lower" | grep -qE 'rename|reformat|classify|triage|commit.message|simple.*(text|transform)|extract.field|sort|prioriti[sz]e|route|tag|label'; then
-        tier="haiku"
-        reason="Simple classification, formatting, or text transform"
-        cost="0.25x"
-    # Flash indicators: summarize, large context, bulk, read, scan
-    elif echo "$desc_lower" | grep -qE 'summari[sz]e|large.*(file|context|document|pdf)|bulk|scan.*files|read.*all|200.page|overview|skim'; then
-        tier="flash"
-        reason="Large context processing or summarization"
-        cost="0.20x"
-    # Pro indicators: large codebase, many files, refactor across
-    elif echo "$desc_lower" | grep -qE 'large.codebase|500.file|many.files|refactor.across|entire.project|full.repo|cross.file'; then
-        tier="pro"
-        reason="Large codebase analysis requiring both context and reasoning"
-        cost="1.5x"
-    fi
+	# Opus indicators: architecture, design, security audit, novel, trade-off, evaluate
+	if echo "$desc_lower" | grep -qE 'architect|system.design|security.audit|novel|trade.?off|evaluat|complex.*(plan|design|decision)|from.scratch'; then
+		tier="opus"
+		reason="Complex reasoning, architecture, or novel problem-solving"
+		cost="3x"
+	# Haiku indicators: rename, format, classify, triage, commit message, simple
+	elif echo "$desc_lower" | grep -qE 'rename|reformat|classify|triage|commit.message|simple.*(text|transform)|extract.field|sort|prioriti[sz]e|route|tag|label'; then
+		tier="haiku"
+		reason="Simple classification, formatting, or text transform"
+		cost="0.25x"
+	# Flash indicators: summarize, large context, bulk, read, scan
+	elif echo "$desc_lower" | grep -qE 'summari[sz]e|large.*(file|context|document|pdf)|bulk|scan.*files|read.*all|200.page|overview|skim'; then
+		tier="flash"
+		reason="Large context processing or summarization"
+		cost="0.20x"
+	# Pro indicators: large codebase, many files, refactor across
+	elif echo "$desc_lower" | grep -qE 'large.codebase|500.file|many.files|refactor.across|entire.project|full.repo|cross.file'; then
+		tier="pro"
+		reason="Large codebase analysis requiring both context and reasoning"
+		cost="1.5x"
+	fi
 
-    # Look up the primary model for this tier from the registry
-    local primary_model=""
-    local fallback_model=""
-    primary_model=$(db_query "SELECT model_id FROM models WHERE tier = '$tier' AND is_primary = 1 LIMIT 1;" 2>/dev/null || echo "")
-    fallback_model=$(db_query "SELECT model_id FROM models WHERE tier = '$tier' AND is_fallback = 1 LIMIT 1;" 2>/dev/null || echo "")
+	# Look up the primary model for this tier from the registry
+	local primary_model=""
+	local fallback_model=""
+	primary_model=$(db_query "SELECT model_id FROM models WHERE tier = '$tier' AND is_primary = 1 LIMIT 1;" 2>/dev/null || echo "")
+	fallback_model=$(db_query "SELECT model_id FROM models WHERE tier = '$tier' AND is_fallback = 1 LIMIT 1;" 2>/dev/null || echo "")
 
-    # Defaults if registry is empty
-    case "$tier" in
-        haiku)   primary_model="${primary_model:-claude-3-5-haiku}"; fallback_model="${fallback_model:-gemini-2.5-flash}" ;;
-        flash)   primary_model="${primary_model:-gemini-2.5-flash}"; fallback_model="${fallback_model:-gpt-4.1-mini}" ;;
-        sonnet)  primary_model="${primary_model:-claude-sonnet-4}"; fallback_model="${fallback_model:-gpt-4.1}" ;;
-        pro)     primary_model="${primary_model:-gemini-2.5-pro}"; fallback_model="${fallback_model:-claude-sonnet-4}" ;;
-        opus)    primary_model="${primary_model:-claude-opus-4}"; fallback_model="${fallback_model:-o3}" ;;
-    esac
+	# Defaults if registry is empty
+	case "$tier" in
+	haiku)
+		primary_model="${primary_model:-claude-3-5-haiku}"
+		fallback_model="${fallback_model:-gemini-2.5-flash}"
+		;;
+	flash)
+		primary_model="${primary_model:-gemini-2.5-flash}"
+		fallback_model="${fallback_model:-gpt-4.1-mini}"
+		;;
+	sonnet)
+		primary_model="${primary_model:-claude-sonnet-4-6}"
+		fallback_model="${fallback_model:-gpt-4.1}"
+		;;
+	pro)
+		primary_model="${primary_model:-gemini-2.5-pro}"
+		fallback_model="${fallback_model:-claude-sonnet-4-6}"
+		;;
+	opus)
+		primary_model="${primary_model:-claude-opus-4-6}"
+		fallback_model="${fallback_model:-o3}"
+		;;
+	esac
 
-    if [[ "$json_flag" == "true" ]]; then
-        printf '{"tier":"%s","model":"%s","fallback":"%s","cost":"%s","reason":"%s"}\n' \
-            "$tier" "$primary_model" "$fallback_model" "$cost" "$reason"
-    else
-        echo ""
-        echo "Task: $description"
-        echo ""
-        echo "  Recommended tier:  $tier"
-        echo "  Primary model:     $primary_model"
-        echo "  Fallback model:    $fallback_model"
-        echo "  Relative cost:     $cost"
-        echo "  Reason:            $reason"
-        echo ""
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		printf '{"tier":"%s","model":"%s","fallback":"%s","cost":"%s","reason":"%s"}\n' \
+			"$tier" "$primary_model" "$fallback_model" "$cost" "$reason"
+	else
+		echo ""
+		echo "Task: $description"
+		echo ""
+		echo "  Recommended tier:  $tier"
+		echo "  Primary model:     $primary_model"
+		echo "  Fallback model:    $fallback_model"
+		echo "  Relative cost:     $cost"
+		echo "  Reason:            $reason"
+		echo ""
+	fi
 
-    return 0
+	return 0
 }
 
 cmd_help() {
-    echo ""
-    echo "Model Registry Helper - Provider/Model Registry with Periodic Sync"
-    echo "==================================================================="
-    echo ""
-    echo "Usage: model-registry-helper.sh [command] [options]"
-    echo ""
-    echo "Commands:"
-    echo "  sync          Sync registry from all sources (subagents, embedded data, APIs)"
-    echo "  list          List all models in the registry"
-    echo "  status        Show registry health, staleness, and tier mapping"
-    echo "  check         Check configured subagent models against registry/APIs"
-    echo "  suggest       Suggest new models discovered from APIs but not tracked"
-    echo "  deprecations  Show deprecated/renamed/unavailable models"
-    echo "  diff          Show differences between registry and local config"
-    echo "  route <desc>  Recommend optimal model tier for a task description"
-    echo "  export        Export registry data (JSON or CSV)"
-    echo "  help          Show this help"
-    echo ""
-    echo "Options:"
-    echo "  --json        Output in JSON format (list, status, export)"
-    echo "  --quiet       Suppress informational output (sync)"
-    echo "  --force       Force full resync even if cache is fresh (sync)"
-    echo "  --provider X  Filter by provider name (list)"
-    echo "  --tier X      Filter by tier (list)"
-    echo "  --csv         Export as CSV instead of JSON (export)"
-    echo ""
-    echo "Examples:"
-    echo "  model-registry-helper.sh sync                    # Full sync"
-    echo "  model-registry-helper.sh sync --force            # Force resync"
-    echo "  model-registry-helper.sh list                    # List all models"
-    echo "  model-registry-helper.sh list --provider Google  # Google models only"
-    echo "  model-registry-helper.sh status                  # Registry health"
-    echo "  model-registry-helper.sh check                   # Verify subagent models"
-    echo "  model-registry-helper.sh suggest                 # New model suggestions"
-    echo "  model-registry-helper.sh diff                    # Config vs registry"
-    echo "  model-registry-helper.sh route 'fix React bug'  # Recommend model tier"
-    echo "  model-registry-helper.sh export --json           # Export as JSON"
-    echo ""
-    echo "Integration:"
-    echo "  - Runs automatically on 'aidevops update'"
-    echo "  - Can be added to cron for periodic sync"
-    echo "  - Storage: $REGISTRY_DB"
-    echo ""
-    echo "Data Sources:"
-    echo "  1. Subagent frontmatter ($MODELS_DIR/*.md)"
-    echo "  2. Embedded data (compare-models-helper.sh MODEL_DATA)"
-    echo "  3. OpenCode model registry (opencode models — preferred, from models.dev)"
-    echo "  4. Provider APIs (Anthropic, OpenAI, Google, OpenRouter, Groq, DeepSeek)"
-    echo ""
-    return 0
+	echo ""
+	echo "Model Registry Helper - Provider/Model Registry with Periodic Sync"
+	echo "==================================================================="
+	echo ""
+	echo "Usage: model-registry-helper.sh [command] [options]"
+	echo ""
+	echo "Commands:"
+	echo "  sync          Sync registry from all sources (subagents, embedded data, APIs)"
+	echo "  list          List all models in the registry"
+	echo "  status        Show registry health, staleness, and tier mapping"
+	echo "  check         Check configured subagent models against registry/APIs"
+	echo "  suggest       Suggest new models discovered from APIs but not tracked"
+	echo "  deprecations  Show deprecated/renamed/unavailable models"
+	echo "  diff          Show differences between registry and local config"
+	echo "  route <desc>  Recommend optimal model tier for a task description"
+	echo "  export        Export registry data (JSON or CSV)"
+	echo "  help          Show this help"
+	echo ""
+	echo "Options:"
+	echo "  --json        Output in JSON format (list, status, export)"
+	echo "  --quiet       Suppress informational output (sync)"
+	echo "  --force       Force full resync even if cache is fresh (sync)"
+	echo "  --provider X  Filter by provider name (list)"
+	echo "  --tier X      Filter by tier (list)"
+	echo "  --csv         Export as CSV instead of JSON (export)"
+	echo ""
+	echo "Examples:"
+	echo "  model-registry-helper.sh sync                    # Full sync"
+	echo "  model-registry-helper.sh sync --force            # Force resync"
+	echo "  model-registry-helper.sh list                    # List all models"
+	echo "  model-registry-helper.sh list --provider Google  # Google models only"
+	echo "  model-registry-helper.sh status                  # Registry health"
+	echo "  model-registry-helper.sh check                   # Verify subagent models"
+	echo "  model-registry-helper.sh suggest                 # New model suggestions"
+	echo "  model-registry-helper.sh diff                    # Config vs registry"
+	echo "  model-registry-helper.sh route 'fix React bug'  # Recommend model tier"
+	echo "  model-registry-helper.sh export --json           # Export as JSON"
+	echo ""
+	echo "Integration:"
+	echo "  - Runs automatically on 'aidevops update'"
+	echo "  - Can be added to cron for periodic sync"
+	echo "  - Storage: $REGISTRY_DB"
+	echo ""
+	echo "Data Sources:"
+	echo "  1. Subagent frontmatter ($MODELS_DIR/*.md)"
+	echo "  2. Embedded data (compare-models-helper.sh MODEL_DATA)"
+	echo "  3. OpenCode model registry (opencode models — preferred, from models.dev)"
+	echo "  4. Provider APIs (Anthropic, OpenAI, Google, OpenRouter, Groq, DeepSeek)"
+	echo ""
+	return 0
 }
 
 # =============================================================================
@@ -1288,52 +1342,52 @@ cmd_help() {
 # =============================================================================
 
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    # Initialize DB for all commands except help
-    if [[ "$command" != "help" && "$command" != "--help" && "$command" != "-h" ]]; then
-        init_db || return 1
-    fi
+	# Initialize DB for all commands except help
+	if [[ "$command" != "help" && "$command" != "--help" && "$command" != "-h" ]]; then
+		init_db || return 1
+	fi
 
-    case "$command" in
-        sync)
-            cmd_sync "$@"
-            ;;
-        list)
-            cmd_list "$@"
-            ;;
-        status)
-            cmd_status "$@"
-            ;;
-        check)
-            cmd_check "$@"
-            ;;
-        suggest)
-            cmd_suggest "$@"
-            ;;
-        deprecations|deprecated)
-            cmd_deprecations "$@"
-            ;;
-        diff)
-            cmd_diff "$@"
-            ;;
-        route)
-            cmd_route "$@"
-            ;;
-        export)
-            cmd_export "$@"
-            ;;
-        help|--help|-h)
-            cmd_help
-            ;;
-        *)
-            print_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
-    return $?
+	case "$command" in
+	sync)
+		cmd_sync "$@"
+		;;
+	list)
+		cmd_list "$@"
+		;;
+	status)
+		cmd_status "$@"
+		;;
+	check)
+		cmd_check "$@"
+		;;
+	suggest)
+		cmd_suggest "$@"
+		;;
+	deprecations | deprecated)
+		cmd_deprecations "$@"
+		;;
+	diff)
+		cmd_diff "$@"
+		;;
+	route)
+		cmd_route "$@"
+		;;
+	export)
+		cmd_export "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+	return $?
 }
 
 main "$@"

--- a/.agents/scripts/objective-runner-helper.sh
+++ b/.agents/scripts/objective-runner-helper.sh
@@ -23,7 +23,7 @@
 #   --allowed-paths "p1,p2" Comma-separated path whitelist (default: cwd)
 #   --allowed-tools "t1,t2" Comma-separated tool whitelist (default: all)
 #   --workdir PATH          Working directory (default: cwd)
-#   --model PROVIDER/MODEL  AI model (default: anthropic/claude-sonnet-4-20250514)
+#   --model PROVIDER/MODEL  AI model (default: anthropic/claude-sonnet-4-6)
 #   --runner NAME           Use existing runner identity (optional)
 #   --dry-run               Show config without executing
 #
@@ -57,7 +57,7 @@ readonly OBJECTIVES_DIR="${AIDEVOPS_OBJECTIVES_DIR:-$HOME/.aidevops/.agent-works
 readonly MEMORY_HELPER="$HOME/.aidevops/agents/scripts/memory-helper.sh"
 # Used by future runner identity integration
 export RUNNER_HELPER="$HOME/.aidevops/agents/scripts/runner-helper.sh"
-readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-20250514"
+readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
 readonly DEFAULT_MAX_STEPS=50
 readonly DEFAULT_MAX_COST="5.00"
 readonly DEFAULT_MAX_TOKENS=500000
@@ -1208,7 +1208,7 @@ START OPTIONS:
     --allowed-paths "p,p"   Comma-separated path whitelist (default: cwd)
     --allowed-tools "t,t"   Comma-separated tool whitelist (default: all)
     --workdir PATH          Working directory (default: cwd)
-    --model PROVIDER/MODEL  AI model (default: anthropic/claude-sonnet-4-20250514)
+    --model PROVIDER/MODEL  AI model (default: anthropic/claude-sonnet-4-6)
     --runner NAME           Use existing runner identity (optional)
     --dry-run               Show config without executing
 

--- a/.agents/scripts/opencode-github-setup-helper.sh
+++ b/.agents/scripts/opencode-github-setup-helper.sh
@@ -439,7 +439,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          model: anthropic/claude-sonnet-4-20250514
+          model: anthropic/claude-sonnet-4-6
 EOF
     
     print_success "Created .github/workflows/opencode.yml"
@@ -624,7 +624,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          model: anthropic/claude-sonnet-4-20250514
+          model: anthropic/claude-sonnet-4-6
           prompt: |
             SECURITY RULES (NEVER VIOLATE):
             1. NEVER modify workflow files (.github/workflows/*)

--- a/.agents/scripts/pipecat-helper.sh
+++ b/.agents/scripts/pipecat-helper.sh
@@ -42,7 +42,7 @@ readonly CLIENT_PID_FILE="${HOME}/.aidevops/.agent-workspace/tmp/.pipecat-client
 readonly DEFAULT_SERVER_PORT=7860
 readonly DEFAULT_CLIENT_PORT=3000
 readonly DEFAULT_LLM_PROVIDER="anthropic"
-readonly DEFAULT_ANTHROPIC_MODEL="claude-sonnet-4-20250514"
+readonly DEFAULT_ANTHROPIC_MODEL="claude-sonnet-4-6"
 readonly DEFAULT_OPENAI_MODEL="gpt-4o"
 readonly DEFAULT_CARTESIA_VOICE_ID="71a7ad14-091c-4e8e-a314-022ece01c121"
 readonly DEFAULT_PYTHON="python3.12"
@@ -289,7 +289,7 @@ def get_llm_service(provider: str):
             sys.exit(1)
         return AnthropicLLMService(
             api_key=api_key,
-            model=os.getenv("PIPECAT_ANTHROPIC_MODEL", "claude-sonnet-4-20250514"),
+            model=os.getenv("PIPECAT_ANTHROPIC_MODEL", "claude-sonnet-4-6"),
         )
     elif provider == "openai":
         from pipecat.services.openai.llm import OpenAILLMService
@@ -593,7 +593,7 @@ cmd_setup() {
 # PIPECAT_LOCAL_LLM_MODEL=local-model
 
 # Optional: Override default models
-# PIPECAT_ANTHROPIC_MODEL=claude-sonnet-4-20250514
+# PIPECAT_ANTHROPIC_MODEL=claude-sonnet-4-6
 # PIPECAT_OPENAI_MODEL=gpt-4o
 ENVEOF
 		print_success "Environment template created: ${PIPECAT_DIR}/.env"
@@ -1188,7 +1188,7 @@ Environment Variables:
   OPENAI_API_KEY           OpenAI LLM key (for openai provider)
   PIPECAT_LOCAL_LLM_URL    Local LLM endpoint (default: http://127.0.0.1:1234/v1)
   PIPECAT_LOCAL_LLM_MODEL  Local LLM model name
-  PIPECAT_ANTHROPIC_MODEL  Override Anthropic model (default: claude-sonnet-4-20250514)
+  PIPECAT_ANTHROPIC_MODEL  Override Anthropic model (default: claude-sonnet-4-6)
   PIPECAT_OPENAI_MODEL     Override OpenAI model (default: gpt-4o)
 
 Directories:

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -43,7 +43,7 @@ readonly MEMORY_HELPER="$HOME/.aidevops/agents/scripts/memory-helper.sh"
 readonly MAIL_HELPER="$HOME/.aidevops/agents/scripts/mail-helper.sh"
 readonly OPENCODE_PORT="${OPENCODE_PORT:-4096}"
 readonly OPENCODE_HOST="${OPENCODE_HOST:-127.0.0.1}"
-readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-20250514"
+readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
 
 readonly BOLD='\033[1m'
 
@@ -958,7 +958,7 @@ EXAMPLES:
     # Create a code reviewer
     runner-helper.sh create code-reviewer \
       --description "Reviews code for security and quality" \
-      --model anthropic/claude-sonnet-4-20250514
+      --model anthropic/claude-sonnet-4-6
 
     # Run a review task
     runner-helper.sh run code-reviewer "Review src/auth/ for vulnerabilities"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1071,7 +1071,7 @@ resolve_model_tier() {
             echo "anthropic/claude-opus-4-6"
             ;;
         sonnet|eval)
-            echo "anthropic/claude-sonnet-4-20250514"
+            echo "anthropic/claude-sonnet-4-6"
             ;;
         haiku|health)
             echo "anthropic/claude-3-5-haiku-20241022"

--- a/.agents/scripts/supervisor/dispatch.sh
+++ b/.agents/scripts/supervisor/dispatch.sh
@@ -112,13 +112,13 @@ resolve_model() {
 		echo "anthropic/claude-opus-4-6"
 		;;
 	sonnet | eval | health)
-		echo "anthropic/claude-sonnet-4-5"
+		echo "anthropic/claude-sonnet-4-6"
 		;;
 	haiku | flash)
 		echo "anthropic/claude-haiku-4-5"
 		;;
 	pro)
-		echo "anthropic/claude-sonnet-4-5"
+		echo "anthropic/claude-sonnet-4-6"
 		;;
 	*)
 		# Unknown tier — treat as coding tier default

--- a/.agents/services/hosting/cloudflare-platform/references/ai-gateway/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/ai-gateway/README.md
@@ -60,7 +60,7 @@ const client = new OpenAI({
 
 // Switch providers by changing model format: {provider}/{model}
 const response = await client.chat.completions.create({
-  model: 'openai/gpt-4o-mini', // or 'anthropic/claude-sonnet-4-5'
+  model: 'openai/gpt-4o-mini', // or 'anthropic/claude-sonnet-4-6'
   messages: [{ role: 'user', content: 'Hello!' }]
 });
 ```
@@ -449,7 +449,7 @@ const response = await client.chat.completions.create({
 ```typescript
 // Dashboard: Create route with Percentage node
 // - 50% to gpt-4o-mini
-// - 50% to claude-sonnet-4-5
+// - 50% to claude-sonnet-4-6
 // Analyze logs to compare quality/cost/latency
 
 const response = await client.chat.completions.create({

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -14,7 +14,7 @@ Video,video.md,AI video generation and prompt engineering,opus
 
 <!--TOON:model_tiers[6]{tier,model_id,use_case}:
 haiku,claude-3-5-haiku-20241022,Triage routing and simple tasks
-sonnet,claude-sonnet-4-20250514,Code review and implementation
+sonnet,claude-sonnet-4-6,Code review and implementation
 opus,claude-opus-4-20250514,Architecture and complex reasoning
 flash,gemini-2.5-flash,Fast cheap large context
 pro,gemini-2.5-pro,Capable large context

--- a/.agents/tools/ai-assistants/fallback-chains.md
+++ b/.agents/tools/ai-assistants/fallback-chains.md
@@ -51,14 +51,14 @@ Add `fallback-chain:` to any model tier file's YAML frontmatter:
 
 ```yaml
 ---
-model: anthropic/claude-sonnet-4-20250514
+model: anthropic/claude-sonnet-4-6
 model-tier: sonnet
 model-fallback: openai/gpt-4.1
 fallback-chain:
-  - anthropic/claude-sonnet-4-20250514
+  - anthropic/claude-sonnet-4-6
   - openai/gpt-4.1
   - google/gemini-2.5-pro
-  - openrouter/anthropic/claude-sonnet-4-20250514
+  - openrouter/anthropic/claude-sonnet-4-6
 ---
 ```
 
@@ -70,10 +70,10 @@ Edit `configs/fallback-chain-config.json` (copy from `.json.txt` template):
 {
   "chains": {
     "sonnet": [
-      "anthropic/claude-sonnet-4-20250514",
+      "anthropic/claude-sonnet-4-6",
       "openai/gpt-4.1",
       "google/gemini-2.5-pro",
-      "openrouter/anthropic/claude-sonnet-4-20250514"
+      "openrouter/anthropic/claude-sonnet-4-6"
     ]
   }
 }
@@ -83,9 +83,9 @@ Edit `configs/fallback-chain-config.json` (copy from `.json.txt` template):
 
 | Format | Example | Description |
 |--------|---------|-------------|
-| `provider/model` | `anthropic/claude-sonnet-4-20250514` | Direct provider API |
-| `openrouter/provider/model` | `openrouter/anthropic/claude-sonnet-4-20250514` | Via OpenRouter gateway |
-| `gateway/cf/provider/model` | `gateway/cf/anthropic/claude-sonnet-4-20250514` | Via Cloudflare AI Gateway |
+| `provider/model` | `anthropic/claude-sonnet-4-6` | Direct provider API |
+| `openrouter/provider/model` | `openrouter/anthropic/claude-sonnet-4-6` | Via OpenRouter gateway |
+| `gateway/cf/provider/model` | `gateway/cf/anthropic/claude-sonnet-4-6` | Via Cloudflare AI Gateway |
 
 ## Trigger Types
 
@@ -130,7 +130,7 @@ fallback-chain-helper.sh gateway openrouter
 
 # Models routed via OpenRouter use the format:
 # openrouter/provider/model
-# e.g., openrouter/anthropic/claude-sonnet-4-20250514
+# e.g., openrouter/anthropic/claude-sonnet-4-6
 ```
 
 **Setup**: Set `OPENROUTER_API_KEY` environment variable or store via `aidevops secret set OPENROUTER_API_KEY`.
@@ -145,7 +145,7 @@ fallback-chain-helper.sh gateway cloudflare
 
 # Models routed via CF AI Gateway use the format:
 # gateway/cf/provider/model
-# e.g., gateway/cf/anthropic/claude-sonnet-4-20250514
+# e.g., gateway/cf/anthropic/claude-sonnet-4-6
 ```
 
 **Setup**: Configure `account_id` and `gateway_id` in `configs/fallback-chain-config.json`. Set `CF_AIG_TOKEN` for authenticated gateways.

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -73,7 +73,7 @@ Simplest approach. Each invocation starts a fresh session (or resumes one).
 opencode run "Review src/auth.ts for security issues"
 
 # With specific model
-opencode run -m anthropic/claude-sonnet-4-20250514 "Generate unit tests for src/utils/"
+opencode run -m anthropic/claude-sonnet-4-6 "Generate unit tests for src/utils/"
 
 # With specific agent
 opencode run --agent plan "Analyze the database schema"
@@ -111,7 +111,7 @@ import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk"
 // Start server + client together
 const { client, server } = await createOpencode({
   port: 4096,
-  config: { model: "anthropic/claude-sonnet-4-20250514" },
+  config: { model: "anthropic/claude-sonnet-4-6" },
 })
 
 // Or connect to existing server
@@ -136,7 +136,7 @@ SESSION_ID=$(curl -sf -X POST "$SERVER/session" \
 curl -sf -X POST "$SERVER/session/$SESSION_ID/message" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": {"providerID": "anthropic", "modelID": "claude-sonnet-4-20250514"},
+    "model": {"providerID": "anthropic", "modelID": "claude-sonnet-4-6"},
     "parts": [{"type": "text", "text": "Explain this codebase"}]
   }'
 
@@ -276,7 +276,7 @@ Runners are named, persistent agent instances with their own identity, instructi
 # Create a runner
 runner-helper.sh create code-reviewer \
   --description "Reviews code for security and quality" \
-  --model anthropic/claude-sonnet-4-20250514
+  --model anthropic/claude-sonnet-4-6
 
 # Run a task
 runner-helper.sh run code-reviewer "Review src/auth/ for vulnerabilities"
@@ -367,7 +367,7 @@ Place in `.opencode/agents/security-reviewer.md`:
 ---
 description: Security-focused code reviewer
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: anthropic/claude-sonnet-4-6
 temperature: 0.1
 tools:
   write: false
@@ -395,7 +395,7 @@ In `opencode.json`:
     "security-reviewer": {
       "description": "Security-focused code reviewer",
       "mode": "subagent",
-      "model": "anthropic/claude-sonnet-4-20250514",
+      "model": "anthropic/claude-sonnet-4-6",
       "tools": { "write": false, "edit": false }
     }
   }
@@ -427,7 +427,7 @@ OpenCode supports any provider via `opencode auth login`. Runners inherit the co
 opencode auth login  # Interactive provider selection
 
 # Override model per dispatch
-opencode run -m openrouter/anthropic/claude-sonnet-4-20250514 "Task"
+opencode run -m openrouter/anthropic/claude-sonnet-4-6 "Task"
 opencode run -m groq/llama-4-scout-17b-16e-instruct "Quick task"
 ```
 

--- a/.agents/tools/ai-assistants/models/README.md
+++ b/.agents/tools/ai-assistants/models/README.md
@@ -49,10 +49,10 @@ Add `fallback-chain:` to any model tier's YAML frontmatter for per-agent overrid
 
 ```yaml
 fallback-chain:
-  - anthropic/claude-sonnet-4-20250514
+  - anthropic/claude-sonnet-4-6
   - openai/gpt-4.1
   - google/gemini-2.5-pro
-  - openrouter/anthropic/claude-sonnet-4-20250514
+  - openrouter/anthropic/claude-sonnet-4-6
 ```
 
 Global defaults are configured in `configs/fallback-chain-config.json`. See `tools/ai-assistants/fallback-chains.md` for full documentation.

--- a/.agents/tools/ai-assistants/models/opus.md
+++ b/.agents/tools/ai-assistants/models/opus.md
@@ -7,7 +7,7 @@ model-fallback: openai/o3
 fallback-chain:
   - anthropic/claude-opus-4-6
   - openai/o3
-  - anthropic/claude-sonnet-4-20250514
+  - anthropic/claude-sonnet-4-6
   - openrouter/anthropic/claude-opus-4-6
 tools:
   read: true

--- a/.agents/tools/ai-assistants/models/pro.md
+++ b/.agents/tools/ai-assistants/models/pro.md
@@ -3,7 +3,7 @@ description: High-capability model for large codebase analysis and complex reaso
 mode: subagent
 model: google/gemini-2.5-pro-preview-06-05
 model-tier: pro
-model-fallback: anthropic/claude-sonnet-4-20250514
+model-fallback: anthropic/claude-sonnet-4-6
 tools:
   read: true
   write: true

--- a/.agents/tools/ai-assistants/models/sonnet.md
+++ b/.agents/tools/ai-assistants/models/sonnet.md
@@ -1,14 +1,14 @@
 ---
 description: Balanced model for code implementation, review, and most development tasks
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: anthropic/claude-sonnet-4-6
 model-tier: sonnet
 model-fallback: openai/gpt-4.1
 fallback-chain:
-  - anthropic/claude-sonnet-4-20250514
+  - anthropic/claude-sonnet-4-6
   - openai/gpt-4.1
   - google/gemini-2.5-pro
-  - openrouter/anthropic/claude-sonnet-4-20250514
+  - openrouter/anthropic/claude-sonnet-4-6
 tools:
   read: true
   write: true
@@ -45,8 +45,12 @@ You are a capable AI assistant optimized for software development tasks. This is
 | Field | Value |
 |-------|-------|
 | Provider | Anthropic |
-| Model | claude-sonnet-4 |
-| Context | 200K tokens |
+| Model | claude-sonnet-4-6 |
+| API ID | claude-sonnet-4-6 |
+| Context | 200K tokens (1M beta) |
+| Max output | 64K tokens |
 | Input cost | $3.00/1M tokens |
 | Output cost | $15.00/1M tokens |
+| Training data cutoff | Jan 2026 |
+| Reliable knowledge cutoff | Aug 2025 |
 | Tier | sonnet (default, balanced) |

--- a/.agents/tools/ai-assistants/opencode-server.md
+++ b/.agents/tools/ai-assistants/opencode-server.md
@@ -105,7 +105,7 @@ const { client, server } = await createOpencode({
   port: 4096,
   hostname: "127.0.0.1",
   config: {
-    model: "anthropic/claude-sonnet-4-20250514",
+    model: "anthropic/claude-sonnet-4-6",
   },
 })
 
@@ -146,7 +146,7 @@ const result = await client.session.prompt({
   body: {
     model: {
       providerID: "anthropic",
-      modelID: "claude-sonnet-4-20250514",
+      modelID: "claude-sonnet-4-6",
     },
     parts: [{ type: "text", text: "Explain this codebase structure" }],
   },
@@ -222,7 +222,7 @@ curl -X POST http://localhost:4096/session/{session_id}/message \
   -d '{
     "model": {
       "providerID": "anthropic",
-      "modelID": "claude-sonnet-4-20250514"
+      "modelID": "claude-sonnet-4-6"
     },
     "parts": [{"type": "text", "text": "Hello!"}]
   }'

--- a/.agents/tools/automation/cron-agent.md
+++ b/.agents/tools/automation/cron-agent.md
@@ -183,7 +183,7 @@ Jobs are stored in `~/.config/aidevops/cron-jobs.json`:
       "workdir": "/Users/me/projects/example-site",
       "timeout": 300,
       "notify": "mail",
-      "model": "anthropic/claude-sonnet-4-20250514",
+      "model": "anthropic/claude-sonnet-4-6",
       "status": "active",
       "created": "2024-01-10T10:00:00Z",
       "lastRun": "2024-01-15T09:00:00Z",

--- a/.agents/tools/build-agent/agent-testing.md
+++ b/.agents/tools/build-agent/agent-testing.md
@@ -74,7 +74,7 @@ Test suites are JSON files defining prompts and expected response patterns:
   "name": "build-agent-tests",
   "description": "Validates build-agent subagent knowledge",
   "agent": "Build+",
-  "model": "anthropic/claude-sonnet-4-20250514",
+  "model": "anthropic/claude-sonnet-4-6",
   "timeout": 120,
   "tests": [
     {
@@ -149,7 +149,7 @@ agent-test-helper.sh run-one "List your tools" --expect "bash"
 # With specific agent and model
 agent-test-helper.sh run-one "Explain git workflow" \
   --agent "Build+" \
-  --model "anthropic/claude-sonnet-4-20250514" \
+  --model "anthropic/claude-sonnet-4-6" \
   --timeout 60
 ```
 

--- a/.agents/tools/content/summarize.md
+++ b/.agents/tools/content/summarize.md
@@ -180,7 +180,7 @@ summarize "https://example.com" --stream off
 | Provider | Model ID Format | API Key |
 |----------|-----------------|---------|
 | OpenAI | `openai/gpt-5-mini` | `OPENAI_API_KEY` |
-| Anthropic | `anthropic/claude-sonnet-4-5` | `ANTHROPIC_API_KEY` |
+| Anthropic | `anthropic/claude-sonnet-4-6` | `ANTHROPIC_API_KEY` |
 | Google | `google/gemini-3-flash-preview` | `GEMINI_API_KEY` |
 | xAI | `xai/grok-4-fast-non-reasoning` | `XAI_API_KEY` |
 | Z.AI | `zai/glm-4.7` | `Z_AI_API_KEY` |

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -189,7 +189,7 @@ The model availability checker (`model-availability-helper.sh`) provides lightwe
 model-availability-helper.sh check anthropic
 
 # Check a specific model
-model-availability-helper.sh check anthropic/claude-sonnet-4-20250514
+model-availability-helper.sh check anthropic/claude-sonnet-4-6
 
 # Resolve best available model for a tier (with automatic fallback)
 model-availability-helper.sh resolve opus

--- a/.agents/tools/git/opencode-github.md
+++ b/.agents/tools/git/opencode-github.md
@@ -105,7 +105,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          model: anthropic/claude-sonnet-4-20250514
+          model: anthropic/claude-sonnet-4-6
 ```
 
 #### 3. Add Secrets
@@ -178,7 +178,7 @@ This function needs better validation. /oc add input validation
 ```yaml
 - uses: sst/opencode/github@latest
   with:
-    model: anthropic/claude-sonnet-4-20250514  # Required
+    model: anthropic/claude-sonnet-4-6  # Required
     agent: build                                # Optional: agent to use
     share: true                                 # Optional: share session (default: true for public repos)
     prompt: |                                   # Optional: custom prompt
@@ -201,7 +201,7 @@ To use `GITHUB_TOKEN` instead of the app:
 ```yaml
 - uses: sst/opencode/github@latest
   with:
-    model: anthropic/claude-sonnet-4-20250514
+    model: anthropic/claude-sonnet-4-6
     token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/.agents/tools/git/opencode-gitlab.md
+++ b/.agents/tools/git/opencode-gitlab.md
@@ -189,7 +189,7 @@ Specify model in the opencode run command:
 
 ```yaml
 script:
-  - opencode run --model anthropic/claude-sonnet-4-20250514 "$AI_FLOW_INPUT"
+  - opencode run --model anthropic/claude-sonnet-4-6 "$AI_FLOW_INPUT"
 ```
 
 ### Self-Hosted GitLab

--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -264,7 +264,7 @@ opencode auth login   # Choose manual API key
 opencode auth status
 
 # Test API access
-opencode run "Hello, Claude!" --model anthropic/claude-sonnet-4-20250514
+opencode run "Hello, Claude!" --model anthropic/claude-sonnet-4-6
 ```
 
 ## Troubleshooting
@@ -385,7 +385,7 @@ Enable verbose logging to troubleshoot authentication issues:
 
 ```bash
 # Set debug environment variable
-DEBUG=opencode:* opencode run "test" --model anthropic/claude-sonnet-4-20250514
+DEBUG=opencode:* opencode run "test" --model anthropic/claude-sonnet-4-6
 
 # Check token expiration
 cat ~/.config/opencode/auth.json | jq '.anthropic'

--- a/.agents/tools/opencode/opencode.md
+++ b/.agents/tools/opencode/opencode.md
@@ -311,7 +311,7 @@ opencode run "List your available tools" --agent SEO
 opencode run "Use dataforseo to get SERP for 'test query'" --agent SEO
 
 # Test with different model
-opencode run "Quick test" --agent Build+ --model anthropic/claude-sonnet-4-20250514
+opencode run "Quick test" --agent Build+ --model anthropic/claude-sonnet-4-6
 
 # Capture errors for debugging
 opencode run "Test the serper MCP" --agent SEO 2>&1

--- a/.agents/tools/vision/image-understanding.md
+++ b/.agents/tools/vision/image-understanding.md
@@ -122,7 +122,7 @@ curl https://api.anthropic.com/v1/messages \
   -H "anthropic-version: 2023-06-01" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-4-6",
     "max_tokens": 1024,
     "messages": [{
       "role": "user",

--- a/.agents/tools/voice/pipecat-opencode.md
+++ b/.agents/tools/voice/pipecat-opencode.md
@@ -173,7 +173,7 @@ async def run_agent(webrtc_connection: SmallWebRTCConnection):
     )
     llm = AnthropicLLMService(
         api_key=os.getenv("ANTHROPIC_API_KEY"),
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-6",
     )
 
     # System prompt for voice interaction
@@ -322,7 +322,7 @@ tools = [
 
 llm = AnthropicLLMService(
     api_key=os.getenv("ANTHROPIC_API_KEY"),
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-4-6",
     tools=tools,
 )
 ```

--- a/.opencode/lib/ai-research.ts
+++ b/.opencode/lib/ai-research.ts
@@ -42,9 +42,9 @@ export interface ResearchResult {
 const AGENTS_BASE = `${process.env.HOME || "~"}/.aidevops/agents`
 
 const MODEL_MAP: Record<string, string> = {
-  haiku: "claude-3-haiku-20240307",
-  sonnet: "claude-sonnet-4-20250514",
-  opus: "claude-opus-4-20250514",
+  haiku: "claude-haiku-4-5",
+  sonnet: "claude-sonnet-4-6",
+  opus: "claude-opus-4-6",
 }
 
 const MAX_CALLS_PER_SESSION = 10

--- a/configs/mcp-templates/opencode-github-workflow.yml
+++ b/configs/mcp-templates/opencode-github-workflow.yml
@@ -49,7 +49,7 @@ jobs:
           # GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         with:
           # Required: AI model to use
-          model: anthropic/claude-sonnet-4-20250514
+          model: anthropic/claude-sonnet-4-6
           
           # Optional: Specify agent (defaults to "build")
           # agent: build

--- a/tests/test-batch-quality-hardening.sh
+++ b/tests/test-batch-quality-hardening.sh
@@ -24,34 +24,34 @@ SKIP_COUNT=0
 TOTAL_COUNT=0
 
 pass() {
-    PASS_COUNT=$((PASS_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;32mPASS\033[0m %s\n" "$1"
 }
 
 fail() {
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
-    if [[ -n "${2:-}" ]]; then
-        printf "       %s\n" "$2"
-    fi
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
 }
 
 skip() {
-    SKIP_COUNT=$((SKIP_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+	SKIP_COUNT=$((SKIP_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
 }
 
 section() {
-    echo ""
-    printf "\033[1m=== %s ===\033[0m\n" "$1"
+	echo ""
+	printf "\033[1m=== %s ===\033[0m\n" "$1"
 }
 
 # Helper: list all git-tracked .sh files with absolute paths
 list_shell_scripts() {
-    git -C "$REPO_DIR" ls-files '*.sh' | while read -r f; do echo "$REPO_DIR/$f"; done
+	git -C "$REPO_DIR" ls-files '*.sh' | while read -r f; do echo "$REPO_DIR/$f"; done
 }
 
 # ============================================================
@@ -61,95 +61,95 @@ section "Supervisor: Worker Launch (nohup + disown)"
 
 # Test: Workers use nohup to survive parent exit
 if grep -q 'nohup bash -c' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "cmd_dispatch uses nohup for worker launch"
+	pass "cmd_dispatch uses nohup for worker launch"
 else
-    fail "cmd_dispatch missing nohup for worker launch" \
-        "Workers will die when cron pulse exits (~2 min)"
+	fail "cmd_dispatch missing nohup for worker launch" \
+		"Workers will die when cron pulse exits (~2 min)"
 fi
 
 # Test: Workers are disowned after launch
 if grep -q 'disown.*worker_pid' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "cmd_dispatch disowns worker process"
+	pass "cmd_dispatch disowns worker process"
 else
-    fail "cmd_dispatch missing disown" \
-        "Workers may receive SIGHUP on parent exit"
+	fail "cmd_dispatch missing disown" \
+		"Workers may receive SIGHUP on parent exit"
 fi
 
 # Test: Re-prompt also uses nohup
 reprompt_nohup=$(grep -c 'nohup bash -c' "$SCRIPTS_DIR/supervisor-helper.sh")
 if [[ "$reprompt_nohup" -ge 3 ]]; then
-    pass "cmd_reprompt also uses nohup (found $reprompt_nohup nohup instances)"
+	pass "cmd_reprompt also uses nohup (found $reprompt_nohup nohup instances)"
 else
-    fail "cmd_reprompt may be missing nohup (found $reprompt_nohup, expected >= 3)" \
-        "Re-prompted workers will also die on cron exit"
+	fail "cmd_reprompt may be missing nohup (found $reprompt_nohup, expected >= 3)" \
+		"Re-prompted workers will also die on cron exit"
 fi
 
 section "Supervisor: Dispatch Exit Code Handling"
 
 # Test: Dispatch loop captures exit code correctly (not $? after if)
 if grep -q 'cmd_dispatch.*||.*dispatch_exit=\$?' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Dispatch loop uses 'cmd || exit=\$?' pattern (not \$? after if)"
+	pass "Dispatch loop uses 'cmd || exit=\$?' pattern (not \$? after if)"
 else
-    fail "Dispatch loop may still use \$? after if (SC2319 bug)" \
-        "Exit code 2 (concurrency) and 3 (provider down) won't be detected"
+	fail "Dispatch loop may still use \$? after if (SC2319 bug)" \
+		"Exit code 2 (concurrency) and 3 (provider down) won't be detected"
 fi
 
 # Test: Dispatch failures are logged (not swallowed by 2>/dev/null)
 if grep -q 'Dispatch failed for.*exit.*trying next' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Dispatch failures are logged with exit code"
+	pass "Dispatch failures are logged with exit code"
 else
-    fail "Dispatch failures may be silently swallowed" \
-        "Cron log will show 'Dispatched: 0' with no explanation"
+	fail "Dispatch failures may be silently swallowed" \
+		"Cron log will show 'Dispatched: 0' with no explanation"
 fi
 
 section "Supervisor: Pulse-Level Health Check Caching"
 
 # Test: _PULSE_HEALTH_VERIFIED flag exists
 if grep -q '_PULSE_HEALTH_VERIFIED' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Pulse-level health check flag exists"
+	pass "Pulse-level health check flag exists"
 else
-    fail "Missing _PULSE_HEALTH_VERIFIED flag" \
-        "Health check will run 8s probe per task instead of once per pulse"
+	fail "Missing _PULSE_HEALTH_VERIFIED flag" \
+		"Health check will run 8s probe per task instead of once per pulse"
 fi
 
 # Test: check_model_health respects pulse flag
 if grep -q 'pulse-verified OK' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "check_model_health has pulse-level fast path"
+	pass "check_model_health has pulse-level fast path"
 else
-    fail "check_model_health missing pulse-level fast path"
+	fail "check_model_health missing pulse-level fast path"
 fi
 
 # Test: Health check sets pulse flag on success
 pulse_flag_sets=$(grep -c '_PULSE_HEALTH_VERIFIED="true"' "$SCRIPTS_DIR/supervisor-helper.sh")
 if [[ "$pulse_flag_sets" -ge 2 ]]; then
-    pass "Health check sets pulse flag on success ($pulse_flag_sets locations)"
+	pass "Health check sets pulse flag on success ($pulse_flag_sets locations)"
 else
-    fail "Health check may not set pulse flag consistently (found $pulse_flag_sets, expected >= 2)"
+	fail "Health check may not set pulse flag consistently (found $pulse_flag_sets, expected >= 2)"
 fi
 
 section "Supervisor: macOS Timeout Compatibility"
 
 # Test: Health check has macOS fallback (no coreutils timeout dependency)
 if grep -qE 'gtimeout|background process with manual kill' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Health check has macOS timeout fallback"
+	pass "Health check has macOS timeout fallback"
 else
-    fail "Health check may depend on coreutils timeout (not available on macOS)"
+	fail "Health check may depend on coreutils timeout (not available on macOS)"
 fi
 
 section "Supervisor: Model Resolution"
 
-# Test: OpenCode model ID is correct (claude-sonnet-4-5, not claude-sonnet-4)
-if grep -q 'claude-sonnet-4-5' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Model ID uses claude-sonnet-4-5 (correct for OpenCode)"
+# Test: OpenCode model ID is correct (claude-sonnet-4-6, not claude-sonnet-4)
+if grep -q 'claude-sonnet-4-6' "$SCRIPTS_DIR/supervisor-helper.sh"; then
+	pass "Model ID uses claude-sonnet-4-6 (correct for OpenCode)"
 else
-    fail "Model ID may be wrong (claude-sonnet-4 instead of claude-sonnet-4-5)"
+	fail "Model ID may be wrong (not claude-sonnet-4-6)"
 fi
 
 # Test: SUPERVISOR_MODEL env var override exists
 if grep -q 'SUPERVISOR_MODEL' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "SUPERVISOR_MODEL env var override supported"
+	pass "SUPERVISOR_MODEL env var override supported"
 else
-    fail "Missing SUPERVISOR_MODEL env var override"
+	fail "Missing SUPERVISOR_MODEL env var override"
 fi
 
 # ============================================================
@@ -158,19 +158,19 @@ fi
 section "t135.4: JSON Config File Integrity"
 
 # Test: pandoc-config.json.txt is valid JSON
-if python3 -m json.tool "$REPO_DIR/configs/pandoc-config.json.txt" > /dev/null 2>&1; then
-    pass "configs/pandoc-config.json.txt is valid JSON"
+if python3 -m json.tool "$REPO_DIR/configs/pandoc-config.json.txt" >/dev/null 2>&1; then
+	pass "configs/pandoc-config.json.txt is valid JSON"
 else
-    fail "configs/pandoc-config.json.txt is INVALID JSON" \
-        "$(python3 -m json.tool "$REPO_DIR/configs/pandoc-config.json.txt" 2>&1 | head -3)"
+	fail "configs/pandoc-config.json.txt is INVALID JSON" \
+		"$(python3 -m json.tool "$REPO_DIR/configs/pandoc-config.json.txt" 2>&1 | head -3)"
 fi
 
 # Test: chrome-devtools.json is valid JSON
-if python3 -m json.tool "$REPO_DIR/configs/mcp-templates/chrome-devtools.json" > /dev/null 2>&1; then
-    pass "configs/mcp-templates/chrome-devtools.json is valid JSON"
+if python3 -m json.tool "$REPO_DIR/configs/mcp-templates/chrome-devtools.json" >/dev/null 2>&1; then
+	pass "configs/mcp-templates/chrome-devtools.json is valid JSON"
 else
-    fail "configs/mcp-templates/chrome-devtools.json is INVALID JSON" \
-        "$(python3 -m json.tool "$REPO_DIR/configs/mcp-templates/chrome-devtools.json" 2>&1 | head -3)"
+	fail "configs/mcp-templates/chrome-devtools.json is INVALID JSON" \
+		"$(python3 -m json.tool "$REPO_DIR/configs/mcp-templates/chrome-devtools.json" 2>&1 | head -3)"
 fi
 
 # Test: No embedded newlines in JSON keys (the original corruption)
@@ -181,24 +181,24 @@ d = json.load(open('$REPO_DIR/configs/pandoc-config.json.txt'))
 bad = [k for k in d if '\n' in k]
 sys.exit(1 if bad else 0)
 " 2>/dev/null; then
-    pass "No embedded newline characters in pandoc-config.json.txt keys"
+	pass "No embedded newline characters in pandoc-config.json.txt keys"
 else
-    fail "pandoc-config.json.txt still has embedded newline in keys"
+	fail "pandoc-config.json.txt still has embedded newline in keys"
 fi
 
 # Test: All git-tracked .json and .json.txt config files are valid
 # Note: gitignored working copies (configs/*.json) are excluded -- only tracked files matter
 json_invalid=0
 while IFS= read -r f; do
-    if ! python3 -m json.tool "$REPO_DIR/$f" > /dev/null 2>&1; then
-        json_invalid=$((json_invalid + 1))
-        [[ "$VERBOSE" == "--verbose" ]] && echo "       Invalid: $f"
-    fi
+	if ! python3 -m json.tool "$REPO_DIR/$f" >/dev/null 2>&1; then
+		json_invalid=$((json_invalid + 1))
+		[[ "$VERBOSE" == "--verbose" ]] && echo "       Invalid: $f"
+	fi
 done < <(git -C "$REPO_DIR" ls-files 'configs/*.json' 'configs/*.json.txt' 'configs/**/*.json' 'configs/**/*.json.txt' 2>/dev/null)
 if [[ "$json_invalid" -eq 0 ]]; then
-    pass "All git-tracked JSON config files in configs/ are valid"
+	pass "All git-tracked JSON config files in configs/ are valid"
 else
-    fail "$json_invalid git-tracked JSON config file(s) are invalid in configs/"
+	fail "$json_invalid git-tracked JSON config file(s) are invalid in configs/"
 fi
 
 # ============================================================
@@ -208,29 +208,29 @@ section "t135.5: Gitignored Artifacts Removed"
 
 # Test: .scannerwork not tracked
 if git -C "$REPO_DIR" ls-files .scannerwork 2>/dev/null | grep -q .; then
-    fail ".scannerwork is still tracked in git"
+	fail ".scannerwork is still tracked in git"
 else
-    pass ".scannerwork is not tracked in git"
+	pass ".scannerwork is not tracked in git"
 fi
 
 # Test: .playwright-cli not tracked
 if git -C "$REPO_DIR" ls-files .playwright-cli 2>/dev/null | grep -q .; then
-    fail ".playwright-cli is still tracked in git"
+	fail ".playwright-cli is still tracked in git"
 else
-    pass ".playwright-cli is not tracked in git"
+	pass ".playwright-cli is not tracked in git"
 fi
 
 # Test: .gitignore has entries for these
 if grep -q 'scannerwork' "$REPO_DIR/.gitignore" 2>/dev/null; then
-    pass ".gitignore contains .scannerwork entry"
+	pass ".gitignore contains .scannerwork entry"
 else
-    fail ".gitignore missing .scannerwork entry"
+	fail ".gitignore missing .scannerwork entry"
 fi
 
 if grep -q 'playwright-cli' "$REPO_DIR/.gitignore" 2>/dev/null; then
-    pass ".gitignore contains .playwright-cli entry"
+	pass ".gitignore contains .playwright-cli entry"
 else
-    fail ".gitignore missing .playwright-cli entry"
+	fail ".gitignore missing .playwright-cli entry"
 fi
 
 # ============================================================
@@ -240,28 +240,28 @@ section "t135.10: package.json Main Field"
 
 # Test: main field is removed (index.js doesn't exist)
 if python3 -c "import json; d=json.load(open('$REPO_DIR/package.json')); exit(0 if 'main' not in d else 1)" 2>/dev/null; then
-    pass "package.json has no 'main' field (index.js doesn't exist)"
+	pass "package.json has no 'main' field (index.js doesn't exist)"
 else
-    main_val=$(python3 -c "import json; d=json.load(open('$REPO_DIR/package.json')); print(d.get('main',''))" 2>/dev/null)
-    if [[ -f "$REPO_DIR/$main_val" ]]; then
-        pass "package.json main field '$main_val' points to existing file"
-    else
-        fail "package.json main field '$main_val' points to non-existent file"
-    fi
+	main_val=$(python3 -c "import json; d=json.load(open('$REPO_DIR/package.json')); print(d.get('main',''))" 2>/dev/null)
+	if [[ -f "$REPO_DIR/$main_val" ]]; then
+		pass "package.json main field '$main_val' points to existing file"
+	else
+		fail "package.json main field '$main_val' points to non-existent file"
+	fi
 fi
 
 # Test: package.json is valid JSON
-if python3 -m json.tool "$REPO_DIR/package.json" > /dev/null 2>&1; then
-    pass "package.json is valid JSON"
+if python3 -m json.tool "$REPO_DIR/package.json" >/dev/null 2>&1; then
+	pass "package.json is valid JSON"
 else
-    fail "package.json is INVALID JSON"
+	fail "package.json is INVALID JSON"
 fi
 
 # Test: bin field exists (this is a CLI tool)
 if python3 -c "import json; d=json.load(open('$REPO_DIR/package.json')); exit(0 if 'bin' in d else 1)" 2>/dev/null; then
-    pass "package.json has 'bin' field (CLI entry point)"
+	pass "package.json has 'bin' field (CLI entry point)"
 else
-    fail "package.json missing 'bin' field"
+	fail "package.json missing 'bin' field"
 fi
 
 # ============================================================
@@ -272,33 +272,33 @@ section "t135.14: Shebang Standardization"
 # Test: No scripts use #!/bin/bash (should all be #!/usr/bin/env bash)
 bin_bash_count=0
 while IFS= read -r f; do
-    first_line=$(head -1 "$f" 2>/dev/null)
-    if [[ "$first_line" == "#!/bin/bash" ]]; then
-        bin_bash_count=$((bin_bash_count + 1))
-        [[ "$VERBOSE" == "--verbose" ]] && echo "       #!/bin/bash: $f"
-    fi
+	first_line=$(head -1 "$f" 2>/dev/null)
+	if [[ "$first_line" == "#!/bin/bash" ]]; then
+		bin_bash_count=$((bin_bash_count + 1))
+		[[ "$VERBOSE" == "--verbose" ]] && echo "       #!/bin/bash: $f"
+	fi
 done < <(list_shell_scripts)
 
 if [[ "$bin_bash_count" -eq 0 ]]; then
-    pass "All .sh files use #!/usr/bin/env bash (0 using #!/bin/bash)"
+	pass "All .sh files use #!/usr/bin/env bash (0 using #!/bin/bash)"
 else
-    fail "$bin_bash_count script(s) still use #!/bin/bash instead of #!/usr/bin/env bash"
+	fail "$bin_bash_count script(s) still use #!/bin/bash instead of #!/usr/bin/env bash"
 fi
 
 # Test: All .sh files have a shebang
 no_shebang_count=0
 while IFS= read -r f; do
-    first_line=$(head -1 "$f" 2>/dev/null)
-    if [[ ! "$first_line" =~ ^#! ]]; then
-        no_shebang_count=$((no_shebang_count + 1))
-        [[ "$VERBOSE" == "--verbose" ]] && echo "       No shebang: $f"
-    fi
+	first_line=$(head -1 "$f" 2>/dev/null)
+	if [[ ! "$first_line" =~ ^#! ]]; then
+		no_shebang_count=$((no_shebang_count + 1))
+		[[ "$VERBOSE" == "--verbose" ]] && echo "       No shebang: $f"
+	fi
 done < <(list_shell_scripts)
 
 if [[ "$no_shebang_count" -eq 0 ]]; then
-    pass "All .sh files have a shebang line"
+	pass "All .sh files have a shebang line"
 else
-    fail "$no_shebang_count script(s) missing shebang line"
+	fail "$no_shebang_count script(s) missing shebang line"
 fi
 
 # ============================================================
@@ -308,30 +308,30 @@ section "t135.15: Supervisor Resource Monitoring"
 
 # Test: calculate_adaptive_concurrency function exists
 if grep -q 'calculate_adaptive_concurrency()' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "calculate_adaptive_concurrency() function exists"
+	pass "calculate_adaptive_concurrency() function exists"
 else
-    fail "calculate_adaptive_concurrency() function missing"
+	fail "calculate_adaptive_concurrency() function missing"
 fi
 
 # Test: Pulse outputs system resource info
 if grep -q 'System resources' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Pulse outputs system resource summary"
+	pass "Pulse outputs system resource summary"
 else
-    fail "Pulse missing system resource output"
+	fail "Pulse missing system resource output"
 fi
 
 # Test: Load monitoring uses sysctl on macOS
 if grep -qE 'sysctl|vm_stat|/proc/loadavg' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Resource monitoring supports macOS (sysctl/vm_stat)"
+	pass "Resource monitoring supports macOS (sysctl/vm_stat)"
 else
-    fail "Resource monitoring may not work on macOS"
+	fail "Resource monitoring may not work on macOS"
 fi
 
 # Test: Adaptive concurrency reduces under load
 if grep -qE 'effective_concurrency=1|halve concurrency' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Adaptive concurrency throttles under high load"
+	pass "Adaptive concurrency throttles under high load"
 else
-    fail "Adaptive concurrency missing throttle logic"
+	fail "Adaptive concurrency missing throttle logic"
 fi
 
 # ============================================================
@@ -341,23 +341,23 @@ section "t137: OpenCode Config Template Deployment"
 
 # Test: Template file exists
 if [[ -f "$REPO_DIR/templates/opencode-config-agents.md" ]]; then
-    pass "templates/opencode-config-agents.md exists"
+	pass "templates/opencode-config-agents.md exists"
 else
-    fail "templates/opencode-config-agents.md missing"
+	fail "templates/opencode-config-agents.md missing"
 fi
 
 # Test: setup.sh has deployment logic for the template
 if grep -q 'opencode-config-agents.md' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh references opencode-config-agents.md for deployment"
+	pass "setup.sh references opencode-config-agents.md for deployment"
 else
-    fail "setup.sh missing opencode-config-agents.md deployment logic"
+	fail "setup.sh missing opencode-config-agents.md deployment logic"
 fi
 
 # Test: Deployed template exists (if setup has been run)
 if [[ -f "$HOME/.config/opencode/AGENTS.md" ]]; then
-    pass "\$HOME/.config/opencode/AGENTS.md is deployed"
+	pass "\$HOME/.config/opencode/AGENTS.md is deployed"
 else
-    skip "\$HOME/.config/opencode/AGENTS.md not deployed (run setup.sh to deploy)"
+	skip "\$HOME/.config/opencode/AGENTS.md not deployed (run setup.sh to deploy)"
 fi
 
 # ============================================================
@@ -367,30 +367,30 @@ section "t138: Update Output Bounding"
 
 # Test: git pull uses --quiet flag
 if grep -qE 'git pull.*--quiet|git pull.*-q' "$REPO_DIR/aidevops.sh"; then
-    pass "aidevops update uses --quiet git pull"
+	pass "aidevops update uses --quiet git pull"
 else
-    fail "aidevops update may produce unbounded git pull output"
+	fail "aidevops update may produce unbounded git pull output"
 fi
 
 # Test: Commit log is filtered to meaningful changes
 if grep -q 'feat|fix|refactor|perf|docs' "$REPO_DIR/aidevops.sh"; then
-    pass "Update output filters to meaningful commit types (feat/fix/refactor/perf/docs)"
+	pass "Update output filters to meaningful commit types (feat/fix/refactor/perf/docs)"
 else
-    fail "Update output may show all commits (including chore/merge)"
+	fail "Update output may show all commits (including chore/merge)"
 fi
 
 # Test: Output is bounded with head
 if grep -q 'head -20' "$REPO_DIR/aidevops.sh"; then
-    pass "Update output bounded to 20 lines max"
+	pass "Update output bounded to 20 lines max"
 else
-    fail "Update output may be unbounded (missing head -20)"
+	fail "Update output may be unbounded (missing head -20)"
 fi
 
 # Test: Overflow message for large updates
 if grep -qE 'and more|full list' "$REPO_DIR/aidevops.sh"; then
-    pass "Shows overflow message when > 20 commits"
+	pass "Shows overflow message when > 20 commits"
 else
-    fail "Missing overflow message for large updates"
+	fail "Missing overflow message for large updates"
 fi
 
 # ============================================================
@@ -400,29 +400,29 @@ section "t139: Memory FTS5 Hyphen Escaping"
 
 # Test: Query is wrapped in double quotes for FTS5
 if grep -q 'escaped_query=.*".*"' "$SCRIPTS_DIR/memory-helper.sh"; then
-    pass "FTS5 query is wrapped in double quotes"
+	pass "FTS5 query is wrapped in double quotes"
 else
-    fail "FTS5 query may not be quoted (hyphens interpreted as NOT operator)"
+	fail "FTS5 query may not be quoted (hyphens interpreted as NOT operator)"
 fi
 
 # Test: Comment explains the hyphen issue
 if grep -qE 'hyphens.*NOT operator|FTS5 treats hyphens' "$SCRIPTS_DIR/memory-helper.sh"; then
-    pass "Code documents the FTS5 hyphen issue"
+	pass "Code documents the FTS5 hyphen issue"
 else
-    fail "Missing documentation about FTS5 hyphen behavior"
+	fail "Missing documentation about FTS5 hyphen behavior"
 fi
 
 # Test: Functional test - recall with hyphenated query doesn't error
 if command -v "$DEPLOYED_DIR/memory-helper.sh" &>/dev/null || [[ -f "$DEPLOYED_DIR/memory-helper.sh" ]]; then
-    recall_output=$(bash "$DEPLOYED_DIR/memory-helper.sh" recall "test-hyphen-query" 2>&1 || true)
-    if echo "$recall_output" | grep -qiE "error.*column|fts5.*syntax|no such column"; then
-        fail "memory-helper.sh recall fails on hyphenated query" \
-            "$recall_output"
-    else
-        pass "memory-helper.sh recall handles hyphenated query without FTS5 error"
-    fi
+	recall_output=$(bash "$DEPLOYED_DIR/memory-helper.sh" recall "test-hyphen-query" 2>&1 || true)
+	if echo "$recall_output" | grep -qiE "error.*column|fts5.*syntax|no such column"; then
+		fail "memory-helper.sh recall fails on hyphenated query" \
+			"$recall_output"
+	else
+		pass "memory-helper.sh recall handles hyphenated query without FTS5 error"
+	fi
 else
-    skip "memory-helper.sh not deployed (can't run functional test)"
+	skip "memory-helper.sh not deployed (can't run functional test)"
 fi
 
 # ============================================================
@@ -432,31 +432,31 @@ section "t140: PEP 668 Skill Scanner Fallback Chain"
 
 # Test: setup.sh has uv fallback
 if grep -q 'uv tool install cisco-ai-skill-scanner' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh has uv tool install fallback"
+	pass "setup.sh has uv tool install fallback"
 else
-    fail "setup.sh missing uv tool install fallback"
+	fail "setup.sh missing uv tool install fallback"
 fi
 
 # Test: setup.sh has pipx fallback
 if grep -q 'pipx install cisco-ai-skill-scanner' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh has pipx install fallback"
+	pass "setup.sh has pipx install fallback"
 else
-    fail "setup.sh missing pipx install fallback"
+	fail "setup.sh missing pipx install fallback"
 fi
 
 # Test: setup.sh has venv+symlink fallback
 # The venv dir and python3 -m venv are on separate lines, so check both exist
 if grep -q 'python3 -m venv' "$REPO_DIR/setup.sh" && grep -q 'cisco-scanner-env' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh has venv+symlink fallback"
+	pass "setup.sh has venv+symlink fallback"
 else
-    fail "setup.sh missing venv+symlink fallback"
+	fail "setup.sh missing venv+symlink fallback"
 fi
 
 # Test: setup.sh has pip3 --user legacy fallback
 if grep -q 'pip3 install --user cisco-ai-skill-scanner' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh has pip3 --user legacy fallback"
+	pass "setup.sh has pip3 --user legacy fallback"
 else
-    fail "setup.sh missing pip3 --user legacy fallback"
+	fail "setup.sh missing pip3 --user legacy fallback"
 fi
 
 # Test: Fallback chain is in correct order (uv -> pipx -> venv -> pip3)
@@ -466,27 +466,27 @@ venv_line=$(grep -n 'cisco-scanner-env' "$REPO_DIR/setup.sh" | head -1 | cut -d:
 pip3_line=$(grep -n 'pip3 install --user cisco' "$REPO_DIR/setup.sh" | head -1 | cut -d: -f1 || true)
 
 if [[ -n "$uv_line" && -n "$pipx_line" && -n "$venv_line" && -n "$pip3_line" ]]; then
-    if [[ "$uv_line" -lt "$pipx_line" && "$pipx_line" -lt "$venv_line" && "$venv_line" -lt "$pip3_line" ]]; then
-        pass "Fallback chain order is correct: uv ($uv_line) -> pipx ($pipx_line) -> venv ($venv_line) -> pip3 ($pip3_line)"
-    else
-        fail "Fallback chain order is wrong: uv=$uv_line pipx=$pipx_line venv=$venv_line pip3=$pip3_line"
-    fi
+	if [[ "$uv_line" -lt "$pipx_line" && "$pipx_line" -lt "$venv_line" && "$venv_line" -lt "$pip3_line" ]]; then
+		pass "Fallback chain order is correct: uv ($uv_line) -> pipx ($pipx_line) -> venv ($venv_line) -> pip3 ($pip3_line)"
+	else
+		fail "Fallback chain order is wrong: uv=$uv_line pipx=$pipx_line venv=$venv_line pip3=$pip3_line"
+	fi
 else
-    fail "Could not determine fallback chain order (missing line numbers)"
+	fail "Could not determine fallback chain order (missing line numbers)"
 fi
 
 # Test: Venv cleanup on failure
 if grep -qE 'rm -rf.*cisco-scanner-env|rm -rf.*venv_dir' "$REPO_DIR/setup.sh"; then
-    pass "Venv is cleaned up on installation failure"
+	pass "Venv is cleaned up on installation failure"
 else
-    fail "Venv may not be cleaned up on failure"
+	fail "Venv may not be cleaned up on failure"
 fi
 
 # Test: Helpful error message when all fallbacks fail
 if grep -qE 'Install manually with.*uv tool install|Or:.*pipx install' "$REPO_DIR/setup.sh"; then
-    pass "Shows helpful manual install instructions on total failure"
+	pass "Shows helpful manual install instructions on total failure"
 else
-    fail "Missing helpful error message when all fallbacks fail"
+	fail "Missing helpful error message when all fallbacks fail"
 fi
 
 # ============================================================
@@ -496,51 +496,51 @@ section "Cross-Cutting: Script Quality"
 
 # Test: supervisor-helper.sh passes bash syntax check
 if bash -n "$SCRIPTS_DIR/supervisor-helper.sh" 2>/dev/null; then
-    pass "supervisor-helper.sh passes bash -n syntax check"
+	pass "supervisor-helper.sh passes bash -n syntax check"
 else
-    fail "supervisor-helper.sh has syntax errors"
+	fail "supervisor-helper.sh has syntax errors"
 fi
 
 # Test: memory-helper.sh passes bash syntax check
 if bash -n "$SCRIPTS_DIR/memory-helper.sh" 2>/dev/null; then
-    pass "memory-helper.sh passes bash -n syntax check"
+	pass "memory-helper.sh passes bash -n syntax check"
 else
-    fail "memory-helper.sh has syntax errors"
+	fail "memory-helper.sh has syntax errors"
 fi
 
 # Test: setup.sh passes bash syntax check
 if bash -n "$REPO_DIR/setup.sh" 2>/dev/null; then
-    pass "setup.sh passes bash -n syntax check"
+	pass "setup.sh passes bash -n syntax check"
 else
-    fail "setup.sh has syntax errors"
+	fail "setup.sh has syntax errors"
 fi
 
 # Test: aidevops.sh passes bash syntax check
 if bash -n "$REPO_DIR/aidevops.sh" 2>/dev/null; then
-    pass "aidevops.sh passes bash -n syntax check"
+	pass "aidevops.sh passes bash -n syntax check"
 else
-    fail "aidevops.sh has syntax errors"
+	fail "aidevops.sh has syntax errors"
 fi
 
 # Test: ShellCheck on supervisor-helper.sh (no errors, only warnings allowed)
 if command -v shellcheck &>/dev/null; then
-    sc_errors=$(shellcheck -S error "$SCRIPTS_DIR/supervisor-helper.sh" 2>&1 | grep -c "error" || true)
-    if [[ "$sc_errors" -eq 0 ]]; then
-        pass "supervisor-helper.sh has 0 ShellCheck errors"
-    else
-        fail "supervisor-helper.sh has $sc_errors ShellCheck errors"
-    fi
+	sc_errors=$(shellcheck -S error "$SCRIPTS_DIR/supervisor-helper.sh" 2>&1 | grep -c "error" || true)
+	if [[ "$sc_errors" -eq 0 ]]; then
+		pass "supervisor-helper.sh has 0 ShellCheck errors"
+	else
+		fail "supervisor-helper.sh has $sc_errors ShellCheck errors"
+	fi
 else
-    skip "shellcheck not installed"
+	skip "shellcheck not installed"
 fi
 
 # Test: No TODO/FIXME/HACK markers in the specific changed functions
 # Exclude legitimate references like "TODO.md" and "auto-dispatch"
 hack_count=$(grep -nE '# (TODO|FIXME|HACK|XXX):' "$SCRIPTS_DIR/supervisor-helper.sh" | grep -cE 'dispatch|health|nohup|reprompt' || true)
 if [[ "$hack_count" -eq 0 ]]; then
-    pass "No TODO/FIXME/HACK markers in dispatch/health/reprompt code"
+	pass "No TODO/FIXME/HACK markers in dispatch/health/reprompt code"
 else
-    fail "$hack_count TODO/FIXME/HACK markers found in critical supervisor code"
+	fail "$hack_count TODO/FIXME/HACK markers found in critical supervisor code"
 fi
 
 # ============================================================
@@ -550,73 +550,73 @@ section "Functional: Supervisor Dispatch (live)"
 
 # Test: Deployed supervisor script matches repo
 if [[ -f "$DEPLOYED_DIR/supervisor-helper.sh" ]]; then
-    if diff -q "$SCRIPTS_DIR/supervisor-helper.sh" "$DEPLOYED_DIR/supervisor-helper.sh" > /dev/null 2>&1; then
-        pass "Deployed supervisor-helper.sh matches repo version"
-    else
-        fail "Deployed supervisor-helper.sh differs from repo version" \
-            "Run: cp $SCRIPTS_DIR/supervisor-helper.sh $DEPLOYED_DIR/supervisor-helper.sh"
-    fi
+	if diff -q "$SCRIPTS_DIR/supervisor-helper.sh" "$DEPLOYED_DIR/supervisor-helper.sh" >/dev/null 2>&1; then
+		pass "Deployed supervisor-helper.sh matches repo version"
+	else
+		fail "Deployed supervisor-helper.sh differs from repo version" \
+			"Run: cp $SCRIPTS_DIR/supervisor-helper.sh $DEPLOYED_DIR/supervisor-helper.sh"
+	fi
 else
-    skip "supervisor-helper.sh not deployed"
+	skip "supervisor-helper.sh not deployed"
 fi
 
 # Test: Deployed memory-helper.sh matches repo
 if [[ -f "$DEPLOYED_DIR/memory-helper.sh" ]]; then
-    if diff -q "$SCRIPTS_DIR/memory-helper.sh" "$DEPLOYED_DIR/memory-helper.sh" > /dev/null 2>&1; then
-        pass "Deployed memory-helper.sh matches repo version"
-    else
-        fail "Deployed memory-helper.sh differs from repo version"
-    fi
+	if diff -q "$SCRIPTS_DIR/memory-helper.sh" "$DEPLOYED_DIR/memory-helper.sh" >/dev/null 2>&1; then
+		pass "Deployed memory-helper.sh matches repo version"
+	else
+		fail "Deployed memory-helper.sh differs from repo version"
+	fi
 else
-    skip "memory-helper.sh not deployed"
+	skip "memory-helper.sh not deployed"
 fi
 
 # Test: Supervisor DB exists and is accessible
 if [[ -f "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" ]]; then
-    task_count=$(sqlite3 "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" "SELECT COUNT(*) FROM tasks;" 2>/dev/null || echo "0")
-    if [[ "$task_count" -gt 0 ]]; then
-        pass "Supervisor DB accessible ($task_count tasks)"
-    else
-        fail "Supervisor DB exists but has 0 tasks"
-    fi
+	task_count=$(sqlite3 "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" "SELECT COUNT(*) FROM tasks;" 2>/dev/null || echo "0")
+	if [[ "$task_count" -gt 0 ]]; then
+		pass "Supervisor DB accessible ($task_count tasks)"
+	else
+		fail "Supervisor DB exists but has 0 tasks"
+	fi
 else
-    skip "Supervisor DB not found (supervisor not initialized)"
+	skip "Supervisor DB not found (supervisor not initialized)"
 fi
 
 # Test: Cron pulse is installed
 if crontab -l 2>/dev/null | grep -q 'supervisor-helper.sh pulse'; then
-    pass "Cron pulse is installed"
+	pass "Cron pulse is installed"
 else
-    skip "Cron pulse not installed (autonomous mode not active)"
+	skip "Cron pulse not installed (autonomous mode not active)"
 fi
 
 # Test: Running workers have valid PIDs (if any)
 if [[ -d "$HOME/.aidevops/.agent-workspace/supervisor/pids" ]]; then
-    stale_pids=0
-    live_pids=0
-    for pid_file in "$HOME/.aidevops/.agent-workspace/supervisor/pids"/*.pid; do
-        [[ -f "$pid_file" ]] || continue
-        pid=$(cat "$pid_file")
-        task=$(basename "$pid_file" .pid)
-        status=$(sqlite3 "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" \
-            "SELECT status FROM tasks WHERE id = '$task';" 2>/dev/null || echo "unknown")
-        if [[ "$status" == "running" || "$status" == "dispatched" ]]; then
-            if kill -0 "$pid" 2>/dev/null; then
-                live_pids=$((live_pids + 1))
-            else
-                stale_pids=$((stale_pids + 1))
-                [[ "$VERBOSE" == "--verbose" ]] && echo "       Stale: $task (PID $pid, status=$status)"
-            fi
-        fi
-    done
-    if [[ "$stale_pids" -eq 0 ]]; then
-        pass "No stale PIDs for running/dispatched tasks ($live_pids alive)"
-    else
-        fail "$stale_pids stale PID(s) for running/dispatched tasks" \
-            "Workers may have died — pulse should clean these up"
-    fi
+	stale_pids=0
+	live_pids=0
+	for pid_file in "$HOME/.aidevops/.agent-workspace/supervisor/pids"/*.pid; do
+		[[ -f "$pid_file" ]] || continue
+		pid=$(cat "$pid_file")
+		task=$(basename "$pid_file" .pid)
+		status=$(sqlite3 "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" \
+			"SELECT status FROM tasks WHERE id = '$task';" 2>/dev/null || echo "unknown")
+		if [[ "$status" == "running" || "$status" == "dispatched" ]]; then
+			if kill -0 "$pid" 2>/dev/null; then
+				live_pids=$((live_pids + 1))
+			else
+				stale_pids=$((stale_pids + 1))
+				[[ "$VERBOSE" == "--verbose" ]] && echo "       Stale: $task (PID $pid, status=$status)"
+			fi
+		fi
+	done
+	if [[ "$stale_pids" -eq 0 ]]; then
+		pass "No stale PIDs for running/dispatched tasks ($live_pids alive)"
+	else
+		fail "$stale_pids stale PID(s) for running/dispatched tasks" \
+			"Workers may have died — pulse should clean these up"
+	fi
 else
-    skip "No PID directory (no workers dispatched)"
+	skip "No PID directory (no workers dispatched)"
 fi
 
 # ============================================================
@@ -625,15 +625,15 @@ fi
 echo ""
 echo "========================================"
 printf "  \033[1mResults: %d total, \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m, \033[0;33m%d skipped\033[0m\n" \
-    "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+	"$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
 echo "========================================"
 
 if [[ "$FAIL_COUNT" -gt 0 ]]; then
-    echo ""
-    printf "\033[0;31mFAILURES DETECTED — review output above\033[0m\n"
-    exit 1
+	echo ""
+	printf "\033[0;31mFAILURES DETECTED — review output above\033[0m\n"
+	exit 1
 else
-    echo ""
-    printf "\033[0;32mAll tests passed.\033[0m\n"
-    exit 0
+	echo ""
+	printf "\033[0;32mAll tests passed.\033[0m\n"
+	exit 0
 fi

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -3770,7 +3770,7 @@ Document and implement patterns for running parallel OpenCode sessions locally, 
 opencode auth login
 
 # Or override per-dispatch
-opencode run -m openrouter/anthropic/claude-sonnet-4-20250514 "task"
+opencode run -m openrouter/anthropic/claude-sonnet-4-6 "task"
 ```
 
 Users can choose any provider supported by OpenCode via `opencode auth login`.


### PR DESCRIPTION
## Summary

- Update all model references from `claude-sonnet-4-5` and `claude-sonnet-4-20250514` to `claude-sonnet-4-6` across 40 files
- Sonnet 4.6: training data cutoff Jan 2026, 64K max output, 1M context beta, same $3/$15 pricing
- Updated: 16 scripts, 18 docs, 2 configs, 1 test, 1 template, 1 TypeScript, 1 PLANS.md

## Changes

**Scripts** (16 files): fallback-chain-helper.sh, model-availability-helper.sh, model-registry-helper.sh, supervisor/dispatch.sh, shared-constants.sh, runner-helper.sh, objective-runner-helper.sh, cron-dispatch.sh, cron-helper.sh, agent-test-helper.sh, contest-helper.sh, pipecat-helper.sh, generate-opencode-agents.sh, opencode-github-setup-helper.sh, document-extraction-helper.sh, model-label-helper.sh

**Docs** (18 files): models/sonnet.md (updated model details table with 4.6 specs), models/README.md, models/pro.md, models/opus.md, fallback-chains.md, headless-dispatch.md, model-routing.md, opencode-server.md, opencode.md, cron-agent.md, agent-testing.md, summarize.md, image-understanding.md, pipecat-opencode.md, opencode-anthropic-auth.md, opencode-github.md, opencode-gitlab.md, cloudflare ai-gateway reference

**Other**: fallback-chain-config.json.txt, subagent-index.toon, ai-research.ts, opencode-github-workflow.yml, test-batch-quality-hardening.sh

## Verification

- ShellCheck: zero new violations
- All old `claude-sonnet-4-5` and `claude-sonnet-4-20250514` references replaced
- Hardcoded fallback chains in fallback-chain-helper.sh resolve to `claude-sonnet-4-6`
- Config template updated to match

Closes #1578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated default AI models across the platform to use newer Claude model variants with enhanced capabilities.
  * System configurations updated to reflect current model availability and performance improvements.

* **Documentation**
  * Updated model references throughout guides and examples to reflect current supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->