### PR TITLE
t1391: Fix duplicate external-contributor comments by moving idempotency guard to shell function

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -75,44 +75,28 @@ perm=$(echo "$response" | tail -1 | jq -r '.permission // empty' 2>/dev/null)
 
 1. **http_status=200 and perm is `admin`, `maintain`, or `write`** → the author is a maintainer. Proceed normally with CI checks and auto-merge.
 
-2. **http_status=200 and perm is `read` or `none`, OR http_status=404 (user not a collaborator)** → the author is an external contributor. **NEVER auto-merge external PRs.** Instead, check if this PR has already been flagged and, if not, comment requesting maintainer review:
+2. **http_status=200 and perm is `read` or `none`, OR http_status=404 (user not a collaborator)** → the author is an external contributor. **NEVER auto-merge external PRs.** Instead, call the deterministic helper function in `pulse-wrapper.sh` to check and flag the PR:
 
 ```bash
-# Idempotency guard: check BOTH label AND comment before posting (belt-and-suspenders).
-# CRITICAL: fail closed — if either API call fails, skip posting entirely.
-# Root cause of duplicate comments (#2795, #2802): API errors were treated as
-# "not found" instead of "unknown", causing the else branch to post every cycle.
+# Deterministic idempotency guard — lives in pulse-wrapper.sh, NOT inline.
+# This function checks BOTH label AND comment, fails closed on API errors,
+# and only posts when it can confirm the PR has not already been flagged.
+# Root cause of duplicate comments (#2795, #2802, #2809): inline bash in
+# pulse.md was re-implemented incorrectly by the LLM on each pulse cycle.
+# Moving to a shell function eliminates that failure mode entirely.
+#
+# Source the wrapper to get the function (it's in the same script directory):
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh 2>/dev/null || true
 
-# Step 1: Check for existing label (capture exit code separately from output)
-label_output=$(gh pr view <number> --repo <slug> --json labels --jq '.labels[].name' 2>/dev/null)
-label_exit=$?
-has_label=false
-if [[ $label_exit -eq 0 ]] && echo "$label_output" | grep -q '^external-contributor$'; then
-  has_label=true
+# Exit codes: 0=already flagged, 1=needs flagging, 2=API error (skip)
+check_external_contributor_pr <number> <slug> <author> --post
+ec=$?
+if [[ $ec -eq 2 ]]; then
+  : # API error — fail closed, next pulse retries
+elif [[ $ec -eq 0 ]]; then
+  : # Already flagged — nothing to do
 fi
-
-# Step 2: Check for existing comment
-comment_output=$(gh pr view <number> --repo <slug> --json comments --jq '.comments[].body' 2>/dev/null)
-comment_exit=$?
-has_comment=false
-if [[ $comment_exit -eq 0 ]] && echo "$comment_output" | grep -qiF 'external contributor'; then
-  has_comment=true
-fi
-
-# Step 3: Decide action based on results
-if [[ $label_exit -ne 0 || $comment_exit -ne 0 ]]; then
-  : # API error on label or comment check — fail closed, skip posting entirely.
-    # The next pulse cycle will retry. Never post when we can't confirm absence.
-elif [[ "$has_label" == "true" || "$has_comment" == "true" ]]; then
-  # Already flagged. Re-add label if missing (comment exists but label doesn't).
-  if [[ "$has_label" == "false" ]]; then
-    gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' 2>/dev/null || true
-  fi
-else
-  # Both API calls succeeded AND neither label nor comment exists — safe to post.
-  gh pr comment <number> --repo <slug> --body "This PR is from an external contributor (@<author>). Auto-merge is disabled for external PRs — a maintainer must review and merge manually." \
-    && gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' 2>/dev/null || true
-fi
+# ec=1 with --post means it just posted the comment and added the label
 ```
 
 Then skip to the next PR. Do NOT dispatch workers to fix failing CI on external PRs either — that's the contributor's responsibility.
