### PR TITLE
refactor: consolidate duplicate utility functions across codebase (#2411)

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -36,28 +36,12 @@ SCAN_RESULTS_FILE=".agents/SKILL-SCAN-RESULTS.md"
 # Helper Functions
 # =============================================================================
 
-log_info() {
-    echo -e "${BLUE}[add-skill]${NC} $1"
-    return 0
-}
-
-log_success() {
-    echo -e "${GREEN}[OK]${NC} $1"
-    return 0
-}
-
-log_warning() {
-    echo -e "${YELLOW}[WARN]${NC} $1"
-    return 0
-}
-
-log_error() {
-    echo -e "${RED}[ERROR]${NC} $1"
-    return 0
-}
+# Logging: uses shared log_* from shared-constants.sh with add-skill prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="add-skill"
 
 show_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 Add External Skill Helper - Import skills from GitHub or ClawdHub to aidevops
 
 USAGE:
@@ -108,115 +92,115 @@ SUPPORTED FORMATS:
 The skill will be converted to aidevops format and placed in .agents/
 with symlinks created to other AI assistant locations by setup.sh.
 EOF
-    return 0
+	return 0
 }
 
 # Ensure skill-sources.json exists
 ensure_skill_sources() {
-    if [[ ! -f "$SKILL_SOURCES" ]]; then
-        mkdir -p "$(dirname "$SKILL_SOURCES")"
-        # shellcheck disable=SC2016 # Single quotes intentional - $schema/$comment are JSON keys, not variables
-        echo '{
+	if [[ ! -f "$SKILL_SOURCES" ]]; then
+		mkdir -p "$(dirname "$SKILL_SOURCES")"
+		# shellcheck disable=SC2016 # Single quotes intentional - $schema/$comment are JSON keys, not variables
+		echo '{
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$comment": "Registry of imported external skills with upstream tracking",
   "version": "1.0.0",
   "skills": []
-}' > "$SKILL_SOURCES"
-    fi
-    return 0
+}' >"$SKILL_SOURCES"
+	fi
+	return 0
 }
 
 # Parse GitHub URL or shorthand into components
 parse_github_url() {
-    local input="$1"
-    local owner=""
-    local repo=""
-    local subpath=""
-    
-    # Remove https://github.com/ prefix if present
-    input="${input#https://github.com/}"
-    input="${input#http://github.com/}"
-    input="${input#github.com/}"
-    
-    # Remove .git suffix if present
-    input="${input%.git}"
-    
-    # Remove /tree/main or /tree/master if present (use bash instead of sed for portability)
-    if [[ "$input" =~ ^(.+)/tree/(main|master)(/.*)?$ ]]; then
-        input="${BASH_REMATCH[1]}${BASH_REMATCH[3]}"
-    fi
-    
-    # Split by /
-    local -a parts
-    IFS='/' read -ra parts <<< "$input"
-    
-    if [[ ${#parts[@]} -ge 2 ]]; then
-        owner="${parts[0]}"
-        repo="${parts[1]}"
-        
-        # Everything after owner/repo is subpath
-        if [[ ${#parts[@]} -gt 2 ]]; then
-            # Join remaining parts with / using printf
-            subpath=$(printf '%s/' "${parts[@]:2}")
-            subpath="${subpath%/}"  # Remove trailing slash
-        fi
-    fi
-    
-    echo "$owner|$repo|$subpath"
-    return 0
+	local input="$1"
+	local owner=""
+	local repo=""
+	local subpath=""
+
+	# Remove https://github.com/ prefix if present
+	input="${input#https://github.com/}"
+	input="${input#http://github.com/}"
+	input="${input#github.com/}"
+
+	# Remove .git suffix if present
+	input="${input%.git}"
+
+	# Remove /tree/main or /tree/master if present (use bash instead of sed for portability)
+	if [[ "$input" =~ ^(.+)/tree/(main|master)(/.*)?$ ]]; then
+		input="${BASH_REMATCH[1]}${BASH_REMATCH[3]}"
+	fi
+
+	# Split by /
+	local -a parts
+	IFS='/' read -ra parts <<<"$input"
+
+	if [[ ${#parts[@]} -ge 2 ]]; then
+		owner="${parts[0]}"
+		repo="${parts[1]}"
+
+		# Everything after owner/repo is subpath
+		if [[ ${#parts[@]} -gt 2 ]]; then
+			# Join remaining parts with / using printf
+			subpath=$(printf '%s/' "${parts[@]:2}")
+			subpath="${subpath%/}" # Remove trailing slash
+		fi
+	fi
+
+	echo "$owner|$repo|$subpath"
+	return 0
 }
 
 # Detect skill format from directory contents
 # Returns: format|skill_subdir (e.g., "skill-md-nested|skill/cloudflare")
 detect_format() {
-    local dir="$1"
-    
-    # Check for direct SKILL.md first
-    if [[ -f "$dir/SKILL.md" ]]; then
-        echo "skill-md|"
-        return 0
-    fi
-    
-    # Check for nested skill directory (e.g., skill/*/SKILL.md)
-    local nested_skill
-    nested_skill=$(find "$dir" -maxdepth 3 -name "SKILL.md" -type f 2>/dev/null | head -1)
-    if [[ -n "$nested_skill" ]]; then
-        local skill_subdir
-        skill_subdir=$(dirname "$nested_skill")
-        skill_subdir="${skill_subdir#"$dir/"}"
-        echo "skill-md-nested|$skill_subdir"
-        return 0
-    fi
-    
-    if [[ -f "$dir/AGENTS.md" ]]; then
-        echo "agents-md|"
-    elif [[ -f "$dir/.cursorrules" ]]; then
-        echo "cursorrules|"
-    elif [[ -f "$dir/README.md" ]]; then
-        echo "readme|"
-    else
-        # Look for any .md file
-        local md_file
-        md_file=$(find "$dir" -maxdepth 1 -name "*.md" -type f | head -1)
-        if [[ -n "$md_file" ]]; then
-            echo "markdown|"
-        else
-            echo "unknown|"
-        fi
-    fi
-    return 0
+	local dir="$1"
+
+	# Check for direct SKILL.md first
+	if [[ -f "$dir/SKILL.md" ]]; then
+		echo "skill-md|"
+		return 0
+	fi
+
+	# Check for nested skill directory (e.g., skill/*/SKILL.md)
+	local nested_skill
+	nested_skill=$(find "$dir" -maxdepth 3 -name "SKILL.md" -type f 2>/dev/null | head -1)
+	if [[ -n "$nested_skill" ]]; then
+		local skill_subdir
+		skill_subdir=$(dirname "$nested_skill")
+		skill_subdir="${skill_subdir#"$dir/"}"
+		echo "skill-md-nested|$skill_subdir"
+		return 0
+	fi
+
+	if [[ -f "$dir/AGENTS.md" ]]; then
+		echo "agents-md|"
+	elif [[ -f "$dir/.cursorrules" ]]; then
+		echo "cursorrules|"
+	elif [[ -f "$dir/README.md" ]]; then
+		echo "readme|"
+	else
+		# Look for any .md file
+		local md_file
+		md_file=$(find "$dir" -maxdepth 1 -name "*.md" -type f | head -1)
+		if [[ -n "$md_file" ]]; then
+			echo "markdown|"
+		else
+			echo "unknown|"
+		fi
+	fi
+	return 0
 }
 
 # Extract skill name from SKILL.md frontmatter
 extract_skill_name() {
-    local file="$1"
-    
-    if [[ ! -f "$file" ]]; then
-        return 1
-    fi
-    
-    # Extract name from YAML frontmatter
-    awk '
+	local file="$1"
+
+	if [[ ! -f "$file" ]]; then
+		return 1
+	fi
+
+	# Extract name from YAML frontmatter
+	awk '
         /^---$/ { in_frontmatter = !in_frontmatter; next }
         in_frontmatter && /^name:/ {
             sub(/^name: */, "")
@@ -225,18 +209,18 @@ extract_skill_name() {
             exit
         }
     ' "$file"
-    return 0
+	return 0
 }
 
 # Extract description from SKILL.md frontmatter
 extract_skill_description() {
-    local file="$1"
-    
-    if [[ ! -f "$file" ]]; then
-        return 1
-    fi
-    
-    awk '
+	local file="$1"
+
+	if [[ ! -f "$file" ]]; then
+		return 1
+	fi
+
+	awk '
         /^---$/ { in_frontmatter = !in_frontmatter; next }
         in_frontmatter && /^description:/ {
             sub(/^description: */, "")
@@ -245,150 +229,150 @@ extract_skill_description() {
             exit
         }
     ' "$file"
-    return 0
+	return 0
 }
 
 # Convert skill name to kebab-case
 to_kebab_case() {
-    local name="$1"
-    echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g'
-    return 0
+	local name="$1"
+	echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g'
+	return 0
 }
 
 # Determine target path in .agents/ based on skill content
 determine_target_path() {
-    local skill_name="$1"
-    local _description="$2"  # Reserved for future category detection
-    local source_dir="$3"
-    
-    # Analyze content to determine category
-    local category="tools"
-    
-    # Check description and content for category hints
-    local content=""
-    if [[ -f "$source_dir/SKILL.md" ]]; then
-        content=$(cat "$source_dir/SKILL.md")
-    elif [[ -f "$source_dir/AGENTS.md" ]]; then
-        content=$(cat "$source_dir/AGENTS.md")
-    fi
-    
-    # Detect category from content (order matters - more specific patterns first)
-    # Check skill name first for known services
-    if [[ "$skill_name" == "cloudflare"* ]]; then
-        category="services/hosting"
-    elif echo "$content" | grep -qi "cloudflare workers\|cloudflare pages\|wrangler"; then
-        category="services/hosting"
-    # Architecture patterns (must come before generic patterns)
-    elif echo "$content" | grep -qi "clean.architecture\|hexagonal\|ddd\|domain.driven\|ports.and.adapters\|onion.architecture\|cqrs\|event.sourcing"; then
-        category="tools/architecture"
-    elif echo "$content" | grep -qi "feature.sliced\|feature-sliced\|fsd.architecture\|slice.organization"; then
-        category="tools/architecture"
-    # Database and ORM
-    elif echo "$content" | grep -qi "postgresql\|postgres\|drizzle\|prisma\|typeorm\|sequelize\|knex\|database.orm"; then
-        category="services/database"
-    # Diagrams and visualization
-    elif echo "$content" | grep -qi "mermaid\|diagram\|flowchart\|sequence.diagram\|er.diagram\|uml"; then
-        category="tools/diagrams"
-    # Programming languages (specific patterns)
-    elif echo "$content" | grep -qi "javascript\|typescript\|es6\|es2020\|es2022\|es2024\|ecmascript\|modern.js"; then
-        category="tools/programming"
-    elif echo "$content" | grep -qi "browser\|playwright\|puppeteer\|selenium"; then
-        category="tools/browser"
-    elif echo "$content" | grep -qi "seo\|search.ranking\|keyword.research"; then
-        category="seo"
-    elif echo "$content" | grep -qi "git\|github\|gitlab"; then
-        category="tools/git"
-    elif echo "$content" | grep -qi "code.review\|lint\|quality"; then
-        category="tools/code-review"
-    elif echo "$content" | grep -qi "credential\|secret\|password\|vault"; then
-        category="tools/credentials"
-    elif echo "$content" | grep -qi "vercel\|coolify\|docker\|kubernetes"; then
-        category="tools/deployment"
-    elif echo "$content" | grep -qi "proxmox\|hypervisor\|virtualization\|vm.management"; then
-        category="services/hosting"
-    elif echo "$content" | grep -qi "calendar\|caldav\|ical\|scheduling"; then
-        category="tools/productivity"
-    elif echo "$content" | grep -qi "dns\|hosting\|domain"; then
-        category="services/hosting"
-    fi
-    
-    # Append -skill suffix to distinguish imported skills from native subagents
-    # This enables: glob *-skill.md for imports, update checks, conflict avoidance
-    echo "$category/${skill_name}-skill"
-    return 0
+	local skill_name="$1"
+	local _description="$2" # Reserved for future category detection
+	local source_dir="$3"
+
+	# Analyze content to determine category
+	local category="tools"
+
+	# Check description and content for category hints
+	local content=""
+	if [[ -f "$source_dir/SKILL.md" ]]; then
+		content=$(cat "$source_dir/SKILL.md")
+	elif [[ -f "$source_dir/AGENTS.md" ]]; then
+		content=$(cat "$source_dir/AGENTS.md")
+	fi
+
+	# Detect category from content (order matters - more specific patterns first)
+	# Check skill name first for known services
+	if [[ "$skill_name" == "cloudflare"* ]]; then
+		category="services/hosting"
+	elif echo "$content" | grep -qi "cloudflare workers\|cloudflare pages\|wrangler"; then
+		category="services/hosting"
+	# Architecture patterns (must come before generic patterns)
+	elif echo "$content" | grep -qi "clean.architecture\|hexagonal\|ddd\|domain.driven\|ports.and.adapters\|onion.architecture\|cqrs\|event.sourcing"; then
+		category="tools/architecture"
+	elif echo "$content" | grep -qi "feature.sliced\|feature-sliced\|fsd.architecture\|slice.organization"; then
+		category="tools/architecture"
+	# Database and ORM
+	elif echo "$content" | grep -qi "postgresql\|postgres\|drizzle\|prisma\|typeorm\|sequelize\|knex\|database.orm"; then
+		category="services/database"
+	# Diagrams and visualization
+	elif echo "$content" | grep -qi "mermaid\|diagram\|flowchart\|sequence.diagram\|er.diagram\|uml"; then
+		category="tools/diagrams"
+	# Programming languages (specific patterns)
+	elif echo "$content" | grep -qi "javascript\|typescript\|es6\|es2020\|es2022\|es2024\|ecmascript\|modern.js"; then
+		category="tools/programming"
+	elif echo "$content" | grep -qi "browser\|playwright\|puppeteer\|selenium"; then
+		category="tools/browser"
+	elif echo "$content" | grep -qi "seo\|search.ranking\|keyword.research"; then
+		category="seo"
+	elif echo "$content" | grep -qi "git\|github\|gitlab"; then
+		category="tools/git"
+	elif echo "$content" | grep -qi "code.review\|lint\|quality"; then
+		category="tools/code-review"
+	elif echo "$content" | grep -qi "credential\|secret\|password\|vault"; then
+		category="tools/credentials"
+	elif echo "$content" | grep -qi "vercel\|coolify\|docker\|kubernetes"; then
+		category="tools/deployment"
+	elif echo "$content" | grep -qi "proxmox\|hypervisor\|virtualization\|vm.management"; then
+		category="services/hosting"
+	elif echo "$content" | grep -qi "calendar\|caldav\|ical\|scheduling"; then
+		category="tools/productivity"
+	elif echo "$content" | grep -qi "dns\|hosting\|domain"; then
+		category="services/hosting"
+	fi
+
+	# Append -skill suffix to distinguish imported skills from native subagents
+	# This enables: glob *-skill.md for imports, update checks, conflict avoidance
+	echo "$category/${skill_name}-skill"
+	return 0
 }
 
 # Check for conflicts with existing files
 # Returns conflict info with type: NATIVE (our subagent) or IMPORTED (previous skill)
 check_conflicts() {
-    local target_path="$1"
-    local agent_dir="$2"
-    
-    local full_path="$agent_dir/$target_path"
-    local md_path="${full_path}.md"
-    local dir_path="$full_path"
-    
-    local conflicts=()
-    
-    if [[ -f "$md_path" ]]; then
-        if [[ "$md_path" == *-skill.md ]]; then
-            conflicts+=("IMPORTED: $md_path")
-        else
-            conflicts+=("NATIVE: $md_path")
-        fi
-    fi
-    
-    if [[ -d "$dir_path" ]]; then
-        if [[ "$dir_path" == *-skill ]]; then
-            conflicts+=("IMPORTED: $dir_path/")
-        else
-            conflicts+=("NATIVE: $dir_path/")
-        fi
-    fi
-    
-    # Also check for native subagent without -skill suffix (same base name)
-    local base_name="${target_path%-skill}"
-    local native_md="${agent_dir}/${base_name}.md"
-    if [[ "$target_path" == *-skill && -f "$native_md" ]]; then
-        # Native subagent exists with same base name - not a conflict since
-        # -skill suffix differentiates, but inform the user
-        conflicts+=("INFO: Native subagent exists at $native_md (no conflict, -skill suffix differentiates)")
-    fi
-    
-    if [[ ${#conflicts[@]} -gt 0 ]]; then
-        printf '%s\n' "${conflicts[@]}"
-        return 1
-    fi
-    
-    return 0
+	local target_path="$1"
+	local agent_dir="$2"
+
+	local full_path="$agent_dir/$target_path"
+	local md_path="${full_path}.md"
+	local dir_path="$full_path"
+
+	local conflicts=()
+
+	if [[ -f "$md_path" ]]; then
+		if [[ "$md_path" == *-skill.md ]]; then
+			conflicts+=("IMPORTED: $md_path")
+		else
+			conflicts+=("NATIVE: $md_path")
+		fi
+	fi
+
+	if [[ -d "$dir_path" ]]; then
+		if [[ "$dir_path" == *-skill ]]; then
+			conflicts+=("IMPORTED: $dir_path/")
+		else
+			conflicts+=("NATIVE: $dir_path/")
+		fi
+	fi
+
+	# Also check for native subagent without -skill suffix (same base name)
+	local base_name="${target_path%-skill}"
+	local native_md="${agent_dir}/${base_name}.md"
+	if [[ "$target_path" == *-skill && -f "$native_md" ]]; then
+		# Native subagent exists with same base name - not a conflict since
+		# -skill suffix differentiates, but inform the user
+		conflicts+=("INFO: Native subagent exists at $native_md (no conflict, -skill suffix differentiates)")
+	fi
+
+	if [[ ${#conflicts[@]} -gt 0 ]]; then
+		printf '%s\n' "${conflicts[@]}"
+		return 1
+	fi
+
+	return 0
 }
 
 # Convert SKILL.md to aidevops format
 convert_skill_md() {
-    local source_file="$1"
-    local target_file="$2"
-    local skill_name="$3"
-    
-    # Read source content
-    local content
-    content=$(cat "$source_file")
-    
-    # Extract frontmatter
-    local name
-    local description
-    name=$(extract_skill_name "$source_file")
-    description=$(extract_skill_description "$source_file")
-    
-    # Escape YAML special characters in description
-    local safe_description
-    safe_description=$(printf '%s' "${description:-Imported skill}" | sed 's/\\/\\\\/g; s/"/\\"/g; s/:/: /g; s/^- /\\- /')
-    
-    # Escape name for markdown heading
-    local safe_name
-    safe_name=$(printf '%s' "${name:-$skill_name}" | sed 's/\\/\\\\/g')
-    
-    # Create aidevops-style header with properly quoted description
-    cat > "$target_file" << EOF
+	local source_file="$1"
+	local target_file="$2"
+	local skill_name="$3"
+
+	# Read source content
+	local content
+	content=$(cat "$source_file")
+
+	# Extract frontmatter
+	local name
+	local description
+	name=$(extract_skill_name "$source_file")
+	description=$(extract_skill_description "$source_file")
+
+	# Escape YAML special characters in description
+	local safe_description
+	safe_description=$(printf '%s' "${description:-Imported skill}" | sed 's/\\/\\\\/g; s/"/\\"/g; s/:/: /g; s/^- /\\- /')
+
+	# Escape name for markdown heading
+	local safe_name
+	safe_name=$(printf '%s' "${name:-$skill_name}" | sed 's/\\/\\\\/g')
+
+	# Create aidevops-style header with properly quoted description
+	cat >"$target_file" <<EOF
 ---
 description: "${safe_description}"
 mode: subagent
@@ -397,68 +381,69 @@ imported_from: external
 # ${safe_name}
 
 EOF
-    
-    # Append content after frontmatter
-    awk '
+
+	# Append content after frontmatter
+	awk '
         BEGIN { in_frontmatter = 0; after_frontmatter = 0 }
         /^---$/ { 
             if (!in_frontmatter) { in_frontmatter = 1; next }
             else { in_frontmatter = 0; after_frontmatter = 1; next }
         }
         after_frontmatter { print }
-    ' "$source_file" >> "$target_file"
-    
-    return 0
+    ' "$source_file" >>"$target_file"
+
+	return 0
 }
 
 # Register skill in skill-sources.json
 register_skill() {
-    local name="$1"
-    local upstream_url="$2"
-    local local_path="$3"
-    local format="$4"
-    local commit="${5:-}"
-    local merge_strategy="${6:-added}"
-    local notes="${7:-}"
-    
-    ensure_skill_sources
-    
-    # jq is required for reliable JSON manipulation
-    if ! command -v jq &>/dev/null; then
-        log_error "jq is required to update $SKILL_SOURCES"
-        log_info "Install with: brew install jq (macOS) or apt install jq (Linux)"
-        return 1
-    fi
-    
-    # Check for existing entry and remove it (update scenario)
-    local existing
-    existing=$(jq -r --arg name "$name" '.skills[] | select(.name == $name) | .name' "$SKILL_SOURCES" 2>/dev/null || echo "")
-    if [[ -n "$existing" ]]; then
-        log_info "Updating existing skill registration: $name"
-        local tmp_file
-        tmp_file=$(mktemp)
-        _save_cleanup_scope; trap '_run_cleanups' RETURN
-        push_cleanup "rm -f '${tmp_file}'"
-        jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" > "$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
-        rm -f "$tmp_file"
-    fi
-    
-    local timestamp
-    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    
-    # Create new skill entry using jq for proper JSON escaping
-    local new_entry
-    new_entry=$(jq -n \
-        --arg name "$name" \
-        --arg upstream_url "$upstream_url" \
-        --arg upstream_commit "$commit" \
-        --arg local_path "$local_path" \
-        --arg format_detected "$format" \
-        --arg imported_at "$timestamp" \
-        --arg last_checked "$timestamp" \
-        --arg merge_strategy "$merge_strategy" \
-        --arg notes "$notes" \
-        '{
+	local name="$1"
+	local upstream_url="$2"
+	local local_path="$3"
+	local format="$4"
+	local commit="${5:-}"
+	local merge_strategy="${6:-added}"
+	local notes="${7:-}"
+
+	ensure_skill_sources
+
+	# jq is required for reliable JSON manipulation
+	if ! command -v jq &>/dev/null; then
+		log_error "jq is required to update $SKILL_SOURCES"
+		log_info "Install with: brew install jq (macOS) or apt install jq (Linux)"
+		return 1
+	fi
+
+	# Check for existing entry and remove it (update scenario)
+	local existing
+	existing=$(jq -r --arg name "$name" '.skills[] | select(.name == $name) | .name' "$SKILL_SOURCES" 2>/dev/null || echo "")
+	if [[ -n "$existing" ]]; then
+		log_info "Updating existing skill registration: $name"
+		local tmp_file
+		tmp_file=$(mktemp)
+		_save_cleanup_scope
+		trap '_run_cleanups' RETURN
+		push_cleanup "rm -f '${tmp_file}'"
+		jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" >"$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
+		rm -f "$tmp_file"
+	fi
+
+	local timestamp
+	timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	# Create new skill entry using jq for proper JSON escaping
+	local new_entry
+	new_entry=$(jq -n \
+		--arg name "$name" \
+		--arg upstream_url "$upstream_url" \
+		--arg upstream_commit "$commit" \
+		--arg local_path "$local_path" \
+		--arg format_detected "$format" \
+		--arg imported_at "$timestamp" \
+		--arg last_checked "$timestamp" \
+		--arg merge_strategy "$merge_strategy" \
+		--arg notes "$notes" \
+		'{
             name: $name,
             upstream_url: $upstream_url,
             upstream_commit: $upstream_commit,
@@ -469,13 +454,13 @@ register_skill() {
             merge_strategy: $merge_strategy,
             notes: $notes
         }')
-    
-    local tmp_file
-    tmp_file=$(mktemp)
-    jq --argjson entry "$new_entry" '.skills += [$entry]' "$SKILL_SOURCES" > "$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
-    rm -f "$tmp_file"
-    
-    return 0
+
+	local tmp_file
+	tmp_file=$(mktemp)
+	jq --argjson entry "$new_entry" '.skills += [$entry]' "$SKILL_SOURCES" >"$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
+	rm -f "$tmp_file"
+
+	return 0
 }
 
 # =============================================================================
@@ -485,170 +470,170 @@ register_skill() {
 # Scan a skill directory for security threats using Cisco Skill Scanner
 # Returns: 0 = safe or scanner not available, 1 = blocked (CRITICAL/HIGH found)
 scan_skill_security() {
-    local scan_path="$1"
-    local skill_name="$2"
-    local skip_security="${3:-false}"
-    
-    # Determine scanner command
-    local scanner_cmd=""
-    if command -v skill-scanner &>/dev/null; then
-        scanner_cmd="skill-scanner"
-    elif command -v uvx &>/dev/null; then
-        scanner_cmd="uvx cisco-ai-skill-scanner"
-    elif command -v pipx &>/dev/null; then
-        scanner_cmd="pipx run cisco-ai-skill-scanner"
-    else
-        log_info "Skill Scanner not installed (skipping security scan)"
-        log_info "Install with: uv tool install cisco-ai-skill-scanner"
-        return 0
-    fi
-    
-    log_info "Running security scan on '$skill_name'..."
-    
-    local scan_output
-    scan_output=$($scanner_cmd scan "$scan_path" --format json 2>/dev/null) || true
-    
-    if [[ -z "$scan_output" ]]; then
-        log_success "Security scan: SAFE (no findings)"
-        log_skill_scan_result "$skill_name" "import" "0" "0" "0" "SAFE"
-        return 0
-    fi
-    
-    local findings max_severity critical_count high_count medium_count
-    findings=$(echo "$scan_output" | jq -r '.total_findings // 0' 2>/dev/null || echo "0")
-    max_severity=$(echo "$scan_output" | jq -r '.max_severity // "SAFE"' 2>/dev/null || echo "SAFE")
-    critical_count=$(echo "$scan_output" | jq -r '.findings | map(select(.severity == "CRITICAL")) | length' 2>/dev/null || echo "0")
-    high_count=$(echo "$scan_output" | jq -r '.findings | map(select(.severity == "HIGH")) | length' 2>/dev/null || echo "0")
-    medium_count=$(echo "$scan_output" | jq -r '.findings | map(select(.severity == "MEDIUM")) | length' 2>/dev/null || echo "0")
-    
-    if [[ "$findings" -eq 0 ]]; then
-        log_success "Security scan: SAFE (no findings)"
-        log_skill_scan_result "$skill_name" "import" "0" "0" "0" "SAFE"
-        return 0
-    fi
-    
-    # Show findings summary
-    echo ""
-    echo -e "${YELLOW}Security scan found $findings issue(s) (max severity: $max_severity):${NC}"
-    
-    # Show individual findings
-    echo "$scan_output" | jq -r '.findings[]? | "  [\(.severity)] \(.rule_id): \(.description // "No description")"' 2>/dev/null || true
-    echo ""
-    
-    # Block on CRITICAL/HIGH unless --skip-security
-    if [[ "$critical_count" -gt 0 || "$high_count" -gt 0 ]]; then
-        if [[ "$skip_security" == true ]]; then
-            log_warning "CRITICAL/HIGH findings detected but --skip-security specified, proceeding"
-            log_skill_scan_result "$skill_name" "import (--skip-security)" "$critical_count" "$high_count" "$medium_count" "$max_severity"
-            return 0
-        fi
-        
-        echo -e "${RED}BLOCKED: $critical_count CRITICAL and $high_count HIGH severity findings.${NC}"
-        echo ""
-        echo "This skill may contain:"
-        echo "  - Prompt injection or jailbreak instructions"
-        echo "  - Data exfiltration patterns"
-        echo "  - Command injection or malicious code"
-        echo "  - Hardcoded secrets or credentials"
-        echo ""
-        echo "Options:"
-        echo "  1. Cancel import (recommended)"
-        echo "  2. Import anyway (--skip-security)"
-        echo ""
-        
-        # In non-interactive mode (piped), block by default
-        if [[ ! -t 0 ]]; then
-            log_error "Import blocked due to security findings (use --skip-security to override)"
-            return 1
-        fi
-        
-        read -rp "Choose option [1-2]: " choice
-        case "$choice" in
-            2)
-                log_warning "Proceeding despite security findings"
-                log_skill_scan_result "$skill_name" "import (user override)" "$critical_count" "$high_count" "$medium_count" "$max_severity"
-                return 0
-                ;;
-            *)
-                log_error "Import cancelled due to security findings"
-                log_skill_scan_result "$skill_name" "import BLOCKED" "$critical_count" "$high_count" "$medium_count" "$max_severity"
-                return 1
-                ;;
-        esac
-    fi
-    
-    # MEDIUM/LOW findings: warn but allow
-    log_warning "Security scan found $findings issue(s) (max: $max_severity) - review recommended"
-    log_skill_scan_result "$skill_name" "import" "$critical_count" "$high_count" "$medium_count" "$max_severity"
-    return 0
+	local scan_path="$1"
+	local skill_name="$2"
+	local skip_security="${3:-false}"
+
+	# Determine scanner command
+	local scanner_cmd=""
+	if command -v skill-scanner &>/dev/null; then
+		scanner_cmd="skill-scanner"
+	elif command -v uvx &>/dev/null; then
+		scanner_cmd="uvx cisco-ai-skill-scanner"
+	elif command -v pipx &>/dev/null; then
+		scanner_cmd="pipx run cisco-ai-skill-scanner"
+	else
+		log_info "Skill Scanner not installed (skipping security scan)"
+		log_info "Install with: uv tool install cisco-ai-skill-scanner"
+		return 0
+	fi
+
+	log_info "Running security scan on '$skill_name'..."
+
+	local scan_output
+	scan_output=$($scanner_cmd scan "$scan_path" --format json 2>/dev/null) || true
+
+	if [[ -z "$scan_output" ]]; then
+		log_success "Security scan: SAFE (no findings)"
+		log_skill_scan_result "$skill_name" "import" "0" "0" "0" "SAFE"
+		return 0
+	fi
+
+	local findings max_severity critical_count high_count medium_count
+	findings=$(echo "$scan_output" | jq -r '.total_findings // 0' 2>/dev/null || echo "0")
+	max_severity=$(echo "$scan_output" | jq -r '.max_severity // "SAFE"' 2>/dev/null || echo "SAFE")
+	critical_count=$(echo "$scan_output" | jq -r '.findings | map(select(.severity == "CRITICAL")) | length' 2>/dev/null || echo "0")
+	high_count=$(echo "$scan_output" | jq -r '.findings | map(select(.severity == "HIGH")) | length' 2>/dev/null || echo "0")
+	medium_count=$(echo "$scan_output" | jq -r '.findings | map(select(.severity == "MEDIUM")) | length' 2>/dev/null || echo "0")
+
+	if [[ "$findings" -eq 0 ]]; then
+		log_success "Security scan: SAFE (no findings)"
+		log_skill_scan_result "$skill_name" "import" "0" "0" "0" "SAFE"
+		return 0
+	fi
+
+	# Show findings summary
+	echo ""
+	echo -e "${YELLOW}Security scan found $findings issue(s) (max severity: $max_severity):${NC}"
+
+	# Show individual findings
+	echo "$scan_output" | jq -r '.findings[]? | "  [\(.severity)] \(.rule_id): \(.description // "No description")"' 2>/dev/null || true
+	echo ""
+
+	# Block on CRITICAL/HIGH unless --skip-security
+	if [[ "$critical_count" -gt 0 || "$high_count" -gt 0 ]]; then
+		if [[ "$skip_security" == true ]]; then
+			log_warning "CRITICAL/HIGH findings detected but --skip-security specified, proceeding"
+			log_skill_scan_result "$skill_name" "import (--skip-security)" "$critical_count" "$high_count" "$medium_count" "$max_severity"
+			return 0
+		fi
+
+		echo -e "${RED}BLOCKED: $critical_count CRITICAL and $high_count HIGH severity findings.${NC}"
+		echo ""
+		echo "This skill may contain:"
+		echo "  - Prompt injection or jailbreak instructions"
+		echo "  - Data exfiltration patterns"
+		echo "  - Command injection or malicious code"
+		echo "  - Hardcoded secrets or credentials"
+		echo ""
+		echo "Options:"
+		echo "  1. Cancel import (recommended)"
+		echo "  2. Import anyway (--skip-security)"
+		echo ""
+
+		# In non-interactive mode (piped), block by default
+		if [[ ! -t 0 ]]; then
+			log_error "Import blocked due to security findings (use --skip-security to override)"
+			return 1
+		fi
+
+		read -rp "Choose option [1-2]: " choice
+		case "$choice" in
+		2)
+			log_warning "Proceeding despite security findings"
+			log_skill_scan_result "$skill_name" "import (user override)" "$critical_count" "$high_count" "$medium_count" "$max_severity"
+			return 0
+			;;
+		*)
+			log_error "Import cancelled due to security findings"
+			log_skill_scan_result "$skill_name" "import BLOCKED" "$critical_count" "$high_count" "$medium_count" "$max_severity"
+			return 1
+			;;
+		esac
+	fi
+
+	# MEDIUM/LOW findings: warn but allow
+	log_warning "Security scan found $findings issue(s) (max: $max_severity) - review recommended"
+	log_skill_scan_result "$skill_name" "import" "$critical_count" "$high_count" "$medium_count" "$max_severity"
+	return 0
 }
 
 # Run VirusTotal scan on skill files and referenced domains
 # Returns: 0 (always, as VT scans are advisory; Cisco scanner is the gate)
 scan_skill_virustotal() {
-    local scan_path="$1"
-    local skill_name="$2"
-    local skip_security="${3:-false}"
-    
-    if [[ "$skip_security" == true ]]; then
-        return 0
-    fi
-    
-    # Check if virustotal-helper.sh is available
-    local vt_helper=""
-    vt_helper="$(dirname "$0")/virustotal-helper.sh"
-    if [[ ! -x "$vt_helper" ]]; then
-        return 0
-    fi
-    
-    # Check if VT API key is configured (don't fail if not)
-    if ! "$vt_helper" status 2>/dev/null | grep -q "API key configured"; then
-        log_info "VirusTotal: API key not configured (skipping VT scan)"
-        return 0
-    fi
-    
-    log_info "Running VirusTotal scan on '$skill_name'..."
-    
-    if ! "$vt_helper" scan-skill "$scan_path" --quiet; then
-        log_warning "VirusTotal flagged potential threats in '$skill_name'"
-        log_info "Run: $vt_helper scan-skill '$scan_path' for details"
-        # VT findings are advisory, not blocking (Cisco scanner is the gate)
-        return 0
-    fi
-    
-    log_success "VirusTotal: No threats detected"
-    return 0
+	local scan_path="$1"
+	local skill_name="$2"
+	local skip_security="${3:-false}"
+
+	if [[ "$skip_security" == true ]]; then
+		return 0
+	fi
+
+	# Check if virustotal-helper.sh is available
+	local vt_helper=""
+	vt_helper="$(dirname "$0")/virustotal-helper.sh"
+	if [[ ! -x "$vt_helper" ]]; then
+		return 0
+	fi
+
+	# Check if VT API key is configured (don't fail if not)
+	if ! "$vt_helper" status 2>/dev/null | grep -q "API key configured"; then
+		log_info "VirusTotal: API key not configured (skipping VT scan)"
+		return 0
+	fi
+
+	log_info "Running VirusTotal scan on '$skill_name'..."
+
+	if ! "$vt_helper" scan-skill "$scan_path" --quiet; then
+		log_warning "VirusTotal flagged potential threats in '$skill_name'"
+		log_info "Run: $vt_helper scan-skill '$scan_path' for details"
+		# VT findings are advisory, not blocking (Cisco scanner is the gate)
+		return 0
+	fi
+
+	log_success "VirusTotal: No threats detected"
+	return 0
 }
 
 # Log a single skill scan result to SKILL-SCAN-RESULTS.md
 # Args: skill_name action critical_count high_count medium_count max_severity
 log_skill_scan_result() {
-    local skill_name="$1"
-    local action="$2"
-    local critical="${3:-0}"
-    local high="${4:-0}"
-    local medium="${5:-0}"
-    local max_severity="${6:-SAFE}"
-    
-    local repo_root=""
-    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
-    
-    if [[ -z "$repo_root" || ! -f "${repo_root}/${SCAN_RESULTS_FILE}" ]]; then
-        return 0
-    fi
-    
-    local scan_date
-    scan_date=$(date -u +"%Y-%m-%d")
-    local safe="1"
-    
-    if [[ "$critical" -gt 0 || "$high" -gt 0 ]]; then
-        safe="0"
-    fi
-    
-    local notes="Skill ${action}: ${skill_name} (${max_severity})"
-    echo "| ${scan_date} | 1 | ${safe} | ${critical} | ${high} | ${medium} | ${notes} |" >> "${repo_root}/${SCAN_RESULTS_FILE}"
-    
-    return 0
+	local skill_name="$1"
+	local action="$2"
+	local critical="${3:-0}"
+	local high="${4:-0}"
+	local medium="${5:-0}"
+	local max_severity="${6:-SAFE}"
+
+	local repo_root=""
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+
+	if [[ -z "$repo_root" || ! -f "${repo_root}/${SCAN_RESULTS_FILE}" ]]; then
+		return 0
+	fi
+
+	local scan_date
+	scan_date=$(date -u +"%Y-%m-%d")
+	local safe="1"
+
+	if [[ "$critical" -gt 0 || "$high" -gt 0 ]]; then
+		safe="0"
+	fi
+
+	local notes="Skill ${action}: ${skill_name} (${max_severity})"
+	echo "| ${scan_date} | 1 | ${safe} | ${critical} | ${high} | ${medium} | ${notes} |" >>"${repo_root}/${SCAN_RESULTS_FILE}"
+
+	return 0
 }
 
 # =============================================================================
@@ -656,442 +641,445 @@ log_skill_scan_result() {
 # =============================================================================
 
 cmd_add() {
-    local url="$1"
-    shift
-    
-    local custom_name=""
-    local force=false
-    local dry_run=false
-    local skip_security=false
-    
-    # Parse options using named variable for clarity (S7679)
-    local opt
-    while [[ $# -gt 0 ]]; do
-        opt="$1"
-        case "$opt" in
-            --name)
-                custom_name="$2"
-                shift 2
-                ;;
-            --force)
-                force=true
-                shift
-                ;;
-            --skip-security)
-                skip_security=true
-                shift
-                ;;
-            --dry-run)
-                dry_run=true
-                shift
-                ;;
-            *)
-                log_error "Unknown option: $opt"
-                return 1
-                ;;
-        esac
-    done
-    
-    log_info "Parsing source: $url"
-    
-    # Detect ClawdHub source (clawdhub:slug or clawdhub.com URL)
-    local is_clawdhub=false
-    local clawdhub_slug=""
-    
-    if [[ "$url" == clawdhub:* ]]; then
-        is_clawdhub=true
-        clawdhub_slug="${url#clawdhub:}"
-    elif [[ "$url" == *clawdhub.com* ]]; then
-        is_clawdhub=true
-        # Strip URL prefix and extract slug (last path segment)
-        clawdhub_slug="${url#*clawdhub.com/}"
-        clawdhub_slug="${clawdhub_slug#/}"
-        clawdhub_slug="${clawdhub_slug%/}"
-        # If format is owner/slug, take just the slug
-        if [[ "$clawdhub_slug" == */* ]]; then
-            clawdhub_slug="${clawdhub_slug##*/}"
-        fi
-    fi
-    
-    if [[ "$is_clawdhub" == true ]]; then
-        cmd_add_clawdhub "$clawdhub_slug" "$custom_name" "$force" "$dry_run" "$skip_security"
-        return $?
-    fi
-    
-    # Parse GitHub URL
-    local parsed owner repo subpath
-    parsed=$(parse_github_url "$url")
-    IFS='|' read -r owner repo subpath <<< "$parsed"
-    
-    if [[ -z "$owner" || -z "$repo" ]]; then
-        log_error "Could not parse source URL: $url"
-        log_info "Expected: owner/repo, https://github.com/owner/repo, or clawdhub:slug"
-        return 1
-    fi
-    
-    log_info "Owner: $owner, Repo: $repo, Subpath: ${subpath:-<root>}"
-    
-    # Create temp directory
-    rm -rf "$TEMP_DIR"
-    mkdir -p "$TEMP_DIR"
-    
-    # Try to use openskills if available
-    if command -v openskills &>/dev/null; then
-        log_info "Using openskills to fetch skill..."
-        if openskills install "$owner/$repo${subpath:+/$subpath}" --yes --universal 2>/dev/null; then
-            log_success "Skill installed via openskills"
-            # openskills handles everything, just register it
-            local skill_name="${custom_name:-$(basename "${subpath:-$repo}")}"
-            skill_name=$(to_kebab_case "$skill_name")
-            # openskills installs to ~/.config/opencode/skills/<name>/SKILL.md
-            # Register with -skill suffix for consistency with direct imports
-            register_skill "$skill_name" "https://github.com/$owner/$repo" ".agents/skills/${skill_name}-skill.md" "skill-md" "" "openskills" "Installed via openskills CLI"
-            return 0
-        fi
-        log_warning "openskills failed, falling back to direct fetch"
-    fi
-    
-    # Clone repository
-    log_info "Cloning repository..."
-    local clone_url="https://github.com/$owner/$repo.git"
-    
-    if ! git clone --depth 1 "$clone_url" "$TEMP_DIR/repo" 2>/dev/null; then
-        log_error "Failed to clone repository: $clone_url"
-        return 1
-    fi
-    
-    # Navigate to subpath if specified
-    local source_dir="$TEMP_DIR/repo"
-    if [[ -n "$subpath" ]]; then
-        source_dir="$TEMP_DIR/repo/$subpath"
-        if [[ ! -d "$source_dir" ]]; then
-            log_error "Subpath not found: $subpath"
-            return 1
-        fi
-    fi
-    
-    # Detect format (returns format|skill_subdir)
-    local format_result skill_subdir format
-    format_result=$(detect_format "$source_dir")
-    IFS='|' read -r format skill_subdir <<< "$format_result"
-    log_info "Detected format: $format"
-    
-    # For nested skills, update source_dir to point to the skill directory
-    local skill_source_dir="$source_dir"
-    if [[ "$format" == "skill-md-nested" && -n "$skill_subdir" ]]; then
-        skill_source_dir="$source_dir/$skill_subdir"
-        log_info "Found nested skill at: $skill_subdir"
-    fi
-    
-    # Determine skill name
-    local skill_name=""
-    if [[ -n "$custom_name" ]]; then
-        skill_name=$(to_kebab_case "$custom_name")
-    elif [[ "$format" == "skill-md" || "$format" == "skill-md-nested" ]]; then
-        skill_name=$(extract_skill_name "$skill_source_dir/SKILL.md")
-        skill_name=$(to_kebab_case "${skill_name:-$(basename "${subpath:-$repo}")}")
-    else
-        skill_name=$(to_kebab_case "$(basename "${subpath:-$repo}")")
-    fi
-    
-    log_info "Skill name: $skill_name"
-    
-    # Get description
-    local description=""
-    if [[ "$format" == "skill-md" || "$format" == "skill-md-nested" ]]; then
-        description=$(extract_skill_description "$skill_source_dir/SKILL.md")
-    fi
-    
-    # Determine target path
-    local target_path
-    target_path=$(determine_target_path "$skill_name" "$description" "$skill_source_dir")
-    log_info "Target path: .agents/$target_path"
-    
-    # Check for conflicts (check_conflicts returns 1 when conflicts exist)
-    local conflicts
-    conflicts=$(check_conflicts "$target_path" ".agent") || true
-    if [[ -n "$conflicts" ]]; then
-        # Filter out INFO lines (informational, not blocking)
-        local blocking_conflicts
-        blocking_conflicts=$(echo "$conflicts" | grep -v "^INFO:" || true)
-        local info_lines
-        info_lines=$(echo "$conflicts" | grep "^INFO:" || true)
-        
-        # Show info lines (native subagent coexistence)
-        if [[ -n "$info_lines" ]]; then
-            echo "$info_lines" | while read -r info; do
-                log_info "${info#INFO: }"
-            done
-        fi
-        
-        # Handle blocking conflicts
-        if [[ -n "$blocking_conflicts" && "$force" != true ]]; then
-            # Determine conflict type for better messaging
-            if echo "$blocking_conflicts" | grep -q "^NATIVE:"; then
-                log_warning "Conflicts with native aidevops subagent(s):"
-                echo "$blocking_conflicts" | while read -r conflict; do
-                    echo "  - ${conflict#NATIVE: }"
-                done
-                echo ""
-                echo "The -skill suffix should prevent this. If you see this,"
-                echo "the imported skill has the same name as a native subagent."
-                echo ""
-            elif echo "$blocking_conflicts" | grep -q "^IMPORTED:"; then
-                log_warning "Conflicts with previously imported skill(s):"
-                echo "$blocking_conflicts" | while read -r conflict; do
-                    echo "  - ${conflict#IMPORTED: }"
-                done
-                echo ""
-            else
-                log_warning "Conflicts detected:"
-                echo "$blocking_conflicts" | while read -r conflict; do
-                    echo "  - $conflict"
-                done
-                echo ""
-            fi
-            
-            echo "Options:"
-            echo "  1. Replace (overwrite existing)"
-            echo "  2. Separate (use different name)"
-            echo "  3. Skip (cancel import)"
-            echo ""
-            read -rp "Choose option [1-3]: " choice
-            
-            local new_name
-            case "$choice" in
-                1)
-                    log_info "Replacing existing..."
-                    ;;
-                2)
-                    read -rp "Enter new name: " new_name
-                    skill_name=$(to_kebab_case "$new_name")
-                    target_path=$(determine_target_path "$skill_name" "$description" "$source_dir")
-                    ;;
-                3|*)
-                    log_info "Import cancelled"
-                    return 0
-                    ;;
-            esac
-        fi
-    fi
-    
-    if [[ "$dry_run" == true ]]; then
-        log_info "DRY RUN - Would create:"
-        echo "  .agents/${target_path}.md"
-        if [[ -d "$skill_source_dir/scripts" || -d "$skill_source_dir/references" ]]; then
-            echo "  .agents/${target_path}/"
-        fi
-        return 0
-    fi
-    
-    # Create target directory
-    local target_dir
-    target_dir=".agents/$(dirname "$target_path")"
-    mkdir -p "$target_dir"
-    
-    # Convert and copy files
-    local target_file=".agents/${target_path}.md"
-    
-    case "$format" in
-        skill-md|skill-md-nested)
-            convert_skill_md "$skill_source_dir/SKILL.md" "$target_file" "$skill_name"
-            ;;
-        agents-md)
-            cp "$source_dir/AGENTS.md" "$target_file"
-            ;;
-        cursorrules)
-            # Convert .cursorrules to markdown
-            {
-                echo "---"
-                echo "description: Imported from .cursorrules"
-                echo "mode: subagent"
-                echo "imported_from: cursorrules"
-                echo "---"
-                echo "# $skill_name"
-                echo ""
-                cat "$source_dir/.cursorrules"
-            } > "$target_file"
-            ;;
-        *)
-            # Copy first markdown file found
-            local md_file
-            md_file=$(find "$source_dir" -maxdepth 1 -name "*.md" -type f | head -1)
-            if [[ -n "$md_file" ]]; then
-                cp "$md_file" "$target_file"
-            else
-                log_error "No suitable files found to import"
-                return 1
-            fi
-            ;;
-    esac
-    
-    log_success "Created: $target_file"
-    
-    # Copy additional resources (scripts, references, assets)
-    for resource_dir in scripts references assets; do
-        if [[ -d "$skill_source_dir/$resource_dir" ]]; then
-            local target_resource_dir=".agents/${target_path}/$resource_dir"
-            mkdir -p "$target_resource_dir"
-            cp -r "$skill_source_dir/$resource_dir/"* "$target_resource_dir/" 2>/dev/null || true
-            log_success "Copied: $resource_dir/"
-        fi
-    done
-    
-    # Security scan before registration (scan the source directory which has full context)
-    if ! scan_skill_security "$skill_source_dir" "$skill_name" "$skip_security"; then
-        # Clean up the partially imported files
-        rm -f "$target_file"
-        local skill_resource_dir=".agents/${target_path}"
-        [[ -d "$skill_resource_dir" ]] && rm -rf "$skill_resource_dir"
-        rm -rf "$TEMP_DIR"
-        return 1
-    fi
-    
-    # VirusTotal scan (advisory, non-blocking -- runs after Cisco scanner gate)
-    scan_skill_virustotal "$skill_source_dir" "$skill_name" "$skip_security"
-    
-    # Get commit hash for tracking
-    local commit_hash=""
-    if [[ -d "$TEMP_DIR/repo/.git" ]]; then
-        commit_hash=$(git -C "$TEMP_DIR/repo" rev-parse HEAD 2>/dev/null || echo "")
-    fi
-    
-    # Register in skill-sources.json
-    register_skill "$skill_name" "https://github.com/$owner/$repo${subpath:+/$subpath}" ".agents/${target_path}.md" "$format" "$commit_hash" "added" ""
-    
-    log_success "Skill '$skill_name' imported successfully"
-    
-    # Cleanup
-    rm -rf "$TEMP_DIR"
-    
-    # Remind about setup.sh
-    echo ""
-    log_info "Run './setup.sh' to create symlinks for other AI assistants"
-    
-    return 0
+	local url="$1"
+	shift
+
+	local custom_name=""
+	local force=false
+	local dry_run=false
+	local skip_security=false
+
+	# Parse options using named variable for clarity (S7679)
+	local opt
+	while [[ $# -gt 0 ]]; do
+		opt="$1"
+		case "$opt" in
+		--name)
+			custom_name="$2"
+			shift 2
+			;;
+		--force)
+			force=true
+			shift
+			;;
+		--skip-security)
+			skip_security=true
+			shift
+			;;
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		*)
+			log_error "Unknown option: $opt"
+			return 1
+			;;
+		esac
+	done
+
+	log_info "Parsing source: $url"
+
+	# Detect ClawdHub source (clawdhub:slug or clawdhub.com URL)
+	local is_clawdhub=false
+	local clawdhub_slug=""
+
+	if [[ "$url" == clawdhub:* ]]; then
+		is_clawdhub=true
+		clawdhub_slug="${url#clawdhub:}"
+	elif [[ "$url" == *clawdhub.com* ]]; then
+		is_clawdhub=true
+		# Strip URL prefix and extract slug (last path segment)
+		clawdhub_slug="${url#*clawdhub.com/}"
+		clawdhub_slug="${clawdhub_slug#/}"
+		clawdhub_slug="${clawdhub_slug%/}"
+		# If format is owner/slug, take just the slug
+		if [[ "$clawdhub_slug" == */* ]]; then
+			clawdhub_slug="${clawdhub_slug##*/}"
+		fi
+	fi
+
+	if [[ "$is_clawdhub" == true ]]; then
+		cmd_add_clawdhub "$clawdhub_slug" "$custom_name" "$force" "$dry_run" "$skip_security"
+		return $?
+	fi
+
+	# Parse GitHub URL
+	local parsed owner repo subpath
+	parsed=$(parse_github_url "$url")
+	IFS='|' read -r owner repo subpath <<<"$parsed"
+
+	if [[ -z "$owner" || -z "$repo" ]]; then
+		log_error "Could not parse source URL: $url"
+		log_info "Expected: owner/repo, https://github.com/owner/repo, or clawdhub:slug"
+		return 1
+	fi
+
+	log_info "Owner: $owner, Repo: $repo, Subpath: ${subpath:-<root>}"
+
+	# Create temp directory
+	rm -rf "$TEMP_DIR"
+	mkdir -p "$TEMP_DIR"
+
+	# Try to use openskills if available
+	if command -v openskills &>/dev/null; then
+		log_info "Using openskills to fetch skill..."
+		if openskills install "$owner/$repo${subpath:+/$subpath}" --yes --universal 2>/dev/null; then
+			log_success "Skill installed via openskills"
+			# openskills handles everything, just register it
+			local skill_name="${custom_name:-$(basename "${subpath:-$repo}")}"
+			skill_name=$(to_kebab_case "$skill_name")
+			# openskills installs to ~/.config/opencode/skills/<name>/SKILL.md
+			# Register with -skill suffix for consistency with direct imports
+			register_skill "$skill_name" "https://github.com/$owner/$repo" ".agents/skills/${skill_name}-skill.md" "skill-md" "" "openskills" "Installed via openskills CLI"
+			return 0
+		fi
+		log_warning "openskills failed, falling back to direct fetch"
+	fi
+
+	# Clone repository
+	log_info "Cloning repository..."
+	local clone_url="https://github.com/$owner/$repo.git"
+
+	if ! git clone --depth 1 "$clone_url" "$TEMP_DIR/repo" 2>/dev/null; then
+		log_error "Failed to clone repository: $clone_url"
+		return 1
+	fi
+
+	# Navigate to subpath if specified
+	local source_dir="$TEMP_DIR/repo"
+	if [[ -n "$subpath" ]]; then
+		source_dir="$TEMP_DIR/repo/$subpath"
+		if [[ ! -d "$source_dir" ]]; then
+			log_error "Subpath not found: $subpath"
+			return 1
+		fi
+	fi
+
+	# Detect format (returns format|skill_subdir)
+	local format_result skill_subdir format
+	format_result=$(detect_format "$source_dir")
+	IFS='|' read -r format skill_subdir <<<"$format_result"
+	log_info "Detected format: $format"
+
+	# For nested skills, update source_dir to point to the skill directory
+	local skill_source_dir="$source_dir"
+	if [[ "$format" == "skill-md-nested" && -n "$skill_subdir" ]]; then
+		skill_source_dir="$source_dir/$skill_subdir"
+		log_info "Found nested skill at: $skill_subdir"
+	fi
+
+	# Determine skill name
+	local skill_name=""
+	if [[ -n "$custom_name" ]]; then
+		skill_name=$(to_kebab_case "$custom_name")
+	elif [[ "$format" == "skill-md" || "$format" == "skill-md-nested" ]]; then
+		skill_name=$(extract_skill_name "$skill_source_dir/SKILL.md")
+		skill_name=$(to_kebab_case "${skill_name:-$(basename "${subpath:-$repo}")}")
+	else
+		skill_name=$(to_kebab_case "$(basename "${subpath:-$repo}")")
+	fi
+
+	log_info "Skill name: $skill_name"
+
+	# Get description
+	local description=""
+	if [[ "$format" == "skill-md" || "$format" == "skill-md-nested" ]]; then
+		description=$(extract_skill_description "$skill_source_dir/SKILL.md")
+	fi
+
+	# Determine target path
+	local target_path
+	target_path=$(determine_target_path "$skill_name" "$description" "$skill_source_dir")
+	log_info "Target path: .agents/$target_path"
+
+	# Check for conflicts (check_conflicts returns 1 when conflicts exist)
+	local conflicts
+	conflicts=$(check_conflicts "$target_path" ".agent") || true
+	if [[ -n "$conflicts" ]]; then
+		# Filter out INFO lines (informational, not blocking)
+		local blocking_conflicts
+		blocking_conflicts=$(echo "$conflicts" | grep -v "^INFO:" || true)
+		local info_lines
+		info_lines=$(echo "$conflicts" | grep "^INFO:" || true)
+
+		# Show info lines (native subagent coexistence)
+		if [[ -n "$info_lines" ]]; then
+			echo "$info_lines" | while read -r info; do
+				log_info "${info#INFO: }"
+			done
+		fi
+
+		# Handle blocking conflicts
+		if [[ -n "$blocking_conflicts" && "$force" != true ]]; then
+			# Determine conflict type for better messaging
+			if echo "$blocking_conflicts" | grep -q "^NATIVE:"; then
+				log_warning "Conflicts with native aidevops subagent(s):"
+				echo "$blocking_conflicts" | while read -r conflict; do
+					echo "  - ${conflict#NATIVE: }"
+				done
+				echo ""
+				echo "The -skill suffix should prevent this. If you see this,"
+				echo "the imported skill has the same name as a native subagent."
+				echo ""
+			elif echo "$blocking_conflicts" | grep -q "^IMPORTED:"; then
+				log_warning "Conflicts with previously imported skill(s):"
+				echo "$blocking_conflicts" | while read -r conflict; do
+					echo "  - ${conflict#IMPORTED: }"
+				done
+				echo ""
+			else
+				log_warning "Conflicts detected:"
+				echo "$blocking_conflicts" | while read -r conflict; do
+					echo "  - $conflict"
+				done
+				echo ""
+			fi
+
+			echo "Options:"
+			echo "  1. Replace (overwrite existing)"
+			echo "  2. Separate (use different name)"
+			echo "  3. Skip (cancel import)"
+			echo ""
+			read -rp "Choose option [1-3]: " choice
+
+			local new_name
+			case "$choice" in
+			1)
+				log_info "Replacing existing..."
+				;;
+			2)
+				read -rp "Enter new name: " new_name
+				skill_name=$(to_kebab_case "$new_name")
+				target_path=$(determine_target_path "$skill_name" "$description" "$source_dir")
+				;;
+			3 | *)
+				log_info "Import cancelled"
+				return 0
+				;;
+			esac
+		fi
+	fi
+
+	if [[ "$dry_run" == true ]]; then
+		log_info "DRY RUN - Would create:"
+		echo "  .agents/${target_path}.md"
+		if [[ -d "$skill_source_dir/scripts" || -d "$skill_source_dir/references" ]]; then
+			echo "  .agents/${target_path}/"
+		fi
+		return 0
+	fi
+
+	# Create target directory
+	local target_dir
+	target_dir=".agents/$(dirname "$target_path")"
+	mkdir -p "$target_dir"
+
+	# Convert and copy files
+	local target_file=".agents/${target_path}.md"
+
+	case "$format" in
+	skill-md | skill-md-nested)
+		convert_skill_md "$skill_source_dir/SKILL.md" "$target_file" "$skill_name"
+		;;
+	agents-md)
+		cp "$source_dir/AGENTS.md" "$target_file"
+		;;
+	cursorrules)
+		# Convert .cursorrules to markdown
+		{
+			echo "---"
+			echo "description: Imported from .cursorrules"
+			echo "mode: subagent"
+			echo "imported_from: cursorrules"
+			echo "---"
+			echo "# $skill_name"
+			echo ""
+			cat "$source_dir/.cursorrules"
+		} >"$target_file"
+		;;
+	*)
+		# Copy first markdown file found
+		local md_file
+		md_file=$(find "$source_dir" -maxdepth 1 -name "*.md" -type f | head -1)
+		if [[ -n "$md_file" ]]; then
+			cp "$md_file" "$target_file"
+		else
+			log_error "No suitable files found to import"
+			return 1
+		fi
+		;;
+	esac
+
+	log_success "Created: $target_file"
+
+	# Copy additional resources (scripts, references, assets)
+	for resource_dir in scripts references assets; do
+		if [[ -d "$skill_source_dir/$resource_dir" ]]; then
+			local target_resource_dir=".agents/${target_path}/$resource_dir"
+			mkdir -p "$target_resource_dir"
+			cp -r "$skill_source_dir/$resource_dir/"* "$target_resource_dir/" 2>/dev/null || true
+			log_success "Copied: $resource_dir/"
+		fi
+	done
+
+	# Security scan before registration (scan the source directory which has full context)
+	if ! scan_skill_security "$skill_source_dir" "$skill_name" "$skip_security"; then
+		# Clean up the partially imported files
+		rm -f "$target_file"
+		local skill_resource_dir=".agents/${target_path}"
+		[[ -d "$skill_resource_dir" ]] && rm -rf "$skill_resource_dir"
+		rm -rf "$TEMP_DIR"
+		return 1
+	fi
+
+	# VirusTotal scan (advisory, non-blocking -- runs after Cisco scanner gate)
+	scan_skill_virustotal "$skill_source_dir" "$skill_name" "$skip_security"
+
+	# Get commit hash for tracking
+	local commit_hash=""
+	if [[ -d "$TEMP_DIR/repo/.git" ]]; then
+		commit_hash=$(git -C "$TEMP_DIR/repo" rev-parse HEAD 2>/dev/null || echo "")
+	fi
+
+	# Register in skill-sources.json
+	register_skill "$skill_name" "https://github.com/$owner/$repo${subpath:+/$subpath}" ".agents/${target_path}.md" "$format" "$commit_hash" "added" ""
+
+	log_success "Skill '$skill_name' imported successfully"
+
+	# Cleanup
+	rm -rf "$TEMP_DIR"
+
+	# Remind about setup.sh
+	echo ""
+	log_info "Run './setup.sh' to create symlinks for other AI assistants"
+
+	return 0
 }
 
 # Import a skill from ClawdHub registry
 cmd_add_clawdhub() {
-    local slug="$1"
-    local custom_name="$2"
-    local force="$3"
-    local dry_run="$4"
-    local skip_security="${5:-false}"
-    
-    if [[ -z "$slug" ]]; then
-        log_error "ClawdHub slug required"
-        return 1
-    fi
-    
-    log_info "Importing from ClawdHub: $slug"
-    
-    # Get skill metadata from API
-    local api_response
-    api_response=$(curl -s --connect-timeout 10 --max-time 30 "${CLAWDHUB_API:-https://clawdhub.com/api/v1}/skills/${slug}" 2>/dev/null)
-    
-    if [[ -z "$api_response" ]] || ! echo "$api_response" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
-        log_error "Could not fetch skill info from ClawdHub API: $slug"
-        return 1
-    fi
-    
-    # Extract metadata
-    local display_name summary owner_handle version
-    display_name=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('skill',{}).get('displayName',''))" 2>/dev/null)
-    summary=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('skill',{}).get('summary',''))" 2>/dev/null)
-    owner_handle=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('owner',{}).get('handle',''))" 2>/dev/null)
-    version=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('latestVersion',{}).get('version',''))" 2>/dev/null)
-    
-    log_info "Found: $display_name v${version} by @${owner_handle}"
-    
-    # Determine skill name
-    local skill_name
-    if [[ -n "$custom_name" ]]; then
-        skill_name=$(to_kebab_case "$custom_name")
-    else
-        skill_name=$(to_kebab_case "$slug")
-    fi
-    
-    # Determine target path
-    local target_path
-    target_path=$(determine_target_path "$skill_name" "$summary" ".")
-    log_info "Target path: .agents/$target_path"
-    
-    # Check for conflicts
-    local conflicts
-    conflicts=$(check_conflicts "$target_path" ".agent") || true
-    if [[ -n "$conflicts" ]]; then
-        local blocking_conflicts
-        blocking_conflicts=$(echo "$conflicts" | grep -v "^INFO:" || true)
-        
-        if [[ -n "$blocking_conflicts" && "$force" != true ]]; then
-            log_warning "Conflicts detected:"
-            echo "$blocking_conflicts" | while read -r conflict; do
-                echo "  - ${conflict#*: }"
-            done
-            echo ""
-            echo "Options:"
-            echo "  1. Replace (overwrite existing)"
-            echo "  2. Separate (use different name)"
-            echo "  3. Skip (cancel import)"
-            echo ""
-            read -rp "Choose option [1-3]: " choice
-            
-            local new_name
-            case "$choice" in
-                1) log_info "Replacing existing..." ;;
-                2)
-                    read -rp "Enter new name: " new_name
-                    skill_name=$(to_kebab_case "$new_name")
-                    target_path=$(determine_target_path "$skill_name" "$summary" ".")
-                    ;;
-                3|*) log_info "Import cancelled"; return 0 ;;
-            esac
-        fi
-    fi
-    
-    if [[ "$dry_run" == true ]]; then
-        log_info "DRY RUN - Would create:"
-        echo "  .agents/${target_path}.md"
-        return 0
-    fi
-    
-    # Fetch SKILL.md content using clawdhub-helper.sh (Playwright-based)
-    local helper_script
-    helper_script="$(dirname "$0")/clawdhub-helper.sh"
-    local fetch_dir="${TMPDIR:-/tmp}/clawdhub-fetch/${slug}"
-    
-    rm -rf "$fetch_dir"
-    
-    if [[ -x "$helper_script" ]]; then
-        if ! "$helper_script" fetch "$slug" --output "$fetch_dir"; then
-            log_error "Failed to fetch SKILL.md from ClawdHub"
-            return 1
-        fi
-    else
-        log_error "clawdhub-helper.sh not found at: $helper_script"
-        return 1
-    fi
-    
-    # Verify SKILL.md was fetched
-    if [[ ! -f "$fetch_dir/SKILL.md" || ! -s "$fetch_dir/SKILL.md" ]]; then
-        log_error "SKILL.md not found or empty after fetch"
-        return 1
-    fi
-    
-    # Create target directory
-    local target_dir
-    target_dir=".agents/$(dirname "$target_path")"
-    mkdir -p "$target_dir"
-    
-    # Convert to aidevops format
-    local target_file=".agents/${target_path}.md"
-    
-    # Write aidevops-style header
-    local safe_summary
-    safe_summary=$(printf '%s' "${summary:-Imported from ClawdHub}" | sed 's/\\/\\\\/g; s/"/\\"/g')
-    
-    cat > "$target_file" << EOF
+	local slug="$1"
+	local custom_name="$2"
+	local force="$3"
+	local dry_run="$4"
+	local skip_security="${5:-false}"
+
+	if [[ -z "$slug" ]]; then
+		log_error "ClawdHub slug required"
+		return 1
+	fi
+
+	log_info "Importing from ClawdHub: $slug"
+
+	# Get skill metadata from API
+	local api_response
+	api_response=$(curl -s --connect-timeout 10 --max-time 30 "${CLAWDHUB_API:-https://clawdhub.com/api/v1}/skills/${slug}" 2>/dev/null)
+
+	if [[ -z "$api_response" ]] || ! echo "$api_response" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+		log_error "Could not fetch skill info from ClawdHub API: $slug"
+		return 1
+	fi
+
+	# Extract metadata
+	local display_name summary owner_handle version
+	display_name=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('skill',{}).get('displayName',''))" 2>/dev/null)
+	summary=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('skill',{}).get('summary',''))" 2>/dev/null)
+	owner_handle=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('owner',{}).get('handle',''))" 2>/dev/null)
+	version=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('latestVersion',{}).get('version',''))" 2>/dev/null)
+
+	log_info "Found: $display_name v${version} by @${owner_handle}"
+
+	# Determine skill name
+	local skill_name
+	if [[ -n "$custom_name" ]]; then
+		skill_name=$(to_kebab_case "$custom_name")
+	else
+		skill_name=$(to_kebab_case "$slug")
+	fi
+
+	# Determine target path
+	local target_path
+	target_path=$(determine_target_path "$skill_name" "$summary" ".")
+	log_info "Target path: .agents/$target_path"
+
+	# Check for conflicts
+	local conflicts
+	conflicts=$(check_conflicts "$target_path" ".agent") || true
+	if [[ -n "$conflicts" ]]; then
+		local blocking_conflicts
+		blocking_conflicts=$(echo "$conflicts" | grep -v "^INFO:" || true)
+
+		if [[ -n "$blocking_conflicts" && "$force" != true ]]; then
+			log_warning "Conflicts detected:"
+			echo "$blocking_conflicts" | while read -r conflict; do
+				echo "  - ${conflict#*: }"
+			done
+			echo ""
+			echo "Options:"
+			echo "  1. Replace (overwrite existing)"
+			echo "  2. Separate (use different name)"
+			echo "  3. Skip (cancel import)"
+			echo ""
+			read -rp "Choose option [1-3]: " choice
+
+			local new_name
+			case "$choice" in
+			1) log_info "Replacing existing..." ;;
+			2)
+				read -rp "Enter new name: " new_name
+				skill_name=$(to_kebab_case "$new_name")
+				target_path=$(determine_target_path "$skill_name" "$summary" ".")
+				;;
+			3 | *)
+				log_info "Import cancelled"
+				return 0
+				;;
+			esac
+		fi
+	fi
+
+	if [[ "$dry_run" == true ]]; then
+		log_info "DRY RUN - Would create:"
+		echo "  .agents/${target_path}.md"
+		return 0
+	fi
+
+	# Fetch SKILL.md content using clawdhub-helper.sh (Playwright-based)
+	local helper_script
+	helper_script="$(dirname "$0")/clawdhub-helper.sh"
+	local fetch_dir="${TMPDIR:-/tmp}/clawdhub-fetch/${slug}"
+
+	rm -rf "$fetch_dir"
+
+	if [[ -x "$helper_script" ]]; then
+		if ! "$helper_script" fetch "$slug" --output "$fetch_dir"; then
+			log_error "Failed to fetch SKILL.md from ClawdHub"
+			return 1
+		fi
+	else
+		log_error "clawdhub-helper.sh not found at: $helper_script"
+		return 1
+	fi
+
+	# Verify SKILL.md was fetched
+	if [[ ! -f "$fetch_dir/SKILL.md" || ! -s "$fetch_dir/SKILL.md" ]]; then
+		log_error "SKILL.md not found or empty after fetch"
+		return 1
+	fi
+
+	# Create target directory
+	local target_dir
+	target_dir=".agents/$(dirname "$target_path")"
+	mkdir -p "$target_dir"
+
+	# Convert to aidevops format
+	local target_file=".agents/${target_path}.md"
+
+	# Write aidevops-style header
+	local safe_summary
+	safe_summary=$(printf '%s' "${summary:-Imported from ClawdHub}" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+	cat >"$target_file" <<EOF
 ---
 description: "${safe_summary}"
 mode: subagent
@@ -1102,190 +1090,191 @@ clawdhub_version: "${version}"
 # ${display_name:-$skill_name}
 
 EOF
-    
-    # Append the fetched SKILL.md content (skip any existing frontmatter)
-    awk '
+
+	# Append the fetched SKILL.md content (skip any existing frontmatter)
+	awk '
         BEGIN { in_frontmatter = 0; after_frontmatter = 0; has_frontmatter = 0 }
         NR == 1 && /^---$/ { in_frontmatter = 1; has_frontmatter = 1; next }
         in_frontmatter && /^---$/ { in_frontmatter = 0; after_frontmatter = 1; next }
         in_frontmatter { next }
         !has_frontmatter || after_frontmatter { print }
-    ' "$fetch_dir/SKILL.md" >> "$target_file"
-    
-    log_success "Created: $target_file"
-    
-    # Security scan before registration
-    if ! scan_skill_security "$fetch_dir" "$skill_name" "$skip_security"; then
-        # Clean up the partially imported files
-        rm -f "$target_file"
-        rm -rf "$fetch_dir"
-        return 1
-    fi
-    
-    # VirusTotal scan (advisory, non-blocking)
-    scan_skill_virustotal "$fetch_dir" "$skill_name" "$skip_security"
-    
-    # Register in skill-sources.json
-    local upstream_url="https://clawdhub.com/${owner_handle}/${slug}"
-    register_skill "$skill_name" "$upstream_url" ".agents/${target_path}.md" "clawdhub" "$version" "added" "ClawdHub v${version} by @${owner_handle}"
-    
-    # Cleanup
-    rm -rf "$fetch_dir"
-    
-    log_success "Skill '$skill_name' imported from ClawdHub successfully"
-    echo ""
-    log_info "Run './setup.sh' to create symlinks for other AI assistants"
-    
-    return 0
+    ' "$fetch_dir/SKILL.md" >>"$target_file"
+
+	log_success "Created: $target_file"
+
+	# Security scan before registration
+	if ! scan_skill_security "$fetch_dir" "$skill_name" "$skip_security"; then
+		# Clean up the partially imported files
+		rm -f "$target_file"
+		rm -rf "$fetch_dir"
+		return 1
+	fi
+
+	# VirusTotal scan (advisory, non-blocking)
+	scan_skill_virustotal "$fetch_dir" "$skill_name" "$skip_security"
+
+	# Register in skill-sources.json
+	local upstream_url="https://clawdhub.com/${owner_handle}/${slug}"
+	register_skill "$skill_name" "$upstream_url" ".agents/${target_path}.md" "clawdhub" "$version" "added" "ClawdHub v${version} by @${owner_handle}"
+
+	# Cleanup
+	rm -rf "$fetch_dir"
+
+	log_success "Skill '$skill_name' imported from ClawdHub successfully"
+	echo ""
+	log_info "Run './setup.sh' to create symlinks for other AI assistants"
+
+	return 0
 }
 
 cmd_list() {
-    ensure_skill_sources
-    
-    echo ""
-    echo "Imported Skills"
-    echo "==============="
-    echo ""
-    
-    if command -v jq &>/dev/null; then
-        local count
-        count=$(jq '.skills | length' "$SKILL_SOURCES")
-        
-        if [[ "$count" -eq 0 ]]; then
-            echo "No skills imported yet."
-            echo ""
-            echo "Use: add-skill-helper.sh add <owner/repo>"
-            return 0
-        fi
-        
-        jq -r '.skills[] | "  \(.name)\n    Path: \(.local_path)\n    Source: \(.upstream_url)\n    Imported: \(.imported_at)\n"' "$SKILL_SOURCES"
-    else
-        cat "$SKILL_SOURCES"
-    fi
-    
-    return 0
+	ensure_skill_sources
+
+	echo ""
+	echo "Imported Skills"
+	echo "==============="
+	echo ""
+
+	if command -v jq &>/dev/null; then
+		local count
+		count=$(jq '.skills | length' "$SKILL_SOURCES")
+
+		if [[ "$count" -eq 0 ]]; then
+			echo "No skills imported yet."
+			echo ""
+			echo "Use: add-skill-helper.sh add <owner/repo>"
+			return 0
+		fi
+
+		jq -r '.skills[] | "  \(.name)\n    Path: \(.local_path)\n    Source: \(.upstream_url)\n    Imported: \(.imported_at)\n"' "$SKILL_SOURCES"
+	else
+		cat "$SKILL_SOURCES"
+	fi
+
+	return 0
 }
 
 cmd_check_updates() {
-    ensure_skill_sources
-    
-    log_info "Checking for upstream updates..."
-    
-    if ! command -v jq &>/dev/null; then
-        log_error "jq is required for update checking"
-        return 1
-    fi
-    
-    local skills
-    skills=$(jq -r '.skills[] | "\(.name)|\(.upstream_url)|\(.upstream_commit)"' "$SKILL_SOURCES")
-    
-    if [[ -z "$skills" ]]; then
-        log_info "No imported skills to check"
-        return 0
-    fi
-    
-    local updates_available=false
-    
-    local name url commit owner repo
-    while IFS='|' read -r name url commit; do
-        # Extract owner/repo from URL
-        local parsed
-        parsed=$(parse_github_url "$url")
-        IFS='|' read -r owner repo _ _ <<< "$parsed"
-        
-        if [[ -z "$owner" || -z "$repo" ]]; then
-            log_warning "Could not parse URL for $name: $url"
-            continue
-        fi
-        
-        # Get latest commit from GitHub API
-        local api_url="https://api.github.com/repos/$owner/$repo/commits?per_page=1"
-        local api_response
-        api_response=$(curl -s --connect-timeout 10 --max-time 30 "$api_url")
-        
-        # Check if response is an array (success) or object (error)
-        local latest_commit
-        if echo "$api_response" | jq -e 'type == "array"' >/dev/null 2>&1; then
-            latest_commit=$(echo "$api_response" | jq -r '.[0].sha // empty')
-        else
-            # API returned an error object (rate limit, not found, etc.)
-            latest_commit=""
-        fi
-        
-        if [[ -z "$latest_commit" ]]; then
-            log_warning "Could not fetch latest commit for $name"
-            continue
-        fi
-        
-        if [[ "$latest_commit" != "$commit" ]]; then
-            updates_available=true
-            echo -e "${YELLOW}UPDATE AVAILABLE${NC}: $name"
-            echo "  Current: ${commit:0:7}"
-            echo "  Latest:  ${latest_commit:0:7}"
-            echo "  Run: aidevops skill update $name"
-            echo ""
-        else
-            echo -e "${GREEN}Up to date${NC}: $name"
-        fi
-    done <<< "$skills"
-    
-    if [[ "$updates_available" == false ]]; then
-        log_success "All skills are up to date"
-    fi
-    
-    return 0
+	ensure_skill_sources
+
+	log_info "Checking for upstream updates..."
+
+	if ! command -v jq &>/dev/null; then
+		log_error "jq is required for update checking"
+		return 1
+	fi
+
+	local skills
+	skills=$(jq -r '.skills[] | "\(.name)|\(.upstream_url)|\(.upstream_commit)"' "$SKILL_SOURCES")
+
+	if [[ -z "$skills" ]]; then
+		log_info "No imported skills to check"
+		return 0
+	fi
+
+	local updates_available=false
+
+	local name url commit owner repo
+	while IFS='|' read -r name url commit; do
+		# Extract owner/repo from URL
+		local parsed
+		parsed=$(parse_github_url "$url")
+		IFS='|' read -r owner repo _ _ <<<"$parsed"
+
+		if [[ -z "$owner" || -z "$repo" ]]; then
+			log_warning "Could not parse URL for $name: $url"
+			continue
+		fi
+
+		# Get latest commit from GitHub API
+		local api_url="https://api.github.com/repos/$owner/$repo/commits?per_page=1"
+		local api_response
+		api_response=$(curl -s --connect-timeout 10 --max-time 30 "$api_url")
+
+		# Check if response is an array (success) or object (error)
+		local latest_commit
+		if echo "$api_response" | jq -e 'type == "array"' >/dev/null 2>&1; then
+			latest_commit=$(echo "$api_response" | jq -r '.[0].sha // empty')
+		else
+			# API returned an error object (rate limit, not found, etc.)
+			latest_commit=""
+		fi
+
+		if [[ -z "$latest_commit" ]]; then
+			log_warning "Could not fetch latest commit for $name"
+			continue
+		fi
+
+		if [[ "$latest_commit" != "$commit" ]]; then
+			updates_available=true
+			echo -e "${YELLOW}UPDATE AVAILABLE${NC}: $name"
+			echo "  Current: ${commit:0:7}"
+			echo "  Latest:  ${latest_commit:0:7}"
+			echo "  Run: aidevops skill update $name"
+			echo ""
+		else
+			echo -e "${GREEN}Up to date${NC}: $name"
+		fi
+	done <<<"$skills"
+
+	if [[ "$updates_available" == false ]]; then
+		log_success "All skills are up to date"
+	fi
+
+	return 0
 }
 
 cmd_remove() {
-    local name="$1"
-    
-    if [[ -z "$name" ]]; then
-        log_error "Skill name required"
-        return 1
-    fi
-    
-    ensure_skill_sources
-    
-    if ! command -v jq &>/dev/null; then
-        log_error "jq is required for skill removal"
-        return 1
-    fi
-    
-    # Find skill in registry
-    local skill_path
-    skill_path=$(jq -r --arg name "$name" '.skills[] | select(.name == $name) | .local_path' "$SKILL_SOURCES")
-    
-    if [[ -z "$skill_path" ]]; then
-        log_error "Skill not found: $name"
-        return 1
-    fi
-    
-    log_info "Removing skill: $name"
-    log_info "Path: $skill_path"
-    
-    # Remove files
-    if [[ -f "$skill_path" ]]; then
-        rm -f "$skill_path"
-        log_success "Removed: $skill_path"
-    fi
-    
-    # Remove directory if exists
-    local dir_path="${skill_path%.md}"
-    if [[ -d "$dir_path" ]]; then
-        rm -rf "$dir_path"
-        log_success "Removed: $dir_path/"
-    fi
-    
-    # Remove from registry
-    local tmp_file
-    tmp_file=$(mktemp)
-    _save_cleanup_scope; trap '_run_cleanups' RETURN
-    push_cleanup "rm -f '${tmp_file}'"
-    jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" > "$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
-    
-    log_success "Skill '$name' removed"
-    
-    return 0
+	local name="$1"
+
+	if [[ -z "$name" ]]; then
+		log_error "Skill name required"
+		return 1
+	fi
+
+	ensure_skill_sources
+
+	if ! command -v jq &>/dev/null; then
+		log_error "jq is required for skill removal"
+		return 1
+	fi
+
+	# Find skill in registry
+	local skill_path
+	skill_path=$(jq -r --arg name "$name" '.skills[] | select(.name == $name) | .local_path' "$SKILL_SOURCES")
+
+	if [[ -z "$skill_path" ]]; then
+		log_error "Skill not found: $name"
+		return 1
+	fi
+
+	log_info "Removing skill: $name"
+	log_info "Path: $skill_path"
+
+	# Remove files
+	if [[ -f "$skill_path" ]]; then
+		rm -f "$skill_path"
+		log_success "Removed: $skill_path"
+	fi
+
+	# Remove directory if exists
+	local dir_path="${skill_path%.md}"
+	if [[ -d "$dir_path" ]]; then
+		rm -rf "$dir_path"
+		log_success "Removed: $dir_path/"
+	fi
+
+	# Remove from registry
+	local tmp_file
+	tmp_file=$(mktemp)
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	push_cleanup "rm -f '${tmp_file}'"
+	jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" >"$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
+
+	log_success "Skill '$name' removed"
+
+	return 0
 }
 
 # =============================================================================
