### PR TITLE
GH#3031: Fix markdown table broken by inserted section in headless-dispatch.md

### DIFF
--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -886,6 +886,8 @@ runner-helper.sh run tester "Write tests for the changes"
 | Generate tests for 5 modules | Parallel | Each module is independent |
 | Plan → implement → verify | Sequential | Each step depends on previous |
 | Decomposed subtasks (same parent) | Batch strategy | Use `batch-strategy-helper.sh` |
+| Cron: daily report + weekly digest | Parallel | Independent scheduled tasks |
+| Migration: schema → data → verify | Sequential | Each step depends on previous |
 
 ### Batch Strategies for Decomposed Tasks (t1408.4)
 
@@ -910,8 +912,6 @@ done
 ```
 
 The helper respects `blocked_by:` dependencies and never includes blocked tasks in a batch. See `scripts/batch-strategy-helper.sh help` for full usage.
-| Cron: daily report + weekly digest | Parallel | Independent scheduled tasks |
-| Migration: schema → data → verify | Sequential | Each step depends on previous |
 
 ### Hybrid Pattern
 


### PR DESCRIPTION
## Summary

- Restores the Decision Table in `headless-dispatch.md` that was broken by PR #3000
- The "Batch Strategies for Decomposed Tasks" section was inserted mid-table, orphaning the "Cron" and "Migration" rows as plain text
- Moves the two orphaned rows back into the table and places the Batch Strategies section after the complete table

Closes #3031