### PR TITLE
GH#3021: Fix pulse.md bash examples using bare TODO.md instead of $path/TODO.md

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -324,9 +324,9 @@ sleep 2
   ```bash
   # Subtask dispatch with lineage context
   PARENT_ID="${TASK_ID%.*}"
-  PARENT_DESC=$(grep -E "^- \[.\] ${PARENT_ID} " TODO.md | head -1 \
+  PARENT_DESC=$(grep -E "^- \[.\] ${PARENT_ID} " "$path/TODO.md" | head -1 \
     | sed -E 's/^- \[.\] [^ ]+ //' | sed -E 's/ #[^ ]+//g' | cut -c1-120)
-  SIBLINGS=$(grep -E "^  - \[.\] ${PARENT_ID}\.[0-9]+" TODO.md \
+  SIBLINGS=$(grep -E "^  - \[.\] ${PARENT_ID}\.[0-9]+" "$path/TODO.md" \
     | sed -E 's/^  - \[.\] ([^ ]+) (.*)/\1: \2/' | sed -E 's/ #[^ ]+//g')
 
   # Build lineage block (see headless-dispatch.md for full assembly)


### PR DESCRIPTION
## Summary

- Fixed the subtask dispatch lineage example in `pulse.md` where `PARENT_DESC` and `SIBLINGS` grep commands read bare `TODO.md` (supervisor CWD) instead of `"$path/TODO.md"` (target repo)
- This ensures lineage context is built from the dispatched repo's TODO.md, not whichever directory the pulse supervisor happens to be running in

## Changes

**`.agents/scripts/commands/pulse.md:327-330`** — Changed `TODO.md` → `"$path/TODO.md"` in the two `grep` commands that compute `PARENT_DESC` and `SIBLINGS` for subtask lineage context.

Consistent with all other `$path/TODO.md` and `git -C "$path"` patterns already used throughout pulse.md.

## Origin

CodeRabbit review feedback on PR #2989 (medium severity).

Closes #3021