### PR TITLE
t1180: Add dispatchable-queue reconciliation between supervisor DB and TODO.md

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -22,6 +22,7 @@
 #   supervisor-helper.sh update-todo <task_id>         Update TODO.md for completed/blocked task
 #   supervisor-helper.sh reconcile-todo [--batch id] [--dry-run]  Bulk-fix stale TODO.md entries
 #   supervisor-helper.sh reconcile-db-todo [--batch id] [--dry-run]  Bidirectional DB<->TODO.md sync
+#   supervisor-helper.sh reconcile-queue [--batch id] [--dry-run]  Sync DB queue with TODO.md dispatchability (t1180)
 #   supervisor-helper.sh notify <task_id>              Send notification about task state
 #   supervisor-helper.sh recall <task_id>              Recall memories relevant to a task
 #   supervisor-helper.sh release [batch_id] [options]  Trigger or configure batch release (t128.10)
@@ -319,6 +320,7 @@ Usage:
   supervisor-helper.sh update-todo <task_id>         Update TODO.md for completed/blocked task
   supervisor-helper.sh reconcile-todo [--batch id] [--dry-run]  Bulk-fix stale TODO.md entries
   supervisor-helper.sh reconcile-db-todo [--batch id] [--dry-run]  Bidirectional DB<->TODO.md sync (t1001)
+  supervisor-helper.sh reconcile-queue [--batch id] [--dry-run]  Sync DB queue with TODO.md dispatchability (t1180)
   supervisor-helper.sh notify <task_id>              Send notification about task state
   supervisor-helper.sh recall <task_id>              Recall memories relevant to a task
   supervisor-helper.sh release [batch_id] [options]  Trigger or configure batch release
@@ -696,6 +698,7 @@ main() {
 	update-todo) cmd_update_todo "$@" ;;
 	reconcile-todo) cmd_reconcile_todo "$@" ;;
 	reconcile-db-todo) cmd_reconcile_db_todo "$@" ;;
+	reconcile-queue) cmd_reconcile_queue_dispatchability "$@" ;;
 	notify) cmd_notify "$@" ;;
 	auto-pickup) cmd_auto_pickup "$@" ;;
 	batch-cleanup)


### PR DESCRIPTION
Adds Phase 0.6 queue-dispatchability reconciliation to the supervisor pulse cycle.

## Problem

The supervisor DB showed 13 queued tasks but only 2 were dispatchable per TODO.md analysis. Root cause: tasks get queued in the DB via `cmd_auto_pickup` but their TODO.md state later diverges — they get completed, cancelled, or lose their `#auto-dispatch` tag. Since `cmd_next()` only queries DB status (not TODO.md), these phantom entries inflate queue metrics and confuse priority decisions.

## Solution

New `cmd_reconcile_queue_dispatchability` function in `todo-sync.sh`, integrated as **Phase 0.6** in the supervisor pulse cycle (runs every pulse, before Phase 0.7 stale-state detection).

### What it does

For each DB task with `status='queued'`:
1. **TODO.md shows `[x]`** → transition DB to `complete`
2. **TODO.md shows `[-]`** → transition DB to `cancelled`
3. **TODO.md open `[ ]` but no `#auto-dispatch` tag AND not in Dispatch Queue section** → cancel in DB (phantom entry)
4. **Has `assignee:`/`started:`** → skip (actively claimed, not phantom)
5. **Missing from TODO.md** → skip (handled by Phase 7b Gap 3 orphan check)

### CLI command

```bash
supervisor-helper.sh reconcile-queue [--batch id] [--dry-run]
```

## Files changed

- `.agents/scripts/supervisor/todo-sync.sh` — new `cmd_reconcile_queue_dispatchability()` function
- `.agents/scripts/supervisor/pulse.sh` — Phase 0.6 integration
- `.agents/scripts/supervisor-helper.sh` — `reconcile-queue` CLI command

Ref #1777