### PR TITLE
fix: add request-retry to review-bot-gate-helper for rate-limited bots

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -121,7 +121,7 @@ Then skip to the next PR. The next pulse cycle will retry the permission check �
   - `WAITING` only means "no known bot activity" — it does NOT mean zero reviews. When `WAITING` is returned, check the formal review count (the `gh pr view` command above). If count > 0, proceed to merge.
   - `SKIP` means the PR has a `skip-review-gate` label — it bypasses the bot gate only, NOT the review count requirement.
   - Skip the PR when the formal review count is 0, regardless of bot gate status.
-- **Green CI + zero reviews** → skip this cycle. Zero reviews means "not yet reviewed", NOT "clean to merge". Review bots typically post within 2-5 minutes. The next pulse will pick it up once a review exists.
+- **Green CI + zero reviews** → skip this cycle, but run `review-bot-gate-helper.sh request-retry <number> <slug>` to self-heal rate-limited bots. The helper checks whether bots posted rate-limit notices instead of real reviews and requests a retry if so (idempotent — safe to call every cycle). The next pulse will find the real review and merge normally. The formal review count gate still applies — this is recovery, not bypass.
 - **Failing CI or changes requested** → before dispatching a fix worker, check whether this is a systemic failure (see "CI failure pattern detection" below). If systemic, skip the per-PR dispatch — the workflow-level issue covers it. If per-PR, dispatch a worker to fix it (counts against worker slots).
 
 **For all PRs (regardless of author):**

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -2,17 +2,20 @@
 # review-bot-gate-helper.sh — Check if AI review bots have posted on a PR
 #
 # Usage:
-#   review-bot-gate-helper.sh check <PR_NUMBER> [REPO]
-#   review-bot-gate-helper.sh wait  <PR_NUMBER> [REPO] [MAX_WAIT_SECONDS]
-#   review-bot-gate-helper.sh list  <PR_NUMBER> [REPO]
+#   review-bot-gate-helper.sh check         <PR_NUMBER> [REPO]
+#   review-bot-gate-helper.sh wait          <PR_NUMBER> [REPO] [MAX_WAIT_SECONDS]
+#   review-bot-gate-helper.sh list          <PR_NUMBER> [REPO]
+#   review-bot-gate-helper.sh request-retry <PR_NUMBER> [REPO]
 #
 # Commands:
-#   check  — Check once, return PASS/WAITING/SKIP
-#   wait   — Poll until a bot posts or timeout (default 600s)
-#   list   — List all bot comments found on the PR
+#   check          — Check once, return PASS/WAITING/SKIP
+#   wait           — Poll until a bot posts or timeout (default 600s)
+#   list           — List all bot comments found on the PR
+#   request-retry  — If bots were rate-limited and no real review exists,
+#                     request a review retry (idempotent, safe to call every pulse)
 #
 # Exit codes:
-#   0 — PASS (at least one bot reviewed) or SKIP (label present)
+#   0 — PASS/SKIP/REQUESTED/ALREADY_REQUESTED/NO_ACTION
 #   1 — WAITING (no bots found yet)
 #   2 — Error (missing args, gh auth failure)
 #
@@ -49,12 +52,13 @@ SKIP_LABEL="skip-review-gate"
 # --- Functions ---
 
 usage() {
-	echo "Usage: $(basename "$0") {check|wait|list} <PR_NUMBER> [REPO] [MAX_WAIT]"
+	echo "Usage: $(basename "$0") {check|wait|list|request-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
 	echo ""
 	echo "Commands:"
-	echo "  check  Check once for bot reviews (returns PASS/WAITING/SKIP)"
-	echo "  wait   Poll until bot reviews appear or timeout"
-	echo "  list   List all bot comments found"
+	echo "  check          Check once for bot reviews (returns PASS/WAITING/SKIP)"
+	echo "  wait           Poll until bot reviews appear or timeout"
+	echo "  list           List all bot comments found"
+	echo "  request-retry  Request review retry if bots were rate-limited (idempotent)"
 	return 0
 }
 
@@ -335,6 +339,108 @@ do_list() {
 	return 0
 }
 
