### PR TITLE
t1327.2: Review and fix SimpleX subagent documentation

### DIFF
--- a/.agents/services/communications/simplex.md
+++ b/.agents/services/communications/simplex.md
@@ -19,7 +19,7 @@ tools:
 ## Quick Reference
 
 - **Type**: Decentralized encrypted messaging — no user identifiers, no phone numbers, no central servers
-- **License**: AGPL-3.0 (client + servers), MIT (TypeScript SDK)
+- **License**: AGPL-3.0 (client, servers, and TypeScript SDK)
 - **Apps**: iOS, Android, Desktop (Linux/macOS/Windows), Terminal CLI
 - **Bot API**: WebSocket JSON API via CLI (`simplex-chat -p 5225`)
 - **TypeScript SDK**: `simplex-chat` + `@simplex-chat/types` (npm)
@@ -413,7 +413,7 @@ type GroupMemberRole = "observer" | "author" | "member" | "moderator" | "admin" 
 
 ### Bot Profile Configuration
 
-Distinguish bot from regular user by setting `peerType: "bot"` in the profile. This enables:
+**Requires CLI v6.4.3+.** Distinguish bot from regular user by setting `peerType: "bot"` in the profile. This enables:
 
 - Command highlighting in messages (text starting with `/`)
 - Command menu UI when users type `/` or tap `//` button
@@ -535,6 +535,7 @@ Bot can automate acceptance of business connections and initial responses. Confi
 - Sent as file attachments (audio format)
 - Bot receives voice notes via `NewChatItems` event with file info
 - Bot can download the file from CLI's local filesystem
+- Sending voice notes requires encoding audio to the expected format and attaching via `APISendMessages` with `MsgContent` type `voice` — there is no dedicated voice API
 - Integration with speech-to-text for transcription (see `.agents/tools/voice/speech-to-speech.md`)
 
 ### File Transfer
@@ -831,6 +832,10 @@ XFTP handles large files but practical limits depend on:
 - Server-configured storage quota
 - 48-hour default retention on XFTP relays
 - Network conditions for chunk upload/download
+
+### AGPL-3.0 SDK License
+
+The TypeScript SDK (`simplex-chat`, `@simplex-chat/types`) is AGPL-3.0 licensed. Bot code that imports the SDK must be AGPL-3.0 compatible or use the raw WebSocket API directly (which does not create a derivative work). This affects distribution — internal-only bots are not affected by AGPL's source disclosure requirement.
 
 ### Push Notifications
 


### PR DESCRIPTION
## Summary

- Fix license inaccuracy: TypeScript SDK (`simplex-chat`, `@simplex-chat/types`) is AGPL-3.0, not MIT as previously stated (verified via `npm view`)
- Add CLI v6.4.3+ version requirement for bot profile/commands feature
- Document voice note sending limitation (no dedicated voice API — requires manual encoding)
- Add AGPL-3.0 SDK license implications to Limitations section (affects bot code distribution)

## Context

The existing 947-line `simplex.md` was created by a prior worker (labels: `implemented:opus`, `needs-review`). This PR addresses the review by verifying accuracy against upstream sources (npm registry, research report t1327.1) and fixing the issues found.

Closes #2247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

- Clarified AGPL-3.0 licensing scope consolidating coverage of client, servers, and TypeScript SDK
- Bot functionality now requires CLI v6.4.3 or higher minimum
- Added bot profile badge feature documentation
- Voice messaging now includes format encoding requirements via API integration
- Expanded bot configuration options available through CLI and API

<!-- end of auto-generated comment: release notes by coderabbit.ai -->