### PR TITLE
feat: Session miner — daily self-improvement pulse from session data

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -58,6 +58,9 @@ Every agent session — interactive, worker, or supervisor — should improve th
 - Improving agent prompts when workers consistently misunderstand instructions
 - Identifying missing automation (e.g., a manual step that could be a `gh` command)
 - Flagging stale tasks that are blocked but not marked as such
+- Running the session miner pulse (`scripts/session-miner-pulse.sh`) to extract learning from past sessions
+
+**Autonomous operation:** When the user says "continue", "monitor", or "keep going" — enter autonomous mode: use sleep/wait loops, maintain a perpetual todo to survive compaction, only interrupt for blocking errors that require user input.
 
 ---
 
@@ -133,7 +136,7 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 Auto-dispatch: `#auto-dispatch` tag — only if brief has 2+ acceptance criteria, file references in How section, and clear deliverable in What section. Add `assignee:` before pushing if working interactively.
 
-Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-DD`. Use `task-complete-helper.sh`.
+Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-DD`. Use `task-complete-helper.sh`. Every completed task must link to its verification evidence — work without an audit trail is unverifiable and may be reverted.
 
 Planning files go direct to main. Code changes need worktree + PR. Workers NEVER edit TODO.md.
 

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -30,7 +30,7 @@ For non-trivial output: Is this a good idea? Compared to what? At what cost? Bas
 
 # Completion and quality discipline
 - Drive to verified completion. Deliver outcomes, not options. Partial results only when genuinely blocked.
-- Self-evaluate before declaring done. Run verification (tests, lint, build) — don't trust self-assessment.
+- Self-evaluate before declaring done. Run the verification command (tests, lint, build) — never mark complete based on self-assessment alone. If no verification exists, state that explicitly.
 - Replan when stuck, don't patch. Try a different strategy; sunk cost is not a reason to continue.
 - Build for change. Don't hardcode what should be parameterized. Design for variation.
 - Prefer lightweight approaches. Simpler tools over heavy dependencies.
