### PR TITLE
t1366: Add git-commit correlation to session miner for productivity analysis

### DIFF
--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -214,6 +214,40 @@ if uncovered:
     for p in uncovered[:5]:
         print(f'  - {p[\"tool\"]}:{p[\"error_category\"]} ({p[\"count\"]}x) — consider adding prevention rule')
     print()
+
+# Git correlation / productivity analysis
+git_data = data.get('git_correlation', {})
+git_summary = git_data.get('summary', {})
+if git_summary:
+    total_s = git_summary.get('total_sessions', 0)
+    productive_s = git_summary.get('productive_sessions', 0)
+    rate = git_summary.get('productivity_rate', 0)
+    total_commits = git_summary.get('total_commits', 0)
+    avg_cpm = git_summary.get('avg_commits_per_message', 0)
+    print('### Git Productivity')
+    print(f'  Sessions with git data: {total_s}')
+    print(f'  Productive sessions (>=1 commit): {productive_s} ({rate:.0%})')
+    print(f'  Total commits: {total_commits}')
+    print(f'  Avg commits/message (productive): {avg_cpm:.3f}')
+    print()
+
+    # Per-project breakdown
+    project_stats = git_data.get('project_stats', {})
+    if project_stats:
+        print('### Productivity by Project')
+        for project, ps in sorted(project_stats.items(), key=lambda x: -x[1].get('total_commits', 0))[:10]:
+            print(f'  {project}: {ps[\"productive_sessions\"]}/{ps[\"sessions\"]} productive, '
+                  f'{ps[\"total_commits\"]} commits, {ps[\"total_lines_changed\"]} lines')
+        print()
+
+    # Top productive sessions
+    top_sessions = git_data.get('top_productive_sessions', [])
+    if top_sessions:
+        print('### Most Productive Sessions')
+        for s in top_sessions[:5]:
+            print(f'  {s[\"title\"][:60]} — {s[\"commits\"]} commits/{s[\"messages\"]} msgs '
+                  f'(ratio: {s[\"ratio\"]:.2f}, {s[\"duration_min\"]:.0f}min)')
+        print()
 " 2>/dev/null
 	return $?
 }


### PR DESCRIPTION
## Summary

- Adds git-commit correlation to the session miner extraction pipeline, cross-referencing session activity with git commit outcomes
- For each session with a project path, computes: commits produced, files changed, productivity ratio (commits/messages), and per-project breakdowns
- Adds `--no-git` flag to `extract.py` for opt-out when git correlation is not needed

## Changes

### `extract.py`
- `_find_git_root()`: resolves git root for a session directory (cached)
- `_git_log_in_window()`: queries `git log` for commits within a session time window (+1h buffer)
- `extract_git_correlation()`: per-session productivity metrics (commits_count, files_changed, insertions, deletions, commits_per_message, lines_per_message)
- `build_chunks()`: git correlation chunking (productive vs unproductive sessions, summary stats)
- `--no-git` CLI flag to skip git correlation extraction

### `compress.py`
- `compress_git_correlation()`: per-project productivity stats, top productive sessions identification
- Integrated into main compressed output as `git_correlation` section

### `session-miner-pulse.sh`
- Git Productivity summary (sessions, commits, avg commits/message)
- Productivity by Project breakdown (top 10 by commits)
- Most Productive Sessions listing (top 5 by commits/message ratio)

## Edge Cases Handled
- Sessions with no `cwd`/project path: gracefully skipped
- Repos not accessible (deleted, moved): graceful skip with warning
- Division by zero: guarded in all ratio calculations
- Subprocess timeouts: 5s for git root, 15s for git log/diff

## Acceptance Criteria
- [x] `session-miner-pulse.sh` produces git correlation data for sessions with a project path
- [x] Extraction output includes `commits_count`, `productivity_ratio`, and commit details per session
- [x] LLM analysis phase receives and comments on productivity patterns
- [x] Sessions without git data are gracefully skipped (no errors)
- [x] Backward compatible — existing functionality unchanged, `--no-git` for opt-out

Closes #2653

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Git Productivity Analytics section to summary reports, displaying project-level metrics (sessions, commits, productivity rates) and identifying top performing sessions.
  * Introduced optional `--no-git` flag to skip git correlation analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->