### PR TITLE
fix: clear dedup guard state on task reset

### DIFF
--- a/.agents/scripts/supervisor/state.sh
+++ b/.agents/scripts/supervisor/state.sh
@@ -638,6 +638,8 @@ cmd_reset() {
             pr_url = NULL,
             started_at = NULL,
             completed_at = NULL,
+            last_failure_at = NULL,
+            consecutive_failure_count = 0,
             updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
         WHERE id = '$escaped_id';
     "


### PR DESCRIPTION
## Summary

- `cmd_reset()` in `state.sh` clears `retries`, `error`, `session_id`, etc. when resetting a task to `queued`, but did **not** clear `last_failure_at` or `consecutive_failure_count`
- This caused the dedup guard (`check_dispatch_dedup_guard`) to see stale failure counts and cancel tasks on their next dispatch attempt
- Root cause of t004.35 and t005.5 being falsely cancelled after manual re-queue

## Fix

Added `last_failure_at = NULL` and `consecutive_failure_count = 0` to the `cmd_reset()` UPDATE statement, matching what `reset_failure_dedup_state()` already does for successful completions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task reset operations now properly clear failure tracking metadata, ensuring a fresh state when resuming previously failed tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->