### PR TITLE
t1412.3: Network domain tiering for worker sandboxing

### DIFF
--- a/.agents/configs/network-tiers.conf
+++ b/.agents/configs/network-tiers.conf
@@ -1,0 +1,222 @@
+# network-tiers.conf — Domain classification for worker network tiering (t1412.3)
+#
+# Four-tier graduated trust model for headless worker network access.
+# Interactive sessions are unrestricted — this only applies to sandboxed workers.
+#
+# Format: One domain per line. Wildcards: *.example.com matches all subdomains.
+# Lines starting with # are comments. Empty lines are ignored.
+#
+# Tier 1: Always allowed, no logging overhead (core infrastructure)
+# Tier 2: Allowed + logged (package registries, build tools)
+# Tier 3: Allowed + logged (known tools, docs, services)
+# Tier 4: (implicit) Any domain not in Tiers 1-3 — allowed + flagged for review
+# Tier 5: Denied (exfiltration indicators, paste sites, raw IPs)
+#
+# User overrides: ~/.config/aidevops/network-tiers-custom.conf
+# Same format. Entries here are merged with (and override) the defaults.
+# To promote a Tier 4 domain to Tier 3, add it under [tier3] in the custom file.
+# To deny a domain, add it under [tier5] in the custom file.
+#
+# Domain data sourced from analysis of 1337+ GitHub hits, 276 x.com hits,
+# and hundreds of other domains from real session transcripts.
+
+[tier1]
+# GitHub — core infrastructure for all workers
+github.com
+*.github.com
+api.github.com
+*.githubusercontent.com
+raw.githubusercontent.com
+objects.githubusercontent.com
+github.githubassets.com
+
+# GitLab (for repos that use it)
+gitlab.com
+*.gitlab.com
+
+[tier2]
+# npm / Node.js
+registry.npmjs.org
+*.npmjs.org
+*.npmjs.com
+
+# Python
+pypi.org
+*.pypi.org
+files.pythonhosted.org
+
+# Rust
+crates.io
+static.crates.io
+
+# Go
+proxy.golang.org
+sum.golang.org
+storage.googleapis.com
+
+# Ruby
+rubygems.org
+
+# PHP / Composer
+packagist.org
+repo.packagist.org
+
+# Container registries
+ghcr.io
+*.ghcr.io
+docker.io
+*.docker.io
+hub.docker.com
+registry.hub.docker.com
+registry-1.docker.io
+auth.docker.io
+production.cloudflare.docker.com
+
+# Bun
+registry.bun.sh
+bun.sh
+
+# Homebrew
+formulae.brew.sh
+ghcr.io
+
+[tier3]
+# Code quality / CI services
+sonarcloud.io
+*.sonarcloud.io
+qlty.sh
+*.qlty.sh
+app.codacy.com
+*.codacy.com
+api.codacy.com
+codefactor.io
+*.codefactor.io
+coderabbit.ai
+*.coderabbit.ai
+app.codecov.io
+codecov.io
+*.codecov.io
+coveralls.io
+snyk.io
+*.snyk.io
+app.snyk.io
+socket.dev
+*.socket.dev
+
+# Documentation sites
+docs.anthropic.com
+docs.github.com
+cli.github.com
+developers.cloudflare.com
+docs.cloudflare.com
+nodejs.org
+docs.npmjs.com
+docs.python.org
+docs.rs
+doc.rust-lang.org
+developer.mozilla.org
+devdocs.io
+stackoverflow.com
+*.stackexchange.com
+
+# AI / LLM providers (workers may call APIs)
+api.anthropic.com
+api.openai.com
+generativelanguage.googleapis.com
+api.x.ai
+
+# Build / runtime tools
+playwright.dev
+*.playwright.dev
+deno.land
+deno.com
+
+# Cloudflare (common deployment target)
+*.cloudflare.com
+*.workers.dev
+
+# Vercel (common deployment target)
+vercel.com
+*.vercel.com
+*.vercel.app
+api.vercel.com
+
+# Cloudron (common deployment target)
+cloudron.io
+*.cloudron.io
+docs.cloudron.io
+
+# CDNs (commonly needed for installs)
+cdn.jsdelivr.net
+unpkg.com
+cdnjs.cloudflare.com
+esm.sh
+
+# Common development services
+sentry.io
+*.sentry.io
+*.ingest.sentry.io
+heygen.com
+api.heygen.com
+
+# Search / SEO tools (for SEO agent tasks)
+api.dataforseo.com
+searchconsole.googleapis.com
+www.googleapis.com
+
+[tier5]
+# Exfiltration indicators — DENY
+# Raw IP addresses are handled programmatically (not listed here)
+
+# Paste / webhook / tunnel sites
+requestbin.com
+*.requestbin.com
+webhook.site
+*.webhook.site
+ngrok.io
+*.ngrok.io
+*.ngrok-free.app
+ngrok-free.app
+pipedream.com
+*.pipedream.com
+hookbin.com
+*.hookbin.com
+requestcatcher.com
+*.requestcatcher.com
+burpcollaborator.net
+*.burpcollaborator.net
+interact.sh
+*.interact.sh
+*.oast.fun
+*.oast.me
+*.oast.live
+canarytokens.com
+*.canarytokens.com
+
+# DNS exfiltration / tunneling
+*.dnslog.cn
+dnslog.cn
+*.ceye.io
+ceye.io
+
+# Anonymous hosting / dark web
+*.onion
+*.bit
+*.i2p
+
+# File sharing (potential exfiltration)
+transfer.sh
+*.transfer.sh
+file.io
+*.file.io
+0x0.st
+ix.io
+sprunge.us
+termbin.com
+
+# URL shorteners (obfuscation)
+bit.ly
+tinyurl.com
+is.gd
+v.gd
+t.co

