### PR TITLE
fix: guard MEMORY_DB unbound variable crashing supervisor pulse

### DIFF
--- a/.agents/scripts/supervisor/memory-integration.sh
+++ b/.agents/scripts/supervisor/memory-integration.sh
@@ -104,7 +104,7 @@ store_failure_pattern() {
 	local recent_count=0
 	local escaped_detail
 	escaped_detail="$(sql_escape "$outcome_detail")"
-	if [[ -r "$MEMORY_DB" ]]; then
+	if [[ -n "${MEMORY_DB:-}" && -r "$MEMORY_DB" ]]; then
 		recent_count=$(sqlite3 "$MEMORY_DB" \
 			"SELECT COUNT(*) FROM learnings WHERE type = 'FAILURE_PATTERN' AND content LIKE '%${escaped_detail}%' AND created_at > datetime('now', '-1 day');" \
 			2>/dev/null || echo "0")


### PR DESCRIPTION
## Summary

- Guards `MEMORY_DB` variable reference in `memory-integration.sh:107` with `${MEMORY_DB:-}` default
- `MEMORY_DB` is defined in `memory/_common.sh` but never sourced by `supervisor-helper.sh`, which sources `memory-integration.sh`
- Under `set -u` (nounset), the unbound variable crashes the pulse after task evaluation, preventing Phase 2+ (dispatch, lifecycle, health updates) from running
- This was the root cause of the pulse exit code 1 and the health issue going stale after 01:24 UTC

## Evidence

From `supervisor.log`:
```
/Users/marcusquinn/.aidevops/agents/scripts/supervisor/memory-integration.sh: line 107: MEMORY_DB: unbound variable
```

This error appeared after every task evaluation (t004.35, t004.36, t004.43), killing the pulse before it could reach Phase 3 (PR lifecycle) or update the health issue.