### PR TITLE
t1386: Post-merge review feedback scanner

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -7,7 +7,8 @@
 #
 # Usage: post-merge-review-scanner.sh {scan|dry-run|help} [REPO]
 # Env:   SCANNER_DAYS (default 7), SCANNER_MAX_ISSUES (default 10),
-#        SCANNER_LABEL (default review-followup)
+#        SCANNER_LABEL (default review-followup),
+#        SCANNER_PR_LIMIT (default 1000)
 #
 # t1386: https://github.com/marcusquinn/aidevops/issues/2785
 set -euo pipefail
@@ -15,6 +16,7 @@ set -euo pipefail
 SCANNER_DAYS="${SCANNER_DAYS:-7}"
 SCANNER_MAX_ISSUES="${SCANNER_MAX_ISSUES:-10}"
 SCANNER_LABEL="${SCANNER_LABEL:-review-followup}"
+SCANNER_PR_LIMIT="${SCANNER_PR_LIMIT:-1000}"
 BOT_RE="coderabbitai|gemini-code-assist|claude-review|gpt-review"
 ACT_RE="should|consider|fix|change|update|refactor|missing|add"
 
@@ -33,21 +35,22 @@ get_lookback_date() {
 fetch_actionable() {
 	local repo="$1" pr="$2"
 	local jq_f='[.[] | select(.user.login | test("'"$BOT_RE"'";"i"))
-		| select(.body | test("'"$ACT_RE"'";"i"))
-		| "\(.user.login)|\(.path // "")|\(.body | gsub("\n";" ") | .[:200])"] | .[]'
+		| select((.body // "") | test("'"$ACT_RE"'";"i"))
+		| "\(.user.login)|\(.path // "")|\((.body // "") | gsub("\n";" ") | .[:200])"] | .[]'
 	{ gh api "repos/${repo}/pulls/${pr}/comments" --paginate 2>/dev/null || echo '[]'; } |
-		jq -r "$jq_f" 2>/dev/null || true
+		jq -r "$jq_f"
 	local jq_r='[.[] | select(.user.login | test("'"$BOT_RE"'";"i"))
-		| select(.body | test("'"$ACT_RE"'";"i"))
-		| "\(.user.login)||\(.body | gsub("\n";" ") | .[:200])"] | .[]'
+		| select((.body // "") | test("'"$ACT_RE"'";"i"))
+		| "\(.user.login)||\((.body // "") | gsub("\n";" ") | .[:200])"] | .[]'
 	{ gh api "repos/${repo}/pulls/${pr}/reviews" --paginate 2>/dev/null || echo '[]'; } |
-		jq -r "$jq_r" 2>/dev/null || true
+		jq -r "$jq_r"
 }
 
 issue_exists() {
 	local repo="$1" pr="$2" count
+	local title_query="Review followup: PR #${pr} —"
 	count=$(gh issue list --repo "$repo" --label "$SCANNER_LABEL" \
-		--search "PR #${pr}" --state open --json number --jq 'length' 2>/dev/null || echo "0")
+		--search "in:title \"${title_query}\"" --state all --json number --jq 'length' 2>/dev/null || echo "0")
 	[[ "$count" -gt 0 ]]
 }
 
@@ -80,7 +83,7 @@ do_scan() {
 	log "Scanning ${repo} since ${since_date} (${SCANNER_DAYS}d)"
 	local pr_numbers
 	pr_numbers=$(gh pr list --state merged --search "merged:>${since_date}" \
-		--repo "$repo" --json number --jq '.[].number' 2>/dev/null || echo "")
+		--repo "$repo" --limit "$SCANNER_PR_LIMIT" --json number --jq '.[].number' 2>/dev/null || echo "")
 	if [[ -z "$pr_numbers" ]]; then
 		log "No merged PRs found"
 		return 0
