### PR TITLE
t1400: Replace kill -0 with ps -p and remove redundant 2>/dev/null in pulse-wrapper.sh

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -131,7 +131,7 @@ check_dedup() {
 	fi
 
 	# Check if the process is still running
-	if ! kill -0 "$old_pid" 2>/dev/null; then
+	if ! ps -p "$old_pid" >/dev/null; then
 		# Process is dead, clean up stale PID file
 		rm -f "$PIDFILE"
 		return 0
@@ -147,7 +147,7 @@ check_dedup() {
 		_kill_tree "$old_pid"
 		sleep 2
 		# Force kill if still alive
-		if kill -0 "$old_pid" 2>/dev/null; then
+		if ps -p "$old_pid" >/dev/null; then
 			_force_kill_tree "$old_pid"
 		fi
 		rm -f "$PIDFILE"
@@ -928,7 +928,7 @@ guard_child_processes() {
 			echo "[pulse-wrapper] Process guard: killing PID $pid ($cmd_base) — $violation" >>"$LOGFILE"
 			_kill_tree "$pid"
 			sleep 1
-			if kill -0 "$pid" 2>/dev/null; then
+			if ps -p "$pid" >/dev/null; then
 				_force_kill_tree "$pid"
 			fi
 			killed=$((killed + 1))
@@ -1019,7 +1019,7 @@ ${state_content}
 	# the stale threshold. Also runs process guard to kill runaway children (t1398).
 	# This replaces the bare `wait` that blocked the wrapper indefinitely when
 	# opencode hung.
-	while kill -0 "$opencode_pid" 2>/dev/null; do
+	while ps -p "$opencode_pid" >/dev/null; do
 		local now
 		now=$(date +%s)
 		local elapsed=$((now - start_epoch))
@@ -1028,7 +1028,7 @@ ${state_content}
 			_kill_tree "$opencode_pid"
 			sleep 2
 			# Force kill if still alive
-			if kill -0 "$opencode_pid" 2>/dev/null; then
+			if ps -p "$opencode_pid" >/dev/null; then
 				_force_kill_tree "$opencode_pid"
 			fi
 			break
@@ -1038,7 +1038,7 @@ ${state_content}
 		# CHILD_RUNTIME_LIMIT (it's governed by PULSE_STALE_THRESHOLD above).
 		guard_child_processes "$opencode_pid"
 		# Sleep 60s then re-check. Portable across bash 3.2+ (macOS default).
-		# The process may exit during sleep — kill -0 at top of loop catches that.
+		# The process may exit during sleep — ps -p at top of loop catches that.
 		sleep 60
 	done
 
@@ -1635,7 +1635,7 @@ run_daily_quality_sweep() {
 	# Timestamp guard — run at most once per QUALITY_SWEEP_INTERVAL
 	if [[ -f "$QUALITY_SWEEP_LAST_RUN" ]]; then
 		local last_run
-		last_run=$(cat "$QUALITY_SWEEP_LAST_RUN" 2>/dev/null || echo "0")
+		last_run=$(cat "$QUALITY_SWEEP_LAST_RUN" || echo "0")
 		# Strip whitespace/newlines and validate integer (t1397)
 		last_run="${last_run//[^0-9]/}"
 		last_run="${last_run:-0}"


### PR DESCRIPTION
## Summary

- Replace all `kill -0 $pid 2>/dev/null` with `ps -p $pid >/dev/null` to avoid masking EPERM errors when checking process liveness (lines 122, 138, 891, 900)
- Remove redundant `2>/dev/null` from `cat` after `-f` existence check (line 1496) — the `|| echo "0"` fallback handles failure; stderr suppression hides permission errors
- Update inline comment referencing `kill -0` to `ps -p` (line 906)

## Why

`kill -0` with `2>/dev/null` suppresses all stderr, including EPERM errors that indicate the process exists but is owned by another user. `ps -p` with only stdout redirected preserves stderr visibility for debugging while still cleanly checking process existence. Similarly, `cat` after a `-f` check doesn't need stderr suppression — the file is known to exist, so any `cat` failure (e.g., permission denied) should be visible.

## Verification

- ShellCheck: zero violations
- All 5 `kill -0` instances replaced (4 code + 1 comment)
- No remaining `kill -0` in the file

Closes #2857