### PR TITLE
fix: add busy_timeout to sqliteExec() preventing database locked errors

### DIFF
--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -36,7 +36,7 @@ const DB_PATH = join(OBS_DIR, "llm-requests.db");
  */
 function sqliteExec(sql, timeout = 5000) {
   try {
-    return execSync(`sqlite3 "${DB_PATH}"`, {
+    return execSync(`sqlite3 -cmd ".timeout 5000" "${DB_PATH}"`, {
       input: sql,
       encoding: "utf-8",
       timeout,


### PR DESCRIPTION
## Summary

- Add `-cmd ".timeout 5000"` to the `sqlite3` invocation in `sqliteExec()` (`observability.mjs:39`), matching the established `_common.sh` `db()` wrapper pattern
- Without this, every `sqliteExec()` call had `busy_timeout=0` (SQLite default), causing instant "database is locked" failures on concurrent writes
- The existing `PRAGMA busy_timeout=5000` in `initDatabase()` only applied to that single connection — SQLite busy_timeout is per-connection, not persistent

## Changes

One-line change in `.agents/plugins/opencode-aidevops/observability.mjs`:

```diff
-    return execSync(`sqlite3 "${DB_PATH}"`, {
+    return execSync(`sqlite3 -cmd ".timeout 5000" "${DB_PATH}"`, {
```

## Verification

- `node --check` passes (syntax valid)
- Pattern matches `supervisor/_common.sh:20` and `memory/_common.sh:33`

Closes #2826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated SQLite query execution to enforce a 5-second operation timeout for database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->