### PR TITLE
t2634: Fix extract.py Python 3.9 compatibility

### DIFF
--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -28,7 +28,7 @@ import sys
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 
 # --- Configuration ---
@@ -141,7 +141,7 @@ def classify_error(error_text: str) -> str:
     return "other"
 
 
-def extract_steerage(conn: sqlite3.Connection, limit: int | None = None) -> list[dict]:
+def extract_steerage(conn: sqlite3.Connection, limit: Optional[int] = None) -> list[dict]:
     """Extract user steerage signals from sessions.
 
     Returns tool-agnostic records with:
@@ -238,7 +238,7 @@ def extract_steerage(conn: sqlite3.Connection, limit: int | None = None) -> list
     return steerage_records
 
 
-def extract_errors(conn: sqlite3.Connection, limit: int | None = None) -> list[dict]:
+def extract_errors(conn: sqlite3.Connection, limit: Optional[int] = None) -> list[dict]:
     """Extract tool error sequences with surrounding context.
 
     For each error, captures:


### PR DESCRIPTION
## Summary

- Replace `int | None` union type syntax (Python 3.10+) with `Optional[int]` from `typing` module for Python 3.9 compatibility
- Fixes `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` that broke session-miner-pulse on macOS default Python 3.9
- Two occurrences fixed: `extract_steerage()` and `extract_errors()` function signatures

## Changes

- `.agents/scripts/session-miner/extract.py`: Added `Optional` to `typing` import, replaced 2x `int | None` with `Optional[int]`

## Verification

- Confirmed syntax parses cleanly on Python 3.9.6 (`python3 -c "import ast; ast.parse(...)"`)
- Confirmed zero remaining `X | Y` union type patterns in the file
- LSP reports no errors after fix

Closes #2634