### PR TITLE
t2724: fix: preserve oh-my-opencode.json by default

### DIFF
--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -50,27 +50,33 @@ cleanup_deprecated_paths() {
 		print_info "Cleaned up $cleaned deprecated agent path(s)"
 	fi
 
-	# Auto-remove oh-my-opencode remnants (no longer supported)
+	# Remove oh-my-opencode remnants (no longer supported) — but respect user preference.
+	# Default: preserve user files. Override with --overwrite flag or settings.json.
+	# See: ~/.config/aidevops/settings.json { "preserve_oh_my_opencode": true }
 	local omo_config="$HOME/.config/opencode/oh-my-opencode.json"
 	if [[ -f "$omo_config" ]]; then
-		rm -f "$omo_config"
-		print_info "Removed oh-my-opencode config"
+		if should_overwrite_user_file "preserve_oh_my_opencode" "oh-my-opencode config ($omo_config)"; then
+			rm -f "$omo_config"
+			print_info "Removed oh-my-opencode config"
+		fi
 	fi
 
 	# Remove osgrep — disproportionate CPU/disk cost (74GB indexes, 4 CPU cores on startup)
 	# rg + fd + LLM comprehension covers the same ground at zero resource cost
 	cleanup_osgrep
 
-	# Remove oh-my-opencode from plugin array if present
+	# Remove oh-my-opencode from plugin array if present — guarded by same setting
 	local opencode_config
 	opencode_config=$(find_opencode_config 2>/dev/null) || true
 	if [[ -n "$opencode_config" ]] && [[ -f "$opencode_config" ]] && command -v jq &>/dev/null; then
 		if jq -e '.plugin | index("oh-my-opencode")' "$opencode_config" >/dev/null 2>&1; then
-			local tmp_file
-			tmp_file=$(mktemp)
-			trap 'rm -f "${tmp_file:-}"' RETURN
-			jq '.plugin = [.plugin[] | select(. != "oh-my-opencode")]' "$opencode_config" >"$tmp_file" && mv "$tmp_file" "$opencode_config"
-			print_info "Removed oh-my-opencode from OpenCode plugin list"
+			if should_overwrite_user_file "preserve_oh_my_opencode" "oh-my-opencode plugin entry in OpenCode config"; then
+				local tmp_file
+				tmp_file=$(mktemp)
+				trap 'rm -f "${tmp_file:-}"' RETURN
+				jq '.plugin = [.plugin[] | select(. != "oh-my-opencode")]' "$opencode_config" >"$tmp_file" && mv "$tmp_file" "$opencode_config"
+				print_info "Removed oh-my-opencode from OpenCode plugin list"
+			fi
 		fi
 	fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,7 @@ CLEAN_MODE=false
 INTERACTIVE_MODE=false
 NON_INTERACTIVE="${AIDEVOPS_NON_INTERACTIVE:-false}"
 UPDATE_TOOLS_MODE=false
+OVERWRITE_MODE=false
 # Platform constants (used across all setup modules)
 PLATFORM_MACOS=$([[ "$(uname -s)" == "Darwin" ]] && echo true || echo false)
 PLATFORM_LINUX=$([[ "$(uname -s)" == "Linux" ]] && echo true || echo false)
@@ -236,6 +237,77 @@ find_python3() {
 		return 0
 	fi
 	return 1
+}
+
+# Read a setting from ~/.config/aidevops/settings.json
+# Usage: get_aidevops_setting "key" "default_value"
+# Returns: the value of the key, or default if key/file missing
+# Example: get_aidevops_setting "preserve_oh_my_opencode" "true"
+get_aidevops_setting() {
+	local key="$1"
+	local default_value="${2:-}"
+	local settings_file="$HOME/.config/aidevops/settings.json"
+
+	if [[ ! -f "$settings_file" ]] || ! command -v jq &>/dev/null; then
+		echo "$default_value"
+		return 0
+	fi
+
+	local value
+	value=$(jq -r --arg k "$key" '.[$k] // empty' "$settings_file" 2>/dev/null) || true
+	if [[ -z "$value" ]]; then
+		echo "$default_value"
+	else
+		echo "$value"
+	fi
+	return 0
+}
+
+# Check whether a user file should be overwritten during cleanup/migration.
+# Non-destructive by default: if a preserve_<key> setting is true (or absent),
+# the file is preserved unless --overwrite was passed or the user confirms interactively.
+# Usage: should_overwrite_user_file "setting_key" "file_description"
+# Returns: 0 if overwrite is allowed, 1 if file should be preserved
+should_overwrite_user_file() {
+	local setting_key="$1"
+	local description="$2"
+	local preserve_setting
+	preserve_setting=$(get_aidevops_setting "$setting_key" "true")
+
+	# If user explicitly set preserve to false, allow overwrite
+	if [[ "$preserve_setting" == "false" ]]; then
+		return 0
+	fi
+
+	# If --overwrite flag was passed, allow overwrite
+	if [[ "$OVERWRITE_MODE" == "true" ]]; then
+		return 0
+	fi
+
+	# In non-interactive mode without --overwrite, preserve the file
+	if [[ "$NON_INTERACTIVE" == "true" ]]; then
+		print_info "Preserving $description (set \"$setting_key\": false in ~/.config/aidevops/settings.json to allow removal, or use --overwrite)"
+		return 1
+	fi
+
+	# Interactive mode: ask the user
+	echo ""
+	echo -e "${YELLOW}Found:${NC} $description"
+	echo -e "This file is preserved by default. Override with --overwrite or set"
+	echo -e "\"$setting_key\": false in ~/.config/aidevops/settings.json"
+	echo ""
+	echo -n -e "${GREEN}Remove this file? [y/N]: ${NC}"
+	read -r response
+	response=$(echo "$response" | tr '[:upper:]' '[:lower:]')
+	case "$response" in
+	y | yes)
+		return 0
+		;;
+	*)
+		print_info "Preserved $description"
+		return 1
+		;;
+	esac
 }
 
 # Install a package globally via npm, with sudo when needed on Linux.
