### PR TITLE
fix: detect OpenCode version via CLI instead of hardcoded bun path

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -69,7 +69,7 @@ detect_app() {
 		case "$parent" in
 		*opencode*)
 			app_name="OpenCode"
-			app_version=$(jq -r '.version // empty' ~/.bun/install/global/node_modules/opencode-ai/package.json 2>/dev/null || echo "")
+			app_version=$(opencode --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
 			;;
 		*claude*)
 			app_name="Claude Code"


### PR DESCRIPTION
## Summary

- `detect_app()` in `aidevops-update-check.sh` read OpenCode version from `~/.bun/install/global/node_modules/opencode-ai/package.json`
- When OpenCode is installed via npm (not bun), this path is stale — showed v1.1.56 instead of actual v1.2.10
- Fix: use `opencode --version` directly, matching the pattern already used for claude and aider detection

## Root cause

The bun global install path had a stale v1.1.56 package.json from a previous install method. The npm install at `/opt/homebrew/lib/node_modules/opencode-ai/` had the correct v1.2.10. Reading a hardcoded package.json path is fragile — the CLI binary is the source of truth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal version detection mechanism for improved reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->