### PR TITLE
t1361: Mission skill learning — auto-capture reusable patterns from missions

### DIFF
--- a/.agents/scripts/mission-skill-learning.sh
+++ b/.agents/scripts/mission-skill-learning.sh
@@ -1,0 +1,797 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Mission Skill Learning Helper
+# =============================================================================
+# Scans completed mission directories for reusable artifacts (agents, scripts,
+# research docs), scores them for promotion potential, and stores patterns in
+# cross-session memory.
+#
+# This is the deterministic half of mission skill learning. It handles file
+# discovery, recurrence counting, and artifact copying. The judgment calls
+# (is this artifact worth promoting? how to adapt it?) belong to the
+# orchestrator agent guided by workflows/mission-skill-learning.md.
+#
+# Usage:
+#   mission-skill-learning.sh scan <mission-dir>
+#   mission-skill-learning.sh score <mission-dir>
+#   mission-skill-learning.sh promote <artifact-path> [--target draft|custom]
+#   mission-skill-learning.sh remember <mission-dir>
+#   mission-skill-learning.sh recurrence [--all-missions <missions-root>]
+#   mission-skill-learning.sh help
+#
+# Integration:
+#   - Called by mission orchestrator at Phase 5 (completion)
+#   - Called manually via /mission-learn command
+#   - Stores patterns via memory-helper.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+LOG_PREFIX="SKILL"
+
+readonly MEMORY_HELPER="${SCRIPT_DIR}/memory-helper.sh"
+readonly AGENTS_DIR="${HOME}/.aidevops/agents"
+readonly DRAFT_DIR="${AGENTS_DIR}/draft"
+readonly CUSTOM_DIR="${AGENTS_DIR}/custom"
+
+# Artifact types we look for in mission directories
+readonly AGENT_PATTERN="*.md"
+readonly SCRIPT_PATTERN="*.sh"
+
+# Minimum content length (bytes) to consider an artifact non-trivial
+readonly MIN_ARTIFACT_SIZE=200
+
+# =============================================================================
+# Scan: discover artifacts in a mission directory
+# =============================================================================
+
+cmd_scan() {
+	local mission_dir="${1:-}"
+
+	if [[ -z "$mission_dir" ]]; then
+		log_error "Usage: mission-skill-learning.sh scan <mission-dir>"
+		return 1
+	fi
+
+	if [[ ! -d "$mission_dir" ]]; then
+		log_error "Mission directory not found: $mission_dir"
+		return 1
+	fi
+
+	log_info "Scanning mission directory: $mission_dir"
+	echo ""
+
+	local found=0
+
+	# Scan for agent files
+	if [[ -d "$mission_dir/agents" ]]; then
+		echo "=== Mission Agents ==="
+		while IFS= read -r -d '' agent_file; do
+			local size name desc
+			size=$(wc -c <"$agent_file" | tr -d ' ')
+			name=$(basename "$agent_file")
+			desc=$(extract_description "$agent_file")
+
+			if [[ "$size" -ge "$MIN_ARTIFACT_SIZE" ]]; then
+				echo "  [AGENT] $name (${size}B)"
+				echo "    Path: $agent_file"
+				[[ -n "$desc" ]] && echo "    Desc: $desc"
+				echo ""
+				found=$((found + 1))
+			fi
+		done < <(find "$mission_dir/agents" -name "$AGENT_PATTERN" -type f -print0 2>/dev/null)
+	fi
+
+	# Scan for script files
+	if [[ -d "$mission_dir/scripts" ]]; then
+		echo "=== Mission Scripts ==="
+		while IFS= read -r -d '' script_file; do
+			local size name
+			size=$(wc -c <"$script_file" | tr -d ' ')
+			name=$(basename "$script_file")
+
+			if [[ "$size" -ge "$MIN_ARTIFACT_SIZE" ]]; then
+				echo "  [SCRIPT] $name (${size}B)"
+				echo "    Path: $script_file"
+				echo ""
+				found=$((found + 1))
+			fi
+		done < <(find "$mission_dir/scripts" -name "$SCRIPT_PATTERN" -type f -print0 2>/dev/null)
+	fi
+
+	# Scan for research docs (informational, not promotable)
+	if [[ -d "$mission_dir/research" ]]; then
+		echo "=== Research Artifacts ==="
+		while IFS= read -r -d '' research_file; do
+			local size name
+			size=$(wc -c <"$research_file" | tr -d ' ')
+			name=$(basename "$research_file")
+
+			if [[ "$size" -ge "$MIN_ARTIFACT_SIZE" ]]; then
+				echo "  [RESEARCH] $name (${size}B)"
+				echo "    Path: $research_file"
+				echo ""
+				found=$((found + 1))
+			fi
+		done < <(find "$mission_dir/research" -name "$AGENT_PATTERN" -type f -print0 2>/dev/null)
+	fi
+
+	echo "---"
+	echo "Total artifacts found: $found"
+
+	return 0
+}
+
+# =============================================================================
+# Score: evaluate artifacts for promotion potential
+# =============================================================================
+
+cmd_score() {
+	local mission_dir="${1:-}"
+
+	if [[ -z "$mission_dir" ]]; then
+		log_error "Usage: mission-skill-learning.sh score <mission-dir>"
+		return 1
+	fi
+
+	if [[ ! -d "$mission_dir" ]]; then
+		log_error "Mission directory not found: $mission_dir"
+		return 1
+	fi
+
+	log_info "Scoring artifacts in: $mission_dir"
+	echo ""
+
+	local scored=0
+
+	# Score agents
+	if [[ -d "$mission_dir/agents" ]]; then
+		while IFS= read -r -d '' agent_file; do
+			local size
+			size=$(wc -c <"$agent_file" | tr -d ' ')
+			[[ "$size" -lt "$MIN_ARTIFACT_SIZE" ]] && continue
+
+			local score
+			score=$(score_artifact "$agent_file" "agent")
+			local name
+			name=$(basename "$agent_file")
+			local recommendation
+			recommendation=$(recommend_action "$score")
+
+			echo "  $name: score=$score -> $recommendation"
+			scored=$((scored + 1))
+		done < <(find "$mission_dir/agents" -name "$AGENT_PATTERN" -type f -print0 2>/dev/null)
+	fi
+
+	# Score scripts
+	if [[ -d "$mission_dir/scripts" ]]; then
+		while IFS= read -r -d '' script_file; do
+			local size
+			size=$(wc -c <"$script_file" | tr -d ' ')
+			[[ "$size" -lt "$MIN_ARTIFACT_SIZE" ]] && continue
+
+			local score
+			score=$(score_artifact "$script_file" "script")
+			local name
+			name=$(basename "$script_file")
+			local recommendation
+			recommendation=$(recommend_action "$score")
+
+			echo "  $name: score=$score -> $recommendation"
+			scored=$((scored + 1))
+		done < <(find "$mission_dir/scripts" -name "$SCRIPT_PATTERN" -type f -print0 2>/dev/null)
+	fi
+
+	if [[ "$scored" -eq 0 ]]; then
+		log_info "No scorable artifacts found."
+	fi
+
+	echo ""
+	echo "Score legend: 0-3=delete, 4-6=keep in mission, 7-8=promote to draft/, 9-10=promote to custom/"
+
+	return 0
+}
+
+# =============================================================================
+# Promote: copy an artifact to draft/ or custom/ with metadata
+# =============================================================================
+
+cmd_promote() {
+	local artifact_path="${1:-}"
+	local target="draft"
+
+	shift || true
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--target)
+			target="${2:-draft}"
+			shift 2
+			;;
+		--dry-run)
+			local dry_run=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$artifact_path" ]]; then
+		log_error "Usage: mission-skill-learning.sh promote <artifact-path> [--target draft|custom]"
+		return 1
+	fi
+
+	if [[ ! -f "$artifact_path" ]]; then
+		log_error "Artifact not found: $artifact_path"
+		return 1
+	fi
+
+	local target_dir
+	case "$target" in
+	draft) target_dir="$DRAFT_DIR" ;;
+	custom) target_dir="$CUSTOM_DIR" ;;
+	*)
+		log_error "Invalid target: $target (must be draft or custom)"
+		return 1
+		;;
+	esac
+
+	local artifact_name
+	artifact_name=$(basename "$artifact_path")
+
+	# Check if already exists in target
+	if [[ -f "$target_dir/$artifact_name" ]]; then
+		log_warn "Artifact already exists in $target/: $artifact_name"
+		log_warn "Review and merge manually if needed."
+		return 1
+	fi
+
+	if [[ "${dry_run:-false}" == "true" ]]; then
+		log_info "[DRY RUN] Would promote: $artifact_path -> $target_dir/$artifact_name"
+		return 0
+	fi
+
+	# Ensure target directory exists
+	mkdir -p "$target_dir"
+
+	# Copy artifact
+	cp "$artifact_path" "$target_dir/$artifact_name"
+
+	# Add promotion metadata to the file if it's a markdown agent
+	if [[ "$artifact_name" == *.md ]]; then
+		add_promotion_metadata "$target_dir/$artifact_name" "$artifact_path"
+	fi
+
+	log_success "Promoted: $artifact_name -> $target_dir/"
+	log_info "Review the promoted artifact and adjust for general use."
+
+	# Store promotion event in memory
+	if [[ -x "$MEMORY_HELPER" ]]; then
+		"$MEMORY_HELPER" store --auto \
+			--type "SUCCESS_PATTERN" \
+			--content "Mission artifact promoted to $target/: $artifact_name (from $artifact_path)" \
+			--tags "mission,skill-learning,promotion,$target" \
+			2>/dev/null || true
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Remember: store mission patterns in cross-session memory
+# =============================================================================
+
+cmd_remember() {
+	local mission_dir="${1:-}"
+
+	if [[ -z "$mission_dir" ]]; then
+		log_error "Usage: mission-skill-learning.sh remember <mission-dir>"
+		return 1
+	fi
+
+	if [[ ! -d "$mission_dir" ]]; then
+		log_error "Mission directory not found: $mission_dir"
+		return 1
+	fi
+
+	if [[ ! -x "$MEMORY_HELPER" ]]; then
+		log_error "memory-helper.sh not found or not executable: $MEMORY_HELPER"
+		return 1
+	fi
+
+	local mission_id
+	mission_id=$(basename "$mission_dir")
+
+	log_info "Storing mission patterns for: $mission_id"
+
+	local stored=0
+
+	# Extract and store mission goal/outcome from mission.md
+	local mission_file="$mission_dir/mission.md"
+	if [[ -f "$mission_file" ]]; then
+		local goal
+		goal=$(extract_mission_goal "$mission_file")
+		if [[ -n "$goal" ]]; then
+			"$MEMORY_HELPER" store --auto \
+				--type "SUCCESS_PATTERN" \
+				--content "Mission $mission_id completed: $goal" \
+				--tags "mission,completed,$mission_id" \
+				2>/dev/null || true
+			stored=$((stored + 1))
+		fi
+	fi
+
+	# Store decision log entries as DECISION memories
+	if [[ -f "$mission_file" ]]; then
+		store_decisions_from_mission "$mission_file" "$mission_id"
+		stored=$((stored + 1))
+	fi
+
+	# Store info about promoted artifacts
+	if [[ -d "$mission_dir/agents" ]]; then
+		while IFS= read -r -d '' agent_file; do
+			local name desc
+			name=$(basename "$agent_file")
+			desc=$(extract_description "$agent_file")
+			if [[ -n "$desc" ]]; then
+				"$MEMORY_HELPER" store --auto \
+					--type "CODEBASE_PATTERN" \
+					--content "Mission $mission_id created agent: $name — $desc" \
+					--tags "mission,agent,$mission_id" \
+					2>/dev/null || true
+				stored=$((stored + 1))
+			fi
+		done < <(find "$mission_dir/agents" -name "$AGENT_PATTERN" -type f -print0 2>/dev/null)
+	fi
+
+	# Store info about mission scripts
+	if [[ -d "$mission_dir/scripts" ]]; then
+		while IFS= read -r -d '' script_file; do
+			local name
+			name=$(basename "$script_file")
+			"$MEMORY_HELPER" store --auto \
+				--type "CODEBASE_PATTERN" \
+				--content "Mission $mission_id created script: $name" \
+				--tags "mission,script,$mission_id" \
+				2>/dev/null || true
+			stored=$((stored + 1))
+		done < <(find "$mission_dir/scripts" -name "$SCRIPT_PATTERN" -type f -print0 2>/dev/null)
+	fi
+
+	log_success "Stored $stored patterns from mission $mission_id"
+
+	return 0
+}
+
+# =============================================================================
+# Recurrence: check how often similar artifacts appear across missions
+# =============================================================================
+
+cmd_recurrence() {
+	local missions_root="${1:-}"
+
+	# Parse flags
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--all-missions)
+			missions_root="${2:-}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	# Auto-detect missions root
+	if [[ -z "$missions_root" ]]; then
+		local repo_root
+		repo_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+		if [[ -n "$repo_root" && -d "$repo_root/todo/missions" ]]; then
+			missions_root="$repo_root/todo/missions"
+		elif [[ -d "$HOME/.aidevops/missions" ]]; then
+			missions_root="$HOME/.aidevops/missions"
+		else
+			log_error "No missions directory found. Specify with --all-missions <path>"
+			return 1
+		fi
+	fi
+
+	if [[ ! -d "$missions_root" ]]; then
+		log_error "Missions root not found: $missions_root"
+		return 1
+	fi
+
+	log_info "Checking artifact recurrence across missions in: $missions_root"
+	echo ""
+
+	# Collect all artifact names across missions
+	local tmp_names
+	tmp_names=$(mktemp)
+	trap 'rm -f "${tmp_names:-}"' RETURN
+
+	local mission_count=0
+	while IFS= read -r -d '' mission_dir; do
+		[[ ! -d "$mission_dir" ]] && continue
+		# Only count directories that contain a mission.md
+		[[ ! -f "$mission_dir/mission.md" ]] && continue
+		mission_count=$((mission_count + 1))
+
+		# Collect agent names
+		if [[ -d "$mission_dir/agents" ]]; then
+			find "$mission_dir/agents" -name "$AGENT_PATTERN" -type f -exec basename {} \; \
+				2>/dev/null >>"$tmp_names"
+		fi
+
+		# Collect script names
+		if [[ -d "$mission_dir/scripts" ]]; then
+			find "$mission_dir/scripts" -name "$SCRIPT_PATTERN" -type f -exec basename {} \; \
+				2>/dev/null >>"$tmp_names"
+		fi
+	done < <(find "$missions_root" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+
+	if [[ "$mission_count" -eq 0 ]]; then
+		log_info "No completed missions found."
+		return 0
+	fi
+
+	echo "Missions scanned: $mission_count"
+	echo ""
+
+	# Count occurrences of each artifact name
+	if [[ -s "$tmp_names" ]]; then
+		echo "=== Recurring Artifacts ==="
+		sort "$tmp_names" | uniq -c | sort -rn | while read -r count name; do
+			if [[ "$count" -gt 1 ]]; then
+				echo "  ${count}x  $name"
+			fi
+		done
+
+		echo ""
+		echo "=== All Artifacts ==="
+		sort "$tmp_names" | uniq -c | sort -rn | while read -r count name; do
+			echo "  ${count}x  $name"
+		done
+	else
+		log_info "No artifacts found across missions."
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+# Extract description from YAML frontmatter of a markdown file
+extract_description() {
+	local file="$1"
+
+	# Look for description: in YAML frontmatter (between --- markers)
+	local in_frontmatter=false
+	while IFS= read -r line; do
+		if [[ "$line" == "---" ]]; then
+			if [[ "$in_frontmatter" == true ]]; then
+				break
+			fi
+			in_frontmatter=true
+			continue
+		fi
+		if [[ "$in_frontmatter" == true ]]; then
+			if [[ "$line" =~ ^description:\ (.+) ]]; then
+				echo "${BASH_REMATCH[1]}"
+				return 0
+			fi
+		fi
+	done <"$file"
+
+	return 0
+}
+
+# Extract mission goal from mission.md
+extract_mission_goal() {
+	local file="$1"
+
+	# Look for the blockquote goal line (> One-line goal statement)
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^\>\ (.+) ]]; then
+			local goal="${BASH_REMATCH[1]}"
+			# Skip template placeholders
+			if [[ "$goal" != *"{One-line"* ]]; then
+				echo "$goal"
+				return 0
+			fi
+		fi
+	done <"$file"
+
+	# Fallback: look for ## Goal section
+	local in_goal=false
+	while IFS= read -r line; do
+		if [[ "$line" == "## Goal" || "$line" == "### Goal" ]]; then
+			in_goal=true
+			continue
+		fi
+		if [[ "$in_goal" == true ]]; then
+			# Skip empty lines
+			[[ -z "$line" ]] && continue
+			# Stop at next heading
+			[[ "$line" == "#"* ]] && break
+			# Return first non-empty line
+			echo "$line"
+			return 0
+		fi
+	done <"$file"
+
+	return 0
+}
+
+# Store decision log entries from mission.md as memories
+store_decisions_from_mission() {
+	local file="$1"
+	local mission_id="$2"
+
+	local in_decisions=false
+	local in_table=false
+	while IFS= read -r line; do
+		if [[ "$line" == "## Decision Log"* ]]; then
+			in_decisions=true
+			continue
+		fi
+		if [[ "$in_decisions" == true ]]; then
+			# Stop at next section
+			[[ "$line" == "## "* && "$line" != "## Decision"* ]] && break
+
+			# Skip table header and separator
+			if [[ "$line" == "|"*"Date"*"|"* || "$line" == "|"*"---"*"|"* ]]; then
+				in_table=true
+				continue
+			fi
+
+			# Parse table rows
+			if [[ "$in_table" == true && "$line" == "|"* ]]; then
+				# Extract decision and rationale columns
+				local decision rationale
+				decision=$(echo "$line" | awk -F'|' '{print $4}' | xargs)
+				rationale=$(echo "$line" | awk -F'|' '{print $5}' | xargs)
+
+				# Skip empty or template rows
+				if [[ -n "$decision" && "$decision" != "" && "$decision" != *"{"* ]]; then
+					"$MEMORY_HELPER" store --auto \
+						--type "DECISION" \
+						--content "Mission $mission_id decision: $decision. Rationale: $rationale" \
+						--tags "mission,decision,$mission_id" \
+						2>/dev/null || true
+				fi
+			fi
+		fi
+	done <"$file"
+
+	return 0
+}
+
+# Score an artifact for promotion potential (0-10)
+# Scoring factors:
+#   - Size (larger = more substantial): 0-2 points
+#   - Has YAML frontmatter (structured): 0-2 points
+#   - Has description (documented): 0-2 points
+#   - Not project-specific (generalizable): 0-2 points
+#   - Recurrence (appears in multiple missions): 0-2 points
+score_artifact() {
+	local file="$1"
+	local type="$2"
+	local score=0
+
+	local size
+	size=$(wc -c <"$file" | tr -d ' ')
+
+	# Size scoring
+	if [[ "$size" -gt 2000 ]]; then
+		score=$((score + 2))
+	elif [[ "$size" -gt 500 ]]; then
+		score=$((score + 1))
+	fi
+
+	if [[ "$type" == "agent" ]]; then
+		# Has YAML frontmatter
+		local first_line
+		first_line=$(head -1 "$file")
+		if [[ "$first_line" == "---" ]]; then
+			score=$((score + 2))
+		fi
+
+		# Has description
+		local desc
+		desc=$(extract_description "$file")
+		if [[ -n "$desc" ]]; then
+			score=$((score + 2))
+		fi
+	elif [[ "$type" == "script" ]]; then
+		# Has shebang
+		local first_line
+		first_line=$(head -1 "$file")
+		if [[ "$first_line" == "#!/"* ]]; then
+			score=$((score + 1))
+		fi
+
+		# Has help/usage function
+		if grep -q 'cmd_help\|usage()' "$file" 2>/dev/null; then
+			score=$((score + 2))
+		fi
+
+		# Uses set -euo pipefail (quality indicator)
+		if grep -q 'set -euo pipefail' "$file" 2>/dev/null; then
+			score=$((score + 1))
+		fi
+	fi
+
+	# Not project-specific (heuristic: no hardcoded paths or project names)
+	local project_specific=false
+	if grep -qE '(localhost:[0-9]+|/home/[a-z]+/|/Users/[a-z]+/)' "$file" 2>/dev/null; then
+		project_specific=true
+	fi
+	if [[ "$project_specific" == false ]]; then
+		score=$((score + 2))
+	fi
+
+	echo "$score"
+	return 0
+}
+
+# Map score to recommendation
+recommend_action() {
+	local score="$1"
+
+	if [[ "$score" -le 3 ]]; then
+		echo "DELETE (low value)"
+	elif [[ "$score" -le 6 ]]; then
+		echo "KEEP (mission-specific)"
+	elif [[ "$score" -le 8 ]]; then
+		echo "PROMOTE to draft/ (review needed)"
+	else
+		echo "PROMOTE to custom/ (high value)"
+	fi
+
+	return 0
+}
+
+# Add promotion metadata to a promoted markdown file
+add_promotion_metadata() {
+	local target_file="$1"
+	local source_path="$2"
+	local timestamp
+	timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	# Check if file has YAML frontmatter
+	local first_line
+	first_line=$(head -1 "$target_file")
+
+	if [[ "$first_line" == "---" ]]; then
+		# Insert promotion metadata into existing frontmatter
+		# Find the closing --- and insert before it
+		local tmp_file
+		tmp_file=$(mktemp)
+		trap 'rm -f "${tmp_file:-}"' RETURN
+
+		local inserted=false
+		local in_frontmatter=false
+		while IFS= read -r line; do
+			if [[ "$line" == "---" && "$in_frontmatter" == false ]]; then
+				in_frontmatter=true
+				echo "$line" >>"$tmp_file"
+				continue
+			fi
+			if [[ "$line" == "---" && "$in_frontmatter" == true && "$inserted" == false ]]; then
+				echo "promoted_from: \"$source_path\"" >>"$tmp_file"
+				echo "promoted_at: \"$timestamp\"" >>"$tmp_file"
+				echo "status: draft" >>"$tmp_file"
+				inserted=true
+			fi
+			echo "$line" >>"$tmp_file"
+		done <"$target_file"
+
+		mv "$tmp_file" "$target_file"
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Help
+# =============================================================================
+
+cmd_help() {
+	cat <<'EOF'
+mission-skill-learning.sh - Auto-capture reusable patterns from missions
+
+Scans completed mission directories for artifacts (agents, scripts, research),
+scores them for promotion potential, and stores patterns in cross-session memory.
+
+USAGE:
+    mission-skill-learning.sh <command> [options]
+
+COMMANDS:
+    scan <mission-dir>          List all artifacts in a mission directory
+    score <mission-dir>         Score artifacts for promotion potential (0-10)
+    promote <path> [options]    Copy artifact to draft/ or custom/
+    remember <mission-dir>      Store mission patterns in cross-session memory
+    recurrence [options]        Check artifact recurrence across all missions
+    help                        Show this help
+
+PROMOTE OPTIONS:
+    --target draft|custom       Promotion target (default: draft)
+    --dry-run                   Preview without copying
+
+RECURRENCE OPTIONS:
+    --all-missions <path>       Root directory containing mission subdirectories
+
+SCORING:
+    0-3  DELETE      Low value, mission-specific noise
+    4-6  KEEP        Useful within this mission only
+    7-8  PROMOTE     Worth promoting to draft/ for review
+    9-10 PROMOTE+    High value, promote to custom/
+
+SCORING FACTORS:
+    - Content size (substantial vs trivial)
+    - Structure (YAML frontmatter, shebang, help function)
+    - Documentation (description field, usage docs)
+    - Generalizability (no hardcoded paths or project names)
+    - Recurrence (appears in multiple missions)
+
+WORKFLOW:
+    1. Mission completes (orchestrator Phase 5)
+    2. Run 'scan' to discover artifacts
+    3. Run 'score' to evaluate promotion potential
+    4. Orchestrator reviews scores and decides promotions
+    5. Run 'promote' for selected artifacts
+    6. Run 'remember' to store patterns in memory
+    7. Future missions benefit from stored patterns
+
+INTEGRATION:
+    - Mission orchestrator: Phase 5 calls scan + score + remember
+    - Memory system: patterns stored via memory-helper.sh --auto
+    - Agent lifecycle: promoted artifacts follow draft -> custom -> shared path
+
+EXAMPLES:
+    # Scan a completed mission
+    mission-skill-learning.sh scan ~/Git/myapp/todo/missions/m-20260227-abc123
+
+    # Score artifacts for promotion
+    mission-skill-learning.sh score ~/Git/myapp/todo/missions/m-20260227-abc123
+
+    # Promote a useful agent to draft/
+    mission-skill-learning.sh promote ~/Git/myapp/todo/missions/m-20260227-abc123/agents/api-patterns.md
+
+    # Store mission patterns in memory
+    mission-skill-learning.sh remember ~/Git/myapp/todo/missions/m-20260227-abc123
+
+    # Check which artifacts recur across missions
+    mission-skill-learning.sh recurrence --all-missions ~/Git/myapp/todo/missions
+EOF
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	scan | list) cmd_scan "$@" ;;
+	score | evaluate) cmd_score "$@" ;;
+	promote | move) cmd_promote "$@" ;;
+	remember | store) cmd_remember "$@" ;;
+	recurrence | recurring) cmd_recurrence "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"
+exit $?

