### PR TITLE
t1333+t1334: Cross-repo supervisor visibility + concurrency underutilisation alerting

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -68,6 +68,8 @@ Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-
 
 Planning files go direct to main. Code changes need worktree + PR. Workers NEVER edit TODO.md.
 
+**Cross-repo awareness**: The supervisor manages tasks across all `repos.json` repos. When querying queue status, check the supervisor DB (`~/.aidevops/.agent-workspace/supervisor/supervisor.db`) for all active tasks across repos, not just the current repo's TODO.md. Use `gh issue list --repo <slug>` for each managed repo to get the full picture.
+
 Full rules: `reference/planning-detail.md`
 
 ## Git Workflow
@@ -114,7 +116,7 @@ Key capabilities (details in `reference/orchestration.md`, `reference/services.m
 
 - **Model routing**: haiku→flash→sonnet→pro→opus (cost-aware)
 - **Memory**: cross-session SQLite FTS5 (`/remember`, `/recall`)
-- **Orchestration**: supervisor dispatch, pulse scheduler, auto-pickup
+- **Orchestration**: supervisor dispatch, pulse scheduler, auto-pickup, cross-repo issue/PR/TODO visibility
 - **Skills**: `aidevops skills`, `/skills`
 - **Auto-update**: GitHub poll + daily skill/repo sync
 - **Browser**: Playwright, dev-browser (persistent login)


### PR DESCRIPTION
## Summary

- **t1333**: Supervisor AI context now queries issues and PRs across all managed repos (not just cwd). Previously missed 19 a managed private repo issues entirely — the AI reasoner was blind to half the work queue.
- **t1334**: Phase 2b now detects concurrency underutilisation (running < max_concurrency while tasks are queued) and logs diagnostic info including rate limit status and batch concurrency bottlenecks.

## Changes

### ai-context.sh
- `build_issues_context()` and `build_prs_context()` now use `--repo <slug>` flag via `detect_repo_slug()` to query the correct GitHub repo regardless of cwd
- `build_ai_context()` iterates all repos from supervisor DB for issues and PRs (same pattern as existing TODO context from t1188)
- Section headers include repo name for disambiguation (`## Open GitHub Issues — a managed private repo`)

### pulse.sh
- Phase 2b: new `elif` branch detects underutilisation when `queued > 0 && running > 0 && running < effective_max`
- Logs utilisation percentage, provider rate limit status (from model-availability cache), and batch concurrency bottlenecks
- Records `underutilised` state to `state_log` for AI self-reflection to pick up

### AGENTS.md
- Added cross-repo awareness guidance for interactive sessions
- Documented cross-repo orchestration capability

## Root Cause

The supervisor's AI context builder (Phase 14) was only seeing issues/PRs from the primary repo because `gh issue list` and `gh pr list` were called without `--repo` flag. The TODO context was already fixed in t1188 but issues/PRs were missed.

## Testing

- `bash -n` passes on both modified scripts
- `shellcheck -S warning` clean (zero new warnings)
- Cross-repo: `detect_repo_slug()` resolves `a managed private repo` from git remote, `marcusquinn/aidevops` from origin