### PR TITLE
t1382: Enforce wait-for-review-bots gate before PR merge

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -272,6 +272,18 @@ Short, concise, GitHub-flavored markdown. Numbered options for prompts (never "[
 # AI Suggestion Verification
 Never apply AI tool suggestions (review bots, linters, PR reviewers) without independent verification. AI reviewers hallucinate. Verify claims against runtime, docs, or project conventions.
 
+# Review Bot Gate (t1382)
+# Before merging any PR, wait for AI code review bots (CodeRabbit, Gemini Code Assist,
+# etc.) to post their reviews. PRs merged before bots post lose security findings.
+# Three enforcement layers:
+# 1. CI: `.github/workflows/review-bot-gate.yml` — required status check
+# 2. Agent: `review-bot-gate-helper.sh check <PR> [REPO]` — returns PASS/WAITING/SKIP
+# 3. Branch protection: add `review-bot-gate` as required check per repo
+- Before merging: run `review-bot-gate-helper.sh check <PR_NUMBER>`. If WAITING, poll up to 10 minutes. Most bots post within 2-5 minutes.
+- If the PR has `skip-review-gate` label, bypass the gate (for docs-only PRs or repos without bots).
+- In headless mode: if still WAITING after timeout, proceed but log a warning. The CI required check is the hard gate.
+- ALWAYS read bot reviews before merging. Address critical/security findings; note non-critical suggestions for follow-up.
+
 # Context Compaction Survival
 # On compaction, ALWAYS preserve: (1) task IDs + states, (2) active batch/concurrency,
 # (3) worktree path + branch, (4) open PR numbers, (5) next 3 actions, (6) blockers,

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -522,11 +522,12 @@ After task completion, the loop automatically:
    A comment like "Resolved by PR #NNN" does NOT create a link — only closing keywords in the PR body do. **Caution:** GitHub parses `Closes #NNN` anywhere in the PR body — including explanatory prose. If describing a bug that involved wrong issue linkage, use backtick-escaped references (`` `Closes #NNN` ``) or rephrase to avoid the pattern. PR #2512 itself closed the wrong issue because its description mentioned `Closes #2498` when explaining the original bug.
 3. **Label Update**: Update linked issue to `status:in-review` (see below)
 4. **PR Review**: Monitors CI checks and review status
-5. **Merge**: Squash merge (without `--delete-branch` when in worktree)
-6. **Issue Closing Comment**: Post a summary comment on linked issues (see below)
-7. **Worktree Cleanup**: Return to main repo, pull, clean merged worktrees
-8. **Postflight**: Verifies release health after merge
-9. **Deploy**: Runs `setup.sh --non-interactive` (aidevops repos only)
+5. **Review Bot Gate (t1382)**: Wait for AI review bots before merge (see below)
+6. **Merge**: Squash merge (without `--delete-branch` when in worktree)
+7. **Issue Closing Comment**: Post a summary comment on linked issues (see below)
+8. **Worktree Cleanup**: Return to main repo, pull, clean merged worktrees
+9. **Postflight**: Verifies release health after merge
+10. **Deploy**: Runs `setup.sh --non-interactive` (aidevops repos only)
 
 **Issue-state guard before any label/comment modification (t1343 — MANDATORY):**
 
@@ -568,6 +569,41 @@ done
 ```
 
 The `status:done` transition is handled automatically by the `sync-on-pr-merge` workflow when the PR merges — workers do not need to set it.
+
+**Review Bot Gate (t1382 — MANDATORY before merge):**
+
+Before merging any PR, wait for AI code review bots to post their reviews. This is a defense-in-depth gate with three layers:
+
+1. **CI layer**: The `review-bot-gate` GitHub Actions workflow (`.github/workflows/review-bot-gate.yml`) runs as a required status check. It checks for comments/reviews from known bots (CodeRabbit, Gemini Code Assist, Augment Code, Copilot) and fails until at least one has posted. The workflow re-triggers on `pull_request_review` and `issue_comment` events, so it automatically passes once a bot reviews.
+
+2. **Agent layer (this rule)**: After creating the PR and before merging, the agent MUST verify that at least one AI review bot has posted. Use the helper script:
+
+   ```bash
+   REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+   RESULT=$(~/.aidevops/agents/scripts/review-bot-gate-helper.sh check "$PR_NUMBER" "$REPO")
+   # Returns: PASS (bots found), WAITING (no bots yet), SKIP (label present)
+   ```
+
+   **If WAITING**: Poll every 60 seconds for up to 10 minutes (configurable via `REVIEW_BOT_WAIT_MAX=600`). Most bots post within 2-5 minutes. If still waiting after the timeout:
+   - In **interactive mode**: warn the user and ask whether to proceed or wait longer
+   - In **headless mode**: proceed with merge but log a warning — the CI gate will block if configured as a required check
+
+   **If PASS**: Proceed to merge. Read the bot reviews and address any critical/security findings before merging. Non-critical suggestions can be noted for follow-up.
+
+   **If SKIP**: The PR has the `skip-review-gate` label — proceed to merge. Use this for docs-only PRs or repos without review bots.
+
+3. **Branch protection layer**: For repos with review bots configured, add `review-bot-gate` as a required status check in GitHub Settings > Branches > Branch protection rules. This is the hard enforcement — even if the agent skips the wait, GitHub blocks the merge.
+
+**Why this matters**: PR #1 on aidevops-cloudron-app was merged before review bots posted, losing all security findings. The bots found real issues that would have been caught if the merge had waited 3 minutes.
+
+**Known review bots** (from `workflows/pr.md`):
+
+| Bot | Login pattern | Typical review time |
+|-----|---------------|-------------------|
+| CodeRabbit | `coderabbitai` | 1-3 minutes |
+| Gemini Code Assist | `gemini-code-assist[bot]` | 2-5 minutes |
+| Augment Code | `augment-code[bot]` | 2-4 minutes |
+| GitHub Copilot | `copilot[bot]` | 1-3 minutes |
 
 **Issue closing comment (MANDATORY — do NOT skip):**
 

--- a/.agents/scripts/commands/pr-loop.md
+++ b/.agents/scripts/commands/pr-loop.md
@@ -42,14 +42,31 @@ Monitor the PR iteratively using `gh` CLI to check CI status, reviews, and merge
 The script performs these checks each iteration:
 
 1. **CI Status** - Check all GitHub Actions workflows
-2. **Review Status** - Check for approvals or change requests
-3. **Merge Readiness** - Verify PR can be merged
+2. **Review Bot Gate (t1382)** - Verify AI review bots have posted (see below)
+3. **Review Status** - Check for approvals or change requests
+4. **Merge Readiness** - Verify PR can be merged
 
 If issues are found:
 - CI failures: Report and wait for fixes
 - Changes requested: **Verify before acting** (see below), then address valid feedback
 - Unresolved AI feedback (COMMENTED): Some bots (e.g., Gemini Code Assist) post as `COMMENTED` rather than `CHANGES_REQUESTED`, so GitHub's `reviewDecision` stays `NONE`. The loop detects unresolved review threads and surfaces this feedback for action.
 - Stale review: Auto-trigger re-review (unless `--no-auto-trigger`)
+
+### Review Bot Gate (t1382)
+
+Before proceeding to merge, the loop MUST verify that at least one AI review bot has posted. This prevents the pattern where PRs are merged before bots finish analysis, losing security findings.
+
+```bash
+# Check if bots have posted
+RESULT=$(~/.aidevops/agents/scripts/review-bot-gate-helper.sh check "$PR_NUMBER" "$REPO")
+# Returns: PASS (bots found), WAITING (no bots yet), SKIP (label present)
+```
+
+**If WAITING**: The loop continues polling. Most bots post within 2-5 minutes. The `review-bot-gate` CI check (if configured as required) also blocks merge at the GitHub level.
+
+**If PASS**: Read the bot reviews and address critical/security findings before merging. Non-critical suggestions can be noted for follow-up.
+
+**If SKIP**: The PR has the `skip-review-gate` label — proceed without waiting.
 
 ### AI Bot Review Verification
 

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# review-bot-gate-helper.sh — Check if AI review bots have posted on a PR
+#
+# Usage:
+#   review-bot-gate-helper.sh check <PR_NUMBER> [REPO]
+#   review-bot-gate-helper.sh wait  <PR_NUMBER> [REPO] [MAX_WAIT_SECONDS]
+#   review-bot-gate-helper.sh list  <PR_NUMBER> [REPO]
+#
+# Commands:
+#   check  — Check once, return PASS/WAITING/SKIP
+#   wait   — Poll until a bot posts or timeout (default 600s)
+#   list   — List all bot comments found on the PR
+#
+# Exit codes:
+#   0 — PASS (at least one bot reviewed) or SKIP (label present)
+#   1 — WAITING (no bots found yet)
+#   2 — Error (missing args, gh auth failure)
+#
+# Environment:
+#   REVIEW_BOT_WAIT_MAX  — Max seconds to wait in 'wait' mode (default: 600)
+#   REVIEW_BOT_POLL_INTERVAL — Seconds between polls (default: 60)
+#
+# t1382: https://github.com/marcusquinn/aidevops/issues/2735
+
+set -euo pipefail
+
+# Known review bot login patterns (lowercase, without [bot] suffix for matching)
+KNOWN_BOTS=(
+	"coderabbitai"
+	"gemini-code-assist"
+	"augment-code"
+	"augmentcode"
+	"copilot"
+)
+
+SKIP_LABEL="skip-review-gate"
+
+# --- Functions ---
+
+usage() {
+	echo "Usage: $(basename "$0") {check|wait|list} <PR_NUMBER> [REPO] [MAX_WAIT]"
+	echo ""
+	echo "Commands:"
+	echo "  check  Check once for bot reviews (returns PASS/WAITING/SKIP)"
+	echo "  wait   Poll until bot reviews appear or timeout"
+	echo "  list   List all bot comments found"
+	return 0
+}
+
+get_all_bot_commenters() {
+	local pr_number="$1"
+	local repo="$2"
+
+	# Collect reviewers from three sources:
+	# 1. PR reviews (formal GitHub reviews)
+	local reviews
+	reviews=$(gh api "repos/${repo}/pulls/${pr_number}/reviews" \
+		--paginate --jq '.[].user.login' 2>/dev/null || echo "")
+
+	# 2. Issue comments (some bots post as comments, not reviews)
+	local comments
+	comments=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
+		--paginate --jq '.[].user.login' 2>/dev/null || echo "")
+
+	# 3. Review comments (inline code comments)
+	local review_comments
+	review_comments=$(gh api "repos/${repo}/pulls/${pr_number}/comments" \
+		--paginate --jq '.[].user.login' 2>/dev/null || echo "")
+
+	# Combine, deduplicate, lowercase
+	echo -e "${reviews}\n${comments}\n${review_comments}" |
+		tr '[:upper:]' '[:lower:]' | sort -u | grep -v '^$' || true
+}
+
+check_for_skip_label() {
+	local pr_number="$1"
+	local repo="$2"
+
+	local labels
+	labels=$(gh pr view "$pr_number" --repo "$repo" \
+		--json labels -q '.labels[].name' 2>/dev/null || echo "")
+
+	if echo "$labels" | grep -q "$SKIP_LABEL"; then
+		return 0
+	fi
+	return 1
+}
+
+match_known_bots() {
+	local all_commenters="$1"
+	local found_bots=""
+	local missing_bots=""
+
+	for bot in "${KNOWN_BOTS[@]}"; do
+		if echo "$all_commenters" | grep -qi "$bot"; then
+			found_bots="${found_bots}${bot} "
+		else
+			missing_bots="${missing_bots}${bot} "
+		fi
+	done
+
+	echo "found:${found_bots}"
+	echo "missing:${missing_bots}"
+}
+
+do_check() {
+	local pr_number="$1"
+	local repo="$2"
+
+	# Check skip label first
+	if check_for_skip_label "$pr_number" "$repo"; then
+		echo "SKIP"
+		return 0
+	fi
+
+	local all_commenters
+	all_commenters=$(get_all_bot_commenters "$pr_number" "$repo")
+
+	local found_bots=""
+	for bot in "${KNOWN_BOTS[@]}"; do
+		if echo "$all_commenters" | grep -qi "$bot"; then
+			found_bots="${found_bots}${bot} "
+		fi
+	done
+
+	if [[ -n "$found_bots" ]]; then
+		echo "PASS"
+		echo "found: ${found_bots}" >&2
+		return 0
+	else
+		echo "WAITING"
+		echo "No review bots found yet. Known bots: ${KNOWN_BOTS[*]}" >&2
+		return 1
+	fi
+}
+
+do_wait() {
+	local pr_number="$1"
+	local repo="$2"
+	local max_wait="${3:-${REVIEW_BOT_WAIT_MAX:-600}}"
+	local poll_interval="${REVIEW_BOT_POLL_INTERVAL:-60}"
+	local elapsed=0
+
+	echo "Waiting up to ${max_wait}s for review bots on PR #${pr_number}..." >&2
+
+	while [[ "$elapsed" -lt "$max_wait" ]]; do
+		local result
+		result=$(do_check "$pr_number" "$repo" 2>/dev/null) || true
+
+		if [[ "$result" == "PASS" || "$result" == "SKIP" ]]; then
+			echo "$result"
+			return 0
+		fi
+
+		echo "[${elapsed}s/${max_wait}s] Still waiting for review bots..." >&2
+		sleep "$poll_interval"
+		elapsed=$((elapsed + poll_interval))
+	done
+
+	echo "WAITING"
+	echo "Timeout after ${max_wait}s — no review bots posted." >&2
+	return 1
+}
+
+do_list() {
+	local pr_number="$1"
+	local repo="$2"
+
+	local all_commenters
+	all_commenters=$(get_all_bot_commenters "$pr_number" "$repo")
+
+	echo "All commenters on PR #${pr_number}:"
+	echo "$all_commenters" | sed 's/^/  /'
+	echo ""
+
+	local result
+	result=$(match_known_bots "$all_commenters")
+	echo "$result"
+	return 0
+}
+
+# --- Main ---
+
+main() {
+	local command="${1:-}"
+	local pr_number="${2:-}"
+	local repo="${3:-}"
+	local max_wait="${4:-}"
+
+	if [[ -z "$command" || -z "$pr_number" ]]; then
+		usage
+		return 2
+	fi
+
+	# Default repo from current git context
+	if [[ -z "$repo" ]]; then
+		repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+		if [[ -z "$repo" ]]; then
+			echo "ERROR: Could not determine repo. Pass REPO as third argument." >&2
+			return 2
+		fi
+	fi
+
+	case "$command" in
+	check)
+		do_check "$pr_number" "$repo"
+		;;
+	wait)
+		do_wait "$pr_number" "$repo" "$max_wait"
+		;;
+	list)
+		do_list "$pr_number" "$repo"
+		;;
+	-h | --help | help)
+		usage
+		;;
+	*)
+		echo "ERROR: Unknown command '$command'" >&2
+		usage
+		return 2
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/workflows/pr.md
+++ b/.agents/workflows/pr.md
@@ -416,6 +416,27 @@ tea pulls create \
 
 **Recommendation**: Use squash for feature branches to keep main history clean.
 
+### Pre-Merge: Review Bot Gate (t1382)
+
+Before merging any PR, verify that AI code review bots have posted their reviews. This is enforced at three layers:
+
+1. **CI check**: `.github/workflows/review-bot-gate.yml` — add as required status check in branch protection
+2. **Agent check**: `review-bot-gate-helper.sh check <PR> [REPO]` — returns PASS/WAITING/SKIP
+3. **Agent rule**: `prompts/build.txt` — agents must wait for bots before merging
+
+```bash
+# Check if bots have reviewed
+~/.aidevops/agents/scripts/review-bot-gate-helper.sh check 123
+
+# Wait up to 10 minutes for bots to post
+~/.aidevops/agents/scripts/review-bot-gate-helper.sh wait 123
+
+# List all bot activity on a PR
+~/.aidevops/agents/scripts/review-bot-gate-helper.sh list 123
+```
+
+To bypass for docs-only PRs or repos without bots, add the `skip-review-gate` label.
+
 ### GitHub
 
 ```bash

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -1,0 +1,205 @@
+name: Review Bot Gate
+
+# Blocks merge until AI code review bots have posted their reviews.
+# Process gap: PRs were merged before CodeRabbit/Gemini posted findings,
+# losing security-relevant feedback. This workflow polls for bot reviews
+# and only passes when at least one configured bot has reviewed.
+#
+# To enforce: add "review-bot-gate" as a required status check in
+# GitHub branch protection settings for each repo.
+#
+# t1382: https://github.com/marcusquinn/aidevops/issues/2735
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+
+# Cancel in-progress runs when a new event fires (e.g., new push)
+concurrency:
+  group: review-bot-gate-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review-bot-gate:
+    name: Wait for AI Review Bots
+    runs-on: ubuntu-latest
+    # Only run on PRs (issue_comment fires for PR comments too)
+    if: >
+      github.event_name == 'pull_request' ||
+      github.event_name == 'pull_request_review' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+
+    permissions:
+      pull-requests: read
+      contents: read
+
+    steps:
+      - name: Check for AI review bot activity
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Checking PR #${PR_NUMBER} for AI review bot activity..."
+
+          # Known review bot patterns (case-insensitive matching on login)
+          # Add new bots here as they are configured
+          KNOWN_BOTS=(
+            "coderabbitai"
+            "gemini-code-assist[bot]"
+            "augment-code[bot]"
+            "augmentcode[bot]"
+            "copilot[bot]"
+          )
+
+          # Minimum wait time (seconds) after PR creation before we check
+          # Gives bots time to start their analysis
+          MIN_WAIT_SECONDS=120
+
+          # Get PR creation time
+          PR_CREATED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json createdAt -q '.createdAt')
+          PR_CREATED_EPOCH=$(date -d "$PR_CREATED" +%s 2>/dev/null || \
+            date -j -f "%Y-%m-%dT%H:%M:%SZ" "$PR_CREATED" +%s 2>/dev/null || \
+            echo "0")
+          NOW_EPOCH=$(date +%s)
+          ELAPSED=$((NOW_EPOCH - PR_CREATED_EPOCH))
+
+          echo "PR created: ${PR_CREATED} (${ELAPSED}s ago)"
+
+          if [[ "$ELAPSED" -lt "$MIN_WAIT_SECONDS" ]]; then
+            echo "::warning::PR is only ${ELAPSED}s old (minimum ${MIN_WAIT_SECONDS}s). Review bots may not have posted yet."
+          fi
+
+          # Check PR reviews (formal GitHub reviews from bots)
+          echo ""
+          echo "=== Checking PR reviews ==="
+          REVIEWS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" \
+            --paginate --jq '.[].user.login' 2>/dev/null || echo "")
+
+          # Check PR comments (some bots post as issue comments, not reviews)
+          echo "=== Checking PR comments ==="
+          COMMENTS=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq '.[].user.login' 2>/dev/null || echo "")
+
+          # Check review comments (inline code comments)
+          echo "=== Checking review comments ==="
+          REVIEW_COMMENTS=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/comments" \
+            --paginate --jq '.[].user.login' 2>/dev/null || echo "")
+
+          # Combine all commenters
+          ALL_COMMENTERS=$(echo -e "${REVIEWS}\n${COMMENTS}\n${REVIEW_COMMENTS}" | \
+            sort -u | tr '[:upper:]' '[:lower:]')
+
+          echo ""
+          echo "All commenters found:"
+          echo "$ALL_COMMENTERS" | grep -v '^$' | sed 's/^/  - /'
+
+          # Check which known bots have posted
+          FOUND_BOTS=""
+          MISSING_BOTS=""
+
+          for bot in "${KNOWN_BOTS[@]}"; do
+            # Use grep pattern matching (bot patterns may contain [bot] suffix)
+            bot_lower=$(echo "$bot" | tr '[:upper:]' '[:lower:]')
+            # Strip [bot] for matching since GitHub may or may not include it
+            bot_base=$(echo "$bot_lower" | sed 's/\[bot\]$//')
+
+            if echo "$ALL_COMMENTERS" | grep -qi "$bot_base"; then
+              FOUND_BOTS="${FOUND_BOTS}${bot} "
+              echo "FOUND: ${bot}"
+            else
+              MISSING_BOTS="${MISSING_BOTS}${bot} "
+              echo "MISSING: ${bot}"
+            fi
+          done
+
+          echo ""
+          echo "Found bots: ${FOUND_BOTS:-none}"
+          echo "Missing bots: ${MISSING_BOTS:-none}"
+
+          # Gate logic: require at least ONE known bot to have reviewed
+          # This is intentionally lenient — not all repos have all bots.
+          # The goal is to catch the case where NO bots have reviewed at all.
+          if [[ -n "$FOUND_BOTS" ]]; then
+            echo ""
+            echo "PASS: At least one AI review bot has posted feedback."
+            echo "gate_passed=true" >> "$GITHUB_OUTPUT"
+            echo "found_bots=${FOUND_BOTS}" >> "$GITHUB_OUTPUT"
+            echo "missing_bots=${MISSING_BOTS}" >> "$GITHUB_OUTPUT"
+          else
+            echo ""
+            echo "WAITING: No AI review bots have posted yet."
+            echo "This check will re-run when a bot posts a review or comment."
+            echo ""
+            echo "Expected bots: ${KNOWN_BOTS[*]}"
+            echo ""
+            echo "If no bots are configured on this repo, add 'skip-review-gate'"
+            echo "label to the PR to bypass this check."
+            echo "gate_passed=false" >> "$GITHUB_OUTPUT"
+            echo "found_bots=" >> "$GITHUB_OUTPUT"
+            echo "missing_bots=${MISSING_BOTS}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for skip label
+        id: skip
+        if: steps.check.outputs.gate_passed != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          LABELS=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
+            --json labels -q '.labels[].name' 2>/dev/null || echo "")
+
+          if echo "$LABELS" | grep -q "skip-review-gate"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "SKIP: 'skip-review-gate' label found — bypassing review bot gate."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Gate result
+        if: steps.check.outputs.gate_passed != 'true' && steps.skip.outputs.skip != 'true'
+        run: |
+          echo "::error::No AI review bots have posted on this PR yet."
+          echo ""
+          echo "This PR cannot be merged until at least one AI code review bot"
+          echo "(CodeRabbit, Gemini Code Assist, etc.) has posted its review."
+          echo ""
+          echo "What to do:"
+          echo "  1. Wait a few minutes for bots to complete their analysis"
+          echo "  2. This check re-runs automatically when a bot posts"
+          echo "  3. If no bots are configured, add 'skip-review-gate' label"
+          echo ""
+          echo "Missing bots: ${{ steps.check.outputs.missing_bots }}"
+          exit 1
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Review Bot Gate"
+            echo ""
+            if [[ "${{ steps.check.outputs.gate_passed }}" == "true" ]]; then
+              echo "**Status**: PASSED"
+              echo ""
+              echo "**Bots that reviewed**: ${{ steps.check.outputs.found_bots }}"
+              if [[ -n "${{ steps.check.outputs.missing_bots }}" ]]; then
+                echo ""
+                echo "**Bots not yet reviewed**: ${{ steps.check.outputs.missing_bots }}"
+              fi
+            elif [[ "${{ steps.skip.outputs.skip }}" == "true" ]]; then
+              echo "**Status**: SKIPPED (skip-review-gate label)"
+            else
+              echo "**Status**: WAITING"
+              echo ""
+              echo "No AI review bots have posted yet. This check will re-run"
+              echo "automatically when a bot posts a review or comment."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

- Adds three-layer defense to prevent PRs from being merged before AI code review bots (CodeRabbit, Gemini Code Assist) post their findings
- CI workflow (`.github/workflows/review-bot-gate.yml`) as a required status check, re-triggers on review/comment events
- Helper script (`review-bot-gate-helper.sh`) for check/wait/list commands for agent and manual use
- Agent rules in `full-loop.md`, `pr-loop.md`, `pr.md`, and `build.txt` — mandatory wait gate before merge step

Process gap: PR #1 on aidevops-cloudron-app was merged before review bots posted, losing all security findings. Bots typically post within 2-5 minutes; the gate polls up to 10 minutes before timing out.

Closes #2735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduces mandatory "Review Bot Gate" before PR merge, requiring at least one AI review bot to provide feedback before allowing merge.
  * Includes configurable wait/poll mechanism with timeout handling and configurable polling intervals.
  * Supports skip-review-gate label to bypass gate for documentation-only changes or bot-exempt repositories.

* **Documentation**
  * Added comprehensive guidance for Review Bot Gate workflow, including usage commands and integration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->