### PR TITLE
t1287: Wire -needed blocker tags into cron auto-pickup and AI reasoner park action

### DIFF
--- a/.agents/scripts/supervisor/cron.sh
+++ b/.agents/scripts/supervisor/cron.sh
@@ -553,6 +553,14 @@ cmd_auto_pickup() {
 				continue
 			fi
 
+			# Skip tasks with -needed blocker tags (t1287) — human action required
+			if echo "$line" | grep -qE '(account|hosting|login|api-key|clarification|resources|payment|approval|decision|design|content|dns|domain|testing)-needed'; then
+				local blocker_tag
+				blocker_tag=$(echo "$line" | grep -oE '(account|hosting|login|api-key|clarification|resources|payment|approval|decision|design|content|dns|domain|testing)-needed' | head -1)
+				log_info "  $task_id: blocked by $blocker_tag (human action required) — skipping auto-pickup"
+				continue
+			fi
+
 			# Check if already in supervisor
 			local existing
 			existing=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$task_id")';" 2>/dev/null || true)
@@ -635,6 +643,14 @@ cmd_auto_pickup() {
 
 			# Skip tasks with unresolved blocked-by dependencies (t1085.4)
 			if _check_and_skip_if_blocked "$line" "$task_id" "$todo_file"; then
+				continue
+			fi
+
+			# Skip tasks with -needed blocker tags (t1287) — human action required
+			if echo "$line" | grep -qE '(account|hosting|login|api-key|clarification|resources|payment|approval|decision|design|content|dns|domain|testing)-needed'; then
+				local blocker_tag
+				blocker_tag=$(echo "$line" | grep -oE '(account|hosting|login|api-key|clarification|resources|payment|approval|decision|design|content|dns|domain|testing)-needed' | head -1)
+				log_info "  $task_id: blocked by $blocker_tag (human action required) — skipping auto-pickup"
 				continue
 			fi
 


### PR DESCRIPTION
## Summary

- **cron.sh**: Add `-needed` blocker tag check to `cmd_auto_pickup` (both Strategy 1 and Strategy 2). Tasks tagged with `payment-needed`, `account-needed`, etc. are now skipped during auto-pickup, preventing wasted worker sessions on tasks that require human action.
- **ai-reason.sh**: Add `park_task` as the 11th action type the AI reasoner can propose. Add "Human-action blockers" as the 11th analysis framework step, teaching the AI to identify tasks needing human intervention.
- **ai-actions.sh**: Add `park_task` to valid action types, field validation (validates `blocker_tag` against the 14 known `-needed` tags), and executor (`_exec_park_task`) that appends the tag to the task line in TODO.md and commits.

## Context

The `-needed` blocker tags (t1188.1) were already wired into the eligibility assessment context and sanity-check, but had two gaps:
1. `cron.sh` auto-pickup didn't check for them — a task tagged `#auto-dispatch payment-needed` would still get dispatched
2. The AI reasoner had no way to proactively add `-needed` tags when it identified tasks requiring human action

## Testing

- ShellCheck clean on all three modified files (only pre-existing SC2016/SC1091 info-level)
- Blocker pattern matches the same 14 tags used in `sanity-check.sh` and `ai-context.sh`