### PR TITLE
t2732: Add missing 'name' field to skill frontmatter

### DIFF
--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -644,7 +644,14 @@ check_skill_frontmatter() {
 	fi
 
 	local skill_count
-	skill_count=$(jq '.skills | length' "$skill_sources" 2>/dev/null || echo "0")
+	if ! skill_count=$(jq -er '
+		if (.skills | type) == "array" then (.skills | length)
+		else error(".skills must be an array")
+		end
+	' "$skill_sources" 2>/dev/null); then
+		print_error "Invalid $skill_sources (cannot parse .skills array)"
+		return 1
+	fi
 
 	if [[ "$skill_count" -eq 0 ]]; then
 		print_info "No imported skills to validate"
@@ -654,6 +661,12 @@ check_skill_frontmatter() {
 	local errors=0
 	local checked=0
 
+	local skill_entries
+	if ! skill_entries=$(jq -er '.skills[] | "\(.name)|\(.local_path)"' "$skill_sources" 2>/dev/null); then
+		print_error "Failed to read skill entries from $skill_sources"
+		return 1
+	fi
+
 	while IFS='|' read -r name local_path; do
 		if [[ ! -f "$local_path" ]]; then
 			print_warning "Skill file missing: $local_path (skill: $name)"
@@ -661,12 +674,14 @@ check_skill_frontmatter() {
 			continue
 		fi
 
-		# Extract name from YAML frontmatter
+		# Extract name from YAML frontmatter (initial block only)
 		local fm_name
 		fm_name=$(awk '
-			/^---$/ { in_fm = !in_fm; next }
-			in_fm && /^name:/ {
-				sub(/^name: */, "")
+			NR == 1 && /^---$/ { in_fm = 1; next }
+			in_fm && /^---$/ { exit }
+			in_fm && /^[[:space:]]*name:[[:space:]]*/ {
+				sub(/^[[:space:]]*name:[[:space:]]*/, "")
+				sub(/[[:space:]]+#.*$/, "")
 				gsub(/^["'"'"']|["'"'"']$/, "")
 				print
 				exit
@@ -682,7 +697,7 @@ check_skill_frontmatter() {
 		fi
 
 		((checked++)) || true
-	done < <(jq -r '.skills[] | "\(.name)|\(.local_path)"' "$skill_sources" 2>/dev/null)
+	done <<<"$skill_entries"
 
 	if [[ $errors -eq 0 ]]; then
 		print_success "Skill frontmatter: $checked skills validated, all have correct 'name' field"

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -11,6 +11,7 @@
 #   - Secretlint for exposed secrets
 #   - Pattern validation (return statements, positional parameters)
 #   - Markdown formatting
+#   - Skill frontmatter validation (name field matches skill-sources.json)
 #
 # For remote auditing (CodeRabbit, Codacy, SonarCloud), use:
 #   /code-audit-remote or code-audit-helper.sh
@@ -621,6 +622,79 @@ check_remote_cli_status() {
 }
 
 # =============================================================================
+# Skill Frontmatter Validation
+# =============================================================================
+# Validates that all imported skills registered in skill-sources.json have a
+# 'name' field in their YAML frontmatter matching the registered skill name.
+# This prevents opencode startup errors from missing name fields.
+
+check_skill_frontmatter() {
+	echo -e "${BLUE}Checking Skill Frontmatter...${NC}"
+
+	local skill_sources=".agents/configs/skill-sources.json"
+
+	if [[ ! -f "$skill_sources" ]]; then
+		print_info "No skill-sources.json found (skipping)"
+		return 0
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		print_info "jq not available (skipping skill frontmatter check)"
+		return 0
+	fi
+
+	local skill_count
+	skill_count=$(jq '.skills | length' "$skill_sources" 2>/dev/null || echo "0")
+
+	if [[ "$skill_count" -eq 0 ]]; then
+		print_info "No imported skills to validate"
+		return 0
+	fi
+
+	local errors=0
+	local checked=0
+
+	while IFS='|' read -r name local_path; do
+		if [[ ! -f "$local_path" ]]; then
+			print_warning "Skill file missing: $local_path (skill: $name)"
+			((errors++)) || true
+			continue
+		fi
+
+		# Extract name from YAML frontmatter
+		local fm_name
+		fm_name=$(awk '
+			/^---$/ { in_fm = !in_fm; next }
+			in_fm && /^name:/ {
+				sub(/^name: */, "")
+				gsub(/^["'"'"']|["'"'"']$/, "")
+				print
+				exit
+			}
+		' "$local_path")
+
+		if [[ -z "$fm_name" ]]; then
+			print_error "Missing 'name' field in frontmatter: $local_path (expected: $name)"
+			((errors++)) || true
+		elif [[ "$fm_name" != "$name" ]]; then
+			print_error "Name mismatch in $local_path: got '$fm_name', expected '$name'"
+			((errors++)) || true
+		fi
+
+		((checked++)) || true
+	done < <(jq -r '.skills[] | "\(.name)|\(.local_path)"' "$skill_sources" 2>/dev/null)
+
+	if [[ $errors -eq 0 ]]; then
+		print_success "Skill frontmatter: $checked skills validated, all have correct 'name' field"
+	else
+		print_error "Skill frontmatter: $errors error(s) in $checked skills"
+		return 1
+	fi
+
+	return 0
+}
+
+# =============================================================================
 # Bundle-Aware Gate Filtering (t1364.6)
 # =============================================================================
 # Resolves the project bundle and checks whether a gate should be skipped.
@@ -728,6 +802,11 @@ main() {
 
 	if ! should_skip_gate "toon-syntax"; then
 		check_toon_syntax || exit_code=1
+		echo ""
+	fi
+
+	if ! should_skip_gate "skill-frontmatter"; then
+		check_skill_frontmatter || exit_code=1
 		echo ""
 	fi
 

--- a/.agents/seo/seo-audit-skill.md
+++ b/.agents/seo/seo-audit-skill.md
@@ -1,4 +1,5 @@
 ---
+name: seo-audit
 description: "When the user wants to audit, review, or diagnose SEO issues on their site. Also use when the user mentions \"SEO audit,\" \"technical SEO,\" \"why am I not ranking,\" \"SEO issues,\" \"on-page SEO,\" \"meta tags review,\" or \"SEO health check.\" For building pages at scale to target keywords, see programmatic-seo. For adding structured data, see schema-markup."
 mode: subagent
 imported_from: external

--- a/.agents/services/hosting/cloudflare-platform.md
+++ b/.agents/services/hosting/cloudflare-platform.md
@@ -1,4 +1,5 @@
 ---
+name: cloudflare-platform
 description: "Cloudflare platform development guidance — patterns, gotchas, decision trees, SDK usage for Workers, Pages, KV, D1, R2, AI, Durable Objects, and 60+ products. Use when building or developing ON the Cloudflare platform. For managing Cloudflare resources (DNS, WAF, DDoS, R2 buckets, Workers deployments), use the Cloudflare Code Mode MCP server instead."
 mode: subagent
 imported_from: external

--- a/.agents/services/hosting/proxmox-full-skill.md
+++ b/.agents/services/hosting/proxmox-full-skill.md
@@ -1,4 +1,5 @@
 ---
+name: proxmox-full
 description: "Complete Proxmox VE hypervisor management via REST API - VMs, containers, snapshots, backups, storage"
 mode: subagent
 imported_from: clawdhub

--- a/.agents/tools/animation/animejs.md
+++ b/.agents/tools/animation/animejs.md
@@ -1,4 +1,5 @@
 ---
+name: animejs
 description: "Anime.js - Lightweight JavaScript animation library for CSS, SVG, DOM attributes and JS objects"
 mode: subagent
 imported_from: context7

--- a/.agents/tools/deployment/cloudron-app-packaging-skill.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill.md
@@ -1,4 +1,5 @@
 ---
+name: cloudron-app-packaging
 description: "Official Cloudron app packaging skill - Dockerfile patterns, manifest, addons, build methods"
 mode: subagent
 imported_from: external

--- a/.agents/tools/deployment/cloudron-app-publishing-skill.md
+++ b/.agents/tools/deployment/cloudron-app-publishing-skill.md
@@ -1,4 +1,5 @@
 ---
+name: cloudron-app-publishing
 description: "Distribute Cloudron apps via CloudronVersions.json version catalogs"
 mode: subagent
 imported_from: external

--- a/.agents/tools/deployment/cloudron-server-ops-skill.md
+++ b/.agents/tools/deployment/cloudron-server-ops-skill.md
@@ -1,4 +1,5 @@
 ---
+name: cloudron-server-ops
 description: "Manage apps on a Cloudron server using the cloudron CLI"
 mode: subagent
 imported_from: external

--- a/.agents/tools/productivity/caldav-calendar-skill.md
+++ b/.agents/tools/productivity/caldav-calendar-skill.md
@@ -1,4 +1,5 @@
 ---
+name: caldav-calendar
 description: "Sync and query CalDAV calendars (iCloud, Google, Fastmail, Nextcloud, etc.) using vdirsyncer + khal"
 mode: subagent
 imported_from: clawdhub

--- a/.agents/tools/video/heygen-skill.md
+++ b/.agents/tools/video/heygen-skill.md
@@ -1,4 +1,5 @@
 ---
+name: heygen
 description: "Best practices for HeyGen - AI avatar video creation API"
 mode: subagent
 imported_from: https://github.com/heygen-com/skills

--- a/.agents/tools/video/remotion.md
+++ b/.agents/tools/video/remotion.md
@@ -1,4 +1,5 @@
 ---
+name: remotion
 description: "Remotion - Programmatic video creation with React. Animations, compositions, media handling, captions, and rendering."
 mode: subagent
 imported_from: external

--- a/.agents/tools/video/video-prompt-design.md
+++ b/.agents/tools/video/video-prompt-design.md
@@ -1,4 +1,5 @@
 ---
+name: video-prompt-design
 description: "Video prompt design - AI video generation prompt engineering for Veo 3 and similar models using the 7-component meta prompt framework"
 mode: subagent
 upstream_url: https://github.com/snubroot/Veo-3-Meta-Framework


### PR DESCRIPTION
## Summary

- Added the required `name` field to YAML frontmatter in all 11 imported skill source files, fixing opencode startup errors when loading skills from `~/.config/opencode/skills/`
- Added a `check_skill_frontmatter` lint gate to `linters-local.sh` that validates all registered skills have a correct `name` field, preventing regression

## Details

Skills deployed to `~/.config/opencode/skills/<name>/SKILL.md` are symlinks to source `.md` files in the repo (via `create_skill_symlinks()` in `setup-modules/plugins.sh`). The opencode skill loader requires a `name` field in the YAML frontmatter matching the directory name. All 11 skills were missing this field.

### Files fixed

| Skill name | Source file |
|---|---|
| remotion | `.agents/tools/video/remotion.md` |
| video-prompt-design | `.agents/tools/video/video-prompt-design.md` |
| caldav-calendar | `.agents/tools/productivity/caldav-calendar-skill.md` |
| cloudron-server-ops | `.agents/tools/deployment/cloudron-server-ops-skill.md` |
| cloudron-app-publishing | `.agents/tools/deployment/cloudron-app-publishing-skill.md` |
| cloudflare-platform | `.agents/services/hosting/cloudflare-platform.md` |
| proxmox-full | `.agents/services/hosting/proxmox-full-skill.md` |
| cloudron-app-packaging | `.agents/tools/deployment/cloudron-app-packaging-skill.md` |
| heygen | `.agents/tools/video/heygen-skill.md` |
| animejs | `.agents/tools/animation/animejs.md` |
| seo-audit | `.agents/seo/seo-audit-skill.md` |

### Regression prevention

Added `check_skill_frontmatter` to `linters-local.sh` (gated as `skill-frontmatter`). It reads `skill-sources.json`, extracts the `name` field from each skill's frontmatter, and validates it matches the registered name. Runs as part of the standard lint suite.

Closes #2732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a frontmatter validation check to enforce consistent skill metadata.
  * Standardized and added metadata (name, description, mode, imported_from, tools) to multiple skill and tool documents to improve organization and discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->