### PR TITLE
t1272: Add missing MuAPI endpoints — specialized apps, storyboarding, payments

### DIFF
--- a/.agents/tools/video/muapi.md
+++ b/.agents/tools/video/muapi.md
@@ -18,10 +18,10 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Unified API for multimodal AI generation (image, video, audio, VFX, music, lipsync, workflows, agents)
+- **Purpose**: Unified API for multimodal AI generation (image, video, audio, VFX, music, lipsync, specialized apps, storyboarding, workflows, agents)
 - **API**: REST API at `https://api.muapi.ai/api/v1`
 - **Auth**: API key via `x-api-key` header, stored as `MUAPI_API_KEY` env var
-- **CLI**: `muapi-helper.sh [generate|video-effects|vfx|motion|flux|music|lipsync|agents|workflows|status|help]`
+- **CLI**: `muapi-helper.sh [flux|video-effects|vfx|motion|music|lipsync|face-swap|upscale|bg-remove|dress-change|stylize|product-shot|storyboard|agent-*|balance|usage|status|help]`
 - **Pattern**: Async submit + poll (same as WaveSpeed/Runway)
 - **Docs**: [muapi.ai/docs](https://muapi.ai/docs/introduction)
 
@@ -35,9 +35,11 @@ tools:
 - Music generation (Suno create/remix/extend)
 - Lip-synchronization (Sync-Lipsync, LatentSync, Creatify, Veed)
 - Audio utilities (MMAudio text-to-audio, video-to-video audio sync)
+- Specialized apps (face swap, skin enhancer, dress change, upscale, background removal, object eraser, image extension, product photography, Ghibli/anime stylization)
+- Storyboarding (character persistence, scene management, episodic structure)
 - Multi-step workflows (node-based AI pipelines via API)
 - AI agents (persistent personas with skills and memory)
-- Storyboarding (character/scene consistency across shots)
+- Payments and credits (balance check, usage tracking)
 
 <!-- AI-CONTEXT-END -->
 
@@ -203,6 +205,92 @@ POST   /agents/{agent_id}/chat           # Chat with agent
 
 Agents are persistent AI personas with skills, memory (via `conversation_id`), and access to the full model catalog.
 
+### Specialized Apps
+
+All specialized apps follow the standard async submit + poll pattern. Submit with input data, receive `request_id`, poll at `/api/v1/predictions/{id}/result`.
+
+#### Portrait & Identity
+
+```bash
+POST /api/v1/ai-image-face-swap         # Face swap on images
+POST /api/v1/ai-video-face-swap         # Face swap on videos
+POST /api/v1/ai-skin-enhancer           # Skin retouching and blemish removal
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `image` / `image_url` | string | Yes | Source image/video URL |
+| `face_image` | string | Yes (face-swap) | Face reference image URL |
+
+#### Creative Transformations
+
+```bash
+POST /api/v1/ai-dress-change            # Swap outfits via text or reference
+POST /api/v1/ai-ghibli-style            # Studio Ghibli stylization
+POST /api/v1/ai-anime-generator         # Anime style transformation
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `image_url` | string | Yes | Source image URL |
+| `prompt` | string | No | Description of desired outfit/style |
+
+#### Image Processing & Utilities
+
+```bash
+POST /api/v1/ai-image-upscale           # Increase resolution with detail regeneration
+POST /api/v1/ai-background-remover      # High-precision subject isolation
+POST /api/v1/ai-object-eraser           # Remove unwanted elements with inpainting
+POST /api/v1/ai-image-extension         # Outpaint beyond original borders
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `image_url` | string | Yes | Source image URL |
+| `mask_url` | string | No (eraser) | Mask indicating area to erase |
+| `prompt` | string | No (extension) | Description for outpainted area |
+
+#### Product & Marketing
+
+```bash
+POST /api/v1/ai-product-shot            # Studio-quality product backgrounds
+POST /api/v1/ai-product-photography     # High-converting product assets
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `image_url` | string | Yes | Product image URL |
+| `prompt` | string | No | Background/scene description |
+
+### Storyboarding
+
+Cinematic production system with character persistence across scenes and episodes.
+
+```bash
+POST /api/storyboard/projects           # Create storyboard project
+```
+
+**Process**:
+
+1. **Character Creation** — Define `StoryboardCharacter` with static features (age, hair) and dynamic features (outfit, mood)
+2. **Project Setup** — Create project housing characters and creative brief
+3. **Episode Generation** — Generate or manually create episodes within the project
+4. **Scene & Shot Definition** — Link shots to characters and backgrounds for visual consistency
+
+Asset generation uses models like Flux and Runway. Storyboard assets can feed into workflows for post-processing (VFX, color grading).
+
+### Payments & Credits
+
+Credit-based consumption system with Stripe integration.
+
+```bash
+GET /api/payments/create_credits_checkout_session   # Purchase credits via Stripe
+```
+
+- **Credit Wallet** — Every user has a `CreditWallet`; generations deduct credits based on model cost and duration
+- **Usage Log** — Complete history of API calls with cost, status, input/output data
+- **Enterprise** — Custom credit limits, private deployment billing, multi-key project tracking
+
 ## CLI Helper
 
 ```bash
@@ -225,6 +313,22 @@ muapi-helper.sh music "upbeat electronic track with synths"
 
 # Lip-sync
 muapi-helper.sh lipsync --video https://example.com/video.mp4 --audio https://example.com/audio.mp3
+
+# Specialized apps
+muapi-helper.sh face-swap --image https://example.com/photo.jpg --face https://example.com/face.jpg
+muapi-helper.sh face-swap --video https://example.com/video.mp4 --face https://example.com/face.jpg --mode video
+muapi-helper.sh upscale --image https://example.com/lowres.jpg
+muapi-helper.sh bg-remove --image https://example.com/product.jpg
+muapi-helper.sh dress-change --image https://example.com/person.jpg "red evening gown"
+muapi-helper.sh stylize --image https://example.com/photo.jpg --style ghibli
+muapi-helper.sh product-shot --image https://example.com/product.jpg "minimalist white studio"
+muapi-helper.sh object-erase --image https://example.com/scene.jpg --mask https://example.com/mask.png
+muapi-helper.sh image-extend --image https://example.com/photo.jpg "extend the landscape"
+muapi-helper.sh skin-enhance --image https://example.com/portrait.jpg
+
+# Credits
+muapi-helper.sh balance
+muapi-helper.sh usage
 
 # Check task status
 muapi-helper.sh status <request-id>
@@ -270,6 +374,8 @@ muapi-helper.sh agent-list
 | Video models | Wan, Runway, Kling, Luma | Wan, Kling, Sora, Veo | Gen-4, Veo 3, Act Two |
 | Audio | Suno music, MMAudio, lipsync | Ace Step music, TTS | ElevenLabs TTS/STS/SFX |
 | VFX/Effects | Built-in effects library | None | None |
+| Specialized Apps | Face swap, upscale, bg-remove, dress change, stylize, product shot | None | None |
+| Storyboarding | Character persistence, episodic structure | None | None |
 | Workflows | Node-based pipeline builder | None | None |
 | Agents | Persistent AI personas | None | None |
 | Auth | `x-api-key` header | Bearer token | Bearer token |


### PR DESCRIPTION
## Summary

- Add 12 specialized app endpoints to muapi.md: face swap (image/video), skin enhancer, dress change, Ghibli/anime stylization, image upscale, background remover, object eraser, image extension, product shot, product photography
- Add storyboarding documentation (character persistence, episodic structure, scene/shot management)
- Add payments & credits section (credit wallet, usage tracking, Stripe checkout)
- Add 11 new CLI commands to muapi-helper.sh: `face-swap`, `upscale`, `bg-remove`, `dress-change`, `stylize`, `product-shot`, `object-erase`, `image-extend`, `skin-enhance`, `balance`, `usage`
- Shared `submit_specialized()` helper function for DRY implementation across all specialized app commands
- Updated comparison table with Specialized Apps and Storyboarding rows
- Zero ShellCheck violations, zero markdownlint violations

## Files Changed

- `.agents/tools/video/muapi.md` — Documentation for all new endpoints
- `.agents/scripts/muapi-helper.sh` — CLI commands for all new endpoints

## Testing

- `shellcheck .agents/scripts/muapi-helper.sh` — zero violations
- `bash -n .agents/scripts/muapi-helper.sh` — syntax valid
- `markdownlint .agents/tools/video/muapi.md` — zero violations