### PR TITLE
t1344: Add local dev routing to Build+ Domain Expertise Check

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -116,6 +116,7 @@ Before implementing, check AGENTS.md domain index. If the task touches a special
 | UI/layout/design/CSS | `workflows/ui-verification.md` + `tools/browser/playwright-emulation.md` + `tools/browser/chrome-devtools.md` |
 | Browser automation | `tools/browser/browser-automation.md` |
 | Accessibility | `services/accessibility/accessibility-audit.md` |
+| Local dev / .local domains / ports / proxy / HTTPS / LocalWP | `services/hosting/local-hosting.md` |
 
 ### 3-4. Investigate & Research
 


### PR DESCRIPTION
## Summary

- Adds a routing entry for local development infrastructure (`.local` domains, ports, proxy, HTTPS, LocalWP) to the Build+ step 2b Domain Expertise Check table in `build-plus.md`
- Routes agents to `services/hosting/local-hosting.md` which documents the actual dnsmasq + Traefik + mkcert + localdev stack
- Prevents agents from guessing incorrect solutions (e.g. suggesting Caddy) when the local hosting architecture is already documented

Closes #2421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation entry for local development configuration options including local domains, ports, proxy, HTTPS, and LocalWP setup to the domain index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->