### PR TITLE
t1327.4: SimpleX bot framework — handlers, session store, config, commands

### DIFF
--- a/.agents/scripts/simplex-bot/README.md
+++ b/.agents/scripts/simplex-bot/README.md
@@ -14,6 +14,42 @@ cd .agents/scripts/simplex-bot
 bun install
 ```
 
+## Configuration
+
+The bot loads config from three sources (highest priority first):
+
+1. **Environment variables** — `SIMPLEX_PORT`, `SIMPLEX_HOST`, etc.
+2. **Config file** — `~/.config/aidevops/simplex-bot.json`
+3. **Defaults** — built-in defaults
+
+### Config File
+
+```json
+{
+  "port": 5225,
+  "host": "127.0.0.1",
+  "displayName": "AIBot",
+  "autoAcceptContacts": false,
+  "businessAddress": false,
+  "autoAcceptFiles": false,
+  "autoJoinGroups": false,
+  "logLevel": "info",
+  "sessionIdleTimeout": 300
+}
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SIMPLEX_PORT` | `5225` | WebSocket port for SimpleX CLI |
+| `SIMPLEX_HOST` | `127.0.0.1` | WebSocket host |
+| `SIMPLEX_BOT_NAME` | `AIBot` | Bot display name |
+| `SIMPLEX_AUTO_ACCEPT` | `false` | Auto-accept contact requests |
+| `SIMPLEX_LOG_LEVEL` | `info` | Log level (debug/info/warn/error) |
+| `SIMPLEX_TLS` | `false` | Use TLS for WebSocket |
+| `SIMPLEX_BUSINESS_ADDRESS` | `false` | Enable business address mode |
+
 ## Usage
 
 ```bash
@@ -23,32 +59,50 @@ bun run start
 # Development mode (auto-reload)
 bun run dev
 
-# With custom port
-SIMPLEX_PORT=5226 bun run start
+# Type checking
+bun run typecheck
 ```
-
-## Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SIMPLEX_PORT` | `5225` | WebSocket port for SimpleX CLI |
-| `SIMPLEX_HOST` | `127.0.0.1` | WebSocket host |
-| `SIMPLEX_BOT_NAME` | `AIBot` | Bot display name |
-| `SIMPLEX_AUTO_ACCEPT` | `false` | Auto-accept contact requests |
-| `SIMPLEX_LOG_LEVEL` | `info` | Log level (debug/info/warn/error) |
 
 ## Built-in Commands
 
-| Command | Description |
-|---------|-------------|
-| `/help` | Show available commands |
-| `/status` | Show aidevops system status |
-| `/ask <question>` | Ask AI a question |
-| `/tasks` | List open tasks |
-| `/task <description>` | Create a new task |
-| `/run <command>` | Execute aidevops CLI command (requires approval) |
-| `/ping` | Check bot responsiveness |
-| `/version` | Show bot version |
+### Core
+
+| Command | DM | Group | Description |
+|---------|:--:|:-----:|-------------|
+| `/help` | Y | Y | Show available commands |
+| `/status` | Y | Y | Show aidevops system status |
+| `/ask <question>` | Y | Y | Ask AI a question |
+| `/ping` | Y | Y | Check bot responsiveness |
+| `/version` | Y | Y | Show bot version |
+
+### Tasks
+
+| Command | DM | Group | Description |
+|---------|:--:|:-----:|-------------|
+| `/tasks` | Y | Y | List open tasks from TODO.md |
+| `/task <description>` | Y | - | Create a new task |
+
+### Execution
+
+| Command | DM | Group | Description |
+|---------|:--:|:-----:|-------------|
+| `/run <command>` | Y | - | Execute aidevops CLI command (requires approval) |
+
+### Group Management
+
+| Command | DM | Group | Description |
+|---------|:--:|:-----:|-------------|
+| `/invite @user` | - | Y | Invite user to group |
+| `/role @user <role>` | - | Y | Set member role |
+| `/broadcast <msg>` | Y | - | Send to all contacts |
+
+### Voice & File
+
+| Command | DM | Group | Description |
+|---------|:--:|:-----:|-------------|
+| `/voice` | Y | Y | Process voice note attachment |
+| `/file` | Y | Y | Process file attachment |
+| `/sessions` | Y | - | Show active bot sessions |
 
 ## Architecture
 
@@ -56,14 +110,41 @@ SIMPLEX_PORT=5226 bun run start
 SimpleX CLI (WebSocket :5225)
     |
 SimplexAdapter (src/index.ts)
+    |--- ContactHandler (handlers/contact.ts)
+    |--- MessageHandler (handlers/message.ts)
+    |--- GroupHandler (handlers/group.ts)
+    |--- FileHandler (handlers/file.ts)
     |
 CommandRouter -> CommandHandlers (src/commands.ts)
     |