--- a/.agents/scripts/network-tier-helper.sh
+++ b/.agents/scripts/network-tier-helper.sh
@@ -1,0 +1,720 @@
+#!/usr/bin/env bash
+# network-tier-helper.sh — Network domain tiering for worker sandboxing (t1412.3)
+# Commands: classify | log-access | check | report | init | help
+#
+# Implements a 4-tier graduated trust model for headless worker network access:
+#   Tier 1: Always allowed, no logging (core infrastructure: github.com)
+#   Tier 2: Allowed + logged (package registries: npmjs.org, pypi.org)
+#   Tier 3: Allowed + logged (known tools/docs: sonarcloud.io, docs.anthropic.com)
+#   Tier 4: Allowed + flagged (unknown domains — logged with alert for review)
+#   Tier 5: Denied (exfiltration indicators: requestbin, ngrok, raw IPs)
+#
+# Interactive sessions are unrestricted — tiering only applies to sandboxed workers.
+#
+# Integration:
+#   - sandbox-exec-helper.sh calls `check` before network operations
+#   - Workers call `log-access` after each network request
+#   - Supervisors call `report` to review flagged domains
+#
+# Config:
+#   - Default tiers: .agents/configs/network-tiers.conf
+#   - User overrides: ~/.config/aidevops/network-tiers-custom.conf
+#
+# Compatibility: bash 3.2+ (macOS default). Uses file-based lookup, not
+# associative arrays, for portability.
+#
+# Usage:
+#   network-tier-helper.sh classify example.com     # → 1|2|3|4|5
+#   network-tier-helper.sh check example.com        # exit 0=allow, 1=deny
+#   network-tier-helper.sh log-access example.com worker-123 200
+#   network-tier-helper.sh report [--last N] [--flagged-only]
+#   network-tier-helper.sh init                     # Create log dirs and validate config
+#   network-tier-helper.sh help
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+set -euo pipefail
+
+LOG_PREFIX="NET-TIER"
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+readonly NET_TIER_DIR="${HOME}/.aidevops/.agent-workspace/network"
+readonly NET_TIER_LOG="${NET_TIER_DIR}/access.jsonl"
+readonly NET_TIER_FLAGGED_LOG="${NET_TIER_DIR}/flagged.jsonl"
+readonly NET_TIER_DENIED_LOG="${NET_TIER_DIR}/denied.jsonl"
+
+# Config file locations (default + user override)
+readonly NET_TIER_DEFAULT_CONF="${SCRIPT_DIR}/../configs/network-tiers.conf"
+readonly NET_TIER_USER_CONF="${HOME}/.config/aidevops/network-tiers-custom.conf"
+
+# File-based tier lookup cache (bash 3.2 compatible — no associative arrays)
+# Format: "exact:domain tier" or "wild:suffix tier", one per line
+_TIER_LOOKUP_FILE=""
+_TIER_DATA_LOADED=""
+
+# =============================================================================
+# Config Parsing
+# =============================================================================
+
+# Parse a network-tiers.conf file and append entries to the lookup file.
+# Reads [tierN] sections. User config entries override defaults (last match wins
+# in grep, so user config is appended after defaults).
+# Arguments:
+#   $1 - config file path
+#   $2 - lookup file to append to
+_parse_tier_config() {
+	local config_file="$1"
+	local lookup_file="$2"
+	local current_tier=""
+
+	if [[ ! -r "$config_file" ]]; then
+		return 0
+	fi
+
+	local line
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		# Skip empty lines and comments
+		[[ -z "$line" || "$line" == \#* ]] && continue
+
+		# Trim whitespace
+		line="${line#"${line%%[![:space:]]*}"}"
+		line="${line%"${line##*[![:space:]]}"}"
+		[[ -z "$line" || "$line" == \#* ]] && continue
+
+		# Section headers: [tier1], [tier2], etc.
+		if [[ "$line" =~ ^\[tier([1-5])\]$ ]]; then
+			current_tier="${BASH_REMATCH[1]}"
+			continue
+		fi
+
+		# Skip lines outside a section
+		[[ -z "$current_tier" ]] && continue
+
+		# Normalize: lowercase, strip trailing dot
+		local domain="$line"
+		domain="$(printf '%s' "$domain" | tr '[:upper:]' '[:lower:]')"
+		domain="${domain%.}"
+
+		if [[ "$domain" == \*.* ]]; then
+			# Wildcard: *.example.com → store the suffix
+			local suffix="${domain#\*.}"
+			printf 'wild:%s %s\n' "$suffix" "$current_tier" >>"$lookup_file"
+		else
+			printf 'exact:%s %s\n' "$domain" "$current_tier" >>"$lookup_file"
+		fi
+	done <"$config_file"
+
+	return 0
+}
+
+# Load tier configuration from default + user override files.
+# Creates a temp file with all tier mappings for grep-based lookup.
+# Called once per script invocation; results cached in _TIER_LOOKUP_FILE.
+_load_tier_data() {
+	if [[ -n "$_TIER_DATA_LOADED" ]]; then
+		return 0
+	fi
+
+	_TIER_LOOKUP_FILE="$(mktemp)"
+
+	# Load default config first
+	_parse_tier_config "$NET_TIER_DEFAULT_CONF" "$_TIER_LOOKUP_FILE"
+
+	# Load user overrides (appended after defaults — last match wins)
+	_parse_tier_config "$NET_TIER_USER_CONF" "$_TIER_LOOKUP_FILE"
+
+	_TIER_DATA_LOADED="1"
+	return 0
+}
+
+# Clean up the temp lookup file on exit.
+_cleanup_tier_data() {
+	if [[ -n "${_TIER_LOOKUP_FILE:-}" && -f "${_TIER_LOOKUP_FILE:-}" ]]; then
+		rm -f "$_TIER_LOOKUP_FILE"
+	fi
+	return 0
+}
+trap '_cleanup_tier_data' EXIT
+
+# Look up a domain in the tier lookup file.
+# Returns the tier number for the last matching entry (user overrides win).
+# Arguments:
+#   $1 - lookup key (e.g., "exact:github.com" or "wild:github.com")
+# Output: tier number on stdout, or empty if no match
+_tier_lookup() {
+	local key="$1"
+
+	if [[ -z "${_TIER_LOOKUP_FILE:-}" || ! -f "${_TIER_LOOKUP_FILE:-}" ]]; then
+		return 0
+	fi
+
+	# grep for the key, take the last match (user override wins)
+	local result
+	result="$(grep "^${key} " "$_TIER_LOOKUP_FILE" 2>/dev/null | tail -1)" || true
+	if [[ -n "$result" ]]; then
+		# Extract tier number (second field)
+		printf '%s' "${result##* }"
+	fi
+
+	return 0
+}
+
+# Count entries in the lookup file by type.
+# Arguments:
+#   $1 - type prefix ("exact" or "wild")
+# Output: count on stdout
+_tier_count() {
+	local type_prefix="$1"
+
+	if [[ -z "${_TIER_LOOKUP_FILE:-}" || ! -f "${_TIER_LOOKUP_FILE:-}" ]]; then
+		echo "0"
+		return 0
+	fi
+
+	grep -c "^${type_prefix}:" "$_TIER_LOOKUP_FILE" 2>/dev/null || echo "0"
+	return 0
+}
+
+# =============================================================================
+# Domain Classification
+# =============================================================================
+
+# Check if a string looks like a raw IP address (IPv4 or IPv6).
+# Raw IPs are Tier 5 (denied) — legitimate services use hostnames.
+# Arguments:
+#   $1 - string to check
+# Returns: 0 if IP address, 1 if hostname
+_is_raw_ip() {
+	local host="$1"
+
+	# IPv4: digits and dots only, 4 octets
+	if [[ "$host" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		return 0
+	fi
+
+	# IPv6: contains colons (simplified check)
+	if [[ "$host" == *:* ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+# Check if a domain has a suspicious TLD (Tier 5).
+# Arguments:
+#   $1 - domain
+# Returns: 0 if suspicious, 1 if normal
+_is_suspicious_tld() {
+	local domain="$1"
+
+	case "$domain" in
+	*.onion | *.bit | *.i2p)
+		return 0
+		;;
+	esac
+
+	return 1
+}
+
+# Classify a domain into its network tier.
+# Arguments:
+#   $1 - domain or hostname (e.g., "api.github.com", "evil.ngrok.io")
+# Output: tier number (1-5) on stdout
+# Returns: 0 always
+classify_domain() {
+	local domain="$1"
+
+	# Normalize: lowercase, strip port, strip protocol, strip trailing dot
+	domain="$(printf '%s' "$domain" | tr '[:upper:]' '[:lower:]')"
+	domain="${domain#*://}"
+	domain="${domain%%:*}"
+	domain="${domain%%/*}"
+	domain="${domain%.}"
+
+	if [[ -z "$domain" ]]; then
+		echo "4"
+		return 0
+	fi
+
+	# Rule 1: Raw IP addresses → Tier 5 (deny)
+	if _is_raw_ip "$domain"; then
+		echo "5"
+		return 0
+	fi
+
+	# Rule 2: Suspicious TLDs → Tier 5 (deny)
+	if _is_suspicious_tld "$domain"; then
+		echo "5"
+		return 0
+	fi
+
+	# Load tier data if not already loaded
+	_load_tier_data
+
+	# Rule 3: Exact match
+	local tier
+	tier="$(_tier_lookup "exact:${domain}")"
+	if [[ -n "$tier" ]]; then
+		echo "$tier"
+		return 0
+	fi
+
+	# Rule 4: Wildcard match — walk up the domain hierarchy
+	# For "api.sub.example.com", check: sub.example.com, example.com
+	local check_domain="$domain"
+	while [[ "$check_domain" == *.* ]]; do
+		# Strip the leftmost label
+		check_domain="${check_domain#*.}"
+		tier="$(_tier_lookup "wild:${check_domain}")"
+		if [[ -n "$tier" ]]; then
+			echo "$tier"
+			return 0
+		fi
+	done
+
+	# Rule 5: No match → Tier 4 (unknown, allowed but flagged)
+	echo "4"
+	return 0
+}
+
+# Human-readable tier label.
+# Arguments:
+#   $1 - tier number (1-5)
+tier_label() {
+	local tier="$1"
+	case "$tier" in
+	1) echo "ALLOW" ;;
+	2) echo "ALLOW+LOG" ;;
+	3) echo "ALLOW+LOG" ;;
+	4) echo "ALLOW+FLAG" ;;
+	5) echo "DENY" ;;
+	*) echo "UNKNOWN" ;;
+	esac
+	return 0
+}
+
+# =============================================================================
+# Access Logging
+# =============================================================================
+
+# Log a network access event to the appropriate JSONL log file.
+# Arguments:
+#   $1 - domain
+#   $2 - worker ID (e.g., "worker-abc123")
+#   $3 - HTTP status code or "blocked" (optional, default "")
+#   $4 - URL path (optional, default "")
+log_access() {
+	local domain="$1"
+	local worker_id="${2:-unknown}"
+	local status_code="${3:-}"
+	local url_path="${4:-}"
+
+	local tier
+	tier=$(classify_domain "$domain")
+	local label
+	label=$(tier_label "$tier")
+	local timestamp
+	timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+	# Ensure log directory exists
+	mkdir -p "$NET_TIER_DIR" 2>/dev/null || true
+
+	# Build JSON record (portable — no jq dependency for writing)
+	local record
+	record=$(printf '{"ts":"%s","domain":"%s","tier":%s,"label":"%s","worker":"%s","status":"%s","path":"%s"}' \
+		"$timestamp" \
+		"$(printf '%s' "$domain" | sed 's/"/\\"/g')" \
+		"$tier" \
+		"$label" \
+		"$(printf '%s' "$worker_id" | sed 's/"/\\"/g')" \
+		"$status_code" \
+		"$(printf '%s' "${url_path:0:500}" | sed 's/"/\\"/g')")
+
+	# Route to appropriate log based on tier
+	case "$tier" in
+	1)
+		# Tier 1: no logging (core infrastructure, high volume)
+		return 0
+		;;
+	2 | 3)
+		# Tier 2-3: log to main access log
+		echo "$record" >>"$NET_TIER_LOG"
+		;;
+	4)
+		# Tier 4: log to both access and flagged logs
+		echo "$record" >>"$NET_TIER_LOG"
+		echo "$record" >>"$NET_TIER_FLAGGED_LOG"
+		log_warn "Tier 4 (unknown domain): ${domain} by ${worker_id}"
+		;;
+	5)
+		# Tier 5: log to denied log (access was blocked)
+		echo "$record" >>"$NET_TIER_DENIED_LOG"
+		log_error "Tier 5 (DENIED): ${domain} by ${worker_id}"
+		;;
+	esac
+
+	return 0
+}
+
+# =============================================================================
+# Access Check (for sandbox integration)
+# =============================================================================
+
+# Check if a domain should be allowed or denied.
+# Arguments:
+#   $1 - domain
+# Returns: 0 if allowed (Tiers 1-4), 1 if denied (Tier 5)
+# Output: tier classification info on stderr
+check_domain() {
+	local domain="$1"
+
+	local tier
+	tier=$(classify_domain "$domain")
+
+	if [[ "$tier" -eq 5 ]]; then
+		log_error "BLOCKED: ${domain} (Tier 5: DENY)"
+		return 1
+	fi
+
+	if [[ "$tier" -eq 4 ]]; then
+		log_warn "FLAGGED: ${domain} (Tier 4: unknown domain)"
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Reporting
+# =============================================================================
+
+# Generate a report of network access events.
+# Arguments:
+#   --last N          Show last N entries (default: 50)
+#   --flagged-only    Show only Tier 4 (flagged) entries
+#   --denied-only     Show only Tier 5 (denied) entries
+#   --summary         Show domain frequency summary
+report() {
+	local last_n=50
+	local mode="all"
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--last)
+			last_n="$2"
+			shift 2
+			;;
+		--flagged-only)
+			mode="flagged"
+			shift
+			;;
+		--denied-only)
+			mode="denied"
+			shift
+			;;
+		--summary)
+			mode="summary"
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+
+	local log_file
+	case "$mode" in
+	flagged) log_file="$NET_TIER_FLAGGED_LOG" ;;
+	denied) log_file="$NET_TIER_DENIED_LOG" ;;
+	*) log_file="$NET_TIER_LOG" ;;
+	esac
+
+	if [[ "$mode" == "summary" ]]; then
+		_report_summary "$last_n"
+		return 0
+	fi
+
+	if [[ ! -f "$log_file" ]]; then
+		echo "No network access logs found."
+		echo "Log location: ${log_file}"
+		return 0
+	fi
+
+	echo "Network access report (${mode}, last ${last_n}):"
+	echo "---"
+
+	tail -n "$last_n" "$log_file" | while IFS= read -r line; do
+		local ts domain tier label worker
+		ts="$(printf '%s' "$line" | jq -r '.ts // "?"' 2>/dev/null)"
+		domain="$(printf '%s' "$line" | jq -r '.domain // "?"' 2>/dev/null)"
+		tier="$(printf '%s' "$line" | jq -r '.tier // "?"' 2>/dev/null)"
+		label="$(printf '%s' "$line" | jq -r '.label // "?"' 2>/dev/null)"
+		worker="$(printf '%s' "$line" | jq -r '.worker // "?"' 2>/dev/null)"
+		printf '%s  T%s %-12s %-40s %s\n' "$ts" "$tier" "$label" "$domain" "$worker"
+	done
+
+	return 0
+}
+
+# Summary report: unique domains by tier with frequency counts.
+_report_summary() {
+	local last_n="$1"
+
+	echo "Network tier summary (from all logs):"
+	echo "---"
+
+	local log_file
+	for log_file in "$NET_TIER_LOG" "$NET_TIER_FLAGGED_LOG" "$NET_TIER_DENIED_LOG"; do
+		[[ ! -f "$log_file" ]] && continue
+		local label
+		label="$(basename "$log_file" .jsonl)"
+		echo ""
+		echo "=== ${label} ==="
+		tail -n "$last_n" "$log_file" |
+			jq -r '[.domain, (.tier | tostring)] | join(" T")' 2>/dev/null |
+			sort | uniq -c | sort -rn | head -20
+	done
+
+	# Show flagged domain count
+	if [[ -f "$NET_TIER_FLAGGED_LOG" ]]; then
+		local flagged_count
+		flagged_count="$(wc -l <"$NET_TIER_FLAGGED_LOG" | tr -d ' ')"
+		echo ""
+		echo "Total flagged (Tier 4) domains: ${flagged_count}"
+	fi
+
+	if [[ -f "$NET_TIER_DENIED_LOG" ]]; then
+		local denied_count
+		denied_count="$(wc -l <"$NET_TIER_DENIED_LOG" | tr -d ' ')"
+		echo "Total denied (Tier 5) attempts: ${denied_count}"
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Init
+# =============================================================================
+
+# Initialize log directories and validate configuration.
+init() {
+	mkdir -p "$NET_TIER_DIR" 2>/dev/null || true
+
+	# Validate default config exists
+	if [[ ! -r "$NET_TIER_DEFAULT_CONF" ]]; then
+		log_error "Default config not found: ${NET_TIER_DEFAULT_CONF}"
+		echo "Run 'aidevops update' to restore default configuration."
+		return 1
+	fi
+
+	# Load and validate tier data
+	_load_tier_data
+
+	local exact_count
+	exact_count="$(_tier_count "exact")"
+	local wildcard_count
+	wildcard_count="$(_tier_count "wild")"
+
+	log_success "Network tier configuration loaded"
+	echo "  Default config: ${NET_TIER_DEFAULT_CONF}"
+	echo "  User overrides: ${NET_TIER_USER_CONF} ($([ -f "$NET_TIER_USER_CONF" ] && echo "present" || echo "not set"))"
+	echo "  Exact domains:  ${exact_count}"
+	echo "  Wildcard rules: ${wildcard_count}"
+	echo "  Log directory:  ${NET_TIER_DIR}"
+
+	# Quick self-test
+	local test_results=0
+	_self_test || test_results=$?
+	if [[ $test_results -ne 0 ]]; then
+		log_error "Self-test failed"
+		return 1
+	fi
+
+	log_success "Self-test passed"
+	return 0
+}
+
+# Quick self-test to verify classification works correctly.
+_self_test() {
+	local failures=0
+
+	# Tier 1: github.com
+	local result
+	result=$(classify_domain "github.com")
+	if [[ "$result" != "1" ]]; then
+		log_error "Self-test: github.com expected tier 1, got tier ${result}"
+		((failures++)) || true
+	fi
+
+	# Tier 1: api.github.com (wildcard *.github.com)
+	result=$(classify_domain "api.github.com")
+	if [[ "$result" != "1" ]]; then
+		log_error "Self-test: api.github.com expected tier 1, got tier ${result}"
+		((failures++)) || true
+	fi
+
+	# Tier 2: registry.npmjs.org
+	result=$(classify_domain "registry.npmjs.org")
+	if [[ "$result" != "2" ]]; then
+		log_error "Self-test: registry.npmjs.org expected tier 2, got tier ${result}"
+		((failures++)) || true
+	fi
+
+	# Tier 3: sonarcloud.io
+	result=$(classify_domain "sonarcloud.io")
+	if [[ "$result" != "3" ]]; then
+		log_error "Self-test: sonarcloud.io expected tier 3, got tier ${result}"
+		((failures++)) || true
+	fi
+
+	# Tier 4: unknown domain
+	result=$(classify_domain "totally-unknown-domain.example.net")
+	if [[ "$result" != "4" ]]; then
+		log_error "Self-test: unknown domain expected tier 4, got tier ${result}"
+		((failures++)) || true
+	fi
+
+	# Tier 5: ngrok.io (deny list)
+	result=$(classify_domain "evil.ngrok.io")
+	if [[ "$result" != "5" ]]; then
+		log_error "Self-test: evil.ngrok.io expected tier 5, got tier ${result}"
+		((failures++)) || true
+	fi
+
+	# Tier 5: raw IP
+	result=$(classify_domain "192.168.1.1")
+	if [[ "$result" != "5" ]]; then
+		log_error "Self-test: raw IP expected tier 5, got tier ${result}"
+		((failures++)) || true
+	fi
+
+	# Tier 5: .onion TLD
+	result=$(classify_domain "hidden.onion")
+	if [[ "$result" != "5" ]]; then
+		log_error "Self-test: .onion expected tier 5, got tier ${result}"
+		((failures++)) || true
+	fi
+
+	# URL normalization: strip protocol and port
+	result=$(classify_domain "https://github.com:443/foo/bar")
+	if [[ "$result" != "1" ]]; then
+		log_error "Self-test: URL normalization expected tier 1, got tier ${result}"
+		((failures++)) || true
+	fi
+
+	if [[ $failures -gt 0 ]]; then
+		return 1
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Help
+# =============================================================================
+
+show_help() {
+	cat <<'HELP'
+network-tier-helper.sh — Network domain tiering for worker sandboxing (t1412.3)
+
+Commands:
+  classify <domain>          Classify domain into tier (1-5)
+  check <domain>             Check if domain is allowed (exit 0) or denied (exit 1)
+  log-access <domain> [worker-id] [status] [path]
+                             Log a network access event
+  report [options]           Show network access report
+  init                       Initialize and validate configuration
+  help                       Show this help
+
+Report options:
+  --last N                   Show last N entries (default: 50)
+  --flagged-only             Show only Tier 4 (unknown/flagged) entries
+  --denied-only              Show only Tier 5 (denied) entries
+  --summary                  Show domain frequency summary
+
+Tier model:
+  Tier 1  ALLOW       Core infrastructure (github.com) — no logging
+  Tier 2  ALLOW+LOG   Package registries (npmjs, pypi) — logged
+  Tier 3  ALLOW+LOG   Known tools/docs (sonarcloud, anthropic) — logged
+  Tier 4  ALLOW+FLAG  Unknown domains — allowed but flagged for review
+  Tier 5  DENY        Exfiltration indicators — blocked
+
+Config files:
+  Default: .agents/configs/network-tiers.conf
+  Custom:  ~/.config/aidevops/network-tiers-custom.conf
+
+Log files:
+  Access:  ~/.aidevops/.agent-workspace/network/access.jsonl
+  Flagged: ~/.aidevops/.agent-workspace/network/flagged.jsonl
+  Denied:  ~/.aidevops/.agent-workspace/network/denied.jsonl
+
+Examples:
+  network-tier-helper.sh classify api.github.com
+  # Output: 1
+
+  network-tier-helper.sh check requestbin.com
+  # Exit 1 (denied)
+
+  network-tier-helper.sh log-access pypi.org worker-abc 200 /simple/requests/
+  network-tier-helper.sh report --flagged-only --last 20
+  network-tier-helper.sh report --summary
+
+Integration with sandbox-exec-helper.sh:
+  Before network access, call:
+    if network-tier-helper.sh check "$domain"; then
+      # proceed with request
+      network-tier-helper.sh log-access "$domain" "$WORKER_ID" "$status"
+    fi
+HELP
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	classify)
+		if [[ -z "${1:-}" ]]; then
+			log_error "Domain required. Usage: network-tier-helper.sh classify <domain>"
+			return 1
+		fi
+		classify_domain "$1"
+		;;
+	check)
+		if [[ -z "${1:-}" ]]; then
+			log_error "Domain required. Usage: network-tier-helper.sh check <domain>"
+			return 1
+		fi
+		check_domain "$1"
+		;;
+	log-access | log)
+		if [[ -z "${1:-}" ]]; then
+			log_error "Domain required. Usage: network-tier-helper.sh log-access <domain> [worker-id] [status] [path]"
+			return 1
+		fi
+		log_access "${1:-}" "${2:-unknown}" "${3:-}" "${4:-}"
+		;;
+	report)
+		report "$@"
+		;;
+	init)
+		init
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		log_error "Unknown command: ${cmd}"
+		show_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -3,12 +3,19 @@
 # Commands: run | audit | config | help
 #
 # Wraps command execution with environment clearing, timeout enforcement,
