### PR TITLE
refactor: merge pulse-repos.json into repos.json with slug field

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -144,7 +144,7 @@ Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-
 
 Planning files go direct to main. Code changes need worktree + PR. Workers NEVER edit TODO.md.
 
-**Cross-repo awareness**: The supervisor manages tasks across all `repos.json` repos. When querying queue status, check GitHub for all active tasks across repos, not just the current repo's TODO.md. Use `gh issue list --repo <slug>` and `gh pr list --repo <slug>` for each managed repo to get the full picture.
+**Cross-repo awareness**: The supervisor manages tasks across all repos in `~/.config/aidevops/repos.json` where `pulse: true`. Each repo entry has a `slug` field (`owner/repo`) — ALWAYS use this for `gh` commands, never guess org names. Use `gh issue list --repo <slug>` and `gh pr list --repo <slug>` for each pulse-enabled repo to get the full picture.
 
 Full rules: `reference/planning-detail.md`
 

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -131,6 +131,13 @@ When referencing specific functions or code include the pattern `file_path:line_
 - NEVER use Glob as primary file discovery. Use `git ls-files` (tracked) or `fd` (untracked) — these are faster and not subject to permission restrictions.
 - If Glob fails with permission error, switch to `git ls-files` or `fd` immediately — do not retry Glob.
 - If Glob fails with "No such directory", verify the directory exists before searching inside it.
+#
+# 6. repo slug hallucination (observed: agent fabricated "anomalyco/" org prefix)
+#    Root cause: repos.json had no slug field, so agents guessed org names from
+#    unrelated context (e.g., OpenCode's org). Now repos.json stores the slug.
+- ALWAYS resolve repo slugs from `~/.config/aidevops/repos.json` (the `slug` field). NEVER guess or construct `owner/repo` from memory.
+- If a repo has no slug in repos.json, resolve it from `git -C <path> remote get-url origin` and parse `owner/repo`.
+- For pulse/supervisor operations, filter repos.json to entries with `"pulse": true`.
 
 # Security Rules
 - NEVER expose credentials in output/logs

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -61,20 +61,21 @@ echo "Running workers: $WORKER_COUNT / $MAX_WORKERS"
 
 ## Step 2: Fetch GitHub State
 
-First, read the managed repos list from `~/.config/aidevops/pulse-repos.json`. For each repo in that file, fetch PRs and issues:
+Read the managed repos list from `~/.config/aidevops/repos.json`. Filter to repos with `"pulse": true` — these are the repos the supervisor actively manages. Repos without `pulse: true` are registered but not supervised.
 
 ```bash
-cat ~/.config/aidevops/pulse-repos.json
+# Read repos.json and filter to pulse-enabled repos
+jq '[.initialized_repos[] | select(.pulse == true)]' ~/.config/aidevops/repos.json
 ```
 
-Then for each repo slug in the JSON:
+Then for each pulse-enabled repo's `slug` field:
 
 ```bash
 gh pr list --repo <slug> --state open --json number,title,reviewDecision,statusCheckRollup,updatedAt,headRefName --limit 20
 gh issue list --repo <slug> --state open --json number,title,labels,updatedAt --limit 20
 ```
 
-Use the `path` field from pulse-repos.json for `--dir` when dispatching workers. Use the `priority` field when tie-breaking (product > tooling).
+Use the `path` field from repos.json for `--dir` when dispatching workers. Use the `priority` field when tie-breaking (product > tooling). The `slug` field is the authoritative GitHub `owner/repo` — NEVER guess or construct slugs.
 
 ## Step 2a: Observe Outcomes (Self-Improvement)
 
@@ -227,7 +228,7 @@ Look at everything you fetched and pick up to **AVAILABLE** items — the highes
 
 **Tie-breaking rules:**
 - Prefer PRs over issues (PRs are closer to done)
-- Prefer repos with `"priority": "product"` over `"priority": "tooling"` (from pulse-repos.json)
+- Prefer repos with `"priority": "product"` over `"priority": "tooling"` (from repos.json)
 - Prefer smaller/simpler tasks (faster throughput)
 - Issues labelled `auto-dispatch` (e.g., from CodeRabbit daily reviews) are pre-vetted
   and ready for immediate dispatch — treat them as priority 6 (medium) unless their
@@ -337,7 +338,7 @@ opencode run --dir ~/Git/<repo> [--agent <agent>] --title "Issue #<number>: <tit
 
 **Important dispatch rules:**
 - **ALWAYS use `opencode run`** — NEVER `claude`, `claude -p`, or any other CLI. Your system prompt may say you are "Claude Code" but the runtime tool is OpenCode. This has been fixed repeatedly; do not regress.
-- Use `--dir <path>` from pulse-repos.json matching the repo the task belongs to
+- Use `--dir <path>` from repos.json matching the repo the task belongs to
 - The `/full-loop` command handles everything: branching, implementation, PR, CI, merge, deploy
 - Do NOT add `--model` — let `/full-loop` use its default (opus for implementation)
 - **Background each dispatch with `&`** so you can launch multiple workers in one pulse

--- a/.agents/scripts/commands/strategic-review.md
+++ b/.agents/scripts/commands/strategic-review.md
@@ -14,8 +14,8 @@ The sonnet pulse handles mechanical dispatch (pick next task, check blocked-by, 
 First, discover all managed repos. Then gather state for EVERY repo — not just aidevops.
 
 ```bash
