### PR TITLE
t1263: Fix false-positive claim detection and add verified skip in auto-pickup

### DIFF
--- a/.agents/scripts/supervisor/cron.sh
+++ b/.agents/scripts/supervisor/cron.sh
@@ -540,9 +540,10 @@ cmd_auto_pickup() {
 				continue
 			fi
 
-			# Skip tasks with assignee: or started: fields (t1062)
-			# These indicate someone is already working on the task
-			if echo "$line" | grep -qE '(assignee:|started:)'; then
+			# Skip tasks with assignee: or started: metadata fields (t1062, t1263)
+			# Match actual metadata fields, not description text containing these words.
+			# assignee: must be followed by a username (word chars), started: by ISO timestamp.
+			if echo "$line" | grep -qE '(assignee:[a-zA-Z0-9_-]+|started:[0-9]{4}-[0-9]{2}-[0-9]{2}T)'; then
 				log_info "  $task_id: already claimed or in progress — skipping auto-pickup"
 				continue
 			fi
@@ -556,7 +557,7 @@ cmd_auto_pickup() {
 			local existing
 			existing=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$task_id")';" 2>/dev/null || true)
 			if [[ -n "$existing" ]]; then
-				if [[ "$existing" == "complete" || "$existing" == "cancelled" ]]; then
+				if [[ "$existing" == "complete" || "$existing" == "cancelled" || "$existing" == "verified" ]]; then
 					continue
 				fi
 				log_info "  $task_id: already tracked (status: $existing)"
@@ -616,9 +617,10 @@ cmd_auto_pickup() {
 				continue
 			fi
 
-			# Skip tasks with assignee: or started: fields (t1062)
-			# These indicate someone is already working on the task
-			if echo "$line" | grep -qE '(assignee:|started:)'; then
+			# Skip tasks with assignee: or started: metadata fields (t1062, t1263)
+			# Match actual metadata fields, not description text containing these words.
+			# assignee: must be followed by a username (word chars), started: by ISO timestamp.
+			if echo "$line" | grep -qE '(assignee:[a-zA-Z0-9_-]+|started:[0-9]{4}-[0-9]{2}-[0-9]{2}T)'; then
 				log_info "  $task_id: already claimed or in progress — skipping auto-pickup"
 				continue
 			fi
@@ -631,7 +633,7 @@ cmd_auto_pickup() {
 			local existing
 			existing=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$task_id")';" 2>/dev/null || true)
 			if [[ -n "$existing" ]]; then
-				if [[ "$existing" == "complete" || "$existing" == "cancelled" ]]; then
+				if [[ "$existing" == "complete" || "$existing" == "cancelled" || "$existing" == "verified" ]]; then
 					continue
 				fi
 				log_info "  $task_id: already tracked (status: $existing)"
@@ -764,8 +766,8 @@ cmd_auto_pickup() {
 					continue
 				fi
 
-				# Skip tasks with assignee: or started: fields
-				if echo "$sub_line" | grep -qE '(assignee:|started:)'; then
+				# Skip tasks with assignee: or started: metadata fields (t1263)
+				if echo "$sub_line" | grep -qE '(assignee:[a-zA-Z0-9_-]+|started:[0-9]{4}-[0-9]{2}-[0-9]{2}T)'; then
 					log_info "  $sub_id: already claimed or in progress — skipping subtask pickup"
 					continue
 				fi


### PR DESCRIPTION
## Summary

- Fix naive `grep -qE '(assignee:|started:)'` matching description text instead of metadata fields
- Add `verified` to silent-skip status list (was only `complete` and `cancelled`)
- Applied to all 3 grep locations (Strategy 1, Strategy 2, subtask pickup)

## Root Cause

Tasks like t1113 contain `worker_never_started:no_sentinel` in their description. The old regex matched `started:` in that text and skipped the task as "already claimed". Similarly, t1263's description mentions `assignee:` and `started:` when explaining the stale-claim problem.

This caused 4 genuinely dispatchable aidevops tasks to be permanently skipped by auto-pickup, stalling the queue for 2+ days.

## Fix

Tightened regex patterns:
- `assignee:` must be followed by word characters (a username): `assignee:[a-zA-Z0-9_-]+`
- `started:` must be followed by an ISO timestamp: `started:[0-9]{4}-[0-9]{2}-[0-9]{2}T`

Also added `verified` to the silent-skip list so verified tasks don't log noisy "already tracked" messages.

## Testing

- ShellCheck: zero errors
- Manual auto-pickup: 4 tasks (t1113, t1190, t1248, t1263) now correctly picked up
- Tasks with real `assignee:username` and `started:2026-...` fields still correctly skipped

## Broader Context

This is the immediate regex fix. The broader self-healing improvement (AI-driven stale-claim detection, TODO/DB reconciliation) remains as the t1263 TODO entry for autonomous dispatch.

Closes #1978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved auto-pickup task filtering with more precise metadata field detection to prevent false matches in automated task processing
  * Extended terminal task status handling to recognize "verified" as a terminal state alongside completed and cancelled tasks, preventing further automated pickup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->