### PR TITLE
feat: mandatory task briefs with session provenance and conversation context

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -26,11 +26,15 @@ Subagent write restrictions: on `main`/`master`, subagents may ONLY write to `RE
 
 ## Development Lifecycle
 
-1. Create TODO entry before starting work
-2. Ask user: implement now or queue for runner?
-3. Full-loop: branch/worktree → implement → test → verify → commit/PR
-4. Queue: add to TODO.md for supervisor dispatch
-5. Never skip testing. Never declare "done" without verification.
+1. Create TODO entry **with brief** before starting work
+2. Brief file at `todo/tasks/{task_id}-brief.md` is MANDATORY (see `templates/brief-template.md`)
+3. Brief must include: session origin, what, why, how, acceptance criteria, context
+4. Ask user: implement now or queue for runner?
+5. Full-loop: branch/worktree → implement → test → verify → commit/PR
+6. Queue: add to TODO.md for supervisor dispatch
+7. Never skip testing. Never declare "done" without verification.
+
+**Task brief rule**: A task without a brief is undevelopable. The brief captures conversation context that would otherwise be lost between sessions. See `workflows/plans.md` and `scripts/commands/new-task.md`.
 
 ---
 
@@ -56,7 +60,9 @@ Format: `- [ ] t001 Description @owner #tag ~4h started:ISO blocked-by:t002`
 
 Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
-Auto-dispatch: `#auto-dispatch` tag. Add `assignee:` before pushing if working interactively.
+**Task briefs are MANDATORY.** Every task must have `todo/tasks/{task_id}-brief.md` capturing: session origin, what, why, how, acceptance criteria, and conversation context. Use `templates/brief-template.md`. A task without a brief loses the knowledge that created it.
+
+Auto-dispatch: `#auto-dispatch` tag — only if brief has 2+ acceptance criteria, file references in How section, and clear deliverable in What section. Add `assignee:` before pushing if working interactively.
 
 Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-DD`. Use `task-complete-helper.sh`.
 

--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -57,24 +57,81 @@ ID: {task_id}
 Ref: ref:{task_ref}
 
 Options:
-1. Add to TODO.md with defaults (~1h #auto-dispatch)
+1. Add to TODO.md with brief (recommended)
 2. Customize estimate, tags, and dependencies
 3. Just show the ID (don't add to TODO.md)
 ```
 
-### Step 5: Add to TODO.md (if requested)
+### Step 5: Create Task Brief (MANDATORY)
+
+**Every task MUST have a brief file** at `todo/tasks/{task_id}-brief.md`. This is non-negotiable. A task without a brief is undevelopable.
+
+Use `templates/brief-template.md` as the base. Populate from conversation context:
+
+```markdown
+# {task_id}: {Title}
+
+## Origin
+- **Created:** {ISO date}
+- **Session:** {app}:{session-id} (detect from runtime — e.g., opencode:session-xyz, claude-code:abc123)
+- **Created by:** {author} (human | ai-supervisor | ai-interactive)
+- **Parent task:** {parent_id} (if subtask — include link to parent brief)
+- **Conversation context:** {1-2 sentence summary of what was discussed}
+
+## What
+{Clear deliverable description — not "implement X" but what it must produce}
+
+## Why
+{Problem, user need, business value, or dependency requiring this}
+
+## How (Approach)
+{Technical approach, key files, patterns to follow}
+{Reference existing code: `path/to/file.ts:45`}
+
+## Acceptance Criteria
+- [ ] {Specific, testable criterion}
+- [ ] Tests pass
+- [ ] Lint clean
+
+## Context & Decisions
+{Key decisions, constraints, things ruled out}
+
+## Relevant Files
+- `path/to/file.ts:45` — {why relevant}
+```
+
+**For subtasks**: The brief MUST reference the parent task's brief and inherit its context. Don't repeat everything — link to the parent and add what's specific to this subtask.
+
+**Session ID capture**: Detect the runtime environment:
+
+- OpenCode: `$OPENCODE_SESSION_ID` or parse from `~/.local/share/opencode/sessions/`
+- Claude Code: `$CLAUDE_SESSION_ID` or the conversation ID from the CLI
+- If unavailable: use `{app}:unknown-{ISO-date}` and note "session ID not captured"
+
+### Step 6: Add to TODO.md
 
 Format the TODO.md entry using the allocated ID:
 
 ```markdown
-- [ ] {task_id} {title} #{tag} #auto-dispatch ~{estimate} ref:{task_ref} logged:{YYYY-MM-DD}
+- [ ] {task_id} {title} #{tag} ~{estimate} ref:{task_ref} logged:{YYYY-MM-DD}
 ```
 
