### PR TITLE
docs: Add launchd/cron naming convention to AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -213,4 +213,11 @@ Tree: `prompts/build.txt`. Agent tiers:
 
 Lifecycle: `tools/build-agent/build-agent.md`.
 
+## Scheduled Tasks (launchd/cron)
+
+When creating launchd plists or cron jobs, use the `aidevops` prefix so they're easy to find in System Settings > General > Login Items & Extensions:
+- **launchd label**: `sh.aidevops.<name>` (reverse domain, e.g., `sh.aidevops.session-miner-pulse`)
+- **plist filename**: `sh.aidevops.<name>.plist`
+- **cron comment**: `# aidevops: <description>`
+
 <!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

- Adds `sh.aidevops.*` naming convention for launchd plists and cron jobs
- Ensures all scheduled tasks are discoverable in System Settings > Login Items & Extensions
- Any main agent can create routines, so this convention belongs in the shared AGENTS.md