### PR TITLE
t3027: Fix classify invocation to pass title as positional argument

### DIFF
--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -118,7 +118,7 @@ After creating the brief, classify the task to determine if it should be decompo
 DECOMPOSE_HELPER="$HOME/.aidevops/agents/scripts/task-decompose-helper.sh"
 
 if [[ -x "$DECOMPOSE_HELPER" ]]; then
-  CLASSIFY=$(/bin/bash "$DECOMPOSE_HELPER" classify --task "{title}" --quiet) || CLASSIFY=""
+  CLASSIFY=$(/bin/bash "$DECOMPOSE_HELPER" classify "{title}") || CLASSIFY=""
   TASK_KIND=$(echo "$CLASSIFY" | jq -r '.kind // "atomic"' || echo "atomic")
 fi
 ```


### PR DESCRIPTION
## Summary

- Fix `classify` call in `new-task.md` Step 5.5 to pass the title as a positional argument instead of using the `--task` flag
- `cmd_classify()` in `task-decompose-helper.sh` expects the description as `$1` (positional), not as `--task <value>` — the old invocation caused the helper to classify the literal string `--task` instead of the actual title
- Also removes `--quiet` which is not a recognized flag for `cmd_classify()`

## Review Feedback Addressed

From [CodeRabbit review on PR #3037](https://github.com/marcusquinn/aidevops/pull/3037#discussion_r2898936106) (major severity):

> Line 121 calls `classify --task "{title}" --quiet`, but the provided `cmd_classify()` implementation only accepts the description as a positional arg plus `--lineage`/`--depth`. With the current parser, `--task` becomes the description, so this branch classifies the literal string `--task` instead of the real title.

## Replaces

PR #3037 (closed — had merge conflict after #3040 merged the `2>/dev/null` fix separately)

Closes #3027