@@ -108,7 +111,7 @@ do_scan() {
 		done <<<"$hits"
 		[[ -z "$summary" ]] && continue
 		log "PR #${pr}: creating issue"
-		create_issue "$repo" "$pr" "$pr_title" "$(echo -e "$summary")" "$dry_run"
+		create_issue "$repo" "$pr" "$pr_title" "$(printf '%b' "$summary")" "$dry_run"
 		issues_created=$((issues_created + 1))
 	done <<<"$pr_numbers"
 	log "Done. Issues created: ${issues_created}"

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -38,12 +38,12 @@ fetch_actionable() {
 		| select((.body // "") | test("'"$ACT_RE"'";"i"))
 		| "\((.user.login // ""))|\(.path // "")|\((.body // "") | gsub("\n";" ") | .[:200])"] | .[]'
 	{ gh api "repos/${repo}/pulls/${pr}/comments" --paginate || echo '[]'; } |
-		jq -r "$jq_f" || true
+		jq -r "$jq_f"
 	local jq_r='[.[] | select((.user.login // "") | test("'"$BOT_RE"'";"i"))
 		| select((.body // "") | test("'"$ACT_RE"'";"i"))
 		| "\((.user.login // ""))||\((.body // "") | gsub("\n";" ") | .[:200])"] | .[]'
 	{ gh api "repos/${repo}/pulls/${pr}/reviews" --paginate || echo '[]'; } |
-		jq -r "$jq_r" || true
+		jq -r "$jq_r"
 }
 
 issue_exists() {

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# post-merge-review-scanner.sh — Scan merged PRs for unactioned review bot feedback
+#
+# Finds actionable suggestions from AI review bots (CodeRabbit, Gemini Code
+# Assist, claude-review, gpt-review) on recently merged PRs and creates
+# GitHub issues for follow-up. Idempotent — skips PRs with existing issues.
+#
+# Usage: post-merge-review-scanner.sh {scan|dry-run|help} [REPO]
+# Env:   SCANNER_DAYS (default 7), SCANNER_MAX_ISSUES (default 10),
+#        SCANNER_LABEL (default review-followup)
+#
+# t1386: https://github.com/marcusquinn/aidevops/issues/2785
+set -euo pipefail
+
+SCANNER_DAYS="${SCANNER_DAYS:-7}"
+SCANNER_MAX_ISSUES="${SCANNER_MAX_ISSUES:-10}"
+SCANNER_LABEL="${SCANNER_LABEL:-review-followup}"
+BOT_RE="coderabbitai|gemini-code-assist|claude-review|gpt-review"
+ACT_RE="should|consider|fix|change|update|refactor|missing|add"
+
+log() { echo "[scanner] $*" >&2; }
+
+get_lookback_date() {
+	local days="$1"
+	if date --version >/dev/null 2>&1; then
+		date -d "${days} days ago" -u +%Y-%m-%dT%H:%M:%SZ
+	else
+		date -u -v-"${days}"d +%Y-%m-%dT%H:%M:%SZ
+	fi
+}
+
+# Fetch actionable bot comments for a PR. Output: "bot|path|snippet" per line.
+fetch_actionable() {
+	local repo="$1" pr="$2"
+	local jq_f='[.[] | select(.user.login | test("'"$BOT_RE"'";"i"))
+		| select(.body | test("'"$ACT_RE"'";"i"))
+		| "\(.user.login)|\(.path // "")|\(.body | gsub("\n";" ") | .[:200])"] | .[]'
+	{ gh api "repos/${repo}/pulls/${pr}/comments" --paginate 2>/dev/null || echo '[]'; } |
+		jq -r "$jq_f" 2>/dev/null || true
+	local jq_r='[.[] | select(.user.login | test("'"$BOT_RE"'";"i"))
+		| select(.body | test("'"$ACT_RE"'";"i"))
+		| "\(.user.login)||\(.body | gsub("\n";" ") | .[:200])"] | .[]'
+	{ gh api "repos/${repo}/pulls/${pr}/reviews" --paginate 2>/dev/null || echo '[]'; } |
+		jq -r "$jq_r" 2>/dev/null || true
+}
+
+issue_exists() {
+	local repo="$1" pr="$2" count
+	count=$(gh issue list --repo "$repo" --label "$SCANNER_LABEL" \
+		--search "PR #${pr}" --state open --json number --jq 'length' 2>/dev/null || echo "0")
+	[[ "$count" -gt 0 ]]
+}
+
+create_issue() {
+	local repo="$1" pr="$2" pr_title="$3" summary="$4" dry_run="$5"
+	local title="Review followup: PR #${pr} — ${pr_title}"
+	if [[ "$dry_run" == "true" ]]; then
+		log "[DRY-RUN] Would create: $title"
+		return 0
+	fi
+	gh label create "$SCANNER_LABEL" --repo "$repo" \
+		--description "Unaddressed review bot feedback" --color "D4C5F9" 2>/dev/null || true
+	local body
+	body="## Unaddressed review bot suggestions
+
+PR #${pr} was merged with unaddressed review bot feedback.
+**Source PR:** https://github.com/${repo}/pull/${pr}
+
+### Actionable comments
+
+${summary}
+---
+*Auto-created by post-merge-review-scanner.sh (t1386)*"
+	gh issue create --repo "$repo" --title "$title" --label "$SCANNER_LABEL" --body "$body"
+}
+
+do_scan() {
+	local repo="$1" dry_run="$2" since_date
+	since_date=$(get_lookback_date "$SCANNER_DAYS")
+	log "Scanning ${repo} since ${since_date} (${SCANNER_DAYS}d)"
+	local pr_numbers
+	pr_numbers=$(gh pr list --state merged --search "merged:>${since_date}" \
+		--repo "$repo" --json number --jq '.[].number' 2>/dev/null || echo "")
+	if [[ -z "$pr_numbers" ]]; then
+		log "No merged PRs found"
+		return 0
+	fi
+	local issues_created=0
+	while IFS= read -r pr; do
+		[[ -z "$pr" ]] && continue
+		if [[ "$issues_created" -ge "$SCANNER_MAX_ISSUES" ]]; then
+			log "Max issues reached (${SCANNER_MAX_ISSUES})"
+			break
+		fi
+		if issue_exists "$repo" "$pr"; then
+			log "PR #${pr}: issue exists, skip"
+			continue
+		fi
+		local hits
+		hits=$(fetch_actionable "$repo" "$pr")
+		[[ -z "$hits" ]] && continue
+		local pr_title summary=""
+		pr_title=$(gh pr view "$pr" --repo "$repo" --json title --jq '.title' 2>/dev/null || echo "Unknown")
+		while IFS='|' read -r bot path snippet; do
+			local ref=""
+			[[ -n "$path" ]] && ref=" (\`${path}\`)"
+			summary="${summary}- **${bot}**${ref}: ${snippet}...\n"
+		done <<<"$hits"
+		[[ -z "$summary" ]] && continue
+		log "PR #${pr}: creating issue"
+		create_issue "$repo" "$pr" "$pr_title" "$(echo -e "$summary")" "$dry_run"
+		issues_created=$((issues_created + 1))
+	done <<<"$pr_numbers"
+	log "Done. Issues created: ${issues_created}"
+	return 0
+}
+
+main() {
+	local command="${1:-}" repo="${2:-}"
+	if [[ -z "$command" ]]; then
+		echo "Usage: $(basename "$0") {scan|dry-run|help} [REPO]"
+		return 2
+	fi
+	if [[ -z "$repo" ]]; then
+		repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+		[[ -z "$repo" ]] && {
+			echo "ERROR: Cannot determine repo" >&2
+			return 1
+		}
+	fi
+	case "$command" in
+	scan) do_scan "$repo" "false" ;;
+	dry-run) do_scan "$repo" "true" ;;
+	-h | --help | help) echo "Usage: $(basename "$0") {scan|dry-run|help} [REPO]" ;;
+	*)
+		echo "ERROR: Unknown command '$command'" >&2
+		return 2
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -34,23 +34,24 @@ get_lookback_date() {
 # Fetch actionable bot comments for a PR. Output: "bot|path|snippet" per line.
 fetch_actionable() {
 	local repo="$1" pr="$2"
-	local jq_f='[.[] | select(.user.login | test("'"$BOT_RE"'";"i"))
+	local jq_f='[.[] | select((.user.login // "") | test("'"$BOT_RE"'";"i"))
 		| select((.body // "") | test("'"$ACT_RE"'";"i"))
-		| "\(.user.login)|\(.path // "")|\((.body // "") | gsub("\n";" ") | .[:200])"] | .[]'
-	{ gh api "repos/${repo}/pulls/${pr}/comments" --paginate 2>/dev/null || echo '[]'; } |
-		jq -r "$jq_f"
-	local jq_r='[.[] | select(.user.login | test("'"$BOT_RE"'";"i"))
+		| "\((.user.login // ""))|\(.path // "")|\((.body // "") | gsub("\n";" ") | .[:200])"] | .[]'
+	{ gh api "repos/${repo}/pulls/${pr}/comments" --paginate || echo '[]'; } |
+		jq -r "$jq_f" || true
+	local jq_r='[.[] | select((.user.login // "") | test("'"$BOT_RE"'";"i"))
 		| select((.body // "") | test("'"$ACT_RE"'";"i"))
-		| "\(.user.login)||\((.body // "") | gsub("\n";" ") | .[:200])"] | .[]'
-	{ gh api "repos/${repo}/pulls/${pr}/reviews" --paginate 2>/dev/null || echo '[]'; } |
-		jq -r "$jq_r"
+		| "\((.user.login // ""))||\((.body // "") | gsub("\n";" ") | .[:200])"] | .[]'
+	{ gh api "repos/${repo}/pulls/${pr}/reviews" --paginate || echo '[]'; } |
+		jq -r "$jq_r" || true
 }
 
 issue_exists() {
 	local repo="$1" pr="$2" count
 	local title_query="Review followup: PR #${pr} —"
 	count=$(gh issue list --repo "$repo" --label "$SCANNER_LABEL" \
-		--search "in:title \"${title_query}\"" --state all --json number --jq 'length' 2>/dev/null || echo "0")
+		--search "in:title \"${title_query}\"" --state all --limit 100 \
+		--json number --jq 'length' || echo "0")
 	[[ "$count" -gt 0 ]]
 }
 
