### PR TITLE
fix: add mandatory OPEN state check before dispatching workers

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -58,7 +58,8 @@ If the first argument is NOT a task ID (it's a description):
 
   ```bash
   # Extract issue number from supervisor dispatch format: "Implement issue #2452 ..."
-  ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oP '(?i)issue\s+#?\K\d+' | head -1)
+  # Use portable sed (POSIX) — grep -oP is GNU-only and fails on macOS/BSD
+  ISSUE_NUM=$(echo "$ARGUMENTS" | sed -En 's/.*[Ii][Ss][Ss][Uu][Ee][[:space:]]*#*([0-9]+).*/\1/p' | head -1)
   ```
 
 **Example session titles:**

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -54,6 +54,12 @@ If the first argument is a task ID (e.g., `t061`):
 If the first argument is NOT a task ID (it's a description):
 - Use the description directly for the session title
 - Call `session-rename` tool with a concise version if the description is very long (truncate to ~60 chars)
+- **Extract issue number if present (#2452 fix):** If `$ARGUMENTS` contains `issue #NNN` or `Issue #NNN`, extract the issue number for the OPEN state check in Step 0.6. Store it as `$ISSUE_NUM` so the state check fires even without a task ID:
+
+  ```bash
+  # Extract issue number from supervisor dispatch format: "Implement issue #2452 ..."
+  ISSUE_NUM=$(echo "$ARGUMENTS" | grep -oP '(?i)issue\s+#?\K\d+' | head -1)
+  ```
 
 **Example session titles:**
 - Task ID `t061` with description "Improve session title format" → `"t061: Improve session title format"`
@@ -95,18 +101,28 @@ If the first argument is a task ID (`t\d+`), claim it before starting work. This
 After claiming the task, update the linked GitHub issue label to reflect that work has started. This gives at-a-glance visibility into which tasks have active workers.
 
 ```bash
-# Find the linked issue number (from task ID search)
-ISSUE_NUM=$(gh issue list --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
-  --state open --search "${TASK_ID}:" --json number,title --limit 5 \
-  | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>/dev/null || true)
+# Find the linked issue number — check multiple sources (#2452 fix):
+# 1. Already extracted from "issue #NNN" in arguments (Step 0)
+# 2. Search by task ID if we have one
+if [[ -z "$ISSUE_NUM" || "$ISSUE_NUM" == "null" ]] && [[ -n "$TASK_ID" ]]; then
+  ISSUE_NUM=$(gh issue list --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
+    --state open --search "${TASK_ID}:" --json number,title --limit 5 \
+    | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty' 2>/dev/null || true)
+fi
 
 if [[ -n "$ISSUE_NUM" && "$ISSUE_NUM" != "null" ]]; then
   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 
-  # t1343: Check issue state before modifying — fail closed (only modify if explicitly OPEN)
+  # t1343 + #2452: Check issue state — if CLOSED, abort the entire worker session.
+  # This is the worker-side defense against being dispatched for a closed issue.
+  # The supervisor checks OPEN state before dispatch (pulse.md Step 3), but if
+  # the issue was closed between dispatch and worker startup, catch it here.
   ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json state -q .state 2>/dev/null || echo "UNKNOWN")
   if [[ "$ISSUE_STATE" != "OPEN" ]]; then
-    echo "[t1343] Issue #$ISSUE_NUM state is $ISSUE_STATE (not OPEN) — skipping label update"
+    echo "[t1343/#2452] Issue #$ISSUE_NUM state is $ISSUE_STATE (not OPEN) — aborting worker"
+    echo "ABORTED: Issue #$ISSUE_NUM is $ISSUE_STATE. Nothing to implement."
+    # In headless mode, exit cleanly. In interactive mode, inform the user.
+    exit 0
   else
     gh issue edit "$ISSUE_NUM" --repo "$REPO" --add-label "status:in-progress" 2>/dev/null || true
     for STALE in "status:available" "status:queued" "status:claimed"; do
@@ -379,6 +395,12 @@ When running as a headless worker (dispatched by the supervisor via `opencode ru
    - If prerequisites are missing, exit immediately with `BLOCKED: prerequisite tXXX not merged — <specific missing item>`. Do not attempt to implement the missing prerequisite yourself.
 
    **Why this matters:** 5 workers running 4+ hours each with no PRs = 20+ hours of wasted compute. A worker that exits after 10 minutes with "BLOCKED: t030 not merged, profile table doesn't exist" saves 3h 50m and gives the supervisor actionable information.
+
+   **Push/PR failure recovery (#2452 pattern):** If `git push` or `gh pr create` fails, do NOT silently continue working. This is the root cause of workers that commit code but never produce a PR — they hit a push failure (auth, branch protection, network) and keep iterating on code instead of addressing the failure. On any push or PR creation failure:
+   1. Log the exact error message
+   2. Retry once after `git pull --rebase origin main` (handles diverged branches)
+   3. If retry fails, exit immediately with: `BLOCKED: push/PR creation failed — <exact error>. Commits exist on local branch <branch-name> in worktree <path>.`
+   4. Do NOT continue implementing code after a push failure — the work is unrecoverable without a PR
 
 9. **Cross-repo routing** — If you discover mid-task that the fix belongs in a different repo (e.g., working in awardsapp but the bug is in an aidevops framework script), do NOT create tasks or TODO entries in the current repo. Instead, file a GitHub issue in the correct repo:
 
@@ -684,10 +706,10 @@ loop until **PR is merged** (max: 20):
   parallel:
     ci = session "Check CI status"
     review = session "Check review status"
-  
+
   if **CI failed**:
     session "Fix CI issues and push"
-  
+
   if **changes requested**:
     session "Evaluate review feedback: verify factual claims against runtime/docs/project conventions, dismiss incorrect suggestions with evidence, address valid ones, then push"
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -133,6 +133,7 @@ Workers now have a self-imposed 2-hour time budget (see full-loop.md rule 8), bu
    - A 2-hour worker with zero commits and no PR is stuck — kill it.
    - A 6-hour worker with a PR stuck in a CI loop is wasting a slot — kill it and comment on the PR.
    - A worker on a genuinely large task (migration, refactor) may need more time — but should have opened a PR by hour 2 at the latest.
+   - **A worker with local commits but no PR (#2452 pattern):** This indicates the worker committed code but failed during push or PR creation (e.g., branch protection, auth failure, push rejection). Kill it and comment with the specific failure pattern so the issue can be re-dispatched with the right fix. Check the worktree for unpushed commits: `git -C ~/Git/<repo>-<branch>/ log --oneline origin/main..HEAD 2>/dev/null`.
 
 3. **Act on your assessment.** If you decide a worker is stuck or zombied, execute the kill:
 
@@ -307,6 +308,20 @@ This turns blocked issues from a dead end into an actively managed queue.
 
 **Deduplication — check running processes:** Before dispatching, check `ps axo command | grep '/full-loop' | grep '\.opencode'` for any running worker whose command line contains the issue/PR number you're about to dispatch (filter to `.opencode` binaries to avoid double-counting node launchers). Different pulse runs may have used different title formats for the same work (e.g., "issue-2300-simplify-infra-scripts" vs "Issue #2300: t1337 Simplify Tier 3"). Extract the canonical number (e.g., `2300`, `t1337`) and check if ANY running worker references it. If so, skip — do not dispatch a duplicate.
 
+**Issue OPEN state verification (MANDATORY before dispatch — t1343):** Before dispatching a worker for any issue, verify the issue is actually OPEN. The `gh issue list --state open` fetch in Step 2 is necessary but not sufficient — issues can be closed between fetch and dispatch, and issues discovered via TODO.md cross-references or blocker-chain resolution may not have gone through the open-issues filter. This check prevents the #2452 failure pattern where a worker was dispatched for closed issue #2411, wasting 6h48m.
+
+```bash
+# MANDATORY: verify issue is OPEN before dispatch (fail-closed)
+STATE=$(gh issue view <number> --repo <owner/repo> --json state -q .state 2>/dev/null || echo "UNKNOWN")
+if [[ "$STATE" != "OPEN" ]]; then
+  echo "[t1343] Issue #<number> state is $STATE (not OPEN) — skipping dispatch"
+  # Do NOT dispatch. Do NOT label. Move to next candidate.
+  continue
+fi
+```
+
+This is a hard gate — if the state check fails (network error, gh timeout), the issue is skipped (`UNKNOWN` is not `OPEN`). The cost of skipping one valid issue for one pulse cycle (2 minutes) is negligible compared to the cost of dispatching a worker for a closed issue (6+ hours wasted).
+
 **Blocker-chain validation (MANDATORY before dispatch):** Before dispatching a worker for any issue, validate that its entire dependency chain is resolved — not just the immediate `status:blocked` label. This prevents the #1 cause of workers running 3-9 hours without producing PRs: they start work on tasks whose prerequisites aren't merged yet, then spin trying to work around missing schemas, APIs, or migrations.
 
 1. **Read the issue body** for `blocked-by:` references (task IDs like `t030` or issue numbers like `#284`).
@@ -371,9 +386,18 @@ opencode run --dir ~/Git/<repo> [--agent <agent>] --title "PR #<number>: <title>
 
 ### For issues that need implementation:
 
+**Defense-in-depth: re-verify OPEN state immediately before dispatch.** The Step 3 check may be minutes old by the time you reach this point (especially if you merged PRs or ran other checks first). This 1-second `gh` call prevents the 6h+ waste of dispatching for a just-closed issue:
+
 ```bash
-opencode run --dir ~/Git/<repo> [--agent <agent>] --title "Issue #<number>: <title>" \
-  "/full-loop Implement issue #<number> (<url>) -- <brief description>" &
+# Re-verify issue is OPEN right before dispatch (t1343 / #2452)
+STATE=$(gh issue view <number> --repo <owner/repo> --json state -q .state 2>/dev/null || echo "UNKNOWN")
+if [[ "$STATE" != "OPEN" ]]; then
+  echo "[t1343] Issue #<number> state is $STATE at dispatch time — skipping"
+  # Skip this issue, move to next candidate
+else
+  opencode run --dir ~/Git/<repo> [--agent <agent>] --title "Issue #<number>: <title>" \
+    "/full-loop Implement issue #<number> (<url>) -- <brief description>" &
+fi
 ```
 
 **Important dispatch rules:**


### PR DESCRIPTION
## Summary

- Add mandatory OPEN state verification in pulse.md Step 3 before dispatching workers, with defense-in-depth re-check in Step 4
- Add worker-side abort in full-loop.md Step 0.6 when dispatched for a non-OPEN issue
- Add push/PR failure recovery guidance to prevent the "committed but no PR" pattern

Fixes #2452

## Problem

Workers were dispatched for closed issues (e.g., #2411 was CLOSED but a worker ran on `refactor/consolidate-utils` for 6h48m). The `chore/perf-resilience-patterns` worker committed code but never opened a PR, running 6h38m.

**Root cause 1 (closed issue dispatch):** pulse.md Step 3 had no explicit OPEN state check before dispatch. It relied on `gh issue list --state open` in Step 2, but issues discovered via TODO.md cross-references or blocker-chain resolution bypass that filter, and issues can close between fetch and dispatch.

**Root cause 2 (commit without PR):** full-loop.md had no guidance for push/PR creation failure recovery. Workers that hit push failures (auth, branch protection) silently continued implementing code instead of exiting.

## Changes

### pulse.md
- **Step 3:** New "Issue OPEN state verification" gate — `gh issue view` check with fail-closed semantics (`UNKNOWN` = skip). Positioned before blocker-chain validation.
- **Step 4:** Defense-in-depth re-verification immediately before `opencode run` dispatch command
- **Step 2a:** New "committed but no PR" detection pattern in long-running worker assessment

### full-loop.md
- **Step 0:** Extract issue number from supervisor dispatch format (`Implement issue #NNN`) so OPEN state check fires for issue-based dispatches (not just task ID dispatches)
- **Step 0.6:** Upgrade from skip-label-update to abort-worker when issue is not OPEN
- **Rule 8:** New "Push/PR failure recovery" section — log error, retry once with rebase, exit on second failure
- Fix pre-existing trailing whitespace in OpenProse example

## Design decisions

- **Fail-closed semantics:** If `gh issue view` fails (network, timeout), the state is `UNKNOWN` which is not `OPEN`, so dispatch is skipped. Cost: one issue skipped for one 2-minute pulse cycle. Benefit: prevents 6h+ wasted sessions.
- **Defense-in-depth:** The check appears in 3 places (pulse Step 3, pulse Step 4, full-loop Step 0.6) because the cost of a false-negative (dispatching for closed issue) is ~1000x the cost of a redundant API call.
- **Intelligence over scripts:** All fixes are guidance improvements in agent docs, not new bash scripts — consistent with the framework's design principle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure handling for push/PR operations with a single automatic retry (and clear abort on repeated failure).
  * Enforced abort behavior when issues are not in OPEN state to prevent wasted work.

* **Documentation**
  * Strengthened workflow guidance: mandatory OPEN-state checks before dispatch, recursive blocker verification, and task decomposition criteria.
  * Added diagnostics for detecting unpushed local commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->