### PR TITLE
t1182: Fix AI actions pipeline 'expected array' parsing errors

### DIFF
--- a/.agents/scripts/supervisor/ai-actions.sh
+++ b/.agents/scripts/supervisor/ai-actions.sh
@@ -1628,7 +1628,11 @@ run_ai_actions_pipeline() {
 	local plan_type
 	plan_type=$(printf '%s' "$action_plan" | jq 'type' 2>/dev/null || echo "")
 	if [[ "$plan_type" != '"array"' ]]; then
-		log_warn "AI Actions Pipeline: expected array, got $plan_type"
+		# Log raw content for debugging (t1182: helps diagnose parse failures)
+		local plan_len plan_head
+		plan_len=$(printf '%s' "$action_plan" | wc -c | tr -d ' ')
+		plan_head=$(printf '%s' "$action_plan" | head -c 200 | tr '\n' ' ')
+		log_warn "AI Actions Pipeline: expected array, got $plan_type (len=${plan_len} head='${plan_head}')"
 		echo '{"error":"invalid_plan_type","actions":[]}'
 		return 1
 	fi


### PR DESCRIPTION
Fix the 8 consecutive 'expected array, got ' errors in the AI supervisor actions pipeline between 15:53-19:15 on 2026-02-18.

## Root Cause

`opencode --format default` includes ANSI escape codes in its output. These codes corrupt JSON parsing in `extract_action_plan`, causing the pipeline to fail with 'expected array, got ' when the AI model returns a valid JSON array wrapped in ANSI terminal formatting.

## Changes

- **ai-reason.sh**: Strip ANSI escape codes from opencode output immediately after capture (root cause fix)
- **ai-reason.sh**: Handle empty/whitespace-only responses gracefully — treat as empty action plan `[]` instead of hard error
- **ai-reason.sh**: Add Try 6 in `extract_action_plan` to strip ANSI codes and retry parsing (belt-and-suspenders for direct calls)
- **ai-reason.sh**: Improve debug logging on parse failure — add hex dump of first 32 bytes and raw response snippet
- **ai-actions.sh**: Log raw `action_plan` content (length + first 200 chars) when type check fails
- **tests**: Add tests 5.5-5.7 covering: analysis text before json block, ANSI-coded responses, empty responses

## Verification

- ShellCheck: zero violations on both modified .sh files
- Tests 5.1-5.7 all pass (5.5-5.7 are new regression tests for t1182)
- Pre-existing test failure (Test 4: adjust_priority field validation) is unrelated to this PR

Ref #1787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error logging with enhanced diagnostics for invalid AI response formats
  * Enhanced handling of empty or whitespace-only responses
  * Added ANSI escape code stripping to prevent JSON parsing corruption
  * Increased robustness of action plan extraction with additional fallback mechanisms

* **Tests**
  * Added end-to-end tests for action plan parsing edge cases including nested code blocks, ANSI codes, and empty responses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->