### PR TITLE
t1363.6: Intelligent threshold replacement — AI judgment for sessionIdleTimeout, pruning, dedup, and prompt length

### DIFF
--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# ai-research-helper.sh — Lightweight Anthropic API wrapper for AI judgments
+# Provides cheap haiku-tier AI calls (~$0.001 each) for threshold decisions,
+# classification, and short-form reasoning tasks.
+#
+# Part of the Intelligence Over Determinism principle: use AI judgment
+# where fixed thresholds would fail on outliers.
+#
+# Usage:
+#   ai-research-helper.sh --prompt "Is this conversation idle?" [--model haiku|sonnet] [--max-tokens 100]
+#   echo "prompt text" | ai-research-helper.sh --stdin [--model haiku]
+#
+# Environment:
+#   ANTHROPIC_API_KEY — set directly, or resolved from gopass/credentials.sh
+#
+# Exit codes: 0=success (response on stdout), 1=error, 2=no API key
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+set -euo pipefail
+
+LOG_PREFIX="AI-RESEARCH"
+
+#######################################
+# Resolve model short name to full model ID
+# Arguments: $1 — short name (haiku, sonnet, opus)
+# Output: full model ID on stdout
+#######################################
+resolve_model_id() {
+	local name="${1:-haiku}"
+	case "$name" in
+	haiku) echo "claude-haiku-4-20250414" ;;
+	sonnet) echo "claude-sonnet-4-20250514" ;;
+	opus) echo "claude-opus-4-20250514" ;;
+	*) echo "claude-haiku-4-20250414" ;; # default to haiku
+	esac
+	return 0
+}
+
+#######################################
+# Resolve Anthropic API key from available sources
+# Priority: env var > gopass > credentials.sh
+# Output: API key on stdout
+# Returns: 0 if found, 1 if not
+#######################################
+resolve_api_key() {
+	# 1. Environment variable
+	if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+		echo "$ANTHROPIC_API_KEY"
+		return 0
+	fi
+
+	# 2. gopass
+	if command -v gopass &>/dev/null; then
+		local key
+		key=$(gopass show -o "aidevops/anthropic-api-key" 2>/dev/null) || true
+		if [[ -n "$key" ]]; then
+			echo "$key"
+			return 0
+		fi
+	fi
+
+	# 3. credentials.sh
+	local creds_file="${HOME}/.config/aidevops/credentials.sh"
+	if [[ -f "$creds_file" ]]; then
+		local key
+		key=$(grep -E '^ANTHROPIC_API_KEY=' "$creds_file" 2>/dev/null | cut -d= -f2- | tr -d '"'"'" || true)
+		if [[ -n "$key" ]]; then
+			echo "$key"
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
+#######################################
+# Call Anthropic Messages API
+# Arguments:
+#   $1 — prompt text
+#   $2 — model short name (default: haiku)
+#   $3 — max tokens (default: 150)
+# Output: response text on stdout
+# Returns: 0 on success, 1 on failure
+#######################################
+call_anthropic() {
+	local prompt="$1"
+	local model_name="${2:-haiku}"
+	local max_tokens="${3:-150}"
+
+	local api_key
+	api_key=$(resolve_api_key) || {
+		log_error "No Anthropic API key found (env, gopass, or credentials.sh)"
+		return 2
+	}
+
+	local model_id
+	model_id=$(resolve_model_id "$model_name")
+
+	# Escape prompt for JSON — use python3 if available, else basic escaping
+	local escaped_prompt
+	if command -v python3 &>/dev/null; then
+		escaped_prompt=$(printf '%s' "$prompt" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))' 2>/dev/null)
+	else
+		# Basic JSON escaping
+		escaped_prompt="\"$(printf '%s' "$prompt" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g; s/\t/\\t/g')\""
+	fi
+
+	local response
+	response=$(curl -sS --max-time 30 \
+		-H "x-api-key: ${api_key}" \
+		-H "anthropic-version: 2023-06-01" \
+		-H "${CONTENT_TYPE_JSON}" \
+		-d "{
+			\"model\": \"${model_id}\",
+			\"max_tokens\": ${max_tokens},
+			\"messages\": [{
+				\"role\": \"user\",
+				\"content\": ${escaped_prompt}
+			}]
+		}" \
+		"https://api.anthropic.com/v1/messages" 2>/dev/null) || {
+		log_error "API call failed"
+		return 1
+	}
+
+	# Extract text from response
+	local text
+	if command -v jq &>/dev/null; then
+		text=$(echo "$response" | jq -r '.content[0].text // empty' 2>/dev/null)
+	elif command -v python3 &>/dev/null; then
+		text=$(echo "$response" | python3 -c 'import sys,json; data=json.load(sys.stdin); print(data["content"][0]["text"])' 2>/dev/null)
+	else
+		log_error "Neither jq nor python3 available for JSON parsing"
+		return 1
+	fi
+
+	if [[ -z "$text" ]]; then
+		# Check for error in response
+		local error_msg
+		error_msg=$(echo "$response" | jq -r '.error.message // empty' 2>/dev/null || echo "")
+		if [[ -n "$error_msg" ]]; then
+			log_error "API error: $error_msg"
+		else
+			log_error "Empty response from API"
+		fi
+		return 1
+	fi
+
+	echo "$text"
+	return 0
+}
+
+#######################################
+# Main entry point
+#######################################
+main() {
+	local prompt=""
+	local model="haiku"
+	local max_tokens="150"
+	local use_stdin=false
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--prompt)
+			prompt="$2"
+			shift 2
+			;;
+		--model)
+			model="$2"
+			shift 2
+			;;
+		--max-tokens)
+			max_tokens="$2"
+			shift 2
+			;;
+		--stdin)
+			use_stdin=true
+			shift
+			;;
+		--help | -h)
+			echo "Usage: ai-research-helper.sh --prompt \"text\" [--model haiku|sonnet|opus] [--max-tokens 150]"
+			echo "       echo \"text\" | ai-research-helper.sh --stdin [--model haiku]"
+			echo ""
+			echo "Lightweight Anthropic API wrapper for AI threshold judgments."
+			echo "Default model: haiku (~\$0.001/call). Use for classification and short reasoning."
+			return 0
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ "$use_stdin" == true ]]; then
+		prompt=$(cat)
+	fi
+
+	if [[ -z "$prompt" ]]; then
+		log_error "No prompt provided. Use --prompt \"text\" or --stdin"
+		return 1
+	fi
+
+	call_anthropic "$prompt" "$model" "$max_tokens"
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/ai-threshold-judge.sh
+++ b/.agents/scripts/ai-threshold-judge.sh
@@ -1,0 +1,433 @@
+#!/usr/bin/env bash
+# ai-threshold-judge.sh — AI-judged threshold decisions for aidevops
+# Replaces hardcoded thresholds with haiku-tier AI judgment (~$0.001/call).
+#
+# Part of the Intelligence Over Determinism principle (p035 / t1363.6):
+# fixed thresholds fail on outliers; AI judgment handles context.
+#
+# Each judgment function:
+#   1. Tries AI judgment via ai-research-helper.sh (haiku tier)
+#   2. Falls back to improved heuristics if AI unavailable
+#   3. Returns a deterministic result (never blocks on AI failure)
+#
+# Usage:
+#   ai-threshold-judge.sh judge-prune-relevance --content "memory content" --age-days 95 --entity "user123"
+#   ai-threshold-judge.sh judge-dedup-similarity --content-a "text1" --content-b "text2"
+#   ai-threshold-judge.sh judge-prompt-length --entity "user123" --channel matrix --message-count 5
+#   ai-threshold-judge.sh help
+#
+# Exit codes: 0=success, 1=error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+set -euo pipefail
+
+LOG_PREFIX="THRESHOLD"
+
+readonly AI_RESEARCH="${SCRIPT_DIR}/ai-research-helper.sh"
+readonly MEMORY_BASE_DIR="${AIDEVOPS_MEMORY_DIR:-$HOME/.aidevops/.agent-workspace/memory}"
+
+#######################################
+# Judge whether a memory entry should be pruned
+# Replaces fixed DEFAULT_MAX_AGE_DAYS=90 with context-aware judgment.
+#
+# Arguments (via flags):
+#   --content    Memory content text
+#   --age-days   Days since creation
+#   --type       Memory type (WORKING_SOLUTION, etc.)
+#   --entity     Entity ID (optional — if set, checks entity relevance)
+#   --accessed   Whether ever accessed (true/false)
+#   --confidence Memory confidence level
+#
+# Output: "prune" or "keep" on stdout
+# Returns: 0 always (deterministic)
+#######################################
+cmd_judge_prune_relevance() {
+	local content="" age_days="" mem_type="" entity="" accessed="false" confidence=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--content)
+			content="$2"
+			shift 2
+			;;
+		--age-days)
+			age_days="$2"
+			shift 2
+			;;
+		--type)
+			mem_type="$2"
+			shift 2
+			;;
+		--entity)
+			entity="$2"
+			shift 2
+			;;
+		--accessed)
+			accessed="$2"
+			shift 2
+			;;
+		--confidence)
+			confidence="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$content" || -z "$age_days" ]]; then
+		log_error "Required: --content and --age-days"
+		echo "keep"
+		return 0
+	fi
+
+	# Fast path: never prune recently accessed high-confidence entries
+	if [[ "$accessed" == "true" && "$confidence" == "high" ]]; then
+		echo "keep"
+		return 0
+	fi
+
+	# Fast path: always prune very old, never-accessed, low-confidence entries
+	if [[ "$accessed" == "false" && "$age_days" -gt 180 && "$confidence" == "low" ]]; then
+		echo "prune"
+		return 0
+	fi
+
+	# Borderline cases: use AI judgment
+	if [[ -x "$AI_RESEARCH" ]]; then
+		local truncated_content="${content:0:300}"
+		local ai_prompt="You are a memory relevance judge. Given this memory entry, decide if it should be PRUNED (removed) or KEPT.
+
+Memory content (truncated): ${truncated_content}
+Age: ${age_days} days
+Type: ${mem_type:-unknown}
+Ever accessed: ${accessed}
+Confidence: ${confidence:-medium}
+Entity context: ${entity:-none}
+
+Consider:
+- WORKING_SOLUTION and ARCHITECTURAL_DECISION types are long-lived — keep unless very stale
+- ERROR_FIX entries lose relevance as codebases change — prune after ~120 days if never accessed
+- USER_PREFERENCE entries are valuable if tied to an active entity
+- CONTEXT entries are ephemeral — prune after ~60 days if never accessed
+- Never-accessed entries are less valuable than frequently-accessed ones
+
+Respond with ONLY one word: 'prune' or 'keep'"
+
+		local ai_result
+		ai_result=$("$AI_RESEARCH" --model haiku --max-tokens 10 --prompt "$ai_prompt" 2>/dev/null || echo "")
+		ai_result=$(echo "$ai_result" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+
+		if [[ "$ai_result" == "prune" || "$ai_result" == "keep" ]]; then
+			echo "$ai_result"
+			return 0
+		fi
+	fi
+
+	# Fallback: improved heuristics (better than flat 90-day cutoff)
+	case "${mem_type:-}" in
+	WORKING_SOLUTION | ARCHITECTURAL_DECISION)
+		# Long-lived types: 180 days if never accessed
+		if [[ "$accessed" == "false" && "$age_days" -gt 180 ]]; then
+			echo "prune"
+		else
+			echo "keep"
+		fi
+		;;
+	ERROR_FIX | FAILED_APPROACH)
+		# Medium-lived: 120 days if never accessed
+		if [[ "$accessed" == "false" && "$age_days" -gt 120 ]]; then
+			echo "prune"
+		else
+			echo "keep"
+		fi
+		;;
+	CONTEXT | OPEN_THREAD)
+		# Short-lived: 60 days if never accessed
+		if [[ "$accessed" == "false" && "$age_days" -gt 60 ]]; then
+			echo "prune"
+		else
+			echo "keep"
+		fi
+		;;
+	USER_PREFERENCE)
+		# Keep user preferences longer — 365 days
+		if [[ "$accessed" == "false" && "$age_days" -gt 365 ]]; then
+			echo "prune"
+		else
+			echo "keep"
+		fi
+		;;
+	*)
+		# Default: original 90-day threshold for unknown types
+		if [[ "$accessed" == "false" && "$age_days" -gt 90 ]]; then
+			echo "prune"
+		else
+			echo "keep"
+		fi
+		;;
+	esac
+
+	return 0
+}
+
+#######################################
+# Judge whether two memory entries are semantic duplicates
+# Replaces exact-string and normalized-string matching with AI similarity.
+#
+# Arguments (via flags):
+#   --content-a  First memory content
+#   --content-b  Second memory content
+#
+# Output: "duplicate" or "distinct" on stdout
+# Returns: 0 always (deterministic)
+#######################################
+cmd_judge_dedup_similarity() {
+	local content_a="" content_b=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--content-a)
+			content_a="$2"
+			shift 2
+			;;
+		--content-b)
+			content_b="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$content_a" || -z "$content_b" ]]; then
+		log_error "Required: --content-a and --content-b"
+		echo "distinct"
+		return 0
+	fi
+
+	# Fast path: exact match
+	if [[ "$content_a" == "$content_b" ]]; then
+		echo "duplicate"
+		return 0
+	fi
+
+	# Fast path: very different lengths suggest distinct content
+	local len_a=${#content_a}
+	local len_b=${#content_b}
+	local len_ratio
+	if [[ "$len_a" -gt "$len_b" ]]; then
+		len_ratio=$((len_a * 100 / (len_b + 1)))
+	else
+		len_ratio=$((len_b * 100 / (len_a + 1)))
+	fi
+	if [[ "$len_ratio" -gt 300 ]]; then
+		echo "distinct"
+		return 0
+	fi
+
+	# AI judgment for borderline cases
+	if [[ -x "$AI_RESEARCH" ]]; then
+		local trunc_a="${content_a:0:200}"
+		local trunc_b="${content_b:0:200}"
+		local ai_prompt="Are these two memory entries semantic duplicates (same information, possibly worded differently) or distinct (different information)?
+
+Entry A: ${trunc_a}
+Entry B: ${trunc_b}
+
+Respond with ONLY one word: 'duplicate' or 'distinct'"
+
+		local ai_result
+		ai_result=$("$AI_RESEARCH" --model haiku --max-tokens 10 --prompt "$ai_prompt" 2>/dev/null || echo "")
+		ai_result=$(echo "$ai_result" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+
+		if [[ "$ai_result" == "duplicate" || "$ai_result" == "distinct" ]]; then
+			echo "$ai_result"
+			return 0
+		fi
+	fi
+
+	# Fallback: normalized string comparison (existing behavior)
+	local norm_a norm_b
+	norm_a=$(echo "$content_a" | tr '[:upper:]' '[:lower:]' | sed "s/[.,'!?]//g" | tr -s '[:space:]' ' ')
+	norm_b=$(echo "$content_b" | tr '[:upper:]' '[:lower:]' | sed "s/[.,'!?]//g" | tr -s '[:space:]' ' ')
+
+	if [[ "$norm_a" == "$norm_b" ]]; then
+		echo "duplicate"
+	else
+		echo "distinct"
+	fi
+
+	return 0
+}
+
+#######################################
+# Judge optimal prompt/response length for an entity
+# Replaces fixed maxPromptLength: 4000 with entity-preference-aware sizing.
+#
+# Arguments (via flags):
+#   --entity         Entity ID (optional)
+#   --channel        Channel type (matrix, simplex, email, cli)
+#   --message-count  Number of messages in current conversation
+#   --last-messages  Recent message text for context (optional)
+#
+# Output: recommended max length (integer) on stdout
+# Returns: 0 always (deterministic)
+#######################################
+cmd_judge_prompt_length() {
+	local entity="" channel="" message_count="" last_messages=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--entity)
+			entity="$2"
+			shift 2
+			;;
+		--channel)
+			channel="$2"
+			shift 2
+			;;
+		--message-count)
+			message_count="$2"
+			shift 2
+			;;
+		--last-messages)
+			last_messages="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	# Check entity preferences in memory DB if entity is specified
+	local entity_pref_length=""
+	if [[ -n "$entity" ]]; then
+		local memory_db="${MEMORY_BASE_DIR}/memory.db"
+		if [[ -f "$memory_db" ]] && command -v sqlite3 &>/dev/null; then
+			local escaped_entity="${entity//"'"/"''"}"
+			# Check for stored preference about response length
+			entity_pref_length=$(sqlite3 "$memory_db" \
+				"SELECT content FROM learnings WHERE type = 'USER_PREFERENCE' AND (content LIKE '%response length%' OR content LIKE '%verbose%' OR content LIKE '%concise%' OR content LIKE '%brief%' OR content LIKE '%detailed%') AND entity_id = '${escaped_entity}' ORDER BY created_at DESC LIMIT 1;" 2>/dev/null || echo "")
+		fi
+	fi
+
+	# AI judgment if we have entity preference context
+	if [[ -x "$AI_RESEARCH" && -n "$entity_pref_length" ]]; then
+		local ai_prompt="Based on this user preference about response length, what is the optimal maximum response length in characters?
+
+User preference: ${entity_pref_length}
+Channel: ${channel:-unknown}
+Messages in conversation: ${message_count:-unknown}
+
+Consider:
+- Matrix/chat channels: shorter responses (2000-4000 chars)
+- Email: longer responses (4000-8000 chars)
+- CLI: medium responses (3000-6000 chars)
+- If user prefers concise/brief: use lower end
+- If user prefers detailed/verbose: use higher end
+
+Respond with ONLY a number (the recommended max character count)"
+
+		local ai_result
+		ai_result=$("$AI_RESEARCH" --model haiku --max-tokens 10 --prompt "$ai_prompt" 2>/dev/null || echo "")
+		ai_result=$(echo "$ai_result" | tr -dc '0-9')
+
+		if [[ -n "$ai_result" && "$ai_result" -gt 500 && "$ai_result" -lt 20000 ]]; then
+			echo "$ai_result"
+			return 0
+		fi
+	fi
+
+	# Fallback: channel-based defaults (better than flat 4000)
+	case "${channel:-}" in
+	matrix | simplex)
+		echo "3000"
+		;;
+	email)
+		echo "6000"
+		;;
+	cli)
+		echo "4000"
+		;;
+	*)
+		echo "4000"
+		;;
+	esac
+
+	return 0
+}
+
+#######################################
+# Display help
+#######################################
+cmd_help() {
+	cat <<'EOF'
+ai-threshold-judge.sh — AI-judged threshold decisions
+
+Replaces hardcoded thresholds with haiku-tier AI judgment (~$0.001/call).
+Falls back to improved heuristics when AI is unavailable.
+
+Commands:
+  judge-prune-relevance   Should a memory entry be pruned or kept?
+    --content TEXT         Memory content
+    --age-days N          Days since creation
+    --type TYPE           Memory type (WORKING_SOLUTION, ERROR_FIX, etc.)
+    --entity ID           Entity ID (optional)
+    --accessed true|false Whether ever accessed
+    --confidence LEVEL    Confidence level (low, medium, high)
+
+  judge-dedup-similarity  Are two entries semantic duplicates?
+    --content-a TEXT      First entry
+    --content-b TEXT      Second entry
+
+  judge-prompt-length     Optimal response length for entity/channel
+    --entity ID           Entity ID (optional)
+    --channel TYPE        Channel (matrix, simplex, email, cli)
+    --message-count N     Messages in conversation
+    --last-messages TEXT   Recent messages (optional)
+
+  help                    Show this help
+
+Examples:
+  ai-threshold-judge.sh judge-prune-relevance --content "CORS fix" --age-days 95 --type ERROR_FIX --accessed false
+  ai-threshold-judge.sh judge-dedup-similarity --content-a "Use nginx for CORS" --content-b "CORS handled by nginx proxy"
+  ai-threshold-judge.sh judge-prompt-length --channel matrix --entity user123
+EOF
+	return 0
+}
+
+#######################################
+# Main entry point
+#######################################
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	judge-prune-relevance)
+		cmd_judge_prune_relevance "$@"
+		;;
+	judge-dedup-similarity)
+		cmd_judge_dedup_similarity "$@"
+		;;
+	judge-prompt-length)
+		cmd_judge_prompt_length "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/services/communications/matrix-bot.md
+++ b/.agents/services/communications/matrix-bot.md
@@ -203,7 +203,7 @@ curl -X POST "https://matrix.example.com/_matrix/client/v3/login" \
   },
   "botPrefix": "!ai",
   "ignoreOwnMessages": true,
