### PR TITLE
t1256: Reduce stale-evaluating frequency via rate limit cooldown and eval checkpoint

### DIFF
--- a/.agents/scripts/supervisor/state.sh
+++ b/.agents/scripts/supervisor/state.sh
@@ -969,6 +969,7 @@ cmd_next() {
             WHERE bt.batch_id = '$escaped_batch'
             AND t.status = 'queued'
             AND t.retries < t.max_retries
+            AND (t.rate_limit_until IS NULL OR t.rate_limit_until <= strftime('%Y-%m-%dT%H:%M:%SZ','now'))
             ORDER BY t.retries ASC, bt.position
             LIMIT $((limit * 5));
         ")
@@ -978,6 +979,7 @@ cmd_next() {
             FROM tasks
             WHERE status = 'queued'
             AND retries < max_retries
+            AND (rate_limit_until IS NULL OR rate_limit_until <= strftime('%Y-%m-%dT%H:%M:%SZ','now'))
             ORDER BY retries ASC, created_at ASC
             LIMIT $((limit * 5));
         ")


### PR DESCRIPTION
## Summary

Root cause analysis of 114 Phase 0.7 stale-state recovery events (30 days) identified systemic issues causing the 93% stale-evaluating rate.

Root causes: worker_rate_limited 33 events (29%), eval_process_died 30 events (26%), worker_failed_before_eval 27 events (24%), worker_oom_killed 12 events (11%).

## Changes

### 1. Rate limit cooldown (database.sh, pulse.sh, state.sh)
- Added rate_limit_until column to tasks table (migration + schema)
- Phase 0.7: when recovering a worker_rate_limited task, sets rate_limit_until = now + 5min
- cmd_next(): filters out tasks where rate_limit_until > now
- Prevents immediate re-dispatch into the same rate limit (addresses #1 root cause, 29%)
- Configurable via SUPERVISOR_RATE_LIMIT_COOLDOWN_SECONDS (default: 300s)

### 2. Eval checkpoint file (evaluate.sh, pulse.sh)
- evaluate_with_ai() writes eval-checkpoints/{task_id}.eval at eval start
- Checkpoint removed on completion (success or timeout) via push_cleanup
- _diagnose_stale_root_cause() now detects pulse_killed_mid_eval vs generic eval_process_died
- Phase 0.7 cleans up checkpoint files after recovery
- Enables more precise observability of pulse-kill vs eval-crash patterns

### 3. Stale GC report enhancement (pulse.sh)
- Added Rate Limit Cooldown section showing currently deferred tasks with retry-after timestamps

## Expected Impact
- 29% reduction in stale-evaluating events from rate limit cooldown
- Improved diagnosis for 26% of eval_process_died events to pulse_killed_mid_eval
- No retry overhead for rate-limited tasks during cooldown window
- Backward compatible: rate_limit_until IS NULL tasks dispatch normally

Ref #1962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented rate limit cooldown mechanism that temporarily pauses task retry scheduling when workers are rate-limited, with a configurable cooldown window.
  * Enhanced task recovery diagnostics to distinguish between pulse process interruption and evaluation failure, improving troubleshooting accuracy.
  * Added checkpoint tracking system to assist with debugging evaluation timeouts and process failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->