### PR TITLE
t031: Add company orchestration agent with runner configs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -87,6 +87,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 
 | Domain | Entry point |
 |--------|-------------|
+| Business | `business.md`, `business/company-runners.md` |
 | Planning | `workflows/plans.md`, `tools/task-management/beads.md` |
 | Accessibility | `services/accessibility/accessibility-audit.md`, `tools/accessibility/accessibility.md` |
 | Code quality | `tools/code-review/code-standards.md` |

--- a/.agents/business.md
+++ b/.agents/business.md
@@ -1,0 +1,193 @@
+---
+name: business
+description: Company orchestration - AI agents managing company functions via runners and coordinator dispatch
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: true
+  grep: true
+subagents:
+  - accounts
+  - sales
+  - marketing
+  - legal
+  - general
+  - explore
+---
+
+# Business - Company Orchestration Agent
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Orchestrate AI agents across company functions (HR, Finance, Operations, Marketing)
+- **Pattern**: Named runners per function, coordinated via `coordinator-helper.sh`
+- **Extends**: Parallel agents (t109), runner-helper.sh, coordinator-helper.sh
+
+**Related Agents**:
+
+- `accounts.md` - Financial operations (QuickFile)
+- `sales.md` - Sales pipeline and CRM (FluentCRM)
+- `marketing.md` - Marketing campaigns and lead generation
+- `legal.md` - Legal compliance and contracts
+
+**Key Scripts**:
+
+- `scripts/runner-helper.sh` - Create and manage named agent instances
+- `scripts/coordinator-helper.sh` - Cross-function task dispatch
+- `scripts/objective-runner-helper.sh` - Long-running objectives with guardrails
+
+<!-- AI-CONTEXT-END -->
+
+## Company Agent Pattern
+
+Inspired by the concept of AI agents managing company functions as autonomous departments,
+each with clear responsibilities, communication channels, and escalation paths.
+
+The pattern maps company departments to named runners that:
+
+1. Have persistent identity and memory (via `runner-helper.sh`)
+2. Communicate through the mailbox system (via `mail-helper.sh`)
+3. Are coordinated by a stateless pulse loop (via `coordinator-helper.sh`)
+4. Operate within safety guardrails (via `objective-runner-helper.sh`)
+
+### Architecture
+
+```text
+coordinator-helper.sh (pulse every 2-5 min)
+├── Reads agent status from SQLite
+├── Processes worker status reports
+├── Dispatches tasks to idle agents
+└── Exits (stateless)
+
+Named Runners (persistent identity):
+├── hiring-coordinator   — Recruitment pipeline
+├── finance-reviewer     — Expense/invoice review
+├── ops-monitor          — Infrastructure and process monitoring
+├── marketing-scheduler  — Campaign scheduling and analytics
+└── support-triage       — Customer issue classification
+```
+
+### Communication Flow
+
+```text
+1. Task arrives (TODO.md, mailbox message, or cron trigger)
+2. coordinator-helper.sh pulse picks it up
+3. Dispatches to appropriate runner via mail-helper.sh
+4. Runner executes with its AGENTS.md personality
+5. Runner sends status_report back to coordinator
+6. Coordinator archives report, dispatches next task
+```
+
+## Setting Up Company Runners
+
+### Quick Start
+
+```bash
+# Create company function runners
+runner-helper.sh create hiring-coordinator \
+  --description "Recruitment pipeline - job posts, candidate screening, interview scheduling" \
+  --model sonnet
+
+runner-helper.sh create finance-reviewer \
+  --description "Expense and invoice review - receipt OCR, approval routing, QuickFile sync" \
+  --model sonnet
+
+runner-helper.sh create ops-monitor \
+  --description "Infrastructure monitoring - uptime checks, deploy verification, incident triage" \
+  --model haiku
+
+# List all runners
+runner-helper.sh list
+
+# Run a task on a specific runner
+runner-helper.sh run hiring-coordinator "Review the 3 latest applications in the hiring pipeline and summarise each candidate's fit"
+```
+
+### Coordinator Integration
+
+```bash
+# Start the coordinator pulse (runs every 5 minutes via cron)
+coordinator-helper.sh watch --interval 300
+
+# Or install as a cron job
+cron-helper.sh add "company-coordinator" \
+  --schedule "*/5 * * * *" \
+  --command "coordinator-helper.sh pulse"
+
+# Manual dispatch to a specific runner
+coordinator-helper.sh dispatch \
+  --task "Review Q1 expense reports for anomalies" \
+  --to finance-reviewer \
+  --priority high
+
+# Group related tasks into a convoy
+coordinator-helper.sh convoy \
+  --name "monthly-close" \
+  --tasks "reconcile-bank,review-expenses,generate-report"
+```
+
+## Example Runner Configurations
+
+See `business/company-runners.md` for detailed runner AGENTS.md templates and
+setup instructions for each company function.
+
+## Cross-Function Workflows
+
+Some tasks span multiple departments. Use convoys or chained dispatch:
+
+### Example: New Hire Onboarding
+
+```bash
+# 1. hiring-coordinator confirms offer accepted
+# 2. Dispatches to finance-reviewer for payroll setup
+# 3. Dispatches to ops-monitor for account provisioning
+
+coordinator-helper.sh convoy \
+  --name "onboard-new-hire" \
+  --tasks "confirm-offer,setup-payroll,provision-accounts"
+```
+
+### Example: Monthly Financial Close
+
+```bash
+coordinator-helper.sh convoy \
+  --name "monthly-close" \
+  --tasks "reconcile-transactions,review-expenses,generate-pnl,send-summary"
+```
+
+## Guardrails
+
+Company runners inherit safety from `objective-runner-helper.sh`:
+
+- **Budget limits**: Max token/cost per run (prevent runaway agents)
+- **Scope constraints**: Path and tool whitelists per runner
+- **Checkpoint reviews**: Periodic human approval for sensitive operations
+- **Audit logging**: Every action logged with timestamps
+- **Rollback**: Git worktree isolation for reversible changes
+
+### Sensitive Operations
+
+Finance and legal runners should always use checkpoint reviews:
+
+```bash
+objective-runner-helper.sh start "Process monthly invoices" \
+  --runner finance-reviewer \
+  --checkpoint-every 5 \
+  --max-cost 2.00 \
+  --allowed-tools "read,bash,quickfile"
+```
+
+## Pre-flight Questions
+
+Before setting up or modifying company orchestration:
+
+1. Which functions need autonomous agents vs. human-triggered workflows?
+2. What is the escalation path when an agent encounters something outside its scope?
+3. What budget and rate limits are appropriate per function?
+4. Which operations require human approval checkpoints?
+5. How will cross-function handoffs be tracked and audited?

