### PR TITLE
t1200.5: CLI interface and agent framework integration for IP reputation checks

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -384,7 +384,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | Voice | `tools/voice/speech-to-speech.md`, `voice-helper.sh talk` (voice bridge) |
 | Email testing | `services/email/email-testing.md` (overview), `services/email/email-design-test.md`, `services/email/email-delivery-test.md`, `email-test-suite-helper.sh` |
 | Encryption | `tools/credentials/encryption-stack.md` (decision tree), `tools/credentials/sops.md`, `tools/credentials/gocryptfs.md`, `tools/credentials/gopass.md` |
-| Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting), `tools/security/ip-reputation.md` (IP reputation), `/ip-check <ip>` |
+| Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting), `tools/security/ip-reputation.md` (IP reputation), `tools/security/cdn-origin-ip.md` (CDN origin leak), `/ip-check <ip>`, `aidevops ip-check` |
 | Cloud GPU | `tools/infrastructure/cloud-gpu.md` |
 | Containers | `tools/containers/orbstack.md` |
 | Networking | `services/networking/tailscale.md` |

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -2637,6 +2637,7 @@ cmd_help() {
 	echo "  auto-update <cmd>  Manage automatic update polling (enable/disable/status)"
 	echo "  update-tools       Check for outdated tools (--update to auto-update)"
 	echo "  repos [cmd]        Manage registered projects (list/add/remove/clean)"
+	echo "  ip-check <cmd>     IP reputation checks (check/batch/report/providers)"
 	echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
 	echo "  detect             Find and register aidevops projects"
 	echo "  uninstall          Remove aidevops from your system"
@@ -2656,6 +2657,13 @@ cmd_help() {
 	echo "  aidevops update-tools        # Check for outdated tools"
 	echo "  aidevops update-tools -u     # Update all outdated tools"
 	echo "  aidevops uninstall           # Remove aidevops"
+	echo ""
+	echo "IP Reputation:"
+	echo "  aidevops ip-check check <ip> # Check IP reputation across providers"
+	echo "  aidevops ip-check batch <f>  # Batch check IPs from file"
+	echo "  aidevops ip-check report <ip># Generate markdown report"
+	echo "  aidevops ip-check providers  # List available providers"
+	echo "  aidevops ip-check cache-stats# Show cache statistics"
 	echo ""
 	echo "Secrets:"
 	echo "  aidevops secret set NAME     # Store a secret (hidden input)"
@@ -2787,6 +2795,19 @@ main() {
 		;;
 	detect | scan)
 		cmd_detect
+		;;
+	ip-check | ip_check)
+		shift
+		local ip_rep_helper="$AGENTS_DIR/scripts/ip-reputation-helper.sh"
+		if [[ ! -f "$ip_rep_helper" ]]; then
+			ip_rep_helper="$INSTALL_DIR/.agents/scripts/ip-reputation-helper.sh"
+		fi
+		if [[ -f "$ip_rep_helper" ]]; then
+			bash "$ip_rep_helper" "$@"
+		else
+			print_error "ip-reputation-helper.sh not found. Run: aidevops update"
+			exit 1
+		fi
 		;;
 	secret | secrets)
 		shift


### PR DESCRIPTION
## Summary

- Add `aidevops ip-check` CLI command to `aidevops.sh`, delegating to `ip-reputation-helper.sh` with fallback from deployed to repo path
- Add help text and examples section for the new command in `cmd_help()`
- Update AGENTS.md security progressive disclosure to include `cdn-origin-ip.md` and `aidevops ip-check` CLI reference

## Changes

**aidevops.sh:**
- New dispatch case `ip-check | ip_check` following existing pattern (secret, auto-update)
- Help text in Commands section and dedicated "IP Reputation" examples block
- Supports all subcommands: `check`, `batch`, `report`, `providers`, `cache-stats`, `cache-clear`

**.agents/AGENTS.md:**
- Security row now includes `cdn-origin-ip.md` (CDN origin leak detection) and `aidevops ip-check` CLI reference

## Testing

- ShellCheck: zero violations on `aidevops.sh`
- Pattern matches existing CLI delegation (secret-helper.sh, auto-update-helper.sh)

Ref #1854