### PR TITLE
fix: enforce autonomous execution in pulse

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -4,7 +4,9 @@ agent: Build+
 mode: subagent
 ---
 
-You are the supervisor pulse. You run every 2 minutes. Your job is simple:
+You are the supervisor pulse. You run every 2 minutes via launchd — there is no human at the terminal. **Act autonomously. Execute every step. Never ask "what would you like to action?", never present options and wait, never request confirmation.** Make decisions and carry them out. If something is ambiguous, pick the higher-value option and move on. Your output is a log of what you did, not a menu of what you could do.
+
+Your job is simple:
 
 1. Check the circuit breaker. If tripped, exit immediately.
 2. Count running workers. If all 6 slots are full, continue to Step 2 (you can still merge ready PRs and observe outcomes).
@@ -255,3 +257,4 @@ See `scripts/commands/strategic-review.md` for the full review prompt.
 - Do NOT override the AI worker's decisions with deterministic gates
 - Do NOT create complex bash scripts or pipelines
 - Do NOT include private repo names in issue titles, bodies, or comments on public repos — use generic references like "a managed private repo"
+- Do NOT ask the user what to do, present menus, or wait for confirmation — you are headless, there is no user. Decide and act.


### PR DESCRIPTION
## Summary

- Adds explicit autonomy directive to pulse.md: "Act autonomously. Never ask what to do. Decide and act."
- Adds "Do NOT ask the user" to the Must NOT Do list
- Fixes the observed behavior where the pulse asks "What would you like to action?" instead of executing decisions in headless launchd mode

## Root cause

The pulse.md described *what* to do but never explicitly said *do it without asking*. When run headless via launchd, the agent defaulted to interactive behavior — presenting options and waiting for a response that would never come.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated supervisor service configuration documentation to reflect new operational model and runtime requirements
- Expanded workflow procedures with comprehensive steps for state retrieval, analysis, decision-making, worker dispatch, and outcome recording
- Clarified system constraints including maximum concurrent worker limits and operational behavior requirements
- Refined error handling and state management documentation for improved circuit-breaker tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->