### PR TITLE
fix: add timeouts to package manager queries — prevents update hangs (#2286)

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -787,12 +787,12 @@ cmd_update() {
 			fi
 			[[ -z "$installed" ]] && continue
 
-			# Get latest version (npm or brew)
+			# Get latest version (npm or brew) — timeout prevents hangs on slow registries
 			if [[ "$pkg_ref" == brew:* ]]; then
 				local brew_pkg="${pkg_ref#brew:}"
-				latest=$(brew info --json=v2 "$brew_pkg" 2>/dev/null | jq -r '.formulae[0].versions.stable // empty' 2>/dev/null || true)
+				latest=$(timeout 30 brew info --json=v2 "$brew_pkg" 2>/dev/null | jq -r '.formulae[0].versions.stable // empty' 2>/dev/null || true)
 			else
-				latest=$(npm view "$pkg_ref" version 2>/dev/null || true)
+				latest=$(timeout 30 npm view "$pkg_ref" version 2>/dev/null || true)
 			fi
 			[[ -z "$latest" ]] && continue
 


### PR DESCRIPTION
## Summary

Fixes the remaining problems from #2286 (comment: https://github.com/marcusquinn/aidevops/issues/2286#issuecomment-3967419393)

**Problem**: `aidevops update` hangs indefinitely when `npm view`, `brew info`, or `pip index` calls stall (slow registry, network issue, broken package). No timeout = infinite hang.

**Fix**: Wrap all external package manager queries in `timeout`:
- `get_npm_latest()`: `timeout 30 npm view ...`
- `get_brew_latest()`: `timeout 30 brew info ...`
- `get_pip_latest()`: `timeout 30 pip index versions ...`
- Inline checks in `aidevops.sh cmd_update()`: `timeout 30` on both npm and brew queries
- Update commands: `timeout 120` on `bash -c "$update_cmd"` (longer timeout for actual installs)

If a query times out, it returns "unknown" and the tool is skipped rather than hanging the entire update.

Closes #2286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout enforcement to package manager queries and update execution to prevent indefinite hangs during tool version checks and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->