### PR TITLE
t1165: Verify — containerized Claude Code CLI instances for multi-subscription scaling

### DIFF
--- a/tests/test-multi-container-batch-dispatch.sh
+++ b/tests/test-multi-container-batch-dispatch.sh
@@ -304,7 +304,7 @@ fi
 # ============================================================
 section "OAuth Routing Across Containers"
 
-# Test: Anthropic model (opus) routes to claude CLI when OAuth available
+# Test: Anthropic model (opus) routes to opencode CLI (PR #2173 removed OAuth routing)
 oauth_opus_cli=$(
 	_run_isolated_test <<OAUTH_TEST
 #!/usr/bin/env bash
@@ -329,13 +329,13 @@ rm -rf "\$mock_home"
 OAUTH_TEST
 )
 
-if [[ "$oauth_opus_cli" == "claude" ]]; then
-	pass "OAuth routing: anthropic/claude-opus-4-6 -> claude CLI"
+if [[ "$oauth_opus_cli" == "opencode" ]]; then
+	pass "CLI routing: anthropic/claude-opus-4-6 -> opencode (PR #2173: opencode is sole worker CLI)"
 else
-	fail "OAuth routing: opus should route to claude" "Got: '$oauth_opus_cli'"
+	fail "CLI routing: opus should route to opencode" "Got: '$oauth_opus_cli'"
 fi
 
-# Test: Anthropic sonnet model also routes to claude CLI
+# Test: Anthropic sonnet model also routes to opencode CLI (PR #2173)
 oauth_sonnet_cli=$(
 	_run_isolated_test <<OAUTH_TEST2
 #!/usr/bin/env bash
@@ -360,10 +360,10 @@ rm -rf "\$mock_home"
 OAUTH_TEST2
 )
 
-if [[ "$oauth_sonnet_cli" == "claude" ]]; then
-	pass "OAuth routing: anthropic/claude-sonnet-4-6 -> claude CLI"
+if [[ "$oauth_sonnet_cli" == "opencode" ]]; then
+	pass "CLI routing: anthropic/claude-sonnet-4-6 -> opencode (PR #2173: opencode is sole worker CLI)"
 else
-	fail "OAuth routing: sonnet should route to claude" "Got: '$oauth_sonnet_cli'"
+	fail "CLI routing: sonnet should route to opencode" "Got: '$oauth_sonnet_cli'"
 fi
 
 # Test: Non-Anthropic model routes to opencode CLI even with OAuth
@@ -462,7 +462,7 @@ else
 	fail "OAuth routing: bare tier should route to opencode" "Got: '$oauth_bare_tier_cli'"
 fi
 
-# Test: Fully-qualified Anthropic haiku routes to claude
+# Test: Fully-qualified Anthropic haiku routes to opencode (PR #2173)
 oauth_fq_haiku_cli=$(
 	_run_isolated_test <<OAUTH_TEST6
 #!/usr/bin/env bash
@@ -487,10 +487,10 @@ rm -rf "\$mock_home"
 OAUTH_TEST6
 )
 
-if [[ "$oauth_fq_haiku_cli" == "claude" ]]; then
-	pass "OAuth routing: anthropic/claude-haiku-3 -> claude CLI"
+if [[ "$oauth_fq_haiku_cli" == "opencode" ]]; then
+	pass "CLI routing: anthropic/claude-haiku-3 -> opencode (PR #2173: opencode is sole worker CLI)"
 else
-	fail "OAuth routing: fully-qualified haiku should route to claude" "Got: '$oauth_fq_haiku_cli'"
+	fail "CLI routing: fully-qualified haiku should route to opencode" "Got: '$oauth_fq_haiku_cli'"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

- Verification of t1165 (containerized Claude Code CLI instances for multi-subscription scaling)
- Fixed 3 stale OAuth routing tests that expected `claude` CLI but should expect `opencode` after PR #2173

## Verification Results

**Subtask status:**
| Subtask | Status | PR |
|---------|--------|-----|
| t1165.3 Remote container support | Merged | #2109 |
| t1165.4 Integration test | Merged | #2111 |
| t1165.1 Container image design | Open (TODO) | - |
| t1165.2 Container pool manager | Open (TODO) | - |

**Delivered artifacts (on main):**
- `remote-dispatch-helper.sh` — 1057-line SSH/Tailscale dispatch helper (host config, dispatch, logs, status, cleanup)
- `remote-dispatch.md` — comprehensive subagent documentation
- `test-multi-container-batch-dispatch.sh` — 1161-line integration test (70 tests)
- Supervisor integration in `dispatch.sh` and `pulse.sh` (dispatch_target routing)
- `orbstack.md` — OrbStack container runtime documentation

**Test results:** 70/70 pass (ShellCheck clean, bash -n clean)

**What was fixed:** 3 OAuth routing tests expected `claude` CLI for Anthropic models, but PR #2173 (merged 2026-02-22) removed OAuth routing — opencode is now the sole worker CLI. Updated test expectations to match.

**Remaining work (t1165.1, t1165.2):** Container image Dockerfile and container pool manager are not yet implemented. These are marked as open in TODO.md. The remote dispatch infrastructure (t1165.3) and integration tests (t1165.4) are complete and functional.

## VERIFY_INCOMPLETE

t1165.3 and t1165.4 are complete and verified. t1165.1 (container image) and t1165.2 (pool manager) remain open. This PR fixes the stale test expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated OAuth routing tests for Anthropic models to align with current routing behavior and ensure test expectations match implementation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->