### PR TITLE
fix: pass --interactive flag to aidevops-update-check.sh in AGENTS.md greeting

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -39,7 +39,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 ## aidevops Framework Status
 
 **On interactive conversation start** (skip this section entirely for headless/command sessions like `/pulse`, `/full-loop`, etc.):
-1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh`
+1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive`
 2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash)
 3. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -3,7 +3,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 ## aidevops Framework Status
 
 **On conversation start**:
-1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh`
+1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive`
 2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash)
 3. Parse the first line of output (format: `aidevops v{version} running in {app} v{app_version} | {repo}`). Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version} in {app} v{app_version}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message


### PR DESCRIPTION
## Summary

- Pass `--interactive` flag to `aidevops-update-check.sh` in both AGENTS.md generation sources so the update check actually runs in AI assistant sessions instead of being silently skipped by headless detection

## Changes

- `.agents/scripts/generate-opencode-agents.sh:42` — add `--interactive` to the update check command in the heredoc that generates `~/.config/Claude/AGENTS.md`
- `templates/opencode-config-agents.md:6` — same change in the OpenCode config template

## Root Cause

`is_headless()` returns true when `[[ ! -t 0 ]]` (no TTY on stdin). Every AI coding assistant runs Bash via piped stdin, so the update check was always skipped. The `--interactive` flag already exists in the script (line 105-110) and is documented for exactly this purpose — it just was never passed.

Closes #2554

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Update checks now support interactive mode, allowing users to directly interact with the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->