### PR TITLE
t3026: Remove 2>/dev/null from task decomposition bash examples

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -90,11 +90,11 @@ DECOMPOSE_HELPER="$HOME/.aidevops/agents/scripts/task-decompose-helper.sh"
 # Only run if the helper exists (t1408.1 must be merged)
 if [[ -x "$DECOMPOSE_HELPER" && -n "$TASK_ID" ]]; then
   # Check if subtasks already exist
-  EXISTING=$(/bin/bash "$DECOMPOSE_HELPER" classify --task-id "$TASK_ID" --repo-path "$(git rev-parse --show-toplevel)" --quiet 2>/dev/null) || EXISTING=""
-  EXISTING_KIND=$(echo "$EXISTING" | jq -r '.kind // "atomic"' 2>/dev/null || echo "atomic")
+  EXISTING=$(/bin/bash "$DECOMPOSE_HELPER" classify --task-id "$TASK_ID" --repo-path "$(git rev-parse --show-toplevel)" --quiet) || EXISTING=""
+  EXISTING_KIND=$(echo "$EXISTING" | jq -r '.kind // "atomic"' || echo "atomic")
 
   if [[ "$EXISTING_KIND" == "composite" ]]; then
-    EXISTING_SUBS=$(echo "$EXISTING" | jq -r '.existing_subtasks // empty' 2>/dev/null || echo "")
+    EXISTING_SUBS=$(echo "$EXISTING" | jq -r '.existing_subtasks // empty' || echo "")
     if [[ -n "$EXISTING_SUBS" && "$EXISTING_SUBS" != "[]" ]]; then
       # Subtasks already exist — skip decomposition
       echo "[t1408.2] Task $TASK_ID already has subtasks — proceeding with implementation"
@@ -103,8 +103,8 @@ if [[ -x "$DECOMPOSE_HELPER" && -n "$TASK_ID" ]]; then
 
   # If no existing subtasks, classify the task description
   if [[ -z "$EXISTING_SUBS" || "$EXISTING_SUBS" == "[]" ]]; then
-    CLASSIFY=$(/bin/bash "$DECOMPOSE_HELPER" classify --task "$TASK_DESC" --task-id "$TASK_ID" --repo-path "$(git rev-parse --show-toplevel)" --quiet 2>/dev/null) || CLASSIFY=""
-    TASK_KIND=$(echo "$CLASSIFY" | jq -r '.kind // "atomic"' 2>/dev/null || echo "atomic")
+    CLASSIFY=$(/bin/bash "$DECOMPOSE_HELPER" classify --task "$TASK_DESC" --task-id "$TASK_ID" --repo-path "$(git rev-parse --show-toplevel)" --quiet) || CLASSIFY=""
+    TASK_KIND=$(echo "$CLASSIFY" | jq -r '.kind // "atomic"' || echo "atomic")
   fi
 fi
 ```
@@ -116,8 +116,8 @@ fi
 Show the decomposition tree and ask for confirmation:
 
 ```bash
-DECOMPOSE=$(/bin/bash "$DECOMPOSE_HELPER" decompose --task "$TASK_DESC" --task-id "$TASK_ID" --repo-path "$(git rev-parse --show-toplevel)" --quiet 2>/dev/null)
-SUBTASK_COUNT=$(echo "$DECOMPOSE" | jq '.subtasks | length' 2>/dev/null || echo 0)
+DECOMPOSE=$(/bin/bash "$DECOMPOSE_HELPER" decompose --task "$TASK_DESC" --task-id "$TASK_ID" --repo-path "$(git rev-parse --show-toplevel)" --quiet) || DECOMPOSE=""
+SUBTASK_COUNT=$(echo "$DECOMPOSE" | jq '.subtasks | length' || echo 0)
 ```
 
 Present to the user:
@@ -306,16 +306,16 @@ Before starting implementation, check if the task should be decomposed into subt
 
 ```bash
 # Check if task already has subtasks (skip if already decomposed)
-HAS_SUBS=$(~/.aidevops/agents/scripts/task-decompose-helper.sh has-subtasks "$TASK_ID" 2>/dev/null || echo "false")
+HAS_SUBS=$(~/.aidevops/agents/scripts/task-decompose-helper.sh has-subtasks "$TASK_ID" || echo "false")
 
 if [[ "$HAS_SUBS" == "false" ]]; then
   # Classify the task
