### PR TITLE
chore: improve update prompt with in-session action hint

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -44,7 +44,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 3. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message
 
-If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest`), inform user: "Update available (current → latest). Run `aidevops update` to update."
+If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter."
 
 ## Pre-Edit Git Check
 

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -8,7 +8,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 3. Parse the first line of output (format: `aidevops v{version} running in {app} v{app_version} | {repo}`). Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version} in {app} v{app_version}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message
 
-If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest|AppName`), inform user: "Update available (current → latest). Run `aidevops update` to update."
+If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest|AppName`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter."
 
 ## Pre-Edit Git Check
 


### PR DESCRIPTION
## Summary

- Updates the update-available prompt to tell users they can run `!aidevops update` directly in the chat session, not just in a separate terminal
- Changes applied to both the template (`templates/opencode-config-agents.md`) and the generator script (`.agents/scripts/generate-opencode-agents.sh`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced update notification messaging with improved clarity and detail for users. When updates are available, users now receive comprehensive guidance that covers multiple update methods—including terminal commands and in-app shortcuts—ensuring better accessibility and clearer pathways for maintaining their software installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->