### PR TITLE
feat: add Qlty CLI to setup.sh tool installation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -595,6 +595,7 @@ main() {
 		confirm_step "Setup Git CLIs (gh, glab, tea)" && setup_git_clis
 		confirm_step "Setup file discovery tools (fd, ripgrep)" && setup_file_discovery_tools
 		confirm_step "Setup shell linting tools (shellcheck, shfmt)" && setup_shell_linting_tools
+		confirm_step "Setup Qlty CLI (multi-linter code quality)" && setup_qlty_cli
 		confirm_step "Rosetta audit (Apple Silicon x86 migration)" && setup_rosetta_audit
 		confirm_step "Setup Worktrunk (git worktree management)" && setup_worktrunk
 		confirm_step "Setup SSH key" && setup_ssh_key


### PR DESCRIPTION
## Summary

- Adds `setup_qlty_cli()` to `setup-modules/tool-install.sh` — installs Qlty CLI via `curl -fsSL https://qlty.sh | bash` using the existing `verified_install` pattern
- Adds `confirm_step` call in `setup.sh` after shell linting tools (shellcheck, shfmt)
- Auto-installs in non-interactive mode; prompts in interactive mode
- Required for the daily quality sweep (`run_daily_quality_sweep()` in pulse-wrapper.sh) to run `qlty smells --all`

## Verification

- ShellCheck: zero violations
- `bash -n`: syntax OK
- Follows existing patterns from `setup_shell_linting_tools()` and `setup_worktrunk()`