### PR TITLE
t1312: Interactive brief generation with /define slash command

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -26,7 +26,7 @@ Subagent write restrictions: on `main`/`master`, subagents may ONLY write to `RE
 
 ## Development Lifecycle
 
-1. Create TODO entry **with brief** before starting work
+1. Define the task: `/define` (interactive interview) or `/new-task` (quick creation)
 2. Brief file at `todo/tasks/{task_id}-brief.md` is MANDATORY (see `templates/brief-template.md`)
 3. Brief must include: session origin, what, why, how, acceptance criteria, context
 4. Ask user: implement now or queue for runner?
@@ -60,7 +60,7 @@ Format: `- [ ] t001 Description @owner #tag ~4h started:ISO blocked-by:t002`
 
 Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
-**Task briefs are MANDATORY.** Every task must have `todo/tasks/{task_id}-brief.md` capturing: session origin, what, why, how, acceptance criteria, and conversation context. Use `templates/brief-template.md`. A task without a brief loses the knowledge that created it.
+**Task briefs are MANDATORY.** Every task must have `todo/tasks/{task_id}-brief.md` capturing: session origin, what, why, how, acceptance criteria, and conversation context. Use `/define` for interactive brief generation with latent criteria probing, or `/new-task` for quick creation from `templates/brief-template.md`. A task without a brief loses the knowledge that created it.
 
 Auto-dispatch: `#auto-dispatch` tag — only if brief has 2+ acceptance criteria, file references in How section, and clear deliverable in What section. Add `assignee:` before pushing if working interactively.
 
@@ -87,7 +87,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Domain | Entry point |
 |--------|-------------|
 | Business | `business.md`, `business/company-runners.md` |
-| Planning | `workflows/plans.md`, `tools/task-management/beads.md` |
+| Planning | `workflows/plans.md`, `scripts/commands/define.md`, `tools/task-management/beads.md` |
 | Code quality | `tools/code-review/code-standards.md` |
 | Git/PRs/Releases | `workflows/git-workflow.md`, `tools/git/github-cli.md`, `workflows/release.md` |
 | Documents/PDF | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |

--- a/.agents/reference/define-probes/bugfix.md
+++ b/.agents/reference/define-probes/bugfix.md
@@ -1,0 +1,107 @@
+---
+description: Probing questions for bugfix tasks — surfaces reproduction context and regression risks
+mode: subagent
+---
+
+# Bugfix Probes
+
+Use 2 probes from this file during `/define` for tasks classified as **bugfix**.
+
+## Default Assumptions
+
+Apply these unless the user overrides during interview:
+
+- Preserve all existing behaviour except the bug
+- Add a regression test that fails before the fix and passes after
+- Root-cause fix preferred over symptom suppression
+- No scope creep — fix the reported bug, not adjacent issues
+
+## Structured Questions
+
+### Reproduction
+
+```text
+Can you reproduce this bug reliably?
+
+1. Yes — here are the steps: [user provides]
+2. Intermittent — happens sometimes under [conditions]
+3. Reported by others — I haven't reproduced it myself
+4. Only in production / specific environment
+```
+
+### Expected vs Actual
+
+```text
+What's the expected behaviour vs what actually happens?
+
+1. [Inferred from description] (recommended)
+2. Let me describe both explicitly
+```
+
+## Probes (select 2)
+
+### Root Cause vs Symptom
+
+```text
+Is the fix you have in mind addressing the root cause or a symptom?
+
+1. Root cause — I know why it breaks (recommended)
+2. Symptom — I know a workaround but not the underlying issue
+3. Not sure — needs investigation first
+```
+
+### Blast Radius
+
+```text
+What else could break when this is fixed?
+
+1. Nothing — the fix is isolated to one code path (recommended)
+2. Related features that share the same code path
+3. Not sure — need to trace dependencies
+4. Let me specify what's at risk
+```
+
+### Regression Context
+
+```text
+Did this work before? If so, what changed?
+
+1. Yes — broke after a recent commit/deploy (regression)
+2. Never worked correctly — latent bug
+3. Works in some environments but not others
+4. Not sure when it started
+```
+
+### Assumption Surfacing
+
+```text
+I'm assuming this bug affects [inferred scope — e.g., "all users" or "only mobile"].
+Is that correct?
+
+1. Yes — affects [scope]
+2. No — it's narrower: [user specifies]
+3. No — it's broader: [user specifies]
+```
+
+### Pre-mortem
+
+```text
+Imagine the fix ships but the bug comes back in a different form.
+What's the most likely variant?
+
+1. Same root cause, different trigger (recommended)
+2. Fix introduces a new bug in adjacent code
+3. Fix works locally but not in production
+4. The original report was incomplete — there's a deeper issue
+```
+
+## Sufficiency Test
+
+Before generating the brief, verify you can answer:
+
+- Can I reproduce this (or do I have clear reproduction steps)?
+- Do I know the root cause or at least where to look?
+- What regression test would catch this if it recurs?
+- What's the blast radius of the fix?
+
+If any answer is "I don't know" — ask one more targeted question.

