### PR TITLE
t1217: Add post-write verification to create_subtasks executor

### DIFF
--- a/.agents/scripts/supervisor/ai-actions.sh
+++ b/.agents/scripts/supervisor/ai-actions.sh
@@ -1052,6 +1052,25 @@ _exec_create_subtasks() {
 	} >"$temp_file"
 	mv "$temp_file" "$todo_file"
 
+	# Post-write verification: confirm each subtask ID was actually persisted (t1217)
+	local missing_ids=""
+	local verify_index=$((existing_subtask_count + 1))
+	local k
+	for ((k = 0; k < subtask_count; k++)); do
+		local expected_id="${parent_task_id}.${verify_index}"
+		if ! grep -q "^\s*- \[.\] ${expected_id} " "$todo_file" 2>/dev/null; then
+			missing_ids="${missing_ids}${expected_id},"
+		fi
+		verify_index=$((verify_index + 1))
+	done
+
+	if [[ -n "$missing_ids" ]]; then
+		missing_ids="${missing_ids%,}"
+		log_warn "create_subtasks: post-write verification FAILED — subtask IDs not found in TODO.md: $missing_ids (parent: $parent_task_id)"
+		echo "{\"created\":false,\"error\":\"subtasks_not_persisted\",\"parent_task_id\":\"$parent_task_id\",\"missing_ids\":\"$missing_ids\"}"
+		return 1
+	fi
+
 	# Commit and push (redirect stdout to log — git operations leak noise)
 	if declare -f commit_and_push_todo &>/dev/null; then
 		commit_and_push_todo "$repo_path" "chore: AI supervisor created subtasks for $parent_task_id" >>"$SUPERVISOR_LOG" 2>&1 || true


### PR DESCRIPTION
## Summary

- Adds a post-write verification loop in `_exec_create_subtasks` that checks each expected subtask ID actually exists in `TODO.md` after the `mv` operation
- If any subtask IDs are missing, logs a `log_warn` and returns `{"created":false,"error":"subtasks_not_persisted",...}` with the missing IDs listed
- Prevents silent failures where the AI reasoner believes subtasks were created but entries were never persisted

## Root Cause

The `_exec_create_subtasks` function wrote subtask lines via a temp file + `mv`, then immediately returned `{"created":true,...}` without verifying the write succeeded. If the `mv` silently failed or the grep pattern did not match, the executor would report success while the eligibility assessment would still flag the parent as `needs-subtasking`.

## Verification

- ShellCheck: zero violations
- Verification uses the same grep pattern already used for parent task existence checks (line 979)

Ref #1852