### PR TITLE
GH#2947: Harden setup.sh plist/cron generation against injection and improve debuggability

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -98,6 +98,17 @@ _xml_escape() {
 	return 0
 }
 
+# Escape a string for safe embedding in crontab entries.
+# Wraps value in single quotes (prevents $(…), backtick, and variable expansion
+# by cron's /bin/sh). Embedded single quotes are escaped via the '\'' idiom.
+_cron_escape() {
+	local str="$1"
+	# Replace each ' with '\'' (end quote, escaped quote, start quote)
+	str="${str//\'/\'\\\'\'}"
+	printf "'%s'" "$str"
+	return 0
+}
+
 # Check if a launchd agent is loaded (SIGPIPE-safe for pipefail, t1265)
 _launchd_has_agent() {
 	local label="$1"
@@ -852,7 +863,7 @@ main() {
 			_pulse_installed=true
 		fi
 	fi
-	if [[ "$_pulse_installed" == "false" ]] && crontab -l 2>/dev/null | grep -qF "pulse-wrapper" 2>/dev/null; then
+	if [[ "$_pulse_installed" == "false" ]] && crontab -l 2>/dev/null | grep -qF "pulse-wrapper"; then
 		_pulse_installed=true
 	fi
 
@@ -882,11 +893,12 @@ main() {
 
 			# XML-escape paths for safe plist embedding (prevents injection
 			# if $HOME or paths contain &, <, > characters)
-			local _xml_wrapper_script _xml_home _xml_opencode_bin _xml_aidevops_dir
+			local _xml_wrapper_script _xml_home _xml_opencode_bin _xml_aidevops_dir _xml_path
 			_xml_wrapper_script=$(_xml_escape "$wrapper_script")
 			_xml_home=$(_xml_escape "$HOME")
 			_xml_opencode_bin=$(_xml_escape "$opencode_bin")
 			_xml_aidevops_dir=$(_xml_escape "$_aidevops_dir")
+			_xml_path=$(_xml_escape "$PATH")
 
 			# Write the plist (always regenerated to pick up config changes)
 			cat >"$pulse_plist" <<PLIST
@@ -910,7 +922,7 @@ main() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>${PATH}</string>
+		<string>${_xml_path}</string>
 		<key>HOME</key>
 		<string>${_xml_home}</string>
 		<key>OPENCODE_BIN</key>
@@ -940,9 +952,15 @@ PLIST
 		else
 			# Linux: use cron entry with wrapper
 			# Remove old-style cron entries (direct opencode invocation)
+			# Shell-escape all interpolated paths to prevent command injection
+			# via $(…) or backticks if paths contain shell metacharacters
+			local _cron_opencode_bin _cron_aidevops_dir _cron_wrapper_script
+			_cron_opencode_bin=$(_cron_escape "$opencode_bin")
+			_cron_aidevops_dir=$(_cron_escape "$_aidevops_dir")
+			_cron_wrapper_script=$(_cron_escape "$wrapper_script")
 			(
 				crontab -l 2>/dev/null | grep -v 'aidevops: supervisor-pulse'
-				echo "*/2 * * * * PATH=\"/usr/local/bin:/usr/bin:/bin\" OPENCODE_BIN=\"${opencode_bin}\" PULSE_DIR=\"${_aidevops_dir}\" /bin/bash \"${wrapper_script}\" >> \"\$HOME/.aidevops/logs/pulse-wrapper.log\" 2>&1 # aidevops: supervisor-pulse"
+				echo "*/2 * * * * PATH=\"/usr/local/bin:/usr/bin:/bin\" OPENCODE_BIN=${_cron_opencode_bin} PULSE_DIR=${_cron_aidevops_dir} /bin/bash ${_cron_wrapper_script} >> \"\$HOME/.aidevops/logs/pulse-wrapper.log\" 2>&1 # aidevops: supervisor-pulse"
 			) | crontab - || true
 			if crontab -l 2>/dev/null | grep -qF "aidevops: supervisor-pulse"; then
 				print_info "Supervisor pulse enabled (cron, every 2 min). Disable: crontab -e and remove the supervisor-pulse line"
@@ -961,7 +979,7 @@ PLIST
 				print_info "Supervisor pulse disabled (launchd agent removed per config)"
 			fi
 		else
-			if crontab -l 2>/dev/null | grep -qF "pulse-wrapper" 2>/dev/null; then
+			if crontab -l 2>/dev/null | grep -qF "pulse-wrapper"; then
 				crontab -l 2>/dev/null | grep -v 'aidevops: supervisor-pulse' | crontab - || true
 				print_info "Supervisor pulse disabled (cron entry removed per config)"
 			fi
@@ -1017,9 +1035,10 @@ PLIST
 
 			# XML-escape paths for safe plist embedding (prevents injection
 			# if $HOME or paths contain &, <, > characters)
-			local _xml_guard_script _xml_guard_home
+			local _xml_guard_script _xml_guard_home _xml_guard_path
 			_xml_guard_script=$(_xml_escape "$guard_script")
 			_xml_guard_home=$(_xml_escape "$HOME")
+			_xml_guard_path=$(_xml_escape "$PATH")
 
 			cat >"$guard_plist" <<GUARD_PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -1043,7 +1062,7 @@ PLIST
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>${PATH}</string>
+		<string>${_xml_guard_path}</string>
 		<key>HOME</key>
 		<string>${_xml_guard_home}</string>
 		<key>SHELLCHECK_RSS_LIMIT_KB</key>
@@ -1071,11 +1090,14 @@ GUARD_PLIST
 		else
 			# Linux: cron entry (every minute — cron minimum granularity)
 			# Always regenerate to pick up config changes (matches macOS behavior)
+			# Shell-escape path to prevent command injection via metacharacters
+			local _cron_guard_script
+			_cron_guard_script=$(_cron_escape "$guard_script")
 			(
 				crontab -l 2>/dev/null | grep -v 'aidevops: process-guard'
-				echo "* * * * * PATH=\"/usr/local/bin:/usr/bin:/bin\" SHELLCHECK_RSS_LIMIT_KB=524288 SHELLCHECK_RUNTIME_LIMIT=120 CHILD_RSS_LIMIT_KB=8388608 CHILD_RUNTIME_LIMIT=7200 /bin/bash \"${guard_script}\" kill-runaways >> \"\$HOME/.aidevops/logs/process-guard.log\" 2>&1 # aidevops: process-guard"
+				echo "* * * * * PATH=\"/usr/local/bin:/usr/bin:/bin\" SHELLCHECK_RSS_LIMIT_KB=524288 SHELLCHECK_RUNTIME_LIMIT=120 CHILD_RSS_LIMIT_KB=8388608 CHILD_RUNTIME_LIMIT=7200 /bin/bash ${_cron_guard_script} kill-runaways >> \"\$HOME/.aidevops/logs/process-guard.log\" 2>&1 # aidevops: process-guard"
 			) | crontab - || true
-			if crontab -l 2>/dev/null | grep -qF "aidevops: process-guard" 2>/dev/null; then
+			if crontab -l 2>/dev/null | grep -qF "aidevops: process-guard"; then
 				print_info "Process guard enabled (cron, every minute)"
 			else
 				print_warning "Failed to install process guard cron entry"

--- a/setup.sh
+++ b/setup.sh
@@ -85,6 +85,19 @@ if [[ -f "$_SHARED_CONSTANTS" ]]; then
 fi
 unset _SHARED_CONSTANTS
 
+# Escape a string for safe embedding in XML (plist heredocs).
+# Prevents XML injection if paths contain &, <, >, ", or ' characters.
+_xml_escape() {
+	local str="$1"
+	str="${str//&/&amp;}"
+	str="${str//</&lt;}"
+	str="${str//>/&gt;}"
+	str="${str//\"/&quot;}"
+	str="${str//\'/&apos;}"
+	printf '%s' "$str"
+	return 0
+}
+
 # Check if a launchd agent is loaded (SIGPIPE-safe for pipefail, t1265)
 _launchd_has_agent() {
 	local label="$1"
@@ -856,16 +869,24 @@ main() {
 
 			# Unload old plist if upgrading
 			if _launchd_has_agent "$pulse_label"; then
-				launchctl unload "$pulse_plist" 2>/dev/null || true
+				launchctl unload "$pulse_plist" || true
 				pkill -f 'Supervisor Pulse' 2>/dev/null || true
 			fi
 
 			# Also clean up old label if present
 			local old_plist="$HOME/Library/LaunchAgents/com.aidevops.supervisor-pulse.plist"
 			if [[ -f "$old_plist" ]]; then
-				launchctl unload "$old_plist" 2>/dev/null || true
+				launchctl unload "$old_plist" || true
 				rm -f "$old_plist"
 			fi
+
+			# XML-escape paths for safe plist embedding (prevents injection
+			# if $HOME or paths contain &, <, > characters)
+			local _xml_wrapper_script _xml_home _xml_opencode_bin _xml_aidevops_dir
+			_xml_wrapper_script=$(_xml_escape "$wrapper_script")
+			_xml_home=$(_xml_escape "$HOME")
+			_xml_opencode_bin=$(_xml_escape "$opencode_bin")
+			_xml_aidevops_dir=$(_xml_escape "$_aidevops_dir")
 
 			# Write the plist (always regenerated to pick up config changes)
 			cat >"$pulse_plist" <<PLIST
@@ -878,24 +899,24 @@ main() {
 	<key>ProgramArguments</key>
 	<array>
 		<string>/bin/bash</string>
-		<string>${wrapper_script}</string>
+		<string>${_xml_wrapper_script}</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>120</integer>
 	<key>StandardOutPath</key>
-	<string>${HOME}/.aidevops/logs/pulse-wrapper.log</string>
+	<string>${_xml_home}/.aidevops/logs/pulse-wrapper.log</string>
 	<key>StandardErrorPath</key>
-	<string>${HOME}/.aidevops/logs/pulse-wrapper.log</string>
+	<string>${_xml_home}/.aidevops/logs/pulse-wrapper.log</string>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
 		<string>${PATH}</string>
 		<key>HOME</key>
-		<string>${HOME}</string>
+		<string>${_xml_home}</string>
 		<key>OPENCODE_BIN</key>
-		<string>${opencode_bin}</string>
+		<string>${_xml_opencode_bin}</string>
 		<key>PULSE_DIR</key>
-		<string>${_aidevops_dir}</string>
+		<string>${_xml_aidevops_dir}</string>
 		<key>PULSE_STALE_THRESHOLD</key>
 		<string>1800</string>
 	</dict>
@@ -907,7 +928,7 @@ main() {
 </plist>
 PLIST
 
-			if launchctl load "$pulse_plist" 2>/dev/null; then
+			if launchctl load "$pulse_plist"; then
 				if [[ "$_pulse_installed" == "true" ]]; then
 					print_info "Supervisor pulse updated (launchd config regenerated)"
 				else
@@ -921,8 +942,8 @@ PLIST
 			# Remove old-style cron entries (direct opencode invocation)
 			(
 				crontab -l 2>/dev/null | grep -v 'aidevops: supervisor-pulse'
-				echo "*/2 * * * * OPENCODE_BIN=${opencode_bin} PULSE_DIR=${_aidevops_dir} /bin/bash ${wrapper_script} >> $HOME/.aidevops/logs/pulse-wrapper.log 2>&1 # aidevops: supervisor-pulse"
-			) | crontab - 2>/dev/null || true
+				echo "*/2 * * * * PATH=\"/usr/local/bin:/usr/bin:/bin\" OPENCODE_BIN=\"${opencode_bin}\" PULSE_DIR=\"${_aidevops_dir}\" /bin/bash \"${wrapper_script}\" >> \"\$HOME/.aidevops/logs/pulse-wrapper.log\" 2>&1 # aidevops: supervisor-pulse"
+			) | crontab - || true
 			if crontab -l 2>/dev/null | grep -qF "aidevops: supervisor-pulse"; then
 				print_info "Supervisor pulse enabled (cron, every 2 min). Disable: crontab -e and remove the supervisor-pulse line"
 			else
@@ -934,14 +955,14 @@ PLIST
 		if [[ "$(uname -s)" == "Darwin" ]]; then
 			local pulse_plist="$HOME/Library/LaunchAgents/${pulse_label}.plist"
 			if _launchd_has_agent "$pulse_label"; then
-				launchctl unload "$pulse_plist" 2>/dev/null || true
+				launchctl unload "$pulse_plist" || true
 				rm -f "$pulse_plist"
 				pkill -f 'Supervisor Pulse' 2>/dev/null || true
 				print_info "Supervisor pulse disabled (launchd agent removed per config)"
 			fi
 		else
 			if crontab -l 2>/dev/null | grep -qF "pulse-wrapper" 2>/dev/null; then
-				crontab -l 2>/dev/null | grep -v 'aidevops: supervisor-pulse' | crontab - 2>/dev/null || true
+				crontab -l 2>/dev/null | grep -v 'aidevops: supervisor-pulse' | crontab - || true
 				print_info "Supervisor pulse disabled (cron entry removed per config)"
 			fi
 		fi
@@ -994,6 +1015,12 @@ PLIST
 				launchctl unload "$guard_plist" || true
 			fi
 
+			# XML-escape paths for safe plist embedding (prevents injection
+			# if $HOME or paths contain &, <, > characters)
+			local _xml_guard_script _xml_guard_home
+			_xml_guard_script=$(_xml_escape "$guard_script")
+			_xml_guard_home=$(_xml_escape "$HOME")
+
 			cat >"$guard_plist" <<GUARD_PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -1003,21 +1030,22 @@ PLIST
 	<string>${guard_label}</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>${guard_script}</string>
+		<string>/bin/bash</string>
+		<string>${_xml_guard_script}</string>
 		<string>kill-runaways</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>30</integer>
 	<key>StandardOutPath</key>
-	<string>${HOME}/.aidevops/logs/process-guard.log</string>
+	<string>${_xml_guard_home}/.aidevops/logs/process-guard.log</string>
 	<key>StandardErrorPath</key>
-	<string>${HOME}/.aidevops/logs/process-guard.log</string>
+	<string>${_xml_guard_home}/.aidevops/logs/process-guard.log</string>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
 		<string>${PATH}</string>
 		<key>HOME</key>
-		<string>${HOME}</string>
+		<string>${_xml_guard_home}</string>
 		<key>SHELLCHECK_RSS_LIMIT_KB</key>
 		<string>524288</string>
 		<key>SHELLCHECK_RUNTIME_LIMIT</key>
@@ -1045,8 +1073,8 @@ GUARD_PLIST
 			# Always regenerate to pick up config changes (matches macOS behavior)
 			(
 				crontab -l 2>/dev/null | grep -v 'aidevops: process-guard'
-				echo "* * * * * SHELLCHECK_RSS_LIMIT_KB=524288 SHELLCHECK_RUNTIME_LIMIT=120 CHILD_RSS_LIMIT_KB=8388608 CHILD_RUNTIME_LIMIT=7200 /bin/bash \"${guard_script}\" kill-runaways >> \"\$HOME/.aidevops/logs/process-guard.log\" 2>&1 # aidevops: process-guard"
-			) | crontab - 2>/dev/null || true
+				echo "* * * * * PATH=\"/usr/local/bin:/usr/bin:/bin\" SHELLCHECK_RSS_LIMIT_KB=524288 SHELLCHECK_RUNTIME_LIMIT=120 CHILD_RSS_LIMIT_KB=8388608 CHILD_RUNTIME_LIMIT=7200 /bin/bash \"${guard_script}\" kill-runaways >> \"\$HOME/.aidevops/logs/process-guard.log\" 2>&1 # aidevops: process-guard"
+			) | crontab - || true
 			if crontab -l 2>/dev/null | grep -qF "aidevops: process-guard" 2>/dev/null; then
 				print_info "Process guard enabled (cron, every minute)"
 			else


### PR DESCRIPTION
## Summary

- Add `_xml_escape()` function to sanitize paths embedded in XML/plist heredocs, preventing plist injection via crafted directory names containing `&`, `<`, `>`, `"`, or `'`
- Apply XML escaping to all variable interpolations in both pulse and guard launchd plists
- Remove blanket `2>/dev/null` from `launchctl load/unload` calls — `|| true` already prevents script abort, but suppressing stderr hid diagnostic errors
- Quote all variables in cron entries and add explicit `PATH` to prevent command-not-found errors in minimal cron environments
- Add `/bin/bash` wrapper to guard plist `ProgramArguments` for consistency with pulse plist pattern

## Findings Addressed

| Severity | Source | Finding | Fix |
|----------|--------|---------|-----|
| HIGH | Gemini | Cron entry command injection via unquoted vars (line ~1046) | Already quoted on main; added explicit `PATH` |
| MEDIUM | Gemini | Plist injection via unsanitized `${guard_script}` in XML | Added `_xml_escape()` for all plist vars |
| MEDIUM | Gemini | `2>/dev/null` on `launchctl unload` hides errors | Removed from all `launchctl load/unload` calls |
| MEDIUM | Gemini | Hardcoded PATH in guard plist | Already `${PATH}` on main (was fixed previously) |
| MEDIUM | Gemini | `2>/dev/null` on `launchctl load` hides errors | Removed |
| NITPICK | CodeRabbit | Guard plist missing `/bin/bash` wrapper | Added for consistency with pulse plist |
| NITPICK | CodeRabbit | Dynamic `PATH` + `HOME` env parity | Already on main; XML-escaped `HOME` now |

Supersedes #2964 (stale branch based on older main).

Closes #2947