### PR TITLE
t3014: fix SC2129 grouped redirect patterns in setup-modules

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -351,9 +351,11 @@ check_requirements() {
 			while IFS= read -r rc_file; do
 				[[ -z "$rc_file" ]] && continue
 				if ! grep -q '/opt/homebrew/bin/brew' "$rc_file" 2>/dev/null; then
-					echo "" >>"$rc_file"
-					echo "# Homebrew (added by aidevops setup)" >>"$rc_file"
-					echo "$brew_line" >>"$rc_file"
+					{
+						echo ""
+						echo "# Homebrew (added by aidevops setup)"
+						echo "$brew_line"
+					} >>"$rc_file"
 					print_success "Added Homebrew to PATH in $rc_file"
 					fixed_rc=true
 				fi
@@ -388,9 +390,11 @@ check_requirements() {
 				while IFS= read -r intel_rc; do
 					[[ -z "$intel_rc" ]] && continue
 					if ! grep -q '/usr/local/bin/brew' "$intel_rc" 2>/dev/null; then
-						echo "" >>"$intel_rc"
-						echo "# Homebrew Intel Mac (added by aidevops setup)" >>"$intel_rc"
-						echo "$intel_brew_line" >>"$intel_rc"
+						{
+							echo ""
+							echo "# Homebrew Intel Mac (added by aidevops setup)"
+							echo "$intel_brew_line"
+						} >>"$intel_rc"
 						print_success "Added Homebrew to PATH in $intel_rc"
 						intel_fixed_rc=true
 					fi

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -327,10 +327,12 @@ setup_browser_tools() {
 						touch "$bun_rc"
 					fi
 					if ! grep -q '\.bun' "$bun_rc" 2>/dev/null; then
-						echo "" >>"$bun_rc"
-						echo "# Bun (added by aidevops setup)" >>"$bun_rc"
-						echo "$bun_path_line" >>"$bun_rc"
-						echo "$bun_export_line" >>"$bun_rc"
+						{
+							echo ""
+							echo "# Bun (added by aidevops setup)"
+							echo "$bun_path_line"
+							echo "$bun_export_line"
+						} >>"$bun_rc"
 						print_info "Added Bun to PATH in $bun_rc"
 					fi
 				done < <(get_all_shell_rcs)

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -434,9 +434,11 @@ add_local_bin_to_path() {
 		fi
 
 		# Add to shell config
-		echo "" >>"$rc_file"
-		echo "# Added by aidevops setup" >>"$rc_file"
-		echo "$path_line" >>"$rc_file"
+		{
+			echo ""
+			echo "# Added by aidevops setup"
+			echo "$path_line"
+		} >>"$rc_file"
 		added_to="${added_to:+$added_to, }$rc_file"
 	done < <(get_all_shell_rcs)
 
@@ -571,18 +573,22 @@ setup_shellcheck_wrapper() {
 		if grep -q 'SHELLCHECK_PATH' "$zshenv"; then
 			already_in="${already_in:+$already_in, }$zshenv"
 		else
-			echo "" >>"$zshenv"
-			echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)" >>"$zshenv"
-			echo "$env_line" >>"$zshenv"
+			{
+				echo ""
+				echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)"
+				echo "$env_line"
+			} >>"$zshenv"
 			added_to="${added_to:+$added_to, }$zshenv"
 		fi
 
 		# PATH prepend for ~/.aidevops/bin (GH#2993: shim must be on PATH)
 		# Use exact-line match so stale entries (append-form, comments) don't short-circuit
 		if ! grep -Fq "$path_line" "$zshenv"; then
-			echo "" >>"$zshenv"
-			echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)" >>"$zshenv"
-			echo "$path_line" >>"$zshenv"
+			{
+				echo ""
+				echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)"
+				echo "$path_line"
+			} >>"$zshenv"
 			print_success "Prepended $shim_dir to PATH in .zshenv"
 		else
 			print_info "$shim_dir already on PATH in .zshenv"
@@ -617,18 +623,22 @@ setup_shellcheck_wrapper() {
 		if grep -q 'SHELLCHECK_PATH' "$rc_file"; then
 			already_in="${already_in:+$already_in, }$rc_file"
 		else
-			echo "" >>"$rc_file"
-			echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)" >>"$rc_file"
-			echo "$rc_env_line" >>"$rc_file"
+			{
+				echo ""
+				echo "# Added by aidevops setup (GH#2915: prevent ShellCheck memory explosion)"
+				echo "$rc_env_line"
+			} >>"$rc_file"
 			added_to="${added_to:+$added_to, }$rc_file"
 		fi
 
 		# PATH prepend for ~/.aidevops/bin (GH#2993)
 		# Use exact-line match so stale entries don't short-circuit
 		if ! grep -Fq "$rc_path_line" "$rc_file"; then
-			echo "" >>"$rc_file"
-			echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)" >>"$rc_file"
-			echo "$rc_path_line" >>"$rc_file"
+			{
+				echo ""
+				echo "# Added by aidevops setup (GH#2993: shellcheck shim on PATH)"
+				echo "$rc_path_line"
+			} >>"$rc_file"
 		fi
 	done < <(get_all_shell_rcs)
 


### PR DESCRIPTION
## Summary

- Group consecutive `echo >> file` redirects into `{ cmd1; cmd2; } >> file` blocks in `setup-modules/mcp-setup.sh`, `setup-modules/shell-env.sh`, and `setup-modules/core.sh`
- Fixes 8 SC2129 ShellCheck style violations (1 in mcp-setup.sh, 4 in shell-env.sh, 2 in core.sh) — note: SC2015 patterns were already fixed in #3011
- Reduces redundant file open/close operations when appending multiple lines to shell rc files

Verified: `shellcheck --norc --include=SC2015,SC2129 setup-modules/*.sh` returns exit 0.

Closes #3014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized setup scripts by consolidating multiple sequential file write operations into grouped blocks across core installation, Bun integration, and shell environment configuration. Changes improve code efficiency and maintainability while preserving identical installation behavior and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->