@@ -1293,36 +1282,36 @@ cmd_remove() {
 # =============================================================================
 
 main() {
-    local command="${1:-help}"
-    shift || true
-    
-    case "$command" in
-        add)
-            if [[ $# -lt 1 ]]; then
-                log_error "URL or owner/repo required"
-                echo "Usage: add-skill-helper.sh add <url|owner/repo> [--name <name>] [--force] [--skip-security]"
-                return 1
-            fi
-            cmd_add "$@"
-            ;;
-        list)
-            cmd_list
-            ;;
-        check-updates|updates)
-            cmd_check_updates
-            ;;
-        remove|rm)
-            cmd_remove "$@"
-            ;;
-        help|--help|-h)
-            show_help
-            ;;
-        *)
-            log_error "Unknown command: $command"
-            show_help
-            return 1
-            ;;
-    esac
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	add)
+		if [[ $# -lt 1 ]]; then
+			log_error "URL or owner/repo required"
+			echo "Usage: add-skill-helper.sh add <url|owner/repo> [--name <name>] [--force] [--skip-security]"
+			return 1
+		fi
+		cmd_add "$@"
+		;;
+	list)
+		cmd_list
+		;;
+	check-updates | updates)
+		cmd_check_updates
+		;;
+	remove | rm)
+		cmd_remove "$@"
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		log_error "Unknown command: $command"
+		show_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -88,11 +88,11 @@ readonly OPENCODE_URL="http://${OPENCODE_HOST}:${OPENCODE_PORT}" # NOSONAR - loc
 readonly BOLD='\033[1m'
 readonly DIM='\033[2m'
 
