### PR TITLE
t1363.6: Intelligent threshold replacement

### DIFF
--- a/.agents/scripts/ai-judgment-helper.sh
+++ b/.agents/scripts/ai-judgment-helper.sh
@@ -1,0 +1,715 @@
+#!/usr/bin/env bash
+# ai-judgment-helper.sh - Intelligent threshold replacement for aidevops
+# Replaces hardcoded thresholds with AI judgment calls (haiku-tier, ~$0.001 each).
+#
+# Part of the conversational memory system (p035 / t1363.6).
+# Per the Intelligence Over Determinism principle: deterministic rules break on
+# outliers; a haiku-tier call handles edge cases that no fixed threshold can.
+#
+# Thresholds replaced:
+#   1. sessionIdleTimeout: 300 → AI judges "has this conversation naturally paused?"
+#      (Delegated to conversation-helper.sh idle-check which already implements this)
+#   2. DEFAULT_MAX_AGE_DAYS=90 → AI judges "is this memory still relevant?"
+#   3. maxPromptLength: 4000 → Dynamic based on entity's observed detail preference
+#
+# Usage:
+#   ai-judgment-helper.sh is-memory-relevant --content "memory text" [--entity <id>] [--age-days N]
+#   ai-judgment-helper.sh optimal-response-length --entity <id> [--channel matrix] [--default 4000]
+#   ai-judgment-helper.sh should-prune --memory-id <id> [--dry-run]
+#   ai-judgment-helper.sh batch-prune-check [--older-than-days 60] [--limit 50] [--dry-run]
+#   ai-judgment-helper.sh help
+#
+# Design:
+#   - Every judgment has a deterministic fallback (the old threshold)
+#   - AI calls are optional — if ANTHROPIC_API_KEY is missing, fallback is used
+#   - Results are cached in memory.db to avoid repeated calls for the same decision
+#   - Batch operations rate-limit to avoid API cost spikes
+#
+# Exit codes:
+#   0 - Success
+#   1 - Error
+#   2 - API unavailable (fallback used, still exits 0 for callers)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+set -euo pipefail
+
+# Configuration
+readonly JUDGMENT_MEMORY_BASE_DIR="${AIDEVOPS_MEMORY_DIR:-$HOME/.aidevops/.agent-workspace/memory}"
+JUDGMENT_MEMORY_DB="${JUDGMENT_MEMORY_BASE_DIR}/memory.db"
+readonly AI_HELPER="${SCRIPT_DIR}/ai-research-helper.sh"
+
+# Fallback thresholds (used when AI is unavailable)
+readonly FALLBACK_MAX_AGE_DAYS=90
+readonly FALLBACK_MAX_PROMPT_LENGTH=4000
+readonly FALLBACK_IDLE_TIMEOUT=300
+
+# Cache TTL for judgment results (seconds) — avoid re-judging the same memory
+readonly JUDGMENT_CACHE_TTL=86400 # 24 hours
+
+#######################################
+# SQLite wrapper
+#######################################
+judgment_db() {
+	sqlite3 -cmd ".timeout 5000" "$@"
+}
+
+#######################################
+# Initialize judgment cache table
+#######################################
+init_judgment_cache() {
+	mkdir -p "$JUDGMENT_MEMORY_BASE_DIR"
+
+	judgment_db "$JUDGMENT_MEMORY_DB" <<'SCHEMA'
+CREATE TABLE IF NOT EXISTS ai_judgment_cache (
+    key TEXT PRIMARY KEY,
+    judgment TEXT NOT NULL,
+    reasoning TEXT DEFAULT '',
+    model TEXT DEFAULT 'haiku',
+    created_at TEXT DEFAULT (datetime('now')),
+    expires_at TEXT DEFAULT (datetime('now', '+1 day'))
+);
+
+-- Index for expiry cleanup
+CREATE INDEX IF NOT EXISTS idx_judgment_cache_expires
+    ON ai_judgment_cache(expires_at);
+SCHEMA
+	return 0
+}
+
+#######################################
+# Check judgment cache
+# Returns: cached judgment or empty string
+#######################################
+get_cached_judgment() {
+	local key="$1"
+	local escaped_key="${key//\'/\'\'}"
+
+	local result
+	result=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+		"SELECT judgment FROM ai_judgment_cache WHERE key = '$escaped_key' AND expires_at > datetime('now');" \
+		2>/dev/null || echo "")
+	echo "$result"
+	return 0
+}
+
+#######################################
+# Store judgment in cache
+#######################################
+cache_judgment() {
+	local key="$1"
+	local judgment="$2"
+	local reasoning="${3:-}"
+	local model="${4:-haiku}"
+
+	local escaped_key="${key//\'/\'\'}"
+	local escaped_judgment="${judgment//\'/\'\'}"
+	local escaped_reasoning="${reasoning//\'/\'\'}"
+
+	judgment_db "$JUDGMENT_MEMORY_DB" <<EOF
+INSERT OR REPLACE INTO ai_judgment_cache (key, judgment, reasoning, model, created_at, expires_at)
+VALUES ('$escaped_key', '$escaped_judgment', '$escaped_reasoning', '$model', datetime('now'), datetime('now', '+1 day'));
+EOF
+	return 0
+}
+
+#######################################
+# Clean expired cache entries
+#######################################
+clean_judgment_cache() {
+	judgment_db "$JUDGMENT_MEMORY_DB" \
+		"DELETE FROM ai_judgment_cache WHERE expires_at < datetime('now');" \
+		2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Check if AI judgment is available
+#######################################
+ai_available() {
+	[[ -x "$AI_HELPER" ]] && "$AI_HELPER" --prompt "test" --max-tokens 1 --quiet >/dev/null 2>&1
+}
+
+#######################################
+# Judge whether a memory is still relevant
+# Replaces: DEFAULT_MAX_AGE_DAYS=90 (fixed prune threshold)
+#
+# Arguments:
+#   --content TEXT    Memory content to evaluate
+#   --entity ID       Entity ID (optional — for entity-relationship context)
+#   --age-days N      Age of the memory in days
+#   --tags TAGS       Memory tags (optional)
+#   --type TYPE       Memory type (optional)
+#
+# Output: "relevant" or "prune" on stdout
+# Exit: 0 always (fallback on error)
+#######################################
+cmd_is_memory_relevant() {
+	local content=""
+	local entity_id=""
+	local age_days=""
+	local tags=""
+	local mem_type=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--content)
+			content="$2"
+			shift 2
+			;;
+		--entity)
+			entity_id="$2"
+			shift 2
+			;;
+		--age-days)
+			age_days="$2"
+			shift 2
+			;;
+		--tags)
+			tags="$2"
+			shift 2
+			;;
+		--type)
+			mem_type="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$content" ]]; then
+		log_error "Usage: ai-judgment-helper.sh is-memory-relevant --content \"text\" [--age-days N]"
+		return 1
+	fi
+
+	init_judgment_cache
+
+	# Generate cache key from content hash
+	local cache_key
+	cache_key="relevance:$(echo -n "$content" | md5sum | cut -d' ' -f1)"
+	local cached
+	cached=$(get_cached_judgment "$cache_key")
+	if [[ -n "$cached" ]]; then
+		echo "$cached"
+		return 0
+	fi
+
+	# Try AI judgment
+	if [[ -x "$AI_HELPER" ]]; then
+		local context_info=""
+		[[ -n "$age_days" ]] && context_info="Age: ${age_days} days. "
+		[[ -n "$tags" ]] && context_info="${context_info}Tags: ${tags}. "
+		[[ -n "$mem_type" ]] && context_info="${context_info}Type: ${mem_type}. "
+
+		# Build entity context if available
+		local entity_context=""
+		if [[ -n "$entity_id" ]]; then
+			local entity_name
+			entity_name=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+				"SELECT name FROM entities WHERE id = '${entity_id//\'/\'\'}' LIMIT 1;" \
+				2>/dev/null || echo "")
+			if [[ -n "$entity_name" ]]; then
+				entity_context="This memory is associated with entity '${entity_name}'. "
+			fi
+		fi
+
+		local prompt="You are evaluating whether a stored memory/learning should be kept or pruned.
+${context_info}${entity_context}
+Memory content: ${content}
+
+Is this memory still likely to be useful? Consider:
+- Is it a timeless pattern/solution, or time-sensitive info that's likely outdated?
+- Would someone working on this codebase/project benefit from knowing this?
+- Is it specific enough to be actionable, or too vague to help?
+
+Respond with ONLY one word: 'relevant' or 'prune'"
+
+		local result
+		result=$("$AI_HELPER" --prompt "$prompt" --model haiku --max-tokens 10 2>/dev/null || echo "")
+		result=$(echo "$result" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
+
+		if [[ "$result" == "relevant" || "$result" == "prune" ]]; then
+			cache_judgment "$cache_key" "$result" "" "haiku"
+			echo "$result"
+			return 0
+		fi
+	fi
+
+	# Fallback: use the old threshold
+	if [[ -n "$age_days" && "$age_days" -gt "$FALLBACK_MAX_AGE_DAYS" ]]; then
+		echo "prune"
+	else
+		echo "relevant"
+	fi
+	return 0
+}
+
+#######################################
+# Determine optimal response length for an entity
+# Replaces: maxPromptLength: 4000 (fixed truncation)
+#
+# Arguments:
+#   --entity ID       Entity ID to check preferences for
+#   --channel TYPE    Channel type (matrix, simplex, etc.)
+#   --default N       Default length if no preference found (default: 4000)
+#
+# Output: integer (max response length in characters)
+#######################################
+cmd_optimal_response_length() {
+	local entity_id=""
+	local channel=""
+	local default_length=$FALLBACK_MAX_PROMPT_LENGTH
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--entity)
+			entity_id="$2"
+			shift 2
+			;;
+		--channel)
+			channel="$2"
+			shift 2
+			;;
+		--default)
+			default_length="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	init_judgment_cache
+
+	# If no entity, return default
+	if [[ -z "$entity_id" ]]; then
+		echo "$default_length"
+		return 0
+	fi
+
+	# Look up entity
+	local entity_name
+	entity_name=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+		"SELECT name FROM entities WHERE id = '${entity_id//\'/\'\'}' LIMIT 1;" \
+		2>/dev/null || echo "")
+
+	if [[ -z "$entity_name" ]]; then
+		echo "$default_length"
+		return 0
+	fi
+
+	# Check entity profile for explicit detail preference FIRST
+	# An explicit preference always wins — no caching needed (local DB lookup is cheap)
+	# Latest version = not superseded by any other entry
+	local detail_pref
+	detail_pref=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+		"SELECT ep.profile_value FROM entity_profiles ep
+		 WHERE ep.entity_id = '${entity_id//\'/\'\'}' AND ep.profile_key = 'detail_preference'
+		   AND ep.id NOT IN (SELECT supersedes_id FROM entity_profiles WHERE supersedes_id IS NOT NULL)
+		 ORDER BY ep.created_at DESC LIMIT 1;" \
+		2>/dev/null || echo "")
+
+	# If we have a stored preference, use it directly (no caching — profile is authoritative)
+	if [[ -n "$detail_pref" ]]; then
+		case "$detail_pref" in
+		concise | brief | short)
+			echo "2000"
+			return 0
+			;;
+		normal | moderate)
+			echo "4000"
+			return 0
+			;;
+		detailed | verbose | long)
+			echo "8000"
+			return 0
+			;;
+		esac
+	fi
+
+	# Get interaction data for AI judgment and heuristic fallback
+	local channel_filter=""
+	if [[ -n "$channel" ]]; then
+		channel_filter="AND i.channel = '${channel//\'/\'\'}'"
+	fi
+
+	local avg_msg_length interaction_count
+	avg_msg_length=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+		"SELECT COALESCE(AVG(LENGTH(i.content)), 0) FROM interactions i
+		 JOIN conversations c ON i.conversation_id = c.id
+		 WHERE c.entity_id = '${entity_id//\'/\'\'}' AND i.direction = 'outbound'
+		 $channel_filter
+		 ORDER BY i.created_at DESC LIMIT 50;" \
+		2>/dev/null || echo "0")
+
+	interaction_count=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+		"SELECT COUNT(*) FROM interactions i
+		 JOIN conversations c ON i.conversation_id = c.id
+		 WHERE c.entity_id = '${entity_id//\'/\'\'}' AND i.direction = 'inbound'
+		 $channel_filter;" \
+		2>/dev/null || echo "0")
+
+	# Not enough interaction data for AI judgment — use default
+	if [[ "$interaction_count" -lt 5 ]]; then
+		echo "$default_length"
+		return 0
+	fi
+
+	# Cache key for AI judgment results (not used for profile-based results)
+	local cache_key="response_length:${entity_id}:${channel}"
+	local cached
+	cached=$(get_cached_judgment "$cache_key")
+	if [[ -n "$cached" ]]; then
+		echo "$cached"
+		return 0
+	fi
+
+	# Try AI judgment based on interaction patterns
+	if [[ -x "$AI_HELPER" ]]; then
+		# Get sample of recent inbound messages to gauge user's communication style
+		local recent_inbound
+		recent_inbound=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+			"SELECT substr(i.content, 1, 100) FROM interactions i
+			 JOIN conversations c ON i.conversation_id = c.id
+			 WHERE c.entity_id = '${entity_id//\'/\'\'}' AND i.direction = 'inbound'
+			 $channel_filter
+			 ORDER BY i.created_at DESC LIMIT 5;" \
+			2>/dev/null || echo "")
+
+		if [[ -n "$recent_inbound" ]]; then
+			local prompt="Based on these recent messages from a user, what response length do they prefer?
+
+Recent messages from user:
+$recent_inbound
+
+Average response length so far: ${avg_msg_length} chars
+Total interactions: ${interaction_count}
+
+Respond with ONLY a number: 2000 (concise), 4000 (normal), or 8000 (detailed)"
+
+			local result
+			result=$("$AI_HELPER" --prompt "$prompt" --model haiku --max-tokens 10 2>/dev/null || echo "")
+			result=$(echo "$result" | tr -dc '0-9')
+
+			if [[ -n "$result" && "$result" -ge 1000 && "$result" -le 16000 ]]; then
+				cache_judgment "$cache_key" "$result"
+				echo "$result"
+				return 0
+			fi
+		fi
+	fi
+
+	# Fallback: scale based on average outbound message length
+	# If we've been sending short responses, keep them short
+	local avg_int
+	avg_int=$(printf "%.0f" "$avg_msg_length" 2>/dev/null || echo "0")
+	if [[ "$avg_int" -gt 0 && "$avg_int" -lt 2000 ]]; then
+		echo "3000"
+	elif [[ "$avg_int" -gt 6000 ]]; then
+		echo "8000"
+	else
+		echo "$default_length"
+	fi
+	return 0
+}
+
+#######################################
+# Check if a specific memory should be pruned
+# Combines age, access patterns, and AI judgment
+#
+# Arguments:
+#   --memory-id ID    Memory ID to check
+#   --dry-run         Don't actually prune, just report
+#
+# Output: "keep" or "prune" with reasoning
+#######################################
+cmd_should_prune() {
+	local memory_id=""
+	local dry_run=false
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--memory-id)
+			memory_id="$2"
+			shift 2
+			;;
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$memory_id" ]]; then
+		log_error "Usage: ai-judgment-helper.sh should-prune --memory-id <id>"
+		return 1
+	fi
+
+	init_judgment_cache
+
+	# Get memory details
+	local escaped_id="${memory_id//\'/\'\'}"
+	local mem_data
+	mem_data=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+		"SELECT l.content, l.type, l.tags, l.created_at,
+		        COALESCE(a.access_count, 0) as access_count,
+		        COALESCE(a.last_accessed_at, '') as last_accessed
+		 FROM learnings l
+		 LEFT JOIN learning_access a ON l.id = a.id
+		 WHERE l.id = '$escaped_id';" \
+		2>/dev/null || echo "")
+
+	if [[ -z "$mem_data" ]]; then
+		log_error "Memory not found: $memory_id"
+		return 1
+	fi
+
+	# Parse fields
+	local content type tags created_at access_count last_accessed
+	IFS='|' read -r content type tags created_at access_count last_accessed <<<"$mem_data"
+
+	# Calculate age in days
+	local created_epoch now_epoch age_days
+	created_epoch=$(date -d "$created_at" +%s 2>/dev/null || date -j -f "%Y-%m-%d %H:%M:%S" "$created_at" +%s 2>/dev/null || echo "0")
+	now_epoch=$(date +%s)
+	age_days=$(((now_epoch - created_epoch) / 86400))
+
+	# Quick keep: recently accessed memories are always kept
+	if [[ "$access_count" -gt 0 && -n "$last_accessed" ]]; then
+		local last_epoch
+		last_epoch=$(date -d "$last_accessed" +%s 2>/dev/null || date -j -f "%Y-%m-%d %H:%M:%S" "$last_accessed" +%s 2>/dev/null || echo "0")
+		local days_since_access=$(((now_epoch - last_epoch) / 86400))
+		if [[ "$days_since_access" -lt 30 ]]; then
+			echo "keep (accessed $days_since_access days ago, $access_count times total)"
+			return 0
+		fi
+	fi
+
+	# Quick prune: very old, never accessed
+	if [[ "$age_days" -gt 180 && "$access_count" -eq 0 ]]; then
+		echo "prune (${age_days} days old, never accessed)"
+		return 0
+	fi
+
+	# Check for entity relationships
+	local entity_linked
+	entity_linked=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+		"SELECT COUNT(*) FROM learning_entities WHERE learning_id = '$escaped_id';" \
+		2>/dev/null || echo "0")
+
+	# AI judgment for borderline cases
+	local result
+	result=$(cmd_is_memory_relevant \
+		--content "$content" \
+		--age-days "$age_days" \
+		--tags "$tags" \
+		--type "$type")
+
+	if [[ "$result" == "prune" ]]; then
+		local reason="AI judged irrelevant (${age_days}d old, ${access_count} accesses"
+		[[ "$entity_linked" -gt 0 ]] && reason="${reason}, linked to ${entity_linked} entities"
+		reason="${reason})"
+		echo "prune ($reason)"
+	else
+		echo "keep (AI judged relevant, ${age_days}d old, ${access_count} accesses)"
+	fi
+	return 0
+}
+
+#######################################
+# Batch prune check — evaluate multiple memories
+# Replaces the blanket DEFAULT_MAX_AGE_DAYS=90 prune
+#
+# Arguments:
+#   --older-than-days N   Only check memories older than N days (default: 60)
+#   --limit N             Max memories to check per batch (default: 50)
+#   --dry-run             Report only, don't prune
+#
+# Output: summary of keep/prune decisions
+#######################################
+cmd_batch_prune_check() {
+	local older_than_days=60
+	local limit=50
+	local dry_run=false
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--older-than-days)
+			older_than_days="$2"
+			shift 2
+			;;
+		--limit)
+			limit="$2"
+			shift 2
+			;;
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+
+	init_judgment_cache
+	clean_judgment_cache
+
+	# Find candidate memories (old, never or rarely accessed)
+	local candidates
+	candidates=$(judgment_db "$JUDGMENT_MEMORY_DB" \
+		"SELECT l.id, substr(l.content, 1, 100), l.type, l.tags, l.created_at,
+		        COALESCE(a.access_count, 0) as access_count
+		 FROM learnings l
+		 LEFT JOIN learning_access a ON l.id = a.id
+		 WHERE l.created_at < datetime('now', '-$older_than_days days')
+		 ORDER BY COALESCE(a.access_count, 0) ASC, l.created_at ASC
+		 LIMIT $limit;" \
+		2>/dev/null || echo "")
+
+	if [[ -z "$candidates" ]]; then
+		log_info "No memories older than $older_than_days days to evaluate"
+		return 0
+	fi
+
+	local keep_count=0
+	local prune_count=0
+	local prune_ids=()
+
+	while IFS='|' read -r mem_id content type tags created_at access_count; do
+		[[ -z "$mem_id" ]] && continue
+
+		# Calculate age
+		local created_epoch now_epoch age_days
+		created_epoch=$(date -d "$created_at" +%s 2>/dev/null || date -j -f "%Y-%m-%d %H:%M:%S" "$created_at" +%s 2>/dev/null || echo "0")
+		now_epoch=$(date +%s)
+		age_days=$(((now_epoch - created_epoch) / 86400))
+
+		# Quick decisions first (no API call needed)
+		if [[ "$access_count" -gt 3 ]]; then
+			keep_count=$((keep_count + 1))
+			continue
+		fi
+
+		if [[ "$age_days" -gt 180 && "$access_count" -eq 0 ]]; then
+			prune_count=$((prune_count + 1))
+			prune_ids+=("$mem_id")
+			continue
+		fi
+
+		# AI judgment for borderline cases
+		local result
+		result=$(cmd_is_memory_relevant \
+			--content "$content" \
+			--age-days "$age_days" \
+			--tags "$tags" \
+			--type "$type")
+
+		if [[ "$result" == "prune" ]]; then
+			prune_count=$((prune_count + 1))
+			prune_ids+=("$mem_id")
+		else
+			keep_count=$((keep_count + 1))
+		fi
+
+		# Rate limit: small delay between AI calls
+		sleep 0.1
+	done <<<"$candidates"
+
+	# Report
+	log_info "Batch prune check: $keep_count keep, $prune_count prune (of $((keep_count + prune_count)) evaluated)"
+
+	if [[ "$dry_run" == true ]]; then
+		if [[ ${#prune_ids[@]} -gt 0 ]]; then
+			log_info "[DRY RUN] Would prune: ${prune_ids[*]}"
+		fi
+	else
+		# Actually prune
+		if [[ ${#prune_ids[@]} -gt 0 ]]; then
+			for pid in "${prune_ids[@]}"; do
+				local escaped_pid="${pid//\'/\'\'}"
+				judgment_db "$JUDGMENT_MEMORY_DB" "DELETE FROM learning_relations WHERE id = '$escaped_pid' OR supersedes_id = '$escaped_pid';" 2>/dev/null || true
+				judgment_db "$JUDGMENT_MEMORY_DB" "DELETE FROM learning_access WHERE id = '$escaped_pid';" 2>/dev/null || true
+				judgment_db "$JUDGMENT_MEMORY_DB" "DELETE FROM learning_entities WHERE learning_id = '$escaped_pid';" 2>/dev/null || true
+				judgment_db "$JUDGMENT_MEMORY_DB" "DELETE FROM learnings WHERE id = '$escaped_pid';" 2>/dev/null || true
+			done
+			judgment_db "$JUDGMENT_MEMORY_DB" "INSERT INTO learnings(learnings) VALUES('rebuild');" 2>/dev/null || true
+			log_success "Pruned $prune_count memories (AI-judged irrelevant)"
+		fi
+	fi
+
+	return 0
+}
+
+#######################################
+# Help
+#######################################
+cmd_help() {
+	cat <<'HELP'
+ai-judgment-helper.sh - Intelligent threshold replacement
+
+Replaces hardcoded thresholds with AI judgment calls (haiku-tier, ~$0.001 each).
+Falls back to deterministic thresholds when AI is unavailable.
+
+Commands:
+  is-memory-relevant    Judge if a memory should be kept or pruned
+  optimal-response-length  Determine ideal response length for an entity
+  should-prune          Check if a specific memory should be pruned
+  batch-prune-check     Evaluate multiple memories for pruning
+  help                  Show this help
+
+Thresholds replaced:
+  sessionIdleTimeout: 300  → conversation-helper.sh idle-check (AI-judged)
+  DEFAULT_MAX_AGE_DAYS=90  → is-memory-relevant / batch-prune-check
+  maxPromptLength: 4000    → optimal-response-length (entity-preference-aware)
+
+Examples:
+  # Check if a memory is still relevant
+  ai-judgment-helper.sh is-memory-relevant --content "CORS fix: add nginx proxy" --age-days 120
+
+  # Get optimal response length for an entity
+  ai-judgment-helper.sh optimal-response-length --entity ent_abc123 --channel matrix
+
+  # Batch evaluate old memories (dry run)
+  ai-judgment-helper.sh batch-prune-check --older-than-days 60 --limit 20 --dry-run
+
+  # Replace the old prune command with intelligent pruning
+  ai-judgment-helper.sh batch-prune-check --older-than-days 60
+
+Environment:
+  ANTHROPIC_API_KEY  Required for AI judgment (falls back to heuristics without it)
+
+Cost: ~$0.001 per haiku judgment call. Batch of 50 memories ≈ $0.05.
+HELP
+	return 0
+}
+
+#######################################
+# Main dispatch
+#######################################
+main() {
+	if [[ $# -eq 0 ]]; then
+		cmd_help
+		return 0
+	fi
+
+	local command="$1"
+	shift
+
+	case "$command" in
+	is-memory-relevant) cmd_is_memory_relevant "$@" ;;
+	optimal-response-length) cmd_optimal_response_length "$@" ;;
+	should-prune) cmd_should_prune "$@" ;;
+	batch-prune-check) cmd_batch_prune_check "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		log_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+# Only run main if not being sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# ai-research-helper.sh - Lightweight Anthropic API wrapper for AI judgment calls
+# Provides haiku-tier (~$0.001/call) AI judgment for replacing hardcoded thresholds.
+#
+# Part of the conversational memory system (p035 / t1363.6).
+# Used by conversation-helper.sh (idle detection), memory-helper.sh (prune relevance),
+# matrix-dispatch-helper.sh (response sizing), and ai-judgment-helper.sh (threshold decisions).
+#
+# Usage:
+#   ai-research-helper.sh --prompt "Is this conversation idle?" [--model haiku] [--max-tokens 50]
+#   ai-research-helper.sh --prompt "Is this memory relevant?" --model haiku --max-tokens 10
+#
+# Options:
+#   --prompt TEXT       The prompt to send (required)
+#   --model MODEL       Model tier: haiku (default), sonnet, opus
+#   --max-tokens N      Maximum response tokens (default: 100)
+#   --system TEXT        System prompt (optional)
+#   --json              Request JSON output format
+#   --quiet             Suppress stderr logging
+#
+# Environment:
+#   ANTHROPIC_API_KEY   API key (or loaded from gopass/credentials.sh)
+#
+# Cost guidance:
+#   haiku:  ~$0.001 per call (judgment calls, yes/no decisions)
+#   sonnet: ~$0.01 per call  (summaries, analysis)
+#   opus:   ~$0.10 per call  (complex reasoning — avoid for thresholds)
+#
+# Exit codes:
+#   0 - Success (response on stdout)
+#   1 - Missing dependencies or configuration
+#   2 - API error (rate limit, auth, etc.)
+#   3 - Invalid arguments
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+
+# Source shared constants if available (for log_* functions)
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+	# shellcheck source=shared-constants.sh
+	source "${SCRIPT_DIR}/shared-constants.sh"
+else
+	# Minimal fallback logging
+	log_info() { echo "[INFO] $*" >&2; }
+	log_error() { echo "[ERROR] $*" >&2; }
+	log_warn() { echo "[WARN] $*" >&2; }
+fi
+
+set -euo pipefail
+
+# Model name mapping
+declare -A MODEL_MAP=(
+	[haiku]="claude-3-5-haiku-20241022"
+	[sonnet]="claude-sonnet-4-20250514"
+	[opus]="claude-opus-4-20250514"
+)
+
+#######################################
+# Load Anthropic API key
+# Priority: env var > gopass > credentials.sh
+#######################################
+load_api_key() {
+	# Already set in environment
+	if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+		return 0
+	fi
+
+	# Try gopass
+	if command -v gopass >/dev/null 2>&1; then
+		ANTHROPIC_API_KEY="$(gopass show -o "aidevops/anthropic-api-key" 2>/dev/null)" || true
+		if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+			export ANTHROPIC_API_KEY
+			return 0
+		fi
+	fi
+
+	# Try credentials.sh
+	local cred_file="${HOME}/.config/aidevops/credentials.sh"
+	if [[ -f "$cred_file" ]]; then
+		# shellcheck source=/dev/null
+		source "$cred_file"
+		if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+			export ANTHROPIC_API_KEY
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
+#######################################
+# Make an Anthropic API call
+# Arguments:
+#   $1 - prompt text
+#   $2 - model tier (haiku|sonnet|opus)
+#   $3 - max tokens
+#   $4 - system prompt (optional)
+# Output: response text on stdout
+#######################################
+call_anthropic() {
+	local prompt="$1"
+	local model_tier="$2"
+	local max_tokens="$3"
+	local system_prompt="${4:-}"
+
+	local model_id="${MODEL_MAP[$model_tier]:-${MODEL_MAP[haiku]}}"
+
+	# Build the request JSON
+	local request_body
+	if [[ -n "$system_prompt" ]]; then
+		request_body=$(jq -n \
+			--arg model "$model_id" \
+			--argjson max_tokens "$max_tokens" \
+			--arg system "$system_prompt" \
+			--arg prompt "$prompt" \
+			'{
+				model: $model,
+				max_tokens: $max_tokens,
+				system: $system,
+				messages: [{ role: "user", content: $prompt }]
+			}')
+	else
+		request_body=$(jq -n \
+			--arg model "$model_id" \
+			--argjson max_tokens "$max_tokens" \
+			--arg prompt "$prompt" \
+			'{
+				model: $model,
+				max_tokens: $max_tokens,
+				messages: [{ role: "user", content: $prompt }]
+			}')
+	fi
+
+	# Make the API call
+	local response
+	local http_code
+	local temp_file
+	temp_file=$(mktemp)
+	# shellcheck disable=SC2064
+	trap "rm -f '$temp_file'" RETURN
+
+	http_code=$(curl -s -w "%{http_code}" -o "$temp_file" \
+		-X POST "https://api.anthropic.com/v1/messages" \
+		-H "Content-Type: application/json" \
+		-H "x-api-key: ${ANTHROPIC_API_KEY}" \
+		-H "anthropic-version: 2023-06-01" \
+		-d "$request_body" \
+		--connect-timeout 10 \
+		--max-time 30)
+
+	response=$(cat "$temp_file")
+
+	# Check HTTP status
+	if [[ "$http_code" != "200" ]]; then
+		local error_msg
+		error_msg=$(echo "$response" | jq -r '.error.message // "Unknown error"' 2>/dev/null || echo "HTTP $http_code")
+		log_error "Anthropic API error ($http_code): $error_msg"
+		return 2
+	fi
+
+	# Extract text from response
+	local text
+	text=$(echo "$response" | jq -r '.content[0].text // ""' 2>/dev/null || echo "")
+
+	if [[ -z "$text" ]]; then
+		log_error "Empty response from Anthropic API"
+		return 2
+	fi
+
+	echo "$text"
+	return 0
+}
+
+#######################################
+# Main entry point
+#######################################
+main() {
+	local prompt=""
+	local model="haiku"
+	local max_tokens=100
+	local system_prompt=""
+	local quiet=false
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--prompt)
+			prompt="$2"
+			shift 2
+			;;
+		--model)
+			model="$2"
+			shift 2
+			;;
+		--max-tokens)
+			max_tokens="$2"
+			shift 2
+			;;
+		--system)
+			system_prompt="$2"
+			shift 2
+			;;
+		--json)
+			# JSON output hint — append to system prompt
+			if [[ -n "$system_prompt" ]]; then
+				system_prompt="$system_prompt Respond in valid JSON."
+			else
+				system_prompt="Respond in valid JSON."
+			fi
+			shift
+			;;
+		--quiet)
+			quiet=true
+			shift
+			;;
+		*)
+			log_error "Unknown argument: $1"
+			return 3
+			;;
+		esac
+	done
+
+	if [[ -z "$prompt" ]]; then
+		log_error "Usage: ai-research-helper.sh --prompt \"your prompt\" [--model haiku] [--max-tokens 100]"
+		return 3
+	fi
+
+	# Validate model tier
+	if [[ ! "${MODEL_MAP[$model]+_}" ]]; then
+		log_error "Invalid model tier: $model. Valid: haiku, sonnet, opus"
+		return 3
+	fi
+
+	# Check dependencies
+	if ! command -v curl >/dev/null 2>&1; then
+		log_error "curl is required but not installed"
+		return 1
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		log_error "jq is required but not installed"
+		return 1
+	fi
+
+	# Load API key
+	if ! load_api_key; then
+		if [[ "$quiet" != true ]]; then
+			log_error "ANTHROPIC_API_KEY not found. Set it via:"
+			log_error "  export ANTHROPIC_API_KEY=sk-ant-..."
+			log_error "  aidevops secret set anthropic-api-key"
+			log_error "  Add to ~/.config/aidevops/credentials.sh"
+		fi
+		return 1
+	fi
+
+	# Make the call
+	call_anthropic "$prompt" "$model" "$max_tokens" "$system_prompt"
+}
+
+# Only run main if not being sourced
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/memory-helper.sh
+++ b/.agents/scripts/memory-helper.sh
@@ -16,7 +16,7 @@
 #   memory-helper.sh recall --query "search terms" [--limit 5] [--type TYPE] [--max-age-days 30] [--entity ent_xxx]
 #   memory-helper.sh history <id>             # Show version history for a memory
 #   memory-helper.sh stats                    # Show memory statistics
