### PR TITLE
t1328 + t1329: Matterbridge agent and cross-review judge pipeline

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -95,6 +95,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Content/Video/Voice | `content.md`, `tools/video/video-prompt-design.md`, `tools/voice/speech-to-speech.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |
 | WordPress | `tools/wordpress/wp-dev.md`, `tools/wordpress/mainwp.md` |
+| Communications | `services/communications/matterbridge.md`, `services/communications/simplex.md`, `services/communications/matrix-bot.md` |
 | Email | `tools/ui/react-email.md`, `services/email/email-testing.md` |
 | Payments | `services/payments/revenuecat.md`, `services/payments/stripe.md` |
 | Security/Encryption | `tools/security/tirith.md`, `tools/credentials/encryption-stack.md` |

--- a/.agents/scripts/commands/cross-review.md
+++ b/.agents/scripts/commands/cross-review.md
@@ -1,0 +1,99 @@
+---
+description: Dispatch the same prompt to multiple AI models, diff results, and optionally auto-score via a judge model
+agent: Build+
+mode: subagent
+---
+
+Dispatch a prompt to multiple AI models in parallel, collect and diff their responses, and optionally score them via a judge model.
+
+Target: $ARGUMENTS
+
+## Instructions
+
+1. Parse the user's arguments. Common forms:
+
+   ```bash
+   /cross-review "review this PR diff" --models sonnet,opus
+   /cross-review "audit this code" --models sonnet,gemini-pro,gpt-4.1 --score
+   /cross-review "design this API" --score --judge opus
+   ```
+
+2. Run the cross-review:
+
+   ```bash
+   # Basic cross-review (diff only)
+   ~/.aidevops/agents/scripts/compare-models-helper.sh cross-review \
+     --prompt "your prompt here" \
+     --models "sonnet,opus"
+
+   # With auto-scoring via judge model (default judge: opus)
+   ~/.aidevops/agents/scripts/compare-models-helper.sh cross-review \
+     --prompt "your prompt here" \
+     --models "sonnet,gemini-pro,gpt-4.1" \
+     --score
+
+   # With custom judge model
+   ~/.aidevops/agents/scripts/compare-models-helper.sh cross-review \
+     --prompt "your prompt here" \
+     --models "sonnet,opus" \
+     --score --judge sonnet
+   ```
+
+3. Present the results:
+   - Show each model's response summary
+   - Show the diff between responses (for 2-model comparisons)
+   - If `--score` was used, show the judge's structured scores and winner declaration
+   - Note any models that failed to respond
+
+4. If `--score` was used, scores are automatically:
+   - Recorded in the model-comparisons SQLite DB
+   - Fed into the pattern tracker for model routing (`/route`, `/patterns`)
+
+## Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--models` | `sonnet,opus` | Comma-separated model tiers to compare |
+| `--score` | off | Auto-score outputs via judge model |
+| `--judge` | `opus` | Judge model tier (used with `--score`) |
+| `--timeout` | `600` | Seconds per model |
+| `--output` | auto | Directory for raw outputs |
+| `--workdir` | `pwd` | Working directory for model context |
+
+## Model Tiers
+
+`haiku`, `flash`, `sonnet`, `pro`, `opus` — or full model IDs like `gemini-2.5-pro`, `gpt-4.1`
+
+## Scoring Criteria (judge model, 1-10 scale)
+
+| Criterion | Description |
+|-----------|-------------|
+| correctness | Factual accuracy and technical correctness |
+| completeness | Coverage of all requirements and edge cases |
+| quality | Code quality, best practices, maintainability |
+| clarity | Clear explanation, good formatting, readability |
+| adherence | Following the original prompt instructions precisely |
+
+## Examples
+
+```bash
+# Compare sonnet vs opus on a code review task
+/cross-review "Review this function for bugs and suggest improvements: $(cat src/auth.ts)"
+
+# Three-way comparison with auto-scoring
+/cross-review "Design a rate limiting strategy for a REST API" \
+  --models sonnet,opus,pro --score
+
+# Quick diff with custom timeout
+/cross-review "Summarize the key changes in this diff" --models haiku,sonnet --timeout 120
+
+# View scoring results after a cross-review
+/score-responses --leaderboard
+```
+
+## Related
+
+- `/compare-models` — Compare model capabilities and pricing (no live dispatch)
+- `/score-responses` — View and manage response scoring history
+- `/route` — Get model routing recommendations based on pattern data
+- `/patterns` — View model performance patterns

--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -648,13 +648,17 @@ cmd_providers() {
 # =============================================================================
 
 #######################################
-# Cross-model review: dispatch same prompt to multiple models (t132.8)
+# Cross-model review: dispatch same prompt to multiple models (t132.8, t1329)
 # Usage: compare-models-helper.sh cross-review --prompt "review this code" \
 #          --models "sonnet,opus,pro" [--workdir path] [--timeout N] [--output dir]
+#          [--score] [--judge <model>]
 # Dispatches via runner-helper.sh in parallel, collects outputs, produces summary.
+# With --score: feeds outputs to a judge model (default: opus) for structured scoring
+# and records results in the model-comparisons DB + pattern tracker.
 #######################################
 cmd_cross_review() {
 	local prompt="" models_str="" workdir="" review_timeout="600" output_dir=""
+	local score_flag=false judge_model="opus"
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -696,6 +700,18 @@ cmd_cross_review() {
 				return 1
 			}
 			output_dir="$2"
+			shift 2
+			;;
+		--score)
+			score_flag=true
+			shift
+			;;
+		--judge)
+			[[ $# -lt 2 ]] && {
+				print_error "--judge requires a value"
+				return 1
+			}
+			judge_model="$2"
 			shift 2
 			;;
 		*)
