### PR TITLE
t1157: fix rc=1 pipeline errors from concurrent supervisor pulse cycles

### DIFF
--- a/.agents/scripts/supervisor/ai-context.sh
+++ b/.agents/scripts/supervisor/ai-context.sh
@@ -940,15 +940,24 @@ build_self_reflection_context() {
 	# Pipeline errors from ai-supervisor.log (last 50 lines)
 	local pipeline_log="${HOME}/.aidevops/.agent-workspace/supervisor/logs/ai-supervisor.log"
 	if [[ -f "$pipeline_log" ]]; then
+		# Extract pipeline errors with surrounding timestamp context (last 500 lines = ~last 2h)
+		# Include the === AI Supervisor Run: TIMESTAMP === lines for context
 		local recent_errors
-		recent_errors=$(tail -100 "$pipeline_log" 2>/dev/null | grep -iE 'error|jq:' | tail -10 || true)
+		recent_errors=$(tail -500 "$pipeline_log" 2>/dev/null | awk '
+			/=== AI Supervisor Run:/ { ts=$0 }
+			/AI Actions Pipeline:.*error|AI Actions Pipeline:.*expected array|Result: rc=1/ {
+				if (ts) print ts
+				print $0
+				ts=""
+			}
+		' | tail -20 || true)
 		if [[ -n "$recent_errors" ]]; then
 			output+="### Pipeline Errors (recent)\n\n"
-			output+="These errors occurred in the action execution pipeline:\n\n"
+			output+="These errors occurred in the action execution pipeline (with timestamps):\n\n"
 			output+="\`\`\`\n"
 			output+="$recent_errors\n"
 			output+="\`\`\`\n\n"
-			output+="If these are recurring, create a \`create_improvement\` task to fix the root cause.\n"
+			output+="If these are recurring (same error in multiple recent runs), create a \`create_improvement\` task to fix the root cause. If timestamps show errors are >1h old and recent runs succeeded, they may be already resolved.\n"
 		fi
 	fi
 

--- a/.agents/scripts/supervisor/ai-reason.sh
+++ b/.agents/scripts/supervisor/ai-reason.sh
@@ -146,6 +146,7 @@ run_ai_reasoning() {
 		# If lock holder is still alive and lock is not stale (< 5 min), skip
 		if kill -0 "$lock_pid" 2>/dev/null && [[ "$lock_age" -lt 300 ]]; then
 			log_info "AI Reasoning: already running (PID $lock_pid, ${lock_age}s old) — skipping"
+			echo '{"skipped":"concurrency_guard","actions":[]}'
 			return 0
 		fi
 		# Stale lock — remove and continue


### PR DESCRIPTION
## Summary

- Root cause: concurrent supervisor pulse cycles trigger the concurrency guard in `run_ai_reasoning()`, which returned 0 with empty stdout; `run_ai_actions_pipeline()` then failed to parse the empty string as JSON, returning rc=1
- Not a duplicate of t1125 (jq parsing in action executor) — this is in the reasoning engine's concurrency guard path
- All 4 recent rc=1 errors (16:40, 17:15, 17:31, 18:42 UTC) were caused by two pulse cycles starting at the same second

## Changes

- **ai-reason.sh**: concurrency guard now outputs `{"skipped":"concurrency_guard","actions":[]}` instead of empty string
- **ai-actions.sh**: add empty-output guard before JSON type check; handle skipped sentinel as rc=0; restructure error/skip detection
- **ai-context.sh**: improve pipeline error reporting with timestamps so AI can distinguish historical vs. current errors

Ref #1739