### PR TITLE
t1200.1: Core orchestrator + free-tier providers for ip-reputation-helper.sh

### DIFF
--- a/.agents/scripts/ip-reputation-helper.sh
+++ b/.agents/scripts/ip-reputation-helper.sh
@@ -1,0 +1,955 @@
+#!/usr/bin/env bash
+# ip-reputation-helper.sh — IP reputation checker using multiple providers
+# Queries multiple IP reputation databases in parallel and merges results
+# into a unified risk report. Use case: vet VPS/server/proxy IPs before
+# purchase or deployment to check if they are burned (blacklisted, flagged).
+#
+# Usage:
+#   ip-reputation-helper.sh check <ip> [options]
+#   ip-reputation-helper.sh batch <file> [options]
+#   ip-reputation-helper.sh report <ip> [options]
+#   ip-reputation-helper.sh providers
+#   ip-reputation-helper.sh help
+#
+# Options:
+#   --provider <p>    Use only specified provider
+#   --timeout <s>     Per-provider timeout in seconds (default: 15)
+#   --format <fmt>    Output format: table (default), json, markdown
+#   --parallel        Run providers in parallel (default)
+#   --sequential      Run providers sequentially
+#   --no-color        Disable color output
+#
+# Providers (free/no-key):
+#   spamhaus      Spamhaus DNSBL (SBL/XBL/PBL via dig)
+#   proxycheck    ProxyCheck.io (proxy/VPN/Tor detection)
+#   stopforumspam StopForumSpam (forum spammer database)
+#   blocklistde   Blocklist.de (attack/botnet IPs)
+#
+# Providers (free tier with API key):
+#   abuseipdb     AbuseIPDB (community abuse reports, 1000/day free)
+#
+# Risk levels: clean → low → medium → high → critical
+#
+# Environment variables:
+#   ABUSEIPDB_API_KEY     AbuseIPDB API key (free at abuseipdb.com)
+#   PROXYCHECK_API_KEY    ProxyCheck.io API key (optional, increases limit)
+#   IP_REP_TIMEOUT        Default per-provider timeout (default: 15)
+#   IP_REP_FORMAT         Default output format (default: table)
+#
+# Examples:
+#   ip-reputation-helper.sh check 1.2.3.4
+#   ip-reputation-helper.sh check 1.2.3.4 --format json
+#   ip-reputation-helper.sh check 1.2.3.4 --provider spamhaus
+#   ip-reputation-helper.sh batch ips.txt
+#   ip-reputation-helper.sh report 1.2.3.4
+#   ip-reputation-helper.sh providers
+
+set -euo pipefail
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+readonly VERSION="1.0.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+readonly SCRIPT_DIR
+readonly PROVIDERS_DIR="${SCRIPT_DIR}/providers"
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || true
+
+# shellcheck source=/dev/null
+[[ -f "${HOME}/.config/aidevops/credentials.sh" ]] && source "${HOME}/.config/aidevops/credentials.sh"
+
+# All available providers (order matters for display)
+readonly ALL_PROVIDERS="spamhaus proxycheck stopforumspam blocklistde abuseipdb"
+
+# Portable timeout command (macOS uses gtimeout from coreutils, Linux has timeout)
+TIMEOUT_CMD=""
+if command -v timeout &>/dev/null; then
+	TIMEOUT_CMD="timeout"
+elif command -v gtimeout &>/dev/null; then
+	TIMEOUT_CMD="gtimeout"
+fi
+readonly TIMEOUT_CMD
+
+# Default settings (prefixed to avoid conflict with shared-constants.sh DEFAULT_TIMEOUT)
+readonly IP_REP_DEFAULT_TIMEOUT="${IP_REP_TIMEOUT:-15}"
+readonly IP_REP_DEFAULT_FORMAT="${IP_REP_FORMAT:-table}"
+
+# =============================================================================
+# Colors (RED, GREEN, YELLOW, CYAN, NC sourced from shared-constants.sh)
+# =============================================================================
+
+# BOLD is not in shared-constants.sh — define it here
+readonly BOLD='\033[1m'
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+log_info() {
+	echo -e "${CYAN}[INFO]${NC} $*" >&2
+	return 0
+}
+
+log_warn() {
+	echo -e "${YELLOW}[WARN]${NC} $*" >&2
+	return 0
+}
+
+log_error() {
+	echo -e "${RED}[ERROR]${NC} $*" >&2
+	return 0
+}
+
+log_success() {
+	echo -e "${GREEN}[OK]${NC} $*" >&2
+	return 0
+}
+
+# =============================================================================
+# Provider Management
+# =============================================================================
+
+# Map provider name to script filename
+provider_script() {
+	local provider="$1"
+	case "$provider" in
+	abuseipdb) echo "ip-rep-abuseipdb.sh" ;;
+	proxycheck) echo "ip-rep-proxycheck.sh" ;;
+	spamhaus) echo "ip-rep-spamhaus.sh" ;;
+	stopforumspam) echo "ip-rep-stopforumspam.sh" ;;
+	blocklistde) echo "ip-rep-blocklistde.sh" ;;
+	*) echo "" ;;
+	esac
+	return 0
+}
+
+# Map provider name to display name
+provider_display_name() {
+	local provider="$1"
+	case "$provider" in
+	abuseipdb) echo "AbuseIPDB" ;;
+	proxycheck) echo "ProxyCheck.io" ;;
+	spamhaus) echo "Spamhaus DNSBL" ;;
+	stopforumspam) echo "StopForumSpam" ;;
+	blocklistde) echo "Blocklist.de" ;;
+	*) echo "$provider" ;;
+	esac
+	return 0
+}
+
+# Check if a provider script exists and is executable
+is_provider_available() {
+	local provider="$1"
+	local script
+	script=$(provider_script "$provider")
+	[[ -n "$script" ]] && [[ -x "${PROVIDERS_DIR}/${script}" ]]
+	return $?
+}
+
+# Get list of available providers (space-separated)
+get_available_providers() {
+	local available=()
+	local provider
+	for provider in $ALL_PROVIDERS; do
+		if is_provider_available "$provider"; then
+			available+=("$provider")
+		fi
+	done
+
+	if [[ ${#available[@]} -eq 0 ]]; then
+		log_error "No provider scripts found in ${PROVIDERS_DIR}/"
+		return 1
+	fi
+
+	echo "${available[*]}"
+	return 0
+}
+
+# =============================================================================
+# Provider Execution
+# =============================================================================
+
+# Run a single provider and write JSON result to stdout
+run_provider() {
+	local provider="$1"
+	local ip="$2"
+	local timeout_secs="$3"
+
+	local script
+	script=$(provider_script "$provider")
+	local script_path="${PROVIDERS_DIR}/${script}"
+
+	if [[ ! -x "$script_path" ]]; then
+		jq -n \
+			--arg provider "$provider" \
+			--arg ip "$ip" \
+			'{provider: $provider, ip: $ip, error: "provider_not_available", is_listed: false, score: 0, risk_level: "unknown"}'
+		return 0
+	fi
+
+	local result
+	local run_cmd=("$script_path" check "$ip")
+	if [[ -n "$TIMEOUT_CMD" ]]; then
+		run_cmd=("$TIMEOUT_CMD" "$timeout_secs" "${run_cmd[@]}")
+	fi
+
+	if result=$("${run_cmd[@]}" 2>/dev/null); then
+		if echo "$result" | jq empty 2>/dev/null; then
+			echo "$result"
+		else
+			jq -n \
+				--arg provider "$provider" \
+				--arg ip "$ip" \
+				'{provider: $provider, ip: $ip, error: "invalid_json_response", is_listed: false, score: 0, risk_level: "unknown"}'
+		fi
+	else
+		local exit_code=$?
+		local err_msg
+		if [[ $exit_code -eq 124 ]]; then
+			err_msg="timeout after ${timeout_secs}s"
+		else
+			err_msg="provider failed (exit ${exit_code})"
+		fi
+		jq -n \
+			--arg provider "$provider" \
+			--arg ip "$ip" \
+			--arg error "$err_msg" \
+			'{provider: $provider, ip: $ip, error: $error, is_listed: false, score: 0, risk_level: "unknown"}'
+	fi
+	return 0
+}
+
+# =============================================================================
+# Risk Scoring
+# =============================================================================
+
+# Merge per-provider results into unified risk assessment
+# Strategy: weighted average of scores, with listing flags as hard signals
+merge_results() {
+	local ip="$1"
+	shift
+	local result_files=("$@")
+
+	local provider_results="[]"
+	local total_score=0
+	local provider_count=0
+	local listed_count=0
+	local is_tor=false
+	local is_proxy=false
+	local is_vpn=false
+	local errors=0
+	local file
+
+	for file in "${result_files[@]}"; do
+		[[ -f "$file" ]] || continue
+		local content
+		content=$(cat "$file")
+		[[ -z "$content" ]] && continue
+
+		# Skip if not valid JSON
+		echo "$content" | jq empty 2>/dev/null || continue
+
+		provider_results=$(echo "$provider_results" | jq --argjson r "$content" '. + [$r]')
+
+		# Check for errors
+		if echo "$content" | jq -e '.error' &>/dev/null; then
+			errors=$((errors + 1))
+			continue
+		fi
+
+		provider_count=$((provider_count + 1))
+
+		local score is_listed
+		score=$(echo "$content" | jq -r '.score // 0')
+		is_listed=$(echo "$content" | jq -r '.is_listed // false')
+
+		total_score=$((total_score + ${score%.*}))
+
+		if [[ "$is_listed" == "true" ]]; then
+			listed_count=$((listed_count + 1))
+		fi
+
+		# Aggregate flags
+		if [[ "$(echo "$content" | jq -r '.is_tor // false')" == "true" ]]; then
+			is_tor=true
+		fi
+		if [[ "$(echo "$content" | jq -r '.is_proxy // false')" == "true" ]]; then
+			is_proxy=true
+		fi
+		if [[ "$(echo "$content" | jq -r '.is_vpn // false')" == "true" ]]; then
+			is_vpn=true
+		fi
+	done
+
+	# Calculate unified score
+	local unified_score=0
+	if [[ "$provider_count" -gt 0 ]]; then
+		unified_score=$((total_score / provider_count))
+	fi
+
+	# Boost score if multiple providers agree on listing
+	if [[ "$listed_count" -ge 3 ]]; then
+		unified_score=$((unified_score > 85 ? 100 : unified_score + 15))
+	elif [[ "$listed_count" -ge 2 ]]; then
+		unified_score=$((unified_score > 90 ? 100 : unified_score + 10))
+	fi
+
+	# Determine unified risk level
+	local risk_level
+	if [[ "$unified_score" -ge 75 ]]; then
+		risk_level="critical"
+	elif [[ "$unified_score" -ge 50 ]]; then
+		risk_level="high"
+	elif [[ "$unified_score" -ge 25 ]]; then
+		risk_level="medium"
+	elif [[ "$unified_score" -ge 5 ]]; then
+		risk_level="low"
+	else
+		risk_level="clean"
+	fi
+
+	# Recommendation
+	local recommendation
+	case "$risk_level" in
+	critical) recommendation="AVOID — IP is heavily flagged across multiple sources" ;;
+	high) recommendation="AVOID — IP has significant abuse/attack history" ;;
+	medium) recommendation="CAUTION — IP has some flags, investigate before use" ;;
+	low) recommendation="PROCEED WITH CAUTION — minor flags detected" ;;
+	clean) recommendation="SAFE — no significant flags detected" ;;
+	*) recommendation="UNKNOWN — insufficient data" ;;
+	esac
+
+	local scan_time
+	scan_time=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	jq -n \
+		--arg ip "$ip" \
+		--argjson unified_score "$unified_score" \
+		--arg risk_level "$risk_level" \
+		--arg recommendation "$recommendation" \
+		--argjson listed_count "$listed_count" \
+		--argjson provider_count "$provider_count" \
+		--argjson errors "$errors" \
+		--argjson is_tor "$is_tor" \
+		--argjson is_proxy "$is_proxy" \
+		--argjson is_vpn "$is_vpn" \
+		--argjson providers "$provider_results" \
+		--arg scan_time "$scan_time" \
+		'{
+            ip: $ip,
+            scan_time: $scan_time,
+            unified_score: $unified_score,
+            risk_level: $risk_level,
+            recommendation: $recommendation,
+            summary: {
+                providers_queried: ($provider_count + $errors),
+                providers_responded: $provider_count,
+                providers_errored: $errors,
+                listed_by: $listed_count,
+                is_tor: $is_tor,
+                is_proxy: $is_proxy,
+                is_vpn: $is_vpn
+            },
+            providers: $providers
+        }'
+	return 0
+}
+
+# =============================================================================
+# Output Formatting
+# =============================================================================
+
+# Risk level color
+risk_color() {
+	local level="$1"
+	case "$level" in
+	critical) echo "$RED" ;;
+	high) echo "$RED" ;;
+	medium) echo "$YELLOW" ;;
+	low) echo "$YELLOW" ;;
+	clean) echo "$GREEN" ;;
+	*) echo "$NC" ;;
+	esac
+	return 0
+}
+
+# Risk level symbol
+risk_symbol() {
+	local level="$1"
+	case "$level" in
+	critical) echo "CRITICAL" ;;
+	high) echo "HIGH" ;;
+	medium) echo "MEDIUM" ;;
+	low) echo "LOW" ;;
+	clean) echo "CLEAN" ;;
+	*) echo "UNKNOWN" ;;
+	esac
+	return 0
+}
+
+# Format results as terminal table
+format_table() {
+	local json="$1"
+
+	local ip risk_level unified_score recommendation scan_time
+	ip=$(echo "$json" | jq -r '.ip')
+	risk_level=$(echo "$json" | jq -r '.risk_level')
+	unified_score=$(echo "$json" | jq -r '.unified_score')
+	recommendation=$(echo "$json" | jq -r '.recommendation')
+	scan_time=$(echo "$json" | jq -r '.scan_time')
+
+	local color
+	color=$(risk_color "$risk_level")
+	local symbol
+	symbol=$(risk_symbol "$risk_level")
+
+	echo ""
+	echo -e "${BOLD}${CYAN}=== IP Reputation Report ===${NC}"
+	echo -e "IP:          ${BOLD}${ip}${NC}"
+	echo -e "Scanned:     ${scan_time}"
+	echo -e "Risk Level:  ${color}${BOLD}${symbol}${NC} (score: ${unified_score}/100)"
+	echo -e "Verdict:     ${color}${recommendation}${NC}"
+	echo ""
+
+	# Summary flags
+	local is_tor is_proxy is_vpn listed_by providers_queried providers_responded
+	is_tor=$(echo "$json" | jq -r '.summary.is_tor')
+	is_proxy=$(echo "$json" | jq -r '.summary.is_proxy')
+	is_vpn=$(echo "$json" | jq -r '.summary.is_vpn')
+	listed_by=$(echo "$json" | jq -r '.summary.listed_by')
+	providers_queried=$(echo "$json" | jq -r '.summary.providers_queried')
+	providers_responded=$(echo "$json" | jq -r '.summary.providers_responded')
+
+	echo -e "${BOLD}Summary:${NC}"
+	echo -e "  Providers:  ${providers_responded}/${providers_queried} responded"
+	echo -e "  Listed by:  ${listed_by} provider(s)"
+	local tor_flag proxy_flag vpn_flag
+	tor_flag=$([[ "$is_tor" == "true" ]] && echo "${RED}YES${NC}" || echo "${GREEN}NO${NC}")
+	proxy_flag=$([[ "$is_proxy" == "true" ]] && echo "${RED}YES${NC}" || echo "${GREEN}NO${NC}")
+	vpn_flag=$([[ "$is_vpn" == "true" ]] && echo "${YELLOW}YES${NC}" || echo "${GREEN}NO${NC}")
+	echo -e "  Tor:        $(echo -e "$tor_flag")"
+	echo -e "  Proxy:      $(echo -e "$proxy_flag")"
+	echo -e "  VPN:        $(echo -e "$vpn_flag")"
+	echo ""
+
+	# Per-provider results
+	echo -e "${BOLD}Provider Results:${NC}"
+	printf "  %-18s %-10s %-8s %s\n" "Provider" "Risk" "Score" "Details"
+	printf "  %-18s %-10s %-8s %s\n" "--------" "----" "-----" "-------"
+
+	echo "$json" | jq -r '.providers[] | [.provider, (.risk_level // "error"), (.score // 0 | tostring), (.error // (.is_listed | if . then "listed" else "clean" end))] | @tsv' 2>/dev/null |
+		while IFS=$'\t' read -r prov risk score detail; do
+			local prov_color
+			prov_color=$(risk_color "$risk")
+			local display_name
+			display_name=$(provider_display_name "$prov")
+			printf "  %-18s ${prov_color}%-10s${NC} %-8s %s\n" "$display_name" "$risk" "$score" "$detail"
+		done
+
+	echo ""
+	return 0
+}
+
+# Format results as markdown report
+format_markdown() {
+	local json="$1"
+
+	local ip risk_level unified_score recommendation scan_time
+	ip=$(echo "$json" | jq -r '.ip')
+	risk_level=$(echo "$json" | jq -r '.risk_level')
+	unified_score=$(echo "$json" | jq -r '.unified_score')
+	recommendation=$(echo "$json" | jq -r '.recommendation')
+	scan_time=$(echo "$json" | jq -r '.scan_time')
+
+	local listed_by providers_queried providers_responded is_tor is_proxy is_vpn
+	listed_by=$(echo "$json" | jq -r '.summary.listed_by')
+	providers_queried=$(echo "$json" | jq -r '.summary.providers_queried')
+	providers_responded=$(echo "$json" | jq -r '.summary.providers_responded')
+	is_tor=$(echo "$json" | jq -r '.summary.is_tor')
+	is_proxy=$(echo "$json" | jq -r '.summary.is_proxy')
+	is_vpn=$(echo "$json" | jq -r '.summary.is_vpn')
+
+	# Uppercase risk level (portable — no bash 4 ^^ operator)
+	local risk_upper
+	risk_upper=$(echo "$risk_level" | tr '[:lower:]' '[:upper:]')
+
+	cat <<EOF
+# IP Reputation Report: ${ip}
+
+- **Scanned**: ${scan_time}
+- **Risk Level**: ${risk_upper} (${unified_score}/100)
+- **Verdict**: ${recommendation}
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Providers queried | ${providers_queried} |
+| Providers responded | ${providers_responded} |
+| Listed by | ${listed_by} provider(s) |
+| Tor exit node | ${is_tor} |
+| Proxy detected | ${is_proxy} |
+| VPN detected | ${is_vpn} |
+
+## Provider Results
+
+| Provider | Risk Level | Score | Listed | Details |
+|----------|-----------|-------|--------|---------|
+EOF
+
+	echo "$json" | jq -r '.providers[] | "| \(.provider) | \(.risk_level // "error") | \(.score // 0) | \(.is_listed // false) | \(.error // "ok") |"' 2>/dev/null
+
+	echo ""
+	echo "---"
+	echo "*Generated by ip-reputation-helper.sh v${VERSION}*"
+	return 0
+}
+
+# Output results in requested format
+output_results() {
+	local json="$1"
+	local format="$2"
+
+	case "$format" in
+	json) echo "$json" ;;
+	markdown) format_markdown "$json" ;;
+	table | *) format_table "$json" ;;
+	esac
+	return 0
+}
+
+# =============================================================================
+# Core Commands
+# =============================================================================
+
+# Check a single IP address
+cmd_check() {
+	local ip=""
+	local specific_provider=""
+	local run_parallel=true
+	local timeout_secs="$IP_REP_DEFAULT_TIMEOUT"
+	local output_format="$IP_REP_DEFAULT_FORMAT"
+
+	# Parse arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--provider | -p)
+			specific_provider="$2"
+			shift 2
+			;;
+		--timeout | -t)
+			timeout_secs="$2"
+			shift 2
+			;;
+		--format | -f)
+			output_format="$2"
+			shift 2
+			;;
+		--parallel)
+			run_parallel=true
+			shift
+			;;
+		--sequential)
+			run_parallel=false
+			shift
+			;;
+		--no-color)
+			shift
+			;;
+		-*)
+			log_warn "Unknown option: $1"
+			shift
+			;;
+		*)
+			if [[ -z "$ip" ]]; then
+				ip="$1"
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$ip" ]]; then
+		log_error "IP address required"
+		echo "Usage: $(basename "$0") check <ip> [options]" >&2
+		return 1
+	fi
+
+	# Validate IPv4 format
+	if ! echo "$ip" | grep -qE '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'; then
+		log_error "Invalid IPv4 address: ${ip}"
+		return 1
+	fi
+
+	log_info "Checking IP reputation for: ${ip}"
+
+	# Determine providers to use
+	local -a providers_to_run=()
+	if [[ -n "$specific_provider" ]]; then
+		if is_provider_available "$specific_provider"; then
+			providers_to_run+=("$specific_provider")
+		else
+			log_error "Provider '${specific_provider}' not available"
+			cmd_providers
+			return 1
+		fi
+	else
+		local available
+		available=$(get_available_providers) || return 1
+		read -ra providers_to_run <<<"$available"
+	fi
+
+	log_info "Using providers: ${providers_to_run[*]}"
+
+	# Create temp directory for results
+	local tmp_dir
+	tmp_dir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '${tmp_dir}'" RETURN
+
+	local -a result_files=()
+	local -a pids=()
+
+	if [[ "$run_parallel" == "true" && ${#providers_to_run[@]} -gt 1 ]]; then
+		# Parallel execution via background jobs
+		local provider
+		for provider in "${providers_to_run[@]}"; do
+			local result_file="${tmp_dir}/${provider}.json"
+			result_files+=("$result_file")
+
+			(
+				local result
+				result=$(run_provider "$provider" "$ip" "$timeout_secs")
+				echo "$result" >"$result_file"
+			) &
+			pids+=($!)
+		done
+
+		# Wait for all background jobs
+		local pid
+		for pid in "${pids[@]}"; do
+			wait "$pid" 2>/dev/null || true
+		done
+	else
+		# Sequential execution
+		local provider
+		for provider in "${providers_to_run[@]}"; do
+			local result_file="${tmp_dir}/${provider}.json"
+			result_files+=("$result_file")
+			local result
+			result=$(run_provider "$provider" "$ip" "$timeout_secs")
+			echo "$result" >"$result_file"
+		done
+	fi
+
+	# Merge results
+	local merged
+	merged=$(merge_results "$ip" "${result_files[@]}") || {
+		log_error "Failed to merge provider results"
+		return 1
+	}
+
+	output_results "$merged" "$output_format"
+	return 0
+}
+
+# Batch check IPs from a file (one IP per line)
+cmd_batch() {
+	local file=""
+	local output_format="$IP_REP_DEFAULT_FORMAT"
+	local timeout_secs="$IP_REP_DEFAULT_TIMEOUT"
+	local specific_provider=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--format | -f)
+			output_format="$2"
+			shift 2
+			;;
+		--timeout | -t)
+			timeout_secs="$2"
+			shift 2
+			;;
+		--provider | -p)
+			specific_provider="$2"
+			shift 2
+			;;
+		-*)
+			log_warn "Unknown option: $1"
+			shift
+			;;
+		*)
+			if [[ -z "$file" ]]; then
+				file="$1"
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$file" ]]; then
+		log_error "File path required"
+		echo "Usage: $(basename "$0") batch <file> [options]" >&2
+		return 1
+	fi
+
+	if [[ ! -f "$file" ]]; then
+		log_error "File not found: ${file}"
+		return 1
+	fi
+
+	local total=0
+	local processed=0
+	local clean=0
+	local flagged=0
+
+	# Count IPs
+	total=$(grep -cE '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' "$file" || echo 0)
+	log_info "Processing ${total} IPs from ${file}"
+
+	local batch_results="[]"
+
+	while IFS= read -r line; do
+		# Skip empty lines and comments
+		[[ -z "$line" || "$line" =~ ^# ]] && continue
+
+		# Validate IP format
+		if ! echo "$line" | grep -qE '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'; then
+			log_warn "Skipping invalid IP: ${line}"
+			continue
+		fi
+
+		processed=$((processed + 1))
+		log_info "[${processed}/${total}] Checking ${line}..."
+
+		local check_args=("$line" "--format" "json" "--timeout" "$timeout_secs")
+		[[ -n "$specific_provider" ]] && check_args+=("--provider" "$specific_provider")
+
+		local result
+		result=$(cmd_check "${check_args[@]}" 2>/dev/null) || {
+			log_warn "Failed to check ${line}"
+			continue
+		}
+
+		local risk_level
+		risk_level=$(echo "$result" | jq -r '.risk_level // "unknown"')
+
+		if [[ "$risk_level" == "clean" ]]; then
+			clean=$((clean + 1))
+		else
+			flagged=$((flagged + 1))
+		fi
+
+		batch_results=$(echo "$batch_results" | jq --argjson r "$result" '. + [$r]')
+
+	done <"$file"
+
+	# Batch summary
+	echo ""
+	echo -e "${BOLD}${CYAN}=== Batch Results ===${NC}"
+	echo -e "File:     ${file}"
+	echo -e "Total:    ${processed} IPs processed"
+	echo -e "Clean:    ${GREEN}${clean}${NC}"
+	echo -e "Flagged:  ${RED}${flagged}${NC}"
+	echo ""
+
+	# Show flagged IPs
+	if [[ "$flagged" -gt 0 ]]; then
+		echo -e "${BOLD}Flagged IPs:${NC}"
+		echo "$batch_results" | jq -r '.[] | select(.risk_level != "clean") | "\(.ip)\t\(.risk_level)\t\(.unified_score)\t\(.recommendation)"' 2>/dev/null |
+			while IFS=$'\t' read -r ip risk score rec; do
+				local color risk_upper
+				color=$(risk_color "$risk")
+				risk_upper=$(echo "$risk" | tr '[:lower:]' '[:upper:]')
+				echo -e "  ${ip}  ${color}${risk_upper}${NC} (${score})  ${rec}"
+			done
+		echo ""
+	fi
+
+	if [[ "$output_format" == "json" ]]; then
+		jq -n \
+			--arg file "$file" \
+			--argjson total "$processed" \
+			--argjson clean "$clean" \
+			--argjson flagged "$flagged" \
+			--argjson results "$batch_results" \
+			'{file: $file, total: $total, clean: $clean, flagged: $flagged, results: $results}'
+	fi
+
+	return 0
+}
+
+# Generate detailed markdown report for an IP
+cmd_report() {
+	local ip=""
+	local timeout_secs="$IP_REP_DEFAULT_TIMEOUT"
+	local specific_provider=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--timeout | -t)
+			timeout_secs="$2"
+			shift 2
+			;;
+		--provider | -p)
+			specific_provider="$2"
+			shift 2
+			;;
+		-*)
+			log_warn "Unknown option: $1"
+			shift
+			;;
+		*)
+			if [[ -z "$ip" ]]; then
+				ip="$1"
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$ip" ]]; then
+		log_error "IP address required"
+		echo "Usage: $(basename "$0") report <ip> [options]" >&2
+		return 1
+	fi
+
+	local check_args=("$ip" "--format" "json" "--timeout" "$timeout_secs")
+	[[ -n "$specific_provider" ]] && check_args+=("--provider" "$specific_provider")
+
+	local result
+	result=$(cmd_check "${check_args[@]}") || return 1
+
+	format_markdown "$result"
+	return 0
+}
+
+# List all providers and their status
+cmd_providers() {
+	echo ""
+	echo -e "${BOLD}${CYAN}=== IP Reputation Providers ===${NC}"
+	echo ""
+	printf "  %-18s %-20s %-10s %-12s %s\n" "Provider" "Display Name" "Status" "Key Req." "Free Tier"
+	printf "  %-18s %-20s %-10s %-12s %s\n" "--------" "------------" "------" "--------" "---------"
+
+	local provider
+	for provider in $ALL_PROVIDERS; do
+		local script
+		script=$(provider_script "$provider")
+		local script_path="${PROVIDERS_DIR}/${script}"
+		local display_name
+		display_name=$(provider_display_name "$provider")
+
+		local status key_req free_tier
+		if [[ -x "$script_path" ]]; then
+			# Get info from provider
+			local info
+			info=$("$script_path" info 2>/dev/null || echo '{}')
+			key_req=$(echo "$info" | jq -r '.requires_key // false | if . then "yes" else "no" end')
+			free_tier=$(echo "$info" | jq -r '.free_tier // "unknown"')
+			status="${GREEN}available${NC}"
+		else
+			status="${RED}missing${NC}"
+			key_req="-"
+			free_tier="-"
+		fi
+
+		printf "  %-18s %-20s " "$provider" "$display_name"
+		echo -e "${status}  ${key_req}          ${free_tier}"
+	done
+
+	echo ""
+	echo -e "Provider scripts location: ${PROVIDERS_DIR}/"
+	echo -e "Each provider implements: check <ip> [--api-key <key>] [--timeout <s>]"
+	echo ""
+	return 0
+}
+
+# =============================================================================
+# Usage
+# =============================================================================
+
+print_usage() {
+	cat <<EOF
+Usage: $(basename "$0") <command> [options]
+
+Commands:
+  check <ip>        Check reputation of a single IP address
+  batch <file>      Check multiple IPs from file (one per line)
+  report <ip>       Generate detailed markdown report for an IP
+  providers         List available providers and their status
+  help              Show this help message
+
+Options:
+  --provider <p>    Use only specified provider
+  --timeout <s>     Per-provider timeout in seconds (default: ${IP_REP_DEFAULT_TIMEOUT})
+  --format <fmt>    Output format: table (default), json, markdown
+  --parallel        Run providers in parallel (default)
+  --sequential      Run providers sequentially
+  --no-color        Disable color output
+
+Providers:
+  spamhaus          Spamhaus DNSBL (no key required)
+  proxycheck        ProxyCheck.io (no key required, optional key for more)
+  stopforumspam     StopForumSpam (no key required)
+  blocklistde       Blocklist.de (no key required)
+  abuseipdb         AbuseIPDB (free API key required: abuseipdb.com)
+
+Environment:
+  ABUSEIPDB_API_KEY     AbuseIPDB API key
+  PROXYCHECK_API_KEY    ProxyCheck.io API key (optional)
+  IP_REP_TIMEOUT        Default timeout (default: 15)
+  IP_REP_FORMAT         Default format (default: table)
+
+Examples:
+  $(basename "$0") check 1.2.3.4
+  $(basename "$0") check 1.2.3.4 --format json
+  $(basename "$0") check 1.2.3.4 --provider spamhaus
+  $(basename "$0") batch ips.txt
+  $(basename "$0") batch ips.txt --format json
+  $(basename "$0") report 1.2.3.4
+  $(basename "$0") providers
+EOF
+	return 0
+}
+
+# =============================================================================
+# Main Dispatch
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	check)
+		cmd_check "$@"
+		;;
+	batch)
+		cmd_batch "$@"
+		;;
+	report)
+		cmd_report "$@"
+		;;
+	providers)
+		cmd_providers
+		;;
+	help | --help | -h)
+		print_usage
+		;;
+	version | --version | -v)
+		echo "ip-reputation-helper.sh v${VERSION}"
+		;;
+	*)
+		log_error "Unknown command: ${command}"
+		print_usage
+		exit 1
+		;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/providers/ip-rep-abuseipdb.sh
+++ b/.agents/scripts/providers/ip-rep-abuseipdb.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# ip-rep-abuseipdb.sh — AbuseIPDB provider for ip-reputation-helper.sh
+# Interface: check <ip> [--api-key <key>] → JSON result on stdout
+# Free tier: 1000 checks/day with API key (key optional for basic check)
+# API docs: https://docs.abuseipdb.com/
+#
+# Returned JSON fields:
+#   provider      string  "abuseipdb"
+#   ip            string  queried IP
+#   score         int     0-100 (abuse confidence %)
+#   risk_level    string  clean/low/medium/high/critical
+#   is_listed     bool    true if any abuse reports
+#   reports       int     number of abuse reports
+#   categories    array   abuse category IDs
+#   country       string  ISO country code
+#   isp           string  ISP name
+#   domain        string  associated domain
+#   is_tor        bool    Tor exit node flag
+#   is_proxy      bool    proxy/VPN flag
+#   error         string  error message if failed (absent on success)
+#   raw           object  full API response
+
+set -euo pipefail
+
+readonly PROVIDER_NAME="abuseipdb"
+readonly PROVIDER_DISPLAY="AbuseIPDB"
+readonly API_BASE="https://api.abuseipdb.com/api/v2"
+readonly DEFAULT_TIMEOUT=15
+
+# shellcheck source=/dev/null
+[[ -f "${HOME}/.config/aidevops/credentials.sh" ]] && source "${HOME}/.config/aidevops/credentials.sh"
+
+# Risk level mapping based on abuse confidence score
+score_to_risk() {
+	local score="$1"
+	if [[ "$score" -ge 75 ]]; then
+		echo "critical"
+	elif [[ "$score" -ge 50 ]]; then
+		echo "high"
+	elif [[ "$score" -ge 25 ]]; then
+		echo "medium"
+	elif [[ "$score" -ge 5 ]]; then
+		echo "low"
+	else
+		echo "clean"
+	fi
+	return 0
+}
+
+# Output error JSON
+error_json() {
+	local ip="$1"
+	local msg="$2"
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--arg error "$msg" \
+		'{provider: $provider, ip: $ip, error: $error, is_listed: false, score: 0, risk_level: "unknown"}'
+	return 0
+}
+
+# Main check function
+cmd_check() {
+	local ip="$1"
+	local api_key="${ABUSEIPDB_API_KEY:-}"
+	local timeout="$DEFAULT_TIMEOUT"
+
+	# Parse optional flags
+	shift
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--api-key)
+			api_key="$2"
+			shift 2
+			;;
+		--timeout)
+			timeout="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$api_key" ]]; then
+		error_json "$ip" "ABUSEIPDB_API_KEY not set — free tier requires API key (1000/day free at abuseipdb.com)"
+		return 0
+	fi
+
+	local response
+	response=$(curl -sf \
+		--max-time "$timeout" \
+		-H "Key: ${api_key}" \
+		-H "Accept: application/json" \
+		-G \
+		--data-urlencode "ipAddress=${ip}" \
+		--data-urlencode "maxAgeInDays=90" \
+		--data-urlencode "verbose" \
+		"${API_BASE}/check" 2>/dev/null) || {
+		error_json "$ip" "curl request failed"
+		return 0
+	}
+
+	# Validate JSON
+	if ! echo "$response" | jq empty 2>/dev/null; then
+		error_json "$ip" "invalid JSON response"
+		return 0
+	fi
+
+	# Check for API errors
+	local api_error
+	api_error=$(echo "$response" | jq -r '.errors[0].detail // empty' 2>/dev/null || true)
+	if [[ -n "$api_error" ]]; then
+		error_json "$ip" "$api_error"
+		return 0
+	fi
+
+	local data
+	data=$(echo "$response" | jq '.data // {}')
+
+	local score is_listed reports country isp domain is_tor is_proxy
+	score=$(echo "$data" | jq -r '.abuseConfidenceScore // 0')
+	is_listed=$(echo "$data" | jq -r 'if .totalReports > 0 then true else false end')
+	reports=$(echo "$data" | jq -r '.totalReports // 0')
+	country=$(echo "$data" | jq -r '.countryCode // "unknown"')
+	isp=$(echo "$data" | jq -r '.isp // "unknown"')
+	domain=$(echo "$data" | jq -r '.domain // "unknown"')
+	is_tor=$(echo "$data" | jq -r '.isTor // false')
+	is_proxy=$(echo "$data" | jq -r 'if .usageType == "VPN Service" or .usageType == "Proxy" then true else false end')
+
+	local risk_level
+	risk_level=$(score_to_risk "${score%.*}")
+
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--argjson score "$score" \
+		--arg risk_level "$risk_level" \
+		--argjson is_listed "$is_listed" \
+		--argjson reports "$reports" \
+		--arg country "$country" \
+		--arg isp "$isp" \
+		--arg domain "$domain" \
+		--argjson is_tor "$is_tor" \
+		--argjson is_proxy "$is_proxy" \
+		--argjson raw "$data" \
+		'{
+            provider: $provider,
+            ip: $ip,
+            score: $score,
+            risk_level: $risk_level,
+            is_listed: $is_listed,
+            reports: $reports,
+            country: $country,
+            isp: $isp,
+            domain: $domain,
+            is_tor: $is_tor,
+            is_proxy: $is_proxy,
+            raw: $raw
+        }'
+	return 0
+}
+
+# Provider info
+cmd_info() {
+	jq -n \
+		--arg name "$PROVIDER_NAME" \
+		--arg display "$PROVIDER_DISPLAY" \
+		'{
+            name: $name,
+            display: $display,
+            requires_key: true,
+            key_env: "ABUSEIPDB_API_KEY",
+            free_tier: "1000 checks/day",
+            url: "https://www.abuseipdb.com/",
+            api_docs: "https://docs.abuseipdb.com/"
+        }'
+	return 0
+}
+
+# Dispatch
+case "${1:-}" in
+check)
+	shift
+	cmd_check "$@"
+	;;
+info)
+	cmd_info
+	;;
+*)
+	echo "Usage: $(basename "$0") check <ip> [--api-key <key>] [--timeout <s>]" >&2
+	echo "       $(basename "$0") info" >&2
+	exit 1
+	;;
+esac

