### PR TITLE
docs: add search tool hierarchy (fd/rg/rga) and install ripgrep-all in setup

### DIFF
--- a/.agents/scripts/setup/_tools.sh
+++ b/.agents/scripts/setup/_tools.sh
@@ -8,7 +8,7 @@ setup_git_clis() {
 	return 0
 }
 
-# Setup file discovery tools (fd, rg)
+# Setup file discovery tools (fd, rg, rga)
 setup_file_discovery_tools() {
 	# TODO: Extract from setup.sh lines 2042-2167
 	:

--- a/.agents/tools/context/context-guardrails.md
+++ b/.agents/tools/context/context-guardrails.md
@@ -155,8 +155,12 @@ Before using `mcp_glob`, check if faster alternatives work:
 | Git-tracked files | `git ls-files '*.md'` | `mcp_glob` |
 | Untracked files | `fd -e md` | `mcp_glob` |
 | System-wide search | `fd -g '*.md' ~/.config/` | `mcp_glob` |
+| Search text file contents | `rg 'pattern'` | `mcp_grep` |
+| Search inside PDFs/DOCX/zips | `rga 'pattern'` | None (unique capability) |
 
 **Why?** `mcp_glob` is CPU-intensive on large codebases. CLI tools are 10x faster.
+
+**Tool roles:** `fd` finds files by name/metadata, `rg` searches text file contents, `rga` (ripgrep-all) searches inside non-text files (PDF, DOCX, SQLite, archives). Same syntax as `rg` but with document adapters.
 
 ## Agent Capability Check
 

--- a/.agents/tools/terminal/terminal-optimization.md
+++ b/.agents/tools/terminal/terminal-optimization.md
@@ -89,6 +89,7 @@ done | tr '\n' ':' | sed 's/:$//')
 |---------|--------|---------|---------|
 | `find` | `fd` | 5-10x | `brew install fd` |
 | `grep` | `ripgrep (rg)` | 5-20x | `brew install ripgrep` |
+| `grep` in PDFs/docs | `ripgrep-all (rga)` | N/A (new capability) | `brew install ripgrep-all` |
 | `cat` | `bat` | Syntax highlighting | `brew install bat` |
 | `ls` | `eza` | Better output | `brew install eza` |
 | `du` | `dust` | Visual tree | `brew install dust` |
@@ -97,6 +98,22 @@ done | tr '\n' ':' | sed 's/:$//')
 | `sed` | `sd` | Simpler syntax | `brew install sd` |
 | `curl` | `xh` | Colorized HTTP | `brew install xh` |
 | `man` | `tldr` | Quick examples | `brew install tldr` |
