### PR TITLE
fix: safe empty array expansion in _run_generator under set -u

### DIFF
--- a/setup-modules/config.sh
+++ b/setup-modules/config.sh
@@ -82,11 +82,14 @@ _run_generator() {
 	fi
 
 	print_info "$info_msg"
-	if bash "$script_path" "${script_args[@]}"; then
+	# Use ${arr[@]+"${arr[@]}"} pattern for safe expansion under set -u when array may be empty
+	if bash "$script_path" ${script_args[@]+"${script_args[@]}"}; then
 		print_success "$success_msg"
 	else
 		print_warning "$failure_msg"
 	fi
+
+	return 0
 }
 
 update_opencode_config() {


### PR DESCRIPTION
## Summary

- Fix `_run_generator()` in `setup-modules/config.sh` crashing with "unbound variable" under `set -euo pipefail` when called without extra arguments (4 of 6 call sites)
- Use `${arr[@]+"${arr[@]}"}` pattern for safe empty array expansion (already used in `setup.sh:178`)
- Add explicit `return 0` to `_run_generator()` for shell quality compliance

## Bug

`setup.sh --non-interactive` would fail at config generation phase because `_run_generator` was called with only 4 positional args, making `script_args=("$@")` an empty array. Under `set -u`, `"${script_args[@]}"` triggers "unbound variable".

## Testing

```bash
# Reproduces the bug:
bash -c 'set -euo pipefail; shift 4; a=("$@"); echo "${a[@]}"' -- a b c d
# → unbound variable

# Fix works:
bash -c 'set -euo pipefail; shift 4; a=("$@"); echo ${a[@]+"${a[@]}"}' -- a b c d
# → (empty, no error)
```

ShellCheck clean.