### PR TITLE
t1206: Add dispatch deduplication guard for repeated task failures

### DIFF
--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -1082,6 +1082,10 @@ ${stale_other_tasks}"
 				cmd_transition "$tid" "retrying" --error "$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 				# Clean up worker process tree before re-prompt (t128.7)
 				cleanup_worker_processes "$tid"
+				# Update dispatch dedup guard state (t1206): track failure timestamp and
+				# consecutive count so check_dispatch_dedup_guard() can enforce cooldown
+				# and block tasks that fail identically 2+ times in succession.
+				update_failure_dedup_state "$tid" "$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 				# Store failure pattern in memory (t128.6)
 				store_failure_pattern "$tid" "retry" "$outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
 				# Track prompt-repeat failure for pattern data (t1097)

--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -1043,6 +1043,10 @@ ${stale_other_tasks}"
 				completed_count=$((completed_count + 1))
 				# Clean up worker process tree and PID file (t128.7)
 				cleanup_worker_processes "$tid"
+				# Reset dispatch dedup guard state on success (t1206): clear last_failure_at
+				# and consecutive_failure_count so a re-queued task is not deferred by a
+				# stale cooldown from a pre-success failure.
+				reset_failure_dedup_state "$tid" 2>>"$SUPERVISOR_LOG" || true
 				# --- Non-critical post-processing below (safe to lose on kill) ---
 				# Proof-log: task completion (t218)
 				write_proof_log --task "$tid" --event "complete" --stage "evaluate" \
@@ -1079,13 +1083,15 @@ ${stale_other_tasks}"
 				write_proof_log --task "$tid" --event "retry" --stage "evaluate" \
 					--decision "retry:$outcome_detail" \
 					--maker "pulse:phase1" 2>/dev/null || true
-				cmd_transition "$tid" "retrying" --error "$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
-				# Clean up worker process tree before re-prompt (t128.7)
-				cleanup_worker_processes "$tid"
 				# Update dispatch dedup guard state (t1206): track failure timestamp and
 				# consecutive count so check_dispatch_dedup_guard() can enforce cooldown
 				# and block tasks that fail identically 2+ times in succession.
+				# NOTE: must run BEFORE cmd_transition so the DB error column still holds
+				# the *previous* failure's error for accurate streak comparison.
 				update_failure_dedup_state "$tid" "$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
+				cmd_transition "$tid" "retrying" --error "$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
+				# Clean up worker process tree before re-prompt (t128.7)
+				cleanup_worker_processes "$tid"
 				# Store failure pattern in memory (t128.6)
 				store_failure_pattern "$tid" "retry" "$outcome_detail" "$tid_desc" 2>>"$SUPERVISOR_LOG" || true
 				# Track prompt-repeat failure for pattern data (t1097)


### PR DESCRIPTION
Adds a dispatch deduplication guard to prevent the supervisor from re-dispatching tasks that fail with the same error in a short window.

## Problem
Worker outcomes showed repeated identical failures wasting tokens:
- t1032.1 dispatched and failed twice within 2 minutes (14:50 and 14:52) with the same error
- t1030 failed twice within 22 minutes (14:24 and 14:46) with identical errors

## Solution

Three-layer guard implemented in the supervisor dispatch pipeline:

1. **10-minute cooldown** — after any failure, the task cannot be re-dispatched for 10 minutes (configurable via `SUPERVISOR_FAILURE_COOLDOWN_SECS`)
2. **Consecutive failure blocking** — after 2 consecutive identical failures, the task is moved to `blocked` status with a diagnostic note requiring manual intervention (configurable via `SUPERVISOR_MAX_CONSECUTIVE_FAILURES`)
3. **Warning logging** — a warning is emitted whenever the same task fails with the same error code twice in succession

## Changes

- `database.sh`: Add `last_failure_at` (TEXT) and `consecutive_failure_count` (INTEGER) columns to `tasks` table — both in `init_db()` schema and as a migration for existing DBs
- `dispatch.sh`: Add `check_dispatch_dedup_guard()` called in `cmd_dispatch()` after max_retries check; returns 1 (block task) or 2 (defer to next pulse)
- `dispatch.sh`: Add `update_failure_dedup_state()` to track failure timestamps and consecutive counts with error-key normalisation (strips detail suffix for comparison)
- `pulse.sh`: Call `update_failure_dedup_state()` in retry handler so dedup state is updated whenever a task is marked for retry

## Verification

- ShellCheck: zero violations on all 3 modified files
- Bash syntax: clean on all 3 files
- Supervisor globals test: 10/10 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dispatch deduplication guard prevents repeated re-dispatch of tasks with identical failures; enforces a configurable cooldown (default 10 minutes) and blocks after a configurable consecutive-failure threshold.
  * Failure details are tracked to decide defer/block actions; retries update this state and successful runs reset it.
  * Failure reasons are recorded to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->