### PR TITLE
t1352: Remove supervisor-helper.sh references from active files

### DIFF
--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -1179,17 +1179,15 @@ If **yes**:
 
 ```bash
 # Enable the supervisor pulse (every 2 min)
-~/.aidevops/agents/scripts/supervisor-helper.sh cron install
-
-# Verify it's running
-~/.aidevops/agents/scripts/supervisor-helper.sh cron status
+# See scripts/commands/runners.md for macOS (launchd) and Linux (cron) setup
+# The pulse dispatches workers, merges PRs, and manages cross-repo work
 ```
 
 If **no**:
 
 ```text
-No problem. You can enable it anytime:
-  supervisor-helper.sh cron install
+No problem. You can enable it anytime — see scripts/commands/runners.md
+for setup instructions (launchd on macOS, cron on Linux).
 
 The strategic review, session miner, and circuit breaker all run as steps
 within the pulse — enabling the pulse enables everything.
@@ -1201,7 +1199,7 @@ Once services are configured:
 
 1. **Create your playground**: `mkdir ~/Git/aidevops-playground && cd ~/Git/aidevops-playground && git init && aidevops init`
 2. **Test a simple task**: "List my GitHub repos" or "Check my Hetzner servers"
-3. **Enable orchestration**: `supervisor-helper.sh cron install` — autonomous task dispatch, PR management, cross-repo visibility, and strategic review
+3. **Enable orchestration**: set up the pulse scheduler (see `scripts/commands/runners.md`) — autonomous task dispatch, PR management, cross-repo visibility, and strategic review
 4. **Explore agents**: Type `@` to see available agents
 5. **Try a workflow**: `/create-prd` → `/generate-tasks` → `/feature` → build → `/release`
 6. **Try autonomous mode**: Add `#auto-dispatch` to a TODO.md task and watch the supervisor pick it up

--- a/.agents/reference/planning-detail.md
+++ b/.agents/reference/planning-detail.md
@@ -78,7 +78,7 @@ Add these tags to tasks that need human action before they can proceed. The supe
 
 ## Stale-Claim Auto-Recovery
 
-(t1263): When interactive sessions claim tasks (assignee: + started:) but die or move on without completing them, the tasks become permanently stuck. Phase 0.5e of the pulse cycle detects stale claims: tasks with assignee:/started: that have (1) no active worker in the supervisor DB, (2) no active worktree, and (3) claim age >24h. It auto-unclaims by stripping assignee: and started: fields so auto-pickup can re-dispatch. Respects t1017 assignee ownership: only unclaims tasks assigned to the local user. Configure threshold: `SUPERVISOR_STALE_CLAIM_SECONDS` (default: 86400 = 24h). Manual check: `supervisor-helper.sh stale-claims [--repo path]`.
+(t1263): When interactive sessions claim tasks (assignee: + started:) but die or move on without completing them, the tasks become permanently stuck. The pulse cycle detects stale claims: tasks with assignee:/started: that have (1) no active worker process, (2) no active worktree, and (3) claim age >24h. It auto-unclaims by stripping assignee: and started: fields so auto-pickup can re-dispatch. Respects t1017 assignee ownership: only unclaims tasks assigned to the local user. Configure threshold: `SUPERVISOR_STALE_CLAIM_SECONDS` (default: 86400 = 24h).
 
 ## Task Completion Rules
 

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -81,8 +81,9 @@ Claim → Branch Setup → Task Development → Preflight → PR Create → PR R
 If the first argument is a task ID (`t\d+`), claim it before starting work. This prevents two agents (or a human and an agent) from working on the same task concurrently.
 
 ```bash
-# Claim the task — adds assignee: to TODO.md
-~/.aidevops/agents/scripts/supervisor-helper.sh claim "$TASK_ID" "$(pwd)"
+# Claim the task — adds assignee:<identity> started:<ISO> to TODO.md task line
+# Uses git pull → grep assignee: → add fields → commit + push
+# Race protection: git push rejection = someone else claimed first
 ```
 
 **Exit codes:**

