### PR TITLE
t004.1: Design multi-org data isolation schema and tenant context model

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -383,6 +383,7 @@ Orchestration agents can create drafts in `draft/` for reusable parallel process
 | ComfyUI | `tools/ai-generation/comfy-cli.md`, `comfy-cli-helper.sh` |
 | Voice | `tools/voice/speech-to-speech.md`, `voice-helper.sh talk` (voice bridge) |
 | Email testing | `services/email/email-testing.md` (overview), `services/email/email-design-test.md`, `services/email/email-delivery-test.md`, `email-test-suite-helper.sh` |
+| Multi-org | `services/database/multi-org-isolation.md` (schema, RLS, context model), `multi-org-helper.sh` |
 | Encryption | `tools/credentials/encryption-stack.md` (decision tree), `tools/credentials/sops.md`, `tools/credentials/gocryptfs.md`, `tools/credentials/gopass.md` |
 | Security | `tools/security/tirith.md` (terminal guard), `tools/security/shannon.md` (pentesting), `tools/security/ip-reputation.md` (IP reputation), `tools/security/cdn-origin-ip.md` (CDN origin leak), `/ip-check <ip>`, `aidevops ip-check` |
 | Cloud GPU | `tools/infrastructure/cloud-gpu.md` |

--- a/.agents/scripts/multi-org-helper.sh
+++ b/.agents/scripts/multi-org-helper.sh
@@ -1,0 +1,519 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+# Multi-Org Helper - Organisation management and tenant context operations
+# Manages multi-org data isolation for aidevops framework
+#
+# Schema: .agents/services/database/schemas/multi-org.ts
+# Context: .agents/services/database/schemas/tenant-context.ts
+# Design: .agents/services/database/multi-org-isolation.md
+#
+# Author: AI DevOps Framework
+# Version: 1.0.0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+readonly CONFIG_DIR="$HOME/.config/aidevops"
+readonly MULTI_ORG_CONFIG="$CONFIG_DIR/multi-org-config.json"
+readonly MULTI_ORG_CONFIG_TEMPLATE="${SCRIPT_DIR}/../../configs/multi-org-config.json.txt"
+readonly ORGS_DIR="$CONFIG_DIR/organisations"
+readonly ACTIVE_ORG_FILE="$CONFIG_DIR/active-org"
+readonly PROJECT_ORG_FILE=".aidevops-org"
+
+# Slug validation: lowercase alphanumeric, hyphens only, 3-63 chars
+readonly SLUG_REGEX='^[a-z][a-z0-9-]{1,61}[a-z0-9]$'
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+validate_slug() {
+	local slug="$1"
+	if [[ ! "$slug" =~ $SLUG_REGEX ]]; then
+		print_error "Invalid org slug: '$slug'. Use lowercase alphanumeric and hyphens, 3-63 chars."
+		return 1
+	fi
+	return 0
+}
+
+validate_role() {
+	local role="$1"
+	case "$role" in
+	owner | admin | member | viewer) return 0 ;;
+	*)
+		print_error "Invalid role: '$role'. Must be: owner, admin, member, viewer."
+		return 1
+		;;
+	esac
+}
+
+validate_plan() {
+	local plan="$1"
+	case "$plan" in
+	free | pro | enterprise) return 0 ;;
+	*)
+		print_error "Invalid plan: '$plan'. Must be: free, pro, enterprise."
+		return 1
+		;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# Org directory helpers
+# ---------------------------------------------------------------------------
+
+ensure_orgs_dir() {
+	if [[ ! -d "$ORGS_DIR" ]]; then
+		mkdir -p "$ORGS_DIR"
+		chmod 700 "$ORGS_DIR"
+	fi
+	return 0
+}
+
+get_org_dir() {
+	local slug="$1"
+	echo "$ORGS_DIR/$slug"
+	return 0
+}
+
+get_org_metadata_file() {
+	local slug="$1"
+	echo "$ORGS_DIR/$slug/org.json"
+	return 0
+}
+
+org_exists() {
+	local slug="$1"
+	local org_dir
+	org_dir="$(get_org_dir "$slug")"
+	[[ -d "$org_dir" && -f "$org_dir/org.json" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Active org resolution
+# ---------------------------------------------------------------------------
+
+get_active_org() {
+	# Priority: 1) Project override, 2) Global active, 3) empty (no default)
+	if [[ -f "$PROJECT_ORG_FILE" ]]; then
+		local project_org
+		project_org=$(tr -d '[:space:]' <"$PROJECT_ORG_FILE" 2>/dev/null)
+		if [[ -n "$project_org" ]]; then
+			echo "$project_org"
+			return 0
+		fi
+	fi
+
+	if [[ -f "$ACTIVE_ORG_FILE" ]]; then
+		local active
+		active=$(tr -d '[:space:]' <"$ACTIVE_ORG_FILE" 2>/dev/null)
+		if [[ -n "$active" ]]; then
+			echo "$active"
+			return 0
+		fi
+	fi
+
+	# No default — multi-org requires explicit selection
+	echo ""
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_init() {
+	ensure_orgs_dir
+
+	# Copy config template if no config exists
+	if [[ ! -f "$MULTI_ORG_CONFIG" && -f "$MULTI_ORG_CONFIG_TEMPLATE" ]]; then
+		cp "$MULTI_ORG_CONFIG_TEMPLATE" "$MULTI_ORG_CONFIG"
+		chmod 600 "$MULTI_ORG_CONFIG"
+		print_success "Created multi-org config: $MULTI_ORG_CONFIG"
+	fi
+
+	print_success "Multi-org storage initialised: $ORGS_DIR"
+	return 0
+}
+
+cmd_create() {
+	local slug="$1"
+	local name="${2:-$slug}"
+	local plan="${3:-free}"
+
+	validate_slug "$slug" || return 1
+	validate_plan "$plan" || return 1
+	ensure_orgs_dir
+
+	local org_dir
+	org_dir="$(get_org_dir "$slug")"
+
+	if [[ -d "$org_dir" ]]; then
+		print_error "Organisation '$slug' already exists."
+		return 1
+	fi
+
+	mkdir -p "$org_dir"
+	chmod 700 "$org_dir"
+
+	# Write org metadata
+	local metadata_file
+	metadata_file="$(get_org_metadata_file "$slug")"
+	local created_at
+	created_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+	cat >"$metadata_file" <<METADATA_EOF
+{
+  "slug": "$slug",
+  "name": "$name",
+  "plan": "$plan",
+  "created_at": "$created_at",
+  "settings": {}
+}
+METADATA_EOF
+	chmod 600 "$metadata_file"
+
+	print_success "Created organisation: $slug ($name) [plan: $plan]"
+	return 0
+}
+
+cmd_delete() {
+	local slug="$1"
+
+	validate_slug "$slug" || return 1
+
+	if ! org_exists "$slug"; then
+		print_error "Organisation '$slug' does not exist."
+		return 1
+	fi
+
+	local org_dir
+	org_dir="$(get_org_dir "$slug")"
+
+	# Safety: check if this is the active org
+	local active_org
+	active_org="$(get_active_org)"
+	if [[ "$active_org" == "$slug" ]]; then
+		print_warning "Removing active org. Clearing active-org pointer."
+		rm -f "$ACTIVE_ORG_FILE"
+	fi
+
+	rm -rf "$org_dir"
+	print_success "Deleted organisation: $slug"
+	return 0
+}
+
+cmd_list() {
+	ensure_orgs_dir
+
+	local active_org
+	active_org="$(get_active_org)"
+
+	if [[ ! -d "$ORGS_DIR" ]] || [[ -z "$(ls -A "$ORGS_DIR" 2>/dev/null)" ]]; then
+		print_info "No organisations found. Create one with: multi-org-helper.sh create <slug> <name>"
+		return 0
+	fi
+
+	printf "%-20s %-30s %-12s %s\n" "SLUG" "NAME" "PLAN" "STATUS"
+	printf "%-20s %-30s %-12s %s\n" "----" "----" "----" "------"
+
+	local slug
+	for org_dir in "$ORGS_DIR"/*/; do
+		[[ -d "$org_dir" ]] || continue
+		slug="$(basename "$org_dir")"
+		local metadata_file="$org_dir/org.json"
+
+		if [[ -f "$metadata_file" ]]; then
+			local name plan status
+			name=$(grep -o '"name": *"[^"]*"' "$metadata_file" | head -1 | sed 's/"name": *"//;s/"$//')
+			plan=$(grep -o '"plan": *"[^"]*"' "$metadata_file" | head -1 | sed 's/"plan": *"//;s/"$//')
+			status=""
+			if [[ "$slug" == "$active_org" ]]; then
+				status="(active)"
+			fi
+			printf "%-20s %-30s %-12s %s\n" "$slug" "$name" "$plan" "$status"
+		fi
+	done
+
+	return 0
+}
+
+cmd_switch() {
+	local slug="$1"
+
+	validate_slug "$slug" || return 1
+
+	if ! org_exists "$slug"; then
+		print_error "Organisation '$slug' does not exist."
+		return 1
+	fi
+
+	ensure_orgs_dir
+	echo "$slug" >"$ACTIVE_ORG_FILE"
+	chmod 600 "$ACTIVE_ORG_FILE"
+
+	print_success "Switched active organisation to: $slug"
+	return 0
+}
+
+cmd_use() {
+	local slug="$1"
+
+	if [[ "$slug" == "--clear" ]]; then
+		rm -f "$PROJECT_ORG_FILE"
+		print_success "Cleared project-level organisation override."
+		return 0
+	fi
+
+	validate_slug "$slug" || return 1
+
+	if ! org_exists "$slug"; then
+		print_error "Organisation '$slug' does not exist."
+		return 1
+	fi
+
+	echo "$slug" >"$PROJECT_ORG_FILE"
+	print_success "Set project-level organisation to: $slug"
+	print_info "Add '$PROJECT_ORG_FILE' to .gitignore if not already present."
+	return 0
+}
+
+cmd_status() {
+	local active_org
+	active_org="$(get_active_org)"
+
+	echo "Multi-Org Status"
+	echo "================"
+	echo ""
+
+	if [[ -n "$active_org" ]]; then
+		echo "Active org: $active_org"
+
+		if org_exists "$active_org"; then
+			local metadata_file
+			metadata_file="$(get_org_metadata_file "$active_org")"
+			if [[ -f "$metadata_file" ]]; then
+				local name plan
+				name=$(grep -o '"name": *"[^"]*"' "$metadata_file" | head -1 | sed 's/"name": *"//;s/"$//')
+				plan=$(grep -o '"plan": *"[^"]*"' "$metadata_file" | head -1 | sed 's/"plan": *"//;s/"$//')
+				echo "  Name: $name"
+				echo "  Plan: $plan"
+			fi
+		fi
+	else
+		echo "Active org: (none)"
+	fi
+
+	echo ""
+
+	# Resolution source
+	if [[ -f "$PROJECT_ORG_FILE" ]]; then
+		local project_org
+		project_org=$(tr -d '[:space:]' <"$PROJECT_ORG_FILE" 2>/dev/null)
+		echo "Resolved via: project_config ($PROJECT_ORG_FILE = $project_org)"
+	elif [[ -f "$ACTIVE_ORG_FILE" ]]; then
+		echo "Resolved via: global ($ACTIVE_ORG_FILE)"
+	else
+		echo "Resolved via: (no org context)"
+	fi
+
+	echo ""
+
+	# Count orgs
+	local org_count=0
+	if [[ -d "$ORGS_DIR" ]]; then
+		org_count=$(find "$ORGS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+	fi
+	echo "Total organisations: $org_count"
+
+	return 0
+}
+
+cmd_info() {
+	local slug="$1"
+
+	validate_slug "$slug" || return 1
+
+	if ! org_exists "$slug"; then
+		print_error "Organisation '$slug' does not exist."
+		return 1
+	fi
+
+	local metadata_file
+	metadata_file="$(get_org_metadata_file "$slug")"
+
+	if [[ -f "$metadata_file" ]]; then
+		cat "$metadata_file"
+	else
+		print_error "No metadata found for '$slug'."
+		return 1
+	fi
+
+	return 0
+}
+
+cmd_set_plan() {
+	local slug="$1"
+	local plan="$2"
+
+	validate_slug "$slug" || return 1
+	validate_plan "$plan" || return 1
+
+	if ! org_exists "$slug"; then
+		print_error "Organisation '$slug' does not exist."
+		return 1
+	fi
+
+	local metadata_file
+	metadata_file="$(get_org_metadata_file "$slug")"
+
+	if [[ ! -f "$metadata_file" ]]; then
+		print_error "No metadata found for '$slug'."
+		return 1
+	fi
+
+	# Update plan in metadata (simple sed replacement)
+	local tmp_file="${metadata_file}.tmp"
+	sed "s/\"plan\": *\"[^\"]*\"/\"plan\": \"$plan\"/" "$metadata_file" >"$tmp_file"
+	mv "$tmp_file" "$metadata_file"
+	chmod 600 "$metadata_file"
+
+	print_success "Updated plan for '$slug' to: $plan"
+	return 0
+}
+
+cmd_context() {
+	# Output current org context as environment variables (for eval)
+	local active_org
+	active_org="$(get_active_org)"
+
+	if [[ -z "$active_org" ]]; then
+		print_error "No active organisation. Use 'switch' or 'use' to set one."
+		return 1
+	fi
+
+	if ! org_exists "$active_org"; then
+		print_error "Active organisation '$active_org' does not exist."
+		return 1
+	fi
+
+	local metadata_file
+	metadata_file="$(get_org_metadata_file "$active_org")"
+
+	local name plan
+	name=$(grep -o '"name": *"[^"]*"' "$metadata_file" | head -1 | sed 's/"name": *"//;s/"$//')
+	plan=$(grep -o '"plan": *"[^"]*"' "$metadata_file" | head -1 | sed 's/"plan": *"//;s/"$//')
+
+	echo "export AIDEVOPS_ORG_SLUG=\"$active_org\""
+	echo "export AIDEVOPS_ORG_NAME=\"$name\""
+	echo "export AIDEVOPS_ORG_PLAN=\"$plan\""
+
+	return 0
+}
+
+cmd_help() {
+	cat <<'HELP_EOF'
+Multi-Org Helper - Organisation management and tenant context
+
+Usage: multi-org-helper.sh <command> [arguments]
+
+Commands:
+  init                          Initialise multi-org storage
+  create <slug> [name] [plan]   Create a new organisation
+  delete <slug>                 Delete an organisation
+  list                          List all organisations
+  switch <slug>                 Set global active organisation
+  use <slug|--clear>            Set/clear project-level organisation
+  status                        Show current org context and resolution
+  info <slug>                   Show organisation metadata
+  set-plan <slug> <plan>        Update organisation plan (free|pro|enterprise)
+  context                       Output org context as env vars (for eval)
+  help                          Show this help
+
+Examples:
+  multi-org-helper.sh create acme-corp "Acme Corporation" pro
+  multi-org-helper.sh switch acme-corp
+  multi-org-helper.sh use acme-corp          # Per-project override
+  eval "$(multi-org-helper.sh context)"      # Load org context into shell
+
+Plans: free, pro, enterprise
+Roles: owner, admin, member, viewer
+
+Schema: .agents/services/database/schemas/multi-org.ts
+Design: .agents/services/database/multi-org-isolation.md
+HELP_EOF
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main dispatch
+# ---------------------------------------------------------------------------
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	init) cmd_init ;;
+	create)
+		if [[ $# -lt 1 ]]; then
+			print_error "Usage: multi-org-helper.sh create <slug> [name] [plan]"
+			return 1
+		fi
+		cmd_create "$@"
+		;;
+	delete)
+		if [[ $# -lt 1 ]]; then
+			print_error "Usage: multi-org-helper.sh delete <slug>"
+			return 1
+		fi
+		cmd_delete "$1"
+		;;
+	list) cmd_list ;;
+	switch)
+		if [[ $# -lt 1 ]]; then
+			print_error "Usage: multi-org-helper.sh switch <slug>"
+			return 1
+		fi
+		cmd_switch "$1"
+		;;
+	use)
+		if [[ $# -lt 1 ]]; then
+			print_error "Usage: multi-org-helper.sh use <slug|--clear>"
+			return 1
+		fi
+		cmd_use "$1"
+		;;
+	status) cmd_status ;;
+	info)
+		if [[ $# -lt 1 ]]; then
+			print_error "Usage: multi-org-helper.sh info <slug>"
+			return 1
+		fi
+		cmd_info "$1"
+		;;
+	set-plan)
+		if [[ $# -lt 2 ]]; then
+			print_error "Usage: multi-org-helper.sh set-plan <slug> <plan>"
+			return 1
+		fi
+		cmd_set_plan "$1" "$2"
+		;;
+	context) cmd_context ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		print_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/services/database/multi-org-isolation.md
+++ b/.agents/services/database/multi-org-isolation.md
@@ -1,0 +1,535 @@
+---
+description: Multi-org data isolation schema and tenant context model
+mode: subagent
+model: sonnet
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# Multi-Org Data Isolation
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Schema**: `.agents/services/database/schemas/multi-org.ts`
+- **Context model**: `.agents/services/database/schemas/tenant-context.ts`
+- **Config template**: `configs/multi-org-config.json.txt`
+- **Helper**: `.agents/scripts/multi-org-helper.sh`
+- **Isolation strategy**: Row-level with `org_id` foreign key on all tenant-scoped tables
+- **Context resolution**: Request header > session > project config > default org
+
+**Sibling tasks**:
+
+- t004.2: Implements tenant-scoped queries and middleware from this schema
+- t004.3: Implements org-switching UI using the context model
+- t004.4: Implements AI context isolation per organisation
+- t004.5: Integration tests for data boundaries
+
+<!-- AI-CONTEXT-END -->
+
+## Architecture Overview
+
+### Isolation Strategy: Row-Level Tenancy
+
+We use **row-level tenancy** (shared database, shared schema, `org_id` column) rather than
+schema-per-tenant or database-per-tenant. Rationale:
+
+| Strategy | Pros | Cons | When to use |
+|----------|------|------|-------------|
+| **Row-level** (chosen) | Simple ops, easy cross-org queries for superadmin, single migration path | Requires discipline on every query | <1000 orgs, shared infrastructure |
+| Schema-per-tenant | Strong isolation, easy per-tenant backup | Migration complexity, connection pooling | Regulated industries |
+| Database-per-tenant | Strongest isolation | Operational nightmare at scale | Enterprise with dedicated infra |
+
+Row-level is the right choice for aidevops because:
+
+1. Organisations share the same feature set (no per-tenant customisation)
+2. Superadmin needs cross-org visibility for framework operations
+3. Single migration path keeps the framework simple
+4. PostgreSQL Row-Level Security (RLS) provides enforcement at the database level
+
+### Data Classification
+
+All tables fall into one of three categories:
+
+| Category | `org_id` column | RLS policy | Examples |
+|----------|----------------|------------|---------|
+| **Org-scoped** | Required, NOT NULL | Enforced | credentials, projects, ai_sessions, api_keys |
+| **Org-optional** | Nullable | Conditional | memories, patterns (can be global or org-specific) |
+| **Global** | None | None | organisations, users, system_config |
+
+## Schema Design
+
+### Entity Relationship
+
+```text
+organisations 1──* org_memberships *──1 users
+     │                                    │
+     │ org_id                             │ user_id
+     ├──* credentials                     │
+     ├──* projects                        │
+     ├──* ai_sessions ────────────────────┘
+     ├──* api_key_sets
+     ├──* org_settings
+     └──* audit_log
+```
+
+### Core Tables
+
+#### organisations
+
+The root tenant entity. Every org-scoped record references this.
+
+```typescript
+export const organisations = pgTable('organisations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  slug: varchar('slug', { length: 63 }).notNull().unique(),
+  name: text('name').notNull(),
+  plan: text('plan', { enum: ['free', 'pro', 'enterprise'] })
+    .notNull().default('free'),
+  settings: jsonb('settings').$type<OrgSettings>().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull().defaultNow().$onUpdate(() => new Date()),
+});
+```
+
+**Design decisions**:
+
+- `slug` is the URL-safe identifier (e.g., `acme-corp`), unique, used in routing
+- `id` (UUID) is the foreign key target — never expose UUIDs in URLs
+- `plan` uses text enum (easier to extend than pgEnum)
+- `settings` JSONB for org-level preferences without schema migrations
+
+#### users
+
+Global user table — users exist independently of organisations.
+
+```typescript
+export const users = pgTable('users', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  email: varchar('email', { length: 255 }).notNull().unique(),
+  name: text('name'),
+  avatarUrl: text('avatar_url'),
+  lastActiveOrgId: uuid('last_active_org_id')
+    .references(() => organisations.id, { onDelete: 'set null' }),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull().defaultNow().$onUpdate(() => new Date()),
+});
+```
+
+**Design decisions**:
+
+- Users are global — a user can belong to multiple organisations
+- `lastActiveOrgId` tracks the most recent org context for session restoration
+- No password field — authentication is delegated (OAuth, passkeys, etc.)
+
+#### org_memberships
+
+Join table with role. This is the authorisation boundary.
+
+```typescript
+export const roleEnum = pgEnum('org_role', [
+  'owner',    // Full control, can delete org
+  'admin',    // Manage members, settings, all data
+  'member',   // Read/write org data
+  'viewer',   // Read-only access
+]);
+
+export const org_memberships = pgTable('org_memberships', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull()
+    .references(() => organisations.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id').notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  role: roleEnum('role').notNull().default('member'),
+  invitedBy: uuid('invited_by')
+    .references(() => users.id, { onDelete: 'set null' }),
+  joinedAt: timestamp('joined_at', { withTimezone: true })
+    .notNull().defaultNow(),
+}, (table) => [
+  uniqueIndex('org_memberships_org_user_idx')
+    .on(table.orgId, table.userId),
+  index('org_memberships_user_idx').on(table.userId),
+]);
+```
+
+**Design decisions**:
+
+- Composite unique on `(org_id, user_id)` — one membership per org per user
+- `role` uses pgEnum (fixed set, enforced at DB level)
+- `cascade` on org/user delete — membership is meaningless without both
+- `invitedBy` for audit trail
+
+### Org-Scoped Tables Pattern
+
+Every org-scoped table follows this pattern:
+
+```typescript
+// Reusable org-scoping columns
+const orgScoped = {
+  orgId: uuid('org_id').notNull()
+    .references(() => organisations.id, { onDelete: 'cascade' }),
+};
+
+// Example: org-scoped credentials
+export const org_credentials = pgTable('org_credentials', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  ...orgScoped,
+  service: varchar('service', { length: 100 }).notNull(),
+  keyName: varchar('key_name', { length: 100 }).notNull(),
+  // Encrypted value — never stored in plaintext
+  encryptedValue: text('encrypted_value').notNull(),
+  createdBy: uuid('created_by')
+    .references(() => users.id, { onDelete: 'set null' }),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull().defaultNow().$onUpdate(() => new Date()),
+}, (table) => [
+  uniqueIndex('org_credentials_org_service_key_idx')
+    .on(table.orgId, table.service, table.keyName),
+  index('org_credentials_org_idx').on(table.orgId),
+]);
+```
+
+### AI Session Isolation
+
+Critical for t004.4 — AI sessions must be strictly org-scoped.
+
+```typescript
+export const ai_sessions = pgTable('ai_sessions', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  ...orgScoped,
+  userId: uuid('user_id').notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  model: varchar('model', { length: 100 }),
+  // Session context — org-specific memories, patterns, preferences
+  context: jsonb('context').$type<SessionContext>().default({}),
+  startedAt: timestamp('started_at', { withTimezone: true })
+    .notNull().defaultNow(),
+  endedAt: timestamp('ended_at', { withTimezone: true }),
+}, (table) => [
+  index('ai_sessions_org_idx').on(table.orgId),
+  index('ai_sessions_user_idx').on(table.userId),
+  index('ai_sessions_org_user_idx').on(table.orgId, table.userId),
+]);
+```
+
+### Org-Scoped Memory
+
+Memories can be global (personal) or org-scoped (shared within org).
+
+```typescript
+export const memories = pgTable('memories', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id')
+    .references(() => organisations.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id').notNull()
+    .references(() => users.id, { onDelete: 'cascade' }),
+  content: text('content').notNull(),
+  confidence: text('confidence', { enum: ['low', 'medium', 'high'] })
+    .notNull().default('medium'),
+  namespace: varchar('namespace', { length: 100 }),
+  accessCount: integer('access_count').notNull().default(0),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull().defaultNow(),
+}, (table) => [
+  index('memories_org_idx').on(table.orgId),
+  index('memories_user_idx').on(table.userId),
+  // Partial index: org-scoped memories only
+  index('memories_org_scoped_idx')
+    .on(table.orgId, table.userId)
+    .where(sql`org_id IS NOT NULL`),
+]);
+```
+
+### Audit Log
+
+All org-scoped mutations are logged for compliance and debugging.
+
+```typescript
+export const audit_log = pgTable('audit_log', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id').notNull()
+    .references(() => organisations.id, { onDelete: 'cascade' }),
+  userId: uuid('user_id')
+    .references(() => users.id, { onDelete: 'set null' }),
+  action: varchar('action', { length: 100 }).notNull(),
+  entityType: varchar('entity_type', { length: 100 }).notNull(),
+  entityId: uuid('entity_id'),
+  metadata: jsonb('metadata').$type<Record<string, unknown>>().default({}),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull().defaultNow(),
+}, (table) => [
+  index('audit_log_org_idx').on(table.orgId),
+  index('audit_log_org_action_idx').on(table.orgId, table.action),
+  index('audit_log_created_idx').on(table.createdAt),
+]);
+```
+
+## Row-Level Security (RLS)
+
+PostgreSQL RLS enforces isolation at the database level, independent of application code.
+This is the safety net — even if application code has a bug, RLS prevents cross-org leaks.
+
+### Setup
+
+```sql
+-- Enable RLS on all org-scoped tables
+ALTER TABLE org_credentials ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_log ENABLE ROW LEVEL SECURITY;
+
+-- Application role (used by the app, not superuser)
+CREATE ROLE app_user;
+
+-- Policy: users can only see rows for their current org
+CREATE POLICY org_isolation ON org_credentials
+  FOR ALL
+  TO app_user
+  USING (org_id = current_setting('app.current_org_id')::uuid);
+
+CREATE POLICY org_isolation ON ai_sessions
+  FOR ALL
+  TO app_user
+  USING (org_id = current_setting('app.current_org_id')::uuid);
+
+-- Memories: org-scoped OR personal (org_id IS NULL and user owns it)
+CREATE POLICY org_or_personal ON memories
+  FOR ALL
+  TO app_user
+  USING (
+    org_id = current_setting('app.current_org_id')::uuid
+    OR (org_id IS NULL AND user_id = current_setting('app.current_user_id')::uuid)
+  );
+
+CREATE POLICY org_isolation ON audit_log
+  FOR ALL
+  TO app_user
+  USING (org_id = current_setting('app.current_org_id')::uuid);
+```
+
+### Setting Context Per Request
+
+```typescript
+// In middleware (before any query)
+await db.execute(
+  sql`SELECT set_config('app.current_org_id', ${orgId}, true)`
+);
+await db.execute(
+  sql`SELECT set_config('app.current_user_id', ${userId}, true)`
+);
+// `true` = local to transaction only
+```
+
+## Tenant Context Model
+
+### Context Resolution Chain
+
+The tenant context determines which organisation's data is accessed. Resolution follows
+a priority chain (first match wins):
+
+```text
+1. Request header: X-Org-Id (API calls, worker dispatch)
+2. Session/cookie: org_id claim in JWT or session store
+3. URL path: /org/:slug/... (web UI routing)
+4. Project config: .aidevops-tenant file (CLI/local dev)
+5. User default: users.last_active_org_id
+6. Single org: If user belongs to exactly one org, use it
+7. Error: No org context — return 403 or prompt org selection
+```
+
+### TenantContext Type
+
+```typescript
+/**
+ * Immutable tenant context — created once per request, passed through
+ * the entire call chain. Never mutated after creation.
+ */
+export interface TenantContext {
+  /** Organisation ID (UUID) — used for all DB queries */
+  readonly orgId: string;
+  /** Organisation slug — used for URL routing, display */
+  readonly orgSlug: string;
+  /** User ID — the authenticated user */
+  readonly userId: string;
+  /** User's role in this organisation */
+  readonly role: OrgRole;
+  /** How the org context was resolved */
+  readonly resolvedVia:
+    | 'header'
+    | 'session'
+    | 'url'
+    | 'project_config'
+    | 'user_default'
+    | 'single_org';
+  /** Organisation plan (affects feature gates) */
+  readonly plan: OrgPlan;
+}
+
+export type OrgRole = 'owner' | 'admin' | 'member' | 'viewer';
+export type OrgPlan = 'free' | 'pro' | 'enterprise';
+```
+
+### Middleware Flow
+
+```text
+Request
+  │
+  ▼
+[Auth Middleware] ─── Verify JWT/session → userId
+  │
+  ▼
+[Tenant Middleware] ─── Resolve org context → TenantContext
+  │                     Set RLS variables (app.current_org_id, app.current_user_id)
+  │                     Verify membership (user belongs to org)
+  │                     Attach TenantContext to request
+  │
+  ▼
+[Route Handler] ─── Access ctx.tenant.orgId for queries
+  │                  All queries automatically filtered by RLS
+  │
+  ▼
+[Audit Middleware] ─── Log mutation with orgId, userId, action
+```
+
+### Org Switching
+
+When a user switches organisations (t004.3):
+
+1. Verify user has membership in target org
+2. Update `users.last_active_org_id` to new org
+3. Issue new session token with updated `org_id` claim
+4. Clear any org-specific caches (AI context, memory namespace)
+5. Redirect to org-scoped URL (`/org/:slug/dashboard`)
+
+### Worker/Headless Context
+
+For autonomous workers (supervisor dispatch), tenant context is set via:
+
+```bash
+# In worker dispatch prompt or environment
+X-Org-Id: <org-uuid>
+
+# Or in credential-helper resolution
+credential-helper.sh export --tenant <org-slug>
+```
+
+The worker's entire session operates within that org's data boundary.
+AI memories stored during the session are tagged with the org's namespace.
+
+### Cross-Org Operations (Superadmin)
+
+Superadmin operations bypass RLS by using the database superuser role:
+
+```typescript
+// Superadmin context — no RLS filtering
+const superadminDb = drizzle(superuserPool);
+
+// List all orgs
+const allOrgs = await superadminDb.select().from(organisations);
+
+// Cross-org aggregation
+const orgStats = await superadminDb
+  .select({
+    orgId: ai_sessions.orgId,
+    sessionCount: count(ai_sessions.id),
+  })
+  .from(ai_sessions)
+  .groupBy(ai_sessions.orgId);
+```
+
+## Integration with Existing Multi-Tenant Credentials
+
+The existing `credential-helper.sh` tenant system maps to this schema:
+
+| Existing concept | New schema equivalent |
+|-----------------|----------------------|
+| Tenant name (e.g., `client-acme`) | `organisations.slug` |
+| `~/.config/aidevops/tenants/{name}/` | `org_credentials` table rows |
+| `active-tenant` file | `users.last_active_org_id` |
+| `.aidevops-tenant` project file | Project-level org binding (unchanged) |
+| `credential-helper.sh switch` | Org switch (update session + last_active) |
+
+The file-based credential system continues to work for CLI/local development.
+The database schema adds server-side isolation for hosted/multi-user deployments.
+
+## Migration Path
+
+### Phase 1: Schema Only (this task, t004.1)
+
+- Define schema types and design document
+- No runtime changes — existing credential-helper continues to work
+
+### Phase 2: Middleware (t004.2)
+
+- Implement tenant middleware and scoped query helpers
+- Add RLS policies to database migrations
+
+### Phase 3: UI (t004.3)
+
+- Org switcher component
+- Session context management
+
+### Phase 4: AI Isolation (t004.4)
+
+- Namespace AI sessions, memories, patterns per org
+- Ensure worker dispatch carries org context
+
+### Phase 5: Tests (t004.5)
+
+- Cross-org boundary tests
+- RLS enforcement verification
+- Org switching integration tests
+
+## TypeScript Types
+
+### OrgSettings
+
+```typescript
+export interface OrgSettings {
+  /** Default AI model tier for this org */
+  defaultModelTier?: 'haiku' | 'sonnet' | 'opus';
+  /** Daily budget cap in USD (token-billed providers) */
+  dailyBudgetUsd?: number;
+  /** Allowed model providers */
+  allowedProviders?: string[];
+  /** Feature flags */
+  features?: Record<string, boolean>;
+  /** Custom branding */
+  branding?: {
+    primaryColor?: string;
+    logoUrl?: string;
+  };
+}
+```
+
+### SessionContext
+
+```typescript
+export interface SessionContext {
+  /** Active model for this session */
+  model?: string;
+  /** Session-specific memory namespace */
+  memoryNamespace?: string;
+  /** Accumulated token usage */
+  tokenUsage?: {
+    input: number;
+    output: number;
+  };
+  /** Session metadata */
+  metadata?: Record<string, unknown>;
+}
+```

--- a/.agents/services/database/schemas/multi-org.ts
+++ b/.agents/services/database/schemas/multi-org.ts
@@ -1,0 +1,364 @@
+/**
+ * Multi-Org Data Isolation Schema
+ *
+ * Task: t004.1 — Design multi-org data isolation schema and tenant context model
+ *
+ * This schema defines the database tables for multi-organisation support.
+ * Uses row-level tenancy with PostgreSQL RLS for enforcement.
+ *
+ * Isolation strategy: shared database, shared schema, org_id column on all
+ * tenant-scoped tables. RLS policies enforce isolation at the DB level.
+ *
+ * Related tasks:
+ * - t004.2: Tenant-scoped queries and middleware
+ * - t004.3: Org-switching UI and session context
+ * - t004.4: AI context isolation per organisation
+ * - t004.5: Integration tests for data boundaries
+ */
+
+import {
+  pgTable,
+  pgEnum,
+  uuid,
+  text,
+  varchar,
+  integer,
+  boolean,
+  timestamp,
+  jsonb,
+  index,
+  uniqueIndex,
+} from 'drizzle-orm/pg-core';
+import { relations, sql } from 'drizzle-orm';
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+export const orgRoleEnum = pgEnum('org_role', [
+  'owner',
+  'admin',
+  'member',
+  'viewer',
+]);
+
+// ---------------------------------------------------------------------------
+// Reusable column patterns
+// ---------------------------------------------------------------------------
+
+const timestamps = {
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+};
+
+// ---------------------------------------------------------------------------
+// Global tables (no org_id)
+// ---------------------------------------------------------------------------
+
+/**
+ * Organisations — the root tenant entity.
+ * Every org-scoped record references this table via org_id.
+ */
+export const organisations = pgTable('organisations', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  slug: varchar('slug', { length: 63 }).notNull().unique(),
+  name: text('name').notNull(),
+  plan: text('plan', { enum: ['free', 'pro', 'enterprise'] })
+    .notNull()
+    .default('free'),
+  settings: jsonb('settings').$type<OrgSettings>().default({}),
+  ...timestamps,
+});
+
+/**
+ * Users — global, exist independently of organisations.
+ * A user can belong to multiple organisations via org_memberships.
+ */
+export const users = pgTable('users', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  email: varchar('email', { length: 255 }).notNull().unique(),
+  name: text('name'),
+  avatarUrl: text('avatar_url'),
+  lastActiveOrgId: uuid('last_active_org_id').references(
+    () => organisations.id,
+    { onDelete: 'set null' },
+  ),
+  ...timestamps,
+});
+
+/**
+ * Org memberships — join table between users and organisations.
+ * This is the authorisation boundary: role determines permissions.
+ */
+export const orgMemberships = pgTable(
+  'org_memberships',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organisations.id, { onDelete: 'cascade' }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    role: orgRoleEnum('role').notNull().default('member'),
+    invitedBy: uuid('invited_by').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    joinedAt: timestamp('joined_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('org_memberships_org_user_idx').on(table.orgId, table.userId),
+    index('org_memberships_user_idx').on(table.userId),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Org-scoped tables (require org_id NOT NULL)
+// ---------------------------------------------------------------------------
+
+/**
+ * Org credentials — encrypted API keys and secrets per organisation.
+ * Maps to the existing credential-helper.sh tenant concept.
+ */
+export const orgCredentials = pgTable(
+  'org_credentials',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organisations.id, { onDelete: 'cascade' }),
+    service: varchar('service', { length: 100 }).notNull(),
+    keyName: varchar('key_name', { length: 100 }).notNull(),
+    encryptedValue: text('encrypted_value').notNull(),
+    createdBy: uuid('created_by').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    ...timestamps,
+  },
+  (table) => [
+    uniqueIndex('org_credentials_org_service_key_idx').on(
+      table.orgId,
+      table.service,
+      table.keyName,
+    ),
+    index('org_credentials_org_idx').on(table.orgId),
+  ],
+);
+
+/**
+ * AI sessions — strictly org-scoped.
+ * Each session operates within a single org's data boundary.
+ * Critical for t004.4 (AI context isolation).
+ */
+export const aiSessions = pgTable(
+  'ai_sessions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organisations.id, { onDelete: 'cascade' }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    model: varchar('model', { length: 100 }),
+    context: jsonb('context').$type<SessionContext>().default({}),
+    startedAt: timestamp('started_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    endedAt: timestamp('ended_at', { withTimezone: true }),
+  },
+  (table) => [
+    index('ai_sessions_org_idx').on(table.orgId),
+    index('ai_sessions_user_idx').on(table.userId),
+    index('ai_sessions_org_user_idx').on(table.orgId, table.userId),
+  ],
+);
+
+/**
+ * Memories — can be global (personal) or org-scoped (shared within org).
+ * org_id is nullable: NULL = personal memory, non-NULL = org memory.
+ */
+export const memories = pgTable(
+  'memories',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id').references(() => organisations.id, {
+      onDelete: 'cascade',
+    }),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    content: text('content').notNull(),
+    confidence: text('confidence', { enum: ['low', 'medium', 'high'] })
+      .notNull()
+      .default('medium'),
+    namespace: varchar('namespace', { length: 100 }),
+    accessCount: integer('access_count').notNull().default(0),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index('memories_org_idx').on(table.orgId),
+    index('memories_user_idx').on(table.userId),
+    index('memories_org_scoped_idx')
+      .on(table.orgId, table.userId)
+      .where(sql`org_id IS NOT NULL`),
+  ],
+);
+
+/**
+ * Audit log — all org-scoped mutations are logged.
+ * Append-only for compliance and debugging.
+ */
+export const auditLog = pgTable(
+  'audit_log',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => organisations.id, { onDelete: 'cascade' }),
+    userId: uuid('user_id').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    action: varchar('action', { length: 100 }).notNull(),
+    entityType: varchar('entity_type', { length: 100 }).notNull(),
+    entityId: uuid('entity_id'),
+    metadata: jsonb('metadata')
+      .$type<Record<string, unknown>>()
+      .default({}),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    index('audit_log_org_idx').on(table.orgId),
+    index('audit_log_org_action_idx').on(table.orgId, table.action),
+    index('audit_log_created_idx').on(table.createdAt),
+  ],
+);
+
+// ---------------------------------------------------------------------------
+// Relations (for Drizzle relational queries)
+// ---------------------------------------------------------------------------
+
+export const organisationsRelations = relations(organisations, ({ many }) => ({
+  memberships: many(orgMemberships),
+  credentials: many(orgCredentials),
+  aiSessions: many(aiSessions),
+  memories: many(memories),
+  auditLog: many(auditLog),
+}));
+
+export const usersRelations = relations(users, ({ one, many }) => ({
+  lastActiveOrg: one(organisations, {
+    fields: [users.lastActiveOrgId],
+    references: [organisations.id],
+  }),
+  memberships: many(orgMemberships),
+  aiSessions: many(aiSessions),
+  memories: many(memories),
+}));
+
+export const orgMembershipsRelations = relations(
+  orgMemberships,
+  ({ one }) => ({
+    organisation: one(organisations, {
+      fields: [orgMemberships.orgId],
+      references: [organisations.id],
+    }),
+    user: one(users, {
+      fields: [orgMemberships.userId],
+      references: [users.id],
+    }),
+    inviter: one(users, {
+      fields: [orgMemberships.invitedBy],
+      references: [users.id],
+    }),
+  }),
+);
+
+export const orgCredentialsRelations = relations(orgCredentials, ({ one }) => ({
+  organisation: one(organisations, {
+    fields: [orgCredentials.orgId],
+    references: [organisations.id],
+  }),
+  creator: one(users, {
+    fields: [orgCredentials.createdBy],
+    references: [users.id],
+  }),
+}));
+
+export const aiSessionsRelations = relations(aiSessions, ({ one }) => ({
+  organisation: one(organisations, {
+    fields: [aiSessions.orgId],
+    references: [organisations.id],
+  }),
+  user: one(users, {
+    fields: [aiSessions.userId],
+    references: [users.id],
+  }),
+}));
+
+export const memoriesRelations = relations(memories, ({ one }) => ({
+  organisation: one(organisations, {
+    fields: [memories.orgId],
+    references: [organisations.id],
+  }),
+  user: one(users, {
+    fields: [memories.userId],
+    references: [users.id],
+  }),
+}));
+
+export const auditLogRelations = relations(auditLog, ({ one }) => ({
+  organisation: one(organisations, {
+    fields: [auditLog.orgId],
+    references: [organisations.id],
+  }),
+  user: one(users, {
+    fields: [auditLog.userId],
+    references: [users.id],
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// TypeScript types
+// ---------------------------------------------------------------------------
+
+export interface OrgSettings {
+  /** Default AI model tier for this org */
+  defaultModelTier?: 'haiku' | 'sonnet' | 'opus';
+  /** Daily budget cap in USD (token-billed providers) */
+  dailyBudgetUsd?: number;
+  /** Allowed model providers */
+  allowedProviders?: string[];
+  /** Feature flags */
+  features?: Record<string, boolean>;
+  /** Custom branding */
+  branding?: {
+    primaryColor?: string;
+    logoUrl?: string;
+  };
+}
+
+export interface SessionContext {
+  /** Active model for this session */
+  model?: string;
+  /** Session-specific memory namespace */
+  memoryNamespace?: string;
+  /** Accumulated token usage */
+  tokenUsage?: {
+    input: number;
+    output: number;
+  };
+  /** Session metadata */
+  metadata?: Record<string, unknown>;
+}

--- a/.agents/services/database/schemas/rls-policies.sql
+++ b/.agents/services/database/schemas/rls-policies.sql
@@ -1,0 +1,171 @@
+-- Multi-Org Row-Level Security Policies
+--
+-- Task: t004.1 — Design multi-org data isolation schema and tenant context model
+--
+-- These policies enforce data isolation at the PostgreSQL level.
+-- Even if application code has a bug, RLS prevents cross-org data leaks.
+--
+-- Prerequisites:
+-- 1. Tables created from multi-org.ts schema
+-- 2. Application connects as 'app_user' role (not superuser)
+-- 3. Middleware sets app.current_org_id and app.current_user_id per request
+--
+-- Usage:
+-- Run this after table creation. The tenant middleware (t004.2) sets
+-- the session variables before each request.
+
+-- ---------------------------------------------------------------------------
+-- Application role
+-- ---------------------------------------------------------------------------
+
+-- Create the application role if it doesn't exist.
+-- The app connects as this role; superuser bypasses RLS.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'app_user') THEN
+    CREATE ROLE app_user;
+  END IF;
+END
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Enable RLS on all org-scoped tables
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE org_credentials ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE memories ENABLE ROW LEVEL SECURITY;
+ALTER TABLE audit_log ENABLE ROW LEVEL SECURITY;
+
+-- Force RLS even for table owners (prevents accidental bypass)
+ALTER TABLE org_credentials FORCE ROW LEVEL SECURITY;
+ALTER TABLE ai_sessions FORCE ROW LEVEL SECURITY;
+ALTER TABLE memories FORCE ROW LEVEL SECURITY;
+ALTER TABLE audit_log FORCE ROW LEVEL SECURITY;
+
+-- ---------------------------------------------------------------------------
+-- Org-scoped policies (strict: org_id must match current_org_id)
+-- ---------------------------------------------------------------------------
+
+-- org_credentials: users can only access credentials for their current org
+CREATE POLICY org_isolation_credentials ON org_credentials
+  FOR ALL
+  TO app_user
+  USING (org_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- ai_sessions: users can only access sessions for their current org
+CREATE POLICY org_isolation_ai_sessions ON ai_sessions
+  FOR ALL
+  TO app_user
+  USING (org_id = current_setting('app.current_org_id', true)::uuid)
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- audit_log: users can only read audit entries for their current org
+-- Write is allowed (for logging) but read is org-scoped
+CREATE POLICY org_isolation_audit_log ON audit_log
+  FOR SELECT
+  TO app_user
+  USING (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- audit_log: allow inserts for current org only
+CREATE POLICY org_insert_audit_log ON audit_log
+  FOR INSERT
+  TO app_user
+  WITH CHECK (org_id = current_setting('app.current_org_id', true)::uuid);
+
+-- ---------------------------------------------------------------------------
+-- Org-optional policies (memories: org-scoped OR personal)
+-- ---------------------------------------------------------------------------
+
+-- memories: can see org memories (if in current org) OR personal memories
+-- Personal memories have org_id IS NULL and belong to the current user
+CREATE POLICY org_or_personal_memories ON memories
+  FOR ALL
+  TO app_user
+  USING (
+    org_id = current_setting('app.current_org_id', true)::uuid
+    OR (
+      org_id IS NULL
+      AND user_id = current_setting('app.current_user_id', true)::uuid
+    )
+  )
+  WITH CHECK (
+    org_id = current_setting('app.current_org_id', true)::uuid
+    OR (
+      org_id IS NULL
+      AND user_id = current_setting('app.current_user_id', true)::uuid
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- Grant permissions to app_user
+-- ---------------------------------------------------------------------------
+
+-- Global tables: read access (memberships checked in application layer)
+GRANT SELECT ON organisations TO app_user;
+GRANT SELECT ON users TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON org_memberships TO app_user;
+
+-- Org-scoped tables: full CRUD (RLS handles isolation)
+GRANT SELECT, INSERT, UPDATE, DELETE ON org_credentials TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ai_sessions TO app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON memories TO app_user;
+GRANT SELECT, INSERT ON audit_log TO app_user;
+
+-- Users can update their own profile
+GRANT UPDATE (name, avatar_url, last_active_org_id) ON users TO app_user;
+
+-- ---------------------------------------------------------------------------
+-- Helper function: verify org membership
+-- ---------------------------------------------------------------------------
+
+-- Used by application code to verify a user belongs to an org
+-- before setting the RLS context. This runs as superuser (definer).
+CREATE OR REPLACE FUNCTION verify_org_membership(
+  p_user_id uuid,
+  p_org_id uuid
+) RETURNS TABLE(role text, org_slug varchar, org_plan text) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    m.role::text,
+    o.slug,
+    o.plan
+  FROM org_memberships m
+  JOIN organisations o ON o.id = m.org_id
+  WHERE m.user_id = p_user_id
+    AND m.org_id = p_org_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+
+-- ---------------------------------------------------------------------------
+-- Helper function: get user's organisations
+-- ---------------------------------------------------------------------------
+
+-- Returns all organisations a user belongs to (for org switcher UI, t004.3)
+CREATE OR REPLACE FUNCTION get_user_organisations(
+  p_user_id uuid
+) RETURNS TABLE(
+  org_id uuid,
+  org_slug varchar,
+  org_name text,
+  org_plan text,
+  user_role text,
+  joined_at timestamptz
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    o.id,
+    o.slug,
+    o.name,
+    o.plan,
+    m.role::text,
+    m.joined_at
+  FROM org_memberships m
+  JOIN organisations o ON o.id = m.org_id
+  WHERE m.user_id = p_user_id
+  ORDER BY m.joined_at ASC;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;

--- a/.agents/services/database/schemas/tenant-context.ts
+++ b/.agents/services/database/schemas/tenant-context.ts
@@ -1,0 +1,285 @@
+/**
+ * Tenant Context Model
+ *
+ * Task: t004.1 — Design multi-org data isolation schema and tenant context model
+ *
+ * Defines how tenant (organisation) context flows through the application:
+ * - Resolution chain (how org context is determined per request)
+ * - TenantContext type (immutable, passed through call chain)
+ * - Middleware interface (for t004.2 implementation)
+ * - RLS setup helpers (for database-level enforcement)
+ *
+ * This module is consumed by:
+ * - t004.2: Middleware implementation
+ * - t004.3: Org-switching UI
+ * - t004.4: AI context isolation
+ * - t004.5: Integration tests
+ */
+
+import type { SQL } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+export type OrgRole = 'owner' | 'admin' | 'member' | 'viewer';
+export type OrgPlan = 'free' | 'pro' | 'enterprise';
+
+/**
+ * How the org context was resolved. Used for audit logging and debugging.
+ */
+export type TenantResolutionMethod =
+  | 'header' // X-Org-Id request header (API calls, worker dispatch)
+  | 'session' // org_id claim in JWT or session store
+  | 'url' // /org/:slug/... path parameter
+  | 'project_config' // .aidevops-tenant file (CLI/local dev)
+  | 'user_default' // users.last_active_org_id
+  | 'single_org'; // User belongs to exactly one org
+
+/**
+ * Immutable tenant context — created once per request, passed through
+ * the entire call chain. Never mutated after creation.
+ *
+ * This is the primary interface consumed by route handlers, services,
+ * and middleware. All org-scoped operations receive this context.
+ */
+export interface TenantContext {
+  /** Organisation ID (UUID) — used for all DB queries */
+  readonly orgId: string;
+  /** Organisation slug — used for URL routing, display */
+  readonly orgSlug: string;
+  /** User ID — the authenticated user */
+  readonly userId: string;
+  /** User's role in this organisation */
+  readonly role: OrgRole;
+  /** How the org context was resolved */
+  readonly resolvedVia: TenantResolutionMethod;
+  /** Organisation plan (affects feature gates) */
+  readonly plan: OrgPlan;
+}
+
+// ---------------------------------------------------------------------------
+// Resolution chain
+// ---------------------------------------------------------------------------
+
+/**
+ * A resolver attempts to extract an org identifier from the request.
+ * Returns the org slug or ID if found, null otherwise.
+ * Resolvers are tried in priority order; first non-null wins.
+ */
+export interface TenantResolver {
+  readonly method: TenantResolutionMethod;
+  resolve(req: TenantResolverInput): Promise<string | null>;
+}
+
+/**
+ * Input provided to each resolver. Abstracted from any specific
+ * HTTP framework (Express, Hono, Fastify, etc.).
+ */
+export interface TenantResolverInput {
+  /** Request headers (lowercase keys) */
+  headers: Record<string, string | undefined>;
+  /** URL path */
+  path: string;
+  /** Session/cookie data (if available) */
+  session?: { orgId?: string; userId?: string };
+  /** Authenticated user ID (from auth middleware) */
+  userId?: string;
+}
+
+/**
+ * Default resolver chain — ordered by priority.
+ * t004.2 implements these; this defines the interface contract.
+ */
+export const DEFAULT_RESOLVER_ORDER: TenantResolutionMethod[] = [
+  'header',
+  'session',
+  'url',
+  'project_config',
+  'user_default',
+  'single_org',
+];
+
+// ---------------------------------------------------------------------------
+// Middleware interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of tenant resolution. Either a valid context or an error.
+ */
+export type TenantResolutionResult =
+  | { ok: true; context: TenantContext }
+  | { ok: false; error: TenantResolutionError };
+
+export type TenantResolutionError =
+  | { code: 'NO_AUTH'; message: string }
+  | { code: 'NO_ORG_CONTEXT'; message: string }
+  | { code: 'ORG_NOT_FOUND'; message: string }
+  | { code: 'NOT_A_MEMBER'; message: string }
+  | { code: 'MEMBERSHIP_SUSPENDED'; message: string };
+
+/**
+ * Tenant middleware contract — implemented by t004.2.
+ *
+ * Usage in route handler:
+ * ```typescript
+ * app.get('/api/data', async (req, res) => {
+ *   const tenant = req.tenant; // TenantContext, set by middleware
+ *   const data = await db.select().from(table)
+ *     .where(eq(table.orgId, tenant.orgId));
+ * });
+ * ```
+ */
+export interface TenantMiddleware {
+  /**
+   * Resolve tenant context from request.
+   * Sets RLS variables on the database connection.
+   * Attaches TenantContext to the request object.
+   */
+  resolve(req: TenantResolverInput): Promise<TenantResolutionResult>;
+}
+
+// ---------------------------------------------------------------------------
+// RLS helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * SQL statements to set RLS context variables per request.
+ * Called by tenant middleware before any org-scoped query.
+ *
+ * Uses PostgreSQL `set_config` with `is_local = true` so the setting
+ * is scoped to the current transaction only.
+ */
+export function setRlsContext(orgId: string, userId: string): SQL[] {
+  return [
+    sql`SELECT set_config('app.current_org_id', ${orgId}, true)`,
+    sql`SELECT set_config('app.current_user_id', ${userId}, true)`,
+  ];
+}
+
+/**
+ * SQL statements to clear RLS context (e.g., for superadmin operations).
+ */
+export function clearRlsContext(): SQL[] {
+  return [
+    sql`SELECT set_config('app.current_org_id', '', true)`,
+    sql`SELECT set_config('app.current_user_id', '', true)`,
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Permission helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Role hierarchy — higher index = more permissions.
+ */
+const ROLE_HIERARCHY: Record<OrgRole, number> = {
+  viewer: 0,
+  member: 1,
+  admin: 2,
+  owner: 3,
+};
+
+/**
+ * Check if a role has at least the required permission level.
+ *
+ * @example
+ * hasPermission('admin', 'member') // true — admin >= member
+ * hasPermission('viewer', 'member') // false — viewer < member
+ */
+export function hasPermission(
+  userRole: OrgRole,
+  requiredRole: OrgRole,
+): boolean {
+  return ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[requiredRole];
+}
+
+/**
+ * Permission requirements for common operations.
+ * Used by route handlers to gate access.
+ */
+export const PERMISSIONS = {
+  // Credential operations
+  'credentials:read': 'member' as OrgRole,
+  'credentials:write': 'admin' as OrgRole,
+  'credentials:delete': 'admin' as OrgRole,
+
+  // Member management
+  'members:read': 'member' as OrgRole,
+  'members:invite': 'admin' as OrgRole,
+  'members:remove': 'admin' as OrgRole,
+  'members:change_role': 'owner' as OrgRole,
+
+  // Org settings
+  'settings:read': 'member' as OrgRole,
+  'settings:write': 'admin' as OrgRole,
+
+  // AI sessions
+  'ai_sessions:read_own': 'member' as OrgRole,
+  'ai_sessions:read_all': 'admin' as OrgRole,
+
+  // Audit log
+  'audit:read': 'admin' as OrgRole,
+
+  // Org lifecycle
+  'org:delete': 'owner' as OrgRole,
+  'org:transfer': 'owner' as OrgRole,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Org switching
+// ---------------------------------------------------------------------------
+
+/**
+ * Steps required when a user switches organisations.
+ * Implemented by t004.3 (UI) and consumed by t004.4 (AI isolation).
+ *
+ * This is a specification — the actual implementation lives in the
+ * middleware and UI layers.
+ */
+export interface OrgSwitchSpec {
+  /** 1. Verify user has membership in target org */
+  verifyMembership: (userId: string, targetOrgId: string) => Promise<boolean>;
+  /** 2. Update users.last_active_org_id */
+  updateLastActiveOrg: (userId: string, orgId: string) => Promise<void>;
+  /** 3. Issue new session with updated org_id claim */
+  refreshSession: (userId: string, orgId: string) => Promise<string>;
+  /** 4. Clear org-specific caches */
+  clearOrgCaches: (orgId: string) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Worker/headless context
+// ---------------------------------------------------------------------------
+
+/**
+ * For autonomous workers dispatched by the supervisor.
+ * The org context is set via environment or dispatch prompt.
+ */
+export interface WorkerTenantConfig {
+  /** Org ID from dispatch metadata */
+  orgId: string;
+  /** User ID of the user who initiated the task */
+  userId: string;
+  /** How credentials are loaded */
+  credentialSource: 'env' | 'credential_helper' | 'database';
+}
+
+/**
+ * Create a TenantContext for a headless worker.
+ * Workers always resolve via 'header' method (explicit org assignment).
+ */
+export function createWorkerContext(
+  config: WorkerTenantConfig & { orgSlug: string; role: OrgRole; plan: OrgPlan },
+): TenantContext {
+  return Object.freeze({
+    orgId: config.orgId,
+    orgSlug: config.orgSlug,
+    userId: config.userId,
+    role: config.role,
+    resolvedVia: 'header',
+    plan: config.plan,
+  });
+}

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -21,7 +21,7 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[50]{folder,purpose,key_files}:
+<!--TOON:subagents[51]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings and UX/CRO,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper|mom-test-ux
@@ -70,6 +70,7 @@ services/crm/,CRM integration - contact management,fluentcrm
 services/analytics/,Website analytics - GA4 reporting,google-analytics
 services/monitoring/,Error monitoring and debugging,sentry|socket
 services/accounting/,Accounting integration - invoicing,quickfile
+services/database/,Database schemas - multi-org isolation Drizzle ORM and PostgreSQL RLS,multi-org-isolation|postgres-drizzle-skill
 services/document-processing/,Document processing - LLM-powered extraction,unstract
 tools/research/,Tech stack research - frontend technology detection providers,providers/unbuilt
 tools/research/,Tech stack research - open-source technology explorer provider,providers/openexplorer
@@ -92,7 +93,7 @@ feature-development,workflows/feature-development.md,Feature development workflo
 conversation-starter,workflows/conversation-starter.md,Session greeting and auto-recall
 -->
 
-<!--TOON:scripts[80]{name,purpose}:
+<!--TOON:scripts[81]{name,purpose}:
 accessibility-helper.sh,Accessibility and contrast testing (WCAG compliance WAVE API for websites and emails)
 accessibility-audit-helper.sh,Accessibility audit CLI wrapping axe-core WAVE API WebAIM contrast and Lighthouse a11y
 auto-update-helper.sh,Automatic update polling daemon (enable disable status check logs)
@@ -183,4 +184,5 @@ wappalyzer-helper.sh,Wappalyzer OSS technology detection provider (detect lookup
 plugin-loader-helper.sh,Plugin agent loader - discover validate load unload agents hooks index status
 claim-task-id.sh,Distributed task ID allocation with collision prevention (online GH/GL issue lock or offline +100 offset)
 planning-commit-helper.sh,Planning file auto-commit helper (next-id complete commit check status)
+multi-org-helper.sh,Multi-org management CLI (init create delete list switch use status info set-plan context)
 -->

--- a/configs/multi-org-config.json.txt
+++ b/configs/multi-org-config.json.txt
@@ -1,0 +1,56 @@
+{
+  "_comment": "Multi-org isolation configuration template. Copy to multi-org-config.json and customise.",
+  "isolation": {
+    "strategy": "row_level",
+    "rls_enabled": true,
+    "rls_forced": true,
+    "db_role": "app_user"
+  },
+  "context_resolution": {
+    "order": [
+      "header",
+      "session",
+      "url",
+      "project_config",
+      "user_default",
+      "single_org"
+    ],
+    "header_name": "X-Org-Id",
+    "url_pattern": "/org/:slug",
+    "project_config_file": ".aidevops-tenant"
+  },
+  "defaults": {
+    "plan": "free",
+    "role": "member",
+    "session_timeout_minutes": 480
+  },
+  "plans": {
+    "free": {
+      "max_members": 5,
+      "max_ai_sessions_per_day": 50,
+      "max_credentials": 20,
+      "allowed_model_tiers": ["haiku", "sonnet"],
+      "memory_retention_days": 30
+    },
+    "pro": {
+      "max_members": 50,
+      "max_ai_sessions_per_day": 500,
+      "max_credentials": 200,
+      "allowed_model_tiers": ["haiku", "sonnet", "opus"],
+      "memory_retention_days": 365
+    },
+    "enterprise": {
+      "max_members": -1,
+      "max_ai_sessions_per_day": -1,
+      "max_credentials": -1,
+      "allowed_model_tiers": ["haiku", "sonnet", "opus"],
+      "memory_retention_days": -1
+    }
+  },
+  "audit": {
+    "enabled": true,
+    "log_reads": false,
+    "log_writes": true,
+    "retention_days": 90
+  }
+}


### PR DESCRIPTION
WIP - incremental commits

## Summary
Design multi-org data isolation schema and tenant context model for aidevops.

## Changes
- **Schema** (`.agents/services/database/schemas/multi-org.ts`): Drizzle ORM schema for organisations, users, org_memberships, org_credentials, ai_sessions, memories, audit_log
- **Tenant Context** (`.agents/services/database/schemas/tenant-context.ts`): Immutable TenantContext type, resolution chain, RLS helpers, permission model, org switching spec
- **RLS Policies** (`.agents/services/database/schemas/rls-policies.sql`): PostgreSQL Row-Level Security policies for database-level isolation
- **Design Doc** (`.agents/services/database/multi-org-isolation.md`): Architecture overview, entity relationships, migration path
- **Config Template** (`configs/multi-org-config.json.txt`): Plan limits, resolution order, audit settings
- **Helper Script** (`.agents/scripts/multi-org-helper.sh`): CLI for org CRUD, membership management, context operations

## Design Decisions
- **Row-level tenancy** over schema-per-tenant: single migration path, simple ops, cross-org superadmin queries
- **PostgreSQL RLS** as safety net: even buggy app code cannot leak cross-org data
- **Immutable TenantContext**: created once per request, frozen, passed through call chain
- **Resolution chain**: header > session > URL > project config > user default > single org
- **Role hierarchy**: owner > admin > member > viewer with permission constants

## Downstream Tasks
- t004.2: Implements tenant-scoped queries and middleware from this schema
- t004.3: Implements org-switching UI using the context model
- t004.4: Implements AI context isolation per organisation
- t004.5: Integration tests for data boundaries

Ref #1897