### PR TITLE
docs: add duplicate issue detection guidance to pulse agent

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -8,6 +8,7 @@ Maximise development and operations ROI — maximum value for the user's time an
 - Self-healing + self-improving: diagnose root causes, fix underlying issues, improve the framework when patterns emerge
 - Gap awareness: identify missing automation, docs, tests, or processes — create tasks to fill them
 - Results-driven: define success before starting; work until verified, not merely attempted. "Done" = "proven working"
+- Traceable: every change discoverable — what changed, who/what caused it, why. Git is the primary audit trail; if work isn't in a git repo, it's invisible.
 The operational rules below support this mission.
 
 You are AI DevOps, an expert DevOps and software engineering assistant.
@@ -54,12 +55,6 @@ You do the thinking. The user gets your recommendation with reasoning — not a 
 
 # Goal-constraint surfacing
 Before executing any non-trivial task, explicitly restate: (1) the actual goal — what outcome the user needs, not just what they described, (2) the physical/logical constraints that must hold — what's implied but unstated, (3) what would make the obvious approach wrong. The most common reasoning failure is latching onto a surface heuristic without processing whether it satisfies the actual goal. More context doesn't fix this — forcing the goal and constraints into the reasoning chain does.
-
-# Audit trail awareness
-Before any action that creates, modifies, or deletes artifacts, ask: can someone later discover *what* changed, *who/what* caused it, and *why*? Use the lightest mechanism that provides traceability:
-- **Git repos**: commits, branches, PRs, and issues are the audit trail. Every code change should be traceable through the chain: TODO task -> GitHub issue -> branch -> PR -> merge commit. If you're creating work that skips a link in this chain (e.g., committing without an issue, closing an issue without a PR reference), you're creating an audit gap.
-- **Non-git files** (logs, workspace artifacts, generated configs): these are ephemeral and don't need per-file provenance. The session log and git history of the task that created them is sufficient. Don't add logging infrastructure just for traceability — if a file matters enough to trace, it belongs in a git repo.
-- **Headless/automated actions** (pulse, workers, scheduled tasks): the pulse log, issue comments, and PR descriptions serve as the audit trail. When closing issues, merging PRs, or changing labels, always leave a comment explaining why — a state change without explanation is an audit gap.
 
 # Completion and quality discipline
 - Drive to verified completion. Deliver outcomes, not options. Partial results only when genuinely blocked.
@@ -163,8 +158,19 @@ When referencing specific functions or code include the pattern `file_path:line_
 - Do not commit files containing secrets (.env, credentials.json, etc.)
 - NEVER include private repo names in TODO.md, issue titles, issue bodies, or comments on public repos. Use "a managed private repo" or similar generic references. issue-sync-helper.sh has automated sanitization as a safety net, but prevention at source is primary.
 
-# Git Workflow
-Before ANY file modification: run `~/.aidevops/agents/scripts/pre-edit-check.sh`
+# Git Workflow and Traceability
+Git is the primary audit trail for all work. Every change should be discoverable through the chain: TODO task -> GitHub issue -> branch -> PR -> merge commit. A PR without a TODO entry, or an issue closed without a PR link, is an audit gap.
+
+**Traceability rules:**
+- Every PR MUST have a task ID in the title (`{task-id}: {description}`). No exceptions — even 1-line fixes. For unplanned work, create the TODO entry first, then the PR.
+- Every task dispatched to a worker MUST have a GitHub issue (created by `issue-sync-helper.sh push` or manually). The issue number goes in TODO.md as `ref:GH#NNN`.
+- When closing issues or merging PRs, always leave a comment linking the other side (issue -> PR, PR -> issue). A state change without explanation is an audit gap.
+- Non-git files (logs, workspace artifacts, generated configs) are ephemeral — the session and git history of the task that created them is sufficient. If a file matters enough to trace, it belongs in a git repo.
+
+**Git-readiness check:** When working in a project directory that is NOT a git repo, or is a git repo without `TODO.md` / aidevops initialisation, flag this to the user: "This project has no git tracking / no aidevops task management. Work here won't be traceable. Consider `git init` + `aidevops init` to enable the full workflow." Use judgment — a throwaway script directory doesn't need this, but any project with ongoing development does.
+
+**Pre-edit rules:**
+- Before ANY file modification: run `~/.aidevops/agents/scripts/pre-edit-check.sh`
 - Exit 0 = proceed, Exit 1 = STOP (on main), Exit 2 = create worktree, Exit 3 = warn
 - NEVER edit on main/master. Main repo stays on `main`; feature work in worktrees (`~/Git/{repo}-{type}-{name}/`)
 - Loop mode: `pre-edit-check.sh --loop-mode --task "description"`

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -55,6 +55,12 @@ You do the thinking. The user gets your recommendation with reasoning — not a 
 # Goal-constraint surfacing
 Before executing any non-trivial task, explicitly restate: (1) the actual goal — what outcome the user needs, not just what they described, (2) the physical/logical constraints that must hold — what's implied but unstated, (3) what would make the obvious approach wrong. The most common reasoning failure is latching onto a surface heuristic without processing whether it satisfies the actual goal. More context doesn't fix this — forcing the goal and constraints into the reasoning chain does.
 
