### PR TITLE
GH#2993: Fix ShellCheck memory explosion regression — PATH shim for bash-language-server

### DIFF
--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -458,18 +458,26 @@ add_local_bin_to_path() {
 	return 0
 }
 
-# GH#2915: Configure SHELLCHECK_PATH to use the safe wrapper that strips
-# --external-sources. The bash language server hardcodes --external-sources
-# in every ShellCheck invocation, causing exponential memory growth (11 GB+)
-# when source chains span 463+ scripts. The wrapper intercepts this.
+# GH#2915, GH#2993: Ensure all processes use the safe ShellCheck wrapper.
 #
-# Three layers ensure all processes see the wrapper:
+# The bash language server hardcodes --external-sources in every ShellCheck
+# invocation, causing exponential memory growth (9+ GB) when source chains
+# span 463+ scripts. The wrapper strips --external-sources and enforces ulimit.
+#
+# GH#2915 set SHELLCHECK_PATH env var, but bash-language-server ignores it —
+# it resolves `shellcheck` via PATH lookup, finding /opt/homebrew/bin/shellcheck
+# directly. GH#2993 fixes this by placing a shim on PATH ahead of the real binary.
+#
+# Four layers ensure all processes use the wrapper:
+#   0. PATH shim — ~/.aidevops/bin/shellcheck symlink + PATH prepend (GH#2993)
 #   1. launchctl setenv (macOS) — GUI-launched apps (current boot only)
 #   2. .zshenv — ALL zsh processes including non-interactive (persists)
 #   3. Shell rc files (.zshrc, .bash_profile) — interactive terminals
