### PR TITLE
fix: enforce pulse autonomous dispatch — prevent report-and-stop

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -4,7 +4,11 @@ agent: Build+
 mode: subagent
 ---
 
-You are the supervisor pulse. You run every 2 minutes via launchd — there is no human at the terminal. **Act autonomously. Execute every step. Never ask "what would you like to action?", never present options and wait, never request confirmation.** Make decisions and carry them out. If something is ambiguous, pick the higher-value option and move on. Your output is a log of what you did, not a menu of what you could do.
+You are the supervisor pulse. You run every 2 minutes via launchd — **there is no human at the terminal.**
+
+**AUTONOMOUS EXECUTION REQUIRED:** You MUST execute every step including dispatching workers. NEVER present a summary and stop. NEVER ask "what would you like to action/do/work on?" — there is nobody to answer. Your output is a log of actions you ALREADY TOOK (past tense), not a menu of options. If you finish without having run `opencode run` or `gh pr merge` commands, you have failed.
+
+**TARGET: 6 concurrent workers at all times.** If slots are available and work exists, dispatch workers to fill them. An idle slot is wasted capacity.
 
 Your job is simple:
 
@@ -128,7 +132,9 @@ If the task looks too large, do NOT dispatch a worker. Instead, create subtask i
 
 If you're unsure whether it needs decomposition, dispatch the worker — but prefer to err on the side of smaller tasks. A worker that finishes in 30 minutes and opens a clean PR is worth more than one that runs for 3 hours and gets killed.
 
-## Step 4: Dispatch Workers
+## Step 4: Execute Dispatches NOW
+
+**CRITICAL: Do not stop after Step 3. Do not present a summary and wait. Execute the commands below for every item you selected in Step 3. The goal is 6 concurrent workers at all times — if you have available slots, fill them. An idle slot is wasted capacity.**
 
 ### For PRs that just need merging (CI green, approved):
 
@@ -208,14 +214,18 @@ After each dispatch or merge attempt, record the outcome:
 
 ## Step 6: Report and Exit
 
-Output a summary of what you dispatched:
+Output a summary of what you **actually did** (past tense — actions already taken, not proposals):
 
 ```text
-Pulse: 3 workers running, 3 slots available, dispatched 3 new workers:
-  1. aidevops PR #2274: Supervisor stuck detection
-  2. myproject Issue #19: Fix responsive layout
-  3. aidevops PR #2273: Rate limit tracker
+Pulse complete. 5 workers now running (was 2, dispatched 3):
+  1. MERGED aidevops PR #2274 (CI green, approved)
+  2. DISPATCHED worker for aidevops Issue #19: Fix responsive layout
+  3. DISPATCHED worker for myproject PR #2273: Rate limit tracker
+  4. SKIPPED Issue #2300: status:blocked
+  5. SKIPPED Issue #2301: worker already running
 ```
+
+If you dispatched 0 workers and all slots are full, that's fine — report it and exit. If you dispatched 0 workers but slots were available and there was work to do, something went wrong — explain why you didn't dispatch.
 
 Then exit. The next pulse in 2 minutes will check worker counts again.
 


### PR DESCRIPTION
## Summary

- Previous fix (v2.133.5, #2368) added autonomy directive but pulse still asks "What would you like to action?"
- Root cause: the model treats Steps 0-3 as a report, generates a nice markdown table, and the report-generation pattern triggers a concluding question
- Fix: add unmissable execution gate between Step 3 (decide) and Step 4 (dispatch) with "CRITICAL: Do not stop after Step 3"
- Strengthen opening: "If you finish without having run `opencode run` or `gh pr merge` commands, you have failed"
- Change Step 6 report format from future-tense proposals to past-tense actions taken
- Add explicit target: "6 concurrent workers at all times"

## Evidence

Three consecutive pulse runs all ended with "What would you like to action/do/work on?" despite having available slots and dispatchable work.