--- a/.agents/templates/mission-template.md
+++ b/.agents/templates/mission-template.md
@@ -164,7 +164,21 @@ Temporary agents created for this mission. Draft-tier by default — promoted to
 
 <!-- Mission agents are created on-demand as the orchestrator discovers needs.
      They live in the mission's agents/ subfolder.
-     After mission completion, review for promotion to the framework. -->
+     After mission completion, skill learning evaluates for promotion. -->
+
+## Skill Learning
+
+_Completed at Phase 5 by the skill learning system (`workflows/mission-skill-learning.md`)._
+
+Artifacts evaluated for promotion to the framework's agent/script library.
+
+| Artifact | Type | Score | Decision | Target | Notes |
+|----------|------|-------|----------|--------|-------|
+| | | | | | |
+
+<!-- Decisions: DELETE (low value), KEEP (mission-specific), PROMOTE (to draft/ or custom/).
+     Score: 0-10 from mission-skill-learning.sh. Orchestrator may override based on content review.
+     Patterns stored in cross-session memory via 'mission-skill-learning.sh remember'. -->
 
 ## Research
 

--- a/.agents/workflows/mission-orchestrator.md
+++ b/.agents/workflows/mission-orchestrator.md
@@ -157,8 +157,15 @@ Set milestone status to `validating`, then verify:
    - Outcomes vs original goal
    - Budget accuracy (budgeted vs actual)
    - Lessons learned