-# Logging
-log_info() { echo -e "${BLUE}[TEST]${NC} $*"; }
+# Logging: uses shared log_* from shared-constants.sh with TEST prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="TEST"
 log_pass() { echo -e "${GREEN}[PASS]${NC} $*"; }
 log_fail() { echo -e "${RED}[FAIL]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_header() { echo -e "${PURPLE}${BOLD}$*${NC}"; }
 
 #######################################

--- a/.agents/scripts/beads-sync-helper.sh
+++ b/.agents/scripts/beads-sync-helper.sh
@@ -33,145 +33,141 @@ set -euo pipefail
 LOCK_FILE="/tmp/beads-sync.lock"
 LOCK_TIMEOUT=60
 
-# Logging
-log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh
 
 # Find project root (contains TODO.md or .beads/)
 find_project_root() {
-    local dir="$PWD"
-    while [[ "$dir" != "/" ]]; do
-        if [[ -f "$dir/TODO.md" ]] || [[ -d "$dir/.beads" ]]; then
-            echo "$dir"
-            return 0
-        fi
-        dir="$(dirname "$dir")"
-    done
-    return 1
+	local dir="$PWD"
+	while [[ "$dir" != "/" ]]; do
+		if [[ -f "$dir/TODO.md" ]] || [[ -d "$dir/.beads" ]]; then
+			echo "$dir"
+			return 0
+		fi
+		dir="$(dirname "$dir")"
+	done
+	return 1
 }
 
 # Acquire lock with timeout
 acquire_lock() {
-    local start_time
-    start_time=$(date +%s)
-    
-    while ! mkdir "$LOCK_FILE" 2>/dev/null; do
-        local current_time
-        current_time=$(date +%s)
-        local elapsed=$((current_time - start_time))
-        
-        if [[ $elapsed -ge $LOCK_TIMEOUT ]]; then
-            log_error "Failed to acquire lock after ${LOCK_TIMEOUT}s"
-            log_error "Another sync may be in progress, or stale lock at: $LOCK_FILE"
-            log_error "To force: rm -rf $LOCK_FILE"
-            return 1
-        fi
-        
-        log_warn "Waiting for lock... (${elapsed}s)"
-        sleep 1
-    done
-    
-    # Store PID in lock directory
-    echo $$ > "$LOCK_FILE/pid"
-    trap 'release_lock' EXIT
-    return 0
+	local start_time
+	start_time=$(date +%s)
+
+	while ! mkdir "$LOCK_FILE" 2>/dev/null; do
+		local current_time
+		current_time=$(date +%s)
+		local elapsed=$((current_time - start_time))
+
+		if [[ $elapsed -ge $LOCK_TIMEOUT ]]; then
+			log_error "Failed to acquire lock after ${LOCK_TIMEOUT}s"
+			log_error "Another sync may be in progress, or stale lock at: $LOCK_FILE"
+			log_error "To force: rm -rf $LOCK_FILE"
+			return 1
+		fi
+
+		log_warn "Waiting for lock... (${elapsed}s)"
+		sleep 1
+	done
+
+	# Store PID in lock directory
+	echo $$ >"$LOCK_FILE/pid"
+	trap 'release_lock' EXIT
+	return 0
 }
 
 # Release lock
 release_lock() {
-    if [[ -d "$LOCK_FILE" ]]; then
-        rm -rf "$LOCK_FILE"
-    fi
+	if [[ -d "$LOCK_FILE" ]]; then
+		rm -rf "$LOCK_FILE"
+	fi
 }
 
 # Calculate checksum of TODO.md
 checksum_todo() {
-    local project_root="$1"
-    if [[ -f "$project_root/TODO.md" ]]; then
-        shasum -a 256 "$project_root/TODO.md" | cut -d' ' -f1
-    else
-        echo "no-todo"
-    fi
+	local project_root="$1"
+	if [[ -f "$project_root/TODO.md" ]]; then
+		shasum -a 256 "$project_root/TODO.md" | cut -d' ' -f1
+	else
+		echo "no-todo"
+	fi
 }
 
 # Calculate checksum of Beads database
 checksum_beads() {
-    local project_root="$1"
-    if [[ -f "$project_root/.beads/issues.jsonl" ]]; then
-        shasum -a 256 "$project_root/.beads/issues.jsonl" | cut -d' ' -f1
-    else
-        echo "no-beads"
-    fi
+	local project_root="$1"
+	if [[ -f "$project_root/.beads/issues.jsonl" ]]; then
+		shasum -a 256 "$project_root/.beads/issues.jsonl" | cut -d' ' -f1
+	else
+		echo "no-beads"
+	fi
 }
 
 # Log sync operation
 log_sync() {
-    local project_root="$1"
-    local operation="$2"
-    local details="$3"
-    local log_file="$project_root/.beads/sync.log"
-    
-    mkdir -p "$project_root/.beads"
-    echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $operation: $details" >> "$log_file"
+	local project_root="$1"
+	local operation="$2"
+	local details="$3"
+	local log_file="$project_root/.beads/sync.log"
+
+	mkdir -p "$project_root/.beads"
+	echo "[$(date -u +"%Y-%m-%dT%H:%M:%SZ")] $operation: $details" >>"$log_file"
 }
 
 # Check if Beads CLI is installed
 check_beads_installed() {
-    if ! command -v bd &> /dev/null; then
-        log_error "Beads CLI (bd) not found"
-        log_info "Install with: brew install steveyegge/beads/bd"
-        log_info "Or download binary: https://github.com/steveyegge/beads/releases"
-        log_info "Or via Go: go install github.com/steveyegge/beads/cmd/bd@latest"
-        return 1
-    fi
-    return 0
+	if ! command -v bd &>/dev/null; then
+		log_error "Beads CLI (bd) not found"
+		log_info "Install with: brew install steveyegge/beads/bd"
+		log_info "Or download binary: https://github.com/steveyegge/beads/releases"
+		log_info "Or via Go: go install github.com/steveyegge/beads/cmd/bd@latest"
+		return 1
+	fi
+	return 0
 }
 
 # Initialize Beads in project
 cmd_init() {
-    local project_root
-    project_root=$(find_project_root) || {
-        log_error "Not in a project directory (no TODO.md found)"
-        return 1
-    }
-    
-    check_beads_installed || return 1
-    
-    if [[ -d "$project_root/.beads" ]]; then
-        log_warn "Beads already initialized in $project_root"
-        return 0
-    fi
-    
-    log_info "Initializing Beads in $project_root..."
-    
-    # Generate prefix from directory name
-    local prefix
-    prefix=$(basename "$project_root" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]' | head -c 4)
-    
-    (cd "$project_root" && bd init --prefix "$prefix")
-    
-    log_success "Beads initialized with prefix: $prefix"
-    log_info "Run 'beads-sync-helper.sh push' to sync TODO.md to Beads"
-    
-    log_sync "$project_root" "INIT" "prefix=$prefix"
-    return 0
+	local project_root
+	project_root=$(find_project_root) || {
+		log_error "Not in a project directory (no TODO.md found)"
+		return 1
+	}
+
+	check_beads_installed || return 1
+
+	if [[ -d "$project_root/.beads" ]]; then
+		log_warn "Beads already initialized in $project_root"
+		return 0
+	fi
+
+	log_info "Initializing Beads in $project_root..."
+
+	# Generate prefix from directory name
+	local prefix
+	prefix=$(basename "$project_root" | tr '[:upper:]' '[:lower:]' | tr -cd '[:alnum:]' | head -c 4)
+
+	(cd "$project_root" && bd init --prefix "$prefix")
+
+	log_success "Beads initialized with prefix: $prefix"
+	log_info "Run 'beads-sync-helper.sh push' to sync TODO.md to Beads"
+
+	log_sync "$project_root" "INIT" "prefix=$prefix"
+	return 0
 }
 
 # Parse TODO.md and extract tasks
 parse_todo_md() {
-    local project_root="$1"
-    local todo_file="$project_root/TODO.md"
-    
-    if [[ ! -f "$todo_file" ]]; then
-        log_error "TODO.md not found in $project_root"
-        return 1
-    fi
-    
-    # Extract TOON backlog block
-    # This is a simplified parser - production would use proper TOON parsing
-    awk '
+	local project_root="$1"
+	local todo_file="$project_root/TODO.md"
+
+	if [[ ! -f "$todo_file" ]]; then
+		log_error "TODO.md not found in $project_root"
+		return 1
+	fi
+
+	# Extract TOON backlog block
+	# This is a simplified parser - production would use proper TOON parsing
+	awk '
     /<!--TOON:backlog\[/ { in_block=1; next }
     /<!--TOON:subtasks\[/ { in_subtasks=1; next }
     /-->/ { in_block=0; in_subtasks=0; next }
@@ -181,347 +177,347 @@ parse_todo_md() {
 
 # Push TODO.md to Beads
 cmd_push() {
-    local _force="${1:-false}"  # Reserved for future force-push support
-    local dry_run="${2:-false}"
-    local verbose="${3:-false}"
-    
-    local project_root
-    project_root=$(find_project_root) || {
-        log_error "Not in a project directory"
-        return 1
-    }
-    
-    check_beads_installed || return 1
-    
-    # Initialize if needed
-    if [[ ! -d "$project_root/.beads" ]]; then
-        log_info "Beads not initialized, running init..."
-        cmd_init || return 1
-    fi
-    
-    acquire_lock || return 1
-    
-    # Capture checksums before
-    local todo_checksum_before
-    local beads_checksum_before
-    todo_checksum_before=$(checksum_todo "$project_root")
-    beads_checksum_before=$(checksum_beads "$project_root")
-    
-    log_info "Syncing TODO.md → Beads..."
-    [[ "$verbose" == "true" ]] && log_info "TODO.md checksum: $todo_checksum_before"
-    
-    if [[ "$dry_run" == "true" ]]; then
-        log_info "[DRY RUN] Would sync the following tasks:"
-        parse_todo_md "$project_root" | head -10
-        return 0
-    fi
-    
-    # Parse TODO.md and create/update Beads issues
-    local task_count=0
-    local error_count=0
-    
-    while IFS= read -r line; do
-        [[ -z "$line" ]] && continue
-        
-        # Parse TOON line - extract first two fields (id, desc)
-        local id desc
-        id=$(echo "$line" | cut -d',' -f1)
-        desc=$(echo "$line" | cut -d',' -f2)
-        [[ -z "$id" ]] && continue
-        
-        # Check if issue exists in Beads
-        if bd show "$id" --json &>/dev/null; then
-            # Update existing
-            if [[ "$verbose" == "true" ]]; then
-                log_info "Updating: $id - $desc"
-            fi
-            # bd update "$id" --title "$desc" --json &>/dev/null || ((error_count++))
-        else
-            # Create new
-            if [[ "$verbose" == "true" ]]; then
-                log_info "Creating: $id - $desc"
-            fi
-            # For now, just count - actual creation would use bd create
-            # bd create "$desc" --json &>/dev/null || ((error_count++))
-        fi
-        ((task_count++))
-    done < <(parse_todo_md "$project_root")
-    
-    # Verify checksums after
-    local beads_checksum_after
-    beads_checksum_after=$(checksum_beads "$project_root")
-    
-    log_sync "$project_root" "PUSH" "tasks=$task_count errors=$error_count todo_checksum=$todo_checksum_before beads_checksum_before=$beads_checksum_before beads_checksum_after=$beads_checksum_after"
-    
-    if [[ $error_count -gt 0 ]]; then
-        log_warn "Sync completed with $error_count errors"
-        return 1
-    fi
-    
-    log_success "Synced $task_count tasks to Beads"
-    return 0
+	local _force="${1:-false}" # Reserved for future force-push support
+	local dry_run="${2:-false}"
+	local verbose="${3:-false}"
+
+	local project_root
+	project_root=$(find_project_root) || {
+		log_error "Not in a project directory"
+		return 1
+	}
+
+	check_beads_installed || return 1
+
+	# Initialize if needed
+	if [[ ! -d "$project_root/.beads" ]]; then
+		log_info "Beads not initialized, running init..."
+		cmd_init || return 1
+	fi
+
+	acquire_lock || return 1
+
+	# Capture checksums before
+	local todo_checksum_before
+	local beads_checksum_before
+	todo_checksum_before=$(checksum_todo "$project_root")
+	beads_checksum_before=$(checksum_beads "$project_root")
+
+	log_info "Syncing TODO.md → Beads..."
+	[[ "$verbose" == "true" ]] && log_info "TODO.md checksum: $todo_checksum_before"
+
+	if [[ "$dry_run" == "true" ]]; then
+		log_info "[DRY RUN] Would sync the following tasks:"
+		parse_todo_md "$project_root" | head -10
+		return 0
+	fi
+
+	# Parse TODO.md and create/update Beads issues
+	local task_count=0
+	local error_count=0
+
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+
+		# Parse TOON line - extract first two fields (id, desc)
+		local id desc
+		id=$(echo "$line" | cut -d',' -f1)
+		desc=$(echo "$line" | cut -d',' -f2)
+		[[ -z "$id" ]] && continue
+
+		# Check if issue exists in Beads
+		if bd show "$id" --json &>/dev/null; then
+			# Update existing
+			if [[ "$verbose" == "true" ]]; then
+				log_info "Updating: $id - $desc"
+			fi
+			# bd update "$id" --title "$desc" --json &>/dev/null || ((error_count++))
+		else
+			# Create new
+			if [[ "$verbose" == "true" ]]; then
+				log_info "Creating: $id - $desc"
+			fi
+			# For now, just count - actual creation would use bd create
+			# bd create "$desc" --json &>/dev/null || ((error_count++))
+		fi
+		((task_count++))
+	done < <(parse_todo_md "$project_root")
+
+	# Verify checksums after
+	local beads_checksum_after
+	beads_checksum_after=$(checksum_beads "$project_root")
+
+	log_sync "$project_root" "PUSH" "tasks=$task_count errors=$error_count todo_checksum=$todo_checksum_before beads_checksum_before=$beads_checksum_before beads_checksum_after=$beads_checksum_after"
+
+	if [[ $error_count -gt 0 ]]; then
+		log_warn "Sync completed with $error_count errors"
+		return 1
+	fi
+
+	log_success "Synced $task_count tasks to Beads"
+	return 0
 }
 
 # Pull from Beads to TODO.md
 cmd_pull() {
-    local force="${1:-false}"
-    local dry_run="${2:-false}"
-    local verbose="${3:-false}"
-    
-    local project_root
-    project_root=$(find_project_root) || {
-        log_error "Not in a project directory"
-        return 1
-    }
-    
-    check_beads_installed || return 1
-    
-    if [[ ! -d "$project_root/.beads" ]]; then
-        log_error "Beads not initialized. Run 'beads-sync-helper.sh init' first"
-        return 1
-    fi
-    
-    acquire_lock || return 1
-    
-    # Capture checksums before
-    local todo_checksum_before
-    local beads_checksum_before
-    todo_checksum_before=$(checksum_todo "$project_root")
-    beads_checksum_before=$(checksum_beads "$project_root")
-    
-    log_info "Syncing Beads → TODO.md..."
-    [[ "$verbose" == "true" ]] && log_info "Beads checksum: $beads_checksum_before"
-    
-    # Suppress unused variable warnings - these are used for logging
-    : "${force:=false}"
-    
-    if [[ "$dry_run" == "true" ]]; then
-        log_info "[DRY RUN] Would import the following from Beads:"
-        (cd "$project_root" && bd list --json 2>/dev/null | head -10) || true
-        return 0
-    fi
-    
-    # Export from Beads
-    local beads_export
-    beads_export=$(cd "$project_root" && bd list --json 2>/dev/null) || {
-        log_error "Failed to export from Beads"
-        return 1
-    }
-    
-    # Count issues
-    local issue_count
-    issue_count=$(echo "$beads_export" | grep -c '"id"' || echo "0")
-    
-    # TODO: Implement actual TODO.md update logic
-    # This would parse the JSON and update TOON blocks
-    
-    log_sync "$project_root" "PULL" "issues=$issue_count todo_checksum_before=$todo_checksum_before beads_checksum=$beads_checksum_before"
-    
-    log_success "Imported $issue_count issues from Beads"
-    log_warn "TODO.md update not yet implemented - manual merge required"
-    return 0
+	local force="${1:-false}"
+	local dry_run="${2:-false}"
+	local verbose="${3:-false}"
+
+	local project_root
+	project_root=$(find_project_root) || {
+		log_error "Not in a project directory"
+		return 1
+	}
+
+	check_beads_installed || return 1
+
+	if [[ ! -d "$project_root/.beads" ]]; then
+		log_error "Beads not initialized. Run 'beads-sync-helper.sh init' first"
+		return 1
+	fi
+
+	acquire_lock || return 1
+
+	# Capture checksums before
+	local todo_checksum_before
+	local beads_checksum_before
+	todo_checksum_before=$(checksum_todo "$project_root")
+	beads_checksum_before=$(checksum_beads "$project_root")
+
+	log_info "Syncing Beads → TODO.md..."
+	[[ "$verbose" == "true" ]] && log_info "Beads checksum: $beads_checksum_before"
+
+	# Suppress unused variable warnings - these are used for logging
+	: "${force:=false}"
+
+	if [[ "$dry_run" == "true" ]]; then
+		log_info "[DRY RUN] Would import the following from Beads:"
+		(cd "$project_root" && bd list --json 2>/dev/null | head -10) || true
+		return 0
+	fi
+
+	# Export from Beads
+	local beads_export
+	beads_export=$(cd "$project_root" && bd list --json 2>/dev/null) || {
+		log_error "Failed to export from Beads"
+		return 1
+	}
+
+	# Count issues
+	local issue_count
+	issue_count=$(echo "$beads_export" | grep -c '"id"' || echo "0")
+
+	# TODO: Implement actual TODO.md update logic
+	# This would parse the JSON and update TOON blocks
+
+	log_sync "$project_root" "PULL" "issues=$issue_count todo_checksum_before=$todo_checksum_before beads_checksum=$beads_checksum_before"
+
+	log_success "Imported $issue_count issues from Beads"
+	log_warn "TODO.md update not yet implemented - manual merge required"
+	return 0
 }
 
 # Two-way sync with conflict detection
 cmd_sync() {
-    local force="${1:-false}"
-    local dry_run="${2:-false}"
-    local verbose="${3:-false}"
-    
-    local project_root
-    project_root=$(find_project_root) || {
-        log_error "Not in a project directory"
-        return 1
-    }
-    
-    check_beads_installed || return 1
-    
-    acquire_lock || return 1
-    
-    # Load last sync state
-    local state_file="$project_root/.beads/sync-state.json"
-    local last_todo_checksum=""
-    local last_beads_checksum=""
-    
-    if [[ -f "$state_file" ]]; then
-        last_todo_checksum=$(grep -o '"todo_checksum":"[^"]*"' "$state_file" | cut -d'"' -f4 || echo "")
-        last_beads_checksum=$(grep -o '"beads_checksum":"[^"]*"' "$state_file" | cut -d'"' -f4 || echo "")
-    fi
-    
-    # Get current checksums
-    local current_todo_checksum
-    local current_beads_checksum
-    current_todo_checksum=$(checksum_todo "$project_root")
-    current_beads_checksum=$(checksum_beads "$project_root")
-    
-    # Detect changes
-    local todo_changed=false
-    local beads_changed=false
-    
-    [[ "$current_todo_checksum" != "$last_todo_checksum" ]] && todo_changed=true
-    [[ "$current_beads_checksum" != "$last_beads_checksum" ]] && beads_changed=true
-    
-    log_info "Sync status:"
-    log_info "  TODO.md changed: $todo_changed"
-    log_info "  Beads changed: $beads_changed"
-    
-    # Conflict detection
-    if [[ "$todo_changed" == "true" ]] && [[ "$beads_changed" == "true" ]]; then
-        if [[ "$force" != "true" ]]; then
-            log_error "CONFLICT: Both TODO.md and Beads have changed since last sync"
-            log_error "Options:"
-            log_error "  1. beads-sync-helper.sh push --force  (TODO.md wins)"
-            log_error "  2. beads-sync-helper.sh pull --force  (Beads wins)"
-            log_error "  3. Manually resolve and run sync again"
-            return 1
-        fi
-        log_warn "Force mode: proceeding despite conflict (TODO.md wins)"
-    fi
-    
-    # Perform sync
-    if [[ "$todo_changed" == "true" ]]; then
-        log_info "TODO.md has changes, pushing to Beads..."
-        cmd_push "$force" "$dry_run" "$verbose" || return 1
-    elif [[ "$beads_changed" == "true" ]]; then
-        log_info "Beads has changes, pulling to TODO.md..."
-        cmd_pull "$force" "$dry_run" "$verbose" || return 1
-    else
-        log_info "No changes detected, already in sync"
-    fi
-    
-    # Save sync state
-    if [[ "$dry_run" != "true" ]]; then
-        mkdir -p "$project_root/.beads"
-        cat > "$state_file" <<EOF
+	local force="${1:-false}"
+	local dry_run="${2:-false}"
+	local verbose="${3:-false}"
+
+	local project_root
+	project_root=$(find_project_root) || {
+		log_error "Not in a project directory"
+		return 1
+	}
+
+	check_beads_installed || return 1
+
+	acquire_lock || return 1
+
+	# Load last sync state
+	local state_file="$project_root/.beads/sync-state.json"
+	local last_todo_checksum=""
+	local last_beads_checksum=""
+
+	if [[ -f "$state_file" ]]; then
+		last_todo_checksum=$(grep -o '"todo_checksum":"[^"]*"' "$state_file" | cut -d'"' -f4 || echo "")
+		last_beads_checksum=$(grep -o '"beads_checksum":"[^"]*"' "$state_file" | cut -d'"' -f4 || echo "")
+	fi
+
+	# Get current checksums
+	local current_todo_checksum
+	local current_beads_checksum
+	current_todo_checksum=$(checksum_todo "$project_root")
+	current_beads_checksum=$(checksum_beads "$project_root")
+
+	# Detect changes
+	local todo_changed=false
+	local beads_changed=false
+
+	[[ "$current_todo_checksum" != "$last_todo_checksum" ]] && todo_changed=true
+	[[ "$current_beads_checksum" != "$last_beads_checksum" ]] && beads_changed=true
+
+	log_info "Sync status:"
+	log_info "  TODO.md changed: $todo_changed"
+	log_info "  Beads changed: $beads_changed"
+
+	# Conflict detection
+	if [[ "$todo_changed" == "true" ]] && [[ "$beads_changed" == "true" ]]; then
+		if [[ "$force" != "true" ]]; then
+			log_error "CONFLICT: Both TODO.md and Beads have changed since last sync"
+			log_error "Options:"
+			log_error "  1. beads-sync-helper.sh push --force  (TODO.md wins)"
+			log_error "  2. beads-sync-helper.sh pull --force  (Beads wins)"
+			log_error "  3. Manually resolve and run sync again"
+			return 1
+		fi
+		log_warn "Force mode: proceeding despite conflict (TODO.md wins)"
+	fi
+
+	# Perform sync
+	if [[ "$todo_changed" == "true" ]]; then
+		log_info "TODO.md has changes, pushing to Beads..."
+		cmd_push "$force" "$dry_run" "$verbose" || return 1
+	elif [[ "$beads_changed" == "true" ]]; then
+		log_info "Beads has changes, pulling to TODO.md..."
+		cmd_pull "$force" "$dry_run" "$verbose" || return 1
+	else
+		log_info "No changes detected, already in sync"
+	fi
+
+	# Save sync state
+	if [[ "$dry_run" != "true" ]]; then
+		mkdir -p "$project_root/.beads"
+		cat >"$state_file" <<EOF
 {
   "last_sync": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
   "todo_checksum": "$(checksum_todo "$project_root")",
   "beads_checksum": "$(checksum_beads "$project_root")"
 }
 EOF
-    fi
-    
-    log_sync "$project_root" "SYNC" "todo_changed=$todo_changed beads_changed=$beads_changed"
-    log_success "Sync complete"
-    return 0
+	fi
+
+	log_sync "$project_root" "SYNC" "todo_changed=$todo_changed beads_changed=$beads_changed"
+	log_success "Sync complete"
+	return 0
 }
 
 # Show sync status
 cmd_status() {
-    local project_root
-    project_root=$(find_project_root) || {
-        log_error "Not in a project directory"
-        return 1
-    }
-    
-    echo "=== Beads Sync Status ==="
-    echo ""
-    echo "Project: $project_root"
-    echo ""
-    
-    # TODO.md status
-    if [[ -f "$project_root/TODO.md" ]]; then
-        local todo_checksum
-        todo_checksum=$(checksum_todo "$project_root")
-        local todo_tasks
-        todo_tasks=$(grep -c '^\- \[' "$project_root/TODO.md" 2>/dev/null || echo "0")
-        echo "TODO.md: $todo_tasks tasks (checksum: ${todo_checksum:0:8}...)"
-    else
-        echo "TODO.md: Not found"
-    fi
-    
-    # Beads status
-    if [[ -d "$project_root/.beads" ]]; then
-        local beads_checksum
-        beads_checksum=$(checksum_beads "$project_root")
-        local beads_issues="0"
-        if command -v bd &> /dev/null; then
-            beads_issues=$(cd "$project_root" && bd list --json 2>/dev/null | grep -c '"id"' || echo "0")
-        fi
-        echo "Beads: $beads_issues issues (checksum: ${beads_checksum:0:8}...)"
-    else
-        echo "Beads: Not initialized"
-    fi
-    
-    # Last sync
-    local state_file="$project_root/.beads/sync-state.json"
-    if [[ -f "$state_file" ]]; then
-        local last_sync
-        last_sync=$(grep -o '"last_sync":"[^"]*"' "$state_file" | cut -d'"' -f4 || echo "never")
-        echo ""
-        echo "Last sync: $last_sync"
-    fi
-    
-    # Sync log
-    local log_file="$project_root/.beads/sync.log"
-    if [[ -f "$log_file" ]]; then
-        echo ""
-        echo "Recent sync operations:"
-        tail -5 "$log_file" | sed 's/^/  /'
-    fi
-    
-    return 0
+	local project_root
+	project_root=$(find_project_root) || {
+		log_error "Not in a project directory"
+		return 1
+	}
+
+	echo "=== Beads Sync Status ==="
+	echo ""
+	echo "Project: $project_root"
+	echo ""
+
+	# TODO.md status
+	if [[ -f "$project_root/TODO.md" ]]; then
+		local todo_checksum
+		todo_checksum=$(checksum_todo "$project_root")
+		local todo_tasks
+		todo_tasks=$(grep -c '^\- \[' "$project_root/TODO.md" 2>/dev/null || echo "0")
+		echo "TODO.md: $todo_tasks tasks (checksum: ${todo_checksum:0:8}...)"
+	else
+		echo "TODO.md: Not found"
+	fi
+
+	# Beads status
+	if [[ -d "$project_root/.beads" ]]; then
+		local beads_checksum
+		beads_checksum=$(checksum_beads "$project_root")
+		local beads_issues="0"
+		if command -v bd &>/dev/null; then
+			beads_issues=$(cd "$project_root" && bd list --json 2>/dev/null | grep -c '"id"' || echo "0")
+		fi
+		echo "Beads: $beads_issues issues (checksum: ${beads_checksum:0:8}...)"
+	else
+		echo "Beads: Not initialized"
+	fi
+
+	# Last sync
+	local state_file="$project_root/.beads/sync-state.json"
+	if [[ -f "$state_file" ]]; then
+		local last_sync
+		last_sync=$(grep -o '"last_sync":"[^"]*"' "$state_file" | cut -d'"' -f4 || echo "never")
+		echo ""
+		echo "Last sync: $last_sync"
+	fi
+
+	# Sync log
+	local log_file="$project_root/.beads/sync.log"
+	if [[ -f "$log_file" ]]; then
+		echo ""
+		echo "Recent sync operations:"
+		tail -5 "$log_file" | sed 's/^/  /'
+	fi
+
+	return 0
 }
 
 # Show ready tasks (no blockers)
 cmd_ready() {
-    local project_root
-    project_root=$(find_project_root) || {
-        log_error "Not in a project directory"
-        return 1
-    }
-    
-    if [[ ! -f "$project_root/TODO.md" ]]; then
-        log_error "TODO.md not found"
-        return 1
-    fi
-    
-    echo "=== Ready Tasks (No Blockers) ==="
-    echo ""
-    
-    # Parse TODO.md for tasks without blocked-by
-    local ready_count=0
-    local blocked_count=0
-    
-    # Simple grep-based approach - production would use proper TOON parsing
-    while IFS= read -r line; do
-        # Skip non-task lines
-        [[ ! "$line" =~ ^-\ \[\ \] ]] && continue
-        
-        # Check for blocked-by
-        if [[ "$line" =~ blocked-by: ]]; then
-            ((blocked_count++))
-            # Extract task ID and blocker
-            local task_id
-            task_id=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1)
-            local blocker
-            blocker=$(echo "$line" | grep -oE 'blocked-by:[^ ]+' | cut -d: -f2)
-            echo "  BLOCKED: $task_id (waiting on: $blocker)"
-        else
-            ((ready_count++))
-            # Extract task ID and description
-            local task_info
-            task_info=$(echo "$line" | sed 's/^- \[ \] //' | cut -d'#' -f1 | head -c 60)
-            echo "  READY: $task_info"
-        fi
-    done < "$project_root/TODO.md"
-    
-    echo ""
-    echo "Summary: $ready_count ready, $blocked_count blocked"
-    
-    # If Beads is available, also show bd ready
-    if command -v bd &> /dev/null && [[ -d "$project_root/.beads" ]]; then
-        echo ""
-        echo "=== Beads Ready (bd ready) ==="
-        (cd "$project_root" && bd ready 2>/dev/null) || true
-    fi
-    
-    return 0
+	local project_root
+	project_root=$(find_project_root) || {
+		log_error "Not in a project directory"
+		return 1
+	}
+
+	if [[ ! -f "$project_root/TODO.md" ]]; then
+		log_error "TODO.md not found"
+		return 1
+	fi
+
+	echo "=== Ready Tasks (No Blockers) ==="
+	echo ""
+
+	# Parse TODO.md for tasks without blocked-by
+	local ready_count=0
+	local blocked_count=0
+
+	# Simple grep-based approach - production would use proper TOON parsing
+	while IFS= read -r line; do
+		# Skip non-task lines
+		[[ ! "$line" =~ ^-\ \[\ \] ]] && continue
+
+		# Check for blocked-by
+		if [[ "$line" =~ blocked-by: ]]; then
+			((blocked_count++))
+			# Extract task ID and blocker
+			local task_id
+			task_id=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1)
+			local blocker
+			blocker=$(echo "$line" | grep -oE 'blocked-by:[^ ]+' | cut -d: -f2)
+			echo "  BLOCKED: $task_id (waiting on: $blocker)"
+		else
+			((ready_count++))
+			# Extract task ID and description
+			local task_info
+			task_info=$(echo "$line" | sed 's/^- \[ \] //' | cut -d'#' -f1 | head -c 60)
+			echo "  READY: $task_info"
+		fi
+	done <"$project_root/TODO.md"
+
+	echo ""
+	echo "Summary: $ready_count ready, $blocked_count blocked"
+
+	# If Beads is available, also show bd ready
+	if command -v bd &>/dev/null && [[ -d "$project_root/.beads" ]]; then
+		echo ""
+		echo "=== Beads Ready (bd ready) ==="
+		(cd "$project_root" && bd ready 2>/dev/null) || true
+	fi
+
+	return 0
 }
 
 # Show help
 show_help() {
-    cat <<EOF
+	cat <<EOF
 beads-sync-helper.sh - Bi-directional sync between aidevops TODO.md and Beads
 
 Usage:
@@ -560,37 +556,41 @@ EOF
 
 # Main
 main() {
-    local command="${1:-help}"
-    shift || true
-    
-    # Parse options
-    local force=false
-    local dry_run=false
-    local verbose=false
-    
-    # Parse options using named variable (S7679)
-    local opt
-    while [[ $# -gt 0 ]]; do
-        opt="$1"
-        case "$opt" in
-            --force) force=true ;;
-            --dry-run) dry_run=true ;;
-            --verbose) verbose=true ;;
-            *) break ;;  # Ignore positional args (project root discovered via git)
-        esac
-        shift
-    done
-    
-    case "$command" in
-        init) cmd_init ;;
-        push) cmd_push "$force" "$dry_run" "$verbose" ;;
-        pull) cmd_pull "$force" "$dry_run" "$verbose" ;;
-        sync) cmd_sync "$force" "$dry_run" "$verbose" ;;
-        status) cmd_status ;;
-        ready) cmd_ready ;;
-        help|--help|-h) show_help ;;
-        *) log_error "Unknown command: $command"; show_help; return 1 ;;
-    esac
+	local command="${1:-help}"
+	shift || true
+
+	# Parse options
+	local force=false
+	local dry_run=false
+	local verbose=false
+
+	# Parse options using named variable (S7679)
+	local opt
+	while [[ $# -gt 0 ]]; do
+		opt="$1"
+		case "$opt" in
+		--force) force=true ;;
+		--dry-run) dry_run=true ;;
+		--verbose) verbose=true ;;
+		*) break ;; # Ignore positional args (project root discovered via git)
+		esac
+		shift
+	done
+
+	case "$command" in
+	init) cmd_init ;;
+	push) cmd_push "$force" "$dry_run" "$verbose" ;;
+	pull) cmd_pull "$force" "$dry_run" "$verbose" ;;
+	sync) cmd_sync "$force" "$dry_run" "$verbose" ;;
+	status) cmd_status ;;
+	ready) cmd_ready ;;
+	help | --help | -h) show_help ;;
+	*)
+		log_error "Unknown command: $command"
+		show_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -91,10 +91,7 @@ _REMOTE_NAME_SET=false
 _COUNTER_BRANCH_SET=false
 
 # Logging (all to stderr so stdout is machine-readable)
