### PR TITLE
t1201: Fix AI supervisor pipeline 'expected array' parsing errors

### DIFF
--- a/.agents/scripts/supervisor/ai-actions.sh
+++ b/.agents/scripts/supervisor/ai-actions.sh
@@ -712,8 +712,21 @@ validate_action_fields() {
 			echo "missing required field: task_id"
 			return 0
 		fi
-		# new_priority is no longer strictly required — the executor infers it
-		# from reasoning text if missing (see _exec_adjust_priority)
+		# new_priority is required — the AI prompt documents this explicitly (t1126, t1201).
+		# The executor can infer from reasoning text as a fallback, but the field must be
+		# present to ensure the AI is producing structured output as intended.
+		if [[ -z "$new_priority" || "$new_priority" == "null" ]]; then
+			echo "missing required field: new_priority (must be high|medium|low|critical)"
+			return 0
+		fi
+		# Validate new_priority value — must be one of the known values (t1197, t1201)
+		case "$new_priority" in
+		high | medium | low | critical) ;;
+		*)
+			echo "invalid new_priority: $new_priority (must be high|medium|low|critical)"
+			return 0
+			;;
+		esac
 		;;
 	close_verified)
 		local issue_number pr_number


### PR DESCRIPTION
Fix AI supervisor pipeline 'expected array' parsing errors.

## Changes

- **ai-actions.sh**: Make `new_priority` required in `adjust_priority` validation (t1126, t1201). Previously optional with executor inference — tests from t1126 expected it required. Fixes regression from t1187. Invalid values (e.g. 'urgent') are also rejected.

- **ai-reason.sh**: Replace full-prompt retry with simplified JSON-only prompt (t1201). When first AI call returns empty/unparseable output, retry with stripped-down prompt explicitly reinforcing 'respond with ONLY a JSON array, no markdown fencing'.

- **ai-reason.sh**: Fix single-line array extraction in Try 4 (t1201). Bracket-based fallback parser failed to extract single-line JSON arrays like `[{...}]` embedded in preamble text. Added Try 4a using grep before multi-line awk fallback.

- **tests/test-ai-actions.sh**: Add tests 18 and 19. All 19 tests pass, ShellCheck zero violations.

## Root Cause

The 8 consecutive 'expected array, got ' errors (15:53-19:15) were caused by the AI model returning empty responses. The existing retry logic repeated the same 15KB+ prompt that caused the failure. The simplified retry prompt is more likely to recover from model confusion.

## Verification

- All 19 unit tests pass
- All 36 e2e tests pass (3 skipped — require --live flag)
- ShellCheck zero violations on all modified files

Ref #1821