### PR TITLE
fix: remove state-diff gate from pulse wrapper

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -62,6 +62,7 @@ Before executing any non-trivial task, explicitly restate: (1) the actual goal �
 - Replan when stuck, don't patch. Try a different strategy; sunk cost is not a reason to continue.
 - Build for change. Don't hardcode what should be parameterized. Design for variation.
 - Prefer lightweight approaches. Simpler tools over heavy dependencies.
+- Crash-resilient by default. Any process, session, or machine can die at any moment — power loss, OOM, network drop, stuck LLM. Every process must recover from a cold start by reading current state, not by assuming a previous step completed. Never chain processes where B depends on A having succeeded without B independently verifying A's outcome. If a process needs to know "did the last run finish?", it should check the result (does the PR exist? is the issue closed?), not rely on a flag the last run was supposed to set.
 
 # Task Management
 Use TodoWrite frequently to track tasks and show progress. Break complex tasks into smaller steps. Mark todos completed immediately — never batch completions.

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -41,8 +41,6 @@ RAM_RESERVE_MB="${RAM_RESERVE_MB:-8192}"       # 8 GB reserved for OS + user app
 MAX_WORKERS_CAP="${MAX_WORKERS_CAP:-8}"        # Hard ceiling regardless of RAM
 REPOS_JSON="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
 STATE_FILE="${HOME}/.aidevops/logs/pulse-state.txt"
-STATE_HASH_FILE="${HOME}/.aidevops/logs/pulse-state-hash.txt"
-FORCE_PULSE="${FORCE_PULSE:-false}" # Set to "true" to bypass state-diff gate
 
 #######################################
 # Ensure log directory exists
@@ -293,51 +291,6 @@ prefetch_state() {
 }
 
 #######################################
-# Check if state has changed since last pulse
-#
-# Compares a SHA-256 hash of the current state file against the
-# previous hash. If identical, there's nothing new to act on —
-# skip the LLM pulse entirely. This saves ~$0.02-0.10 per idle
-# cycle (720 cycles/day at 2-min intervals).
-#
-# Returns: 0 if state changed (pulse needed), 1 if unchanged (skip)
-#######################################
-check_state_changed() {
-	if [[ "$FORCE_PULSE" == "true" ]]; then
-		echo "[pulse-wrapper] FORCE_PULSE=true — skipping state-diff gate" >>"$LOGFILE"
-		return 0
-	fi
-
-	if [[ ! -f "$STATE_FILE" ]]; then
-		return 0
-	fi
-
-	# Hash only the repo data, not the timestamp header (line 1 changes every run)
-	local current_hash
-	current_hash=$(tail -n +2 "$STATE_FILE" | shasum -a 256 | cut -d' ' -f1)
-
-	if [[ ! -f "$STATE_HASH_FILE" ]]; then
-		# First run — no previous hash to compare
-		echo "$current_hash" >"$STATE_HASH_FILE"
-		return 0
-	fi
-
-	local previous_hash
-	previous_hash=$(cat "$STATE_HASH_FILE" 2>/dev/null || echo "")
-
-	# Save current hash for next comparison
-	echo "$current_hash" >"$STATE_HASH_FILE"
-
-	if [[ "$current_hash" == "$previous_hash" ]]; then
-		echo "[pulse-wrapper] State unchanged (hash: ${current_hash:0:12}…) — skipping LLM pulse" >>"$LOGFILE"
-		return 1
-	fi
-
-	echo "[pulse-wrapper] State changed (${previous_hash:0:12}… → ${current_hash:0:12}…) — launching pulse" >>"$LOGFILE"
-	return 0
-}
-
-#######################################
 # Run the pulse — no hard timeout
 #
 # The pulse runs until opencode exits naturally. If opencode enters its
@@ -401,12 +354,6 @@ main() {
 	cleanup_orphans
 	calculate_max_workers
 	prefetch_state
-
-	# Gate: only launch the LLM pulse if repo state actually changed
-	if ! check_state_changed; then
-		return 0
-	fi
-
 	run_pulse
 	return 0
 }


### PR DESCRIPTION
## Summary

- Removes the `check_state_changed()` function and state-hash comparison added in v2.140.0
- The gate assumed "unchanged state = nothing to do" but this is false when the previous pulse crashed or failed to act — creating a deadlock where work is visible but no pulse fires
- This is a deterministic rule encoding a judgment call, violating the Intelligence Over Determinism principle
- The LLM pulse decides whether there's work; the wrapper's job is to give it fresh state

Observed failure: duplicate issues #2476/#2477 were visible to the pulse but the pulse crashed before acting. The gate then blocked all subsequent pulses because "state unchanged."