-# temp directory isolation, and optional network restriction.
+# temp directory isolation, optional network restriction, and network tiering.
 # Inspired by OpenFang's WASM sandbox — adapted for shell-native use.
+#
+# Network tiering (t1412.3): When --network-tiering is enabled, commands that
+# access the network have their target domains classified into tiers (1-5).
+# Tier 5 domains (exfiltration indicators) are logged and flagged. Tier 4
+# (unknown) domains are allowed but flagged for post-session review.
+# See network-tier-helper.sh for the full tier model.
 #
 # Usage:
 #   sandbox-exec-helper.sh run "command args"
 #   sandbox-exec-helper.sh run --timeout 60 --no-network "curl example.com"
+#   sandbox-exec-helper.sh run --network-tiering --worker-id w123 "curl example.com"
 #   sandbox-exec-helper.sh run --passthrough "GITHUB_TOKEN,NPM_TOKEN" "npm publish"
 #   sandbox-exec-helper.sh audit [--last N]
 #   sandbox-exec-helper.sh config --show
@@ -34,6 +41,9 @@ readonly MAX_OUTPUT_BYTES=10485760 # 10MB per stream
 
 # Minimal environment passthrough — only what's needed for basic operation
 readonly DEFAULT_PASSTHROUGH="PATH HOME USER LANG TERM SHELL"
