### PR TITLE
t2782: fix SC2120/SC2119 in chrome-webstore-helper.sh load_credentials

### DIFF
--- a/.agents/scripts/chrome-webstore-helper.sh
+++ b/.agents/scripts/chrome-webstore-helper.sh
@@ -121,6 +121,7 @@ check_dependencies() {
 # CREDENTIAL MANAGEMENT
 # ------------------------------------------------------------------------------
 
+# shellcheck disable=SC2120 # Optional arg with default — callers use the default
 load_credentials() {
 	local env_file="${1:-.env}"
 


### PR DESCRIPTION
## Summary

- Suppress ShellCheck SC2120/SC2119 warnings on `load_credentials()` in `chrome-webstore-helper.sh`
- The function accepts an optional env file path (`$1`) with a sensible default (`.env`). All three callers intentionally use the default — this is correct behavior, not a bug.
- Added `# shellcheck disable=SC2120` directive with inline rationale comment.

## Verification

- `shellcheck .agents/scripts/chrome-webstore-helper.sh` — SC2120 and SC2119 warnings eliminated. Only pre-existing SC1091 (info) remains.

Closes #2782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality checks in internal build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->