### PR TITLE
t2602: Fix issue-sync-helper.sh dirname failure in headless pulse

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -18,7 +18,13 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# Defensive PATH export — ensures coreutils (sed, grep, awk, jq, gh) are available
+# in headless/MCP environments where PATH may be minimal.
+export PATH="/usr/local/bin:/usr/bin:/bin:${PATH:-}"
+
+# Use pure-bash parameter expansion instead of dirname (which is an external binary
+# and may not be in PATH in headless/MCP environments). See issue #2602.
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=issue-sync-lib.sh
 source "${SCRIPT_DIR}/issue-sync-lib.sh"

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -28,7 +28,9 @@ _ISSUE_SYNC_LIB_LOADED=1
 # Source shared-constants.sh to make the library self-contained.
 # Resolves SCRIPT_DIR from BASH_SOURCE so it works when sourced from any location.
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
-	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	# Use pure-bash parameter expansion instead of dirname (external binary).
+	# See issue #2602 — dirname may not be in PATH in headless/MCP environments.
+	SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 fi
 source "${SCRIPT_DIR}/shared-constants.sh"
 


### PR DESCRIPTION
## Summary

- Replace `dirname` (external binary) with pure-bash `${BASH_SOURCE[0]%/*}` parameter expansion in `issue-sync-helper.sh` and `issue-sync-lib.sh` — fixes "dirname: command not found" in headless/MCP environments
- Add defensive `PATH` export at script entry to ensure coreutils (`sed`, `grep`, `awk`, `jq`, `gh`) are available in restricted environments
- Both changes are backward-compatible — `${var%/*}` is POSIX and works on bash 3.2+

## Root Cause

In headless pulse sessions (Claude Code MCP shell), `/usr/bin` and `/usr/local/bin` may not be in `PATH`. `dirname` is a coreutils binary, not a shell builtin, so `$(dirname "${BASH_SOURCE[0]}")` fails with "command not found". This caused TODO sync to silently fail on every pulse cycle across all 6 repos.

## Testing

- `bash -n` syntax check: pass
- `shellcheck`: no new warnings (only pre-existing SC1091 info)
- Functional test: `issue-sync-helper.sh help` runs successfully
- Verified `${BASH_SOURCE[0]%/*}` produces identical output to `dirname`

Closes #2602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of agent scripts when running in minimal-environment configurations by reducing external tool dependencies and optimizing initialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->