### PR TITLE
fix: use full URL with {slug} placeholder in wiki clone example

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -288,7 +288,7 @@ Git is the primary audit trail for all work. Every change should be discoverable
 # 9. GitHub discussions: `gh api repos/{slug}/discussions` (if enabled).
 #    Long-form design discussions, RFCs, community Q&A.
 # 10. GitHub wiki: `gh api repos/{slug}/pages` or clone the wiki repo
-#    (`git clone {repo}.wiki.git`). Persistent documentation that may contain
+#    (`git clone https://github.com/{slug}.wiki.git`). Persistent documentation that may contain
 #    architectural decisions, onboarding guides, or historical context.
 #
 # Examples:


### PR DESCRIPTION
## Summary

- Fixed incomplete `git clone` command in `build.txt` wiki documentation (line 291)
- Changed `git clone {repo}.wiki.git` to `git clone https://github.com/{slug}.wiki.git` — making it a valid, executable URL with the consistent `{slug}` placeholder used throughout the file

Closes #2816