### PR TITLE
t2814: Remove 2>/dev/null from pulse external-contributor label API calls

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -106,12 +106,12 @@ if [[ $label_exit -ne 0 || $comment_exit -ne 0 ]]; then
 elif [[ "$has_label" == "true" || "$has_comment" == "true" ]]; then
   # Already flagged. Re-add label if missing (comment exists but label doesn't).
   if [[ "$has_label" == "false" ]]; then
-    gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' 2>/dev/null || true
+    gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' || true
   fi
 else
   # Both API calls succeeded AND neither label nor comment exists — safe to post.
   gh pr comment <number> --repo <slug> --body "This PR is from an external contributor (@<author>). Auto-merge is disabled for external PRs — a maintainer must review and merge manually." \
-    && gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' 2>/dev/null || true
+    && gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor' || true
 fi
 ```
 


### PR DESCRIPTION
## Summary

- Removed `2>/dev/null` stderr suppression from two `gh api` label POST calls in the external-contributor gate (lines 109 and 114)
- `|| true` already prevents script exit on non-zero — the stderr suppression was masking auth, network, and API errors that are critical for debugging

## Changes

**File:** `.agents/scripts/commands/pulse.md`

Both `gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=external-contributor'` calls in the external-contributor section now allow stderr to flow through while still using `|| true` to prevent script abort.

## Source

Gemini code review finding on PR #2803 (critical severity).

Closes #2814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error visibility for label management operations by displaying previously hidden error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->