### PR TITLE
t1085: Add create_improvement and escalate_model action types to AI executor

### DIFF
--- a/.agents/scripts/supervisor/ai-reason.sh
+++ b/.agents/scripts/supervisor/ai-reason.sh
@@ -239,7 +239,8 @@ PROMPT
 	log_info "AI Reasoning: using $ai_model via $ai_cli"
 
 	# Step 6: Spawn AI session
-	local ai_timeout="${SUPERVISOR_AI_TIMEOUT:-120}"
+	# Default 300s (5 min) — opus needs time to analyze 15KB+ context and produce structured JSON
+	local ai_timeout="${SUPERVISOR_AI_TIMEOUT:-300}"
 	local ai_result=""
 
 	local full_prompt="${system_prompt}


### PR DESCRIPTION
## Summary

- Adds `create_improvement` action type: creates self-improvement tasks in TODO.md with `#self-improvement` and `#auto-dispatch` tags, plus category metadata
- Adds `escalate_model` action type: updates a task's model tier in supervisor DB and TODO.md, logs escalation event for pattern tracking
- Both types include field validation and follow existing patterns (claim-task-id.sh, commit_and_push_todo)

## Why

The AI reasoning engine already proposes these action types (added to the prompt in a prior PR), but the executor rejected them as "invalid type". On the first successful reasoning cycle, 4 out of 8 proposed actions were `create_improvement` — all skipped. This fills that gap.

## What the AI wanted to create (but couldn't)

1. Batch remediation of 11 falsely closed GitHub issues
2. Hardening the issue-sync pipeline to prevent false closures
3. Two other self-improvement tasks

After this PR merges, the next reasoning cycle will be able to execute these.