### PR TITLE
GH#2821: Collapse redundant jq severity elif/else branches

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -589,7 +589,6 @@ _scan_single_pr() {
 		 elif ($body | test("high-priority\\.svg|severity:.*high|HIGH"; "i")) then "high"
 		 elif ($body | test("medium-priority\\.svg|severity:.*medium|MEDIUM"; "i")) then "medium"
 		 elif ($body | test("low-priority\\.svg|severity:.*low|LOW|nit"; "i")) then "low"
-		 elif ($reviewer == "human") then "medium"
 		 else "medium"
 		 end) as $severity |
 
@@ -636,7 +635,6 @@ _scan_single_pr() {
 		 elif ($body | test("high-priority\\.svg|severity:.*high|HIGH"; "i")) then "high"
 		 elif ($body | test("medium-priority\\.svg|severity:.*medium|MEDIUM"; "i")) then "medium"
 		 elif ($body | test("low-priority\\.svg|severity:.*low|LOW|nit"; "i")) then "low"
-		 elif ($reviewer == "human") then "medium"
 		 else "medium"
 		 end) as $severity |
 


### PR DESCRIPTION
## Summary

- Removed redundant `elif ($reviewer == "human") then "medium"` branches in the jq severity-extraction logic in `quality-feedback-helper.sh`
- Both the `elif` and the final `else` returned `"medium"`, so the `elif` was a no-op — collapsed into a single `else "medium"` branch
- Applied to both occurrences (review-body block ~line 592 and review-comment block ~line 639)

Closes #2821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Internal code cleanup with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->