### PR TITLE
#2433: Fix session-miner-pulse.sh 'File: unbound variable' crash

### DIFF
--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -55,6 +55,8 @@ check_lock() {
 		# Cross-platform file mtime: Linux (stat -c) first, macOS (stat -f) fallback
 		local lock_mtime
 		lock_mtime=$(stat -c %Y "${LOCK_FILE}" 2>/dev/null || stat -f %m "${LOCK_FILE}" 2>/dev/null || echo 0)
+		# Guard: ensure numeric (stat -f on Linux produces multi-line text, not a number)
+		[[ "${lock_mtime}" =~ ^[0-9]+$ ]] || lock_mtime=0
 		lock_age=$(($(date +%s) - lock_mtime))
 		# Stale lock (>1 hour)
 		if [[ "${lock_age}" -gt 3600 ]]; then
@@ -275,6 +277,8 @@ main() {
 	local db_size
 	# Cross-platform file size: Linux (stat -c) first, macOS (stat -f) fallback
 	db_size=$(stat -c %s "${db_path}" 2>/dev/null || stat -f %z "${db_path}" 2>/dev/null || echo 0)
+	# Guard: ensure numeric (stat -f on Linux produces multi-line text, not a number)
+	[[ "${db_size}" =~ ^[0-9]+$ ]] || db_size=0
 	if [[ "${db_size}" -lt 1000 ]]; then
 		log_info "Database too small (${db_size} bytes). Nothing to mine."
 		release_lock


### PR DESCRIPTION
## Summary

- Adds numeric validation guards after `stat` output in `session-miner-pulse.sh` to prevent `set -u` crash when `stat -f` on Linux produces multi-line filesystem text instead of a number
- Guards both `lock_mtime` (line 57) and `db_size` (line 277) with `[[ "${var}" =~ ^[0-9]+$ ]] || var=0`

## Root Cause

On Linux, `stat -f %z <file>` is a **filesystem** stat (not file stat). It outputs multi-line text including `File: "/path"` to stdout and exits 0. With `set -u`, when this garbage value is used in arithmetic (`-lt`), bash interprets `File:` as a variable reference and crashes with `File: unbound variable`.

The `stat -c || stat -f || echo 0` chain from PR #2428 handles the platform difference (Linux uses `-c`, macOS uses `-f`), but doesn't protect against the case where `stat -c` is unavailable and `stat -f` produces non-numeric output. The numeric guard is a defense-in-depth fix.

## Verification

Reproduced the exact crash on Linux and confirmed the fix:

```bash
# Before fix: crashes
$ bash -c 'set -euo pipefail; db_size=$(stat -f %z /tmp 2>/dev/null || echo 0); [[ "${db_size}" -lt 1000 ]]'
bash: line 1: File: unbound variable

# After fix: works
$ bash -c 'set -euo pipefail; db_size=$(stat -f %z /tmp 2>/dev/null || echo 0); [[ "${db_size}" =~ ^[0-9]+$ ]] || db_size=0; [[ "${db_size}" -lt 1000 ]] && echo small'
small
```

ShellCheck: zero violations.

Closes #2433