@@ -120,15 +104,11 @@ Then skip to the next PR. Do NOT dispatch workers to fix failing CI on external 
 3. **Any other http_status (403, 429, 5xx) or empty/missing status (network error, auth failure)** → the permission check itself failed. **Fail closed: do NOT auto-merge, do NOT label as external-contributor.** Post a distinct comment asking for manual intervention:
 
 ```bash
-# Only comment once — check for existing permission-failure comment.
-# Fail closed: if the comment check API call itself fails, skip posting.
-perm_comments=$(gh pr view <number> --repo <slug> --json comments --jq '.comments[].body' 2>/dev/null)
-perm_comment_exit=$?
-if [[ $perm_comment_exit -ne 0 ]]; then
-  : # API error checking comments — fail closed, skip posting. Next pulse retries.
-elif ! echo "$perm_comments" | grep -qF 'Permission check failed'; then
-  gh pr comment <number> --repo <slug> --body "Permission check failed for this PR (HTTP $http_status from collaborator permission API). Unable to determine if @<author> is a maintainer or external contributor. **A maintainer must review and merge this PR manually.** This is a fail-closed safety measure — the pulse will not auto-merge until the permission API succeeds."
-fi
+# Deterministic idempotency guard — lives in pulse-wrapper.sh.
+# Checks for existing "Permission check failed" comment before posting.
+# Fails closed on API errors (exit code 2 = skip, next pulse retries).
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh 2>/dev/null || true
+check_permission_failure_pr <number> <slug> <author> "$http_status"
 ```
 
 Then skip to the next PR. The next pulse cycle will retry the permission check — if the API recovers, the PR will be processed normally.
@@ -488,4 +468,4 @@ Output a brief summary of what you did (past tense), then exit.
 9. **NEVER create an issue if one already exists for the same task ID.** Before `gh issue create`, check `gh issue list --repo <slug> --search "tNNN" --state all` to see if an issue with that task ID prefix already exists. If it does (open or closed), use the existing one — don't create a duplicate. This applies to both issue-sync-helper and manual issue creation.
 10. **NEVER ask the user anything.** You are headless. Decide and act.
 11. **NEVER close or modify issues with the `supervisor` label.** These are health dashboard issues managed by `pulse-wrapper.sh` — one per runner per repo. The wrapper handles dedup (closing old ones when creating new ones). If you close them, the wrapper creates replacements on the next cycle, producing churn. Similarly, NEVER create new `[Supervisor:*]` issues — the wrapper creates and updates them automatically. Your job is to act on task/PR issues, not manage supervisor infrastructure.
-12. **NEVER auto-merge PRs from external contributors or when the permission check fails.** Check author permission via `gh api -i repos/<slug>/collaborators/<author>/permission` before ANY merge — use `-i` to capture the HTTP status code. Only HTTP 200 with `admin`, `maintain`, or `write` permission = maintainer. HTTP 200 with `read`/`none`, or HTTP 404 = external contributor (comment + label). Any other HTTP status (403/429/5xx) or network failure = fail closed (distinct comment requesting manual intervention, no label, no merge). See "External contributor gate" in Step 3.
+12. **NEVER auto-merge PRs from external contributors or when the permission check fails.** Check author permission via `gh api -i repos/<slug>/collaborators/<author>/permission` before ANY merge — use `-i` to capture the HTTP status code. Only HTTP 200 with `admin`, `maintain`, or `write` permission = maintainer. HTTP 200 with `read`/`none`, or HTTP 404 = external contributor — call `check_external_contributor_pr` from `pulse-wrapper.sh`. Any other HTTP status (403/429/5xx) or network failure = fail closed — call `check_permission_failure_pr` from `pulse-wrapper.sh`. NEVER write inline idempotency checks — always use the helper functions. See "External contributor gate" in Step 3.

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -589,6 +589,145 @@ _compute_struggle_ratio() {
 }
 
 #######################################
