### PR TITLE
fix: self-assign issues on dispatch, correct title pluralization

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -131,7 +131,9 @@ if [[ -n "$ISSUE_NUM" && "$ISSUE_NUM" != "null" ]]; then
     # In headless mode, exit cleanly. In interactive mode, inform the user.
     exit 0
   else
-    gh issue edit "$ISSUE_NUM" --repo "$REPO" --add-label "status:in-progress" 2>/dev/null || true
+    # Self-assign to prevent duplicate work by other runners/humans
+    WORKER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
+    gh issue edit "$ISSUE_NUM" --repo "$REPO" --add-assignee "$WORKER_USER" --add-label "status:in-progress" 2>/dev/null || true
     for STALE in "status:available" "status:queued" "status:claimed"; do
       gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "$STALE" 2>/dev/null || true
     done


### PR DESCRIPTION
## Summary

- **Self-assign on dispatch**: Pulse assigns issue to runner user before dispatching worker, preventing duplicate work by other runners/humans
- **Skip assigned issues**: Pulse skips issues already assigned to someone else during dispatch
- **Worker self-assign**: Worker self-assigns in Step 0.6 as defense-in-depth (covers manual dispatch, interactive sessions)
- **Correct pluralization**: Health issue title shows "1 PR" not "1 PRs", "1 worker" not "1 workers"
- **Assignees in prefetch**: Issue queries now include `assignees` field so pulse agent can see who's working on what

## Why

Multiple runners dispatching workers for the same issue wastes compute and creates conflicting PRs. GitHub issue assignment is the standard mechanism for claiming work — the pulse should use it. The worker also self-assigns as a fallback for manual/interactive dispatch.

## Files changed

- `.agents/scripts/commands/pulse.md` — dispatch step adds `--add-assignee`, new skip rule for assigned issues
- `.agents/scripts/commands/full-loop.md` — Step 0.6 adds `--add-assignee` on worker start
- `.agents/scripts/pulse-wrapper.sh` — pluralization fix in title, assignees in prefetch queries