### PR TITLE
feat: add automatic worktree cleanup for merged PRs

### DIFF
--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -17,7 +17,7 @@
 #   remove <path|branch>   Remove a worktree
 #   status                 Show current worktree info
 #   switch <branch>        Open/create worktree for branch (prints path)
-#   clean                  Remove worktrees for merged branches
+#   clean [--auto]         Remove worktrees for merged branches
 #   help                   Show this help
 #
 # Examples:
@@ -679,6 +679,12 @@ cmd_switch() {
 }
 
 cmd_clean() {
+	local auto_mode=false
+	if [[ "${1:-}" == "--auto" ]]; then
+		auto_mode=true
+		shift
+	fi
+
 	echo -e "${BOLD}Checking for worktrees with merged branches...${NC}"
 	echo ""
 
@@ -755,9 +761,14 @@ cmd_clean() {
 		return 0
 	fi
 
-	echo ""
-	echo -e "${YELLOW}Remove these worktrees? [y/N]${NC}"
-	read -r response
+	local response="n"
+	if [[ "$auto_mode" == "true" ]]; then
+		response="y"
+	else
+		echo ""
+		echo -e "${YELLOW}Remove these worktrees? [y/N]${NC}"
+		read -r response
+	fi
 
 	if [[ "$response" =~ ^[Yy]$ ]]; then
 		# Re-iterate and remove
@@ -923,7 +934,8 @@ COMMANDS
   
   switch <branch>        Get/create worktree for branch (prints path)
   
-  clean                  Remove worktrees for merged branches
+  clean [--auto]         Remove worktrees for merged branches
+                         --auto: skip confirmation prompt (for automated cleanup)
                          Skips worktrees owned by other active sessions (t189)
   
   registry [list|prune]  View or prune the ownership registry (t189, t197)


### PR DESCRIPTION
## Summary

- Adds `--auto` flag to `worktree-helper.sh clean` that skips the interactive confirmation prompt
- Adds `cleanup_worktrees()` step to `pulse-wrapper.sh` that runs before each pulse cycle
- Automatically removes worktrees whose branches were merged or deleted on the remote

## Root Cause

Workers create worktrees via `wt switch -c`, do their work, push branches, and create PRs. When PRs are merged on GitHub, the remote branch is auto-deleted, but nothing triggers local worktree cleanup. The `worktree-helper.sh clean` command existed but was interactive-only and never called by any automated workflow.

This caused 85+ stale worktrees to accumulate on disk, consuming storage and cluttering `git worktree list` / `wt list` output.

## Safety

All existing safeguards in `worktree-helper.sh` apply:
- Skips worktrees with uncommitted changes
- Skips worktrees owned by active sessions (PID check)
- Only removes branches that are confirmed merged or whose remote branch was deleted