### PR TITLE
t3028: Fix task-decompose-helper.sh invocation contract in docs

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -89,21 +89,15 @@ DECOMPOSE_HELPER="$HOME/.aidevops/agents/scripts/task-decompose-helper.sh"
 
 # Only run if the helper exists (t1408.1 must be merged)
 if [[ -x "$DECOMPOSE_HELPER" && -n "$TASK_ID" ]]; then
-  # Check if subtasks already exist
-  EXISTING=$(/bin/bash "$DECOMPOSE_HELPER" classify --task-id "$TASK_ID" --repo-path "$(git rev-parse --show-toplevel)" --quiet) || EXISTING=""
-  EXISTING_KIND=$(echo "$EXISTING" | jq -r '.kind // "atomic"' || echo "atomic")
+  # Check if subtasks already exist (returns "true" or "false")
+  HAS_SUBS=$(/bin/bash "$DECOMPOSE_HELPER" has-subtasks "$TASK_ID") || HAS_SUBS="false"
 
-  if [[ "$EXISTING_KIND" == "composite" ]]; then
-    EXISTING_SUBS=$(echo "$EXISTING" | jq -r '.existing_subtasks // empty' || echo "")
-    if [[ -n "$EXISTING_SUBS" && "$EXISTING_SUBS" != "[]" ]]; then
-      # Subtasks already exist — skip decomposition
-      echo "[t1408.2] Task $TASK_ID already has subtasks — proceeding with implementation"
-    fi
-  fi
-
-  # If no existing subtasks, classify the task description
-  if [[ -z "$EXISTING_SUBS" || "$EXISTING_SUBS" == "[]" ]]; then
-    CLASSIFY=$(/bin/bash "$DECOMPOSE_HELPER" classify --task "$TASK_DESC" --task-id "$TASK_ID" --repo-path "$(git rev-parse --show-toplevel)" --quiet) || CLASSIFY=""
+  if [[ "$HAS_SUBS" == "true" ]]; then
+    # Subtasks already exist — skip decomposition
+    echo "[t1408.2] Task $TASK_ID already has subtasks — proceeding with implementation"
+  else
+    # No existing subtasks — classify the task description
+    CLASSIFY=$(/bin/bash "$DECOMPOSE_HELPER" classify "$TASK_DESC" --depth 0) || CLASSIFY=""
     TASK_KIND=$(echo "$CLASSIFY" | jq -r '.kind // "atomic"' || echo "atomic")
   fi
 fi
@@ -116,7 +110,7 @@ fi
 Show the decomposition tree and ask for confirmation:
 
 ```bash
-DECOMPOSE=$(/bin/bash "$DECOMPOSE_HELPER" decompose --task "$TASK_DESC" --task-id "$TASK_ID" --repo-path "$(git rev-parse --show-toplevel)" --quiet) || DECOMPOSE=""
+DECOMPOSE=$(/bin/bash "$DECOMPOSE_HELPER" decompose "$TASK_DESC" --max-subtasks "${DECOMPOSE_MAX_SUBTASKS:-5}") || DECOMPOSE=""
 SUBTASK_COUNT=$(echo "$DECOMPOSE" | jq '.subtasks | length' || echo 0)
 ```
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -235,7 +235,7 @@ TASK_DESC="<issue title and first paragraph of body>"
 
 # Classify — uses haiku-tier LLM call (~$0.001)
 CLASSIFY_RESULT=$(/bin/bash ~/.aidevops/agents/scripts/task-decompose-helper.sh classify \
-  --task "$TASK_DESC" --repo-path "$path" --quiet) || CLASSIFY_RESULT=""
+  "$TASK_DESC" --depth 0) || CLASSIFY_RESULT=""
 
 # Parse result
 TASK_KIND=$(echo "$CLASSIFY_RESULT" | jq -r '.kind // "atomic"' || echo "atomic")
@@ -248,8 +248,7 @@ TASK_KIND=$(echo "$CLASSIFY_RESULT" | jq -r '.kind // "atomic"' || echo "atomic"
 ```bash
 # Decompose into subtasks
 DECOMPOSE_RESULT=$(/bin/bash ~/.aidevops/agents/scripts/task-decompose-helper.sh decompose \
-  --task "$TASK_DESC" --repo-path "$path" \
-  --depth 0 --max-depth "${DECOMPOSE_MAX_DEPTH:-3}" --quiet) || DECOMPOSE_RESULT=""
+  "$TASK_DESC" --max-subtasks "${DECOMPOSE_MAX_SUBTASKS:-5}") || DECOMPOSE_RESULT=""
 
 SUBTASK_COUNT=$(echo "$DECOMPOSE_RESULT" | jq '.subtasks | length' || echo 0)
 ```

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -712,15 +712,16 @@ classify(task, lineage)
 
 ```bash
 # Classify: atomic or composite? (~$0.001, haiku tier)
-task-decompose-helper.sh classify --task "Build auth with login and OAuth"
+task-decompose-helper.sh classify "Build auth with login and OAuth" --depth 0
 # → {"kind": "composite", "confidence": 0.9, "reasoning": "..."}
 
 # Decompose: split into subtasks with dependency edges
-task-decompose-helper.sh decompose --task "Build auth with login and OAuth"
-# → {"subtasks": [{"description": "...", "depends_on": [], "estimate": "~2h"}], ...}
+task-decompose-helper.sh decompose "Build auth with login and OAuth" --max-subtasks 5
+# → {"subtasks": [{"description": "...", "blocked_by": []}], "strategy": "..."}
 
-# Lineage: show ancestor/sibling context for a subtask
-task-decompose-helper.sh lineage --task-id t1408.2 --repo-path ~/Git/myproject
+# Format lineage: show ancestor/sibling context for a subtask
+task-decompose-helper.sh format-lineage --parent "Build auth" \
+  --children '[{"description": "login"}, {"description": "OAuth"}]' --current 1
 # → formatted hierarchy with sibling tasks
 ```
 


### PR DESCRIPTION
## Summary

- Fix `task-decompose-helper.sh` invocations in `pulse.md`, `full-loop.md`, and `headless-dispatch.md` to match the actual script API
- Remove incorrect flags (`--task`, `--repo-path`, `--task-id`, `--quiet`, `--max-depth`) and use positional arguments + correct flags (`--depth`, `--max-subtasks`)
- Fix `full-loop.md` Step 0.45 which incorrectly used `classify` to check for existing subtasks — now uses `has-subtasks` subcommand with correct output parsing
- Fix `headless-dispatch.md` which referenced a non-existent `lineage` subcommand — corrected to `format-lineage` with proper flags

### Root cause

The bash examples were written before the helper script API was finalized. The script accepts task descriptions as positional arguments (not `--task` flags), and uses `--depth`/`--max-subtasks`/`--lineage` (not `--repo-path`/`--quiet`/`--max-depth`). The mismatch meant the helper would treat `--task` as the description and ignore the real task text.

### Files changed

| File | What changed |
|------|-------------|
| `.agents/scripts/commands/pulse.md` | `classify` and `decompose` invocations: positional arg, correct flags |
| `.agents/scripts/commands/full-loop.md` | Step 0.45: use `has-subtasks` instead of `classify` for existing subtask check; fix `classify` and `decompose` invocations |
| `.agents/tools/ai-assistants/headless-dispatch.md` | Fix all 3 example invocations to match actual API |

Closes #3028