### PR TITLE
t3069: fix dead code warnings in setup.sh and generate-claude-commands.sh

### DIFF
--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2016 # $ARGUMENTS is a Claude Code template placeholder written literally to .md files
+# shellcheck disable=SC2016,SC2317
+# SC2016: $ARGUMENTS is a Claude Code template placeholder written literally to .md files
+# SC2317: Functions defined after arg-parsing case (which contains exit 0 in --help)
+#         appear unreachable to ShellCheck but are always reached in normal execution
 # =============================================================================
 # Generate Claude Code Commands from Agent Files
 # =============================================================================

--- a/setup.sh
+++ b/setup.sh
@@ -29,8 +29,8 @@ CLEAN_MODE=false
 INTERACTIVE_MODE=false
 NON_INTERACTIVE="${AIDEVOPS_NON_INTERACTIVE:-false}"
 UPDATE_TOOLS_MODE=false
-# Platform constants — exported so ShellCheck sees them as used (consumed by
-# sourced setup-modules: shell-env.sh:552,653 and tool-install.sh:249).
+# Platform constants — exported for sourced setup-modules (shell-env.sh,
+# tool-install.sh) that reference them at runtime.
 PLATFORM_MACOS=$([[ "$(uname -s)" == "Darwin" ]] && echo true || echo false)
 PLATFORM_ARM64=$([[ "$(uname -m)" == "arm64" || "$(uname -m)" == "aarch64" ]] && echo true || echo false)
 export PLATFORM_MACOS PLATFORM_ARM64


### PR DESCRIPTION
## Summary

- Addresses ShellCheck dead code warnings (SC2034, SC2317, SC2329) found by quality sweep
- Removes stale line-number references from `setup.sh` PLATFORM_* comment (variables are already exported and used by sourced setup-modules)
- Adds SC2317 disable with rationale to `generate-claude-commands.sh` — functions defined after arg-parsing case appear unreachable to ShellCheck but are always reached in normal execution
- `tests/test-ai-actions.sh` already had correct file-level disables with explanatory comments (no change needed)

## Verification

- All three files pass `shellcheck` and `shellcheck --enable=all` with zero SC2034/SC2317/SC2329 warnings
- All three files pass `bash -n` syntax check
- `generate-claude-commands.sh --help` works correctly

Closes #3069