### PR TITLE
t1385: Fix code quality review feedback on chat platform docs

### DIFF
--- a/.agents/services/communications/discord.md
+++ b/.agents/services/communications/discord.md
@@ -219,21 +219,27 @@ const commands = [
     .setDescription("Check bot and runner status"),
 ].map((cmd) => cmd.toJSON());
 
-const rest = new REST().setToken(process.env.DISCORD_BOT_TOKEN!);
+const token = process.env.DISCORD_BOT_TOKEN;
+const appId = process.env.DISCORD_APP_ID;
+if (!token || !appId) {
+  throw new Error("DISCORD_BOT_TOKEN and DISCORD_APP_ID must be set");
+}
+
+const rest = new REST().setToken(token);
 
 // Register globally (takes up to 1 hour to propagate)
-await rest.put(Routes.applicationCommands(process.env.DISCORD_APP_ID!), {
+await rest.put(Routes.applicationCommands(appId), {
   body: commands,
 });
 
 // Or register per-guild (instant, good for development)
-await rest.put(
-  Routes.applicationGuildCommands(
-    process.env.DISCORD_APP_ID!,
-    "GUILD_ID"
-  ),
-  { body: commands }
-);
+const guildId = process.env.DISCORD_GUILD_ID;
+if (guildId) {
+  await rest.put(
+    Routes.applicationGuildCommands(appId, guildId),
+    { body: commands }
+  );
+}
 ```
 
 ### Handling Commands
@@ -652,17 +658,20 @@ Users should assume:
 ### Dispatch Pattern
 
 ```typescript
-import { execSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 async function dispatchToRunner(
   runner: string,
   prompt: string
 ): Promise<string> {
-  // Sanitize prompt (remove potential injection)
-  const sanitized = prompt.replace(/[`$\\]/g, "");
-
-  const result = execSync(
-    `runner-helper.sh dispatch "${runner}" "${sanitized}"`,
+  // Use execFile with array args to prevent command injection
+  // (never use execSync with string interpolation)
+  const { stdout } = await execFileAsync(
+    "runner-helper.sh",
+    ["dispatch", runner, prompt],
     {
       encoding: "utf-8",
       timeout: 600_000, // 10 minutes
@@ -670,7 +679,7 @@ async function dispatchToRunner(
     }
   );
 
-  return result.trim();
+  return stdout.trim();
 }
 ```
 

--- a/.agents/services/communications/google-chat.md
+++ b/.agents/services/communications/google-chat.md
@@ -236,7 +236,7 @@ google-chat-helper.sh setup
 
 ### Inbound (Google to Bot)
 
-Google signs every HTTP request to the bot with a bearer token (JWT). The bot must verify this token to prevent spoofed requests.
+> **CRITICAL**: Google signs every HTTP request to the bot with a bearer token (JWT). The bot **MUST** verify this token on every request to prevent spoofed requests. Without verification, anyone who discovers the webhook URL can send forged events to the bot. This is not optional — implement it before deploying to production.
 
 **Verification flow**:
 

--- a/.agents/services/communications/imessage.md
+++ b/.agents/services/communications/imessage.md
@@ -161,13 +161,12 @@ BlueBubbles exposes a comprehensive REST API. All requests require the server pa
 #### Authentication
 
 ```bash
-# Query parameter authentication
-curl "http://localhost:1234/api/v1/chat?password=YOUR_PASSWORD"
-
-# Or header authentication
+# Header authentication (recommended — avoids password in URL/logs)
 curl -H "Authorization: Bearer YOUR_PASSWORD" \
   "http://localhost:1234/api/v1/chat"
 ```
+
+> **Security note**: BlueBubbles also supports `?password=` query parameter authentication, but this is **not recommended** — query strings are logged by web servers, proxies, and browser history. Always use the `Authorization` header instead.
 
 #### Key Endpoints
 
@@ -189,37 +188,37 @@ curl -H "Authorization: Bearer YOUR_PASSWORD" \
 # Send text message to individual
 curl -X POST "http://localhost:1234/api/v1/message/text" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_PASSWORD" \
   -d '{
     "chatGuid": "iMessage;-;+1234567890",
     "message": "Hello from the bot!",
-    "method": "apple-script",
-    "password": "YOUR_PASSWORD"
+    "method": "apple-script"
   }'
 
 # Send text to group chat
 curl -X POST "http://localhost:1234/api/v1/message/text" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_PASSWORD" \
   -d '{
     "chatGuid": "iMessage;+;chat123456",
     "message": "Hello group!",
-    "method": "apple-script",
-    "password": "YOUR_PASSWORD"
+    "method": "apple-script"
   }'
 
 # Send attachment
 curl -X POST "http://localhost:1234/api/v1/message/attachment" \
+  -H "Authorization: Bearer YOUR_PASSWORD" \
   -F "chatGuid=iMessage;-;+1234567890" \
-  -F "attachment=@/path/to/file.png" \
-  -F "password=YOUR_PASSWORD"
+  -F "attachment=@/path/to/file.png"
 
 # Send reaction (tapback)
 curl -X POST "http://localhost:1234/api/v1/message/react" \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_PASSWORD" \
   -d '{
     "chatGuid": "iMessage;-;+1234567890",
     "selectedMessageGuid": "p:0/MESSAGE-GUID",
-    "reaction": "love",
-    "password": "YOUR_PASSWORD"
+    "reaction": "love"
   }'
 ```
 

--- a/.agents/services/communications/msteams.md
+++ b/.agents/services/communications/msteams.md
@@ -253,10 +253,13 @@ Minimal bot server:
 const { BotFrameworkAdapter, TeamsActivityHandler, CardFactory } = require("botbuilder");
 const express = require("express");
 
-const adapter = new BotFrameworkAdapter({
-  appId: process.env.MSTEAMS_APP_ID,
-  appPassword: process.env.MSTEAMS_CLIENT_SECRET,
-});
+const appId = process.env.MSTEAMS_APP_ID;
+const appPassword = process.env.MSTEAMS_CLIENT_SECRET;
+if (!appId || !appPassword) {
+  throw new Error("MSTEAMS_APP_ID and MSTEAMS_CLIENT_SECRET must be set");
+}
+
+const adapter = new BotFrameworkAdapter({ appId, appPassword });
 
 // Error handler
 adapter.onTurnError = async (context, error) => {
@@ -392,10 +395,7 @@ await context.sendActivity(replyActivity);
 
 // Create a new top-level post in a channel
 // Requires Graph API — Bot Framework sends replies by default
-const { Client } = require("@microsoft/microsoft-graph-client");
-const graphClient = Client.init({
-  authProvider: (done) => done(null, accessToken),
-});
+// (assumes graphClient is initialized as shown in "Graph API Integration" section)
 await graphClient
   .api(`/teams/${teamId}/channels/${channelId}/messages`)
   .post({ body: { content: "New top-level post" } });
@@ -650,9 +650,11 @@ The `appType` in the Azure Bot resource controls this:
 
 `~/.config/aidevops/msteams-bot.json` (600 permissions):
 
+> **Security**: Store `appId` and `clientSecret` in gopass (`aidevops secret set msteams-app-id`, `aidevops secret set msteams-client-secret`), not in this JSON file. Reference them via environment variables or `credentials.sh`. The values below are placeholders only.
+
 ```json
 {
-  "appId": "00000000-0000-0000-0000-000000000000",
+  "appId": "stored-in-gopass",
   "tenantId": "00000000-0000-0000-0000-000000000000",
   "botEndpoint": "https://your-server.example.com/api/messages",
   "allowedUsers": [],
@@ -694,7 +696,10 @@ The `appType` in the Azure Bot resource controls this:
 The bot dispatches to aidevops runners following the same pattern as the Matrix bot:
 
 ```javascript
-const { execSync } = require("child_process");
+const { execFile } = require("child_process");
+const { promisify } = require("util");
+
+const execFileAsync = promisify(execFile);
 
 async function dispatchToRunner(prompt, context) {
   const channelId = context.activity.channelData?.channel?.id;
@@ -707,12 +712,14 @@ async function dispatchToRunner(prompt, context) {
   }
 
   try {
-    // Dispatch via runner-helper.sh
-    const result = execSync(
-      `runner-helper.sh dispatch "${runner}" "${prompt.replace(/"/g, '\\"')}"`,
+    // Use execFile with array args to prevent command injection
+    // (never use execSync with string interpolation)
+    const { stdout } = await execFileAsync(
+      "runner-helper.sh",
+      ["dispatch", runner, prompt],
       { timeout: config.responseTimeout * 1000, encoding: "utf-8" }
     );
-    return result.trim();
+    return stdout.trim();
   } catch (error) {
     return `Runner dispatch failed: ${error.message}`;
   }

--- a/.agents/services/communications/slack.md
+++ b/.agents/services/communications/slack.md
@@ -201,11 +201,13 @@ npm install @slack/bolt
 ```typescript
 import { App } from "@slack/bolt";
 
-const app = new App({
-  token: process.env.SLACK_BOT_TOKEN,       // xoxb-...
-  appToken: process.env.SLACK_APP_TOKEN,     // xapp-... (Socket Mode)
-  socketMode: true,
-});
+const token = process.env.SLACK_BOT_TOKEN;       // xoxb-...
+const appToken = process.env.SLACK_APP_TOKEN;     // xapp-... (Socket Mode)
+if (!token || !appToken) {
+  throw new Error("SLACK_BOT_TOKEN and SLACK_APP_TOKEN must be set");
+}
+
+const app = new App({ token, appToken, socketMode: true });
 
 // Listen for messages mentioning the bot
 app.event("app_mention", async ({ event, say }) => {
@@ -583,11 +585,13 @@ When a Slack user sends a message, the bot resolves their Slack user ID to an en
 
 `~/.config/aidevops/slack-bot.json` (600 permissions):
 
+> **Security**: Store `botToken`, `appToken`, and `signingSecret` in gopass (`aidevops secret set slack-bot-token`), not in this JSON file. Reference them via environment variables or `credentials.sh`. The values below are placeholders only.
+
 ```json
 {
-  "botToken": "xoxb-...",
-  "appToken": "xapp-...",
-  "signingSecret": "",
+  "botToken": "stored-in-gopass",
+  "appToken": "stored-in-gopass",
+  "signingSecret": "stored-in-gopass",
   "socketMode": true,
   "allowedChannels": ["C04ABCDEF", "C04GHIJKL"],
   "allowedUsers": [],

--- a/.agents/services/communications/telegram.md
+++ b/.agents/services/communications/telegram.md
@@ -520,9 +520,9 @@ bot.command("run", adminOnly, async (ctx) => {
 
   await ctx.reply(`Dispatching: ${command}`);
 
-  // Dispatch via runner-helper.sh
+  // Dispatch via runner-helper.sh (use array args to prevent command injection)
   const proc = Bun.spawn(
-    ["bash", "-c", `runner-helper.sh dispatch "${command}"`],
+    ["runner-helper.sh", "dispatch", command],
     { stdout: "pipe", stderr: "pipe" }
   );
   const output = await new Response(proc.stdout).text();

--- a/.agents/services/communications/urbit.md
+++ b/.agents/services/communications/urbit.md
@@ -445,7 +445,10 @@ sse.listen({
       if (data.json?.["add-nodes"]) {
         const nodes = data.json["add-nodes"].nodes
         for (const [index, node] of Object.entries(nodes)) {
-          const post = (node as { post: { author: string; contents: { text?: string }[] } }).post
+          // Runtime type check instead of unsafe type assertion
+          const nodeObj = node as Record<string, unknown>
+          if (!nodeObj?.post || typeof nodeObj.post !== "object") continue
+          const post = nodeObj.post as { author: string; contents: { text?: string }[] }
           if (post.author !== SHIP_NAME) {
             const textContent = post.contents
               .filter((c: { text?: string }) => c.text)


### PR DESCRIPTION
## Summary

Address all code quality review feedback from PRs #2771, #2765, #2769, #2770 on the t1385 chat platform integration docs.

### Critical (command injection)
- **telegram.md**: Replace `Bun.spawn(["bash", "-c", ...])` with `Bun.spawn(["runner-helper.sh", "dispatch", command])` — array args prevent shell interpretation
- **discord.md**: Replace `execSync` with async `execFile` + array args
- **msteams.md**: Replace `execSync` with async `execFile` + array args

### High (credential exposure / auth bypass)
- **google-chat.md**: Emphasize JWT verification as CRITICAL/mandatory, not just recommended
- **imessage.md**: Replace `?password=` query parameter with `Authorization: Bearer` header in all examples (query strings are logged by servers/proxies)

### Medium (robustness / best practices)
- **discord.md**: Replace `process.env.X!` non-null assertions with explicit validation + error messages
- **slack.md**: Add env var validation; add gopass security note to config JSON
- **msteams.md**: Add env var validation; add gopass security note to config; remove deprecated `Client.init()` in favour of reference to modern `initWithMiddleware` section
- **urbit.md**: Replace unsafe `as { post: ... }` type assertion with runtime type guard

### Reviewed but not changed (review bot was incorrect)
- **urbit.md `sampel-palnet`**: This is the correct Urbit convention for sample ship names (like `example.com`), not a typo of "sampel-planet"
- **urbit.md vere repo**: Our version already points to `github.com/urbit/urbit` (correct), not the archived `vere` repo
- **urbit.md Airlock**: Our version doesn't reference the deprecated Airlock name

## Files Changed
7 files, 76 insertions, 54 deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication and integration guides for Discord, iMessage, MS Teams, Slack, Telegram, and Urbit services
  * Enhanced credential validation with explicit error handling for Discord, MS Teams, and Slack
  * Changed iMessage authentication from query parameters to secure header-based method
  * Improved command execution safety practices across services to prevent injection attacks
  * Added security recommendations for credential storage and verification procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->