### PR TITLE
t1327.6: Add opsec agent — threat modeling, secure comms, VPN, browser privacy

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -100,7 +100,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Communications | `services/communications/matterbridge.md`, `services/communications/simplex.md`, `services/communications/matrix-bot.md` |
 | Email | `tools/ui/react-email.md`, `services/email/email-testing.md` |
 | Payments | `services/payments/revenuecat.md`, `services/payments/stripe.md` |
-| Security/Encryption | `tools/security/tirith.md`, `tools/credentials/encryption-stack.md` |
+| Security/Encryption | `tools/security/tirith.md`, `tools/security/opsec.md`, `tools/credentials/encryption-stack.md` |
 | Database/Local-first | `tools/database/pglite-local-first.md`, `services/database/postgres-drizzle-skill.md` |
 | Local Development | `services/hosting/local-hosting.md` |
 | Infrastructure | `tools/infrastructure/cloud-gpu.md`, `tools/containers/orbstack.md`, `tools/containers/remote-dispatch.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -58,7 +58,7 @@ tools/data-extraction/,Data extraction - scraping business data,outscraper
 tools/deployment/,Deployment automation - self-hosted PaaS and orchestration,coolify|coolify-cli|vercel|cloudron-app-packaging|uncloud
 tools/git/,Git operations - GitHub/GitLab/Gitea CLIs and diff tools,github-cli|gitlab-cli|gitea-cli|github-actions|worktrunk|lumen|jujutsu|conflict-resolution
 tools/credentials/,Secret management - API keys vaults and encryption stack,api-key-setup|api-key-management|vaultwarden|gopass|psst|multi-tenant|list-keys|sops|gocryptfs|encryption-stack
-tools/security/,Security tools - terminal guards privacy filtering IP reputation and scanning,tirith|shannon|cdn-origin-ip|privacy-filter|ip-reputation
+tools/security/,Security tools - terminal guards privacy filtering IP reputation scanning and opsec,tirith|shannon|cdn-origin-ip|privacy-filter|ip-reputation|opsec
 tools/task-management/,Task tracking - dependency graphs,beads
 tools/terminal/,Terminal integration - tab titles,terminal-title
 tools/automation/,Automation - cron scheduling objective runner and macOS AppleScript/JXA,cron-agent|objective-runner|mac|macos-automator


### PR DESCRIPTION
## Summary

- Add `.agents/tools/security/opsec.md` — operational security agent covering threat modeling, secure communications, VPN/network privacy, and browser hardening
- Includes SimpleX vs Matrix comparison, platform trust matrix (E2E status, metadata exposure, AI training policies), Mullvad/IVPN/ProtonVPN VPN comparison, NetBird mesh VPN, DNS privacy, Brave/Mullvad Browser/CamoFox browser selection, and dev team opsec practices
- Updates subagent-index.toon and AGENTS.md domain index with cross-references to existing security, credentials, and browser agents

Ref #2250