### PR TITLE
fix: calculate LLM cost from tokens — OpenCode does not provide msg.cost

### DIFF
--- a/.agents/configs/model-pricing.json
+++ b/.agents/configs/model-pricing.json
@@ -1,0 +1,21 @@
+{
+  "_comment": "Single source of truth for LLM model pricing (per 1M tokens). Consumed by observability.mjs and shared-constants.sh get_model_pricing(). Update this file when model pricing changes.",
+  "_format": "Each key is a substring matched against model IDs. Values: input, output, cache_read, cache_write (all per 1M tokens in USD).",
+  "models": {
+    "opus-4":          { "input": 15.0,  "output": 75.0,  "cache_read": 1.50,   "cache_write": 18.75 },
+    "sonnet-4":        { "input": 3.0,   "output": 15.0,  "cache_read": 0.30,   "cache_write": 3.75  },
+    "haiku-4":         { "input": 0.80,  "output": 4.0,   "cache_read": 0.08,   "cache_write": 1.0   },
+    "haiku-3":         { "input": 0.80,  "output": 4.0,   "cache_read": 0.08,   "cache_write": 1.0   },
+    "gpt-4.1-mini":    { "input": 0.40,  "output": 1.60,  "cache_read": 0.10,   "cache_write": 0.40  },
+    "gpt-4.1":         { "input": 2.0,   "output": 8.0,   "cache_read": 0.50,   "cache_write": 2.0   },
+    "o3":              { "input": 10.0,  "output": 40.0,  "cache_read": 2.50,   "cache_write": 10.0  },
+    "o4-mini":         { "input": 1.10,  "output": 4.40,  "cache_read": 0.275,  "cache_write": 1.10  },
+    "gemini-2.5-pro":  { "input": 1.25,  "output": 10.0,  "cache_read": 0.3125, "cache_write": 2.50  },
+    "gemini-2.5-flash":{ "input": 0.15,  "output": 0.60,  "cache_read": 0.0375, "cache_write": 0.15  },
+    "gemini-3-pro":    { "input": 1.25,  "output": 10.0,  "cache_read": 0.3125, "cache_write": 2.50  },
+    "gemini-3-flash":  { "input": 0.10,  "output": 0.40,  "cache_read": 0.025,  "cache_write": 0.10  },
+    "deepseek-r1":     { "input": 0.55,  "output": 2.19,  "cache_read": 0.14,   "cache_write": 0.55  },
+    "deepseek-v3":     { "input": 0.27,  "output": 1.10,  "cache_read": 0.07,   "cache_write": 0.27  }
+  },
+  "default": { "input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75 }
+}

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -24,6 +24,76 @@ const OBS_DIR = join(HOME, ".aidevops", ".agent-workspace", "observability");
 const DB_PATH = join(OBS_DIR, "llm-requests.db");
 
 // ---------------------------------------------------------------------------
+// Pricing table — per-million-token rates (input | output | cache_read | cache_write)
+// Mirrors shared-constants.sh get_model_pricing(). Update when models change.
+// ---------------------------------------------------------------------------
+
+const MODEL_PRICING = {
+  // Anthropic
+  "opus-4":    { input: 15.0,  output: 75.0,  cacheRead: 1.50,   cacheWrite: 18.75 },
+  "sonnet-4":  { input: 3.0,   output: 15.0,  cacheRead: 0.30,   cacheWrite: 3.75  },
+  "haiku-4":   { input: 0.80,  output: 4.0,   cacheRead: 0.08,   cacheWrite: 1.0   },
+  "haiku-3":   { input: 0.80,  output: 4.0,   cacheRead: 0.08,   cacheWrite: 1.0   },
+  // OpenAI
+  "gpt-4.1-mini": { input: 0.40, output: 1.60, cacheRead: 0.10,  cacheWrite: 0.40  },
+  "gpt-4.1":      { input: 2.0,  output: 8.0,  cacheRead: 0.50,  cacheWrite: 2.0   },
+  "o3":            { input: 10.0, output: 40.0, cacheRead: 2.50,  cacheWrite: 10.0  },
+  "o4-mini":       { input: 1.10, output: 4.40, cacheRead: 0.275, cacheWrite: 1.10  },
+  // Google
+  "gemini-2.5-pro":   { input: 1.25, output: 10.0, cacheRead: 0.3125, cacheWrite: 2.50 },
+  "gemini-2.5-flash": { input: 0.15, output: 0.60, cacheRead: 0.0375, cacheWrite: 0.15 },
+  "gemini-3-pro":     { input: 1.25, output: 10.0, cacheRead: 0.3125, cacheWrite: 2.50 },
+  "gemini-3-flash":   { input: 0.10, output: 0.40, cacheRead: 0.025,  cacheWrite: 0.10 },
+  // DeepSeek
+  "deepseek-r1": { input: 0.55, output: 2.19, cacheRead: 0.14, cacheWrite: 0.55 },
+  "deepseek-v3": { input: 0.27, output: 1.10, cacheRead: 0.07, cacheWrite: 0.27 },
+};
+
+// Default pricing (sonnet-tier) for unknown models
+const DEFAULT_PRICING = { input: 3.0, output: 15.0, cacheRead: 0.30, cacheWrite: 3.75 };
+
+/**
+ * Look up pricing for a model ID. Matches against the pricing table keys
+ * as substrings of the model ID (e.g., "claude-sonnet-4-20250514" matches "sonnet-4").
+ * @param {string} modelID
+ * @returns {{ input: number, output: number, cacheRead: number, cacheWrite: number }}
+ */
+function getPricing(modelID) {
+  if (!modelID) return DEFAULT_PRICING;
+  const lower = modelID.toLowerCase();
+  for (const [key, pricing] of Object.entries(MODEL_PRICING)) {
+    if (lower.includes(key)) return pricing;
+  }
+  return DEFAULT_PRICING;
+}
+
+/**
+ * Calculate cost from token counts and model pricing.
+ * OpenCode does not provide cost in message events — we must compute it.
+ * @param {object} tokens - { input, output, reasoning, cache: { read, write } }
+ * @param {string} modelID
+ * @returns {number} Total cost in USD
+ */
+function calculateCost(tokens, modelID) {
+  if (!tokens) return 0.0;
+  const pricing = getPricing(modelID);
+  const inputTokens = tokens.input || 0;
+  const outputTokens = tokens.output || 0;
+  const reasoningTokens = tokens.reasoning || 0;
+  const cacheRead = tokens.cache?.read || 0;
+  const cacheWrite = tokens.cache?.write || 0;
+
+  // Reasoning tokens are billed at output rate
+  const cost =
+    (inputTokens / 1e6) * pricing.input +
+    ((outputTokens + reasoningTokens) / 1e6) * pricing.output +
+    (cacheRead / 1e6) * pricing.cacheRead +
+    (cacheWrite / 1e6) * pricing.cacheWrite;
+
+  return Math.round(cost * 1e8) / 1e8; // 8 decimal places
+}
+
+// ---------------------------------------------------------------------------
 // SQLite helpers (uses sqlite3 CLI — no native dependency needed in ESM)
 // ---------------------------------------------------------------------------
 
@@ -171,7 +241,60 @@ CREATE INDEX IF NOT EXISTS idx_session_summaries_session
     sqliteExec("ALTER TABLE tool_calls ADD COLUMN intent TEXT;", 5000);
   }
 
