### PR TITLE
fix: enforce 0600 permissions on credentials files

### DIFF
--- a/.agents/scripts/credential-helper.sh
+++ b/.agents/scripts/credential-helper.sh
@@ -32,60 +32,60 @@ readonly PROJECT_TENANT_FILE=".aidevops-tenant"
 
 # Validate tenant name (alphanumeric, hyphens, underscores)
 validate_tenant_name() {
-    local name="$1"
-    if [[ ! "$name" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]*$ ]]; then
-        print_error "Invalid tenant name: '$name'. Use alphanumeric, hyphens, underscores."
-        return 1
-    fi
-    return 0
+	local name="$1"
+	if [[ ! "$name" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]*$ ]]; then
+		print_error "Invalid tenant name: '$name'. Use alphanumeric, hyphens, underscores."
+		return 1
+	fi
+	return 0
 }
 
 # Get the active tenant name
 get_active_tenant() {
-    # Priority: 1) Project override, 2) Global active, 3) "default"
-    if [[ -f "$PROJECT_TENANT_FILE" ]]; then
-        local project_tenant
-        project_tenant=$(cat "$PROJECT_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
-        if [[ -n "$project_tenant" ]]; then
-            echo "$project_tenant"
-            return 0
-        fi
-    fi
+	# Priority: 1) Project override, 2) Global active, 3) "default"
+	if [[ -f "$PROJECT_TENANT_FILE" ]]; then
+		local project_tenant
+		project_tenant=$(cat "$PROJECT_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
+		if [[ -n "$project_tenant" ]]; then
+			echo "$project_tenant"
+			return 0
+		fi
+	fi
 
-    if [[ -f "$ACTIVE_TENANT_FILE" ]]; then
-        local active
-        active=$(cat "$ACTIVE_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
-        if [[ -n "$active" ]]; then
-            echo "$active"
-            return 0
-        fi
-    fi
+	if [[ -f "$ACTIVE_TENANT_FILE" ]]; then
+		local active
+		active=$(cat "$ACTIVE_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
+		if [[ -n "$active" ]]; then
+			echo "$active"
+			return 0
+		fi
+	fi
 
-    echo "default"
-    return 0
+	echo "default"
+	return 0
 }
 
 # Get the env file path for a tenant
 get_tenant_env_file() {
-    local tenant="$1"
-    echo "$TENANTS_DIR/$tenant/credentials.sh"
-    return 0
+	local tenant="$1"
+	echo "$TENANTS_DIR/$tenant/credentials.sh"
+	return 0
 }
 
 # Ensure tenant directory exists with proper permissions
 ensure_tenant_dir() {
-    local tenant="$1"
-    local tenant_dir="$TENANTS_DIR/$tenant"
+	local tenant="$1"
+	local tenant_dir="$TENANTS_DIR/$tenant"
 
-    if [[ ! -d "$tenant_dir" ]]; then
-        mkdir -p "$tenant_dir"
-        chmod 700 "$tenant_dir"
-    fi
+	if [[ ! -d "$tenant_dir" ]]; then
+		mkdir -p "$tenant_dir"
+		chmod 700 "$tenant_dir"
+	fi
 
-    local env_file
-    env_file=$(get_tenant_env_file "$tenant")
-    if [[ ! -f "$env_file" ]]; then
-        cat > "$env_file" << 'HEADER'
+	local env_file
+	env_file=$(get_tenant_env_file "$tenant")
+	if [[ ! -f "$env_file" ]]; then
+		cat >"$env_file" <<'HEADER'
 #!/bin/bash
 # ------------------------------------------------------------------------------
 # Multi-Tenant Credential Storage
@@ -94,103 +94,103 @@ ensure_tenant_dir() {
 # ------------------------------------------------------------------------------
 
 HEADER
-        chmod 600 "$env_file"
-    fi
+		chmod 600 "$env_file"
+	fi
 
-    return 0
+	return 0
 }
 
 # Migrate from old mcp-env.sh to credentials.sh (file rename)
 migrate_mcp_env_to_credentials() {
-    # Migrate root-level mcp-env.sh -> credentials.sh
-    if [[ -f "$LEGACY_MCP_ENV_FILE" && ! -L "$LEGACY_MCP_ENV_FILE" ]]; then
-        if [[ ! -f "$CREDENTIALS_FILE" ]]; then
-            mv "$LEGACY_MCP_ENV_FILE" "$CREDENTIALS_FILE"
-            chmod 600 "$CREDENTIALS_FILE"
-            print_info "Renamed mcp-env.sh to credentials.sh"
-        fi
-        # Create backward-compatible symlink
-        if [[ ! -L "$LEGACY_MCP_ENV_FILE" ]]; then
-            ln -sf "credentials.sh" "$LEGACY_MCP_ENV_FILE"
-            print_info "Created symlink mcp-env.sh -> credentials.sh"
-        fi
-    fi
+	# Migrate root-level mcp-env.sh -> credentials.sh
+	if [[ -f "$LEGACY_MCP_ENV_FILE" && ! -L "$LEGACY_MCP_ENV_FILE" ]]; then
+		if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+			mv "$LEGACY_MCP_ENV_FILE" "$CREDENTIALS_FILE"
+			chmod 600 "$CREDENTIALS_FILE"
+			print_info "Renamed mcp-env.sh to credentials.sh"
+		fi
+		# Create backward-compatible symlink
+		if [[ ! -L "$LEGACY_MCP_ENV_FILE" ]]; then
+			ln -sf "credentials.sh" "$LEGACY_MCP_ENV_FILE"
+			print_info "Created symlink mcp-env.sh -> credentials.sh"
+		fi
+	fi
 
-    # Migrate tenant-level mcp-env.sh -> credentials.sh
-    if [[ -d "$TENANTS_DIR" ]]; then
-        for tenant_dir in "$TENANTS_DIR"/*/; do
-            [[ -d "$tenant_dir" ]] || continue
-            local old_file="$tenant_dir/mcp-env.sh"
-            local new_file="$tenant_dir/credentials.sh"
-            if [[ -f "$old_file" && ! -L "$old_file" ]]; then
-                if [[ ! -f "$new_file" ]]; then
-                    mv "$old_file" "$new_file"
-                    chmod 600 "$new_file"
-                fi
-                if [[ ! -L "$old_file" ]]; then
-                    ln -sf "credentials.sh" "$old_file"
-                fi
-            fi
-        done
-    fi
+	# Migrate tenant-level mcp-env.sh -> credentials.sh
+	if [[ -d "$TENANTS_DIR" ]]; then
+		for tenant_dir in "$TENANTS_DIR"/*/; do
+			[[ -d "$tenant_dir" ]] || continue
+			local old_file="$tenant_dir/mcp-env.sh"
+			local new_file="$tenant_dir/credentials.sh"
+			if [[ -f "$old_file" && ! -L "$old_file" ]]; then
+				if [[ ! -f "$new_file" ]]; then
+					mv "$old_file" "$new_file"
+					chmod 600 "$new_file"
+				fi
+				if [[ ! -L "$old_file" ]]; then
+					ln -sf "credentials.sh" "$old_file"
+				fi
+			fi
+		done
+	fi
 
-    return 0
+	return 0
 }
 
 # Migrate legacy credentials.sh to default tenant
 migrate_legacy() {
-    # First handle mcp-env.sh -> credentials.sh rename
-    migrate_mcp_env_to_credentials
+	# First handle mcp-env.sh -> credentials.sh rename
+	migrate_mcp_env_to_credentials
 
-    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
-        return 0
-    fi
+	if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+		return 0
+	fi
 
-    # Check if already migrated (tenants dir exists with default)
-    local default_env
-    default_env=$(get_tenant_env_file "default")
-    if [[ -f "$default_env" ]]; then
-        # Already migrated - check if legacy has keys not in default
-        local legacy_keys
-        legacy_keys=$(grep -c "^export " "$CREDENTIALS_FILE" 2>/dev/null || echo "0")
-        if [[ "$legacy_keys" -eq 0 ]]; then
-            return 0
-        fi
+	# Check if already migrated (tenants dir exists with default)
+	local default_env
+	default_env=$(get_tenant_env_file "default")
+	if [[ -f "$default_env" ]]; then
+		# Already migrated - check if legacy has keys not in default
+		local legacy_keys
+		legacy_keys=$(grep -c "^export " "$CREDENTIALS_FILE" 2>/dev/null || echo "0")
+		if [[ "$legacy_keys" -eq 0 ]]; then
+			return 0
+		fi
 
-        # Merge any missing keys from legacy to default
-        while IFS= read -r line; do
-            if [[ "$line" =~ ^export[[:space:]]+([A-Z_][A-Z0-9_]*)= ]]; then
-                local key_name="${BASH_REMATCH[1]}"
-                if ! grep -q "^export ${key_name}=" "$default_env" 2>/dev/null; then
-                    echo "$line" >> "$default_env"
-                    print_info "Migrated $key_name to default tenant"
-                fi
-            fi
-        done < "$CREDENTIALS_FILE"
-        return 0
-    fi
+		# Merge any missing keys from legacy to default
+		while IFS= read -r line; do
+			if [[ "$line" =~ ^export[[:space:]]+([A-Z_][A-Z0-9_]*)= ]]; then
+				local key_name="${BASH_REMATCH[1]}"
+				if ! grep -q "^export ${key_name}=" "$default_env" 2>/dev/null; then
+					echo "$line" >>"$default_env"
+					print_info "Migrated $key_name to default tenant"
+				fi
+			fi
+		done <"$CREDENTIALS_FILE"
+		return 0
+	fi
 
-    # First migration: copy legacy to default tenant
-    ensure_tenant_dir "default"
-    cp "$CREDENTIALS_FILE" "$default_env"
-    chmod 600 "$default_env"
+	# First migration: copy legacy to default tenant
+	ensure_tenant_dir "default"
+	cp "$CREDENTIALS_FILE" "$default_env"
+	chmod 600 "$default_env"
 
-    # Set default as active
-    echo "default" > "$ACTIVE_TENANT_FILE"
-    chmod 600 "$ACTIVE_TENANT_FILE"
+	# Set default as active
+	echo "default" >"$ACTIVE_TENANT_FILE"
+	chmod 600 "$ACTIVE_TENANT_FILE"
 
-    print_success "Migrated existing credentials to 'default' tenant"
-    return 0
+	print_success "Migrated existing credentials to 'default' tenant"
+	return 0
 }
 
 # Update the credentials.sh to source the active tenant
 update_legacy_sourcing() {
-    local active_tenant="$1"
-    local tenant_env
-    tenant_env=$(get_tenant_env_file "$active_tenant")
+	local active_tenant="$1"
+	local tenant_env
+	tenant_env=$(get_tenant_env_file "$active_tenant")
 
-    # Rewrite credentials file to source the active tenant
-    cat > "$CREDENTIALS_FILE" << EOF
+	# Rewrite credentials file to source the active tenant
+	cat >"$CREDENTIALS_FILE" <<EOF
 #!/bin/bash
 # ------------------------------------------------------------------------------
 # Multi-Tenant Credential Loader
@@ -208,731 +208,736 @@ if [[ -f "$tenant_env" ]]; then
     source "$tenant_env"
 fi
 EOF
-    chmod 600 "$CREDENTIALS_FILE"
+	chmod 600 "$CREDENTIALS_FILE"
 
-    # Ensure backward-compatible symlink exists
-    if [[ ! -L "$LEGACY_MCP_ENV_FILE" ]]; then
-        ln -sf "credentials.sh" "$LEGACY_MCP_ENV_FILE"
-    fi
+	# Ensure backward-compatible symlink exists
+	if [[ ! -L "$LEGACY_MCP_ENV_FILE" ]]; then
+		ln -sf "credentials.sh" "$LEGACY_MCP_ENV_FILE"
+	fi
 
-    return 0
+	return 0
 }
 
 # --- Commands ---
 
 # Create a new tenant
 cmd_create() {
-    local tenant="$1"
+	local tenant="$1"
 
-    if [[ -z "$tenant" ]]; then
-        print_error "Usage: credential-helper.sh create <tenant-name>"
-        return 1
-    fi
+	if [[ -z "$tenant" ]]; then
+		print_error "Usage: credential-helper.sh create <tenant-name>"
+		return 1
+	fi
 
-    validate_tenant_name "$tenant" || return 1
+	validate_tenant_name "$tenant" || return 1
 
-    local tenant_dir="$TENANTS_DIR/$tenant"
-    if [[ -d "$tenant_dir" ]]; then
-        print_warning "Tenant '$tenant' already exists"
-        return 0
-    fi
+	local tenant_dir="$TENANTS_DIR/$tenant"
+	if [[ -d "$tenant_dir" ]]; then
+		print_warning "Tenant '$tenant' already exists"
+		return 0
+	fi
 
-    ensure_tenant_dir "$tenant"
-    print_success "Created tenant: $tenant"
-    print_info "Add keys: credential-helper.sh set <key> <value> --tenant $tenant"
-    return 0
+	ensure_tenant_dir "$tenant"
+	print_success "Created tenant: $tenant"
+	print_info "Add keys: credential-helper.sh set <key> <value> --tenant $tenant"
+	return 0
 }
 
 # Switch active tenant
 cmd_switch() {
-    local tenant="$1"
+	local tenant="$1"
 
-    if [[ -z "$tenant" ]]; then
-        print_error "Usage: credential-helper.sh switch <tenant-name>"
-        return 1
-    fi
+	if [[ -z "$tenant" ]]; then
+		print_error "Usage: credential-helper.sh switch <tenant-name>"
+		return 1
+	fi
 
-    local tenant_env
-    tenant_env=$(get_tenant_env_file "$tenant")
-    if [[ ! -f "$tenant_env" ]]; then
-        print_error "Tenant '$tenant' does not exist. Create it first: credential-helper.sh create $tenant"
-        return 1
-    fi
+	local tenant_env
+	tenant_env=$(get_tenant_env_file "$tenant")
+	if [[ ! -f "$tenant_env" ]]; then
+		print_error "Tenant '$tenant' does not exist. Create it first: credential-helper.sh create $tenant"
+		return 1
+	fi
 
-    echo "$tenant" > "$ACTIVE_TENANT_FILE"
-    chmod 600 "$ACTIVE_TENANT_FILE"
+	echo "$tenant" >"$ACTIVE_TENANT_FILE"
+	chmod 600 "$ACTIVE_TENANT_FILE"
 
-    # Update legacy sourcing
-    update_legacy_sourcing "$tenant"
+	# Update legacy sourcing
+	update_legacy_sourcing "$tenant"
 
-    print_success "Switched to tenant: $tenant"
-    print_info "Run 'source ~/.zshrc' or restart terminal to load new credentials"
-    return 0
+	print_success "Switched to tenant: $tenant"
+	print_info "Run 'source ~/.zshrc' or restart terminal to load new credentials"
+	return 0
 }
 
 # List all tenants
 cmd_list() {
-    migrate_legacy
+	migrate_legacy
 
-    if [[ ! -d "$TENANTS_DIR" ]]; then
-        print_info "No tenants configured. Run: credential-helper.sh create <name>"
-        return 0
-    fi
+	if [[ ! -d "$TENANTS_DIR" ]]; then
+		print_info "No tenants configured. Run: credential-helper.sh create <name>"
+		return 0
+	fi
 
-    local active
-    active=$(get_active_tenant)
+	local active
+	active=$(get_active_tenant)
 
-    print_info "Configured tenants:"
-    echo ""
+	print_info "Configured tenants:"
+	echo ""
 
-    for tenant_dir in "$TENANTS_DIR"/*/; do
-        if [[ ! -d "$tenant_dir" ]]; then
-            continue
-        fi
-        local tenant_name
-        tenant_name=$(basename "$tenant_dir")
-        local env_file="$tenant_dir/credentials.sh"
-        local key_count=0
+	for tenant_dir in "$TENANTS_DIR"/*/; do
+		if [[ ! -d "$tenant_dir" ]]; then
+			continue
+		fi
+		local tenant_name
+		tenant_name=$(basename "$tenant_dir")
+		local env_file="$tenant_dir/credentials.sh"
+		local key_count=0
 
-        if [[ -f "$env_file" ]]; then
-            key_count=$(grep -c "^export " "$env_file" 2>/dev/null || echo "0")
-        fi
+		if [[ -f "$env_file" ]]; then
+			key_count=$(grep -c "^export " "$env_file" 2>/dev/null || echo "0")
+		fi
 
-        local marker=""
-        if [[ "$tenant_name" == "$active" ]]; then
-            marker=" ${GREEN}(active)${NC}"
-        fi
+		local marker=""
+		if [[ "$tenant_name" == "$active" ]]; then
+			marker=" ${GREEN}(active)${NC}"
+		fi
 
-        echo -e "  ${BLUE}$tenant_name${NC}${marker} - $key_count keys"
-    done
+		echo -e "  ${BLUE}$tenant_name${NC}${marker} - $key_count keys"
+	done
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 # Set a key for a tenant
 cmd_set() {
-    local key=""
-    local value=""
-    local tenant=""
+	local key=""
+	local value=""
+	local tenant=""
 
-    # Parse arguments
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --tenant|-t)
-                tenant="$2"
-                shift 2
-                ;;
-            *)
-                if [[ -z "$key" ]]; then
-                    key="$1"
-                elif [[ -z "$value" ]]; then
-                    value="$1"
-                fi
-                shift
-                ;;
-        esac
-    done
+	# Parse arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--tenant | -t)
+			tenant="$2"
+			shift 2
+			;;
+		*)
+			if [[ -z "$key" ]]; then
+				key="$1"
+			elif [[ -z "$value" ]]; then
+				value="$1"
+			fi
+			shift
+			;;
+		esac
+	done
 
-    if [[ -z "$key" || -z "$value" ]]; then
-        print_error "Usage: credential-helper.sh set <KEY_NAME> <value> [--tenant <name>]"
-        return 1
-    fi
+	if [[ -z "$key" || -z "$value" ]]; then
+		print_error "Usage: credential-helper.sh set <KEY_NAME> <value> [--tenant <name>]"
+		return 1
+	fi
 
-    # Default to active tenant
-    if [[ -z "$tenant" ]]; then
-        tenant=$(get_active_tenant)
-    fi
+	# Default to active tenant
+	if [[ -z "$tenant" ]]; then
+		tenant=$(get_active_tenant)
+	fi
 
-    migrate_legacy
-    ensure_tenant_dir "$tenant"
+	migrate_legacy
+	ensure_tenant_dir "$tenant"
 
-    local env_file
-    env_file=$(get_tenant_env_file "$tenant")
+	local env_file
+	env_file=$(get_tenant_env_file "$tenant")
 
-    # Convert service name to env var if needed
-    local env_var
-    if [[ "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
-        env_var="$key"
-    else
-        env_var=$(echo "$key" | tr '[:lower:]-' '[:upper:]_')
-    fi
+	# Convert service name to env var if needed
+	local env_var
+	if [[ "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
+		env_var="$key"
+	else
+		env_var=$(echo "$key" | tr '[:lower:]-' '[:upper:]_')
+	fi
 
-    # Escape value for safe double-quoted storage
-    # Escapes: backslash, double-quote, dollar, backtick
-    # This avoids printf %q which requires eval/bash -c to decode
-    local escaped_value="$value"
-    escaped_value="${escaped_value//\\/\\\\}"
-    escaped_value="${escaped_value//\"/\\\"}"
-    escaped_value="${escaped_value//\$/\\\$}"
-    escaped_value="${escaped_value//\`/\\\`}"
+	# Escape value for safe double-quoted storage
+	# Escapes: backslash, double-quote, dollar, backtick
+	# This avoids printf %q which requires eval/bash -c to decode
+	local escaped_value="$value"
+	escaped_value="${escaped_value//\\/\\\\}"
+	escaped_value="${escaped_value//\"/\\\"}"
+	escaped_value="${escaped_value//\$/\\\$}"
+	escaped_value="${escaped_value//\`/\\\`}"
 
-    # Update or append
-    if grep -q "^export ${env_var}=" "$env_file" 2>/dev/null; then
-        # Rewrite file excluding the old key, then append new value
-        # Avoids sed delimiter injection with arbitrary values
-        local tmp_file="${env_file}.tmp"
-        grep -v "^export ${env_var}=" "$env_file" > "$tmp_file"
-        echo "export ${env_var}=\"${escaped_value}\"" >> "$tmp_file"
-        mv "$tmp_file" "$env_file"
-        chmod 600 "$env_file"
-        print_success "Updated $env_var in tenant '$tenant'"
-    else
-        echo "export ${env_var}=\"${escaped_value}\"" >> "$env_file"
-        chmod 600 "$env_file"
-        print_success "Added $env_var to tenant '$tenant'"
-    fi
+	# Update or append
+	if grep -q "^export ${env_var}=" "$env_file" 2>/dev/null; then
+		# Rewrite file excluding the old key, then append new value
+		# Avoids sed delimiter injection with arbitrary values
+		local tmp_file="${env_file}.tmp"
+		grep -v "^export ${env_var}=" "$env_file" >"$tmp_file"
+		echo "export ${env_var}=\"${escaped_value}\"" >>"$tmp_file"
+		mv "$tmp_file" "$env_file"
+		chmod 600 "$env_file"
+		print_success "Updated $env_var in tenant '$tenant'"
+	else
+		echo "export ${env_var}=\"${escaped_value}\"" >>"$env_file"
+		chmod 600 "$env_file"
+		print_success "Added $env_var to tenant '$tenant'"
+	fi
 
-    return 0
+	return 0
 }
 
 # Get a key from a tenant
 cmd_get() {
-    local key=""
-    local tenant=""
+	local key=""
+	local tenant=""
 
-    # Parse arguments
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --tenant|-t)
-                tenant="$2"
-                shift 2
-                ;;
-            *)
-                if [[ -z "$key" ]]; then
-                    key="$1"
-                fi
-                shift
-                ;;
-        esac
-    done
+	# Parse arguments
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--tenant | -t)
+			tenant="$2"
+			shift 2
+			;;
+		*)
+			if [[ -z "$key" ]]; then
+				key="$1"
+			fi
+			shift
+			;;
+		esac
+	done
 
-    if [[ -z "$key" ]]; then
-        print_error "Usage: credential-helper.sh get <KEY_NAME> [--tenant <name>]"
-        return 1
-    fi
+	if [[ -z "$key" ]]; then
+		print_error "Usage: credential-helper.sh get <KEY_NAME> [--tenant <name>]"
+		return 1
+	fi
 
-    if [[ -z "$tenant" ]]; then
-        tenant=$(get_active_tenant)
-    fi
+	if [[ -z "$tenant" ]]; then
+		tenant=$(get_active_tenant)
+	fi
 
-    local env_file
-    env_file=$(get_tenant_env_file "$tenant")
+	local env_file
+	env_file=$(get_tenant_env_file "$tenant")
 
-    if [[ ! -f "$env_file" ]]; then
-        print_error "Tenant '$tenant' not found"
-        return 1
-    fi
+	if [[ ! -f "$env_file" ]]; then
+		print_error "Tenant '$tenant' not found"
+		return 1
+	fi
 
-    # Convert service name to env var if needed
-    local env_var
-    if [[ "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
-        env_var="$key"
-    else
-        env_var=$(echo "$key" | tr '[:lower:]-' '[:upper:]_')
-    fi
+	# Convert service name to env var if needed
+	local env_var
+	if [[ "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
+		env_var="$key"
+	else
+		env_var=$(echo "$key" | tr '[:lower:]-' '[:upper:]_')
+	fi
 
-    # Extract the value safely without eval/bash -c
-    # Handles: export KEY="value" (current format) and export KEY=value (legacy)
-    local line
-    line=$(grep "^export ${env_var}=" "$env_file" 2>/dev/null || true)
+	# Extract the value safely without eval/bash -c
+	# Handles: export KEY="value" (current format) and export KEY=value (legacy)
+	local line
+	line=$(grep "^export ${env_var}=" "$env_file" 2>/dev/null || true)
 
-    if [[ -n "$line" ]]; then
-        # Strip the "export KEY=" prefix to get the raw value portion
-        local raw_value="${line#export "${env_var}"=}"
+	if [[ -n "$line" ]]; then
+		# Strip the "export KEY=" prefix to get the raw value portion
+		local raw_value="${line#export "${env_var}"=}"
 
-        # Remove surrounding double quotes if present (current format)
-        if [[ "$raw_value" =~ ^\"(.*)\"$ ]]; then
-            raw_value="${BASH_REMATCH[1]}"
-            # Unescape: \\, \", \$, \` back to originals
-            raw_value="${raw_value//\\\\/\\}"
-            raw_value="${raw_value//\\\"/\"}"
-            raw_value="${raw_value//\\\$/\$}"
-            raw_value="${raw_value//\\\`/\`}"
-        elif [[ "$raw_value" =~ ^\'(.*)\'$ ]]; then
-            # Single-quoted values need no unescaping
-            raw_value="${BASH_REMATCH[1]}"
-        fi
-        # Unquoted values (legacy printf %q format) are returned as-is
+		# Remove surrounding double quotes if present (current format)
+		if [[ "$raw_value" =~ ^\"(.*)\"$ ]]; then
+			raw_value="${BASH_REMATCH[1]}"
+			# Unescape: \\, \", \$, \` back to originals
+			raw_value="${raw_value//\\\\/\\}"
+			raw_value="${raw_value//\\\"/\"}"
+			raw_value="${raw_value//\\\$/\$}"
+			raw_value="${raw_value//\\\`/\`}"
+		elif [[ "$raw_value" =~ ^\'(.*)\'$ ]]; then
+			# Single-quoted values need no unescaping
+			raw_value="${BASH_REMATCH[1]}"
+		fi
+		# Unquoted values (legacy printf %q format) are returned as-is
 
-        if [[ -n "$raw_value" ]]; then
-            echo "$raw_value"
-            return 0
-        fi
-    fi
+		if [[ -n "$raw_value" ]]; then
+			echo "$raw_value"
+			return 0
+		fi
+	fi
 
-    print_error "Key $env_var not found in tenant '$tenant'"
-    return 1
+	print_error "Key $env_var not found in tenant '$tenant'"
+	return 1
 }
 
 # Remove a key from a tenant
 cmd_remove() {
-    local key=""
-    local tenant=""
+	local key=""
+	local tenant=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --tenant|-t)
-                tenant="$2"
-                shift 2
-                ;;
-            *)
-                if [[ -z "$key" ]]; then
-                    key="$1"
-                fi
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--tenant | -t)
+			tenant="$2"
+			shift 2
+			;;
+		*)
+			if [[ -z "$key" ]]; then
+				key="$1"
+			fi
+			shift
+			;;
+		esac
+	done
 
-    if [[ -z "$key" ]]; then
-        print_error "Usage: credential-helper.sh remove <KEY_NAME> [--tenant <name>]"
-        return 1
-    fi
+	if [[ -z "$key" ]]; then
+		print_error "Usage: credential-helper.sh remove <KEY_NAME> [--tenant <name>]"
+		return 1
+	fi
 
-    if [[ -z "$tenant" ]]; then
-        tenant=$(get_active_tenant)
-    fi
+	if [[ -z "$tenant" ]]; then
+		tenant=$(get_active_tenant)
+	fi
 
-    local env_file
-    env_file=$(get_tenant_env_file "$tenant")
+	local env_file
+	env_file=$(get_tenant_env_file "$tenant")
 
-    if [[ ! -f "$env_file" ]]; then
-        print_error "Tenant '$tenant' not found"
-        return 1
-    fi
+	if [[ ! -f "$env_file" ]]; then
+		print_error "Tenant '$tenant' not found"
+		return 1
+	fi
 
-    local env_var
-    if [[ "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
-        env_var="$key"
-    else
-        env_var=$(echo "$key" | tr '[:lower:]-' '[:upper:]_')
-    fi
+	local env_var
+	if [[ "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
+		env_var="$key"
+	else
+		env_var=$(echo "$key" | tr '[:lower:]-' '[:upper:]_')
+	fi
 
-    if grep -q "^export ${env_var}=" "$env_file" 2>/dev/null; then
-        local tmp_file="${env_file}.tmp"
-        grep -v "^export ${env_var}=" "$env_file" > "$tmp_file"
-        mv "$tmp_file" "$env_file"
-        chmod 600 "$env_file"
-        print_success "Removed $env_var from tenant '$tenant'"
-    else
-        print_warning "Key $env_var not found in tenant '$tenant'"
-    fi
+	if grep -q "^export ${env_var}=" "$env_file" 2>/dev/null; then
+		local tmp_file="${env_file}.tmp"
+		grep -v "^export ${env_var}=" "$env_file" >"$tmp_file"
+		mv "$tmp_file" "$env_file"
+		chmod 600 "$env_file"
+		print_success "Removed $env_var from tenant '$tenant'"
+	else
+		print_warning "Key $env_var not found in tenant '$tenant'"
+	fi
 
-    return 0
+	return 0
 }
 
 # Delete a tenant entirely
 cmd_delete() {
-    local tenant="$1"
+	local tenant="$1"
 
-    if [[ -z "$tenant" ]]; then
-        print_error "Usage: credential-helper.sh delete <tenant-name>"
-        return 1
-    fi
+	if [[ -z "$tenant" ]]; then
+		print_error "Usage: credential-helper.sh delete <tenant-name>"
+		return 1
+	fi
 
-    if [[ "$tenant" == "default" ]]; then
-        print_error "Cannot delete the 'default' tenant"
-        return 1
-    fi
+	if [[ "$tenant" == "default" ]]; then
+		print_error "Cannot delete the 'default' tenant"
+		return 1
+	fi
 
-    local tenant_dir="$TENANTS_DIR/$tenant"
-    if [[ ! -d "$tenant_dir" ]]; then
-        print_error "Tenant '$tenant' does not exist"
-        return 1
-    fi
+	local tenant_dir="$TENANTS_DIR/$tenant"
+	if [[ ! -d "$tenant_dir" ]]; then
+		print_error "Tenant '$tenant' does not exist"
+		return 1
+	fi
 
-    # Check if this is the active tenant
-    local active
-    active=$(get_active_tenant)
-    if [[ "$active" == "$tenant" ]]; then
-        print_warning "Switching to 'default' tenant first"
-        cmd_switch "default"
-    fi
+	# Check if this is the active tenant
+	local active
+	active=$(get_active_tenant)
+	if [[ "$active" == "$tenant" ]]; then
+		print_warning "Switching to 'default' tenant first"
+		cmd_switch "default"
+	fi
 
-    rm -rf "$tenant_dir"
-    print_success "Deleted tenant: $tenant"
-    return 0
+	rm -rf "$tenant_dir"
+	print_success "Deleted tenant: $tenant"
+	return 0
 }
 
 # Show keys in a tenant (names only, never values)
 cmd_keys() {
-    local tenant=""
+	local tenant=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --tenant|-t)
-                tenant="$2"
-                shift 2
-                ;;
-            *)
-                if [[ -z "$tenant" ]]; then
-                    tenant="$1"
-                fi
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--tenant | -t)
+			tenant="$2"
+			shift 2
+			;;
+		*)
+			if [[ -z "$tenant" ]]; then
+				tenant="$1"
+			fi
+			shift
+			;;
+		esac
+	done
 
-    if [[ -z "$tenant" ]]; then
-        tenant=$(get_active_tenant)
-    fi
+	if [[ -z "$tenant" ]]; then
+		tenant=$(get_active_tenant)
+	fi
 
-    migrate_legacy
+	migrate_legacy
 
-    local env_file
-    env_file=$(get_tenant_env_file "$tenant")
+	local env_file
+	env_file=$(get_tenant_env_file "$tenant")
 
-    if [[ ! -f "$env_file" ]]; then
-        print_error "Tenant '$tenant' not found"
-        return 1
-    fi
+	if [[ ! -f "$env_file" ]]; then
+		print_error "Tenant '$tenant' not found"
+		return 1
+	fi
 
-    print_info "Keys in tenant '$tenant':"
-    echo ""
-    grep "^export " "$env_file" 2>/dev/null | sed 's/=.*//' | sed 's/export /  /' | sort
-    echo ""
-    return 0
+	print_info "Keys in tenant '$tenant':"
+	echo ""
+	grep "^export " "$env_file" 2>/dev/null | sed 's/=.*//' | sed 's/export /  /' | sort
+	echo ""
+	return 0
 }
 
 # Copy keys between tenants
 cmd_copy() {
-    local source_tenant=""
-    local dest_tenant=""
-    local key_filter=""
+	local source_tenant=""
+	local dest_tenant=""
+	local key_filter=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --key|-k)
-                key_filter="$2"
-                shift 2
-                ;;
-            *)
-                if [[ -z "$source_tenant" ]]; then
-                    source_tenant="$1"
-                elif [[ -z "$dest_tenant" ]]; then
-                    dest_tenant="$1"
-                fi
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--key | -k)
+			key_filter="$2"
+			shift 2
+			;;
+		*)
+			if [[ -z "$source_tenant" ]]; then
+				source_tenant="$1"
+			elif [[ -z "$dest_tenant" ]]; then
+				dest_tenant="$1"
+			fi
+			shift
+			;;
+		esac
+	done
 
-    if [[ -z "$source_tenant" || -z "$dest_tenant" ]]; then
-        print_error "Usage: credential-helper.sh copy <source-tenant> <dest-tenant> [--key KEY_NAME]"
-        return 1
-    fi
+	if [[ -z "$source_tenant" || -z "$dest_tenant" ]]; then
+		print_error "Usage: credential-helper.sh copy <source-tenant> <dest-tenant> [--key KEY_NAME]"
+		return 1
+	fi
 
-    local source_env
-    source_env=$(get_tenant_env_file "$source_tenant")
-    if [[ ! -f "$source_env" ]]; then
-        print_error "Source tenant '$source_tenant' not found"
-        return 1
-    fi
+	local source_env
+	source_env=$(get_tenant_env_file "$source_tenant")
+	if [[ ! -f "$source_env" ]]; then
+		print_error "Source tenant '$source_tenant' not found"
+		return 1
+	fi
 
-    ensure_tenant_dir "$dest_tenant"
-    local dest_env
-    dest_env=$(get_tenant_env_file "$dest_tenant")
+	ensure_tenant_dir "$dest_tenant"
+	local dest_env
+	dest_env=$(get_tenant_env_file "$dest_tenant")
 
-    local copied=0
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^export[[:space:]]+([A-Z_][A-Z0-9_]*)= ]]; then
-            local var_name="${BASH_REMATCH[1]}"
+	local copied=0
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^export[[:space:]]+([A-Z_][A-Z0-9_]*)= ]]; then
+			local var_name="${BASH_REMATCH[1]}"
 
-            # Apply key filter if specified
-            if [[ -n "$key_filter" && "$var_name" != "$key_filter" ]]; then
-                continue
-            fi
+			# Apply key filter if specified
+			if [[ -n "$key_filter" && "$var_name" != "$key_filter" ]]; then
+				continue
+			fi
 
-            # Skip if already exists in destination
-            if grep -q "^export ${var_name}=" "$dest_env" 2>/dev/null; then
-                print_warning "Skipping $var_name (already exists in '$dest_tenant')"
-                continue
-            fi
+			# Skip if already exists in destination
+			if grep -q "^export ${var_name}=" "$dest_env" 2>/dev/null; then
+				print_warning "Skipping $var_name (already exists in '$dest_tenant')"
+				continue
+			fi
 
-            echo "$line" >> "$dest_env"
-            ((copied++))
-        fi
-    done < "$source_env"
+			echo "$line" >>"$dest_env"
+			((copied++))
+		fi
+	done <"$source_env"
 
-    print_success "Copied $copied key(s) from '$source_tenant' to '$dest_tenant'"
-    return 0
+	# Enforce secure permissions after copy
+	if [[ "$copied" -gt 0 ]]; then
+		chmod 600 "$dest_env" 2>/dev/null || true
+	fi
+
+	print_success "Copied $copied key(s) from '$source_tenant' to '$dest_tenant'"
+	return 0
 }
 
 # Set project-level tenant override
 cmd_use() {
-    local tenant="$1"
+	local tenant="$1"
 
-    if [[ -z "$tenant" ]]; then
-        # Show current project tenant
-        if [[ -f "$PROJECT_TENANT_FILE" ]]; then
-            local current
-            current=$(cat "$PROJECT_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
-            print_info "Project tenant: $current"
-        else
-            print_info "No project-level tenant set (using global: $(get_active_tenant))"
-        fi
-        return 0
-    fi
+	if [[ -z "$tenant" ]]; then
+		# Show current project tenant
+		if [[ -f "$PROJECT_TENANT_FILE" ]]; then
+			local current
+			current=$(cat "$PROJECT_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
+			print_info "Project tenant: $current"
+		else
+			print_info "No project-level tenant set (using global: $(get_active_tenant))"
+		fi
+		return 0
+	fi
 
-    if [[ "$tenant" == "--clear" || "$tenant" == "--reset" ]]; then
-        if [[ -f "$PROJECT_TENANT_FILE" ]]; then
-            rm -f "$PROJECT_TENANT_FILE"
-            print_success "Cleared project-level tenant override"
-        else
-            print_info "No project-level tenant to clear"
-        fi
-        return 0
-    fi
+	if [[ "$tenant" == "--clear" || "$tenant" == "--reset" ]]; then
+		if [[ -f "$PROJECT_TENANT_FILE" ]]; then
+			rm -f "$PROJECT_TENANT_FILE"
+			print_success "Cleared project-level tenant override"
+		else
+			print_info "No project-level tenant to clear"
+		fi
+		return 0
+	fi
 
-    # Verify tenant exists
-    local tenant_env
-    tenant_env=$(get_tenant_env_file "$tenant")
-    if [[ ! -f "$tenant_env" ]]; then
-        print_error "Tenant '$tenant' does not exist. Create it first."
-        return 1
-    fi
+	# Verify tenant exists
+	local tenant_env
+	tenant_env=$(get_tenant_env_file "$tenant")
+	if [[ ! -f "$tenant_env" ]]; then
+		print_error "Tenant '$tenant' does not exist. Create it first."
+		return 1
+	fi
 
-    echo "$tenant" > "$PROJECT_TENANT_FILE"
-    print_success "Set project tenant to: $tenant"
-    print_info "This overrides the global active tenant for this directory"
+	echo "$tenant" >"$PROJECT_TENANT_FILE"
+	print_success "Set project tenant to: $tenant"
+	print_info "This overrides the global active tenant for this directory"
 
-    # Add to .gitignore if not already there
-    if [[ -f ".gitignore" ]] && ! grep -q "^\.aidevops-tenant$" ".gitignore" 2>/dev/null; then
-        echo ".aidevops-tenant" >> ".gitignore"
-        print_info "Added .aidevops-tenant to .gitignore"
-    fi
+	# Add to .gitignore if not already there
+	if [[ -f ".gitignore" ]] && ! grep -q "^\.aidevops-tenant$" ".gitignore" 2>/dev/null; then
+		echo ".aidevops-tenant" >>".gitignore"
+		print_info "Added .aidevops-tenant to .gitignore"
+	fi
 
-    return 0
+	return 0
 }
 
 # Show current status
 cmd_status() {
-    migrate_legacy
+	migrate_legacy
 
-    local active
-    active=$(get_active_tenant)
-    local project_tenant=""
+	local active
+	active=$(get_active_tenant)
+	local project_tenant=""
 
-    if [[ -f "$PROJECT_TENANT_FILE" ]]; then
-        project_tenant=$(cat "$PROJECT_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
-    fi
+	if [[ -f "$PROJECT_TENANT_FILE" ]]; then
+		project_tenant=$(cat "$PROJECT_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
+	fi
 
-    echo ""
-    print_info "Multi-Tenant Credential Status"
-    echo "================================"
-    echo ""
-    echo -e "  Active tenant:  ${GREEN}$active${NC}"
+	echo ""
+	print_info "Multi-Tenant Credential Status"
+	echo "================================"
+	echo ""
+	echo -e "  Active tenant:  ${GREEN}$active${NC}"
 
-    if [[ -n "$project_tenant" ]]; then
-        echo -e "  Project tenant: ${BLUE}$project_tenant${NC} (overrides global)"
-    fi
+	if [[ -n "$project_tenant" ]]; then
+		echo -e "  Project tenant: ${BLUE}$project_tenant${NC} (overrides global)"
+	fi
 
-    local global_active=""
-    if [[ -f "$ACTIVE_TENANT_FILE" ]]; then
-        global_active=$(cat "$ACTIVE_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
-    fi
-    if [[ -n "$global_active" && "$global_active" != "$active" ]]; then
-        echo -e "  Global tenant:  ${DIM}$global_active${NC}"
-    fi
+	local global_active=""
+	if [[ -f "$ACTIVE_TENANT_FILE" ]]; then
+		global_active=$(cat "$ACTIVE_TENANT_FILE" 2>/dev/null | tr -d '[:space:]')
+	fi
+	if [[ -n "$global_active" && "$global_active" != "$active" ]]; then
+		echo -e "  Global tenant:  ${DIM}$global_active${NC}"
+	fi
 
-    echo ""
+	echo ""
 
-    # List tenants with key counts
-    if [[ -d "$TENANTS_DIR" ]]; then
-        print_info "Tenants:"
-        for tenant_dir in "$TENANTS_DIR"/*/; do
-            if [[ ! -d "$tenant_dir" ]]; then
-                continue
-            fi
-            local tenant_name
-            tenant_name=$(basename "$tenant_dir")
-            local env_file="$tenant_dir/credentials.sh"
-            local key_count=0
+	# List tenants with key counts
+	if [[ -d "$TENANTS_DIR" ]]; then
+		print_info "Tenants:"
+		for tenant_dir in "$TENANTS_DIR"/*/; do
+			if [[ ! -d "$tenant_dir" ]]; then
+				continue
+			fi
+			local tenant_name
+			tenant_name=$(basename "$tenant_dir")
+			local env_file="$tenant_dir/credentials.sh"
+			local key_count=0
 
-            if [[ -f "$env_file" ]]; then
-                key_count=$(grep -c "^export " "$env_file" 2>/dev/null || echo "0")
-            fi
+			if [[ -f "$env_file" ]]; then
+				key_count=$(grep -c "^export " "$env_file" 2>/dev/null || echo "0")
+			fi
 
-            local marker=""
-            if [[ "$tenant_name" == "$active" ]]; then
-                marker=" ${GREEN}*${NC}"
-            fi
+			local marker=""
+			if [[ "$tenant_name" == "$active" ]]; then
+				marker=" ${GREEN}*${NC}"
+			fi
 
-            echo -e "  ${BLUE}$tenant_name${NC}${marker} ($key_count keys)"
-        done
-    else
-        print_info "No tenants configured"
-    fi
+			echo -e "  ${BLUE}$tenant_name${NC}${marker} ($key_count keys)"
+		done
+	else
+		print_info "No tenants configured"
+	fi
 
-    echo ""
-    echo -e "  ${DIM}Storage: $TENANTS_DIR${NC}"
-    echo ""
-    return 0
+	echo ""
+	echo -e "  ${DIM}Storage: $TENANTS_DIR${NC}"
+	echo ""
+	return 0
 }
 
 # Initialize multi-tenant system
 cmd_init() {
-    print_info "Initializing multi-tenant credential storage..."
+	print_info "Initializing multi-tenant credential storage..."
 
-    # Ensure base directories
-    mkdir -p "$CONFIG_DIR"
-    chmod 700 "$CONFIG_DIR"
-    mkdir -p "$TENANTS_DIR"
-    chmod 700 "$TENANTS_DIR"
+	# Ensure base directories
+	mkdir -p "$CONFIG_DIR"
+	chmod 700 "$CONFIG_DIR"
+	mkdir -p "$TENANTS_DIR"
+	chmod 700 "$TENANTS_DIR"
 
-    # Migrate legacy credentials
-    migrate_legacy
+	# Migrate legacy credentials
+	migrate_legacy
 
-    # Ensure default tenant exists
-    ensure_tenant_dir "default"
+	# Ensure default tenant exists
+	ensure_tenant_dir "default"
 
-    # Set default as active if no active tenant
-    if [[ ! -f "$ACTIVE_TENANT_FILE" ]]; then
-        echo "default" > "$ACTIVE_TENANT_FILE"
-        chmod 600 "$ACTIVE_TENANT_FILE"
-    fi
+	# Set default as active if no active tenant
+	if [[ ! -f "$ACTIVE_TENANT_FILE" ]]; then
+		echo "default" >"$ACTIVE_TENANT_FILE"
+		chmod 600 "$ACTIVE_TENANT_FILE"
+	fi
 
-    # Update legacy file to source active tenant
-    local active
-    active=$(get_active_tenant)
-    update_legacy_sourcing "$active"
+	# Update legacy file to source active tenant
+	local active
+	active=$(get_active_tenant)
+	update_legacy_sourcing "$active"
 
-    print_success "Multi-tenant credential storage initialized"
-    cmd_status
-    return 0
+	print_success "Multi-tenant credential storage initialized"
+	cmd_status
+	return 0
 }
 
 # Export active tenant's credentials to stdout
 # Preferred usage: source <(credential-helper.sh export)
 # Legacy usage:    eval "$(credential-helper.sh export)" (less safe)
 cmd_export() {
-    local tenant=""
+	local tenant=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --tenant|-t)
-                tenant="$2"
-                shift 2
-                ;;
-            *)
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--tenant | -t)
+			tenant="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
 
-    if [[ -z "$tenant" ]]; then
-        tenant=$(get_active_tenant)
-    fi
+	if [[ -z "$tenant" ]]; then
+		tenant=$(get_active_tenant)
+	fi
 
-    local env_file
-    env_file=$(get_tenant_env_file "$tenant")
+	local env_file
+	env_file=$(get_tenant_env_file "$tenant")
 
-    if [[ ! -f "$env_file" ]]; then
-        print_error "Tenant '$tenant' not found" >&2
-        return 1
-    fi
+	if [[ ! -f "$env_file" ]]; then
+		print_error "Tenant '$tenant' not found" >&2
+		return 1
+	fi
 
-    # Validate and output only well-formed export lines
-    # Rejects lines that don't match strict "export VAR_NAME=..." pattern
-    # to prevent command injection if the env file is tampered with
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^export[[:space:]]+[A-Z_][A-Z0-9_]*= ]]; then
-            echo "$line"
-        fi
-    done < "$env_file"
-    echo "export AIDEVOPS_ACTIVE_TENANT=\"$tenant\""
-    return 0
+	# Validate and output only well-formed export lines
+	# Rejects lines that don't match strict "export VAR_NAME=..." pattern
+	# to prevent command injection if the env file is tampered with
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^export[[:space:]]+[A-Z_][A-Z0-9_]*= ]]; then
+			echo "$line"
+		fi
+	done <"$env_file"
+	echo "export AIDEVOPS_ACTIVE_TENANT=\"$tenant\""
+	return 0
 }
 
 # Show help
 cmd_help() {
-    echo ""
-    print_info "AI DevOps - Multi-Tenant Credential Storage"
-    echo ""
-    echo "  Manage multiple credential sets for different accounts, clients, or environments."
-    echo ""
-    print_info "Commands:"
-    echo ""
-    echo "  init                              Initialize multi-tenant storage"
-    echo "  status                            Show current tenant status"
-    echo "  create <tenant>                   Create a new tenant"
-    echo "  switch <tenant>                   Switch active tenant globally"
-    echo "  use [<tenant>|--clear]            Set/show project-level tenant"
-    echo "  list                              List all tenants"
-    echo "  keys [--tenant <name>]            Show keys in a tenant"
-    echo ""
-    echo "  set <KEY> <value> [--tenant <n>]  Set a key in a tenant"
-    echo "  get <KEY> [--tenant <name>]       Get a key value"
-    echo "  remove <KEY> [--tenant <name>]    Remove a key from a tenant"
-    echo ""
-    echo "  copy <src> <dest> [--key KEY]     Copy keys between tenants"
-    echo "  delete <tenant>                   Delete a tenant (not 'default')"
-    echo "  export [--tenant <name>]          Output exports (use with source)"
-    echo ""
-    print_info "Examples:"
-    echo ""
-    echo "  # Initialize (migrates existing credentials to 'default' tenant)"
-    echo "  credential-helper.sh init"
-    echo ""
-    echo "  # Create tenants for different clients"
-    echo "  credential-helper.sh create client-acme"
-    echo "  credential-helper.sh create client-globex"
-    echo ""
-    echo "  # Add keys to a tenant"
-    echo "  credential-helper.sh set GITHUB_TOKEN ghp_xxx --tenant client-acme"
-    echo "  credential-helper.sh set VERCEL_TOKEN xxx --tenant client-acme"
-    echo ""
-    echo "  # Switch between tenants"
-    echo "  credential-helper.sh switch client-acme"
-    echo ""
-    echo "  # Per-project tenant (overrides global)"
-    echo "  cd ~/projects/acme-app" || exit
-    echo "  credential-helper.sh use client-acme"
-    echo ""
-    echo "  # Copy shared keys to new tenant"
-    echo "  credential-helper.sh copy default client-acme --key OPENAI_API_KEY"
-    echo ""
-    echo "  # Load tenant credentials in a script (preferred: source)"
-    echo "  source <(credential-helper.sh export --tenant client-acme)"
-    echo ""
-    echo "  # Legacy alternative (less safe)"
-    echo "  eval \"\$(credential-helper.sh export --tenant client-acme)\""
-    echo ""
-    return 0
+	echo ""
+	print_info "AI DevOps - Multi-Tenant Credential Storage"
+	echo ""
+	echo "  Manage multiple credential sets for different accounts, clients, or environments."
+	echo ""
+	print_info "Commands:"
+	echo ""
+	echo "  init                              Initialize multi-tenant storage"
+	echo "  status                            Show current tenant status"
+	echo "  create <tenant>                   Create a new tenant"
+	echo "  switch <tenant>                   Switch active tenant globally"
+	echo "  use [<tenant>|--clear]            Set/show project-level tenant"
+	echo "  list                              List all tenants"
+	echo "  keys [--tenant <name>]            Show keys in a tenant"
+	echo ""
+	echo "  set <KEY> <value> [--tenant <n>]  Set a key in a tenant"
+	echo "  get <KEY> [--tenant <name>]       Get a key value"
+	echo "  remove <KEY> [--tenant <name>]    Remove a key from a tenant"
+	echo ""
+	echo "  copy <src> <dest> [--key KEY]     Copy keys between tenants"
+	echo "  delete <tenant>                   Delete a tenant (not 'default')"
+	echo "  export [--tenant <name>]          Output exports (use with source)"
+	echo ""
+	print_info "Examples:"
+	echo ""
+	echo "  # Initialize (migrates existing credentials to 'default' tenant)"
+	echo "  credential-helper.sh init"
+	echo ""
+	echo "  # Create tenants for different clients"
+	echo "  credential-helper.sh create client-acme"
+	echo "  credential-helper.sh create client-globex"
+	echo ""
+	echo "  # Add keys to a tenant"
+	echo "  credential-helper.sh set GITHUB_TOKEN ghp_xxx --tenant client-acme"
+	echo "  credential-helper.sh set VERCEL_TOKEN xxx --tenant client-acme"
+	echo ""
+	echo "  # Switch between tenants"
+	echo "  credential-helper.sh switch client-acme"
+	echo ""
+	echo "  # Per-project tenant (overrides global)"
+	echo "  cd ~/projects/acme-app" || exit
+	echo "  credential-helper.sh use client-acme"
+	echo ""
+	echo "  # Copy shared keys to new tenant"
+	echo "  credential-helper.sh copy default client-acme --key OPENAI_API_KEY"
+	echo ""
+	echo "  # Load tenant credentials in a script (preferred: source)"
+	echo "  source <(credential-helper.sh export --tenant client-acme)"
+	echo ""
+	echo "  # Legacy alternative (less safe)"
+	echo "  eval \"\$(credential-helper.sh export --tenant client-acme)\""
+	echo ""
+	return 0
 }
 
 # Main dispatch
 main() {
-    local command="${1:-help}"
-    shift 2>/dev/null || true
+	local command="${1:-help}"
+	shift 2>/dev/null || true
 
-    case "$command" in
-        init)       cmd_init "$@" ;;
-        create)     cmd_create "$@" ;;
-        switch)     cmd_switch "$@" ;;
-        list)       cmd_list "$@" ;;
-        set)        cmd_set "$@" ;;
-        get)        cmd_get "$@" ;;
-        remove|rm)  cmd_remove "$@" ;;
-        delete)     cmd_delete "$@" ;;
-        keys)       cmd_keys "$@" ;;
-        copy|cp)    cmd_copy "$@" ;;
-        use)        cmd_use "$@" ;;
-        status)     cmd_status "$@" ;;
-        export)     cmd_export "$@" ;;
-        help|--help|-h)
-            cmd_help
-            ;;
-        *)
-            print_error "$ERROR_UNKNOWN_COMMAND $command"
-            echo ""
-            cmd_help
-            return 1
-            ;;
-    esac
+	case "$command" in
+	init) cmd_init "$@" ;;
+	create) cmd_create "$@" ;;
+	switch) cmd_switch "$@" ;;
+	list) cmd_list "$@" ;;
+	set) cmd_set "$@" ;;
+	get) cmd_get "$@" ;;
+	remove | rm) cmd_remove "$@" ;;
+	delete) cmd_delete "$@" ;;
+	keys) cmd_keys "$@" ;;
+	copy | cp) cmd_copy "$@" ;;
+	use) cmd_use "$@" ;;
+	status) cmd_status "$@" ;;
+	export) cmd_export "$@" ;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		print_error "$ERROR_UNKNOWN_COMMAND $command"
+		echo ""
+		cmd_help
+		return 1
+		;;
+	esac
 
