### PR TITLE
t1083: Align haiku and opus model IDs to non-dated aliases

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -216,9 +216,9 @@ SKIP_CUSTOM_PROMPT = set()
 # Maps tier names to actual model identifiers
 # Agents declare their tier; the coordinator uses this for cost-effective routing
 MODEL_TIERS = {
-    "haiku": "claude-3-5-haiku-20241022",      # Triage, routing, simple tasks
+    "haiku": "claude-haiku-4-5",               # Triage, routing, simple tasks
     "sonnet": "claude-sonnet-4-6",             # Code, review, implementation
-    "opus": "claude-opus-4-20250514",          # Architecture, complex reasoning
+    "opus": "claude-opus-4-6",                 # Architecture, complex reasoning
     "flash": "gemini-2.5-flash",               # Fast, cheap, large context
     "pro": "gemini-2.5-pro",                   # Capable, large context
 }

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -127,7 +127,7 @@ get_tier_models() {
 		esac
 	else
 		case "$tier" in
-		haiku) echo "anthropic/claude-3-5-haiku-20241022|google/gemini-2.5-flash" ;;
+		haiku) echo "anthropic/claude-haiku-4-5|google/gemini-2.5-flash" ;;
 		flash) echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
 		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-4.1" ;;
 		pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1095,7 +1095,7 @@ resolve_model_tier() {
 		echo "anthropic/claude-sonnet-4-6"
 		;;
 	haiku | health)
-		echo "anthropic/claude-3-5-haiku-20241022"
+		echo "anthropic/claude-haiku-4-5"
 		;;
 	flash)
 		echo "google/gemini-2.5-flash-preview-05-20"

--- a/.opencode/lib/ai-research.ts
+++ b/.opencode/lib/ai-research.ts
@@ -42,9 +42,9 @@ export interface ResearchResult {
 const AGENTS_BASE = `${process.env.HOME || "~"}/.aidevops/agents`
 
 const MODEL_MAP: Record<string, string> = {
-  haiku: "claude-3-haiku-20240307",
+  haiku: "claude-haiku-4-5",
   sonnet: "claude-sonnet-4-6",
-  opus: "claude-opus-4-20250514",
+  opus: "claude-opus-4-6",
 }
 
 const MAX_CALLS_PER_SESSION = 10


### PR DESCRIPTION
## Summary

- Update stale haiku model IDs from `claude-3-haiku-20240307` / `claude-3-5-haiku-20241022` to `claude-haiku-4-5`
- Update stale opus model IDs from `claude-opus-4-20250514` to `claude-opus-4-6`
- Aligns all 4 files with the canonical non-dated aliases already used in `fallback-chain-config.json.txt` and `supervisor/dispatch.sh`

## Files Changed (4 files, 6 lines)

- `.opencode/lib/ai-research.ts` — MODEL_MAP haiku + opus entries
- `.agents/scripts/generate-opencode-agents.sh` — MODEL_TIERS haiku + opus entries
- `.agents/scripts/model-availability-helper.sh` — get_tier_models() haiku fallback
- `.agents/scripts/shared-constants.sh` — resolve_model_tier() haiku/health case

## Context

Follow-up to PR #1594 (Sonnet 4.6 update). CodeRabbit flagged that haiku and opus model IDs diverged across the codebase after the sonnet update. This PR resolves that inconsistency.

Ref #1578