### PR TITLE
fix: install memory pressure monitor via setup.sh for reboot survival

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1055,6 +1055,82 @@ GUARD_PLIST
 		fi
 	fi
 
+	# Memory pressure monitor — process-focused memory watchdog (t1398.5, GH#2915).
+	# Monitors individual process RSS, runtime, session count, and aggregate memory.
+	# Auto-kills runaway ShellCheck (language server respawns them). Always installed
+	# when the script exists; no consent needed (safety net, not autonomous action).
+	# macOS: launchd plist (60s interval, RunAtLoad=true) | Linux: cron (every minute)
+	local monitor_script="$HOME/.aidevops/agents/scripts/memory-pressure-monitor.sh"
+	local monitor_label="sh.aidevops.memory-pressure-monitor"
+	if [[ -x "$monitor_script" ]]; then
+		mkdir -p "$HOME/.aidevops/logs"
+
+		if [[ "$(uname -s)" == "Darwin" ]]; then
+			local monitor_plist="$HOME/Library/LaunchAgents/${monitor_label}.plist"
+
+			# Unload old plist if upgrading
+			if _launchd_has_agent "$monitor_label"; then
+				launchctl unload "$monitor_plist" 2>/dev/null || true
+			fi
+
+			cat >"$monitor_plist" <<MONITOR_PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${monitor_label}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>${monitor_script}</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>60</integer>
+	<key>StandardOutPath</key>
+	<string>${HOME}/.aidevops/logs/memory-pressure-launchd.log</string>
+	<key>StandardErrorPath</key>
+	<string>${HOME}/.aidevops/logs/memory-pressure-launchd.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<key>HOME</key>
+		<string>${HOME}</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityBackgroundIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+</dict>
+</plist>
+MONITOR_PLIST
+
+			if launchctl load "$monitor_plist" 2>/dev/null; then
+				print_info "Memory pressure monitor enabled (launchd, every 60s, survives reboot)"
+			else
+				print_warning "Failed to load memory pressure monitor LaunchAgent"
+			fi
+		else
+			# Linux: cron entry (every minute — cron minimum granularity)
+			(
+				crontab -l 2>/dev/null | grep -v 'aidevops: memory-pressure-monitor'
+				echo "* * * * * /bin/bash \"${monitor_script}\" >> \"\$HOME/.aidevops/logs/memory-pressure-launchd.log\" 2>&1 # aidevops: memory-pressure-monitor"
+			) | crontab - 2>/dev/null || true
+			if crontab -l 2>/dev/null | grep -qF "aidevops: memory-pressure-monitor" 2>/dev/null; then
+				print_info "Memory pressure monitor enabled (cron, every minute)"
+			else
+				print_warning "Failed to install memory pressure monitor cron entry"
+			fi
+		fi
+	fi
+
 	echo ""
 	echo "CLI Command:"
 	echo "  aidevops init         - Initialize aidevops in a project"


### PR DESCRIPTION
## Summary

- Memory pressure monitor (`memory-pressure-monitor.sh`) was deployed but not auto-installed by `setup.sh` — it didn't survive reboots or `aidevops update`
- Adds launchd plist generation (macOS, 60s interval, `RunAtLoad=true`) and cron entry (Linux) alongside the existing process guard block
- No consent gate — this is a safety net (auto-kills runaway ShellCheck at >4 GB RSS), same as the process guard

## Context

The t1398 series (PRs #2855, #2881, #2882, #2883, #2884, #2885, #2918, #2930) fixed the root cause of memory blowups (ShellCheck `--external-sources` exponential expansion inside Tabby's bash language server). The memory pressure monitor is the defense-in-depth layer — but it was only installable via `--install` flag, not auto-deployed by `setup.sh`. After a reboot, the monitor wasn't running.

## Verification

- ShellCheck clean on `setup.sh`
- Follows exact same pattern as the process guard block (lines 980-1056)
- Plist matches the one generated by `memory-pressure-monitor.sh --install`
- Monitor confirmed running after manual install: `launchctl list | grep memory-pressure`