### PR TITLE
t1163: OAuth-aware dispatch routing

### DIFF
--- a/.agents/scripts/budget-tracker-helper.sh
+++ b/.agents/scripts/budget-tracker-helper.sh
@@ -281,6 +281,10 @@ get_billing_type() {
 		# OpenCode uses OAuth with periodic allowances (Max plan)
 		echo "$BILLING_SUBSCRIPTION"
 		;;
+	claude-oauth)
+		# Claude CLI with OAuth (Max/Pro subscription) — zero marginal cost (t1163)
+		echo "$BILLING_SUBSCRIPTION"
+		;;
 	*)
 		echo "$BILLING_TOKEN"
 		;;

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -431,6 +431,33 @@ opencode run -m openrouter/anthropic/claude-sonnet-4-6 "Task"
 opencode run -m groq/llama-4-scout-17b-16e-instruct "Quick task"
 ```
 
+### OAuth-Aware Dispatch Routing (t1163)
+
+When `SUPERVISOR_PREFER_OAUTH=true` (default), the supervisor automatically detects if the Claude CLI has OAuth authentication (subscription/Max plan) and routes Anthropic model requests through it. This is zero marginal cost for Anthropic models.
+
+**Routing logic:**
+
+- Anthropic models + Claude OAuth available → `claude` CLI (subscription billing)
+- Anthropic models + no OAuth → `opencode` CLI (token billing)
+- Non-Anthropic models → `opencode` CLI (multi-provider support)
+
+**Configuration:**
+
+```bash
+# Enable/disable OAuth preference (default: true)
+export SUPERVISOR_PREFER_OAUTH=true
+
+# Force a specific CLI (overrides OAuth routing)
+export SUPERVISOR_CLI=opencode
+
+# Configure claude-oauth as subscription provider in budget tracker
+budget-tracker-helper.sh configure claude-oauth --billing-type subscription
+budget-tracker-helper.sh configure-period claude-oauth \
+  --start 2026-02-01 --end 2026-03-01 --allowance 500 --unit usd
+```
+
+**Detection:** The supervisor checks for OAuth by looking for Claude CLI credentials in `~/.claude/`. Results are cached for 5 minutes.
+
 Environment variables for non-interactive setup:
 
 ```bash


### PR DESCRIPTION
## Summary

OAuth-aware dispatch routing for the supervisor — detects Claude CLI OAuth availability and routes Anthropic model requests through it when a subscription is active (zero marginal cost).

## Changes

### Core: OAuth-aware dispatch routing (`dispatch.sh`)
- **`detect_claude_oauth()`** — New function that detects if Claude CLI has OAuth credentials by checking `~/.claude/settings.json` and credential files. Results cached for 5 minutes.
- **`resolve_ai_cli()`** — Updated to accept optional model parameter. When `SUPERVISOR_PREFER_OAUTH=true` (default) and the target model is Anthropic, prefers Claude CLI if OAuth is available.
- **`cmd_dispatch()`** — Added OAuth-aware CLI re-resolution after model resolution. If the resolved model is Anthropic and OAuth is available, switches from opencode to claude CLI with health check fallback.

### Budget tracker (`budget-tracker-helper.sh`)
- Added `claude-oauth` as a recognized subscription billing type in `get_billing_type()`
- Integrates with existing `budget-preferred-provider` logic for zero-cost routing

### Documentation (`headless-dispatch.md`)
- New "OAuth-Aware Dispatch Routing" section documenting routing logic, configuration, and detection

### Tests (`test-dispatch-claude-cli.sh`)
- 6 new tests covering OAuth detection, Anthropic vs non-Anthropic routing, preference toggle, and CLI override precedence
- All 66 tests pass (65 pass, 1 expected skip)

## Routing Logic

```
SUPERVISOR_CLI set? → use that CLI (override)
SUPERVISOR_PREFER_OAUTH=true + Anthropic model + OAuth available? → claude CLI
Otherwise → opencode CLI (default)
```

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `SUPERVISOR_PREFER_OAUTH` | `true` | Prefer Claude CLI for Anthropic models when OAuth available |
| `SUPERVISOR_CLI` | (unset) | Force specific CLI (overrides OAuth routing) |

Ref #1760