### PR TITLE
t1323: Fix shell-local-params false-positives on currency/pricing text

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -795,6 +795,11 @@ function validatePositionalParams(filePath) {
         ) {
           continue;
         }
+        // Skip currency/pricing patterns: $[1-9] followed by digits, decimal, comma,
+        // or slash (e.g. $28/mo, $1.99, $1,000) — false-positives in markdown tables.
+        if (/\$[1-9][0-9.,/]/.test(trimmed)) {
+          continue;
+        }
         details.push(`  Line ${i + 1}: direct positional parameter: ${trimmed.substring(0, 80)}`);
         violations++;
       }
@@ -1505,7 +1510,9 @@ const BUILTIN_TTSR_RULES = [
     // Only match bare $N at the start of a line or after whitespace in what looks
     // like a shell assignment/command context — avoids matching $1 inside prose,
     // documentation, quoted examples, or tool output from file reads.
-    pattern: "^\\s+(?:echo|printf|return|if|\\[\\[).*\\$[1-9](?!.*local\\s+\\w+=)",
+    // Excludes currency/pricing patterns: $[1-9] followed by digits, decimal, comma,
+    // or slash (e.g. $28/mo, $1.99, $1,000) to prevent false-positives in markdown tables.
+    pattern: "^\\s+(?:echo|printf|return|if|\\[\\[).*\\$[1-9](?![0-9.,/])(?!.*local\\s+\\w+=)",
     correction: "Use `local var=\"$1\"` pattern — never use positional parameters directly (SonarCloud S7679).",
     severity: "warn",
     systemPrompt: "Shell scripts: use `local var=\"$1\"` — never use $1 directly in function bodies.",

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -187,6 +187,9 @@ check_positional_parameters() {
             /echo.*\$[1-9]/ { next }
             /print.*\$[1-9]/ { next }
             /Usage:/ { next }
+            # Skip currency/pricing patterns: $[1-9] followed by digit, decimal, comma,
+            # or slash (e.g. $28/mo, $1.99, $1,000) — false-positives in markdown tables.
+            /\$[1-9][0-9.,\/]/ { next }
             in_func && /\$[1-9]/ && !/local.*=.*\$[1-9]/ {
                 print FILENAME ":" NR ": " $0
             }

--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -77,9 +77,11 @@ validate_positional_parameters() {
 	print_info "Validating positional parameters..."
 
 	for file in "$@"; do
-		if [[ -f "$file" ]] && grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' >/dev/null; then
+		# Exclude currency/pricing patterns: $[1-9] followed by digit, decimal, comma,
+		# or slash (e.g. $28/mo, $1.99, $1,000) — false-positives in markdown tables.
+		if [[ -f "$file" ]] && grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' | grep -vE '\$[1-9][0-9.,/]' >/dev/null; then
 			print_error "Direct positional parameter usage in $file"
-			grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' | head -3
+			grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' | grep -vE '\$[1-9][0-9.,/]' | head -3
 			((violations++))
 		fi
 	done


### PR DESCRIPTION
## Summary

- Fixes false-positive violations from the `shell-local-params` TTSR rule when AI output contains currency/pricing text like `$28/mo`, `$1.99`, or `$1,000` in markdown tables
- The regex `$[1-9]` was matching dollar amounts (e.g. `$28` where `$2` is the positional param match) causing spurious correction injections
- Adds currency exclusion pattern: `$[1-9]` followed by `[0-9.,/]` is treated as a currency amount, not a shell positional parameter

## Changes

- `.agents/plugins/opencode-aidevops/index.mjs`: Updated TTSR rule pattern with negative lookahead `(?![0-9.,/])` + added currency skip in `validatePositionalParams()`
- `.agents/scripts/linters-local.sh`: Added awk rule to skip currency patterns
- `.agents/scripts/pre-commit-hook.sh`: Added `grep -vE '\$[1-9][0-9.,/]'` to exclude currency from grep chain

## Verification

- Regex tested: `$28/mo`, `$1.99`, `$1,000`, `$5.00/month` → no match (correct)
- Real violations `$1`, `$2`, `$3` still match (correct)
- ShellCheck: zero violations on modified `.sh` files

Ref #2194
Ref #2234