### PR TITLE
fix: use npm for tool updates, fix OpenCode package name, capture locals in run_with_spinner

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -2,7 +2,7 @@
 # Tool Version Check
 # Checks versions of key tools and flags outdated ones
 #
-# Usage: 
+# Usage:
 #   tool-version-check.sh              # Check all tools
 #   tool-version-check.sh --update     # Check and update outdated tools
 #   tool-version-check.sh --category npm  # Check only npm tools
@@ -24,79 +24,79 @@ JSON_OUTPUT=false
 QUIET=false
 
 while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --update|-u)
-            AUTO_UPDATE=true
-            shift
-            ;;
-        --category|-c)
-            if [[ -z "${2:-}" ]]; then
-                echo "Error: --category requires a value (npm, brew, pip, all)"
-                exit 1
-            fi
-            CATEGORY="$2"
-            shift 2
-            ;;
-        --json|-j)
-            JSON_OUTPUT=true
-            shift
-            ;;
-        --quiet|-q)
-            QUIET=true
-            shift
-            ;;
-        --help|-h)
-            echo "Usage: tool-version-check.sh [OPTIONS]"
-            echo ""
-            echo "Options:"
-            echo "  --update, -u       Automatically update outdated tools"
-            echo "  --category, -c     Check only specific category (npm, brew, pip, all)"
-            echo "  --json, -j         Output results as JSON"
-            echo "  --quiet, -q        Only show outdated tools"
-            echo "  --help, -h         Show this help"
-            exit 0
-            ;;
-        *)
-            echo "Unknown option: $1"
-            exit 1
-            ;;
-    esac
+	case "$1" in
+	--update | -u)
+		AUTO_UPDATE=true
+		shift
+		;;
+	--category | -c)
+		if [[ -z "${2:-}" ]]; then
+			echo "Error: --category requires a value (npm, brew, pip, all)"
+			exit 1
+		fi
+		CATEGORY="$2"
+		shift 2
+		;;
+	--json | -j)
+		JSON_OUTPUT=true
+		shift
+		;;
+	--quiet | -q)
+		QUIET=true
+		shift
+		;;
+	--help | -h)
+		echo "Usage: tool-version-check.sh [OPTIONS]"
+		echo ""
+		echo "Options:"
+		echo "  --update, -u       Automatically update outdated tools"
+		echo "  --category, -c     Check only specific category (npm, brew, pip, all)"
+		echo "  --json, -j         Output results as JSON"
+		echo "  --quiet, -q        Only show outdated tools"
+		echo "  --help, -h         Show this help"
+		exit 0
+		;;
+	*)
+		echo "Unknown option: $1"
+		exit 1
+		;;
+	esac
 done
 
 # Tool definitions
 # Format: category|display_name|cli_command|version_flag|package_name|update_command
 
 NPM_TOOLS=(
-    "npm|osgrep|osgrep|--version|osgrep|npm update -g osgrep"
-    "npm|Augment CLI|auggie|--version|@augmentcode/auggie@prerelease|npm update -g @augmentcode/auggie@prerelease"
-    "npm|Repomix|repomix|--version|repomix|bun install -g repomix@latest"
-    "npm|DSPyGround|dspyground|--version|dspyground|npm update -g dspyground"
-    "npm|LocalWP MCP|mcp-local-wp|--version|@verygoodplugins/mcp-local-wp|npm update -g @verygoodplugins/mcp-local-wp"
-    "npm|Beads UI|beads-ui|--version|beads-ui|npm update -g beads-ui"
-    "npm|BDUI|bdui|--version|bdui|npm update -g bdui"
-    "npm|OpenCode|opencode|--version|opencode|bun install -g opencode-ai@latest"
-    "npm|Chrome DevTools MCP|chrome-devtools-mcp|--version|chrome-devtools-mcp|bun install -g chrome-devtools-mcp@latest"
-    "npm|GSC MCP|mcp-server-gsc|--version|mcp-server-gsc|bun install -g mcp-server-gsc@latest"
-    "npm|Playwriter MCP|playwriter|--version|playwriter|bun install -g playwriter@latest"
-    "npm|macOS Automator MCP|macos-automator-mcp|--version|@steipete/macos-automator-mcp|bun install -g @steipete/macos-automator-mcp@latest"
-    "npm|Claude Code MCP|claude-code-mcp|--version|@steipete/claude-code-mcp|bun install -g @steipete/claude-code-mcp@latest"
+	"npm|osgrep|osgrep|--version|osgrep|npm update -g osgrep"
+	"npm|Augment CLI|auggie|--version|@augmentcode/auggie@prerelease|npm update -g @augmentcode/auggie@prerelease"
+	"npm|Repomix|repomix|--version|repomix|npm install -g repomix@latest"
+	"npm|DSPyGround|dspyground|--version|dspyground|npm update -g dspyground"
+	"npm|LocalWP MCP|mcp-local-wp|--version|@verygoodplugins/mcp-local-wp|npm update -g @verygoodplugins/mcp-local-wp"
+	"npm|Beads UI|beads-ui|--version|beads-ui|npm update -g beads-ui"
+	"npm|BDUI|bdui|--version|bdui|npm update -g bdui"
+	"npm|OpenCode|opencode|--version|opencode-ai|npm install -g opencode-ai@latest"
+	"npm|Chrome DevTools MCP|chrome-devtools-mcp|--version|chrome-devtools-mcp|npm install -g chrome-devtools-mcp@latest"
+	"npm|GSC MCP|mcp-server-gsc|--version|mcp-server-gsc|npm install -g mcp-server-gsc@latest"
+	"npm|Playwriter MCP|playwriter|--version|playwriter|npm install -g playwriter@latest"
+	"npm|macOS Automator MCP|macos-automator-mcp|--version|@steipete/macos-automator-mcp|npm install -g @steipete/macos-automator-mcp@latest"
+	"npm|Claude Code MCP|claude-code-mcp|--version|@steipete/claude-code-mcp|npm install -g @steipete/claude-code-mcp@latest"
 )
 
 BREW_TOOLS=(
-    "brew|GitHub CLI|gh|--version|gh|brew upgrade gh"
-    "brew|GitLab CLI|glab|--version|glab|brew upgrade glab"
-    "brew|Worktrunk|wt|--version|max-sixty/worktrunk/wt|brew upgrade max-sixty/worktrunk/wt"
-    "brew|Beads CLI|bd|version|steveyegge/beads/bd|brew upgrade steveyegge/beads/bd"
-    "brew|jq|jq|--version|jq|brew upgrade jq"
-    "brew|ShellCheck|shellcheck|--version|shellcheck|brew upgrade shellcheck"
+	"brew|GitHub CLI|gh|--version|gh|brew upgrade gh"
+	"brew|GitLab CLI|glab|--version|glab|brew upgrade glab"
+	"brew|Worktrunk|wt|--version|max-sixty/worktrunk/wt|brew upgrade max-sixty/worktrunk/wt"
+	"brew|Beads CLI|bd|version|steveyegge/beads/bd|brew upgrade steveyegge/beads/bd"
+	"brew|jq|jq|--version|jq|brew upgrade jq"
+	"brew|ShellCheck|shellcheck|--version|shellcheck|brew upgrade shellcheck"
 )
 
 PIP_TOOLS=(
-    "pip|Beads Viewer|beads_viewer|--version|beads-viewer|pip install --upgrade beads-viewer"
-    "pip|DSPy|dspy|--version|dspy-ai|pip install --upgrade dspy-ai"
-    "pip|Crawl4AI|crawl4ai|--version|crawl4ai|pip install --upgrade crawl4ai"
-    "pip|Analytics MCP|analytics-mcp|--version|analytics-mcp|pipx upgrade analytics-mcp"
-    "pip|Outscraper MCP|outscraper-mcp-server|--version|outscraper-mcp-server|uv tool upgrade outscraper-mcp-server"
+	"pip|Beads Viewer|beads_viewer|--version|beads-viewer|pip install --upgrade beads-viewer"
+	"pip|DSPy|dspy|--version|dspy-ai|pip install --upgrade dspy-ai"
+	"pip|Crawl4AI|crawl4ai|--version|crawl4ai|pip install --upgrade crawl4ai"
+	"pip|Analytics MCP|analytics-mcp|--version|analytics-mcp|pipx upgrade analytics-mcp"
+	"pip|Outscraper MCP|outscraper-mcp-server|--version|outscraper-mcp-server|uv tool upgrade outscraper-mcp-server"
 )
 
 # Counters
