### PR TITLE
chore: update stale model references to current Anthropic lineup

### DIFF
--- a/.agents/scripts/eeat-score-helper.sh
+++ b/.agents/scripts/eeat-score-helper.sh
@@ -48,104 +48,104 @@ WEIGHT_WRITING=0.10
 
 # Print functions
 print_header() {
-    local message="$1"
-    echo -e "${PURPLE}=== $message ===${NC}"
-    return 0
+	local message="$1"
+	echo -e "${PURPLE}=== $message ===${NC}"
+	return 0
 }
 
 # Load configuration
 load_config() {
-    if [[ -f "$CONFIG_FILE" ]] && command -v jq &> /dev/null; then
-        LLM_PROVIDER=$(jq -r '.llm_provider // "openai"' "$CONFIG_FILE")
-        LLM_MODEL=$(jq -r '.llm_model // "gpt-4o"' "$CONFIG_FILE")
-        TEMPERATURE=$(jq -r '.temperature // 0.3' "$CONFIG_FILE")
-        MAX_TOKENS=$(jq -r '.max_tokens // 500' "$CONFIG_FILE")
-        CONCURRENT_REQUESTS=$(jq -r '.concurrent_requests // 3' "$CONFIG_FILE")
-        OUTPUT_FORMAT=$(jq -r '.output_format // "xlsx"' "$CONFIG_FILE")
-        INCLUDE_REASONING=$(jq -r '.include_reasoning // true' "$CONFIG_FILE")
-        
-        # Load weights
-        WEIGHT_AUTHORSHIP=$(jq -r '.weights.authorship // 0.15' "$CONFIG_FILE")
-        WEIGHT_CITATION=$(jq -r '.weights.citation // 0.15' "$CONFIG_FILE")
-        WEIGHT_EFFORT=$(jq -r '.weights.effort // 0.15' "$CONFIG_FILE")
-        WEIGHT_ORIGINALITY=$(jq -r '.weights.originality // 0.15' "$CONFIG_FILE")
-        WEIGHT_INTENT=$(jq -r '.weights.intent // 0.15' "$CONFIG_FILE")
-        WEIGHT_SUBJECTIVE=$(jq -r '.weights.subjective // 0.15' "$CONFIG_FILE")
-        WEIGHT_WRITING=$(jq -r '.weights.writing // 0.10' "$CONFIG_FILE")
-    fi
-    return 0
+	if [[ -f "$CONFIG_FILE" ]] && command -v jq &>/dev/null; then
+		LLM_PROVIDER=$(jq -r '.llm_provider // "openai"' "$CONFIG_FILE")
+		LLM_MODEL=$(jq -r '.llm_model // "gpt-4o"' "$CONFIG_FILE")
+		TEMPERATURE=$(jq -r '.temperature // 0.3' "$CONFIG_FILE")
+		MAX_TOKENS=$(jq -r '.max_tokens // 500' "$CONFIG_FILE")
+		CONCURRENT_REQUESTS=$(jq -r '.concurrent_requests // 3' "$CONFIG_FILE")
+		OUTPUT_FORMAT=$(jq -r '.output_format // "xlsx"' "$CONFIG_FILE")
+		INCLUDE_REASONING=$(jq -r '.include_reasoning // true' "$CONFIG_FILE")
+
+		# Load weights
+		WEIGHT_AUTHORSHIP=$(jq -r '.weights.authorship // 0.15' "$CONFIG_FILE")
+		WEIGHT_CITATION=$(jq -r '.weights.citation // 0.15' "$CONFIG_FILE")
+		WEIGHT_EFFORT=$(jq -r '.weights.effort // 0.15' "$CONFIG_FILE")
+		WEIGHT_ORIGINALITY=$(jq -r '.weights.originality // 0.15' "$CONFIG_FILE")
+		WEIGHT_INTENT=$(jq -r '.weights.intent // 0.15' "$CONFIG_FILE")
+		WEIGHT_SUBJECTIVE=$(jq -r '.weights.subjective // 0.15' "$CONFIG_FILE")
+		WEIGHT_WRITING=$(jq -r '.weights.writing // 0.10' "$CONFIG_FILE")
+	fi
+	return 0
 }
 
 # Check dependencies
 check_dependencies() {
-    local missing=()
-    
-    if ! command -v curl &> /dev/null; then
-        missing+=("curl")
-    fi
-    
-    if ! command -v jq &> /dev/null; then
-        missing+=("jq")
-    fi
-    
-    if ! command -v python3 &> /dev/null; then
-        missing+=("python3")
-    fi
-    
-    if [[ ${#missing[@]} -gt 0 ]]; then
-        print_error "Missing dependencies: ${missing[*]}"
-        print_info "Install with: brew install ${missing[*]}"
-        return 1
-    fi
-    
-    return 0
+	local missing=()
+
+	if ! command -v curl &>/dev/null; then
+		missing+=("curl")
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		missing+=("jq")
+	fi
+
+	if ! command -v python3 &>/dev/null; then
+		missing+=("python3")
+	fi
+
+	if [[ ${#missing[@]} -gt 0 ]]; then
+		print_error "Missing dependencies: ${missing[*]}"
+		print_info "Install with: brew install ${missing[*]}"
+		return 1
+	fi
+
+	return 0
 }
 
 # Check API key
 check_api_key() {
-    if [[ "$LLM_PROVIDER" == "openai" ]]; then
-        if [[ -z "${OPENAI_API_KEY:-}" ]]; then
-            print_error "OPENAI_API_KEY environment variable not set"
-            print_info "Set with: export OPENAI_API_KEY='sk-...'"
-            return 1
-        fi
-    elif [[ "$LLM_PROVIDER" == "anthropic" ]]; then
-        if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-            print_error "ANTHROPIC_API_KEY environment variable not set"
-            return 1
-        fi
-    fi
-    return 0
+	if [[ "$LLM_PROVIDER" == "openai" ]]; then
+		if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+			print_error "OPENAI_API_KEY environment variable not set"
+			print_info "Set with: export OPENAI_API_KEY='sk-...'"
+			return 1
+		fi
+	elif [[ "$LLM_PROVIDER" == "anthropic" ]]; then
+		if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+			print_error "ANTHROPIC_API_KEY environment variable not set"
+			return 1
+		fi
+	fi
+	return 0
 }
 
 # Extract domain from URL
 get_domain() {
-    local url="$1"
-    echo "$url" | sed -E 's|^https?://||' | sed -E 's|/.*||' | sed -E 's|:.*||'
+	local url="$1"
+	echo "$url" | sed -E 's|^https?://||' | sed -E 's|/.*||' | sed -E 's|:.*||'
 }
 
 # Create output directory structure
 create_output_dir() {
-    local domain="$1"
-    local output_base="${2:-$DEFAULT_OUTPUT_DIR}"
-    local timestamp
-    timestamp=$(date +%Y-%m-%d_%H%M%S)
-    
-    local output_dir="${output_base}/${domain}/${timestamp}"
-    mkdir -p "$output_dir"
-    
-    # Update _latest symlink
-    local latest_link="${output_base}/${domain}/_latest"
-    rm -f "$latest_link"
-    ln -sf "$timestamp" "$latest_link"
-    
-    echo "$output_dir"
-    return 0
+	local domain="$1"
+	local output_base="${2:-$DEFAULT_OUTPUT_DIR}"
+	local timestamp
+	timestamp=$(date +%Y-%m-%d_%H%M%S)
+
+	local output_dir="${output_base}/${domain}/${timestamp}"
+	mkdir -p "$output_dir"
+
+	# Update _latest symlink
+	local latest_link="${output_base}/${domain}/_latest"
+	rm -f "$latest_link"
+	ln -sf "$timestamp" "$latest_link"
+
+	echo "$output_dir"
+	return 0
 }
 
 # Generate Python E-E-A-T analyzer script
 generate_analyzer_script() {
-    cat << 'PYTHON_SCRIPT'
+	cat <<'PYTHON_SCRIPT'
 #!/usr/bin/env python3
 """
 E-E-A-T Score Analyzer
@@ -428,7 +428,7 @@ class EEATAnalyzer:
         }
         
         payload = {
-            "model": self.model if "claude" in self.model else "claude-3-sonnet-20240229",
+            "model": self.model if "claude" in self.model else "claude-sonnet-4-6",
             "max_tokens": 500,
             "messages": [
                 {"role": "user", "content": f"{prompt}\n\nAnalyze this content:\n\n{content}"}
@@ -768,336 +768,336 @@ PYTHON_SCRIPT
 
 # Analyze crawled pages
 do_analyze() {
-    local input_file="$1"
-    shift
-    
-    if [[ ! -f "$input_file" ]]; then
-        print_error "Input file not found: $input_file"
-        return 1
-    fi
-    
-    # Parse options
-    local output_base="$DEFAULT_OUTPUT_DIR"
-    local format="$OUTPUT_FORMAT"
-    local provider="$LLM_PROVIDER"
-    local model="$LLM_MODEL"
-    
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --output)
-                output_base="$2"
-                shift 2
-                ;;
-            --format)
-                format="$2"
-                shift 2
-                ;;
-            --provider)
-                provider="$2"
-                shift 2
-                ;;
-            --model)
-                model="$2"
-                shift 2
-                ;;
-            *)
-                shift
-                ;;
-        esac
-    done
-    
-    # Extract URLs from crawl data
-    local urls=()
-    if [[ "$input_file" == *.json ]]; then
-        # JSON format - extract URLs with status 200
-        mapfile -t urls < <(jq -r '.[] | select(.status_code == 200) | .url' "$input_file" 2>/dev/null || echo "")
-    elif [[ "$input_file" == *.csv ]]; then
-        # CSV format - extract URLs from first column where status is 200
-        mapfile -t urls < <(tail -n +2 "$input_file" | awk -F',' '$2 == "200" || $2 == 200 {gsub(/"/, "", $1); print $1}')
-    fi
-    
-    if [[ ${#urls[@]} -eq 0 ]]; then
-        print_error "No valid URLs found in input file"
-        return 1
-    fi
-    
-    print_header "E-E-A-T Score Analysis"
-    print_info "Input: $input_file"
-    print_info "URLs to analyze: ${#urls[@]}"
-    
-    # Determine domain from first URL
-    local domain
-    domain=$(get_domain "${urls[0]}")
-    
-    # Get output directory (use same as crawl data if in domain folder)
-    local input_dir
-    input_dir=$(dirname "$input_file")
-    local output_dir
-    
-    if [[ "$input_dir" == *"$domain"* ]]; then
-        output_dir="$input_dir"
-    else
-        output_dir=$(create_output_dir "$domain" "$output_base")
-    fi
-    
-    print_info "Output: $output_dir"
-    
-    # Check Python dependencies
-    if ! python3 -c "import aiohttp, bs4" 2>/dev/null; then
-        print_warning "Installing Python dependencies..."
-        pip3 install aiohttp beautifulsoup4 openpyxl --quiet
-    fi
-    
-    # Generate and run analyzer
-    local analyzer_script="/tmp/eeat_analyzer_$$.py"
-    generate_analyzer_script > "$analyzer_script"
-    
-    # Limit to reasonable number for API costs
-    local max_urls=50
-    if [[ ${#urls[@]} -gt $max_urls ]]; then
-        print_warning "Limiting analysis to first $max_urls URLs (of ${#urls[@]})"
-        urls=("${urls[@]:0:$max_urls}")
-    fi
-    
-    python3 "$analyzer_script" "${urls[@]}" \
-        --output "$output_dir" \
-        --provider "$provider" \
-        --model "$model" \
-        --format "$format" \
-        --domain "$domain"
-    
-    rm -f "$analyzer_script"
-    
-    print_success "E-E-A-T analysis complete!"
-    print_info "Results: $output_dir"
-    
-    return 0
+	local input_file="$1"
+	shift
+
+	if [[ ! -f "$input_file" ]]; then
+		print_error "Input file not found: $input_file"
+		return 1
+	fi
+
+	# Parse options
+	local output_base="$DEFAULT_OUTPUT_DIR"
+	local format="$OUTPUT_FORMAT"
+	local provider="$LLM_PROVIDER"
+	local model="$LLM_MODEL"
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--output)
+			output_base="$2"
+			shift 2
+			;;
+		--format)
+			format="$2"
+			shift 2
+			;;
+		--provider)
+			provider="$2"
+			shift 2
+			;;
+		--model)
+			model="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	# Extract URLs from crawl data
+	local urls=()
+	if [[ "$input_file" == *.json ]]; then
+		# JSON format - extract URLs with status 200
+		mapfile -t urls < <(jq -r '.[] | select(.status_code == 200) | .url' "$input_file" 2>/dev/null || echo "")
+	elif [[ "$input_file" == *.csv ]]; then
+		# CSV format - extract URLs from first column where status is 200
+		mapfile -t urls < <(tail -n +2 "$input_file" | awk -F',' '$2 == "200" || $2 == 200 {gsub(/"/, "", $1); print $1}')
+	fi
+
+	if [[ ${#urls[@]} -eq 0 ]]; then
+		print_error "No valid URLs found in input file"
+		return 1
+	fi
+
+	print_header "E-E-A-T Score Analysis"
+	print_info "Input: $input_file"
+	print_info "URLs to analyze: ${#urls[@]}"
+
+	# Determine domain from first URL
+	local domain
+	domain=$(get_domain "${urls[0]}")
+
+	# Get output directory (use same as crawl data if in domain folder)
+	local input_dir
+	input_dir=$(dirname "$input_file")
+	local output_dir
+
+	if [[ "$input_dir" == *"$domain"* ]]; then
+		output_dir="$input_dir"
+	else
+		output_dir=$(create_output_dir "$domain" "$output_base")
+	fi
+
+	print_info "Output: $output_dir"
+
+	# Check Python dependencies
+	if ! python3 -c "import aiohttp, bs4" 2>/dev/null; then
+		print_warning "Installing Python dependencies..."
+		pip3 install aiohttp beautifulsoup4 openpyxl --quiet
+	fi
+
+	# Generate and run analyzer
+	local analyzer_script="/tmp/eeat_analyzer_$$.py"
+	generate_analyzer_script >"$analyzer_script"
+
+	# Limit to reasonable number for API costs
+	local max_urls=50
+	if [[ ${#urls[@]} -gt $max_urls ]]; then
+		print_warning "Limiting analysis to first $max_urls URLs (of ${#urls[@]})"
+		urls=("${urls[@]:0:$max_urls}")
+	fi
+
+	python3 "$analyzer_script" "${urls[@]}" \
+		--output "$output_dir" \
+		--provider "$provider" \
+		--model "$model" \
+		--format "$format" \
+		--domain "$domain"
+
+	rm -f "$analyzer_script"
+
+	print_success "E-E-A-T analysis complete!"
+	print_info "Results: $output_dir"
+
+	return 0
 }
 
 # Score single URL
 do_score() {
-    local url="$1"
-    shift
-    
-    local verbose=false
-    local output_base="$DEFAULT_OUTPUT_DIR"
-    
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --verbose|-v)
-                verbose=true
-                shift
-                ;;
-            --output)
-                output_base="$2"
-                shift 2
-                ;;
-            *)
-                shift
-                ;;
-        esac
-    done
-    
-    local domain
-    domain=$(get_domain "$url")
-    local output_dir
-    output_dir=$(create_output_dir "$domain" "$output_base")
-    
-    print_header "E-E-A-T Score Analysis"
-    print_info "URL: $url"
-    
-    # Check Python dependencies
-    if ! python3 -c "import aiohttp, bs4" 2>/dev/null; then
-        print_warning "Installing Python dependencies..."
-        pip3 install aiohttp beautifulsoup4 openpyxl --quiet
-    fi
-    
-    local analyzer_script="/tmp/eeat_analyzer_$$.py"
-    generate_analyzer_script > "$analyzer_script"
-    
-    python3 "$analyzer_script" "$url" \
-        --output "$output_dir" \
-        --provider "$LLM_PROVIDER" \
-        --model "$LLM_MODEL" \
-        --format "all" \
-        --domain "$domain"
-    
-    rm -f "$analyzer_script"
-    
-    print_success "Analysis complete!"
-    print_info "Results: $output_dir"
-    
-    return 0
+	local url="$1"
+	shift
+
+	local verbose=false
+	local output_base="$DEFAULT_OUTPUT_DIR"
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--verbose | -v)
+			verbose=true
+			shift
+			;;
+		--output)
+			output_base="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	local domain
+	domain=$(get_domain "$url")
+	local output_dir
+	output_dir=$(create_output_dir "$domain" "$output_base")
+
+	print_header "E-E-A-T Score Analysis"
+	print_info "URL: $url"
+
+	# Check Python dependencies
+	if ! python3 -c "import aiohttp, bs4" 2>/dev/null; then
+		print_warning "Installing Python dependencies..."
+		pip3 install aiohttp beautifulsoup4 openpyxl --quiet
+	fi
+
+	local analyzer_script="/tmp/eeat_analyzer_$$.py"
+	generate_analyzer_script >"$analyzer_script"
+
+	python3 "$analyzer_script" "$url" \
+		--output "$output_dir" \
+		--provider "$LLM_PROVIDER" \
+		--model "$LLM_MODEL" \
+		--format "all" \
+		--domain "$domain"
+
+	rm -f "$analyzer_script"
+
+	print_success "Analysis complete!"
+	print_info "Results: $output_dir"
+
+	return 0
 }
 
 # Batch analyze URLs from file
 do_batch() {
-    local urls_file="$1"
-    shift
-    
-    if [[ ! -f "$urls_file" ]]; then
-        print_error "URLs file not found: $urls_file"
-        return 1
-    fi
-    
-    local urls=()
-    while IFS= read -r url; do
-        [[ -n "$url" && ! "$url" =~ ^# ]] && urls+=("$url")
-    done < "$urls_file"
-    
-    if [[ ${#urls[@]} -eq 0 ]]; then
-        print_error "No URLs found in file"
-        return 1
-    fi
-    
-    local output_base="$DEFAULT_OUTPUT_DIR"
-    local format="$OUTPUT_FORMAT"
-    
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --output)
-                output_base="$2"
-                shift 2
-                ;;
-            --format)
-                format="$2"
-                shift 2
-                ;;
-            *)
-                shift
-                ;;
-        esac
-    done
-    
-    local domain
-    domain=$(get_domain "${urls[0]}")
-    local output_dir
-    output_dir=$(create_output_dir "$domain" "$output_base")
-    
-    print_header "E-E-A-T Batch Analysis"
-    print_info "URLs: ${#urls[@]}"
-    print_info "Output: $output_dir"
-    
-    # Check Python dependencies
-    if ! python3 -c "import aiohttp, bs4" 2>/dev/null; then
-        print_warning "Installing Python dependencies..."
-        pip3 install aiohttp beautifulsoup4 openpyxl --quiet
-    fi
-    
-    local analyzer_script="/tmp/eeat_analyzer_$$.py"
-    generate_analyzer_script > "$analyzer_script"
-    
-    python3 "$analyzer_script" "${urls[@]}" \
-        --output "$output_dir" \
-        --provider "$LLM_PROVIDER" \
-        --model "$LLM_MODEL" \
-        --format "$format" \
-        --domain "$domain"
-    
-    rm -f "$analyzer_script"
-    
-    print_success "Batch analysis complete!"
-    print_info "Results: $output_dir"
-    
-    return 0
+	local urls_file="$1"
+	shift
+
+	if [[ ! -f "$urls_file" ]]; then
+		print_error "URLs file not found: $urls_file"
+		return 1
+	fi
+
+	local urls=()
+	while IFS= read -r url; do
+		[[ -n "$url" && ! "$url" =~ ^# ]] && urls+=("$url")
+	done <"$urls_file"
+
+	if [[ ${#urls[@]} -eq 0 ]]; then
+		print_error "No URLs found in file"
+		return 1
+	fi
+
+	local output_base="$DEFAULT_OUTPUT_DIR"
+	local format="$OUTPUT_FORMAT"
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--output)
+			output_base="$2"
+			shift 2
+			;;
+		--format)
+			format="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	local domain
+	domain=$(get_domain "${urls[0]}")
+	local output_dir
+	output_dir=$(create_output_dir "$domain" "$output_base")
+
+	print_header "E-E-A-T Batch Analysis"
+	print_info "URLs: ${#urls[@]}"
+	print_info "Output: $output_dir"
+
+	# Check Python dependencies
+	if ! python3 -c "import aiohttp, bs4" 2>/dev/null; then
+		print_warning "Installing Python dependencies..."
+		pip3 install aiohttp beautifulsoup4 openpyxl --quiet
+	fi
+
+	local analyzer_script="/tmp/eeat_analyzer_$$.py"
+	generate_analyzer_script >"$analyzer_script"
+
+	python3 "$analyzer_script" "${urls[@]}" \
+		--output "$output_dir" \
+		--provider "$LLM_PROVIDER" \
+		--model "$LLM_MODEL" \
+		--format "$format" \
+		--domain "$domain"
+
+	rm -f "$analyzer_script"
+
+	print_success "Batch analysis complete!"
+	print_info "Results: $output_dir"
+
+	return 0
 }
 
 # Generate report from existing scores
 do_report() {
-    local scores_file="$1"
-    shift
-    
-    if [[ ! -f "$scores_file" ]]; then
-        print_error "Scores file not found: $scores_file"
-        return 1
-    fi
-    
-    print_header "Generating E-E-A-T Report"
-    print_info "Input: $scores_file"
-    
-    # For now, just display summary from JSON
-    if [[ "$scores_file" == *.json ]]; then
-        if command -v jq &> /dev/null; then
-            jq '.' "$scores_file"
-        else
-            cat "$scores_file"
-        fi
-    fi
-    
-    return 0
+	local scores_file="$1"
+	shift
+
+	if [[ ! -f "$scores_file" ]]; then
+		print_error "Scores file not found: $scores_file"
+		return 1
+	fi
+
+	print_header "Generating E-E-A-T Report"
+	print_info "Input: $scores_file"
+
+	# For now, just display summary from JSON
+	if [[ "$scores_file" == *.json ]]; then
+		if command -v jq &>/dev/null; then
+			jq '.' "$scores_file"
+		else
+			cat "$scores_file"
+		fi
+	fi
+
+	return 0
 }
 
 # Check status
 check_status() {
-    print_header "E-E-A-T Score Helper Status"
-    
-    # Check dependencies
-    print_info "Checking dependencies..."
-    
-    if command -v curl &> /dev/null; then
-        print_success "curl: installed"
-    else
-        print_error "curl: not installed"
-    fi
-    
-    if command -v jq &> /dev/null; then
-        print_success "jq: installed"
-    else
-        print_error "jq: not installed"
-    fi
-    
-    if command -v python3 &> /dev/null; then
-        print_success "python3: installed"
-        
-        if python3 -c "import aiohttp" 2>/dev/null; then
-            print_success "  aiohttp: installed"
-        else
-            print_warning "  aiohttp: not installed (pip3 install aiohttp)"
-        fi
-        
-        if python3 -c "import bs4" 2>/dev/null; then
-            print_success "  beautifulsoup4: installed"
-        else
-            print_warning "  beautifulsoup4: not installed"
-        fi
-        
-        if python3 -c "import openpyxl" 2>/dev/null; then
-            print_success "  openpyxl: installed"
-        else
-            print_warning "  openpyxl: not installed"
-        fi
-    else
-        print_error "python3: not installed"
-    fi
-    
-    # Check API keys
-    print_info "Checking API keys..."
-    
-    if [[ -n "${OPENAI_API_KEY:-}" ]]; then
-        print_success "OPENAI_API_KEY: set"
-    else
-        print_warning "OPENAI_API_KEY: not set"
-    fi
-    
-    if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
-        print_success "ANTHROPIC_API_KEY: set"
-    else
-        print_info "ANTHROPIC_API_KEY: not set (optional)"
-    fi
-    
-    # Check config
-    if [[ -f "$CONFIG_FILE" ]]; then
-        print_success "Config: $CONFIG_FILE"
-    else
-        print_info "Config: using defaults"
-    fi
-    
-    return 0
+	print_header "E-E-A-T Score Helper Status"
+
+	# Check dependencies
+	print_info "Checking dependencies..."
+
+	if command -v curl &>/dev/null; then
+		print_success "curl: installed"
+	else
+		print_error "curl: not installed"
+	fi
+
+	if command -v jq &>/dev/null; then
+		print_success "jq: installed"
+	else
+		print_error "jq: not installed"
+	fi
+
+	if command -v python3 &>/dev/null; then
+		print_success "python3: installed"
+
+		if python3 -c "import aiohttp" 2>/dev/null; then
+			print_success "  aiohttp: installed"
+		else
+			print_warning "  aiohttp: not installed (pip3 install aiohttp)"
+		fi
+
+		if python3 -c "import bs4" 2>/dev/null; then
+			print_success "  beautifulsoup4: installed"
+		else
+			print_warning "  beautifulsoup4: not installed"
+		fi
+
+		if python3 -c "import openpyxl" 2>/dev/null; then
+			print_success "  openpyxl: installed"
+		else
+			print_warning "  openpyxl: not installed"
+		fi
+	else
+		print_error "python3: not installed"
+	fi
+
+	# Check API keys
+	print_info "Checking API keys..."
+
+	if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+		print_success "OPENAI_API_KEY: set"
+	else
+		print_warning "OPENAI_API_KEY: not set"
+	fi
+
+	if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+		print_success "ANTHROPIC_API_KEY: set"
+	else
+		print_info "ANTHROPIC_API_KEY: not set (optional)"
+	fi
+
+	# Check config
+	if [[ -f "$CONFIG_FILE" ]]; then
+		print_success "Config: $CONFIG_FILE"
+	else
+		print_info "Config: using defaults"
+	fi
+
+	return 0
 }
 
 # Show help
 show_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 E-E-A-T Score Helper - Content Quality Analysis
 
 Usage: eeat-score-helper.sh [command] [input] [options]
@@ -1162,49 +1162,49 @@ Related:
   - Site crawler: site-crawler-helper.sh
   - Crawl4AI: crawl4ai-helper.sh
 EOF
-    return 0
+	return 0
 }
 
 # Main function
 main() {
-    load_config
-    
-    local command="${1:-help}"
-    shift || true
-    
-    case "$command" in
-        analyze)
-            check_dependencies || exit 1
-            check_api_key || exit 1
-            do_analyze "$@"
-            ;;
-        score)
-            check_dependencies || exit 1
-            check_api_key || exit 1
-            do_score "$@"
-            ;;
-        batch)
-            check_dependencies || exit 1
-            check_api_key || exit 1
-            do_batch "$@"
-            ;;
-        report)
-            do_report "$@"
-            ;;
-        status)
-            check_status
-            ;;
-        help|-h|--help|"")
-            show_help
-            ;;
-        *)
-            print_error "Unknown command: $command"
-            show_help
-            exit 1
-            ;;
-    esac
-    
-    return 0
+	load_config
+
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	analyze)
+		check_dependencies || exit 1
+		check_api_key || exit 1
+		do_analyze "$@"
+		;;
+	score)
+		check_dependencies || exit 1
+		check_api_key || exit 1
+		do_score "$@"
+		;;
+	batch)
+		check_dependencies || exit 1
+		check_api_key || exit 1
+		do_batch "$@"
+		;;
+	report)
+		do_report "$@"
+		;;
+	status)
+		check_status
+		;;
+	help | -h | --help | "")
+		show_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		show_help
+		exit 1
+		;;
+	esac
+
+	return 0
 }
 
 main "$@"

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -115,7 +115,7 @@ get_tier_models() {
 	# Check if OpenCode is available (CLI installed and models cache exists)
 	if _is_opencode_available; then
 		case "$tier" in
-		haiku) echo "opencode/claude-3-5-haiku|opencode/gemini-3-flash" ;;
+		haiku) echo "opencode/claude-haiku-4-5|opencode/gemini-3-flash" ;;
 		flash) echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
 		sonnet) echo "opencode/claude-sonnet-4|anthropic/claude-sonnet-4-6" ;;
 		pro) echo "google/gemini-2.5-pro|opencode/gemini-3-pro" ;;
@@ -128,6 +128,7 @@ get_tier_models() {
 	else
 		case "$tier" in
 		haiku) echo "anthropic/claude-haiku-4-5|google/gemini-2.5-flash" ;;
+
 		flash) echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
 		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-4.1" ;;
 		pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;

--- a/.agents/scripts/model-label-helper.sh
+++ b/.agents/scripts/model-label-helper.sh
@@ -108,19 +108,19 @@ normalize_model() {
 	# Normalize concrete model names to tiers
 	# Specific patterns first, then wildcards
 	case "$model" in
-	claude-3-haiku* | claude-3-5-haiku*)
+	claude-haiku-4* | claude-3-haiku* | claude-3-5-haiku*)
 		echo "haiku"
 		;;
 	gemini-*-flash*)
 		echo "flash"
 		;;
-	claude-3-sonnet* | claude-3-5-sonnet* | claude-sonnet-4*)
+	claude-sonnet-4* | claude-3-sonnet* | claude-3-5-sonnet*)
 		echo "sonnet"
 		;;
 	gemini-*-pro*)
 		echo "pro"
 		;;
-	claude-3-opus* | claude-opus-4* | o3 | o1*)
+	claude-opus-4* | claude-3-opus* | o3 | o1*)
 		echo "opus"
 		;;
 	*haiku*)

--- a/.agents/scripts/model-registry-helper.sh
+++ b/.agents/scripts/model-registry-helper.sh
@@ -116,7 +116,7 @@ init_db() {
 # Model Name Normalization
 # =============================================================================
 # Normalizes model names for fuzzy matching across different naming conventions.
-# e.g., "claude-3-5-haiku" and "claude-haiku-3.5" both normalize to "claude-haiku"
+# e.g., "claude-haiku-4-5" and "claude-3-5-haiku" both normalize to "claude-haiku"
 
 normalize_model_name() {
 	local name="$1"
@@ -1245,7 +1245,7 @@ cmd_route() {
 	# Defaults if registry is empty
 	case "$tier" in
 	haiku)
-		primary_model="${primary_model:-claude-3-5-haiku}"
+		primary_model="${primary_model:-claude-haiku-4-5}"
 		fallback_model="${fallback_model:-gemini-2.5-flash}"
 		;;
 	flash)

--- a/.agents/services/hosting/cloudflare-platform/references/ai-gateway/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/ai-gateway/README.md
@@ -368,7 +368,7 @@ AI Gateway works with 15+ providers via unified API or provider-specific endpoin
 | Provider | Unified API | Provider Endpoint | Notes |
 |----------|-------------|-------------------|-------|
 | OpenAI | ✅ `openai/gpt-4o` | `/openai/*` | Full support |
-| Anthropic | ✅ `anthropic/claude-3-5-sonnet` | `/anthropic/*` | Full support |
+| Anthropic | ✅ `anthropic/claude-sonnet-4-6` | `/anthropic/*` | Full support |
 | Google AI Studio | ✅ `google-ai-studio/gemini-2.0-flash` | `/google-ai-studio/*` | Full support |
 | Workers AI | ✅ `workersai/@cf/meta/llama-3` | `/workers-ai/*` | Native integration |
 | Azure OpenAI | ✅ `azure-openai/*` | `/azure-openai/*` | Deployment names |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -14,9 +14,9 @@ Video,video.md,AI video generation and prompt engineering,opus
 -->
 
 <!--TOON:model_tiers[6]{tier,model_id,use_case}:
-haiku,claude-3-5-haiku-20241022,Triage routing and simple tasks
+haiku,claude-haiku-4-5,Triage routing and simple tasks
 sonnet,claude-sonnet-4-6,Code review and implementation
-opus,claude-opus-4-20250514,Architecture and complex reasoning
+opus,claude-opus-4-6,Architecture and complex reasoning
 flash,gemini-2.5-flash,Fast cheap large context
 pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge

--- a/.agents/tools/ai-assistants/models/README.md
+++ b/.agents/tools/ai-assistants/models/README.md
@@ -6,7 +6,7 @@ Model-specific subagents enable cross-provider model routing. Instead of passing
 
 | Tier | Subagent | Primary Model | Fallback |
 |------|----------|---------------|----------|
-| `haiku` | `models/haiku.md` | claude-3-5-haiku | gemini-2.5-flash |
+| `haiku` | `models/haiku.md` | claude-haiku-4-5 | gemini-2.5-flash |
 | `flash` | `models/flash.md` | gemini-2.5-flash | gpt-4.1-mini |
 | `sonnet` | `models/sonnet.md` | claude-sonnet-4 | gpt-4.1 |
 | `pro` | `models/pro.md` | gemini-2.5-pro | claude-sonnet-4 |

--- a/.agents/tools/api/vercel-ai-sdk.md
+++ b/.agents/tools/api/vercel-ai-sdk.md
@@ -286,7 +286,7 @@ const openaiResult = streamText({
 });
 
 const claudeResult = streamText({
-  model: anthropic("claude-3-5-sonnet-20241022"),
+  model: anthropic("claude-sonnet-4-6"),
   messages,
 });
 ```

--- a/.agents/tools/browser/stagehand.md
+++ b/.agents/tools/browser/stagehand.md
@@ -250,7 +250,7 @@ const stagehand = new Stagehand({
             "--disable-features=VizDisplayCompositor"
         ]
     },
-    modelName: "gpt-4o", // or "claude-3-5-sonnet-20241022"
+    modelName: "gpt-4o", // or "claude-sonnet-4-6"
     modelClientOptions: {
         apiKey: process.env.OPENAI_API_KEY
     }

--- a/.agents/tools/code-review/skill-scanner.md
+++ b/.agents/tools/code-review/skill-scanner.md
@@ -172,7 +172,7 @@ echo 'export VIRUSTOTAL_API_KEY="your_key"' >> ~/.config/aidevops/credentials.sh
 ```bash
 # LLM analyzer (optional)
 export SKILL_SCANNER_LLM_API_KEY="your_api_key"
-export SKILL_SCANNER_LLM_MODEL="claude-3-5-sonnet-20241022"
+export SKILL_SCANNER_LLM_MODEL="claude-sonnet-4-6"
 
 # VirusTotal (optional - prefer gopass: aidevops secret set VIRUSTOTAL_MARCUSQUINN)
 export VIRUSTOTAL_API_KEY="your_key"

--- a/.agents/tools/context/dspy.md
+++ b/.agents/tools/context/dspy.md
@@ -173,7 +173,7 @@ result = compiled_qa(question="Explain neural networks")
       "anthropic": {
         "api_key": "YOUR_ANTHROPIC_API_KEY",
         "models": {
-          "claude-3-sonnet": "claude-3-sonnet-20240229"
+          "claude-sonnet": "claude-sonnet-4-6"
         }
       }
     }

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -27,7 +27,7 @@ model: haiku
 
 | Tier | Model | Cost | Best For |
 |------|-------|------|----------|
-| `haiku` | claude-3-5-haiku | Lowest | Triage, classification, simple transforms, formatting |
+| `haiku` | claude-haiku-4-5 | Lowest | Triage, classification, simple transforms, formatting |
 | `flash` | gemini-2.5-flash | Low | Large context reads, summarization, bulk processing |
 | `sonnet` | claude-sonnet-4 | Medium | Code implementation, review, most development tasks |
 | `pro` | gemini-2.5-pro | Medium-High | Large codebase analysis, complex reasoning with big context |
@@ -108,7 +108,7 @@ Concrete model subagents are defined in `tools/ai-assistants/models/`:
 
 | Tier | Subagent | Primary Model | Fallback |
 |------|----------|---------------|----------|
-| `haiku` | `models/haiku.md` | claude-3-5-haiku | gemini-2.5-flash |
+| `haiku` | `models/haiku.md` | claude-haiku-4-5 | gemini-2.5-flash |
 | `flash` | `models/flash.md` | gemini-2.5-flash | gpt-4.1-mini |
 | `sonnet` | `models/sonnet.md` | claude-sonnet-4 | gpt-4.1 |
 | `pro` | `models/pro.md` | gemini-2.5-pro | claude-sonnet-4 |
@@ -148,7 +148,7 @@ Each tier defines a primary model and a fallback from a different provider. When
 
 | Tier | Primary | Fallback | When to Fallback |
 |------|---------|----------|------------------|
-| `haiku` | claude-3-5-haiku | gemini-2.5-flash | No Anthropic key |
+| `haiku` | claude-haiku-4-5 | gemini-2.5-flash | No Anthropic key |
 | `flash` | gemini-2.5-flash | gpt-4.1-mini | No Google key |
 | `sonnet` | claude-sonnet-4 | gpt-4.1 | No Anthropic key |
 | `pro` | gemini-2.5-pro | claude-sonnet-4 | No Google key |


### PR DESCRIPTION
## Summary

- Update all Claude model references to match current lineup: **Opus 4.6**, **Sonnet 4.6**, **Haiku 4.5**
- Replace stale `claude-3-5-sonnet`, `claude-3-5-haiku`, and date-suffixed model IDs across 12 files
- Retain backward-compatible normalization patterns in `model-label-helper.sh` for historical data

## Changes

### Documentation (7 files)
- `subagent-index.toon` — haiku tier + opus model ID
- `tools/context/model-routing.md` — haiku tier references (3x)
- `tools/ai-assistants/models/README.md` — haiku tier mapping
- `services/hosting/cloudflare-platform/.../ai-gateway/README.md` — Anthropic example
- `tools/api/vercel-ai-sdk.md` — Anthropic SDK example
- `tools/browser/stagehand.md` — model name comment
- `tools/context/dspy.md` — Anthropic model config
- `tools/code-review/skill-scanner.md` — env var example

### Scripts (4 files)
- `scripts/eeat-score-helper.sh` — fallback model ID
- `scripts/model-availability-helper.sh` — haiku tier in OpenCode path
- `scripts/model-label-helper.sh` — added 4.x patterns as primary (kept 3.x for backward compat)
- `scripts/model-registry-helper.sh` — comment + default haiku model

## Verification

- `rg` sweep confirms zero stale references outside backward-compat normalization
- ShellCheck: no new violations
- Runtime configs (`fallback-chain-config.json.txt`, `dispatch.sh`, `ai-reason.sh`) were already on 4.6 — no changes needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude model references across configurations: haiku tier updated to claude-haiku-4-5, sonnet tier to claude-sonnet-4-6, and opus to claude-opus-4-6.

* **Documentation**
  * Updated model tier mapping and examples to reflect new Claude model versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->