### PR TITLE
t3045: export platform/repo constants to prevent recurring SC2034

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -29,16 +29,16 @@ CLEAN_MODE=false
 INTERACTIVE_MODE=false
 NON_INTERACTIVE="${AIDEVOPS_NON_INTERACTIVE:-false}"
 UPDATE_TOOLS_MODE=false
-# Platform constants (used across sourced setup modules: shell-env.sh, tool-install.sh)
-# shellcheck disable=SC2034  # PLATFORM_MACOS used in shell-env.sh:549,642 and tool-install.sh:249
+# Platform constants — exported so ShellCheck sees them as used (consumed by
+# sourced setup-modules: shell-env.sh:552,653 and tool-install.sh:249).
 PLATFORM_MACOS=$([[ "$(uname -s)" == "Darwin" ]] && echo true || echo false)
-# shellcheck disable=SC2034  # PLATFORM_ARM64 used in tool-install.sh:249
 PLATFORM_ARM64=$([[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]] && echo true || echo false)
+export PLATFORM_MACOS PLATFORM_ARM64
 readonly PLATFORM_MACOS PLATFORM_ARM64
-# shellcheck disable=SC2034  # Used by sourced modules (setup-modules/core.sh, agent-deploy.sh)
+# Repo constants — exported; consumed by setup-modules/core.sh, agent-deploy.sh
 REPO_URL="https://github.com/marcusquinn/aidevops.git"
-# shellcheck disable=SC2034  # Used by sourced modules (setup-modules/core.sh, agent-deploy.sh)
 INSTALL_DIR="$HOME/Git/aidevops"
+export REPO_URL INSTALL_DIR
 
 # Source modular setup functions (t316.2)
 # These modules are sourced only when setup.sh is run from the repo directory


### PR DESCRIPTION
## Summary

- Replaces fragile inline `# shellcheck disable=SC2034` comments with explicit `export` statements for `PLATFORM_MACOS`, `PLATFORM_ARM64`, `REPO_URL`, and `INSTALL_DIR`
- Exported variables are structurally "used" by ShellCheck, so SC2034 cannot recur regardless of how the quality sweep runs
- Previous fixes (#3010, #3013, #3018) used inline disable comments that kept being re-filed by quality sweeps that don't parse shellcheck directives

## Root cause

ShellCheck's SC2034 fires when a variable is assigned but not used *within the same file*. These variables are defined in `setup.sh` and consumed by sourced modules (`setup-modules/shell-env.sh`, `setup-modules/tool-install.sh`). Previous fixes suppressed the warning with inline comments, but the daily quality sweep (LLM-based) doesn't respect shellcheck directives and kept re-filing the same issue.

`export` makes the variables structurally "used" — they're exported to the environment, which ShellCheck recognises as usage. This eliminates the warning at the source level rather than suppressing it.

## Verification

- `shellcheck setup.sh` exits 0 (no warnings)
- `shellcheck setup-modules/shell-env.sh` exits 0
- `shellcheck setup-modules/tool-install.sh` exits 0
- `export` then `readonly` preserves both attributes correctly

Closes #3045

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced setup script reliability by properly exporting and protecting core configuration constants, ensuring consistent behavior across child processes while preventing accidental modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->