### PR TITLE
t1214: fix subtask visibility in eligibility assessment and add post-exec verification

### DIFF
--- a/.agents/scripts/supervisor/ai-actions.sh
+++ b/.agents/scripts/supervisor/ai-actions.sh
@@ -1060,7 +1060,15 @@ _exec_create_subtasks() {
 	# Remove trailing comma from created_ids
 	created_ids="${created_ids%,}"
 
-	echo "{\"created\":true,\"parent_task_id\":\"$parent_task_id\",\"subtask_ids\":\"$created_ids\",\"count\":$subtask_count}"
+	# Post-execution verification: confirm subtasks are visible in TODO.md (t1214)
+	local verified_count
+	verified_count=$(grep -c "^[[:space:]]*- \[.\] ${parent_task_id}\." "$todo_file" 2>/dev/null || echo 0)
+	if [[ "$verified_count" -lt "$subtask_count" ]]; then
+		echo "{\"created\":true,\"parent_task_id\":\"$parent_task_id\",\"subtask_ids\":\"$created_ids\",\"count\":$subtask_count,\"verified_count\":$verified_count,\"warning\":\"subtask_count_mismatch\"}"
+		return 0
+	fi
+
+	echo "{\"created\":true,\"parent_task_id\":\"$parent_task_id\",\"subtask_ids\":\"$created_ids\",\"count\":$subtask_count,\"verified_count\":$verified_count}"
 	return 0
 }
 

--- a/.agents/scripts/supervisor/ai-context.sh
+++ b/.agents/scripts/supervisor/ai-context.sh
@@ -1372,8 +1372,16 @@ build_auto_dispatch_eligibility_context() {
 						eligible="no"
 						reason="estimate too small (<30m)"
 					elif [[ "$est_minutes" -gt 240 ]]; then
-						eligible="no"
-						reason="estimate too large (>4h)"
+						# Check if subtasks already exist for this task (t1214)
+						local has_subtasks_count
+						has_subtasks_count=$(grep -c "^[[:space:]]*- \[.\] ${tid}\." "$scan_todo" 2>/dev/null || echo 0)
+						if [[ "$has_subtasks_count" -gt 0 ]]; then
+							eligible="no"
+							reason="has-subtasks: ${has_subtasks_count} subtask(s) exist — dispatch subtasks instead"
+						else
+							eligible="no"
+							reason="estimate too large (>4h) — use create_subtasks to break down"
+						fi
 					fi
 				fi
 			fi


### PR DESCRIPTION
Fix subtask visibility in eligibility assessment — t1200 subtasks (created by t1212) not appearing because `build_auto_dispatch_eligibility_context()` lacked the subtask existence check that `build_autodispatch_eligibility_context()` has.

**Root cause**: Two eligibility assessment functions exist. The newer `build_auto_dispatch_eligibility_context()` (Section 11, full scope) marks >4h tasks as ineligible without checking for existing subtasks. The older `build_autodispatch_eligibility_context()` (Section 3b) has the subtask check but uses a different code path.

**Changes**:
- `ai-context.sh`: Added subtask existence check in `build_auto_dispatch_eligibility_context()` — tasks with existing subtasks now show `has-subtasks: N subtask(s) exist` instead of `estimate too large`
- `ai-actions.sh`: Added post-execution verification in `_exec_create_subtasks()` — counts subtasks after insertion and emits `verified_count` + `warning` fields if mismatch detected

Ref #1845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Subtask creation process now includes post-execution verification, reporting confirmed subtask counts and alerting when expected subtasks don't match actual counts for better visibility into creation results.
  * Task dispatch eligibility logic now checks for existing subtasks before creating new ones, providing contextual guidance on whether to dispatch existing subtasks or break down the task further.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->