### PR TITLE
t1327.10: Exec approval flow for remote chat commands

### DIFF
--- a/.agents/scripts/simplex-bot/src/approval.test.ts
+++ b/.agents/scripts/simplex-bot/src/approval.test.ts
@@ -16,6 +16,7 @@ describe("ApprovalManager", () => {
 
   beforeEach(() => {
     manager = new ApprovalManager();
+    noopReply.mockClear();
   });
 
   // ===========================================================================

--- a/.agents/scripts/simplex-bot/src/approval.test.ts
+++ b/.agents/scripts/simplex-bot/src/approval.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for the Exec Approval Manager
+ *
+ * Verifies: classification, request lifecycle, timeout, approve/reject flows.
+ * Run: bun test
+ */
+
+import { describe, expect, test, beforeEach, mock } from "bun:test";
+import { ApprovalManager } from "./approval";
+import type { ExecApprovalConfig } from "./types";
+import { DEFAULT_EXEC_APPROVAL_CONFIG } from "./types";
+
+describe("ApprovalManager", () => {
+  let manager: ApprovalManager;
+  const noopReply = mock(async (_text: string): Promise<void> => {});
+
+  beforeEach(() => {
+    manager = new ApprovalManager();
+  });
+
+  // ===========================================================================
+  // Classification
+  // ===========================================================================
+
+  describe("classify", () => {
+    test("allowlisted commands return 'allowed'", () => {
+      expect(manager.classify("aidevops status")).toBe("allowed");
+      expect(manager.classify("aidevops repos")).toBe("allowed");
+      expect(manager.classify("aidevops features")).toBe("allowed");
+    });
+
+    test("allowlist matching is case-insensitive", () => {
+      expect(manager.classify("AIDEVOPS STATUS")).toBe("allowed");
+      expect(manager.classify("Aidevops Repos")).toBe("allowed");
+    });
+
+    test("allowlist matches prefix (allows args after allowlisted command)", () => {
+      expect(manager.classify("aidevops status --verbose")).toBe("allowed");
+    });
+
+    test("blocklisted patterns return 'blocked'", () => {
+      expect(manager.classify("rm -rf /")).toBe("blocked");
+      expect(manager.classify("sudo shutdown -h now")).toBe("blocked");
+      expect(manager.classify("reboot")).toBe("blocked");
+      expect(manager.classify("mkfs.ext4 /dev/sda1")).toBe("blocked");
+    });
+
+    test("blocklist takes priority over allowlist", () => {
+      const custom = new ApprovalManager({
+        allowlist: ["rm -rf"],
+        blocklist: ["rm -rf"],
+      });
+      expect(custom.classify("rm -rf /tmp")).toBe("blocked");
+    });
+
+    test("unknown commands require approval by default", () => {
+      expect(manager.classify("curl https://example.com")).toBe("approval-required");
+      expect(manager.classify("ls -la")).toBe("approval-required");
+      expect(manager.classify("docker ps")).toBe("approval-required");
+    });
+
+    test("requireApprovalByDefault=false allows unknown commands", () => {
+      const permissive = new ApprovalManager({
+        requireApprovalByDefault: false,
+      });
+      expect(permissive.classify("curl https://example.com")).toBe("allowed");
+    });
+  });
+
+  // ===========================================================================
+  // Request Lifecycle
+  // ===========================================================================
+
+  describe("createRequest", () => {
+    test("creates a pending request with unique ID", () => {
+      const req = manager.createRequest("docker ps", 1, "alice", noopReply);
+      expect(req.id).toHaveLength(4);
+      expect(req.command).toBe("docker ps");
+      expect(req.contactId).toBe(1);
+      expect(req.contactName).toBe("alice");
+      expect(req.state).toBe("pending");
+    });
+
+    test("multiple requests get unique IDs", () => {
+      const req1 = manager.createRequest("cmd1", 1, "alice", noopReply);
+      const req2 = manager.createRequest("cmd2", 1, "alice", noopReply);
+      expect(req1.id).not.toBe(req2.id);
+    });
+  });
+
+  describe("approve", () => {
+    test("approves a pending request from the same contact", () => {
+      const req = manager.createRequest("docker ps", 1, "alice", noopReply);
+      const approved = manager.approve(req.id, 1);
+      expect(approved).not.toBeNull();
+      expect(approved!.state).toBe("approved");
+    });
+
+    test("rejects approval from a different contact", () => {
+      const req = manager.createRequest("docker ps", 1, "alice", noopReply);
+      const result = manager.approve(req.id, 2);
+      expect(result).toBeNull();
+    });
+
+    test("returns null for non-existent request", () => {
+      expect(manager.approve("xxxx", 1)).toBeNull();
+    });
+
+    test("returns null for already-approved request", () => {
+      const req = manager.createRequest("docker ps", 1, "alice", noopReply);
+      manager.approve(req.id, 1);
+      const second = manager.approve(req.id, 1);
+      expect(second).toBeNull();
+    });
+  });
+
+  describe("reject", () => {
+    test("rejects a pending request", () => {
+      const req = manager.createRequest("docker ps", 1, "alice", noopReply);
+      const rejected = manager.reject(req.id);
+      expect(rejected).not.toBeNull();
+      expect(rejected!.state).toBe("rejected");
+    });
+
+    test("returns null for non-existent request", () => {
+      expect(manager.reject("xxxx")).toBeNull();
+    });
+  });
+
+  describe("listPending", () => {
+    test("lists all pending requests", () => {
+      manager.createRequest("cmd1", 1, "alice", noopReply);
+      manager.createRequest("cmd2", 2, "bob", noopReply);
+      expect(manager.listPending()).toHaveLength(2);
+    });
+
+    test("filters by contactId", () => {
+      manager.createRequest("cmd1", 1, "alice", noopReply);
+      manager.createRequest("cmd2", 2, "bob", noopReply);
+      expect(manager.listPending(1)).toHaveLength(1);
+      expect(manager.listPending(1)[0].contactName).toBe("alice");
+    });
+
+    test("excludes non-pending requests", () => {
+      const req = manager.createRequest("cmd1", 1, "alice", noopReply);
+      manager.approve(req.id, 1);
+      manager.createRequest("cmd2", 1, "alice", noopReply);
+      expect(manager.listPending(1)).toHaveLength(1);
+    });
+  });
+
+  // ===========================================================================
+  // Timeout
+  // ===========================================================================
+
+  describe("timeout", () => {
+    test("expires request after timeout and notifies requester", async () => {
+      const replyMock = mock(async (_text: string): Promise<void> => {});
+      const shortTimeout = new ApprovalManager({ approvalTimeoutMs: 100 });
+      const req = shortTimeout.createRequest("docker ps", 1, "alice", replyMock);
+
+      // Wait for timeout to fire
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Request should be expired and cleaned up
+      expect(shortTimeout.getRequest(req.id)).toBeUndefined();
+      expect(shortTimeout.listPending()).toHaveLength(0);
+
+      // Reply should have been called with expiry message
+      expect(replyMock).toHaveBeenCalledTimes(1);
+      const callArg = replyMock.mock.calls[0][0];
+      expect(callArg).toContain("expired");
+      expect(callArg).toContain(req.id);
+
+      shortTimeout.shutdown();
+    });
+  });
+
+  // ===========================================================================
+  // Shutdown
+  // ===========================================================================
+
+  describe("shutdown", () => {
+    test("clears all pending requests and timers", () => {
+      manager.createRequest("cmd1", 1, "alice", noopReply);
+      manager.createRequest("cmd2", 2, "bob", noopReply);
+      manager.shutdown();
+      expect(manager.listPending()).toHaveLength(0);
+    });
+  });
+
+  // ===========================================================================
+  // Custom Config
+  // ===========================================================================
+
+  describe("custom config", () => {
+    test("custom allowlist overrides defaults", () => {
+      const custom = new ApprovalManager({
+        allowlist: ["git status", "git log"],
+      });
+      expect(custom.classify("git status")).toBe("allowed");
+      expect(custom.classify("aidevops status")).toBe("approval-required");
+    });
+
+    test("custom blocklist merges with intent", () => {
+      const custom = new ApprovalManager({
+        blocklist: [...DEFAULT_EXEC_APPROVAL_CONFIG.blocklist, "curl"],
+      });
+      expect(custom.classify("curl https://evil.com")).toBe("blocked");
+      expect(custom.classify("rm -rf /")).toBe("blocked");
+    });
+
+    test("formatTimeout returns human-readable string", () => {
+      const m1 = new ApprovalManager({ approvalTimeoutMs: 60_000 });
+      expect(m1.formatTimeout()).toBe("1m");
+
+      const m2 = new ApprovalManager({ approvalTimeoutMs: 30_000 });
+      expect(m2.formatTimeout()).toBe("30s");
+
+      const m3 = new ApprovalManager({ approvalTimeoutMs: 120_000 });
+      expect(m3.formatTimeout()).toBe("2m");
+    });
+  });
+});

--- a/.agents/scripts/simplex-bot/src/approval.ts
+++ b/.agents/scripts/simplex-bot/src/approval.ts
@@ -1,0 +1,284 @@
+/**
+ * SimpleX Bot — Exec Approval Manager
+ *
+ * Manages the approval flow for remote command execution via chat.
+ * Three-tier classification:
+ *   - allowlist: execute immediately (safe commands like /status, /tasks)
+ *   - approval-required: send approval request, wait for /approve, timeout-to-reject
+ *   - blocklist: always rejected (dangerous patterns like rm -rf, shutdown)
+ *
+ * Reference: t1327.10 exec approval flow specification
+ */
+
+import type {
+  ApprovalState,
+  ExecApprovalConfig,
+  ExecClassification,
+  PendingApproval,
+} from "./types";
+import { DEFAULT_EXEC_APPROVAL_CONFIG } from "./types";
+
+// =============================================================================
+// Approval Manager
+// =============================================================================
+
+/** Manages pending approval requests with timeout-to-reject */
+export class ApprovalManager {
+  private config: ExecApprovalConfig;
+  private pending: Map<string, PendingApproval> = new Map();
+  private timers: Map<string, ReturnType<typeof setTimeout>> = new Map();
+
+  /** Create an approval manager with optional config overrides */
+  constructor(config: Partial<ExecApprovalConfig> = {}) {
+    this.config = { ...DEFAULT_EXEC_APPROVAL_CONFIG, ...config };
+  }
+
+  /** Classify a command string into allowed/approval-required/blocked */
+  classify(command: string): ExecClassification {
+    const normalised = command.toLowerCase().trim();
+
+    // Check blocklist first (safety takes priority)
+    for (const pattern of this.config.blocklist) {
+      if (normalised.includes(pattern.toLowerCase())) {
+        return "blocked";
+      }
+    }
+
+    // Check allowlist
+    for (const pattern of this.config.allowlist) {
+      if (normalised.startsWith(pattern.toLowerCase())) {
+        return "allowed";
+      }
+    }
+
+    // Default behaviour
+    return this.config.requireApprovalByDefault ? "approval-required" : "allowed";
+  }
+
+  /** Generate a short unique approval ID (4 hex chars) */
+  private generateId(): string {
+    const bytes = new Uint8Array(2);
+    crypto.getRandomValues(bytes);
+    const id = Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    // Avoid collisions with existing pending requests
+    if (this.pending.has(id)) {
+      return this.generateId();
+    }
+    return id;
+  }
+
+  /**
+   * Create a pending approval request.
+   * Returns the PendingApproval with a unique ID.
+   * Starts the timeout timer — if not approved within the timeout, auto-rejects.
+   */
+  createRequest(
+    command: string,
+    contactId: number,
+    contactName: string,
+    reply: (text: string) => Promise<void>,
+  ): PendingApproval {
+    const id = this.generateId();
+    const request: PendingApproval = {
+      id,
+      command,
+      contactId,
+      contactName,
+      createdAt: Date.now(),
+      state: "pending",
+      reply,
+    };
+
+    this.pending.set(id, request);
+
+    // Start timeout timer
+    const timer = setTimeout(() => {
+      this.expireRequest(id);
+    }, this.config.approvalTimeoutMs);
+    this.timers.set(id, timer);
+
+    return request;
+  }
+
+  /**
+   * Approve a pending request by ID.
+   * Returns the request if found and still pending, null otherwise.
+   */
+  approve(id: string, approverContactId: number): PendingApproval | null {
+    const request = this.pending.get(id);
+    if (!request) {
+      return null;
+    }
+
+    if (request.state !== "pending") {
+      return null;
+    }
+
+    // Only the original requester can approve their own commands
+    if (request.contactId !== approverContactId) {
+      return null;
+    }
+
+    request.state = "approved";
+    this.clearTimer(id);
+    return request;
+  }
+
+  /**
+   * Reject a pending request by ID.
+   * Returns the request if found and still pending, null otherwise.
+   */
+  reject(id: string): PendingApproval | null {
+    const request = this.pending.get(id);
+    if (!request) {
+      return null;
+    }
+
+    if (request.state !== "pending") {
+      return null;
+    }
+
+    request.state = "rejected";
+    this.clearTimer(id);
+    this.pending.delete(id);
+    return request;
+  }
+
+  /** Get a pending request by ID */
+  getRequest(id: string): PendingApproval | undefined {
+    return this.pending.get(id);
+  }
+
+  /** List all pending requests for a given contact */
+  listPending(contactId?: number): PendingApproval[] {
+    const results: PendingApproval[] = [];
+    for (const request of this.pending.values()) {
+      if (request.state !== "pending") {
+        continue;
+      }
+      if (contactId !== undefined && request.contactId !== contactId) {
+        continue;
+      }
+      results.push(request);
+    }
+    return results;
+  }
+
+  /** Format the approval timeout as a human-readable string */
+  formatTimeout(): string {
+    const seconds = Math.round(this.config.approvalTimeoutMs / 1000);
+    if (seconds >= 60) {
+      const minutes = Math.round(seconds / 60);
+      return `${minutes}m`;
+    }
+    return `${seconds}s`;
+  }
+
+  /** Clean up a completed/expired request */
+  private cleanupRequest(id: string): void {
+    this.clearTimer(id);
+    this.pending.delete(id);
+  }
+
+  /** Clear the timeout timer for a request */
+  private clearTimer(id: string): void {
+    const timer = this.timers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+    }
+  }
+
+  /** Expire a request (called by timeout timer) */
+  private expireRequest(id: string): void {
+    const request = this.pending.get(id);
+    if (!request || request.state !== "pending") {
+      this.cleanupRequest(id);
+      return;
+    }
+
+    request.state = "expired";
+
+    // Notify the requester that their command expired
+    void request.reply(
+      `Approval request [${id}] expired.\n` +
+      `Command: ${request.command}\n` +
+      `Timed out after ${this.formatTimeout()}. Re-run the command to try again.`,
+    ).catch(() => {
+      // Best-effort notification — don't crash on reply failure
+    });
+
+    this.cleanupRequest(id);
+  }
+
+  /** Shut down the manager — clear all timers */
+  shutdown(): void {
+    for (const timer of this.timers.values()) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
+    this.pending.clear();
+  }
+}
+
+// =============================================================================
+// Command Execution
+// =============================================================================
+
+/**
+ * Execute a shell command and return the output.
+ * Used after approval is granted.
+ * Enforces a per-command timeout to prevent runaway processes.
+ */
+export async function executeShellCommand(
+  command: string,
+  timeoutMs: number = 30_000,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(["sh", "-c", command], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Race between command completion and timeout
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => {
+      proc.kill();
+      reject(new Error(`Command timed out after ${Math.round(timeoutMs / 1000)}s`));
+    }, timeoutMs);
+  });
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.race([
+      Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]),
+      timeoutPromise,
+    ]);
+
+    return {
+      exitCode,
+      stdout: truncateOutput(stdout),
+      stderr: truncateOutput(stderr),
+    };
+  } catch (err) {
+    return {
+      exitCode: -1,
+      stdout: "",
+      stderr: String(err),
+    };
+  }
+}
+
+/** Truncate command output to prevent flooding the chat */
+function truncateOutput(text: string, maxLength: number = 2000): string {
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return trimmed.substring(0, maxLength) + "\n... (truncated)";
+}

