### PR TITLE
t3057: fix SC2034 unused variables in test scripts and agent scripts

### DIFF
--- a/.agents/scripts/batch-strategy-helper.sh
+++ b/.agents/scripts/batch-strategy-helper.sh
@@ -37,6 +37,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
+# shellcheck disable=SC2034 # Used by log_info/log_error/log_warn in shared-constants.sh
 LOG_PREFIX="BATCH"
 
 # Default configuration

--- a/.agents/scripts/entity-helper.sh
+++ b/.agents/scripts/entity-helper.sh
@@ -54,8 +54,8 @@ readonly VALID_CHANNELS="matrix simplex email cli slack discord telegram irc web
 # Valid interaction directions
 readonly VALID_DIRECTIONS="inbound outbound system"
 
-# Valid confidence levels for identity links
-readonly VALID_LINK_CONFIDENCE="confirmed suggested inferred"
+# Confidence levels for identity links: validated by SQL CHECK constraint
+# in entity_channels table (confirmed, suggested, inferred)
 
 #######################################
 # SQLite wrapper (same as memory system)

--- a/tests/test-backup-safety.sh
+++ b/tests/test-backup-safety.sh
@@ -19,7 +19,6 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPTS_DIR="$REPO_DIR/.agents/scripts"
-VERBOSE="${1:-}"
 
 # --- Test Framework ---
 PASS_COUNT=0