-aidevops CLI / AI model routing
+SessionStore (src/session.ts) — SQLite WAL
+    |
+Config (src/config.ts) — env > file > defaults
+    |
+Runner (src/runner.ts) — aidevops CLI bridge
 ```
 
 The bot is designed as a channel-agnostic gateway. SimpleX is the first adapter.
 Future adapters (Matrix, etc.) can plug into the same command router.
+
+### Event Handling
+
+| Event | Handler | Description |
+|-------|---------|-------------|
+| `newChatItems` | message.ts | Incoming messages, command routing |
+| `contactConnected` | contact.ts | New contact via address |
+| `receivedContactRequest` | contact.ts | Contact request (auto-accept off) |
+| `acceptingBusinessRequest` | contact.ts | Business address connection |
+| `receivedGroupInvitation` | group.ts | Bot invited to group |
+| `joinedGroupMember` | group.ts | Member joined group |
+| `deletedMemberUser` | group.ts | Bot removed from group |
+| `rcvFileDescrReady` | file.ts | Incoming file ready |
+| `rcvFileComplete` | file.ts | File download complete |
+
+### Business Address Mode
+
+When `businessAddress: true`, each connecting customer gets a dedicated group chat.
+This enables support-team patterns where multiple agents can join the customer's group.
 
 ## Adding Custom Commands
 
@@ -89,3 +170,5 @@ bot.registerCommand(myCommand);
 - `.agents/services/communications/simplex.md` — SimpleX subagent documentation
 - `.agents/scripts/simplex-helper.sh` — CLI helper script
 - `.agents/tools/security/opsec.md` — Operational security guidance
+- `todo/tasks/t1327-brief.md` — Task brief with full architecture decisions
+- `todo/tasks/t1327.1-research.md` — Research report with API details

--- a/.agents/scripts/simplex-bot/src/commands.ts
+++ b/.agents/scripts/simplex-bot/src/commands.ts
@@ -351,20 +351,153 @@ const versionCommand: CommandDefinition = {
 };
 
 // =============================================================================
+// Group Commands
+// =============================================================================
+
+/** Invite a user to a group (group only) */
+const inviteCommand: CommandDefinition = {
+  name: "invite",
+  description: "Invite a user to this group",
+  groupEnabled: true,
+  dmEnabled: false,
+  handler: async (ctx: CommandContext): Promise<string> => {
+    const user = ctx.args[0];
+    if (!user) {
+      return "Usage: /invite @username";
+    }
+    // Scaffold — in production this calls /_add_member
+    return (
+      "Invite request for " + user + " noted.\n\n" +
+      "(Group member management not yet connected. This is a scaffold.)"
+    );
+  },
+};
+
+/** Set a member's role in a group (group only) */
+const roleCommand: CommandDefinition = {
+  name: "role",
+  description: "Set member role (observer/member/admin)",
+  groupEnabled: true,
+  dmEnabled: false,
+  handler: async (ctx: CommandContext): Promise<string> => {
+    const user = ctx.args[0];
+    const role = ctx.args[1];
+    if (!user || !role) {
+      return "Usage: /role @username [observer|member|admin]";
+    }
+    const validRoles = ["observer", "author", "member", "moderator", "admin"];
+    if (!validRoles.includes(role.toLowerCase())) {
+      return "Valid roles: " + validRoles.join(", ");
+    }
+    return (
+      "Role change: " + user + " → " + role + "\n\n" +
+      "(Role management not yet connected. This is a scaffold.)"
+    );
+  },
+};
+
+/** Broadcast a message to all contacts (DM only) */
+const broadcastCommand: CommandDefinition = {
+  name: "broadcast",
+  description: "Send message to all connected contacts",
+  groupEnabled: false,
+  dmEnabled: true,
+  handler: async (ctx: CommandContext): Promise<string> => {
+    const message = ctx.args.join(" ");
+    if (!message) {
+      return "Usage: /broadcast [message]";
+    }
+    return (
+      "Broadcast queued: \"" + message + "\"\n\n" +
+      "(Broadcast delivery not yet connected. This is a scaffold.)"
+    );
+  },
+};
+
+// =============================================================================
+// Voice & File Commands
+// =============================================================================
+
+/** Process a voice note attachment */
+const voiceCommand: CommandDefinition = {
+  name: "voice",
+  description: "Process voice note (attach voice message before this command)",
+  groupEnabled: true,
+  dmEnabled: true,
+  handler: async (_ctx: CommandContext): Promise<string> => {
+    return [
+      "Voice processing:",
+      "1. Send a voice note in this chat",
+      "2. The bot will receive it as a file attachment",
+      "3. Once speech-to-speech agent is connected, it will be transcribed and processed",
+      "",
+      "(Voice transcription not yet connected. This is a scaffold.)",
+    ].join("\n");
+  },
+};
+
+/** Process a file attachment */
+const fileCommand: CommandDefinition = {
+  name: "file",
+  description: "Process file attachment (send file before this command)",
+  groupEnabled: true,
+  dmEnabled: true,
+  handler: async (_ctx: CommandContext): Promise<string> => {
+    return [
+      "File processing:",
+      "1. Send a file in this chat",
+      "2. The bot will auto-accept files within size limits",
+      "3. Supported: documents, images, code files",
+      "",
+      "(File analysis not yet connected. This is a scaffold.)",
+    ].join("\n");
+  },
+};
+
+/** Show active sessions and stats */
+const sessionsCommand: CommandDefinition = {
+  name: "sessions",
+  description: "Show active bot sessions",
+  groupEnabled: false,
+  dmEnabled: true,
+  handler: async (_ctx: CommandContext): Promise<string> => {
+    // Scaffold — in production this queries the SessionStore
+    return [
+      "Session management:",
+      "Active sessions and statistics will be shown here.",
+      "",
+      "(Session store query not yet connected. This is a scaffold.)",
+    ].join("\n");
+  },
+};
+
+// =============================================================================
 // Command Registry
 // =============================================================================
 
 /** All built-in commands */
 export const BUILTIN_COMMANDS: CommandDefinition[] = [
+  // Core commands
   helpCommand,
   statusCommand,
   askCommand,
+  pingCommand,
+  versionCommand,
+  // Task commands
   tasksCommand,
   taskCommand,
+  // Execution
   runCommand,
   approveCommand,
   rejectCommand,
   pendingCommand,
-  pingCommand,
-  versionCommand,
+  // Group commands
+  inviteCommand,
+  roleCommand,
+  broadcastCommand,
+  // Voice & file
+  voiceCommand,
+  fileCommand,
+  // Session management
+  sessionsCommand,
 ];

--- a/.agents/scripts/simplex-bot/src/config-validation.ts
+++ b/.agents/scripts/simplex-bot/src/config-validation.ts
@@ -1,0 +1,88 @@
+/**
+ * SimpleX Bot — Configuration Validation
+ *
+ * Validates and sanitizes parsed config values.
+ * Extracted from config.ts to keep per-file complexity low.
+ */
+
+import { DEFAULT_BOT_CONFIG } from "./types";
+
+/** Fields allowed in the config file (for validation) */
+export const VALID_CONFIG_KEYS: ReadonlySet<string> = new Set([
+  "port",
+  "host",
+  "displayName",
+  "autoAcceptContacts",
+  "welcomeMessage",
+  "logLevel",
+  "reconnectInterval",
+  "maxReconnectAttempts",
+  "useTls",
+  "businessAddress",
+  "autoAcceptFiles",
+  "maxFileSize",
+  "autoJoinGroups",
+  "allowedContacts",
+  "groupPermissions",
+  "sessionIdleTimeout",
+  "maxPromptLength",
+  "responseTimeout",
+  "dataDir",
+  "leakDetection",
+]);
+
+/** Valid log levels */
+export const VALID_LOG_LEVELS = new Set(["debug", "info", "warn", "error"]);
+
+/** Check whether a numeric config field is valid (non-negative number) */
+export function isValidPositiveNumber(value: unknown, min = 0): boolean {
+  return typeof value === "number" && value >= min;
+}
+
+/** Remove a config key with a warning if it fails validation */
+export function removeInvalid(parsed: Record<string, unknown>, key: string, reason: string): void {
+  console.warn(`[config] Invalid ${key} "${String(parsed[key])}" — ${reason}`);
+  delete parsed[key];
+}
+
+/** Validate port: must be 1-65535 */
+export function validatePort(parsed: Record<string, unknown>): void {
+  if (parsed.port === undefined) return;
+  if (!isValidPositiveNumber(parsed.port, 1) || (parsed.port as number) > 65535) {
+    removeInvalid(parsed, "port", `using default ${DEFAULT_BOT_CONFIG.port}`);
+  }
+}
+
+/** Validate log level: must be one of the known levels */
+export function validateLogLevel(parsed: Record<string, unknown>): void {
+  if (!parsed.logLevel) return;
+  if (!VALID_LOG_LEVELS.has(String(parsed.logLevel))) {
+    removeInvalid(parsed, "logLevel", `using default "${DEFAULT_BOT_CONFIG.logLevel}"`);
+  }
+}
+
+/** Validate numeric fields that must be non-negative */
+export function validateNumericFields(parsed: Record<string, unknown>): void {
+  const fields = ["reconnectInterval", "maxReconnectAttempts"] as const;
+  for (const field of fields) {
+    if (parsed[field] !== undefined && !isValidPositiveNumber(parsed[field])) {
+      removeInvalid(parsed, field, "using default");
+    }
+  }
+}
+
+/** Warn about unknown keys in the parsed config */
+export function warnUnknownKeys(parsed: Record<string, unknown>, configPath: string): void {
+  for (const key of Object.keys(parsed)) {
+    if (!VALID_CONFIG_KEYS.has(key)) {
+      console.warn(`[config] Unknown key "${key}" in ${configPath} — ignored`);
+    }
+  }
+}
+
+/** Validate and sanitize parsed config values, removing invalid entries */
+export function validateParsedConfig(parsed: Record<string, unknown>): void {
+  validateLogLevel(parsed);
+  validatePort(parsed);
+  validateNumericFields(parsed);
+}

--- a/.agents/scripts/simplex-bot/src/config.ts
+++ b/.agents/scripts/simplex-bot/src/config.ts
@@ -1,0 +1,206 @@
+/**
+ * SimpleX Bot — Configuration Loader
+ *
+ * Loads bot configuration from ~/.config/aidevops/simplex-bot.json
+ * with environment variable overrides and validation.
+ *
+ * Priority: env vars > config file > defaults
+ *
+ * Reference: t1327.4 bot framework specification
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import type { BotConfig } from "./types";
+import { DEFAULT_BOT_CONFIG } from "./types";
+
+/** Path to the config file */
+const CONFIG_PATH = resolve(
+  homedir(),
+  ".config/aidevops/simplex-bot.json",
+);
+
+/** Fields allowed in the config file (for validation) */
+const VALID_CONFIG_KEYS: ReadonlySet<string> = new Set([
+  "port",
+  "host",
+  "displayName",
+  "autoAcceptContacts",
+  "welcomeMessage",
+  "logLevel",
+  "reconnectInterval",
+  "maxReconnectAttempts",
+  "useTls",
+  "businessAddress",
+  "autoAcceptFiles",
+  "maxFileSize",
+  "autoJoinGroups",
+  "allowedContacts",
+  "groupPermissions",
+  "sessionIdleTimeout",
+  "maxPromptLength",
+  "responseTimeout",
+  "dataDir",
+  "leakDetection",
+]);
+
+/** Valid log levels */
+const VALID_LOG_LEVELS = new Set(["debug", "info", "warn", "error"]);
+
+/** Check whether a numeric config field is valid (non-negative number) */
+export function isValidPositiveNumber(value: unknown, min = 0): boolean {
+  return typeof value === "number" && value >= min;
+}
+
+/** Warn about unknown keys in the parsed config */
+export function warnUnknownKeys(parsed: Record<string, unknown>): void {
+  for (const key of Object.keys(parsed)) {
+    if (!VALID_CONFIG_KEYS.has(key)) {
+      console.warn(`[config] Unknown key "${key}" in ${CONFIG_PATH} — ignored`);
+    }
+  }
+}
+
+/** Remove a config key with a warning if it fails validation */
+export function removeInvalid(parsed: Record<string, unknown>, key: string, reason: string): void {
+  console.warn(`[config] Invalid ${key} "${String(parsed[key])}" — ${reason}`);
+  delete parsed[key];
+}
+
+/** Validate port: must be 1-65535 */
+export function validatePort(parsed: Record<string, unknown>): void {
+  if (parsed.port === undefined) return;
+  if (!isValidPositiveNumber(parsed.port, 1) || (parsed.port as number) > 65535) {
+    removeInvalid(parsed, "port", `using default ${DEFAULT_BOT_CONFIG.port}`);
+  }
+}
+
+/** Validate log level: must be one of the known levels */
+export function validateLogLevel(parsed: Record<string, unknown>): void {
+  if (!parsed.logLevel) return;
+  if (!VALID_LOG_LEVELS.has(String(parsed.logLevel))) {
+    removeInvalid(parsed, "logLevel", `using default "${DEFAULT_BOT_CONFIG.logLevel}"`);
+  }
+}
+
+/** Validate numeric fields that must be non-negative */
+export function validateNumericFields(parsed: Record<string, unknown>): void {
+  const fields = ["reconnectInterval", "maxReconnectAttempts"] as const;
+  for (const field of fields) {
+    if (parsed[field] !== undefined && !isValidPositiveNumber(parsed[field])) {
+      removeInvalid(parsed, field, "using default");
+    }
+  }
+}
+
+/** Validate and sanitize parsed config values, removing invalid entries */
+export function validateParsedConfig(parsed: Record<string, unknown>): void {
+  validateLogLevel(parsed);
+  validatePort(parsed);
+  validateNumericFields(parsed);
+}
+
+/**
+ * Load config from JSON file if it exists.
+ * Returns partial config (only fields present in the file).
+ */
+export function loadConfigFile(): Partial<BotConfig> {
+  if (!existsSync(CONFIG_PATH)) {
+    return {};
+  }
+
+  try {
+    const text = readFileSync(CONFIG_PATH, "utf-8");
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+
+    warnUnknownKeys(parsed);
+    validateParsedConfig(parsed);
+
+    return parsed as Partial<BotConfig>;
+  } catch (err) {
+    console.error(`[config] Failed to load ${CONFIG_PATH}:`, err);
+    return {};
+  }
+}
+
+/** Env var → config key mapping for simple string assignments */
+const STRING_ENV_MAP: ReadonlyArray<[string, keyof BotConfig]> = [
+  ["SIMPLEX_HOST", "host"],
+  ["SIMPLEX_BOT_NAME", "displayName"],
+];
+
+/** Env var → config key mapping for boolean assignments */
+const BOOLEAN_ENV_MAP: ReadonlyArray<[string, keyof BotConfig]> = [
+  ["SIMPLEX_AUTO_ACCEPT", "autoAcceptContacts"],
+  ["SIMPLEX_TLS", "useTls"],
+  ["SIMPLEX_BUSINESS_ADDRESS", "businessAddress"],
+];
+
+/** Parse port from env var, returning undefined if invalid */
+export function parseEnvPort(): number | undefined {
+  const raw = process.env.SIMPLEX_PORT;
+  if (!raw) return undefined;
+  const port = Number(raw);
+  return port >= 1 && port <= 65535 ? port : undefined;
+}
+
+/** Parse log level from env var, returning undefined if invalid */
+export function parseEnvLogLevel(): BotConfig["logLevel"] | undefined {
+  const level = process.env.SIMPLEX_LOG_LEVEL;
+  if (!level || !VALID_LOG_LEVELS.has(level)) return undefined;
+  return level as BotConfig["logLevel"];
+}
+
+/**
+ * Parse environment variable overrides.
+ * Env vars take highest priority.
+ */
+export function loadEnvOverrides(): Partial<BotConfig> {
+  const overrides: Partial<BotConfig> = {};
+
+  const port = parseEnvPort();
+  if (port !== undefined) overrides.port = port;
+
+  const logLevel = parseEnvLogLevel();
+  if (logLevel !== undefined) overrides.logLevel = logLevel;
+
+  for (const [envKey, configKey] of STRING_ENV_MAP) {
+    const val = process.env[envKey];
+    if (val) (overrides as Record<string, unknown>)[configKey] = val;
+  }
+
+  for (const [envKey, configKey] of BOOLEAN_ENV_MAP) {
+    const val = process.env[envKey];
+    if (val) (overrides as Record<string, unknown>)[configKey] = val === "true";
+  }
+
+  return overrides;
+}
+
+/**
+ * Load the full bot configuration.
+ * Merges: defaults < config file < env vars
+ */
+export function loadConfig(): BotConfig {
+  const fileConfig = loadConfigFile();
+  const envConfig = loadEnvOverrides();
+
+  const merged: BotConfig = {
+    ...DEFAULT_BOT_CONFIG,
+    ...fileConfig,
+    ...envConfig,
+  };
+
+  return merged;
+}
+
+/** Get the config file path (for diagnostics) */
+export function getConfigPath(): string {
+  return CONFIG_PATH;
+}
+
+/** Check whether a config file exists */
+export function configFileExists(): boolean {
+  return existsSync(CONFIG_PATH);
+}

--- a/.agents/scripts/simplex-bot/src/config.ts
+++ b/.agents/scripts/simplex-bot/src/config.ts
@@ -14,6 +14,7 @@ import { resolve } from "node:path";
 import { homedir } from "node:os";
 import type { BotConfig } from "./types";
 import { DEFAULT_BOT_CONFIG } from "./types";
+import { VALID_LOG_LEVELS, warnUnknownKeys, validateParsedConfig } from "./config-validation";
 
 /** Path to the config file */
 const CONFIG_PATH = resolve(
@@ -21,85 +22,16 @@ const CONFIG_PATH = resolve(
   ".config/aidevops/simplex-bot.json",
 );
 
-/** Fields allowed in the config file (for validation) */
-const VALID_CONFIG_KEYS: ReadonlySet<string> = new Set([
-  "port",
-  "host",
-  "displayName",
-  "autoAcceptContacts",
-  "welcomeMessage",
-  "logLevel",
-  "reconnectInterval",
-  "maxReconnectAttempts",
-  "useTls",
-  "businessAddress",
-  "autoAcceptFiles",
-  "maxFileSize",
-  "autoJoinGroups",
-  "allowedContacts",
-  "groupPermissions",
-  "sessionIdleTimeout",
-  "maxPromptLength",
-  "responseTimeout",
-  "dataDir",
-  "leakDetection",
-]);
-
-/** Valid log levels */
-const VALID_LOG_LEVELS = new Set(["debug", "info", "warn", "error"]);
-
-/** Check whether a numeric config field is valid (non-negative number) */
-export function isValidPositiveNumber(value: unknown, min = 0): boolean {
-  return typeof value === "number" && value >= min;
-}
-
-/** Warn about unknown keys in the parsed config */
-export function warnUnknownKeys(parsed: Record<string, unknown>): void {
-  for (const key of Object.keys(parsed)) {
-    if (!VALID_CONFIG_KEYS.has(key)) {
-      console.warn(`[config] Unknown key "${key}" in ${CONFIG_PATH} — ignored`);
-    }
-  }
-}
-
-/** Remove a config key with a warning if it fails validation */
-export function removeInvalid(parsed: Record<string, unknown>, key: string, reason: string): void {
-  console.warn(`[config] Invalid ${key} "${String(parsed[key])}" — ${reason}`);
-  delete parsed[key];
-}
-
-/** Validate port: must be 1-65535 */
-export function validatePort(parsed: Record<string, unknown>): void {
-  if (parsed.port === undefined) return;
-  if (!isValidPositiveNumber(parsed.port, 1) || (parsed.port as number) > 65535) {
-    removeInvalid(parsed, "port", `using default ${DEFAULT_BOT_CONFIG.port}`);
-  }
-}
-
-/** Validate log level: must be one of the known levels */
-export function validateLogLevel(parsed: Record<string, unknown>): void {
-  if (!parsed.logLevel) return;
-  if (!VALID_LOG_LEVELS.has(String(parsed.logLevel))) {
-    removeInvalid(parsed, "logLevel", `using default "${DEFAULT_BOT_CONFIG.logLevel}"`);
-  }
-}
-
-/** Validate numeric fields that must be non-negative */
-export function validateNumericFields(parsed: Record<string, unknown>): void {
-  const fields = ["reconnectInterval", "maxReconnectAttempts"] as const;
-  for (const field of fields) {
-    if (parsed[field] !== undefined && !isValidPositiveNumber(parsed[field])) {
-      removeInvalid(parsed, field, "using default");
-    }
-  }
-}
-
-/** Validate and sanitize parsed config values, removing invalid entries */
-export function validateParsedConfig(parsed: Record<string, unknown>): void {
-  validateLogLevel(parsed);
-  validatePort(parsed);
-  validateNumericFields(parsed);
-}
+// Re-export validation utilities for external consumers
+export {
+  isValidPositiveNumber,
+  removeInvalid,
+  validatePort,
+  validateLogLevel,
+  validateNumericFields,
+  warnUnknownKeys,
+  validateParsedConfig,
+} from "./config-validation";
 
 /**
  * Load config from JSON file if it exists.
@@ -114,7 +46,7 @@ export function loadConfigFile(): Partial<BotConfig> {
     const text = readFileSync(CONFIG_PATH, "utf-8");
     const parsed = JSON.parse(text) as Record<string, unknown>;
 
-    warnUnknownKeys(parsed);
+    warnUnknownKeys(parsed, CONFIG_PATH);
     validateParsedConfig(parsed);
 
     return parsed as Partial<BotConfig>;

--- a/.agents/scripts/simplex-bot/src/handlers/command-executor.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/command-executor.ts
@@ -1,0 +1,93 @@
+/**
+ * SimpleX Bot — Command Execution
+ *
+ * Handles command routing, permission checking, context building, and execution.
+ * Extracted from message.ts to keep per-file complexity low.
+ */
+
+import type {
+  ChatItem,
+  CommandContext,
+  CommandDefinition,
+} from "../types";
+import type { MessageHandlerDeps } from "./message";
+
+/** Check whether a command is allowed in the current chat context */
+export function checkCommandPermission(
+  cmdDef: CommandDefinition,
+  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
+): { allowed: boolean; reason?: string } {
+  const isGroup = chatDir.groupId !== undefined;
+  const isDm = chatDir.contactId !== undefined;
+
+  if (isGroup && !cmdDef.groupEnabled) {
+    return {
+      allowed: false,
+      reason: `/${cmdDef.name} is not available in group chats.`,
+    };
+  }
+  if (isDm && !cmdDef.dmEnabled) {
+    return {
+      allowed: false,
+      reason: `/${cmdDef.name} is not available in direct messages.`,
+    };
+  }
+  return { allowed: true };
+}
+
+/** Build a CommandContext for the handler */
+export function buildCommandContext(
+  item: ChatItem,
+  parsed: { command: string; args: string[] },
+  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
+  deps: MessageHandlerDeps,
+): CommandContext {
+  return {
+    command: parsed.command,
+    args: parsed.args,
+    rawText: item.chatItem.content.msgContent.text ?? "",
+    chatItem: item,
+    contact:
+      chatDir.contactId !== undefined
+        ? deps.buildContactInfo(chatDir.contactId)
+        : undefined,
+    group:
+      chatDir.groupId !== undefined
+        ? deps.buildGroupInfo(chatDir.groupId)
+        : undefined,
+    reply: async (replyText: string) => {
+      await deps.replyToItem(item, replyText);
+    },
+  };
+}
+
+/** Execute a command handler with error handling */
+export async function executeCommand(
+  cmdDef: CommandDefinition,
+  ctx: CommandContext,
+  deps: MessageHandlerDeps,
+): Promise<void> {
+  try {
+    deps.logger.info(`Executing command: /${cmdDef.name}`);
+
+    // Track last command in session metadata
+    const sessionId = ctx.contact
+      ? `direct:${ctx.contact.contactId}`
+      : ctx.group
+        ? `group:${ctx.group.groupId}`
+        : null;
+    if (sessionId) {
+      deps.sessions.updateMetadata(sessionId, {
+        lastCommand: `/${cmdDef.name}`,
+      });
+    }
+
+    const result = await cmdDef.handler(ctx);
+    if (result) {
+      await ctx.reply(result);
+    }
+  } catch (err) {
+    deps.logger.error(`Command /${cmdDef.name} failed:`, err);
+    await ctx.reply(`Error executing /${cmdDef.name}: ${String(err)}`);
+  }
+}

--- a/.agents/scripts/simplex-bot/src/handlers/contact.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/contact.ts
@@ -1,0 +1,162 @@
+/**
+ * SimpleX Bot — Contact Event Handlers
+ *
+ * Handles contact lifecycle events:
+ * - contactConnected: new contact connected via address
+ * - receivedContactRequest: incoming contact request (when auto-accept is off)
+ * - acceptingBusinessRequest: new business address connection
+ *
+ * Reference: t1327.1 research, section 4.1 (Essential Events for Bots)
+ */
+
+import type {
+  BotConfig,
+  ContactConnectedEvent,
+  ContactRequestEvent,
+  BusinessRequestEvent,
+  SimplexEvent,
+} from "../types";
+import type { SessionStore } from "../session";
+
+/** Logger interface (matches the Logger class in index.ts) */
+interface Logger {
+  debug(msg: string, ...args: unknown[]): void;
+  info(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  error(msg: string, ...args: unknown[]): void;
+}
+
+/** Callback to send a SimpleX CLI command */
+type SendCommand = (cmd: string) => Promise<void>;
+
+/** Contact handler dependencies */
+export interface ContactHandlerDeps {
+  config: BotConfig;
+  logger: Logger;
+  sessions: SessionStore;
+  sendCommand: SendCommand;
+  /** Cache a contact display name for reply routing */
+  cacheContactName: (contactId: number, displayName: string) => void;
+  /** Cache a group display name for reply routing */
+  cacheGroupName: (groupId: number, displayName: string) => void;
+}
+
+/**
+ * Handle contactConnected event.
+ * Fired when a user connects via the bot's address.
+ * Caches display name, creates session, sends welcome message.
+ */
+export async function handleContactConnected(
+  event: SimplexEvent,
+  deps: ContactHandlerDeps,
+): Promise<void> {
+  const contactEvent = event as ContactConnectedEvent;
+  const contact = contactEvent.contact;
+
+  if (!contact) {
+    deps.logger.warn("contactConnected event missing contact data");
+    return;
+  }
+
+  const name = contact.localDisplayName ?? "unknown";
+  const contactId = contact.contactId;
+
+  deps.logger.info(`New contact connected: ${name} (id: ${contactId})`);
+
+  // Cache display name for reply routing
+  if (contactId !== undefined) {
+    deps.cacheContactName(contactId, name);
+  }
+
+  // Create or update session
+  deps.sessions.getContactSession(contactId, name);
+
+  // Send welcome message if configured
+  if (deps.config.autoAcceptContacts && deps.config.welcomeMessage) {
+    try {
+      await deps.sendCommand(`@${name} ${deps.config.welcomeMessage}`);
+    } catch (err) {
+      deps.logger.error(`Failed to send welcome message to ${name}:`, err);
+    }
+  }
+}
+
+/**
+ * Handle receivedContactRequest event.
+ * Fired when auto-accept is off and a new contact request arrives.
+ * If auto-accept is enabled in config, accepts automatically.
+ */
+export async function handleContactRequest(
+  event: SimplexEvent,
+  deps: ContactHandlerDeps,
+): Promise<void> {
+  const requestEvent = event as ContactRequestEvent;
+  const contactRequest = requestEvent.contactRequest;
+
+  if (!contactRequest) {
+    deps.logger.warn("receivedContactRequest event missing contactRequest data");
+    return;
+  }
+
+  const name = contactRequest.localDisplayName ?? "unknown";
+  const reqId = contactRequest.contactRequestId;
+
+  deps.logger.info(`Contact request from: ${name} (reqId: ${reqId})`);
+
+  if (deps.config.autoAcceptContacts) {
+    deps.logger.info(`Auto-accepting contact request from ${name}`);
+    try {
+      await deps.sendCommand(`/_accept ${reqId}`);
+    } catch (err) {
+      deps.logger.error(`Failed to accept contact request from ${name}:`, err);
+    }
+  } else {
+    deps.logger.info(
+      `Contact request from ${name} pending manual approval (reqId: ${reqId})`,
+    );
+  }
+}
+
+/**
+ * Handle acceptingBusinessRequest event.
+ * Fired when a user connects via a business address.
+ * Creates a group chat per customer (business address pattern).
+ */
+export async function handleBusinessRequest(
+  event: SimplexEvent,
+  deps: ContactHandlerDeps,
+): Promise<void> {
+  const bizEvent = event as BusinessRequestEvent;
+  const groupInfo = bizEvent.groupInfo;
+
+  if (!groupInfo) {
+    deps.logger.warn("acceptingBusinessRequest event missing groupInfo");
+    return;
+  }
+
+  const groupId = groupInfo.groupId;
+  const name = groupInfo.localDisplayName ?? `business-${groupId}`;
+
+  deps.logger.info(
+    `Business request: new customer group created (groupId: ${groupId}, name: ${name})`,
+  );
+
+  // Cache group name for reply routing
+  deps.cacheGroupName(groupId, name);
+
+  // Create session with business metadata
+  const session = deps.sessions.getGroupSession(groupId, name);
+  deps.sessions.updateMetadata(session.id, { businessChat: true });
+
+  // Send welcome message to the business group
+  if (deps.config.welcomeMessage) {
+    try {
+      await deps.sendCommand(`#${name} ${deps.config.welcomeMessage}`);
+    } catch (err) {
+      deps.logger.error(
+        `Failed to send welcome to business group ${name}:`,
+        err,
+      );
+    }
+  }
+}

