### PR TITLE
t1391: Improve actionability of conversational memory lookup guidance

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -251,8 +251,9 @@ Git is the primary audit trail for all work. Every change should be discoverable
 # every vague reference — match the source to the question.
 #
 # Tier 1 — Local cached (instant, zero cost):
-# 1. Cross-session memory (MCP): `mcp_aidevops_memory_recall` — curated signal,
-#    most likely to have the answer. Solutions, decisions, preferences, patterns.
+# 1. Cross-session memory: `memory-helper.sh recall "keywords"` (CLI) or
+#    `aidevops_memory_recall` (MCP tool) — curated signal, most likely to have
+#    the answer. Solutions, decisions, preferences, patterns.
 # 2. TODO.md + completed tasks: `rg "keyword" TODO.md` — task IDs, PR numbers,
 #    completion dates, brief descriptions of all past work.
 #
@@ -262,15 +263,21 @@ Git is the primary audit trail for all work. Every change should be discoverable
 # 4. Session transcripts (Claude Code): `~/.claude/transcripts/*.jsonl` — full
 #    JSONL conversation logs. `rg "keyword" ~/.claude/transcripts/`. Recovers
 #    exact conversation context, what was discussed, tool calls made.
+#    For structured field searches, pipe through jq:
+#    `rg -l "keyword" ~/.claude/transcripts/ | xargs -I{} jq 'select(.type=="assistant") | .message.content' {}`
 # 5. Session database (OpenCode): `~/.local/share/opencode/opencode.db` — SQLite
 #    with session + message tables. Find sessions by title, date, project directory.
 #    Schema: session(id,title,directory,time_created), message(id,session_id,data).
 #    Example: sqlite3 ~/.local/share/opencode/opencode.db "SELECT id,title FROM
 #    session WHERE title LIKE '%keyword%' ORDER BY time_created DESC LIMIT 5"
-# 6. Observability DB: `~/.aidevops/.agent-workspace/observability/llm-requests.db`
-#    — LLM request metadata, costs, models, tool calls per session.
-#    Tables: llm_requests(session_id,model_id,cost,tokens_total,timestamp),
-#    tool_calls(session_id,tool_name,intent,success,duration_ms).
+# 6. Observability metrics: `~/.aidevops/.agent-workspace/observability/metrics.jsonl`
+#    — JSONL log of LLM request metadata, costs, models, tokens per session.
+#    Fields per record: provider, model, session_id, request_id, project,
+#    input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+#    cost_input, cost_output, cost_total, stop_reason, git_branch, recorded_at.
+#    Example: jq -s '[.[] | select(.project=="aidevops")] | group_by(.model)
+#    | map({model:.[0].model, total_cost:([.[].cost_total] | add),
+#    requests:length})' ~/.aidevops/.agent-workspace/observability/metrics.jsonl
 #
 # Tier 3 — Remote targeted (API calls, need a specific number):
 # 7. GitHub issue/PR comments: `gh issue view {num} --comments --repo {slug}`,
@@ -294,7 +301,7 @@ Git is the primary audit trail for all work. Every change should be discoverable
 # Examples:
 # "Remember that auth fix?" → memory recall + git log.
 # "What did we discuss about the database schema?" → memory recall + transcripts.
-# "How much did last week's batch run cost?" → observability DB.
+# "How much did last week's batch run cost?" → observability metrics.
 # "What did the reviewer say about that PR?" → TODO.md (get PR#) + PR comments.
 # "Was there a discussion about the migration?" → GitHub discussions/wiki.
 


### PR DESCRIPTION
## Summary

- Addresses 4 medium-severity Gemini review findings from PR #2797 on `.agents/prompts/build.txt` (Conversational Memory Lookup section)
- Fixes inaccurate observability DB description (was SQLite, actually JSONL) and adds actionable command examples throughout

## Changes

**Finding 1** (line 254): Replaced non-runnable `mcp_aidevops_memory_recall` with actual CLI command (`memory-helper.sh recall "keywords"`) and correct MCP tool name (`aidevops_memory_recall`).

**Finding 2** (line 264): Added `jq` example for structured JSONL field searches in session transcripts, complementing the existing `rg` keyword search.

**Finding 3** (line 267): Already addressed — the OpenCode `sqlite3` example query was present in the current code. No change needed.

**Finding 4** (lines 270-273): Fixed incorrect description — observability storage is JSONL (`metrics.jsonl`), not SQLite (`llm-requests.db`). Added accurate field schema from `observability-helper.sh _write_metric()` and a `jq` query example for cost-by-model analysis.

Closes #2818
Closes #2827