### PR TITLE
t1349: fix: strengthen webfetch guidance to prevent 404 errors

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -120,7 +120,21 @@ Before implementing, check AGENTS.md domain index. If the task touches a special
 
 ### 3-4. Investigate & Research
 
-Explore codebase, search for relevant code, identify root cause. For external research: use context7 MCP for library docs, `gh api` for GitHub content, `webfetch` only for URLs from user messages or tool output (never construct URLs — 47% failure rate on guessed URLs).
+Explore codebase, search for relevant code, identify root cause.
+
+**External content lookup — use the right tool:**
+
+| Need | Use | NOT |
+|------|-----|-----|
+| GitHub file content | `gh api repos/{owner}/{repo}/contents/{path}` | `webfetch` on `raw.githubusercontent.com` |
+| GitHub repo overview | `gh api repos/{owner}/{repo}` + `--jq '.description'` | `webfetch` on `github.com` URLs |
+| Discover files in a repo | `gh api repos/{owner}/{repo}/git/trees/{branch}?recursive=1` | Guessing paths |
+| Library/framework docs | Context7 MCP (`resolve-library-id` then `get-library-docs`) | `webfetch` on docs sites |
+| npm/package info | `gh api` to fetch README from the repo, or Context7 | `webfetch` on npmjs.com |
+| PR/issue details | `gh pr view`, `gh issue view`, `gh api` | `webfetch` on github.com |
+| User-provided URL | `webfetch` (the one valid use case) | N/A |
+
+**Why:** 47% of webfetch calls fail. 70% of those failures are agents inventing `raw.githubusercontent.com` paths that don't exist. `gh api` handles auth, returns structured JSON, and gives clear 404s. Context7 MCP returns curated docs without guessing URL structures.
 
 ### 5. Plan
 

--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -127,7 +127,7 @@ Explore codebase, search for relevant code, identify root cause.
 | Need | Use | NOT |
 |------|-----|-----|
 | GitHub file content | `gh api repos/{owner}/{repo}/contents/{path}` | `webfetch` on `raw.githubusercontent.com` |
-| GitHub repo overview | `gh api repos/{owner}/{repo}` + `--jq '.description'` | `webfetch` on `github.com` URLs |
+| GitHub repo overview | `gh api repos/{owner}/{repo} --jq '.description'` | `webfetch` on `github.com` URLs |
 | Discover files in a repo | `gh api repos/{owner}/{repo}/git/trees/{branch}?recursive=1` | Guessing paths |
 | Library/framework docs | Context7 MCP (`resolve-library-id` then `get-library-docs`) | `webfetch` on docs sites |
 | npm/package info | `gh api` to fetch README from the repo, or Context7 | `webfetch` on npmjs.com |

--- a/.agents/tools/context/context-builder.md
+++ b/.agents/tools/context/context-builder.md
@@ -85,7 +85,7 @@ npx repomix@latest . --stdout | pbcopy
 
 **NEVER blindly pack a remote repository.** Follow this escalation:
 
-1. **Fetch README first** - `webfetch "https://github.com/{user}/{repo}"` (~1-5K tokens)
+1. **Fetch README first** - `gh api repos/{owner}/{repo}/contents/README.md --jq '.content' | base64 -d` (~1-5K tokens)
 2. **Check repo size** - `gh api repos/{user}/{repo} --jq '.size'` (size in KB)
 3. **Apply size thresholds**:
 

--- a/.agents/tools/context/context-builder.md
+++ b/.agents/tools/context/context-builder.md
@@ -85,7 +85,7 @@ npx repomix@latest . --stdout | pbcopy
 
 **NEVER blindly pack a remote repository.** Follow this escalation:
 
-1. **Fetch README first** - `gh api repos/{owner}/{repo}/contents/README.md --jq '.content' | base64 -d` (~1-5K tokens)
+1. **Fetch README first** - `gh api repos/{owner}/{repo}/readme --jq '.content' | base64 -d` (~1-5K tokens)
 2. **Check repo size** - `gh api repos/{user}/{repo} --jq '.size'` (size in KB)
 3. **Apply size thresholds**:
 

