### PR TITLE
GH#2947: Harden setup.sh plist/cron generation against injection

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -85,6 +85,19 @@ if [[ -f "$_SHARED_CONSTANTS" ]]; then
 fi
 unset _SHARED_CONSTANTS
 
+# Escape a string for safe embedding in XML (plist heredocs).
+# Prevents XML injection if paths contain &, <, >, ", or ' characters.
+_xml_escape() {
+	local str="$1"
+	str="${str//&/&amp;}"
+	str="${str//</&lt;}"
+	str="${str//>/&gt;}"
+	str="${str//\"/&quot;}"
+	str="${str//\'/&apos;}"
+	printf '%s' "$str"
+	return 0
+}
+
 # Check if a launchd agent is loaded (SIGPIPE-safe for pipefail, t1265)
 _launchd_has_agent() {
 	local label="$1"
@@ -856,16 +869,24 @@ main() {
 
 			# Unload old plist if upgrading
 			if _launchd_has_agent "$pulse_label"; then
-				launchctl unload "$pulse_plist" 2>/dev/null || true
+				launchctl unload "$pulse_plist" || true
 				pkill -f 'Supervisor Pulse' 2>/dev/null || true
 			fi
 
 			# Also clean up old label if present
 			local old_plist="$HOME/Library/LaunchAgents/com.aidevops.supervisor-pulse.plist"
 			if [[ -f "$old_plist" ]]; then
-				launchctl unload "$old_plist" 2>/dev/null || true
+				launchctl unload "$old_plist" || true
 				rm -f "$old_plist"
 			fi
+
+			# XML-escape paths for safe plist embedding (prevents injection
+			# if $HOME or paths contain &, <, > characters)
+			local _xml_wrapper_script _xml_home _xml_opencode_bin _xml_aidevops_dir
+			_xml_wrapper_script=$(_xml_escape "$wrapper_script")
+			_xml_home=$(_xml_escape "$HOME")
+			_xml_opencode_bin=$(_xml_escape "$opencode_bin")
+			_xml_aidevops_dir=$(_xml_escape "$_aidevops_dir")
 
 			# Write the plist (always regenerated to pick up config changes)
 			cat >"$pulse_plist" <<PLIST
@@ -878,24 +899,24 @@ main() {
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/bash</string>
-		<string>${wrapper_script}</string>
+		<string>${_xml_wrapper_script}</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>120</integer>
 	<key>StandardOutPath</key>
-	<string>${HOME}/.aidevops/logs/pulse-wrapper.log</string>
+	<string>${_xml_home}/.aidevops/logs/pulse-wrapper.log</string>
 	<key>StandardErrorPath</key>
-	<string>${HOME}/.aidevops/logs/pulse-wrapper.log</string>
+	<string>${_xml_home}/.aidevops/logs/pulse-wrapper.log</string>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
 		<string>${PATH}</string>
 		<key>HOME</key>
-		<string>${HOME}</string>
+		<string>${_xml_home}</string>
 		<key>OPENCODE_BIN</key>
-		<string>${opencode_bin}</string>
+		<string>${_xml_opencode_bin}</string>
 		<key>PULSE_DIR</key>
-		<string>${_aidevops_dir}</string>
+		<string>${_xml_aidevops_dir}</string>
 		<key>PULSE_STALE_THRESHOLD</key>
 		<string>1800</string>
 	</dict>
@@ -907,7 +928,7 @@ main() {
 </plist>
 PLIST
 
-			if launchctl load "$pulse_plist" 2>/dev/null; then
+			if launchctl load "$pulse_plist"; then
 				if [[ "$_pulse_installed" == "true" ]]; then
 					print_info "Supervisor pulse updated (launchd config regenerated)"
 				else
@@ -921,8 +942,8 @@ PLIST
 			# Remove old-style cron entries (direct opencode invocation)
 			(
 				crontab -l 2>/dev/null | grep -v 'aidevops: supervisor-pulse'
-				echo "*/2 * * * * OPENCODE_BIN=${opencode_bin} PULSE_DIR=${_aidevops_dir} /bin/bash ${wrapper_script} >> $HOME/.aidevops/logs/pulse-wrapper.log 2>&1 # aidevops: supervisor-pulse"
-			) | crontab - 2>/dev/null || true
+				echo "*/2 * * * * PATH=\"/usr/local/bin:/usr/bin:/bin\" OPENCODE_BIN=\"${opencode_bin}\" PULSE_DIR=\"${_aidevops_dir}\" /bin/bash \"${wrapper_script}\" >> \"\$HOME/.aidevops/logs/pulse-wrapper.log\" 2>&1 # aidevops: supervisor-pulse"
+			) | crontab - || true
 			if crontab -l 2>/dev/null | grep -qF "aidevops: supervisor-pulse"; then
 				print_info "Supervisor pulse enabled (cron, every 2 min). Disable: crontab -e and remove the supervisor-pulse line"
 			else
@@ -934,14 +955,14 @@ PLIST
 		if [[ "$(uname -s)" == "Darwin" ]]; then
 			local pulse_plist="$HOME/Library/LaunchAgents/${pulse_label}.plist"
 			if _launchd_has_agent "$pulse_label"; then
-				launchctl unload "$pulse_plist" 2>/dev/null || true
+				launchctl unload "$pulse_plist" || true
 				rm -f "$pulse_plist"
 				pkill -f 'Supervisor Pulse' 2>/dev/null || true
 				print_info "Supervisor pulse disabled (launchd agent removed per config)"
 			fi
 		else
 			if crontab -l 2>/dev/null | grep -qF "pulse-wrapper" 2>/dev/null; then
-				crontab -l 2>/dev/null | grep -v 'aidevops: supervisor-pulse' | crontab - 2>/dev/null || true
+				crontab -l 2>/dev/null | grep -v 'aidevops: supervisor-pulse' | crontab - || true
 				print_info "Supervisor pulse disabled (cron entry removed per config)"
 			fi
 		fi
@@ -994,6 +1015,12 @@ PLIST
 				launchctl unload "$guard_plist" || true
 			fi
 
+			# XML-escape paths for safe plist embedding (prevents injection
+			# if $HOME or paths contain &, <, > characters)
+			local _xml_guard_script _xml_guard_home
+			_xml_guard_script=$(_xml_escape "$guard_script")
+			_xml_guard_home=$(_xml_escape "$HOME")
+
 			cat >"$guard_plist" <<GUARD_PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1003,21 +1030,21 @@ PLIST
 	<string>${guard_label}</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>${guard_script}</string>
+		<string>${_xml_guard_script}</string>
 		<string>kill-runaways</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>30</integer>
 	<key>StandardOutPath</key>
-	<string>${HOME}/.aidevops/logs/process-guard.log</string>
+	<string>${_xml_guard_home}/.aidevops/logs/process-guard.log</string>
 	<key>StandardErrorPath</key>
-	<string>${HOME}/.aidevops/logs/process-guard.log</string>
+	<string>${_xml_guard_home}/.aidevops/logs/process-guard.log</string>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
 		<string>${PATH}</string>
 		<key>HOME</key>
-		<string>${HOME}</string>
+		<string>${_xml_guard_home}</string>
 		<key>SHELLCHECK_RSS_LIMIT_KB</key>
 		<string>524288</string>
 		<key>SHELLCHECK_RUNTIME_LIMIT</key>
@@ -1045,8 +1072,8 @@ GUARD_PLIST
 			# Always regenerate to pick up config changes (matches macOS behavior)
 			(
 				crontab -l 2>/dev/null | grep -v 'aidevops: process-guard'
-				echo "* * * * * SHELLCHECK_RSS_LIMIT_KB=524288 SHELLCHECK_RUNTIME_LIMIT=120 CHILD_RSS_LIMIT_KB=8388608 CHILD_RUNTIME_LIMIT=7200 /bin/bash \"${guard_script}\" kill-runaways >> \"\$HOME/.aidevops/logs/process-guard.log\" 2>&1 # aidevops: process-guard"
-			) | crontab - 2>/dev/null || true
+				echo "* * * * * PATH=\"/usr/local/bin:/usr/bin:/bin\" SHELLCHECK_RSS_LIMIT_KB=524288 SHELLCHECK_RUNTIME_LIMIT=120 CHILD_RSS_LIMIT_KB=8388608 CHILD_RUNTIME_LIMIT=7200 /bin/bash \"${guard_script}\" kill-runaways >> \"\$HOME/.aidevops/logs/process-guard.log\" 2>&1 # aidevops: process-guard"
+			) | crontab - || true
 			if crontab -l 2>/dev/null | grep -qF "aidevops: process-guard" 2>/dev/null; then
 				print_info "Process guard enabled (cron, every minute)"
 			else


### PR DESCRIPTION
## Summary

Addresses all 5 findings from PR #2940 review feedback (quality-debt issue #2947).

Closes #2947

## Changes

### HIGH: Cron entry command injection (line 1046)
- Added `PATH="/usr/local/bin:/usr/bin:/bin"` to both cron entries for reliable command resolution
- Properly quoted all variable expansions in cron entries to prevent word splitting
- Removed `2>/dev/null` from `crontab -` (install) so errors are visible; `|| true` still prevents script exit

### MEDIUM: Plist XML injection (line 1006)
- Added `_xml_escape()` helper function that escapes `&`, `<`, `>`, `"`, `'` for safe XML embedding
- All path variables in both pulse and guard plist heredocs are now XML-escaped before embedding
- Prevents malformed plist if `$HOME` or paths contain XML special characters

### MEDIUM: launchctl stderr suppression (lines 994, 1036)
- These were already fixed in the merged PR #2940 code (no `2>/dev/null` on guard launchctl calls)
- Extended the fix to the pulse section for consistency — removed `2>/dev/null` from 4 `launchctl` calls
- `|| true` already prevents script exit; stderr is now visible for debugging

### MEDIUM: Hardcoded PATH in plist (line 1018)
- Already uses `${PATH}` in the merged code — no action needed

### Intentionally kept `2>/dev/null`
- `crontab -l 2>/dev/null` — expected error when no crontab exists (first run)
- `pkill -f ... 2>/dev/null` — expected error when no matching process exists