+has_formal_reviews() {
+	# Check if the PR has at least one formal GitHub review (any state).
+	local pr_number="$1"
+	local repo="$2"
+
+	local count
+	count=$(gh pr view "$pr_number" --repo "$repo" \
+		--json reviews --jq '.reviews | length' 2>/dev/null || echo "0")
+	if [[ "$count" -gt 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+has_retry_comment() {
+	# Check if we already posted a review retry request on this PR.
+	# Looks for our specific marker comment to ensure idempotency.
+	local pr_number="$1"
+	local repo="$2"
+
+	local marker="<!-- review-bot-retry-requested -->"
+	local comments
+	comments=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
+		--paginate --jq '.[].body' 2>/dev/null || echo "")
+	if echo "$comments" | grep -qF "$marker"; then
+		return 0
+	fi
+	return 1
+}
+
+find_rate_limited_bots() {
+	# Return space-separated list of bots that posted only rate-limit notices.
+	# Empty string if no rate-limited bots found.
+	local pr_number="$1"
+	local repo="$2"
+
+	local all_commenters
+	all_commenters=$(get_all_bot_commenters "$pr_number" "$repo")
+
+	local rate_limited=""
+	local bot
+	for bot in "${KNOWN_BOTS[@]}"; do
+		if echo "$all_commenters" | grep -qi "$bot"; then
+			if ! bot_has_real_review "$pr_number" "$repo" "$bot"; then
+				rate_limited="${rate_limited}${bot} "
+			fi
+		fi
+	done
+	echo "$rate_limited"
+	return 0
+}
+
+do_request_retry() {
+	# Self-healing: if bots were rate-limited at PR creation and never came
+	# back, request a review retry. Idempotent — checks for prior retry
+	# comment before posting. Does NOT bypass the formal review gate.
+	#
+	# Returns: REQUESTED, ALREADY_REQUESTED, NO_ACTION, or HAS_REVIEWS
+	local pr_number="$1"
+	local repo="$2"
+
+	# If formal reviews already exist, nothing to do
+	if has_formal_reviews "$pr_number" "$repo"; then
+		echo "HAS_REVIEWS"
+		echo "PR already has formal reviews — no retry needed." >&2
+		return 0
+	fi
+
+	# If we already requested a retry, don't spam
+	if has_retry_comment "$pr_number" "$repo"; then
+		echo "ALREADY_REQUESTED"
+		echo "Retry already requested on PR #${pr_number} — waiting for bot response." >&2
+		return 0
+	fi
+
+	# Check if any bots posted rate-limit notices
+	local rate_limited_bots
+	rate_limited_bots=$(find_rate_limited_bots "$pr_number" "$repo")
+
+	if [[ -z "$rate_limited_bots" ]]; then
+		echo "NO_ACTION"
+		echo "No rate-limited bots found — nothing to retry." >&2
+		return 0
+	fi
+
+	# Post retry request with idempotency marker
+	local comment_body
+	comment_body="<!-- review-bot-retry-requested -->
+@coderabbitai review
+
+Review bots were rate-limited when this PR was created (affected: ${rate_limited_bots% }). Requesting a review retry."
+
+	if gh pr comment "$pr_number" --repo "$repo" --body "$comment_body" >/dev/null 2>&1; then
+		echo "REQUESTED"
+		echo "Requested review retry on PR #${pr_number} (rate-limited bots: ${rate_limited_bots% })." >&2
+		return 0
+	else
+		echo "ERROR: Failed to post retry comment on PR #${pr_number}." >&2
+		return 2
+	fi
+}
+
 # --- Main ---
 
 main() {
@@ -366,6 +472,9 @@ main() {
 		;;
 	list)
 		do_list "$pr_number" "$repo"
+		;;
+	request-retry)
+		do_request_retry "$pr_number" "$repo"
 		;;
 	-h | --help | help)
 		usage


### PR DESCRIPTION
## Summary

- Add `request-retry` command to `review-bot-gate-helper.sh` that detects rate-limited review bots and requests a review retry (idempotent)
- Update `pulse.md` to call `request-retry` on zero-review PRs, self-healing the rate-limit gap instead of skipping indefinitely

## Root Cause

When review bots (CodeRabbit, Gemini) hit rate limits at PR creation time, they post quota notices instead of formal GitHub reviews. The pulse's mandatory review-count gate (`gh pr view --json reviews --jq '.reviews | length'`) correctly blocks PRs with zero reviews — but the bots never come back to retry, so the PR is stuck forever. PR #2989 was blocked for 24+ hours by this exact scenario.

## Fix Design

**Deterministic, not intelligence-based.** The detection (rate-limit string patterns, review count, idempotency marker) and action (post `@coderabbitai review`) have exactly one correct answer regardless of context — no judgment needed.

### `review-bot-gate-helper.sh request-retry <PR> [REPO]`

1. If formal reviews already exist → `HAS_REVIEWS` (exit 0)
2. If retry already requested (HTML comment marker) → `ALREADY_REQUESTED` (exit 0)
3. If no rate-limited bots found → `NO_ACTION` (exit 0)
4. If rate-limited bots found → posts `@coderabbitai review` with marker → `REQUESTED` (exit 0)

### `pulse.md` (one-line change)

Zero-review PRs now call `request-retry` before skipping. The formal review gate is unchanged — this is recovery, not bypass.

## Validation

Tested live on PR #2989:
- `request-retry` detected both `coderabbitai` and `gemini-code-assist` as rate-limited
- Posted retry comment → CodeRabbit responded within 14 seconds
- CodeRabbit posted a formal review (CHANGES_REQUESTED) within ~3 minutes
- Formal review count went from 0 → 1
- Second `request-retry` call returned `ALREADY_REQUESTED` (idempotent)
- Third call (after review posted) returned `HAS_REVIEWS`

Closes #3005