### PR TITLE
t1363.3: Memory system integration — entity-scoped store/recall

### DIFF
--- a/.agents/scripts/memory-helper.sh
+++ b/.agents/scripts/memory-helper.sh
@@ -11,9 +11,9 @@
 # - Contextual disambiguation (atomic, self-contained memories)
 #
 # Usage:
-#   memory-helper.sh store --content "learning" [--type TYPE] [--tags "a,b"] [--session-id ID]
+#   memory-helper.sh store --content "learning" [--type TYPE] [--tags "a,b"] [--session-id ID] [--entity ent_xxx]
 #   memory-helper.sh store --content "new info" --supersedes mem_xxx --relation updates
-#   memory-helper.sh recall --query "search terms" [--limit 5] [--type TYPE] [--max-age-days 30]
+#   memory-helper.sh recall --query "search terms" [--limit 5] [--type TYPE] [--max-age-days 30] [--entity ent_xxx]
 #   memory-helper.sh history <id>             # Show version history for a memory
 #   memory-helper.sh stats                    # Show memory statistics
 #   memory-helper.sh prune [--older-than-days 90] [--dry-run]  # Remove stale entries
@@ -125,6 +125,7 @@ STORE OPTIONS:
     --supersedes <id>     ID of memory this updates/extends/derives from
     --relation <type>     Relation type: updates, extends, derives
     --auto                Mark as auto-captured (sets source=auto, tracked separately)
+    --entity <id>         Link learning to an entity (e.g., ent_xxx)
 
 VALID TYPES:
     WORKING_SOLUTION, FAILED_APPROACH, CODEBASE_PATTERN, USER_PREFERENCE,
@@ -145,6 +146,8 @@ RECALL OPTIONS:
     --type <type>         Filter by type
     --max-age-days <n>    Only recent entries
     --project <path>      Filter by project path
+    --entity <id>         Filter by entity (only memories linked to this entity)
+                          Combines with --project for cross-query (entity + project)
     --recent [n]          Show n most recent entries (default: 10)
     --shared              Also search global memory (when using --namespace)
     --auto-only           Show only auto-captured memories
@@ -252,6 +255,19 @@ EXAMPLES:
     memory-helper.sh dedup --dry-run
     memory-helper.sh dedup
     memory-helper.sh dedup --exact-only
+
+ENTITY EXAMPLES:
+    # Store a learning linked to an entity
+    memory-helper.sh store --content "Prefers concise responses" --entity ent_xxx --type USER_PREFERENCE
+
+    # Recall all memories for an entity
+    memory-helper.sh recall --query "preferences" --entity ent_xxx
+
+    # Recent memories for an entity
+    memory-helper.sh recall --recent --entity ent_xxx
+
+    # Cross-query: entity + project (what does this person know about this project?)
+    memory-helper.sh recall --query "deployment" --entity ent_xxx --project ~/Git/myproject
 
 NAMESPACE EXAMPLES:
     # Store in a runner-specific namespace

--- a/.agents/scripts/memory/store.sh
+++ b/.agents/scripts/memory/store.sh
@@ -23,6 +23,7 @@ cmd_store() {
 	local supersedes_id=""
 	local relation_type=""
 	local auto_captured=0
+	local entity_id=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -70,6 +71,10 @@ cmd_store() {
 			auto_captured=1
 			source="auto"
 			shift
+			;;
+		--entity)
+			entity_id="$2"
+			shift 2
 			;;
 		*)
 			# Allow content as positional argument
@@ -227,6 +232,16 @@ INSERT INTO learning_relations (id, supersedes_id, relation_type, created_at)
 VALUES ('$id', '$escaped_supersedes', '$relation_type', '$created_at');
 EOF
 		log_info "Relation: $id $relation_type $supersedes_id"
+	fi
+
+	# Link to entity if --entity was provided (t1363.3)
+	if [[ -n "$entity_id" ]]; then
+		if ! validate_entity_id "$entity_id"; then
+			log_warn "Entity '$entity_id' not found — learning stored but not linked to entity"
+		else
+			link_learning_entity "$id" "$entity_id"
+			log_info "Linked to entity: $entity_id"
+		fi
 	fi
 
 	log_success "Stored learning: $id"


### PR DESCRIPTION
## Summary

- Add `--entity <id>` flag to `memory-helper.sh store` and `recall` for entity-scoped memory queries
- Entity-linked memories stored via `learning_entities` junction table (M:M relationship)
- Cross-query support: combine `--entity` with `--project` to find what an entity knows about a specific project
- Fix pre-existing `--recent` flag parsing bug where limit was incorrectly set to the next flag value

## Changes

| File | Change |
|------|--------|
| `memory/store.sh` | Parse `--entity`, validate entity exists, link learning after insert |
| `memory/recall.sh` | Parse `--entity`, INNER JOIN `learning_entities` for FTS5 + recent queries |
| `memory/_common.sh` | `learning_entities` schema (init + migrate), `validate_entity_id()`, `link_learning_entity()` |
| `memory-helper.sh` | Help text with `--entity` docs and entity examples |

## Backward Compatibility

- No `--entity` flag = existing behavior completely unchanged
- Store with invalid entity: warns but still stores (graceful degradation)
- Recall with invalid entity: errors immediately (fail-fast for queries)
- All existing tests/usage patterns unaffected

## Testing

Verified: store with/without `--entity`, recall with/without `--entity`, `--recent --entity`, cross-query (`--entity` + `--project`), JSON output, invalid entity handling, ShellCheck clean.

Closes #2523