### PR TITLE
feat: add repo courtesy file scaffolding to aidevops init

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,8 @@ See `.agents/tools/terminal/terminal-title.md` for customization options.
 
 **Collaborator compatibility:** Projects initialized with `aidevops init` include pointer files (`.cursorrules`, `.windsurfrules`, etc.) that reference `AGENTS.md`, helping collaborators using other editors find project context. aidevops does not install into or configure those tools.
 
+**Repo courtesy files:** `aidevops init` scaffolds standard repo files if they don't exist: `README.md`, `LICENCE` (MIT), `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`. Author name and email are auto-detected from git config. Existing files are never overwritten.
+
 ## **Core Capabilities**
 
 **AI-First Infrastructure Management:**
@@ -430,6 +432,22 @@ Scan results are logged to [`.agents/SKILL-SCAN-RESULTS.md`](.agents/SKILL-SCAN-
 - [vercel-labs/add-skill](https://github.com/vercel-labs/add-skill) - The upstream CLI tool (aidevops uses its own implementation)
 - [anthropics/skills](https://github.com/anthropics/skills) - Official Anthropic example skills
 - [agentskills/agentskills](https://github.com/agentskills/agentskills) - Specification source and reference library
+
+## **Agent Sources (Private Repos)**
+
+Sync agents from private Git repositories into the framework. Private repos keep their own agents, helper scripts, and slash commands — `aidevops sources sync` deploys them alongside the core agents.
+
+```bash
+aidevops sources add ~/Git/my-private-agents     # Register a local repo
+aidevops sources add-remote git@github.com:u/r.git  # Clone and register a remote repo
+aidevops sources list                             # List configured sources
+aidevops sources sync                             # Sync all sources
+aidevops sources remove my-private-agents         # Remove a source
+```
+
+**How it works:** Private repos contain a `.agents/` directory with agent subdirectories. Agents with `mode: primary` in their frontmatter are symlinked to the agents root for auto-discovery as primary agent tabs. Markdown files with `agent:` frontmatter are deployed as `/slash` commands. All sources sync automatically during `aidevops update`.
+
+**Reference:** `.agents/aidevops/agent-sources.md`
 
 ## **Agent Design Patterns**
 


### PR DESCRIPTION
## Summary

- Add `scaffold_repo_courtesy_files()` function to `aidevops.sh` that creates standard repo files during `aidevops init` if they don't exist: README.md, LICENCE (MIT), CHANGELOG.md, CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md
- Auto-detects author name/email from git config, repo description from `.aidevops.json`
- Document the agent sources feature in README.md (new section)
- Document the courtesy files feature in README.md

## Details

### Courtesy File Scaffolding

When `aidevops init` runs on any project, it now checks for and creates missing standard repo files:

| File | Content |
|------|---------|
| `README.md` | Project name from directory, description from `.aidevops.json` |
| `LICENCE` | MIT licence with author from `git config user.name`, current year |
| `CHANGELOG.md` | Keep a Changelog format with `[Unreleased]` section |
| `CONTRIBUTING.md` | Conventional commits guide |
| `SECURITY.md` | Vulnerability reporting template with email from `git config user.email` |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 (abbreviated) |

All files are skip-if-exists — safe to re-run. ShellCheck clean (zero violations).

### README Updates

- New "Agent Sources (Private Repos)" section documenting the `aidevops sources` CLI
- New "Repo courtesy files" paragraph under collaborator compatibility

## Testing

- ShellCheck: zero violations on `aidevops.sh`
- Manually tested courtesy file creation on 3 private agent-source repos (all files created correctly)
- Verified existing files are never overwritten (skip-if-exists logic)