### PR TITLE
GH#3031: Fix broken Decision Table in headless-dispatch.md

### DIFF
--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -883,6 +883,8 @@ runner-helper.sh run tester "Write tests for the changes"
 | Generate tests for 5 modules | Parallel | Each module is independent |
 | Plan → implement → verify | Sequential | Each step depends on previous |
 | Decomposed subtasks (same parent) | Batch strategy | Use `batch-strategy-helper.sh` |
+| Cron: daily report + weekly digest | Parallel | Independent scheduled tasks |
+| Migration: schema → data → verify | Sequential | Each step depends on previous |
 
 ### Batch Strategies for Decomposed Tasks (t1408.4)
 
@@ -907,8 +909,6 @@ done
 ```
 
 The helper respects `blocked_by:` dependencies and never includes blocked tasks in a batch. See `scripts/batch-strategy-helper.sh help` for full usage.
-| Cron: daily report + weekly digest | Parallel | Independent scheduled tasks |
-| Migration: schema → data → verify | Sequential | Each step depends on previous |
 
 ### Hybrid Pattern
 


### PR DESCRIPTION
## Summary

- Move two orphaned markdown table rows back into the Decision Table in `headless-dispatch.md`
- PR #3000 inserted the "Batch Strategies for Decomposed Tasks" section in the middle of the table, stranding the "Cron" and "Migration" scenario rows after the section
- Those rows rendered as plain text instead of table cells — now restored to the table

## Details

The Gemini code review on PR #3000 flagged this issue: the new section and preceding blank line were inserted mid-table, breaking rendering for the last two rows. This fix moves those rows back into the table (before the blank line that terminates it) and places the Batch Strategies section after the complete table.

**Verification:** `markdownlint-cli2` reports 0 errors on the fixed file.

Closes #3031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved decision table with additional practical examples demonstrating parallel versus sequential task execution patterns, including scheduled reporting workflows and step-dependent migration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->