### PR TITLE
fix: skip interactive greeting in headless command sessions

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -38,7 +38,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 
 ## aidevops Framework Status
 
-**On conversation start**:
+**On interactive conversation start** (skip this section entirely for headless/command sessions like `/pulse`, `/full-loop`, etc.):
 1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh`
 2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash)
 3. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"


### PR DESCRIPTION
## Summary

- Root cause found for pulse asking "What would you like to work on?" despite autonomy directives in pulse.md
- The global `~/.config/opencode/AGENTS.md` (generated by `generate-opencode-agents.sh`) tells every session to greet with "What would you like to work on?" — including headless `/pulse` sessions
- Fix: add "(skip this section entirely for headless/command sessions like `/pulse`, `/full-loop`, etc.)" qualifier
- This was the missing piece — the previous two fixes (#2368, #2376) strengthened pulse.md but the global AGENTS.md was overriding them

## Evidence

Three pulse runs with the v2.133.6 autonomy directives still ended with "What would you like to work on/action/do?" because the global AGENTS.md greeting instruction was being followed.