### PR TITLE
t1279: Fix wp-helper.sh run_wp_command() CONFIG_FILE not propagated from get_site_config subshell

### DIFF
--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -99,7 +99,7 @@ resolve_server_ref() {
 	server_def=$(jq -r --arg ref "$server_ref" '.servers[$ref] // empty' "$CONFIG_FILE" 2>/dev/null)
 
 	if [[ -z "$server_def" ]]; then
-		print_warning "server_ref '$server_ref' not found in servers section — using site config as-is"
+		print_warning "server_ref '$server_ref' not found in servers section — using site config as-is" >&2
 		echo "$site_config"
 		return 0
 	fi
@@ -349,6 +349,8 @@ run_wp_command() {
 		print_error "$ERROR_COMMAND_REQUIRED"
 		exit 1
 	fi
+
+	load_config
 
 	local site_config
 	site_config=$(get_site_config "$site_key")


### PR DESCRIPTION
## Summary

Two related bugs in `wp-helper.sh` affecting the most common code path (`run_wp_command`):

**Bug 1 — Missing `load_config` before subshell call**

`run_wp_command()` called `get_site_config()` via command substitution `$()` without first calling `load_config`. The `CONFIG_FILE` variable set inside `get_site_config`'s subshell was lost when the subshell exited, leaving `CONFIG_FILE` empty when `execute_wp_via_ssh()` → `resolve_server_ref()` tried to read it.

Fix: added `load_config` before the `get_site_config "$site_key"` call, matching the pattern already used by `run_on_category()` and `run_on_all()`.

**Bug 2 — `print_warning` stdout pollution in `resolve_server_ref()`**

`print_warning` (via `print_shared_warning`) outputs to stdout without `>&2`. When `resolve_server_ref()` emits a warning for a missing `server_ref`, the warning text was captured by the `$()` in `execute_wp_via_ssh`, prepended to the JSON, and caused downstream `jq` parse errors.

Fix: added `>&2` redirect to the `print_warning` call in `resolve_server_ref()` so the warning goes to stderr and does not pollute the captured JSON.

## Verification

- ShellCheck: zero violations (`shellcheck -x -S warning .agents/scripts/wp-helper.sh`)
- Both fixes match patterns already established in the codebase

Ref #1991