### PR TITLE
fix: replace dirname with parameter expansion for stripped PATH compatibility

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -18,7 +18,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=issue-sync-lib.sh
 source "${SCRIPT_DIR}/issue-sync-lib.sh"

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -28,7 +28,7 @@ _ISSUE_SYNC_LIB_LOADED=1
 # Source shared-constants.sh to make the library self-contained.
 # Resolves SCRIPT_DIR from BASH_SOURCE so it works when sourced from any location.
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
-	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 fi
 source "${SCRIPT_DIR}/shared-constants.sh"
 

--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 # --- Configuration ---
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "${BASH_SOURCE[0]%/*}" && pwd)"
 MINER_DIR="${HOME}/.aidevops/.agent-workspace/work/session-miner"
 # Shipped with aidevops; copied to workspace on first run
 EXTRACTOR_SRC="${SCRIPT_DIR}/session-miner/extract.py"


### PR DESCRIPTION
## Summary

- Replaces `dirname` (external command) with `${BASH_SOURCE[0]%/*}` (bash parameter expansion) in 3 scripts
- `dirname` is not available in stripped PATH environments (e.g., pulse sessions via Claude Code MCP)
- This caused all pulse TODO syncs to fail silently — no tasks were synced to GitHub issues

## Files Changed

- `.agents/scripts/issue-sync-helper.sh` line 21
- `.agents/scripts/issue-sync-lib.sh` line 31
- `.agents/scripts/session-miner-pulse.sh` line 22

## Verification

```bash
env -i HOME="$HOME" PATH="/usr/bin:/bin" bash issue-sync-helper.sh --help
# Output: Issue Sync Helper — stateless TODO.md <-> GitHub Issues sync via gh CLI.
```

Closes #2605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal build and deployment scripts for improved portability and efficiency. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->