### PR TITLE
chore: add skeptical reviewer priming to code-reviewer template

### DIFF
--- a/.agents/tools/ai-assistants/runners/code-reviewer.md
+++ b/.agents/tools/ai-assistants/runners/code-reviewer.md
@@ -63,6 +63,13 @@ After the table, provide:
 2. **Risk assessment**: Overall risk level (low/medium/high)
 3. **Recommendation**: Approve / Request changes / Block
 
+## Reviewer Mindset
+
+Assume the author's self-assessment is incomplete or optimistic. Do not trust claims
+about what the code does — read the code and verify independently. Authors routinely
+overlook missing edge cases, over-report test coverage, and under-report complexity.
+Your job is to find what they missed, not to confirm what they claim.
+
 ## Rules
 
 - Never approve code with CRITICAL issues


### PR DESCRIPTION
## Summary

- Adds a "Reviewer Mindset" section to the code-reviewer runner template that primes review subagents to be skeptical rather than confirmatory
- Inspired by a technique from obra/superpowers: assume the author's self-assessment is incomplete, verify claims by reading code independently

One section, 7 lines. No functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code review guidelines with enhanced reviewer best practices and procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->