### PR TITLE
t1331: Supervisor circuit breaker — pause on consecutive failures

### DIFF
--- a/.agents/scripts/supervisor-helper.sh
+++ b/.agents/scripts/supervisor-helper.sh
@@ -371,6 +371,7 @@ Usage:
   supervisor-helper.sh stale-gc-report [--days N] [--json]  Stale state GC metrics report (t1202)
   supervisor-helper.sh stuck-detection                     Run stuck detection checks manually (t1332)
   supervisor-helper.sh stuck-detection-report [--days N] [--json]  Stuck detection metrics report (t1332)
+  supervisor-helper.sh circuit-breaker <status|reset|check|trip>   Circuit breaker controls (t1331)
   supervisor-helper.sh stale-claims [--repo path]          Detect and recover stale TODO.md claims (t1263)
   supervisor-helper.sh labels [--action X] [--model Y] [--json]  Query model usage labels (t1010)
   supervisor-helper.sh pool <subcommand> [args]      Container pool manager (t1165.2)

--- a/.agents/scripts/supervisor/circuit-breaker.sh
+++ b/.agents/scripts/supervisor/circuit-breaker.sh
@@ -18,9 +18,15 @@
 
 # Number of consecutive failures before tripping the circuit breaker
 CIRCUIT_BREAKER_THRESHOLD="${SUPERVISOR_CIRCUIT_BREAKER_THRESHOLD:-3}"
+# Validate numeric — strip non-digits, fallback to default if empty
+CIRCUIT_BREAKER_THRESHOLD="${CIRCUIT_BREAKER_THRESHOLD//[!0-9]/}"
+[[ -n "$CIRCUIT_BREAKER_THRESHOLD" ]] || CIRCUIT_BREAKER_THRESHOLD=3
 
 # Auto-reset cooldown in seconds (default: 30 minutes)
 CIRCUIT_BREAKER_COOLDOWN_SECS="${SUPERVISOR_CIRCUIT_BREAKER_COOLDOWN_SECS:-1800}"
+# Validate numeric — strip non-digits, fallback to default if empty
+CIRCUIT_BREAKER_COOLDOWN_SECS="${CIRCUIT_BREAKER_COOLDOWN_SECS//[!0-9]/}"
+[[ -n "$CIRCUIT_BREAKER_COOLDOWN_SECS" ]] || CIRCUIT_BREAKER_COOLDOWN_SECS=1800
 
 # ============================================================
 # STATE FILE
@@ -30,6 +36,78 @@ _cb_state_file() {
 	local dir="${SUPERVISOR_DIR:-${HOME}/.aidevops/.agent-workspace/supervisor}"
 	mkdir -p "$dir" || true
 	echo "$dir/circuit-breaker.state"
+	return 0
+}
+
+# ============================================================
+# LOCK WRAPPER — serialise read-modify-write sequences
+# ============================================================
+
+#######################################
+# Acquire a directory-based lock, run a command, then release.
+# Uses mkdir for atomic lock creation (POSIX-safe).
+# Uses trap to ensure cleanup even under set -e / errexit.
+# Args: $@ = command and arguments to run under lock
+# Returns: exit code of the wrapped command, or 1 on lock timeout
+#######################################
+_cb_with_state_lock() {
+	local lock_dir
+	lock_dir="$(_cb_state_file).lock"
+	local attempts=0
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		sleep 0.05
+		attempts=$((attempts + 1))
+		if [[ "$attempts" -gt 200 ]]; then
+			log_warn "circuit-breaker: lock acquisition timed out after 10s"
+			return 1
+		fi
+	done
+	# Trap ensures lock cleanup even if "$@" fails under set -e
+	# shellcheck disable=SC2064
+	trap "rmdir '$lock_dir' 2>/dev/null || true" RETURN
+	"$@"
+	local rc=$?
+	return "$rc"
+}
+
+# ============================================================
+# HELPERS
+# ============================================================
+
+#######################################
+# Parse an ISO 8601 timestamp to epoch seconds.
+# Returns epoch via stdout. On parse failure returns empty string
+# (caller must handle — never silently returns 0).
+# Args: $1 = ISO 8601 timestamp (e.g. "2026-02-19T08:00:00Z")
+#######################################
+_cb_iso_to_epoch() {
+	local ts="$1"
+	local epoch=""
+	# macOS date
+	epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" '+%s' 2>/dev/null) ||
+		# GNU date
+		epoch=$(date -u -d "$ts" '+%s' 2>/dev/null) ||
+		epoch=""
+	echo "$epoch"
+	return 0
+}
+
+#######################################
+# Calculate seconds elapsed since a given ISO timestamp.
+# Returns elapsed seconds via stdout, or empty string on parse failure.
+# Args: $1 = ISO 8601 timestamp
+#######################################
+_cb_elapsed_since() {
+	local ts="$1"
+	local epoch
+	epoch=$(_cb_iso_to_epoch "$ts")
+	if [[ -z "$epoch" || "$epoch" == "0" ]]; then
+		echo ""
+		return 0
+	fi
+	local now_epoch
+	now_epoch=$(date -u +%s) || now_epoch=0
+	echo $((now_epoch - epoch))
 	return 0
 }
 
