### PR TITLE
fix: session-distill-helper.sh jq error on grep -c zero matches

### DIFF
--- a/.agents/scripts/session-distill-helper.sh
+++ b/.agents/scripts/session-distill-helper.sh
@@ -65,12 +65,14 @@ analyze_session() {
 
 	# Check for error patterns in recent commits
 	local error_fixes
-	error_fixes=$(echo "$recent_commits" | grep -ci "fix\|error\|bug\|issue" || echo "0")
+	error_fixes=$(echo "$recent_commits" | grep -ci "fix\|error\|bug\|issue" || true)
+	[[ -z "$error_fixes" ]] && error_fixes=0
 
 	# Check TODO.md for completed tasks
 	local completed_tasks
 	if [[ -f "TODO.md" ]]; then
-		completed_tasks=$(grep -c "^\- \[x\]" TODO.md 2>/dev/null || echo "0")
+		completed_tasks=$(grep -c "^\- \[x\]" TODO.md 2>/dev/null || true)
+		[[ -z "$completed_tasks" ]] && completed_tasks=0
 	else
 		completed_tasks="0"
 	fi


### PR DESCRIPTION
## Summary

- `grep -c` exits non-zero when zero matches are found, causing `|| echo "0"` to append a second `0` to the captured output — producing `"0\n0"` which is not valid JSON and fails `jq --argjson`
- Replaced `|| echo "0"` with `|| true` on both affected lines, then added an empty-string guard to default to `0`
- Affects `error_fixes` (line 68) and `completed_tasks` (line 73) in `analyze_session()`

## Verification

ShellCheck passes (only pre-existing SC1091 info-level finding for sourced script).

Closes #2790

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling and robustness in internal session analysis scripts to ensure reliable result counting in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->