### PR TITLE
t1148: Add completed-task exclusion list to supervisor AI context

### DIFF
--- a/.agents/scripts/supervisor/ai-reason.sh
+++ b/.agents/scripts/supervisor/ai-reason.sh
@@ -439,6 +439,7 @@ Respond with ONLY a JSON array of actions. Each action is an object with:
 
 ## Rules
 
+- **EXCLUSION LIST (MANDATORY)**: The context snapshot begins with a "DO NOT ACT — Exclusion List" section. Before proposing ANY action, check its `task_id` and `issue_number` against that list. If the target appears in the exclusion list, OMIT the action entirely. Do not include it in your output, even as a comment. This is the highest-priority rule — it overrides all other analysis.
 - Be conservative. Only propose actions you are confident are correct.
 - Never close an issue unless you can verify a merged PR exists with real changes.
 - Prefer acknowledging issues over ignoring them — a brief "We've seen this, it's queued" is better than silence.


### PR DESCRIPTION
Adds a completed-task exclusion list to the supervisor AI context to prevent repeated actions on finished work.

## Changes

- `ai-context.sh`: New `build_exclusion_context()` function (Section 0) that collects:
  - Task IDs completed/verified/deployed in the last 48h from supervisor DB
  - Issue numbers and task IDs acted on in the last 5 action log cycles
- `ai-context.sh`: Injects exclusion list at the top of `build_ai_context()` output, before the issues list
- `ai-reason.sh`: Adds MANDATORY exclusion rule to system prompt — AI must omit any action whose `task_id` or `issue_number` appears in the exclusion list

## Why

The supervisor AI was proposing actions on already-completed tasks (t1125, t1126, t1127, t1130 each acted on 2+ times). The context included these in "Recently Completed" but the AI still generated actions for them. This fix prevents the AI from even proposing redundant actions, saving reasoning tokens.

Complementary to t1138 (runtime dedup) — this is the upstream prevention layer.

## Testing

- ShellCheck: zero violations on both modified files
- Logic: exclusion list is populated from DB + action logs, deduplicated, and placed first in context

Ref #1725