### PR TITLE
t1407: Check contributing guidelines before filing issues/PRs on external repos

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -238,6 +238,27 @@ Git is the primary audit trail for all work. Every change should be discoverable
 
 **Pulse scope boundary (t1405, GH#2928):** When dispatched by the pulse, `PULSE_SCOPE_REPOS` (comma-separated repo slugs) defines which repos you may create branches and PRs on. Filing issues is always allowed on any repo. Code changes (branches, PRs, commits) are restricted to repos in `PULSE_SCOPE_REPOS`. If the target repo is not in scope, file the issue and stop — do not implement the fix. If `PULSE_SCOPE_REPOS` is empty or unset (interactive mode), no scope restriction applies. This prevents pulse-dispatched workers from creating PRs on repos outside the user's managed scope.
 
+# External Repo Issue/PR Submission (t1407)
+# When filing issues or PRs on repos we don't maintain, template compliance bots
+# (e.g., GitHub Actions that check issue format) will auto-close submissions that
+# don't match the repo's required templates. Many popular repos enforce this —
+# well-crafted issues get closed within hours if they don't use the right format.
+#
+# This is a judgment call, not a deterministic check. Read the templates and
+# contributing guidelines, then format your submission accordingly.
+- Before `gh issue create --repo <slug>` on a repo NOT in `~/.config/aidevops/repos.json`:
+  1. Check for issue templates: `gh api repos/{slug}/contents/.github/ISSUE_TEMPLATE/ --jq '.[].name'`
+  2. If templates exist, fetch the relevant one (e.g., `bug-report.yml` for bugs): `gh api repos/{slug}/contents/.github/ISSUE_TEMPLATE/bug-report.yml --jq '.content' | base64 -d`
+  3. Check for contributing guidelines: `gh api repos/{slug}/contents/CONTRIBUTING.md --jq '.content' | base64 -d`
+  4. Format the issue body to match the required template structure. YAML form templates (`.yml`) generate `### Label` section headers when submitted via the web UI — replicate this structure in your `--body`.
+  5. If no templates exist, use a clear, well-structured format (title, description, steps to reproduce, expected/actual behaviour).
+- Before `gh pr create` targeting an external repo:
+  1. Check for PR templates: `gh api repos/{slug}/contents/.github/PULL_REQUEST_TEMPLATE.md --jq '.content' | base64 -d`
+  2. Check `CONTRIBUTING.md` for PR requirements (branch naming, commit format, CLA, etc.)
+  3. Format the PR body to match their template and follow their contributing guidelines.
+- If a submission is auto-closed by a compliance bot, read the bot's comment for formatting requirements, then resubmit with the correct format.
+- Practical examples and template mapping: `tools/git/github-cli.md` "External Repo Submissions" section.
+
 **Git-readiness check:** When working in a project directory that is NOT a git repo, or is a git repo without `TODO.md` / aidevops initialisation, flag this to the user: "This project has no git tracking / no aidevops task management. Work here won't be traceable. Consider `git init` + `aidevops init` to enable the full workflow." Use judgment — a throwaway script directory doesn't need this, but any project with ongoing development does.
 
 **Pre-edit rules:**

--- a/.agents/tools/git/github-cli.md
+++ b/.agents/tools/git/github-cli.md
@@ -222,6 +222,121 @@ export GH_TOKEN=$(gh auth token)
 4. **Use `gh api`** - For advanced GitHub API access
 5. **Use `gh pr create --fill`** - Auto-fill PR details from commits
 
+## External Repo Submissions
+
+When filing issues or PRs on repos you don't maintain, many repos enforce template compliance via bots that auto-close non-conforming submissions. Check their guidelines first.
+
+### Discovering Issue Templates
+
+```bash
+# List available issue templates
+gh api repos/{owner}/{repo}/contents/.github/ISSUE_TEMPLATE/ --jq '.[].name'
+# Example output: bug-report.yml  feature-request.yml  config.yml
+
+# Read a specific template (YAML form)
+gh api repos/{owner}/{repo}/contents/.github/ISSUE_TEMPLATE/bug-report.yml \
+  --jq '.content' | base64 -d
+
+# Check for CONTRIBUTING.md
+gh api repos/{owner}/{repo}/contents/CONTRIBUTING.md \
+  --jq '.content' | base64 -d
+```
+
+### Mapping YAML Form Templates to Markdown
+
+GitHub's YAML issue forms (`.yml`) render as structured forms in the web UI. When submitted, they produce markdown with `### Label` headers matching each field's `label:` attribute. To submit a compliant issue via `gh issue create`, replicate this structure.
+
+**Example YAML form fields:**
+
+```yaml
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+  - type: input
+    id: version
+    attributes:
+      label: Version
+```
+
+**Corresponding compliant issue body:**
+
+```markdown
+### Describe the bug
+
+The application crashes when clicking the save button after editing a profile.
+
+### Steps to reproduce
+
+1. Navigate to Settings > Profile
+2. Change the display name
+3. Click Save
+
+### Expected behavior
+
+Profile should save and show a success message.
+
+### Actual behavior
+
+Page crashes with a white screen. Console shows: TypeError: Cannot read property 'id' of undefined.
+
+### Version
+
+v2.4.1
+```
+
+**Key rules for YAML form compliance:**
+
+- Each `label:` value becomes a `### Label` header — match the text exactly (case-sensitive)
+- Every required field must have a non-empty section below its header
+- `type: checkboxes` fields render as `- [x]` / `- [ ]` lists under the header
+- `type: dropdown` fields render as the selected option text under the header
+- `type: input` fields render as plain text under the header
+- Fields with `required: true` must not be left blank — compliance bots check this
+
+### Discovering PR Templates
+
+```bash
+# Check for PR template
+gh api repos/{owner}/{repo}/contents/.github/PULL_REQUEST_TEMPLATE.md \
+  --jq '.content' | base64 -d
+
+# Some repos use a directory of templates
+gh api repos/{owner}/{repo}/contents/.github/PULL_REQUEST_TEMPLATE/ \
+  --jq '.[].name'
+```
+
+### Handling Auto-Close Bots
+
+If a submission is auto-closed by a compliance bot:
+
+1. Read the bot's closing comment — it usually explains what's missing
+2. Check the close window (some bots give 2 hours to fix before closing)
+3. Resubmit with the correct format rather than editing the closed issue
+4. Some bots use AI (e.g., Claude/Sonnet) to verify template compliance — partial matches may not pass
+
+### Quick Checklist
+
+Before submitting to an external repo:
+
+1. Is this repo in `~/.config/aidevops/repos.json`? If yes, skip these checks (it's ours)
+2. Does `.github/ISSUE_TEMPLATE/` exist? If yes, use the matching template
+3. Does `CONTRIBUTING.md` exist? If yes, follow its guidelines (CLA, branch naming, etc.)
+4. For PRs: check if they require signed commits, specific branch targets, or linked issues
+
 ## See Also
 
 - `lumen.md` - AI-powered visual diffs, commit message generation, and PR review


### PR DESCRIPTION
## Summary

- Adds agent-level guidance to `build.txt` for checking issue templates and `CONTRIBUTING.md` before filing issues/PRs on external repos
- Adds comprehensive "External Repo Submissions" section to `github-cli.md` with practical examples for YAML form template mapping, PR template discovery, and handling auto-close bots
- Prevents well-crafted issues from being auto-closed by template compliance bots (e.g., opencode's `compliance-close.yml` which has auto-closed 214+ issues and 126+ PRs)

## Changes

### `build.txt` (agent rules)
- New `# External Repo Issue/PR Submission (t1407)` section with step-by-step guidance
- Covers both issue creation and PR creation on external repos
- References `github-cli.md` for detailed examples

### `github-cli.md` (reference docs)
- New "External Repo Submissions" section with:
  - Template discovery commands (`gh api` for issue templates, PR templates, CONTRIBUTING.md)
  - YAML form-to-markdown mapping guide with concrete example
  - Key rules for YAML form compliance (headers, required fields, checkboxes, dropdowns)
  - PR template discovery
  - Auto-close bot handling guidance
  - Quick checklist for pre-submission

## Verification

- [x] `markdownlint-cli2` passes on `github-cli.md` (0 errors)
- [x] Guidance covers both issues and PRs
- [x] No helper script needed — this is judgment-based guidance per "Intelligence Over Determinism"

Closes #2967