### PR TITLE
t1355: Fix pulse-repos.json migration jq exit 5 error

### DIFF
--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -907,7 +907,7 @@ migrate_pulse_repos_to_repos_json() {
 				"$repos_file" >"$temp_file" && mv "$temp_file" "$repos_file"
 			((migrated++)) || true
 		fi
-	done < <(jq -r '.repos[]? | [.slug, .path, .priority] | @tsv' "$pulse_file" 2>/dev/null)
+	done < <(jq -r '(.repos? // .)[] | [.slug, .path, .priority] | @tsv' "$pulse_file" 2>/dev/null)
 
 	if [[ $migrated -gt 0 ]]; then
 		print_success "Migrated $migrated repo(s) from pulse-repos.json into repos.json"


### PR DESCRIPTION
## Summary

- Fix jq exit 5 (type error) in `migrate_pulse_repos_to_repos_json()` that printed `[ERROR] migrations.sh:867 exit 5` on every `setup.sh` run

## Root Cause

`pulse-repos.json` is a bare JSON array `[{...}, {...}]`, but the jq query used `.repos[]?` which expects `{"repos": [...]}`. When jq encounters a type mismatch (indexing an array with string "repos"), it returns exit code 5. Under `set -Eeuo pipefail` + `inherit_errexit`, this triggers the ERR trap even though `2>/dev/null` suppresses stderr.

## Fix

Changed jq query from `.repos[]?` to `(.repos? // .)[]`:
- `.repos?` — try the `.repos` key (returns null if not found, no error)
- `// .` — if null, fall back to the root element (the bare array)
- `[]` — iterate the result

This handles both formats: `{"repos": [...]}` and `[...]`.

## Verification

- Tested with bare array, object-with-repos-key, empty array, and empty object — all return exit 0
- Ran `setup.sh` from the worktree — no `[ERROR]` output
- Migration successfully added 2 repos from `pulse-repos.json` into `repos.json` and renamed the source to `.migrated`
- ShellCheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration script robustness to handle varied data structure formats, preventing potential failures when processing input with missing or differently structured data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->