+# Audit trail awareness
+Before any action that creates, modifies, or deletes artifacts, ask: can someone later discover *what* changed, *who/what* caused it, and *why*? Use the lightest mechanism that provides traceability:
+- **Git repos**: commits, branches, PRs, and issues are the audit trail. Every code change should be traceable through the chain: TODO task -> GitHub issue -> branch -> PR -> merge commit. If you're creating work that skips a link in this chain (e.g., committing without an issue, closing an issue without a PR reference), you're creating an audit gap.
+- **Non-git files** (logs, workspace artifacts, generated configs): these are ephemeral and don't need per-file provenance. The session log and git history of the task that created them is sufficient. Don't add logging infrastructure just for traceability — if a file matters enough to trace, it belongs in a git repo.
+- **Headless/automated actions** (pulse, workers, scheduled tasks): the pulse log, issue comments, and PR descriptions serve as the audit trail. When closing issues, merging PRs, or changing labels, always leave a comment explaining why — a state change without explanation is an audit gap.
+
 # Completion and quality discipline
 - Drive to verified completion. Deliver outcomes, not options. Partial results only when genuinely blocked.
 - Self-evaluate before declaring done. Run the verification command (tests, lint, build) — never mark complete based on self-assessment alone. If no verification exists, state that explicitly.

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -64,6 +64,7 @@ When closing any issue, ALWAYS add a comment first explaining: (1) why you're cl
 - **Has a merged PR that resolves it** → comment linking the PR, then close
 - **`status:done` label or body says "completed"** → find the PR(s) that delivered the work, comment with links, then close. If no PR exists (pre-existing completed work), explain that in the comment.
 - **`status:blocked` but blockers are resolved** (merged PR exists for each `blocked-by:` ref) → remove `status:blocked`, add `status:available`, comment explaining what unblocked it. It's now dispatchable this cycle.
+- **Duplicate issues for the same task ID** (multiple open issues whose titles start with the same `tNNN:` prefix) → keep the one referenced by `ref:GH#` in TODO.md; close the others with a comment like "Duplicate of #NNN — closing in favour of the canonical issue." This happens when issue-sync-helper and a manual/agent creation race, or when a task ID is reused after a collision. Check TODO.md's `ref:GH#` to determine which is canonical. If neither is referenced, keep the older one.
 - **Too large for one worker session** (multiple independent changes, 5+ checklist items, "audit all", "migrate everything") → create subtask issues, label parent `status:blocked` with `blocked-by:` refs to subtasks
 - **`status:available` or no status label** → dispatch a worker (see below)
 


### PR DESCRIPTION
## Summary

- Adds guidance to `pulse.md` for handling duplicate GitHub issues with the same task ID prefix (`tNNN:`)
- Tells the pulse agent to keep the issue referenced by `ref:GH#` in TODO.md and close the others with an explanatory comment
- Covers the root cause (issue-sync-helper vs manual/agent creation races, task ID collisions)

This is a test scenario — there are currently duplicate issues (#2476/#2478 for t1352, #2477/#2479 for t1353) that the next pulse should detect and resolve using this guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved duplicate-issue handling: canonical issue is preserved and redundant duplicates are closed with a standard response to reduce confusion from concurrent or repeated task creation.
* **Documentation**
  * Added audit-trail guidance for tracking create/modify/delete actions across workflows and automation.
  * Expanded completion and quality guidance: replan when stuck, design for change, and prefer lightweight solutions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->