### PR TITLE
docs: add external contribution policy and supervisor triage guidance

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -80,6 +80,17 @@ When closing any issue, ALWAYS add a comment first explaining: (1) why you're cl
 - **`status:queued` or `status:in-progress`** → likely being worked on (possibly on another machine). Check the `updatedAt` timestamp: if the issue was updated within the last 3 hours, skip it. If it's been 3+ hours with no open PR and no recent commits on a related branch, the worker likely died — relabel to `status:available`, unassign, and comment explaining the recovery. It's now dispatchable.
 - **`status:available` or no status label** → dispatch a worker (see below)
 
+### External issues and PRs — scope check
+
+Issues and PRs from non-maintainers (check `authorAssociation`: `NONE`, `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, `CONTRIBUTOR`) require a scope check before dispatching workers. Architectural decisions — what the project integrates with, supports, tests against, or bundles — are maintainer-only.
+
+- **Destructive behaviour reports** (aidevops deletes files, overwrites configs, breaks the user's setup) → valid bug, dispatch a fix. The fix should be "stop being destructive" (add a config toggle, preserve user files), not "add integration with their tool".
+- **Feature requests for third-party integrations** (add support for tool X, test against framework Y, bundle library Z) → label `needs-maintainer-review`, do NOT dispatch a worker. Comment acknowledging the request and explaining it needs maintainer decision on scope.
+- **PRs that add dependencies, integrations, or change architecture** → do NOT merge autonomously. Label `needs-maintainer-review`. These require explicit maintainer approval regardless of CI status.
+- **Bug fixes and documentation PRs** → normal review process, can be merged if CI passes and changes are scoped correctly.
+
+The principle: fix our bugs, but don't commit to supporting external tools without maintainer sign-off. Compatibility is best-effort, not guaranteed.
+
 ### Kill stuck workers
 
 Check `ps axo pid,etime,command | grep '/full-loop' | grep '\.opencode'`. Any worker running 3+ hours with no open PR is likely stuck. Kill it: `kill <pid>`. Comment on the issue explaining why. This frees a slot. If the worker has recent commits or an open PR with activity, leave it alone — it's making progress.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,5 +24,8 @@ What you expected to happen.
 - aidevops version: [run `aidevops --version`]
 - Shell: [e.g., zsh, bash]
 
+**Does this involve a third-party tool?**
+If the bug involves a clash with another tool (e.g., aidevops overwrites or deletes files managed by another tool), please name the tool and describe the conflict. We fix destructive behaviour on our side but don't guarantee compatibility with external tools. See [CONTRIBUTING.md](../../CONTRIBUTING.md#scope-of-contributions).
+
 **Additional context**
 Any other relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,5 +15,8 @@ How would you like it to work?
 **Alternatives considered**
 Any other approaches you've thought about.
 
+**Does this involve third-party tool integration?**
+If this request involves adding support for, bundling, or testing against an external tool or service, please note that architectural decisions are made by maintainers. We welcome the suggestion but can't guarantee it will be adopted. See [CONTRIBUTING.md](../../CONTRIBUTING.md#scope-of-contributions).
+
 **Additional context**
 Any other relevant information.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,4 @@ Brief description of changes.
 - [ ] I have tested my changes locally
 - [ ] I have followed the commit message conventions
 - [ ] I have updated documentation if needed
-- [ ] This PR does not add third-party integrations or change architecture (if it does, maintainer approval is required — see [CONTRIBUTING.md](../CONTRIBUTING.md#scope-of-contributions))
+- [ ] For architectural changes or new integrations, I have obtained maintainer approval (see [CONTRIBUTING.md](../CONTRIBUTING.md#scope-of-contributions))

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,4 @@ Brief description of changes.
 - [ ] I have tested my changes locally
 - [ ] I have followed the commit message conventions
 - [ ] I have updated documentation if needed
+- [ ] This PR does not add third-party integrations or change architecture (if it does, maintainer approval is required — see [CONTRIBUTING.md](../CONTRIBUTING.md#scope-of-contributions))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,27 @@ We use [Conventional Commits](https://www.conventionalcommits.org/):
 - Markdown: Follow `.markdownlint.json` rules
 - Quality target: SonarCloud A-grade
 
+## Scope of Contributions
+
+aidevops is an opinionated framework. Architectural decisions — what the project integrates with, supports, tests against, or bundles — are made by maintainers.
+
+**What we welcome from everyone:**
+
+- Bug reports (especially destructive behaviour — deleting files, breaking configs)
+- Feature requests (we'll assess fit and priority)
+- Bug fixes and documentation improvements via PR
+
+**What requires maintainer approval before implementation:**
+
+- Adding integrations with third-party tools or services
+- Changing default behaviours or configuration structure
+- Adding new dependencies
+- Modifying the agent framework architecture
+
+**Third-party compatibility:** aidevops aims not to break other tools in your environment (we won't delete your files or overwrite your configs without opt-in). However, we don't guarantee compatibility with specific third-party tools and don't maintain test coverage for them. If you encounter a clash, report it — we'll fix destructive behaviour on our side, but we won't add integration code or test suites for external projects.
+
+If you're unsure whether your contribution is in scope, open an issue first to discuss before investing time in a PR.
+
 ## Questions?
 
 Open an issue or start a discussion. We're happy to help!


### PR DESCRIPTION
## Summary

- Adds a "Scope of Contributions" section to CONTRIBUTING.md establishing that architectural decisions (integrations, dependencies, defaults) require maintainer approval
- Adds supervisor triage rules in pulse.md so the autonomous pulse correctly handles external issues/PRs — dispatching fixes for destructive bugs but labelling `needs-maintainer-review` for integration/architecture requests
- Updates issue templates (bug report, feature request) with third-party tool fields
- Adds architecture-change checklist item to PR template

## Motivation

External contributors were filing issues requesting third-party integrations (e.g., oh-my-opencode), and the supervisor was auto-dispatching workers to implement them without maintainer review. This policy ensures compatibility bugs get fixed promptly while architectural scope decisions remain with maintainers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Scope of Contributions" section clarifying maintainer-driven architectural decisions and third-party compatibility guidelines.
  * Updated issue templates with questions about third-party tool involvement.
  * Updated pull request template with a checklist item for third-party integrations and architectural changes.
  * Enhanced contribution workflow documentation with external contribution scope rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->