+
+# Network tier helper (t1412.3)
+readonly NET_TIER_HELPER="${SCRIPT_DIR}/network-tier-helper.sh"
 
 # =============================================================================
 # Helpers
@@ -74,12 +84,59 @@ log_execution() {
 }
 
 # =============================================================================
+# Network Tiering Integration (t1412.3)
+# =============================================================================
+
+# Extract domains from a command string and check them against network tiers.
+# Best-effort heuristic: parses URLs and hostnames from common patterns
+# (curl, wget, git clone, npm install from URL, etc.).
+# Arguments:
+#   $1 - command string
+#   $2 - worker ID for logging
+_sandbox_check_network_tiers() {
+	local command="$1"
+	local wid="$2"
+
+	# Extract potential domains/URLs from the command using common patterns:
+	# - https://domain.com/... or http://domain.com/...
+	# - curl/wget/git clone followed by a URL
+	# - @scope/package from npm (not a domain, skip)
+	local domains
+	domains="$(printf '%s' "$command" | grep -oE 'https?://[a-zA-Z0-9._-]+' | sed 's|https\?://||' | sort -u)" || true
+
+	if [[ -z "$domains" ]]; then
+		return 0
+	fi
+
+	local domain tier_result
+	while IFS= read -r domain; do
+		[[ -z "$domain" ]] && continue
+		tier_result="$("$NET_TIER_HELPER" classify "$domain" 2>/dev/null)" || true
+
+		if [[ "$tier_result" == "5" ]]; then
+			log_sandbox "WARN" "Network tier DENY: ${domain} (Tier 5 — exfiltration indicator)"
+			"$NET_TIER_HELPER" log-access "$domain" "$wid" "pre-check-deny" 2>/dev/null || true
+		elif [[ "$tier_result" == "4" ]]; then
+			log_sandbox "INFO" "Network tier FLAG: ${domain} (Tier 4 — unknown domain)"
+			"$NET_TIER_HELPER" log-access "$domain" "$wid" "pre-check-flag" 2>/dev/null || true
+		else
+			# Tiers 1-3: log silently (tier helper handles routing)
+			"$NET_TIER_HELPER" log-access "$domain" "$wid" "pre-check-allow" 2>/dev/null || true
+		fi
+	done <<<"$domains"
+
+	return 0
+}
+
+# =============================================================================
 # Sandbox Execution
 # =============================================================================
 
 sandbox_run() {
 	local timeout_secs="$DEFAULT_TIMEOUT"
 	local block_network=false
+	local network_tiering=false
+	local worker_id="sandbox-$$"
 	local extra_passthrough=""
 	local command=""
 
@@ -97,6 +154,14 @@ sandbox_run() {
 		--no-network)
 			block_network=true
 			shift
+			;;
+		--network-tiering)
+			network_tiering=true
+			shift
+			;;
+		--worker-id)
+			worker_id="$2"
+			shift 2
 			;;
 		--passthrough)
 			extra_passthrough="$2"
