### PR TITLE
fix: curl install dies at SETUP_MODULES_DIR under set -e on fresh machines

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -31,7 +31,7 @@ INSTALL_DIR="$HOME/Git/aidevops"
 # Source modular setup functions (t316.2)
 # These modules are sourced only when setup.sh is run from the repo directory
 # (not during bootstrap from curl, which re-execs after cloning)
-SETUP_MODULES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.agents/scripts/setup" 2>/dev/null && pwd)"
+SETUP_MODULES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.agents/scripts/setup" 2>/dev/null && pwd)" || true
 if [[ -d "$SETUP_MODULES_DIR" ]]; then
 	# shellcheck disable=SC1091  # Dynamic path via $SETUP_MODULES_DIR; files exist at runtime
 	source "$SETUP_MODULES_DIR/_common.sh"


### PR DESCRIPTION
## Summary

- One-line fix for `bash <(curl -fsSL https://aidevops.sh/install)` silently dying on fresh machines
- v2.122.1 added the bootstrap guard but missed that the `SETUP_MODULES_DIR` subshell assignment itself was the first failure point

## Root cause

```bash
SETUP_MODULES_DIR="$(cd ".../.agents/scripts/setup" 2>/dev/null && pwd)"
```

Under `set -euo pipefail`, the `$()` subshell inherits `set -e`. When `cd` fails (directory doesn't exist on fresh machine), the subshell exits non-zero. `2>/dev/null` only suppresses stderr — the non-zero exit code still propagates and kills the parent script silently.

## Fix

```diff
-SETUP_MODULES_DIR="$(cd ... 2>/dev/null && pwd)"
+SETUP_MODULES_DIR="$(cd ... 2>/dev/null && pwd)" || true
```

Only affects fresh installs via `bash <(curl ...)`. Existing installs are unaffected (the `cd` succeeds).

## Verified

```bash
$ bash -c 'set -euo pipefail; r="$(cd /nonexistent 2>/dev/null && pwd)"; echo alive'
# exits silently

$ bash -c 'set -euo pipefail; r="$(cd /nonexistent 2>/dev/null && pwd)" || true; echo alive'
alive
```