### PR TITLE
fix: Phase 3 priority — PR review/merge before blocked task diagnosis

### DIFF
--- a/.agents/scripts/supervisor/ai-lifecycle.sh
+++ b/.agents/scripts/supervisor/ai-lifecycle.sh
@@ -734,10 +734,10 @@ process_ai_lifecycle() {
 				WHEN 'merging' THEN 1
 				WHEN 'merged' THEN 2
 				WHEN 'deploying' THEN 3
-				WHEN 'blocked' THEN 4
-				WHEN 'review_triage' THEN 5
-				WHEN 'pr_review' THEN 6
-				WHEN 'complete' THEN 7
+				WHEN 'review_triage' THEN 4
+				WHEN 'pr_review' THEN 5
+				WHEN 'complete' THEN 6
+				WHEN 'blocked' THEN 7
 				WHEN 'running' THEN 8
 				WHEN 'evaluating' THEN 9
 				WHEN 'dispatched' THEN 10


### PR DESCRIPTION
## Summary

Reorders Phase 3 lifecycle priority so pr_review tasks are processed before blocked tasks.

## Why

Phase 3 processes ~1 task per pulse (each task requires an opus API call). With the previous ordering, 7 blocked tasks (t1327.x chain) were ahead of 11 pr_review tasks (8 open PRs). At 2 min/pulse, the PRs wouldn't be reached for ~14 minutes — and blocked task diagnosis often dispatches workers that take longer, further delaying PR merges.

Merging a PR is immediate, concrete progress. Diagnosing a blocked task is speculative.

## Change

`ai-lifecycle.sh` priority order:
- Before: merging(1) > merged(2) > deploying(3) > **blocked(4)** > review_triage(5) > **pr_review(6)**
- After: merging(1) > merged(2) > deploying(3) > **review_triage(4)** > **pr_review(5)** > complete(6) > **blocked(7)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated task processing priority order in the AI lifecycle workflow. Review and PR-related tasks now receive priority earlier in the processing sequence, while blocked tasks are handled later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->