### PR TITLE
t1254: Fix stale-evaluating periodic heartbeat — eliminate false recoveries for long evals

### DIFF
--- a/.agents/scripts/supervisor/evaluate.sh
+++ b/.agents/scripts/supervisor/evaluate.sh
@@ -1463,7 +1463,7 @@ Respond with ONLY the verdict line, nothing else. Example: VERDICT:retry:rate_li
 			done
 		) &
 		_hb_pid=$!
-		push_cleanup "rm -f '${_hb_sentinel}' 2>/dev/null || true; kill '${_hb_pid}' 2>/dev/null; wait '${_hb_pid}' 2>/dev/null || true"
+		push_cleanup "rm -f '${_hb_sentinel}' 2>/dev/null || true; kill '${_hb_pid}' 2>/dev/null || true; wait '${_hb_pid}' 2>/dev/null || true"
 	fi
 
 	# t1252: Watchdog timer — detect evaluation hangs within 60s instead of
@@ -1513,10 +1513,10 @@ Respond with ONLY the verdict line, nothing else. Example: VERDICT:retry:rate_li
 
 	# t1254: Stop periodic heartbeat — eval completed (or timed out).
 	# Remove sentinel first so the heartbeat loop exits cleanly on its next iteration.
-	if [[ -n "$_hb_sentinel" ]]; then
-		rm -f "$_hb_sentinel" 2>/dev/null || true
-	fi
+	# _hb_pid is only set when _hb_sentinel was successfully created, so checking
+	# _hb_pid alone is sufficient to guard all heartbeat cleanup operations.
 	if [[ -n "$_hb_pid" ]]; then
+		rm -f "$_hb_sentinel" 2>/dev/null || true
 		kill "$_hb_pid" 2>/dev/null || true
 		wait "$_hb_pid" 2>/dev/null || true
 	fi

--- a/.agents/scripts/supervisor/evaluate.sh
+++ b/.agents/scripts/supervisor/evaluate.sh
@@ -1439,10 +1439,32 @@ Respond with ONLY the verdict line, nothing else. Example: VERDICT:retry:rate_li
 	# "eval in progress" vs "eval died" — reduces false stale-evaluating recoveries.
 	log_info "evaluate_with_ai: starting AI eval for $task_id (timeout=${eval_timeout}s, model=$eval_model, started=$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo 'unknown'))"
 
-	# t1251: Heartbeat — touch updated_at so Phase 0.7's grace period doesn't
-	# fire while evaluation is actively running. Without this, a 60s+ eval that
-	# started just before the grace window expires triggers unnecessary recovery.
+	# t1251: Initial heartbeat — touch updated_at so Phase 0.7's grace period
+	# doesn't fire while evaluation is actively running.
 	db "$SUPERVISOR_DB" "UPDATE tasks SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = '$(sql_escape "$task_id")';" 2>/dev/null || true
+
+	# t1254: Periodic heartbeat — refresh updated_at every 20s during the AI call.
+	# The one-shot heartbeat from t1251 only covers eval_timeout+30s (120s window).
+	# If the AI eval takes >120s (slow model, large log), Phase 0.7 triggers false
+	# recovery even though eval is actively running. A periodic heartbeat keeps
+	# updated_at fresh for the full duration of the eval, regardless of how long
+	# it takes. The loop self-terminates when the sentinel file is removed.
+	local _hb_sentinel
+	_hb_sentinel=$(mktemp 2>/dev/null || echo "")
+	local _hb_pid=""
+	if [[ -n "$_hb_sentinel" ]]; then
+		local _hb_task_id="$task_id"
+		local _hb_db="$SUPERVISOR_DB"
+		(
+			while [[ -f "$_hb_sentinel" ]]; do
+				sleep 20
+				[[ -f "$_hb_sentinel" ]] || break
+				db "$_hb_db" "UPDATE tasks SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = '$(sql_escape "$_hb_task_id")';" 2>/dev/null || true
+			done
+		) &
+		_hb_pid=$!
+		push_cleanup "rm -f '${_hb_sentinel}' 2>/dev/null || true; kill '${_hb_pid}' 2>/dev/null; wait '${_hb_pid}' 2>/dev/null || true"
+	fi
 
 	# t1252: Watchdog timer — detect evaluation hangs within 60s instead of
 	# waiting for the full stale timeout (120s grace + eval_timeout).
@@ -1488,6 +1510,21 @@ Respond with ONLY the verdict line, nothing else. Example: VERDICT:retry:rate_li
 			--model "$claude_model" \
 			--output-format text 2>/dev/null || echo "")
 	fi
