### PR TITLE
fix: remove unreachable return guard in generate-claude-commands.sh (SC2317)

### DIFF
--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -768,4 +768,4 @@ echo "Commands are available immediately in Claude Code (no restart needed)."
 echo "Type / in Claude Code to see the command list."
 echo ""
 
-return 0 2>/dev/null || exit 0
+exit 0


### PR DESCRIPTION
## Summary

- Replace `return 0 2>/dev/null || exit 0` with `exit 0` in `generate-claude-commands.sh`
- The script is always executed via `bash script.sh` (never sourced), so the `return` guard is dead code that ShellCheck flags as SC2317 (unreachable command)

Closes #3053

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build script termination logic for improved execution clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->