### PR TITLE
t1395: Dataset convention for repeatable LLM evaluations

### DIFF
--- a/.agents/scripts/dataset-helper.sh
+++ b/.agents/scripts/dataset-helper.sh
@@ -1,0 +1,906 @@
+#!/usr/bin/env bash
+# Dataset Helper — Standardised JSONL dataset management for LLM evaluations (t1395)
+#
+# Provides a convention for storing, validating, and managing evaluation test cases
+# in JSONL format. Enables repeatable evaluations across bench (t1393) and
+# evaluator (t1394) workflows.
+#
+# Dataset format (one JSON object per line):
+#   Required: id, input
+#   Optional: expected, context, tags, source, metadata
+#
+# Directory convention:
+#   Global:  ~/.aidevops/.agent-workspace/datasets/   (cross-project)
+#   Project: <repo>/datasets/                          (version-controlled)
+#
+# Commands:
+#   create    <name> [--project]           Create empty dataset
+#   validate  <file>                       Validate JSONL schema
+#   add       <file> --input "..." [opts]  Append entry
+#   list      [--project <path>]           List available datasets
+#   stats     <file>                       Row count, tag/source breakdown
+#   promote   --trace-id <id>              Convert observability trace to entry
+#   merge     <file1> <file2> -o <out>     Merge datasets, dedup by id
+#   schema                                 Print the dataset JSON schema
+#   help                                   Show this help
+#
+# Author: AI DevOps Framework
+# Version: 1.0.0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+set -euo pipefail
+init_log_file
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+readonly GLOBAL_DATASETS_DIR="${HOME}/.aidevops/.agent-workspace/datasets"
+readonly OBS_METRICS="${HOME}/.aidevops/.agent-workspace/observability/metrics.jsonl"
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+# Generate a short unique ID (8-char hex)
+_generate_id() {
+	if command -v uuidgen &>/dev/null; then
+		uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8
+	elif [[ -r /dev/urandom ]]; then
+		od -An -tx1 -N4 /dev/urandom | tr -d ' \n'
+	else
+		printf '%08x' "$$$(date +%s)"
+	fi
+	return 0
+}
+
+# Resolve dataset directory: global or project-local
+_resolve_datasets_dir() {
+	local project_path="${1:-}"
+
+	if [[ -n "$project_path" ]]; then
+		echo "${project_path}/datasets"
+	else
+		echo "$GLOBAL_DATASETS_DIR"
+	fi
+	return 0
+}
+
+# Ensure a directory exists
+_ensure_dir() {
+	local dir="$1"
+	if [[ ! -d "$dir" ]]; then
+		mkdir -p "$dir"
+	fi
+	return 0
+}
+
+# Validate that jq is available
+_require_jq() {
+	if ! command -v jq &>/dev/null; then
+		print_error "jq is required but not installed. Install with: brew install jq"
+		return 1
+	fi
+	return 0
+}
+
+# =============================================================================
+# Commands
+# =============================================================================
+
+# Create an empty dataset file
+cmd_create() {
+	local name=""
+	local project_path=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--project)
+			project_path="${2:-.}"
+			shift 2
+			;;
+		--help | -h)
+			echo "Usage: dataset-helper.sh create <name> [--project [path]]"
+			echo ""
+			echo "Creates an empty dataset JSONL file."
+			echo ""
+			echo "Options:"
+			echo "  --project [path]  Create in project datasets/ dir (default: current dir)"
+			echo ""
+			echo "Examples:"
+			echo "  dataset-helper.sh create golden-prompts"
+			echo "  dataset-helper.sh create api-tests --project ~/Git/myproject"
+			return 0
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		*)
+			name="$1"
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$name" ]]; then
+		print_error "Dataset name is required"
+		echo "Usage: dataset-helper.sh create <name> [--project [path]]"
+		return 1
+	fi
+
+	# Sanitise name: allow alphanumeric, hyphens, underscores
+	if [[ ! "$name" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]*$ ]]; then
+		print_error "Invalid dataset name: '$name'. Use alphanumeric, hyphens, underscores."
+		return 1
+	fi
+
+	local datasets_dir
+	datasets_dir=$(_resolve_datasets_dir "$project_path")
+	_ensure_dir "$datasets_dir"
+
+	local file_path="${datasets_dir}/${name}.jsonl"
+
+	if [[ -f "$file_path" ]]; then
+		print_warning "Dataset already exists: $file_path"
+		return 1
+	fi
+
+	touch "$file_path"
+	print_success "Created dataset: $file_path"
+	return 0
+}
+
+# Validate a JSONL dataset file
+cmd_validate() {
+	local file_path=""
+	local strict=false
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--strict)
+			strict=true
+			shift
+			;;
+		--help | -h)
+			echo "Usage: dataset-helper.sh validate <file> [--strict]"
+			echo ""
+			echo "Validates a JSONL dataset file."
+			echo ""
+			echo "Checks:"
+			echo "  - Each line is valid JSON"
+			echo "  - Required fields present: id, input"
+			echo "  - No duplicate IDs"
+			echo ""
+			echo "Options:"
+			echo "  --strict  Also validate optional field types"
+			return 0
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		*)
+			file_path="$1"
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$file_path" ]]; then
+		print_error "File path is required"
+		echo "Usage: dataset-helper.sh validate <file>"
+		return 1
+	fi
+
+	_require_jq || return 1
+
+	if [[ ! -f "$file_path" ]]; then
+		print_error "File not found: $file_path"
+		return 1
+	fi
+
+	# Empty file is valid (newly created dataset)
+	local line_count
+	line_count=$(wc -l <"$file_path" | tr -d ' ')
+	if [[ "$line_count" -eq 0 ]]; then
+		print_success "Valid dataset (empty): $file_path"
+		return 0
+	fi
+
+	local errors=0
+	local line_num=0
+	local seen_ids=""
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		line_num=$((line_num + 1))
+
+		# Skip empty lines
+		[[ -z "$line" ]] && continue
+
+		# Check valid JSON
+		if ! echo "$line" | jq empty 2>/dev/null; then
+			print_error "Line $line_num: Invalid JSON"
+			errors=$((errors + 1))
+			continue
+		fi
+
+		# Check required fields
+		local has_id has_input
+		has_id=$(echo "$line" | jq 'has("id")' 2>/dev/null)
+		has_input=$(echo "$line" | jq 'has("input")' 2>/dev/null)
+
+		if [[ "$has_id" != "true" ]]; then
+			print_error "Line $line_num: Missing required field 'id'"
+			errors=$((errors + 1))
+		fi
+
+		if [[ "$has_input" != "true" ]]; then
+			print_error "Line $line_num: Missing required field 'input'"
+			errors=$((errors + 1))
+		fi
+
+		# Check for duplicate IDs
+		if [[ "$has_id" == "true" ]]; then
+			local entry_id
+			entry_id=$(echo "$line" | jq -r '.id' 2>/dev/null)
+			if echo "$seen_ids" | grep -qx "$entry_id" 2>/dev/null; then
+				print_error "Line $line_num: Duplicate ID '$entry_id'"
+				errors=$((errors + 1))
+			else
+				seen_ids="${seen_ids}${entry_id}"$'\n'
+			fi
+		fi
+
+		# Strict mode: validate optional field types
+		if [[ "$strict" == "true" ]]; then
+			local type_errors
+			type_errors=$(echo "$line" | jq '
+				[ if has("tags") and (.tags | type) != "array" then "tags must be array" else empty end,
+				  if has("expected") and (.expected | type) != "string" and .expected != null then "expected must be string or null" else empty end,
+				  if has("context") and (.context | type) != "string" and .context != null then "context must be string or null" else empty end,
+				  if has("source") and (.source | type) != "string" then "source must be string" else empty end,
+				  if has("metadata") and (.metadata | type) != "object" and .metadata != null then "metadata must be object or null" else empty end
+				] | .[]' 2>/dev/null || echo "")
+
+			if [[ -n "$type_errors" ]]; then
+				while IFS= read -r err; do
+					[[ -z "$err" ]] && continue
+					# Remove surrounding quotes from jq string output
+					err="${err#\"}"
+					err="${err%\"}"
+					print_error "Line $line_num: $err"
+					errors=$((errors + 1))
+				done <<<"$type_errors"
+			fi
+		fi
+	done <"$file_path"
+
+	if [[ "$errors" -gt 0 ]]; then
+		print_error "Validation failed: $errors error(s) in $file_path"
+		return 1
+	fi
+
+	print_success "Valid dataset ($line_num entries): $file_path"
+	return 0
+}
+
+# Add an entry to a dataset
+cmd_add() {
+	local file_path=""
+	local input_text=""
+	local expected_text=""
+	local context_text=""
+	local tags_csv=""
+	local source_text="manual"
+	local entry_id=""
+	local metadata_json=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--input)
+			input_text="$2"
+			shift 2
+			;;
+		--expected)
+			expected_text="$2"
+			shift 2
+			;;
+		--context)
+			context_text="$2"
+			shift 2
+			;;
+		--tags)
+			tags_csv="$2"
+			shift 2
+			;;
+		--source)
+			source_text="$2"
+			shift 2
+			;;
+		--id)
+			entry_id="$2"
+			shift 2
+			;;
+		--metadata)
+			metadata_json="$2"
+			shift 2
+			;;
+		--help | -h)
+			echo "Usage: dataset-helper.sh add <file> --input \"...\" [options]"
+			echo ""
+			echo "Appends an entry to a dataset."
+			echo ""
+			echo "Options:"
+			echo "  --input \"text\"      Input prompt (required)"
+			echo "  --expected \"text\"   Expected output (optional)"
+			echo "  --context \"text\"    Context for grounding (optional)"
+			echo "  --tags \"a,b,c\"     Comma-separated tags (optional)"
+			echo "  --source \"text\"    Provenance: manual, trace:ID, generated:model (default: manual)"
+			echo "  --id \"text\"        Custom ID (default: auto-generated)"
+			echo "  --metadata '{}'    JSON object with extra fields (optional)"
+			return 0
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		*)
+			if [[ -z "$file_path" ]]; then
+				file_path="$1"
+			else
+				print_error "Unexpected argument: $1"
+				return 1
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$file_path" ]]; then
+		print_error "File path is required"
+		echo "Usage: dataset-helper.sh add <file> --input \"...\""
+		return 1
+	fi
+
+	if [[ -z "$input_text" ]]; then
+		print_error "--input is required"
+		return 1
+	fi
+
+	_require_jq || return 1
+
+	if [[ ! -f "$file_path" ]]; then
+		print_error "Dataset file not found: $file_path"
+		echo "Create one first: dataset-helper.sh create <name>"
+		return 1
+	fi
+
+	# Auto-generate ID if not provided
+	if [[ -z "$entry_id" ]]; then
+		entry_id=$(_generate_id)
+	fi
+
+	# Build tags array
+	local tags_json="[]"
+	if [[ -n "$tags_csv" ]]; then
+		tags_json=$(echo "$tags_csv" | tr ',' '\n' | jq -R . | jq -s .)
+	fi
+
+	# Build the entry JSON
+	local entry
+	entry=$(jq -c -n \
+		--arg id "$entry_id" \
+		--arg input "$input_text" \
+		--argjson tags "$tags_json" \
+		--arg source "$source_text" \
+		'{id: $id, input: $input, tags: $tags, source: $source}')
+
+	# Add optional fields
+	if [[ -n "$expected_text" ]]; then
+		entry=$(echo "$entry" | jq -c --arg expected "$expected_text" '. + {expected: $expected}')
+	fi
+
+	if [[ -n "$context_text" ]]; then
+		entry=$(echo "$entry" | jq -c --arg context "$context_text" '. + {context: $context}')
+	fi
+
+	if [[ -n "$metadata_json" ]]; then
+		# Validate metadata is valid JSON object
+		if echo "$metadata_json" | jq 'type == "object"' 2>/dev/null | grep -q true; then
+			entry=$(echo "$entry" | jq -c --argjson meta "$metadata_json" '. + {metadata: $meta}')
+		else
+			print_warning "Invalid metadata JSON (must be object), skipping"
+		fi
+	fi
+
+	echo "$entry" >>"$file_path"
+	print_success "Added entry '$entry_id' to $(basename "$file_path")"
+	return 0
+}
+
+# List available datasets
+cmd_list() {
+	local project_path=""
+	local show_global=true
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--project)
+			project_path="${2:-.}"
+			shift 2
+			;;
+		--no-global)
+			show_global=false
+			shift
+			;;
+		--help | -h)
+			echo "Usage: dataset-helper.sh list [--project <path>] [--no-global]"
+			echo ""
+			echo "Lists available datasets."
+			echo ""
+			echo "Options:"
+			echo "  --project <path>  Also list project datasets"
+			echo "  --no-global       Skip global datasets"
+			return 0
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	local found=0
+
+	# Global datasets
+	if [[ "$show_global" == "true" && -d "$GLOBAL_DATASETS_DIR" ]]; then
+		local global_files
+		global_files=$(find "$GLOBAL_DATASETS_DIR" -maxdepth 1 -name "*.jsonl" -type f 2>/dev/null | sort)
+		if [[ -n "$global_files" ]]; then
+			echo -e "${CYAN}Global datasets${NC} ($GLOBAL_DATASETS_DIR):"
+			while IFS= read -r f; do
+				local name count
+				name=$(basename "$f" .jsonl)
+				count=$(wc -l <"$f" | tr -d ' ')
+				printf "  %-30s %s entries\n" "$name" "$count"
+				found=$((found + 1))
+			done <<<"$global_files"
+		fi
+	fi
+
+	# Project datasets
+	if [[ -n "$project_path" ]]; then
+		local project_dir="${project_path}/datasets"
+		if [[ -d "$project_dir" ]]; then
+			local project_files
+			project_files=$(find "$project_dir" -maxdepth 1 -name "*.jsonl" -type f 2>/dev/null | sort)
+			if [[ -n "$project_files" ]]; then
+				echo -e "${CYAN}Project datasets${NC} ($project_dir):"
+				while IFS= read -r f; do
+					local name count
+					name=$(basename "$f" .jsonl)
+					count=$(wc -l <"$f" | tr -d ' ')
+					printf "  %-30s %s entries\n" "$name" "$count"
+					found=$((found + 1))
+				done <<<"$project_files"
+			fi
+		fi
+	fi
+
+	if [[ "$found" -eq 0 ]]; then
+		print_info "No datasets found. Create one: dataset-helper.sh create <name>"
+	fi
+
+	return 0
+}
+
+# Show dataset statistics
+cmd_stats() {
+	local file_path=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--help | -h)
+			echo "Usage: dataset-helper.sh stats <file>"
+			echo ""
+			echo "Shows statistics for a dataset."
+			echo ""
+			echo "Output:"
+			echo "  - Total entries"
+			echo "  - Tag distribution"
+			echo "  - Source breakdown"
+			echo "  - Entries with/without expected output"
+			return 0
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		*)
+			file_path="$1"
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$file_path" ]]; then
+		print_error "File path is required"
+		echo "Usage: dataset-helper.sh stats <file>"
+		return 1
+	fi
+
+	_require_jq || return 1
+
+	if [[ ! -f "$file_path" ]]; then
+		print_error "File not found: $file_path"
+		return 1
+	fi
+
+	local total
+	total=$(wc -l <"$file_path" | tr -d ' ')
+
+	echo -e "${CYAN}Dataset:${NC} $(basename "$file_path")"
+	echo -e "${CYAN}Path:${NC}    $file_path"
+	echo -e "${CYAN}Entries:${NC} $total"
+
+	if [[ "$total" -eq 0 ]]; then
+		print_info "Dataset is empty"
+		return 0
+	fi
+
+	# Entries with expected output
+	local with_expected
+	with_expected=$(jq -r 'select(.expected != null and .expected != "") | .id' <"$file_path" 2>/dev/null | wc -l | tr -d ' ')
+	echo -e "${CYAN}With expected output:${NC} $with_expected / $total"
+
+	# Entries with context
+	local with_context
+	with_context=$(jq -r 'select(.context != null and .context != "") | .id' <"$file_path" 2>/dev/null | wc -l | tr -d ' ')
+	echo -e "${CYAN}With context:${NC} $with_context / $total"
+
+	# Source breakdown
+	echo ""
+	echo -e "${CYAN}Source breakdown:${NC}"
+	jq -r '.source // "unknown"' <"$file_path" 2>/dev/null | sort | uniq -c | sort -rn | while read -r count source; do
+		printf "  %-25s %s\n" "$source" "$count"
+	done
+
+	# Tag distribution
+	echo ""
+	echo -e "${CYAN}Tag distribution:${NC}"
+	local tag_data
+	tag_data=$(jq -r '.tags // [] | .[]' <"$file_path" 2>/dev/null | sort | uniq -c | sort -rn)
+	if [[ -n "$tag_data" ]]; then
+		echo "$tag_data" | while read -r count tag; do
+			printf "  %-25s %s\n" "$tag" "$count"
+		done
+	else
+		echo "  (no tags)"
+	fi
+
+	return 0
+}
+
+# Promote an observability trace to a dataset entry
+cmd_promote() {
+	local trace_id=""
+	local output_file=""
+	local tags_csv=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--trace-id)
+			trace_id="$2"
+			shift 2
+			;;
+		--output | -o)
+			output_file="$2"
+			shift 2
+			;;
+		--tags)
+			tags_csv="$2"
+			shift 2
+			;;
+		--help | -h)
+			echo "Usage: dataset-helper.sh promote --trace-id <id> [-o <dataset>] [--tags \"a,b\"]"
+			echo ""
+			echo "Converts an observability trace into a dataset entry."
+			echo ""
+			echo "Options:"
+			echo "  --trace-id <id>   Request ID from observability metrics (required)"
+			echo "  -o <dataset>      Output dataset file (default: global promoted.jsonl)"
+			echo "  --tags \"a,b\"      Additional tags for the entry"
+			echo ""
+			echo "The trace's model, project, and cost are stored in metadata."
+			return 0
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$trace_id" ]]; then
+		print_error "--trace-id is required"
+		echo "Usage: dataset-helper.sh promote --trace-id <id>"
+		return 1
+	fi
+
+	_require_jq || return 1
+
+	if [[ ! -f "$OBS_METRICS" ]]; then
+		print_error "Observability metrics not found: $OBS_METRICS"
+		echo "Run 'observability-helper.sh ingest' first."
+		return 1
+	fi
+
+	# Find the trace in metrics
+	local trace_data
+	trace_data=$(jq -c "select(.request_id == \"$trace_id\")" <"$OBS_METRICS" 2>/dev/null | head -1)
+
+	if [[ -z "$trace_data" ]]; then
+		# Try matching by session_id as fallback
+		trace_data=$(jq -c "select(.session_id == \"$trace_id\")" <"$OBS_METRICS" 2>/dev/null | head -1)
+	fi
+
+	if [[ -z "$trace_data" ]]; then
+		print_error "Trace not found: $trace_id"
+		echo "Check available traces with: jq '.request_id' $OBS_METRICS | head"
+		return 1
+	fi
+
+	# Extract fields from trace
+	local model project cost_total recorded_at
+	model=$(echo "$trace_data" | jq -r '.model // "unknown"')
+	project=$(echo "$trace_data" | jq -r '.project // "unknown"')
+	cost_total=$(echo "$trace_data" | jq -r '.cost_total // 0')
+	recorded_at=$(echo "$trace_data" | jq -r '.recorded_at // ""')
+
+	# Default output file
+	if [[ -z "$output_file" ]]; then
+		_ensure_dir "$GLOBAL_DATASETS_DIR"
+		output_file="${GLOBAL_DATASETS_DIR}/promoted.jsonl"
+		[[ -f "$output_file" ]] || touch "$output_file"
+	fi
+
+	if [[ ! -f "$output_file" ]]; then
+		print_error "Output dataset not found: $output_file"
+		return 1
+	fi
+
+	# Build tags
+	local tags_json="[\"promoted\"]"
+	if [[ -n "$tags_csv" ]]; then
+		tags_json=$(echo "promoted,$tags_csv" | tr ',' '\n' | jq -R . | jq -s 'unique')
+	fi
+
+	# Build metadata from trace
+	local metadata
+	metadata=$(jq -c -n \
+		--arg model "$model" \
+		--arg project "$project" \
+		--arg cost "$cost_total" \
+		--arg recorded_at "$recorded_at" \
+		--arg trace_id "$trace_id" \
+		'{model: $model, project: $project, cost: ($cost | tonumber), recorded_at: $recorded_at, original_trace_id: $trace_id}')
+
+	# Create dataset entry — input is a placeholder since traces don't store prompts
+	local entry_id
+	entry_id=$(_generate_id)
+
+	local entry
+	entry=$(jq -c -n \
+		--arg id "$entry_id" \
+		--arg input "[Promoted from trace $trace_id] Model: $model, Project: $project" \
+		--argjson tags "$tags_json" \
+		--arg source "trace:$trace_id" \
+		--argjson metadata "$metadata" \
+		'{id: $id, input: $input, tags: $tags, source: $source, metadata: $metadata}')
+
+	echo "$entry" >>"$output_file"
+	print_success "Promoted trace '$trace_id' to dataset entry '$entry_id' in $(basename "$output_file")"
+	return 0
+}
+
+# Merge two datasets, deduplicating by ID
+cmd_merge() {
+	local file1=""
+	local file2=""
+	local output_file=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		-o | --output)
+			output_file="$2"
+			shift 2
+			;;
+		--help | -h)
+			echo "Usage: dataset-helper.sh merge <file1> <file2> -o <output>"
+			echo ""
+			echo "Merges two datasets, deduplicating by ID."
+			echo "When IDs conflict, entries from file2 take precedence."
+			return 0
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		*)
+			if [[ -z "$file1" ]]; then
+				file1="$1"
+			elif [[ -z "$file2" ]]; then
+				file2="$1"
+			else
+				print_error "Unexpected argument: $1"
+				return 1
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$file1" || -z "$file2" ]]; then
+		print_error "Two input files are required"
+		echo "Usage: dataset-helper.sh merge <file1> <file2> -o <output>"
+		return 1
+	fi
+
+	if [[ -z "$output_file" ]]; then
+		print_error "-o <output> is required"
+		return 1
+	fi
+
+	_require_jq || return 1
+
+	for f in "$file1" "$file2"; do
+		if [[ ! -f "$f" ]]; then
+			print_error "File not found: $f"
+			return 1
+		fi
+	done
+
+	# Merge: file1 first, then file2 overrides on ID conflict
+	# Use jq slurp to deduplicate by id (last wins)
+	local merged
+	merged=$(cat "$file1" "$file2" | jq -c -s '
+		group_by(.id) | map(last) | .[]
+	' 2>/dev/null)
+
+	if [[ -z "$merged" ]]; then
+		# Both files might be empty
+		touch "$output_file"
+		print_success "Merged (empty result): $output_file"
+		return 0
+	fi
+
+	echo "$merged" >"$output_file"
+
+	local count
+	count=$(wc -l <"$output_file" | tr -d ' ')
+	local count1 count2
+	count1=$(wc -l <"$file1" | tr -d ' ')
+	count2=$(wc -l <"$file2" | tr -d ' ')
+	local deduped=$((count1 + count2 - count))
+
+	print_success "Merged $count entries into $output_file ($deduped duplicates removed)"
+	return 0
+}
+
+# Print the dataset JSON schema
+cmd_schema() {
+	cat <<'SCHEMA'
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AI DevOps Evaluation Dataset Entry",
+  "description": "A single test case for LLM evaluation",
+  "type": "object",
+  "required": ["id", "input"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for this entry (auto-generated if omitted on add)"
+    },
+    "input": {
+      "type": "string",
+      "description": "The prompt or input to send to the model"
+    },
+    "expected": {
+      "type": ["string", "null"],
+      "description": "Expected output (null for open-ended evaluations like summarization)"
+    },
+    "context": {
+      "type": ["string", "null"],
+      "description": "Context for grounding — what the model should base its answer on"
+    },
+    "tags": {
+      "type": "array",
+      "items": {"type": "string"},
+      "description": "Tags for filtering: scenario type, domain, difficulty"
+    },
+    "source": {
+      "type": "string",
+      "description": "Provenance: 'manual', 'trace:<id>', 'generated:<model>'",
+      "default": "manual"
+    },
+    "metadata": {
+      "type": ["object", "null"],
+      "description": "Arbitrary key-value pairs for extra context"
+    }
+  },
+  "additionalProperties": false
+}
+SCHEMA
+	return 0
+}
+
+# Show help
+cmd_help() {
+	cat <<'HELP'
+dataset-helper.sh — Standardised JSONL dataset management for LLM evaluations
+
+Usage: dataset-helper.sh <command> [options]
+
+Commands:
+  create    <name> [--project]           Create empty dataset
+  validate  <file> [--strict]            Validate JSONL schema
+  add       <file> --input "..." [opts]  Append entry with auto-generated ID
+  list      [--project <path>]           List available datasets
+  stats     <file>                       Row count, tag/source breakdown
+  promote   --trace-id <id> [-o <file>]  Convert observability trace to entry
+  merge     <file1> <file2> -o <out>     Merge datasets, dedup by id
+  schema                                 Print the dataset JSON schema
+  help                                   Show this help
+
+Dataset format (JSONL — one JSON object per line):
+  Required: id, input
+  Optional: expected, context, tags, source, metadata
+
+Directory convention:
+  Global:  ~/.aidevops/.agent-workspace/datasets/
+  Project: <repo>/datasets/
+
+Examples:
+  dataset-helper.sh create golden-prompts
+  dataset-helper.sh add ~/.aidevops/.agent-workspace/datasets/golden-prompts.jsonl \
+    --input "What is the capital of France?" --expected "Paris" --tags "geography,factual"
+  dataset-helper.sh validate ~/.aidevops/.agent-workspace/datasets/golden-prompts.jsonl
+  dataset-helper.sh stats ~/.aidevops/.agent-workspace/datasets/golden-prompts.jsonl
+  dataset-helper.sh promote --trace-id abc123
+  dataset-helper.sh merge dataset1.jsonl dataset2.jsonl -o merged.jsonl
+HELP
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift 2>/dev/null || true
+
+	case "$command" in
+	create) cmd_create "$@" ;;
+	validate) cmd_validate "$@" ;;
+	add) cmd_add "$@" ;;
+	list) cmd_list "$@" ;;
+	stats) cmd_stats "$@" ;;
+	promote) cmd_promote "$@" ;;
+	merge) cmd_merge "$@" ;;
+	schema) cmd_schema ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		print_error "$ERROR_UNKNOWN_COMMAND: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/dataset-helper.sh
+++ b/.agents/scripts/dataset-helper.sh
@@ -229,8 +229,8 @@ cmd_validate() {
 
 		# Check required fields
 		local has_id has_input
-		has_id=$(echo "$line" | jq 'has("id")' 2>/dev/null)
-		has_input=$(echo "$line" | jq 'has("input")' 2>/dev/null)
+		has_id=$(echo "$line" | jq 'has("id")')
+		has_input=$(echo "$line" | jq 'has("input")')
 
 		if [[ "$has_id" != "true" ]]; then
 			print_error "Line $line_num: Missing required field 'id'"
@@ -245,7 +245,7 @@ cmd_validate() {
 		# Check for duplicate IDs (O(1) lookup via associative array)
 		if [[ "$has_id" == "true" ]]; then
 			local entry_id
-			entry_id=$(echo "$line" | jq -r '.id' 2>/dev/null)
+			entry_id=$(echo "$line" | jq -r '.id')
 			if [[ -n "${seen_ids[$entry_id]+x}" ]]; then
 				print_error "Line $line_num: Duplicate ID '$entry_id'"
 				errors=$((errors + 1))
@@ -265,7 +265,7 @@ cmd_validate() {
 				  if has("context") and (.context | type) != "string" and .context != null then "context must be string or null" else empty end,
 				  if has("source") and (.source | type) != "string" then "source must be string" else empty end,
 				  if has("metadata") and (.metadata | type) != "object" and .metadata != null then "metadata must be object or null" else empty end
-				] | .[]' 2>/dev/null || echo "")
+				] | .[]' || echo "")
 
 			if [[ -n "$type_errors" ]]; then
 				while IFS= read -r err; do
@@ -439,7 +439,7 @@ cmd_add() {
 
 	if [[ -n "$metadata_json" ]]; then
 		# Validate metadata is valid JSON object
-		if echo "$metadata_json" | jq 'type == "object"' 2>/dev/null | grep -q true; then
+		if echo "$metadata_json" | jq -e 'type == "object"' >/dev/null 2>&1; then
 			entry=$(echo "$entry" | jq -c --argjson meta "$metadata_json" '. + {metadata: $meta}')
 		else
 			print_warning "Invalid metadata JSON (must be object), skipping"
@@ -508,9 +508,12 @@ cmd_list() {
 	# Project datasets
 	if [[ -n "$project_path" ]]; then
 		local project_dir="${project_path}/datasets"
+		# Resolve to absolute path to prevent option injection if path starts with hyphen
 		if [[ -d "$project_dir" ]]; then
+			local abs_project_dir
+			abs_project_dir=$(cd "$project_dir" && pwd)
 			local project_files
-			project_files=$(find "$project_dir" -maxdepth 1 -name "*.jsonl" -type f 2>/dev/null | sort)
+			project_files=$(find "$abs_project_dir" -maxdepth 1 -name "*.jsonl" -type f 2>/dev/null | sort)
 			if [[ -n "$project_files" ]]; then
 				echo -e "${CYAN}Project datasets${NC} ($project_dir):"
 				while IFS= read -r f; do
@@ -587,18 +590,18 @@ cmd_stats() {
 
 	# Entries with expected output
 	local with_expected
-	with_expected=$(jq -r 'select(.expected != null and .expected != "") | .id' <"$file_path" 2>/dev/null | wc -l | tr -d ' ')
+	with_expected=$(jq -r 'select(.expected != null and .expected != "") | .id' <"$file_path" | wc -l | tr -d ' ')
 	echo -e "${CYAN}With expected output:${NC} $with_expected / $total"
 
 	# Entries with context
 	local with_context
-	with_context=$(jq -r 'select(.context != null and .context != "") | .id' <"$file_path" 2>/dev/null | wc -l | tr -d ' ')
+	with_context=$(jq -r 'select(.context != null and .context != "") | .id' <"$file_path" | wc -l | tr -d ' ')
 	echo -e "${CYAN}With context:${NC} $with_context / $total"
 
 	# Source breakdown
 	echo ""
 	echo -e "${CYAN}Source breakdown:${NC}"
-	jq -r '.source // "unknown"' <"$file_path" 2>/dev/null | sort | uniq -c | sort -rn | while read -r count source; do
+	jq -r '.source // "unknown"' <"$file_path" | sort | uniq -c | sort -rn | while read -r count source; do
 		printf "  %-25s %s\n" "$source" "$count"
 	done
 
@@ -606,7 +609,7 @@ cmd_stats() {
 	echo ""
 	echo -e "${CYAN}Tag distribution:${NC}"
 	local tag_data
-	tag_data=$(jq -r '.tags // [] | .[]' <"$file_path" 2>/dev/null | sort | uniq -c | sort -rn)
+	tag_data=$(jq -r '.tags // [] | .[]' <"$file_path" | sort | uniq -c | sort -rn)
 	if [[ -n "$tag_data" ]]; then
 		echo "$tag_data" | while read -r count tag; do
 			printf "  %-25s %s\n" "$tag" "$count"
@@ -627,14 +630,26 @@ cmd_promote() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--trace-id)
+			[[ $# -ge 2 ]] || {
+				print_error "--trace-id requires a value"
+				return 1
+			}
 			trace_id="$2"
 			shift 2
 			;;
 		--output | -o)
+			[[ $# -ge 2 ]] || {
+				print_error "-o/--output requires a value"
+				return 1
+			}
 			output_file="$2"
 			shift 2
 			;;
 		--tags)
+			[[ $# -ge 2 ]] || {
+				print_error "--tags requires a value"
+				return 1
+			}
 			tags_csv="$2"
 			shift 2
 			;;
@@ -656,7 +671,8 @@ cmd_promote() {
 			return 1
 			;;
 		*)
-			shift
+			print_error "Unexpected argument: $1"
+			return 1
 			;;
 		esac
 	done
@@ -677,11 +693,11 @@ cmd_promote() {
 
 	# Find the trace in metrics (use --arg to safely pass trace_id)
 	local trace_data
-	trace_data=$(jq -c --arg trace_id "$trace_id" 'select(.request_id == $trace_id)' <"$OBS_METRICS" 2>/dev/null | head -1)
+	trace_data=$(jq -c --arg trace_id "$trace_id" 'select(.request_id == $trace_id)' <"$OBS_METRICS" | head -1)
 
 	if [[ -z "$trace_data" ]]; then
 		# Try matching by session_id as fallback
-		trace_data=$(jq -c --arg trace_id "$trace_id" 'select(.session_id == $trace_id)' <"$OBS_METRICS" 2>/dev/null | head -1)
+		trace_data=$(jq -c --arg trace_id "$trace_id" 'select(.session_id == $trace_id)' <"$OBS_METRICS" | head -1)
 	fi
 
 	if [[ -z "$trace_data" ]]; then
@@ -752,6 +768,10 @@ cmd_merge() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		-o | --output)
+			[[ $# -ge 2 ]] || {
+				print_error "-o/--output requires a value"
+				return 1
+			}
 			output_file="$2"
 			shift 2
 			;;
@@ -805,7 +825,7 @@ cmd_merge() {
 	local merged
 	if ! merged=$(jq -c -s '
 		reduce .[] as $row ({}; .[$row.id] = $row) | .[]
-	' "$file1" "$file2" 2>/dev/null); then
+	' -- "$file1" "$file2"); then
 		print_error "Merge failed: invalid JSON input"
 		return 1
 	fi

--- a/.agents/scripts/dataset-helper.sh
+++ b/.agents/scripts/dataset-helper.sh
@@ -212,7 +212,7 @@ cmd_validate() {
 
 	local errors=0
 	local line_num=0
-	local seen_ids=""
+	local -A seen_ids=()
 
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		line_num=$((line_num + 1))
@@ -242,15 +242,15 @@ cmd_validate() {
 			errors=$((errors + 1))
 		fi
 
-		# Check for duplicate IDs
+		# Check for duplicate IDs (O(1) lookup via associative array)
 		if [[ "$has_id" == "true" ]]; then
 			local entry_id
 			entry_id=$(echo "$line" | jq -r '.id' 2>/dev/null)
-			if echo "$seen_ids" | grep -qx "$entry_id" 2>/dev/null; then
+			if [[ -n "${seen_ids[$entry_id]+x}" ]]; then
 				print_error "Line $line_num: Duplicate ID '$entry_id'"
 				errors=$((errors + 1))
 			else
-				seen_ids="${seen_ids}${entry_id}"$'\n'
+				seen_ids["$entry_id"]=1
 			fi
 		fi
 
@@ -258,7 +258,9 @@ cmd_validate() {
 		if [[ "$strict" == "true" ]]; then
 			local type_errors
 			type_errors=$(echo "$line" | jq '
-				[ if has("tags") and (.tags | type) != "array" then "tags must be array" else empty end,
+				[ if has("id") and (.id | type) != "string" then "id must be string" else empty end,
+				  if has("input") and (.input | type) != "string" then "input must be string" else empty end,
+				  if has("tags") and ((.tags | type) != "array" or any(.tags[]?; type != "string")) then "tags must be an array of strings" else empty end,
 				  if has("expected") and (.expected | type) != "string" and .expected != null then "expected must be string or null" else empty end,
 				  if has("context") and (.context | type) != "string" and .context != null then "context must be string or null" else empty end,
 				  if has("source") and (.source | type) != "string" then "source must be string" else empty end,
@@ -301,30 +303,58 @@ cmd_add() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--input)
+			[[ $# -ge 2 ]] || {
+				print_error "--input requires a value"
+				return 1
+			}
 			input_text="$2"
 			shift 2
 			;;
 		--expected)
+			[[ $# -ge 2 ]] || {
+				print_error "--expected requires a value"
+				return 1
+			}
 			expected_text="$2"
 			shift 2
 			;;
 		--context)
+			[[ $# -ge 2 ]] || {
+				print_error "--context requires a value"
+				return 1
+			}
 			context_text="$2"
 			shift 2
 			;;
 		--tags)
+			[[ $# -ge 2 ]] || {
+				print_error "--tags requires a value"
+				return 1
+			}
 			tags_csv="$2"
 			shift 2
 			;;
 		--source)
+			[[ $# -ge 2 ]] || {
+				print_error "--source requires a value"
+				return 1
+			}
 			source_text="$2"
 			shift 2
 			;;
 		--id)
+			[[ $# -ge 2 ]] || {
+				print_error "--id requires a value"
+				return 1
+			}
 			entry_id="$2"
 			shift 2
 			;;
 		--metadata)
+			[[ $# -ge 2 ]] || {
+				print_error "--metadata requires a value"
+				return 1
+			}
 			metadata_json="$2"
 			shift 2
 			;;
@@ -446,8 +476,13 @@ cmd_list() {
 			echo "  --no-global       Skip global datasets"
 			return 0
 			;;
+		-*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
 		*)
-			shift
+			print_error "Unexpected argument: $1"
+			return 1
 			;;
 		esac
 	done
@@ -640,13 +675,13 @@ cmd_promote() {
 		return 1
 	fi
 
-	# Find the trace in metrics
+	# Find the trace in metrics (use --arg to safely pass trace_id)
 	local trace_data
-	trace_data=$(jq -c "select(.request_id == \"$trace_id\")" <"$OBS_METRICS" 2>/dev/null | head -1)
+	trace_data=$(jq -c --arg trace_id "$trace_id" 'select(.request_id == $trace_id)' <"$OBS_METRICS" 2>/dev/null | head -1)
 
 	if [[ -z "$trace_data" ]]; then
 		# Try matching by session_id as fallback
-		trace_data=$(jq -c "select(.session_id == \"$trace_id\")" <"$OBS_METRICS" 2>/dev/null | head -1)
+		trace_data=$(jq -c --arg trace_id "$trace_id" 'select(.session_id == $trace_id)' <"$OBS_METRICS" 2>/dev/null | head -1)
 	fi
 
 	if [[ -z "$trace_data" ]]; then
@@ -766,11 +801,14 @@ cmd_merge() {
 	done
 
 	# Merge: file1 first, then file2 overrides on ID conflict
-	# Use jq slurp to deduplicate by id (last wins)
+	# Use reduce-to-map so "file2 wins" is deterministic (last write wins by key)
 	local merged
-	merged=$(cat "$file1" "$file2" | jq -c -s '
-		group_by(.id) | map(last) | .[]
-	' 2>/dev/null)
+	if ! merged=$(jq -c -s '
+		reduce .[] as $row ({}; .[$row.id] = $row) | .[]
+	' "$file1" "$file2" 2>/dev/null); then
+		print_error "Merge failed: invalid JSON input"
+		return 1
+	fi
 
 	if [[ -z "$merged" ]]; then
 		# Both files might be empty

--- a/.agents/tools/ai-assistants/datasets.md
+++ b/.agents/tools/ai-assistants/datasets.md
@@ -43,36 +43,39 @@ Run `dataset-helper.sh schema` for the full JSON Schema.
 ## CLI Reference
 
 ```bash
+# Set the global dataset directory for copy/paste convenience
+DATASET_DIR="$HOME/.aidevops/.agent-workspace/datasets"
+
 # Create a new dataset
 dataset-helper.sh create golden-prompts                    # Global
 dataset-helper.sh create api-tests --project ~/Git/myapp   # Project-local
 
-# Add entries
-dataset-helper.sh add golden-prompts.jsonl \
+# Add entries (use full path from create output, or $DATASET_DIR)
+dataset-helper.sh add "$DATASET_DIR/golden-prompts.jsonl" \
   --input "What is the capital of France?" \
   --expected "Paris" \
   --tags "geography,factual"
 
-dataset-helper.sh add golden-prompts.jsonl \
+dataset-helper.sh add "$DATASET_DIR/golden-prompts.jsonl" \
   --input "Summarize this code" \
   --context "function add(a, b) { return a + b; }" \
   --tags "code,summarization" \
   --source "manual"
 
 # Validate dataset schema
-dataset-helper.sh validate golden-prompts.jsonl            # Basic checks
-dataset-helper.sh validate golden-prompts.jsonl --strict   # + type checking
+dataset-helper.sh validate "$DATASET_DIR/golden-prompts.jsonl"            # Basic checks
+dataset-helper.sh validate "$DATASET_DIR/golden-prompts.jsonl" --strict   # + type checking
 
 # List available datasets
 dataset-helper.sh list                                     # Global only
 dataset-helper.sh list --project ~/Git/myapp               # Global + project
 
 # Show statistics
-dataset-helper.sh stats golden-prompts.jsonl
+dataset-helper.sh stats "$DATASET_DIR/golden-prompts.jsonl"
 
 # Promote observability trace to dataset entry
 dataset-helper.sh promote --trace-id abc123
-dataset-helper.sh promote --trace-id abc123 -o regression.jsonl --tags "regression"
+dataset-helper.sh promote --trace-id abc123 -o "$DATASET_DIR/regression.jsonl" --tags "regression"
 
 # Merge datasets (dedup by ID, file2 wins on conflict)
 dataset-helper.sh merge dataset1.jsonl dataset2.jsonl -o merged.jsonl

--- a/.agents/tools/ai-assistants/datasets.md
+++ b/.agents/tools/ai-assistants/datasets.md
@@ -1,0 +1,118 @@
+# Evaluation Datasets
+
+Standardised JSONL format and directory convention for storing LLM evaluation test cases. Enables repeatable evaluations across bench and evaluator workflows.
+
+## Dataset Format
+
+Each line is a JSON object (JSONL). Required fields: `id`, `input`.
+
+```jsonl
+{"id":"001","input":"What is the capital of France?","expected":"Paris","context":"France is in Western Europe.","tags":["geography","factual"],"source":"manual"}
+{"id":"002","input":"Summarize this PR","expected":null,"context":"PR #123 adds auth middleware...","tags":["code-review","summarization"],"source":"trace:abc123"}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `id` | string | Yes | Unique identifier (auto-generated on `add`) |
+| `input` | string | Yes | Prompt or input to send to the model |
+| `expected` | string/null | No | Expected output (null for open-ended evaluations) |
+| `context` | string/null | No | Context for grounding (faithfulness evaluation) |
+| `tags` | string[] | No | Tags for filtering: scenario type, domain, difficulty |
+| `source` | string | No | Provenance: `manual`, `trace:<id>`, `generated:<model>` |
+| `metadata` | object/null | No | Arbitrary key-value pairs for extra context |
+
+Run `dataset-helper.sh schema` for the full JSON Schema.
+
+## Directory Convention
+
+```text
+~/.aidevops/.agent-workspace/datasets/    # Global datasets (cross-project)
+  golden-prompts.jsonl                     # Curated test prompts
+  regression-auth.jsonl                    # Auth-related regression cases
+  promoted.jsonl                           # Auto-created by promote command
+
+~/Git/myproject/datasets/                  # Project-specific datasets
+  api-responses.jsonl                      # Expected API response quality
+```
+
+- **Global datasets** live in agent-workspace — shared across all projects
+- **Project datasets** live in the repo's `datasets/` directory — version-controlled with the code
+
+## CLI Reference
+
+```bash
+# Create a new dataset
+dataset-helper.sh create golden-prompts                    # Global
+dataset-helper.sh create api-tests --project ~/Git/myapp   # Project-local
+
+# Add entries
+dataset-helper.sh add golden-prompts.jsonl \
+  --input "What is the capital of France?" \
+  --expected "Paris" \
+  --tags "geography,factual"
+
+dataset-helper.sh add golden-prompts.jsonl \
+  --input "Summarize this code" \
+  --context "function add(a, b) { return a + b; }" \
+  --tags "code,summarization" \
+  --source "manual"
+
+# Validate dataset schema
+dataset-helper.sh validate golden-prompts.jsonl            # Basic checks
+dataset-helper.sh validate golden-prompts.jsonl --strict   # + type checking
+
+# List available datasets
+dataset-helper.sh list                                     # Global only
+dataset-helper.sh list --project ~/Git/myapp               # Global + project
+
+# Show statistics
+dataset-helper.sh stats golden-prompts.jsonl
+
+# Promote observability trace to dataset entry
+dataset-helper.sh promote --trace-id abc123
+dataset-helper.sh promote --trace-id abc123 -o regression.jsonl --tags "regression"
+
+# Merge datasets (dedup by ID, file2 wins on conflict)
+dataset-helper.sh merge dataset1.jsonl dataset2.jsonl -o merged.jsonl
+```
+
+## Workflows
+
+### Building a Golden Dataset
+
+1. Start with manual entries for known test cases
+2. Run evaluations, identify failures
+3. Add failure cases to the dataset with appropriate tags
+4. Re-run evaluations after prompt changes to detect regressions
+
+### Promoting from Traces
+
+When observability captures an interesting interaction:
+
+1. Find the trace ID: `jq '.request_id' ~/.aidevops/.agent-workspace/observability/metrics.jsonl | tail`
+2. Promote it: `dataset-helper.sh promote --trace-id <id> --tags "edge-case"`
+3. Edit the promoted entry to add expected output and refine the input
+
+### Integration with Bench (t1393)
+
+```bash
+# Run the same dataset through multiple models
+compare-models-helper.sh bench --dataset golden-prompts.jsonl
+```
+
+### Integration with Evaluators (t1394)
+
+```bash
+# Score model outputs against dataset expectations
+ai-judgment-helper.sh evaluate --dataset golden-prompts.jsonl
+```
+
+## Design Decisions
+
+- **JSONL over CSV/JSON-array**: Streamable (append without rewriting), one entry per line (easy grep/wc), standard in ML/eval tooling, consistent with observability-helper.sh
+- **`id` required**: Enables deduplication, trace-back, and merge operations
+- **`expected` optional**: Many evaluations don't have a single correct answer (summarization, creative writing)
+- **`source` tracks provenance**: Know whether a test case was hand-written, promoted from production, or synthetically generated
+- **`tags` enable filtering**: Run subsets of a dataset by scenario type, domain, or difficulty


### PR DESCRIPTION
## Summary

- Adds `dataset-helper.sh` with standardised JSONL dataset management for LLM evaluations
- Establishes directory convention: global datasets in `~/.aidevops/.agent-workspace/datasets/`, project datasets in `<repo>/datasets/`
- Adds `datasets.md` agent documentation covering format spec, CLI reference, and workflows

## Deliverables

| Acceptance Criteria | Status |
|---|---|
| `create` creates valid empty JSONL file | Verified |
| `validate` checks JSONL schema (required fields, valid JSON, duplicate IDs) | Verified |
| `validate --strict` checks optional field types | Verified |
| `add` appends entries with auto-generated IDs | Verified |
| `promote --trace-id` converts observability trace to dataset entry | Verified |
| `stats` shows row count, tag distribution, source breakdown | Verified |
| `merge` deduplicates by ID (file2 wins on conflict) | Verified |
| `schema` prints full JSON Schema | Verified |
| ShellCheck clean | Verified |
| Documentation covers format spec, directory convention, workflows | Verified |

## Subcommands

```
create    <name> [--project]           Create empty dataset
validate  <file> [--strict]            Validate JSONL schema
add       <file> --input "..." [opts]  Append entry with auto-generated ID
list      [--project <path>]           List available datasets
stats     <file>                       Row count, tag/source breakdown
promote   --trace-id <id> [-o <file>]  Convert observability trace to entry
merge     <file1> <file2> -o <out>     Merge datasets, dedup by id
schema                                 Print the dataset JSON schema
```

## Dataset Format (JSONL)

```jsonl
{"id":"001","input":"What is the capital of France?","expected":"Paris","tags":["geography"],"source":"manual"}
```

Required: `id`, `input`. Optional: `expected`, `context`, `tags`, `source`, `metadata`.

Closes #2905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a dataset management toolkit for standardized JSONL evaluation workflows, supporting create, validate (including strict mode), add (auto-ID), list, stats, promote (trace-to-dataset), merge (deduplication), schema output, and help/CLI.

* **Documentation**
  * Added comprehensive guide detailing dataset format, required/optional fields, directory conventions, examples, and recommended workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->