### PR TITLE
t2955: Replace blanket 2>/dev/null with explicit file checks in shell-env.sh

### DIFF
--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -508,7 +508,7 @@ setup_shellcheck_wrapper() {
 	# shells, so SHELLCHECK_PATH set only in .zshrc is invisible to the LSP.
 	local zshenv="$HOME/.zshenv"
 	if [[ -f "$zshenv" ]] || command -v zsh >/dev/null 2>&1; then
-		if grep -q 'SHELLCHECK_PATH' "$zshenv" 2>/dev/null; then
+		if [[ -f "$zshenv" ]] && grep -q 'SHELLCHECK_PATH' "$zshenv"; then
 			already_in="${already_in:+$already_in, }$zshenv"
 		else
 			touch "$zshenv"
@@ -529,8 +529,8 @@ setup_shellcheck_wrapper() {
 			touch "$rc_file"
 		fi
 
-		# Check if already added
-		if grep -q 'SHELLCHECK_PATH' "$rc_file" 2>/dev/null; then
+		# Check if already added (file existence guaranteed by check above)
+		if grep -q 'SHELLCHECK_PATH' "$rc_file"; then
 			already_in="${already_in:+$already_in, }$rc_file"
 			continue
 		fi


### PR DESCRIPTION
## Summary

- Addresses PR #2937 review feedback: `grep` with `2>/dev/null` masks permission errors and other non-file-not-found failures in `setup_shellcheck_wrapper()`
- Line 511: adds `[[ -f "$zshenv" ]]` guard before `grep` — the file may not exist when entering via the `command -v zsh` branch of the outer condition
- Line 533: removes redundant `2>/dev/null` — file existence is already guaranteed by the `[[ ! -f "$rc_file" ]]` check + `touch` at lines 527-530

## Changes

Two targeted fixes in `setup-modules/shell-env.sh`, both in the `setup_shellcheck_wrapper()` function:

1. **Explicit file check** (line 511): `grep -q 'SHELLCHECK_PATH' "$zshenv" 2>/dev/null` → `[[ -f "$zshenv" ]] && grep -q 'SHELLCHECK_PATH' "$zshenv"`
2. **Remove redundant suppression** (line 533): `grep -q 'SHELLCHECK_PATH' "$rc_file" 2>/dev/null` → `grep -q 'SHELLCHECK_PATH' "$rc_file"`

## Verification

- ShellCheck passes clean
- Logic preserved: when `$zshenv` doesn't exist, the `[[ -f ]]` short-circuits to false → falls through to the `else` branch which creates the file (same behaviour as before)

Closes #2955