### PR TITLE
t1291: Clarify cloudflare-platform.md role and add intent-based routing to cloudflare.md

### DIFF
--- a/.agents/services/hosting/cloudflare-platform.md
+++ b/.agents/services/hosting/cloudflare-platform.md
@@ -1,11 +1,28 @@
 ---
-description: "Comprehensive Cloudflare platform skill covering Workers, Pages, storage (KV, D1, R2), AI (Workers AI, Vectorize, Agents SDK), networking (Tunnel, Spectrum), security (WAF, DDoS), and infrastructure-as-code (Terraform, Pulumi). Use for any Cloudflare development task."
+description: "Cloudflare platform development guidance — patterns, gotchas, decision trees, SDK usage for Workers, Pages, KV, D1, R2, AI, Durable Objects, and 60+ products. Use when building or developing ON the Cloudflare platform. For managing/configuring CF resources via API, use the Cloudflare Code Mode MCP (cloudflare-mcp.md)."
 mode: subagent
 imported_from: external
 ---
-# cloudflare
+# cloudflare-platform
 
 # Cloudflare Platform Skill
+
+**Role**: Development guidance for building on the Cloudflare platform — patterns, gotchas, decision trees, SDK usage, and API references. This skill is for **developers writing code that runs on Cloudflare** (Workers, Pages, D1, R2, KV, Durable Objects, AI, etc.).
+
+> **Not for API operations**: To manage, configure, or update Cloudflare resources (DNS records, zone settings, deployments) use the Cloudflare Code Mode MCP — see `tools/api/cloudflare-mcp.md`.
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Role**: Development guidance — patterns, gotchas, SDK usage, decision trees
+- **Scope**: Building code that runs ON Cloudflare (Workers, Pages, D1, R2, KV, DO, AI, etc.)
+- **Not for**: Managing/configuring CF resources → use `tools/api/cloudflare-mcp.md` (Code Mode MCP)
+- **Entry point**: Use decision trees below to find the right product, then load `./references/<product>/README.md`
+- **Reference format**: Multi-file (`api.md`, `configuration.md`, `patterns.md`, `gotchas.md`) or single-file
+- **60+ products** indexed below with direct entry-point paths
+
+<!-- AI-CONTEXT-END -->
 
 Consolidated skill for building on the Cloudflare platform. Use decision trees below to find the right product, then load detailed references.
 

--- a/.agents/services/hosting/cloudflare.md
+++ b/.agents/services/hosting/cloudflare.md
@@ -1,5 +1,5 @@
 ---
-description: Cloudflare DNS and CDN API integration
+description: Cloudflare DNS, CDN, and API token setup for managing/configuring Cloudflare resources. For building on the Cloudflare platform (Workers, Pages, D1, R2, KV, AI, etc.), see cloudflare-platform.md.
 mode: subagent
 tools:
   read: true
@@ -12,8 +12,6 @@ tools:
 ---
 
 # Cloudflare API Setup for AI-Assisted Development
-
-> **For Cloudflare development** (Workers, Pages, D1, R2, KV, Durable Objects, AI, etc.), see `cloudflare-platform.md` which covers 60 products with detailed API references, patterns, and gotchas.
 
 <!-- AI-CONTEXT-START -->
 
@@ -28,7 +26,20 @@ tools:
 - **API test**: `curl -X GET "https://api.cloudflare.com/client/v4/zones" -H "Authorization: Bearer TOKEN"`
 - **Security**: IP filtering, expiration dates, minimal permissions
 - **Rotation**: Every 6-12 months or after team changes
+
+## Intent-Based Routing
+
+| Intent | Tool |
+|--------|------|
+| Manage, configure, or update CF resources (DNS, zones, deployments, KV data, D1 queries) | Cloudflare Code Mode MCP → `tools/api/cloudflare-mcp.md` |
+| Build or develop on the CF platform (Workers, Pages, D1 schema, R2, AI, Durable Objects) | Platform skill docs → `services/hosting/cloudflare-platform.md` |
+| Set up API token auth for DNS/CDN management | This file (`cloudflare.md`) |
+
 <!-- AI-CONTEXT-END -->
+
+> **Building on Cloudflare?** (Workers, Pages, D1, R2, KV, Durable Objects, AI, etc.) → see `cloudflare-platform.md` which covers 60+ products with patterns, gotchas, decision trees, and SDK references.
+>
+> **Managing CF resources via MCP?** (deploy Workers, run D1 SQL, manage KV, trigger Pages builds) → see `tools/api/cloudflare-mcp.md` for the Code Mode MCP (no token setup needed — uses OAuth).
 
 This guide shows you how to securely set up Cloudflare API access for local AI-assisted development, DevOps, and system administration.
 


### PR DESCRIPTION
## Summary

- **cloudflare-platform.md**: Added explicit role statement clarifying this is development guidance (patterns, gotchas, decision trees, SDK usage) — not for API operations. Added Quick Reference section with scope, entry point, and reference format. Added callout pointing to `cloudflare-mcp.md` for resource management.
- **cloudflare.md**: Added Intent-Based Routing table inside `AI-CONTEXT` block: "manage/configure/update CF resources" → Code Mode MCP, "build/develop on CF platform" → skill docs. Updated frontmatter description. Added routing callouts above body content.

Both files now clearly delineate their scope to reduce agent routing confusion.

Ref #2061