### PR TITLE
fix: add cross-repo routing rule to prevent wrong-repo task creation

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -249,6 +249,15 @@ When running as a headless worker (dispatched by the supervisor via `opencode ru
    When proceeding, document the choice: `feat: add retry logic (chose exponential backoff — matches existing patterns)`
    When exiting, be specific: `BLOCKED: Task says 'update auth endpoint' but 3 exist (JWT, OAuth, API key). Need clarification.`
 
+8. **Cross-repo routing** — If you discover mid-task that the fix belongs in a different repo (e.g., working in awardsapp but the bug is in an aidevops framework script), do NOT create tasks or TODO entries in the current repo. Instead, file a GitHub issue in the correct repo:
+
+   ```bash
+   gh issue create --repo <owner/correct-repo> --title "<description>" \
+     --body "Discovered while working on <current-task> in <current-repo>. <details>"
+   ```
+
+   Then continue with your assigned task in the current repo. The pulse supervisor will pick up the cross-repo issue on its next cycle. This prevents framework-level work from being tracked in app repos and vice versa.
+
 **README gate (MANDATORY - do NOT skip):**
 
 Before emitting `TASK_COMPLETE`, answer this decision tree:


### PR DESCRIPTION
## Summary

Add rule 8 to full-loop.md headless worker rules: when a worker discovers mid-task that the fix belongs in a different repo, file a `gh issue` in the correct repo instead of creating tasks in the current repo's TODO.md.

## Problem

webapp PR #255 created t025 in webapp's TODO.md to fix aidevops framework scripts (`claim-task-id.sh`, `supervisor-helper.sh`). The scripts live in the aidevops repo — the task should have been filed there, not in webapp.

## Fix

One new rule in `full-loop.md` "Headless mode rules" section:

> If you discover mid-task that the fix belongs in a different repo, file a GitHub issue in the correct repo using `gh issue create --repo <owner/correct-repo>`. The pulse supervisor will pick it up on its next cycle.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/commands/full-loop.md` | +9 lines: cross-repo routing rule (rule 8) |