### PR TITLE
t1199: Tune worker hung timeout based on task ~estimate field

### DIFF
--- a/.agents/scripts/supervisor/dispatch.sh
+++ b/.agents/scripts/supervisor/dispatch.sh
@@ -2251,6 +2251,11 @@ cmd_dispatch() {
 	# Pre-create log file with dispatch metadata (t183)
 	# If the worker fails to start (opencode not found, permission error, etc.),
 	# the log file still exists with context for diagnosis instead of no_log_file.
+	# Compute per-task hung timeout for logging (t1199)
+	local dispatch_hung_timeout
+	dispatch_hung_timeout=$(get_task_hung_timeout "$task_id" 2>/dev/null || echo "1800")
+	log_info "Hung timeout for $task_id: ${dispatch_hung_timeout}s (2x estimate, 4h cap, 30m default)"
+
 	{
 		echo "=== DISPATCH METADATA (t183) ==="
 		echo "task_id=$task_id"
@@ -2262,6 +2267,7 @@ cmd_dispatch() {
 		echo "dispatch_mode=$(detect_dispatch_mode 2>/dev/null || echo unknown)"
 		echo "dispatch_type=${verify_mode:+verify}"
 		echo "verify_reason=${verify_reason:-}"
+		echo "hung_timeout_seconds=${dispatch_hung_timeout}"
 		echo "=== END DISPATCH METADATA ==="
 		echo ""
 	} >"$log_file" 2>/dev/null || true


### PR DESCRIPTION
Fixes worker hung timeout being a fixed 30m default regardless of task complexity.

## Changes

- **`_common.sh`**: New `get_task_hung_timeout()` function — parses `~estimate` from TODO.md, returns 2x estimate (4h cap, 30m minimum/default). Supports `~Nh`, `~N.Nh`, `~Nm` formats.
- **`pulse.sh` Phase 4**: Per-task hung timeout replaces global `SUPERVISOR_WORKER_TIMEOUT` for the 'no log output' check. Global timeout still applies as the absolute max runtime (Check 1).
- **`dispatch.sh`**: Logs computed hung timeout at dispatch time (`hung_timeout_seconds=` in dispatch metadata + supervisor log).

## Behaviour

| Estimate | Hung timeout |
|----------|-------------|
| `~30m` | 1h (1800s → 3600s) |
| `~1h` | 2h (7200s) |
| `~2h` | 4h (14400s, at cap) |
| `~3h` | 4h (capped) |
| none | 30m (1800s default) |

## Root cause

t311.2, t311.3, and t303 all failed with `Worker hung (no output for ~1800s, timeout 1800s)`. The 30m default was too short for legitimately long tasks. This PR makes the timeout proportional to the task's declared estimate.

Ref #1818