### PR TITLE
t1302: Fix undefined memory content in WORKING_SOLUTION entries

### DIFF
--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -277,10 +277,16 @@ export function createTools(scriptsDir, run, pipelines) {
       action: "store",
       description:
         'Store a new memory in the aidevops cross-session memory. Args: content (string), confidence (string: low/medium/high, default "medium")',
-      buildArgs: (args, helper) => ({
-        cmd: `bash "${helper}" store "${args.content}" --confidence ${args.confidence || "medium"} 2>/dev/null`,
-        timeout: 10000,
-      }),
+      buildArgs: (args, helper) => {
+        const content = typeof args.content === "string" ? args.content.trim() : "";
+        if (!content) {
+          return { cmd: `echo "Error: content is required to store a memory" >&2; exit 1`, timeout: 1000 };
+        }
+        return {
+          cmd: `bash "${helper}" store "${content}" --confidence ${args.confidence || "medium"} 2>/dev/null`,
+          timeout: 10000,
+        };
+      },
     }),
 
     aidevops_pre_edit_check: createPreEditCheckTool(scriptsDir),

--- a/.agents/scripts/memory/store.sh
+++ b/.agents/scripts/memory/store.sh
@@ -87,6 +87,13 @@ cmd_store() {
 		return 1
 	fi
 
+	# Guard against literal "undefined" or "null" strings passed by JS callers
+	# when args.content is undefined in a template literal (produces "undefined").
+	if [[ "$content" == "undefined" || "$content" == "null" ]]; then
+		log_error "Content is 'undefined' or 'null' — refusing to store. Pass a real value."
+		return 1
+	fi
+
 	# Privacy filter: strip <private>...</private> blocks
 	content=$(echo "$content" | sed 's/<private>[^<]*<\/private>//g' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
 


### PR DESCRIPTION
Root cause: `aidevops_memory_store` MCP tool in `tools.mjs` used a JS template literal to build the shell command. When `args.content` is `undefined` (AI omits the arg), the template literal produces the string `'undefined'`, which passes the empty-string check in `store.sh` and gets written to the DB.

**Evidence**: `mem_20260222012936_839b12cb` has `content='undefined'`, `tags=''`, `source='manual'` — consistent with a direct MCP tool call without content arg.

## Changes

- **`tools.mjs`** (primary fix): validate `args.content` before building the shell command; return an error if content is missing/empty/undefined
- **`store.sh`** (defense in depth): reject literal strings `'undefined'` and `'null'` before any further processing

## Verification

- ShellCheck passes on `store.sh` (exit 0)
- Existing DB entry `mem_20260222012936_839b12cb` (content='undefined') remains — cleanup is a separate concern

## Note

One existing bad entry in the DB: `mem_20260222012936_839b12cb` with `content='undefined'`. This fix prevents future occurrences. Manual cleanup of the existing entry can be done with:
```sql
DELETE FROM learnings WHERE id = 'mem_20260222012936_839b12cb';
```

Ref #2124