### PR TITLE
t1288.5: Add OpenAPI Search to MCP integrations doc and subagent index

### DIFF
--- a/.agents/aidevops/mcp-integrations.md
+++ b/.agents/aidevops/mcp-integrations.md
@@ -43,6 +43,7 @@ tools:
 - LocalWP MCP: WordPress database access
 - Cloudflare Code Mode MCP: Workers, D1, KV, R2, Pages, AI Gateway via OAuth
 - MCPorter: Discover, call, compose, and generate CLIs/typed clients for MCP servers
+- OpenAPI Search MCP: Search and explore any OpenAPI spec — zero install, remote Cloudflare Worker
 
 **Config Location**: `configs/mcp-templates/`
 <!-- AI-CONTEXT-END -->
@@ -73,6 +74,7 @@ This document provides comprehensive setup and usage instructions for advanced M
 - **Next.js DevTools MCP**: Next.js development and debugging assistance
 - **Cloudflare Code Mode MCP**: Deploy Workers, query D1, manage KV/R2/Pages, AI Gateway — OAuth-authenticated remote server
 - **MCPorter**: TypeScript runtime, CLI, and code-generation toolkit — discover, call, compose, and generate CLIs/typed clients for any MCP server
+- **OpenAPI Search MCP**: Search and explore any OpenAPI specification — semantic search across 3000+ public APIs, zero install, no auth required
 
 ### **📄 Document Processing**
 
@@ -160,6 +162,50 @@ brew tap steipete/tap && brew install steipete/tap/mcporter
 **Auto-imports**: Merges configs from Claude Code, Claude Desktop, Cursor, Codex, Windsurf, OpenCode, VS Code automatically.
 
 See `tools/mcp-toolkit/mcporter.md` for full documentation.
+
+### **OpenAPI Search MCP**
+
+No installation required — this is a remote Cloudflare Worker with no authentication needed.
+
+```bash
+# Claude Code (recommended)
+claude mcp add --scope user openapi-search --transport http https://openapi-mcp.openapisearch.com/mcp
+```
+
+**For OpenCode** (`~/.config/opencode/opencode.json`):
+
+```json
+{
+  "mcp": {
+    "openapi-search": {
+      "type": "remote",
+      "url": "https://openapi-mcp.openapisearch.com/mcp",
+      "enabled": false
+    }
+  }
+}
+```
+
+**For Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "openapi-search": {
+      "type": "http",
+      "url": "https://openapi-mcp.openapisearch.com/mcp"
+    }
+  }
+}
+```
+
+**Available Tools**: `searchAPIs` (semantic search across 3000+ public APIs), `getAPIOverview` (endpoint summary), `getOperationDetails` (full request/response schema).
+
+**Workflow**: `searchAPIs` → `getAPIOverview` → `getOperationDetails` — keeps context usage minimal by loading only what you need.
+
+**Per-Agent Enablement**: The `tools/context/openapi-search.md` subagent has `openapi-search_*: true` in its tools section. Disabled globally, enabled on-demand for API exploration tasks.
+
+See `tools/context/openapi-search.md` for full documentation.
 
 ### **Cloudflare Code Mode MCP**
 

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -81,6 +81,21 @@ tools/research/,Tech stack research - open-source technology explorer provider,p
 tools/research/,Tech stack research - Wappalyzer OSS technology detection provider,providers/wappalyzer
 -->
 
+<!--TOON:mcp_servers[12]{name,url,auth,subagent,purpose}:
+chrome-devtools,npx chrome-devtools-mcp@latest,none,tools/browser/chrome-devtools.md,Browser automation debugging and performance analysis
+playwright,npx playwright-mcp@latest,none,tools/browser/playwright.md,Cross-browser testing and automation
+cloudflare-api,https://mcp.cloudflare.com/mcp,oauth,tools/api/cloudflare-mcp.md,Workers D1 KV R2 Pages AI Gateway via OAuth
+openapi-search,https://openapi-mcp.openapisearch.com/mcp,none,tools/context/openapi-search.md,Search and explore any OpenAPI spec — semantic search across 3000+ public APIs
+context7,npx @upstash/context7-mcp@latest,none,tools/context/context7.md,Real-time library documentation for development
+ios-simulator,npx ios-simulator-mcp,none,tools/mobile/ios-simulator-mcp.md,AI-driven iOS simulator interaction
+fluentcrm,local-build,api-key,services/crm/fluentcrm.md,WordPress CRM contacts campaigns automations email marketing
+unstract,docker unstract/mcp-server,api-key,services/document-processing/unstract.md,LLM-powered structured data extraction from unstructured documents
+ahrefs,npx @ahrefs/mcp@latest,api-key,seo/dataforseo.md,SEO analysis backlink research keyword data
+perplexity,npx perplexity-mcp@latest,api-key,tools/context/model-routing.md,AI-powered web search and research
+google-search-console,npx mcp-server-gsc@latest,service-account,seo/google-search-console.md,Search performance data and insights
+mcporter,npx mcporter,none,tools/mcp-toolkit/mcporter.md,Discover call compose and generate CLIs for any MCP server
+-->
+
 <!--TOON:workflows[13]{name,file,purpose}:
 git-workflow,workflows/git-workflow.md,Branch naming and commit conventions
 plans,workflows/plans.md,Complex execution plans


### PR DESCRIPTION
## Summary

- Added OpenAPI Search MCP to `mcp-integrations.md`: quick reference, available integrations list, and full setup section (Claude Code CLI, OpenCode, Claude Desktop configs)
- Added `mcp_servers` TOON block to `subagent-index.toon` listing 12 MCP integrations, making them explicitly discoverable as a structured index
- `openapi-search` was already registered in the `tools/context/` subagents block; the new `mcp_servers` block adds a dedicated MCP-focused index

## Details

- Zero install, no auth required — remote Cloudflare Worker at `https://openapi-mcp.openapisearch.com/mcp`
- 3-step workflow: `searchAPIs` → `getAPIOverview` → `getOperationDetails`
- Lazy-loaded: disabled globally, enabled on-demand via `@openapi-search` subagent
- Per-agent enablement documented with reference to `tools/context/openapi-search.md`

Ref #2073