### PR TITLE
GH#3022: Fix incorrect format-lineage helper reference in headless-dispatch docs

### DIFF
--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -662,14 +662,11 @@ Workers that receive lineage context should:
 
 ### Integration with task-decompose-helper.sh
 
-When `task-decompose-helper.sh` (t1408.1) is available, use its `format-lineage` subcommand instead of manual assembly:
-
-```bash
-# Preferred: use helper for consistent formatting
-LINEAGE_BLOCK=$(task-decompose-helper.sh format-lineage "$TASK_ID")
-
-# Fallback: manual assembly from TODO.md (see above)
-```
+Use the manual TODO.md assembly shown above to build lineage blocks. The
+`task-decompose-helper.sh` helper (t1408.1) does not yet accept a task-id
+argument or emit the `TASK LINEAGE:` block format required by workers. Once
+the helper supports task-id lookup and produces the same block shape, it will
+be documented here as the preferred path.
 
 ## Pre-Dispatch Task Decomposition (t1408.2)
 


### PR DESCRIPTION
## Summary

- Removed the incorrect "preferred" code snippet that referenced `task-decompose-helper.sh format-lineage "$TASK_ID"` — the helper doesn't accept a task-id argument and emits `PROJECT CONTEXT:` not `TASK LINEAGE:`
- Reverted to manual TODO.md assembly as the only supported path for building lineage blocks
- Added a note that the helper will be documented here once it supports task-id lookup and emits the `TASK LINEAGE:` block format

Closes #3022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for building lineage blocks to specify manual assembly from existing resources
  * Added notes on current tool limitations and roadmap for future automation support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->