### PR TITLE
fix: suppress SC2016 for intentionally literal single-quoted strings

### DIFF
--- a/.agents/scripts/archived/finding-to-task-helper.sh
+++ b/.agents/scripts/archived/finding-to-task-helper.sh
@@ -309,6 +309,7 @@ task_exists_in_todo() {
             ;;
         rule)
             # Check if there's an open task referencing this rule
+            # shellcheck disable=SC2016 # sed replacement pattern is intentionally literal
             if grep -qF "$group_key" "$todo_file" 2>/dev/null && \
                grep -qE "^[[:space:]]*- \[ \] t[0-9].*$(echo "$group_key" | sed 's/[.[\*^$()+?{|]/\\&/g')" "$todo_file" 2>/dev/null; then
                 return 0

--- a/.agents/scripts/generate-claude-agents.sh
+++ b/.agents/scripts/generate-claude-agents.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016 # $ARGUMENTS is a Claude Code template placeholder written literally to .md files
 # =============================================================================
 # Generate Claude Code Configuration
 # =============================================================================

--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016 # $ARGUMENTS is a Claude Code template placeholder written literally to .md files
 # =============================================================================
 # Generate Claude Code Commands from Agent Files
 # =============================================================================

--- a/.agents/scripts/observability-helper.sh
+++ b/.agents/scripts/observability-helper.sh
@@ -273,7 +273,9 @@ _rl_jq() {
 	echo "${val:-$default}"
 }
 
+# shellcheck disable=SC2016 # $p and $f are jq variable references, not shell variables
 _get_rl_field() { _rl_jq '.providers[$p][$f]' "$1" "$2" "0"; }