--- a/.agents/scripts/simplex-bot/src/commands.ts
+++ b/.agents/scripts/simplex-bot/src/commands.ts
@@ -274,7 +274,14 @@ const approveCommand: CommandDefinition = {
   },
 };
 
-/** Reject a pending command execution */
+/**
+ * Reject a pending command execution.
+ *
+ * Authorization note: /reject intentionally has no identity check (unlike /approve
+ * which validates contactId). This allows any DM contact to reject suspicious
+ * commands — a safety-first design. To restrict rejection to the original
+ * requester, pass contactId to approvalManager.reject() (see approval.ts).
+ */
 const rejectCommand: CommandDefinition = {
   name: "reject",
   description: "Reject a pending command execution",

--- a/.agents/scripts/simplex-bot/src/commands.ts
+++ b/.agents/scripts/simplex-bot/src/commands.ts
@@ -5,11 +5,33 @@
  * Each command is a self-contained handler that receives a CommandContext.
  *
  * Reference: t1327.4 bot framework specification
+ * Reference: t1327.10 exec approval flow
  */
 
 import { resolve } from "node:path";
 import type { CommandContext, CommandDefinition } from "./types";
+import { ApprovalManager, executeShellCommand } from "./approval";
 import pkg from "../package.json";
+
+// =============================================================================
+// Shared Approval Manager
+// =============================================================================
+
+/**
+ * Singleton approval manager — shared across all command handlers.
+ * Initialised with defaults; the bot can reconfigure via setApprovalManager().
+ */
+let approvalManager = new ApprovalManager();
+
+/** Replace the approval manager (called by SimplexAdapter after config is loaded) */
+export function setApprovalManager(manager: ApprovalManager): void {
+  approvalManager = manager;
+}
+
+/** Get the current approval manager (for shutdown cleanup) */
+export function getApprovalManager(): ApprovalManager {
+  return approvalManager;
+}
 
 // =============================================================================
 // Built-in Commands
@@ -136,10 +158,17 @@ const taskCommand: CommandDefinition = {
   },
 };
 
