### PR TITLE
fix: remove useless cat (SC2002) in test scripts

### DIFF
--- a/.agents/scripts/test-task-id-collision.sh
+++ b/.agents/scripts/test-task-id-collision.sh
@@ -119,7 +119,7 @@ EOF
 
 	# Verify counter file was updated
 	local final_counter
-	final_counter=$(cat "$test_repo/.task-counter" 2>/dev/null | tr -d '[:space:]')
+	final_counter=$(tr -d '[:space:]' <"$test_repo/.task-counter" 2>/dev/null)
 	info "Final .task-counter value: $final_counter"
 
 	if [[ "$final_counter" -gt 200 ]]; then
@@ -185,7 +185,7 @@ EOF
 
 	# Verify counter was updated locally
 	local new_counter
-	new_counter=$(cat "$test_repo/.task-counter" 2>/dev/null | tr -d '[:space:]')
+	new_counter=$(tr -d '[:space:]' <"$test_repo/.task-counter" 2>/dev/null)
 	if [[ "$new_counter" == "181" ]]; then
 		pass "Local counter updated to 181 (next available after t180)"
 	else
@@ -822,7 +822,7 @@ EOF
 
 	# Verify counter was updated
 	local new_counter
-	new_counter=$(cat "$test_repo/.task-counter" 2>/dev/null | tr -d '[:space:]')
+	new_counter=$(tr -d '[:space:]' <"$test_repo/.task-counter" 2>/dev/null)
 	if [[ "$new_counter" == "605" ]]; then
 		pass "Counter updated to 605 after batch allocation"
 	else

--- a/tests/test-email-signature-parser.sh
+++ b/tests/test-email-signature-parser.sh
@@ -196,7 +196,7 @@ test_stdin_input() {
 	setup
 
 	local output
-	output=$(cat "${TEST_DIR}/standard-business.txt" | "$PARSER" parse - "$CONTACTS_DIR" 2>&1) || true
+	output=$("$PARSER" parse - "$CONTACTS_DIR" <"${TEST_DIR}/standard-business.txt" 2>&1) || true
 
 	assert_file_exists "${CONTACTS_DIR}/john.doe@acmecorp.com.toon" "TOON file created from stdin"
 


### PR DESCRIPTION
## Summary

- Replace `cat file | cmd` with `cmd < file` in 4 instances across 2 test scripts to fix SC2002 ShellCheck violations (useless cat)
- `tests/test-email-signature-parser.sh`: 1 instance (`cat | parser` → `parser < file`)
- `.agents/scripts/test-task-id-collision.sh`: 3 instances (`cat | tr` → `tr < file`)

## Verification

- ShellCheck passes with zero SC2002 violations on both files
- Email signature parser test suite: 28 passed, 0 failed
- Task ID collision test suite: 34 passed, 0 failed

Closes #2643

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test script efficiency through input method optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->