@@ -62,7 +63,7 @@ create_issue() {
 		return 0
 	fi
 	gh label create "$SCANNER_LABEL" --repo "$repo" \
-		--description "Unaddressed review bot feedback" --color "D4C5F9" 2>/dev/null || true
+		--description "Unaddressed review bot feedback" --color "D4C5F9" || true
 	local body
 	body="## Unaddressed review bot suggestions
 
@@ -83,7 +84,7 @@ do_scan() {
 	log "Scanning ${repo} since ${since_date} (${SCANNER_DAYS}d)"
 	local pr_numbers
 	pr_numbers=$(gh pr list --state merged --search "merged:>${since_date}" \
-		--repo "$repo" --limit "$SCANNER_PR_LIMIT" --json number --jq '.[].number' 2>/dev/null || echo "")
+		--repo "$repo" --limit "$SCANNER_PR_LIMIT" --json number --jq '.[].number' || echo "")
 	if [[ -z "$pr_numbers" ]]; then
 		log "No merged PRs found"
 		return 0
@@ -103,15 +104,15 @@ do_scan() {
 		hits=$(fetch_actionable "$repo" "$pr")
 		[[ -z "$hits" ]] && continue
 		local pr_title summary=""
-		pr_title=$(gh pr view "$pr" --repo "$repo" --json title --jq '.title' 2>/dev/null || echo "Unknown")
+		pr_title=$(gh pr view "$pr" --repo "$repo" --json title --jq '.title' || echo "Unknown")
 		while IFS='|' read -r bot path snippet; do
 			local ref=""
 			[[ -n "$path" ]] && ref=" (\`${path}\`)"
-			summary="${summary}- **${bot}**${ref}: ${snippet}...\n"
+			printf -v summary '%s- **%s**%s: %s...\n' "$summary" "$bot" "$ref" "$snippet"
 		done <<<"$hits"
 		[[ -z "$summary" ]] && continue
 		log "PR #${pr}: creating issue"
-		create_issue "$repo" "$pr" "$pr_title" "$(printf '%b' "$summary")" "$dry_run"
+		create_issue "$repo" "$pr" "$pr_title" "$summary" "$dry_run"
 		issues_created=$((issues_created + 1))
 	done <<<"$pr_numbers"
 	log "Done. Issues created: ${issues_created}"
@@ -125,7 +126,7 @@ main() {
 		return 2
 	fi
 	if [[ -z "$repo" ]]; then
-		repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+		repo=$(gh repo view --json nameWithOwner -q .nameWithOwner || echo "")
 		[[ -z "$repo" ]] && {
 			echo "ERROR: Cannot determine repo" >&2
 			return 1


### PR DESCRIPTION
## Summary

- Adds `.agents/scripts/post-merge-review-scanner.sh` — scans merged PRs for unaddressed AI review bot suggestions and creates GitHub issues for follow-up
- Supports `scan` (creates issues) and `dry-run` (preview only) modes
- Configurable via env vars: `SCANNER_DAYS` (lookback window, default 7), `SCANNER_MAX_ISSUES` (cap per run, default 10), `SCANNER_LABEL` (issue label, default `review-followup`)

## Details

Detects actionable comments from CodeRabbit, Gemini Code Assist, claude-review, and gpt-review bots containing keywords: should, consider, fix, change, update, refactor, missing, add. Idempotent — skips PRs that already have a follow-up issue.

**Verification:**
- ShellCheck: zero violations
- `help` command: works
- `dry-run marcusquinn/aidevops`: found 10 PRs with unaddressed bot feedback (correctly capped at SCANNER_MAX_ISSUES)
- 142 lines (under 150 limit)

Closes #2785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated scan of merged PRs to detect actionable feedback from AI review tools.
  * Automatically creates labeled GitHub follow-up issues summarizing actionable items and linking the PR.
  * Configurable scan window, per-run issue and PR limits, label selection, and dry-run mode for safe testing.
  * Idempotent behavior: skips PRs with existing follow-up issues to avoid duplicates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->