### PR TITLE
t1221: Fix create_subtasks executor — grep -c bug caused 10 consecutive failures

### DIFF
--- a/tests/test-ai-actions.sh
+++ b/tests/test-ai-actions.sh
@@ -1539,7 +1539,7 @@ _test_create_subtasks_grep_c_bug() {
 			failures=$((failures + 1))
 		fi
 
-		rm -rf "$tmp_dir" "/tmp/test-ai-actions-logs-$$" "/tmp/test-$$.db" 2>/dev/null || true
+		rm -rf "$tmp_dir" "/tmp/test-ai-actions-logs-$$" "/tmp/test-subtasks-$$.db" 2>/dev/null || true
 		exit "$failures"
 	)
 }
@@ -1555,6 +1555,7 @@ echo "Test 24: create_subtasks executor — missing parent_task_id returns clear
 
 _test_create_subtasks_missing_parent() {
 	(
+		set +e
 		BLUE='' GREEN='' YELLOW='' RED='' NC=''
 		SUPERVISOR_DB="/tmp/test-subtasks-missing-$$.db"
 		SUPERVISOR_LOG="/dev/null"
@@ -1615,6 +1616,7 @@ echo "Test 25: create_subtasks executor — parent task not in primary repo retu
 
 _test_create_subtasks_cross_repo() {
 	(
+		set +e
 		BLUE='' GREEN='' YELLOW='' RED='' NC=''
 		SUPERVISOR_DB="/tmp/test-subtasks-cross-$$.db"
 		SUPERVISOR_LOG="/dev/null"


### PR DESCRIPTION
Fix create_subtasks executor — 10 consecutive failures indicate structural bug

## Root Cause

`grep -c` returns exit code 1 when count is 0 in an existing file. The `|| echo 0` fallback then also ran, producing `0\n0` instead of `0`. This broke the arithmetic expression `$((existing_subtask_count + 1))` with 'syntax error in expression' under `set -euo pipefail`, killing the function before it could output any result — hence the empty `Result:` in all 10 failure logs.

## Changes

- **Primary fix**: Replace `grep -c ... || echo 0` with `grep -c ... || var=0; var=${var:-0}` at both occurrences (`existing_subtask_count`, `verified_count`)
- **Input validation**: Early validation with clear error messages for missing `parent_task_id` and empty `subtasks` array
- **Cross-repo support**: When parent task not found in primary repo, look up its repo path from `SUPERVISOR_DB` and retry (handles a private project t003/t009 scenario)
- **Better diagnostics**: All error messages now include `parent_task_id` and `todo_file` path

## Tests

25/25 pass — added 3 new tests:
- Test 23: grep -c with no existing subtasks does not crash (the actual bug)
- Test 24: missing parent_task_id returns clear error
- Test 25: cross-repo task returns clear parent_task_not_found error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cross-repository support for managing parent tasks across multiple repositories.

* **Bug Fixes**
  * Improved input validation with clearer error messages for subtask creation.
  * Enhanced error handling for missing tasks and invalid configurations.

* **Tests**
  * Added test coverage for error handling and cross-repository scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->