### PR TITLE
fix: skip .gitignore modification for repos with tracked .agents/ directory

### DIFF
--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -243,8 +243,15 @@ migrate_agent_to_agents_folder() {
 			fi
 
 			# Update .gitignore: add .agents, keep .agent for backward compat
+			# Skip repos where .agents/ is a git-tracked directory (e.g., the aidevops
+			# source repo itself). Adding bare ".agents" to .gitignore there would hide
+			# the entire framework directory from git.
 			local gitignore="$repo_path/.gitignore"
-			if [[ -f "$gitignore" ]]; then
+			local is_tracked_dir=false
+			if [[ -n "$(git -C "$repo_path" ls-files .agents/ 2>/dev/null | head -1)" ]]; then
+				is_tracked_dir=true
+			fi
+			if [[ -f "$gitignore" ]] && [[ "$is_tracked_dir" == "false" ]]; then
 				# Add .agents entry if not present
 				if ! grep -q "^\.agents$" "$gitignore" 2>/dev/null; then
 					# Replace .agent with .agents if it exists


### PR DESCRIPTION
## Summary

- Fixes recurring bug where `setup.sh` migrations append bare `.agents` to `.gitignore` in the aidevops source repo, which would hide the entire framework directory from git
- Root cause: `migrate_agent_to_agents_folder()` in `setup-modules/migrations.sh` iterates all repos in `repos.json` and adds `.agents` to `.gitignore` — correct for user projects (where `.agents/` is a symlink to ignore) but destructive for the aidevops repo itself (where `.agents/` is a tracked directory)
- Fix: check if `.agents/` contains git-tracked files before modifying `.gitignore`; skip if it does

## Root Cause

`setup-modules/migrations.sh:255` — the migration runs on every repo in `repos.json`, including the aidevops source repo. Since the aidevops `.gitignore` doesn't have a bare `.agents` line (it has specific subdirectory patterns like `.agents/scripts-private/`, `.agents/tmp/*`), the `grep -q "^\.agents$"` check returns false, and `echo ".agents" >> .gitignore` fires.

This has been causing recurring dirty `.gitignore` state that blocks `version-manager.sh release`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed migration script to prevent unintended modifications to .gitignore in repositories where the agents folder is already tracked by version control, improving migration safety and avoiding configuration conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->