### PR TITLE
fix: remove broken relative links in documentation

### DIFF
--- a/.agents/services/hosting/cloudflare-platform/references/ai-search/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/ai-search/README.md
@@ -4,8 +4,6 @@ Expert guidance for implementing Cloudflare AI Search (formerly AutoRAG), Cloudf
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/analytics-engine/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/analytics-engine/README.md
@@ -4,8 +4,6 @@ Expert guidance for implementing unlimited-cardinality analytics at scale using 
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/api-shield/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/api-shield/README.md
@@ -4,8 +4,6 @@ Expert guidance for API Shield - comprehensive API security suite for discovery,
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, session identifiers, rules, token/mTLS configs
-- **[api.md](./api.md)** - Endpoint management, discovery, validation APIs, GraphQL operations
 - **[patterns.md](./patterns.md)** - Common patterns, progressive rollout, OWASP mappings, workflows
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, false positives, performance, best practices
 

--- a/.agents/services/hosting/cloudflare-platform/references/api/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/api/README.md
@@ -11,8 +11,6 @@ Use when working with:
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/argo-smart-routing/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/argo-smart-routing/README.md
@@ -6,8 +6,6 @@ Cloudflare Argo Smart Routing is a performance optimization service that detects
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/bindings/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/bindings/README.md
@@ -4,8 +4,6 @@ Expert guidance on Cloudflare Workers Bindings - the runtime APIs that connect W
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/bot-management/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/bot-management/README.md
@@ -59,8 +59,6 @@ export default {
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - Product tiers, WAF rule setup, JavaScript Detections, ML auto-updates
-- [api.md](./api.md) - Workers BotManagement interface, WAF fields, JA4 Signals
 - [patterns.md](./patterns.md) - E-commerce, API protection, mobile app allowlisting, SEO-friendly handling
 - [gotchas.md](./gotchas.md) - False positives/negatives, score=0 issues, JSD limitations, CSP requirements
 

--- a/.agents/services/hosting/cloudflare-platform/references/browser-rendering/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/browser-rendering/README.md
@@ -6,8 +6,6 @@
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/cache-reserve/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/cache-reserve/README.md
@@ -87,7 +87,5 @@ curl -I https://example.com/asset.jpg | grep -i cache
 
 ## See Also
 
-- [Configuration](./configuration.md) - Setup, API, and Cache Rules
-- [API Reference](./api.md) - Purging, monitoring, and management APIs
 - [Patterns](./patterns.md) - Best practices and architecture patterns
 - [Gotchas](./gotchas.md) - Common issues, troubleshooting, limits

--- a/.agents/services/hosting/cloudflare-platform/references/cache-reserve/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/cache-reserve/gotchas.md
@@ -198,6 +198,4 @@ const endpoints = {
 ## See Also
 
 - [README](./README.md) - Overview and core concepts
-- [Configuration](./configuration.md) - Setup and Cache Rules
-- [API Reference](./api.md) - Purging and monitoring
 - [Patterns](./patterns.md) - Best practices and optimization

--- a/.agents/services/hosting/cloudflare-platform/references/cache-reserve/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/cache-reserve/patterns.md
@@ -175,6 +175,4 @@ const optimizeTTL = {
 ## See Also
 
 - [README](./README.md) - Overview and core concepts
-- [Configuration](./configuration.md) - Setup and Cache Rules
-- [API Reference](./api.md) - Purging and monitoring
 - [Gotchas](./gotchas.md) - Common issues and troubleshooting

--- a/.agents/services/hosting/cloudflare-platform/references/containers/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/containers/README.md
@@ -6,8 +6,6 @@ Use when working with Cloudflare Containers: deploying containerized apps on Wor
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/cron-triggers/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/cron-triggers/README.md
@@ -82,7 +82,5 @@ curl "http://localhost:8787/__scheduled?cron=*/5+*+*+*+*"
 
 ## See Also
 
-- [configuration.md](./configuration.md) - wrangler config, env-specific schedules
-- [api.md](./api.md) - ScheduledController, handler params
 - [patterns.md](./patterns.md) - Use cases, batch processing, monitoring
 - [gotchas.md](./gotchas.md) - Timezone issues, debugging, limits

--- a/.agents/services/hosting/cloudflare-platform/references/cron-triggers/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/cron-triggers/patterns.md
@@ -120,5 +120,4 @@ query CronMetrics($accountTag: string!, $workerName: string!) {
 ## See Also
 
 - [README.md](./README.md) - Overview
-- [api.md](./api.md) - Handler implementation
 - [gotchas.md](./gotchas.md) - Troubleshooting

--- a/.agents/services/hosting/cloudflare-platform/references/d1/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/d1/README.md
@@ -78,8 +78,6 @@ wrangler dev --persist-to=./.wrangler/state
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - wrangler.toml setup, TypeScript types, binding configuration
-- [api.md](./api.md) - D1Database API, prepared statements, batch operations, testing
 - [patterns.md](./patterns.md) - Pagination, bulk operations, caching, multi-tenant patterns
 - [gotchas.md](./gotchas.md) - SQL injection prevention, error handling, performance pitfalls
 

--- a/.agents/services/hosting/cloudflare-platform/references/ddos/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/ddos/README.md
@@ -28,7 +28,5 @@ Zone overrides take precedence over account overrides.
 
 ## See Also
 
-- [configuration.md](./configuration.md) - Dashboard & rule setup
-- [api.md](./api.md) - API endpoints & management
 - [patterns.md](./patterns.md) - Protection strategies
 - [gotchas.md](./gotchas.md) - False positives & tuning

--- a/.agents/services/hosting/cloudflare-platform/references/ddos/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/ddos/patterns.md
@@ -154,5 +154,3 @@ const config = {
 ## Defense in Depth
 
 Combine DDoS with WAF, Rate Limiting, Bot Management. Layer protections at different levels.
-
-See [configuration.md](./configuration.md) for rule structure details.

--- a/.agents/services/hosting/cloudflare-platform/references/do-storage/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/do-storage/README.md
@@ -50,8 +50,6 @@ export class Counter extends DurableObject {
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - wrangler.jsonc migrations, SQLite vs KV setup
-- [api.md](./api.md) - SQL exec/cursors, KV methods, transactions, alarms, PITR
 - [patterns.md](./patterns.md) - Schema migrations, caching, rate limiting, batch processing
 - [gotchas.md](./gotchas.md) - Concurrency gates, transaction rules, SQL limits, async pitfalls
 

--- a/.agents/services/hosting/cloudflare-platform/references/durable-objects/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/durable-objects/README.md
@@ -119,8 +119,6 @@ npx wrangler deploy           # Deploy + auto-apply migrations
 
 ## In This Reference
 
-- [Configuration](./configuration.md) - wrangler.jsonc setup, migrations, bindings
-- [API](./api.md) - Class structure, storage APIs, alarms, WebSockets
 - [Patterns](./patterns.md) - Rate limiting, locks, real-time collab, sessions
 - [Gotchas](./gotchas.md) - Limits, common issues, troubleshooting
 

--- a/.agents/services/hosting/cloudflare-platform/references/email-routing/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/email-routing/README.md
@@ -8,8 +8,6 @@ Cloudflare Email Routing enables custom email addresses for your domain that rou
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/hyperdrive/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/hyperdrive/README.md
@@ -54,8 +54,6 @@ export default {
 
 ## See Also
 
-- [configuration.md](./configuration.md) - Setup, wrangler config
-- [api.md](./api.md) - Binding APIs, query patterns
 - [patterns.md](./patterns.md) - Use cases, ORMs
 - [gotchas.md](./gotchas.md) - Limits, troubleshooting
 

--- a/.agents/services/hosting/cloudflare-platform/references/hyperdrive/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/hyperdrive/gotchas.md
@@ -1,6 +1,6 @@
 # Gotchas
 
-See [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md).
+See [README.md](./README.md), [patterns.md](./patterns.md).
 
 ## Limits
 

--- a/.agents/services/hosting/cloudflare-platform/references/hyperdrive/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/hyperdrive/patterns.md
@@ -1,6 +1,6 @@
 # Patterns
 
-See [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md).
+See [README.md](./README.md)
 
 ## High-Traffic Read-Heavy
 

--- a/.agents/services/hosting/cloudflare-platform/references/images/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/images/README.md
@@ -4,8 +4,6 @@
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/kv/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/kv/README.md
@@ -48,8 +48,6 @@ const json = await env.MY_KV.get<Config>("config", "json");
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - wrangler.jsonc setup, namespace creation, TypeScript types
-- [api.md](./api.md) - KV methods, bulk operations, cacheTtl, content types
 - [patterns.md](./patterns.md) - Caching, sessions, rate limiting, A/B testing
 - [gotchas.md](./gotchas.md) - Eventual consistency, concurrent writes, value limits
 

--- a/.agents/services/hosting/cloudflare-platform/references/miniflare/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/miniflare/README.md
@@ -53,8 +53,6 @@ await mf.dispose();
 
 ## See Also
 
-- [configuration.md](./configuration.md) - Config options, bindings, wrangler.toml
-- [api.md](./api.md) - Programmatic API, methods, event dispatching
 - [patterns.md](./patterns.md) - Testing patterns, CI, mocking
 - [gotchas.md](./gotchas.md) - Compatibility issues, limits, debugging
 

--- a/.agents/services/hosting/cloudflare-platform/references/network-interconnect/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/network-interconnect/README.md
@@ -54,7 +54,5 @@ Private, high-performance connectivity to Cloudflare's network. **Enterprise-onl
 
 ## See Also
 
-- [configuration.md](./configuration.md) - BGP, routing, setup
-- [api.md](./api.md) - API endpoints, SDKs
 - [patterns.md](./patterns.md) - HA, hybrid cloud, failover
 - [gotchas.md](./gotchas.md) - Troubleshooting, limits

--- a/.agents/services/hosting/cloudflare-platform/references/observability/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/observability/README.md
@@ -8,8 +8,6 @@
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/pages-functions/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/pages-functions/README.md
@@ -53,7 +53,5 @@ export function onRequest(context) {
 
 ## See Also
 
-- [configuration.md](./configuration.md) - Routes, headers, redirects, wrangler config
-- [api.md](./api.md) - EventContext, handlers, bindings
 - [patterns.md](./patterns.md) - Auth, CORS, rate limiting, forms, caching
 - [gotchas.md](./gotchas.md) - Common issues, debugging, limits

--- a/.agents/services/hosting/cloudflare-platform/references/pages-functions/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/pages-functions/gotchas.md
@@ -147,6 +147,4 @@ In `_worker.js`: `return env.ASSETS.fetch(request)` for static assets.
 ## See Also
 
 - [README.md](./README.md) - Overview
-- [configuration.md](./configuration.md) - wrangler.json
-- [api.md](./api.md) - EventContext, bindings
 - [patterns.md](./patterns.md) - Common patterns

--- a/.agents/services/hosting/cloudflare-platform/references/pages-functions/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/pages-functions/patterns.md
@@ -186,5 +186,4 @@ export default {
 ## See Also
 
 - [README.md](./README.md) - Overview
-- [api.md](./api.md) - EventContext, bindings
 - [gotchas.md](./gotchas.md) - Common issues

--- a/.agents/services/hosting/cloudflare-platform/references/pages/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/pages/README.md
@@ -67,8 +67,6 @@ npx wrangler pages deployment tail --project-name=my-project
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - wrangler.jsonc, build, env vars
-- [api.md](./api.md) - Functions API, bindings, context
 - [patterns.md](./patterns.md) - Full-stack patterns, frameworks
 - [gotchas.md](./gotchas.md) - Build issues, limits, debugging
 

--- a/.agents/services/hosting/cloudflare-platform/references/pulumi/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/pulumi/README.md
@@ -116,4 +116,4 @@ import * as cloudflare from "@pulumi/cloudflare";
 - `*Bindings` - Connect resources to Workers
 
 ---
-See: [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)
+See: [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)

--- a/.agents/services/hosting/cloudflare-platform/references/pulumi/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/pulumi/gotchas.md
@@ -247,4 +247,4 @@ deploy:
 - **Workers Docs:** https://developers.cloudflare.com/workers/
 
 ---
-See: [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md)
+See: [README.md](./README.md), [patterns.md](./patterns.md)

--- a/.agents/services/hosting/cloudflare-platform/references/pulumi/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/pulumi/patterns.md
@@ -136,4 +136,4 @@ const worker = new cloudflare.WorkerScript("worker", {
 ```
 
 ---
-See: [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [gotchas.md](./gotchas.md)
+See: [README.md](./README.md), [gotchas.md](./gotchas.md)

--- a/.agents/services/hosting/cloudflare-platform/references/queues/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/queues/README.md
@@ -57,8 +57,6 @@ export default {
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - wrangler.jsonc setup, producer/consumer config, DLQ
-- [api.md](./api.md) - Send/batch methods, queue handler, ack/retry, pull API
 - [patterns.md](./patterns.md) - Async tasks, buffering, rate limiting, event workflows
 - [gotchas.md](./gotchas.md) - Idempotency, retry limits, content types, cost optimization
 

--- a/.agents/services/hosting/cloudflare-platform/references/r2-data-catalog/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/r2-data-catalog/README.md
@@ -8,8 +8,6 @@ R2 Data Catalog is a managed Apache Iceberg REST catalog built directly into R2 
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/r2/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/r2/README.md
@@ -48,8 +48,6 @@ if (object) return new Response(object.body);
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - wrangler.jsonc bindings, S3 SDK setup, location hints
-- [api.md](./api.md) - Workers API methods, multipart uploads, conditional requests
 - [patterns.md](./patterns.md) - Streaming, caching, presigned URLs, storage transitions
 - [gotchas.md](./gotchas.md) - List truncation, etag format, checksum limits, multipart pitfalls
 

--- a/.agents/services/hosting/cloudflare-platform/references/realtime-sfu/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/realtime-sfu/README.md
@@ -4,8 +4,6 @@ Expert guidance for building real-time audio/video/data applications using Cloud
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, environment variables, Wrangler config
-- **[api.md](./api.md)** - Sessions, tracks, endpoints, request/response patterns
 - **[patterns.md](./patterns.md)** - Architecture patterns, use cases, integration examples
 - **[gotchas.md](./gotchas.md)** - Common issues, debugging, performance, security
 

--- a/.agents/services/hosting/cloudflare-platform/references/realtimekit/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/realtimekit/README.md
@@ -63,8 +63,6 @@ await meeting.join();
 
 ## In This Reference
 
-- [Configuration](./configuration.md) - Setup, installation, wrangler config
-- [API](./api.md) - Meeting object, REST API, SDK methods
 - [Patterns](./patterns.md) - Common workflows, code examples
 - [Gotchas](./gotchas.md) - Common issues, troubleshooting
 

--- a/.agents/services/hosting/cloudflare-platform/references/realtimekit/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/realtimekit/gotchas.md
@@ -184,6 +184,4 @@ meeting.chat.on('chatUpdate', (data) => console.log('[chat] chatUpdate:', data))
 ## In This Reference
 
 - [README.md](./README.md) - Overview, core concepts, quick start
-- [configuration.md](./configuration.md) - SDK config, presets, wrangler setup
-- [api.md](./api.md) - Client SDK APIs, REST endpoints
 - [patterns.md](./patterns.md) - Common patterns, React hooks, backend integration

--- a/.agents/services/hosting/cloudflare-platform/references/realtimekit/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/realtimekit/patterns.md
@@ -159,6 +159,4 @@ export default {
 ## In This Reference
 
 - [README.md](./README.md) - Overview, core concepts, quick start
-- [configuration.md](./configuration.md) - SDK config, presets, wrangler setup
-- [api.md](./api.md) - Client SDK APIs, REST endpoints
 - [gotchas.md](./gotchas.md) - Common issues, troubleshooting, limits

--- a/.agents/services/hosting/cloudflare-platform/references/sandbox/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/sandbox/README.md
@@ -85,8 +85,6 @@ EXPOSE 8080 3000  # Required for wrangler dev
 
 ## Resources
 
-- [Configuration](./configuration.md) - Config, CLI, environment
-- [API Reference](./api.md) - Programmatic API, testing
 - [Patterns](./patterns.md) - Common workflows, CI/CD
 - [Gotchas](./gotchas.md) - Issues, limits, best practices
 - [Official Docs](https://developers.cloudflare.com/sandbox/)

--- a/.agents/services/hosting/cloudflare-platform/references/smart-placement/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/smart-placement/README.md
@@ -79,8 +79,6 @@ wrangler tail your-worker-name --header cf-placement
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - wrangler.toml setup, placement hints, dashboard config
-- [api.md](./api.md) - Placement Status API, cf-placement header, monitoring
 - [patterns.md](./patterns.md) - Frontend/backend split, database workers, SSR patterns
 - [gotchas.md](./gotchas.md) - Troubleshooting INSUFFICIENT_INVOCATIONS, performance issues
 

--- a/.agents/services/hosting/cloudflare-platform/references/snippets/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/snippets/README.md
@@ -6,8 +6,6 @@ Expert guidance for **Cloudflare Snippets ONLY** - a lightweight JavaScript-base
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/spectrum/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/spectrum/README.md
@@ -6,8 +6,6 @@ Cloudflare Spectrum provides security and acceleration for ANY TCP or UDP-based 
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/static-assets/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/static-assets/README.md
@@ -4,8 +4,6 @@ Expert guidance for deploying and configuring static assets with Cloudflare Work
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/stream/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/stream/README.md
@@ -99,8 +99,6 @@ curl -X POST \
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - Setup, environment variables, wrangler config
-- [api.md](./api.md) - Upload, playback, live streaming, management APIs
 - [patterns.md](./patterns.md) - Full-stack flows, state management, best practices
 - [gotchas.md](./gotchas.md) - Error codes, troubleshooting, limits
 

--- a/.agents/services/hosting/cloudflare-platform/references/stream/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/stream/gotchas.md
@@ -136,8 +136,6 @@ async function uploadWithErrorHandling(url: string, file: File) {
 ## In This Reference
 
 - [README.md](./README.md) - Overview and quick start
-- [configuration.md](./configuration.md) - Setup and config
-- [api.md](./api.md) - Upload, playback, live streaming APIs
 - [patterns.md](./patterns.md) - Full-stack flows, best practices
 
 ## See Also

--- a/.agents/services/hosting/cloudflare-platform/references/stream/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/stream/patterns.md
@@ -144,8 +144,6 @@ export default {
 ## In This Reference
 
 - [README.md](./README.md) - Overview and quick start
-- [configuration.md](./configuration.md) - Setup and config
-- [api.md](./api.md) - Upload, playback, live streaming APIs
 - [gotchas.md](./gotchas.md) - Error codes, troubleshooting
 
 ## See Also

--- a/.agents/services/hosting/cloudflare-platform/references/terraform/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/terraform/README.md
@@ -70,7 +70,5 @@ terraform validate      # Validate configuration
 
 ## See Also
 
-- [Configuration Reference](./configuration.md) - Resources for zones, DNS, workers, KV, R2, D1, Pages, rulesets
-- [API Reference](./api.md) - Data sources for existing resources
 - [Patterns & Use Cases](./patterns.md) - Architecture patterns, multi-env setup, CI/CD integration
 - [Troubleshooting & Best Practices](./gotchas.md) - Common issues, security, best practices

--- a/.agents/services/hosting/cloudflare-platform/references/terraform/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/terraform/gotchas.md
@@ -205,7 +205,5 @@ terraform state push terraform.tfstate
 ## See Also
 
 - [README](./README.md) - Provider setup
-- [Configuration](./configuration.md) - Resources
-- [API](./api.md) - Data sources
 - [Patterns](./patterns.md) - Use cases
 - Provider docs: https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs

--- a/.agents/services/hosting/cloudflare-platform/references/terraform/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/terraform/patterns.md
@@ -130,6 +130,4 @@ output "zone_id" { value = cloudflare_zone.main.id }
 ## See Also
 
 - [README](./README.md) - Provider setup
-- [Configuration Reference](./configuration.md) - All resource types
-- [API Reference](./api.md) - Data sources
 - [Troubleshooting](./gotchas.md) - Best practices, common issues

--- a/.agents/services/hosting/cloudflare-platform/references/tunnel/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/tunnel/README.md
@@ -70,8 +70,6 @@ ingress:
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - Config file options, ingress rules, TLS settings
-- [api.md](./api.md) - Cloudflare API, remotely-managed tunnels, programmatic control
 - [patterns.md](./patterns.md) - Docker, Kubernetes, HA, service types, use cases
 - [gotchas.md](./gotchas.md) - Troubleshooting, limitations, best practices
 

--- a/.agents/services/hosting/cloudflare-platform/references/turnstile/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/turnstile/README.md
@@ -4,8 +4,6 @@ Expert guidance for implementing Cloudflare Turnstile - a smart CAPTCHA alternat
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/waf/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/waf/README.md
@@ -4,8 +4,6 @@
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/web-analytics/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/web-analytics/README.md
@@ -9,8 +9,6 @@ Cloudflare Web Analytics is a free, privacy-focused analytics service that:
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/workerd/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workerd/README.md
@@ -42,8 +42,6 @@ workerd test config.capnp
 
 ## See Also
 
-- [configuration.md](./configuration.md) - Config format, services, bindings
-- [api.md](./api.md) - Runtime APIs, C++ embedding
 - [patterns.md](./patterns.md) - Multi-service, DO, proxies
 - [gotchas.md](./gotchas.md) - Common errors, debugging
 

--- a/.agents/services/hosting/cloudflare-platform/references/workerd/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workerd/gotchas.md
@@ -237,4 +237,4 @@ Workerd version = max compat date supported. If `compatibilityDate = "2025-01-01
 6. **Isolate issue**: Minimal repro config
 7. **Review schema**: [workerd.capnp](https://github.com/cloudflare/workerd/blob/main/src/workerd/server/workerd.capnp)
 
-See [configuration.md](./configuration.md) for config details, [patterns.md](./patterns.md) for working examples, [api.md](./api.md) for runtime APIs.
+See [patterns.md](./patterns.md) for working examples

--- a/.agents/services/hosting/cloudflare-platform/references/workerd/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workerd/patterns.md
@@ -226,4 +226,4 @@ export default {
 };
 ```
 
-See [configuration.md](./configuration.md) for config syntax, [api.md](./api.md) for runtime APIs, [gotchas.md](./gotchas.md) for common errors.
+See [gotchas.md](./gotchas.md) for common errors.

--- a/.agents/services/hosting/cloudflare-platform/references/workers-for-platforms/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workers-for-platforms/README.md
@@ -40,7 +40,7 @@ Request → Dispatch Worker → Determines user Worker → env.DISPATCHER.get("c
 
 ## Quick Start
 
-See [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)
+See [patterns.md](./patterns.md), [gotchas.md](./gotchas.md)
 
 ## Refs
 

--- a/.agents/services/hosting/cloudflare-platform/references/workers-for-platforms/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workers-for-platforms/gotchas.md
@@ -138,4 +138,4 @@ interface Fetcher {
 7. **Not using wildcard routes** → Hit route limits, DNS issues
 8. **Assuming DO/mTLS interception** → Outbound Worker doesn't catch these
 
-See [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md)
+See [README.md](./README.md), [patterns.md](./patterns.md)

--- a/.agents/services/hosting/cloudflare-platform/references/workers-for-platforms/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workers-for-platforms/patterns.md
@@ -150,7 +150,6 @@ const userWorker = env.DISPATCHER.get(workerName);
 ### Website Builder
 
 - Deploy static assets + Worker code
-- See [api.md](./api.md#static-assets) for full implementation
 - Salt hashes for asset isolation
 
 ## Best Practices
@@ -180,4 +179,4 @@ const userWorker = env.DISPATCHER.get(workerName);
 - Enable bulk operations
 - Filter efficiently
 
-See [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [gotchas.md](./gotchas.md)
+See [README.md](./README.md), [gotchas.md](./gotchas.md)

--- a/.agents/services/hosting/cloudflare-platform/references/workers-playground/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workers-playground/README.md
@@ -6,8 +6,6 @@ Cloudflare Workers Playground is a browser-based sandbox for instantly experimen
 
 ## In This Reference
 
-- **[configuration.md](./configuration.md)** - Setup, deployment, configuration
-- **[api.md](./api.md)** - API endpoints, methods, interfaces
 - **[patterns.md](./patterns.md)** - Common patterns, use cases, examples
 - **[gotchas.md](./gotchas.md)** - Troubleshooting, best practices, limitations
 

--- a/.agents/services/hosting/cloudflare-platform/references/workers/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workers/README.md
@@ -81,8 +81,6 @@ async tail(events: TraceItem[], env: Env, ctx: ExecutionContext): Promise<void>
 
 ## In This Reference
 
-- [Configuration](./configuration.md) - wrangler.jsonc setup, bindings, environments
-- [API](./api.md) - Runtime APIs, bindings, execution context
 - [Patterns](./patterns.md) - Common workflows, testing, optimization
 - [Gotchas](./gotchas.md) - Common issues, limits, troubleshooting
 

--- a/.agents/services/hosting/cloudflare-platform/references/workers/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workers/gotchas.md
@@ -95,5 +95,3 @@ export default {
 ## See Also
 
 - [Patterns](./patterns.md) - Best practices
-- [API](./api.md) - Runtime APIs
-- [Configuration](./configuration.md) - Setup

--- a/.agents/services/hosting/cloudflare-platform/references/workers/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workers/patterns.md
@@ -144,6 +144,4 @@ if (bucket < rolloutPercent) return newFeature(request);
 
 ## See Also
 
-- [API](./api.md) - Runtime APIs
 - [Gotchas](./gotchas.md) - Common issues
-- [Configuration](./configuration.md) - Setup

--- a/.agents/services/hosting/cloudflare-platform/references/workflows/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workflows/README.md
@@ -54,8 +54,6 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, Params> {
 
 ## Further Reading
 
-- [configuration.md](./configuration.md) - wrangler.toml, step config
-- [api.md](./api.md) - Step APIs, instance management
 - [patterns.md](./patterns.md) - Common workflows, orchestration
 - [gotchas.md](./gotchas.md) - Timeouts, limits, debugging
 

--- a/.agents/services/hosting/cloudflare-platform/references/workflows/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workflows/gotchas.md
@@ -144,4 +144,4 @@ export class MyWorkflow extends WorkflowEntrypoint<Env, MyParams> {
 - [Limits](https://developers.cloudflare.com/workflows/reference/limits/)
 - [Pricing](https://developers.cloudflare.com/workflows/reference/pricing/)
 
-See: [README.md](./README.md), [configuration.md](./configuration.md), [api.md](./api.md), [patterns.md](./patterns.md)
+See: [README.md](./README.md), [patterns.md](./patterns.md)

--- a/.agents/services/hosting/cloudflare-platform/references/workflows/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/workflows/patterns.md
@@ -133,4 +133,4 @@ export class DailyWorkflow extends WorkflowEntrypoint<Env, Params> {
 }
 ```
 
-See: [configuration.md](./configuration.md), [api.md](./api.md), [gotchas.md](./gotchas.md)
+See: [gotchas.md](./gotchas.md)

--- a/.agents/services/hosting/cloudflare-platform/references/wrangler/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/wrangler/README.md
@@ -91,7 +91,5 @@ wrangler tail --status error      # Filter by status
 
 ## In This Reference
 
-- [configuration.md](./configuration.md) - wrangler.jsonc setup, environments, bindings
-- [api.md](./api.md) - Programmatic API (`unstable_startWorker`, `getPlatformProxy`)
 - [patterns.md](./patterns.md) - Common workflows and development patterns
 - [gotchas.md](./gotchas.md) - Common pitfalls, limits, and troubleshooting

--- a/.agents/services/hosting/cloudflare-platform/references/wrangler/gotchas.md
+++ b/.agents/services/hosting/cloudflare-platform/references/wrangler/gotchas.md
@@ -104,6 +104,4 @@ wrangler dev --persist-to ./local-state  # Custom persist location
 ## See Also
 
 - [README.md](./README.md) - Commands
-- [configuration.md](./configuration.md) - Config
-- [api.md](./api.md) - Programmatic API
 - [patterns.md](./patterns.md) - Workflows

--- a/.agents/services/hosting/cloudflare-platform/references/wrangler/patterns.md
+++ b/.agents/services/hosting/cloudflare-platform/references/wrangler/patterns.md
@@ -146,6 +146,4 @@ return new Response(data, {
 ## See Also
 
 - [README.md](./README.md) - Commands
-- [configuration.md](./configuration.md) - Config
-- [api.md](./api.md) - Programmatic API
 - [gotchas.md](./gotchas.md) - Issues

--- a/.agents/tools/context/dspyground.md
+++ b/.agents/tools/context/dspyground.md
@@ -369,8 +369,6 @@ DSPyGround complements other AI DevOps Framework components:
 - **Documentation**: Generate optimized technical writing prompts
 - **Monitoring**: Develop prompts for alert analysis and response
 
-## 🔗 **Related Documentation**
+## Related Documentation
 
-- [DSPy Integration Guide](./DSPY-INTEGRATION.md) - Core DSPy framework integration
 - [AI DevOps Framework Overview](../README.md) - Main framework documentation
-- [MCP Integrations](./MCP-INTEGRATIONS.md) - Model Context Protocol integrations


### PR DESCRIPTION
## Summary

- Removes 132 broken relative links across 74 documentation files
- `./configuration.md` and `./api.md` were referenced in Cloudflare platform reference docs but never existed
- Also fixes broken links in `dspyground.md` (`./DSPY-INTEGRATION.md`, `./MCP-INTEGRATIONS.md`) and `workers-for-platforms/patterns.md` (`./api.md#static-assets`)
- All 144 remaining relative links verified to resolve to existing files

## Approach

Removed broken link references rather than creating 100+ stub files. The content these files would have covered is already partially present in each reference directory's README.md. Lines referencing only broken targets were deleted; mixed lines (with both broken and valid links) were edited to retain only the valid links.

Closes #2412