### PR TITLE
t1346: fix agents looking for workflows/pulse.md — use full path scripts/commands/pulse.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -60,7 +60,7 @@ Every agent session — interactive, worker, or supervisor — should improve th
 - Flagging stale tasks that are blocked but not marked as such
 - Running the session miner pulse (`scripts/session-miner-pulse.sh`) to extract learning from past sessions
 
-**Intelligence over scripts:** When fixing orchestration or supervisor bugs, improve the guidance in agent docs (e.g., `pulse.md`, `full-loop.md`) — do NOT create new bash scripts, helper utilities, or deterministic state-tracking layers. The framework previously had 37,000 lines of fragile bash orchestration that was never reliable. It was replaced with intelligence-guided agents for good reason. Helper scripts are for deterministic utilities (version bumping, credential lookup), not for decisions requiring judgment (dispatch priority, stuck detection, dedup). See `aidevops/architecture.md` "Intelligence Over Scripts" for the full rationale.
+**Intelligence over scripts:** When fixing orchestration or supervisor bugs, improve the guidance in agent docs (e.g., `scripts/commands/pulse.md`, `scripts/commands/full-loop.md`) — do NOT create new bash scripts, helper utilities, or deterministic state-tracking layers. The framework previously had 37,000 lines of fragile bash orchestration that was never reliable. It was replaced with intelligence-guided agents for good reason. Helper scripts are for deterministic utilities (version bumping, credential lookup), not for decisions requiring judgment (dispatch priority, stuck detection, dedup). See `aidevops/architecture.md` "Intelligence Over Scripts" for the full rationale.
 
 **Autonomous operation:** When the user says "continue", "monitor", or "keep going" — enter autonomous mode: use sleep/wait loops, maintain a perpetual todo to survive compaction, only interrupt for blocking errors that require user input.
 
@@ -184,7 +184,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | OpenAPI exploration | `tools/context/openapi-search.md` |
 | Local models | `tools/local-models/local-models.md`, `tools/local-models/huggingface.md`, `scripts/local-model-helper.sh` |
 | Model routing | `tools/context/model-routing.md`, `reference/orchestration.md` |
-| Orchestration | `reference/orchestration.md`, `tools/ai-assistants/headless-dispatch.md` |
+| Orchestration | `reference/orchestration.md`, `tools/ai-assistants/headless-dispatch.md`, `scripts/commands/pulse.md` |
 | Agent/MCP dev | `tools/build-agent/build-agent.md`, `tools/build-mcp/build-mcp.md`, `tools/mcp-toolkit/mcporter.md` |
 | Framework | `aidevops/architecture.md`, `scripts/commands/skills.md` |
 

--- a/.agents/aidevops/architecture.md
+++ b/.agents/aidevops/architecture.md
@@ -55,11 +55,11 @@ Key integrations:
 
 aidevops previously had a 37,000-line deterministic supervisor in bash (SQLite state DB, phase-based pipelines, grace periods, heartbeat windows, stale-state GC, dedup helpers). It was fragile, never reliable, and impossible to maintain. Every edge case spawned another script, another phase, another grace period — compounding complexity without improving outcomes.
 
-The current architecture deliberately replaced all of that with a simple pattern: an AI agent reads `pulse.md` (guidance), fetches live state from GitHub (the only state DB), reasons about what to do, and acts. When the agent makes mistakes, the fix is **better guidance in the agent doc** — not a new bash script, helper, or deterministic gate.
+The current architecture deliberately replaced all of that with a simple pattern: an AI agent reads `scripts/commands/pulse.md` (guidance), fetches live state from GitHub (the only state DB), reasons about what to do, and acts. When the agent makes mistakes, the fix is **better guidance in the agent doc** — not a new bash script, helper, or deterministic gate.
 
 **When you encounter a supervisor/orchestration bug:**
 
