### PR TITLE
fix: memory recall uses per-token quoting instead of phrase matching

### DIFF
--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -176,12 +176,31 @@ cmd_recall() {
 		return $?
 	fi
 
-	# Escape query for FTS5 - wrap in double quotes to handle special chars
-	# FTS5 treats hyphens as NOT operator, asterisks as prefix, etc.
-	# Quoting the query makes it a literal phrase search.
+	# Escape query for FTS5 — tokenise into individual words joined by AND.
+	# Previous approach wrapped the entire query in double quotes, making it a
+	# phrase search (words must appear adjacent and in order). This caused most
+	# multi-word queries to return zero results — e.g., "shellcheck memory"
+	# only matched if those exact words appeared side-by-side in content.
+	#
+	# FTS5 implicit AND (space-separated tokens) is the correct default:
+	# each word must appear somewhere in the document, but not necessarily
+	# adjacent. Special characters (hyphens, asterisks) are handled by
+	# quoting individual tokens that contain them.
 	local escaped_query="${query//"'"/"''"}"
-	# Escape embedded double quotes for FTS5 (double them), then wrap in quotes
-	escaped_query="\"${escaped_query//\"/\"\"}\""
+	# Quote each token individually to handle special chars (hyphens = NOT in FTS5)
+	# "foo-bar baz" → "\"foo-bar\" \"baz\"" (each token quoted, joined by implicit AND)
+	local tokenised_query=""
+	local token
+	for token in $escaped_query; do
+		# Escape embedded double quotes within each token
+		token="${token//\"/\"\"}"
+		if [[ -n "$tokenised_query" ]]; then
+			tokenised_query="$tokenised_query \"$token\""
+		else
+			tokenised_query="\"$token\""
+		fi
+	done
+	escaped_query="$tokenised_query"
 
 	# Build filters with validation
 	local extra_filters=""

--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -191,6 +191,7 @@ cmd_recall() {
 	# "foo-bar baz" → "\"foo-bar\" \"baz\"" (each token quoted, joined by implicit AND)
 	local tokenised_query=""
 	local token
+	set -f # Disable globbing during tokenization (SC2086)
 	for token in $escaped_query; do
 		# Escape embedded double quotes within each token
 		token="${token//\"/\"\"}"
@@ -200,6 +201,7 @@ cmd_recall() {
 			tokenised_query="\"$token\""
 		fi
 	done
+	set +f # Re-enable globbing
 	escaped_query="$tokenised_query"
 
 	# Build filters with validation


### PR DESCRIPTION
## Summary

- Fix FTS5 recall query that wrapped multi-word searches in double quotes (phrase matching), causing most queries to return zero results
- Tokenise query into individual quoted words joined by implicit AND — each word must appear in the document but not necessarily adjacent
- Preserves special character handling (hyphens, asterisks) via per-token quoting

## Problem

`memory-helper.sh recall "shellcheck memory"` returned no results because FTS5 phrase search required those exact words to appear adjacent. Of 2,110 memories, 22 contain "shellcheck" and 42 contain "memory" but none contain the phrase "shellcheck memory".

## Testing

Before fix:
- `recall "shellcheck memory"` → 0 results
- `recall "supervisor task completed"` → 0 results
- `recall "auto-update setup deploy"` → 0 results

After fix:
- `recall "supervisor task completed"` → 5 results (correct)
- `recall "auto-update"` → 3 results (hyphenated terms still work)
- `recall "shellcheck"` → 5 results (single-word unchanged)
- `recall "memory pressure"` → 2 results (terms that happen to be adjacent still match)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search query matching behavior to find results containing individual keywords rather than exact phrases, enabling more flexible and relevant search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->