-#   memory-helper.sh prune [--older-than-days 90] [--dry-run]  # Remove stale entries
+#   memory-helper.sh prune [--older-than-days 90] [--dry-run] [--intelligent]  # Remove stale entries
 #   memory-helper.sh validate                 # Check for stale/low-quality entries
 #   memory-helper.sh export [--format json|toon]  # Export all memories
 #

--- a/.agents/scripts/simplex-bot/src/config-validation.ts
+++ b/.agents/scripts/simplex-bot/src/config-validation.ts
@@ -25,6 +25,7 @@ export const VALID_CONFIG_KEYS: ReadonlySet<string> = new Set([
   "allowedContacts",
   "groupPermissions",
   "sessionIdleTimeout",
+  "useIntelligentThresholds",
   "maxPromptLength",
   "responseTimeout",
   "dataDir",

--- a/.agents/scripts/simplex-bot/src/types.ts
+++ b/.agents/scripts/simplex-bot/src/types.ts
@@ -361,8 +361,17 @@ export interface BotConfig {
   maxFileSize: number;
   /** Auto-join group invitations */
   autoJoinGroups: boolean;
-  /** Session idle timeout in seconds (default: 300) */
+  /** Session idle timeout in seconds (default: 300, used as fallback when AI judgment unavailable) */
   sessionIdleTimeout: number;
+  /**
+   * Enable AI-judged thresholds (t1363.6).
+   * When true, replaces fixed sessionIdleTimeout with AI judgment via
+   * conversation-helper.sh idle-check, and uses entity-preference-aware
+   * response sizing instead of fixed maxPromptLength.
+   * Falls back to deterministic thresholds when AI is unavailable.
+   * Default: auto-detected (true if ai-research-helper.sh exists)
+   */
+  useIntelligentThresholds?: boolean;
   /** Data directory for bot state (default: ~/.aidevops/.agent-workspace/simplex-bot) */
   dataDir?: string;
 }

--- a/tests/test-ai-judgment-helper.sh
+++ b/tests/test-ai-judgment-helper.sh
@@ -1,0 +1,418 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+set -euo pipefail
+
+# Test suite for ai-judgment-helper.sh and ai-research-helper.sh (t1363.6)
+# Tests the intelligent threshold replacement system.
+#
+# Tests are designed to work WITHOUT an Anthropic API key — they verify
+# the fallback behavior (deterministic thresholds) and the script structure.
+# AI judgment tests are skipped when ANTHROPIC_API_KEY is not set.
+#
+# Usage: bash tests/test-ai-judgment-helper.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+AI_JUDGMENT="${REPO_DIR}/.agents/scripts/ai-judgment-helper.sh"
+AI_RESEARCH="${REPO_DIR}/.agents/scripts/ai-research-helper.sh"
+MEMORY_HELPER="${REPO_DIR}/.agents/scripts/memory-helper.sh"
+ENTITY_HELPER="${REPO_DIR}/.agents/scripts/entity-helper.sh"
+WORK_DIR=""
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+SKIP=0
+
+setup() {
+	WORK_DIR=$(mktemp -d)
+	export AIDEVOPS_MEMORY_DIR="$WORK_DIR"
+	# Initialize memory tables first (creates learnings FTS5 table)
+	# then entity tables (adds entity-specific tables to same DB)
+	"$MEMORY_HELPER" store --content "init" --type CONTEXT 2>/dev/null || true
+	"$MEMORY_HELPER" prune --older-than-days 0 --include-accessed 2>/dev/null || true
+	"$ENTITY_HELPER" migrate 2>/dev/null || true
+	return 0
+}
+
+teardown() {
+	if [[ -n "$WORK_DIR" && -d "$WORK_DIR" ]]; then
+		rm -rf "$WORK_DIR"
+	fi
+	return 0
+}
+
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+
+	if [[ "$actual" == "$expected" ]]; then
+		echo -e "  ${GREEN}PASS${NC}: $description"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: $description (expected '$expected', got '$actual')"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_contains() {
+	local haystack="$1"
+	local needle="$2"
+	local description="$3"
+
+	if echo "$haystack" | grep -qF "$needle"; then
+		echo -e "  ${GREEN}PASS${NC}: $description"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: $description ('$needle' not found in output)"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_not_empty() {
+	local value="$1"
+	local description="$2"
+
+	if [[ -n "$value" ]]; then
+		echo -e "  ${GREEN}PASS${NC}: $description"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: $description (value is empty)"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_exit_code() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+
+	if [[ "$actual" -eq "$expected" ]]; then
+		echo -e "  ${GREEN}PASS${NC}: $description"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: $description (expected exit $expected, got $actual)"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+skip_test() {
+	local description="$1"
+	echo -e "  ${YELLOW}SKIP${NC}: $description"
+	SKIP=$((SKIP + 1))
+	return 0
+}
+
+has_api_key() {
+	[[ -n "${ANTHROPIC_API_KEY:-}" ]]
+}
+
+# ============================================================
+# Test: ai-research-helper.sh exists and is executable
+# ============================================================
+test_ai_research_helper_exists() {
+	echo "Test: ai-research-helper.sh structure"
+
+	assert_eq "true" "$(test -x "$AI_RESEARCH" && echo true || echo false)" \
+		"ai-research-helper.sh is executable"
+
+	# Test help/usage output
+	local output
+	output=$("$AI_RESEARCH" 2>&1 || true)
+	assert_contains "$output" "Usage" "Shows usage on no args"
+
+	return 0
+}
+
+# ============================================================
+# Test: ai-research-helper.sh argument validation
+# ============================================================
+test_ai_research_argument_validation() {
+	echo "Test: ai-research-helper.sh argument validation"
+
+	# Missing prompt
+	local exit_code=0
+	"$AI_RESEARCH" 2>/dev/null || exit_code=$?
+	assert_eq "3" "$exit_code" "Exits 3 on missing --prompt"
+
+	# Invalid model
+	exit_code=0
+	"$AI_RESEARCH" --prompt "test" --model invalid 2>/dev/null || exit_code=$?
+	assert_eq "3" "$exit_code" "Exits 3 on invalid model tier"
+
+	return 0
+}
+
+# ============================================================
+# Test: ai-judgment-helper.sh exists and is executable
+# ============================================================
+test_ai_judgment_helper_exists() {
+	echo "Test: ai-judgment-helper.sh structure"
+
+	assert_eq "true" "$(test -x "$AI_JUDGMENT" && echo true || echo false)" \
+		"ai-judgment-helper.sh is executable"
+
+	# Test help output
+	local output
+	output=$("$AI_JUDGMENT" help 2>&1)
+	assert_contains "$output" "Intelligent threshold replacement" "Help shows description"
+	assert_contains "$output" "is-memory-relevant" "Help lists is-memory-relevant command"
+	assert_contains "$output" "optimal-response-length" "Help lists optimal-response-length command"
+	assert_contains "$output" "batch-prune-check" "Help lists batch-prune-check command"
+
+	return 0
+}
+
+# ============================================================
+# Test: is-memory-relevant fallback (no API key)
+# ============================================================
+test_is_memory_relevant_fallback() {
+	echo "Test: is-memory-relevant fallback behavior"
+	setup
+
+	# Young memory — should be kept
+	local result
+	result=$("$AI_JUDGMENT" is-memory-relevant --content "CORS fix: add nginx proxy_pass" --age-days 30 2>/dev/null)
+	assert_eq "relevant" "$result" "Young memory (30d) is relevant"
+
+	# Old memory — should be pruned by fallback threshold
+	result=$("$AI_JUDGMENT" is-memory-relevant --content "Temporary debug logging" --age-days 120 2>/dev/null)
+	assert_eq "prune" "$result" "Old memory (120d) is pruned by fallback"
+
+	# Memory at threshold boundary
+	result=$("$AI_JUDGMENT" is-memory-relevant --content "Some learning" --age-days 89 2>/dev/null)
+	assert_eq "relevant" "$result" "Memory at 89d is relevant (under 90d threshold)"
+
+	result=$("$AI_JUDGMENT" is-memory-relevant --content "Some learning" --age-days 91 2>/dev/null)
+	assert_eq "prune" "$result" "Memory at 91d is pruned (over 90d threshold)"
+
+	teardown
+	return 0
+}
+
+# ============================================================
+# Test: optimal-response-length defaults
+# ============================================================
+test_optimal_response_length_defaults() {
+	echo "Test: optimal-response-length defaults"
+	setup
+
+	# No entity — returns default
+	local result
+	result=$("$AI_JUDGMENT" optimal-response-length 2>/dev/null)
+	assert_eq "4000" "$result" "No entity returns default 4000"
+
+	# Custom default
+	result=$("$AI_JUDGMENT" optimal-response-length --default 6000 2>/dev/null)
+	assert_eq "6000" "$result" "Custom default is respected"
+
+	# Non-existent entity — returns default
+	result=$("$AI_JUDGMENT" optimal-response-length --entity "ent_nonexistent" 2>/dev/null)
+	assert_eq "4000" "$result" "Non-existent entity returns default"
+
+	teardown
+	return 0
+}
+
+# ============================================================
+# Test: optimal-response-length with entity profile
+# ============================================================
+test_optimal_response_length_with_profile() {
+	echo "Test: optimal-response-length with entity profile"
+	setup
+
+	# Create an entity
+	local entity_output
+	entity_output=$("$ENTITY_HELPER" create --name "Test User" --type person 2>/dev/null)
+	local entity_id
+	entity_id=$(echo "$entity_output" | grep -oP 'ent_[a-f0-9_]+' | head -1)
+
+	if [[ -z "$entity_id" ]]; then
+		skip_test "Could not create test entity"
+		teardown
+		return 0
+	fi
+
+	# Set detail preference to concise
+	"$ENTITY_HELPER" profile-update "$entity_id" --key "detail_preference" --value "concise" 2>/dev/null || true
+
+	local result
+	result=$("$AI_JUDGMENT" optimal-response-length --entity "$entity_id" 2>/dev/null)
+	assert_eq "2000" "$result" "Concise preference returns 2000"
+
+	# Update to verbose
+	"$ENTITY_HELPER" profile-update "$entity_id" --key "detail_preference" --value "detailed" 2>/dev/null || true
+
+	result=$("$AI_JUDGMENT" optimal-response-length --entity "$entity_id" 2>/dev/null)
+	assert_eq "8000" "$result" "Detailed preference returns 8000"
+
+	teardown
+	return 0
+}
+
+# ============================================================
+# Test: should-prune with memory data
+# ============================================================
+test_should_prune() {
+	echo "Test: should-prune with memory data"
+	setup
+
+	# Store a memory
+	local store_output
+	store_output=$("$MEMORY_HELPER" store --content "Test memory for pruning" --type WORKING_SOLUTION 2>/dev/null)
+	local mem_id
+	mem_id=$(echo "$store_output" | grep -oP 'mem_[a-f0-9_]+' | head -1)
+
+	if [[ -z "$mem_id" ]]; then
+		skip_test "Could not store test memory"
+		teardown
+		return 0
+	fi
+
+	# Fresh memory should be kept
+	local result
+	result=$("$AI_JUDGMENT" should-prune --memory-id "$mem_id" 2>/dev/null)
+	assert_contains "$result" "keep" "Fresh memory is kept"
+
+	teardown
+	return 0
+}
+
+# ============================================================
+# Test: batch-prune-check with no old memories
+# ============================================================
+test_batch_prune_empty() {
+	echo "Test: batch-prune-check with no old memories"
+	setup
+
+	# Store a fresh memory
+	"$MEMORY_HELPER" store --content "Fresh memory" --type WORKING_SOLUTION 2>/dev/null || true
+
+	# Batch check should find nothing to prune
+	local result
+	result=$("$AI_JUDGMENT" batch-prune-check --older-than-days 60 --dry-run 2>&1)
+	assert_contains "$result" "No memories older than" "No old memories to evaluate"
+
+	teardown
+	return 0
+}
+
+# ============================================================
+# Test: judgment cache initialization
+# ============================================================
+test_judgment_cache() {
+	echo "Test: judgment cache table creation"
+	setup
+
+	# Run any command to trigger cache init
+	"$AI_JUDGMENT" is-memory-relevant --content "test" --age-days 10 2>/dev/null || true
+
+	# Check that cache table exists
+	local tables
+	tables=$(sqlite3 "$WORK_DIR/memory.db" ".tables" 2>/dev/null || echo "")
+	assert_contains "$tables" "ai_judgment_cache" "Cache table created"
+
+	teardown
+	return 0
+}
+
+# ============================================================
+# Test: AI judgment (requires API key)
+# ============================================================
+test_ai_judgment_with_api() {
+	echo "Test: AI judgment with API key"
+
+	if ! has_api_key; then
+		skip_test "ANTHROPIC_API_KEY not set — skipping AI judgment tests"
+		return 0
+	fi
+
+	setup
+
+	# Test ai-research-helper.sh with a simple prompt
+	local result
+	result=$("$AI_RESEARCH" --prompt "Respond with only the word 'hello'" --model haiku --max-tokens 10 2>/dev/null || echo "")
+	assert_not_empty "$result" "AI research helper returns a response"
+
+	# Test is-memory-relevant with AI
+	result=$("$AI_JUDGMENT" is-memory-relevant --content "How to fix CORS errors with nginx reverse proxy: add proxy_set_header Origin" --age-days 120 2>/dev/null)
+	# This is a timeless pattern — AI should judge it relevant even though it's old
+	assert_not_empty "$result" "AI judgment returns a result for memory relevance"
+
+	teardown
+	return 0
+}
+
+# ============================================================
+# Test: memory-helper.sh prune --intelligent flag
+# ============================================================
+test_memory_prune_intelligent_flag() {
+	echo "Test: memory-helper.sh prune --intelligent flag"
+	setup
+
+	# Store a fresh memory
+	"$MEMORY_HELPER" store --content "Test memory" --type WORKING_SOLUTION 2>/dev/null || true
+
+	# Run prune with --intelligent --dry-run
+	local result
+	result=$("$MEMORY_HELPER" prune --intelligent --dry-run 2>&1 || true)
+	# Should either use AI judgment or fall back gracefully
+	assert_not_empty "$result" "Intelligent prune produces output"
+
+	teardown
+	return 0
+}
+
+# ============================================================
+# Run all tests
+# ============================================================
+main() {
+	echo "============================================"
+	echo "  AI Judgment Helper Tests (t1363.6)"
+	echo "============================================"
+	echo ""
+
+	test_ai_research_helper_exists
+	echo ""
+	test_ai_research_argument_validation
+	echo ""
+	test_ai_judgment_helper_exists
+	echo ""
+	test_is_memory_relevant_fallback
+	echo ""
+	test_optimal_response_length_defaults
+	echo ""
+	test_optimal_response_length_with_profile
+	echo ""
+	test_should_prune
+	echo ""
+	test_batch_prune_empty
+	echo ""
+	test_judgment_cache
+	echo ""
+	test_ai_judgment_with_api
+	echo ""
+	test_memory_prune_intelligent_flag
+	echo ""
+
+	echo "============================================"
+	echo -e "  Results: ${GREEN}$PASS passed${NC}, ${RED}$FAIL failed${NC}, ${YELLOW}$SKIP skipped${NC}"
+	echo "============================================"
+
+	if [[ "$FAIL" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Replace three hardcoded thresholds (`sessionIdleTimeout: 300`, `DEFAULT_MAX_AGE_DAYS=90`, `maxPromptLength: 4000`) with haiku-tier AI judgment calls (~$0.001 each), with deterministic fallbacks when AI is unavailable
- Create `ai-research-helper.sh` (lightweight Anthropic API wrapper) and `ai-judgment-helper.sh` (threshold replacement functions with caching)
- Integrate into matrix-dispatch-helper.sh (idle detection + response sizing), memory system (intelligent pruning), and simplex-bot config

## Thresholds Replaced

| Before | After | Fallback |
|--------|-------|----------|
| `sessionIdleTimeout: 300` (fixed 5min) | AI judges "has this conversation naturally paused?" based on last messages + elapsed time | Heuristic: 10min/30min/1hr scaled by conversation length |
| `DEFAULT_MAX_AGE_DAYS=90` (fixed prune) | AI judges "is this memory still relevant?" considering content, type, entity relationships | Original 90-day threshold |
| `maxPromptLength: 4000` (fixed truncation) | Entity-preference-aware sizing from profile (`detail_preference` key) + AI judgment from interaction patterns | Original 4000 chars |

## New Files

- `.agents/scripts/ai-research-helper.sh` — Anthropic API wrapper (haiku/sonnet/opus tiers, credential loading via gopass/credentials.sh)
- `.agents/scripts/ai-judgment-helper.sh` — `is-memory-relevant`, `optimal-response-length`, `should-prune`, `batch-prune-check` commands with SQLite judgment cache
- `tests/test-ai-judgment-helper.sh` — 22 tests (all pass without API key via fallback behavior)

## Modified Files

- `memory/_common.sh` — `auto_prune()` delegates to AI batch-prune-check when available
- `memory/maintenance.sh` — `cmd_prune` adds `--intelligent` flag
- `matrix-dispatch-helper.sh` — `compactIdleSessions()` uses AI idle detection; response truncation uses entity-preference-aware sizing; auto-detects `useIntelligentThresholds`
- `simplex-bot/src/types.ts` — adds `useIntelligentThresholds` config option
- `simplex-bot/src/config-validation.ts` — validates new config key
- `memory-helper.sh` — documents `--intelligent` flag in usage

## Design Decisions

- **Every judgment has a deterministic fallback** — if `ANTHROPIC_API_KEY` is missing or `ai-research-helper.sh` doesn't exist, the old thresholds are used unchanged
- **Judgment cache** (SQLite, 24h TTL) prevents repeated API calls for the same decision
- **Profile-based results bypass cache** — entity profile is authoritative and changes should take effect immediately
- **Batch operations rate-limit** (0.1s between calls) to avoid API cost spikes
- **Matrix bot auto-detects** intelligent thresholds by checking if `ai-research-helper.sh` exists

## Test Results

```
22 passed, 0 failed, 1 skipped (API key tests skipped without ANTHROPIC_API_KEY)
```

Existing test suites unaffected:
- `test-conversation-helper.sh`: 83 passed, 0 failed
- `test-entity-helper.sh`: same 6 pre-existing failures (unrelated to this PR)

Closes #2526