### PR TITLE
t1294.3: Add MCPorter to MCP integrations and discovery docs

### DIFF
--- a/.agents/aidevops/mcp-integrations.md
+++ b/.agents/aidevops/mcp-integrations.md
@@ -42,6 +42,7 @@ tools:
 - Context7 MCP: Real-time library docs
 - LocalWP MCP: WordPress database access
 - Cloudflare Code Mode MCP: Workers, D1, KV, R2, Pages, AI Gateway via OAuth
+- MCPorter: Discover, call, compose, and generate CLIs/typed clients for MCP servers
 
 **Config Location**: `configs/mcp-templates/`
 <!-- AI-CONTEXT-END -->
@@ -71,6 +72,7 @@ This document provides comprehensive setup and usage instructions for advanced M
 - **Claude Code MCP**: Run Claude Code as an MCP server for automation
 - **Next.js DevTools MCP**: Next.js development and debugging assistance
 - **Cloudflare Code Mode MCP**: Deploy Workers, query D1, manage KV/R2/Pages, AI Gateway — OAuth-authenticated remote server
+- **MCPorter**: TypeScript runtime, CLI, and code-generation toolkit — discover, call, compose, and generate CLIs/typed clients for any MCP server
 
 ### **📄 Document Processing**
 
@@ -139,6 +141,25 @@ claude mcp add claude-code-mcp "npx -y github:marcusquinn/claude-code-mcp"
 **One-time setup**: run `claude --dangerously-skip-permissions` and accept prompts.
 **Upstream**: https://github.com/steipete/claude-code-mcp (revert if merged).
 **Local dev (optional)**: clone the fork and swap the command to `./start.sh` for instant iteration.
+
+### **MCPorter**
+
+```bash
+# Zero-install (npx)
+npx mcporter list
+
+# Project dependency
+pnpm add mcporter
+
+# Homebrew
+brew tap steipete/tap && brew install steipete/tap/mcporter
+```
+
+**Core commands**: `mcporter list` (discover servers/tools), `mcporter call` (invoke tools), `mcporter generate-cli` (mint standalone CLIs), `mcporter emit-ts` (typed client wrappers), `mcporter auth` (OAuth login), `mcporter daemon` (keep stateful servers warm).
+
+**Auto-imports**: Merges configs from Claude Code, Claude Desktop, Cursor, Codex, Windsurf, OpenCode, VS Code automatically.
+
+See `tools/mcp-toolkit/mcporter.md` for full documentation.
 
 ### **Cloudflare Code Mode MCP**
 

--- a/.agents/tools/context/mcp-discovery.md
+++ b/.agents/tools/context/mcp-discovery.md
@@ -21,8 +21,9 @@ tools:
 - **Purpose**: Discover MCP tools without loading all definitions upfront
 - **Pattern**: Search → Find MCP → Enable → Use
 - **Script**: `~/.aidevops/agents/scripts/mcp-index-helper.sh`
+- **Alternative**: MCPorter (`npx mcporter list`) — ad-hoc discovery across all configured MCP clients
 
-**Commands**:
+**Commands (mcp-index-helper.sh)**:
 
 ```bash
 # Search for tools by capability
@@ -38,6 +39,19 @@ mcp-index-helper.sh get-mcp "query-docs"
 
 # Show index status
 mcp-index-helper.sh status
+```
+
+**Commands (MCPorter — alternative)**:
+
+```bash
+# Discover all configured MCP servers and their tools
+npx mcporter list
+
+# List tools for a specific server
+npx mcporter list context7
+
+# Find and call a tool directly
+npx mcporter call context7.resolve-library-id libraryName=react
 ```
 
 **Why this matters**:
@@ -133,6 +147,40 @@ mcp-index-helper.sh list dataforseo
 # dataforseo_keywords     Keyword research and metrics
 # dataforseo_backlinks    Backlink analysis
 ```
+
+## MCPorter: Alternative Discovery Method
+
+[MCPorter](https://mcporter.dev) (`steipete/mcporter`, MIT) is a TypeScript runtime, CLI, and code-generation toolkit that provides an alternative approach to MCP discovery. Unlike `mcp-index-helper.sh` (which queries a local SQLite index built from your `opencode.json`), MCPorter reads directly from all configured MCP clients (Claude Code, Claude Desktop, Cursor, Codex, Windsurf, OpenCode, VS Code) and queries live servers.
+
+### When to use MCPorter vs mcp-index-helper.sh
+
+| Scenario | Use |
+|----------|-----|
+| Searching the local index for a capability | `mcp-index-helper.sh search "capability"` |
+| Discovering tools across all MCP clients | `npx mcporter list` |
+| Calling a tool ad-hoc without config changes | `npx mcporter call server.tool arg=value` |
+| Generating a typed CLI or TypeScript client | `npx mcporter generate-cli` / `mcporter emit-ts` |
+| Keeping stateful servers warm between calls | `mcporter daemon start` |
+
+### Quick start
+
+```bash
+# Zero-install: list all configured MCP servers
+npx mcporter list
+
+# Inspect a specific server's tools
+npx mcporter list context7 --schema
+
+# Call a tool directly
+npx mcporter call context7.resolve-library-id libraryName=react
+
+# Generate a standalone CLI from any MCP server
+npx mcporter generate-cli --command https://mcp.context7.com/mcp --compile
+```
+
+MCPorter auto-merges configs from all supported AI assistants, so `mcporter list` shows the union of all your configured servers without any additional setup.
+
+See `tools/mcp-toolkit/mcporter.md` for full documentation and `aidevops/mcp-integrations.md` for setup instructions.
 
 ## Integration with Agents
 


### PR DESCRIPTION
## Summary

- **mcp-integrations.md**: Added MCPorter to Quick Reference Development list, Development Tools section, and a new setup subsection with install options and core commands
- **mcp-discovery.md**: Added MCPorter as an alternative discovery method alongside `mcp-index-helper.sh` — includes comparison table, quick-start examples, and cross-references

## Details

MCPorter (`steipete/mcporter`, MIT, 2k+ stars) is a TypeScript runtime, CLI, and code-generation toolkit for MCP servers. It complements the existing `mcp-index-helper.sh` approach:

| Scenario | Tool |
|----------|------|
| Search local SQLite index for a capability | `mcp-index-helper.sh search` |
| Discover tools across all MCP clients live | `npx mcporter list` |
| Call a tool ad-hoc without config changes | `npx mcporter call server.tool` |
| Generate typed CLI or TypeScript client | `mcporter generate-cli` / `emit-ts` |

Ref #2066