### PR TITLE
t1408.7: Fix SC2030 PATH modification local to subshell in tests

### DIFF
--- a/tests/test-ai-supervisor-e2e.sh
+++ b/tests/test-ai-supervisor-e2e.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034,SC1090,SC2317,SC2329
+# shellcheck disable=SC2034,SC1090,SC2030,SC2317,SC2329
 # SC2034: Variables set for sourced scripts (BLUE, SUPERVISOR_DB, etc.)
 # SC1090: Non-constant source paths (test harness pattern)
+# SC2030: PATH modification inside subshells is intentional — each test
+#         runs in a ( ... ) subshell for isolation, and export PATH is
+#         needed so sourced scripts and child processes see mock binaries.
 # SC2317: Commands inside subshell test functions appear unreachable to ShellCheck
 # SC2329: _test_* functions defined and called inline; ShellCheck cannot trace subshell calls
 #


### PR DESCRIPTION
## Summary

- Adds `SC2030` to the shellcheck disable directive in `tests/test-ai-supervisor-e2e.sh` with a comment explaining the intentional design
- The test harness uses `( ... )` subshells for test isolation, with `export PATH="$MOCK_PATH"` so sourced scripts and child processes see mock binaries — the PATH modification being local to the subshell is the intended behaviour, not a bug

Closes #3048