### PR TITLE
t1097: Add prompt-repeat retry strategy to dispatch.sh

### DIFF
--- a/.agents/scripts/supervisor/dispatch.sh
+++ b/.agents/scripts/supervisor/dispatch.sh
@@ -628,10 +628,11 @@ should_prompt_repeat() {
 	local pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
 	if [[ -x "$pattern_helper" ]]; then
 		# Query success/failure counts for prompt_repeat patterns
-		local pr_success pr_failure
-		pr_success=$("$pattern_helper" stats 2>/dev/null |
+		local stats_output pr_success pr_failure
+		stats_output=$("$pattern_helper" stats 2>/dev/null)
+		pr_success=$(echo "$stats_output" |
 			grep -c 'prompt_repeat.*SUCCESS\|SUCCESS.*prompt_repeat' 2>/dev/null || echo "0")
-		pr_failure=$("$pattern_helper" stats 2>/dev/null |
+		pr_failure=$(echo "$stats_output" |
 			grep -c 'prompt_repeat.*FAILURE\|FAILURE.*prompt_repeat' 2>/dev/null || echo "0")
 
 		local pr_total=$((pr_success + pr_failure))

--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -271,6 +271,21 @@ cmd_pulse() {
 				send_task_notification "$tid" "complete" "$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 				# Store success pattern in memory (t128.6)
 				store_success_pattern "$tid" "$outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
+				# Track prompt-repeat outcome for pattern data (t1097)
+				local tid_pr_done
+				tid_pr_done=$(db "$SUPERVISOR_DB" "SELECT COALESCE(prompt_repeat_done, 0) FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo "0")
+				if [[ "$tid_pr_done" -ge 1 ]]; then
+					local pr_pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+					if [[ -x "$pr_pattern_helper" ]]; then
+						"$pr_pattern_helper" record \
+							--type "SUCCESS_PATTERN" \
+							--task "$tid" \
+							--model "${tid_model:-unknown}" \
+							--detail "prompt_repeat_success: task completed after reinforced prompt at same tier" \
+							2>/dev/null || true
+					fi
+					log_info "  $tid: prompt-repeat strategy succeeded (t1097)"
+				fi
 				# Add implemented:model label to GitHub issue (t1010)
 				add_model_label "$tid" "implemented" "$tid_model" "${tid_repo:-.}" 2>>"$SUPERVISOR_LOG" || true
 				# Self-heal: if this was a diagnostic task, re-queue the parent (t150)
@@ -287,10 +302,25 @@ cmd_pulse() {
 				cleanup_worker_processes "$tid"
 				# Store failure pattern in memory (t128.6)
 				store_failure_pattern "$tid" "retry" "$outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
+				# Track prompt-repeat failure for pattern data (t1097)
+				# If this task already had a prompt-repeat attempt and is failing again,
+				# record that prompt-repeat didn't help for this task type.
+				local tid_pr_done_retry
+				tid_pr_done_retry=$(db "$SUPERVISOR_DB" "SELECT COALESCE(prompt_repeat_done, 0) FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo "0")
+				if [[ "$tid_pr_done_retry" -ge 1 ]]; then
+					local pr_pattern_helper_retry="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+					if [[ -x "$pr_pattern_helper_retry" ]]; then
+						"$pr_pattern_helper_retry" record \
+							--type "FAILURE_PATTERN" \
+							--task "$tid" \
+							--model "${tid_model:-unknown}" \
+							--detail "prompt_repeat_failure: task failed again after reinforced prompt ($outcome_detail)" \
+							2>/dev/null || true
+					fi
+					log_info "  $tid: prompt-repeat strategy failed, will escalate model (t1097)"
+				fi
 				# Add retried:model label to GitHub issue (t1010)
 				add_model_label "$tid" "retried" "$tid_model" "${tid_repo:-.}" 2>>"$SUPERVISOR_LOG" || true
-				# Auto-escalate model on retry so re-prompt uses stronger model (t314 wiring)
-				escalate_model_on_failure "$tid" 2>>"$SUPERVISOR_LOG" || true
 				# Backend quota errors: defer re-prompt to next pulse (t095-diag-1).
 				# Quota resets take hours, not minutes. Immediate re-prompt wastes
 				# retry attempts. Leave in retrying state for deferred retry loop.
@@ -298,6 +328,26 @@ cmd_pulse() {
 					log_warn "  $tid: backend issue ($outcome_detail), deferring re-prompt to next pulse"
 					continue
 				fi
+				# Prompt-repeat retry strategy (t1097): before escalating to a more
+				# expensive model, try the same tier with a reinforced prompt. Many
+				# failures are due to insufficient prompt clarity, not model capability.
+				local prompt_repeat_eligible=""
+				prompt_repeat_eligible=$(should_prompt_repeat "$tid" "$outcome_detail" 2>/dev/null) || prompt_repeat_eligible=""
+				if [[ "$prompt_repeat_eligible" == "eligible" ]]; then
+					log_info "  $tid: attempting prompt-repeat retry at same tier (t1097)"
+					local pr_rc=0
+					do_prompt_repeat "$tid" 2>>"$SUPERVISOR_LOG" || pr_rc=$?
+					if [[ "$pr_rc" -eq 0 ]]; then
+						dispatched_count=$((dispatched_count + 1))
+						log_info "  $tid: prompt-repeat dispatched successfully"
+						continue
+					fi
+					log_warn "  $tid: prompt-repeat dispatch failed (rc=$pr_rc), falling through to model escalation"
+				else
+					log_info "  $tid: prompt-repeat not eligible ($prompt_repeat_eligible), proceeding to model escalation"
+				fi
+				# Auto-escalate model on retry so re-prompt uses stronger model (t314 wiring)
+				escalate_model_on_failure "$tid" 2>>"$SUPERVISOR_LOG" || true
 				# Re-prompt in existing worktree (continues context)
 				local reprompt_rc=0
 				cmd_reprompt "$tid" 2>>"$SUPERVISOR_LOG" || reprompt_rc=$?


### PR DESCRIPTION
## Summary

Add a prompt-repeat retry strategy to the supervisor dispatch pipeline that retries failed tasks with a reinforced prompt at the **same model tier** before escalating to a more expensive model.

### Problem

Many worker failures are due to insufficient prompt clarity (e.g., worker exits without emitting FULL_LOOP_COMPLETE, does not create a PR, produces trivial output) rather than model capability limitations. The current flow immediately escalates to a higher-tier model on retry, which is ~2-5x more expensive and often unnecessary.

### Solution

Insert a prompt-repeat step **before** model escalation in the pulse retry handler:

1. **should_prompt_repeat()** -- checks eligibility: config toggle, not already attempted, retryable failure, pattern tracker data
2. **do_prompt_repeat()** -- dispatches with reinforced prompt at same tier, reuses existing worktree
3. **Pattern tracking** -- records SUCCESS_PATTERN/FAILURE_PATTERN with prompt_repeat tag for data-driven routing

### Files Changed

- .agents/scripts/supervisor/dispatch.sh -- new functions: should_prompt_repeat(), mark_prompt_repeat_done(), build_prompt_repeat_prompt(), do_prompt_repeat()
- .agents/scripts/supervisor/pulse.sh -- integrate prompt-repeat before model escalation in Phase 1 retry handler, add pattern tracking for outcomes
- .agents/scripts/supervisor/database.sh -- add prompt_repeat_done column to tasks table (schema + migration)

### Configuration

- SUPERVISOR_PROMPT_REPEAT_ENABLED=true (default) -- set to false to disable
- Self-tuning via pattern tracker: accumulates data on which task types benefit

Ref #1622