### PR TITLE
t1491: Add WebKit for SwiftUI (WWDC25) to Swift development guide

### DIFF
--- a/.agents/mobile-app-dev/swift.md
+++ b/.agents/mobile-app-dev/swift.md
@@ -31,6 +31,7 @@ tools:
 - Maximum native performance (games, AR, complex animations)
 - Apple Watch, tvOS, or visionOS targets
 - Leveraging Swift-specific libraries
+- Hybrid native + web content apps (WebKit for SwiftUI provides first-class WebView)
 
 **Project scaffold via XcodeBuildMCP**:
 
@@ -153,6 +154,22 @@ SwiftUI provides excellent built-in animation support:
 | Biometrics | LocalAuthentication | Face ID, Touch ID |
 | Camera | AVFoundation | Photo/video capture |
 | NFC | Core NFC | NFC tag reading |
+| Web content | WebKit for SwiftUI | Native WebView, JS bridge, custom URL schemes (iOS 26+) |
+
+### Hybrid Content (WebKit for SwiftUI)
+
+Introduced at WWDC 2025, WebKit for SwiftUI provides native SwiftUI views for embedding web content. Use this when your app needs to display rich HTML (help pages, articles, terms of service) or build hybrid native + web architectures.
+
+Key APIs:
+
+- `WebView(url:)` — display web content as a SwiftUI view
+- `WebPage` — `@Observable` class to load, control, and communicate with web content (title, URL, progress, theme color)
+- `callJavaScript()` — evaluate JS with typed argument dictionaries, cast return values to Swift types
+- `URLSchemeHandler` — serve bundled HTML/CSS via custom URL schemes (e.g., `myapp://article/1`)
+- `WebPage.NavigationDeciding` — control navigation policies (allow, cancel, open in external browser)
+- View modifiers: `webViewScrollPosition`, `onScrollGeometryChange`, `findNavigator`, `webViewScrollInputBehavior` (visionOS look-to-scroll)
+
+Requires iOS 26+ / macOS 26+ / visionOS 26+. For older deployment targets, use `WKWebView` via UIKit/AppKit bridge.
 
 ### Swift Concurrency
 


### PR DESCRIPTION
## Summary

- Add WebKit for SwiftUI coverage from WWDC 2025 Session 231 to `mobile-app-dev/swift.md`
- New table row, new section, and platform decision update — 17 lines added, 0 removed
- No personal elements, no custom skill references, no secrets

Closes #2840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for embedding web content within SwiftUI applications using WebKit integration
  * Documented new APIs for web content interaction, navigation controls, and custom URL scheme handling
  * Updated deployment target requirements and compatibility specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->