### PR TITLE
t1403: fix macOS timeout compatibility and UTC timezone parsing in aidevops update

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -414,7 +414,8 @@ check_skill_freshness() {
 	if [[ -n "$last_skill_check" ]]; then
 		local last_epoch now_epoch elapsed
 		if [[ "$(uname)" == "Darwin" ]]; then
-			last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_skill_check" "+%s" 2>/dev/null || echo "0")
+			# TZ=UTC: stored timestamps are UTC — macOS date -j ignores the Z suffix
+			last_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_skill_check" "+%s" 2>/dev/null || echo "0")
 		else
 			last_epoch=$(date -d "$last_skill_check" "+%s" 2>/dev/null || echo "0")
 		fi
@@ -533,7 +534,8 @@ check_openclaw_freshness() {
 	if [[ -n "$last_openclaw_check" ]]; then
 		local last_epoch now_epoch elapsed
 		if [[ "$(uname)" == "Darwin" ]]; then
-			last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_openclaw_check" "+%s" 2>/dev/null || echo "0")
+			# TZ=UTC: stored timestamps are UTC — macOS date -j ignores the Z suffix
+			last_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_openclaw_check" "+%s" 2>/dev/null || echo "0")
 		else
 			last_epoch=$(date -d "$last_openclaw_check" "+%s" 2>/dev/null || echo "0")
 		fi
@@ -744,7 +746,8 @@ check_tool_freshness() {
 	if [[ -n "$last_tool_check" ]]; then
 		local last_epoch now_epoch elapsed
 		if [[ "$(uname)" == "Darwin" ]]; then
-			last_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_tool_check" "+%s" 2>/dev/null || echo "0")
+			# TZ=UTC: stored timestamps are UTC — macOS date -j ignores the Z suffix
+			last_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$last_tool_check" "+%s" 2>/dev/null || echo "0")
 		else
 			last_epoch=$(date -d "$last_tool_check" "+%s" 2>/dev/null || echo "0")
 		fi

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -372,11 +372,19 @@ main() {
 				# Commands are hardcoded in tool definitions, not user input
 				# Timeout prevents hangs on slow registries/network issues
 				# Use timeout_sec for macOS compatibility (no native timeout)
-				if timeout_sec 120 bash -c "$update_cmd" 2>&1 | tail -2; then
+				# NOTE: Do NOT pipe timeout_sec output to tail/head — on macOS the
+				# perl alarm fallback doesn't close the pipe's write end on SIGALRM,
+				# causing tail to block forever. Use a temp file instead.
+				local _update_log
+				_update_log=$(mktemp "${TMPDIR:-/tmp}/tool-update.XXXXXX")
+				if timeout_sec 120 bash -c "$update_cmd" >"$_update_log" 2>&1; then
+					tail -2 "$_update_log"
 					echo -e "  ${GREEN}✓ Updated${NC}"
 				else
+					tail -2 "$_update_log"
 					echo -e "  ${RED}✗ Failed${NC}"
 				fi
+				rm -f "$_update_log"
 				echo ""
 			done
 			echo -e "${GREEN}Updates complete. Re-run to verify.${NC}"

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -119,7 +119,10 @@ get_installed_version() {
 		# fallback doesn't close the pipe write end on SIGALRM, causing head to
 		# block forever. Use a temp file instead.
 		local _ver_log
-		_ver_log=$(mktemp "${TMPDIR:-/tmp}/tool-ver.XXXXXX")
+		if ! _ver_log=$(mktemp "${TMPDIR:-/tmp}/tool-ver.XXXXXX"); then
+			echo "unknown"
+			return 0
+		fi
 		# shellcheck disable=SC2086
 		timeout_sec 5 "$cmd" $ver_flag >"$_ver_log" 2>/dev/null || true
 		version=$(head -1 "$_ver_log" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
@@ -144,13 +147,14 @@ timeout_sec() {
 		# Linux has native timeout
 		timeout "$timeout" "$@"
 	else
-		# macOS: use perl or gtimeout if available, otherwise run without timeout
-		if command -v perl &>/dev/null; then
-			perl -e 'alarm shift; exec @ARGV' "$timeout" "$@"
-		elif command -v gtimeout &>/dev/null; then
+		# macOS: prefer gtimeout (robust exit codes, pipe handling) over perl alarm
+		if command -v gtimeout &>/dev/null; then
 			gtimeout "$timeout" "$@"
+		elif command -v perl &>/dev/null; then
+			perl -e 'alarm shift; exec @ARGV' "$timeout" "$@"
 		else
 			# No timeout available - run directly (will hang if command hangs)
+			echo "[WARN] No timeout command available - running without timeout" >&2
 			"$@"
 		fi
 	fi
@@ -384,7 +388,10 @@ main() {
 				# perl alarm fallback doesn't close the pipe's write end on SIGALRM,
 				# causing tail to block forever. Use a temp file instead.
 				local _update_log
-				_update_log=$(mktemp "${TMPDIR:-/tmp}/tool-update.XXXXXX")
+				if ! _update_log=$(mktemp "${TMPDIR:-/tmp}/tool-update.XXXXXX"); then
+					echo -e "  ${RED}✗ Failed to create temp log${NC}"
+					continue
+				fi
 				if timeout_sec 120 bash -c "$update_cmd" >"$_update_log" 2>&1; then
 					tail -2 "$_update_log"
 					echo -e "  ${GREEN}✓ Updated${NC}"

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -371,7 +371,8 @@ main() {
 				# Run update command directly (not via eval for security)
 				# Commands are hardcoded in tool definitions, not user input
 				# Timeout prevents hangs on slow registries/network issues
-				if timeout 120 bash -c "$update_cmd" 2>&1 | tail -2; then
+				# Use timeout_sec for macOS compatibility (no native timeout)
+				if timeout_sec 120 bash -c "$update_cmd" 2>&1 | tail -2; then
 					echo -e "  ${GREEN}✓ Updated${NC}"
 				else
 					echo -e "  ${RED}✗ Failed${NC}"

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -112,13 +112,21 @@ get_installed_version() {
 
 	if command -v "$cmd" &>/dev/null; then
 		local version
+		# Timeout version checks — some tools (MCP servers) start a blocking
+		# server process when given --version instead of printing a version.
+		# Without a timeout, the subshell hangs forever.
+		# NOTE: Do NOT pipe timeout_sec to head/grep — on macOS the perl alarm
+		# fallback doesn't close the pipe write end on SIGALRM, causing head to
+		# block forever. Use a temp file instead.
+		local _ver_log
+		_ver_log=$(mktemp "${TMPDIR:-/tmp}/tool-ver.XXXXXX")
 		# shellcheck disable=SC2086
-		version=$("$cmd" $ver_flag 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
+		timeout_sec 5 "$cmd" $ver_flag >"$_ver_log" 2>/dev/null || true
+		version=$(head -1 "$_ver_log" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")
 		if [[ -z "$version" ]]; then
-			# Try alternative patterns
-			# shellcheck disable=SC2086
-			version=$("$cmd" $ver_flag 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "unknown")
+			version=$(head -1 "$_ver_log" | grep -oE '[0-9]+\.[0-9]+' | head -1 || echo "unknown")
 		fi
+		rm -f "$_ver_log"
 		echo "$version"
 	else
 		echo "not installed"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -34,10 +34,10 @@ _timeout_cmd() {
 	shift
 	if command -v timeout &>/dev/null; then
 		timeout "$secs" "$@"
-	elif command -v perl &>/dev/null; then
-		perl -e 'alarm shift; exec @ARGV' "$secs" "$@"
 	elif command -v gtimeout &>/dev/null; then
 		gtimeout "$secs" "$@"
+	elif command -v perl &>/dev/null; then
+		perl -e 'alarm shift; exec @ARGV' "$secs" "$@"
 	else
 		"$@"
 	fi
@@ -864,9 +864,9 @@ cmd_update() {
 			# Get latest version (npm or brew) — timeout prevents hangs on slow registries
 			if [[ "$pkg_ref" == brew:* ]]; then
 				local brew_pkg="${pkg_ref#brew:}"
-				latest=$(_timeout_cmd 30 brew info --json=v2 "$brew_pkg" 2>/dev/null | jq -r '.formulae[0].versions.stable // empty' 2>/dev/null || true)
+				latest=$(_timeout_cmd 30 brew info --json=v2 "$brew_pkg" | jq -r '.formulae[0].versions.stable // empty' || true)
 			else
-				latest=$(_timeout_cmd 30 npm view "$pkg_ref" version 2>/dev/null || true)
+				latest=$(_timeout_cmd 30 npm view "$pkg_ref" version || true)
 			fi
 			[[ -z "$latest" ]] && continue
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -39,6 +39,7 @@ _timeout_cmd() {
 	elif command -v perl &>/dev/null; then
 		perl -e 'alarm shift; exec @ARGV' "$secs" "$@"
 	else
+		echo "[WARN] No timeout command available - running without timeout" >&2
 		"$@"
 	fi
 }

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -28,6 +28,21 @@ VERSION_FILE="$INSTALL_DIR/VERSION"
 # Portable sed in-place edit (macOS BSD sed vs GNU sed)
 sed_inplace() { if [[ "$(uname)" == "Darwin" ]]; then sed -i '' "$@"; else sed -i "$@"; fi; }
 
+# Portable timeout (macOS has no coreutils timeout)
+_timeout_cmd() {
+	local secs="$1"
+	shift
+	if command -v timeout &>/dev/null; then
+		timeout "$secs" "$@"
+	elif command -v perl &>/dev/null; then
+		perl -e 'alarm shift; exec @ARGV' "$secs" "$@"
+	elif command -v gtimeout &>/dev/null; then
+		gtimeout "$secs" "$@"
+	else
+		"$@"
+	fi
+}
+
 print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 print_success() { echo -e "${GREEN}[OK]${NC} $1"; }
 print_warning() { echo -e "${YELLOW}[WARN]${NC} $1"; }
@@ -849,9 +864,9 @@ cmd_update() {
 			# Get latest version (npm or brew) — timeout prevents hangs on slow registries
 			if [[ "$pkg_ref" == brew:* ]]; then
 				local brew_pkg="${pkg_ref#brew:}"
-				latest=$(timeout 30 brew info --json=v2 "$brew_pkg" 2>/dev/null | jq -r '.formulae[0].versions.stable // empty' 2>/dev/null || true)
+				latest=$(_timeout_cmd 30 brew info --json=v2 "$brew_pkg" 2>/dev/null | jq -r '.formulae[0].versions.stable // empty' 2>/dev/null || true)
 			else
-				latest=$(timeout 30 npm view "$pkg_ref" version 2>/dev/null || true)
+				latest=$(_timeout_cmd 30 npm view "$pkg_ref" version 2>/dev/null || true)
 			fi
 			[[ -z "$latest" ]] && continue
 


### PR DESCRIPTION
## Summary

- **macOS has no native `timeout` command** — `aidevops update` calls `timeout 30 npm view ...` and `timeout 120 bash -c "$update_cmd"` which silently fail (exit 127) or hang on macOS. Added `_timeout_cmd()` in `aidevops.sh` and `timeout_sec()` in `tool-version-check.sh` using perl alarm fallback (available on all macOS).
- **Pipe to `tail` hangs with perl alarm** — even with `timeout_sec` working, `timeout_sec 120 bash -c "$cmd" 2>&1 | tail -2` hangs forever on macOS. The perl alarm (`SIGALRM`) kills the process but doesn't close the pipe's write end, so `tail` blocks waiting for EOF. Replaced with temp file: write output to file, then `tail -2` the file.
- **UTC timezone parsing bug** — `date -j -f` on macOS ignores the `Z` suffix, interpreting UTC timestamps in local time. This caused freshness checks to be off by the local UTC offset (e.g., 7 hours for MST), potentially skipping update checks. Fixed by prefixing with `TZ=UTC`.

## Files Changed

- `aidevops.sh` — Added `_timeout_cmd()` portable function, replaced 2 bare `timeout` calls
- `.agents/scripts/tool-version-check.sh` — Added `timeout_sec()` portable function, replaced bare `timeout 120` in update execution, replaced `| tail -2` pipe with temp file to prevent SIGALRM hang
- `.agents/scripts/auto-update-helper.sh` — Fixed 3 `date -j` calls to use `TZ=UTC`

## Root Cause Analysis

Two separate bugs causing the same symptom (hang at tool update):

1. **Missing `timeout` command** — macOS has no `timeout`. The shell tries to execute it, fails with exit 127, and `|| true` swallows the error. Fixed with `timeout_sec()` / `_timeout_cmd()` using `perl -e 'alarm shift; exec @ARGV'`.

2. **SIGALRM + pipe deadlock** — Even with the perl alarm working, piping its output to `tail -2` creates a deadlock. When SIGALRM fires, perl sends the signal to the exec'd process, but the pipe's write-end file descriptor isn't closed cleanly. `tail` holds the read end open, waiting for EOF that never comes. Linux's `timeout` command avoids this by using process groups (`kill -TERM -- -$pgid`). Fixed by redirecting to a temp file instead of piping.

## Testing

Verified on macOS (no native `timeout`):
- `_timeout_cmd` correctly times out via perl alarm (exit 142)
- `timeout_sec` correctly wraps npm/brew queries
- UTC fix eliminates 7-hour offset in freshness calculations
- Temp file approach correctly shows last 2 lines of output and terminates cleanly

Closes #2490

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp parsing on macOS so UTC-formatted timestamps (trailing Z) are handled correctly.

* **Chores**
  * Standardized timeout handling across scripts with a portable wrapper to prevent hangs.
  * Capture update/version output to temporary logs and surface concise end-of-operation output (last lines) for clearer success/failure feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->