### PR TITLE
t2793: fix pulse external-contributor comment spam — use REST API for labels

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -81,7 +81,7 @@ perm=$(echo "$response" | tail -1 | jq -r '.permission // empty' 2>/dev/null)
 # Idempotency guard: skip if already labelled (pulse runs every 2 minutes)
 if ! gh pr view <number> --repo <slug> --json labels --jq '.labels[].name' 2>/dev/null | grep -q '^external-contributor$'; then
   gh pr comment <number> --repo <slug> --body "This PR is from an external contributor (@<author>). Auto-merge is disabled for external PRs — a maintainer must review and merge manually."
-  gh pr edit <number> --repo <slug> --add-label "external-contributor" 2>/dev/null || true
+  gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' 2>/dev/null || true
 fi
 ```
 
@@ -243,7 +243,7 @@ gh pr comment <number> --repo <slug> --body "This PR appears orphaned — no act
 2. **Add the `status:orphaned` label:**
 
 ```bash
-gh pr edit <number> --repo <slug> --add-label "status:orphaned" 2>/dev/null || true
+gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=status:orphaned' 2>/dev/null || true
 ```
 
 3. **Flag the corresponding issue for re-dispatch.** Find the issue referenced in the PR title (task ID pattern `tNNN:` or `Issue #NNN`). If the issue exists and is labelled `status:in-progress` or `status:in-review`, relabel it to `status:available` so the next dispatch cycle picks it up:


### PR DESCRIPTION
## Summary

- Replace `gh pr edit --add-label` with `gh api repos/<slug>/issues/<number>/labels -X POST` REST endpoint in two locations in `pulse.md`
- The GraphQL-backed `gh pr edit` fails with "Projects (classic) is being deprecated" warning (exit 1), preventing label application and breaking the idempotency guard
- This caused 17+ duplicate "external contributor" comments on PR #2792 because the label was never applied and the guard never triggered

## Changes

**`.agents/scripts/commands/pulse.md`** — two one-line replacements:

1. **Line 84** (external-contributor gate): `gh pr edit --add-label "external-contributor"` → `gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor'`
2. **Line 246** (orphaned PR scanner): `gh pr edit --add-label "status:orphaned"` → `gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=status:orphaned'`

Both retain the `2>/dev/null || true` error suppression for resilience.

## Why REST API

The GitHub REST endpoint `POST /repos/{owner}/{repo}/issues/{number}/labels` is not affected by the GraphQL Projects deprecation. It returns a clean 200 and applies the label reliably. This was already validated manually on PR #2792.

Closes #2793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PR labeling process to use an alternative method for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->