### PR TITLE
fix: add PATH normalisation to pulse for MCP shell compatibility

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -21,6 +21,14 @@
 set -euo pipefail
 
 #######################################
+# PATH normalisation
+# The MCP shell environment may have a minimal PATH that excludes /bin
+# and other standard directories, causing `env bash` to fail. Ensure
+# essential directories are always present.
+#######################################
+export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
+
+#######################################
 # Configuration
 #######################################
 PULSE_STALE_THRESHOLD="${PULSE_STALE_THRESHOLD:-1800}" # 30 min = definitely stuck (opencode idle bug)


### PR DESCRIPTION
## Summary

- Adds **Step 0: Normalise PATH** to `pulse.md` — exports `/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin` into PATH before any script calls, fixing `env: bash: No such file or directory` in the MCP shell
- Documents the `/bin/bash` prefix fallback workaround in the cross-repo TODO sync section
- Adds the same PATH normalisation to `pulse-wrapper.sh` for resilience

## Root Cause

The MCP shell's PATH does not include `/bin`, so `env` cannot locate `bash` even though `/bin/bash` exists. Every pulse that calls helper scripts (issue-sync-helper.sh, circuit-breaker-helper.sh, session-miner-pulse.sh) via the MCP Bash tool was affected.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/commands/pulse.md` | New Step 0 with `export PATH=...`; documented `/bin/bash` fallback in TODO sync section |
| `.agents/scripts/pulse-wrapper.sh` | Added PATH normalisation after `set -euo pipefail` |

## Verification

- ShellCheck passes clean on `pulse-wrapper.sh`
- PATH export is idempotent — safe when PATH is already correct
- No functional changes to pulse logic; only PATH environment setup

Closes #2613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved script execution reliability by normalizing PATH environment variable to ensure essential executables are consistently available across different environments.

## Documentation
* Updated guidance on handling PATH-related issues in script execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->