### PR TITLE
fix: resolve bare tier names to full model strings before DB storage

### DIFF
--- a/.agents/scripts/supervisor/batch.sh
+++ b/.agents/scripts/supervisor/batch.sh
@@ -119,6 +119,18 @@ cmd_add() {
 		fi
 	fi
 
+	# Resolve bare tier names (e.g., "sonnet", "opus") to full model strings
+	# (e.g., "anthropic/claude-sonnet-4-6") before storing in DB. Bare tier names
+	# cause model_config_error when passed to the CLI at dispatch time.
+	if [[ -n "$model" && "$model" != *"/"* ]]; then
+		local resolved_model
+		resolved_model=$(resolve_model "$model" "opencode" 2>/dev/null) || resolved_model=""
+		if [[ -n "$resolved_model" ]]; then
+			log_info "Task $task_id: resolved tier '$model' to '$resolved_model' for DB storage"
+			model="$resolved_model"
+		fi
+	fi
+
 	ensure_db
 
 	# Check if task already exists


### PR DESCRIPTION
## Summary

- **batch.sh**: `cmd_add()` extracted `model:sonnet` from TODO.md and stored the bare tier name in the DB. Workers received `sonnet` as the model string, causing `model_config_error_sonnet_invalid_provider_format`. Now resolves via `resolve_model()` before INSERT.
- **ai-actions.sh**: `_exec_escalate_model()` used wrong column name (`task_id` instead of `id`) so the UPDATE silently matched 0 rows. Also stored bare tier name. Fixed column, added `sql_escape()`, and `resolve_model()`.
- **dispatch.sh**: Dispatch metadata logged `resolved_model` before it was set (fell back to bare `$tmodel`). Moved model resolution before metadata write.

## Impact

- Fixes `model_config_error_sonnet_invalid_provider_format` failures (t003.5, t009.1)
- Fixes silent no-op in `_exec_escalate_model()` (wrong column name)
- Dispatch logs now show the actual resolved model, not the bare tier name
- Also cleaned up 13 existing bare tier names in the supervisor DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved model tier normalization before database persistence to ensure accurate record-keeping across agent operations
  * Enhanced resolution of bare model names to full model identifiers for consistency
  * Streamlined model resolution workflow to eliminate redundancy and ensure single source of truth for dispatched model selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->