### PR TITLE
t1351: fix: Add Python >= 3.10 pre-check before cisco-ai-skill-scanner install

### DIFF
--- a/tests/test-batch-quality-hardening.sh
+++ b/tests/test-batch-quality-hardening.sh
@@ -489,6 +489,37 @@ else
 	fail "Missing helpful error message when all fallbacks fail"
 fi
 
+# Test: Python version pre-check before cisco-ai-skill-scanner install (t1351)
+PLUGINS_SH="$REPO_DIR/setup-modules/plugins.sh"
+if [[ -f "$PLUGINS_SH" ]]; then
+	if grep -q 'check_python_for_skill_scanner' "$PLUGINS_SH"; then
+		pass "plugins.sh has Python version pre-check for skill scanner (t1351)"
+	else
+		fail "plugins.sh missing Python version pre-check (t1351)"
+	fi
+
+	if grep -q 'Python >= 3.10' "$PLUGINS_SH"; then
+		pass "plugins.sh shows clear Python version requirement in error message"
+	else
+		fail "plugins.sh missing clear Python version requirement message"
+	fi
+
+	if grep -qE 'brew install python|uv python install' "$PLUGINS_SH"; then
+		pass "plugins.sh shows fix instructions for missing Python"
+	else
+		fail "plugins.sh missing fix instructions for Python version"
+	fi
+else
+	skip "plugins.sh not found (tests may need updating after modularization)"
+fi
+
+# Test: security-helper.sh has Python version pre-check (t1351)
+if grep -q 'check_python_for_skill_scanner' "$SCRIPTS_DIR/security-helper.sh"; then
+	pass "security-helper.sh has Python version pre-check for skill scanner"
+else
+	fail "security-helper.sh missing Python version pre-check"
+fi
+
 # ============================================================
 # CROSS-CUTTING: Script Quality
 # ============================================================


### PR DESCRIPTION
## Summary

- Adds `check_python_for_skill_scanner()` function to both `setup-modules/plugins.sh` and `.agents/scripts/security-helper.sh` that verifies Python >= 3.10 before attempting cisco-ai-skill-scanner install
- If no compatible Python is found and `uv` is available, auto-installs Python 3.11 via `uv python install 3.11`
- On failure, emits clear error showing exact Python version found and actionable fix instructions (`brew install python@3.11`, `uv python install 3.11`, `apt install python3.11`)
- Adds test coverage for the pre-check in `tests/test-batch-quality-hardening.sh`

## Problem

On systems with Python < 3.10, `pip3 install cisco-ai-skill-scanner` fails with a confusing "no matching distribution found" error. No pre-check was performed, and the fallback chain (`uv tool install`, `pipx install`, venv, `pip3 --user`) all fail silently with the same root cause.

## Changes

| File | Change |
|------|--------|
| `setup-modules/plugins.sh` | Added `check_python_for_skill_scanner()` with version detection, versioned binary scan, uv auto-install, and clear error messages. Called before the install fallback chain in `scan_imported_skills()`. |
| `.agents/scripts/security-helper.sh` | Added equivalent `check_python_for_skill_scanner()` function. Integrated into both `cmd_install skill-scanner` and `cmd_install all` paths. |
| `tests/test-batch-quality-hardening.sh` | Added 4 tests verifying the pre-check exists in both files with correct error messages and fix instructions. |

## Verification

- `shellcheck` passes on both modified scripts (zero new warnings)
- `bash -n` syntax check passes on both scripts
- All new tests target the correct files (`plugins.sh`, not `setup.sh`)

Closes #2470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cisco Skill Scanner now validates Python 3.10+ availability before running and provides guidance if the required Python version is not found on your system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->