### PR TITLE
t1260: Fix setup.sh to install launchd schedulers on macOS for all users

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -40,7 +40,7 @@ readonly STATE_FILE="$HOME/.aidevops/cache/auto-update-state.json"
 readonly CRON_MARKER="# aidevops-auto-update"
 readonly DEFAULT_INTERVAL=10
 readonly DEFAULT_SKILL_FRESHNESS_HOURS=24
-readonly LAUNCHD_LABEL="com.aidevops.auto-update"
+readonly LAUNCHD_LABEL="com.aidevops.aidevops-auto-update"
 readonly LAUNCHD_DIR="$HOME/Library/LaunchAgents"
 readonly LAUNCHD_PLIST="${LAUNCHD_DIR}/${LAUNCHD_LABEL}.plist"
 
@@ -573,6 +573,15 @@ cmd_enable() {
 	if [[ "$backend" == "launchd" ]]; then
 		local interval_seconds=$((interval * 60))
 
+		# Migrate from old label if present (t1260)
+		local old_label="com.aidevops.auto-update"
+		local old_plist="${LAUNCHD_DIR}/${old_label}.plist"
+		if launchctl list 2>/dev/null | grep -qF "$old_label"; then
+			launchctl unload -w "$old_plist" 2>/dev/null || true
+			log_info "Unloaded old LaunchAgent: $old_label"
+		fi
+		rm -f "$old_plist"
+
 		# Auto-migrate existing cron entry if present
 		_migrate_cron_to_launchd "$script_path" "$interval_seconds"
 
@@ -861,7 +870,7 @@ ENVIRONMENT:
     AIDEVOPS_SKILL_FRESHNESS_HOURS=24    Hours between skill checks (default: 24)
 
 SCHEDULER BACKENDS:
-    macOS:  launchd LaunchAgent (~/Library/LaunchAgents/com.aidevops.auto-update.plist)
+    macOS:  launchd LaunchAgent (~/Library/LaunchAgents/com.aidevops.aidevops-auto-update.plist)
             - Native macOS scheduler, survives reboots without cron
             - Auto-migrates existing cron entries on first 'enable'
     Linux:  cron (crontab entry with # aidevops-auto-update marker)

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -593,7 +593,15 @@ cmd_enable() {
 		fi
 
 		mkdir -p "$LAUNCHD_DIR"
-		_generate_auto_update_plist "$script_path" "$interval_seconds" "${PATH}" >"$LAUNCHD_PLIST"
+
+		# Create named symlink so macOS System Settings shows "aidevops-auto-update"
+		# instead of the raw script name (t1260)
+		local bin_dir="$HOME/.aidevops/bin"
+		mkdir -p "$bin_dir"
+		local display_link="$bin_dir/aidevops-auto-update"
+		ln -sf "$script_path" "$display_link"
+
+		_generate_auto_update_plist "$display_link" "$interval_seconds" "${PATH}" >"$LAUNCHD_PLIST"
 
 		if launchctl load -w "$LAUNCHD_PLIST" 2>/dev/null; then
 			update_state "enable" "$(get_local_version)" "enabled"

--- a/.agents/scripts/supervisor/launchd.sh
+++ b/.agents/scripts/supervisor/launchd.sh
@@ -298,6 +298,13 @@ launchd_install_supervisor_pulse() {
 	# GH_TOKEN is resolved at runtime by the pulse script (not baked into plist)
 	local env_path="${PATH}"
 
+	# Create named symlink so macOS System Settings shows "aidevops-supervisor-pulse"
+	# instead of the raw script name (t1260)
+	local bin_dir="$HOME/.aidevops/bin"
+	mkdir -p "$bin_dir"
+	local display_link="$bin_dir/aidevops-supervisor-pulse"
+	ln -sf "$script_path" "$display_link"
+
 	# Check if already loaded
 	if _launchd_is_loaded "$label"; then
 		log_warn "LaunchAgent $label already loaded. Unload first to change settings."
@@ -305,9 +312,9 @@ launchd_install_supervisor_pulse() {
 		return 0
 	fi
 
-	# Generate and write plist (no GH_TOKEN — resolved at runtime)
+	# Generate and write plist using symlink for display name (no GH_TOKEN — resolved at runtime)
 	_generate_supervisor_pulse_plist \
-		"$script_path" \
+		"$display_link" \
 		"$interval_seconds" \
 		"$log_path" \
 		"$batch_arg" \
@@ -422,15 +429,22 @@ launchd_install_auto_update() {
 
 	local env_path="${PATH}"
 
+	# Create named symlink so macOS System Settings shows "aidevops-auto-update"
+	# instead of the raw script name (t1260)
+	local bin_dir="$HOME/.aidevops/bin"
+	mkdir -p "$bin_dir"
+	local display_link="$bin_dir/aidevops-auto-update"
+	ln -sf "$script_path" "$display_link"
+
 	# Check if already loaded
 	if _launchd_is_loaded "$label"; then
 		log_warn "LaunchAgent $label already loaded. Unload first to change settings."
 		return 0
 	fi
 
-	# Generate and write plist
+	# Generate and write plist using symlink for display name
 	_generate_auto_update_plist \
-		"$script_path" \
+		"$display_link" \
 		"$interval_seconds" \
 		"$log_path" \
 		"$env_path" >"$plist_path"
@@ -539,15 +553,22 @@ launchd_install_todo_watcher() {
 
 	local env_path="${PATH}"
 
+	# Create named symlink so macOS System Settings shows "aidevops-todo-watcher"
+	# instead of the raw script name (t1260)
+	local bin_dir="$HOME/.aidevops/bin"
+	mkdir -p "$bin_dir"
+	local display_link="$bin_dir/aidevops-todo-watcher"
+	ln -sf "$script_path" "$display_link"
+
 	# Check if already loaded
 	if _launchd_is_loaded "$label"; then
 		log_warn "LaunchAgent $label already loaded."
 		return 0
 	fi
 
-	# Generate and write plist
+	# Generate and write plist using symlink for display name
 	_generate_todo_watcher_plist \
-		"$script_path" \
+		"$display_link" \
 		"$todo_path" \
 		"$repo_path" \
 		"$log_path" \

--- a/setup.sh
+++ b/setup.sh
@@ -519,9 +519,21 @@ main() {
 	print_success "🎉 Setup complete!"
 
 	# Enable auto-update if not already enabled
+	# Check both launchd (macOS) and cron (Linux) for existing installation
 	local auto_update_script="$HOME/.aidevops/agents/scripts/auto-update-helper.sh"
 	if [[ -x "$auto_update_script" ]] && [[ "${AIDEVOPS_AUTO_UPDATE:-true}" != "false" ]]; then
-		if ! crontab -l 2>/dev/null | grep -q "aidevops-auto-update"; then
+		local _auto_update_installed=false
+		if launchctl list 2>/dev/null | grep -qF "com.aidevops.auto-update"; then
+			_auto_update_installed=true
+		elif crontab -l 2>/dev/null | grep -q "aidevops-auto-update"; then
+			if [[ "$(uname -s)" == "Darwin" ]]; then
+				# macOS: cron entry exists but no launchd plist — migrate silently
+				bash "$auto_update_script" enable >/dev/null 2>&1 || true
+				print_info "Auto-update migrated from cron to launchd"
+			fi
+			_auto_update_installed=true
+		fi
+		if [[ "$_auto_update_installed" == "false" ]]; then
 			if [[ "$NON_INTERACTIVE" == "true" ]]; then
 				# Non-interactive: enable silently
 				bash "$auto_update_script" enable >/dev/null 2>&1 || true
@@ -536,6 +548,40 @@ main() {
 					bash "$auto_update_script" enable
 				else
 					print_info "Skipped. Enable later: aidevops auto-update enable"
+				fi
+			fi
+		fi
+	fi
+
+	# Enable supervisor pulse scheduler if not already installed
+	# This is REQUIRED for autonomous task orchestration (dispatch, evaluation, cleanup)
+	local supervisor_script="$HOME/.aidevops/agents/scripts/supervisor-helper.sh"
+	if [[ -x "$supervisor_script" ]]; then
+		local _pulse_installed=false
+		if launchctl list 2>/dev/null | grep -qF "com.aidevops.supervisor-pulse"; then
+			_pulse_installed=true
+		elif crontab -l 2>/dev/null | grep -q "aidevops-supervisor-pulse"; then
+			if [[ "$(uname -s)" == "Darwin" ]]; then
+				# macOS: cron entry exists but no launchd plist — migrate silently
+				bash "$supervisor_script" cron install >/dev/null 2>&1 || true
+				print_info "Supervisor pulse migrated from cron to launchd"
+			fi
+			_pulse_installed=true
+		fi
+		if [[ "$_pulse_installed" == "false" ]]; then
+			if [[ "$NON_INTERACTIVE" == "true" ]]; then
+				bash "$supervisor_script" cron install >/dev/null 2>&1 || true
+				print_info "Supervisor pulse enabled (every 2 min). Disable: supervisor-helper.sh cron uninstall"
+			else
+				echo ""
+				echo "The supervisor pulse runs every 2 minutes to dispatch tasks, evaluate"
+				echo "worker results, merge PRs, and clean up. Required for autonomous operation."
+				echo ""
+				read -r -p "Enable supervisor pulse? [Y/n]: " enable_pulse
+				if [[ "$enable_pulse" =~ ^[Yy]?$ || -z "$enable_pulse" ]]; then
+					bash "$supervisor_script" cron install
+				else
+					print_info "Skipped. Enable later: supervisor-helper.sh cron install"
 				fi
 			fi
 		fi

--- a/setup.sh
+++ b/setup.sh
@@ -527,14 +527,20 @@ main() {
 			_auto_update_installed=true
 		elif launchctl list 2>/dev/null | grep -qF "com.aidevops.auto-update"; then
 			# Old label — re-running enable will migrate to new label
-			bash "$auto_update_script" enable >/dev/null 2>&1 || true
-			print_info "Auto-update LaunchAgent migrated to new label"
+			if bash "$auto_update_script" enable >/dev/null 2>&1; then
+				print_info "Auto-update LaunchAgent migrated to new label"
+			else
+				print_warning "Auto-update label migration failed. Run: aidevops auto-update enable"
+			fi
 			_auto_update_installed=true
-		elif crontab -l 2>/dev/null | grep -q "aidevops-auto-update"; then
+		elif crontab -l 2>/dev/null | grep -qF "aidevops-auto-update"; then
 			if [[ "$(uname -s)" == "Darwin" ]]; then
-				# macOS: cron entry exists but no launchd plist — migrate silently
-				bash "$auto_update_script" enable >/dev/null 2>&1 || true
-				print_info "Auto-update migrated from cron to launchd"
+				# macOS: cron entry exists but no launchd plist — migrate
+				if bash "$auto_update_script" enable >/dev/null 2>&1; then
+					print_info "Auto-update migrated from cron to launchd"
+				else
+					print_warning "Auto-update cron→launchd migration failed. Run: aidevops auto-update enable"
+				fi
 			fi
 			_auto_update_installed=true
 		fi
@@ -561,20 +567,26 @@ main() {
 	# Enable supervisor pulse scheduler if not already installed
 	# This is REQUIRED for autonomous task orchestration (dispatch, evaluation, cleanup)
 	local supervisor_script="$HOME/.aidevops/agents/scripts/supervisor-helper.sh"
-	if [[ -x "$supervisor_script" ]]; then
+	if [[ -x "$supervisor_script" ]] && [[ "${AIDEVOPS_SUPERVISOR_PULSE:-true}" != "false" ]]; then
 		local _pulse_installed=false
 		if launchctl list 2>/dev/null | grep -qF "com.aidevops.aidevops-supervisor-pulse"; then
 			_pulse_installed=true
 		elif launchctl list 2>/dev/null | grep -qF "com.aidevops.supervisor-pulse"; then
 			# Old label — re-running install will migrate to new label
-			bash "$supervisor_script" cron install >/dev/null 2>&1 || true
-			print_info "Supervisor pulse LaunchAgent migrated to new label"
+			if bash "$supervisor_script" cron install >/dev/null 2>&1; then
+				print_info "Supervisor pulse LaunchAgent migrated to new label"
+			else
+				print_warning "Supervisor pulse label migration failed. Run: supervisor-helper.sh cron install"
+			fi
 			_pulse_installed=true
-		elif crontab -l 2>/dev/null | grep -q "aidevops-supervisor-pulse"; then
+		elif crontab -l 2>/dev/null | grep -qF "aidevops-supervisor-pulse"; then
 			if [[ "$(uname -s)" == "Darwin" ]]; then
-				# macOS: cron entry exists but no launchd plist — migrate silently
-				bash "$supervisor_script" cron install >/dev/null 2>&1 || true
-				print_info "Supervisor pulse migrated from cron to launchd"
+				# macOS: cron entry exists but no launchd plist — migrate
+				if bash "$supervisor_script" cron install >/dev/null 2>&1; then
+					print_info "Supervisor pulse migrated from cron to launchd"
+				else
+					print_warning "Supervisor pulse cron→launchd migration failed. Run: supervisor-helper.sh cron install"
+				fi
 			fi
 			_pulse_installed=true
 		fi

--- a/setup.sh
+++ b/setup.sh
@@ -523,7 +523,12 @@ main() {
 	local auto_update_script="$HOME/.aidevops/agents/scripts/auto-update-helper.sh"
 	if [[ -x "$auto_update_script" ]] && [[ "${AIDEVOPS_AUTO_UPDATE:-true}" != "false" ]]; then
 		local _auto_update_installed=false
-		if launchctl list 2>/dev/null | grep -qF "com.aidevops.auto-update"; then
+		if launchctl list 2>/dev/null | grep -qF "com.aidevops.aidevops-auto-update"; then
+			_auto_update_installed=true
+		elif launchctl list 2>/dev/null | grep -qF "com.aidevops.auto-update"; then
+			# Old label — re-running enable will migrate to new label
+			bash "$auto_update_script" enable >/dev/null 2>&1 || true
+			print_info "Auto-update LaunchAgent migrated to new label"
 			_auto_update_installed=true
 		elif crontab -l 2>/dev/null | grep -q "aidevops-auto-update"; then
 			if [[ "$(uname -s)" == "Darwin" ]]; then
@@ -558,7 +563,12 @@ main() {
 	local supervisor_script="$HOME/.aidevops/agents/scripts/supervisor-helper.sh"
 	if [[ -x "$supervisor_script" ]]; then
 		local _pulse_installed=false
-		if launchctl list 2>/dev/null | grep -qF "com.aidevops.supervisor-pulse"; then
+		if launchctl list 2>/dev/null | grep -qF "com.aidevops.aidevops-supervisor-pulse"; then
+			_pulse_installed=true
+		elif launchctl list 2>/dev/null | grep -qF "com.aidevops.supervisor-pulse"; then
+			# Old label — re-running install will migrate to new label
+			bash "$supervisor_script" cron install >/dev/null 2>&1 || true
+			print_info "Supervisor pulse LaunchAgent migrated to new label"
 			_pulse_installed=true
 		elif crontab -l 2>/dev/null | grep -q "aidevops-supervisor-pulse"; then
 			if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
## Summary

- `setup.sh` (run by `aidevops update`) now installs both schedulers on macOS using launchd
- Existing cron entries are auto-migrated to launchd during setup
- Fixes the gap where t1219 added launchd support but setup never activated it

## Problem

PR #1864 (t1219) added launchd LaunchAgent support for macOS, but:

1. **`setup.sh` only checked cron** for auto-update (line 524: `crontab -l | grep "aidevops-auto-update"`) — missed launchd plist detection entirely
2. **Supervisor pulse was never installed by setup** — users had to manually run `supervisor-helper.sh cron install`, which most wouldn't know to do
3. **No migration path during update** — macOS users with existing cron entries were never migrated to launchd

Result: the supervisor pulse scheduler was not running for any user, meaning autonomous task dispatch, PR merging, and worker evaluation were all inactive.

## Changes

### `setup.sh` — 3 fixes

**1. Auto-update detection** — now checks `launchctl list` for `com.aidevops.auto-update` first, falls back to `crontab -l`. On macOS, if cron entry exists but no launchd plist, re-runs `enable` to migrate.

**2. Supervisor pulse install** — new section after auto-update that installs the supervisor pulse scheduler. Interactive mode asks the user; non-interactive enables silently. Checks both launchd and cron to avoid duplicate installation.

**3. Cron-to-launchd migration** — on macOS, when cron entries exist but launchd plists don't, both schedulers are silently migrated during setup. The `enable` and `cron install` commands handle the actual migration (remove cron entry, install plist).

## Behaviour Matrix

| Platform | Existing State | Action |
|----------|---------------|--------|
| macOS | Nothing installed | Install both via launchd (ask in interactive) |
| macOS | Cron entries only | Migrate to launchd silently |
| macOS | Launchd plists | Skip (already installed) |
| Linux | Nothing installed | Install both via cron (ask in interactive) |
| Linux | Cron entries | Skip (already installed) |

## Verification

- ShellCheck: zero new violations
- Syntax: `bash -n` passes
- Idempotent: re-running setup with existing schedulers skips installation

Ref #1970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Supervisor pulse scheduler can be enabled automatically during setup (silent in non-interactive, prompt in interactive).
* **Migration**
  * Existing scheduler installations and older macOS entries are detected and migrated to the new installer-managed scheduler; migrated items are logged.
* **Behavior Changes**
  * macOS scheduler display names and status messages updated for clarity in System Settings.
  * Credentials (tokens) are resolved at runtime for scheduled runs instead of being injected into schedule entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->