### PR TITLE
chore: cleanup stale bun opencode install, prefer npm

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -227,18 +227,14 @@ find_python3() {
 	return 1
 }
 
-# Install a package globally via npm or bun, with sudo when needed on Linux.
+# Install a package globally via npm, with sudo when needed on Linux.
 # Usage: npm_global_install "package-name" OR npm_global_install "package@version"
-# Uses bun if available (no sudo needed), falls back to npm.
 # On Linux with apt-installed npm, automatically prepends sudo.
 # Returns: 0 on success, 1 on failure
 npm_global_install() {
 	local pkg="$1"
 
-	if command -v bun >/dev/null 2>&1; then
-		bun install -g "$pkg"
-		return $?
-	elif command -v npm >/dev/null 2>&1; then
+	if command -v npm >/dev/null 2>&1; then
 		# npm global installs need sudo on Linux when prefix dir isn't writable
 		if [[ "$(uname)" != "Darwin" ]] && [[ ! -w "$(npm config get prefix 2>/dev/null)/lib" ]]; then
 			sudo npm install -g "$pkg"
@@ -533,6 +529,7 @@ main() {
 		migrate_mcp_env_to_credentials
 		cleanup_deprecated_paths
 		cleanup_deprecated_mcps
+		cleanup_stale_bun_opencode
 		validate_opencode_config
 		deploy_aidevops_agents
 		setup_safety_hooks
@@ -583,6 +580,7 @@ main() {
 		confirm_step "Migrate mcp-env.sh -> credentials.sh" && migrate_mcp_env_to_credentials
 		confirm_step "Cleanup deprecated agent paths" && cleanup_deprecated_paths
 		confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
+		confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode
 		confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config
 		confirm_step "Extract OpenCode prompts" && extract_opencode_prompts
 		confirm_step "Check OpenCode prompt drift" && check_opencode_prompt_drift


### PR DESCRIPTION
## Summary

- Add one-time migration `cleanup_stale_bun_opencode()` to remove stale `~/.bun/bin/opencode` and `~/.bun/install/global/node_modules/opencode-ai/` left over from pre-v2.123.1 bun installs
- Flip `npm_global_install()` to use npm only (removed bun preference) — aligns with tool-version-check.sh which already switched to npm in v2.123.1
- Wired into both non-interactive and interactive setup flows

## Why

Prior to v2.123.1, `tool-version-check.sh` used `bun install -g opencode-ai`. Users who ran that have a stale binary at `~/.bun/bin/opencode` that can shadow the current npm install if `~/.bun/bin` appears earlier in PATH. This caused version detection issues and potentially running outdated opencode.

## Safety

- Only removes bun binary after confirming npm version is installed
- If npm version isn't installed, installs it first via `npm_global_install`
- If npm isn't available at all, leaves bun version in place (user still has a working opencode)
- Works on macOS (zsh/bash) and Linux — no platform-specific code

## Cross-platform

| Platform | npm bin location | Cleanup target | Status |
|----------|-----------------|----------------|--------|
| macOS (Homebrew) | `/opt/homebrew/bin/` | `~/.bun/bin/opencode` | Works |
| macOS (nvm) | `~/.nvm/.../bin/` | `~/.bun/bin/opencode` | Works |
| Linux | `/usr/local/bin/` or `/usr/bin/` | `~/.bun/bin/opencode` | Works |
| Linux (no bun) | N/A | No-op (nothing to clean) | Works |