### PR TITLE
fix: disable SC1091 globally and remove source-path=SCRIPTDIR from .shellcheckrc

### DIFF
--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -310,23 +310,13 @@ run_shellcheck() {
 		return 0
 	fi
 
-	# t1398.2: Hardened ShellCheck invocation to prevent exponential expansion.
+	# ShellCheck invocation — no source following.
 	#
-	# Root cause: shellcheck --external-sources (-x) with source-path=SCRIPTDIR
-	# follows source directives across 100+ scripts, causing exponential
-	# expansion (5.7 GB RSS, 88% CPU, 35+ min observed — March 3 kernel panic).
-	#
-	# Hardening layers (defense in depth):
-	#   1. Per-file mode with timeout (30s) to cap each invocation
-	#   2. ulimit -v (1 GB) to cap virtual memory per shellcheck subprocess
-	#   3. -P SCRIPTDIR restricts source resolution to the script's own directory
-	#      (prevents cross-directory recursive expansion chains)
-	#   4. .shellcheckrc source-path=SCRIPTDIR is intentionally kept for
-	#      interactive use — the per-file timeout + ulimit prevent runaway
-	#
-	# Trade-off: linters-local.sh keeps -x for better source resolution
-	# (unlike pulse-wrapper.sh which uses --norc). This is acceptable because
-	# linters-local.sh is interactive with per-file timeout + ulimit guards.
+	# SC1091 is disabled globally in .shellcheckrc. We no longer pass -x
+	# (--external-sources) or -P SCRIPTDIR because source-path=SCRIPTDIR
+	# combined with -x caused exponential memory expansion (11 GB RSS,
+	# kernel panics — GH#2915). Per-file timeout + ulimit remain as
+	# defense-in-depth against any future regression.
 	local violations=0
 	local result=""
 	local timed_out=0
@@ -341,10 +331,10 @@ run_shellcheck() {
 	for file in "${ALL_SH_FILES[@]}"; do
 		[[ -f "$file" ]] || continue
 		file_result=""
-		# t1398.2: run in subshell with ulimit -v to cap virtual memory
+		# Run in subshell with ulimit -v to cap virtual memory
 		file_result=$(
 			ulimit -v 1048576 2>/dev/null || true
-			timeout_sec "$sc_timeout" shellcheck -x -P SCRIPTDIR --severity=warning --format=gcc "$file" 2>&1
+			timeout_sec "$sc_timeout" shellcheck --severity=warning --format=gcc "$file" 2>&1
 		) || {
 			local sc_exit=$?
 			# Exit code 124 = timeout killed the process

--- a/.agents/scripts/memory-pressure-monitor.sh
+++ b/.agents/scripts/memory-pressure-monitor.sh
@@ -8,10 +8,9 @@
 #
 # Auto-kill (GH#2915): ShellCheck processes that hit CRITICAL RSS or exceed
 # runtime limits are automatically killed. This is safe because the bash
-# language server respawns them, and the .shellcheckrc in .agents/scripts/
-# now prevents the recursive source-chain expansion that caused the bloat.
-# The auto-kill is a safety net for cases where ShellCheck is invoked without
-# the .shellcheckrc (e.g., different source-path, --norc flag).
+# language server respawns them. The root cause (source-path=SCRIPTDIR in
+# .shellcheckrc causing recursive expansion) has been removed — SC1091 is
+# now globally disabled instead. This monitor remains as defense-in-depth.
 #
 # kern.memorystatus_level is a secondary/informational signal only. macOS runs
 # fine with compression + swap; aggressive thresholds on that metric cause false

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1985,26 +1985,11 @@ _quality_sweep_for_repo() {
 	local sweep_high_critical=0
 
 	# --- 1. ShellCheck ---
-	# t1398.2: Hardened ShellCheck invocation to prevent exponential expansion.
-	#
-	# Root cause of March 3 kernel panic: shellcheck --external-sources with
-	# source-path=SCRIPTDIR follows source directives across 100+ scripts,
-	# causing exponential expansion (5.7 GB RSS, 88% CPU, 35+ min observed).
-	#
-	# Hardening layers (defense in depth):
-	#   1. NEVER pass -x / --external-sources — shellcheck runs in syntax-only
-	#      mode for the quality sweep (source directives are not followed)
-	#   2. --norc — ignore .shellcheckrc which sets source-path=SCRIPTDIR
-	#      (prevents implicit source following via rc file)
-	#   3. Per-file timeout (30s) — caps each invocation regardless
-	#   4. ulimit -v to cap virtual memory per shellcheck subprocess
-	#   5. guard_child_processes() in the watchdog loop kills any shellcheck
-	#      exceeding SHELLCHECK_RSS_LIMIT_KB or SHELLCHECK_RUNTIME_LIMIT
-	#
-	# Trade-off: --norc means the quality sweep won't resolve source directives,
-	# so SC1091 ("Not following: ... was not specified as input") will appear.
-	# This is acceptable — the sweep is for catching real bugs, not source
-	# resolution. linters-local.sh (interactive, with timeout) handles that.
+	# SC1091 is disabled globally in .shellcheckrc and source-path=SCRIPTDIR
+	# has been removed (it caused 11 GB RSS / kernel panics — GH#2915).
+	# The quality sweep uses --norc + no -x for maximum isolation.
+	# Per-file timeout + ulimit + guard_child_processes() remain as
+	# defense-in-depth.
 	local shellcheck_section=""
 	if command -v shellcheck &>/dev/null; then
 		local sh_files

--- a/.agents/scripts/shellcheck-wrapper.sh
+++ b/.agents/scripts/shellcheck-wrapper.sh
@@ -2,9 +2,10 @@
 # Safe ShellCheck wrapper for language servers (shellcheck-wrapper.sh)
 #
 # The bash language server hardcodes --external-sources in every ShellCheck
-# invocation (bash-language-server/out/shellcheck/index.js:82). Combined with
-# --source-path pointing to a directory with 463+ cross-sourcing scripts, this
-# causes exponential AST expansion (observed: 11 GB RSS, kernel panics).
+# invocation (bash-language-server/out/shellcheck/index.js:82). Even though
+# source-path=SCRIPTDIR has been removed from .shellcheckrc (and SC1091 is
+# now globally disabled), this wrapper remains as defense-in-depth: it strips
+# --external-sources to prevent any residual source-following expansion.
 #
 # This wrapper strips --external-sources from the arguments before passing them
 # to the real ShellCheck binary. It also enforces a memory limit via ulimit.

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,16 +1,24 @@
 # ShellCheck configuration for aidevops
-# Resolves SC1091 ("Not following: ... was not specified as input") by telling
-# ShellCheck to look in the same directory as the script being checked.
-# This handles source "./shared-constants.sh" and source "./_common.sh" patterns.
 #
-# WARNING (t1398.2): This directive combined with -x/--external-sources can cause
-# exponential expansion across 100+ scripts (observed: 5.7 GB RSS, 35+ min).
-# Automated/headless invocations (pulse-wrapper.sh quality sweep) MUST use --norc
-# to ignore this file. Interactive invocations (linters-local.sh) use per-file
-# timeout + ulimit -v as guards. See pulse-wrapper.sh and linters-local.sh.
-source-path=SCRIPTDIR
+# SC1091 ("Not following: ... was not specified as input") is disabled globally.
+# ShellCheck cannot resolve dynamic source paths like "${SCRIPT_DIR}/foo.sh"
+# (255 of 404 scripts use this pattern), so source-path=SCRIPTDIR only partially
+# worked and caused catastrophic memory expansion when combined with
+# --external-sources (-x): 11 GB RSS, kernel panics, 73 zombie processes.
+# See GH#2915, PR#2918, PR#2937 for the full incident chain.
+#
+# Defense-in-depth: even without source-path, the shellcheck-wrapper.sh strips
+# --external-sources from bash-language-server invocations, and SHELLCHECK_PATH
+# is set in .zshenv to route through the wrapper for non-interactive shells.
 
 # Project-wide accepted patterns and false positives:
+#
+# Source resolution:
+# SC1091: "Not following: ... was not specified as input" — info-level hint
+#         that ShellCheck cannot resolve a sourced file. Disabled because 255
+#         scripts use dynamic paths (${SCRIPT_DIR}/foo.sh) that ShellCheck
+#         cannot follow, and the previous fix (source-path=SCRIPTDIR) caused
+#         exponential memory expansion. See header comment.
 #
 # Library/sourced-file architecture:
 # SC2329: "Function is never invoked" — false positive for library functions
@@ -35,6 +43,7 @@ source-path=SCRIPTDIR
 # SC2153: "Possible misspelling" — false positive for UPPER/lower conventions
 # SC2004: "$/${} unnecessary on arithmetic variables" — style preference
 # SC2009: "Consider using pgrep" — ps|grep is intentional for portability
+disable=SC1091
 disable=SC2329
 disable=SC2317
 disable=SC2034


### PR DESCRIPTION
## Summary

- Removes `source-path=SCRIPTDIR` from `.shellcheckrc` — the root cause of exponential memory expansion (11 GB RSS, kernel panics, 73 zombie processes) when combined with `--external-sources` (`-x`)
- Adds `disable=SC1091` globally — SC1091 is an info-level hint that ShellCheck cannot follow a sourced file, not a real error. 255 of 404 scripts use dynamic paths (`${SCRIPT_DIR}/foo.sh`) that ShellCheck cannot resolve regardless
- Removes `-x` and `-P SCRIPTDIR` flags from `linters-local.sh` shellcheck invocations
- Updates comments in `pulse-wrapper.sh`, `shellcheck-wrapper.sh`, `memory-pressure-monitor.sh`

## Why

The previous fix for SC1091 noise (PR #2427, t1344) added `source-path=SCRIPTDIR` to `.shellcheckrc`. This solved a cosmetic problem (info-level warnings) but created a catastrophic one: when bash-language-server hardcodes `--external-sources`, ShellCheck recursively follows source directives across 460+ scripts, causing exponential memory growth.

Multiple defense-in-depth layers were added (PR #2885, #2918, #2923, #2937) to contain the damage — but the root cause remained in `.shellcheckrc`. This PR removes it.

## Defense-in-depth layers (all remain active)

1. `shellcheck-wrapper.sh` strips `--external-sources` from bash-language-server invocations
2. `SHELLCHECK_PATH` in `.zshenv` routes through the wrapper for non-interactive shells
3. Per-file timeouts (30s) in `linters-local.sh`
4. `ulimit -v` (1 GB) caps virtual memory per shellcheck subprocess
5. `process-guard-helper.sh` kills shellcheck processes exceeding 512 MB RSS
6. `pulse-wrapper.sh` uses `--norc` for quality sweeps

## Verified

- `shellcheck -x` completes instantly with no memory expansion when `source-path=SCRIPTDIR` is absent
- SC1091 warnings are fully suppressed by the global disable
- All modified scripts pass `shellcheck` and `bash -n` syntax check

## Related

Closes #2915

Previous fixes in the incident chain:
- PR #2918 — shellcheck-wrapper.sh + process guard
- PR #2885 — harden shellcheck invocation (--norc, timeouts)
- PR #2937 — .zshenv fix for non-interactive shells
- PR #2427 — original SC1091 fix that introduced source-path=SCRIPTDIR

**Note:** The upstream hazard remains for other opencode/shellcheck users. See [anomalyco/opencode#16209](https://github.com/anomalyco/opencode/issues/16209) for the suggested upstream fix.