### PR TITLE
t217: Enforce Task tool parallelism for independent subtasks in worker dispatch

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -355,6 +355,8 @@ The AI will iterate on the task until outputting:
 6. Conventional commits used (for auto-changelog)
 7. **Headless rules observed** (see below)
 
+**Parallelism rule (t217)**: When your task involves multiple independent operations (reading several files, running lint + typecheck + tests, researching separate modules), use the Task tool to run them concurrently in a single message — not one at a time. Serial execution of independent work wastes wall-clock time proportional to the number of subtasks. See `tools/ai-assistants/headless-dispatch.md` "Worker Efficiency Protocol" point 5 for criteria and examples.
+
 **Replanning rule**: If your approach isn't working after a reasonable attempt, step back
 and try a fundamentally different strategy before giving up. A fresh approach often
 succeeds where incremental fixes to a broken one fail.


### PR DESCRIPTION
## Summary

- Strengthens Worker Efficiency Protocol point 5 from advisory ("can use") to mandatory ("MUST use") with clear when-to/when-not-to criteria, concrete wrong/right examples, and throughput impact data
- Adds a parallelism rule reference in `full-loop.md` Step 3 (Task Development) so workers see the requirement during their main implementation phase
- Updates the comparison table to quantify the serial vs parallel cost difference

Closes #2618

## Changes

### `.agents/tools/ai-assistants/headless-dispatch.md`
- **Point 5** rewritten from a single sentence to a comprehensive section with:
  - "When to parallelise" checklist (6 criteria)
  - "When to stay sequential" checklist (4 criteria)
  - "How" explanation with wrong/right code examples
  - Throughput impact quantification (30-60% wall-clock savings)
- Comparison table row updated: `All work sequential → 3x slower for 3 independent tasks`

### `.agents/scripts/commands/full-loop.md`
- Added **Parallelism rule (t217)** in Step 3 completion criteria, cross-referencing the full guidance in headless-dispatch.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved guidance on parallelizing independent operations to reduce overall execution time
  * Added detailed conditions clarifying when to run tasks concurrently versus sequentially
  * Included practical examples demonstrating best practices and performance benefits of parallel execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->