### PR TITLE
fix: replace SC2181 indirect exit code checks in stash-audit-helper.sh

### DIFF
--- a/.agents/scripts/stash-audit-helper.sh
+++ b/.agents/scripts/stash-audit-helper.sh
@@ -225,8 +225,7 @@ cmd_audit() {
 	local repo_path="${1:-$(pwd)}"
 	local repo_root
 
-	repo_root=$(get_repo_root "$repo_path")
-	if [[ $? -ne 0 ]]; then
+	if ! repo_root=$(get_repo_root "$repo_path"); then
 		return 1
 	fi
 
@@ -301,8 +300,7 @@ cmd_list() {
 	local repo_path="${1:-$(pwd)}"
 	local repo_root
 
-	repo_root=$(get_repo_root "$repo_path")
-	if [[ $? -ne 0 ]]; then
+	if ! repo_root=$(get_repo_root "$repo_path"); then
 		return 1
 	fi
 
@@ -327,8 +325,7 @@ cmd_clean() {
 	local repo_path="${1:-$(pwd)}"
 	local repo_root
 
-	repo_root=$(get_repo_root "$repo_path")
-	if [[ $? -ne 0 ]]; then
+	if ! repo_root=$(get_repo_root "$repo_path"); then
 		return 1
 	fi
 
@@ -404,8 +401,7 @@ cmd_auto_clean() {
 	local repo_path="${1:-$(pwd)}"
 	local repo_root
 
-	repo_root=$(get_repo_root "$repo_path")
-	if [[ $? -ne 0 ]]; then
+	if ! repo_root=$(get_repo_root "$repo_path"); then
 		return 1
 	fi
 


### PR DESCRIPTION
## Summary

- Replace `cmd; if [[ $? -ne 0 ]]` patterns with `if ! cmd;` in all 4 `cmd_*` functions (`cmd_audit`, `cmd_list`, `cmd_clean`, `cmd_auto_clean`)
- Eliminates all 4 SC2181 ShellCheck violations in `stash-audit-helper.sh`
- Verified: `shellcheck` reports 0 SC2181 findings, `bash -n` syntax check passes

Closes #2644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified error-checking patterns in internal build scripts for improved code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->