### PR TITLE
t1343: Fix worker PR lookup race condition in issue lifecycle

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -103,10 +103,10 @@ ISSUE_NUM=$(gh issue list --repo "$(gh repo view --json nameWithOwner -q .nameWi
 if [[ -n "$ISSUE_NUM" && "$ISSUE_NUM" != "null" ]]; then
   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
-  # t1343: Check issue state before modifying — if already closed, skip label updates
+  # t1343: Check issue state before modifying — fail closed (only modify if explicitly OPEN)
   ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json state -q .state 2>/dev/null || echo "UNKNOWN")
-  if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
-    echo "[t1343] Issue #$ISSUE_NUM already CLOSED — skipping label update, task may be resolved by another session"
+  if [[ "$ISSUE_STATE" != "OPEN" ]]; then
+    echo "[t1343] Issue #$ISSUE_NUM state is $ISSUE_STATE (not OPEN) — skipping label update"
   else
     gh issue edit "$ISSUE_NUM" --repo "$REPO" --add-label "status:in-progress" 2>/dev/null || true
     for STALE in "status:available" "status:queued" "status:claimed"; do
@@ -426,22 +426,23 @@ After task completion, the loop automatically:
 
 **Issue-state guard before any label/comment modification (t1343 — MANDATORY):**
 
-Before modifying any linked issue (adding labels, posting comments, or changing state), ALWAYS check if the issue is already closed:
+Before modifying any linked issue (adding labels, posting comments, or changing state), ALWAYS check its current state. Use fail-closed semantics — only proceed when state is explicitly `OPEN`:
 
 ```bash
 for ISSUE_NUM in $LINKED_ISSUES; do
   ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json state -q .state 2>/dev/null || echo "UNKNOWN")
-  if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
-    # Issue already resolved — do NOT modify. Another session (supervisor or worker)
-    # already closed it with proper evidence. Skip to avoid overwriting correct state.
-    echo "[t1343] Skipping issue #$ISSUE_NUM — already CLOSED"
+  if [[ "$ISSUE_STATE" != "OPEN" ]]; then
+    # Fail closed: skip on CLOSED, UNKNOWN, empty, or any non-OPEN state.
+    # CLOSED = already resolved by another session. UNKNOWN = gh failure/timeout.
+    # Either way, do NOT modify — modifications on ambiguous state cause noise.
+    echo "[t1343] Skipping issue #$ISSUE_NUM — state is $ISSUE_STATE (not OPEN)"
     continue
   fi
   # ... proceed with label/comment updates only for OPEN issues
 done
 ```
 
-This prevents the race condition where a worker's delayed lifecycle transition overwrites a supervisor's correct closure. If the issue is already closed with a merged PR, any further label changes (`needs-review`, `status:in-review`, etc.) are noise.
+This prevents the race condition where a worker's delayed lifecycle transition overwrites a supervisor's correct closure. If the issue is already closed with a merged PR, any further label changes (`needs-review`, `status:in-review`, etc.) are noise. The fail-closed design also protects against transient `gh` failures — if the state check fails, modifications are skipped rather than allowed.
 
 **PR lookup fallback (t1343):** When checking whether a merged PR exists for the current task (e.g., before deciding to flag an issue as `needs-review`), do NOT rely solely on your session's local state. Use the fallback chain from `planning-detail.md` "PR Lookup Fallback" — check local state first, then `gh pr list --state merged --search "<task_id>"`, then issue timeline cross-references. If ANY source confirms a merged PR, the task has PR evidence.
 
