### PR TITLE
fix: prevent duplicate issue creation from concurrent push

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -142,17 +142,28 @@ sleep 2
 
 ### Cross-repo TODO sync
 
-For each repo with a `TODO.md`, run the issue sync helper to create GitHub issues for unsynced tasks.
+Sync GitHub issue refs and close completed issues. **Issue creation (push) is handled
+exclusively by CI** (GitHub Actions `issue-sync.yml` on TODO.md push to main) to prevent
+duplicate issues from concurrent local + CI execution. Local sessions use `pull` (sync
+refs back to TODO.md) and `close` (close issues for completed tasks).
 
 **Note:** Helper scripts use `#!/usr/bin/env bash` shebangs which fail in the MCP shell if PATH is incomplete. Step 0's `export PATH=...` fixes this for the session. If you still see `env: bash: No such file or directory`, call scripts with an explicit `/bin/bash` prefix as shown below:
 
 ```bash
-/bin/bash ~/.aidevops/agents/scripts/issue-sync-helper.sh push --repo "$slug" 2>&1 || true
+# Pull: sync issue refs from GitHub to TODO.md (safe, idempotent)
+/bin/bash ~/.aidevops/agents/scripts/issue-sync-helper.sh pull --repo "$slug" 2>&1 || true
+# Close: close issues for completed tasks (safe, idempotent)
+/bin/bash ~/.aidevops/agents/scripts/issue-sync-helper.sh close --repo "$slug" 2>&1 || true
 # Commit any ref changes
 git -C "$path" diff --quiet TODO.md 2>/dev/null || {
   git -C "$path" add TODO.md && git -C "$path" commit -m "chore: sync GitHub issue refs to TODO.md [skip ci]" && git -C "$path" push
 } 2>/dev/null || true
 ```
+
+**Why not push locally?** When TODO.md merges to main, CI runs `push` to create issues.
+If the local pulse also runs `push`, both see "no existing issue" and both create one —
+producing duplicates. Single-task issue creation still works via `claim-task-id.sh` (which
+creates issues at claim time, before TODO.md hits main).
 
 ### Orphaned PR scanner (t216)
 
