### PR TITLE
chore: exclude archived code from lint/CI checks

### DIFF
--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -42,14 +42,16 @@ print_header() {
 }
 
 # Collect all shell scripts to lint, including modularised subdirectories
-# (e.g. memory/, supervisor-modules/, setup/) but excluding _archive/.
+# (e.g. memory/, supervisor-modules/, setup/) but excluding archived code.
+# Excludes: _archive/, archived/, supervisor-archived/ — these are versioned
+# for reference but not actively maintained (reduces lint noise).
 # Also includes setup-modules/ and setup.sh from the repo root.
 # Populates the ALL_SH_FILES array for use by check functions.
 collect_shell_files() {
 	ALL_SH_FILES=()
 	while IFS= read -r -d '' f; do
 		ALL_SH_FILES+=("$f")
-	done < <(find .agents/scripts -name "*.sh" -not -path "*/_archive/*" -print0 2>/dev/null | sort -z)
+	done < <(find .agents/scripts -name "*.sh" -not -path "*/_archive/*" -not -path "*/archived/*" -not -path "*/supervisor-archived/*" -print0 2>/dev/null | sort -z)
 
 	# Include setup-modules/ (extracted setup.sh modules) if present
 	while IFS= read -r -d '' f; do

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -112,6 +112,8 @@ jobs:
         echo "Validating shell scripts with ShellCheck..."
         errors=0
 
+        # Exclude archived code from lint — these are versioned for reference
+        # but not actively maintained. Reduces noise-to-signal ratio in CI.
         while IFS= read -r file; do
           if shellcheck -S error "$file" > /dev/null 2>&1; then
             echo "OK $file"
@@ -120,7 +122,7 @@ jobs:
             shellcheck -S error -f gcc "$file" 2>&1
             errors=$((errors + 1))
           fi
-        done < <(git ls-files '*.sh')
+        done < <(git ls-files '*.sh' | grep -v 'archived/')
 
         if [ "$errors" -gt 0 ]; then
           echo ""

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,7 +14,8 @@ sonar.sources=.agents,configs,templates
 sonar.sourceEncoding=UTF-8
 
 # Exclusions - files and directories to exclude from analysis
-sonar.exclusions=**/*.txt,**/tmp/**,**/logs/**,.git/**,**/*.json
+# Archived code is versioned for reference but not actively maintained
+sonar.exclusions=**/*.txt,**/tmp/**,**/logs/**,.git/**,**/*.json,**/archived/**,**/supervisor-archived/**
 
 # Coverage exclusions (shell scripts, docs, and example files don't have traditional coverage)
 sonar.coverage.exclusions=**/*.sh,**/*.md,**/*.json,**/*.yml,**/*.yaml,configs/**/*.py,**/example*.py,**/*-example.py


### PR DESCRIPTION
## Summary

Reduces lint/CI noise-to-signal ratio by excluding `archived/` and `supervisor-archived/` directories from all quality checks.

**Problem**: 46 archived scripts (54K lines, 12.6% of all shell scripts) are versioned for reference but not actively maintained. Including them in lint checks inflates issue counts and makes it harder to catch real issues in active code.

**Changes**:
- **CI** (`code-quality.yml`): Filter archived paths from ShellCheck step via `grep -v 'archived/'`
- **Local linters** (`linters-local.sh`): Add `-not -path` exclusions to `collect_shell_files()` for `archived/` and `supervisor-archived/`
- **SonarCloud** (`sonar-project.properties`): Add `**/archived/**` and `**/supervisor-archived/**` to `sonar.exclusions`

Archived code remains versioned in git for reference — this only removes it from quality gate checks.

Closes #2413