### PR TITLE
t1338.1: Align local tier fallback to haiku and add local to routing table

### DIFF
--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -3,6 +3,7 @@
   "_docs": "See .agents/tools/context/model-routing.md for routing rules, .agents/tools/ai-assistants/fallback-chains.md for integration.",
 
   "tiers": {
+    "local":  { "models": ["local/llama.cpp"], "fallback": "haiku", "cost": 0 },
     "haiku":  { "models": ["anthropic/claude-haiku-4-5"] },
     "flash":  { "models": ["anthropic/claude-haiku-4-5"] },
     "sonnet": { "models": ["anthropic/claude-sonnet-4-6"] },
@@ -14,6 +15,13 @@
   },
 
   "providers": {
+    "local": {
+      "endpoint": "http://localhost:8080/v1/chat/completions",
+      "key_env": null,
+      "probe_path": "/v1/models",
+      "probe_timeout_seconds": 3,
+      "_comment": "llama.cpp or compatible OpenAI-API server. No API key needed. Use local-model-helper.sh status to check."
+    },
     "anthropic": {
       "endpoint": "https://api.anthropic.com/v1/messages",
       "key_env": "ANTHROPIC_API_KEY",


### PR DESCRIPTION
## Summary

- **Fix fallback chain inconsistency**: Local tier previously fell back to `flash`, but AGENTS.md defines the routing chain as `local→haiku→flash→sonnet→pro→opus`. Updated all 6 references in model-routing.md to fall back to `haiku` instead of `flash`.
- **Add local tier to model-routing-table.json**: Added `local` tier entry with `fallback: "haiku"` and `cost: 0`, plus a `local` provider entry for llama.cpp's OpenAI-compatible API (localhost:8080, no API key).
- **Consistent semantics**: Local has no same-tier fallback (no alternative local provider). For privacy/on-device tasks it FAILs closed; for cost-optimisation it skips directly to haiku (cheapest cloud tier in the chain).

## Changes

| File | What changed |
|------|-------------|
| `.agents/tools/context/model-routing.md` | Updated cost spectrum, routing rules fallback, frontmatter note, model-specific subagents table, fallback routing table, and decision flowchart — all `flash` → `haiku` for local tier fallback |
| `.agents/configs/model-routing-table.json` | Added `local` tier and `local` provider entries |

## Verification

- JSON validated (python3 json.load)
- All 6 local-fallback references in model-routing.md confirmed consistent (haiku, not flash)
- No stale `flash` fallback references for local tier remain
- Cost spectrum matches AGENTS.md ordering: `local→haiku→flash→sonnet→pro→opus`

Ref #2320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for local AI model server integration, enabling users to run models locally with automatic fallback to cloud-based services when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->