--- a/.agents/scripts/providers/ip-rep-blocklistde.sh
+++ b/.agents/scripts/providers/ip-rep-blocklistde.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# ip-rep-blocklistde.sh — Blocklist.de provider for ip-reputation-helper.sh
+# Interface: check <ip> → JSON result on stdout
+# Free tier: No key required, open API
+# API docs: https://www.blocklist.de/en/api.html
+#
+# Blocklist.de tracks IPs that have attacked servers (SSH brute force,
+# FTP attacks, web exploits, spam, etc.) reported by fail2ban users.
+#
+# Returned JSON fields:
+#   provider      string  "blocklistde"
+#   ip            string  queried IP
+#   score         int     0-100 (derived from attack count)
+#   risk_level    string  clean/low/medium/high/critical
+#   is_listed     bool    true if in attack database
+#   attacks       int     number of attacks reported
+#   reports       int     number of reports
+#   attack_types  array   types of attacks (ssh, ftp, web, etc.)
+#   error         string  error message if failed (absent on success)
+#   raw           object  raw API response
+
+set -euo pipefail
+
+readonly PROVIDER_NAME="blocklistde"
+readonly PROVIDER_DISPLAY="Blocklist.de"
+readonly API_BASE="https://api.blocklist.de/api.php"
+readonly DEFAULT_TIMEOUT=15
+
+# Output error JSON
+error_json() {
+	local ip="$1"
+	local msg="$2"
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--arg error "$msg" \
+		'{provider: $provider, ip: $ip, error: $error, is_listed: false, score: 0, risk_level: "unknown"}'
+	return 0
+}
+
+# Derive score from attack count
+attacks_to_score() {
+	local attacks="$1"
+	if [[ "$attacks" -ge 100 ]]; then
+		echo 90
+	elif [[ "$attacks" -ge 50 ]]; then
+		echo 75
+	elif [[ "$attacks" -ge 20 ]]; then
+		echo 60
+	elif [[ "$attacks" -ge 5 ]]; then
+		echo 40
+	elif [[ "$attacks" -ge 1 ]]; then
+		echo 25
+	else
+		echo 0
+	fi
+	return 0
+}
+
+score_to_risk() {
+	local score="$1"
+	if [[ "$score" -ge 75 ]]; then
+		echo "critical"
+	elif [[ "$score" -ge 50 ]]; then
+		echo "high"
+	elif [[ "$score" -ge 25 ]]; then
+		echo "medium"
+	elif [[ "$score" -ge 5 ]]; then
+		echo "low"
+	else
+		echo "clean"
+	fi
+	return 0
+}
+
+# Main check function
+cmd_check() {
+	local ip="$1"
+	local timeout="$DEFAULT_TIMEOUT"
+
+	shift
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--timeout)
+			timeout="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	# Blocklist.de API returns plain text: "attacks: N\nreports: M\n" or "listed: 0"
+	local response
+	response=$(curl -sf \
+		--max-time "$timeout" \
+		"${API_BASE}?ip=${ip}&txt=1" 2>/dev/null) || {
+		error_json "$ip" "curl request failed"
+		return 0
+	}
+
+	# Parse response — may be plain text or HTML with <br /> tags
+	# Normalize: strip HTML tags, convert <br /> to newlines
+	local normalized
+	normalized=$(echo "$response" | sed 's/<br[[:space:]]*\/?>/\n/g' | sed 's/<[^>]*>//g')
+
+	local attacks=0
+	local reports=0
+	local is_listed=false
+
+	if echo "$normalized" | grep -q "listed: 0"; then
+		is_listed=false
+		attacks=0
+		reports=0
+	elif echo "$normalized" | grep -q "attacks:"; then
+		# Extract numbers after "attacks:" and "reports:" labels
+		attacks=$(echo "$normalized" | grep -oE 'attacks:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$' || echo "0")
+		reports=$(echo "$normalized" | grep -oE 'reports:[[:space:]]*[0-9]+' | grep -oE '[0-9]+$' || echo "0")
+		attacks="${attacks:-0}"
+		reports="${reports:-0}"
+		if [[ "$attacks" -gt 0 || "$reports" -gt 0 ]]; then
+			is_listed=true
+		else
+			is_listed=false
+		fi
+	else
+		# Unexpected response format — treat as error
+		error_json "$ip" "unexpected response format: ${response:0:100}"
+		return 0
+	fi
+
+	local score
+	score=$(attacks_to_score "$attacks")
+
+	local risk_level
+	risk_level=$(score_to_risk "$score")
+
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--argjson score "$score" \
+		--arg risk_level "$risk_level" \
+		--argjson is_listed "$is_listed" \
+		--argjson attacks "$attacks" \
+		--argjson reports "$reports" \
+		--arg raw_response "$response" \
+		'{
+            provider: $provider,
+            ip: $ip,
+            score: $score,
+            risk_level: $risk_level,
+            is_listed: $is_listed,
+            attacks: $attacks,
+            reports: $reports,
+            raw: {response: $raw_response}
+        }'
+	return 0
+}
+
+# Provider info
+cmd_info() {
+	jq -n \
+		--arg name "$PROVIDER_NAME" \
+		--arg display "$PROVIDER_DISPLAY" \
+		'{
+            name: $name,
+            display: $display,
+            requires_key: false,
+            key_env: "",
+            free_tier: "Unlimited, no key required",
+            url: "https://www.blocklist.de/",
+            api_docs: "https://www.blocklist.de/en/api.html"
+        }'
+	return 0
+}
+
+# Dispatch
+case "${1:-}" in
+check)
+	shift
+	cmd_check "$@"
+	;;
+info)
+	cmd_info
+	;;
+*)
+	echo "Usage: $(basename "$0") check <ip> [--timeout <s>]" >&2
+	echo "       $(basename "$0") info" >&2
+	exit 1
+	;;
+esac

