### PR TITLE
chore: wire CodeRabbit daily review to issue creation and dispatch pipeline

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -415,23 +415,46 @@ Focus areas:
 - Performance concerns'
 ```
 
-**Step 2 — Request issue creation (next pulse cycle):**
+**Step 2 — Create issues from findings (next pulse cycle):**
 
-On the next pulse (2 minutes later), check if CodeRabbit has responded. If it has
-posted a review comment but no follow-up requesting issue creation exists yet:
+On the next pulse (2+ minutes later), check if CodeRabbit has responded with a
+review. If it has posted findings but no issues have been created from them yet:
+
+1. Read CodeRabbit's latest review comment on #2386.
+2. Parse each numbered finding (CodeRabbit uses numbered headings like "1)", "2)" etc.).
+3. For each finding, create a GitHub issue:
 
 ```bash
-gh issue comment 2386 --repo <owner/repo> --body '@coderabbitai Yes, please open issues for each finding. Use these conventions:
+gh issue create --repo <owner/repo> \
+  --title "coderabbit: <short description from finding>" \
+  --label "coderabbit-pulse,auto-dispatch" \
+  --body "**Finding #N: <title>**
 
-- **Title format**: `coderabbit: <short description>`
-- **Labels**: `coderabbit-pulse`, `auto-dispatch`
-- **Body**: Include the finding number, evidence, risk, and recommended action
-- **One issue per finding** — keep them atomic so they can be worked independently'
+**Evidence:** <evidence from CodeRabbit's review>
+
+**Risk:** <risk assessment>
+
+**Recommended Action:** <CodeRabbit's recommendation>
+
+---
+**Source:** https://github.com/<owner/repo>/issues/2386"
 ```
 
-CodeRabbit creates the issues. They enter the normal dispatch queue via Step 3
-(they appear as open issues with `auto-dispatch` label). No further action needed
-here — the standard priority pipeline handles the rest.
+4. After creating all issues, post a summary comment on #2386:
+
+```bash
+gh issue comment 2386 --repo <owner/repo> \
+  --body "Created issues #XXXX-#YYYY from CodeRabbit review (YYYY-MM-DD).
+  Issues labelled coderabbit-pulse + auto-dispatch for worker dispatch."
+```
+
+**Why the supervisor creates issues, not CodeRabbit:** CodeRabbit's sandbox does
+not have authenticated `gh` CLI access. It can generate the script but cannot
+execute it. The supervisor has `gh` access and creates the issues directly.
+
+The issues enter the normal dispatch queue via Step 3 (they appear as open issues
+with `auto-dispatch` label). No further action needed — the standard priority
+pipeline handles the rest.
 
 See `tools/code-review/coderabbit.md` "Daily Full Codebase Review" for full details.
 

--- a/.agents/tools/code-review/coderabbit.md
+++ b/.agents/tools/code-review/coderabbit.md
@@ -143,8 +143,8 @@ The supervisor pulse triggers a daily full codebase review via GitHub issue #238
 1. **Trigger**: Supervisor posts a comment on #2386 mentioning `@coderabbitai`
    with a request for a full codebase review and focus areas.
 2. **Review**: CodeRabbit runs its analysis and posts findings as a comment.
-3. **Issue creation**: The supervisor replies asking CodeRabbit to create one
-   GitHub issue per finding, using these conventions:
+3. **Issue creation**: On the next pulse cycle, the supervisor reads CodeRabbit's
+   findings and creates one GitHub issue per finding via `gh issue create`:
    - Title: `coderabbit: <short description>`
    - Labels: `coderabbit-pulse`, `auto-dispatch`
    - Body: finding number, evidence, risk, recommended action
@@ -155,10 +155,15 @@ The supervisor pulse triggers a daily full codebase review via GitHub issue #238
 
 **Do not close issue #2386** — it is the persistent trigger point for daily reviews.
 
+**Why the supervisor creates issues, not CodeRabbit:** CodeRabbit's sandbox does
+not have `gh` CLI access. It can analyse the codebase and post findings, but
+cannot create issues. The supervisor (which has `gh` access) parses the findings
+and creates the issues.
+
 > **Archived (t1336):** `review-pulse-helper.sh`, `coderabbit-pulse-helper.sh`,
 > and `coderabbit-task-creator-helper.sh` have been archived to `scripts/archived/`.
-> The daily review now uses CodeRabbit's native issue creation instead of custom
-> bash scripts for parsing and task creation.
+> The daily review now uses the supervisor to create issues from CodeRabbit's
+> findings, replacing the old bash scripts for parsing and task creation.
 
 ## Troubleshooting
 

--- a/.agents/tools/code-review/coderabbit.md
+++ b/.agents/tools/code-review/coderabbit.md
@@ -133,12 +133,32 @@ CodeRabbit analyzes:
 ## Automated Reviews
 
 CodeRabbit reviews every PR automatically via the GitHub App. No manual trigger
-scripts are needed. The pulse supervisor observes CodeRabbit findings from PR
-comments and can create tasks from them using AI judgment.
+scripts are needed.
+
+### Daily Full Codebase Review (Issue #2386)
+
+The supervisor pulse triggers a daily full codebase review via GitHub issue #2386
+(labelled `coderabbit-pulse`). The flow:
+
+1. **Trigger**: Supervisor posts a comment on #2386 mentioning `@coderabbitai`
+   with a request for a full codebase review and focus areas.
+2. **Review**: CodeRabbit runs its analysis and posts findings as a comment.
+3. **Issue creation**: The supervisor replies asking CodeRabbit to create one
+   GitHub issue per finding, using these conventions:
+   - Title: `coderabbit: <short description>`
+   - Labels: `coderabbit-pulse`, `auto-dispatch`
+   - Body: finding number, evidence, risk, recommended action
+4. **Pickup**: The normal supervisor pulse (Step 3 in `pulse.md`) picks up
+   these issues via `gh issue list` — they appear as open issues with the
+   `auto-dispatch` label and enter the standard priority queue.
+5. **Dispatch**: Workers implement fixes via the normal `/full-loop` pipeline.
+
+**Do not close issue #2386** — it is the persistent trigger point for daily reviews.
 
 > **Archived (t1336):** `review-pulse-helper.sh`, `coderabbit-pulse-helper.sh`,
 > and `coderabbit-task-creator-helper.sh` have been archived to `scripts/archived/`.
-> AI reads CodeRabbit PR comments directly and creates better-scoped tasks with context.
+> The daily review now uses CodeRabbit's native issue creation instead of custom
+> bash scripts for parsing and task creation.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Closes the loop on the daily CodeRabbit codebase review (issue #2386) which was producing findings that sat unprocessed as comments
- The supervisor now asks CodeRabbit to create one GitHub issue per finding (labelled `coderabbit-pulse` + `auto-dispatch`), which the normal pulse dispatch pipeline picks up and assigns to workers
- No new scripts — leverages CodeRabbit's native issue creation and the existing supervisor dispatch queue

## Changes

- **`coderabbit.md`**: Documents the daily review flow (trigger -> review -> issue creation -> dispatch)
- **`pulse.md`**: Adds Step 7b for daily CodeRabbit review with 24h cooldown guard
- **`pulse.md`**: Adds `auto-dispatch` priority guidance to Step 3 tie-breaking rules

## Note

`.github/workflows/review-pulse.yml` also needs updating (currently references archived scripts that don't exist). The updated file is in the worktree but couldn't be pushed due to OAuth `workflow` scope. The workflow update replaces the broken script-based approach with a lightweight issue-comment trigger matching the new flow.

## Flow

```
Daily schedule (3 AM UTC or supervisor pulse)
  -> Comment on #2386: "@coderabbitai full codebase review"
  -> CodeRabbit posts findings
  -> Next pulse: "please open issues for each finding"
  -> CodeRabbit creates issues (coderabbit-pulse + auto-dispatch labels)
  -> Normal supervisor pulse picks them up via gh issue list
  -> Workers dispatched via /full-loop
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new daily CodeRabbit codebase review workflow that automatically triggers once per day to scan the entire codebase.

* **Documentation**
  * Expanded priority logic for automated issue dispatch with enhanced tie-breaking rules.
  * Updated documentation describing the daily review workflow and how findings are processed into actionable issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->