### PR TITLE
t1261: Fix dispatch stall from orphaned DB tasks

### DIFF
--- a/.agents/scripts/supervisor/dispatch.sh
+++ b/.agents/scripts/supervisor/dispatch.sh
@@ -2196,8 +2196,8 @@ cmd_dispatch() {
 	local dispatch_todo_file="${trepo:-.}/TODO.md"
 	if [[ -n "$trepo" && -f "$dispatch_todo_file" ]]; then
 		local task_in_registered_repo
-		task_in_registered_repo=$(grep -cE "^[[:space:]]*- \[.\] $task_id( |$)" "$dispatch_todo_file" 2>/dev/null || echo 0)
-		if [[ "$task_in_registered_repo" -eq 0 ]]; then
+		task_in_registered_repo=$(grep -cE "^[[:space:]]*- \[.\] $task_id( |$)" "$dispatch_todo_file" 2>/dev/null | head -1 || echo 0)
+		if [[ "${task_in_registered_repo:-0}" -eq 0 ]]; then
 			log_error "Cross-repo misregistration detected at dispatch: $task_id not found in $(basename "$trepo") TODO.md ($dispatch_todo_file) — cancelling to prevent wrong-repo worker spawn (t1239)"
 			db "$SUPERVISOR_DB" "UPDATE tasks SET status='cancelled', error='Cross-repo misregistration: task not found in registered repo TODO.md (t1239)' WHERE id='$(sql_escape "$task_id")';"
 			return 1


### PR DESCRIPTION
## Summary

Fixes the dispatch stall where 7 queued tasks had 0 running workers. Root cause: AI supervisor's `_exec_create_task` appended tasks to TODO.md but `commit_and_push_todo` failed silently (merge conflict). Auto-pickup added the tasks to the DB from the local (uncommitted) copy, but the next `git pull` removed the uncommitted lines — creating orphaned DB tasks that could never be dispatched.

## Changes

1. **dispatch.sh**: Fix `grep -c` multi-line output causing bash `[[` syntax error in cross-repo validation. Added `head -1` pipe and default value.

2. **ai-actions.sh**: `_exec_create_task` now verifies `commit_and_push_todo` succeeds. On failure, reverts the TODO.md append and returns error — preventing orphaned DB tasks from being created.

3. **todo-sync.sh**: Phase 0.6 now cancels queued tasks not found in any TODO.md instead of silently skipping them (previously deferred to non-existent "Phase 7b"). This is the self-healing safety net — even if orphans are created by other paths, they'll be cleaned up within one pulse cycle.

## Impact

- Prevents permanent dispatch stalls from orphaned DB tasks
- Self-healing: orphans are auto-cancelled within 2 minutes (one pulse cycle)
- No changes to the happy path — only affects error recovery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Task creation now includes commit verification; failed commits automatically revert pending entries to prevent orphaned task artifacts
  * Enhanced task dispatch calculation with safer numeric handling to properly handle edge cases
  * Orphaned tasks in the database that are missing from task records are now automatically detected and cancelled for improved system consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->