### PR TITLE
t1364.3: Wire parallel model verification into pipeline

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -159,6 +159,19 @@ When referencing specific functions or code include the pattern `file_path:line_
 - Do not commit files containing secrets (.env, credentials.json, etc.)
 - NEVER include private repo names in TODO.md, issue titles, issue bodies, or comments on public repos. Use "a managed private repo" or similar generic references. issue-sync-helper.sh has automated sanitization as a safety net, but prevention at source is primary.
 
+# Parallel Model Verification (t1364)
+# High-stakes operations are verified by a second model before execution.
+# This catches single-model hallucinations before destructive operations cause
+# irreversible damage. Different providers have different failure modes, so
+# correlated errors are rare. Verification is targeted — not every operation,
+# only those matching the risk taxonomy.
+- Before destructive operations (force push, DB drop, production deploy, secret exposure): source `verify-operation-helper.sh` and call `check_operation()`. If risk is critical/high, call `verify_operation()` and respect the result.
+- pre-edit-check.sh accepts `--verify-op "command"` to gate operations at the pre-edit stage.
+- dispatch.sh automatically screens task descriptions via `check_task_high_stakes()` before committing workers.
+- Verification is opt-out (`VERIFY_ENABLED=false`) not opt-in. High-stakes operations are verified by default.
+- Verification uses the cheapest model tier (haiku) — cost is minimal per check.
+- When verification is unavailable (no verifier model reachable): critical operations are blocked in headless mode, warned in interactive mode. Non-critical operations proceed.
+
 # Git Workflow and Traceability
 Git is the primary audit trail for all work. Every change should be discoverable through the chain: TODO task -> GitHub issue -> branch -> PR -> merge commit. A PR without a TODO entry, or an issue closed without a PR link, is an audit gap.
 


### PR DESCRIPTION
## Summary

- Add `verify-operation-helper.sh` with operation risk taxonomy (critical/high/moderate/low) and cross-provider model verification for high-stakes operations
- Wire verification into `pre-edit-check.sh` (`--verify-op` flag), `dispatch.sh` (task description screening via `check_task_high_stakes()`), and `full-loop.md` (Step 1.5 documentation)
- Update `build.txt` security section with parallel model verification rules

## How it works

Operations are classified by a pattern-based taxonomy:
- **Critical**: force push to main, `rm -rf /`, drop database, deploy to production, expose secrets → blocked in headless, warned in interactive
- **High**: force push, hard reset, branch deletion, DB migration, npm publish → verified via cross-provider model call
- **Moderate**: package installs, config changes → logged only
- **Low**: code edits, docs, tests → no verification

When a high-stakes operation is detected, `verify_operation()` invokes a second AI model (haiku tier, ~$0.001/check) to independently assess safety. The verifier returns `verified`, `concerns`, or `blocked`.

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `VERIFY_ENABLED` | `true` | Enable/disable globally |
| `VERIFY_POLICY` | `warn` | `warn`, `block`, or `skip` |
| `VERIFY_TIMEOUT` | `30` | Seconds for verifier response |
| `VERIFY_MODEL` | `haiku` | Model tier for verification |

## Testing

All modified scripts pass ShellCheck with zero violations. Taxonomy classification tested with 15+ operation patterns covering all risk levels.

Closes #2563