+# Check and flag external-contributor PRs (t1391)
+#
+# Deterministic idempotency guard for the external-contributor comment.
+# Moved from pulse.md inline bash to a shell function because the LLM
+# kept getting the fail-closed logic wrong (4 prior fix attempts:
+# PRs #2794, #2796, #2801, #2803 — all in pulse.md prompt text).
+#
+# This is exactly the kind of logic that belongs in the harness, not
+# the prompt: it has one correct answer regardless of context.
+#
+# Arguments:
+#   $1 - PR number
+#   $2 - repo slug (owner/repo)
+#   $3 - PR author login
+#
+# Exit codes:
+#   0 - already flagged (label or comment exists) — no action needed
+#   1 - not yet flagged AND API calls succeeded — caller should post
+#   2 - API error (fail closed) — caller must skip, next pulse retries
+#
+# Side effects when exit=1 (caller invokes with --post):
+#   Posts the external-contributor comment and adds the label.
+#######################################
+check_external_contributor_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_author="$3"
+	local do_post="${4:-}"
+
+	# Validate arguments
+	if [[ -z "$pr_number" || -z "$repo_slug" || -z "$pr_author" ]]; then
+		echo "[pulse-wrapper] check_external_contributor_pr: missing arguments" >>"$LOGFILE"
+		return 2
+	fi
+
+	# Step 1: Check for existing label (capture exit code separately from output)
+	local label_output
+	label_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json labels --jq '.labels[].name' 2>/dev/null)
+	local label_exit=$?
+
+	local has_label=false
+	if [[ $label_exit -eq 0 ]] && echo "$label_output" | grep -q '^external-contributor$'; then
+		has_label=true
+	fi
+
+	# Step 2: Check for existing comment
+	local comment_output
+	comment_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body' 2>/dev/null)
+	local comment_exit=$?
+
+	local has_comment=false
+	if [[ $comment_exit -eq 0 ]] && echo "$comment_output" | grep -qiF 'external contributor'; then
+		has_comment=true
+	fi
+
+	# Step 3: Decide action based on results
+	if [[ $label_exit -ne 0 || $comment_exit -ne 0 ]]; then
+		# API error on label or comment check — fail closed, skip posting entirely.
+		# The next pulse cycle will retry. Never post when we can't confirm absence.
+		echo "[pulse-wrapper] check_external_contributor_pr: API error (label_exit=$label_exit, comment_exit=$comment_exit) for PR #$pr_number in $repo_slug — skipping (fail closed)" >>"$LOGFILE"
+		return 2
+	fi
+
+	if [[ "$has_label" == "true" || "$has_comment" == "true" ]]; then
+		# Already flagged. Re-add label if missing (comment exists but label doesn't).
+		if [[ "$has_label" == "false" ]]; then
+			gh api "repos/${repo_slug}/issues/${pr_number}/labels" \
+				-X POST -f 'labels[]=external-contributor' 2>/dev/null || true
+		fi
+		return 0
+	fi
+
+	# Both API calls succeeded AND neither label nor comment exists.
+	if [[ "$do_post" == "--post" ]]; then
+		# Safe to post — this is the only code path that creates a comment.
+		gh pr comment "$pr_number" --repo "$repo_slug" \
+			--body "This PR is from an external contributor (@${pr_author}). Auto-merge is disabled for external PRs — a maintainer must review and merge manually." &&
+			gh api "repos/${repo_slug}/issues/${pr_number}/labels" \
+				-X POST -f 'labels[]=external-contributor' 2>/dev/null || true
+		echo "[pulse-wrapper] check_external_contributor_pr: flagged PR #$pr_number in $repo_slug as external contributor (@$pr_author)" >>"$LOGFILE"
+	fi
+	return 1
+}
+
+#######################################
+# Check and post permission-failure comment on a PR (t1391)
+#
+# Companion to check_external_contributor_pr() for the case where the
+# collaborator permission API itself fails (403, 429, 5xx, network error).
+# Posts a distinct "Permission check failed" comment so a maintainer
+# knows to review manually. Idempotent — checks for existing comment
+# before posting, fails closed on API errors.
+#
+# Arguments:
+#   $1 - PR number
+#   $2 - repo slug (owner/repo)
+#   $3 - PR author login
+#   $4 - HTTP status code from the failed permission check
+#
+# Exit codes:
+#   0 - comment already exists or was just posted
+#   2 - API error checking for existing comment (fail closed, skip)
+#######################################
+check_permission_failure_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local pr_author="$3"
+	local http_status="${4:-unknown}"
+
+	if [[ -z "$pr_number" || -z "$repo_slug" || -z "$pr_author" ]]; then
+		echo "[pulse-wrapper] check_permission_failure_pr: missing arguments" >>"$LOGFILE"
+		return 2
+	fi
+
+	# Check for existing permission-failure comment (fail closed on API error)
+	local perm_comments
+	perm_comments=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body' 2>/dev/null)
+	local perm_exit=$?
+
+	if [[ $perm_exit -ne 0 ]]; then
+		echo "[pulse-wrapper] check_permission_failure_pr: API error (exit=$perm_exit) for PR #$pr_number in $repo_slug — skipping (fail closed)" >>"$LOGFILE"
+		return 2
+	fi
+
+	if echo "$perm_comments" | grep -qF 'Permission check failed'; then
+		# Already posted — nothing to do
+		return 0
+	fi
+
+	# Safe to post — no existing comment and API call succeeded
+	gh pr comment "$pr_number" --repo "$repo_slug" \
+		--body "Permission check failed for this PR (HTTP ${http_status} from collaborator permission API). Unable to determine if @${pr_author} is a maintainer or external contributor. **A maintainer must review and merge this PR manually.** This is a fail-closed safety measure — the pulse will not auto-merge until the permission API succeeds." \
+		2>/dev/null || true
+
+	echo "[pulse-wrapper] check_permission_failure_pr: posted permission-failure comment on PR #$pr_number in $repo_slug (HTTP $http_status)" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
 # Pre-fetch active worker processes (t216, t1367)
 #
 # Captures a snapshot of running worker processes so the pulse agent
