### PR TITLE
t1085: Fix --format text -> --format default for opencode run in AI reasoning

### DIFF
--- a/.agents/scripts/supervisor/ai-reason.sh
+++ b/.agents/scripts/supervisor/ai-reason.sh
@@ -249,7 +249,7 @@ ${user_prompt}"
 	if [[ "$ai_cli" == "opencode" ]]; then
 		ai_result=$(portable_timeout "$ai_timeout" opencode run \
 			-m "$ai_model" \
-			--format text \
+			--format default \
 			--title "ai-supervisor-${timestamp}" \
 			"$full_prompt" 2>/dev/null || echo "")
 	else


### PR DESCRIPTION
## Summary

- Fixes the root cause of 0-byte AI responses in Phase 14 reasoning
- `opencode run` only accepts `--format default` or `--format json` — `--format text` is invalid
- With `--format text`, the CLI prints help text and exits with an error, which `2>/dev/null || echo ""` silently swallows
- This has been the cause of **every** AI reasoning cycle failing since Phase 14 was introduced

## Evidence

10 consecutive reasoning cycles all show:
```
Response length: 0 bytes
Status: FAILED - no parseable JSON action plan
```

The context was being built correctly (15KB+), the prompt was being logged, but the AI CLI never actually ran.

## Fix

One-character change: `--format text` → `--format default`

## Verification

Tested `opencode run --format default` manually — returns actual AI response. Tested `opencode run --format text` — prints help and exits.