### PR TITLE
t1200.3: Agent doc + slash command + index updates + output formatting

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -384,7 +384,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | Voice | `tools/voice/speech-to-speech.md`, `voice-helper.sh talk` (voice bridge) |
 | Email testing | `services/email/email-testing.md` (overview), `services/email/email-design-test.md`, `services/email/email-delivery-test.md`, `email-test-suite-helper.sh` |
 | Encryption | `tools/credentials/encryption-stack.md` (decision tree), `tools/credentials/sops.md`, `tools/credentials/gocryptfs.md`, `tools/credentials/gopass.md` |
-| Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting) |
+| Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting), `tools/security/ip-reputation.md` (IP reputation), `/ip-check <ip>` |
 | Cloud GPU | `tools/infrastructure/cloud-gpu.md` |
 | Containers | `tools/containers/orbstack.md` |
 | Networking | `services/networking/tailscale.md` |

--- a/.agents/scripts/commands/ip-check.md
+++ b/.agents/scripts/commands/ip-check.md
@@ -1,0 +1,163 @@
+---
+description: Check IP reputation across multiple providers — vet VPS/server/proxy IPs before purchase or deployment
+agent: Build+
+mode: subagent
+---
+
+Check IP reputation and risk level across multiple providers.
+
+Arguments: $ARGUMENTS
+
+## Workflow
+
+### Step 1: Parse Arguments
+
+Parse `$ARGUMENTS` to determine the check type:
+
+- **IP only** (e.g., `1.2.3.4`): Full multi-provider check, table output
+- **IP + format** (e.g., `1.2.3.4 -f json`): Check with specified output format
+- **IP + report** (e.g., `1.2.3.4 report`): Generate detailed markdown report
+- **IP + provider** (e.g., `1.2.3.4 --provider abuseipdb`): Single-provider check
+- **File** (e.g., `ips.txt`): Batch check from file
+- **No args**: Show usage
+
+### Step 2: Run the Check
+
+```bash
+# Full check (default table output)
+~/.aidevops/agents/scripts/ip-reputation-helper.sh check "$IP"
+
+# JSON output
+~/.aidevops/agents/scripts/ip-reputation-helper.sh check "$IP" -f json
+
+# Markdown report
+~/.aidevops/agents/scripts/ip-reputation-helper.sh report "$IP"
+
+# Single provider
+~/.aidevops/agents/scripts/ip-reputation-helper.sh check "$IP" --provider "$PROVIDER"
+
+# Batch from file
+~/.aidevops/agents/scripts/ip-reputation-helper.sh batch "$FILE"
+```
+
+### Step 3: Present Results
+
+Summarize the output clearly:
+
+```text
+IP Reputation: 1.2.3.4
+
+Risk Level:  CLEAN (score: 2/100)
+Verdict:     SAFE — no significant flags detected
+
+Providers (8/10 responded):
+  Spamhaus DNSBL    clean   (0)
+  ProxyCheck.io     clean   (0)
+  StopForumSpam     clean   (0)
+  Blocklist.de      clean   (0)
+  GreyNoise         clean   (0)
+  AbuseIPDB         clean   (0)
+  IPQualityScore    clean   (2)
+  Scamalytics       clean   (0)
+
+Flags: Tor=NO  Proxy=NO  VPN=NO
+```
+
+### Step 4: Offer Follow-up Actions
+
+```text
+Actions:
+1. Generate full markdown report
+2. Check with a specific provider
+3. Batch check a list of IPs
+4. Show raw JSON output
+5. Clear cache and re-check
+```
+
+## Options
+
+| Command | Purpose |
+|---------|---------|
+| `/ip-check 1.2.3.4` | Full multi-provider check |
+| `/ip-check 1.2.3.4 -f json` | JSON output |
+| `/ip-check 1.2.3.4 report` | Detailed markdown report |
+| `/ip-check 1.2.3.4 --provider abuseipdb` | Single provider |
+| `/ip-check 1.2.3.4 --no-cache` | Bypass cache |
+| `/ip-check ips.txt` | Batch check from file |
+| `/ip-check ips.txt --dnsbl-overlap` | Batch with DNSBL cross-reference |
+
+## Examples
+
+**Clean IP:**
+
+```text
+User: /ip-check 8.8.8.8
+AI: Checking IP reputation for 8.8.8.8...
+
+    IP Reputation: 8.8.8.8
+    Risk Level:  CLEAN (score: 0/100)
+    Verdict:     SAFE — no significant flags detected
+
+    Providers (8/10 responded):
+      Spamhaus DNSBL    clean   (0)
+      ProxyCheck.io     clean   (0)
+      ...
+
+    Flags: Tor=NO  Proxy=NO  VPN=NO
+```
+
+**Flagged IP:**
+
+```text
+User: /ip-check 185.220.101.1
+AI: Checking IP reputation for 185.220.101.1...
+
+    IP Reputation: 185.220.101.1
+    Risk Level:  CRITICAL (score: 92/100)
+    Verdict:     AVOID — IP is heavily flagged across multiple sources
+
+    Providers (9/10 responded):
+      Spamhaus DNSBL    critical  (100)  listed
+      AbuseIPDB         critical  (98)   listed
+      GreyNoise         high      (85)   listed
+      ...
+
+    Flags: Tor=YES  Proxy=YES  VPN=NO
+    Listed by: 7 provider(s)
+```
+
+**JSON output:**
+
+```text
+User: /ip-check 1.2.3.4 -f json
+AI: {
+      "ip": "1.2.3.4",
+      "scan_time": "2026-02-19T12:00:00Z",
+      "unified_score": 2,
+      "risk_level": "clean",
+      "recommendation": "SAFE — no significant flags detected",
+      ...
+    }
+```
+
+**Markdown report:**
+
+```text
+User: /ip-check 1.2.3.4 report
+AI: # IP Reputation Report: 1.2.3.4
+
+    - **Scanned**: 2026-02-19T12:00:00Z
+    - **Risk Level**: CLEAN (2/100)
+    - **Verdict**: SAFE — no significant flags detected
+
+    ## Summary
+    | Metric | Value |
+    ...
+```
+
+## Related
+
+- `tools/security/ip-reputation.md` — Full documentation and provider reference
+- `tools/security/tirith.md` — Terminal security guard
+- `tools/security/cdn-origin-ip.md` — CDN origin IP leak detection
+- `/email-health-check` — Email DNSBL and deliverability check

