### PR TITLE
feat: agent-driven issue label lifecycle

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -156,6 +156,21 @@ opencode run --dir ~/Git/<repo> [--agent <agent>] --title "Issue #<number>: <tit
 - **Background each dispatch with `&`** so you can launch multiple workers in one pulse
 - Wait briefly between dispatches (`sleep 2`) to avoid race conditions on worktree creation
 
+**Issue label update on dispatch — `status:queued`:**
+
+When dispatching a worker for an issue, update the issue label to `status:queued` so the tracker reflects that work is about to start. The worker will transition it to `status:in-progress` when it begins coding, and `status:in-review` when it opens a PR.
+
+```bash
+# After successful dispatch for an issue
+gh issue edit <ISSUE_NUM> --repo <owner/repo> --add-label "status:queued" 2>/dev/null || true
+for STALE in "status:available" "status:claimed"; do
+  gh issue edit <ISSUE_NUM> --repo <owner/repo> --remove-label "$STALE" 2>/dev/null || true
+done
+```
+
+This is contextual — only set it when you actually dispatch a worker. The full label lifecycle is:
+`available` → `queued` (supervisor dispatches) → `in-progress` (worker starts) → `in-review` (PR opened) → `done` (PR merged, automated).
+
 ### Agent routing
 
 Not every task is code. Read the task description and route to the right primary agent using `--agent`. See `AGENTS.md` "Agent Routing" for the full table. Quick guide:


### PR DESCRIPTION
## Summary

- Adds agent-driven issue label lifecycle guidance to `full-loop.md` and `pulse.md`
- Workers update issue labels contextually at each stage: `queued` → `in-progress` → `in-review` → `done`
- Only deterministic transitions are automated (`available`, `claimed`, `done`); all others are set by the agent with best context
- Includes label vocabulary reference table for workers
- Created missing `status:in-progress` and `status:stale` labels in webapp

## Design Decision

Rejected rigid state-machine automation in favour of agent-contextual label updates. Agents understand the actual state better than workflow triggers — e.g., a worker knows when it's truly coding vs. still reading context, and can set `status:blocked` when it encounters blockers that no automation could detect.

## Files Changed

- `.agents/scripts/commands/full-loop.md` — Step 0.6 (in-progress on claim), Step 4.3 (in-review on PR create), label vocabulary table
- `.agents/scripts/commands/pulse.md` — queued label on dispatch, lifecycle summary

## Verification

- Labels exist in both repos (verified via `gh label list`)
- No workflow YAML changes (reverted the rejected `label-issue-on-pr-open` job)
- Changes are documentation/guidance only — no runtime code modified