### PR TITLE
t1385.13: Update cross-references and indexes for communications platform subagents

### DIFF
--- a/.agents/services/communications/bitchat.md
+++ b/.agents/services/communications/bitchat.md
@@ -274,8 +274,11 @@ Bitchat has no programmatic API — it is a native mobile/desktop app only. Dire
 
 ## Related
 
-- `services/communications/simplex.md` — SimpleX Chat (zero-knowledge, internet-based)
+- `services/communications/discord.md` — Discord bot integration (community, slash commands)
+- `services/communications/msteams.md` — Microsoft Teams bot integration (enterprise, Azure Bot Framework)
 - `services/communications/matrix-bot.md` — Matrix bot integration (federated, internet-based)
+- `services/communications/urbit.md` — Urbit (sovereign personal server, P2P encrypted)
+- `services/communications/simplex.md` — SimpleX Chat (zero-knowledge, internet-based)
 - `services/communications/xmtp.md` — XMTP (Web3 messaging, internet-based)
 - `services/communications/matterbridge.md` — Multi-platform chat bridge
 - `tools/security/opsec.md` — Operational security guidance

--- a/.agents/services/communications/discord.md
+++ b/.agents/services/communications/discord.md
@@ -925,9 +925,12 @@ Discord's server and clients are closed-source. There is no way to audit what Di
 ## Related
 
 - `services/communications/matterbridge.md` — Multi-platform chat bridge (native Discord support)
+- `services/communications/msteams.md` — Microsoft Teams bot integration (enterprise, Azure Bot Framework)
 - `services/communications/matrix-bot.md` — Matrix bot integration (federated, E2E capable)
+- `services/communications/urbit.md` — Urbit (sovereign personal server, P2P encrypted)
 - `services/communications/simplex.md` — SimpleX Chat (maximum privacy, no identifiers)
 - `services/communications/xmtp.md` — XMTP (Web3 messaging, agent SDK)
+- `services/communications/bitchat.md` — Bitchat (Bluetooth mesh, offline P2P)
 - `tools/security/opsec.md` — Operational security guidance
 - `tools/voice/speech-to-speech.md` — Voice pipeline for audio interactions
 - `tools/ai-assistants/headless-dispatch.md` — Headless AI dispatch patterns

--- a/.agents/services/communications/matrix-bot.md
+++ b/.agents/services/communications/matrix-bot.md
@@ -421,11 +421,18 @@ runner-helper.sh edit code-reviewer
 
 ## Related
 
-- `scripts/entity-helper.sh` - Entity memory system (identity resolution, Layer 0/1/2)
-- `scripts/runner-helper.sh` - Runner management
-- `scripts/memory-helper.sh` - Memory system (shared memory.db)
-- `scripts/cron-dispatch.sh` - Cron-triggered dispatch (similar pattern)
-- `tools/ai-assistants/headless-dispatch.md` - Headless dispatch patterns
-- `tools/ai-assistants/opencode-server.md` - OpenCode server API
-- `tools/ai-assistants/openclaw.md` - Alternative: OpenClaw multi-channel bot
-- `services/hosting/cloudron.md` - Cloudron platform for hosting Synapse
+- `services/communications/discord.md` — Discord bot integration (community, slash commands)
+- `services/communications/msteams.md` — Microsoft Teams bot integration (enterprise, Azure Bot Framework)
+- `services/communications/urbit.md` — Urbit (sovereign personal server, P2P encrypted)
+- `services/communications/simplex.md` — SimpleX Chat (zero-knowledge, E2E encrypted)
+- `services/communications/bitchat.md` — Bitchat (Bluetooth mesh, offline P2P)
+- `services/communications/xmtp.md` — XMTP (Web3 messaging, agent SDK)
+- `services/communications/matterbridge.md` — Multi-platform chat bridge
+- `scripts/entity-helper.sh` — Entity memory system (identity resolution, Layer 0/1/2)
+- `scripts/runner-helper.sh` — Runner management
+- `scripts/memory-helper.sh` — Memory system (shared memory.db)
+- `scripts/cron-dispatch.sh` — Cron-triggered dispatch (similar pattern)
+- `tools/ai-assistants/headless-dispatch.md` — Headless dispatch patterns
+- `tools/ai-assistants/opencode-server.md` — OpenCode server API
+- `tools/ai-assistants/openclaw.md` — Alternative: OpenClaw multi-channel bot
+- `services/hosting/cloudron.md` — Cloudron platform for hosting Synapse

