### PR TITLE
fix: remove 2>/dev/null from gh pr view in check_external_contributor_pr

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -86,7 +86,7 @@ perm=$(echo "$response" | tail -1 | jq -r '.permission // empty' 2>/dev/null)
 # Moving to a shell function eliminates that failure mode entirely.
 #
 # Source the wrapper to get the function (it's in the same script directory):
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh 2>/dev/null || true
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh || true
 
 # Exit codes: 0=already flagged, 1=needs flagging, 2=API error (skip)
 check_external_contributor_pr <number> <slug> <author> --post
@@ -107,7 +107,7 @@ Then skip to the next PR. Do NOT dispatch workers to fix failing CI on external 
 # Deterministic idempotency guard — lives in pulse-wrapper.sh.
 # Checks for existing "Permission check failed" comment before posting.
 # Fails closed on API errors (exit code 2 = skip, next pulse retries).
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh 2>/dev/null || true
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh || true
 check_permission_failure_pr <number> <slug> <author> "$http_status"
 ```
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -628,7 +628,7 @@ check_external_contributor_pr() {
 
 	# Step 1: Check for existing label (capture exit code separately from output)
 	local label_output
-	label_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json labels --jq '.labels[].name' 2>/dev/null)
+	label_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json labels --jq '.labels[].name')
 	local label_exit=$?
 
 	local has_label=false
@@ -638,7 +638,7 @@ check_external_contributor_pr() {
 
 	# Step 2: Check for existing comment
 	local comment_output
-	comment_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body' 2>/dev/null)
+	comment_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body')
 	local comment_exit=$?
 
 	local has_comment=false


### PR DESCRIPTION
## Summary

- Removes `2>/dev/null` from two `gh pr view` commands in `check_external_contributor_pr()` (lines 631, 641 of `pulse-wrapper.sh`)
- The exit code is already captured via `$?` and checked before acting — stderr suppression only hides useful debugging info (auth errors, network failures, API issues)

Closes #2812