### PR TITLE
t1374: Wire design skill into agent index and update cross-references

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -180,6 +180,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | OCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |
 | Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `mobile-app-dev.md`, `browser-extension-dev.md` |
 | Content/Video/Voice | `content.md`, `tools/video/video-prompt-design.md`, `tools/voice/speech-to-speech.md` |
+| Design | `tools/design/ui-ux-inspiration.md`, `tools/design/ui-ux-catalogue.toon`, `tools/design/brand-identity.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |
 | WordPress | `tools/wordpress/wp-dev.md`, `tools/wordpress/mainwp.md` |
 | Communications | `services/communications/matterbridge.md`, `services/communications/simplex.md`, `services/communications/matrix-bot.md` |

--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -114,6 +114,7 @@ Before implementing, check AGENTS.md domain index. If the task touches a special
 | SEO/blog posts | `seo/` + `content/distribution/` |
 | WordPress | `tools/wordpress/wp-dev.md` |
 | UI/layout/design/CSS | `workflows/ui-verification.md` + `tools/browser/playwright-emulation.md` + `tools/browser/chrome-devtools.md` |
+| Design system/brand identity/style | `tools/design/ui-ux-inspiration.md` + `tools/design/ui-ux-catalogue.toon` + `tools/design/brand-identity.md` |
 | Browser automation | `tools/browser/browser-automation.md` |
 | Accessibility | `services/accessibility/accessibility-audit.md` |
 | Local dev / .local domains / ports / proxy / HTTPS / LocalWP | `services/hosting/local-hosting.md` |

--- a/.agents/content/guidelines.md
+++ b/.agents/content/guidelines.md
@@ -31,6 +31,8 @@ tools:
 
 These guidelines define the standard for creating high-quality, human-sounding, SEO-optimized content for our websites (specifically tailored for local businesses like Trinity Joinery).
 
+**Brand identity override**: When a project has `context/brand-identity.toon`, the brand voice and visual identity come from there. This file provides structural copywriting rules only — tone, vocabulary, and personality are defined per-project in the brand identity. See `tools/design/brand-identity.md` for the bridge agent that creates and maintains brand identity files.
+
 ## Tone of Voice
 
 - **Authentic & Local:** Sound like a local expert, not a generic corporation. Use "We make..." instead of "Trinity Joinery crafts...".

--- a/.agents/content/platform-personas.md
+++ b/.agents/content/platform-personas.md
@@ -9,6 +9,8 @@ model: haiku
 
 Adapt your core brand voice for each platform. The base voice comes from `content/guidelines.md` and project-level `context/brand-voice.md` -- this subagent defines how to shift that voice per channel.
 
+**Brand identity integration**: When a project has `context/brand-identity.toon`, read it first for the base voice and visual identity before applying platform shifts below. The brand identity defines tone, vocabulary, imagery style, and personality that should carry through to every channel. See `tools/design/brand-identity.md`.
+
 ## How to Use
 
 1. Establish your core voice in `content/guidelines.md` or `context/brand-voice.md`

--- a/.agents/content/production/image.md
+++ b/.agents/content/production/image.md
@@ -855,6 +855,8 @@ See `tools/video/enhancor.md` for complete API reference, examples, and integrat
 
 ## Cross-References
 
+- **Brand identity**: `tools/design/brand-identity.md` — when a project has `context/brand-identity.toon`, check it for imagery style, iconography, colour palette, and visual identity parameters before generating images
+- **Design catalogue**: `tools/design/ui-ux-catalogue.toon` — 96 colour palettes, 67 UI styles, and industry-specific design patterns for style selection
 - **Model comparison**: `tools/vision/image-generation.md` — detailed comparison of DALL-E 3, Midjourney, FLUX, SD XL
 - **Video production**: `content/production/video.md` — frame-to-video workflow, Veo 3.1 ingredients
 - **Character consistency**: `content/production/characters.md` — Facial Engineering Framework, character bibles

--- a/.agents/mobile-app-dev/ui-design.md
+++ b/.agents/mobile-app-dev/ui-design.md
@@ -141,7 +141,7 @@ Use vision AI tools for icon generation:
 
 ## Design Inspiration Resources
 
-See `tools/design/design-inspiration.md` for the full catalogue of 60+ design inspiration resources.
+See `tools/design/design-inspiration.md` for the full catalogue of 60+ design inspiration resources. For structured design intelligence — UI styles, colour palettes, font pairings, and industry-specific patterns — see `tools/design/ui-ux-catalogue.toon`. For brand identity and style interviews, see `tools/design/brand-identity.md` and `tools/design/ui-ux-inspiration.md`.
 
 **Quick picks for mobile app design**:
 

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -23,7 +23,7 @@ pro,gemini-2.5-pro,Capable large context
 grok,grok-3,Research and real-time web knowledge
 -->
 
-<!--TOON:subagents[61]{folder,purpose,key_files}:
+<!--TOON:subagents[62]{folder,purpose,key_files}:
 aidevops/,Framework internals - extending aidevops and architecture and plugins,setup|architecture|troubleshooting|self-improving-agents|claude-flow-comparison|plugins
 business/,Company orchestration - runner configs for company functions,company-runners
 memory/,Cross-session memory - SQLite FTS5 storage,README
@@ -43,6 +43,7 @@ tools/pdf/,PDF processing - form filling and digital signatures,overview|libpdf
 tools/accessibility/,Accessibility and contrast testing - WCAG compliance for websites and emails,accessibility
 tools/performance/,Web performance - Core Web Vitals and network analysis,performance|webpagetest
 tools/research/,Technology research - tech stack detection and reverse lookup,tech-stack-lookup
+tools/design/,UI/UX design intelligence - style catalogue brand identity interview and inspiration,design-inspiration|ui-ux-inspiration|ui-ux-catalogue|brand-identity
 tools/ui/,UI components - design systems and debugging,shadcn|ui-skills|frontend-debugging|ai-chat-sidebar
 tools/code-review/,Code quality - linting and security scanning,code-standards|code-simplifier|codacy|coderabbit|qlty|snyk|secretlint|security-analysis|security-audit
 tools/context/,Context optimization - semantic search and indexing,augment-context-engine|context-builder|context7|toon|mcp-discovery|github-search|model-routing|openapi-search


### PR DESCRIPTION
## Summary

- Add `tools/design/` entry to `subagent-index.toon` with all four design files (design-inspiration, ui-ux-inspiration, ui-ux-catalogue, brand-identity)
- Add Design row to AGENTS.md domain index and build-plus.md domain expertise table
- Add `brand-identity.toon` cross-references to content agents (guidelines.md, platform-personas.md, image.md) and mobile-app-dev/ui-design.md

## Changes (7 files, 11 insertions, 2 deletions)

| File | Change |
|------|--------|
| `.agents/subagent-index.toon` | New `tools/design/` entry with 4 key files; count 61→62 |
| `.agents/AGENTS.md` | Design row in domain index table |
| `.agents/build-plus.md` | Design system/brand identity row in domain expertise table |
| `.agents/content/guidelines.md` | Brand identity override note |
| `.agents/content/platform-personas.md` | Brand identity integration note |
| `.agents/content/production/image.md` | Brand identity + design catalogue cross-references |
| `.agents/mobile-app-dev/ui-design.md` | Catalogue and brand identity references |

## Dependencies

Blocked by t1371, t1372, t1373 — the three design files referenced here must be merged first. This PR wires the cross-references so agents can discover them.

## Verification

- All acceptance criteria patterns verified via `rg`
- markdownlint-cli2: 0 errors on all 6 modified .md files
- TOON entry count matches header (62)
- Referenced file paths will exist once t1371-t1373 merge

Closes #2689