--- a/.agents/services/communications/msteams.md
+++ b/.agents/services/communications/msteams.md
@@ -993,8 +993,12 @@ Teams client and server are proprietary. There is no way to:
 ## Related
 
 - `services/communications/matterbridge.md` — Multi-platform bridge (native Teams support)
+- `services/communications/discord.md` — Discord bot integration (community, slash commands)
 - `services/communications/matrix-bot.md` — Matrix bot integration (self-hosted, E2E optional)
+- `services/communications/urbit.md` — Urbit (sovereign personal server, P2P encrypted)
 - `services/communications/simplex.md` — SimpleX Chat (zero-knowledge, E2E encrypted)
+- `services/communications/xmtp.md` — XMTP (Web3 messaging, agent SDK)
+- `services/communications/bitchat.md` — Bitchat (Bluetooth mesh, offline P2P)
 - `tools/security/opsec.md` — Operational security guidance
 - `tools/ai-assistants/headless-dispatch.md` — Headless dispatch patterns
 - `scripts/runner-helper.sh` — Runner management

--- a/.agents/services/communications/simplex.md
+++ b/.agents/services/communications/simplex.md
@@ -943,11 +943,17 @@ No technical conflict — SimpleX bot commands run in chat context, aidevops com
 
 ## Related
 
-- `.agents/services/communications/matrix-bot.md` — Matrix messaging integration (federated, user IDs)
-- `.agents/tools/security/opsec.md` — Operational security guidance
-- `.agents/tools/voice/speech-to-speech.md` — Voice note transcription
-- `.agents/tools/ai-assistants/headless-dispatch.md` — Headless AI dispatch patterns
-- `.agents/services/networking/netbird.md` — Mesh VPN (complementary to SimpleX for infrastructure)
+- `services/communications/discord.md` — Discord bot integration (community, slash commands)
+- `services/communications/msteams.md` — Microsoft Teams bot integration (enterprise, Azure Bot Framework)
+- `services/communications/matrix-bot.md` — Matrix messaging integration (federated, user IDs)
+- `services/communications/urbit.md` — Urbit (sovereign personal server, P2P encrypted)
+- `services/communications/bitchat.md` — Bitchat (Bluetooth mesh, offline P2P)
+- `services/communications/xmtp.md` — XMTP (Web3 messaging, agent SDK)
+- `services/communications/matterbridge.md` — Multi-platform chat bridge
+- `tools/security/opsec.md` — Operational security guidance
+- `tools/voice/speech-to-speech.md` — Voice note transcription
+- `tools/ai-assistants/headless-dispatch.md` — Headless AI dispatch patterns
+- `services/networking/netbird.md` — Mesh VPN (complementary to SimpleX for infrastructure)
 - SimpleX Docs: https://simplex.chat/docs/
 - SimpleX Bot API: https://github.com/simplex-chat/simplex-chat/tree/stable/bots
 - SimpleX Whitepaper: https://github.com/simplex-chat/simplexmq/blob/stable/protocol/overview-tjr.md

--- a/.agents/services/communications/urbit.md
+++ b/.agents/services/communications/urbit.md
@@ -698,15 +698,17 @@ No protocol-level support for voice or video calls. Some experimental integratio
 
 ## Related
 
