### PR TITLE
t1085: Increase AI reasoning timeout from 120s to 300s

### DIFF
--- a/.agents/scripts/supervisor/ai-reason.sh
+++ b/.agents/scripts/supervisor/ai-reason.sh
@@ -239,7 +239,8 @@ PROMPT
 	log_info "AI Reasoning: using $ai_model via $ai_cli"
 
 	# Step 6: Spawn AI session
-	local ai_timeout="${SUPERVISOR_AI_TIMEOUT:-120}"
+	# Default 300s (5 min) — opus needs time to analyze 15KB+ context and produce structured JSON
+	local ai_timeout="${SUPERVISOR_AI_TIMEOUT:-300}"
 	local ai_result=""
 
 	local full_prompt="${system_prompt}


### PR DESCRIPTION
## Summary

- Increases default `SUPERVISOR_AI_TIMEOUT` from 120s to 300s (5 min)
- Opus needs more time to analyze 15KB+ of project context and produce structured JSON
- First successful AI response was cut off mid-reasoning at 120s (2005 bytes of chain-of-thought, no JSON output)
- Still configurable via `SUPERVISOR_AI_TIMEOUT` env var

## Evidence

From `reason-20260218-142828.md` — first run with working `--format default`:
- Response: 2005 bytes of reasoning (10 observations, analysis of audit findings)
- But no JSON action plan — model was still thinking when timeout hit
- Previous runs: 0 bytes (due to `--format text` bug, now fixed in PR #1642)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased AI session timeout from 2 minutes to 5 minutes to improve stability and reduce premature session terminations during longer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->