### PR TITLE
GH#2951: Fix quality-debt in pulse-session-helper.sh from PR #2935 review feedback

### DIFF
--- a/.agents/scripts/pulse-session-helper.sh
+++ b/.agents/scripts/pulse-session-helper.sh
@@ -82,7 +82,7 @@ is_session_active() {
 #######################################
 count_workers() {
 	local count
-	count=$(ps axo command | grep '/full-loop' | grep -v grep | grep -c '\.opencode') || count=0
+	count=$(ps axo command | grep '[/]full-loop' | grep -c '\.opencode') || count=0
 	echo "$count"
 	return 0
 }
@@ -277,7 +277,7 @@ EOF
 				kill "$pid" 2>/dev/null || true
 				killed=$((killed + 1))
 			fi
-		done < <(ps axo pid,command | grep '/full-loop' | grep '\.opencode' | grep -v grep)
+		done < <(ps axo pid,command | grep '[/]full-loop' | grep '\.opencode')
 
 		if [[ "$killed" -gt 0 ]]; then
 			print_info "Sent SIGTERM to ${killed} worker(s)"
@@ -289,7 +289,7 @@ EOF
 			if [[ "$remaining" -gt 0 ]]; then
 				print_warning "${remaining} worker(s) still running after SIGTERM"
 				echo "  They will finish their current operation and exit."
-				echo "  Force kill with: kill -9 \$(ps axo pid,command | grep '/full-loop' | grep '.opencode' | grep -v grep | awk '{print \$1}')"
+				echo "  Force kill with: kill -9 \$(ps axo pid,command | grep '[/]full-loop' | grep '\\.opencode' | awk '{print \$1}')"
 			else
 				print_success "All workers stopped"
 			fi
@@ -454,7 +454,7 @@ cmd_status() {
 		echo -e "${BOLD}Active Workers${NC}"
 		echo "──────────────"
 		echo ""
-		ps axo pid,etime,command | grep '/full-loop' | grep '\.opencode' | grep -v grep | while IFS= read -r line; do
+		ps axo pid,etime,command | grep '[/]full-loop' | grep '\.opencode' | while IFS= read -r line; do
 			local w_pid w_etime w_cmd
 			read -r w_pid w_etime w_cmd <<<"$line"
 


### PR DESCRIPTION
## Summary

- Replace fragile `grep pattern | grep -v grep` with `grep '[c]haracter-class'` pattern at 4 locations to prevent grep from matching its own process
- Escape the unescaped dot in the user-facing force-kill hint (`'.opencode'` → `'\\.opencode'`) so it matches the literal string only

## Findings addressed

From [PR #2935 review feedback](https://github.com/marcusquinn/aidevops/issues/2951):

| # | Severity | Finding | Status |
|---|----------|---------|--------|
| 1 | medium | `grep -v grep` fragile pattern (lines 85, 280, 457) | **Fixed** — character class `[/]` |
| 2 | medium | Suppressed stderr with `2>/dev/null` on jq | Already fixed in current code |
| 3 | medium | Redundant `2>/dev/null` after file existence checks | Already fixed in current code |
| 4 | medium | Unescaped dot in force-kill hint (line 292) | **Fixed** — escaped dot + character class |

Findings 2 and 3 were already addressed during or after PR #2935 — the current `main` code no longer has those patterns.

## Verification

- ShellCheck: passes (only SC1091 info for external source, expected)
- All changes are mechanical grep pattern improvements — no logic changes

Closes #2951