### PR TITLE
feat: auto-update opt-out via settings.json

### DIFF
--- a/.agents/reference/services.md
+++ b/.agents/reference/services.md
@@ -83,6 +83,31 @@ When local search returns no results, the `/skills` command suggests searching t
 
 **CLI**: `aidevops [init|update|auto-update|status|repos|skill|skills|detect|features|uninstall]`. See `/onboarding` for setup wizard.
 
+## User Settings
+
+Persistent user preferences are stored in `~/.config/aidevops/settings.json`. This file is optional — all keys default to sensible values. Environment variables always take priority over settings.json.
+
+**Supported keys:**
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `auto_update` | `true` | Enable/disable the auto-update launchd/cron job |
+| `supervisor_pulse` | `true` | Enable/disable the supervisor pulse scheduler |
+| `repo_sync` | `true` | Enable/disable the daily repo sync job |
+
+**Example** — disable auto-update and supervisor pulse:
+
+```json
+{
+  "auto_update": false,
+  "supervisor_pulse": false
+}
+```
+
+**Priority**: environment variable > settings.json > default (`true`).
+
+**Shell access**: Scripts that source `shared-constants.sh` can read settings via `get_setting "key" "default"`.
+
 ## Auto-Update
 
 Automatic polling for new releases. Checks GitHub every 10 minutes and runs `aidevops update` when a new version is available. Safe to run while AI sessions are active.