@@ -863,6 +879,184 @@ cmd_cross_review() {
 	echo "Full results saved to: $output_dir"
 	echo ""
 
+	# Judge scoring pipeline (t1329)
+	# When --score is set, dispatch all outputs to a judge model for structured scoring.
+	if [[ "$score_flag" == "true" ]]; then
+		_cross_review_judge_score \
+			"$prompt" "$models_str" "$output_dir" "$judge_model" "${model_names[@]}"
+	fi
+
+	return 0
+}
+
+# Judge scoring for cross-review (t1329)
+# Dispatches all model outputs to a judge model, parses structured JSON scores,
+# records results via cmd_score, and feeds into the pattern tracker.
+#
+# Args:
+#   $1 - original prompt
+#   $2 - models_str (comma-separated)
+#   $3 - output_dir
+#   $4 - judge_model tier
+#   $5+ - model_names array
+_cross_review_judge_score() {
+	local original_prompt="$1"
+	local models_str="$2"
+	local output_dir="$3"
+	local judge_model="$4"
+	shift 4
+	local -a model_names=("$@")
+
+	local runner_helper="${SCRIPT_DIR}/runner-helper.sh"
+	if [[ ! -x "$runner_helper" ]]; then
+		print_warning "runner-helper.sh not found — skipping judge scoring"
+		return 0
+	fi
+
+	echo "=== JUDGE SCORING (${judge_model}) ==="
+	echo ""
+
+	# Build judge prompt: include original prompt + all model responses
+	local judge_prompt
+	judge_prompt="You are a neutral judge evaluating AI model responses. Score each response on a 1-10 scale.
+
+ORIGINAL PROMPT:
+${original_prompt}
+
+MODEL RESPONSES:
+"
+	local models_with_output=()
+	for model_tier in "${model_names[@]}"; do
+		local result_file="${output_dir}/${model_tier}.txt"
+		if [[ -f "$result_file" && -s "$result_file" ]]; then
+			local response_text
+			response_text=$(cat "$result_file")
+			judge_prompt+="
+=== MODEL: ${model_tier} ===
+${response_text}
+"
+			models_with_output+=("$model_tier")
+		fi
+	done
+
+	if [[ ${#models_with_output[@]} -lt 2 ]]; then
+		print_warning "Not enough model outputs for judge scoring (need 2+)"
+		return 0
+	fi
+
+	judge_prompt+="
+SCORING INSTRUCTIONS:
+Score each model on these criteria (1-10 scale):
+- correctness: Factual accuracy and technical correctness
+- completeness: Coverage of all requirements and edge cases
+- quality: Code quality, best practices, maintainability
+- clarity: Clear explanation, good formatting, readability
+- adherence: Following the original prompt instructions precisely
+
+Respond with ONLY a valid JSON object in this exact format (no markdown, no explanation):
+{
+  \"task_type\": \"general\",
+  \"winner\": \"<model_tier_of_best_response>\",
+  \"reasoning\": \"<one sentence explaining the winner>\",
+  \"scores\": {
+    \"<model_tier>\": {
+      \"correctness\": <1-10>,
+      \"completeness\": <1-10>,
+      \"quality\": <1-10>,
+      \"clarity\": <1-10>,
+      \"adherence\": <1-10>
+    }
+  }
+}"
+
+	# Dispatch to judge model
+	local judge_runner="cross-review-judge-$$"
+	local judge_output_file="${output_dir}/judge-${judge_model}.json"
+
+	echo "  Dispatching to judge (${judge_model})..."
+
+	"$runner_helper" create "$judge_runner" \
+		--model "$judge_model" \
+		--description "Cross-review judge" \
+		--workdir "$(pwd)" 2>/dev/null || true
+
+	"$runner_helper" run "$judge_runner" "$judge_prompt" \
+		--model "$judge_model" \
+		--timeout "120" \
+		--format text 2>/dev/null >"$judge_output_file" || true
+
+	"$runner_helper" destroy "$judge_runner" --force 2>/dev/null || true
+
+	if [[ ! -f "$judge_output_file" || ! -s "$judge_output_file" ]]; then
+		print_warning "Judge model returned no output — skipping scoring"
+		return 0
+	fi
+
+	# Extract JSON from judge output (strip any surrounding text)
+	local judge_json
+	judge_json=$(grep -o '{.*}' "$judge_output_file" 2>/dev/null | head -1 || true)
+	if [[ -z "$judge_json" ]]; then
+		# Try multiline JSON extraction
+		judge_json=$(python3 -c "
+import sys, json, re
+text = open('${judge_output_file}').read()
+m = re.search(r'\{.*\}', text, re.DOTALL)
+if m:
+    try:
+        obj = json.loads(m.group())
+        print(json.dumps(obj))
+    except Exception:
+        pass
+" 2>/dev/null || true)
+	fi
+
+	if [[ -z "$judge_json" ]]; then
+		print_warning "Could not parse judge JSON output. Raw output saved to: $judge_output_file"
+		return 0
+	fi
+
+	# Parse winner and task_type
+	local winner task_type reasoning
+	winner=$(echo "$judge_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('winner',''))" 2>/dev/null || true)
+	task_type=$(echo "$judge_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('task_type','general'))" 2>/dev/null || echo "general")
+	reasoning=$(echo "$judge_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('reasoning',''))" 2>/dev/null || true)
+
+	echo "  Judge winner: ${winner:-unknown}"
+	[[ -n "$reasoning" ]] && echo "  Reasoning: ${reasoning}"
+	echo ""
+
+	# Build cmd_score arguments from judge JSON
+	local -a score_args=(
+		--task "$original_prompt"
+		--type "$task_type"
+		--evaluator "$judge_model"
+	)
+	[[ -n "$winner" ]] && score_args+=(--winner "$winner")
+
+	for model_tier in "${models_with_output[@]}"; do
+		local corr comp qual clar adhr
+		corr=$(echo "$judge_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('scores',{}).get('${model_tier}',{}).get('correctness',0))" 2>/dev/null || echo "0")
+		comp=$(echo "$judge_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('scores',{}).get('${model_tier}',{}).get('completeness',0))" 2>/dev/null || echo "0")
+		qual=$(echo "$judge_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('scores',{}).get('${model_tier}',{}).get('quality',0))" 2>/dev/null || echo "0")
+		clar=$(echo "$judge_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('scores',{}).get('${model_tier}',{}).get('clarity',0))" 2>/dev/null || echo "0")
+		adhr=$(echo "$judge_json" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('scores',{}).get('${model_tier}',{}).get('adherence',0))" 2>/dev/null || echo "0")
+
+		score_args+=(
+			--model "$model_tier"
+			--correctness "$corr"
+			--completeness "$comp"
+			--quality "$qual"
+			--clarity "$clar"
+			--adherence "$adhr"
+		)
+	done
+
+	# Record scores via cmd_score (also syncs to pattern tracker)
+	cmd_score "${score_args[@]}"
+
+	echo "Judge scores recorded. Judge output: $judge_output_file"
+	echo ""
+
 	return 0
 }
 
@@ -1021,6 +1215,12 @@ cmd_help() {
 	echo "  compare-models-helper.sh cross-review \\"
 	echo "    --prompt 'Audit the architecture of this project' \\"
 	echo "    --models 'opus,pro' --timeout 900"
+	echo "  compare-models-helper.sh cross-review \\"
+	echo "    --prompt 'Review this PR diff' --models 'sonnet,gemini-pro' \\"
+	echo "    --score                          # auto-score via judge model (default: opus)"
+	echo "  compare-models-helper.sh cross-review \\"
+	echo "    --prompt 'Review this PR diff' --models 'sonnet,gemini-pro' \\"
+	echo "    --score --judge sonnet            # use sonnet as judge instead"
 	echo ""
 	echo "Data is embedded in this script. Last updated: 2025-02-08."
 	echo "For live pricing, use /compare-models (with web fetch)."

--- a/.agents/scripts/matterbridge-helper.sh
+++ b/.agents/scripts/matterbridge-helper.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# matterbridge-helper.sh — Manage Matterbridge multi-platform chat bridge
+# Usage: matterbridge-helper.sh [setup|start|stop|status|logs|validate|update]
+set -euo pipefail
+
+BINARY_PATH="/usr/local/bin/matterbridge"
+CONFIG_PATH="${MATTERBRIDGE_CONFIG:-$HOME/.config/aidevops/matterbridge.toml}"
+DATA_DIR="$HOME/.aidevops/.agent-workspace/matterbridge"
+PID_FILE="$DATA_DIR/matterbridge.pid"
+LOG_FILE="$DATA_DIR/matterbridge.log"
+LATEST_RELEASE_URL="https://api.github.com/repos/42wim/matterbridge/releases/latest"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+log() {
+	local msg="$1"
+	echo "[matterbridge] $msg"
+	return 0
+}
+
+die() {
+	local msg="$1"
+	echo "[matterbridge] ERROR: $msg" >&2
+	return 1
+}
+
+ensure_dirs() {
+	mkdir -p "$DATA_DIR"
+	return 0
+}
+
+get_latest_version() {
+	local version
+	version=$(curl -fsSL "$LATEST_RELEASE_URL" 2>/dev/null | grep '"tag_name"' | head -1 | sed 's/.*"v\([^"]*\)".*/\1/')
+	echo "${version:-1.26.0}"
+	return 0
+}
+
+detect_os_arch() {
+	local os arch
+	os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+	arch="$(uname -m)"
+
+	case "$arch" in
+	x86_64) arch="64bit" ;;
+	aarch64 | arm64) arch="arm64" ;;
+	*) arch="64bit" ;;
+	esac
+
+	case "$os" in
+	linux) echo "linux-${arch}" ;;
+	darwin) echo "darwin-amd64" ;;
+	*) echo "linux-${arch}" ;;
+	esac
+	return 0
+}
+
+is_running() {
+	if [ -f "$PID_FILE" ]; then
+		local pid
+		pid="$(cat "$PID_FILE")"
+		if kill -0 "$pid" 2>/dev/null; then
+			return 0
+		fi
+	fi
+	return 1
+}
+
+# ── commands ─────────────────────────────────────────────────────────────────
+
+cmd_setup() {
+	ensure_dirs
+
+	# Download binary if not present
+	if [ ! -f "$BINARY_PATH" ]; then
+		local version os_arch download_url
+		version="$(get_latest_version)"
+		os_arch="$(detect_os_arch)"
+		download_url="https://github.com/42wim/matterbridge/releases/latest/download/matterbridge-${version}-${os_arch}"
+
+		log "Downloading matterbridge v${version} (${os_arch})..."
+		curl -fsSL "$download_url" -o "$BINARY_PATH" || {
+			die "Download failed. Check: https://github.com/42wim/matterbridge/releases"
+			return 1
+		}
+		chmod +x "$BINARY_PATH"
+		log "Installed to $BINARY_PATH"
+	else
+		log "Binary already installed: $BINARY_PATH ($($BINARY_PATH -version 2>&1 | head -1))"
+	fi
+
+	# Create config if not present
+	if [ ! -f "$CONFIG_PATH" ]; then
+		mkdir -p "$(dirname "$CONFIG_PATH")"
+		cat >"$CONFIG_PATH" <<'TOML'
+# Matterbridge configuration
+# Docs: https://github.com/42wim/matterbridge/wiki
+# Security: chmod 600 this file — it contains credentials
+
+[general]
+RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
+
+# Example: Matrix <-> Discord bridge
+# Uncomment and fill in credentials to use
+
+# [matrix]
+#   [matrix.home]
+#   Server="https://matrix.example.com"
+#   Login="bridgebot"
+#   Password="secret"
+
+# [discord]
+#   [discord.myserver]
+#   Token="Bot YOUR_DISCORD_BOT_TOKEN"
+#   Server="My Server Name"
+
+# [[gateway]]
+# name="mybridge"
+# enable=true
+#
+#   [[gateway.inout]]
+#   account="matrix.home"
+#   channel="#general:example.com"
+#
+#   [[gateway.inout]]
+#   account="discord.myserver"
+#   channel="general"
+TOML
+		chmod 600 "$CONFIG_PATH"
+		log "Created config template: $CONFIG_PATH"
+		log "Edit the config file, then run: matterbridge-helper.sh validate"
+	else
+		log "Config already exists: $CONFIG_PATH"
+	fi
+
+	return 0
+}
+
+cmd_validate() {
+	local config_path="${1:-$CONFIG_PATH}"
+
+	if [ ! -f "$config_path" ]; then
+		die "Config not found: $config_path. Run: matterbridge-helper.sh setup"
+		return 1
+	fi
+
+	if [ ! -f "$BINARY_PATH" ]; then
+		die "Binary not found: $BINARY_PATH. Run: matterbridge-helper.sh setup"
+		return 1
+	fi
+
+	# Basic TOML syntax check via matterbridge dry-run
+	# matterbridge exits non-zero if config is invalid
+	log "Validating config: $config_path"
+	if timeout 5 "$BINARY_PATH" -conf "$config_path" -version >/dev/null 2>&1; then
+		log "Binary OK"
+	fi
+
+	# Check for required sections
+	if ! grep -q '^\[\[gateway\]\]' "$config_path"; then
+		log "WARNING: No [[gateway]] section found — bridge will do nothing"
+	fi
+
+	log "Config validation complete (syntax check only — credentials not verified)"
+	return 0
+}
+
+cmd_start() {
+	local daemon_mode=false
+	local arg="${1:-}"
+
+	if [ "$arg" = "--daemon" ]; then
+		daemon_mode=true
+	fi
+
+	if is_running; then
+		log "Already running (PID: $(cat "$PID_FILE"))"
+		return 0
+	fi
+
+	if [ ! -f "$CONFIG_PATH" ]; then
+		die "Config not found: $CONFIG_PATH. Run: matterbridge-helper.sh setup"
+		return 1
+	fi
+
+	ensure_dirs
+
+	if [ "$daemon_mode" = true ]; then
+		log "Starting in daemon mode..."
+		nohup "$BINARY_PATH" -conf "$CONFIG_PATH" >>"$LOG_FILE" 2>&1 &
+		echo $! >"$PID_FILE"
+		sleep 1
+		if is_running; then
+			log "Started (PID: $(cat "$PID_FILE"))"
+		else
+			die "Failed to start. Check logs: $LOG_FILE"
+			return 1
+		fi
+	else
+		log "Starting in foreground (Ctrl+C to stop)..."
+		"$BINARY_PATH" -conf "$CONFIG_PATH"
+	fi
+
+	return 0
+}
+
+cmd_stop() {
+	if ! is_running; then
+		log "Not running"
+		return 0
+	fi
+
+	local pid
+	pid="$(cat "$PID_FILE")"
+	log "Stopping (PID: $pid)..."
+	kill "$pid" 2>/dev/null || true
+
+	local timeout=10
+	local count=0
+	while is_running && [ $count -lt $timeout ]; do
+		sleep 1
+		count=$((count + 1))
+	done
+
+	if is_running; then
+		log "Force killing..."
+		kill -9 "$pid" 2>/dev/null || true
+	fi
+
+	rm -f "$PID_FILE"
+	log "Stopped"
+	return 0
+}
+
+cmd_status() {
+	if is_running; then
+		local pid
+		pid="$(cat "$PID_FILE")"
+		log "Running (PID: $pid)"
+		log "Config: $CONFIG_PATH"
+		log "Log: $LOG_FILE"
+	else
+		log "Not running"
+	fi
+	return 0
+}
+
+cmd_logs() {
+	local follow=false
+	local tail_lines=50
+	local arg="${1:-}"
+
+	case "$arg" in
+	--follow | -f) follow=true ;;
+	--tail) tail_lines="${2:-50}" ;;
+	esac
+
+	if [ ! -f "$LOG_FILE" ]; then
+		log "No log file found: $LOG_FILE"
+		return 0
+	fi
+
+	if [ "$follow" = true ]; then
+		tail -f "$LOG_FILE"
+	else
+		tail -n "$tail_lines" "$LOG_FILE"
+	fi
+
+	return 0
+}
+
+cmd_update() {
+	local current_version new_version
+	current_version="$("$BINARY_PATH" -version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")"
+	new_version="$(get_latest_version)"
+
+	if [ "$current_version" = "$new_version" ]; then
+		log "Already at latest version: v$current_version"
+		return 0
+	fi
+
+	log "Updating from v$current_version to v$new_version..."
+
+	local was_running=false
+	if is_running; then
+		was_running=true
+		cmd_stop
+	fi
+
+	local os_arch download_url
+	os_arch="$(detect_os_arch)"
+	download_url="https://github.com/42wim/matterbridge/releases/latest/download/matterbridge-${new_version}-${os_arch}"
+
+	curl -fsSL "$download_url" -o "$BINARY_PATH" || {
+		die "Download failed"
+		return 1
+	}
+	chmod +x "$BINARY_PATH"
+	log "Updated to v$new_version"
+
+	if [ "$was_running" = true ]; then
+		cmd_start --daemon
+	fi
+
+	return 0
+}
+
+cmd_help() {
+	cat <<'HELP'
+matterbridge-helper.sh — Manage Matterbridge multi-platform chat bridge
+
+Commands:
+  setup              Download binary and create config template
+  validate [config]  Validate config file syntax
+  start [--daemon]   Start bridge (foreground or daemon)
+  stop               Stop bridge daemon
+  status             Show running status
+  logs [--follow]    Show/follow log output
+  update             Update to latest release
+
+Config: ~/.config/aidevops/matterbridge.toml (override: MATTERBRIDGE_CONFIG)
+Docs:   .agents/services/communications/matterbridge.md
+HELP
+	return 0
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	setup) cmd_setup "$@" ;;
+	validate) cmd_validate "$@" ;;
+	start) cmd_start "$@" ;;
+	stop) cmd_stop "$@" ;;
+	status) cmd_status "$@" ;;
+	logs) cmd_logs "$@" ;;
+	update) cmd_update "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		echo "Unknown command: $cmd" >&2
+		cmd_help
+		return 1
+		;;
+	esac
+
+	return 0
+}
+
+main "$@"