--- a/.agents/scripts/ip-reputation-helper.sh
+++ b/.agents/scripts/ip-reputation-helper.sh
@@ -231,6 +231,10 @@ cmd_cache_clear() {
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		--help | -h)
+			print_usage_cache_clear
+			return 0
+			;;
 		--provider | -p)
 			specific_provider="$2"
 			shift 2
@@ -793,6 +797,10 @@ cmd_check() {
 	# Parse arguments
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		--help | -h)
+			print_usage_check
+			return 0
+			;;
 		--provider | -p)
 			specific_provider="$2"
 			shift 2
@@ -970,6 +978,10 @@ cmd_batch() {
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		--help | -h)
+			print_usage_batch
+			return 0
+			;;
 		--format | -f)
 			output_format="$2"
 			shift 2
@@ -1148,6 +1160,10 @@ cmd_report() {
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		--help | -h)
+			print_usage_report
+			return 0
+			;;
 		--timeout | -t)
 			timeout_secs="$2"
 			shift 2
@@ -1223,6 +1239,113 @@ cmd_providers() {
 	echo -e "Provider scripts location: ${PROVIDERS_DIR}/"
 	echo -e "Each provider implements: check <ip> [--api-key <key>] [--timeout <s>]"
 	echo ""
+	return 0
+}
+
+# =============================================================================
+# Per-Subcommand Help
+# =============================================================================
+
+print_usage_check() {
+	cat <<EOF
+Usage: $(basename "$0") check <ip> [options]
+
+Check the reputation of a single IP address across multiple providers.
+
+Arguments:
+  <ip>              IPv4 address to check (required)
+
+Options:
+  --provider, -p <p>    Use only specified provider (default: all available)
+  --timeout, -t <s>     Per-provider timeout in seconds (default: ${IP_REP_DEFAULT_TIMEOUT})
+  --format, -f <fmt>    Output format: table (default), json, markdown
+  --parallel            Run providers in parallel (default)
+  --sequential          Run providers sequentially
+  --no-cache            Bypass cache for this query
+  --no-color            Disable color output
+
+Examples:
+  $(basename "$0") check 1.2.3.4
+  $(basename "$0") check 1.2.3.4 -f json
+  $(basename "$0") check 1.2.3.4 --format markdown
+  $(basename "$0") check 1.2.3.4 --provider abuseipdb
+  $(basename "$0") check 1.2.3.4 --no-cache
+  $(basename "$0") check 1.2.3.4 --sequential --timeout 30
+EOF
+	return 0
+}
+
+print_usage_batch() {
+	cat <<EOF
+Usage: $(basename "$0") batch <file> [options]
+
+Check multiple IP addresses from a file (one IP per line).
+Lines starting with # and blank lines are skipped.
+
+Arguments:
+  <file>            Path to file containing IPs (required)
+
+Options:
+  --provider, -p <p>    Use only specified provider (default: all available)
+  --timeout, -t <s>     Per-provider timeout in seconds (default: ${IP_REP_DEFAULT_TIMEOUT})
+  --format, -f <fmt>    Output format: table (default), json
+  --no-cache            Bypass cache for this query
+  --rate-limit <n>      Requests per second per provider (default: 2)
+  --dnsbl-overlap       Cross-reference results with email DNSBL zones
+
+Examples:
+  $(basename "$0") batch ips.txt
+  $(basename "$0") batch ips.txt --rate-limit 1
+  $(basename "$0") batch ips.txt --dnsbl-overlap
+  $(basename "$0") batch ips.txt -f json
+  $(basename "$0") batch ips.txt --provider spamhaus --rate-limit 5
+EOF
+	return 0
+}
+
+print_usage_report() {
+	cat <<EOF
+Usage: $(basename "$0") report <ip> [options]
+
+Generate a detailed markdown report for an IP address.
+Queries all available providers and outputs a formatted markdown document
+suitable for documentation, audit trails, or sharing.
+
+Arguments:
+  <ip>              IPv4 address to report on (required)
+
+Options:
+  --provider, -p <p>    Use only specified provider (default: all available)
+  --timeout, -t <s>     Per-provider timeout in seconds (default: ${IP_REP_DEFAULT_TIMEOUT})
+
+Examples:
+  $(basename "$0") report 1.2.3.4
+  $(basename "$0") report 1.2.3.4 > report.md
+  $(basename "$0") report 1.2.3.4 --provider abuseipdb
+  $(basename "$0") report 1.2.3.4 --timeout 30
+
+Note: Equivalent to: $(basename "$0") check 1.2.3.4 --format markdown
+EOF
+	return 0
+}
+
+print_usage_cache_clear() {
+	cat <<EOF
+Usage: $(basename "$0") cache-clear [options]
+
+Clear cached IP reputation results from the SQLite cache.
+Without filters, clears all cached entries.
+
+Options:
+  --provider, -p <p>    Clear cache only for specified provider
+  --ip <ip>             Clear cache only for specified IP address
+
+Examples:
+  $(basename "$0") cache-clear
+  $(basename "$0") cache-clear --provider abuseipdb
+  $(basename "$0") cache-clear --ip 1.2.3.4
+  $(basename "$0") cache-clear --provider spamhaus --ip 1.2.3.4
+EOF
 	return 0
 }
 

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -54,7 +54,7 @@ tools/data-extraction/,Data extraction - scraping business data,outscraper
 tools/deployment/,Deployment automation - self-hosted PaaS and orchestration,coolify|coolify-cli|vercel|cloudron-app-packaging|uncloud
 tools/git/,Git operations - GitHub/GitLab/Gitea CLIs and diff tools,github-cli|gitlab-cli|gitea-cli|github-actions|worktrunk|lumen|jujutsu|conflict-resolution
 tools/credentials/,Secret management - API keys vaults and encryption stack,api-key-setup|api-key-management|vaultwarden|gopass|psst|multi-tenant|list-keys|sops|gocryptfs|encryption-stack
