### PR TITLE
Link task IDs to GitHub issues in health dashboard

### DIFF
--- a/.agents/scripts/supervisor/issue-sync.sh
+++ b/.agents/scripts/supervisor/issue-sync.sh
@@ -950,7 +950,16 @@ update_queue_health_issue() {
 			# Extract short description — strip metadata tags but preserve natural #refs
 			local f_desc_short
 			f_desc_short=$(echo "$f_desc" | sed 's/ #[a-z][a-z_-]*//g; s/ ~[0-9][0-9hm]*//g; s/ ref:[^ ]*//g; s/ model:[^ ]*//g; s/ —.*//' | head -c 80)
-			local f_entry="  - \`${f_id}\` — ${f_desc_short:-unknown task}"
+			# Link task ID to its GitHub issue if ref:GH#NNNN exists in description
+			local f_issue_num
+			f_issue_num=$(echo "$f_desc" | sed -n 's/.*ref:GH#\([0-9]*\).*/\1/p' | head -1)
+			local f_id_display
+			if [[ -n "$f_issue_num" ]]; then
+				f_id_display="[${f_id}](https://github.com/${repo_slug}/issues/${f_issue_num})"
+			else
+				f_id_display="\`${f_id}\`"
+			fi
+			local f_entry="  - ${f_id_display} — ${f_desc_short:-unknown task}"
 
 			if [[ "$f_err" == *"superseded"* ]]; then
 				cat_superseded="${cat_superseded}${f_entry}


### PR DESCRIPTION
## Summary

- Task IDs in the health dashboard Alerts section now link to their GitHub issues
- Extracts `ref:GH#NNNN` from task descriptions to build `[tNNN](https://github.com/owner/repo/issues/NNNN)` links
- Tasks without a GitHub issue ref fall back to plain `` `tNNN` `` format

## Before

```
  - `t1155` — Verify and resolve 6 high-severity audit findings
  - `t1161.4` — Wire update_claude_config() into setup.sh
```

## After

```
  - [t1155](https://github.com/marcusquinn/aidevops/issues/1737) — Verify and resolve 6 high-severity audit findings
  - [t1161.4](https://github.com/marcusquinn/aidevops/issues/1758) — Wire update_claude_config() into setup.sh
  - `t1300` — Investigate t1165.1 repeated failures (no GH issue — fallback)
```

## Testing

- Dry-run tested against live DB: 7 of 8 aidevops failed tasks linked, 1 (t1300, diagnostic task) falls back correctly
- ShellCheck: zero new violations
- Change: +10/-1 lines in `issue-sync.sh`