### PR TITLE
t1385.4: Add iMessage/BlueBubbles subagent doc

### DIFF
--- a/.agents/services/communications/imessage.md
+++ b/.agents/services/communications/imessage.md
@@ -22,7 +22,7 @@ tools:
 - **License**: BlueBubbles (Apache-2.0), imsg CLI (MIT, [github.com/steipete/imsg](https://github.com/steipete/imsg))
 - **Bot tools**: BlueBubbles REST API (recommended, full-featured) OR imsg CLI (simple send-only)
 - **Protocol**: Apple Push Notification service (APNs) + iMessage protocol
-- **Encryption**: E2E (ECDSA P-256 for newer devices, RSA-2048 + AES-128-CTR for legacy)
+- **Encryption**: E2E (PQ3 with AES-256-CTR on iOS 17.4+; classic: RSA-OAEP/ECIES key wrapping + AES-128-CTR; ECDSA P-256 for signing)
 - **BlueBubbles server**: [github.com/BlueBubblesApp/bluebubbles-server](https://github.com/BlueBubblesApp/bluebubbles-server)
 - **BlueBubbles docs**: [docs.bluebubbles.app](https://docs.bluebubbles.app/)
 - **Requirement**: macOS host with Messages.app (always-on Mac, Apple ID signed in)
@@ -246,9 +246,17 @@ app.listen(3000);
 
 ### Encryption
 
-- **Newer devices (2020+)**: ECDSA P-256 key agreement, AES-256-GCM message encryption
-- **Legacy devices**: RSA-2048 key exchange + AES-128-CTR message encryption
-- **Group chats**: Each message individually encrypted per recipient (no group key)
+iMessage uses E2E encryption with different cryptographic primitives depending on protocol version:
+
+| Component | Classic iMessage | PQ3 (iOS 17.4+) |
+|-----------|-----------------|------------------|
+| Content encryption | AES-128-CTR (per-message key) | AES-256-CTR |
+| Key wrapping | RSA-OAEP (modulus size not specified by Apple); ECIES on P-256 available since iOS 13 | Post-quantum key establishment (Kyber-768 + P-256 ECDH) |
+| Signing / authentication | ECDSA P-256 (sender authentication, not content encryption) | ECDSA P-256 |
+| Attachment encryption | AES-256-CTR (random 256-bit key) | AES-256-CTR |
+| Forward secrecy | Limited — keys rotate on device changes, not per-message | Periodic rekeying via post-quantum ratchet |
+
+- **Group chats**: Each message individually encrypted per recipient device (no group key)
 - **Key verification**: Contact Key Verification (iOS 17.2+) — manual verification like Signal's safety numbers
 - Apple **cannot** read iMessage content in transit
 


### PR DESCRIPTION
## Summary

- Create `.agents/services/communications/imessage.md` — comprehensive subagent doc for iMessage bot integration
- Register `imessage` in `subagent-index.toon` under Communications

## What's Covered

- **Two integration paths**: BlueBubbles REST API (recommended, full-featured) and imsg CLI (send-only)
- **macOS requirements**: Hardware options, Messages.app keepalive, VM/headless setup, monitoring script
- **BlueBubbles REST API**: Authentication, key endpoints, sending messages, attachments, reactions, webhooks with event types and payload examples
- **Messaging features matrix**: DMs, groups, reactions/tapbacks, reply threading, edit/unsend, typing indicators, read receipts, attachments, SMS fallback
- **Access control**: API password auth, allowlist patterns (phone/email, group, command-level, rate limiting), credential storage via gopass
- **Privacy/security assessment**: iMessage E2E encryption details (RSA-2048/ECDSA P-256 + AES), Apple metadata visibility, Advanced Data Protection, BlueBubbles security model, threat model, comparison table vs Signal/SimpleX/Matrix, Apple privacy policy summary
- **aidevops integration**: Runner dispatch pattern, webhook handler architecture, Matterbridge bridging options
- **Limitations**: Platform lock-in, reliability concerns, feature gaps, legal/ToS considerations
- **Troubleshooting**: Common issues and solutions table

Closes #2751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive iMessage integration guide covering BlueBubbles API setup, message flows, webhooks, authentication, and security best practices.

* **Chores**
  * Updated communications service index to reflect iMessage and Web3 messaging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->