### PR TITLE
t1369.4: Add OCR cross-references and index entries

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -177,6 +177,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Code quality | `tools/code-review/code-standards.md` |
 | Git/PRs/Releases | `workflows/git-workflow.md`, `tools/git/github-cli.md`, `workflows/release.md` |
 | Documents/PDF | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
+| OCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |
 | Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `mobile-app-dev.md`, `browser-extension-dev.md` |
 | Content/Video/Voice | `content.md`, `tools/video/video-prompt-design.md`, `tools/voice/speech-to-speech.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -48,7 +48,7 @@ tools/code-review/,Code quality - linting and security scanning,code-standards|c
 tools/context/,Context optimization - semantic search and indexing,augment-context-engine|context-builder|context7|toon|mcp-discovery|github-search|model-routing|openapi-search
 tools/conversion/,Format conversion - document transformation,pandoc
 tools/document/,Document extraction - conversion structured data extraction schemas and workflow orchestration,document-extraction|extraction-schemas|extraction-workflow|docstrange
-tools/ocr/,OCR and text extraction - local document processing via Ollama,glm-ocr
+tools/ocr/,OCR and text extraction - scene text screenshots documents and local processing,overview|paddleocr|glm-ocr|ocr-research
 tools/accounts/,Accounting tools - receipt OCR subscription audit,receipt-ocr|subscription-audit
 tools/ai-generation/,AI generation management - ComfyUI install nodes models workflows via comfy-cli,comfy-cli
 tools/video/,Video creation and generation - programmatic editing and AI generation APIs,remotion|higgsfield|runway|wavespeed|yt-dlp|video-prompt-design|real-video-enhancer
@@ -119,7 +119,7 @@ conversation-starter,workflows/conversation-starter.md,Session greeting and auto
 mission-skill-learning,workflows/mission-skill-learning.md,Auto-capture reusable patterns from missions and suggest promotion
 -->
 
-<!--TOON:scripts[98]{name,purpose}:
+<!--TOON:scripts[99]{name,purpose}:
 accessibility-helper.sh,Accessibility and contrast testing (WCAG compliance WAVE API for websites and emails)
 browser-qa-worker.sh,Browser QA visual testing — Playwright screenshots broken links console errors for milestone validation
 browser-qa-helper.sh,Playwright-based visual QA for milestone validation (smoke screenshots links a11y)
@@ -166,6 +166,7 @@ unstract-helper.sh,Unstract self-hosted document processing (install start stop)
 document-extraction-helper.sh,Document extraction with PII redaction (extract batch pii-scan pii-redact convert install status schemas)
 frontmatter-helper.sh,YAML frontmatter enforcement for markdown files (enforce check show batch)
 ocr-receipt-helper.sh,OCR receipt/invoice extraction pipeline with QuickFile integration (scan extract batch quickfile preview status install)
+paddleocr-helper.sh,PaddleOCR scene text OCR (install ocr serve stop status models)
 quickfile-helper.sh,QuickFile purchase/expense recording bridge - supplier resolution and MCP instruction generation (record-purchase record-expense supplier-resolve batch-record preview status)
 cloudron-package-helper.sh,Cloudron app packaging workflow (init scaffold build test)
 email-agent-helper.sh,Autonomous email agent for mission 3rd-party communication (send poll extract-codes thread conversations status)

--- a/.agents/tools/document/document-extraction.md
+++ b/.agents/tools/document/document-extraction.md
@@ -266,6 +266,8 @@ Use this stack when you need custom Pydantic schemas, PII redaction, or fully lo
 - `tools/document/docstrange.md` - DocStrange: simpler single-install alternative (NanoNets, 7B model, schema extraction)
 - `tools/conversion/pandoc.md` - Document format conversion
 - `tools/conversion/mineru.md` - PDF to markdown (layout-aware)
+- `tools/ocr/overview.md` - OCR tool selection guide (when to use which tool)
+- `tools/ocr/paddleocr.md` - PaddleOCR scene text OCR (screenshots, photos, scanned PDFs)
 - `tools/ocr/glm-ocr.md` - Local OCR via Ollama
 - `services/document-processing/unstract.md` - Self-hosted document processing (alternative)
 - `todo/tasks/prd-document-extraction.md` - Full PRD

--- a/.agents/tools/pdf/overview.md
+++ b/.agents/tools/pdf/overview.md
@@ -34,6 +34,7 @@ tools:
 | Merge/split | LibPDF | Full page manipulation |
 | Text extraction | LibPDF | With position information |
 | PDF to markdown/JSON | MinerU | Layout-aware, OCR, formula support |
+| Scanned PDF OCR | PaddleOCR | Scene text, 100+ languages, bounding boxes |
 | Render to image | pdf.js | LibPDF doesn't render (yet) |
 
 **Subagents**:
@@ -142,5 +143,7 @@ const { bytes: signed } = await pdf.sign({
 - `libpdf.md` - Detailed LibPDF usage guide
 - `tools/document/document-creation.md` - Unified document format conversion and creation
 - `tools/conversion/mineru.md` - PDF to markdown/JSON (layout-aware, OCR)
+- `tools/ocr/overview.md` - OCR tool selection guide (PaddleOCR, GLM-OCR, MinerU, Docling)
+- `tools/ocr/paddleocr.md` - PaddleOCR scene text OCR for scanned PDFs and images
 - `tools/conversion/pandoc.md` - General document format conversion
 - `tools/browser/playwright.md` - For PDF rendering/screenshots


### PR DESCRIPTION
## Summary

- Adds OCR row to AGENTS.md domain index
- Updates subagent-index.toon with PaddleOCR entries
- Cross-references PaddleOCR in PDF overview.md tool selection table
- Links from document-extraction.md to new OCR tools

Closes #2665

## Notes

Branch was created by a prior worker but no PR was opened. CI checks pending.