### PR TITLE
t1370.4: Update cross-references and indexes for vector search

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -186,6 +186,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Payments | `services/payments/revenuecat.md`, `services/payments/stripe.md`, `services/payments/procurement.md` |
 | Security/Encryption | `tools/security/tirith.md`, `tools/security/opsec.md`, `tools/credentials/encryption-stack.md` |
 | Database/Local-first | `tools/database/pglite-local-first.md`, `services/database/postgres-drizzle-skill.md` |
+| Vector Search | `tools/database/vector-search.md` |
 | Local Development | `services/hosting/local-hosting.md` |
 | Infrastructure | `tools/infrastructure/cloud-gpu.md`, `tools/containers/orbstack.md`, `tools/containers/remote-dispatch.md` |
 | Accessibility | `services/accessibility/accessibility-audit.md` |

--- a/.agents/services/database/multi-org-isolation.md
+++ b/.agents/services/database/multi-org-isolation.md
@@ -533,3 +533,9 @@ export interface SessionContext {
   metadata?: Record<string, unknown>;
 }
 ```
+
+## Related
+
+- **Vector search per-tenant isolation**: `tools/database/vector-search.md` — decision guide for vector databases (zvec, pgvector, Vectorize) with per-tenant RAG isolation patterns that complement this schema
+- **PGlite local-first**: `tools/database/pglite-local-first.md` — embedded Postgres for desktop/extension apps
+- **Postgres + Drizzle**: `services/database/postgres-drizzle-skill.md` — schema patterns and query optimization

--- a/.agents/services/database/postgres-drizzle-skill.md
+++ b/.agents/services/database/postgres-drizzle-skill.md
@@ -181,3 +181,9 @@ await db.transaction(async (tx) => {
 - **Index Types**: https://www.postgresql.org/docs/current/indexes-types.html
 - **JSON Functions**: https://www.postgresql.org/docs/current/functions-json.html
 - **Row Level Security**: https://www.postgresql.org/docs/current/ddl-rowsecurity.html
+
+### Related Subagents
+
+- **Vector search**: `tools/database/vector-search.md` — decision guide for vector databases including pgvector with Drizzle
+- **Multi-org isolation**: `services/database/multi-org-isolation.md` — tenant isolation schema with RLS
+- **PGlite local-first**: `tools/database/pglite-local-first.md` — embedded Postgres for desktop/extension apps

--- a/.agents/services/hosting/cloudflare-platform/references/vectorize/README.md
+++ b/.agents/services/hosting/cloudflare-platform/references/vectorize/README.md
@@ -680,6 +680,11 @@ try {
 - [Wrangler Commands](https://developers.cloudflare.com/workers/wrangler/commands/#vectorize)
 - [Discord: #vectorize](https://discord.cloudflare.com)
 
+## Related
+
+- **Vector search decision guide**: `tools/database/vector-search.md` — compare Vectorize with zvec, pgvector, and other vector databases for per-tenant RAG
+- **Multi-org isolation**: `services/database/multi-org-isolation.md` — tenant isolation schema patterns
+
 ---
 
 **Version:** V2 (GA) - Requires Wrangler 3.71.0+

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -23,7 +23,7 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[59]{folder,purpose,key_files}:
+<!--TOON:subagents[60]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
 business/,Company orchestration - runner configs for company functions,company-runners
 memory/,Cross-session memory - SQLite FTS5 storage,README
@@ -79,6 +79,7 @@ services/accounting/,Accounting integration - invoicing,quickfile
 services/payments/,Payment processing and autonomous procurement - Stripe Issuing virtual cards budget enforcement receipt capture,stripe|revenuecat|superwall|procurement
 services/database/,Database schemas - multi-org isolation Drizzle ORM and PostgreSQL RLS,multi-org-isolation|postgres-drizzle-skill
 tools/database/,Embedded database - PGlite local-first Postgres for desktop and extension apps,pglite-local-first
+tools/database/,Vector search decision guide - zvec pgvector Vectorize comparison and per-tenant RAG patterns,vector-search
 services/document-processing/,Document processing - LLM-powered extraction,unstract
 tools/research/,Tech stack research - frontend technology detection providers,providers/unbuilt
 tools/research/,Tech stack research - open-source technology explorer provider,providers/openexplorer

--- a/.agents/tools/database/pglite-local-first.md
+++ b/.agents/tools/database/pglite-local-first.md
@@ -367,7 +367,9 @@ const { unsubscribe } = await client.live.query(
 
 ## Related
 
+- **Vector search**: `tools/database/vector-search.md` — decision guide for vector databases including PGlite+pgvector for local-first vector search
 - **SQLite (for aidevops internals)**: `memory/README.md` - SQLite FTS5 for cross-session memory
+- **Multi-org isolation**: `services/database/multi-org-isolation.md` — tenant isolation schema for server-side Postgres
 - **PowerSync**: https://www.powersync.com - SQLite sync with Postgres (better for React Native)
 - **ElectricSQL**: https://electric-sql.com - Postgres sync engine (works with PGlite)
 - **TanStack DB**: https://tanstack.com/db - Reactive client store (pairs with Electric)


### PR DESCRIPTION
## Summary

- Adds **Vector Search** row to the AGENTS.md domain index table pointing to `tools/database/vector-search.md`
- Adds vector-search entry to `subagent-index.toon` (subagent count 59 -> 60)
- Adds cross-references from 4 related database docs:
  - `multi-org-isolation.md` — links to per-tenant vector isolation patterns
  - `pglite-local-first.md` — links to PGlite+pgvector local vector search
  - `Cloudflare Vectorize README.md` — links to comparison with other vector DBs
  - `postgres-drizzle-skill.md` — links to pgvector with Drizzle

**Note:** The target file `tools/database/vector-search.md` will be created by t1370.1 and t1370.2. These cross-references are ready for when those docs land.

Closes #2677

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Vector Search domain entry to the Domain Index
  * Enhanced documentation cross-referencing between database-related guides (vector search, multi-org isolation, PostgreSQL+Drizzle, and PGlite)
  * Expanded subagent catalog with entries across multiple tool and service categories
  * Updated subagent index version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->