--- a/.agents/reference/define-probes/docs.md
+++ b/.agents/reference/define-probes/docs.md
@@ -1,0 +1,98 @@
+---
+description: Probing questions for documentation tasks — surfaces audience, accuracy, and maintenance concerns
+mode: subagent
+---
+
+# Docs Probes
+
+Use 2 probes from this file during `/define` for tasks classified as **docs**.
+
+## Default Assumptions
+
+Apply these unless the user overrides during interview:
+
+- Follow existing documentation patterns and style in the project
+- Accurate and verifiable — no speculative claims
+- Concise — prefer examples over lengthy explanations
+- Maintainable — don't document implementation details that change frequently
+
+## Structured Questions
+
+### Audience
+
+```text
+Who is the primary reader of this documentation?
+
+1. Developers using this project (recommended)
+2. Contributors to this project
+3. End users (non-technical)
+4. AI agents / automated systems
+```
+
+### Format
+
+```text
+What format should this take?
+
+1. Inline code comments / docstrings
+2. Markdown file (README, guide, reference) (recommended)
+3. API documentation (OpenAPI, JSDoc, etc.)
+4. Tutorial / walkthrough with examples
+```
+
+## Probes (select 2)
+
+### Accuracy Verification
+
+```text
+How will you verify the documentation is accurate?
+
+1. Run the examples / commands described (recommended)
+2. Cross-reference with source code
+3. Review by someone who uses the feature
+4. It's conceptual — accuracy is about clarity, not runnable examples
+```
+
+### Staleness Risk
+
+```text
+How likely is this documentation to become stale?
+
+1. Low — documents stable interfaces or concepts (recommended)
+2. Medium — documents features that evolve quarterly
+3. High — documents implementation details that change frequently
+4. Not sure
+```
+
+### Negative Space
+
+```text
+What's the most common mistake someone would make after reading this?
+
+1. Misunderstanding the scope — thinking it covers more than it does
+2. Missing a prerequisite or setup step
+3. Using an outdated example
+4. Nothing obvious — the topic is straightforward
+```
+
+### Backcasting
+
+```text
+After reading this documentation, what should the reader be able to do?
+
+1. [Inferred from task description] (recommended)
+2. Understand the concept but not necessarily implement it
+3. Follow step-by-step to a working result
+4. Let me specify the learning outcome
+```
+
+## Sufficiency Test
+
+Before generating the brief, verify you can answer:
+
+- Who reads this and what do they need to do afterwards?
+- What existing docs does this complement or replace?
+- How will accuracy be verified?
+- What's the maintenance burden?
+
+If any answer is "I don't know" — ask one more targeted question.

