### PR TITLE
t1340: Opus strategic review phase in supervisor pulse

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -208,9 +208,27 @@ Run the session miner pulse. It has its own 20-hour interval guard, so this is a
 
 If it produces output (new suggestions), create a TODO entry or GitHub issue in the aidevops repo for the harness improvement. The session miner extracts user corrections and tool error patterns from past sessions and suggests harness rules that would prevent recurring issues.
 
+## Step 8: Strategic Review (Every 4h, Opus Tier)
+
+Check if an opus-tier strategic review is due. The helper script enforces a 4-hour minimum interval:
+
+```bash
+if ~/.aidevops/agents/scripts/opus-review-helper.sh check 2>/dev/null; then
+  # Review is due — dispatch an opus session
+  opencode run --dir ~/Git/aidevops --model opus --title "Strategic Review $(date +%Y-%m-%d-%H%M)" \
+    "/strategic-review" &
+fi
+```
+
+The strategic review does what sonnet cannot: meta-reasoning about queue health, resource utilisation, stuck chains, stale state, and systemic issues. It can take corrective actions (merge ready PRs, file issues, clean worktrees, dispatch high-value work).
+
+This does NOT count against the 6-worker concurrency limit — it's a supervisor function, not a task worker.
+
+See `scripts/commands/strategic-review.md` for the full review prompt.
+
 ## What You Must NOT Do
 
