### PR TITLE
t1160.6: Add claude to orphan process detection in pulse.sh

### DIFF
--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -2902,10 +2902,10 @@ RULES:
 		[[ -z "$self_pid" ]] && break
 	done
 
-	# Find orphaned opencode/shellcheck/bash-language-server processes with PPID=1
+	# Find orphaned claude/opencode/shellcheck/bash-language-server processes with PPID=1
 	# PPID=1 means the parent died and the process was reparented to init/launchd
 	local orphan_candidates
-	orphan_candidates=$(pgrep -f 'opencode|shellcheck|bash-language-server' 2>/dev/null || true)
+	orphan_candidates=$(pgrep -f 'claude|opencode|shellcheck|bash-language-server' 2>/dev/null || true)
 	if [[ -n "$orphan_candidates" ]]; then
 		while read -r opid; do
 			[[ -z "$opid" ]] && continue
@@ -2937,7 +2937,7 @@ RULES:
 	if [[ "${sys_memory:-}" == "high" ]]; then
 		log_error "  CRITICAL: Memory pressure HIGH — emergency worker cleanup"
 		local emergency_candidates
-		emergency_candidates=$(pgrep -f 'opencode|shellcheck|bash-language-server' 2>/dev/null || true)
+		emergency_candidates=$(pgrep -f 'claude|opencode|shellcheck|bash-language-server' 2>/dev/null || true)
 		if [[ -n "$emergency_candidates" ]]; then
 			while read -r epid; do
 				[[ -z "$epid" ]] && continue


### PR DESCRIPTION
## Summary

- Add `claude` to the pgrep pattern in Phase 4e orphan process detection (`pulse.sh`)
- Both the PPID=1 orphan sweep (line 2908) and the memory-pressure emergency kill (line 2940) now detect orphaned `claude` processes alongside `opencode`, `shellcheck`, and `bash-language-server`
- Consistent with `cleanup.sh` which already includes `claude` in its pgrep pattern (line 425)

Ref #1752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced system process monitoring to expand coverage of managed processes and optimize automatic cleanup during memory pressure scenarios, improving overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->