--- a/.agents/tools/context/context-guardrails.md
+++ b/.agents/tools/context/context-guardrails.md
@@ -126,7 +126,7 @@ webfetch("https://docs.example.com/")  # May return 50K+ tokens
 # resolve-library-id → get-library-docs
 
 # BETTER - use gh api for GitHub content (handles auth, structured JSON)
-gh api repos/{owner}/{repo}/contents/README.md --jq '.content' | base64 -d
+gh api repos/{owner}/{repo}/readme --jq '.content' | base64 -d
 
 # AVOID - raw.githubusercontent.com URLs have 70% failure rate (agents guess wrong paths)
 # webfetch("https://raw.githubusercontent.com/user/repo/main/README.md")  # DON'T

--- a/.agents/tools/context/context-guardrails.md
+++ b/.agents/tools/context/context-guardrails.md
@@ -122,9 +122,14 @@ sed -n '100,200p' context.xml
 # CAUTION - docs sites can be large
 webfetch("https://docs.example.com/")  # May return 50K+ tokens
 
-# BETTER - target specific pages
-webfetch("https://docs.example.com/getting-started")
-webfetch("https://raw.githubusercontent.com/user/repo/main/README.md")
+# BETTER - use Context7 MCP for library docs (curated, no guessing URLs)
+# resolve-library-id → get-library-docs
+
+# BETTER - use gh api for GitHub content (handles auth, structured JSON)
+gh api repos/{owner}/{repo}/contents/README.md --jq '.content' | base64 -d
+
+# AVOID - raw.githubusercontent.com URLs have 70% failure rate (agents guess wrong paths)
+# webfetch("https://raw.githubusercontent.com/user/repo/main/README.md")  # DON'T
 ```
 
 ## Recovery from Context Overflow

--- a/todo/tasks/t1349-brief.md
+++ b/todo/tasks/t1349-brief.md
@@ -1,0 +1,89 @@
+---
+mode: subagent
+---
+# t1349: fix: webfetch 404 errors — add guidance to prevent raw GitHub URL fetching
+
+## Origin
+
+- **Created:** 2026-02-27
+- **Session:** headless:full-loop-t1349
+- **Created by:** ai-interactive
+- **Conversation context:** Session miner pulse detected 117 webfetch 404 errors (46.8% failure rate). 70% were guessed raw.githubusercontent.com paths. Issue GH#2461 filed.
+
+## What
+
+Strengthen agent guidance across build-plus.md, context-guardrails.md, and context-builder.md to prevent agents from constructing raw.githubusercontent.com URLs or guessing documentation URLs for webfetch. Agents should use `gh api` for GitHub content and Context7 MCP for library docs.
+
+## Why
+
+117 out of 250 webfetch calls fail (46.8%). 70% of failures are agents inventing raw.githubusercontent.com file paths. This wastes tokens, time, and causes cascading retry loops. build.txt already has error prevention guidance but downstream agent docs still recommend the bad patterns.
+
+## How (Approach)
+
+1. `build-plus.md` — add a webfetch decision table to the research section (step 3-4)
+2. `context-guardrails.md:127` — replace raw.githubusercontent.com example with `gh api` alternative
+3. `context-builder.md:88` — replace `webfetch` GitHub URL with `gh api` approach
+4. Verify build.txt guidance is already complete (it is — lines 99-109)
+
+## Acceptance Criteria
+
+- [ ] build-plus.md contains a "what to use instead of webfetch" decision table
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "gh api.*repos"
+    path: ".agents/build-plus.md"
+  ```
+- [ ] context-guardrails.md no longer recommends raw.githubusercontent.com
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "raw\\.githubusercontent\\.com"
+    path: ".agents/tools/context/context-guardrails.md"
+    expect: absent
+  ```
+- [ ] context-builder.md uses gh api instead of webfetch for GitHub repos
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "webfetch.*github\\.com/\\{user\\}"
+    path: ".agents/tools/context/context-builder.md"
+    expect: absent
+  ```
+- [ ] No raw.githubusercontent.com recommended as a positive pattern in any agent doc
+  ```yaml
+  verify:
+    method: bash
+    run: "rg 'raw\\.githubusercontent\\.com' .agents/ --type md -l | grep -v 'build.txt' | xargs -I{} rg -c 'NEVER|CAUTION|avoid|bad|wrong|DON.T' {} | grep ':0$' && exit 1 || exit 0"
+  ```
+- [ ] Lint clean (shellcheck / markdownlint)
+
+## Context & Decisions
+
+- build.txt already has comprehensive webfetch error prevention (lines 97-109) — no changes needed there
+- The fix is about downstream agent docs that still recommend the bad patterns
+- raw.githubusercontent.com fails because agents guess file paths that don't exist
+- gh api repos/{owner}/{repo}/contents/{path} is the correct alternative (handles auth, returns JSON)
+- Context7 MCP is the correct alternative for library/framework documentation
+
+## Relevant Files
+
+- `.agents/prompts/build.txt:97-109` — existing error prevention (verify complete, no changes)
+- `.agents/build-plus.md:95-123` — research section needs decision table
+- `.agents/tools/context/context-guardrails.md:119-128` — bad example to fix
+- `.agents/tools/context/context-builder.md:86-88` — bad example to fix
+
+## Dependencies
+
+- **Blocked by:** none
+- **Blocks:** none
+- **External:** none
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Research/read | 5m | Read target files, assess gaps |
+| Implementation | 15m | Edit 3 files |
+| Testing | 5m | Lint, verify patterns |
+| **Total** | **25m** | |