-  "maxPromptLength": 4000,
+  "maxPromptLength": 3000,
   "responseTimeout": 600,
   "sessionIdleTimeout": 300
 }
@@ -220,9 +220,9 @@ curl -X POST "https://matrix.example.com/_matrix/client/v3/login" \
 | `roomMappings` | `{}` | Room ID to runner name mapping |
 | `botPrefix` | `!ai` | Command prefix to trigger the bot |
 | `ignoreOwnMessages` | `true` | Ignore messages from the bot itself |
-| `maxPromptLength` | `4000` | Max response length before truncation |
+| `maxPromptLength` | `3000` | Max response length before truncation (channel-appropriate default) |
 | `responseTimeout` | `600` | Max seconds to wait for runner response |
-| `sessionIdleTimeout` | `300` | Seconds of inactivity before compacting a session |
+| `sessionIdleTimeout` | `300` | Fallback idle timeout in seconds (AI-judged idle detection is primary) |
 
 ## Room-to-Runner Mapping
 

--- a/tests/test-ai-threshold-judge.sh
+++ b/tests/test-ai-threshold-judge.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+set -euo pipefail
+
+# Test suite for ai-threshold-judge.sh and ai-research-helper.sh (t1363.6)
+# Tests the fallback heuristics (no API key needed) and script structure.
+# AI-judged paths are tested only when ANTHROPIC_API_KEY is available.
+#
+# Usage: bash tests/test-ai-threshold-judge.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+THRESHOLD_JUDGE="${REPO_DIR}/.agents/scripts/ai-threshold-judge.sh"
+AI_RESEARCH="${REPO_DIR}/.agents/scripts/ai-research-helper.sh"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+SKIP=0
+
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+
+	if [[ "$actual" == "$expected" ]]; then
+		echo -e "  ${GREEN}PASS${NC}: $description"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: $description (expected '$expected', got '$actual')"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_contains() {
+	local haystack="$1"
+	local needle="$2"
+	local description="$3"
+
+	if echo "$haystack" | grep -qF -- "$needle"; then
+		echo -e "  ${GREEN}PASS${NC}: $description"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: $description ('$needle' not found in output)"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_numeric() {
+	local value="$1"
+	local description="$2"
+
+	if [[ "$value" =~ ^[0-9]+$ ]]; then
+		echo -e "  ${GREEN}PASS${NC}: $description"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: $description (expected numeric, got '$value')"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+skip_test() {
+	local description="$1"
+	echo -e "  ${YELLOW}SKIP${NC}: $description"
+	SKIP=$((SKIP + 1))
+	return 0
+}
+
+# ============================================================
+# ai-research-helper.sh tests
+# ============================================================
+
+test_ai_research_help() {
+	echo ""
+	echo "=== ai-research-helper.sh ==="
+
+	local output
+	output=$("$AI_RESEARCH" --help 2>&1)
+	assert_contains "$output" "Lightweight Anthropic API wrapper" "help text shows description"
+	assert_contains "$output" "--prompt" "help text shows --prompt flag"
+	assert_contains "$output" "--model" "help text shows --model flag"
+	return 0
+}
+
+test_ai_research_no_prompt() {
+	local output
+	output=$("$AI_RESEARCH" 2>&1 || true)
+	assert_contains "$output" "No prompt provided" "error on missing prompt"
+	return 0
+}
+
+# ============================================================
+# ai-threshold-judge.sh tests
+# ============================================================
+
+test_threshold_help() {
+	echo ""
+	echo "=== ai-threshold-judge.sh help ==="
+
+	local output
+	output=$("$THRESHOLD_JUDGE" help 2>&1)
+	assert_contains "$output" "AI-judged threshold decisions" "help text shows description"
+	assert_contains "$output" "judge-prune-relevance" "help lists prune command"
+	assert_contains "$output" "judge-dedup-similarity" "help lists dedup command"
+	assert_contains "$output" "judge-prompt-length" "help lists prompt-length command"
+	return 0
+}
+
+test_threshold_unknown_command() {
+	local output
+	output=$("$THRESHOLD_JUDGE" nonexistent 2>&1 || true)
+	assert_contains "$output" "Unknown command" "error on unknown command"
+	return 0
+}
+
+# ============================================================
+# Prune relevance tests (heuristic fallback — no API needed)
+# ============================================================
+
+test_prune_high_confidence_accessed() {
+	echo ""
+	echo "=== Prune relevance: heuristic fallback ==="
+
+	# High confidence + accessed = always keep
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "CORS fix with nginx reverse proxy" \
+		--age-days 200 \
+		--type "WORKING_SOLUTION" \
+		--accessed "true" \
+		--confidence "high" 2>/dev/null)
+	assert_eq "keep" "$result" "high confidence + accessed = keep"
+	return 0
+}
+
+test_prune_very_old_low_confidence() {
+	# Very old + never accessed + low confidence = always prune
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "Temporary debug note" \
+		--age-days 200 \
+		--type "CONTEXT" \
+		--accessed "false" \
+		--confidence "low" 2>/dev/null)
+	assert_eq "prune" "$result" "very old + never accessed + low confidence = prune"
+	return 0
+}
+
+test_prune_working_solution_type() {
+	# WORKING_SOLUTION: long-lived, 180 day threshold
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "Use nginx for CORS headers" \
+		--age-days 100 \
+		--type "WORKING_SOLUTION" \
+		--accessed "false" \
+		--confidence "medium" 2>/dev/null)
+	assert_eq "keep" "$result" "WORKING_SOLUTION at 100 days = keep (threshold 180)"
+
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "Use nginx for CORS headers" \
+		--age-days 190 \
+		--type "WORKING_SOLUTION" \
+		--accessed "false" \
+		--confidence "medium" 2>/dev/null)
+	assert_eq "prune" "$result" "WORKING_SOLUTION at 190 days = prune (threshold 180)"
+	return 0
+}
+
+test_prune_error_fix_type() {
+	# ERROR_FIX: medium-lived, 120 day threshold
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "Fix: add missing semicolon in config" \
+		--age-days 100 \
+		--type "ERROR_FIX" \
+		--accessed "false" \
+		--confidence "medium" 2>/dev/null)
+	assert_eq "keep" "$result" "ERROR_FIX at 100 days = keep (threshold 120)"
+
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "Fix: add missing semicolon in config" \
+		--age-days 130 \
+		--type "ERROR_FIX" \
+		--accessed "false" \
+		--confidence "medium" 2>/dev/null)
+	assert_eq "prune" "$result" "ERROR_FIX at 130 days = prune (threshold 120)"
+	return 0
+}
+
+test_prune_context_type() {
+	# CONTEXT: short-lived, 60 day threshold
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "Working on feature branch for auth" \
+		--age-days 50 \
+		--type "CONTEXT" \
+		--accessed "false" \
+		--confidence "medium" 2>/dev/null)
+	assert_eq "keep" "$result" "CONTEXT at 50 days = keep (threshold 60)"
+
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "Working on feature branch for auth" \
+		--age-days 70 \
+		--type "CONTEXT" \
+		--accessed "false" \
+		--confidence "medium" 2>/dev/null)
+	assert_eq "prune" "$result" "CONTEXT at 70 days = prune (threshold 60)"
+	return 0
+}
+
+test_prune_user_preference_type() {
+	# USER_PREFERENCE: very long-lived, 365 day threshold
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "User prefers concise responses" \
+		--age-days 300 \
+		--type "USER_PREFERENCE" \
+		--accessed "false" \
+		--confidence "medium" 2>/dev/null)
+	assert_eq "keep" "$result" "USER_PREFERENCE at 300 days = keep (threshold 365)"
+
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance \
+		--content "User prefers concise responses" \
+		--age-days 400 \
+		--type "USER_PREFERENCE" \
+		--accessed "false" \
+		--confidence "medium" 2>/dev/null)
+	assert_eq "prune" "$result" "USER_PREFERENCE at 400 days = prune (threshold 365)"
+	return 0
+}
+
+test_prune_missing_args() {
+	# Missing required args = keep (safe default)
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prune-relevance --content "test" 2>/dev/null)
+	assert_eq "keep" "$result" "missing --age-days = keep (safe default)"
+	return 0
+}
+
+# ============================================================
+# Dedup similarity tests (heuristic fallback — no API needed)
+# ============================================================
+
+test_dedup_exact_match() {
+	echo ""
+	echo "=== Dedup similarity: heuristic fallback ==="
+
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-dedup-similarity \
+		--content-a "Use nginx for CORS headers" \
+		--content-b "Use nginx for CORS headers" 2>/dev/null)
+	assert_eq "duplicate" "$result" "exact match = duplicate"
+	return 0
+}
+
+test_dedup_normalized_match() {
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-dedup-similarity \
+		--content-a "Use nginx for CORS headers." \
+		--content-b "Use nginx for CORS headers" 2>/dev/null)
+	assert_eq "duplicate" "$result" "normalized match (punctuation) = duplicate"
+	return 0
+}
+
+test_dedup_very_different_lengths() {
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-dedup-similarity \
+		--content-a "Short" \
+		--content-b "This is a much longer piece of content that discusses many different topics and has a very different length from the first entry which makes it clearly distinct" 2>/dev/null)
+	assert_eq "distinct" "$result" "very different lengths = distinct"
+	return 0
+}
+
+test_dedup_clearly_different() {
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-dedup-similarity \
+		--content-a "Use nginx for CORS headers" \
+		--content-b "Deploy with Docker Compose on production" 2>/dev/null)
+	assert_eq "distinct" "$result" "clearly different content = distinct"
+	return 0
+}
+
+test_dedup_missing_args() {
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-dedup-similarity --content-a "test" 2>/dev/null)
+	assert_eq "distinct" "$result" "missing --content-b = distinct (safe default)"
+	return 0
+}
+
+# ============================================================
+# Prompt length tests (heuristic fallback — no API needed)
+# ============================================================
+
+test_prompt_length_matrix() {
+	echo ""
+	echo "=== Prompt length: channel defaults ==="
+
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prompt-length --channel matrix 2>/dev/null)
+	assert_eq "3000" "$result" "matrix channel = 3000"
+	return 0
+}
+
+test_prompt_length_email() {
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prompt-length --channel email 2>/dev/null)
+	assert_eq "6000" "$result" "email channel = 6000"
+	return 0
+}
+
+test_prompt_length_cli() {
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prompt-length --channel cli 2>/dev/null)
+	assert_eq "4000" "$result" "cli channel = 4000"
+	return 0
+}
+
+test_prompt_length_simplex() {
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prompt-length --channel simplex 2>/dev/null)
+	assert_eq "3000" "$result" "simplex channel = 3000"
+	return 0
+}
+
+test_prompt_length_default() {
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prompt-length 2>/dev/null)
+	assert_eq "4000" "$result" "no channel = 4000 default"
+	return 0
+}
+
+test_prompt_length_numeric() {
+	local result
+	result=$("$THRESHOLD_JUDGE" judge-prompt-length --channel matrix 2>/dev/null)
+	assert_numeric "$result" "prompt length is numeric"
+	return 0
+}
+
+# ============================================================
+# Main
+# ============================================================
+
+main() {
+	echo "============================================"
+	echo "  ai-threshold-judge.sh + ai-research-helper.sh tests"
+	echo "============================================"
+
+	# Verify scripts exist
+	if [[ ! -x "$THRESHOLD_JUDGE" ]]; then
+		echo -e "${RED}ERROR${NC}: ai-threshold-judge.sh not found or not executable"
+		exit 1
+	fi
+	if [[ ! -x "$AI_RESEARCH" ]]; then
+		echo -e "${RED}ERROR${NC}: ai-research-helper.sh not found or not executable"
+		exit 1
+	fi
+
+	# ai-research-helper tests
+	test_ai_research_help
+	test_ai_research_no_prompt
+
+	# ai-threshold-judge tests
+	test_threshold_help
+	test_threshold_unknown_command
+
+	# Prune relevance (heuristic fallback)
+	test_prune_high_confidence_accessed
+	test_prune_very_old_low_confidence
+	test_prune_working_solution_type
+	test_prune_error_fix_type
+	test_prune_context_type
+	test_prune_user_preference_type
+	test_prune_missing_args
+
+	# Dedup similarity (heuristic fallback)
+	test_dedup_exact_match
+	test_dedup_normalized_match
+	test_dedup_very_different_lengths
+	test_dedup_clearly_different
+	test_dedup_missing_args
+
+	# Prompt length (channel defaults)
+	test_prompt_length_matrix
+	test_prompt_length_email
+	test_prompt_length_cli
+	test_prompt_length_simplex
+	test_prompt_length_default
+	test_prompt_length_numeric
+
+	# Summary
+	echo ""
+	echo "============================================"
+	echo -e "Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}, ${YELLOW}${SKIP} skipped${NC}"
+	echo "============================================"
+
+	if [[ "$FAIL" -gt 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Replace hardcoded thresholds across the framework with haiku-tier AI judgment (~$0.001/call), with type-aware heuristic fallbacks when AI is unavailable
- Add `ai-research-helper.sh` (lightweight Anthropic API wrapper) and `ai-threshold-judge.sh` (domain-specific threshold decisions)
- Matrix bot idle detection now uses conversation context analysis instead of fixed 300s timeout; memory pruning uses per-type thresholds (60-365 days) instead of flat 90-day cutoff; dedup gains `--semantic` flag for AI-judged similarity

## Thresholds replaced

| Before | After | Fallback |
|--------|-------|----------|
| `sessionIdleTimeout: 300` (flat) | AI judges "has this conversation naturally paused?" | Configured timeout value |
| `DEFAULT_MAX_AGE_DAYS=90` (flat) | AI judges per-entry relevance by type/confidence/access | Type-aware: 60d (CONTEXT) to 365d (USER_PREFERENCE) |
| Exact-string dedup only | `--semantic` flag: AI judges semantic similarity | Normalized-string matching |
| `maxPromptLength: 4000` (flat) | Channel-appropriate default (3000 for Matrix/SimpleX) | Configurable per-channel |

## New files

- `.agents/scripts/ai-research-helper.sh` — Anthropic API wrapper (haiku default, gopass/env/credentials.sh key resolution)
- `.agents/scripts/ai-threshold-judge.sh` — `judge-prune-relevance`, `judge-dedup-similarity`, `judge-prompt-length` commands
- `tests/test-ai-threshold-judge.sh` — 31 tests covering all heuristic fallback paths

## Modified files

- `.agents/scripts/memory/_common.sh` — `auto_prune()` uses AI-judged relevance per entry
- `.agents/scripts/memory/maintenance.sh` — `cmd_prune --ai-judged`, `cmd_dedup --semantic`
- `.agents/scripts/matrix-dispatch-helper.sh` — AI-judged idle detection, channel-appropriate prompt length
- `.agents/services/communications/matrix-bot.md` — Updated config documentation

## Testing

- 31/31 tests pass (heuristic fallback paths, no API key required)
- ShellCheck clean on all new/modified shell scripts
- Existing conversation-helper tests unaffected (pre-existing timeout in test suite)

## Design decisions

- **AI calls are optional**: every judgment has a deterministic fallback. No API key = improved heuristics still better than flat thresholds
- **Cost control**: haiku tier (~$0.001/call), `--semantic` dedup is opt-in, auto-prune runs max once per 24h
- **No breaking changes**: existing configs continue to work; `sessionIdleTimeout` becomes a fallback value rather than the primary mechanism

Closes #2526