### PR TITLE
t1325: AI timeout architecture and deferred re-evaluation queue

### DIFF
--- a/.agents/scripts/supervisor/pulse.sh
+++ b/.agents/scripts/supervisor/pulse.sh
@@ -3209,6 +3209,13 @@ cmd_pulse() {
 		log_verbose "  Phase 14: AI pipeline disabled (SUPERVISOR_AI_ENABLED=false)"
 	fi
 
+	# Phase 15: Process deferred AI assessments (t1325)
+	# Retries AI assessments that failed due to timeout/unavailability in previous pulses.
+	# Runs late in the pulse cycle to avoid competing with active AI workloads.
+	if type process_deferred_assessments &>/dev/null; then
+		process_deferred_assessments 2>>"$SUPERVISOR_LOG" || true
+	fi
+
 	# t1052: Clear deferred batch completion flag to avoid leaking state
 	# if the supervisor process is reused for non-pulse commands
 	_PULSE_DEFER_BATCH_COMPLETION=""


### PR DESCRIPTION
## Summary

- Increases AI assessment timeouts from 15s to 30s across all assessment functions to prevent killing actively-working models
- Adds deferred re-evaluation queue (`pending-assessments.jsonl`) so fallback decisions from AI unavailability are retried on the next pulse instead of becoming permanent
- Hooks deferred assessment processing into pulse Phase 15

## Changes

### Timeout increases (15s → 30s)
- `check_task_staleness()` in issue-sync.sh
- `ai_detect_duplicate_issue()` in issue-sync.sh
- `ai_assess_auto_dispatch()` in issue-sync.sh
- `_ai_check_duplicate()` in issue-sync-helper.sh

### Deferred re-evaluation queue
- `queue_deferred_assessment()` — writes failed assessments to JSONL file
- `process_deferred_assessments()` — retries on next pulse, expires after 24h
- Wired into `create_github_issue()` for both dedup (exit 2) and auto-dispatch failures
- Wired into `issue-sync-helper.sh cmd_push()` for standalone dedup failures

### Auto-dispatch assessment
- Added `ai_assess_auto_dispatch()` call to `create_github_issue()` so newly created issues are evaluated for supervisor pickup

### Pulse integration
- `process_deferred_assessments()` runs as Phase 15 (after all active work)

## Problem solved

When AI is temporarily unavailable during a pulse:
- **Before**: Duplicate issues created permanently, tasks never get `#auto-dispatch`, stale tasks assumed current
- **After**: Failed assessments queued and retried on subsequent pulses until AI is available (24h expiry)

## Testing

- `bash -n` passes on all 3 modified files
- `shellcheck -S warning` passes with zero violations on all 3 files
- Hotfix deployed to `~/.aidevops/agents/scripts/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Extended AI operation timeouts from 15 to 30 seconds across issue assessment operations to reduce processing interruptions and improve system reliability.
  * Implemented automatic retry mechanism for AI assessments that encounter temporary failures, ensuring all issues receive proper evaluation. Expired retry attempts are automatically cleaned up after 24 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->