### PR TITLE
t1357.5: Integrate mission awareness into pulse supervisor

### DIFF
--- a/.agents/templates/mission-template.md
+++ b/.agents/templates/mission-template.md
@@ -67,6 +67,8 @@ preferences:
 
 Milestones are sequential. Features within each milestone are parallelisable.
 
+**TODO integration (Full mode):** Each feature becomes a TODO entry tagged `mission:{id}` (e.g., `mission:m001`). This tag lets the pulse supervisor correlate features back to their mission. Example TODO format: `- [ ] t042 Implement user auth #mission:m001 ~3h`
+
 ### Milestone 1: {Name}
 
 **Status:** pending  <!-- pending | active | validating | passed | failed | skipped -->

--- a/.agents/workflows/mission-orchestrator.md
+++ b/.agents/workflows/mission-orchestrator.md
@@ -35,6 +35,8 @@ tools:
 
 **Lifecycle**: `/mission` creates the state file (planning) -> orchestrator drives execution (active) -> milestone validation -> completion or re-plan
 
+**Pulse integration**: The pulse supervisor (`scripts/commands/pulse.md` Step 3.5) automatically detects active missions via `pulse-wrapper.sh` prefetch. It handles lightweight operations: dispatching pending features, detecting milestone completion, advancing milestones, and tracking budget. The orchestrator handles heavyweight operations: re-planning on failure, validation design, and research. In Full mode, mission features are regular TODO entries tagged `mission:{id}` (e.g., `mission:m001`) so they flow through the standard issue/PR pipeline.
+
 **Self-organisation principle**: The orchestrator creates what it needs (folders, agents, scripts) as it discovers needs — not upfront. Every created artifact is temporary (draft tier) unless promoted.
 
 <!-- AI-CONTEXT-END -->


### PR DESCRIPTION
## Summary

- Add "check active missions" phase (Step 3.5) to the pulse supervisor cycle
- `pulse-wrapper.sh` now prefetches active mission state from `todo/missions/` and `~/.aidevops/missions/`, extracting milestone/feature summaries into the pre-fetched state
- `pulse.md` Step 3.5 guides the pulse agent to: dispatch pending features, detect milestone completion, trigger validation workers, advance milestones, track budget spend, and handle paused/blocked missions
- Mission features become regular TODO entries tagged `mission:mNNN` (Full mode) or are dispatched directly from the state file (POC mode)

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/pulse-wrapper.sh` | `prefetch_missions()`, `_extract_frontmatter_field()`, `_extract_milestone_summary()` — scan for active missions and include compact state in prefetch |
| `.agents/scripts/commands/pulse.md` | Step 3.5 Mission Awareness section, updated priority order (mission features at #4), updated job-done definition |
| `.agents/templates/mission-template.md` | Document `mission:{id}` tag convention for TODO entries |
| `.agents/workflows/mission-orchestrator.md` | Document pulse integration relationship |

## Verification

- ShellCheck: zero new violations on `pulse-wrapper.sh`
- Markdown lint: all 3 modified `.md` files pass with no issues
- Backward compatible: no missions = no "Active Missions" section in prefetch = Step 3.5 is skipped entirely

Closes #2499