-1. Improve the guidance in the relevant agent doc (e.g., `pulse.md`, `full-loop.md`)
+1. Improve the guidance in the relevant agent doc (e.g., `scripts/commands/pulse.md`, `scripts/commands/full-loop.md`)
 2. Add the missing knowledge the agent needed to make the right decision
 3. Never create a bash script to enforce what the agent should reason about
 4. Never add state files, databases, or tracking layers

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -116,7 +116,7 @@ if [[ -n "$ISSUE_NUM" && "$ISSUE_NUM" != "null" ]]; then
 
   # t1343 + #2452: Check issue state — if CLOSED, abort the entire worker session.
   # This is the worker-side defense against being dispatched for a closed issue.
-  # The supervisor checks OPEN state before dispatch (pulse.md Step 3), but if
+  # The supervisor checks OPEN state before dispatch (scripts/commands/pulse.md Step 3), but if
   # the issue was closed between dispatch and worker startup, catch it here.
   ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --repo "$REPO" --json state -q .state 2>/dev/null || echo "UNKNOWN")
   if [[ "$ISSUE_STATE" != "OPEN" ]]; then

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -29,7 +29,7 @@ For unattended operation, the `/pulse` command runs every 2 minutes via launchd.
 4. Uses AI (sonnet) to pick the highest-value items to fill available slots
 5. Dispatches workers via `opencode run "/full-loop ..."`, routing to the right agent
 
-See `pulse.md` for the full spec.
+See `scripts/commands/pulse.md` for the full spec.
 
 ### Pulse Scheduler Setup
 

--- a/.agents/tools/code-review/coderabbit.md
+++ b/.agents/tools/code-review/coderabbit.md
@@ -148,7 +148,7 @@ The supervisor pulse triggers a daily full codebase review via GitHub issue #238
    - Title: `coderabbit: <short description>`
    - Labels: `coderabbit-pulse`, `auto-dispatch`
    - Body: finding number, evidence, risk, recommended action
-4. **Pickup**: The normal supervisor pulse (Step 3 in `pulse.md`) picks up
+4. **Pickup**: The normal supervisor pulse (Step 3 in `scripts/commands/pulse.md`) picks up
    these issues via `gh issue list` — they appear as open issues with the
    `auto-dispatch` label and enter the standard priority queue.
 5. **Dispatch**: Workers implement fixes via the normal `/full-loop` pipeline.


### PR DESCRIPTION
## Summary

- Updated 6 bare `pulse.md` references across 5 files to use the full relative path `scripts/commands/pulse.md`
- Added `scripts/commands/pulse.md` to the Domain Index table under Orchestration in AGENTS.md
- Eliminates 75 `file_not_found` errors where agents guessed `workflows/pulse.md` as the path

## Root Cause

Agent docs referenced `pulse.md` without a directory prefix. Agents inferred `workflows/pulse.md` (likely from the nearby `workflows/` entries in the Domain Index), but the actual file is at `scripts/commands/pulse.md`.

## Files Changed

| File | Change |
|------|--------|
| `.agents/AGENTS.md` | `pulse.md` → `scripts/commands/pulse.md` in Intelligence-over-scripts paragraph; added to Domain Index Orchestration row |
| `.agents/aidevops/architecture.md` | Two bare `pulse.md` references → full path |
| `.agents/scripts/commands/full-loop.md` | Comment reference → full path |
| `.agents/scripts/commands/runners.md` | Cross-reference → full path |
| `.agents/tools/code-review/coderabbit.md` | Step reference → full path |

## Verification

- `rg 'pulse\.md' .agents/ --type md` confirms all 10 references now use `scripts/commands/pulse.md`
- Target file `.agents/scripts/commands/pulse.md` exists and is unchanged
- No bare `pulse.md` references remain that could cause path guessing

Closes #2457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Consolidated documentation path references to use standardized, centralized locations across all internal guidance materials
* Updated cross-references throughout agent configuration and automation script documentation to reflect consistent directory structure
* Improved documentation consistency and maintainability by establishing standard paths for guidance resource references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->