### PR TITLE
t1160.4: Add Claude CLI branching to contest-helper.sh

### DIFF
--- a/tests/test-contest-helper.sh
+++ b/tests/test-contest-helper.sh
@@ -292,6 +292,56 @@ else
 fi
 
 # ============================================================
+section "11. CLI Branching Functions (t1160.4)"
+# ============================================================
+
+# Source the helper to test internal functions
+# shellcheck source=../.agents/scripts/contest-helper.sh
+source "$HELPER" --source-only 2>/dev/null || true
+
+# Test resolve_ai_cli function exists and works
+if declare -f resolve_ai_cli &>/dev/null; then
+	pass "resolve_ai_cli function is defined"
+else
+	fail "resolve_ai_cli function not found"
+fi
+
+# Test run_ai_scoring function exists
+if declare -f run_ai_scoring &>/dev/null; then
+	pass "run_ai_scoring function is defined"
+else
+	fail "run_ai_scoring function not found"
+fi
+
+# Verify resolve_ai_cli returns a known CLI name
+if declare -f resolve_ai_cli &>/dev/null; then
+	cli_result=$(resolve_ai_cli 2>/dev/null || echo "none")
+	if [[ "$cli_result" == "opencode" || "$cli_result" == "claude" ]]; then
+		pass "resolve_ai_cli returns valid CLI: $cli_result"
+	elif [[ "$cli_result" == "none" ]]; then
+		skip "resolve_ai_cli: no AI CLI installed (opencode or claude)"
+	else
+		fail "resolve_ai_cli returned unexpected value: $cli_result"
+	fi
+fi
+
+# Verify the script no longer has hardcoded opencode-only dispatch in scoring
+# The old pattern was: 'command -v opencode' immediately followed by 'opencode run'
+# for scoring. Now it should use run_ai_scoring instead.
+if grep -q 'Use opencode for scoring if available' "$HELPER" 2>/dev/null; then
+	fail "Found old hardcoded opencode-only scoring comment"
+else
+	pass "No hardcoded opencode-only dispatch in scoring path"
+fi
+
+# Verify run_ai_scoring is called in cmd_evaluate
+if grep -q 'run_ai_scoring' "$HELPER"; then
+	pass "cmd_evaluate uses run_ai_scoring abstraction"
+else
+	fail "cmd_evaluate does not use run_ai_scoring"
+fi
+
+# ============================================================
 section "Summary"
 # ============================================================
 


### PR DESCRIPTION
## Summary

- Added `resolve_ai_cli()` and `run_ai_scoring()` functions to `contest-helper.sh` that detect the available CLI (opencode preferred, claude fallback) and dispatch scoring prompts accordingly
- Replaced hardcoded `opencode run` call in `cmd_evaluate` with the new `run_ai_scoring` abstraction — matching the pattern from `supervisor/dispatch.sh` `build_cli_cmd()`
- Added `--source-only` guard for testability and new test section (section 11) covering CLI branching functions

Ref #1750

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/contest-helper.sh` | Added `resolve_ai_cli()`, `run_ai_scoring()`, `--source-only` guard; replaced hardcoded opencode dispatch |
| `tests/test-contest-helper.sh` | Added section 11: CLI branching function tests (5 new test cases) |

## Verification

- ShellCheck: zero violations on both files
- Tests: 25/25 pass (including 5 new CLI branching tests)