### PR TITLE
t1392: Fix CodeRabbit sweep first-run delta inflation

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1908,15 +1908,25 @@ ${type_breakdown}
 	local high_critical_delta=$((sweep_high_critical - prev_high_critical))
 	local trigger_active=false
 	local trigger_reasons=""
+	local is_first_run=false
 
-	# Condition 1: Quality gate is failing
+	# Detect first run: prev_gate is UNKNOWN when no state file exists.
+	# On first run, delta comparisons are meaningless (comparing against 0
+	# inflates every metric into a "spike"). Only condition 1 (gate status)
+	# is valid on first run. Conditions 2 and 3 require a prior baseline.
+	if [[ "$prev_gate" == "UNKNOWN" ]]; then
+		is_first_run=true
+	fi
+
+	# Condition 1: Quality gate is failing (valid on first run and subsequent)
 	if [[ "$sweep_gate_status" == "ERROR" || "$sweep_gate_status" == "WARN" ]]; then
 		trigger_active=true
 		trigger_reasons="quality gate ${sweep_gate_status}"
 	fi
 
 	# Condition 2: Issue count spiked by threshold or more
-	if [[ "$issue_delta" -ge "$CODERABBIT_ISSUE_SPIKE" ]]; then
+	# Skip on first run — delta vs 0 is not a real spike (t1392)
+	if [[ "$is_first_run" == false && "$issue_delta" -ge "$CODERABBIT_ISSUE_SPIKE" ]]; then
 		trigger_active=true
 		if [[ -n "$trigger_reasons" ]]; then
 			trigger_reasons="${trigger_reasons}, issue spike +${issue_delta}"
@@ -1926,7 +1936,8 @@ ${type_breakdown}
 	fi
 
 	# Condition 3: New high/critical severity findings
-	if [[ "$high_critical_delta" -gt 0 ]]; then
+	# Skip on first run — delta vs 0 is not a real increase (t1392)
+	if [[ "$is_first_run" == false && "$high_critical_delta" -gt 0 ]]; then
 		trigger_active=true
 		if [[ -n "$trigger_reasons" ]]; then
 			trigger_reasons="${trigger_reasons}, +${high_critical_delta} high/critical"
@@ -1948,9 +1959,13 @@ ${type_breakdown}
 "
 		echo "[pulse-wrapper] CodeRabbit: active review triggered for ${repo_slug} (${trigger_reasons})" >>"$LOGFILE"
 	else
+		local baseline_note=""
+		if [[ "$is_first_run" == true ]]; then
+			baseline_note=" (first run — baseline established, deltas will be computed from next sweep)"
+		fi
 		coderabbit_section="### CodeRabbit
 
-_Monitoring: ${sweep_total_issues} issues (delta: ${issue_delta}), gate ${sweep_gate_status}, ${sweep_high_critical} high/critical — no active review needed._
+_Monitoring: ${sweep_total_issues} issues (delta: ${issue_delta}), gate ${sweep_gate_status}, ${sweep_high_critical} high/critical — no active review needed.${baseline_note}_
 "
 	fi
 	tool_count=$((tool_count + 1))


### PR DESCRIPTION
## Summary

- Fixes CodeRabbit `@coderabbitai` review request being triggered unconditionally on the first sweep run after PR #2808 (t1390)
- Root cause: on first run, `_load_sweep_state()` returns `prev_issues=0`, so the delta calculation (`113 - 0 = 113`) exceeds the spike threshold of 10, triggering an active review even when metrics are stable
- Fix: detect first run via `prev_gate==UNKNOWN` and skip delta-based conditions (issue spike, high/critical increase) — only quality gate status (condition 1) is evaluated on first run since it doesn't depend on deltas

## Root Cause Analysis

PR #2808 added conditional logic with three trigger conditions:
1. Quality gate is ERROR/WARN
2. Issue count spike >= 10 since last sweep
3. High/critical severity count increased

The state persistence (`_load_sweep_state` / `_save_sweep_state`) was correct, but the **first run** had no prior state file, so `_load_sweep_state` returned defaults: `UNKNOWN|0|0`. This made the delta calculation compare current metrics against zero:
- `issue_delta = 113 - 0 = 113` (exceeds threshold of 10)
- `high_critical_delta = 8 - 0 = 8` (> 0)

Both conditions 2 and 3 fired, triggering the `@coderabbitai` mention.

## Verification

- ShellCheck: zero violations
- Bash syntax check: passes
- Functional tests: all 7 pass (17 assertions):
  1. First run, stable metrics → suppressed (FIXED)
  2. Second run, no change → suppressed
  3. Issue spike +15 on subsequent run → triggered
  4. Gate ERROR on first run → triggered (condition 1 still works)
  5. High/critical increase on subsequent run → triggered
  6. Exact reproduction of 05:50 UTC bug → suppressed (FIXED)
  7. Small delta +4 below threshold → suppressed

Closes #2832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced first-run quality sweep behavior: delta-based triggers for issue spikes and new critical findings are now deferred to subsequent sweeps, reducing false positives during baseline establishment.
  * Added baseline messaging throughout monitoring summaries to inform users that delta metrics will be computed starting from the next sweep.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->