### PR TITLE
t1290: Add Cloudflare Code Mode MCP server config and subagent doc

### DIFF
--- a/.agents/aidevops/mcp-integrations.md
+++ b/.agents/aidevops/mcp-integrations.md
@@ -41,6 +41,7 @@ tools:
 - Next.js DevTools MCP
 - Context7 MCP: Real-time library docs
 - LocalWP MCP: WordPress database access
+- Cloudflare Code Mode MCP: Workers, D1, KV, R2, Pages, AI Gateway via OAuth
 
 **Config Location**: `configs/mcp-templates/`
 <!-- AI-CONTEXT-END -->
@@ -69,6 +70,7 @@ This document provides comprehensive setup and usage instructions for advanced M
 
 - **Claude Code MCP**: Run Claude Code as an MCP server for automation
 - **Next.js DevTools MCP**: Next.js development and debugging assistance
+- **Cloudflare Code Mode MCP**: Deploy Workers, query D1, manage KV/R2/Pages, AI Gateway — OAuth-authenticated remote server
 
 ### **📄 Document Processing**
 
@@ -137,6 +139,51 @@ claude mcp add claude-code-mcp "npx -y github:marcusquinn/claude-code-mcp"
 **One-time setup**: run `claude --dangerously-skip-permissions` and accept prompts.
 **Upstream**: https://github.com/steipete/claude-code-mcp (revert if merged).
 **Local dev (optional)**: clone the fork and swap the command to `./start.sh` for instant iteration.
