### PR TITLE
t1353: docs: Add cross-repo task creation guidance to AGENTS.md and build.txt

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -146,6 +146,13 @@ Planning files go direct to main. Code changes need worktree + PR. Workers NEVER
 
 **Cross-repo awareness**: The supervisor manages tasks across all repos in `~/.config/aidevops/repos.json` where `pulse: true`. Each repo entry has a `slug` field (`owner/repo`) — ALWAYS use this for `gh` commands, never guess org names. Use `gh issue list --repo <slug>` and `gh pr list --repo <slug>` for each pulse-enabled repo to get the full picture. Repos with `"local_only": true` have no GitHub remote — skip `gh` operations on them. Repo paths may be nested (e.g., `~/Git/cloudron/netbird-app`), not just `~/Git/<name>`.
 
+**Cross-repo task creation**: When a session creates a task in a *different* repo (e.g., adding an aidevops TODO while working in another project), follow the full workflow — not just the TODO edit:
+
+1. **Claim the ID atomically**: Run `claim-task-id.sh --repo-path <target-repo> --title "description"`. This allocates the next ID via CAS on the counter branch and optionally creates the GitHub issue. NEVER grep TODO.md to guess the next ID — concurrent sessions will collide.
+2. **Add the TODO entry and commit+push immediately**: Planning files go direct to main. The supervisor/pulse only sees remote state, so an uncommitted TODO entry is invisible to dispatch. Push right after committing.
+3. **Create a GitHub issue for dispatch**: If `claim-task-id.sh` was run with `--no-issue`, or you added the TODO manually, create the issue separately: `gh issue create --repo <slug> --title "tNNN: description" --body "..."`. Record the issue number in TODO.md as `ref:GH#NNN`.
+4. **Code changes still need a worktree + PR**: The TODO/issue creation above is planning — it goes direct to main. If the task also involves code changes in the *current* repo, those follow the normal worktree + PR flow.
+
 Full rules: `reference/planning-detail.md`
 
 ## Git Workflow

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -168,6 +168,12 @@ Git is the primary audit trail for all work. Every change should be discoverable
 - When closing issues or merging PRs, always leave a comment linking the other side (issue -> PR, PR -> issue). A state change without explanation is an audit gap.
 - Non-git files (logs, workspace artifacts, generated configs) are ephemeral — the session and git history of the task that created them is sufficient. If a file matters enough to trace, it belongs in a git repo.
 
+**Cross-repo task creation:** When a session creates a task in a *different* repo (e.g., adding an aidevops TODO while working in another project), the full workflow must be followed — not just the TODO edit. Agents that only add a TODO line without committing, pushing, and creating an issue leave tasks invisible to dispatch and risk ID collisions.
+1. Claim the ID: `claim-task-id.sh --repo-path <target-repo> --title "description"` (CAS-based, atomic). NEVER grep TODO.md for the next ID.
+2. Commit and push the TODO immediately — planning files go direct to main, and pulse only sees remote state.
+3. Create a GitHub issue: `gh issue create --repo <slug> --title "tNNN: description"`. Record `ref:GH#NNN` in TODO.md. (If `claim-task-id.sh` already created the issue, this step is done.)
+4. Code changes in the current repo still require a worktree + PR as normal.
+
 **Git-readiness check:** When working in a project directory that is NOT a git repo, or is a git repo without `TODO.md` / aidevops initialisation, flag this to the user: "This project has no git tracking / no aidevops task management. Work here won't be traceable. Consider `git init` + `aidevops init` to enable the full workflow." Use judgment — a throwaway script directory doesn't need this, but any project with ongoing development does.
 
 **Pre-edit rules:**


### PR DESCRIPTION
## Summary

- Adds a structured 4-step "Cross-repo task creation" section to both `.agents/AGENTS.md` (user guide, Planning & Tasks) and `.agents/prompts/build.txt` (Git Workflow and Traceability)
- Covers: `claim-task-id.sh` for atomic ID allocation, immediate commit+push of TODO, `gh issue create` for dispatch visibility, and worktree+PR for code changes
- Addresses the pattern where agents add TODO entries in other repos but leave them uncommitted, skip issue creation, and risk task ID collisions

## Changes

| File | Change |
|------|--------|
| `.agents/AGENTS.md` | New "Cross-repo task creation" subsection under Planning & Tasks (+7 lines) |
| `.agents/prompts/build.txt` | New "Cross-repo task creation" paragraph under Git Workflow and Traceability (+6 lines) |

## Verification

- Markdown lint: clean (no violations)
- `claim-task-id.sh` flags verified: `--repo-path`, `--title`, `--no-issue` all exist in the script
- Content matches all 4 requirements from issue #2479

Closes #2479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated cross-repository task creation workflow with explicit four-step process for atomic ID claiming, immediate commits, and GitHub issue creation
  * Added operational checks and warnings to ensure cross-repository task traceability
  * Enhanced pre-edit validation rules and Git-readiness checks for task processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->