-# Layer 2 is critical: opencode spawns bash-language-server as a non-interactive
-# child process. .zshrc is NOT sourced for non-interactive shells, so without
-# .zshenv the wrapper is invisible to the LSP and shellcheck runs unbounded.
+#
+# Layer 0 is the primary fix: bash-language-server does a PATH lookup for
+# "shellcheck". By placing ~/.aidevops/bin first on PATH with a symlink to
+# the wrapper, the language server finds the wrapper instead of the real binary.
+# Layers 1-3 are retained for tools that honour SHELLCHECK_PATH.
 setup_shellcheck_wrapper() {
 	local wrapper_path="$HOME/.aidevops/agents/scripts/shellcheck-wrapper.sh"
 
@@ -492,8 +500,38 @@ setup_shellcheck_wrapper() {
 	local env_line
 	# shellcheck disable=SC2016 # env_line is written to rc files; must expand at shell startup
 	env_line='export SHELLCHECK_PATH="$HOME/.aidevops/agents/scripts/shellcheck-wrapper.sh"'
+	# shellcheck disable=SC2016 # path_line is written to rc files; must expand at shell startup
+	local path_line='export PATH="$HOME/.aidevops/bin:$PATH"'
 	local added_to=""
 	local already_in=""
+
+	# Layer 0: PATH shim (GH#2993)
+	# Create ~/.aidevops/bin/shellcheck as a symlink to the wrapper.
+	# This is the primary fix: bash-language-server resolves `shellcheck` via
+	# PATH, so the symlink must appear on PATH before /opt/homebrew/bin.
+	local shim_dir="$HOME/.aidevops/bin"
+	local shim_path="$shim_dir/shellcheck"
+	mkdir -p "$shim_dir"
+
+	# Create or update the symlink
+	local wrapper_realpath
+	wrapper_realpath="$(realpath "$wrapper_path" 2>/dev/null || readlink -f "$wrapper_path" 2>/dev/null || echo "$wrapper_path")"
+	if [[ -L "$shim_path" ]]; then
+		local current_target
+		current_target="$(realpath "$shim_path" 2>/dev/null || readlink -f "$shim_path" 2>/dev/null || echo "")"
+		if [[ "$current_target" != "$wrapper_realpath" ]]; then
+			ln -sf "$wrapper_path" "$shim_path"
+			print_info "Updated shellcheck shim symlink: $shim_path → $wrapper_path"
+		fi
+	elif [[ -e "$shim_path" ]]; then
+		# Regular file exists — back up and replace with symlink
+		mv "$shim_path" "${shim_path}.bak.$(date +%Y%m%d_%H%M%S)"
+		ln -sf "$wrapper_path" "$shim_path"
+		print_info "Replaced shellcheck shim with symlink: $shim_path → $wrapper_path"
+	else
+		ln -sf "$wrapper_path" "$shim_path"
+		print_success "Created shellcheck shim: $shim_path → $wrapper_path"
+	fi
 
 	# Layer 1: launchctl setenv (macOS) — affects all GUI-launched processes
 	if [[ "$PLATFORM_MACOS" == "true" ]]; then
@@ -506,16 +544,29 @@ setup_shellcheck_wrapper() {
 	# This is critical because opencode spawns bash-language-server as a
 	# non-interactive child process. .zshrc is NOT sourced for non-interactive
 	# shells, so SHELLCHECK_PATH set only in .zshrc is invisible to the LSP.
+	# GH#2993: Also prepend ~/.aidevops/bin to PATH here so the shim is found.
 	local zshenv="$HOME/.zshenv"
 	if [[ -f "$zshenv" ]] || command -v zsh >/dev/null 2>&1; then
+		touch "$zshenv"
+
+		# SHELLCHECK_PATH env var (for tools that honour it)
 		if grep -q 'SHELLCHECK_PATH' "$zshenv" 2>/dev/null; then
 			already_in="${already_in:+$already_in, }$zshenv"
 		else
-			touch "$zshenv"
 			echo "" >>"$zshenv"
 			echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)" >>"$zshenv"
 			echo "$env_line" >>"$zshenv"
 			added_to="${added_to:+$added_to, }$zshenv"
+		fi
+
+		# PATH prepend for ~/.aidevops/bin (GH#2993: shim must be on PATH)
+		if ! grep -q '\.aidevops/bin' "$zshenv" 2>/dev/null; then
+			echo "" >>"$zshenv"
+			echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)" >>"$zshenv"
+			echo "$path_line" >>"$zshenv"
+			print_success "Prepended $shim_dir to PATH in .zshenv"
+		else
+			print_info "$shim_dir already on PATH in .zshenv"
 		fi
 	fi
 
@@ -529,16 +580,22 @@ setup_shellcheck_wrapper() {
 			touch "$rc_file"
 		fi
 
-		# Check if already added
+		# SHELLCHECK_PATH env var
 		if grep -q 'SHELLCHECK_PATH' "$rc_file" 2>/dev/null; then
 			already_in="${already_in:+$already_in, }$rc_file"
-			continue
+		else
+			echo "" >>"$rc_file"
+			echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)" >>"$rc_file"
+			echo "$env_line" >>"$rc_file"
+			added_to="${added_to:+$added_to, }$rc_file"
 		fi
 
-		echo "" >>"$rc_file"
-		echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)" >>"$rc_file"
-		echo "$env_line" >>"$rc_file"
-		added_to="${added_to:+$added_to, }$rc_file"
+		# PATH prepend for ~/.aidevops/bin (GH#2993)
+		if ! grep -q '\.aidevops/bin' "$rc_file" 2>/dev/null; then
+			echo "" >>"$rc_file"
+			echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)" >>"$rc_file"
+			echo "$path_line" >>"$rc_file"
+		fi
 	done < <(get_all_shell_rcs)
 
 	if [[ -n "$added_to" ]]; then