--- a/.agents/reference/define-probes/feature.md
+++ b/.agents/reference/define-probes/feature.md
@@ -1,0 +1,112 @@
+---
+description: Probing questions for feature tasks — surfaces latent requirements before implementation
+mode: subagent
+---
+
+# Feature Probes
+
+Use 2 probes from this file during `/define` for tasks classified as **feature**.
+
+## Default Assumptions
+
+Apply these unless the user overrides during interview:
+
+- Minimal footprint — no new dependencies without discussion
+- Follow existing patterns in the codebase
+- Include tests for new behaviour
+- No breaking changes to existing APIs
+
+## Structured Questions
+
+### Scope & Integration
+
+```text
+Where does this feature live in the user's workflow?
+
+1. Standalone — accessed from a menu/command/button (recommended)
+2. Inline — embedded in an existing flow
+3. Background — runs automatically without user action
+4. Let me describe the integration point
+```
+
+### Data & State
+
+```text
+Does this feature need to persist state?
+
+1. No — stateless, computed on demand (recommended)
+2. Yes — local storage / file system
+3. Yes — database / API
+4. Not sure yet
+```
+
+## Probes (select 2)
+
+### Pre-mortem
+
+```text
+Imagine this feature ships and a user reports a problem within the first week.
+What's the most likely complaint?
+
+1. [Inferred from feature description — e.g., "It doesn't handle edge case X"] (recommended)
+2. Performance is too slow for large inputs
+3. The UI is confusing or hard to discover
+4. It conflicts with an existing feature
+```
+
+### Backcasting
+
+```text
+Working backwards from "done" — what's the very last thing you'd verify
+before calling this complete?
+
+1. End-to-end test passes with realistic data (recommended)
+2. Documentation is updated
+3. Existing features still work (regression check)
+4. Let me specify
+```
+
+### Domain Grounding
+
+```text
+Similar features in this codebase follow [detected pattern].
+Should this feature:
+
+1. Follow the same pattern (recommended — consistency)
+2. Diverge — here's why: [user explains]
+3. I'm not sure what pattern exists — show me
+```
+
+### Negative Space
+
+```text
+What would make a technically correct implementation unacceptable?
+
+1. If it's too slow (>Xs response time)
+2. If it requires a migration or breaking change
+3. If it adds significant bundle size / dependencies
+4. Nothing — correctness is sufficient
+```
+
+### Outside View
+
+```text
+Features of this scope in this project typically take [estimated time].
+Does that match your expectation?
+
+1. Yes — that's about right
+2. No — this should be simpler (~Xh)
+3. No — this is more complex (~Xh)
+4. I have no estimate yet
+```
+
+## Sufficiency Test
+
+Before generating the brief, verify you can answer:
+
+- What does the user see/experience when this is done?
+- What existing code does this touch?
+- What would a code reviewer reject?
+- What's the one edge case most likely to be missed?
+
+If any answer is "I don't know" — ask one more targeted question.

--- a/.agents/reference/define-probes/refactor.md
+++ b/.agents/reference/define-probes/refactor.md
@@ -1,0 +1,111 @@
+---
+description: Probing questions for refactor tasks — surfaces behaviour preservation constraints and migration risks
+mode: subagent
+---
+
+# Refactor Probes
+
+Use 2 probes from this file during `/define` for tasks classified as **refactor**.
+
+## Default Assumptions
+
+Apply these unless the user overrides during interview:
+
+- Zero behaviour changes — all existing tests must pass unchanged
+- No new dependencies
+- Improve readability, maintainability, or performance (pick one primary goal)
+- If tests don't exist for the refactored code, add them before refactoring
+
+## Structured Questions
+
+### Primary Goal
+
+```text
+What's the main reason for this refactor?
+
+1. Readability — code is hard to understand or maintain (recommended)
+2. Performance — current implementation is too slow
+3. Extensibility — need to add features and current structure blocks it
+4. Duplication — same logic exists in multiple places
+5. Let me explain
+```
+
+### Scope Boundary
+
+```text
+How far should this refactor go?
+
+1. Minimal — only the specific file/function mentioned (recommended)
+2. Module-level — refactor the entire module for consistency
+3. Cross-cutting — follow the pattern change across the codebase
+4. Let me specify the boundary
+```
+
+## Probes (select 2)
+
+### Behaviour Preservation
+
+```text
+How will you verify that behaviour hasn't changed?
+
+1. Existing tests cover it — they must all pass (recommended)
+2. No tests exist — I'll add them before refactoring
+3. Manual testing against specific scenarios
+4. Type system / compiler will catch regressions
+```
+
+### Outside View
+
+```text
+Refactors of this scope in this codebase typically follow [detected pattern].
+Should this refactor:
+
+1. Follow the same approach (recommended — consistency)
+2. Establish a new pattern — here's why: [user explains]
+3. I'm not sure what the existing pattern is
+```
+
+### Pre-mortem
+
+```text
+Imagine this refactor is merged and something breaks in production.
+What's the most likely cause?
+
+1. A code path that wasn't covered by tests (recommended)
+2. Subtle behaviour change in edge cases
+3. Performance regression under load
+4. Downstream consumers that depend on internal implementation details
+```
+
+### Assumption Surfacing
+
+```text
+I'm assuming this refactor should NOT change the public API / interface.
+Is that correct?
+
+1. Correct — internal changes only (recommended)
+2. No — the API should change too (this might be a feature, not a refactor)
+3. The API can change if callers are updated in the same PR
+```
+
+### Domain Grounding
+
+```text
+The [language/framework] community typically recommends [pattern] for this kind of restructuring.
+Does that apply here?
+
+1. Yes — follow the standard approach (recommended)
+2. Partially — adapt it because [reason]
+3. No — this codebase has its own conventions
+```
+
+## Sufficiency Test
+
+Before generating the brief, verify you can answer:
+
+- What tests exist for the code being refactored?
+- What's the public API that must not change?
+- What's the primary metric that improves (readability/performance/extensibility)?
+- What would a code reviewer check to verify behaviour preservation?
+
+If any answer is "I don't know" — ask one more targeted question.

