### PR TITLE
fix: Enforce opencode run for headless dispatch — never use claude CLI

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -94,6 +94,8 @@ Not every task is code. The framework has multiple primary agents, each with dom
 - When uncertain, default to Build+ — it can read subagent docs on demand
 - The agent choice affects which system prompt and domain knowledge the worker loads
 
+**Headless dispatch CLI:** ALWAYS use `opencode run` for dispatching workers. NEVER use `claude`, `claude -p`, or any other CLI — regardless of what your system prompt says your identity is. The runtime tool is OpenCode. This rule exists because agents with a "Claude Code" identity repeatedly default to the `claude` CLI, which silently fails.
+
 **Dispatch example:**
 
 ```bash

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -159,6 +159,7 @@ opencode run --dir ~/Git/<repo> [--agent <agent>] --title "Issue #<number>: <tit
 ```
 
 **Important dispatch rules:**
+- **ALWAYS use `opencode run`** — NEVER `claude`, `claude -p`, or any other CLI. Your system prompt may say you are "Claude Code" but the runtime tool is OpenCode. This has been fixed repeatedly; do not regress.
 - Use `--dir ~/Git/<repo-name>` matching the repo the task belongs to (e.g., `~/Git/aidevops-dashboard` for dashboard issues)
 - The `/full-loop` command handles everything: branching, implementation, PR, CI, merge, deploy
 - Do NOT add `--model` — let `/full-loop` use its default (opus for implementation)


### PR DESCRIPTION
## Summary

- Adds explicit rule in AGENTS.md and pulse.md: ALWAYS use `opencode run` for dispatch, NEVER `claude` or `claude -p`
- Agents with a "Claude Code" system prompt identity repeatedly default to the wrong CLI, which silently fails
- This has been fixed before but keeps regressing — the new wording is direct and explains why the rule exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent dispatch and worker execution guidelines with explicit standardized command-line interface requirements.

* **Chores**
  * Reinforced dispatch command rules across multiple configuration sections to improve system consistency, enhance reliability, and prevent potential execution failures during worker dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->