### PR TITLE
feat: add CI guard to auto-reopen persistent-labeled issues

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -61,6 +61,7 @@ Scan the pre-fetched state above. Act immediately on each item — don't build a
 
 When closing any issue, ALWAYS add a comment first explaining: (1) why you're closing it, and (2) which PR(s) delivered the work (link them: `Resolved by #N`). If the work was done before the issue existed (synced from a completed TODO), say so and link the most relevant PRs. An issue closed without a comment is an audit failure.
 
+- **`persistent` label** → NEVER close. These are long-running tracking issues (e.g., daily CodeRabbit reviews). If a PR body incorrectly references one with `Closes #N`, that's a hallucinated link — ignore it. A CI guard will auto-reopen if accidentally closed.
 - **Has a merged PR that resolves it** → comment linking the PR, then close
 - **`status:done` label or body says "completed"** → find the PR(s) that delivered the work, comment with links, then close. If no PR exists (pre-existing completed work), explain that in the comment.
 - **`status:blocked` but blockers are resolved** (merged PR exists for each `blocked-by:` ref) → remove `status:blocked`, add `status:available`, comment explaining what unblocked it. It's now dispatchable this cycle.

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
     types: [closed, opened, edited]
   issues:
-    types: [opened]
+    types: [opened, closed]
   workflow_dispatch:
     inputs:
       command:
@@ -572,3 +572,31 @@ jobs:
           fi
 
           echo "No issue reference found — this is acceptable for chore/docs PRs without tracked issues"
+
+  guard-persistent-issues:
+    name: Reopen Persistent Issues
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      issues: write
+
+    steps:
+      - name: Reopen if persistent label
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if echo "$ISSUE_LABELS" | grep -q 'persistent'; then
+            gh issue reopen "$ISSUE_NUMBER" --repo "$REPO" \
+              --comment "Auto-reopened: this issue has the \`persistent\` label and should not be closed. If closure was intentional, remove the \`persistent\` label first."
+            # Remove status:done if it was added
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --remove-label "status:done" 2>/dev/null || true
+            echo "Reopened persistent issue #$ISSUE_NUMBER"
+          else
+            echo "Issue #$ISSUE_NUMBER is not persistent — closure allowed"
+          fi


### PR DESCRIPTION
## Summary

- Adds a `guard-persistent-issues` job to `issue-sync.yml` that auto-reopens any issue with the `persistent` label when closed
- Adds guidance to `pulse.md` instructing the supervisor to never close persistent-labeled issues
- Prevents accidental closure of long-running tracking issues (e.g., #2386 Daily CodeRabbit Pulse Review) by workers hallucinating `Closes #N` references

## Changes

### `.github/workflows/issue-sync.yml`
- Added `closed` to the `issues` event trigger types
- Added `guard-persistent-issues` job that:
  - Triggers only on issue close events
  - Checks if the closed issue has the `persistent` label
  - If yes: reopens with explanatory comment, removes `status:done` label
  - If no: allows closure

### `.agents/scripts/commands/pulse.md`
- Added `persistent` label bullet to Issues triage section — NEVER close these issues

## Context

Issue #2386 (Daily CodeRabbit Pulse Review) was repeatedly closed by:
1. Workers adding `Resolves #2386` to PR bodies (hallucinated reference)
2. Issue-sync jobs marking it as done

The `persistent` label + CI guard provides defense-in-depth: the pulse agent is instructed not to close them, and if anything does close them, CI auto-reopens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persistent issue protection: Issues labeled as persistent are now protected from accidental closure. If closed, they automatically reopen, ensuring long-running tracking issues remain active.
  * Pull requests attempting to close persistent issues will have their close directives ignored, with automated guards preventing unintended closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->