### PR TITLE
t1200.4: Core IP reputation lookup module using AbuseIPDB and VirusTotal APIs

### DIFF
--- a/.agents/scripts/ip-reputation-helper.sh
+++ b/.agents/scripts/ip-reputation-helper.sh
@@ -33,6 +33,7 @@
 #
 # Providers (free tier with API key):
 #   abuseipdb       AbuseIPDB (community abuse reports, 1000/day free)
+#   virustotal      VirusTotal (70+ AV engines, 500/day free)
 #   ipqualityscore  IPQualityScore (fraud/proxy/VPN detection, 5000/month free)
 #   scamalytics     Scamalytics (fraud scoring, 5000/month free)
 #   shodan          Shodan (open ports, vulns, tags — free key, limited credits)
@@ -42,6 +43,7 @@
 #
 # Environment variables:
 #   ABUSEIPDB_API_KEY         AbuseIPDB API key (free at abuseipdb.com)
+#   VIRUSTOTAL_API_KEY        VirusTotal API key (free at virustotal.com)
 #   PROXYCHECK_API_KEY        ProxyCheck.io API key (optional, increases limit)
 #   IPQUALITYSCORE_API_KEY    IPQualityScore API key (free at ipqualityscore.com)
 #   SCAMALYTICS_API_KEY       Scamalytics API key (free at scamalytics.com)
@@ -57,7 +59,7 @@
 # Cache TTL per provider (seconds):
 #   spamhaus/blocklistde/stopforumspam: 3600  (1h — DNSBL data changes frequently)
 #   proxycheck/iphub:                   21600 (6h)
-#   abuseipdb/ipqualityscore:           86400 (24h)
+#   abuseipdb/ipqualityscore/virustotal: 86400 (24h)
 #   scamalytics/greynoise:              86400 (24h)
 #   shodan:                             604800 (7d — scan data changes slowly)
 #
@@ -92,7 +94,7 @@ source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || true
 
 # All available providers (order matters for display)
 # greynoise has a free community API (no key required) but also supports keyed full API
-readonly ALL_PROVIDERS="spamhaus proxycheck stopforumspam blocklistde greynoise abuseipdb ipqualityscore scamalytics shodan iphub"
+readonly ALL_PROVIDERS="spamhaus proxycheck stopforumspam blocklistde greynoise abuseipdb virustotal ipqualityscore scamalytics shodan iphub"
 
 # =============================================================================
 # SQLite Cache
@@ -346,6 +348,7 @@ provider_script() {
 	local provider="$1"
 	case "$provider" in
 	abuseipdb) echo "ip-rep-abuseipdb.sh" ;;
+	virustotal) echo "ip-rep-virustotal.sh" ;;
 	proxycheck) echo "ip-rep-proxycheck.sh" ;;
 	spamhaus) echo "ip-rep-spamhaus.sh" ;;
 	stopforumspam) echo "ip-rep-stopforumspam.sh" ;;
@@ -365,6 +368,7 @@ provider_display_name() {
 	local provider="$1"
 	case "$provider" in
 	abuseipdb) echo "AbuseIPDB" ;;
+	virustotal) echo "VirusTotal" ;;
 	proxycheck) echo "ProxyCheck.io" ;;
 	spamhaus) echo "Spamhaus DNSBL" ;;
 	stopforumspam) echo "StopForumSpam" ;;
@@ -1386,6 +1390,7 @@ Providers (no key required):
 
 Providers (free API key required):
   abuseipdb         AbuseIPDB — 1000/day free (abuseipdb.com)
+  virustotal        VirusTotal — 500/day free (virustotal.com)
   ipqualityscore    IPQualityScore — 5000/month free (ipqualityscore.com)
   scamalytics       Scamalytics — 5000/month free (scamalytics.com)
   shodan            Shodan — free key, limited credits (shodan.io)
@@ -1393,6 +1398,7 @@ Providers (free API key required):
 
 Environment:
   ABUSEIPDB_API_KEY         AbuseIPDB API key
+  VIRUSTOTAL_API_KEY        VirusTotal API key
   PROXYCHECK_API_KEY        ProxyCheck.io API key (optional)
   IPQUALITYSCORE_API_KEY    IPQualityScore API key
   SCAMALYTICS_API_KEY       Scamalytics API key

