### PR TITLE
t1247: fix auto-unblock when blocker is deployed/verified in DB

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -713,6 +713,22 @@ main() {
 	reconcile-queue) cmd_reconcile_queue_dispatchability "$@" ;;
 	notify) cmd_notify "$@" ;;
 	auto-pickup) cmd_auto_pickup "$@" ;;
+	auto-unblock)
+		# t1247: Manually trigger auto-unblock for a repo
+		# Usage: supervisor-helper.sh auto-unblock [--repo <path>]
+		local _au_repo="${REPO_PATH:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+			--repo)
+				_au_repo="$2"
+				shift 2
+				;;
+			*) shift ;;
+			esac
+		done
+		ensure_db
+		auto_unblock_resolved_tasks "$_au_repo"
+		;;
 	batch-cleanup)
 		local _bc_helper="${SCRIPT_DIR}/batch-cleanup-helper.sh"
 		if [[ ! -x "$_bc_helper" ]]; then


### PR DESCRIPTION
Fix two gaps in the pulse cycle's auto-unblock phase that caused tasks to remain blocked after their blocker was deployed/verified.

## Root Cause

t1224.9 remained blocked despite t1224.6 being deployed and verified because:

1. **Phase ordering gap**: Phase 0.5d (auto-unblock) runs BEFORE Phase 1 (which calls `update_todo_on_complete`). Tasks completed in the same pulse were missed — downstream tasks waited an extra 2-minute cycle.

2. **TODO.md-only check**: `auto_unblock_resolved_tasks` only checked TODO.md for `[x]`/`[-]` markers. If `update_todo_on_complete` failed (deliverable verification, subtask guard, PR lookup failure), the blocker stayed as `[ ]` in TODO.md even though it was `deployed`/`verified` in the DB — causing permanent orphaning.

## Changes

- **`todo-sync.sh`**: DB fallback in `auto_unblock_resolved_tasks` — checks supervisor DB for `complete`/`deployed`/`verified`/`merged` status when blocker still shows `[ ]` in TODO.md
- **`pulse.sh`**: Phase 1d post-completion auto-unblock pass — runs immediately after Phase 1 so same-pulse completions unblock downstream tasks atomically
- **`supervisor-helper.sh`**: New `auto-unblock --repo <path>` CLI command for manual triggering and testability
- **`test-supervisor-state-machine.sh`**: 4 new tests covering all scenarios

## Tests

All 4 new tests pass (verified locally):
- Blocker `[x]` in TODO.md → downstream unblocked ✓
- Blocker `deployed` in DB but `[ ]` in TODO.md → downstream unblocked via DB fallback ✓
- Blocker `queued` in DB → downstream NOT unblocked ✓
- Orphaned blocker reference → downstream unblocked ✓

Ref #1942