### PR TITLE
t2634: fix session-miner extract.py Python 3.9 union type syntax

### DIFF
--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -28,7 +28,7 @@ import sys
 from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 
 # --- Configuration ---
@@ -141,7 +141,7 @@ def classify_error(error_text: str) -> str:
     return "other"
 
 
-def extract_steerage(conn: sqlite3.Connection, limit: int | None = None) -> list[dict]:
+def extract_steerage(conn: sqlite3.Connection, limit: Optional[int] = None) -> list[dict]:
     """Extract user steerage signals from sessions.
 
     Returns tool-agnostic records with:
@@ -238,7 +238,7 @@ def extract_steerage(conn: sqlite3.Connection, limit: int | None = None) -> list
     return steerage_records
 
 
-def extract_errors(conn: sqlite3.Connection, limit: int | None = None) -> list[dict]:
+def extract_errors(conn: sqlite3.Connection, limit: Optional[int] = None) -> list[dict]:
     """Extract tool error sequences with surrounding context.
 
     For each error, captures:


### PR DESCRIPTION
## Summary

- Replace `int | None` union type syntax (Python 3.10+) with `Optional[int]` (Python 3.9+) in `extract.py`
- Fixes `extract_steerage()` and `extract_errors()` function signatures
- Adds `Optional` to the existing `from typing import Any` import

## Problem

`session-miner-pulse.sh` fails every pulse with:
```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```
because macOS ships Python 3.9 by default, which doesn't support the `X | Y` union type syntax in annotations.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/session-miner/extract.py:31` | `from typing import Any` → `from typing import Any, Optional` |
| `.agents/scripts/session-miner/extract.py:144` | `limit: int \| None` → `limit: Optional[int]` |
| `.agents/scripts/session-miner/extract.py:241` | `limit: int \| None` → `limit: Optional[int]` |

## Verification

- `python3 -c "import ast; ast.parse(...)"` — syntax validates cleanly
- Scanned entire file for remaining `X | Y` union syntax — none found (all other `|` are regex patterns in string literals)

Closes #2634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type annotations across internal utilities to improve code clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->