### PR TITLE
fix: remaining grep -c || echo multiline output breaking pulse-wrapper arithmetic

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -748,7 +748,7 @@ cleanup_worktrees() {
 			clean_result=$(cd "$repo_path" && bash "$helper" clean --auto --force-merged 2>&1) || true
 
 			local count
-			count=$(echo "$clean_result" | grep -c 'Removing' || echo "0")
+			count=$(echo "$clean_result" | grep -c 'Removing') || count=0
 			if [[ "$count" -gt 0 ]]; then
 				local repo_name
 				repo_name=$(basename "$repo_path")
@@ -760,8 +760,10 @@ cleanup_worktrees() {
 		# Fallback: just clean the current repo (legacy behaviour)
 		local cleaned_output
 		cleaned_output=$(bash "$helper" clean --auto --force-merged 2>&1) || true
-		if echo "$cleaned_output" | grep -q "Removing\|removed"; then
-			echo "[pulse-wrapper] Worktree cleanup: $(echo "$cleaned_output" | grep -c 'Removing') worktree(s) removed" >>"$LOGFILE"
+		local fallback_count
+		fallback_count=$(echo "$cleaned_output" | grep -c 'Removing') || fallback_count=0
+		if [[ "$fallback_count" -gt 0 ]]; then
+			echo "[pulse-wrapper] Worktree cleanup: $fallback_count worktree(s) removed" >>"$LOGFILE"
 		fi
 	fi
 


### PR DESCRIPTION
## Summary

- Fixes 2 remaining instances of `grep -c ... || echo "0"` pattern in `cleanup_worktrees()` that were missed in bd3225ee
- This pattern produces multiline output (`"0\n0"`) when grep finds no matches, breaking bash arithmetic and causing pulse-wrapper to crash every 2 minutes

## Root Cause

`grep -c 'pattern' || echo "0"` — when grep finds 0 matches, it outputs `0` with exit code 1. The `|| echo "0"` appends another `0`, resulting in `"0\n0"`. This value in `$((...))` arithmetic triggers `syntax error in expression`.

## Fix

Use `count=$(grep -c ...) || count=0` — assignment captures grep's stdout; `||` handles the exit code separately without concatenation.

Closes the recurring error:
```
pulse-wrapper.sh: line 1311: 0
0: syntax error in expression (error token is "0")
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling and control flow in the worktree cleanup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->