### PR TITLE
t1385.9: Restore msteams index entries lost during merge conflict resolution

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -183,7 +183,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Design | `tools/design/ui-ux-inspiration.md`, `tools/design/ui-ux-catalogue.toon`, `tools/design/brand-identity.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |
 | WordPress | `tools/wordpress/wp-dev.md`, `tools/wordpress/mainwp.md` |
-| Communications | `services/communications/matterbridge.md`, `services/communications/discord.md`, `services/communications/simplex.md`, `services/communications/matrix-bot.md`, `services/communications/bitchat.md`, `services/communications/xmtp.md` |
+| Communications | `services/communications/matterbridge.md`, `services/communications/discord.md`, `services/communications/msteams.md`, `services/communications/simplex.md`, `services/communications/matrix-bot.md`, `services/communications/bitchat.md`, `services/communications/xmtp.md` |
 | Email | `tools/ui/react-email.md`, `services/email/email-testing.md`, `services/email/email-agent.md` |
 | Payments | `services/payments/revenuecat.md`, `services/payments/stripe.md`, `services/payments/procurement.md` |
 | Security/Encryption | `tools/security/tirith.md`, `tools/security/opsec.md`, `tools/security/prompt-injection-defender.md`, `tools/credentials/encryption-stack.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -72,7 +72,7 @@ services/accessibility/,Unified web and email accessibility auditing - WCAG comp
 services/hosting/,Hosting providers - DNS and cloud servers and local dev,local-hosting|localhost|hostinger|hetzner|cloudflare|cloudflare-platform|cloudron|closte
 services/networking/,Networking - mesh VPN and secure device connectivity,tailscale|netbird
 services/email/,Email services - transactional email deliverability testing and autonomous mission communication,ses|email-agent|email-health-check|email-testing|email-delivery-test|email-design-test|email-delivery-testing|email-design-testing
-services/communications/,Communications - SMS voice Matrix bot Discord bot multi-platform chat bridging Bluetooth mesh and Web3 messaging,twilio|telfon|matrix-bot|discord|matterbridge|simplex|bitchat|xmtp
+services/communications/,Communications - SMS voice Matrix bot Discord bot MS Teams multi-platform chat bridging Bluetooth mesh and Web3 messaging,twilio|telfon|matrix-bot|discord|msteams|matterbridge|simplex|bitchat|xmtp
 services/crm/,CRM integration - contact management,fluentcrm
 services/analytics/,Website analytics - GA4 reporting,google-analytics
 services/monitoring/,Error monitoring and debugging,sentry|socket


### PR DESCRIPTION
## Summary

- Restores `msteams.md` entry to the Communications row in `.agents/AGENTS.md` domain index
- Restores `msteams` keyword to the communications entry in `.agents/subagent-index.toon`

## Root Cause

PR #2770 (t1385.9 MS Teams agent) was merged after PR #2765 (t1385.7 Discord agent). Both PRs modified `.agents/AGENTS.md` and `.agents/subagent-index.toon`. During conflict resolution, the Teams additions to these index files were dropped — the merge commit `3afda235` only included the `msteams.md` file itself, not the index entries that make it discoverable.

## Verification

After this fix, `rg msteams .agents/AGENTS.md .agents/subagent-index.toon` returns matches in both files, and the actual doc file `.agents/services/communications/msteams.md` (already present from the original merge) is now properly indexed.

Closes #2756