### PR TITLE
t2956: Remove jq stderr suppression in config-helper.sh

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -236,7 +236,7 @@ _jsonc_get() {
 	# NOTE: Do NOT use jq's // (alternative operator) here — it treats false and
 	# null identically, discarding false values. Instead, use 'if . == null'.
 	local value
-	value=$(echo "$merged" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' 2>/dev/null) || value=""
+	value=$(echo "$merged" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end') || value=""
 
 	if [[ -n "$value" ]]; then
 		echo "$value"
@@ -263,7 +263,7 @@ _jsonc_get_raw() {
 		echo ""
 		return 0
 	}
-	echo "$json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' 2>/dev/null || echo ""
+	echo "$json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' || echo ""
 	return 0
 }
 
@@ -488,7 +488,7 @@ cmd_list() {
 
 		local user_val env_val effective source
 
-		user_val=$(echo "$user_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' 2>/dev/null) || user_val=""
+		user_val=$(echo "$user_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end') || user_val=""
 
 		# Check env override
 		env_val=""
@@ -584,11 +584,13 @@ cmd_set() {
 	# Validate key exists in defaults
 	local defaults_json
 	defaults_json=$(_strip_jsonc "$JSONC_DEFAULTS") || return 1
-	local default_val
 	# Use jq type check instead of // empty — false and 0 are valid defaults
-	local default_type
-	default_type=$(echo "$defaults_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | type' 2>/dev/null) || default_type="null"
-	default_val=$(echo "$defaults_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' 2>/dev/null) || default_val=""
+	# Get type and value in a single jq call for efficiency
+	local default_type default_val
+	if ! read -r default_type default_val < <(echo "$defaults_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | [type, (if . == null then "" else tostring end)] | @tsv'); then
+		default_type="null"
+		default_val=""
+	fi
 
 	if [[ "$default_type" == "null" ]]; then
 		echo "[ERROR] Unknown config key: $dotpath" >&2
@@ -656,7 +658,7 @@ HEADER
 		;;
 	number)
 		updated=$(echo "$user_json" | jq --arg p "$dotpath" --argjson v "$value" \
-			'setpath($p | split("."); $v)' 2>/dev/null) || {
+			'setpath($p | split("."); $v)') || {
 			echo "[ERROR] Failed to update config" >&2
 			return 1
 		}


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from 5 jq calls in `config-helper.sh` where `|| fallback` patterns already handle failures, per PR #2931 Gemini code review feedback
- Consolidate two separate jq calls (type + value lookup) in `cmd_set` into a single efficient call using `@tsv` output
- Makes real jq errors (malformed JSON, syntax issues) visible for debugging instead of silently swallowing them

## Findings addressed

All 5 medium-severity findings from [PR #2931 review](https://github.com/marcusquinn/aidevops/pull/2931):

| Line | Function | Change |
|------|----------|--------|
| 239 | `_jsonc_get` | Remove `2>/dev/null` (has `\|\| value=""`) |
| 266 | `_jsonc_get_raw` | Remove `2>/dev/null` (has `\|\| echo ""`) |
| 491 | `cmd_list` | Remove `2>/dev/null` (has `\|\| user_val=""`) |
| 589-591 | `cmd_set` | Consolidate 2 jq calls into 1 via `@tsv`, remove `2>/dev/null` |
| 659 | `cmd_set` (number) | Remove `2>/dev/null` (has `\|\| { error }`) |

## Verification

- ShellCheck: zero violations (SC1091 info-only, pre-existing)
- `bash -n`: syntax check passes
- `config-helper.sh list`: functional, displays all config values correctly
- `config-helper.sh set/reset`: number and boolean set/reset operations work correctly

Closes #2956