@@ -95,7 +120,9 @@ Automatic polling for new releases. Checks GitHub every 10 minutes and runs `aid
 
 **Scheduler**: macOS uses launchd (`~/Library/LaunchAgents/com.aidevops.auto-update.plist`); Linux uses cron. Auto-migrates existing cron entries on macOS when `enable` is run.
 
-**Env override**: `AIDEVOPS_AUTO_UPDATE=false` disables even if scheduler is installed.
+**Config file**: `~/.config/aidevops/settings.json` — set `"auto_update": false` to persistently disable auto-update. This is the recommended way to opt out (survives shell restarts, no env var needed). The file is optional; all keys default to `true`.
+
+**Env override**: `AIDEVOPS_AUTO_UPDATE=false` disables even if scheduler is installed. Env vars take priority over settings.json.
 
 **Logs**: `~/.aidevops/logs/auto-update.log`
 
@@ -117,9 +144,11 @@ Automatic daily `git pull` for all git repos in configured parent directories. K
 
 **Scheduler**: macOS uses launchd (`~/Library/LaunchAgents/com.aidevops.aidevops-repo-sync.plist`); Linux uses cron (daily at 3am).
 
+**Config file**: `~/.config/aidevops/settings.json` — set `"repo_sync": false` to persistently disable. Env vars take priority.
+
 **Env overrides**:
 
-- `AIDEVOPS_REPO_SYNC=false` — disable even if scheduler is installed
+- `AIDEVOPS_REPO_SYNC=false` — disable even if scheduler is installed (overrides settings.json)
 - `AIDEVOPS_REPO_SYNC_INTERVAL=1440` — minutes between syncs (default: 1440 = daily)
 
 **Configuration** (`~/.config/aidevops/repos.json`):

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -25,7 +25,13 @@
 #   auto-update-helper.sh logs [--tail N]  View update logs
 #   auto-update-helper.sh help             Show this help
 #
-# Configuration:
+# Configuration (settings.json — persistent, survives shell restarts):
+#   ~/.config/aidevops/settings.json      Optional JSON config file
+#     { "auto_update": false }            Disable auto-update checks
+#     { "supervisor_pulse": false }        Disable supervisor pulse
+#     { "repo_sync": false }              Disable daily repo sync
+#
+# Configuration (env vars — override settings.json):
 #   AIDEVOPS_AUTO_UPDATE=true|false        Override enable/disable (env var)
 #   AIDEVOPS_UPDATE_INTERVAL=10           Minutes between checks (default: 10)
 #   AIDEVOPS_SKILL_AUTO_UPDATE=false      Disable daily skill freshness check
@@ -35,6 +41,8 @@
 #   AIDEVOPS_TOOL_AUTO_UPDATE=false       Disable 6-hourly tool freshness check
 #   AIDEVOPS_TOOL_FRESHNESS_HOURS=6       Hours between tool checks (default: 6)
 #   AIDEVOPS_TOOL_IDLE_HOURS=6            Required user idle hours before tool updates (default: 6)
+#
+# Priority: env var > settings.json > default (true)
 #
 # Logs: ~/.aidevops/logs/auto-update.log
 
@@ -857,9 +865,15 @@ update_tool_check_timestamp() {
 cmd_check() {
 	ensure_dirs
 
-	# Respect env var override
+	# Respect env var override, then settings.json
 	if [[ "${AIDEVOPS_AUTO_UPDATE:-}" == "false" ]]; then
 		log_info "Auto-update disabled via AIDEVOPS_AUTO_UPDATE=false"
+		return 0
+	fi
+
+	# Check settings.json (only when env var is not set)
+	if [[ -z "${AIDEVOPS_AUTO_UPDATE:-}" ]] && [[ "$(get_setting "auto_update" "true")" == "false" ]]; then
+		log_info "Auto-update disabled via settings.json (auto_update: false)"
 		return 0
 	fi
 
@@ -968,6 +982,12 @@ cmd_check() {
 #######################################
 cmd_enable() {
 	ensure_dirs
+
+	# Warn if settings.json disables auto-update (scheduler will install but checks will no-op)
+	if [[ "$(get_setting "auto_update" "true")" == "false" ]]; then
+		print_warning "settings.json has auto_update: false — scheduler will install but checks will be skipped"
+		print_info "To enable: set auto_update to true in ~/.config/aidevops/settings.json"
+	fi
 
 	local interval="${AIDEVOPS_UPDATE_INTERVAL:-$DEFAULT_INTERVAL}"
 	local script_path="$HOME/.aidevops/agents/scripts/auto-update-helper.sh"
@@ -1264,10 +1284,18 @@ cmd_status() {
 		fi
 	fi
 
-	# Check env var overrides
+	# Check settings.json overrides
+	local _settings_auto_update
+	_settings_auto_update="$(get_setting "auto_update" "true")"
+	if [[ "$_settings_auto_update" == "false" ]]; then
+		echo ""
+		echo -e "  ${YELLOW}Note: settings.json has auto_update: false (checks will be skipped)${NC}"
+	fi
+
+	# Check env var overrides (env vars take priority over settings.json)
 	if [[ "${AIDEVOPS_AUTO_UPDATE:-}" == "false" ]]; then
 		echo ""
-		echo -e "  ${YELLOW}Note: AIDEVOPS_AUTO_UPDATE=false is set (overrides scheduler)${NC}"
+		echo -e "  ${YELLOW}Note: AIDEVOPS_AUTO_UPDATE=false is set (overrides scheduler and settings.json)${NC}"
 	fi
 	if [[ "${AIDEVOPS_SKILL_AUTO_UPDATE:-}" == "false" ]]; then
 		echo ""
@@ -1338,8 +1366,21 @@ COMMANDS:
     logs --follow       Follow log output in real-time
     help                Show this help
 
+CONFIGURATION FILE:
+    ~/.config/aidevops/settings.json     Persistent user preferences (optional)
+
+    Supported keys (all default to true):
+      "auto_update": false               Disable auto-update checks
+      "supervisor_pulse": false           Disable supervisor pulse scheduler
+      "repo_sync": false                  Disable daily repo sync
+
+    Example:
+      echo '{"auto_update": false}' > ~/.config/aidevops/settings.json
+
+    Priority: environment variable > settings.json > default (true)
+
 ENVIRONMENT:
-    AIDEVOPS_AUTO_UPDATE=false           Disable auto-update (overrides scheduler)
+    AIDEVOPS_AUTO_UPDATE=false           Disable auto-update (overrides settings.json)
     AIDEVOPS_UPDATE_INTERVAL=10          Minutes between checks (default: 10)
     AIDEVOPS_SKILL_AUTO_UPDATE=false     Disable daily skill freshness check
     AIDEVOPS_SKILL_FRESHNESS_HOURS=24    Hours between skill checks (default: 24)

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1283,6 +1283,68 @@ get_provider_from_model() {
 	return 0
 }
 
+# =============================================================================
+# User Settings Reader (~/.config/aidevops/settings.json)
+# =============================================================================
+# Provides a single function to read user preferences from settings.json.
+# Settings file is optional — all keys have sensible defaults.
+# Environment variables always override settings.json values.
+#
+# Supported keys (all optional, defaults shown):
+#   auto_update: true          - Enable/disable the auto-update launchd/cron job
+#   supervisor_pulse: true     - Enable/disable the supervisor pulse scheduler
+#   repo_sync: true            - Enable/disable the daily repo sync job
+#   update_interval: 10        - Minutes between auto-update checks
+#
+# Usage:
+#   value=$(get_setting "auto_update" "true")
+#   if [[ "$(get_setting "auto_update" "true")" == "false" ]]; then ...
+#
+# The settings file is NOT created automatically. Users create it manually
+# or via `aidevops config set <key> <value>` (future CLI command).
+
+readonly AIDEVOPS_SETTINGS_FILE="${HOME}/.config/aidevops/settings.json"
+
+# Read a value from ~/.config/aidevops/settings.json.
+# Falls back to the provided default if the file doesn't exist,
+# the key is missing, or jq is not available.
+# Arguments:
+#   $1 - JSON key name (required, top-level only)
+#   $2 - default value if key is missing (required)
+# Output: the value on stdout (string — caller interprets type)
+# Returns: 0 always (missing file/key is not an error)
+get_setting() {
+	local key="$1"
+	local default_value="$2"
+
+	# No settings file — return default
+	if [[ ! -f "$AIDEVOPS_SETTINGS_FILE" ]]; then
+		echo "$default_value"
+		return 0
+	fi
+
+	# No jq — return default
+	if ! command -v jq &>/dev/null; then
+		echo "$default_value"
+		return 0
+	fi
+
+	# Use has() to distinguish "key missing" from "key is false/null".
+	# jq's // (alternative operator) treats false and null as empty,
+	# which would make {"auto_update": false} indistinguishable from {}.
+	local value
+	value=$(jq -r --arg k "$key" \
+		'if has($k) then .[$k] | tostring else "___MISSING___" end' \
+		"$AIDEVOPS_SETTINGS_FILE" 2>/dev/null) || value="___MISSING___"
+
+	if [[ "$value" == "___MISSING___" || "$value" == "null" ]]; then
+		echo "$default_value"
+	else
+		echo "$value"
+	fi
+	return 0
+}
+
 # This ensures all constants are available when this file is sourced
 export CONTENT_TYPE_JSON CONTENT_TYPE_FORM USER_AGENT
 export HTTP_OK HTTP_CREATED HTTP_BAD_REQUEST HTTP_UNAUTHORIZED HTTP_FORBIDDEN HTTP_NOT_FOUND HTTP_INTERNAL_ERROR

--- a/setup.sh
+++ b/setup.sh
@@ -651,8 +651,18 @@ main() {
 
 	# Enable auto-update if not already enabled
 	# Check both launchd (macOS) and cron (Linux) for existing installation
+	# Priority: env var AIDEVOPS_AUTO_UPDATE > settings.json auto_update > default true
 	local auto_update_script="$HOME/.aidevops/agents/scripts/auto-update-helper.sh"
-	if [[ -x "$auto_update_script" ]] && [[ "${AIDEVOPS_AUTO_UPDATE:-true}" != "false" ]]; then
+	local _auto_update_setting="${AIDEVOPS_AUTO_UPDATE:-}"
+	if [[ -z "$_auto_update_setting" ]]; then
+		# No env var — check settings.json (requires jq; defaults to "true")
+		if [[ -f "$HOME/.config/aidevops/settings.json" ]] && command -v jq &>/dev/null; then
+			_auto_update_setting=$(jq -r 'if has("auto_update") then .auto_update | tostring else "true" end' "$HOME/.config/aidevops/settings.json" 2>/dev/null) || _auto_update_setting="true"
+		else
+			_auto_update_setting="true"
+		fi
+	fi
+	if [[ -x "$auto_update_script" ]] && [[ "$_auto_update_setting" != "false" ]]; then
 		local _auto_update_installed=false
 		if _launchd_has_agent "com.aidevops.aidevops-auto-update"; then
 			_auto_update_installed=true
@@ -700,7 +710,16 @@ main() {
 	# macOS: launchd plist invoking wrapper | Linux: cron entry invoking wrapper
 	# The plist is ALWAYS regenerated on setup.sh to pick up config changes (env vars,
 	# thresholds). Only the first-install prompt is gated on _pulse_installed.
-	if [[ "${AIDEVOPS_SUPERVISOR_PULSE:-true}" != "false" ]]; then
+	# Priority: env var AIDEVOPS_SUPERVISOR_PULSE > settings.json supervisor_pulse > default true
+	local _pulse_setting="${AIDEVOPS_SUPERVISOR_PULSE:-}"
+	if [[ -z "$_pulse_setting" ]]; then
+		if [[ -f "$HOME/.config/aidevops/settings.json" ]] && command -v jq &>/dev/null; then
+			_pulse_setting=$(jq -r 'if has("supervisor_pulse") then .supervisor_pulse | tostring else "true" end' "$HOME/.config/aidevops/settings.json" 2>/dev/null) || _pulse_setting="true"
+		else
+			_pulse_setting="true"
+		fi
+	fi
+	if [[ "$_pulse_setting" != "false" ]]; then
 		local wrapper_script="$HOME/.aidevops/agents/scripts/pulse-wrapper.sh"
 		local pulse_label="com.aidevops.aidevops-supervisor-pulse"
 		local _aidevops_dir
@@ -831,8 +850,17 @@ PLIST
 
 	# Enable repo-sync scheduler if not already installed
 	# Keeps local git repos up to date with daily ff-only pulls
+	# Priority: env var AIDEVOPS_REPO_SYNC > settings.json repo_sync > default true
 	local repo_sync_script="$HOME/.aidevops/agents/scripts/repo-sync-helper.sh"
-	if [[ -x "$repo_sync_script" ]] && [[ "${AIDEVOPS_REPO_SYNC:-}" != "false" ]]; then
+	local _repo_sync_setting="${AIDEVOPS_REPO_SYNC:-}"
+	if [[ -z "$_repo_sync_setting" ]]; then
+		if [[ -f "$HOME/.config/aidevops/settings.json" ]] && command -v jq &>/dev/null; then
+			_repo_sync_setting=$(jq -r 'if has("repo_sync") then .repo_sync | tostring else "true" end' "$HOME/.config/aidevops/settings.json" 2>/dev/null) || _repo_sync_setting="true"
+		else
+			_repo_sync_setting="true"
+		fi
+	fi
+	if [[ -x "$repo_sync_script" ]] && [[ "$_repo_sync_setting" != "false" ]]; then
 		local _repo_sync_installed=false
 		if _launchd_has_agent "com.aidevops.aidevops-repo-sync"; then
 			_repo_sync_installed=true


### PR DESCRIPTION
## Summary

- Adds `~/.config/aidevops/settings.json` as a persistent config file for user preferences
- `setup.sh` reads `auto_update`, `supervisor_pulse`, and `repo_sync` keys before scheduling launchd/cron jobs
- If `auto_update: false`, the auto-update scheduler is not installed and checks are skipped
- Priority chain: environment variable > settings.json > default (`true`)

## Changes

- **shared-constants.sh**: New `get_setting()` utility function. Handles JSON boolean `false` correctly (jq's `//` operator treats `false` as empty — uses `has()` + `tostring` instead)
- **setup.sh**: All three scheduler sections (auto-update, supervisor pulse, repo sync) now check settings.json before the env var fallback
- **auto-update-helper.sh**: `cmd_check` respects settings.json, `cmd_enable` warns if disabled, `cmd_status` shows settings.json state, help text documents the config file
- **services.md**: New "User Settings" section with supported keys table, updated Auto-Update and Repo Sync sections

## Testing

- ShellCheck: zero violations on all modified files
- Markdown lint: zero violations on services.md
- Functional tests: `get_setting()` correctly handles boolean `false`, string `"false"`, missing keys, and missing file
- jq pattern in setup.sh tested with all value types (boolean false, string false, missing key, boolean true)

Closes #2722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent configuration file support at ~/.config/aidevops/settings.json for managing auto-update, supervisor pulse, and repo-sync features.
  * Configuration supports three settable keys with clear precedence: environment variables override settings file, which overrides built-in defaults.
  * Users can now persistently disable individual features via settings file as an alternative to temporary environment variable overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->