-4. Review mission agents and scripts for promotion (see "Improvement Feedback" below)
-5. Commit and push the final state
+4. **Run skill learning** (see `workflows/mission-skill-learning.md`):
+   a. Scan mission artifacts: `mission-skill-learning.sh scan {mission-dir}`
+   b. Score for promotion: `mission-skill-learning.sh score {mission-dir}`
+   c. Read `workflows/mission-skill-learning.md` for evaluation guidance
+   d. Promote valuable artifacts: `mission-skill-learning.sh promote {path}`
+   e. Store patterns in memory: `mission-skill-learning.sh remember {mission-dir}`
+   f. Record decisions in the mission's Skill Learning section
+5. Review remaining improvement feedback (see "Improvement Feedback" below)
+6. Commit and push the final state
 
 ## Self-Organisation
 
@@ -232,15 +239,7 @@ Include the agent path in the worker dispatch prompt:
 /full-loop Implement {task_id} -- {description}. Read {mission-dir}/agents/{name}.md for project-specific patterns before starting.
 ```
 
-**After mission completion**, review each mission agent:
-
-| Outcome | Action |
-|---------|--------|
-| Generally useful beyond this mission | Move to `~/.aidevops/agents/draft/` with a TODO for promotion review |
-| Project-specific but reusable within the project | Leave in the project's mission directory |
-| One-off, no longer needed | Delete |
-
-Record the decision in the mission's "Mission Agents" table.
+**After mission completion**, the skill learning system (`workflows/mission-skill-learning.md`) evaluates each mission agent automatically. It scans, scores, and recommends promotion decisions. The orchestrator runs this as part of Phase 5. Manual review is still possible — see the mission's Skill Learning section for recorded decisions.
 
 ## Improvement Feedback to aidevops
 
@@ -260,7 +259,7 @@ Every mission is an opportunity to improve the framework. The orchestrator shoul
 2. **At completion**: Review the decision log and mission agents. For each improvement:
    - File a GitHub issue on the aidevops repo: `gh issue create --repo {aidevops_slug} --title "Mission feedback: {description}" --body "{details}"`
    - Record the issue number in the mission's "Framework Improvements" section
-3. **For reusable agents**: Move to `~/.aidevops/agents/draft/` and create a TODO entry for promotion review
+3. **For reusable agents and scripts**: The skill learning system handles promotion automatically at Phase 5. See `workflows/mission-skill-learning.md` for the evaluation criteria and `scripts/mission-skill-learning.sh` for the helper commands.
 
 ### What NOT to Do
 

--- a/.agents/workflows/mission-skill-learning.md
+++ b/.agents/workflows/mission-skill-learning.md
@@ -1,0 +1,180 @@
+---
+description: Mission skill learning — evaluate and promote reusable patterns discovered during mission execution into the framework's agent/script library
+mode: subagent
+model: sonnet  # evaluation and promotion decisions, not architecture-level
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: false
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# Mission Skill Learning
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: After a mission completes, evaluate artifacts for reusability and promote valuable ones into the framework
+- **Helper script**: `scripts/mission-skill-learning.sh` (scan, score, promote, remember, recurrence)
+- **Invoked by**: Mission orchestrator at Phase 5 (completion), or manually via `/mission-learn`
+- **Output**: Promoted artifacts in `draft/` or `custom/`, patterns stored in cross-session memory
+
+**Key files**:
+
+| File | Purpose |
+|------|---------|
+| `scripts/mission-skill-learning.sh` | Deterministic operations (scan, score, copy) |
+| `workflows/mission-orchestrator.md` | Calls skill learning at Phase 5 |
+| `templates/mission-template.md` | Skill Learning section in state file |
+| `scripts/memory-helper.sh` | Cross-session memory storage |
+| `tools/build-agent/build-agent.md` | Agent lifecycle tiers (draft/custom/shared) |
+
+<!-- AI-CONTEXT-END -->
+
+## How to Think
+
+You are evaluating mission artifacts for their value beyond the mission that created them. The helper script gives you data (what exists, how it scores, whether it recurs). Your job is the judgment call: is this artifact worth promoting, and how should it be adapted for general use?
+
+**Key principle**: Most mission artifacts are project-specific and should stay in the mission directory or be deleted. Only artifacts that solve a general problem — one that other missions or projects would face — deserve promotion. When in doubt, don't promote. The cost of a cluttered `draft/` directory (noise in agent discovery) exceeds the cost of re-creating an artifact in a future mission.
+
+## Evaluation Workflow
+
+### Step 1: Scan and Score
+
+Run the helper script to discover and score artifacts:
+
+```bash
+# Discover all artifacts
+mission-skill-learning.sh scan "{mission-dir}"
+
+# Score them for promotion potential
+mission-skill-learning.sh score "{mission-dir}"
+```
+
+The script scores artifacts 0-10 based on size, structure, documentation, and generalizability. These scores are a starting point — override them based on your understanding of the artifact's content.
+
+### Step 2: Evaluate Each Candidate
+
+For artifacts scoring 7+ (or any artifact you think deserves a closer look), read the file and assess:
+
+**Promotion criteria** (all must be true):
+
+1. **Solves a general problem**: Would another mission or project benefit from this? If the artifact is about "how to use ProjectX's custom ORM", it's project-specific. If it's about "how to integrate any ORM with a REST API", it's general.
+
+2. **Self-contained**: The artifact works without the mission's specific context. It doesn't reference mission-specific file paths, environment variables, or data models that only exist in the mission's project.
+
+3. **Not already covered**: Check if an existing agent or script in `~/.aidevops/agents/` already covers this domain. Use `rg "{keyword}" ~/.aidevops/agents/` to search. If existing coverage is partial, consider extending the existing file rather than promoting a new one.
+
+4. **Quality bar**: The artifact has clear documentation (description, usage examples), follows framework conventions (YAML frontmatter for agents, `set -euo pipefail` for scripts), and is under 200 lines (focused, not a kitchen sink).
+
+### Step 3: Decide and Act
+
+For each artifact, choose one action:
+
+| Decision | When | Action |
+|----------|------|--------|
+| **Delete** | Score 0-3, or project-specific noise | No action needed (stays in mission dir, cleaned up later) |
+| **Keep** | Score 4-6, useful within this project only | Leave in mission directory |
+| **Promote to draft/** | Score 7-8, or general but needs refinement | `mission-skill-learning.sh promote {path} --target draft` |
+| **Promote to custom/** | Score 9-10, polished and immediately useful | `mission-skill-learning.sh promote {path} --target custom` |
+| **Extend existing** | Overlaps with existing agent/script | Edit the existing file to incorporate the new knowledge |
+
+**After promotion**, the artifact follows the standard agent lifecycle:
+- `draft/` — experimental, survives updates, reviewed periodically
+- `custom/` — user's permanent agents, survives updates
+- `shared/` (root) — framework-wide, requires PR review (not done during skill learning)
+
+### Step 4: Store Patterns in Memory
+
+After evaluation, store the mission's learnings in cross-session memory:
+
+```bash
+mission-skill-learning.sh remember "{mission-dir}"
+```
+
+This stores:
+- Mission completion with goal summary (`SUCCESS_PATTERN`)
+- Decision log entries (`DECISION`)
+- Created agents and scripts (`CODEBASE_PATTERN`)
+
+These memories surface in future mission planning via `/recall "mission patterns"` and auto-recall at session start.
+
+### Step 5: Update Mission State File
+
+Record promotion decisions in the mission's Skill Learning section:
+
+```markdown
+## Skill Learning
+
+| Artifact | Score | Decision | Target | Notes |
+|----------|-------|----------|--------|-------|
+| api-patterns.md | 8 | Promoted | draft/ | General REST API patterns |
+| seed-script.sh | 4 | Keep | mission | Project-specific data |
+| auth-flow.md | 3 | Delete | - | Covered by existing auth agent |
+```
+
+### Step 6: Check Recurrence
+
+If multiple missions have been completed, check for recurring patterns:
+
+```bash
+mission-skill-learning.sh recurrence --all-missions "{missions-root}"
+```
+
+Artifacts that appear in 2+ missions are strong promotion candidates — they represent patterns that missions keep re-discovering. Prioritize these for promotion even if their individual scores are moderate.
+
+## What Makes a Good Promotion Candidate
+
+**Strong signals** (promote):
+- Artifact was used by 3+ workers in the mission (high internal reuse)
+- Similar artifact was created in a previous mission (recurrence)
+- Artifact documents integration patterns for a service not yet covered by aidevops
+- Artifact contains error handling or gotcha documentation that would save future debugging
+
+**Weak signals** (keep or delete):
+- Artifact is a thin wrapper around an existing tool (adds no new knowledge)
+- Artifact contains hardcoded values specific to one project
+- Artifact duplicates existing framework documentation with minor variations
+- Artifact is a data migration or seed script (inherently project-specific)
+
+## Adapting Artifacts for General Use
+
+When promoting, the artifact often needs adaptation:
+
+1. **Remove project-specific references**: Replace hardcoded paths, project names, and environment variables with placeholders or parameters
+2. **Add YAML frontmatter** (for agents): `description`, `mode: subagent`, `status: draft`, `tools` permissions
+3. **Add usage examples**: Show how to use the artifact in a different project context
+4. **Reference existing agents**: If the artifact extends a domain already covered, add a "See also" section linking to the existing agent
+5. **Keep it focused**: If the artifact covers multiple topics, split it into separate files
+
+## Anti-Patterns
+
+- **Promoting everything**: Most artifacts are project-specific. A 20% promotion rate is healthy; 50%+ suggests insufficient filtering.
+- **Promoting without adaptation**: A promoted artifact that still references `~/Git/myapp/src/models/user.ts` is useless to other projects.
+- **Skipping memory storage**: Even if no artifacts are promoted, the mission's decisions and patterns should be stored in memory. Future missions benefit from knowing what was tried and what worked.
+- **Promoting to shared/ directly**: Mission artifacts go to `draft/` or `custom/` only. Promotion to shared/ (framework-wide) requires a separate PR review process.
+
+## Integration with Mission Orchestrator
+
+The mission orchestrator calls skill learning as part of Phase 5 (completion). The orchestrator should:
+
+1. Run `mission-skill-learning.sh scan` and `score` to get data
+2. Read this document for evaluation guidance
+3. Make promotion decisions based on artifact content and mission context
+4. Run `promote` for selected artifacts
+5. Run `remember` to store patterns
+6. Record decisions in the mission state file's Skill Learning section
+7. Commit and push the updated state file
+
+## Related
+
+- `scripts/mission-skill-learning.sh` — Helper script for deterministic operations
+- `workflows/mission-orchestrator.md` — Calls skill learning at Phase 5
+- `tools/build-agent/build-agent.md` — Agent lifecycle tiers
+- `memory/README.md` — Cross-session memory system
+- `scripts/memory-graduate-helper.sh` — Similar pattern: graduating memories to shared docs

--- a/todo/tasks/t1361-brief.md
+++ b/todo/tasks/t1361-brief.md
@@ -1,0 +1,128 @@
+---
+mode: subagent
+---
+
+# t1361: Mission skill learning
+
+## Origin
+
+- **Created:** 2026-02-27
+- **Session:** claude-code:interactive
+- **Created by:** ai-interactive
+- **Parent task:** t1357 (Mission system)
+- **Conversation context:** Part of the mission system feature set (t1357-t1362). After the mission orchestrator (t1357.3) was completed, this task implements the learning feedback loop — auto-capturing reusable patterns from completed missions.
+
+## What
+
+A skill learning system that runs at mission completion to:
+
+1. Scan mission directories for artifacts (agents, scripts, research docs) created during execution
+2. Score artifacts for reusability based on content quality and cross-mission recurrence
+3. Suggest promotion of useful artifacts from mission-local to `custom/` (user-permanent) or `draft/` (framework R&D)
+4. Store discovered patterns in cross-session memory for future mission planning
+5. Track which patterns recur across missions to identify high-value learnings
+
+## Why
+
+Missions create temporary agents and scripts that often solve general problems. Without a learning loop, these artifacts die with the mission — the same problems get re-solved in future missions. This closes the feedback loop: missions produce knowledge, knowledge improves future missions.
+
+Blocked t1357.3 (now complete). Feeds into the broader self-improvement principle in AGENTS.md.
+
+## How (Approach)
+
+**Helper script** (`mission-skill-learning.sh`): Deterministic operations — scan directories, find `.md` agent files and `.sh` scripts, check if similar artifacts exist in other mission dirs, compute recurrence scores. This is the "what to look at" tool.
+
+**Agent doc** (`workflows/mission-skill-learning.md`): Judgment-based guidance — how to evaluate whether an artifact is worth promoting, what makes a good candidate, how to adapt mission-specific content for general use. This is the "how to decide" guide.
+
+**Integration points:**
+- `workflows/mission-orchestrator.md` Phase 5 — call skill learning after mission completion
+- `templates/mission-template.md` — add Skill Learning section for tracking promotion decisions
+- `memory-helper.sh` — store patterns via existing `--auto` flag with `SUCCESS_PATTERN` type
+
+**Key files:**
+- `.agents/scripts/mission-skill-learning.sh` — new helper script
+- `.agents/workflows/mission-skill-learning.md` — new agent doc
+- `.agents/workflows/mission-orchestrator.md:156-264` — Phase 5 + Improvement Feedback sections
+- `.agents/templates/mission-template.md:157-167` — Mission Agents table
+- `.agents/scripts/memory-helper.sh` — existing, used for storage
+
+## Acceptance Criteria
+
+- [ ] `mission-skill-learning.sh scan <mission-dir>` lists all agent/script artifacts with metadata
+  ```yaml
+  verify:
+    method: bash
+    run: "test -x ~/.aidevops/agents/scripts/mission-skill-learning.sh && ~/.aidevops/agents/scripts/mission-skill-learning.sh help | grep -q 'scan'"
+  ```
+- [ ] `mission-skill-learning.sh score <mission-dir>` outputs promotion recommendations with scores
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "cmd_score"
+    path: ".agents/scripts/mission-skill-learning.sh"
+  ```
+- [ ] `mission-skill-learning.sh promote <artifact-path>` copies artifact to draft/ with metadata
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "cmd_promote"
+    path: ".agents/scripts/mission-skill-learning.sh"
+  ```
+- [ ] `mission-skill-learning.sh remember <mission-dir>` stores patterns in cross-session memory
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "cmd_remember"
+    path: ".agents/scripts/mission-skill-learning.sh"
+  ```
+- [ ] Mission orchestrator Phase 5 references skill learning
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "mission-skill-learning"
+    path: ".agents/workflows/mission-orchestrator.md"
+  ```
+- [ ] Mission template includes Skill Learning section
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "Skill Learning"
+    path: ".agents/templates/mission-template.md"
+  ```
+- [ ] ShellCheck passes on mission-skill-learning.sh
+  ```yaml
+  verify:
+    method: bash
+    run: "shellcheck ~/.aidevops/agents/scripts/mission-skill-learning.sh"
+  ```
+
+## Context & Decisions
+
+- **Helper script + agent doc split**: Deterministic operations (file scanning, copying) belong in bash. Judgment calls (is this artifact worth promoting?) belong in agent guidance. This follows the "Intelligence Over Determinism" principle.
+- **Recurrence scoring**: Simple heuristic — count how many mission dirs contain similar artifacts (by filename pattern or content similarity). Not ML-based; just frequency counting.
+- **Memory integration**: Uses existing `memory-helper.sh store --auto` with `SUCCESS_PATTERN` type. No new memory infrastructure needed.
+- **Promotion target**: `draft/` tier (not `custom/` or shared) — promotion to higher tiers requires human review per build-agent.md lifecycle.
+
+## Relevant Files
+
+- `.agents/workflows/mission-orchestrator.md` — integration point at Phase 5
+- `.agents/templates/mission-template.md` — template update for Skill Learning section
+- `.agents/scripts/memory-helper.sh` — memory storage integration
+- `.agents/scripts/memory-graduate-helper.sh` — pattern for graduation/promotion scripts
+- `.agents/tools/build-agent/build-agent.md` — agent lifecycle tiers
+- `.agents/memory/README.md` — memory system docs
+
+## Dependencies
+
+- **Blocked by:** t1357.3 (mission orchestrator) — completed
+- **Blocks:** nothing directly; enables self-improvement loop
+- **External:** none
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Research/read | 30m | Existing mission + memory system |
+| Implementation | 2.5h | Helper script + agent doc + integrations |
+| Testing | 30m | ShellCheck + manual verification |
+| **Total** | **~3.5h** | |