-    return 0
+	return 0
 }
 
 main "$@"

--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -284,7 +284,7 @@ cmd_set() {
 		read -rs value
 		echo ""
 
-		mkdir -p "$CONFIG_DIR"
+		ensure_credentials_file "$CREDENTIALS_FILE"
 		if [[ -f "$CREDENTIALS_FILE" ]] && grep -q "^export ${name}=" "$CREDENTIALS_FILE" 2>/dev/null; then
 			local tmp_file="${CREDENTIALS_FILE}.tmp"
 			grep -v "^export ${name}=" "$CREDENTIALS_FILE" >"$tmp_file"

--- a/.agents/scripts/setup-local-api-keys.sh
+++ b/.agents/scripts/setup-local-api-keys.sh
@@ -15,25 +15,25 @@ readonly CREDENTIALS_FILE="$API_KEY_DIR/credentials.sh"
 
 # Shell config files to check/update
 SHELL_CONFIGS=(
-    "$HOME/.zshrc"
-    "$HOME/.bashrc"
-    "$HOME/.bash_profile"
+	"$HOME/.zshrc"
+	"$HOME/.bashrc"
+	"$HOME/.bash_profile"
 )
 
 # Create secure API key directory
 setup_secure_directory() {
-    if [[ ! -d "$API_KEY_DIR" ]]; then
-        mkdir -p "$API_KEY_DIR"
-        chmod 700 "$API_KEY_DIR"
-        print_success "Created secure API key directory: $API_KEY_DIR"
-    fi
-    
-    # Ensure proper permissions
-    chmod 700 "$API_KEY_DIR"
-    
-    # Create credentials.sh if it doesn't exist
-    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
-        cat > "$CREDENTIALS_FILE" << 'EOF'
+	if [[ ! -d "$API_KEY_DIR" ]]; then
+		mkdir -p "$API_KEY_DIR"
+		chmod 700 "$API_KEY_DIR"
+		print_success "Created secure API key directory: $API_KEY_DIR"
+	fi
+
+	# Ensure proper permissions on directory
+	chmod 700 "$API_KEY_DIR"
+
+	# Create credentials.sh if it doesn't exist
+	if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+		cat >"$CREDENTIALS_FILE" <<'EOF'
 #!/bin/bash
 # ------------------------------------------------------------------------------
 # API Keys & Tokens - Single Source of Truth
@@ -46,263 +46,265 @@ setup_secure_directory() {
 # ------------------------------------------------------------------------------
 
 EOF
-        chmod 600 "$CREDENTIALS_FILE"
-        print_success "Created credentials.sh"
-    fi
-    
-    return 0
+		print_success "Created credentials.sh"
+	fi
+
+	# Enforce 0600 on credentials file (whether new or existing)
+	chmod 600 "$CREDENTIALS_FILE" 2>/dev/null || true
+
+	return 0
 }
 
 # Ensure shell configs source credentials.sh
 setup_shell_integration() {
-    local source_line='[[ -f ~/.config/aidevops/credentials.sh ]] && source ~/.config/aidevops/credentials.sh'
-    local updated=0
-    
-    for config in "${SHELL_CONFIGS[@]}"; do
-        if [[ -f "$config" ]] && ! grep -q "credentials.sh" "$config" 2>/dev/null; then
-            echo "" >> "$config"
-            echo "# AI DevOps API Keys (single source of truth)" >> "$config"
-            echo "$source_line" >> "$config"
-            print_success "Added credentials.sh sourcing to $config"
-            ((updated++)) || true
-        fi
-    done
-    
-    if [[ $updated -eq 0 ]]; then
-        print_info "Shell configs already configured"
-    fi
-    
-    return 0
+	local source_line='[[ -f ~/.config/aidevops/credentials.sh ]] && source ~/.config/aidevops/credentials.sh'
+	local updated=0
+
+	for config in "${SHELL_CONFIGS[@]}"; do
+		if [[ -f "$config" ]] && ! grep -q "credentials.sh" "$config" 2>/dev/null; then
+			echo "" >>"$config"
+			echo "# AI DevOps API Keys (single source of truth)" >>"$config"
+			echo "$source_line" >>"$config"
+			print_success "Added credentials.sh sourcing to $config"
+			((updated++)) || true
+		fi
+	done
+
+	if [[ $updated -eq 0 ]]; then
+		print_info "Shell configs already configured"
+	fi
+
+	return 0
 }
 
 # Convert service name to env var name (e.g., "updown-api-key" -> "UPDOWN_API_KEY")
 service_to_env_var() {
-    local service="$1"
-    echo "$service" | tr '[:lower:]-' '[:upper:]_'
-    return 0
+	local service="$1"
+	echo "$service" | tr '[:lower:]-' '[:upper:]_'
+	return 0
 }
 
 # Parse export command (e.g., 'export VERCEL_TOKEN="xxx"' -> extracts var name and value)
 parse_export_command() {
-    local input="$1"
-    
-    # Remove 'export ' prefix if present
-    input="${input#export }"
-    
-    # Extract var name and value
-    local var_name="${input%%=*}"
-    local value="${input#*=}"
-    
-    # Remove quotes from value
-    value="${value#\"}"
-    value="${value%\"}"
-    value="${value#\'}"
-    value="${value%\'}"
-    
-    echo "$var_name"
-    echo "$value"
-    return 0
+	local input="$1"
+
+	# Remove 'export ' prefix if present
+	input="${input#export }"
+
+	# Extract var name and value
+	local var_name="${input%%=*}"
+	local value="${input#*=}"
+
+	# Remove quotes from value
+	value="${value#\"}"
+	value="${value%\"}"
+	value="${value#\'}"
+	value="${value%\'}"
+
+	echo "$var_name"
+	echo "$value"
+	return 0
 }
 
 # Set API key securely
 set_api_key() {
-    local service="$1"
-    local key="$2"
-    
-    if [[ -z "$service" ]]; then
-        print_warning "Usage: $0 set <service> <api_key>"
-        print_info "Or paste an export command: $0 add 'export TOKEN=\"xxx\"'"
-        return 1
-    fi
-    
-    # If only one argument and it looks like an export command
-    if [[ -z "$key" && "$service" == export* ]]; then
-        local parsed
-        parsed=$(parse_export_command "$service")
-        service=$(echo "$parsed" | head -1)
-        key=$(echo "$parsed" | tail -1)
-        print_info "Parsed export command: $service"
-    fi
-    
-    if [[ -z "$key" ]]; then
-        print_warning "Usage: $0 set <service> <api_key>"
-        return 1
-    fi
-    
-    setup_secure_directory
-    
-    local env_var
-    # If service is already UPPER_CASE, use it directly
-    if [[ "$service" =~ ^[A-Z_]+$ ]]; then
-        env_var="$service"
-    else
-        env_var=$(service_to_env_var "$service")
-    fi
-    
-    # Check if the env var already exists in the file
-    if grep -q "^export ${env_var}=" "$CREDENTIALS_FILE" 2>/dev/null; then
-        # Update existing entry
-        local tmp_file="${CREDENTIALS_FILE}.tmp"
-        sed "s|^export ${env_var}=.*|export ${env_var}=\"${key}\"|" "$CREDENTIALS_FILE" > "$tmp_file"
-        mv "$tmp_file" "$CREDENTIALS_FILE"
-        chmod 600 "$CREDENTIALS_FILE"
-        print_success "Updated $env_var in credentials.sh"
-    else
-        # Append new entry
-        echo "export ${env_var}=\"${key}\"" >> "$CREDENTIALS_FILE"
-        chmod 600 "$CREDENTIALS_FILE"
-        print_success "Added $env_var to credentials.sh"
-    fi
-    
-    # Also export to current shell
-    export "${env_var}=${key}"
-    print_info "Exported to current shell. Run 'source ~/.zshrc' (or ~/.bashrc) for other terminals."
-    
-    return 0
+	local service="$1"
+	local key="$2"
+
+	if [[ -z "$service" ]]; then
+		print_warning "Usage: $0 set <service> <api_key>"
+		print_info "Or paste an export command: $0 add 'export TOKEN=\"xxx\"'"
+		return 1
+	fi
+
+	# If only one argument and it looks like an export command
+	if [[ -z "$key" && "$service" == export* ]]; then
+		local parsed
+		parsed=$(parse_export_command "$service")
+		service=$(echo "$parsed" | head -1)
+		key=$(echo "$parsed" | tail -1)
+		print_info "Parsed export command: $service"
+	fi
+
+	if [[ -z "$key" ]]; then
+		print_warning "Usage: $0 set <service> <api_key>"
+		return 1
+	fi
+
+	setup_secure_directory
+
+	local env_var
+	# If service is already UPPER_CASE, use it directly
+	if [[ "$service" =~ ^[A-Z_]+$ ]]; then
+		env_var="$service"
+	else
+		env_var=$(service_to_env_var "$service")
+	fi
+
+	# Check if the env var already exists in the file
+	if grep -q "^export ${env_var}=" "$CREDENTIALS_FILE" 2>/dev/null; then
+		# Update existing entry
+		local tmp_file="${CREDENTIALS_FILE}.tmp"
+		sed "s|^export ${env_var}=.*|export ${env_var}=\"${key}\"|" "$CREDENTIALS_FILE" >"$tmp_file"
+		mv "$tmp_file" "$CREDENTIALS_FILE"
+		chmod 600 "$CREDENTIALS_FILE"
+		print_success "Updated $env_var in credentials.sh"
+	else
+		# Append new entry
+		echo "export ${env_var}=\"${key}\"" >>"$CREDENTIALS_FILE"
+		chmod 600 "$CREDENTIALS_FILE"
+		print_success "Added $env_var to credentials.sh"
+	fi
+
+	# Also export to current shell
+	export "${env_var}=${key}"
+	print_info "Exported to current shell. Run 'source ~/.zshrc' (or ~/.bashrc) for other terminals."
+
+	return 0
 }
 
 # Add command - alias for set, better for pasting export commands
 add_api_key() {
-    set_api_key "$@"
-    return 0
+	set_api_key "$@"
+	return 0
 }
 
 # Get API key
 get_api_key() {
-    local service="$1"
-    
-    if [[ -z "$service" ]]; then
-        print_warning "Usage: $0 get <service>"
-        return 1
-    fi
-    
-    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
-        print_warning "No API keys configured. Run '$0 setup' first."
-        return 1
-    fi
-    
-    local env_var
-    # If service is already UPPER_CASE, use it directly
-    if [[ "$service" =~ ^[A-Z_]+$ ]]; then
-        env_var="$service"
-    else
-        env_var=$(service_to_env_var "$service")
-    fi
-    
-    # First check environment (already loaded)
-    local key="${!env_var}"
-    
-    # If not in env, try to extract from file
-    if [[ -z "$key" ]]; then
-        key=$(grep "^export ${env_var}=" "$CREDENTIALS_FILE" 2>/dev/null | sed 's/^export [^=]*="//' | sed 's/"$//')
-    fi
-    
-    if [[ -n "$key" ]]; then
-        echo "$key"
-        return 0
-    else
-        print_warning "API key for $service ($env_var) not found"
-        return 1
-    fi
-    return 0
+	local service="$1"
+
+	if [[ -z "$service" ]]; then
+		print_warning "Usage: $0 get <service>"
+		return 1
+	fi
+
+	if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+		print_warning "No API keys configured. Run '$0 setup' first."
+		return 1
+	fi
+
+	local env_var
+	# If service is already UPPER_CASE, use it directly
+	if [[ "$service" =~ ^[A-Z_]+$ ]]; then
+		env_var="$service"
+	else
+		env_var=$(service_to_env_var "$service")
+	fi
+
+	# First check environment (already loaded)
+	local key="${!env_var}"
+
+	# If not in env, try to extract from file
+	if [[ -z "$key" ]]; then
+		key=$(grep "^export ${env_var}=" "$CREDENTIALS_FILE" 2>/dev/null | sed 's/^export [^=]*="//' | sed 's/"$//')
+	fi
+
+	if [[ -n "$key" ]]; then
+		echo "$key"
+		return 0
+	else
+		print_warning "API key for $service ($env_var) not found"
+		return 1
+	fi
+	return 0
 }
 
 # List configured services (without showing keys)
 list_services() {
-    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
-        print_info "No API keys configured"
-        return 0
-    fi
-    
-    print_info "Configured API keys in credentials.sh:"
-    echo ""
-    grep "^export " "$CREDENTIALS_FILE" | sed 's/=.*//' | sed 's/export /  /' | sort
-    echo ""
-    print_info "File: $CREDENTIALS_FILE"
-    
-    return 0
+	if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+		print_info "No API keys configured"
+		return 0
+	fi
+
+	print_info "Configured API keys in credentials.sh:"
+	echo ""
+	grep "^export " "$CREDENTIALS_FILE" | sed 's/=.*//' | sed 's/export /  /' | sort
+	echo ""
+	print_info "File: $CREDENTIALS_FILE"
+
+	return 0
 }
 
 # Show help
 show_help() {
-    print_info "AI DevOps - Secure Local API Key Management"
-    echo ""
-    print_info "Manages API keys in: $CREDENTIALS_FILE"
-    print_info "This file is sourced by shell configs (zsh & bash) for all processes."
-    echo ""
-    print_info "Usage: $0 <command> [args]"
-    echo ""
-    print_info "Commands:"
-    echo "  setup                  - Initialize storage and shell integration"
-    echo "  set <service> <key>    - Store API key for service"
-    echo "  add 'export X=\"y\"'   - Parse and store from export command"
-    echo "  get <service>          - Retrieve API key for service"
-    echo "  list                   - List configured services"
-    echo "  tenant <subcommand>    - Multi-tenant management (see: credential-helper.sh help)"
-    echo ""
-    print_info "Examples:"
-    echo "  $0 setup"
-    echo "  $0 set vercel-token YOUR_TOKEN"
-    echo "  $0 add 'export VERCEL_TOKEN=\"abc123\"'    # Paste from service"
-    echo "  $0 set SUPABASE_KEY abc123                # Direct env var name"
-    echo "  $0 get vercel-token"
-    echo "  $0 list"
-    echo ""
-    print_info "When a service gives you 'export TOKEN=xxx', use:"
-    echo "  $0 add 'export TOKEN=\"xxx\"'"
-    echo ""
-    print_info "Service names are converted to env vars:"
-    echo "  vercel-token    ->  VERCEL_TOKEN"
-    echo "  supabase-key    ->  SUPABASE_KEY"
-    echo "  DIRECT_NAME     ->  DIRECT_NAME (kept as-is)"
-    return 0
+	print_info "AI DevOps - Secure Local API Key Management"
+	echo ""
+	print_info "Manages API keys in: $CREDENTIALS_FILE"
+	print_info "This file is sourced by shell configs (zsh & bash) for all processes."
+	echo ""
+	print_info "Usage: $0 <command> [args]"
+	echo ""
+	print_info "Commands:"
+	echo "  setup                  - Initialize storage and shell integration"
+	echo "  set <service> <key>    - Store API key for service"
+	echo "  add 'export X=\"y\"'   - Parse and store from export command"
+	echo "  get <service>          - Retrieve API key for service"
+	echo "  list                   - List configured services"
+	echo "  tenant <subcommand>    - Multi-tenant management (see: credential-helper.sh help)"
+	echo ""
+	print_info "Examples:"
+	echo "  $0 setup"
+	echo "  $0 set vercel-token YOUR_TOKEN"
+	echo "  $0 add 'export VERCEL_TOKEN=\"abc123\"'    # Paste from service"
+	echo "  $0 set SUPABASE_KEY abc123                # Direct env var name"
+	echo "  $0 get vercel-token"
+	echo "  $0 list"
+	echo ""
+	print_info "When a service gives you 'export TOKEN=xxx', use:"
+	echo "  $0 add 'export TOKEN=\"xxx\"'"
+	echo ""
+	print_info "Service names are converted to env vars:"
+	echo "  vercel-token    ->  VERCEL_TOKEN"
+	echo "  supabase-key    ->  SUPABASE_KEY"
+	echo "  DIRECT_NAME     ->  DIRECT_NAME (kept as-is)"
+	return 0
 }
 
 # Main execution
 main() {
-    local command="$1"
-    shift 2>/dev/null || true
-    
-    case "$command" in
-        "set")
-            set_api_key "$@"
-            ;;
-        "add")
-            add_api_key "$@"
-            ;;
-        "get")
-            get_api_key "$@"
-            ;;
-        "list")
-            list_services
-            ;;
-        "setup")
-            setup_secure_directory
-            setup_shell_integration
-            print_success "Secure API key storage ready"
-            echo ""
-            show_help
-            ;;
-        "tenant"|"tenants")
-            # Delegate to multi-tenant credential helper
-            local script_dir
-            script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-source "${SCRIPT_DIR}/shared-constants.sh"
+	local command="$1"
+	shift 2>/dev/null || true
 
