### PR TITLE
fix: blocked-by parser matches backtick-quoted code in task descriptions

### DIFF
--- a/.agents/scripts/supervisor/ai-actions.sh
+++ b/.agents/scripts/supervisor/ai-actions.sh
@@ -163,7 +163,7 @@ _compute_target_state_hash() {
 				local started
 				started=$(printf '%s' "$task_line" | grep -oE 'started:[^ ]+' || echo "")
 				local blocked
-				blocked=$(printf '%s' "$task_line" | grep -oE 'blocked-by:[^ ]+' || echo "")
+				blocked=$(printf '%s' "$task_line" | grep -oE 'blocked-by:t[0-9][^ ]*' || echo "")
 				local pr_field
 				pr_field=$(printf '%s' "$task_line" | grep -oE 'pr:#[0-9]+' || echo "")
 				# t1285: Include [proposed:...] annotations in state hash so

--- a/.agents/scripts/supervisor/ai-context.sh
+++ b/.agents/scripts/supervisor/ai-context.sh
@@ -466,7 +466,7 @@ build_todo_context() {
 			if [[ -n "$task_id" ]] && echo "$_db_done_ids" | grep -qxF "$task_id"; then
 				continue
 			fi
-			blocker=$(echo "$line" | grep -oE 'blocked-by:[^ ]+' | head -1)
+			blocker=$(echo "$line" | grep -oE 'blocked-by:t[0-9][^ ]*' | head -1)
 			output+="- $task_id ($blocker)\n"
 		done <<<"$blocked_tasks"
 	fi

--- a/.agents/scripts/supervisor/cron.sh
+++ b/.agents/scripts/supervisor/cron.sh
@@ -389,9 +389,10 @@ is_task_blocked() {
 	local task_line="$1"
 	local todo_file="$2"
 
-	# Extract blocked-by: field
+	# Extract blocked-by: field — require value to start with a task ID (tNNN)
+	# to avoid matching backtick-quoted mentions like `blocked-by:` in descriptions
 	local blocked_by
-	blocked_by=$(printf '%s' "$task_line" | grep -oE 'blocked-by:[^ ]+' | sed 's/blocked-by://' || true)
+	blocked_by=$(printf '%s' "$task_line" | grep -oE 'blocked-by:t[0-9][^ ]*' | sed 's/blocked-by://' || true)
 
 	if [[ -z "$blocked_by" ]]; then
 		return 1 # No dependencies — not blocked

--- a/.agents/scripts/supervisor/sanity-check.sh
+++ b/.agents/scripts/supervisor/sanity-check.sh
@@ -558,7 +558,7 @@ _execute_sanity_action() {
 		local current_line
 		current_line=$(sed -n "${line_num}p" "$todo_file")
 		local blocked_by
-		blocked_by=$(printf '%s' "$current_line" | grep -oE 'blocked-by:[^ ]+' | head -1 | sed 's/blocked-by://' || echo "")
+		blocked_by=$(printf '%s' "$current_line" | grep -oE 'blocked-by:t[0-9][^ ]*' | head -1 | sed 's/blocked-by://' || echo "")
 
 		if [[ -z "$blocked_by" ]]; then
 			echo "no blocked-by field found"

--- a/.agents/scripts/supervisor/todo-sync.sh
+++ b/.agents/scripts/supervisor/todo-sync.sh
@@ -1174,7 +1174,7 @@ auto_unblock_resolved_tasks() {
 
 		# Extract blocked-by dependencies
 		local blocked_by=""
-		blocked_by=$(printf '%s' "$line" | grep -oE 'blocked-by:[^ ]+' | head -1 | sed 's/blocked-by://' || echo "")
+		blocked_by=$(printf '%s' "$line" | grep -oE 'blocked-by:t[0-9][^ ]*' | head -1 | sed 's/blocked-by://' || echo "")
 		[[ -z "$blocked_by" ]] && continue
 
 		# Check each blocker


### PR DESCRIPTION
## Summary

- `blocked-by:[^ ]+` regex matches backticks from inline code in descriptions
- Tasks t1311 and t1314 were falsely blocked by dependency `` ` ``
- Fix: require value to start with task ID pattern `blocked-by:t[0-9]`
- Applied to all 5 affected files (cron.sh, ai-actions.sh, todo-sync.sh, sanity-check.sh, ai-context.sh)

## Impact

- t1311 and t1314 are now correctly picked up by auto-pickup
- Already deployed and verified working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined task blocker dependency recognition to only match properly formatted task ID references. Task blockers will now be correctly identified when they follow the standard task ID format, preventing misidentification of non-standard blocker references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->