@@ -60,7 +60,10 @@ When referencing specific functions or code include the pattern `file_path:line_
 
 # File Operations (CRITICAL)
 - ALWAYS Read a file before Edit or Write. These tools FAIL without a prior Read in this conversation. No exceptions.
-- Re-read files immediately before editing (stale reads cause errors)
+- After any tool modifies a file (Edit, Write, Bash), re-read before the next Edit/Write on that same file. Stale content is the #1 error source.
+- Before Read/Edit/Write, verify the path exists (`git ls-files` or `fd`). Never assume a path from memory.
+- When using Edit, include 3+ lines of surrounding context in oldString to ensure a unique match. Never pass identical oldString and newString.
+- Before deleting, moving, or substantially rewriting a file, verify no accumulated knowledge (edge-case handling, gotcha notes) will be lost. Prefer additive changes.
 - Never consume >100K tokens on a single operation
 - For remote repos: fetch README first, check size with `gh api`, use `includePatterns`
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -185,6 +185,16 @@ Pulse: 3 workers running, 3 slots available, dispatched 3 new workers:
 
 Then exit. The next pulse in 2 minutes will check worker counts again.
 
+## Step 7: Session Miner (Daily)
+
+Run the session miner pulse. It has its own 20-hour interval guard, so this is a no-op on most pulses:
+
+```bash
+~/.aidevops/agents/scripts/session-miner-pulse.sh 2>&1 || true
+```
+
+If it produces output (new suggestions), create a TODO entry or GitHub issue in the aidevops repo for the harness improvement. The session miner extracts user corrections and tool error patterns from past sessions and suggests harness rules that would prevent recurring issues.
+
 ## What You Must NOT Do
 
 - Do NOT maintain state files, databases, or logs (the circuit breaker helper manages its own state file — that's the only exception)

--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# session-miner-pulse.sh — Daily self-improvement pulse
+#
+# Extracts learning signals from coding assistant session data,
+# compresses them, and logs TODO suggestions for harness improvements.
+#
+# Designed for OpenCode now, adaptable to Claude Code or other tools.
+#
+# Usage:
+#   session-miner-pulse.sh                    # Run with defaults
+#   session-miner-pulse.sh --since 24h        # Only sessions from last 24h
+#   session-miner-pulse.sh --db /path/to.db   # Custom DB path
+#   session-miner-pulse.sh --dry-run          # Show what would be logged, don't write
+#
+# Called by: supervisor pulse (daily), manual invocation
+# Output: Suggestions written to stdout. Use with opencode run for analysis.
+
+set -euo pipefail
+
+# --- Configuration ---
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MINER_DIR="${HOME}/.aidevops/.agent-workspace/work/session-miner"
+# Shipped with aidevops; copied to workspace on first run
+EXTRACTOR_SRC="${SCRIPT_DIR}/session-miner/extract.py"
+COMPRESSOR_SRC="${SCRIPT_DIR}/session-miner/compress.py"
+EXTRACTOR="${MINER_DIR}/extract.py"
+COMPRESSOR="${MINER_DIR}/compress.py"
+STATE_FILE="${MINER_DIR}/.last-pulse"
+LOCK_FILE="${MINER_DIR}/.pulse.lock"
+
+# Default: OpenCode DB
+DEFAULT_DB="${HOME}/.local/share/opencode/opencode.db"
+
+# Minimum interval between pulses (seconds) — default 20 hours
+MIN_INTERVAL="${SESSION_MINER_INTERVAL:-72000}"
+
+# --- Functions ---
+
+log_info() {
+	local msg="$1"
+	echo "[session-miner] ${msg}" >&2
+	return 0
+}
+
+log_error() {
+	local msg="$1"
+	echo "[session-miner] ERROR: ${msg}" >&2
+	return 0
+}
+
+check_lock() {
+	if [[ -f "${LOCK_FILE}" ]]; then
+		local lock_age
+		lock_age=$(($(date +%s) - $(stat -f %m "${LOCK_FILE}" 2>/dev/null || echo 0)))
+		# Stale lock (>1 hour)
+		if [[ "${lock_age}" -gt 3600 ]]; then
+			log_info "Removing stale lock (${lock_age}s old)"
+			rm -f "${LOCK_FILE}"
+		else
+			log_info "Another pulse is running (lock age: ${lock_age}s). Exiting."
+			return 1
+		fi
+	fi
+	echo "$$" >"${LOCK_FILE}"
+	return 0
+}
+
+release_lock() {
+	rm -f "${LOCK_FILE}"
+	return 0
+}
+
+check_interval() {
+	if [[ -f "${STATE_FILE}" ]]; then
+		local last_run
+		last_run=$(cat "${STATE_FILE}" 2>/dev/null || echo 0)
+		local now
+		now=$(date +%s)
+		local elapsed=$((now - last_run))
+		if [[ "${elapsed}" -lt "${MIN_INTERVAL}" ]]; then
+			local remaining=$((MIN_INTERVAL - elapsed))
+			log_info "Last pulse was ${elapsed}s ago. Next in ${remaining}s. Skipping."
+			return 1
+		fi
+	fi
+	return 0
+}
+
+record_pulse() {
+	mkdir -p "${MINER_DIR}"
+	date +%s >"${STATE_FILE}"
+	return 0
+}
+
+detect_db() {
+	local db_path="$1"
+
+	if [[ -n "${db_path}" ]] && [[ -f "${db_path}" ]]; then
+		echo "${db_path}"
+		return 0
+	fi
+
+	# OpenCode
+	if [[ -f "${DEFAULT_DB}" ]]; then
+		echo "${DEFAULT_DB}"
+		return 0
+	fi
+
+	# Claude Code (future — placeholder)
+	# local claude_db="${HOME}/.claude/sessions.db"
+	# if [[ -f "${claude_db}" ]]; then
+	#     echo "${claude_db}"
+	#     return 0
+	# fi
+
+	log_error "No session database found"
+	return 1
+}
+
+count_new_sessions() {
+	local db_path="$1"
+	local since_ts="$2"
+
+	local count
+	count=$(sqlite3 "${db_path}" "SELECT COUNT(*) FROM session WHERE time_created > ${since_ts};" 2>/dev/null || echo 0)
+	echo "${count}"
+	return 0
+}
+
+run_extraction() {
+	local db_path="$1"
+	local output_dir="$2"
+
+	if [[ ! -f "${EXTRACTOR}" ]]; then
+		log_error "Extractor not found at ${EXTRACTOR}"
+		return 1
+	fi
+
+	log_info "Running extraction from ${db_path}..."
+	python3 "${EXTRACTOR}" --db "${db_path}" --format chunks --output "${output_dir}" 2>&1
+	return $?
+}
+
+run_compression() {
+	local chunks_dir="$1"
+
+	if [[ ! -f "${COMPRESSOR}" ]]; then
+		log_error "Compressor not found at ${COMPRESSOR}"
+		return 1
+	fi
+
+	log_info "Running compression..."
+	python3 "${COMPRESSOR}" "${chunks_dir}" 2>&1
+	return $?
+}
+
+generate_summary() {
+	local compressed_file="$1"
+
+	if [[ ! -f "${compressed_file}" ]]; then
+		log_error "Compressed signals file not found"
+		return 1
+	fi
+
+	# Extract key metrics using python for JSON parsing
+	python3 -c "
+import json, sys
+from pathlib import Path
+
+data = json.loads(Path('${compressed_file}').read_text())
+
+steerage = data.get('steerage', {})
+errors = data.get('errors', {}).get('patterns', [])
+total_steerage = sum(len(v) for v in steerage.values())
+
+# Top error patterns (>10 occurrences)
+top_errors = [p for p in errors if p['count'] > 10]
+top_errors.sort(key=lambda x: -x['count'])
+
+# Steerage category counts
+cat_counts = {k: len(v) for k, v in steerage.items()}
+
+print('## Session Miner Pulse Summary')
+print()
+print(f'Unique steerage signals: {total_steerage}')
+print(f'Error patterns (>10 occurrences): {len(top_errors)}')
+print()
+
+if top_errors:
+    print('### Top Error Patterns')
+    for p in top_errors[:10]:
+        recovery = p.get('recovery_patterns', [])
+        recovery_str = f' -> recovery: {recovery[0][:60]}' if recovery else ''
+        print(f'  {p[\"tool\"]}:{p[\"error_category\"]} ({p[\"count\"]}x){recovery_str}')
+    print()
+
+if cat_counts:
+    print('### Steerage Categories')
+    for cat, count in sorted(cat_counts.items(), key=lambda x: -x[1]):
+        print(f'  {cat}: {count}')
+    print()
+
+# Flag high-frequency errors not yet in harness
+harness_covered = {'edit_stale_read', 'not_read_first', 'edit_mismatch'}
+uncovered = [p for p in top_errors if p['error_category'] not in harness_covered]
+if uncovered:
+    print('### Suggested Harness Improvements')
+    for p in uncovered[:5]:
+        print(f'  - {p[\"tool\"]}:{p[\"error_category\"]} ({p[\"count\"]}x) — consider adding prevention rule')
+    print()
+" 2>/dev/null
+	return $?
+}
+
+# --- Main ---
+
+main() {
+	local db_override=""
+	local dry_run=false
+	local force=false
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--db)
+			db_override="$2"
+			shift 2
+			;;
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		--force)
+			force=true
+			shift
+			;;
+		--since)
+			# Ignored for now — full extraction each time, incremental later
+			shift 2
+			;;
+		*)
+			log_error "Unknown argument: $1"
+			return 1
+			;;
+		esac
+	done
+
+	# Ensure extractor/compressor are in workspace
+	mkdir -p "${MINER_DIR}"
+	if [[ -f "${EXTRACTOR_SRC}" ]] && [[ ! -f "${EXTRACTOR}" || "${EXTRACTOR_SRC}" -nt "${EXTRACTOR}" ]]; then
+		cp "${EXTRACTOR_SRC}" "${EXTRACTOR}"
+	fi
+	if [[ -f "${COMPRESSOR_SRC}" ]] && [[ ! -f "${COMPRESSOR}" || "${COMPRESSOR_SRC}" -nt "${COMPRESSOR}" ]]; then
+		cp "${COMPRESSOR_SRC}" "${COMPRESSOR}"
+	fi
+
+	# Check interval (skip if too recent, unless forced)
+	if [[ "${force}" != true ]]; then
+		check_interval || return 0
+	fi
+
+	# Acquire lock
+	check_lock || return 0
+	trap release_lock EXIT
+
+	# Find database
+	local db_path
+	db_path=$(detect_db "${db_override}") || return 1
+	log_info "Using database: ${db_path}"
+
+	# Check DB size
+	local db_size
+	db_size=$(stat -f %z "${db_path}" 2>/dev/null || echo 0)
+	if [[ "${db_size}" -lt 1000 ]]; then
+		log_info "Database too small (${db_size} bytes). Nothing to mine."
+		release_lock
+		return 0
+	fi
+
+	# Create output directory for this run
+	local run_ts
+	run_ts=$(date +%Y%m%d_%H%M%S)
+	local output_dir="${MINER_DIR}/pulse_${run_ts}"
+	mkdir -p "${output_dir}"
+
+	# Run extraction
+	local extract_output
+	extract_output=$(run_extraction "${db_path}" "${output_dir}" 2>&1) || {
+		log_error "Extraction failed: ${extract_output}"
+		release_lock
+		return 1
+	}
+
+	# Find the chunks directory (extract.py creates a timestamped subdir)
+	local chunks_dir
+	chunks_dir=$(find "${output_dir}" -maxdepth 1 -type d -name "chunks_*" | head -1)
+	if [[ -z "${chunks_dir}" ]]; then
+		log_error "No chunks directory found in ${output_dir}"
+		release_lock
+		return 1
+	fi
+
+	# Run compression
+	run_compression "${chunks_dir}" 2>&1 || {
+		log_error "Compression failed"
+		release_lock
+		return 1
+	}
+
+	local compressed_file="${MINER_DIR}/compressed_signals.json"
+
+	# Generate summary
+	local summary
+	summary=$(generate_summary "${compressed_file}" 2>&1)
+
+	if [[ "${dry_run}" == true ]]; then
+		echo "--- DRY RUN ---"
+		echo "${summary}"
+		echo "--- Would log TODO suggestions to relevant repos ---"
+	else
+		echo "${summary}"
+		record_pulse
+		log_info "Pulse complete. Output: ${output_dir}"
+		log_info "Compressed signals: ${compressed_file}"
+		log_info "Run 'opencode run --dir ~/Git/REPO --title \"Session miner analysis\" \"Analyse ${compressed_file} against the current harness and suggest improvements\"' for deep analysis."
+	fi
+
+	# Clean up old pulse directories (keep last 7)
+	local old_dirs
+	old_dirs=$(find "${MINER_DIR}" -maxdepth 1 -type d -name "pulse_*" | sort | head -n -7 2>/dev/null || true)
+	if [[ -n "${old_dirs}" ]]; then
+		echo "${old_dirs}" | while read -r dir; do
+			rm -rf "${dir}"
+		done
+		log_info "Cleaned up old pulse directories"
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -1,0 +1,657 @@
+#!/usr/bin/env python3
+"""
+Session Miner — Phase 1: Extract high-signal data from coding assistant sessions.
+
+Extracts two categories of learning signal from local session databases:
+1. User steerage: corrections, preferences, guidance, workflow patterns
+2. Model errors: tool failures with surrounding context (what failed, what fixed it)
+
+Output format is tool-agnostic — works with OpenCode now, adaptable to
+Claude Code, Cursor, or any tool that stores session data.
+
+All data stays local. Output goes to ~/.aidevops/.agent-workspace/work/session-miner/
+
+Usage:
+    python3 extract.py                    # Extract from default OpenCode DB
+    python3 extract.py --db /path/to.db   # Custom DB path
+    python3 extract.py --format jsonl     # JSONL output (default)
+    python3 extract.py --format chunks    # Pre-chunked for model analysis
+    python3 extract.py --limit 100        # Limit sessions processed
+"""
+
+import argparse
+import json
+import os
+import re
+import sqlite3
+import sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+# --- Configuration ---
+
+DEFAULT_DB = Path.home() / ".local/share/opencode/opencode.db"
+OUTPUT_DIR = Path.home() / ".aidevops/.agent-workspace/work/session-miner"
+
+# Steerage detection patterns — things users say when correcting/guiding
+STEERAGE_PATTERNS = {
+    "correction": [
+        r"\bno[,.]?\s+(don'?t|do not|never|stop)\b",
+        r"\bthat'?s\s+(wrong|incorrect|not right|not what)\b",
+        r"\bactually[,.]?\s",
+        r"\binstead[,.]?\s",
+        r"\bshould\s+(have|be|use|do)\b",
+        r"\bwhy\s+(did you|are you|would you)\b",
+    ],
+    "preference": [
+        r"\b(i\s+)?prefer\b",
+        r"\balways\s+(use|do|check|run|make)\b",
+        r"\bnever\s+(use|do|create|make|add|commit)\b",
+        r"\bdon'?t\s+(ever|always|just)\b",
+        r"\buse\s+\w+\s+instead\s+of\b",
+    ],
+    "guidance": [
+        r"\bmake\s+sure\s+(to|that|you)\b",
+        r"\bremember\s+(to|that)\b",
+        r"\bimportant[:\s]",
+        r"\bcritical[:\s]",
+        r"\brule[:\s]",
+        r"\bconvention[:\s]",
+        r"\bstandard[:\s]",
+    ],
+    "workflow": [
+        r"\bbefore\s+(you|doing|making|editing|committing)\b",
+        r"\bafter\s+(you|doing|making|editing|committing)\b",
+        r"\bfirst[,.]?\s+(check|read|run|verify)\b",
+        r"\bthe\s+process\s+is\b",
+        r"\bthe\s+workflow\s+is\b",
+    ],
+    "quality": [
+        r"\btest(s|ing)?\s+(first|before|after)\b",
+        r"\blint\b",
+        r"\bverif(y|ied|ication)\b",
+        r"\bclean\s+up\b",
+        r"\bself-improvement\b",
+        r"\btake\s+every\s+.+\s+opportunity\b",
+    ],
+}
+
+# Compile patterns once
+COMPILED_PATTERNS = {
+    category: [re.compile(p, re.IGNORECASE) for p in patterns]
+    for category, patterns in STEERAGE_PATTERNS.items()
+}
+
+# Error categories for tool failures
+ERROR_CATEGORIES = {
+    "file_not_found": re.compile(r"(file not found|no such file|ENOENT)", re.IGNORECASE),
+    "edit_stale_read": re.compile(r"modified since.*(last read|was read)", re.IGNORECASE),
+    "edit_mismatch": re.compile(r"(oldString|could not find).*in (the )?file", re.IGNORECASE),
+    "edit_multiple": re.compile(r"(multiple matches|found multiple)", re.IGNORECASE),
+    "permission": re.compile(r"permission denied", re.IGNORECASE),
+    "timeout": re.compile(r"(timeout|timed out)", re.IGNORECASE),
+    "exit_code": re.compile(r"(exit code|exited with|ShellError)", re.IGNORECASE),
+    "not_read_first": re.compile(r"must.*read.*before|without.*prior.*read", re.IGNORECASE),
+}
+
+
+def connect_db(db_path: Path) -> sqlite3.Connection:
+    """Connect to session database read-only."""
+    if not db_path.exists():
+        print(f"Error: Database not found at {db_path}", file=sys.stderr)
+        sys.exit(1)
+
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def classify_steerage(text: str) -> list[dict[str, Any]]:
+    """Classify user text into steerage categories with matched patterns."""
+    if not text or len(text) < 15:
+        return []
+
+    matches = []
+    for category, patterns in COMPILED_PATTERNS.items():
+        for pattern in patterns:
+            m = pattern.search(text)
+            if m:
+                matches.append({
+                    "category": category,
+                    "matched": m.group(0),
+                    "position": m.start(),
+                })
+                break  # One match per category is enough
+
+    return matches
+
+
+def classify_error(error_text: str) -> str:
+    """Classify a tool error into a category."""
+    if not error_text:
+        return "unknown"
+
+    for category, pattern in ERROR_CATEGORIES.items():
+        if pattern.search(error_text):
+            return category
+
+    return "other"
+
+
+def extract_steerage(conn: sqlite3.Connection, limit: int | None = None) -> list[dict]:
+    """Extract user steerage signals from sessions.
+
+    Returns tool-agnostic records with:
+    - session context (title, directory, timestamp)
+    - user text
+    - steerage classification
+    - surrounding assistant context (what was the model doing when corrected)
+    """
+    print("Extracting user steerage signals...", file=sys.stderr)
+
+    query = """
+    SELECT
+        s.id as session_id,
+        s.title as session_title,
+        s.directory as session_dir,
+        m.id as message_id,
+        m.time_created as msg_time,
+        json_extract(m.data, '$.role') as role,
+        json_extract(m.data, '$.modelID') as model
+    FROM message m
+    JOIN session s ON m.session_id = s.id
+    WHERE json_extract(m.data, '$.role') = 'user'
+    ORDER BY m.time_created ASC
+    """
+    if limit:
+        query += f" LIMIT {int(limit) * 10}"  # Oversample, filter later
+
+    steerage_records = []
+    seen_texts = set()
+
+    for row in conn.execute(query):
+        # Get user text parts
+        parts = conn.execute(
+            """SELECT json_extract(data, '$.text') as text
+               FROM part
+               WHERE message_id = ? AND json_extract(data, '$.type') = 'text'""",
+            (row["message_id"],),
+        ).fetchall()
+
+        for part in parts:
+            text = part["text"]
+            if not text or len(text) < 20:
+                continue
+
+            # Skip automated/templated messages
+            if text.startswith("/full-loop") or text.startswith('"You are the supervisor'):
+                continue
+
+            # Skip exact duplicates (common with "Continue if you have next steps")
+            text_hash = hash(text[:200])
+            if text_hash in seen_texts:
+                continue
+            seen_texts.add(text_hash)
+
+            classifications = classify_steerage(text)
+            if not classifications:
+                continue
+
+            # Get preceding assistant message for context
+            prev_assistant = conn.execute(
+                """SELECT json_extract(p.data, '$.text') as text
+                   FROM part p
+                   JOIN message m ON p.message_id = m.id
+                   WHERE m.session_id = ?
+                     AND m.time_created < ?
+                     AND json_extract(m.data, '$.role') = 'assistant'
+                     AND json_extract(p.data, '$.type') = 'text'
+                   ORDER BY m.time_created DESC
+                   LIMIT 1""",
+                (row["session_id"], row["msg_time"]),
+            ).fetchone()
+
+            # Sanitize: strip repo-specific paths, keep only basename
+            sanitized_dir = _sanitize_path(row["session_dir"] or "")
+
+            record = {
+                "type": "steerage",
+                "session_title": row["session_title"] or "",
+                "session_dir": sanitized_dir,
+                "timestamp": row["msg_time"],
+                "user_text": text[:2000],  # Cap length
+                "classifications": classifications,
+                "preceding_context": (prev_assistant["text"][:500] if prev_assistant and prev_assistant["text"] else ""),
+            }
+            steerage_records.append(record)
+
+            if limit and len(steerage_records) >= limit:
+                break
+
+        if limit and len(steerage_records) >= limit:
+            break
+
+    print(f"  Found {len(steerage_records)} steerage signals", file=sys.stderr)
+    return steerage_records
+
+
+def extract_errors(conn: sqlite3.Connection, limit: int | None = None) -> list[dict]:
+    """Extract tool error sequences with surrounding context.
+
+    For each error, captures:
+    - What tool failed and how
+    - What the model was trying to do (preceding assistant text)
+    - What happened next (did the model recover? how?)
+    - What the user said (if anything)
+    """
+    print("Extracting error sequences...", file=sys.stderr)
+
+    query = """
+    SELECT
+        p.id as part_id,
+        p.session_id,
+        p.message_id,
+        p.time_created,
+        json_extract(p.data, '$.tool') as tool_name,
+        json_extract(p.data, '$.state.error') as error_text,
+        json_extract(p.data, '$.state.input') as tool_input_json,
+        s.title as session_title,
+        s.directory as session_dir
+    FROM part p
+    JOIN session s ON p.session_id = s.id
+    WHERE json_extract(p.data, '$.type') = 'tool'
+      AND json_extract(p.data, '$.state.status') = 'error'
+    ORDER BY p.time_created DESC
+    """
+    if limit:
+        query += f" LIMIT {int(limit)}"
+
+    error_records = []
+
+    for row in conn.execute(query):
+        error_text = row["error_text"] or ""
+        tool_name = row["tool_name"] or "unknown"
+        error_category = classify_error(error_text)
+
+        # Parse tool input for context
+        tool_input = {}
+        if row["tool_input_json"]:
+            try:
+                tool_input = json.loads(row["tool_input_json"]) if isinstance(row["tool_input_json"], str) else row["tool_input_json"]
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        # Get what happened next — did the same tool succeed?
+        next_tool = conn.execute(
+            """SELECT
+                json_extract(data, '$.tool') as tool,
+                json_extract(data, '$.state.status') as status,
+                json_extract(data, '$.state.input') as input_json
+               FROM part
+               WHERE session_id = ?
+                 AND time_created > ?
+                 AND json_extract(data, '$.type') = 'tool'
+               ORDER BY time_created ASC
+               LIMIT 3""",
+            (row["session_id"], row["time_created"]),
+        ).fetchall()
+
+        recovery = None
+        for nt in next_tool:
+            if nt["tool"] == tool_name and nt["status"] == "completed":
+                recovery_input = {}
+                if nt["input_json"]:
+                    try:
+                        recovery_input = json.loads(nt["input_json"]) if isinstance(nt["input_json"], str) else nt["input_json"]
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                recovery = {
+                    "tool": nt["tool"],
+                    "approach": _summarize_tool_input(nt["tool"], recovery_input),
+                }
+                break
+
+        # Get user message after error (if any, within 3 messages)
+        user_after = conn.execute(
+            """SELECT json_extract(p2.data, '$.text') as text
+               FROM part p2
+               JOIN message m ON p2.message_id = m.id
+               WHERE m.session_id = ?
+                 AND m.time_created > ?
+                 AND json_extract(m.data, '$.role') = 'user'
+                 AND json_extract(p2.data, '$.type') = 'text'
+               ORDER BY m.time_created ASC
+               LIMIT 1""",
+            (row["session_id"], row["time_created"]),
+        ).fetchone()
+
+        record = {
+            "type": "error",
+            "session_title": row["session_title"] or "",
+            "session_dir": _sanitize_path(row["session_dir"] or ""),
+            "timestamp": row["time_created"],
+            "tool": tool_name,
+            "error_category": error_category,
+            "error_text": error_text[:500],
+            "tool_input_summary": _summarize_tool_input(tool_name, tool_input),
+            "recovery": recovery,
+            "user_response": (user_after["text"][:500] if user_after and user_after["text"] else None),
+        }
+        error_records.append(record)
+
+    print(f"  Found {len(error_records)} error sequences", file=sys.stderr)
+    return error_records
+
+
+def extract_error_stats(conn: sqlite3.Connection) -> dict:
+    """Extract aggregate error statistics for the summary."""
+    stats = {}
+
+    # Error counts by tool
+    rows = conn.execute("""
+        SELECT
+            json_extract(data, '$.tool') as tool,
+            COUNT(*) as total,
+            SUM(CASE WHEN json_extract(data, '$.state.status') = 'error' THEN 1 ELSE 0 END) as errors
+        FROM part
+        WHERE json_extract(data, '$.type') = 'tool'
+        GROUP BY tool
+        ORDER BY total DESC
+    """).fetchall()
+
+    stats["tool_error_rates"] = {
+        row["tool"]: {
+            "total": row["total"],
+            "errors": row["errors"],
+            "rate": round(row["errors"] / max(row["total"], 1), 4),
+        }
+        for row in rows
+        if row["tool"]
+    }
+
+    # Error categories
+    rows = conn.execute("""
+        SELECT json_extract(data, '$.state.error') as err
+        FROM part
+        WHERE json_extract(data, '$.type') = 'tool'
+          AND json_extract(data, '$.state.status') = 'error'
+    """).fetchall()
+
+    category_counts = defaultdict(int)
+    for row in rows:
+        cat = classify_error(row["err"] or "")
+        category_counts[cat] += 1
+
+    stats["error_categories"] = dict(sorted(category_counts.items(), key=lambda x: -x[1]))
+
+    # Model usage
+    rows = conn.execute("""
+        SELECT json_extract(data, '$.modelID') as model, COUNT(*) as cnt
+        FROM message
+        WHERE json_extract(data, '$.role') = 'assistant'
+        GROUP BY model
+        ORDER BY cnt DESC
+        LIMIT 10
+    """).fetchall()
+
+    stats["model_usage"] = {row["model"]: row["cnt"] for row in rows if row["model"]}
+
+    # Session count and date range
+    row = conn.execute("""
+        SELECT COUNT(*) as cnt,
+               MIN(time_created) as earliest,
+               MAX(time_created) as latest
+        FROM session
+    """).fetchone()
+
+    stats["sessions"] = {
+        "total": row["cnt"],
+        "earliest": row["earliest"],
+        "latest": row["latest"],
+    }
+
+    return stats
+
+
+def _sanitize_path(path: str) -> str:
+    """Strip user-specific path components, keep only project-relevant parts."""
+    if not path:
+        return ""
+    # ~/Git/reponame or ~/Git/reponame-worktree-name -> just the last component
+    parts = Path(path).parts
+    # Find the Git directory marker and take everything after
+    for i, part in enumerate(parts):
+        if part == "Git" and i + 1 < len(parts):
+            return "/".join(parts[i + 1:])
+    # Fallback: just the last 2 components
+    return "/".join(parts[-2:]) if len(parts) >= 2 else path
+
+
+def _summarize_tool_input(tool: str, tool_input: Any) -> str:
+    """Create a brief summary of what a tool call was trying to do."""
+    if not isinstance(tool_input, dict):
+        return ""
+
+    if tool == "edit":
+        fp = tool_input.get("filePath", "")
+        return f"edit {Path(fp).name}" if fp else "edit"
+    elif tool == "read":
+        fp = tool_input.get("filePath", "")
+        return f"read {Path(fp).name}" if fp else "read"
+    elif tool == "write":
+        fp = tool_input.get("filePath", "")
+        return f"write {Path(fp).name}" if fp else "write"
+    elif tool == "bash":
+        cmd = tool_input.get("command", "")
+        # First 80 chars of command, strip newlines
+        return f"bash: {cmd[:80].replace(chr(10), ' ')}" if cmd else "bash"
+    elif tool == "glob":
+        return f"glob: {tool_input.get('pattern', '')}"
+    elif tool == "grep":
+        return f"grep: {tool_input.get('pattern', '')}"
+    elif tool == "webfetch":
+        return f"fetch: {tool_input.get('url', '')[:80]}"
+
+    return tool
+
+
+def build_chunks(steerage: list[dict], errors: list[dict], stats: dict,
+                 max_chunk_bytes: int = 80_000) -> list[dict]:
+    """Build analysis-ready chunks that fit within model context.
+
+    Each chunk is self-contained with:
+    - A batch of steerage or error records
+    - Enough context for the model to extract patterns
+    - Metadata for deduplication
+    """
+    chunks = []
+
+    # Chunk 0: Summary statistics (always first)
+    chunks.append({
+        "chunk_id": "stats",
+        "chunk_type": "summary",
+        "data": stats,
+    })
+
+    # Chunk steerage by category
+    by_category = defaultdict(list)
+    for record in steerage:
+        for cls in record["classifications"]:
+            by_category[cls["category"]].append(record)
+
+    for category, records in by_category.items():
+        current_chunk = []
+        current_size = 0
+
+        for record in records:
+            record_json = json.dumps(record)
+            record_size = len(record_json.encode("utf-8"))
+
+            if current_size + record_size > max_chunk_bytes and current_chunk:
+                chunks.append({
+                    "chunk_id": f"steerage_{category}_{len(chunks)}",
+                    "chunk_type": "steerage",
+                    "category": category,
+                    "record_count": len(current_chunk),
+                    "records": current_chunk,
+                })
+                current_chunk = []
+                current_size = 0
+
+            current_chunk.append(record)
+            current_size += record_size
+
+        if current_chunk:
+            chunks.append({
+                "chunk_id": f"steerage_{category}_{len(chunks)}",
+                "chunk_type": "steerage",
+                "category": category,
+                "record_count": len(current_chunk),
+                "records": current_chunk,
+            })
+
+    # Chunk errors by category
+    errors_by_cat = defaultdict(list)
+    for record in errors:
+        errors_by_cat[record["error_category"]].append(record)
+
+    for category, records in errors_by_cat.items():
+        current_chunk = []
+        current_size = 0
+
+        for record in records:
+            record_json = json.dumps(record)
+            record_size = len(record_json.encode("utf-8"))
+
+            if current_size + record_size > max_chunk_bytes and current_chunk:
+                chunks.append({
+                    "chunk_id": f"error_{category}_{len(chunks)}",
+                    "chunk_type": "error",
+                    "category": category,
+                    "record_count": len(current_chunk),
+                    "records": current_chunk,
+                })
+                current_chunk = []
+                current_size = 0
+
+            current_chunk.append(record)
+            current_size += record_size
+
+        if current_chunk:
+            chunks.append({
+                "chunk_id": f"error_{category}_{len(chunks)}",
+                "chunk_type": "error",
+                "category": category,
+                "record_count": len(current_chunk),
+                "records": current_chunk,
+            })
+
+    return chunks
+
+
+def write_output(data: list[dict], output_dir: Path, fmt: str = "jsonl") -> Path:
+    """Write extracted data to output files."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    out_path = output_dir / f"extraction_{timestamp}.jsonl"  # default
+
+    if fmt == "jsonl":
+        out_path = output_dir / f"extraction_{timestamp}.jsonl"
+        with open(out_path, "w", encoding="utf-8") as f:
+            for record in data:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    elif fmt == "chunks":
+        out_path = output_dir / f"chunks_{timestamp}"
+        out_path.mkdir(parents=True, exist_ok=True)
+        for i, chunk in enumerate(data):
+            chunk_path = out_path / f"{chunk.get('chunk_id', f'chunk_{i}')}.json"
+            with open(chunk_path, "w", encoding="utf-8") as f:
+                json.dump(chunk, f, indent=2, ensure_ascii=False)
+        # Also write a manifest
+        manifest = {
+            "chunk_count": len(data),
+            "chunks": [
+                {
+                    "id": c.get("chunk_id"),
+                    "type": c.get("chunk_type"),
+                    "category": c.get("category", ""),
+                    "records": c.get("record_count", 0),
+                }
+                for c in data
+            ],
+            "created": timestamp,
+        }
+        with open(out_path / "manifest.json", "w", encoding="utf-8") as f:
+            json.dump(manifest, f, indent=2)
+
+    return out_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract learning signals from coding sessions")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB,
+                        help=f"Path to session database (default: {DEFAULT_DB})")
+    parser.add_argument("--format", choices=["jsonl", "chunks"], default="chunks",
+                        help="Output format (default: chunks)")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Limit records extracted per category")
+    parser.add_argument("--output", type=Path, default=OUTPUT_DIR,
+                        help=f"Output directory (default: {OUTPUT_DIR})")
+    args = parser.parse_args()
+
+    print(f"Session Miner — Extracting from {args.db}", file=sys.stderr)
+    print(f"  DB size: {args.db.stat().st_size / 1024 / 1024:.1f} MB", file=sys.stderr)
+
+    conn = connect_db(args.db)
+
+    try:
+        # Phase 1a: Extract steerage
+        steerage = extract_steerage(conn, limit=args.limit)
+
+        # Phase 1b: Extract errors
+        errors = extract_errors(conn, limit=args.limit)
+
+        # Phase 1c: Aggregate stats
+        stats = extract_error_stats(conn)
+
+        # Phase 2: Build chunks for model analysis
+        if args.format == "chunks":
+            chunks = build_chunks(steerage, errors, stats)
+            out_path = write_output(chunks, args.output, fmt="chunks")
+            print(f"\nOutput: {out_path}/", file=sys.stderr)
+            print(f"  {len(chunks)} chunks written", file=sys.stderr)
+            print(f"  {len(steerage)} steerage signals", file=sys.stderr)
+            print(f"  {len(errors)} error sequences", file=sys.stderr)
+        else:
+            all_records = [{"type": "stats", **stats}] + steerage + errors
+            out_path = write_output(all_records, args.output, fmt="jsonl")
+            print(f"\nOutput: {out_path}", file=sys.stderr)
+            print(f"  {len(steerage)} steerage + {len(errors)} errors", file=sys.stderr)
+
+        # Print summary to stdout
+        print(json.dumps({
+            "steerage_count": len(steerage),
+            "error_count": len(errors),
+            "steerage_categories": dict(
+                sorted(
+                    defaultdict(int, {
+                        cat: sum(1 for s in steerage if any(c["category"] == cat for c in s["classifications"]))
+                        for cat in STEERAGE_PATTERNS
+                    }).items(),
+                    key=lambda x: -x[1],
+                )
+            ),
+            "error_categories": stats.get("error_categories", {}),
+            "output": str(out_path),
+        }, indent=2))
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Mines user steerage (corrections, preferences, guidance) and model errors from coding assistant session databases to distill harness improvements
- Adds daily self-improvement pulse integrated into supervisor scheduler (Step 7)
- Applies evidence-based harness improvements from 4,544 sessions of real usage data

## Harness changes (build.txt: 126 → 129 lines)

**Strengthened:**
- "Re-read files before editing" → explicit trigger: after any modification to that file (591 stale-read errors)
- "Self-evaluate before declaring done" → must run verification command, not self-assess (32 tasks falsely marked complete incident)

**New rules:**
- Verify file path exists before Read/Edit/Write — 194 file-not-found errors from guessed paths
- Edit: include 3+ context lines in oldString — 106 multiple-match/identical-string errors
- Knowledge preservation: verify no accumulated wisdom lost before rewriting files — 8+ sessions

## AGENTS.md changes

- Autonomous operation mode (20+ sessions requesting this)
- Audit trail requirement on task completions

## Session miner tooling

- `extract.py` — SQL extractor for OpenCode sessions (tool-agnostic output format)
- `compress.py` — Signal compressor (4.3 GB DB → 1.2 MB actionable signals)
- `session-miner-pulse.sh` — Daily pulse with 20h interval guard, lock file, cleanup
- Integrated into supervisor pulse.md as Step 7

## Design decisions

- **Local-only**: raw session data never leaves the machine. Only compressed signals are analysed.
- **Tool-agnostic**: extractor outputs a generic format. Adapting to Claude Code means writing a new DB adapter, not rewriting the pipeline.
- **Generic rules only**: all harness additions apply to any repo, any project. Repo-specific patterns filtered out.
- **Additive only**: no rules that repeat what models already know. Focus on gaps proven by error data.