-log_info() { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
-log_success() { echo -e "${GREEN}[OK]${NC} $*" >&2; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh
 
 # Load project-level config from .aidevops.json in the repo root.
 # Populates REMOTE_NAME and COUNTER_BRANCH unless already set by CLI flags.

--- a/.agents/scripts/codacy-collector-helper.sh
+++ b/.agents/scripts/codacy-collector-helper.sh
@@ -44,25 +44,10 @@ readonly AUDIT_CONFIG="configs/code-audit-config.json"
 readonly AUDIT_CONFIG_TEMPLATE="configs/code-audit-config.json.txt"
 
 # =============================================================================
-# Logging
+# Logging: uses shared log_* from shared-constants.sh with CODACY prefix
 # =============================================================================
-
-log_info() {
-	echo -e "${BLUE}[CODACY]${NC} $*" >&2
-	return 0
-}
-log_success() {
-	echo -e "${GREEN}[CODACY]${NC} $*" >&2
-	return 0
-}
-log_warn() {
-	echo -e "${YELLOW}[CODACY]${NC} $*" >&2
-	return 0
-}
-log_error() {
-	echo -e "${RED}[CODACY]${NC} $*" >&2
-	return 0
-}
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="CODACY"
 
 # =============================================================================
 # SQLite wrapper: sets busy_timeout on every connection (t135.3 pattern)

--- a/.agents/scripts/code-audit-helper.sh
+++ b/.agents/scripts/code-audit-helper.sh
@@ -40,25 +40,10 @@ readonly AUDIT_CONFIG="configs/code-audit-config.json"
 readonly KNOWN_SERVICES="coderabbit codacy sonarcloud codefactor"
 
 # =============================================================================
-# Logging
+# Logging: uses shared log_* from shared-constants.sh with AUDIT prefix
 # =============================================================================
-
-log_info() {
-	echo -e "${BLUE}[AUDIT]${NC} $*" >&2
-	return 0
-}
-log_success() {
-	echo -e "${GREEN}[AUDIT]${NC} $*" >&2
-	return 0
-}
-log_warn() {
-	echo -e "${YELLOW}[AUDIT]${NC} $*" >&2
-	return 0
-}
-log_error() {
-	echo -e "${RED}[AUDIT]${NC} $*" >&2
-	return 0
-}
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="AUDIT"
 
 # =============================================================================
 # SQLite wrapper: sets busy_timeout on every connection (t135.3 pattern)

--- a/.agents/scripts/coderabbit-collector-helper.sh
+++ b/.agents/scripts/coderabbit-collector-helper.sh
@@ -37,25 +37,10 @@ readonly COLLECTOR_DB="${COLLECTOR_DATA_DIR}/reviews.db"
 readonly CODERABBIT_BOT_LOGIN="coderabbitai"
 
 # =============================================================================
-# Logging
+# Logging: uses shared log_* from shared-constants.sh with COLLECTOR prefix
 # =============================================================================
-
-log_info() {
-	echo -e "${BLUE}[COLLECTOR]${NC} $*"
-	return 0
-}
-log_success() {
-	echo -e "${GREEN}[COLLECTOR]${NC} $*"
-	return 0
-}
-log_warn() {
-	echo -e "${YELLOW}[COLLECTOR]${NC} $*"
-	return 0
-}
-log_error() {
-	echo -e "${RED}[COLLECTOR]${NC} $*" >&2
-	return 0
-}
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="COLLECTOR"
 
 # =============================================================================
 # SQLite wrapper: sets busy_timeout on every connection (t135.3 pattern)

--- a/.agents/scripts/comfy-cli-helper.sh
+++ b/.agents/scripts/comfy-cli-helper.sh
@@ -8,51 +8,31 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # shellcheck source=/dev/null
 if [[ -f "$SCRIPT_DIR/shared-constants.sh" ]]; then
-    source "$SCRIPT_DIR/shared-constants.sh"
+	source "$SCRIPT_DIR/shared-constants.sh"
 else
-    RED='\033[0;31m'
-    GREEN='\033[0;32m'
-    YELLOW='\033[1;33m'
-    BLUE='\033[0;34m'
-    NC='\033[0m'
+	RED='\033[0;31m'
+	GREEN='\033[0;32m'
+	YELLOW='\033[1;33m'
+	BLUE='\033[0;34m'
+	NC='\033[0m'
 fi
 
 ##############################################################################
 # Helpers
 ##############################################################################
 
-log_info() {
-    local msg="$1"
-    printf "${BLUE}[comfy-cli]${NC} %s\n" "$msg"
-    return 0
-}
-
-log_success() {
-    local msg="$1"
-    printf "${GREEN}[comfy-cli]${NC} %s\n" "$msg"
-    return 0
-}
-
-log_warn() {
-    local msg="$1"
-    printf "${YELLOW}[comfy-cli]${NC} %s\n" "$msg" >&2
-    return 0
-}
-
-log_error() {
-    local msg="$1"
-    printf "${RED}[comfy-cli]${NC} %s\n" "$msg" >&2
-    return 0
-}
+# Logging: uses shared log_* from shared-constants.sh with comfy-cli prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="comfy-cli"
 
 check_comfy_cli() {
-    if ! command -v comfy >/dev/null 2>&1; then
-        log_error "comfy-cli is not installed."
-        log_info "Install with: pip install comfy-cli"
-        log_info "Or: brew tap Comfy-Org/comfy-cli && brew install comfy-org/comfy-cli/comfy-cli"
-        return 1
-    fi
-    return 0
+	if ! command -v comfy >/dev/null 2>&1; then
+		log_error "comfy-cli is not installed."
+		log_info "Install with: pip install comfy-cli"
+		log_info "Or: brew tap Comfy-Org/comfy-cli && brew install comfy-org/comfy-cli/comfy-cli"
+		return 1
+	fi
+	return 0
 }
 
 ##############################################################################
@@ -60,243 +40,268 @@ check_comfy_cli() {
 ##############################################################################
 
 cmd_status() {
-    log_info "Checking comfy-cli status..."
+	log_info "Checking comfy-cli status..."
 
-    if command -v comfy >/dev/null 2>&1; then
-        local version
-        version=$(comfy --version 2>/dev/null || echo "unknown")
-        log_success "comfy-cli installed: $version"
-        log_info "Location: $(command -v comfy)"
-    else
-        log_warn "comfy-cli is not installed"
-        return 1
-    fi
+	if command -v comfy >/dev/null 2>&1; then
+		local version
+		version=$(comfy --version 2>/dev/null || echo "unknown")
+		log_success "comfy-cli installed: $version"
+		log_info "Location: $(command -v comfy)"
+	else
+		log_warn "comfy-cli is not installed"
+		return 1
+	fi
 
-    if command -v python3 >/dev/null 2>&1; then
-        local py_version
-        py_version=$(python3 --version 2>/dev/null || echo "unknown")
-        log_info "Python: $py_version"
-    else
-        log_warn "Python 3 not found"
-    fi
+	if command -v python3 >/dev/null 2>&1; then
+		local py_version
+		py_version=$(python3 --version 2>/dev/null || echo "unknown")
+		log_info "Python: $py_version"
+	else
+		log_warn "Python 3 not found"
+	fi
 
-    if command -v git >/dev/null 2>&1; then
-        log_info "git: $(git --version 2>/dev/null)"
-    else
-        log_warn "git not found (required by comfy-cli)"
-    fi
+	if command -v git >/dev/null 2>&1; then
+		log_info "git: $(git --version 2>/dev/null)"
+	else
+		log_warn "git not found (required by comfy-cli)"
+	fi
 
-    return 0
+	return 0
 }
 
 cmd_install() {
-    log_info "Installing comfy-cli..."
+	log_info "Installing comfy-cli..."
 
-    if command -v comfy >/dev/null 2>&1; then
-        log_success "comfy-cli is already installed"
-        cmd_status
-        return 0
-    fi
+	if command -v comfy >/dev/null 2>&1; then
+		log_success "comfy-cli is already installed"
+		cmd_status
+		return 0
+	fi
 
-    # Try pip first, then brew
-    if command -v pip >/dev/null 2>&1; then
-        log_info "Installing via pip..."
-        pip install comfy-cli
-    elif command -v pip3 >/dev/null 2>&1; then
-        log_info "Installing via pip3..."
-        pip3 install comfy-cli
-    elif command -v brew >/dev/null 2>&1; then
-        log_info "Installing via Homebrew..."
-        brew tap Comfy-Org/comfy-cli
-        brew install comfy-org/comfy-cli/comfy-cli
-    else
-        log_error "No package manager found. Install pip or Homebrew first."
-        return 1
-    fi
+	# Try pip first, then brew
+	if command -v pip >/dev/null 2>&1; then
+		log_info "Installing via pip..."
+		pip install comfy-cli
+	elif command -v pip3 >/dev/null 2>&1; then
+		log_info "Installing via pip3..."
+		pip3 install comfy-cli
+	elif command -v brew >/dev/null 2>&1; then
+		log_info "Installing via Homebrew..."
+		brew tap Comfy-Org/comfy-cli
+		brew install comfy-org/comfy-cli/comfy-cli
+	else
+		log_error "No package manager found. Install pip or Homebrew first."
+		return 1
+	fi
 
-    if command -v comfy >/dev/null 2>&1; then
-        log_success "comfy-cli installed successfully"
-        cmd_status
-    else
-        log_error "Installation failed"
-        return 1
-    fi
+	if command -v comfy >/dev/null 2>&1; then
+		log_success "comfy-cli installed successfully"
+		cmd_status
+	else
+		log_error "Installation failed"
+		return 1
+	fi
 
-    return 0
+	return 0
 }
 
 cmd_setup() {
-    local path=""
+	local path=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --path) path="$2"; shift 2 ;;
-            *) log_error "Unknown option: $1"; return 1 ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--path)
+			path="$2"
+			shift 2
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
 
-    check_comfy_cli || return 1
+	check_comfy_cli || return 1
 
-    if [[ -n "$path" ]]; then
-        log_info "Installing ComfyUI to: $path"
-        mkdir -p "$path"
-        # shellcheck disable=SC2164
-        cd "$path"
-    fi
+	if [[ -n "$path" ]]; then
+		log_info "Installing ComfyUI to: $path"
+		mkdir -p "$path"
+		# shellcheck disable=SC2164
+		cd "$path"
+	fi
 
-    log_info "Running comfy install..."
-    comfy install
+	log_info "Running comfy install..."
+	comfy install
 
-    log_success "ComfyUI installed"
-    log_info "Launch with: comfy-cli-helper.sh launch"
-    return 0
+	log_success "ComfyUI installed"
+	log_info "Launch with: comfy-cli-helper.sh launch"
+	return 0
 }
 
 cmd_launch() {
-    local port=""
-    local listen=""
-    local extra_args=()
+	local port=""
+	local listen=""
+	local extra_args=()
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --port) port="$2"; shift 2 ;;
-            --listen) listen="$2"; shift 2 ;;
-            --) shift; extra_args+=("$@"); break ;;
-            *) extra_args+=("$1"); shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--port)
+			port="$2"
+			shift 2
+			;;
+		--listen)
+			listen="$2"
+			shift 2
+			;;
+		--)
+			shift
+			extra_args+=("$@")
+			break
+			;;
+		*)
+			extra_args+=("$1")
+			shift
+			;;
+		esac
+	done
 
-    check_comfy_cli || return 1
+	check_comfy_cli || return 1
 
-    local launch_args=()
-    if [[ -n "$port" ]] || [[ -n "$listen" ]] || [[ ${#extra_args[@]} -gt 0 ]]; then
-        launch_args+=("--")
-        [[ -n "$listen" ]] && launch_args+=("--listen" "$listen")
-        [[ -n "$port" ]] && launch_args+=("--port" "$port")
-        [[ ${#extra_args[@]} -gt 0 ]] && launch_args+=("${extra_args[@]}")
-    fi
+	local launch_args=()
+	if [[ -n "$port" ]] || [[ -n "$listen" ]] || [[ ${#extra_args[@]} -gt 0 ]]; then
+		launch_args+=("--")
+		[[ -n "$listen" ]] && launch_args+=("--listen" "$listen")
+		[[ -n "$port" ]] && launch_args+=("--port" "$port")
+		[[ ${#extra_args[@]} -gt 0 ]] && launch_args+=("${extra_args[@]}")
+	fi
 
-    log_info "Launching ComfyUI..."
-    comfy launch "${launch_args[@]}"
-    return 0
+	log_info "Launching ComfyUI..."
+	comfy launch "${launch_args[@]}"
+	return 0
 }
 
 cmd_node_install() {
-    local node_name="${1:-}"
-    if [[ -z "$node_name" ]]; then
-        log_error "Usage: comfy-cli-helper.sh node-install <node-name>"
-        return 1
-    fi
-    shift
+	local node_name="${1:-}"
+	if [[ -z "$node_name" ]]; then
+		log_error "Usage: comfy-cli-helper.sh node-install <node-name>"
+		return 1
+	fi
+	shift
 
-    check_comfy_cli || return 1
+	check_comfy_cli || return 1
 
-    log_info "Installing custom node: $node_name"
-    comfy node install "$node_name" "$@"
-    log_success "Node installed: $node_name"
-    return 0
+	log_info "Installing custom node: $node_name"
+	comfy node install "$node_name" "$@"
+	log_success "Node installed: $node_name"
+	return 0
 }
 
 cmd_node_list() {
-    local filter="${1:-installed}"
+	local filter="${1:-installed}"
 
-    check_comfy_cli || return 1
+	check_comfy_cli || return 1
 
-    log_info "Listing nodes: $filter"
-    comfy node show "$filter"
-    return 0
+	log_info "Listing nodes: $filter"
+	comfy node show "$filter"
+	return 0
 }
 
 cmd_model_download() {
-    local url="${1:-}"
-    local relative_path="${2:-models/checkpoints}"
+	local url="${1:-}"
+	local relative_path="${2:-models/checkpoints}"
 
-    if [[ -z "$url" ]]; then
-        log_error "Usage: comfy-cli-helper.sh model-download <url> [relative-path]"
-        return 1
-    fi
+	if [[ -z "$url" ]]; then
+		log_error "Usage: comfy-cli-helper.sh model-download <url> [relative-path]"
+		return 1
+	fi
 
-    check_comfy_cli || return 1
+	check_comfy_cli || return 1
 
-    log_info "Downloading model to: $relative_path"
-    comfy model download --url "$url" --relative-path "$relative_path"
-    log_success "Model downloaded"
-    return 0
+	log_info "Downloading model to: $relative_path"
+	comfy model download --url "$url" --relative-path "$relative_path"
+	log_success "Model downloaded"
+	return 0
 }
 
 cmd_model_list() {
-    local relative_path="${1:-models/checkpoints}"
+	local relative_path="${1:-models/checkpoints}"
 
-    check_comfy_cli || return 1
+	check_comfy_cli || return 1
 
-    log_info "Listing models in: $relative_path"
-    comfy model list --relative-path "$relative_path"
-    return 0
+	log_info "Listing models in: $relative_path"
+	comfy model list --relative-path "$relative_path"
+	return 0
 }
 
 cmd_snapshot_save() {
-    local output=""
+	local output=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --output) output="$2"; shift 2 ;;
-            *) log_error "Unknown option: $1"; return 1 ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--output)
+			output="$2"
+			shift 2
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
 
-    check_comfy_cli || return 1
+	check_comfy_cli || return 1
 
-    local save_args=()
-    [[ -n "$output" ]] && save_args+=("--output" "$output")
+	local save_args=()
+	[[ -n "$output" ]] && save_args+=("--output" "$output")
 
-    log_info "Saving environment snapshot..."
-    comfy node save-snapshot "${save_args[@]}"
-    log_success "Snapshot saved"
-    return 0
+	log_info "Saving environment snapshot..."
+	comfy node save-snapshot "${save_args[@]}"
+	log_success "Snapshot saved"
+	return 0
 }
 
 cmd_snapshot_restore() {
-    local snapshot_path="${1:-}"
-    if [[ -z "$snapshot_path" ]]; then
-        log_error "Usage: comfy-cli-helper.sh snapshot-restore <file.json>"
-        return 1
-    fi
+	local snapshot_path="${1:-}"
+	if [[ -z "$snapshot_path" ]]; then
+		log_error "Usage: comfy-cli-helper.sh snapshot-restore <file.json>"
+		return 1
+	fi
 
-    if [[ ! -f "$snapshot_path" ]]; then
-        log_error "Snapshot file not found: $snapshot_path"
-        return 1
-    fi
+	if [[ ! -f "$snapshot_path" ]]; then
+		log_error "Snapshot file not found: $snapshot_path"
+		return 1
+	fi
 
-    check_comfy_cli || return 1
+	check_comfy_cli || return 1
 
-    log_info "Restoring snapshot from: $snapshot_path"
-    comfy node restore-snapshot "$snapshot_path"
-    log_success "Snapshot restored"
-    return 0
+	log_info "Restoring snapshot from: $snapshot_path"
+	comfy node restore-snapshot "$snapshot_path"
+	log_success "Snapshot restored"
+	return 0
 }
 
 cmd_workflow_deps() {
-    local workflow="${1:-}"
-    if [[ -z "$workflow" ]]; then
-        log_error "Usage: comfy-cli-helper.sh workflow-deps <workflow.json>"
-        return 1
-    fi
+	local workflow="${1:-}"
+	if [[ -z "$workflow" ]]; then
+		log_error "Usage: comfy-cli-helper.sh workflow-deps <workflow.json>"
+		return 1
+	fi
 
-    if [[ ! -f "$workflow" ]]; then
-        log_error "Workflow file not found: $workflow"
-        return 1
-    fi
+	if [[ ! -f "$workflow" ]]; then
+		log_error "Workflow file not found: $workflow"
+		return 1
+	fi
 
-    check_comfy_cli || return 1
+	check_comfy_cli || return 1
 
-    log_info "Installing dependencies from workflow: $workflow"
-    comfy node install-deps --workflow "$workflow"
-    log_success "Workflow dependencies installed"
-    return 0
+	log_info "Installing dependencies from workflow: $workflow"
+	comfy node install-deps --workflow "$workflow"
+	log_success "Workflow dependencies installed"
+	return 0
 }
 
 cmd_help() {
-    cat <<'EOF'
+	cat <<'EOF'
 comfy-cli-helper.sh — ComfyUI management via comfy-cli
 
 Usage:
@@ -327,7 +332,7 @@ Examples:
 
 Docs: https://docs.comfy.org/comfy-cli/getting-started
 EOF
-    return 0
+	return 0
 }
 
 ##############################################################################
@@ -335,28 +340,28 @@ EOF
 ##############################################################################
 
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    case "$command" in
-        status)           cmd_status "$@" ;;
-        install)          cmd_install "$@" ;;
-        setup)            cmd_setup "$@" ;;
-        launch)           cmd_launch "$@" ;;
-        node-install)     cmd_node_install "$@" ;;
-        node-list)        cmd_node_list "$@" ;;
-        model-download)   cmd_model_download "$@" ;;
-        model-list)       cmd_model_list "$@" ;;
-        snapshot-save)    cmd_snapshot_save "$@" ;;
-        snapshot-restore) cmd_snapshot_restore "$@" ;;
-        workflow-deps)    cmd_workflow_deps "$@" ;;
-        help|--help|-h)   cmd_help ;;
-        *)
-            log_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
+	case "$command" in
+	status) cmd_status "$@" ;;
+	install) cmd_install "$@" ;;
+	setup) cmd_setup "$@" ;;
+	launch) cmd_launch "$@" ;;
+	node-install) cmd_node_install "$@" ;;
+	node-list) cmd_node_list "$@" ;;
+	model-download) cmd_model_download "$@" ;;
+	model-list) cmd_model_list "$@" ;;
+	snapshot-save) cmd_snapshot_save "$@" ;;
+	snapshot-restore) cmd_snapshot_restore "$@" ;;
+	workflow-deps) cmd_workflow_deps "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/cron-helper.sh
+++ b/.agents/scripts/cron-helper.sh
@@ -39,13 +39,9 @@ readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
 # shellcheck disable=SC2034  # CYAN reserved for future use
 readonly BOLD='\033[1m'
 
-#######################################
-# Logging
-#######################################
-log_info() { echo -e "${BLUE}[CRON]${NC} $*"; }
-log_success() { echo -e "${GREEN}[CRON]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[CRON]${NC} $*"; }
-log_error() { echo -e "${RED}[CRON]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh with CRON prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="CRON"
 
 #######################################
 # Ensure directories and config exist

--- a/.agents/scripts/gsc-sitemap-helper.sh
+++ b/.agents/scripts/gsc-sitemap-helper.sh
@@ -25,10 +25,7 @@ readonly DEFAULT_SITEMAP="sitemap.xml"
 [[ -z "${BLUE+x}" ]] && BLUE='\033[0;34m'
 [[ -z "${NC+x}" ]] && NC='\033[0m'
 
-log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+# Logging: uses shared log_* from shared-constants.sh
 
 show_help() {
 	cat <<'HELP'

--- a/.agents/scripts/ip-reputation-helper.sh
+++ b/.agents/scripts/ip-reputation-helper.sh
@@ -480,28 +480,8 @@ disable_colors() {
 }
 
 # =============================================================================
-# Logging
+# Logging: uses shared log_* from shared-constants.sh
 # =============================================================================
-
-log_info() {
-	echo -e "$(c_cyan)[INFO]$(c_nc) $*" >&2
-	return 0
-}
-
-log_warn() {
-	echo -e "$(c_yellow)[WARN]$(c_nc) $*" >&2
-	return 0
-}
-
-log_error() {
-	echo -e "$(c_red)[ERROR]$(c_nc) $*" >&2
-	return 0
-}
-
-log_success() {
-	echo -e "$(c_green)[OK]$(c_nc) $*" >&2
-	return 0
-}
 
 # =============================================================================
 # Provider Management

--- a/.agents/scripts/mail-helper.sh
+++ b/.agents/scripts/mail-helper.sh
@@ -59,13 +59,9 @@ readonly MATRIX_BOT_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/aidevops/matrix-bo
 readonly MAIL_ENVELOPE_PREFIX="[AIDEVOPS-MAIL]"
 readonly MAIL_ENVELOPE_VERSION="1"
 
-#######################################
-# Logging
-#######################################
-log_info() { echo -e "${BLUE}[MAIL]${NC} $*"; }
-log_success() { echo -e "${GREEN}[MAIL]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[MAIL]${NC} $*"; }
-log_error() { echo -e "${RED}[MAIL]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh with MAIL prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="MAIL"
 
 #######################################
 # SQLite wrapper: sets busy_timeout on every connection (t135.3)

--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -52,13 +52,9 @@ readonly OPENCODE_HOST="${OPENCODE_HOST:-127.0.0.1}"
 
 readonly BOLD='\033[1m'
 
-#######################################
-# Logging
-#######################################
-log_info() { echo -e "${BLUE}[MATRIX]${NC} $*"; }
-log_success() { echo -e "${GREEN}[MATRIX]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[MATRIX]${NC} $*"; }
-log_error() { echo -e "${RED}[MATRIX]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh with MATRIX prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="MATRIX"
 
 #######################################
 # Check dependencies

--- a/.agents/scripts/mcp-index-helper.sh
+++ b/.agents/scripts/mcp-index-helper.sh
@@ -31,10 +31,7 @@ readonly OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
 # shellcheck disable=SC2034  # Used for future cache invalidation
 readonly CACHE_TTL_HOURS=24
 
-log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh
 
 #######################################
 # Initialize SQLite database with FTS5

--- a/.agents/scripts/memory-audit-pulse.sh
+++ b/.agents/scripts/memory-audit-pulse.sh
@@ -42,17 +42,16 @@ readonly AUDIT_INTERVAL_HOURS=24
 # Minimum interval between audit pulses (prevents redundant runs)
 readonly AUDIT_INTERVAL_SECONDS=$((AUDIT_INTERVAL_HOURS * 3600))
 
+# Logging: uses shared log_* from shared-constants.sh with AUDIT prefix
 # All log functions write to stderr so phase functions can return counts on stdout
-log_info() { echo -e "${BLUE}[AUDIT]${NC} $*" >&2; }
-log_success() { echo -e "${GREEN}[AUDIT]${NC} $*" >&2; }
-log_warn() { echo -e "${YELLOW}[AUDIT]${NC} $*" >&2; }
-log_error() { echo -e "${RED}[AUDIT]${NC} $*" >&2; }
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="AUDIT"
 
 #######################################
 # SQLite wrapper with busy_timeout
 #######################################
 db() {
-    sqlite3 -cmd ".timeout 5000" "$@"
+	sqlite3 -cmd ".timeout 5000" "$@"
 }
 
 #######################################
@@ -60,142 +59,142 @@ db() {
 # Returns 0 if audit should run, 1 if too soon
 #######################################
 should_run() {
-    if [[ ! -f "$AUDIT_MARKER" ]]; then
-        return 0
-    fi
+	if [[ ! -f "$AUDIT_MARKER" ]]; then
+		return 0
+	fi
 
-    local last_run
-    last_run=$(stat -c %Y "$AUDIT_MARKER" 2>/dev/null || stat -f %m "$AUDIT_MARKER" 2>/dev/null || echo "0")
-    local now
-    now=$(date +%s)
-    local elapsed=$((now - last_run))
+	local last_run
+	last_run=$(stat -c %Y "$AUDIT_MARKER" 2>/dev/null || stat -f %m "$AUDIT_MARKER" 2>/dev/null || echo "0")
+	local now
+	now=$(date +%s)
+	local elapsed=$((now - last_run))
 
-    if [[ "$elapsed" -lt "$AUDIT_INTERVAL_SECONDS" ]]; then
-        local remaining=$(( (AUDIT_INTERVAL_SECONDS - elapsed) / 3600 ))
-        log_info "Last audit was $((elapsed / 3600))h ago (interval: ${AUDIT_INTERVAL_HOURS}h). Next in ~${remaining}h."
-        return 1
-    fi
+	if [[ "$elapsed" -lt "$AUDIT_INTERVAL_SECONDS" ]]; then
+		local remaining=$(((AUDIT_INTERVAL_SECONDS - elapsed) / 3600))
+		log_info "Last audit was $((elapsed / 3600))h ago (interval: ${AUDIT_INTERVAL_HOURS}h). Next in ~${remaining}h."
+		return 1
+	fi
 
-    return 0
+	return 0
 }
 
 #######################################
 # Phase 1: Deduplication
 #######################################
 phase_dedup() {
-    local dry_run="$1"
-    local quiet="$2"
+	local dry_run="$1"
+	local quiet="$2"
 
-    [[ "$quiet" != "true" ]] && log_info "Phase 1: Deduplication..."
+	[[ "$quiet" != "true" ]] && log_info "Phase 1: Deduplication..."
 
-    local output
-    if [[ "$dry_run" == "true" ]]; then
-        output=$("${SCRIPT_DIR}/memory-helper.sh" dedup --dry-run 2>&1) || true
-    else
-        output=$("${SCRIPT_DIR}/memory-helper.sh" dedup 2>&1) || true
-    fi
+	local output
+	if [[ "$dry_run" == "true" ]]; then
+		output=$("${SCRIPT_DIR}/memory-helper.sh" dedup --dry-run 2>&1) || true
+	else
+		output=$("${SCRIPT_DIR}/memory-helper.sh" dedup 2>&1) || true
+	fi
 
-    # Extract count from output
-    local removed=0
-    if echo "$output" | grep -q "Removed"; then
-        removed=$(echo "$output" | grep -oE 'Removed [0-9]+' | grep -oE '[0-9]+' || echo "0")
-    elif echo "$output" | grep -q "Would remove"; then
-        removed=$(echo "$output" | grep -oE 'Would remove [0-9]+' | grep -oE '[0-9]+' || echo "0")
-    fi
+	# Extract count from output
+	local removed=0
+	if echo "$output" | grep -q "Removed"; then
+		removed=$(echo "$output" | grep -oE 'Removed [0-9]+' | grep -oE '[0-9]+' || echo "0")
+	elif echo "$output" | grep -q "Would remove"; then
+		removed=$(echo "$output" | grep -oE 'Would remove [0-9]+' | grep -oE '[0-9]+' || echo "0")
+	fi
 
-    [[ "$quiet" != "true" ]] && {
-        if [[ "$removed" -gt 0 ]]; then
-            log_success "Dedup: ${removed} duplicates ${dry_run:+would be }removed"
-        else
-            log_success "Dedup: no duplicates found"
-        fi
-    }
+	[[ "$quiet" != "true" ]] && {
+		if [[ "$removed" -gt 0 ]]; then
+			log_success "Dedup: ${removed} duplicates ${dry_run:+would be }removed"
+		else
+			log_success "Dedup: no duplicates found"
+		fi
+	}
 
-    echo "$removed"
-    return 0
+	echo "$removed"
+	return 0
 }
 
 #######################################
 # Phase 2: Pruning
 #######################################
 phase_prune() {
-    local dry_run="$1"
-    local quiet="$2"
+	local dry_run="$1"
+	local quiet="$2"
 
-    [[ "$quiet" != "true" ]] && log_info "Phase 2: Pruning stale entries..."
+	[[ "$quiet" != "true" ]] && log_info "Phase 2: Pruning stale entries..."
 
-    if [[ ! -f "$MEMORY_DB" ]]; then
-        echo "0"
-        return 0
-    fi
+	if [[ ! -f "$MEMORY_DB" ]]; then
+		echo "0"
+		return 0
+	fi
 
-    # Count stale entries (>90 days, never accessed)
-    local stale_count
-    stale_count=$(db "$MEMORY_DB" \
-        "SELECT COUNT(*) FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.created_at < datetime('now', '-90 days') AND a.id IS NULL;" \
-        2>/dev/null || echo "0")
+	# Count stale entries (>90 days, never accessed)
+	local stale_count
+	stale_count=$(db "$MEMORY_DB" \
+		"SELECT COUNT(*) FROM learnings l LEFT JOIN learning_access a ON l.id = a.id WHERE l.created_at < datetime('now', '-90 days') AND a.id IS NULL;" \
+		2>/dev/null || echo "0")
 
-    if [[ "$stale_count" -gt 0 ]]; then
-        if [[ "$dry_run" == "true" ]]; then
-            [[ "$quiet" != "true" ]] && log_info "Prune: would remove $stale_count stale entries"
-        else
-            # The auto_prune in memory-helper.sh handles this, but we force it here
-            "${SCRIPT_DIR}/memory-helper.sh" prune --older-than-days 90 >/dev/null 2>&1 || true
-            [[ "$quiet" != "true" ]] && log_success "Prune: removed $stale_count stale entries"
-        fi
-    else
-        [[ "$quiet" != "true" ]] && log_success "Prune: no stale entries"
-    fi
+	if [[ "$stale_count" -gt 0 ]]; then
+		if [[ "$dry_run" == "true" ]]; then
+			[[ "$quiet" != "true" ]] && log_info "Prune: would remove $stale_count stale entries"
+		else
+			# The auto_prune in memory-helper.sh handles this, but we force it here
+			"${SCRIPT_DIR}/memory-helper.sh" prune --older-than-days 90 >/dev/null 2>&1 || true
+			[[ "$quiet" != "true" ]] && log_success "Prune: removed $stale_count stale entries"
+		fi
+	else
+		[[ "$quiet" != "true" ]] && log_success "Prune: no stale entries"
+	fi
 
-    echo "$stale_count"
-    return 0
+	echo "$stale_count"
+	return 0
 }
 
 #######################################
 # Phase 3: Graduation
 #######################################
 phase_graduate() {
-    local dry_run="$1"
-    local quiet="$2"
+	local dry_run="$1"
+	local quiet="$2"
 
-    [[ "$quiet" != "true" ]] && log_info "Phase 3: Graduating high-value memories..."
+	[[ "$quiet" != "true" ]] && log_info "Phase 3: Graduating high-value memories..."
 
-    local graduate_script="${SCRIPT_DIR}/memory-graduate-helper.sh"
+	local graduate_script="${SCRIPT_DIR}/memory-graduate-helper.sh"
 
-    if [[ ! -x "$graduate_script" ]]; then
-        # Try repo path as fallback
-        local repo_root
-        repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
-        if [[ -n "$repo_root" && -x "$repo_root/.agents/scripts/memory-graduate-helper.sh" ]]; then
-            graduate_script="$repo_root/.agents/scripts/memory-graduate-helper.sh"
-        else
-            [[ "$quiet" != "true" ]] && log_warn "Graduate: memory-graduate-helper.sh not found, skipping"
-            echo "0"
-            return 0
-        fi
-    fi
+	if [[ ! -x "$graduate_script" ]]; then
+		# Try repo path as fallback
+		local repo_root
+		repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+		if [[ -n "$repo_root" && -x "$repo_root/.agents/scripts/memory-graduate-helper.sh" ]]; then
+			graduate_script="$repo_root/.agents/scripts/memory-graduate-helper.sh"
+		else
+			[[ "$quiet" != "true" ]] && log_warn "Graduate: memory-graduate-helper.sh not found, skipping"
+			echo "0"
+			return 0
+		fi
+	fi
 
-    local grad_args=("graduate")
-    [[ "$dry_run" == "true" ]] && grad_args+=("--dry-run")
+	local grad_args=("graduate")
+	[[ "$dry_run" == "true" ]] && grad_args+=("--dry-run")
 
-    local output
-    output=$("$graduate_script" "${grad_args[@]}" 2>&1) || true
+	local output
+	output=$("$graduate_script" "${grad_args[@]}" 2>&1) || true
 
-    local graduated=0
-    if echo "$output" | grep -q "Graduated"; then
-        graduated=$(echo "$output" | grep -oE 'Graduated [0-9]+' | grep -oE '[0-9]+' || echo "0")
-    fi
+	local graduated=0
+	if echo "$output" | grep -q "Graduated"; then
+		graduated=$(echo "$output" | grep -oE 'Graduated [0-9]+' | grep -oE '[0-9]+' || echo "0")
+	fi
 
-    [[ "$quiet" != "true" ]] && {
-        if [[ "$graduated" -gt 0 ]]; then
-            log_success "Graduate: ${graduated} memories ${dry_run:+would be }promoted to shared docs"
-        else
-            log_success "Graduate: no new candidates"
-        fi
-    }
+	[[ "$quiet" != "true" ]] && {
+		if [[ "$graduated" -gt 0 ]]; then
+			log_success "Graduate: ${graduated} memories ${dry_run:+would be }promoted to shared docs"
+		else
+			log_success "Graduate: no new candidates"
+		fi
+	}
 
-    echo "$graduated"
-    return 0
+	echo "$graduated"
+	return 0
 }
 
 #######################################
@@ -203,21 +202,22 @@ phase_graduate() {
 # Identifies patterns that suggest self-improvement opportunities
 #######################################
 phase_opportunities() {
-    local quiet="$1"
+	local quiet="$1"
 
-    [[ "$quiet" != "true" ]] && log_info "Phase 4: Scanning for improvement opportunities..."
+	[[ "$quiet" != "true" ]] && log_info "Phase 4: Scanning for improvement opportunities..."
 
-    if [[ ! -f "$MEMORY_DB" ]]; then
-        echo "0"
-        return 0
-    fi
+	if [[ ! -f "$MEMORY_DB" ]]; then
+		echo "0"
+		return 0
+	fi
 
-    local opportunities=0
-    local opportunity_details=""
+	local opportunities=0
+	local opportunity_details=""
 
-    # 4a. Check for repeated failure patterns (same type of error recurring)
-    local repeated_failures
-    repeated_failures=$(db "$MEMORY_DB" <<'EOF'
+	# 4a. Check for repeated failure patterns (same type of error recurring)
+	local repeated_failures
+	repeated_failures=$(
+		db "$MEMORY_DB" <<'EOF'
 SELECT type, COUNT(*) as cnt
 FROM learnings
 WHERE type IN ('FAILED_APPROACH', 'FAILURE_PATTERN', 'ERROR_FIX')
@@ -226,20 +226,21 @@ GROUP BY type
 HAVING cnt >= 3
 ORDER BY cnt DESC;
 EOF
-    )
+	)
 
-    if [[ -n "$repeated_failures" ]]; then
-        while IFS='|' read -r ftype fcount; do
-            [[ -z "$ftype" ]] && continue
-            opportunities=$((opportunities + 1))
-            opportunity_details+="  - Recurring ${ftype}: ${fcount} in last 30 days (investigate root cause)\n"
-        done <<< "$repeated_failures"
-    fi
+	if [[ -n "$repeated_failures" ]]; then
+		while IFS='|' read -r ftype fcount; do
+			[[ -z "$ftype" ]] && continue
+			opportunities=$((opportunities + 1))
+			opportunity_details+="  - Recurring ${ftype}: ${fcount} in last 30 days (investigate root cause)\n"
+		done <<<"$repeated_failures"
+	fi
 
-    # 4b. Check for low-confidence memories that are frequently accessed
-    # (suggests they should be validated and upgraded)
-    local low_conf_popular
-    low_conf_popular=$(db "$MEMORY_DB" <<'EOF'
+	# 4b. Check for low-confidence memories that are frequently accessed
+	# (suggests they should be validated and upgraded)
+	local low_conf_popular
+	low_conf_popular=$(
+		db "$MEMORY_DB" <<'EOF'
 SELECT l.id, substr(l.content, 1, 80), COALESCE(a.access_count, 0) as ac
 FROM learnings l
 LEFT JOIN learning_access a ON l.id = a.id
@@ -247,261 +248,272 @@ WHERE l.confidence = 'low'
 AND COALESCE(a.access_count, 0) >= 3
 LIMIT 5;
 EOF
-    )
+	)
 
-    if [[ -n "$low_conf_popular" ]]; then
-        while IFS='|' read -r lid lcontent lac; do
-            [[ -z "$lid" ]] && continue
-            opportunities=$((opportunities + 1))
-            opportunity_details+="  - Popular but low-confidence ($lid, ${lac}x): upgrade confidence? ${lcontent}...\n"
-        done <<< "$low_conf_popular"
-    fi
+	if [[ -n "$low_conf_popular" ]]; then
+		while IFS='|' read -r lid lcontent lac; do
+			[[ -z "$lid" ]] && continue
+			opportunities=$((opportunities + 1))
+			opportunity_details+="  - Popular but low-confidence ($lid, ${lac}x): upgrade confidence? ${lcontent}...\n"
+		done <<<"$low_conf_popular"
+	fi
 
-    # 4c. Check for memories with no tags (harder to find later)
-    local untagged_count
-    untagged_count=$(db "$MEMORY_DB" \
-        "SELECT COUNT(*) FROM learnings WHERE tags = '' OR tags IS NULL;" \
-        2>/dev/null || echo "0")
+	# 4c. Check for memories with no tags (harder to find later)
+	local untagged_count
+	untagged_count=$(db "$MEMORY_DB" \
+		"SELECT COUNT(*) FROM learnings WHERE tags = '' OR tags IS NULL;" \
+		2>/dev/null || echo "0")
 
-    if [[ "$untagged_count" -gt 10 ]]; then
-        opportunities=$((opportunities + 1))
-        opportunity_details+="  - ${untagged_count} memories have no tags (reduces discoverability)\n"
-    fi
+	if [[ "$untagged_count" -gt 10 ]]; then
+		opportunities=$((opportunities + 1))
+		opportunity_details+="  - ${untagged_count} memories have no tags (reduces discoverability)\n"
+	fi
 
-    # 4d. Check for superseded memories that were never cleaned up
-    local orphan_superseded
-    orphan_superseded=$(db "$MEMORY_DB" <<'EOF'
+	# 4d. Check for superseded memories that were never cleaned up
+	local orphan_superseded
+	orphan_superseded=$(
+		db "$MEMORY_DB" <<'EOF'
 SELECT COUNT(*) FROM learning_relations lr
 WHERE lr.relation_type = 'updates'
 AND lr.supersedes_id IN (SELECT id FROM learnings);
 EOF
-    )
-    orphan_superseded="${orphan_superseded:-0}"
+	)
+	orphan_superseded="${orphan_superseded:-0}"
 
-    if [[ "$orphan_superseded" -gt 5 ]]; then
-        opportunities=$((opportunities + 1))
-        opportunity_details+="  - ${orphan_superseded} superseded memories still in DB (consider archiving)\n"
-    fi
+	if [[ "$orphan_superseded" -gt 5 ]]; then
+		opportunities=$((opportunities + 1))
+		opportunity_details+="  - ${orphan_superseded} superseded memories still in DB (consider archiving)\n"
+	fi
 
-    # 4e. Check memory growth rate (warn if growing too fast)
-    local recent_7d
-    recent_7d=$(db "$MEMORY_DB" \
-        "SELECT COUNT(*) FROM learnings WHERE created_at >= datetime('now', '-7 days');" \
-        2>/dev/null || echo "0")
+	# 4e. Check memory growth rate (warn if growing too fast)
+	local recent_7d
+	recent_7d=$(db "$MEMORY_DB" \
+		"SELECT COUNT(*) FROM learnings WHERE created_at >= datetime('now', '-7 days');" \
+		2>/dev/null || echo "0")
 
-    if [[ "$recent_7d" -gt 50 ]]; then
-        opportunities=$((opportunities + 1))
-        opportunity_details+="  - High memory growth: ${recent_7d} in 7 days (check for noisy auto-capture)\n"
-    fi
+	if [[ "$recent_7d" -gt 50 ]]; then
+		opportunities=$((opportunities + 1))
+		opportunity_details+="  - High memory growth: ${recent_7d} in 7 days (check for noisy auto-capture)\n"
+	fi
 
-    # 4f. Check for batch retrospective noise (session metadata stored as memories)
-    local noise_count
-    noise_count=$(db "$MEMORY_DB" <<'EOF'
+	# 4f. Check for batch retrospective noise (session metadata stored as memories)
+	local noise_count
+	noise_count=$(
+		db "$MEMORY_DB" <<'EOF'
 SELECT COUNT(*) FROM learnings
 WHERE content LIKE 'Batch retrospective:%'
    OR content LIKE 'Session review for batch%'
    OR content LIKE 'Implemented feature: t%'
    OR content LIKE 'Supervisor task t%';
 EOF
-    )
-    noise_count="${noise_count:-0}"
+	)
+	noise_count="${noise_count:-0}"
 
-    if [[ "$noise_count" -gt 5 ]]; then
-        opportunities=$((opportunities + 1))
-        opportunity_details+="  - ${noise_count} session-metadata memories (low value, consider filtering in auto-capture)\n"
-    fi
+	if [[ "$noise_count" -gt 5 ]]; then
+		opportunities=$((opportunities + 1))
+		opportunity_details+="  - ${noise_count} session-metadata memories (low value, consider filtering in auto-capture)\n"
+	fi
 
-    [[ "$quiet" != "true" ]] && {
-        if [[ "$opportunities" -gt 0 ]]; then
-            log_warn "Found $opportunities improvement opportunities:"
-            echo -e "$opportunity_details" >&2
-        else
-            log_success "No improvement opportunities found"
-        fi
-    }
+	[[ "$quiet" != "true" ]] && {
+		if [[ "$opportunities" -gt 0 ]]; then
+			log_warn "Found $opportunities improvement opportunities:"
+			echo -e "$opportunity_details" >&2
+		else
+			log_success "No improvement opportunities found"
+		fi
+	}
 
-    echo "$opportunities"
-    return 0
+	echo "$opportunities"
+	return 0
 }
 
 #######################################
 # Phase 5: Report
 #######################################
 phase_report() {
-    local dedup_count="$1"
-    local prune_count="$2"
-    local graduate_count="$3"
-    local opportunity_count="$4"
-    local dry_run="$5"
-    local quiet="$6"
+	local dedup_count="$1"
+	local prune_count="$2"
+	local graduate_count="$3"
+	local opportunity_count="$4"
+	local dry_run="$5"
+	local quiet="$6"
 
-    # Get current stats
-    local total_memories=0
-    if [[ -f "$MEMORY_DB" ]]; then
-        total_memories=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings;" 2>/dev/null || echo "0")
-    fi
+	# Get current stats
+	local total_memories=0
+	if [[ -f "$MEMORY_DB" ]]; then
+		total_memories=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings;" 2>/dev/null || echo "0")
+	fi
 
-    local db_size="0K"
-    if [[ -f "$MEMORY_DB" ]]; then
-        db_size=$(du -h "$MEMORY_DB" | cut -f1)
-    fi
+	local db_size="0K"
+	if [[ -f "$MEMORY_DB" ]]; then
+		db_size=$(du -h "$MEMORY_DB" | cut -f1)
+	fi
 
-    local timestamp
-    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+	local timestamp
+	timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-    # Build report
-    local report=""
-    report+="Memory Audit Pulse Report\n"
-    report+="========================\n"
-    report+="Timestamp: $timestamp\n"
-    local mode_label="LIVE"
-    [[ "$dry_run" == "true" ]] && mode_label="DRY RUN"
-    report+="Mode: $mode_label\n"
-    report+="\n"
-    report+="Actions:\n"
-    report+="  Duplicates removed: $dedup_count\n"
-    report+="  Stale entries pruned: $prune_count\n"
-    report+="  Memories graduated: $graduate_count\n"
-    report+="  Opportunities found: $opportunity_count\n"
-    report+="\n"
-    report+="Database:\n"
-    report+="  Total memories: $total_memories\n"
-    report+="  Database size: $db_size\n"
+	# Build report
+	local report=""
+	report+="Memory Audit Pulse Report\n"
+	report+="========================\n"
+	report+="Timestamp: $timestamp\n"
+	local mode_label="LIVE"
+	[[ "$dry_run" == "true" ]] && mode_label="DRY RUN"
+	report+="Mode: $mode_label\n"
+	report+="\n"
+	report+="Actions:\n"
+	report+="  Duplicates removed: $dedup_count\n"
+	report+="  Stale entries pruned: $prune_count\n"
+	report+="  Memories graduated: $graduate_count\n"
+	report+="  Opportunities found: $opportunity_count\n"
+	report+="\n"
+	report+="Database:\n"
+	report+="  Total memories: $total_memories\n"
+	report+="  Database size: $db_size\n"
 
-    [[ "$quiet" != "true" ]] && {
-        echo ""
-        echo -e "$report"
-    }
+	[[ "$quiet" != "true" ]] && {
+		echo ""
+		echo -e "$report"
+	}
 
-    # Save report to audit log
-    mkdir -p "$AUDIT_LOG_DIR"
-    local report_file
-    report_file="$AUDIT_LOG_DIR/audit-$(date -u +%Y%m%d-%H%M%S).txt"
-    echo -e "$report" > "$report_file"
+	# Save report to audit log
+	mkdir -p "$AUDIT_LOG_DIR"
+	local report_file
+	report_file="$AUDIT_LOG_DIR/audit-$(date -u +%Y%m%d-%H%M%S).txt"
+	echo -e "$report" >"$report_file"
 
-    # Append to JSONL history
-    local history_file="$AUDIT_LOG_DIR/history.jsonl"
-    echo "{\"timestamp\":\"$timestamp\",\"dedup\":$dedup_count,\"pruned\":$prune_count,\"graduated\":$graduate_count,\"opportunities\":$opportunity_count,\"total\":$total_memories,\"dry_run\":${dry_run:-false}}" >> "$history_file"
+	# Append to JSONL history
+	local history_file="$AUDIT_LOG_DIR/history.jsonl"
+	echo "{\"timestamp\":\"$timestamp\",\"dedup\":$dedup_count,\"pruned\":$prune_count,\"graduated\":$graduate_count,\"opportunities\":$opportunity_count,\"total\":$total_memories,\"dry_run\":${dry_run:-false}}" >>"$history_file"
 
-    return 0
+	return 0
 }
 
 #######################################
 # Main: run all phases
 #######################################
 cmd_run() {
-    local dry_run="false"
-    local quiet="false"
-    local force="false"
+	local dry_run="false"
+	local quiet="false"
+	local force="false"
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --dry-run) dry_run="true"; shift ;;
-            --quiet|-q) quiet="true"; shift ;;
-            --force|-f) force="true"; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--dry-run)
+			dry_run="true"
+			shift
+			;;
+		--quiet | -q)
+			quiet="true"
+			shift
+			;;
+		--force | -f)
+			force="true"
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    # Check interval (skip if --force)
-    if [[ "$force" != "true" ]] && ! should_run; then
-        return 0
-    fi
+	# Check interval (skip if --force)
+	if [[ "$force" != "true" ]] && ! should_run; then
+		return 0
+	fi
 
-    [[ "$quiet" != "true" ]] && log_info "Starting memory audit pulse..."
+	[[ "$quiet" != "true" ]] && log_info "Starting memory audit pulse..."
 
-    if [[ ! -f "$MEMORY_DB" ]]; then
-        [[ "$quiet" != "true" ]] && log_warn "No memory database found at $MEMORY_DB"
-        return 0
-    fi
+	if [[ ! -f "$MEMORY_DB" ]]; then
+		[[ "$quiet" != "true" ]] && log_warn "No memory database found at $MEMORY_DB"
+		return 0
+	fi
 
-    # Run all phases
-    local dedup_count prune_count graduate_count opportunity_count
+	# Run all phases
+	local dedup_count prune_count graduate_count opportunity_count
 
-    dedup_count=$(phase_dedup "$dry_run" "$quiet")
-    prune_count=$(phase_prune "$dry_run" "$quiet")
-    graduate_count=$(phase_graduate "$dry_run" "$quiet")
-    opportunity_count=$(phase_opportunities "$quiet")
+	dedup_count=$(phase_dedup "$dry_run" "$quiet")
+	prune_count=$(phase_prune "$dry_run" "$quiet")
+	graduate_count=$(phase_graduate "$dry_run" "$quiet")
+	opportunity_count=$(phase_opportunities "$quiet")
 
-    # Generate report
-    phase_report "$dedup_count" "$prune_count" "$graduate_count" "$opportunity_count" "$dry_run" "$quiet"
+	# Generate report
+	phase_report "$dedup_count" "$prune_count" "$graduate_count" "$opportunity_count" "$dry_run" "$quiet"
 
-    # Update marker (only on live runs)
-    if [[ "$dry_run" != "true" ]]; then
-        touch "$AUDIT_MARKER"
-    fi
+	# Update marker (only on live runs)
+	if [[ "$dry_run" != "true" ]]; then
+		touch "$AUDIT_MARKER"
+	fi
 
-    [[ "$quiet" != "true" ]] && log_success "Audit pulse complete."
+	[[ "$quiet" != "true" ]] && log_success "Audit pulse complete."
 
-    return 0
+	return 0
 }
 
 #######################################
 # Show audit status and history
 #######################################
 cmd_status() {
-    echo ""
-    echo "=== Memory Audit Pulse Status ==="
-    echo ""
+	echo ""
+	echo "=== Memory Audit Pulse Status ==="
+	echo ""
 
-    # Last audit
-    if [[ -f "$AUDIT_MARKER" ]]; then
-        local last_run
-        last_run=$(stat -c %Y "$AUDIT_MARKER" 2>/dev/null || stat -f %m "$AUDIT_MARKER" 2>/dev/null || echo "0")
-        local now
-        now=$(date +%s)
-        local elapsed=$(( (now - last_run) / 3600 ))
-        log_info "Last audit: ${elapsed}h ago"
-    else
-        log_info "Last audit: never"
-    fi
+	# Last audit
+	if [[ -f "$AUDIT_MARKER" ]]; then
+		local last_run
+		last_run=$(stat -c %Y "$AUDIT_MARKER" 2>/dev/null || stat -f %m "$AUDIT_MARKER" 2>/dev/null || echo "0")
+		local now
+		now=$(date +%s)
+		local elapsed=$(((now - last_run) / 3600))
+		log_info "Last audit: ${elapsed}h ago"
+	else
+		log_info "Last audit: never"
+	fi
 
-    # Audit interval
-    log_info "Audit interval: ${AUDIT_INTERVAL_HOURS}h"
+	# Audit interval
+	log_info "Audit interval: ${AUDIT_INTERVAL_HOURS}h"
 
-    # History
-    local history_file="$AUDIT_LOG_DIR/history.jsonl"
-    if [[ -f "$history_file" ]]; then
-        local history_count
-        history_count=$(wc -l < "$history_file" | tr -d ' ')
-        log_info "Total audits: $history_count"
+	# History
+	local history_file="$AUDIT_LOG_DIR/history.jsonl"
+	if [[ -f "$history_file" ]]; then
+		local history_count
+		history_count=$(wc -l <"$history_file" | tr -d ' ')
+		log_info "Total audits: $history_count"
 
-        echo ""
-        echo "Recent audits:"
-        tail -5 "$history_file" | while IFS= read -r line; do
-            local ts dedup pruned graduated opps
-            ts=$(echo "$line" | jq -r '.timestamp' 2>/dev/null || echo "?")
-            dedup=$(echo "$line" | jq -r '.dedup' 2>/dev/null || echo "0")
-            pruned=$(echo "$line" | jq -r '.pruned' 2>/dev/null || echo "0")
-            graduated=$(echo "$line" | jq -r '.graduated' 2>/dev/null || echo "0")
-            opps=$(echo "$line" | jq -r '.opportunities' 2>/dev/null || echo "0")
-            echo "  $ts | dedup:$dedup prune:$pruned grad:$graduated opps:$opps"
-        done
-    else
-        log_info "No audit history yet"
-    fi
+		echo ""
+		echo "Recent audits:"
+		tail -5 "$history_file" | while IFS= read -r line; do
+			local ts dedup pruned graduated opps
+			ts=$(echo "$line" | jq -r '.timestamp' 2>/dev/null || echo "?")
+			dedup=$(echo "$line" | jq -r '.dedup' 2>/dev/null || echo "0")
+			pruned=$(echo "$line" | jq -r '.pruned' 2>/dev/null || echo "0")
+			graduated=$(echo "$line" | jq -r '.graduated' 2>/dev/null || echo "0")
+			opps=$(echo "$line" | jq -r '.opportunities' 2>/dev/null || echo "0")
+			echo "  $ts | dedup:$dedup prune:$pruned grad:$graduated opps:$opps"
+		done
+	else
+		log_info "No audit history yet"
+	fi
 
-    # Memory DB stats
-    echo ""
-    if [[ -f "$MEMORY_DB" ]]; then
-        local total
-        total=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings;" 2>/dev/null || echo "0")
-        local db_size
-        db_size=$(du -h "$MEMORY_DB" | cut -f1)
-        log_info "Memory DB: $total memories, $db_size"
-    else
-        log_info "Memory DB: not found"
-    fi
+	# Memory DB stats
+	echo ""
+	if [[ -f "$MEMORY_DB" ]]; then
+		local total
+		total=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings;" 2>/dev/null || echo "0")
+		local db_size
+		db_size=$(du -h "$MEMORY_DB" | cut -f1)
+		log_info "Memory DB: $total memories, $db_size"
+	else
+		log_info "Memory DB: not found"
+	fi
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 #######################################
 # Show help
 #######################################
 cmd_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 memory-audit-pulse.sh - Periodic memory self-improvement scan
 
 Automated memory hygiene that deduplicates, prunes, graduates, and
@@ -556,26 +568,26 @@ EXAMPLES:
     # Check status and history
     memory-audit-pulse.sh status
 EOF
-    return 0
+	return 0
 }
 
 #######################################
 # Main
 #######################################
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    case "$command" in
-        run|pulse)    cmd_run "$@" ;;
-        status|stats) cmd_status ;;
-        help|--help|-h) cmd_help ;;
-        *)
-            log_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
+	case "$command" in
+	run | pulse) cmd_run "$@" ;;
+	status | stats) cmd_status ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/memory-graduate-helper.sh
+++ b/.agents/scripts/memory-graduate-helper.sh
@@ -38,62 +38,59 @@ readonly DEFAULT_LIMIT=20
 # Target file for graduated learnings (relative to repo root)
 readonly GRADUATED_FILE_NAME="graduated-learnings.md"
 