--- a/.agents/scripts/providers/ip-rep-virustotal.sh
+++ b/.agents/scripts/providers/ip-rep-virustotal.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# ip-rep-virustotal.sh — VirusTotal provider for ip-reputation-helper.sh
+# Interface: check <ip> [--api-key <key>] → JSON result on stdout
+# Free tier: 4 requests/minute, 500/day, 15.5K/month with API key
+# API docs: https://developers.virustotal.com/reference/ip-object
+#
+# Returned JSON fields:
+#   provider      string  "virustotal"
+#   ip            string  queried IP
+#   score         int     0-100 (derived from malicious detection ratio)
+#   risk_level    string  clean/low/medium/high/critical
+#   is_listed     bool    true if any engine flagged malicious
+#   malicious     int     number of engines detecting as malicious
+#   suspicious    int     number of engines detecting as suspicious
+#   harmless      int     number of engines detecting as harmless
+#   undetected    int     number of engines with no detection
+#   reputation    int     VT community reputation score
+#   as_owner      string  autonomous system owner
+#   country       string  ISO country code
+#   network       string  network CIDR
+#   error         string  error message if failed (absent on success)
+#   raw           object  full API response attributes
+
+set -euo pipefail
+
+readonly PROVIDER_NAME="virustotal"
+readonly PROVIDER_DISPLAY="VirusTotal"
+readonly API_BASE="https://www.virustotal.com/api/v3"
+readonly DEFAULT_TIMEOUT=15
+
+# shellcheck source=/dev/null
+[[ -f "${HOME}/.config/aidevops/credentials.sh" ]] && source "${HOME}/.config/aidevops/credentials.sh"
+
+# Risk level mapping based on malicious detection ratio
+# Uses the ratio of malicious detections to total engines
+score_to_risk() {
+	local score="$1"
+	if [[ "$score" -ge 75 ]]; then
+		echo "critical"
+	elif [[ "$score" -ge 50 ]]; then
+		echo "high"
+	elif [[ "$score" -ge 25 ]]; then
+		echo "medium"
+	elif [[ "$score" -ge 5 ]]; then
+		echo "low"
+	else
+		echo "clean"
+	fi
+	return 0
+}
+
+# Output error JSON
+error_json() {
+	local ip="$1"
+	local msg="$2"
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--arg error "$msg" \
+		'{provider: $provider, ip: $ip, error: $error, is_listed: false, score: 0, risk_level: "unknown"}'
+	return 0
+}
+
+# Main check function
+cmd_check() {
+	local ip="$1"
+	local api_key="${VIRUSTOTAL_API_KEY:-}"
+	local timeout="$DEFAULT_TIMEOUT"
+
+	# Parse optional flags
+	shift
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--api-key)
+			[[ $# -lt 2 ]] && {
+				echo "Error: --api-key requires a value" >&2
+				return 1
+			}
+			api_key="$2"
+			shift 2
+			;;
+		--timeout)
+			[[ $# -lt 2 ]] && {
+				echo "Error: --timeout requires a value" >&2
+				return 1
+			}
+			timeout="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	# Try gopass fallback if env var not set
+	if [[ -z "$api_key" ]] && command -v gopass &>/dev/null; then
+		api_key=$(gopass show -o "aidevops/VIRUSTOTAL_API_KEY" 2>/dev/null || true)
+	fi
+
+	if [[ -z "$api_key" ]]; then
+		error_json "$ip" "VIRUSTOTAL_API_KEY not set — free tier requires API key (virustotal.com)"
+		return 0
+	fi
+
+	local response
+	response=$(curl -sf \
+		--max-time "$timeout" \
+		-H "x-apikey: ${api_key}" \
+		-H "Accept: application/json" \
+		"${API_BASE}/ip_addresses/${ip}" 2>/dev/null) || {
+		error_json "$ip" "curl request failed"
+		return 0
+	}
+
+	# Validate JSON
+	if ! echo "$response" | jq empty 2>/dev/null; then
+		error_json "$ip" "invalid JSON response"
+		return 0
+	fi
+
+	# Check for API errors
+	local api_error
+	api_error=$(echo "$response" | jq -r '.error.code // empty' 2>/dev/null || true)
+	if [[ -n "$api_error" ]]; then
+		local api_msg
+		api_msg=$(echo "$response" | jq -r '.error.message // "Unknown error"' 2>/dev/null || true)
+		error_json "$ip" "${api_error}: ${api_msg}"
+		return 0
+	fi
+
+	local attrs
+	attrs=$(echo "$response" | jq '.data.attributes // {}')
+
+	# Extract analysis stats
+	local malicious suspicious harmless undetected
+	malicious=$(echo "$attrs" | jq -r '.last_analysis_stats.malicious // 0')
+	suspicious=$(echo "$attrs" | jq -r '.last_analysis_stats.suspicious // 0')
+	harmless=$(echo "$attrs" | jq -r '.last_analysis_stats.harmless // 0')
+	undetected=$(echo "$attrs" | jq -r '.last_analysis_stats.undetected // 0')
+
+	local total=$((malicious + suspicious + harmless + undetected))
+
+	# Calculate score: weighted ratio of malicious+suspicious to total engines
+	# malicious counts fully, suspicious counts at half weight
+	local score=0
+	if [[ "$total" -gt 0 ]]; then
+		local weighted=$((malicious * 100 + suspicious * 50))
+		score=$((weighted / total))
+		# Cap at 100
+		if [[ "$score" -gt 100 ]]; then
+			score=100
+		fi
+	fi
+
+	local is_listed=false
+	if [[ "$malicious" -gt 0 ]]; then
+		is_listed=true
+	fi
+
+	local risk_level
+	risk_level=$(score_to_risk "$score")
+
+	# Extract metadata
+	local reputation as_owner country network
+	reputation=$(echo "$attrs" | jq -r '.reputation // 0')
+	as_owner=$(echo "$attrs" | jq -r '.as_owner // "unknown"')
+	country=$(echo "$attrs" | jq -r '.country // "unknown"')
+	network=$(echo "$attrs" | jq -r '.network // "unknown"')
+
+	jq -n \
+		--arg provider "$PROVIDER_NAME" \
+		--arg ip "$ip" \
+		--argjson score "$score" \
+		--arg risk_level "$risk_level" \
+		--argjson is_listed "$is_listed" \
+		--argjson malicious "$malicious" \
+		--argjson suspicious "$suspicious" \
+		--argjson harmless "$harmless" \
+		--argjson undetected "$undetected" \
+		--argjson reputation "$reputation" \
+		--arg as_owner "$as_owner" \
+		--arg country "$country" \
+		--arg network "$network" \
+		--argjson raw "$attrs" \
+		'{
+            provider: $provider,
+            ip: $ip,
+            score: $score,
+            risk_level: $risk_level,
+            is_listed: $is_listed,
+            malicious: $malicious,
+            suspicious: $suspicious,
+            harmless: $harmless,
+            undetected: $undetected,
+            reputation: $reputation,
+            as_owner: $as_owner,
+            country: $country,
+            network: $network,
+            raw: $raw
+        }'
+	return 0
+}
+
+# Provider info
+cmd_info() {
+	jq -n \
+		--arg name "$PROVIDER_NAME" \
+		--arg display "$PROVIDER_DISPLAY" \
+		'{
+            name: $name,
+            display: $display,
+            requires_key: true,
+            key_env: "VIRUSTOTAL_API_KEY",
+            free_tier: "4 req/min, 500/day, 15.5K/month",
+            url: "https://www.virustotal.com/",
+            api_docs: "https://developers.virustotal.com/reference/ip-object"
+        }'
+	return 0
+}
+
+# Dispatch
+case "${1:-}" in
+check)
+	shift
+	cmd_check "$@"
+	;;
+info)
+	cmd_info
+	;;
+*)
+	echo "Usage: $(basename "$0") check <ip> [--api-key <key>] [--timeout <s>]" >&2
+	echo "       $(basename "$0") info" >&2
+	exit 1
+	;;
+esac

