### PR TITLE
fix: replace token-like example with obvious placeholder in telegram.md

### DIFF
--- a/.agents/services/communications/telegram.md
+++ b/.agents/services/communications/telegram.md
@@ -111,7 +111,7 @@ npm install grammy
 1. Open Telegram and search for `@BotFather`
 2. Send `/newbot` and follow the prompts
 3. Choose a name (display name) and username (must end in `bot`)
-4. BotFather returns an API token: `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`
+4. BotFather returns an API token (format: `<bot-id>:<auth-token>`, e.g. `123456789:YOUR-TOKEN-FROM-BOTFATHER`)
 5. Store the token securely (see [Security Considerations](#security-considerations))
 
 **BotFather commands**:
@@ -448,7 +448,7 @@ The proprietary server means there is **no way to independently verify** what ha
 gopass insert aidevops/telegram/bot-token
 
 # Or via credentials.sh (600 permissions)
-echo 'export TELEGRAM_BOT_TOKEN="123456:ABC..."' >> ~/.config/aidevops/credentials.sh
+echo 'export TELEGRAM_BOT_TOKEN="<your-token>"' >> ~/.config/aidevops/credentials.sh
 
 # NEVER commit tokens to git
 # NEVER log tokens in output


### PR DESCRIPTION
## Summary

- Resolve both GitHub secret scanning alerts (#1 and #2) — both false positives from fake/example credentials
- Replace example Telegram bot token in `telegram.md` that matched the real token regex and triggered alert #2
- Add inline comment to MongoDB test fixture in `leak-detector.test.ts` explaining it's an intentionally fake credential (alert #1)
- Add `**/leak-detector.test.*` to `.secretlintignore` since leak-detector tests must contain realistic-looking secrets by design

## Alert #1 — MongoDB Atlas URI (`used_in_tests`)

- **File**: `.agents/scripts/simplex-bot/src/leak-detector.test.ts:155`
- **Fix**: Inline comment + `.secretlintignore` entry. Test fixture kept realistic since that's the point of a leak detector test.

## Alert #2 — Telegram Bot Token (`false_positive`)

- **File**: `.agents/services/communications/telegram.md:114`
- **Fix**: Replaced `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11` (matched `\d+:[A-Za-z0-9_-]{35}`) with `123456789:YOUR-TOKEN-FROM-BOTFATHER` (won't match scanner patterns).