### PR TITLE
t1402: fix: remove stderr suppression from shellcheck invocation in quality sweep

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1992,7 +1992,7 @@ _quality_sweep_for_repo() {
 					# ulimit -v in subshell to cap RSS per shellcheck process.
 					result=$(
 						ulimit -v 1048576 2>/dev/null || true
-						$sc_timeout_cmd shellcheck --norc -f gcc "$shfile" 2>/dev/null || true
+						$sc_timeout_cmd shellcheck --norc -f gcc "$shfile" || true
 					)
 					if [[ -n "$result" ]]; then
 						local file_errors

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1990,9 +1990,12 @@ _quality_sweep_for_repo() {
 					local result
 					# t1398.2: hardened invocation — no -x, --norc, per-file timeout,
 					# ulimit -v in subshell to cap RSS per shellcheck process.
+					# t1402: stderr merged into stdout (2>&1) so diagnostic messages
+					# (parse errors, timeouts, permission failures) are captured in
+					# $result and appear in the sweep summary.
 					result=$(
 						ulimit -v 1048576 2>/dev/null || true
-						$sc_timeout_cmd shellcheck --norc -f gcc "$shfile" || true
+						$sc_timeout_cmd shellcheck --norc -f gcc "$shfile" 2>&1 || true
 					)
 					if [[ -n "$result" ]]; then
 						local file_errors


### PR DESCRIPTION
## Summary

- Removes `2>/dev/null` from the shellcheck invocation in `_quality_sweep_for_repo()` — stderr suppression hid real errors (parse failures, permission issues) while `|| true` already prevents non-zero exit from aborting the sweep
- The `ulimit -v` line above correctly retains its `2>/dev/null` since `ulimit` may not be supported on all platforms

## Change

```diff
-$sc_timeout_cmd shellcheck --norc -f gcc "$shfile" 2>/dev/null || true
+$sc_timeout_cmd shellcheck --norc -f gcc "$shfile" || true
```

## Verification

- ShellCheck passes cleanly on the modified file
- `|| true` still prevents the command from causing a non-zero exit
- Diagnostic stderr from shellcheck is now preserved in the captured `result` variable

Closes #2902

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved code quality diagnostics by adjusting error redirection in shell scripts, allowing diagnostic messages to be properly captured and displayed during quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->