### PR TITLE
t1218: Improve semantic dedup to prevent duplicate task creation

### DIFF
--- a/.agents/scripts/supervisor/ai-reason.sh
+++ b/.agents/scripts/supervisor/ai-reason.sh
@@ -591,6 +591,7 @@ Respond with ONLY a JSON array of actions. Each action is an object with:
 - Keep comments professional and concise.
 - If nothing needs attention, return an empty array: []
 - Maximum 10 actions per reasoning cycle to keep changes manageable.
+- **CRITICAL — DUPLICATE PREVENTION**: Before proposing `create_task` or `create_improvement`, scan the TODO tasks list in the context for ANY existing task (open OR recently completed) that addresses the same root cause, symptom, or investigation area. If such a task exists, DO NOT create a new one — instead, comment on the existing task's issue or adjust its priority. Creating duplicate investigation tasks wastes tokens and compute. A task completed yesterday about the same symptom means the fix is either deployed (wait and observe) or failed (reopen/escalate the existing task). Never create a new task when an existing one covers the same ground.
 - For model selection on new tasks: use the cheapest tier that can succeed. Check pattern data — if similar tasks have >75% success at sonnet, don't use opus. Default to sonnet unless the task requires complex reasoning or architecture decisions.
 - For escalate_model: only recommend when pattern data shows repeated failures at the current tier, or when the task description clearly requires capabilities beyond the current tier.
 - For create_improvement: focus on changes that reduce future token spend or manual intervention. Quantify the expected benefit when possible (e.g., "saves ~500 tokens/task" or "eliminates manual step that fails 30% of the time").


### PR DESCRIPTION
## Summary

The AI supervisor's reasoning engine created 9+ duplicate tasks about the same root symptom ("stale evaluating recovery") because the semantic dedup system had several gaps. This PR fixes 5 issues:

## Changes

### 1. Stop words list reduced (ai-actions.sh)
Action verbs like "investigate", "fix", "add", "implement" were being stripped as stop words in the keyword pre-filter. These carry critical semantic signal for dedup — "Investigate X" and "Investigate Y" share a pattern that should be detected.

### 2. Recently completed tasks scanned (ai-actions.sh)
The dedup only checked open `[ ]` tasks. A task completed 30 minutes ago about the same symptom didn't prevent creating a new one. Now scans `[x]` tasks with `completed:` timestamps from today or yesterday.

### 3. AI semantic dedup prompt strengthened (ai-actions.sh)
The sonnet dedup prompt was too lenient. Now uses "strict task deduplication checker" framing with 5 explicit duplicate criteria and "when in doubt, mark as duplicate" instruction.

### 4. Keyword safety net (ai-actions.sh)
When the AI says "not duplicate" but keyword overlap is 4+ matches, treat as duplicate anyway. Prevents the scenario where the AI is wrong but keywords clearly show overlap.

### 5. Reasoning prompt duplicate prevention (ai-reason.sh)
Added a CRITICAL DUPLICATE PREVENTION rule to the reasoning system prompt, instructing the AI to scan TODO for existing tasks before proposing `create_task` or `create_improvement`.

## Testing

- ShellCheck: zero new violations (only pre-existing SC1091/SC2016 info notices)
- Syntax: `bash -n` passes on both files
- Test suite: 30/31 pass (1 pre-existing failure in Test 27, unrelated to this PR)
- **New tests**: Test 30 (keyword pre-filter signal words) and Test 31 (recently completed task scanning)

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `.agents/scripts/supervisor/ai-actions.sh` | +116/-30 | 4 fixes: stop words, completed tasks, prompt, safety net |
| `.agents/scripts/supervisor/ai-reason.sh` | +1 | Duplicate prevention rule in reasoning prompt |
| `tests/test-ai-actions.sh` | +170 | 2 new tests (Test 30, Test 31) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved duplicate task detection now examines both open and recently completed tasks.
  * Enhanced safety mechanisms to prevent creation of near-duplicate tasks.
  * Strengthened AI reasoning with additional duplicate prevention safeguards.

* **Tests**
  * Added comprehensive tests for task matching and duplicate detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->