### PR TITLE
t2364: Add prevention rules for top 5 recurring error patterns

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -85,11 +85,49 @@ When referencing specific functions or code include the pattern `file_path:line_
 # File Operations (CRITICAL)
 - ALWAYS Read a file before Edit or Write. These tools FAIL without a prior Read in this conversation. No exceptions.
 - After any tool modifies a file (Edit, Write, Bash), re-read before the next Edit/Write on that same file. Stale content is the #1 error source.
-- Before Read/Edit/Write, verify the path exists (`git ls-files` or `fd`). Never assume a path from memory.
-- When using Edit, include 3+ lines of surrounding context in oldString to ensure a unique match. Never pass identical oldString and newString.
+- Before Read/Edit/Write, verify the path exists (`git ls-files` or `fd`). Never assume a path from memory or from AGENTS.md references — paths move between releases.
+- When using Edit, include 3+ lines of surrounding context in oldString to ensure a unique match. Never pass identical oldString and newString — this is a silent no-op that wastes a tool call.
 - Before deleting, moving, or substantially rewriting a file, verify no accumulated knowledge (edge-case handling, gotcha notes) will be lost. Prefer additive changes.
 - Never consume >100K tokens on a single operation
 - For remote repos: fetch README first, check size with `gh api`, use `includePatterns`
+
+# Error Prevention (top recurring patterns from session mining)
+#
+# 1. webfetch failures (259x observed)
+#    Root cause: constructing or guessing URLs that don't exist (GitHub blob URLs,
+#    PR review URLs, npm pages, external docs). webfetch has a ~16% failure rate.
+- NEVER guess or construct URLs for webfetch. Only fetch URLs that appear in user messages, tool output, or file contents.
+- For GitHub content: use `gh api` or `gh pr view` instead of webfetch — these handle auth and are more reliable.
+- For npm/package docs: use context7 MCP or `gh api` to fetch README from the repo.
+- If webfetch returns 404/403, do NOT retry the same URL. Find an alternative source or ask the user.
+#
+# 2. markdown-formatter exit codes (200x observed, 100% failure rate)
+#    Root cause: markdown-formatter exits non-zero when it finds lint issues —
+#    this is expected linter behavior, not a tool failure.
+- markdown-formatter exit code 1 means "issues found", not "tool broken". Read the output for the actual findings.
+- NEVER retry markdown-formatter expecting a different exit code — fix the reported issues first, then re-run.
+- When calling markdown-formatter with action "check" or "lint", expect non-zero exit if the file has issues.
+#
+# 3. read:file_not_found (169x observed)
+#    Root cause: assuming file paths from memory, AGENTS.md references, or prior
+#    sessions. Files move between releases and worktrees have different paths.
+- Before Read: run `git ls-files '<pattern>'` or `fd -g '<pattern>'` to confirm the file exists at the expected path.
+- In worktrees: the path prefix changes (e.g., `~/Git/repo.branch-name/` not `~/Git/repo/`). Always use the worktree path.
+- AGENTS.md references like `prompts/build.txt` are relative — resolve against the actual repo root, which may be `.agents/prompts/build.txt`.
+#
+# 4. edit:other (80x observed)
+#    Root causes: (a) identical oldString/newString (no-op), (b) permission denied
+#    on protected files, (c) editing files in wrong worktree.
+- Before Edit: confirm oldString differs from newString. If the content is already correct, skip the edit.
+- Permission errors mean the file is protected by user rules. Do not retry — check if you're in the right worktree or if the file requires a different workflow.
+- On "multiple matches" errors: include more surrounding context lines (5+) to make oldString unique, or use replaceAll if all instances should change.
+#
+# 5. glob:other (50x observed)
+#    Root cause: using Glob tool when it's blocked by permissions or searching
+#    non-existent directories. Glob is the LAST RESORT per File Discovery rules.
+- NEVER use Glob as primary file discovery. Use `git ls-files` (tracked) or `fd` (untracked) — these are faster and not subject to permission restrictions.
+- If Glob fails with permission error, switch to `git ls-files` or `fd` immediately — do not retry Glob.
+- If Glob fails with "No such directory", verify the directory exists before searching inside it.
 
 # Security Rules
 - NEVER expose credentials in output/logs


### PR DESCRIPTION
## Summary

- Adds an "Error Prevention" section to `prompts/build.txt` with specific, actionable rules for the top 5 recurring error patterns identified by session mining across 4,554 sessions
- Strengthens two existing File Operations rules with root-cause context from the data

## Error Patterns Addressed

| Pattern | Count | Prevention Rule |
|---------|-------|-----------------|
| `webfetch:other` | 259x | Never guess URLs; prefer `gh api`/`gh pr view` for GitHub content |
| `markdown-formatter:exit_code` | 200x | Exit 1 = lint findings (expected), not tool failure |
| `read:file_not_found` | 169x | Verify paths with `git ls-files`/`fd` before Read; worktree path awareness |
| `edit:other` | 80x | Prevent no-op edits (identical old/new); handle permission errors gracefully |
| `glob:other` | 50x | Reinforce `git ls-files`/`fd` over Glob; handle permission blocks |

## Evidence

Source: `~/.aidevops/.agent-workspace/work/session-miner/compressed_signals.json`

These 5 patterns account for 758 tool errors. Each rule targets the specific root cause observed in the error samples (not generic advice).

Closes #2364