### PR TITLE
t3010: remove unused PLATFORM_LINUX and annotate cross-file SC2034 variables

### DIFF
--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -120,6 +120,7 @@ setup_oh_my_zsh() {
 	if [[ "$install_omz" =~ ^[Yy]$ ]]; then
 		print_info "Installing Oh My Zsh..."
 		# Use verified download + --unattended to avoid changing the shell or starting zsh
+		# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
 		VERIFIED_INSTALL_SHELL="sh"
 		if verified_install "Oh My Zsh" "https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh" --unattended; then
 			print_success "Oh My Zsh installed"

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -645,6 +645,7 @@ setup_recommended_tools() {
 						case "$pkg_manager" in
 						apt)
 							# Add packagecloud repo for Tabby (verified download, not piped to sudo)
+							# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
 							VERIFIED_INSTALL_SUDO="true"
 							if verified_install "Tabby repository (apt)" "https://packagecloud.io/install/repositories/eugeny/tabby/script.deb.sh"; then
 								if ! sudo apt-get install -y tabby-terminal; then
@@ -654,6 +655,7 @@ setup_recommended_tools() {
 							fi
 							;;
 						dnf | yum)
+							# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
 							VERIFIED_INSTALL_SUDO="true"
 							if verified_install "Tabby repository (rpm)" "https://packagecloud.io/install/repositories/eugeny/tabby/script.rpm.sh"; then
 								if ! sudo "$pkg_manager" install -y tabby-terminal; then
@@ -698,6 +700,7 @@ setup_recommended_tools() {
 					fi
 				elif [[ "$(uname)" == "Linux" ]]; then
 					# Zed provides an install script for Linux (verified download)
+					# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
 					VERIFIED_INSTALL_SHELL="sh"
 					if verified_install "Zed" "https://zed.dev/install.sh"; then
 						zed_installed=true
@@ -981,6 +984,7 @@ setup_nodejs() {
 			# Use NodeSource for a recent version (apt default may be old)
 			print_info "Installing Node.js (via NodeSource for latest LTS)..."
 			if command -v curl >/dev/null 2>&1; then
+				# shellcheck disable=SC2034  # Read by verified_install() in setup.sh
 				VERIFIED_INSTALL_SUDO="true"
 				if verified_install "NodeSource repository" "https://deb.nodesource.com/setup_22.x"; then
 					# Install nodejs (NodeSource bundles npm, but distro fallback may not)

--- a/setup.sh
+++ b/setup.sh
@@ -29,11 +29,12 @@ CLEAN_MODE=false
 INTERACTIVE_MODE=false
 NON_INTERACTIVE="${AIDEVOPS_NON_INTERACTIVE:-false}"
 UPDATE_TOOLS_MODE=false
-# Platform constants (used across all setup modules)
+# Platform constants (used across sourced setup modules: shell-env.sh, tool-install.sh)
+# shellcheck disable=SC2034  # PLATFORM_MACOS used in shell-env.sh:549,642 and tool-install.sh:249
 PLATFORM_MACOS=$([[ "$(uname -s)" == "Darwin" ]] && echo true || echo false)
-PLATFORM_LINUX=$([[ "$(uname -s)" == "Linux" ]] && echo true || echo false)
+# shellcheck disable=SC2034  # PLATFORM_ARM64 used in tool-install.sh:249
 PLATFORM_ARM64=$([[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]] && echo true || echo false)
-readonly PLATFORM_MACOS PLATFORM_LINUX PLATFORM_ARM64
+readonly PLATFORM_MACOS PLATFORM_ARM64
 # shellcheck disable=SC2034  # Used by sourced modules (setup-modules/core.sh, agent-deploy.sh)
 REPO_URL="https://github.com/marcusquinn/aidevops.git"
 # shellcheck disable=SC2034  # Used by sourced modules (setup-modules/core.sh, agent-deploy.sh)


### PR DESCRIPTION
## Summary

- Removed genuinely unused `PLATFORM_LINUX` variable from `setup.sh` (defined but never referenced by any sourced module)
- Added inline `# shellcheck disable=SC2034` comments with specific cross-file usage references to `PLATFORM_MACOS`, `PLATFORM_ARM64`, `VERIFIED_INSTALL_SHELL`, and `VERIFIED_INSTALL_SUDO`

## Analysis

The issue reported 7 SC2034 violations across 3 files. Investigation found:

| Variable | File | Verdict |
|----------|------|---------|
| `PLATFORM_MACOS` | setup.sh | **Used** in shell-env.sh:549,642 and tool-install.sh:249 — annotated |
| `PLATFORM_LINUX` | setup.sh | **Unused** — removed (dead code) |
| `PLATFORM_ARM64` | setup.sh | **Used** in tool-install.sh:249 — annotated |
| `VERIFIED_INSTALL_SHELL` | shell-env.sh | **Used** by `verified_install()` in setup.sh — annotated |
| `VERIFIED_INSTALL_SHELL` | tool-install.sh | **Used** by `verified_install()` in setup.sh — annotated |
| `VERIFIED_INSTALL_SUDO` | tool-install.sh (×3) | **Used** by `verified_install()` in setup.sh — annotated |

SC2034 is already globally disabled in `.shellcheckrc`, but inline annotations document the cross-file dependency for maintainers.

## Verification

- `shellcheck setup.sh setup-modules/shell-env.sh setup-modules/tool-install.sh` — clean
- `bash -n` syntax check — all three files pass
- `rg PLATFORM_LINUX` — zero references confirm safe removal

Closes #3010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal setup script improvements and shell static analysis enhancements
  * Removed unused platform variable declaration
  * Added verification directives for installation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->