--- a/.agents/scripts/providers/ip-rep-proxycheck.sh
+++ b/.agents/scripts/providers/ip-rep-proxycheck.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# ip-rep-proxycheck.sh — ProxyCheck.io provider for ip-reputation-helper.sh
+# Interface: check <ip> [--api-key <key>] → JSON result on stdout
+# Free tier: 1000 req/day without key, 100/day with free key (more with paid)
+# API docs: https://proxycheck.io/api/
+#
+# Returned JSON fields:
+#   provider      string  "proxycheck"
+#   ip            string  queried IP
+#   score         int     0-100 (risk score)
+#   risk_level    string  clean/low/medium/high/critical
+#   is_listed     bool    true if proxy/VPN detected
+#   is_proxy      bool    proxy detected
+#   is_vpn        bool    VPN detected
+#   is_tor        bool    Tor exit node
+#   proxy_type    string  type of proxy if detected
+#   country       string  ISO country code
+#   isp           string  ISP name
+#   error         string  error message if failed (absent on success)
+#   raw           object  full API response
+
+set -euo pipefail
+
+readonly PROVIDER_NAME="proxycheck"
+readonly PROVIDER_DISPLAY="ProxyCheck.io"
+readonly API_BASE="https://proxycheck.io/v2"
+readonly DEFAULT_TIMEOUT=15
+
+# shellcheck source=/dev/null
+[[ -f "${HOME}/.config/aidevops/credentials.sh" ]] && source "${HOME}/.config/aidevops/credentials.sh"
+
+# Risk level mapping based on risk score
+score_to_risk() {
+	local score="$1"
+	if [[ "$score" -ge 75 ]]; then
+		echo "critical"
+	elif [[ "$score" -ge 50 ]]; then
+		echo "high"
+	elif [[ "$score" -ge 25 ]]; then
+		echo "medium"
+	elif [[ "$score" -ge 5 ]]; then
+		echo "low"
+	else
+		echo "clean"
+	fi
+	return 0
+}
+
+# Output error JSON
+error_json() {
+	local ip="$1"
+	local msg="$2"
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--arg error "$msg" \
+		'{provider: $provider, ip: $ip, error: $error, is_listed: false, score: 0, risk_level: "unknown"}'
+	return 0
+}
+
+# Main check function
+cmd_check() {
+	local ip="$1"
+	local api_key="${PROXYCHECK_API_KEY:-}"
+	local timeout="$DEFAULT_TIMEOUT"
+
+	shift
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--api-key)
+			api_key="$2"
+			shift 2
+			;;
+		--timeout)
+			timeout="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	# Build URL — key is optional for free tier
+	local url="${API_BASE}/${ip}?vpn=1&risk=1&port=1&seen=1&days=7&tag=ip-reputation-helper"
+	if [[ -n "$api_key" ]]; then
+		url="${url}&key=${api_key}"
+	fi
+
+	local response
+	response=$(curl -sf \
+		--max-time "$timeout" \
+		-H "Accept: application/json" \
+		"$url" 2>/dev/null) || {
+		error_json "$ip" "curl request failed"
+		return 0
+	}
+
+	if ! echo "$response" | jq empty 2>/dev/null; then
+		error_json "$ip" "invalid JSON response"
+		return 0
+	fi
+
+	# Check API status
+	local status
+	status=$(echo "$response" | jq -r '.status // "ok"')
+	if [[ "$status" == "error" ]]; then
+		local api_error
+		api_error=$(echo "$response" | jq -r '.message // "unknown error"')
+		error_json "$ip" "$api_error"
+		return 0
+	fi
+
+	# ProxyCheck returns data under the IP key
+	local data
+	data=$(echo "$response" | jq --arg ip "$ip" '.[$ip] // {}')
+
+	local score is_proxy is_vpn is_tor proxy_type country isp
+	score=$(echo "$data" | jq -r '.risk // 0')
+	is_proxy=$(echo "$data" | jq -r 'if .proxy == "yes" then true else false end')
+	is_vpn=$(echo "$data" | jq -r 'if .type == "VPN" then true else false end')
+	is_tor=$(echo "$data" | jq -r 'if .type == "TOR" then true else false end')
+	proxy_type=$(echo "$data" | jq -r '.type // "none"')
+	country=$(echo "$data" | jq -r '.isocode // "unknown"')
+	isp=$(echo "$data" | jq -r '.provider // "unknown"')
+
+	local is_listed
+	is_listed=$(echo "$data" | jq -r 'if .proxy == "yes" then true else false end')
+
+	local risk_level
+	risk_level=$(score_to_risk "${score%.*}")
+
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--argjson score "$score" \
+		--arg risk_level "$risk_level" \
+		--argjson is_listed "$is_listed" \
+		--argjson is_proxy "$is_proxy" \
+		--argjson is_vpn "$is_vpn" \
+		--argjson is_tor "$is_tor" \
+		--arg proxy_type "$proxy_type" \
+		--arg country "$country" \
+		--arg isp "$isp" \
+		--argjson raw "$data" \
+		'{
+            provider: $provider,
+            ip: $ip,
+            score: $score,
+            risk_level: $risk_level,
+            is_listed: $is_listed,
+            is_proxy: $is_proxy,
+            is_vpn: $is_vpn,
+            is_tor: $is_tor,
+            proxy_type: $proxy_type,
+            country: $country,
+            isp: $isp,
+            raw: $raw
+        }'
+	return 0
+}
+
+# Provider info
+cmd_info() {
+	jq -n \
+		--arg name "$PROVIDER_NAME" \
+		--arg display "$PROVIDER_DISPLAY" \
+		'{
+            name: $name,
+            display: $display,
+            requires_key: false,
+            key_env: "PROXYCHECK_API_KEY",
+            free_tier: "1000 req/day (no key), more with free key",
+            url: "https://proxycheck.io/",
+            api_docs: "https://proxycheck.io/api/"
+        }'
+	return 0
+}
+
+# Dispatch
+case "${1:-}" in
+check)
+	shift
+	cmd_check "$@"
+	;;
+info)
+	cmd_info
+	;;
+*)
+	echo "Usage: $(basename "$0") check <ip> [--api-key <key>] [--timeout <s>]" >&2
+	echo "       $(basename "$0") info" >&2
+	exit 1
+	;;
+esac

