### PR TITLE
fix: always regenerate pulse plist on setup.sh upgrades

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -768,10 +768,8 @@ main() {
 		<string>${opencode_bin}</string>
 		<key>PULSE_DIR</key>
 		<string>${_aidevops_dir}</string>
-		<key>PULSE_TIMEOUT</key>
-		<string>600</string>
 		<key>PULSE_STALE_THRESHOLD</key>
-		<string>900</string>
+		<string>1800</string>
 	</dict>
 	<key>RunAtLoad</key>
 	<false/>


### PR DESCRIPTION
## Summary

Root cause fix for the stale plist problem that has been recurring across multiple sessions.

## Problem

`setup.sh` checked if the plist existed and contained `pulse-wrapper`, then set `_pulse_installed=true` and **skipped the entire install block**. This meant:
- New env vars (`OPENCODE_BIN`, `PULSE_DIR`) never got added
- Removed vars (`PULSE_TIMEOUT`) stayed in the plist forever
- Updated thresholds (`PULSE_STALE_THRESHOLD` 900→1800) never applied

Every release shipped correct config but existing users never got it.

## Fix

- Plist is **always regenerated** on every `setup.sh` run
- User prompt ("Enable supervisor pulse?") only appears on **first install**
- Upgrades regenerate silently and print "Supervisor pulse updated"
- Linux cron entry also always regenerated

## Files changed

- `setup.sh` — restructure pulse install logic: separate first-install prompt from always-regenerate plist