-log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh
 
 #######################################
 # SQLite wrapper with busy_timeout
 #######################################
 db() {
-    sqlite3 -cmd ".timeout 5000" "$@"
+	sqlite3 -cmd ".timeout 5000" "$@"
 }
 
 #######################################
 # Find the repo root (for writing graduated-learnings.md)
 #######################################
 find_repo_root() {
-    git rev-parse --show-toplevel 2>/dev/null || echo ""
+	git rev-parse --show-toplevel 2>/dev/null || echo ""
 }
 
 #######################################
 # Resolve the graduated learnings file path
 #######################################
 graduated_file_path() {
-    local repo_root
-    repo_root=$(find_repo_root)
-    if [[ -z "$repo_root" ]]; then
-        log_error "Not in a git repository. Cannot locate graduated-learnings.md"
-        return 1
-    fi
-    echo "$repo_root/.agents/aidevops/$GRADUATED_FILE_NAME"
+	local repo_root
+	repo_root=$(find_repo_root)
+	if [[ -z "$repo_root" ]]; then
+		log_error "Not in a git repository. Cannot locate graduated-learnings.md"
+		return 1
+	fi
+	echo "$repo_root/.agents/aidevops/$GRADUATED_FILE_NAME"
 }
 
 #######################################
 # Ensure the graduated_at column exists in learning_access
 #######################################
 ensure_schema() {
-    if [[ ! -f "$MEMORY_DB" ]]; then
-        log_error "Memory database not found: $MEMORY_DB"
-        log_error "Run memory-helper.sh store to initialize."
-        return 1
-    fi
+	if [[ ! -f "$MEMORY_DB" ]]; then
+		log_error "Memory database not found: $MEMORY_DB"
+		log_error "Run memory-helper.sh store to initialize."
+		return 1
+	fi
 
-    local has_graduated
-    has_graduated=$(db "$MEMORY_DB" \
-        "SELECT COUNT(*) FROM pragma_table_info('learning_access') WHERE name='graduated_at';" \
-        2>/dev/null || echo "0")
+	local has_graduated
+	has_graduated=$(db "$MEMORY_DB" \
+		"SELECT COUNT(*) FROM pragma_table_info('learning_access') WHERE name='graduated_at';" \
+		2>/dev/null || echo "0")
 
-    if [[ "$has_graduated" == "0" ]]; then
-        log_info "Migrating schema: adding graduated_at column..."
-        db "$MEMORY_DB" \
-            "ALTER TABLE learning_access ADD COLUMN graduated_at TEXT DEFAULT NULL;" \
-            2>/dev/null || true
-        log_success "Schema updated"
-    fi
+	if [[ "$has_graduated" == "0" ]]; then
+		log_info "Migrating schema: adding graduated_at column..."
+		db "$MEMORY_DB" \
+			"ALTER TABLE learning_access ADD COLUMN graduated_at TEXT DEFAULT NULL;" \
+			2>/dev/null || true
+		log_success "Schema updated"
+	fi
 
-    return 0
+	return 0
 }
 
 #######################################
@@ -101,78 +98,78 @@ ensure_schema() {
 # Returns 0 if content is actionable, 1 if it should be skipped
 #######################################
 is_actionable() {
-    local content="$1"
+	local content="$1"
 
-    # Skip batch retrospectives (session metadata)
-    if [[ "$content" == *"Batch retrospective:"* ]]; then
-        return 1
-    fi
+	# Skip batch retrospectives (session metadata)
+	if [[ "$content" == *"Batch retrospective:"* ]]; then
+		return 1
+	fi
 
-    # Skip session review entries
-    if [[ "$content" == *"Session review for batch"* ]]; then
-        return 1
-    fi
+	# Skip session review entries
+	if [[ "$content" == *"Session review for batch"* ]]; then
+		return 1
+	fi
 
-    # Skip "Implemented feature:" one-liners (too vague)
-    if [[ "$content" =~ ^Implemented\ feature:\ [a-zA-Z0-9_-]+$ ]]; then
-        return 1
-    fi
+	# Skip "Implemented feature:" one-liners (too vague)
+	if [[ "$content" =~ ^Implemented\ feature:\ [a-zA-Z0-9_-]+$ ]]; then
+		return 1
+	fi
 
-    # Skip pure commit message references (no actionable content)
-    if [[ "$content" =~ ^(Merge\ pull\ request|docs:\ (add|mark|update)) ]]; then
-        return 1
-    fi
+	# Skip pure commit message references (no actionable content)
+	if [[ "$content" =~ ^(Merge\ pull\ request|docs:\ (add|mark|update)) ]]; then
+		return 1
+	fi
 
-    # Skip entries shorter than 20 chars (too terse to be useful)
-    if [[ ${#content} -lt 20 ]]; then
-        return 1
-    fi
+	# Skip entries shorter than 20 chars (too terse to be useful)
+	if [[ ${#content} -lt 20 ]]; then
+		return 1
+	fi
 
-    # Skip user-specific config (GPG keys, email addresses, local paths)
-    if [[ "$content" == *"GPG key"* || "$content" == *"pinentry-mac"* ]]; then
-        return 1
-    fi
-    if [[ "$content" == *"@"*".com"* && "$content" == *"initialized"* ]]; then
-        return 1
-    fi
+	# Skip user-specific config (GPG keys, email addresses, local paths)
+	if [[ "$content" == *"GPG key"* || "$content" == *"pinentry-mac"* ]]; then
+		return 1
+	fi
+	if [[ "$content" == *"@"*".com"* && "$content" == *"initialized"* ]]; then
+		return 1
+	fi
 
-    # Skip supervisor task status entries (operational, not learnings)
-    if [[ "$content" =~ ^Supervisor\ task\ t[0-9]+ ]]; then
-        return 1
-    fi
+	# Skip supervisor task status entries (operational, not learnings)
+	if [[ "$content" =~ ^Supervisor\ task\ t[0-9]+ ]]; then
+		return 1
+	fi
 
-    return 0
+	return 0
 }
 
 #######################################
 # Categorize a memory into a section for the graduated doc
 #######################################
 categorize_memory() {
-    local type="$1"
+	local type="$1"
 
-    case "$type" in
-        WORKING_SOLUTION|ERROR_FIX)
-            echo "Solutions & Fixes"
-            ;;
-        FAILED_APPROACH|FAILURE_PATTERN)
-            echo "Anti-Patterns (What NOT to Do)"
-            ;;
-        CODEBASE_PATTERN|SUCCESS_PATTERN)
-            echo "Patterns & Best Practices"
-            ;;
-        DECISION|ARCHITECTURAL_DECISION)
-            echo "Architecture Decisions"
-            ;;
-        USER_PREFERENCE|TOOL_CONFIG)
-            echo "Configuration & Preferences"
-            ;;
-        CONTEXT)
-            echo "Context & Background"
-            ;;
-        *)
-            echo "General Learnings"
-            ;;
-    esac
+	case "$type" in
+	WORKING_SOLUTION | ERROR_FIX)
+		echo "Solutions & Fixes"
+		;;
+	FAILED_APPROACH | FAILURE_PATTERN)
+		echo "Anti-Patterns (What NOT to Do)"
+		;;
+	CODEBASE_PATTERN | SUCCESS_PATTERN)
+		echo "Patterns & Best Practices"
+		;;
+	DECISION | ARCHITECTURAL_DECISION)
+		echo "Architecture Decisions"
+		;;
+	USER_PREFERENCE | TOOL_CONFIG)
+		echo "Configuration & Preferences"
+		;;
+	CONTEXT)
+		echo "Context & Background"
+		;;
+	*)
+		echo "General Learnings"
+		;;
+	esac
 }
 
 #######################################
@@ -180,25 +177,35 @@ categorize_memory() {
 # Criteria: high confidence OR frequently accessed, not yet graduated
 #######################################
 cmd_candidates() {
-    local limit=$DEFAULT_LIMIT
-    local min_access=$DEFAULT_MIN_ACCESS
+	local limit=$DEFAULT_LIMIT
+	local min_access=$DEFAULT_MIN_ACCESS
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --limit|-l) limit="$2"; shift 2 ;;
-            --min-access) min_access="$2"; shift 2 ;;
-            --json) local format="json"; shift ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--limit | -l)
+			limit="$2"
+			shift 2
+			;;
+		--min-access)
+			min_access="$2"
+			shift 2
+			;;
+		--json)
+			local format="json"
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
 
-    ensure_schema || return 1
+	ensure_schema || return 1
 
-    log_info "Finding graduation candidates (min access: $min_access, limit: $limit)..."
-    echo ""
+	log_info "Finding graduation candidates (min access: $min_access, limit: $limit)..."
+	echo ""
 
-    local results
-    results=$(db -json "$MEMORY_DB" <<EOF
+	local results
+	results=$(
+		db -json "$MEMORY_DB" <<EOF
 SELECT
     l.id,
     l.type,
@@ -221,84 +228,94 @@ ORDER BY
     l.created_at ASC
 LIMIT $limit;
 EOF
-    )
+	)
 
-    if [[ -z "$results" || "$results" == "[]" ]]; then
-        log_info "No graduation candidates found."
-        log_info "Memories qualify when: confidence=high OR access_count >= $min_access"
-        return 0
-    fi
+	if [[ -z "$results" || "$results" == "[]" ]]; then
+		log_info "No graduation candidates found."
+		log_info "Memories qualify when: confidence=high OR access_count >= $min_access"
+		return 0
+	fi
 
-    if [[ "${format:-text}" == "json" ]]; then
-        echo "$results"
-        return 0
-    fi
+	if [[ "${format:-text}" == "json" ]]; then
+		echo "$results"
+		return 0
+	fi
 
-    echo "=== Graduation Candidates ==="
-    echo ""
+	echo "=== Graduation Candidates ==="
+	echo ""
 
-    local count=0
-    local actionable=0
+	local count=0
+	local actionable=0
 
-    while IFS= read -r entry; do
-        local id type content confidence access_count
-        id=$(echo "$entry" | jq -r '.id')
-        type=$(echo "$entry" | jq -r '.type')
-        content=$(echo "$entry" | jq -r '.content')
-        confidence=$(echo "$entry" | jq -r '.confidence')
-        access_count=$(echo "$entry" | jq -r '.access_count')
+	while IFS= read -r entry; do
+		local id type content confidence access_count
+		id=$(echo "$entry" | jq -r '.id')
+		type=$(echo "$entry" | jq -r '.type')
+		content=$(echo "$entry" | jq -r '.content')
+		confidence=$(echo "$entry" | jq -r '.confidence')
+		access_count=$(echo "$entry" | jq -r '.access_count')
 
-        count=$((count + 1))
+		count=$((count + 1))
 
-        if is_actionable "$content"; then
-            actionable=$((actionable + 1))
-            local category
-            category=$(categorize_memory "$type")
-            echo "  [$type] (confidence: $confidence, accessed: ${access_count}x)"
-            echo "  Category: $category"
-            echo "  ID: $id"
-            echo "  $content"
-            echo ""
-        else
-            echo "  [SKIP] $id - session metadata / low-value"
-        fi
-    done < <(echo "$results" | jq -c '.[]')
+		if is_actionable "$content"; then
+			actionable=$((actionable + 1))
+			local category
+			category=$(categorize_memory "$type")
+			echo "  [$type] (confidence: $confidence, accessed: ${access_count}x)"
+			echo "  Category: $category"
+			echo "  ID: $id"
+			echo "  $content"
+			echo ""
+		else
+			echo "  [SKIP] $id - session metadata / low-value"
+		fi
+	done < <(echo "$results" | jq -c '.[]')
 
-    echo "---"
-    echo "Total candidates: $count (actionable: $actionable)"
-    echo ""
-    echo "Run 'memory-graduate-helper.sh graduate' to promote these to shared docs."
+	echo "---"
+	echo "Total candidates: $count (actionable: $actionable)"
+	echo ""
+	echo "Run 'memory-graduate-helper.sh graduate' to promote these to shared docs."
 
-    return 0
+	return 0
 }
 
 #######################################
 # Graduate memories into shared docs
 #######################################
 cmd_graduate() {
-    local dry_run=false
-    local limit=$DEFAULT_LIMIT
-    local min_access=$DEFAULT_MIN_ACCESS
+	local dry_run=false
+	local limit=$DEFAULT_LIMIT
+	local min_access=$DEFAULT_MIN_ACCESS
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --dry-run) dry_run=true; shift ;;
-            --limit|-l) limit="$2"; shift 2 ;;
-            --min-access) min_access="$2"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		--limit | -l)
+			limit="$2"
+			shift 2
+			;;
+		--min-access)
+			min_access="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    ensure_schema || return 1
+	ensure_schema || return 1
 
-    local target_file
-    target_file=$(graduated_file_path) || return 1
+	local target_file
+	target_file=$(graduated_file_path) || return 1
 
-    log_info "Graduating memories to $target_file..."
+	log_info "Graduating memories to $target_file..."
 
-    # Fetch candidates
-    local results
-    results=$(db -json "$MEMORY_DB" <<EOF
+	# Fetch candidates
+	local results
+	results=$(
+		db -json "$MEMORY_DB" <<EOF
 SELECT
     l.id,
     l.type,
@@ -320,122 +337,122 @@ ORDER BY
     l.created_at ASC
 LIMIT $limit;
 EOF
-    )
+	)
 
-    if [[ -z "$results" || "$results" == "[]" ]]; then
-        log_info "No memories to graduate."
-        return 0
-    fi
+	if [[ -z "$results" || "$results" == "[]" ]]; then
+		log_info "No memories to graduate."
+		return 0
+	fi
 
-    # Collect actionable entries grouped by category
-    # Use temp files for category grouping (bash 3.2 compat - no assoc arrays)
-    local tmp_dir
-    tmp_dir=$(mktemp -d)
-    # shellcheck disable=SC2064
-    trap "rm -rf '$tmp_dir'" EXIT
+	# Collect actionable entries grouped by category
+	# Use temp files for category grouping (bash 3.2 compat - no assoc arrays)
+	local tmp_dir
+	tmp_dir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmp_dir'" EXIT
 
-    local graduated_count=0
-    local skipped_count=0
-    local graduated_ids=()
+	local graduated_count=0
+	local skipped_count=0
+	local graduated_ids=()
 
-    while IFS= read -r entry; do
-        local id type content confidence access_count
-        id=$(echo "$entry" | jq -r '.id')
-        type=$(echo "$entry" | jq -r '.type')
-        content=$(echo "$entry" | jq -r '.content')
-        confidence=$(echo "$entry" | jq -r '.confidence')
-        access_count=$(echo "$entry" | jq -r '.access_count')
+	while IFS= read -r entry; do
+		local id type content confidence access_count
+		id=$(echo "$entry" | jq -r '.id')
+		type=$(echo "$entry" | jq -r '.type')
+		content=$(echo "$entry" | jq -r '.content')
+		confidence=$(echo "$entry" | jq -r '.confidence')
+		access_count=$(echo "$entry" | jq -r '.access_count')
 
-        if ! is_actionable "$content"; then
-            skipped_count=$((skipped_count + 1))
-            # Mark skipped entries as graduated too (so they don't reappear)
-            graduated_ids+=("$id")
-            continue
-        fi
+		if ! is_actionable "$content"; then
+			skipped_count=$((skipped_count + 1))
+			# Mark skipped entries as graduated too (so they don't reappear)
+			graduated_ids+=("$id")
+			continue
+		fi
 
