### PR TITLE
t1334: Diagnose t003.5 repeated worker deaths during cross-browser testing

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -194,6 +194,25 @@ The AI will iterate on the task until outputting:
 and try a fundamentally different strategy before giving up. A fresh approach often
 succeeds where incremental fixes to a broken one fail.
 
+**CI failure debugging (t1334)**: When a task involves fixing CI failures or a PR has
+failing checks, ALWAYS read the CI logs first before attempting any code changes:
+
+```bash
+# 1. Identify the failing job
+gh pr checks <PR_NUMBER> --repo <owner/repo>
+
+# 2. Get the run ID and read failure logs
+gh run view <RUN_ID> --repo <owner/repo> --log | grep -iE 'FAIL|Error.*spec|expect.*received'
+
+# 3. Identify the EXACT test name, file, and line number from the error
+```
+
+This prevents context exhaustion from blind debugging. Workers that skip this step
+waste entire sessions guessing at root causes. Common pitfalls:
+- Testing the wrong DOM element (e.g., `<main>` vs its child `<div>`)
+- Assuming infrastructure issues (OOM, timeouts) when the test itself is wrong
+- Not checking if another PR (e.g., a CI investigation PR) already identified the fix
+
 **Headless dispatch rules (MANDATORY for supervisor-dispatched workers - t158/t174):**
 
 When running as a headless worker (dispatched by the supervisor via `opencode run` or `Claude -p`), the `--headless` flag is passed automatically. The full-loop-helper.sh script enforces these rules:


### PR DESCRIPTION
## Summary

Root cause investigation for t003.5 (cross-browser and device testing) which failed 3+ consecutive times with `worker_process_died_mid_task_pr_open_unmerged` at both sonnet and opus tiers.

## Root Cause

**Single failing test**: `e2e/responsive.spec.ts:672` — "dashboard inset constrains content width on wide desktop"

The test measured the `<main>` element (which is `SidebarInset` — fills available space after sidebar) instead of the `DashboardInset` div inside it (which has `max-w-7xl`). On a 1920px viewport, `<main>` is wider than 1280px by design, so the assertion `expect(mainBox.width).toBeLessThanOrEqual(1280)` always failed.

**Why workers died**: Workers consumed their entire context windows trying to debug responsive CSS and test infrastructure when the fix was a 4-line test selector change. They never read the CI logs first to identify the exact failing assertion.

## Fixes Applied

### 1. Test fix (a managed private repo repo, feature/t003.5 branch)
Changed the test to measure `main.locator("> div").first()` (DashboardInset) instead of `main` (SidebarInset).

### 2. Self-improvement (this repo)
Added "CI failure debugging" guidance to `.agents/scripts/commands/full-loop.md` worker protocol. Workers must now read CI logs via `gh run view` before attempting code changes on CI failure tasks.

## Investigation Findings

| Question | Answer |
|----------|--------|
| Playwright/browser infra configured? | Yes — all other E2E tests pass (168/169 on shards 1-2, 160/162 on shard 4) |
| Memory/time limits causing OOM? | No — tests complete normally, just with assertion failures |
| Responsive fixes caused regressions? | No — the CSS changes are correct; the test was wrong |
| PR #253 overlap? | Partial — PR #253 fixed WebKit overflow and sidebar org context issues, but not this test |

## CI Status

- a managed private repo PR #250: CI re-running with fix (pushed `17d4e960` to `feature/t003.5`)
- All non-E2E checks pass: Format, Lint, Typecheck, Unit Tests, E2E Build, Security

Ref #2282

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CI failure debugging guidance with step-by-step instructions for identifying failing jobs, interpreting run logs, and pinpointing exact error locations in test files and code lines.
  * Introduced detailed operational guidelines for headless execution mode, including safety constraints, prohibited operations, and best practices for automated job processing and dispatcher-initiated execution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->