### PR TITLE
t1161.4: Wire generate-claude-agents.sh into update_claude_config()

### DIFF
--- a/setup-modules/config.sh
+++ b/setup-modules/config.sh
@@ -145,5 +145,29 @@ update_claude_config() {
 		print_warning "Claude Code command generator not found at $commands_script"
 	fi
 
+	# Generate Claude Code agent configuration (MCPs, settings.json, slash commands)
+	# Mirrors update_opencode_config() calling generate-opencode-agents.sh (t1161.4)
+	local generator_script=".agents/scripts/generate-claude-agents.sh"
+	if [[ -f "$generator_script" ]]; then
+		print_info "Generating Claude Code agent configuration..."
+		if bash "$generator_script"; then
+			print_success "Claude Code agents configured (MCPs, settings, commands)"
+		else
+			print_warning "Claude Code agent generation encountered issues"
+		fi
+	else
+		print_warning "Claude Code agent generator not found at $generator_script"
+	fi
+
+	# Regenerate subagent index (shared between OpenCode and Claude Code)
+	local index_script=".agents/scripts/subagent-index-helper.sh"
+	if [[ -f "$index_script" ]]; then
+		if bash "$index_script" generate; then
+			print_success "Subagent index regenerated"
+		else
+			print_warning "Subagent index generation encountered issues"
+		fi
+	fi
+
 	return 0
 }


### PR DESCRIPTION
Wire `generate-claude-agents.sh` into `update_claude_config()` in `setup-modules/config.sh`.

## Summary
- `update_claude_config()` now calls `generate-claude-agents.sh` (MCP server registration, settings.json updates, slash commands) in addition to `generate-claude-commands.sh`
- Also regenerates the shared subagent index via `subagent-index-helper.sh`
- Mirrors the structure of `update_opencode_config()` which calls `generate-opencode-agents.sh` + subagent index
- All conditional on `claude` binary existing (guard already present)

## Changes
- `setup-modules/config.sh`: Added agent generator and subagent index calls to `update_claude_config()`

Ref #1758

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized configuration generation processes with improved error messaging and consistent handling across setup modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->