### PR TITLE
GH#2956: Fix quality-debt in config-helper.sh from PR #2931 review

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -236,7 +236,7 @@ _jsonc_get() {
 	# NOTE: Do NOT use jq's // (alternative operator) here — it treats false and
 	# null identically, discarding false values. Instead, use 'if . == null'.
 	local value
-	value=$(echo "$merged" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' 2>/dev/null) || value=""
+	value=$(echo "$merged" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end') || value=""
 
 	if [[ -n "$value" ]]; then
 		echo "$value"
@@ -263,7 +263,7 @@ _jsonc_get_raw() {
 		echo ""
 		return 0
 	}
-	echo "$json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' 2>/dev/null || echo ""
+	echo "$json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' || echo ""
 	return 0
 }
 
@@ -488,7 +488,7 @@ cmd_list() {
 
 		local user_val env_val effective source
 
-		user_val=$(echo "$user_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' 2>/dev/null) || user_val=""
+		user_val=$(echo "$user_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end') || user_val=""
 
 		# Check env override
 		env_val=""
@@ -586,9 +586,12 @@ cmd_set() {
 	defaults_json=$(_strip_jsonc "$JSONC_DEFAULTS") || return 1
 	local default_val
 	# Use jq type check instead of // empty — false and 0 are valid defaults
+	# Get type and value in a single jq call for efficiency
 	local default_type
-	default_type=$(echo "$defaults_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | type' 2>/dev/null) || default_type="null"
-	default_val=$(echo "$defaults_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | if . == null then empty else tostring end' 2>/dev/null) || default_val=""
+	if ! read -r default_type default_val < <(echo "$defaults_json" | jq -r --arg p "$dotpath" 'getpath($p | split(".")) | [type, (if . == null then "" else tostring end)] | @tsv'); then
+		default_type="null"
+		default_val=""
+	fi
 
 	if [[ "$default_type" == "null" ]]; then
 		echo "[ERROR] Unknown config key: $dotpath" >&2
@@ -649,21 +652,21 @@ HEADER
 		local lower_value
 		lower_value=$(echo "$value" | tr '[:upper:]' '[:lower:]')
 		updated=$(echo "$user_json" | jq --arg p "$dotpath" --argjson v "$lower_value" \
-			'setpath($p | split("."); $v)' 2>/dev/null) || {
+			'setpath($p | split("."); $v)') || {
 			echo "[ERROR] Failed to update config" >&2
 			return 1
 		}
 		;;
 	number)
 		updated=$(echo "$user_json" | jq --arg p "$dotpath" --argjson v "$value" \
-			'setpath($p | split("."); $v)' 2>/dev/null) || {
+			'setpath($p | split("."); $v)') || {
 			echo "[ERROR] Failed to update config" >&2
 			return 1
 		}
 		;;
 	*)
 		updated=$(echo "$user_json" | jq --arg p "$dotpath" --arg v "$value" \
-			'setpath($p | split("."); $v)' 2>/dev/null) || {
+			'setpath($p | split("."); $v)') || {
 			echo "[ERROR] Failed to update config" >&2
 			return 1
 		}


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from 7 jq calls across `_jsonc_get`, `_jsonc_get_raw`, `cmd_list`, and `cmd_set` where `|| fallback` patterns already prevent `set -e` aborts
- Consolidate two separate jq calls (type + value lookup) in `cmd_set` into a single call using `@tsv` output

## Findings Addressed

All 5 medium-severity findings from [PR #2931 review](https://github.com/marcusquinn/aidevops/pull/2931) (gemini-code-assist):

| # | Location | Fix |
|---|----------|-----|
| 1 | `_jsonc_get:239` | Remove `2>/dev/null` |
| 2 | `_jsonc_get_raw:266` | Remove `2>/dev/null` |
| 3 | `cmd_list:491` | Remove `2>/dev/null` |
| 4 | `cmd_set:590-591` | Consolidate 2 jq calls into 1 |
| 5 | `cmd_set:652,659,666` | Remove `2>/dev/null` from 3 setpath calls |

## Rationale

`2>/dev/null` suppresses genuine jq errors (malformed JSON, syntax issues) making debugging harder. The existing `|| fallback` patterns already prevent `set -e` from aborting on non-zero exit status, so the stderr suppression is redundant and harmful.

## Verification

- ShellCheck clean (only pre-existing SC1091 info)
- `config-helper.sh help` runs correctly
- `config-helper.sh get updates.auto_update` returns expected value
- `config-helper.sh validate` passes

Closes #2956