-- Do NOT maintain state files, databases, or logs (the circuit breaker helper manages its own state file — that's the only exception)
+- Do NOT maintain state files, databases, or logs (the circuit breaker and opus review helpers manage their own state files — those are the only exceptions)
 - Do NOT dispatch more workers than available slots (max 6 total)
 - Do NOT try to implement anything yourself — you are the supervisor, not a worker
 - Do NOT read source code, run tests, or do any task work

--- a/.agents/scripts/commands/strategic-review.md
+++ b/.agents/scripts/commands/strategic-review.md
@@ -1,0 +1,147 @@
+---
+description: Opus-tier strategic review of queue health, resource utilisation, and systemic issues
+agent: Build+
+mode: subagent
+model: opus
+---
+
+You are the strategic reviewer. You run every 4 hours at opus tier. Your job is the meta-reasoning that the sonnet pulse cannot do: assess the overall health of the development operation, identify systemic issues, and take corrective action.
+
+The sonnet pulse handles mechanical dispatch (pick next task, check blocked-by, launch worker). You handle strategy: is the system making the most of available resources? Are there stuck chains? Stale state? Wasted capacity?
+
+## Step 1: Gather State
+
+Run these commands to build a complete picture:
+
+```bash
+# Open tasks in TODO.md
+rg '^\- \[ \] t\d+' TODO.md
+
+# Completed tasks (count only)
+rg -c '^\- \[x\] t\d+' TODO.md
+
+# Open PRs across managed repos
+gh pr list --repo marcusquinn/aidevops --state open --json number,title,updatedAt,statusCheckRollup --limit 20
+
+# Recently merged PRs (last 24h velocity)
+gh pr list --repo marcusquinn/aidevops --state merged --json number,title,mergedAt --limit 15
+
+# Recently closed (not merged) PRs — failed workers
+gh pr list --repo marcusquinn/aidevops --state closed --json number,title,closedAt,mergedAt --limit 10
+
+# Open issues
+gh issue list --repo marcusquinn/aidevops --state open --json number,title,labels,updatedAt --limit 20
+
+# Active worktrees
+git worktree list
+
+# Running workers
+pgrep -f '/full-loop' 2>/dev/null | wc -l | tr -d ' '
+
+# For each managed repo in repos.json, also check PRs and issues:
+# gh pr list --repo <owner/repo> --state open --json number,title,updatedAt --limit 10
+# gh issue list --repo <owner/repo> --state open --json number,title,labels --limit 10
+```
+
+## Step 2: Assess Queue Health
+
+Analyse the gathered state across these dimensions:
+
+### 2a: Blocked Chain Analysis
+
+- Which tasks are blocked, and by what?
+- Are any blockers themselves stale (no PR, no worker, no progress)?
+- What's the longest blocked chain? How much downstream work does unblocking the root release?
+- Are any tasks marked `status:merging` but have no open PR? (stuck in limbo)
+
+### 2b: State Consistency
+
+- Are any tasks marked `CANCELLED` in issue notes but still `[ ]` in TODO.md?
+- Are there tasks with `assignee:` but no active worker process?
+- Do any completed tasks lack `pr:#NNN` or `verified:` evidence?
+- Are there duplicate issues/PRs for the same work?
+
+### 2c: Resource Utilisation
+
+- How many worker slots are in use vs available (max 6)?
+- How many hours of dispatchable (unblocked) work is sitting idle?
+- How many worktrees exist? How many are stale (merged/closed PR, no active branch)?
+- Is disk space being wasted by dead worktrees?
+
+### 2d: Velocity and Trends
+
+- How many PRs merged in the last 24h?
+- Are there any PRs open for 6+ hours with no progress?
+- Were any PRs closed without merging (worker failures)?
+- Is the completion rate trending up or down?
+
+### 2e: Quality Signals
+
+- Are any merged PRs showing CI failures post-merge?
+- Are there recurring patterns in worker failures?
+- Are review bots flagging the same issues repeatedly?
+
+## Step 3: Take Action
+
+Based on your assessment, take concrete actions. You are not advisory — you act.
+
+### Actions you SHOULD take:
+
+1. **Unblock stuck chains** — if a blocker task is complete but not marked done, update it. If a `status:merging` task has no open PR, investigate and resolve.
+
+2. **Clean stale worktrees** — run `git worktree prune` and identify worktree directories that can be removed (merged PRs, closed branches). List them but do NOT remove directories without confirming the branch is fully merged.
+
+3. **File issues for systemic problems** — if you see a pattern (same CI failure, same type of worker failure, same blocked chain), create a GitHub issue describing the pattern and proposed fix.
+
+4. **Dispatch high-value work** — if worker slots are available and dispatchable work exists, dispatch workers for the highest-impact items (prefer items that unblock other work).
+
+5. **Clean up TODO.md inconsistencies** — cancelled tasks still marked open, completed tasks missing evidence, stale assignees.
+
+6. **Prioritise recommendations** — output a ranked list of what the next pulse cycles should focus on.
+
+### Actions you must NOT take:
+
+- Do NOT revert anyone's changes
+- Do NOT force-push or reset branches
+- Do NOT remove worktree directories without verifying the branch is merged
+- Do NOT modify tasks in repos you don't manage
+- Do NOT include private repo names in public issue titles or comments
+
+## Step 4: Report
+
+Output a structured report:
+
+```text
+Strategic Review — {date} {time}
+================================
+
+## Queue Health
+- Open tasks: {N} ({N} dispatchable, {N} blocked)
+- Completed: {N} total, {N} in last 24h
+- Open PRs: {N} | Workers running: {N}/6
+
+## Issues Found
+1. {issue description} — {action taken or recommended}
+2. ...
+
+## Actions Taken
+1. {what you did}
+2. ...
+
+## Recommendations for Next Cycles
+1. {highest priority}
+2. {second priority}
+3. ...
+
+## Resource Cleanup
+- Worktrees: {N} total, {N} prunable
+- {cleanup actions taken}
+```
+
+After outputting the report, record the review:
+
+```bash
+~/.aidevops/agents/scripts/opus-review-helper.sh record
+```
+
+Then exit. The next review runs in 4 hours.

--- a/.agents/scripts/opus-review-helper.sh
+++ b/.agents/scripts/opus-review-helper.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# opus-review-helper.sh — Cadence control for opus strategic review (t1340)
+#
+# The supervisor pulse runs every 2 minutes at sonnet tier for mechanical
+# dispatch. Every 4 hours, this helper gates an opus-tier strategic review
+# that does what sonnet can't: meta-reasoning about queue health, resource
+# utilisation, stuck chains, and systemic issues.
+#
+# Usage:
+#   opus-review-helper.sh check       Check if review is due (exit 0=due, 1=too soon)
+#   opus-review-helper.sh record      Record that a review just ran
+#   opus-review-helper.sh status      Show last review time and next due
+#   opus-review-helper.sh reset       Clear last-run timestamp (forces next review)
+#   opus-review-helper.sh help        Show usage
+#
+# Called by: pulse.md Step 8 (Strategic Review)
+# Pattern: follows session-miner-pulse.sh cadence control
+
+set -euo pipefail
+
+# ============================================================
+# CONFIGURATION
+# ============================================================
+
+# Minimum interval between reviews (seconds) — default 4 hours
+OPUS_REVIEW_INTERVAL="${OPUS_REVIEW_INTERVAL:-14400}"
+# Validate numeric — strip non-digits, fallback to default if empty
+OPUS_REVIEW_INTERVAL="${OPUS_REVIEW_INTERVAL//[!0-9]/}"
+[[ -n "$OPUS_REVIEW_INTERVAL" ]] || OPUS_REVIEW_INTERVAL=14400
+
+# State directory
+STATE_DIR="${SUPERVISOR_DIR:-${HOME}/.aidevops/.agent-workspace/supervisor}"
+
+# State file — stores epoch timestamp of last review
+STATE_FILE="${STATE_DIR}/.opus-review-last"
+
+# ============================================================
+# COLOURS
+# ============================================================
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ============================================================
+# FUNCTIONS
+# ============================================================
+
+_ensure_state_dir() {
+	mkdir -p "$STATE_DIR" 2>/dev/null || true
+	return 0
+}
+
+_get_last_run() {
+	if [[ -f "$STATE_FILE" ]]; then
+		cat "$STATE_FILE" 2>/dev/null || echo "0"
+	else
+		echo "0"
+	fi
+	return 0
+}
+
+_get_now() {
+	date +%s
+	return 0
+}
+
+_format_duration() {
+	local seconds="$1"
+	local hours=$((seconds / 3600))
+	local minutes=$(((seconds % 3600) / 60))
+	if [[ "$hours" -gt 0 ]]; then
+		echo "${hours}h ${minutes}m"
+	else
+		echo "${minutes}m"
+	fi
+	return 0
+}
+
+cmd_check() {
+	_ensure_state_dir
+
+	local last_run
+	last_run="$(_get_last_run)"
+	local now
+	now="$(_get_now)"
+	local elapsed=$((now - last_run))
+
+	if [[ "$elapsed" -ge "$OPUS_REVIEW_INTERVAL" ]]; then
+		# Review is due
+		if [[ "$last_run" -eq 0 ]]; then
+			echo -e "${GREEN}Opus review: never run — due now${NC}" >&2
+		else
+			echo -e "${GREEN}Opus review: due (last run $(_format_duration "$elapsed") ago, interval $(_format_duration "$OPUS_REVIEW_INTERVAL"))${NC}" >&2
+		fi
+		return 0
+	else
+		# Too soon
+		local remaining=$((OPUS_REVIEW_INTERVAL - elapsed))
+		echo -e "${BLUE}Opus review: not due (next in $(_format_duration "$remaining"))${NC}" >&2
+		return 1
+	fi
+}
+
+cmd_record() {
+	_ensure_state_dir
+
+	local now
+	now="$(_get_now)"
+	echo "$now" >"$STATE_FILE"
+	echo -e "${GREEN}Opus review: recorded at $(date -r "$now" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date -d "@$now" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "$now")${NC}" >&2
+	return 0
+}
+
+cmd_status() {
+	_ensure_state_dir
+
+	local last_run
+	last_run="$(_get_last_run)"
+	local now
+	now="$(_get_now)"
+	local elapsed=$((now - last_run))
+	local interval_fmt
+	interval_fmt="$(_format_duration "$OPUS_REVIEW_INTERVAL")"
+
+	echo "Opus Strategic Review Status"
+	echo "============================"
+	echo "Interval:    ${interval_fmt} (${OPUS_REVIEW_INTERVAL}s)"
+
+	if [[ "$last_run" -eq 0 ]]; then
+		echo "Last run:    never"
+		echo "Status:      DUE NOW"
+	else
+		local last_fmt
+		last_fmt="$(date -r "$last_run" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date -d "@$last_run" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "$last_run")"
+		echo "Last run:    ${last_fmt} ($(_format_duration "$elapsed") ago)"
+
+		if [[ "$elapsed" -ge "$OPUS_REVIEW_INTERVAL" ]]; then
+			echo -e "Status:      ${GREEN}DUE NOW${NC}"
+		else
+			local remaining=$((OPUS_REVIEW_INTERVAL - elapsed))
+			echo -e "Status:      ${BLUE}Next in $(_format_duration "$remaining")${NC}"
+		fi
+	fi
+
+	echo "State file:  ${STATE_FILE}"
+	return 0
+}
+
+cmd_reset() {
+	_ensure_state_dir
+
+	if [[ -f "$STATE_FILE" ]]; then
+		rm -f "$STATE_FILE"
+		echo -e "${YELLOW}Opus review: timestamp cleared — next pulse will trigger review${NC}" >&2
+	else
+		echo -e "${BLUE}Opus review: no timestamp to clear${NC}" >&2
+	fi
+	return 0
+}
+
+cmd_help() {
+	echo "opus-review-helper.sh — Cadence control for opus strategic review"
+	echo ""
+	echo "Usage:"
+	echo "  opus-review-helper.sh check       Check if review is due (exit 0=due, 1=too soon)"
+	echo "  opus-review-helper.sh record      Record that a review just ran"
+	echo "  opus-review-helper.sh status      Show last review time and next due"
+	echo "  opus-review-helper.sh reset       Clear last-run timestamp (forces next review)"
+	echo "  opus-review-helper.sh help        Show usage"
+	echo ""
+	echo "Environment:"
+	echo "  OPUS_REVIEW_INTERVAL    Seconds between reviews (default: 14400 = 4h)"
+	echo "  SUPERVISOR_DIR          State directory (default: ~/.aidevops/.agent-workspace/supervisor)"
+	return 0
+}
+
+# ============================================================
+# MAIN
+# ============================================================
+
+main() {
+	local command="${1:-help}"
+
+	case "$command" in
+	check)
+		cmd_check
+		;;
+	record)
+		cmd_record
+		;;
+	status)
+		cmd_status
+		;;
+	reset)
+		cmd_reset
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		echo "Unknown command: $command" >&2
+		cmd_help >&2
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/todo/tasks/t1340-brief.md
+++ b/todo/tasks/t1340-brief.md
@@ -1,0 +1,117 @@
+---
+mode: subagent
+---
+# t1340: Opus strategic review phase in supervisor pulse
+
+## Origin
+
+- **Created:** 2026-02-26
+- **Session:** opencode:interactive
+- **Created by:** marcusquinn (human + ai-interactive)
+- **Conversation context:** User asked for queue status, I (opus) provided strategic assessment that the sonnet-tier pulse cannot do — spotted stuck chains, stale worktrees, cancelled-but-open tasks, idle capacity. User observed this meta-reasoning should be automated, not on-demand.
+
+## What
+
+Add a periodic opus-tier strategic review to the supervisor pulse. Every 4 hours, the pulse dispatches an opus session that:
+
+1. Assesses queue health (blocked chains, stale states, cancelled-but-open tasks)
+2. Checks resource utilisation (worktrees, open PRs, active workers vs available work)
+3. Identifies bottlenecks (what's blocking the most downstream work)
+4. Takes corrective action (unblock, clean up, dispatch, file issues)
+5. Prioritises strategically (not just "what's next" but "what unblocks the most value")
+
+This is a strategic layer on top of the existing sonnet pulse, which handles mechanical dispatch.
+
+## Why
+
+The sonnet-tier pulse is good at executing defined steps (check PRs, dispatch workers, merge ready PRs) but weak at meta-reasoning: spotting that 55 worktrees is a problem, noticing gaps between cancelled notes and TODO.md state, recognising that 0 workers + 25h of dispatchable work = wasted capacity. Without this, systemic issues accumulate until a human notices.
+
+Cost: ~$1-2/day (6 opus calls, ~10-20K input tokens each). Value: prevents hours of idle capacity and stuck chains.
+
+## How (Approach)
+
+Three components, following existing patterns:
+
+1. **`opus-review-helper.sh`** — cadence control script (follows `session-miner-pulse.sh` pattern). Checks last-run timestamp, enforces 4h minimum interval, manages lock file. Exit 0 = review needed, exit 1 = too soon.
+
+2. **`strategic-review.md`** — AI prompt for the opus review session (follows `pulse.md` pattern). Defines what to check, how to assess, and what actions to take. The prompt is the intelligence; the script is the gate.
+
+3. **Wire into `pulse.md`** — add a new step (after Step 7: Session Miner) that calls the helper script and, if due, dispatches an opus review session.
+
+Key files:
+- `.agents/scripts/opus-review-helper.sh` — cadence control
+- `.agents/scripts/commands/strategic-review.md` — opus review prompt
+- `.agents/scripts/commands/pulse.md` — add Step 8
+
+## Acceptance Criteria
+
+- [ ] `opus-review-helper.sh check` returns exit 0 when no review has run in 4+ hours
+
+  ```yaml
+  verify:
+    method: bash
+    run: "rm -f ~/.aidevops/.agent-workspace/supervisor/.opus-review-last && bash ~/.aidevops/agents/scripts/opus-review-helper.sh check"
+  ```
+
+- [ ] `opus-review-helper.sh check` returns exit 1 when review ran recently
+
+  ```yaml
+  verify:
+    method: bash
+    run: "mkdir -p ~/.aidevops/.agent-workspace/supervisor && date +%s > ~/.aidevops/.agent-workspace/supervisor/.opus-review-last && ! bash ~/.aidevops/agents/scripts/opus-review-helper.sh check"
+  ```
+
+- [ ] `strategic-review.md` exists with structured review prompt
+
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "strategic review"
+    path: ".agents/scripts/commands/strategic-review.md"
+  ```
+
+- [ ] `pulse.md` references strategic review as a step
+
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "strategic.review|opus.review"
+    path: ".agents/scripts/commands/pulse.md"
+  ```
+
+- [ ] ShellCheck clean on opus-review-helper.sh
+
+  ```yaml
+  verify:
+    method: bash
+    run: "shellcheck ~/.aidevops/agents/scripts/opus-review-helper.sh"
+  ```
+
+## Context & Decisions
+
+- Chose option 2 (extend pulse) over standalone launchd job — keeps orchestration in one system
+- 4h cadence balances cost (~$1-2/day) vs responsiveness
+- Follows existing patterns: session-miner-pulse.sh for cadence, pulse.md for AI prompt
+- The opus review can take actions (merge PRs, file issues, clean worktrees) — it's not just advisory
+- Start with fixed 4h; can tune later based on observed value
+
+## Relevant Files
+
+- `.agents/scripts/commands/pulse.md` — existing pulse prompt to extend
+- `.agents/scripts/session-miner-pulse.sh` — cadence control pattern to follow
+- `.agents/scripts/circuit-breaker-helper.sh` — state file pattern to follow
+
+## Dependencies
+
+- **Blocked by:** nothing
+- **Blocks:** nothing directly, but improves all queue throughput
+- **External:** none
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Research/read | 15m | pulse.md, session-miner pattern |
+| Implementation | 1.5h | helper script + prompt + pulse.md wiring |
+| Testing | 15m | shellcheck, cadence logic |
+| **Total** | **~2h** | |


### PR DESCRIPTION
## Summary

- Adds a 4-hourly opus-tier strategic review to the supervisor pulse that performs meta-reasoning sonnet cannot: queue health, blocked chains, resource utilisation, stale state, systemic issues
- Three components: `opus-review-helper.sh` (cadence control), `strategic-review.md` (opus prompt), `pulse.md` Step 8 (wiring)
- Cost: ~$1-2/day for 6 opus calls. Value: prevents hours of idle capacity and stuck chains accumulating unnoticed

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/opus-review-helper.sh` | New — cadence control (check/record/status/reset) |
| `.agents/scripts/commands/strategic-review.md` | New — opus review prompt with structured assessment |
| `.agents/scripts/commands/pulse.md` | Modified — added Step 8 for strategic review |
| `todo/tasks/t1340-brief.md` | New — task brief |

## Verification

- ShellCheck: clean (0 violations)
- Markdown lint: clean (0 errors)
- Cadence logic: tested 6 scenarios (never-run, just-ran, status, reset, custom interval)

Closes #2332