### PR TITLE
t1161.2: Automate MCP registration via claude mcp add-json

### DIFF
--- a/.agents/scripts/mcp-register-claude.sh
+++ b/.agents/scripts/mcp-register-claude.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+
+# MCP Registration Script for Claude Code
+# Reads configs/mcp-templates/*.json and registers MCP servers via `claude mcp add-json`.
+# Extracts claude_code_command / claude_code_manual / claude_code_cli / claude_code
+# entries from template files, or auto-generates from mcpServers structure.
+#
+# Usage:
+#   mcp-register-claude.sh [options] [template...]
+#
+# Options:
+#   --dry-run       Show commands without executing
+#   --scope <scope> Override scope (user, local, project). Default: user
+#   --force         Re-register even if already registered
+#   --list          List available templates and their registration status
+#   --skip <name>   Skip specific template (repeatable)
+#   --help          Show this help
+#
+# Examples:
+#   mcp-register-claude.sh                    # Register all templates
+#   mcp-register-claude.sh --dry-run          # Preview all commands
+#   mcp-register-claude.sh --list             # Show status
+#   mcp-register-claude.sh augment osgrep     # Register specific templates
+#   mcp-register-claude.sh --skip quickfile   # Skip templates with placeholders
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)" || exit
+
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+# Defaults
+DRY_RUN=false
+SCOPE="user"
+FORCE=false
+LIST_MODE=false
+declare -a SKIP_LIST=()
+declare -a TARGETS=()
+TEMPLATE_DIR="${REPO_ROOT}/configs/mcp-templates"
+
+# Templates to always skip (meta-configs, aggregates)
+DEFAULT_SKIP=("complete-mcp-config")
+
+# Counters
+declare -i registered=0
+declare -i skipped=0
+declare -i failed=0
+declare -i already=0
+
+usage() {
+	local script_name
+	script_name="$(basename "$0")"
+	cat <<EOF
+Usage: ${script_name} [options] [template...]
+
+Register MCP servers with Claude Code from configs/mcp-templates/ JSON files.
+
+Options:
+  --dry-run       Show commands without executing
+  --scope <scope> Override scope (user, local, project). Default: user
+  --force         Re-register even if already registered
+  --list          List available templates and their registration status
+  --skip <name>   Skip specific template (repeatable)
+  --help          Show this help
+
+Templates are matched by filename stem (e.g. 'augment' matches augment-context-engine.json).
+If no templates specified, all templates with claude_code_command entries are processed.
+EOF
+	return 0
+}
+
+# Parse arguments
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--dry-run)
+			DRY_RUN=true
+			shift
+			;;
+		--scope)
+			SCOPE="${2:-user}"
+			shift 2
+			;;
+		--force)
+			FORCE=true
+			shift
+			;;
+		--list)
+			LIST_MODE=true
+			shift
+			;;
+		--skip)
+			SKIP_LIST+=("${2:-}")
+			shift 2
+			;;
+		--help | -h)
+			usage
+			exit 0
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			usage
+			exit 1
+			;;
+		*)
+			TARGETS+=("$1")
+			shift
+			;;
+		esac
+	done
+	return 0
+}
+
+# Check if claude CLI is available
+check_claude_cli() {
+	if ! command -v claude &>/dev/null; then
+		print_error "claude CLI not found. Install Claude Code first."
+		exit 1
+	fi
+	return 0
+}
+
+# Get list of currently registered MCP server names
+get_registered_servers() {
+	local servers
+	# claude mcp list outputs lines like: "name: command - status"
+	servers=$(claude mcp list 2>/dev/null | grep -oE '^\S+:' | sed 's/:$//' || true)
+	echo "$servers"
+	return 0
+}
+
+# Check if a server name is already registered
+is_registered() {
+	local name="$1"
+	local registered_list="$2"
+	echo "$registered_list" | grep -qx "$name" 2>/dev/null
+	return $?
+}
+
+# Check if a template should be skipped
+should_skip() {
+	local template_stem="$1"
+	# Check default skip list
+	local skip_name
+	for skip_name in "${DEFAULT_SKIP[@]}"; do
+		if [[ "$template_stem" == "$skip_name" ]]; then
+			return 0
+		fi
+	done
+	# Check user skip list
+	if [[ ${#SKIP_LIST[@]} -gt 0 ]]; then
+		for skip_name in "${SKIP_LIST[@]}"; do
+			if [[ "$template_stem" == *"$skip_name"* ]]; then
+				return 0
+			fi
+		done
+	fi
+	return 1
+}
+
+# Check if template matches any target filter
+matches_target() {
+	local template_stem="$1"
+	# No targets = match all
+	if [[ ${#TARGETS[@]} -eq 0 ]]; then
+		return 0
+	fi
+	local target
+	for target in "${TARGETS[@]}"; do
+		if [[ "$template_stem" == *"$target"* ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Extract claude_code_command string from a template JSON file.
+# Checks keys: claude_code_command, claude_code_manual, claude_code_cli, claude_code (string only)
+# Returns the command string or empty.
+extract_command() {
+	local template_file="$1"
+
+	# Try each key variant in priority order
+	local key
+	for key in "claude_code_command" "claude_code_manual" "claude_code_cli" "claude_code"; do
+		local value
+		value=$(python3 -c "
+import json, sys
+with open('$template_file') as f:
+    data = json.load(f)
+val = data.get('$key', None)
+if isinstance(val, str) and val.startswith('claude mcp'):
+    print(val)
+" 2>/dev/null || true)
+		if [[ -n "$value" ]]; then
+			echo "$value"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+# Auto-generate a claude mcp add-json command from mcpServers structure.
+# Only works for simple stdio servers with command/args.
+generate_command_from_mcpservers() {
+	local template_file="$1"
+
+	python3 -c "
+import json, sys
+
+with open('$template_file') as f:
+    data = json.load(f)
+
+servers = data.get('mcpServers', {})
+if not servers:
+    # Try claude_desktop.mcpServers
+    cd = data.get('claude_desktop', {})
+    servers = cd.get('mcpServers', {})
+
+if not servers:
+    sys.exit(1)
+
+for name, config in servers.items():
+    # Skip non-dict entries
+    if not isinstance(config, dict):
+        continue
+    # Build stdio JSON
+    cmd = config.get('command', '')
+    args = config.get('args', [])
+    env = config.get('env', {})
+    url = config.get('url', '')
+
+    if url:
+        # HTTP/SSE server
+        entry = {'type': 'http', 'url': url}
+        print(f'claude mcp add-json {name} --scope $SCOPE ' + \"'\" + json.dumps(entry, separators=(',', ':')) + \"'\")
+    elif cmd:
+        entry = {'type': 'stdio', 'command': cmd, 'args': args}
+        if env:
+            entry['env'] = env
+        print(f'claude mcp add-json {name} --scope $SCOPE ' + \"'\" + json.dumps(entry, separators=(',', ':')) + \"'\")
+    # Only generate for the first server entry
+    break
+" 2>/dev/null || true
+	return 0
+}
+
+# Extract the MCP server name from a command string.
+# Handles: claude mcp add-json <name> ...
+#           claude mcp add [--flag value]... <name> ...
+extract_server_name() {
+	local cmd="$1"
+
+	# Strip everything from the first single-quote onward (JSON payload)
+	local stripped="${cmd%%\'*}"
+
+	# Split into words and find the name after add/add-json, skipping --flag value pairs
+	local -a words
+	read -ra words <<<"$stripped"
+
+	local found_subcmd=false
+	local i=0
+	while [[ $i -lt ${#words[@]} ]]; do
+		local word="${words[$i]}"
+		if [[ "$found_subcmd" == true ]]; then
+			if [[ "$word" == --* ]]; then
+				# Skip flag and its value
+				i=$((i + 2))
+				continue
+			fi
+			# This is the server name
+			echo "$word"
+			return 0
+		fi
+		if [[ "$word" == "add-json" ]] || [[ "$word" == "add" ]]; then
+			found_subcmd=true
+		fi
+		i=$((i + 1))
+	done
+
+	return 1
+}
+
+# Detect if a command contains placeholder values that need user customization
+has_placeholders() {
+	local cmd="$1"
+	# Common placeholder patterns
+	if [[ "$cmd" == *"/path/to/"* ]] ||
+		[[ "$cmd" == *"your_"*"_here"* ]] ||
+		[[ "$cmd" == *"your-"*"-here"* ]] ||
+		[[ "$cmd" == *"YOUR_"* ]] ||
+		[[ "$cmd" == *"/Users/YOU/"* ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# Normalize scope in a command to match the requested scope
+normalize_scope() {
+	local cmd="$1"
+	local target_scope="$2"
+
+	# If command already has --scope, replace it
+	if [[ "$cmd" == *"--scope "* ]]; then
+		cmd=$(echo "$cmd" | sed "s/--scope [a-z]*/--scope ${target_scope}/")
+	# If it's an add-json command without --scope, add it
+	elif [[ "$cmd" == *"add-json"* ]] && [[ "$cmd" != *"--scope"* ]]; then
+		cmd=$(echo "$cmd" | sed "s/add-json \([^ ]*\)/add-json \1 --scope ${target_scope}/")
+	fi
+
+	echo "$cmd"
+	return 0
+}
+
+# Execute or display a registration command
+run_command() {
+	local cmd="$1"
+	local template_name="$2"
+
+	if [[ "$DRY_RUN" == true ]]; then
+		echo "  ${cmd}"
+		((registered++))
+		return 0
+	fi
+
+	if eval "$cmd" 2>/dev/null; then
+		print_success "${template_name}: registered"
+		((registered++))
+	else
+		print_error "${template_name}: registration failed"
+		((failed++))
+	fi
+	return 0
+}
+
+# List mode: show all templates and their status
+list_templates() {
+	local registered_list
+	registered_list=$(get_registered_servers)
+
+	printf "%-35s %-20s %s\n" "TEMPLATE" "SERVER NAME" "STATUS"
+	printf "%-35s %-20s %s\n" "--------" "-----------" "------"
+
+	for template_file in "${TEMPLATE_DIR}"/*.json; do
+		[[ -f "$template_file" ]] || continue
+		local stem
+		stem=$(basename "$template_file" .json)
+
+		local cmd
+		cmd=$(extract_command "$template_file" || true)
+		if [[ -z "$cmd" ]]; then
+			cmd=$(generate_command_from_mcpservers "$template_file" || true)
+		fi
+
+		if [[ -z "$cmd" ]]; then
+			printf "%-35s %-20s %s\n" "$stem" "-" "no command"
+			continue
+		fi
+
+		local server_name
+		server_name=$(extract_server_name "$cmd" || true)
+		[[ -z "$server_name" ]] && server_name="?"
+
+		local status="not registered"
+		if is_registered "$server_name" "$registered_list"; then
+			status="registered"
+		fi
+
+		if has_placeholders "$cmd"; then
+			status="${status} (has placeholders)"
+		fi
+
+		printf "%-35s %-20s %s\n" "$stem" "$server_name" "$status"
+	done
+	return 0
+}
+
+# Main registration logic
+register_all() {
+	local registered_list
+	registered_list=$(get_registered_servers)
+
+	if [[ "$DRY_RUN" == true ]]; then
+		print_info "Dry run — commands will be shown but not executed"
+		echo
+	fi
+
+	for template_file in "${TEMPLATE_DIR}"/*.json; do
+		[[ -f "$template_file" ]] || continue
+		local stem
+		stem=$(basename "$template_file" .json)
+
+		# Filter by target
+		if ! matches_target "$stem"; then
+			continue
+		fi
+
+		# Check skip list (includes default skips)
+		if should_skip "$stem"; then
+			((skipped++))
+			continue
+		fi
+
+		# Extract command
+		local cmd
+		cmd=$(extract_command "$template_file" || true)
+		if [[ -z "$cmd" ]]; then
+			cmd=$(generate_command_from_mcpservers "$template_file" || true)
+		fi
+
+		if [[ -z "$cmd" ]]; then
+			((skipped++))
+			continue
+		fi
+
+		# Skip commands with placeholders (unless forced)
+		if has_placeholders "$cmd" && [[ "$FORCE" != true ]]; then
+			print_warning "${stem}: skipped (contains placeholders — use --force to override)"
+			((skipped++))
+			continue
+		fi
+
+		# Extract server name for duplicate check
+		local server_name
+		server_name=$(extract_server_name "$cmd" || true)
+
+		# Check if already registered
+		if [[ -n "$server_name" ]] && is_registered "$server_name" "$registered_list" && [[ "$FORCE" != true ]]; then
+			print_info "${stem}: already registered as '${server_name}'"
+			((already++))
+			continue
+		fi
+
+		# Normalize scope
+		cmd=$(normalize_scope "$cmd" "$SCOPE")
+
+		# Execute
+		run_command "$cmd" "$stem"
+	done
+
+	echo
+	if [[ "$DRY_RUN" == true ]]; then
+		print_info "Dry run summary: ${registered} would register, ${skipped} skipped, ${already} already registered"
+	else
+		print_info "Summary: ${registered} registered, ${skipped} skipped, ${already} already registered, ${failed} failed"
+	fi
+	return 0
+}
+
+main() {
+	parse_args "$@"
+
+	check_claude_cli
+
+	if [[ ! -d "$TEMPLATE_DIR" ]]; then
+		print_error "Template directory not found: ${TEMPLATE_DIR}"
+		exit 1
+	fi
+
+	if [[ "$LIST_MODE" == true ]]; then
+		list_templates
+	else
+		register_all
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/configs/mcp-templates/chrome-devtools.json
+++ b/configs/mcp-templates/chrome-devtools.json
@@ -1,4 +1,6 @@
 {
+  "claude_code_command": "claude mcp add-json chrome-devtools --scope user '{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"chrome-devtools-mcp@latest\",\"--channel=canary\",\"--headless=true\",\"--isolated=true\",\"--viewport=1920x1080\",\"--logFile=/tmp/chrome-mcp.log\"]}'",
+
   "mcpServers": {
     "chrome-devtools": {
       "command": "npx",

--- a/configs/mcp-templates/crawl4ai-mcp-config.json
+++ b/configs/mcp-templates/crawl4ai-mcp-config.json
@@ -1,4 +1,6 @@
 {
+  "claude_code_command": "claude mcp add-json crawl4ai --scope user '{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"crawl4ai-mcp-server@latest\"],\"env\":{\"CRAWL4AI_API_URL\":\"http://localhost:11235\",\"CRAWL4AI_TIMEOUT\":\"60\",\"CRAWL4AI_MAX_PAGES\":\"50\",\"CRAWL4AI_DEFAULT_FORMAT\":\"markdown\"}}'",
+
   "mcpServers": {
     "crawl4ai": {
       "command": "npx",

--- a/configs/mcp-templates/grep-vercel.json
+++ b/configs/mcp-templates/grep-vercel.json
@@ -1,4 +1,6 @@
 {
+  "claude_code_command": "claude mcp add-json gh_grep --scope user '{\"type\":\"http\",\"url\":\"https://mcp.grep.app\"}'",
+
   "mcpServers": {
     "gh_grep": {
       "type": "remote",

--- a/configs/mcp-templates/nextjs-devtools.json
+++ b/configs/mcp-templates/nextjs-devtools.json
@@ -1,4 +1,6 @@
 {
+  "claude_code_command": "claude mcp add-json nextjs-devtools --scope user '{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"next-devtools-mcp@latest\",\"--dev-mode=true\",\"--hot-reload=true\"]}'",
+
   "mcpServers": {
     "nextjs-devtools": {
       "command": "npx",

--- a/configs/mcp-templates/peekaboo.json
+++ b/configs/mcp-templates/peekaboo.json
@@ -9,6 +9,8 @@
   ],
   "_install": "brew install steipete/tap/peekaboo",
 
+  "claude_code_command": "claude mcp add-json peekaboo --scope user '{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@steipete/peekaboo\"],\"env\":{\"PEEKABOO_AI_PROVIDERS\":\"openai/gpt-4o,anthropic/claude-sonnet-4\"}}'",
+
   "claude_desktop": {
     "_comment": "Add to Claude Desktop config (Developer > Edit Config)",
     "mcpServers": {

--- a/configs/mcp-templates/playwright.json
+++ b/configs/mcp-templates/playwright.json
@@ -1,4 +1,6 @@
 {
+  "claude_code_command": "claude mcp add-json playwright --scope user '{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"playwright-mcp@latest\"]}'",
+
   "mcpServers": {
     "playwright": {
       "command": "npx",

--- a/configs/mcp-templates/shadcn.json
+++ b/configs/mcp-templates/shadcn.json
@@ -1,4 +1,6 @@
 {
+  "claude_code_command": "claude mcp add-json shadcn --scope user '{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"shadcn@latest\",\"mcp\"]}'",
+
   "mcpServers": {
     "shadcn": {
       "command": "npx",

--- a/configs/mcp-templates/stagehand.json
+++ b/configs/mcp-templates/stagehand.json
@@ -1,4 +1,6 @@
 {
+  "claude_code_command": "claude mcp add-json stagehand --scope user '{\"type\":\"stdio\",\"command\":\"node\",\"args\":[\"-e\",\"const { Stagehand } = require(\\u0027@browserbasehq/stagehand\\u0027); console.log(\\u0027Stagehand JavaScript AI Browser Automation Ready\\u0027);\"],\"env\":{\"STAGEHAND_ENV\":\"LOCAL\",\"STAGEHAND_VERBOSE\":\"1\",\"STAGEHAND_HEADLESS\":\"false\"}}'",
+
   "mcpServers": {
     "stagehand": {
       "command": "node",


### PR DESCRIPTION
## Summary

Automates MCP server registration with Claude Code by reading existing `configs/mcp-templates/*.json` files and executing `claude mcp add-json` commands.

Ref #1756

## Changes

### New script: `.agents/scripts/mcp-register-claude.sh`

Scans `configs/mcp-templates/*.json` for `claude_code_command` / `claude_code_manual` / `claude_code_cli` / `claude_code` entries and registers MCP servers via `claude mcp add-json`.

**Features:**
- Extracts registration commands from template JSON files (4 key variants supported)
- Falls back to auto-generating `claude mcp add-json` from `mcpServers` structure
- Detects placeholder values (`/path/to/`, `your_*_here`) and skips by default
- Checks existing registrations to avoid duplicates
- Supports `--dry-run`, `--list`, `--force`, `--scope`, `--skip` flags
- Targeted registration by template name substring
- Skips meta-configs (`complete-mcp-config`) by default
- ShellCheck clean (zero violations)

### Template updates

Added `claude_code_command` entries to 8 templates that had `mcpServers` but no explicit Claude Code registration command:
- `chrome-devtools.json`
- `playwright.json`
- `shadcn.json`
- `nextjs-devtools.json`
- `peekaboo.json`
- `grep-vercel.json`
- `stagehand.json`
- `crawl4ai-mcp-config.json`

## Usage

```bash
# Preview all registration commands
mcp-register-claude.sh --dry-run

# Register all available MCP servers
mcp-register-claude.sh

# Show template status
mcp-register-claude.sh --list

# Register specific templates
mcp-register-claude.sh augment osgrep playwright

# Skip templates with placeholders
mcp-register-claude.sh --skip quickfile --skip outscraper
```