-        local category
-        category=$(categorize_memory "$type")
-        local safe_category
-        safe_category=$(echo "$category" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
+		local category
+		category=$(categorize_memory "$type")
+		local safe_category
+		safe_category=$(echo "$category" | sed 's/[^a-zA-Z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//')
 
-        # Store the real category name in a mapping file
-        echo "$category" > "$tmp_dir/${safe_category}.name"
+		# Store the real category name in a mapping file
+		echo "$category" >"$tmp_dir/${safe_category}.name"
 
-        # Append to category file
-        {
-            echo "- **[$type]** $content"
-            echo "  *(confidence: $confidence, validated: ${access_count}x)*"
-            echo ""
-        } >> "$tmp_dir/${safe_category}.entries"
+		# Append to category file
+		{
+			echo "- **[$type]** $content"
+			echo "  *(confidence: $confidence, validated: ${access_count}x)*"
+			echo ""
+		} >>"$tmp_dir/${safe_category}.entries"
 
-        graduated_ids+=("$id")
-        graduated_count=$((graduated_count + 1))
-    done < <(echo "$results" | jq -c '.[]')
+		graduated_ids+=("$id")
+		graduated_count=$((graduated_count + 1))
+	done < <(echo "$results" | jq -c '.[]')
 
-    if [[ "$graduated_count" -eq 0 ]]; then
-        log_info "No actionable memories to graduate ($skipped_count skipped as metadata)."
-        # Still mark skipped entries
-        if [[ "$dry_run" == false && ${#graduated_ids[@]} -gt 0 ]]; then
-            mark_graduated "${graduated_ids[@]}"
-        fi
-        return 0
-    fi
+	if [[ "$graduated_count" -eq 0 ]]; then
+		log_info "No actionable memories to graduate ($skipped_count skipped as metadata)."
+		# Still mark skipped entries
+		if [[ "$dry_run" == false && ${#graduated_ids[@]} -gt 0 ]]; then
+			mark_graduated "${graduated_ids[@]}"
+		fi
+		return 0
+	fi
 
-    if [[ "$dry_run" == true ]]; then
-        log_info "[DRY RUN] Would graduate $graduated_count memories ($skipped_count skipped)"
-        echo ""
-        echo "=== Preview of graduated content ==="
-        echo ""
-        for entries_file in "$tmp_dir"/*.entries; do
-            [[ -f "$entries_file" ]] || continue
-            local base_name cat_name
-            base_name=$(basename "$entries_file" .entries)
-            cat_name=$(cat "$tmp_dir/${base_name}.name" 2>/dev/null || echo "$base_name")
-            echo "### $cat_name"
-            echo ""
-            cat "$entries_file"
-        done
-        return 0
-    fi
+	if [[ "$dry_run" == true ]]; then
+		log_info "[DRY RUN] Would graduate $graduated_count memories ($skipped_count skipped)"
+		echo ""
+		echo "=== Preview of graduated content ==="
+		echo ""
+		for entries_file in "$tmp_dir"/*.entries; do
+			[[ -f "$entries_file" ]] || continue
+			local base_name cat_name
+			base_name=$(basename "$entries_file" .entries)
+			cat_name=$(cat "$tmp_dir/${base_name}.name" 2>/dev/null || echo "$base_name")
+			echo "### $cat_name"
+			echo ""
+			cat "$entries_file"
+		done
+		return 0
+	fi
 
-    # Build the content to append
-    local new_content=""
-    local timestamp
-    timestamp=$(date -u +"%Y-%m-%d")
+	# Build the content to append
+	local new_content=""
+	local timestamp
+	timestamp=$(date -u +"%Y-%m-%d")
 
-    new_content+="
+	new_content+="
 ## Graduated: $timestamp
 
 "
 
-    local first_category=true
-    for entries_file in "$tmp_dir"/*.entries; do
-        [[ -f "$entries_file" ]] || continue
-        local base_name cat_name
-        base_name=$(basename "$entries_file" .entries)
-        cat_name=$(cat "$tmp_dir/${base_name}.name" 2>/dev/null || echo "$base_name")
-        # Add blank line before heading (MD022) - skip for first category
-        # (already has blank line from ## Graduated header above)
-        if [[ "$first_category" == true ]]; then
-            first_category=false
-        else
-            new_content+="
+	local first_category=true
+	for entries_file in "$tmp_dir"/*.entries; do
+		[[ -f "$entries_file" ]] || continue
+		local base_name cat_name
+		base_name=$(basename "$entries_file" .entries)
+		cat_name=$(cat "$tmp_dir/${base_name}.name" 2>/dev/null || echo "$base_name")
+		# Add blank line before heading (MD022) - skip for first category
+		# (already has blank line from ## Graduated header above)
+		if [[ "$first_category" == true ]]; then
+			first_category=false
+		else
+			new_content+="
 "
-        fi
-        new_content+="### $cat_name
+		fi
+		new_content+="### $cat_name
 
 "
-        new_content+=$(cat "$entries_file")
-        new_content+="
+		new_content+=$(cat "$entries_file")
+		new_content+="
 "
-    done
+	done
 
-    # Ensure target file exists with header
-    if [[ ! -f "$target_file" ]]; then
-        local target_dir
-        target_dir=$(dirname "$target_file")
-        mkdir -p "$target_dir"
-        cat > "$target_file" << 'HEADER'
+	# Ensure target file exists with header
+	if [[ ! -f "$target_file" ]]; then
+		local target_dir
+		target_dir=$(dirname "$target_file")
+		mkdir -p "$target_dir"
+		cat >"$target_file" <<'HEADER'
 ---
 description: Shared learnings graduated from local memory across all users
 mode: subagent
@@ -468,88 +485,91 @@ candidates and appends them here. Each graduation batch is timestamped.
 - **Context & Background**: Important background information
 
 HEADER
-        log_info "Created $target_file"
-    fi
+		log_info "Created $target_file"
+	fi
 
-    # Append graduated content
-    echo "$new_content" >> "$target_file"
+	# Append graduated content
+	echo "$new_content" >>"$target_file"
 
-    # Mark memories as graduated in the DB
-    mark_graduated "${graduated_ids[@]}"
+	# Mark memories as graduated in the DB
+	mark_graduated "${graduated_ids[@]}"
 
-    log_success "Graduated $graduated_count memories ($skipped_count skipped as metadata)"
-    log_info "Updated: $target_file"
-    log_info "Remember to commit and push the changes."
+	log_success "Graduated $graduated_count memories ($skipped_count skipped as metadata)"
+	log_info "Updated: $target_file"
+	log_info "Remember to commit and push the changes."
 
-    return 0
+	return 0
 }
 
 #######################################
 # Mark memories as graduated in the DB
 #######################################
 mark_graduated() {
-    local timestamp
-    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+	local timestamp
+	timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-    for id in "$@"; do
-        local escaped_id="${id//"'"/"''"}"
-        db "$MEMORY_DB" <<EOF
+	for id in "$@"; do
+		local escaped_id="${id//"'"/"''"}"
+		db "$MEMORY_DB" <<EOF
 INSERT INTO learning_access (id, last_accessed_at, access_count, graduated_at)
 VALUES ('$escaped_id', datetime('now'), 0, '$timestamp')
 ON CONFLICT(id) DO UPDATE SET graduated_at = '$timestamp';
 EOF
-    done
+	done
 
-    return 0
+	return 0
 }
 
 #######################################
 # Show graduation status
 #######################################
 cmd_status() {
-    ensure_schema || return 1
+	ensure_schema || return 1
 
-    echo ""
-    echo "=== Memory Graduation Status ==="
-    echo ""
+	echo ""
+	echo "=== Memory Graduation Status ==="
+	echo ""
 
-    # Total memories
-    local total
-    total=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings;" 2>/dev/null || echo "0")
-    echo "Total memories: $total"
+	# Total memories
+	local total
+	total=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings;" 2>/dev/null || echo "0")
+	echo "Total memories: $total"
 
-    # Already graduated
-    local graduated
-    graduated=$(db "$MEMORY_DB" \
-        "SELECT COUNT(*) FROM learning_access WHERE graduated_at IS NOT NULL AND graduated_at != '';" \
-        2>/dev/null || echo "0")
-    echo "Already graduated: $graduated"
+	# Already graduated
+	local graduated
+	graduated=$(db "$MEMORY_DB" \
+		"SELECT COUNT(*) FROM learning_access WHERE graduated_at IS NOT NULL AND graduated_at != '';" \
+		2>/dev/null || echo "0")
+	echo "Already graduated: $graduated"
 
-    # Candidates (high confidence)
-    local high_conf
-    high_conf=$(db "$MEMORY_DB" <<EOF
+	# Candidates (high confidence)
+	local high_conf
+	high_conf=$(
+		db "$MEMORY_DB" <<EOF
 SELECT COUNT(*) FROM learnings l
 LEFT JOIN learning_access a ON l.id = a.id
 WHERE l.confidence = 'high'
 AND (a.graduated_at IS NULL OR a.graduated_at = '');
 EOF
-    )
-    echo "High confidence (pending): ${high_conf:-0}"
+	)
+	echo "High confidence (pending): ${high_conf:-0}"
 
-    # Candidates (frequently accessed)
-    local freq_accessed
-    freq_accessed=$(db "$MEMORY_DB" <<EOF
+	# Candidates (frequently accessed)
+	local freq_accessed
+	freq_accessed=$(
+		db "$MEMORY_DB" <<EOF
 SELECT COUNT(*) FROM learnings l
 LEFT JOIN learning_access a ON l.id = a.id
 WHERE COALESCE(a.access_count, 0) >= $DEFAULT_MIN_ACCESS
 AND (a.graduated_at IS NULL OR a.graduated_at = '');
 EOF
-    )
-    echo "Frequently accessed (pending): ${freq_accessed:-0}"
+	)
+	echo "Frequently accessed (pending): ${freq_accessed:-0}"
 
-    # Total candidates (union)
-    local total_candidates
-    total_candidates=$(db "$MEMORY_DB" <<EOF
+	# Total candidates (union)
+	local total_candidates
+	total_candidates=$(
+		db "$MEMORY_DB" <<EOF
 SELECT COUNT(*) FROM learnings l
 LEFT JOIN learning_access a ON l.id = a.id
 WHERE (
@@ -558,31 +578,31 @@ WHERE (
 )
 AND (a.graduated_at IS NULL OR a.graduated_at = '');
 EOF
-    )
-    echo "Total candidates: ${total_candidates:-0}"
+	)
+	echo "Total candidates: ${total_candidates:-0}"
 
-    # Check if graduated-learnings.md exists
-    local target_file
-    target_file=$(graduated_file_path 2>/dev/null || echo "")
-    if [[ -n "$target_file" && -f "$target_file" ]]; then
-        local line_count
-        line_count=$(wc -l < "$target_file" | tr -d ' ')
-        echo ""
-        echo "Shared doc: $target_file ($line_count lines)"
-    else
-        echo ""
-        echo "Shared doc: not yet created (will be created on first graduation)"
-    fi
+	# Check if graduated-learnings.md exists
+	local target_file
+	target_file=$(graduated_file_path 2>/dev/null || echo "")
+	if [[ -n "$target_file" && -f "$target_file" ]]; then
+		local line_count
+		line_count=$(wc -l <"$target_file" | tr -d ' ')
+		echo ""
+		echo "Shared doc: $target_file ($line_count lines)"
+	else
+		echo ""
+		echo "Shared doc: not yet created (will be created on first graduation)"
+	fi
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 #######################################
 # Show help
 #######################################
 cmd_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 memory-graduate-helper.sh - Promote validated memories into shared docs
 
 Moves high-value learnings from the local SQLite memory database into
@@ -652,27 +672,27 @@ EXAMPLES:
     # Check status
     memory-graduate-helper.sh status
 EOF
-    return 0
+	return 0
 }
 
 #######################################
 # Main
 #######################################
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    case "$command" in
-        candidates|list) cmd_candidates "$@" ;;
-        graduate|promote) cmd_graduate "$@" ;;
-        status|stats) cmd_status ;;
-        help|--help|-h) cmd_help ;;
-        *)
-            log_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
+	case "$command" in
+	candidates | list) cmd_candidates "$@" ;;
+	graduate | promote) cmd_graduate "$@" ;;
+	status | stats) cmd_status ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/planning-commit-helper.sh
+++ b/.agents/scripts/planning-commit-helper.sh
@@ -24,21 +24,9 @@ set -euo pipefail
 # Planning file patterns
 readonly PLANNING_PATTERNS="^TODO\.md$|^todo/"
 
-log_info() {
-	echo -e "${BLUE}[plan]${NC} $1"
-}
-
-log_success() {
-	echo -e "${GREEN}[plan]${NC} $1"
-}
-
-log_warning() {
-	echo -e "${YELLOW}[plan]${NC} $1"
-}
-
-log_error() {
-	echo -e "${RED}[plan]${NC} $1" >&2
-}
+# Logging: uses shared log_* from shared-constants.sh with plan prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="plan"
 
 # Check if we're in a git repository
 check_git_repo() {

--- a/.agents/scripts/plugin-loader-helper.sh
+++ b/.agents/scripts/plugin-loader-helper.sh
@@ -34,32 +34,10 @@ PLUGINS_FILE="${AIDEVOPS_CONFIG_DIR:-$HOME/.config/aidevops}/plugins.json"
 PLUGIN_CACHE_DIR="${HOME}/.aidevops/.agent-workspace/tmp/plugin-cache"
 
 # =============================================================================
-# Logging
+# Logging: uses shared log_* from shared-constants.sh with plugin-loader prefix
 # =============================================================================
-
-log_info() {
-    local msg="$1"
-    echo -e "${BLUE:-}[plugin-loader]${NC:-} $msg"
-    return 0
-}
-
-log_success() {
-    local msg="$1"
-    echo -e "${GREEN:-}[OK]${NC:-} $msg"
-    return 0
-}
-
-log_warning() {
-    local msg="$1"
-    echo -e "${YELLOW:-}[WARN]${NC:-} $msg"
-    return 0
-}
-
-log_error() {
-    local msg="$1"
-    echo -e "${RED:-}[ERROR]${NC:-} $msg"
-    return 0
-}
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="plugin-loader"
 
 # =============================================================================
 # Plugin Discovery
@@ -68,114 +46,114 @@ log_error() {
 # Get list of enabled plugin namespaces from plugins.json
 # Returns: newline-separated list of namespace strings
 get_enabled_namespaces() {
-    if [[ ! -f "$PLUGINS_FILE" ]]; then
-        return 0
-    fi
-    if ! command -v jq &>/dev/null; then
-        log_warning "jq not found; cannot read plugins.json"
-        return 0
-    fi
-    jq -r '.plugins[] | select(.enabled != false) | .namespace // empty' "$PLUGINS_FILE" 2>/dev/null || true
-    return 0
+	if [[ ! -f "$PLUGINS_FILE" ]]; then
+		return 0
+	fi
+	if ! command -v jq &>/dev/null; then
+		log_warning "jq not found; cannot read plugins.json"
+		return 0
+	fi
+	jq -r '.plugins[] | select(.enabled != false) | .namespace // empty' "$PLUGINS_FILE" 2>/dev/null || true
+	return 0
 }
 
 # Get all plugin namespaces (enabled and disabled)
 get_all_namespaces() {
-    if [[ ! -f "$PLUGINS_FILE" ]]; then
-        return 0
-    fi
-    if ! command -v jq &>/dev/null; then
-        log_warning "jq not found; cannot read plugins.json"
-        return 0
-    fi
-    jq -r '.plugins[].namespace // empty' "$PLUGINS_FILE" 2>/dev/null || true
-    return 0
+	if [[ ! -f "$PLUGINS_FILE" ]]; then
+		return 0
+	fi
+	if ! command -v jq &>/dev/null; then
+		log_warning "jq not found; cannot read plugins.json"
+		return 0
+	fi
+	jq -r '.plugins[].namespace // empty' "$PLUGINS_FILE" 2>/dev/null || true
+	return 0
 }
 
 # Get a field from a plugin entry in plugins.json
 # Arguments: namespace, field_name
 get_plugin_field() {
-    local namespace="$1"
-    local field="$2"
-    if [[ ! -f "$PLUGINS_FILE" ]]; then
-        return 0
-    fi
-    jq -r --arg ns "$namespace" --arg f "$field" \
-        '.plugins[] | select(.namespace == $ns) | .[$f] // empty' \
-        "$PLUGINS_FILE" 2>/dev/null || echo ""
-    return 0
+	local namespace="$1"
+	local field="$2"
+	if [[ ! -f "$PLUGINS_FILE" ]]; then
+		return 0
+	fi
+	jq -r --arg ns "$namespace" --arg f "$field" \
+		'.plugins[] | select(.namespace == $ns) | .[$f] // empty' \
+		"$PLUGINS_FILE" 2>/dev/null || echo ""
+	return 0
 }
 
 # Check if a namespace is a valid installed plugin
 # Arguments: namespace
 # Returns: 0 if valid, 1 if not
 is_valid_plugin() {
-    local namespace="$1"
-    local plugin_dir="$AGENTS_DIR/$namespace"
+	local namespace="$1"
+	local plugin_dir="$AGENTS_DIR/$namespace"
 
-    if [[ ! -d "$plugin_dir" ]]; then
-        return 1
-    fi
+	if [[ ! -d "$plugin_dir" ]]; then
+		return 1
+	fi
 
-    # Check it's registered in plugins.json
-    local registered
-    registered=$(get_plugin_field "$namespace" "name")
-    if [[ -z "$registered" ]]; then
-        return 1
-    fi
+	# Check it's registered in plugins.json
+	local registered
+	registered=$(get_plugin_field "$namespace" "name")
+	if [[ -z "$registered" ]]; then
+		return 1
+	fi
 
-    return 0
+	return 0
 }
 
 # Discover all installed plugins and their status
 # Output: tab-separated lines: namespace, name, enabled, has_manifest, agent_count
 cmd_discover() {
-    if [[ ! -f "$PLUGINS_FILE" ]]; then
-        echo "No plugins configured (plugins.json not found)"
-        return 0
-    fi
+	if [[ ! -f "$PLUGINS_FILE" ]]; then
+		echo "No plugins configured (plugins.json not found)"
+		return 0
+	fi
 
-    local count
-    count=$(jq '.plugins | length' "$PLUGINS_FILE" 2>/dev/null || echo "0")
+	local count
+	count=$(jq '.plugins | length' "$PLUGINS_FILE" 2>/dev/null || echo "0")
 
-    if [[ "$count" == "0" ]]; then
-        echo "No plugins installed."
-        echo ""
-        echo "Add a plugin: aidevops plugin add <repo-url> --namespace <name>"
-        return 0
-    fi
+	if [[ "$count" == "0" ]]; then
+		echo "No plugins installed."
+		echo ""
+		echo "Add a plugin: aidevops plugin add <repo-url> --namespace <name>"
+		return 0
+	fi
 
-    echo "Discovered plugins ($count):"
-    echo ""
-    printf "  %-12s %-15s %-8s %-10s %-8s\n" "NAMESPACE" "NAME" "ENABLED" "MANIFEST" "AGENTS"
-    printf "  %-12s %-15s %-8s %-10s %-8s\n" "---------" "----" "-------" "--------" "------"
+	echo "Discovered plugins ($count):"
+	echo ""
+	printf "  %-12s %-15s %-8s %-10s %-8s\n" "NAMESPACE" "NAME" "ENABLED" "MANIFEST" "AGENTS"
+	printf "  %-12s %-15s %-8s %-10s %-8s\n" "---------" "----" "-------" "--------" "------"
 
-    while IFS=$'\t' read -r ns name enabled; do
-        [[ -z "$ns" ]] && continue
+	while IFS=$'\t' read -r ns name enabled; do
+		[[ -z "$ns" ]] && continue
 
-        local has_manifest="no"
-        local agent_count=0
-        local plugin_dir="$AGENTS_DIR/$ns"
+		local has_manifest="no"
+		local agent_count=0
+		local plugin_dir="$AGENTS_DIR/$ns"
 
-        if [[ -d "$plugin_dir" ]]; then
-            # Check for manifest
-            if [[ -f "$plugin_dir/plugin.json" ]]; then
-                has_manifest="yes"
-            fi
+		if [[ -d "$plugin_dir" ]]; then
+			# Check for manifest
+			if [[ -f "$plugin_dir/plugin.json" ]]; then
+				has_manifest="yes"
+			fi
 
-            # Count agent files
-            agent_count=$(find "$plugin_dir" -name '*.md' -not -name 'README*' -not -name 'AGENTS*' -not -name '*-skill.md' 2>/dev/null | wc -l | tr -d ' ')
-        fi
+			# Count agent files
+			agent_count=$(find "$plugin_dir" -name '*.md' -not -name 'README*' -not -name 'AGENTS*' -not -name '*-skill.md' 2>/dev/null | wc -l | tr -d ' ')
+		fi
 
-        local enabled_str="yes"
-        if [[ "$enabled" == "false" ]]; then
-            enabled_str="no"
-        fi
+		local enabled_str="yes"
+		if [[ "$enabled" == "false" ]]; then
+			enabled_str="no"
+		fi
 
-        printf "  %-12s %-15s %-8s %-10s %-8s\n" "$ns" "$name" "$enabled_str" "$has_manifest" "$agent_count"
-    done < <(jq -r '.plugins[] | [.namespace, .name, (.enabled // true | tostring)] | @tsv' "$PLUGINS_FILE" 2>/dev/null)
+		printf "  %-12s %-15s %-8s %-10s %-8s\n" "$ns" "$name" "$enabled_str" "$has_manifest" "$agent_count"
+	done < <(jq -r '.plugins[] | [.namespace, .name, (.enabled // true | tostring)] | @tsv' "$PLUGINS_FILE" 2>/dev/null)
 
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -186,148 +164,148 @@ cmd_discover() {
 # Arguments: namespace
 # Returns: 0 if valid, 1 if invalid or missing
 validate_manifest() {
-    local namespace="$1"
-    local plugin_dir="$AGENTS_DIR/$namespace"
-    local manifest="$plugin_dir/plugin.json"
+	local namespace="$1"
+	local plugin_dir="$AGENTS_DIR/$namespace"
+	local manifest="$plugin_dir/plugin.json"
 
-    if [[ ! -d "$plugin_dir" ]]; then
-        log_error "Plugin directory not found: $plugin_dir"
-        return 1
-    fi
+	if [[ ! -d "$plugin_dir" ]]; then
+		log_error "Plugin directory not found: $plugin_dir"
+		return 1
+	fi
 
-    # Manifest is optional — plugins work without it (backward compatible)
-    if [[ ! -f "$manifest" ]]; then
-        log_info "No manifest found for '$namespace' (using defaults)"
-        return 0
-    fi
+	# Manifest is optional — plugins work without it (backward compatible)
+	if [[ ! -f "$manifest" ]]; then
+		log_info "No manifest found for '$namespace' (using defaults)"
+		return 0
+	fi
 
-    if ! command -v jq &>/dev/null; then
-        log_warning "jq not found; cannot validate manifest"
-        return 0
-    fi
+	if ! command -v jq &>/dev/null; then
+		log_warning "jq not found; cannot validate manifest"
+		return 0
+	fi
 
-    # Validate JSON syntax
-    if ! jq empty "$manifest" 2>/dev/null; then
-        log_error "Invalid JSON in $manifest"
-        return 1
-    fi
+	# Validate JSON syntax
+	if ! jq empty "$manifest" 2>/dev/null; then
+		log_error "Invalid JSON in $manifest"
+		return 1
+	fi
 
-    local errors=0
+	local errors=0
 
-    # Check required fields
-    local name
-    name=$(jq -r '.name // empty' "$manifest" 2>/dev/null)
-    if [[ -z "$name" ]]; then
-        log_error "Manifest missing required field: name"
-        errors=$((errors + 1))
-    fi
+	# Check required fields
+	local name
+	name=$(jq -r '.name // empty' "$manifest" 2>/dev/null)
+	if [[ -z "$name" ]]; then
+		log_error "Manifest missing required field: name"
+		errors=$((errors + 1))
+	fi
 
-    local version
-    version=$(jq -r '.version // empty' "$manifest" 2>/dev/null)
-    if [[ -z "$version" ]]; then
-        log_error "Manifest missing required field: version"
-        errors=$((errors + 1))
-    fi
+	local version
+	version=$(jq -r '.version // empty' "$manifest" 2>/dev/null)
+	if [[ -z "$version" ]]; then
+		log_error "Manifest missing required field: version"
+		errors=$((errors + 1))
+	fi
 
-    # Validate version format (semver-like)
-    if [[ -n "$version" ]] && [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-        log_warning "Version '$version' is not semver format (expected: X.Y.Z)"
-    fi
+	# Validate version format (semver-like)
+	if [[ -n "$version" ]] && [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+		log_warning "Version '$version' is not semver format (expected: X.Y.Z)"
+	fi
 
-    # Validate agents array if present
-    local agents_count
-    agents_count=$(jq '.agents | length // 0' "$manifest" 2>/dev/null || echo "0")
-    if [[ "$agents_count" -gt 0 ]]; then
-        # Check each agent has required fields
-        local i=0
-        while [[ "$i" -lt "$agents_count" ]]; do
-            local agent_file
-            agent_file=$(jq -r --argjson i "$i" '.agents[$i].file // empty' "$manifest" 2>/dev/null)
-            if [[ -z "$agent_file" ]]; then
-                log_error "Agent entry $i missing required field: file"
-                errors=$((errors + 1))
-            elif [[ ! -f "$plugin_dir/$agent_file" ]]; then
-                log_warning "Agent file not found: $plugin_dir/$agent_file"
-            fi
-            i=$((i + 1))
-        done
-    fi
+	# Validate agents array if present
+	local agents_count
+	agents_count=$(jq '.agents | length // 0' "$manifest" 2>/dev/null || echo "0")
+	if [[ "$agents_count" -gt 0 ]]; then
+		# Check each agent has required fields
+		local i=0
+		while [[ "$i" -lt "$agents_count" ]]; do
+			local agent_file
+			agent_file=$(jq -r --argjson i "$i" '.agents[$i].file // empty' "$manifest" 2>/dev/null)
+			if [[ -z "$agent_file" ]]; then
+				log_error "Agent entry $i missing required field: file"
+				errors=$((errors + 1))
+			elif [[ ! -f "$plugin_dir/$agent_file" ]]; then
+				log_warning "Agent file not found: $plugin_dir/$agent_file"
+			fi
+			i=$((i + 1))
+		done
+	fi
 
-    # Validate hooks if present
-    local hooks
-    hooks=$(jq -r '.hooks // empty | keys[]' "$manifest" 2>/dev/null || true)
-    if [[ -n "$hooks" ]]; then
-        while IFS= read -r hook; do
-            local hook_script
-            hook_script=$(jq -r --arg h "$hook" '.hooks[$h] // empty' "$manifest" 2>/dev/null)
-            if [[ -n "$hook_script" && ! -f "$plugin_dir/$hook_script" ]]; then
-                log_warning "Hook script not found: $plugin_dir/$hook_script (hook: $hook)"
-            fi
-        done <<< "$hooks"
-    fi
+	# Validate hooks if present
+	local hooks
+	hooks=$(jq -r '.hooks // empty | keys[]' "$manifest" 2>/dev/null || true)
+	if [[ -n "$hooks" ]]; then
+		while IFS= read -r hook; do
+			local hook_script
+			hook_script=$(jq -r --arg h "$hook" '.hooks[$h] // empty' "$manifest" 2>/dev/null)
+			if [[ -n "$hook_script" && ! -f "$plugin_dir/$hook_script" ]]; then
+				log_warning "Hook script not found: $plugin_dir/$hook_script (hook: $hook)"
+			fi
+		done <<<"$hooks"
+	fi
 
-    # Validate min_version if present
-    local min_version
-    min_version=$(jq -r '.min_aidevops_version // empty' "$manifest" 2>/dev/null)
-    if [[ -n "$min_version" ]]; then
-        local current_version
-        current_version=$(cat "$HOME/.aidevops/version" 2>/dev/null || echo "0.0.0")
-        # Simple version comparison (major.minor only)
-        local min_major min_minor cur_major cur_minor
-        min_major=$(echo "$min_version" | cut -d. -f1)
-        min_minor=$(echo "$min_version" | cut -d. -f2)
-        cur_major=$(echo "$current_version" | cut -d. -f1)
-        cur_minor=$(echo "$current_version" | cut -d. -f2)
-        if [[ "$cur_major" -lt "$min_major" ]] || { [[ "$cur_major" -eq "$min_major" ]] && [[ "$cur_minor" -lt "$min_minor" ]]; }; then
-            log_warning "Plugin requires aidevops >= $min_version (current: $current_version)"
-        fi
-    fi
+	# Validate min_version if present
+	local min_version
+	min_version=$(jq -r '.min_aidevops_version // empty' "$manifest" 2>/dev/null)
+	if [[ -n "$min_version" ]]; then
+		local current_version
+		current_version=$(cat "$HOME/.aidevops/version" 2>/dev/null || echo "0.0.0")
+		# Simple version comparison (major.minor only)
+		local min_major min_minor cur_major cur_minor
+		min_major=$(echo "$min_version" | cut -d. -f1)
+		min_minor=$(echo "$min_version" | cut -d. -f2)
+		cur_major=$(echo "$current_version" | cut -d. -f1)
+		cur_minor=$(echo "$current_version" | cut -d. -f2)
+		if [[ "$cur_major" -lt "$min_major" ]] || { [[ "$cur_major" -eq "$min_major" ]] && [[ "$cur_minor" -lt "$min_minor" ]]; }; then
+			log_warning "Plugin requires aidevops >= $min_version (current: $current_version)"
+		fi
+	fi
 
-    if [[ "$errors" -gt 0 ]]; then
-        log_error "Manifest validation failed with $errors error(s)"
-        return 1
-    fi
+	if [[ "$errors" -gt 0 ]]; then
+		log_error "Manifest validation failed with $errors error(s)"
+		return 1
+	fi
 
-    log_success "Manifest valid for '$namespace'"
-    return 0
+	log_success "Manifest valid for '$namespace'"
+	return 0
 }
 
 # Validate all plugin manifests
 cmd_validate() {
-    local target="${1:-}"
-    local failed=0
+	local target="${1:-}"
+	local failed=0
 
-    if [[ -n "$target" ]]; then
-        if ! is_valid_plugin "$target"; then
-            log_error "Plugin '$target' not found"
-            return 1
-        fi
-        validate_manifest "$target"
-        return $?
-    fi
+	if [[ -n "$target" ]]; then
+		if ! is_valid_plugin "$target"; then
+			log_error "Plugin '$target' not found"
+			return 1
+		fi
+		validate_manifest "$target"
+		return $?
+	fi
 
-    # Validate all enabled plugins
-    local namespaces
-    namespaces=$(get_enabled_namespaces)
-    if [[ -z "$namespaces" ]]; then
-        echo "No enabled plugins to validate."
-        return 0
-    fi
+	# Validate all enabled plugins
+	local namespaces
+	namespaces=$(get_enabled_namespaces)
+	if [[ -z "$namespaces" ]]; then
+		echo "No enabled plugins to validate."
+		return 0
+	fi
 
-    while IFS= read -r ns; do
-        [[ -z "$ns" ]] && continue
-        if ! validate_manifest "$ns"; then
-            failed=$((failed + 1))
-        fi
-    done <<< "$namespaces"
+	while IFS= read -r ns; do
+		[[ -z "$ns" ]] && continue
+		if ! validate_manifest "$ns"; then
+			failed=$((failed + 1))
+		fi
+	done <<<"$namespaces"
 
-    if [[ "$failed" -gt 0 ]]; then
-        log_error "$failed plugin(s) failed validation"
-        return 1
-    fi
+	if [[ "$failed" -gt 0 ]]; then
+		log_error "$failed plugin(s) failed validation"
+		return 1
+	fi
 
-    log_success "All plugin manifests valid"
-    return 0
+	log_success "All plugin manifests valid"
+	return 0
 }
 
 # =============================================================================
@@ -339,217 +317,217 @@ cmd_validate() {
 # Arguments: namespace
 # Output: tab-separated lines: name, file, description, model_tier
 load_plugin_agents() {
-    local namespace="$1"
-    local plugin_dir="$AGENTS_DIR/$namespace"
-    local manifest="$plugin_dir/plugin.json"
+	local namespace="$1"
+	local plugin_dir="$AGENTS_DIR/$namespace"
+	local manifest="$plugin_dir/plugin.json"
 
-    if [[ ! -d "$plugin_dir" ]]; then
-        return 0
-    fi
+	if [[ ! -d "$plugin_dir" ]]; then
+		return 0
+	fi
 
-    # If manifest exists and has agents array, use it
-    if [[ -f "$manifest" ]] && command -v jq &>/dev/null; then
-        local agents_count
-        agents_count=$(jq '.agents | length // 0' "$manifest" 2>/dev/null || echo "0")
+	# If manifest exists and has agents array, use it
+	if [[ -f "$manifest" ]] && command -v jq &>/dev/null; then
+		local agents_count
+		agents_count=$(jq '.agents | length // 0' "$manifest" 2>/dev/null || echo "0")
 
-        if [[ "$agents_count" -gt 0 ]]; then
-            jq -r --arg ns "$namespace" '.agents[] | [
+		if [[ "$agents_count" -gt 0 ]]; then
+			jq -r --arg ns "$namespace" '.agents[] | [
                 .name // (.file | sub("\\.md$"; "")),
                 ($ns + "/" + .file),
                 .description // "",
                 .model // "sonnet"
             ] | @tsv' "$manifest" 2>/dev/null || true
-            return 0
-        fi
-    fi
+			return 0
+		fi
+	fi
 
-    # Fallback: scan directory for .md files and parse frontmatter
-    local md_files
-    md_files=$(find "$plugin_dir" -name '*.md' \
-        -not -name 'README*' \
-        -not -name 'AGENTS*' \
-        -not -name '*-skill.md' \
-        -not -path '*/node_modules/*' \
-        -not -path '*/.git/*' \
-        2>/dev/null | sort)
+	# Fallback: scan directory for .md files and parse frontmatter
+	local md_files
+	md_files=$(find "$plugin_dir" -name '*.md' \
+		-not -name 'README*' \
+		-not -name 'AGENTS*' \
+		-not -name '*-skill.md' \
+		-not -path '*/node_modules/*' \
+		-not -path '*/.git/*' \
+		2>/dev/null | sort)
 
-    if [[ -z "$md_files" ]]; then
-        return 0
-    fi
+	if [[ -z "$md_files" ]]; then
+		return 0
+	fi
 
-    while IFS= read -r md_file; do
-        [[ -z "$md_file" ]] && continue
+	while IFS= read -r md_file; do
+		[[ -z "$md_file" ]] && continue
 
-        local rel_path="${md_file#"$AGENTS_DIR/"}"
-        local base_name
-        base_name=$(basename "$md_file" .md)
+		local rel_path="${md_file#"$AGENTS_DIR/"}"
+		local base_name
+		base_name=$(basename "$md_file" .md)
 
-        # Extract description from frontmatter if available
-        local description=""
-        local model="sonnet"
-        if head -1 "$md_file" 2>/dev/null | grep -q '^---'; then
-            # Parse YAML frontmatter (lightweight)
-            local frontmatter
-            frontmatter=$(sed -n '2,/^---$/p' "$md_file" 2>/dev/null | head -20)
-            description=$(echo "$frontmatter" | grep -E '^description:' | sed 's/^description:\s*//' | head -1)
-            local fm_model
-            fm_model=$(echo "$frontmatter" | grep -E '^model:' | sed 's/^model:\s*//' | head -1)
-            if [[ -n "$fm_model" ]]; then
-                model="$fm_model"
-            fi
-        fi
+		# Extract description from frontmatter if available
+		local description=""
+		local model="sonnet"
+		if head -1 "$md_file" 2>/dev/null | grep -q '^---'; then
+			# Parse YAML frontmatter (lightweight)
+			local frontmatter
+			frontmatter=$(sed -n '2,/^---$/p' "$md_file" 2>/dev/null | head -20)
+			description=$(echo "$frontmatter" | grep -E '^description:' | sed 's/^description:\s*//' | head -1)
+			local fm_model
+			fm_model=$(echo "$frontmatter" | grep -E '^model:' | sed 's/^model:\s*//' | head -1)
+			if [[ -n "$fm_model" ]]; then
+				model="$fm_model"
+			fi
+		fi
 
-        # If no description from frontmatter, use first heading
-        if [[ -z "$description" ]]; then
-            description=$(grep -m1 '^# ' "$md_file" 2>/dev/null | sed 's/^# //')
-        fi
+		# If no description from frontmatter, use first heading
+		if [[ -z "$description" ]]; then
+			description=$(grep -m1 '^# ' "$md_file" 2>/dev/null | sed 's/^# //')
+		fi
 
-        printf "%s\t%s\t%s\t%s\n" "$base_name" "$rel_path" "$description" "$model"
-    done <<< "$md_files"
+		printf "%s\t%s\t%s\t%s\n" "$base_name" "$rel_path" "$description" "$model"
+	done <<<"$md_files"
 
-    return 0
+	return 0
 }
 
 # Load all enabled plugin agents
 cmd_load() {
-    local target="${1:-}"
+	local target="${1:-}"
 
-    if [[ -n "$target" ]]; then
-        if ! is_valid_plugin "$target"; then
-            log_error "Plugin '$target' not found or not registered"
-            return 1
-        fi
+	if [[ -n "$target" ]]; then
+		if ! is_valid_plugin "$target"; then
+			log_error "Plugin '$target' not found or not registered"
+			return 1
+		fi
 
-        # Run init hook if available
-        run_hook "$target" "init" 2>/dev/null || true
+		# Run init hook if available
+		run_hook "$target" "init" 2>/dev/null || true
 
-        local agents
-        agents=$(load_plugin_agents "$target")
-        if [[ -z "$agents" ]]; then
-            log_info "No agents found in plugin '$target'"
-            return 0
-        fi
+		local agents
+		agents=$(load_plugin_agents "$target")
+		if [[ -z "$agents" ]]; then
+			log_info "No agents found in plugin '$target'"
+			return 0
+		fi
 
-        log_success "Loaded agents from '$target':"
-        echo "$agents" | while IFS=$'\t' read -r name file desc model; do
-            printf "  %-20s %-30s %s\n" "$name" "$file" "$desc"
-        done
+		log_success "Loaded agents from '$target':"
+		echo "$agents" | while IFS=$'\t' read -r name file desc model; do
+			printf "  %-20s %-30s %s\n" "$name" "$file" "$desc"
+		done
 
-        # Run load hook if available
-        run_hook "$target" "load" 2>/dev/null || true
-        return 0
-    fi
+		# Run load hook if available
+		run_hook "$target" "load" 2>/dev/null || true
+		return 0
+	fi
 
-    # Load all enabled plugins
-    local namespaces
-    namespaces=$(get_enabled_namespaces)
-    if [[ -z "$namespaces" ]]; then
-        echo "No enabled plugins to load."
-        return 0
-    fi
+	# Load all enabled plugins
+	local namespaces
+	namespaces=$(get_enabled_namespaces)
+	if [[ -z "$namespaces" ]]; then
+		echo "No enabled plugins to load."
+		return 0
+	fi
 
-    local total_agents=0
-    local total_plugins=0
+	local total_agents=0
+	local total_plugins=0
 
-    while IFS= read -r ns; do
-        [[ -z "$ns" ]] && continue
+	while IFS= read -r ns; do
+		[[ -z "$ns" ]] && continue
 
-        # Run init hook
-        run_hook "$ns" "init" 2>/dev/null || true
+		# Run init hook
+		run_hook "$ns" "init" 2>/dev/null || true
 
-        local agents
-        agents=$(load_plugin_agents "$ns")
-        if [[ -n "$agents" ]]; then
-            local count
-            count=$(echo "$agents" | wc -l | tr -d ' ')
-            total_agents=$((total_agents + count))
-            total_plugins=$((total_plugins + 1))
-            log_info "Loaded $count agent(s) from '$ns'"
-        fi
+		local agents
+		agents=$(load_plugin_agents "$ns")
+		if [[ -n "$agents" ]]; then
+			local count
+			count=$(echo "$agents" | wc -l | tr -d ' ')
+			total_agents=$((total_agents + count))
+			total_plugins=$((total_plugins + 1))
+			log_info "Loaded $count agent(s) from '$ns'"
+		fi
 
-        # Run load hook
-        run_hook "$ns" "load" 2>/dev/null || true
-    done <<< "$namespaces"
+		# Run load hook
+		run_hook "$ns" "load" 2>/dev/null || true
+	done <<<"$namespaces"
 
-    log_success "Loaded $total_agents agent(s) from $total_plugins plugin(s)"
-    return 0
+	log_success "Loaded $total_agents agent(s) from $total_plugins plugin(s)"
+	return 0
 }
 
 # Unload a plugin's agents (run unload hook)
 cmd_unload() {
-    local namespace="${1:-}"
+	local namespace="${1:-}"
 
-    if [[ -z "$namespace" ]]; then
-        log_error "Namespace required"
-        echo "Usage: plugin-loader-helper.sh unload <namespace>"
-        return 1
-    fi
+	if [[ -z "$namespace" ]]; then
+		log_error "Namespace required"
+		echo "Usage: plugin-loader-helper.sh unload <namespace>"
+		return 1
+	fi
 
-    if ! is_valid_plugin "$namespace"; then
-        log_error "Plugin '$namespace' not found"
-        return 1
-    fi
+	if ! is_valid_plugin "$namespace"; then
+		log_error "Plugin '$namespace' not found"
+		return 1
+	fi
 
-    # Run unload hook
-    run_hook "$namespace" "unload"
+	# Run unload hook
+	run_hook "$namespace" "unload"
 
-    log_success "Unloaded plugin '$namespace'"
-    return 0
+	log_success "Unloaded plugin '$namespace'"
+	return 0
 }
 
 # List agents from plugin(s)
 cmd_agents() {
-    local target="${1:-}"
+	local target="${1:-}"
 
-    if [[ -n "$target" ]]; then
-        if ! is_valid_plugin "$target"; then
-            log_error "Plugin '$target' not found"
-            return 1
-        fi
+	if [[ -n "$target" ]]; then
+		if ! is_valid_plugin "$target"; then
+			log_error "Plugin '$target' not found"
+			return 1
+		fi
 
-        local agents
-        agents=$(load_plugin_agents "$target")
-        if [[ -z "$agents" ]]; then
-            echo "No agents found in plugin '$target'"
-            return 0
-        fi
+		local agents
+		agents=$(load_plugin_agents "$target")
+		if [[ -z "$agents" ]]; then
+			echo "No agents found in plugin '$target'"
+			return 0
+		fi
 
-        echo "Agents in plugin '$target':"
-        echo ""
-        printf "  %-20s %-35s %-8s %s\n" "NAME" "FILE" "MODEL" "DESCRIPTION"
-        printf "  %-20s %-35s %-8s %s\n" "----" "----" "-----" "-----------"
+		echo "Agents in plugin '$target':"
+		echo ""
+		printf "  %-20s %-35s %-8s %s\n" "NAME" "FILE" "MODEL" "DESCRIPTION"
+		printf "  %-20s %-35s %-8s %s\n" "----" "----" "-----" "-----------"
 
-        echo "$agents" | while IFS=$'\t' read -r name file desc model; do
-            printf "  %-20s %-35s %-8s %s\n" "$name" "$file" "$model" "$desc"
-        done
-        return 0
-    fi
+		echo "$agents" | while IFS=$'\t' read -r name file desc model; do
+			printf "  %-20s %-35s %-8s %s\n" "$name" "$file" "$model" "$desc"
+		done
+		return 0
+	fi
 
-    # List agents from all enabled plugins
-    local namespaces
-    namespaces=$(get_enabled_namespaces)
-    if [[ -z "$namespaces" ]]; then
-        echo "No enabled plugins."
-        return 0
-    fi
+	# List agents from all enabled plugins
+	local namespaces
+	namespaces=$(get_enabled_namespaces)
+	if [[ -z "$namespaces" ]]; then
+		echo "No enabled plugins."
+		return 0
+	fi
 
-    echo "Plugin agents:"
-    echo ""
-    printf "  %-12s %-20s %-35s %-8s %s\n" "PLUGIN" "NAME" "FILE" "MODEL" "DESCRIPTION"
-    printf "  %-12s %-20s %-35s %-8s %s\n" "------" "----" "----" "-----" "-----------"
+	echo "Plugin agents:"
+	echo ""
+	printf "  %-12s %-20s %-35s %-8s %s\n" "PLUGIN" "NAME" "FILE" "MODEL" "DESCRIPTION"
+	printf "  %-12s %-20s %-35s %-8s %s\n" "------" "----" "----" "-----" "-----------"
 
-    while IFS= read -r ns; do
-        [[ -z "$ns" ]] && continue
-        local agents
-        agents=$(load_plugin_agents "$ns")
-        if [[ -n "$agents" ]]; then
-            echo "$agents" | while IFS=$'\t' read -r name file desc model; do
-                printf "  %-12s %-20s %-35s %-8s %s\n" "$ns" "$name" "$file" "$model" "$desc"
-            done
-        fi
-    done <<< "$namespaces"
+	while IFS= read -r ns; do
+		[[ -z "$ns" ]] && continue
+		local agents
+		agents=$(load_plugin_agents "$ns")
+		if [[ -n "$agents" ]]; then
+			echo "$agents" | while IFS=$'\t' read -r name file desc model; do
+				printf "  %-12s %-20s %-35s %-8s %s\n" "$ns" "$name" "$file" "$model" "$desc"
+			done
+		fi
+	done <<<"$namespaces"
 
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -560,88 +538,88 @@ cmd_agents() {
 # Arguments: namespace, hook_name (init|load|unload)
 # Returns: 0 on success or if no hook defined, 1 on hook failure
 run_hook() {
-    local namespace="$1"
-    local hook_name="$2"
-    local plugin_dir="$AGENTS_DIR/$namespace"
-    local manifest="$plugin_dir/plugin.json"
+	local namespace="$1"
+	local hook_name="$2"
+	local plugin_dir="$AGENTS_DIR/$namespace"
+	local manifest="$plugin_dir/plugin.json"
 
-    # Validate hook name
-    case "$hook_name" in
-        init|load|unload) ;;
-        *)
-            log_error "Invalid hook name: $hook_name (valid: init, load, unload)"
-            return 1
-            ;;
-    esac
+	# Validate hook name
+	case "$hook_name" in
+	init | load | unload) ;;
+	*)
+		log_error "Invalid hook name: $hook_name (valid: init, load, unload)"
+		return 1
+		;;
+	esac
 
-    local hook_script=""
+	local hook_script=""
 
-    # Check manifest for hook definition
-    if [[ -f "$manifest" ]] && command -v jq &>/dev/null; then
-        hook_script=$(jq -r --arg h "$hook_name" '.hooks[$h] // empty' "$manifest" 2>/dev/null)
-    fi
+	# Check manifest for hook definition
+	if [[ -f "$manifest" ]] && command -v jq &>/dev/null; then
+		hook_script=$(jq -r --arg h "$hook_name" '.hooks[$h] // empty' "$manifest" 2>/dev/null)
+	fi
 
-    # Fallback: check for conventional hook script names
-    if [[ -z "$hook_script" ]]; then
-        local conventional="scripts/on-${hook_name}.sh"
-        if [[ -f "$plugin_dir/$conventional" ]]; then
-            hook_script="$conventional"
-        fi
-    fi
+	# Fallback: check for conventional hook script names
+	if [[ -z "$hook_script" ]]; then
+		local conventional="scripts/on-${hook_name}.sh"
+		if [[ -f "$plugin_dir/$conventional" ]]; then
+			hook_script="$conventional"
+		fi
+	fi
 
-    # No hook defined — that's fine
-    if [[ -z "$hook_script" ]]; then
-        return 0
-    fi
+	# No hook defined — that's fine
+	if [[ -z "$hook_script" ]]; then
+		return 0
+	fi
 
-    local full_path="$plugin_dir/$hook_script"
-    if [[ ! -f "$full_path" ]]; then
-        log_warning "Hook script not found: $full_path"
-        return 0
-    fi
+	local full_path="$plugin_dir/$hook_script"
+	if [[ ! -f "$full_path" ]]; then
+		log_warning "Hook script not found: $full_path"
+		return 0
+	fi
 
-    # Ensure executable
-    if [[ ! -x "$full_path" ]]; then
-        chmod +x "$full_path"
-    fi
+	# Ensure executable
+	if [[ ! -x "$full_path" ]]; then
+		chmod +x "$full_path"
+	fi
 
-    log_info "Running $hook_name hook for '$namespace'..."
+	log_info "Running $hook_name hook for '$namespace'..."
 
-    # Run hook with plugin context environment variables
-    local exit_code=0
-    AIDEVOPS_PLUGIN_NAMESPACE="$namespace" \
-    AIDEVOPS_PLUGIN_DIR="$plugin_dir" \
-    AIDEVOPS_AGENTS_DIR="$AGENTS_DIR" \
-    AIDEVOPS_HOOK="$hook_name" \
-    bash "$full_path" || exit_code=$?
+	# Run hook with plugin context environment variables
+	local exit_code=0
+	AIDEVOPS_PLUGIN_NAMESPACE="$namespace" \
+		AIDEVOPS_PLUGIN_DIR="$plugin_dir" \
+		AIDEVOPS_AGENTS_DIR="$AGENTS_DIR" \
+		AIDEVOPS_HOOK="$hook_name" \
+		bash "$full_path" || exit_code=$?
 
-    if [[ "$exit_code" -ne 0 ]]; then
-        log_warning "Hook $hook_name for '$namespace' exited with code $exit_code"
-        return 1
-    fi
+	if [[ "$exit_code" -ne 0 ]]; then
+		log_warning "Hook $hook_name for '$namespace' exited with code $exit_code"
+		return 1
+	fi
 
-    return 0
+	return 0
 }
 
 # Run a specific hook via CLI
 cmd_hooks() {
-    local namespace="${1:-}"
-    local hook="${2:-}"
+	local namespace="${1:-}"
+	local hook="${2:-}"
 
-    if [[ -z "$namespace" || -z "$hook" ]]; then
-        log_error "Namespace and hook name required"
-        echo "Usage: plugin-loader-helper.sh hooks <namespace> <hook>"
-        echo "Hooks: init, load, unload"
-        return 1
-    fi
+	if [[ -z "$namespace" || -z "$hook" ]]; then
+		log_error "Namespace and hook name required"
+		echo "Usage: plugin-loader-helper.sh hooks <namespace> <hook>"
+		echo "Hooks: init, load, unload"
+		return 1
+	fi
 
-    if ! is_valid_plugin "$namespace"; then
-        log_error "Plugin '$namespace' not found"
-        return 1
-    fi
+	if ! is_valid_plugin "$namespace"; then
+		log_error "Plugin '$namespace' not found"
+		return 1
+	fi
 
-    run_hook "$namespace" "$hook"
-    return $?
+	run_hook "$namespace" "$hook"
+	return $?
 }
 
 # =============================================================================
@@ -651,64 +629,64 @@ cmd_hooks() {
 # Generate TOON-format subagent index entries for all plugin agents
 # Output: TOON lines suitable for appending to subagent-index.toon
 cmd_index() {
-    local namespaces
-    namespaces=$(get_enabled_namespaces)
-    if [[ -z "$namespaces" ]]; then
-        return 0
-    fi
+	local namespaces
+	namespaces=$(get_enabled_namespaces)
+	if [[ -z "$namespaces" ]]; then
+		return 0
+	fi
 
-    local entries=()
-    local plugin_count=0
+	local entries=()
+	local plugin_count=0
 
-    while IFS= read -r ns; do
-        [[ -z "$ns" ]] && continue
+	while IFS= read -r ns; do
+		[[ -z "$ns" ]] && continue
 
-        local agents
-        agents=$(load_plugin_agents "$ns")
-        if [[ -z "$agents" ]]; then
-            continue
-        fi
+		local agents
+		agents=$(load_plugin_agents "$ns")
+		if [[ -z "$agents" ]]; then
+			continue
+		fi
 
-        # Collect agent files for this plugin
-        local key_files=""
-        while IFS=$'\t' read -r name file desc model; do
-            local base
-            base=$(basename "$file" .md)
-            if [[ -n "$key_files" ]]; then
-                key_files="${key_files}|${base}"
-            else
-                key_files="$base"
-            fi
-        done <<< "$agents"
+		# Collect agent files for this plugin
+		local key_files=""
+		while IFS=$'\t' read -r name file desc model; do
+			local base
+			base=$(basename "$file" .md)
+			if [[ -n "$key_files" ]]; then
+				key_files="${key_files}|${base}"
+			else
+				key_files="$base"
+			fi
+		done <<<"$agents"
 
-        # Get plugin description from manifest or plugins.json
-        local plugin_desc=""
-        local manifest="$AGENTS_DIR/$ns/plugin.json"
-        if [[ -f "$manifest" ]] && command -v jq &>/dev/null; then
-            plugin_desc=$(jq -r '.description // empty' "$manifest" 2>/dev/null)
-        fi
-        if [[ -z "$plugin_desc" ]]; then
-            local plugin_name
-            plugin_name=$(get_plugin_field "$ns" "name")
-            plugin_desc="Plugin: ${plugin_name:-$ns}"
-        fi
+		# Get plugin description from manifest or plugins.json
+		local plugin_desc=""
+		local manifest="$AGENTS_DIR/$ns/plugin.json"
+		if [[ -f "$manifest" ]] && command -v jq &>/dev/null; then
+			plugin_desc=$(jq -r '.description // empty' "$manifest" 2>/dev/null)
+		fi
+		if [[ -z "$plugin_desc" ]]; then
+			local plugin_name
+			plugin_name=$(get_plugin_field "$ns" "name")
+			plugin_desc="Plugin: ${plugin_name:-$ns}"
+		fi
 
-        entries+=("${ns}/,${plugin_desc},${key_files}")
-        plugin_count=$((plugin_count + 1))
-    done <<< "$namespaces"
+		entries+=("${ns}/,${plugin_desc},${key_files}")
+		plugin_count=$((plugin_count + 1))
+	done <<<"$namespaces"
 
-    if [[ "${#entries[@]}" -eq 0 ]]; then
-        return 0
-    fi
+	if [[ "${#entries[@]}" -eq 0 ]]; then
+		return 0
+	fi
 
-    # Output TOON format
-    echo "<!--TOON:plugin_agents[${#entries[@]}]{folder,purpose,key_files}:"
-    for entry in "${entries[@]}"; do
-        echo "$entry"
-    done
-    echo "-->"
+	# Output TOON format
+	echo "<!--TOON:plugin_agents[${#entries[@]}]{folder,purpose,key_files}:"
+	for entry in "${entries[@]}"; do
+		echo "$entry"
+	done
+	echo "-->"
 
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -716,58 +694,58 @@ cmd_index() {
 # =============================================================================
 
 cmd_status() {
-    echo "Plugin System Status"
-    echo "===================="
-    echo ""
+	echo "Plugin System Status"
+	echo "===================="
+	echo ""
 
-    # Check plugins.json
-    if [[ -f "$PLUGINS_FILE" ]]; then
-        local total enabled disabled
-        total=$(jq '.plugins | length' "$PLUGINS_FILE" 2>/dev/null || echo "0")
-        enabled=$(jq '[.plugins[] | select(.enabled != false)] | length' "$PLUGINS_FILE" 2>/dev/null || echo "0")
-        disabled=$((total - enabled))
-        echo "Plugins configured: $total ($enabled enabled, $disabled disabled)"
-    else
-        echo "Plugins configured: 0 (plugins.json not found)"
-    fi
+	# Check plugins.json
+	if [[ -f "$PLUGINS_FILE" ]]; then
+		local total enabled disabled
+		total=$(jq '.plugins | length' "$PLUGINS_FILE" 2>/dev/null || echo "0")
+		enabled=$(jq '[.plugins[] | select(.enabled != false)] | length' "$PLUGINS_FILE" 2>/dev/null || echo "0")
+		disabled=$((total - enabled))
+		echo "Plugins configured: $total ($enabled enabled, $disabled disabled)"
+	else
+		echo "Plugins configured: 0 (plugins.json not found)"
+	fi
 
-    # Count total agents across plugins
-    local total_agents=0
-    local namespaces
-    namespaces=$(get_enabled_namespaces)
-    if [[ -n "$namespaces" ]]; then
-        while IFS= read -r ns; do
-            [[ -z "$ns" ]] && continue
-            local agents
-            agents=$(load_plugin_agents "$ns")
-            if [[ -n "$agents" ]]; then
-                local count
-                count=$(echo "$agents" | wc -l | tr -d ' ')
-                total_agents=$((total_agents + count))
-            fi
-        done <<< "$namespaces"
-    fi
-    echo "Total plugin agents: $total_agents"
+	# Count total agents across plugins
+	local total_agents=0
+	local namespaces
+	namespaces=$(get_enabled_namespaces)
+	if [[ -n "$namespaces" ]]; then
+		while IFS= read -r ns; do
+			[[ -z "$ns" ]] && continue
+			local agents
+			agents=$(load_plugin_agents "$ns")
+			if [[ -n "$agents" ]]; then
+				local count
+				count=$(echo "$agents" | wc -l | tr -d ' ')
+				total_agents=$((total_agents + count))
+			fi
+		done <<<"$namespaces"
+	fi
+	echo "Total plugin agents: $total_agents"
 
-    # Check for manifests
-    local with_manifest=0
-    if [[ -n "$namespaces" ]]; then
-        while IFS= read -r ns; do
-            [[ -z "$ns" ]] && continue
-            if [[ -f "$AGENTS_DIR/$ns/plugin.json" ]]; then
-                with_manifest=$((with_manifest + 1))
-            fi
-        done <<< "$namespaces"
-    fi
-    echo "Plugins with manifest: $with_manifest"
+	# Check for manifests
+	local with_manifest=0
+	if [[ -n "$namespaces" ]]; then
+		while IFS= read -r ns; do
+			[[ -z "$ns" ]] && continue
+			if [[ -f "$AGENTS_DIR/$ns/plugin.json" ]]; then
+				with_manifest=$((with_manifest + 1))
+			fi
+		done <<<"$namespaces"
+	fi
+	echo "Plugins with manifest: $with_manifest"
 
-    echo ""
-    echo "Paths:"
-    echo "  Plugins config: $PLUGINS_FILE"
-    echo "  Agents dir:     $AGENTS_DIR"
-    echo "  Cache dir:      $PLUGIN_CACHE_DIR"
+	echo ""
+	echo "Paths:"
+	echo "  Plugins config: $PLUGINS_FILE"
+	echo "  Agents dir:     $AGENTS_DIR"
+	echo "  Cache dir:      $PLUGIN_CACHE_DIR"
 
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -775,7 +753,7 @@ cmd_status() {
 # =============================================================================
 
 show_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 Plugin Loader Helper - Core plugin structure and agent loader
 
 USAGE:
@@ -835,7 +813,7 @@ EXAMPLES:
     plugin-loader-helper.sh index >> subagent-index.toon
     plugin-loader-helper.sh status
 EOF
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -843,25 +821,25 @@ EOF
 # =============================================================================
 
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    case "$command" in
-        discover|disc|d)    cmd_discover "$@" ;;
-        load|l)             cmd_load "$@" ;;
-        unload|ul)          cmd_unload "$@" ;;
-        validate|val|v)     cmd_validate "$@" ;;
-        agents|ag|a)        cmd_agents "$@" ;;
-        hooks|hook|h)       cmd_hooks "$@" ;;
-        index|idx|i)        cmd_index "$@" ;;
-        status|st|s)        cmd_status "$@" ;;
-        help|--help|-h)     show_help ;;
-        *)
-            log_error "Unknown command: $command"
-            echo "Run 'plugin-loader-helper.sh help' for usage."
-            return 1
-            ;;
-    esac
+	case "$command" in
+	discover | disc | d) cmd_discover "$@" ;;
+	load | l) cmd_load "$@" ;;
+	unload | ul) cmd_unload "$@" ;;
+	validate | val | v) cmd_validate "$@" ;;
+	agents | ag | a) cmd_agents "$@" ;;
+	hooks | hook | h) cmd_hooks "$@" ;;
+	index | idx | i) cmd_index "$@" ;;
+	status | st | s) cmd_status "$@" ;;
+	help | --help | -h) show_help ;;
+	*)
+		log_error "Unknown command: $command"
+		echo "Run 'plugin-loader-helper.sh help' for usage."
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -53,13 +53,9 @@ readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
 
 readonly BOLD='\033[1m'
 