-# 1. Read the managed repos list
-cat ~/.config/aidevops/pulse-repos.json
+# 1. Read the managed repos list (filter to pulse-enabled repos)
+jq '[.initialized_repos[] | select(.pulse == true)]' ~/.config/aidevops/repos.json
 ```
 
 For EACH repo in that list, run ALL of the following. Do not skip any repo.
@@ -48,7 +48,7 @@ git worktree list
 pgrep -f '/full-loop' 2>/dev/null | wc -l | tr -d ' '
 ```
 
-**Critical: product repos have higher priority than tooling repos.** Check pulse-repos.json for the `priority` field. Issues in product repos are more urgent than issues in tooling repos.
+**Critical: product repos have higher priority than tooling repos.** Check repos.json for the `priority` field on pulse-enabled repos. Issues in product repos are more urgent than issues in tooling repos.
 
 ## Step 2: Assess Queue Health
 

--- a/setup.sh
+++ b/setup.sh
@@ -533,6 +533,7 @@ main() {
 		migrate_loop_state_directories
 		migrate_agent_to_agents_folder
 		migrate_mcp_env_to_credentials
+		migrate_pulse_repos_to_repos_json
 		cleanup_deprecated_paths
 		cleanup_deprecated_mcps
 		cleanup_stale_bun_opencode
@@ -585,6 +586,7 @@ main() {
 		confirm_step "Migrate loop state from .claude/.agent/ to .agents/loop-state/" && migrate_loop_state_directories
 		confirm_step "Migrate .agent -> .agents in user projects" && migrate_agent_to_agents_folder
 		confirm_step "Migrate mcp-env.sh -> credentials.sh" && migrate_mcp_env_to_credentials
+		confirm_step "Migrate pulse-repos.json into repos.json" && migrate_pulse_repos_to_repos_json
 		confirm_step "Cleanup deprecated agent paths" && cleanup_deprecated_paths
 		confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
 		confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode


### PR DESCRIPTION
## Summary

- Merges `pulse-repos.json` into `repos.json` as single source of truth for all repo config
- Adds `slug` (owner/repo), `pulse`, and `priority` fields to repos.json entries
- Auto-detects slug from `git remote origin` on `aidevops init`
- Backfills slugs for existing entries via migration
- Prevents agent hallucination of org prefixes (root cause: no authoritative slug field)

## Changes

| File | What |
|------|------|
| `aidevops.sh` | `get_repo_slug()` helper, `register_repo()` stores slug, `init_repos_file()` backfills |
| `pulse.md` | Reads `repos.json` with `pulse:true` filter instead of `pulse-repos.json` |
| `strategic-review.md` | Same change |
| `AGENTS.md` | Cross-repo awareness references slug field |
| `build.txt` | Error prevention rule #6: repo slug hallucination |
| `migrations.sh` | `migrate_pulse_repos_to_repos_json()` — merges old file, renames to `.migrated` |
| `setup.sh` | Calls new migration in both interactive and non-interactive paths |

## repos.json schema (new fields)

```json
{
  "path": "/Users/me/Git/myrepo",
  "slug": "owner/repo",
  "pulse": true,
  "priority": "product",
  "version": "2.136.0",
  "features": [...]
}
```

- `slug`: authoritative GitHub `owner/repo` — resolved from git remote, never guessed
- `pulse`: `true` = supervisor actively manages this repo (replaces pulse-repos.json)
- `priority`: `"product"` or `"tooling"` — used for dispatch tie-breaking

## Testing

- ShellCheck clean on `aidevops.sh` and `migrations.sh`
- Live `repos.json` updated with all 9 managed repos and correct slugs
- `pulse-repos.json` renamed to `.migrated`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic GitHub repository slug detection from git remote URLs for repositories lacking explicit slug configuration.
  * Centralized repository metadata management through unified repos.json configuration file.

* **Chores**
  * Added migration utility to consolidate legacy pulse-repos.json entries into repos.json with automatic slug population and backup preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->