### PR TITLE
fix: add local_only field and support nested repo paths

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -144,7 +144,7 @@ Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-
 
 Planning files go direct to main. Code changes need worktree + PR. Workers NEVER edit TODO.md.
 
-**Cross-repo awareness**: The supervisor manages tasks across all repos in `~/.config/aidevops/repos.json` where `pulse: true`. Each repo entry has a `slug` field (`owner/repo`) — ALWAYS use this for `gh` commands, never guess org names. Use `gh issue list --repo <slug>` and `gh pr list --repo <slug>` for each pulse-enabled repo to get the full picture.
+**Cross-repo awareness**: The supervisor manages tasks across all repos in `~/.config/aidevops/repos.json` where `pulse: true`. Each repo entry has a `slug` field (`owner/repo`) — ALWAYS use this for `gh` commands, never guess org names. Use `gh issue list --repo <slug>` and `gh pr list --repo <slug>` for each pulse-enabled repo to get the full picture. Repos with `"local_only": true` have no GitHub remote — skip `gh` operations on them. Repo paths may be nested (e.g., `~/Git/cloudron/netbird-app`), not just `~/Git/<name>`.
 
 Full rules: `reference/planning-detail.md`
 

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -142,6 +142,8 @@ When referencing specific functions or code include the pattern `file_path:line_
 - ALWAYS resolve repo slugs from `~/.config/aidevops/repos.json` (the `slug` field). NEVER guess or construct `owner/repo` from memory.
 - If a repo has no slug in repos.json, resolve it from `git -C <path> remote get-url origin` and parse `owner/repo`.
 - For pulse/supervisor operations, filter repos.json to entries with `"pulse": true`.
+- Repos with `"local_only": true` have no GitHub remote — skip all `gh` operations on them.
+- Repo paths may be nested (e.g., `~/Git/cloudron/netbird-app`) — never assume repos are only at `~/Git/<name>`.
 
 # Security Rules
 - NEVER expose credentials in output/logs

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -64,8 +64,8 @@ echo "Running workers: $WORKER_COUNT / $MAX_WORKERS"
 Read the managed repos list from `~/.config/aidevops/repos.json`. Filter to repos with `"pulse": true` — these are the repos the supervisor actively manages. Repos without `pulse: true` are registered but not supervised.
 
 ```bash
-# Read repos.json and filter to pulse-enabled repos
-jq '[.initialized_repos[] | select(.pulse == true)]' ~/.config/aidevops/repos.json
+# Read repos.json and filter to pulse-enabled repos (exclude local_only repos)
+jq '[.initialized_repos[] | select(.pulse == true and .local_only != true)]' ~/.config/aidevops/repos.json
 ```
 
 Then for each pulse-enabled repo's `slug` field:

--- a/.agents/scripts/commands/strategic-review.md
+++ b/.agents/scripts/commands/strategic-review.md
@@ -15,7 +15,7 @@ First, discover all managed repos. Then gather state for EVERY repo — not just
 
 ```bash
 # 1. Read the managed repos list (filter to pulse-enabled repos)
-jq '[.initialized_repos[] | select(.pulse == true)]' ~/.config/aidevops/repos.json
+jq '[.initialized_repos[] | select(.pulse == true and .local_only != true)]' ~/.config/aidevops/repos.json
 ```
 
 For EACH repo in that list, run ALL of the following. Do not skip any repo.


### PR DESCRIPTION
## Summary

Follow-up to #2448. Fixes two issues found during review:

- **Nested repo paths**: `~/Git/cloudron/netbird-app` was missed because discovery only searched `maxdepth 1` in `~/Git/`. Now documented that paths can be nested.
- **Local-only repos**: Added `"local_only": true` field for repos with no GitHub remote (e.g., `planning-jersey-agents`). Agents skip `gh` operations on these.

## Changes

| File | What |
|------|------|
| `aidevops.sh` | `register_repo()` auto-detects `local_only` when no git remote exists |
| `pulse.md` | jq filter excludes `local_only` repos |
| `strategic-review.md` | Same filter |
| `AGENTS.md` | Documents `local_only` and nested paths |
| `build.txt` | Error prevention rules for `local_only` and nested paths |

Also fixed `repos.json` (user config, not committed):
- `cloudron-netbird-app` path corrected to `~/Git/cloudron/netbird-app`
- `planning-jersey-agents` marked `local_only: true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for local repositories without GitHub remotes; GitHub operations are automatically skipped for these repos.
  * Extended repository path handling to support nested directory structures.
  * Repositories are now automatically detected and tracked when they lack remote GitHub connectivity.

* **Chores**
  * Updated repository management guidelines and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->