-  CLASSIFY=$(~/.aidevops/agents/scripts/task-decompose-helper.sh classify "$TASK_DESC" 2>/dev/null || echo '{"kind":"atomic"}')
+  CLASSIFY=$(~/.aidevops/agents/scripts/task-decompose-helper.sh classify "$TASK_DESC" || echo '{"kind":"atomic"}')
   TASK_KIND=$(echo "$CLASSIFY" | sed -n 's/.*"kind"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
   if [[ "$TASK_KIND" == "composite" ]]; then
     # Decompose into subtasks
-    DECOMPOSITION=$(~/.aidevops/agents/scripts/task-decompose-helper.sh decompose "$TASK_DESC" 2>/dev/null || echo "")
+    DECOMPOSITION=$(~/.aidevops/agents/scripts/task-decompose-helper.sh decompose "$TASK_DESC" || echo "")
 
     # Interactive mode: show tree and ask for confirmation
     # Headless mode: auto-proceed (create child tasks and dispatch)

--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -118,8 +118,8 @@ After creating the brief, classify the task to determine if it should be decompo
 DECOMPOSE_HELPER="$HOME/.aidevops/agents/scripts/task-decompose-helper.sh"
 
 if [[ -x "$DECOMPOSE_HELPER" ]]; then
-  CLASSIFY=$(/bin/bash "$DECOMPOSE_HELPER" classify --task "{title}" --quiet 2>/dev/null) || CLASSIFY=""
-  TASK_KIND=$(echo "$CLASSIFY" | jq -r '.kind // "atomic"' 2>/dev/null || echo "atomic")
+  CLASSIFY=$(/bin/bash "$DECOMPOSE_HELPER" classify --task "{title}" --quiet) || CLASSIFY=""
+  TASK_KIND=$(echo "$CLASSIFY" | jq -r '.kind // "atomic"' || echo "atomic")
 fi
 ```
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -235,10 +235,10 @@ TASK_DESC="<issue title and first paragraph of body>"
 
 # Classify — uses haiku-tier LLM call (~$0.001)
 CLASSIFY_RESULT=$(/bin/bash ~/.aidevops/agents/scripts/task-decompose-helper.sh classify \
-  --task "$TASK_DESC" --repo-path "$path" --quiet 2>/dev/null) || CLASSIFY_RESULT=""
+  --task "$TASK_DESC" --repo-path "$path" --quiet) || CLASSIFY_RESULT=""
 
 # Parse result
-TASK_KIND=$(echo "$CLASSIFY_RESULT" | jq -r '.kind // "atomic"' 2>/dev/null || echo "atomic")
+TASK_KIND=$(echo "$CLASSIFY_RESULT" | jq -r '.kind // "atomic"' || echo "atomic")
 ```
 
 **If atomic:** Dispatch the worker directly (unchanged flow — proceed to step 6 below).
@@ -249,9 +249,9 @@ TASK_KIND=$(echo "$CLASSIFY_RESULT" | jq -r '.kind // "atomic"' 2>/dev/null || e
 # Decompose into subtasks
 DECOMPOSE_RESULT=$(/bin/bash ~/.aidevops/agents/scripts/task-decompose-helper.sh decompose \
   --task "$TASK_DESC" --repo-path "$path" \
-  --depth 0 --max-depth "${DECOMPOSE_MAX_DEPTH:-3}" --quiet 2>/dev/null) || DECOMPOSE_RESULT=""
+  --depth 0 --max-depth "${DECOMPOSE_MAX_DEPTH:-3}" --quiet) || DECOMPOSE_RESULT=""
 
-SUBTASK_COUNT=$(echo "$DECOMPOSE_RESULT" | jq '.subtasks | length' 2>/dev/null || echo 0)
+SUBTASK_COUNT=$(echo "$DECOMPOSE_RESULT" | jq '.subtasks | length' || echo 0)
 ```
 
 If decomposition succeeds (`SUBTASK_COUNT >= 2`):
@@ -262,7 +262,7 @@ If decomposition succeeds (`SUBTASK_COUNT >= 2`):
    for i in $(seq 0 $((SUBTASK_COUNT - 1))); do
      SUB_DESC=$(echo "$DECOMPOSE_RESULT" | jq -r ".subtasks[$i].description")
      SUB_ESTIMATE=$(echo "$DECOMPOSE_RESULT" | jq -r ".subtasks[$i].estimate // \"~2h\"")
-     SUB_DEPS=$(echo "$DECOMPOSE_RESULT" | jq -r ".subtasks[$i].depends_on | map(\"blocked-by:${TASK_ID}.\" + tostring) | join(\" \")" 2>/dev/null || echo "")
+     SUB_DEPS=$(echo "$DECOMPOSE_RESULT" | jq -r ".subtasks[$i].depends_on | map(\"blocked-by:${TASK_ID}.\" + tostring) | join(\" \")" || echo "")
 
      # Claim child task ID
      CHILD_OUTPUT=$(/bin/bash ~/.aidevops/agents/scripts/claim-task-id.sh \


### PR DESCRIPTION
## Summary

- Remove blanket `2>/dev/null` error suppression from task decomposition bash examples in `full-loop.md`, `new-task.md`, and `pulse.md`
- The `||` fallback construct already handles command failures gracefully — `2>/dev/null` was hiding valuable debugging information (API failures, malformed JSON, missing dependencies)
- Added `|| DECOMPOSE=""` fallback to the `decompose` command in `full-loop.md` for `set -e` safety

## Changes

| File | Instances removed |
|------|-------------------|
| `.agents/scripts/commands/full-loop.md` | 10 (Steps 0.45 and 0.8) |
| `.agents/scripts/commands/new-task.md` | 2 (Step 5.5) |
| `.agents/scripts/commands/pulse.md` | 5 (Task decomposition before dispatch) |

## Context

Addresses unactioned review feedback from PR #2997 (Gemini Code Assist). All findings were medium severity, same pattern: `2>/dev/null` suppresses stderr which hides debugging info while the `||` construct already handles failures.

Closes #3026