@@ -471,6 +543,10 @@ parse_args() {
 			UPDATE_TOOLS_MODE=true
 			shift
 			;;
+		--overwrite)
+			OVERWRITE_MODE=true
+			shift
+			;;
 		--help | -h)
 			echo "Usage: ./setup.sh [OPTIONS]"
 			echo ""
@@ -478,10 +554,13 @@ parse_args() {
 			echo "  --clean            Remove stale files before deploying (cleans ~/.aidevops/agents/)"
 			echo "  --interactive, -i  Ask confirmation before each step"
 			echo "  --non-interactive, -n  Deploy agents only, skip all optional installs (no prompts)"
+			echo "  --overwrite        Force removal of user files that are preserved by default"
 			echo "  --update, -u       Check for and offer to update outdated tools after setup"
 			echo "  --help             Show this help message"
 			echo ""
 			echo "Default behavior adds/overwrites files without removing deleted agents."
+			echo "User config files (e.g. oh-my-opencode.json) are preserved by default."
+			echo "Override with --overwrite or set preserve_<key>: false in settings.json."
 			echo "Use --clean after removing or renaming agents to sync deletions."
 			echo "Use --interactive to control each step individually."
 			echo "Use --non-interactive for CI/CD or AI agent shells (no stdin required)."


### PR DESCRIPTION
## Summary

- setup.sh now checks `preserve_oh_my_opencode` in `~/.config/aidevops/settings.json` before deleting `oh-my-opencode.json` or removing its plugin entry
- Default behaviour is non-destructive (preserve user files)
- Three override paths: `--overwrite` CLI flag, `settings.json` `preserve_oh_my_opencode: false`, or interactive confirmation prompt

## Changes

**`setup.sh`:**
- Added `OVERWRITE_MODE` global flag and `--overwrite` CLI option
- Added `get_aidevops_setting()` — reads keys from `~/.config/aidevops/settings.json` with jq, falls back to default
- Added `should_overwrite_user_file()` — checks settings → `--overwrite` flag → interactive prompt (or preserves in non-interactive mode)
- Updated `--help` text to document `--overwrite` and the preserve-by-default behaviour

**`setup-modules/migrations.sh`:**
- Guarded `oh-my-opencode.json` deletion with `should_overwrite_user_file`
- Guarded oh-my-opencode plugin array removal with same guard

## Verification

- `shellcheck setup.sh` — zero violations
- `shellcheck setup-modules/migrations.sh` — zero violations

Closes #2724

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line option to control whether user files are overwritten during setup
  * Integrated user settings management to respect preservation preferences

* **Improvements**
  * User configuration files are now preserved by default during installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->