### PR TITLE
t2723: standalone config file for aidevops settings

### DIFF
--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -25,6 +25,8 @@ subagents:
 
 - **Command**: `/onboarding` or `@onboarding`
 - **Script**: `~/.aidevops/agents/scripts/onboarding-helper.sh`
+- **Settings**: `~/.config/aidevops/settings.json` (canonical config file)
+- **Settings helper**: `~/.aidevops/agents/scripts/settings-helper.sh`
 - **Purpose**: Interactive wizard to discover, configure, and verify aidevops integrations
 
 **CRITICAL - OpenCode Setup**: NEVER manually write `opencode.json`. Always run:
@@ -33,12 +35,15 @@ subagents:
 ~/.aidevops/agents/scripts/generate-opencode-agents.sh
 ```
 
+**Settings file**: All onboarding choices are persisted to `~/.config/aidevops/settings.json`. This file is the canonical config — users can edit it directly or via `/onboarding`. Created with documented defaults on first run.
+
 **Workflow**:
 1. Welcome & explain aidevops capabilities
 2. Ask about user's work/interests for personalized suggestions
-3. Show current setup status (configured vs needs setup)
-4. Guide through setting up selected services
-5. Verify configurations work
+3. **Save choices to settings.json** (work type, concepts, orchestration preference)
+4. Show current setup status (configured vs needs setup)
+5. Guide through setting up selected services
+6. Verify configurations work
 
 <!-- AI-CONTEXT-END -->
 
@@ -205,7 +210,19 @@ For example:
 5. Something else (describe it)
 ```
 
-Based on their answer, highlight relevant services.
+Based on their answer, highlight relevant services and **save the choice**:
+
+```bash
+# Save work type (maps 1=web, 2=devops, 3=seo, 4=wordpress)
+~/.aidevops/agents/scripts/onboarding-helper.sh save-work-type devops
+```
+
+Also save the concept familiarity from Step 2:
+
+```bash
+# Save familiar concepts (from Step 2 responses)
+~/.aidevops/agents/scripts/onboarding-helper.sh save-concepts 'git,terminal,api-keys'
+```
 
 ### Step 4: Show Current Status
 
@@ -1178,12 +1195,18 @@ You stay in control — the supervisor only dispatches tasks you've tagged.
 If **yes**:
 
 ```bash
-# Enable the supervisor pulse (every 2 min)
+# Save preference and enable the supervisor pulse (every 2 min)
+~/.aidevops/agents/scripts/onboarding-helper.sh save-orchestration true
 # See scripts/commands/runners.md for macOS (launchd) and Linux (cron) setup
 # The pulse dispatches workers, merges PRs, and manages cross-repo work
 ```
 
 If **no**:
+
+```bash
+# Save preference
+~/.aidevops/agents/scripts/onboarding-helper.sh save-orchestration false
+```
 
 ```text
 No problem. You can enable it anytime — see scripts/commands/runners.md
@@ -1192,6 +1215,38 @@ for setup instructions (launchd on macOS, cron on Linux).
 The strategic review, session miner, and circuit breaker all run as steps
 within the pulse — enabling the pulse enables everything.
 ```
+
+## Settings File
+
+All onboarding choices are saved to `~/.config/aidevops/settings.json`. This is the canonical config file for aidevops — users can edit it directly with any text editor.
+
+**View current settings:**
+
+```bash
+~/.aidevops/agents/scripts/settings-helper.sh list
+```
+
+**Edit a setting:**
+
+```bash
+~/.aidevops/agents/scripts/settings-helper.sh set orchestration.enabled true
+~/.aidevops/agents/scripts/settings-helper.sh set user.work_type devops
+~/.aidevops/agents/scripts/settings-helper.sh set repo_sync.directories '["~/Git","~/Projects"]'
+```
+
+**Export as clean JSON (no docs):**
+
+```bash
+~/.aidevops/agents/scripts/settings-helper.sh json
+```
+
+**Reset to defaults:**
+
+```bash
+~/.aidevops/agents/scripts/settings-helper.sh reset
+```
+
+Settings sections: `user` (profile), `orchestration` (autonomous workers), `repo_sync` (daily pulls), `quality` (linting), `model_routing` (AI providers), `notifications`, `ui` (display). Each setting has inline documentation — run `settings-helper.sh list` to see descriptions.
 
 ## Next Steps After Setup
 

