### PR TITLE
t1294.4: Register mcporter in subagent-index.toon and AGENTS.md domain index

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -97,7 +97,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | OpenAPI exploration | `tools/context/openapi-search.md` |
 | Model routing | `tools/context/model-routing.md`, `reference/orchestration.md` |
 | Orchestration | `reference/orchestration.md`, `tools/ai-assistants/headless-dispatch.md` |
-| Agent/MCP dev | `tools/build-agent/build-agent.md`, `tools/build-mcp/build-mcp.md` |
+| Agent/MCP dev | `tools/build-agent/build-agent.md`, `tools/build-mcp/build-mcp.md`, `tools/mcp-toolkit/mcporter.md` |
 | Framework | `aidevops/architecture.md`, `scripts/commands/skills.md` |
 
 ## Capabilities

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -22,7 +22,7 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[54]{folder,purpose,key_files}:
+<!--TOON:subagents[55]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
 business/,Company orchestration - runner configs for company functions,company-runners
 memory/,Cross-session memory - SQLite FTS5 storage,README
@@ -33,6 +33,7 @@ tools/social-media/,Social media tools - X/Twitter LinkedIn and Reddit,bird|link
 tools/api/,API integrations - authentication ORM framework and Cloudflare MCP,better-auth|cloudflare-mcp|drizzle|hono|vercel-ai-sdk
 tools/build-agent/,Agent design - composing efficient agents,build-agent|agent-review|agent-testing
 tools/build-mcp/,MCP development - creating MCP servers and plugins,build-mcp|server-patterns|api-wrapper|transports|deployment|aidevops-plugin
+tools/mcp-toolkit/,MCP runtime toolkit - discover call compose and generate CLIs/typed clients for MCP servers,mcporter
 tools/ai-assistants/,AI tool integration - OpenCode headless dispatch model comparison and response scoring,agno|capsolver|claude-code|compare-models|response-scoring|overview|openclaw|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
 tools/browser/,Browser automation - scraping and testing,agent-browser|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy|chrome-webstore-release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ See `.agents/aidevops/` for framework development guidance:
 | `tools/build-agent/build-agent.md` | Composing efficient agents |
 | `tools/build-agent/agent-review.md` | Reviewing and improving agents |
 | `tools/build-mcp/build-mcp.md` | MCP server development |
+| `tools/mcp-toolkit/mcporter.md` | MCP runtime toolkit (discover, call, generate CLIs) |
 | `architecture.md` | Framework structure |
 | `setup.md` | AI guide to setup.sh |
 


### PR DESCRIPTION
## Summary

- Add `tools/mcp-toolkit/` entry to `subagent-index.toon` (subagent count 54→55) with mcporter as key file
- Add `tools/mcp-toolkit/mcporter.md` to the Agent/MCP dev domain row in `.agents/AGENTS.md` progressive disclosure table
- Add `tools/mcp-toolkit/mcporter.md` to the Contributing table in root `AGENTS.md` for MCP dev contributors

## Changes

| File | Change |
|------|--------|
| `.agents/subagent-index.toon` | New `tools/mcp-toolkit/` subagent entry, count 54→55 |
| `.agents/AGENTS.md` | mcporter added to Agent/MCP dev domain row |
| `AGENTS.md` | mcporter added to Contributing table |

Ref #2067