### PR TITLE
t1368: Add write-time quality enforcement rules

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -210,7 +210,7 @@ Key capabilities (details in `reference/orchestration.md`, `reference/services.m
 - **Skills**: `aidevops skills`, `/skills`
 - **Auto-update**: GitHub poll + daily skill/repo sync
 - **Browser**: Playwright, dev-browser (persistent login)
-- **Quality**: `linters-local.sh` → `/pr review` → `/postflight`. Bundle `skip_gates` filter irrelevant checks per project type.
+- **Quality**: Write-time per-edit linting → `linters-local.sh` → `/pr review` → `/postflight`. Fix violations at edit time, not commit time. See `prompts/build.txt` "Write-Time Quality Enforcement". Bundle `skip_gates` filter irrelevant checks per project type.
 - **Sessions**: `/session-review`, `/checkpoint`, compaction resilience
 
 ## Security

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -204,6 +204,22 @@ Git is the primary audit trail for all work. Every change should be discoverable
 - Explicit returns in all functions
 - Conventional commits: feat:, fix:, docs:, refactor:, chore:, perf:
 
+# Write-Time Quality Enforcement
+# Inspired by Plankton (github.com/alexfazio/plankton) — adapted for runtime-agnostic use.
+# Plankton uses Claude Code PostToolUse hooks to lint on every edit. OpenCode does not yet
+# have equivalent hooks (feature requested: anomalyco/opencode). Until then, enforce via
+# prompt-level discipline and explicit tool calls.
+#
+# Linter config protection (soft rule):
+- When a linter reports violations, fix the code — not the linter config.
+- If a rule is genuinely wrong for the project (false positive, architectural pattern), modifying the config is acceptable — but document the rationale in a comment in the config file and in the commit message. Never disable a rule solely to silence a violation.
+- Existing config customisations (e.g., .shellcheckrc disables, .markdownlint.json overrides) are intentional project decisions. Respect them; don't revert without understanding why they exist.
+#
+# Per-edit quality feedback:
+- After editing code files (shell, Python, TypeScript, markdown), run the relevant linter on the modified file before proceeding to the next edit. For shell: `shellcheck <file>`. For markdown: `markdownlint-cli2 <file>`. For project-wide: `linters-local.sh`.
+- Fix violations immediately rather than accumulating them for a batch fix at commit time. Write-time feedback produces better code than post-hoc correction.
+- When available, use the `quality-check` MCP tool or `linters-local.sh` for comprehensive checks before committing.
+
 # Agent Framework
 - Agents are defined in `~/.aidevops/agents/`
 - Subagents provide domain expertise (read on demand, not upfront)


### PR DESCRIPTION
## Summary

- Add prompt-level write-time quality enforcement to `prompts/build.txt`, inspired by [Plankton](https://github.com/alexfazio/plankton)
- Add soft linter config protection rule (fix code not rules, but allow documented config changes)
- Add per-edit linting instruction (run linter after each edit, not just at commit time)
- Update AGENTS.md quality pipeline to reference write-time enforcement

## Context

Evaluated Plankton's write-time quality enforcement pattern (PostToolUse hooks that lint on every file edit). The pattern is proven effective but depends on Claude Code hooks that OpenCode doesn't yet support.

**Upstream tracking:**
- Issue: [anomalyco/opencode#12472](https://github.com/anomalyco/opencode/issues/12472) — Native Claude Code hooks compatibility
- PR: [anomalyco/opencode#11525](https://github.com/anomalyco/opencode/pull/11525) — Implements all 12 hooks
- Our comment: [#12472 comment](https://github.com/anomalyco/opencode/issues/12472#issuecomment-3981078833)

Until OpenCode ships native hooks, we enforce via prompt-level discipline. When hooks land, we can upgrade to automatic PostToolUse linting using our existing `linters-local.sh` infrastructure.

Cross-session memory stored for tracking the upstream feature.

Closes #2654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quality assurance process documentation to reflect write-time linting enforcement.
  * Enhanced guidelines for code quality checks and enforcement workflows.

* **Chores**
  * Configuration updates to quality and agent framework documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->