### PR TITLE
fix: export HOMEBREW_NO_AUTO_UPDATE so it propagates to backgrounded brew install

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -217,7 +217,11 @@ install_packages() {
 		# Run brew update with spinner (Homebrew auto-update is slow and silent)
 		run_with_spinner "Updating Homebrew" brew update
 		# Install with auto-update disabled (we just ran it)
-		HOMEBREW_NO_AUTO_UPDATE=1 run_with_spinner "Installing ${packages[*]}" brew install "${packages[@]}"
+		# Must export — run_with_spinner backgrounds the command, so env var
+		# prefix syntax (VAR=x cmd) doesn't propagate to the child process.
+		export HOMEBREW_NO_AUTO_UPDATE=1
+		run_with_spinner "Installing ${packages[*]}" brew install "${packages[@]}"
+		unset HOMEBREW_NO_AUTO_UPDATE
 		;;
 	apt)
 		run_with_spinner "Updating package lists" sudo apt-get update -qq


### PR DESCRIPTION
## Summary

- `run_with_spinner` backgrounds commands via `"$@" &>/dev/null &`, so env var prefix syntax (`VAR=x cmd`) doesn't reach the child process
- This caused `brew install` to trigger a second auto-update (~50MB download), stalling setup on fresh machines for 30-60s+
- Fix: `export` the var before the call, `unset` after

## Root Cause

```bash
# Before (broken): VAR=x only sets for run_with_spinner, not the backgrounded brew
HOMEBREW_NO_AUTO_UPDATE=1 run_with_spinner "Installing..." brew install shellcheck shfmt

# After (fixed): export propagates to all child processes
export HOMEBREW_NO_AUTO_UPDATE=1
run_with_spinner "Installing..." brew install shellcheck shfmt
unset HOMEBREW_NO_AUTO_UPDATE
```

Fixes the stall reported during fresh `bash <(curl -fsSL https://aidevops.sh/install)` on macOS.