--- a/.agents/scripts/onboarding-helper.sh
+++ b/.agents/scripts/onboarding-helper.sh
@@ -583,12 +583,7 @@ check_orchestration() {
 	if [[ "$pulse_active" == "true" ]]; then
 		print_service "Supervisor Pulse" "ready" "dispatches workers, merges PRs every 2 min"
 	else
-		local supervisor_script="$HOME/.aidevops/agents/scripts/supervisor-helper.sh"
-		if [[ -x "$supervisor_script" ]]; then
-			print_service "Supervisor Pulse" "needs-setup" "supervisor-helper.sh cron install"
-		else
-			print_service "Supervisor Pulse" "needs-setup" "run aidevops update first"
-		fi
+		print_service "Supervisor Pulse" "needs-setup" "see scripts/commands/runners.md for setup"
 	fi
 
 	# Auto-pickup is implicit when pulse is active

--- a/.agents/tools/automation/objective-runner.md
+++ b/.agents/tools/automation/objective-runner.md
@@ -24,7 +24,7 @@ tools:
 
 - **Use instead**: `/full-loop "objective description"` for iterative task execution
 - **Runner dispatch**: `runner-helper.sh` for single-shot named agents
-- **Batch tasks**: `supervisor-helper.sh` for multi-task orchestration
+- **Multi-task dispatch**: `/runners` for parallel task dispatch, `/pulse` for autonomous orchestration
 - **Archived script**: `scripts/archived/objective-runner-helper.sh` (1,334 lines, reference only)
 
 <!-- AI-CONTEXT-END -->
@@ -41,5 +41,6 @@ See `scripts/archived/objective-runner-helper.sh` for the original implementatio
 
 - `/full-loop` - End-to-end development loop (replacement)
 - `scripts/runner-helper.sh` - Single-shot named agents
-- `scripts/supervisor-helper.sh` - Batch task orchestration
+- `scripts/commands/runners.md` - Parallel task dispatch via `/runners`
+- `scripts/commands/pulse.md` - Autonomous orchestration via `/pulse`
 - `workflows/plans.md` - Task planning and tracking

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -749,8 +749,10 @@ An "always switch branches for TODO.md" rule fails the 80% universal applicabili
 **Claim flow:**
 
 ```bash
-supervisor-helper.sh claim tNNN    # Add assignee:identity + started:ISO to task line, sync to GH issue
-supervisor-helper.sh unclaim tNNN  # Remove assignee: + started:, sync to GH issue
+# Claim: add assignee:<identity> started:<ISO> to task line in TODO.md, sync to GH issue
+# Unclaim: remove assignee: + started: fields, sync to GH issue
+# The /full-loop command handles claiming automatically before starting work.
+# Race protection: git push rejection = someone else claimed first — pull, re-check, abort.
 ```
 
 **How it works:**

--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -401,9 +401,9 @@ Worktrees are registered to the creating session's PID in a SQLite registry. Thi
 
 **How it works**:
 
-- `worktree-helper.sh add` and `supervisor-helper.sh dispatch` register ownership
+- `worktree-helper.sh add` registers ownership when creating worktrees
 - `worktree-helper.sh remove` and `clean` refuse to touch worktrees owned by other live processes
-- `supervisor-helper.sh cleanup` skips worktrees owned by other sessions
+- Cleanup operations skip worktrees owned by other sessions
 - Stale entries (dead PIDs, missing directories) are auto-pruned
 
 **Commands**:


### PR DESCRIPTION
## Summary

- Remove/replace 30+ references to archived `supervisor-helper.sh` from 9 active docs and scripts
- Rewrite `runners-check.md` to use current tooling (ps, gh, worktree) instead of supervisor SQLite DB
- Rewrite `orchestration.md` Supervisor CLI section for the current `/pulse` system
- Update onboarding docs and helper to point to `scripts/commands/runners.md` for pulse setup

## Scope

**Done (this PR):** 9 files — the highest-priority docs and command specs that agents read frequently:
`orchestration.md`, `runners-check.md`, `full-loop.md`, `plans.md`, `worktree.md`, `objective-runner.md`, `planning-detail.md`, `onboarding.md`, `onboarding-helper.sh`

**Remaining (needs human review):** 11 files still reference `supervisor-helper.sh`:
- `contest-helper.sh` — functional calls to supervisor DB (may be dead code)
- `youtube/pipeline.md` — 11 refs, entire batch workflow section needs rewrite
- `session-checkpoint-helper.sh` — gracefully fails already (`|| echo "none"`)
- `graduated-learnings.md` — historical records (keep as-is or annotate?)
- `supervisor-module-map.md` — entire file documents archived script
- `subagent-index.toon` — lists supervisor-helper.sh as active tool
- `model-availability-helper.sh`, `pre-edit-check.sh`, `migrate-pr-backfill.sh`, `test-staleness-check.sh`, `test-task-id-collision.sh` — comments only

## Closes

Resolves #753

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced autonomous pulse scheduler for task orchestration.
  * Added `/runners` for targeted task dispatch and `/pulse` for automated scheduling.

* **Documentation**
  * Updated setup instructions to use new scheduler configuration guide.
  * Simplified orchestration workflow documentation.
  * Reorganized command references.

* **Refactor**
  * Streamlined task claiming mechanism with automatic assignee and timestamp tracking.
  * Enhanced system health diagnostics to monitor worker status and queue depth.

* **Chores**
  * Updated helper scripts and configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->