### PR TITLE
t1330: Verify — fix jq quoting bug in rate-limits command

### DIFF
--- a/.agents/scripts/observability-helper.sh
+++ b/.agents/scripts/observability-helper.sh
@@ -381,7 +381,7 @@ _count_usage_in_window() {
 	fi
 
 	local result
-	result=$(jq -s --arg p "$provider" --arg c "$cutoff" '
+	result=$(jq -sr --arg p "$provider" --arg c "$cutoff" '
 		[.[] | select(.provider == $p and .recorded_at >= $c)] |
 		"\(length)|\(map(.input_tokens + .output_tokens + .cache_read_tokens + .cache_write_tokens) | add // 0)"
 	' "$OBS_METRICS" 2>/dev/null) || result="0|0"


### PR DESCRIPTION
## Summary

- **Verification of t1330** (rate limit tracker for provider utilisation monitoring)
- Found and fixed a bug: `_count_usage_in_window()` used `jq -s` without `-r`, causing JSON-quoted output (`"0|0"` instead of `0|0`) that broke downstream awk percentage calculations
- All other deliverables verified complete: `rate-limits` command, `check_rate_limit_risk()` API, config template, ShellCheck clean

## Verification Evidence

| Check | Result |
|-------|--------|
| `rate-limits` command (table) | PASS |
| `rate-limits --json` | PASS |
| `rate-limits --provider X` | PASS |
| `check_rate_limit_risk()` API | PASS (returns "ok"/0) |
| `rate-limits.json.txt` config | Present, 8 providers |
| ShellCheck | 0 violations |
| Integration with model-availability-helper.sh | Public API exists; caller integration was removed by t1337.5 refactor (separate concern) |

## Change

One-line fix: `jq -s` → `jq -sr` in `_count_usage_in_window()` (line 384).