### PR TITLE
t1329: Cross-review judge pipeline and /cross-review slash command

### DIFF
--- a/.agents/scripts/commands/cross-review.md
+++ b/.agents/scripts/commands/cross-review.md
@@ -1,10 +1,10 @@
 ---
-description: Dispatch the same prompt to multiple AI models, diff results, and optionally auto-score via a judge model
+description: Dispatch a prompt to multiple AI models, diff results, and optionally score via a judge model
 agent: Build+
 mode: subagent
 ---
 
-Dispatch a prompt to multiple AI models in parallel, collect and diff their responses, and optionally score them via a judge model.
+Run a multi-model adversarial review: dispatch the same prompt to N models in parallel, collect outputs, diff results, and optionally score via a judge model (Ouroboros-style pipeline).
 
 Target: $ARGUMENTS
 
@@ -15,7 +15,7 @@ Target: $ARGUMENTS
    ```bash
    /cross-review "review this PR diff" --models sonnet,opus
    /cross-review "audit this code" --models sonnet,gemini-pro,gpt-4.1 --score
-   /cross-review "design this API" --score --judge opus
+   /cross-review "design this API" --score --judge opus --task-type analysis
    ```
 
 2. Run the cross-review:
@@ -32,11 +32,11 @@ Target: $ARGUMENTS
      --models "sonnet,gemini-pro,gpt-4.1" \
      --score
 
-   # With custom judge model
+   # With custom judge model and task type
    ~/.aidevops/agents/scripts/compare-models-helper.sh cross-review \
      --prompt "your prompt here" \
      --models "sonnet,opus" \
-     --score --judge sonnet
+     --score --judge sonnet --task-type review
    ```
 
 3. Present the results:
@@ -46,16 +46,18 @@ Target: $ARGUMENTS
    - Note any models that failed to respond
 
 4. If `--score` was used, scores are automatically:
-   - Recorded in the model-comparisons SQLite DB
-   - Fed into the pattern tracker for model routing (`/route`, `/patterns`)
+   - Recorded in the model-comparisons SQLite DB (`~/.aidevops/.agent-workspace/memory/model-comparisons.db`)
+   - Fed into the pattern tracker for data-driven model routing (`/route`, `/patterns`)
 
 ## Options
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `--prompt` | (required) | The review prompt |
 | `--models` | `sonnet,opus` | Comma-separated model tiers to compare |
 | `--score` | off | Auto-score outputs via judge model |
 | `--judge` | `opus` | Judge model tier (used with `--score`) |
+| `--task-type` | `general` | Scoring category: `code`, `review`, `analysis`, `text`, `general` |
 | `--timeout` | `600` | Seconds per model |
 | `--output` | auto | Directory for raw outputs |
 | `--workdir` | `pwd` | Working directory for model context |
@@ -72,7 +74,7 @@ Target: $ARGUMENTS
 | completeness | Coverage of all requirements and edge cases |
 | quality | Code quality, best practices, maintainability |
 | clarity | Clear explanation, good formatting, readability |
-| adherence | Following the original prompt instructions precisely |
+| overall | Judge's holistic assessment |
 
 ## Examples
 
@@ -84,12 +86,24 @@ Target: $ARGUMENTS
 /cross-review "Design a rate limiting strategy for a REST API" \
   --models sonnet,opus,pro --score
 
+# Custom judge model and task type
+/cross-review "Audit this architecture" --models "sonnet,opus" --score --judge opus --task-type analysis
+
 # Quick diff with custom timeout
 /cross-review "Summarize the key changes in this diff" --models haiku,sonnet --timeout 120
 
 # View scoring results after a cross-review
 /score-responses --leaderboard
 ```
+
+## Output
+
+- Per-model responses displayed inline
+- Diff summary (word counts, unified diff for 2-model comparisons)
+- Judge scores table (when `--score` is set)
+- Winner declaration with reasoning
+- Results saved to `~/.aidevops/.agent-workspace/tmp/cross-review-<timestamp>/`
+- Judge JSON saved to `<output_dir>/judge-scores.json`
 
 ## Related
 