--- a/.agents/business.md
+++ b/.agents/business.md
@@ -10,12 +10,11 @@ tools:
   glob: true
   grep: true
 subagents:
+  - company-runners
   - accounts
   - sales
   - marketing
   - legal
-  - general
-  - explore
 ---
 
 # Business - Company Orchestration Agent
@@ -127,8 +126,8 @@ coordinator-helper.sh dispatch \
 
 # Group related tasks into a convoy
 coordinator-helper.sh convoy \
-  --name "monthly-close" \
-  --tasks "reconcile-bank,review-expenses,generate-report"
+  --name "example-convoy" \
+  --tasks "task-a,task-b,task-c"
 ```
 
 ## Example Runner Configurations

--- a/.agents/business/company-runners.md
+++ b/.agents/business/company-runners.md
@@ -193,6 +193,11 @@ You are a marketing operations assistant. Your responsibilities:
 - FluentCRM MCP for email campaigns
 - Google Analytics for performance data
 - Content calendar in TODO.md format
+
+## Communication
+- Send weekly campaign performance summaries to coordinator via status_report
+- Flag campaigns awaiting human approval as priority:high
+- Alert immediately on delivery failures or campaigns with open-rate anomalies
 ```
 
 ## Support Triage
@@ -240,9 +245,12 @@ Create all runners in one go:
 
 set -euo pipefail
 
+# Source shared constants for print_info
+. shared-constants.sh
+
 RUNNER="runner-helper.sh"
 