@@ -1801,4 +1940,10 @@ calculate_max_workers() {
 	return 0
 }
 
-main "$@"
+# Only run main when executed directly, not when sourced.
+# The pulse agent sources this file to access helper functions
+# (check_external_contributor_pr, check_permission_failure_pr)
+# without triggering the full pulse lifecycle.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi


### PR DESCRIPTION
## Summary

- Moves the external-contributor idempotency guard from inline bash in `pulse.md` to deterministic shell functions in `pulse-wrapper.sh` (`check_external_contributor_pr()` and `check_permission_failure_pr()`)
- Adds source guard (`BASH_SOURCE` check) so `pulse-wrapper.sh` can be sourced for its functions without triggering the full pulse lifecycle
- Updates `pulse.md` to call the helper functions instead of re-implementing the logic inline each cycle

## Problem

PR #2792 accumulated 15+ identical "This PR is from an external contributor" comments posted by the pulse supervisor between 2026-03-03T20:30 and 2026-03-03T23:48. Despite 4 prior fix attempts (PRs #2794, #2796, #2801, #2803) — all modifying the inline bash pattern in `pulse.md` — the LLM kept re-implementing the fail-closed logic incorrectly on each pulse cycle.

## Root Cause

The idempotency check is **deterministic** — it has exactly one correct answer regardless of context. But it was encoded as prompt guidance that the LLM had to re-implement from scratch each cycle. Per the "Intelligence Over Determinism" principle, deterministic logic belongs in the harness (shell functions), not the prompt.

## Fix

Two new functions in `pulse-wrapper.sh`:

1. **`check_external_contributor_pr()`** — checks BOTH label AND comment, captures exit codes separately from output, fails closed on any API error, only posts when it can confirm the PR has not already been flagged. Exit codes: 0=already flagged, 1=needs flagging, 2=API error (skip).

2. **`check_permission_failure_pr()`** — companion for the permission API failure case. Checks for existing "Permission check failed" comment before posting. Fails closed on API errors.

Both functions log their actions to `$LOGFILE` for audit trail.

## Verification

- `shellcheck .agents/scripts/pulse-wrapper.sh` — zero violations
- Source guard tested: `source pulse-wrapper.sh` no longer triggers `main()`

Closes #2809