### PR TITLE
fix: resolve CI check failures on all PRs — regex false positive + concurrency

### DIFF
--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -29,6 +29,12 @@ jobs:
   security-check:
     name: Security Validation
     runs-on: ubuntu-latest
+    # Needs write permissions to post rejection replies on untrusted comments.
+    # Without this, the GITHUB_TOKEN defaults to read-only and the
+    # createReplyForReviewComment/createComment calls fail with 403. GH#2973.
+    permissions:
+      pull-requests: write
+      issues: write
     outputs:
       allowed: ${{ steps.check.outputs.allowed }}
       reason: ${{ steps.check.outputs.reason }}
@@ -46,8 +52,11 @@ jobs:
             const issue = context.payload.issue || context.payload.pull_request;
             const isPRReviewComment = context.eventName === 'pull_request_review_comment';
             
-            // Must contain /oc or /opencode trigger
-            const hasTrigger = /\/(oc|opencode)\b/.test(comment.body);
+            // Must contain /oc or /opencode trigger at start of line or after whitespace.
+            // The previous regex /\/(oc|opencode)\b/ matched file paths in bot review
+            // comments (e.g., /opencode-aidevops/observability.mjs), causing false
+            // positive triggers on every CodeRabbit review. GH#2973.
+            const hasTrigger = /(^|\s)\/(oc|opencode)\b/m.test(comment.body);
             if (!hasTrigger) {
               core.setOutput('allowed', 'false');
               core.setOutput('reason', 'No /oc or /opencode trigger found');

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -18,10 +18,15 @@ on:
   issue_comment:
     types: [created]
 
-# Cancel in-progress runs when a new event fires (e.g., new push)
+# Do NOT cancel in-progress runs. When cancel-in-progress was true, the initial
+# pull_request:opened run was cancelled by the issue_comment:created event (fired
+# when a bot posted). The cancelled run left a permanent stale CANCELLED check on
+# the PR, making mergeStateStatus UNSTABLE even though the re-triggered run passed.
+# With cancel-in-progress: false, both runs complete — the first passes early
+# (PR too young) and the second confirms the bot posted. GH#2973.
 concurrency:
   group: review-bot-gate-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   review-bot-gate:


### PR DESCRIPTION
## Summary

Fixes three compounding bugs that caused every open PR to show failing/cancelled CI checks:

- **opencode-agent.yml regex false positive**: The trigger regex `/\/(oc|opencode)\b/` matched file paths in CodeRabbit review comments (e.g., `.agents/plugins/opencode-aidevops/observability.mjs`), causing the workflow to fire on every bot review. Fixed by requiring the trigger at line start or after whitespace.
- **opencode-agent.yml missing permissions**: The `security-check` job had no `permissions` block, so `GITHUB_TOKEN` defaulted to read-only. When the false-positive fired and the job tried to reply with a rejection message, it failed with HTTP 403.
- **review-bot-gate.yml stale CANCELLED checks**: `cancel-in-progress: true` cancelled the initial `pull_request:opened` run when a bot posted, leaving a permanent stale CANCELLED check that made `mergeStateStatus: UNSTABLE`.

## Why self-improvement didn't catch this

The pulse/supervisor checks for open PRs and stale issues but doesn't analyze *why* CI checks fail. It sees `UNSTABLE` but doesn't drill into which check or root cause. The OpenCode Agent workflow (which could fix this via `/oc` commands) was itself broken by the same regex bug — a circular failure.

## Testing

- YAML syntax validated (both files)
- Regex tested with Node.js: file paths no longer trigger, actual `/oc` and `/opencode` commands still trigger correctly

Closes #2973