### PR TITLE
t1280: Extend skills discovery with skills.sh registry search

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -506,6 +506,16 @@ Import community skills: `aidevops skill add <source>` (→ `*-skill.md` suffix)
 
 **Commands**: `aidevops skills search <query>`, `aidevops skills browse <category>`, `aidevops skills describe <name>`, `aidevops skills categories`, `aidevops skills recommend "<task>"`, `aidevops skills list [--imported]`
 
+**Online registry search**: Search the public [skills.sh](https://skills.sh/) registry for community skills:
+
+```bash
+aidevops skills search --registry "browser automation"
+aidevops skills search --online "seo"
+aidevops skills install vercel-labs/agent-browser@agent-browser
+```
+
+When local search returns no results, the `/skills` command suggests searching the public registry automatically.
+
 **Cross-tool**: Claude marketplace plugin, Agent Skills (SKILL.md), Claude Code agents, manual AGENTS.md reference.
 
 **Skill persistence**: Imported skills are stored in `~/.aidevops/agents/` and tracked in `configs/skill-sources.json`. The daily auto-update skill refresh (see Auto-Update above) keeps them current from upstream. Note: `aidevops update` overwrites shared agent files — only `custom/` and `draft/` survive. Re-import skills after an update, or place them in `custom/` for persistence.

--- a/.agents/scripts/commands/skills.md
+++ b/.agents/scripts/commands/skills.md
@@ -16,12 +16,15 @@ Parse `$ARGUMENTS` to determine what to run:
 
 - If empty or "help": show available commands and quick examples
 - If starts with "search" or is a free-text query: search for matching skills
+- If "search --registry" or "search --online" <query>: search the public skills.sh registry
 - If "browse" [category]: browse skills by category
 - If "describe" or "show" <name>: show detailed skill description
 - If "info" <name>: show metadata (path, source, model tier)
 - If "list" [filter]: list all skills with optional filter
 - If "categories" or "cats": list all categories with counts
 - If "recommend" <task>: suggest skills for a task description
+- If "install" <owner/repo@skill>: install from the public skills.sh registry
+- If "registry" or "online" <query>: search the public skills.sh registry
 - If "add" <source>: delegate to `aidevops skill add` for importing
 - If "update" or "check": delegate to `aidevops skill check/update`
 - If "remove" <name>: delegate to `aidevops skill remove`
@@ -32,6 +35,14 @@ Parse `$ARGUMENTS` to determine what to run:
 
 ```bash
 ~/.aidevops/agents/scripts/skills-helper.sh search "$ARGUMENTS"
+```
+
+**Search the public skills.sh registry (online):**
+
+```bash
+~/.aidevops/agents/scripts/skills-helper.sh search --registry "$ARGUMENTS"
+# or
+~/.aidevops/agents/scripts/skills-helper.sh search --online "$ARGUMENTS"
 ```
 
 **Browse categories:**
@@ -77,6 +88,14 @@ Parse `$ARGUMENTS` to determine what to run:
 ~/.aidevops/agents/scripts/skills-helper.sh recommend "scrape a website and extract product data"
 ```
 
+**Install from public registry:**
+
+```bash
+~/.aidevops/agents/scripts/skills-helper.sh install vercel-labs/agent-browser@agent-browser
+# or via aidevops CLI
+aidevops skills install vercel-labs/agent-browser@agent-browser
+```
+
 **Import/manage (delegate to existing skill commands):**
 
 ```bash
@@ -93,6 +112,12 @@ Format the output conversationally:
 - **Browse**: Show skills grouped by category with descriptions
 - **Describe**: Full description, subagents, preview, and usage hints
 - **Recommend**: Matched categories with relevant skills and usage tips
+- **Registry search**: Results from skills.sh with install count and URL
+
+**When local search returns no results**, proactively offer registry search:
+
+> "No local skills found for '<query>'. Search the public skills.sh registry?"
+> Run: `/skills search --registry <query>`
 
 ### Step 4: Offer Follow-up Actions
 
@@ -100,10 +125,12 @@ After presenting results, suggest relevant next steps:
 
 ```text
 Next steps:
-1. /skills describe <name>    — Get full details on a skill
-2. /skills browse <category>  — Explore a category
-3. /skills recommend "<task>" — Get task-specific suggestions
-4. aidevops skill add <repo>  — Import a community skill
+1. /skills describe <name>              — Get full details on a skill
+2. /skills browse <category>            — Explore a category
+3. /skills recommend "<task>"           — Get task-specific suggestions
+4. /skills search --registry "<query>"  — Search the public skills.sh registry
+5. /skills install <owner/repo@skill>   — Install from the public registry
+6. aidevops skill add <repo>            — Import a community skill
 ```
 
 ## Quick Reference
@@ -113,6 +140,7 @@ Next steps:
 | `/skills` | Show help and quick examples |
 | `/skills browser` | Search for browser-related skills |
 | `/skills search "deploy"` | Search by keyword |
+| `/skills search --registry "seo"` | Search the public skills.sh registry |
 | `/skills browse tools` | Browse tools category |
 | `/skills browse services` | Browse services category |
 | `/skills describe playwright` | Full description of playwright |
@@ -120,6 +148,7 @@ Next steps:
 | `/skills list --imported` | List imported community skills |
 | `/skills categories` | List all categories with counts |
 | `/skills recommend "test my API"` | Get skill recommendations |
+| `/skills install owner/repo@skill` | Install from public registry |
 
 ## Conversational Mode
 
@@ -131,8 +160,14 @@ When the user asks questions like:
 - "I need to deploy a Next.js app" → Run recommend "deploy Next.js app"
 - "How many skills are installed?" → Run list, report count
 - "What categories are available?" → Run categories
+- "Are there any public skills for X?" → Run search --registry "X"
+- "Find skills on skills.sh for Y" → Run search --registry "Y"
+- "Install the vercel browser skill" → Run install vercel-labs/agent-browser@agent-browser
 
 Interpret natural language intent and map to the appropriate command.
+
+**Registry search fallback**: When local search returns 0 results, always suggest:
+> "No local skills found. Try the public registry: `/skills search --registry <query>`"
 
 ## Related
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -2661,6 +2661,12 @@ cmd_skills() {
 	recommend | rec | suggest)
 		bash "$skills_helper" recommend "$@"
 		;;
+	install | add)
+		bash "$skills_helper" install "$@"
+		;;
+	registry | online)
+		bash "$skills_helper" registry "$@"
+		;;
 	help | --help | -h)
 		print_header "Skill Discovery & Exploration"
 		echo ""