--- a/.agents/reference/define-probes/research.md
+++ b/.agents/reference/define-probes/research.md
@@ -1,0 +1,113 @@
+---
+description: Probing questions for research/spike tasks — surfaces time-box, deliverable format, and decision criteria
+mode: subagent
+---
+
+# Research Probes
+
+Use 2 probes from this file during `/define` for tasks classified as **research**.
+
+## Default Assumptions
+
+Apply these unless the user overrides during interview:
+
+- Time-boxed — research without a deadline expands indefinitely
+- Deliverable is a written recommendation, not code
+- Compare at least 2 options (never recommend without alternatives)
+- Include cost/effort estimates for each option
+
+## Structured Questions
+
+### Time Box
+
+```text
+How much time should be spent on this research?
+
+1. 30 minutes — quick comparison (recommended for simple evaluations)
+2. 1-2 hours — thorough analysis with examples
+3. Half day — deep dive with prototypes
+4. Let me specify
+```
+
+### Deliverable Format
+
+```text
+What should the research produce?
+
+1. Written recommendation with pros/cons table (recommended)
+2. Prototype / proof of concept
+3. Decision document for team review
+4. Just a verbal summary in this conversation
+```
+
+## Probes (select 2)
+
+### Decision Criteria
+
+```text
+What matters most when choosing between options?
+
+1. Cost (monetary or compute) (recommended if comparing services/tools)
+2. Developer experience / ease of integration
+3. Performance / scalability
+4. Community support / longevity
+5. Let me rank my priorities
+```
+
+### Assumption Surfacing
+
+```text
+I'm assuming the decision will be made by [you / the team / a specific person].
+Who needs to be convinced?
+
+1. Just me — I'll decide based on the research (recommended)
+2. The team — needs to be presentable
+3. A specific stakeholder — needs to address their concerns
+4. No decision needed — this is exploratory
+```
+
+### Outside View
+
+```text
+Have you or the team evaluated similar options before?
+What was the outcome?
+
+1. Yes — we chose [X] last time, checking if it's still the best option
+2. Yes — we rejected [X] last time, want to reconsider
+3. No — this is a new area for us
+4. Not sure — I'll check
+```
+
+### Pre-mortem
+
+```text
+Imagine you pick an option based on this research and regret it 3 months later.
+What's the most likely reason?
+
+1. Hidden costs or limitations that weren't obvious during evaluation (recommended)
+2. The chosen option doesn't scale as expected
+3. A better option emerged after the decision
+4. The evaluation criteria were wrong
+```
+
+### Backcasting
+
+```text
+After this research is done, what's the next concrete action?
+
+1. Implement the recommended option (recommended)
+2. Present findings and get approval
+3. Create a task/brief for the implementation
+4. Nothing immediate — this is for future reference
+```
+
+## Sufficiency Test
+
+Before generating the brief, verify you can answer:
+
+- What's the time box?
+- What format is the deliverable?
+- What are the decision criteria, ranked?
+- Who makes the final decision?
+
+If any answer is "I don't know" — ask one more targeted question.

