### PR TITLE
t2819: replace 2>/dev/null with --silent on gh api label POST calls

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -276,7 +276,7 @@ gh pr comment <number> --repo <slug> --body "This PR appears orphaned — no act
 2. **Add the `status:orphaned` label:**
 
 ```bash
-gh api "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=status:orphaned' 2>/dev/null || true
+gh api --silent "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=status:orphaned' || true
 ```
 
 3. **Flag the corresponding issue for re-dispatch.** Find the issue referenced in the PR title (task ID pattern `tNNN:` or `Issue #NNN`). If the issue exists and is labelled `status:in-progress` or `status:in-review`, relabel it to `status:available` so the next dispatch cycle picks it up:

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -657,8 +657,8 @@ check_external_contributor_pr() {
 	if [[ "$has_label" == "true" || "$has_comment" == "true" ]]; then
 		# Already flagged. Re-add label if missing (comment exists but label doesn't).
 		if [[ "$has_label" == "false" ]]; then
-			gh api "repos/${repo_slug}/issues/${pr_number}/labels" \
-				-X POST -f 'labels[]=external-contributor' 2>/dev/null || true
+			gh api --silent "repos/${repo_slug}/issues/${pr_number}/labels" \
+				-X POST -f 'labels[]=external-contributor' || true
 		fi
 		return 0
 	fi
@@ -668,8 +668,8 @@ check_external_contributor_pr() {
 		# Safe to post — this is the only code path that creates a comment.
 		gh pr comment "$pr_number" --repo "$repo_slug" \
 			--body "This PR is from an external contributor (@${pr_author}). Auto-merge is disabled for external PRs — a maintainer must review and merge manually." &&
-			gh api "repos/${repo_slug}/issues/${pr_number}/labels" \
-				-X POST -f 'labels[]=external-contributor' 2>/dev/null || true
+			gh api --silent "repos/${repo_slug}/issues/${pr_number}/labels" \
+				-X POST -f 'labels[]=external-contributor' || true
 		echo "[pulse-wrapper] check_external_contributor_pr: flagged PR #$pr_number in $repo_slug as external contributor (@$pr_author)" >>"$LOGFILE"
 	fi
 	return 1


### PR DESCRIPTION
## Summary

- Replace `2>/dev/null` with `--silent` flag on three `gh api` label POST calls in `pulse.md` and `pulse-wrapper.sh`
- `2>/dev/null` suppresses all stderr including auth/network/API errors, making debugging difficult
- `--silent` only suppresses the successful JSON response body on stdout while preserving genuine error output on stderr

## Changes

**`.agents/scripts/commands/pulse.md`** (1 site):
- Line 279: orphaned PR `status:orphaned` label application

**`.agents/scripts/pulse-wrapper.sh`** (2 sites):
- Line 660: `external-contributor` label re-add (when comment exists but label is missing)
- Line 671: `external-contributor` label on first flag

All three retain `|| true` for resilience — the change only affects error visibility, not control flow.

## Context

Addresses quality-debt review feedback from Gemini on PR #2794. The original PR replaced `gh pr edit --add-label` with `gh api` REST calls (fixing a GraphQL deprecation issue), but used `2>/dev/null` for error suppression. The reviewer correctly noted this hides genuine errors and suggested `--silent` instead.

Closes #2819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation script configurations to improve error handling and output visibility in CI/CD workflows by refining GitHub CLI invocation behavior for label management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->