### PR TITLE
fix: add shell safety baseline to setup-modules and setup.sh

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -2,6 +2,13 @@
 # Agent deployment functions: deploy_aidevops_agents, deploy_ai_templates, inject_agents_reference, safety-hooks, beads
 # Part of aidevops setup.sh modularization (t316.3)
 
+# Shell safety baseline
+set -Eeuo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC2154  # rc is assigned by $? in the trap string
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
+
 deploy_ai_templates() {
 	print_info "Deploying AI assistant templates..."
 

--- a/setup-modules/config.sh
+++ b/setup-modules/config.sh
@@ -2,6 +2,13 @@
 # Configuration functions: setup_configs, set_permissions, ssh, aidevops-cli, opencode-config, claude-config, validate, extract-prompts, drift-check
 # Part of aidevops setup.sh modularization (t316.3)
 
+# Shell safety baseline
+set -Eeuo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC2154  # rc is assigned by $? in the trap string
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
+
 setup_configs() {
 	print_info "Setting up configuration files..."
 

--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -2,6 +2,13 @@
 # Core setup functions: requirements, permissions, location
 # Part of aidevops setup.sh modularization (t316.3)
 
+# Shell safety baseline
+set -Eeuo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC2154  # rc is assigned by $? in the trap string
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
+
 bootstrap_repo() {
 	# Detect if running from curl (no script directory context)
 	local script_path="${BASH_SOURCE[0]}"

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -2,6 +2,13 @@
 # MCP setup functions: install_mcp_packages, resolve_mcp_binary, localwp, augment, seo, analytics, quickfile, browser-tools, opencode-plugins
 # Part of aidevops setup.sh modularization (t316.3)
 
+# Shell safety baseline
+set -Eeuo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC2154  # rc is assigned by $? in the trap string
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
+
 install_mcp_packages() {
 	print_info "Installing MCP server packages globally (eliminates npx startup delay)..."
 

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -2,6 +2,13 @@
 # Migration functions: migrate_* and cleanup_* functions
 # Part of aidevops setup.sh modularization (t316.3)
 
+# Shell safety baseline
+set -Eeuo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC2154  # rc is assigned by $? in the trap string
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
+
 cleanup_deprecated_paths() {
 	local agents_dir="$HOME/.aidevops/agents"
 	local cleaned=0

--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -2,6 +2,13 @@
 # Plugin functions: deploy_plugins, sanitize_plugin_namespace, generate_agent_skills, create_skill_symlinks, check_skill_updates, scan_imported_skills, multi-tenant
 # Part of aidevops setup.sh modularization (t316.3)
 
+# Shell safety baseline
+set -Eeuo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC2154  # rc is assigned by $? in the trap string
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
+
 sanitize_plugin_namespace() {
 	local ns="$1"
 	# Strip any path components, keep only the final directory name
@@ -499,4 +506,3 @@ check_tool_updates() {
 
 	return 0
 }
-

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -2,6 +2,13 @@
 # Shell environment setup functions: oh-my-zsh, shell-compat, aliases, terminal-title
 # Part of aidevops setup.sh modularization (t316.3)
 
+# Shell safety baseline
+set -Eeuo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC2154  # rc is assigned by $? in the trap string
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
+
 detect_running_shell() {
 	if [[ -n "${ZSH_VERSION:-}" ]]; then
 		echo "zsh"

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -2,6 +2,13 @@
 # Tool installation functions: git-clis, fd, ripgrep, shellcheck, shfmt, rosetta, worktrunk, minisim, recommended-tools, nodejs, python, orbstack
 # Part of aidevops setup.sh modularization (t316.3)
 
+# Shell safety baseline
+set -Eeuo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC2154  # rc is assigned by $? in the trap string
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
+
 setup_git_clis() {
 	print_info "Setting up Git CLI tools..."
 
@@ -1116,4 +1123,3 @@ setup_ai_orchestration() {
 
 	return 0
 }
-

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-set -euo pipefail
+
+# Shell safety baseline
+set -Eeuo pipefail
+IFS=$'\n\t'
+# shellcheck disable=SC2154  # rc is assigned by $? in the trap string
+trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
+shopt -s inherit_errexit 2>/dev/null || true
 
 # AI Assistant Server Access Framework Setup Script
 # Helps developers set up the framework for their infrastructure


### PR DESCRIPTION
## Summary

- Adds standard shell safety prologue (`set -Eeuo pipefail`, `IFS=$'\n\t'`, ERR trap, `inherit_errexit`) to all 8 `setup-modules/*.sh` scripts and upgrades `setup.sh` from `set -euo pipefail` to the full baseline
- Prevents silent partial failures in bootstrap paths and provides clear `[ERROR] file:line exit N` diagnostics on stderr when errors occur

## Changes

| File | Change |
|------|--------|
| `setup.sh` | Upgraded from `set -euo pipefail` to full safety baseline |
| `setup-modules/agent-deploy.sh` | Added safety baseline prologue |
| `setup-modules/config.sh` | Added safety baseline prologue |
| `setup-modules/core.sh` | Added safety baseline prologue |
| `setup-modules/mcp-setup.sh` | Added safety baseline prologue |
| `setup-modules/migrations.sh` | Added safety baseline prologue |
| `setup-modules/plugins.sh` | Added safety baseline prologue |
| `setup-modules/shell-env.sh` | Added safety baseline prologue |
| `setup-modules/tool-install.sh` | Added safety baseline prologue |

## Safety baseline

```bash
set -Eeuo pipefail
IFS=$'\n\t'
trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
shopt -s inherit_errexit 2>/dev/null || true
```

**What each setting does:**
- `set -E` — propagates ERR traps into functions (previously missing)
- `IFS=$'\n\t'` — prevents word splitting on spaces (safer for filenames)
- ERR trap — prints `[ERROR] file:line exit N` to stderr on any command failure
- `inherit_errexit` — makes command substitutions inherit `set -e` (previously missing)

## Verification

- ShellCheck passes with zero new warnings (SC2154 false positive suppressed with inline directive)
- All pre-existing ShellCheck findings (SC2016, SC2129, SC2015) are unrelated and unchanged

Closes #2405