--- a/.agents/scripts/commands/cross-review.md
+++ b/.agents/scripts/commands/cross-review.md
@@ -10,6 +10,15 @@ Target: $ARGUMENTS
 
 ## Instructions
 
+Parse the arguments to extract:
+- `--prompt`: the review prompt (required)
+- `--models`: comma-separated model tiers (default: `sonnet,opus`)
+- `--score`: enable judge scoring pipeline (optional flag)
+- `--judge`: judge model tier (default: `opus`)
+- `--task-type`: scoring category — `code`, `review`, `analysis`, `text`, `general` (default: `general`)
+- `--timeout`: per-model timeout in seconds (default: 600)
+- `--output`: output directory (default: auto-generated tmp dir)
+
 1. Parse the user's arguments. Common forms:
 
    ```bash
@@ -68,13 +77,14 @@ Target: $ARGUMENTS
 
 ## Scoring Criteria (judge model, 1-10 scale)
 
-| Criterion | Description |
-|-----------|-------------|
-| correctness | Factual accuracy and technical correctness |
-| completeness | Coverage of all requirements and edge cases |
-| quality | Code quality, best practices, maintainability |
-| clarity | Clear explanation, good formatting, readability |
-| overall | Judge's holistic assessment |
+| Criterion | Scale | Description |
+|-----------|-------|-------------|
+| Correctness | 1-10 | Factual accuracy and technical correctness |
+| Completeness | 1-10 | Coverage of all requirements and edge cases |
+| Quality | 1-10 | Code quality / writing quality |
+| Clarity | 1-10 | Clear explanation, good formatting, readability |
+| Adherence | 1-10 | Following instructions precisely, staying on-task |
+| Overall | 1-10 | Judge's holistic assessment |
 
 ## Examples
 

--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -741,13 +741,14 @@ ${response_text}"
 
 	# Build judge system prompt
 	local system_prompt
-	system_prompt='You are an expert AI model evaluator. You will be given a prompt and responses from multiple AI models. Score each model on four criteria (1-10 scale) and declare a winner.
+	system_prompt='You are an expert AI model evaluator. You will be given a prompt and responses from multiple AI models. Score each model on five criteria (1-10 scale) and declare a winner.
 
 Scoring criteria:
 - correctness (1-10): Factual accuracy and technical correctness
 - completeness (1-10): Coverage of all requirements and edge cases
 - quality (1-10): Code quality, best practices, structure (or writing quality for non-code)
 - clarity (1-10): Clear explanation, good formatting, readability
+- adherence (1-10): Following instructions precisely, staying on-task
 
 Respond with ONLY a valid JSON object in this exact format (no markdown, no explanation):
 {
@@ -757,6 +758,7 @@ Respond with ONLY a valid JSON object in this exact format (no markdown, no expl
       "completeness": <1-10>,
       "quality": <1-10>,
       "clarity": <1-10>,
+      "adherence": <1-10>,
       "overall": <1-10>,
       "strengths": "<brief strengths>",
       "weaknesses": "<brief weaknesses>"
@@ -780,7 +782,7 @@ Score each model and declare a winner."
 	local judge_model_id
 	judge_model_id=$(resolve_model_tier "$judge_model" 2>/dev/null || echo "$judge_model")
 
-	# Strip provider prefix — Anthropic Messages API expects raw model IDs
+	# Anthropic Messages API expects raw model IDs without provider prefix
 	if [[ "$judge_model_id" == anthropic/* ]]; then
 		judge_model_id="${judge_model_id#anthropic/}"
 	elif [[ "$judge_model_id" == */* ]]; then
@@ -1102,8 +1104,8 @@ cmd_cross_review() {
 
 		local judge_json
 		if ! judge_json=$(_judge_cross_review "$output_dir" "$models_str" "$prompt" "$judge_model" "$task_type"); then
-			print_warning "Judge scoring failed — raw outputs still saved to $output_dir"
-			return 0
+			print_error "Judge scoring failed — raw outputs still saved to $output_dir"
+			return 1
 		fi
 
 		# Save judge output
@@ -1118,11 +1120,11 @@ cmd_cross_review() {
 		printf "%-22s %6s %6s %6s %6s %7s\n" "-----" "----" "----" "----" "----" "-------"
 
 		local winner=""
-		winner=$(echo "$judge_json" | jq -r '.winner // empty' 2>/dev/null)
+		winner=$(echo "$judge_json" | jq -r '.winner // empty')
 		local winner_reasoning=""
-		winner_reasoning=$(echo "$judge_json" | jq -r '.winner_reasoning // empty' 2>/dev/null)
+		winner_reasoning=$(echo "$judge_json" | jq -r '.winner_reasoning // empty')
 		local judge_task_type=""
-		judge_task_type=$(echo "$judge_json" | jq -r '.task_type // empty' 2>/dev/null)
+		judge_task_type=$(echo "$judge_json" | jq -r '.task_type // empty')
 		[[ -n "$judge_task_type" ]] && task_type="$judge_task_type"
 
 		# Build cmd_score args from judge JSON
@@ -1131,17 +1133,24 @@ cmd_cross_review() {
 		local -a scored_models=()
 		while IFS= read -r model_name; do
 			scored_models+=("$model_name")
-		done < <(echo "$judge_json" | jq -r '.scores | keys[]' 2>/dev/null)
+		done < <(echo "$judge_json" | jq -r '.scores | keys[]')
 
 		for model_name in "${scored_models[@]}"; do
-			local m_corr m_comp m_qual m_clar m_overall m_str m_wea
-			m_corr=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].correctness // 0" 2>/dev/null)
-			m_comp=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].completeness // 0" 2>/dev/null)
-			m_qual=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].quality // 0" 2>/dev/null)
-			m_clar=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].clarity // 0" 2>/dev/null)
-			m_overall=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].overall // 0" 2>/dev/null)
-			m_str=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].strengths // \"\"" 2>/dev/null)
-			m_wea=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].weaknesses // \"\"" 2>/dev/null)
+			# Consolidate jq calls into a single pass using --arg for safe variable passing
+			local m_corr m_comp m_qual m_clar m_adh m_overall m_str m_wea
+			read -r m_corr m_comp m_qual m_clar m_adh m_overall m_str m_wea <<<"$(echo "$judge_json" | jq -r --arg mn "$model_name" '
+				.scores[$mn] |
+				[
+					(.correctness // 0),
+					(.completeness // 0),
+					(.quality // 0),
+					(.clarity // 0),
+					(.adherence // 0),
+					(.overall // 0),
+					(.strengths // ""),
+					(.weaknesses // "")
+				] | @tsv
+			')"
 
 			local result_file="${output_dir}/${model_name}.txt"
 			printf "%-22s %6s %6s %6s %6s %7s\n" \
@@ -1154,7 +1163,7 @@ cmd_cross_review() {
 				--completeness "$m_comp"
 				--quality "$m_qual"
 				--clarity "$m_clar"
-				--adherence "$m_overall"
+				--adherence "$m_adh"
 				--strengths "$m_str"
 				--weaknesses "$m_wea"
 				--response "${result_file:-}"
@@ -1172,7 +1181,7 @@ cmd_cross_review() {
 
 		# Record scores in model-comparisons DB via cmd_score
 		echo "Recording scores in model-comparisons DB..."
-		if cmd_score "${score_args[@]}" 2>/dev/null; then
+		if cmd_score "${score_args[@]}"; then
 			print_success "Scores recorded in model-comparisons DB"
 		else
 			print_warning "cmd_score recording failed (scores still in $judge_file)"
@@ -1187,22 +1196,21 @@ cmd_cross_review() {
 			[[ -z "$winner_tier" ]] && winner_tier="$winner"
 
 			for model_name in "${scored_models[@]}"; do
-				local m_ove
-				m_ove=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].overall // 0" 2>/dev/null)
+				# Extract scores in a single jq pass using --arg for safe variable passing
+				local m_ove raw_corr raw_comp raw_qual raw_clar
+				read -r m_ove raw_corr raw_comp raw_qual raw_clar <<<"$(echo "$judge_json" | jq -r --arg mn "$model_name" '
+					.scores[$mn] | [(.overall // 0), (.correctness // 0), (.completeness // 0), (.quality // 0), (.clarity // 0)] | @tsv
+				')"
 				local m_tier
 				m_tier=$(model_id_to_tier "$model_name")
 				[[ -z "$m_tier" ]] && m_tier="$model_name"
 
 				# Normalize 1-10 to 1-5 for pattern tracker
 				local norm_corr norm_comp norm_qual norm_clar
-				norm_corr=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].correctness // 0" 2>/dev/null)
-				norm_comp=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].completeness // 0" 2>/dev/null)
-				norm_qual=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].quality // 0" 2>/dev/null)
-				norm_clar=$(echo "$judge_json" | jq -r ".scores[\"${model_name}\"].clarity // 0" 2>/dev/null)
-				norm_corr=$(awk "BEGIN{v=int($norm_corr/2+0.5); if(v<1)v=1; if(v>5)v=5; print v}")
-				norm_comp=$(awk "BEGIN{v=int($norm_comp/2+0.5); if(v<1)v=1; if(v>5)v=5; print v}")
-				norm_qual=$(awk "BEGIN{v=int($norm_qual/2+0.5); if(v<1)v=1; if(v>5)v=5; print v}")
-				norm_clar=$(awk "BEGIN{v=int($norm_clar/2+0.5); if(v<1)v=1; if(v>5)v=5; print v}")
+				norm_corr=$(awk "BEGIN{v=int($raw_corr/2+0.5); if(v<1)v=1; if(v>5)v=5; print v}")
+				norm_comp=$(awk "BEGIN{v=int($raw_comp/2+0.5); if(v<1)v=1; if(v>5)v=5; print v}")
+				norm_qual=$(awk "BEGIN{v=int($raw_qual/2+0.5); if(v<1)v=1; if(v>5)v=5; print v}")
+				norm_clar=$(awk "BEGIN{v=int($raw_clar/2+0.5); if(v<1)v=1; if(v>5)v=5; print v}")
 
 				"$pt_helper" score \
 					--model "$m_tier" \


### PR DESCRIPTION
## Summary

- Add `--score` flag to `/cross-review` slash command that dispatches model outputs to a judge model (default: opus) for structured scoring on correctness, completeness, quality, clarity, and overall (1-10 scale)
- Implement `_resolve_cross_review_auth()` for Anthropic API auth resolution (env var, OAuth token, API key from OpenCode auth.json)
- Implement `_judge_cross_review()` that calls the Anthropic Messages API directly with curl, using `--config` process substitution to keep auth secrets out of the process list
- Record judge scores in the model-comparisons SQLite DB via `cmd_score` and sync winner/loser data to the pattern tracker for data-driven model routing
- Update `/cross-review` slash command documentation with argument parsing reference, scoring criteria table (including Adherence), and usage examples

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/compare-models-helper.sh` | Add `_resolve_cross_review_auth()`, `_judge_cross_review()`, judge scoring pipeline in `cmd_cross_review()`, pattern tracker sync, hardened curl auth |
| `.agents/scripts/commands/cross-review.md` | Add argument parsing reference, scoring criteria with Adherence column, `--score`/`--judge`/`--task-type` options |

## Testing

- Rebased cleanly onto current main (3 commits, all conflicts resolved)
- No new dependencies — uses existing `curl`, `jq`, `sqlite3`, `pattern-tracker-helper.sh`