### PR TITLE
docs: add build-agent routing instruction for all primary agents

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -180,6 +180,8 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Agent/MCP dev | `tools/build-agent/build-agent.md`, `tools/build-mcp/build-mcp.md`, `tools/mcp-toolkit/mcporter.md` |
 | Framework | `aidevops/architecture.md`, `scripts/commands/skills.md` |
 
+**Creating agents**: When a user asks to create, build, or design an agent — regardless of which primary agent is active — always read `tools/build-agent/build-agent.md` first. It contains the tier prompt (draft/custom/shared), design checklist, and lifecycle rules.
+
 ## Capabilities
 
 Key capabilities (details in `reference/orchestration.md`, `reference/services.md`, `reference/session.md`):


### PR DESCRIPTION
## Summary

- Adds a cross-cutting instruction in `.agents/AGENTS.md` Domain Index section so that **all** primary agents (SEO, Content, Marketing, etc.) know to load `tools/build-agent/build-agent.md` when a user asks to create an agent
- Previously only Build+ and @aidevops had `build-agent` as a subagent dependency — users on other agents would miss the tier prompt (draft/custom/shared) and design checklist
- One line, zero risk — placed in the section all agents already read on startup