### PR TITLE
t1129: Include MODELS.md in aidevops init workflow for per-repo performance tracking

### DIFF
--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -2009,13 +2009,13 @@ RULES:
 					[[ -n "$models_repo_path" && -d "$models_repo_path" ]] || continue
 					local models_repo_root
 					models_repo_root=$(git -C "$models_repo_path" rev-parse --show-toplevel 2>/dev/null) || continue
-					log_verbose "  Phase 12: Regenerating MODELS.md in $models_repo_root"
-					if "$generate_script" --output "${models_repo_root}/MODELS.md" --quiet 2>/dev/null; then
+					log_verbose "  Phase 12: Regenerating MODELS.md in $models_repo_root (per-repo filtered)"
+					if "$generate_script" --output "${models_repo_root}/MODELS.md" --repo-path "$models_repo_root" --quiet 2>/dev/null; then
 						if git -C "$models_repo_root" diff --quiet -- MODELS.md 2>/dev/null; then
 							log_verbose "  Phase 12: MODELS.md unchanged in $models_repo_root"
 						else
 							git -C "$models_repo_root" add MODELS.md 2>/dev/null &&
-								git -C "$models_repo_root" commit -m "chore: regenerate MODELS.md leaderboard (t1012)" --no-verify 2>/dev/null &&
+								git -C "$models_repo_root" commit -m "chore: regenerate MODELS.md leaderboard (t1012, t1129)" --no-verify 2>/dev/null &&
 								git -C "$models_repo_root" push 2>/dev/null &&
 								log_info "  Phase 12: MODELS.md updated and pushed ($models_repo_root)" ||
 								log_warn "  Phase 12: MODELS.md regenerated but commit/push failed ($models_repo_root)"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1247,6 +1247,19 @@ SOPSEOF
 		print_info "Collaborator pointer files already exist"
 	fi
 
+	# Generate MODELS.md (per-repo model performance leaderboard, t1129)
+	local generate_models_script="$AGENTS_DIR/scripts/generate-models-md.sh"
+	if [[ -x "$generate_models_script" ]] && command -v sqlite3 &>/dev/null; then
+		print_info "Generating MODELS.md (model performance leaderboard)..."
+		if "$generate_models_script" --output "$project_root/MODELS.md" --repo-path "$project_root" --quiet 2>/dev/null; then
+			print_success "Created MODELS.md (per-repo model leaderboard)"
+		else
+			print_warning "MODELS.md generation failed (will be populated as tasks run)"
+		fi
+	else
+		print_info "MODELS.md skipped (sqlite3 or generate script not available)"
+	fi
+
 	# Build features string for registration
 	local features_list=""
 	[[ "$enable_planning" == "true" ]] && features_list="${features_list}planning,"
@@ -1272,6 +1285,7 @@ SOPSEOF
 	[[ "$enable_database" == "true" ]] && echo "  ✓ Database (schemas/, migrations/, seeds/)"
 	[[ "$enable_beads" == "true" ]] && echo "  ✓ Beads (task graph visualization)"
 	[[ "$enable_sops" == "true" ]] && echo "  ✓ SOPS (encrypted config files with age backend)"
+	[[ -f "$project_root/MODELS.md" ]] && echo "  ✓ MODELS.md (per-repo model performance leaderboard)"
 	echo ""
 	echo "Next steps:"
 	if [[ "$enable_beads" == "true" ]]; then


### PR DESCRIPTION
## Summary

- Add `--repo-path` flag to `generate-models-md.sh` to filter pattern data by `project_path` column in the learnings FTS5 table, enabling per-repo MODELS.md with repo-specific stats instead of global aggregates
- Update `aidevops init` to generate MODELS.md in the project root during initialization, giving each project its own model performance leaderboard from day one
- Update supervisor Phase 12 to pass `--repo-path` when regenerating MODELS.md, so periodic refreshes also produce per-repo filtered data

## Changes

### `generate-models-md.sh`
- New `--repo-path PATH` argument
- New `repo_path_filter()` helper that builds SQL WHERE clause fragments matching `project_path` (exact, subdirectory, or worktree basename)
- All pattern queries (`generate_leaderboard`, `generate_task_type_breakdown`, `generate_stats_summary`) now apply the filter
- Stats summary shows scope indicator (repo-specific vs global)
- Updated help text and footer

### `aidevops.sh`
- `cmd_init()` now calls `generate-models-md.sh --repo-path` after collaborator pointer files
- MODELS.md listed in "Enabled features" output when present

### `supervisor/pulse.sh`
- Phase 12 now passes `--repo-path "$models_repo_root"` to the generate script
- Commit message updated to reference t1129

## Verification

- ShellCheck passes with zero violations on all three modified files
- MODELS.md is not caught by any `.gitignore` pattern (verified with `git check-ignore`)
- No breaking changes: `--repo-path` is optional; omitting it preserves existing global behavior

Ref #1691