### PR TITLE
t1285: Fix supervisor pipeline — BSD sed, dedup suppression, adaptive pulsing

### DIFF
--- a/.agents/scripts/supervisor/ai-actions.sh
+++ b/.agents/scripts/supervisor/ai-actions.sh
@@ -159,7 +159,11 @@ _compute_target_state_hash() {
 				blocked=$(printf '%s' "$task_line" | grep -oE 'blocked-by:[^ ]+' || echo "")
 				local pr_field
 				pr_field=$(printf '%s' "$task_line" | grep -oE 'pr:#[0-9]+' || echo "")
-				state_data="${checkbox}|${assignee}|${started}|${blocked}|${pr_field}"
+				# t1285: Include [proposed:...] annotations in state hash so
+				# cycle-aware dedup detects two-phase flow state changes
+				local proposed
+				proposed=$(printf '%s' "$task_line" | grep -oE '\[proposed:[^]]*\]' || echo "")
+				state_data="${checkbox}|${assignee}|${started}|${blocked}|${pr_field}|${proposed}"
 			fi
 		fi
 		# Also check DB state
@@ -239,6 +243,34 @@ _is_duplicate_action() {
 	# Dedup disabled
 	if [[ "${AI_ACTION_DEDUP_WINDOW:-0}" -eq 0 ]]; then
 		return 1
+	fi
+
+	# t1285: Exempt propose_auto_dispatch confirmation phase from dedup.
+	# The two-phase flow uses the same action type for both phases:
+	#   Phase 1: propose_auto_dispatch adds [proposed:auto-dispatch] annotation
+	#   Phase 2: propose_auto_dispatch converts annotation to #auto-dispatch tag
+	# The state hash doesn't capture [proposed:...] annotations, so the dedup
+	# window suppresses Phase 2 for ~2.5 hours (5 cycles). Fix: when the target
+	# task already has [proposed:auto-dispatch], bypass dedup to allow confirmation.
+	if [[ "$action_type" == "propose_auto_dispatch" ]]; then
+		local target_task_id="${target#task:}"
+		local _pad_todo_file=""
+		# Search for the task in TODO.md files across registered repos
+		for _pad_search_dir in "${REPO_PATH:-}" $(db "$SUPERVISOR_DB" "SELECT DISTINCT repo FROM tasks WHERE repo IS NOT NULL AND repo != '';" 2>/dev/null || echo ""); do
+			[[ -z "$_pad_search_dir" || ! -f "$_pad_search_dir/TODO.md" ]] && continue
+			if grep -qE "^[[:space:]]*- \[ \] ${target_task_id}( |$)" "$_pad_search_dir/TODO.md" 2>/dev/null; then
+				_pad_todo_file="$_pad_search_dir/TODO.md"
+				break
+			fi
+		done
+		if [[ -n "$_pad_todo_file" ]]; then
+			local _pad_task_line
+			_pad_task_line=$(grep -E "^[[:space:]]*- \[ \] ${target_task_id}( |$)" "$_pad_todo_file" 2>/dev/null | head -1 || echo "")
+			if echo "$_pad_task_line" | grep -q '\[proposed:auto-dispatch'; then
+				log_verbose "AI Actions: dedup bypass for propose_auto_dispatch on $target (Phase 2 confirmation)"
+				return 1
+			fi
+		fi
 	fi
 
 	# Check if DB and table exist
@@ -2286,7 +2318,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 		detect_repo_slug() {
 			local repo_path="${1:-.}"
 			git -C "$repo_path" remote get-url origin 2>/dev/null |
-				sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#' || echo ""
+				sed -E 's#.*[:/]([^/]+/[^/]+)$#\1#' | sed 's/\.git$//' || echo ""
 			return 0
 		}
 	fi

--- a/.agents/scripts/supervisor/routine-scheduler.sh
+++ b/.agents/scripts/supervisor/routine-scheduler.sh
@@ -167,7 +167,7 @@ routine_refresh_signals() {
 	if command -v gh &>/dev/null; then
 		local gh_repo=""
 		gh_repo=$(git -C "${REPO_PATH:-$(pwd)}" remote get-url origin 2>/dev/null |
-			sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#' || echo "")
+			sed -E 's#.*[:/]([^/]+/[^/]+)$#\1#' | sed 's/\.git$//' || echo "")
 		if [[ -n "$gh_repo" ]]; then
 			critical_count=$(gh issue list --repo "$gh_repo" --state open \
 				--search 'label:bug,critical,P0,P1,"severity:critical","severity:high"' \


### PR DESCRIPTION
## Summary

Fixes 4 interconnected issues preventing the supervisor pipeline from dispatching tasks:

- **BSD sed regex error** — `+?` lazy quantifier unsupported on macOS BSD sed, causing repo slug extraction to fail every pulse cycle (3 files fixed)
- **Bash arithmetic error** — `grep -c` returning multi-line output causing `[[: 0 0: syntax error in expression` in `has_actionable_work()`
- **Dedup suppression blocking auto-dispatch** — Two-phase `propose_auto_dispatch` flow was broken because Phase 2 (confirmation) was suppressed by dedup window (~2.5 hours). 864 total suppressions observed. Fixed with explicit bypass + state hash improvement
- **Fixed 300s AI reasoning cooldown** — Now adaptive: 60s when queued tasks exist, 600s when idle. Configurable via `SUPERVISOR_AI_COOLDOWN_ACTIVE` and `SUPERVISOR_AI_COOLDOWN_IDLE`

## Changes

| File | Fix |
|------|-----|
| `ai-reason.sh` | BSD sed fix, grep -c sanitization, adaptive cooldown |
| `ai-actions.sh` | BSD sed fix, dedup bypass for Phase 2 confirmation, `[proposed:...]` in state hash |
| `routine-scheduler.sh` | BSD sed fix |

## Testing

- ShellCheck: zero new violations on all 3 files
- BSD sed regex verified on macOS: correctly extracts `owner/repo` from SSH and HTTPS URLs with/without `.git` suffix
- Phase 0.7 stale-eval recovery confirmed working (t1120.4 already recovered to `verified`)

## Post-merge

After merge and `aidevops update`, reset stuck tasks:
```bash
sqlite3 ~/.aidevops/.agent-workspace/supervisor/supervisor.db \
  "UPDATE tasks SET status='queued', retries=0, error=NULL, updated_at=strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id IN ('t1158','t1267');"
```

Closes #2038