### PR TITLE
t1399: Remove blanket stderr suppression from db() call in todo-sync.sh

### DIFF
--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -1975,7 +1975,7 @@ cmd_reconcile_queue_dispatchability() {
 			WHERE bt.task_id = '$(sql_escape "$tid")'
 			AND b.status IN ('active','paused')
 			LIMIT 1;
-		" 2>/dev/null || echo "")
+		" || echo "")
 		if [[ -n "$active_batch_id" ]]; then
 			in_active_batch=true
 		fi


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from the `active_batch_id` db() call at line 1978 of `todo-sync.sh`
- Keep the `|| echo ""` fallback for `set -e` safety
- Allows database/SQL errors to remain visible on stderr for debugging

This addresses the Gemini code review finding from PR #2844 (HIGH severity) about blanket error suppression hiding important diagnostic information.

Closes #2864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for queue reconciliation edge cases, ensuring more reliable operations during SQL query failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->