### PR TITLE
fix: use provider-prefixed model IDs in OpenCode agent config

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -222,11 +222,11 @@ SKIP_CUSTOM_PROMPT = set()
 # Maps tier names to actual model identifiers
 # Agents declare their tier; the coordinator uses this for cost-effective routing
 MODEL_TIERS = {
-    "haiku": "claude-haiku-4-5",               # Triage, routing, simple tasks
-    "sonnet": "claude-sonnet-4-6",             # Code, review, implementation
-    "opus": "claude-opus-4-6",                 # Architecture, complex reasoning
-    "flash": "gemini-2.5-flash",               # Fast, cheap, large context
-    "pro": "gemini-2.5-pro",                   # Capable, large context
+    "haiku": "anthropic/claude-haiku-4-5",     # Triage, routing, simple tasks
+    "sonnet": "anthropic/claude-sonnet-4-6",   # Code, review, implementation
+    "opus": "anthropic/claude-opus-4-6",       # Architecture, complex reasoning
+    "flash": "google/gemini-2.5-flash",        # Fast, cheap, large context
+    "pro": "google/gemini-2.5-pro",            # Capable, large context
 }
 
 # Default model tier per agent (overridden by frontmatter 'model:' field)


### PR DESCRIPTION
## Summary

- Fix `Agent Content's configured model claude-opus-4-6/ is not valid` error
- OpenCode requires `provider/model` format (e.g. `anthropic/claude-opus-4-6`), not bare model names
- Updated all MODEL_TIERS entries with provider prefix

## Affected

Only Content agent currently has a model override (`model: opus` in frontmatter). Other agents use the user's authenticated model. This fix ensures any future model tier assignments also work correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI model identifier formats to use standardized vendor prefixes for internal consistency and improved organization across Claude and Gemini model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->