--- a/.agents/scripts/providers/ip-rep-spamhaus.sh
+++ b/.agents/scripts/providers/ip-rep-spamhaus.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# ip-rep-spamhaus.sh — Spamhaus DNSBL provider for ip-reputation-helper.sh
+# Interface: check <ip> → JSON result on stdout
+# Free tier: DNS-based lookups, no key required (non-commercial use)
+# Zones checked: zen.spamhaus.org (SBL+XBL+PBL combined)
+#   SBL: Spamhaus Block List (spam sources)
+#   XBL: Exploits Block List (hijacked/infected)
+#   PBL: Policy Block List (end-user IPs not for direct mail)
+#   DBL: Domain Block List (not checked here — domain-based)
+#
+# Returned JSON fields:
+#   provider      string  "spamhaus"
+#   ip            string  queried IP
+#   score         int     0-100 (derived from listing severity)
+#   risk_level    string  clean/low/medium/high/critical
+#   is_listed     bool    true if listed in any zone
+#   zones         array   list of zones where IP is listed
+#   zone_details  object  per-zone listing details
+#   error         string  error message if failed (absent on success)
+#   raw           object  raw DNS lookup results
+
+set -euo pipefail
+
+readonly PROVIDER_NAME="spamhaus"
+readonly PROVIDER_DISPLAY="Spamhaus DNSBL"
+readonly DEFAULT_TIMEOUT=10
+
+# DNSBL zones to check
+readonly ZEN_ZONE="zen.spamhaus.org"
+
+# Return codes from zen.spamhaus.org
+# 127.0.0.2 = SBL (spam source)
+# 127.0.0.3 = SBL CSS (snowshoe spam)
+# 127.0.0.4-7 = XBL (exploits/malware)
+# 127.0.0.10-11 = PBL (policy block)
+
+# Output error JSON
+error_json() {
+	local ip="$1"
+	local msg="$2"
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--arg error "$msg" \
+		'{provider: $provider, ip: $ip, error: $error, is_listed: false, score: 0, risk_level: "unknown"}'
+	return 0
+}
+
+# Reverse an IPv4 address for DNSBL lookup
+reverse_ip() {
+	local ip="$1"
+	local a b c d
+	IFS='.' read -r a b c d <<<"$ip"
+	echo "${d}.${c}.${b}.${a}"
+	return 0
+}
+
+# Classify a DNSBL return code
+classify_return_code() {
+	local code="$1"
+	case "$code" in
+	"127.0.0.2") echo "SBL:spam_source" ;;
+	"127.0.0.3") echo "SBL_CSS:snowshoe_spam" ;;
+	"127.0.0.4") echo "XBL:exploits" ;;
+	"127.0.0.5") echo "XBL:exploits" ;;
+	"127.0.0.6") echo "XBL:exploits" ;;
+	"127.0.0.7") echo "XBL:exploits" ;;
+	"127.0.0.10") echo "PBL:policy_block_isp" ;;
+	"127.0.0.11") echo "PBL:policy_block_user" ;;
+	*) echo "LISTED:unknown_code_${code}" ;;
+	esac
+	return 0
+}
+
+# Score based on listing type
+listing_score() {
+	local zone_type="$1"
+	case "$zone_type" in
+	SBL*) echo 85 ;;
+	XBL*) echo 75 ;;
+	PBL*) echo 40 ;;
+	*) echo 60 ;;
+	esac
+	return 0
+}
+
+# Risk level from score
+score_to_risk() {
+	local score="$1"
+	if [[ "$score" -ge 75 ]]; then
+		echo "critical"
+	elif [[ "$score" -ge 50 ]]; then
+		echo "high"
+	elif [[ "$score" -ge 25 ]]; then
+		echo "medium"
+	elif [[ "$score" -ge 5 ]]; then
+		echo "low"
+	else
+		echo "clean"
+	fi
+	return 0
+}
+
+# Main check function
+cmd_check() {
+	local ip="$1"
+	local timeout="$DEFAULT_TIMEOUT"
+
+	shift
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--timeout)
+			timeout="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	# Validate IPv4 (basic check)
+	if ! echo "$ip" | grep -qE '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'; then
+		error_json "$ip" "invalid IPv4 address format"
+		return 0
+	fi
+
+	# Check dig is available
+	if ! command -v dig &>/dev/null; then
+		error_json "$ip" "dig not found — install bind-utils or dnsutils"
+		return 0
+	fi
+
+	local reversed
+	reversed=$(reverse_ip "$ip")
+
+	# Query zen.spamhaus.org (combined SBL+XBL+PBL)
+	local lookup_host="${reversed}.${ZEN_ZONE}"
+	local dig_result
+	dig_result=$(dig +short +time="${timeout}" +tries=1 "$lookup_host" A 2>/dev/null || true)
+
+	local is_listed=false
+	local zones=()
+	local max_score=0
+	local zone_details="{}"
+
+	if [[ -n "$dig_result" ]]; then
+		is_listed=true
+		local zone_json="{}"
+
+		while IFS= read -r code; do
+			[[ -z "$code" ]] && continue
+			local classification
+			classification=$(classify_return_code "$code")
+			local zone_type="${classification%%:*}"
+			local zone_reason="${classification#*:}"
+			local zone_score
+			zone_score=$(listing_score "$zone_type")
+
+			zones+=("$zone_type")
+
+			if [[ "$zone_score" -gt "$max_score" ]]; then
+				max_score="$zone_score"
+			fi
+
+			zone_json=$(echo "$zone_json" | jq \
+				--arg zone "$zone_type" \
+				--arg reason "$zone_reason" \
+				--arg code "$code" \
+				'. + {($zone): {reason: $reason, return_code: $code}}')
+		done <<<"$dig_result"
+
+		zone_details="$zone_json"
+	fi
+
+	local risk_level
+	risk_level=$(score_to_risk "$max_score")
+
+	# Build zones JSON array
+	local zones_json="[]"
+	local z
+	for z in "${zones[@]+"${zones[@]}"}"; do
+		zones_json=$(echo "$zones_json" | jq --arg z "$z" '. + [$z]')
+	done
+
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--argjson score "$max_score" \
+		--arg risk_level "$risk_level" \
+		--argjson is_listed "$is_listed" \
+		--argjson zones "$zones_json" \
+		--argjson zone_details "$zone_details" \
+		--arg lookup_host "$lookup_host" \
+		--arg dig_result "$dig_result" \
+		'{
+            provider: $provider,
+            ip: $ip,
+            score: $score,
+            risk_level: $risk_level,
+            is_listed: $is_listed,
+            zones: $zones,
+            zone_details: $zone_details,
+            raw: {
+                lookup_host: $lookup_host,
+                dns_response: $dig_result
+            }
+        }'
+	return 0
+}
+
+# Provider info
+cmd_info() {
+	jq -n \
+		--arg name "$PROVIDER_NAME" \
+		--arg display "$PROVIDER_DISPLAY" \
+		'{
+            name: $name,
+            display: $display,
+            requires_key: false,
+            key_env: "",
+            free_tier: "DNS-based, no key required (non-commercial)",
+            url: "https://www.spamhaus.org/",
+            api_docs: "https://www.spamhaus.org/zen/"
+        }'
+	return 0
+}
+
+# Dispatch
+case "${1:-}" in
+check)
+	shift
+	cmd_check "$@"
+	;;
+info)
+	cmd_info
+	;;
+*)
+	echo "Usage: $(basename "$0") check <ip> [--timeout <s>]" >&2
+	echo "       $(basename "$0") info" >&2
+	exit 1
+	;;
+esac