--- a/.agents/scripts/commands/define.md
+++ b/.agents/scripts/commands/define.md
@@ -1,0 +1,252 @@
+---
+description: Interactive brief generation — interview the user to surface latent requirements before creating a task brief
+agent: Build+
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+---
+
+Interview the user to define a task with full context, then generate a complete brief from `templates/brief-template.md`.
+
+Topic: $ARGUMENTS
+
+## Purpose
+
+Surface implicit requirements before code is written. Most task failures come from unstated assumptions, not implementation bugs. This command runs a structured interview that:
+
+1. Classifies the task type (feature/bugfix/refactor/docs/research)
+2. Asks concrete questions with 2-4 options (one recommended)
+3. Probes for latent criteria the user hasn't thought to mention
+4. Generates a complete brief ready for `/full-loop` or `/new-task`
+
+Inspired by [manifest-dev](https://github.com/doodledood/manifest-dev) but lighter — single brief output instead of manifest + discovery log + verifier agent.
+
+## Workflow
+
+### Step 1: Classify Task Type
+
+Parse `$ARGUMENTS` to classify the task. Use keyword signals:
+
+| Type | Signal Words | Default Assumptions |
+|------|-------------|---------------------|
+| **feature** | add, create, build, implement, new | Minimal footprint, no new deps without discussion |
+| **bugfix** | fix, broken, wrong, error, crash, regression | Preserve all other behaviour, add regression test |
+| **refactor** | clean, restructure, improve, simplify, extract | No behaviour changes, all tests must still pass |
+| **docs** | document, readme, guide, explain, describe | Accurate, concise, follows existing doc patterns |
+| **research** | investigate, explore, evaluate, compare, spike | Time-boxed, deliverable is a written recommendation |
+
+If ambiguous, ask:
+
+```text
+What type of task is this?
+
+1. Feature — adding new capability (recommended based on your description)
+2. Bug fix — correcting broken behaviour
+3. Refactor — restructuring without behaviour change
+4. Docs — documentation or guides
+5. Research — investigation with written deliverable
+```
+
+Store the classification for probe selection in Step 3.
+
+### Step 2: Structured Interview (3-5 questions)
+
+Ask questions sequentially. Each question offers 2-4 concrete options with one recommended. Adapt based on task type.
+
+**Core questions (all types):**
+
+**Q1: Goal** (always first)
+
+```text
+In one sentence, what must this task produce?
+
+1. [Inferred goal from $ARGUMENTS] (recommended)
+2. Let me describe it differently
+```
+
+**Q2: Scope boundary**
+
+```text
+What is explicitly NOT in scope?
+
+1. [Inferred exclusion based on task type] (recommended)
+2. Nothing — keep scope open
+3. Let me specify exclusions
+```
+
+**Q3: Success criteria**
+
+```text
+How will you know this is done? Pick the verification approach:
+
+1. Automated tests pass (unit/integration) (recommended for feature/bugfix)
+2. Manual verification against specific scenario
+3. Code review approval is sufficient
+4. Let me define custom criteria
+```
+
+**Type-specific questions** — load from `reference/define-probes/{type}.md`:
+
+```bash
+probe_file="$HOME/.aidevops/agents/reference/define-probes/${task_type}.md"
+```
+
+Read the probe file for the classified type and ask 1-2 additional questions from it.
+
+### Step 3: Latent Criteria Probing
+
+After the structured interview, run exactly **2 probes** selected from the task-type probe file. These use established techniques to surface requirements the user hasn't thought to mention:
+
+| Technique | Question Pattern | When to Use |
+|-----------|-----------------|-------------|
+| **Domain grounding** | "In [domain], the usual pitfall is X. Does that apply here?" | Always — grounds in real patterns |
+| **Pre-mortem** | "Imagine this ships and fails. What went wrong?" | Features, refactors |
+| **Backcasting** | "Working backwards from 'done' — what's the last thing you'd verify?" | Features, research |
+| **Outside view** | "Similar tasks in this codebase took N approach. Should we follow or diverge?" | Refactors, features |
+| **Negative space** | "What would make a correct solution unacceptable?" | All types |
+| **Assumption surfacing** | "I'm assuming X — correct, or should it be Y?" | All types |
+
+Present probes as concrete questions with options, not open-ended prompts.
+
+### Step 4: Sufficiency Gate
+
+Before generating the brief, internally verify:
+
+> "Do I know enough to predict what a code review would reject?"
+
+If NO — ask one more targeted question. Maximum total questions: 7 (including probes).
+
+If YES — proceed to brief generation.
+
+### Step 5: Generate Brief
+
+Read `templates/brief-template.md` and populate every section from interview answers:
+
+```bash
+# Read the template
+cat ~/.aidevops/agents/reference/../templates/brief-template.md
+```
+
+Map interview answers to brief sections:
+
+| Interview Data | Brief Section |
+|---------------|---------------|
+| Task type + goal | **What** |
+| Why this matters (from probes) | **Why** |
+| Scope + exclusions | **Context & Decisions** (non-goals) |
+| Success criteria | **Acceptance Criteria** |
+| Domain grounding results | **How (Approach)** |
+| Pre-mortem / negative space | **Acceptance Criteria** (negative criteria) |
+| Files mentioned | **Relevant Files** |
+
+### Step 6: Present and Confirm
+
+Show the generated brief in full, then offer:
+
+```text
+Brief generated for: {task_type} — "{goal}"
+
+[Full brief content]
+
+---
+
+Next steps:
+
+1. Save brief and create task (/new-task) (recommended)
+2. Edit brief before saving
+3. Save brief only (no TODO.md entry)
+4. Start over with different answers
+```
+
+If the user chooses 1, delegate to `/new-task` with the brief content pre-populated.
+
+## Headless Mode
+
+When `--headless` is passed or `$ARGUMENTS` contains ` -- ` (supervisor dispatch), skip the interview and generate the brief directly from the inline description:
+
+```text
+/define --headless -- Add retry logic to API client with exponential backoff
+```
+
+In headless mode:
+1. Auto-classify task type from description
+2. Apply default assumptions for that type
+3. Generate brief with `Created by: ai-supervisor` in Origin
+4. Write brief to `todo/tasks/{task_id}-brief.md`
+5. No confirmation prompt — save immediately
+
+## Examples
+
+```text
+User: /define Add a dark mode toggle to settings
+
+AI: Classifying: **feature** (adding new capability)
+
+Q1: In one sentence, what must this task produce?
+  1. A toggle in the settings page that switches the app between light and dark themes (recommended)
+  2. Let me describe it differently
+
+User: 1
+
+AI: Q2: What is explicitly NOT in scope?
+  1. Per-component theming — just a global light/dark switch (recommended)
+  2. Nothing — keep scope open
+  3. Let me specify exclusions
+
+User: 1
+
+AI: Q3: How will you know this is done?
+  1. Toggle works, theme persists across page reloads, no visual regressions (recommended)
+  2. Manual verification only
+  3. Let me define custom criteria
+
+User: 1
+
+AI: [Pre-mortem probe] Imagine this ships and a user reports a bug. What's most likely?
+  1. Some components don't respect the theme (CSS specificity issues) (recommended)
+  2. Theme resets on navigation
+  3. Performance issues from re-rendering
+  4. Something else
+
+User: 1
+
+AI: [Domain grounding] Dark mode implementations typically need a CSS variable system
+   or a theme provider. Does this project already have one?
+  1. Yes — extend the existing system
+  2. No — create a minimal one
+  3. Not sure — I'll check
+
+User: 2
+
+AI: Brief generated for: feature — "Dark mode toggle in settings"
+
+[Shows complete brief]
+
+Next steps:
+1. Save brief and create task (/new-task) (recommended)
+2. Edit brief before saving
+3. Save brief only
+4. Start over
+```
+
+```text
+User: /define fix the login timeout on mobile
+
+AI: Classifying: **bugfix** (correcting broken behaviour)
+
+Q1: What's the expected vs actual behaviour?
+  1. Users should stay logged in for 24h but get logged out after ~5 minutes on mobile (recommended if this matches)
+  2. Let me describe the bug differently
+
+[... continues with bugfix-specific questions ...]
+```
+
+## Related
+
+- `templates/brief-template.md` — Output template
+- `reference/define-probes/` — Per-type probing questions
+- `scripts/commands/new-task.md` — Task creation (called after brief generation)
+- `workflows/plans.md` — Planning workflow integration

--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -6,6 +6,8 @@ mode: subagent
 
 Allocate a new task ID using `claim-task-id.sh` (distributed lock via GitHub/GitLab issue creation) and add it to TODO.md.
 
+For complex tasks where requirements are unclear, use `/define` first — it runs an interactive interview to surface latent criteria before creating the brief.
+
 Topic/context: $ARGUMENTS
 
 ## Workflow


### PR DESCRIPTION
## Summary

- Adds `/define` slash command that interviews the user before creating a task brief
- Classifies task type (feature/bugfix/refactor/docs/research) from keywords
- Runs structured interview with concrete options (2-4 per question, one recommended)
- Probes for latent criteria via domain grounding, pre-mortem, backcasting, outside view, negative space, assumption surfacing
- Generates complete brief from `templates/brief-template.md`
- Per-type probing questions in `.agents/reference/define-probes/`
- Supports headless mode for supervisor dispatch

Inspired by manifest-dev's `/define` workflow (doodledood/manifest-dev) but adapted to be lighter — single brief output instead of manifest + discovery log + verifier agent.

Ref #2178

## Files

- `.agents/scripts/commands/define.md` — main slash command entry point
- `.agents/reference/define-probes/feature.md` — feature task probes
- `.agents/reference/define-probes/bugfix.md` — bugfix task probes
- `.agents/reference/define-probes/refactor.md` — refactor task probes
- `.agents/reference/define-probes/docs.md` — documentation task probes
- `.agents/reference/define-probes/research.md` — research/spike task probes