### PR TITLE
fix: remove hard timeout from pulse-wrapper

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -768,10 +768,8 @@ main() {
 		<string>${opencode_bin}</string>
 		<key>PULSE_DIR</key>
 		<string>${_aidevops_dir}</string>
-		<key>PULSE_TIMEOUT</key>
-		<string>600</string>
 		<key>PULSE_STALE_THRESHOLD</key>
-		<string>900</string>
+		<string>1800</string>
 	</dict>
 	<key>RunAtLoad</key>
 	<false/>


### PR DESCRIPTION
## Summary

- Remove the 10-minute hard timeout that was killing active pulses mid-dispatch
- Pulse now runs to natural completion — no arbitrary kill
- Stale threshold (increased to 30 min) on the *next* launchd invocation is the sole kill mechanism for the opencode idle-state bug
- Remove `PULSE_TIMEOUT` from setup.sh plist environment variables

## Problem

The hard timeout was self-destructive: it killed pulses that were actively analyzing PRs and dispatching workers, leaving 7/8 worker slots empty. The timeout couldn't distinguish "doing real work" from "stuck idle."

## Fix

The stale threshold already handles stuck processes correctly — the next launchd trigger (every 120s) checks if the previous pulse has been running too long and kills it. This is the right mechanism because it's the *next* invocation making the judgment with fresh context, not a blind timer.

## Files changed

- `.agents/scripts/pulse-wrapper.sh` — remove timeout loop, simplify `run_pulse()` to `wait`
- `setup.sh` — remove `PULSE_TIMEOUT` from plist env vars, update stale threshold to 1800s