### PR TITLE
t1395: Dataset convention for repeatable LLM evaluations

### DIFF
--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -2633,7 +2633,7 @@ if m:
 #
 # Options:
 #   --judge           Enable LLM-as-judge scoring (haiku-tier, ~$0.001/call)
-#   --dataset FILE    Read prompts from JSONL file (each line: {"prompt":"..."})
+#   --dataset FILE    Read prompts from JSONL file (each line: {"input":"..."} or {"prompt":"..."})
 #   --max-tokens N    Max output tokens per model (default: 1024)
 #   --dry-run         Show what would happen without making API calls
 #   --history         Show historical bench results
@@ -2722,7 +2722,7 @@ cmd_bench() {
 		echo ""
 		echo "Options:"
 		echo "  --judge           Enable LLM-as-judge quality scoring"
-		echo "  --dataset FILE    Read prompts from JSONL (each line: {\"prompt\":\"...\"})"
+		echo "  --dataset FILE    Read prompts from JSONL (each line: {\"input\":\"...\"} or {\"prompt\":\"...\"})"
 		echo "  --max-tokens N    Max output tokens per model (default: 1024)"
 		echo "  --dry-run         Show plan without making API calls"
 		echo "  --history         Show historical bench results"
@@ -2753,13 +2753,14 @@ cmd_bench() {
 		while IFS= read -r line; do
 			[[ -z "$line" ]] && continue
 			local p
-			p=$(echo "$line" | jq -r '.prompt // empty' 2>/dev/null || echo "")
+			# Support both dataset convention (.input) and legacy (.prompt)
+			p=$(echo "$line" | jq -r '(.input // .prompt) // empty' 2>/dev/null || echo "")
 			if [[ -n "$p" ]]; then
 				prompts+=("$p")
 			fi
 		done <"$dataset_file"
 		if [[ ${#prompts[@]} -eq 0 ]]; then
-			print_error "No valid prompts found in dataset (expected JSONL with {\"prompt\":\"...\"})"
+			print_error "No valid prompts found in dataset (expected JSONL with {\"input\":\"...\"} or {\"prompt\":\"...\"})"
 			return 1
 		fi
 	else

--- a/.agents/scripts/dataset-helper.sh
+++ b/.agents/scripts/dataset-helper.sh
@@ -212,7 +212,7 @@ cmd_validate() {
 
 	local errors=0
 	local line_num=0
-	local -A seen_ids=()
+	local seen_ids=""
 
 	while IFS= read -r line || [[ -n "$line" ]]; do
 		line_num=$((line_num + 1))
@@ -242,15 +242,16 @@ cmd_validate() {
 			errors=$((errors + 1))
 		fi
 
-		# Check for duplicate IDs (O(1) lookup via associative array)
+		# Check for duplicate IDs (newline-separated list, bash 3.2 compatible)
 		if [[ "$has_id" == "true" ]]; then
 			local entry_id
 			entry_id=$(echo "$line" | jq -r '.id')
-			if [[ -n "${seen_ids[$entry_id]+x}" ]]; then
+			if echo "$seen_ids" | grep -qxF "$entry_id"; then
 				print_error "Line $line_num: Duplicate ID '$entry_id'"
 				errors=$((errors + 1))
 			else
-				seen_ids["$entry_id"]=1
+				seen_ids="${seen_ids}${entry_id}
+"
 			fi
 		fi
 


### PR DESCRIPTION
## Summary

- Fix bash 3.2 compatibility bug in `dataset-helper.sh` validate command — `local -A` (associative arrays) requires bash 4+ but macOS ships bash 3.2
- Align `compare-models-helper.sh bench --dataset` with the dataset convention (`.input` field) while maintaining backward compatibility with legacy `.prompt` field

## Changes

### `dataset-helper.sh` (bug fix)
- Replace `local -A seen_ids=()` with newline-separated string + `grep -qxF` for duplicate ID detection
- All subcommands verified working: create, validate, add, list, stats, promote, merge, schema

### `compare-models-helper.sh` (integration)
- Update bench `--dataset` to read `.input` (dataset convention) with fallback to `.prompt` (legacy)
- Update help text and comments to document both formats

## Verification

All acceptance criteria verified:
- `create` creates valid empty JSONL files (global and project-local)
- `validate` checks JSON validity, required fields (`id`, `input`), duplicate IDs
- `validate --strict` checks optional field types
- `add` appends entries with auto-generated IDs, all optional fields work
- `stats` shows entry count, expected/context coverage, source/tag breakdown
- `promote --trace-id` converts observability traces to dataset entries (tested with real trace data)
- `merge` deduplicates by ID, file2 wins on conflict
- `schema` prints full JSON Schema
- ShellCheck clean (SC1091 disabled project-wide per `.shellcheckrc`)
- `ai-judgment-helper.sh evaluate --dataset` already reads `.input` — no changes needed
- `compare-models-helper.sh bench --dataset` now reads `.input` with `.prompt` fallback

Closes #3076