### PR TITLE
fix: suppress Homebrew auto-update globally in run_with_spinner

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -217,11 +217,8 @@ install_packages() {
 		# Run brew update with spinner (Homebrew auto-update is slow and silent)
 		run_with_spinner "Updating Homebrew" brew update
 		# Install with auto-update disabled (we just ran it)
-		# Must export — run_with_spinner backgrounds the command, so env var
-		# prefix syntax (VAR=x cmd) doesn't propagate to the child process.
-		export HOMEBREW_NO_AUTO_UPDATE=1
+		# Note: run_with_spinner auto-exports HOMEBREW_NO_AUTO_UPDATE for brew commands
 		run_with_spinner "Installing ${packages[*]}" brew install "${packages[@]}"
-		unset HOMEBREW_NO_AUTO_UPDATE
 		;;
 	apt)
 		run_with_spinner "Updating package lists" sudo apt-get update -qq


### PR DESCRIPTION
## Summary

- Moves `HOMEBREW_NO_AUTO_UPDATE` handling into `run_with_spinner()` itself
- Automatically exports the var for any `brew` command except `brew update`
- Covers all 10 `brew install` call sites across `setup-modules/` (bv, beads, worktrunk, tabby, zed, minisim, node, orbstack, etc.)
- Reverts the per-call-site fix from #2155 in `core.sh` (no longer needed)

## Problem

PR #2155 only fixed `install_packages()` in `core.sh`. Every other `run_with_spinner "..." brew install ...` call still triggered Homebrew's auto-update (~50MB index download), causing 30-60s stalls during setup.

## Fix

```bash
# In run_with_spinner(): auto-detect brew commands and suppress auto-update
if [[ "$1" == "brew" && "$2" != "update" ]]; then
    export HOMEBREW_NO_AUTO_UPDATE=1
fi
# ... background command ...
# Restore after completion
```