@@ -108,263 +108,263 @@ declare -a JSON_RESULTS=()
 
 # Get installed version
 get_installed_version() {
-    local cmd="$1"
-    local ver_flag="$2"
-    
-    if command -v "$cmd" &>/dev/null; then
-        local version
-        # shellcheck disable=SC2086
-        version=$("$cmd" $ver_flag 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
-        if [[ -z "$version" ]]; then
-            # Try alternative patterns
-            # shellcheck disable=SC2086
-            version=$("$cmd" $ver_flag 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "unknown")
-        fi
-        echo "$version"
-    else
-        echo "not installed"
-    fi
-    return 0
+	local cmd="$1"
+	local ver_flag="$2"
+
+	if command -v "$cmd" &>/dev/null; then
+		local version
+		# shellcheck disable=SC2086
+		version=$("$cmd" $ver_flag 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+		if [[ -z "$version" ]]; then
+			# Try alternative patterns
+			# shellcheck disable=SC2086
+			version=$("$cmd" $ver_flag 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "unknown")
+		fi
+		echo "$version"
+	else
+		echo "not installed"
+	fi
+	return 0
 }
 
 # Get latest npm version
 get_npm_latest() {
-    local pkg="$1"
-    npm view "$pkg" version 2>/dev/null || echo "unknown"
-    return 0
+	local pkg="$1"
+	npm view "$pkg" version 2>/dev/null || echo "unknown"
+	return 0
 }
 
 # Get latest brew version
 get_brew_latest() {
-    local pkg="$1"
-    if command -v brew &>/dev/null; then
-        brew info "$pkg" 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown"
-    else
-        echo "unknown"
-    fi
-    return 0
+	local pkg="$1"
+	if command -v brew &>/dev/null; then
+		brew info "$pkg" 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown"
+	else
+		echo "unknown"
+	fi
+	return 0
 }
 
 # Get latest pip version
 get_pip_latest() {
-    local pkg="$1"
-    pip index versions "$pkg" 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown"
-    return 0
+	local pkg="$1"
+	pip index versions "$pkg" 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown"
+	return 0
 }
 
 # Compare versions (returns 0 if v1 < v2)
 version_lt() {
-    local v1="$1"
-    local v2="$2"
-    
-    if [[ "$v1" == "$v2" ]]; then
-        return 1
-    fi
-    
-    # Use sort -V for version comparison
-    local lowest
-    lowest=$(printf '%s\n%s' "$v1" "$v2" | sort -V | head -1)
-    [[ "$lowest" == "$v1" ]]
+	local v1="$1"
+	local v2="$2"
+
+	if [[ "$v1" == "$v2" ]]; then
+		return 1
+	fi
+
+	# Use sort -V for version comparison
+	local lowest
+	lowest=$(printf '%s\n%s' "$v1" "$v2" | sort -V | head -1)
+	[[ "$lowest" == "$v1" ]]
 }
 
 # Check a single tool
 check_tool() {
-    local category="$1"
-    local name="$2"
-    local cmd="$3"
-    local ver_flag="$4"
-    local pkg="$5"
-    local update_cmd="$6"
-    
-    local installed
-    installed=$(get_installed_version "$cmd" "$ver_flag")
-    
-    local latest="unknown"
-    case "$category" in
-        npm) latest=$(get_npm_latest "$pkg") ;;
-        brew) latest=$(get_brew_latest "$pkg") ;;
-        pip) latest=$(get_pip_latest "$pkg") ;;
-        *) latest="unknown" ;;
-    esac
-    
-    local status="up_to_date"
-    local icon="✓"
-    local color="$GREEN"
-    
-    if [[ "$installed" == "not installed" ]]; then
-        status="not_installed"
-        icon="○"
-        color="$YELLOW"
-        ((NOT_INSTALLED_COUNT++)) || true
-    elif [[ "$installed" == "unknown" || "$latest" == "unknown" ]]; then
-        status="unknown"
-        icon="?"
-        color="$YELLOW"
-        ((INSTALLED_COUNT++)) || true
-    elif [[ "$installed" != "$latest" ]] && version_lt "$installed" "$latest"; then
-        status="outdated"
-        icon="⬆"
-        color="$RED"
-        ((OUTDATED_COUNT++)) || true
-        OUTDATED_PACKAGES+=("$update_cmd")
-    else
-        ((INSTALLED_COUNT++)) || true
-    fi
-    
-    # JSON output (escape special characters for valid JSON)
-    if [[ "$JSON_OUTPUT" == "true" ]]; then
-        # Escape backslashes and double quotes for JSON safety
-        local json_name="${name//\\/\\\\}"
-        json_name="${json_name//\"/\\\"}"
-        local json_update="${update_cmd//\\/\\\\}"
-        json_update="${json_update//\"/\\\"}"
-        JSON_RESULTS+=("{\"name\":\"$json_name\",\"category\":\"$category\",\"installed\":\"$installed\",\"latest\":\"$latest\",\"status\":\"$status\",\"update_cmd\":\"$json_update\"}")
-    else
-        # Console output
-        if [[ "$QUIET" == "true" && "$status" != "outdated" ]]; then
-            return
-        fi
-        
-        case "$status" in
-            not_installed)
-                echo -e "${color}${icon}  $name: not installed${NC}"
-                if [[ "$QUIET" != "true" ]]; then
-                    echo "   Latest: $latest"
-                fi
-                ;;
-            outdated)
-                echo -e "${color}${icon}  $name: $installed → $latest (UPDATE AVAILABLE)${NC}"
-                ;;
-            unknown)
-                echo -e "${color}${icon}  $name: $installed (could not check latest)${NC}"
-                ;;
-            up_to_date)
-                echo -e "${color}${icon}  $name: $installed${NC}"
-                ;;
-            *)
-                echo -e "${color}${icon}  $name: $installed (status: $status)${NC}"
-                ;;
-        esac
-    fi
+	local category="$1"
+	local name="$2"
+	local cmd="$3"
+	local ver_flag="$4"
+	local pkg="$5"
+	local update_cmd="$6"
+
+	local installed
+	installed=$(get_installed_version "$cmd" "$ver_flag")
+
+	local latest="unknown"
+	case "$category" in
+	npm) latest=$(get_npm_latest "$pkg") ;;
+	brew) latest=$(get_brew_latest "$pkg") ;;
+	pip) latest=$(get_pip_latest "$pkg") ;;
+	*) latest="unknown" ;;
+	esac
+
+	local status="up_to_date"
+	local icon="✓"
+	local color="$GREEN"
+
+	if [[ "$installed" == "not installed" ]]; then
+		status="not_installed"
+		icon="○"
+		color="$YELLOW"
+		((NOT_INSTALLED_COUNT++)) || true
+	elif [[ "$installed" == "unknown" || "$latest" == "unknown" ]]; then
+		status="unknown"
+		icon="?"
+		color="$YELLOW"
+		((INSTALLED_COUNT++)) || true
+	elif [[ "$installed" != "$latest" ]] && version_lt "$installed" "$latest"; then
+		status="outdated"
+		icon="⬆"
+		color="$RED"
+		((OUTDATED_COUNT++)) || true
+		OUTDATED_PACKAGES+=("$update_cmd")
+	else
+		((INSTALLED_COUNT++)) || true
+	fi
+
+	# JSON output (escape special characters for valid JSON)
+	if [[ "$JSON_OUTPUT" == "true" ]]; then
+		# Escape backslashes and double quotes for JSON safety
+		local json_name="${name//\\/\\\\}"
+		json_name="${json_name//\"/\\\"}"
+		local json_update="${update_cmd//\\/\\\\}"
+		json_update="${json_update//\"/\\\"}"
+		JSON_RESULTS+=("{\"name\":\"$json_name\",\"category\":\"$category\",\"installed\":\"$installed\",\"latest\":\"$latest\",\"status\":\"$status\",\"update_cmd\":\"$json_update\"}")
+	else
+		# Console output
+		if [[ "$QUIET" == "true" && "$status" != "outdated" ]]; then
+			return
+		fi
+
+		case "$status" in
+		not_installed)
+			echo -e "${color}${icon}  $name: not installed${NC}"
+			if [[ "$QUIET" != "true" ]]; then
+				echo "   Latest: $latest"
+			fi
+			;;
+		outdated)
+			echo -e "${color}${icon}  $name: $installed → $latest (UPDATE AVAILABLE)${NC}"
+			;;
+		unknown)
+			echo -e "${color}${icon}  $name: $installed (could not check latest)${NC}"
+			;;
+		up_to_date)
+			echo -e "${color}${icon}  $name: $installed${NC}"
+			;;
+		*)
+			echo -e "${color}${icon}  $name: $installed (status: $status)${NC}"
+			;;
+		esac
+	fi
 }
 
 # Check tools by category
 check_category() {
-    local cat_name="$1"
-    shift
-    local tools=("$@")
-    
-    if [[ "$JSON_OUTPUT" != "true" && "$QUIET" != "true" ]]; then
-        echo ""
-        echo -e "${BOLD}${CYAN}=== $cat_name Tools ===${NC}"
-    fi
-    
-    local category name cmd ver_flag pkg update_cmd
-    for tool_spec in "${tools[@]}"; do
-        IFS='|' read -r category name cmd ver_flag pkg update_cmd <<< "$tool_spec"
-        check_tool "$category" "$name" "$cmd" "$ver_flag" "$pkg" "$update_cmd"
-    done
-    return 0
+	local cat_name="$1"
+	shift
+	local tools=("$@")
+
+	if [[ "$JSON_OUTPUT" != "true" && "$QUIET" != "true" ]]; then
+		echo ""
+		echo -e "${BOLD}${CYAN}=== $cat_name Tools ===${NC}"
+	fi
+
+	local category name cmd ver_flag pkg update_cmd
+	for tool_spec in "${tools[@]}"; do
+		IFS='|' read -r category name cmd ver_flag pkg update_cmd <<<"$tool_spec"
+		check_tool "$category" "$name" "$cmd" "$ver_flag" "$pkg" "$update_cmd"
+	done
+	return 0
 }
 
 # Main
 main() {
-    if [[ "$JSON_OUTPUT" != "true" && "$QUIET" != "true" ]]; then
-        echo -e "${BOLD}${BLUE}Tool Version Check${NC}"
-        echo "=================="
-    fi
-    
-    # Check requested categories
-    case "$CATEGORY" in
-        npm)
-            check_category "NPM" "${NPM_TOOLS[@]}"
-            ;;
-        brew)
-            check_category "Homebrew" "${BREW_TOOLS[@]}"
-            ;;
-        pip)
-            check_category "Python/Pip" "${PIP_TOOLS[@]}"
-            ;;
-        all|*)
-            if [[ ${#NPM_TOOLS[@]} -gt 0 ]]; then
-                check_category "NPM" "${NPM_TOOLS[@]}"
-            fi
-            if command -v brew &>/dev/null && [[ ${#BREW_TOOLS[@]} -gt 0 ]]; then
-                check_category "Homebrew" "${BREW_TOOLS[@]}"
-            fi
-            if command -v pip &>/dev/null && [[ ${#PIP_TOOLS[@]} -gt 0 ]]; then
-                check_category "Python/Pip" "${PIP_TOOLS[@]}"
-            fi
-            ;;
-    esac
-    
-    # Output results
-    if [[ "$JSON_OUTPUT" == "true" ]]; then
-        echo "{"
-        echo "  \"summary\": {"
-        echo "    \"installed\": $INSTALLED_COUNT,"
-        echo "    \"outdated\": $OUTDATED_COUNT,"
-        echo "    \"not_installed\": $NOT_INSTALLED_COUNT"
-        echo "  },"
-        echo "  \"tools\": ["
-        local first=true
-        for result in "${JSON_RESULTS[@]}"; do
-            if [[ "$first" == "true" ]]; then
-                first=false
-            else
-                echo ","
-            fi
-            echo -n "    $result"
-        done
-        echo ""
-        echo "  ]"
-        echo "}"
-        return 0
-    fi
-    
-    # Summary (skip in quiet mode if nothing outdated)
-    if [[ "$QUIET" == "true" && $OUTDATED_COUNT -eq 0 ]]; then
-        return 0
-    fi
-    
-    if [[ "$QUIET" != "true" ]]; then
-        echo ""
-        echo -e "${BOLD}Summary${NC}"
-        echo "  Installed & up to date: $INSTALLED_COUNT"
-        echo "  Outdated: $OUTDATED_COUNT"
-        echo "  Not installed: $NOT_INSTALLED_COUNT"
-        echo ""
-    fi
-    
-    # Handle updates
-    if [[ $OUTDATED_COUNT -gt 0 ]]; then
-        if [[ "$AUTO_UPDATE" == "true" ]]; then
-            echo -e "${BLUE}Updating outdated tools...${NC}"
-            echo ""
-            for update_cmd in "${OUTDATED_PACKAGES[@]}"; do
-                echo "  Running: $update_cmd"
-                # Run update command directly (not via eval for security)
-                # Commands are hardcoded in tool definitions, not user input
-                if bash -c "$update_cmd" 2>&1 | tail -2; then
-                    echo -e "  ${GREEN}✓ Updated${NC}"
-                else
-                    echo -e "  ${RED}✗ Failed${NC}"
-                fi
-                echo ""
-            done
-            echo -e "${GREEN}Updates complete. Re-run to verify.${NC}"
-        else
-            echo "To update all outdated tools, run:"
-            echo "  tool-version-check.sh --update"
-            echo ""
-            echo "Or update individually:"
-            for update_cmd in "${OUTDATED_PACKAGES[@]}"; do
-                echo "  $update_cmd"
-            done
-        fi
-    else
-        echo -e "${GREEN}All installed tools are up to date!${NC}"
-    fi
+	if [[ "$JSON_OUTPUT" != "true" && "$QUIET" != "true" ]]; then
+		echo -e "${BOLD}${BLUE}Tool Version Check${NC}"
+		echo "=================="
+	fi
+
+	# Check requested categories
+	case "$CATEGORY" in
+	npm)
+		check_category "NPM" "${NPM_TOOLS[@]}"
+		;;
+	brew)
+		check_category "Homebrew" "${BREW_TOOLS[@]}"
+		;;
+	pip)
+		check_category "Python/Pip" "${PIP_TOOLS[@]}"
+		;;
+	all | *)
+		if [[ ${#NPM_TOOLS[@]} -gt 0 ]]; then
+			check_category "NPM" "${NPM_TOOLS[@]}"
+		fi
+		if command -v brew &>/dev/null && [[ ${#BREW_TOOLS[@]} -gt 0 ]]; then
+			check_category "Homebrew" "${BREW_TOOLS[@]}"
+		fi
+		if command -v pip &>/dev/null && [[ ${#PIP_TOOLS[@]} -gt 0 ]]; then
+			check_category "Python/Pip" "${PIP_TOOLS[@]}"
+		fi
+		;;
+	esac
+
+	# Output results
+	if [[ "$JSON_OUTPUT" == "true" ]]; then
+		echo "{"
+		echo "  \"summary\": {"
+		echo "    \"installed\": $INSTALLED_COUNT,"
+		echo "    \"outdated\": $OUTDATED_COUNT,"
+		echo "    \"not_installed\": $NOT_INSTALLED_COUNT"
+		echo "  },"
+		echo "  \"tools\": ["
+		local first=true
+		for result in "${JSON_RESULTS[@]}"; do
+			if [[ "$first" == "true" ]]; then
+				first=false
+			else
+				echo ","
+			fi
+			echo -n "    $result"
+		done
+		echo ""
+		echo "  ]"
+		echo "}"
+		return 0
+	fi
+
+	# Summary (skip in quiet mode if nothing outdated)
+	if [[ "$QUIET" == "true" && $OUTDATED_COUNT -eq 0 ]]; then
+		return 0
+	fi
+
+	if [[ "$QUIET" != "true" ]]; then
+		echo ""
+		echo -e "${BOLD}Summary${NC}"
+		echo "  Installed & up to date: $INSTALLED_COUNT"
+		echo "  Outdated: $OUTDATED_COUNT"
+		echo "  Not installed: $NOT_INSTALLED_COUNT"
+		echo ""
+	fi
+
+	# Handle updates
+	if [[ $OUTDATED_COUNT -gt 0 ]]; then
+		if [[ "$AUTO_UPDATE" == "true" ]]; then
+			echo -e "${BLUE}Updating outdated tools...${NC}"
+			echo ""
+			for update_cmd in "${OUTDATED_PACKAGES[@]}"; do
+				echo "  Running: $update_cmd"
+				# Run update command directly (not via eval for security)
+				# Commands are hardcoded in tool definitions, not user input
+				if bash -c "$update_cmd" 2>&1 | tail -2; then
+					echo -e "  ${GREEN}✓ Updated${NC}"
+				else
+					echo -e "  ${RED}✗ Failed${NC}"
+				fi
+				echo ""
+			done
+			echo -e "${GREEN}Updates complete. Re-run to verify.${NC}"
+		else
+			echo "To update all outdated tools, run:"
+			echo "  tool-version-check.sh --update"
+			echo ""
+			echo "Or update individually:"
+			for update_cmd in "${OUTDATED_PACKAGES[@]}"; do
+				echo "  $update_cmd"
+			done
+		fi
+	else
+		echo -e "${GREEN}All installed tools are up to date!${NC}"
+	fi
 }
 
 main

--- a/setup.sh
+++ b/setup.sh
@@ -84,7 +84,9 @@ run_with_spinner() {
 	# run_with_spinner backgrounds via "$@" &, so env var prefix syntax
 	# (VAR=x cmd) doesn't propagate. Export globally for the child process.
 	local _brew_was_set="${HOMEBREW_NO_AUTO_UPDATE:-}"
-	if [[ "$1" == "brew" && "$2" != "update" ]]; then
+	local _cmd="${1:-}"
+	local _subcmd="${2:-}"
+	if [[ "$_cmd" == "brew" && "$_subcmd" != "update" ]]; then
 		export HOMEBREW_NO_AUTO_UPDATE=1
 	fi
 


### PR DESCRIPTION
## Summary

- **tool-version-check.sh**: Replace all `bun install -g` with `npm install -g` — bun is not guaranteed to be installed, causing update failures and EEXIST conflicts when npm-installed tools exist
- **tool-version-check.sh**: Fix OpenCode `package_name` field from `opencode` to `opencode-ai` (the actual npm package name)
- **setup.sh**: Capture `$1`/`$2` after `shift` as `local _cmd` / `local _subcmd` in `run_with_spinner()` for code quality compliance

## Problem

1. `tool-version-check.sh` used `bun install -g` for 6 tools but bun isn't always installed. On systems with npm-installed tools, this caused `EEXIST` errors or installed duplicates
2. OpenCode's package name was listed as `opencode` but the npm package is `opencode-ai`, so version lookups against the npm registry would fail
3. Bare `$1`/`$2` after `shift` in `run_with_spinner` violated local variable conventions

## Tools affected

| Tool | Old update command | New update command |
|------|-------------------|-------------------|
| Repomix | `bun install -g repomix@latest` | `npm install -g repomix@latest` |
| OpenCode | `bun install -g opencode-ai@latest` | `npm install -g opencode-ai@latest` |
| Chrome DevTools MCP | `bun install -g chrome-devtools-mcp@latest` | `npm install -g chrome-devtools-mcp@latest` |
| GSC MCP | `bun install -g mcp-server-gsc@latest` | `npm install -g mcp-server-gsc@latest` |
| Playwriter MCP | `bun install -g playwriter@latest` | `npm install -g playwriter@latest` |
| macOS Automator MCP | `bun install -g @steipete/macos-automator-mcp@latest` | `npm install -g @steipete/macos-automator-mcp@latest` |
| Claude Code MCP | `bun install -g @steipete/claude-code-mcp@latest` | `npm install -g @steipete/claude-code-mcp@latest` |