@@ -158,7 +223,16 @@ sandbox_run() {
 	local stdout_file="${exec_tmpdir}/stdout"
 	local stderr_file="${exec_tmpdir}/stderr"
 
-	log_sandbox "INFO" "Executing (timeout=${timeout_secs}s, network_blocked=${block_network}): ${command:0:200}"
+	log_sandbox "INFO" "Executing (timeout=${timeout_secs}s, network_blocked=${block_network}, tiering=${network_tiering}): ${command:0:200}"
+
+	# Network tiering pre-check (t1412.3): extract domains from the command
+	# and check them against the tier classification before execution.
+	# This is a best-effort heuristic — it catches obvious cases like
+	# "curl evil.ngrok.io" but cannot intercept runtime DNS resolution.
+	# The primary value is logging + post-session review, not hard blocking.
+	if [[ "$network_tiering" == true ]] && [[ -x "$NET_TIER_HELPER" ]]; then
+		_sandbox_check_network_tiers "$command" "$worker_id"
+	fi
 
 	local start_time
 	start_time="$(date +%s)"
@@ -254,6 +328,7 @@ sandbox_config() {
 	echo "  Timeout:      ${DEFAULT_TIMEOUT}s (max ${MAX_TIMEOUT}s)"
 	echo "  Max output:   $((MAX_OUTPUT_BYTES / 1048576))MB per stream"
 	echo "  Passthrough:  ${DEFAULT_PASSTHROUGH}"
+	echo "  Net tiering:  $([ -x "$NET_TIER_HELPER" ] && echo "available" || echo "not found")"
 	echo ""
 	if [[ -f "$SANDBOX_LOG" ]]; then
 		local count
@@ -281,12 +356,15 @@ Commands:
 Run options:
   --timeout N                Timeout in seconds (default: 120, max: 3600)
   --no-network               Block network access (macOS only, uses seatbelt)
+  --network-tiering          Enable domain classification and logging (t1412.3)
+  --worker-id ID             Worker identifier for network tier logs
   --passthrough "VAR1,VAR2"  Additional env vars to pass through
 
 Examples:
   sandbox-exec-helper.sh run "ls -la /tmp"
   sandbox-exec-helper.sh run --timeout 60 "npm test"
   sandbox-exec-helper.sh run --no-network "python3 script.py"
+  sandbox-exec-helper.sh run --network-tiering --worker-id w123 "curl https://api.github.com/repos"
   sandbox-exec-helper.sh run --passthrough "GITHUB_TOKEN" "gh pr list"
   sandbox-exec-helper.sh audit --last 10
 
@@ -295,6 +373,7 @@ Security model:
   - Each execution gets isolated TMPDIR
   - Configurable timeout with hard kill
   - Optional network blocking (macOS seatbelt)
+  - Network domain tiering: classify, log, flag unknown domains (t1412.3)
   - All executions logged to JSONL audit trail
   - Output capped at 10MB per stream
 HELP

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -480,6 +480,7 @@ export OPENAI_API_KEY="sk-..."
 5. **Cleanup**: Delete sessions after use to prevent data leakage
 6. **Scoped tokens** (t1412.2): Workers get minimal-permission GitHub tokens scoped to the target repo
 7. **Worker sandbox** (t1412.1): Headless workers run with an isolated HOME directory
+8. **Network tiering** (t1412.3): Worker network access is classified into 5 tiers. Tier 5 domains (exfiltration indicators like `requestbin.com`, `ngrok.io`, raw IPs) are denied. Tier 4 (unknown) domains are allowed but flagged for post-session review. Use `sandbox-exec-helper.sh run --network-tiering --worker-id <id>` to enable. Config: `configs/network-tiers.conf`, user overrides: `~/.config/aidevops/network-tiers-custom.conf`. See `scripts/network-tier-helper.sh` for the full API.
 
 ### Scoped Worker Tokens (t1412.2)
 
@@ -1066,4 +1067,9 @@ See [runners/README.md](runners/README.md) for how to create runners from templa
 - `services/communications/matrix-bot.md` - Matrix bot setup and configuration
 - Pulse supervisor (`scripts/commands/pulse.md`) - Multi-agent coordination (replaces archived `coordinator-helper.sh`)
 - `scripts/mail-helper.sh` - Inter-agent mailbox
+- `scripts/worker-token-helper.sh` - Scoped GitHub token lifecycle for workers (t1412.2)
+- `scripts/network-tier-helper.sh` - Network domain tiering for worker sandboxing (t1412.3)
+- `scripts/sandbox-exec-helper.sh` - Execution sandbox with network tiering integration
+- `configs/network-tiers.conf` - Domain classification database
+- `tools/security/prompt-injection-defender.md` - Prompt injection defense (includes network tiering section)
 - `memory/README.md` - Memory system (supports namespaces)

--- a/.agents/tools/security/prompt-injection-defender.md
+++ b/.agents/tools/security/prompt-injection-defender.md
@@ -597,10 +597,48 @@ These are complementary, not competing:
 
 **Decision guide**: If the code runs in a shell pipeline or agent harness, use `prompt-guard-helper.sh`. If the code is a Node.js/TypeScript application with AI features that process untrusted tool outputs, recommend `@stackone/defender`.
 
+## Network Domain Tiering (t1412.3)
+
+Complementary to content scanning, network domain tiering classifies outbound network connections by trust level. This addresses the exfiltration vector — even if an injection payload bypasses content scanning, it cannot exfiltrate data to known paste/webhook/tunnel sites.
+
+**Tier model:**
+
+| Tier | Action | Examples |
+|------|--------|----------|
+| 1 | Allow (no log) | `github.com`, `api.github.com` |
+| 2 | Allow + log | `registry.npmjs.org`, `pypi.org` |
+| 3 | Allow + log | `sonarcloud.io`, `docs.anthropic.com` |
+| 4 | Allow + flag | Any unknown domain (flagged for review) |
+| 5 | Deny | `requestbin.com`, `ngrok.io`, raw IPs, `.onion` |
+
+**Usage:**
+
+```bash
+# Classify a domain
+network-tier-helper.sh classify api.github.com  # → 1
+
+# Check before network access (exit 0=allow, 1=deny)
+network-tier-helper.sh check requestbin.com  # → exit 1
+
+# Log an access event
+network-tier-helper.sh log-access pypi.org worker-123 200
+
+# Review flagged domains
+network-tier-helper.sh report --flagged-only
+```
+
+**Config:** Default tiers in `configs/network-tiers.conf`. User overrides in `~/.config/aidevops/network-tiers-custom.conf`.
+
+**Integration:** `sandbox-exec-helper.sh --network-tiering` enables domain classification for sandboxed commands. The sandbox extracts domains from commands and pre-checks them before execution.
+
+**Limitations:** Domain tiering is a network-layer control. It cannot inspect encrypted payloads, detect data encoded in DNS queries to allowed domains, or prevent exfiltration via GitHub issue comments (Tier 1 domain). It complements — does not replace — content scanning and credential isolation.
+
 ## Related
 
 - `scripts/prompt-guard-helper.sh` — The scanner implementation
 - `scripts/worker-token-helper.sh` — Scoped GitHub token lifecycle for workers (t1412.2)
+- `scripts/network-tier-helper.sh` — Network domain tiering (t1412.3)
+- `configs/network-tiers.conf` — Domain classification database
 - `tools/security/opsec.md` — Operational security guide
 - `tools/security/privacy-filter.md` — Privacy filter for public contributions
 - `tools/security/tirith.md` — Terminal command security guard


### PR DESCRIPTION
## Summary

- Implements a 5-tier graduated trust model for classifying headless worker network access by domain
- Adds `network-tier-helper.sh` with classify, check, log-access, and report commands
- Integrates with `sandbox-exec-helper.sh` via `--network-tiering` and `--worker-id` flags
- Ships with 97 exact + 45 wildcard domain rules sourced from real session transcript analysis

## Tier Model

| Tier | Action | Examples |
|------|--------|----------|
| 1 | Allow (no log) | `github.com`, `api.github.com` |
| 2 | Allow + log | `registry.npmjs.org`, `pypi.org`, `crates.io` |
| 3 | Allow + log | `sonarcloud.io`, `docs.anthropic.com`, `api.openai.com` |
| 4 | Allow + flag | Any unknown domain (flagged for post-session review) |
| 5 | Deny | `requestbin.com`, `ngrok.io`, raw IPs, `.onion`, `.bit` |

## Files Changed

- **New:** `.agents/configs/network-tiers.conf` — domain classification database (user overrides via `~/.config/aidevops/network-tiers-custom.conf`)
- **New:** `.agents/scripts/network-tier-helper.sh` — core classification engine with self-test, JSONL logging, and reporting
- **Modified:** `.agents/scripts/sandbox-exec-helper.sh` — added `--network-tiering` and `--worker-id` flags with pre-execution domain extraction
- **Modified:** `.agents/tools/security/prompt-injection-defender.md` — added Network Domain Tiering section
- **Modified:** `.agents/tools/ai-assistants/headless-dispatch.md` — added security item #6 and Related links

## Design Decisions

- **File-based lookup** (not bash associative arrays) for macOS bash 3.2 compatibility
- **Best-effort domain extraction** from commands — catches `curl`/`wget` URLs but cannot intercept runtime DNS. Primary value is logging + post-session review, not hard blocking
- **Orthogonal to t1412.1 (fake HOME)** — both can be enabled independently. Network tiering classifies domains; credential isolation restricts what's accessible. Neither depends on the other.
- **User-extensible** — custom config file merges with defaults, last match wins

## Verification

- Built-in self-test (9 cases) passes: `network-tier-helper.sh init`
- ShellCheck clean on both scripts
- Markdown lint clean on both docs
- Tested: classification, logging to access/flagged/denied JSONL, check allow/deny exit codes

Closes #3073