+
+### Search Tool Hierarchy
+
+`fd`, `rg`, and `rga` are complementary — same ecosystem, same `.gitignore` awareness:
+
+| Tool | Purpose | Use when |
+|------|---------|----------|
+| `fd` | Find files by **name, type, size, date** | "Find all `.ts` files modified today" |
+| `rg` | Search **text file contents** by pattern | "Find where `handleAuth` is called" |
+| `rga` | Search **inside non-text files** (PDF, DOCX, SQLite, zip, tar) | "Find 'invoice' in downloaded PDFs" |
+
+- `fd` replaces `find` — file discovery by metadata
+- `rg` replaces `grep` — content search in source/text files
+- `rga` extends `rg` — same syntax, but reaches inside binary/document formats
+
+`rga` supported formats: PDF, DOCX/XLSX/PPTX, ODT, SQLite, compressed archives (zip, tar, gz), and more via adapters.
 
 ### 4. Shell Aliases
 

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -127,13 +127,25 @@ setup_file_discovery_tools() {
 		print_success "ripgrep found: $rg_version"
 	fi
 
+	# Check for ripgrep-all (searches inside PDFs, DOCX, SQLite, archives)
+	if ! command -v rga >/dev/null 2>&1; then
+		missing_tools+=("rga")
+		missing_packages+=("ripgrep-all")
+		missing_names+=("ripgrep-all (search inside PDFs/docs/archives)")
+	else
+		local rga_version
+		rga_version=$(rga --version 2>/dev/null | head -1 || echo "unknown")
+		print_success "ripgrep-all found: $rga_version"
+	fi
+
 	# Offer to install missing tools
 	if [[ ${#missing_tools[@]} -gt 0 ]]; then
 		print_warning "Missing file discovery tools: ${missing_names[*]}"
 		echo ""
 		echo "  These tools provide 10x faster file discovery than built-in glob:"
-		echo "    fd      - Fast alternative to 'find', respects .gitignore"
-		echo "    ripgrep - Fast alternative to 'grep', respects .gitignore"
+		echo "    fd          - Fast alternative to 'find', respects .gitignore"
+		echo "    ripgrep     - Fast alternative to 'grep', respects .gitignore"
+		echo "    ripgrep-all - Extends ripgrep to search inside PDFs, DOCX, SQLite, archives"
 		echo ""
 		echo "  AI agents use these for efficient codebase navigation."
 		echo ""
@@ -202,18 +214,18 @@ setup_file_discovery_tools() {
 				print_info "Skipped file discovery tools installation"
 				echo ""
 				echo "  Manual installation:"
-				echo "    macOS:        brew install fd ripgrep"
-				echo "    Ubuntu/Debian: sudo apt install fd-find ripgrep"
-				echo "    Fedora:       sudo dnf install fd-find ripgrep"
-				echo "    Arch:         sudo pacman -S fd ripgrep"
+				echo "    macOS:        brew install fd ripgrep ripgrep-all"
+				echo "    Ubuntu/Debian: sudo apt install fd-find ripgrep  # rga: cargo install ripgrep_all"
+				echo "    Fedora:       sudo dnf install fd-find ripgrep   # rga: cargo install ripgrep_all"
+				echo "    Arch:         sudo pacman -S fd ripgrep ripgrep-all"
 			fi
 		else
 			echo ""
 			echo "  Manual installation:"
-			echo "    macOS:        brew install fd ripgrep"
-			echo "    Ubuntu/Debian: sudo apt install fd-find ripgrep"
-			echo "    Fedora:       sudo dnf install fd-find ripgrep"
-			echo "    Arch:         sudo pacman -S fd ripgrep"
+			echo "    macOS:        brew install fd ripgrep ripgrep-all"
+			echo "    Ubuntu/Debian: sudo apt install fd-find ripgrep  # rga: cargo install ripgrep_all"
+			echo "    Fedora:       sudo dnf install fd-find ripgrep   # rga: cargo install ripgrep_all"
+			echo "    Arch:         sudo pacman -S fd ripgrep ripgrep-all"
 		fi
 	else
 		print_success "All file discovery tools installed!"

--- a/setup.sh
+++ b/setup.sh
@@ -593,7 +593,7 @@ main() {
 		confirm_step "Setup recommended tools (Tabby, Zed, etc.)" && setup_recommended_tools
 		confirm_step "Setup MiniSim (iOS/Android emulator launcher)" && setup_minisim
 		confirm_step "Setup Git CLIs (gh, glab, tea)" && setup_git_clis
-		confirm_step "Setup file discovery tools (fd, ripgrep)" && setup_file_discovery_tools
+		confirm_step "Setup file discovery tools (fd, ripgrep, ripgrep-all)" && setup_file_discovery_tools
 		confirm_step "Setup shell linting tools (shellcheck, shfmt)" && setup_shell_linting_tools
 		confirm_step "Setup Qlty CLI (multi-linter code quality)" && setup_qlty_cli
 		confirm_step "Rosetta audit (Apple Silicon x86 migration)" && setup_rosetta_audit


### PR DESCRIPTION
## Summary

- Add **Search Tool Hierarchy** section to `terminal-optimization.md` explaining when to use `fd` vs `rg` vs `rga` with comparison table
- Add `rg` and `rga` rows to `context-guardrails.md` file discovery table
- Add `ripgrep-all` (rga) to `setup_file_discovery_tools()` in `tool-install.sh` so it gets installed alongside fd and ripgrep during setup
- Update setup.sh confirm step and `_tools.sh` stub to reflect the new tool

## Why

Agents had no guidance on when to use `fd` (find files by name) vs `rg` (search text contents) vs `rga` (search inside PDFs/DOCX/archives). The tools are complementary but agents need to know which to reach for. `rga` was not installed by setup despite being referenced in terminal-optimization docs.

## Files changed

- `.agents/tools/terminal/terminal-optimization.md` — rga in tool table + new Search Tool Hierarchy section
- `.agents/tools/context/context-guardrails.md` — rg/rga rows in discovery table + tool roles summary
- `setup-modules/tool-install.sh` — rga check/install in setup_file_discovery_tools()
- `setup.sh` — confirm step text updated
- `.agents/scripts/setup/_tools.sh` — stub comment updated