### PR TITLE
t2800: fix pulse idempotency guard for external-contributor label check

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -79,18 +79,22 @@ perm=$(echo "$response" | tail -1 | jq -r '.permission // empty' 2>/dev/null)
 
 ```bash
 # Idempotency guard: skip if already labelled OR already commented (belt-and-suspenders).
-# IMPORTANT: Do NOT suppress stderr on the label check — a failed API call must not
-# silently bypass the guard (root cause of duplicate comments in #2795).
-labels=$(gh pr view <number> --repo <slug> --json labels --jq '.labels[].name' 2>&1) || true
-if echo "$labels" | grep -q '^external-contributor$'; then
+# Uses jq any() for a clean boolean result — avoids grep anchor issues with multi-line
+# output that caused duplicate comments (#2795, #2800).
+has_label=$(gh pr view <number> --repo <slug> --json labels --jq 'any(.labels[]; .name == "external-contributor")' 2>&1) || true
+if [ "$has_label" = "true" ]; then
   : # Already labelled — skip
-elif gh pr view <number> --repo <slug> --json comments --jq '.comments[].body' 2>&1 | grep -qiF 'external contributor'; then
-  # Comment already exists but label is missing — re-add the label only
-  gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' 2>/dev/null || true
 else
-  # Neither label nor comment exists — post comment and add label atomically
-  gh pr comment <number> --repo <slug> --body "This PR is from an external contributor (@<author>). Auto-merge is disabled for external PRs — a maintainer must review and merge manually." \
-    && gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' 2>/dev/null || true
+  # Label not found (or API failed) — check for existing comment as fallback
+  existing_comment=$(gh pr view <number> --repo <slug> --json comments --jq '[.comments[].body | select(test("external contributor"; "i"))] | length' 2>&1) || true
+  if [ "$existing_comment" != "0" ] && [ -n "$existing_comment" ]; then
+    # Comment already exists but label is missing — re-add the label only
+    gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' 2>/dev/null || true
+  else
+    # Neither label nor comment exists — post comment and add label atomically
+    gh pr comment <number> --repo <slug> --body "This PR is from an external contributor (@<author>). Auto-merge is disabled for external PRs — a maintainer must review and merge manually." \
+      && gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' 2>/dev/null || true
+  fi
 fi
 ```
 
@@ -100,9 +104,9 @@ Then skip to the next PR. Do NOT dispatch workers to fix failing CI on external 
 
 ```bash
 # Only comment once — check for existing permission-failure comment.
-# Do NOT suppress stderr — a failed API call must not bypass the guard.
-comments=$(gh pr view <number> --repo <slug> --json comments --jq '.comments[].body' 2>&1) || true
-if ! echo "$comments" | grep -qF 'Permission check failed'; then
+# Uses jq select+test for robust matching — avoids grep issues with multi-line output.
+perm_comment_count=$(gh pr view <number> --repo <slug> --json comments --jq '[.comments[].body | select(test("Permission check failed"))] | length' 2>&1) || true
+if [ "$perm_comment_count" = "0" ] || [ -z "$perm_comment_count" ]; then
   gh pr comment <number> --repo <slug> --body "Permission check failed for this PR (HTTP $http_status from collaborator permission API). Unable to determine if @<author> is a maintainer or external contributor. **A maintainer must review and merge this PR manually.** This is a fail-closed safety measure — the pulse will not auto-merge until the permission API succeeds."
 fi
 ```


### PR DESCRIPTION
## Summary

- Replace fragile `echo "$labels" | grep -q '^external-contributor$'` with `jq any(.labels[]; .name == "external-contributor")` which returns a clean boolean `true`/`false` — no grep anchor ambiguity with multi-line output, trailing whitespace, or stderr contamination
- Restructure the external-contributor gate from `if/elif/else` to `if/else { if/else }` so the comment-existence fallback is **always** reached when the label is not found (or API fails), instead of being skipped when grep fails unexpectedly
- Apply the same jq-based pattern to the permission-failure comment idempotency check for consistency

## Root Cause

PR #2796 fixed the `2>/dev/null` silent-failure issue but kept the `grep -q '^external-contributor$'` pattern. This pattern is fragile because:
1. `^` and `$` anchors can fail with trailing whitespace/CR in the output
2. `2>&1` mixes stderr into the label output, potentially breaking line boundaries
3. As agent prompt documentation (not a script), the LLM interpreting these instructions could misapply the grep pattern

The `elif` structure also meant that if the grep check failed (even when the label was present), the code would skip the comment-existence fallback and go straight to posting a new comment — producing duplicates every pulse cycle (~2 min).

## Verification

Tested against PR #2792 (the PR with 18 duplicate comments):
- `jq any()` correctly returns `true` when `external-contributor` label is present
- `jq select+test` correctly counts existing comments
- Edge cases verified: API failure, no labels, empty output — all fall through to comment check safely

Closes #2800

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the robustness of automation script handling for labels and comments by refining detection mechanisms and edge case management.
  * Enhanced fallback logic to ensure reliable label and comment operations in various workflow states.
  * Strengthened reliability against potential API inconsistencies and multi-state scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->