### PR TITLE
t2846: Add secret-leaking prevention guardrails for agent conversations

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -185,7 +185,7 @@ When referencing specific functions or code include the pattern `file_path:line_
   - `systemctl show <service> --property=Environment`
   - Python/Node/Ruby one-liners that parse files containing credentials (e.g., `python3 -c "import json; print(json.load(open('.env')))"`)
   - `heroku config`, `vercel env pull`, `fly secrets list` (with values)
-  - Any command (including `grep`/`rg`) that prints or reconstructs secret VALUES from files known to contain secrets (`grep`/`rg` patterns that extract KEY NAMES only — e.g., `grep -oP '^[A-Z_]+(?==)' .env` — are allowed; see SAFE examples below)
+  - Disallow `grep`/`rg` (or any command) that may display secret values; allow `grep`/`rg` only when using patterns or processing steps that guarantee values are not printed (see `grep -oP '^[A-Z_]+(?==)' .env`, `printenv | cut -d= -f1`)
 - When debugging env var issues, show key NAMES only, never values:
   - SAFE: `pm2 show <app> --json | jq -r '.[0].pm2_env | keys_unsorted[]'` (key names only, robust)
   - SAFE: `printenv | cut -d= -f1 | sort` (list env var names without values)

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -185,12 +185,12 @@ When referencing specific functions or code include the pattern `file_path:line_
   - `systemctl show <service> --property=Environment`
   - Python/Node/Ruby one-liners that parse files containing credentials (e.g., `python3 -c "import json; print(json.load(open('.env')))"`)
   - `heroku config`, `vercel env pull`, `fly secrets list` (with values)
-  - Any `grep` or `rg` command targeting files known to contain secrets
+  - Any command (including `grep`/`rg`) that prints or reconstructs secret VALUES from files known to contain secrets (`grep`/`rg` patterns that extract KEY NAMES only — e.g., `grep -oP '^[A-Z_]+(?==)' .env` — are allowed; see SAFE examples below)
 - When debugging env var issues, show key NAMES only, never values:
-  - SAFE: `pm2 show <app> | grep -oP '^\s+\K[A-Z_]+(?=\s)'` (key names only)
+  - SAFE: `pm2 show <app> --json | jq -r '.[0].pm2_env | keys_unsorted[]'` (key names only, robust)
   - SAFE: `printenv | cut -d= -f1 | sort` (list env var names without values)
   - SAFE: `grep -oP '^[A-Z_]+(?==)' .env` (key names from .env without values)
