### PR TITLE
t1491: Add WebKit for SwiftUI (WWDC25) to Swift development guide

### DIFF
--- a/.agents/mobile-app-dev/swift.md
+++ b/.agents/mobile-app-dev/swift.md
@@ -30,6 +30,7 @@ tools:
 - Deep Apple ecosystem integration (HealthKit, HomeKit, Siri Intents, Widgets)
 - Maximum native performance (games, AR, complex animations)
 - Apple Watch, tvOS, or visionOS targets
+- Hybrid native + web content apps (WebKit for SwiftUI provides first-class WebView support)
 - Leveraging Swift-specific libraries
 
 **Project scaffold via XcodeBuildMCP**:
@@ -153,6 +154,7 @@ SwiftUI provides excellent built-in animation support:
 | Biometrics | LocalAuthentication | Face ID, Touch ID |
 | Camera | AVFoundation | Photo/video capture |
 | NFC | Core NFC | NFC tag reading |
+| Web content | WebKit for SwiftUI | Native WebView, JS bridge, custom URL schemes (iOS 26+) |
 
 ### Swift Concurrency
 
@@ -173,6 +175,81 @@ Use structured concurrency throughout:
 | Keychain | Secure credentials and tokens |
 | FileManager | Documents, cached files |
 | CloudKit | iCloud sync across devices |
+
+## Hybrid Content (WebKit for SwiftUI)
+
+> iOS 26+ / macOS 26+ / visionOS 26+. Requires `import WebKit`.
+> Source: WWDC 2025 Session 231 — "Meet WebKit for SwiftUI".
+
+First-class SwiftUI views for embedding web content — replaces the old `WKWebView` UIKit/AppKit bridge pattern.
+
+### WebView and WebPage
+
+```swift
+import WebKit
+
+struct ArticleView: View {
+    @State private var page = WebPage()
+
+    var body: some View {
+        WebView(page)
+            .onAppear { page.url = URL(string: "https://example.com/article")! }
+            .navigationTitle(page.title ?? "Loading...")
+    }
+}
+```
+
+`WebPage` is an `@Observable` class exposing: `url`, `title`, `isLoading`, `estimatedProgress`, `themeColor`, `isAtTop`, `isAtBottom`.
+
+### JavaScript Bridge
+
+Call JavaScript with typed argument dictionaries and get typed results:
+
+```swift
+let count: Int = try await page.callJavaScript(
+    "addItems",
+    arguments: ["items": ["apple", "banana"], "startIndex": 0]
+)
+```
+
+Arguments and return values are automatically bridged between Swift and JavaScript types.
+
+### Custom URL Schemes
+
+Serve bundled HTML/CSS/JS via custom URL schemes using `URLSchemeHandler`:
+
+```swift
+WebView(page)
+    .urlScheme("app-resource") { request in
+        let path = Bundle.main.path(forResource: request.url!.path, ofType: nil)!
+        let data = try! Data(contentsOf: URL(fileURLWithPath: path))
+        return .init(statusCode: 200, headerFields: [:], data: data)
+    }
+```
+
+Load with `app-resource:///index.html` — content stays local, no network requests.
+
+### Navigation Policy
+
+Control which navigations are allowed using `WebPage.NavigationDeciding`:
+
+```swift
+page.navigationDeciding = .handler { action in
+    if action.request.url?.host == "example.com" {
+        return .allow
+    }
+    return .cancel
+}
+```
+
+### View Modifiers
+
+| Modifier | Purpose |
+|----------|---------|
+| `webViewScrollPosition(_:)` | Bind scroll position |
+| `onScrollGeometryChange` | React to scroll geometry changes |
+| `findNavigator(isPresented:)` | In-page find (Cmd+F) |
+| `webViewScrollInputBehavior(_:for:)` | Control scroll input handling |
 
 ## Build and Test
 

--- a/.agents/mobile-app-dev/swift.md
+++ b/.agents/mobile-app-dev/swift.md
@@ -183,6 +183,18 @@ Use structured concurrency throughout:
 
 First-class SwiftUI views for embedding web content — replaces the old `WKWebView` UIKit/AppKit bridge pattern.
 
+**Compatibility**: These APIs require iOS 26+. For apps targeting earlier versions, guard with `#available` and provide a `WKWebView` fallback:
+
+```swift
+var body: some View {
+    if #available(iOS 26.0, *) {
+        WebView(url: url)
+    } else {
+        LegacyWKWebView(url: url) // UIViewRepresentable wrapper around WKWebView
+    }
+}
+```
+
 ### WebView and WebPage
 
 ```swift
@@ -193,7 +205,10 @@ struct ArticleView: View {
 
     var body: some View {
         WebView(page)
-            .onAppear { page.url = URL(string: "https://example.com/article")! }
+            .onAppear {
+                guard let url = URL(string: "https://example.com/article") else { return }
+                page.url = url
+            }
             .navigationTitle(page.title ?? "Loading...")
     }
 }
@@ -221,9 +236,24 @@ Serve bundled HTML/CSS/JS via custom URL schemes using `URLSchemeHandler`:
 ```swift
 WebView(page)
     .urlScheme("app-resource") { request in
-        let path = Bundle.main.path(forResource: request.url!.path, ofType: nil)!
-        let data = try! Data(contentsOf: URL(fileURLWithPath: path))
-        return .init(statusCode: 200, headerFields: [:], data: data)
+        guard
+            let url = request.url,
+            !url.path.isEmpty
+        else {
+            return .init(statusCode: 400, headerFields: [:], data: Data())
+        }
+
+        let relativePath = url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard let fileURL = Bundle.main.resourceURL?.appendingPathComponent(relativePath) else {
+            return .init(statusCode: 404, headerFields: [:], data: Data())
+        }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            return .init(statusCode: 200, headerFields: [:], data: data)
+        } catch {
+            return .init(statusCode: 404, headerFields: [:], data: Data())
+        }
     }
 ```
 


### PR DESCRIPTION
## Summary

- Add WebKit for SwiftUI (WWDC 2025, Session 231) documentation to `.agents/mobile-app-dev/swift.md`
- Covers `WebView`, `WebPage`, `callJavaScript()`, `URLSchemeHandler`, `NavigationDeciding`, and view modifiers
- Deployment target: iOS 26+ / macOS 26+ / visionOS 26+

## Changes

1. **Platform decision** — added "Hybrid native + web content apps" as a reason to choose Swift
2. **Native Capabilities table** — added `Web content | WebKit for SwiftUI` row
3. **New section** — "Hybrid Content (WebKit for SwiftUI)" with code examples for WebView/WebPage, JavaScript bridge, custom URL schemes, navigation policy, and view modifiers

## Source

WWDC 2025 Session 231: "Meet WebKit for SwiftUI"

Closes #2840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive WebKit integration guidance for SwiftUI: hybrid native/web content, WebView/WebPage usage, JavaScript bridge patterns, custom URL schemes, navigation policy handling, and related modifiers.
  * Updated Quick Reference with a new Web content entry and compatibility notes plus extensive practical examples and usage patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->