-#######################################
-# Logging
-#######################################
-log_info() { echo -e "${BLUE}[RUNNER]${NC} $*"; }
-log_success() { echo -e "${GREEN}[RUNNER]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[RUNNER]${NC} $*"; }
-log_error() { echo -e "${RED}[RUNNER]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh with RUNNER prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="RUNNER"
 
 #######################################
 # Mailbox bookend: check inbox before work

--- a/.agents/scripts/session-distill-helper.sh
+++ b/.agents/scripts/session-distill-helper.sh
@@ -32,10 +32,7 @@ readonly DISTILL_OUTPUT="$SESSION_DIR/distill-output.json"
 
 # shellcheck disable=SC2034  # Available for future use
 
-log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh
 
 #######################################
 # Ensure session directory exists

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -277,6 +277,51 @@ print_info() {
 	return $?
 }
 
+# =============================================================================
+# Shared Logging Functions (issue #2411)
+# =============================================================================
+# Consolidated log_info/log_error/log_success/log_warn to eliminate duplication
+# across 70+ scripts. Each script can customize the prefix label by setting
+# LOG_PREFIX before sourcing this file (default: "INFO"/"ERROR"/"OK"/"WARN").
+#
+# Usage:
+#   LOG_PREFIX="CODACY"  # Optional: set before sourcing for custom labels
+#   source shared-constants.sh
+#   log_info "Processing..."   # Output: [CODACY] Processing...
+#
+# If LOG_PREFIX is not set, labels default to level names:
+#   log_info  -> [INFO]
+#   log_error -> [ERROR]
+#   log_success -> [OK]
+#   log_warn  -> [WARN]
+#
+# All log functions write to stderr and return 0.
+# Scripts that need different behavior can still override after sourcing.
+
+log_info() {
+	local label="${LOG_PREFIX:-INFO}"
+	echo -e "${BLUE}[${label}]${NC} $*" >&2
+	return 0
+}
+
+log_error() {
+	local label="${LOG_PREFIX:+${LOG_PREFIX}}"
+	echo -e "${RED}[${label:-ERROR}]${NC} $*" >&2
+	return 0
+}
+
+log_success() {
+	local label="${LOG_PREFIX:-OK}"
+	echo -e "${GREEN}[${label}]${NC} $*" >&2
+	return 0
+}
+
+log_warn() {
+	local label="${LOG_PREFIX:-WARN}"
+	echo -e "${YELLOW}[${label}]${NC} $*" >&2
+	return 0
+}
+
 # Validate required parameter
 validate_required_param() {
 	local param_name="$1"

--- a/.agents/scripts/skills-helper.sh
+++ b/.agents/scripts/skills-helper.sh
@@ -39,25 +39,9 @@ SKILL_SOURCES="${AGENTS_DIR}/configs/skill-sources.json"
 # Helper Functions
 # =============================================================================
 
-log_info() {
-	echo -e "${BLUE}[skills]${NC} $1" >&2
-	return 0
-}
-
-log_success() {
-	echo -e "${GREEN}[OK]${NC} $1" >&2
-	return 0
-}
-
-log_warning() {
-	echo -e "${YELLOW}[WARN]${NC} $1" >&2
-	return 0
-}
-
-log_error() {
-	echo -e "${RED}[ERROR]${NC} $1" >&2
-	return 0
-}
+# Logging: uses shared log_* from shared-constants.sh with skills prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="skills"
 
 show_help() {
 	cat <<'EOF'

--- a/.agents/scripts/sonarcloud-collector-helper.sh
+++ b/.agents/scripts/sonarcloud-collector-helper.sh
@@ -39,22 +39,9 @@ readonly SONARCLOUD_API_BASE="https://sonarcloud.io/api"
 # Logging
 # =============================================================================
 
-log_info() {
-	echo -e "${BLUE}[SONARCLOUD]${NC} $*"
-	return 0
-}
-log_success() {
-	echo -e "${GREEN}[SONARCLOUD]${NC} $*"
-	return 0
-}
-log_warn() {
-	echo -e "${YELLOW}[SONARCLOUD]${NC} $*"
-	return 0
-}
-log_error() {
-	echo -e "${RED}[SONARCLOUD]${NC} $*" >&2
-	return 0
-}
+# Logging: uses shared log_* from shared-constants.sh with SONARCLOUD prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="SONARCLOUD"
 
 # =============================================================================
 # SQLite wrapper: sets busy_timeout on every connection (t135.3 pattern)

--- a/.agents/scripts/stash-audit-helper.sh
+++ b/.agents/scripts/stash-audit-helper.sh
@@ -35,29 +35,12 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 set -euo pipefail
 
 readonly BOLD='\033[1m'
-readonly RESET="$NC"  # Alias for NC from shared-constants.sh
-readonly STASH_AGE_THRESHOLD=30  # days
+readonly RESET="$NC"            # Alias for NC from shared-constants.sh
+readonly STASH_AGE_THRESHOLD=30 # days
 
 # Color constants are defined in shared-constants.sh
 
-#######################################
-# Logging functions
-#######################################
-log_info() {
-    echo -e "${BLUE}[INFO]${NC} $*"
-}
-
-log_success() {
-    echo -e "${GREEN}[OK]${NC} $*"
-}
-
-log_warn() {
-    echo -e "${YELLOW}[WARN]${NC} $*"
-}
-
-log_error() {
-    echo -e "${RED}[ERROR]${NC} $*" >&2
-}
+# Logging: uses shared log_* from shared-constants.sh
 
 #######################################
 # Show help message
@@ -67,7 +50,7 @@ log_error() {
 #   0 always
 #######################################
 show_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 Git Stash Audit Helper
 
 Usage:
@@ -96,7 +79,7 @@ Safety:
   - Auto-clean only drops stashes classified as safe-to-drop
   - Dry-run available via audit command
 EOF
-    return 0
+	return 0
 }
 
 #######################################
@@ -109,25 +92,25 @@ EOF
 #   Repository root path
 #######################################
 get_repo_root() {
-    local repo_path="${1:-$(pwd)}"
-    
-    if [[ ! -d "$repo_path" ]]; then
-        log_error "Directory does not exist: $repo_path"
-        return 1
-    fi
-    
-    cd "$repo_path" || return 1
-    
-    local root
-    root=$(git rev-parse --show-toplevel 2>/dev/null)
-    
-    if [[ -z "$root" ]]; then
-        log_error "Not a git repository: $repo_path"
-        return 1
-    fi
-    
-    echo "$root"
-    return 0
+	local repo_path="${1:-$(pwd)}"
+
+	if [[ ! -d "$repo_path" ]]; then
+		log_error "Directory does not exist: $repo_path"
+		return 1
+	fi
+
+	cd "$repo_path" || return 1
+
+	local root
+	root=$(git rev-parse --show-toplevel 2>/dev/null)
+
+	if [[ -z "$root" ]]; then
+		log_error "Not a git repository: $repo_path"
+		return 1
+	fi
+
+	echo "$root"
+	return 0
 }
 
 #######################################
@@ -140,24 +123,24 @@ get_repo_root() {
 #   Age in days
 #######################################
 get_stash_age() {
-    local stash_ref="$1"
-    local stash_timestamp
-    local current_timestamp
-    local age_seconds
-    local age_days
-    
-    stash_timestamp=$(git log -1 --format=%ct "$stash_ref" 2>/dev/null)
-    if [[ -z "$stash_timestamp" ]]; then
-        echo "0"
-        return 1
-    fi
-    
-    current_timestamp=$(date +%s)
-    age_seconds=$((current_timestamp - stash_timestamp))
-    age_days=$((age_seconds / 86400))
-    
-    echo "$age_days"
-    return 0
+	local stash_ref="$1"
+	local stash_timestamp
+	local current_timestamp
+	local age_seconds
+	local age_days
+
+	stash_timestamp=$(git log -1 --format=%ct "$stash_ref" 2>/dev/null)
+	if [[ -z "$stash_timestamp" ]]; then
+		echo "0"
+		return 1
+	fi
+
+	current_timestamp=$(date +%s)
+	age_seconds=$((current_timestamp - stash_timestamp))
+	age_days=$((age_seconds / 86400))
+
+	echo "$age_days"
+	return 0
 }
 
 #######################################
@@ -168,36 +151,36 @@ get_stash_age() {
 #   0 if all changes are in HEAD, 1 otherwise
 #######################################
 stash_changes_in_head() {
-    local stash_ref="$1"
-    
-    # Get files changed in the stash
-    local stash_files
-    stash_files=$(git stash show --name-only "$stash_ref" 2>/dev/null || echo "")
-    
-    if [[ -z "$stash_files" ]]; then
-        # Empty stash, safe to drop
-        return 0
-    fi
-    
-    # For each file in stash, compare content with HEAD
-    while IFS= read -r file; do
-        [[ -z "$file" ]] && continue
-        
-        # Get file content from stash and HEAD
-        local stash_content
-        local head_content
-        
-        stash_content=$(git show "$stash_ref:$file" 2>/dev/null || echo "__STASH_FILE_NOT_FOUND__")
-        head_content=$(git show "HEAD:$file" 2>/dev/null || echo "__HEAD_FILE_NOT_FOUND__")
-        
-        # If content differs, stash has unique changes
-        if [[ "$stash_content" != "$head_content" ]]; then
-            return 1
-        fi
-    done <<< "$stash_files"
-    
-    # All files match HEAD
-    return 0
+	local stash_ref="$1"
+
+	# Get files changed in the stash
+	local stash_files
+	stash_files=$(git stash show --name-only "$stash_ref" 2>/dev/null || echo "")
+
+	if [[ -z "$stash_files" ]]; then
+		# Empty stash, safe to drop
+		return 0
+	fi
+
+	# For each file in stash, compare content with HEAD
+	while IFS= read -r file; do
+		[[ -z "$file" ]] && continue
+
+		# Get file content from stash and HEAD
+		local stash_content
+		local head_content
+
+		stash_content=$(git show "$stash_ref:$file" 2>/dev/null || echo "__STASH_FILE_NOT_FOUND__")
+		head_content=$(git show "HEAD:$file" 2>/dev/null || echo "__HEAD_FILE_NOT_FOUND__")
+
+		# If content differs, stash has unique changes
+		if [[ "$stash_content" != "$head_content" ]]; then
+			return 1
+		fi
+	done <<<"$stash_files"
+
+	# All files match HEAD
+	return 0
 }
 
 #######################################
@@ -210,25 +193,25 @@ stash_changes_in_head() {
 #   Classification: safe-to-drop, obsolete, or needs-review
 #######################################
 classify_stash() {
-    local stash_ref="$1"
-    
-    # Check if all changes are in HEAD
-    if stash_changes_in_head "$stash_ref"; then
-        echo "safe-to-drop"
-        return 0
-    fi
-    
-    # Check age
-    local age_days
-    age_days=$(get_stash_age "$stash_ref")
-    
-    if [[ "$age_days" -ge "$STASH_AGE_THRESHOLD" ]]; then
-        echo "obsolete"
-        return 0
-    fi
-    
-    echo "needs-review"
-    return 0
+	local stash_ref="$1"
+
+	# Check if all changes are in HEAD
+	if stash_changes_in_head "$stash_ref"; then
+		echo "safe-to-drop"
+		return 0
+	fi
+
+	# Check age
+	local age_days
+	age_days=$(get_stash_age "$stash_ref")
+
+	if [[ "$age_days" -ge "$STASH_AGE_THRESHOLD" ]]; then
+		echo "obsolete"
+		return 0
+	fi
+
+	echo "needs-review"
+	return 0
 }
 
 #######################################
@@ -239,72 +222,72 @@ classify_stash() {
 #   0 on success, 1 on failure
 #######################################
 cmd_audit() {
-    local repo_path="${1:-$(pwd)}"
-    local repo_root
-    
-    repo_root=$(get_repo_root "$repo_path")
-    if [[ $? -ne 0 ]]; then
-        return 1
-    fi
-    
-    cd "$repo_root" || return 1
-    
-    # Get stash list
-    local stash_list
-    stash_list=$(git stash list 2>/dev/null)
-    
-    if [[ -z "$stash_list" ]]; then
-        log_info "No stashes found"
-        return 0
-    fi
-    
-    log_info "Auditing stashes in: $repo_root"
-    echo ""
-    
-    local safe_count=0
-    local obsolete_count=0
-    local review_count=0
-    
-    while IFS= read -r stash_line; do
-        local stash_ref
-        stash_ref=$(echo "$stash_line" | cut -d: -f1)
-        
-        local classification
-        classification=$(classify_stash "$stash_ref")
-        
-        local age_days
-        age_days=$(get_stash_age "$stash_ref")
-        
-        local message
-        message=$(echo "$stash_line" | cut -d: -f2- | sed 's/^ //')
-        
-        case "$classification" in
-            safe-to-drop)
-                echo -e "${GREEN}✓${RESET} $stash_ref (${age_days}d): $message"
-                echo "  → safe-to-drop (all changes in HEAD)"
-                safe_count=$((safe_count + 1))
-                ;;
-            obsolete)
-                echo -e "${YELLOW}⚠${RESET} $stash_ref (${age_days}d): $message"
-                echo "  → obsolete (>$STASH_AGE_THRESHOLD days old)"
-                obsolete_count=$((obsolete_count + 1))
-                ;;
-            needs-review)
-                echo -e "${RED}✗${RESET} $stash_ref (${age_days}d): $message"
-                echo "  → needs-review (contains unique changes)"
-                review_count=$((review_count + 1))
-                ;;
-        esac
-        echo ""
-    done <<< "$stash_list"
-    
-    log_info "Summary:"
-    echo "  Safe to drop:  $safe_count"
-    echo "  Obsolete:      $obsolete_count"
-    echo "  Needs review:  $review_count"
-    echo "  Total:         $((safe_count + obsolete_count + review_count))"
-    
-    return 0
+	local repo_path="${1:-$(pwd)}"
+	local repo_root
+
+	repo_root=$(get_repo_root "$repo_path")
+	if [[ $? -ne 0 ]]; then
+		return 1
+	fi
+
+	cd "$repo_root" || return 1
+
+	# Get stash list
+	local stash_list
+	stash_list=$(git stash list 2>/dev/null)
+
+	if [[ -z "$stash_list" ]]; then
+		log_info "No stashes found"
+		return 0
+	fi
+
+	log_info "Auditing stashes in: $repo_root"
+	echo ""
+
+	local safe_count=0
+	local obsolete_count=0
+	local review_count=0
+
+	while IFS= read -r stash_line; do
+		local stash_ref
+		stash_ref=$(echo "$stash_line" | cut -d: -f1)
+
+		local classification
+		classification=$(classify_stash "$stash_ref")
+
+		local age_days
+		age_days=$(get_stash_age "$stash_ref")
+
+		local message
+		message=$(echo "$stash_line" | cut -d: -f2- | sed 's/^ //')
+
+		case "$classification" in
+		safe-to-drop)
+			echo -e "${GREEN}✓${RESET} $stash_ref (${age_days}d): $message"
+			echo "  → safe-to-drop (all changes in HEAD)"
+			safe_count=$((safe_count + 1))
+			;;
+		obsolete)
+			echo -e "${YELLOW}⚠${RESET} $stash_ref (${age_days}d): $message"
+			echo "  → obsolete (>$STASH_AGE_THRESHOLD days old)"
+			obsolete_count=$((obsolete_count + 1))
+			;;
+		needs-review)
+			echo -e "${RED}✗${RESET} $stash_ref (${age_days}d): $message"
+			echo "  → needs-review (contains unique changes)"
+			review_count=$((review_count + 1))
+			;;
+		esac
+		echo ""
+	done <<<"$stash_list"
+
+	log_info "Summary:"
+	echo "  Safe to drop:  $safe_count"
+	echo "  Obsolete:      $obsolete_count"
+	echo "  Needs review:  $review_count"
+	echo "  Total:         $((safe_count + obsolete_count + review_count))"
+
+	return 0
 }
 
 #######################################
@@ -315,22 +298,22 @@ cmd_audit() {
 #   0 on success, 1 on failure
 #######################################
 cmd_list() {
-    local repo_path="${1:-$(pwd)}"
-    local repo_root
-    
-    repo_root=$(get_repo_root "$repo_path")
-    if [[ $? -ne 0 ]]; then
-        return 1
-    fi
-    
-    cd "$repo_root" || return 1
-    
-    log_info "Stashes in: $repo_root"
-    echo ""
-    
-    git stash list --format="%gd: %cr - %s" 2>/dev/null
-    
-    return 0
+	local repo_path="${1:-$(pwd)}"
+	local repo_root
+
+	repo_root=$(get_repo_root "$repo_path")
+	if [[ $? -ne 0 ]]; then
+		return 1
+	fi
+
+	cd "$repo_root" || return 1
+
+	log_info "Stashes in: $repo_root"
+	echo ""
+
+	git stash list --format="%gd: %cr - %s" 2>/dev/null
+
+	return 0
 }
 
 #######################################
@@ -341,73 +324,73 @@ cmd_list() {
 #   0 on success, 1 on failure
 #######################################
 cmd_clean() {
-    local repo_path="${1:-$(pwd)}"
-    local repo_root
-    
-    repo_root=$(get_repo_root "$repo_path")
-    if [[ $? -ne 0 ]]; then
-        return 1
-    fi
-    
-    cd "$repo_root" || return 1
-    
-    # Get stash list
-    local stash_list
-    stash_list=$(git stash list 2>/dev/null)
-    
-    if [[ -z "$stash_list" ]]; then
-        log_info "No stashes found"
-        return 0
-    fi
-    
-    log_info "Finding safe-to-drop stashes..."
-    echo ""
-    
-    local safe_stashes=()
-    
-    while IFS= read -r stash_line; do
-        local stash_ref
-        stash_ref=$(echo "$stash_line" | cut -d: -f1)
-        
-        local classification
-        classification=$(classify_stash "$stash_ref")
-        
-        if [[ "$classification" == "safe-to-drop" ]]; then
-            safe_stashes+=("$stash_ref")
-            local message
-            message=$(echo "$stash_line" | cut -d: -f2- | sed 's/^ //')
-            echo "  $stash_ref: $message"
-        fi
-    done <<< "$stash_list"
-    
-    if [[ ${#safe_stashes[@]} -eq 0 ]]; then
-        log_info "No safe-to-drop stashes found"
-        return 0
-    fi
-    
-    echo ""
-    log_warn "Found ${#safe_stashes[@]} safe-to-drop stash(es)"
-    echo -n "Drop these stashes? [y/N] "
-    read -r response
-    
-    if [[ ! "$response" =~ ^[Yy]$ ]]; then
-        log_info "Cancelled"
-        return 0
-    fi
-    
-    local dropped=0
-    for stash_ref in "${safe_stashes[@]}"; do
-        if git stash drop "$stash_ref" 2>/dev/null; then
-            log_success "Dropped: $stash_ref"
-            dropped=$((dropped + 1))
-        else
-            log_error "Failed to drop: $stash_ref"
-        fi
-    done
-    
-    log_success "Dropped $dropped stash(es)"
-    
-    return 0
+	local repo_path="${1:-$(pwd)}"
+	local repo_root
+
+	repo_root=$(get_repo_root "$repo_path")
+	if [[ $? -ne 0 ]]; then
+		return 1
+	fi
+
+	cd "$repo_root" || return 1
+
+	# Get stash list
+	local stash_list
+	stash_list=$(git stash list 2>/dev/null)
+
+	if [[ -z "$stash_list" ]]; then
+		log_info "No stashes found"
+		return 0
+	fi
+
+	log_info "Finding safe-to-drop stashes..."
+	echo ""
+
+	local safe_stashes=()
+
+	while IFS= read -r stash_line; do
+		local stash_ref
+		stash_ref=$(echo "$stash_line" | cut -d: -f1)
+
+		local classification
+		classification=$(classify_stash "$stash_ref")
+
+		if [[ "$classification" == "safe-to-drop" ]]; then
+			safe_stashes+=("$stash_ref")
+			local message
+			message=$(echo "$stash_line" | cut -d: -f2- | sed 's/^ //')
+			echo "  $stash_ref: $message"
+		fi
+	done <<<"$stash_list"
+
+	if [[ ${#safe_stashes[@]} -eq 0 ]]; then
+		log_info "No safe-to-drop stashes found"
+		return 0
+	fi
+
+	echo ""
+	log_warn "Found ${#safe_stashes[@]} safe-to-drop stash(es)"
+	echo -n "Drop these stashes? [y/N] "
+	read -r response
+
+	if [[ ! "$response" =~ ^[Yy]$ ]]; then
+		log_info "Cancelled"
+		return 0
+	fi
+
+	local dropped=0
+	for stash_ref in "${safe_stashes[@]}"; do
+		if git stash drop "$stash_ref" 2>/dev/null; then
+			log_success "Dropped: $stash_ref"
+			dropped=$((dropped + 1))
+		else
+			log_error "Failed to drop: $stash_ref"
+		fi
+	done
+
+	log_success "Dropped $dropped stash(es)"
+
+	return 0
 }
 
 #######################################
@@ -418,61 +401,61 @@ cmd_clean() {
 #   0 on success, 1 on failure
 #######################################
 cmd_auto_clean() {
-    local repo_path="${1:-$(pwd)}"
-    local repo_root
-    
-    repo_root=$(get_repo_root "$repo_path")
-    if [[ $? -ne 0 ]]; then
-        return 1
-    fi
-    
-    cd "$repo_root" || return 1
-    
-    # Get stash list
-    local stash_list
-    stash_list=$(git stash list 2>/dev/null)
-    
-    if [[ -z "$stash_list" ]]; then
-        log_info "No stashes found in: $repo_root"
-        return 0
-    fi
-    
-    local safe_stashes=()
-    
-    while IFS= read -r stash_line; do
-        local stash_ref
-        stash_ref=$(echo "$stash_line" | cut -d: -f1)
-        
-        local classification
-        classification=$(classify_stash "$stash_ref")
-        
-        if [[ "$classification" == "safe-to-drop" ]]; then
-            safe_stashes+=("$stash_ref")
-        fi
-    done <<< "$stash_list"
-    
-    if [[ ${#safe_stashes[@]} -eq 0 ]]; then
-        log_info "No safe-to-drop stashes found in: $repo_root"
-        return 0
-    fi
-    
-    log_info "Auto-cleaning ${#safe_stashes[@]} safe-to-drop stash(es) in: $repo_root"
-    
-    local dropped=0
-    for stash_ref in "${safe_stashes[@]}"; do
-        if git stash drop "$stash_ref" 2>/dev/null; then
-            log_info "  Dropped: $stash_ref"
-            dropped=$((dropped + 1))
-        else
-            log_warn "  Failed to drop: $stash_ref"
-        fi
-    done
-    
-    if [[ "$dropped" -gt 0 ]]; then
-        log_success "Auto-cleaned $dropped stash(es) in: $repo_root"
-    fi
-    
-    return 0
+	local repo_path="${1:-$(pwd)}"
+	local repo_root
+
+	repo_root=$(get_repo_root "$repo_path")
+	if [[ $? -ne 0 ]]; then
+		return 1
+	fi
+
+	cd "$repo_root" || return 1
+
+	# Get stash list
+	local stash_list
+	stash_list=$(git stash list 2>/dev/null)
+
+	if [[ -z "$stash_list" ]]; then
+		log_info "No stashes found in: $repo_root"
+		return 0
+	fi
+
+	local safe_stashes=()
+
+	while IFS= read -r stash_line; do
+		local stash_ref
+		stash_ref=$(echo "$stash_line" | cut -d: -f1)
+
+		local classification
+		classification=$(classify_stash "$stash_ref")
+
+		if [[ "$classification" == "safe-to-drop" ]]; then
+			safe_stashes+=("$stash_ref")
+		fi
+	done <<<"$stash_list"
+
+	if [[ ${#safe_stashes[@]} -eq 0 ]]; then
+		log_info "No safe-to-drop stashes found in: $repo_root"
+		return 0
+	fi
+
+	log_info "Auto-cleaning ${#safe_stashes[@]} safe-to-drop stash(es) in: $repo_root"
+
+	local dropped=0
+	for stash_ref in "${safe_stashes[@]}"; do
+		if git stash drop "$stash_ref" 2>/dev/null; then
+			log_info "  Dropped: $stash_ref"
+			dropped=$((dropped + 1))
+		else
+			log_warn "  Failed to drop: $stash_ref"
+		fi
+	done
+
+	if [[ "$dropped" -gt 0 ]]; then
+		log_success "Auto-cleaned $dropped stash(es) in: $repo_root"
+	fi
+
+	return 0
 }
 
 #######################################
@@ -483,57 +466,57 @@ cmd_auto_clean() {
 #   0 on success, 1 on failure
 #######################################
 main() {
-    if [[ $# -eq 0 ]]; then
-        show_help
-        return 1
-    fi
-    
-    local command="$1"
-    shift
-    
-    local repo_path=""
-    
-    # Parse common options
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --repo)
-                repo_path="$2"
-                shift 2
-                ;;
-            *)
-                log_error "Unknown option: $1"
-                return 1
-                ;;
-        esac
-    done
-    
-    case "$command" in
-        audit)
-            cmd_audit "$repo_path"
-            ;;
-        clean)
-            cmd_clean "$repo_path"
-            ;;
-        auto-clean)
-            cmd_auto_clean "$repo_path"
-            ;;
-        list)
-            cmd_list "$repo_path"
-            ;;
-        help|--help|-h)
-            show_help
-            ;;
-        *)
-            log_error "Unknown command: $command"
-            show_help
-            return 1
-            ;;
-    esac
-    
-    return $?
+	if [[ $# -eq 0 ]]; then
+		show_help
+		return 1
+	fi
+
+	local command="$1"
+	shift
+
+	local repo_path=""
+
+	# Parse common options
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo)
+			repo_path="$2"
+			shift 2
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	case "$command" in
+	audit)
+		cmd_audit "$repo_path"
+		;;
+	clean)
+		cmd_clean "$repo_path"
+		;;
+	auto-clean)
+		cmd_auto_clean "$repo_path"
+		;;
+	list)
+		cmd_list "$repo_path"
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		log_error "Unknown command: $command"
+		show_help
+		return 1
+		;;
+	esac
+
+	return $?
 }
 
 # Run main if executed directly
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    main "$@"
+	main "$@"
 fi

--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -45,11 +45,7 @@ REPO_PATH="$PWD"
 NO_PUSH=false
 VERIFY_BRIEF=false
 
-# Logging
-log_info() { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
-log_success() { echo -e "${GREEN}[OK]${NC} $*" >&2; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*" >&2; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh
 
 # Show help
 show_help() {

--- a/.agents/scripts/tech-stack-helper.sh
+++ b/.agents/scripts/tech-stack-helper.sh
@@ -115,25 +115,8 @@ provider_display_name() {
 }
 
 # =============================================================================
-# Logging — thin wrappers over shared print_* (all output to stderr for logging)
+# Logging: uses shared log_* from shared-constants.sh
 # =============================================================================
-
-log_info() {
-	print_info "$1" >&2
-	return 0
-}
-log_success() {
-	print_success "$1" >&2
-	return 0
-}
-log_warning() {
-	print_warning "$1" >&2
-	return 0
-}
-log_error() {
-	print_error "$1"
-	return 0
-} # print_error already writes to stderr
 
 # =============================================================================
 # Dependencies

--- a/.agents/scripts/terminal-title-helper.sh
+++ b/.agents/scripts/terminal-title-helper.sh
@@ -28,11 +28,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
 
-# Logging
-log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $*"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh
 
 # Configuration (support both old and new env var names for compatibility)
 TERMINAL_TITLE_FORMAT="${TERMINAL_TITLE_FORMAT:-${TABBY_TAB_TITLE_FORMAT:-repo/branch}}"
@@ -45,170 +41,170 @@ TERMINAL_TITLE_ENABLED="${TERMINAL_TITLE_ENABLED:-${AIDEVOPS_TABBY_ENABLED:-true
 # Set tab title using OSC escape sequence
 # Works with most modern terminals: Tabby, iTerm2, Windows Terminal, Kitty, Alacritty, etc.
 set_tab_title() {
-    local title="$1"
-    
-    if [[ "$TERMINAL_TITLE_ENABLED" == "false" ]]; then
-        return 0
-    fi
-    
-    # OSC 0 sets both icon name and window title
-    # OSC 2 sets window title only
-    # Using OSC 0 for broader compatibility
-    printf '\033]0;%s\007' "$title"
+	local title="$1"
+
+	if [[ "$TERMINAL_TITLE_ENABLED" == "false" ]]; then
+		return 0
+	fi
+
+	# OSC 0 sets both icon name and window title
+	# OSC 2 sets window title only
+	# Using OSC 0 for broader compatibility
+	printf '\033]0;%s\007' "$title"
 }
 
 # Reset tab title to default (empty string triggers terminal default)
 reset_tab_title() {
-    # Send empty title to reset
-    printf '\033]0;\007'
-    log_success "Tab title reset to default"
+	# Send empty title to reset
+	printf '\033]0;\007'
+	log_success "Tab title reset to default"
 }
 
 # Detect terminal type and OSC compatibility
 detect_terminal() {
-    local term_program="${TERM_PROGRAM:-}"
-    local term="${TERM:-}"
-    
-    # Check known terminals by TERM_PROGRAM
-    case "$term_program" in
-        "Tabby")
-            echo "tabby"
-            return 0
-            ;;
-        "iTerm.app")
-            echo "iterm2"
-            return 0
-            ;;
-        "Apple_Terminal")
-            echo "apple-terminal"
-            return 0
-            ;;
-        "vscode")
-            echo "vscode"
-            return 0
-            ;;
-        "WezTerm")
-            echo "wezterm"
-            return 0
-            ;;
-        "Hyper")
-            echo "hyper"
-            return 0
-            ;;
-        *)
-            # Not a known TERM_PROGRAM, continue to TERM check
-            ;;
-    esac
-    
-    # Check by TERM variable for other terminals
-    case "$term" in
-        xterm*|rxvt*|screen*|tmux*|alacritty|kitty*)
-            echo "compatible"
-            return 0
-            ;;
-        *)
-            # Not a known TERM, continue to other checks
-            ;;
-    esac
-    
-    # Check for Windows Terminal
-    if [[ -n "${WT_SESSION:-}" ]]; then
-        echo "windows-terminal"
-        return 0
-    fi
-    
-    # Check for Kitty
-    if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
-        echo "kitty"
-        return 0
-    fi
-    
-    # Fallback - if TERM is set and not dumb, likely compatible
-    if [[ -n "$term" ]] && [[ "$term" != "dumb" ]]; then
-        echo "compatible"
-        return 0
-    fi
-    
-    echo "unknown"
-    return 1
+	local term_program="${TERM_PROGRAM:-}"
+	local term="${TERM:-}"
+
+	# Check known terminals by TERM_PROGRAM
+	case "$term_program" in
+	"Tabby")
+		echo "tabby"
+		return 0
+		;;
+	"iTerm.app")
+		echo "iterm2"
+		return 0
+		;;
+	"Apple_Terminal")
+		echo "apple-terminal"
+		return 0
+		;;
+	"vscode")
+		echo "vscode"
+		return 0
+		;;
+	"WezTerm")
+		echo "wezterm"
+		return 0
+		;;
+	"Hyper")
+		echo "hyper"
+		return 0
+		;;
+	*)
+		# Not a known TERM_PROGRAM, continue to TERM check
+		;;
+	esac
+
+	# Check by TERM variable for other terminals
+	case "$term" in
+	xterm* | rxvt* | screen* | tmux* | alacritty | kitty*)
+		echo "compatible"
+		return 0
+		;;
+	*)
+		# Not a known TERM, continue to other checks
+		;;
+	esac
+
+	# Check for Windows Terminal
+	if [[ -n "${WT_SESSION:-}" ]]; then
+		echo "windows-terminal"
+		return 0
+	fi
+
+	# Check for Kitty
+	if [[ -n "${KITTY_WINDOW_ID:-}" ]]; then
+		echo "kitty"
+		return 0
+	fi
+
+	# Fallback - if TERM is set and not dumb, likely compatible
+	if [[ -n "$term" ]] && [[ "$term" != "dumb" ]]; then
+		echo "compatible"
+		return 0
+	fi
+
+	echo "unknown"
+	return 1
 }
 
 # Get current git repository name (resolves to main repo name even in worktrees)
 get_repo_name() {
-    local git_common_dir repo_path
-    
-    # git rev-parse --git-common-dir returns the main .git directory
-    # even when in a linked worktree
-    git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
-    
-    # Convert to absolute path to handle subdirectories correctly
-    # realpath may not exist on all systems, use cd/pwd as fallback
-    local abs_path=""
-    if command -v realpath &>/dev/null; then
-        abs_path=$(realpath "$git_common_dir" 2>/dev/null)
-    fi
-    
-    # Fallback to cd/pwd if realpath failed or doesn't exist
-    if [[ -z "$abs_path" ]]; then
-        abs_path=$(cd "$git_common_dir" 2>/dev/null && pwd) || return 1
-    fi
-    
-    git_common_dir="$abs_path"
-    
-    # The common dir is the .git folder of the main repo
-    # Get its parent to find the main repo root
-    repo_path=$(dirname "$git_common_dir")
-    
-    basename "$repo_path"
+	local git_common_dir repo_path
+
+	# git rev-parse --git-common-dir returns the main .git directory
+	# even when in a linked worktree
+	git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
+
+	# Convert to absolute path to handle subdirectories correctly
+	# realpath may not exist on all systems, use cd/pwd as fallback
+	local abs_path=""
+	if command -v realpath &>/dev/null; then
+		abs_path=$(realpath "$git_common_dir" 2>/dev/null)
+	fi
+
+	# Fallback to cd/pwd if realpath failed or doesn't exist
+	if [[ -z "$abs_path" ]]; then
+		abs_path=$(cd "$git_common_dir" 2>/dev/null && pwd) || return 1
+	fi
+
+	git_common_dir="$abs_path"
+
+	# The common dir is the .git folder of the main repo
+	# Get its parent to find the main repo root
+	repo_path=$(dirname "$git_common_dir")
+
+	basename "$repo_path"
 }
 
 # Get current git branch name
 get_branch_name() {
-    git branch --show-current 2>/dev/null || echo ""
+	git branch --show-current 2>/dev/null || echo ""
 }
 
 # Generate tab title based on format
 generate_title() {
-    local format="${1:-$TERMINAL_TITLE_FORMAT}"
-    local repo_name branch_name
-    
-    repo_name=$(get_repo_name) || repo_name=""
-    branch_name=$(get_branch_name) || branch_name=""
-    
-    case "$format" in
-        "repo/branch")
-            if [[ -n "$repo_name" ]] && [[ -n "$branch_name" ]]; then
-                echo "${repo_name}/${branch_name}"
-            elif [[ -n "$repo_name" ]]; then
-                echo "$repo_name"
-            elif [[ -n "$branch_name" ]]; then
-                echo "$branch_name"
-            else
-                echo ""
-            fi
-            ;;
-        "branch")
-            echo "$branch_name"
-            ;;
-        "repo")
-            echo "$repo_name"
-            ;;
-        "branch/repo")
-            if [[ -n "$branch_name" ]] && [[ -n "$repo_name" ]]; then
-                echo "${branch_name} (${repo_name})"
-            elif [[ -n "$branch_name" ]]; then
-                echo "$branch_name"
-            elif [[ -n "$repo_name" ]]; then
-                echo "$repo_name"
-            else
-                echo ""
-            fi
-            ;;
-        *)
-            # Custom format - use as-is
-            echo "$format"
-            ;;
-    esac
+	local format="${1:-$TERMINAL_TITLE_FORMAT}"
+	local repo_name branch_name
+
+	repo_name=$(get_repo_name) || repo_name=""
+	branch_name=$(get_branch_name) || branch_name=""
+
+	case "$format" in
+	"repo/branch")
+		if [[ -n "$repo_name" ]] && [[ -n "$branch_name" ]]; then
+			echo "${repo_name}/${branch_name}"
+		elif [[ -n "$repo_name" ]]; then
+			echo "$repo_name"
+		elif [[ -n "$branch_name" ]]; then
+			echo "$branch_name"
+		else
+			echo ""
+		fi
+		;;
+	"branch")
+		echo "$branch_name"
+		;;
+	"repo")
+		echo "$repo_name"
+		;;
+	"branch/repo")
+		if [[ -n "$branch_name" ]] && [[ -n "$repo_name" ]]; then
+			echo "${branch_name} (${repo_name})"
+		elif [[ -n "$branch_name" ]]; then
+			echo "$branch_name"
+		elif [[ -n "$repo_name" ]]; then
+			echo "$repo_name"
+		else
+			echo ""
+		fi
+		;;
+	*)
+		# Custom format - use as-is
+		echo "$format"
+		;;
+	esac
 }
 
 # =============================================================================