-  - SAFE: `docker inspect <c> --format '{{range .Config.Env}}{{println .}}{{end}}' | cut -d= -f1`
+  - SAFE: `docker inspect <container> --format '{{range .Config.Env}}{{println .}}{{end}}' | cut -d= -f1`
   - UNSAFE: anything that prints the right side of `KEY=VALUE`
 - For credential lookups, pre-stage the command for the user's own terminal:
   - "Run this in your terminal (not here): `gopass show <path>`"

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -165,7 +165,41 @@ When referencing specific functions or code include the pattern `file_path:line_
 - NEVER expose credentials in output/logs
 - Store secrets via `aidevops secret set NAME` (gopass encrypted) or `~/.config/aidevops/credentials.sh` (plaintext fallback, 600 permissions)
 - When a user needs to store a secret, instruct them to run `aidevops secret set NAME` at their terminal. NEVER accept secret values in conversation.
-- NEVER run `gopass show`, `cat credentials.sh`, `echo $SECRET`, or any command that prints secret values
+#
+# 8. Secret value leaking in conversation (t2846)
+#    Threat: agent suggests or runs commands whose output contains secret values,
+#    exposing credentials in the conversation transcript. Transcripts are stored
+#    on disk and may be synced, logged, or visible to other tools. Once a secret
+#    appears in conversation, it must be rotated — the damage is done.
+#    Root cause: agents pattern-match on "I need to check the value" and reach
+#    for the obvious command (gopass show, cat .env, pm2 env) without considering
+#    that the output enters the conversation context.
+#    Incident: ILDS t006 session — Zoho OAuth credentials exposed, required rotation.
+- NEVER run, suggest, or output any command whose stdout/stderr would contain secret values. This is a principle, not a blocklist — apply judgment to ANY command that could print credentials. Common violations include but are not limited to:
+  - `gopass show <secret>`, `pass show`, `op read` (password managers)
+  - `cat .env`, `cat credentials.sh`, `cat dump.pm2`, `cat */secrets.*`
+  - `echo $SECRET_NAME`, `printenv SECRET_NAME`, `env | grep KEY`
+  - `pm2 env <app>` (dumps all env vars including secrets unfiltered)
+  - `docker inspect <container>` (includes env vars), `docker exec ... env`
+  - `kubectl get secret -o yaml`, `kubectl exec ... env`
+  - `systemctl show <service> --property=Environment`
+  - Python/Node/Ruby one-liners that parse files containing credentials (e.g., `python3 -c "import json; print(json.load(open('.env')))"`)
+  - `heroku config`, `vercel env pull`, `fly secrets list` (with values)
+  - Any `grep` or `rg` command targeting files known to contain secrets
+- When debugging env var issues, show key NAMES only, never values:
+  - SAFE: `pm2 show <app> | grep -oP '^\s+\K[A-Z_]+(?=\s)'` (key names only)
+  - SAFE: `printenv | cut -d= -f1 | sort` (list env var names without values)
+  - SAFE: `grep -oP '^[A-Z_]+(?==)' .env` (key names from .env without values)
+  - SAFE: `docker inspect <c> --format '{{range .Config.Env}}{{println .}}{{end}}' | cut -d= -f1`
+  - UNSAFE: anything that prints the right side of `KEY=VALUE`
+- For credential lookups, pre-stage the command for the user's own terminal:
+  - "Run this in your terminal (not here): `gopass show <path>`"
+  - "Paste the value directly into the config file / environment, not into this conversation"
+  - NEVER say "show me the output" or "paste the result here" for credential commands
+- When a user pastes what appears to be a credential value (API key, token, password, OAuth secret, connection string with embedded credentials) directly into conversation:
+  - Immediately warn: "That looks like a credential. Conversation transcripts are stored on disk — treat this value as compromised. Rotate it and store the new value via `aidevops secret set NAME` in your terminal."
+  - Do NOT repeat, echo, or reference the pasted credential value in your response
+  - Continue helping with the task using a placeholder like `<YOUR_API_KEY>` instead
 - Confirm destructive operations before execution
 - NEVER create files in `~/` root - use `~/.aidevops/.agent-workspace/work/[project]/`
 - Do not commit files containing secrets (.env, credentials.json, etc.)


### PR DESCRIPTION
## Summary

- Adds comprehensive rules to `prompts/build.txt` preventing agents from suggesting or running commands that expose secret values in conversation transcripts
- Replaces the previous single-line command blocklist with a principle-based approach covering password managers, env dumps, container inspection, cloud CLI tools, and scripting one-liners
- Adds safe alternatives for debugging env var issues (key names only, never values)
- Adds pre-staging guidance so credential lookups happen in the user's terminal, not in conversation
- Adds credential-paste detection: when a user pastes a credential value, the agent warns about compromise and suggests rotation

## Why

During an ILDS session, the agent repeatedly suggested commands (`gopass show`, `pm2 env`, `cat dump.pm2`) that would expose secret values in the conversation transcript. Credentials were exposed and had to be rotated. The existing rule (line 168) only listed 3 specific commands — this expands to a principle-based approach that covers the full attack surface.

## Design decisions

- **Principle over blocklist**: The rule says "apply judgment to ANY command that could print credentials" rather than relying on an exhaustive list. This follows the "Intelligence Over Determinism" framework principle — the examples teach the pattern, but the agent should catch novel violations too.
- **Safe alternatives included**: Rather than just saying "don't do X", the rules show exactly how to debug env var issues safely (key names only).
- **No new scripts or automation**: This is a prompt-level guardrail, not a deterministic filter. The agent's judgment is the enforcement mechanism, which is appropriate for this class of problem (infinite command variations that could leak secrets).

Closes #2846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified security guidelines for handling sensitive credentials, including prohibited commands, safer debugging practices, and procedures for managing pasted credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->