### PR TITLE
feat: pulse CI failure pattern detection — identify systemic workflow bugs

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -122,7 +122,7 @@ Then skip to the next PR. The next pulse cycle will retry the permission check �
   - `SKIP` means the PR has a `skip-review-gate` label — it bypasses the bot gate only, NOT the review count requirement.
   - Skip the PR when the formal review count is 0, regardless of bot gate status.
 - **Green CI + zero reviews** → skip this cycle. Zero reviews means "not yet reviewed", NOT "clean to merge". Review bots typically post within 2-5 minutes. The next pulse will pick it up once a review exists.
-- **Failing CI or changes requested** → dispatch a worker to fix it (counts against worker slots)
+- **Failing CI or changes requested** → before dispatching a fix worker, check whether this is a systemic failure (see "CI failure pattern detection" below). If systemic, skip the per-PR dispatch — the workflow-level issue covers it. If per-PR, dispatch a worker to fix it (counts against worker slots).
 
 **For all PRs (regardless of author):**
 


### PR DESCRIPTION
## Summary

- Adds a new `### CI failure pattern detection` subsection to `pulse.md` Step 3 that correlates CI failures across PRs to detect workflow-level bugs
- When 3+ PRs share the same failing check name, the pulse files a single workflow-level issue instead of dispatching N individual fix workers
- Modifies the existing "Failing CI" bullet to cross-reference the new detection section before dispatching per-PR fix workers

## Problem

The pulse processed PRs individually without cross-PR correlation. When a workflow bug caused the same CI check to fail on all PRs (e.g., GH#2973: regex false positive + concurrency cancellation), the pulse dispatched individual fix workers for each PR — workers that tried to fix code when the problem was the CI configuration. This wasted worker slots and never fixed the root cause.

## Design decisions

- **Threshold of 3+ PRs**: Guideline, not hard rule — the pulse agent uses judgment (2 PRs with identical errors = probably systemic; 4 PRs with different errors = probably coincidence)
- **On-demand check fetching**: Individual check names are fetched via `gh pr checks` only when 3+ PRs are failing, avoiding unnecessary API calls on normal cycles
- **Rate limited**: Max 2 systemic CI issues per repo per pulse cycle
- **Dedup**: Checks for existing issues before creating new ones
- **Mixed handling**: PRs with both systemic and per-PR failures get fix workers for the per-PR failures only

Closes #2975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI failure handling with an intelligent pre-dispatch check that distinguishes between systemic workflow issues and per-PR problems, optimizing the dispatch process and reducing unnecessary worker invocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->