+  // Migration: backfill cost for rows where cost=0 but tokens exist.
+  // OpenCode never provided msg.cost — all historical rows have cost=0.
+  // This runs once (subsequent runs find 0 rows to update) and takes ~1s.
+  backfillCosts();
+
   return true;
+}
+
+/**
+ * Backfill cost for historical rows where cost=0 but tokens exist.
+ * Uses SQL CASE expressions matching the JS pricing table to avoid
+ * round-tripping each row through JS. Runs in a single UPDATE statement.
+ * Idempotent — only updates rows where cost=0 AND tokens_total>0.
+ */
+function backfillCosts() {
+  // Build SQL CASE expression from the pricing table
+  const cases = Object.entries(MODEL_PRICING).map(([key, p]) =>
+    `WHEN lower(model_id) LIKE '%${key}%' THEN ` +
+    `(tokens_input * ${p.input} + (tokens_output + tokens_reasoning) * ${p.output} ` +
+    `+ tokens_cache_read * ${p.cacheRead} + tokens_cache_write * ${p.cacheWrite}) / 1000000.0`
+  ).join("\n    ");
+
+  const sql = `
+UPDATE llm_requests
+SET cost = CASE
+    ${cases}
+    ELSE (tokens_input * ${DEFAULT_PRICING.input} + (tokens_output + tokens_reasoning) * ${DEFAULT_PRICING.output}
+      + tokens_cache_read * ${DEFAULT_PRICING.cacheRead} + tokens_cache_write * ${DEFAULT_PRICING.cacheWrite}) / 1000000.0
+  END
+WHERE cost = 0.0 AND tokens_total > 0;
+`;
+
+  const result = sqliteExec(sql, 30000); // 30s timeout for large backfill
+  if (result !== null) {
+    // Check how many rows were updated
+    const count = sqliteExec("SELECT changes();", 5000);
+    if (count && parseInt(count, 10) > 0) {
+      console.error(`[aidevops] Observability: backfilled cost for ${count} rows`);
+
+      // Also rebuild session_summaries from the corrected data
+      sqliteExec(`
+DELETE FROM session_summaries;
+INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count,
+  total_tokens_input, total_tokens_output, total_cost, total_tool_calls, total_errors,
+  project_path, models_used)
+SELECT session_id, MIN(timestamp), MAX(timestamp), COUNT(*),
+  SUM(tokens_input), SUM(tokens_output), SUM(cost), MAX(tool_call_count), 0,
+  MAX(project_path), GROUP_CONCAT(DISTINCT model_id)
+FROM llm_requests
+GROUP BY session_id;
+`, 30000);
+      console.error("[aidevops] Observability: rebuilt session_summaries with corrected costs");
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -275,6 +398,9 @@ function handleMessageUpdated(event) {
 
   const projectPath = msg.path?.root || msg.path?.cwd || null;
 
+  // Calculate cost from tokens — OpenCode does not provide msg.cost
+  const cost = calculateCost(msg.tokens, msg.modelID);
+
   const sql = `INSERT INTO llm_requests (
     session_id, message_id, provider_id, model_id, agent,
     tokens_input, tokens_output, tokens_reasoning,
@@ -293,7 +419,7 @@ function handleMessageUpdated(event) {
     ${msg.tokens?.cache?.read || 0},
     ${msg.tokens?.cache?.write || 0},
     ${msg.tokens?.total || 0},
-    ${msg.cost || 0.0},
+    ${cost},
     ${durationMs !== null ? durationMs : "NULL"},
     ${sqlEscape(msg.finish || null)},
     ${sqlEscape(errorType)},
@@ -306,7 +432,7 @@ function handleMessageUpdated(event) {
   sqliteExec(sql);
 
   // Update session summary (upsert)
-  updateSessionSummary(msg, toolCallCount);
+  updateSessionSummary(msg, cost, toolCallCount);
 }
 
 /**
@@ -314,9 +440,10 @@ function handleMessageUpdated(event) {
  * Uses INSERT OR REPLACE with accumulated values.
  *
  * @param {object} msg - Assistant message
+ * @param {number} cost - Pre-calculated cost for this request
  * @param {number} toolCallCount - Current tool call count for session
  */
-function updateSessionSummary(msg, toolCallCount) {
+function updateSessionSummary(msg, cost, toolCallCount) {
   const now = new Date().toISOString();
   const projectPath = msg.path?.root || msg.path?.cwd || null;
   const hasError = msg.error ? 1 : 0;
@@ -333,7 +460,7 @@ INSERT INTO session_summaries (
   1,
   ${msg.tokens?.input || 0},
   ${msg.tokens?.output || 0},
-  ${msg.cost || 0.0},
+  ${cost},
   ${toolCallCount},
   ${hasError},
   ${sqlEscape(projectPath)},
@@ -344,7 +471,7 @@ ON CONFLICT(session_id) DO UPDATE SET
   request_count = request_count + 1,
   total_tokens_input = total_tokens_input + ${msg.tokens?.input || 0},
   total_tokens_output = total_tokens_output + ${msg.tokens?.output || 0},
-  total_cost = total_cost + ${msg.cost || 0.0},
+  total_cost = total_cost + ${cost},
   total_tool_calls = ${toolCallCount},
   total_errors = total_errors + ${hasError},
   models_used = CASE

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -14,43 +14,78 @@
  * @module observability
  */
 
-import { mkdirSync } from "fs";
-import { join } from "path";
+import { mkdirSync, readFileSync } from "fs";
+import { join, dirname } from "path";
 import { homedir } from "os";
 import { execSync } from "child_process";
+import { fileURLToPath } from "url";
 
 const HOME = homedir();
 const OBS_DIR = join(HOME, ".aidevops", ".agent-workspace", "observability");
 const DB_PATH = join(OBS_DIR, "llm-requests.db");
 
 // ---------------------------------------------------------------------------
-// Pricing table — per-million-token rates (input | output | cache_read | cache_write)
-// Mirrors shared-constants.sh get_model_pricing(). Update when models change.
+// Pricing table — loaded from shared JSON (single source of truth).
+// File: .agents/configs/model-pricing.json (also consumed by shared-constants.sh)
+// Falls back to hardcoded defaults if the JSON file is missing/unreadable.
 // ---------------------------------------------------------------------------
 
-const MODEL_PRICING = {
-  // Anthropic
+/** Hardcoded fallback — used only when model-pricing.json is unreadable */
+const FALLBACK_PRICING = {
   "opus-4":    { input: 15.0,  output: 75.0,  cacheRead: 1.50,   cacheWrite: 18.75 },
   "sonnet-4":  { input: 3.0,   output: 15.0,  cacheRead: 0.30,   cacheWrite: 3.75  },
   "haiku-4":   { input: 0.80,  output: 4.0,   cacheRead: 0.08,   cacheWrite: 1.0   },
   "haiku-3":   { input: 0.80,  output: 4.0,   cacheRead: 0.08,   cacheWrite: 1.0   },
-  // OpenAI
-  "gpt-4.1-mini": { input: 0.40, output: 1.60, cacheRead: 0.10,  cacheWrite: 0.40  },
-  "gpt-4.1":      { input: 2.0,  output: 8.0,  cacheRead: 0.50,  cacheWrite: 2.0   },
-  "o3":            { input: 10.0, output: 40.0, cacheRead: 2.50,  cacheWrite: 10.0  },
-  "o4-mini":       { input: 1.10, output: 4.40, cacheRead: 0.275, cacheWrite: 1.10  },
-  // Google
-  "gemini-2.5-pro":   { input: 1.25, output: 10.0, cacheRead: 0.3125, cacheWrite: 2.50 },
-  "gemini-2.5-flash": { input: 0.15, output: 0.60, cacheRead: 0.0375, cacheWrite: 0.15 },
-  "gemini-3-pro":     { input: 1.25, output: 10.0, cacheRead: 0.3125, cacheWrite: 2.50 },
-  "gemini-3-flash":   { input: 0.10, output: 0.40, cacheRead: 0.025,  cacheWrite: 0.10 },
-  // DeepSeek
-  "deepseek-r1": { input: 0.55, output: 2.19, cacheRead: 0.14, cacheWrite: 0.55 },
-  "deepseek-v3": { input: 0.27, output: 1.10, cacheRead: 0.07, cacheWrite: 0.27 },
 };
+const FALLBACK_DEFAULT = { input: 3.0, output: 15.0, cacheRead: 0.30, cacheWrite: 3.75 };
 
-// Default pricing (sonnet-tier) for unknown models
-const DEFAULT_PRICING = { input: 3.0, output: 15.0, cacheRead: 0.30, cacheWrite: 3.75 };
+/**
+ * Load pricing from the shared JSON file.
+ * The JSON uses snake_case keys (cache_read, cache_write) for cross-language
+ * compatibility; we convert to camelCase for JS consumption.
+ * @returns {{ models: Record<string, {input,output,cacheRead,cacheWrite}>, default: {input,output,cacheRead,cacheWrite} }}
+ */
+function loadPricingFromJSON() {
+  // Resolve relative to this file's location (works in both dev repo and deployed ~/.aidevops/)
+  const thisDir = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(thisDir, "..", "..", "configs", "model-pricing.json"),          // repo: .agents/plugins/../../configs/
+    join(HOME, ".aidevops", "agents", "configs", "model-pricing.json"), // deployed
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const raw = JSON.parse(readFileSync(candidate, "utf-8"));
+      const models = {};
+      for (const [key, p] of Object.entries(raw.models || {})) {
+        models[key] = {
+          input: p.input,
+          output: p.output,
+          cacheRead: p.cache_read,
+          cacheWrite: p.cache_write,
+        };
+      }
+      const def = raw.default || {};
+      const defaultPricing = {
+        input: def.input ?? 3.0,
+        output: def.output ?? 15.0,
+        cacheRead: def.cache_read ?? 0.30,
+        cacheWrite: def.cache_write ?? 3.75,
+      };
+      return { models, default: defaultPricing };
+    } catch {
+      // Try next candidate
+    }
+  }
+
+  // All candidates failed — use hardcoded fallback
+  console.error("[aidevops] Observability: model-pricing.json not found, using hardcoded fallback");
+  return { models: FALLBACK_PRICING, default: FALLBACK_DEFAULT };
+}
+
+const _pricing = loadPricingFromJSON();
+const MODEL_PRICING = _pricing.models;
+const DEFAULT_PRICING = _pricing.default;
 
 /**
  * Look up pricing for a model ID. Matches against the pricing table keys

--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -273,27 +273,28 @@ SET cost = CASE
 WHERE cost = 0.0 AND tokens_total > 0;
 `;
 
-  const result = sqliteExec(sql, 30000); // 30s timeout for large backfill
-  if (result !== null) {
-    // Check how many rows were updated
-    const count = sqliteExec("SELECT changes();", 5000);
-    if (count && parseInt(count, 10) > 0) {
-      console.error(`[aidevops] Observability: backfilled cost for ${count} rows`);
+  // Combine UPDATE and SELECT changes() in a single sqliteExec so they run
+  // on the same sqlite3 connection — a separate call would always return 0.
+  const countRaw = sqliteExec(`${sql}\nSELECT changes();`, 30000);
+  const count = countRaw?.split("\n").pop() ?? "0";
+  if (parseInt(count, 10) > 0) {
+    console.error(`[aidevops] Observability: backfilled cost for ${count} rows`);
 
-      // Also rebuild session_summaries from the corrected data
-      sqliteExec(`
+    // Rebuild session_summaries from the corrected data.
+    // Compute total_errors from actual error columns instead of hardcoding 0.
+    sqliteExec(`
 DELETE FROM session_summaries;
 INSERT INTO session_summaries (session_id, first_seen, last_seen, request_count,
   total_tokens_input, total_tokens_output, total_cost, total_tool_calls, total_errors,
   project_path, models_used)
 SELECT session_id, MIN(timestamp), MAX(timestamp), COUNT(*),
-  SUM(tokens_input), SUM(tokens_output), SUM(cost), MAX(tool_call_count), 0,
+  SUM(tokens_input), SUM(tokens_output), SUM(cost), MAX(tool_call_count),
+  SUM(CASE WHEN error_type IS NOT NULL OR error_message IS NOT NULL THEN 1 ELSE 0 END),
   MAX(project_path), GROUP_CONCAT(DISTINCT model_id)
 FROM llm_requests
 GROUP BY session_id;
 `, 30000);
-      console.error("[aidevops] Observability: rebuilt session_summaries with corrected costs");
-    }
+    console.error("[aidevops] Observability: rebuilt session_summaries with corrected costs");
   }
 }
 

--- a/.agents/scripts/observability-helper.sh
+++ b/.agents/scripts/observability-helper.sh
@@ -172,8 +172,19 @@ cmd_ingest() {
 		shift
 	done
 
+	# Primary source: OpenCode plugin writes to SQLite DB in real-time.
+	# JSONL ingest is legacy (Claude Code transcripts, no longer updated).
+	local obs_db="${OBS_DIR}/llm-requests.db"
+	if [[ -f "$obs_db" ]] && command -v sqlite3 &>/dev/null; then
+		local row_count
+		row_count=$(sqlite3 "$obs_db" "SELECT COUNT(*) FROM llm_requests;" 2>/dev/null) || row_count=0
+		[[ "$quiet" != "true" ]] && print_success "SQLite DB has $row_count rows (real-time via OpenCode plugin)"
+		return 0
+	fi
+
+	# Legacy fallback: parse Claude Code JSONL transcripts
 	[[ -d "$CLAUDE_LOG_DIR" ]] || {
-		print_warning "Claude log directory not found: $CLAUDE_LOG_DIR"
+		print_warning "No data sources found. OpenCode plugin SQLite DB not found, Claude log directory not found."
 		return 0
 	}
 	command -v jq &>/dev/null || {
@@ -313,6 +324,26 @@ _get_config_val() { _rl_jq '.[$f]' "" "$1" "$2"; }
 
 _count_usage_in_window() {
 	local provider="$1" window_minutes="$2"
+
+	# Prefer SQLite DB (populated by OpenCode plugin in real-time) over JSONL
+	local obs_db="${OBS_DIR}/llm-requests.db"
+	if [[ -f "$obs_db" ]] && command -v sqlite3 &>/dev/null; then
+		local result
+		result=$(sqlite3 "$obs_db" "
+			SELECT COUNT(*), COALESCE(SUM(tokens_input + tokens_output + tokens_cache_read + tokens_cache_write), 0)
+			FROM llm_requests
+			WHERE lower(provider_id) = lower('${provider}')
+			  AND timestamp > datetime('now', '-${window_minutes} minutes');
+		" 2>/dev/null) || result=""
+		if [[ -n "$result" ]]; then
+			local req_count tok_count
+			IFS='|' read -r req_count tok_count <<<"$result"
+			echo "${req_count:-0}|${tok_count:-0}"
+			return 0
+		fi
+	fi
+
+	# Fallback to JSONL (legacy — Claude Code transcripts, no longer updated)
 	[[ -f "$OBS_METRICS" ]] || {
 		echo "0|0"
 		return 0

--- a/.agents/scripts/observability-helper.sh
+++ b/.agents/scripts/observability-helper.sh
@@ -177,9 +177,11 @@ cmd_ingest() {
 	local obs_db="${OBS_DIR}/llm-requests.db"
 	if [[ -f "$obs_db" ]] && command -v sqlite3 &>/dev/null; then
 		local row_count
-		row_count=$(sqlite3 "$obs_db" "SELECT COUNT(*) FROM llm_requests;" 2>/dev/null) || row_count=0
-		[[ "$quiet" != "true" ]] && print_success "SQLite DB has $row_count rows (real-time via OpenCode plugin)"
-		return 0
+		if row_count=$(sqlite3 "$obs_db" "SELECT COUNT(*) FROM llm_requests;" 2>/dev/null); then
+			[[ "$quiet" != "true" ]] && print_success "SQLite DB has $row_count rows (real-time via OpenCode plugin)"
+			return 0
+		fi
+		[[ "$quiet" != "true" ]] && print_warning "SQLite DB exists but llm_requests could not be queried; falling back to legacy JSONL ingest"
 	fi
 
 	# Legacy fallback: parse Claude Code JSONL transcripts
@@ -333,7 +335,7 @@ _count_usage_in_window() {
 			SELECT COUNT(*), COALESCE(SUM(tokens_input + tokens_output + tokens_cache_read + tokens_cache_write), 0)
 			FROM llm_requests
 			WHERE lower(provider_id) = lower('${provider}')
-			  AND timestamp > datetime('now', '-${window_minutes} minutes');
+			  AND timestamp > strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-${window_minutes} minutes');
 		" 2>/dev/null) || result=""
 		if [[ -n "$result" ]]; then
 			local req_count tok_count

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1297,12 +1297,71 @@ detect_ai_backends() {
 # =============================================================================
 # Model Pricing & Provider Detection (consolidated from t1337.2)
 # =============================================================================
-# Shared by budget-tracker-helper.sh and observability-helper.sh.
+# Single source of truth: .agents/configs/model-pricing.json
+# Also consumed by observability.mjs (OpenCode plugin).
 # Pricing: per 1M tokens — input|output|cache_read|cache_write.
 # Budget-tracker uses only input|output; observability uses all four.
+#
+# Falls back to hardcoded case statement if jq or the JSON file is unavailable.
+
+# Cache for JSON-loaded pricing (avoids re-reading the file on every call)
+_MODEL_PRICING_JSON=""
+_MODEL_PRICING_JSON_LOADED=""
+
+# Load model-pricing.json into the cache variable.
+# Called once on first get_model_pricing() invocation.
+_load_model_pricing_json() {
+	_MODEL_PRICING_JSON_LOADED="attempted"
+	local json_file
+	# Try repo-relative path first (works in dev), then deployed path
+	local script_dir="${BASH_SOURCE[0]%/*}"
+	for json_file in \
+		"${script_dir}/../configs/model-pricing.json" \
+		"${HOME}/.aidevops/agents/configs/model-pricing.json"; do
+		if [[ -r "$json_file" ]] && command -v jq &>/dev/null; then
+			_MODEL_PRICING_JSON=$(cat "$json_file" 2>/dev/null) || _MODEL_PRICING_JSON=""
+			if [[ -n "$_MODEL_PRICING_JSON" ]]; then
+				return 0
+			fi
+		fi
+	done
+	return 1
+}
 
 get_model_pricing() {
 	local model="$1"
+
+	# Try JSON source first (single source of truth)
+	if [[ -z "$_MODEL_PRICING_JSON_LOADED" ]]; then
+		_load_model_pricing_json
+	fi
+
+	if [[ -n "$_MODEL_PRICING_JSON" ]]; then
+		local ms="${model#*/}"
+		ms="${ms%%-202*}"
+		ms=$(echo "$ms" | tr '[:upper:]' '[:lower:]')
+		# Search for a matching key in the JSON models object
+		local result
+		result=$(echo "$_MODEL_PRICING_JSON" | jq -r --arg ms "$ms" '
+			.models | to_entries[] |
+			select(.key as $k | $ms | contains($k)) |
+			"\(.value.input)|\(.value.output)|\(.value.cache_read)|\(.value.cache_write)"
+		' 2>/dev/null | head -1)
+		if [[ -n "$result" ]]; then
+			echo "$result"
+			return 0
+		fi
+		# No match — return default from JSON
+		result=$(echo "$_MODEL_PRICING_JSON" | jq -r '
+			"\(.default.input)|\(.default.output)|\(.default.cache_read)|\(.default.cache_write)"
+		' 2>/dev/null)
+		if [[ -n "$result" && "$result" != "null|null|null|null" ]]; then
+			echo "$result"
+			return 0
+		fi
+	fi
+
+	# Hardcoded fallback (no jq or JSON file unavailable)
 	local ms="${model#*/}"
 	ms="${ms%%-202*}"
 	case "$ms" in


### PR DESCRIPTION
## Summary

- **Root cause**: After migrating from Claude Code to OpenCode, the observability plugin wrote `cost=0.0` for all 59,752+ rows because OpenCode's `message.updated` events don't include a `cost` field (Claude Code did). The JSONL ingest (`observability-helper.sh`) also stopped because it reads Claude Code transcripts (`~/.claude/projects/*.jsonl`) that are no longer written.
- **Fix**: Add a pricing table to `observability.mjs` (mirroring `shared-constants.sh`), calculate cost from `tokens × model pricing` at write time, and include a one-time backfill migration for all historical rows.
- **Also**: Updated `observability-helper.sh` rate-limit checks to read from the SQLite DB (live data) instead of the stale JSONL file.

## Verification

Backfill already applied to live DB:
- 56,798 rows updated with calculated costs
- Total tracked spend: $8,313.94 across 3,158 sessions
- Cost breakdown: opus-4 $8,029 (42,427 reqs), sonnet-4 $280 (14,170 reqs)
- Per-project cost now visible (e.g., last hour: aidevops $193, webapp $33, turbostarter-plus $31)

## Files Changed

- `.agents/plugins/opencode-aidevops/observability.mjs` — pricing table, `calculateCost()`, `backfillCosts()` migration
- `.agents/scripts/observability-helper.sh` — SQLite-first rate limit checks, deprecation-aware ingest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost calculation and tracking for language model requests based on input, output, reasoning, and cached tokens.
  * Enabled cost-aware session summaries with aggregated usage metrics.

* **Chores**
  * Migrated historical request data to include computed costs.
  * Updated data ingestion to prioritize real-time database source with legacy fallback support.
  * Enhanced token usage counting from the primary data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->