### PR TITLE
t2602: fix dirname not found in headless pulse environments

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -18,7 +18,15 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# Use pure-bash parameter expansion instead of dirname (external binary) to avoid
+# "dirname: command not found" in headless/MCP environments where PATH is restricted.
+# Defensive PATH export ensures downstream tools (gh, git, jq, sed, awk) are findable.
+export PATH="/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+_script_path="${BASH_SOURCE[0]%/*}"
+[[ "$_script_path" == "${BASH_SOURCE[0]}" ]] && _script_path="."
+SCRIPT_DIR="$(cd "$_script_path" && pwd)" || exit
+unset _script_path
 source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=issue-sync-lib.sh
 source "${SCRIPT_DIR}/issue-sync-lib.sh"

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -28,7 +28,11 @@ _ISSUE_SYNC_LIB_LOADED=1
 # Source shared-constants.sh to make the library self-contained.
 # Resolves SCRIPT_DIR from BASH_SOURCE so it works when sourced from any location.
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
-	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	# Pure-bash dirname replacement — avoids external binary dependency
+	_lib_path="${BASH_SOURCE[0]%/*}"
+	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
+	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
+	unset _lib_path
 fi
 source "${SCRIPT_DIR}/shared-constants.sh"
 
@@ -61,7 +65,8 @@ find_project_root() {
 			echo "$dir"
 			return 0
 		fi
-		dir="$(dirname "$dir")"
+		dir="${dir%/*}"
+		[[ -z "$dir" ]] && dir="/"
 	done
 	print_error "No TODO.md found in directory tree"
 	return 1


### PR DESCRIPTION
## Summary

- Replace `dirname` (external binary) with pure-bash `${BASH_SOURCE[0]%/*}` parameter expansion in `issue-sync-helper.sh` and `issue-sync-lib.sh` to fix "dirname: command not found" failures in headless/MCP environments with restricted PATH
- Add defensive `export PATH="/usr/local/bin:/usr/bin:/bin:${PATH:-}"` to ensure downstream tools (gh, git, jq, sed, awk) are findable
- Fix `find_project_root()` edge case where `${dir%/*}` produces empty string at filesystem root level

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/issue-sync-helper.sh` | Replace `dirname` with parameter expansion + add PATH hardening |
| `.agents/scripts/issue-sync-lib.sh` | Replace `dirname` in SCRIPT_DIR fallback and `find_project_root()` |

## Testing

- `shellcheck` passes (zero new warnings)
- `bash issue-sync-helper.sh help` works with full PATH
- `env PATH="/usr/bin" bash issue-sync-helper.sh help` works with minimal PATH
- Edge case: `${dir%/*}` on single-component paths (e.g., `/home`) correctly falls back to `/`

## Impact

Fixes silent TODO sync failures on every pulse cycle in affected headless environments. All 6 repos that failed with `dirname: command not found` will now sync correctly.

Closes #2602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced robustness of internal automation scripts in restricted execution environments by improving path resolution mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->