### PR TITLE
fix: grep -c arithmetic error in quality sweep ShellCheck section

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1305,9 +1305,9 @@ _quality_sweep_for_repo() {
 				result=$(shellcheck -f gcc "$shfile" 2>/dev/null || true)
 				if [[ -n "$result" ]]; then
 					local file_errors
-					file_errors=$(echo "$result" | grep -c ':.*: error:' || echo "0")
+					file_errors=$(echo "$result" | grep -c ':.*: error:') || file_errors=0
 					local file_warnings
-					file_warnings=$(echo "$result" | grep -c ':.*: warning:' || echo "0")
+					file_warnings=$(echo "$result" | grep -c ':.*: warning:') || file_warnings=0
 					sc_errors=$((sc_errors + file_errors))
 					sc_warnings=$((sc_warnings + file_warnings))
 


### PR DESCRIPTION
## Summary

- Fixes `syntax error in expression (error token is "0\n0")` that prevented the daily quality sweep from completing
- Root cause: `grep -c` outputs `0` on no match AND exits 1. With `|| echo "0"`, output becomes `0\n0` (two lines) which fails in `$(( ))` arithmetic
- Fix: `file_errors=$(... | grep -c ...) || file_errors=0` — the fallback assigns directly instead of appending to stdout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced shell script linting result detection and processing for more consistent error and warning identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->