### PR TITLE
t1188.2: Auto-subtasking detection and cross-repo dispatch fairness

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -117,6 +117,10 @@ Use `/save-todo` after planning. Auto-detects complexity:
 
 **Blocker statuses**: Add these tags to tasks that need human action before they can proceed. The supervisor's eligibility assessment detects them and skips dispatch: `account-needed`, `hosting-needed`, `login-needed`, `api-key-needed`, `clarification-needed`, `resources-needed`, `payment-needed`, `approval-needed`, `decision-needed`, `design-needed`, `content-needed`, `dns-needed`, `domain-needed`, `testing-needed`.
 
+**Auto-subtasking** (t1188.2): Tasks with estimates >4h that have no existing subtasks are flagged as `needs-subtasking` in the eligibility assessment. The AI reasoner uses `create_subtasks` to break them into dispatchable units (~30m-4h each) before attempting dispatch. Tasks that already have subtasks are flagged as `has-subtasks` — the supervisor dispatches the subtasks instead.
+
+**Cross-repo concurrency fairness** (t1188.2): When multiple repos have queued tasks, each repo gets at least 1 dispatch slot, then remaining slots are distributed proportionally by queued task count. This prevents one repo's large backlog from starving other repos.
+
 **Working on #auto-dispatch tasks interactively** (t1062): When you start working on a task tagged with `#auto-dispatch`, immediately add `assignee:` to the TODO entry before pushing. This prevents the supervisor from racing and dispatching a worker for the same task. The supervisor's auto-pickup skips tasks with `assignee:` or `started:` fields.
 
 **Task completion rules** (CRITICAL - prevents false completion cascade):


### PR DESCRIPTION
## Summary

- **Auto-subtasking**: Tasks >4h without existing subtasks are flagged `needs-subtasking` in the eligibility assessment, prompting the AI to use `create_subtasks` before dispatch. Tasks with subtasks show `has-subtasks` so the supervisor dispatches subtasks instead.
- **Cross-repo fairness**: `cmd_next()` now interleaves tasks from different repos proportionally — each repo gets min 1 slot, remaining slots distributed by queued task count ratio. Prevents one repo's backlog from starving others.

## Why

The supervisor was dispatching all slots to whichever repo had tasks queued first (aidevops), leaving a private project tasks permanently starved. Large tasks (>4h) were flagged as ineligible but had no mechanism to be broken down automatically.

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/supervisor/ai-context.sh` | `needs-subtasking` vs `has-subtasks` detection in eligibility assessment |
| `.agents/scripts/supervisor/state.sh` | Repo-fair interleaving in `cmd_next()` with min-1-per-repo + proportional allocation |
| `.agents/AGENTS.md` | Document both features in Planning & Tasks section |

## Algorithm (cross-repo fairness)

Given concurrency=5, aidevops has 20 queued tasks, a private project has 5:
1. Guaranteed: 1 aidevops + 1 a private project = 2 slots used
2. Remaining 3 slots: aidevops gets 80% (2.4→2), a private project gets 20% (0.6→1)
3. Result: aidevops=3, a private project=2 (instead of aidevops=5, a private project=0)