### PR TITLE
docs: add Intelligence Over Scripts to system prompt and PR issue-linkage guidance

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -163,6 +163,13 @@ Before ANY file modification: run `~/.aidevops/agents/scripts/pre-edit-check.sh`
 - Progressive disclosure: pointers to subagents, not inline content
 - MCP tools loaded on-demand per subagent (reduces context overhead)
 
+# Intelligence Over Scripts (CORE PRINCIPLE)
+When fixing orchestration, supervisor, or workflow bugs: improve agent guidance docs — do NOT add bash scripts, helper utilities, or deterministic state-tracking layers. You are an LLM. You can reason about whether two issues are duplicates, whether a task is stuck, or how to prioritize work. A regex or title-prefix match cannot. The framework previously had 37,000 lines of fragile bash orchestration that was never reliable. It was replaced with intelligence-guided agents for good reason.
+- If your proposed fix adds a `.sh` file or state mechanism: STOP. You are going in the wrong direction.
+- If your proposed fix adds a paragraph of clear guidance to an agent doc: you are on the right track.
+- Helper scripts are appropriate ONLY for deterministic utilities (version bumping, file discovery, credential lookup) — never for decisions requiring judgment.
+- When you encounter a problem that "could be solved with a script", ask: could this be solved by telling the agent what to look for and how to decide? If yes, update the guidance doc instead.
+
 # Working Directories
 ~/.aidevops/.agent-workspace/
 ├── work/[project]/    # Persistent project files

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -416,6 +416,7 @@ After task completion, the loop automatically:
 
 1. **Preflight**: Runs quality checks, auto-fixes issues
 2. **PR Create**: Verifies `gh auth`, rebases onto `origin/main`, pushes branch, creates PR with proper title/body
+   **Issue linkage in PR body (MANDATORY):** The PR body MUST include `Closes #NNN` (or `Fixes`/`Resolves`) for every related issue — this is the ONLY mechanism that creates a GitHub PR-issue link. Before writing the PR body, search for ALL open issues related to your task: `gh issue list --state open --search "<task description keywords>"`. Issues may exist under different title formats (e.g., `coderabbit: Fix X` and `t1234: Fix X` for the same task). Include closing keywords for every match. A comment like "Resolved by PR #NNN" does NOT create a link — only closing keywords in the PR body do.
 3. **Label Update**: Update linked issue to `status:in-review` (see below)
 4. **PR Review**: Monitors CI checks and review status
 5. **Merge**: Squash merge (without `--delete-branch` when in worktree)


### PR DESCRIPTION
## Summary

- Adds "Intelligence Over Scripts" as a core principle in `build.txt` (the system prompt loaded by every worker) so it's in the active reasoning chain — not buried in `architecture.md` where headless workers may never read it
- Adds mandatory issue-linkage guidance to `full-loop.md` Step 4 (PR Create): workers must search for ALL related issues before composing the PR body and include `Closes #NNN` for each match

## Problem

PRs weren't connecting to the issues they resolved (observed on #2421, #2341):

1. **Duplicate issues under different title formats** — CodeRabbit creates `coderabbit: Fix X`, then `claim-task-id.sh` creates `t1234: Fix X` for the same task. The deterministic title-prefix dedup (`startswith("t1234:")`) misses the CodeRabbit-format issue entirely.
2. **Workers closing duplicates with comments** — A worker posted "Resolved by PR #2427" as a comment on #2421, but comments don't create GitHub PR-issue links. Only `Closes/Fixes/Resolves #NNN` in the PR body does.
3. **Stale labels on manually closed issues** — #2341 was closed manually but kept `needs-review` label.

## Fix approach

Intelligence over scripts: instead of adding more regex/heuristic dedup logic to bash scripts, tell the worker (an LLM that can reason about semantic similarity) to search for all related issues and link them properly. Two guidance-doc edits, zero new scripts.

Also cleaned up labels on #2421 and #2341 directly.