### PR TITLE
t1160.2: Add SUPERVISOR_CLI env var to resolve_ai_cli()

### DIFF
--- a/.agents/scripts/supervisor/ai-reason.sh
+++ b/.agents/scripts/supervisor/ai-reason.sh
@@ -893,10 +893,15 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 	if ! declare -f resolve_ai_cli &>/dev/null; then
 		resolve_ai_cli() {
 			if [[ -n "${SUPERVISOR_CLI:-}" ]]; then
+				if [[ "$SUPERVISOR_CLI" != "opencode" && "$SUPERVISOR_CLI" != "claude" ]]; then
+					log_error "SUPERVISOR_CLI='$SUPERVISOR_CLI' is not a supported CLI (opencode|claude)"
+					return 1
+				fi
 				if command -v "$SUPERVISOR_CLI" &>/dev/null; then
 					echo "$SUPERVISOR_CLI"
 					return 0
 				fi
+				log_error "SUPERVISOR_CLI='$SUPERVISOR_CLI' not found in PATH"
 				return 1
 			fi
 			if command -v opencode &>/dev/null; then

--- a/.agents/scripts/supervisor/ai-reason.sh
+++ b/.agents/scripts/supervisor/ai-reason.sh
@@ -892,6 +892,13 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 	# Stub resolve_ai_cli and resolve_model if not available
 	if ! declare -f resolve_ai_cli &>/dev/null; then
 		resolve_ai_cli() {
+			if [[ -n "${SUPERVISOR_CLI:-}" ]]; then
+				if command -v "$SUPERVISOR_CLI" &>/dev/null; then
+					echo "$SUPERVISOR_CLI"
+					return 0
+				fi
+				return 1
+			fi
 			if command -v opencode &>/dev/null; then
 				echo "opencode"
 			elif command -v claude &>/dev/null; then

--- a/.agents/scripts/supervisor/dispatch.sh
+++ b/.agents/scripts/supervisor/dispatch.sh
@@ -32,6 +32,15 @@ detect_dispatch_mode() {
 # claude CLI fallback is DEPRECATED and will be removed in a future release.
 #######################################
 resolve_ai_cli() {
+	# Allow env var override for explicit CLI preference
+	if [[ -n "${SUPERVISOR_CLI:-}" ]]; then
+		if command -v "$SUPERVISOR_CLI" &>/dev/null; then
+			echo "$SUPERVISOR_CLI"
+			return 0
+		fi
+		log_error "SUPERVISOR_CLI='$SUPERVISOR_CLI' not found in PATH"
+		return 1
+	fi
 	# opencode is the primary and only supported CLI
 	if command -v opencode &>/dev/null; then
 		echo "opencode"

--- a/.agents/scripts/supervisor/dispatch.sh
+++ b/.agents/scripts/supervisor/dispatch.sh
@@ -34,6 +34,10 @@ detect_dispatch_mode() {
 resolve_ai_cli() {
 	# Allow env var override for explicit CLI preference
 	if [[ -n "${SUPERVISOR_CLI:-}" ]]; then
+		if [[ "$SUPERVISOR_CLI" != "opencode" && "$SUPERVISOR_CLI" != "claude" ]]; then
+			log_error "SUPERVISOR_CLI='$SUPERVISOR_CLI' is not a supported CLI (opencode|claude)"
+			return 1
+		fi
 		if command -v "$SUPERVISOR_CLI" &>/dev/null; then
 			echo "$SUPERVISOR_CLI"
 			return 0


### PR DESCRIPTION
## Summary

Add `SUPERVISOR_CLI` env var override to `resolve_ai_cli()` — allows explicit CLI preference instead of relying solely on auto-detection (opencode first, then deprecated claude fallback).

## Changes

- **`.agents/scripts/supervisor/dispatch.sh`**: Added `SUPERVISOR_CLI` check at top of `resolve_ai_cli()`. If set, validates the CLI exists in PATH and returns it. If not found, logs error and returns 1. Follows the same pattern as `SUPERVISOR_MODEL` in `resolve_model()`.
- **`.agents/scripts/supervisor/ai-reason.sh`**: Applied same override to the standalone fallback stub of `resolve_ai_cli()` for consistency when `dispatch.sh` isn't sourced.

## Behaviour

| `SUPERVISOR_CLI` | CLI in PATH? | Result |
|---|---|---|
| unset | — | Auto-detect (opencode → claude → error) |
| `opencode` | yes | Uses `opencode` |
| `claude` | yes | Uses `claude` |
| `my-cli` | no | Error + return 1 |

## Verification

- ShellCheck passes on both modified files (zero violations)
- No changes to existing tests (stubs in e2e tests override the function entirely)

Ref #1748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SUPERVISOR_CLI environment variable support, enabling users to override the default AI CLI selection with a custom executable path. If the specified path is invalid, the system falls back to the original CLI detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->