@@ -47,7 +125,15 @@ cb_read_state() {
 	state_file=$(_cb_state_file)
 
 	if [[ -f "$state_file" ]]; then
-		cat "$state_file"
+		# Validate JSON before returning — corrupted file returns defaults
+		local content
+		content=$(cat "$state_file" 2>/dev/null) || content=""
+		if printf '%s' "$content" | jq empty 2>/dev/null; then
+			echo "$content"
+		else
+			log_warn "circuit-breaker: corrupted state file, returning defaults"
+			echo '{"consecutive_failures":0,"tripped":false,"tripped_at":"","last_failure_at":"","last_failure_task":"","last_reset_at":""}'
+		fi
 	else
 		echo '{"consecutive_failures":0,"tripped":false,"tripped_at":"","last_failure_at":"","last_failure_task":"","last_reset_at":""}'
 	fi
@@ -56,7 +142,9 @@ cb_read_state() {
 
 #######################################
 # Write circuit breaker state atomically
+# Hardened: failures here must not propagate errexit to caller.
 # Args: $1 = JSON state string
+# Returns: 0 on success, 1 on failure (logged, non-fatal)
 #######################################
 cb_write_state() {
 	local state_json="$1"
@@ -65,8 +153,16 @@ cb_write_state() {
 
 	# Atomic write via temp file + mv
 	local tmp_file="${state_file}.tmp.$$"
-	printf '%s\n' "$state_json" >"$tmp_file"
-	mv -f "$tmp_file" "$state_file"
+	if ! printf '%s\n' "$state_json" >"$tmp_file" 2>/dev/null; then
+		log_warn "circuit-breaker: failed to write temp state file: $tmp_file"
+		rm -f "$tmp_file" 2>/dev/null || true
+		return 1
+	fi
+	if ! mv -f "$tmp_file" "$state_file" 2>/dev/null; then
+		log_warn "circuit-breaker: failed to move temp state to: $state_file"
+		rm -f "$tmp_file" 2>/dev/null || true
+		return 1
+	fi
 	return 0
 }
 
@@ -81,42 +177,41 @@ cb_write_state() {
 # Returns: 0 always (non-blocking — must not abort dispatch flow)
 #######################################
 cb_record_failure() {
+	_cb_with_state_lock _cb_record_failure_impl "$@" || true
+	return 0
+}
+
+_cb_record_failure_impl() {
 	local task_id="$1"
 	local failure_reason="${2:-unknown}"
 
 	local state
-	state=$(cb_read_state)
+	state=$(cb_read_state) || {
+		log_warn "circuit-breaker: failed to read state"
+		return 0
+	}
 
-	local current_count
-	current_count=$(printf '%s' "$state" | jq -r '.consecutive_failures // 0' || echo "0")
-
-	local new_count=$((current_count + 1))
-	local now
+	local current_count tripped now
+	current_count=$(printf '%s' "$state" | jq -r '.consecutive_failures // 0') || current_count=0
+	tripped=$(printf '%s' "$state" | jq -r '.tripped // false') || tripped="false"
 	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-	local tripped
-	tripped=$(printf '%s' "$state" | jq -r '.tripped // false' || echo "false")
+	local new_count=$((current_count + 1))
 
-	# Update state with new failure count
+	# Build complete new state in a single jq pass
 	local new_state
-	new_state=$(printf '%s' "$state" | jq \
-		--argjson count "$new_count" \
-		--arg now "$now" \
-		--arg task "$task_id" \
-		--arg reason "$failure_reason" \
-		'.consecutive_failures = $count | .last_failure_at = $now | .last_failure_task = $task | .last_failure_reason = $reason')
-
-	if [[ -z "$new_state" ]]; then
-		log_warn "circuit-breaker: failed to update state JSON"
-		return 0
-	fi
-
-	# Check if we should trip the breaker
 	if [[ "$tripped" != "true" && "$new_count" -ge "$CIRCUIT_BREAKER_THRESHOLD" ]]; then
-		new_state=$(printf '%s' "$new_state" | jq \
+		# Trip the breaker — set tripped + tripped_at in one jq call
+		new_state=$(printf '%s' "$state" | jq \
+			--argjson count "$new_count" \
 			--arg now "$now" \
-			'.tripped = true | .tripped_at = $now')
-		cb_write_state "$new_state"
+			--arg task "$task_id" \
+			--arg reason "$failure_reason" \
+			'.consecutive_failures = $count | .last_failure_at = $now | .last_failure_task = $task | .last_failure_reason = $reason | .tripped = true | .tripped_at = $now') || {
+			log_warn "circuit-breaker: failed to update state JSON"
+			return 0
+		}
+		cb_write_state "$new_state" || return 0
 		log_error "circuit-breaker: TRIPPED after $new_count consecutive failures (threshold: $CIRCUIT_BREAKER_THRESHOLD)"
 		log_error "circuit-breaker: last failure: $task_id ($failure_reason)"
 		log_error "circuit-breaker: dispatch is PAUSED. Reset with: supervisor-helper.sh circuit-breaker reset"
@@ -124,7 +219,17 @@ cb_record_failure() {
 		# Create/update GitHub issue
 		_cb_create_or_update_issue "$new_count" "$task_id" "$failure_reason" || true
 	else
-		cb_write_state "$new_state"
+		# Update failure count only
+		new_state=$(printf '%s' "$state" | jq \
+			--argjson count "$new_count" \
+			--arg now "$now" \
+			--arg task "$task_id" \
+			--arg reason "$failure_reason" \
+			'.consecutive_failures = $count | .last_failure_at = $now | .last_failure_task = $task | .last_failure_reason = $reason') || {
+			log_warn "circuit-breaker: failed to update state JSON"
+			return 0
+		}
+		cb_write_state "$new_state" || return 0
 		if [[ "$tripped" == "true" ]]; then
 			log_warn "circuit-breaker: failure recorded ($new_count total) — breaker already tripped"
 		else
@@ -140,14 +245,17 @@ cb_record_failure() {
 # Returns: 0 always
 #######################################
 cb_record_success() {
+	_cb_with_state_lock _cb_record_success_impl || true
+	return 0
+}
+
+_cb_record_success_impl() {
 	local state
-	state=$(cb_read_state)
+	state=$(cb_read_state) || return 0
 
-	local current_count
-	current_count=$(printf '%s' "$state" | jq -r '.consecutive_failures // 0' || echo "0")
-
-	local was_tripped
-	was_tripped=$(printf '%s' "$state" | jq -r '.tripped // false' || echo "false")
+	local current_count was_tripped
+	current_count=$(printf '%s' "$state" | jq -r '.consecutive_failures // 0') || current_count=0
+	was_tripped=$(printf '%s' "$state" | jq -r '.tripped // false') || was_tripped="false"
 
 	# Only write if there's something to reset
 	if [[ "$current_count" -eq 0 && "$was_tripped" != "true" ]]; then
@@ -160,13 +268,11 @@ cb_record_success() {
 	local new_state
 	new_state=$(printf '%s' "$state" | jq \
 		--arg now "$now" \
-		'.consecutive_failures = 0 | .tripped = false | .last_reset_at = $now | .reset_reason = "task_success"')
-
-	if [[ -z "$new_state" ]]; then
+		'.consecutive_failures = 0 | .tripped = false | .last_reset_at = $now | .reset_reason = "task_success"') || {
 		return 0
-	fi
+	}
 
-	cb_write_state "$new_state"
+	cb_write_state "$new_state" || return 0
 
 	if [[ "$was_tripped" == "true" ]]; then
 		log_success "circuit-breaker: RESET by task success (was tripped with $current_count consecutive failures)"
@@ -186,10 +292,10 @@ cb_record_success() {
 #######################################
 cb_check() {
 	local state
-	state=$(cb_read_state)
+	state=$(cb_read_state) || return 0
 
 	local tripped
-	tripped=$(printf '%s' "$state" | jq -r '.tripped // false' || echo "false")
+	tripped=$(printf '%s' "$state" | jq -r '.tripped // false') || tripped="false"
 
 	if [[ "$tripped" != "true" ]]; then
 		return 0
@@ -197,15 +303,17 @@ cb_check() {
 
 	# Check auto-reset cooldown
 	local tripped_at
-	tripped_at=$(printf '%s' "$state" | jq -r '.tripped_at // ""' || echo "")
+	tripped_at=$(printf '%s' "$state" | jq -r '.tripped_at // ""') || tripped_at=""
 
 	if [[ -n "$tripped_at" && "$CIRCUIT_BREAKER_COOLDOWN_SECS" -gt 0 ]]; then
-		local now_epoch tripped_epoch elapsed
-		now_epoch=$(date -u +%s) || now_epoch=0
-		tripped_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$tripped_at" '+%s' ||
-			date -u -d "$tripped_at" '+%s' ||
-			echo 0)
-		elapsed=$((now_epoch - tripped_epoch))
+		local elapsed
+		elapsed=$(_cb_elapsed_since "$tripped_at")
+
+		# If timestamp parse failed, keep breaker open (don't auto-reset on bad data)
+		if [[ -z "$elapsed" ]]; then
+			log_warn "circuit-breaker: TRIPPED — could not parse tripped_at timestamp, keeping breaker open"
+			return 1
+		fi
 
 		if [[ "$elapsed" -ge "$CIRCUIT_BREAKER_COOLDOWN_SECS" ]]; then
 			log_info "circuit-breaker: auto-reset after ${elapsed}s cooldown (threshold: ${CIRCUIT_BREAKER_COOLDOWN_SECS}s)"
@@ -229,15 +337,21 @@ cb_check() {
 #######################################
 cb_reset() {
 	local reason="${1:-manual_reset}"
+	_cb_with_state_lock _cb_reset_impl "$reason"
+}
+
+_cb_reset_impl() {
+	local reason="$1"
 
 	local state
-	state=$(cb_read_state)
+	state=$(cb_read_state) || {
+		log_error "circuit-breaker: failed to read state for reset"
+		return 1
+	}
 
-	local was_tripped
-	was_tripped=$(printf '%s' "$state" | jq -r '.tripped // false' || echo "false")
-
-	local prev_count
-	prev_count=$(printf '%s' "$state" | jq -r '.consecutive_failures // 0' || echo "0")
+	local was_tripped prev_count
+	was_tripped=$(printf '%s' "$state" | jq -r '.tripped // false') || was_tripped="false"
+	prev_count=$(printf '%s' "$state" | jq -r '.consecutive_failures // 0') || prev_count=0
 
 	local now
 	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -246,14 +360,12 @@ cb_reset() {
 	new_state=$(printf '%s' "$state" | jq \
 		--arg now "$now" \
 		--arg reason "$reason" \
-		'.consecutive_failures = 0 | .tripped = false | .last_reset_at = $now | .reset_reason = $reason')
-
-	if [[ -z "$new_state" ]]; then
+		'.consecutive_failures = 0 | .tripped = false | .last_reset_at = $now | .reset_reason = $reason') || {
 		log_error "circuit-breaker: failed to build reset state"
 		return 1
-	fi
+	}
 
-	cb_write_state "$new_state"
+	cb_write_state "$new_state" || return 1
 
 	if [[ "$was_tripped" == "true" ]]; then
 		log_success "circuit-breaker: RESET ($reason) — dispatch resumed (was $prev_count consecutive failures)"
@@ -272,14 +384,18 @@ cb_reset() {
 #######################################
 cb_status() {
 	local state
-	state=$(cb_read_state)
+	state=$(cb_read_state) || {
+		echo "Circuit Breaker Status: unable to read state"
+		return 0
+	}
 
 	local tripped count tripped_at last_failure last_reset
-	tripped=$(printf '%s' "$state" | jq -r '.tripped // false' || echo "false")
-	count=$(printf '%s' "$state" | jq -r '.consecutive_failures // 0' || echo "0")
-	tripped_at=$(printf '%s' "$state" | jq -r '.tripped_at // "never"' || echo "never")
-	last_failure=$(printf '%s' "$state" | jq -r '.last_failure_task // "none"' || echo "none")
-	last_reset=$(printf '%s' "$state" | jq -r '.last_reset_at // "never"' || echo "never")
+	tripped=$(printf '%s' "$state" | jq -r '.tripped // false') || tripped="false"
+	count=$(printf '%s' "$state" | jq -r '.consecutive_failures // 0') || count=0
+	# Use if/then/else in jq to handle both null and empty string
+	tripped_at=$(printf '%s' "$state" | jq -r 'if (.tripped_at // "") == "" then "never" else .tripped_at end') || tripped_at="never"
+	last_failure=$(printf '%s' "$state" | jq -r 'if (.last_failure_task // "") == "" then "none" else .last_failure_task end') || last_failure="none"
+	last_reset=$(printf '%s' "$state" | jq -r 'if (.last_reset_at // "") == "" then "never" else .last_reset_at end') || last_reset="never"
 
 	echo "Circuit Breaker Status"
 	echo "======================"
@@ -297,17 +413,17 @@ cb_status() {
 
 	# Show time until auto-reset if tripped
 	if [[ "$tripped" == "true" && "$tripped_at" != "never" && "$CIRCUIT_BREAKER_COOLDOWN_SECS" -gt 0 ]]; then
-		local now_epoch tripped_epoch elapsed remaining
-		now_epoch=$(date -u +%s) || now_epoch=0
-		tripped_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$tripped_at" '+%s' ||
-			date -u -d "$tripped_at" '+%s' ||
-			echo 0)
-		elapsed=$((now_epoch - tripped_epoch))
-		remaining=$((CIRCUIT_BREAKER_COOLDOWN_SECS - elapsed))
-		if [[ "$remaining" -gt 0 ]]; then
-			echo "Auto-reset in:        ${remaining}s"
+		local elapsed
+		elapsed=$(_cb_elapsed_since "$tripped_at")
+		if [[ -n "$elapsed" ]]; then
+			local remaining=$((CIRCUIT_BREAKER_COOLDOWN_SECS - elapsed))
+			if [[ "$remaining" -gt 0 ]]; then
+				echo "Auto-reset in:        ${remaining}s"
+			else
+				echo "Auto-reset in:        overdue (will reset on next check)"
+			fi
 		else
-			echo "Auto-reset in:        overdue (will reset on next check)"
+			echo "Auto-reset in:        unknown (could not parse tripped_at)"
 		fi
 	fi
 
@@ -317,6 +433,18 @@ cb_status() {
 # ============================================================
 # GITHUB ISSUE MANAGEMENT
 # ============================================================
+
+#######################################
+# Resolve the GitHub repo slug once for all gh CLI operations.
+# Returns: repo slug via stdout (e.g. "owner/repo"), or empty on failure.
+# Does not suppress stderr — auth/network errors remain visible.
+#######################################
+_cb_resolve_repo_slug() {
+	local repo_slug
+	repo_slug=$(gh repo view --json nameWithOwner -q '.nameWithOwner') || repo_slug=""
+	echo "$repo_slug"
+	return 0
+}
 
 #######################################
 # Create or update a GitHub issue when the circuit breaker trips
@@ -334,10 +462,18 @@ _cb_create_or_update_issue() {
 		return 1
 	fi
 
+	# Resolve repo slug once for all gh commands in this function
+	local repo_slug
+	repo_slug=$(_cb_resolve_repo_slug)
+	if [[ -z "$repo_slug" ]]; then
+		log_warn "circuit-breaker: could not determine GitHub repository, skipping issue creation"
+		return 1
+	fi
+
 	# Check for existing open circuit-breaker issue
 	local existing_issue
 	existing_issue=$(gh issue list \
-		--repo "$(gh repo view --json nameWithOwner -q '.nameWithOwner' || echo '')" \
+		--repo "$repo_slug" \
 		--label "circuit-breaker" \
 		--state open \
 		--json number \
@@ -378,6 +514,7 @@ Supervisor dispatch is **paused**. No new tasks will be dispatched until the cir
 	if [[ -n "$existing_issue" ]]; then
 		# Update existing issue with a comment
 		gh issue comment "$existing_issue" \
+			--repo "$repo_slug" \
 			--body "### Circuit breaker re-tripped at ${now}
 
 - Consecutive failures: ${failure_count}
@@ -391,12 +528,14 @@ Supervisor dispatch is **paused**. No new tasks will be dispatched until the cir
 		# Create new issue
 		# Ensure the circuit-breaker label exists
 		gh label create "circuit-breaker" \
+			--repo "$repo_slug" \
 			--description "Supervisor circuit breaker tripped — dispatch paused" \
 			--color "D93F0B" \
 			--force || true
 
 		local issue_url
 		issue_url=$(gh issue create \
+			--repo "$repo_slug" \
 			--title "Supervisor circuit breaker tripped — ${failure_count} consecutive failures" \
 			--body "$body" \
 			--label "circuit-breaker") || {
@@ -421,8 +560,15 @@ _cb_close_issue() {
 		return 1
 	fi
 
+	local repo_slug
+	repo_slug=$(_cb_resolve_repo_slug)
+	if [[ -z "$repo_slug" ]]; then
+		return 1
+	fi
+
 	local existing_issue
 	existing_issue=$(gh issue list \
+		--repo "$repo_slug" \
 		--label "circuit-breaker" \
 		--state open \
 		--json number \
@@ -433,6 +579,7 @@ _cb_close_issue() {
 	fi
 
 	gh issue close "$existing_issue" \
+		--repo "$repo_slug" \
 		--comment "Circuit breaker reset: ${reason}" || {
 		log_warn "circuit-breaker: failed to close issue #$existing_issue"
 		return 1
@@ -487,7 +634,7 @@ cmd_circuit_breaker() {
 			log_error "circuit-breaker: failed to build trip state JSON"
 			return 1
 		}
-		cb_write_state "$state"
+		cb_write_state "$state" || return 1
 		log_warn "circuit-breaker: manually tripped (task: $task_id, reason: $reason)"
 		_cb_create_or_update_issue "$CIRCUIT_BREAKER_THRESHOLD" "$task_id" "$reason" || true
 		;;

--- a/todo/tasks/t1331-brief.md
+++ b/todo/tasks/t1331-brief.md
@@ -49,7 +49,8 @@ Key files:
     method: codebase
     pattern: "circuit.breaker|consecutive_fail"
     path: ".agents/scripts/supervisor/"
-  ```
+   ```
+
 - [ ] A GitHub issue is created/updated with `circuit-breaker` label on trip
 
   ```yaml
@@ -57,7 +58,8 @@ Key files:
     method: codebase
     pattern: "circuit-breaker"
     path: ".agents/scripts/supervisor/"
-  ```
+   ```
+
 - [ ] `supervisor-helper.sh circuit-breaker status` shows current state
 - [ ] `supervisor-helper.sh circuit-breaker reset` resumes dispatch
 - [ ] Counter resets to 0 on any successful task completion

--- a/todo/tasks/t1331-brief.md
+++ b/todo/tasks/t1331-brief.md
@@ -64,12 +64,14 @@ Key files:
 - [ ] `supervisor-helper.sh circuit-breaker reset` resumes dispatch
 - [ ] Counter resets to 0 on any successful task completion
 - [ ] Threshold is configurable via `SUPERVISOR_CIRCUIT_BREAKER_THRESHOLD`
+
   ```yaml
   verify:
     method: codebase
     pattern: "SUPERVISOR_CIRCUIT_BREAKER_THRESHOLD"
     path: ".agents/scripts/supervisor/"
   ```
+
 - [ ] ShellCheck clean on modified scripts
 
 ## Context & Decisions


### PR DESCRIPTION
## Summary

- **Circuit breaker module** (`circuit-breaker.sh`): Tracks consecutive task failures globally. After N failures (default: 3, configurable via `SUPERVISOR_CIRCUIT_BREAKER_THRESHOLD`), pauses dispatch and creates/updates a GitHub issue with the `circuit-breaker` label. Auto-resets after configurable cooldown (default: 30 min) or on any task success. Manual reset via `supervisor-helper.sh circuit-breaker reset`.
- **Stuck detection module** (`stuck-detection.sh`): Advisory milestone checks at 30/60/120 min for long-running tasks. Uses haiku-tier AI reasoning to evaluate whether a task is stuck (confidence >0.7 threshold). Tags GitHub issues with `stuck-detection` label and posts explanatory comments. **Advisory only** — never auto-cancels or modifies tasks.
- **Pulse integration**: Circuit breaker check gates Phase 2 dispatch; failure/success outcomes in Phase 1 feed the circuit breaker counter; stuck detection runs as Phase 0.75.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/supervisor/circuit-breaker.sh` | New — 511 lines. State management (JSON file), failure/success recording, auto-reset cooldown, GitHub issue lifecycle, CLI subcommand handler |
| `.agents/scripts/supervisor/stuck-detection.sh` | New — 670 lines. Milestone tracking, AI evaluation, GitHub label management, DB schema, reporting |
| `.agents/scripts/supervisor/pulse.sh` | Integrate circuit breaker (Phase 2 gate, success/failure/blocked recording) and stuck detection (Phase 0.75) |
| `.agents/scripts/supervisor/database.sh` | Add `stuck_detection_log` table schema + migration + pruning |
| `.agents/scripts/supervisor-helper.sh` | Source new modules, register CLI subcommands (`circuit-breaker`, `stuck-detection`, `stuck-detection-report`) |
| `.agents/scripts/commands/full-loop.md` | Add CI failure debugging guidance (t1334) |
| `.agents/scripts/compare-models-helper.sh` | Add `--score`/`--judge` flags and judge scoring pipeline for cross-review (t1329) |
| `.agents/AGENTS.md` | Add Communications and opsec to domain index |
| `todo/tasks/t1331-brief.md` | Task brief |
| `todo/tasks/t1332-brief.md` | Task brief |

## Testing

- `supervisor-helper.sh circuit-breaker status` — shows CLOSED state
- `supervisor-helper.sh circuit-breaker trip` — manually trips, creates GitHub issue
- `supervisor-helper.sh circuit-breaker reset` — resets, closes GitHub issue
- `supervisor-helper.sh circuit-breaker check` — returns exit 0 (closed) or 1 (open)
- Stuck detection integrates into pulse Phase 0.75 and is advisory-only

## Related

- t1331: Supervisor circuit breaker
- t1332: Supervisor stuck detection (advisory milestone checks)
- t1329: Cross-review judge scoring pipeline
- t1334: CI failure debugging guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Circuit-breaker added: automatic pause of Phase 2 dispatch after consecutive failures, with auto-reset cooldown and manual controls.
  * GitHub issue integration to create/update/close tracking issues when the circuit trips or resets.
  * CLI now exposes circuit-breaker commands (status|reset|check|trip) in the help surface.

* **Bug Fixes / Reliability**
  * Safer state handling, validation, locking and time handling to prevent corruption and race conditions.

* **Documentation**
  * Help/usage text and brief task notes updated for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->