### PR TITLE
t1266: Add daily OpenClaw auto-update to housekeeping routine

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -540,7 +540,7 @@ check_openclaw_freshness() {
 	# Check if user has a channel preference in openclaw config
 	local openclaw_channel=""
 	openclaw_channel=$(openclaw update status 2>/dev/null | grep "Channel" | sed 's/[^a-zA-Z]*Channel[^a-zA-Z]*//' | awk '{print $1}' || true)
-	if [[ -n "$openclaw_channel" && "$openclaw_channel" != "stable" ]]; then
+	if [[ "$openclaw_channel" =~ ^(beta|dev)$ ]]; then
 		update_cmd=(openclaw update --channel "$openclaw_channel" --yes --no-restart)
 	fi
 


### PR DESCRIPTION
## Summary

- Adds `check_openclaw_freshness()` to `auto-update-helper.sh` — daily 24h-gated OpenClaw update check, same pattern as the existing skill freshness check
- Silently skips if `openclaw` CLI is not installed (no-op for users without it)
- Respects user's configured channel (beta/dev/stable) by parsing `openclaw update status`
- Opt-out via `AIDEVOPS_OPENCLAW_AUTO_UPDATE=false`; frequency via `AIDEVOPS_OPENCLAW_FRESHNESS_HOURS`
- State tracked in `auto-update-state.json` (`last_openclaw_check`); visible in `aidevops auto-update status`

## Testing

- ShellCheck: zero new violations (only pre-existing SC1091)
- `bash -n`: syntax OK
- Verified `openclaw update --yes --no-restart` works correctly (updated 2026.2.15 -> 2026.2.19-2)
- Channel detection tested against `openclaw update status` table output

Closes #1994

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic daily OpenClaw update checks (24-hour frequency).
  * Made auto-update checks opt-out via environment variable configuration.
  * Added configurable freshness interval for update checks.
  * Extended status output to display OpenClaw version and last check timestamp.

* **Documentation**
  * Updated help text and environment variable documentation with OpenClaw auto-update settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->