### PR TITLE
fix: Phase 3 stuck on first task — worker_pid column in _dispatch_ai_worker UPDATE

### DIFF
--- a/.agents/scripts/supervisor/ai-lifecycle.sh
+++ b/.agents/scripts/supervisor/ai-lifecycle.sh
@@ -680,11 +680,11 @@ Output ONLY one of: FIXED:<what you did> or FAILED:<why you couldn't fix it>"
 	fi
 	local worker_pid=$!
 
-	# Record in DB
+	# Record in DB — use session_id (not worker_pid which was removed in schema migration)
 	db "$SUPERVISOR_DB" "UPDATE tasks SET
 		status = 'running',
 		error = '${action_type}: AI worker solving (PID $worker_pid)',
-		worker_pid = $worker_pid,
+		session_id = 'pid:$worker_pid',
 		log_file = '$(sql_escape "$worker_log")',
 		updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
 	WHERE id = '$escaped_id';" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Same root cause as PR #2275 — the removed `worker_pid` column is referenced in a SQL UPDATE, causing silent failure.

## Problem

`_dispatch_ai_worker()` at line 687 writes `worker_pid = $worker_pid` in an UPDATE statement. This column doesn't exist. SQLite fails the entire UPDATE silently (suppressed by `2>/dev/null`), so:

1. Task status never transitions from `blocked` to `running`
2. Next pulse, same task is first in priority order, gets actioned again
3. Same failure repeats — the other 19 eligible tasks are never reached
4. Phase 3 reports "evaluated 1 tasks, actioned 1" every pulse but nothing actually progresses

## Fix

Replace `worker_pid = $worker_pid` with `session_id = 'pid:$worker_pid'` — matching the pattern used by `dispatch.sh` and `deploy.sh`.

## Impact

This unblocks Phase 3 from processing all 20 eligible tasks (8 PRs waiting for review/merge, 11 tasks in pr_review state). The pipeline should start reviewing and merging PRs on the next pulse after deployment.