@@ -2670,19 +2676,23 @@ cmd_skills() {
 		echo "Usage: aidevops skills <command> [options]"
 		echo ""
 		echo "Commands:"
-		echo "  search <query>     Search skills by keyword"
-		echo "  browse [category]  Browse skills by category"
-		echo "  describe <name>    Show detailed skill description"
-		echo "  info <name>        Show skill metadata (path, source, model tier)"
-		echo "  list [filter]      List skills (--imported, --native, --all)"
-		echo "  categories         List all categories with skill counts"
-		echo "  recommend <task>   Suggest skills for a task description"
+		echo "  search <query>          Search installed skills by keyword"
+		echo "  search --registry <q>   Search the public skills.sh registry (online)"
+		echo "  browse [category]       Browse skills by category"
+		echo "  describe <name>         Show detailed skill description"
+		echo "  info <name>             Show skill metadata (path, source, model tier)"
+		echo "  list [filter]           List skills (--imported, --native, --all)"
+		echo "  categories              List all categories with skill counts"
+		echo "  recommend <task>        Suggest skills for a task description"
+		echo "  install <owner/repo@s>  Install a skill from the public registry"
 		echo ""
 		echo "Options:"
-		echo "  --json             Output in JSON format (for scripting)"
+		echo "  --json                  Output in JSON format (for scripting)"
+		echo "  --registry, --online    Search the public skills.sh registry"
 		echo ""
 		echo "Examples:"
 		echo "  aidevops skills search \"browser automation\""
+		echo "  aidevops skills search --registry \"seo\""
 		echo "  aidevops skills browse tools"
 		echo "  aidevops skills browse tools/browser"
 		echo "  aidevops skills describe playwright"
@@ -2690,6 +2700,7 @@ cmd_skills() {
 		echo "  aidevops skills list --imported"
 		echo "  aidevops skills categories"
 		echo "  aidevops skills recommend \"deploy a Next.js app\""
+		echo "  aidevops skills install vercel-labs/agent-browser@agent-browser"
 		echo ""
 		echo "See also: aidevops skill help  (import/manage skills)"
 		;;


### PR DESCRIPTION
## Summary

- Add `search --registry <query>` / `search --online <query>` to `skills-helper.sh` — runs `npx skills find <query>` and displays results from the public [skills.sh](https://skills.sh/) registry
- Add `install <owner/repo@skill>` subcommand to `skills-helper.sh` — delegates to `npx skills add <pkg> -g -y`
- When local search returns 0 results, suggest registry search with the exact command to run
- Update `aidevops skills` CLI to expose `install` and `registry` subcommands with updated help text
- Update `/skills` chat command (`commands/skills.md`) to document registry search and offer it as fallback
- Update `AGENTS.md` Skills section with online search examples

## Changes

- `.agents/scripts/skills-helper.sh`: `cmd_search_registry()`, `cmd_install()`, `--registry`/`--online` flag handling, no-results registry hint
- `aidevops.sh`: `install` and `registry` subcommands in `cmd_skills()`, updated help
- `.agents/scripts/commands/skills.md`: registry search docs, install docs, fallback workflow
- `.agents/AGENTS.md`: Skills section updated with online search examples

## Testing

```bash
# Registry search
aidevops skills search --registry "browser automation"
aidevops skills search --online "seo"

# Install shortcut
aidevops skills install vercel-labs/agent-browser@agent-browser

# No-results fallback hint
aidevops skills search "nonexistent-xyz-skill"
```

Ref #2034