@@ -556,6 +613,7 @@ setup_shellcheck_wrapper() {
 
 	# Also export for current session
 	export SHELLCHECK_PATH="$wrapper_path"
+	export PATH="$HOME/.aidevops/bin:$PATH"
 
 	return 0
 }

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -542,6 +542,9 @@ setup_shellcheck_wrapper() {
 	# Layer 1: launchctl setenv (macOS) — affects all GUI-launched processes
 	# Set both SHELLCHECK_PATH (for tools that honour it) and PATH (for tools
 	# that resolve shellcheck via PATH lookup, like bash-language-server).
+	# Note: 2>/dev/null on launchctl is intentional — launchctl may not be
+	# available in non-GUI contexts (SSH, containers). Unlike grep where we
+	# want errors visible, launchctl failure is a non-fatal fallback.
 	if [[ "$PLATFORM_MACOS" == "true" ]]; then
 		if launchctl setenv SHELLCHECK_PATH "$wrapper_path" 2>/dev/null; then
 			print_info "Set SHELLCHECK_PATH via launchctl (GUI processes)"

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -501,7 +501,13 @@ setup_shellcheck_wrapper() {
 	# shellcheck disable=SC2016 # env_line is written to rc files; must expand at shell startup
 	env_line='export SHELLCHECK_PATH="$HOME/.aidevops/agents/scripts/shellcheck-wrapper.sh"'
 	# shellcheck disable=SC2016 # path_line is written to rc files; must expand at shell startup
-	local path_line='export PATH="$HOME/.aidevops/bin:$PATH"'
+	# Use case guard so repeated sourcing (e.g. nested shells) doesn't duplicate PATH entries
+	local path_line='case ":$PATH:" in *":$HOME/.aidevops/bin:"*) ;; *) export PATH="$HOME/.aidevops/bin:$PATH" ;; esac'
+	# Fish shell uses different syntax (set -gx instead of export)
+	# shellcheck disable=SC2016 # fish lines are written to config.fish; must expand at shell startup
+	local env_line_fish='set -gx SHELLCHECK_PATH "$HOME/.aidevops/agents/scripts/shellcheck-wrapper.sh"'
+	# shellcheck disable=SC2016
+	local path_line_fish='contains -- "$HOME/.aidevops/bin" $PATH; or set -gx PATH "$HOME/.aidevops/bin" $PATH'
 	local added_to=""
 	local already_in=""
 
@@ -534,9 +540,16 @@ setup_shellcheck_wrapper() {
 	fi
 
 	# Layer 1: launchctl setenv (macOS) — affects all GUI-launched processes
+	# Set both SHELLCHECK_PATH (for tools that honour it) and PATH (for tools
+	# that resolve shellcheck via PATH lookup, like bash-language-server).
 	if [[ "$PLATFORM_MACOS" == "true" ]]; then
 		if launchctl setenv SHELLCHECK_PATH "$wrapper_path" 2>/dev/null; then
 			print_info "Set SHELLCHECK_PATH via launchctl (GUI processes)"
+		fi
+		if [[ ":$PATH:" != *":$shim_dir:"* ]]; then
+			if launchctl setenv PATH "$shim_dir:$PATH" 2>/dev/null; then
+				print_info "Prepended $shim_dir to PATH via launchctl (GUI processes)"
+			fi
 		fi
 	fi
 
@@ -550,7 +563,7 @@ setup_shellcheck_wrapper() {
 		touch "$zshenv"
 
 		# SHELLCHECK_PATH env var (for tools that honour it)
-		if grep -q 'SHELLCHECK_PATH' "$zshenv" 2>/dev/null; then
+		if grep -q 'SHELLCHECK_PATH' "$zshenv"; then
 			already_in="${already_in:+$already_in, }$zshenv"
 		else
 			echo "" >>"$zshenv"
@@ -560,7 +573,8 @@ setup_shellcheck_wrapper() {
 		fi
 
 		# PATH prepend for ~/.aidevops/bin (GH#2993: shim must be on PATH)
-		if ! grep -q '\.aidevops/bin' "$zshenv" 2>/dev/null; then
+		# Use exact-line match so stale entries (append-form, comments) don't short-circuit
+		if ! grep -Fq "$path_line" "$zshenv"; then
 			echo "" >>"$zshenv"
 			echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)" >>"$zshenv"
 			echo "$path_line" >>"$zshenv"
@@ -580,21 +594,36 @@ setup_shellcheck_wrapper() {
 			touch "$rc_file"
 		fi
 
+		# Detect fish config — uses set -gx syntax, not export
+		local is_fish_rc=false
+		if [[ "$rc_file" == *"/fish/config.fish" ]]; then
+			is_fish_rc=true
+		fi
+
+		# Select the correct syntax for this shell
+		local rc_env_line="$env_line"
+		local rc_path_line="$path_line"
+		if [[ "$is_fish_rc" == "true" ]]; then
+			rc_env_line="$env_line_fish"
+			rc_path_line="$path_line_fish"
+		fi
+
 		# SHELLCHECK_PATH env var
-		if grep -q 'SHELLCHECK_PATH' "$rc_file" 2>/dev/null; then
+		if grep -q 'SHELLCHECK_PATH' "$rc_file"; then
 			already_in="${already_in:+$already_in, }$rc_file"
 		else
 			echo "" >>"$rc_file"
 			echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)" >>"$rc_file"
-			echo "$env_line" >>"$rc_file"
+			echo "$rc_env_line" >>"$rc_file"
 			added_to="${added_to:+$added_to, }$rc_file"
 		fi
 
 		# PATH prepend for ~/.aidevops/bin (GH#2993)
-		if ! grep -q '\.aidevops/bin' "$rc_file" 2>/dev/null; then
+		# Use exact-line match so stale entries don't short-circuit
+		if ! grep -Fq "$rc_path_line" "$rc_file"; then
 			echo "" >>"$rc_file"
 			echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)" >>"$rc_file"
-			echo "$path_line" >>"$rc_file"
+			echo "$rc_path_line" >>"$rc_file"
 		fi
 	done < <(get_all_shell_rcs)
 


### PR DESCRIPTION
## Summary

- Fixes bash-language-server bypassing `shellcheck-wrapper.sh` by resolving `shellcheck` via PATH to `/opt/homebrew/bin/shellcheck` instead of the wrapper
- Creates `~/.aidevops/bin/shellcheck` symlink pointing to `shellcheck-wrapper.sh` and prepends `~/.aidevops/bin` to PATH in `.zshenv` and shell rc files
- Prevents the 9+ GB RAM blowup from `--external-sources` flag that the language server hardcodes

## Root Cause

GH#2915 set `SHELLCHECK_PATH` env var, but bash-language-server ignores it — it does a standard PATH lookup for `shellcheck`, finding `/opt/homebrew/bin/shellcheck` directly. The wrapper's `--external-sources` stripping and `ulimit` protections never applied.

## Fix

Added **Layer 0** (PATH shim) to `setup_shellcheck_wrapper()`:

1. Creates `~/.aidevops/bin/shellcheck` as a symlink to `shellcheck-wrapper.sh`
2. Prepends `~/.aidevops/bin` to PATH in `.zshenv` (all zsh processes) and shell rc files
3. bash-language-server's PATH lookup now finds the wrapper first
4. Wrapper's existing `realpath` self-detection correctly skips the symlink, finds the real binary — no recursion

Layers 1-3 (launchctl, .zshenv SHELLCHECK_PATH, rc files) are retained for tools that honour `SHELLCHECK_PATH`.

## Testing

Verified locally:
- `which shellcheck` with `~/.aidevops/bin` on PATH → finds the shim
- Shim executes correctly (`--version` works, finds real binary)
- `--external-sources` is stripped (no memory explosion)
- No infinite recursion (wrapper skips symlink via `realpath` comparison)
- ShellCheck passes on modified file (zero violations)

Closes #2993

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved shell environment setup for ShellCheck wrapper: adds a PATH shim, validates and wires the wrapper only when usable, propagates shim and SHELLCHECK_PATH across macOS launchctl, .zshenv and common shell rc files, avoids duplicate entries, and updates current session environment so the wrapper is used consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->