--- a/.agents/scripts/simplex-bot/src/handlers/file.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/file.ts
@@ -1,0 +1,205 @@
+/**
+ * SimpleX Bot — File & Voice Event Handlers
+ *
+ * Handles file lifecycle events:
+ * - rcvFileDescrReady: incoming file descriptor ready (initiate download)
+ * - rcvFileComplete: file download complete (process file)
+ * - Voice notes: received as file attachments with type "voice"
+ *
+ * Reference: t1327.1 research, section 4.1 (Essential Events for Bots)
+ */
+
+import type {
+  ChatItem,
+  SimplexEvent,
+  FileEvent,
+} from "../types";
+import type { SessionStore } from "../session";
+
+/** Logger interface */
+interface Logger {
+  debug(msg: string, ...args: unknown[]): void;
+  info(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  error(msg: string, ...args: unknown[]): void;
+}
+
+/** Callback to send a SimpleX CLI command */
+type SendCommand = (cmd: string) => Promise<void>;
+
+/** File handler dependencies */
+export interface FileHandlerDeps {
+  logger: Logger;
+  sessions: SessionStore;
+  sendCommand: SendCommand;
+  /** Reply to the chat item that sent the file */
+  replyToItem: (item: ChatItem, text: string) => Promise<void>;
+  /** Maximum file size to auto-accept (bytes, default: 50MB) */
+  maxFileSize?: number;
+  /** Whether to auto-accept incoming files */
+  autoAcceptFiles: boolean;
+}
+
+/** Default max file size: 50MB */
+const DEFAULT_MAX_FILE_SIZE = 50 * 1024 * 1024;
+
+/**
+ * Handle rcvFileDescrReady event.
+ * Fired when an incoming file descriptor is ready.
+ * Auto-accepts the file if configured and within size limits.
+ */
+export async function handleFileReady(
+  event: SimplexEvent,
+  deps: FileHandlerDeps,
+): Promise<void> {
+  const fileEvent = event as FileEvent;
+  const fileId = fileEvent.fileId;
+  const fileName = fileEvent.fileName ?? "unknown";
+  const fileSize = fileEvent.fileSize ?? 0;
+
+  if (fileId === undefined) {
+    deps.logger.warn("rcvFileDescrReady event missing fileId");
+    return;
+  }
+
+  deps.logger.info(
+    `Incoming file: ${fileName} (${formatFileSize(fileSize)}, fileId: ${fileId})`,
+  );
+
+  const maxSize = deps.maxFileSize ?? DEFAULT_MAX_FILE_SIZE;
+
+  if (!deps.autoAcceptFiles) {
+    deps.logger.info(`File auto-accept disabled, ignoring file ${fileName}`);
+    return;
+  }
+
+  if (fileSize > maxSize) {
+    deps.logger.warn(
+      `File ${fileName} exceeds max size (${formatFileSize(fileSize)} > ${formatFileSize(maxSize)}), skipping`,
+    );
+    return;
+  }
+
+  // Accept the file
+  try {
+    await deps.sendCommand(`/freceive ${fileId}`);
+    deps.logger.info(`Accepted file: ${fileName} (fileId: ${fileId})`);
+  } catch (err) {
+    deps.logger.error(`Failed to accept file ${fileName}:`, err);
+  }
+}
+
+/**
+ * Handle rcvFileComplete event.
+ * Fired when a file download is complete.
+ * Determines file type and dispatches to appropriate processor.
+ */
+export async function handleFileComplete(
+  event: SimplexEvent,
+  deps: FileHandlerDeps,
+): Promise<void> {
+  const fileEvent = event as FileEvent;
+  const fileId = fileEvent.fileId;
+  const filePath = fileEvent.filePath;
+  const fileName = fileEvent.fileName ?? "unknown";
+
+  if (fileId === undefined) {
+    deps.logger.warn("rcvFileComplete event missing fileId");
+    return;
+  }
+
+  deps.logger.info(
+    `File download complete: ${fileName} (fileId: ${fileId}, path: ${filePath ?? "unknown"})`,
+  );
+
+  // File processing is a scaffold — in production this would:
+  // 1. Detect file type (voice, image, document, etc.)
+  // 2. Route to appropriate processor
+  // 3. Return results to the sender
+  //
+  // For now, log the completion for manual processing
+  deps.logger.info(
+    `File ready for processing: ${filePath ?? fileName}`,
+  );
+}
+
+/**
+ * Handle non-text message types from chat items.
+ * Called by the message handler when a non-text message is received.
+ * Routes voice notes, images, files to appropriate handlers.
+ */
+export async function handleNonTextMessage(
+  item: ChatItem,
+  msgType: string,
+  deps: FileHandlerDeps,
+): Promise<void> {
+  const content = item?.chatItem?.content?.msgContent;
+
+  switch (msgType) {
+    case "voice": {
+      deps.logger.info("Voice note received");
+      // Voice notes are file attachments — the file events handle download.
+      // After download, the voice file can be transcribed via speech-to-speech agent.
+      // Scaffold: acknowledge receipt
+      await deps.replyToItem(
+        item,
+        "Voice note received. Voice processing is not yet connected. " +
+          "(Requires speech-to-speech agent integration.)",
+      );
+      break;
+    }
+
+    case "image": {
+      deps.logger.info("Image received");
+      await deps.replyToItem(
+        item,
+        "Image received. Image analysis is not yet connected.",
+      );
+      break;
+    }
+
+    case "file": {
+      deps.logger.info(`File attachment received: ${content?.fileName ?? "unknown"}`);
+      // File download is handled by rcvFileDescrReady/rcvFileComplete events
+      await deps.replyToItem(
+        item,
+        `File received: ${content?.fileName ?? "unknown"}. Processing via file events.`,
+      );
+      break;
+    }
+
+    case "video": {
+      deps.logger.info("Video received");
+      await deps.replyToItem(
+        item,
+        "Video received. Video processing is not yet supported.",
+      );
+      break;
+    }
+
+    case "link": {
+      deps.logger.debug("Link preview message — treating as text");
+      // Link messages have text content too, handled by message handler
+      break;
+    }
+
+    default: {
+      deps.logger.debug(`Unhandled message type: ${msgType}`);
+      break;
+    }
+  }
+}
+
+/** Format file size for human-readable display */
+function formatFileSize(bytes: number): string {
+  if (bytes === 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB"];
+  const i = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
+  const size = bytes / Math.pow(1024, i);
+  return `${size.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}

--- a/.agents/scripts/simplex-bot/src/handlers/group.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/group.ts
@@ -1,0 +1,162 @@
+/**
+ * SimpleX Bot — Group Event Handlers
+ *
+ * Handles group lifecycle events:
+ * - receivedGroupInvitation: bot invited to a group
+ * - joinedGroupMember: new member joined a group
+ * - deletedMemberUser: bot removed from a group
+ * - memberConnected: member fully connected to group
+ *
+ * Reference: t1327.1 research, section 4.1 (Essential Events for Bots)
+ */
+
+import type {
+  SimplexEvent,
+  GroupInvitationEvent,
+  GroupMemberEvent,
+} from "../types";
+import type { SessionStore } from "../session";
+
+/** Logger interface */
+interface Logger {
+  debug(msg: string, ...args: unknown[]): void;
+  info(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  error(msg: string, ...args: unknown[]): void;
+}
+
+/** Callback to send a SimpleX CLI command */
+type SendCommand = (cmd: string) => Promise<void>;
+
+/** Group handler dependencies */
+export interface GroupHandlerDeps {
+  logger: Logger;
+  sessions: SessionStore;
+  sendCommand: SendCommand;
+  /** Cache a group display name for reply routing */
+  cacheGroupName: (groupId: number, displayName: string) => void;
+  /** Whether to auto-join group invitations */
+  autoJoinGroups: boolean;
+}
+
+/**
+ * Handle receivedGroupInvitation event.
+ * Fired when the bot is invited to a group.
+ * Auto-joins if configured, otherwise logs for manual approval.
+ */
+export async function handleGroupInvitation(
+  event: SimplexEvent,
+  deps: GroupHandlerDeps,
+): Promise<void> {
+  const inviteEvent = event as GroupInvitationEvent;
+  const groupInfo = inviteEvent.groupInfo;
+
+  if (!groupInfo) {
+    deps.logger.warn("receivedGroupInvitation event missing groupInfo");
+    return;
+  }
+
+  const groupId = groupInfo.groupId;
+  const name = groupInfo.localDisplayName ?? `group-${groupId}`;
+
+  deps.logger.info(`Group invitation received: ${name} (groupId: ${groupId})`);
+
+  // Cache group name
+  deps.cacheGroupName(groupId, name);
+
+  if (deps.autoJoinGroups) {
+    deps.logger.info(`Auto-joining group: ${name}`);
+    try {
+      await deps.sendCommand(`/_join #${groupId}`);
+      // Create session for the group
+      deps.sessions.getGroupSession(groupId, name);
+    } catch (err) {
+      deps.logger.error(`Failed to join group ${name}:`, err);
+    }
+  } else {
+    deps.logger.info(
+      `Group invitation from ${name} pending manual approval (groupId: ${groupId})`,
+    );
+  }
+}
+
+/**
+ * Handle joinedGroupMember event.
+ * Fired when a new member joins a group the bot is in.
+ * Optionally sends a welcome message.
+ */
+export async function handleMemberJoined(
+  event: SimplexEvent,
+  deps: GroupHandlerDeps,
+): Promise<void> {
+  const memberEvent = event as GroupMemberEvent;
+  const groupInfo = memberEvent.groupInfo;
+  const member = memberEvent.member;
+
+  if (!groupInfo || !member) {
+    deps.logger.debug("joinedGroupMember event missing groupInfo or member");
+    return;
+  }
+
+  const groupName = groupInfo.localDisplayName ?? `group-${groupInfo.groupId}`;
+  const memberName = member.localDisplayName ?? "unknown";
+
+  deps.logger.info(
+    `Member joined group ${groupName}: ${memberName}`,
+  );
+
+  // Update session activity
+  deps.sessions.getGroupSession(groupInfo.groupId, groupName);
+}
+
+/**
+ * Handle deletedMemberUser event.
+ * Fired when the bot is removed from a group.
+ * Cleans up the session.
+ */
+export async function handleBotRemovedFromGroup(
+  event: SimplexEvent,
+  deps: GroupHandlerDeps,
+): Promise<void> {
+  const memberEvent = event as GroupMemberEvent;
+  const groupInfo = memberEvent.groupInfo;
+
+  if (!groupInfo) {
+    deps.logger.warn("deletedMemberUser event missing groupInfo");
+    return;
+  }
+
+  const groupId = groupInfo.groupId;
+  const name = groupInfo.localDisplayName ?? `group-${groupId}`;
+
+  deps.logger.info(`Bot removed from group: ${name} (groupId: ${groupId})`);
+
+  // Clean up session
+  deps.sessions.deleteSession(`group:${groupId}`);
+}
+
+/**
+ * Handle memberConnected event.
+ * Fired when a group member's connection is fully established.
+ * Useful for knowing when a member can receive messages.
+ */
+export async function handleMemberConnected(
+  event: SimplexEvent,
+  deps: GroupHandlerDeps,
+): Promise<void> {
+  const memberEvent = event as GroupMemberEvent;
+  const groupInfo = memberEvent.groupInfo;
+  const member = memberEvent.member;
+
+  if (!groupInfo || !member) {
+    deps.logger.debug("memberConnected event missing data");
+    return;
+  }
+
+  const groupName = groupInfo.localDisplayName ?? `group-${groupInfo.groupId}`;
+  const memberName = member.localDisplayName ?? "unknown";
+
+  deps.logger.debug(
+    `Member connected in ${groupName}: ${memberName}`,
+  );
+}

