### PR TITLE
t1246: Verify t1243 auto-unblock deployment and fix hardcoded task ref in commit message

### DIFF
--- a/.agents/scripts/supervisor/todo-sync.sh
+++ b/.agents/scripts/supervisor/todo-sync.sh
@@ -1006,7 +1006,7 @@ auto_unblock_resolved_tasks() {
 
 	if [[ "$unblocked_count" -gt 0 ]]; then
 		log_success "auto_unblock_resolved_tasks: unblocked $unblocked_count task(s): $unblocked_ids"
-		commit_and_push_todo "$repo_path" "chore: auto-unblock $unblocked_count task(s) with resolved blockers (t1243): $unblocked_ids"
+		commit_and_push_todo "$repo_path" "chore: auto-unblock $unblocked_count task(s) with resolved blockers: $unblocked_ids"
 	else
 		log_verbose "auto_unblock_resolved_tasks: no tasks to unblock"
 	fi


### PR DESCRIPTION
## Verification Summary

t1243 auto-unblock Phase is working correctly. All 3 tasks from the audit findings have been resolved:

- **t1224.5**: Already `[x]` completed (PR #1934) before t1243 was deployed — no unblocking needed
- **t1224.7**: Auto-unblock Phase removed `blocked-by:t1224.2,t1224.4` (commit 2928ac08)
- **t1224.8**: Auto-unblock Phase removed `blocked-by:t1224.3` (commit 2928ac08)

The task description was based on stale state from before the Phase ran. The Phase worked correctly.

## Fix Applied

Removed hardcoded `(t1243)` from the auto-unblock commit message in `todo-sync.sh`. The feature is now permanent and the commit message should be generic, not reference the task that created it.

**Before**: `chore: auto-unblock N task(s) with resolved blockers (t1243): ...`
**After**: `chore: auto-unblock N task(s) with resolved blockers: ...`

Ref #1937