@@ -451,10 +452,10 @@ After creating the PR, update linked issues to `status:in-review`. Extract linke
 
 ```bash
 for ISSUE_NUM in $LINKED_ISSUES; do
-  # t1343: Check issue state before modifying
+  # t1343: Check issue state before modifying — fail closed (only modify if explicitly OPEN)
   ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json state -q .state 2>/dev/null || echo "UNKNOWN")
-  if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
-    echo "[t1343] Skipping issue #$ISSUE_NUM — already CLOSED"
+  if [[ "$ISSUE_STATE" != "OPEN" ]]; then
+    echo "[t1343] Skipping issue #$ISSUE_NUM — state is $ISSUE_STATE (not OPEN)"
     continue
   fi
   gh issue edit "$ISSUE_NUM" --repo "$REPO" --add-label "status:in-review" 2>/dev/null || true

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -80,17 +80,22 @@ Use the `path` field from pulse-repos.json for `--dir` when dispatching workers.
 
 Check for patterns that indicate systemic problems. Use the GitHub data you already fetched — no extra state needed.
 
-**Issue-state guard (t1343 — MANDATORY before any issue modification):** Before adding labels, posting comments, or modifying any issue, ALWAYS check its current state first:
+**Issue-state guard (t1343 — MANDATORY before any issue modification):** Before adding labels, posting comments, or modifying any issue, ALWAYS check its current state first. Use fail-closed semantics — only modify when state is explicitly `OPEN`:
 
 ```bash
 STATE=$(gh issue view <number> --repo <owner/repo> --json state -q .state 2>/dev/null || echo "UNKNOWN")
+if [[ "$STATE" == "OPEN" ]]; then
+  # Proceed with label/comment modifications
+  gh issue edit <number> --repo <owner/repo> --add-label "needs-review" 2>/dev/null || true
+else
+  # Fail closed: CLOSED, UNKNOWN, empty, or any non-OPEN value — skip all modifications
+  echo "[t1343] Issue #<number> state is $STATE (not OPEN) — skipping modification"
+fi
 ```
-
-Use fail-closed semantics — only modify when state is explicitly `OPEN`:
 
 - If `STATE` is `OPEN`: proceed with your intended modification.
 - If `STATE` is `CLOSED`: do NOT add `needs-review`, `status:*`, or any other label. Do NOT post comments suggesting the issue needs action. A closed issue with a merged PR is resolved — modifying it creates noise and confuses the lifecycle.
-- If `STATE` is empty, `UNKNOWN`, or any other value: skip modification, log a warning (`echo "[t1343] Issue #<number> state is $STATE (not OPEN) — skipping modification"`), and move on. Fail closed — never modify on unknown state. Transient `gh` failures or timeouts must not allow accidental writes.
+- If `STATE` is empty, `UNKNOWN`, or any other value: skip modification, log a warning, and move on. Fail closed — never modify on unknown state. Transient `gh` failures or timeouts must not allow accidental writes.
 
 This prevents the race condition where a worker's delayed lifecycle transition overwrites a supervisor's correct closure (observed: Issue #2250 — supervisor closed with merged PR evidence at 19:29, worker added `needs-review` at 19:55 because its DB lacked the PR URL).
 


### PR DESCRIPTION
## Summary

- Adds mandatory issue-state guard (`gh issue view --json state`) before any label/comment modification in supervisor pulse and worker full-loop — prevents workers from overwriting a supervisor's correct closure
- Adds PR lookup fallback chain (local DB → `gh pr list --search` → issue timeline cross-references) so workers don't miss PRs created by other sessions
- Adds terminal state guard at worker Step 0.6 and Step 4 to skip label updates on already-closed issues

## Root Cause

Observed on Issue #2250: supervisor correctly closed the issue at 19:29 with merged PR #2268 evidence, but a worker added `needs-review` at 19:55 and 19:59 with "No merged PR on record". The worker's DB didn't have the PR URL (created by a different session), and it never checked if the issue was already closed.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/commands/pulse.md` | Issue-state guard in Step 2a — check `state` before modifying any issue |
| `.agents/reference/planning-detail.md` | PR lookup fallback chain under Task Completion Rules |
| `.agents/scripts/commands/full-loop.md` | Terminal state guard at Step 0.6 + Step 4 label updates + PR lookup reference |

All changes are guidance-only (markdown docs), per the "Intelligence Over Scripts" principle — no new bash scripts.

Fixes #2419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved PR evidence verification with a multi-source fallback and clearer verification rules.
  * Clarified task completion requirements, including explicit checks that evidence truly reflects merged PRs.
* **Bug Fixes**
  * Added pre-modification guards so label/comment updates only proceed for open issues, preventing race-condition side effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->