### PR TITLE
t1393: Live model benchmarking

### DIFF
--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -16,6 +16,7 @@
 #   providers     List supported providers
 #   discover      Detect available providers and models from local config
 #   cross-review  Dispatch same prompt to multiple models, diff results (t132.8)
+#   bench         Live benchmark: send same prompt to N models, compare outputs (t1393)
 #   help          Show this help
 #
 # Author: AI DevOps Framework
@@ -1307,6 +1308,7 @@ cmd_help() {
 	echo "  score         Record model comparison scores (from evaluation)"
 	echo "  results       View past comparison results and rankings"
 	echo "  cross-review  Dispatch same prompt to multiple models, diff results"
+	echo "  bench         Live benchmark: send same prompt to N models, compare outputs (t1393)"
 	echo "  help          Show this help"
 	echo ""
 	echo "Examples:"
@@ -1350,6 +1352,13 @@ cmd_help() {
 	echo "  compare-models-helper.sh cross-review \\"
 	echo "    --prompt 'Review this PR diff' --models 'sonnet,gemini-pro' \\"
 	echo "    --score --judge sonnet            # use sonnet as judge instead"
+	echo ""
+	echo "Bench examples (t1393):"
+	echo "  compare-models-helper.sh bench 'What is 2+2?' claude-sonnet-4-6 gpt-4o"
+	echo "  compare-models-helper.sh bench 'Explain quicksort' claude-sonnet-4-6 gpt-4.1 gemini-2.5-pro --judge"
+	echo "  compare-models-helper.sh bench --dataset prompts.jsonl claude-sonnet-4-6 gpt-4o --judge"
+	echo "  compare-models-helper.sh bench 'What is 2+2?' claude-sonnet-4-6 --dry-run"
+	echo "  compare-models-helper.sh bench --history --limit 10"
 	echo ""
 	echo "Data is embedded in this script. Last updated: 2025-02-08."
 	echo "For live pricing, use /compare-models (with web fetch)."
@@ -2119,6 +2128,830 @@ cmd_results() {
 }
 
 # =============================================================================
+# Live Model Benchmarking (t1393)
+# =============================================================================
+# Sends the same prompt (or JSONL dataset) to N models and compares actual
+# outputs with latency, tokens, cost, and optional LLM-as-judge quality score.
+#
+# Storage: ~/.aidevops/.agent-workspace/observability/bench-results.jsonl
+
+readonly BENCH_RESULTS_DIR="${HOME}/.aidevops/.agent-workspace/observability"
+readonly BENCH_RESULTS_FILE="${BENCH_RESULTS_DIR}/bench-results.jsonl"
+
+# Resolve a provider API key value for use in curl calls.
+# Uses the same resolution chain as check_provider_key but returns the value.
+# Arguments: $1 — env var name (e.g. ANTHROPIC_API_KEY)
+# Output: key value on stdout
+# Returns: 0 if found, 1 if not
+_resolve_key_value() {
+	local key_name="$1"
+
+	# 1. Environment variable
+	if [[ -n "${!key_name:-}" ]]; then
+		echo "${!key_name}"
+		return 0
+	fi
+
+	# 2. gopass
+	if command -v gopass &>/dev/null; then
+		local val
+		val=$(gopass show -o "aidevops/${key_name}" 2>/dev/null) || true
+		if [[ -n "$val" ]]; then
+			echo "$val"
+			return 0
+		fi
+	fi
+
+	# 3. credentials.sh
+	local creds_file="${HOME}/.config/aidevops/credentials.sh"
+	if [[ -f "$creds_file" ]]; then
+		local val
+		val=$(grep -E "^(export )?${key_name}=" "$creds_file" 2>/dev/null | head -1 | sed "s/^export //" | cut -d= -f2- | tr -d '"'"'" || true)
+		if [[ -n "$val" ]]; then
+			echo "$val"
+			return 0
+		fi
+	fi
+
+	return 1
+}
+
+# Determine which provider a model_id belongs to and its API key env var.
+# Output: "provider|key_env_var" or empty if unknown
+_model_provider_info() {
+	local model_id="$1"
+	local match
+	match=$(echo "$MODEL_DATA" | grep "^${model_id}|" || true)
+	if [[ -z "$match" ]]; then
+		# Try partial match
+		match=$(find_model "$model_id" | head -1)
+	fi
+	if [[ -z "$match" ]]; then
+		echo ""
+		return 0
+	fi
+
+	local provider
+	provider=$(get_field "$match" 2)
+	local actual_model_id
+	actual_model_id=$(get_field "$match" 1)
+
+	local key_var=""
+	case "$provider" in
+	Anthropic) key_var="ANTHROPIC_API_KEY" ;;
+	OpenAI) key_var="OPENAI_API_KEY" ;;
+	Google) key_var="GOOGLE_API_KEY" ;;
+	DeepSeek) key_var="DEEPSEEK_API_KEY" ;;
+	*) key_var="" ;;
+	esac
+
+	echo "${provider}|${key_var}|${actual_model_id}"
+	return 0
+}
+
+# Map model_id to the API model string each provider expects
+_api_model_string() {
+	local model_id="$1"
+	case "$model_id" in
+	claude-opus-4-6) echo "claude-opus-4-20250514" ;;
+	claude-sonnet-4-6) echo "claude-sonnet-4-20250514" ;;
+	claude-haiku-4-5) echo "claude-haiku-4-20250414" ;;
+	gpt-4.1) echo "gpt-4.1" ;;
+	gpt-4.1-mini) echo "gpt-4.1-mini" ;;
+	gpt-4.1-nano) echo "gpt-4.1-nano" ;;
+	gpt-4o) echo "gpt-4o" ;;
+	gpt-4o-mini) echo "gpt-4o-mini" ;;
+	o3) echo "o3" ;;
+	o4-mini) echo "o4-mini" ;;
+	gemini-2.5-pro) echo "gemini-2.5-pro" ;;
+	gemini-2.5-flash) echo "gemini-2.5-flash" ;;
+	gemini-2.0-flash) echo "gemini-2.0-flash" ;;
+	deepseek-r1) echo "deepseek-reasoner" ;;
+	deepseek-v3) echo "deepseek-chat" ;;
+	*) echo "$model_id" ;;
+	esac
+	return 0
+}
+
+# Call a single model API and capture response + metrics.
+# Arguments:
+#   $1 — model_id (from MODEL_DATA)
+#   $2 — prompt text
+#   $3 — max_tokens
+#   $4 — output directory for result files
+# Output: writes result JSON to $4/$model_id.json
+# Returns: 0 on success, 1 on failure
+_bench_call_model() {
+	local model_id="$1"
+	local prompt="$2"
+	local max_tokens="$3"
+	local out_dir="$4"
+
+	local info
+	info=$(_model_provider_info "$model_id")
+	if [[ -z "$info" ]]; then
+		echo "{\"error\":\"unknown model: ${model_id}\"}" >"${out_dir}/${model_id}.json"
+		return 1
+	fi
+
+	local provider key_var actual_id
+	IFS='|' read -r provider key_var actual_id <<<"$info"
+
+	if [[ -z "$key_var" ]]; then
+		echo "{\"error\":\"no API key mapping for provider: ${provider}\"}" >"${out_dir}/${actual_id}.json"
+		return 1
+	fi
+
+	local api_key
+	api_key=$(_resolve_key_value "$key_var") || {
+		echo "{\"error\":\"API key not found: ${key_var}\"}" >"${out_dir}/${actual_id}.json"
+		return 1
+	}
+
+	local api_model
+	api_model=$(_api_model_string "$actual_id")
+
+	# Escape prompt for JSON
+	local escaped_prompt
+	if command -v python3 &>/dev/null; then
+		escaped_prompt=$(printf '%s' "$prompt" | python3 -c 'import sys,json; print(json.dumps(sys.stdin.read()))' 2>/dev/null)
+	else
+		escaped_prompt="\"$(printf '%s' "$prompt" | sed 's/\\/\\\\/g; s/"/\\"/g; s/\n/\\n/g; s/\t/\\t/g')\""
+	fi
+
+	local start_ms response http_code end_ms latency_ms
+	start_ms=$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || date +%s000)
+
+	local result_file="${out_dir}/${actual_id}.json"
+	local raw_file="${out_dir}/${actual_id}-raw.json"
+
+	case "$provider" in
+	Anthropic)
+		http_code=$(curl -sS -o "$raw_file" -w "%{http_code}" --max-time 120 \
+			-H "x-api-key: ${api_key}" \
+			-H "anthropic-version: 2023-06-01" \
+			-H "${CONTENT_TYPE_JSON}" \
+			-d "{
+				\"model\": \"${api_model}\",
+				\"max_tokens\": ${max_tokens},
+				\"messages\": [{\"role\": \"user\", \"content\": ${escaped_prompt}}]
+			}" \
+			"https://api.anthropic.com/v1/messages" 2>/dev/null) || http_code="000"
+		;;
+	OpenAI)
+		http_code=$(curl -sS -o "$raw_file" -w "%{http_code}" --max-time 120 \
+			-H "Authorization: Bearer ${api_key}" \
+			-H "${CONTENT_TYPE_JSON}" \
+			-d "{
+				\"model\": \"${api_model}\",
+				\"max_tokens\": ${max_tokens},
+				\"messages\": [{\"role\": \"user\", \"content\": ${escaped_prompt}}]
+			}" \
+			"https://api.openai.com/v1/chat/completions" 2>/dev/null) || http_code="000"
+		;;
+	Google)
+		# Google uses a different API format
+		http_code=$(curl -sS -o "$raw_file" -w "%{http_code}" --max-time 120 \
+			-H "${CONTENT_TYPE_JSON}" \
+			-d "{
+				\"contents\": [{\"parts\": [{\"text\": ${escaped_prompt}}]}],
+				\"generationConfig\": {\"maxOutputTokens\": ${max_tokens}}
+			}" \
+			"https://generativelanguage.googleapis.com/v1beta/models/${api_model}:generateContent?key=${api_key}" \
+			2>/dev/null) || http_code="000"
+		;;
+	DeepSeek)
+		http_code=$(curl -sS -o "$raw_file" -w "%{http_code}" --max-time 120 \
+			-H "Authorization: Bearer ${api_key}" \
+			-H "${CONTENT_TYPE_JSON}" \
+			-d "{
+				\"model\": \"${api_model}\",
+				\"max_tokens\": ${max_tokens},
+				\"messages\": [{\"role\": \"user\", \"content\": ${escaped_prompt}}]
+			}" \
+			"https://api.deepseek.com/v1/chat/completions" 2>/dev/null) || http_code="000"
+		;;
+	*)
+		echo "{\"error\":\"unsupported provider: ${provider}\"}" >"$result_file"
+		return 1
+		;;
+	esac
+
+	end_ms=$(python3 -c 'import time; print(int(time.time()*1000))' 2>/dev/null || date +%s000)
+	latency_ms=$((end_ms - start_ms))
+
+	# Parse response into normalized format using python3
+	if [[ ! -f "$raw_file" ]] || [[ ! -s "$raw_file" ]]; then
+		echo "{\"error\":\"empty response\",\"http_code\":\"${http_code}\",\"latency_ms\":${latency_ms}}" >"$result_file"
+		return 1
+	fi
+
+	python3 -c "
+import json, sys
+
+provider = '${provider}'
+model_id = '${actual_id}'
+latency_ms = ${latency_ms}
+http_code = '${http_code}'
+
+try:
+    with open('${raw_file}', 'r') as f:
+        raw = json.load(f)
+except Exception as e:
+    json.dump({'error': str(e), 'http_code': http_code, 'latency_ms': latency_ms, 'model': model_id}, sys.stdout)
+    sys.exit(0)
+
+result = {
+    'model': model_id,
+    'provider': provider,
+    'latency_ms': latency_ms,
+    'http_code': http_code,
+    'tokens_in': 0,
+    'tokens_out': 0,
+    'output': '',
+    'error': ''
+}
+
+if provider == 'Anthropic':
+    result['output'] = ''.join(b.get('text', '') for b in raw.get('content', []))
+    usage = raw.get('usage', {})
+    result['tokens_in'] = usage.get('input_tokens', 0)
+    result['tokens_out'] = usage.get('output_tokens', 0)
+    if raw.get('error'):
+        result['error'] = raw['error'].get('message', str(raw['error']))
+elif provider in ('OpenAI', 'DeepSeek'):
+    choices = raw.get('choices', [])
+    if choices:
+        result['output'] = choices[0].get('message', {}).get('content', '')
+    usage = raw.get('usage', {})
+    result['tokens_in'] = usage.get('prompt_tokens', 0)
+    result['tokens_out'] = usage.get('completion_tokens', 0)
+    if raw.get('error'):
+        result['error'] = raw['error'].get('message', str(raw['error']))
+elif provider == 'Google':
+    candidates = raw.get('candidates', [])
+    if candidates:
+        parts = candidates[0].get('content', {}).get('parts', [])
+        result['output'] = ''.join(p.get('text', '') for p in parts)
+    usage = raw.get('usageMetadata', {})
+    result['tokens_in'] = usage.get('promptTokenCount', 0)
+    result['tokens_out'] = usage.get('candidatesTokenCount', 0)
+    if raw.get('error'):
+        result['error'] = raw['error'].get('message', str(raw['error']))
+
+json.dump(result, sys.stdout)
+" >"$result_file" 2>/dev/null || {
+		echo "{\"error\":\"parse failure\",\"latency_ms\":${latency_ms},\"model\":\"${actual_id}\"}" >"$result_file"
+		return 1
+	}
+
+	# Clean up raw file
+	rm -f "$raw_file"
+	return 0
+}
+
+# Calculate cost from token counts and model pricing
+# Arguments: $1=model_id $2=tokens_in $3=tokens_out
+# Output: cost as decimal string
+_calc_bench_cost() {
+	local model_id="$1"
+	local tokens_in="$2"
+	local tokens_out="$3"
+
+	local match
+	match=$(echo "$MODEL_DATA" | grep "^${model_id}|" | head -1 || true)
+	if [[ -z "$match" ]]; then
+		echo "0.0000"
+		return 0
+	fi
+
+	local input_price output_price
+	input_price=$(get_field "$match" 5)
+	output_price=$(get_field "$match" 6)
+
+	# Cost = (tokens / 1M) * price_per_1M
+	awk "BEGIN{printf \"%.6f\", (${tokens_in}/1000000.0)*${input_price} + (${tokens_out}/1000000.0)*${output_price}}"
+	return 0
+}
+
+# Store bench result as JSONL
+_store_bench_result() {
+	local model_id="$1"
+	local prompt_text="$2"
+	local latency_ms="$3"
+	local tokens_in="$4"
+	local tokens_out="$5"
+	local cost="$6"
+	local judge_score="${7:-}"
+	local prompt_version="${8:-}"
+
+	mkdir -p "$BENCH_RESULTS_DIR"
+
+	local ts
+	ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	local prompt_hash
+	prompt_hash=$(printf '%s' "$prompt_text" | sha256sum | cut -c1-12)
+
+	local output_hash
+	output_hash=$(printf '%s' "${model_id}:${ts}" | sha256sum | cut -c1-12)
+
+	local judge_field=""
+	if [[ -n "$judge_score" ]]; then
+		judge_field=",\"judge_score\":${judge_score}"
+	fi
+
+	local version_field=""
+	if [[ -n "$prompt_version" ]]; then
+		version_field=",\"prompt_version\":\"${prompt_version}\""
+	fi
+
+	printf '{"ts":"%s","prompt_hash":"%s","model":"%s","latency_ms":%d,"tokens_in":%d,"tokens_out":%d,"cost":%s%s%s,"output_hash":"%s"}\n' \
+		"$ts" "$prompt_hash" "$model_id" "$latency_ms" "$tokens_in" "$tokens_out" "$cost" \
+		"$judge_field" "$version_field" "$output_hash" >>"$BENCH_RESULTS_FILE"
+	return 0
+}
+
+# LLM-as-judge scoring for bench results
+# Arguments: $1=prompt $2=output_dir (contains model result files)
+# Output: model_id|score lines on stdout
+_bench_judge_score() {
+	local original_prompt="$1"
+	local out_dir="$2"
+
+	local ai_helper="${SCRIPT_DIR}/ai-research-helper.sh"
+	if [[ ! -x "$ai_helper" ]]; then
+		print_warning "ai-research-helper.sh not found — skipping judge scoring"
+		return 0
+	fi
+
+	# Build judge prompt with all model outputs
+	local judge_prompt="You are evaluating AI model responses to the same prompt. Rate each response on a 0.0-1.0 scale for overall quality (accuracy, completeness, clarity, relevance).
+
+ORIGINAL PROMPT:
+${original_prompt}
+
+MODEL RESPONSES:
+"
+	local -a models_with_output=()
+	for result_file in "${out_dir}"/*.json; do
+		[[ -f "$result_file" ]] || continue
+		local basename_file
+		basename_file=$(basename "$result_file" .json)
+		# Skip non-model files
+		[[ "$basename_file" == *"-raw"* ]] && continue
+		[[ "$basename_file" == "judge"* ]] && continue
+
+		local output error
+		output=$(jq -r '.output // ""' "$result_file" 2>/dev/null || echo "")
+		error=$(jq -r '.error // ""' "$result_file" 2>/dev/null || echo "")
+
+		if [[ -n "$output" && -z "$error" ]]; then
+			# Truncate to 2000 chars per model for judge prompt
+			local truncated="${output:0:2000}"
+			judge_prompt+="
+=== MODEL: ${basename_file} ===
+${truncated}
+"
+			models_with_output+=("$basename_file")
+		fi
+	done
+
+	if [[ ${#models_with_output[@]} -lt 1 ]]; then
+		return 0
+	fi
+
+	judge_prompt+="
+Respond with ONLY a valid JSON object mapping model names to scores:
+{\"model_name\": 0.85, \"other_model\": 0.72}
+No explanation, no markdown, just the JSON object."
+
+	local judge_result
+	judge_result=$("$ai_helper" --prompt "$judge_prompt" --model haiku --max-tokens 200 2>/dev/null || echo "")
+
+	if [[ -z "$judge_result" ]]; then
+		print_warning "Judge returned no output"
+		return 0
+	fi
+
+	# Parse judge JSON and output model|score lines
+	echo "$judge_result" | python3 -c "
+import sys, json, re
+text = sys.stdin.read()
+m = re.search(r'\{[^}]+\}', text)
+if m:
+    try:
+        scores = json.loads(m.group())
+        for model, score in scores.items():
+            s = float(score)
+            if s < 0: s = 0.0
+            if s > 1: s = 1.0
+            print(f'{model}|{s:.2f}')
+    except Exception:
+        pass
+" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Live model benchmarking (t1393)
+# Usage: compare-models-helper.sh bench "prompt text" model1 model2 [model3...]
+#        compare-models-helper.sh bench --dataset path/to/dataset.jsonl model1 model2
+#        compare-models-helper.sh bench --history [--limit N]
+#
+# Options:
+#   --judge           Enable LLM-as-judge scoring (haiku-tier, ~$0.001/call)
+#   --dataset FILE    Read prompts from JSONL file (each line: {"prompt":"..."})
+#   --max-tokens N    Max output tokens per model (default: 1024)
+#   --dry-run         Show what would happen without making API calls
+#   --history         Show historical bench results
+#   --limit N         Limit history output (default: 20)
+#   --version TAG     Tag results with a prompt version (e.g. git short hash)
+#######################################
+cmd_bench() {
+	local prompt="" dataset_file="" max_tokens=1024 dry_run=false
+	local judge_flag=false history_flag=false history_limit=20
+	local prompt_version=""
+	local -a model_args=()
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--dataset)
+			[[ $# -lt 2 ]] && {
+				print_error "--dataset requires a file path"
+				return 1
+			}
+			dataset_file="$2"
+			shift 2
+			;;
+		--judge)
+			judge_flag=true
+			shift
+			;;
+		--max-tokens)
+			[[ $# -lt 2 ]] && {
+				print_error "--max-tokens requires a value"
+				return 1
+			}
+			max_tokens="$2"
+			shift 2
+			;;
+		--dry-run)
+			dry_run=true
+			shift
+			;;
+		--history)
+			history_flag=true
+			shift
+			;;
+		--limit)
+			[[ $# -lt 2 ]] && {
+				print_error "--limit requires a value"
+				return 1
+			}
+			history_limit="$2"
+			shift 2
+			;;
+		--version)
+			[[ $# -lt 2 ]] && {
+				print_error "--version requires a value"
+				return 1
+			}
+			prompt_version="$2"
+			shift 2
+			;;
+		--*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		*)
+			# First non-option arg without --dataset is the prompt, rest are models
+			if [[ -z "$prompt" && -z "$dataset_file" ]]; then
+				prompt="$1"
+			else
+				model_args+=("$1")
+			fi
+			shift
+			;;
+		esac
+	done
+
+	# Handle --history subcommand
+	if [[ "$history_flag" == true ]]; then
+		_bench_show_history "$history_limit"
+		return $?
+	fi
+
+	# Validate inputs
+	if [[ -z "$prompt" && -z "$dataset_file" ]]; then
+		print_error "Usage: compare-models-helper.sh bench \"prompt\" model1 model2 [model3...]"
+		echo "       compare-models-helper.sh bench --dataset file.jsonl model1 model2"
+		echo "       compare-models-helper.sh bench --history [--limit N]"
+		echo ""
+		echo "Options:"
+		echo "  --judge           Enable LLM-as-judge quality scoring"
+		echo "  --dataset FILE    Read prompts from JSONL (each line: {\"prompt\":\"...\"})"
+		echo "  --max-tokens N    Max output tokens per model (default: 1024)"
+		echo "  --dry-run         Show plan without making API calls"
+		echo "  --history         Show historical bench results"
+		echo "  --version TAG     Tag results with prompt version"
+		return 1
+	fi
+
+	if [[ ${#model_args[@]} -lt 1 ]]; then
+		print_error "At least 1 model required for benchmarking"
+		return 1
+	fi
+
+	# Validate dataset file exists
+	if [[ -n "$dataset_file" && ! -f "$dataset_file" ]]; then
+		print_error "Dataset file not found: $dataset_file"
+		return 1
+	fi
+
+	# Validate max_tokens is numeric
+	if ! [[ "$max_tokens" =~ ^[0-9]+$ ]]; then
+		print_error "Invalid --max-tokens value: $max_tokens"
+		return 1
+	fi
+
+	# Build prompts list
+	local -a prompts=()
+	if [[ -n "$dataset_file" ]]; then
+		while IFS= read -r line; do
+			[[ -z "$line" ]] && continue
+			local p
+			p=$(echo "$line" | jq -r '.prompt // empty' 2>/dev/null || echo "")
+			if [[ -n "$p" ]]; then
+				prompts+=("$p")
+			fi
+		done <"$dataset_file"
+		if [[ ${#prompts[@]} -eq 0 ]]; then
+			print_error "No valid prompts found in dataset (expected JSONL with {\"prompt\":\"...\"})"
+			return 1
+		fi
+	else
+		prompts+=("$prompt")
+	fi
+
+	# Validate models exist in MODEL_DATA
+	local -a valid_models=()
+	for m in "${model_args[@]}"; do
+		local info
+		info=$(_model_provider_info "$m")
+		if [[ -z "$info" ]]; then
+			print_warning "Unknown model: $m (skipping)"
+		else
+			local actual_id
+			actual_id=$(echo "$info" | cut -d'|' -f3)
+			valid_models+=("$actual_id")
+		fi
+	done
+
+	if [[ ${#valid_models[@]} -lt 1 ]]; then
+		print_error "No valid models found"
+		return 1
+	fi
+
+	# Dry-run mode
+	if [[ "$dry_run" == true ]]; then
+		echo ""
+		echo "Bench Plan (dry-run)"
+		echo "===================="
+		echo ""
+		echo "Prompts: ${#prompts[@]}"
+		echo "Models:  ${valid_models[*]}"
+		echo "Max tokens: $max_tokens"
+		echo "Judge: $judge_flag"
+		echo "Total API calls: $((${#prompts[@]} * ${#valid_models[@]}))"
+		echo ""
+
+		# Estimate cost
+		echo "| Model                  | Est. Cost/prompt | Provider |"
+		echo "|------------------------|------------------|----------|"
+		for m in "${valid_models[@]}"; do
+			local match
+			match=$(echo "$MODEL_DATA" | grep "^${m}|" | head -1 || true)
+			if [[ -n "$match" ]]; then
+				local prov input_p output_p
+				prov=$(get_field "$match" 2)
+				input_p=$(get_field "$match" 5)
+				output_p=$(get_field "$match" 6)
+				# Estimate: ~200 input tokens, ~max_tokens output tokens
+				local est_cost
+				est_cost=$(awk "BEGIN{printf \"%.4f\", (200/1000000.0)*${input_p} + (${max_tokens}/1000000.0)*${output_p}}")
+				printf "| %-22s | \$%-15s | %-8s |\n" "$m" "$est_cost" "$prov"
+			fi
+		done
+		echo ""
+
+		if [[ "$judge_flag" == true ]]; then
+			echo "Judge cost: ~\$0.001 per prompt (haiku-tier)"
+		fi
+		echo ""
+		echo "Run without --dry-run to execute."
+		return 0
+	fi
+
+	# Execute benchmarks
+	echo ""
+	echo "Live Model Benchmark"
+	echo "===================="
+	echo ""
+	echo "Models: ${valid_models[*]}"
+	echo "Prompts: ${#prompts[@]}"
+	echo "Max tokens: $max_tokens"
+	[[ "$judge_flag" == true ]] && echo "Judge: enabled (haiku)"
+	echo ""
+
+	local prompt_idx=0
+	for p in "${prompts[@]}"; do
+		prompt_idx=$((prompt_idx + 1))
+		local prompt_label="Prompt"
+		if [[ ${#prompts[@]} -gt 1 ]]; then
+			prompt_label="Prompt ${prompt_idx}/${#prompts[@]}"
+		fi
+
+		# Truncate prompt for display
+		local display_prompt="${p:0:80}"
+		[[ ${#p} -gt 80 ]] && display_prompt="${display_prompt}..."
+		echo "${prompt_label}: ${display_prompt}"
+		echo ""
+
+		# Create temp directory for this prompt's results
+		local bench_dir
+		bench_dir=$(mktemp -d "${TMPDIR:-/tmp}/bench-XXXXXX")
+
+		# Run models in parallel
+		local -a pids=()
+		for m in "${valid_models[@]}"; do
+			echo "  Calling ${m}..."
+			_bench_call_model "$m" "$p" "$max_tokens" "$bench_dir" &
+			pids+=($!)
+		done
+
+		# Wait for all
+		for pid in "${pids[@]}"; do
+			wait "$pid" 2>/dev/null || true
+		done
+
+		# Collect judge scores if enabled
+		declare -A judge_scores=()
+		if [[ "$judge_flag" == true ]]; then
+			echo "  Scoring with judge (haiku)..."
+			local judge_output
+			judge_output=$(_bench_judge_score "$p" "$bench_dir")
+			while IFS='|' read -r jm js; do
+				[[ -z "$jm" ]] && continue
+				judge_scores["$jm"]="$js"
+			done <<<"$judge_output"
+		fi
+
+		# Build and display results table
+		echo ""
+		if [[ "$judge_flag" == true ]]; then
+			printf "| %-22s | %7s | %15s | %9s | %11s |\n" \
+				"Model" "Latency" "Tokens (in/out)" "Cost" "Judge Score"
+			printf "| %-22s | %7s | %15s | %9s | %11s |\n" \
+				"----------------------" "-------" "---------------" "---------" "-----------"
+		else
+			printf "| %-22s | %7s | %15s | %9s |\n" \
+				"Model" "Latency" "Tokens (in/out)" "Cost"
+			printf "| %-22s | %7s | %15s | %9s |\n" \
+				"----------------------" "-------" "---------------" "---------"
+		fi
+
+		for m in "${valid_models[@]}"; do
+			local result_file="${bench_dir}/${m}.json"
+			if [[ ! -f "$result_file" ]]; then
+				if [[ "$judge_flag" == true ]]; then
+					printf "| %-22s | %7s | %15s | %9s | %11s |\n" "$m" "ERROR" "-" "-" "-"
+				else
+					printf "| %-22s | %7s | %15s | %9s |\n" "$m" "ERROR" "-" "-"
+				fi
+				continue
+			fi
+
+			local latency tokens_in tokens_out error_msg
+			latency=$(jq -r '.latency_ms // 0' "$result_file" 2>/dev/null || echo "0")
+			tokens_in=$(jq -r '.tokens_in // 0' "$result_file" 2>/dev/null || echo "0")
+			tokens_out=$(jq -r '.tokens_out // 0' "$result_file" 2>/dev/null || echo "0")
+			error_msg=$(jq -r '.error // ""' "$result_file" 2>/dev/null || echo "")
+
+			if [[ -n "$error_msg" ]]; then
+				if [[ "$judge_flag" == true ]]; then
+					printf "| %-22s | %7s | %15s | %9s | %11s |\n" "$m" "FAIL" "$error_msg" "-" "-"
+				else
+					printf "| %-22s | %7s | %15s | %9s |\n" "$m" "FAIL" "$error_msg" "-"
+				fi
+				continue
+			fi
+
+			local latency_fmt
+			if [[ "$latency" -ge 1000 ]]; then
+				latency_fmt=$(awk "BEGIN{printf \"%.1fs\", ${latency}/1000.0}")
+			else
+				latency_fmt="${latency}ms"
+			fi
+
+			local tokens_fmt="${tokens_in}/${tokens_out}"
+			local cost
+			cost=$(_calc_bench_cost "$m" "$tokens_in" "$tokens_out")
+			local cost_fmt
+			cost_fmt=$(printf "\$%.4f" "$cost")
+
+			local judge_score="${judge_scores[$m]:-}"
+
+			# Store result
+			_store_bench_result "$m" "$p" "$latency" "$tokens_in" "$tokens_out" "$cost" \
+				"$judge_score" "$prompt_version"
+
+			if [[ "$judge_flag" == true ]]; then
+				local judge_fmt="${judge_score:-  -  }"
+				printf "| %-22s | %7s | %15s | %9s | %11s |\n" \
+					"$m" "$latency_fmt" "$tokens_fmt" "$cost_fmt" "$judge_fmt"
+			else
+				printf "| %-22s | %7s | %15s | %9s |\n" \
+					"$m" "$latency_fmt" "$tokens_fmt" "$cost_fmt"
+			fi
+		done
+
+		echo ""
+
+		# Clean up temp dir
+		rm -rf "$bench_dir"
+	done
+
+	echo "Results stored: $BENCH_RESULTS_FILE"
+	echo ""
+	return 0
+}
+
+# Show historical bench results
+_bench_show_history() {
+	local limit="${1:-20}"
+
+	if [[ ! -f "$BENCH_RESULTS_FILE" ]]; then
+		echo "No bench history found."
+		echo "Run a benchmark first: compare-models-helper.sh bench \"prompt\" model1 model2"
+		return 0
+	fi
+
+	# Validate limit is numeric
+	if ! [[ "$limit" =~ ^[0-9]+$ ]]; then
+		print_error "Invalid --limit value: $limit"
+		return 1
+	fi
+
+	echo ""
+	echo "Bench History (last $limit results)"
+	echo "===================================="
+	echo ""
+
+	printf "| %-20s | %-22s | %7s | %7s | %9s | %5s |\n" \
+		"Timestamp" "Model" "Latency" "Tok Out" "Cost" "Judge"
+	printf "| %-20s | %-22s | %7s | %7s | %9s | %5s |\n" \
+		"--------------------" "----------------------" "-------" "-------" "---------" "-----"
+
+	tail -n "$limit" "$BENCH_RESULTS_FILE" | while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local ts model lat tok_out cost judge
+		ts=$(echo "$line" | jq -r '.ts // "-"' 2>/dev/null || echo "-")
+		model=$(echo "$line" | jq -r '.model // "-"' 2>/dev/null || echo "-")
+		lat=$(echo "$line" | jq -r '.latency_ms // 0' 2>/dev/null || echo "0")
+		tok_out=$(echo "$line" | jq -r '.tokens_out // 0' 2>/dev/null || echo "0")
+		cost=$(echo "$line" | jq -r '.cost // 0' 2>/dev/null || echo "0")
+		judge=$(echo "$line" | jq -r '.judge_score // "-"' 2>/dev/null || echo "-")
+
+		# Format timestamp (trim seconds)
+		local ts_short="${ts:0:16}"
+
+		local lat_fmt
+		if [[ "$lat" -ge 1000 ]]; then
+			lat_fmt=$(awk "BEGIN{printf \"%.1fs\", ${lat}/1000.0}")
+		else
+			lat_fmt="${lat}ms"
+		fi
+
+		local cost_fmt
+		cost_fmt=$(printf "\$%.4f" "$cost")
+
+		printf "| %-20s | %-22s | %7s | %7s | %9s | %5s |\n" \
+			"$ts_short" "$model" "$lat_fmt" "$tok_out" "$cost_fmt" "$judge"
+	done
+
+	echo ""
+
+	# Show aggregate stats
+	local total_entries
+	total_entries=$(wc -l <"$BENCH_RESULTS_FILE" | tr -d ' ')
+	echo "Total entries: $total_entries"
+	echo "File: $BENCH_RESULTS_FILE"
+	echo ""
+	return 0
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -2162,6 +2995,9 @@ main() {
 		;;
 	cross-review)
 		cmd_cross_review "$@"
+		;;
+	bench)
+		cmd_bench "$@"
 		;;
 	help | --help | -h)
 		cmd_help

--- a/.agents/tools/ai-assistants/compare-models.md
+++ b/.agents/tools/ai-assistants/compare-models.md
@@ -21,7 +21,7 @@ model: sonnet
 
 - **Purpose**: Compare AI models by capability, pricing, context window, and task suitability
 - **Commands**: `/compare-models` (full, with web fetch), `/compare-models-free` (offline, embedded data)
-- **Helper**: `compare-models-helper.sh [list|compare|recommend|pricing|context|capabilities|patterns|providers|discover]`
+- **Helper**: `compare-models-helper.sh [list|compare|recommend|pricing|context|capabilities|patterns|providers|discover|bench]`
 - **Discovery**: `compare-models-helper.sh discover [--probe] [--list-models] [--json]`
 - **Pattern data**: `compare-models-helper.sh patterns [--task-type TYPE]` — live success rates from pattern tracker
 - **Data sources**: Embedded reference data + live pattern tracker data + optional web fetch for latest pricing
@@ -169,6 +169,57 @@ Discovery checks three sources for API keys (in order):
 3. Plaintext credentials (`~/.config/aidevops/credentials.sh`)
 
 Use discovery output to filter `/compare-models` to only show models the user can actually use.
+
+## Live Model Benchmarking (t1393)
+
+Send the same prompt to multiple models and compare actual outputs with latency, tokens, cost, and optional LLM-as-judge quality scoring.
+
+```bash
+# Basic benchmark: compare two models on a prompt
+~/.aidevops/agents/scripts/compare-models-helper.sh bench "Explain quicksort" claude-sonnet-4-6 gpt-4o
+
+# With LLM-as-judge scoring (haiku-tier, ~$0.001/call)
+~/.aidevops/agents/scripts/compare-models-helper.sh bench "Explain quicksort" claude-sonnet-4-6 gpt-4o gemini-2.5-pro --judge
+
+# Benchmark from a dataset file (JSONL, each line: {"prompt":"..."})
+~/.aidevops/agents/scripts/compare-models-helper.sh bench --dataset prompts.jsonl claude-sonnet-4-6 gpt-4.1 --judge
+
+# Dry-run: show plan and estimated costs without making API calls
+~/.aidevops/agents/scripts/compare-models-helper.sh bench "What is 2+2?" claude-sonnet-4-6 gpt-4o --dry-run
+
+# View historical benchmark results
+~/.aidevops/agents/scripts/compare-models-helper.sh bench --history --limit 10
+```
+
+### Output format
+
+```text
+| Model                  | Latency | Tokens (in/out) | Cost    | Judge Score |
+|------------------------|---------|-----------------|---------|-------------|
+| claude-sonnet-4-6      | 1.2s    | 150/320         | $0.0062 | 0.92        |
+| gpt-4o                 | 0.9s    | 150/290         | $0.0048 | 0.88        |
+| gemini-2.5-pro         | 1.8s    | 150/350         | $0.0071 | 0.90        |
+```
+
+### Result storage
+
+Results are stored as JSONL at `~/.aidevops/.agent-workspace/observability/bench-results.jsonl` for historical trending:
+
+```jsonl
+{"ts":"2026-03-05T10:00:00Z","prompt_hash":"abc123","model":"claude-sonnet-4-6","latency_ms":1200,"tokens_in":150,"tokens_out":320,"cost":0.0062,"judge_score":0.92,"output_hash":"def456"}
+```
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--judge` | Enable LLM-as-judge quality scoring (haiku-tier, ~$0.001/call) |
+| `--dataset FILE` | Read prompts from JSONL file (each line: `{"prompt":"..."}`) |
+| `--max-tokens N` | Max output tokens per model (default: 1024) |
+| `--dry-run` | Show plan and estimated costs without making API calls |
+| `--history` | Show historical benchmark results |
+| `--limit N` | Limit history output (default: 20) |
+| `--version TAG` | Tag results with a prompt version (e.g., git short hash) |
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Add `compare-models-helper.sh bench` subcommand for live model benchmarking — sends the same prompt to N models and compares actual outputs with latency, tokens, cost, and optional LLM-as-judge quality scoring
- Supports direct API calls to Anthropic, OpenAI, Google, and DeepSeek providers with parallel execution
- Includes `--dry-run`, `--judge`, `--dataset` (JSONL), `--history`, and `--version` flags

## Changes

### `.agents/scripts/compare-models-helper.sh`
- Added `bench` subcommand with 9 new functions (~830 lines)
- `_resolve_key_value()` — credential resolution (env → gopass → credentials.sh)
- `_model_provider_info()` — maps model IDs to providers and API key env vars
- `_api_model_string()` — maps model IDs to provider-specific API model strings
- `_bench_call_model()` — calls a single model API with curl, captures response + metrics
- `_calc_bench_cost()` — calculates cost from token counts and embedded pricing
- `_store_bench_result()` — appends JSONL to `bench-results.jsonl`
- `_bench_judge_score()` — LLM-as-judge scoring via `ai-research-helper.sh` (haiku-tier)
- `cmd_bench()` — main bench command with argument parsing, validation, parallel execution
- `_bench_show_history()` — displays historical bench results from JSONL

### `.agents/tools/ai-assistants/compare-models.md`
- Added "Live Model Benchmarking (t1393)" section with usage examples, output format, result storage, and options table

## Testing

- `--dry-run` mode verified with single model, multiple models, `--judge`, and `--dataset`
- `--history` mode verified with empty state
- ShellCheck clean on all new functions
- All acceptance criteria patterns verified in codebase

Closes #2903