### PR TITLE
fix: skip Phase 4b2 legacy pr_review recovery when AI lifecycle is active

### DIFF
--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -2641,16 +2641,21 @@ RULES:
 	fi
 
 	# Phase 4b2: Stale pr_review recovery (t1208)
-	# Tasks in 'pr_review' are processed by Phase 3 (process_post_pr_lifecycle) each
-	# pulse. However, if cmd_pr_lifecycle fails repeatedly or the PR is in an
-	# unexpected state, the task can get stuck in pr_review indefinitely.
-	# After SUPERVISOR_PR_REVIEW_STALE_SECONDS (default 3600 = 1h), force a
-	# re-attempt via cmd_pr_lifecycle. If that also fails, log a warning so the
-	# operator can investigate — do NOT auto-fail pr_review tasks since the PR
-	# may be legitimately waiting for CI or human review.
-	local pr_review_stale_seconds="${SUPERVISOR_PR_REVIEW_STALE_SECONDS:-3600}"
-	local stale_pr_review
-	stale_pr_review=$(db -separator '|' "$SUPERVISOR_DB" "
+	# When AI lifecycle is active, Phase 3 handles all pr_review tasks via
+	# process_ai_lifecycle — skip legacy cmd_pr_lifecycle to avoid clobbering
+	# AI decisions (e.g., marking tasks as "Merge failed" when the AI already
+	# decided to escalate or wait).
+	if [[ "${SUPERVISOR_AI_LIFECYCLE:-true}" != "true" ]]; then
+		# Tasks in 'pr_review' are processed by Phase 3 (process_post_pr_lifecycle) each
+		# pulse. However, if cmd_pr_lifecycle fails repeatedly or the PR is in an
+		# unexpected state, the task can get stuck in pr_review indefinitely.
+		# After SUPERVISOR_PR_REVIEW_STALE_SECONDS (default 3600 = 1h), force a
+		# re-attempt via cmd_pr_lifecycle. If that also fails, log a warning so the
+		# operator can investigate — do NOT auto-fail pr_review tasks since the PR
+		# may be legitimately waiting for CI or human review.
+		local pr_review_stale_seconds="${SUPERVISOR_PR_REVIEW_STALE_SECONDS:-3600}"
+		local stale_pr_review
+		stale_pr_review=$(db -separator '|' "$SUPERVISOR_DB" "
         SELECT id, pr_url, updated_at
         FROM tasks
         WHERE status = 'pr_review'
@@ -2658,28 +2663,29 @@ RULES:
         ORDER BY updated_at ASC;
     " 2>/dev/null || echo "")
 
-	if [[ -n "$stale_pr_review" ]]; then
-		local pr_review_recovered=0
-		while IFS='|' read -r spr_id spr_pr_url spr_updated; do
-			[[ -n "$spr_id" ]] || continue
-			log_warn "  Stale pr_review: $spr_id (last updated: ${spr_updated:-unknown}, >${pr_review_stale_seconds}s) — re-attempting lifecycle (t1208)"
-			if cmd_pr_lifecycle "$spr_id" 2>>"$SUPERVISOR_LOG"; then
-				local spr_new_status
-				spr_new_status=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$spr_id")';" 2>/dev/null || echo "")
-				if [[ "$spr_new_status" != "pr_review" ]]; then
-					log_info "  Phase 4b2: $spr_id advanced from pr_review → $spr_new_status"
-					pr_review_recovered=$((pr_review_recovered + 1))
+		if [[ -n "$stale_pr_review" ]]; then
+			local pr_review_recovered=0
+			while IFS='|' read -r spr_id spr_pr_url spr_updated; do
+				[[ -n "$spr_id" ]] || continue
+				log_warn "  Stale pr_review: $spr_id (last updated: ${spr_updated:-unknown}, >${pr_review_stale_seconds}s) — re-attempting lifecycle (t1208)"
+				if cmd_pr_lifecycle "$spr_id" 2>>"$SUPERVISOR_LOG"; then
+					local spr_new_status
+					spr_new_status=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$spr_id")';" 2>/dev/null || echo "")
+					if [[ "$spr_new_status" != "pr_review" ]]; then
+						log_info "  Phase 4b2: $spr_id advanced from pr_review → $spr_new_status"
+						pr_review_recovered=$((pr_review_recovered + 1))
+					else
+						log_warn "  Phase 4b2: $spr_id still in pr_review after lifecycle attempt — may need manual review (PR: ${spr_pr_url:-none})"
+					fi
 				else
-					log_warn "  Phase 4b2: $spr_id still in pr_review after lifecycle attempt — may need manual review (PR: ${spr_pr_url:-none})"
+					log_warn "  Phase 4b2: cmd_pr_lifecycle failed for stale $spr_id — will retry next pulse (PR: ${spr_pr_url:-none})"
 				fi
-			else
-				log_warn "  Phase 4b2: cmd_pr_lifecycle failed for stale $spr_id — will retry next pulse (PR: ${spr_pr_url:-none})"
+			done <<<"$stale_pr_review"
+			if [[ "$pr_review_recovered" -gt 0 ]]; then
+				log_info "  Phase 4b2: $pr_review_recovered stale pr_review task(s) advanced"
 			fi
-		done <<<"$stale_pr_review"
-		if [[ "$pr_review_recovered" -gt 0 ]]; then
-			log_info "  Phase 4b2: $pr_review_recovered stale pr_review task(s) advanced"
 		fi
-	fi
+	fi # End of Phase 4b2 legacy guard (SUPERVISOR_AI_LIFECYCLE != true)
 
 	# Phase 4c: Cancel stale diagnostic subtasks whose parent is already resolved
 	# Diagnostic tasks (diagnostic_of != NULL) become stale when the parent task


### PR DESCRIPTION
## Summary

- Phase 4b2 (stale pr_review recovery) was running the legacy `cmd_pr_lifecycle` on tasks that Phase 3's AI lifecycle had already processed
- This clobbered AI decisions — e.g., marking tasks as "Merge failed" when the AI had already decided to escalate or wait
- Fix: wrap Phase 4b2 in the same `SUPERVISOR_AI_LIFECYCLE` guard used for Phase 3.5/3.6

## Evidence

3 of 6 awards app tasks (t005.2, t007.8, t010) were re-blocked by Phase 4b2 with "Merge failed" immediately after the AI lifecycle correctly processed them in Phase 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stale PR review handling with improved logging to provide better visibility into PR lifecycle status changes and processing outcomes.

* **Chores**
  * Optimized PR lifecycle recovery logic with conditional processing that improves efficiency and reduces potential conflicts when handling stale PR reviews during automated lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->