-            bash "$script_dir/credential-helper.sh" "$@"
-            ;;
-        "help"|"--help"|"-h"|"")
-            show_help
-            ;;
-        *)
-            print_error "$ERROR_UNKNOWN_COMMAND $command"
-            echo ""
-            show_help
-            return 1
-            ;;
-    esac
-    
-    return 0
+	case "$command" in
+	"set")
+		set_api_key "$@"
+		;;
+	"add")
+		add_api_key "$@"
+		;;
+	"get")
+		get_api_key "$@"
+		;;
+	"list")
+		list_services
+		;;
+	"setup")
+		setup_secure_directory
+		setup_shell_integration
+		print_success "Secure API key storage ready"
+		echo ""
+		show_help
+		;;
+	"tenant" | "tenants")
+		# Delegate to multi-tenant credential helper
+		local script_dir
+		script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+		source "${SCRIPT_DIR}/shared-constants.sh"
+
+		bash "$script_dir/credential-helper.sh" "$@"
+		;;
+	"help" | "--help" | "-h" | "")
+		show_help
+		;;
+	*)
+		print_error "$ERROR_UNKNOWN_COMMAND $command"
+		echo ""
+		show_help
+		return 1
+		;;
+	esac
+
+	return 0
 }
 
 main "$@"

--- a/.agents/scripts/unstract-helper.sh
+++ b/.agents/scripts/unstract-helper.sh
@@ -21,344 +21,347 @@ readonly BACKEND_URL="http://backend.unstract.localhost"
 
 # Check prerequisites
 check_prerequisites() {
-    local missing=0
+	local missing=0
 
-    if ! command -v docker &>/dev/null; then
-        print_error "Docker is required but not installed"
-        print_info "Install from: https://docs.docker.com/get-docker/"
-        missing=1
-    fi
+	if ! command -v docker &>/dev/null; then
+		print_error "Docker is required but not installed"
+		print_info "Install from: https://docs.docker.com/get-docker/"
+		missing=1
+	fi
 
-    if ! command -v docker compose &>/dev/null && ! command -v docker-compose &>/dev/null; then
-        print_error "Docker Compose is required but not installed"
-        missing=1
-    fi
+	if ! command -v docker compose &>/dev/null && ! command -v docker-compose &>/dev/null; then
+		print_error "Docker Compose is required but not installed"
+		missing=1
+	fi
 
-    if ! command -v git &>/dev/null; then
-        print_error "Git is required but not installed"
-        missing=1
-    fi
+	if ! command -v git &>/dev/null; then
+		print_error "Git is required but not installed"
+		missing=1
+	fi
 
-    if [[ "$missing" -eq 1 ]]; then
-        return 1
-    fi
+	if [[ "$missing" -eq 1 ]]; then
+		return 1
+	fi
 
-    # Check available RAM (minimum 8GB)
-    local ram_gb
-    if [[ "$(uname)" == "Darwin" ]]; then
-        ram_gb=$(( $(sysctl -n hw.memsize) / 1073741824 ))
-    else
-        ram_gb=$(( $(grep MemTotal /proc/meminfo | awk '{print $2}') / 1048576 ))
-    fi
+	# Check available RAM (minimum 8GB)
+	local ram_gb
+	if [[ "$(uname)" == "Darwin" ]]; then
+		ram_gb=$(($(sysctl -n hw.memsize) / 1073741824))
+	else
+		ram_gb=$(($(grep MemTotal /proc/meminfo | awk '{print $2}') / 1048576))
+	fi
 
-    if [[ "$ram_gb" -lt 8 ]]; then
-        print_warning "System has ${ram_gb}GB RAM. Unstract recommends 8GB minimum."
-    else
-        print_info "System RAM: ${ram_gb}GB (meets 8GB minimum)"
-    fi
+	if [[ "$ram_gb" -lt 8 ]]; then
+		print_warning "System has ${ram_gb}GB RAM. Unstract recommends 8GB minimum."
+	else
+		print_info "System RAM: ${ram_gb}GB (meets 8GB minimum)"
+	fi
 
-    return 0
+	return 0
 }
 
 # Install Unstract self-hosted
 do_install() {
-    print_info "Installing Unstract self-hosted platform..."
+	print_info "Installing Unstract self-hosted platform..."
 
-    if [[ -d "$UNSTRACT_DIR" ]]; then
-        print_warning "Unstract already installed at ${UNSTRACT_DIR}"
-        print_info "Use 'unstract-helper.sh start' to start, or 'unstract-helper.sh uninstall' first"
-        return 0
-    fi
+	if [[ -d "$UNSTRACT_DIR" ]]; then
+		print_warning "Unstract already installed at ${UNSTRACT_DIR}"
+		print_info "Use 'unstract-helper.sh start' to start, or 'unstract-helper.sh uninstall' first"
+		return 0
+	fi
 
-    check_prerequisites || return 1
+	check_prerequisites || return 1
 
-    # Clone repository
-    print_info "Cloning Unstract repository..."
-    git clone "$UNSTRACT_REPO" "$UNSTRACT_DIR"
+	# Clone repository
+	print_info "Cloning Unstract repository..."
+	git clone "$UNSTRACT_REPO" "$UNSTRACT_DIR"
 
-    # Disable analytics in frontend
-    local frontend_env="${UNSTRACT_DIR}/frontend/.env"
-    if [[ -f "$frontend_env" ]]; then
-        if grep -q "REACT_APP_ENABLE_POSTHOG" "$frontend_env"; then
-            sed_inplace 's/REACT_APP_ENABLE_POSTHOG=.*/REACT_APP_ENABLE_POSTHOG=false/' "$frontend_env"
-        else
-            echo "REACT_APP_ENABLE_POSTHOG=false" >> "$frontend_env"
-        fi
-    else
-        echo "REACT_APP_ENABLE_POSTHOG=false" > "$frontend_env"
-    fi
-    print_success "Analytics disabled (REACT_APP_ENABLE_POSTHOG=false)"
+	# Disable analytics in frontend
+	local frontend_env="${UNSTRACT_DIR}/frontend/.env"
+	if [[ -f "$frontend_env" ]]; then
+		if grep -q "REACT_APP_ENABLE_POSTHOG" "$frontend_env"; then
+			sed_inplace 's/REACT_APP_ENABLE_POSTHOG=.*/REACT_APP_ENABLE_POSTHOG=false/' "$frontend_env"
+		else
+			echo "REACT_APP_ENABLE_POSTHOG=false" >>"$frontend_env"
+		fi
+	else
+		echo "REACT_APP_ENABLE_POSTHOG=false" >"$frontend_env"
+	fi
+	print_success "Analytics disabled (REACT_APP_ENABLE_POSTHOG=false)"
 
-    # Start the platform
-    do_start
+	# Start the platform
+	do_start
 
-    # Configure MCP env to point to local instance
-    configure_local_mcp_env
+	# Configure MCP env to point to local instance
+	configure_local_mcp_env
 
-    print_success "Unstract self-hosted installation complete!"
-    echo
-    print_info "Next steps:"
-    print_info "1. Visit ${FRONTEND_URL} (login: unstract/unstract)"
-    print_info "2. Add LLM adapters (Settings > Adapters) using your existing API keys"
-    print_info "3. Create a Prompt Studio project and deploy as API"
-    print_info "4. The MCP will automatically connect to your local instance"
-    echo
-    print_info "Run 'unstract-helper.sh configure-llm' for help adding LLM keys"
+	print_success "Unstract self-hosted installation complete!"
+	echo
+	print_info "Next steps:"
+	print_info "1. Visit ${FRONTEND_URL} (login: unstract/unstract)"
+	print_info "2. Add LLM adapters (Settings > Adapters) using your existing API keys"
+	print_info "3. Create a Prompt Studio project and deploy as API"
+	print_info "4. The MCP will automatically connect to your local instance"
+	echo
+	print_info "Run 'unstract-helper.sh configure-llm' for help adding LLM keys"
 
-    return 0
+	return 0
 }
 
 # Start Unstract
 do_start() {
-    if [[ ! -d "$UNSTRACT_DIR" ]]; then
-        print_error "Unstract not installed. Run 'unstract-helper.sh install' first"
-        return 1
-    fi
+	if [[ ! -d "$UNSTRACT_DIR" ]]; then
+		print_error "Unstract not installed. Run 'unstract-helper.sh install' first"
+		return 1
+	fi
 
-    print_info "Starting Unstract platform..."
-    cd "$UNSTRACT_DIR" || exit
+	print_info "Starting Unstract platform..."
+	cd "$UNSTRACT_DIR" || exit
 
-    if [[ -f "run-platform.sh" ]]; then
-        bash run-platform.sh
-    else
-        docker compose up -d
-    fi
+	if [[ -f "run-platform.sh" ]]; then
+		bash run-platform.sh
+	else
+		docker compose up -d
+	fi
 
-    # Wait for services to be ready
-    print_info "Waiting for services to start..."
-    local attempts=0
-    while [[ $attempts -lt 30 ]]; do
-        if curl -s -o /dev/null -w "%{http_code}" "$FRONTEND_URL" 2>/dev/null | grep -q "200\|301\|302"; then
-            print_success "Unstract is running at ${FRONTEND_URL}"
-            return 0
-        fi
-        sleep 2
-        attempts=$((attempts + 1))
-    done
+	# Wait for services to be ready
+	print_info "Waiting for services to start..."
+	local attempts=0
+	while [[ $attempts -lt 30 ]]; do
+		if curl -s -o /dev/null -w "%{http_code}" "$FRONTEND_URL" 2>/dev/null | grep -q "200\|301\|302"; then
+			print_success "Unstract is running at ${FRONTEND_URL}"
+			return 0
+		fi
+		sleep 2
+		attempts=$((attempts + 1))
+	done
 
-    print_warning "Services may still be starting. Check: unstract-helper.sh status"
-    return 0
+	print_warning "Services may still be starting. Check: unstract-helper.sh status"
+	return 0
 }
 
 # Stop Unstract
 do_stop() {
-    if [[ ! -d "$UNSTRACT_DIR" ]]; then
-        print_error "Unstract not installed"
-        return 1
-    fi
+	if [[ ! -d "$UNSTRACT_DIR" ]]; then
+		print_error "Unstract not installed"
+		return 1
+	fi
 
-    print_info "Stopping Unstract platform..."
-    cd "$UNSTRACT_DIR" || exit
-    docker compose down
-    print_success "Unstract stopped"
-    return 0
+	print_info "Stopping Unstract platform..."
+	cd "$UNSTRACT_DIR" || exit
+	docker compose down
+	print_success "Unstract stopped"
+	return 0
 }
 
 # Check status
 do_status() {
-    if [[ ! -d "$UNSTRACT_DIR" ]]; then
-        print_info "Unstract: Not installed"
-        print_info "Run 'unstract-helper.sh install' to set up"
-        return 0
-    fi
+	if [[ ! -d "$UNSTRACT_DIR" ]]; then
+		print_info "Unstract: Not installed"
+		print_info "Run 'unstract-helper.sh install' to set up"
+		return 0
+	fi
 
-    print_info "Unstract installation: ${UNSTRACT_DIR}"
+	print_info "Unstract installation: ${UNSTRACT_DIR}"
 
-    cd "$UNSTRACT_DIR" || exit
-    local running
-    running=$(docker compose ps --format json 2>/dev/null | grep -c '"running"' 2>/dev/null || echo "0")
+	cd "$UNSTRACT_DIR" || exit
+	local running
+	running=$(docker compose ps --format json 2>/dev/null | grep -c '"running"' 2>/dev/null || echo "0")
 
-    if [[ "$running" -gt 0 ]]; then
-        print_success "Unstract: Running (${running} containers)"
-        print_info "Frontend: ${FRONTEND_URL}"
-        print_info "Backend: ${BACKEND_URL}"
-    else
-        print_warning "Unstract: Installed but not running"
-        print_info "Run 'unstract-helper.sh start' to start"
-    fi
+	if [[ "$running" -gt 0 ]]; then
+		print_success "Unstract: Running (${running} containers)"
+		print_info "Frontend: ${FRONTEND_URL}"
+		print_info "Backend: ${BACKEND_URL}"
+	else
+		print_warning "Unstract: Installed but not running"
+		print_info "Run 'unstract-helper.sh start' to start"
+	fi
 
-    # Check MCP env
-    if [[ -f "$CREDENTIALS_FILE" ]] && grep -q "API_BASE_URL" "$CREDENTIALS_FILE"; then
-        local url
-        url=$(grep "^export API_BASE_URL" "$CREDENTIALS_FILE" | sed 's/.*=//' | tr -d '"' | tr -d "'")
-        print_info "MCP configured: ${url}"
-    else
-        print_warning "MCP not configured. Run 'unstract-helper.sh configure-llm'"
-    fi
+	# Check MCP env
+	if [[ -f "$CREDENTIALS_FILE" ]] && grep -q "API_BASE_URL" "$CREDENTIALS_FILE"; then
+		local url
+		url=$(grep "^export API_BASE_URL" "$CREDENTIALS_FILE" | sed 's/.*=//' | tr -d '"' | tr -d "'")
+		print_info "MCP configured: ${url}"
+	else
+		print_warning "MCP not configured. Run 'unstract-helper.sh configure-llm'"
+	fi
 
-    return 0
+	return 0
 }
 
 # Show logs
 do_logs() {
-    if [[ ! -d "$UNSTRACT_DIR" ]]; then
-        print_error "Unstract not installed"
-        return 1
-    fi
+	if [[ ! -d "$UNSTRACT_DIR" ]]; then
+		print_error "Unstract not installed"
+		return 1
+	fi
 
-    cd "$UNSTRACT_DIR" || exit
-    local service="${1:-}"
-    if [[ -n "$service" ]]; then
-        docker compose logs -f "$service"
-    else
-        docker compose logs -f --tail=50
-    fi
-    return 0
+	cd "$UNSTRACT_DIR" || exit
+	local service="${1:-}"
+	if [[ -n "$service" ]]; then
+		docker compose logs -f "$service"
+	else
+		docker compose logs -f --tail=50
+	fi
+	return 0
 }
 
 # Uninstall
 do_uninstall() {
-    if [[ ! -d "$UNSTRACT_DIR" ]]; then
-        print_info "Unstract not installed, nothing to remove"
-        return 0
-    fi
+	if [[ ! -d "$UNSTRACT_DIR" ]]; then
+		print_info "Unstract not installed, nothing to remove"
+		return 0
+	fi
 
-    print_warning "This will stop and remove the Unstract installation"
-    print_warning "Location: ${UNSTRACT_DIR}"
-    echo -n "Continue? [y/N] "
-    read -r confirm
-    if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
-        print_info "Cancelled"
-        return 0
-    fi
+	print_warning "This will stop and remove the Unstract installation"
+	print_warning "Location: ${UNSTRACT_DIR}"
+	echo -n "Continue? [y/N] "
+	read -r confirm
+	if [[ "$confirm" != "y" && "$confirm" != "Y" ]]; then
+		print_info "Cancelled"
+		return 0
+	fi
 
-    cd "$UNSTRACT_DIR" || exit
-    docker compose down -v 2>/dev/null || true
-    cd "$HOME" || exit
-    rm -rf "$UNSTRACT_DIR"
+	cd "$UNSTRACT_DIR" || exit
+	docker compose down -v 2>/dev/null || true
+	cd "$HOME" || exit
+	rm -rf "$UNSTRACT_DIR"
 
-    # Remove MCP env entries
-    if [[ -f "$CREDENTIALS_FILE" ]]; then
-        sed_inplace '/UNSTRACT_API_KEY/d' "$CREDENTIALS_FILE"
-        sed_inplace '/^export API_BASE_URL.*unstract/d' "$CREDENTIALS_FILE"
-    fi
+	# Remove MCP env entries
+	if [[ -f "$CREDENTIALS_FILE" ]]; then
+		sed_inplace '/UNSTRACT_API_KEY/d' "$CREDENTIALS_FILE"
+		sed_inplace '/^export API_BASE_URL.*unstract/d' "$CREDENTIALS_FILE"
+	fi
 
-    print_success "Unstract uninstalled"
-    return 0
+	print_success "Unstract uninstalled"
+	return 0
 }
 
 # Configure local MCP environment
 configure_local_mcp_env() {
-    mkdir -p "$(dirname "$CREDENTIALS_FILE")"
+	# Ensure credentials file exists with secure permissions (0600)
+	ensure_credentials_file "$CREDENTIALS_FILE"
 
-    # Set default local URL (user will update deployment ID after creating a project)
-    local needs_update=0
+	# Set default local URL (user will update deployment ID after creating a project)
+	local needs_update=0
 
-    if ! grep -q "^export API_BASE_URL" "$CREDENTIALS_FILE" 2>/dev/null; then
-        echo 'export API_BASE_URL="http://backend.unstract.localhost/deployment/api/YOUR_DEPLOYMENT_ID/"' >> "$CREDENTIALS_FILE"
-        needs_update=1
-    fi
+	if ! grep -q "^export API_BASE_URL" "$CREDENTIALS_FILE" 2>/dev/null; then
+		echo 'export API_BASE_URL="http://backend.unstract.localhost/deployment/api/YOUR_DEPLOYMENT_ID/"' >>"$CREDENTIALS_FILE"
+		needs_update=1
+	fi
 
-    if ! grep -q "UNSTRACT_API_KEY" "$CREDENTIALS_FILE" 2>/dev/null; then
-        echo 'export UNSTRACT_API_KEY="YOUR_LOCAL_API_KEY"' >> "$CREDENTIALS_FILE"
-        needs_update=1
-    fi
+	if ! grep -q "UNSTRACT_API_KEY" "$CREDENTIALS_FILE" 2>/dev/null; then
+		echo 'export UNSTRACT_API_KEY="YOUR_LOCAL_API_KEY"' >>"$CREDENTIALS_FILE"
+		needs_update=1
+	fi
 
-    if [[ "$needs_update" -eq 1 ]]; then
-        chmod 600 "$CREDENTIALS_FILE"
-        print_info "Added UNSTRACT_API_KEY and API_BASE_URL to ${CREDENTIALS_FILE}"
-        print_warning "Update these after creating your first API deployment in Prompt Studio"
-    fi
+	if [[ "$needs_update" -eq 1 ]]; then
+		print_info "Added UNSTRACT_API_KEY and API_BASE_URL to ${CREDENTIALS_FILE}"
+		print_warning "Update these after creating your first API deployment in Prompt Studio"
+	fi
 
-    return 0
+	return 0
 }
 
 # Help with LLM adapter configuration
 do_configure_llm() {
-    print_info "Unstract LLM Adapter Configuration"
-    echo
-    print_info "Unstract uses 'Adapters' to connect to LLM providers."
-    print_info "Add these in the Unstract UI: Settings > Adapters > Add Adapter"
-    echo
-    print_info "Your existing API keys from ~/.config/aidevops/credentials.sh can be used:"
-    echo
+	print_info "Unstract LLM Adapter Configuration"
+	echo
+	print_info "Unstract uses 'Adapters' to connect to LLM providers."
+	print_info "Add these in the Unstract UI: Settings > Adapters > Add Adapter"
+	echo
+	print_info "Your existing API keys from ~/.config/aidevops/credentials.sh can be used:"
+	echo
 
-    # Check which keys the user already has
-    local found_keys=0
-    if [[ -f "$CREDENTIALS_FILE" ]]; then
-        if grep -q "OPENAI_API_KEY" "$CREDENTIALS_FILE" 2>/dev/null; then
-            print_success "OpenAI API key found - add as 'OpenAI' adapter in Unstract"
-            found_keys=$((found_keys + 1))
-        fi
-        if grep -q "ANTHROPIC_API_KEY" "$CREDENTIALS_FILE" 2>/dev/null; then
-            print_success "Anthropic API key found - add as 'Anthropic' adapter in Unstract"
-            found_keys=$((found_keys + 1))
-        fi
-        if grep -q "GOOGLE_API_KEY\|GOOGLE_APPLICATION_CREDENTIALS\|VERTEX" "$CREDENTIALS_FILE" 2>/dev/null; then
-            print_success "Google/Vertex AI key found - add as 'Google VertexAI' adapter"
-            found_keys=$((found_keys + 1))
-        fi
-        if grep -q "AZURE_OPENAI" "$CREDENTIALS_FILE" 2>/dev/null; then
-            print_success "Azure OpenAI key found - add as 'Azure OpenAI' adapter"
-            found_keys=$((found_keys + 1))
-        fi
-        if grep -q "AWS_ACCESS_KEY\|AWS_SECRET" "$CREDENTIALS_FILE" 2>/dev/null; then
-            print_success "AWS credentials found - add as 'Bedrock' adapter"
-            found_keys=$((found_keys + 1))
-        fi
-    fi
+	# Check which keys the user already has
+	local found_keys=0
+	if [[ -f "$CREDENTIALS_FILE" ]]; then
+		if grep -q "OPENAI_API_KEY" "$CREDENTIALS_FILE" 2>/dev/null; then
+			print_success "OpenAI API key found - add as 'OpenAI' adapter in Unstract"
+			found_keys=$((found_keys + 1))
+		fi
+		if grep -q "ANTHROPIC_API_KEY" "$CREDENTIALS_FILE" 2>/dev/null; then
+			print_success "Anthropic API key found - add as 'Anthropic' adapter in Unstract"
+			found_keys=$((found_keys + 1))
+		fi
+		if grep -q "GOOGLE_API_KEY\|GOOGLE_APPLICATION_CREDENTIALS\|VERTEX" "$CREDENTIALS_FILE" 2>/dev/null; then
+			print_success "Google/Vertex AI key found - add as 'Google VertexAI' adapter"
+			found_keys=$((found_keys + 1))
+		fi
+		if grep -q "AZURE_OPENAI" "$CREDENTIALS_FILE" 2>/dev/null; then
+			print_success "Azure OpenAI key found - add as 'Azure OpenAI' adapter"
+			found_keys=$((found_keys + 1))
+		fi
+		if grep -q "AWS_ACCESS_KEY\|AWS_SECRET" "$CREDENTIALS_FILE" 2>/dev/null; then
+			print_success "AWS credentials found - add as 'Bedrock' adapter"
+			found_keys=$((found_keys + 1))
+		fi
+	fi
 
-    if [[ "$found_keys" -eq 0 ]]; then
-        print_warning "No LLM API keys found in ${CREDENTIALS_FILE}"
-        print_info "Add at least one LLM key to use Unstract:"
-        echo
-    fi
+	if [[ "$found_keys" -eq 0 ]]; then
+		print_warning "No LLM API keys found in ${CREDENTIALS_FILE}"
+		print_info "Add at least one LLM key to use Unstract:"
+		echo
+	fi
 
-    echo
-    print_info "Supported LLM providers in Unstract:"
-    print_info "  - OpenAI (GPT-4, GPT-4o)"
-    print_info "  - Anthropic (Claude)"
-    print_info "  - Google VertexAI / Gemini"
-    print_info "  - Azure OpenAI"
-    print_info "  - AWS Bedrock"
-    print_info "  - Ollama (local, no API key needed)"
-    print_info "  - Mistral AI"
-    echo
-    print_info "For Ollama (fully local, no cloud):"
-    print_info "  1. Install Ollama: https://ollama.ai"
-    print_info "  2. Pull a model: ollama pull llama3"
-    print_info "  3. Add as 'Ollama' adapter in Unstract (URL: http://host.docker.internal:11434)"
-    echo
-    print_info "Visit ${FRONTEND_URL} > Settings > Adapters to configure"
+	echo
+	print_info "Supported LLM providers in Unstract:"
+	print_info "  - OpenAI (GPT-4, GPT-4o)"
+	print_info "  - Anthropic (Claude)"
+	print_info "  - Google VertexAI / Gemini"
+	print_info "  - Azure OpenAI"
+	print_info "  - AWS Bedrock"
+	print_info "  - Ollama (local, no API key needed)"
+	print_info "  - Mistral AI"
+	echo
+	print_info "For Ollama (fully local, no cloud):"
+	print_info "  1. Install Ollama: https://ollama.ai"
+	print_info "  2. Pull a model: ollama pull llama3"
+	print_info "  3. Add as 'Ollama' adapter in Unstract (URL: http://host.docker.internal:11434)"
+	echo
+	print_info "Visit ${FRONTEND_URL} > Settings > Adapters to configure"
 
-    return 0
+	return 0
 }
 
 # Main
 main() {
-    local command="${1:-help}"
+	local command="${1:-help}"
 
-    case "$command" in
-        install)    do_install ;;
-        start)      do_start ;;
-        stop)       do_stop ;;
-        status)     do_status ;;
-        logs)       shift; do_logs "${1:-}" ;;
-        uninstall)  do_uninstall ;;
-        configure-llm) do_configure_llm ;;
-        help|--help|-h)
-            echo "Usage: unstract-helper.sh [command]"
-            echo
-            echo "Commands:"
-            echo "  install        Clone and start Unstract self-hosted (analytics disabled)"
-            echo "  start          Start Unstract containers"
-            echo "  stop           Stop Unstract containers"
-            echo "  status         Show installation and running status"
-            echo "  logs [svc]     Show container logs (optionally for specific service)"
-            echo "  uninstall      Remove Unstract installation and data"
-            echo "  configure-llm  Show how to add LLM adapters using your existing API keys"
-            echo
-            echo "Prerequisites: Docker, Docker Compose, Git, 8GB RAM"
-            echo "Install location: ${UNSTRACT_DIR}"
-            ;;
-        *)
-            print_error "Unknown command: ${command}"
-            echo "Run 'unstract-helper.sh help' for usage"
-            return 1
-            ;;
-    esac
+	case "$command" in
+	install) do_install ;;
+	start) do_start ;;
+	stop) do_stop ;;
+	status) do_status ;;
+	logs)
+		shift
+		do_logs "${1:-}"
+		;;
+	uninstall) do_uninstall ;;
+	configure-llm) do_configure_llm ;;
+	help | --help | -h)
+		echo "Usage: unstract-helper.sh [command]"
+		echo
+		echo "Commands:"
+		echo "  install        Clone and start Unstract self-hosted (analytics disabled)"
+		echo "  start          Start Unstract containers"
+		echo "  stop           Stop Unstract containers"
+		echo "  status         Show installation and running status"
+		echo "  logs [svc]     Show container logs (optionally for specific service)"
+		echo "  uninstall      Remove Unstract installation and data"
+		echo "  configure-llm  Show how to add LLM adapters using your existing API keys"
+		echo
+		echo "Prerequisites: Docker, Docker Compose, Git, 8GB RAM"
+		echo "Install location: ${UNSTRACT_DIR}"
+		;;
+	*)
+		print_error "Unknown command: ${command}"
+		echo "Run 'unstract-helper.sh help' for usage"
+		return 1
+		;;
+	esac
 
