### PR TITLE
t1323: Fix TTSR shell-local-params rule false-positives on currency/pricing text

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1510,9 +1510,11 @@ const BUILTIN_TTSR_RULES = [
     // Only match bare $N at the start of a line or after whitespace in what looks
     // like a shell assignment/command context — avoids matching $1 inside prose,
     // documentation, quoted examples, or tool output from file reads.
-    // Excludes currency/pricing patterns: $[1-9] followed by digits, decimal, comma,
-    // or slash (e.g. $28/mo, $1.99, $1,000) to prevent false-positives in markdown tables.
-    pattern: "^\\s+(?:echo|printf|return|if|\\[\\[).*\\$[1-9](?![0-9.,/])(?!.*local\\s+\\w+=)",
+    // Excludes currency/pricing patterns:
+    //   - $[1-9] followed by digits, decimal, comma, or slash (e.g. $28/mo, $1.99, $1,000)
+    //   - $[1-9] followed by pipe (markdown table cell boundary)
+    //   - $[1-9] followed by common currency/pricing unit words (per, mo, month, flat, etc.)
+    pattern: "^\\s+(?:echo|printf|return|if|\\[\\[).*\\$[1-9](?![0-9.,/])(?!\\s*[|])(?!\\s+(?:per|mo(?:nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)\\b)(?!.*local\\s+\\w+=)",
     correction: "Use `local var=\"$1\"` pattern — never use positional parameters directly (SonarCloud S7679).",
     severity: "warn",
     systemPrompt: "Shell scripts: use `local var=\"$1\"` — never use $1 directly in function bodies.",

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -188,8 +188,12 @@ check_positional_parameters() {
             /print.*\$[1-9]/ { next }
             /Usage:/ { next }
             # Skip currency/pricing patterns: $[1-9] followed by digit, decimal, comma,
-            # or slash (e.g. $28/mo, $1.99, $1,000) — false-positives in markdown tables.
+            # slash (e.g. $28/mo, $1.99, $1,000), pipe (markdown table), or common
+            # currency/pricing unit words (per, mo, month, flat, etc.).
             /\$[1-9][0-9.,\/]/ { next }
+            /\$[1-9][[:space:]]*\|/ { next }
+            /\$[1-9][[:space:]]+(per|mo(nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)[[:space:][:punct:]]/ { next }
+            /\$[1-9][[:space:]]+(per|mo(nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)$/ { next }
             in_func && /\$[1-9]/ && !/local.*=.*\$[1-9]/ {
                 print FILENAME ":" NR ": " $0
             }

--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -78,10 +78,11 @@ validate_positional_parameters() {
 
 	for file in "$@"; do
 		# Exclude currency/pricing patterns: $[1-9] followed by digit, decimal, comma,
-		# or slash (e.g. $28/mo, $1.99, $1,000) — false-positives in markdown tables.
-		if [[ -f "$file" ]] && grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' | grep -vE '\$[1-9][0-9.,/]' >/dev/null; then
+		# slash (e.g. $28/mo, $1.99, $1,000), pipe (markdown table cell), or common
+		# currency/pricing unit words (per, mo, month, flat, etc.).
+		if [[ -f "$file" ]] && grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' | grep -vE '\$[1-9][0-9.,/]' | grep -vE '\$[1-9]\s*\|' | grep -vE '\$[1-9]\s+(per|mo(nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)\b' >/dev/null; then
 			print_error "Direct positional parameter usage in $file"
-			grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' | grep -vE '\$[1-9][0-9.,/]' | head -3
+			grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' | grep -vE '\$[1-9][0-9.,/]' | grep -vE '\$[1-9]\s*\|' | grep -vE '\$[1-9]\s+(per|mo(nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)\b' | head -3
 			((violations++))
 		fi
 	done


### PR DESCRIPTION
## Summary

- Expanded negative lookaheads in the `shell-local-params` TTSR rule regex to exclude currency/pricing patterns that were causing false-positives
- Fixed across all three enforcement points: TTSR plugin (`index.mjs`), `linters-local.sh`, and `pre-commit-hook.sh`
- Added exclusions for: pipe characters (markdown table cells), and 20+ common currency/pricing unit words (per, mo, month, year, flat, each, fee, plan, tier, user, seat, etc.)

## Problem

The regex `$[1-9]` in the shell-local-params rule was matching dollar amounts like `$5 per month`, `$9 mo`, `$3 monthly` in markdown tables and pricing documentation. The existing negative lookahead `(?![0-9.,/])` only excluded multi-digit amounts (`$28`) and amounts with decimals/commas/slashes (`$1.99`, `$1,000`, `$5/mo`), but not standalone single-digit amounts followed by currency unit words.

## Testing

Verified with 28 test cases covering:
- **True positives**: bare `$1`-`$9` in shell commands (still correctly detected)
- **True negatives**: currency amounts with digits/decimals/commas/slashes (still excluded)
- **New true negatives**: `$5 per month`, `$9 mo`, `$3 monthly`, `$7 annual`, `$5 flat`, `$1 trial`, pipe-delimited table cells, etc.

All 28 tests pass with zero failures. ShellCheck and Node syntax checks pass clean.

Closes #2194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Reduced false positives in linting validation by properly handling Markdown table syntax and currency/pricing patterns.
  * Improved parameter validation to correctly recognize legitimate parameter usage in additional contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->