-echo "Creating company function runners..."
+print_info "Creating company function runners..."
 
 $RUNNER create hiring-coordinator \
   --description "Recruitment pipeline - screening, scheduling, offers" \
@@ -264,12 +272,12 @@ $RUNNER create support-triage \
   --description "Customer issue classification and routing" \
   --model haiku
 
-echo "Done. Runners created:"
+print_info "Done. Runners created:"
 $RUNNER list
 
 echo ""
-echo "Next steps:"
-echo "  1. Edit each runner's AGENTS.md: runner-helper.sh edit <name>"
-echo "  2. Start the coordinator: coordinator-helper.sh watch --interval 300"
-echo "  3. Test a runner: runner-helper.sh run ops-monitor 'Check all health endpoints'"
+print_info "Next steps:"
+print_info "  1. Edit each runner's AGENTS.md: runner-helper.sh edit <name>"
+print_info "  2. Start the coordinator: coordinator-helper.sh watch --interval 300"
+print_info "  3. Test a runner: runner-helper.sh run ops-monitor 'Check all health endpoints'"
 ```

--- a/.agents/business/company-runners.md
+++ b/.agents/business/company-runners.md
@@ -1,0 +1,275 @@
+---
+description: Example runner configurations for company function agents
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+---
+
+# Company Function Runners
+
+Example AGENTS.md templates and setup for common company function runners.
+Each runner is created via `runner-helper.sh create` and gets its own
+personality file at `~/.aidevops/.agent-workspace/runners/<name>/AGENTS.md`.
+
+## Hiring Coordinator
+
+Manages the recruitment pipeline: job descriptions, candidate screening,
+interview scheduling, and offer tracking.
+
+### Setup
+
+```bash
+runner-helper.sh create hiring-coordinator \
+  --description "Recruitment pipeline management" \
+  --model sonnet
+```
+
+### AGENTS.md Template
+
+```markdown
+# Hiring Coordinator
+
+You are a recruitment operations assistant. Your responsibilities:
+
+1. **Job Descriptions**: Draft and refine job postings based on role requirements
+2. **Candidate Screening**: Review applications against job criteria, flag top candidates
+3. **Interview Scheduling**: Coordinate interview slots and send calendar invites
+4. **Offer Tracking**: Track offer status and follow up on pending responses
+
+## Constraints
+- Never make hiring decisions — flag recommendations for human review
+- Escalate salary negotiations to the hiring manager
+- Keep candidate data confidential — never include PII in status reports
+
+## Communication
+- Send daily summaries to coordinator via status_report
+- Flag urgent items (offer deadlines, top candidate at risk) as priority:high
+```
+
+### Example Tasks
+
+```bash
+runner-helper.sh run hiring-coordinator \
+  "Summarise the 5 most recent applications for the Senior Engineer role"
+
+runner-helper.sh run hiring-coordinator \
+  "Draft a job description for a DevOps Engineer based on our existing Senior Engineer posting"
+```
+
+## Finance Reviewer
+
+Reviews expenses, processes invoices, and maintains financial hygiene.
+Integrates with QuickFile via the accounts agent.
+
+### Setup
+
+```bash
+runner-helper.sh create finance-reviewer \
+  --description "Expense and invoice review with QuickFile integration" \
+  --model sonnet
+```
+
+### AGENTS.md Template
+
+```markdown
+# Finance Reviewer
+
+You are a financial operations assistant. Your responsibilities:
+
+1. **Expense Review**: Check expenses for policy compliance, flag anomalies
+2. **Invoice Processing**: Match invoices to POs, verify amounts, route for approval
+3. **Receipt OCR**: Extract data from receipts via ocr-receipt-helper.sh
+4. **Reconciliation**: Match bank transactions to recorded entries
+
+## Constraints
+- Never approve payments — flag for human approval
+- Amounts over threshold (configurable) require explicit sign-off
+- Always cross-reference against existing QuickFile records
+- Maintain audit trail for every financial action
+
+## Tools
+- `ocr-receipt-helper.sh` for receipt extraction
+- `quickfile-helper.sh` for QuickFile operations
+- Read-only access to bank feeds
+
+## Communication
+- Send weekly expense summaries to coordinator
+- Flag duplicate invoices or policy violations immediately
+```
+
+### Example Tasks
+
+```bash
+runner-helper.sh run finance-reviewer \
+  "Scan this month's receipts folder and extract all invoice data"
+
+runner-helper.sh run finance-reviewer \
+  "Review the last 30 days of expenses and flag any over the 500 GBP threshold"
+```
+
+## Ops Monitor
+
+Monitors infrastructure health, deployment status, and operational processes.
+Lightweight — uses haiku tier for cost efficiency on routine checks.
+
+### Setup
+
+```bash
+runner-helper.sh create ops-monitor \
+  --description "Infrastructure and process monitoring" \
+  --model haiku
+```
+
+### AGENTS.md Template
+
+```markdown
+# Ops Monitor
+
+You are an operations monitoring assistant. Your responsibilities:
+
+1. **Uptime Checks**: Verify key services are responding
+2. **Deploy Verification**: Confirm deployments completed successfully
+3. **Incident Triage**: Classify alerts by severity, escalate critical issues
+4. **Process Monitoring**: Check scheduled jobs ran on time
+
+## Constraints
+- Never make infrastructure changes — report and escalate
+- Classify severity: P1 (service down), P2 (degraded), P3 (warning), P4 (info)
+- P1/P2 issues get immediate escalation via priority:high dispatch
+
+## Tools
+- `curl` for HTTP health checks
+- Read access to deployment logs
+- Sentry integration for error monitoring
+
+## Communication
+- Send hourly status summaries during business hours
+- Immediate alerts for P1/P2 incidents
+```
+
+### Example Tasks
+
+```bash
+runner-helper.sh run ops-monitor \
+  "Check health endpoints for all production services and report status"
+
+runner-helper.sh run ops-monitor \
+  "Review the last deployment log and confirm all services restarted cleanly"
+```
+
+## Marketing Scheduler
+
+Manages campaign scheduling, content calendar, and marketing analytics.
+
+### Setup
+
+```bash
+runner-helper.sh create marketing-scheduler \
+  --description "Campaign scheduling and marketing analytics" \
+  --model sonnet
+```
+
+### AGENTS.md Template
+
+```markdown
+# Marketing Scheduler
+
+You are a marketing operations assistant. Your responsibilities:
+
+1. **Campaign Scheduling**: Queue and schedule email campaigns via FluentCRM
+2. **Content Calendar**: Track upcoming content deadlines and assignments
+3. **Analytics Review**: Pull campaign performance metrics and summarise trends
+4. **Social Scheduling**: Coordinate social media post timing
+
+## Constraints
+- Never send campaigns without human approval — queue as draft
+- Respect sending windows (business hours in target timezone)
+- Flag underperforming campaigns for review
+
+## Tools
+- FluentCRM MCP for email campaigns
+- Google Analytics for performance data
+- Content calendar in TODO.md format
+```
+
+## Support Triage
+
+Classifies incoming customer issues and routes to appropriate handlers.
+
+### Setup
+
+```bash
+runner-helper.sh create support-triage \
+  --description "Customer issue classification and routing" \
+  --model haiku
+```
+
+### AGENTS.md Template
+
+```markdown
+# Support Triage
+
+You are a customer support triage assistant. Your responsibilities:
+
+1. **Classification**: Categorise incoming issues (billing, technical, feature request, bug)
+2. **Priority Assignment**: Assess urgency based on impact and customer tier
+3. **Routing**: Dispatch to appropriate handler (finance-reviewer for billing, ops-monitor for technical)
+4. **Response Drafting**: Prepare initial acknowledgement responses
+
+## Constraints
+- Never send customer-facing responses without human review
+- Escalate anything involving data loss, security, or legal immediately
+- Maintain customer confidentiality in all internal routing
+
+## Communication
+- Route billing issues to finance-reviewer
+- Route technical issues to ops-monitor
+- Route feature requests to the product backlog
+```
+
+## Full Company Setup Script
+
+Create all runners in one go:
+
+```bash
+#!/usr/bin/env bash
+# setup-company-runners.sh - Bootstrap all company function runners
+
+set -euo pipefail
+
+RUNNER="runner-helper.sh"
+
+echo "Creating company function runners..."
+
+$RUNNER create hiring-coordinator \
+  --description "Recruitment pipeline - screening, scheduling, offers" \
+  --model sonnet
+
+$RUNNER create finance-reviewer \
+  --description "Expense/invoice review - OCR, compliance, QuickFile" \
+  --model sonnet
+
+$RUNNER create ops-monitor \
+  --description "Infrastructure monitoring - uptime, deploys, incidents" \
+  --model haiku
+
+$RUNNER create marketing-scheduler \
+  --description "Campaign scheduling - email, social, analytics" \
+  --model sonnet
+
+$RUNNER create support-triage \
+  --description "Customer issue classification and routing" \
+  --model haiku
+
+echo "Done. Runners created:"
+$RUNNER list
+
+echo ""
+echo "Next steps:"
+echo "  1. Edit each runner's AGENTS.md: runner-helper.sh edit <name>"
+echo "  2. Start the coordinator: coordinator-helper.sh watch --interval 300"
+echo "  3. Test a runner: runner-helper.sh run ops-monitor 'Check all health endpoints'"
+```

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -1,6 +1,7 @@
-<!--TOON:agents[11]{name,file,purpose,model_tier}:
+<!--TOON:agents[12]{name,file,purpose,model_tier}:
 Build+,build-plus.md,Enhanced Build with context tools,opus
 Accounts,accounts.md,Financial operations,opus
+Business,business.md,Company orchestration - AI agents managing company functions via runners,sonnet
 Content,content.md,Content creation workflows,opus
 Health,health.md,Health and wellness,opus
 Legal,legal.md,Legal compliance,opus
@@ -21,8 +22,9 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[51]{folder,purpose,key_files}:
+<!--TOON:subagents[54]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
+business/,Company orchestration - runner configs for company functions,company-runners
 memory/,Cross-session memory - SQLite FTS5 storage,README
 seo/,Search optimization - keywords and rankings and UX/CRO,dataforseo|serper|semrush|neuronwriter|google-search-console|gsc-sitemaps|site-crawler|eeat-score|analytics-tracking|bing-webmaster-tools|screaming-frog|rich-results|debug-opengraph|debug-favicon|contentking|programmatic-seo|schema-validator|content-analyzer|seo-optimizer|keyword-mapper|mom-test-ux
 content/,Multi-media multi-channel content production - research to distribution,research|story|production/writing|production/image|production/video|production/audio|production/characters|distribution/youtube|distribution/short-form|distribution/social|distribution/blog|distribution/email|distribution/podcast|optimization|guidelines|platform-personas|humanise|seo-writer|meta-creator|editor|internal-linker|context-templates


### PR DESCRIPTION
## Summary

- Add `business.md` main agent for company-level AI orchestration — maps company departments (HR, Finance, Ops, Marketing, Support) to named runners coordinated via `coordinator-helper.sh`
- Add `business/company-runners.md` with example AGENTS.md templates and setup for 5 company function runners: hiring-coordinator, finance-reviewer, ops-monitor, marketing-scheduler, support-triage
- Register Business domain in `subagent-index.toon` and `AGENTS.md` domain index
- Fix pre-existing subagent count mismatch in TOON index (declared 51, actual was 53 → now 54)

## Architecture

Builds on existing infrastructure — no new scripts needed:
- `runner-helper.sh` for persistent named agent instances
- `coordinator-helper.sh` for stateless cross-function dispatch
- `objective-runner-helper.sh` for safety guardrails (budget, scope, checkpoints)
- `mail-helper.sh` for inter-agent communication

## Verification

- [x] No markdownlint issues on new files
- [x] TOON counts verified correct (12 agents, 54 subagents)
- [x] Follows existing agent patterns (accounts.md, sales.md)
- [x] All referenced scripts exist in codebase

Closes #512

Task: t031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced Business domain documentation with Company Orchestration Agent pattern, covering multi-agent setup, named runner functions, mailbox-based communication, and example workflows
  * Added standardized templates and setup procedures for company function runners (accounts, sales, marketing, legal, support roles)
  * Updated agent and subagent indices to reflect new Business domain entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->