### PR TITLE
t1370.2: Add zvec in-process vector database reference

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -187,7 +187,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Payments | `services/payments/revenuecat.md`, `services/payments/stripe.md`, `services/payments/procurement.md` |
 | Security/Encryption | `tools/security/tirith.md`, `tools/security/opsec.md`, `tools/credentials/encryption-stack.md` |
 | Database/Local-first | `tools/database/pglite-local-first.md`, `services/database/postgres-drizzle-skill.md` |
-| Vector Search | `tools/database/vector-search.md` |
+| Vector Search | `tools/database/vector-search.md`, `tools/database/vector-search/zvec.md` |
 | Local Development | `services/hosting/local-hosting.md` |
 | Infrastructure | `tools/infrastructure/cloud-gpu.md`, `tools/containers/orbstack.md`, `tools/containers/remote-dispatch.md` |
 | Accessibility | `services/accessibility/accessibility-audit.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -23,7 +23,7 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[60]{folder,purpose,key_files}:
+<!--TOON:subagents[61]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
 business/,Company orchestration - runner configs for company functions,company-runners
 memory/,Cross-session memory - SQLite FTS5 storage,README
@@ -80,6 +80,7 @@ services/payments/,Payment processing and autonomous procurement - Stripe Issuin
 services/database/,Database schemas - multi-org isolation Drizzle ORM and PostgreSQL RLS,multi-org-isolation|postgres-drizzle-skill
 tools/database/,Embedded database - PGlite local-first Postgres for desktop and extension apps,pglite-local-first
 tools/database/,Vector search decision guide - zvec pgvector Vectorize comparison and per-tenant RAG patterns,vector-search
+tools/database/vector-search/,In-process vector database - Zvec embedded similarity search hybrid dense+sparse RAG,zvec
 services/document-processing/,Document processing - LLM-powered extraction,unstract
 tools/research/,Tech stack research - frontend technology detection providers,providers/unbuilt
 tools/research/,Tech stack research - open-source technology explorer provider,providers/openexplorer

--- a/.agents/tools/database/vector-search/zvec.md
+++ b/.agents/tools/database/vector-search/zvec.md
@@ -1,0 +1,785 @@
+---
+description: Zvec - In-process embedded vector database for SaaS RAG pipelines
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Zvec - In-Process Embedded Vector Database
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Embedded C++ vector database (Proxima engine) for server-side similarity search without a separate DB service
+- **Python**: `pip install zvec` (Python 3.10-3.12)
+- **Node.js**: `npm install @zvec/zvec`
+- **Platforms**: Linux x86_64/ARM64, macOS ARM64
+- **Repo**: <https://github.com/alibaba/zvec> (8.4k stars, Apache-2.0)
+- **Docs**: <https://zvec.org/en/docs/>
+- **License**: Apache 2.0
+
+**When to use Zvec**: You need in-process vector search for a SaaS app where each tenant uploads documents for RAG. Zvec runs in the same process as your app server (zero network hop), supports collection-per-tenant isolation, and ships with built-in embedding functions and rerankers.
+
+**When NOT to use Zvec**:
+
+- Browser/WASM apps (native C++ binary, not WASM)
+- Windows servers (Linux and macOS ARM64 only)
+- Distributed multi-node clusters (single-process; use Milvus or Qdrant for horizontal scaling)
+- You already run Postgres and want to avoid a second data store (use pgvector)
+- Datasets >100M vectors per collection where you need distributed sharding
+
+<!-- AI-CONTEXT-END -->
+
+## Installation
+
+### Python
+
+```bash
+pip install zvec
+```
+
+Requires Python 3.10, 3.11, or 3.12. Installs a native C++ extension via prebuilt wheels.
+
+### Node.js
+
+```bash
+npm install @zvec/zvec
+```
+
+### Optional dependencies for embedding/reranking
+
+```bash
+# Local dense + sparse embeddings (Sentence Transformers)
+pip install sentence-transformers
+
+# BM25 sparse embeddings
+pip install dashtext
+
+# OpenAI embeddings
+pip install openai
+
+# Jina embeddings
+pip install openai  # Jina uses OpenAI-compatible API
+
+# Qwen embeddings (DashScope)
+pip install dashscope
+
+# ModelScope model source (alternative to Hugging Face for China)
+pip install modelscope
+```
+
+## Core Concepts
+
+### Architecture
+
+```text
+Your App Process
+  |
+  +-- zvec (in-process C++ library via Python/Node.js bindings)
+  |     |
+  |     +-- Collection A (tenant_1)  -->  /data/vectors/tenant_1/
+  |     +-- Collection B (tenant_2)  -->  /data/vectors/tenant_2/
+  |     +-- Collection C (tenant_3)  -->  /data/vectors/tenant_3/
+  |
+  +-- No network hop, no separate server process
+```
+
+### Data Model
+
+- **Collection**: Named container for documents (analogous to a table). Each collection has a schema and lives at a filesystem path.
+- **Document** (`Doc`): A record with a string `id`, scalar fields, and one or more vector fields.
+- **Schema**: Defines scalar fields (`FieldSchema`) and vector fields (`VectorSchema`) for a collection.
+
+## Collection Schema
+
+### Scalar Data Types
+
+| Type | Constant | Notes |
+|------|----------|-------|
+| 32-bit int | `DataType.INT32` | |
+| 64-bit int | `DataType.INT64` | |
+| 32-bit uint | `DataType.UINT32` | |
+| 64-bit uint | `DataType.UINT64` | |
+| Float | `DataType.FLOAT` | 32-bit |
+| Double | `DataType.DOUBLE` | 64-bit |
+| String | `DataType.STRING` | |
+| Boolean | `DataType.BOOL` | |
+| Array types | `DataType.ARRAY_INT32`, `ARRAY_STRING`, etc. | Typed arrays |
+
+### Vector Data Types
+
+| Type | Constant | Use case |
+|------|----------|----------|
+| FP32 dense | `DataType.VECTOR_FP32` | Default for most embeddings |
+| FP16 dense | `DataType.VECTOR_FP16` | Half memory, slight precision loss |
+| FP64 dense | `DataType.VECTOR_FP64` | Maximum precision |
+| INT8 dense | `DataType.VECTOR_INT8` | Quantized (4x memory reduction) |
+| FP32 sparse | `DataType.SPARSE_VECTOR_FP32` | BM25/SPLADE sparse vectors |
+| FP16 sparse | `DataType.SPARSE_VECTOR_FP16` | Sparse with half precision |
+
+### Schema Definition (Python)
+
+```python
+import zvec
+
+schema = zvec.CollectionSchema(
+    name="documents",
+    fields=[
+        zvec.FieldSchema("title", zvec.DataType.STRING, nullable=True),
+        zvec.FieldSchema("category", zvec.DataType.STRING, nullable=False),
+        zvec.FieldSchema("publish_year", zvec.DataType.INT32, nullable=True),
+    ],
+    vectors=[
+        zvec.VectorSchema("dense_emb", zvec.DataType.VECTOR_FP32, dimension=384),
+        zvec.VectorSchema("sparse_emb", zvec.DataType.SPARSE_VECTOR_FP32),
+    ],
+)
+```
+
+### Schema with Index Parameters
+
+```python
+schema = zvec.CollectionSchema(
+    name="documents",
+    fields=[
+        zvec.FieldSchema(
+            "category",
+            zvec.DataType.STRING,
+            index_param=zvec.InvertIndexParam(),  # Inverted index for filtering
+        ),
+    ],
+    vectors=[
+        zvec.VectorSchema(
+            "embedding",
+            zvec.DataType.VECTOR_FP32,
+            dimension=384,
+            index_param=zvec.HnswIndexParam(ef_construction=200, m=16),
+        ),
+    ],
+)
+```
+
+## Index Types
+
+### Vector Indexes
+
+| Index | Class | Best for | Trade-off |
+|-------|-------|----------|-----------|
+| **HNSW** | `HnswIndexParam` | General use, <50M vectors | High recall, higher memory |
+| **IVF** | `IVFIndexParam` | Memory-constrained, >10M vectors | Lower memory, slightly lower recall |
+| **Flat** | `FlatIndexParam` | Small collections (<100k), exact search | Exact results, O(n) search |
+
+### HNSW Parameters
+
+```python
+zvec.HnswIndexParam(
+    ef_construction=200,  # Build-time quality (higher = better recall, slower build)
+    m=16,                 # Max connections per node (higher = better recall, more memory)
+)
+
+# Query-time parameter
+zvec.HnswQueryParam(
+    ef=300,  # Search-time quality (higher = better recall, slower query)
+)
+```
+
+### IVF Parameters
+
+```python
+zvec.IVFIndexParam(
+    nlist=1024,  # Number of clusters (sqrt(n) is a good starting point)
+)
+
+# Query-time parameter
+zvec.IVFQueryParam(
+    nprobe=64,  # Clusters to search (higher = better recall, slower query)
+)
+```
+
+### Scalar Indexes
+
+```python
+# Inverted index for scalar fields (enables fast filtering)
+zvec.InvertIndexParam()
+```
+
+### Creating Indexes After Collection Creation
+
+```python
+collection.create_index("embedding", zvec.HnswIndexParam(ef_construction=200, m=16))
+collection.create_index("category", zvec.InvertIndexParam())
+collection.drop_index("embedding")  # Remove an index
+```
+
+## Quantization
+
+Zvec supports INT8 quantization for reduced memory usage:
+
+```python
+# Use VECTOR_INT8 data type in schema for 4x memory reduction
+zvec.VectorSchema("embedding", zvec.DataType.VECTOR_INT8, dimension=384)
+```
+
+For benchmarks, INT8 quantization is used with a refiner for maintaining recall:
+
+```bash
+# Benchmark command showing INT8 + refiner usage
+vectordbbench zvec --quantize-type int8 --is-using-refiner
+```
+
+INT8 quantization reduces memory by ~4x compared to FP32 while maintaining >95% recall when combined with a refiner pass.
+
+## Dense and Sparse Vectors
+
+Zvec natively supports both dense and sparse vectors in the same collection, enabling hybrid search in a single query.
+
+### Dense Vectors
+
+Standard fixed-dimension float vectors from embedding models (Sentence Transformers, OpenAI, Jina, etc.).
+
+```python
+zvec.VectorSchema("dense", zvec.DataType.VECTOR_FP32, dimension=384)
+```
+
+### Sparse Vectors
+
+Variable-length vectors where most dimensions are zero (BM25, SPLADE). Stored as `{index: weight}` dictionaries.
+
+```python
+zvec.VectorSchema("sparse", zvec.DataType.SPARSE_VECTOR_FP32)
+# No dimension needed -- sparse vectors have variable length
+```
+
+## Built-in Embedding Functions
+
+Zvec ships with embedding functions that run locally or call APIs. No separate embedding service needed.
+
+### Local Embeddings (No API Key)
+
+| Function | Model | Dimensions | Speed | Dependency |
+|----------|-------|------------|-------|------------|
+| `DefaultLocalDenseEmbedding` | all-MiniLM-L6-v2 | 384 | ~1k sent/sec CPU | `sentence-transformers` |
+| `DefaultLocalSparseEmbedding` | SPLADE cocondenser | ~30k (sparse) | ~500 sent/sec CPU | `sentence-transformers` |
+| `BM25EmbeddingFunction` | DashText BM25 | variable (sparse) | Fast | `dashtext` |
+
+### API-Based Embeddings
+
+| Function | Provider | Dimensions | Env var |
+|----------|----------|------------|---------|
+| `OpenAIDenseEmbedding` | OpenAI | 1536 (default) | `OPENAI_API_KEY` |
+| `JinaDenseEmbedding` | Jina AI | 768 (nano) / 1024 (small) | `JINA_API_KEY` |
+| `QwenDenseEmbedding` | Alibaba Qwen | varies | `DASHSCOPE_API_KEY` |
+| `QwenSparseEmbedding` | Alibaba Qwen | sparse | `DASHSCOPE_API_KEY` |
+
+### Local Dense Embedding Example
+
+```python
+from zvec.extension import DefaultLocalDenseEmbedding
+
+emb = DefaultLocalDenseEmbedding()  # Downloads all-MiniLM-L6-v2 on first run (~50MB)
+vector = emb.embed("Machine learning is a subset of AI")
+len(vector)  # 384
+
+# GPU acceleration
+emb_gpu = DefaultLocalDenseEmbedding(device="cuda")
+
+# Apple Silicon
+emb_mps = DefaultLocalDenseEmbedding(device="mps")
+```
+
+### Local Sparse Embedding (SPLADE)
+
+```python
+from zvec.extension import DefaultLocalSparseEmbedding
+
+# Query encoding (asymmetric retrieval)
+query_emb = DefaultLocalSparseEmbedding(encoding_type="query")
+query_vec = query_emb.embed("what is machine learning")
+# Returns: {10: 0.45, 23: 0.87, 56: 0.32, ...}  (only non-zero dims)
+
+# Document encoding
+doc_emb = DefaultLocalSparseEmbedding(encoding_type="document")
+doc_vec = doc_emb.embed("Machine learning is a branch of artificial intelligence...")
+```
+
+### BM25 Embedding
+
+```python
+from zvec.extension import BM25EmbeddingFunction
+
+# Built-in encoder (no corpus needed)
+bm25 = BM25EmbeddingFunction(language="en", encoding_type="query")
+sparse_vec = bm25.embed("vector search algorithms")
+
+# Custom corpus for domain-specific accuracy
+bm25_custom = BM25EmbeddingFunction(
+    corpus=["doc1 text...", "doc2 text...", "doc3 text..."],
+    encoding_type="document",
+    b=0.75,   # Length normalization [0,1]
+    k1=1.2,   # Term frequency saturation
+)
+```
+
+### OpenAI Embedding
+
+```python
+from zvec.extension import OpenAIDenseEmbedding
+
+emb = OpenAIDenseEmbedding(
+    model="text-embedding-3-small",  # 1536 dims, cost-efficient
+    # model="text-embedding-3-large",  # 3072 dims, highest quality
+    dimension=1024,  # Custom dimension (Matryoshka)
+    # api_key="sk-..."  # Or set OPENAI_API_KEY env var
+)
+vector = emb.embed("Hello world")
+```
+
+### Jina Embedding (Matryoshka Dimensions)
+
+```python
+from zvec.extension import JinaDenseEmbedding
+
+# Jina v5 supports Matryoshka dimensions: 32, 64, 128, 256, 512, 768, 1024
+emb = JinaDenseEmbedding(
+    model="jina-embeddings-v5-text-small",  # 1024 dims default, 32K context
+    dimension=256,  # Reduce to 256 dims (4x storage savings)
+    task="retrieval.query",  # Optimize for search queries
+    # task="retrieval.passage",  # Use for documents
+    # api_key="jina_..."  # Or set JINA_API_KEY env var
+)
+```
+
+## Rerankers
+
+Zvec includes built-in rerankers for refining search results, especially useful in multi-vector (hybrid) search.
+
+### Reciprocal Rank Fusion (RRF)
+
+Combines results from multiple vector queries without needing relevance scores. Score formula: `1 / (k + rank + 1)`.
+
+```python
+from zvec.extension import RrfReRanker
+
+reranker = RrfReRanker(
+    topn=10,
+    rank_constant=60,  # Smoothing constant (higher = less impact from early ranks)
+)
+
+results = collection.query(
+    vectors=[
+        zvec.VectorQuery("dense_emb", vector=dense_vec),
+        zvec.VectorQuery("sparse_emb", vector=sparse_vec),
+    ],
+    topk=50,
+    reranker=reranker,
+)
+```
+
+### Weighted Reranker
+
+Combines scores from multiple vector fields with configurable weights. Normalizes scores based on metric type.
+
+```python
+from zvec.extension import WeightedReRanker
+from zvec import MetricType
+
+reranker = WeightedReRanker(
+    topn=10,
+    metric=MetricType.COSINE,
+    weights={"dense_emb": 0.7, "sparse_emb": 0.3},
+)
+```
+
+### Cross-Encoder Reranker (Local)
+
+Uses a Sentence Transformer cross-encoder model for deep semantic re-ranking. More accurate than bi-encoder similarity but slower (evaluates query-document pairs jointly).
+
+```python
+from zvec.extension import DefaultLocalReRanker
+
+reranker = DefaultLocalReRanker(
+    query="machine learning algorithms",
+    topn=5,
+    rerank_field="title",  # Which document field to use for re-ranking
+    model_name="cross-encoder/ms-marco-MiniLM-L6-v2",  # ~80MB, fast
+    # model_name="BAAI/bge-reranker-large",  # ~560MB, highest quality
+    device="cuda",  # Optional GPU acceleration
+)
+
+results = collection.query(
+    vectors=zvec.VectorQuery("embedding", vector=query_vec),
+    topk=50,  # Retrieve more candidates for re-ranking
+    reranker=reranker,
+)
+```
+
+### Qwen Reranker (API)
+
+```python
+from zvec.extension import QwenReRanker
+
+reranker = QwenReRanker(
+    query="search query",
+    topn=10,
+    rerank_field="content",
+    # api_key="..."  # Or set DASHSCOPE_API_KEY env var
+)
+```
+
+## Hybrid Search
+
+Combine dense semantic search with sparse lexical matching in a single query for best retrieval quality.
+
+### Full Hybrid Search Pipeline
+
+```python
+import zvec
+from zvec.extension import (
+    DefaultLocalDenseEmbedding,
+    DefaultLocalSparseEmbedding,
+    RrfReRanker,
+)
+
+# 1. Set up embedding functions
+dense_emb = DefaultLocalDenseEmbedding()
+sparse_query_emb = DefaultLocalSparseEmbedding(encoding_type="query")
+sparse_doc_emb = DefaultLocalSparseEmbedding(encoding_type="document")
+
+# 2. Define schema with both dense and sparse vectors
+schema = zvec.CollectionSchema(
+    name="hybrid_docs",
+    fields=[
+        zvec.FieldSchema("content", zvec.DataType.STRING),
+    ],
+    vectors=[
+        zvec.VectorSchema("dense", zvec.DataType.VECTOR_FP32, dimension=dense_emb.dimension),
+        zvec.VectorSchema("sparse", zvec.DataType.SPARSE_VECTOR_FP32),
+    ],
+)
+
+# 3. Create collection and insert documents
+collection = zvec.create_and_open(path="./hybrid_example", schema=schema)
+
+docs = [
+    "Machine learning is a subset of artificial intelligence.",
+    "Neural networks are inspired by biological neurons.",
+    "Python is a popular programming language for data science.",
+]
+
+collection.insert([
+    zvec.Doc(
+        id=f"doc_{i}",
+        fields={"content": text},
+        vectors={
+            "dense": dense_emb.embed(text),
+            "sparse": sparse_doc_emb.embed(text),
+        },
+    )
+    for i, text in enumerate(docs)
+])
+
+# 4. Hybrid query with RRF reranking
+query = "what is deep learning"
+results = collection.query(
+    vectors=[
+        zvec.VectorQuery("dense", vector=dense_emb.embed(query)),
+        zvec.VectorQuery("sparse", vector=sparse_query_emb.embed(query)),
+    ],
+    topk=10,
+    reranker=RrfReRanker(topn=5),
+)
+```
+
+## Python API Reference
+
+### Initialization
+
+```python
+import zvec
+
+# Initialize with defaults (auto-detect resources)
+zvec.init()
+
+# Customize for production
+zvec.init(
+    log_type=zvec.LogType.FILE,
+    log_dir="/var/log/zvec",
+    log_level=zvec.LogLevel.WARN,
+    query_threads=4,          # None = auto-detect from CPU/cgroup
+    optimize_threads=2,       # Background compaction threads
+    memory_limit_mb=2048,     # Soft memory cap (None = auto from cgroup)
+)
+```
+
+`init()` can only be called once. Subsequent calls raise `RuntimeError`. Parameters set to `None` fall back to environment-aware defaults (cgroup-friendly for Docker/K8s).
+
+### Collection Lifecycle
+
+```python
+# Create and open
+collection = zvec.create_and_open(path="./my_collection", schema=schema)
+
+# Open existing
+collection = zvec.open(path="./my_collection")
+
+# Inspect
+print(collection.schema)   # Schema definition
+print(collection.stats)    # Doc count, size, etc.
+print(collection.path)     # Filesystem path
+
+# Optimize (merge segments, rebuild indexes)
+collection.optimize()
+
+# Destroy (irreversible -- deletes all data)
+collection.destroy()
+```
+
+### CRUD Operations
+
+```python
+# Insert
+status = collection.insert(zvec.Doc(
+    id="doc_1",
+    fields={"title": "Example", "category": "tech"},
+    vectors={"embedding": [0.1, 0.2, 0.3, 0.4]},
+))
+
+# Batch insert
+statuses = collection.insert([doc1, doc2, doc3])
+
+# Upsert (insert or update)
+collection.upsert(zvec.Doc(id="doc_1", fields={"title": "Updated"}))
+
+# Update (partial -- only specified fields)
+collection.update(zvec.Doc(id="doc_1", fields={"category": "science"}))
+
+# Fetch by ID
+docs = collection.fetch("doc_1")           # Single
+docs = collection.fetch(["doc_1", "doc_2"])  # Batch
+
+# Delete
+collection.delete("doc_1")
+collection.delete(["doc_1", "doc_2"])
+collection.delete_by_filter("publish_year < 1900")
+
+# Flush (force writes to disk)
+collection.flush()
+```
+
+### Query API
+
+```python
+results = collection.query(
+    vectors=zvec.VectorQuery("embedding", vector=[0.1, 0.2, 0.3, 0.4]),
+    topk=10,
+    filter="category == 'tech' AND publish_year > 2020",
+    include_vector=False,       # Whether to return vector data
+    output_fields=["title"],    # Specific fields to return (None = all)
+    reranker=None,              # Optional reranker
+)
+
+# Query by document ID (use stored vector)
+results = collection.query(
+    vectors=zvec.VectorQuery("embedding", id="doc_1"),
+    topk=10,
+)
+
+# Multi-vector query with index-specific params
+results = collection.query(
+    vectors=[
+        zvec.VectorQuery("dense", vector=dense_vec, param=zvec.HnswQueryParam(ef=300)),
+        zvec.VectorQuery("sparse", vector=sparse_vec),
+    ],
+    topk=50,
+    reranker=RrfReRanker(topn=10),
+)
+```
+
+### Schema Evolution
+
+```python
+# Add a column
+collection.add_column(
+    zvec.FieldSchema("new_field", zvec.DataType.STRING, nullable=True),
+    expression="",  # Default value expression
+)
+
+# Drop a column
+collection.drop_column("old_field")
+
+# Rename a column
+collection.alter_column("old_name", new_name="new_name")
+```
+
+## Node.js API
+
+The Node.js API (`@zvec/zvec`) mirrors the Python API. Key differences:
+
+- Uses camelCase method names instead of snake_case
+- Async operations where applicable
+- Same schema definition pattern
+
+```javascript
+const zvec = require('@zvec/zvec');
+
+// Create collection
+const schema = new zvec.CollectionSchema({
+  name: "example",
+  vectors: [
+    new zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, 384),
+  ],
+});
+
+const collection = zvec.createAndOpen("./my_collection", schema);
+
+// Insert
+collection.insert([
+  new zvec.Doc("doc_1", { embedding: [0.1, 0.2, 0.3, ...] }),
+]);
+
+// Query
+const results = collection.query(
+  new zvec.VectorQuery("embedding", { vector: [0.1, 0.2, 0.3, ...] }),
+  { topk: 10 }
+);
+
+// Optimize
+collection.optimize();
+
+// Destroy
+collection.destroy();
+```
+
+Note: The Node.js bindings are less mature than Python. The Python API has richer embedding function and reranker support. For production RAG pipelines, Python is the recommended binding.
+
+## Collection-Per-Tenant Pattern
+
+Zvec's collection model maps naturally to multi-tenant SaaS isolation. Each tenant gets a dedicated collection with its own data files on disk.
+
+### Why Collection-Per-Tenant
+
+| Property | Benefit |
+|----------|---------|
+| Physical isolation | Each tenant's vectors in separate files -- no data leakage risk |
+| Independent lifecycle | Create/destroy a tenant's data with a single function call |
+| No metadata filtering | No `WHERE tenant_id = ?` on every query -- the collection IS the tenant |
+| Independent optimization | Optimize one tenant's index without affecting others |
+| Simple backup/restore | Copy/delete a directory to backup/restore a tenant |
+
+### Implementation
+
+```python
+import zvec
+from pathlib import Path
+
+VECTOR_DATA_ROOT = Path("/data/vectors")
+
+def create_tenant_collection(org_id: str, dimension: int = 384) -> zvec.Collection:
+    """Create a new vector collection for a tenant."""
+    tenant_path = VECTOR_DATA_ROOT / org_id
+    schema = zvec.CollectionSchema(
+        name=f"tenant_{org_id}",
+        fields=[
+            zvec.FieldSchema("content_chunk", zvec.DataType.STRING),
+            zvec.FieldSchema("source_file", zvec.DataType.STRING),
+            zvec.FieldSchema("chunk_index", zvec.DataType.INT32),
+        ],
+        vectors=[
+            zvec.VectorSchema("embedding", zvec.DataType.VECTOR_FP32, dimension=dimension),
+        ],
+    )
+    return zvec.create_and_open(path=str(tenant_path), schema=schema)
+
+def open_tenant_collection(org_id: str) -> zvec.Collection:
+    """Open an existing tenant's collection."""
+    tenant_path = VECTOR_DATA_ROOT / org_id
+    return zvec.open(path=str(tenant_path))
+
+def destroy_tenant_collection(org_id: str) -> None:
+    """Permanently delete a tenant's vector data."""
+    collection = open_tenant_collection(org_id)
+    collection.destroy()
+```
+
+### Scaling Considerations
+
+- **<10k tenants**: Collection-per-tenant works well. Each collection is a directory with index files.
+- **10k-100k tenants**: Consider lazy loading -- only open collections for active tenants. Zvec collections are opened/closed per request or with a TTL cache.
+- **>100k tenants**: Consider namespace-based isolation (metadata filtering) or a hosted solution. File descriptor and directory limits become a factor.
+
+## Performance Benchmarks
+
+Benchmarked using [VectorDBBench](https://github.com/zilliztech/VectorDBBench) on a 16 vCPU / 64 GiB instance (g9i.4xlarge).
+
+### Cohere 10M (768-dim, 10M vectors)
+
+Configuration: HNSW with `m=50`, `ef_search=118`, INT8 quantization + refiner.
+
+Zvec achieves the highest QPS among tested databases at >95% recall on the 10M benchmark, with the fastest index build time.
+
+### Cohere 1M (768-dim, 1M vectors)
+
+Configuration: HNSW with `m=15`, `ef_search=180`, INT8 quantization.
+
+### Key Performance Characteristics
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Search latency | Sub-millisecond | In-process, no network hop |
+| Index build | Fastest in VectorDBBench | Parallel C++ indexing |
+| Memory efficiency | ~4x reduction with INT8 | Quantization + refiner maintains recall |
+| Recall | >95% at high QPS | HNSW + INT8 + refiner |
+
+### Reproducing Benchmarks
+
+```bash
+pip install zvec==v0.1.1
+pip install vectordbbench
+
+# 10M benchmark
+vectordbbench zvec --path Performance768D10M --case-type Performance768D10M \
+  --num-concurrency 12,14,16,18,20 --quantize-type int8 \
+  --m 50 --ef-search 118 --is-using-refiner
+
+# 1M benchmark
+vectordbbench zvec --path Performance768D1M --case-type Performance768D1M \
+  --num-concurrency 12,14,16,18,20 --quantize-type int8 \
+  --m 15 --ef-search 180
+```
+
+## Metric Types
+
+| Metric | Constant | Description |
+|--------|----------|-------------|
+| L2 (Euclidean) | `MetricType.L2` | Euclidean distance (lower = more similar) |
+| Inner Product | `MetricType.IP` | Dot product (higher = more similar) |
+| Cosine | `MetricType.COSINE` | Cosine similarity (higher = more similar) |
+
+## Comparison with Alternatives
+
+| Feature | Zvec | pgvector | Qdrant | Milvus | Pinecone |
+|---------|------|----------|--------|--------|----------|
+| Deployment | In-process | Postgres extension | Server | Distributed | Hosted |
+| Network hop | None | Yes | Yes | Yes | Yes |
+| Built-in embeddings | Yes | No | No | No | No |
+| Built-in rerankers | Yes | No | No | No | No |
+| Hybrid search | Native | Via tsvector | Yes | Yes | Yes |
+| Tenant isolation | Collection/dir | RLS/schema | Collection | Collection | Namespace |
+| Horizontal scaling | No | Limited | Yes | Yes | Yes |
+| Ops overhead | None | Postgres admin | Server admin | Complex | None (hosted) |
+| License | Apache 2.0 | PostgreSQL | Apache 2.0 | Apache 2.0 | Proprietary |
+
+## Related Resources
+
+- [PGlite - Local-First Embedded Postgres](../pglite-local-first.md) -- For apps needing full SQL + pgvector
+- [Zvec GitHub](https://github.com/alibaba/zvec) -- Source code and issues
+- [Zvec Documentation](https://zvec.org/en/docs/) -- Official docs
+- [VectorDBBench](https://github.com/zilliztech/VectorDBBench) -- Benchmark framework


### PR DESCRIPTION
## Summary

- Add comprehensive zvec deep-dive reference at `.agents/tools/database/vector-search/zvec.md` covering installation, collection schema, index types (HNSW/IVF/Flat), dense+sparse vectors, hybrid search, built-in embedding functions, rerankers, quantization, Python and Node.js APIs, collection-per-tenant pattern, and performance benchmarks
- Add vector search entry to AGENTS.md domain index and subagent-index.toon

Closes #2675

## Details

All API examples sourced directly from the zvec Python source code at [alibaba/zvec](https://github.com/alibaba/zvec) and the [official documentation](https://zvec.org/en/docs/). Covers:

- **Installation**: pip (Python 3.10-3.12) and npm (`@zvec/zvec`), plus optional deps for embeddings/rerankers
- **Schema**: Full scalar and vector data type reference with code examples
- **Index types**: HNSW, IVF, Flat vector indexes with parameter tuning guidance; InvertIndexParam for scalar filtering
- **Vectors**: Dense (FP32/FP16/FP64/INT8) and sparse (SPARSE_VECTOR_FP32/FP16) with hybrid search pipeline
- **Embedding functions**: Local (all-MiniLM-L6-v2, SPLADE, BM25/DashText) and API (OpenAI, Jina v5 with Matryoshka dims, Qwen)
- **Rerankers**: RRF, Weighted, cross-encoder (DefaultLocalReRanker), Qwen API
- **Quantization**: INT8 for ~4x memory reduction with refiner for recall preservation
- **APIs**: Full Python CRUD/query reference, Node.js API overview
- **Multi-tenant**: Collection-per-tenant pattern with implementation code and scaling guidance
- **Benchmarks**: VectorDBBench results (Cohere 1M/10M) with reproduction commands
- **Comparison table**: Zvec vs pgvector vs Qdrant vs Milvus vs Pinecone