### PR TITLE
fix: unpin stale supervisor health issues when closing or replacing them

### DIFF
--- a/.agents/scripts/supervisor/issue-sync.sh
+++ b/.agents/scripts/supervisor/issue-sync.sh
@@ -542,13 +542,14 @@ _unpin_health_issue() {
 	issue_node_id=$(gh issue view "$issue_number" --repo "$repo_slug" --json id --jq '.id' 2>/dev/null || echo "")
 	[[ -z "$issue_node_id" ]] && return 0
 
-	gh api graphql -f query="
+	if gh api graphql -f query="
 		mutation {
 			unpinIssue(input: {issueId: \"${issue_node_id}\"}) {
 				issue { number }
 			}
-		}" >/dev/null 2>&1 || true
-	log_verbose "  Unpinned health issue #$issue_number"
+		}" >/dev/null 2>&1; then
+		log_verbose "  Unpinned health issue #$issue_number"
+	fi
 
 	return 0
 }


### PR DESCRIPTION
## Summary

- Stale supervisor health issues remained pinned after being closed/replaced, cluttering the issues page
- Adds `_unpin_health_issue()` helper and calls it in all close/replace paths
- Ensures the active health issue is always pinned (idempotent) and sweeps closed issues for stale pins

## Changes

- **New**: `_unpin_health_issue()` — best-effort GraphQL unpin helper
- **Fix**: Unpin cached issues found closed before discarding cache
- **Fix**: Unpin duplicates before closing in dedup guard
- **Fix**: Ensure active issue is always pinned (covers search-found issues that lost pin)
- **Fix**: Sweep up to 10 recent closed supervisor issues per runner to catch historical stale pins

## Manual fix applied

Unpinned #1502 and #1334 (old supervisor issues), pinned #2199 and #2198 (current).