### PR TITLE
t1346: Strengthen webfetch error prevention guidance (46.8% → <20% target)

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -75,7 +75,7 @@ Detect intent before acting:
 
 Greenfield = ambitious. Existing codebase = surgical, minimal changes.
 
-Use `webfetch` to verify third-party packages when knowledge may be stale.
+Use context7 MCP or `gh api` to verify third-party packages when knowledge may be stale. Only use `webfetch` for URLs from user messages or tool output — never construct URLs.
 Tell user what you're doing before each tool call (one sentence).
 On "resume"/"continue": find next incomplete step and continue.
 
@@ -119,7 +119,7 @@ Before implementing, check AGENTS.md domain index. If the task touches a special
 
 ### 3-4. Investigate & Research
 
-Explore codebase, search for relevant code, identify root cause. Use `webfetch` for external research — fetch actual pages, not summaries.
+Explore codebase, search for relevant code, identify root cause. For external research: use context7 MCP for library docs, `gh api` for GitHub content, `webfetch` only for URLs from user messages or tool output (never construct URLs — 47% failure rate on guessed URLs).
 
 ### 5. Plan
 

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -96,36 +96,40 @@ When referencing specific functions or code include the pattern `file_path:line_
 
 # Error Prevention (top recurring patterns from session mining)
 #
-# 1. webfetch failures (259x observed)
-#    Root cause: constructing or guessing URLs that don't exist (GitHub blob URLs,
-#    PR review URLs, npm pages, external docs). webfetch has a ~16% failure rate.
+# 1. webfetch failures (250 uses, 117 errors = 46.8% failure rate)
+#    Root cause breakdown: 94% are 404s from constructed/guessed URLs, 4% rate
+#    limiting, 2% auth. 70% of all failures are guessed raw.githubusercontent.com
+#    paths (agent invents file paths in repos). 23% are guessed documentation URLs.
 - NEVER guess or construct URLs for webfetch. Only fetch URLs that appear in user messages, tool output, or file contents.
-- For GitHub content: use `gh api` or `gh pr view` instead of webfetch — these handle auth and are more reliable.
-- For npm/package docs: use context7 MCP or `gh api` to fetch README from the repo.
-- If webfetch returns 404/403, do NOT retry the same URL. Find an alternative source or ask the user.
+- For GitHub file content: use `gh api repos/{owner}/{repo}/contents/{path}` — NOT raw.githubusercontent.com URLs. The API handles auth, returns JSON with content, and gives a clear 404 if the path doesn't exist. Use `gh api repos/{owner}/{repo}/git/trees/{branch}?recursive=1` to discover file paths first.
+- For GitHub PRs/issues/repos: use `gh pr view`, `gh issue view`, `gh api` — NOT webfetch on github.com URLs.
+- For library/framework docs: use context7 MCP (`resolve-library-id` then `get-library-docs`) — NOT webfetch on documentation sites. Documentation URL structures change frequently and cause 404s.
+- For npm/package info: use `gh api` to fetch README from the repo, or context7 MCP.
+- If webfetch returns 404/403, do NOT retry the same URL or a variation. The URL was likely constructed/guessed. Find an alternative source (gh api, context7, ask the user).
+- If webfetch returns 429 (rate limited), wait before retrying. Do not make multiple rapid requests to the same domain.
 #
-# 2. markdown-formatter exit codes (200x observed, 100% failure rate)
+# 2. markdown-formatter exit codes (6 uses, 100% "failure" rate — expected behavior)
 #    Root cause: markdown-formatter exits non-zero when it finds lint issues —
 #    this is expected linter behavior, not a tool failure.
 - markdown-formatter exit code 1 means "issues found", not "tool broken". Read the output for the actual findings.
 - NEVER retry markdown-formatter expecting a different exit code — fix the reported issues first, then re-run.
 - When calling markdown-formatter with action "check" or "lint", expect non-zero exit if the file has issues.
 #
-# 3. read:file_not_found (169x observed)
+# 3. read:file_not_found (53x observed)
 #    Root cause: assuming file paths from memory, AGENTS.md references, or prior
 #    sessions. Files move between releases and worktrees have different paths.
 - Before Read: run `git ls-files '<pattern>'` or `fd -g '<pattern>'` to confirm the file exists at the expected path.
 - In worktrees: the path prefix changes (e.g., `~/Git/repo.branch-name/` not `~/Git/repo/`). Always use the worktree path.
 - AGENTS.md references like `prompts/build.txt` are relative — resolve against the actual repo root, which may be `.agents/prompts/build.txt`.
 #
-# 4. edit:other (80x observed)
+# 4. edit:other (14x observed)
 #    Root causes: (a) identical oldString/newString (no-op), (b) permission denied
 #    on protected files, (c) editing files in wrong worktree.
 - Before Edit: confirm oldString differs from newString. If the content is already correct, skip the edit.
 - Permission errors mean the file is protected by user rules. Do not retry — check if you're in the right worktree or if the file requires a different workflow.
 - On "multiple matches" errors: include more surrounding context lines (5+) to make oldString unique, or use replaceAll if all instances should change.
 #
-# 5. glob:other (50x observed)
+# 5. glob:other (24x observed)
 #    Root cause: using Glob tool when it's blocked by permissions or searching
 #    non-existent directories. Glob is the LAST RESORT per File Discovery rules.
 - NEVER use Glob as primary file discovery. Use `git ls-files` (tracked) or `fd` (untracked) — these are faster and not subject to permission restrictions.

--- a/todo/tasks/t1346-brief.md
+++ b/todo/tasks/t1346-brief.md
@@ -1,0 +1,99 @@
+# t1346: Investigate webfetch 46.8% error rate — add retry guidance or fallback
+
+## Origin
+
+- **Created:** 2026-02-27
+- **Session:** Claude Code (interactive)
+- **Created by:** ai-interactive
+- **Parent task:** none
+- **Conversation context:** Session miner pulse (2026-02-27) revealed webfetch has a 46.8% error rate across 250 uses. Issue #2441 filed to investigate root causes and add guidance.
+
+## What
+
+Update `prompts/build.txt` and `build-plus.md` with data-driven webfetch error prevention guidance based on root cause analysis of 117 failures. Provide specific alternatives for each failure category.
+
+## Why
+
+Nearly half of all webfetch calls fail, wasting tokens and time. Agents that rely on webfetch for documentation lookups, API reference, or research fail ~50% of the time. The existing guidance (from an earlier pulse) cited outdated stats and lacked specificity about the dominant failure patterns.
+
+## How (Approach)
+
+1. Extract and categorize all 117 webfetch errors from session miner compressed signals
+2. Identify root cause categories with percentages
+3. Update `prompts/build.txt` error prevention section with specific guidance per category
+4. Update `build-plus.md` to reinforce alternatives to webfetch
+
+## Acceptance Criteria
+
+- [x] Root cause categories identified (94% 404, 4% rate limiting, 2% auth)
+
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "46\\.8%|94%.*404|rate.limit"
+    path: ".agents/prompts/build.txt"
+  ```
+
+- [x] Guidance added for raw.githubusercontent.com alternative (gh api)
+
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "gh api repos.*contents"
+    path: ".agents/prompts/build.txt"
+  ```
+
+- [x] Guidance added for documentation site alternative (context7 MCP)
+
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "context7 MCP.*resolve-library-id"
+    path: ".agents/prompts/build.txt"
+  ```
+
+- [x] Rate limiting guidance added
+
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "429.*rate.limit"
+    path: ".agents/prompts/build.txt"
+  ```
+
+- [ ] Session miner shows improvement in next pulse
+
+  ```yaml
+  verify:
+    method: manual
+    prompt: "Run session-miner-pulse.sh after 1 week and check if webfetch error rate dropped below 20%"
+  ```
+
+## Context & Decisions
+
+- Root cause analysis showed 70% of failures are from `raw.githubusercontent.com` URLs that agents construct/guess (mostly from skills audit sessions)
+- 23% are from guessed documentation site URLs
+- Only 14.5% of failures had any recovery — agents mostly give up after webfetch fails
+- Chose to strengthen existing guidance rather than add a new section, keeping instruction count stable
+- Updated all error pattern stats to match latest session miner data
+- Also updated build-plus.md which had generic "use webfetch" guidance without caveats
+
+## Relevant Files
+
+- `.agents/prompts/build.txt:97-109` — Error prevention section (updated)
+- `.agents/build-plus.md:78,122` — Build workflow webfetch references (updated)
+
+## Dependencies
+
+- **Blocked by:** none
+- **Blocks:** none
+- **External:** none
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Research/read | 15m | Session miner data analysis |
+| Implementation | 15m | Update guidance in 2 files |
+| Testing | 5m | Lint checks |
+| **Total** | **35m** | |


### PR DESCRIPTION
## Summary

- Analyzed 117 webfetch failures (46.8% error rate) from session miner data to identify root causes
- Updated `prompts/build.txt` with data-driven guidance targeting the top failure patterns
- Updated `build-plus.md` to reinforce alternatives to webfetch for common use cases

## Root Cause Analysis

| Category | Count | % | Root Cause |
|----------|-------|---|------------|
| 404 Not Found | 110 | 94% | Agent constructs/guesses URLs |
| 429 Rate Limited | 5 | 4.3% | Too many requests to same domain |
| 400/401 | 2 | 1.7% | Auth required or bad request |

**Dominant pattern:** 70% of all failures are `raw.githubusercontent.com` URLs where the agent invents file paths in repos (mostly from skills audit sessions). 23% are guessed documentation site URLs.

## Changes

### `prompts/build.txt`
- Updated webfetch stats from "259x, ~16%" to "250 uses, 46.8% failure rate"
- Added specific `gh api repos/{owner}/{repo}/contents/{path}` guidance as alternative to raw.githubusercontent.com
- Added `gh api repos/{owner}/{repo}/git/trees/{branch}?recursive=1` for path discovery
- Added context7 MCP (`resolve-library-id` → `get-library-docs`) as primary for library docs
- Added 429 rate limiting guidance
- Updated all other error pattern stats to latest session miner data

### `build-plus.md`
- Changed "Use webfetch to verify third-party packages" → "Use context7 MCP or gh api"
- Changed "Use webfetch for external research" → specific alternatives with 47% failure rate warning

### `todo/tasks/t1346-brief.md`
- Task brief with root cause analysis, acceptance criteria, and verify blocks

## Verification

The guidance changes target the specific failure patterns observed. Effectiveness will be measured by the next session miner pulse (acceptance criterion: webfetch error rate < 20%).

Closes #2441