### PR TITLE
fix: curl install silently exits — bootstrap guard before source lines

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -387,7 +387,7 @@ if [[ ! -d "$_setup_script_dir/setup-modules" ]]; then
 	if [[ -d "$INSTALL_DIR/.git" ]]; then
 		print_info "Existing installation found — updating..."
 		cd "$INSTALL_DIR" || exit 1
-		git pull --ff-only 2>/dev/null || {
+		git pull --ff-only || {
 			print_warning "Git pull failed — resetting to origin/main"
 			git fetch origin
 			git reset --hard origin/main


### PR DESCRIPTION
## Summary

- Fixes `bash <(curl -fsSL https://aidevops.sh/install)` silently exiting with no output on fresh machines
- Root cause: `BASH_SOURCE[0]` is `/dev/fd/NN` during process substitution, so `source "$(dirname ...)/setup-modules/core.sh"` resolves to `/dev/fd/setup-modules/core.sh` which doesn't exist, causing silent exit under `set -euo pipefail`
- The existing `bootstrap_repo()` in `core.sh` was supposed to handle this, but it's a chicken-and-egg problem — `core.sh` itself can't be sourced

## Fix

Adds an inline bootstrap guard **before** the `source` lines in `setup.sh` that:

1. Detects curl/process-substitution execution by checking if `setup-modules/` exists relative to `BASH_SOURCE[0]`
2. Auto-installs git if missing (macOS Xcode CLT, apt, dnf, yum, pacman, apk)
3. Clones the repo to `~/Git/aidevops`
4. `exec`s the local copy of `setup.sh` (which has `setup-modules/` available)

## Testing

- `bash -n setup.sh` — syntax OK
- ShellCheck — clean
- Bootstrap detection verified: triggers from `/dev/fd/`, skips from repo dir