### PR TITLE
t1304: Soft TTSR — wire rules into OpenCode plugin hooks

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1601,19 +1601,22 @@ async function messagesTransformHook(_input, output) {
 
   // Inject as a synthetic user message at the end of the history
   // so the model sees the correction before generating its next response
+  const correctionId = `ttsr-correction-${Date.now()}`;
+  const sessionID = output.messages[0]?.info?.sessionID || "";
+
   output.messages.push({
     info: {
-      id: `ttsr-correction-${Date.now()}`,
-      sessionID: output.messages[0]?.info?.sessionID || "",
+      id: correctionId,
+      sessionID,
       role: "user",
       time: { created: Date.now() },
       parentID: "",
     },
     parts: [
       {
-        id: `ttsr-correction-part-${Date.now()}`,
-        sessionID: output.messages[0]?.info?.sessionID || "",
-        messageID: `ttsr-correction-${Date.now()}`,
+        id: `${correctionId}-part`,
+        sessionID,
+        messageID: correctionId,
         type: "text",
         text: correctionText,
         synthetic: true,

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1391,7 +1391,7 @@ const BUILTIN_TTSR_RULES = [
   {
     id: "no-credentials-in-output",
     description: "Never expose credentials, API keys, or secrets in output",
-    pattern: "(?:api[_-]?key|secret|password|token)\\s*[:=]\\s*['\"][A-Za-z0-9+/=]{16,}['\"]",
+    pattern: "(?:api[_-]?key|secret|password|token)\\s*[:=]\\s*['\"][A-Za-z0-9+/=_-]{16,}['\"]",
     correction: "SECURITY: Never expose credentials in output. Use `aidevops secret set NAME` for secure storage.",
     severity: "error",
     systemPrompt: "NEVER expose credentials, API keys, or secrets in output or logs.",


### PR DESCRIPTION
## Summary

Wire three previously-unused OpenCode experimental plugin hooks for **Soft TTSR** (preventative rule enforcement without stream-level interception):

1. **`experimental.chat.system.transform`** — Injects active quality rules into the system prompt before every LLM call, so the model is aware of conventions before generating output (preventative)
2. **`experimental.chat.messages.transform`** — Scans the last 3 assistant messages for rule violations and injects a synthetic correction message into the message history (corrective)
3. **`experimental.text.complete`** — Detects violations post-hoc in completed text, logs them for observability, and appends HTML comment markers for subsequent turns (observational)

## Rules System

7 built-in data-driven rules covering:
- File discovery (use `git ls-files` not Glob)
- File reading (use Read tool not cat/head/tail)
- Read-before-Edit enforcement
- Credential exposure prevention
- Pre-edit check enforcement
- Shell explicit returns (S7682)
- Shell local params (S7679)

Users can extend/override rules via `~/.aidevops/agents/configs/ttsr-rules.json`.

## Testing

- All hooks register correctly (9 total including existing hooks)
- System prompt injection: 7 rules injected
- Message transform: correctly detects violations, no false positives
- Text complete: correctly flags violations, no false positives
- Edge cases: empty messages, null parts, user-only messages all handled
- Performance: 8ms for 100 iterations on 25KB text
- Consistent IDs in synthetic correction messages

Ref #2128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Text-to-Speech Rules (TTSR) system for content compliance and enforcement.
  * Rules apply across system prompts, chat messages, and text outputs with violation detection and corrective feedback.
  * Support for custom user-defined rules with built-in defaults available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->