-/** Execute an aidevops CLI command remotely (DM only, requires approval) */
+/**
+ * Execute a command remotely (DM only).
+ *
+ * Three-tier classification:
+ *   - allowlist: executes immediately (e.g., "aidevops status")
+ *   - approval-required: sends approval request, waits for /approve <id>
+ *   - blocklist: always rejected (e.g., "rm -rf")
+ */
 const runCommand: CommandDefinition = {
   name: "run",
-  description: "Execute an aidevops CLI command remotely",
+  description: "Execute a command remotely (approval required for unsafe commands)",
   groupEnabled: false,
   dmEnabled: true,
   handler: async (ctx: CommandContext): Promise<string> => {
@@ -147,14 +176,148 @@ const runCommand: CommandDefinition = {
     if (!command) {
       return "Usage: /run [command]\nExample: /run aidevops status";
     }
-    // Security: this should go through exec approval flow (t1327.10)
-    return [
-      "Command: " + command,
-      "",
-      "Remote command execution requires approval (t1327.10).",
-      "Safe commands (/status, /tasks) can be allowlisted.",
-      "This is a scaffold — exec approval flow not yet implemented.",
-    ].join("\n");
+
+    const contactId = ctx.contact?.contactId;
+    const contactName = ctx.contact?.localDisplayName ?? "unknown";
+    if (contactId === undefined) {
+      return "Cannot execute commands: no contact identity available.";
+    }
+
+    const classification = approvalManager.classify(command);
+
+    switch (classification) {
+      case "blocked":
+        return (
+          "BLOCKED: This command matches a blocked pattern and cannot be executed.\n" +
+          "Command: " + command
+        );
+
+      case "allowed": {
+        // Execute immediately — command is on the allowlist
+        const result = await executeShellCommand(command);
+        const lines = ["Executed (allowlisted):", ""];
+        if (result.stdout) {
+          lines.push(result.stdout);
+        }
+        if (result.stderr) {
+          lines.push("stderr: " + result.stderr);
+        }
+        lines.push("", "Exit code: " + result.exitCode);
+        return lines.join("\n");
+      }
+
+      case "approval-required": {
+        // Create pending approval request
+        const request = approvalManager.createRequest(
+          command,
+          contactId,
+          contactName,
+          ctx.reply,
+        );
+
+        return [
+          "Approval required for command execution.",
+          "",
+          "Command: " + command,
+          "Request ID: " + request.id,
+          "Timeout: " + approvalManager.formatTimeout(),
+          "",
+          "To approve:  /approve " + request.id,
+          "To reject:   /reject " + request.id,
+          "To list all: /pending",
+        ].join("\n");
+      }
+    }
+  },
+};
+
+/** Approve a pending command execution */
+const approveCommand: CommandDefinition = {
+  name: "approve",
+  description: "Approve a pending command execution",
+  groupEnabled: false,
+  dmEnabled: true,
+  handler: async (ctx: CommandContext): Promise<string> => {
+    const requestId = ctx.args[0];
+    if (!requestId) {
+      return "Usage: /approve [request-id]\nExample: /approve a3f7";
+    }
+
+    const contactId = ctx.contact?.contactId;
+    if (contactId === undefined) {
+      return "Cannot approve: no contact identity available.";
+    }
+
+    const request = approvalManager.approve(requestId, contactId);
+    if (!request) {
+      // Check if the request exists but is in a non-pending state
+      const existing = approvalManager.getRequest(requestId);
+      if (existing) {
+        return "Request [" + requestId + "] is no longer pending (state: " + existing.state + ").";
+      }
+      return "No pending request found with ID: " + requestId;
+    }
+
+    // Execute the approved command
+    await ctx.reply("Approved. Executing: " + request.command);
+
+    const result = await executeShellCommand(request.command);
+    const lines = ["Result for [" + requestId + "]:", ""];
+    if (result.stdout) {
+      lines.push(result.stdout);
+    }
+    if (result.stderr) {
+      lines.push("stderr: " + result.stderr);
+    }
+    lines.push("", "Exit code: " + result.exitCode);
+    return lines.join("\n");
+  },
+};
+
+/** Reject a pending command execution */
+const rejectCommand: CommandDefinition = {
+  name: "reject",
+  description: "Reject a pending command execution",
+  groupEnabled: false,
+  dmEnabled: true,
+  handler: async (ctx: CommandContext): Promise<string> => {
+    const requestId = ctx.args[0];
+    if (!requestId) {
+      return "Usage: /reject [request-id]\nExample: /reject a3f7";
+    }
+
+    const request = approvalManager.reject(requestId);
+    if (!request) {
+      return "No pending request found with ID: " + requestId;
+    }
+
+    return "Rejected command [" + requestId + "]: " + request.command;
+  },
+};
+
+/** List pending approval requests */
+const pendingCommand: CommandDefinition = {
+  name: "pending",
+  description: "List pending command approval requests",
+  groupEnabled: false,
+  dmEnabled: true,
+  handler: async (ctx: CommandContext): Promise<string> => {
+    const contactId = ctx.contact?.contactId;
+    const requests = approvalManager.listPending(contactId);
+
+    if (requests.length === 0) {
+      return "No pending approval requests.";
+    }
+
+    const lines = ["Pending approval requests:", ""];
+    for (const req of requests) {
+      const ageSeconds = Math.round((Date.now() - req.createdAt) / 1000);
+      lines.push(
+        "[" + req.id + "] " + req.command + " (" + ageSeconds + "s ago)",
+      );
+    }
+    lines.push("", "Use /approve <id> or /reject <id> to respond.");
+    return lines.join("\n");
   },
 };
 
@@ -192,6 +355,9 @@ export const BUILTIN_COMMANDS: CommandDefinition[] = [
   tasksCommand,
   taskCommand,
   runCommand,
+  approveCommand,
+  rejectCommand,
+  pendingCommand,
   pingCommand,
   versionCommand,
 ];

--- a/.agents/scripts/simplex-bot/src/index.ts
+++ b/.agents/scripts/simplex-bot/src/index.ts
@@ -572,15 +572,23 @@ function parseExecApprovalConfig(): Partial<ExecApprovalConfig> {
 
   const allowlist = parseListEnv(process.env.SIMPLEX_EXEC_ALLOWLIST);
   if (allowlist) {
-    config.allowlist = allowlist;
+    // Merge with defaults — default safe commands should persist (mirrors blocklist behaviour)
+    config.allowlist = [
+      ...new Set([
+        ...DEFAULT_EXEC_APPROVAL_CONFIG.allowlist,
+        ...allowlist,
+      ]),
+    ];
   }
 
   const blocklist = parseListEnv(process.env.SIMPLEX_EXEC_BLOCKLIST);
   if (blocklist) {
     // Merge with defaults rather than replacing — safety patterns should persist
     config.blocklist = [
-      ...DEFAULT_EXEC_APPROVAL_CONFIG.blocklist,
-      ...blocklist,
+      ...new Set([
+        ...DEFAULT_EXEC_APPROVAL_CONFIG.blocklist,
+        ...blocklist,
+      ]),
     ];
   }
 
@@ -592,8 +600,11 @@ function parseExecApprovalConfig(): Partial<ExecApprovalConfig> {
     }
   }
 
-  if (process.env.SIMPLEX_EXEC_REQUIRE_APPROVAL === "false") {
+  const requireApproval = process.env.SIMPLEX_EXEC_REQUIRE_APPROVAL?.toLowerCase();
+  if (requireApproval === "false") {
     config.requireApprovalByDefault = false;
+  } else if (requireApproval === "true") {
+    config.requireApprovalByDefault = true;
   }
 
   return config;

--- a/todo/tasks/t1327.10-exec-approval-brief.md
+++ b/todo/tasks/t1327.10-exec-approval-brief.md
@@ -1,0 +1,118 @@
+---
+mode: subagent
+---
+# t1327.10: Exec approval flow for remote chat commands
+
+## Origin
+
+- **Created:** 2026-02-26
+- **Session:** claude-code:feature/exec-approval-flow
+- **Created by:** ai-interactive
+- **Parent task:** t1327 (SimpleX bot framework plan p032)
+- **Conversation context:** Issue #2261 requested an approval flow for the /run command in the SimpleX bot, requiring explicit user confirmation before executing dangerous commands via chat.
+
+## What
+
+A three-tier exec approval system for the SimpleX bot's `/run` command:
+
+1. **Allowlist**: Safe commands (e.g., `aidevops status`) execute immediately without approval
+2. **Approval-required**: Unknown commands send an approval request back to chat with a unique ID; user must `/approve <id>` within a configurable timeout (default 60s) or the request auto-rejects
+3. **Blocklist**: Dangerous patterns (e.g., `rm -rf`, `shutdown`) are always rejected
+
+New chat commands: `/approve <id>`, `/reject <id>`, `/pending`
+
+## Why
+
+The `/run` command was a scaffold placeholder (t1327.4) that refused all execution. Without an approval flow, the bot cannot safely execute remote commands — either everything is blocked (useless) or everything is allowed (dangerous). This implements the security boundary that makes remote command execution viable.
+
+## How (Approach)
+
+- New `approval.ts` module: `ApprovalManager` class with classify/create/approve/reject/timeout lifecycle
+- Extended `types.ts`: `ExecApprovalConfig`, `PendingApproval`, `ApprovalState` types added to `BotConfig`
+- Updated `commands.ts`: `/run` now classifies and routes through approval; new `/approve`, `/reject`, `/pending` commands
+- Updated `index.ts`: Initialises `ApprovalManager` from config, supports env var configuration, cleans up on shutdown
+- Pattern: `commands.ts:11` — existing command handler pattern with `CommandContext`
+- Tests: `approval.test.ts` — 23 tests covering classification, lifecycle, timeout, config
+
+## Acceptance Criteria
+
+- [ ] Allowlisted commands execute immediately via /run
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "case \"allowed\""
+    path: ".agents/scripts/simplex-bot/src/commands.ts"
+  ```
+- [ ] Blocklisted commands are always rejected
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "case \"blocked\""
+    path: ".agents/scripts/simplex-bot/src/commands.ts"
+  ```
+- [ ] Unknown commands require explicit /approve before execution
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "case \"approval-required\""
+    path: ".agents/scripts/simplex-bot/src/commands.ts"
+  ```
+- [ ] Pending approvals auto-expire after configurable timeout
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "expireRequest"
+    path: ".agents/scripts/simplex-bot/src/approval.ts"
+  ```
+- [ ] Configuration via environment variables (SIMPLEX_EXEC_ALLOWLIST, SIMPLEX_EXEC_BLOCKLIST, SIMPLEX_EXEC_TIMEOUT)
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "SIMPLEX_EXEC_"
+    path: ".agents/scripts/simplex-bot/src/index.ts"
+  ```
+- [ ] Tests pass (`bun test`)
+  ```yaml
+  verify:
+    method: bash
+    run: "cd .agents/scripts/simplex-bot && ~/.bun/bin/bun test"
+  ```
+- [ ] TypeScript typecheck passes
+  ```yaml
+  verify:
+    method: bash
+    run: "cd .agents/scripts/simplex-bot && ~/.bun/bin/bun x tsc --noEmit"
+  ```
+
+## Context & Decisions
+
+- Blocklist takes priority over allowlist (safety-first: if a pattern appears in both, it's blocked)
+- Allowlist uses prefix matching (e.g., "aidevops status" matches "aidevops status --verbose")
+- Blocklist uses substring matching (e.g., "rm -rf" matches "sudo rm -rf /tmp")
+- Only the original requester can approve their own commands (prevents social engineering in shared contexts)
+- Custom blocklist entries from env vars are merged with defaults, not replaced (safety patterns persist)
+- Shell command execution has a 30s per-command timeout to prevent runaway processes
+- Output is truncated to 2000 chars to prevent chat flooding
+
+## Relevant Files
+
+- `.agents/scripts/simplex-bot/src/approval.ts` — new: ApprovalManager + executeShellCommand
+- `.agents/scripts/simplex-bot/src/approval.test.ts` — new: 23 tests for approval flow
+- `.agents/scripts/simplex-bot/src/types.ts:159-230` — new types: ExecApprovalConfig, PendingApproval
+- `.agents/scripts/simplex-bot/src/commands.ts:139-280` — updated /run + new /approve, /reject, /pending
+- `.agents/scripts/simplex-bot/src/index.ts:23-37,152-162,225-237,533-575` — approval manager init, config, cleanup
+
+## Dependencies
+
+- **Blocked by:** t1327.4 (bot framework) — completed
+- **Blocks:** t1327.11+ (future remote execution features)
+- **External:** None
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Research/read | 15m | Read bot framework, understand command flow |
+| Implementation | 1h | approval.ts, types, commands, index integration |
+| Testing | 30m | 23 unit tests + typecheck |
+| **Total** | **~2h** | |

--- a/todo/tasks/t1327.10-exec-approval-brief.md
+++ b/todo/tasks/t1327.10-exec-approval-brief.md
@@ -37,47 +37,60 @@ The `/run` command was a scaffold placeholder (t1327.4) that refused all executi
 ## Acceptance Criteria
 
 - [ ] Allowlisted commands execute immediately via /run
+
   ```yaml
   verify:
     method: codebase
     pattern: "case \"allowed\""
     path: ".agents/scripts/simplex-bot/src/commands.ts"
   ```
+
 - [ ] Blocklisted commands are always rejected
+
   ```yaml
   verify:
     method: codebase
     pattern: "case \"blocked\""
     path: ".agents/scripts/simplex-bot/src/commands.ts"
   ```
+
 - [ ] Unknown commands require explicit /approve before execution
+
   ```yaml
   verify:
     method: codebase
     pattern: "case \"approval-required\""
     path: ".agents/scripts/simplex-bot/src/commands.ts"
   ```
+
 - [ ] Pending approvals auto-expire after configurable timeout
+
   ```yaml
   verify:
     method: codebase
     pattern: "expireRequest"
     path: ".agents/scripts/simplex-bot/src/approval.ts"
   ```
+
 - [ ] Configuration via environment variables (SIMPLEX_EXEC_ALLOWLIST, SIMPLEX_EXEC_BLOCKLIST, SIMPLEX_EXEC_TIMEOUT)
+
   ```yaml
   verify:
     method: codebase
     pattern: "SIMPLEX_EXEC_"
     path: ".agents/scripts/simplex-bot/src/index.ts"
   ```
+
 - [ ] Tests pass (`bun test`)
+
   ```yaml
   verify:
     method: bash
     run: "cd .agents/scripts/simplex-bot && ~/.bun/bin/bun test"
   ```
+
 - [ ] TypeScript typecheck passes
+
   ```yaml
   verify:
     method: bash


### PR DESCRIPTION
## Summary

- Implements three-tier exec approval flow for the SimpleX bot `/run` command: **allowlist** (immediate execution), **approval-required** (needs `/approve <id>` within configurable timeout), **blocklist** (always rejected)
- Adds new chat commands: `/approve <id>`, `/reject <id>`, `/pending`
- Configurable via environment variables: `SIMPLEX_EXEC_ALLOWLIST`, `SIMPLEX_EXEC_BLOCKLIST`, `SIMPLEX_EXEC_TIMEOUT`, `SIMPLEX_EXEC_REQUIRE_APPROVAL`

## Changes

| File | Change |
|------|--------|
| `src/approval.ts` | New: `ApprovalManager` class with classify/create/approve/reject/timeout lifecycle + `executeShellCommand` |
| `src/approval.test.ts` | New: 23 unit tests covering classification, request lifecycle, timeout, config |
| `src/types.ts` | New types: `ExecApprovalConfig`, `PendingApproval`, `ApprovalState`; extended `BotConfig` |
| `src/commands.ts` | Updated `/run` with approval flow; added `/approve`, `/reject`, `/pending` commands |
| `src/index.ts` | Approval manager init from config, env var parsing, shutdown cleanup |
| `todo/tasks/t1327.10-exec-approval-brief.md` | Task brief |

## Design Decisions

- **Blocklist > allowlist priority**: If a pattern appears in both, it's blocked (safety-first)
- **Allowlist = prefix match**: `"aidevops status"` matches `"aidevops status --verbose"`
- **Blocklist = substring match**: `"rm -rf"` matches `"sudo rm -rf /tmp"`
- **Same-contact approval only**: Only the requester can approve their own commands
- **Custom blocklist merges with defaults**: Safety patterns always persist
- **30s per-command execution timeout**: Prevents runaway processes
- **2000 char output truncation**: Prevents chat flooding

## Verification

- `bun test` — 23 tests pass
- `tsc --noEmit` — typecheck clean

Closes #2261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command approval workflow with three-tier classification: allowed (executes immediately), approval-required (creates a pending request), and blocked (returns a blocked message).
  * New commands: /approve, /reject, /pending to manage pending executions.
  * Environment-driven allowlist/blocklist, automatic expiration with requester notification, and cleanup on shutdown.
  * Executed commands return combined stdout/stderr with enforced timeouts and output truncation.

* **Tests**
  * Added comprehensive tests covering classification, request lifecycle, timeouts/expiration, shutdown, and config behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->