### PR TITLE
fix: t1340 strategic review — cross-repo, action/TODO split, concurrency

### DIFF
--- a/.agents/scripts/commands/strategic-review.md
+++ b/.agents/scripts/commands/strategic-review.md
@@ -11,37 +11,44 @@ The sonnet pulse handles mechanical dispatch (pick next task, check blocked-by, 
 
 ## Step 1: Gather State
 
-Run these commands to build a complete picture:
+First, discover all managed repos. Then gather state for EVERY repo — not just aidevops.
 
 ```bash
-# Open tasks in TODO.md
-rg '^\- \[ \] t\d+' TODO.md
+# 1. Read the managed repos list
+cat ~/.config/aidevops/pulse-repos.json
+```
 
-# Completed tasks (count only)
-rg -c '^\- \[x\] t\d+' TODO.md
+For EACH repo in that list, run ALL of the following. Do not skip any repo.
 
-# Open PRs across managed repos
-gh pr list --repo marcusquinn/aidevops --state open --json number,title,updatedAt,statusCheckRollup --limit 20
+```bash
+# Per-repo: open PRs
+gh pr list --repo <owner/repo> --state open --json number,title,updatedAt,statusCheckRollup --limit 20
 
-# Recently merged PRs (last 24h velocity)
-gh pr list --repo marcusquinn/aidevops --state merged --json number,title,mergedAt --limit 15
+# Per-repo: recently merged PRs (velocity)
+gh pr list --repo <owner/repo> --state merged --json number,title,mergedAt --limit 15
 
-# Recently closed (not merged) PRs — failed workers
-gh pr list --repo marcusquinn/aidevops --state closed --json number,title,closedAt,mergedAt --limit 10
+# Per-repo: closed-not-merged PRs (failed workers)
+gh pr list --repo <owner/repo> --state closed --json number,title,closedAt,mergedAt --limit 10
 
-# Open issues
-gh issue list --repo marcusquinn/aidevops --state open --json number,title,labels,updatedAt --limit 20
+# Per-repo: open issues
+gh issue list --repo <owner/repo> --state open --json number,title,labels,updatedAt --limit 30
 
-# Active worktrees
+# Per-repo: TODO.md tasks (if the repo has one)
+# rg '^\- \[ \] t\d+' ~/Git/<repo>/TODO.md
+# rg -c '^\- \[x\] t\d+' ~/Git/<repo>/TODO.md
+```
+
+Then gather system-wide state:
+
+```bash
+# Active worktrees (all repos share the worktree namespace)
 git worktree list
 
 # Running workers
 pgrep -f '/full-loop' 2>/dev/null | wc -l | tr -d ' '
-
-# For each managed repo in repos.json, also check PRs and issues:
-# gh pr list --repo <owner/repo> --state open --json number,title,updatedAt --limit 10
-# gh issue list --repo <owner/repo> --state open --json number,title,labels --limit 10
 ```
+
+**Critical: product repos have higher priority than tooling repos.** Check pulse-repos.json for the `priority` field. Issues in product repos are more urgent than issues in tooling repos.
 
 ## Step 2: Assess Queue Health
 
@@ -54,16 +61,18 @@ Analyse the gathered state across these dimensions:
 - What's the longest blocked chain? How much downstream work does unblocking the root release?
 - Are any tasks marked `status:merging` but have no open PR? (stuck in limbo)
 
-### 2b: State Consistency
+### 2b: State Consistency (check EVERY managed repo)
 
 - Are any tasks marked `CANCELLED` in issue notes but still `[ ]` in TODO.md?
 - Are there tasks with `assignee:` but no active worker process?
 - Do any completed tasks lack `pr:#NNN` or `verified:` evidence?
 - Are there duplicate issues/PRs for the same work?
+- Are any parent tasks/issues still open when ALL subtasks are complete? This is a common miss — check each open issue that has subtask checkboxes and verify whether all are checked.
+- Cross-repo: do any issues reference subtasks in another repo? Check those subtask states too.
 
 ### 2c: Resource Utilisation
 
-- How many worker slots are in use vs available (max 6)?
+- How many workers are running? The pulse default is 6, but this is a soft guideline — not a hard limit. Workers may also be launched manually or by other sessions. High concurrency is good if the system has rate limit headroom and the machine isn't under memory/CPU pressure. Only flag concurrency as a problem if you see evidence of harm: rate limit errors in logs, workers timing out, OOM kills, or the machine becoming unresponsive.
 - How many hours of dispatchable (unblocked) work is sitting idle?
 - How many worktrees exist? How many are stale (merged/closed PR, no active branch)?
 - Is disk space being wasted by dead worktrees?
@@ -83,27 +92,28 @@ Analyse the gathered state across these dimensions:
 
 ## Step 3: Take Action
 
-Based on your assessment, take concrete actions. You are not advisory — you act.
+Based on your assessment, take action — but distinguish between safe mechanical actions you do directly and state changes that need a TODO for the next pulse or human to verify.
 
-### Actions you SHOULD take:
+### Act directly (mechanical, reversible, no judgment needed):
 
-1. **Unblock stuck chains** — if a blocker task is complete but not marked done, update it. If a `status:merging` task has no open PR, investigate and resolve.
+1. **`git worktree prune`** — safe, only removes worktrees whose directories are already gone.
+2. **Merge CI-green PRs with approved reviews** — `gh pr merge --squash`. Same as the pulse does.
+3. **File GitHub issues for systemic problems** — if you see a pattern (same CI failure, same type of worker failure, same blocked chain), create an issue describing the pattern and proposed fix.
+4. **Record observations** — the report itself is the primary output.
 
-2. **Clean stale worktrees** — run `git worktree prune` and identify worktree directories that can be removed (merged PRs, closed branches). List them but do NOT remove directories without confirming the branch is fully merged.
+### Create TODOs for (need verification or judgment):
 
-3. **File issues for systemic problems** — if you see a pattern (same CI failure, same type of worker failure, same blocked chain), create a GitHub issue describing the pattern and proposed fix.
-
-4. **Dispatch high-value work** — if worker slots are available and dispatchable work exists, dispatch workers for the highest-impact items (prefer items that unblock other work).
-
-5. **Clean up TODO.md inconsistencies** — cancelled tasks still marked open, completed tasks missing evidence, stale assignees.
-
-6. **Prioritise recommendations** — output a ranked list of what the next pulse cycles should focus on.
+1. **Unblock stuck chains** — if a blocker task appears complete (merged PR exists) but is still `[ ]` or `status:merging`, create a TODO or GitHub issue to investigate and fix the state. Don't directly edit TODO.md — the state fix needs verification that the work is genuinely complete.
+2. **Clean up TODO.md inconsistencies** — cancelled tasks still marked open, completed tasks missing evidence, `status:deployed` parents with all subtasks done. Flag these as TODOs for the next pulse to action.
+3. **Dispatch recommendations** — if dispatchable work is sitting idle, recommend what to dispatch and why (what it unblocks). The pulse handles actual dispatch.
+4. **Stale worktree directories** — list directories that can likely be removed (merged PRs, closed branches), but do NOT `rm -rf` them. Output the list for human or pulse to action after confirming branches are merged.
 
 ### Actions you must NOT take:
 
+- Do NOT directly edit TODO.md (workers never edit TODO.md — the review is a supervisor function)
 - Do NOT revert anyone's changes
 - Do NOT force-push or reset branches
-- Do NOT remove worktree directories without verifying the branch is merged
+- Do NOT `rm -rf` worktree directories — only `git worktree prune` (safe) and list candidates
 - Do NOT modify tasks in repos you don't manage
 - Do NOT include private repo names in public issue titles or comments
 
@@ -118,23 +128,22 @@ Strategic Review — {date} {time}
 ## Queue Health
 - Open tasks: {N} ({N} dispatchable, {N} blocked)
 - Completed: {N} total, {N} in last 24h
-- Open PRs: {N} | Workers running: {N}/6
+- Open PRs: {N} | Workers running: {N}
 
 ## Issues Found
-1. {issue description} — {action taken or recommended}
+1. {issue description} — {severity}
 2. ...
 
-## Actions Taken
-1. {what you did}
+## Actions Taken (direct)
+1. {what you did — merges, prune, issues filed}
 2. ...
 
-## Recommendations for Next Cycles
-1. {highest priority}
-2. {second priority}
-3. ...
+## TODOs Created (for pulse/human)
+1. {state fix or dispatch recommendation — with reasoning}
+2. ...
 
 ## Resource Cleanup
-- Worktrees: {N} total, {N} prunable
+- Worktrees: {N} total, {N} prunable, {N} stale candidates listed
 - {cleanup actions taken}
 ```
 


### PR DESCRIPTION
## Summary

Three refinements from live-testing the opus strategic review with the user:

- **Cross-repo discovery**: reads `pulse-repos.json`, iterates ALL managed repos (not just aidevops). Product repos flagged higher priority. This caught webapp #183 (parent open, all 8 subtasks done) that v1 missed entirely.
- **Action/TODO split**: safe mechanical actions (prune, merge, file issues) done directly; state changes (marking tasks done, unblocking chains) created as TODOs for pulse/human verification.
- **Concurrency awareness**: worker count is informational, not a hard limit. Only flagged if evidence of harm (rate limits, OOM, timeouts).

Follow-up to #2333 (merged before refinements landed).