### PR TITLE
t1363.3: Memory system integration — entity-scoped store/recall

### DIFF
--- a/.agents/scripts/commands/recall.md
+++ b/.agents/scripts/commands/recall.md
@@ -66,7 +66,10 @@ This suggests: {interpretation for current task}
 | `/recall {query}` | Search by keywords |
 | `/recall --type WORKING_SOLUTION` | Filter by type |
 | `/recall --project myapp` | Filter by project |
+| `/recall --entity ent_xxx` | Filter by entity |
+| `/recall --entity ent_xxx --project myapp` | Cross-query: entity + project |
 | `/recall --recent` | Show 10 most recent |
+| `/recall --recent --entity ent_xxx` | Recent for entity |
 | `/recall --stats` | Show memory statistics |
 
 ## Examples
@@ -110,6 +113,22 @@ AI: Found 8 memories for project "wordpress-plugin":
     2. [DECISION] Using SCF instead of ACF for custom fields
     3. [WORKING_SOLUTION] Fixed activation hook by checking PHP version first
     ...
+```
+
+**Entity-scoped search:**
+
+```text
+User: /recall --entity ent_abc123 --query "preferences"
+AI: Found 3 memories for "preferences" [entity: ent_abc123]:
+
+    1. [USER_PREFERENCE] Prefers concise responses
+       Tags: communication | Project: global | 2 days ago
+
+    2. [USER_PREFERENCE] Wants deployment status updates daily
+       Tags: ops,deployment | Project: api-gateway | 1 week ago
+
+    3. [CONTEXT] Usually asks about CI/CD pipeline issues
+       Tags: ci,patterns | Project: global | 2 weeks ago
 ```
 
 **Recent memories:**

--- a/.agents/scripts/memory-helper.sh
+++ b/.agents/scripts/memory-helper.sh
@@ -125,6 +125,7 @@ STORE OPTIONS:
     --supersedes <id>     ID of memory this updates/extends/derives from
     --relation <type>     Relation type: updates, extends, derives
     --auto                Mark as auto-captured (sets source=auto, tracked separately)
+    --entity <id>         Link memory to an entity (from entity-helper.sh)
 
 VALID TYPES:
     WORKING_SOLUTION, FAILED_APPROACH, CODEBASE_PATTERN, USER_PREFERENCE,
@@ -145,6 +146,7 @@ RECALL OPTIONS:
     --type <type>         Filter by type
     --max-age-days <n>    Only recent entries
     --project <path>      Filter by project path
+    --entity <id>         Filter by entity (from entity-helper.sh)
     --recent [n]          Show n most recent entries (default: 10)
     --shared              Also search global memory (when using --namespace)
     --auto-only           Show only auto-captured memories
@@ -252,6 +254,20 @@ EXAMPLES:
     memory-helper.sh dedup --dry-run
     memory-helper.sh dedup
     memory-helper.sh dedup --exact-only
+
+ENTITY EXAMPLES:
+    # Store a memory linked to an entity
+    memory-helper.sh store --content "Prefers concise responses" \
+        --type USER_PREFERENCE --entity ent_xxx
+
+    # Recall memories for a specific entity
+    memory-helper.sh recall --query "preferences" --entity ent_xxx
+
+    # Cross-query: entity + project
+    memory-helper.sh recall --query "deployment" --entity ent_xxx --project myapp
+
+    # Recent memories for an entity
+    memory-helper.sh recall --recent --entity ent_xxx
 
 NAMESPACE EXAMPLES:
     # Store in a runner-specific namespace

--- a/.agents/scripts/memory/_common.sh
+++ b/.agents/scripts/memory/_common.sh
@@ -311,6 +311,24 @@ EOF
 		log_success "Entity memory tables created (t1363.1)"
 	fi
 
+	# Create learning_entities table if missing (t1363.3 migration)
+	# Links learnings to entities for entity-scoped recall
+	local has_learning_entities
+	has_learning_entities=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='learning_entities';" 2>/dev/null || echo "0")
+	if [[ "$has_learning_entities" == "0" ]]; then
+		log_info "Creating learning_entities table (t1363.3)..."
+		db "$MEMORY_DB" <<'EOF'
+CREATE TABLE IF NOT EXISTS learning_entities (
+    learning_id TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    PRIMARY KEY (learning_id, entity_id)
+);
+CREATE INDEX IF NOT EXISTS idx_learning_entities_entity ON learning_entities(entity_id);
+EOF
+		log_success "learning_entities table created (t1363.3)"
+	fi
+
 	return 0
 }
 
@@ -417,6 +435,119 @@ CREATE TABLE IF NOT EXISTS pattern_metadata (
     tokens_out INTEGER DEFAULT NULL,
     estimated_cost REAL DEFAULT NULL
 );
+
+-- Entity tables (t1363.1) — conversational memory system (p035)
+-- Layer 2: Entity relationship model
+CREATE TABLE IF NOT EXISTS entities (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL CHECK(type IN ('person', 'agent', 'service')),
+    display_name TEXT DEFAULT NULL,
+    aliases TEXT DEFAULT '',
+    notes TEXT DEFAULT '',
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+-- Cross-channel identity linking
+CREATE TABLE IF NOT EXISTS entity_channels (
+    entity_id TEXT NOT NULL,
+    channel TEXT NOT NULL CHECK(channel IN ('matrix', 'simplex', 'email', 'cli', 'slack', 'discord', 'telegram', 'irc', 'web')),
+    channel_id TEXT NOT NULL,
+    display_name TEXT DEFAULT NULL,
+    confidence TEXT DEFAULT 'suggested' CHECK(confidence IN ('confirmed', 'suggested', 'inferred')),
+    verified_at TEXT DEFAULT NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    PRIMARY KEY (channel, channel_id),
+    FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_entity_channels_entity ON entity_channels(entity_id);
+
+-- Layer 0: Raw interaction log (immutable, append-only)
+CREATE TABLE IF NOT EXISTS interactions (
+    id TEXT PRIMARY KEY,
+    entity_id TEXT NOT NULL,
+    channel TEXT NOT NULL,
+    channel_id TEXT DEFAULT NULL,
+    conversation_id TEXT DEFAULT NULL,
+    direction TEXT NOT NULL DEFAULT 'inbound' CHECK(direction IN ('inbound', 'outbound', 'system')),
+    content TEXT NOT NULL,
+    metadata TEXT DEFAULT '{}',
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_interactions_entity ON interactions(entity_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_interactions_conversation ON interactions(conversation_id);
+CREATE INDEX IF NOT EXISTS idx_interactions_channel ON interactions(channel, channel_id, created_at DESC);
+
+-- Layer 1: Per-conversation context
+CREATE TABLE IF NOT EXISTS conversations (
+    id TEXT PRIMARY KEY,
+    entity_id TEXT NOT NULL,
+    channel TEXT NOT NULL,
+    channel_id TEXT DEFAULT NULL,
+    topic TEXT DEFAULT '',
+    summary TEXT DEFAULT '',
+    status TEXT DEFAULT 'active' CHECK(status IN ('active', 'idle', 'closed')),
+    interaction_count INTEGER DEFAULT 0,
+    first_interaction_at TEXT DEFAULT NULL,
+    last_interaction_at TEXT DEFAULT NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_conversations_entity ON conversations(entity_id, status);
+
+-- Layer 2: Versioned entity profiles
+CREATE TABLE IF NOT EXISTS entity_profiles (
+    id TEXT PRIMARY KEY,
+    entity_id TEXT NOT NULL,
+    profile_key TEXT NOT NULL,
+    profile_value TEXT NOT NULL,
+    evidence TEXT DEFAULT '',
+    confidence TEXT DEFAULT 'medium' CHECK(confidence IN ('high', 'medium', 'low')),
+    supersedes_id TEXT DEFAULT NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE,
+    FOREIGN KEY (supersedes_id) REFERENCES entity_profiles(id)
+);
+CREATE INDEX IF NOT EXISTS idx_entity_profiles_entity ON entity_profiles(entity_id, profile_key);
+CREATE INDEX IF NOT EXISTS idx_entity_profiles_supersedes ON entity_profiles(supersedes_id);
+
+-- Capability gaps detected from entity interactions
+CREATE TABLE IF NOT EXISTS capability_gaps (
+    id TEXT PRIMARY KEY,
+    entity_id TEXT DEFAULT NULL,
+    description TEXT NOT NULL,
+    evidence TEXT DEFAULT '',
+    frequency INTEGER DEFAULT 1,
+    status TEXT DEFAULT 'detected' CHECK(status IN ('detected', 'todo_created', 'resolved', 'wont_fix')),
+    todo_ref TEXT DEFAULT NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS idx_capability_gaps_status ON capability_gaps(status);
+
+-- FTS5 index for searching interactions
+CREATE VIRTUAL TABLE IF NOT EXISTS interactions_fts USING fts5(
+    id UNINDEXED,
+    entity_id UNINDEXED,
+    content,
+    channel UNINDEXED,
+    created_at UNINDEXED,
+    tokenize='porter unicode61'
+);
+
+-- Entity-memory linking (t1363.3) — companion table linking learnings to entities
+-- Enables entity-scoped recall and cross-queries (entity + project)
+CREATE TABLE IF NOT EXISTS learning_entities (
+    learning_id TEXT NOT NULL,
+    entity_id TEXT NOT NULL,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    PRIMARY KEY (learning_id, entity_id)
+);
+CREATE INDEX IF NOT EXISTS idx_learning_entities_entity ON learning_entities(entity_id);
 EOF
 		log_success "Database initialized with relational versioning support"
 	else

--- a/tests/test-memory-entity-integration.sh
+++ b/tests/test-memory-entity-integration.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# test-memory-entity-integration.sh
+#
+# Tests for memory-entity integration (t1363.3):
+# - Store with --entity flag links memory to entity
+# - Recall with --entity flag filters by entity
+# - Cross-query: --entity + --project
+# - Backward compatibility: store/recall without --entity unchanged
+# - Entity validation: store fails for nonexistent entity
+# - learning_entities table migration
+#
+# Uses isolated temp directories to avoid touching production data.
+#
+# Usage: bash tests/test-memory-entity-integration.sh [--verbose]
+#
+# Exit codes: 0 = all pass, 1 = failures found
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPTS_DIR="$REPO_DIR/.agents/scripts"
+VERBOSE="${1:-}"
+
+# --- Test Framework ---
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+TOTAL_COUNT=0
+
+pass() {
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+}
+
+fail() {
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
+}
+
+skip() {
+	SKIP_COUNT=$((SKIP_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+}
+
+summary() {
+	echo ""
+	echo "=== Results ==="
+	echo "  Total: $TOTAL_COUNT | Pass: $PASS_COUNT | Fail: $FAIL_COUNT | Skip: $SKIP_COUNT"
+	if [[ $FAIL_COUNT -gt 0 ]]; then
+		echo "  STATUS: FAILED"
+		return 1
+	else
+		echo "  STATUS: PASSED"
+		return 0
+	fi
+}
+
+# --- Setup ---
+TEST_DIR=$(mktemp -d)
+export AIDEVOPS_MEMORY_DIR="$TEST_DIR/memory"
+mkdir -p "$AIDEVOPS_MEMORY_DIR"
+
+cleanup() {
+	rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+# Check prerequisites
+if ! command -v sqlite3 &>/dev/null; then
+	echo "SKIP: sqlite3 not found"
+	exit 0
+fi
+
+echo ""
+echo "=== Memory-Entity Integration Tests (t1363.3) ==="
+echo "  Test dir: $TEST_DIR"
+echo ""
+
+# --- Helper: create entity directly in DB ---
+create_test_entity() {
+	local entity_id="$1"
+	local name="$2"
+	local entity_type="${3:-person}"
+
+	sqlite3 -cmd ".timeout 5000" "$AIDEVOPS_MEMORY_DIR/memory.db" <<EOF
+INSERT OR IGNORE INTO entities (id, name, type)
+VALUES ('$entity_id', '$name', '$entity_type');
+EOF
+}
+
+# --- Test 1: Schema migration creates learning_entities table ---
+echo "--- Schema & Migration ---"
+
+# Initialize DB by running store (which calls init_db)
+output=$("$SCRIPTS_DIR/memory-helper.sh" store --content "Schema init test" --type WORKING_SOLUTION 2>&1) || true
+
+# Check learning_entities table exists
+table_exists=$(sqlite3 "$AIDEVOPS_MEMORY_DIR/memory.db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='learning_entities';" 2>/dev/null || echo "0")
+if [[ "$table_exists" == "1" ]]; then
+	pass "learning_entities table created on init"
+else
+	fail "learning_entities table not created" "Expected table to exist after init_db"
+fi
+
+# Check entity tables also exist (from t1363.1 migration)
+entities_exists=$(sqlite3 "$AIDEVOPS_MEMORY_DIR/memory.db" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='entities';" 2>/dev/null || echo "0")
+if [[ "$entities_exists" == "1" ]]; then
+	pass "entities table exists (t1363.1 prerequisite)"
+else
+	fail "entities table missing" "Entity tables from t1363.1 not created"
+fi
+
+# --- Test 2: Store without --entity (backward compatibility) ---
+echo ""
+echo "--- Backward Compatibility ---"
+
+output=$("$SCRIPTS_DIR/memory-helper.sh" store --content "No entity learning" --type DECISION 2>&1)
+mem_id=$(echo "$output" | grep -o 'mem_[a-z0-9_]*' | tail -1)
+
+if [[ -n "$mem_id" ]]; then
+	pass "Store without --entity succeeds"
+else
+	fail "Store without --entity failed" "$output"
+fi
+
+# Verify no learning_entities row created
+le_count=$(sqlite3 "$AIDEVOPS_MEMORY_DIR/memory.db" "SELECT COUNT(*) FROM learning_entities WHERE learning_id = '$mem_id';" 2>/dev/null || echo "0")
+if [[ "$le_count" == "0" ]]; then
+	pass "No entity link created when --entity not used"
+else
+	fail "Unexpected entity link created" "Found $le_count rows for $mem_id"
+fi
+
+# --- Test 3: Store with --entity links memory to entity ---
+echo ""
+echo "--- Store with --entity ---"
+
+# Create a test entity
+create_test_entity "ent_test001" "Test Person"
+
+output=$("$SCRIPTS_DIR/memory-helper.sh" store --content "Entity-linked learning about deployment" --type WORKING_SOLUTION --entity ent_test001 2>&1)
+entity_mem_id=$(echo "$output" | grep -o 'mem_[a-z0-9_]*' | tail -1)
+
+if [[ -n "$entity_mem_id" ]]; then
+	pass "Store with --entity succeeds"
+else
+	fail "Store with --entity failed" "$output"
+fi
+
+# Verify learning_entities row created
+le_count=$(sqlite3 "$AIDEVOPS_MEMORY_DIR/memory.db" "SELECT COUNT(*) FROM learning_entities WHERE learning_id = '$entity_mem_id' AND entity_id = 'ent_test001';" 2>/dev/null || echo "0")
+if [[ "$le_count" == "1" ]]; then
+	pass "Entity link created in learning_entities"
+else
+	fail "Entity link not created" "Expected 1 row, got $le_count"
+fi
+
+# --- Test 4: Store with nonexistent entity fails ---
+output=$("$SCRIPTS_DIR/memory-helper.sh" store --content "Should fail" --type DECISION --entity ent_nonexistent 2>&1) && rc=$? || rc=$?
+if [[ $rc -ne 0 ]]; then
+	pass "Store with nonexistent entity fails"
+else
+	fail "Store with nonexistent entity should have failed" "$output"
+fi
+
+# --- Test 5: Recall without --entity (backward compatibility) ---
+echo ""
+echo "--- Recall Backward Compatibility ---"
+
+output=$("$SCRIPTS_DIR/memory-helper.sh" recall --query "deployment" 2>&1)
+if echo "$output" | grep -q "deployment"; then
+	pass "Recall without --entity returns results"
+else
+	fail "Recall without --entity returned no results" "$output"
+fi
+
+# --- Test 6: Recall with --entity filters correctly ---
+echo ""
+echo "--- Recall with --entity ---"
+
+# Store another memory for a different entity
+create_test_entity "ent_test002" "Other Person"
+"$SCRIPTS_DIR/memory-helper.sh" store --content "Different entity learning about deployment" --type WORKING_SOLUTION --entity ent_test002 >/dev/null 2>&1
+
+# Recall for ent_test001 should only return its memory
+output=$("$SCRIPTS_DIR/memory-helper.sh" recall --query "deployment" --entity ent_test001 2>&1)
+if echo "$output" | grep -q "Entity-linked learning"; then
+	pass "Recall --entity returns entity's memory"
+else
+	fail "Recall --entity did not return entity's memory" "$output"
+fi
+
+# Check that the other entity's memory is NOT in the results
+if echo "$output" | grep -q "Different entity learning"; then
+	fail "Recall --entity returned wrong entity's memory" "Should not contain 'Different entity learning'"
+else
+	pass "Recall --entity excludes other entities' memories"
+fi
+
+# --- Test 7: Recall --entity with --recent ---
+echo ""
+echo "--- Recall --entity --recent ---"
+
+output=$("$SCRIPTS_DIR/memory-helper.sh" recall --recent --entity ent_test001 2>&1)
+if echo "$output" | grep -q "Entity-linked learning"; then
+	pass "Recall --recent --entity returns entity's memories"
+else
+	fail "Recall --recent --entity failed" "$output"
+fi
+
+# --- Test 8: Cross-query: --entity + --project ---
+echo ""
+echo "--- Cross-query: --entity + --project ---"
+
+# Store a memory with entity + specific project
+"$SCRIPTS_DIR/memory-helper.sh" store --content "Project-specific entity memory about testing" --type WORKING_SOLUTION --entity ent_test001 --project "/tmp/myproject" >/dev/null 2>&1
+
+# Cross-query should find it
+output=$("$SCRIPTS_DIR/memory-helper.sh" recall --query "testing" --entity ent_test001 --project "/tmp/myproject" 2>&1)
+if echo "$output" | grep -q "Project-specific entity memory"; then
+	pass "Cross-query (entity + project) returns correct result"
+else
+	fail "Cross-query (entity + project) failed" "$output"
+fi
+
+# Cross-query with wrong project should not find it
+output=$("$SCRIPTS_DIR/memory-helper.sh" recall --query "testing" --entity ent_test001 --project "/tmp/otherproject" 2>&1)
+if echo "$output" | grep -q "Project-specific entity memory"; then
+	fail "Cross-query with wrong project returned result" "Should not match /tmp/otherproject"
+else
+	pass "Cross-query with wrong project correctly excludes"
+fi
+
+# --- Test 9: Entity header in text output ---
+echo ""
+echo "--- Output formatting ---"
+
+output=$("$SCRIPTS_DIR/memory-helper.sh" recall --query "deployment" --entity ent_test001 2>&1)
+if echo "$output" | grep -q "\[entity: ent_test001\]"; then
+	pass "Entity shown in recall header"
+else
+	fail "Entity not shown in recall header" "$output"
+fi
+
+# --- Test 10: Multiple entities on same memory (edge case) ---
+echo ""
+echo "--- Edge cases ---"
+
+# Manually insert a second entity link for the same memory
+sqlite3 "$AIDEVOPS_MEMORY_DIR/memory.db" "INSERT OR IGNORE INTO learning_entities (learning_id, entity_id) VALUES ('$entity_mem_id', 'ent_test002');"
+
+# Both entities should find this memory
+output1=$("$SCRIPTS_DIR/memory-helper.sh" recall --query "Entity-linked" --entity ent_test001 2>&1)
+output2=$("$SCRIPTS_DIR/memory-helper.sh" recall --query "Entity-linked" --entity ent_test002 2>&1)
+
+if echo "$output1" | grep -q "Entity-linked learning" && echo "$output2" | grep -q "Entity-linked learning"; then
+	pass "Memory linked to multiple entities found by both"
+else
+	fail "Multi-entity linking failed" "ent_test001 found: $(echo "$output1" | grep -c 'Entity-linked'), ent_test002 found: $(echo "$output2" | grep -c 'Entity-linked')"
+fi
+
+# --- Test 11: JSON output with --entity ---
+output=$("$SCRIPTS_DIR/memory-helper.sh" recall --query "deployment" --entity ent_test001 --json 2>&1)
+if echo "$output" | grep -q '"id"'; then
+	pass "JSON output with --entity works"
+else
+	fail "JSON output with --entity failed" "$output"
+fi
+
+# --- Summary ---
+summary


### PR DESCRIPTION
## Summary

- Add `--entity <id>` flag to `memory-helper.sh store` and `recall` for entity-scoped memory operations
- Include entity tables in fresh DB creation (previously only in migration path), fixing schema gaps for new installations
- Fix `--recent` arg parsing bug that consumed the next flag as a limit value (`--recent --entity` → `LIMIT --entity`)

Closes #2523

## Changes

**Store** (`memory/store.sh`):
- `--entity <id>` parameter links memory to entity via `learning_entities` junction table
- Validates entity exists before storing (rejects nonexistent IDs with helpful error)

**Recall** (`memory/recall.sh`):
- `--entity <id>` parameter filters results to entity-scoped memories
- Cross-query support: `--entity` + `--project` for combined filtering
- Entity filter works with `--recent`, `--json`, `--shared` modes
- Entity shown in recall header: `[entity: ent_xxx]`
- Uses subquery filters (not JOINs) for FTS5 compatibility — JOINs on FTS5 tables cause hangs

**Schema** (`memory/_common.sh`):
- `init_db`: fresh DB creation now includes all entity tables (t1363.1) + `learning_entities` (t1363.3)
- `migrate_db`: adds `learning_entities` migration for existing databases

**Docs** (`commands/recall.md`, `memory-helper.sh`):
- Updated help text, search options table, and entity-scoped examples

## Testing

- 16 new integration tests (`tests/test-memory-entity-integration.sh`): schema, store, recall, cross-query, backward compat, edge cases
- 66 existing tests pass unchanged (full backward compatibility)
- ShellCheck clean (only SC1091 info-level for sourced files)

## Backward Compatibility

Existing `/remember` and `/recall` commands work identically without `--entity`. No breaking changes.