### PR TITLE
t1375.4: Update cross-references and indexes for prompt injection scanner

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -185,7 +185,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Communications | `services/communications/matterbridge.md`, `services/communications/simplex.md`, `services/communications/matrix-bot.md` |
 | Email | `tools/ui/react-email.md`, `services/email/email-testing.md`, `services/email/email-agent.md` |
 | Payments | `services/payments/revenuecat.md`, `services/payments/stripe.md`, `services/payments/procurement.md` |
-| Security/Encryption | `tools/security/tirith.md`, `tools/security/opsec.md`, `tools/credentials/encryption-stack.md` |
+| Security/Encryption | `tools/security/tirith.md`, `tools/security/opsec.md`, `tools/security/prompt-injection-defender.md`, `tools/credentials/encryption-stack.md` |
 | Database/Local-first | `tools/database/pglite-local-first.md`, `services/database/postgres-drizzle-skill.md` |
 | Vector Search | `tools/database/vector-search.md`, `tools/database/vector-search/zvec.md` |
 | Local Development | `services/hosting/local-hosting.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -59,7 +59,7 @@ tools/data-extraction/,Data extraction - scraping business data,outscraper
 tools/deployment/,Deployment automation - self-hosted PaaS and orchestration,coolify|coolify-cli|vercel|cloudron-app-packaging|cloudron-app-packaging-skill|cloudron-app-publishing-skill|cloudron-server-ops-skill|uncloud
 tools/git/,Git operations - GitHub/GitLab/Gitea CLIs and diff tools,github-cli|gitlab-cli|gitea-cli|github-actions|worktrunk|lumen|jujutsu|conflict-resolution
 tools/credentials/,Secret management - API keys vaults and encryption stack,api-key-setup|api-key-management|vaultwarden|gopass|psst|multi-tenant|list-keys|sops|gocryptfs|encryption-stack
-tools/security/,Security tools - terminal guards privacy filtering IP reputation scanning and opsec,tirith|shannon|cdn-origin-ip|privacy-filter|ip-reputation|opsec
+tools/security/,Security tools - terminal guards privacy filtering IP reputation scanning prompt injection defense and opsec,tirith|shannon|cdn-origin-ip|privacy-filter|ip-reputation|opsec|prompt-injection-defender
 tools/task-management/,Task tracking - dependency graphs,beads
 tools/terminal/,Terminal integration - tab titles,terminal-title
 tools/automation/,Automation - cron scheduling objective runner and macOS AppleScript/JXA,cron-agent|objective-runner|mac|macos-automator
@@ -121,7 +121,7 @@ conversation-starter,workflows/conversation-starter.md,Session greeting and auto
 mission-skill-learning,workflows/mission-skill-learning.md,Auto-capture reusable patterns from missions and suggest promotion
 -->
 
-<!--TOON:scripts[99]{name,purpose}:
+<!--TOON:scripts[100]{name,purpose}:
 accessibility-helper.sh,Accessibility and contrast testing (WCAG compliance WAVE API for websites and emails)
 browser-qa-worker.sh,Browser QA visual testing — Playwright screenshots broken links console errors for milestone validation
 browser-qa-helper.sh,Playwright-based visual QA for milestone validation (smoke screenshots links a11y)
@@ -219,4 +219,5 @@ planning-commit-helper.sh,Planning file auto-commit helper (next-id complete com
 multi-org-helper.sh,Multi-org management CLI (init create delete list switch use status info set-plan context)
 simplex-helper.sh,SimpleX Chat CLI helper (install init bot-start bot-stop send send-group connect address group status server)
 skills-helper.sh,Skill discovery and exploration CLI (search browse describe info list categories recommend)
+prompt-guard-helper.sh,Prompt injection defense - scan content for injection patterns with YAML pattern loading and policy enforcement (check scan-stdin scan-file patterns test)
 -->

--- a/.agents/tools/code-review/security-audit.md
+++ b/.agents/tools/code-review/security-audit.md
@@ -43,6 +43,7 @@ mcp:
 | CORS configuration | Web server code present |
 | Auth / rate limiting | API server code present |
 | Insecure HTTP URLs | Always |
+| Prompt injection patterns | AI/agent code present |
 | Security automation (Dependabot) | Always |
 
 <!-- AI-CONTEXT-END -->
@@ -298,7 +299,27 @@ rg -n 'http://' \
   grep -v 'localhost\|127\.0\.0\.1\|0\.0\.0\.0\|example\.com' | head -20
 ```
 
