### PR TITLE
GH#2946: fix quality-debt in pulse-wrapper.sh from PR #2944 review feedback

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1244,7 +1244,7 @@ cleanup_worktrees() {
 		# worktrees in any managed repo. Skip local_only repos since
 		# worktree-helper.sh uses gh pr list for squash-merge detection.
 		local repo_paths
-		repo_paths=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path' "$repos_json" 2>/dev/null || echo "")
+		repo_paths=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path' "$repos_json" || echo "")
 
 		local repo_path
 		while IFS= read -r repo_path; do
@@ -1252,7 +1252,7 @@ cleanup_worktrees() {
 			[[ ! -d "$repo_path/.git" ]] && continue
 
 			local wt_count
-			wt_count=$(git -C "$repo_path" worktree list 2>/dev/null | wc -l | tr -d ' ')
+			wt_count=$(git -C "$repo_path" worktree list | wc -l | tr -d ' ')
 			# Skip repos with only 1 worktree (the main one) — nothing to clean
 			if [[ "${wt_count:-0}" -le 1 ]]; then
 				continue


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from `jq` command in `cleanup_worktrees()` (line 1247) — the `|| echo ""` already handles jq failures under `set -e`, and suppressing stderr hides malformed JSON or permission errors
- Remove `2>/dev/null` from `git worktree list` command (line 1255) — the `.git` directory existence is already checked on the preceding line, making file-not-found suppression redundant while masking other diagnostic errors

## Root Cause

Blanket stderr suppression (`2>/dev/null`) was applied defensively but is redundant when prior checks (file existence, `|| echo ""` fallback) already handle the expected failure modes. The suppression masks unexpected errors (permissions, malformed config) that would aid debugging.

## Review Feedback Source

Both findings from Gemini Code Assist review on PR #2944:
- [Comment on line 1244](https://github.com/marcusquinn/aidevops/pull/2944#discussion_r2893347665)
- [Comment on line 1252](https://github.com/marcusquinn/aidevops/pull/2944#discussion_r2893347674)

## Testing

- ShellCheck passes with no new violations (only pre-existing SC1091 info for external source)
- Changes are minimal and mechanical — removing error suppression, not altering logic

Closes #2946