+
+### **Cloudflare Code Mode MCP**
+
+No installation required — this is a remote MCP server authenticated via OAuth.
+
+```json
+{
+  "cloudflare-api": {
+    "url": "https://mcp.cloudflare.com/mcp"
+  }
+}
+```
+
+On first connection, your MCP client opens a browser OAuth flow to `dash.cloudflare.com`. After authorizing, the token is stored automatically — no manual API key setup needed.
+
+**For Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}
+```
+
+**For OpenCode** (`~/.config/opencode/config.json`):
+
+```json
+{
+  "mcp": {
+    "cloudflare-api": {
+      "type": "remote",
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}
+```
+
+**Available Tools**: Workers (deploy/update/tail), D1 (SQL queries/schema), KV (get/put/delete/list), R2 (objects/buckets), Pages (projects/deployments), AI Gateway (logs/analytics), DNS records, zone analytics.
+
+**Per-Agent Enablement**: The `tools/api/cloudflare-mcp.md` subagent has `cloudflare-api_*: true` in its tools section. Disabled globally, enabled on-demand for Cloudflare platform work.
+
+See `tools/api/cloudflare-mcp.md` for detailed documentation.
 
 ### **Ahrefs MCP**
 

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -28,6 +28,7 @@ seo/,Search optimization - keywords and rankings and UX/CRO,dataforseo|serper|se
 content/,Multi-media multi-channel content production - research to distribution,research|story|production/writing|production/image|production/video|production/audio|production/characters|distribution/youtube|distribution/short-form|distribution/social|distribution/blog|distribution/email|distribution/podcast|optimization|guidelines|platform-personas|humanise|seo-writer|meta-creator|editor|internal-linker|context-templates
 tools/content/,Content tools - calendar planning summarization and extraction,content-calendar|summarize
 tools/social-media/,Social media tools - X/Twitter LinkedIn and Reddit,bird|linkedin|reddit
+tools/api/,API integrations - authentication ORM framework and Cloudflare MCP,better-auth|cloudflare-mcp|drizzle|hono|vercel-ai-sdk
 tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-review|agent-testing
 tools/build-mcp/,MCP development - creating MCP servers and plugins,build-mcp|server-patterns|api-wrapper|transports|deployment|aidevops-plugin
 tools/ai-assistants/,AI tool integration - OpenCode headless dispatch model comparison and response scoring,agno|capsolver|claude-code|compare-models|response-scoring|overview|openclaw|opencode-server|headless-dispatch

--- a/.agents/tools/api/cloudflare-mcp.md
+++ b/.agents/tools/api/cloudflare-mcp.md
@@ -95,7 +95,7 @@ Use these patterns when asking the AI to interact with Cloudflare resources:
 
 ### Workers
 
-```
+```text
 List all Workers in my account
 Show the code for Worker named "api-gateway"
 Deploy the Worker script at ./src/worker.ts to "my-worker"
@@ -104,7 +104,7 @@ Tail logs for Worker "my-worker"
 
 ### D1 (SQLite)
 
-```
+```text
 List all D1 databases
 Run SQL: SELECT * FROM users LIMIT 10 on database "prod-db"
 Show the schema for D1 database "prod-db"
@@ -113,7 +113,7 @@ Create a table in D1: CREATE TABLE events (id INTEGER PRIMARY KEY, name TEXT)
 
 ### KV (Key-Value)
 
-```
+```text
 List all KV namespaces
 Get the value of key "config:feature-flags" from namespace "APP_CONFIG"
 Put key "session:abc123" with value "..." in namespace "SESSIONS"
@@ -123,7 +123,7 @@ Delete key "cache:stale" from namespace "CACHE"
 
 ### R2 (Object Storage)
 
-```
+```text
 List all R2 buckets
 List objects in bucket "assets" with prefix "images/"
 Get object "images/logo.png" from bucket "assets"
@@ -133,7 +133,7 @@ Delete object "tmp/old-file.txt" from bucket "assets"
 
 ### Pages
 
-```
+```text
 List all Pages projects
 Show deployments for Pages project "my-site"
 Trigger a new deployment for Pages project "my-site"
@@ -141,7 +141,7 @@ Trigger a new deployment for Pages project "my-site"
 
 ### AI Gateway
 
-```
+```text
 List all AI Gateways
 Show recent logs for AI Gateway "production"
 Get analytics for AI Gateway "production" for the last 24 hours
@@ -149,7 +149,7 @@ Get analytics for AI Gateway "production" for the last 24 hours
 
 ### DNS
 
-```
+```text
 List DNS records for zone "example.com"
 Add A record: api.example.com → 1.2.3.4 with TTL 300
 Delete CNAME record "www" from zone "example.com"
@@ -161,14 +161,14 @@ Common end-to-end workflows:
 
 ### Deploy a Worker
 
-```
+```text
 Read ./src/worker.ts and deploy it as a Cloudflare Worker named "my-api".
 Bind it to the KV namespace "APP_DATA" and D1 database "prod-db".
 ```
 
 ### Query D1 and return results
 
-```
+```text
 On D1 database "analytics", run:
 SELECT date, count(*) as visits FROM page_views
 WHERE date >= date('now', '-7 days')
@@ -177,14 +177,14 @@ GROUP BY date ORDER BY date DESC
 
 ### Sync local files to R2
 
-```
+```text
 Upload all files in ./dist/ to R2 bucket "static-assets" under prefix "v2.1.0/".
 List the uploaded objects to confirm.
 ```
 
 ### Inspect KV namespace
 
-```
+```text
 List all keys in KV namespace "FEATURE_FLAGS".
 For each key, get its value and show me the full config.
 ```

--- a/.agents/tools/api/cloudflare-mcp.md
+++ b/.agents/tools/api/cloudflare-mcp.md
@@ -1,0 +1,203 @@
+---
+description: Cloudflare Code Mode MCP — Workers, D1, KV, R2, Pages, AI Gateway
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  cloudflare-api_*: true
+---
+
+# Cloudflare Code Mode MCP
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Server**: `https://mcp.cloudflare.com/mcp` (remote, no install)
+- **Auth**: OAuth 2.0 via Cloudflare dashboard (browser flow on first connect)
+- **Config key**: `cloudflare-api` in `configs/mcp-servers-config.json.txt`
+- **Setup guide**: `aidevops/mcp-integrations.md` → Cloudflare Code Mode MCP section
+- **Platform docs**: `services/hosting/cloudflare-platform.md` (60 products, API refs)
+
+**Capabilities**:
+- Workers: deploy, update, list, tail logs
+- D1: execute SQL, inspect schema, list databases
+- KV: get/put/delete/list keys across namespaces
+- R2: list buckets, get/put/delete objects
+- Pages: list projects, trigger deployments
+- AI Gateway: view logs and analytics
+- DNS: read/manage records
+- Analytics: zone traffic and performance data
+
+<!-- AI-CONTEXT-END -->
+
+## Auth Setup
+
+Cloudflare Code Mode MCP uses OAuth 2.0 — no API tokens to manage manually.
+
+### First-Time Connection
+
+1. Add the server config (see below)
+2. Start your MCP client (Claude Desktop, OpenCode, etc.)
+3. On first tool call, a browser window opens to `dash.cloudflare.com`
+4. Authorize the OAuth app for your account
+5. The client stores the token — subsequent connections are seamless
+
+### Config
+
+**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "cloudflare-api": {
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}
+```
+
+**OpenCode** (`~/.config/opencode/config.json`):
+
+```json
+{
+  "mcp": {
+    "cloudflare-api": {
+      "type": "remote",
+      "url": "https://mcp.cloudflare.com/mcp"
+    }
+  }
+}
+```
+
+**Claude Code CLI**:
+
+```bash
+claude mcp add cloudflare-api --transport http https://mcp.cloudflare.com/mcp
+```
+
+## Security Model
+
+- **OAuth scopes**: Tied to your Cloudflare account — access matches your dashboard permissions
+- **No secrets in config**: The URL contains no credentials; OAuth tokens are stored by the MCP client in its secure token store
+- **Revocation**: Revoke access at `dash.cloudflare.com` > My Profile > API Tokens > OAuth Apps
+- **Least privilege**: If you need to restrict scope, use a sub-account or create a scoped API token instead (see `services/hosting/cloudflare.md`)
+- **Audit trail**: All MCP actions appear in Cloudflare's audit log under your account
+
+## Search Patterns
+
+Use these patterns when asking the AI to interact with Cloudflare resources:
+
+### Workers
+
+```
+List all Workers in my account
+Show the code for Worker named "api-gateway"
+Deploy the Worker script at ./src/worker.ts to "my-worker"
+Tail logs for Worker "my-worker"
+```
+
+### D1 (SQLite)
+
+```
+List all D1 databases
+Run SQL: SELECT * FROM users LIMIT 10 on database "prod-db"
+Show the schema for D1 database "prod-db"
+Create a table in D1: CREATE TABLE events (id INTEGER PRIMARY KEY, name TEXT)
+```
+
+### KV (Key-Value)
+
+```
+List all KV namespaces
+Get the value of key "config:feature-flags" from namespace "APP_CONFIG"
+Put key "session:abc123" with value "..." in namespace "SESSIONS"
+List all keys with prefix "user:" in namespace "APP_DATA"
+Delete key "cache:stale" from namespace "CACHE"
+```
+
+### R2 (Object Storage)
+
+```
+List all R2 buckets
+List objects in bucket "assets" with prefix "images/"
+Get object "images/logo.png" from bucket "assets"
+Upload file ./dist/app.js to bucket "releases" as "v1.2.3/app.js"
+Delete object "tmp/old-file.txt" from bucket "assets"
+```
+
+### Pages
+
+```
+List all Pages projects
+Show deployments for Pages project "my-site"
+Trigger a new deployment for Pages project "my-site"
+```
+
+### AI Gateway
+
+```
+List all AI Gateways
+Show recent logs for AI Gateway "production"
+Get analytics for AI Gateway "production" for the last 24 hours
+```
+
+### DNS
+
+```
+List DNS records for zone "example.com"
+Add A record: api.example.com → 1.2.3.4 with TTL 300
+Delete CNAME record "www" from zone "example.com"
+```
+
+## Execute Patterns
+
+Common end-to-end workflows:
+
+### Deploy a Worker
+
+```
+Read ./src/worker.ts and deploy it as a Cloudflare Worker named "my-api".
+Bind it to the KV namespace "APP_DATA" and D1 database "prod-db".
+```
+
+### Query D1 and return results
+
+```
+On D1 database "analytics", run:
+SELECT date, count(*) as visits FROM page_views
+WHERE date >= date('now', '-7 days')
+GROUP BY date ORDER BY date DESC
+```
+
+### Sync local files to R2
+
+```
+Upload all files in ./dist/ to R2 bucket "static-assets" under prefix "v2.1.0/".
+List the uploaded objects to confirm.
+```
+
+### Inspect KV namespace
+
+```
+List all keys in KV namespace "FEATURE_FLAGS".
+For each key, get its value and show me the full config.
+```
+
+## Per-Agent Enablement
+
+This subagent has `cloudflare-api_*: true` in its tools frontmatter. The MCP tools are disabled globally and enabled only when this subagent is active.
+
+To invoke this subagent: reference `tools/api/cloudflare-mcp.md` in your agent's tools section, or ask the AI to use Cloudflare MCP tools directly when this subagent is loaded.
+
+## Related Docs
+
+- `services/hosting/cloudflare.md` — DNS/CDN API setup, token scoping, security
+- `services/hosting/cloudflare-platform.md` — Full platform reference (Workers, D1, R2, KV, Pages, AI, 60 products)
+- `aidevops/mcp-integrations.md` — All MCP integrations overview and setup
+- `configs/mcp-servers-config.json.txt` — Master MCP server config template

--- a/configs/mcp-servers-config.json.txt
+++ b/configs/mcp-servers-config.json.txt
@@ -57,6 +57,11 @@
         "GOOGLE_PROJECT_ID": "YOUR_GCP_PROJECT_ID_HERE"
       },
       "description": "Google Analytics MCP server for GA4 reporting (requires pipx and Google Cloud ADC)"
+    },
+    "cloudflare-api": {
+      "type": "remote",
+      "url": "https://mcp.cloudflare.com/mcp",
+      "description": "Cloudflare Code Mode MCP — Workers, D1, KV, R2, Pages, AI Gateway (OAuth on first connect)"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `cloudflare-api` remote MCP entry to `configs/mcp-servers-config.json.txt` (Claude.json template)
- Add Cloudflare Code Mode MCP section to `aidevops/mcp-integrations.md` with setup instructions for Claude Desktop and OpenCode
- Create `tools/api/cloudflare-mcp.md` subagent doc with: auth setup (OAuth), security model, search patterns (Workers/D1/KV/R2/Pages/AI Gateway/DNS), execute patterns, per-agent enablement
- Add `tools/api/` folder to `subagent-index.toon` with `cloudflare-mcp` entry

## Config

```json
{
  "cloudflare-api": {
    "url": "https://mcp.cloudflare.com/mcp"
  }
}
```

Auth: OAuth 2.0 — browser flow on first connect, no manual API token setup required.

Ref #2059