--- a/todo/tasks/t1349-brief.md
+++ b/todo/tasks/t1349-brief.md
@@ -28,13 +28,16 @@ Strengthen agent guidance across build-plus.md, context-guardrails.md, and conte
 ## Acceptance Criteria
 
 - [ ] build-plus.md contains a "what to use instead of webfetch" decision table
+
   ```yaml
   verify:
     method: codebase
     pattern: "gh api.*repos"
     path: ".agents/build-plus.md"
   ```
+
 - [ ] context-guardrails.md no longer recommends raw.githubusercontent.com
+
   ```yaml
   verify:
     method: codebase
@@ -42,7 +45,9 @@ Strengthen agent guidance across build-plus.md, context-guardrails.md, and conte
     path: ".agents/tools/context/context-guardrails.md"
     expect: absent
   ```
+
 - [ ] context-builder.md uses gh api instead of webfetch for GitHub repos
+
   ```yaml
   verify:
     method: codebase
@@ -50,7 +55,9 @@ Strengthen agent guidance across build-plus.md, context-guardrails.md, and conte
     path: ".agents/tools/context/context-builder.md"
     expect: absent
   ```
+
 - [ ] No raw.githubusercontent.com recommended as a positive pattern in any agent doc
+
   ```yaml
   verify:
     method: bash


### PR DESCRIPTION
## Summary

- Added a **webfetch decision table** to `build-plus.md` research section — maps each content need (GitHub files, library docs, PR/issue details) to the correct tool (`gh api`, Context7 MCP) with explicit "NOT" column showing what to avoid
- Fixed `context-guardrails.md` which recommended `raw.githubusercontent.com` as a **positive example** — replaced with `gh api` and Context7 MCP alternatives
- Fixed `context-builder.md` which recommended `webfetch` on `github.com` URLs — replaced with `gh api repos/{owner}/{repo}/contents/README.md`

## Context

Session miner detected **117 webfetch 404 errors** out of 250 calls (47% failure rate). 70% of failures were agents inventing `raw.githubusercontent.com` paths that don't exist. `build.txt` already had comprehensive error prevention guidance (lines 97-109) — this PR fixes the downstream agent docs that still recommended the bad patterns.

## Files Changed

| File | Change |
|------|--------|
| `.agents/build-plus.md` | Added 7-row decision table for external content lookup |
| `.agents/tools/context/context-guardrails.md` | Replaced raw.githubusercontent.com positive example with gh api + Context7 |
| `.agents/tools/context/context-builder.md` | Replaced webfetch GitHub URL with gh api command |
| `todo/tasks/t1349-brief.md` | Task brief |

Closes #2461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated research and investigation guidance with structured tool recommendations and decision tables
  * Improved protocols for accessing library documentation and repository information  
  * Enhanced guidance clarity with best practice recommendations for various research tasks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->