### PR TITLE
t1338.6: Add huggingface.md reference to AGENTS.md domain index

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -182,7 +182,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Infrastructure | `tools/infrastructure/cloud-gpu.md`, `tools/containers/orbstack.md`, `tools/containers/remote-dispatch.md` |
 | Accessibility | `services/accessibility/accessibility-audit.md` |
 | OpenAPI exploration | `tools/context/openapi-search.md` |
-| Local models | `tools/local-models/local-models.md`, `scripts/local-model-helper.sh` |
+| Local models | `tools/local-models/local-models.md`, `tools/local-models/huggingface.md`, `scripts/local-model-helper.sh` |
 | Model routing | `tools/context/model-routing.md`, `reference/orchestration.md` |
 | Orchestration | `reference/orchestration.md`, `tools/ai-assistants/headless-dispatch.md` |
 | Agent/MCP dev | `tools/build-agent/build-agent.md`, `tools/build-mcp/build-mcp.md`, `tools/mcp-toolkit/mcporter.md` |


### PR DESCRIPTION
## Summary

- Add `tools/local-models/huggingface.md` reference to the Local models domain index entry in AGENTS.md
- Ensures complete documentation of local models support (local-models.md, huggingface.md, and helper script)

## Verification

- [x] AGENTS.md domain index includes complete local-models entry with huggingface.md reference
- [x] subagent-index.toon already has local-models entry with both local-models and huggingface
- [x] model-routing.md already has local tier documented
- [x] All changes are markdown-valid

Ref #2325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Hugging Face local models resource to the domain index documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->