### PR TITLE
fix: skip batch tasks in Phase 0.6 reconcile-queue to prevent premature cancellation

### DIFF
--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -1964,8 +1964,25 @@ cmd_reconcile_queue_dispatchability() {
 			in_dispatch_queue=true
 		fi
 
+		# Check if task belongs to an active batch (GH#2836)
+		# Batch membership is explicit dispatch intent — skip reconciliation
+		# to avoid cancelling newly-added tasks before Phase 0.9 can tag them.
+		local in_active_batch=false
+		local active_batch_id=""
+		active_batch_id=$(db "$SUPERVISOR_DB" "
+			SELECT bt.batch_id FROM batch_tasks bt
+			JOIN batches b ON b.id = bt.batch_id
+			WHERE bt.task_id = '$(sql_escape "$tid")'
+			AND b.status IN ('active','paused')
+			LIMIT 1;
+		" 2>/dev/null || echo "")
+		if [[ -n "$active_batch_id" ]]; then
+			in_active_batch=true
+		fi
+
 		# If neither condition is met, this is a phantom queue entry
-		if [[ "$has_auto_dispatch" == "false" && "$in_dispatch_queue" == "false" ]]; then
+		# But skip tasks in active batches — they are intentionally queued
+		if [[ "$has_auto_dispatch" == "false" && "$in_dispatch_queue" == "false" && "$in_active_batch" == "false" ]]; then
 			phantom_count=$((phantom_count + 1))
 			if [[ "$dry_run" == "true" ]]; then
 				log_warn "[dry-run] Phase 0.6: $tid queued in DB but not dispatchable in TODO.md (no #auto-dispatch, not in Dispatch Queue)"
@@ -1980,7 +1997,7 @@ cmd_reconcile_queue_dispatchability() {
 				cancelled_count=$((cancelled_count + 1))
 			fi
 		else
-			log_verbose "Phase 0.6: $tid is dispatchable (has_auto_dispatch=$has_auto_dispatch, in_dispatch_queue=$in_dispatch_queue)"
+			log_verbose "Phase 0.6: $tid is dispatchable (has_auto_dispatch=$has_auto_dispatch, in_dispatch_queue=$in_dispatch_queue, in_active_batch=$in_active_batch)"
 		fi
 	done <<<"$queued_tasks"
 


### PR DESCRIPTION
## Summary

- Phase 0.6 (`cmd_reconcile_queue_dispatchability`) cancelled newly-added batch tasks before Phase 0.9 could tag them with `#auto-dispatch`, causing all tasks in a batch to be immediately cancelled on the first pulse
- Added a batch membership check: before cancelling a task as a "phantom queue entry", Phase 0.6 now queries `batch_tasks` + `batches` tables to see if the task belongs to an active/paused batch
- Tasks in active batches are skipped — batch membership is explicit dispatch intent

## Root Cause

Phase ordering race condition:
1. `supervisor-helper.sh add` puts tasks in DB as `queued` but does NOT modify TODO.md
2. Phase 0.6 checks TODO.md for `#auto-dispatch` tag — not found → cancels as phantom
3. Phase 0.9 (sanity check) would have auto-tagged, but only runs when queue is empty — which it now is because Phase 0.6 cancelled everything

## Fix

Option 2 from the issue: Phase 0.6 checks `batch_tasks JOIN batches` for active/paused batch membership before the phantom cancellation decision. This is the cleanest approach because batch membership is an explicit, queryable signal of dispatch intent.

## Changed Files

- `.agents/scripts/supervisor-archived/todo-sync.sh` — `cmd_reconcile_queue_dispatchability()` (lines 1967-1981): added batch membership check before phantom cancellation

## Verification

- ShellCheck: zero violations
- The fix is a pure additive guard — existing phantom detection for non-batch tasks is unchanged

Closes #2836