### PR TITLE
t1125: Fix jq JSON parsing errors in supervisor action executor pipeline

### DIFF
--- a/.agents/scripts/supervisor/ai-actions.sh
+++ b/.agents/scripts/supervisor/ai-actions.sh
@@ -111,7 +111,10 @@ execute_action_plan() {
 		if ! validate_action_type "$action_type"; then
 			log_warn "AI Actions: skipping invalid action type '$action_type'"
 			skipped=$((skipped + 1))
-			results=$(printf '%s' "$results" | jq ". + [{\"index\":$i,\"type\":\"$action_type\",\"status\":\"skipped\",\"reason\":\"invalid_action_type\"}]")
+			results=$(printf '%s' "$results" | jq \
+				--argjson idx "$i" \
+				--arg type "$action_type" \
+				'. + [{"index": $idx, "type": $type, "status": "skipped", "reason": "invalid_action_type"}]')
 			{
 				echo "## Action $((i + 1)): $action_type — SKIPPED (invalid type)"
 				echo ""
@@ -125,9 +128,11 @@ execute_action_plan() {
 		if [[ -n "$validation_error" ]]; then
 			log_warn "AI Actions: skipping $action_type — $validation_error"
 			skipped=$((skipped + 1))
-			local escaped_reason
-			escaped_reason=$(printf '%s' "$validation_error" | jq -Rs '.')
-			results=$(printf '%s' "$results" | jq ". + [{\"index\":$i,\"type\":\"$action_type\",\"status\":\"skipped\",\"reason\":$escaped_reason}]")
+			results=$(printf '%s' "$results" | jq \
+				--argjson idx "$i" \
+				--arg type "$action_type" \
+				--arg reason "$validation_error" \
+				'. + [{"index": $idx, "type": $type, "status": "skipped", "reason": $reason}]')
 			{
 				echo "## Action $((i + 1)): $action_type — SKIPPED ($validation_error)"
 				echo ""
@@ -139,7 +144,10 @@ execute_action_plan() {
 		if [[ "$mode" == "validate-only" ]]; then
 			log_info "AI Actions: [$((i + 1))/$action_count] $action_type — validated"
 			skipped=$((skipped + 1))
-			results=$(printf '%s' "$results" | jq ". + [{\"index\":$i,\"type\":\"$action_type\",\"status\":\"validated\"}]")
+			results=$(printf '%s' "$results" | jq \
+				--argjson idx "$i" \
+				--arg type "$action_type" \
+				'. + [{"index": $idx, "type": $type, "status": "validated"}]')
 			{
 				echo "## Action $((i + 1)): $action_type — VALIDATED"
 				echo "Reasoning: $reasoning"
@@ -151,7 +159,10 @@ execute_action_plan() {
 		if [[ "$mode" == "dry-run" || "$AI_ACTIONS_DRY_RUN" == "true" ]]; then
 			log_info "AI Actions: [$((i + 1))/$action_count] $action_type — dry-run"
 			executed=$((executed + 1))
-			results=$(printf '%s' "$results" | jq ". + [{\"index\":$i,\"type\":\"$action_type\",\"status\":\"dry_run\"}]")
+			results=$(printf '%s' "$results" | jq \
+				--argjson idx "$i" \
+				--arg type "$action_type" \
+				'. + [{"index": $idx, "type": $type, "status": "dry_run"}]')
 			{
 				echo "## Action $((i + 1)): $action_type — DRY RUN"
 				echo "Reasoning: $reasoning"
@@ -175,20 +186,26 @@ execute_action_plan() {
 		local exec_result_json
 		exec_result_json=$(printf '%s' "$exec_result" | grep -E '^\{' | tail -1)
 		if [[ -z "$exec_result_json" ]] || ! printf '%s' "$exec_result_json" | jq '.' &>/dev/null; then
-			# Not valid JSON — escape the entire result as a string
-			exec_result_json=$(printf '%s' "$exec_result" | jq -Rs '.')
+			# Not valid JSON — wrap the entire result as a JSON string value
+			exec_result_json=$(jq -Rn --arg v "$exec_result" '$v')
 		fi
 
 		if [[ $exec_rc -eq 0 ]]; then
 			executed=$((executed + 1))
 			log_info "AI Actions: [$((i + 1))/$action_count] $action_type — success"
-			results=$(printf '%s' "$results" | jq --argjson r "$exec_result_json" ". + [{\"index\":$i,\"type\":\"$action_type\",\"status\":\"executed\",\"result\":\$r}]")
+			results=$(printf '%s' "$results" | jq \
+				--argjson idx "$i" \
+				--arg type "$action_type" \
+				--argjson r "$exec_result_json" \
+				'. + [{"index": $idx, "type": $type, "status": "executed", "result": $r}]')
 		else
 			failed=$((failed + 1))
 			log_warn "AI Actions: [$((i + 1))/$action_count] $action_type — failed"
-			local escaped_result
-			escaped_result=$(printf '%s' "$exec_result" | jq -Rs '.')
-			results=$(printf '%s' "$results" | jq --argjson e "$escaped_result" ". + [{\"index\":$i,\"type\":\"$action_type\",\"status\":\"failed\",\"error\":\$e}]")
+			results=$(printf '%s' "$results" | jq \
+				--argjson idx "$i" \
+				--arg type "$action_type" \
+				--arg error "$exec_result" \
+				'. + [{"index": $idx, "type": $type, "status": "failed", "error": $error}]')
 		fi
 
 		{
@@ -544,7 +561,8 @@ _exec_create_task() {
 		commit_and_push_todo "$repo_path" "chore: AI supervisor created task $task_id" >>"$SUPERVISOR_LOG" 2>&1 || true
 	fi
 
-	echo "{\"created\":true,\"task_id\":\"$task_id\",\"title\":$(printf '%s' "$title" | jq -Rs '.')}"
+	jq -n --arg task_id "$task_id" --arg title "$title" \
+		'{"created": true, "task_id": $task_id, "title": $title}'
 	return 0
 }
 
@@ -949,7 +967,8 @@ _exec_create_improvement() {
 		commit_and_push_todo "$repo_path" "chore: AI supervisor created improvement task $task_id" >>"$SUPERVISOR_LOG" 2>&1 || true
 	fi
 
-	echo "{\"created\":true,\"task_id\":\"$task_id\",\"title\":$(printf '%s' "$title" | jq -Rs '.'),\"category\":\"$category\"}"
+	jq -n --arg task_id "$task_id" --arg title "$title" --arg category "$category" \
+		'{"created": true, "task_id": $task_id, "title": $title, "category": $category}'
 	return 0
 }
 

--- a/.agents/scripts/supervisor/issue-audit.sh
+++ b/.agents/scripts/supervisor/issue-audit.sh
@@ -819,7 +819,12 @@ run_full_audit() {
 
 	# Count by severity across all findings
 	local all_findings=""
-	all_findings=$(printf '%s' "$closed_findings" | jq ". + $(printf '%s' "$stale_findings") + $(printf '%s' "$orphan_findings") + $(printf '%s' "$blocked_findings")")
+	all_findings=$(jq -n \
+		--argjson closed "$closed_findings" \
+		--argjson stale "$stale_findings" \
+		--argjson orphan "$orphan_findings" \
+		--argjson blocked "$blocked_findings" \
+		'$closed + $stale + $orphan + $blocked')
 	local high_count=""
 	high_count=$(printf '%s' "$all_findings" | jq '[.[] | select(.severity == "high")] | length' 2>/dev/null || echo "0")
 	local medium_count=""


### PR DESCRIPTION
Fix jq JSON parsing errors in supervisor action executor pipeline.

Root cause: shell variables were interpolated directly into jq filter strings, causing `syntax error, unexpected LITERAL` and `invalid JSON text passed to --argjson` when values contained apostrophes, quotes, or special characters. These rc=1 errors silently dropped valid actions from the pipeline.

## Changes

**`ai-actions.sh`** (primary fix):
- All jq filter string interpolation replaced with `--arg`/`--argjson` named parameters
- `jq -Rn --arg v "$var" '$v'` replaces `jq -Rs '.'` for safe string wrapping
- `jq -n --arg/--argjson` used for JSON output construction in `_exec_create_task` and `_exec_create_improvement`
- Removed intermediate `escaped_result` variable (now passed directly via `--arg error`)

**`issue-audit.sh`**:
- Replaced unsafe `". + $(printf '%s' "$stale_findings")..."` filter interpolation with `jq -n --argjson` for safe array merging

## Verification

Tested with apostrophes, double quotes, newlines, and backslashes — all pass through jq's own escaping layer correctly. ShellCheck: zero violations.

Ref #1684