+# shellcheck disable=SC2016 # $f is a jq variable reference, not a shell variable
 _get_config_val() { _rl_jq '.[$f]' "" "$1" "$2"; }
 
 _count_usage_in_window() {

--- a/.agents/scripts/remote-dispatch-helper.sh
+++ b/.agents/scripts/remote-dispatch-helper.sh
@@ -331,6 +331,7 @@ cmd_check() {
 	fi
 
 	# Test 4: Check SSH agent forwarding
+	# shellcheck disable=SC2016 # $SSH_AUTH_SOCK must expand on the remote host, not locally
 	if "${ssh_cmd[@]}" 'test -n "$SSH_AUTH_SOCK"' 2>/dev/null; then
 		_log_success "SSH agent forwarding: working"
 	else

--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -538,6 +538,7 @@ get_skill_diff_summary() {
 	fi
 
 	# Format as code block for readability
+	# shellcheck disable=SC2016 # backticks are literal markdown, not command substitution
 	printf '```\n%s\n```\n' "$diff_stat"
 	return 0
 }

--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -1399,12 +1399,14 @@ _exec_create_task() {
 			log_warn "AI Actions: commit_and_push_todo failed for $task_id — reverting TODO.md append (t1261)"
 			# Revert the append: remove the task line we just added
 			local escaped_task_id
+			# shellcheck disable=SC2016 # sed replacement pattern is intentionally literal
 			escaped_task_id=$(printf '%s' "$task_id" | sed 's/[.[\*^$()+?{|\\]/\\&/g')
 			sed -i '' "/^- \[ \] ${escaped_task_id} /d" "$todo_file" 2>/dev/null || true
 		fi
 	fi
 
 	if [[ "$commit_ok" != "true" ]]; then
+		# shellcheck disable=SC2016 # $task_id and $error are jq variable references
 		jq -n --arg task_id "$task_id" --arg error "commit_failed" \
 			'{"created": false, "task_id": $task_id, "error": $error}'
 		return 1
@@ -2148,6 +2150,7 @@ _exec_propose_auto_dispatch() {
 
 		# Apply the change
 		local escaped_old
+		# shellcheck disable=SC2016 # sed replacement pattern is intentionally literal
 		escaped_old=$(printf '%s\n' "$task_line" | sed 's/[[\.*^$()+?{|]/\\&/g')
 		sed -i.bak "s|${escaped_old}|${new_line}|" "$todo_file"
 		rm -f "${todo_file}.bak"
@@ -2175,6 +2178,7 @@ _exec_propose_auto_dispatch() {
 	local new_line="${task_line}${annotation}"
 
 	local escaped_old
+	# shellcheck disable=SC2016 # sed replacement pattern is intentionally literal
 	escaped_old=$(printf '%s\n' "$task_line" | sed 's/[[\.*^$()+?{|]/\\&/g')
 	sed -i.bak "s|${escaped_old}|${new_line}|" "$todo_file"
 	rm -f "${todo_file}.bak"

--- a/.agents/scripts/supervisor-archived/cron.sh
+++ b/.agents/scripts/supervisor-archived/cron.sh
@@ -1213,6 +1213,7 @@ EOF
 
 	# Wrapper script with cleanup handlers (matches cmd_dispatch pattern)
 	local wrapper_script="${SUPERVISOR_DIR}/pids/${task_id}-decompose-wrapper.sh"
+	# shellcheck disable=SC2016 # echo statements generate a child script; variables must expand at child runtime
 	{
 		echo '#!/usr/bin/env bash'
 		echo 'cleanup_children() {'

--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -905,6 +905,7 @@ check_review_threads() {
 
 	# GraphQL query to fetch all review threads with resolution status
 	local graphql_query
+	# shellcheck disable=SC2016 # $owner, $repo, $pr are GraphQL variables, not shell variables
 	graphql_query='query($owner: String!, $repo: String!, $pr: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
@@ -989,6 +990,7 @@ resolve_bot_review_threads() {
 
 	# Fetch all unresolved threads with author info
 	local graphql_query
+	# shellcheck disable=SC2016 # $owner, $repo, $pr are GraphQL variables, not shell variables
 	graphql_query='query($owner: String!, $repo: String!, $pr: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
@@ -1042,6 +1044,7 @@ resolve_bot_review_threads() {
 	while IFS= read -r thread_id; do
 		[[ -z "$thread_id" ]] && continue
 		local resolve_mutation
+		# shellcheck disable=SC2016 # $threadId is a GraphQL variable, not a shell variable
 		resolve_mutation='mutation($threadId: ID!) {
   resolveReviewThread(input: {threadId: $threadId}) {
     thread {
@@ -1369,6 +1372,7 @@ Instructions:
 	# Wrapper script (t183): captures dispatch errors in log file
 	# t253: Add cleanup handlers to prevent orphaned children when wrapper exits
 	local wrapper_script="${SUPERVISOR_DIR}/pids/${task_id}-review-fix-wrapper.sh"
+	# shellcheck disable=SC2016 # echo statements generate a child script; variables must expand at child runtime
 	{
 		echo '#!/usr/bin/env bash'
 		echo '# t253: Recursive cleanup to kill all descendant processes'

--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -1048,6 +1048,7 @@ do_prompt_repeat() {
 	# Wrapper script with cleanup handlers (t253)
 	# t1190: Use timestamped filename to prevent overwrite race condition.
 	local wrapper_script="${SUPERVISOR_DIR}/pids/${task_id}-prompt-repeat-wrapper-${pr_dispatch_ts}.sh"
+	# shellcheck disable=SC2016 # echo statements generate a child script; variables must expand at child runtime
 	{
 		echo '#!/usr/bin/env bash'
 		# t1190: Wrapper-level sentinel written before running dispatch script.
@@ -3095,6 +3096,7 @@ cmd_dispatch() {
 	# t253: Add cleanup handlers to prevent orphaned children when wrapper exits
 	# t1190: Use timestamped filename (matches dispatch_ts) to prevent overwrite race.
 	local wrapper_script="${SUPERVISOR_DIR}/pids/${task_id}-wrapper-${dispatch_ts}.sh"
+	# shellcheck disable=SC2016 # echo statements generate a child script; variables must expand at child runtime
 	{
 		echo '#!/usr/bin/env bash'
 		# t1190: Wrapper-level sentinel — written before running the dispatch script.
@@ -3648,6 +3650,7 @@ Task description: ${tdesc:-$task_id}"
 	# t253: Add cleanup handlers to prevent orphaned children when wrapper exits
 	# t1190: Use timestamped filename to prevent overwrite race condition.
 	local wrapper_script="${SUPERVISOR_DIR}/pids/${task_id}-reprompt-wrapper-${reprompt_dispatch_ts}.sh"
+	# shellcheck disable=SC2016 # echo statements generate a child script; variables must expand at child runtime
 	{
 		echo '#!/usr/bin/env bash'
 		# t1190: Wrapper-level sentinel written before running dispatch script.

--- a/.agents/scripts/supervisor-archived/issue-sync.sh
+++ b/.agents/scripts/supervisor-archived/issue-sync.sh
@@ -1479,6 +1479,7 @@ get_task_assignee() {
 	local assignee=""
 	# Strip backtick-quoted segments to avoid matching `assignee:foo` in descriptions
 	local stripped_line
+	# shellcheck disable=SC2016 # sed pattern with backticks is intentionally literal
 	stripped_line=$(echo "$task_line" | sed 's/`[^`]*`//g')
 	# Take the last assignee:value match (metadata fields are at the end of the line)
 	assignee=$(echo "$stripped_line" | grep -oE ' assignee:[A-Za-z0-9._@-]+' | tail -1 | sed 's/^ *assignee://' || echo "")

--- a/.agents/scripts/verify-run-helper.sh
+++ b/.agents/scripts/verify-run-helper.sh
@@ -423,6 +423,7 @@ cmd_log() {
         echo "Total runs: ${total_runs}"
         echo ""
         local start_pattern
+        # shellcheck disable=SC2016 # sed replacement pattern is intentionally literal
         start_pattern=$(grep "^## v[0-9]" "$log_file" | tail -"$last_n" | head -1 | sed 's/[[\.*^$()+?{|]/\\&/g')
         if [[ -n "$start_pattern" ]]; then
             sed -n "/${start_pattern}/,\$p" "$log_file"

--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -337,6 +337,7 @@ check_requirements() {
 		# Only modify rc files during interactive setup (not updates)
 		# Users may intentionally remove these lines; re-adding on every update is harmful
 		if [[ "$NON_INTERACTIVE" != "true" ]]; then
+			# shellcheck disable=SC2016 # brew_line is written to rc files; must expand at shell startup, not now
 			local brew_line='eval "$(/opt/homebrew/bin/brew shellenv)"'
 			local fixed_rc=false
 			local rc_file
@@ -373,6 +374,7 @@ check_requirements() {
 
 			# Only modify rc files during interactive setup (not updates)
 			if [[ "$NON_INTERACTIVE" != "true" ]]; then
+				# shellcheck disable=SC2016 # intel_brew_line is written to rc files; must expand at shell startup, not now
 				local intel_brew_line='eval "$(/usr/local/bin/brew shellenv)"'
 				local intel_fixed_rc=false
 				local intel_rc

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -309,7 +309,9 @@ setup_browser_tools() {
 
 				# Bun's installer may only write to the running shell's rc file.
 				# Ensure Bun PATH is in all shell rc files for cross-shell compat.
+				# shellcheck disable=SC2016 # written to rc files; must expand at shell startup, not now
 				local bun_path_line='export BUN_INSTALL="$HOME/.bun"'
+				# shellcheck disable=SC2016 # written to rc files; must expand at shell startup, not now
 				local bun_export_line='export PATH="$BUN_INSTALL/bin:$PATH"'
 				local bun_rc
 				while IFS= read -r bun_rc; do

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -403,6 +403,7 @@ check_optional_deps() {
 }
 
 add_local_bin_to_path() {
+	# shellcheck disable=SC2016 # path_line is written to rc files; must expand at shell startup, not now
 	local path_line='export PATH="$HOME/.local/bin:$PATH"'
 	local added_to=""
 	local already_in=""


### PR DESCRIPTION
## Summary

- Added `# shellcheck disable=SC2016` with explanatory comments to 15 shell scripts across the codebase
- All violations were **intentionally literal** — single-quoted strings where `$variables` must NOT expand in the current shell context
- Zero SC2016 violations remain (verified with `shellcheck -f gcc` across all 365 `.sh` files)

## Categories of intentional single-quoting

| Category | Files | Example |
|----------|-------|---------|
| Claude Code `$ARGUMENTS` placeholder | `generate-claude-agents.sh`, `generate-claude-commands.sh` | Template variable written literally to `.md` files |
| jq variable references | `observability-helper.sh`, `ai-actions.sh` | `$p`, `$f`, `$task_id` in jq filter expressions |
| GraphQL variables | `deploy.sh` | `$owner`, `$repo`, `$threadId` in query strings |
| Script generators (echo blocks) | `cron.sh`, `deploy.sh`, `dispatch.sh` | `$$`, `$children`, `$wrapper_pid` in child scripts |
| RC file lines | `core.sh`, `mcp-setup.sh`, `shell-env.sh` | `$HOME`, `$BUN_INSTALL` — must expand at user shell startup |
| SSH remote commands | `remote-dispatch-helper.sh` | `$SSH_AUTH_SOCK` — must expand on remote host |
| sed/regex patterns | `finding-to-task-helper.sh`, `verify-run-helper.sh`, `ai-actions.sh`, `issue-sync.sh` | Metacharacter escaping patterns |

## Verification

```
$ git ls-files '*.sh' | xargs -P4 -n20 shellcheck -f gcc 2>/dev/null | grep 'SC2016' | wc -l
0
```

Closes #2409