--- a/.agents/scripts/simplex-bot/src/handlers/index.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/index.ts
@@ -1,0 +1,30 @@
+/**
+ * SimpleX Bot — Handler Barrel Export
+ *
+ * Re-exports all event handlers for clean imports.
+ */
+
+export {
+  handleContactConnected,
+  handleContactRequest,
+  handleBusinessRequest,
+} from "./contact";
+export type { ContactHandlerDeps } from "./contact";
+
+export { handleNewChatItems } from "./message";
+export type { MessageHandlerDeps } from "./message";
+
+export {
+  handleGroupInvitation,
+  handleMemberJoined,
+  handleBotRemovedFromGroup,
+  handleMemberConnected,
+} from "./group";
+export type { GroupHandlerDeps } from "./group";
+
+export {
+  handleFileReady,
+  handleFileComplete,
+  handleNonTextMessage,
+} from "./file";
+export type { FileHandlerDeps } from "./file";

--- a/.agents/scripts/simplex-bot/src/handlers/message.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/message.ts
@@ -1,0 +1,269 @@
+/**
+ * SimpleX Bot — Message Event Handler
+ *
+ * Handles newChatItems events (incoming messages).
+ * Extracts text content, routes to command handler or ignores non-commands.
+ *
+ * Reference: t1327.1 research, section 4.2 (Message Event Structure)
+ */
+
+import type {
+  ChatItem,
+  CommandContext,
+  CommandDefinition,
+  ContactInfo,
+  GroupInfo,
+  NewChatItemsEvent,
+} from "../types";
+import type { SessionStore } from "../session";
+
+/** Logger interface */
+interface Logger {
+  debug(msg: string, ...args: unknown[]): void;
+  info(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  error(msg: string, ...args: unknown[]): void;
+}
+
+/** Command router interface */
+interface CommandRouter {
+  parse(text: string): { command: string; args: string[] } | null;
+  get(name: string): CommandDefinition | undefined;
+}
+
+/** Message handler dependencies */
+export interface MessageHandlerDeps {
+  logger: Logger;
+  router: CommandRouter;
+  sessions: SessionStore;
+  /** Send a reply to a chat item */
+  replyToItem: (item: ChatItem, text: string) => Promise<void>;
+  /** Cache a contact display name */
+  cacheContactName: (contactId: number, displayName: string) => void;
+  /** Cache a group display name */
+  cacheGroupName: (groupId: number, displayName: string) => void;
+  /** Build ContactInfo from cached data */
+  buildContactInfo: (contactId: number) => ContactInfo;
+  /** Build GroupInfo from cached data */
+  buildGroupInfo: (groupId: number) => GroupInfo;
+  /** Callback for non-text messages (voice, file, image) */
+  onNonTextMessage?: (item: ChatItem, msgType: string) => Promise<void>;
+}
+
+/**
+ * Handle newChatItems event.
+ * Processes each chat item: extracts text, routes commands, tracks sessions.
+ */
+export async function handleNewChatItems(
+  event: NewChatItemsEvent,
+  deps: MessageHandlerDeps,
+): Promise<void> {
+  for (const item of event.chatItems ?? []) {
+    try {
+      await processItem(item, deps);
+    } catch (err) {
+      deps.logger.error("Error processing chat item:", err);
+    }
+  }
+}
+
+/**
+ * Extract text content from a chat item, handling non-text message routing.
+ * Returns the text string if this is a text message, or null otherwise.
+ */
+export async function extractTextContent(
+  item: ChatItem,
+  deps: MessageHandlerDeps,
+): Promise<string | null> {
+  const content = item?.chatItem?.content;
+  if (content?.type !== "rcvMsgContent") return null;
+
+  const msgContent = content.msgContent;
+  if (!msgContent) return null;
+
+  if (msgContent.type !== "text") {
+    deps.logger.debug(`Non-text message type: ${msgContent.type}`);
+    if (deps.onNonTextMessage) {
+      await deps.onNonTextMessage(item, msgContent.type);
+    }
+    return null;
+  }
+
+  return msgContent.text || null;
+}
+
+/** Route a parsed command to its handler */
+export async function routeCommand(
+  item: ChatItem,
+  text: string,
+  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
+  deps: MessageHandlerDeps,
+): Promise<void> {
+  const parsed = deps.router.parse(text);
+  if (!parsed) {
+    deps.logger.debug("Not a command, ignoring");
+    return;
+  }
+
+  const cmdDef = deps.router.get(parsed.command);
+  if (!cmdDef) {
+    deps.logger.debug(`Unknown command: /${parsed.command}`);
+    await deps.replyToItem(
+      item,
+      `Unknown command: /${parsed.command}. Type /help for available commands.`,
+    );
+    return;
+  }
+
+  const permission = checkCommandPermission(cmdDef, chatDir);
+  if (!permission.allowed) {
+    await deps.replyToItem(item, permission.reason ?? "Command not allowed.");
+    return;
+  }
+
+  const ctx = buildCommandContext(item, parsed, chatDir, deps);
+  await executeCommand(cmdDef, ctx, deps);
+}
+
+/** Process a single chat item */
+export async function processItem(
+  item: ChatItem,
+  deps: MessageHandlerDeps,
+): Promise<void> {
+  const chatDir = item?.chatItem?.chatDir;
+  if (!chatDir) return;
+
+  // Cache display names from incoming messages
+  cacheContactDisplayName(chatDir, deps);
+  cacheGroupDisplayName(chatDir, deps);
+
+  // Track session activity
+  trackSession(chatDir, deps);
+
+  // Extract text content (routes non-text messages internally)
+  const text = await extractTextContent(item, deps);
+  if (!text) return;
+
+  deps.logger.debug(`Received message: ${text.substring(0, 100)}`);
+  await routeCommand(item, text, chatDir, deps);
+}
+
+/** Cache a contact display name if present in the chat direction */
+export function cacheContactDisplayName(
+  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
+  deps: MessageHandlerDeps,
+): void {
+  if (chatDir.contactId === undefined) return;
+  const name = chatDir.contact?.localDisplayName;
+  if (name) deps.cacheContactName(chatDir.contactId, name);
+}
+
+/** Cache a group display name if present in the chat direction */
+export function cacheGroupDisplayName(
+  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
+  deps: MessageHandlerDeps,
+): void {
+  if (chatDir.groupId === undefined) return;
+  const name = chatDir.groupInfo?.localDisplayName;
+  if (name) deps.cacheGroupName(chatDir.groupId, name);
+}
+
+/** Track session activity for the chat */
+export function trackSession(
+  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
+  deps: MessageHandlerDeps,
+): void {
+  if (chatDir.contactId !== undefined) {
+    const session = deps.sessions.getContactSession(
+      chatDir.contactId,
+      chatDir.contact?.localDisplayName,
+    );
+    deps.sessions.recordMessage(session.id);
+  } else if (chatDir.groupId !== undefined) {
+    const session = deps.sessions.getGroupSession(
+      chatDir.groupId,
+      chatDir.groupInfo?.localDisplayName,
+    );
+    deps.sessions.recordMessage(session.id);
+  }
+}
+
+/** Check whether a command is allowed in the current chat context */
+export function checkCommandPermission(
+  cmdDef: CommandDefinition,
+  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
+): { allowed: boolean; reason?: string } {
+  const isGroup = chatDir.groupId !== undefined;
+  const isDm = chatDir.contactId !== undefined;
+
+  if (isGroup && !cmdDef.groupEnabled) {
+    return {
+      allowed: false,
+      reason: `/${cmdDef.name} is not available in group chats.`,
+    };
+  }
+  if (isDm && !cmdDef.dmEnabled) {
+    return {
+      allowed: false,
+      reason: `/${cmdDef.name} is not available in direct messages.`,
+    };
+  }
+  return { allowed: true };
+}
+
+/** Build a CommandContext for the handler */
+export function buildCommandContext(
+  item: ChatItem,
+  parsed: { command: string; args: string[] },
+  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
+  deps: MessageHandlerDeps,
+): CommandContext {
+  return {
+    command: parsed.command,
+    args: parsed.args,
+    rawText: item.chatItem.content.msgContent.text ?? "",
+    chatItem: item,
+    contact:
+      chatDir.contactId !== undefined
+        ? deps.buildContactInfo(chatDir.contactId)
+        : undefined,
+    group:
+      chatDir.groupId !== undefined
+        ? deps.buildGroupInfo(chatDir.groupId)
+        : undefined,
+    reply: async (replyText: string) => {
+      await deps.replyToItem(item, replyText);
+    },
+  };
+}
+
+/** Execute a command handler with error handling */
+export async function executeCommand(
+  cmdDef: CommandDefinition,
+  ctx: CommandContext,
+  deps: MessageHandlerDeps,
+): Promise<void> {
+  try {
+    deps.logger.info(`Executing command: /${cmdDef.name}`);
+
+    // Track last command in session metadata
+    const sessionId = ctx.contact
+      ? `direct:${ctx.contact.contactId}`
+      : ctx.group
+        ? `group:${ctx.group.groupId}`
+        : null;
+    if (sessionId) {
+      deps.sessions.updateMetadata(sessionId, {
+        lastCommand: `/${cmdDef.name}`,
+      });
+    }
+
+    const result = await cmdDef.handler(ctx);
+    if (result) {
+      await ctx.reply(result);
+    }
+  } catch (err) {
+    deps.logger.error(`Command /${cmdDef.name} failed:`, err);
+    await ctx.reply(`Error executing /${cmdDef.name}: ${String(err)}`);
+  }
+}

--- a/.agents/scripts/simplex-bot/src/handlers/message.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/message.ts
@@ -9,13 +9,13 @@
 
 import type {
   ChatItem,
-  CommandContext,
   CommandDefinition,
   ContactInfo,
   GroupInfo,
   NewChatItemsEvent,
 } from "../types";
 import type { SessionStore } from "../session";
+import { checkCommandPermission, buildCommandContext, executeCommand } from "./command-executor";
 
 /** Logger interface */
 interface Logger {
@@ -49,6 +49,9 @@ export interface MessageHandlerDeps {
   /** Callback for non-text messages (voice, file, image) */
   onNonTextMessage?: (item: ChatItem, msgType: string) => Promise<void>;
 }
+
+// Re-export command execution utilities for external consumers
+export { checkCommandPermission, buildCommandContext, executeCommand } from "./command-executor";
 
 /**
  * Handle newChatItems event.
@@ -185,85 +188,5 @@ export function trackSession(
       chatDir.groupInfo?.localDisplayName,
     );
     deps.sessions.recordMessage(session.id);
-  }
-}
-
-/** Check whether a command is allowed in the current chat context */
-export function checkCommandPermission(
-  cmdDef: CommandDefinition,
-  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
-): { allowed: boolean; reason?: string } {
-  const isGroup = chatDir.groupId !== undefined;
-  const isDm = chatDir.contactId !== undefined;
-
-  if (isGroup && !cmdDef.groupEnabled) {
-    return {
-      allowed: false,
-      reason: `/${cmdDef.name} is not available in group chats.`,
-    };
-  }
-  if (isDm && !cmdDef.dmEnabled) {
-    return {
-      allowed: false,
-      reason: `/${cmdDef.name} is not available in direct messages.`,
-    };
-  }
-  return { allowed: true };
-}
-
-/** Build a CommandContext for the handler */
-export function buildCommandContext(
-  item: ChatItem,
-  parsed: { command: string; args: string[] },
-  chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
-  deps: MessageHandlerDeps,
-): CommandContext {
-  return {
-    command: parsed.command,
-    args: parsed.args,
-    rawText: item.chatItem.content.msgContent.text ?? "",
-    chatItem: item,
-    contact:
-      chatDir.contactId !== undefined
-        ? deps.buildContactInfo(chatDir.contactId)
-        : undefined,
-    group:
-      chatDir.groupId !== undefined
-        ? deps.buildGroupInfo(chatDir.groupId)
-        : undefined,
-    reply: async (replyText: string) => {
-      await deps.replyToItem(item, replyText);
-    },
-  };
-}
-
-/** Execute a command handler with error handling */
-export async function executeCommand(
-  cmdDef: CommandDefinition,
-  ctx: CommandContext,
-  deps: MessageHandlerDeps,
-): Promise<void> {
-  try {
-    deps.logger.info(`Executing command: /${cmdDef.name}`);
-
-    // Track last command in session metadata
-    const sessionId = ctx.contact
-      ? `direct:${ctx.contact.contactId}`
-      : ctx.group
-        ? `group:${ctx.group.groupId}`
-        : null;
-    if (sessionId) {
-      deps.sessions.updateMetadata(sessionId, {
-        lastCommand: `/${cmdDef.name}`,
-      });
-    }
-
-    const result = await cmdDef.handler(ctx);
-    if (result) {
-      await ctx.reply(result);
-    }
-  } catch (err) {
-    deps.logger.error(`Command /${cmdDef.name} failed:`, err);
-    await ctx.reply(`Error executing /${cmdDef.name}: ${String(err)}`);
   }
 }

--- a/.agents/scripts/simplex-bot/src/runner.ts
+++ b/.agents/scripts/simplex-bot/src/runner.ts
@@ -1,0 +1,163 @@
+/**
+ * SimpleX Bot — Runner Dispatch Bridge
+ *
+ * Bridges bot commands to the aidevops runner system.
+ * Dispatches tasks to runner-helper.sh for execution,
+ * with output capture and timeout handling.
+ *
+ * Reference: t1327.4 bot framework specification
+ */
+
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+
+/** Runner dispatch result */
+export interface RunnerResult {
+  /** Whether the command succeeded */
+  success: boolean;
+  /** Command output (stdout) */
+  output: string;
+  /** Error output (stderr) */
+  error: string;
+  /** Exit code */
+  exitCode: number;
+  /** Execution time in milliseconds */
+  durationMs: number;
+}
+
+/** Commands that are safe to execute without approval */
+const SAFE_COMMANDS: ReadonlySet<string> = new Set([
+  "aidevops status",
+  "aidevops repos",
+  "aidevops features",
+  "aidevops skills",
+]);
+
+/** Maximum output length to return via chat (characters) */
+const MAX_OUTPUT_LENGTH = 4000;
+
+/** Default command timeout (30 seconds) */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+/**
+ * Check whether a command is in the safe allowlist.
+ * Safe commands can be executed without explicit approval.
+ */
+export function isSafeCommand(command: string): boolean {
+  const normalized = command.trim().toLowerCase();
+  return SAFE_COMMANDS.has(normalized);
+}
+
+/**
+ * Execute an aidevops CLI command via Bun.spawn.
+ * Returns structured result with output, error, and timing.
+ */
+export async function executeCommand(
+  command: string,
+  timeoutMs: number = DEFAULT_TIMEOUT_MS,
+): Promise<RunnerResult> {
+  const startTime = Date.now();
+
+  try {
+    // Split command into parts for spawn
+    const parts = command.trim().split(/\s+/);
+    if (parts.length === 0) {
+      return {
+        success: false,
+        output: "",
+        error: "Empty command",
+        exitCode: 1,
+        durationMs: 0,
+      };
+    }
+
+    const proc = Bun.spawn(parts, {
+      stdout: "pipe",
+      stderr: "pipe",
+      cwd: homedir(),
+      env: {
+        ...process.env,
+        // Ensure aidevops scripts can find their config
+        HOME: homedir(),
+      },
+    });
+
+    // Race between command completion and timeout
+    const timeoutPromise = new Promise<"timeout">((resolve) => {
+      setTimeout(() => resolve("timeout"), timeoutMs);
+    });
+
+    const result = await Promise.race([
+      proc.exited.then(() => "done" as const),
+      timeoutPromise,
+    ]);
+
+    if (result === "timeout") {
+      proc.kill();
+      return {
+        success: false,
+        output: "",
+        error: `Command timed out after ${timeoutMs}ms`,
+        exitCode: 124,
+        durationMs: Date.now() - startTime,
+      };
+    }
+
+    const output = await new Response(proc.stdout).text();
+    const error = await new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+
+    return {
+      success: exitCode === 0,
+      output: truncateOutput(output),
+      error: truncateOutput(error),
+      exitCode,
+      durationMs: Date.now() - startTime,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      output: "",
+      error: String(err),
+      exitCode: 1,
+      durationMs: Date.now() - startTime,
+    };
+  }
+}
+
+/**
+ * Format a runner result for display in chat.
+ * Includes exit code, timing, and truncated output.
+ */
+export function formatResult(result: RunnerResult): string {
+  const lines: string[] = [];
+
+  if (result.success) {
+    lines.push(`Exit: 0 (${result.durationMs}ms)`);
+  } else {
+    lines.push(`Exit: ${result.exitCode} (${result.durationMs}ms)`);
+  }
+
+  if (result.output.trim()) {
+    lines.push("");
+    lines.push(result.output.trim());
+  }
+
+  if (result.error.trim() && !result.success) {
+    lines.push("");
+    lines.push(`Error: ${result.error.trim()}`);
+  }
+
+  return lines.join("\n");
+}
+
+/** Truncate output to fit chat message limits */
+function truncateOutput(text: string): string {
+  if (text.length <= MAX_OUTPUT_LENGTH) {
+    return text;
+  }
+  return (
+    text.substring(0, MAX_OUTPUT_LENGTH) +
+    `\n\n... (truncated, ${text.length - MAX_OUTPUT_LENGTH} chars omitted)`
+  );
+}

--- a/.agents/scripts/simplex-bot/src/session.ts
+++ b/.agents/scripts/simplex-bot/src/session.ts
@@ -1,0 +1,243 @@
+/**
+ * SimpleX Bot — Session Store
+ *
+ * SQLite-backed session store using bun:sqlite for per-contact/group
+ * session isolation. Tracks conversation state, last activity, and
+ * metadata for each chat context.
+ *
+ * Reference: t1327.4 bot framework specification
+ */
+
+import { Database } from "bun:sqlite";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { homedir } from "node:os";
+
+/** Default data directory for bot state */
+const DEFAULT_DATA_DIR = resolve(
+  homedir(),
+  ".aidevops/.agent-workspace/simplex-bot",
+);
+
+/** Session record stored in SQLite */
+export interface Session {
+  /** Unique session ID (format: "contact:<id>" or "group:<id>") */
+  id: string;
+  /** Chat type: "direct" or "group" */
+  chatType: "direct" | "group";
+  /** Contact or group ID from SimpleX */
+  chatId: number;
+  /** Display name of the contact or group */
+  displayName: string;
+  /** ISO timestamp of session creation */
+  createdAt: string;
+  /** ISO timestamp of last activity */
+  lastActivity: string;
+  /** Number of messages processed in this session */
+  messageCount: number;
+  /** JSON-encoded metadata (extensible) */
+  metadata: string;
+}
+
+/** Session metadata (parsed from JSON) */
+export interface SessionMetadata {
+  /** Whether this is a business address chat */
+  businessChat?: boolean;
+  /** Whether the contact has been approved (pairing) */
+  approved?: boolean;
+  /** Custom tags for this session */
+  tags?: string[];
+  /** Last command executed */
+  lastCommand?: string;
+}
+
+/** SQLite-backed session store */
+export class SessionStore {
+  private db: Database;
+
+  /** Create a session store, initializing the database if needed */
+  constructor(dataDir?: string) {
+    const dir = dataDir ?? DEFAULT_DATA_DIR;
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    const dbPath = resolve(dir, "sessions.db");
+    this.db = new Database(dbPath);
+
+    // Enable WAL mode for concurrent reads (matches mail-helper.sh pattern)
+    this.db.exec("PRAGMA journal_mode=WAL");
+    this.db.exec("PRAGMA busy_timeout=5000");
+
+    this.initSchema();
+  }
+
+  /** Create the sessions table if it doesn't exist */
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS sessions (
+        id TEXT PRIMARY KEY,
+        chat_type TEXT NOT NULL,
+        chat_id INTEGER NOT NULL,
+        display_name TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        last_activity TEXT NOT NULL DEFAULT (datetime('now')),
+        message_count INTEGER NOT NULL DEFAULT 0,
+        metadata TEXT NOT NULL DEFAULT '{}'
+      )
+    `);
+
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_sessions_chat_id
+        ON sessions(chat_type, chat_id)
+    `);
+
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_sessions_last_activity
+        ON sessions(last_activity)
+    `);
+  }
+
+  /** Get or create a session for a contact */
+  getContactSession(contactId: number, displayName?: string): Session {
+    return this.getOrCreate("direct", contactId, displayName ?? "");
+  }
+
+  /** Get or create a session for a group */
+  getGroupSession(groupId: number, displayName?: string): Session {
+    return this.getOrCreate("group", groupId, displayName ?? "");
+  }
+
+  /** Get or create a session by chat type and ID */
+  private getOrCreate(
+    chatType: "direct" | "group",
+    chatId: number,
+    displayName: string,
+  ): Session {
+    const id = `${chatType}:${chatId}`;
+
+    const existing = this.db
+      .query<Session, [string]>("SELECT * FROM sessions WHERE id = ?")
+      .get(id);
+
+    if (existing) {
+      // Update last activity
+      this.db
+        .query("UPDATE sessions SET last_activity = datetime('now') WHERE id = ?")
+        .run(id);
+      return existing;
+    }
+
+    // Create new session
+    this.db
+      .query(
+        `INSERT INTO sessions (id, chat_type, chat_id, display_name, created_at, last_activity, message_count, metadata)
+         VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), 0, '{}')`,
+      )
+      .run(id, chatType, chatId, displayName);
+
+    return this.db
+      .query<Session, [string]>("SELECT * FROM sessions WHERE id = ?")
+      .get(id)!;
+  }
+
+  /** Increment the message count for a session */
+  recordMessage(sessionId: string): void {
+    this.db
+      .query(
+        `UPDATE sessions
+         SET message_count = message_count + 1,
+             last_activity = datetime('now')
+         WHERE id = ?`,
+      )
+      .run(sessionId);
+  }
+
+  /** Update session metadata (merges with existing) */
+  updateMetadata(sessionId: string, updates: Partial<SessionMetadata>): void {
+    const existing = this.db
+      .query<{ metadata: string }, [string]>(
+        "SELECT metadata FROM sessions WHERE id = ?",
+      )
+      .get(sessionId);
+
+    if (!existing) {
+      return;
+    }
+
+    let current: SessionMetadata;
+    try {
+      current = JSON.parse(existing.metadata) as SessionMetadata;
+    } catch {
+      current = {};
+    }
+
+    const merged = { ...current, ...updates };
+    this.db
+      .query("UPDATE sessions SET metadata = ? WHERE id = ?")
+      .run(JSON.stringify(merged), sessionId);
+  }
+
+  /** Get session metadata */
+  getMetadata(sessionId: string): SessionMetadata {
+    const row = this.db
+      .query<{ metadata: string }, [string]>(
+        "SELECT metadata FROM sessions WHERE id = ?",
+      )
+      .get(sessionId);
+
+    if (!row) {
+      return {};
+    }
+
+    try {
+      return JSON.parse(row.metadata) as SessionMetadata;
+    } catch {
+      return {};
+    }
+  }
+
+  /** List all active sessions (ordered by last activity) */
+  listSessions(limit = 50): Session[] {
+    return this.db
+      .query<Session, [number]>(
+        "SELECT * FROM sessions ORDER BY last_activity DESC LIMIT ?",
+      )
+      .all(limit);
+  }
+
+  /** Delete sessions idle for more than the given number of seconds */
+  cleanupIdle(idleSeconds: number): number {
+    const result = this.db
+      .query(
+        `DELETE FROM sessions
+         WHERE last_activity < datetime('now', '-' || ? || ' seconds')`,
+      )
+      .run(idleSeconds);
+
+    return result.changes;
+  }
+
+  /** Delete a specific session */
+  deleteSession(sessionId: string): boolean {
+    const result = this.db
+      .query("DELETE FROM sessions WHERE id = ?")
+      .run(sessionId);
+
+    return result.changes > 0;
+  }
+
+  /** Get total session count */
+  count(): number {
+    const row = this.db
+      .query<{ count: number }, []>("SELECT COUNT(*) as count FROM sessions")
+      .get();
+
+    return row?.count ?? 0;
+  }
+
+  /** Close the database connection */
+  close(): void {
+    this.db.close();
+  }
+}

--- a/.agents/scripts/simplex-bot/src/types.ts
+++ b/.agents/scripts/simplex-bot/src/types.ts
@@ -90,6 +90,51 @@ export interface ContactConnectedEvent extends SimplexEvent {
   contact: ContactInfo;
 }
 
+/** Contact request event (when auto-accept is off) */
+export interface ContactRequestEvent extends SimplexEvent {
+  type: "receivedContactRequest";
+  contactRequest: {
+    contactRequestId: number;
+    localDisplayName: string;
+    profile: {
+      displayName: string;
+      fullName?: string;
+    };
+  };
+}
+
+/** Business address request event (per-customer group chat) */
+export interface BusinessRequestEvent extends SimplexEvent {
+  type: "acceptingBusinessRequest";
+  groupInfo: GroupInfo;
+}
+
+/** Group invitation event */
+export interface GroupInvitationEvent extends SimplexEvent {
+  type: "receivedGroupInvitation";
+  groupInfo: GroupInfo;
+}
+
+/** Group member event (join, leave, connect) */
+export interface GroupMemberEvent extends SimplexEvent {
+  type: "joinedGroupMember" | "deletedMemberUser" | "memberConnected";
+  groupInfo: GroupInfo;
+  member: {
+    groupMemberId: number;
+    localDisplayName: string;
+    memberRole: string;
+  };
+}
+
+/** File event (ready, complete) */
+export interface FileEvent extends SimplexEvent {
+  type: "rcvFileDescrReady" | "rcvFileComplete";
+  fileId: number;
+  fileName?: string;
+  fileSize?: number;
+  filePath?: string;
+}
+
 /** Contact info */
 export interface ContactInfo {
   contactId: number;
@@ -308,6 +353,18 @@ export interface BotConfig {
   leakDetection: LeakDetectionConfig;
   /** Exec approval flow configuration */
   execApproval: ExecApprovalConfig;
+  /** Enable business address mode (per-customer group chats) */
+  businessAddress: boolean;
+  /** Auto-accept incoming files */
+  autoAcceptFiles: boolean;
+  /** Maximum file size to auto-accept in bytes (default: 50MB) */
+  maxFileSize: number;
+  /** Auto-join group invitations */
+  autoJoinGroups: boolean;
+  /** Session idle timeout in seconds (default: 300) */
+  sessionIdleTimeout: number;
+  /** Data directory for bot state (default: ~/.aidevops/.agent-workspace/simplex-bot) */
+  dataDir?: string;
 }
 
 /** Default bot configuration */
@@ -323,6 +380,11 @@ export const DEFAULT_BOT_CONFIG: BotConfig = {
   useTls: false,
   leakDetection: DEFAULT_LEAK_DETECTION_CONFIG,
   execApproval: DEFAULT_EXEC_APPROVAL_CONFIG,
+  businessAddress: false,
+  autoAcceptFiles: false,
+  maxFileSize: 50 * 1024 * 1024,
+  autoJoinGroups: false,
+  sessionIdleTimeout: 300,
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- Complete the SimpleX bot framework scaffold with modular event handler architecture, SQLite session store, config file loader, runner dispatch bridge, and expanded command set
- Add business address support (per-customer group chats), voice/file handling, and group management commands
- All TypeScript, zero type errors (`tsc --noEmit` passes clean)

## Changes

### New Files (8)
- `src/config.ts` — Config loader from `~/.config/aidevops/simplex-bot.json` with env var overrides and validation
- `src/session.ts` — SQLite session store via `bun:sqlite` with WAL mode, per-contact/group isolation, metadata tracking
- `src/runner.ts` — Runner dispatch bridge for executing aidevops CLI commands with timeout and output capture
- `src/handlers/contact.ts` — Handlers for `contactConnected`, `receivedContactRequest`, `acceptingBusinessRequest`
- `src/handlers/message.ts` — Handler for `newChatItems` with session tracking and non-text message routing
- `src/handlers/group.ts` — Handlers for `receivedGroupInvitation`, `joinedGroupMember`, `deletedMemberUser`, `memberConnected`
- `src/handlers/file.ts` — Handlers for `rcvFileDescrReady`, `rcvFileComplete`, voice/image/video message types
- `src/handlers/index.ts` — Barrel export for all handlers

### Modified Files (4)
- `src/types.ts` — Added 5 new event types (`ContactRequestEvent`, `BusinessRequestEvent`, `GroupInvitationEvent`, `GroupMemberEvent`, `FileEvent`), added `businessAddress`, `autoAcceptFiles`, `maxFileSize`, `autoJoinGroups`, `sessionIdleTimeout`, `dataDir` to `BotConfig`
- `src/index.ts` — Integrated all handlers via dependency injection, config loader, session store; refactored event dispatch to modular handler architecture
- `src/commands.ts` — Added 6 new commands: `/invite`, `/role`, `/broadcast`, `/voice`, `/file`, `/sessions` (total: 14 commands)
- `README.md` — Updated with full command reference, config file docs, architecture diagram, event handling table

## Verification

- `bun x tsc --noEmit` — zero errors
- All acceptance criteria patterns present: `NewChatItems`, `contactConnected`, `receivedContactRequest`, `acceptingBusinessRequest`, `rcvFileDescrReady`, `rcvFileComplete`, `receivedGroupInvitation`

## Ref

- Task: t1327.4
- Issue: #2249
- Research: `todo/tasks/t1327.1-research.md`
- Brief: `todo/tasks/t1327-brief.md`