### PR TITLE
fix: resolve canonical model names in routing tiers output

### DIFF
--- a/.agents/scripts/generate-models-md.sh
+++ b/.agents/scripts/generate-models-md.sh
@@ -199,10 +199,21 @@ generate_routing_tiers() {
 	echo "| Tier | Primary Model | Relative Cost |"
 	echo "|------|---------------|---------------|"
 
+	# Resolve canonical model names from the models table.
+	# subagent_models may store preview/versioned names (e.g. gemini-2.5-flash-preview-05-20)
+	# while models stores canonical names (e.g. gemini-2.5-flash).
+	# Use a correlated subquery to find the longest matching canonical name,
+	# falling back to sm.model_id if no match or if already canonical.
 	sqlite3 -separator '|' "$REGISTRY_DB" "
         SELECT
             sm.tier,
-            sm.model_id,
+            COALESCE(
+                (SELECT m.model_id FROM models m
+                 WHERE sm.model_id LIKE m.model_id || '%'
+                 ORDER BY LENGTH(m.model_id) DESC
+                 LIMIT 1),
+                sm.model_id
+            ),
             CASE sm.tier
                 WHEN 'haiku' THEN '~0.33x'
                 WHEN 'flash' THEN '~0.20x'


### PR DESCRIPTION
## Summary

- Fix `generate-models-md.sh` to resolve canonical model names in the Routing Tiers section
- `subagent_models` stores preview/versioned names (e.g. `gemini-2.5-flash-preview-05-20`) while the `models` table stores canonical names (`gemini-2.5-flash`)
- Uses a correlated subquery to find the longest matching canonical name, falling back to the raw name when already canonical

## Problem

PR #33 manually fixed MODELS.md model names, but the Gemini reviewer correctly identified that MODELS.md is auto-generated — manual edits are overwritten on next generation. The fix must go into the generator script.

**Before**: Routing Tiers showed `gemini-2.5-flash-preview-05-20` and `gemini-2.5-pro-preview-06-05`
**After**: Routing Tiers shows `gemini-2.5-flash` and `gemini-2.5-pro` (matching the Available Models table)

## Verification

Tested the query against the live model-registry.db — all five tiers resolve correctly:

```
haiku  | claude-haiku-4-5   | ~0.33x
flash  | gemini-2.5-flash   | ~0.20x
sonnet | claude-sonnet-4-6  | 1x (baseline)
pro    | gemini-2.5-pro     | ~1.5x
opus   | claude-opus-4-6    | ~1.7x
```

Regenerated MODELS.md end-to-end — routing tier names now match the Available Models table.

Addresses marcusquinn/aidevops.sh#51