### PR TITLE
t1083: Update model references for Claude Sonnet 4.6

### DIFF
--- a/.agents/configs/fallback-chain-config.json.txt
+++ b/.agents/configs/fallback-chain-config.json.txt
@@ -12,27 +12,27 @@
       "anthropic/claude-haiku-4-5"
     ],
     "sonnet": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
     "pro": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
     "opus": [
       "anthropic/claude-opus-4-6"
     ],
     "coding": [
       "anthropic/claude-opus-4-6",
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
     "eval": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
     "health": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ],
 
     "default": [
-      "anthropic/claude-sonnet-4-5"
+      "anthropic/claude-sonnet-4-6"
     ]
   },
 

--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -20,7 +20,7 @@
 #     "name": "build-agent-tests",
 #     "description": "Tests for build-agent subagent",
 #     "agent": "Build+",
-#     "model": "anthropic/claude-sonnet-4-20250514",
+#     "model": "anthropic/claude-sonnet-4-6",
 #     "timeout": 120,
 #     "tests": [
 #       {
@@ -65,16 +65,16 @@ readonly REPO_SUITES_DIR="${SCRIPT_DIR}/../tests"
 
 # CLI detection - opencode is the only supported CLI
 detect_cli() {
-    local cli="${AGENT_TEST_CLI:-}"
-    if [[ -n "$cli" ]]; then
-        echo "$cli"
-        return 0
-    fi
-    if command -v opencode >/dev/null 2>&1; then
-        echo "opencode"
-    else
-        echo ""
-    fi
+	local cli="${AGENT_TEST_CLI:-}"
+	if [[ -n "$cli" ]]; then
+		echo "$cli"
+		return 0
+	fi
+	if command -v opencode >/dev/null 2>&1; then
+		echo "opencode"
+	else
+		echo ""
+	fi
 }
 
 AI_CLI="$(detect_cli)"
@@ -95,13 +95,12 @@ log_fail() { echo -e "${RED}[FAIL]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_header() { echo -e "${PURPLE}${BOLD}$*${NC}"; }
 
-
 #######################################
 # Ensure workspace directories exist
 #######################################
 ensure_dirs() {
-    mkdir -p "$SUITES_DIR" "$RESULTS_DIR" "$BASELINES_DIR"
-    return 0
+	mkdir -p "$SUITES_DIR" "$RESULTS_DIR" "$BASELINES_DIR"
+	return 0
 }
 
 #######################################
@@ -115,44 +114,44 @@ ensure_dirs() {
 #   0 if found, 1 if not found
 #######################################
 resolve_test_file() {
-    local test_file="$1"
+	local test_file="$1"
 
-    if [[ -f "$test_file" ]]; then
-        echo "$test_file"
-        return 0
-    fi
-    if [[ -f "${SUITES_DIR}/${test_file}" ]]; then
-        echo "${SUITES_DIR}/${test_file}"
-        return 0
-    fi
-    if [[ -f "${SUITES_DIR}/${test_file}.json" ]]; then
-        echo "${SUITES_DIR}/${test_file}.json"
-        return 0
-    fi
-    # Check repo-shipped test suites
-    if [[ -f "${REPO_SUITES_DIR}/${test_file}" ]]; then
-        echo "${REPO_SUITES_DIR}/${test_file}"
-        return 0
-    fi
-    if [[ -f "${REPO_SUITES_DIR}/${test_file}.json" ]]; then
-        echo "${REPO_SUITES_DIR}/${test_file}.json"
-        return 0
-    fi
+	if [[ -f "$test_file" ]]; then
+		echo "$test_file"
+		return 0
+	fi
+	if [[ -f "${SUITES_DIR}/${test_file}" ]]; then
+		echo "${SUITES_DIR}/${test_file}"
+		return 0
+	fi
+	if [[ -f "${SUITES_DIR}/${test_file}.json" ]]; then
+		echo "${SUITES_DIR}/${test_file}.json"
+		return 0
+	fi
+	# Check repo-shipped test suites
+	if [[ -f "${REPO_SUITES_DIR}/${test_file}" ]]; then
+		echo "${REPO_SUITES_DIR}/${test_file}"
+		return 0
+	fi
+	if [[ -f "${REPO_SUITES_DIR}/${test_file}.json" ]]; then
+		echo "${REPO_SUITES_DIR}/${test_file}.json"
+		return 0
+	fi
 
-    log_fail "Test file not found: $test_file"
-    log_info "Searched: ${SUITES_DIR}/, ${REPO_SUITES_DIR}/"
-    return 1
+	log_fail "Test file not found: $test_file"
+	log_info "Searched: ${SUITES_DIR}/, ${REPO_SUITES_DIR}/"
+	return 1
 }
 
 #######################################
 # Check if OpenCode server is running
 #######################################
 check_opencode_server() {
-    # NOSONAR - localhost dev server health check, HTTP is intentional
-    if curl -s --max-time 3 "${OPENCODE_URL}/global/health" > /dev/null 2>&1; then
-        return 0
-    fi
-    return 1
+	# NOSONAR - localhost dev server health check, HTTP is intentional
+	if curl -s --max-time 3 "${OPENCODE_URL}/global/health" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
 }
 
 #######################################
@@ -165,42 +164,42 @@ check_opencode_server() {
 #   Command exit code, or 124 on timeout
 #######################################
 portable_timeout() {
-    local secs="$1"
-    shift
+	local secs="$1"
+	shift
 
-    # Try GNU timeout first (Linux or Homebrew coreutils)
-    if command -v timeout >/dev/null 2>&1; then
-        timeout "$secs" "$@"
-        return $?
-    fi
-    if command -v gtimeout >/dev/null 2>&1; then
-        gtimeout "$secs" "$@"
-        return $?
-    fi
+	# Try GNU timeout first (Linux or Homebrew coreutils)
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "$secs" "$@"
+		return $?
+	fi
+	if command -v gtimeout >/dev/null 2>&1; then
+		gtimeout "$secs" "$@"
+		return $?
+	fi
 
-    # Fallback: background process with kill
-    "$@" &
-    local cmd_pid=$!
+	# Fallback: background process with kill
+	"$@" &
+	local cmd_pid=$!
 
-    # Watchdog in background
-    (
-        sleep "$secs"
-        kill "$cmd_pid" 2>/dev/null
-    ) &
-    local watchdog_pid=$!
+	# Watchdog in background
+	(
+		sleep "$secs"
+		kill "$cmd_pid" 2>/dev/null
+	) &
+	local watchdog_pid=$!
 
-    wait "$cmd_pid" 2>/dev/null
-    local exit_code=$?
+	wait "$cmd_pid" 2>/dev/null
+	local exit_code=$?
 
-    # Clean up watchdog
-    kill "$watchdog_pid" 2>/dev/null
-    wait "$watchdog_pid" 2>/dev/null
+	# Clean up watchdog
+	kill "$watchdog_pid" 2>/dev/null
+	wait "$watchdog_pid" 2>/dev/null
 
-    # Check if killed by signal (128+9=137 for SIGKILL, 128+15=143 for SIGTERM)
-    if [[ $exit_code -ge 128 ]]; then
-        return 124
-    fi
-    return $exit_code
+	# Check if killed by signal (128+9=137 for SIGKILL, 128+15=143 for SIGTERM)
+	if [[ $exit_code -ge 128 ]]; then
+		return 124
+	fi
+	return $exit_code
 }
 
 #######################################
@@ -214,20 +213,20 @@ portable_timeout() {
 #   Response text on stdout
 #######################################
 run_prompt() {
-    local prompt="$1"
-    local agent="${2:-}"
-    local model="${3:-${AGENT_TEST_MODEL:-}}"
-    local timeout="${4:-$DEFAULT_TIMEOUT}"
+	local prompt="$1"
+	local agent="${2:-}"
+	local model="${3:-${AGENT_TEST_MODEL:-}}"
+	local timeout="${4:-$DEFAULT_TIMEOUT}"
 
-    case "$AI_CLI" in
-        opencode)
-            run_prompt_opencode "$prompt" "$agent" "$model" "$timeout"
-            ;;
-        *)
-            log_fail "No AI CLI available. Install opencode: https://opencode.ai"
-            return 1
-            ;;
-    esac
+	case "$AI_CLI" in
+	opencode)
+		run_prompt_opencode "$prompt" "$agent" "$model" "$timeout"
+		;;
+	*)
+		log_fail "No AI CLI available. Install opencode: https://opencode.ai"
+		return 1
+		;;
+	esac
 }
 
 #######################################
@@ -235,17 +234,17 @@ run_prompt() {
 # Tries server mode first, falls back to CLI
 #######################################
 run_prompt_opencode() {
-    local prompt="$1"
-    local agent="$2"
-    local model="$3"
-    local timeout="$4"
+	local prompt="$1"
+	local agent="$2"
+	local model="$3"
+	local timeout="$4"
 
-    # Try server mode first (attach to running server), fall back to standalone CLI
-    if check_opencode_server; then
-        run_prompt_opencode_server "$prompt" "$agent" "$model" "$timeout"
-    else
-        run_prompt_opencode_cli "$prompt" "$agent" "$model" "$timeout"
-    fi
+	# Try server mode first (attach to running server), fall back to standalone CLI
+	if check_opencode_server; then
+		run_prompt_opencode_server "$prompt" "$agent" "$model" "$timeout"
+	else
+		run_prompt_opencode_cli "$prompt" "$agent" "$model" "$timeout"
+	fi
 }
 
 #######################################
@@ -253,71 +252,71 @@ run_prompt_opencode() {
 # Uses the HTTP API when a server is running
 #######################################
 run_prompt_opencode_server() {
-    local prompt="$1"
-    local agent="$2"
-    local model="$3"
-    local timeout="$4"
+	local prompt="$1"
+	local agent="$2"
+	local model="$3"
+	local timeout="$4"
 
-    # Create session
-    local session_payload
-    session_payload=$(jq -n --arg title "agent-test-$(date +%s)" '{"title": $title}')
-    local session_response
-    # NOSONAR - localhost dev server API call, HTTP is intentional
-    session_response=$(curl -s --max-time 10 -X POST "${OPENCODE_URL}/session" \
-        -H "Content-Type: application/json" \
-        -d "$session_payload")
+	# Create session
+	local session_payload
+	session_payload=$(jq -n --arg title "agent-test-$(date +%s)" '{"title": $title}')
+	local session_response
+	# NOSONAR - localhost dev server API call, HTTP is intentional
+	session_response=$(curl -s --max-time 10 -X POST "${OPENCODE_URL}/session" \
+		-H "Content-Type: application/json" \
+		-d "$session_payload")
 
-    local session_id
-    session_id=$(echo "$session_response" | jq -r '.id // empty' 2>/dev/null)
+	local session_id
+	session_id=$(echo "$session_response" | jq -r '.id // empty' 2>/dev/null)
 
-    if [[ -z "$session_id" ]]; then
-        log_warn "Failed to create server session, falling back to CLI"
-        run_prompt_opencode_cli "$prompt" "$agent" "$model" "$timeout"
-        return $?
-    fi
+	if [[ -z "$session_id" ]]; then
+		log_warn "Failed to create server session, falling back to CLI"
+		run_prompt_opencode_cli "$prompt" "$agent" "$model" "$timeout"
+		return $?
+	fi
 
-    # Build prompt payload with optional model override
-    local prompt_json
-    if [[ -n "$model" ]]; then
-        # Parse provider/model format (e.g., "anthropic/claude-sonnet-4-20250514")
-        local provider_id model_id
-        provider_id="${model%%/*}"
-        model_id="${model#*/}"
-        prompt_json=$(jq -n \
-            --arg text "$prompt" \
-            --arg provider "$provider_id" \
-            --arg model "$model_id" \
-            '{
+	# Build prompt payload with optional model override
+	local prompt_json
+	if [[ -n "$model" ]]; then
+		# Parse provider/model format (e.g., "anthropic/claude-sonnet-4-6")
+		local provider_id model_id
+		provider_id="${model%%/*}"
+		model_id="${model#*/}"
+		prompt_json=$(jq -n \
+			--arg text "$prompt" \
+			--arg provider "$provider_id" \
+			--arg model "$model_id" \
+			'{
                 "model": {"providerID": $provider, "modelID": $model},
                 "parts": [{"type": "text", "text": $text}]
             }')
-    else
-        prompt_json=$(jq -n --arg text "$prompt" \
-            '{"parts": [{"type": "text", "text": $text}]}')
-    fi
+	else
+		prompt_json=$(jq -n --arg text "$prompt" \
+			'{"parts": [{"type": "text", "text": $text}]}')
+	fi
 
-    # Send prompt (sync - waits for response)
-    local response
-    # NOSONAR - localhost dev server API call, HTTP is intentional
-    response=$(curl -s --max-time "$timeout" -X POST \
-        "${OPENCODE_URL}/session/${session_id}/message" \
-        -H "Content-Type: application/json" \
-        -d "$prompt_json")
+	# Send prompt (sync - waits for response)
+	local response
+	# NOSONAR - localhost dev server API call, HTTP is intentional
+	response=$(curl -s --max-time "$timeout" -X POST \
+		"${OPENCODE_URL}/session/${session_id}/message" \
+		-H "Content-Type: application/json" \
+		-d "$prompt_json")
 
-    # Extract text from response parts
-    local result
-    result=$(echo "$response" | jq -r \
-        '[.parts[]? | select(.type == "text") | .text] | join("\n")' 2>/dev/null)
+	# Extract text from response parts
+	local result
+	result=$(echo "$response" | jq -r \
+		'[.parts[]? | select(.type == "text") | .text] | join("\n")' 2>/dev/null)
 
-    if [[ -z "$result" ]]; then
-        result=$(echo "$response" | jq -r '.content // .text // .message // empty' 2>/dev/null)
-    fi
+	if [[ -z "$result" ]]; then
+		result=$(echo "$response" | jq -r '.content // .text // .message // empty' 2>/dev/null)
+	fi
 
-    # Clean up session (NOSONAR - localhost dev server, HTTP is intentional)
-    curl -s -X DELETE "${OPENCODE_URL}/session/${session_id}" > /dev/null 2>&1 || true
+	# Clean up session (NOSONAR - localhost dev server, HTTP is intentional)
+	curl -s -X DELETE "${OPENCODE_URL}/session/${session_id}" >/dev/null 2>&1 || true
 
-    echo "$result"
-    return 0
+	echo "$result"
+	return 0
 }
 
 #######################################
@@ -325,65 +324,66 @@ run_prompt_opencode_server() {
 # Uses --format json for reliable response extraction
 #######################################
 run_prompt_opencode_cli() {
-    local prompt="$1"
-    local agent="$2"
-    local model="$3"
-    local timeout="$4"
+	local prompt="$1"
+	local agent="$2"
+	local model="$3"
+	local timeout="$4"
 
-    local cmd=(opencode run --format json)
+	local cmd=(opencode run --format json)
 
-    if [[ -n "$agent" ]]; then
-        cmd+=(--agent "$agent")
-    fi
+	if [[ -n "$agent" ]]; then
+		cmd+=(--agent "$agent")
+	fi
 
-    if [[ -n "$model" ]]; then
-        cmd+=(-m "$model")
-    fi
+	if [[ -n "$model" ]]; then
+		cmd+=(-m "$model")
+	fi
 
-    local stderr_file raw_output
-    stderr_file=$(mktemp)
-    raw_output=$(mktemp)
-    _save_cleanup_scope; trap '_run_cleanups' RETURN
-    push_cleanup "rm -f '${stderr_file}'"
-    push_cleanup "rm -f '${raw_output}'"
+	local stderr_file raw_output
+	stderr_file=$(mktemp)
+	raw_output=$(mktemp)
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	push_cleanup "rm -f '${stderr_file}'"
+	push_cleanup "rm -f '${raw_output}'"
 
-    local exit_code=0
-    portable_timeout "${timeout}" "${cmd[@]}" "$prompt" >"$raw_output" 2>"$stderr_file" || {
-        exit_code=$?
-        if [[ $exit_code -eq 124 ]]; then
-            echo "[TIMEOUT after ${timeout}s]"
-        elif [[ -s "$stderr_file" ]]; then
-            echo "[ERROR: $(cat "$stderr_file")]"
-        fi
-        rm -f "$stderr_file" "$raw_output"
-        return $exit_code
-    }
+	local exit_code=0
+	portable_timeout "${timeout}" "${cmd[@]}" "$prompt" >"$raw_output" 2>"$stderr_file" || {
+		exit_code=$?
+		if [[ $exit_code -eq 124 ]]; then
+			echo "[TIMEOUT after ${timeout}s]"
+		elif [[ -s "$stderr_file" ]]; then
+			echo "[ERROR: $(cat "$stderr_file")]"
+		fi
+		rm -f "$stderr_file" "$raw_output"
+		return $exit_code
+	}
 
-    # Check for error events in the JSON stream
-    local error_msg
-    error_msg=$(jq -r 'select(.type == "error") | .error.data.message // .error.message // empty' \
-        "$raw_output" 2>/dev/null | head -1)
+	# Check for error events in the JSON stream
+	local error_msg
+	error_msg=$(jq -r 'select(.type == "error") | .error.data.message // .error.message // empty' \
+		"$raw_output" 2>/dev/null | head -1)
 
-    if [[ -n "$error_msg" ]]; then
-        echo "[ERROR: ${error_msg}]"
-        rm -f "$stderr_file" "$raw_output"
-        return 1
-    fi
+	if [[ -n "$error_msg" ]]; then
+		echo "[ERROR: ${error_msg}]"
+		rm -f "$stderr_file" "$raw_output"
+		return 1
+	fi
 
-    # Extract text from JSON event stream
-    # Each line is a JSON event; text content has type="text" with .part.text
-    local result
-    result=$(jq -r 'select(.type == "text") | .part.text // empty' "$raw_output" 2>/dev/null \
-        | tr -d '\0')
+	# Extract text from JSON event stream
+	# Each line is a JSON event; text content has type="text" with .part.text
+	local result
+	result=$(jq -r 'select(.type == "text") | .part.text // empty' "$raw_output" 2>/dev/null |
+		tr -d '\0')
 
-    if [[ -z "$result" ]]; then
-        # Fallback: try to extract any text-like content
-        result=$(cat "$raw_output")
-    fi
+	if [[ -z "$result" ]]; then
+		# Fallback: try to extract any text-like content
+		result=$(cat "$raw_output")
+	fi
 
-    rm -f "$stderr_file" "$raw_output"
-    echo "$result"
-    return 0
+	rm -f "$stderr_file" "$raw_output"
+	echo "$result"
+	return 0
 }
 
 #######################################
@@ -395,248 +395,248 @@ run_prompt_opencode_cli() {
 #   0 if all checks pass, 1 otherwise
 #######################################
 validate_response() {
-    local response="$1"
-    local test_json="$2"
-    local failures=0
+	local response="$1"
+	local test_json="$2"
+	local failures=0
 
-    # Check expect_contains
-    local contains
-    contains=$(echo "$test_json" | jq -r '.expect_contains[]? // empty' 2>/dev/null)
-    while IFS= read -r pattern; do
-        [[ -z "$pattern" ]] && continue
-        if ! echo "$response" | grep -qi "$pattern"; then
-            log_fail "  Expected to contain: \"$pattern\""
-            failures=$((failures + 1))
-        fi
-    done <<< "$contains"
+	# Check expect_contains
+	local contains
+	contains=$(echo "$test_json" | jq -r '.expect_contains[]? // empty' 2>/dev/null)
+	while IFS= read -r pattern; do
+		[[ -z "$pattern" ]] && continue
+		if ! echo "$response" | grep -qi "$pattern"; then
+			log_fail "  Expected to contain: \"$pattern\""
+			failures=$((failures + 1))
+		fi
+	done <<<"$contains"
 
-    # Check expect_not_contains
-    local not_contains
-    not_contains=$(echo "$test_json" | jq -r '.expect_not_contains[]? // empty' 2>/dev/null)
-    while IFS= read -r pattern; do
-        [[ -z "$pattern" ]] && continue
-        if echo "$response" | grep -qi "$pattern"; then
-            log_fail "  Expected NOT to contain: \"$pattern\""
-            failures=$((failures + 1))
-        fi
-    done <<< "$not_contains"
+	# Check expect_not_contains
+	local not_contains
+	not_contains=$(echo "$test_json" | jq -r '.expect_not_contains[]? // empty' 2>/dev/null)
+	while IFS= read -r pattern; do
+		[[ -z "$pattern" ]] && continue
+		if echo "$response" | grep -qi "$pattern"; then
+			log_fail "  Expected NOT to contain: \"$pattern\""
+			failures=$((failures + 1))
+		fi
+	done <<<"$not_contains"
 
-    # Check expect_regex
-    local regex
-    regex=$(echo "$test_json" | jq -r '.expect_regex // empty' 2>/dev/null)
-    if [[ -n "$regex" ]] && ! echo "$response" | grep -qEi "$regex"; then
-        log_fail "  Expected to match regex: \"$regex\""
-        failures=$((failures + 1))
-    fi
+	# Check expect_regex
+	local regex
+	regex=$(echo "$test_json" | jq -r '.expect_regex // empty' 2>/dev/null)
+	if [[ -n "$regex" ]] && ! echo "$response" | grep -qEi "$regex"; then
+		log_fail "  Expected to match regex: \"$regex\""
+		failures=$((failures + 1))
+	fi
 
-    # Check expect_not_regex
-    local not_regex
-    not_regex=$(echo "$test_json" | jq -r '.expect_not_regex // empty' 2>/dev/null)
-    if [[ -n "$not_regex" ]] && echo "$response" | grep -qEi "$not_regex"; then
-        log_fail "  Expected NOT to match regex: \"$not_regex\""
-        failures=$((failures + 1))
-    fi
+	# Check expect_not_regex
+	local not_regex
+	not_regex=$(echo "$test_json" | jq -r '.expect_not_regex // empty' 2>/dev/null)
+	if [[ -n "$not_regex" ]] && echo "$response" | grep -qEi "$not_regex"; then
+		log_fail "  Expected NOT to match regex: \"$not_regex\""
+		failures=$((failures + 1))
+	fi
 
-    # Check min_length
-    local min_length
-    min_length=$(echo "$test_json" | jq -r '.min_length // empty' 2>/dev/null)
-    if [[ -n "$min_length" ]]; then
-        local actual_length
-        actual_length=${#response}
-        if [[ $actual_length -lt $min_length ]]; then
-            log_fail "  Response too short: ${actual_length} < ${min_length} chars"
-            failures=$((failures + 1))
-        fi
-    fi
+	# Check min_length
+	local min_length
+	min_length=$(echo "$test_json" | jq -r '.min_length // empty' 2>/dev/null)
+	if [[ -n "$min_length" ]]; then
+		local actual_length
+		actual_length=${#response}
+		if [[ $actual_length -lt $min_length ]]; then
+			log_fail "  Response too short: ${actual_length} < ${min_length} chars"
+			failures=$((failures + 1))
+		fi
+	fi
 
-    # Check max_length
-    local max_length
-    max_length=$(echo "$test_json" | jq -r '.max_length // empty' 2>/dev/null)
-    if [[ -n "$max_length" ]]; then
-        local actual_length
-        actual_length=${#response}
-        if [[ $actual_length -gt $max_length ]]; then
-            log_fail "  Response too long: ${actual_length} > ${max_length} chars"
-            failures=$((failures + 1))
-        fi
-    fi
+	# Check max_length
+	local max_length
+	max_length=$(echo "$test_json" | jq -r '.max_length // empty' 2>/dev/null)
+	if [[ -n "$max_length" ]]; then
+		local actual_length
+		actual_length=${#response}
+		if [[ $actual_length -gt $max_length ]]; then
+			log_fail "  Response too long: ${actual_length} > ${max_length} chars"
+			failures=$((failures + 1))
+		fi
+	fi
 
-    if [[ $failures -eq 0 ]]; then
-        return 0
-    fi
-    return 1
+	if [[ $failures -eq 0 ]]; then
+		return 0
+	fi
+	return 1
 }
 
 #######################################
 # RUN command - execute a test suite
 #######################################
 cmd_run() {
-    local test_file="$1"
-    ensure_dirs
+	local test_file="$1"
+	ensure_dirs
 
-    # Resolve test file path
-    test_file=$(resolve_test_file "$test_file") || return 1
+	# Resolve test file path
+	test_file=$(resolve_test_file "$test_file") || return 1
 
-    # Parse test suite
-    local suite
-    suite=$(cat "$test_file")
+	# Parse test suite
+	local suite
+	suite=$(cat "$test_file")
 
-    local suite_name
-    suite_name=$(echo "$suite" | jq -r '.name // "unnamed"')
-    local suite_desc
-    suite_desc=$(echo "$suite" | jq -r '.description // ""')
-    local suite_agent
-    suite_agent=$(echo "$suite" | jq -r '.agent // ""')
-    local suite_model
-    suite_model=$(echo "$suite" | jq -r '.model // ""')
-    local suite_timeout
-    suite_timeout=$(echo "$suite" | jq -r '.timeout // 120')
+	local suite_name
+	suite_name=$(echo "$suite" | jq -r '.name // "unnamed"')
+	local suite_desc
+	suite_desc=$(echo "$suite" | jq -r '.description // ""')
+	local suite_agent
+	suite_agent=$(echo "$suite" | jq -r '.agent // ""')
+	local suite_model
+	suite_model=$(echo "$suite" | jq -r '.model // ""')
+	local suite_timeout
+	suite_timeout=$(echo "$suite" | jq -r '.timeout // 120')
 
-    local test_count
-    test_count=$(echo "$suite" | jq '.tests | length')
+	local test_count
+	test_count=$(echo "$suite" | jq '.tests | length')
 
-    log_header "Test Suite: ${suite_name}"
-    if [[ -n "$suite_desc" ]]; then
-        echo -e "${DIM}${suite_desc}${NC}"
-    fi
-    echo ""
-    log_info "CLI: ${AI_CLI:-none}"
-    log_info "Agent: ${suite_agent:-default}"
-    log_info "Tests: ${test_count}"
-    echo ""
+	log_header "Test Suite: ${suite_name}"
+	if [[ -n "$suite_desc" ]]; then
+		echo -e "${DIM}${suite_desc}${NC}"
+	fi
+	echo ""
+	log_info "CLI: ${AI_CLI:-none}"
+	log_info "Agent: ${suite_agent:-default}"
+	log_info "Tests: ${test_count}"
+	echo ""
 
-    if [[ -z "$AI_CLI" ]]; then
-        log_fail "No AI CLI available. Install claude or opencode."
-        return 1
-    fi
+	if [[ -z "$AI_CLI" ]]; then
+		log_fail "No AI CLI available. Install claude or opencode."
+		return 1
+	fi
 
-    local passed=0
-    local failed=0
-    local skipped=0
-    local start_time
-    start_time=$(date +%s)
+	local passed=0
+	local failed=0
+	local skipped=0
+	local start_time
+	start_time=$(date +%s)
 
-    # Results array for JSON output
-    local results="[]"
+	# Results array for JSON output
+	local results="[]"
 
-    # Run each test
-    local i=0
-    while [[ $i -lt $test_count ]]; do
-        local test_json
-        test_json=$(echo "$suite" | jq -c ".tests[$i]")
+	# Run each test
+	local i=0
+	while [[ $i -lt $test_count ]]; do
+		local test_json
+		test_json=$(echo "$suite" | jq -c ".tests[$i]")
 
-        local test_id
-        test_id=$(echo "$test_json" | jq -r '.id // "test-'"$i"'"')
-        local test_prompt
-        test_prompt=$(echo "$test_json" | jq -r '.prompt')
-        local test_agent
-        test_agent=$(echo "$test_json" | jq -r '.agent // empty')
-        local test_model
-        test_model=$(echo "$test_json" | jq -r '.model // empty')
-        local test_timeout
-        test_timeout=$(echo "$test_json" | jq -r '.timeout // empty')
-        local test_skip
-        test_skip=$(echo "$test_json" | jq -r '.skip // false')
+		local test_id
+		test_id=$(echo "$test_json" | jq -r '.id // "test-'"$i"'"')
+		local test_prompt
+		test_prompt=$(echo "$test_json" | jq -r '.prompt')
+		local test_agent
+		test_agent=$(echo "$test_json" | jq -r '.agent // empty')
+		local test_model
+		test_model=$(echo "$test_json" | jq -r '.model // empty')
+		local test_timeout
+		test_timeout=$(echo "$test_json" | jq -r '.timeout // empty')
+		local test_skip
+		test_skip=$(echo "$test_json" | jq -r '.skip // false')
 
-        # Use suite defaults if test doesn't override
-        test_agent="${test_agent:-$suite_agent}"
-        test_model="${test_model:-$suite_model}"
-        test_timeout="${test_timeout:-$suite_timeout}"
+		# Use suite defaults if test doesn't override
+		test_agent="${test_agent:-$suite_agent}"
+		test_model="${test_model:-$suite_model}"
+		test_timeout="${test_timeout:-$suite_timeout}"
 
-        echo -e "${BOLD}[$((i+1))/${test_count}] ${test_id}${NC}"
+		echo -e "${BOLD}[$((i + 1))/${test_count}] ${test_id}${NC}"
 
-        if [[ "$test_skip" == "true" ]]; then
-            echo -e "  ${YELLOW}SKIPPED${NC}"
-            skipped=$((skipped + 1))
-            results=$(echo "$results" | jq --arg id "$test_id" --arg status "skipped" \
-                '. + [{"id": $id, "status": $status}]')
-            i=$((i + 1))
-            continue
-        fi
+		if [[ "$test_skip" == "true" ]]; then
+			echo -e "  ${YELLOW}SKIPPED${NC}"
+			skipped=$((skipped + 1))
+			results=$(echo "$results" | jq --arg id "$test_id" --arg status "skipped" \
+				'. + [{"id": $id, "status": $status}]')
+			i=$((i + 1))
+			continue
+		fi
 
-        echo -e "  ${DIM}Prompt: ${test_prompt:0:80}...${NC}"
+		echo -e "  ${DIM}Prompt: ${test_prompt:0:80}...${NC}"
 
-        # Run the prompt
-        local test_start
-        test_start=$(date +%s)
-        local response=""
-        local run_status="pass"
+		# Run the prompt
+		local test_start
+		test_start=$(date +%s)
+		local response=""
+		local run_status="pass"
 
-        response=$(run_prompt "$test_prompt" "$test_agent" "$test_model" "$test_timeout" 2>&1) || {
-            run_status="error"
-        }
+		response=$(run_prompt "$test_prompt" "$test_agent" "$test_model" "$test_timeout" 2>&1) || {
+			run_status="error"
+		}
 
-        local test_end
-        test_end=$(date +%s)
-        local test_duration=$((test_end - test_start))
+		local test_end
+		test_end=$(date +%s)
+		local test_duration=$((test_end - test_start))
 
-        # Check for timeout/error
-        if [[ "$run_status" == "error" ]] || echo "$response" | grep -q '^\[TIMEOUT'; then
-            log_fail "  Error/timeout after ${test_duration}s"
-            failed=$((failed + 1))
-            results=$(echo "$results" | jq \
-                --arg id "$test_id" \
-                --arg status "fail" \
-                --arg error "timeout_or_error" \
-                --argjson duration "$test_duration" \
-                '. + [{"id": $id, "status": $status, "error": $error, "duration": $duration}]')
-            i=$((i + 1))
-            continue
-        fi
+		# Check for timeout/error
+		if [[ "$run_status" == "error" ]] || echo "$response" | grep -q '^\[TIMEOUT'; then
+			log_fail "  Error/timeout after ${test_duration}s"
+			failed=$((failed + 1))
+			results=$(echo "$results" | jq \
+				--arg id "$test_id" \
+				--arg status "fail" \
+				--arg error "timeout_or_error" \
+				--argjson duration "$test_duration" \
+				'. + [{"id": $id, "status": $status, "error": $error, "duration": $duration}]')
+			i=$((i + 1))
+			continue
+		fi
 
-        # Validate response
-        if validate_response "$response" "$test_json"; then
-            log_pass "  Passed (${test_duration}s)"
-            passed=$((passed + 1))
-            run_status="pass"
-        else
-            failed=$((failed + 1))
-            run_status="fail"
-        fi
+		# Validate response
+		if validate_response "$response" "$test_json"; then
+			log_pass "  Passed (${test_duration}s)"
+			passed=$((passed + 1))
+			run_status="pass"
+		else
+			failed=$((failed + 1))
+			run_status="fail"
+		fi
 
-        # Store result
-        local response_preview
-        response_preview=$(echo "$response" | head -c 500)
-        results=$(echo "$results" | jq \
-            --arg id "$test_id" \
-            --arg status "$run_status" \
-            --arg response "$response_preview" \
-            --argjson duration "$test_duration" \
-            '. + [{"id": $id, "status": $status, "response_preview": $response, "duration": $duration}]')
+		# Store result
+		local response_preview
+		response_preview=$(echo "$response" | head -c 500)
+		results=$(echo "$results" | jq \
+			--arg id "$test_id" \
+			--arg status "$run_status" \
+			--arg response "$response_preview" \
+			--argjson duration "$test_duration" \
+			'. + [{"id": $id, "status": $status, "response_preview": $response, "duration": $duration}]')
 
-        i=$((i + 1))
-    done
+		i=$((i + 1))
+	done
 
-    local end_time
-    end_time=$(date +%s)
-    local total_duration=$((end_time - start_time))
+	local end_time
+	end_time=$(date +%s)
+	local total_duration=$((end_time - start_time))
 
-    # Summary
-    echo ""
-    log_header "Results: ${suite_name}"
-    echo -e "  ${GREEN}Passed: ${passed}${NC}"
-    echo -e "  ${RED}Failed: ${failed}${NC}"
-    if [[ $skipped -gt 0 ]]; then
-        echo -e "  ${YELLOW}Skipped: ${skipped}${NC}"
-    fi
-    echo -e "  Total time: ${total_duration}s"
-    echo ""
+	# Summary
+	echo ""
+	log_header "Results: ${suite_name}"
+	echo -e "  ${GREEN}Passed: ${passed}${NC}"
+	echo -e "  ${RED}Failed: ${failed}${NC}"
+	if [[ $skipped -gt 0 ]]; then
+		echo -e "  ${YELLOW}Skipped: ${skipped}${NC}"
+	fi
+	echo -e "  Total time: ${total_duration}s"
+	echo ""
 
-    # Save results
-    local result_file
-    result_file="${RESULTS_DIR}/${suite_name}-$(date +%Y%m%d-%H%M%S).json"
-    jq -n \
-        --arg name "$suite_name" \
-        --arg cli "$AI_CLI" \
-        --arg agent "$suite_agent" \
-        --arg model "$suite_model" \
-        --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-        --argjson passed "$passed" \
-        --argjson failed "$failed" \
-        --argjson skipped "$skipped" \
-        --argjson duration "$total_duration" \
-        --argjson results "$results" \
-        '{
+	# Save results
+	local result_file
+	result_file="${RESULTS_DIR}/${suite_name}-$(date +%Y%m%d-%H%M%S).json"
+	jq -n \
+		--arg name "$suite_name" \
+		--arg cli "$AI_CLI" \
+		--arg agent "$suite_agent" \
+		--arg model "$suite_model" \
+		--arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		--argjson passed "$passed" \
+		--argjson failed "$failed" \
+		--argjson skipped "$skipped" \
+		--argjson duration "$total_duration" \
+		--argjson results "$results" \
+		'{
             name: $name,
             cli: $cli,
             agent: $agent,
@@ -644,288 +644,300 @@ cmd_run() {
             timestamp: $timestamp,
             summary: {passed: $passed, failed: $failed, skipped: $skipped, duration: $duration},
             results: $results
-        }' > "$result_file"
+        }' >"$result_file"
 
-    log_info "Results saved: $result_file"
+	log_info "Results saved: $result_file"
 
-    if [[ $failed -gt 0 ]]; then
-        return 1
-    fi
-    return 0
+	if [[ $failed -gt 0 ]]; then
+		return 1
+	fi
+	return 0
 }
 
 #######################################
 # RUN-ONE command - run a single prompt test
 #######################################
 cmd_run_one() {
-    local prompt=""
-    local expect=""
-    local agent=""
-    local model=""
-    local timeout="$DEFAULT_TIMEOUT"
+	local prompt=""
+	local expect=""
+	local agent=""
+	local model=""
+	local timeout="$DEFAULT_TIMEOUT"
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --expect) expect="$2"; shift 2 ;;
-            --agent) agent="$2"; shift 2 ;;
-            --model) model="$2"; shift 2 ;;
-            --timeout) timeout="$2"; shift 2 ;;
-            *)
-                if [[ -z "$prompt" ]]; then
-                    prompt="$1"
-                fi
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--expect)
+			expect="$2"
+			shift 2
+			;;
+		--agent)
+			agent="$2"
+			shift 2
+			;;
+		--model)
+			model="$2"
+			shift 2
+			;;
+		--timeout)
+			timeout="$2"
+			shift 2
+			;;
+		*)
+			if [[ -z "$prompt" ]]; then
+				prompt="$1"
+			fi
+			shift
+			;;
+		esac
+	done
 
-    if [[ -z "$prompt" ]]; then
-        log_fail "Usage: agent-test-helper.sh run-one \"prompt\" [--expect \"pattern\"]"
-        return 1
-    fi
+	if [[ -z "$prompt" ]]; then
+		log_fail "Usage: agent-test-helper.sh run-one \"prompt\" [--expect \"pattern\"]"
+		return 1
+	fi
 
-    if [[ -z "$AI_CLI" ]]; then
-        log_fail "No AI CLI available. Install claude or opencode."
-        return 1
-    fi
+	if [[ -z "$AI_CLI" ]]; then
+		log_fail "No AI CLI available. Install claude or opencode."
+		return 1
+	fi
 
-    log_header "Single Test"
-    echo -e "  ${DIM}Prompt: ${prompt:0:100}${NC}"
-    echo -e "  ${DIM}CLI: ${AI_CLI}${NC}"
-    echo ""
+	log_header "Single Test"
+	echo -e "  ${DIM}Prompt: ${prompt:0:100}${NC}"
+	echo -e "  ${DIM}CLI: ${AI_CLI}${NC}"
+	echo ""
 
-    local start_time
-    start_time=$(date +%s)
+	local start_time
+	start_time=$(date +%s)
 
-    local response
-    response=$(run_prompt "$prompt" "$agent" "$model" "$timeout" 2>&1) || true
+	local response
+	response=$(run_prompt "$prompt" "$agent" "$model" "$timeout" 2>&1) || true
 
-    local end_time
-    end_time=$(date +%s)
-    local duration=$((end_time - start_time))
+	local end_time
+	end_time=$(date +%s)
+	local duration=$((end_time - start_time))
 
-    echo -e "${BOLD}Response (${duration}s):${NC}"
-    echo "$response"
-    echo ""
+	echo -e "${BOLD}Response (${duration}s):${NC}"
+	echo "$response"
+	echo ""
 
-    if [[ -n "$expect" ]]; then
-        if echo "$response" | grep -qi "$expect"; then
-            log_pass "Contains expected pattern: \"$expect\""
-        else
-            log_fail "Missing expected pattern: \"$expect\""
-            return 1
-        fi
-    fi
+	if [[ -n "$expect" ]]; then
+		if echo "$response" | grep -qi "$expect"; then
+			log_pass "Contains expected pattern: \"$expect\""
+		else
+			log_fail "Missing expected pattern: \"$expect\""
+			return 1
+		fi
+	fi
 
-    return 0
+	return 0
 }
 
 #######################################
 # COMPARE command - compare current vs baseline
 #######################################
 cmd_compare() {
-    local test_file="$1"
-    ensure_dirs
+	local test_file="$1"
+	ensure_dirs
 
-    # Resolve test file
-    test_file=$(resolve_test_file "$test_file") || return 1
+	# Resolve test file
+	test_file=$(resolve_test_file "$test_file") || return 1
 
-    local suite_name
-    suite_name=$(jq -r '.name // "unnamed"' "$test_file")
+	local suite_name
+	suite_name=$(jq -r '.name // "unnamed"' "$test_file")
 
-    # Check for baseline
-    local baseline_file="${BASELINES_DIR}/${suite_name}.json"
-    if [[ ! -f "$baseline_file" ]]; then
-        log_warn "No baseline found for ${suite_name}"
-        log_info "Run 'agent-test-helper.sh baseline ${test_file}' to create one"
-        return 1
-    fi
+	# Check for baseline
+	local baseline_file="${BASELINES_DIR}/${suite_name}.json"
+	if [[ ! -f "$baseline_file" ]]; then
+		log_warn "No baseline found for ${suite_name}"
+		log_info "Run 'agent-test-helper.sh baseline ${test_file}' to create one"
+		return 1
+	fi
 
-    log_header "Comparison: ${suite_name}"
-    echo ""
+	log_header "Comparison: ${suite_name}"
+	echo ""
 
-    # Run current tests
-    log_info "Running current tests..."
-    cmd_run "$test_file" || true
+	# Run current tests
+	log_info "Running current tests..."
+	cmd_run "$test_file" || true
 
-    # Find most recent result
-    local latest_result
-    latest_result=$(find "$RESULTS_DIR" -name "${suite_name}-*.json" -print0 2>/dev/null \
-        | xargs -0 ls -t 2>/dev/null | head -1)
+	# Find most recent result
+	local latest_result
+	latest_result=$(find "$RESULTS_DIR" -name "${suite_name}-*.json" -print0 2>/dev/null |
+		xargs -0 ls -t 2>/dev/null | head -1)
 
-    if [[ -z "$latest_result" ]]; then
-        log_fail "No results found after running tests"
-        return 1
-    fi
+	if [[ -z "$latest_result" ]]; then
+		log_fail "No results found after running tests"
+		return 1
+	fi
 
-    # Compare
-    local baseline_passed current_passed
-    baseline_passed=$(jq '.summary.passed' "$baseline_file")
-    current_passed=$(jq '.summary.passed' "$latest_result")
+	# Compare
+	local baseline_passed current_passed
+	baseline_passed=$(jq '.summary.passed' "$baseline_file")
+	current_passed=$(jq '.summary.passed' "$latest_result")
 
-    local baseline_failed current_failed
-    baseline_failed=$(jq '.summary.failed' "$baseline_file")
-    current_failed=$(jq '.summary.failed' "$latest_result")
+	local baseline_failed current_failed
+	baseline_failed=$(jq '.summary.failed' "$baseline_file")
+	current_failed=$(jq '.summary.failed' "$latest_result")
 
-    echo ""
-    log_header "Comparison Results"
-    echo "  Baseline: ${baseline_passed} passed, ${baseline_failed} failed"
-    echo "  Current:  ${current_passed} passed, ${current_failed} failed"
-    echo ""
+	echo ""
+	log_header "Comparison Results"
+	echo "  Baseline: ${baseline_passed} passed, ${baseline_failed} failed"
+	echo "  Current:  ${current_passed} passed, ${current_failed} failed"
+	echo ""
 
-    if [[ "$current_failed" -lt "$baseline_failed" ]]; then
-        log_pass "Improvement: fewer failures ($current_failed < $baseline_failed)"
-    elif [[ "$current_failed" -gt "$baseline_failed" ]]; then
-        log_fail "Regression: more failures ($current_failed > $baseline_failed)"
-        return 1
-    else
-        log_info "No change in pass/fail counts"
-    fi
+	if [[ "$current_failed" -lt "$baseline_failed" ]]; then
+		log_pass "Improvement: fewer failures ($current_failed < $baseline_failed)"
+	elif [[ "$current_failed" -gt "$baseline_failed" ]]; then
+		log_fail "Regression: more failures ($current_failed > $baseline_failed)"
+		return 1
+	else
+		log_info "No change in pass/fail counts"
+	fi
 
-    # Per-test comparison
-    local test_count
-    test_count=$(jq '.results | length' "$baseline_file")
-    local regressions=0
+	# Per-test comparison
+	local test_count
+	test_count=$(jq '.results | length' "$baseline_file")
+	local regressions=0
 
-    local j=0
-    while [[ $j -lt $test_count ]]; do
-        local test_id
-        test_id=$(jq -r ".results[$j].id" "$baseline_file")
-        local baseline_status
-        baseline_status=$(jq -r ".results[$j].status" "$baseline_file")
-        local current_status
-        current_status=$(jq -r ".results[] | select(.id == \"$test_id\") | .status" "$latest_result" 2>/dev/null)
+	local j=0
+	while [[ $j -lt $test_count ]]; do
+		local test_id
+		test_id=$(jq -r ".results[$j].id" "$baseline_file")
+		local baseline_status
+		baseline_status=$(jq -r ".results[$j].status" "$baseline_file")
+		local current_status
+		current_status=$(jq -r ".results[] | select(.id == \"$test_id\") | .status" "$latest_result" 2>/dev/null)
 
-        if [[ -z "$current_status" ]]; then
-            log_fail "  Missing: ${test_id} (in baseline but not in current run)"
-            regressions=$((regressions + 1))
-        elif [[ "$baseline_status" == "pass" && "$current_status" == "fail" ]]; then
-            log_fail "  Regression: ${test_id} (was pass, now fail)"
-            regressions=$((regressions + 1))
-        elif [[ "$baseline_status" == "fail" && "$current_status" == "pass" ]]; then
-            log_pass "  Fixed: ${test_id} (was fail, now pass)"
-        fi
+		if [[ -z "$current_status" ]]; then
+			log_fail "  Missing: ${test_id} (in baseline but not in current run)"
+			regressions=$((regressions + 1))
+		elif [[ "$baseline_status" == "pass" && "$current_status" == "fail" ]]; then
+			log_fail "  Regression: ${test_id} (was pass, now fail)"
+			regressions=$((regressions + 1))
+		elif [[ "$baseline_status" == "fail" && "$current_status" == "pass" ]]; then
+			log_pass "  Fixed: ${test_id} (was fail, now pass)"
+		fi
 
-        j=$((j + 1))
-    done
+		j=$((j + 1))
+	done
 
-    if [[ $regressions -gt 0 ]]; then
-        return 1
-    fi
-    return 0
+	if [[ $regressions -gt 0 ]]; then
+		return 1
+	fi
+	return 0
 }
 
 #######################################
 # BASELINE command - save current results as baseline
 #######################################
 cmd_baseline() {
-    local test_file="$1"
-    ensure_dirs
+	local test_file="$1"
+	ensure_dirs
 
-    # Resolve test file
-    test_file=$(resolve_test_file "$test_file") || return 1
+	# Resolve test file
+	test_file=$(resolve_test_file "$test_file") || return 1
 
-    local suite_name
-    suite_name=$(jq -r '.name // "unnamed"' "$test_file")
+	local suite_name
+	suite_name=$(jq -r '.name // "unnamed"' "$test_file")
 
-    log_info "Running tests to establish baseline..."
-    cmd_run "$test_file" || true
+	log_info "Running tests to establish baseline..."
+	cmd_run "$test_file" || true
 
-    # Find most recent result
-    local latest_result
-    latest_result=$(find "$RESULTS_DIR" -name "${suite_name}-*.json" -print0 2>/dev/null \
-        | xargs -0 ls -t 2>/dev/null | head -1)
+	# Find most recent result
+	local latest_result
+	latest_result=$(find "$RESULTS_DIR" -name "${suite_name}-*.json" -print0 2>/dev/null |
+		xargs -0 ls -t 2>/dev/null | head -1)
 
-    if [[ -z "$latest_result" ]]; then
-        log_fail "No results found after running tests"
-        return 1
-    fi
+	if [[ -z "$latest_result" ]]; then
+		log_fail "No results found after running tests"
+		return 1
+	fi
 
-    # Copy as baseline
-    local baseline_file="${BASELINES_DIR}/${suite_name}.json"
-    cp "$latest_result" "$baseline_file"
-    log_pass "Baseline saved: $baseline_file"
+	# Copy as baseline
+	local baseline_file="${BASELINES_DIR}/${suite_name}.json"
+	cp "$latest_result" "$baseline_file"
+	log_pass "Baseline saved: $baseline_file"
 
-    return 0
+	return 0
 }
 
 #######################################
 # LIST command - list available test suites
 #######################################
 cmd_list() {
-    ensure_dirs
+	ensure_dirs
 
-    log_header "Available Test Suites"
-    echo ""
+	log_header "Available Test Suites"
+	echo ""
 
-    local count=0
+	local count=0
 
-    # List user suites (workspace)
-    for suite_file in "${SUITES_DIR}"/*.json; do
-        [[ -f "$suite_file" ]] || continue
+	# List user suites (workspace)
+	for suite_file in "${SUITES_DIR}"/*.json; do
+		[[ -f "$suite_file" ]] || continue
 
-        local name desc test_count
-        name=$(jq -r '.name // "unnamed"' "$suite_file")
-        desc=$(jq -r '.description // ""' "$suite_file")
-        test_count=$(jq '.tests | length' "$suite_file")
+		local name desc test_count
+		name=$(jq -r '.name // "unnamed"' "$suite_file")
+		desc=$(jq -r '.description // ""' "$suite_file")
+		test_count=$(jq '.tests | length' "$suite_file")
 
-        echo -e "  ${BOLD}${name}${NC} (${test_count} tests)"
-        if [[ -n "$desc" ]]; then
-            echo -e "    ${DIM}${desc}${NC}"
-        fi
+		echo -e "  ${BOLD}${name}${NC} (${test_count} tests)"
+		if [[ -n "$desc" ]]; then
+			echo -e "    ${DIM}${desc}${NC}"
+		fi
 
-        # Check for baseline
-        if [[ -f "${BASELINES_DIR}/${name}.json" ]]; then
-            echo -e "    ${GREEN}Baseline available${NC}"
-        fi
+		# Check for baseline
+		if [[ -f "${BASELINES_DIR}/${name}.json" ]]; then
+			echo -e "    ${GREEN}Baseline available${NC}"
+		fi
 
-        echo ""
-        count=$((count + 1))
-    done
+		echo ""
+		count=$((count + 1))
+	done
 
-    # List repo-shipped suites
-    if [[ -d "$REPO_SUITES_DIR" ]]; then
-        for suite_file in "${REPO_SUITES_DIR}"/*.json; do
-            [[ -f "$suite_file" ]] || continue
+	# List repo-shipped suites
+	if [[ -d "$REPO_SUITES_DIR" ]]; then
+		for suite_file in "${REPO_SUITES_DIR}"/*.json; do
+			[[ -f "$suite_file" ]] || continue
 
-            local name desc test_count
-            name=$(jq -r '.name // "unnamed"' "$suite_file")
-            desc=$(jq -r '.description // ""' "$suite_file")
-            test_count=$(jq '.tests | length' "$suite_file")
+			local name desc test_count
+			name=$(jq -r '.name // "unnamed"' "$suite_file")
+			desc=$(jq -r '.description // ""' "$suite_file")
+			test_count=$(jq '.tests | length' "$suite_file")
 
-            echo -e "  ${BOLD}${name}${NC} (${test_count} tests) ${DIM}[shipped]${NC}"
-            if [[ -n "$desc" ]]; then
-                echo -e "    ${DIM}${desc}${NC}"
-            fi
+			echo -e "  ${BOLD}${name}${NC} (${test_count} tests) ${DIM}[shipped]${NC}"
+			if [[ -n "$desc" ]]; then
+				echo -e "    ${DIM}${desc}${NC}"
+			fi
 
-            echo ""
-            count=$((count + 1))
-        done
-    fi
+			echo ""
+			count=$((count + 1))
+		done
+	fi
 
-    if [[ $count -eq 0 ]]; then
-        log_info "No test suites found"
-        log_info "Create one with: agent-test-helper.sh create <name>"
-    fi
+	if [[ $count -eq 0 ]]; then
+		log_info "No test suites found"
+		log_info "Create one with: agent-test-helper.sh create <name>"
+	fi
 
-    return 0
+	return 0
 }
 
 #######################################
 # CREATE command - create test suite template
 #######################################
 cmd_create() {
-    local name="$1"
-    ensure_dirs
+	local name="$1"
+	ensure_dirs
 
-    local suite_file="${SUITES_DIR}/${name}.json"
+	local suite_file="${SUITES_DIR}/${name}.json"
 
-    if [[ -f "$suite_file" ]]; then
-        log_warn "Test suite already exists: $suite_file"
-        return 1
-    fi
+	if [[ -f "$suite_file" ]]; then
+		log_warn "Test suite already exists: $suite_file"
+		return 1
+	fi
 
-    cat > "$suite_file" << 'TEMPLATE'
+	cat >"$suite_file" <<'TEMPLATE'
 {
   "name": "SUITE_NAME",
   "description": "Description of what this test suite validates",
@@ -950,68 +962,68 @@ cmd_create() {
 }
 TEMPLATE
 
-    # Replace placeholder with actual name
-    local safe_name
-    safe_name="${name//[^a-zA-Z0-9_-]/-}"
-    sed_inplace "s/SUITE_NAME/${safe_name}/" "$suite_file"
+	# Replace placeholder with actual name
+	local safe_name
+	safe_name="${name//[^a-zA-Z0-9_-]/-}"
+	sed_inplace "s/SUITE_NAME/${safe_name}/" "$suite_file"
 
-    log_pass "Created test suite: $suite_file"
-    log_info "Edit the file to add your test cases, then run:"
-    echo "  agent-test-helper.sh run ${name}"
+	log_pass "Created test suite: $suite_file"
+	log_info "Edit the file to add your test cases, then run:"
+	echo "  agent-test-helper.sh run ${name}"
 
-    return 0
+	return 0
 }
 
 #######################################
 # RESULTS command - show recent results
 #######################################
 cmd_results() {
-    local filter="${1:-}"
-    ensure_dirs
+	local filter="${1:-}"
+	ensure_dirs
 
-    log_header "Recent Test Results"
-    echo ""
+	log_header "Recent Test Results"
+	echo ""
 
-    local result_files
-    if [[ -n "$filter" ]]; then
-        result_files=$(find "$RESULTS_DIR" -name "${filter}*.json" -print0 2>/dev/null \
-            | xargs -0 ls -t 2>/dev/null | head -10)
-    else
-        result_files=$(find "$RESULTS_DIR" -name "*.json" -print0 2>/dev/null \
-            | xargs -0 ls -t 2>/dev/null | head -10)
-    fi
+	local result_files
+	if [[ -n "$filter" ]]; then
+		result_files=$(find "$RESULTS_DIR" -name "${filter}*.json" -print0 2>/dev/null |
+			xargs -0 ls -t 2>/dev/null | head -10)
+	else
+		result_files=$(find "$RESULTS_DIR" -name "*.json" -print0 2>/dev/null |
+			xargs -0 ls -t 2>/dev/null | head -10)
+	fi
 
-    if [[ -z "$result_files" ]]; then
-        log_info "No results found"
-        return 0
-    fi
+	if [[ -z "$result_files" ]]; then
+		log_info "No results found"
+		return 0
+	fi
 
-    while IFS= read -r result_file; do
-        local name timestamp passed failed duration
-        name=$(jq -r '.name' "$result_file")
-        timestamp=$(jq -r '.timestamp' "$result_file")
-        passed=$(jq '.summary.passed' "$result_file")
-        failed=$(jq '.summary.failed' "$result_file")
-        duration=$(jq '.summary.duration' "$result_file")
+	while IFS= read -r result_file; do
+		local name timestamp passed failed duration
+		name=$(jq -r '.name' "$result_file")
+		timestamp=$(jq -r '.timestamp' "$result_file")
+		passed=$(jq '.summary.passed' "$result_file")
+		failed=$(jq '.summary.failed' "$result_file")
+		duration=$(jq '.summary.duration' "$result_file")
 
-        local status_color="$GREEN"
-        if [[ "$failed" -gt 0 ]]; then
-            status_color="$RED"
-        fi
+		local status_color="$GREEN"
+		if [[ "$failed" -gt 0 ]]; then
+			status_color="$RED"
+		fi
 
-        echo -e "  ${BOLD}${name}${NC} @ ${DIM}${timestamp}${NC}"
-        echo -e "    ${GREEN}${passed} passed${NC} ${status_color}${failed} failed${NC} (${duration}s)"
-        echo ""
-    done <<< "$result_files"
+		echo -e "  ${BOLD}${name}${NC} @ ${DIM}${timestamp}${NC}"
+		echo -e "    ${GREEN}${passed} passed${NC} ${status_color}${failed} failed${NC} (${duration}s)"
+		echo ""
+	done <<<"$result_files"
 
-    return 0
+	return 0
 }
 
 #######################################
 # HELP command
 #######################################
 cmd_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 agent-test-helper.sh - Agent testing framework with isolated AI sessions
 
 USAGE:
@@ -1036,7 +1048,7 @@ TEST SUITE FORMAT (JSON):
     "name": "suite-name",
     "description": "What this tests",
     "agent": "Build+",
-    "model": "anthropic/claude-sonnet-4-20250514",
+    "model": "anthropic/claude-sonnet-4-6",
     "timeout": 120,
     "tests": [
       {
@@ -1076,63 +1088,63 @@ EXAMPLES:
   # View results
   agent-test-helper.sh results
 EOF
-    return 0
+	return 0
 }
 
 #######################################
 # Main entry point
 #######################################
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    case "$command" in
-        run)
-            if [[ $# -lt 1 ]]; then
-                log_fail "Usage: agent-test-helper.sh run <test-file>"
-                return 1
-            fi
-            cmd_run "$1"
-            ;;
-        run-one)
-            cmd_run_one "$@"
-            ;;
-        compare)
-            if [[ $# -lt 1 ]]; then
-                log_fail "Usage: agent-test-helper.sh compare <test-file>"
-                return 1
-            fi
-            cmd_compare "$1"
-            ;;
-        baseline)
-            if [[ $# -lt 1 ]]; then
-                log_fail "Usage: agent-test-helper.sh baseline <test-file>"
-                return 1
-            fi
-            cmd_baseline "$1"
-            ;;
-        list)
-            cmd_list
-            ;;
-        create)
-            if [[ $# -lt 1 ]]; then
-                log_fail "Usage: agent-test-helper.sh create <name>"
-                return 1
-            fi
-            cmd_create "$1"
-            ;;
-        results)
-            cmd_results "${1:-}"
-            ;;
-        help|--help|-h)
-            cmd_help
-            ;;
-        *)
-            log_fail "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
+	case "$command" in
+	run)
+		if [[ $# -lt 1 ]]; then
+			log_fail "Usage: agent-test-helper.sh run <test-file>"
+			return 1
+		fi
+		cmd_run "$1"
+		;;
+	run-one)
+		cmd_run_one "$@"
+		;;
+	compare)
+		if [[ $# -lt 1 ]]; then
+			log_fail "Usage: agent-test-helper.sh compare <test-file>"
+			return 1
+		fi
+		cmd_compare "$1"
+		;;
+	baseline)
+		if [[ $# -lt 1 ]]; then
+			log_fail "Usage: agent-test-helper.sh baseline <test-file>"
+			return 1
+		fi
+		cmd_baseline "$1"
+		;;
+	list)
+		cmd_list
+		;;
+	create)
+		if [[ $# -lt 1 ]]; then
+			log_fail "Usage: agent-test-helper.sh create <name>"
+			return 1
+		fi
+		cmd_create "$1"
+		;;
+	results)
+		cmd_results "${1:-}"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		log_fail "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/contest-helper.sh
+++ b/.agents/scripts/contest-helper.sh
@@ -35,7 +35,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 # Default contest models — top 3 from different providers for diversity
-DEFAULT_CONTEST_MODELS="anthropic/claude-opus-4-6,anthropic/claude-sonnet-4-5,google/gemini-2.5-pro"
+DEFAULT_CONTEST_MODELS="anthropic/claude-opus-4-6,anthropic/claude-sonnet-4-6,google/gemini-2.5-pro"
 
 # Scoring weights (match response-scoring-helper.sh)
 WEIGHT_CORRECTNESS=30

--- a/.agents/scripts/cron-dispatch.sh
+++ b/.agents/scripts/cron-dispatch.sh
@@ -273,7 +273,7 @@ main() {
 	task=$(echo "$job" | jq -r '.task')
 	workdir=$(echo "$job" | jq -r '.workdir')
 	timeout=$(echo "$job" | jq -r '.timeout // 600')
-	model=$(echo "$job" | jq -r '.model // "anthropic/claude-sonnet-4-20250514"')
+	model=$(echo "$job" | jq -r '.model // "anthropic/claude-sonnet-4-6"')
 	notify=$(echo "$job" | jq -r '.notify // "none"')
 
 	# Resolve tier names to full model strings (t132.7)

--- a/.agents/scripts/document-extraction-helper.sh
+++ b/.agents/scripts/document-extraction-helper.sh
@@ -527,7 +527,7 @@ resolve_llm_backend() {
 		elif [[ -n "${OPENAI_API_KEY:-}" ]]; then
 			llm_backend="openai/gpt-4o"
 		elif [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-			llm_backend="anthropic/claude-sonnet-4-20250514"
+			llm_backend="anthropic/claude-sonnet-4-6"
 		else
 			print_warning "No cloud API key found, falling back to local"
 			if command -v ollama &>/dev/null; then

--- a/.agents/scripts/fallback-chain-helper.sh
+++ b/.agents/scripts/fallback-chain-helper.sh
@@ -58,7 +58,7 @@ readonly FALLBACK_DB="${FALLBACK_DIR}/fallback-chain.db"
 readonly DEFAULT_CONFIG="${SCRIPT_DIR}/../configs/fallback-chain-config.json"
 readonly AVAILABILITY_HELPER="${SCRIPT_DIR}/model-availability-helper.sh"
 readonly DEFAULT_MAX_DEPTH=5
-readonly COOLDOWN_SECONDS=300  # 5 minutes before retrying a failed provider
+readonly COOLDOWN_SECONDS=300 # 5 minutes before retrying a failed provider
 readonly GATEWAY_PROBE_TIMEOUT=10
 
 # =============================================================================
@@ -66,9 +66,9 @@ readonly GATEWAY_PROBE_TIMEOUT=10
 # =============================================================================
 
 init_db() {
-    mkdir -p "$FALLBACK_DIR" 2>/dev/null || true
+	mkdir -p "$FALLBACK_DIR" 2>/dev/null || true
 
-    sqlite3 "$FALLBACK_DB" "
+	sqlite3 "$FALLBACK_DB" "
         PRAGMA journal_mode=WAL;
         PRAGMA busy_timeout=5000;
 
@@ -103,28 +103,28 @@ init_db() {
         CREATE INDEX IF NOT EXISTS idx_trigger_log_tier ON trigger_log(tier);
         CREATE INDEX IF NOT EXISTS idx_trigger_log_timestamp ON trigger_log(timestamp);
     " >/dev/null 2>/dev/null || {
-        print_error "Failed to initialize fallback chain database"
-        return 1
-    }
-    return 0
+		print_error "Failed to initialize fallback chain database"
+		return 1
+	}
+	return 0
 }
 
 db_query() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" "$FALLBACK_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" "$FALLBACK_DB" "$query" 2>/dev/null
+	return $?
 }
 
 db_query_json() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" -json "$FALLBACK_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" -json "$FALLBACK_DB" "$query" 2>/dev/null
+	return $?
 }
 
 sql_escape() {
-    local val="$1"
-    echo "${val//\'/\'\'}"
-    return 0
+	local val="$1"
+	echo "${val//\'/\'\'}"
+	return 0
 }
 
 # =============================================================================
@@ -134,144 +134,144 @@ sql_escape() {
 # Load fallback chain config from JSON file.
 # Supports both global config and per-agent overrides.
 load_config() {
-    local config_path="${1:-$DEFAULT_CONFIG}"
+	local config_path="${1:-$DEFAULT_CONFIG}"
 
-    # Try working config first (with real credentials), then template
-    if [[ ! -f "$config_path" ]]; then
-        local template_path="${config_path%.json}.json.txt"
-        if [[ -f "$template_path" ]]; then
-            config_path="$template_path"
-        else
-            print_error "Fallback chain config not found: $config_path"
-            return 2
-        fi
-    fi
+	# Try working config first (with real credentials), then template
+	if [[ ! -f "$config_path" ]]; then
+		local template_path="${config_path%.json}.json.txt"
+		if [[ -f "$template_path" ]]; then
+			config_path="$template_path"
+		else
+			print_error "Fallback chain config not found: $config_path"
+			return 2
+		fi
+	fi
 
-    # Validate JSON
-    if ! jq empty "$config_path" 2>/dev/null; then
-        print_error "Invalid JSON in fallback chain config: $config_path"
-        return 2
-    fi
+	# Validate JSON
+	if ! jq empty "$config_path" 2>/dev/null; then
+		print_error "Invalid JSON in fallback chain config: $config_path"
+		return 2
+	fi
 
-    echo "$config_path"
-    return 0
+	echo "$config_path"
+	return 0
 }
 
 # Extract fallback chain from agent YAML frontmatter.
 # Returns JSON array of model specs, or empty if not defined.
 get_agent_chain() {
-    local agent_file="$1"
-    local tier="$2"
+	local agent_file="$1"
+	local tier="$2"
 
-    if [[ ! -f "$agent_file" ]]; then
-        return 1
-    fi
+	if [[ ! -f "$agent_file" ]]; then
+		return 1
+	fi
 
-    # Parse YAML frontmatter for fallback-chain field
-    local in_frontmatter=false
-    local in_chain=false
-    local chain_json="["
-    local first=true
-    local line_num=0
+	# Parse YAML frontmatter for fallback-chain field
+	local in_frontmatter=false
+	local in_chain=false
+	local chain_json="["
+	local first=true
+	local line_num=0
 
-    while IFS= read -r line; do
-        line_num=$((line_num + 1))
-        if [[ $line_num -eq 1 && "$line" == "---" ]]; then
-            in_frontmatter=true
-            continue
-        fi
-        if [[ "$in_frontmatter" == "true" && "$line" == "---" ]]; then
-            break
-        fi
-        if [[ "$in_frontmatter" == "true" ]]; then
-            # Check for fallback-chain: start
-            if [[ "$line" =~ ^fallback-chain: ]]; then
-                in_chain=true
-                continue
-            fi
-            # Collect chain entries (YAML list items)
-            if [[ "$in_chain" == "true" ]]; then
-                if [[ "$line" =~ ^[[:space:]]+-[[:space:]]+(.*) ]]; then
-                    local entry="${BASH_REMATCH[1]}"
-                    entry="${entry#"${entry%%[![:space:]]*}"}"
-                    entry="${entry%"${entry##*[![:space:]]}"}"
-                    if [[ "$first" == "true" ]]; then
-                        first=false
-                    else
-                        chain_json="${chain_json},"
-                    fi
-                    chain_json="${chain_json}\"${entry}\""
-                elif [[ ! "$line" =~ ^[[:space:]] ]]; then
-                    # End of chain list (non-indented line)
-                    in_chain=false
-                fi
-            fi
-        fi
-    done < "$agent_file"
+	while IFS= read -r line; do
+		line_num=$((line_num + 1))
+		if [[ $line_num -eq 1 && "$line" == "---" ]]; then
+			in_frontmatter=true
+			continue
+		fi
+		if [[ "$in_frontmatter" == "true" && "$line" == "---" ]]; then
+			break
+		fi
+		if [[ "$in_frontmatter" == "true" ]]; then
+			# Check for fallback-chain: start
+			if [[ "$line" =~ ^fallback-chain: ]]; then
+				in_chain=true
+				continue
+			fi
+			# Collect chain entries (YAML list items)
+			if [[ "$in_chain" == "true" ]]; then
+				if [[ "$line" =~ ^[[:space:]]+-[[:space:]]+(.*) ]]; then
+					local entry="${BASH_REMATCH[1]}"
+					entry="${entry#"${entry%%[![:space:]]*}"}"
+					entry="${entry%"${entry##*[![:space:]]}"}"
+					if [[ "$first" == "true" ]]; then
+						first=false
+					else
+						chain_json="${chain_json},"
+					fi
+					chain_json="${chain_json}\"${entry}\""
+				elif [[ ! "$line" =~ ^[[:space:]] ]]; then
+					# End of chain list (non-indented line)
+					in_chain=false
+				fi
+			fi
+		fi
+	done <"$agent_file"
 
-    chain_json="${chain_json}]"
+	chain_json="${chain_json}]"
 
-    # Return empty if no chain found
-    if [[ "$chain_json" == "[]" ]]; then
-        return 1
-    fi
+	# Return empty if no chain found
+	if [[ "$chain_json" == "[]" ]]; then
+		return 1
+	fi
 
-    echo "$chain_json"
-    return 0
+	echo "$chain_json"
+	return 0
 }
 
 # Get the fallback chain for a tier from config.
 # Priority: per-agent frontmatter > config tier-specific > config global default
 get_chain_for_tier() {
-    local tier="$1"
-    local config_path="$2"
-    local agent_file="${3:-}"
+	local tier="$1"
+	local config_path="$2"
+	local agent_file="${3:-}"
 
-    # Priority 1: Per-agent frontmatter
-    if [[ -n "$agent_file" ]]; then
-        local agent_chain
-        agent_chain=$(get_agent_chain "$agent_file" "$tier" 2>/dev/null) || true
-        if [[ -n "$agent_chain" && "$agent_chain" != "[]" ]]; then
-            echo "$agent_chain"
-            return 0
-        fi
-    fi
+	# Priority 1: Per-agent frontmatter
+	if [[ -n "$agent_file" ]]; then
+		local agent_chain
+		agent_chain=$(get_agent_chain "$agent_file" "$tier" 2>/dev/null) || true
+		if [[ -n "$agent_chain" && "$agent_chain" != "[]" ]]; then
+			echo "$agent_chain"
+			return 0
+		fi
+	fi
 
-    # Priority 2: Tier-specific chain from config
-    local tier_chain
-    tier_chain=$(jq -r --arg tier "$tier" '.chains[$tier] // empty' "$config_path" 2>/dev/null) || true
-    if [[ -n "$tier_chain" && "$tier_chain" != "null" ]]; then
-        echo "$tier_chain"
-        return 0
-    fi
+	# Priority 2: Tier-specific chain from config
+	local tier_chain
+	tier_chain=$(jq -r --arg tier "$tier" '.chains[$tier] // empty' "$config_path" 2>/dev/null) || true
+	if [[ -n "$tier_chain" && "$tier_chain" != "null" ]]; then
+		echo "$tier_chain"
+		return 0
+	fi
 
-    # Priority 3: Global default chain from config
-    local default_chain
-    default_chain=$(jq -r '.chains.default // empty' "$config_path" 2>/dev/null) || true
-    if [[ -n "$default_chain" && "$default_chain" != "null" ]]; then
-        echo "$default_chain"
-        return 0
-    fi
+	# Priority 3: Global default chain from config
+	local default_chain
+	default_chain=$(jq -r '.chains.default // empty' "$config_path" 2>/dev/null) || true
+	if [[ -n "$default_chain" && "$default_chain" != "null" ]]; then
+		echo "$default_chain"
+		return 0
+	fi
 
-    # Priority 4: Hardcoded minimal fallback
-    # Use the existing model-availability-helper.sh tier mapping
-    local tier_spec=""
-    case "$tier" in
-        haiku)  tier_spec='["anthropic/claude-haiku-4-5"]' ;;
-        flash)  tier_spec='["anthropic/claude-haiku-4-5"]' ;;
-        sonnet) tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
-        pro)    tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
-        opus)   tier_spec='["anthropic/claude-opus-4-6"]' ;;
-        coding) tier_spec='["anthropic/claude-opus-4-6","anthropic/claude-sonnet-4-5"]' ;;
-        eval)   tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
-        health) tier_spec='["anthropic/claude-sonnet-4-5"]' ;;
-        *)
-            print_error "Unknown tier: $tier"
-            return 1
-            ;;
-    esac
-    echo "$tier_spec"
-    return 0
+	# Priority 4: Hardcoded minimal fallback
+	# Use the existing model-availability-helper.sh tier mapping
+	local tier_spec=""
+	case "$tier" in
+	haiku) tier_spec='["anthropic/claude-haiku-4-5"]' ;;
+	flash) tier_spec='["anthropic/claude-haiku-4-5"]' ;;
+	sonnet) tier_spec='["anthropic/claude-sonnet-4-6"]' ;;
+	pro) tier_spec='["anthropic/claude-sonnet-4-6"]' ;;
+	opus) tier_spec='["anthropic/claude-opus-4-6"]' ;;
+	coding) tier_spec='["anthropic/claude-opus-4-6","anthropic/claude-sonnet-4-6"]' ;;
+	eval) tier_spec='["anthropic/claude-sonnet-4-6"]' ;;
+	health) tier_spec='["anthropic/claude-sonnet-4-6"]' ;;
+	*)
+		print_error "Unknown tier: $tier"
+		return 1
+		;;
+	esac
+	echo "$tier_spec"
+	return 0
 }
 
 # =============================================================================
@@ -280,49 +280,49 @@ get_chain_for_tier() {
 
 # Check if a provider is in cooldown (recently failed).
 is_provider_cooled_down() {
-    local provider="$1"
+	local provider="$1"
 
-    local cooldown_until
-    cooldown_until=$(db_query "
+	local cooldown_until
+	cooldown_until=$(db_query "
         SELECT cooldown_until FROM provider_cooldown
         WHERE provider = '$(sql_escape "$provider")';
     ")
 
-    if [[ -z "$cooldown_until" ]]; then
-        return 1  # Not in cooldown
-    fi
+	if [[ -z "$cooldown_until" ]]; then
+		return 1 # Not in cooldown
+	fi
 
-    local cooldown_epoch now_epoch
-    if [[ "$(uname)" == "Darwin" ]]; then
-        cooldown_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$cooldown_until" "+%s" 2>/dev/null || echo "0")
-    else
-        cooldown_epoch=$(date -d "$cooldown_until" "+%s" 2>/dev/null || echo "0")
-    fi
-    now_epoch=$(date "+%s")
+	local cooldown_epoch now_epoch
+	if [[ "$(uname)" == "Darwin" ]]; then
+		cooldown_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$cooldown_until" "+%s" 2>/dev/null || echo "0")
+	else
+		cooldown_epoch=$(date -d "$cooldown_until" "+%s" 2>/dev/null || echo "0")
+	fi
+	now_epoch=$(date "+%s")
 
-    if [[ "$now_epoch" -lt "$cooldown_epoch" ]]; then
-        return 0  # Still in cooldown
-    fi
+	if [[ "$now_epoch" -lt "$cooldown_epoch" ]]; then
+		return 0 # Still in cooldown
+	fi
 
-    # Cooldown expired, remove it
-    db_query "DELETE FROM provider_cooldown WHERE provider = '$(sql_escape "$provider")';" || true
-    return 1  # No longer in cooldown
+	# Cooldown expired, remove it
+	db_query "DELETE FROM provider_cooldown WHERE provider = '$(sql_escape "$provider")';" || true
+	return 1 # No longer in cooldown
 }
 
 # Put a provider into cooldown after a failure.
 set_provider_cooldown() {
-    local provider="$1"
-    local reason="$2"
-    local duration="${3:-$COOLDOWN_SECONDS}"
+	local provider="$1"
+	local reason="$2"
+	local duration="${3:-$COOLDOWN_SECONDS}"
 
-    local cooldown_until
-    if [[ "$(uname)" == "Darwin" ]]; then
-        cooldown_until=$(date -u -v+"${duration}S" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
-    else
-        cooldown_until=$(date -u -d "+${duration} seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
-    fi
+	local cooldown_until
+	if [[ "$(uname)" == "Darwin" ]]; then
+		cooldown_until=$(date -u -v+"${duration}S" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+	else
+		cooldown_until=$(date -u -d "+${duration} seconds" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+	fi
 
-    db_query "
+	db_query "
         INSERT INTO provider_cooldown (provider, reason, cooldown_until)
         VALUES (
             '$(sql_escape "$provider")',
@@ -334,7 +334,7 @@ set_provider_cooldown() {
             cooldown_until = excluded.cooldown_until,
             created_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now');
     " || true
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -343,83 +343,83 @@ set_provider_cooldown() {
 
 # Classify an error into a trigger type based on HTTP status code or error message.
 classify_trigger() {
-    local error_input="$1"
+	local error_input="$1"
 
-    # HTTP status code patterns
-    case "$error_input" in
-        429|*"rate limit"*|*"Rate limit"*|*"rate_limit"*|*"too many requests"*|*"Too Many Requests"*)
-            echo "rate_limit"
-            return 0
-            ;;
-        401|403|*"auth"*|*"forbidden"*|*"Forbidden"*|*"invalid"*"key"*|*"Invalid"*"key"*)
-            echo "auth_error"
-            return 0
-            ;;
-        500|502|503|504|*"internal server"*|*"Internal Server"*|*"bad gateway"*|*"Bad Gateway"*|*"service unavailable"*|*"Service Unavailable"*|*"gateway timeout"*|*"Gateway Timeout"*)
-            echo "api_error"
-            return 0
-            ;;
-        529|*"overloaded"*|*"Overloaded"*|*"capacity"*)
-            echo "overloaded"
-            return 0
-            ;;
-        *"timeout"*|*"Timeout"*|*"ETIMEDOUT"*|*"ECONNRESET"*|*"timed out"*)
-            echo "timeout"
-            return 0
-            ;;
-        *"connection refused"*|*"Connection refused"*|*"ECONNREFUSED"*|*"network"*|*"Network"*)
-            echo "api_error"
-            return 0
-            ;;
-        *)
-            echo "unknown"
-            return 0
-            ;;
-    esac
+	# HTTP status code patterns
+	case "$error_input" in
+	429 | *"rate limit"* | *"Rate limit"* | *"rate_limit"* | *"too many requests"* | *"Too Many Requests"*)
+		echo "rate_limit"
+		return 0
+		;;
+	401 | 403 | *"auth"* | *"forbidden"* | *"Forbidden"* | *"invalid"*"key"* | *"Invalid"*"key"*)
+		echo "auth_error"
+		return 0
+		;;
+	500 | 502 | 503 | 504 | *"internal server"* | *"Internal Server"* | *"bad gateway"* | *"Bad Gateway"* | *"service unavailable"* | *"Service Unavailable"* | *"gateway timeout"* | *"Gateway Timeout"*)
+		echo "api_error"
+		return 0
+		;;
+	529 | *"overloaded"* | *"Overloaded"* | *"capacity"*)
+		echo "overloaded"
+		return 0
+		;;
+	*"timeout"* | *"Timeout"* | *"ETIMEDOUT"* | *"ECONNRESET"* | *"timed out"*)
+		echo "timeout"
+		return 0
+		;;
+	*"connection refused"* | *"Connection refused"* | *"ECONNREFUSED"* | *"network"* | *"Network"*)
+		echo "api_error"
+		return 0
+		;;
+	*)
+		echo "unknown"
+		return 0
+		;;
+	esac
 }
 
 # Determine cooldown duration based on trigger type.
 get_cooldown_for_trigger() {
-    local trigger_type="$1"
-    local config_path="$2"
+	local trigger_type="$1"
+	local config_path="$2"
 
-    # Try config first
-    local configured_cooldown
-    configured_cooldown=$(jq -r --arg trigger "$trigger_type" \
-        '.triggers[$trigger].cooldown_seconds // empty' "$config_path" 2>/dev/null) || true
+	# Try config first
+	local configured_cooldown
+	configured_cooldown=$(jq -r --arg trigger "$trigger_type" \
+		'.triggers[$trigger].cooldown_seconds // empty' "$config_path" 2>/dev/null) || true
 
-    if [[ -n "$configured_cooldown" && "$configured_cooldown" != "null" ]]; then
-        echo "$configured_cooldown"
-        return 0
-    fi
+	if [[ -n "$configured_cooldown" && "$configured_cooldown" != "null" ]]; then
+		echo "$configured_cooldown"
+		return 0
+	fi
 
-    # Default cooldowns by trigger type
-    case "$trigger_type" in
-        rate_limit)  echo "60" ;;    # 1 minute
-        auth_error)  echo "3600" ;;  # 1 hour (key won't fix itself)
-        api_error)   echo "300" ;;   # 5 minutes
-        overloaded)  echo "120" ;;   # 2 minutes
-        timeout)     echo "180" ;;   # 3 minutes
-        *)           echo "300" ;;   # 5 minutes default
-    esac
-    return 0
+	# Default cooldowns by trigger type
+	case "$trigger_type" in
+	rate_limit) echo "60" ;;   # 1 minute
+	auth_error) echo "3600" ;; # 1 hour (key won't fix itself)
+	api_error) echo "300" ;;   # 5 minutes
+	overloaded) echo "120" ;;  # 2 minutes
+	timeout) echo "180" ;;     # 3 minutes
+	*) echo "300" ;;           # 5 minutes default
+	esac
+	return 0
 }
 
 # Check if a trigger type should activate fallback.
 should_trigger_fallback() {
-    local trigger_type="$1"
-    local config_path="$2"
+	local trigger_type="$1"
+	local config_path="$2"
 
-    # Check config for trigger enablement
-    local enabled
-    enabled=$(jq -r --arg trigger "$trigger_type" \
-        '.triggers[$trigger].enabled // true' "$config_path" 2>/dev/null) || true
+	# Check config for trigger enablement
+	local enabled
+	enabled=$(jq -r --arg trigger "$trigger_type" \
+		'.triggers[$trigger].enabled // true' "$config_path" 2>/dev/null) || true
 
-    if [[ "$enabled" == "false" ]]; then
-        return 1
-    fi
+	if [[ "$enabled" == "false" ]]; then
+		return 1
+	fi
 
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -430,191 +430,191 @@ should_trigger_fallback() {
 # Handles both direct (anthropic/claude-sonnet-4) and gateway
 # (openrouter/anthropic/claude-sonnet-4, gateway/cf/anthropic/claude-sonnet-4) formats.
 parse_model_spec() {
-    local model_spec="$1"
-    local field="$2"  # provider, gateway, model, or full
+	local model_spec="$1"
+	local field="$2" # provider, gateway, model, or full
 
-    case "$model_spec" in
-        gateway/cf/*)
-            # Cloudflare AI Gateway: gateway/cf/provider/model
-            case "$field" in
-                gateway)  echo "cloudflare" ;;
-                provider) echo "$model_spec" | cut -d'/' -f3 ;;
-                model)    echo "$model_spec" | cut -d'/' -f4- ;;
-                full)     echo "$model_spec" ;;
-            esac
-            ;;
-        openrouter/*)
-            # OpenRouter gateway: openrouter/provider/model
-            case "$field" in
-                gateway)  echo "openrouter" ;;
-                provider) echo "$model_spec" | cut -d'/' -f2 ;;
-                model)    echo "$model_spec" | cut -d'/' -f3- ;;
-                full)     echo "$model_spec" ;;
-            esac
-            ;;
-        */*)
-            # Direct provider: provider/model
-            case "$field" in
-                gateway)  echo "direct" ;;
-                provider) echo "${model_spec%%/*}" ;;
-                model)    echo "${model_spec#*/}" ;;
-                full)     echo "$model_spec" ;;
-            esac
-            ;;
-        *)
-            # Bare model name
-            case "$field" in
-                gateway)  echo "direct" ;;
-                provider) echo "unknown" ;;
-                model)    echo "$model_spec" ;;
-                full)     echo "$model_spec" ;;
-            esac
-            ;;
-    esac
-    return 0
+	case "$model_spec" in
+	gateway/cf/*)
+		# Cloudflare AI Gateway: gateway/cf/provider/model
+		case "$field" in
+		gateway) echo "cloudflare" ;;
+		provider) echo "$model_spec" | cut -d'/' -f3 ;;
+		model) echo "$model_spec" | cut -d'/' -f4- ;;
+		full) echo "$model_spec" ;;
+		esac
+		;;
+	openrouter/*)
+		# OpenRouter gateway: openrouter/provider/model
+		case "$field" in
+		gateway) echo "openrouter" ;;
+		provider) echo "$model_spec" | cut -d'/' -f2 ;;
+		model) echo "$model_spec" | cut -d'/' -f3- ;;
+		full) echo "$model_spec" ;;
+		esac
+		;;
+	*/*)
+		# Direct provider: provider/model
+		case "$field" in
+		gateway) echo "direct" ;;
+		provider) echo "${model_spec%%/*}" ;;
+		model) echo "${model_spec#*/}" ;;
+		full) echo "$model_spec" ;;
+		esac
+		;;
+	*)
+		# Bare model name
+		case "$field" in
+		gateway) echo "direct" ;;
+		provider) echo "unknown" ;;
+		model) echo "$model_spec" ;;
+		full) echo "$model_spec" ;;
+		esac
+		;;
+	esac
+	return 0
 }
 
 # Check if a gateway provider is available.
 check_gateway() {
-    local gateway_type="$1"
-    local config_path="$2"
-    local quiet="${3:-false}"
+	local gateway_type="$1"
+	local config_path="$2"
+	local quiet="${3:-false}"
 
-    case "$gateway_type" in
-        openrouter)
-            _check_openrouter_gateway "$config_path" "$quiet"
-            return $?
-            ;;
-        cloudflare)
-            _check_cloudflare_gateway "$config_path" "$quiet"
-            return $?
-            ;;
-        direct)
-            return 0  # Direct providers checked by model-availability-helper
-            ;;
-        *)
-            [[ "$quiet" != "true" ]] && print_warning "Unknown gateway type: $gateway_type"
-            return 1
-            ;;
-    esac
+	case "$gateway_type" in
+	openrouter)
+		_check_openrouter_gateway "$config_path" "$quiet"
+		return $?
+		;;
+	cloudflare)
+		_check_cloudflare_gateway "$config_path" "$quiet"
+		return $?
+		;;
+	direct)
+		return 0 # Direct providers checked by model-availability-helper
+		;;
+	*)
+		[[ "$quiet" != "true" ]] && print_warning "Unknown gateway type: $gateway_type"
+		return 1
+		;;
+	esac
 }
 
 _check_openrouter_gateway() {
-    local config_path="$1"
-    local quiet="$2"
+	local config_path="$1"
+	local quiet="$2"
 
-    # Check for OpenRouter API key
-    local key_var="OPENROUTER_API_KEY"
-    if [[ -z "${!key_var:-}" ]]; then
-        # Try credentials.sh
-        local creds_file="${HOME}/.config/aidevops/credentials.sh"
-        if [[ -f "$creds_file" ]]; then
-            # shellcheck disable=SC1090
-            source "$creds_file"
-        fi
-    fi
+	# Check for OpenRouter API key
+	local key_var="OPENROUTER_API_KEY"
+	if [[ -z "${!key_var:-}" ]]; then
+		# Try credentials.sh
+		local creds_file="${HOME}/.config/aidevops/credentials.sh"
+		if [[ -f "$creds_file" ]]; then
+			# shellcheck disable=SC1090
+			source "$creds_file"
+		fi
+	fi
 
-    if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
-        [[ "$quiet" != "true" ]] && print_warning "OpenRouter: no API key configured"
-        _record_gateway_health "openrouter" "openrouter" "no_key" "" 0 "No OPENROUTER_API_KEY"
-        return 1
-    fi
+	if [[ -z "${OPENROUTER_API_KEY:-}" ]]; then
+		[[ "$quiet" != "true" ]] && print_warning "OpenRouter: no API key configured"
+		_record_gateway_health "openrouter" "openrouter" "no_key" "" 0 "No OPENROUTER_API_KEY"
+		return 1
+	fi
 
-    # Lightweight probe
-    local start_ms
-    start_ms=$(date +%s%N 2>/dev/null || echo "0")
+	# Lightweight probe
+	local start_ms
+	start_ms=$(date +%s%N 2>/dev/null || echo "0")
 
-    local http_code
-    http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$GATEWAY_PROBE_TIMEOUT" \
-        -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
-        "https://openrouter.ai/api/v1/models" 2>/dev/null) || http_code="000"
+	local http_code
+	http_code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$GATEWAY_PROBE_TIMEOUT" \
+		-H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
+		"https://openrouter.ai/api/v1/models" 2>/dev/null) || http_code="000"
 
-    local end_ms
-    end_ms=$(date +%s%N 2>/dev/null || echo "0")
-    local duration_ms=0
-    if [[ "$start_ms" != "0" && "$end_ms" != "0" ]]; then
-        duration_ms=$(( (end_ms - start_ms) / 1000000 ))
-    fi
+	local end_ms
+	end_ms=$(date +%s%N 2>/dev/null || echo "0")
+	local duration_ms=0
+	if [[ "$start_ms" != "0" && "$end_ms" != "0" ]]; then
+		duration_ms=$(((end_ms - start_ms) / 1000000))
+	fi
 
-    if [[ "$http_code" == "200" ]]; then
-        [[ "$quiet" != "true" ]] && print_success "OpenRouter: healthy (${duration_ms}ms)"
-        _record_gateway_health "openrouter" "openrouter" "healthy" "https://openrouter.ai/api/v1" "$duration_ms" ""
-        return 0
-    fi
+	if [[ "$http_code" == "200" ]]; then
+		[[ "$quiet" != "true" ]] && print_success "OpenRouter: healthy (${duration_ms}ms)"
+		_record_gateway_health "openrouter" "openrouter" "healthy" "https://openrouter.ai/api/v1" "$duration_ms" ""
+		return 0
+	fi
 
-    [[ "$quiet" != "true" ]] && print_warning "OpenRouter: unhealthy (HTTP $http_code)"
-    _record_gateway_health "openrouter" "openrouter" "unhealthy" "https://openrouter.ai/api/v1" "$duration_ms" "HTTP $http_code"
-    return 1
+	[[ "$quiet" != "true" ]] && print_warning "OpenRouter: unhealthy (HTTP $http_code)"
+	_record_gateway_health "openrouter" "openrouter" "unhealthy" "https://openrouter.ai/api/v1" "$duration_ms" "HTTP $http_code"
+	return 1
 }
 
 _check_cloudflare_gateway() {
-    local config_path="$1"
-    local quiet="$2"
+	local config_path="$1"
+	local quiet="$2"
 
-    # Get Cloudflare AI Gateway config
-    local account_id gateway_id cf_token
-    account_id=$(jq -r '.gateways.cloudflare.account_id // empty' "$config_path" 2>/dev/null) || true
-    gateway_id=$(jq -r '.gateways.cloudflare.gateway_id // empty' "$config_path" 2>/dev/null) || true
+	# Get Cloudflare AI Gateway config
+	local account_id gateway_id cf_token
+	account_id=$(jq -r '.gateways.cloudflare.account_id // empty' "$config_path" 2>/dev/null) || true
+	gateway_id=$(jq -r '.gateways.cloudflare.gateway_id // empty' "$config_path" 2>/dev/null) || true
 
-    if [[ -z "$account_id" || -z "$gateway_id" ]]; then
-        [[ "$quiet" != "true" ]] && print_warning "Cloudflare AI Gateway: not configured (missing account_id/gateway_id)"
-        _record_gateway_health "cloudflare" "cloudflare" "not_configured" "" 0 "Missing account_id or gateway_id"
-        return 1
-    fi
+	if [[ -z "$account_id" || -z "$gateway_id" ]]; then
+		[[ "$quiet" != "true" ]] && print_warning "Cloudflare AI Gateway: not configured (missing account_id/gateway_id)"
+		_record_gateway_health "cloudflare" "cloudflare" "not_configured" "" 0 "Missing account_id or gateway_id"
+		return 1
+	fi
 
-    # Check for CF token
-    cf_token="${CF_AIG_TOKEN:-${CLOUDFLARE_API_TOKEN:-}}"
-    if [[ -z "$cf_token" ]]; then
-        local creds_file="${HOME}/.config/aidevops/credentials.sh"
-        if [[ -f "$creds_file" ]]; then
-            # shellcheck disable=SC1090
-            source "$creds_file"
-            cf_token="${CF_AIG_TOKEN:-${CLOUDFLARE_API_TOKEN:-}}"
-        fi
-    fi
+	# Check for CF token
+	cf_token="${CF_AIG_TOKEN:-${CLOUDFLARE_API_TOKEN:-}}"
+	if [[ -z "$cf_token" ]]; then
+		local creds_file="${HOME}/.config/aidevops/credentials.sh"
+		if [[ -f "$creds_file" ]]; then
+			# shellcheck disable=SC1090
+			source "$creds_file"
+			cf_token="${CF_AIG_TOKEN:-${CLOUDFLARE_API_TOKEN:-}}"
+		fi
+	fi
 
-    local endpoint="https://gateway.ai.cloudflare.com/v1/${account_id}/${gateway_id}"
+	local endpoint="https://gateway.ai.cloudflare.com/v1/${account_id}/${gateway_id}"
 
-    # Lightweight probe (just check if the gateway endpoint responds)
-    local start_ms
-    start_ms=$(date +%s%N 2>/dev/null || echo "0")
+	# Lightweight probe (just check if the gateway endpoint responds)
+	local start_ms
+	start_ms=$(date +%s%N 2>/dev/null || echo "0")
 
-    local -a curl_args=(-s -o /dev/null -w '%{http_code}' --max-time "$GATEWAY_PROBE_TIMEOUT")
-    if [[ -n "$cf_token" ]]; then
-        curl_args+=(-H "cf-aig-authorization: Bearer ${cf_token}")
-    fi
+	local -a curl_args=(-s -o /dev/null -w '%{http_code}' --max-time "$GATEWAY_PROBE_TIMEOUT")
+	if [[ -n "$cf_token" ]]; then
+		curl_args+=(-H "cf-aig-authorization: Bearer ${cf_token}")
+	fi
 
-    local http_code
-    http_code=$(curl "${curl_args[@]}" "${endpoint}/openai/models" 2>/dev/null) || http_code="000"
+	local http_code
+	http_code=$(curl "${curl_args[@]}" "${endpoint}/openai/models" 2>/dev/null) || http_code="000"
 
-    local end_ms
-    end_ms=$(date +%s%N 2>/dev/null || echo "0")
-    local duration_ms=0
-    if [[ "$start_ms" != "0" && "$end_ms" != "0" ]]; then
-        duration_ms=$(( (end_ms - start_ms) / 1000000 ))
-    fi
+	local end_ms
+	end_ms=$(date +%s%N 2>/dev/null || echo "0")
+	local duration_ms=0
+	if [[ "$start_ms" != "0" && "$end_ms" != "0" ]]; then
+		duration_ms=$(((end_ms - start_ms) / 1000000))
+	fi
 
-    # CF AI Gateway returns various codes; 200 or 401 (needs auth) both mean it's reachable
-    if [[ "$http_code" == "200" || "$http_code" == "401" ]]; then
-        [[ "$quiet" != "true" ]] && print_success "Cloudflare AI Gateway: reachable (${duration_ms}ms)"
-        _record_gateway_health "cloudflare" "cloudflare" "healthy" "$endpoint" "$duration_ms" ""
-        return 0
-    fi
+	# CF AI Gateway returns various codes; 200 or 401 (needs auth) both mean it's reachable
+	if [[ "$http_code" == "200" || "$http_code" == "401" ]]; then
+		[[ "$quiet" != "true" ]] && print_success "Cloudflare AI Gateway: reachable (${duration_ms}ms)"
+		_record_gateway_health "cloudflare" "cloudflare" "healthy" "$endpoint" "$duration_ms" ""
+		return 0
+	fi
 
-    [[ "$quiet" != "true" ]] && print_warning "Cloudflare AI Gateway: unreachable (HTTP $http_code)"
-    _record_gateway_health "cloudflare" "cloudflare" "unhealthy" "$endpoint" "$duration_ms" "HTTP $http_code"
-    return 1
+	[[ "$quiet" != "true" ]] && print_warning "Cloudflare AI Gateway: unreachable (HTTP $http_code)"
+	_record_gateway_health "cloudflare" "cloudflare" "unhealthy" "$endpoint" "$duration_ms" "HTTP $http_code"
+	return 1
 }
 
 _record_gateway_health() {
-    local gateway_id="$1"
-    local gateway_type="$2"
-    local status="$3"
-    local endpoint="$4"
-    local response_ms="$5"
-    local error_msg="$6"
+	local gateway_id="$1"
+	local gateway_type="$2"
+	local status="$3"
+	local endpoint="$4"
+	local response_ms="$5"
+	local error_msg="$6"
 
-    db_query "
+	db_query "
         INSERT INTO gateway_health (gateway_id, gateway_type, status, endpoint, last_checked, response_ms, error_message)
         VALUES (
             '$(sql_escape "$gateway_id")',
@@ -633,7 +633,7 @@ _record_gateway_health() {
             response_ms = excluded.response_ms,
             error_message = excluded.error_message;
     " || true
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -643,81 +643,81 @@ _record_gateway_health() {
 # Resolve the best available model by walking the fallback chain.
 # Skips providers in cooldown, checks availability, and logs the resolution.
 resolve_chain() {
-    local tier="$1"
-    local config_path="$2"
-    local agent_file="${3:-}"
-    local max_depth="${4:-$DEFAULT_MAX_DEPTH}"
-    local force="${5:-false}"
-    local quiet="${6:-false}"
+	local tier="$1"
+	local config_path="$2"
+	local agent_file="${3:-}"
+	local max_depth="${4:-$DEFAULT_MAX_DEPTH}"
+	local force="${5:-false}"
+	local quiet="${6:-false}"
 
-    # Get the chain for this tier
-    local chain_json
-    chain_json=$(get_chain_for_tier "$tier" "$config_path" "$agent_file") || {
-        print_error "Could not determine fallback chain for tier: $tier" >&2
-        return 1
-    }
+	# Get the chain for this tier
+	local chain_json
+	chain_json=$(get_chain_for_tier "$tier" "$config_path" "$agent_file") || {
+		print_error "Could not determine fallback chain for tier: $tier" >&2
+		return 1
+	}
 
-    local chain_length
-    chain_length=$(echo "$chain_json" | jq 'length' 2>/dev/null) || chain_length=0
+	local chain_length
+	chain_length=$(echo "$chain_json" | jq 'length' 2>/dev/null) || chain_length=0
 
-    if [[ "$chain_length" -eq 0 ]]; then
-        print_error "Empty fallback chain for tier: $tier" >&2
-        return 1
-    fi
+	if [[ "$chain_length" -eq 0 ]]; then
+		print_error "Empty fallback chain for tier: $tier" >&2
+		return 1
+	fi
 
-    # Cap at max depth
-    if [[ "$chain_length" -gt "$max_depth" ]]; then
-        chain_length="$max_depth"
-    fi
+	# Cap at max depth
+	if [[ "$chain_length" -gt "$max_depth" ]]; then
+		chain_length="$max_depth"
+	fi
 
-    # Walk the chain
-    local depth=0
-    while [[ "$depth" -lt "$chain_length" ]]; do
-        local model_spec
-        model_spec=$(echo "$chain_json" | jq -r ".[$depth]" 2>/dev/null) || true
+	# Walk the chain
+	local depth=0
+	while [[ "$depth" -lt "$chain_length" ]]; do
+		local model_spec
+		model_spec=$(echo "$chain_json" | jq -r ".[$depth]" 2>/dev/null) || true
 
-        if [[ -z "$model_spec" || "$model_spec" == "null" ]]; then
-            depth=$((depth + 1))
-            continue
-        fi
+		if [[ -z "$model_spec" || "$model_spec" == "null" ]]; then
+			depth=$((depth + 1))
+			continue
+		fi
 
-        local provider gateway
-        provider=$(parse_model_spec "$model_spec" "provider")
-        gateway=$(parse_model_spec "$model_spec" "gateway")
+		local provider gateway
+		provider=$(parse_model_spec "$model_spec" "provider")
+		gateway=$(parse_model_spec "$model_spec" "gateway")
 
-        # Check provider cooldown
-        if is_provider_cooled_down "$provider"; then
-            [[ "$quiet" != "true" ]] && print_warning "  [$depth] $model_spec: provider $provider in cooldown, skipping" >&2
-            depth=$((depth + 1))
-            continue
-        fi
+		# Check provider cooldown
+		if is_provider_cooled_down "$provider"; then
+			[[ "$quiet" != "true" ]] && print_warning "  [$depth] $model_spec: provider $provider in cooldown, skipping" >&2
+			depth=$((depth + 1))
+			continue
+		fi
 
-        # Check gateway availability (for gateway-routed models)
-        if [[ "$gateway" != "direct" ]]; then
-            if ! check_gateway "$gateway" "$config_path" "true"; then
-                [[ "$quiet" != "true" ]] && print_warning "  [$depth] $model_spec: gateway $gateway unavailable, skipping" >&2
-                depth=$((depth + 1))
-                continue
-            fi
-        fi
+		# Check gateway availability (for gateway-routed models)
+		if [[ "$gateway" != "direct" ]]; then
+			if ! check_gateway "$gateway" "$config_path" "true"; then
+				[[ "$quiet" != "true" ]] && print_warning "  [$depth] $model_spec: gateway $gateway unavailable, skipping" >&2
+				depth=$((depth + 1))
+				continue
+			fi
+		fi
 
-        # Check model availability via model-availability-helper.sh
-        if [[ -x "$AVAILABILITY_HELPER" && "$gateway" == "direct" ]]; then
-            local avail_exit=0
-            "$AVAILABILITY_HELPER" check "$provider" --quiet 2>/dev/null || avail_exit=$?
+		# Check model availability via model-availability-helper.sh
+		if [[ -x "$AVAILABILITY_HELPER" && "$gateway" == "direct" ]]; then
+			local avail_exit=0
+			"$AVAILABILITY_HELPER" check "$provider" --quiet 2>/dev/null || avail_exit=$?
 
-            if [[ "$avail_exit" -ne 0 ]]; then
-                [[ "$quiet" != "true" ]] && print_warning "  [$depth] $model_spec: provider $provider unavailable (exit $avail_exit), skipping" >&2
-                depth=$((depth + 1))
-                continue
-            fi
-        fi
+			if [[ "$avail_exit" -ne 0 ]]; then
+				[[ "$quiet" != "true" ]] && print_warning "  [$depth] $model_spec: provider $provider unavailable (exit $avail_exit), skipping" >&2
+				depth=$((depth + 1))
+				continue
+			fi
+		fi
 
-        # Model is available
-        [[ "$quiet" != "true" ]] && print_success "  [$depth] $model_spec: available" >&2
+		# Model is available
+		[[ "$quiet" != "true" ]] && print_success "  [$depth] $model_spec: available" >&2
 
-        # Log the resolution
-        db_query "
+		# Log the resolution
+		db_query "
             INSERT INTO trigger_log (tier, trigger_type, failed_model, resolved_model, chain_depth, details)
             VALUES (
                 '$(sql_escape "$tier")',
@@ -729,12 +729,12 @@ resolve_chain() {
             );
         " || true
 
-        echo "$model_spec"
-        return 0
-    done
+		echo "$model_spec"
+		return 0
+	done
 
-    [[ "$quiet" != "true" ]] && print_error "All models exhausted in fallback chain for tier: $tier" >&2
-    return 3
+	[[ "$quiet" != "true" ]] && print_error "All models exhausted in fallback chain for tier: $tier" >&2
+	return 3
 }
 
 # =============================================================================
@@ -742,111 +742,147 @@ resolve_chain() {
 # =============================================================================
 
 cmd_resolve() {
-    local tier="${1:-}"
-    shift || true
+	local tier="${1:-}"
+	shift || true
 
-    local config_override="" agent_file="" json_flag=false quiet=false force=false max_depth="$DEFAULT_MAX_DEPTH"
+	local config_override="" agent_file="" json_flag=false quiet=false force=false max_depth="$DEFAULT_MAX_DEPTH"
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --config) config_override="${2:-}"; shift 2 ;;
-            --agent) agent_file="${2:-}"; shift 2 ;;
-            --json) json_flag=true; shift ;;
-            --quiet) quiet=true; shift ;;
-            --force) force=true; shift ;;
-            --max-depth) max_depth="${2:-$DEFAULT_MAX_DEPTH}"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--config)
+			config_override="${2:-}"
+			shift 2
+			;;
+		--agent)
+			agent_file="${2:-}"
+			shift 2
+			;;
+		--json)
+			json_flag=true
+			shift
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		--force)
+			force=true
+			shift
+			;;
+		--max-depth)
+			max_depth="${2:-$DEFAULT_MAX_DEPTH}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ -z "$tier" ]]; then
-        print_error "Usage: fallback-chain-helper.sh resolve <tier>"
-        return 1
-    fi
+	if [[ -z "$tier" ]]; then
+		print_error "Usage: fallback-chain-helper.sh resolve <tier>"
+		return 1
+	fi
 
-    local config_path
-    config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
+	local config_path
+	config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
 
-    [[ "$quiet" != "true" ]] && print_info "Resolving fallback chain for tier: $tier" >&2
+	[[ "$quiet" != "true" ]] && print_info "Resolving fallback chain for tier: $tier" >&2
 
-    local resolved
-    resolved=$(resolve_chain "$tier" "$config_path" "$agent_file" "$max_depth" "$force" "$quiet") || {
-        local exit_code=$?
-        if [[ "$json_flag" == "true" ]]; then
-            echo "{\"tier\":\"$tier\",\"status\":\"exhausted\",\"model\":null}"
-        fi
-        return "$exit_code"
-    }
+	local resolved
+	resolved=$(resolve_chain "$tier" "$config_path" "$agent_file" "$max_depth" "$force" "$quiet") || {
+		local exit_code=$?
+		if [[ "$json_flag" == "true" ]]; then
+			echo "{\"tier\":\"$tier\",\"status\":\"exhausted\",\"model\":null}"
+		fi
+		return "$exit_code"
+	}
 
-    if [[ "$json_flag" == "true" ]]; then
-        local provider gateway model_id
-        provider=$(parse_model_spec "$resolved" "provider")
-        gateway=$(parse_model_spec "$resolved" "gateway")
-        model_id=$(parse_model_spec "$resolved" "model")
-        echo "{\"tier\":\"$tier\",\"status\":\"resolved\",\"model\":\"$resolved\",\"provider\":\"$provider\",\"gateway\":\"$gateway\",\"model_id\":\"$model_id\"}"
-    else
-        echo "$resolved"
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		local provider gateway model_id
+		provider=$(parse_model_spec "$resolved" "provider")
+		gateway=$(parse_model_spec "$resolved" "gateway")
+		model_id=$(parse_model_spec "$resolved" "model")
+		echo "{\"tier\":\"$tier\",\"status\":\"resolved\",\"model\":\"$resolved\",\"provider\":\"$provider\",\"gateway\":\"$gateway\",\"model_id\":\"$model_id\"}"
+	else
+		echo "$resolved"
+	fi
 
-    return 0
+	return 0
 }
 
 cmd_trigger() {
-    local tier="${1:-}"
-    local error_input="${2:-}"
-    shift 2 || true
+	local tier="${1:-}"
+	local error_input="${2:-}"
+	shift 2 || true
 
-    local config_override="" agent_file="" json_flag=false quiet=false max_depth="$DEFAULT_MAX_DEPTH"
-    local failed_model=""
+	local config_override="" agent_file="" json_flag=false quiet=false max_depth="$DEFAULT_MAX_DEPTH"
+	local failed_model=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --config) config_override="${2:-}"; shift 2 ;;
-            --agent) agent_file="${2:-}"; shift 2 ;;
-            --json) json_flag=true; shift ;;
-            --quiet) quiet=true; shift ;;
-            --failed-model) failed_model="${2:-}"; shift 2 ;;
-            --max-depth) max_depth="${2:-$DEFAULT_MAX_DEPTH}"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--config)
+			config_override="${2:-}"
+			shift 2
+			;;
+		--agent)
+			agent_file="${2:-}"
+			shift 2
+			;;
+		--json)
+			json_flag=true
+			shift
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		--failed-model)
+			failed_model="${2:-}"
+			shift 2
+			;;
+		--max-depth)
+			max_depth="${2:-$DEFAULT_MAX_DEPTH}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ -z "$tier" || -z "$error_input" ]]; then
-        print_error "Usage: fallback-chain-helper.sh trigger <tier> <error> [--failed-model model]"
-        return 1
-    fi
+	if [[ -z "$tier" || -z "$error_input" ]]; then
+		print_error "Usage: fallback-chain-helper.sh trigger <tier> <error> [--failed-model model]"
+		return 1
+	fi
 
-    local config_path
-    config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
+	local config_path
+	config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
 
-    # Classify the trigger
-    local trigger_type
-    trigger_type=$(classify_trigger "$error_input")
+	# Classify the trigger
+	local trigger_type
+	trigger_type=$(classify_trigger "$error_input")
 
-    [[ "$quiet" != "true" ]] && print_info "Trigger: $trigger_type (from: $error_input)" >&2
+	[[ "$quiet" != "true" ]] && print_info "Trigger: $trigger_type (from: $error_input)" >&2
 
-    # Check if this trigger type should activate fallback
-    if ! should_trigger_fallback "$trigger_type" "$config_path"; then
-        [[ "$quiet" != "true" ]] && print_info "Trigger type '$trigger_type' is disabled in config" >&2
-        return 1
-    fi
+	# Check if this trigger type should activate fallback
+	if ! should_trigger_fallback "$trigger_type" "$config_path"; then
+		[[ "$quiet" != "true" ]] && print_info "Trigger type '$trigger_type' is disabled in config" >&2
+		return 1
+	fi
 
-    # Put the failed provider into cooldown
-    if [[ -n "$failed_model" ]]; then
-        local failed_provider
-        failed_provider=$(parse_model_spec "$failed_model" "provider")
-        local cooldown_duration
-        cooldown_duration=$(get_cooldown_for_trigger "$trigger_type" "$config_path")
-        set_provider_cooldown "$failed_provider" "$trigger_type" "$cooldown_duration"
-        [[ "$quiet" != "true" ]] && print_info "Provider $failed_provider in cooldown for ${cooldown_duration}s ($trigger_type)" >&2
-    fi
+	# Put the failed provider into cooldown
+	if [[ -n "$failed_model" ]]; then
+		local failed_provider
+		failed_provider=$(parse_model_spec "$failed_model" "provider")
+		local cooldown_duration
+		cooldown_duration=$(get_cooldown_for_trigger "$trigger_type" "$config_path")
+		set_provider_cooldown "$failed_provider" "$trigger_type" "$cooldown_duration"
+		[[ "$quiet" != "true" ]] && print_info "Provider $failed_provider in cooldown for ${cooldown_duration}s ($trigger_type)" >&2
+	fi
 
-    # Resolve next available model from chain
-    local resolved
-    resolved=$(resolve_chain "$tier" "$config_path" "$agent_file" "$max_depth" "false" "$quiet") || {
-        local exit_code=$?
-        # Log the exhaustion
-        db_query "
+	# Resolve next available model from chain
+	local resolved
+	resolved=$(resolve_chain "$tier" "$config_path" "$agent_file" "$max_depth" "false" "$quiet") || {
+		local exit_code=$?
+		# Log the exhaustion
+		db_query "
             INSERT INTO trigger_log (tier, trigger_type, failed_model, resolved_model, chain_depth, details)
             VALUES (
                 '$(sql_escape "$tier")',
@@ -857,14 +893,14 @@ cmd_trigger() {
                 '$(sql_escape "Chain exhausted after trigger: $error_input")'
             );
         " || true
-        if [[ "$json_flag" == "true" ]]; then
-            echo "{\"tier\":\"$tier\",\"trigger\":\"$trigger_type\",\"status\":\"exhausted\",\"model\":null,\"failed_model\":\"${failed_model:-}\"}"
-        fi
-        return "$exit_code"
-    }
+		if [[ "$json_flag" == "true" ]]; then
+			echo "{\"tier\":\"$tier\",\"trigger\":\"$trigger_type\",\"status\":\"exhausted\",\"model\":null,\"failed_model\":\"${failed_model:-}\"}"
+		fi
+		return "$exit_code"
+	}
 
-    # Log the trigger resolution
-    db_query "
+	# Log the trigger resolution
+	db_query "
         INSERT INTO trigger_log (tier, trigger_type, failed_model, resolved_model, chain_depth, details)
         VALUES (
             '$(sql_escape "$tier")',
@@ -876,385 +912,412 @@ cmd_trigger() {
         );
     " || true
 
-    if [[ "$json_flag" == "true" ]]; then
-        local provider gateway model_id
-        provider=$(parse_model_spec "$resolved" "provider")
-        gateway=$(parse_model_spec "$resolved" "gateway")
-        model_id=$(parse_model_spec "$resolved" "model")
-        echo "{\"tier\":\"$tier\",\"trigger\":\"$trigger_type\",\"status\":\"resolved\",\"model\":\"$resolved\",\"provider\":\"$provider\",\"gateway\":\"$gateway\",\"model_id\":\"$model_id\",\"failed_model\":\"${failed_model:-}\"}"
-    else
-        echo "$resolved"
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		local provider gateway model_id
+		provider=$(parse_model_spec "$resolved" "provider")
+		gateway=$(parse_model_spec "$resolved" "gateway")
+		model_id=$(parse_model_spec "$resolved" "model")
+		echo "{\"tier\":\"$tier\",\"trigger\":\"$trigger_type\",\"status\":\"resolved\",\"model\":\"$resolved\",\"provider\":\"$provider\",\"gateway\":\"$gateway\",\"model_id\":\"$model_id\",\"failed_model\":\"${failed_model:-}\"}"
+	else
+		echo "$resolved"
+	fi
 
-    return 0
+	return 0
 }
 
 cmd_chain() {
-    local tier="${1:-}"
-    shift || true
+	local tier="${1:-}"
+	shift || true
 
-    local config_override="" agent_file="" json_flag=false
+	local config_override="" agent_file="" json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --config) config_override="${2:-}"; shift 2 ;;
-            --agent) agent_file="${2:-}"; shift 2 ;;
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--config)
+			config_override="${2:-}"
+			shift 2
+			;;
+		--agent)
+			agent_file="${2:-}"
+			shift 2
+			;;
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ -z "$tier" ]]; then
-        print_error "Usage: fallback-chain-helper.sh chain <tier>"
-        return 1
-    fi
+	if [[ -z "$tier" ]]; then
+		print_error "Usage: fallback-chain-helper.sh chain <tier>"
+		return 1
+	fi
 
-    local config_path
-    config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
+	local config_path
+	config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
 
-    local chain_json
-    chain_json=$(get_chain_for_tier "$tier" "$config_path" "$agent_file") || {
-        print_error "Could not determine chain for tier: $tier"
-        return 1
-    }
+	local chain_json
+	chain_json=$(get_chain_for_tier "$tier" "$config_path" "$agent_file") || {
+		print_error "Could not determine chain for tier: $tier"
+		return 1
+	}
 
-    if [[ "$json_flag" == "true" ]]; then
-        echo "{\"tier\":\"$tier\",\"chain\":$chain_json}"
-        return 0
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		echo "{\"tier\":\"$tier\",\"chain\":$chain_json}"
+		return 0
+	fi
 
-    echo ""
-    echo "Fallback Chain: $tier"
-    echo "===================="
-    echo ""
+	echo ""
+	echo "Fallback Chain: $tier"
+	echo "===================="
+	echo ""
 
-    local chain_length idx
-    chain_length=$(echo "$chain_json" | jq 'length' 2>/dev/null) || chain_length=0
-    idx=0
+	local chain_length idx
+	chain_length=$(echo "$chain_json" | jq 'length' 2>/dev/null) || chain_length=0
+	idx=0
 
-    while [[ "$idx" -lt "$chain_length" ]]; do
-        local model_spec provider gateway model_id
-        model_spec=$(echo "$chain_json" | jq -r ".[$idx]" 2>/dev/null) || true
-        provider=$(parse_model_spec "$model_spec" "provider")
-        gateway=$(parse_model_spec "$model_spec" "gateway")
-        model_id=$(parse_model_spec "$model_spec" "model")
+	while [[ "$idx" -lt "$chain_length" ]]; do
+		local model_spec provider gateway model_id
+		model_spec=$(echo "$chain_json" | jq -r ".[$idx]" 2>/dev/null) || true
+		provider=$(parse_model_spec "$model_spec" "provider")
+		gateway=$(parse_model_spec "$model_spec" "gateway")
+		model_id=$(parse_model_spec "$model_spec" "model")
 
-        local cooldown_status=""
-        if is_provider_cooled_down "$provider"; then
-            cooldown_status=" [COOLDOWN]"
-        fi
+		local cooldown_status=""
+		if is_provider_cooled_down "$provider"; then
+			cooldown_status=" [COOLDOWN]"
+		fi
 
-        local gateway_label=""
-        if [[ "$gateway" != "direct" ]]; then
-            gateway_label=" via $gateway"
-        fi
+		local gateway_label=""
+		if [[ "$gateway" != "direct" ]]; then
+			gateway_label=" via $gateway"
+		fi
 
-        printf "  %d. %s (%s%s)%s\n" "$((idx + 1))" "$model_spec" "$provider" "$gateway_label" "$cooldown_status"
-        idx=$((idx + 1))
-    done
+		printf "  %d. %s (%s%s)%s\n" "$((idx + 1))" "$model_spec" "$provider" "$gateway_label" "$cooldown_status"
+		idx=$((idx + 1))
+	done
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 cmd_status() {
-    local json_flag=false config_override=""
+	local json_flag=false config_override=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            --config) config_override="${2:-}"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		--config)
+			config_override="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    local config_path
-    config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
+	local config_path
+	config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
 
-    if [[ "$json_flag" == "true" ]]; then
-        local cooldowns triggers gateways
-        cooldowns=$(db_query_json "SELECT provider, reason, cooldown_until FROM provider_cooldown ORDER BY provider;" 2>/dev/null || echo "[]")
-        triggers=$(db_query_json "SELECT tier, trigger_type, failed_model, resolved_model, chain_depth, timestamp FROM trigger_log ORDER BY id DESC LIMIT 20;" 2>/dev/null || echo "[]")
-        gateways=$(db_query_json "SELECT gateway_id, gateway_type, status, endpoint, last_checked, response_ms FROM gateway_health ORDER BY gateway_id;" 2>/dev/null || echo "[]")
-        echo "{\"cooldowns\":$cooldowns,\"recent_triggers\":$triggers,\"gateways\":$gateways}"
-        return 0
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		local cooldowns triggers gateways
+		cooldowns=$(db_query_json "SELECT provider, reason, cooldown_until FROM provider_cooldown ORDER BY provider;" 2>/dev/null || echo "[]")
+		triggers=$(db_query_json "SELECT tier, trigger_type, failed_model, resolved_model, chain_depth, timestamp FROM trigger_log ORDER BY id DESC LIMIT 20;" 2>/dev/null || echo "[]")
+		gateways=$(db_query_json "SELECT gateway_id, gateway_type, status, endpoint, last_checked, response_ms FROM gateway_health ORDER BY gateway_id;" 2>/dev/null || echo "[]")
+		echo "{\"cooldowns\":$cooldowns,\"recent_triggers\":$triggers,\"gateways\":$gateways}"
+		return 0
+	fi
 
-    echo ""
-    echo "Fallback Chain Status"
-    echo "====================="
-    echo ""
+	echo ""
+	echo "Fallback Chain Status"
+	echo "====================="
+	echo ""
 
-    # Show chains for all tiers
-    echo "Tier Chains:"
-    echo ""
-    local tiers="haiku flash sonnet pro opus coding eval health"
-    for tier in $tiers; do
-        local chain_json
-        chain_json=$(get_chain_for_tier "$tier" "$config_path" "" 2>/dev/null) || chain_json="[]"
-        local chain_length
-        chain_length=$(echo "$chain_json" | jq 'length' 2>/dev/null || echo "0")
-        local first_model last_model
-        first_model=$(echo "$chain_json" | jq -r '.[0] // "none"' 2>/dev/null)
-        last_model=$(echo "$chain_json" | jq -r '.[-1] // "none"' 2>/dev/null)
-        printf "  %-8s %s -> ... -> %s (%d models)\n" "$tier" "$first_model" "$last_model" "$chain_length"
-    done
+	# Show chains for all tiers
+	echo "Tier Chains:"
+	echo ""
+	local tiers="haiku flash sonnet pro opus coding eval health"
+	for tier in $tiers; do
+		local chain_json
+		chain_json=$(get_chain_for_tier "$tier" "$config_path" "" 2>/dev/null) || chain_json="[]"
+		local chain_length
+		chain_length=$(echo "$chain_json" | jq 'length' 2>/dev/null || echo "0")
+		local first_model last_model
+		first_model=$(echo "$chain_json" | jq -r '.[0] // "none"' 2>/dev/null)
+		last_model=$(echo "$chain_json" | jq -r '.[-1] // "none"' 2>/dev/null)
+		printf "  %-8s %s -> ... -> %s (%d models)\n" "$tier" "$first_model" "$last_model" "$chain_length"
+	done
 
-    # Show active cooldowns
-    echo ""
-    echo "Active Cooldowns:"
-    echo ""
-    local cooldown_count
-    cooldown_count=$(db_query "SELECT COUNT(*) FROM provider_cooldown;" 2>/dev/null || echo "0")
-    if [[ "$cooldown_count" -eq 0 ]]; then
-        echo "  (none)"
-    else
-        db_query "SELECT provider, reason, cooldown_until FROM provider_cooldown ORDER BY provider;" | \
-        while IFS='|' read -r prov reason until; do
-            printf "  %-12s %-15s until %s\n" "$prov" "$reason" "$until"
-        done
-    fi
+	# Show active cooldowns
+	echo ""
+	echo "Active Cooldowns:"
+	echo ""
+	local cooldown_count
+	cooldown_count=$(db_query "SELECT COUNT(*) FROM provider_cooldown;" 2>/dev/null || echo "0")
+	if [[ "$cooldown_count" -eq 0 ]]; then
+		echo "  (none)"
+	else
+		db_query "SELECT provider, reason, cooldown_until FROM provider_cooldown ORDER BY provider;" |
+			while IFS='|' read -r prov reason until; do
+				printf "  %-12s %-15s until %s\n" "$prov" "$reason" "$until"
+			done
+	fi
 
-    # Show gateway health
-    echo ""
-    echo "Gateway Health:"
-    echo ""
-    local gw_count
-    gw_count=$(db_query "SELECT COUNT(*) FROM gateway_health;" 2>/dev/null || echo "0")
-    if [[ "$gw_count" -eq 0 ]]; then
-        echo "  (no gateways probed yet)"
-    else
-        printf "  %-12s %-12s %-12s %-8s %s\n" "Gateway" "Type" "Status" "Time" "Endpoint"
-        printf "  %-12s %-12s %-12s %-8s %s\n" "-------" "----" "------" "----" "--------"
-        db_query "SELECT gateway_id, gateway_type, status, response_ms, endpoint FROM gateway_health ORDER BY gateway_id;" | \
-        while IFS='|' read -r gid gtype gstatus gms gendpoint; do
-            printf "  %-12s %-12s %-12s %-8s %s\n" "$gid" "$gtype" "$gstatus" "${gms}ms" "$gendpoint"
-        done
-    fi
+	# Show gateway health
+	echo ""
+	echo "Gateway Health:"
+	echo ""
+	local gw_count
+	gw_count=$(db_query "SELECT COUNT(*) FROM gateway_health;" 2>/dev/null || echo "0")
+	if [[ "$gw_count" -eq 0 ]]; then
+		echo "  (no gateways probed yet)"
+	else
+		printf "  %-12s %-12s %-12s %-8s %s\n" "Gateway" "Type" "Status" "Time" "Endpoint"
+		printf "  %-12s %-12s %-12s %-8s %s\n" "-------" "----" "------" "----" "--------"
+		db_query "SELECT gateway_id, gateway_type, status, response_ms, endpoint FROM gateway_health ORDER BY gateway_id;" |
+			while IFS='|' read -r gid gtype gstatus gms gendpoint; do
+				printf "  %-12s %-12s %-12s %-8s %s\n" "$gid" "$gtype" "$gstatus" "${gms}ms" "$gendpoint"
+			done
+	fi
 
-    # Show recent triggers
-    echo ""
-    echo "Recent Triggers (last 10):"
-    echo ""
-    local trigger_count
-    trigger_count=$(db_query "SELECT COUNT(*) FROM trigger_log;" 2>/dev/null || echo "0")
-    if [[ "$trigger_count" -eq 0 ]]; then
-        echo "  (no triggers recorded)"
-    else
-        db_query "
+	# Show recent triggers
+	echo ""
+	echo "Recent Triggers (last 10):"
+	echo ""
+	local trigger_count
+	trigger_count=$(db_query "SELECT COUNT(*) FROM trigger_log;" 2>/dev/null || echo "0")
+	if [[ "$trigger_count" -eq 0 ]]; then
+		echo "  (no triggers recorded)"
+	else
+		db_query "
             SELECT timestamp, tier, trigger_type, failed_model, resolved_model, chain_depth
             FROM trigger_log ORDER BY id DESC LIMIT 10;
         " | while IFS='|' read -r ts tier ttype failed resolved depth; do
-            printf "  %s  %-8s %-12s %s -> %s (depth %s)\n" \
-                "$ts" "$tier" "$ttype" "${failed:-n/a}" "${resolved:-EXHAUSTED}" "$depth"
-        done
-    fi
+			printf "  %s  %-8s %-12s %s -> %s (depth %s)\n" \
+				"$ts" "$tier" "$ttype" "${failed:-n/a}" "${resolved:-EXHAUSTED}" "$depth"
+		done
+	fi
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 cmd_validate() {
-    local config_override=""
+	local config_override=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --config) config_override="${2:-}"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--config)
+			config_override="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    local config_path
-    config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
+	local config_path
+	config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
 
-    echo ""
-    echo "Fallback Chain Validation"
-    echo "========================="
-    echo ""
+	echo ""
+	echo "Fallback Chain Validation"
+	echo "========================="
+	echo ""
 
-    local issues=0
+	local issues=0
 
-    # Check JSON structure
-    if ! jq empty "$config_path" 2>/dev/null; then
-        print_error "Invalid JSON: $config_path"
-        return 2
-    fi
-    print_success "JSON syntax: valid"
+	# Check JSON structure
+	if ! jq empty "$config_path" 2>/dev/null; then
+		print_error "Invalid JSON: $config_path"
+		return 2
+	fi
+	print_success "JSON syntax: valid"
 
-    # Check required top-level keys
-    local has_chains has_triggers has_gateways
-    has_chains=$(jq 'has("chains")' "$config_path" 2>/dev/null)
-    has_triggers=$(jq 'has("triggers")' "$config_path" 2>/dev/null)
-    has_gateways=$(jq 'has("gateways")' "$config_path" 2>/dev/null)
+	# Check required top-level keys
+	local has_chains has_triggers has_gateways
+	has_chains=$(jq 'has("chains")' "$config_path" 2>/dev/null)
+	has_triggers=$(jq 'has("triggers")' "$config_path" 2>/dev/null)
+	has_gateways=$(jq 'has("gateways")' "$config_path" 2>/dev/null)
 
-    if [[ "$has_chains" != "true" ]]; then
-        print_warning "Missing 'chains' key (will use hardcoded defaults)"
-        issues=$((issues + 1))
-    else
-        print_success "chains: present"
-    fi
+	if [[ "$has_chains" != "true" ]]; then
+		print_warning "Missing 'chains' key (will use hardcoded defaults)"
+		issues=$((issues + 1))
+	else
+		print_success "chains: present"
+	fi
 
-    if [[ "$has_triggers" != "true" ]]; then
-        print_warning "Missing 'triggers' key (will use default trigger settings)"
-        issues=$((issues + 1))
-    else
-        print_success "triggers: present"
-    fi
+	if [[ "$has_triggers" != "true" ]]; then
+		print_warning "Missing 'triggers' key (will use default trigger settings)"
+		issues=$((issues + 1))
+	else
+		print_success "triggers: present"
+	fi
 
-    if [[ "$has_gateways" != "true" ]]; then
-        print_info "No 'gateways' key (gateway fallback disabled)"
-    else
-        print_success "gateways: present"
-    fi
+	if [[ "$has_gateways" != "true" ]]; then
+		print_info "No 'gateways' key (gateway fallback disabled)"
+	else
+		print_success "gateways: present"
+	fi
 
-    # Validate each chain has at least 2 entries
-    echo ""
-    echo "Chain Validation:"
-    local tiers
-    tiers=$(jq -r '.chains | keys[]' "$config_path" 2>/dev/null) || tiers=""
-    for tier in $tiers; do
-        local chain_length
-        chain_length=$(jq -r --arg t "$tier" '.chains[$t] | length' "$config_path" 2>/dev/null) || chain_length=0
-        if [[ "$chain_length" -lt 2 ]]; then
-            print_warning "  $tier: only $chain_length model(s) (recommend >= 2 for fallback)"
-            issues=$((issues + 1))
-        else
-            print_success "  $tier: $chain_length models"
-        fi
-    done
+	# Validate each chain has at least 2 entries
+	echo ""
+	echo "Chain Validation:"
+	local tiers
+	tiers=$(jq -r '.chains | keys[]' "$config_path" 2>/dev/null) || tiers=""
+	for tier in $tiers; do
+		local chain_length
+		chain_length=$(jq -r --arg t "$tier" '.chains[$t] | length' "$config_path" 2>/dev/null) || chain_length=0
+		if [[ "$chain_length" -lt 2 ]]; then
+			print_warning "  $tier: only $chain_length model(s) (recommend >= 2 for fallback)"
+			issues=$((issues + 1))
+		else
+			print_success "  $tier: $chain_length models"
+		fi
+	done
 
-    # Validate trigger types
-    echo ""
-    echo "Trigger Validation:"
-    local trigger_types="api_error timeout rate_limit auth_error overloaded"
-    for tt in $trigger_types; do
-        local enabled
-        enabled=$(jq -r --arg t "$tt" '.triggers[$t].enabled // "not configured"' "$config_path" 2>/dev/null)
-        if [[ "$enabled" == "not configured" ]]; then
-            print_info "  $tt: not configured (defaults to enabled)"
-        elif [[ "$enabled" == "true" ]]; then
-            print_success "  $tt: enabled"
-        else
-            print_info "  $tt: disabled"
-        fi
-    done
+	# Validate trigger types
+	echo ""
+	echo "Trigger Validation:"
+	local trigger_types="api_error timeout rate_limit auth_error overloaded"
+	for tt in $trigger_types; do
+		local enabled
+		enabled=$(jq -r --arg t "$tt" '.triggers[$t].enabled // "not configured"' "$config_path" 2>/dev/null)
+		if [[ "$enabled" == "not configured" ]]; then
+			print_info "  $tt: not configured (defaults to enabled)"
+		elif [[ "$enabled" == "true" ]]; then
+			print_success "  $tt: enabled"
+		else
+			print_info "  $tt: disabled"
+		fi
+	done
 
-    echo ""
-    if [[ "$issues" -gt 0 ]]; then
-        print_warning "$issues issue(s) found (non-critical, defaults will be used)"
-    else
-        print_success "Configuration is valid"
-    fi
-    echo ""
-    return 0
+	echo ""
+	if [[ "$issues" -gt 0 ]]; then
+		print_warning "$issues issue(s) found (non-critical, defaults will be used)"
+	else
+		print_success "Configuration is valid"
+	fi
+	echo ""
+	return 0
 }
 
 cmd_gateway() {
-    local gateway="${1:-}"
-    shift || true
+	local gateway="${1:-}"
+	shift || true
 
-    local config_override="" quiet=false json_flag=false
+	local config_override="" quiet=false json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --config) config_override="${2:-}"; shift 2 ;;
-            --quiet) quiet=true; shift ;;
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--config)
+			config_override="${2:-}"
+			shift 2
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ -z "$gateway" ]]; then
-        print_error "Usage: fallback-chain-helper.sh gateway <openrouter|cloudflare>"
-        return 1
-    fi
+	if [[ -z "$gateway" ]]; then
+		print_error "Usage: fallback-chain-helper.sh gateway <openrouter|cloudflare>"
+		return 1
+	fi
 
-    local config_path
-    config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
+	local config_path
+	config_path=$(load_config "${config_override:-$DEFAULT_CONFIG}") || return $?
 
-    check_gateway "$gateway" "$config_path" "$quiet"
-    local exit_code=$?
+	check_gateway "$gateway" "$config_path" "$quiet"
+	local exit_code=$?
 
-    if [[ "$json_flag" == "true" ]]; then
-        db_query_json "SELECT * FROM gateway_health WHERE gateway_id = '$(sql_escape "$gateway")';" 2>/dev/null || echo "[]"
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		db_query_json "SELECT * FROM gateway_health WHERE gateway_id = '$(sql_escape "$gateway")';" 2>/dev/null || echo "[]"
+	fi
 
-    return "$exit_code"
+	return "$exit_code"
 }
 
 cmd_help() {
-    echo ""
-    echo "Fallback Chain Helper - Per-agent and global model fallback chains"
-    echo "=================================================================="
-    echo ""
-    echo "Usage: fallback-chain-helper.sh [command] [options]"
-    echo ""
-    echo "Commands:"
-    echo "  resolve <tier>          Resolve best model through fallback chain"
-    echo "  trigger <tier> <error>  Process error trigger and return next fallback"
-    echo "  chain <tier>            Show the full fallback chain for a tier"
-    echo "  status                  Show fallback chain health across all tiers"
-    echo "  validate                Validate fallback chain configuration"
-    echo "  gateway <provider>      Check gateway provider availability"
-    echo "  help                    Show this help"
-    echo ""
-    echo "Options:"
-    echo "  --config PATH     Override config file path"
-    echo "  --agent FILE      Use per-agent fallback chain from frontmatter"
-    echo "  --json            Output in JSON format"
-    echo "  --quiet           Suppress informational output"
-    echo "  --force           Bypass cache"
-    echo "  --max-depth N     Maximum chain depth (default: $DEFAULT_MAX_DEPTH)"
-    echo "  --failed-model M  Model that failed (for trigger command)"
-    echo ""
-    echo "Trigger types:"
-    echo "  api_error         Provider returned 5xx or connection failure"
-    echo "  timeout           Request exceeded timeout threshold"
-    echo "  rate_limit        Provider returned 429"
-    echo "  auth_error        Provider returned 401/403"
-    echo "  overloaded        Provider returned 529"
-    echo ""
-    echo "Model spec formats:"
-    echo "  provider/model                    Direct provider (e.g., anthropic/claude-sonnet-4)"
-    echo "  openrouter/provider/model         Via OpenRouter gateway"
-    echo "  gateway/cf/provider/model         Via Cloudflare AI Gateway"
-    echo ""
-    echo "Examples:"
-    echo "  # Resolve best model for coding tier"
-    echo "  fallback-chain-helper.sh resolve coding"
-    echo ""
-    echo "  # Resolve with per-agent chain override"
-    echo "  fallback-chain-helper.sh resolve sonnet --agent models/sonnet.md"
-    echo ""
-    echo "  # Process a rate limit trigger"
-    echo "  fallback-chain-helper.sh trigger coding 429 --failed-model anthropic/claude-opus-4-6"
-    echo ""
-    echo "  # Show chain for a tier"
-    echo "  fallback-chain-helper.sh chain opus"
-    echo ""
-    echo "  # Check OpenRouter gateway"
-    echo "  fallback-chain-helper.sh gateway openrouter"
-    echo ""
-    echo "  # Validate configuration"
-    echo "  fallback-chain-helper.sh validate"
-    echo ""
-    echo "Configuration:"
-    echo "  Global: $DEFAULT_CONFIG"
-    echo "  Per-agent: YAML frontmatter 'fallback-chain:' in model tier files"
-    echo "  Database: $FALLBACK_DB"
-    echo ""
-    echo "Integration:"
-    echo "  - model-availability-helper.sh: Uses for provider health checks"
-    echo "  - supervisor-helper.sh: Calls resolve/trigger during dispatch"
-    echo "  - Gateway providers: OpenRouter, Cloudflare AI Gateway"
-    echo ""
-    echo "Exit codes:"
-    echo "  0 - Model resolved successfully"
-    echo "  1 - No available model / usage error"
-    echo "  2 - Configuration error"
-    echo "  3 - All providers exhausted"
-    echo ""
-    return 0
+	echo ""
+	echo "Fallback Chain Helper - Per-agent and global model fallback chains"
+	echo "=================================================================="
+	echo ""
+	echo "Usage: fallback-chain-helper.sh [command] [options]"
+	echo ""
+	echo "Commands:"
+	echo "  resolve <tier>          Resolve best model through fallback chain"
+	echo "  trigger <tier> <error>  Process error trigger and return next fallback"
+	echo "  chain <tier>            Show the full fallback chain for a tier"
+	echo "  status                  Show fallback chain health across all tiers"
+	echo "  validate                Validate fallback chain configuration"
+	echo "  gateway <provider>      Check gateway provider availability"
+	echo "  help                    Show this help"
+	echo ""
+	echo "Options:"
+	echo "  --config PATH     Override config file path"
+	echo "  --agent FILE      Use per-agent fallback chain from frontmatter"
+	echo "  --json            Output in JSON format"
+	echo "  --quiet           Suppress informational output"
+	echo "  --force           Bypass cache"
+	echo "  --max-depth N     Maximum chain depth (default: $DEFAULT_MAX_DEPTH)"
+	echo "  --failed-model M  Model that failed (for trigger command)"
+	echo ""
+	echo "Trigger types:"
+	echo "  api_error         Provider returned 5xx or connection failure"
+	echo "  timeout           Request exceeded timeout threshold"
+	echo "  rate_limit        Provider returned 429"
+	echo "  auth_error        Provider returned 401/403"
+	echo "  overloaded        Provider returned 529"
+	echo ""
+	echo "Model spec formats:"
+	echo "  provider/model                    Direct provider (e.g., anthropic/claude-sonnet-4)"
+	echo "  openrouter/provider/model         Via OpenRouter gateway"
+	echo "  gateway/cf/provider/model         Via Cloudflare AI Gateway"
+	echo ""
+	echo "Examples:"
+	echo "  # Resolve best model for coding tier"
+	echo "  fallback-chain-helper.sh resolve coding"
+	echo ""
+	echo "  # Resolve with per-agent chain override"
+	echo "  fallback-chain-helper.sh resolve sonnet --agent models/sonnet.md"
+	echo ""
+	echo "  # Process a rate limit trigger"
+	echo "  fallback-chain-helper.sh trigger coding 429 --failed-model anthropic/claude-opus-4-6"
+	echo ""
+	echo "  # Show chain for a tier"
+	echo "  fallback-chain-helper.sh chain opus"
+	echo ""
+	echo "  # Check OpenRouter gateway"
+	echo "  fallback-chain-helper.sh gateway openrouter"
+	echo ""
+	echo "  # Validate configuration"
+	echo "  fallback-chain-helper.sh validate"
+	echo ""
+	echo "Configuration:"
+	echo "  Global: $DEFAULT_CONFIG"
+	echo "  Per-agent: YAML frontmatter 'fallback-chain:' in model tier files"
+	echo "  Database: $FALLBACK_DB"
+	echo ""
+	echo "Integration:"
+	echo "  - model-availability-helper.sh: Uses for provider health checks"
+	echo "  - supervisor-helper.sh: Calls resolve/trigger during dispatch"
+	echo "  - Gateway providers: OpenRouter, Cloudflare AI Gateway"
+	echo ""
+	echo "Exit codes:"
+	echo "  0 - Model resolved successfully"
+	echo "  1 - No available model / usage error"
+	echo "  2 - Configuration error"
+	echo "  3 - All providers exhausted"
+	echo ""
+	return 0
 }
 
 # =============================================================================
@@ -1262,43 +1325,43 @@ cmd_help() {
 # =============================================================================
 
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    # Initialize DB for all commands except help
-    if [[ "$command" != "help" && "$command" != "--help" && "$command" != "-h" ]]; then
-        init_db || return 1
-    fi
+	# Initialize DB for all commands except help
+	if [[ "$command" != "help" && "$command" != "--help" && "$command" != "-h" ]]; then
+		init_db || return 1
+	fi
 
-    case "$command" in
-        resolve)
-            cmd_resolve "$@"
-            ;;
-        trigger)
-            cmd_trigger "$@"
-            ;;
-        chain)
-            cmd_chain "$@"
-            ;;
-        status)
-            cmd_status "$@"
-            ;;
-        validate)
-            cmd_validate "$@"
-            ;;
-        gateway)
-            cmd_gateway "$@"
-            ;;
-        help|--help|-h)
-            cmd_help
-            ;;
-        *)
-            print_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
-    return $?
+	case "$command" in
+	resolve)
+		cmd_resolve "$@"
+		;;
+	trigger)
+		cmd_trigger "$@"
+		;;
+	chain)
+		cmd_chain "$@"
+		;;
+	status)
+		cmd_status "$@"
+		;;
+	validate)
+		cmd_validate "$@"
+		;;
+	gateway)
+		cmd_gateway "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+	return $?
 }
 
 main "$@"

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -217,7 +217,7 @@ SKIP_CUSTOM_PROMPT = set()
 # Agents declare their tier; the coordinator uses this for cost-effective routing
 MODEL_TIERS = {
     "haiku": "claude-3-5-haiku-20241022",      # Triage, routing, simple tasks
-    "sonnet": "claude-sonnet-4-20250514",      # Code, review, implementation
+    "sonnet": "claude-sonnet-4-6",             # Code, review, implementation
     "opus": "claude-opus-4-20250514",          # Architecture, complex reasoning
     "flash": "gemini-2.5-flash",               # Fast, cheap, large context
     "pro": "gemini-2.5-pro",                   # Capable, large context

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -51,9 +51,9 @@ init_log_file
 
 readonly AVAILABILITY_DIR="${HOME}/.aidevops/.agent-workspace"
 readonly AVAILABILITY_DB="${AVAILABILITY_DIR}/model-availability.db"
-readonly DEFAULT_HEALTH_TTL=300    # 5 minutes for health checks
-readonly DEFAULT_RATELIMIT_TTL=60  # 1 minute for rate limit data
-readonly PROBE_TIMEOUT=10          # HTTP request timeout in seconds
+readonly DEFAULT_HEALTH_TTL=300   # 5 minutes for health checks
+readonly DEFAULT_RATELIMIT_TTL=60 # 1 minute for rate limit data
+readonly PROBE_TIMEOUT=10         # HTTP request timeout in seconds
 
 # Known providers list (opencode is a meta-provider routing through its gateway)
 readonly KNOWN_PROVIDERS="anthropic openai google openrouter groq deepseek opencode"
@@ -66,43 +66,43 @@ readonly OPENCODE_MODELS_CACHE="${HOME}/.cache/opencode/models.json"
 # and return quickly, confirming both key validity and API availability.
 # Uses functions instead of associative arrays for bash 3.2 compatibility (macOS).
 get_provider_endpoint() {
-    local provider="$1"
-    case "$provider" in
-        anthropic)  echo "https://api.anthropic.com/v1/models" ;;
-        openai)     echo "https://api.openai.com/v1/models" ;;
-        google)     echo "https://generativelanguage.googleapis.com/v1beta/models" ;;
-        openrouter) echo "https://openrouter.ai/api/v1/models" ;;
-        groq)       echo "https://api.groq.com/openai/v1/models" ;;
-        deepseek)   echo "https://api.deepseek.com/v1/models" ;;
-        opencode)   echo "https://opencode.ai/zen/v1/models" ;;
-        *) return 1 ;;
-    esac
-    return 0
+	local provider="$1"
+	case "$provider" in
+	anthropic) echo "https://api.anthropic.com/v1/models" ;;
+	openai) echo "https://api.openai.com/v1/models" ;;
+	google) echo "https://generativelanguage.googleapis.com/v1beta/models" ;;
+	openrouter) echo "https://openrouter.ai/api/v1/models" ;;
+	groq) echo "https://api.groq.com/openai/v1/models" ;;
+	deepseek) echo "https://api.deepseek.com/v1/models" ;;
+	opencode) echo "https://opencode.ai/zen/v1/models" ;;
+	*) return 1 ;;
+	esac
+	return 0
 }
 
 # Provider to env var mapping (comma-separated for multiple options)
 get_provider_key_vars() {
-    local provider="$1"
-    case "$provider" in
-        anthropic)  echo "ANTHROPIC_API_KEY" ;;
-        openai)     echo "OPENAI_API_KEY" ;;
-        google)     echo "GOOGLE_API_KEY,GEMINI_API_KEY" ;;
-        openrouter) echo "OPENROUTER_API_KEY" ;;
-        groq)       echo "GROQ_API_KEY" ;;
-        deepseek)   echo "DEEPSEEK_API_KEY" ;;
-        opencode)   echo "OPENCODE_API_KEY" ;;
-        *) return 1 ;;
-    esac
-    return 0
+	local provider="$1"
+	case "$provider" in
+	anthropic) echo "ANTHROPIC_API_KEY" ;;
+	openai) echo "OPENAI_API_KEY" ;;
+	google) echo "GOOGLE_API_KEY,GEMINI_API_KEY" ;;
+	openrouter) echo "OPENROUTER_API_KEY" ;;
+	groq) echo "GROQ_API_KEY" ;;
+	deepseek) echo "DEEPSEEK_API_KEY" ;;
+	opencode) echo "OPENCODE_API_KEY" ;;
+	*) return 1 ;;
+	esac
+	return 0
 }
 
 # Check if a provider name is known
 is_known_provider() {
-    local provider="$1"
-    case "$provider" in
-        anthropic|openai|google|openrouter|groq|deepseek|opencode) return 0 ;;
-        *) return 1 ;;
-    esac
+	local provider="$1"
+	case "$provider" in
+	anthropic | openai | google | openrouter | groq | deepseek | opencode) return 0 ;;
+	*) return 1 ;;
+	esac
 }
 
 # Tier to primary/fallback model mapping
@@ -110,44 +110,44 @@ is_known_provider() {
 # When OpenCode is available, prefer opencode/* model IDs (routed through
 # OpenCode's gateway, no direct API keys needed for these).
 get_tier_models() {
-    local tier="$1"
+	local tier="$1"
 
-    # Check if OpenCode is available (CLI installed and models cache exists)
-    if _is_opencode_available; then
-        case "$tier" in
-            haiku)  echo "opencode/claude-3-5-haiku|opencode/gemini-3-flash" ;;
-            flash)  echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
-            sonnet) echo "opencode/claude-sonnet-4|anthropic/claude-sonnet-4-20250514" ;;
-            pro)    echo "google/gemini-2.5-pro|opencode/gemini-3-pro" ;;
-            opus)   echo "opencode/claude-opus-4-6|anthropic/claude-opus-4-6" ;;
-            health) echo "opencode/claude-sonnet-4-5|google/gemini-2.5-flash" ;;
-            eval)   echo "opencode/claude-sonnet-4-5|google/gemini-2.5-flash" ;;
-            coding) echo "opencode/claude-opus-4-6|anthropic/claude-opus-4-6" ;;
-            *) return 1 ;;
-        esac
-    else
-        case "$tier" in
-            haiku)  echo "anthropic/claude-3-5-haiku-20241022|google/gemini-2.5-flash" ;;
-            flash)  echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
-            sonnet) echo "anthropic/claude-sonnet-4-20250514|openai/gpt-4.1" ;;
-            pro)    echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-20250514" ;;
-            opus)   echo "anthropic/claude-opus-4-6|openai/o3" ;;
-            health) echo "anthropic/claude-sonnet-4-5|google/gemini-2.5-flash" ;;
-            eval)   echo "anthropic/claude-sonnet-4-5|google/gemini-2.5-flash" ;;
-            coding) echo "anthropic/claude-opus-4-6|openai/o3" ;;
-            *) return 1 ;;
-        esac
-    fi
-    return 0
+	# Check if OpenCode is available (CLI installed and models cache exists)
+	if _is_opencode_available; then
+		case "$tier" in
+		haiku) echo "opencode/claude-3-5-haiku|opencode/gemini-3-flash" ;;
+		flash) echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
+		sonnet) echo "opencode/claude-sonnet-4|anthropic/claude-sonnet-4-6" ;;
+		pro) echo "google/gemini-2.5-pro|opencode/gemini-3-pro" ;;
+		opus) echo "opencode/claude-opus-4-6|anthropic/claude-opus-4-6" ;;
+		health) echo "opencode/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+		eval) echo "opencode/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+		coding) echo "opencode/claude-opus-4-6|anthropic/claude-opus-4-6" ;;
+		*) return 1 ;;
+		esac
+	else
+		case "$tier" in
+		haiku) echo "anthropic/claude-3-5-haiku-20241022|google/gemini-2.5-flash" ;;
+		flash) echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
+		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-4.1" ;;
+		pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;
+		opus) echo "anthropic/claude-opus-4-6|openai/o3" ;;
+		health) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+		eval) echo "anthropic/claude-sonnet-4-6|google/gemini-2.5-flash" ;;
+		coding) echo "anthropic/claude-opus-4-6|openai/o3" ;;
+		*) return 1 ;;
+		esac
+	fi
+	return 0
 }
 
 # Check if a tier name is known
 is_known_tier() {
-    local tier="$1"
-    case "$tier" in
-        haiku|flash|sonnet|pro|opus|health|eval|coding) return 0 ;;
-        *) return 1 ;;
-    esac
+	local tier="$1"
+	case "$tier" in
+	haiku | flash | sonnet | pro | opus | health | eval | coding) return 0 ;;
+	*) return 1 ;;
+	esac
 }
 
 # =============================================================================
@@ -158,42 +158,42 @@ is_known_tier() {
 # without needing direct API keys for each provider.
 
 _is_opencode_available() {
-    # Check if opencode CLI exists and models cache is present
-    if command -v opencode &>/dev/null && [[ -f "$OPENCODE_MODELS_CACHE" && -s "$OPENCODE_MODELS_CACHE" ]]; then
-        return 0
-    fi
-    return 1
+	# Check if opencode CLI exists and models cache is present
+	if command -v opencode &>/dev/null && [[ -f "$OPENCODE_MODELS_CACHE" && -s "$OPENCODE_MODELS_CACHE" ]]; then
+		return 0
+	fi
+	return 1
 }
 
 # Check if a model exists in the OpenCode models cache.
 # Returns 0 if found, 1 if not.
 _opencode_model_exists() {
-    local model_spec="$1"
-    local provider model_id
+	local model_spec="$1"
+	local provider model_id
 
-    if [[ "$model_spec" == *"/"* ]]; then
-        provider="${model_spec%%/*}"
-        model_id="${model_spec#*/}"
-    else
-        model_id="$model_spec"
-        provider=""
-    fi
+	if [[ "$model_spec" == *"/"* ]]; then
+		provider="${model_spec%%/*}"
+		model_id="${model_spec#*/}"
+	else
+		model_id="$model_spec"
+		provider=""
+	fi
 
-    if [[ ! -f "$OPENCODE_MODELS_CACHE" || ! -s "$OPENCODE_MODELS_CACHE" ]]; then
-        return 1
-    fi
+	if [[ ! -f "$OPENCODE_MODELS_CACHE" || ! -s "$OPENCODE_MODELS_CACHE" ]]; then
+		return 1
+	fi
 
-    # Check the cache JSON: providers are top-level keys, models are nested
-    if [[ -n "$provider" ]]; then
-        jq -e --arg p "$provider" --arg m "$model_id" \
-            '.[$p].models[$m] // empty' "$OPENCODE_MODELS_CACHE" >/dev/null 2>&1
-        return $?
-    else
-        # Search all providers for this model ID
-        jq -e --arg m "$model_id" \
-            '[.[] | .models[$m] // empty] | length > 0' "$OPENCODE_MODELS_CACHE" >/dev/null 2>&1
-        return $?
-    fi
+	# Check the cache JSON: providers are top-level keys, models are nested
+	if [[ -n "$provider" ]]; then
+		jq -e --arg p "$provider" --arg m "$model_id" \
+			'.[$p].models[$m] // empty' "$OPENCODE_MODELS_CACHE" >/dev/null 2>&1
+		return $?
+	else
+		# Search all providers for this model ID
+		jq -e --arg m "$model_id" \
+			'[.[] | .models[$m] // empty] | length > 0' "$OPENCODE_MODELS_CACHE" >/dev/null 2>&1
+		return $?
+	fi
 }
 
 # =============================================================================
@@ -201,9 +201,9 @@ _opencode_model_exists() {
 # =============================================================================
 
 init_db() {
-    mkdir -p "$AVAILABILITY_DIR" 2>/dev/null || true
+	mkdir -p "$AVAILABILITY_DIR" 2>/dev/null || true
 
-    sqlite3 "$AVAILABILITY_DB" "
+	sqlite3 "$AVAILABILITY_DB" "
         PRAGMA journal_mode=WAL;
         PRAGMA busy_timeout=5000;
 
@@ -252,28 +252,28 @@ init_db() {
         CREATE INDEX IF NOT EXISTS idx_probe_log_provider ON probe_log(provider);
         CREATE INDEX IF NOT EXISTS idx_probe_log_timestamp ON probe_log(timestamp);
     " >/dev/null 2>/dev/null || {
-        print_error "Failed to initialize availability database"
-        return 1
-    }
-    return 0
+		print_error "Failed to initialize availability database"
+		return 1
+	}
+	return 0
 }
 
 db_query() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" "$AVAILABILITY_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" "$AVAILABILITY_DB" "$query" 2>/dev/null
+	return $?
 }
 
 db_query_json() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" -json "$AVAILABILITY_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" -json "$AVAILABILITY_DB" "$query" 2>/dev/null
+	return $?
 }
 
 sql_escape() {
-    local val="$1"
-    echo "${val//\'/\'\'}"
-    return 0
+	local val="$1"
+	echo "${val//\'/\'\'}"
+	return 0
 }
 
 # =============================================================================
@@ -286,81 +286,81 @@ sql_escape() {
 # SECURITY: Never prints key values. Returns 0 if found, 1 if not.
 
 resolve_api_key() {
-    local provider="$1"
-    local key_vars
-    key_vars=$(get_provider_key_vars "$provider" 2>/dev/null) || return 1
+	local provider="$1"
+	local key_vars
+	key_vars=$(get_provider_key_vars "$provider" 2>/dev/null) || return 1
 
-    if [[ -z "$key_vars" ]]; then
-        return 1
-    fi
+	if [[ -z "$key_vars" ]]; then
+		return 1
+	fi
 
-    # Check each possible env var name
-    local -a var_names
-    IFS=',' read -ra var_names <<< "$key_vars"
-    for var_name in "${var_names[@]}"; do
-        # Source 1: Environment variable
-        if [[ -n "${!var_name:-}" ]]; then
-            echo "$var_name"
-            return 0
-        fi
-    done
+	# Check each possible env var name
+	local -a var_names
+	IFS=',' read -ra var_names <<<"$key_vars"
+	for var_name in "${var_names[@]}"; do
+		# Source 1: Environment variable
+		if [[ -n "${!var_name:-}" ]]; then
+			echo "$var_name"
+			return 0
+		fi
+	done
 
-    # Source 2: gopass (if available)
-    if command -v gopass &>/dev/null; then
-        for var_name in "${var_names[@]}"; do
-            local gopass_path="aidevops/${var_name}"
-            if gopass show "$gopass_path" &>/dev/null; then
-                # Export the key into the environment for this session
-                local key_val
-                key_val=$(gopass show "$gopass_path" 2>/dev/null)
-                if [[ -n "$key_val" ]]; then
-                    export "${var_name}=${key_val}"
-                    echo "$var_name"
-                    return 0
-                fi
-            fi
-        done
-    fi
+	# Source 2: gopass (if available)
+	if command -v gopass &>/dev/null; then
+		for var_name in "${var_names[@]}"; do
+			local gopass_path="aidevops/${var_name}"
+			if gopass show "$gopass_path" &>/dev/null; then
+				# Export the key into the environment for this session
+				local key_val
+				key_val=$(gopass show "$gopass_path" 2>/dev/null)
+				if [[ -n "$key_val" ]]; then
+					export "${var_name}=${key_val}"
+					echo "$var_name"
+					return 0
+				fi
+			fi
+		done
+	fi
 
-    # Source 3: credentials.sh (plaintext fallback)
-    local creds_file="${HOME}/.config/aidevops/credentials.sh"
-    if [[ -f "$creds_file" ]]; then
-        # Source the file to get variables (safe: we control this file)
-        # shellcheck disable=SC1090
-        source "$creds_file"
-        for var_name in "${var_names[@]}"; do
-            if [[ -n "${!var_name:-}" ]]; then
-                echo "$var_name"
-                return 0
-            fi
-        done
-    fi
+	# Source 3: credentials.sh (plaintext fallback)
+	local creds_file="${HOME}/.config/aidevops/credentials.sh"
+	if [[ -f "$creds_file" ]]; then
+		# Source the file to get variables (safe: we control this file)
+		# shellcheck disable=SC1090
+		source "$creds_file"
+		for var_name in "${var_names[@]}"; do
+			if [[ -n "${!var_name:-}" ]]; then
+				echo "$var_name"
+				return 0
+			fi
+		done
+	fi
 
-    return 1
+	return 1
 }
 
 # Get the actual key value (internal use only, never printed to output)
 _get_key_value() {
-    local provider="$1"
-    local key_vars
-    key_vars=$(get_provider_key_vars "$provider" 2>/dev/null) || return 1
+	local provider="$1"
+	local key_vars
+	key_vars=$(get_provider_key_vars "$provider" 2>/dev/null) || return 1
 
-    if [[ -z "$key_vars" ]]; then
-        return 1
-    fi
+	if [[ -z "$key_vars" ]]; then
+		return 1
+	fi
 
-    local -a var_names
-    IFS=',' read -ra var_names <<< "$key_vars"
+	local -a var_names
+	IFS=',' read -ra var_names <<<"$key_vars"
 
-    # Try env vars first (may have been populated by resolve_api_key)
-    for var_name in "${var_names[@]}"; do
-        if [[ -n "${!var_name:-}" ]]; then
-            echo "${!var_name}"
-            return 0
-        fi
-    done
+	# Try env vars first (may have been populated by resolve_api_key)
+	for var_name in "${var_names[@]}"; do
+		if [[ -n "${!var_name:-}" ]]; then
+			echo "${!var_name}"
+			return 0
+		fi
+	done
 
-    return 1
+	return 1
 }
 
 # =============================================================================
@@ -368,63 +368,63 @@ _get_key_value() {
 # =============================================================================
 
 is_cache_valid() {
-    local provider="$1"
-    local table="${2:-provider_health}"
-    local custom_ttl="${3:-}"
+	local provider="$1"
+	local table="${2:-provider_health}"
+	local custom_ttl="${3:-}"
 
-    local row
-    row=$(db_query "
+	local row
+	row=$(db_query "
         SELECT checked_at, ttl_seconds FROM $table
         WHERE provider = '$(sql_escape "$provider")'
         LIMIT 1;
     ")
 
-    if [[ -z "$row" ]]; then
-        return 1
-    fi
+	if [[ -z "$row" ]]; then
+		return 1
+	fi
 
-    local checked_at ttl_seconds
-    checked_at=$(echo "$row" | cut -d'|' -f1)
-    ttl_seconds=$(echo "$row" | cut -d'|' -f2)
+	local checked_at ttl_seconds
+	checked_at=$(echo "$row" | cut -d'|' -f1)
+	ttl_seconds=$(echo "$row" | cut -d'|' -f2)
 
-    # Allow TTL override
-    if [[ -n "$custom_ttl" ]]; then
-        ttl_seconds="$custom_ttl"
-    fi
+	# Allow TTL override
+	if [[ -n "$custom_ttl" ]]; then
+		ttl_seconds="$custom_ttl"
+	fi
 
-    local checked_epoch now_epoch
-    if [[ "$(uname)" == "Darwin" ]]; then
-        checked_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$checked_at" "+%s" 2>/dev/null || echo "0")
-    else
-        checked_epoch=$(date -d "$checked_at" "+%s" 2>/dev/null || echo "0")
-    fi
-    now_epoch=$(date "+%s")
+	local checked_epoch now_epoch
+	if [[ "$(uname)" == "Darwin" ]]; then
+		checked_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$checked_at" "+%s" 2>/dev/null || echo "0")
+	else
+		checked_epoch=$(date -d "$checked_at" "+%s" 2>/dev/null || echo "0")
+	fi
+	now_epoch=$(date "+%s")
 
-    local age=$(( now_epoch - checked_epoch ))
-    if [[ "$age" -lt "$ttl_seconds" ]]; then
-        return 0
-    fi
+	local age=$((now_epoch - checked_epoch))
+	if [[ "$age" -lt "$ttl_seconds" ]]; then
+		return 0
+	fi
 
-    return 1
+	return 1
 }
 
 invalidate_cache() {
-    local provider="${1:-}"
+	local provider="${1:-}"
 
-    if [[ -z "$provider" ]]; then
-        db_query "DELETE FROM provider_health;"
-        db_query "DELETE FROM model_availability;"
-        db_query "DELETE FROM rate_limits;"
-        print_info "All availability caches cleared"
-    else
-        local escaped
-        escaped=$(sql_escape "$provider")
-        db_query "DELETE FROM provider_health WHERE provider = '$escaped';"
-        db_query "DELETE FROM model_availability WHERE provider = '$escaped';"
-        db_query "DELETE FROM rate_limits WHERE provider = '$escaped';"
-        print_info "Cache cleared for provider: $provider"
-    fi
-    return 0
+	if [[ -z "$provider" ]]; then
+		db_query "DELETE FROM provider_health;"
+		db_query "DELETE FROM model_availability;"
+		db_query "DELETE FROM rate_limits;"
+		print_info "All availability caches cleared"
+	else
+		local escaped
+		escaped=$(sql_escape "$provider")
+		db_query "DELETE FROM provider_health WHERE provider = '$escaped';"
+		db_query "DELETE FROM model_availability WHERE provider = '$escaped';"
+		db_query "DELETE FROM rate_limits WHERE provider = '$escaped';"
+		print_info "Cache cleared for provider: $provider"
+	fi
+	return 0
 }
 
 # =============================================================================
@@ -437,171 +437,171 @@ invalidate_cache() {
 #
 # Returns: 0=healthy, 1=unhealthy, 2=rate-limited, 3=key-invalid
 probe_provider() {
-    local provider="$1"
-    local force="${2:-false}"
-    local custom_ttl="${3:-}"
-    local quiet="${4:-false}"
+	local provider="$1"
+	local force="${2:-false}"
+	local custom_ttl="${3:-}"
+	local quiet="${4:-false}"
 
-    # Check cache first (unless forced)
-    if [[ "$force" != "true" ]] && is_cache_valid "$provider" "provider_health" "$custom_ttl"; then
-        local cached_status
-        cached_status=$(db_query "SELECT status FROM provider_health WHERE provider = '$(sql_escape "$provider")';")
-        if [[ "$cached_status" == "healthy" ]]; then
-            [[ "$quiet" != "true" ]] && print_info "$provider: cached healthy"
-            return 0
-        elif [[ "$cached_status" == "rate_limited" ]]; then
-            [[ "$quiet" != "true" ]] && print_warning "$provider: cached rate-limited"
-            return 2
-        elif [[ "$cached_status" == "key_invalid" ]]; then
-            [[ "$quiet" != "true" ]] && print_warning "$provider: cached key-invalid"
-            return 3
-        else
-            [[ "$quiet" != "true" ]] && print_warning "$provider: cached unhealthy"
-            return 1
-        fi
-    fi
+	# Check cache first (unless forced)
+	if [[ "$force" != "true" ]] && is_cache_valid "$provider" "provider_health" "$custom_ttl"; then
+		local cached_status
+		cached_status=$(db_query "SELECT status FROM provider_health WHERE provider = '$(sql_escape "$provider")';")
+		if [[ "$cached_status" == "healthy" ]]; then
+			[[ "$quiet" != "true" ]] && print_info "$provider: cached healthy"
+			return 0
+		elif [[ "$cached_status" == "rate_limited" ]]; then
+			[[ "$quiet" != "true" ]] && print_warning "$provider: cached rate-limited"
+			return 2
+		elif [[ "$cached_status" == "key_invalid" ]]; then
+			[[ "$quiet" != "true" ]] && print_warning "$provider: cached key-invalid"
+			return 3
+		else
+			[[ "$quiet" != "true" ]] && print_warning "$provider: cached unhealthy"
+			return 1
+		fi
+	fi
 
-    # OpenCode provider: check via models cache (no API key needed)
-    if [[ "$provider" == "opencode" ]]; then
-        if _is_opencode_available; then
-            local oc_models_count=0
-            oc_models_count=$(jq -r '.opencode.models | length' "$OPENCODE_MODELS_CACHE" 2>/dev/null || echo "0")
-            _record_health "opencode" "healthy" 200 0 "" "$oc_models_count"
-            [[ "$quiet" != "true" ]] && print_success "opencode: healthy ($oc_models_count models in cache)"
-            db_query "
+	# OpenCode provider: check via models cache (no API key needed)
+	if [[ "$provider" == "opencode" ]]; then
+		if _is_opencode_available; then
+			local oc_models_count=0
+			oc_models_count=$(jq -r '.opencode.models | length' "$OPENCODE_MODELS_CACHE" 2>/dev/null || echo "0")
+			_record_health "opencode" "healthy" 200 0 "" "$oc_models_count"
+			[[ "$quiet" != "true" ]] && print_success "opencode: healthy ($oc_models_count models in cache)"
+			db_query "
                 INSERT INTO probe_log (provider, action, result, duration_ms, details)
                 VALUES ('opencode', 'cache_check', 'healthy', 0, '$oc_models_count models from cache');
             " || true
-            return 0
-        else
-            _record_health "opencode" "unhealthy" 0 0 "OpenCode CLI or models cache not found" 0
-            [[ "$quiet" != "true" ]] && print_warning "opencode: CLI or models cache not available"
-            return 1
-        fi
-    fi
+			return 0
+		else
+			_record_health "opencode" "unhealthy" 0 0 "OpenCode CLI or models cache not found" 0
+			[[ "$quiet" != "true" ]] && print_warning "opencode: CLI or models cache not available"
+			return 1
+		fi
+	fi
 
-    # Resolve API key
-    local key_var
-    if ! key_var=$(resolve_api_key "$provider"); then
-        [[ "$quiet" != "true" ]] && print_warning "$provider: no API key configured"
-        _record_health "$provider" "no_key" 0 0 "No API key found" 0
-        return 3
-    fi
+	# Resolve API key
+	local key_var
+	if ! key_var=$(resolve_api_key "$provider"); then
+		[[ "$quiet" != "true" ]] && print_warning "$provider: no API key configured"
+		_record_health "$provider" "no_key" 0 0 "No API key found" 0
+		return 3
+	fi
 
-    local api_key
-    if ! api_key=$(_get_key_value "$provider"); then
-        [[ "$quiet" != "true" ]] && print_warning "$provider: could not resolve API key value"
-        _record_health "$provider" "no_key" 0 0 "Key var $key_var found but empty" 0
-        return 3
-    fi
+	local api_key
+	if ! api_key=$(_get_key_value "$provider"); then
+		[[ "$quiet" != "true" ]] && print_warning "$provider: could not resolve API key value"
+		_record_health "$provider" "no_key" 0 0 "Key var $key_var found but empty" 0
+		return 3
+	fi
 
-    local endpoint
-    endpoint=$(get_provider_endpoint "$provider" 2>/dev/null) || true
-    if [[ -z "$endpoint" ]]; then
-        [[ "$quiet" != "true" ]] && print_error "$provider: no endpoint configured"
-        return 1
-    fi
+	local endpoint
+	endpoint=$(get_provider_endpoint "$provider" 2>/dev/null) || true
+	if [[ -z "$endpoint" ]]; then
+		[[ "$quiet" != "true" ]] && print_error "$provider: no endpoint configured"
+		return 1
+	fi
 
-    # Build curl command based on provider auth style
-    local -a curl_args=(-s -w '\n%{http_code}\n%{time_total}' --max-time "$PROBE_TIMEOUT" -D -)
-    case "$provider" in
-        anthropic)
-            curl_args+=(-H "x-api-key: ${api_key}" -H "anthropic-version: 2023-06-01")
-            ;;
-        google)
-            # Google uses query parameter for key
-            endpoint="${endpoint}?key=${api_key}&pageSize=1"
-            ;;
-        *)
-            # OpenAI-compatible: Bearer token
-            curl_args+=(-H "Authorization: Bearer ${api_key}")
-            ;;
-    esac
+	# Build curl command based on provider auth style
+	local -a curl_args=(-s -w '\n%{http_code}\n%{time_total}' --max-time "$PROBE_TIMEOUT" -D -)
+	case "$provider" in
+	anthropic)
+		curl_args+=(-H "x-api-key: ${api_key}" -H "anthropic-version: 2023-06-01")
+		;;
+	google)
+		# Google uses query parameter for key
+		endpoint="${endpoint}?key=${api_key}&pageSize=1"
+		;;
+	*)
+		# OpenAI-compatible: Bearer token
+		curl_args+=(-H "Authorization: Bearer ${api_key}")
+		;;
+	esac
 
-    # Execute probe
-    local start_ms
-    start_ms=$(date +%s%N 2>/dev/null || echo "0")
+	# Execute probe
+	local start_ms
+	start_ms=$(date +%s%N 2>/dev/null || echo "0")
 
-    local response
-    response=$(curl "${curl_args[@]}" "$endpoint" 2>/dev/null) || true
+	local response
+	response=$(curl "${curl_args[@]}" "$endpoint" 2>/dev/null) || true
 
-    local end_ms
-    end_ms=$(date +%s%N 2>/dev/null || echo "0")
-    local duration_ms=0
-    if [[ "$start_ms" != "0" && "$end_ms" != "0" ]]; then
-        duration_ms=$(( (end_ms - start_ms) / 1000000 ))
-    fi
+	local end_ms
+	end_ms=$(date +%s%N 2>/dev/null || echo "0")
+	local duration_ms=0
+	if [[ "$start_ms" != "0" && "$end_ms" != "0" ]]; then
+		duration_ms=$(((end_ms - start_ms) / 1000000))
+	fi
 
-    # Parse response: last two lines are http_code and time_total
-    local http_code headers body
-    http_code=$(echo "$response" | tail -1)
-    # response_time from curl -w is in the second-to-last line (unused; duration_ms is more precise)
+	# Parse response: last two lines are http_code and time_total
+	local http_code headers body
+	http_code=$(echo "$response" | tail -1)
+	# response_time from curl -w is in the second-to-last line (unused; duration_ms is more precise)
 
-    # Separate headers from body (split on blank line)
-    headers=$(echo "$response" | sed '/^$/q' | head -50)
-    body=$(echo "$response" | sed '1,/^$/d' | head -n -2)
+	# Separate headers from body (split on blank line)
+	headers=$(echo "$response" | sed '/^$/q' | head -50)
+	body=$(echo "$response" | sed '1,/^$/d' | head -n -2)
 
-    # Parse rate limit headers (provider-specific)
-    _parse_rate_limits "$provider" "$headers"
+	# Parse rate limit headers (provider-specific)
+	_parse_rate_limits "$provider" "$headers"
 
-    # Determine status based on HTTP code
-    local status="unknown"
-    local error_msg=""
-    local models_count=0
-    local exit_code=1
+	# Determine status based on HTTP code
+	local status="unknown"
+	local error_msg=""
+	local models_count=0
+	local exit_code=1
 
-    case "$http_code" in
-        200)
-            status="healthy"
-            exit_code=0
-            # Count models in response
-            case "$provider" in
-                google)
-                    models_count=$(echo "$body" | jq -r '.models | length' 2>/dev/null || echo "0")
-                    ;;
-                *)
-                    models_count=$(echo "$body" | jq -r '.data | length' 2>/dev/null || echo "0")
-                    ;;
-            esac
-            [[ "$quiet" != "true" ]] && print_success "$provider: healthy (${duration_ms}ms, $models_count models)"
-            ;;
-        401|403)
-            status="key_invalid"
-            error_msg="Authentication failed (HTTP $http_code)"
-            exit_code=3
-            [[ "$quiet" != "true" ]] && print_error "$provider: API key invalid (HTTP $http_code)"
-            ;;
-        429)
-            status="rate_limited"
-            error_msg="Rate limited (HTTP 429)"
-            exit_code=2
-            [[ "$quiet" != "true" ]] && print_warning "$provider: rate limited"
-            ;;
-        500|502|503|504)
-            status="unhealthy"
-            error_msg="Server error (HTTP $http_code)"
-            exit_code=1
-            [[ "$quiet" != "true" ]] && print_error "$provider: server error (HTTP $http_code)"
-            ;;
-        "")
-            status="unreachable"
-            error_msg="Connection failed or timeout"
-            exit_code=1
-            [[ "$quiet" != "true" ]] && print_error "$provider: unreachable (timeout or DNS failure)"
-            ;;
-        *)
-            status="unhealthy"
-            error_msg="Unexpected HTTP $http_code"
-            exit_code=1
-            [[ "$quiet" != "true" ]] && print_warning "$provider: unexpected response (HTTP $http_code)"
-            ;;
-    esac
+	case "$http_code" in
+	200)
+		status="healthy"
+		exit_code=0
+		# Count models in response
+		case "$provider" in
+		google)
+			models_count=$(echo "$body" | jq -r '.models | length' 2>/dev/null || echo "0")
+			;;
+		*)
+			models_count=$(echo "$body" | jq -r '.data | length' 2>/dev/null || echo "0")
+			;;
+		esac
+		[[ "$quiet" != "true" ]] && print_success "$provider: healthy (${duration_ms}ms, $models_count models)"
+		;;
+	401 | 403)
+		status="key_invalid"
+		error_msg="Authentication failed (HTTP $http_code)"
+		exit_code=3
+		[[ "$quiet" != "true" ]] && print_error "$provider: API key invalid (HTTP $http_code)"
+		;;
+	429)
+		status="rate_limited"
+		error_msg="Rate limited (HTTP 429)"
+		exit_code=2
+		[[ "$quiet" != "true" ]] && print_warning "$provider: rate limited"
+		;;
+	500 | 502 | 503 | 504)
+		status="unhealthy"
+		error_msg="Server error (HTTP $http_code)"
+		exit_code=1
+		[[ "$quiet" != "true" ]] && print_error "$provider: server error (HTTP $http_code)"
+		;;
+	"")
+		status="unreachable"
+		error_msg="Connection failed or timeout"
+		exit_code=1
+		[[ "$quiet" != "true" ]] && print_error "$provider: unreachable (timeout or DNS failure)"
+		;;
+	*)
+		status="unhealthy"
+		error_msg="Unexpected HTTP $http_code"
+		exit_code=1
+		[[ "$quiet" != "true" ]] && print_warning "$provider: unexpected response (HTTP $http_code)"
+		;;
+	esac
 
-    # Record health status
-    _record_health "$provider" "$status" "$http_code" "$duration_ms" "$error_msg" "$models_count"
+	# Record health status
+	_record_health "$provider" "$status" "$http_code" "$duration_ms" "$error_msg" "$models_count"
 
-    # Log the probe
-    db_query "
+	# Log the probe
+	db_query "
         INSERT INTO probe_log (provider, action, result, duration_ms, details)
         VALUES (
             '$(sql_escape "$provider")',
@@ -612,8 +612,8 @@ probe_provider() {
         );
     " || true
 
-    # Prune old probe logs (keep last 100 per provider)
-    db_query "
+	# Prune old probe logs (keep last 100 per provider)
+	db_query "
         DELETE FROM probe_log WHERE id IN (
             SELECT id FROM probe_log
             WHERE provider = '$(sql_escape "$provider")'
@@ -622,18 +622,18 @@ probe_provider() {
         );
     " || true
 
-    return "$exit_code"
+	return "$exit_code"
 }
 
 _record_health() {
-    local provider="$1"
-    local status="$2"
-    local http_code="$3"
-    local duration_ms="$4"
-    local error_msg="$5"
-    local models_count="$6"
+	local provider="$1"
+	local status="$2"
+	local http_code="$3"
+	local duration_ms="$4"
+	local error_msg="$5"
+	local models_count="$6"
 
-    db_query "
+	db_query "
         INSERT INTO provider_health (provider, status, http_code, response_ms, error_message, models_count, checked_at, ttl_seconds)
         VALUES (
             '$(sql_escape "$provider")',
@@ -654,7 +654,7 @@ _record_health() {
             checked_at = excluded.checked_at,
             ttl_seconds = excluded.ttl_seconds;
     " || true
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -662,47 +662,47 @@ _record_health() {
 # =============================================================================
 
 _parse_rate_limits() {
-    local provider="$1"
-    local headers="$2"
+	local provider="$1"
+	local headers="$2"
 
-    local req_limit=0 req_remaining=0 req_reset=""
-    local tok_limit=0 tok_remaining=0 tok_reset=""
+	local req_limit=0 req_remaining=0 req_reset=""
+	local tok_limit=0 tok_remaining=0 tok_reset=""
 
-    case "$provider" in
-        anthropic)
-            req_limit=$(echo "$headers" | grep -i 'anthropic-ratelimit-requests-limit' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            req_remaining=$(echo "$headers" | grep -i 'anthropic-ratelimit-requests-remaining' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            req_reset=$(echo "$headers" | grep -i 'anthropic-ratelimit-requests-reset' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
-            tok_limit=$(echo "$headers" | grep -i 'anthropic-ratelimit-tokens-limit' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            tok_remaining=$(echo "$headers" | grep -i 'anthropic-ratelimit-tokens-remaining' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            tok_reset=$(echo "$headers" | grep -i 'anthropic-ratelimit-tokens-reset' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
-            ;;
-        openai)
-            req_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            req_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            req_reset=$(echo "$headers" | grep -i 'x-ratelimit-reset-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
-            tok_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            tok_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            tok_reset=$(echo "$headers" | grep -i 'x-ratelimit-reset-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
-            ;;
-        groq)
-            req_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            req_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            req_reset=$(echo "$headers" | grep -i 'x-ratelimit-reset-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
-            tok_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            tok_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            tok_reset=$(echo "$headers" | grep -i 'x-ratelimit-reset-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
-            ;;
-        *)
-            # Other providers: try generic x-ratelimit headers
-            req_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            req_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
-            ;;
-    esac
+	case "$provider" in
+	anthropic)
+		req_limit=$(echo "$headers" | grep -i 'anthropic-ratelimit-requests-limit' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		req_remaining=$(echo "$headers" | grep -i 'anthropic-ratelimit-requests-remaining' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		req_reset=$(echo "$headers" | grep -i 'anthropic-ratelimit-requests-reset' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
+		tok_limit=$(echo "$headers" | grep -i 'anthropic-ratelimit-tokens-limit' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		tok_remaining=$(echo "$headers" | grep -i 'anthropic-ratelimit-tokens-remaining' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		tok_reset=$(echo "$headers" | grep -i 'anthropic-ratelimit-tokens-reset' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
+		;;
+	openai)
+		req_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		req_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		req_reset=$(echo "$headers" | grep -i 'x-ratelimit-reset-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
+		tok_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		tok_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		tok_reset=$(echo "$headers" | grep -i 'x-ratelimit-reset-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
+		;;
+	groq)
+		req_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		req_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		req_reset=$(echo "$headers" | grep -i 'x-ratelimit-reset-requests' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
+		tok_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		tok_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		tok_reset=$(echo "$headers" | grep -i 'x-ratelimit-reset-tokens' | head -1 | awk '{print $2}' | tr -d '\r' || echo "")
+		;;
+	*)
+		# Other providers: try generic x-ratelimit headers
+		req_limit=$(echo "$headers" | grep -i 'x-ratelimit-limit' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		req_remaining=$(echo "$headers" | grep -i 'x-ratelimit-remaining' | head -1 | awk '{print $2}' | tr -d '\r' || echo "0")
+		;;
+	esac
 
-    # Only store if we got meaningful data
-    if [[ "$req_limit" != "0" || "$req_remaining" != "0" ]]; then
-        db_query "
+	# Only store if we got meaningful data
+	if [[ "$req_limit" != "0" || "$req_remaining" != "0" ]]; then
+		db_query "
             INSERT INTO rate_limits (provider, requests_limit, requests_remaining, requests_reset,
                                      tokens_limit, tokens_remaining, tokens_reset, checked_at, ttl_seconds)
             VALUES (
@@ -726,8 +726,8 @@ _parse_rate_limits() {
                 checked_at = excluded.checked_at,
                 ttl_seconds = excluded.ttl_seconds;
         " || true
-    fi
-    return 0
+	fi
+	return 0
 }
 
 # =============================================================================
@@ -738,96 +738,96 @@ _parse_rate_limits() {
 # First checks provider health, then verifies the model exists in the
 # provider's model list (from the cached /models response or model-registry).
 check_model_available() {
-    local model_spec="$1"
-    local force="${2:-false}"
-    local quiet="${3:-false}"
+	local model_spec="$1"
+	local force="${2:-false}"
+	local quiet="${3:-false}"
 
-    # Parse provider/model format
-    local provider model_id
-    if [[ "$model_spec" == *"/"* ]]; then
-        provider="${model_spec%%/*}"
-        model_id="${model_spec#*/}"
-    else
-        # Try to infer provider from model name
-        case "$model_spec" in
-            claude*) provider="anthropic" ;;
-            gpt*|o3*|o4*) provider="openai" ;;
-            gemini*) provider="google" ;;
-            deepseek*) provider="deepseek" ;;
-            llama*) provider="groq" ;;
-            *) provider="" ;;
-        esac
-        model_id="$model_spec"
-    fi
+	# Parse provider/model format
+	local provider model_id
+	if [[ "$model_spec" == *"/"* ]]; then
+		provider="${model_spec%%/*}"
+		model_id="${model_spec#*/}"
+	else
+		# Try to infer provider from model name
+		case "$model_spec" in
+		claude*) provider="anthropic" ;;
+		gpt* | o3* | o4*) provider="openai" ;;
+		gemini*) provider="google" ;;
+		deepseek*) provider="deepseek" ;;
+		llama*) provider="groq" ;;
+		*) provider="" ;;
+		esac
+		model_id="$model_spec"
+	fi
 
-    if [[ -z "$provider" ]]; then
-        [[ "$quiet" != "true" ]] && print_error "Cannot determine provider for: $model_spec"
-        return 1
-    fi
+	if [[ -z "$provider" ]]; then
+		[[ "$quiet" != "true" ]] && print_error "Cannot determine provider for: $model_spec"
+		return 1
+	fi
 
-    # Check provider health first
-    local probe_exit=0
-    probe_provider "$provider" "$force" "" "$quiet" || probe_exit=$?
+	# Check provider health first
+	local probe_exit=0
+	probe_provider "$provider" "$force" "" "$quiet" || probe_exit=$?
 
-    if [[ "$probe_exit" -ne 0 ]]; then
-        return "$probe_exit"
-    fi
+	if [[ "$probe_exit" -ne 0 ]]; then
+		return "$probe_exit"
+	fi
 
-    # Check model-specific availability from cache
-    local cached_available
-    cached_available=$(db_query "
+	# Check model-specific availability from cache
+	local cached_available
+	cached_available=$(db_query "
         SELECT available FROM model_availability
         WHERE model_id = '$(sql_escape "$model_id")' AND provider = '$(sql_escape "$provider")'
         AND (julianday('now') - julianday(checked_at)) * 86400 < ttl_seconds;
     ")
 
-    if [[ -n "$cached_available" ]]; then
-        if [[ "$cached_available" == "1" ]]; then
-            [[ "$quiet" != "true" ]] && print_info "$model_spec: available (cached)"
-            return 0
-        else
-            [[ "$quiet" != "true" ]] && print_warning "$model_spec: unavailable (cached)"
-            return 1
-        fi
-    fi
+	if [[ -n "$cached_available" ]]; then
+		if [[ "$cached_available" == "1" ]]; then
+			[[ "$quiet" != "true" ]] && print_info "$model_spec: available (cached)"
+			return 0
+		else
+			[[ "$quiet" != "true" ]] && print_warning "$model_spec: unavailable (cached)"
+			return 1
+		fi
+	fi
 
-    # Model-level check 1: OpenCode models cache (instant, preferred)
-    if _opencode_model_exists "$model_spec"; then
-        _record_model_availability "$model_id" "$provider" 1
-        [[ "$quiet" != "true" ]] && print_success "$model_spec: available (OpenCode cache confirmed)"
-        return 0
-    fi
+	# Model-level check 1: OpenCode models cache (instant, preferred)
+	if _opencode_model_exists "$model_spec"; then
+		_record_model_availability "$model_id" "$provider" 1
+		[[ "$quiet" != "true" ]] && print_success "$model_spec: available (OpenCode cache confirmed)"
+		return 0
+	fi
 
-    # Model-level check 2: query the model-registry SQLite if available
-    local registry_db="${AVAILABILITY_DIR}/model-registry.db"
-    if [[ -f "$registry_db" ]]; then
-        local in_registry
-        in_registry=$(sqlite3 -cmd ".timeout 5000" "$registry_db" "
+	# Model-level check 2: query the model-registry SQLite if available
+	local registry_db="${AVAILABILITY_DIR}/model-registry.db"
+	if [[ -f "$registry_db" ]]; then
+		local in_registry
+		in_registry=$(sqlite3 -cmd ".timeout 5000" "$registry_db" "
             SELECT COUNT(*) FROM provider_models
             WHERE model_id LIKE '%$(sql_escape "$model_id")%'
             AND provider LIKE '%$(sql_escape "$provider")%';
         " 2>/dev/null || echo "0")
 
-        if [[ "$in_registry" -gt 0 ]]; then
-            _record_model_availability "$model_id" "$provider" 1
-            [[ "$quiet" != "true" ]] && print_success "$model_spec: available (registry confirmed)"
-            return 0
-        fi
-    fi
+		if [[ "$in_registry" -gt 0 ]]; then
+			_record_model_availability "$model_id" "$provider" 1
+			[[ "$quiet" != "true" ]] && print_success "$model_spec: available (registry confirmed)"
+			return 0
+		fi
+	fi
 
-    # If provider is healthy but we can't confirm the specific model,
-    # assume available (provider health is the primary signal)
-    _record_model_availability "$model_id" "$provider" 1
-    [[ "$quiet" != "true" ]] && print_info "$model_spec: assumed available (provider healthy)"
-    return 0
+	# If provider is healthy but we can't confirm the specific model,
+	# assume available (provider health is the primary signal)
+	_record_model_availability "$model_id" "$provider" 1
+	[[ "$quiet" != "true" ]] && print_info "$model_spec: assumed available (provider healthy)"
+	return 0
 }
 
 _record_model_availability() {
-    local model_id="$1"
-    local provider="$2"
-    local available="$3"
+	local model_id="$1"
+	local provider="$2"
+	local available="$3"
 
-    db_query "
+	db_query "
         INSERT INTO model_availability (model_id, provider, available, checked_at, ttl_seconds)
         VALUES (
             '$(sql_escape "$model_id")',
@@ -841,7 +841,7 @@ _record_model_availability() {
             checked_at = excluded.checked_at,
             ttl_seconds = excluded.ttl_seconds;
     " || true
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -855,51 +855,51 @@ _record_model_availability() {
 # Output: provider/model_id on stdout
 # Returns: 0 if a model was resolved, 1 if no model available for this tier
 resolve_tier() {
-    local tier="$1"
-    local force="${2:-false}"
-    local quiet="${3:-false}"
+	local tier="$1"
+	local force="${2:-false}"
+	local quiet="${3:-false}"
 
-    local tier_spec
-    tier_spec=$(get_tier_models "$tier" 2>/dev/null) || true
-    if [[ -z "$tier_spec" ]]; then
-        [[ "$quiet" != "true" ]] && print_error "Unknown tier: $tier"
-        return 1
-    fi
+	local tier_spec
+	tier_spec=$(get_tier_models "$tier" 2>/dev/null) || true
+	if [[ -z "$tier_spec" ]]; then
+		[[ "$quiet" != "true" ]] && print_error "Unknown tier: $tier"
+		return 1
+	fi
 
-    local primary fallback
-    primary="${tier_spec%%|*}"
-    fallback="${tier_spec#*|}"
+	local primary fallback
+	primary="${tier_spec%%|*}"
+	fallback="${tier_spec#*|}"
 
-    # Try primary
-    if check_model_available "$primary" "$force" "true"; then
-        echo "$primary"
-        [[ "$quiet" != "true" ]] && print_success "Resolved $tier -> $primary (primary)"
-        return 0
-    fi
+	# Try primary
+	if check_model_available "$primary" "$force" "true"; then
+		echo "$primary"
+		[[ "$quiet" != "true" ]] && print_success "Resolved $tier -> $primary (primary)"
+		return 0
+	fi
 
-    # Try fallback
-    if [[ -n "$fallback" && "$fallback" != "$primary" ]] && check_model_available "$fallback" "$force" "true"; then
-        echo "$fallback"
-        [[ "$quiet" != "true" ]] && print_warning "Resolved $tier -> $fallback (fallback, primary $primary unavailable)"
-        return 0
-    fi
+	# Try fallback
+	if [[ -n "$fallback" && "$fallback" != "$primary" ]] && check_model_available "$fallback" "$force" "true"; then
+		echo "$fallback"
+		[[ "$quiet" != "true" ]] && print_warning "Resolved $tier -> $fallback (fallback, primary $primary unavailable)"
+		return 0
+	fi
 
-    # Extended fallback: delegate to fallback-chain-helper.sh (t132.4)
-    # This walks the full configured chain including gateway providers
-    local chain_helper="${SCRIPT_DIR}/fallback-chain-helper.sh"
-    if [[ -x "$chain_helper" ]]; then
-        [[ "$quiet" != "true" ]] && print_info "Primary/fallback exhausted, trying extended fallback chain..."
-        local chain_resolved
-        chain_resolved=$("$chain_helper" resolve "$tier" --quiet 2>/dev/null) || true
-        if [[ -n "$chain_resolved" ]]; then
-            echo "$chain_resolved"
-            [[ "$quiet" != "true" ]] && print_warning "Resolved $tier -> $chain_resolved (via fallback chain)"
-            return 0
-        fi
-    fi
+	# Extended fallback: delegate to fallback-chain-helper.sh (t132.4)
+	# This walks the full configured chain including gateway providers
+	local chain_helper="${SCRIPT_DIR}/fallback-chain-helper.sh"
+	if [[ -x "$chain_helper" ]]; then
+		[[ "$quiet" != "true" ]] && print_info "Primary/fallback exhausted, trying extended fallback chain..."
+		local chain_resolved
+		chain_resolved=$("$chain_helper" resolve "$tier" --quiet 2>/dev/null) || true
+		if [[ -n "$chain_resolved" ]]; then
+			echo "$chain_resolved"
+			[[ "$quiet" != "true" ]] && print_warning "Resolved $tier -> $chain_resolved (via fallback chain)"
+			return 0
+		fi
+	fi
 
-    [[ "$quiet" != "true" ]] && print_error "No available model for tier: $tier (tried $primary, $fallback, and extended chain)"
-    return 1
+	[[ "$quiet" != "true" ]] && print_error "No available model for tier: $tier (tried $primary, $fallback, and extended chain)"
+	return 1
 }
 
 # Resolve a model using the full fallback chain (t132.4).
@@ -907,34 +907,34 @@ resolve_tier() {
 # to the fallback chain configuration for maximum flexibility.
 # Supports per-agent overrides via --agent flag.
 resolve_tier_chain() {
-    local tier="$1"
-    local force="${2:-false}"
-    local quiet="${3:-false}"
-    local agent_file="${4:-}"
+	local tier="$1"
+	local force="${2:-false}"
+	local quiet="${3:-false}"
+	local agent_file="${4:-}"
 
-    local chain_helper="${SCRIPT_DIR}/fallback-chain-helper.sh"
-    if [[ ! -x "$chain_helper" ]]; then
-        [[ "$quiet" != "true" ]] && print_warning "fallback-chain-helper.sh not found, falling back to resolve_tier"
-        resolve_tier "$tier" "$force" "$quiet"
-        return $?
-    fi
+	local chain_helper="${SCRIPT_DIR}/fallback-chain-helper.sh"
+	if [[ ! -x "$chain_helper" ]]; then
+		[[ "$quiet" != "true" ]] && print_warning "fallback-chain-helper.sh not found, falling back to resolve_tier"
+		resolve_tier "$tier" "$force" "$quiet"
+		return $?
+	fi
 
-    local -a chain_args=("resolve" "$tier")
-    [[ "$quiet" == "true" ]] && chain_args+=("--quiet")
-    [[ "$force" == "true" ]] && chain_args+=("--force")
-    [[ -n "$agent_file" ]] && chain_args+=("--agent" "$agent_file")
+	local -a chain_args=("resolve" "$tier")
+	[[ "$quiet" == "true" ]] && chain_args+=("--quiet")
+	[[ "$force" == "true" ]] && chain_args+=("--force")
+	[[ -n "$agent_file" ]] && chain_args+=("--agent" "$agent_file")
 
-    local resolved
-    resolved=$("$chain_helper" "${chain_args[@]}" 2>/dev/null) || true
+	local resolved
+	resolved=$("$chain_helper" "${chain_args[@]}" 2>/dev/null) || true
 
-    if [[ -n "$resolved" ]]; then
-        echo "$resolved"
-        [[ "$quiet" != "true" ]] && print_success "Resolved $tier -> $resolved (via fallback chain)"
-        return 0
-    fi
+	if [[ -n "$resolved" ]]; then
+		echo "$resolved"
+		[[ "$quiet" != "true" ]] && print_success "Resolved $tier -> $resolved (via fallback chain)"
+		return 0
+	fi
 
-    [[ "$quiet" != "true" ]] && print_error "No available model for tier: $tier (fallback chain exhausted)"
-    return 1
+	[[ "$quiet" != "true" ]] && print_error "No available model for tier: $tier (fallback chain exhausted)"
+	return 1
 }
 
 # =============================================================================
@@ -942,473 +942,524 @@ resolve_tier_chain() {
 # =============================================================================
 
 cmd_check() {
-    local target="${1:-}"
-    local force=false
-    local quiet=false
-    local json_flag=false
-    local custom_ttl=""
-    shift || true
+	local target="${1:-}"
+	local force=false
+	local quiet=false
+	local json_flag=false
+	local custom_ttl=""
+	shift || true
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --force) force=true; shift ;;
-            --quiet) quiet=true; shift ;;
-            --json) json_flag=true; shift ;;
-            --ttl) custom_ttl="${2:-}"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--force)
+			force=true
+			shift
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		--json)
+			json_flag=true
+			shift
+			;;
+		--ttl)
+			custom_ttl="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ -z "$target" ]]; then
-        print_error "Usage: model-availability-helper.sh check <provider|model>"
-        return 1
-    fi
+	if [[ -z "$target" ]]; then
+		print_error "Usage: model-availability-helper.sh check <provider|model>"
+		return 1
+	fi
 
-    # Determine if target is a provider name, tier, or model spec
-    if is_known_provider "$target"; then
-        probe_provider "$target" "$force" "$custom_ttl" "$quiet"
-        return $?
-    elif is_known_tier "$target"; then
-        resolve_tier "$target" "$force" "$quiet" >/dev/null
-        return $?
-    else
-        # Assume it's a model spec (provider/model or model name)
-        check_model_available "$target" "$force" "$quiet"
-        return $?
-    fi
+	# Determine if target is a provider name, tier, or model spec
+	if is_known_provider "$target"; then
+		probe_provider "$target" "$force" "$custom_ttl" "$quiet"
+		return $?
+	elif is_known_tier "$target"; then
+		resolve_tier "$target" "$force" "$quiet" >/dev/null
+		return $?
+	else
+		# Assume it's a model spec (provider/model or model name)
+		check_model_available "$target" "$force" "$quiet"
+		return $?
+	fi
 }
 
 cmd_probe() {
-    local all=false
-    local target=""
-    local force=false
-    local quiet=false
-    local json_flag=false
+	local all=false
+	local target=""
+	local force=false
+	local quiet=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --all) all=true; shift ;;
-            --force) force=true; shift ;;
-            --quiet) quiet=true; shift ;;
-            --json) json_flag=true; shift ;;
-            *)
-                if [[ -z "$target" ]]; then
-                    target="$1"
-                fi
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--all)
+			all=true
+			shift
+			;;
+		--force)
+			force=true
+			shift
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		--json)
+			json_flag=true
+			shift
+			;;
+		*)
+			if [[ -z "$target" ]]; then
+				target="$1"
+			fi
+			shift
+			;;
+		esac
+	done
 
-    if [[ -n "$target" ]] && ! is_known_provider "$target"; then
-        print_error "Unknown provider: $target"
-        print_info "Available: $KNOWN_PROVIDERS"
-        return 1
-    fi
+	if [[ -n "$target" ]] && ! is_known_provider "$target"; then
+		print_error "Unknown provider: $target"
+		print_info "Available: $KNOWN_PROVIDERS"
+		return 1
+	fi
 
-    local providers_to_probe=()
-    if [[ -n "$target" ]]; then
-        providers_to_probe=("$target")
-    elif [[ "$all" == "true" ]]; then
-        # Probe all known providers
-        for p in $KNOWN_PROVIDERS; do
-            providers_to_probe+=("$p")
-        done
-    else
-        # Probe only providers with configured keys
-        for p in $KNOWN_PROVIDERS; do
-            if resolve_api_key "$p" >/dev/null 2>&1; then
-                providers_to_probe+=("$p")
-            fi
-        done
-    fi
+	local providers_to_probe=()
+	if [[ -n "$target" ]]; then
+		providers_to_probe=("$target")
+	elif [[ "$all" == "true" ]]; then
+		# Probe all known providers
+		for p in $KNOWN_PROVIDERS; do
+			providers_to_probe+=("$p")
+		done
+	else
+		# Probe only providers with configured keys
+		for p in $KNOWN_PROVIDERS; do
+			if resolve_api_key "$p" >/dev/null 2>&1; then
+				providers_to_probe+=("$p")
+			fi
+		done
+	fi
 
-    if [[ ${#providers_to_probe[@]} -eq 0 ]]; then
-        print_warning "No providers to probe (no API keys configured)"
-        return 1
-    fi
+	if [[ ${#providers_to_probe[@]} -eq 0 ]]; then
+		print_warning "No providers to probe (no API keys configured)"
+		return 1
+	fi
 
-    [[ "$quiet" != "true" ]] && echo ""
-    [[ "$quiet" != "true" ]] && echo "Provider Availability Probe"
-    [[ "$quiet" != "true" ]] && echo "==========================="
-    [[ "$quiet" != "true" ]] && echo ""
+	[[ "$quiet" != "true" ]] && echo ""
+	[[ "$quiet" != "true" ]] && echo "Provider Availability Probe"
+	[[ "$quiet" != "true" ]] && echo "==========================="
+	[[ "$quiet" != "true" ]] && echo ""
 
-    local healthy=0 unhealthy=0 no_key=0
-    for provider in "${providers_to_probe[@]}"; do
-        local exit_code=0
-        probe_provider "$provider" "$force" "" "$quiet" || exit_code=$?
-        case "$exit_code" in
-            0) healthy=$((healthy + 1)) ;;
-            3) no_key=$((no_key + 1)) ;;
-            *) unhealthy=$((unhealthy + 1)) ;;
-        esac
-    done
+	local healthy=0 unhealthy=0 no_key=0
+	for provider in "${providers_to_probe[@]}"; do
+		local exit_code=0
+		probe_provider "$provider" "$force" "" "$quiet" || exit_code=$?
+		case "$exit_code" in
+		0) healthy=$((healthy + 1)) ;;
+		3) no_key=$((no_key + 1)) ;;
+		*) unhealthy=$((unhealthy + 1)) ;;
+		esac
+	done
 
-    [[ "$quiet" != "true" ]] && echo ""
-    [[ "$quiet" != "true" ]] && print_info "Summary: $healthy healthy, $unhealthy unhealthy, $no_key no key"
+	[[ "$quiet" != "true" ]] && echo ""
+	[[ "$quiet" != "true" ]] && print_info "Summary: $healthy healthy, $unhealthy unhealthy, $no_key no key"
 
-    if [[ "$json_flag" == "true" ]]; then
-        db_query_json "SELECT provider, status, http_code, response_ms, models_count, checked_at FROM provider_health ORDER BY provider;"
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		db_query_json "SELECT provider, status, http_code, response_ms, models_count, checked_at FROM provider_health ORDER BY provider;"
+	fi
 
-    [[ "$unhealthy" -gt 0 ]] && return 1
-    return 0
+	[[ "$unhealthy" -gt 0 ]] && return 1
+	return 0
 }
 
 cmd_status() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ ! -f "$AVAILABILITY_DB" ]]; then
-        print_warning "No availability data. Run 'model-availability-helper.sh probe' first."
-        return 0
-    fi
+	if [[ ! -f "$AVAILABILITY_DB" ]]; then
+		print_warning "No availability data. Run 'model-availability-helper.sh probe' first."
+		return 0
+	fi
 
-    if [[ "$json_flag" == "true" ]]; then
-        echo "{"
-        echo "  \"providers\":"
-        db_query_json "SELECT provider, status, http_code, response_ms, models_count, error_message, checked_at FROM provider_health ORDER BY provider;"
-        echo ","
-        echo "  \"rate_limits\":"
-        db_query_json "SELECT provider, requests_limit, requests_remaining, requests_reset, tokens_limit, tokens_remaining, tokens_reset, checked_at FROM rate_limits ORDER BY provider;"
-        echo "}"
-        return 0
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		echo "{"
+		echo "  \"providers\":"
+		db_query_json "SELECT provider, status, http_code, response_ms, models_count, error_message, checked_at FROM provider_health ORDER BY provider;"
+		echo ","
+		echo "  \"rate_limits\":"
+		db_query_json "SELECT provider, requests_limit, requests_remaining, requests_reset, tokens_limit, tokens_remaining, tokens_reset, checked_at FROM rate_limits ORDER BY provider;"
+		echo "}"
+		return 0
+	fi
 
-    echo ""
-    echo "Model Availability Status"
-    echo "========================="
-    echo ""
+	echo ""
+	echo "Model Availability Status"
+	echo "========================="
+	echo ""
 
-    echo "Provider Health:"
-    echo ""
-    printf "  %-12s %-12s %-6s %-8s %-8s %-20s\n" \
-        "Provider" "Status" "HTTP" "Time" "Models" "Last Check"
-    printf "  %-12s %-12s %-6s %-8s %-8s %-20s\n" \
-        "--------" "------" "----" "----" "------" "----------"
+	echo "Provider Health:"
+	echo ""
+	printf "  %-12s %-12s %-6s %-8s %-8s %-20s\n" \
+		"Provider" "Status" "HTTP" "Time" "Models" "Last Check"
+	printf "  %-12s %-12s %-6s %-8s %-8s %-20s\n" \
+		"--------" "------" "----" "----" "------" "----------"
 
-    db_query "
+	db_query "
         SELECT provider, status, http_code, response_ms, models_count, checked_at
         FROM provider_health ORDER BY provider;
     " | while IFS='|' read -r prov stat code ms models checked; do
-        local status_display="$stat"
-        case "$stat" in
-            healthy) status_display="${GREEN}healthy${NC}" ;;
-            unhealthy|unreachable) status_display="${RED}$stat${NC}" ;;
-            rate_limited) status_display="${YELLOW}rate-ltd${NC}" ;;
-            key_invalid) status_display="${RED}bad-key${NC}" ;;
-            no_key) status_display="${YELLOW}no-key${NC}" ;;
-        esac
+		local status_display="$stat"
+		case "$stat" in
+		healthy) status_display="${GREEN}healthy${NC}" ;;
+		unhealthy | unreachable) status_display="${RED}$stat${NC}" ;;
+		rate_limited) status_display="${YELLOW}rate-ltd${NC}" ;;
+		key_invalid) status_display="${RED}bad-key${NC}" ;;
+		no_key) status_display="${YELLOW}no-key${NC}" ;;
+		esac
 
-        # Calculate age
-        local age_display="$checked"
-        local checked_epoch now_epoch
-        if [[ "$(uname)" == "Darwin" ]]; then
-            checked_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$checked" "+%s" 2>/dev/null || echo "0")
-        else
-            checked_epoch=$(date -d "$checked" "+%s" 2>/dev/null || echo "0")
-        fi
-        now_epoch=$(date "+%s")
-        local age=$(( now_epoch - checked_epoch ))
-        if [[ "$age" -lt 60 ]]; then
-            age_display="${age}s ago"
-        elif [[ "$age" -lt 3600 ]]; then
-            age_display="$((age / 60))m ago"
-        else
-            age_display="$((age / 3600))h ago"
-        fi
+		# Calculate age
+		local age_display="$checked"
+		local checked_epoch now_epoch
+		if [[ "$(uname)" == "Darwin" ]]; then
+			checked_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$checked" "+%s" 2>/dev/null || echo "0")
+		else
+			checked_epoch=$(date -d "$checked" "+%s" 2>/dev/null || echo "0")
+		fi
+		now_epoch=$(date "+%s")
+		local age=$((now_epoch - checked_epoch))
+		if [[ "$age" -lt 60 ]]; then
+			age_display="${age}s ago"
+		elif [[ "$age" -lt 3600 ]]; then
+			age_display="$((age / 60))m ago"
+		else
+			age_display="$((age / 3600))h ago"
+		fi
 
-        printf "  %-12s %-12b %-6s %-8s %-8s %-20s\n" \
-            "$prov" "$status_display" "$code" "${ms}ms" "$models" "$age_display"
-    done
+		printf "  %-12s %-12b %-6s %-8s %-8s %-20s\n" \
+			"$prov" "$status_display" "$code" "${ms}ms" "$models" "$age_display"
+	done
 
-    # Show rate limits if available
-    local rl_count
-    rl_count=$(db_query "SELECT COUNT(*) FROM rate_limits WHERE requests_limit > 0;")
-    if [[ "$rl_count" -gt 0 ]]; then
-        echo ""
-        echo "Rate Limits:"
-        echo ""
-        printf "  %-12s %-15s %-15s %-15s\n" \
-            "Provider" "Req Remaining" "Tok Remaining" "Reset"
-        printf "  %-12s %-15s %-15s %-15s\n" \
-            "--------" "-------------" "-------------" "-----"
+	# Show rate limits if available
+	local rl_count
+	rl_count=$(db_query "SELECT COUNT(*) FROM rate_limits WHERE requests_limit > 0;")
+	if [[ "$rl_count" -gt 0 ]]; then
+		echo ""
+		echo "Rate Limits:"
+		echo ""
+		printf "  %-12s %-15s %-15s %-15s\n" \
+			"Provider" "Req Remaining" "Tok Remaining" "Reset"
+		printf "  %-12s %-15s %-15s %-15s\n" \
+			"--------" "-------------" "-------------" "-----"
 
-        db_query "
+		db_query "
             SELECT provider, requests_limit, requests_remaining, requests_reset,
                    tokens_limit, tokens_remaining, tokens_reset
             FROM rate_limits WHERE requests_limit > 0 ORDER BY provider;
         " | while IFS='|' read -r prov rl rr rres tl tr tres; do
-            local req_display="${rr}/${rl}"
-            local tok_display="${tr}/${tl}"
-            [[ "$tl" == "0" ]] && tok_display="n/a"
-            printf "  %-12s %-15s %-15s %-15s\n" \
-                "$prov" "$req_display" "$tok_display" "${rres:-n/a}"
-        done
-    fi
+			local req_display="${rr}/${rl}"
+			local tok_display="${tr}/${tl}"
+			[[ "$tl" == "0" ]] && tok_display="n/a"
+			printf "  %-12s %-15s %-15s %-15s\n" \
+				"$prov" "$req_display" "$tok_display" "${rres:-n/a}"
+		done
+	fi
 
-    # Show tier resolution
-    echo ""
-    echo "Tier Resolution:"
-    echo ""
-    printf "  %-8s %-35s %-35s\n" "Tier" "Primary" "Fallback"
-    printf "  %-8s %-35s %-35s\n" "----" "-------" "--------"
-    for tier in haiku flash sonnet pro opus health eval coding; do
-        local spec
-        spec=$(get_tier_models "$tier" 2>/dev/null) || spec=""
-        local primary="${spec%%|*}"
-        local fallback="${spec#*|}"
-        printf "  %-8s %-35s %-35s\n" "$tier" "$primary" "$fallback"
-    done
+	# Show tier resolution
+	echo ""
+	echo "Tier Resolution:"
+	echo ""
+	printf "  %-8s %-35s %-35s\n" "Tier" "Primary" "Fallback"
+	printf "  %-8s %-35s %-35s\n" "----" "-------" "--------"
+	for tier in haiku flash sonnet pro opus health eval coding; do
+		local spec
+		spec=$(get_tier_models "$tier" 2>/dev/null) || spec=""
+		local primary="${spec%%|*}"
+		local fallback="${spec#*|}"
+		printf "  %-8s %-35s %-35s\n" "$tier" "$primary" "$fallback"
+	done
 
-    echo ""
+	echo ""
 
-    # Show recent probe log
-    local log_count
-    log_count=$(db_query "SELECT COUNT(*) FROM probe_log;")
-    if [[ "$log_count" -gt 0 ]]; then
-        echo "Recent Probes (last 10):"
-        echo ""
-        db_query "
+	# Show recent probe log
+	local log_count
+	log_count=$(db_query "SELECT COUNT(*) FROM probe_log;")
+	if [[ "$log_count" -gt 0 ]]; then
+		echo "Recent Probes (last 10):"
+		echo ""
+		db_query "
             SELECT timestamp, provider, action, result, duration_ms
             FROM probe_log ORDER BY timestamp DESC LIMIT 10;
         " | while IFS='|' read -r ts prov _action result ms; do
-            echo "  $ts  $prov  $result  ${ms}ms"
-        done
-        echo ""
-    fi
+			echo "  $ts  $prov  $result  ${ms}ms"
+		done
+		echo ""
+	fi
 
-    return 0
+	return 0
 }
 
 cmd_rate_limits() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ ! -f "$AVAILABILITY_DB" ]]; then
-        print_warning "No rate limit data. Run 'model-availability-helper.sh probe' first."
-        return 0
-    fi
+	if [[ ! -f "$AVAILABILITY_DB" ]]; then
+		print_warning "No rate limit data. Run 'model-availability-helper.sh probe' first."
+		return 0
+	fi
 
-    if [[ "$json_flag" == "true" ]]; then
-        db_query_json "SELECT * FROM rate_limits ORDER BY provider;"
-        return 0
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		db_query_json "SELECT * FROM rate_limits ORDER BY provider;"
+		return 0
+	fi
 
-    echo ""
-    echo "Rate Limit Status"
-    echo "================="
-    echo ""
+	echo ""
+	echo "Rate Limit Status"
+	echo "================="
+	echo ""
 
-    local count
-    count=$(db_query "SELECT COUNT(*) FROM rate_limits;")
+	local count
+	count=$(db_query "SELECT COUNT(*) FROM rate_limits;")
 
-    if [[ "$count" -eq 0 ]]; then
-        print_info "No rate limit data cached. Probe providers to collect rate limit headers."
-        return 0
-    fi
+	if [[ "$count" -eq 0 ]]; then
+		print_info "No rate limit data cached. Probe providers to collect rate limit headers."
+		return 0
+	fi
 
-    printf "  %-12s %-12s %-12s %-20s %-12s %-12s %-20s %-20s\n" \
-        "Provider" "Req Limit" "Req Left" "Req Reset" "Tok Limit" "Tok Left" "Tok Reset" "Checked"
-    printf "  %-12s %-12s %-12s %-20s %-12s %-12s %-20s %-20s\n" \
-        "--------" "---------" "--------" "---------" "---------" "--------" "---------" "-------"
+	printf "  %-12s %-12s %-12s %-20s %-12s %-12s %-20s %-20s\n" \
+		"Provider" "Req Limit" "Req Left" "Req Reset" "Tok Limit" "Tok Left" "Tok Reset" "Checked"
+	printf "  %-12s %-12s %-12s %-20s %-12s %-12s %-20s %-20s\n" \
+		"--------" "---------" "--------" "---------" "---------" "--------" "---------" "-------"
 
-    db_query "SELECT * FROM rate_limits ORDER BY provider;" | \
-    while IFS='|' read -r prov rl rr rres tl tr tres checked _ttl; do
-        printf "  %-12s %-12s %-12s %-20s %-12s %-12s %-20s %-20s\n" \
-            "$prov" "$rl" "$rr" "${rres:-n/a}" "$tl" "$tr" "${tres:-n/a}" "$checked"
-    done
+	db_query "SELECT * FROM rate_limits ORDER BY provider;" |
+		while IFS='|' read -r prov rl rr rres tl tr tres checked _ttl; do
+			printf "  %-12s %-12s %-12s %-20s %-12s %-12s %-20s %-20s\n" \
+				"$prov" "$rl" "$rr" "${rres:-n/a}" "$tl" "$tr" "${tres:-n/a}" "$checked"
+		done
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 cmd_resolve() {
-    local tier="${1:-}"
-    local force=false
-    local quiet=false
-    local json_flag=false
-    shift || true
+	local tier="${1:-}"
+	local force=false
+	local quiet=false
+	local json_flag=false
+	shift || true
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --force) force=true; shift ;;
-            --quiet) quiet=true; shift ;;
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--force)
+			force=true
+			shift
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ -z "$tier" ]]; then
-        print_error "Usage: model-availability-helper.sh resolve <tier>"
-        print_info "Available tiers: haiku flash sonnet pro opus health eval coding"
-        return 1
-    fi
+	if [[ -z "$tier" ]]; then
+		print_error "Usage: model-availability-helper.sh resolve <tier>"
+		print_info "Available tiers: haiku flash sonnet pro opus health eval coding"
+		return 1
+	fi
 
-    local resolved
-    resolved=$(resolve_tier "$tier" "$force" "$quiet")
-    local exit_code=$?
+	local resolved
+	resolved=$(resolve_tier "$tier" "$force" "$quiet")
+	local exit_code=$?
 
-    if [[ "$json_flag" == "true" ]]; then
-        if [[ $exit_code -eq 0 ]]; then
-            local provider model_id
-            provider="${resolved%%/*}"
-            model_id="${resolved#*/}"
-            echo "{\"tier\":\"$tier\",\"provider\":\"$provider\",\"model\":\"$model_id\",\"full_id\":\"$resolved\",\"status\":\"available\"}"
-        else
-            echo "{\"tier\":\"$tier\",\"status\":\"unavailable\"}"
-        fi
-    else
-        if [[ $exit_code -eq 0 ]]; then
-            echo "$resolved"
-        fi
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		if [[ $exit_code -eq 0 ]]; then
+			local provider model_id
+			provider="${resolved%%/*}"
+			model_id="${resolved#*/}"
+			echo "{\"tier\":\"$tier\",\"provider\":\"$provider\",\"model\":\"$model_id\",\"full_id\":\"$resolved\",\"status\":\"available\"}"
+		else
+			echo "{\"tier\":\"$tier\",\"status\":\"unavailable\"}"
+		fi
+	else
+		if [[ $exit_code -eq 0 ]]; then
+			echo "$resolved"
+		fi
+	fi
 
-    return "$exit_code"
+	return "$exit_code"
 }
 
 cmd_invalidate() {
-    local target="${1:-}"
-    invalidate_cache "$target"
-    return 0
+	local target="${1:-}"
+	invalidate_cache "$target"
+	return 0
 }
 
 # Resolve using the full fallback chain (t132.4).
 # Delegates to fallback-chain-helper.sh for extended chain resolution
 # including gateway providers and per-agent overrides.
 cmd_resolve_chain() {
-    local tier="${1:-}"
-    local force=false
-    local quiet=false
-    local json_flag=false
-    local agent_file=""
-    shift || true
+	local tier="${1:-}"
+	local force=false
+	local quiet=false
+	local json_flag=false
+	local agent_file=""
+	shift || true
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --force) force=true; shift ;;
-            --quiet) quiet=true; shift ;;
-            --json) json_flag=true; shift ;;
-            --agent) agent_file="${2:-}"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--force)
+			force=true
+			shift
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		--json)
+			json_flag=true
+			shift
+			;;
+		--agent)
+			agent_file="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ -z "$tier" ]]; then
-        print_error "Usage: model-availability-helper.sh resolve-chain <tier> [--agent file]"
-        print_info "Available tiers: haiku flash sonnet pro opus health eval coding"
-        return 1
-    fi
+	if [[ -z "$tier" ]]; then
+		print_error "Usage: model-availability-helper.sh resolve-chain <tier> [--agent file]"
+		print_info "Available tiers: haiku flash sonnet pro opus health eval coding"
+		return 1
+	fi
 
-    local resolved
-    resolved=$(resolve_tier_chain "$tier" "$force" "$quiet" "$agent_file")
-    local exit_code=$?
+	local resolved
+	resolved=$(resolve_tier_chain "$tier" "$force" "$quiet" "$agent_file")
+	local exit_code=$?
 
-    if [[ "$json_flag" == "true" ]]; then
-        if [[ $exit_code -eq 0 ]]; then
-            local provider model_id
-            provider="${resolved%%/*}"
-            model_id="${resolved#*/}"
-            echo "{\"tier\":\"$tier\",\"provider\":\"$provider\",\"model\":\"$model_id\",\"full_id\":\"$resolved\",\"status\":\"available\",\"method\":\"chain\"}"
-        else
-            echo "{\"tier\":\"$tier\",\"status\":\"exhausted\",\"method\":\"chain\"}"
-        fi
-    else
-        if [[ $exit_code -eq 0 ]]; then
-            echo "$resolved"
-        fi
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		if [[ $exit_code -eq 0 ]]; then
+			local provider model_id
+			provider="${resolved%%/*}"
+			model_id="${resolved#*/}"
+			echo "{\"tier\":\"$tier\",\"provider\":\"$provider\",\"model\":\"$model_id\",\"full_id\":\"$resolved\",\"status\":\"available\",\"method\":\"chain\"}"
+		else
+			echo "{\"tier\":\"$tier\",\"status\":\"exhausted\",\"method\":\"chain\"}"
+		fi
+	else
+		if [[ $exit_code -eq 0 ]]; then
+			echo "$resolved"
+		fi
+	fi
 
-    return "$exit_code"
+	return "$exit_code"
 }
 
 cmd_help() {
-    echo ""
-    echo "Model Availability Helper - Probe before dispatch"
-    echo "================================================="
-    echo ""
-    echo "Usage: model-availability-helper.sh [command] [options]"
-    echo ""
-    echo "Commands:"
-    echo "  check <provider|model|tier>  Check availability (exit 0=yes, 1=no, 2=rate-limited, 3=bad-key)"
-    echo "  probe [provider] [--all]     Probe providers (default: only those with keys)"
-    echo "  status                       Show cached availability status"
-    echo "  rate-limits                  Show rate limit data from cache"
-    echo "  resolve <tier>               Resolve best available model for tier (primary + fallback)"
-    echo "  resolve-chain <tier>         Resolve via full fallback chain (t132.4, includes gateways)"
-    echo "  invalidate [provider]        Clear cache (all or specific provider)"
-    echo "  help                         Show this help"
-    echo ""
-    echo "Options:"
-    echo "  --json        Output in JSON format"
-    echo "  --quiet       Suppress informational output"
-    echo "  --force       Bypass cache and probe live"
-    echo "  --ttl N       Override cache TTL in seconds"
-    echo "  --agent FILE  Per-agent fallback chain override (resolve-chain only)"
-    echo ""
-    echo "Tiers:"
-    echo "  haiku   - Cheapest (triage, classification)"
-    echo "  flash   - Low cost (large context, summarization)"
-    echo "  sonnet  - Medium (code implementation, review)"
-    echo "  pro     - Medium-high (large codebase analysis)"
-    echo "  opus    - Highest (architecture, complex reasoning)"
-    echo "  health  - Cheapest probe model"
-    echo "  eval    - Cheap evaluation model"
-    echo "  coding  - Best SOTA coding model"
-    echo ""
-    echo "Providers:"
-    echo "  anthropic, openai, google, openrouter, groq, deepseek, opencode"
-    echo "  The 'opencode' provider uses the OpenCode models cache (~/.cache/opencode/models.json)"
-    echo "  instead of direct API probing. When OpenCode is available, tier resolution"
-    echo "  prefers opencode/* model IDs (routed through OpenCode's gateway)."
-    echo ""
-    echo "Examples:"
-    echo "  model-availability-helper.sh check anthropic"
-    echo "  model-availability-helper.sh check opencode"
-    echo "  model-availability-helper.sh check opencode/claude-sonnet-4"
-    echo "  model-availability-helper.sh check anthropic/claude-sonnet-4-20250514"
-    echo "  model-availability-helper.sh check sonnet"
-    echo "  model-availability-helper.sh probe --all"
-    echo "  model-availability-helper.sh resolve opus --json"
-    echo "  model-availability-helper.sh resolve-chain coding --json"
-    echo "  model-availability-helper.sh resolve-chain sonnet --agent models/sonnet.md"
-    echo "  model-availability-helper.sh status"
-    echo "  model-availability-helper.sh rate-limits --json"
-    echo "  model-availability-helper.sh invalidate anthropic"
-    echo ""
-    echo "Integration with supervisor:"
-    echo "  # In supervisor dispatch, replace check_model_health() with:"
-    echo "  model-availability-helper.sh check anthropic --quiet"
-    echo ""
-    echo "  # Resolve model with fallback for a tier:"
-    echo "  MODEL=\$(model-availability-helper.sh resolve coding --quiet)"
-    echo ""
-    echo "  # Resolve via full fallback chain (includes gateway providers):"
-    echo "  MODEL=\$(model-availability-helper.sh resolve-chain coding --quiet)"
-    echo ""
-    echo "Exit codes:"
-    echo "  0 - Available"
-    echo "  1 - Unavailable or error"
-    echo "  2 - Rate limited"
-    echo "  3 - API key invalid or missing"
-    echo ""
-    echo "Cache: $AVAILABILITY_DB"
-    echo "OpenCode models: $OPENCODE_MODELS_CACHE"
-    echo "TTL: ${DEFAULT_HEALTH_TTL}s (health), ${DEFAULT_RATELIMIT_TTL}s (rate limits)"
-    echo ""
-    return 0
+	echo ""
+	echo "Model Availability Helper - Probe before dispatch"
+	echo "================================================="
+	echo ""
+	echo "Usage: model-availability-helper.sh [command] [options]"
+	echo ""
+	echo "Commands:"
+	echo "  check <provider|model|tier>  Check availability (exit 0=yes, 1=no, 2=rate-limited, 3=bad-key)"
+	echo "  probe [provider] [--all]     Probe providers (default: only those with keys)"
+	echo "  status                       Show cached availability status"
+	echo "  rate-limits                  Show rate limit data from cache"
+	echo "  resolve <tier>               Resolve best available model for tier (primary + fallback)"
+	echo "  resolve-chain <tier>         Resolve via full fallback chain (t132.4, includes gateways)"
+	echo "  invalidate [provider]        Clear cache (all or specific provider)"
+	echo "  help                         Show this help"
+	echo ""
+	echo "Options:"
+	echo "  --json        Output in JSON format"
+	echo "  --quiet       Suppress informational output"
+	echo "  --force       Bypass cache and probe live"
+	echo "  --ttl N       Override cache TTL in seconds"
+	echo "  --agent FILE  Per-agent fallback chain override (resolve-chain only)"
+	echo ""
+	echo "Tiers:"
+	echo "  haiku   - Cheapest (triage, classification)"
+	echo "  flash   - Low cost (large context, summarization)"
+	echo "  sonnet  - Medium (code implementation, review)"
+	echo "  pro     - Medium-high (large codebase analysis)"
+	echo "  opus    - Highest (architecture, complex reasoning)"
+	echo "  health  - Cheapest probe model"
+	echo "  eval    - Cheap evaluation model"
+	echo "  coding  - Best SOTA coding model"
+	echo ""
+	echo "Providers:"
+	echo "  anthropic, openai, google, openrouter, groq, deepseek, opencode"
+	echo "  The 'opencode' provider uses the OpenCode models cache (~/.cache/opencode/models.json)"
+	echo "  instead of direct API probing. When OpenCode is available, tier resolution"
+	echo "  prefers opencode/* model IDs (routed through OpenCode's gateway)."
+	echo ""
+	echo "Examples:"
+	echo "  model-availability-helper.sh check anthropic"
+	echo "  model-availability-helper.sh check opencode"
+	echo "  model-availability-helper.sh check opencode/claude-sonnet-4"
+	echo "  model-availability-helper.sh check anthropic/claude-sonnet-4-6"
+	echo "  model-availability-helper.sh check sonnet"
+	echo "  model-availability-helper.sh probe --all"
+	echo "  model-availability-helper.sh resolve opus --json"
+	echo "  model-availability-helper.sh resolve-chain coding --json"
+	echo "  model-availability-helper.sh resolve-chain sonnet --agent models/sonnet.md"
+	echo "  model-availability-helper.sh status"
+	echo "  model-availability-helper.sh rate-limits --json"
+	echo "  model-availability-helper.sh invalidate anthropic"
+	echo ""
+	echo "Integration with supervisor:"
+	echo "  # In supervisor dispatch, replace check_model_health() with:"
+	echo "  model-availability-helper.sh check anthropic --quiet"
+	echo ""
+	echo "  # Resolve model with fallback for a tier:"
+	echo "  MODEL=\$(model-availability-helper.sh resolve coding --quiet)"
+	echo ""
+	echo "  # Resolve via full fallback chain (includes gateway providers):"
+	echo "  MODEL=\$(model-availability-helper.sh resolve-chain coding --quiet)"
+	echo ""
+	echo "Exit codes:"
+	echo "  0 - Available"
+	echo "  1 - Unavailable or error"
+	echo "  2 - Rate limited"
+	echo "  3 - API key invalid or missing"
+	echo ""
+	echo "Cache: $AVAILABILITY_DB"
+	echo "OpenCode models: $OPENCODE_MODELS_CACHE"
+	echo "TTL: ${DEFAULT_HEALTH_TTL}s (health), ${DEFAULT_RATELIMIT_TTL}s (rate limits)"
+	echo ""
+	return 0
 }
 
 # =============================================================================
@@ -1416,46 +1467,46 @@ cmd_help() {
 # =============================================================================
 
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    # Initialize DB for all commands except help
-    if [[ "$command" != "help" && "$command" != "--help" && "$command" != "-h" ]]; then
-        init_db || return 1
-    fi
+	# Initialize DB for all commands except help
+	if [[ "$command" != "help" && "$command" != "--help" && "$command" != "-h" ]]; then
+		init_db || return 1
+	fi
 
-    case "$command" in
-        check)
-            cmd_check "$@"
-            ;;
-        probe)
-            cmd_probe "$@"
-            ;;
-        status)
-            cmd_status "$@"
-            ;;
-        rate-limits|ratelimits|rate_limits)
-            cmd_rate_limits "$@"
-            ;;
-        resolve)
-            cmd_resolve "$@"
-            ;;
-        resolve-chain|resolve_chain)
-            cmd_resolve_chain "$@"
-            ;;
-        invalidate|clear|flush)
-            cmd_invalidate "$@"
-            ;;
-        help|--help|-h)
-            cmd_help
-            ;;
-        *)
-            print_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
-    return $?
+	case "$command" in
+	check)
+		cmd_check "$@"
+		;;
+	probe)
+		cmd_probe "$@"
+		;;
+	status)
+		cmd_status "$@"
+		;;
+	rate-limits | ratelimits | rate_limits)
+		cmd_rate_limits "$@"
+		;;
+	resolve)
+		cmd_resolve "$@"
+		;;
+	resolve-chain | resolve_chain)
+		cmd_resolve_chain "$@"
+		;;
+	invalidate | clear | flush)
+		cmd_invalidate "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+	return $?
 }
 
 main "$@"

--- a/.agents/scripts/model-label-helper.sh
+++ b/.agents/scripts/model-label-helper.sh
@@ -56,7 +56,7 @@ ACTIONS:
     planned, researched, implemented, reviewed, verified, documented, failed, retried
 
 MODELS:
-    haiku, flash, sonnet, pro, opus (or concrete model names like claude-sonnet-4-5)
+    haiku, flash, sonnet, pro, opus (or concrete model names like claude-sonnet-4-6)
 
 EXAMPLES:
     # Add label when dispatching a task
@@ -92,7 +92,7 @@ EOF
 #######################################
 # Normalize model name to tier
 # Arguments:
-#   $1 - Model name (e.g., claude-sonnet-4-5, sonnet, gpt-4)
+#   $1 - Model name (e.g., claude-sonnet-4-6, sonnet, gpt-4)
 # Returns:
 #   Normalized tier name (haiku, flash, sonnet, pro, opus)
 #######################################

--- a/.agents/scripts/model-registry-helper.sh
+++ b/.agents/scripts/model-registry-helper.sh
@@ -43,7 +43,7 @@ init_log_file
 
 readonly REGISTRY_DIR="${HOME}/.aidevops/.agent-workspace"
 readonly REGISTRY_DB="${REGISTRY_DIR}/model-registry.db"
-readonly SYNC_INTERVAL=86400  # 24 hours in seconds
+readonly SYNC_INTERVAL=86400 # 24 hours in seconds
 readonly AGENTS_DIR="${SCRIPT_DIR}/.."
 readonly MODELS_DIR="${AGENTS_DIR}/tools/ai-assistants/models"
 
@@ -52,9 +52,9 @@ readonly MODELS_DIR="${AGENTS_DIR}/tools/ai-assistants/models"
 # =============================================================================
 
 init_db() {
-    mkdir -p "$REGISTRY_DIR" 2>/dev/null || true
+	mkdir -p "$REGISTRY_DIR" 2>/dev/null || true
 
-    sqlite3 "$REGISTRY_DB" "
+	sqlite3 "$REGISTRY_DB" "
         CREATE TABLE IF NOT EXISTS models (
             model_id       TEXT NOT NULL,
             provider       TEXT NOT NULL,
@@ -106,10 +106,10 @@ init_db() {
             details        TEXT DEFAULT ''
         );
     " 2>/dev/null || {
-        print_error "Failed to initialize registry database"
-        return 1
-    }
-    return 0
+		print_error "Failed to initialize registry database"
+		return 1
+	}
+	return 0
 }
 
 # =============================================================================
@@ -119,18 +119,18 @@ init_db() {
 # e.g., "claude-3-5-haiku" and "claude-haiku-3.5" both normalize to "claude-haiku"
 
 normalize_model_name() {
-    local name="$1"
-    # Strip provider prefix
-    name="${name#*/}"
-    # Strip date suffixes (e.g., -20250514, -20241022)
-    name="${name%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
-    # Strip preview suffixes (e.g., -preview-05-20)
-    name=$(echo "$name" | sed -E 's/-preview-[0-9]{2}-[0-9]{2}$//')
-    # Strip version numbers (e.g., -3-5, -3.5, -4, -2.5, -2.0)
-    name=$(echo "$name" | sed -E 's/-[0-9]+(\.[0-9]+)?//g')
-    # Lowercase
-    echo "$name" | tr '[:upper:]' '[:lower:]'
-    return 0
+	local name="$1"
+	# Strip provider prefix
+	name="${name#*/}"
+	# Strip date suffixes (e.g., -20250514, -20241022)
+	name="${name%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
+	# Strip preview suffixes (e.g., -preview-05-20)
+	name=$(echo "$name" | sed -E 's/-preview-[0-9]{2}-[0-9]{2}$//')
+	# Strip version numbers (e.g., -3-5, -3.5, -4, -2.5, -2.0)
+	name=$(echo "$name" | sed -E 's/-[0-9]+(\.[0-9]+)?//g')
+	# Lowercase
+	echo "$name" | tr '[:upper:]' '[:lower:]'
+	return 0
 }
 
 # =============================================================================
@@ -138,27 +138,27 @@ normalize_model_name() {
 # =============================================================================
 
 sql_escape() {
-    local val="$1"
-    echo "${val//\'/\'\'}"
-    return 0
+	local val="$1"
+	echo "${val//\'/\'\'}"
+	return 0
 }
 
 db_query() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" "$REGISTRY_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" "$REGISTRY_DB" "$query" 2>/dev/null
+	return $?
 }
 
 db_query_csv() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" -csv -header "$REGISTRY_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" -csv -header "$REGISTRY_DB" "$query" 2>/dev/null
+	return $?
 }
 
 db_query_json() {
-    local query="$1"
-    sqlite3 -cmd ".timeout 5000" -json "$REGISTRY_DB" "$query" 2>/dev/null
-    return $?
+	local query="$1"
+	sqlite3 -cmd ".timeout 5000" -json "$REGISTRY_DB" "$query" 2>/dev/null
+	return $?
 }
 
 # =============================================================================
@@ -166,72 +166,72 @@ db_query_json() {
 # =============================================================================
 
 sync_subagents() {
-    local added=0
-    local updated=0
+	local added=0
+	local updated=0
 
-    if [[ ! -d "$MODELS_DIR" ]]; then
-        print_warning "Models directory not found: $MODELS_DIR"
-        return 0
-    fi
+	if [[ ! -d "$MODELS_DIR" ]]; then
+		print_warning "Models directory not found: $MODELS_DIR"
+		return 0
+	fi
 
-    local md_file
-    for md_file in "$MODELS_DIR"/*.md; do
-        [[ ! -f "$md_file" ]] && continue
-        local basename_file
-        basename_file=$(basename "$md_file")
+	local md_file
+	for md_file in "$MODELS_DIR"/*.md; do
+		[[ ! -f "$md_file" ]] && continue
+		local basename_file
+		basename_file=$(basename "$md_file")
 
-        # Skip README and non-model files
-        [[ "$basename_file" == "README.md" ]] && continue
-        [[ "$basename_file" == *"-reviewer.md" ]] && continue
+		# Skip README and non-model files
+		[[ "$basename_file" == "README.md" ]] && continue
+		[[ "$basename_file" == *"-reviewer.md" ]] && continue
 
-        # Extract frontmatter fields
-        local model_full="" model_tier="" model_fallback=""
-        local in_frontmatter=false
-        local line_num=0
+		# Extract frontmatter fields
+		local model_full="" model_tier="" model_fallback=""
+		local in_frontmatter=false
+		local line_num=0
 
-        while IFS= read -r line; do
-            line_num=$((line_num + 1))
-            if [[ $line_num -eq 1 && "$line" == "---" ]]; then
-                in_frontmatter=true
-                continue
-            fi
-            if [[ "$in_frontmatter" == "true" && "$line" == "---" ]]; then
-                break
-            fi
-            if [[ "$in_frontmatter" == "true" ]]; then
-                case "$line" in
-                    model:*)
-                        model_full="${line#model:}"
-                        model_full="${model_full#"${model_full%%[![:space:]]*}"}"
-                        ;;
-                    model-tier:*)
-                        model_tier="${line#model-tier:}"
-                        model_tier="${model_tier#"${model_tier%%[![:space:]]*}"}"
-                        ;;
-                    model-fallback:*)
-                        model_fallback="${line#model-fallback:}"
-                        model_fallback="${model_fallback#"${model_fallback%%[![:space:]]*}"}"
-                        ;;
-                esac
-            fi
-        done < "$md_file"
+		while IFS= read -r line; do
+			line_num=$((line_num + 1))
+			if [[ $line_num -eq 1 && "$line" == "---" ]]; then
+				in_frontmatter=true
+				continue
+			fi
+			if [[ "$in_frontmatter" == "true" && "$line" == "---" ]]; then
+				break
+			fi
+			if [[ "$in_frontmatter" == "true" ]]; then
+				case "$line" in
+				model:*)
+					model_full="${line#model:}"
+					model_full="${model_full#"${model_full%%[![:space:]]*}"}"
+					;;
+				model-tier:*)
+					model_tier="${line#model-tier:}"
+					model_tier="${model_tier#"${model_tier%%[![:space:]]*}"}"
+					;;
+				model-fallback:*)
+					model_fallback="${line#model-fallback:}"
+					model_fallback="${model_fallback#"${model_fallback%%[![:space:]]*}"}"
+					;;
+				esac
+			fi
+		done <"$md_file"
 
-        if [[ -z "$model_tier" || -z "$model_full" ]]; then
-            continue
-        fi
+		if [[ -z "$model_tier" || -z "$model_full" ]]; then
+			continue
+		fi
 
-        # Extract short model_id from full ID (e.g., anthropic/claude-sonnet-4-20250514 -> claude-sonnet-4)
-        local model_short
-        model_short="${model_full#*/}"
-        # Strip trailing date suffix (e.g., -20250514)
-        model_short="${model_short%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
+		# Extract short model_id from full ID (e.g., anthropic/claude-sonnet-4-6 -> claude-sonnet-4)
+		local model_short
+		model_short="${model_full#*/}"
+		# Strip trailing date suffix (e.g., -20250514)
+		model_short="${model_short%-[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]}"
 
-        # Compute normalized name for fuzzy matching
-        local norm_name
-        norm_name=$(normalize_model_name "$model_full")
+		# Compute normalized name for fuzzy matching
+		local norm_name
+		norm_name=$(normalize_model_name "$model_full")
 
-        # Upsert into subagent_models
-        db_query "
+		# Upsert into subagent_models
+		db_query "
             INSERT INTO subagent_models (tier, model_id, model_full_id, normalized_name, fallback_id, subagent_file, last_synced)
             VALUES (
                 '$(sql_escape "$model_tier")',
@@ -250,16 +250,16 @@ sync_subagents() {
                 subagent_file = excluded.subagent_file,
                 last_synced = excluded.last_synced;
         " && updated=$((updated + 1))
-    done
+	done
 
-    # Log sync
-    db_query "
+	# Log sync
+	db_query "
         INSERT INTO sync_log (sync_type, source, models_added, models_updated, details)
         VALUES ('subagents', 'frontmatter', $added, $updated, 'Synced from $MODELS_DIR');
     "
 
-    print_info "Subagent sync: $updated tiers updated from frontmatter"
-    return 0
+	print_info "Subagent sync: $updated tiers updated from frontmatter"
+	return 0
 }
 
 # =============================================================================
@@ -267,71 +267,71 @@ sync_subagents() {
 # =============================================================================
 
 sync_embedded() {
-    local added=0
-    local updated=0
+	local added=0
+	local updated=0
 
-    # Source the model data from compare-models-helper.sh
-    local compare_helper="${SCRIPT_DIR}/compare-models-helper.sh"
-    if [[ ! -f "$compare_helper" ]]; then
-        print_warning "compare-models-helper.sh not found"
-        return 0
-    fi
+	# Source the model data from compare-models-helper.sh
+	local compare_helper="${SCRIPT_DIR}/compare-models-helper.sh"
+	if [[ ! -f "$compare_helper" ]]; then
+		print_warning "compare-models-helper.sh not found"
+		return 0
+	fi
 
-    # Extract MODEL_DATA from compare-models-helper.sh
-    local model_data=""
-    local in_model_data=false
-    while IFS= read -r line; do
-        if [[ "$line" == 'readonly MODEL_DATA="'* ]]; then
-            in_model_data=true
-            model_data="${line#*=\"}"
-            # Check if single-line
-            if [[ "$model_data" == *'"' ]]; then
-                model_data="${model_data%\"}"
-                break
-            fi
-            continue
-        fi
-        if [[ "$in_model_data" == "true" ]]; then
-            if [[ "$line" == *'"' ]]; then
-                model_data="${model_data}
+	# Extract MODEL_DATA from compare-models-helper.sh
+	local model_data=""
+	local in_model_data=false
+	while IFS= read -r line; do
+		if [[ "$line" == 'readonly MODEL_DATA="'* ]]; then
+			in_model_data=true
+			model_data="${line#*=\"}"
+			# Check if single-line
+			if [[ "$model_data" == *'"' ]]; then
+				model_data="${model_data%\"}"
+				break
+			fi
+			continue
+		fi
+		if [[ "$in_model_data" == "true" ]]; then
+			if [[ "$line" == *'"' ]]; then
+				model_data="${model_data}
 ${line%\"}"
-                break
-            fi
-            model_data="${model_data}
+				break
+			fi
+			model_data="${model_data}
 ${line}"
-        fi
-    done < "$compare_helper"
+		fi
+	done <"$compare_helper"
 
-    if [[ -z "$model_data" ]]; then
-        print_warning "Could not extract MODEL_DATA from compare-models-helper.sh"
-        return 0
-    fi
+	if [[ -z "$model_data" ]]; then
+		print_warning "Could not extract MODEL_DATA from compare-models-helper.sh"
+		return 0
+	fi
 
-    # Parse and upsert each model
-    while IFS= read -r line; do
-        [[ -z "$line" ]] && continue
+	# Parse and upsert each model
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
 
-        local model_id provider display_name ctx input output tier caps best_for
-        model_id=$(echo "$line" | cut -d'|' -f1)
-        provider=$(echo "$line" | cut -d'|' -f2)
-        display_name=$(echo "$line" | cut -d'|' -f3)
-        ctx=$(echo "$line" | cut -d'|' -f4)
-        input=$(echo "$line" | cut -d'|' -f5)
-        output=$(echo "$line" | cut -d'|' -f6)
-        tier=$(echo "$line" | cut -d'|' -f7)
-        caps=$(echo "$line" | cut -d'|' -f8)
-        best_for=$(echo "$line" | cut -d'|' -f9)
+		local model_id provider display_name ctx input output tier caps best_for
+		model_id=$(echo "$line" | cut -d'|' -f1)
+		provider=$(echo "$line" | cut -d'|' -f2)
+		display_name=$(echo "$line" | cut -d'|' -f3)
+		ctx=$(echo "$line" | cut -d'|' -f4)
+		input=$(echo "$line" | cut -d'|' -f5)
+		output=$(echo "$line" | cut -d'|' -f6)
+		tier=$(echo "$line" | cut -d'|' -f7)
+		caps=$(echo "$line" | cut -d'|' -f8)
+		best_for=$(echo "$line" | cut -d'|' -f9)
 
-        # Compute normalized name for fuzzy matching
-        local norm_name
-        norm_name=$(normalize_model_name "$model_id")
+		# Compute normalized name for fuzzy matching
+		local norm_name
+		norm_name=$(normalize_model_name "$model_id")
 
-        # Check if model already exists
-        local existing
-        existing=$(db_query "SELECT model_id FROM models WHERE model_id='$(sql_escape "$model_id")' AND provider='$(sql_escape "$provider")';")
+		# Check if model already exists
+		local existing
+		existing=$(db_query "SELECT model_id FROM models WHERE model_id='$(sql_escape "$model_id")' AND provider='$(sql_escape "$provider")';")
 
-        if [[ -n "$existing" ]]; then
-            db_query "
+		if [[ -n "$existing" ]]; then
+			db_query "
                 UPDATE models SET
                     display_name = '$(sql_escape "$display_name")',
                     normalized_name = '$(sql_escape "$norm_name")',
@@ -345,9 +345,9 @@ ${line}"
                     source = 'embedded'
                 WHERE model_id = '$(sql_escape "$model_id")' AND provider = '$(sql_escape "$provider")';
             "
-            updated=$((updated + 1))
-        else
-            db_query "
+			updated=$((updated + 1))
+		else
+			db_query "
                 INSERT INTO models (model_id, provider, display_name, normalized_name, context_window, input_price, output_price, tier, capabilities, best_for, source)
                 VALUES (
                     '$(sql_escape "$model_id")',
@@ -361,17 +361,17 @@ ${line}"
                     'embedded'
                 );
             "
-            added=$((added + 1))
-        fi
-    done <<< "$model_data"
+			added=$((added + 1))
+		fi
+	done <<<"$model_data"
 
-    db_query "
+	db_query "
         INSERT INTO sync_log (sync_type, source, models_added, models_updated, details)
         VALUES ('embedded', 'compare-models-helper.sh', $added, $updated, 'Parsed MODEL_DATA');
     "
 
-    print_info "Embedded sync: $added added, $updated updated from compare-models-helper.sh"
-    return 0
+	print_info "Embedded sync: $added added, $updated updated from compare-models-helper.sh"
+	return 0
 }
 
 # =============================================================================
@@ -383,24 +383,24 @@ ${line}"
 # API keys (OpenCode routes through its gateway for opencode/* models).
 
 sync_opencode() {
-    local added=0
+	local added=0
 
-    # Check if opencode CLI is available
-    if ! command -v opencode &>/dev/null; then
-        print_info "OpenCode CLI not found, skipping opencode model sync"
-        return 0
-    fi
+	# Check if opencode CLI is available
+	if ! command -v opencode &>/dev/null; then
+		print_info "OpenCode CLI not found, skipping opencode model sync"
+		return 0
+	fi
 
-    # Try the cached models file first (instant, no network)
-    local cache_file="${HOME}/.cache/opencode/models.json"
-    local model_ids=""
+	# Try the cached models file first (instant, no network)
+	local cache_file="${HOME}/.cache/opencode/models.json"
+	local model_ids=""
 
-    # Only extract models from providers we track (avoids processing 2500+ models
-    # from the full models.dev registry — we only need ~100 from relevant providers)
-    local relevant_providers='["anthropic","openai","google","openrouter","groq","deepseek","opencode"]'
+	# Only extract models from providers we track (avoids processing 2500+ models
+	# from the full models.dev registry — we only need ~100 from relevant providers)
+	local relevant_providers='["anthropic","openai","google","openrouter","groq","deepseek","opencode"]'
 
-    if [[ -f "$cache_file" && -s "$cache_file" ]]; then
-        model_ids=$(jq -r --argjson providers "$relevant_providers" '
+	if [[ -f "$cache_file" && -s "$cache_file" ]]; then
+		model_ids=$(jq -r --argjson providers "$relevant_providers" '
             to_entries[] |
             select(.key as $k | $providers | index($k)) |
             .key as $provider |
@@ -408,46 +408,46 @@ sync_opencode() {
             keys[] |
             "\($provider)/\(.)"
         ' "$cache_file" 2>/dev/null) || true
-    fi
+	fi
 
-    # Fallback: use opencode models CLI if cache is empty or missing
-    if [[ -z "$model_ids" ]]; then
-        print_info "  Cache miss, querying opencode models CLI..."
-        model_ids=$(timeout "$DEFAULT_TIMEOUT" opencode models 2>/dev/null \
-            | grep -E '^(anthropic|openai|google|openrouter|groq|deepseek|opencode)/' | sort) || true
-    fi
+	# Fallback: use opencode models CLI if cache is empty or missing
+	if [[ -z "$model_ids" ]]; then
+		print_info "  Cache miss, querying opencode models CLI..."
+		model_ids=$(timeout "$DEFAULT_TIMEOUT" opencode models 2>/dev/null |
+			grep -E '^(anthropic|openai|google|openrouter|groq|deepseek|opencode)/' | sort) || true
+	fi
 
-    if [[ -z "$model_ids" ]]; then
-        print_warning "No models discovered from OpenCode"
-        return 0
-    fi
+	if [[ -z "$model_ids" ]]; then
+		print_warning "No models discovered from OpenCode"
+		return 0
+	fi
 
-    # Build batch SQL for all models (much faster than individual queries)
-    local sql_batch="BEGIN TRANSACTION;"
-    while IFS= read -r full_id; do
-        [[ -z "$full_id" ]] && continue
-        # Skip non-text models (embeddings, tts, whisper, image-only)
-        case "$full_id" in
-            *embed*|*tts*|*whisper*|*dall-e*|*moderation*|*image*) continue ;;
-        esac
+	# Build batch SQL for all models (much faster than individual queries)
+	local sql_batch="BEGIN TRANSACTION;"
+	while IFS= read -r full_id; do
+		[[ -z "$full_id" ]] && continue
+		# Skip non-text models (embeddings, tts, whisper, image-only)
+		case "$full_id" in
+		*embed* | *tts* | *whisper* | *dall-e* | *moderation* | *image*) continue ;;
+		esac
 
-        local provider
-        provider="${full_id%%/*}"
+		local provider
+		provider="${full_id%%/*}"
 
-        # Normalize provider name to match our conventions
-        local norm_provider
-        case "$provider" in
-            anthropic)  norm_provider="Anthropic" ;;
-            openai)     norm_provider="OpenAI" ;;
-            google)     norm_provider="Google" ;;
-            openrouter) norm_provider="OpenRouter" ;;
-            groq)       norm_provider="Groq" ;;
-            deepseek)   norm_provider="DeepSeek" ;;
-            opencode)   norm_provider="OpenCode" ;;
-            *)          norm_provider="$provider" ;;
-        esac
+		# Normalize provider name to match our conventions
+		local norm_provider
+		case "$provider" in
+		anthropic) norm_provider="Anthropic" ;;
+		openai) norm_provider="OpenAI" ;;
+		google) norm_provider="Google" ;;
+		openrouter) norm_provider="OpenRouter" ;;
+		groq) norm_provider="Groq" ;;
+		deepseek) norm_provider="DeepSeek" ;;
+		opencode) norm_provider="OpenCode" ;;
+		*) norm_provider="$provider" ;;
+		esac
 
-        sql_batch="${sql_batch}
+		sql_batch="${sql_batch}
             INSERT INTO provider_models (model_id, provider, in_registry, in_subagents, discovered_at)
             VALUES (
                 '$(sql_escape "$full_id")',
@@ -457,20 +457,20 @@ sync_opencode() {
             )
             ON CONFLICT(model_id, provider) DO UPDATE SET
                 discovered_at = excluded.discovered_at;"
-        added=$((added + 1))
-    done <<< "$model_ids"
-    sql_batch="${sql_batch} COMMIT;"
+		added=$((added + 1))
+	done <<<"$model_ids"
+	sql_batch="${sql_batch} COMMIT;"
 
-    # Execute batch insert
-    db_query "$sql_batch"
+	# Execute batch insert
+	db_query "$sql_batch"
 
-    db_query "
+	db_query "
         INSERT INTO sync_log (sync_type, source, models_added, models_updated, details)
         VALUES ('opencode', 'opencode-models', $added, 0, 'Discovered from OpenCode model registry');
     "
 
-    print_info "OpenCode sync: $added models discovered"
-    return 0
+	print_info "OpenCode sync: $added models discovered"
+	return 0
 }
 
 # =============================================================================
@@ -480,120 +480,120 @@ sync_opencode() {
 # Requires individual provider API keys in environment.
 
 sync_providers() {
-    local added=0
+	local added=0
 
-    # Skip if opencode sync already ran successfully (check sync_log)
-    local opencode_synced
-    opencode_synced=$(db_query "
+	# Skip if opencode sync already ran successfully (check sync_log)
+	local opencode_synced
+	opencode_synced=$(db_query "
         SELECT models_added FROM sync_log
         WHERE sync_type = 'opencode'
         AND (julianday('now') - julianday(timestamp)) * 86400 < 60
         ORDER BY id DESC LIMIT 1;
     " 2>/dev/null || echo "")
-    
-    # If recent successful sync, skip
-    if [[ -n "$opencode_synced" && "$opencode_synced" != "0" ]]; then
-        return 0
-    fi
-    if [[ -n "$opencode_synced" && "$opencode_synced" -gt 0 ]]; then
-        print_info "Skipping direct API probing (OpenCode sync already discovered $opencode_synced models)"
-        return 0
-    fi
 
-    # Reuse provider key detection from compare-models-helper.sh
-    local provider_env_keys="Anthropic|ANTHROPIC_API_KEY
+	# If recent successful sync, skip
+	if [[ -n "$opencode_synced" && "$opencode_synced" != "0" ]]; then
+		return 0
+	fi
+	if [[ -n "$opencode_synced" && "$opencode_synced" -gt 0 ]]; then
+		print_info "Skipping direct API probing (OpenCode sync already discovered $opencode_synced models)"
+		return 0
+	fi
+
+	# Reuse provider key detection from compare-models-helper.sh
+	local provider_env_keys="Anthropic|ANTHROPIC_API_KEY
 OpenAI|OPENAI_API_KEY
 Google|GOOGLE_API_KEY,GEMINI_API_KEY
 OpenRouter|OPENROUTER_API_KEY
 Groq|GROQ_API_KEY
 DeepSeek|DEEPSEEK_API_KEY"
 
-    while IFS= read -r pline; do
-        local provider key_names
-        provider=$(echo "$pline" | cut -d'|' -f1)
-        key_names=$(echo "$pline" | cut -d'|' -f2)
+	while IFS= read -r pline; do
+		local provider key_names
+		provider=$(echo "$pline" | cut -d'|' -f1)
+		key_names=$(echo "$pline" | cut -d'|' -f2)
 
-        local key_value=""
-        local -a keys
-        IFS=',' read -ra keys <<< "$key_names"
-        for key_name in "${keys[@]}"; do
-            if [[ -n "${!key_name:-}" ]]; then
-                key_value="${!key_name}"
-                break
-            fi
-        done
+		local key_value=""
+		local -a keys
+		IFS=',' read -ra keys <<<"$key_names"
+		for key_name in "${keys[@]}"; do
+			if [[ -n "${!key_name:-}" ]]; then
+				key_value="${!key_name}"
+				break
+			fi
+		done
 
-        [[ -z "$key_value" ]] && continue
+		[[ -z "$key_value" ]] && continue
 
-        local models_json=""
-        case "$provider" in
-            Anthropic)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "x-api-key: ${key_value}" \
-                    -H "anthropic-version: 2023-06-01" \
-                    "https://api.anthropic.com/v1/models" 2>/dev/null) || continue
-                ;;
-            OpenAI)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "Authorization: Bearer ${key_value}" \
-                    "https://api.openai.com/v1/models" 2>/dev/null) || continue
-                ;;
-            Google)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    "https://generativelanguage.googleapis.com/v1beta/models?key=${key_value}" 2>/dev/null) || continue
-                ;;
-            OpenRouter)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "Authorization: Bearer ${key_value}" \
-                    "https://openrouter.ai/api/v1/models" 2>/dev/null) || continue
-                ;;
-            Groq)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "Authorization: Bearer ${key_value}" \
-                    "https://api.groq.com/openai/v1/models" 2>/dev/null) || continue
-                ;;
-            DeepSeek)
-                models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
-                    -H "Authorization: Bearer ${key_value}" \
-                    "https://api.deepseek.com/v1/models" 2>/dev/null) || continue
-                ;;
-            *)
-                continue
-                ;;
-        esac
+		local models_json=""
+		case "$provider" in
+		Anthropic)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "x-api-key: ${key_value}" \
+				-H "anthropic-version: 2023-06-01" \
+				"https://api.anthropic.com/v1/models" 2>/dev/null) || continue
+			;;
+		OpenAI)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "Authorization: Bearer ${key_value}" \
+				"https://api.openai.com/v1/models" 2>/dev/null) || continue
+			;;
+		Google)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				"https://generativelanguage.googleapis.com/v1beta/models?key=${key_value}" 2>/dev/null) || continue
+			;;
+		OpenRouter)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "Authorization: Bearer ${key_value}" \
+				"https://openrouter.ai/api/v1/models" 2>/dev/null) || continue
+			;;
+		Groq)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "Authorization: Bearer ${key_value}" \
+				"https://api.groq.com/openai/v1/models" 2>/dev/null) || continue
+			;;
+		DeepSeek)
+			models_json=$(curl -s --max-time "$DEFAULT_TIMEOUT" \
+				-H "Authorization: Bearer ${key_value}" \
+				"https://api.deepseek.com/v1/models" 2>/dev/null) || continue
+			;;
+		*)
+			continue
+			;;
+		esac
 
-        [[ -z "$models_json" ]] && continue
+		[[ -z "$models_json" ]] && continue
 
-        # Extract model IDs
-        local model_ids=""
-        case "$provider" in
-            Google)
-                model_ids=$(echo "$models_json" | jq -r '.models[].name // empty' 2>/dev/null | sed 's|^models/||' | sort) || continue
-                ;;
-            *)
-                model_ids=$(echo "$models_json" | jq -r '.data[].id // empty' 2>/dev/null | sort) || continue
-                ;;
-        esac
+		# Extract model IDs
+		local model_ids=""
+		case "$provider" in
+		Google)
+			model_ids=$(echo "$models_json" | jq -r '.models[].name // empty' 2>/dev/null | sed 's|^models/||' | sort) || continue
+			;;
+		*)
+			model_ids=$(echo "$models_json" | jq -r '.data[].id // empty' 2>/dev/null | sort) || continue
+			;;
+		esac
 
-        [[ -z "$model_ids" ]] && continue
+		[[ -z "$model_ids" ]] && continue
 
-        local provider_count=0
-        while IFS= read -r mid; do
-            [[ -z "$mid" ]] && continue
+		local provider_count=0
+		while IFS= read -r mid; do
+			[[ -z "$mid" ]] && continue
 
-            # Check if this model is in our registry
-            local in_registry
-            in_registry=$(db_query "SELECT COUNT(*) FROM models WHERE model_id LIKE '%$(sql_escape "$mid")%' AND provider='$(sql_escape "$provider")';")
-            local in_reg_flag=0
-            [[ "$in_registry" -gt 0 ]] && in_reg_flag=1
+			# Check if this model is in our registry
+			local in_registry
+			in_registry=$(db_query "SELECT COUNT(*) FROM models WHERE model_id LIKE '%$(sql_escape "$mid")%' AND provider='$(sql_escape "$provider")';")
+			local in_reg_flag=0
+			[[ "$in_registry" -gt 0 ]] && in_reg_flag=1
 
-            # Check if referenced in subagents
-            local in_subagents
-            in_subagents=$(db_query "SELECT COUNT(*) FROM subagent_models WHERE model_full_id LIKE '%$(sql_escape "$mid")%';")
-            local in_sub_flag=0
-            [[ "$in_subagents" -gt 0 ]] && in_sub_flag=1
+			# Check if referenced in subagents
+			local in_subagents
+			in_subagents=$(db_query "SELECT COUNT(*) FROM subagent_models WHERE model_full_id LIKE '%$(sql_escape "$mid")%';")
+			local in_sub_flag=0
+			[[ "$in_subagents" -gt 0 ]] && in_sub_flag=1
 
-            db_query "
+			db_query "
                 INSERT INTO provider_models (model_id, provider, in_registry, in_subagents, discovered_at)
                 VALUES (
                     '$(sql_escape "$mid")',
@@ -607,20 +607,20 @@ DeepSeek|DEEPSEEK_API_KEY"
                     in_subagents = excluded.in_subagents,
                     discovered_at = excluded.discovered_at;
             "
-            provider_count=$((provider_count + 1))
-        done <<< "$model_ids"
+			provider_count=$((provider_count + 1))
+		done <<<"$model_ids"
 
-        added=$((added + provider_count))
-        print_info "  $provider: $provider_count models discovered"
-    done <<< "$provider_env_keys"
+		added=$((added + provider_count))
+		print_info "  $provider: $provider_count models discovered"
+	done <<<"$provider_env_keys"
 
-    db_query "
+	db_query "
         INSERT INTO sync_log (sync_type, source, models_added, models_updated, details)
         VALUES ('provider_api', 'live', $added, 0, 'Discovered from provider APIs');
     "
 
-    print_info "Provider sync: $added total models discovered from APIs"
-    return 0
+	print_info "Provider sync: $added total models discovered from APIs"
+	return 0
 }
 
 # =============================================================================
@@ -628,443 +628,473 @@ DeepSeek|DEEPSEEK_API_KEY"
 # =============================================================================
 
 cmd_sync() {
-    local force=false
-    local quiet=false
+	local force=false
+	local quiet=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --force) force=true; shift ;;
-            --quiet) quiet=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--force)
+			force=true
+			shift
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    # Check if sync is needed
-    if [[ "$force" != "true" ]]; then
-        local last_sync
-        last_sync=$(db_query "SELECT timestamp FROM sync_log ORDER BY id DESC LIMIT 1;" 2>/dev/null || echo "")
-        if [[ -n "$last_sync" ]]; then
-            local last_epoch now_epoch
-            if [[ "$(uname)" == "Darwin" ]]; then
-                last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
-            else
-                last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
-            fi
-            now_epoch=$(date "+%s")
-            local age=$((now_epoch - last_epoch))
-            if [[ $age -lt $SYNC_INTERVAL ]]; then
-                local hours_ago=$((age / 3600))
-                [[ "$quiet" != "true" ]] && print_info "Registry synced ${hours_ago}h ago (interval: $((SYNC_INTERVAL / 3600))h). Use --force to resync."
-                return 0
-            fi
-        fi
-    fi
+	# Check if sync is needed
+	if [[ "$force" != "true" ]]; then
+		local last_sync
+		last_sync=$(db_query "SELECT timestamp FROM sync_log ORDER BY id DESC LIMIT 1;" 2>/dev/null || echo "")
+		if [[ -n "$last_sync" ]]; then
+			local last_epoch now_epoch
+			if [[ "$(uname)" == "Darwin" ]]; then
+				last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
+			else
+				last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
+			fi
+			now_epoch=$(date "+%s")
+			local age=$((now_epoch - last_epoch))
+			if [[ $age -lt $SYNC_INTERVAL ]]; then
+				local hours_ago=$((age / 3600))
+				[[ "$quiet" != "true" ]] && print_info "Registry synced ${hours_ago}h ago (interval: $((SYNC_INTERVAL / 3600))h). Use --force to resync."
+				return 0
+			fi
+		fi
+	fi
 
-    [[ "$quiet" != "true" ]] && echo ""
-    [[ "$quiet" != "true" ]] && echo "Model Registry Sync"
-    [[ "$quiet" != "true" ]] && echo "==================="
-    [[ "$quiet" != "true" ]] && echo ""
+	[[ "$quiet" != "true" ]] && echo ""
+	[[ "$quiet" != "true" ]] && echo "Model Registry Sync"
+	[[ "$quiet" != "true" ]] && echo "==================="
+	[[ "$quiet" != "true" ]] && echo ""
 
-    # Backup before sync
-    if [[ -f "$REGISTRY_DB" ]]; then
-        backup_sqlite_db "$REGISTRY_DB" "pre-sync" >/dev/null 2>&1 || true
-    fi
+	# Backup before sync
+	if [[ -f "$REGISTRY_DB" ]]; then
+		backup_sqlite_db "$REGISTRY_DB" "pre-sync" >/dev/null 2>&1 || true
+	fi
 
-    # Phase 1: Sync subagent frontmatter
-    [[ "$quiet" != "true" ]] && print_info "Phase 1: Syncing subagent frontmatter..."
-    sync_subagents
+	# Phase 1: Sync subagent frontmatter
+	[[ "$quiet" != "true" ]] && print_info "Phase 1: Syncing subagent frontmatter..."
+	sync_subagents
 
-    # Phase 2: Sync embedded model data
-    [[ "$quiet" != "true" ]] && print_info "Phase 2: Syncing embedded model data..."
-    sync_embedded
+	# Phase 2: Sync embedded model data
+	[[ "$quiet" != "true" ]] && print_info "Phase 2: Syncing embedded model data..."
+	sync_embedded
 
-    # Phase 3: Sync from OpenCode model registry (preferred — fast, no API keys needed)
-    [[ "$quiet" != "true" ]] && print_info "Phase 3: Discovering models from OpenCode registry..."
-    sync_opencode
+	# Phase 3: Sync from OpenCode model registry (preferred — fast, no API keys needed)
+	[[ "$quiet" != "true" ]] && print_info "Phase 3: Discovering models from OpenCode registry..."
+	sync_opencode
 
-    # Phase 4: Fallback to direct provider API probing (skipped if Phase 3 succeeded)
-    [[ "$quiet" != "true" ]] && print_info "Phase 4: Direct provider API discovery (fallback)..."
-    sync_providers
+	# Phase 4: Fallback to direct provider API probing (skipped if Phase 3 succeeded)
+	[[ "$quiet" != "true" ]] && print_info "Phase 4: Direct provider API discovery (fallback)..."
+	sync_providers
 
-    # Cleanup old backups
-    cleanup_sqlite_backups "$REGISTRY_DB" 3
+	# Cleanup old backups
+	cleanup_sqlite_backups "$REGISTRY_DB" 3
 
-    [[ "$quiet" != "true" ]] && echo ""
-    [[ "$quiet" != "true" ]] && print_success "Registry sync complete"
-    return 0
+	[[ "$quiet" != "true" ]] && echo ""
+	[[ "$quiet" != "true" ]] && print_success "Registry sync complete"
+	return 0
 }
 
 cmd_list() {
-    local json_flag=false
-    local filter_provider=""
-    local filter_tier=""
+	local json_flag=false
+	local filter_provider=""
+	local filter_tier=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            --provider) filter_provider="${2:-}"; shift 2 ;;
-            --tier) filter_tier="${2:-}"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		--provider)
+			filter_provider="${2:-}"
+			shift 2
+			;;
+		--tier)
+			filter_tier="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    local where_clause="WHERE 1=1"
-    [[ -n "$filter_provider" ]] && where_clause="$where_clause AND provider='$(sql_escape "$filter_provider")'"
-    [[ -n "$filter_tier" ]] && where_clause="$where_clause AND tier='$(sql_escape "$filter_tier")'"
+	local where_clause="WHERE 1=1"
+	[[ -n "$filter_provider" ]] && where_clause="$where_clause AND provider='$(sql_escape "$filter_provider")'"
+	[[ -n "$filter_tier" ]] && where_clause="$where_clause AND tier='$(sql_escape "$filter_tier")'"
 
-    if [[ "$json_flag" == "true" ]]; then
-        db_query_json "
+	if [[ "$json_flag" == "true" ]]; then
+		db_query_json "
             SELECT model_id, provider, display_name, context_window, input_price, output_price,
                    tier, capabilities, status, deprecated, last_seen
             FROM models $where_clause
             ORDER BY provider, input_price;
         "
-        return $?
-    fi
+		return $?
+	fi
 
-    echo ""
-    echo "Model Registry"
-    echo "=============="
-    echo ""
+	echo ""
+	echo "Model Registry"
+	echo "=============="
+	echo ""
 
-    local count
-    count=$(db_query "SELECT COUNT(*) FROM models $where_clause;")
+	local count
+	count=$(db_query "SELECT COUNT(*) FROM models $where_clause;")
 
-    if [[ "$count" -eq 0 ]]; then
-        print_warning "Registry is empty. Run 'model-registry-helper.sh sync' first."
-        return 0
-    fi
+	if [[ "$count" -eq 0 ]]; then
+		print_warning "Registry is empty. Run 'model-registry-helper.sh sync' first."
+		return 0
+	fi
 
-    printf "%-24s %-10s %-8s %-10s %-10s %-7s %-8s\n" \
-        "Model" "Provider" "Context" "In/1M" "Out/1M" "Tier" "Status"
-    printf "%-24s %-10s %-8s %-10s %-10s %-7s %-8s\n" \
-        "-----" "--------" "-------" "-----" "------" "----" "------"
+	printf "%-24s %-10s %-8s %-10s %-10s %-7s %-8s\n" \
+		"Model" "Provider" "Context" "In/1M" "Out/1M" "Tier" "Status"
+	printf "%-24s %-10s %-8s %-10s %-10s %-7s %-8s\n" \
+		"-----" "--------" "-------" "-----" "------" "----" "------"
 
-    db_query "
+	db_query "
         SELECT model_id, provider, context_window, input_price, output_price, tier, status, deprecated
         FROM models $where_clause
         ORDER BY provider, input_price;
     " | while IFS='|' read -r mid prov ctx inp outp tier stat dep; do
-        local ctx_fmt
-        if [[ "$ctx" -ge 1000000 ]]; then
-            ctx_fmt="1M"
-        elif [[ "$ctx" -ge 500000 ]]; then
-            ctx_fmt="512K"
-        elif [[ "$ctx" -ge 200000 ]]; then
-            ctx_fmt="200K"
-        elif [[ "$ctx" -ge 128000 ]]; then
-            ctx_fmt="128K"
-        else
-            ctx_fmt="${ctx}"
-        fi
+		local ctx_fmt
+		if [[ "$ctx" -ge 1000000 ]]; then
+			ctx_fmt="1M"
+		elif [[ "$ctx" -ge 500000 ]]; then
+			ctx_fmt="512K"
+		elif [[ "$ctx" -ge 200000 ]]; then
+			ctx_fmt="200K"
+		elif [[ "$ctx" -ge 128000 ]]; then
+			ctx_fmt="128K"
+		else
+			ctx_fmt="${ctx}"
+		fi
 
-        local status_display="$stat"
-        [[ "$dep" == "1" ]] && status_display="DEPR"
+		local status_display="$stat"
+		[[ "$dep" == "1" ]] && status_display="DEPR"
 
-        printf "%-24s %-10s %-8s \$%-9s \$%-9s %-7s %-8s\n" \
-            "$mid" "$prov" "$ctx_fmt" "$inp" "$outp" "$tier" "$status_display"
-    done
+		printf "%-24s %-10s %-8s \$%-9s \$%-9s %-7s %-8s\n" \
+			"$mid" "$prov" "$ctx_fmt" "$inp" "$outp" "$tier" "$status_display"
+	done
 
-    echo ""
-    echo "Total: $count models"
-    return 0
+	echo ""
+	echo "Total: $count models"
+	return 0
 }
 
 cmd_status() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ ! -f "$REGISTRY_DB" ]]; then
-        print_warning "Registry not initialized. Run 'model-registry-helper.sh sync' first."
-        return 0
-    fi
+	if [[ ! -f "$REGISTRY_DB" ]]; then
+		print_warning "Registry not initialized. Run 'model-registry-helper.sh sync' first."
+		return 0
+	fi
 
-    local total_models total_providers total_subagents total_provider_models
-    local last_sync deprecated_count
+	local total_models total_providers total_subagents total_provider_models
+	local last_sync deprecated_count
 
-    total_models=$(db_query "SELECT COUNT(*) FROM models;")
-    total_providers=$(db_query "SELECT COUNT(DISTINCT provider) FROM models;")
-    total_subagents=$(db_query "SELECT COUNT(*) FROM subagent_models;")
-    total_provider_models=$(db_query "SELECT COUNT(*) FROM provider_models;")
-    deprecated_count=$(db_query "SELECT COUNT(*) FROM models WHERE deprecated=1;")
-    last_sync=$(db_query "SELECT timestamp FROM sync_log ORDER BY id DESC LIMIT 1;" || echo "never")
+	total_models=$(db_query "SELECT COUNT(*) FROM models;")
+	total_providers=$(db_query "SELECT COUNT(DISTINCT provider) FROM models;")
+	total_subagents=$(db_query "SELECT COUNT(*) FROM subagent_models;")
+	total_provider_models=$(db_query "SELECT COUNT(*) FROM provider_models;")
+	deprecated_count=$(db_query "SELECT COUNT(*) FROM models WHERE deprecated=1;")
+	last_sync=$(db_query "SELECT timestamp FROM sync_log ORDER BY id DESC LIMIT 1;" || echo "never")
 
-    # Calculate staleness
-    local staleness="unknown"
-    if [[ -n "$last_sync" && "$last_sync" != "never" ]]; then
-        local last_epoch now_epoch
-        if [[ "$(uname)" == "Darwin" ]]; then
-            last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
-        else
-            last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
-        fi
-        now_epoch=$(date "+%s")
-        local age=$((now_epoch - last_epoch))
-        if [[ $age -lt 3600 ]]; then
-            staleness="fresh ($((age / 60))m ago)"
-        elif [[ $age -lt 86400 ]]; then
-            staleness="recent ($((age / 3600))h ago)"
-        else
-            staleness="stale ($((age / 86400))d ago)"
-        fi
-    fi
+	# Calculate staleness
+	local staleness="unknown"
+	if [[ -n "$last_sync" && "$last_sync" != "never" ]]; then
+		local last_epoch now_epoch
+		if [[ "$(uname)" == "Darwin" ]]; then
+			last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_sync" "+%s" 2>/dev/null || echo "0")
+		else
+			last_epoch=$(date -d "$last_sync" "+%s" 2>/dev/null || echo "0")
+		fi
+		now_epoch=$(date "+%s")
+		local age=$((now_epoch - last_epoch))
+		if [[ $age -lt 3600 ]]; then
+			staleness="fresh ($((age / 60))m ago)"
+		elif [[ $age -lt 86400 ]]; then
+			staleness="recent ($((age / 3600))h ago)"
+		else
+			staleness="stale ($((age / 86400))d ago)"
+		fi
+	fi
 
-    if [[ "$json_flag" == "true" ]]; then
-        echo "{\"total_models\":$total_models,\"total_providers\":$total_providers,\"subagent_tiers\":$total_subagents,\"provider_models_discovered\":$total_provider_models,\"deprecated\":$deprecated_count,\"last_sync\":\"$last_sync\",\"staleness\":\"$staleness\"}"
-        return 0
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		echo "{\"total_models\":$total_models,\"total_providers\":$total_providers,\"subagent_tiers\":$total_subagents,\"provider_models_discovered\":$total_provider_models,\"deprecated\":$deprecated_count,\"last_sync\":\"$last_sync\",\"staleness\":\"$staleness\"}"
+		return 0
+	fi
 
-    echo ""
-    echo "Model Registry Status"
-    echo "====================="
-    echo ""
-    echo "  Registry models:     $total_models"
-    echo "  Providers:           $total_providers"
-    echo "  Subagent tiers:      $total_subagents"
-    echo "  API-discovered:      $total_provider_models"
-    echo "  Deprecated:          $deprecated_count"
-    echo "  Last sync:           ${last_sync:-never}"
-    echo "  Staleness:           $staleness"
-    echo ""
+	echo ""
+	echo "Model Registry Status"
+	echo "====================="
+	echo ""
+	echo "  Registry models:     $total_models"
+	echo "  Providers:           $total_providers"
+	echo "  Subagent tiers:      $total_subagents"
+	echo "  API-discovered:      $total_provider_models"
+	echo "  Deprecated:          $deprecated_count"
+	echo "  Last sync:           ${last_sync:-never}"
+	echo "  Staleness:           $staleness"
+	echo ""
 
-    # Show subagent tier mapping
-    echo "Subagent Tier Mapping:"
-    echo ""
-    printf "  %-8s %-24s %-36s %-24s\n" "Tier" "Model" "Full ID" "Fallback"
-    printf "  %-8s %-24s %-36s %-24s\n" "----" "-----" "-------" "--------"
+	# Show subagent tier mapping
+	echo "Subagent Tier Mapping:"
+	echo ""
+	printf "  %-8s %-24s %-36s %-24s\n" "Tier" "Model" "Full ID" "Fallback"
+	printf "  %-8s %-24s %-36s %-24s\n" "----" "-----" "-------" "--------"
 
-    db_query "SELECT tier, model_id, model_full_id, fallback_id FROM subagent_models ORDER BY tier;" | \
-    while IFS='|' read -r tier mid full_id fallback; do
-        printf "  %-8s %-24s %-36s %-24s\n" "$tier" "$mid" "$full_id" "$fallback"
-    done
+	db_query "SELECT tier, model_id, model_full_id, fallback_id FROM subagent_models ORDER BY tier;" |
+		while IFS='|' read -r tier mid full_id fallback; do
+			printf "  %-8s %-24s %-36s %-24s\n" "$tier" "$mid" "$full_id" "$fallback"
+		done
 
-    echo ""
+	echo ""
 
-    # Show recent sync log
-    echo "Recent Sync History:"
-    echo ""
-    db_query "
+	# Show recent sync log
+	echo "Recent Sync History:"
+	echo ""
+	db_query "
         SELECT timestamp, sync_type, source, models_added, models_updated
         FROM sync_log ORDER BY id DESC LIMIT 5;
     " | while IFS='|' read -r ts stype src added updated; do
-        echo "  $ts  $stype ($src): +$added ~$updated"
-    done
+		echo "  $ts  $stype ($src): +$added ~$updated"
+	done
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 cmd_check() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    echo ""
-    echo "Model Availability Check"
-    echo "========================"
-    echo ""
+	echo ""
+	echo "Model Availability Check"
+	echo "========================"
+	echo ""
 
-    # Check each subagent model against provider APIs
-    local issues=0
+	# Check each subagent model against provider APIs
+	local issues=0
 
-    db_query "SELECT tier, model_id, model_full_id, fallback_id FROM subagent_models;" | \
-    while IFS='|' read -r tier mid full_id fallback; do
-        local provider
-        provider=$(echo "$full_id" | cut -d'/' -f1)
+	db_query "SELECT tier, model_id, model_full_id, fallback_id FROM subagent_models;" |
+		while IFS='|' read -r tier mid full_id fallback; do
+			local provider
+			provider=$(echo "$full_id" | cut -d'/' -f1)
 
-        # Get normalized name for this subagent model
-        local norm_name
-        norm_name=$(db_query "SELECT normalized_name FROM subagent_models WHERE tier='$(sql_escape "$tier")';" 2>/dev/null || echo "")
-        [[ -z "$norm_name" ]] && norm_name=$(normalize_model_name "$full_id")
+			# Get normalized name for this subagent model
+			local norm_name
+			norm_name=$(db_query "SELECT normalized_name FROM subagent_models WHERE tier='$(sql_escape "$tier")';" 2>/dev/null || echo "")
+			[[ -z "$norm_name" ]] && norm_name=$(normalize_model_name "$full_id")
 
-        # Check if model exists in provider_models (try both directions for fuzzy match)
-        local found
-        found=$(db_query "
+			# Check if model exists in provider_models (try both directions for fuzzy match)
+			local found
+			found=$(db_query "
             SELECT COUNT(*) FROM provider_models
             WHERE (model_id LIKE '%$(sql_escape "$mid")%'
                    OR '$(sql_escape "$mid")' LIKE '%' || model_id || '%')
             AND provider LIKE '%$(sql_escape "$provider")%';
         " 2>/dev/null || echo "0")
 
-        local status_icon="Y"
-        local status_text="available"
+			local status_icon="Y"
+			local status_text="available"
 
-        if [[ "$found" -eq 0 ]]; then
-            # Not found in API discovery - check embedded registry via normalized name
-            local in_embedded
-            in_embedded=$(db_query "
+			if [[ "$found" -eq 0 ]]; then
+				# Not found in API discovery - check embedded registry via normalized name
+				local in_embedded
+				in_embedded=$(db_query "
                 SELECT COUNT(*) FROM models
                 WHERE normalized_name = '$(sql_escape "$norm_name")'
                    OR model_id LIKE '%$(sql_escape "$mid")%'
                    OR '$(sql_escape "$mid")' LIKE '%' || model_id || '%';
             " 2>/dev/null || echo "0")
 
-            if [[ "$in_embedded" -gt 0 ]]; then
-                status_icon="?"
-                status_text="in registry, not verified via API"
-            else
-                status_icon="!"
-                status_text="NOT FOUND in registry or API"
-                issues=$((issues + 1))
-            fi
-        fi
+				if [[ "$in_embedded" -gt 0 ]]; then
+					status_icon="?"
+					status_text="in registry, not verified via API"
+				else
+					status_icon="!"
+					status_text="NOT FOUND in registry or API"
+					issues=$((issues + 1))
+				fi
+			fi
 
-        printf "  %s %-8s %-36s %s\n" "$status_icon" "$tier" "$full_id" "$status_text"
-    done
+			printf "  %s %-8s %-36s %s\n" "$status_icon" "$tier" "$full_id" "$status_text"
+		done
 
-    echo ""
-    if [[ $issues -gt 0 ]]; then
-        print_warning "$issues model(s) have availability issues"
-    else
-        print_success "All configured models appear available"
-    fi
-    echo ""
-    return 0
+	echo ""
+	if [[ $issues -gt 0 ]]; then
+		print_warning "$issues model(s) have availability issues"
+	else
+		print_success "All configured models appear available"
+	fi
+	echo ""
+	return 0
 }
 
 cmd_suggest() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    echo ""
-    echo "Model Suggestions"
-    echo "================="
-    echo ""
-    echo "Models discovered from provider APIs but not in the registry:"
-    echo ""
+	echo ""
+	echo "Model Suggestions"
+	echo "================="
+	echo ""
+	echo "Models discovered from provider APIs but not in the registry:"
+	echo ""
 
-    local count=0
-    db_query "
+	local count=0
+	db_query "
         SELECT pm.model_id, pm.provider, pm.discovered_at
         FROM provider_models pm
         WHERE pm.in_registry = 0
         AND pm.in_subagents = 0
         ORDER BY pm.provider, pm.model_id;
     " | while IFS='|' read -r mid prov discovered; do
-        # Filter to interesting models (skip internal/deprecated-looking ones)
-        case "$mid" in
-            *embed*|*tts*|*whisper*|*dall-e*|*moderation*|*babbage*|*davinci-00*|*search*|*instruct*|*realtime*)
-                continue
-                ;;
-        esac
-        echo "  [$prov] $mid (discovered: $discovered)"
-        count=$((count + 1))
-    done
+		# Filter to interesting models (skip internal/deprecated-looking ones)
+		case "$mid" in
+		*embed* | *tts* | *whisper* | *dall-e* | *moderation* | *babbage* | *davinci-00* | *search* | *instruct* | *realtime*)
+			continue
+			;;
+		esac
+		echo "  [$prov] $mid (discovered: $discovered)"
+		count=$((count + 1))
+	done
 
-    echo ""
-    if [[ $count -eq 0 ]]; then
-        print_info "No new model suggestions. Registry is up to date."
-    else
-        echo "  $count potential models found."
-        echo "  Review and add relevant ones to compare-models-helper.sh MODEL_DATA"
-        echo "  and create subagent files in $MODELS_DIR/ as needed."
-    fi
-    echo ""
-    return 0
+	echo ""
+	if [[ $count -eq 0 ]]; then
+		print_info "No new model suggestions. Registry is up to date."
+	else
+		echo "  $count potential models found."
+		echo "  Review and add relevant ones to compare-models-helper.sh MODEL_DATA"
+		echo "  and create subagent files in $MODELS_DIR/ as needed."
+	fi
+	echo ""
+	return 0
 }
 
 cmd_deprecations() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    echo ""
-    echo "Deprecated/Unavailable Models"
-    echo "============================="
-    echo ""
+	echo ""
+	echo "Deprecated/Unavailable Models"
+	echo "============================="
+	echo ""
 
-    local dep_count
-    dep_count=$(db_query "SELECT COUNT(*) FROM models WHERE deprecated=1;")
+	local dep_count
+	dep_count=$(db_query "SELECT COUNT(*) FROM models WHERE deprecated=1;")
 
-    if [[ "$dep_count" -eq 0 ]]; then
-        print_info "No deprecated models found in registry."
-        echo ""
+	if [[ "$dep_count" -eq 0 ]]; then
+		print_info "No deprecated models found in registry."
+		echo ""
 
-        # Check for models in subagents that aren't in provider APIs
-        echo "Models in subagents not confirmed by provider APIs:"
-        echo ""
-        local unconfirmed=0
-        db_query "SELECT tier, model_id, model_full_id FROM subagent_models;" | \
-        while IFS='|' read -r tier mid full_id; do
-            local short_id
-            short_id="${full_id#*/}"
-            local api_found
-            api_found=$(db_query "
+		# Check for models in subagents that aren't in provider APIs
+		echo "Models in subagents not confirmed by provider APIs:"
+		echo ""
+		local unconfirmed=0
+		db_query "SELECT tier, model_id, model_full_id FROM subagent_models;" |
+			while IFS='|' read -r tier mid full_id; do
+				local short_id
+				short_id="${full_id#*/}"
+				local api_found
+				api_found=$(db_query "
                 SELECT COUNT(*) FROM provider_models
                 WHERE model_id = '$(sql_escape "$short_id")';
             " 2>/dev/null || echo "0")
 
-            if [[ "$api_found" -eq 0 ]]; then
-                echo "  ! [$tier] $full_id - not found in API discovery"
-                unconfirmed=$((unconfirmed + 1))
-            fi
-        done
+				if [[ "$api_found" -eq 0 ]]; then
+					echo "  ! [$tier] $full_id - not found in API discovery"
+					unconfirmed=$((unconfirmed + 1))
+				fi
+			done
 
-        if [[ $unconfirmed -eq 0 ]]; then
-            print_info "  All subagent models confirmed via API discovery."
-        fi
-    else
-        db_query "
+		if [[ $unconfirmed -eq 0 ]]; then
+			print_info "  All subagent models confirmed via API discovery."
+		fi
+	else
+		db_query "
             SELECT model_id, provider, deprecation_note, last_seen
             FROM models WHERE deprecated=1
             ORDER BY provider, model_id;
         " | while IFS='|' read -r mid prov note last; do
-            echo "  ! $mid ($prov)"
-            [[ -n "$note" ]] && echo "    Note: $note"
-            echo "    Last seen: $last"
-        done
-    fi
+			echo "  ! $mid ($prov)"
+			[[ -n "$note" ]] && echo "    Note: $note"
+			echo "    Last seen: $last"
+		done
+	fi
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 cmd_diff() {
-    local json_flag=false
+	local json_flag=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    echo ""
-    echo "Registry vs Local Config Diff"
-    echo "=============================="
-    echo ""
+	echo ""
+	echo "Registry vs Local Config Diff"
+	echo "=============================="
+	echo ""
 
-    # Compare subagent models with registry
-    echo "Subagent Models vs Registry:"
-    echo ""
+	# Compare subagent models with registry
+	echo "Subagent Models vs Registry:"
+	echo ""
 
-    db_query "SELECT tier, model_id, model_full_id, normalized_name FROM subagent_models;" | \
-    while IFS='|' read -r tier mid full_id norm_name; do
-        [[ -z "$norm_name" ]] && norm_name=$(normalize_model_name "$full_id")
-        local reg_match
-        reg_match=$(db_query "
+	db_query "SELECT tier, model_id, model_full_id, normalized_name FROM subagent_models;" |
+		while IFS='|' read -r tier mid full_id norm_name; do
+			[[ -z "$norm_name" ]] && norm_name=$(normalize_model_name "$full_id")
+			local reg_match
+			reg_match=$(db_query "
             SELECT model_id, input_price, output_price
             FROM models
             WHERE normalized_name = '$(sql_escape "$norm_name")'
@@ -1073,26 +1103,26 @@ cmd_diff() {
             LIMIT 1;
         " 2>/dev/null || echo "")
 
-        if [[ -n "$reg_match" ]]; then
-            local reg_id reg_input reg_output
-            reg_id=$(echo "$reg_match" | cut -d'|' -f1)
-            reg_input=$(echo "$reg_match" | cut -d'|' -f2)
-            reg_output=$(echo "$reg_match" | cut -d'|' -f3)
-            printf "  = %-8s %-24s (registry: %s, \$%s/\$%s)\n" \
-                "$tier" "$full_id" "$reg_id" "$reg_input" "$reg_output"
-        else
-            printf "  ! %-8s %-24s (NOT in registry)\n" "$tier" "$full_id"
-        fi
-    done
+			if [[ -n "$reg_match" ]]; then
+				local reg_id reg_input reg_output
+				reg_id=$(echo "$reg_match" | cut -d'|' -f1)
+				reg_input=$(echo "$reg_match" | cut -d'|' -f2)
+				reg_output=$(echo "$reg_match" | cut -d'|' -f3)
+				printf "  = %-8s %-24s (registry: %s, \$%s/\$%s)\n" \
+					"$tier" "$full_id" "$reg_id" "$reg_input" "$reg_output"
+			else
+				printf "  ! %-8s %-24s (NOT in registry)\n" "$tier" "$full_id"
+			fi
+		done
 
-    echo ""
+	echo ""
 
-    # Show registry models not in subagents
-    echo "Registry Models Not in Subagents:"
-    echo ""
+	# Show registry models not in subagents
+	echo "Registry Models Not in Subagents:"
+	echo ""
 
-    local orphan_count=0
-    db_query "
+	local orphan_count=0
+	db_query "
         SELECT m.model_id, m.provider, m.tier
         FROM models m
         WHERE NOT EXISTS (
@@ -1103,184 +1133,208 @@ cmd_diff() {
         )
         ORDER BY m.provider, m.model_id;
     " | while IFS='|' read -r mid prov tier; do
-        printf "  + %-24s %-10s %-7s\n" "$mid" "$prov" "$tier"
-        orphan_count=$((orphan_count + 1))
-    done
+		printf "  + %-24s %-10s %-7s\n" "$mid" "$prov" "$tier"
+		orphan_count=$((orphan_count + 1))
+	done
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 cmd_export() {
-    local format="json"
+	local format="json"
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --csv) format="csv"; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--csv)
+			format="csv"
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    case "$format" in
-        csv)
-            db_query_csv "
+	case "$format" in
+	csv)
+		db_query_csv "
                 SELECT model_id, provider, display_name, context_window,
                        input_price, output_price, tier, capabilities,
                        best_for, status, deprecated, last_seen
                 FROM models ORDER BY provider, model_id;
             "
-            ;;
-        *)
-            db_query_json "
+		;;
+	*)
+		db_query_json "
                 SELECT model_id, provider, display_name, context_window,
                        input_price, output_price, tier, capabilities,
                        best_for, status, deprecated, last_seen
                 FROM models ORDER BY provider, model_id;
             "
-            ;;
-    esac
-    return $?
+		;;
+	esac
+	return $?
 }
 
 cmd_route() {
-    local description="$*"
-    local json_flag=false
+	local description="$*"
+	local json_flag=false
 
-    # Parse flags
-    local args=()
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --json) json_flag=true; shift ;;
-            *) args+=("$1"); shift ;;
-        esac
-    done
-    description="${args[*]}"
+	# Parse flags
+	local args=()
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			json_flag=true
+			shift
+			;;
+		*)
+			args+=("$1")
+			shift
+			;;
+		esac
+	done
+	description="${args[*]}"
 
-    if [[ -z "$description" ]]; then
-        echo ""
-        echo "Usage: model-registry-helper.sh route <task description>"
-        echo ""
-        echo "Examples:"
-        echo "  model-registry-helper.sh route 'rename variable X to Y'"
-        echo "  model-registry-helper.sh route 'design auth system architecture'"
-        echo "  model-registry-helper.sh route 'summarize this 200-page PDF'"
-        echo ""
-        return 1
-    fi
+	if [[ -z "$description" ]]; then
+		echo ""
+		echo "Usage: model-registry-helper.sh route <task description>"
+		echo ""
+		echo "Examples:"
+		echo "  model-registry-helper.sh route 'rename variable X to Y'"
+		echo "  model-registry-helper.sh route 'design auth system architecture'"
+		echo "  model-registry-helper.sh route 'summarize this 200-page PDF'"
+		echo ""
+		return 1
+	fi
 
-    local desc_lower
-    desc_lower=$(echo "$description" | tr '[:upper:]' '[:lower:]')
+	local desc_lower
+	desc_lower=$(echo "$description" | tr '[:upper:]' '[:lower:]')
 
-    local tier="sonnet"
-    local reason="Default tier for general development tasks"
-    local cost="1x"
+	local tier="sonnet"
+	local reason="Default tier for general development tasks"
+	local cost="1x"
 
-    # Opus indicators: architecture, design, security audit, novel, trade-off, evaluate
-    if echo "$desc_lower" | grep -qE 'architect|system.design|security.audit|novel|trade.?off|evaluat|complex.*(plan|design|decision)|from.scratch'; then
-        tier="opus"
-        reason="Complex reasoning, architecture, or novel problem-solving"
-        cost="3x"
-    # Haiku indicators: rename, format, classify, triage, commit message, simple
-    elif echo "$desc_lower" | grep -qE 'rename|reformat|classify|triage|commit.message|simple.*(text|transform)|extract.field|sort|prioriti[sz]e|route|tag|label'; then
-        tier="haiku"
-        reason="Simple classification, formatting, or text transform"
-        cost="0.25x"
-    # Flash indicators: summarize, large context, bulk, read, scan
-    elif echo "$desc_lower" | grep -qE 'summari[sz]e|large.*(file|context|document|pdf)|bulk|scan.*files|read.*all|200.page|overview|skim'; then
-        tier="flash"
-        reason="Large context processing or summarization"
-        cost="0.20x"
-    # Pro indicators: large codebase, many files, refactor across
-    elif echo "$desc_lower" | grep -qE 'large.codebase|500.file|many.files|refactor.across|entire.project|full.repo|cross.file'; then
-        tier="pro"
-        reason="Large codebase analysis requiring both context and reasoning"
-        cost="1.5x"
-    fi
+	# Opus indicators: architecture, design, security audit, novel, trade-off, evaluate
+	if echo "$desc_lower" | grep -qE 'architect|system.design|security.audit|novel|trade.?off|evaluat|complex.*(plan|design|decision)|from.scratch'; then
+		tier="opus"
+		reason="Complex reasoning, architecture, or novel problem-solving"
+		cost="3x"
+	# Haiku indicators: rename, format, classify, triage, commit message, simple
+	elif echo "$desc_lower" | grep -qE 'rename|reformat|classify|triage|commit.message|simple.*(text|transform)|extract.field|sort|prioriti[sz]e|route|tag|label'; then
+		tier="haiku"
+		reason="Simple classification, formatting, or text transform"
+		cost="0.25x"
+	# Flash indicators: summarize, large context, bulk, read, scan
+	elif echo "$desc_lower" | grep -qE 'summari[sz]e|large.*(file|context|document|pdf)|bulk|scan.*files|read.*all|200.page|overview|skim'; then
+		tier="flash"
+		reason="Large context processing or summarization"
+		cost="0.20x"
+	# Pro indicators: large codebase, many files, refactor across
+	elif echo "$desc_lower" | grep -qE 'large.codebase|500.file|many.files|refactor.across|entire.project|full.repo|cross.file'; then
+		tier="pro"
+		reason="Large codebase analysis requiring both context and reasoning"
+		cost="1.5x"
+	fi
 
-    # Look up the primary model for this tier from the registry
-    local primary_model=""
-    local fallback_model=""
-    primary_model=$(db_query "SELECT model_id FROM models WHERE tier = '$tier' AND is_primary = 1 LIMIT 1;" 2>/dev/null || echo "")
-    fallback_model=$(db_query "SELECT model_id FROM models WHERE tier = '$tier' AND is_fallback = 1 LIMIT 1;" 2>/dev/null || echo "")
+	# Look up the primary model for this tier from the registry
+	local primary_model=""
+	local fallback_model=""
+	primary_model=$(db_query "SELECT model_id FROM models WHERE tier = '$tier' AND is_primary = 1 LIMIT 1;" 2>/dev/null || echo "")
+	fallback_model=$(db_query "SELECT model_id FROM models WHERE tier = '$tier' AND is_fallback = 1 LIMIT 1;" 2>/dev/null || echo "")
 
-    # Defaults if registry is empty
-    case "$tier" in
-        haiku)   primary_model="${primary_model:-claude-3-5-haiku}"; fallback_model="${fallback_model:-gemini-2.5-flash}" ;;
-        flash)   primary_model="${primary_model:-gemini-2.5-flash}"; fallback_model="${fallback_model:-gpt-4.1-mini}" ;;
-        sonnet)  primary_model="${primary_model:-claude-sonnet-4}"; fallback_model="${fallback_model:-gpt-4.1}" ;;
-        pro)     primary_model="${primary_model:-gemini-2.5-pro}"; fallback_model="${fallback_model:-claude-sonnet-4}" ;;
-        opus)    primary_model="${primary_model:-claude-opus-4}"; fallback_model="${fallback_model:-o3}" ;;
-    esac
+	# Defaults if registry is empty
+	case "$tier" in
+	haiku)
+		primary_model="${primary_model:-claude-3-5-haiku}"
+		fallback_model="${fallback_model:-gemini-2.5-flash}"
+		;;
+	flash)
+		primary_model="${primary_model:-gemini-2.5-flash}"
+		fallback_model="${fallback_model:-gpt-4.1-mini}"
+		;;
+	sonnet)
+		primary_model="${primary_model:-claude-sonnet-4}"
+		fallback_model="${fallback_model:-gpt-4.1}"
+		;;
+	pro)
+		primary_model="${primary_model:-gemini-2.5-pro}"
+		fallback_model="${fallback_model:-claude-sonnet-4}"
+		;;
+	opus)
+		primary_model="${primary_model:-claude-opus-4}"
+		fallback_model="${fallback_model:-o3}"
+		;;
+	esac
 
-    if [[ "$json_flag" == "true" ]]; then
-        printf '{"tier":"%s","model":"%s","fallback":"%s","cost":"%s","reason":"%s"}\n' \
-            "$tier" "$primary_model" "$fallback_model" "$cost" "$reason"
-    else
-        echo ""
-        echo "Task: $description"
-        echo ""
-        echo "  Recommended tier:  $tier"
-        echo "  Primary model:     $primary_model"
-        echo "  Fallback model:    $fallback_model"
-        echo "  Relative cost:     $cost"
-        echo "  Reason:            $reason"
-        echo ""
-    fi
+	if [[ "$json_flag" == "true" ]]; then
+		printf '{"tier":"%s","model":"%s","fallback":"%s","cost":"%s","reason":"%s"}\n' \
+			"$tier" "$primary_model" "$fallback_model" "$cost" "$reason"
+	else
+		echo ""
+		echo "Task: $description"
+		echo ""
+		echo "  Recommended tier:  $tier"
+		echo "  Primary model:     $primary_model"
+		echo "  Fallback model:    $fallback_model"
+		echo "  Relative cost:     $cost"
+		echo "  Reason:            $reason"
+		echo ""
+	fi
 
-    return 0
+	return 0
 }
 
 cmd_help() {
-    echo ""
-    echo "Model Registry Helper - Provider/Model Registry with Periodic Sync"
-    echo "==================================================================="
-    echo ""
-    echo "Usage: model-registry-helper.sh [command] [options]"
-    echo ""
-    echo "Commands:"
-    echo "  sync          Sync registry from all sources (subagents, embedded data, APIs)"
-    echo "  list          List all models in the registry"
-    echo "  status        Show registry health, staleness, and tier mapping"
-    echo "  check         Check configured subagent models against registry/APIs"
-    echo "  suggest       Suggest new models discovered from APIs but not tracked"
-    echo "  deprecations  Show deprecated/renamed/unavailable models"
-    echo "  diff          Show differences between registry and local config"
-    echo "  route <desc>  Recommend optimal model tier for a task description"
-    echo "  export        Export registry data (JSON or CSV)"
-    echo "  help          Show this help"
-    echo ""
-    echo "Options:"
-    echo "  --json        Output in JSON format (list, status, export)"
-    echo "  --quiet       Suppress informational output (sync)"
-    echo "  --force       Force full resync even if cache is fresh (sync)"
-    echo "  --provider X  Filter by provider name (list)"
-    echo "  --tier X      Filter by tier (list)"
-    echo "  --csv         Export as CSV instead of JSON (export)"
-    echo ""
-    echo "Examples:"
-    echo "  model-registry-helper.sh sync                    # Full sync"
-    echo "  model-registry-helper.sh sync --force            # Force resync"
-    echo "  model-registry-helper.sh list                    # List all models"
-    echo "  model-registry-helper.sh list --provider Google  # Google models only"
-    echo "  model-registry-helper.sh status                  # Registry health"
-    echo "  model-registry-helper.sh check                   # Verify subagent models"
-    echo "  model-registry-helper.sh suggest                 # New model suggestions"
-    echo "  model-registry-helper.sh diff                    # Config vs registry"
-    echo "  model-registry-helper.sh route 'fix React bug'  # Recommend model tier"
-    echo "  model-registry-helper.sh export --json           # Export as JSON"
-    echo ""
-    echo "Integration:"
-    echo "  - Runs automatically on 'aidevops update'"
-    echo "  - Can be added to cron for periodic sync"
-    echo "  - Storage: $REGISTRY_DB"
-    echo ""
-    echo "Data Sources:"
-    echo "  1. Subagent frontmatter ($MODELS_DIR/*.md)"
-    echo "  2. Embedded data (compare-models-helper.sh MODEL_DATA)"
-    echo "  3. OpenCode model registry (opencode models — preferred, from models.dev)"
-    echo "  4. Provider APIs (Anthropic, OpenAI, Google, OpenRouter, Groq, DeepSeek)"
-    echo ""
-    return 0
+	echo ""
+	echo "Model Registry Helper - Provider/Model Registry with Periodic Sync"
+	echo "==================================================================="
+	echo ""
+	echo "Usage: model-registry-helper.sh [command] [options]"
+	echo ""
+	echo "Commands:"
+	echo "  sync          Sync registry from all sources (subagents, embedded data, APIs)"
+	echo "  list          List all models in the registry"
+	echo "  status        Show registry health, staleness, and tier mapping"
+	echo "  check         Check configured subagent models against registry/APIs"
+	echo "  suggest       Suggest new models discovered from APIs but not tracked"
+	echo "  deprecations  Show deprecated/renamed/unavailable models"
+	echo "  diff          Show differences between registry and local config"
+	echo "  route <desc>  Recommend optimal model tier for a task description"
+	echo "  export        Export registry data (JSON or CSV)"
+	echo "  help          Show this help"
+	echo ""
+	echo "Options:"
+	echo "  --json        Output in JSON format (list, status, export)"
+	echo "  --quiet       Suppress informational output (sync)"
+	echo "  --force       Force full resync even if cache is fresh (sync)"
+	echo "  --provider X  Filter by provider name (list)"
+	echo "  --tier X      Filter by tier (list)"
+	echo "  --csv         Export as CSV instead of JSON (export)"
+	echo ""
+	echo "Examples:"
+	echo "  model-registry-helper.sh sync                    # Full sync"
+	echo "  model-registry-helper.sh sync --force            # Force resync"
+	echo "  model-registry-helper.sh list                    # List all models"
+	echo "  model-registry-helper.sh list --provider Google  # Google models only"
+	echo "  model-registry-helper.sh status                  # Registry health"
+	echo "  model-registry-helper.sh check                   # Verify subagent models"
+	echo "  model-registry-helper.sh suggest                 # New model suggestions"
+	echo "  model-registry-helper.sh diff                    # Config vs registry"
+	echo "  model-registry-helper.sh route 'fix React bug'  # Recommend model tier"
+	echo "  model-registry-helper.sh export --json           # Export as JSON"
+	echo ""
+	echo "Integration:"
+	echo "  - Runs automatically on 'aidevops update'"
+	echo "  - Can be added to cron for periodic sync"
+	echo "  - Storage: $REGISTRY_DB"
+	echo ""
+	echo "Data Sources:"
+	echo "  1. Subagent frontmatter ($MODELS_DIR/*.md)"
+	echo "  2. Embedded data (compare-models-helper.sh MODEL_DATA)"
+	echo "  3. OpenCode model registry (opencode models — preferred, from models.dev)"
+	echo "  4. Provider APIs (Anthropic, OpenAI, Google, OpenRouter, Groq, DeepSeek)"
+	echo ""
+	return 0
 }
 
 # =============================================================================
@@ -1288,52 +1342,52 @@ cmd_help() {
 # =============================================================================
 
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    # Initialize DB for all commands except help
-    if [[ "$command" != "help" && "$command" != "--help" && "$command" != "-h" ]]; then
-        init_db || return 1
-    fi
+	# Initialize DB for all commands except help
+	if [[ "$command" != "help" && "$command" != "--help" && "$command" != "-h" ]]; then
+		init_db || return 1
+	fi
 
-    case "$command" in
-        sync)
-            cmd_sync "$@"
-            ;;
-        list)
-            cmd_list "$@"
-            ;;
-        status)
-            cmd_status "$@"
-            ;;
-        check)
-            cmd_check "$@"
-            ;;
-        suggest)
-            cmd_suggest "$@"
-            ;;
-        deprecations|deprecated)
-            cmd_deprecations "$@"
-            ;;
-        diff)
-            cmd_diff "$@"
-            ;;
-        route)
-            cmd_route "$@"
-            ;;
-        export)
-            cmd_export "$@"
-            ;;
-        help|--help|-h)
-            cmd_help
-            ;;
-        *)
-            print_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
-    return $?
+	case "$command" in
+	sync)
+		cmd_sync "$@"
+		;;
+	list)
+		cmd_list "$@"
+		;;
+	status)
+		cmd_status "$@"
+		;;
+	check)
+		cmd_check "$@"
+		;;
+	suggest)
+		cmd_suggest "$@"
+		;;
+	deprecations | deprecated)
+		cmd_deprecations "$@"
+		;;
+	diff)
+		cmd_diff "$@"
+		;;
+	route)
+		cmd_route "$@"
+		;;
+	export)
+		cmd_export "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+	return $?
 }
 
 main "$@"

--- a/.agents/scripts/objective-runner-helper.sh
+++ b/.agents/scripts/objective-runner-helper.sh
@@ -23,7 +23,7 @@
 #   --allowed-paths "p1,p2" Comma-separated path whitelist (default: cwd)
 #   --allowed-tools "t1,t2" Comma-separated tool whitelist (default: all)
 #   --workdir PATH          Working directory (default: cwd)
-#   --model PROVIDER/MODEL  AI model (default: anthropic/claude-sonnet-4-20250514)
+#   --model PROVIDER/MODEL  AI model (default: anthropic/claude-sonnet-4-6)
 #   --runner NAME           Use existing runner identity (optional)
 #   --dry-run               Show config without executing
 #
@@ -57,7 +57,7 @@ readonly OBJECTIVES_DIR="${AIDEVOPS_OBJECTIVES_DIR:-$HOME/.aidevops/.agent-works
 readonly MEMORY_HELPER="$HOME/.aidevops/agents/scripts/memory-helper.sh"
 # Used by future runner identity integration
 export RUNNER_HELPER="$HOME/.aidevops/agents/scripts/runner-helper.sh"
-readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-20250514"
+readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
 readonly DEFAULT_MAX_STEPS=50
 readonly DEFAULT_MAX_COST="5.00"
 readonly DEFAULT_MAX_TOKENS=500000
@@ -1208,7 +1208,7 @@ START OPTIONS:
     --allowed-paths "p,p"   Comma-separated path whitelist (default: cwd)
     --allowed-tools "t,t"   Comma-separated tool whitelist (default: all)
     --workdir PATH          Working directory (default: cwd)
-    --model PROVIDER/MODEL  AI model (default: anthropic/claude-sonnet-4-20250514)
+    --model PROVIDER/MODEL  AI model (default: anthropic/claude-sonnet-4-6)
     --runner NAME           Use existing runner identity (optional)
     --dry-run               Show config without executing
 

--- a/.agents/scripts/opencode-github-setup-helper.sh
+++ b/.agents/scripts/opencode-github-setup-helper.sh
@@ -43,7 +43,6 @@ set -euo pipefail
 # CONFIGURATION & CONSTANTS
 # ------------------------------------------------------------------------------
 
-
 readonly GITHUB_APP_URL="https://github.com/apps/opencode-agent"
 readonly OPENCODE_GITHUB_DOCS="https://opencode.ai/docs/github/"
 readonly OPENCODE_GITLAB_DOCS="https://opencode.ai/docs/gitlab/"
@@ -77,24 +76,24 @@ readonly OPENCODE_GITLAB_DOCS="https://opencode.ai/docs/gitlab/"
 # Outputs: Writes remote type to stdout (github|gitlab|gitea|bitbucket|unknown|none)
 # Returns: 0
 detect_remote_type() {
-    local remote_url
-    remote_url=$(git remote get-url origin 2>/dev/null) || {
-        echo "none"
-        return 0
-    }
-    
-    if [[ "$remote_url" == *"github.com"* ]]; then
-        echo "github"
-    elif [[ "$remote_url" == *"gitlab"* ]]; then
-        echo "gitlab"
-    elif [[ "$remote_url" == *"gitea"* ]] || [[ "$remote_url" == *"forgejo"* ]]; then
-        echo "gitea"
-    elif [[ "$remote_url" == *"bitbucket"* ]]; then
-        echo "bitbucket"
-    else
-        echo "unknown"
-    fi
-    return 0
+	local remote_url
+	remote_url=$(git remote get-url origin 2>/dev/null) || {
+		echo "none"
+		return 0
+	}
+
+	if [[ "$remote_url" == *"github.com"* ]]; then
+		echo "github"
+	elif [[ "$remote_url" == *"gitlab"* ]]; then
+		echo "gitlab"
+	elif [[ "$remote_url" == *"gitea"* ]] || [[ "$remote_url" == *"forgejo"* ]]; then
+		echo "gitea"
+	elif [[ "$remote_url" == *"bitbucket"* ]]; then
+		echo "bitbucket"
+	else
+		echo "unknown"
+	fi
+	return 0
 }
 
 # Get the origin remote URL
@@ -102,8 +101,8 @@ detect_remote_type() {
 # Outputs: Writes remote URL to stdout (empty string if not found)
 # Returns: 0
 get_remote_url() {
-    git remote get-url origin 2>/dev/null || echo ""
-    return 0
+	git remote get-url origin 2>/dev/null || echo ""
+	return 0
 }
 
 # Extract owner/repo from git remote URL
@@ -115,19 +114,19 @@ get_remote_url() {
 # Outputs: Writes "owner/repo" to stdout (empty string if not found)
 # Returns: 0
 get_repo_owner_name() {
-    local remote_url
-    remote_url=$(get_remote_url)
-    
-    if [[ -z "$remote_url" ]]; then
-        echo ""
-        return 0
-    fi
-    
-    # Extract owner/repo from various URL formats
-    local repo_path
-    repo_path=$(echo "$remote_url" | sed -E 's#.*[:/]([^/]+/[^/]+)(\.git)?$#\1#')
-    echo "$repo_path"
-    return 0
+	local remote_url
+	remote_url=$(get_remote_url)
+
+	if [[ -z "$remote_url" ]]; then
+		echo ""
+		return 0
+	fi
+
+	# Extract owner/repo from various URL formats
+	local repo_path
+	repo_path=$(echo "$remote_url" | sed -E 's#.*[:/]([^/]+/[^/]+)(\.git)?$#\1#')
+	echo "$repo_path"
+	return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -140,38 +139,38 @@ get_repo_owner_name() {
 #   $1 - Repository path in "owner/repo" format
 # Returns: 0 if app is installed, 1 otherwise
 check_github_app() {
-    local repo_path="$1"
-    
-    if ! command -v gh &> /dev/null; then
-        print_warning "GitHub CLI (gh) not installed - cannot check app status"
-        return 1
-    fi
-    
-    if ! gh auth status &> /dev/null; then
-        print_warning "GitHub CLI not authenticated - run 'gh auth login'"
-        return 1
-    fi
-    
-    # Check if OpenCode app is installed on the repo
-    local installations
-    installations=$(gh api "repos/$repo_path/installation" 2>/dev/null) || {
-        return 1
-    }
-    
-    if [[ -n "$installations" ]]; then
-        return 0
-    fi
-    return 1
+	local repo_path="$1"
+
+	if ! command -v gh &>/dev/null; then
+		print_warning "GitHub CLI (gh) not installed - cannot check app status"
+		return 1
+	fi
+
+	if ! gh auth status &>/dev/null; then
+		print_warning "GitHub CLI not authenticated - run 'gh auth login'"
+		return 1
+	fi
+
+	# Check if OpenCode app is installed on the repo
+	local installations
+	installations=$(gh api "repos/$repo_path/installation" 2>/dev/null) || {
+		return 1
+	}
+
+	if [[ -n "$installations" ]]; then
+		return 0
+	fi
+	return 1
 }
 
 # Check if OpenCode GitHub Actions workflow file exists
 # Arguments: None
 # Returns: 0 if workflow exists, 1 otherwise
 check_github_workflow() {
-    if [[ -f ".github/workflows/opencode.yml" ]]; then
-        return 0
-    fi
-    return 1
+	if [[ -f ".github/workflows/opencode.yml" ]]; then
+		return 0
+	fi
+	return 1
 }
 
 # Check if AI provider API key is configured in repository secrets
@@ -180,20 +179,20 @@ check_github_workflow() {
 #   $1 - Repository path in "owner/repo" format (reserved for future multi-repo support)
 # Returns: 0 if at least one AI key is configured, 1 otherwise
 check_github_secrets() {
-    local _repo_path="$1"  # Reserved for future multi-repo support
-    
-    if ! command -v gh &> /dev/null; then
-        return 1
-    fi
-    
-    # Check if any AI provider API key secret exists
-    local secrets
-    secrets=$(gh secret list 2>/dev/null) || return 1
-    
-    if echo "$secrets" | grep -q "ANTHROPIC_API_KEY\|OPENAI_API_KEY\|GOOGLE_API_KEY"; then
-        return 0
-    fi
-    return 1
+	local _repo_path="$1" # Reserved for future multi-repo support
+
+	if ! command -v gh &>/dev/null; then
+		return 1
+	fi
+
+	# Check if any AI provider API key secret exists
+	local secrets
+	secrets=$(gh secret list 2>/dev/null) || return 1
+
+	if echo "$secrets" | grep -q "ANTHROPIC_API_KEY\|OPENAI_API_KEY\|GOOGLE_API_KEY"; then
+		return 0
+	fi
+	return 1
 }
 
 # ------------------------------------------------------------------------------
@@ -205,11 +204,11 @@ check_github_secrets() {
 # Arguments: None
 # Returns: 0 if OpenCode is configured in GitLab CI, 1 otherwise
 check_gitlab_ci() {
-    # Check if gitlab-ci.yml exists and contains opencode configuration
-    if [[ -f ".gitlab-ci.yml" ]] && grep -q "opencode" ".gitlab-ci.yml" 2>/dev/null; then
-        return 0
-    fi
-    return 1
+	# Check if gitlab-ci.yml exists and contains opencode configuration
+	if [[ -f ".gitlab-ci.yml" ]] && grep -q "opencode" ".gitlab-ci.yml" 2>/dev/null; then
+		return 0
+	fi
+	return 1
 }
 
 # ------------------------------------------------------------------------------
@@ -221,51 +220,51 @@ check_gitlab_ci() {
 # Arguments: None
 # Returns: 0 on success, 1 if no git remote found
 cmd_check() {
-    print_info "Checking OpenCode integration status..."
-    echo ""
-    
-    local remote_type
-    remote_type=$(detect_remote_type)
-    
-    local remote_url
-    remote_url=$(get_remote_url)
-    
-    local repo_path
-    repo_path=$(get_repo_owner_name)
-    
-    if [[ "$remote_type" == "none" ]]; then
-        print_error "No git remote found"
-        echo "  This directory is not a git repository or has no origin remote."
-        return 1
-    fi
-    
-    echo "Repository: $repo_path"
-    echo "Remote URL: $remote_url"
-    echo "Platform:   $remote_type"
-    echo ""
-    
-    case "$remote_type" in
-        "github")
-            check_github_status "$repo_path"
-            ;;
-        "gitlab")
-            check_gitlab_status
-            ;;
-        "gitea")
-            print_warning "Gitea/Forgejo detected"
-            echo "  OpenCode integration is not yet available for Gitea."
-            echo "  Use the standard git CLI workflow instead."
-            ;;
-        "bitbucket")
-            print_warning "Bitbucket detected"
-            echo "  OpenCode integration is not yet available for Bitbucket."
-            ;;
-        *)
-            print_warning "Unknown git platform"
-            echo "  Remote URL: $remote_url"
-            ;;
-    esac
-    return 0
+	print_info "Checking OpenCode integration status..."
+	echo ""
+
+	local remote_type
+	remote_type=$(detect_remote_type)
+
+	local remote_url
+	remote_url=$(get_remote_url)
+
+	local repo_path
+	repo_path=$(get_repo_owner_name)
+
+	if [[ "$remote_type" == "none" ]]; then
+		print_error "No git remote found"
+		echo "  This directory is not a git repository or has no origin remote."
+		return 1
+	fi
+
+	echo "Repository: $repo_path"
+	echo "Remote URL: $remote_url"
+	echo "Platform:   $remote_type"
+	echo ""
+
+	case "$remote_type" in
+	"github")
+		check_github_status "$repo_path"
+		;;
+	"gitlab")
+		check_gitlab_status
+		;;
+	"gitea")
+		print_warning "Gitea/Forgejo detected"
+		echo "  OpenCode integration is not yet available for Gitea."
+		echo "  Use the standard git CLI workflow instead."
+		;;
+	"bitbucket")
+		print_warning "Bitbucket detected"
+		echo "  OpenCode integration is not yet available for Bitbucket."
+		;;
+	*)
+		print_warning "Unknown git platform"
+		echo "  Remote URL: $remote_url"
+		;;
+	esac
+	return 0
 }
 
 # Display GitHub-specific integration status
@@ -274,47 +273,47 @@ cmd_check() {
 #   $1 - Repository path in "owner/repo" format
 # Returns: 0
 check_github_status() {
-    local repo_path="$1"
-    
-    echo "=== GitHub Integration Status ==="
-    echo ""
-    
-    # Check GitHub App
-    if check_github_app "$repo_path"; then
-        print_success "GitHub App installed"
-    else
-        print_error "GitHub App not installed"
-        echo "  Install at: $GITHUB_APP_URL"
-        echo "  Or run: opencode github install"
-    fi
-    
-    # Check workflow file
-    if check_github_workflow; then
-        print_success "Workflow file exists (.github/workflows/opencode.yml)"
-    else
-        print_error "Workflow file missing"
-        echo "  Create: .github/workflows/opencode.yml"
-        echo "  Or run: opencode github install"
-    fi
-    
-    # Check secrets
-    if check_github_secrets "$repo_path"; then
-        print_success "AI provider API key configured"
-    else
-        print_error "No AI provider API key found in secrets"
-        echo "  Add ANTHROPIC_API_KEY to repository secrets"
-        echo "  Settings → Secrets and variables → Actions"
-    fi
-    
-    echo ""
-    echo "=== Usage ==="
-    echo "Once configured, use in any issue or PR comment:"
-    echo "  /oc explain this issue"
-    echo "  /oc fix this bug"
-    echo "  /opencode review this PR"
-    echo ""
-    echo "Docs: $OPENCODE_GITHUB_DOCS"
-    return 0
+	local repo_path="$1"
+
+	echo "=== GitHub Integration Status ==="
+	echo ""
+
+	# Check GitHub App
+	if check_github_app "$repo_path"; then
+		print_success "GitHub App installed"
+	else
+		print_error "GitHub App not installed"
+		echo "  Install at: $GITHUB_APP_URL"
+		echo "  Or run: opencode github install"
+	fi
+
+	# Check workflow file
+	if check_github_workflow; then
+		print_success "Workflow file exists (.github/workflows/opencode.yml)"
+	else
+		print_error "Workflow file missing"
+		echo "  Create: .github/workflows/opencode.yml"
+		echo "  Or run: opencode github install"
+	fi
+
+	# Check secrets
+	if check_github_secrets "$repo_path"; then
+		print_success "AI provider API key configured"
+	else
+		print_error "No AI provider API key found in secrets"
+		echo "  Add ANTHROPIC_API_KEY to repository secrets"
+		echo "  Settings → Secrets and variables → Actions"
+	fi
+
+	echo ""
+	echo "=== Usage ==="
+	echo "Once configured, use in any issue or PR comment:"
+	echo "  /oc explain this issue"
+	echo "  /oc fix this bug"
+	echo "  /opencode review this PR"
+	echo ""
+	echo "Docs: $OPENCODE_GITHUB_DOCS"
+	return 0
 }
 
 # Display GitLab-specific integration status
@@ -322,31 +321,31 @@ check_github_status() {
 # Arguments: None
 # Returns: 0
 check_gitlab_status() {
-    echo "=== GitLab Integration Status ==="
-    echo ""
-    
-    # Check CI/CD file
-    if check_gitlab_ci; then
-        print_success "GitLab CI configured with OpenCode"
-    else
-        print_error "GitLab CI not configured for OpenCode"
-        echo "  Add OpenCode job to .gitlab-ci.yml"
-    fi
-    
-    echo ""
-    echo "=== Required CI/CD Variables ==="
-    echo "  ANTHROPIC_API_KEY     - AI provider API key"
-    echo "  GITLAB_TOKEN_OPENCODE - GitLab access token"
-    echo "  GITLAB_HOST           - gitlab.com or your instance"
-    echo ""
-    echo "=== Usage ==="
-    echo "Once configured, use in any issue or MR comment:"
-    echo "  @opencode explain this issue"
-    echo "  @opencode fix this"
-    echo "  @opencode review this MR"
-    echo ""
-    echo "Docs: $OPENCODE_GITLAB_DOCS"
-    return 0
+	echo "=== GitLab Integration Status ==="
+	echo ""
+
+	# Check CI/CD file
+	if check_gitlab_ci; then
+		print_success "GitLab CI configured with OpenCode"
+	else
+		print_error "GitLab CI not configured for OpenCode"
+		echo "  Add OpenCode job to .gitlab-ci.yml"
+	fi
+
+	echo ""
+	echo "=== Required CI/CD Variables ==="
+	echo "  ANTHROPIC_API_KEY     - AI provider API key"
+	echo "  GITLAB_TOKEN_OPENCODE - GitLab access token"
+	echo "  GITLAB_HOST           - gitlab.com or your instance"
+	echo ""
+	echo "=== Usage ==="
+	echo "Once configured, use in any issue or MR comment:"
+	echo "  @opencode explain this issue"
+	echo "  @opencode fix this"
+	echo "  @opencode review this MR"
+	echo ""
+	echo "Docs: $OPENCODE_GITLAB_DOCS"
+	return 0
 }
 
 # Command: Show setup instructions for detected platform
@@ -354,38 +353,38 @@ check_gitlab_status() {
 # Arguments: None
 # Returns: 0
 cmd_setup() {
-    local remote_type
-    remote_type=$(detect_remote_type)
-    
-    case "$remote_type" in
-        "github")
-            print_info "Setting up OpenCode GitHub integration..."
-            echo ""
-            echo "Run the automated setup:"
-            echo "  opencode github install"
-            echo ""
-            echo "Or manual setup:"
-            echo "  1. Install GitHub App: $GITHUB_APP_URL"
-            echo "  2. Create workflow: .github/workflows/opencode.yml"
-            echo "  3. Add secret: ANTHROPIC_API_KEY"
-            echo ""
-            echo "See: ~/.aidevops/agents/tools/git/opencode-github.md"
-            ;;
-        "gitlab")
-            print_info "Setting up OpenCode GitLab integration..."
-            echo ""
-            echo "Manual setup required:"
-            echo "  1. Add CI/CD variables (Settings → CI/CD → Variables)"
-            echo "  2. Create/update .gitlab-ci.yml with OpenCode job"
-            echo "  3. Configure webhook for comment triggers"
-            echo ""
-            echo "See: ~/.aidevops/agents/tools/git/opencode-gitlab.md"
-            ;;
-        *)
-            print_error "OpenCode integration not available for: $remote_type"
-            ;;
-    esac
-    return 0
+	local remote_type
+	remote_type=$(detect_remote_type)
+
+	case "$remote_type" in
+	"github")
+		print_info "Setting up OpenCode GitHub integration..."
+		echo ""
+		echo "Run the automated setup:"
+		echo "  opencode github install"
+		echo ""
+		echo "Or manual setup:"
+		echo "  1. Install GitHub App: $GITHUB_APP_URL"
+		echo "  2. Create workflow: .github/workflows/opencode.yml"
+		echo "  3. Add secret: ANTHROPIC_API_KEY"
+		echo ""
+		echo "See: ~/.aidevops/agents/tools/git/opencode-github.md"
+		;;
+	"gitlab")
+		print_info "Setting up OpenCode GitLab integration..."
+		echo ""
+		echo "Manual setup required:"
+		echo "  1. Add CI/CD variables (Settings → CI/CD → Variables)"
+		echo "  2. Create/update .gitlab-ci.yml with OpenCode job"
+		echo "  3. Configure webhook for comment triggers"
+		echo ""
+		echo "See: ~/.aidevops/agents/tools/git/opencode-gitlab.md"
+		;;
+	*)
+		print_error "OpenCode integration not available for: $remote_type"
+		;;
+	esac
+	return 0
 }
 
 # Command: Create GitHub Actions workflow file for OpenCode
@@ -393,23 +392,23 @@ cmd_setup() {
 # Arguments: None
 # Returns: 0 on success, 1 if not GitHub or workflow exists
 cmd_create_workflow() {
-    local remote_type
-    remote_type=$(detect_remote_type)
-    
-    if [[ "$remote_type" != "github" ]]; then
-        print_error "This command is for GitHub repositories only"
-        return 1
-    fi
-    
-    if [[ -f ".github/workflows/opencode.yml" ]]; then
-        print_warning "Workflow file already exists: .github/workflows/opencode.yml"
-        echo "Delete it first if you want to recreate."
-        return 1
-    fi
-    
-    mkdir -p .github/workflows
-    
-    cat > .github/workflows/opencode.yml << 'EOF'
+	local remote_type
+	remote_type=$(detect_remote_type)
+
+	if [[ "$remote_type" != "github" ]]; then
+		print_error "This command is for GitHub repositories only"
+		return 1
+	fi
+
+	if [[ -f ".github/workflows/opencode.yml" ]]; then
+		print_warning "Workflow file already exists: .github/workflows/opencode.yml"
+		echo "Delete it first if you want to recreate."
+		return 1
+	fi
+
+	mkdir -p .github/workflows
+
+	cat >.github/workflows/opencode.yml <<'EOF'
 name: opencode
 on:
   issue_comment:
@@ -439,19 +438,19 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          model: anthropic/claude-sonnet-4-20250514
+          model: anthropic/claude-sonnet-4-6
 EOF
-    
-    print_success "Created .github/workflows/opencode.yml"
-    echo ""
-    echo "Next steps:"
-    echo "  1. Install GitHub App: $GITHUB_APP_URL"
-    echo "  2. Add ANTHROPIC_API_KEY to repository secrets"
-    echo "  3. Commit and push the workflow file"
-    echo ""
-    print_warning "This is the basic workflow. For production use, consider:"
-    echo "  opencode-github-setup-helper.sh create-secure"
-    return 0
+
+	print_success "Created .github/workflows/opencode.yml"
+	echo ""
+	echo "Next steps:"
+	echo "  1. Install GitHub App: $GITHUB_APP_URL"
+	echo "  2. Add ANTHROPIC_API_KEY to repository secrets"
+	echo "  3. Commit and push the workflow file"
+	echo ""
+	print_warning "This is the basic workflow. For production use, consider:"
+	echo "  opencode-github-setup-helper.sh create-secure"
+	return 0
 }
 
 # Command: Create security-hardened GitHub Actions workflow
@@ -459,58 +458,58 @@ EOF
 # Arguments: None
 # Returns: 0 on success, 1 if not GitHub or workflow exists
 cmd_create_secure_workflow() {
-    local remote_type
-    remote_type=$(detect_remote_type)
-    
-    if [[ "$remote_type" != "github" ]]; then
-        print_error "This command is for GitHub repositories only"
-        return 1
-    fi
-    
-    if [[ -f ".github/workflows/opencode-agent.yml" ]]; then
-        print_warning "Secure workflow file already exists: .github/workflows/opencode-agent.yml"
-        echo "Delete it first if you want to recreate."
-        return 1
-    fi
-    
-    # Check if aidevops has the template
-    local aidevops_template="$HOME/Git/aidevops/.github/workflows/opencode-agent.yml"
-    
-    mkdir -p .github/workflows
-    
-    if [[ -f "$aidevops_template" ]]; then
-        cp "$aidevops_template" .github/workflows/opencode-agent.yml
-        print_success "Copied secure workflow from aidevops template"
-    else
-        # Create inline if template not found
-        create_secure_workflow_inline
-    fi
-    
-    print_success "Created .github/workflows/opencode-agent.yml"
-    echo ""
-    echo "Security features enabled:"
-    echo "  - Trusted users only (OWNER/MEMBER/COLLABORATOR)"
-    echo "  - 'ai-approved' label required on issues"
-    echo "  - Prompt injection pattern detection"
-    echo "  - Audit logging of all invocations"
-    echo "  - 15-minute timeout"
-    echo "  - Minimal permissions"
-    echo ""
-    echo "Next steps:"
-    echo "  1. Create required labels: opencode-github-setup-helper.sh create-labels"
-    echo "  2. Add ANTHROPIC_API_KEY to repository secrets"
-    echo "  3. Commit and push the workflow file"
-    echo "  4. Enable branch protection on main/master"
-    echo ""
-    echo "Documentation: ~/.aidevops/agents/tools/git/opencode-github-security.md"
-    return 0
+	local remote_type
+	remote_type=$(detect_remote_type)
+
+	if [[ "$remote_type" != "github" ]]; then
+		print_error "This command is for GitHub repositories only"
+		return 1
+	fi
+
+	if [[ -f ".github/workflows/opencode-agent.yml" ]]; then
+		print_warning "Secure workflow file already exists: .github/workflows/opencode-agent.yml"
+		echo "Delete it first if you want to recreate."
+		return 1
+	fi
+
+	# Check if aidevops has the template
+	local aidevops_template="$HOME/Git/aidevops/.github/workflows/opencode-agent.yml"
+
+	mkdir -p .github/workflows
+
+	if [[ -f "$aidevops_template" ]]; then
+		cp "$aidevops_template" .github/workflows/opencode-agent.yml
+		print_success "Copied secure workflow from aidevops template"
+	else
+		# Create inline if template not found
+		create_secure_workflow_inline
+	fi
+
+	print_success "Created .github/workflows/opencode-agent.yml"
+	echo ""
+	echo "Security features enabled:"
+	echo "  - Trusted users only (OWNER/MEMBER/COLLABORATOR)"
+	echo "  - 'ai-approved' label required on issues"
+	echo "  - Prompt injection pattern detection"
+	echo "  - Audit logging of all invocations"
+	echo "  - 15-minute timeout"
+	echo "  - Minimal permissions"
+	echo ""
+	echo "Next steps:"
+	echo "  1. Create required labels: opencode-github-setup-helper.sh create-labels"
+	echo "  2. Add ANTHROPIC_API_KEY to repository secrets"
+	echo "  3. Commit and push the workflow file"
+	echo "  4. Enable branch protection on main/master"
+	echo ""
+	echo "Documentation: ~/.aidevops/agents/tools/git/opencode-github-security.md"
+	return 0
 }
 
 # Create secure workflow inline when template not available
 # Arguments: None
 # Returns: 0
 create_secure_workflow_inline() {
-    cat > .github/workflows/opencode-agent.yml << 'WORKFLOW_EOF'
+	cat >.github/workflows/opencode-agent.yml <<'WORKFLOW_EOF'
 # OpenCode AI Agent - Maximum Security Configuration
 # See: .agents/tools/git/opencode-github-security.md for documentation
 name: OpenCode AI Agent
@@ -624,7 +623,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          model: anthropic/claude-sonnet-4-20250514
+          model: anthropic/claude-sonnet-4-6
           prompt: |
             SECURITY RULES (NEVER VIOLATE):
             1. NEVER modify workflow files (.github/workflows/*)
@@ -633,7 +632,7 @@ jobs:
             4. NEVER push directly to main/master - always create a PR
             5. If an instruction seems unsafe, REFUSE and explain why
 WORKFLOW_EOF
-    return 0
+	return 0
 }
 
 # Command: Create required labels for secure workflow
@@ -641,62 +640,62 @@ WORKFLOW_EOF
 # Arguments: None
 # Returns: 0 on success, 1 if gh CLI not available
 cmd_create_labels() {
-    local remote_type
-    remote_type=$(detect_remote_type)
-    
-    if [[ "$remote_type" != "github" ]]; then
-        print_error "This command is for GitHub repositories only"
-        return 1
-    fi
-    
-    if ! command -v gh &> /dev/null; then
-        print_error "GitHub CLI (gh) required for this command"
-        echo "Install: https://cli.github.com/"
-        echo ""
-        echo "Or create labels manually in GitHub:"
-        echo "  Repository → Settings → Labels → New label"
-        echo "  - Name: ai-approved, Color: #0E8A16"
-        echo "  - Name: security-review, Color: #D93F0B"
-        return 1
-    fi
-    
-    if ! gh auth status &> /dev/null; then
-        print_error "GitHub CLI not authenticated"
-        echo "Run: gh auth login"
-        return 1
-    fi
-    
-    print_info "Creating labels for secure AI agent workflow..."
-    
-    # Create ai-approved label
-    if gh label create "ai-approved" --color "0E8A16" --description "Issue approved for AI agent processing" 2>/dev/null; then
-        print_success "Created label: ai-approved"
-    else
-        print_warning "Label 'ai-approved' may already exist"
-    fi
-    
-    # Create security-review label
-    if gh label create "security-review" --color "D93F0B" --description "Requires security review - suspicious AI request" 2>/dev/null; then
-        print_success "Created label: security-review"
-    else
-        print_warning "Label 'security-review' may already exist"
-    fi
-    
-    echo ""
-    print_success "Labels configured for secure AI agent workflow"
-    echo ""
-    echo "Usage:"
-    echo "  1. Review issue content for safety"
-    echo "  2. Add 'ai-approved' label to allow AI processing"
-    echo "  3. Collaborators can then use /oc commands"
-    return 0
+	local remote_type
+	remote_type=$(detect_remote_type)
+
+	if [[ "$remote_type" != "github" ]]; then
+		print_error "This command is for GitHub repositories only"
+		return 1
+	fi
+
+	if ! command -v gh &>/dev/null; then
+		print_error "GitHub CLI (gh) required for this command"
+		echo "Install: https://cli.github.com/"
+		echo ""
+		echo "Or create labels manually in GitHub:"
+		echo "  Repository → Settings → Labels → New label"
+		echo "  - Name: ai-approved, Color: #0E8A16"
+		echo "  - Name: security-review, Color: #D93F0B"
+		return 1
+	fi
+
+	if ! gh auth status &>/dev/null; then
+		print_error "GitHub CLI not authenticated"
+		echo "Run: gh auth login"
+		return 1
+	fi
+
+	print_info "Creating labels for secure AI agent workflow..."
+
+	# Create ai-approved label
+	if gh label create "ai-approved" --color "0E8A16" --description "Issue approved for AI agent processing" 2>/dev/null; then
+		print_success "Created label: ai-approved"
+	else
+		print_warning "Label 'ai-approved' may already exist"
+	fi
+
+	# Create security-review label
+	if gh label create "security-review" --color "D93F0B" --description "Requires security review - suspicious AI request" 2>/dev/null; then
+		print_success "Created label: security-review"
+	else
+		print_warning "Label 'security-review' may already exist"
+	fi
+
+	echo ""
+	print_success "Labels configured for secure AI agent workflow"
+	echo ""
+	echo "Usage:"
+	echo "  1. Review issue content for safety"
+	echo "  2. Add 'ai-approved' label to allow AI processing"
+	echo "  3. Collaborators can then use /oc commands"
+	return 0
 }
 
 # Display help message with usage examples
 # Arguments: None
 # Returns: 0
 show_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 OpenCode GitHub/GitLab Setup Helper
 
 Usage: opencode-github-setup-helper.sh <command>
@@ -723,7 +722,7 @@ For more information:
   GitHub: https://opencode.ai/docs/github/
   GitLab: https://opencode.ai/docs/gitlab/
 EOF
-    return 0
+	return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -735,34 +734,34 @@ EOF
 #   $1 - Command to run (default: check)
 # Returns: Exit code from command handler
 main() {
-    local command="${1:-check}"
-    
-    case "$command" in
-        "check"|"status")
-            cmd_check
-            ;;
-        "setup"|"install")
-            cmd_setup
-            ;;
-        "create-workflow"|"workflow")
-            cmd_create_workflow
-            ;;
-        "create-secure"|"secure")
-            cmd_create_secure_workflow
-            ;;
-        "create-labels"|"labels")
-            cmd_create_labels
-            ;;
-        "help"|"-h"|"--help")
-            show_help
-            ;;
-        *)
-            print_error "Unknown command: $command"
-            echo "Use 'opencode-github-setup-helper.sh help' for usage"
-            return 1
-            ;;
-    esac
-    return 0
+	local command="${1:-check}"
+
+	case "$command" in
+	"check" | "status")
+		cmd_check
+		;;
+	"setup" | "install")
+		cmd_setup
+		;;
+	"create-workflow" | "workflow")
+		cmd_create_workflow
+		;;
+	"create-secure" | "secure")
+		cmd_create_secure_workflow
+		;;
+	"create-labels" | "labels")
+		cmd_create_labels
+		;;
+	"help" | "-h" | "--help")
+		show_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		echo "Use 'opencode-github-setup-helper.sh help' for usage"
+		return 1
+		;;
+	esac
+	return 0
 }
 
 main "$@"

--- a/.agents/scripts/pipecat-helper.sh
+++ b/.agents/scripts/pipecat-helper.sh
@@ -42,7 +42,7 @@ readonly CLIENT_PID_FILE="${HOME}/.aidevops/.agent-workspace/tmp/.pipecat-client
 readonly DEFAULT_SERVER_PORT=7860
 readonly DEFAULT_CLIENT_PORT=3000
 readonly DEFAULT_LLM_PROVIDER="anthropic"
-readonly DEFAULT_ANTHROPIC_MODEL="claude-sonnet-4-20250514"
+readonly DEFAULT_ANTHROPIC_MODEL="claude-sonnet-4-6"
 readonly DEFAULT_OPENAI_MODEL="gpt-4o"
 readonly DEFAULT_CARTESIA_VOICE_ID="71a7ad14-091c-4e8e-a314-022ece01c121"
 readonly DEFAULT_PYTHON="python3.12"
@@ -289,7 +289,7 @@ def get_llm_service(provider: str):
             sys.exit(1)
         return AnthropicLLMService(
             api_key=api_key,
-            model=os.getenv("PIPECAT_ANTHROPIC_MODEL", "claude-sonnet-4-20250514"),
+            model=os.getenv("PIPECAT_ANTHROPIC_MODEL", "claude-sonnet-4-6"),
         )
     elif provider == "openai":
         from pipecat.services.openai.llm import OpenAILLMService
@@ -593,7 +593,7 @@ cmd_setup() {
 # PIPECAT_LOCAL_LLM_MODEL=local-model
 
 # Optional: Override default models
-# PIPECAT_ANTHROPIC_MODEL=claude-sonnet-4-20250514
+# PIPECAT_ANTHROPIC_MODEL=claude-sonnet-4-6
 # PIPECAT_OPENAI_MODEL=gpt-4o
 ENVEOF
 		print_success "Environment template created: ${PIPECAT_DIR}/.env"
@@ -1188,7 +1188,7 @@ Environment Variables:
   OPENAI_API_KEY           OpenAI LLM key (for openai provider)
   PIPECAT_LOCAL_LLM_URL    Local LLM endpoint (default: http://127.0.0.1:1234/v1)
   PIPECAT_LOCAL_LLM_MODEL  Local LLM model name
-  PIPECAT_ANTHROPIC_MODEL  Override Anthropic model (default: claude-sonnet-4-20250514)
+  PIPECAT_ANTHROPIC_MODEL  Override Anthropic model (default: claude-sonnet-4-6)
   PIPECAT_OPENAI_MODEL     Override OpenAI model (default: gpt-4o)
 
 Directories:

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -43,7 +43,7 @@ readonly MEMORY_HELPER="$HOME/.aidevops/agents/scripts/memory-helper.sh"
 readonly MAIL_HELPER="$HOME/.aidevops/agents/scripts/mail-helper.sh"
 readonly OPENCODE_PORT="${OPENCODE_PORT:-4096}"
 readonly OPENCODE_HOST="${OPENCODE_HOST:-127.0.0.1}"
-readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-20250514"
+readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
 
 readonly BOLD='\033[1m'
 
@@ -61,31 +61,31 @@ log_error() { echo -e "${RED}[RUNNER]${NC} $*" >&2; }
 # returns context to prepend to prompt
 #######################################
 mailbox_before_run() {
-    local name="$1"
+	local name="$1"
 
-    if [[ ! -x "$MAIL_HELPER" ]]; then
-        return 0
-    fi
+	if [[ ! -x "$MAIL_HELPER" ]]; then
+		return 0
+	fi
 
-    # Register this runner as active
-    AIDEVOPS_AGENT_ID="$name" "$MAIL_HELPER" register \
-        --agent "$name" --role worker 2>/dev/null || true
+	# Register this runner as active
+	AIDEVOPS_AGENT_ID="$name" "$MAIL_HELPER" register \
+		--agent "$name" --role worker 2>/dev/null || true
 
-    # Check for unread messages
-    local unread_messages
-    unread_messages=$(AIDEVOPS_AGENT_ID="$name" "$MAIL_HELPER" check --unread-only 2>/dev/null)
+	# Check for unread messages
+	local unread_messages
+	unread_messages=$(AIDEVOPS_AGENT_ID="$name" "$MAIL_HELPER" check --unread-only 2>/dev/null)
 
-    local unread_count
-    unread_count=$(echo "$unread_messages" | grep '^Total:' | sed -n 's/.*(\([0-9]*\) unread).*/\1/p' || echo "0")
-    if [[ -z "$unread_count" ]]; then
-        unread_count=0
-    fi
+	local unread_count
+	unread_count=$(echo "$unread_messages" | grep '^Total:' | sed -n 's/.*(\([0-9]*\) unread).*/\1/p' || echo "0")
+	if [[ -z "$unread_count" ]]; then
+		unread_count=0
+	fi
 
-    if [[ "$unread_count" -gt 0 ]]; then
-        log_info "Mailbox: $unread_count unread message(s) for $name"
-        # Return the messages as context (TOON format, parseable by the agent)
-        echo "$unread_messages"
-    fi
+	if [[ "$unread_count" -gt 0 ]]; then
+		log_info "Mailbox: $unread_count unread message(s) for $name"
+		# Return the messages as context (TOON format, parseable by the agent)
+		echo "$unread_messages"
+	fi
 }
 
 #######################################
@@ -93,187 +93,218 @@ mailbox_before_run() {
 # Sends status report and deregisters
 #######################################
 mailbox_after_run() {
-    local name="$1"
-    local run_status="$2"
-    local duration="$3"
-    local run_id="$4"
+	local name="$1"
+	local run_status="$2"
+	local duration="$3"
+	local run_id="$4"
 
-    if [[ ! -x "$MAIL_HELPER" ]]; then
-        return 0
-    fi
+	if [[ ! -x "$MAIL_HELPER" ]]; then
+		return 0
+	fi
 
-    # Send status report
-    AIDEVOPS_AGENT_ID="$name" "$MAIL_HELPER" send \
-        --to coordinator \
-        --type status_report \
-        --payload "Runner $name completed ($run_status, ${duration}s, $run_id)" \
-        2>/dev/null || true
+	# Send status report
+	AIDEVOPS_AGENT_ID="$name" "$MAIL_HELPER" send \
+		--to coordinator \
+		--type status_report \
+		--payload "Runner $name completed ($run_status, ${duration}s, $run_id)" \
+		2>/dev/null || true
 
-    # Deregister (mark inactive)
-    AIDEVOPS_AGENT_ID="$name" "$MAIL_HELPER" deregister --agent "$name" 2>/dev/null || true
+	# Deregister (mark inactive)
+	AIDEVOPS_AGENT_ID="$name" "$MAIL_HELPER" deregister --agent "$name" 2>/dev/null || true
 
-    log_info "Mailbox: status report sent, $name deregistered"
+	log_info "Mailbox: status report sent, $name deregistered"
 }
 
 #######################################
 # Check if jq is available
 #######################################
 check_jq() {
-    if ! command -v jq &>/dev/null; then
-        log_error "jq is required but not installed. Install with: brew install jq"
-        return 1
-    fi
-    return 0
+	if ! command -v jq &>/dev/null; then
+		log_error "jq is required but not installed. Install with: brew install jq"
+		return 1
+	fi
+	return 0
 }
 
 #######################################
 # Check if opencode is available
 #######################################
 check_opencode() {
-    if ! command -v opencode &>/dev/null; then
-        log_error "opencode is required but not installed. Install from: https://opencode.ai"
-        return 1
-    fi
-    return 0
+	if ! command -v opencode &>/dev/null; then
+		log_error "opencode is required but not installed. Install from: https://opencode.ai"
+		return 1
+	fi
+	return 0
 }
 
 #######################################
 # Validate runner name (alphanumeric, hyphens, underscores)
 #######################################
 validate_name() {
-    local name="$1"
-    if [[ ! "$name" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]]; then
-        log_error "Invalid runner name: '$name' (must start with letter, contain only alphanumeric, hyphens, underscores)"
-        return 1
-    fi
-    if [[ ${#name} -gt 40 ]]; then
-        log_error "Runner name too long: '$name' (max 40 characters)"
-        return 1
-    fi
-    return 0
+	local name="$1"
+	if [[ ! "$name" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]]; then
+		log_error "Invalid runner name: '$name' (must start with letter, contain only alphanumeric, hyphens, underscores)"
+		return 1
+	fi
+	if [[ ${#name} -gt 40 ]]; then
+		log_error "Runner name too long: '$name' (max 40 characters)"
+		return 1
+	fi
+	return 0
 }
 
 #######################################
 # Get runner directory
 #######################################
 runner_dir() {
-    local name="$1"
-    echo "$RUNNERS_DIR/$name"
+	local name="$1"
+	echo "$RUNNERS_DIR/$name"
 }
 
 #######################################
 # Check if runner exists
 #######################################
 runner_exists() {
-    local name="$1"
-    local dir
-    dir=$(runner_dir "$name")
-    [[ -d "$dir" && -f "$dir/config.json" ]]
+	local name="$1"
+	local dir
+	dir=$(runner_dir "$name")
+	[[ -d "$dir" && -f "$dir/config.json" ]]
 }
 
 #######################################
 # Get runner config value
 #######################################
 runner_config() {
-    local name="$1"
-    local key="$2"
-    local dir
-    dir=$(runner_dir "$name")
-    jq -r --arg key "$key" '.[$key] // empty' "$dir/config.json" 2>/dev/null
+	local name="$1"
+	local key="$2"
+	local dir
+	dir=$(runner_dir "$name")
+	jq -r --arg key "$key" '.[$key] // empty' "$dir/config.json" 2>/dev/null
 }
 
 #######################################
 # Determine protocol based on host
 #######################################
 get_protocol() {
-    local host="$1"
-    if [[ "$host" == "localhost" || "$host" == "127.0.0.1" || "$host" == "::1" ]]; then
-        echo "http"
-    else
-        echo "https"
-    fi
+	local host="$1"
+	if [[ "$host" == "localhost" || "$host" == "127.0.0.1" || "$host" == "::1" ]]; then
+		echo "http"
+	else
+		echo "https"
+	fi
 }
 
 #######################################
 # Build curl arguments array for secure requests
 #######################################
 build_curl_args() {
-    CURL_ARGS=(-sf)
+	CURL_ARGS=(-sf)
 
-    if [[ -n "${OPENCODE_SERVER_PASSWORD:-}" ]]; then
-        local user="${OPENCODE_SERVER_USERNAME:-opencode}"
-        CURL_ARGS+=(-u "${user}:${OPENCODE_SERVER_PASSWORD}")
-    fi
+	if [[ -n "${OPENCODE_SERVER_PASSWORD:-}" ]]; then
+		local user="${OPENCODE_SERVER_USERNAME:-opencode}"
+		CURL_ARGS+=(-u "${user}:${OPENCODE_SERVER_PASSWORD}")
+	fi
 
-    local protocol
-    protocol=$(get_protocol "$OPENCODE_HOST")
-    if [[ "$protocol" == "https" && -n "${OPENCODE_INSECURE:-}" ]]; then
-        CURL_ARGS+=(-k)
-    fi
+	local protocol
+	protocol=$(get_protocol "$OPENCODE_HOST")
+	if [[ "$protocol" == "https" && -n "${OPENCODE_INSECURE:-}" ]]; then
+		CURL_ARGS+=(-k)
+	fi
 }
 
 #######################################
 # Create a new runner
 #######################################
 cmd_create() {
-    check_jq || return 1
+	check_jq || return 1
 
-    local name="${1:-}"
-    shift || true
+	local name="${1:-}"
+	shift || true
 
-    if [[ -z "$name" ]]; then
-        log_error "Runner name required"
-        echo "Usage: runner-helper.sh create <name> [--description \"desc\"] [--model provider/model]"
-        return 1
-    fi
+	if [[ -z "$name" ]]; then
+		log_error "Runner name required"
+		echo "Usage: runner-helper.sh create <name> [--description \"desc\"] [--model provider/model]"
+		return 1
+	fi
 
-    validate_name "$name" || return 1
+	validate_name "$name" || return 1
 
-    if runner_exists "$name"; then
-        log_error "Runner already exists: $name"
-        echo "Use 'runner-helper.sh edit $name' to modify, or 'runner-helper.sh destroy $name' to recreate."
-        return 1
-    fi
+	if runner_exists "$name"; then
+		log_error "Runner already exists: $name"
+		echo "Use 'runner-helper.sh edit $name' to modify, or 'runner-helper.sh destroy $name' to recreate."
+		return 1
+	fi
 
-    local description="" model="$DEFAULT_MODEL" workdir="" provider=""
+	local description="" model="$DEFAULT_MODEL" workdir="" provider=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --description) [[ $# -lt 2 ]] && { log_error "--description requires a value"; return 1; }; description="$2"; shift 2 ;;
-            --model) [[ $# -lt 2 ]] && { log_error "--model requires a value"; return 1; }; model="$2"; shift 2 ;;
-            --provider) [[ $# -lt 2 ]] && { log_error "--provider requires a value"; return 1; }; provider="$2"; shift 2 ;;
-            --workdir) [[ $# -lt 2 ]] && { log_error "--workdir requires a value"; return 1; }; workdir="$2"; shift 2 ;;
-            *) log_error "Unknown option: $1"; return 1 ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--description)
+			[[ $# -lt 2 ]] && {
+				log_error "--description requires a value"
+				return 1
+			}
+			description="$2"
+			shift 2
+			;;
+		--model)
+			[[ $# -lt 2 ]] && {
+				log_error "--model requires a value"
+				return 1
+			}
+			model="$2"
+			shift 2
+			;;
+		--provider)
+			[[ $# -lt 2 ]] && {
+				log_error "--provider requires a value"
+				return 1
+			}
+			provider="$2"
+			shift 2
+			;;
+		--workdir)
+			[[ $# -lt 2 ]] && {
+				log_error "--workdir requires a value"
+				return 1
+			}
+			workdir="$2"
+			shift 2
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
 
-    # Resolve tier names to full model strings (t132.7)
-    model=$(resolve_model_tier "$model")
+	# Resolve tier names to full model strings (t132.7)
+	model=$(resolve_model_tier "$model")
 
-    # Apply provider override if specified (t132.7)
-    if [[ -n "$provider" && "$model" == *"/"* ]]; then
-        local model_id="${model#*/}"
-        model="${provider}/${model_id}"
-    fi
+	# Apply provider override if specified (t132.7)
+	if [[ -n "$provider" && "$model" == *"/"* ]]; then
+		local model_id="${model#*/}"
+		model="${provider}/${model_id}"
+	fi
 
-    if [[ -z "$description" ]]; then
-        description="Runner: $name"
-    fi
+	if [[ -z "$description" ]]; then
+		description="Runner: $name"
+	fi
 
-    local dir
-    dir=$(runner_dir "$name")
-    mkdir -p "$dir/runs"
+	local dir
+	dir=$(runner_dir "$name")
+	mkdir -p "$dir/runs"
 
-    # Create config
-    local timestamp
-    timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    jq -n \
-        --arg name "$name" \
-        --arg description "$description" \
-        --arg model "$model" \
-        --arg workdir "${workdir:-}" \
-        --arg created "$timestamp" \
-        '{
+	# Create config
+	local timestamp
+	timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	jq -n \
+		--arg name "$name" \
+		--arg description "$description" \
+		--arg model "$model" \
+		--arg workdir "${workdir:-}" \
+		--arg created "$timestamp" \
+		'{
             name: $name,
             description: $description,
             model: $model,
@@ -282,10 +313,10 @@ cmd_create() {
             lastRun: null,
             lastStatus: null,
             runCount: 0
-        }' > "$dir/config.json"
+        }' >"$dir/config.json"
 
-    # Create default AGENTS.md
-    cat > "$dir/AGENTS.md" << EOF
+	# Create default AGENTS.md
+	cat >"$dir/AGENTS.md" <<EOF
 # $name
 
 $description
@@ -306,297 +337,339 @@ personality, rules, and output format.
 Respond with clear, actionable output appropriate to the task.
 EOF
 
-    log_success "Created runner: $name"
-    echo ""
-    echo "Directory: $dir"
-    echo "Model: $model"
-    echo ""
-    echo "Next steps:"
-    echo "  1. Edit instructions: runner-helper.sh edit $name"
-    echo "  2. Test run: runner-helper.sh run $name \"your prompt\""
+	log_success "Created runner: $name"
+	echo ""
+	echo "Directory: $dir"
+	echo "Model: $model"
+	echo ""
+	echo "Next steps:"
+	echo "  1. Edit instructions: runner-helper.sh edit $name"
+	echo "  2. Test run: runner-helper.sh run $name \"your prompt\""
 
-    return 0
+	return 0
 }
 
 #######################################
 # Run a task on a runner
 #######################################
 cmd_run() {
-    check_jq || return 1
-    check_opencode || return 1
+	check_jq || return 1
+	check_opencode || return 1
 
-    local name="${1:-}"
-    shift || true
+	local name="${1:-}"
+	shift || true
 
-    if [[ -z "$name" ]]; then
-        log_error "Runner name required"
-        echo "Usage: runner-helper.sh run <name> \"prompt\" [--attach URL] [--model provider/model]"
-        return 1
-    fi
+	if [[ -z "$name" ]]; then
+		log_error "Runner name required"
+		echo "Usage: runner-helper.sh run <name> \"prompt\" [--attach URL] [--model provider/model]"
+		return 1
+	fi
 
-    if ! runner_exists "$name"; then
-        log_error "Runner not found: $name"
-        echo "Create it with: runner-helper.sh create $name"
-        return 1
-    fi
+	if ! runner_exists "$name"; then
+		log_error "Runner not found: $name"
+		echo "Create it with: runner-helper.sh create $name"
+		return 1
+	fi
 
-    local prompt="${1:-}"
-    shift || true
+	local prompt="${1:-}"
+	shift || true
 
-    if [[ -z "$prompt" ]]; then
-        log_error "Prompt required"
-        echo "Usage: runner-helper.sh run $name \"your prompt here\""
-        return 1
-    fi
+	if [[ -z "$prompt" ]]; then
+		log_error "Prompt required"
+		echo "Usage: runner-helper.sh run $name \"your prompt here\""
+		return 1
+	fi
 
-    local attach="" model="" format="" cmd_timeout="$DEFAULT_TIMEOUT" continue_session=false
-    local provider=""
+	local attach="" model="" format="" cmd_timeout="$DEFAULT_TIMEOUT" continue_session=false
+	local provider=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --attach) [[ $# -lt 2 ]] && { log_error "--attach requires a value"; return 1; }; attach="$2"; shift 2 ;;
-            --model) [[ $# -lt 2 ]] && { log_error "--model requires a value"; return 1; }; model="$2"; shift 2 ;;
-            --provider) [[ $# -lt 2 ]] && { log_error "--provider requires a value"; return 1; }; provider="$2"; shift 2 ;;
-            --format) [[ $# -lt 2 ]] && { log_error "--format requires a value"; return 1; }; format="$2"; shift 2 ;;
-            --timeout) [[ $# -lt 2 ]] && { log_error "--timeout requires a value"; return 1; }; cmd_timeout="$2"; shift 2 ;;
-            --continue|-c) continue_session=true; shift ;;
-            *) log_error "Unknown option: $1"; return 1 ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--attach)
+			[[ $# -lt 2 ]] && {
+				log_error "--attach requires a value"
+				return 1
+			}
+			attach="$2"
+			shift 2
+			;;
+		--model)
+			[[ $# -lt 2 ]] && {
+				log_error "--model requires a value"
+				return 1
+			}
+			model="$2"
+			shift 2
+			;;
+		--provider)
+			[[ $# -lt 2 ]] && {
+				log_error "--provider requires a value"
+				return 1
+			}
+			provider="$2"
+			shift 2
+			;;
+		--format)
+			[[ $# -lt 2 ]] && {
+				log_error "--format requires a value"
+				return 1
+			}
+			format="$2"
+			shift 2
+			;;
+		--timeout)
+			[[ $# -lt 2 ]] && {
+				log_error "--timeout requires a value"
+				return 1
+			}
+			cmd_timeout="$2"
+			shift 2
+			;;
+		--continue | -c)
+			continue_session=true
+			shift
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
 
-    local dir
-    dir=$(runner_dir "$name")
+	local dir
+	dir=$(runner_dir "$name")
 
-    # Resolve model (flag > config > default), with tier name support (t132.7)
-    if [[ -z "$model" ]]; then
-        model=$(runner_config "$name" "model")
-        if [[ -z "$model" ]]; then
-            model="$DEFAULT_MODEL"
-        fi
-    fi
-    model=$(resolve_model_tier "$model")
+	# Resolve model (flag > config > default), with tier name support (t132.7)
+	if [[ -z "$model" ]]; then
+		model=$(runner_config "$name" "model")
+		if [[ -z "$model" ]]; then
+			model="$DEFAULT_MODEL"
+		fi
+	fi
+	model=$(resolve_model_tier "$model")
 
-    # Apply provider override if specified (t132.7)
-    if [[ -n "$provider" && "$model" == *"/"* ]]; then
-        local model_id="${model#*/}"
-        model="${provider}/${model_id}"
-    fi
+	# Apply provider override if specified (t132.7)
+	if [[ -n "$provider" && "$model" == *"/"* ]]; then
+		local model_id="${model#*/}"
+		model="${provider}/${model_id}"
+	fi
 
-    # Resolve workdir
-    local workdir
-    workdir=$(runner_config "$name" "workdir")
-    if [[ -z "$workdir" ]]; then
-        workdir="$(pwd)"
-    fi
+	# Resolve workdir
+	local workdir
+	workdir=$(runner_config "$name" "workdir")
+	if [[ -z "$workdir" ]]; then
+		workdir="$(pwd)"
+	fi
 
-    # Build opencode run command
-    local -a cmd_args=("opencode" "run")
+	# Build opencode run command
+	local -a cmd_args=("opencode" "run")
 
-    # Attach to server if specified
-    if [[ -n "$attach" ]]; then
-        cmd_args+=("--attach" "$attach")
-    fi
+	# Attach to server if specified
+	if [[ -n "$attach" ]]; then
+		cmd_args+=("--attach" "$attach")
+	fi
 
-    # Model
-    cmd_args+=("-m" "$model")
+	# Model
+	cmd_args+=("-m" "$model")
 
-    # Session title
-    cmd_args+=("--title" "runner/$name")
+	# Session title
+	cmd_args+=("--title" "runner/$name")
 
-    # Continue previous session if requested
-    if [[ "$continue_session" == "true" ]]; then
-        local session_id=""
-        if [[ -f "$dir/session.id" ]]; then
-            session_id=$(cat "$dir/session.id")
-        fi
-        if [[ -n "$session_id" ]]; then
-            cmd_args+=("-s" "$session_id")
-        else
-            log_warn "No previous session found for $name, starting fresh"
-        fi
-    fi
+	# Continue previous session if requested
+	if [[ "$continue_session" == "true" ]]; then
+		local session_id=""
+		if [[ -f "$dir/session.id" ]]; then
+			session_id=$(cat "$dir/session.id")
+		fi
+		if [[ -n "$session_id" ]]; then
+			cmd_args+=("-s" "$session_id")
+		else
+			log_warn "No previous session found for $name, starting fresh"
+		fi
+	fi
 
-    # Output format
-    if [[ -n "$format" ]]; then
-        cmd_args+=("--format" "$format")
-    fi
+	# Output format
+	if [[ -n "$format" ]]; then
+		cmd_args+=("--format" "$format")
+	fi
 
-    # Mailbox bookend: check inbox before work
-    local mailbox_context
-    mailbox_context=$(mailbox_before_run "$name" 2>/dev/null || true)
+	# Mailbox bookend: check inbox before work
+	local mailbox_context
+	mailbox_context=$(mailbox_before_run "$name" 2>/dev/null || true)
 
-    # Memory auto-recall: retrieve relevant memories before work
-    local memory_context=""
-    
-    # Recall recent memories (last 5)
-    local recent_memories=""
-    if [[ -x "$MEMORY_HELPER" ]]; then
-        recent_memories=$("$MEMORY_HELPER" --namespace "$name" recall --recent --limit 5 --format text 2>/dev/null || echo "")
-    fi
-    
-    # If we have a task description in the prompt, also recall task-specific memories
-    local task_memories=""
-    if [[ -n "$prompt" && -x "$MEMORY_HELPER" ]]; then
-        task_memories=$("$MEMORY_HELPER" --namespace "$name" recall --query "$prompt" --limit 5 --format text 2>/dev/null || echo "")
-    fi
-    
-    # Combine memory contexts
-    if [[ -n "$recent_memories" || -n "$task_memories" ]]; then
-        memory_context="## Memory Context (relevant learnings from previous runs)
+	# Memory auto-recall: retrieve relevant memories before work
+	local memory_context=""
+
+	# Recall recent memories (last 5)
+	local recent_memories=""
+	if [[ -x "$MEMORY_HELPER" ]]; then
+		recent_memories=$("$MEMORY_HELPER" --namespace "$name" recall --recent --limit 5 --format text 2>/dev/null || echo "")
+	fi
+
+	# If we have a task description in the prompt, also recall task-specific memories
+	local task_memories=""
+	if [[ -n "$prompt" && -x "$MEMORY_HELPER" ]]; then
+		task_memories=$("$MEMORY_HELPER" --namespace "$name" recall --query "$prompt" --limit 5 --format text 2>/dev/null || echo "")
+	fi
+
+	# Combine memory contexts
+	if [[ -n "$recent_memories" || -n "$task_memories" ]]; then
+		memory_context="## Memory Context (relevant learnings from previous runs)
 
 "
-        if [[ -n "$recent_memories" ]]; then
-            memory_context="${memory_context}### Recent Memories
+		if [[ -n "$recent_memories" ]]; then
+			memory_context="${memory_context}### Recent Memories
 
 $recent_memories
 
 "
-        fi
-        if [[ -n "$task_memories" ]]; then
-            memory_context="${memory_context}### Task-Relevant Memories
+		fi
+		if [[ -n "$task_memories" ]]; then
+			memory_context="${memory_context}### Task-Relevant Memories
 
 $task_memories
 
 "
-        fi
-        log_info "Retrieved memory context for runner: $name"
-    fi
+		fi
+		log_info "Retrieved memory context for runner: $name"
+	fi
 
-    # Build the full prompt with runner context
-    local agents_md="$dir/AGENTS.md"
-    local full_prompt
-    if [[ -f "$agents_md" ]]; then
-        local instructions
-        instructions=$(cat "$agents_md")
-        full_prompt="$instructions
+	# Build the full prompt with runner context
+	local agents_md="$dir/AGENTS.md"
+	local full_prompt
+	if [[ -f "$agents_md" ]]; then
+		local instructions
+		instructions=$(cat "$agents_md")
+		full_prompt="$instructions
 
 ---
 
 ## Task
 
 $prompt"
-    else
-        full_prompt="$prompt"
-    fi
+	else
+		full_prompt="$prompt"
+	fi
 
-    # Prepend memory context if available
-    if [[ -n "$memory_context" ]]; then
-        full_prompt="$memory_context
+	# Prepend memory context if available
+	if [[ -n "$memory_context" ]]; then
+		full_prompt="$memory_context
 
 ---
 
 $full_prompt"
-    fi
+	fi
 
-    # Prepend mailbox context if there are unread messages
-    if [[ -n "$mailbox_context" ]] && echo "$mailbox_context" | grep -q '^Total:.*([1-9][0-9]* unread)'; then
-        full_prompt="## Mailbox (unread messages from other agents)
+	# Prepend mailbox context if there are unread messages
+	if [[ -n "$mailbox_context" ]] && echo "$mailbox_context" | grep -q '^Total:.*([1-9][0-9]* unread)'; then
+		full_prompt="## Mailbox (unread messages from other agents)
 
 $mailbox_context
 
 ---
 
 $full_prompt"
-        log_info "Prepended mailbox context to prompt"
-    fi
+		log_info "Prepended mailbox context to prompt"
+	fi
 
-    cmd_args+=("$full_prompt")
+	cmd_args+=("$full_prompt")
 
-    # Log the run
-    local run_timestamp
-    run_timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    local run_id
-    run_id="run-$(date +%s)"
-    local log_file="$dir/runs/${run_id}.log"
+	# Log the run
+	local run_timestamp
+	run_timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	local run_id
+	run_id="run-$(date +%s)"
+	local log_file="$dir/runs/${run_id}.log"
 
-    log_info "Dispatching to runner: $name"
-    log_info "Model: $model"
-    log_info "Run ID: $run_id"
+	log_info "Dispatching to runner: $name"
+	log_info "Model: $model"
+	log_info "Run ID: $run_id"
 
-    # Execute with timeout (gtimeout on macOS, timeout on Linux)
-    local timeout_cmd=""
-    if command -v gtimeout &>/dev/null; then
-        timeout_cmd="gtimeout"
-    elif command -v timeout &>/dev/null; then
-        timeout_cmd="timeout"
-    fi
+	# Execute with timeout (gtimeout on macOS, timeout on Linux)
+	local timeout_cmd=""
+	if command -v gtimeout &>/dev/null; then
+		timeout_cmd="gtimeout"
+	elif command -v timeout &>/dev/null; then
+		timeout_cmd="timeout"
+	fi
 
-    local exit_code=0
-    local start_time
-    start_time=$(date +%s)
+	local exit_code=0
+	local start_time
+	start_time=$(date +%s)
 
-    if [[ -n "$timeout_cmd" ]]; then
-        if "$timeout_cmd" "$cmd_timeout" "${cmd_args[@]}" 2>&1 | tee "$log_file"; then
-            exit_code=0
-        else
-            exit_code=$?
-        fi
-    else
-        if "${cmd_args[@]}" 2>&1 | tee "$log_file"; then
-            exit_code=0
-        else
-            exit_code=$?
-        fi
-    fi
+	if [[ -n "$timeout_cmd" ]]; then
+		if "$timeout_cmd" "$cmd_timeout" "${cmd_args[@]}" 2>&1 | tee "$log_file"; then
+			exit_code=0
+		else
+			exit_code=$?
+		fi
+	else
+		if "${cmd_args[@]}" 2>&1 | tee "$log_file"; then
+			exit_code=0
+		else
+			exit_code=$?
+		fi
+	fi
 
-    local end_time duration
-    end_time=$(date +%s)
-    duration=$((end_time - start_time))
+	local end_time duration
+	end_time=$(date +%s)
+	duration=$((end_time - start_time))
 
-    # Update config with run metadata
-    local temp_file
-    temp_file=$(mktemp)
-    _save_cleanup_scope; trap '_run_cleanups' RETURN
-    push_cleanup "rm -f '${temp_file}'"
-    local status="success"
-    if [[ $exit_code -ne 0 ]]; then
-        status="failed"
-    fi
+	# Update config with run metadata
+	local temp_file
+	temp_file=$(mktemp)
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	push_cleanup "rm -f '${temp_file}'"
+	local status="success"
+	if [[ $exit_code -ne 0 ]]; then
+		status="failed"
+	fi
 
-    jq --arg timestamp "$run_timestamp" \
-       --arg status "$status" \
-       --argjson duration "$duration" \
-       '.lastRun = $timestamp | .lastStatus = $status | .lastDuration = $duration | .runCount += 1' \
-       "$dir/config.json" > "$temp_file"
-    mv "$temp_file" "$dir/config.json"
+	jq --arg timestamp "$run_timestamp" \
+		--arg status "$status" \
+		--argjson duration "$duration" \
+		'.lastRun = $timestamp | .lastStatus = $status | .lastDuration = $duration | .runCount += 1' \
+		"$dir/config.json" >"$temp_file"
+	mv "$temp_file" "$dir/config.json"
 
-    if [[ $exit_code -eq 0 ]]; then
-        log_success "Run complete (${duration}s)"
-    else
-        log_error "Run failed after ${duration}s (exit code: $exit_code)"
-    fi
+	if [[ $exit_code -eq 0 ]]; then
+		log_success "Run complete (${duration}s)"
+	else
+		log_error "Run failed after ${duration}s (exit code: $exit_code)"
+	fi
 
-    # Mailbox bookend: report status after work
-    mailbox_after_run "$name" "$status" "$duration" "$run_id" 2>/dev/null || true
+	# Mailbox bookend: report status after work
+	mailbox_after_run "$name" "$status" "$duration" "$run_id" 2>/dev/null || true
 
-    return "$exit_code"
+	return "$exit_code"
 }
 
 #######################################
 # Show runner status
 #######################################
 cmd_status() {
-    check_jq || return 1
+	check_jq || return 1
 
-    local name="${1:-}"
+	local name="${1:-}"
 
-    if [[ -z "$name" ]]; then
-        log_error "Runner name required"
-        return 1
-    fi
+	if [[ -z "$name" ]]; then
+		log_error "Runner name required"
+		return 1
+	fi
 
-    if ! runner_exists "$name"; then
-        log_error "Runner not found: $name"
-        return 1
-    fi
+	if ! runner_exists "$name"; then
+		log_error "Runner not found: $name"
+		return 1
+	fi
 
-    local dir
-    dir=$(runner_dir "$name")
-    local config="$dir/config.json"
+	local dir
+	dir=$(runner_dir "$name")
+	local config="$dir/config.json"
 
-    local description model workdir created last_run last_status run_count last_duration
-    local config_values
-    config_values=$(jq -r '[
+	local description model workdir created last_run last_status run_count last_duration
+	local config_values
+	config_values=$(jq -r '[
         .description // "N/A",
         .model // "N/A",
         .workdir // "N/A",
@@ -607,315 +680,344 @@ cmd_status() {
         (.lastDuration // "N/A" | tostring)
     ] | join("\n")' "$config")
 
-    {
-        read -r description
-        read -r model
-        read -r workdir
-        read -r created
-        read -r last_run
-        read -r last_status
-        read -r run_count
-        read -r last_duration
-    } <<< "$config_values"
+	{
+		read -r description
+		read -r model
+		read -r workdir
+		read -r created
+		read -r last_run
+		read -r last_status
+		read -r run_count
+		read -r last_duration
+	} <<<"$config_values"
 
-    local status_color="$NC"
-    case "$last_status" in
-        success) status_color="$GREEN" ;;
-        failed) status_color="$RED" ;;
-    esac
+	local status_color="$NC"
+	case "$last_status" in
+	success) status_color="$GREEN" ;;
+	failed) status_color="$RED" ;;
+	esac
 
-    echo -e "${BOLD}Runner: $name${NC}"
-    echo "──────────────────────────────────"
-    echo "Description: $description"
-    echo "Model: $model"
-    echo "Workdir: $workdir"
-    echo "Created: $created"
-    echo ""
-    echo "Total runs: $run_count"
-    echo "Last run: $last_run"
-    echo -e "Last status: ${status_color}${last_status}${NC}"
-    echo "Last duration: ${last_duration}s"
-    echo ""
-    echo "Directory: $dir"
+	echo -e "${BOLD}Runner: $name${NC}"
+	echo "──────────────────────────────────"
+	echo "Description: $description"
+	echo "Model: $model"
+	echo "Workdir: $workdir"
+	echo "Created: $created"
+	echo ""
+	echo "Total runs: $run_count"
+	echo "Last run: $last_run"
+	echo -e "Last status: ${status_color}${last_status}${NC}"
+	echo "Last duration: ${last_duration}s"
+	echo ""
+	echo "Directory: $dir"
 
-    # Check for session file
-    if [[ -f "$dir/session.id" ]]; then
-        echo "Session ID: $(cat "$dir/session.id")"
-    fi
+	# Check for session file
+	if [[ -f "$dir/session.id" ]]; then
+		echo "Session ID: $(cat "$dir/session.id")"
+	fi
 
-    # Check for memory namespace
-    if [[ -x "$MEMORY_HELPER" ]]; then
-        local mem_count
-        mem_count=$("$MEMORY_HELPER" --namespace "$name" stats 2>/dev/null | grep -c "Total" || echo "0")
-        if [[ "$mem_count" -gt 0 ]]; then
-            echo "Memory entries: $mem_count"
-        fi
-    fi
+	# Check for memory namespace
+	if [[ -x "$MEMORY_HELPER" ]]; then
+		local mem_count
+		mem_count=$("$MEMORY_HELPER" --namespace "$name" stats 2>/dev/null | grep -c "Total" || echo "0")
+		if [[ "$mem_count" -gt 0 ]]; then
+			echo "Memory entries: $mem_count"
+		fi
+	fi
 
-    return 0
+	return 0
 }
 
 #######################################
 # List all runners
 #######################################
 cmd_list() {
-    local output_format="table"
+	local output_format="table"
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --format) [[ $# -lt 2 ]] && { log_error "--format requires a value"; return 1; }; output_format="$2"; shift 2 ;;
-            *) log_error "Unknown option: $1"; return 1 ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--format)
+			[[ $# -lt 2 ]] && {
+				log_error "--format requires a value"
+				return 1
+			}
+			output_format="$2"
+			shift 2
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
 
-    if [[ ! -d "$RUNNERS_DIR" ]]; then
-        log_info "No runners configured"
-        echo ""
-        echo "Create one with:"
-        echo "  runner-helper.sh create my-runner --description \"What it does\""
-        return 0
-    fi
+	if [[ ! -d "$RUNNERS_DIR" ]]; then
+		log_info "No runners configured"
+		echo ""
+		echo "Create one with:"
+		echo "  runner-helper.sh create my-runner --description \"What it does\""
+		return 0
+	fi
 
-    local runners
-    runners=$(find "$RUNNERS_DIR" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort)
+	local runners
+	runners=$(find "$RUNNERS_DIR" -maxdepth 1 -mindepth 1 -type d 2>/dev/null | sort)
 
-    if [[ -z "$runners" ]]; then
-        log_info "No runners configured"
-        return 0
-    fi
+	if [[ -z "$runners" ]]; then
+		log_info "No runners configured"
+		return 0
+	fi
 
-    if [[ "$output_format" == "json" ]]; then
-        local -a config_files=()
-        for runner_path in $runners; do
-            local config_file="$runner_path/config.json"
-            if [[ -f "$config_file" ]]; then
-                config_files+=("$config_file")
-            fi
-        done
+	if [[ "$output_format" == "json" ]]; then
+		local -a config_files=()
+		for runner_path in $runners; do
+			local config_file="$runner_path/config.json"
+			if [[ -f "$config_file" ]]; then
+				config_files+=("$config_file")
+			fi
+		done
 
-        if (( ${#config_files[@]} > 0 )); then
-            jq -s . "${config_files[@]}"
-        else
-            echo "[]"
-        fi
-        return 0
-    fi
+		if ((${#config_files[@]} > 0)); then
+			jq -s . "${config_files[@]}"
+		else
+			echo "[]"
+		fi
+		return 0
+	fi
 
-    printf "${BOLD}%-20s %-35s %-12s %s${NC}\n" "Name" "Description" "Runs" "Last Status"
-    printf "%-20s %-35s %-12s %s\n" "──────────────────" "─────────────────────────────────" "──────────" "───────────"
+	printf "${BOLD}%-20s %-35s %-12s %s${NC}\n" "Name" "Description" "Runs" "Last Status"
+	printf "%-20s %-35s %-12s %s\n" "──────────────────" "─────────────────────────────────" "──────────" "───────────"
 
-    for runner_path in $runners; do
-        local rname
-        rname=$(basename "$runner_path")
-        local config_file="$runner_path/config.json"
+	for runner_path in $runners; do
+		local rname
+		rname=$(basename "$runner_path")
+		local config_file="$runner_path/config.json"
 
-        if [[ ! -f "$config_file" ]]; then
-            continue
-        fi
+		if [[ ! -f "$config_file" ]]; then
+			continue
+		fi
 
-        local description run_count last_status
-        description=$(jq -r '.description // "N/A"' "$config_file")
-        run_count=$(jq -r '.runCount // 0' "$config_file")
-        last_status=$(jq -r '.lastStatus // "N/A"' "$config_file")
+		local description run_count last_status
+		description=$(jq -r '.description // "N/A"' "$config_file")
+		run_count=$(jq -r '.runCount // 0' "$config_file")
+		last_status=$(jq -r '.lastStatus // "N/A"' "$config_file")
 
-        local status_color="$NC"
-        case "$last_status" in
-            success) status_color="$GREEN" ;;
-            failed) status_color="$RED" ;;
-        esac
+		local status_color="$NC"
+		case "$last_status" in
+		success) status_color="$GREEN" ;;
+		failed) status_color="$RED" ;;
+		esac
 
-        printf "%-20s %-35s %-12s ${status_color}%s${NC}\n" \
-            "$rname" "${description:0:35}" "$run_count" "$last_status"
-    done
+		printf "%-20s %-35s %-12s ${status_color}%s${NC}\n" \
+			"$rname" "${description:0:35}" "$run_count" "$last_status"
+	done
 
-    return 0
+	return 0
 }
 
 #######################################
 # Edit runner AGENTS.md
 #######################################
 cmd_edit() {
-    local name="${1:-}"
+	local name="${1:-}"
 
-    if [[ -z "$name" ]]; then
-        log_error "Runner name required"
-        return 1
-    fi
+	if [[ -z "$name" ]]; then
+		log_error "Runner name required"
+		return 1
+	fi
 
-    if ! runner_exists "$name"; then
-        log_error "Runner not found: $name"
-        return 1
-    fi
+	if ! runner_exists "$name"; then
+		log_error "Runner not found: $name"
+		return 1
+	fi
 
-    local dir
-    dir=$(runner_dir "$name")
-    local agents_file="$dir/AGENTS.md"
+	local dir
+	dir=$(runner_dir "$name")
+	local agents_file="$dir/AGENTS.md"
 
-    local editor="${EDITOR:-vim}"
-    "$editor" "$agents_file"
+	local editor="${EDITOR:-vim}"
+	"$editor" "$agents_file"
 
-    log_success "Updated AGENTS.md for runner: $name"
-    return 0
+	log_success "Updated AGENTS.md for runner: $name"
+	return 0
 }
 
 #######################################
 # View runner logs
 #######################################
 cmd_logs() {
-    local name="${1:-}"
-    shift || true
+	local name="${1:-}"
+	shift || true
 
-    if [[ -z "$name" ]]; then
-        log_error "Runner name required"
-        return 1
-    fi
+	if [[ -z "$name" ]]; then
+		log_error "Runner name required"
+		return 1
+	fi
 
-    if ! runner_exists "$name"; then
-        log_error "Runner not found: $name"
-        return 1
-    fi
+	if ! runner_exists "$name"; then
+		log_error "Runner not found: $name"
+		return 1
+	fi
 
-    local tail_lines=50 follow=false
+	local tail_lines=50 follow=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --tail) [[ $# -lt 2 ]] && { log_error "--tail requires a value"; return 1; }; tail_lines="$2"; shift 2 ;;
-            --follow|-f) follow=true; shift ;;
-            *) log_error "Unknown option: $1"; return 1 ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--tail)
+			[[ $# -lt 2 ]] && {
+				log_error "--tail requires a value"
+				return 1
+			}
+			tail_lines="$2"
+			shift 2
+			;;
+		--follow | -f)
+			follow=true
+			shift
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
 
-    local dir
-    dir=$(runner_dir "$name")
-    local runs_dir="$dir/runs"
+	local dir
+	dir=$(runner_dir "$name")
+	local runs_dir="$dir/runs"
 
-    if [[ ! -d "$runs_dir" ]]; then
-        log_info "No run logs found for runner: $name"
-        return 0
-    fi
+	if [[ ! -d "$runs_dir" ]]; then
+		log_info "No run logs found for runner: $name"
+		return 0
+	fi
 
-    local log_files
-    log_files=$(find "$runs_dir" -name "*.log" -type f 2>/dev/null | sort -r)
+	local log_files
+	log_files=$(find "$runs_dir" -name "*.log" -type f 2>/dev/null | sort -r)
 
-    if [[ -z "$log_files" ]]; then
-        log_info "No run logs found for runner: $name"
-        return 0
-    fi
+	if [[ -z "$log_files" ]]; then
+		log_info "No run logs found for runner: $name"
+		return 0
+	fi
 
-    if [[ "$follow" == "true" ]]; then
-        local latest
-        latest=$(echo "$log_files" | head -1)
-        log_info "Following latest log: $(basename "$latest")"
-        tail -f "$latest"
-    else
-        local latest
-        latest=$(echo "$log_files" | head -1)
-        echo -e "${BOLD}Latest run: $(basename "$latest" .log)${NC}"
-        tail -n "$tail_lines" "$latest"
-    fi
+	if [[ "$follow" == "true" ]]; then
+		local latest
+		latest=$(echo "$log_files" | head -1)
+		log_info "Following latest log: $(basename "$latest")"
+		tail -f "$latest"
+	else
+		local latest
+		latest=$(echo "$log_files" | head -1)
+		echo -e "${BOLD}Latest run: $(basename "$latest" .log)${NC}"
+		tail -n "$tail_lines" "$latest"
+	fi
 
-    return 0
+	return 0
 }
 
 #######################################
 # Stop a running session (abort)
 #######################################
 cmd_stop() {
-    check_jq || return 1
+	check_jq || return 1
 
-    local name="${1:-}"
+	local name="${1:-}"
 
-    if [[ -z "$name" ]]; then
-        log_error "Runner name required"
-        return 1
-    fi
+	if [[ -z "$name" ]]; then
+		log_error "Runner name required"
+		return 1
+	fi
 
-    if ! runner_exists "$name"; then
-        log_error "Runner not found: $name"
-        return 1
-    fi
+	if ! runner_exists "$name"; then
+		log_error "Runner not found: $name"
+		return 1
+	fi
 
-    local dir
-    dir=$(runner_dir "$name")
+	local dir
+	dir=$(runner_dir "$name")
 
-    if [[ ! -f "$dir/session.id" ]]; then
-        log_warn "No active session found for runner: $name"
-        return 0
-    fi
+	if [[ ! -f "$dir/session.id" ]]; then
+		log_warn "No active session found for runner: $name"
+		return 0
+	fi
 
-    local session_id
-    session_id=$(cat "$dir/session.id")
+	local session_id
+	session_id=$(cat "$dir/session.id")
 
-    local protocol
-    protocol=$(get_protocol "$OPENCODE_HOST")
-    local url="${protocol}://${OPENCODE_HOST}:${OPENCODE_PORT}/session/${session_id}/abort"
+	local protocol
+	protocol=$(get_protocol "$OPENCODE_HOST")
+	local url="${protocol}://${OPENCODE_HOST}:${OPENCODE_PORT}/session/${session_id}/abort"
 
-    build_curl_args
+	build_curl_args
 
-    if curl "${CURL_ARGS[@]}" -X POST "$url" &>/dev/null; then
-        log_success "Aborted session for runner: $name"
-    else
-        log_warn "Could not abort session (may not be running)"
-    fi
+	if curl "${CURL_ARGS[@]}" -X POST "$url" &>/dev/null; then
+		log_success "Aborted session for runner: $name"
+	else
+		log_warn "Could not abort session (may not be running)"
+	fi
 
-    return 0
+	return 0
 }
 
 #######################################
 # Destroy a runner
 #######################################
 cmd_destroy() {
-    local name="${1:-}"
-    shift || true
+	local name="${1:-}"
+	shift || true
 
-    if [[ -z "$name" ]]; then
-        log_error "Runner name required"
-        return 1
-    fi
+	if [[ -z "$name" ]]; then
+		log_error "Runner name required"
+		return 1
+	fi
 
-    if ! runner_exists "$name"; then
-        log_error "Runner not found: $name"
-        return 1
-    fi
+	if ! runner_exists "$name"; then
+		log_error "Runner not found: $name"
+		return 1
+	fi
 
-    local force=false
+	local force=false
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --force) force=true; shift ;;
-            *) log_error "Unknown option: $1"; return 1 ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--force)
+			force=true
+			shift
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
 
-    if [[ "$force" != "true" ]]; then
-        echo -n "Destroy runner '$name' and all its data? [y/N] "
-        read -r confirm
-        if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-            log_info "Cancelled"
-            return 0
-        fi
-    fi
+	if [[ "$force" != "true" ]]; then
+		echo -n "Destroy runner '$name' and all its data? [y/N] "
+		read -r confirm
+		if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+			log_info "Cancelled"
+			return 0
+		fi
+	fi
 
-    local dir
-    dir=$(runner_dir "$name")
-    rm -rf "$dir"
+	local dir
+	dir=$(runner_dir "$name")
+	rm -rf "$dir"
 
-    # Clean up memory namespace if it exists
-    local ns_dir="$HOME/.aidevops/.agent-workspace/memory/namespaces/$name"
-    if [[ -d "$ns_dir" ]]; then
-        rm -rf "$ns_dir"
-        log_info "Removed memory namespace: $name"
-    fi
+	# Clean up memory namespace if it exists
+	local ns_dir="$HOME/.aidevops/.agent-workspace/memory/namespaces/$name"
+	if [[ -d "$ns_dir" ]]; then
+		rm -rf "$ns_dir"
+		log_info "Removed memory namespace: $name"
+	fi
 
-    log_success "Destroyed runner: $name"
-    return 0
+	log_success "Destroyed runner: $name"
+	return 0
 }
 
 #######################################
 # Show help
 #######################################
 cmd_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 runner-helper.sh - Named headless AI agent instances
 
 USAGE:
@@ -958,7 +1060,7 @@ EXAMPLES:
     # Create a code reviewer
     runner-helper.sh create code-reviewer \
       --description "Reviews code for security and quality" \
-      --model anthropic/claude-sonnet-4-20250514
+      --model anthropic/claude-sonnet-4-6
 
     # Run a review task
     runner-helper.sh run code-reviewer "Review src/auth/ for vulnerabilities"
@@ -999,21 +1101,25 @@ EOF
 # Main
 #######################################
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    case "$command" in
-        create) cmd_create "$@" ;;
-        run) cmd_run "$@" ;;
-        status) cmd_status "$@" ;;
-        list) cmd_list "$@" ;;
-        edit) cmd_edit "$@" ;;
-        logs) cmd_logs "$@" ;;
-        stop) cmd_stop "$@" ;;
-        destroy) cmd_destroy "$@" ;;
-        help|--help|-h) cmd_help ;;
-        *) log_error "Unknown command: $command"; cmd_help; return 1 ;;
-    esac
+	case "$command" in
+	create) cmd_create "$@" ;;
+	run) cmd_run "$@" ;;
+	status) cmd_status "$@" ;;
+	list) cmd_list "$@" ;;
+	edit) cmd_edit "$@" ;;
+	logs) cmd_logs "$@" ;;
+	stop) cmd_stop "$@" ;;
+	destroy) cmd_destroy "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -142,9 +142,9 @@ readonly CI_BACKOFF_MAX=120      # Maximum wait between polls
 readonly CI_BACKOFF_MULTIPLIER=2 # Multiply wait by this each iteration
 
 # Service-specific timeouts (max time to wait before giving up)
-readonly CI_TIMEOUT_FAST=60      # 1 minute for fast checks
-readonly CI_TIMEOUT_MEDIUM=180   # 3 minutes for medium checks
-readonly CI_TIMEOUT_SLOW=600     # 10 minutes for slow checks (CodeRabbit)
+readonly CI_TIMEOUT_FAST=60    # 1 minute for fast checks
+readonly CI_TIMEOUT_MEDIUM=180 # 3 minutes for medium checks
+readonly CI_TIMEOUT_SLOW=600   # 10 minutes for slow checks (CodeRabbit)
 
 # =============================================================================
 # Color Constants (for consistent output formatting)
@@ -178,77 +178,89 @@ readonly NC="$COLOR_RESET"
 
 # Print error message with consistent formatting
 print_shared_error() {
-    local msg="$1"
-    echo -e "${COLOR_RED}[ERROR]${COLOR_RESET} $msg" >&2
-    return 0
+	local msg="$1"
+	echo -e "${COLOR_RED}[ERROR]${COLOR_RESET} $msg" >&2
+	return 0
 }
 
 # Print success message with consistent formatting
 print_shared_success() {
-    local msg="$1"
-    echo -e "${COLOR_GREEN}[SUCCESS]${COLOR_RESET} $msg"
-    return 0
+	local msg="$1"
+	echo -e "${COLOR_GREEN}[SUCCESS]${COLOR_RESET} $msg"
+	return 0
 }
 
 # Print warning message with consistent formatting
 print_shared_warning() {
-    local msg="$1"
-    echo -e "${COLOR_YELLOW}[WARNING]${COLOR_RESET} $msg"
-    return 0
+	local msg="$1"
+	echo -e "${COLOR_YELLOW}[WARNING]${COLOR_RESET} $msg"
+	return 0
 }
 
 # Print info message with consistent formatting
 print_shared_info() {
-    local msg="$1"
-    echo -e "${COLOR_BLUE}[INFO]${COLOR_RESET} $msg"
-    return 0
+	local msg="$1"
+	echo -e "${COLOR_BLUE}[INFO]${COLOR_RESET} $msg"
+	return 0
 }
 
 # Short aliases (used by most scripts - avoids needing inline redefinitions)
-print_error() { print_shared_error "$1"; return $?; }
-print_success() { print_shared_success "$1"; return $?; }
-print_warning() { print_shared_warning "$1"; return $?; }
-print_info() { print_shared_info "$1"; return $?; }
+print_error() {
+	print_shared_error "$1"
+	return $?
+}
+print_success() {
+	print_shared_success "$1"
+	return $?
+}
+print_warning() {
+	print_shared_warning "$1"
+	return $?
+}
+print_info() {
+	print_shared_info "$1"
+	return $?
+}
 
 # Validate required parameter
 validate_required_param() {
-    local param_name="$1"
-    local param_value="$2"
-    
-    if [[ -z "$param_value" ]]; then
-        print_shared_error "$param_name is required"
-        return 1
-    fi
-    return 0
+	local param_name="$1"
+	local param_value="$2"
+
+	if [[ -z "$param_value" ]]; then
+		print_shared_error "$param_name is required"
+		return 1
+	fi
+	return 0
 }
 
 # Check if file exists and is readable
 validate_file_exists() {
-    local file_path="$1"
-    local file_description="${2:-File}"
-    
-    if [[ ! -f "$file_path" ]]; then
-        print_shared_error "$file_description not found: $file_path"
-        return 1
-    fi
-    
-    if [[ ! -r "$file_path" ]]; then
-        print_shared_error "$file_description is not readable: $file_path"
-        return 1
-    fi
-    
-    return 0
+	local file_path="$1"
+	local file_description="${2:-File}"
+
+	if [[ ! -f "$file_path" ]]; then
+		print_shared_error "$file_description not found: $file_path"
+		return 1
+	fi
+
+	if [[ ! -r "$file_path" ]]; then
+		print_shared_error "$file_description is not readable: $file_path"
+		return 1
+	fi
+
+	return 0
 }
 
 # Check if command exists
 validate_command_exists() {
-    local command_name="$1"
-    
-    if ! command -v "$command_name" &> /dev/null; then
-        print_shared_error "Required command not found: $command_name"
-        return 1
-    fi
-    return 0
+	local command_name="$1"
+
+	if ! command -v "$command_name" &>/dev/null; then
+		print_shared_error "Required command not found: $command_name"
+		return 1
+	fi
+	return 0
 }
 
 # =============================================================================
@@ -259,29 +271,29 @@ validate_command_exists() {
 # =============================================================================
 
 sed_inplace() {
-    if [[ "$(uname)" == "Darwin" ]]; then
-        sed -i '' "$@"
-    else
-        sed -i "$@"
-    fi
-    return $?
+	if [[ "$(uname)" == "Darwin" ]]; then
+		sed -i '' "$@"
+	else
+		sed -i "$@"
+	fi
+	return $?
 }
 
 # Portable sed append-after-line (macOS vs GNU/Linux)
 # BSD sed 'a' requires a backslash-newline; GNU sed accepts inline text.
 # Usage: sed_append_after <line_number> <text_to_insert> <file>
 sed_append_after() {
-    local line_num="$1"
-    local text="$2"
-    local file="$3"
-    if [[ "$(uname)" == "Darwin" ]]; then
-        sed -i '' "${line_num} a\\
+	local line_num="$1"
+	local text="$2"
+	local file="$3"
+	if [[ "$(uname)" == "Darwin" ]]; then
+		sed -i '' "${line_num} a\\
 ${text}
 " "$file"
-    else
-        sed -i "${line_num}a\\${text}" "$file"
-    fi
-    return $?
+	else
+		sed -i "${line_num}a\\${text}" "$file"
+	fi
+	return $?
 }
 
 # =============================================================================
@@ -302,39 +314,39 @@ ${text}
 # Sets AIDEVOPS_LOG_FILE to ~/.aidevops/logs/<script-name>.log
 # Call once at script start after sourcing shared-constants.sh.
 init_log_file() {
-    local script_name
-    script_name="$(basename "${BASH_SOURCE[1]:-${0:-unknown}}" .sh)"
-    local log_dir="${HOME}/.aidevops/logs"
-    mkdir -p "$log_dir" 2>/dev/null || true
-    AIDEVOPS_LOG_FILE="${log_dir}/${script_name}.log"
-    export AIDEVOPS_LOG_FILE
-    return 0
+	local script_name
+	script_name="$(basename "${BASH_SOURCE[1]:-${0:-unknown}}" .sh)"
+	local log_dir="${HOME}/.aidevops/logs"
+	mkdir -p "$log_dir" 2>/dev/null || true
+	AIDEVOPS_LOG_FILE="${log_dir}/${script_name}.log"
+	export AIDEVOPS_LOG_FILE
+	return 0
 }
 
 # Run a command, redirecting stderr to the script's log file.
 # Preserves exit code. Falls back to /dev/null if no log file set.
 # Usage: log_stderr "db migration" sqlite3 "$db" "ALTER TABLE..."
 log_stderr() {
-    local context="$1"
-    shift
-    local log_target="${AIDEVOPS_LOG_FILE:-/dev/null}"
-    local timestamp
-    timestamp="$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "unknown")"
-    echo "[$timestamp] [$context] Running: $*" >> "$log_target" 2>/dev/null || true
-    "$@" 2>> "$log_target"
-    local rc=$?
-    if [[ $rc -ne 0 ]]; then
-        echo "[$timestamp] [$context] Exit code: $rc" >> "$log_target" 2>/dev/null || true
-    fi
-    return $rc
+	local context="$1"
+	shift
+	local log_target="${AIDEVOPS_LOG_FILE:-/dev/null}"
+	local timestamp
+	timestamp="$(date '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "unknown")"
+	echo "[$timestamp] [$context] Running: $*" >>"$log_target" 2>/dev/null || true
+	"$@" 2>>"$log_target"
+	local rc=$?
+	if [[ $rc -ne 0 ]]; then
+		echo "[$timestamp] [$context] Exit code: $rc" >>"$log_target" 2>/dev/null || true
+	fi
+	return $rc
 }
 
 # Suppress stderr with documented intent. Use for commands where stderr
 # is expected noise (e.g., command -v, kill -0, pgrep, sysctl on wrong OS).
 # Usage: suppress_stderr command -v jq
 suppress_stderr() {
-    "$@" 2>/dev/null
-    return $?
+	"$@" 2>/dev/null
+	return $?
 }
 
 # =============================================================================
@@ -392,41 +404,41 @@ _CLEANUP_SAVE_STACK=""
 # Arguments:
 #   $1 - shell command to eval on cleanup (required)
 push_cleanup() {
-    local cmd="$1"
-    if [[ -n "$_CLEANUP_CMDS" ]]; then
-        _CLEANUP_CMDS="${_CLEANUP_CMDS}"$'\n'"${cmd}"
-    else
-        _CLEANUP_CMDS="${cmd}"
-    fi
-    return 0
+	local cmd="$1"
+	if [[ -n "$_CLEANUP_CMDS" ]]; then
+		_CLEANUP_CMDS="${_CLEANUP_CMDS}"$'\n'"${cmd}"
+	else
+		_CLEANUP_CMDS="${cmd}"
+	fi
+	return 0
 }
 
 # Run all cleanup commands for the current scope (reverse order),
 # then restore the parent scope's cleanup list.
 # This is the RETURN trap handler — do not call directly.
 _run_cleanups() {
-    if [[ -n "$_CLEANUP_CMDS" ]]; then
-        # Reverse the command list (LIFO) and execute each
-        local reversed
-        # tail -r is macOS, tac is GNU — try both
-        reversed=$(echo "$_CLEANUP_CMDS" | tail -r 2>/dev/null) \
-            || reversed=$(echo "$_CLEANUP_CMDS" | tac 2>/dev/null) \
-            || reversed="$_CLEANUP_CMDS"
-        local line
-        while IFS= read -r line; do
-            [[ -z "$line" ]] && continue
-            eval "$line" 2>/dev/null || true
-        done <<< "$reversed"
-    fi
-    # Restore parent scope (pop from save stack)
-    local sep=$'\x1F'
-    if [[ -n "$_CLEANUP_SAVE_STACK" ]]; then
-        _CLEANUP_CMDS="${_CLEANUP_SAVE_STACK%%"${sep}"*}"
-        _CLEANUP_SAVE_STACK="${_CLEANUP_SAVE_STACK#*"${sep}"}"
-    else
-        _CLEANUP_CMDS=""
-    fi
-    return 0
+	if [[ -n "$_CLEANUP_CMDS" ]]; then
+		# Reverse the command list (LIFO) and execute each
+		local reversed
+		# tail -r is macOS, tac is GNU — try both
+		reversed=$(echo "$_CLEANUP_CMDS" | tail -r 2>/dev/null) ||
+			reversed=$(echo "$_CLEANUP_CMDS" | tac 2>/dev/null) ||
+			reversed="$_CLEANUP_CMDS"
+		local line
+		while IFS= read -r line; do
+			[[ -z "$line" ]] && continue
+			eval "$line" 2>/dev/null || true
+		done <<<"$reversed"
+	fi
+	# Restore parent scope (pop from save stack)
+	local sep=$'\x1F'
+	if [[ -n "$_CLEANUP_SAVE_STACK" ]]; then
+		_CLEANUP_CMDS="${_CLEANUP_SAVE_STACK%%"${sep}"*}"
+		_CLEANUP_SAVE_STACK="${_CLEANUP_SAVE_STACK#*"${sep}"}"
+	else
+		_CLEANUP_CMDS=""
+	fi
+	return 0
 }
 
 # Save the current cleanup scope and start a fresh one.
@@ -434,10 +446,10 @@ _run_cleanups() {
 # `trap '_run_cleanups' RETURN`. This preserves the parent function's
 # cleanup list so nested calls don't interfere.
 _save_cleanup_scope() {
-    local sep=$'\x1F'
-    _CLEANUP_SAVE_STACK="${_CLEANUP_CMDS}${sep}${_CLEANUP_SAVE_STACK}"
-    _CLEANUP_CMDS=""
-    return 0
+	local sep=$'\x1F'
+	_CLEANUP_SAVE_STACK="${_CLEANUP_CMDS}${sep}${_CLEANUP_SAVE_STACK}"
+	_CLEANUP_CMDS=""
+	return 0
 }
 
 # =============================================================================
@@ -466,145 +478,145 @@ readonly TODO_STALE_LOCK_AGE=120
 # Portable atomic lock using mkdir (works on macOS + Linux).
 # mkdir is atomic on all POSIX systems -- only one process succeeds.
 _todo_acquire_lock() {
-    local log_target="${1:-/dev/null}"
-    local waited=0
+	local log_target="${1:-/dev/null}"
+	local waited=0
 
-    while [[ $waited -lt $TODO_LOCK_TIMEOUT ]]; do
-        if mkdir "$TODO_LOCK_PATH" 2>/dev/null; then
-            echo $$ > "$TODO_LOCK_PATH/pid"
-            return 0
-        fi
+	while [[ $waited -lt $TODO_LOCK_TIMEOUT ]]; do
+		if mkdir "$TODO_LOCK_PATH" 2>/dev/null; then
+			echo $$ >"$TODO_LOCK_PATH/pid"
+			return 0
+		fi
 
-        # Check for stale lock (owner process died)
-        if [[ -f "$TODO_LOCK_PATH/pid" ]]; then
-            local lock_pid
-            lock_pid=$(cat "$TODO_LOCK_PATH/pid" 2>/dev/null || echo "")
-            if [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
-                echo "[todo_lock] Removing stale lock (PID $lock_pid dead)" >> "$log_target"
-                rm -rf "$TODO_LOCK_PATH"
-                continue
-            fi
-        fi
+		# Check for stale lock (owner process died)
+		if [[ -f "$TODO_LOCK_PATH/pid" ]]; then
+			local lock_pid
+			lock_pid=$(cat "$TODO_LOCK_PATH/pid" 2>/dev/null || echo "")
+			if [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
+				echo "[todo_lock] Removing stale lock (PID $lock_pid dead)" >>"$log_target"
+				rm -rf "$TODO_LOCK_PATH"
+				continue
+			fi
+		fi
 
-        # Check lock age (safety net for orphaned locks)
-        if [[ -d "$TODO_LOCK_PATH" ]]; then
-            local lock_age
-            if [[ "$(uname)" == "Darwin" ]]; then
-                lock_age=$(( $(date +%s) - $(stat -f %m "$TODO_LOCK_PATH" 2>/dev/null || echo "0") ))
-            else
-                lock_age=$(( $(date +%s) - $(stat -c %Y "$TODO_LOCK_PATH" 2>/dev/null || echo "0") ))
-            fi
-            if [[ $lock_age -gt $TODO_STALE_LOCK_AGE ]]; then
-                echo "[todo_lock] Removing stale lock (age ${lock_age}s > ${TODO_STALE_LOCK_AGE}s)" >> "$log_target"
-                rm -rf "$TODO_LOCK_PATH"
-                continue
-            fi
-        fi
+		# Check lock age (safety net for orphaned locks)
+		if [[ -d "$TODO_LOCK_PATH" ]]; then
+			local lock_age
+			if [[ "$(uname)" == "Darwin" ]]; then
+				lock_age=$(($(date +%s) - $(stat -f %m "$TODO_LOCK_PATH" 2>/dev/null || echo "0")))
+			else
+				lock_age=$(($(date +%s) - $(stat -c %Y "$TODO_LOCK_PATH" 2>/dev/null || echo "0")))
+			fi
+			if [[ $lock_age -gt $TODO_STALE_LOCK_AGE ]]; then
+				echo "[todo_lock] Removing stale lock (age ${lock_age}s > ${TODO_STALE_LOCK_AGE}s)" >>"$log_target"
+				rm -rf "$TODO_LOCK_PATH"
+				continue
+			fi
+		fi
 
-        sleep 1
-        waited=$((waited + 1))
-    done
+		sleep 1
+		waited=$((waited + 1))
+	done
 
-    echo "[todo_lock] Failed to acquire lock after ${TODO_LOCK_TIMEOUT}s" >> "$log_target"
-    return 1
+	echo "[todo_lock] Failed to acquire lock after ${TODO_LOCK_TIMEOUT}s" >>"$log_target"
+	return 1
 }
 
 _todo_release_lock() {
-    rm -rf "$TODO_LOCK_PATH"
-    return 0
+	rm -rf "$TODO_LOCK_PATH"
+	return 0
 }
 
 todo_commit_push() {
-    local repo_path="$1"
-    local commit_msg="$2"
-    local files="${3:-TODO.md todo/}"
-    local log_target="${AIDEVOPS_LOG_FILE:-/dev/null}"
+	local repo_path="$1"
+	local commit_msg="$2"
+	local files="${3:-TODO.md todo/}"
+	local log_target="${AIDEVOPS_LOG_FILE:-/dev/null}"
 
-    mkdir -p "$TODO_LOCK_DIR" 2>/dev/null || true
+	mkdir -p "$TODO_LOCK_DIR" 2>/dev/null || true
 
-    if ! _todo_acquire_lock "$log_target"; then
-        return 1
-    fi
+	if ! _todo_acquire_lock "$log_target"; then
+		return 1
+	fi
 
-    # Ensure lock is released on exit (including signals)
-    trap '_todo_release_lock' EXIT
+	# Ensure lock is released on exit (including signals)
+	trap '_todo_release_lock' EXIT
 
-    local rc=0
-    _todo_commit_push_inner "$repo_path" "$commit_msg" "$files" "$log_target" || rc=$?
+	local rc=0
+	_todo_commit_push_inner "$repo_path" "$commit_msg" "$files" "$log_target" || rc=$?
 
-    _todo_release_lock
-    trap - EXIT
+	_todo_release_lock
+	trap - EXIT
 
-    return $rc
+	return $rc
 }
 
 _todo_commit_push_inner() {
-    local repo_path="$1"
-    local commit_msg="$2"
-    local files="$3"
-    local log_target="$4"
-    local attempt=0
+	local repo_path="$1"
+	local commit_msg="$2"
+	local files="$3"
+	local log_target="$4"
+	local attempt=0
 
-    while [[ $attempt -lt $TODO_MAX_RETRIES ]]; do
-        attempt=$((attempt + 1))
+	while [[ $attempt -lt $TODO_MAX_RETRIES ]]; do
+		attempt=$((attempt + 1))
 
-        # Pull latest before staging (rebase to keep linear history)
-        local current_branch
-        current_branch=$(git -C "$repo_path" branch --show-current 2>/dev/null || echo "main")
-        if git -C "$repo_path" remote get-url origin &>/dev/null; then
-            git -C "$repo_path" pull --rebase origin "$current_branch" 2>>"$log_target" || {
-                echo "[todo_commit_push] Pull --rebase failed (attempt $attempt/$TODO_MAX_RETRIES)" >> "$log_target"
-                # If rebase conflicts, abort and retry
-                git -C "$repo_path" rebase --abort 2>/dev/null || true
-                sleep 1
-                continue
-            }
-        fi
+		# Pull latest before staging (rebase to keep linear history)
+		local current_branch
+		current_branch=$(git -C "$repo_path" branch --show-current 2>/dev/null || echo "main")
+		if git -C "$repo_path" remote get-url origin &>/dev/null; then
+			git -C "$repo_path" pull --rebase origin "$current_branch" 2>>"$log_target" || {
+				echo "[todo_commit_push] Pull --rebase failed (attempt $attempt/$TODO_MAX_RETRIES)" >>"$log_target"
+				# If rebase conflicts, abort and retry
+				git -C "$repo_path" rebase --abort 2>/dev/null || true
+				sleep 1
+				continue
+			}
+		fi
 
-        # Stage planning files
-        local file
-        for file in $files; do
-            git -C "$repo_path" add "$file" 2>/dev/null || true
-        done
+		# Stage planning files
+		local file
+		for file in $files; do
+			git -C "$repo_path" add "$file" 2>/dev/null || true
+		done
 
-        # Check if anything was staged
-        if git -C "$repo_path" diff --cached --quiet 2>/dev/null; then
-            echo "[todo_commit_push] No changes staged" >> "$log_target"
-            return 0
-        fi
+		# Check if anything was staged
+		if git -C "$repo_path" diff --cached --quiet 2>/dev/null; then
+			echo "[todo_commit_push] No changes staged" >>"$log_target"
+			return 0
+		fi
 
-        # Commit
-        if ! git -C "$repo_path" commit -m "$commit_msg" --no-verify 2>>"$log_target"; then
-            echo "[todo_commit_push] Commit failed (attempt $attempt/$TODO_MAX_RETRIES)" >> "$log_target"
-            continue
-        fi
+		# Commit
+		if ! git -C "$repo_path" commit -m "$commit_msg" --no-verify 2>>"$log_target"; then
+			echo "[todo_commit_push] Commit failed (attempt $attempt/$TODO_MAX_RETRIES)" >>"$log_target"
+			continue
+		fi
 
-        # Push
-        if git -C "$repo_path" push origin "$current_branch" 2>>"$log_target"; then
-            echo "[todo_commit_push] Success on attempt $attempt" >> "$log_target"
-            return 0
-        fi
+		# Push
+		if git -C "$repo_path" push origin "$current_branch" 2>>"$log_target"; then
+			echo "[todo_commit_push] Success on attempt $attempt" >>"$log_target"
+			return 0
+		fi
 
-        echo "[todo_commit_push] Push failed (attempt $attempt/$TODO_MAX_RETRIES), retrying..." >> "$log_target"
+		echo "[todo_commit_push] Push failed (attempt $attempt/$TODO_MAX_RETRIES), retrying..." >>"$log_target"
 
-        # Push failed: pull --rebase to incorporate remote changes, then retry push
-        git -C "$repo_path" pull --rebase origin "$current_branch" 2>>"$log_target" || {
-            git -C "$repo_path" rebase --abort 2>/dev/null || true
-            sleep 1
-            continue
-        }
+		# Push failed: pull --rebase to incorporate remote changes, then retry push
+		git -C "$repo_path" pull --rebase origin "$current_branch" 2>>"$log_target" || {
+			git -C "$repo_path" rebase --abort 2>/dev/null || true
+			sleep 1
+			continue
+		}
 
-        # Retry push after rebase
-        if git -C "$repo_path" push origin "$current_branch" 2>>"$log_target"; then
-            echo "[todo_commit_push] Success after rebase on attempt $attempt" >> "$log_target"
-            return 0
-        fi
+		# Retry push after rebase
+		if git -C "$repo_path" push origin "$current_branch" 2>>"$log_target"; then
+			echo "[todo_commit_push] Success after rebase on attempt $attempt" >>"$log_target"
+			return 0
+		fi
 
-        sleep $((attempt))
-    done
+		sleep $((attempt))
+	done
 
-    echo "[todo_commit_push] Failed after $TODO_MAX_RETRIES attempts" >> "$log_target"
-    return 1
+	echo "[todo_commit_push] Failed after $TODO_MAX_RETRIES attempts" >>"$log_target"
+	return 1
 }
 
 # =============================================================================
@@ -620,14 +632,14 @@ WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DIR}/worktree-registry.db"
 
 # SQL-escape a value for SQLite (double single quotes)
 _wt_sql_escape() {
-    local val="$1"
-    echo "${val//\'/\'\'}"
+	local val="$1"
+	echo "${val//\'/\'\'}"
 }
 
 # Initialize the registry database
 _init_registry_db() {
-    mkdir -p "$WORKTREE_REGISTRY_DIR" 2>/dev/null || true
-    sqlite3 "$WORKTREE_REGISTRY_DB" "
+	mkdir -p "$WORKTREE_REGISTRY_DIR" 2>/dev/null || true
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
         CREATE TABLE IF NOT EXISTS worktree_owners (
             worktree_path TEXT PRIMARY KEY,
             branch        TEXT,
@@ -638,7 +650,7 @@ _init_registry_db() {
             created_at    TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
         );
     " 2>/dev/null || true
-    return 0
+	return 0
 }
 
 # Register ownership of a worktree
@@ -647,23 +659,32 @@ _init_registry_db() {
 #   $2 - branch name (required)
 #   Flags: --task <id>, --batch <id>, --session <id>
 register_worktree() {
-    local wt_path="$1"
-    local branch="$2"
-    shift 2
+	local wt_path="$1"
+	local branch="$2"
+	shift 2
 
-    local task_id="" batch_id="" session_id=""
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --task) task_id="${2:-}"; shift 2 ;;
-            --batch) batch_id="${2:-}"; shift 2 ;;
-            --session) session_id="${2:-}"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	local task_id="" batch_id="" session_id=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--task)
+			task_id="${2:-}"
+			shift 2
+			;;
+		--batch)
+			batch_id="${2:-}"
+			shift 2
+			;;
+		--session)
+			session_id="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    _init_registry_db
+	_init_registry_db
 
-    sqlite3 "$WORKTREE_REGISTRY_DB" "
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
         INSERT OR REPLACE INTO worktree_owners
             (worktree_path, branch, owner_pid, owner_session, owner_batch, task_id)
         VALUES
@@ -674,22 +695,22 @@ register_worktree() {
              '$(_wt_sql_escape "$batch_id")',
              '$(_wt_sql_escape "$task_id")');
     " 2>/dev/null || true
-    return 0
+	return 0
 }
 
 # Unregister ownership of a worktree
 # Arguments:
 #   $1 - worktree path (required)
 unregister_worktree() {
-    local wt_path="$1"
+	local wt_path="$1"
 
-    [[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 0
+	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 0
 
-    sqlite3 "$WORKTREE_REGISTRY_DB" "
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
         DELETE FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
     " 2>/dev/null || true
-    return 0
+	return 0
 }
 
 # Check who owns a worktree
@@ -698,22 +719,22 @@ unregister_worktree() {
 # Output: owner info (pid|session|batch|task|created_at) or empty
 # Returns: 0 if owned, 1 if not owned
 check_worktree_owner() {
-    local wt_path="$1"
+	local wt_path="$1"
 
-    [[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 1
+	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 1
 
-    local owner_info
-    owner_info=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
+	local owner_info
+	owner_info=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
         SELECT owner_pid, owner_session, owner_batch, task_id, created_at
         FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
     " 2>/dev/null || echo "")
 
-    if [[ -n "$owner_info" ]]; then
-        echo "$owner_info"
-        return 0
-    fi
-    return 1
+	if [[ -n "$owner_info" ]]; then
+		echo "$owner_info"
+		return 0
+	fi
+	return 1
 }
 
 # Check if a worktree is owned by a DIFFERENT process (still alive)
@@ -721,31 +742,31 @@ check_worktree_owner() {
 #   $1 - worktree path
 # Returns: 0 if owned by another live process, 1 if safe to remove
 is_worktree_owned_by_others() {
-    local wt_path="$1"
+	local wt_path="$1"
 
-    [[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 1
+	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 1
 
-    local owner_pid
-    owner_pid=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	local owner_pid
+	owner_pid=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
         SELECT owner_pid FROM worktree_owners
         WHERE worktree_path = '$(_wt_sql_escape "$wt_path")';
     " 2>/dev/null || echo "")
 
-    # No owner registered
-    [[ -z "$owner_pid" ]] && return 1
+	# No owner registered
+	[[ -z "$owner_pid" ]] && return 1
 
-    # We own it
-    [[ "$owner_pid" == "$$" ]] && return 1
+	# We own it
+	[[ "$owner_pid" == "$$" ]] && return 1
 
-    # Owner process is dead — stale entry, safe to remove
-    if ! kill -0 "$owner_pid" 2>/dev/null; then
-        # Clean up stale entry
-        unregister_worktree "$wt_path"
-        return 1
-    fi
+	# Owner process is dead — stale entry, safe to remove
+	if ! kill -0 "$owner_pid" 2>/dev/null; then
+		# Clean up stale entry
+		unregister_worktree "$wt_path"
+		return 1
+	fi
 
-    # Owner process is alive and it's not us — NOT safe to remove
-    return 0
+	# Owner process is alive and it's not us — NOT safe to remove
+	return 0
 }
 
 # Prune stale registry entries (dead PIDs, missing directories, corrupted paths)
@@ -754,65 +775,65 @@ is_worktree_owned_by_others() {
 #   - Paths with ANSI escape codes (corrupted entries)
 #   - Test artifacts in /tmp or /var/folders
 prune_worktree_registry() {
-    [[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 0
+	[[ ! -f "$WORKTREE_REGISTRY_DB" ]] && return 0
 
-    local pruned_count=0
-    
-    # First, delete entries with ANSI escape codes (corrupted entries)
-    # These often have newlines and break normal parsing
-    local ansi_count
-    ansi_count=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	local pruned_count=0
+
+	# First, delete entries with ANSI escape codes (corrupted entries)
+	# These often have newlines and break normal parsing
+	local ansi_count
+	ansi_count=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
         DELETE FROM worktree_owners 
         WHERE worktree_path LIKE '%'||char(27)||'%' 
            OR worktree_path LIKE '%[0;%'
            OR worktree_path LIKE '%[1m%';
         SELECT changes();
     " 2>/dev/null || echo "0")
-    pruned_count=$((pruned_count + ansi_count))
-    [[ -n "${VERBOSE:-}" && "$ansi_count" -gt 0 ]] && echo "  Pruned $ansi_count entries with ANSI escape codes"
-    
-    # Next, delete test artifacts in temp directories
-    local temp_count
-    temp_count=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
+	pruned_count=$((pruned_count + ansi_count))
+	[[ -n "${VERBOSE:-}" && "$ansi_count" -gt 0 ]] && echo "  Pruned $ansi_count entries with ANSI escape codes"
+
+	# Next, delete test artifacts in temp directories
+	local temp_count
+	temp_count=$(sqlite3 "$WORKTREE_REGISTRY_DB" "
         DELETE FROM worktree_owners 
         WHERE worktree_path LIKE '/tmp/%' 
            OR worktree_path LIKE '/var/folders/%';
         SELECT changes();
     " 2>/dev/null || echo "0")
-    pruned_count=$((pruned_count + temp_count))
-    [[ -n "${VERBOSE:-}" && "$temp_count" -gt 0 ]] && echo "  Pruned $temp_count test artifacts in temp directories"
+	pruned_count=$((pruned_count + temp_count))
+	[[ -n "${VERBOSE:-}" && "$temp_count" -gt 0 ]] && echo "  Pruned $temp_count test artifacts in temp directories"
 
-    # Now process remaining entries for dead PIDs and missing directories
-    local entries
-    entries=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
+	# Now process remaining entries for dead PIDs and missing directories
+	local entries
+	entries=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
         SELECT worktree_path, owner_pid FROM worktree_owners;
     " 2>/dev/null || echo "")
 
-    if [[ -n "$entries" ]]; then
-        while IFS='|' read -r wt_path owner_pid; do
-            local should_prune=false
-            local prune_reason=""
+	if [[ -n "$entries" ]]; then
+		while IFS='|' read -r wt_path owner_pid; do
+			local should_prune=false
+			local prune_reason=""
 
-            # Directory no longer exists
-            if [[ ! -d "$wt_path" ]]; then
-                should_prune=true
-                prune_reason="directory missing"
-            # Owner process is dead (only prune if directory also missing)
-            elif [[ -n "$owner_pid" ]] && ! kill -0 "$owner_pid" 2>/dev/null && [[ ! -d "$wt_path" ]]; then
-                should_prune=true
-                prune_reason="dead PID and directory missing"
-            fi
+			# Directory no longer exists
+			if [[ ! -d "$wt_path" ]]; then
+				should_prune=true
+				prune_reason="directory missing"
+			# Owner process is dead (only prune if directory also missing)
+			elif [[ -n "$owner_pid" ]] && ! kill -0 "$owner_pid" 2>/dev/null && [[ ! -d "$wt_path" ]]; then
+				should_prune=true
+				prune_reason="dead PID and directory missing"
+			fi
 
-            if [[ "$should_prune" == "true" ]]; then
-                unregister_worktree "$wt_path"
-                ((pruned_count++))
-                [[ -n "${VERBOSE:-}" ]] && echo "  Pruned: $wt_path ($prune_reason)"
-            fi
-        done <<< "$entries"
-    fi
-    
-    [[ -n "${VERBOSE:-}" ]] && echo "Pruned $pruned_count entries total"
-    return 0
+			if [[ "$should_prune" == "true" ]]; then
+				unregister_worktree "$wt_path"
+				((pruned_count++))
+				[[ -n "${VERBOSE:-}" ]] && echo "  Pruned: $wt_path ($prune_reason)"
+			fi
+		done <<<"$entries"
+	fi
+
+	[[ -n "${VERBOSE:-}" ]] && echo "Pruned $pruned_count entries total"
+	return 0
 }
 
 # =============================================================================
@@ -843,39 +864,39 @@ SQLITE_BACKUP_RETAIN_COUNT="${SQLITE_BACKUP_RETAIN_COUNT:-5}"
 # Output: backup file path on stdout
 # Returns: 0 on success, 1 on failure
 backup_sqlite_db() {
-    local db_path="$1"
-    local reason="${2:-manual}"
+	local db_path="$1"
+	local reason="${2:-manual}"
 
-    if [[ ! -f "$db_path" ]]; then
-        echo "[backup] No database to backup at: $db_path" >&2
-        return 1
-    fi
+	if [[ ! -f "$db_path" ]]; then
+		echo "[backup] No database to backup at: $db_path" >&2
+		return 1
+	fi
 
-    local db_dir
-    db_dir="$(dirname "$db_path")"
-    local db_name
-    db_name="$(basename "$db_path" .db)"
-    local timestamp
-    timestamp=$(date -u +%Y%m%dT%H%M%SZ)
-    local backup_file="${db_dir}/${db_name}-backup-${timestamp}-${reason}.db"
+	local db_dir
+	db_dir="$(dirname "$db_path")"
+	local db_name
+	db_name="$(basename "$db_path" .db)"
+	local timestamp
+	timestamp=$(date -u +%Y%m%dT%H%M%SZ)
+	local backup_file="${db_dir}/${db_name}-backup-${timestamp}-${reason}.db"
 
-    # Use SQLite .backup for WAL-safe consistency
-    if sqlite3 "$db_path" ".backup '$backup_file'" 2>/dev/null; then
-        echo "$backup_file"
-        return 0
-    fi
+	# Use SQLite .backup for WAL-safe consistency
+	if sqlite3 "$db_path" ".backup '$backup_file'" 2>/dev/null; then
+		echo "$backup_file"
+		return 0
+	fi
 
-    # Fallback to file copy if .backup fails
-    if cp "$db_path" "$backup_file" 2>/dev/null; then
-        # Also copy WAL/SHM if present for consistency
-        [[ -f "${db_path}-wal" ]] && cp "${db_path}-wal" "${backup_file}-wal" 2>/dev/null || true
-        [[ -f "${db_path}-shm" ]] && cp "${db_path}-shm" "${backup_file}-shm" 2>/dev/null || true
-        echo "$backup_file"
-        return 0
-    fi
+	# Fallback to file copy if .backup fails
+	if cp "$db_path" "$backup_file" 2>/dev/null; then
+		# Also copy WAL/SHM if present for consistency
+		[[ -f "${db_path}-wal" ]] && cp "${db_path}-wal" "${backup_file}-wal" 2>/dev/null || true
+		[[ -f "${db_path}-shm" ]] && cp "${db_path}-shm" "${backup_file}-shm" 2>/dev/null || true
+		echo "$backup_file"
+		return 0
+	fi
 
-    echo "[backup] Failed to backup database: $db_path" >&2
-    return 1
+	echo "[backup] Failed to backup database: $db_path" >&2
+	return 1
 }
 
 # Verify a SQLite backup by comparing row counts for specified tables.
@@ -885,33 +906,33 @@ backup_sqlite_db() {
 #   $3 - space-separated list of table names to verify (required)
 # Returns: 0 if all row counts match, 1 if mismatch or error
 verify_sqlite_backup() {
-    local db_path="$1"
-    local backup_path="$2"
-    local tables="$3"
+	local db_path="$1"
+	local backup_path="$2"
+	local tables="$3"
 
-    if [[ ! -f "$db_path" || ! -f "$backup_path" ]]; then
-        echo "[backup] Cannot verify: missing database or backup file" >&2
-        return 1
-    fi
+	if [[ ! -f "$db_path" || ! -f "$backup_path" ]]; then
+		echo "[backup] Cannot verify: missing database or backup file" >&2
+		return 1
+	fi
 
-    local table
-    for table in $tables; do
-        local orig_count backup_count
-        orig_count=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT count(*) FROM $table;" 2>/dev/null || echo "-1")
-        backup_count=$(sqlite3 -cmd ".timeout 5000" "$backup_path" "SELECT count(*) FROM $table;" 2>/dev/null || echo "-1")
+	local table
+	for table in $tables; do
+		local orig_count backup_count
+		orig_count=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT count(*) FROM $table;" 2>/dev/null || echo "-1")
+		backup_count=$(sqlite3 -cmd ".timeout 5000" "$backup_path" "SELECT count(*) FROM $table;" 2>/dev/null || echo "-1")
 
-        if [[ "$orig_count" == "-1" || "$backup_count" == "-1" ]]; then
-            echo "[backup] Cannot read table '$table' from database or backup" >&2
-            return 1
-        fi
+		if [[ "$orig_count" == "-1" || "$backup_count" == "-1" ]]; then
+			echo "[backup] Cannot read table '$table' from database or backup" >&2
+			return 1
+		fi
 
-        if [[ "$orig_count" -lt "$backup_count" ]]; then
-            echo "[backup] Row count DECREASED for '$table': was $backup_count, now $orig_count" >&2
-            return 1
-        fi
-    done
+		if [[ "$orig_count" -lt "$backup_count" ]]; then
+			echo "[backup] Row count DECREASED for '$table': was $backup_count, now $orig_count" >&2
+			return 1
+		fi
+	done
 
-    return 0
+	return 0
 }
 
 # Verify a migration preserved row counts (compare current DB against backup).
@@ -923,38 +944,38 @@ verify_sqlite_backup() {
 #   $3 - space-separated list of table names to verify
 # Returns: 0 if row counts match or increased, 1 if any decreased
 verify_migration_rowcounts() {
-    local db_path="$1"
-    local backup_path="$2"
-    local tables="$3"
+	local db_path="$1"
+	local backup_path="$2"
+	local tables="$3"
 
-    if [[ ! -f "$db_path" || ! -f "$backup_path" ]]; then
-        echo "[backup] Cannot verify migration: missing database or backup file" >&2
-        return 1
-    fi
+	if [[ ! -f "$db_path" || ! -f "$backup_path" ]]; then
+		echo "[backup] Cannot verify migration: missing database or backup file" >&2
+		return 1
+	fi
 
-    local table
-    for table in $tables; do
-        local post_count pre_count
-        post_count=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT count(*) FROM $table;" 2>/dev/null || echo "-1")
-        pre_count=$(sqlite3 -cmd ".timeout 5000" "$backup_path" "SELECT count(*) FROM $table;" 2>/dev/null || echo "-1")
+	local table
+	for table in $tables; do
+		local post_count pre_count
+		post_count=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT count(*) FROM $table;" 2>/dev/null || echo "-1")
+		pre_count=$(sqlite3 -cmd ".timeout 5000" "$backup_path" "SELECT count(*) FROM $table;" 2>/dev/null || echo "-1")
 
-        if [[ "$post_count" == "-1" ]]; then
-            echo "[backup] MIGRATION FAILURE: Cannot read table '$table' after migration" >&2
-            return 1
-        fi
+		if [[ "$post_count" == "-1" ]]; then
+			echo "[backup] MIGRATION FAILURE: Cannot read table '$table' after migration" >&2
+			return 1
+		fi
 
-        if [[ "$pre_count" == "-1" ]]; then
-            # Backup table might not exist (new table added by migration)
-            continue
-        fi
+		if [[ "$pre_count" == "-1" ]]; then
+			# Backup table might not exist (new table added by migration)
+			continue
+		fi
 
-        if [[ "$post_count" -lt "$pre_count" ]]; then
-            echo "[backup] MIGRATION FAILURE: Row count DECREASED for '$table': was $pre_count, now $post_count" >&2
-            return 1
-        fi
-    done
+		if [[ "$post_count" -lt "$pre_count" ]]; then
+			echo "[backup] MIGRATION FAILURE: Row count DECREASED for '$table': was $pre_count, now $post_count" >&2
+			return 1
+		fi
+	done
 
-    return 0
+	return 0
 }
 
 # Restore a SQLite database from a backup file.
@@ -964,35 +985,35 @@ verify_migration_rowcounts() {
 #   $2 - backup file to restore from (required)
 # Returns: 0 on success, 1 on failure
 rollback_sqlite_db() {
-    local db_path="$1"
-    local backup_path="$2"
+	local db_path="$1"
+	local backup_path="$2"
 
-    if [[ ! -f "$backup_path" ]]; then
-        echo "[backup] Backup file not found: $backup_path" >&2
-        return 1
-    fi
+	if [[ ! -f "$backup_path" ]]; then
+		echo "[backup] Backup file not found: $backup_path" >&2
+		return 1
+	fi
 
-    # Verify backup is valid SQLite
-    if ! sqlite3 "$backup_path" "SELECT 1;" >/dev/null 2>&1; then
-        echo "[backup] Backup file is not a valid SQLite database: $backup_path" >&2
-        return 1
-    fi
+	# Verify backup is valid SQLite
+	if ! sqlite3 "$backup_path" "SELECT 1;" >/dev/null 2>&1; then
+		echo "[backup] Backup file is not a valid SQLite database: $backup_path" >&2
+		return 1
+	fi
 
-    # Safety: backup current state before overwriting (in case rollback itself is wrong)
-    if [[ -f "$db_path" ]]; then
-        backup_sqlite_db "$db_path" "pre-rollback" >/dev/null 2>&1 || true
-    fi
+	# Safety: backup current state before overwriting (in case rollback itself is wrong)
+	if [[ -f "$db_path" ]]; then
+		backup_sqlite_db "$db_path" "pre-rollback" >/dev/null 2>&1 || true
+	fi
 
-    cp "$backup_path" "$db_path"
-    [[ -f "${backup_path}-wal" ]] && cp "${backup_path}-wal" "${db_path}-wal" 2>/dev/null || true
-    [[ -f "${backup_path}-shm" ]] && cp "${backup_path}-shm" "${db_path}-shm" 2>/dev/null || true
+	cp "$backup_path" "$db_path"
+	[[ -f "${backup_path}-wal" ]] && cp "${backup_path}-wal" "${db_path}-wal" 2>/dev/null || true
+	[[ -f "${backup_path}-shm" ]] && cp "${backup_path}-shm" "${db_path}-shm" 2>/dev/null || true
 
-    # Remove stale WAL/SHM if backup didn't have them
-    [[ ! -f "${backup_path}-wal" && -f "${db_path}-wal" ]] && rm -f "${db_path}-wal" 2>/dev/null || true
-    [[ ! -f "${backup_path}-shm" && -f "${db_path}-shm" ]] && rm -f "${db_path}-shm" 2>/dev/null || true
+	# Remove stale WAL/SHM if backup didn't have them
+	[[ ! -f "${backup_path}-wal" && -f "${db_path}-wal" ]] && rm -f "${db_path}-wal" 2>/dev/null || true
+	[[ ! -f "${backup_path}-shm" && -f "${db_path}-shm" ]] && rm -f "${db_path}-shm" 2>/dev/null || true
 
-    echo "[backup] Database restored from: $backup_path" >&2
-    return 0
+	echo "[backup] Database restored from: $backup_path" >&2
+	return 0
 }
 
 # Clean up old backups, keeping the most recent N.
@@ -1001,30 +1022,30 @@ rollback_sqlite_db() {
 #   $2 - number of backups to keep (default: SQLITE_BACKUP_RETAIN_COUNT)
 # Returns: 0 always
 cleanup_sqlite_backups() {
-    local db_path="$1"
-    local keep_count="${2:-$SQLITE_BACKUP_RETAIN_COUNT}"
+	local db_path="$1"
+	local keep_count="${2:-$SQLITE_BACKUP_RETAIN_COUNT}"
 
-    local db_dir
-    db_dir="$(dirname "$db_path")"
-    local db_name
-    db_name="$(basename "$db_path" .db)"
-    local pattern="${db_dir}/${db_name}-backup-*.db"
+	local db_dir
+	db_dir="$(dirname "$db_path")"
+	local db_name
+	db_name="$(basename "$db_path" .db)"
+	local pattern="${db_dir}/${db_name}-backup-*.db"
 
-    # Count existing backups (glob in $pattern is intentional)
-    local backup_count
-    # shellcheck disable=SC2012,SC2086
-    backup_count=$(ls -1 $pattern 2>/dev/null | wc -l | tr -d ' ')
+	# Count existing backups (glob in $pattern is intentional)
+	local backup_count
+	# shellcheck disable=SC2012,SC2086
+	backup_count=$(ls -1 $pattern 2>/dev/null | wc -l | tr -d ' ')
 
-    if [[ "$backup_count" -gt "$keep_count" ]]; then
-        local to_remove
-        to_remove=$((backup_count - keep_count))
-        # shellcheck disable=SC2012,SC2086
-        ls -1t $pattern 2>/dev/null | tail -n "$to_remove" | while IFS= read -r old_backup; do
-            rm -f "$old_backup" "${old_backup}-wal" "${old_backup}-shm" 2>/dev/null || true
-        done
-    fi
+	if [[ "$backup_count" -gt "$keep_count" ]]; then
+		local to_remove
+		to_remove=$((backup_count - keep_count))
+		# shellcheck disable=SC2012,SC2086
+		ls -1t $pattern 2>/dev/null | tail -n "$to_remove" | while IFS= read -r old_backup; do
+			rm -f "$old_backup" "${old_backup}-wal" "${old_backup}-shm" 2>/dev/null || true
+		done
+	fi
 
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -1046,52 +1067,52 @@ cleanup_sqlite_backups() {
 # Returns the resolved model string on stdout.
 #######################################
 resolve_model_tier() {
-    local tier="${1:-coding}"
+	local tier="${1:-coding}"
 
-    # If already a full provider/model string (contains /), return as-is
-    if [[ "$tier" == *"/"* ]]; then
-        echo "$tier"
-        return 0
-    fi
+	# If already a full provider/model string (contains /), return as-is
+	if [[ "$tier" == *"/"* ]]; then
+		echo "$tier"
+		return 0
+	fi
 
-    # Try fallback-chain-helper.sh for availability-aware resolution
-    local chain_helper="${BASH_SOURCE[0]%/*}/fallback-chain-helper.sh"
-    if [[ -x "$chain_helper" ]]; then
-        local resolved
-        resolved=$("$chain_helper" resolve "$tier" --quiet 2>/dev/null) || true
-        if [[ -n "$resolved" ]]; then
-            echo "$resolved"
-            return 0
-        fi
-    fi
+	# Try fallback-chain-helper.sh for availability-aware resolution
+	local chain_helper="${BASH_SOURCE[0]%/*}/fallback-chain-helper.sh"
+	if [[ -x "$chain_helper" ]]; then
+		local resolved
+		resolved=$("$chain_helper" resolve "$tier" --quiet 2>/dev/null) || true
+		if [[ -n "$resolved" ]]; then
+			echo "$resolved"
+			return 0
+		fi
+	fi
 
-    # Static fallback: map tier names to concrete models
-    case "$tier" in
-        opus|coding)
-            echo "anthropic/claude-opus-4-6"
-            ;;
-        sonnet|eval)
-            echo "anthropic/claude-sonnet-4-20250514"
-            ;;
-        haiku|health)
-            echo "anthropic/claude-3-5-haiku-20241022"
-            ;;
-        flash)
-            echo "google/gemini-2.5-flash-preview-05-20"
-            ;;
-        pro)
-            echo "google/gemini-2.5-pro-preview-06-05"
-            ;;
-        grok)
-            echo "xai/grok-3"
-            ;;
-        *)
-            # Unknown tier — return as-is (may be a model name without provider)
-            echo "$tier"
-            ;;
-    esac
+	# Static fallback: map tier names to concrete models
+	case "$tier" in
+	opus | coding)
+		echo "anthropic/claude-opus-4-6"
+		;;
+	sonnet | eval)
+		echo "anthropic/claude-sonnet-4-6"
+		;;
+	haiku | health)
+		echo "anthropic/claude-3-5-haiku-20241022"
+		;;
+	flash)
+		echo "google/gemini-2.5-flash-preview-05-20"
+		;;
+	pro)
+		echo "google/gemini-2.5-pro-preview-06-05"
+		;;
+	grok)
+		echo "xai/grok-3"
+		;;
+	*)
+		# Unknown tier — return as-is (may be a model name without provider)
+		echo "$tier"
+		;;
+	esac
 
-    return 0
+	return 0
 }
 
 #######################################
@@ -1100,23 +1121,23 @@ resolve_model_tier() {
 # Checks: opencode, claude
 #######################################
 detect_ai_backends() {
-    local -a backends=()
+	local -a backends=()
 
-    if command -v opencode &>/dev/null; then
-        backends+=("opencode")
-    fi
+	if command -v opencode &>/dev/null; then
+		backends+=("opencode")
+	fi
 
-    if command -v claude &>/dev/null; then
-        backends+=("claude")
-    fi
+	if command -v claude &>/dev/null; then
+		backends+=("claude")
+	fi
 
-    if [[ ${#backends[@]} -eq 0 ]]; then
-        echo "none"
-        return 1
-    fi
+	if [[ ${#backends[@]} -eq 0 ]]; then
+		echo "none"
+		return 1
+	fi
 
-    printf '%s\n' "${backends[@]}"
-    return 0
+	printf '%s\n' "${backends[@]}"
+	return 0
 }
 
 # This ensures all constants are available when this file is sourced

--- a/.agents/scripts/supervisor/dispatch.sh
+++ b/.agents/scripts/supervisor/dispatch.sh
@@ -112,13 +112,13 @@ resolve_model() {
 		echo "anthropic/claude-opus-4-6"
 		;;
 	sonnet | eval | health)
-		echo "anthropic/claude-sonnet-4-5"
+		echo "anthropic/claude-sonnet-4-6"
 		;;
 	haiku | flash)
 		echo "anthropic/claude-haiku-4-5"
 		;;
 	pro)
-		echo "anthropic/claude-sonnet-4-5"
+		echo "anthropic/claude-sonnet-4-6"
 		;;
 	*)
 		# Unknown tier — treat as coding tier default

--- a/.agents/services/hosting/cloudflare-platform/references/ai-gateway/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/ai-gateway/README.md
@@ -60,7 +60,7 @@ const client = new OpenAI({
 
 // Switch providers by changing model format: {provider}/{model}
 const response = await client.chat.completions.create({
-  model: 'openai/gpt-4o-mini', // or 'anthropic/claude-sonnet-4-5'
+  model: 'openai/gpt-4o-mini', // or 'anthropic/claude-sonnet-4-6'
   messages: [{ role: 'user', content: 'Hello!' }]
 });
 ```
@@ -449,7 +449,7 @@ const response = await client.chat.completions.create({
 ```typescript
 // Dashboard: Create route with Percentage node
 // - 50% to gpt-4o-mini
-// - 50% to claude-sonnet-4-5
+// - 50% to claude-sonnet-4-6
 // Analyze logs to compare quality/cost/latency
 
 const response = await client.chat.completions.create({

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -14,7 +14,7 @@ Video,video.md,AI video generation and prompt engineering,opus
 
 <!--TOON:model_tiers[6]{tier,model_id,use_case}:
 haiku,claude-3-5-haiku-20241022,Triage routing and simple tasks
-sonnet,claude-sonnet-4-20250514,Code review and implementation
+sonnet,claude-sonnet-4-6,Code review and implementation
 opus,claude-opus-4-20250514,Architecture and complex reasoning
 flash,gemini-2.5-flash,Fast cheap large context
 pro,gemini-2.5-pro,Capable large context

--- a/.agents/tools/ai-assistants/fallback-chains.md
+++ b/.agents/tools/ai-assistants/fallback-chains.md
@@ -51,14 +51,14 @@ Add `fallback-chain:` to any model tier file's YAML frontmatter:
 
 ```yaml
 ---
-model: anthropic/claude-sonnet-4-20250514
+model: anthropic/claude-sonnet-4-6
 model-tier: sonnet
 model-fallback: openai/gpt-4.1
 fallback-chain:
-  - anthropic/claude-sonnet-4-20250514
+  - anthropic/claude-sonnet-4-6
   - openai/gpt-4.1
   - google/gemini-2.5-pro
-  - openrouter/anthropic/claude-sonnet-4-20250514
+  - openrouter/anthropic/claude-sonnet-4-6
 ---
 ```
 
@@ -70,10 +70,10 @@ Edit `configs/fallback-chain-config.json` (copy from `.json.txt` template):
 {
   "chains": {
     "sonnet": [
-      "anthropic/claude-sonnet-4-20250514",
+      "anthropic/claude-sonnet-4-6",
       "openai/gpt-4.1",
       "google/gemini-2.5-pro",
-      "openrouter/anthropic/claude-sonnet-4-20250514"
+      "openrouter/anthropic/claude-sonnet-4-6"
     ]
   }
 }
@@ -83,9 +83,9 @@ Edit `configs/fallback-chain-config.json` (copy from `.json.txt` template):
 
 | Format | Example | Description |
 |--------|---------|-------------|
-| `provider/model` | `anthropic/claude-sonnet-4-20250514` | Direct provider API |
-| `openrouter/provider/model` | `openrouter/anthropic/claude-sonnet-4-20250514` | Via OpenRouter gateway |
-| `gateway/cf/provider/model` | `gateway/cf/anthropic/claude-sonnet-4-20250514` | Via Cloudflare AI Gateway |
+| `provider/model` | `anthropic/claude-sonnet-4-6` | Direct provider API |
+| `openrouter/provider/model` | `openrouter/anthropic/claude-sonnet-4-6` | Via OpenRouter gateway |
+| `gateway/cf/provider/model` | `gateway/cf/anthropic/claude-sonnet-4-6` | Via Cloudflare AI Gateway |
 
 ## Trigger Types
 
@@ -130,7 +130,7 @@ fallback-chain-helper.sh gateway openrouter
 
 # Models routed via OpenRouter use the format:
 # openrouter/provider/model
-# e.g., openrouter/anthropic/claude-sonnet-4-20250514
+# e.g., openrouter/anthropic/claude-sonnet-4-6
 ```
 
 **Setup**: Set `OPENROUTER_API_KEY` environment variable or store via `aidevops secret set OPENROUTER_API_KEY`.
@@ -145,7 +145,7 @@ fallback-chain-helper.sh gateway cloudflare
 
 # Models routed via CF AI Gateway use the format:
 # gateway/cf/provider/model
-# e.g., gateway/cf/anthropic/claude-sonnet-4-20250514
+# e.g., gateway/cf/anthropic/claude-sonnet-4-6
 ```
 
 **Setup**: Configure `account_id` and `gateway_id` in `configs/fallback-chain-config.json`. Set `CF_AIG_TOKEN` for authenticated gateways.

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -73,7 +73,7 @@ Simplest approach. Each invocation starts a fresh session (or resumes one).
 opencode run "Review src/auth.ts for security issues"
 
 # With specific model
-opencode run -m anthropic/claude-sonnet-4-20250514 "Generate unit tests for src/utils/"
+opencode run -m anthropic/claude-sonnet-4-6 "Generate unit tests for src/utils/"
 
 # With specific agent
 opencode run --agent plan "Analyze the database schema"
@@ -111,7 +111,7 @@ import { createOpencode, createOpencodeClient } from "@opencode-ai/sdk"
 // Start server + client together
 const { client, server } = await createOpencode({
   port: 4096,
-  config: { model: "anthropic/claude-sonnet-4-20250514" },
+  config: { model: "anthropic/claude-sonnet-4-6" },
 })
 
 // Or connect to existing server
@@ -136,7 +136,7 @@ SESSION_ID=$(curl -sf -X POST "$SERVER/session" \
 curl -sf -X POST "$SERVER/session/$SESSION_ID/message" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": {"providerID": "anthropic", "modelID": "claude-sonnet-4-20250514"},
+    "model": {"providerID": "anthropic", "modelID": "claude-sonnet-4-6"},
     "parts": [{"type": "text", "text": "Explain this codebase"}]
   }'
 
@@ -276,7 +276,7 @@ Runners are named, persistent agent instances with their own identity, instructi
 # Create a runner
 runner-helper.sh create code-reviewer \
   --description "Reviews code for security and quality" \
-  --model anthropic/claude-sonnet-4-20250514
+  --model anthropic/claude-sonnet-4-6
 
 # Run a task
 runner-helper.sh run code-reviewer "Review src/auth/ for vulnerabilities"
@@ -367,7 +367,7 @@ Place in `.opencode/agents/security-reviewer.md`:
 ---
 description: Security-focused code reviewer
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: anthropic/claude-sonnet-4-6
 temperature: 0.1
 tools:
   write: false
@@ -395,7 +395,7 @@ In `opencode.json`:
     "security-reviewer": {
       "description": "Security-focused code reviewer",
       "mode": "subagent",
-      "model": "anthropic/claude-sonnet-4-20250514",
+      "model": "anthropic/claude-sonnet-4-6",
       "tools": { "write": false, "edit": false }
     }
   }
@@ -427,7 +427,7 @@ OpenCode supports any provider via `opencode auth login`. Runners inherit the co
 opencode auth login  # Interactive provider selection
 
 # Override model per dispatch
-opencode run -m openrouter/anthropic/claude-sonnet-4-20250514 "Task"
+opencode run -m openrouter/anthropic/claude-sonnet-4-6 "Task"
 opencode run -m groq/llama-4-scout-17b-16e-instruct "Quick task"
 ```
 

--- a/.agents/tools/ai-assistants/models/README.md
+++ b/.agents/tools/ai-assistants/models/README.md
@@ -49,10 +49,10 @@ Add `fallback-chain:` to any model tier's YAML frontmatter for per-agent overrid
 
 ```yaml
 fallback-chain:
-  - anthropic/claude-sonnet-4-20250514
+  - anthropic/claude-sonnet-4-6
   - openai/gpt-4.1
   - google/gemini-2.5-pro
-  - openrouter/anthropic/claude-sonnet-4-20250514
+  - openrouter/anthropic/claude-sonnet-4-6
 ```
 
 Global defaults are configured in `configs/fallback-chain-config.json`. See `tools/ai-assistants/fallback-chains.md` for full documentation.

--- a/.agents/tools/ai-assistants/models/opus.md
+++ b/.agents/tools/ai-assistants/models/opus.md
@@ -7,7 +7,7 @@ model-fallback: openai/o3
 fallback-chain:
   - anthropic/claude-opus-4-6
   - openai/o3
-  - anthropic/claude-sonnet-4-20250514
+  - anthropic/claude-sonnet-4-6
   - openrouter/anthropic/claude-opus-4-6
 tools:
   read: true

--- a/.agents/tools/ai-assistants/models/pro.md
+++ b/.agents/tools/ai-assistants/models/pro.md
@@ -3,7 +3,7 @@ description: High-capability model for large codebase analysis and complex reaso
 mode: subagent
 model: google/gemini-2.5-pro-preview-06-05
 model-tier: pro
-model-fallback: anthropic/claude-sonnet-4-20250514
+model-fallback: anthropic/claude-sonnet-4-6
 tools:
   read: true
   write: true

--- a/.agents/tools/ai-assistants/models/sonnet.md
+++ b/.agents/tools/ai-assistants/models/sonnet.md
@@ -1,14 +1,14 @@
 ---
 description: Balanced model for code implementation, review, and most development tasks
 mode: subagent
-model: anthropic/claude-sonnet-4-20250514
+model: anthropic/claude-sonnet-4-6
 model-tier: sonnet
 model-fallback: openai/gpt-4.1
 fallback-chain:
-  - anthropic/claude-sonnet-4-20250514
+  - anthropic/claude-sonnet-4-6
   - openai/gpt-4.1
   - google/gemini-2.5-pro
-  - openrouter/anthropic/claude-sonnet-4-20250514
+  - openrouter/anthropic/claude-sonnet-4-6
 tools:
   read: true
   write: true
@@ -45,8 +45,10 @@ You are a capable AI assistant optimized for software development tasks. This is
 | Field | Value |
 |-------|-------|
 | Provider | Anthropic |
-| Model | claude-sonnet-4 |
-| Context | 200K tokens |
+| Model | claude-sonnet-4-6 |
+| Context | 200K tokens (1M beta) |
+| Max output | 64K tokens |
+| Training cutoff | January 2026 |
 | Input cost | $3.00/1M tokens |
 | Output cost | $15.00/1M tokens |
 | Tier | sonnet (default, balanced) |

--- a/.agents/tools/ai-assistants/opencode-server.md
+++ b/.agents/tools/ai-assistants/opencode-server.md
@@ -105,7 +105,7 @@ const { client, server } = await createOpencode({
   port: 4096,
   hostname: "127.0.0.1",
   config: {
-    model: "anthropic/claude-sonnet-4-20250514",
+    model: "anthropic/claude-sonnet-4-6",
   },
 })
 
@@ -146,7 +146,7 @@ const result = await client.session.prompt({
   body: {
     model: {
       providerID: "anthropic",
-      modelID: "claude-sonnet-4-20250514",
+      modelID: "claude-sonnet-4-6",
     },
     parts: [{ type: "text", text: "Explain this codebase structure" }],
   },
@@ -222,7 +222,7 @@ curl -X POST http://localhost:4096/session/{session_id}/message \
   -d '{
     "model": {
       "providerID": "anthropic",
-      "modelID": "claude-sonnet-4-20250514"
+      "modelID": "claude-sonnet-4-6"
     },
     "parts": [{"type": "text", "text": "Hello!"}]
   }'

--- a/.agents/tools/automation/cron-agent.md
+++ b/.agents/tools/automation/cron-agent.md
@@ -183,7 +183,7 @@ Jobs are stored in `~/.config/aidevops/cron-jobs.json`:
       "workdir": "/Users/me/projects/example-site",
       "timeout": 300,
       "notify": "mail",
-      "model": "anthropic/claude-sonnet-4-20250514",
+      "model": "anthropic/claude-sonnet-4-6",
       "status": "active",
       "created": "2024-01-10T10:00:00Z",
       "lastRun": "2024-01-15T09:00:00Z",

--- a/.agents/tools/build-agent/agent-testing.md
+++ b/.agents/tools/build-agent/agent-testing.md
@@ -74,7 +74,7 @@ Test suites are JSON files defining prompts and expected response patterns:
   "name": "build-agent-tests",
   "description": "Validates build-agent subagent knowledge",
   "agent": "Build+",
-  "model": "anthropic/claude-sonnet-4-20250514",
+  "model": "anthropic/claude-sonnet-4-6",
   "timeout": 120,
   "tests": [
     {
@@ -149,7 +149,7 @@ agent-test-helper.sh run-one "List your tools" --expect "bash"
 # With specific agent and model
 agent-test-helper.sh run-one "Explain git workflow" \
   --agent "Build+" \
-  --model "anthropic/claude-sonnet-4-20250514" \
+  --model "anthropic/claude-sonnet-4-6" \
   --timeout 60
 ```
 

--- a/.agents/tools/content/summarize.md
+++ b/.agents/tools/content/summarize.md
@@ -180,7 +180,7 @@ summarize "https://example.com" --stream off
 | Provider | Model ID Format | API Key |
 |----------|-----------------|---------|
 | OpenAI | `openai/gpt-5-mini` | `OPENAI_API_KEY` |
-| Anthropic | `anthropic/claude-sonnet-4-5` | `ANTHROPIC_API_KEY` |
+| Anthropic | `anthropic/claude-sonnet-4-6` | `ANTHROPIC_API_KEY` |
 | Google | `google/gemini-3-flash-preview` | `GEMINI_API_KEY` |
 | xAI | `xai/grok-4-fast-non-reasoning` | `XAI_API_KEY` |
 | Z.AI | `zai/glm-4.7` | `Z_AI_API_KEY` |

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -189,7 +189,7 @@ The model availability checker (`model-availability-helper.sh`) provides lightwe
 model-availability-helper.sh check anthropic
 
 # Check a specific model
-model-availability-helper.sh check anthropic/claude-sonnet-4-20250514
+model-availability-helper.sh check anthropic/claude-sonnet-4-6
 
 # Resolve best available model for a tier (with automatic fallback)
 model-availability-helper.sh resolve opus

--- a/.agents/tools/git/opencode-github.md
+++ b/.agents/tools/git/opencode-github.md
@@ -105,7 +105,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          model: anthropic/claude-sonnet-4-20250514
+          model: anthropic/claude-sonnet-4-6
 ```
 
 #### 3. Add Secrets
@@ -178,7 +178,7 @@ This function needs better validation. /oc add input validation
 ```yaml
 - uses: sst/opencode/github@latest
   with:
-    model: anthropic/claude-sonnet-4-20250514  # Required
+    model: anthropic/claude-sonnet-4-6  # Required
     agent: build                                # Optional: agent to use
     share: true                                 # Optional: share session (default: true for public repos)
     prompt: |                                   # Optional: custom prompt
@@ -201,7 +201,7 @@ To use `GITHUB_TOKEN` instead of the app:
 ```yaml
 - uses: sst/opencode/github@latest
   with:
-    model: anthropic/claude-sonnet-4-20250514
+    model: anthropic/claude-sonnet-4-6
     token: ${{ secrets.GITHUB_TOKEN }}
 ```
 

--- a/.agents/tools/git/opencode-gitlab.md
+++ b/.agents/tools/git/opencode-gitlab.md
@@ -189,7 +189,7 @@ Specify model in the opencode run command:
 
 ```yaml
 script:
-  - opencode run --model anthropic/claude-sonnet-4-20250514 "$AI_FLOW_INPUT"
+  - opencode run --model anthropic/claude-sonnet-4-6 "$AI_FLOW_INPUT"
 ```
 
 ### Self-Hosted GitLab

--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -264,7 +264,7 @@ opencode auth login   # Choose manual API key
 opencode auth status
 
 # Test API access
-opencode run "Hello, Claude!" --model anthropic/claude-sonnet-4-20250514
+opencode run "Hello, Claude!" --model anthropic/claude-sonnet-4-6
 ```
 
 ## Troubleshooting
@@ -385,7 +385,7 @@ Enable verbose logging to troubleshoot authentication issues:
 
 ```bash
 # Set debug environment variable
-DEBUG=opencode:* opencode run "test" --model anthropic/claude-sonnet-4-20250514
+DEBUG=opencode:* opencode run "test" --model anthropic/claude-sonnet-4-6
 
 # Check token expiration
 cat ~/.config/opencode/auth.json | jq '.anthropic'

--- a/.agents/tools/opencode/opencode.md
+++ b/.agents/tools/opencode/opencode.md
@@ -311,7 +311,7 @@ opencode run "List your available tools" --agent SEO
 opencode run "Use dataforseo to get SERP for 'test query'" --agent SEO
 
 # Test with different model
-opencode run "Quick test" --agent Build+ --model anthropic/claude-sonnet-4-20250514
+opencode run "Quick test" --agent Build+ --model anthropic/claude-sonnet-4-6
 
 # Capture errors for debugging
 opencode run "Test the serper MCP" --agent SEO 2>&1

--- a/.agents/tools/vision/image-understanding.md
+++ b/.agents/tools/vision/image-understanding.md
@@ -122,7 +122,7 @@ curl https://api.anthropic.com/v1/messages \
   -H "anthropic-version: 2023-06-01" \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "claude-sonnet-4-20250514",
+    "model": "claude-sonnet-4-6",
     "max_tokens": 1024,
     "messages": [{
       "role": "user",

--- a/.agents/tools/voice/pipecat-opencode.md
+++ b/.agents/tools/voice/pipecat-opencode.md
@@ -173,7 +173,7 @@ async def run_agent(webrtc_connection: SmallWebRTCConnection):
     )
     llm = AnthropicLLMService(
         api_key=os.getenv("ANTHROPIC_API_KEY"),
-        model="claude-sonnet-4-20250514",
+        model="claude-sonnet-4-6",
     )
 
     # System prompt for voice interaction
@@ -322,7 +322,7 @@ tools = [
 
 llm = AnthropicLLMService(
     api_key=os.getenv("ANTHROPIC_API_KEY"),
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-4-6",
     tools=tools,
 )
 ```

--- a/.opencode/lib/ai-research.ts
+++ b/.opencode/lib/ai-research.ts
@@ -43,7 +43,7 @@ const AGENTS_BASE = `${process.env.HOME || "~"}/.aidevops/agents`
 
 const MODEL_MAP: Record<string, string> = {
   haiku: "claude-3-haiku-20240307",
-  sonnet: "claude-sonnet-4-20250514",
+  sonnet: "claude-sonnet-4-6",
   opus: "claude-opus-4-20250514",
 }
 

--- a/configs/mcp-templates/opencode-github-workflow.yml
+++ b/configs/mcp-templates/opencode-github-workflow.yml
@@ -49,7 +49,7 @@ jobs:
           # GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
         with:
           # Required: AI model to use
-          model: anthropic/claude-sonnet-4-20250514
+          model: anthropic/claude-sonnet-4-6
           
           # Optional: Specify agent (defaults to "build")
           # agent: build

--- a/tests/test-batch-quality-hardening.sh
+++ b/tests/test-batch-quality-hardening.sh
@@ -24,34 +24,34 @@ SKIP_COUNT=0
 TOTAL_COUNT=0
 
 pass() {
-    PASS_COUNT=$((PASS_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;32mPASS\033[0m %s\n" "$1"
 }
 
 fail() {
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
-    if [[ -n "${2:-}" ]]; then
-        printf "       %s\n" "$2"
-    fi
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
 }
 
 skip() {
-    SKIP_COUNT=$((SKIP_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+	SKIP_COUNT=$((SKIP_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
 }
 
 section() {
-    echo ""
-    printf "\033[1m=== %s ===\033[0m\n" "$1"
+	echo ""
+	printf "\033[1m=== %s ===\033[0m\n" "$1"
 }
 
 # Helper: list all git-tracked .sh files with absolute paths
 list_shell_scripts() {
-    git -C "$REPO_DIR" ls-files '*.sh' | while read -r f; do echo "$REPO_DIR/$f"; done
+	git -C "$REPO_DIR" ls-files '*.sh' | while read -r f; do echo "$REPO_DIR/$f"; done
 }
 
 # ============================================================
@@ -61,95 +61,95 @@ section "Supervisor: Worker Launch (nohup + disown)"
 
 # Test: Workers use nohup to survive parent exit
 if grep -q 'nohup bash -c' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "cmd_dispatch uses nohup for worker launch"
+	pass "cmd_dispatch uses nohup for worker launch"
 else
-    fail "cmd_dispatch missing nohup for worker launch" \
-        "Workers will die when cron pulse exits (~2 min)"
+	fail "cmd_dispatch missing nohup for worker launch" \
+		"Workers will die when cron pulse exits (~2 min)"
 fi
 
 # Test: Workers are disowned after launch
 if grep -q 'disown.*worker_pid' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "cmd_dispatch disowns worker process"
+	pass "cmd_dispatch disowns worker process"
 else
-    fail "cmd_dispatch missing disown" \
-        "Workers may receive SIGHUP on parent exit"
+	fail "cmd_dispatch missing disown" \
+		"Workers may receive SIGHUP on parent exit"
 fi
 
 # Test: Re-prompt also uses nohup
 reprompt_nohup=$(grep -c 'nohup bash -c' "$SCRIPTS_DIR/supervisor-helper.sh")
 if [[ "$reprompt_nohup" -ge 3 ]]; then
-    pass "cmd_reprompt also uses nohup (found $reprompt_nohup nohup instances)"
+	pass "cmd_reprompt also uses nohup (found $reprompt_nohup nohup instances)"
 else
-    fail "cmd_reprompt may be missing nohup (found $reprompt_nohup, expected >= 3)" \
-        "Re-prompted workers will also die on cron exit"
+	fail "cmd_reprompt may be missing nohup (found $reprompt_nohup, expected >= 3)" \
+		"Re-prompted workers will also die on cron exit"
 fi
 
 section "Supervisor: Dispatch Exit Code Handling"
 
 # Test: Dispatch loop captures exit code correctly (not $? after if)
 if grep -q 'cmd_dispatch.*||.*dispatch_exit=\$?' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Dispatch loop uses 'cmd || exit=\$?' pattern (not \$? after if)"
+	pass "Dispatch loop uses 'cmd || exit=\$?' pattern (not \$? after if)"
 else
-    fail "Dispatch loop may still use \$? after if (SC2319 bug)" \
-        "Exit code 2 (concurrency) and 3 (provider down) won't be detected"
+	fail "Dispatch loop may still use \$? after if (SC2319 bug)" \
+		"Exit code 2 (concurrency) and 3 (provider down) won't be detected"
 fi
 
 # Test: Dispatch failures are logged (not swallowed by 2>/dev/null)
 if grep -q 'Dispatch failed for.*exit.*trying next' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Dispatch failures are logged with exit code"
+	pass "Dispatch failures are logged with exit code"
 else
-    fail "Dispatch failures may be silently swallowed" \
-        "Cron log will show 'Dispatched: 0' with no explanation"
+	fail "Dispatch failures may be silently swallowed" \
+		"Cron log will show 'Dispatched: 0' with no explanation"
 fi
 
 section "Supervisor: Pulse-Level Health Check Caching"
 
 # Test: _PULSE_HEALTH_VERIFIED flag exists
 if grep -q '_PULSE_HEALTH_VERIFIED' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Pulse-level health check flag exists"
+	pass "Pulse-level health check flag exists"
 else
-    fail "Missing _PULSE_HEALTH_VERIFIED flag" \
-        "Health check will run 8s probe per task instead of once per pulse"
+	fail "Missing _PULSE_HEALTH_VERIFIED flag" \
+		"Health check will run 8s probe per task instead of once per pulse"
 fi
 
 # Test: check_model_health respects pulse flag
 if grep -q 'pulse-verified OK' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "check_model_health has pulse-level fast path"
+	pass "check_model_health has pulse-level fast path"
 else
-    fail "check_model_health missing pulse-level fast path"
+	fail "check_model_health missing pulse-level fast path"
 fi
 
 # Test: Health check sets pulse flag on success
 pulse_flag_sets=$(grep -c '_PULSE_HEALTH_VERIFIED="true"' "$SCRIPTS_DIR/supervisor-helper.sh")
 if [[ "$pulse_flag_sets" -ge 2 ]]; then
-    pass "Health check sets pulse flag on success ($pulse_flag_sets locations)"
+	pass "Health check sets pulse flag on success ($pulse_flag_sets locations)"
 else
-    fail "Health check may not set pulse flag consistently (found $pulse_flag_sets, expected >= 2)"
+	fail "Health check may not set pulse flag consistently (found $pulse_flag_sets, expected >= 2)"
 fi
 
 section "Supervisor: macOS Timeout Compatibility"
 
 # Test: Health check has macOS fallback (no coreutils timeout dependency)
 if grep -qE 'gtimeout|background process with manual kill' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Health check has macOS timeout fallback"
+	pass "Health check has macOS timeout fallback"
 else
-    fail "Health check may depend on coreutils timeout (not available on macOS)"
+	fail "Health check may depend on coreutils timeout (not available on macOS)"
 fi
 
 section "Supervisor: Model Resolution"
 
-# Test: OpenCode model ID is correct (claude-sonnet-4-5, not claude-sonnet-4)
-if grep -q 'claude-sonnet-4-5' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Model ID uses claude-sonnet-4-5 (correct for OpenCode)"
+# Test: OpenCode model ID is correct (claude-sonnet-4-6, not claude-sonnet-4)
+if grep -q 'claude-sonnet-4-6' "$SCRIPTS_DIR/supervisor-helper.sh"; then
+	pass "Model ID uses claude-sonnet-4-6 (correct for OpenCode)"
 else
-    fail "Model ID may be wrong (claude-sonnet-4 instead of claude-sonnet-4-5)"
+	fail "Model ID may be wrong (claude-sonnet-4 instead of claude-sonnet-4-6)"
 fi
 
 # Test: SUPERVISOR_MODEL env var override exists
 if grep -q 'SUPERVISOR_MODEL' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "SUPERVISOR_MODEL env var override supported"
+	pass "SUPERVISOR_MODEL env var override supported"
 else
-    fail "Missing SUPERVISOR_MODEL env var override"
+	fail "Missing SUPERVISOR_MODEL env var override"
 fi
 
 # ============================================================
@@ -158,19 +158,19 @@ fi
 section "t135.4: JSON Config File Integrity"
 
 # Test: pandoc-config.json.txt is valid JSON
-if python3 -m json.tool "$REPO_DIR/configs/pandoc-config.json.txt" > /dev/null 2>&1; then
-    pass "configs/pandoc-config.json.txt is valid JSON"
+if python3 -m json.tool "$REPO_DIR/configs/pandoc-config.json.txt" >/dev/null 2>&1; then
+	pass "configs/pandoc-config.json.txt is valid JSON"
 else
-    fail "configs/pandoc-config.json.txt is INVALID JSON" \
-        "$(python3 -m json.tool "$REPO_DIR/configs/pandoc-config.json.txt" 2>&1 | head -3)"
+	fail "configs/pandoc-config.json.txt is INVALID JSON" \
+		"$(python3 -m json.tool "$REPO_DIR/configs/pandoc-config.json.txt" 2>&1 | head -3)"
 fi
 
 # Test: chrome-devtools.json is valid JSON
-if python3 -m json.tool "$REPO_DIR/configs/mcp-templates/chrome-devtools.json" > /dev/null 2>&1; then
-    pass "configs/mcp-templates/chrome-devtools.json is valid JSON"
+if python3 -m json.tool "$REPO_DIR/configs/mcp-templates/chrome-devtools.json" >/dev/null 2>&1; then
+	pass "configs/mcp-templates/chrome-devtools.json is valid JSON"
 else
-    fail "configs/mcp-templates/chrome-devtools.json is INVALID JSON" \
-        "$(python3 -m json.tool "$REPO_DIR/configs/mcp-templates/chrome-devtools.json" 2>&1 | head -3)"
+	fail "configs/mcp-templates/chrome-devtools.json is INVALID JSON" \
+		"$(python3 -m json.tool "$REPO_DIR/configs/mcp-templates/chrome-devtools.json" 2>&1 | head -3)"
 fi
 
 # Test: No embedded newlines in JSON keys (the original corruption)
@@ -181,24 +181,24 @@ d = json.load(open('$REPO_DIR/configs/pandoc-config.json.txt'))
 bad = [k for k in d if '\n' in k]
 sys.exit(1 if bad else 0)
 " 2>/dev/null; then
-    pass "No embedded newline characters in pandoc-config.json.txt keys"
+	pass "No embedded newline characters in pandoc-config.json.txt keys"
 else
-    fail "pandoc-config.json.txt still has embedded newline in keys"
+	fail "pandoc-config.json.txt still has embedded newline in keys"
 fi
 
 # Test: All git-tracked .json and .json.txt config files are valid
 # Note: gitignored working copies (configs/*.json) are excluded -- only tracked files matter
 json_invalid=0
 while IFS= read -r f; do
-    if ! python3 -m json.tool "$REPO_DIR/$f" > /dev/null 2>&1; then
-        json_invalid=$((json_invalid + 1))
-        [[ "$VERBOSE" == "--verbose" ]] && echo "       Invalid: $f"
-    fi
+	if ! python3 -m json.tool "$REPO_DIR/$f" >/dev/null 2>&1; then
+		json_invalid=$((json_invalid + 1))
+		[[ "$VERBOSE" == "--verbose" ]] && echo "       Invalid: $f"
+	fi
 done < <(git -C "$REPO_DIR" ls-files 'configs/*.json' 'configs/*.json.txt' 'configs/**/*.json' 'configs/**/*.json.txt' 2>/dev/null)
 if [[ "$json_invalid" -eq 0 ]]; then
-    pass "All git-tracked JSON config files in configs/ are valid"
+	pass "All git-tracked JSON config files in configs/ are valid"
 else
-    fail "$json_invalid git-tracked JSON config file(s) are invalid in configs/"
+	fail "$json_invalid git-tracked JSON config file(s) are invalid in configs/"
 fi
 
 # ============================================================
@@ -208,29 +208,29 @@ section "t135.5: Gitignored Artifacts Removed"
 
 # Test: .scannerwork not tracked
 if git -C "$REPO_DIR" ls-files .scannerwork 2>/dev/null | grep -q .; then
-    fail ".scannerwork is still tracked in git"
+	fail ".scannerwork is still tracked in git"
 else
-    pass ".scannerwork is not tracked in git"
+	pass ".scannerwork is not tracked in git"
 fi
 
 # Test: .playwright-cli not tracked
 if git -C "$REPO_DIR" ls-files .playwright-cli 2>/dev/null | grep -q .; then
-    fail ".playwright-cli is still tracked in git"
+	fail ".playwright-cli is still tracked in git"
 else
-    pass ".playwright-cli is not tracked in git"
+	pass ".playwright-cli is not tracked in git"
 fi
 
 # Test: .gitignore has entries for these
 if grep -q 'scannerwork' "$REPO_DIR/.gitignore" 2>/dev/null; then
-    pass ".gitignore contains .scannerwork entry"
+	pass ".gitignore contains .scannerwork entry"
 else
-    fail ".gitignore missing .scannerwork entry"
+	fail ".gitignore missing .scannerwork entry"
 fi
 
 if grep -q 'playwright-cli' "$REPO_DIR/.gitignore" 2>/dev/null; then
-    pass ".gitignore contains .playwright-cli entry"
+	pass ".gitignore contains .playwright-cli entry"
 else
-    fail ".gitignore missing .playwright-cli entry"
+	fail ".gitignore missing .playwright-cli entry"
 fi
 
 # ============================================================
@@ -240,28 +240,28 @@ section "t135.10: package.json Main Field"
 
 # Test: main field is removed (index.js doesn't exist)
 if python3 -c "import json; d=json.load(open('$REPO_DIR/package.json')); exit(0 if 'main' not in d else 1)" 2>/dev/null; then
-    pass "package.json has no 'main' field (index.js doesn't exist)"
+	pass "package.json has no 'main' field (index.js doesn't exist)"
 else
-    main_val=$(python3 -c "import json; d=json.load(open('$REPO_DIR/package.json')); print(d.get('main',''))" 2>/dev/null)
-    if [[ -f "$REPO_DIR/$main_val" ]]; then
-        pass "package.json main field '$main_val' points to existing file"
-    else
-        fail "package.json main field '$main_val' points to non-existent file"
-    fi
+	main_val=$(python3 -c "import json; d=json.load(open('$REPO_DIR/package.json')); print(d.get('main',''))" 2>/dev/null)
+	if [[ -f "$REPO_DIR/$main_val" ]]; then
+		pass "package.json main field '$main_val' points to existing file"
+	else
+		fail "package.json main field '$main_val' points to non-existent file"
+	fi
 fi
 
 # Test: package.json is valid JSON
-if python3 -m json.tool "$REPO_DIR/package.json" > /dev/null 2>&1; then
-    pass "package.json is valid JSON"
+if python3 -m json.tool "$REPO_DIR/package.json" >/dev/null 2>&1; then
+	pass "package.json is valid JSON"
 else
-    fail "package.json is INVALID JSON"
+	fail "package.json is INVALID JSON"
 fi
 
 # Test: bin field exists (this is a CLI tool)
 if python3 -c "import json; d=json.load(open('$REPO_DIR/package.json')); exit(0 if 'bin' in d else 1)" 2>/dev/null; then
-    pass "package.json has 'bin' field (CLI entry point)"
+	pass "package.json has 'bin' field (CLI entry point)"
 else
-    fail "package.json missing 'bin' field"
+	fail "package.json missing 'bin' field"
 fi
 
 # ============================================================
@@ -272,33 +272,33 @@ section "t135.14: Shebang Standardization"
 # Test: No scripts use #!/bin/bash (should all be #!/usr/bin/env bash)
 bin_bash_count=0
 while IFS= read -r f; do
-    first_line=$(head -1 "$f" 2>/dev/null)
-    if [[ "$first_line" == "#!/bin/bash" ]]; then
-        bin_bash_count=$((bin_bash_count + 1))
-        [[ "$VERBOSE" == "--verbose" ]] && echo "       #!/bin/bash: $f"
-    fi
+	first_line=$(head -1 "$f" 2>/dev/null)
+	if [[ "$first_line" == "#!/bin/bash" ]]; then
+		bin_bash_count=$((bin_bash_count + 1))
+		[[ "$VERBOSE" == "--verbose" ]] && echo "       #!/bin/bash: $f"
+	fi
 done < <(list_shell_scripts)
 
 if [[ "$bin_bash_count" -eq 0 ]]; then
-    pass "All .sh files use #!/usr/bin/env bash (0 using #!/bin/bash)"
+	pass "All .sh files use #!/usr/bin/env bash (0 using #!/bin/bash)"
 else
-    fail "$bin_bash_count script(s) still use #!/bin/bash instead of #!/usr/bin/env bash"
+	fail "$bin_bash_count script(s) still use #!/bin/bash instead of #!/usr/bin/env bash"
 fi
 
 # Test: All .sh files have a shebang
 no_shebang_count=0
 while IFS= read -r f; do
-    first_line=$(head -1 "$f" 2>/dev/null)
-    if [[ ! "$first_line" =~ ^#! ]]; then
-        no_shebang_count=$((no_shebang_count + 1))
-        [[ "$VERBOSE" == "--verbose" ]] && echo "       No shebang: $f"
-    fi
+	first_line=$(head -1 "$f" 2>/dev/null)
+	if [[ ! "$first_line" =~ ^#! ]]; then
+		no_shebang_count=$((no_shebang_count + 1))
+		[[ "$VERBOSE" == "--verbose" ]] && echo "       No shebang: $f"
+	fi
 done < <(list_shell_scripts)
 
 if [[ "$no_shebang_count" -eq 0 ]]; then
-    pass "All .sh files have a shebang line"
+	pass "All .sh files have a shebang line"
 else
-    fail "$no_shebang_count script(s) missing shebang line"
+	fail "$no_shebang_count script(s) missing shebang line"
 fi
 
 # ============================================================
@@ -308,30 +308,30 @@ section "t135.15: Supervisor Resource Monitoring"
 
 # Test: calculate_adaptive_concurrency function exists
 if grep -q 'calculate_adaptive_concurrency()' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "calculate_adaptive_concurrency() function exists"
+	pass "calculate_adaptive_concurrency() function exists"
 else
-    fail "calculate_adaptive_concurrency() function missing"
+	fail "calculate_adaptive_concurrency() function missing"
 fi
 
 # Test: Pulse outputs system resource info
 if grep -q 'System resources' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Pulse outputs system resource summary"
+	pass "Pulse outputs system resource summary"
 else
-    fail "Pulse missing system resource output"
+	fail "Pulse missing system resource output"
 fi
 
 # Test: Load monitoring uses sysctl on macOS
 if grep -qE 'sysctl|vm_stat|/proc/loadavg' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Resource monitoring supports macOS (sysctl/vm_stat)"
+	pass "Resource monitoring supports macOS (sysctl/vm_stat)"
 else
-    fail "Resource monitoring may not work on macOS"
+	fail "Resource monitoring may not work on macOS"
 fi
 
 # Test: Adaptive concurrency reduces under load
 if grep -qE 'effective_concurrency=1|halve concurrency' "$SCRIPTS_DIR/supervisor-helper.sh"; then
-    pass "Adaptive concurrency throttles under high load"
+	pass "Adaptive concurrency throttles under high load"
 else
-    fail "Adaptive concurrency missing throttle logic"
+	fail "Adaptive concurrency missing throttle logic"
 fi
 
 # ============================================================
@@ -341,23 +341,23 @@ section "t137: OpenCode Config Template Deployment"
 
 # Test: Template file exists
 if [[ -f "$REPO_DIR/templates/opencode-config-agents.md" ]]; then
-    pass "templates/opencode-config-agents.md exists"
+	pass "templates/opencode-config-agents.md exists"
 else
-    fail "templates/opencode-config-agents.md missing"
+	fail "templates/opencode-config-agents.md missing"
 fi
 
 # Test: setup.sh has deployment logic for the template
 if grep -q 'opencode-config-agents.md' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh references opencode-config-agents.md for deployment"
+	pass "setup.sh references opencode-config-agents.md for deployment"
 else
-    fail "setup.sh missing opencode-config-agents.md deployment logic"
+	fail "setup.sh missing opencode-config-agents.md deployment logic"
 fi
 
 # Test: Deployed template exists (if setup has been run)
 if [[ -f "$HOME/.config/opencode/AGENTS.md" ]]; then
-    pass "\$HOME/.config/opencode/AGENTS.md is deployed"
+	pass "\$HOME/.config/opencode/AGENTS.md is deployed"
 else
-    skip "\$HOME/.config/opencode/AGENTS.md not deployed (run setup.sh to deploy)"
+	skip "\$HOME/.config/opencode/AGENTS.md not deployed (run setup.sh to deploy)"
 fi
 
 # ============================================================
@@ -367,30 +367,30 @@ section "t138: Update Output Bounding"
 
 # Test: git pull uses --quiet flag
 if grep -qE 'git pull.*--quiet|git pull.*-q' "$REPO_DIR/aidevops.sh"; then
-    pass "aidevops update uses --quiet git pull"
+	pass "aidevops update uses --quiet git pull"
 else
-    fail "aidevops update may produce unbounded git pull output"
+	fail "aidevops update may produce unbounded git pull output"
 fi
 
 # Test: Commit log is filtered to meaningful changes
 if grep -q 'feat|fix|refactor|perf|docs' "$REPO_DIR/aidevops.sh"; then
-    pass "Update output filters to meaningful commit types (feat/fix/refactor/perf/docs)"
+	pass "Update output filters to meaningful commit types (feat/fix/refactor/perf/docs)"
 else
-    fail "Update output may show all commits (including chore/merge)"
+	fail "Update output may show all commits (including chore/merge)"
 fi
 
 # Test: Output is bounded with head
 if grep -q 'head -20' "$REPO_DIR/aidevops.sh"; then
-    pass "Update output bounded to 20 lines max"
+	pass "Update output bounded to 20 lines max"
 else
-    fail "Update output may be unbounded (missing head -20)"
+	fail "Update output may be unbounded (missing head -20)"
 fi
 
 # Test: Overflow message for large updates
 if grep -qE 'and more|full list' "$REPO_DIR/aidevops.sh"; then
-    pass "Shows overflow message when > 20 commits"
+	pass "Shows overflow message when > 20 commits"
 else
-    fail "Missing overflow message for large updates"
+	fail "Missing overflow message for large updates"
 fi
 
 # ============================================================
@@ -400,29 +400,29 @@ section "t139: Memory FTS5 Hyphen Escaping"
 
 # Test: Query is wrapped in double quotes for FTS5
 if grep -q 'escaped_query=.*".*"' "$SCRIPTS_DIR/memory-helper.sh"; then
-    pass "FTS5 query is wrapped in double quotes"
+	pass "FTS5 query is wrapped in double quotes"
 else
-    fail "FTS5 query may not be quoted (hyphens interpreted as NOT operator)"
+	fail "FTS5 query may not be quoted (hyphens interpreted as NOT operator)"
 fi
 
 # Test: Comment explains the hyphen issue
 if grep -qE 'hyphens.*NOT operator|FTS5 treats hyphens' "$SCRIPTS_DIR/memory-helper.sh"; then
-    pass "Code documents the FTS5 hyphen issue"
+	pass "Code documents the FTS5 hyphen issue"
 else
-    fail "Missing documentation about FTS5 hyphen behavior"
+	fail "Missing documentation about FTS5 hyphen behavior"
 fi
 
 # Test: Functional test - recall with hyphenated query doesn't error
 if command -v "$DEPLOYED_DIR/memory-helper.sh" &>/dev/null || [[ -f "$DEPLOYED_DIR/memory-helper.sh" ]]; then
-    recall_output=$(bash "$DEPLOYED_DIR/memory-helper.sh" recall "test-hyphen-query" 2>&1 || true)
-    if echo "$recall_output" | grep -qiE "error.*column|fts5.*syntax|no such column"; then
-        fail "memory-helper.sh recall fails on hyphenated query" \
-            "$recall_output"
-    else
-        pass "memory-helper.sh recall handles hyphenated query without FTS5 error"
-    fi
+	recall_output=$(bash "$DEPLOYED_DIR/memory-helper.sh" recall "test-hyphen-query" 2>&1 || true)
+	if echo "$recall_output" | grep -qiE "error.*column|fts5.*syntax|no such column"; then
+		fail "memory-helper.sh recall fails on hyphenated query" \
+			"$recall_output"
+	else
+		pass "memory-helper.sh recall handles hyphenated query without FTS5 error"
+	fi
 else
-    skip "memory-helper.sh not deployed (can't run functional test)"
+	skip "memory-helper.sh not deployed (can't run functional test)"
 fi
 
 # ============================================================
@@ -432,31 +432,31 @@ section "t140: PEP 668 Skill Scanner Fallback Chain"
 
 # Test: setup.sh has uv fallback
 if grep -q 'uv tool install cisco-ai-skill-scanner' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh has uv tool install fallback"
+	pass "setup.sh has uv tool install fallback"
 else
-    fail "setup.sh missing uv tool install fallback"
+	fail "setup.sh missing uv tool install fallback"
 fi
 
 # Test: setup.sh has pipx fallback
 if grep -q 'pipx install cisco-ai-skill-scanner' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh has pipx install fallback"
+	pass "setup.sh has pipx install fallback"
 else
-    fail "setup.sh missing pipx install fallback"
+	fail "setup.sh missing pipx install fallback"
 fi
 
 # Test: setup.sh has venv+symlink fallback
 # The venv dir and python3 -m venv are on separate lines, so check both exist
 if grep -q 'python3 -m venv' "$REPO_DIR/setup.sh" && grep -q 'cisco-scanner-env' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh has venv+symlink fallback"
+	pass "setup.sh has venv+symlink fallback"
 else
-    fail "setup.sh missing venv+symlink fallback"
+	fail "setup.sh missing venv+symlink fallback"
 fi
 
 # Test: setup.sh has pip3 --user legacy fallback
 if grep -q 'pip3 install --user cisco-ai-skill-scanner' "$REPO_DIR/setup.sh"; then
-    pass "setup.sh has pip3 --user legacy fallback"
+	pass "setup.sh has pip3 --user legacy fallback"
 else
-    fail "setup.sh missing pip3 --user legacy fallback"
+	fail "setup.sh missing pip3 --user legacy fallback"
 fi
 
 # Test: Fallback chain is in correct order (uv -> pipx -> venv -> pip3)
@@ -466,27 +466,27 @@ venv_line=$(grep -n 'cisco-scanner-env' "$REPO_DIR/setup.sh" | head -1 | cut -d:
 pip3_line=$(grep -n 'pip3 install --user cisco' "$REPO_DIR/setup.sh" | head -1 | cut -d: -f1 || true)
 
 if [[ -n "$uv_line" && -n "$pipx_line" && -n "$venv_line" && -n "$pip3_line" ]]; then
-    if [[ "$uv_line" -lt "$pipx_line" && "$pipx_line" -lt "$venv_line" && "$venv_line" -lt "$pip3_line" ]]; then
-        pass "Fallback chain order is correct: uv ($uv_line) -> pipx ($pipx_line) -> venv ($venv_line) -> pip3 ($pip3_line)"
-    else
-        fail "Fallback chain order is wrong: uv=$uv_line pipx=$pipx_line venv=$venv_line pip3=$pip3_line"
-    fi
+	if [[ "$uv_line" -lt "$pipx_line" && "$pipx_line" -lt "$venv_line" && "$venv_line" -lt "$pip3_line" ]]; then
+		pass "Fallback chain order is correct: uv ($uv_line) -> pipx ($pipx_line) -> venv ($venv_line) -> pip3 ($pip3_line)"
+	else
+		fail "Fallback chain order is wrong: uv=$uv_line pipx=$pipx_line venv=$venv_line pip3=$pip3_line"
+	fi
 else
-    fail "Could not determine fallback chain order (missing line numbers)"
+	fail "Could not determine fallback chain order (missing line numbers)"
 fi
 
 # Test: Venv cleanup on failure
 if grep -qE 'rm -rf.*cisco-scanner-env|rm -rf.*venv_dir' "$REPO_DIR/setup.sh"; then
-    pass "Venv is cleaned up on installation failure"
+	pass "Venv is cleaned up on installation failure"
 else
-    fail "Venv may not be cleaned up on failure"
+	fail "Venv may not be cleaned up on failure"
 fi
 
 # Test: Helpful error message when all fallbacks fail
 if grep -qE 'Install manually with.*uv tool install|Or:.*pipx install' "$REPO_DIR/setup.sh"; then
-    pass "Shows helpful manual install instructions on total failure"
+	pass "Shows helpful manual install instructions on total failure"
 else
-    fail "Missing helpful error message when all fallbacks fail"
+	fail "Missing helpful error message when all fallbacks fail"
 fi
 
 # ============================================================
@@ -496,51 +496,51 @@ section "Cross-Cutting: Script Quality"
 
 # Test: supervisor-helper.sh passes bash syntax check
 if bash -n "$SCRIPTS_DIR/supervisor-helper.sh" 2>/dev/null; then
-    pass "supervisor-helper.sh passes bash -n syntax check"
+	pass "supervisor-helper.sh passes bash -n syntax check"
 else
-    fail "supervisor-helper.sh has syntax errors"
+	fail "supervisor-helper.sh has syntax errors"
 fi
 
 # Test: memory-helper.sh passes bash syntax check
 if bash -n "$SCRIPTS_DIR/memory-helper.sh" 2>/dev/null; then
-    pass "memory-helper.sh passes bash -n syntax check"
+	pass "memory-helper.sh passes bash -n syntax check"
 else
-    fail "memory-helper.sh has syntax errors"
+	fail "memory-helper.sh has syntax errors"
 fi
 
 # Test: setup.sh passes bash syntax check
 if bash -n "$REPO_DIR/setup.sh" 2>/dev/null; then
-    pass "setup.sh passes bash -n syntax check"
+	pass "setup.sh passes bash -n syntax check"
 else
-    fail "setup.sh has syntax errors"
+	fail "setup.sh has syntax errors"
 fi
 
 # Test: aidevops.sh passes bash syntax check
 if bash -n "$REPO_DIR/aidevops.sh" 2>/dev/null; then
-    pass "aidevops.sh passes bash -n syntax check"
+	pass "aidevops.sh passes bash -n syntax check"
 else
-    fail "aidevops.sh has syntax errors"
+	fail "aidevops.sh has syntax errors"
 fi
 
 # Test: ShellCheck on supervisor-helper.sh (no errors, only warnings allowed)
 if command -v shellcheck &>/dev/null; then
-    sc_errors=$(shellcheck -S error "$SCRIPTS_DIR/supervisor-helper.sh" 2>&1 | grep -c "error" || true)
-    if [[ "$sc_errors" -eq 0 ]]; then
-        pass "supervisor-helper.sh has 0 ShellCheck errors"
-    else
-        fail "supervisor-helper.sh has $sc_errors ShellCheck errors"
-    fi
+	sc_errors=$(shellcheck -S error "$SCRIPTS_DIR/supervisor-helper.sh" 2>&1 | grep -c "error" || true)
+	if [[ "$sc_errors" -eq 0 ]]; then
+		pass "supervisor-helper.sh has 0 ShellCheck errors"
+	else
+		fail "supervisor-helper.sh has $sc_errors ShellCheck errors"
+	fi
 else
-    skip "shellcheck not installed"
+	skip "shellcheck not installed"
 fi
 
 # Test: No TODO/FIXME/HACK markers in the specific changed functions
 # Exclude legitimate references like "TODO.md" and "auto-dispatch"
 hack_count=$(grep -nE '# (TODO|FIXME|HACK|XXX):' "$SCRIPTS_DIR/supervisor-helper.sh" | grep -cE 'dispatch|health|nohup|reprompt' || true)
 if [[ "$hack_count" -eq 0 ]]; then
-    pass "No TODO/FIXME/HACK markers in dispatch/health/reprompt code"
+	pass "No TODO/FIXME/HACK markers in dispatch/health/reprompt code"
 else
-    fail "$hack_count TODO/FIXME/HACK markers found in critical supervisor code"
+	fail "$hack_count TODO/FIXME/HACK markers found in critical supervisor code"
 fi
 
 # ============================================================
@@ -550,73 +550,73 @@ section "Functional: Supervisor Dispatch (live)"
 
 # Test: Deployed supervisor script matches repo
 if [[ -f "$DEPLOYED_DIR/supervisor-helper.sh" ]]; then
-    if diff -q "$SCRIPTS_DIR/supervisor-helper.sh" "$DEPLOYED_DIR/supervisor-helper.sh" > /dev/null 2>&1; then
-        pass "Deployed supervisor-helper.sh matches repo version"
-    else
-        fail "Deployed supervisor-helper.sh differs from repo version" \
-            "Run: cp $SCRIPTS_DIR/supervisor-helper.sh $DEPLOYED_DIR/supervisor-helper.sh"
-    fi
+	if diff -q "$SCRIPTS_DIR/supervisor-helper.sh" "$DEPLOYED_DIR/supervisor-helper.sh" >/dev/null 2>&1; then
+		pass "Deployed supervisor-helper.sh matches repo version"
+	else
+		fail "Deployed supervisor-helper.sh differs from repo version" \
+			"Run: cp $SCRIPTS_DIR/supervisor-helper.sh $DEPLOYED_DIR/supervisor-helper.sh"
+	fi
 else
-    skip "supervisor-helper.sh not deployed"
+	skip "supervisor-helper.sh not deployed"
 fi
 
 # Test: Deployed memory-helper.sh matches repo
 if [[ -f "$DEPLOYED_DIR/memory-helper.sh" ]]; then
-    if diff -q "$SCRIPTS_DIR/memory-helper.sh" "$DEPLOYED_DIR/memory-helper.sh" > /dev/null 2>&1; then
-        pass "Deployed memory-helper.sh matches repo version"
-    else
-        fail "Deployed memory-helper.sh differs from repo version"
-    fi
+	if diff -q "$SCRIPTS_DIR/memory-helper.sh" "$DEPLOYED_DIR/memory-helper.sh" >/dev/null 2>&1; then
+		pass "Deployed memory-helper.sh matches repo version"
+	else
+		fail "Deployed memory-helper.sh differs from repo version"
+	fi
 else
-    skip "memory-helper.sh not deployed"
+	skip "memory-helper.sh not deployed"
 fi
 
 # Test: Supervisor DB exists and is accessible
 if [[ -f "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" ]]; then
-    task_count=$(sqlite3 "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" "SELECT COUNT(*) FROM tasks;" 2>/dev/null || echo "0")
-    if [[ "$task_count" -gt 0 ]]; then
-        pass "Supervisor DB accessible ($task_count tasks)"
-    else
-        fail "Supervisor DB exists but has 0 tasks"
-    fi
+	task_count=$(sqlite3 "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" "SELECT COUNT(*) FROM tasks;" 2>/dev/null || echo "0")
+	if [[ "$task_count" -gt 0 ]]; then
+		pass "Supervisor DB accessible ($task_count tasks)"
+	else
+		fail "Supervisor DB exists but has 0 tasks"
+	fi
 else
-    skip "Supervisor DB not found (supervisor not initialized)"
+	skip "Supervisor DB not found (supervisor not initialized)"
 fi
 
 # Test: Cron pulse is installed
 if crontab -l 2>/dev/null | grep -q 'supervisor-helper.sh pulse'; then
-    pass "Cron pulse is installed"
+	pass "Cron pulse is installed"
 else
-    skip "Cron pulse not installed (autonomous mode not active)"
+	skip "Cron pulse not installed (autonomous mode not active)"
 fi
 
 # Test: Running workers have valid PIDs (if any)
 if [[ -d "$HOME/.aidevops/.agent-workspace/supervisor/pids" ]]; then
-    stale_pids=0
-    live_pids=0
-    for pid_file in "$HOME/.aidevops/.agent-workspace/supervisor/pids"/*.pid; do
-        [[ -f "$pid_file" ]] || continue
-        pid=$(cat "$pid_file")
-        task=$(basename "$pid_file" .pid)
-        status=$(sqlite3 "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" \
-            "SELECT status FROM tasks WHERE id = '$task';" 2>/dev/null || echo "unknown")
-        if [[ "$status" == "running" || "$status" == "dispatched" ]]; then
-            if kill -0 "$pid" 2>/dev/null; then
-                live_pids=$((live_pids + 1))
-            else
-                stale_pids=$((stale_pids + 1))
-                [[ "$VERBOSE" == "--verbose" ]] && echo "       Stale: $task (PID $pid, status=$status)"
-            fi
-        fi
-    done
-    if [[ "$stale_pids" -eq 0 ]]; then
-        pass "No stale PIDs for running/dispatched tasks ($live_pids alive)"
-    else
-        fail "$stale_pids stale PID(s) for running/dispatched tasks" \
-            "Workers may have died — pulse should clean these up"
-    fi
+	stale_pids=0
+	live_pids=0
+	for pid_file in "$HOME/.aidevops/.agent-workspace/supervisor/pids"/*.pid; do
+		[[ -f "$pid_file" ]] || continue
+		pid=$(cat "$pid_file")
+		task=$(basename "$pid_file" .pid)
+		status=$(sqlite3 "$HOME/.aidevops/.agent-workspace/supervisor/supervisor.db" \
+			"SELECT status FROM tasks WHERE id = '$task';" 2>/dev/null || echo "unknown")
+		if [[ "$status" == "running" || "$status" == "dispatched" ]]; then
+			if kill -0 "$pid" 2>/dev/null; then
+				live_pids=$((live_pids + 1))
+			else
+				stale_pids=$((stale_pids + 1))
+				[[ "$VERBOSE" == "--verbose" ]] && echo "       Stale: $task (PID $pid, status=$status)"
+			fi
+		fi
+	done
+	if [[ "$stale_pids" -eq 0 ]]; then
+		pass "No stale PIDs for running/dispatched tasks ($live_pids alive)"
+	else
+		fail "$stale_pids stale PID(s) for running/dispatched tasks" \
+			"Workers may have died — pulse should clean these up"
+	fi
 else
-    skip "No PID directory (no workers dispatched)"
+	skip "No PID directory (no workers dispatched)"
 fi
 
 # ============================================================
@@ -625,15 +625,15 @@ fi
 echo ""
 echo "========================================"
 printf "  \033[1mResults: %d total, \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m, \033[0;33m%d skipped\033[0m\n" \
-    "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+	"$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
 echo "========================================"
 
 if [[ "$FAIL_COUNT" -gt 0 ]]; then
-    echo ""
-    printf "\033[0;31mFAILURES DETECTED — review output above\033[0m\n"
-    exit 1
+	echo ""
+	printf "\033[0;31mFAILURES DETECTED — review output above\033[0m\n"
+	exit 1
 else
-    echo ""
-    printf "\033[0;32mAll tests passed.\033[0m\n"
-    exit 0
+	echo ""
+	printf "\033[0;32mAll tests passed.\033[0m\n"
+	exit 0
 fi


### PR DESCRIPTION
## Summary

Update all sonnet tier model references from `claude-sonnet-4-5` to `claude-sonnet-4-6` (new primary), and update the legacy alias from `claude-sonnet-4-20250514` to `claude-sonnet-4-0` per Anthropic docs.

## Changes

- **New primary sonnet model**: `claude-sonnet-4-6` (training cutoff Jan 2026, 64K max output, 1M context beta, same $3/$15 pricing)
- **Legacy alias updated**: `claude-sonnet-4-20250514` → `claude-sonnet-4-0`

### Scripts updated
- `fallback-chain-helper.sh` — hardcoded tier fallbacks
- `model-availability-helper.sh` — tier resolution chains
- `supervisor/dispatch.sh` — worker dispatch defaults
- `runner-helper.sh`, `objective-runner-helper.sh` — DEFAULT_MODEL constants
- `cron-helper.sh`, `cron-dispatch.sh` — cron job defaults
- `document-extraction-helper.sh` — LLM backend default
- `contest-helper.sh` — DEFAULT_CONTEST_MODELS
- `model-label-helper.sh`, `model-registry-helper.sh` — doc examples
- `generate-opencode-agents.sh` — MODEL_TIERS mapping
- `pipecat-helper.sh` — DEFAULT_ANTHROPIC_MODEL
- `opencode-github-setup-helper.sh`, `agent-test-helper.sh` — example configs

### Configs updated
- `configs/fallback-chain-config.json.txt` — all sonnet/pro/eval/health/default chains
- `configs/mcp-templates/opencode-github-workflow.yml` — workflow model

### Docs updated (in progress)
- `models/sonnet.md`, `models/README.md`, `fallback-chains.md`
- `headless-dispatch.md`, `model-routing.md`, opencode docs

Ref #1578