-- `.agents/services/communications/nostr.md` — Nostr (decentralized, relay-based, censorship-resistant)
-- `.agents/services/communications/simplex.md` — SimpleX Chat (strongest metadata privacy)
-- `.agents/services/communications/matrix-bot.md` — Matrix messaging (federated, mature ecosystem)
-- `.agents/services/communications/bitchat.md` — BitChat (Bitcoin-native messaging)
-- `.agents/services/communications/xmtp.md` — XMTP (Ethereum-native messaging)
-- `.agents/services/communications/matterbridge.md` — Matterbridge (cross-platform bridging)
-- `.agents/tools/security/opsec.md` — Operational security guidance
-- `.agents/tools/credentials/gopass.md` — Secret management (for ship code storage)
-- `.agents/tools/ai-assistants/headless-dispatch.md` — Headless AI dispatch patterns
+- `services/communications/nostr.md` — Nostr (decentralized, relay-based, censorship-resistant)
+- `services/communications/simplex.md` — SimpleX Chat (strongest metadata privacy)
+- `services/communications/matrix-bot.md` — Matrix messaging (federated, mature ecosystem)
+- `services/communications/discord.md` — Discord bot integration (community, slash commands)
+- `services/communications/msteams.md` — Microsoft Teams bot integration (enterprise, Azure Bot Framework)
+- `services/communications/bitchat.md` — BitChat (Bitcoin-native messaging)
+- `services/communications/xmtp.md` — XMTP (Ethereum-native messaging)
+- `services/communications/matterbridge.md` — Matterbridge (cross-platform bridging)
+- `tools/security/opsec.md` — Operational security guidance
+- `tools/credentials/gopass.md` — Secret management (for ship code storage)
+- `tools/ai-assistants/headless-dispatch.md` — Headless AI dispatch patterns
 - Urbit Docs: https://docs.urbit.org/
 - Urbit Developers: https://developers.urbit.org/
 - Azimuth (Identity): https://azimuth.network/

--- a/.agents/services/communications/xmtp.md
+++ b/.agents/services/communications/xmtp.md
@@ -418,8 +418,11 @@ XMTP provides tools for AI-assisted development:
 
 ## Related
 
-- `services/communications/simplex.md` — SimpleX Chat (zero-knowledge, no identifiers)
+- `services/communications/discord.md` — Discord bot integration (community, slash commands)
+- `services/communications/msteams.md` — Microsoft Teams bot integration (enterprise, Azure Bot Framework)
 - `services/communications/matrix-bot.md` — Matrix bot integration (federated)
+- `services/communications/urbit.md` — Urbit (sovereign personal server, P2P encrypted)
+- `services/communications/simplex.md` — SimpleX Chat (zero-knowledge, no identifiers)
 - `services/communications/bitchat.md` — Bitchat (Bluetooth mesh, offline)
 - `services/communications/matterbridge.md` — Multi-platform chat bridge
 - `tools/security/opsec.md` — Operational security guidance


### PR DESCRIPTION
## Summary

- Add `msteams` and `urbit` to `subagent-index.toon` key_files and description (Discord was already added by PR #2765)
- Add `services/communications/msteams.md` and `services/communications/urbit.md` to the Communications row in `.agents/AGENTS.md` Domain Index
- Update `## Related` sections in all 8 merged communications agents to cross-reference each other: discord, msteams, urbit, matterbridge, matrix-bot, simplex, bitchat, xmtp
- Normalize simplex.md paths from `.agents/` prefix to relative format for consistency

## State of t1385 subtasks

**Merged to main (included in cross-references):**
- t1385.7: Discord (#2765)
- t1385.9: Microsoft Teams (#2770)
- t1385.11: Urbit (#2769)

**Still in open PRs (will need cross-ref updates when merged):**
- t1385.1: Telegram (#2768)
- t1385.2: Signal (#2767)
- t1385.3: WhatsApp (#2761)
- t1385.4: iMessage (#2762)
- t1385.5: Nostr (#2764)
- t1385.6: Slack (#2766)
- t1385.8: Google Chat (#2763)

**No PR yet:** t1385.10 (Nextcloud Talk), t1385.12 (privacy-comparison)

Closes #2760