--- a/.agents/services/communications/matterbridge.md
+++ b/.agents/services/communications/matterbridge.md
@@ -1,0 +1,463 @@
+---
+description: Matterbridge multi-platform chat bridge — install, configure, and run bridges between 20+ platforms including Matrix, Discord, Telegram, Slack, IRC, WhatsApp, XMPP, and SimpleX via adapter
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: false
+  webfetch: false
+  task: false
+---
+
+# Matterbridge — Multi-Platform Chat Bridge
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Repo**: [github.com/42wim/matterbridge](https://github.com/42wim/matterbridge) (7.4K stars, Apache-2.0, Go)
+- **Version**: v1.26.0 (stable)
+- **Script**: `matterbridge-helper.sh [setup|start|stop|status|logs|validate]`
+- **Config**: `~/.config/aidevops/matterbridge.toml` (600 permissions)
+- **Data**: `~/.aidevops/.agent-workspace/matterbridge/`
+- **Requires**: Go 1.18+ (build) or pre-compiled binary
+
+**Quick start**:
+
+```bash
+matterbridge-helper.sh setup          # Download binary + interactive config
+matterbridge-helper.sh validate       # Validate config before starting
+matterbridge-helper.sh start --daemon
+```
+
+**Security/privacy warnings**: See `tools/security/opsec.md` — bridging to unencrypted platforms (Discord, Slack, IRC) exposes messages to those platforms' operators and metadata collection. E2E encryption is broken at bridge boundaries.
+
+<!-- AI-CONTEXT-END -->
+
+## Natively Supported Platforms
+
+| Platform | Protocol | Notes |
+|----------|----------|-------|
+| Discord | Bot API | Requires bot token + server invite |
+| Gitter | REST API | GitHub-owned |
+| IRC | IRC | libera.chat, OFTC, etc. |
+| Keybase | Keybase API | |
+| Matrix | Client-Server API | E2E broken at bridge |
+| Mattermost | API v4 | Self-hosted or cloud |
+| Microsoft Teams | Graph API | Requires Azure app registration |
+| Mumble | Mumble protocol | Voice-only (text chat) |
+| Nextcloud Talk | Talk API | |
+| Rocket.Chat | REST + WebSocket | |
+| Slack | RTM/Events API | Bot token required |
+| SSH-chat | SSH | |
+| Telegram | Bot API | |
+| Twitch | IRC | Chat only |
+| VK | VK API | |
+| WhatsApp | go-whatsapp (legacy) / whatsmeow (multidevice) | Unofficial; ToS risk |
+| XMPP | XMPP | Jabber-compatible |
+| Zulip | Zulip API | |
+
+### 3rd Party via Matterbridge API
+
+- **SimpleX**: [matterbridge-simplex](https://github.com/simplex-chat/matterbridge-simplex) adapter — routes via SimpleX CLI
+- **Delta Chat**: matterdelta
+- **Minecraft**: mattercraft, MatterBukkit
+
+## Installation
+
+### Binary (Recommended)
+
+```bash
+# Download latest stable
+curl -L https://github.com/42wim/matterbridge/releases/latest/download/matterbridge-1.26.0-linux-64bit \
+  -o /usr/local/bin/matterbridge
+chmod +x /usr/local/bin/matterbridge
+
+# macOS
+curl -L https://github.com/42wim/matterbridge/releases/latest/download/matterbridge-1.26.0-darwin-amd64 \
+  -o /usr/local/bin/matterbridge
+chmod +x /usr/local/bin/matterbridge
+
+# Verify
+matterbridge -version
+```
+
+### Packages
+
+```bash
+snap install matterbridge          # Snap
+scoop install matterbridge         # Windows Scoop
+```
+
+### Build from Source
+
+```bash
+# Standard build (all bridges, ~3GB RAM to compile)
+go install github.com/42wim/matterbridge
+
+# Reduced build (exclude MS Teams, saves ~2.5GB RAM)
+go install -tags nomsteams github.com/42wim/matterbridge
+
+# With WhatsApp multidevice (GPL3 dependency — binary not distributed)
+go install -tags whatsappmulti github.com/42wim/matterbridge@master
+
+# Without MS Teams + with WhatsApp multidevice
+go install -tags nomsteams,whatsappmulti github.com/42wim/matterbridge@master
+```
+
+## Configuration
+
+### Config File Location
+
+```bash
+# Default search order
+./matterbridge.toml
+~/.config/aidevops/matterbridge.toml  # aidevops convention
+
+# Explicit path
+matterbridge -conf /path/to/matterbridge.toml
+```
+
+### Basic Structure
+
+Every config has three sections:
+
+1. **Protocol blocks** — credentials and settings per platform instance
+2. **`[general]`** — global settings (nick format, etc.)
+3. **`[[gateway]]`** — bridge definitions connecting accounts to channels
+
+```toml
+# Protocol block: one per platform instance
+[matrix]
+  [matrix.home]
+  Server="https://matrix.example.com"
+  Login="bridgebot"
+  Password="secret"
+  RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
+
+[discord]
+  [discord.myserver]
+  Token="Bot YOUR_DISCORD_BOT_TOKEN"
+  Server="My Discord Server"
+
+[telegram]
+  [telegram.main]
+  Token="YOUR_TELEGRAM_BOT_TOKEN"
+
+[irc]
+  [irc.libera]
+  Server="irc.libera.chat:6667"
+  Nick="matterbridge"
+  UseTLS=true
+
+# Global settings
+[general]
+RemoteNickFormat="[{PROTOCOL}/{BRIDGE}] <{NICK}> "
+
+# Gateway: connects accounts + channels
+[[gateway]]
+name="mybridge"
+enable=true
+
+  [[gateway.inout]]
+  account="matrix.home"
+  channel="#general:example.com"
+
+  [[gateway.inout]]
+  account="discord.myserver"
+  channel="general"
+
+  [[gateway.inout]]
+  account="telegram.main"
+  channel="-1001234567890"  # Group chat ID (negative)
+
+  [[gateway.inout]]
+  account="irc.libera"
+  channel="#myproject"
+```
+
+### Nick Format Variables
+
+| Variable | Value |
+|----------|-------|
+| `{NICK}` | Sender's username |
+| `{PROTOCOL}` | Platform name (matrix, discord, etc.) |
+| `{BRIDGE}` | Bridge instance name |
+| `{GATEWAY}` | Gateway name |
+
+### One-Way Bridges (in/out)
+
+```toml
+[[gateway]]
+name="announcements"
+enable=true
+
+  # Source: only receives from this channel
+  [[gateway.in]]
+  account="slack.work"
+  channel="announcements"
+
+  # Destinations: only sends to these channels
+  [[gateway.out]]
+  account="discord.myserver"
+  channel="announcements"
+
+  [[gateway.out]]
+  account="matrix.home"
+  channel="#announcements:example.com"
+```
+
+### Platform-Specific Configuration
+
+#### Matrix
+
+```toml
+[matrix]
+  [matrix.home]
+  Server="https://matrix.example.com"
+  Login="bridgebot"
+  Password="secret"
+  # Or use access token (preferred)
+  # Token="syt_..."
+  RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
+  # Preserve threading
+  PreserveThreading=true
+```
+
+#### Discord
+
+```toml
+[discord]
+  [discord.myserver]
+  Token="Bot YOUR_BOT_TOKEN"
+  Server="My Server Name"
+  # Use webhooks for better username/avatar spoofing
+  WebhookURL="https://discord.com/api/webhooks/..."
+  RemoteNickFormat="{NICK} [{PROTOCOL}]"
+```
+
+#### Telegram
+
+```toml
+[telegram]
+  [telegram.main]
+  Token="YOUR_BOT_TOKEN"
+  # For supergroups, use negative ID
+  # Get ID: add @userinfobot to group
+```
+
+#### Slack
+
+```toml
+[slack]
+  [slack.workspace]
+  Token="xoxb-YOUR-BOT-TOKEN"
+  # Legacy token (deprecated): xoxp-...
+  # Bot token (recommended): xoxb-...
+  PrefixMessagesWithNick=true
+```
+
+#### IRC
+
+```toml
+[irc]
+  [irc.libera]
+  Server="irc.libera.chat:6697"
+  Nick="matterbridge"
+  Password=""
+  UseTLS=true
+  SkipTLSVerify=false
+  NickServNick="NickServ"
+  NickServPassword="your-nickserv-password"
+```
+
+#### XMPP
+
+```toml
+[xmpp]
+  [xmpp.jabber]
+  Server="jabber.example.com:5222"
+  Jid="bridgebot@jabber.example.com"
+  Password="secret"
+  Muc="conference.jabber.example.com"
+  Nick="matterbridge"
+```
+
+#### Mattermost
+
+```toml
+[mattermost]
+  [mattermost.work]
+  Server="mattermost.example.com"
+  Team="myteam"
+  Login="bridgebot@example.com"
+  Password="secret"
+  PrefixMessagesWithNick=true
+  RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
+```
+
+### SimpleX via Adapter
+
+SimpleX is not natively supported. Use [matterbridge-simplex](https://github.com/simplex-chat/matterbridge-simplex):
+
+```bash
+# Install SimpleX CLI first
+curl -o- https://raw.githubusercontent.com/simplex-chat/simplex-chat/stable/install.sh | bash
+
+# Install matterbridge-simplex adapter
+go install github.com/simplex-chat/matterbridge-simplex@latest
+
+# Run adapter (exposes Matterbridge API endpoint)
+matterbridge-simplex --port 4242 --profile simplex-bridge
+```
+
+```toml
+# Matterbridge config: use API bridge to connect to adapter
+[api]
+  [api.simplex]
+  BindAddress="0.0.0.0:4243"
+  Token="your-api-token"
+
+[[gateway]]
+name="simplex-matrix"
+enable=true
+
+  [[gateway.inout]]
+  account="api.simplex"
+  channel="api"
+
+  [[gateway.inout]]
+  account="matrix.home"
+  channel="#bridged:example.com"
+```
+
+**Note**: SimpleX E2E encryption is broken at the bridge boundary. Messages entering the bridge are decrypted and re-encrypted for the destination platform. See `tools/security/opsec.md` for implications.
+
+## Running
+
+### CLI
+
+```bash
+# Foreground (debug)
+matterbridge -conf matterbridge.toml -debug
+
+# Background
+matterbridge -conf matterbridge.toml &
+
+# Validate config only
+matterbridge -conf matterbridge.toml -validate  # (if supported by version)
+```
+
+### Docker
+
+```bash
+# Docker run
+docker run -d \
+  --name matterbridge \
+  --restart unless-stopped \
+  -v /path/to/matterbridge.toml:/etc/matterbridge/matterbridge.toml:ro \
+  42wim/matterbridge:stable
+
+# Docker Compose
+cat > docker-compose.yml <<'EOF'
+version: "3"
+services:
+  matterbridge:
+    image: 42wim/matterbridge:stable
+    restart: unless-stopped
+    volumes:
+      - ./matterbridge.toml:/etc/matterbridge/matterbridge.toml:ro
+EOF
+
+docker compose up -d
+```
+
+### Systemd
+
+```ini
+# /etc/systemd/system/matterbridge.service
+[Unit]
+Description=Matterbridge chat bridge
+After=network.target
+
+[Service]
+Type=simple
+User=matterbridge
+ExecStart=/usr/local/bin/matterbridge -conf /etc/matterbridge/matterbridge.toml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now matterbridge
+sudo journalctl -fu matterbridge
+```
+
+## REST API
+
+Matterbridge exposes a simple REST API for custom integrations:
+
+```toml
+[api]
+  [api.myapi]
+  BindAddress="127.0.0.1:4242"
+  Token="your-secret-token"
+  Buffer=1000
+```
+
+```bash
+# Send message to bridge
+curl -X POST http://localhost:4242/api/message \
+  -H "Authorization: Bearer your-secret-token" \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello from API", "username": "bot", "gateway": "mybridge"}'
+
+# Receive messages (long-poll)
+curl http://localhost:4242/api/messages \
+  -H "Authorization: Bearer your-secret-token"
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Messages not bridging | Check `matterbridge -debug` output; verify account credentials |
+| Discord bot not posting | Ensure bot has `Send Messages` permission in channel |
+| Matrix messages duplicated | Check `IgnoreMessages` config; ensure bot is not in both sides |
+| Telegram group ID wrong | Use `@userinfobot` or check bot updates for correct chat ID |
+| WhatsApp disconnects | WhatsApp multidevice is beta; expect instability |
+| High memory on build | Use `-tags nomsteams` to reduce build memory to ~500MB |
+| IRC nick conflicts | Set `NickServPassword` or use unique nick |
+
+## Security Considerations
+
+**E2E encryption is broken at bridge boundaries.** When bridging:
+
+- Messages are decrypted by Matterbridge process
+- Re-encrypted (or sent plaintext) to destination platform
+- The bridge host has access to all message content in plaintext
+- Metadata (sender, timestamp, channel) is visible to all bridged platforms
+
+**Mitigations**:
+
+- Run Matterbridge on a trusted, hardened host
+- Use NetBird/WireGuard to restrict access to the bridge host
+- Avoid bridging sensitive channels to unencrypted platforms (IRC, Slack, Discord)
+- Store credentials in gopass: `aidevops secret set MATTERBRIDGE_DISCORD_TOKEN`
+- Config file must have 600 permissions: `chmod 600 matterbridge.toml`
+
+See `tools/security/opsec.md` for full platform trust matrix and threat modeling.
+
+## Related
+
+- `services/communications/matrix-bot.md` — Matrix bot for aidevops runner dispatch
+- `services/communications/simplex.md` — SimpleX install, bot API, self-hosted servers
+- `tools/security/opsec.md` — Platform trust matrix, E2E status, metadata warnings
+- `tools/ai-assistants/headless-dispatch.md` — Headless dispatch patterns

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -69,7 +69,7 @@ services/accessibility/,Unified web and email accessibility auditing - WCAG comp
 services/hosting/,Hosting providers - DNS and cloud servers and local dev,local-hosting|localhost|hostinger|hetzner|cloudflare|cloudflare-platform|cloudron|closte
 services/networking/,Networking - mesh VPN and secure device connectivity,tailscale|netbird
 services/email/,Email services - transactional email deliverability and testing,ses|email-health-check|email-testing|email-delivery-test|email-design-test|email-delivery-testing|email-design-testing
-services/communications/,Communications - SMS voice and Matrix bot dispatch,twilio|telfon|matrix-bot
+services/communications/,Communications - SMS voice Matrix bot and multi-platform chat bridging,twilio|telfon|matrix-bot|matterbridge|simplex
 services/crm/,CRM integration - contact management,fluentcrm
 services/analytics/,Website analytics - GA4 reporting,google-analytics
 services/monitoring/,Error monitoring and debugging,sentry|socket


### PR DESCRIPTION
## Summary

- **t1328**: Matterbridge multi-platform chat bridge subagent (`matterbridge.md`) and helper script (`matterbridge-helper.sh`) — install, configure, start/stop, Docker, REST API, SimpleX adapter, security cross-reference to opsec agent
- **t1329**: Cross-review judge pipeline — `--score`/`--judge` flags added to `cmd_cross_review()`, dispatches all model outputs to a configurable judge model (default: opus), parses structured JSON scores, records via `cmd_score`, feeds pattern tracker; `/cross-review` slash command doc added

## Files Changed

| File | Change |
|------|--------|
| `.agents/services/communications/matterbridge.md` | New — Matterbridge subagent doc |
| `.agents/scripts/matterbridge-helper.sh` | New — CLI helper (setup/start/stop/status/logs/update) |
| `.agents/scripts/compare-models-helper.sh` | Extended `cmd_cross_review()` with `--score`/`--judge` + `_cross_review_judge_score()` |
| `.agents/scripts/commands/cross-review.md` | New — `/cross-review` slash command |
| `.agents/subagent-index.toon` | Updated communications entry |
| `.agents/AGENTS.md` | Added Communications row to domain index |

## Verification

- All t1328 acceptance criteria pass (matterbridge.md, helper script, opsec cross-ref, subagent index)
- All t1329 acceptance criteria pass (`--score` flag, `cmd_score` integration, slash command, pattern tracker)
- `shellcheck` clean on both scripts (pre-existing SC1091/SC2001 in original `cmd_score` unchanged)

Closes #2254, #2262