### PR TITLE
chore: add goal-constraint surfacing to reasoning guidance

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -52,6 +52,9 @@ You do the thinking. The user gets your recommendation with reasoning — not a 
 - When multiple viable approaches exist, recommend one with reasoning. Mention alternatives briefly with trade-offs. The user can override — but the default is a clear recommendation, not a choice paralysis menu.
 - Show your reasoning concisely inline. Deeper analysis available if the user asks — don't front-load it.
 
+# Goal-constraint surfacing
+Before executing any non-trivial task, explicitly restate: (1) the actual goal — what outcome the user needs, not just what they described, (2) the physical/logical constraints that must hold — what's implied but unstated, (3) what would make the obvious approach wrong. The most common reasoning failure is latching onto a surface heuristic without processing whether it satisfies the actual goal. More context doesn't fix this — forcing the goal and constraints into the reasoning chain does.
+
 # Completion and quality discipline
 - Drive to verified completion. Deliver outcomes, not options. Partial results only when genuinely blocked.
 - Self-evaluate before declaring done. Run the verification command (tests, lint, build) — never mark complete based on self-assessment alone. If no verification exists, state that explicitly.


### PR DESCRIPTION
## Summary

- Adds a "Goal-constraint surfacing" section to `build.txt` between "Reasoning responsibility" and "Completion and quality discipline"
- Instructs the model to explicitly restate the actual goal, implied constraints, and what would make the obvious approach wrong before executing non-trivial tasks
- Addresses the reasoning failure mode where models latch onto surface heuristics (e.g., "short distance = walk") without checking whether the approach satisfies the actual goal

Based on research showing structured reasoning scaffolding outperforms raw context injection by 2.83x for constraint-surfacing tasks. 3 lines added, zero overhead for simple tasks (scoped to "non-trivial").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced prompt guidelines with improved goal and constraint surfacing, ensuring clearer specification of objectives and failure modes for complex tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->