### PR TITLE
docs: recommend subscription plans over API billing for regular use

### DIFF
--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -1146,8 +1146,21 @@ Here's how it works:
   finds blocked chains, stale state, idle capacity, and systemic issues
 - It creates self-improvement tasks when it finds root causes in the framework
 
-Cost: the pulse uses sonnet-tier (~$0.50/day active). The strategic review uses
-opus (~$1-2/day). Workers use the model specified per task.
+Cost depends on how you access the models:
+
+Subscription plans (recommended for regular use):
+- Claude Max ($100-200/mo) or Pro ($20/mo) give generous allowances
+- OpenAI Pro ($200/mo) or Plus ($20/mo) for GPT models
+- Subscriptions are significantly cheaper than API for sustained daily use
+- The pulse, workers, and strategic review all run within your allowance
+
+API billing (for testing and occasional use only):
+- Pay-per-token pricing adds up fast with autonomous orchestration
+- A busy day with 10+ workers can cost $20-50+ on API billing
+- Reserve API keys for testing new providers or burst capacity
+
+Recommendation: use a subscription plan as your primary provider.
+Configure API keys as fallback only.
 
 You stay in control — the supervisor only dispatches tasks you've tagged.
 ```

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -112,7 +112,9 @@ When `model:` is absent, `sonnet` is assumed (the default tier).
 
 ## Cost Estimation
 
-Approximate relative costs (sonnet = 1x baseline):
+**Subscription vs API billing:** Subscription plans (Claude Pro/Max, OpenAI Plus/Pro) are recommended for regular use — they provide generous allowances at a flat monthly rate. API billing is pay-per-token and adds up fast with autonomous orchestration (pulse, workers, strategic review). Reserve API keys for testing new providers or burst capacity beyond your subscription allowance.
+
+Approximate relative API costs (sonnet = 1x baseline):
 
 | Tier | Input Cost | Output Cost | Relative |
 |------|-----------|-------------|----------|


### PR DESCRIPTION
## Summary

- **onboarding.md**: Updated orchestration cost section to recommend subscription plans (Claude Pro/Max, OpenAI Plus/Pro) as primary, API keys as fallback for testing/burst only
- **model-routing.md**: Added subscription vs API billing guidance above the cost estimation table, clarified the table shows API costs specifically

Subscription plans are significantly cheaper for sustained daily use with autonomous orchestration. A busy day with 10+ workers can cost $20-50+ on API billing vs being included in a flat monthly subscription.