@@ -285,7 +296,7 @@ In Full mode, mission features are regular TODO entries tagged with `mission:mNN
 - They appear in `gh issue list` like any other task
 - They follow the standard label lifecycle (`available` → `queued` → `in-progress` → `done`)
 - The `mission:mNNN` tag lets the pulse correlate features back to their mission
-- Issue sync works normally — `issue-sync-helper.sh push` creates GitHub issues for them
+- Issue sync works normally — CI creates GitHub issues when TODO.md is pushed to main
 
 In POC mode, features are tracked only in the mission state file (no TODO entries, no GitHub issues). The pulse dispatches them directly from the state file.
 

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -38,6 +38,7 @@ source "${SCRIPT_DIR}/issue-sync-lib.sh"
 VERBOSE="${VERBOSE:-false}"
 DRY_RUN="${DRY_RUN:-false}"
 FORCE_CLOSE="${FORCE_CLOSE:-false}"
+FORCE_PUSH="${FORCE_PUSH:-false}"
 REPO_SLUG=""
 
 log_verbose() {
@@ -241,6 +242,24 @@ cmd_push() {
 	local target_task="${1:-}"
 	_init_cmd || return 1
 	local repo="$_CMD_REPO" todo_file="$_CMD_TODO" project_root="$_CMD_ROOT"
+
+	# Guard: issue creation from TODO.md should only happen in ONE place to
+	# prevent duplicates. CI (GitHub Actions issue-sync.yml) is the single
+	# authority for bulk push. Local sessions use claim-task-id.sh (which
+	# creates issues at claim time) or target a single task explicitly.
+	#
+	# The race condition: when TODO.md merges to main, both CI and local
+	# pulse/supervisor run "push" simultaneously. Both see "no existing issue"
+	# and both create one — producing duplicates (observed: t1365, t1366,
+	# t1367, t1370.x, t1375.x all had duplicate issues).
+	#
+	# Fix: bulk push (no target_task) is CI-only unless --force is passed.
+	# Single-task push (claim-task-id.sh path) is always allowed.
+	if [[ -z "$target_task" && "${GITHUB_ACTIONS:-}" != "true" && "$FORCE_PUSH" != "true" ]]; then
+		print_info "Bulk push skipped — CI is the single authority for issue creation from TODO.md"
+		print_info "Use 'issue-sync-helper.sh push <task_id>' for single tasks, or --force-push to override"
+		return 0
+	fi
 
 	local tasks=()
 	if [[ -n "$target_task" ]]; then
@@ -653,6 +672,10 @@ Issue Sync Helper — stateless TODO.md <-> GitHub Issues sync via gh CLI.
 Usage: issue-sync-helper.sh [command] [options]
 Commands: push [tNNN] | enrich [tNNN] | pull | close [tNNN] | reconcile | status | help
 Options: --repo SLUG | --dry-run | --verbose | --force (skip evidence on close)
+         --force-push (allow bulk push outside CI — use with caution, risk of duplicates)
+
+Note: Bulk push (no task ID) is CI-only by default to prevent duplicate issues.
+      Use 'push <task_id>' for single tasks, or --force-push to override.
 EOF
 }
 
@@ -674,6 +697,10 @@ main() {
 			;;
 		--force)
 			FORCE_CLOSE="true"
+			shift
+			;;
+		--force-push)
+			FORCE_PUSH="true"
 			shift
 			;;
 		help | --help | -h)

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -253,7 +253,7 @@ cmd_push() {
 	# and both create one — producing duplicates (observed: t1365, t1366,
 	# t1367, t1370.x, t1375.x all had duplicate issues).
 	#
-	# Fix: bulk push (no target_task) is CI-only unless --force is passed.
+	# Fix: bulk push (no target_task) is CI-only unless --force-push is passed.
 	# Single-task push (claim-task-id.sh path) is always allowed.
 	if [[ -z "$target_task" && "${GITHUB_ACTIONS:-}" != "true" && "$FORCE_PUSH" != "true" ]]; then
 		print_info "Bulk push skipped — CI is the single authority for issue creation from TODO.md"


### PR DESCRIPTION
## Summary

- Makes CI (GitHub Actions `issue-sync.yml`) the single authority for bulk issue creation from TODO.md
- Local pulse/supervisor sessions now use `pull` + `close` only (safe, idempotent)
- Single-task push (via `claim-task-id.sh`) is unaffected — it creates issues at claim time before TODO.md hits main

## Problem

When TODO.md merges to main, both GitHub Actions and local pulse/supervisor sessions run `issue-sync-helper.sh push` concurrently. Both see "no existing issue" for new tasks and both create one — producing duplicate issues.

**Evidence:** 13 duplicate issue pairs observed across t1365, t1366, t1367, t1370.x, t1375.x. In every case, `app/github-actions` created the issue 3-20 seconds before the local user's session created an identical one.

## Changes

### `issue-sync-helper.sh`
- Bulk push (no target task ID) now requires `GITHUB_ACTIONS=true` env var
- Single-task push is always allowed (used by `claim-task-id.sh`)
- Added `--force-push` flag for manual override when needed

### `pulse.md`
- Replaced `push` call with `pull` + `close` in cross-repo TODO sync
- Added explanation of why push is CI-only

## How it was tested

- ShellCheck passes (only pre-existing SC1091 info-level notes)
- Verified `GITHUB_ACTIONS` env var is set by GitHub Actions runners
- Verified `claim-task-id.sh` uses single-task push (unaffected by guard)
- Verified CI workflow sets no special flags (uses bare `push` command, which works because `GITHUB_ACTIONS=true` in CI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added safeguards to prevent duplicate GitHub issue creation when syncing local TODO changes.

* **Documentation**
  * Clarified CI-driven issue creation workflow with updated guidance on local pull and close operations.
  * Expanded orphaned pull request detection procedures with explicit detection steps and handling commands.

* **Chores**
  * Introduced `--force-push` flag for bulk push operations to provide explicit control over issue sync behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->