--- a/.agents/scripts/onboarding-helper.sh
+++ b/.agents/scripts/onboarding-helper.sh
@@ -26,6 +26,10 @@ set -euo pipefail
 
 readonly DIM='\033[2m'
 
+# Settings file (canonical config — see settings-helper.sh)
+readonly SETTINGS_FILE="$HOME/.config/aidevops/settings.json"
+readonly SETTINGS_HELPER="${SCRIPT_DIR}/settings-helper.sh"
+
 # Credential file locations
 readonly CREDENTIALS_FILE="$HOME/.config/aidevops/credentials.sh"
 readonly CODERABBIT_KEY_FILE="$HOME/.config/coderabbit/api_key"
@@ -35,6 +39,35 @@ if [[ -f "$CREDENTIALS_FILE" ]]; then
 	# shellcheck source=/dev/null
 	source "$CREDENTIALS_FILE"
 fi
+
+# Ensure settings.json exists with defaults
+_ensure_settings() {
+	if [[ -x "$SETTINGS_HELPER" ]]; then
+		bash "$SETTINGS_HELPER" init >/dev/null 2>&1
+	fi
+	return 0
+}
+
+# Read a setting from settings.json
+_get_setting() {
+	local key="$1"
+	if [[ -x "$SETTINGS_HELPER" ]]; then
+		bash "$SETTINGS_HELPER" get "$key" 2>/dev/null
+	else
+		echo "null"
+	fi
+	return 0
+}
+
+# Write a setting to settings.json
+_set_setting() {
+	local key="$1"
+	local value="$2"
+	if [[ -x "$SETTINGS_HELPER" ]]; then
+		bash "$SETTINGS_HELPER" set "$key" "$value" >/dev/null 2>&1
+	fi
+	return 0
+}
 
 # Check if an environment variable is set and not a placeholder
 is_configured() {
@@ -558,11 +591,30 @@ configure_dirs() {
 		echo ""
 		echo "Added $added directory/directories."
 		echo "Run 'aidevops repo-sync check' to sync now."
+
+		# Sync directories to settings.json
+		_sync_dirs_to_settings "$config_file"
 	elif [[ ${#current_dirs[@]} -eq 0 ]]; then
 		echo "No directories added. Using default: ~/Git"
 	fi
 
 	echo ""
+	return 0
+}
+
+# Sync git_parent_dirs from repos.json into settings.json
+_sync_dirs_to_settings() {
+	local config_file="$1"
+
+	if [[ ! -f "$config_file" ]] || ! command -v jq &>/dev/null; then
+		return 0
+	fi
+
+	local dirs_json
+	dirs_json=$(jq -c '[.git_parent_dirs[]? // empty]' "$config_file" 2>/dev/null || echo '["~/Git"]')
+
+	_set_setting "repo_sync.directories" "$dirs_json"
+	_set_setting "repo_sync.enabled" "true"
 	return 0
 }
 
@@ -916,6 +968,67 @@ show_guide() {
 	return 0
 }
 
+# Save user's work type to settings.json (called by AI agent during onboarding)
+save_work_type() {
+	local work_type="$1"
+
+	_ensure_settings
+	_set_setting "user.work_type" "$work_type"
+	echo "Saved work type: $work_type"
+	return 0
+}
+
+# Save user's familiar concepts to settings.json (called by AI agent during onboarding)
+save_concepts() {
+	local concepts="$1"
+
+	_ensure_settings
+
+	# Accept comma-separated list or JSON array
+	if [[ "$concepts" == \[* ]]; then
+		_set_setting "user.familiar_concepts" "$concepts"
+	else
+		# Convert comma-separated to JSON array
+		local json_array
+		json_array=$(echo "$concepts" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | jq -R . | jq -s .)
+		_set_setting "user.familiar_concepts" "$json_array"
+	fi
+	echo "Saved familiar concepts"
+	return 0
+}
+
+# Save orchestration preference to settings.json
+save_orchestration() {
+	local enabled="$1"
+
+	_ensure_settings
+	_set_setting "orchestration.enabled" "$enabled"
+	echo "Saved orchestration.enabled: $enabled"
+	return 0
+}
+
+# Show current settings summary
+show_settings() {
+	_ensure_settings
+
+	echo ""
+	echo -e "${BLUE}Current Settings${NC}"
+	echo "================"
+	echo ""
+
+	if [[ -x "$SETTINGS_HELPER" ]]; then
+		bash "$SETTINGS_HELPER" list
+	else
+		echo "Settings helper not found. Settings file: $SETTINGS_FILE"
+		if [[ -f "$SETTINGS_FILE" ]]; then
+			jq '.' "$SETTINGS_FILE" 2>/dev/null || cat "$SETTINGS_FILE"
+		else
+			echo "(not created yet — run /onboarding)"
+		fi
+	fi
+	return 0
+}
+
 # Show help
 show_help() {
 	echo "Onboarding Helper - Interactive setup and service status for aidevops"
@@ -931,6 +1044,10 @@ show_help() {
 	echo "                                  dataforseo, augment, sonarcloud, openclaw,"
 	echo "                                  tailscale, orbstack, orchestration"
 	echo "  configure-dirs      - Interactively add git parent directories for repo-sync"
+	echo "  settings            - Show current settings from settings.json"
+	echo "  save-work-type <t>  - Save work type (web, devops, seo, wordpress)"
+	echo "  save-concepts <c>   - Save familiar concepts (comma-separated or JSON array)"
+	echo "  save-orchestration  - Save orchestration enabled/disabled (true/false)"
 	echo "  json                - Output status as JSON for programmatic use"
 	echo "  help                - Show this help message"
 	echo ""
@@ -939,7 +1056,11 @@ show_help() {
 	echo "  $0 recommend devops"
 	echo "  $0 guide openai"
 	echo "  $0 configure-dirs"
+	echo "  $0 save-work-type devops"
+	echo "  $0 save-concepts 'git,terminal,api-keys'"
+	echo "  $0 settings"
 	echo ""
+	echo "Settings file: $SETTINGS_FILE"
 	echo "Use /onboarding in Claude Code for the full interactive experience."
 	return 0
 }
@@ -1053,11 +1174,22 @@ main() {
 	local command="${1:-status}"
 	local arg="${2:-}"
 
+	# Ensure settings.json exists on any invocation
+	_ensure_settings
+
 	case "$command" in
 	status)
 		show_status
 		;;
 	recommend | recommendations)
+		# If no arg, try to use saved work_type from settings
+		if [[ -z "$arg" ]]; then
+			local saved_type
+			saved_type=$(_get_setting "user.work_type")
+			if [[ "$saved_type" != "null" && -n "$saved_type" ]]; then
+				arg="$saved_type"
+			fi
+		fi
 		show_recommendations "$arg"
 		;;
 	guide | setup)
@@ -1068,6 +1200,30 @@ main() {
 		;;
 	configure-dirs | dirs)
 		configure_dirs
+		;;
+	settings)
+		show_settings
+		;;
+	save-work-type)
+		if [[ -z "$arg" ]]; then
+			print_error "Usage: $0 save-work-type <web|devops|seo|wordpress>"
+			return 1
+		fi
+		save_work_type "$arg"
+		;;
+	save-concepts)
+		if [[ -z "$arg" ]]; then
+			print_error "Usage: $0 save-concepts <comma-separated or JSON array>"
+			return 1
+		fi
+		save_concepts "$arg"
+		;;
+	save-orchestration)
+		if [[ -z "$arg" ]]; then
+			print_error "Usage: $0 save-orchestration <true|false>"
+			return 1
+		fi
+		save_orchestration "$arg"
 		;;
 	help | --help | -h)
 		show_help

