### PR TITLE
fix: replace dirname with POSIX parameter expansion in issue-sync scripts

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -18,7 +18,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=issue-sync-lib.sh
 source "${SCRIPT_DIR}/issue-sync-lib.sh"

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -28,7 +28,7 @@ _ISSUE_SYNC_LIB_LOADED=1
 # Source shared-constants.sh to make the library self-contained.
 # Resolves SCRIPT_DIR from BASH_SOURCE so it works when sourced from any location.
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
-	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 fi
 source "${SCRIPT_DIR}/shared-constants.sh"
 


### PR DESCRIPTION
## Summary

- Replace `$(dirname "${BASH_SOURCE[0]}")` with `${BASH_SOURCE[0]%/*}` in `issue-sync-helper.sh` (line 21) and `issue-sync-lib.sh` (line 31)
- The `dirname` command is an external binary not available in stripped PATH environments (e.g., Claude Code MCP pulse sessions), causing all TODO-to-GitHub issue syncs to fail silently across all 6 pulse-enabled repos
- The `%/*` parameter expansion is a bash builtin that performs identical directory extraction without requiring any external command

## Verification

Tested with `PATH=""` — old version fails at line 21 with `dirname: No such file or directory`, new version passes through successfully. ShellCheck clean (zero new warnings).

## Note

~200 other scripts in `.agents/scripts/` use the same `dirname` pattern. This PR fixes only the two scripts in the critical pulse path. A follow-up issue should address the systemic pattern across all scripts.

Closes #2605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal script execution path resolution for build and synchronization utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->