### PR TITLE
docs: align git workflow docs with assignment and worktree conventions

### DIFF
--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -392,13 +392,14 @@ fi
 # - "feature"/"enhancement" label → feature/
 # - Default → feature/
 
-# 4. Create branch
+# 4. Create worktree for the issue (main repo stays on main)
 git checkout main && git pull origin main
-git checkout -b {type}/{issue_number}-{slug-from-title}
-# Example: feature/42-add-user-dashboard
+~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{issue_number}-{slug-from-title}
+# Creates: ~/Git/{repo}-{type}-{issue_number}-{slug}/
+# Example: ~/Git/myapp-feature-42-add-user-dashboard/
 
 # 5. Inform user
-echo "Created branch {type}/{issue_number}-{slug} linked to issue #{issue_number}"
+echo "Created worktree for {type}/{issue_number}-{slug} linked to issue #{issue_number}"
 ```
 
 ### Platform Detection


### PR DESCRIPTION
## Summary

- Updated label vocabulary table in `full-loop.md` to include assignee column and document the full assignment lifecycle
- Fixed `git-workflow.md` issue URL section that contradicted the worktree-first convention

## Audit findings

After implementing issue assignment (PRs #2628, #2629), audited all git workflow docs for consistency. Found two misalignments:

1. **`full-loop.md` label table was stale**: Missing assignee information, still listed dead `status:claimed` state from the old supervisor, didn't document the recovery flow (pulse unassigns stale issues after 3h)

2. **`git-workflow.md` self-contradiction**: Line 339 says "Always use worktrees, not `git checkout -b`" but the issue URL handling section at line 396 used `git checkout -b`. Fixed to use `worktree-helper.sh add`.