### PR TITLE
t1354: Guard Rosetta detection against missing file command

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,11 @@ CLEAN_MODE=false
 INTERACTIVE_MODE=false
 NON_INTERACTIVE="${AIDEVOPS_NON_INTERACTIVE:-false}"
 UPDATE_TOOLS_MODE=false
+# Platform constants (used across all setup modules)
+PLATFORM_MACOS=$([[ "$(uname -s)" == "Darwin" ]] && echo true || echo false)
+PLATFORM_LINUX=$([[ "$(uname -s)" == "Linux" ]] && echo true || echo false)
+PLATFORM_ARM64=$([[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]] && echo true || echo false)
+readonly PLATFORM_MACOS PLATFORM_LINUX PLATFORM_ARM64
 # shellcheck disable=SC2034  # Used by sourced modules (setup-modules/core.sh, agent-deploy.sh)
 REPO_URL="https://github.com/marcusquinn/aidevops.git"
 # shellcheck disable=SC2034  # Used by sourced modules (setup-modules/core.sh, agent-deploy.sh)


### PR DESCRIPTION
## Summary

- Fix `setup.sh` crash on Linux: `file` command not found (exit 127) + `grep` on empty input (exit 1)
- Add `PLATFORM_MACOS`, `PLATFORM_LINUX`, `PLATFORM_ARM64` readonly constants to `setup.sh`
- Rosetta detection now only runs on macOS arm64 when `file` is available

## Root Cause

`setup-modules/tool-install.sh:238` called `file "$sc_path"` unconditionally. On Linux systems without the `file` package, this exits 127. The subsequent `grep -oE '(x86_64)'` on the empty result exits 1. Both are fatal under `set -Eeuo pipefail` + `inherit_errexit`.

## Fix

Rosetta is macOS-only, so the entire `file`-based architecture check is guarded behind `PLATFORM_MACOS && PLATFORM_ARM64 && command -v file`. On Linux the block is skipped entirely.

Resolves #2386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ShellCheck detection on ARM64 macOS systems with Rosetta compatibility checks.
  * Added warning notification when ShellCheck is detected running under Rosetta emulation.
  * Enhanced cross-platform setup detection for improved installation reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->