@@ -28,29 +27,29 @@ SKIP_COUNT=0
 TOTAL_COUNT=0
 
 pass() {
-    PASS_COUNT=$((PASS_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;32mPASS\033[0m %s\n" "$1"
 }
 
 fail() {
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
-    if [[ -n "${2:-}" ]]; then
-        printf "       %s\n" "$2"
-    fi
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
 }
 
 skip() {
-    SKIP_COUNT=$((SKIP_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+	SKIP_COUNT=$((SKIP_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
 }
 
 section() {
-    echo ""
-    printf "\033[1m=== %s ===\033[0m\n" "$1"
+	echo ""
+	printf "\033[1m=== %s ===\033[0m\n" "$1"
 }
 
 # --- Setup ---
@@ -62,10 +61,10 @@ source "$SCRIPTS_DIR/shared-constants.sh"
 
 # Create a test database with sample data
 create_test_db() {
-    local db_path="$1"
-    local row_count="${2:-10}"
+	local db_path="$1"
+	local row_count="${2:-10}"
 
-    sqlite3 "$db_path" <<SQL
+	sqlite3 "$db_path" <<SQL
 CREATE TABLE IF NOT EXISTS tasks (
     id TEXT PRIMARY KEY,
     description TEXT,
@@ -77,13 +76,13 @@ CREATE TABLE IF NOT EXISTS batches (
 );
 SQL
 
-    local i
-    for ((i = 1; i <= row_count; i++)); do
-        sqlite3 "$db_path" "INSERT OR IGNORE INTO tasks (id, description, status) VALUES ('t$i', 'Task $i', 'queued');"
-    done
-    sqlite3 "$db_path" "INSERT OR IGNORE INTO batches (id, name) VALUES ('b1', 'test-batch');"
+	local i
+	for ((i = 1; i <= row_count; i++)); do
+		sqlite3 "$db_path" "INSERT OR IGNORE INTO tasks (id, description, status) VALUES ('t$i', 'Task $i', 'queued');"
+	done
+	sqlite3 "$db_path" "INSERT OR IGNORE INTO batches (id, name) VALUES ('b1', 'test-batch');"
 
-    return 0
+	return 0
 }
 
 # ============================================================
@@ -95,32 +94,32 @@ test_db="$TEMP_DIR/test1.db"
 create_test_db "$test_db" 5
 backup_file=$(backup_sqlite_db "$test_db" "test-reason")
 if [[ -f "$backup_file" ]]; then
-    pass "backup_sqlite_db creates backup file"
+	pass "backup_sqlite_db creates backup file"
 else
-    fail "backup_sqlite_db creates backup file" "File not found: $backup_file"
+	fail "backup_sqlite_db creates backup file" "File not found: $backup_file"
 fi
 
 # Test 2: Backup filename contains reason
 if echo "$backup_file" | grep -q "test-reason"; then
-    pass "backup filename contains reason label"
+	pass "backup filename contains reason label"
 else
-    fail "backup filename contains reason label" "Got: $backup_file"
+	fail "backup filename contains reason label" "Got: $backup_file"
 fi
 
 # Test 3: Backup contains same data
 orig_count=$(sqlite3 "$test_db" "SELECT count(*) FROM tasks;")
 backup_count=$(sqlite3 "$backup_file" "SELECT count(*) FROM tasks;")
 if [[ "$orig_count" == "$backup_count" ]]; then
-    pass "backup contains same row count ($orig_count)"
+	pass "backup contains same row count ($orig_count)"
 else
-    fail "backup contains same row count" "Original: $orig_count, Backup: $backup_count"
+	fail "backup contains same row count" "Original: $orig_count, Backup: $backup_count"
 fi
 
 # Test 4: Backup of non-existent file fails
 if backup_sqlite_db "$TEMP_DIR/nonexistent.db" "test" >/dev/null 2>&1; then
-    fail "backup of non-existent file returns error"
+	fail "backup of non-existent file returns error"
 else
-    pass "backup of non-existent file returns error"
+	pass "backup of non-existent file returns error"
 fi
 
 # ============================================================
@@ -129,17 +128,17 @@ section "verify_sqlite_backup"
 
 # Test 5: Verification passes when counts match
 if verify_sqlite_backup "$test_db" "$backup_file" "tasks batches"; then
-    pass "verify_sqlite_backup passes when counts match"
+	pass "verify_sqlite_backup passes when counts match"
 else
-    fail "verify_sqlite_backup passes when counts match"
+	fail "verify_sqlite_backup passes when counts match"
 fi
 
 # Test 6: Verification fails when original has fewer rows
 sqlite3 "$test_db" "DELETE FROM tasks WHERE id = 't1';"
 if verify_sqlite_backup "$test_db" "$backup_file" "tasks" 2>/dev/null; then
-    fail "verify_sqlite_backup detects row count decrease"
+	fail "verify_sqlite_backup detects row count decrease"
 else
-    pass "verify_sqlite_backup detects row count decrease"
+	pass "verify_sqlite_backup detects row count decrease"
 fi
 
 # Restore the deleted row for subsequent tests
@@ -151,25 +150,25 @@ section "verify_migration_rowcounts"
 
 # Test 7: Migration verification passes when counts match
 if verify_migration_rowcounts "$test_db" "$backup_file" "tasks batches"; then
-    pass "verify_migration_rowcounts passes when counts match"
+	pass "verify_migration_rowcounts passes when counts match"
 else
-    fail "verify_migration_rowcounts passes when counts match"
+	fail "verify_migration_rowcounts passes when counts match"
 fi
 
 # Test 8: Migration verification passes when counts increase
 sqlite3 "$test_db" "INSERT INTO tasks (id, description, status) VALUES ('t99', 'Extra task', 'queued');"
 if verify_migration_rowcounts "$test_db" "$backup_file" "tasks"; then
-    pass "verify_migration_rowcounts passes when counts increase"
+	pass "verify_migration_rowcounts passes when counts increase"
 else
-    fail "verify_migration_rowcounts passes when counts increase"
+	fail "verify_migration_rowcounts passes when counts increase"
 fi
 
 # Test 9: Migration verification fails when counts decrease
 sqlite3 "$test_db" "DELETE FROM tasks WHERE id IN ('t1', 't2', 't3');"
 if verify_migration_rowcounts "$test_db" "$backup_file" "tasks" 2>/dev/null; then
-    fail "verify_migration_rowcounts detects data loss"
+	fail "verify_migration_rowcounts detects data loss"
 else
-    pass "verify_migration_rowcounts detects data loss"
+	pass "verify_migration_rowcounts detects data loss"
 fi
 
 # ============================================================
@@ -180,24 +179,24 @@ section "rollback_sqlite_db"
 rollback_sqlite_db "$test_db" "$backup_file" 2>/dev/null
 restored_count=$(sqlite3 "$test_db" "SELECT count(*) FROM tasks;")
 if [[ "$restored_count" == "5" ]]; then
-    pass "rollback_sqlite_db restores original data ($restored_count rows)"
+	pass "rollback_sqlite_db restores original data ($restored_count rows)"
 else
-    fail "rollback_sqlite_db restores original data" "Expected 5, got $restored_count"
+	fail "rollback_sqlite_db restores original data" "Expected 5, got $restored_count"
 fi
 
 # Test 11: Rollback creates pre-rollback safety backup
 pre_rollback_count=$(ls -1 "$TEMP_DIR"/test1-backup-*-pre-rollback.db 2>/dev/null | wc -l | tr -d ' ')
 if [[ "$pre_rollback_count" -ge 1 ]]; then
-    pass "rollback creates pre-rollback safety backup"
+	pass "rollback creates pre-rollback safety backup"
 else
-    fail "rollback creates pre-rollback safety backup" "Found $pre_rollback_count pre-rollback backups"
+	fail "rollback creates pre-rollback safety backup" "Found $pre_rollback_count pre-rollback backups"
 fi
 
 # Test 12: Rollback of non-existent backup fails
 if rollback_sqlite_db "$test_db" "$TEMP_DIR/nonexistent.db" 2>/dev/null; then
-    fail "rollback of non-existent backup returns error"
+	fail "rollback of non-existent backup returns error"
 else
-    pass "rollback of non-existent backup returns error"
+	pass "rollback of non-existent backup returns error"
 fi
 
 # ============================================================
@@ -208,8 +207,8 @@ section "cleanup_sqlite_backups"
 cleanup_db="$TEMP_DIR/cleanup-test.db"
 create_test_db "$cleanup_db" 3
 for i in 1 2 3 4 5 6 7; do
-    sleep 1  # Ensure unique timestamps
-    backup_sqlite_db "$cleanup_db" "test-$i" >/dev/null 2>&1
+	sleep 1 # Ensure unique timestamps
+	backup_sqlite_db "$cleanup_db" "test-$i" >/dev/null 2>&1
 done
 
 pre_cleanup_count=$(ls -1 "$TEMP_DIR"/cleanup-test-backup-*.db 2>/dev/null | wc -l | tr -d ' ')
@@ -217,9 +216,9 @@ cleanup_sqlite_backups "$cleanup_db" 3
 post_cleanup_count=$(ls -1 "$TEMP_DIR"/cleanup-test-backup-*.db 2>/dev/null | wc -l | tr -d ' ')
 
 if [[ "$post_cleanup_count" -le 3 ]]; then
-    pass "cleanup_sqlite_backups keeps at most N backups ($pre_cleanup_count -> $post_cleanup_count)"
+	pass "cleanup_sqlite_backups keeps at most N backups ($pre_cleanup_count -> $post_cleanup_count)"
 else
-    fail "cleanup_sqlite_backups keeps at most N backups" "Expected <=3, got $post_cleanup_count (was $pre_cleanup_count)"
+	fail "cleanup_sqlite_backups keeps at most N backups" "Expected <=3, got $post_cleanup_count (was $pre_cleanup_count)"
 fi
 
 # ============================================================
@@ -247,25 +246,25 @@ SQL
 
 post_migrate_count=$(sqlite3 "$e2e_db" "SELECT count(*) FROM tasks;")
 if [[ "$post_migrate_count" -eq 0 ]]; then
-    pass "simulated bad migration empties table (count: $post_migrate_count)"
+	pass "simulated bad migration empties table (count: $post_migrate_count)"
 else
-    fail "simulated bad migration empties table" "Expected 0, got $post_migrate_count"
+	fail "simulated bad migration empties table" "Expected 0, got $post_migrate_count"
 fi
 
 # Verify detects the problem
 if verify_migration_rowcounts "$e2e_db" "$e2e_backup" "tasks" 2>/dev/null; then
-    fail "verify_migration_rowcounts catches empty table"
+	fail "verify_migration_rowcounts catches empty table"
 else
-    pass "verify_migration_rowcounts catches empty table"
+	pass "verify_migration_rowcounts catches empty table"
 fi
 
 # Rollback
 rollback_sqlite_db "$e2e_db" "$e2e_backup" 2>/dev/null
 final_count=$(sqlite3 "$e2e_db" "SELECT count(*) FROM tasks;")
 if [[ "$final_count" -eq 20 ]]; then
-    pass "rollback restores all 20 rows after bad migration"
+	pass "rollback restores all 20 rows after bad migration"
 else
-    fail "rollback restores all 20 rows after bad migration" "Expected 20, got $final_count"
+	fail "rollback restores all 20 rows after bad migration" "Expected 20, got $final_count"
 fi
 
 # ============================================================
@@ -312,17 +311,17 @@ SQL
 
 sup_output=$("$SCRIPTS_DIR/supervisor-helper.sh" backup "test-t188" 2>&1)
 if echo "$sup_output" | grep -q "backed up"; then
-    pass "supervisor backup command succeeds"
+	pass "supervisor backup command succeeds"
 else
-    fail "supervisor backup command succeeds" "Output: $sup_output"
+	fail "supervisor backup command succeeds" "Output: $sup_output"
 fi
 
 # Verify backup file exists
 sup_backup_count=$(ls -1 "$AIDEVOPS_SUPERVISOR_DIR"/supervisor-backup-*.db 2>/dev/null | wc -l | tr -d ' ')
 if [[ "$sup_backup_count" -ge 1 ]]; then
-    pass "supervisor backup creates file ($sup_backup_count backups)"
+	pass "supervisor backup creates file ($sup_backup_count backups)"
 else
-    fail "supervisor backup creates file" "Found $sup_backup_count backups"
+	fail "supervisor backup creates file" "Found $sup_backup_count backups"
 fi
 
 # ============================================================
@@ -331,12 +330,12 @@ fi
 echo ""
 printf "\033[1m=== Results ===\033[0m\n"
 printf "  Total: %d | \033[0;32mPass: %d\033[0m | \033[0;31mFail: %d\033[0m | \033[0;33mSkip: %d\033[0m\n" \
-    "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+	"$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
 
 if [[ "$FAIL_COUNT" -gt 0 ]]; then
-    echo ""
-    printf "\033[0;31mFAILED\033[0m\n"
-    exit 1
+	echo ""
+	printf "\033[0;31mFAILED\033[0m\n"
+	exit 1
 fi
 
 echo ""

--- a/tests/test-memory-mail.sh
+++ b/tests/test-memory-mail.sh
@@ -17,7 +17,6 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPTS_DIR="$REPO_DIR/.agents/scripts"
 MEMORY_SCRIPT="$SCRIPTS_DIR/memory-helper.sh"
 MAIL_SCRIPT="$SCRIPTS_DIR/mail-helper.sh"
-VERBOSE="${1:-}"
 
 # --- Test Framework ---
 PASS_COUNT=0
@@ -26,29 +25,29 @@ SKIP_COUNT=0
 TOTAL_COUNT=0
 
 pass() {
-    PASS_COUNT=$((PASS_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;32mPASS\033[0m %s\n" "$1"
 }
 
 fail() {
-    FAIL_COUNT=$((FAIL_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
-    if [[ -n "${2:-}" ]]; then
-        printf "       %s\n" "$2"
-    fi
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
 }
 
 skip() {
-    SKIP_COUNT=$((SKIP_COUNT + 1))
-    TOTAL_COUNT=$((TOTAL_COUNT + 1))
-    printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+	SKIP_COUNT=$((SKIP_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
 }
 
 section() {
-    echo ""
-    printf "\033[1m=== %s ===\033[0m\n" "$1"
+	echo ""
+	printf "\033[1m=== %s ===\033[0m\n" "$1"
 }
 
 # --- Isolated Test Environment ---
@@ -59,22 +58,22 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 
 # Helper: run memory command
 mem() {
-    bash "$MEMORY_SCRIPT" "$@" 2>&1
+	bash "$MEMORY_SCRIPT" "$@" 2>&1
 }
 
 # Helper: run mail command
 mail_cmd() {
-    bash "$MAIL_SCRIPT" "$@" 2>&1
+	bash "$MAIL_SCRIPT" "$@" 2>&1
 }
 
 # Helper: query memory DB
 mem_db() {
-    sqlite3 -cmd ".timeout 5000" "$AIDEVOPS_MEMORY_DIR/memory.db" "$@"
+	sqlite3 -cmd ".timeout 5000" "$AIDEVOPS_MEMORY_DIR/memory.db" "$@"
 }
 
 # Helper: query mail DB
 mail_db() {
-    sqlite3 -cmd ".timeout 5000" "$AIDEVOPS_MAIL_DIR/mailbox.db" "$@"
+	sqlite3 -cmd ".timeout 5000" "$AIDEVOPS_MAIL_DIR/mailbox.db" "$@"
 }
 
 # ============================================================
@@ -86,25 +85,25 @@ section "Memory: Database Initialization"
 # Test: first store creates database
 mem store --content "Test memory entry" --type "WORKING_SOLUTION" --tags "test,init" >/dev/null
 if [[ -f "$AIDEVOPS_MEMORY_DIR/memory.db" ]]; then
-    pass "memory store creates database"
+	pass "memory store creates database"
 else
-    fail "memory store did not create database"
+	fail "memory store did not create database"
 fi
 
 # Test: FTS5 table exists
 fts_check=$(mem_db "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='learnings';")
 if [[ "$fts_check" -ge 1 ]]; then
-    pass "FTS5 learnings table exists"
+	pass "FTS5 learnings table exists"
 else
-    fail "FTS5 learnings table missing"
+	fail "FTS5 learnings table missing"
 fi
 
 # Test: WAL mode
 journal=$(mem_db "PRAGMA journal_mode;")
 if [[ "$journal" == "wal" ]]; then
-    pass "Memory DB uses WAL mode"
+	pass "Memory DB uses WAL mode"
 else
-    fail "Memory DB journal mode is '$journal', expected 'wal'"
+	fail "Memory DB journal mode is '$journal', expected 'wal'"
 fi
 
 section "Memory: Store and Recall"
@@ -112,35 +111,35 @@ section "Memory: Store and Recall"
 # Test: store returns success
 store_output=$(mem store --content "Bash arrays need declare -a for indexed arrays" --type "CODEBASE_PATTERN" --tags "bash,arrays")
 if echo "$store_output" | grep -qi "stored\|ok\|success"; then
-    pass "memory store reports success"
+	pass "memory store reports success"
 else
-    fail "memory store output unexpected" "$store_output"
+	fail "memory store output unexpected" "$store_output"
 fi
 
 # Test: recall finds stored content
 recall_output=$(mem recall --query "bash arrays")
 if echo "$recall_output" | grep -qi "arrays\|bash"; then
-    pass "memory recall finds stored content by keyword"
+	pass "memory recall finds stored content by keyword"
 else
-    fail "memory recall did not find stored content" "$recall_output"
+	fail "memory recall did not find stored content" "$recall_output"
 fi
 
 # Test: recall with type filter
 mem store --content "User prefers dark mode in terminal" --type "USER_PREFERENCE" --tags "ui,terminal" >/dev/null
 recall_typed=$(mem recall --query "dark mode" --type "USER_PREFERENCE")
 if echo "$recall_typed" | grep -qi "dark mode"; then
-    pass "memory recall with --type filter works"
+	pass "memory recall with --type filter works"
 else
-    fail "memory recall with --type filter failed" "$recall_typed"
+	fail "memory recall with --type filter failed" "$recall_typed"
 fi
 
 # Test: FTS5 hyphenated query (t139 regression)
 mem store --content "Fixed pre-commit hook for shellcheck" --type "WORKING_SOLUTION" --tags "pre-commit,shellcheck" >/dev/null
 recall_hyphen=$(mem recall --query "pre-commit hook" 2>&1)
 if echo "$recall_hyphen" | grep -qiE "error.*column|fts5.*syntax"; then
-    fail "FTS5 hyphenated query causes error (t139 regression)" "$recall_hyphen"
+	fail "FTS5 hyphenated query causes error (t139 regression)" "$recall_hyphen"
 else
-    pass "FTS5 hyphenated query works without error (t139)"
+	pass "FTS5 hyphenated query works without error (t139)"
 fi
 
 # Test: recall with limit
@@ -151,18 +150,18 @@ recall_limited=$(mem recall --query "memory test entry" --limit 2)
 # Count result entries (each has a type marker like [CONTEXT])
 result_count=$(echo "$recall_limited" | grep -c '\[CONTEXT\]' || true)
 if [[ "$result_count" -le 2 ]]; then
-    pass "memory recall --limit restricts results"
+	pass "memory recall --limit restricts results"
 else
-    fail "memory recall --limit did not restrict (got $result_count, expected <= 2)"
+	fail "memory recall --limit did not restrict (got $result_count, expected <= 2)"
 fi
 
 section "Memory: Stats"
 
 stats_output=$(mem stats)
 if echo "$stats_output" | grep -qiE "total|memories|entries|count"; then
-    pass "memory stats produces output"
+	pass "memory stats produces output"
 else
-    fail "memory stats output unexpected" "$stats_output"
+	fail "memory stats output unexpected" "$stats_output"
 fi
 
 section "Memory: Relational Versioning"
@@ -172,16 +171,16 @@ original_output=$(mem store --content "Favorite color is blue" --type "USER_PREF
 original_id=$(echo "$original_output" | grep -oE 'mem_[a-z0-9_]+' | head -1 || true)
 
 if [[ -n "$original_id" ]]; then
-    # Store an update that supersedes the original
-    update_output=$(mem store --content "Favorite color is now green" --type "USER_PREFERENCE" --tags "preference" --supersedes "$original_id" --relation updates 2>&1 || true)
-    if echo "$update_output" | grep -qi "stored\|ok\|success"; then
-        pass "Relational versioning: store with --supersedes works"
-    else
-        # May not support --supersedes flag yet, that's OK
-        skip "Relational versioning: --supersedes may not be implemented yet"
-    fi
+	# Store an update that supersedes the original
+	update_output=$(mem store --content "Favorite color is now green" --type "USER_PREFERENCE" --tags "preference" --supersedes "$original_id" --relation updates 2>&1 || true)
+	if echo "$update_output" | grep -qi "stored\|ok\|success"; then
+		pass "Relational versioning: store with --supersedes works"
+	else
+		# May not support --supersedes flag yet, that's OK
+		skip "Relational versioning: --supersedes may not be implemented yet"
+	fi
 else
-    skip "Could not extract memory ID for relational test"
+	skip "Could not extract memory ID for relational test"
 fi
 
 section "Memory: Namespace Isolation"
@@ -189,32 +188,32 @@ section "Memory: Namespace Isolation"
 # Store in a namespace
 ns_output=$(mem --namespace test-runner store --content "Runner-specific config" --type "TOOL_CONFIG" --tags "runner" 2>&1)
 if echo "$ns_output" | grep -qi "stored\|ok\|success"; then
-    pass "Namespace store works"
+	pass "Namespace store works"
 
-    # Verify namespace directory created
-    if [[ -d "$AIDEVOPS_MEMORY_DIR/namespaces/test-runner" ]]; then
-        pass "Namespace directory created"
-    else
-        fail "Namespace directory not created"
-    fi
+	# Verify namespace directory created
+	if [[ -d "$AIDEVOPS_MEMORY_DIR/namespaces/test-runner" ]]; then
+		pass "Namespace directory created"
+	else
+		fail "Namespace directory not created"
+	fi
 
-    # Recall from namespace
-    ns_recall=$(mem --namespace test-runner recall --query "runner config" 2>&1)
-    if echo "$ns_recall" | grep -qi "runner\|config"; then
-        pass "Namespace recall finds namespace-specific content"
-    else
-        fail "Namespace recall failed" "$ns_recall"
-    fi
+	# Recall from namespace
+	ns_recall=$(mem --namespace test-runner recall --query "runner config" 2>&1)
+	if echo "$ns_recall" | grep -qi "runner\|config"; then
+		pass "Namespace recall finds namespace-specific content"
+	else
+		fail "Namespace recall failed" "$ns_recall"
+	fi
 else
-    skip "Namespace store failed" "$ns_output"
+	skip "Namespace store failed" "$ns_output"
 fi
 
 # Invalid namespace name
 invalid_ns=$(mem --namespace "invalid namespace!" store --content "test" --type "CONTEXT" 2>&1 || true)
 if echo "$invalid_ns" | grep -qi "invalid"; then
-    pass "Invalid namespace name rejected"
+	pass "Invalid namespace name rejected"
 else
-    fail "Invalid namespace name was not rejected"
+	fail "Invalid namespace name was not rejected"
 fi
 
 section "Memory: Prune"
@@ -222,18 +221,18 @@ section "Memory: Prune"
 # Prune with dry-run (should not delete anything)
 prune_output=$(mem prune --dry-run 2>&1 || true)
 if echo "$prune_output" | grep -qiE "prune|would|dry|entries|0"; then
-    pass "memory prune --dry-run works"
+	pass "memory prune --dry-run works"
 else
-    skip "memory prune --dry-run output unexpected" "$prune_output"
+	skip "memory prune --dry-run output unexpected" "$prune_output"
 fi
 
 section "Memory: Help"
 
 help_output=$(mem help 2>&1)
 if echo "$help_output" | grep -qiE "usage|store|recall|memory|COMMANDS"; then
-    pass "memory help shows usage information"
+	pass "memory help shows usage information"
 else
-    fail "memory help output unexpected" "$(echo "$help_output" | head -3)"
+	fail "memory help output unexpected" "$(echo "$help_output" | head -3)"
 fi
 
 section "Memory: Deduplication on Store"
@@ -245,43 +244,43 @@ first_id=$(echo "$first_store" | grep -oE 'mem_[a-z0-9_]+' | head -1 || true)
 
 second_store=$(mem store --content "$dedup_content" --type "WORKING_SOLUTION" --tags "dedup-test")
 if echo "$second_store" | grep -qi "duplicate"; then
-    pass "Exact duplicate detected on store"
+	pass "Exact duplicate detected on store"
 else
-    fail "Exact duplicate not detected on store" "$second_store"
+	fail "Exact duplicate not detected on store" "$second_store"
 fi
 
 # Verify the returned ID matches the original
 second_id=$(echo "$second_store" | grep -oE 'mem_[a-z0-9_]+' | head -1 || true)
 if [[ -n "$first_id" && "$second_id" == "$first_id" ]]; then
-    pass "Duplicate store returns original memory ID"
+	pass "Duplicate store returns original memory ID"
 else
-    fail "Duplicate store returned different ID" "first=$first_id second=$second_id"
+	fail "Duplicate store returned different ID" "first=$first_id second=$second_id"
 fi
 
 # Test: near-duplicate (different case/punctuation) is detected
 near_dup_store=$(mem store --content "Exact Duplicate Test Content For Deduplication!" --type "WORKING_SOLUTION" --tags "near-dedup" 2>&1)
 if echo "$near_dup_store" | grep -qi "duplicate"; then
-    pass "Near-duplicate (case/punctuation) detected on store"
+	pass "Near-duplicate (case/punctuation) detected on store"
 else
-    fail "Near-duplicate not detected on store" "$near_dup_store"
+	fail "Near-duplicate not detected on store" "$near_dup_store"
 fi
 
 # Test: different content is NOT flagged as duplicate
 unique_store=$(mem store --content "Completely unique content that should not match anything" --type "CONTEXT" --tags "unique-test")
 if echo "$unique_store" | grep -qi "stored\|ok\|success"; then
-    pass "Unique content stored successfully (not flagged as duplicate)"
+	pass "Unique content stored successfully (not flagged as duplicate)"
 else
-    fail "Unique content was incorrectly flagged" "$unique_store"
+	fail "Unique content was incorrectly flagged" "$unique_store"
 fi
 
 # Test: relational updates bypass dedup check
 if [[ -n "$first_id" ]]; then
-    relational_store=$(mem store --content "$dedup_content" --type "WORKING_SOLUTION" --supersedes "$first_id" --relation updates 2>&1)
-    if echo "$relational_store" | grep -qi "stored\|ok\|success"; then
-        pass "Relational update bypasses dedup check"
-    else
-        fail "Relational update was blocked by dedup" "$relational_store"
-    fi
+	relational_store=$(mem store --content "$dedup_content" --type "WORKING_SOLUTION" --supersedes "$first_id" --relation updates 2>&1)
+	if echo "$relational_store" | grep -qi "stored\|ok\|success"; then
+		pass "Relational update bypasses dedup check"
+	else
+		fail "Relational update was blocked by dedup" "$relational_store"
+	fi
 fi
 
 section "Memory: Dedup Command"
@@ -296,33 +295,33 @@ mem_db "INSERT INTO learnings (id, session_id, content, type, tags, confidence, 
 # Test: dedup --dry-run shows duplicates without removing
 dedup_dry=$(mem dedup --dry-run 2>&1)
 if echo "$dedup_dry" | grep -qiE "dry.run|would remove|duplicate"; then
-    pass "dedup --dry-run reports duplicates"
+	pass "dedup --dry-run reports duplicates"
 else
-    fail "dedup --dry-run output unexpected" "$dedup_dry"
+	fail "dedup --dry-run output unexpected" "$dedup_dry"
 fi
 
 # Verify entries still exist after dry-run
 forced_count=$(mem_db "SELECT COUNT(*) FROM learnings WHERE id LIKE 'mem_dedup_test_%';")
 if [[ "$forced_count" -eq 2 ]]; then
-    pass "dedup --dry-run does not delete entries"
+	pass "dedup --dry-run does not delete entries"
 else
-    fail "dedup --dry-run deleted entries (count=$forced_count, expected 2)"
+	fail "dedup --dry-run deleted entries (count=$forced_count, expected 2)"
 fi
 
 # Test: dedup actually removes duplicates
 dedup_output=$(mem dedup 2>&1)
 if echo "$dedup_output" | grep -qiE "removed|duplicates|no duplicates"; then
-    pass "dedup command executes successfully"
+	pass "dedup command executes successfully"
 else
-    fail "dedup command output unexpected" "$dedup_output"
+	fail "dedup command output unexpected" "$dedup_output"
 fi
 
 # Verify one of the forced duplicates was removed
 forced_after=$(mem_db "SELECT COUNT(*) FROM learnings WHERE id LIKE 'mem_dedup_test_%';")
 if [[ "$forced_after" -le 1 ]]; then
-    pass "dedup removed duplicate entries"
+	pass "dedup removed duplicate entries"
 else
-    fail "dedup did not remove duplicates (count=$forced_after, expected <= 1)"
+	fail "dedup did not remove duplicates (count=$forced_after, expected <= 1)"
 fi
 
 # Test: dedup --exact-only
@@ -330,9 +329,9 @@ mem_db "INSERT INTO learnings (id, session_id, content, type, tags, confidence, 
 mem_db "INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source) VALUES ('mem_exact_002', 'test', 'Exact only test', 'CONTEXT', 'exact2', 'medium', datetime('now'), datetime('now'), '/test', 'manual');"
 dedup_exact=$(mem dedup --exact-only 2>&1)
 if echo "$dedup_exact" | grep -qiE "removed|duplicates|no duplicates"; then
-    pass "dedup --exact-only executes successfully"
+	pass "dedup --exact-only executes successfully"
 else
-    fail "dedup --exact-only output unexpected" "$dedup_exact"
+	fail "dedup --exact-only output unexpected" "$dedup_exact"
 fi
 
 section "Memory: Validate (Enhanced)"
@@ -340,9 +339,9 @@ section "Memory: Validate (Enhanced)"
 # Validate should report on duplicates
 validate_output=$(mem validate 2>&1)
 if echo "$validate_output" | grep -qiE "validation|stale|duplicate|size"; then
-    pass "validate produces comprehensive report"
+	pass "validate produces comprehensive report"
 else
-    fail "validate output missing expected sections" "$validate_output"
+	fail "validate output missing expected sections" "$validate_output"
 fi
 
 section "Memory: Auto-Prune"
@@ -353,9 +352,9 @@ mem_db "INSERT INTO learnings (id, session_id, content, type, tags, confidence, 
 # Verify it exists
 old_exists=$(mem_db "SELECT COUNT(*) FROM learnings WHERE id = 'mem_old_stale_001';")
 if [[ "$old_exists" -eq 1 ]]; then
-    pass "Old stale entry inserted for auto-prune test"
+	pass "Old stale entry inserted for auto-prune test"
 else
-    fail "Could not insert old stale entry"
+	fail "Could not insert old stale entry"
 fi
 
 # Remove the auto-prune marker to force a prune run
@@ -364,40 +363,40 @@ rm -f "$AIDEVOPS_MEMORY_DIR/.last_auto_prune"
 # Store something to trigger auto-prune
 auto_prune_store=$(mem store --content "Trigger auto-prune by storing new content" --type "CONTEXT" --tags "auto-prune-trigger" 2>&1)
 if echo "$auto_prune_store" | grep -qi "stored\|ok\|success\|auto-pruned\|prune"; then
-    pass "Store with auto-prune trigger succeeds"
+	pass "Store with auto-prune trigger succeeds"
 else
-    fail "Store with auto-prune trigger failed" "$auto_prune_store"
+	fail "Store with auto-prune trigger failed" "$auto_prune_store"
 fi
 
 # Check if the old stale entry was pruned
 old_after=$(mem_db "SELECT COUNT(*) FROM learnings WHERE id = 'mem_old_stale_001';")
 if [[ "$old_after" -eq 0 ]]; then
-    pass "Auto-prune removed stale entry"
+	pass "Auto-prune removed stale entry"
 else
-    # Auto-prune may not have run if marker was recently touched
-    skip "Auto-prune did not remove stale entry (may be timing-dependent)"
+	# Auto-prune may not have run if marker was recently touched
+	skip "Auto-prune did not remove stale entry (may be timing-dependent)"
 fi
 
 # Verify the prune marker was created
 if [[ -f "$AIDEVOPS_MEMORY_DIR/.last_auto_prune" ]]; then
-    pass "Auto-prune marker file created"
+	pass "Auto-prune marker file created"
 else
-    fail "Auto-prune marker file not created"
+	fail "Auto-prune marker file not created"
 fi
 
 section "Memory: Help (dedup listed)"
 
 help_dedup=$(mem help 2>&1)
 if echo "$help_dedup" | grep -qi "dedup"; then
-    pass "Help text includes dedup command"
+	pass "Help text includes dedup command"
 else
-    fail "Help text missing dedup command"
+	fail "Help text missing dedup command"
 fi
 
 if echo "$help_dedup" | grep -qi "auto-prun"; then
-    pass "Help text mentions auto-pruning"
+	pass "Help text mentions auto-pruning"
 else
-    fail "Help text missing auto-pruning info"
+	fail "Help text missing auto-pruning info"
 fi
 
 # ============================================================
@@ -409,17 +408,17 @@ section "Mail: Database Initialization"
 # Test: first command creates database
 mail_cmd status >/dev/null 2>&1 || true
 if [[ -f "$AIDEVOPS_MAIL_DIR/mailbox.db" ]]; then
-    pass "mail command creates database"
+	pass "mail command creates database"
 else
-    fail "mail command did not create database"
+	fail "mail command did not create database"
 fi
 
 # Test: tables exist
 mail_tables=$(mail_db "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;" | tr '\n' ',')
 if [[ "$mail_tables" == *"messages"* && "$mail_tables" == *"agents"* ]]; then
-    pass "Mail tables exist (messages, agents)"
+	pass "Mail tables exist (messages, agents)"
 else
-    fail "Missing mail tables" "Found: $mail_tables"
+	fail "Missing mail tables" "Found: $mail_tables"
 fi
 
 section "Mail: Agent Registration"
@@ -427,9 +426,9 @@ section "Mail: Agent Registration"
 # Register an agent
 reg_output=$(mail_cmd register --agent "test-agent-1" --role "worker" 2>&1)
 if echo "$reg_output" | grep -qiE "register|success|ok"; then
-    pass "Agent registration works"
+	pass "Agent registration works"
 else
-    fail "Agent registration failed" "$(echo "$reg_output" | head -3)"
+	fail "Agent registration failed" "$(echo "$reg_output" | head -3)"
 fi
 
 # Register second agent
@@ -438,9 +437,9 @@ mail_cmd register --agent "test-agent-2" --role "orchestrator" >/dev/null 2>&1
 # List agents
 agents_output=$(mail_cmd agents 2>&1)
 if echo "$agents_output" | grep -q "test-agent-1"; then
-    pass "Registered agent appears in agent list"
+	pass "Registered agent appears in agent list"
 else
-    fail "Registered agent not in list" "$agents_output"
+	fail "Registered agent not in list" "$agents_output"
 fi
 
 section "Mail: Send and Receive"
@@ -448,78 +447,78 @@ section "Mail: Send and Receive"
 # Send a message
 send_output=$(mail_cmd send --from "test-agent-1" --to "test-agent-2" --type "task_dispatch" --payload "Please process task t001" 2>&1)
 if echo "$send_output" | grep -qiE "sent|success|ok|msg-"; then
-    pass "mail send works"
+	pass "mail send works"
 else
-    fail "mail send failed" "$(echo "$send_output" | head -3)"
+	fail "mail send failed" "$(echo "$send_output" | head -3)"
 fi
 
 # Check inbox
 check_output=$(mail_cmd check --agent "test-agent-2" 2>&1)
 if echo "$check_output" | grep -qiE "1|unread|message"; then
-    pass "mail check shows unread messages"
+	pass "mail check shows unread messages"
 else
-    fail "mail check did not show unread messages" "$check_output"
+	fail "mail check did not show unread messages" "$check_output"
 fi
 
 # Read message
 # First get the message ID
 msg_id=$(mail_db "SELECT id FROM messages WHERE to_agent = 'test-agent-2' LIMIT 1;" 2>/dev/null || echo "")
 if [[ -n "$msg_id" ]]; then
-    read_output=$(mail_cmd read "$msg_id" 2>&1)
-    if echo "$read_output" | grep -qiE "task t001|process|payload"; then
-        pass "mail read shows message content"
-    else
-        fail "mail read did not show content" "$(echo "$read_output" | head -3)"
-    fi
+	read_output=$(mail_cmd read "$msg_id" 2>&1)
+	if echo "$read_output" | grep -qiE "task t001|process|payload"; then
+		pass "mail read shows message content"
+	else
+		fail "mail read did not show content" "$(echo "$read_output" | head -3)"
+	fi
 
-    # Verify message marked as read
-    msg_status=$(mail_db "SELECT status FROM messages WHERE id = '$msg_id';")
-    if [[ "$msg_status" == "read" ]]; then
-        pass "Message marked as 'read' after reading"
-    else
-        fail "Message status is '$msg_status', expected 'read'"
-    fi
+	# Verify message marked as read
+	msg_status=$(mail_db "SELECT status FROM messages WHERE id = '$msg_id';")
+	if [[ "$msg_status" == "read" ]]; then
+		pass "Message marked as 'read' after reading"
+	else
+		fail "Message status is '$msg_status', expected 'read'"
+	fi
 else
-    fail "Could not find message ID in database"
+	fail "Could not find message ID in database"
 fi
 
 section "Mail: Archive"
 
 if [[ -n "$msg_id" ]]; then
-    archive_output=$(mail_cmd archive "$msg_id" 2>&1)
-    if echo "$archive_output" | grep -qiE "archived|success|ok"; then
-        pass "mail archive works"
-    else
-        fail "mail archive failed" "$(echo "$archive_output" | head -3)"
-    fi
+	archive_output=$(mail_cmd archive "$msg_id" 2>&1)
+	if echo "$archive_output" | grep -qiE "archived|success|ok"; then
+		pass "mail archive works"
+	else
+		fail "mail archive failed" "$(echo "$archive_output" | head -3)"
+	fi
 
-    # Verify archived
-    archived_status=$(mail_db "SELECT status FROM messages WHERE id = '$msg_id';")
-    if [[ "$archived_status" == "archived" ]]; then
-        pass "Message status is 'archived' after archiving"
-    else
-        fail "Message status is '$archived_status', expected 'archived'"
-    fi
+	# Verify archived
+	archived_status=$(mail_db "SELECT status FROM messages WHERE id = '$msg_id';")
+	if [[ "$archived_status" == "archived" ]]; then
+		pass "Message status is 'archived' after archiving"
+	else
+		fail "Message status is '$archived_status', expected 'archived'"
+	fi
 fi
 
 section "Mail: Message Types"
 
 # Test all valid message types
 for msg_type in task_dispatch status_report discovery request broadcast; do
-    type_output=$(mail_cmd send --from "test-agent-1" --to "test-agent-2" --type "$msg_type" --payload "Test $msg_type" 2>&1)
-    if echo "$type_output" | grep -qiE "sent|success|ok|msg-"; then
-        pass "mail send type=$msg_type"
-    else
-        fail "mail send type=$msg_type failed" "$(echo "$type_output" | head -3)"
-    fi
+	type_output=$(mail_cmd send --from "test-agent-1" --to "test-agent-2" --type "$msg_type" --payload "Test $msg_type" 2>&1)
+	if echo "$type_output" | grep -qiE "sent|success|ok|msg-"; then
+		pass "mail send type=$msg_type"
+	else
+		fail "mail send type=$msg_type failed" "$(echo "$type_output" | head -3)"
+	fi
 done
 
 # Test invalid message type
 invalid_type_output=$(mail_cmd send --from "test-agent-1" --to "test-agent-2" --type "invalid_type" --payload "Test" 2>&1 || true)
 if echo "$invalid_type_output" | grep -qiE "invalid|error|constraint"; then
-    pass "Invalid message type rejected"
+	pass "Invalid message type rejected"
 else
-    fail "Invalid message type was not rejected" "$invalid_type_output"
+	fail "Invalid message type was not rejected" "$invalid_type_output"
 fi
 
 section "Mail: Priority"
@@ -527,36 +526,36 @@ section "Mail: Priority"
 # Send with priority
 priority_output=$(mail_cmd send --from "test-agent-1" --to "test-agent-2" --type "request" --priority "high" --payload "Urgent request" 2>&1)
 if echo "$priority_output" | grep -qiE "sent|success|ok|msg-"; then
-    pass "mail send with --priority works"
+	pass "mail send with --priority works"
 else
-    fail "mail send with --priority failed" "$(echo "$priority_output" | head -3)"
+	fail "mail send with --priority failed" "$(echo "$priority_output" | head -3)"
 fi
 
 section "Mail: Status"
 
 status_output=$(mail_cmd status 2>&1)
 if echo "$status_output" | grep -qiE "message|agent|total|unread|mail"; then
-    pass "mail status produces summary"
+	pass "mail status produces summary"
 else
-    fail "mail status output unexpected" "$status_output"
+	fail "mail status output unexpected" "$status_output"
 fi
 
 section "Mail: Deregister"
 
 dereg_output=$(mail_cmd deregister --agent "test-agent-1" 2>&1)
 if echo "$dereg_output" | grep -qiE "deregister|removed|success|ok|inactive"; then
-    pass "Agent deregistration works"
+	pass "Agent deregistration works"
 else
-    fail "Agent deregistration failed" "$(echo "$dereg_output" | head -3)"
+	fail "Agent deregistration failed" "$(echo "$dereg_output" | head -3)"
 fi
 
 section "Mail: Prune"
 
 prune_mail_output=$(mail_cmd prune 2>&1 || true)
 if echo "$prune_mail_output" | grep -qiE "prune|storage|archived|messages|0"; then
-    pass "mail prune works"
+	pass "mail prune works"
 else
-    skip "mail prune output unexpected" "$prune_mail_output"
+	skip "mail prune output unexpected" "$prune_mail_output"
 fi
 
 section "Mail: Help"
@@ -564,9 +563,9 @@ section "Mail: Help"
 # mail-helper.sh doesn't have a cmd_help but main() should show usage on unknown command
 help_mail=$(mail_cmd help 2>&1 || true)
 if echo "$help_mail" | grep -qiE "usage|send|check|read|mail|commands"; then
-    pass "mail help shows usage information"
+	pass "mail help shows usage information"
 else
-    fail "mail help output unexpected" "$(echo "$help_mail" | head -3)"
+	fail "mail help output unexpected" "$(echo "$help_mail" | head -3)"
 fi
 
 # ============================================================
@@ -577,7 +576,7 @@ EMBEDDINGS_SCRIPT="$SCRIPTS_DIR/memory-embeddings-helper.sh"
 
 # Helper: run embeddings command
 emb() {
-    bash "$EMBEDDINGS_SCRIPT" "$@" 2>&1
+	bash "$EMBEDDINGS_SCRIPT" "$@" 2>&1
 }
 
 section "Embeddings: Help and CLI"
@@ -585,9 +584,9 @@ section "Embeddings: Help and CLI"
 # Test: help command works
 emb_help=$(emb help 2>&1)
 if echo "$emb_help" | grep -qiE "provider|setup|search|hybrid"; then
-    pass "embeddings help shows provider and hybrid info"
+	pass "embeddings help shows provider and hybrid info"
 else
-    fail "embeddings help missing expected content" "$(echo "$emb_help" | head -3)"
+	fail "embeddings help missing expected content" "$(echo "$emb_help" | head -3)"
 fi
 
 section "Embeddings: Provider Configuration"
@@ -595,38 +594,38 @@ section "Embeddings: Provider Configuration"
 # Test: provider command shows default
 emb_provider=$(emb provider 2>&1)
 if echo "$emb_provider" | grep -qiE "local|current"; then
-    pass "embeddings provider shows default (local)"
+	pass "embeddings provider shows default (local)"
 else
-    fail "embeddings provider output unexpected" "$emb_provider"
+	fail "embeddings provider output unexpected" "$emb_provider"
 fi
 
 # Test: provider switch to openai (config only, no deps needed)
 mkdir -p "$AIDEVOPS_MEMORY_DIR"
-echo "provider=openai" > "$AIDEVOPS_MEMORY_DIR/.embeddings-config"
-echo "configured_at=2025-01-01T00:00:00Z" >> "$AIDEVOPS_MEMORY_DIR/.embeddings-config"
+echo "provider=openai" >"$AIDEVOPS_MEMORY_DIR/.embeddings-config"
+echo "configured_at=2025-01-01T00:00:00Z" >>"$AIDEVOPS_MEMORY_DIR/.embeddings-config"
 
 emb_provider_openai=$(emb provider 2>&1)
 if echo "$emb_provider_openai" | grep -qiE "openai"; then
-    pass "embeddings provider reads openai from config"
+	pass "embeddings provider reads openai from config"
 else
-    fail "embeddings provider did not read openai config" "$emb_provider_openai"
+	fail "embeddings provider did not read openai config" "$emb_provider_openai"
 fi
 
 # Test: provider switch back to local
-echo "provider=local" > "$AIDEVOPS_MEMORY_DIR/.embeddings-config"
+echo "provider=local" >"$AIDEVOPS_MEMORY_DIR/.embeddings-config"
 emb_provider_local=$(emb provider 2>&1)
 if echo "$emb_provider_local" | grep -qiE "local"; then
-    pass "embeddings provider reads local from config"
+	pass "embeddings provider reads local from config"
 else
-    fail "embeddings provider did not read local config" "$emb_provider_local"
+	fail "embeddings provider did not read local config" "$emb_provider_local"
 fi
 
 # Test: invalid provider rejected
 emb_invalid=$(emb provider "invalid" 2>&1 || true)
 if echo "$emb_invalid" | grep -qiE "invalid|error"; then
-    pass "embeddings rejects invalid provider"
+	pass "embeddings rejects invalid provider"
 else
-    fail "embeddings did not reject invalid provider" "$emb_invalid"
+	fail "embeddings did not reject invalid provider" "$emb_invalid"
 fi
 
 section "Embeddings: Status Without Index"
@@ -635,9 +634,9 @@ section "Embeddings: Status Without Index"
 rm -f "$AIDEVOPS_MEMORY_DIR/embeddings.db"
 emb_status=$(emb status 2>&1)
 if echo "$emb_status" | grep -qiE "not created|setup"; then
-    pass "embeddings status reports no index"
+	pass "embeddings status reports no index"
 else
-    fail "embeddings status output unexpected" "$emb_status"
+	fail "embeddings status output unexpected" "$emb_status"
 fi
 
 section "Embeddings: Auto-Index Hook"
@@ -646,18 +645,18 @@ section "Embeddings: Auto-Index Hook"
 rm -f "$AIDEVOPS_MEMORY_DIR/.embeddings-config"
 # Should exit 0 silently (no config = no-op)
 if emb auto-index "mem_test_123" >/dev/null 2>&1; then
-    pass "auto-index no-op when not configured"
+	pass "auto-index no-op when not configured"
 else
-    fail "auto-index failed when not configured"
+	fail "auto-index failed when not configured"
 fi
 
 # Test: auto-index silently succeeds when no embeddings DB
-echo "provider=local" > "$AIDEVOPS_MEMORY_DIR/.embeddings-config"
+echo "provider=local" >"$AIDEVOPS_MEMORY_DIR/.embeddings-config"
 rm -f "$AIDEVOPS_MEMORY_DIR/embeddings.db"
 if emb auto-index "mem_test_123" >/dev/null 2>&1; then
-    pass "auto-index no-op when no embeddings DB"
+	pass "auto-index no-op when no embeddings DB"
 else
-    fail "auto-index failed when no embeddings DB"
+	fail "auto-index failed when no embeddings DB"
 fi
 
 section "Embeddings: Graceful Degradation"
@@ -665,9 +664,9 @@ section "Embeddings: Graceful Degradation"
 # Test: search fails gracefully when no index
 emb_search_noindex=$(emb search "test query" 2>&1 || true)
 if echo "$emb_search_noindex" | grep -qiE "not found|setup|missing|error"; then
-    pass "search fails gracefully when no index"
+	pass "search fails gracefully when no index"
 else
-    fail "search did not fail gracefully" "$emb_search_noindex"
+	fail "search did not fail gracefully" "$emb_search_noindex"
 fi
 
 section "Embeddings: Memory Helper --hybrid Flag"
@@ -676,30 +675,30 @@ section "Embeddings: Memory Helper --hybrid Flag"
 # (will fail gracefully since no embeddings are set up, but should not crash)
 hybrid_output=$(mem recall --query "test" --hybrid 2>&1 || true)
 if echo "$hybrid_output" | grep -qiE "not available|setup|error|not found"; then
-    pass "memory recall --hybrid fails gracefully without embeddings"
+	pass "memory recall --hybrid fails gracefully without embeddings"
 else
-    # It might also succeed if embeddings happen to be available
-    pass "memory recall --hybrid flag accepted"
+	# It might also succeed if embeddings happen to be available
+	pass "memory recall --hybrid flag accepted"
 fi
 
 section "Embeddings: Config File Format"
 
 # Test: config file has expected format
-echo "provider=local" > "$AIDEVOPS_MEMORY_DIR/.embeddings-config"
-echo "configured_at=2025-01-01T00:00:00Z" >> "$AIDEVOPS_MEMORY_DIR/.embeddings-config"
+echo "provider=local" >"$AIDEVOPS_MEMORY_DIR/.embeddings-config"
+echo "configured_at=2025-01-01T00:00:00Z" >>"$AIDEVOPS_MEMORY_DIR/.embeddings-config"
 
 config_provider=$(grep '^provider=' "$AIDEVOPS_MEMORY_DIR/.embeddings-config" | cut -d= -f2)
 if [[ "$config_provider" == "local" ]]; then
-    pass "config file stores provider correctly"
+	pass "config file stores provider correctly"
 else
-    fail "config file provider incorrect" "got: $config_provider"
+	fail "config file provider incorrect" "got: $config_provider"
 fi
 
 config_date=$(grep '^configured_at=' "$AIDEVOPS_MEMORY_DIR/.embeddings-config" | cut -d= -f2)
 if [[ -n "$config_date" ]]; then
-    pass "config file stores configured_at timestamp"
+	pass "config file stores configured_at timestamp"
 else
-    fail "config file missing configured_at"
+	fail "config file missing configured_at"
 fi
 
 # Clean up embeddings config for remaining tests
@@ -711,15 +710,15 @@ rm -f "$AIDEVOPS_MEMORY_DIR/.embeddings-config"
 echo ""
 echo "========================================"
 printf "  \033[1mResults: %d total, \033[0;32m%d passed\033[0m, \033[0;31m%d failed\033[0m, \033[0;33m%d skipped\033[0m\n" \
-    "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
+	"$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT" "$SKIP_COUNT"
 echo "========================================"
 
 if [[ "$FAIL_COUNT" -gt 0 ]]; then
-    echo ""
-    printf "\033[0;31mFAILURES DETECTED - review output above\033[0m\n"
-    exit 1
+	echo ""
+	printf "\033[0;31mFAILURES DETECTED - review output above\033[0m\n"
+	exit 1
 else
-    echo ""
-    printf "\033[0;32mAll tests passed.\033[0m\n"
-    exit 0
+	echo ""
+	printf "\033[0;32mAll tests passed.\033[0m\n"
+	exit 0
 fi

--- a/tests/test-memory-pressure-monitor.sh
+++ b/tests/test-memory-pressure-monitor.sh
@@ -21,7 +21,6 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT_UNDER_TEST="$REPO_DIR/.agents/scripts/memory-pressure-monitor.sh"
-VERBOSE="${1:-}"
 
 # --- Test Framework ---
 PASS_COUNT=0

--- a/tests/test-supervisor-state-machine.sh
+++ b/tests/test-supervisor-state-machine.sh
@@ -19,7 +19,6 @@ set -euo pipefail
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPTS_DIR="$REPO_DIR/.agents/scripts"
 SUPERVISOR_SCRIPT="$SCRIPTS_DIR/supervisor-helper.sh"
-VERBOSE="${1:-}"
 
 # --- Test Framework ---
 PASS_COUNT=0
@@ -1963,6 +1962,7 @@ TODOEOF
 	test_db "INSERT OR REPLACE INTO tasks (id, status) VALUES ('t28380', 'complete');"
 	reset_output=$(
 		# Subshell: stub supervisor globals, source sanity-check.sh, call the guard
+		# shellcheck disable=SC2034 # Used by sourced sanity-check.sh
 		SUPERVISOR_DB="$TEST_DIR/supervisor.db"
 		# Stubs for functions expected by sanity-check.sh from supervisor-helper.sh
 		db() { sqlite3 -cmd ".timeout 5000" "$@"; }


### PR DESCRIPTION
## Summary

- Remove unused `VERBOSE` variable from 4 test files (dead code — assigned from `$1` but never referenced)
- Add `# shellcheck disable=SC2034` for `SUPERVISOR_DB` in `test-supervisor-state-machine.sh` (used by sourced `sanity-check.sh`)
- Add `# shellcheck disable=SC2034` for `LOG_PREFIX` in `batch-strategy-helper.sh` (used by logging functions in sourced `shared-constants.sh`)
- Remove unused `VALID_LINK_CONFIDENCE` constant from `entity-helper.sh` (SQL `CHECK` constraint handles validation)

### Already resolved (no changes needed)

- `setup.sh` `PLATFORM_MACOS`/`PLATFORM_ARM64` — fixed in prior commit (`8216649d`)
- `has_cycle` in `batch-strategy-helper.sh` — removed in prior quality-debt fix (`6ab1b38c`)

### Verification

- ShellCheck: zero SC2034 violations across all 6 files listed in the issue
- Tests: `test-backup-safety.sh` (all pass), `test-memory-mail.sh` (66/66 pass), `test-memory-pressure-monitor.sh` (37/37 pass)
- `test-supervisor-state-machine.sh` exits 127 on baseline (pre-existing dependency issue, not caused by this change)

Closes #3057