### PR TITLE
fix: provide default path for SSH key generation in setup

### DIFF
--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -823,7 +823,8 @@ setup_ssh_key() {
 
 		if [[ "$generate_key" =~ ^[Yy]?$ ]]; then
 			read -r -p "Enter your email address: " email
-			ssh-keygen -t ed25519 -C "$email"
+			mkdir -p ~/.ssh && chmod 700 ~/.ssh
+			ssh-keygen -t ed25519 -C "$email" -f ~/.ssh/id_ed25519
 			print_success "SSH key generated"
 		else
 			print_info "Skipping SSH key generation"


### PR DESCRIPTION
## Summary

- Pass `-f ~/.ssh/id_ed25519` to `ssh-keygen` in `setup_ssh_key()` so users see the default save location instead of a bare prompt
- Ensure `~/.ssh` directory exists with `700` permissions before key generation

Fixes a UX confusion point where new users didn't know what path to enter when prompted by `ssh-keygen`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH key setup reliability by ensuring the SSH configuration directory is created with proper security permissions (700 mode) before key generation and explicitly specifying the Ed25519 key file location, enhancing setup consistency and reducing potential errors across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->