-    return 0
+	return 0
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Closes #2407

- Add `ensure_credentials_file()` utility to `shared-constants.sh` that guarantees `0700` on the parent directory and `0600` on the credentials file before any write
- Replace ad-hoc `mkdir -p` calls with this utility in `watercrawl-helper.sh`, `unstract-helper.sh`, and `secret-helper.sh`
- Add `chmod 600` after `cmd_copy` appends in `credential-helper.sh`
- Enforce permissions on existing files in `setup-local-api-keys.sh` (not just newly created ones)
- Add fallback `ensure_credentials_file` definition in `watercrawl-helper.sh` for resilience when `shared-constants.sh` fails to load

## Problem

Several helper scripts that write to `~/.config/aidevops/credentials.sh` could leave the file world-readable on fresh creation or when appending to an existing file. Specifically:

| Script | Issue |
|--------|-------|
| `watercrawl-helper.sh` | No `chmod 600` when appending to existing file |
| `unstract-helper.sh` | `mkdir -p` without `chmod 700` on directory |
| `credential-helper.sh` | `cmd_copy` appends without enforcing permissions |
| `secret-helper.sh` | `mkdir -p` without directory permissions |
| `setup-local-api-keys.sh` | Only set `chmod 600` on new files, not existing |

## Solution

Centralized `ensure_credentials_file()` function in `shared-constants.sh` that:
1. Creates parent directory with `0700` if missing
2. Creates file if missing
3. Enforces `0600` on the file regardless of current permissions
4. Is idempotent (safe to call multiple times)

All credential-writing scripts now call this before their first write.

## Verification

- `shellcheck` passes on all modified files (no new findings)
- `git diff -w` confirms only security-relevant content changes (whitespace normalization is from the Edit tool)