--- a/.agents/scripts/providers/ip-rep-stopforumspam.sh
+++ b/.agents/scripts/providers/ip-rep-stopforumspam.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# ip-rep-stopforumspam.sh — StopForumSpam provider for ip-reputation-helper.sh
+# Interface: check <ip> → JSON result on stdout
+# Free tier: No key required, open API
+# API docs: https://www.stopforumspam.com/usage
+#
+# Returned JSON fields:
+#   provider      string  "stopforumspam"
+#   ip            string  queried IP
+#   score         int     0-100 (derived from frequency/confidence)
+#   risk_level    string  clean/low/medium/high/critical
+#   is_listed     bool    true if in spammer database
+#   frequency     int     number of times seen as spammer
+#   confidence    float   confidence score (0-100) from SFS
+#   last_seen     string  ISO date of last spam activity
+#   error         string  error message if failed (absent on success)
+#   raw           object  full API response
+
+set -euo pipefail
+
+readonly PROVIDER_NAME="stopforumspam"
+readonly PROVIDER_DISPLAY="StopForumSpam"
+readonly API_BASE="https://api.stopforumspam.org/api"
+readonly DEFAULT_TIMEOUT=15
+
+# Output error JSON
+error_json() {
+	local ip="$1"
+	local msg="$2"
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--arg error "$msg" \
+		'{provider: $provider, ip: $ip, error: $error, is_listed: false, score: 0, risk_level: "unknown"}'
+	return 0
+}
+
+# Risk level from confidence and frequency
+derive_score() {
+	local confidence="$1"
+	local frequency="$2"
+
+	# Use confidence as primary signal, boost by frequency
+	local score="${confidence%.*}"
+
+	# Frequency boost: high frequency = more certain threat
+	if [[ "$frequency" -ge 100 ]]; then
+		score=$((score > 90 ? 100 : score + 10))
+	elif [[ "$frequency" -ge 10 ]]; then
+		score=$((score > 95 ? 100 : score + 5))
+	fi
+
+	echo "$score"
+	return 0
+}
+
+score_to_risk() {
+	local score="$1"
+	if [[ "$score" -ge 75 ]]; then
+		echo "critical"
+	elif [[ "$score" -ge 50 ]]; then
+		echo "high"
+	elif [[ "$score" -ge 25 ]]; then
+		echo "medium"
+	elif [[ "$score" -ge 5 ]]; then
+		echo "low"
+	else
+		echo "clean"
+	fi
+	return 0
+}
+
+# Main check function
+cmd_check() {
+	local ip="$1"
+	local timeout="$DEFAULT_TIMEOUT"
+
+	shift
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--timeout)
+			timeout="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	local response
+	response=$(curl -sf \
+		--max-time "$timeout" \
+		-H "Accept: application/json" \
+		"${API_BASE}?ip=${ip}&json" 2>/dev/null) || {
+		error_json "$ip" "curl request failed"
+		return 0
+	}
+
+	if ! echo "$response" | jq empty 2>/dev/null; then
+		error_json "$ip" "invalid JSON response"
+		return 0
+	fi
+
+	# Check for API-level success
+	local api_success
+	api_success=$(echo "$response" | jq -r '.success // 1')
+	if [[ "$api_success" == "0" ]]; then
+		local api_error
+		api_error=$(echo "$response" | jq -r '.error // "unknown error"')
+		error_json "$ip" "$api_error"
+		return 0
+	fi
+
+	local ip_data
+	ip_data=$(echo "$response" | jq '.ip // {}')
+
+	local is_listed frequency confidence last_seen
+	is_listed=$(echo "$ip_data" | jq -r 'if .appears == 1 then true else false end')
+	frequency=$(echo "$ip_data" | jq -r '.frequency // 0')
+	confidence=$(echo "$ip_data" | jq -r '.confidence // 0')
+	last_seen=$(echo "$ip_data" | jq -r '.lastseen // "never"')
+
+	local score
+	score=$(derive_score "$confidence" "${frequency%.*}")
+
+	local risk_level
+	risk_level=$(score_to_risk "$score")
+
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--argjson score "$score" \
+		--arg risk_level "$risk_level" \
+		--argjson is_listed "$is_listed" \
+		--argjson frequency "$frequency" \
+		--argjson confidence "$confidence" \
+		--arg last_seen "$last_seen" \
+		--argjson raw "$ip_data" \
+		'{
+            provider: $provider,
+            ip: $ip,
+            score: $score,
+            risk_level: $risk_level,
+            is_listed: $is_listed,
+            frequency: $frequency,
+            confidence: $confidence,
+            last_seen: $last_seen,
+            raw: $raw
+        }'
+	return 0
+}
+
+# Provider info
+cmd_info() {
+	jq -n \
+		--arg name "$PROVIDER_NAME" \
+		--arg display "$PROVIDER_DISPLAY" \
+		'{
+            name: $name,
+            display: $display,
+            requires_key: false,
+            key_env: "",
+            free_tier: "Unlimited, no key required",
+            url: "https://www.stopforumspam.com/",
+            api_docs: "https://www.stopforumspam.com/usage"
+        }'
+	return 0
+}
+
+# Dispatch
+case "${1:-}" in
+check)
+	shift
+	cmd_check "$@"
+	;;
+info)
+	cmd_info
+	;;
+*)
+	echo "Usage: $(basename "$0") check <ip> [--timeout <s>]" >&2
+	echo "       $(basename "$0") info" >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
## Summary

