### PR TITLE
fix: use gh pr update-branch CLI instead of raw API with empty sha

### DIFF
--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -2641,16 +2641,21 @@ RULES:
 	fi
 
 	# Phase 4b2: Stale pr_review recovery (t1208)
-	# Tasks in 'pr_review' are processed by Phase 3 (process_post_pr_lifecycle) each
-	# pulse. However, if cmd_pr_lifecycle fails repeatedly or the PR is in an
-	# unexpected state, the task can get stuck in pr_review indefinitely.
-	# After SUPERVISOR_PR_REVIEW_STALE_SECONDS (default 3600 = 1h), force a
-	# re-attempt via cmd_pr_lifecycle. If that also fails, log a warning so the
-	# operator can investigate — do NOT auto-fail pr_review tasks since the PR
-	# may be legitimately waiting for CI or human review.
-	local pr_review_stale_seconds="${SUPERVISOR_PR_REVIEW_STALE_SECONDS:-3600}"
-	local stale_pr_review
-	stale_pr_review=$(db -separator '|' "$SUPERVISOR_DB" "
+	# When AI lifecycle is active, Phase 3 handles all pr_review tasks via
+	# process_ai_lifecycle — skip legacy cmd_pr_lifecycle to avoid clobbering
+	# AI decisions (e.g., marking tasks as "Merge failed" when the AI already
+	# decided to escalate or wait).
+	if [[ "${SUPERVISOR_AI_LIFECYCLE:-true}" != "true" ]]; then
+		# Tasks in 'pr_review' are processed by Phase 3 (process_post_pr_lifecycle) each
+		# pulse. However, if cmd_pr_lifecycle fails repeatedly or the PR is in an
+		# unexpected state, the task can get stuck in pr_review indefinitely.
+		# After SUPERVISOR_PR_REVIEW_STALE_SECONDS (default 3600 = 1h), force a
+		# re-attempt via cmd_pr_lifecycle. If that also fails, log a warning so the
+		# operator can investigate — do NOT auto-fail pr_review tasks since the PR
+		# may be legitimately waiting for CI or human review.
+		local pr_review_stale_seconds="${SUPERVISOR_PR_REVIEW_STALE_SECONDS:-3600}"
+		local stale_pr_review
+		stale_pr_review=$(db -separator '|' "$SUPERVISOR_DB" "
         SELECT id, pr_url, updated_at
         FROM tasks
         WHERE status = 'pr_review'
@@ -2658,28 +2663,29 @@ RULES:
         ORDER BY updated_at ASC;
     " 2>/dev/null || echo "")
 
-	if [[ -n "$stale_pr_review" ]]; then
-		local pr_review_recovered=0
-		while IFS='|' read -r spr_id spr_pr_url spr_updated; do
-			[[ -n "$spr_id" ]] || continue
-			log_warn "  Stale pr_review: $spr_id (last updated: ${spr_updated:-unknown}, >${pr_review_stale_seconds}s) — re-attempting lifecycle (t1208)"
-			if cmd_pr_lifecycle "$spr_id" 2>>"$SUPERVISOR_LOG"; then
-				local spr_new_status
-				spr_new_status=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$spr_id")';" 2>/dev/null || echo "")
-				if [[ "$spr_new_status" != "pr_review" ]]; then
-					log_info "  Phase 4b2: $spr_id advanced from pr_review → $spr_new_status"
-					pr_review_recovered=$((pr_review_recovered + 1))
+		if [[ -n "$stale_pr_review" ]]; then
+			local pr_review_recovered=0
+			while IFS='|' read -r spr_id spr_pr_url spr_updated; do
+				[[ -n "$spr_id" ]] || continue
+				log_warn "  Stale pr_review: $spr_id (last updated: ${spr_updated:-unknown}, >${pr_review_stale_seconds}s) — re-attempting lifecycle (t1208)"
+				if cmd_pr_lifecycle "$spr_id" 2>>"$SUPERVISOR_LOG"; then
+					local spr_new_status
+					spr_new_status=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$spr_id")';" 2>/dev/null || echo "")
+					if [[ "$spr_new_status" != "pr_review" ]]; then
+						log_info "  Phase 4b2: $spr_id advanced from pr_review → $spr_new_status"
+						pr_review_recovered=$((pr_review_recovered + 1))
+					else
+						log_warn "  Phase 4b2: $spr_id still in pr_review after lifecycle attempt — may need manual review (PR: ${spr_pr_url:-none})"
+					fi
 				else
-					log_warn "  Phase 4b2: $spr_id still in pr_review after lifecycle attempt — may need manual review (PR: ${spr_pr_url:-none})"
+					log_warn "  Phase 4b2: cmd_pr_lifecycle failed for stale $spr_id — will retry next pulse (PR: ${spr_pr_url:-none})"
 				fi
-			else
-				log_warn "  Phase 4b2: cmd_pr_lifecycle failed for stale $spr_id — will retry next pulse (PR: ${spr_pr_url:-none})"
+			done <<<"$stale_pr_review"
+			if [[ "$pr_review_recovered" -gt 0 ]]; then
+				log_info "  Phase 4b2: $pr_review_recovered stale pr_review task(s) advanced"
 			fi
-		done <<<"$stale_pr_review"
-		if [[ "$pr_review_recovered" -gt 0 ]]; then
-			log_info "  Phase 4b2: $pr_review_recovered stale pr_review task(s) advanced"
 		fi
-	fi
+	fi # End of Phase 4b2 legacy guard (SUPERVISOR_AI_LIFECYCLE != true)
 
 	# Phase 4c: Cancel stale diagnostic subtasks whose parent is already resolved
 	# Diagnostic tasks (diagnostic_of != NULL) become stale when the parent task


### PR DESCRIPTION
The raw API call `gh api repos/.../update-branch -f expected_head_sha=""` was passing an empty sha, causing 422 errors. Switch to `gh pr update-branch` which handles sha correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging and instrumentation in internal supervisor automation scripts for improved debugging and monitoring of automated processes
  * Improved branch update handling with updated error reporting in continuous integration automation
  * Added conditional logic to support AI-driven lifecycle management as an alternative to legacy task recovery processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->