### PR TITLE
t1265: Fix SIGPIPE in _launchd_is_loaded breaking plist content comparison

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -109,7 +109,11 @@ _get_scheduler_backend() {
 # Returns: 0 if loaded, 1 if not
 #######################################
 _launchd_is_loaded() {
-	launchctl list 2>/dev/null | grep -qF "$LAUNCHD_LABEL"
+	# Use a variable to avoid SIGPIPE (141) when grep -q exits early
+	# under set -o pipefail (t1265)
+	local output
+	output=$(launchctl list 2>/dev/null) || true
+	echo "$output" | grep -qF "$LAUNCHD_LABEL"
 	return $?
 }
 

--- a/.agents/scripts/repo-sync-helper.sh
+++ b/.agents/scripts/repo-sync-helper.sh
@@ -108,7 +108,11 @@ _get_scheduler_backend() {
 # Returns: 0 if loaded, 1 if not
 #######################################
 _launchd_is_loaded() {
-	launchctl list 2>/dev/null | grep -qF "$LAUNCHD_LABEL"
+	# Use a variable to avoid SIGPIPE (141) when grep -q exits early
+	# under set -o pipefail (t1265)
+	local output
+	output=$(launchctl list 2>/dev/null) || true
+	echo "$output" | grep -qF "$LAUNCHD_LABEL"
 	return $?
 }
 

--- a/.agents/scripts/supervisor/launchd.sh
+++ b/.agents/scripts/supervisor/launchd.sh
@@ -54,7 +54,11 @@ _plist_path() {
 #######################################
 _launchd_is_loaded() {
 	local label="$1"
-	launchctl list 2>/dev/null | grep -qF "$label"
+	# Use a variable to avoid SIGPIPE (141) when grep -q exits early
+	# under set -o pipefail (t1265)
+	local output
+	output=$(launchctl list 2>/dev/null) || true
+	echo "$output" | grep -qF "$label"
 	return $?
 }
 


### PR DESCRIPTION
## Summary

- Fix SIGPIPE (exit 141) in `_launchd_is_loaded()` that prevented the plist content comparison from PR #1993 from ever executing
- Follow-up to #1993 — the content comparison logic was correct but never reached due to this pipeline bug

## Root Cause

`launchctl list | grep -qF` under `set -o pipefail`:
1. `launchctl list` produces large output
2. `grep -qF` finds match and exits immediately
3. `launchctl list` receives SIGPIPE, exits with code 141
4. `pipefail` propagates 141 as the pipeline exit code
5. `_launchd_is_loaded` returns 141 (truthy in bash but non-zero)
6. `if _launchd_is_loaded` evaluates as **false** — skips the content comparison
7. Script falls through to write + load the plist every time

## Fix

Capture `launchctl list` output into a variable first (`|| true` to handle any launchctl errors), then grep the variable. No pipeline, no SIGPIPE.

Applied to:
- `auto-update-helper.sh` — `_launchd_is_loaded()`
- `supervisor/launchd.sh` — `_launchd_is_loaded()`
- `repo-sync-helper.sh` — `_launchd_is_loaded()`
- `setup.sh` — new `_launchd_has_agent()` helper replacing 5 inline `launchctl list | grep` calls

Closes #1992