--- a/setup.sh
+++ b/setup.sh
@@ -577,6 +577,27 @@ parse_args() {
 	return 0
 }
 
+# Initialize ~/.config/aidevops/settings.json with documented defaults.
+# Idempotent — merges missing keys without overwriting existing values.
+init_settings_json() {
+	local settings_helper="$HOME/.aidevops/agents/scripts/settings-helper.sh"
+	if [[ -x "$settings_helper" ]]; then
+		if bash "$settings_helper" init >/dev/null 2>&1; then
+			print_info "Settings file initialized: ~/.config/aidevops/settings.json"
+		fi
+	else
+		# Fallback: try from repo directory (first run before deployment)
+		local repo_helper
+		repo_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/.agents/scripts/settings-helper.sh"
+		if [[ -x "$repo_helper" ]]; then
+			if bash "$repo_helper" init >/dev/null 2>&1; then
+				print_info "Settings file initialized: ~/.config/aidevops/settings.json"
+			fi
+		fi
+	fi
+	return 0
+}
+
 # Main setup function
 main() {
 	# Bootstrap first (handles curl install)
@@ -631,6 +652,7 @@ main() {
 		deploy_aidevops_agents
 		sync_agent_sources
 		setup_safety_hooks
+		init_settings_json
 
 		# Parallelise independent skill operations (t1356: ~84s serial -> ~18s parallel)
 		# generate_agent_skills (18s), create_skill_symlinks (<1s), and
@@ -698,6 +720,7 @@ main() {
 		confirm_step "Deploy aidevops agents to ~/.aidevops/agents/" && deploy_aidevops_agents
 		confirm_step "Sync agents from private repositories" && sync_agent_sources
 		confirm_step "Install Claude Code safety hooks (block destructive commands)" && setup_safety_hooks
+		confirm_step "Initialize settings.json (canonical config file)" && init_settings_json
 		confirm_step "Setup multi-tenant credential storage" && setup_multi_tenant_credentials
 		confirm_step "Generate agent skills (SKILL.md files)" && generate_agent_skills
 		confirm_step "Create symlinks for imported skills" && create_skill_symlinks


### PR DESCRIPTION
## Summary

- Creates `~/.config/aidevops/settings.json` as the canonical config file for all user-configurable settings
- All settings configurable via `/onboarding` are now readable/writable in this file
- `/onboarding` reads from and writes to this file (not a separate store)
- File is created with documented defaults on first run via `setup.sh`
- Each setting has inline documentation visible via `settings-helper.sh list`

## Changes

### New: `.agents/scripts/settings-helper.sh`
CLI for managing settings.json with commands: `init`, `get`, `set`, `list`, `validate`, `reset`, `json`, `path`. Supports dot-notation keys (e.g., `orchestration.enabled`), type inference (booleans, numbers, strings, arrays), and deep-merge on init (preserves existing values while adding new defaults).

### Modified: `.agents/scripts/onboarding-helper.sh`
- New commands: `save-work-type`, `save-concepts`, `save-orchestration`, `settings`
- `recommend` auto-reads saved `user.work_type` from settings when no argument given
- `configure-dirs` syncs directories to `settings.json` `repo_sync` section
- All invocations ensure settings.json exists via `_ensure_settings()`

### Modified: `.agents/aidevops/onboarding.md`
- Documents settings file location and helper commands
- Adds save steps to the onboarding workflow (Steps 3, orchestration)
- New "Settings File" section with usage examples

### Modified: `setup.sh`
- `init_settings_json()` function creates settings with defaults on first run
- Called in both interactive and non-interactive setup paths

## Settings Schema

Sections: `user`, `orchestration`, `repo_sync`, `quality`, `model_routing`, `notifications`, `ui`

Each setting has a companion `*_doc` field with human-readable description, stripped from `json` output.

## Testing

All commands verified:
- `init` (idempotent, merges missing keys)
- `get`/`set` roundtrip for booleans, numbers, strings, null, arrays
- `validate` checks structure and field types
- `list` shows all settings with colored values and descriptions
- `json` outputs clean JSON without doc fields
- `reset` backs up before overwriting
- Onboarding `save-*` commands persist correctly
- ShellCheck clean on all modified files

Closes #2723

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced centralized settings file for persistent configuration management
  * Added settings management interface to view, edit, export, and reset preferences
  * Enhanced onboarding workflow to save user choices (work type, concepts, orchestration enablement)
  * Introduced repo synchronization and autonomous orchestration configuration sections
  * New commands to persist user selections throughout the setup process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->