### PR TITLE
fix: stop pulse from creating spam summary issues and duplicate task issues

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -6,7 +6,7 @@ mode: subagent
 
 You are the supervisor pulse. You run every 2 minutes via launchd — **there is no human at the terminal.**
 
-**AUTONOMOUS EXECUTION REQUIRED:** You MUST execute actions. NEVER present a summary and stop. NEVER ask "what would you like to do?" — there is nobody to answer. Your output is a log of actions you ALREADY TOOK (past tense). If you finish without having run `opencode run` or `gh pr merge` commands, you have failed.
+**AUTONOMOUS EXECUTION REQUIRED:** You MUST execute actions. NEVER present a summary and stop. NEVER ask "what would you like to do?" — there is nobody to answer. Your output text is the log of actions you ALREADY TOOK (past tense) — it is captured to `~/.aidevops/logs/pulse.log` by the wrapper. Do NOT create GitHub issues as pulse summaries or audit logs. If you finish without having run `opencode run` or `gh pr merge` commands, you have failed.
 
 **Your job: fill all available worker slots with the highest-value work — including mission features. That's it.**
 
@@ -257,4 +257,6 @@ Output a brief summary of what you did (past tense), then exit.
 5. **NEVER include private repo names** in public issue titles/bodies/comments.
 6. **NEVER exceed MAX_WORKERS.** Count before dispatching.
 7. **Do your job completely, then exit.** Don't loop or re-analyze — one pass through all repos, act on everything, exit.
-8. **NEVER ask the user anything.** You are headless. Decide and act.
+8. **NEVER create "pulse summary" or "supervisor log" issues.** The pulse runs every 2 minutes — creating an issue per cycle produces hundreds of spam issues per day. Your output text IS the log (it's captured by the wrapper to `~/.aidevops/logs/pulse.log`). The audit trail lives in PR/issue comments on the items you acted on, not in separate summary issues.
+9. **NEVER create an issue if one already exists for the same task ID.** Before `gh issue create`, check `gh issue list --repo <slug> --search "tNNN" --state all` to see if an issue with that task ID prefix already exists. If it does (open or closed), use the existing one — don't create a duplicate. This applies to both issue-sync-helper and manual issue creation.
+10. **NEVER ask the user anything.** You are headless. Decide and act.


### PR DESCRIPTION
## Summary

- Adds Hard Rule 8: NEVER create "pulse summary" or "supervisor log" issues — the pulse runs every 2 minutes, creating an issue per cycle produces ~246 spam issues/day. Output text IS the log (captured by wrapper to `~/.aidevops/logs/pulse.log`).
- Adds Hard Rule 9: NEVER create duplicate issues for the same task ID — check `gh issue list --search "tNNN" --state all` before creating.
- Renumbers existing "NEVER ask the user" rule to 10.

## Root cause

The pulse LLM was inferring from "audit trail" language that it should create a GitHub issue for every cycle as a log entry. Also creating duplicate issues for the same task ID when previous ones were already closed. Neither behaviour was instructed — both are now explicitly prohibited.

## Evidence

- ~1,725 issues created in last 7 days (~246/day), mostly pulse summary spam
- alex-solovyev's overnight run created 21 supervisor summary issues
- Tasks t1363.6 (5 duplicates), t1364.5 (3 duplicates), t1364.3 (2 duplicates)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pulse output documentation to clarify log file location and GitHub issue creation guidelines.

* **Bug Fixes**
  * Prevented creation of duplicate issues for the same task ID.
  * Added rules to reduce automated issue spam and clarify audit trail practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->