- Implements `ip-reputation-helper.sh` CLI with `check`, `batch`, `report`, `providers` subcommands
- Provider interface pattern: source-able `providers/ip-rep-*.sh` scripts (matches tech-stack-helper.sh pattern from t1063)
- 5 providers implemented: Spamhaus DNSBL (dig-based), ProxyCheck.io, StopForumSpam, Blocklist.de (all no-key), AbuseIPDB (free key)
- Parallel query execution via background jobs + `wait`
- Unified risk scoring: clean/low/medium/high/critical merging per-provider results

## Validation

```
# Clean IP (Google DNS)
ip-reputation-helper.sh check 8.8.8.8
→ CLEAN (score: 0/100) — 4/5 providers responded

# Known Tor exit node
ip-reputation-helper.sh check 185.220.101.1
→ HIGH (score: 60/100) — ProxyCheck: CRITICAL, StopForumSpam: CRITICAL
```

## Quality

- ShellCheck: zero violations on all 6 scripts
- Portable: handles macOS (no GNU `timeout`), uses `gtimeout` fallback
- Follows existing framework patterns (shared-constants.sh, color vars, error JSON)

## Notes

- AbuseIPDB requires free API key (1000/day) — gracefully degrades without it
- t1200.2 will add SQLite caching + remaining keyed providers (IPQualityScore, GreyNoise, Shodan, IP Hub)
- t1200.3 will add agent doc + slash command + index updates

Ref #1847