### PR TITLE
t1257: Add sequential dependency enforcement for t1120 subtask chain

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1591,9 +1591,9 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
   - Tested working prototype in a managed project repo: gitea-issue-sync.sh (separate script, ~600 lines)
   - Key findings from testing: (1) `set -euo pipefail` + grep in pipelines needs `{ grep ... || true; }` guard, (2) macOS sed `\s` doesn't work — use `[[:space:]]`, (3) dots in task IDs (t007.1) need escaping in sed patterns, (4) Gitea label API returns IDs not names (need ID array in create payload)
   - [x] t1120.1 Extract platform-agnostic functions from issue-sync-helper.sh (parse, compose, ref management) ~1h ref:GH#1676 assignee:marcusquinn started:2026-02-20T19:52:54Z pr:#2029 completed:2026-02-20
-  - [x] t1120.2 Add Gitea API adapter functions (create/close/edit/list/search/labels) ~1h ref:GH#1677 assignee:marcusquinn started:2026-02-20T21:24:40Z pr:#2031 completed:2026-02-20
+   - [x] t1120.2 Add Gitea API adapter functions (create/close/edit/list/search/labels) ~1h ref:GH#1677 blocked-by:t1120.1 assignee:marcusquinn started:2026-02-20T21:24:40Z pr:#2031 completed:2026-02-20
   - [x] t1120.3 Add platform detection from git remote URL + multi-platform push/pull/close ~1h ref:GH#1678 #auto-dispatch model:sonnet assignee:marcusquinn started:2026-02-18T22:07:40Z pr:#1815 completed:2026-02-18
-  - [x] t1120.4 Test with dual-hosted repo (GitHub + Gitea sync) ~30m ref:GH#1679 assignee:marcusquinn started:2026-02-20T22:21:08Z pr:#2033 completed:2026-02-20
+   - [x] t1120.4 Test with dual-hosted repo (GitHub + Gitea sync) ~30m ref:GH#1679 blocked-by:t1120.1 assignee:marcusquinn started:2026-02-20T22:21:08Z pr:#2033 completed:2026-02-20
 
 - [x] t1121 Fix tea CLI TTY requirement in non-interactive mode #bugfix #git ~30m model:haiku ref:GH#1680 assignee:marcusquinn started:2026-02-18T22:08:17Z logged:2026-02-18 #auto-dispatch pr:#1814 completed:2026-02-18
   - `tea issues list` fails with `huh: could not open a new TTY: open /dev/tty: device not configured` when run from scripts/CI


### PR DESCRIPTION
## Summary

Add explicit `blocked-by:t1120.1` dependencies to t1120.2 and t1120.4 to prevent simultaneous auto-dispatch of subtasks with implicit sequential dependencies.

## Problem

t1120.1 (extract functions), t1120.2 (add adapter), and t1120.4 (test) are all marked with `#auto-dispatch` and have no explicit dependencies. The supervisor's auto-dispatch Phase 0 could dispatch them simultaneously, causing t1120.2 and t1120.4 to fail because t1120.1 hasn't landed yet. This wastes dispatch cycles and creates false failures.

## Solution

Add `blocked-by:t1120.1` to both t1120.2 and t1120.4 in TODO.md to enforce the sequential dependency:
1. t1120.1 (extract functions) → completes
2. t1120.2 (add adapter) → unblocked, runs
3. t1120.4 (test) → unblocked, runs

This prevents wasted dispatch cycles and ensures proper ordering.

## Changes

- Added `blocked-by:t1120.1` to t1120.2 line in TODO.md
- Added `blocked-by:t1120.1` to t1120.4 line in TODO.md

## Verification

- [x] Changes applied to TODO.md
- [x] Commit message follows conventional format
- [x] Branch pushed to remote

Ref #1964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal task planning and workflow documentation to reflect enhanced cross-repository capabilities, improved automation resilience mechanisms, expanded verification and audit procedures, and strengthened consistency checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->