+
+	# t1254: Stop periodic heartbeat — eval completed (or timed out).
+	# Remove sentinel first so the heartbeat loop exits cleanly on its next iteration.
+	if [[ -n "$_hb_sentinel" ]]; then
+		rm -f "$_hb_sentinel" 2>/dev/null || true
+	fi
+	if [[ -n "$_hb_pid" ]]; then
+		kill "$_hb_pid" 2>/dev/null || true
+		wait "$_hb_pid" 2>/dev/null || true
+	fi
+
+	# t1254: Final heartbeat touch — extend the Phase 0.7 grace window through
+	# post-eval teardown. Without this, if watchdog fires at eval_timeout and
+	# teardown takes >30s, Phase 0.7 could recover the task mid-teardown.
+	db "$SUPERVISOR_DB" "UPDATE tasks SET updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = '$(sql_escape "$task_id")';" 2>/dev/null || true
 
 	# t1252: Cancel watchdog — eval completed (or timed out), no longer needed.
 	# Remove sentinel first so watchdog subshell won't fire if it wakes up late.

--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -192,13 +192,15 @@ _diagnose_stale_root_cause() {
 			return 0
 		fi
 
-		# t1251: Check if evaluation is actively in progress via heartbeat.
-		# evaluate_with_ai() updates updated_at at the start of each AI eval call.
-		# If updated_at is very recent (< eval_timeout + 30s buffer), the eval is
-		# likely still running — not stuck. Return a distinct cause so callers can
-		# skip recovery for actively-evaluating tasks.
+		# t1251/t1254: Check if evaluation is actively in progress via heartbeat.
+		# evaluate_with_ai() updates updated_at at the start of each AI eval call
+		# and every 20s via a periodic background heartbeat (t1254).
+		# heartbeat_window = eval_timeout * 2 + 60: covers slow models that exceed
+		# eval_timeout (e.g., 90s timeout but model responds at 150s), plus 60s
+		# buffer for teardown. The periodic heartbeat keeps updated_at fresh, so
+		# this window only needs to cover the 20s heartbeat interval + teardown.
 		local eval_timeout_cfg="${SUPERVISOR_EVAL_TIMEOUT:-90}"
-		local heartbeat_window=$((eval_timeout_cfg + 30))
+		local heartbeat_window=$((eval_timeout_cfg * 2 + 60))
 		local db_updated_at
 		db_updated_at=$(db "$SUPERVISOR_DB" "SELECT updated_at FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "")
 		if [[ -n "$db_updated_at" ]]; then

--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -195,10 +195,11 @@ _diagnose_stale_root_cause() {
 		# t1251/t1254: Check if evaluation is actively in progress via heartbeat.
 		# evaluate_with_ai() updates updated_at at the start of each AI eval call
 		# and every 20s via a periodic background heartbeat (t1254).
-		# heartbeat_window = eval_timeout * 2 + 60: covers slow models that exceed
-		# eval_timeout (e.g., 90s timeout but model responds at 150s), plus 60s
-		# buffer for teardown. The periodic heartbeat keeps updated_at fresh, so
-		# this window only needs to cover the 20s heartbeat interval + teardown.
+		# heartbeat_window = eval_timeout * 2 + 60: defense-in-depth in case the
+		# heartbeat process itself fails or is delayed. Under normal operation the
+		# periodic heartbeat keeps updated_at fresh and a much smaller window would
+		# suffice, but this wider window ensures Phase 0.7 does not fire if the
+		# heartbeat subshell is unexpectedly killed or stalled.
 		local eval_timeout_cfg="${SUPERVISOR_EVAL_TIMEOUT:-90}"
 		local heartbeat_window=$((eval_timeout_cfg * 2 + 60))
 		local db_updated_at


### PR DESCRIPTION
Fixes the remaining stale-evaluating false recovery gap left after t1251 (PR #1952).

## Root Cause

t1251 added a one-shot `updated_at` heartbeat at eval start, but if the AI eval takes longer than `heartbeat_window` (eval_timeout+30s = 120s default), Phase 0.7 still triggers false recovery — interrupting a live eval and causing unnecessary re-queuing.

**Failure scenario before this fix:**
- eval_timeout=90s, heartbeat_window=120s
- Eval starts, updated_at set at T=0
- AI call takes 150s (slow model, large log tail)
- At T=121s, Phase 0.7: secs_since_update=121 > 120 → triggers recovery
- Original eval still running → duplicate execution / race condition

## Fixes

1. **Periodic heartbeat loop** (20s interval) runs alongside the AI call in a background subshell, keeping `updated_at` fresh for the full eval duration regardless of how long it takes
2. **Wider heartbeat_window** in `_diagnose_stale_root_cause`: `eval_timeout*2+60` (240s default) instead of `eval_timeout+30` (120s) — covers slow models that exceed eval_timeout
3. **Final heartbeat touch** after AI call completes, before teardown — covers the post-watchdog race window where Phase 0.7 could fire during teardown

## Expected Impact

Eliminates remaining ~35min/task stale recovery overhead for evals that exceed 120s. Combined with t1251's fixes, this should reduce the stale-evaluating rate from 73% toward near-zero.

## Files Changed

- `.agents/scripts/supervisor/evaluate.sh`: periodic heartbeat loop + final touch
- `.agents/scripts/supervisor/pulse.sh`: wider heartbeat_window formula

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added periodic heartbeat during AI evaluations to prevent premature recovery actions for long-running tasks.
  * Extended the detection window and adjusted timeout behavior to better accommodate slower models.
  * Improved cleanup and teardown timing to ensure graceful completion and reduce false timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->