@@ -216,85 +212,85 @@ generate_title() {
 # =============================================================================
 
 cmd_rename() {
-    local title="${1:-}"
-    
-    if [[ -z "$title" ]]; then
-        # Generate title from git context
-        title=$(generate_title)
-    fi
-    
-    if [[ -z "$title" ]]; then
-        log_warn "No title provided and not in a git repository"
-        return 1
-    fi
-    
-    set_tab_title "$title"
-    log_success "Tab title set to: $title"
+	local title="${1:-}"
+
+	if [[ -z "$title" ]]; then
+		# Generate title from git context
+		title=$(generate_title)
+	fi
+
+	if [[ -z "$title" ]]; then
+		log_warn "No title provided and not in a git repository"
+		return 1
+	fi
+
+	set_tab_title "$title"
+	log_success "Tab title set to: $title"
 }
 
 cmd_sync() {
-    local title
-    title=$(generate_title)
-    
-    if [[ -z "$title" ]]; then
-        log_warn "Not in a git repository - cannot sync tab title"
-        return 1
-    fi
-    
-    set_tab_title "$title"
-    log_success "Tab synced: $title"
+	local title
+	title=$(generate_title)
+
+	if [[ -z "$title" ]]; then
+		log_warn "Not in a git repository - cannot sync tab title"
+		return 1
+	fi
+
+	set_tab_title "$title"
+	log_success "Tab synced: $title"
 }
 
 cmd_reset() {
-    reset_tab_title
+	reset_tab_title
 }
 
 cmd_detect() {
-    local terminal
-    terminal=$(detect_terminal)
-    local upper_terminal
-    upper_terminal=$(echo "$terminal" | tr '[:lower:]-' '[:upper:]_')
-    
-    case "$terminal" in
-        "tabby")
-            log_success "Running in Tabby terminal (full OSC support)"
-            ;;
-        "iterm2")
-            log_success "Running in iTerm2 (full OSC support)"
-            ;;
-        "windows-terminal")
-            log_success "Running in Windows Terminal (full OSC support)"
-            ;;
-        "kitty")
-            log_success "Running in Kitty terminal (full OSC support)"
-            ;;
-        "wezterm")
-            log_success "Running in WezTerm (full OSC support)"
-            ;;
-        "vscode")
-            log_success "Running in VS Code integrated terminal (OSC support)"
-            ;;
-        "apple-terminal")
-            log_success "Running in Apple Terminal (basic OSC support)"
-            ;;
-        "hyper")
-            log_success "Running in Hyper terminal (OSC support)"
-            ;;
-        "compatible")
-            log_info "Running in OSC-compatible terminal: ${TERM:-unknown}"
-            ;;
-        *)
-            log_warn "Unknown terminal - OSC sequences may not work"
-            echo "$upper_terminal"
-            return 1
-            ;;
-    esac
-    
-    echo "$upper_terminal"
+	local terminal
+	terminal=$(detect_terminal)
+	local upper_terminal
+	upper_terminal=$(echo "$terminal" | tr '[:lower:]-' '[:upper:]_')
+
+	case "$terminal" in
+	"tabby")
+		log_success "Running in Tabby terminal (full OSC support)"
+		;;
+	"iterm2")
+		log_success "Running in iTerm2 (full OSC support)"
+		;;
+	"windows-terminal")
+		log_success "Running in Windows Terminal (full OSC support)"
+		;;
+	"kitty")
+		log_success "Running in Kitty terminal (full OSC support)"
+		;;
+	"wezterm")
+		log_success "Running in WezTerm (full OSC support)"
+		;;
+	"vscode")
+		log_success "Running in VS Code integrated terminal (OSC support)"
+		;;
+	"apple-terminal")
+		log_success "Running in Apple Terminal (basic OSC support)"
+		;;
+	"hyper")
+		log_success "Running in Hyper terminal (OSC support)"
+		;;
+	"compatible")
+		log_info "Running in OSC-compatible terminal: ${TERM:-unknown}"
+		;;
+	*)
+		log_warn "Unknown terminal - OSC sequences may not work"
+		echo "$upper_terminal"
+		return 1
+		;;
+	esac
+
+	echo "$upper_terminal"
 }
 
 cmd_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 terminal-title-helper.sh - Terminal tab/window title integration for aidevops
 
 Sets terminal tab titles using OSC escape sequences. Works with most modern terminals:
@@ -354,31 +350,31 @@ EOF
 # =============================================================================
 
 main() {
-    local command="${1:-help}"
-    shift || true
-    
-    case "$command" in
-        rename)
-            cmd_rename "$@"
-            ;;
-        sync)
-            cmd_sync
-            ;;
-        reset)
-            cmd_reset
-            ;;
-        detect)
-            cmd_detect
-            ;;
-        help|--help|-h)
-            cmd_help
-            ;;
-        *)
-            log_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	rename)
+		cmd_rename "$@"
+		;;
+	sync)
+		cmd_sync
+		;;
+	reset)
+		cmd_reset
+		;;
+	detect)
+		cmd_detect
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/terminal-title-setup.sh
+++ b/.agents/scripts/terminal-title-setup.sh
@@ -20,11 +20,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
 
-# Logging
-log_info() { echo -e "${BLUE}[INFO]${NC} $*"; return 0; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $*"; return 0; }
-log_warn() { echo -e "${YELLOW}[WARNING]${NC} $*"; return 0; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; return 0; }
+# Logging: uses shared log_* from shared-constants.sh
 
 # Marker comments for our integration
 MARKER_START="# >>> aidevops terminal-title integration >>>"
@@ -35,32 +31,32 @@ MARKER_END="# <<< aidevops terminal-title integration <<<"
 # =============================================================================
 
 detect_shell() {
-    local shell_name
-    shell_name=$(basename "${SHELL:-/bin/bash}")
-    echo "$shell_name"
-    return 0
+	local shell_name
+	shell_name=$(basename "${SHELL:-/bin/bash}")
+	echo "$shell_name"
+	return 0
 }
 
 has_oh_my_zsh() {
-    [[ -d "$HOME/.oh-my-zsh" ]]
-    return 0
+	[[ -d "$HOME/.oh-my-zsh" ]]
+	return 0
 }
 
 has_oh_my_bash() {
-    [[ -d "$HOME/.oh-my-bash" ]]
-    return 0
+	[[ -d "$HOME/.oh-my-bash" ]]
+	return 0
 }
 
 has_starship() {
-    command -v starship &>/dev/null
-    return 0
+	command -v starship &>/dev/null
+	return 0
 }
 
 has_powerlevel10k() {
-    [[ -d "$HOME/.oh-my-zsh/custom/themes/powerlevel10k" ]] || \
-    [[ -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k" ]] || \
-    grep -q "powerlevel10k" "$HOME/.zshrc" 2>/dev/null
-    return 0
+	[[ -d "$HOME/.oh-my-zsh/custom/themes/powerlevel10k" ]] ||
+		[[ -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k" ]] ||
+		grep -q "powerlevel10k" "$HOME/.zshrc" 2>/dev/null
+	return 0
 }
 
 # =============================================================================
@@ -70,78 +66,79 @@ has_powerlevel10k() {
 TABBY_CONFIG_FILE="$HOME/Library/Application Support/tabby/config.yaml"
 
 has_tabby() {
-    [[ -f "$TABBY_CONFIG_FILE" ]]
-    return 0
+	[[ -f "$TABBY_CONFIG_FILE" ]]
+	return 0
 }
 
 # Check if Tabby has disableDynamicTitle: true (blocks OSC title changes)
 tabby_has_dynamic_title_disabled() {
-    if [[ ! -f "$TABBY_CONFIG_FILE" ]]; then
-        return 1
-    fi
-    grep -q "disableDynamicTitle: true" "$TABBY_CONFIG_FILE" 2>/dev/null
+	if [[ ! -f "$TABBY_CONFIG_FILE" ]]; then
+		return 1
+	fi
+	grep -q "disableDynamicTitle: true" "$TABBY_CONFIG_FILE" 2>/dev/null
 }
 
 # Count how many profiles have dynamic title disabled
 tabby_count_disabled_profiles() {
-    if [[ ! -f "$TABBY_CONFIG_FILE" ]]; then
-        echo "0"
-        return 0
-    fi
-    grep -c "disableDynamicTitle: true" "$TABBY_CONFIG_FILE" 2>/dev/null || echo "0"
-    return 0
+	if [[ ! -f "$TABBY_CONFIG_FILE" ]]; then
+		echo "0"
+		return 0
+	fi
+	grep -c "disableDynamicTitle: true" "$TABBY_CONFIG_FILE" 2>/dev/null || echo "0"
+	return 0
 }
 
 # Fix Tabby config to allow dynamic titles
 tabby_enable_dynamic_titles() {
-    if [[ ! -f "$TABBY_CONFIG_FILE" ]]; then
-        log_error "Tabby config not found: $TABBY_CONFIG_FILE"
-        return 1
-    fi
-    
-    # Create backup
-    cp "$TABBY_CONFIG_FILE" "${TABBY_CONFIG_FILE}.aidevops-backup"
-    
-    # Replace all instances (cross-platform: works on both macOS and Linux)
-    local temp_file
-    temp_file=$(mktemp)
-    _save_cleanup_scope; trap '_run_cleanups' RETURN
-    push_cleanup "rm -f '${temp_file}'"
-    sed 's/disableDynamicTitle: true/disableDynamicTitle: false/g' "$TABBY_CONFIG_FILE" > "$temp_file" && mv "$temp_file" "$TABBY_CONFIG_FILE"
-    
-    local count
-    count=$(grep -c "disableDynamicTitle: false" "$TABBY_CONFIG_FILE" 2>/dev/null || echo "0")
-    log_success "Updated $count Tabby profile(s) to allow dynamic titles"
-    log_info "Backup saved to: ${TABBY_CONFIG_FILE}.aidevops-backup"
-    log_info "Restart Tabby for changes to take effect"
+	if [[ ! -f "$TABBY_CONFIG_FILE" ]]; then
+		log_error "Tabby config not found: $TABBY_CONFIG_FILE"
+		return 1
+	fi
+
+	# Create backup
+	cp "$TABBY_CONFIG_FILE" "${TABBY_CONFIG_FILE}.aidevops-backup"
+
+	# Replace all instances (cross-platform: works on both macOS and Linux)
+	local temp_file
+	temp_file=$(mktemp)
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	push_cleanup "rm -f '${temp_file}'"
+	sed 's/disableDynamicTitle: true/disableDynamicTitle: false/g' "$TABBY_CONFIG_FILE" >"$temp_file" && mv "$temp_file" "$TABBY_CONFIG_FILE"
+
+	local count
+	count=$(grep -c "disableDynamicTitle: false" "$TABBY_CONFIG_FILE" 2>/dev/null || echo "0")
+	log_success "Updated $count Tabby profile(s) to allow dynamic titles"
+	log_info "Backup saved to: ${TABBY_CONFIG_FILE}.aidevops-backup"
+	log_info "Restart Tabby for changes to take effect"
 }
 
 # Check and offer to fix Tabby configuration
 check_and_fix_tabby() {
-    if ! has_tabby; then
-        return 0
-    fi
-    
-    if ! tabby_has_dynamic_title_disabled; then
-        log_success "Tabby is configured to allow dynamic tab titles"
-        return 0
-    fi
-    
-    local count
-    count=$(tabby_count_disabled_profiles)
-    
-    echo ""
-    log_warn "Tabby has 'disableDynamicTitle: true' in $count profile(s)"
-    log_info "This prevents terminal title sync from working"
-    echo ""
-    read -r -p "Fix Tabby config to allow dynamic titles? [Y/n]: " fix_tabby
-    
-    if [[ "$fix_tabby" =~ ^[Yy]?$ ]]; then
-        tabby_enable_dynamic_titles
-    else
-        log_info "Skipped Tabby config fix"
-        log_info "You can fix manually: Settings → Profiles → Uncheck 'Disable dynamic title'"
-    fi
+	if ! has_tabby; then
+		return 0
+	fi
+
+	if ! tabby_has_dynamic_title_disabled; then
+		log_success "Tabby is configured to allow dynamic tab titles"
+		return 0
+	fi
+
+	local count
+	count=$(tabby_count_disabled_profiles)
+
+	echo ""
+	log_warn "Tabby has 'disableDynamicTitle: true' in $count profile(s)"
+	log_info "This prevents terminal title sync from working"
+	echo ""
+	read -r -p "Fix Tabby config to allow dynamic titles? [Y/n]: " fix_tabby
+
+	if [[ "$fix_tabby" =~ ^[Yy]?$ ]]; then
+		tabby_enable_dynamic_titles
+	else
+		log_info "Skipped Tabby config fix"
+		log_info "You can fix manually: Settings → Profiles → Uncheck 'Disable dynamic title'"
+	fi
 }
 
 # =============================================================================
@@ -149,7 +146,7 @@ check_and_fix_tabby() {
 # =============================================================================
 
 generate_zsh_omz_integration() {
-    cat << 'EOF'
+	cat <<'EOF'
 # Sync terminal tab title with git repo/branch (works with Oh-My-Zsh)
 # Falls back to directory when not in a git repo
 _aidevops_terminal_title() {
@@ -180,7 +177,7 @@ EOF
 }
 
 generate_zsh_plain_integration() {
-    cat << 'EOF'
+	cat <<'EOF'
 # Sync terminal tab title with git repo/branch
 _aidevops_terminal_title() {
     local title=""
@@ -207,7 +204,7 @@ EOF
 }
 
 generate_bash_integration() {
-    cat << 'EOF'
+	cat <<'EOF'
 # Sync terminal tab title with git repo/branch
 _aidevops_terminal_title() {
     local title=""
@@ -237,7 +234,7 @@ EOF
 }
 
 generate_fish_integration() {
-    cat << 'EOF'
+	cat <<'EOF'
 # Sync terminal tab title with git repo/branch
 function _aidevops_terminal_title --on-event fish_prompt
     if git rev-parse --is-inside-work-tree &>/dev/null 2>&1
@@ -251,7 +248,7 @@ function _aidevops_terminal_title --on-event fish_prompt
     end
 end
 EOF
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -259,104 +256,105 @@ EOF
 # =============================================================================
 
 get_rc_file() {
-    local shell_name="$1"
-    case "$shell_name" in
-        zsh)
-            echo "$HOME/.zshrc"
-            ;;
-        bash)
-            # Prefer .bashrc, fall back to .bash_profile
-            if [[ -f "$HOME/.bashrc" ]]; then
-                echo "$HOME/.bashrc"
-            else
-                echo "$HOME/.bash_profile"
-            fi
-            ;;
-        fish)
-            echo "$HOME/.config/fish/config.fish"
-            ;;
-        *)
-            echo ""
-            ;;
-    esac
-    return 0
+	local shell_name="$1"
+	case "$shell_name" in
+	zsh)
+		echo "$HOME/.zshrc"
+		;;
+	bash)
+		# Prefer .bashrc, fall back to .bash_profile
+		if [[ -f "$HOME/.bashrc" ]]; then
+			echo "$HOME/.bashrc"
+		else
+			echo "$HOME/.bash_profile"
+		fi
+		;;
+	fish)
+		echo "$HOME/.config/fish/config.fish"
+		;;
+	*)
+		echo ""
+		;;
+	esac
+	return 0
 }
 
 is_installed() {
-    local rc_file="$1"
-    [[ -f "$rc_file" ]] && grep -q "$MARKER_START" "$rc_file"
-    return 0
+	local rc_file="$1"
+	[[ -f "$rc_file" ]] && grep -q "$MARKER_START" "$rc_file"
+	return 0
 }
 
 remove_integration() {
-    local rc_file="$1"
-    
-    if [[ ! -f "$rc_file" ]]; then
-        return 0
-    fi
-    
-    if ! grep -q "$MARKER_START" "$rc_file"; then
-        return 0
-    fi
-    
-    # Create backup
-    cp "$rc_file" "${rc_file}.aidevops-backup"
-    
-    # Remove our integration block (cross-platform: works on both macOS and Linux)
-    local temp_file
-    temp_file=$(mktemp)
-    _save_cleanup_scope; trap '_run_cleanups' RETURN
-    push_cleanup "rm -f '${temp_file}'"
-    sed "/$MARKER_START/,/$MARKER_END/d" "$rc_file" > "$temp_file" && mv "$temp_file" "$rc_file"
-    
-    log_success "Removed integration from $rc_file (backup: ${rc_file}.aidevops-backup)"
+	local rc_file="$1"
+
+	if [[ ! -f "$rc_file" ]]; then
+		return 0
+	fi
+
+	if ! grep -q "$MARKER_START" "$rc_file"; then
+		return 0
+	fi
+
+	# Create backup
+	cp "$rc_file" "${rc_file}.aidevops-backup"
+
+	# Remove our integration block (cross-platform: works on both macOS and Linux)
+	local temp_file
+	temp_file=$(mktemp)
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	push_cleanup "rm -f '${temp_file}'"
+	sed "/$MARKER_START/,/$MARKER_END/d" "$rc_file" >"$temp_file" && mv "$temp_file" "$rc_file"
+
+	log_success "Removed integration from $rc_file (backup: ${rc_file}.aidevops-backup)"
 }
 
 install_integration() {
-    local shell_name="$1"
-    local rc_file="$2"
-    local integration_code=""
-    
-    # Generate appropriate integration code
-    case "$shell_name" in
-        zsh)
-            if has_oh_my_zsh; then
-                log_info "Detected Oh-My-Zsh"
-                integration_code=$(generate_zsh_omz_integration)
-            else
-                integration_code=$(generate_zsh_plain_integration)
-            fi
-            ;;
-        bash)
-            integration_code=$(generate_bash_integration)
-            ;;
-        fish)
-            integration_code=$(generate_fish_integration)
-            ;;
-        *)
-            log_error "Unsupported shell: $shell_name"
-            return 1
-            ;;
-    esac
-    
-    # Ensure rc file exists
-    if [[ ! -f "$rc_file" ]]; then
-        mkdir -p "$(dirname "$rc_file")"
-        touch "$rc_file"
-    fi
-    
-    # Create backup
-    cp "$rc_file" "${rc_file}.aidevops-backup"
-    
-    # Append integration
-    {
-        echo ""
-        echo "$MARKER_START"
-        echo "$integration_code"
-        echo "$MARKER_END"
-    } >> "$rc_file"
-    
-    log_success "Installed integration to $rc_file"
+	local shell_name="$1"
+	local rc_file="$2"
+	local integration_code=""
+
+	# Generate appropriate integration code
+	case "$shell_name" in
+	zsh)
+		if has_oh_my_zsh; then
+			log_info "Detected Oh-My-Zsh"
+			integration_code=$(generate_zsh_omz_integration)
+		else
+			integration_code=$(generate_zsh_plain_integration)
+		fi
+		;;
+	bash)
+		integration_code=$(generate_bash_integration)
+		;;
+	fish)
+		integration_code=$(generate_fish_integration)
+		;;
+	*)
+		log_error "Unsupported shell: $shell_name"
+		return 1
+		;;
+	esac
+
+	# Ensure rc file exists
+	if [[ ! -f "$rc_file" ]]; then
+		mkdir -p "$(dirname "$rc_file")"
+		touch "$rc_file"
+	fi
+
+	# Create backup
+	cp "$rc_file" "${rc_file}.aidevops-backup"
+
+	# Append integration
+	{
+		echo ""
+		echo "$MARKER_START"
+		echo "$integration_code"
+		echo "$MARKER_END"
+	} >>"$rc_file"
+
+	log_success "Installed integration to $rc_file"
 }
 
 # =============================================================================
@@ -364,120 +362,120 @@ install_integration() {
 # =============================================================================
 
 cmd_install() {
-    local shell_name
-    shell_name=$(detect_shell)
-    local rc_file
-    rc_file=$(get_rc_file "$shell_name")
-    
-    if [[ -z "$rc_file" ]]; then
-        log_error "Could not determine RC file for shell: $shell_name"
-        return 1
-    fi
-    
-    log_info "Detected shell: $shell_name"
-    log_info "RC file: $rc_file"
-    
-    # Check for special configurations
-    if [[ "$shell_name" == "zsh" ]]; then
-        if has_oh_my_zsh; then
-            log_info "Oh-My-Zsh detected - will integrate with existing title hooks"
-        fi
-        if has_powerlevel10k; then
-            log_info "Powerlevel10k detected - integration should work alongside it"
-        fi
-    fi
-    
-    if has_starship; then
-        log_info "Starship prompt detected - integration should work alongside it"
-    fi
-    
-    # Remove existing integration if present
-    if is_installed "$rc_file"; then
-        log_info "Existing integration found, updating..."
-        remove_integration "$rc_file"
-    fi
-    
-    # Install new integration
-    install_integration "$shell_name" "$rc_file"
-    
-    # Check and fix Tabby configuration if needed
-    check_and_fix_tabby
-    
-    echo ""
-    log_success "Terminal title integration installed!"
-    echo ""
-    echo "To activate, either:"
-    echo "  1. Restart your terminal, or"
-    echo "  2. Run: source $rc_file"
-    echo ""
-    echo "Your terminal tab will now show: repo/branch (e.g., aidevops/feature/xyz)"
+	local shell_name
+	shell_name=$(detect_shell)
+	local rc_file
+	rc_file=$(get_rc_file "$shell_name")
+
+	if [[ -z "$rc_file" ]]; then
+		log_error "Could not determine RC file for shell: $shell_name"
+		return 1
+	fi
+
+	log_info "Detected shell: $shell_name"
+	log_info "RC file: $rc_file"
+
+	# Check for special configurations
+	if [[ "$shell_name" == "zsh" ]]; then
+		if has_oh_my_zsh; then
+			log_info "Oh-My-Zsh detected - will integrate with existing title hooks"
+		fi
+		if has_powerlevel10k; then
+			log_info "Powerlevel10k detected - integration should work alongside it"
+		fi
+	fi
+
+	if has_starship; then
+		log_info "Starship prompt detected - integration should work alongside it"
+	fi
+
+	# Remove existing integration if present
+	if is_installed "$rc_file"; then
+		log_info "Existing integration found, updating..."
+		remove_integration "$rc_file"
+	fi
+
+	# Install new integration
+	install_integration "$shell_name" "$rc_file"
+
+	# Check and fix Tabby configuration if needed
+	check_and_fix_tabby
+
+	echo ""
+	log_success "Terminal title integration installed!"
+	echo ""
+	echo "To activate, either:"
+	echo "  1. Restart your terminal, or"
+	echo "  2. Run: source $rc_file"
+	echo ""
+	echo "Your terminal tab will now show: repo/branch (e.g., aidevops/feature/xyz)"
 }
 
 cmd_uninstall() {
-    local shell_name
-    shell_name=$(detect_shell)
-    local rc_file
-    rc_file=$(get_rc_file "$shell_name")
-    
-    if [[ -z "$rc_file" ]]; then
-        log_error "Could not determine RC file for shell: $shell_name"
-        return 1
-    fi
-    
-    if ! is_installed "$rc_file"; then
-        log_info "No integration found in $rc_file"
-        return 0
-    fi
-    
-    remove_integration "$rc_file"
-    
-    echo ""
-    log_success "Terminal title integration removed!"
-    echo "Restart your terminal or run: source $rc_file"
+	local shell_name
+	shell_name=$(detect_shell)
+	local rc_file
+	rc_file=$(get_rc_file "$shell_name")
+
+	if [[ -z "$rc_file" ]]; then
+		log_error "Could not determine RC file for shell: $shell_name"
+		return 1
+	fi
+
+	if ! is_installed "$rc_file"; then
+		log_info "No integration found in $rc_file"
+		return 0
+	fi
+
+	remove_integration "$rc_file"
+
+	echo ""
+	log_success "Terminal title integration removed!"
+	echo "Restart your terminal or run: source $rc_file"
 }
 
 cmd_status() {
-    local shell_name
-    shell_name=$(detect_shell)
-    local rc_file
-    rc_file=$(get_rc_file "$shell_name")
-    
-    echo "Shell: $shell_name"
-    echo "RC file: $rc_file"
-    echo ""
-    
-    if [[ "$shell_name" == "zsh" ]]; then
-        echo "Oh-My-Zsh: $(has_oh_my_zsh && echo "yes" || echo "no")"
-        echo "Powerlevel10k: $(has_powerlevel10k && echo "yes" || echo "no")"
-    fi
-    echo "Starship: $(has_starship && echo "yes" || echo "no")"
-    
-    # Tabby status
-    if has_tabby; then
-        echo ""
-        echo "Tabby terminal: yes"
-        if tabby_has_dynamic_title_disabled; then
-            local count
-            count=$(tabby_count_disabled_profiles)
-            log_warn "Tabby has dynamic titles DISABLED in $count profile(s)"
-            echo "  Run 'terminal-title-setup.sh install' to fix"
-        else
-            echo "Tabby dynamic titles: enabled"
-        fi
-    fi
-    echo ""
-    
-    if [[ -n "$rc_file" ]] && is_installed "$rc_file"; then
-        log_success "Terminal title integration is installed"
-    else
-        log_warn "Terminal title integration is NOT installed"
-        echo "Run: terminal-title-setup.sh install"
-    fi
-    return 0
+	local shell_name
+	shell_name=$(detect_shell)
+	local rc_file
+	rc_file=$(get_rc_file "$shell_name")
+
+	echo "Shell: $shell_name"
+	echo "RC file: $rc_file"
+	echo ""
+
+	if [[ "$shell_name" == "zsh" ]]; then
+		echo "Oh-My-Zsh: $(has_oh_my_zsh && echo "yes" || echo "no")"
+		echo "Powerlevel10k: $(has_powerlevel10k && echo "yes" || echo "no")"
+	fi
+	echo "Starship: $(has_starship && echo "yes" || echo "no")"
+
+	# Tabby status
+	if has_tabby; then
+		echo ""
+		echo "Tabby terminal: yes"
+		if tabby_has_dynamic_title_disabled; then
+			local count
+			count=$(tabby_count_disabled_profiles)
+			log_warn "Tabby has dynamic titles DISABLED in $count profile(s)"
+			echo "  Run 'terminal-title-setup.sh install' to fix"
+		else
+			echo "Tabby dynamic titles: enabled"
+		fi
+	fi
+	echo ""
+
+	if [[ -n "$rc_file" ]] && is_installed "$rc_file"; then
+		log_success "Terminal title integration is installed"
+	else
+		log_warn "Terminal title integration is NOT installed"
+		echo "Run: terminal-title-setup.sh install"
+	fi
+	return 0
 }
 
 cmd_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 terminal-title-setup.sh - Install shell integration for terminal title sync
 
 USAGE:
@@ -513,7 +511,7 @@ EXAMPLES:
     terminal-title-setup.sh uninstall
 
 EOF
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -521,28 +519,28 @@ EOF
 # =============================================================================
 
 main() {
-    local command="${1:-install}"
-    
-    case "$command" in
-        install)
-            cmd_install
-            ;;
-        uninstall)
-            cmd_uninstall
-            ;;
-        status)
-            cmd_status
-            ;;
-        help|--help|-h)
-            cmd_help
-            ;;
-        *)
-            log_error "Unknown command: $command"
-            cmd_help
-            return 1
-            ;;
-    esac
-    # Return status of the executed command
+	local command="${1:-install}"
+
+	case "$command" in
+	install)
+		cmd_install
+		;;
+	uninstall)
+		cmd_uninstall
+		;;
+	status)
+		cmd_status
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+	# Return status of the executed command
 }
 
 main "$@"

--- a/.agents/scripts/verify-brief.sh
+++ b/.agents/scripts/verify-brief.sh
@@ -50,8 +50,8 @@ TOTAL_CRITERIA=0
 # Results array (for JSON output)
 declare -a RESULTS=()
 
-# Logging
-log_info() { echo -e "${BLUE}[INFO]${NC} $*" >&2; }
+# Logging: uses shared log_info/log_error/log_success/log_warn from shared-constants.sh
+# Script-specific log levels kept inline
 log_pass() { echo -e "${GREEN}[PASS]${NC} $*" >&2; }
 log_fail() { echo -e "${RED}[FAIL]${NC} $*" >&2; }
 log_skip() { echo -e "${YELLOW}[SKIP]${NC} $*" >&2; }

--- a/.agents/scripts/verify-run-helper.sh
+++ b/.agents/scripts/verify-run-helper.sh
@@ -34,9 +34,9 @@ C_YELLOW="\033[1;33m"
 C_BLUE="\033[0;34m"
 C_NC="\033[0m"
 
-log_info() { echo -e "${C_BLUE}[VERIFY]${C_NC} $*"; }
-log_warn() { echo -e "${C_YELLOW}[WARN]${C_NC} $*" >&2; }
-log_error() { echo -e "${C_RED}[ERROR]${C_NC} $*" >&2; }
+# Logging: uses shared log_* from shared-constants.sh with VERIFY prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="VERIFY"
 
 # Find project root
 find_project_root() {

--- a/.agents/scripts/virustotal-helper.sh
+++ b/.agents/scripts/virustotal-helper.sh
@@ -28,29 +28,9 @@ readonly RATE_LIMIT_DELAY="${VT_RATE_LIMIT_DELAY:-16}" # 4 req/min = 1 every 15s
 # Helper Functions
 # =============================================================================
 
-log_info() {
-	local msg="$1"
-	echo -e "${BLUE}[virustotal]${NC} ${msg}" >&2
-	return 0
-}
-
-log_success() {
-	local msg="$1"
-	echo -e "${GREEN}[OK]${NC} ${msg}" >&2
-	return 0
-}
-
-log_warning() {
-	local msg="$1"
-	echo -e "${YELLOW}[WARN]${NC} ${msg}" >&2
-	return 0
-}
-
-log_error() {
-	local msg="$1"
-	echo -e "${RED}[ERROR]${NC} ${msg}" >&2
-	return 0
-}
+# Logging: uses shared log_* from shared-constants.sh with virustotal prefix
+# shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions
+LOG_PREFIX="virustotal"
 
 print_usage() {
 	cat <<'EOF'


### PR DESCRIPTION
## Summary

- Added shared `log_info`, `log_error`, `log_success`, `log_warn` functions to `shared-constants.sh` with configurable `LOG_PREFIX` support
- Refactored 34 scripts to use the shared logging functions instead of inline definitions
- Scripts with genuinely different behavior (file logging, `NO_COLOR`, `QUIET` mode, timestamped output) retain custom implementations

## Details

**Problem**: `log_info()` was defined 70+ times, `log_error()` 67+ times across the codebase. Nearly identical implementations with only the bracket label varying (e.g., `[INFO]`, `[CODACY]`, `[RUNNER]`).

**Solution**: Added 4 shared functions to `shared-constants.sh` that use a `LOG_PREFIX` variable for customization:

```bash
# In shared-constants.sh (new)
log_info() {
    local label="${LOG_PREFIX:-INFO}"
    echo -e "${BLUE}[${label}]${NC} $*" >&2
    return 0
}
```

Scripts customize by setting `LOG_PREFIX` before sourcing:

```bash
LOG_PREFIX="CODACY"
source "${SCRIPT_DIR}/shared-constants.sh"
log_info "Processing..."  # Output: [CODACY] Processing...
```

**Scope**: 35 files changed, net ~140 lines removed. Scripts intentionally excluded from consolidation:
- `auto-update-helper.sh`, `repo-sync-helper.sh` — log to file, not stderr
- `simplex-helper.sh` — `NO_COLOR` support
- `skill-update-helper.sh` — `NON_INTERACTIVE` mode
- `generate-models-md.sh` — `QUIET` mode
- `generate-skills.sh` — emoji in output
- `cron-dispatch.sh` — timestamped log format

## Verification

- All 35 modified files pass `bash -n` syntax check
- ShellCheck clean (SC2034 suppressed with comment for `LOG_PREFIX`)
- Shared functions tested with default and custom prefixes

Closes #2411