### PR TITLE
t1401: Refactor CodeRabbit trigger logic to reduce repeated code

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2215,19 +2215,21 @@ ${type_breakdown}
 	[[ "$prev_high_critical" =~ ^[0-9]+$ ]] || prev_high_critical=0
 
 	# First-run guard: if no previous state exists (prev_gate is UNKNOWN from
-	# _load_sweep_state default), save the current metrics as baseline and skip
-	# the trigger. Without this, the delta from 0 to current issue count always
-	# exceeds the spike threshold, causing every first run (or run after state
-	# loss) to trigger a full review.
-	if [[ "$prev_gate" == "UNKNOWN" ]]; then
-		_save_sweep_state "$repo_slug" "$sweep_gate_status" "$sweep_total_issues" "$sweep_high_critical"
+	# _load_sweep_state default), skip delta-based triggers. Without this, the
+	# delta from 0 to current issue count always exceeds the spike threshold,
+	# causing every first run (or run after state loss) to trigger a full review.
+	#
+	# Refactored (t1401): _save_sweep_state and tool_count are common to all
+	# branches — hoisted outside the conditional to reduce duplication.
+	local is_baseline_run=false
+	[[ "$prev_gate" == "UNKNOWN" ]] && is_baseline_run=true
+
+	if [[ "$is_baseline_run" == true ]]; then
 		coderabbit_section="### CodeRabbit
 
 _First sweep run — baseline saved (${sweep_total_issues} issues, gate ${sweep_gate_status}). Review trigger will activate on next sweep if quality degrades._
 "
-		tool_count=$((tool_count + 1))
 		echo "[pulse-wrapper] CodeRabbit: first run for ${repo_slug} — saved baseline, skipping trigger" >>"$LOGFILE"
-		# Skip the rest of section 5 — jump to section 6
 	else
 		local issue_delta=$((sweep_total_issues - prev_issues))
 		local trigger_active=false
@@ -2267,11 +2269,11 @@ _First sweep run — baseline saved (${sweep_total_issues} issues, gate ${sweep_
 _Monitoring: ${sweep_total_issues} issues (delta: ${issue_delta}), gate ${sweep_gate_status} — no active review needed._
 "
 		fi
-		tool_count=$((tool_count + 1))
-
-		# Save current state for next sweep's delta comparison
-		_save_sweep_state "$repo_slug" "$sweep_gate_status" "$sweep_total_issues" "$sweep_high_critical"
 	fi
+
+	# Common to all branches: save state for next sweep and count the tool
+	_save_sweep_state "$repo_slug" "$sweep_gate_status" "$sweep_total_issues" "$sweep_high_critical"
+	tool_count=$((tool_count + 1))
 
 	# --- 6. Merged PR review scanner ---
 	# Scans recently merged PRs for unactioned review feedback from bots


### PR DESCRIPTION
## Summary

- Hoists `_save_sweep_state()` and `tool_count` increment out of the if/else branches into a single call site after the conditional, eliminating code duplication flagged by Gemini Code Assist in PR #2835
- Introduces `is_baseline_run` flag for clearer intent, replacing the direct `prev_gate == UNKNOWN` conditional

## Context

Gemini Code Assist reviewed PR #2835 (t1392: Fix CodeRabbit sweep first-run baseline detection) and suggested refactoring the conditional logic to reduce repeated code. Both the first-run baseline path and the subsequent-run trigger path performed identical `_save_sweep_state()` and `tool_count++` operations — these are now hoisted to a single location after the if/else.

## Verification

- ShellCheck: zero violations
- Bash syntax: passes
- Behavior is unchanged — only the code structure is improved

Closes #2868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and reduced duplication in evaluation logic while maintaining all existing functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->