--- a/.agents/tools/security/ip-reputation.md
+++ b/.agents/tools/security/ip-reputation.md
@@ -20,7 +20,7 @@ tools:
 - **Purpose**: Vet VPS/server/proxy IPs before purchase or deployment — check if they are burned (blacklisted, flagged)
 - **Helper**: `ip-reputation-helper.sh`
 - **Slash command**: `/ip-check <ip>`
-- **Providers**: 10 providers (5 free/no-key, 5 free-tier with API key)
+- **Providers**: 11 providers (5 free/no-key, 6 free-tier with API key)
 - **Output formats**: `table` (default), `json`, `markdown`
 - **Cache**: SQLite, per-provider TTL (1h–7d)
 
@@ -107,6 +107,7 @@ ip-reputation-helper.sh cache-clear --help
 | Provider | What it checks | Free Limit | Cache TTL |
 |----------|---------------|------------|-----------|
 | `abuseipdb` | Community abuse reports | 1,000/day | 24h |
+| `virustotal` | 70+ AV engine IP analysis | 500/day | 24h |
 | `ipqualityscore` | Fraud/proxy/VPN detection | 5,000/month | 24h |
 | `scamalytics` | Fraud scoring | 5,000/month | 24h |
 | `shodan` | Open ports, vulns, tags | Free key, limited credits | 7d |
@@ -205,6 +206,7 @@ Store keys via `aidevops secret set NAME` (never paste in conversation):
 
 ```bash
 aidevops secret set ABUSEIPDB_API_KEY
+aidevops secret set VIRUSTOTAL_API_KEY
 aidevops secret set IPQUALITYSCORE_API_KEY
 aidevops secret set SCAMALYTICS_API_KEY
 aidevops secret set SHODAN_API_KEY


### PR DESCRIPTION
WIP - incremental commits

## Summary
- Add VirusTotal IP reputation provider (`ip-rep-virustotal.sh`) using VT API v3
- Wire into `ip-reputation-helper.sh` as 11th provider
- Update `ip-reputation.md` documentation

Ref #1853