### PR DESCRIPTION
## Summary

- Add mission skill learning system that evaluates temporary artifacts (agents, scripts) created during missions for promotion to the framework's `draft/` or `custom/` library
- New helper script (`mission-skill-learning.sh`) provides deterministic operations: scan, score, promote, remember, and cross-mission recurrence tracking
- New agent doc (`mission-skill-learning.md`) provides judgment-based evaluation guidance for the orchestrator
- Integrates with mission orchestrator Phase 5 (completion) and cross-session memory system

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/mission-skill-learning.sh` | **New** — 797-line helper script with 5 commands |
| `.agents/workflows/mission-skill-learning.md` | **New** — evaluation criteria, promotion workflow, anti-patterns |
| `.agents/workflows/mission-orchestrator.md` | **Updated** — Phase 5 now calls skill learning before improvement feedback |
| `.agents/templates/mission-template.md` | **Updated** — added Skill Learning section for tracking promotion decisions |
| `todo/tasks/t1361-brief.md` | **New** — task brief |

## Design

Follows the "Intelligence Over Determinism" principle:
- **Deterministic** (helper script): file discovery, size checks, structural scoring, file copying, memory storage
- **Judgment** (agent doc): is this artifact worth promoting? how to adapt it? what makes a good candidate?

Scoring factors: content size, structure (YAML frontmatter, shebang), documentation, generalizability (no hardcoded paths), cross-mission recurrence.

## Verification

- ShellCheck passes with `-x` flag (zero violations)
- Functional test with mock mission directory: scan discovers artifacts, score produces recommendations
- Help command outputs complete usage documentation

Closes #2505