-#### 3.12 Security Automation (Always)
+#### 3.12 Prompt Injection Patterns (When AI/agent code present)
+
+If the project processes untrusted content through AI/LLM pipelines (user uploads, web scraping, API responses, chat inputs), check for prompt injection defenses:
+
+```bash
+# Check for prompt injection scanning in the codebase
+rg -in '(prompt.?inject|prompt.?guard|content.?scan|injection.?detect)' \
+  --glob '*.{js,ts,py,go,rs,sh,yaml,yml}' -l
+
+# Check for untrusted content ingestion without scanning
+rg -in '(webfetch|fetch|requests\.get|urllib|curl)' \
+  --glob '*.{js,ts,py,go,rs,sh}' -l | head -10
+
+# Check for LLM/AI framework usage (indicates prompt injection risk)
+rg -in '(openai|anthropic|langchain|llama|ollama|ai\.run|completion)' \
+  --glob '*.{js,ts,py,go,rs}' -l | head -10
+```
+
+For aidevops projects, verify `prompt-guard-helper.sh` integration. See `tools/security/prompt-injection-defender.md` for defense patterns and integration guidance.
+
+#### 3.13 Security Automation (Always)
 
 ```bash
 # Dependabot
@@ -389,11 +410,15 @@ Use this exact structure for the audit report:
 
 {http:// references in source code}
 
-### 11. Security Automation -- **{PASS/FAIL/WARN}**
+### 11. Prompt Injection Defense -- **{PASS/FAIL/WARN/SKIP}**
+
+{prompt injection scanning presence, untrusted content handling, or "No AI/agent code found (SKIP)"}
+
+### 12. Security Automation -- **{PASS/FAIL/WARN}**
 
 {Dependabot/Renovate, CI scanning, SECURITY.md}
 
-### 12. Security Architecture -- **{assessment}**
+### 13. Security Architecture -- **{assessment}**
 
 {qualitative assessment of auth, validation, error handling}
 
@@ -439,6 +464,7 @@ This audit reuses existing aidevops security infrastructure where applicable:
 
 - **`security-helper.sh scan-deps`**: For dependency vulnerability scanning via OSV-Scanner
 - **`secretlint-helper.sh`**: For credential detection
+- **`prompt-guard-helper.sh`**: For prompt injection pattern scanning (chat, content, stdin). See `tools/security/prompt-injection-defender.md` for integration patterns.
 - **ShellCheck**: For shell script analysis (via `linters-local.sh` patterns)
 
-The audit adds categories not covered by existing commands: GitHub Actions supply chain, Docker security, CORS, auth/rate limiting, and the structured severity report.
+The audit adds categories not covered by existing commands: GitHub Actions supply chain, Docker security, CORS, auth/rate limiting, prompt injection defense, and the structured severity report.


### PR DESCRIPTION
## Summary

- Add `prompt-injection-defender.md` to `subagent-index.toon` under the Security domain (key_files list)
- Add `prompt-guard-helper.sh` to the scripts section of `subagent-index.toon` (99 → 100 scripts)
- Add `tools/security/prompt-injection-defender.md` to the Security/Encryption row in `.agents/AGENTS.md` domain index table
- Add prompt injection audit category (section 3.12) to `security-audit.md` with detection patterns for AI/agent code
- Add report template section 11 for prompt injection defense findings
- Reference `prompt-guard-helper.sh` in the security-audit.md integration section

These cross-references ensure the new prompt injection defender doc (being created by t1375.2) is discoverable from all standard entry points: the TOON subagent index, the AGENTS.md domain table, and the security audit checklist.

Closes #2702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prompt injection defense tooling and helpers to enhance security capabilities.

* **Documentation**
  * Expanded security audit guidance with prompt injection pattern detection and defense procedures.
  * Updated security domain index to include prompt injection defender resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->