### PR TITLE
t1318-t1320: Migrate check_task_staleness() to AI, document mechanical modules

### DIFF
--- a/.agents/scripts/supervisor/cron.sh
+++ b/.agents/scripts/supervisor/cron.sh
@@ -375,6 +375,9 @@ cmd_watch() {
 # the unresolved blocker IDs to stdout. Returns 1 (not blocked)
 # if all dependencies are resolved or no blocked-by: field exists.
 #
+# t1319: Reviewed for AI migration — mechanical (parse field, check checkboxes).
+# No judgment calls — stays as shell plumbing.
+#
 # Args:
 #   $1 - task line from TODO.md
 #   $2 - path to TODO.md file
@@ -454,6 +457,9 @@ _check_and_skip_if_blocked() {
 # This prevents subtasks or tasks from private repos from being
 # picked up as if they belong to the current repo.
 #
+# t1319: Reviewed for AI migration — mechanical (DB lookup, string compare).
+# No judgment calls — stays as shell plumbing.
+#
 # Args:
 #   $1 - task_id (e.g. t004.1)
 #   $2 - current repo path being scanned
@@ -492,6 +498,11 @@ _is_cross_repo_misregistration() {
 # Scan TODO.md for tasks tagged #auto-dispatch or in a
 # "Dispatch Queue" section. Auto-adds them to supervisor
 # if not already tracked, then queues them for dispatch.
+#
+# t1319: Reviewed for AI migration — this function is mechanical filtering
+# (skip claimed, skip blocked, skip already tracked, skip cross-repo).
+# All guards are deterministic checks against DB/TODO.md state.
+# No judgment calls — stays as shell plumbing.
 #######################################
 cmd_auto_pickup() {
 	local repo=""

--- a/.agents/scripts/supervisor/state.sh
+++ b/.agents/scripts/supervisor/state.sh
@@ -2,6 +2,14 @@
 # state.sh - State machine and task/batch status functions
 #
 # Functions for state transitions, status queries, and task lifecycle
+#
+# t1320: Reviewed for AI migration — all functions in this module are mechanical:
+# - validate_transition(): state machine lookup (array scan)
+# - cmd_transition(): DB update with validation
+# - cmd_status/cmd_list(): DB queries + formatting
+# - check_batch_completion(): count incomplete tasks (SQL aggregate)
+# - cmd_next(): task selection with sibling limits + round-robin (SQL + arithmetic)
+# No judgment calls — entire module stays as shell plumbing.
 
 #######################################
 # Validate a state transition

--- a/.agents/scripts/supervisor/todo-sync.sh
+++ b/.agents/scripts/supervisor/todo-sync.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 # todo-sync.sh - Supervisor TODO.md synchronization functions
 # Part of the AI DevOps Framework supervisor module
+#
+# t1318: Reviewed for AI migration — all functions in this module are mechanical:
+# - commit_and_push_todo(): git commit/push with retry (plumbing)
+# - recover_stale_claims(): timestamp/threshold checks, ownership verification
+# - auto_unblock_resolved_tasks(): check TODO.md/DB for completed blockers
+# - update_todo_on_complete/cancelled/blocked(): text manipulation (sed/grep)
+# - cmd_reconcile_todo/db_todo(): DB↔TODO.md consistency checks
+# No judgment calls — entire module stays as shell plumbing.
 
 #######################################
 # Commit and push TODO.md with pull-rebase retry


### PR DESCRIPTION
## Summary

- **t1318**: Replace `check_task_staleness()` 180-line scoring heuristic in issue-sync.sh with AI judgment via sonnet. Keeps all 4 signal-gathering blocks (git log, git grep, git ls-files), removes numeric scoring threshold, sends structured evidence to AI for stale/uncertain/current verdict.
- **t1319**: Document `is_task_blocked()`, `_is_cross_repo_misregistration()`, and `cmd_auto_pickup()` in cron.sh as mechanical plumbing — no AI migration needed.
- **t1320**: Document all state.sh functions (`validate_transition`, `check_batch_completion`, `cmd_next`) as mechanical plumbing — no AI migration needed.
- **t1318**: Document all todo-sync.sh functions as mechanical plumbing — no AI migration needed.

## Changes

| File | Change |
|------|--------|
| `issue-sync.sh` | `check_task_staleness()`: gather signals as text → AI verdict (replaces numeric scoring) |
| `cron.sh` | Documentation: 3 functions confirmed as mechanical plumbing |
| `state.sh` | Documentation: all functions confirmed as mechanical plumbing |
| `todo-sync.sh` | Documentation: all functions confirmed as mechanical plumbing |

## Impact

- Net: +120/-33 lines (AI integration adds code, but removes all scoring heuristics)
- `check_task_staleness()` was the only real judgment call across all 4 remaining files
- Conservative fallback: returns "current" if AI unavailable
- No interface changes — same return codes (0=stale, 1=current, 2=uncertain)

## Verification

- `bash -n` syntax check: all 4 files pass
- `shellcheck -S warning`: zero violations on all 4 files
- Pattern follows proven `classify_task_complexity()` and `get_task_timeout()` migrations

Closes #2214, closes #2215, closes #2216