### PR TITLE
fix: scope TTSR read-before-edit rule to existing files only

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1491,11 +1491,11 @@ const BUILTIN_TTSR_RULES = [
   },
   {
     id: "read-before-edit",
-    description: "Always Read a file before Edit or Write operations",
-    pattern: "(?:I'll edit|Let me edit|I'll write to|Let me write)(?:(?!I'll read|let me read|I've read|already read).){0,200}$",
-    correction: "ALWAYS Read a file before Edit/Write. These tools fail without a prior Read in this conversation.",
+    description: "Always Read a file before Edit or Write to existing files",
+    pattern: "(?:I'll edit|Let me edit|I'll write to|Let me write)(?!.*(?:creat|new file|new \\w+ file|generat))(?:(?!I'll read|let me read|I've read|already read).){0,200}$",
+    correction: "ALWAYS Read a file before Edit/Write to an existing file. These tools fail without a prior Read in this conversation. (This rule does not apply when creating new files.)",
     severity: "error",
-    systemPrompt: "ALWAYS Read a file before Edit or Write. These tools FAIL without a prior Read in this conversation.",
+    systemPrompt: "ALWAYS Read a file before Edit or Write to an existing file. These tools FAIL without a prior Read in this conversation. For NEW files, verify the parent directory exists instead.",
   },
   {
     id: "no-credentials-in-output",

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -88,7 +88,7 @@ Use TodoWrite frequently to track tasks and show progress. Break complex tasks i
 When referencing specific functions or code include the pattern `file_path:line_number` to allow the user to easily navigate to the source code location.
 
 # File Operations (CRITICAL)
-- ALWAYS Read a file before Edit or Write. These tools FAIL without a prior Read in this conversation. No exceptions.
+- ALWAYS Read a file before Edit or Write to an existing file. These tools FAIL without a prior Read in this conversation. For NEW files (creating from scratch), verify the parent directory exists instead — reading a nonexistent file is not possible.
 - After any tool modifies a file (Edit, Write, Bash), re-read before the next Edit/Write on that same file. Stale content is the #1 error source.
 - Before Read/Edit/Write, verify the path exists (`git ls-files` or `fd`). Never assume a path from memory or from AGENTS.md references — paths move between releases.
 - When using Edit, include 3+ lines of surrounding context in oldString to ensure a unique match. Never pass identical oldString and newString — this is a silent no-op that wastes a tool call.


### PR DESCRIPTION
## Summary

Fixes #2487

The `read-before-edit` TTSR rule fired false positive ERROR-level violations when creating new files via the Write tool. The Write tool itself only requires a prior Read for **existing** files, but the aidevops rule layer did not distinguish new vs. existing files.

## Changes

- **`build.txt:91`**: Replace blanket "No exceptions" with scoped guidance — Read is required before Edit/Write to an **existing** file. For new files, verify the parent directory exists instead.
- **`index.mjs:1493-1498`**: Add negative lookahead `(?!.*(?:creat|new file|new \w+ file|generat))` to the TTSR regex so it skips new file creation contexts.
- Updated `correction` and `systemPrompt` text to mention the new-file exception.

## Verification

Tested the updated regex against 13 cases:
- 7 false positive cases (new file creation) — all correctly **excluded** (no longer trigger)
- 4 true positive cases (existing file edit without read) — all correctly **detected** (still trigger)
- 2 true negative cases (edit with prior read mention) — pre-existing behavior, unchanged

## Impact

- Eliminates false ERROR-level violations on every new file creation
- Stops agents from wasting tool calls "reading" nonexistent files to satisfy the rule
- Removes confusing self-correction HTML comments injected into conversation for new files
- Aligns the rule layer with the Write tool's actual behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated file operation rules to better distinguish between editing existing files and creating new files with refined applicability conditions
  * Enhanced verification requirements: parent directory verification for new file creation and read-before-edit validation for existing file modifications
  * Improved clarity and accuracy in handling guidance across different file operation scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->