### PR TITLE
t1188.1: Expand blocker statuses for auto-dispatch eligibility

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -115,6 +115,8 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **Auto-dispatch**: Add `#auto-dispatch` to tasks that can run autonomously (clear spec, bounded scope, no user input needed). Default to including it — only omit when a specific exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria. The supervisor's Phase 0 picks these up automatically every 2 minutes and auto-creates batches (`auto-YYYYMMDD-HHMMSS`, concurrency = cores/2, min 2) when no active batch exists.
 
+**Blocker statuses**: Add these tags to tasks that need human action before they can proceed. The supervisor's eligibility assessment detects them and skips dispatch: `account-needed`, `hosting-needed`, `login-needed`, `api-key-needed`, `clarification-needed`, `resources-needed`, `payment-needed`, `approval-needed`, `decision-needed`, `design-needed`, `content-needed`, `dns-needed`, `domain-needed`, `testing-needed`.
+
 **Working on #auto-dispatch tasks interactively** (t1062): When you start working on a task tagged with `#auto-dispatch`, immediately add `assignee:` to the TODO entry before pushing. This prevents the supervisor from racing and dispatching a worker for the same task. The supervisor's auto-pickup skips tasks with `assignee:` or `started:` fields.
 
 **Task completion rules** (CRITICAL - prevents false completion cascade):

--- a/.agents/scripts/supervisor/ai-context.sh
+++ b/.agents/scripts/supervisor/ai-context.sh
@@ -505,7 +505,9 @@ build_todo_context() {
 #
 # Blocker statuses (user-defined, non-dispatchable reasons):
 #   account-needed, hosting-needed, login-needed, api-key-needed,
-#   clarification-needed, resources-needed, payment-needed
+#   clarification-needed, resources-needed, payment-needed,
+#   approval-needed, decision-needed, design-needed, content-needed,
+#   dns-needed, domain-needed, testing-needed
 #######################################
 build_autodispatch_eligibility_context() {
 	local output="## Auto-Dispatch Eligibility Assessment\n\n"
@@ -514,12 +516,12 @@ build_autodispatch_eligibility_context() {
 
 	# Known blocker statuses that indicate a task cannot be auto-dispatched
 	# These are human-action-required blockers, not technical dependencies
-	local blocker_pattern="account-needed\|hosting-needed\|login-needed\|api-key-needed\|clarification-needed\|resources-needed\|payment-needed"
+	local blocker_pattern="account-needed\|hosting-needed\|login-needed\|api-key-needed\|clarification-needed\|resources-needed\|payment-needed\|approval-needed\|decision-needed\|design-needed\|content-needed\|dns-needed\|domain-needed\|testing-needed"
 
 	output+="### Eligibility Criteria\n\n"
 	output+="- **Eligible**: Clear spec, bounded scope (~30m-~4h), no unresolved blockers, no assignee\n"
 	output+="- **Ineligible**: Vague description, >~4h estimate, has assignee, has unresolved blocked-by, or has a blocker status\n"
-	output+="- **Blocker statuses** (human action required): account-needed, hosting-needed, login-needed, api-key-needed, clarification-needed, resources-needed, payment-needed\n\n"
+	output+="- **Blocker statuses** (human action required): account-needed, hosting-needed, login-needed, api-key-needed, clarification-needed, resources-needed, payment-needed, approval-needed, decision-needed, design-needed, content-needed, dns-needed, domain-needed, testing-needed\n\n"
 
 	local all_repos
 	all_repos=$(db "$SUPERVISOR_DB" "SELECT DISTINCT repo FROM tasks WHERE repo IS NOT NULL AND repo != '';" 2>/dev/null || echo "")
@@ -574,7 +576,7 @@ build_autodispatch_eligibility_context() {
 			# Check for blocker statuses
 			if echo "$line" | grep -qE "$blocker_pattern"; then
 				local blocker
-				blocker=$(echo "$line" | grep -oE "(account|hosting|login|api-key|clarification|resources|payment)-needed" | head -1)
+				blocker=$(echo "$line" | grep -oE "(account|hosting|login|api-key|clarification|resources|payment|approval|decision|design|content|dns|domain|testing)-needed" | head -1)
 				status="blocked"
 				reason="$blocker"
 			# Check for blocked-by dependency


### PR DESCRIPTION
## Summary

- Adds 7 new human-action-required blocker statuses to the supervisor's auto-dispatch eligibility assessment: `approval-needed`, `decision-needed`, `design-needed`, `content-needed`, `dns-needed`, `domain-needed`, `testing-needed`
- Total blocker statuses now: 14 (up from 7)
- Documents the full blocker status list in AGENTS.md user guide

## Why

The original 7 statuses covered infrastructure/access blockers but missed common project workflow blockers (waiting on stakeholder approval, design assets, content, DNS/domain setup, manual testing). Users can now tag tasks with these statuses and the supervisor will recognise them at a glance in the eligibility assessment, skipping dispatch attempts on tasks that need human action.

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/supervisor/ai-context.sh` | Added 7 new statuses to blocker_pattern, comment, output text, and grep extraction |
| `.agents/AGENTS.md` | Added blocker statuses documentation to Planning & Tasks section |