-Then commit and push via `planning-commit-helper.sh`:
+**Auto-dispatch eligibility**: Only add `#auto-dispatch` if the brief has:
+- At least 2 acceptance criteria beyond "tests pass" and "lint clean"
+- A non-empty "How (Approach)" section with file references
+- A non-empty "What" section with clear deliverable
+
+If the brief is too thin for auto-dispatch, omit the tag and note why.
+
+### Step 7: Commit and Push
+
+Commit both the brief and TODO.md change:
 
 ```bash
 ~/.aidevops/agents/scripts/planning-commit-helper.sh "plan: add {task_id} {short_title}"
 ```
+
+The brief file (`todo/tasks/{task_id}-brief.md`) is a planning file and goes directly to main alongside TODO.md.
 
 ## Offline Handling
 
@@ -92,24 +149,53 @@ If `TASK_OFFLINE=true`, warn the user:
 User: /new-task Add CSV export button
 AI: Allocated: t325 (ref:GH#1260)
     Task: "Add CSV export button"
-    1. Add to TODO.md with defaults  2. Customize  3. Just show ID
+
+    Creating brief from conversation context...
+
+    Brief: todo/tasks/t325-brief.md
+    - What: Add a CSV export button to the data table component that exports
+      the current filtered view as a downloadable CSV file
+    - Why: Users need to export filtered data for offline analysis and reporting
+    - How: Add ExportButton to DataTable toolbar, use papaparse for CSV generation
+    - Acceptance: Button visible in toolbar, exports current filter, handles 10k+ rows
+
+    1. Confirm and add to TODO.md
+    2. Edit brief first
+    3. Cancel
 User: 1
-AI: Added to TODO.md:
-    - [ ] t325 Add CSV export button #auto-dispatch ~1h ref:GH#1260 logged:2026-02-12
+AI: Added:
+    - todo/tasks/t325-brief.md (brief)
+    - TODO.md: - [ ] t325 Add CSV export button #feature #auto-dispatch ~1h ref:GH#1260 logged:2026-02-12
 ```
 
 ```text
-User: /new-task
-AI: What's the task title?
-User: Fix login timeout on mobile
+User: /new-task Fix login timeout on mobile
 AI: Allocated: t326 (ref:GH#1261)
     Task: "Fix login timeout on mobile"
-    1. Add to TODO.md with defaults  2. Customize  3. Just show ID
-User: 2
-AI: Customize:
-    - Estimate: ~2h
-    - Tags: #bugfix
-    - Dependencies: blocked-by:t300
-    - Auto-dispatch: yes
-    Confirm? [y/n]
+
+    I need more context for the brief:
+    1. What's the current timeout behaviour? (error message, redirect, etc.)
+    2. Which auth provider? (Better Auth, NextAuth, custom)
+    3. Mobile-specific or all platforms?
+
+User: Better Auth, only on iOS Safari, users get logged out after 5 minutes
+AI: Brief: todo/tasks/t326-brief.md
+    - What: Fix premature session expiry on iOS Safari — sessions should last 24h
+    - Why: iOS Safari users lose work after 5 min due to aggressive cookie handling
+    - How: Check Better Auth session config, likely needs SameSite=None + Secure
+      for iOS Safari cookie persistence. File: packages/auth/src/config.ts
+    - Acceptance: iOS Safari session persists 24h, no regression on other browsers
+
+    1. Confirm  2. Edit  3. Cancel
 ```
+
+## CRITICAL: Supervisor Subtask Creation
+
+When the AI supervisor creates subtasks (e.g., decomposing t005 into t005.1-t005.5), it MUST:
+
+1. Create a brief for EACH subtask at `todo/tasks/{subtask_id}-brief.md`
+2. Reference the parent task's brief: `**Parent task:** {parent_id} — see [todo/tasks/{parent_id}-brief.md]`
+3. Inherit context from the parent but add subtask-specific details
+4. Include the session ID of the supervisor session that created the subtask
+
+A subtask without a brief is a knowledge loss. The parent task's rich context (from the original conversation) must flow down to every subtask.

--- a/.agents/scripts/generate-brief.sh
+++ b/.agents/scripts/generate-brief.sh
@@ -1,0 +1,491 @@
+#!/usr/bin/env bash
+# generate-brief.sh — Generate a task brief from OpenCode session history
+#
+# Usage: generate-brief.sh <task_id> [project_root]
+#
+# Traces a task back to its source session in OpenCode's DB,
+# extracts the conversation context, and generates a brief file.
+#
+# Output: todo/tasks/{task_id}-brief.md
+#
+# Dependencies: sqlite3, git, python3 (for JSON parsing)
+
+set -euo pipefail
+
+readonly OPENCODE_DB="${HOME}/.local/share/opencode/opencode.db"
+readonly SUPERVISOR_DB="${HOME}/.aidevops/.agent-workspace/supervisor/supervisor.db"
+
+# --- Helpers ---
+
+log_info() { echo "[INFO] $*" >&2; }
+log_warn() { echo "[WARN] $*" >&2; }
+log_error() { echo "[ERROR] $*" >&2; }
+
+usage() {
+	echo "Usage: $0 <task_id> [project_root]"
+	echo ""
+	echo "Generates a task brief from OpenCode session history."
+	echo "Output: {project_root}/todo/tasks/{task_id}-brief.md"
+	exit 1
+}
+
+# --- Step 1: Find creation commit ---
+
+find_creation_commit() {
+	local task_id="$1"
+	local project_root="$2"
+
+	# Find the first commit that introduced this task ID in TODO.md
+	local commit
+	commit=$(git -C "$project_root" log --all --format="%H" -S "- [ ] ${task_id} " -- TODO.md 2>/dev/null | tail -1)
+
+	if [[ -z "$commit" ]]; then
+		# Try without the checkbox
+		commit=$(git -C "$project_root" log --all --format="%H" -S "${task_id}" -- TODO.md 2>/dev/null | tail -1)
+	fi
+
+	echo "$commit"
+}
+
+get_commit_info() {
+	local commit="$1"
+	local project_root="$2"
+
+	git -C "$project_root" log -1 --format="COMMIT_DATE=%ai%nCOMMIT_AUTHOR=%an%nCOMMIT_MSG=%s%nCOMMIT_EPOCH=%ct" "$commit" 2>/dev/null
+}
+
+# --- Step 2: Find OpenCode session ---
+
+find_opencode_project_id() {
+	local project_root="$1"
+
+	if [[ ! -f "$OPENCODE_DB" ]]; then
+		return 1
+	fi
+
+	sqlite3 "$OPENCODE_DB" "
+		SELECT id FROM project WHERE worktree = '$project_root'
+	" 2>/dev/null | head -1
+}
+
+find_session_by_timestamp() {
+	local project_id="$1"
+	local epoch_secs="$2"
+	local epoch_ms=$((epoch_secs * 1000))
+
+	if [[ ! -f "$OPENCODE_DB" ]]; then
+		return 1
+	fi
+
+	# Find session that was active at this timestamp
+	# (created before, updated after or within 1 hour)
+	sqlite3 "$OPENCODE_DB" "
+		SELECT s.id, s.title, s.parent_id,
+		       datetime(s.time_created/1000, 'unixepoch') as created,
+		       datetime(s.time_updated/1000, 'unixepoch') as updated
+		FROM session s
+		WHERE s.project_id = '$project_id'
+		AND s.time_created <= $epoch_ms
+		AND s.time_updated >= ($epoch_ms - 3600000)
+		ORDER BY s.time_updated DESC
+		LIMIT 1
+	" 2>/dev/null
+}
+
+find_parent_session() {
+	local session_id="$1"
+
+	if [[ ! -f "$OPENCODE_DB" ]]; then
+		return 1
+	fi
+
+	local parent_id
+	parent_id=$(sqlite3 "$OPENCODE_DB" "
+		SELECT parent_id FROM session WHERE id = '$session_id'
+	" 2>/dev/null)
+
+	if [[ -n "$parent_id" ]]; then
+		sqlite3 "$OPENCODE_DB" "
+			SELECT id, title, datetime(time_created/1000, 'unixepoch')
+			FROM session WHERE id = '$parent_id'
+		" 2>/dev/null
+	fi
+}
+
+# --- Step 3: Extract conversation context ---
+
+extract_session_context() {
+	local session_id="$1"
+	local task_id="$2"
+
+	if [[ ! -f "$OPENCODE_DB" ]]; then
+		return 1
+	fi
+
+	# Find user messages that mention this task or were around the creation time
+	# Extract summary titles and diff content
+	python3 -c "
+import sqlite3, json, sys, re
+
+db = sqlite3.connect('$OPENCODE_DB')
+cursor = db.cursor()
+
+# Get all user messages from this session
+cursor.execute('''
+    SELECT m.data, m.time_created
+    FROM message m
+    WHERE m.session_id = ?
+    AND json_extract(m.data, '\$.role') = 'user'
+    ORDER BY m.time_created
+''', ('$session_id',))
+
+task_id = '$task_id'
+context_parts = []
+
+for row in cursor.fetchall():
+    try:
+        data = json.loads(row[0])
+        summary = data.get('summary', {})
+        title = summary.get('title', '')
+        diffs = summary.get('diffs', [])
+
+        # Check if this message's diff added the task
+        for diff in diffs:
+            after = diff.get('after', '')
+            before = diff.get('before', '')
+            if task_id in after and task_id not in before:
+                # This message created the task — extract the full block
+                lines = after.split('\n')
+                capturing = False
+                task_block = []
+                # Find the task line and determine its indent level
+                task_indent = -1
+                for i, line in enumerate(lines):
+                    # Match the task line (with or without checkbox)
+                    if re.search(rf'- \[.\] {re.escape(task_id)} ', line):
+                        capturing = True
+                        task_indent = len(line) - len(line.lstrip())
+                        task_block.append(line)
+                        continue
+                    if capturing:
+                        stripped = line.lstrip()
+                        current_indent = len(line) - len(stripped)
+                        # Continue capturing if:
+                        # - line is blank (preserve structure)
+                        # - line is more indented than the task line
+                        if line.strip() == '':
+                            # Blank line: peek ahead to see if next non-blank
+                            # line is still part of this block
+                            still_in_block = False
+                            for j in range(i + 1, min(i + 3, len(lines))):
+                                if lines[j].strip():
+                                    next_indent = len(lines[j]) - len(lines[j].lstrip())
+                                    if next_indent > task_indent:
+                                        still_in_block = True
+                                    break
+                            if still_in_block:
+                                task_block.append(line)
+                            else:
+                                break
+                        elif current_indent > task_indent:
+                            task_block.append(line)
+                        else:
+                            # Same or less indent = new task or section
+                            break
+
+                if task_block:
+                    context_parts.append('TASK_BLOCK_START')
+                    context_parts.extend(task_block)
+                    context_parts.append('TASK_BLOCK_END')
+
+                context_parts.append(f'MESSAGE_TITLE={title}')
+                break
+    except (json.JSONDecodeError, KeyError):
+        continue
+
+db.close()
+
+if context_parts:
+    print('\n'.join(context_parts))
+else:
+    print('NO_CONTEXT_FOUND')
+" 2>/dev/null
+}
+
+# --- Step 4: Check supervisor DB ---
+
+find_supervisor_context() {
+	local task_id="$1"
+
+	if [[ ! -f "$SUPERVISOR_DB" ]]; then
+		return 0
+	fi
+
+	# Exact match on task ID only — LIKE is too loose and matches unrelated tasks
+	sqlite3 "$SUPERVISOR_DB" "
+		SELECT id, description, session_id, created_at, completed_at
+		FROM tasks
+		WHERE id = '$task_id'
+		LIMIT 1
+	" 2>/dev/null
+}
+
+# --- Step 5: Generate brief ---
+
+generate_brief() {
+	local task_id="$1"
+	local project_root="$2"
+	local output_file="$project_root/todo/tasks/${task_id}-brief.md"
+
+	mkdir -p "$project_root/todo/tasks"
+
+	# Find creation commit
+	local commit
+	commit=$(find_creation_commit "$task_id" "$project_root")
+	if [[ -z "$commit" ]]; then
+		log_warn "No creation commit found for $task_id"
+		return 1
+	fi
+
+	# Get commit info
+	local commit_date="" commit_author="" commit_msg="" commit_epoch=""
+	while IFS='=' read -r key value; do
+		case "$key" in
+		COMMIT_DATE) commit_date="$value" ;;
+		COMMIT_AUTHOR) commit_author="$value" ;;
+		COMMIT_MSG) commit_msg="$value" ;;
+		COMMIT_EPOCH) commit_epoch="$value" ;;
+		esac
+	done <<<"$(get_commit_info "$commit" "$project_root")"
+
+	log_info "$task_id: commit $commit ($commit_date) by $commit_author"
+
+	# Find OpenCode session
+	local session_id="" session_title="" parent_session=""
+	local project_id
+	project_id=$(find_opencode_project_id "$project_root")
+
+	if [[ -n "$project_id" && -n "$commit_epoch" ]]; then
+		local session_info
+		session_info=$(find_session_by_timestamp "$project_id" "$commit_epoch")
+		if [[ -n "$session_info" ]]; then
+			session_id=$(echo "$session_info" | cut -d'|' -f1)
+			session_title=$(echo "$session_info" | cut -d'|' -f2)
+			local parent_id
+			parent_id=$(echo "$session_info" | cut -d'|' -f3)
+
+			if [[ -n "$parent_id" ]]; then
+				parent_session=$(find_parent_session "$session_id")
+			fi
+
+			log_info "$task_id: session $session_id '$session_title'"
+		fi
+	fi
+
+	# Extract conversation context
+	local context="NO_CONTEXT_FOUND"
+	local search_session="${session_id}"
+
+	# If this was a subagent commit session, search the parent
+	if [[ "$session_title" == *"subagent"* && -n "$parent_session" ]]; then
+		search_session=$(echo "$parent_session" | cut -d'|' -f1)
+		local parent_title
+		parent_title=$(echo "$parent_session" | cut -d'|' -f2)
+		log_info "$task_id: searching parent session '$parent_title'"
+	fi
+
+	if [[ -n "$search_session" ]]; then
+		context=$(extract_session_context "$search_session" "$task_id")
+	fi
+
+	# Check supervisor DB
+	local supervisor_info=""
+	supervisor_info=$(find_supervisor_context "$task_id")
+
+	# Extract task description from TODO.md
+	local task_line=""
+	task_line=$(grep -E "^\s*- \[.\] ${task_id} " "$project_root/TODO.md" 2>/dev/null | head -1)
+	local task_title=""
+	task_title=$(echo "$task_line" | sed -E 's/^.*\] t[0-9]+(\.[0-9]+)* //' | sed -E 's/ #.*//' | sed -E 's/ ~.*//')
+
+	# Extract task block (subtasks/notes) from TODO.md
+	# Captures the task line and all lines more indented than it
+	local task_block=""
+	task_block=$(python3 -c "
+import re, sys
+task_id = '$task_id'
+lines = open('$project_root/TODO.md').readlines()
+capturing = False
+task_indent = -1
+block = []
+for i, line in enumerate(lines):
+    rline = line.rstrip('\n')
+    if re.search(rf'- \[.\] {re.escape(task_id)} ', rline):
+        capturing = True
+        task_indent = len(rline) - len(rline.lstrip())
+        block.append(rline)
+        continue
+    if capturing:
+        if rline.strip() == '':
+            # Blank line: check if next non-blank is still indented
+            still_in = False
+            for j in range(i + 1, min(i + 3, len(lines))):
+                nxt = lines[j].rstrip('\n')
+                if nxt.strip():
+                    if (len(nxt) - len(nxt.lstrip())) > task_indent:
+                        still_in = True
+                    break
+            if still_in:
+                block.append(rline)
+            else:
+                break
+        elif (len(rline) - len(rline.lstrip())) > task_indent:
+            block.append(rline)
+        else:
+            break
+print('\n'.join(block))
+" 2>/dev/null)
+
+	# Extract REBASE comment
+	local rebase_note=""
+	rebase_note=$(echo "$task_line" | grep -oE '<!-- REBASE:[^>]+-->' | sed 's/<!-- REBASE: //;s/ -->//' || true)
+
+	# Determine session origin string
+	local session_origin="unknown"
+	if [[ -n "$session_id" ]]; then
+		if [[ -n "$parent_session" ]]; then
+			local parent_id parent_title
+			parent_id=$(echo "$parent_session" | cut -d'|' -f1)
+			parent_title=$(echo "$parent_session" | cut -d'|' -f2)
+			session_origin="opencode:${parent_id} '${parent_title}' (committed via subagent ${session_id})"
+		else
+			session_origin="opencode:${session_id} '${session_title}'"
+		fi
+	elif [[ -n "$supervisor_info" ]]; then
+		local sup_session
+		sup_session=$(echo "$supervisor_info" | cut -d'|' -f3)
+		session_origin="supervisor:${sup_session} (headless Claude CLI)"
+	elif [[ "$commit_author" != "marcusquinn" ]]; then
+		session_origin="external contributor ($commit_author)"
+	fi
+
+	# Determine created_by — supervisor match must be exact (id field only)
+	local created_by="ai-interactive"
+	local sup_id=""
+	if [[ -n "$supervisor_info" ]]; then
+		sup_id=$(echo "$supervisor_info" | cut -d'|' -f1)
+	fi
+	if [[ -n "$sup_id" && "$sup_id" == "$task_id" ]]; then
+		created_by="ai-supervisor"
+	elif [[ "$commit_author" != "marcusquinn" && "$commit_author" != "GitHub Actions" ]]; then
+		created_by="human ($commit_author)"
+	fi
+
+	# Check for parent task
+	local parent_task=""
+	if echo "$task_id" | grep -qE '\.'; then
+		parent_task=$(echo "$task_id" | sed -E 's/\.[0-9]+$//')
+	fi
+
+	# Extract context block from session data
+	local context_block=""
+	if [[ "$context" != "NO_CONTEXT_FOUND" ]]; then
+		local msg_title
+		msg_title=$(echo "$context" | grep '^MESSAGE_TITLE=' | head -1 | sed 's/MESSAGE_TITLE=//')
+		local task_content
+		task_content=$(echo "$context" | sed -n '/^TASK_BLOCK_START$/,/^TASK_BLOCK_END$/p' | grep -v 'TASK_BLOCK_')
+		if [[ -n "$task_content" ]]; then
+			context_block="$task_content"
+		fi
+		if [[ -n "$msg_title" ]]; then
+			session_origin="${session_origin} — message: '${msg_title}'"
+		fi
+	fi
+
+	# Prefer session context block over TODO.md extraction (session has original rich content)
+	local best_block="${context_block:-${task_block:-${task_line}}}"
+
+	# Write the brief
+	cat >"$output_file" <<BRIEF
+---
+mode: subagent
+---
+# ${task_id}: ${task_title}
+
+## Origin
+
+- **Created:** ${commit_date%% *}
+- **Session:** ${session_origin}
+- **Created by:** ${created_by}
+$(if [[ -n "$parent_task" ]]; then echo "- **Parent task:** ${parent_task} — see [todo/tasks/${parent_task}-brief.md](${parent_task}-brief.md)"; fi)
+- **Commit:** ${commit} — "${commit_msg}"
+
+## What
+
+${task_title}
+
+## Specification
+
+\`\`\`markdown
+${best_block}
+\`\`\`
+$(if [[ -n "$context_block" && -n "$task_block" && "$context_block" != "$task_block" ]]; then echo "
+## Current TODO.md State
+
+\`\`\`markdown
+${task_block}
+\`\`\`"; fi)
+$(if [[ -n "$rebase_note" ]]; then echo "
+## Implementation Notes (from REBASE)
+
+${rebase_note}"; fi)
+$(if [[ -n "$supervisor_info" && "$sup_id" == "$task_id" ]]; then echo "
+## Supervisor Context
+
+\`\`\`
+${supervisor_info}
+\`\`\`"; fi)
+
+## Acceptance Criteria
+
+- [ ] Implementation matches the specification above
+- [ ] Tests pass
+- [ ] Lint clean
+
+## Relevant Files
+
+<!-- TODO: Add relevant file paths after codebase analysis -->
+BRIEF
+
+	log_info "$task_id: brief written to $output_file"
+	return 0
+}
+
+# --- Main ---
+
+main() {
+	local task_id="${1:-}"
+	local project_root="${2:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+	if [[ -z "$task_id" ]]; then
+		usage
+	fi
+
+	if [[ "$task_id" == "--all" ]]; then
+		# Generate briefs for all open tasks without briefs
+		local count=0
+		while IFS= read -r line; do
+			local tid
+			tid=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1)
+			if [[ -n "$tid" && ! -f "$project_root/todo/tasks/${tid}-brief.md" ]]; then
+				generate_brief "$tid" "$project_root" || true
+				count=$((count + 1))
+			fi
+		done < <(grep -E '^\s*- \[ \] t[0-9]' "$project_root/TODO.md")
+		log_info "Generated $count briefs"
+	else
+		generate_brief "$task_id" "$project_root"
+	fi
+}
+
+main "$@"

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -889,7 +889,9 @@ compose_issue_body() {
 
 	# Extract HTML comments (e.g., REBASE notes) from the task line
 	local html_comments
-	html_comments=$(echo "$first_line" | grep -oE '<!--[^>]+-->' | sed 's/<!--//;s/-->//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+	# Match HTML comments — use sed to extract content between <!-- and -->
+	# Handles comments containing > characters (e.g., "use a -> b pattern")
+	html_comments=$(echo "$first_line" | sed -n 's/.*\(<!--.*-->\).*/\1/p' | sed 's/<!--//;s/-->//' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 	if [[ -n "$html_comments" ]]; then
 		body="$body"$'\n\n'"## Implementation Notes"$'\n\n'"$html_comments"
 	fi

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -1,0 +1,63 @@
+---
+mode: subagent
+---
+# {task_id}: {Title}
+
+## Origin
+
+- **Created:** {YYYY-MM-DD}
+- **Session:** {app}:{session-id}
+- **Created by:** {author} (human | ai-supervisor | ai-interactive)
+- **Parent task:** {parent_id} (if subtask)
+- **Conversation context:** {1-2 sentence summary of what was discussed that led to this task}
+
+## What
+
+{Clear description of the deliverable. Not "implement X" but what the implementation must produce, what it must do, and what the user/system will experience when it's done.}
+
+## Why
+
+{Problem being solved, user need, business value, or dependency chain that requires this. Why now? What breaks or stalls without it?}
+
+## How (Approach)
+
+{Technical approach, key files to modify, patterns to follow, libraries to use.}
+{Reference existing code: `path/to/file.ts:45` — what pattern to follow}
+{Reference existing tests: `path/to/file.test.ts` — test patterns to match}
+
+## Acceptance Criteria
+
+- [ ] {Specific, testable criterion — e.g., "User can toggle sidebar with Cmd+B"}
+- [ ] {Another criterion — e.g., "Conversation history persists across page reloads"}
+- [ ] {Negative criterion — e.g., "Org A's data never appears in Org B's context"}
+- [ ] Tests pass (`npm test` / `bun test` / project-specific)
+- [ ] Lint clean (`eslint` / `shellcheck` / project-specific)
+
+## Context & Decisions
+
+{Key decisions from the conversation that created this task:}
+{- Why approach A was chosen over B}
+{- Constraints discovered during discussion}
+{- Things explicitly ruled out (non-goals)}
+{- Prior art or references consulted}
+
+## Relevant Files
+
+- `path/to/file.ts:45` — {why relevant, what to change}
+- `path/to/related.ts` — {dependency or pattern to follow}
+- `path/to/test.test.ts` — {existing test patterns}
+
+## Dependencies
+
+- **Blocked by:** {task_ids or external requirements}
+- **Blocks:** {what this unblocks when complete}
+- **External:** {APIs, services, credentials, purchases needed}
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Research/read | {Xm} | {what to read} |
+| Implementation | {Xh} | {scope} |
+| Testing | {Xm} | {test strategy} |
+| **Total** | **{Xh}** | |

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -208,6 +208,20 @@ These use `quality-loop-helper.sh` which applies Ralph patterns to quality workf
 
 ## Saving Work
 
+### MANDATORY: Task Brief Requirement
+
+**Every task MUST have a brief file** at `todo/tasks/{task_id}-brief.md`. A task without a brief is undevelopable — it loses the conversation context that informed it.
+
+Use `templates/brief-template.md`. The brief captures:
+- **Origin**: session ID, date, author, conversation context
+- **What**: clear deliverable (not "implement X" but what it produces)
+- **Why**: problem, user need, business value
+- **How**: technical approach, file references, patterns
+- **Acceptance criteria**: specific, testable conditions
+- **Context & decisions**: from the conversation that created the task
+
+**Session provenance is mandatory.** Every brief must link back to the session that created it. Detect runtime: `$OPENCODE_SESSION_ID`, `$CLAUDE_SESSION_ID`, or `{app}:unknown-{date}`.
+
 ### Step 1: Extract from Conversation
 
 - **Title**: Concise task/plan name
@@ -215,6 +229,7 @@ These use `quality-loop-helper.sh` which applies Ralph patterns to quality workf
 - **Estimate**: Time estimate with breakdown `~Xh (ai:Xh test:Xh read:Xm)`
 - **Tags**: Relevant categories (#seo, #security, #feature, etc.)
 - **Context**: Key decisions, research findings, constraints discussed
+- **Session**: Current session ID for audit trail
 
 ### Step 2: Present with Auto-Detection
 
@@ -223,8 +238,13 @@ These use `quality-loop-helper.sh` which applies Ralph patterns to quality workf
 ```text
 Saving to TODO.md: "{title}" ~{estimate}
 
-1. Confirm
-2. Add more details first
+Creating brief: todo/tasks/{task_id}-brief.md
+- What: {deliverable summary}
+- Why: {problem/need}
+- Acceptance: {key criteria}
+
+1. Confirm (creates brief + TODO entry)
+2. Add more details to brief first
 3. Create full plan instead (PLANS.md)
 ```
 
@@ -237,16 +257,20 @@ Title: {title}
 Estimate: ~{estimate}
 Phases: {count} identified
 
-1. Confirm and create plan
-2. Simplify to TODO.md only
+Creating brief: todo/tasks/{task_id}-brief.md
+(Full context from this conversation will be captured)
+
+1. Confirm and create plan + brief
+2. Simplify to TODO.md + brief only
 3. Add more context first
 ```
 
 ### Step 3: Save Appropriately
 
-#### Simple Save (TODO.md only)
+#### Simple Save (TODO.md + brief)
 
-Add to TODO.md Backlog:
+1. **Create brief** at `todo/tasks/{task_id}-brief.md` from conversation context
+2. **Add to TODO.md** Backlog:
 
 ```markdown
 ## Backlog
@@ -263,10 +287,13 @@ Add to TODO.md Backlog:
 - `blocked-by:t001,t002` - Dependencies (cannot start until these done)
 - `blocks:t003` - What this unblocks when complete
 
+**Auto-dispatch gate**: Only add `#auto-dispatch` if the brief has at least 2 specific acceptance criteria, a non-empty How section with file references, and a clear What section. Thin briefs = no auto-dispatch.
+
 Respond:
 
 ```text
 Saved: "{title}" to TODO.md (~{estimate})
+Brief: todo/tasks/{task_id}-brief.md
 Start anytime with: "Let's work on {title}"
 ```
 


### PR DESCRIPTION
## Summary

- Adds mandatory task brief requirement to the framework — every task must have `todo/tasks/{task_id}-brief.md` capturing session origin, what, why, how, acceptance criteria, and conversation context
- Adds `generate-brief.sh` script that traces tasks back to their source OpenCode sessions and supervisor DB, extracting the original conversation context that created each task
- Updates `new-task.md`, `plans.md`, `AGENTS.md`, `issue-sync-lib.sh`, and `brief-template.md` to enforce briefs going forward

## Problem

Every open task across both repos (58 a managed private repo, 13 aidevops = 71 total) had NO brief file. Tasks were bare one-liners in TODO.md with no context about what, why, how, or acceptance criteria. The AI supervisor created subtasks as one-liners that lost all parent context. No session provenance linked tasks back to the conversations that created them.

## What Changed

### Framework enforcement (prevents future knowledge loss)
- `new-task.md` — rewritten to require brief creation before TODO.md entry
- `plans.md` — added "MANDATORY: Task Brief Requirement" section
- `AGENTS.md` — development lifecycle now includes brief requirement
- `brief-template.md` — new template with Origin, What, Why, How, Acceptance Criteria sections
- `issue-sync-lib.sh` — `compose_issue_body` now includes brief content in GitHub issues

### Backfill tool
- `generate-brief.sh` — traces task → git commit → OpenCode session → conversation context
  - Queries OpenCode DB (`~/.local/share/opencode/opencode.db`) for session messages with diffs
  - Queries supervisor DB for headless dispatch context
  - Extracts full indented task blocks from session diffs (not just the one-liner)
  - Handles parent/child task relationships, REBASE notes, external contributors
  - ShellCheck clean, tested on all 71 tasks

### Backfill results (committed separately)
- 57 a managed private repo briefs (3,024 lines of recovered context) — committed to a managed private repo repo
- 13 aidevops briefs (554 lines) — committed to main

## Key examples

- `t004-brief.md`: 392 lines — full 9-layer multi-org architecture spec recovered from original session
- `t005-brief.md`: 203 lines — complete AI chat sidebar UX spec with @mentions, /commands, tool calls, etc.
- `t005.4-brief.md`: Links to parent t005, includes REBASE notes and supervisor context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced mandatory task briefing system with standardized structure (origin, goals, approach, acceptance criteria)
  * Added automated brief generation from session history
  * Auto-dispatch now requires high-quality briefs meeting specific quality criteria

* **Chores**
  * Enhanced development lifecycle documentation and workflow
  * Refined task creation process with mandatory brief requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->