-tools/security/,Security tools - terminal guards privacy filtering and scanning,tirith|shannon|cdn-origin-ip|privacy-filter
+tools/security/,Security tools - terminal guards privacy filtering IP reputation and scanning,tirith|shannon|cdn-origin-ip|privacy-filter|ip-reputation
 tools/task-management/,Task tracking - dependency graphs,beads
 tools/terminal/,Terminal integration - tab titles,terminal-title
 tools/automation/,Automation - cron scheduling objective runner and macOS AppleScript/JXA,cron-agent|objective-runner|mac|macos-automator
@@ -119,6 +119,7 @@ quality-sweep-helper.sh,Unified quality debt sweep (SonarCloud Codacy CodeFactor
 finding-to-task-helper.sh,Convert quality findings into grouped TODO tasks with auto-dispatch
 secretlint-helper.sh,Secret detection
 security-helper.sh,Security analysis (OSV Ferret history full-scan)
+ip-reputation-helper.sh,IP reputation checker - multi-provider risk scoring for VPS/server/proxy IPs (check batch report providers cache-stats cache-clear)
 beads-sync-helper.sh,Sync TODO.md/PLANS.md with Beads graph
 todo-ready.sh,Show tasks with no open blockers
 ralph-loop-helper.sh,Iterative AI development loops

--- a/.agents/tools/security/ip-reputation.md
+++ b/.agents/tools/security/ip-reputation.md
@@ -1,0 +1,262 @@
+---
+description: IP reputation checker — multi-provider risk scoring for VPS/server/proxy IPs before purchase or deployment
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: false
+---
+
+# IP Reputation Checker
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Vet VPS/server/proxy IPs before purchase or deployment — check if they are burned (blacklisted, flagged)
+- **Helper**: `ip-reputation-helper.sh`
+- **Slash command**: `/ip-check <ip>`
+- **Providers**: 10 providers (5 free/no-key, 5 free-tier with API key)
+- **Output formats**: `table` (default), `json`, `markdown`
+- **Cache**: SQLite, per-provider TTL (1h–7d)
+
+<!-- AI-CONTEXT-END -->
+
+## Use Cases
+
+- Vet a VPS IP before purchasing a server
+- Check if a proxy/VPN IP is burned before use
+- Batch-screen a list of IPs for deployment
+- Generate a markdown report for audit/compliance
+- Cross-reference with email DNSBL blacklists
+
+## Commands
+
+```bash
+# Check a single IP (table output)
+ip-reputation-helper.sh check 1.2.3.4
+
+# Check with JSON output
+ip-reputation-helper.sh check 1.2.3.4 -f json
+
+# Check with markdown report output
+ip-reputation-helper.sh check 1.2.3.4 --format markdown
+
+# Generate detailed markdown report
+ip-reputation-helper.sh report 1.2.3.4
+
+# Batch check from file (one IP per line)
+ip-reputation-helper.sh batch ips.txt
+
+# Batch with rate limiting and DNSBL overlap
+ip-reputation-helper.sh batch ips.txt --rate-limit 1 --dnsbl-overlap
+
+# Batch with JSON output
+ip-reputation-helper.sh batch ips.txt -f json
+
+# Use a single provider only
+ip-reputation-helper.sh check 1.2.3.4 --provider abuseipdb
+
+# Bypass cache for fresh results
+ip-reputation-helper.sh check 1.2.3.4 --no-cache
+
+# List all providers and their status
+ip-reputation-helper.sh providers
+
+# Show cache statistics
+ip-reputation-helper.sh cache-stats
+
+# Clear cache for a provider
+ip-reputation-helper.sh cache-clear --provider abuseipdb
+
+# Clear cache for a specific IP
+ip-reputation-helper.sh cache-clear --ip 1.2.3.4
+
+# Show help
+ip-reputation-helper.sh help
+```
+
+## Subcommand Help
+
+```bash
+# Per-subcommand help (--help flag)
+ip-reputation-helper.sh check --help
+ip-reputation-helper.sh batch --help
+ip-reputation-helper.sh report --help
+ip-reputation-helper.sh cache-clear --help
+```
+
+## Providers
+
+### Free / No API Key Required
+
+| Provider | What it checks | Cache TTL |
+|----------|---------------|-----------|
+| `spamhaus` | Spamhaus DNSBL (SBL/XBL/PBL) via DNS | 1h |
+| `proxycheck` | Proxy/VPN/Tor detection (ProxyCheck.io) | 6h |
+| `stopforumspam` | Forum spammer database | 1h |
+| `blocklistde` | Attack/botnet IPs (Blocklist.de) | 1h |
+| `greynoise` | Internet noise scanner (Community API) | 24h |
+
+### Free Tier with API Key
+
+| Provider | What it checks | Free Limit | Cache TTL |
+|----------|---------------|------------|-----------|
+| `abuseipdb` | Community abuse reports | 1,000/day | 24h |
+| `ipqualityscore` | Fraud/proxy/VPN detection | 5,000/month | 24h |
+| `scamalytics` | Fraud scoring | 5,000/month | 24h |
+| `shodan` | Open ports, vulns, tags | Free key, limited credits | 7d |
+| `iphub` | Proxy/VPN/hosting detection | 1,000/day | 6h |
+
+## Risk Levels
+
+| Level | Score | Meaning |
+|-------|-------|---------|
+| `clean` | 0–4 | No significant flags |
+| `low` | 5–24 | Minor flags detected |
+| `medium` | 25–49 | Some flags, investigate before use |
+| `high` | 50–74 | Significant abuse/attack history |
+| `critical` | 75–100 | Heavily flagged across multiple sources |
+
+## Output Formats
+
+### Table (default)
+
+Terminal-friendly colored output with per-provider breakdown:
+
+```text
+=== IP Reputation Report ===
+IP:          1.2.3.4
+Scanned:     2026-02-19T12:00:00Z
+Risk Level:  CLEAN (score: 2/100)
+Verdict:     SAFE — no significant flags detected
+
+Summary:
+  Providers:  8/10 responded
+  Listed by:  0 provider(s)
+  Tor:        NO
+  Proxy:      NO
+  VPN:        NO
+
+Provider Results:
+  Provider           Risk       Score    Details
+  --------           ----       -----    -------
+  Spamhaus DNSBL     clean      0        clean
+  ProxyCheck.io      clean      0        clean
+  ...
+```
+
+### JSON (`-f json`)
+
+Machine-readable structured output:
+
+```json
+{
+  "ip": "1.2.3.4",
+  "scan_time": "2026-02-19T12:00:00Z",
+  "unified_score": 2,
+  "risk_level": "clean",
+  "recommendation": "SAFE — no significant flags detected",
+  "summary": {
+    "providers_queried": 10,
+    "providers_responded": 8,
+    "providers_errored": 2,
+    "listed_by": 0,
+    "is_tor": false,
+    "is_proxy": false,
+    "is_vpn": false
+  },
+  "providers": [...]
+}
+```
+
+### Markdown (`report` subcommand or `--format markdown`)
+
+Full markdown report suitable for documentation or audit:
+
+```markdown
+# IP Reputation Report: 1.2.3.4
+
+- **Scanned**: 2026-02-19T12:00:00Z
+- **Risk Level**: CLEAN (2/100)
+- **Verdict**: SAFE — no significant flags detected
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Providers queried | 10 |
+...
+
+## Provider Results
+
+| Provider | Risk Level | Score | Listed | Details |
+|----------|-----------|-------|--------|---------|
+...
+```
+
+## API Key Setup
+
+Store keys via `aidevops secret set NAME` (never paste in conversation):
+
+```bash
+aidevops secret set ABUSEIPDB_API_KEY
+aidevops secret set IPQUALITYSCORE_API_KEY
+aidevops secret set SCAMALYTICS_API_KEY
+aidevops secret set SHODAN_API_KEY
+aidevops secret set IPHUB_API_KEY
+# Optional (increases rate limits):
+aidevops secret set PROXYCHECK_API_KEY
+aidevops secret set GREYNOISE_API_KEY
+```
+
+Keys are loaded automatically from `~/.config/aidevops/credentials.sh`.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IP_REP_TIMEOUT` | `15` | Per-provider timeout (seconds) |
+| `IP_REP_FORMAT` | `table` | Default output format |
+| `IP_REP_CACHE_DIR` | `~/.cache/ip-reputation` | SQLite cache directory |
+| `IP_REP_CACHE_TTL` | `86400` | Default cache TTL (seconds) |
+| `IP_REP_RATE_LIMIT` | `2` | Batch requests/second per provider |
+
+## Options Reference
+
+| Option | Short | Description |
+|--------|-------|-------------|
+| `--provider <p>` | `-p` | Use only specified provider |
+| `--timeout <s>` | `-t` | Per-provider timeout in seconds |
+| `--format <fmt>` | `-f` | Output format: `table`, `json`, `markdown` |
+| `--parallel` | | Run providers in parallel (default) |
+| `--sequential` | | Run providers sequentially |
+| `--no-cache` | | Bypass cache for this query |
+| `--no-color` | | Disable color output |
+| `--rate-limit <n>` | | Batch requests/second (default: 2) |
+| `--dnsbl-overlap` | | Cross-reference with email DNSBL in batch mode |
+
+## Integration with Email Health Check
+
+The `--dnsbl-overlap` flag in batch mode cross-references results with the same
+DNSBL zones used by `email-health-check-helper.sh` (zen.spamhaus.org, bl.spamcop.net,
+b.barracudacentral.org). Useful when vetting IPs for email sending.
+
+## Scoring Algorithm
+
+1. Each provider returns a score (0–100) and `is_listed` flag
+2. Unified score = weighted average across responding providers
+3. Boost applied if 2+ providers agree on listing (+10) or 3+ agree (+15)
+4. Final risk level determined by unified score thresholds
+
+## Related
+
+- `tools/security/tirith.md` — Terminal security guard
+- `tools/security/shannon.md` — AI pentesting for web applications
+- `tools/security/cdn-origin-ip.md` — CDN origin IP leak detection
+- `services/email/email-health-check.md` — Email DNSBL and deliverability
+- `/ip-check <ip>` — Slash command shortcut


### PR DESCRIPTION
Agent doc + slash command + index updates + output formatting for IP reputation checker.

## Changes

- `tools/security/ip-reputation.md`: New agent doc with full provider reference, risk levels, output format examples, API key setup, and env vars
- `scripts/commands/ip-check.md`: New `/ip-check <ip>` slash command with argument parsing workflow and examples
- `subagent-index.toon`: Added `ip-reputation` to `tools/security/` folder and `ip-reputation-helper.sh` to scripts section
- `AGENTS.md`: Extended Security row in progressive disclosure table with `ip-reputation.md` and `/ip-check <ip>`
- `ip-reputation-helper.sh`: Added per-subcommand `--help` for `check`, `batch`, `report`, `cache-clear`

## Verification

- `bash -n`: syntax OK
- `shellcheck -S warning`: zero violations
- All subcommand `--help` flags tested and working
- `report` subcommand and `-f json` format confirmed working (pre-existing)

Ref #1849