### PR TITLE
t1412.11: Per-repo security posture in aidevops init

### DIFF
--- a/.agents/scripts/security-posture-helper.sh
+++ b/.agents/scripts/security-posture-helper.sh
@@ -1,0 +1,759 @@
+#!/usr/bin/env bash
+# security-posture-helper.sh — Per-repo security posture assessment
+#
+# Scans a repository for security baseline issues:
+#   1. GitHub Actions workflows for unsafe AI patterns
+#   2. Branch protection (requires PR reviews)
+#   3. Review-bot-gate as required status check
+#   4. Dependency scanning (Socket.dev / npm audit / pip-audit)
+#   5. Stores security posture in .aidevops.json
+#
+# Usage:
+#   security-posture-helper.sh check [repo-path]    # Run all checks, report findings
+#   security-posture-helper.sh audit [repo-path]     # Alias for check
+#   security-posture-helper.sh store [repo-path]     # Run checks and store in .aidevops.json
+#   security-posture-helper.sh summary [repo-path]   # One-line summary for greeting
+#   security-posture-helper.sh help                  # Show usage
+#
+# Exit codes:
+#   0 — All checks passed (or findings stored successfully)
+#   1 — Findings detected (non-zero issues)
+#   2 — Error (missing args, tool failure)
+#
+# t1412.11: https://github.com/marcusquinn/aidevops/issues/3087
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Counters
+FINDINGS_CRITICAL=0
+FINDINGS_WARNING=0
+FINDINGS_INFO=0
+FINDINGS_PASS=0
+
+# Collected findings for JSON output
+FINDINGS_JSON="[]"
+
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_pass() {
+	echo -e "${GREEN}[PASS]${NC} $1"
+	((FINDINGS_PASS++)) || true
+}
+print_warn() {
+	echo -e "${YELLOW}[WARN]${NC} $1"
+	((FINDINGS_WARNING++)) || true
+}
+print_crit() {
+	echo -e "${RED}[CRIT]${NC} $1"
+	((FINDINGS_CRITICAL++)) || true
+}
+print_skip() {
+	echo -e "${CYAN}[SKIP]${NC} $1"
+	((FINDINGS_INFO++)) || true
+}
+print_header() { echo -e "\n${BOLD}${CYAN}$1${NC}"; }
+
+# Add a finding to the JSON array
+# Usage: add_finding <severity> <category> <message>
+add_finding() {
+	local severity="$1"
+	local category="$2"
+	local message="$3"
+
+	FINDINGS_JSON=$(echo "$FINDINGS_JSON" | jq \
+		--arg sev "$severity" \
+		--arg cat "$category" \
+		--arg msg "$message" \
+		'. += [{"severity": $sev, "category": $cat, "message": $msg}]')
+	return 0
+}
+
+# Resolve the GitHub slug for a repo path
+# Usage: resolve_slug <repo-path>
+resolve_slug() {
+	local repo_path="$1"
+	local remote_url
+	remote_url=$(git -C "$repo_path" remote get-url origin 2>/dev/null) || return 1
+	local slug
+	slug=$(echo "$remote_url" | sed 's|.*github\.com[:/]||;s|\.git$||')
+	if [[ -n "$slug" && "$slug" == *"/"* ]]; then
+		echo "$slug"
+		return 0
+	fi
+	return 1
+}
+
+# Phase 1: Scan .github/workflows/ for unsafe AI patterns
+# Checks for:
+#   - shell + credentials + untrusted input (injection risk)
+#   - allowed_non_write_users: "*" (overly permissive)
+#   - cached long-lived tokens
+check_workflow_security() {
+	local repo_path="$1"
+	local workflows_dir="$repo_path/.github/workflows"
+
+	print_header "Phase 1: GitHub Actions Workflow Security"
+
+	if [[ ! -d "$workflows_dir" ]]; then
+		print_skip "No .github/workflows/ directory found"
+		add_finding "info" "workflows" "No .github/workflows/ directory"
+		return 0
+	fi
+
+	local workflow_files
+	workflow_files=$(find "$workflows_dir" -name "*.yml" -o -name "*.yaml" 2>/dev/null)
+
+	if [[ -z "$workflow_files" ]]; then
+		print_skip "No workflow files found"
+		add_finding "info" "workflows" "No workflow YAML files found"
+		return 0
+	fi
+
+	local file_count
+	file_count=$(echo "$workflow_files" | wc -l | tr -d ' ')
+	print_info "Scanning $file_count workflow file(s)..."
+
+	local unsafe_found=false
+
+	while IFS= read -r wf; do
+		[[ -z "$wf" ]] && continue
+		local wf_name
+		wf_name=$(basename "$wf")
+
+		# Check 1: Shell commands using github.event context (injection vector)
+		# Pattern: run: ... ${{ github.event.issue.title }} or similar
+		if grep -qE '\$\{\{\s*github\.event\.(issue|pull_request|comment)\.' "$wf" 2>/dev/null; then
+			if grep -qE '^\s*run:' "$wf" 2>/dev/null; then
+				print_crit "$wf_name: Uses github.event context in shell run step (injection risk)"
+				add_finding "critical" "workflows" "$wf_name: github.event context in shell run step"
+				unsafe_found=true
+			fi
+		fi
+
+		# Check 2: Overly permissive allowed_non_write_users or permissions
+		if grep -qE 'allowed_non_write_users:\s*"\*"' "$wf" 2>/dev/null; then
+			print_crit "$wf_name: allowed_non_write_users set to wildcard '*'"
+			add_finding "critical" "workflows" "$wf_name: allowed_non_write_users wildcard"
+			unsafe_found=true
+		fi
+
+		# Check 3: Workflow uses pull_request_target with checkout of PR head
+		# This is the classic "pwn request" pattern
+		if grep -qE 'pull_request_target' "$wf" 2>/dev/null; then
+			if grep -qE 'ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.(ref|sha)' "$wf" 2>/dev/null; then
+				print_crit "$wf_name: pull_request_target with PR head checkout (pwn request risk)"
+				add_finding "critical" "workflows" "$wf_name: pull_request_target with PR head checkout"
+				unsafe_found=true
+			else
+				print_warn "$wf_name: Uses pull_request_target (review checkout refs carefully)"
+				add_finding "warning" "workflows" "$wf_name: uses pull_request_target"
+			fi
+		fi
+
+		# Check 4: Long-lived tokens cached or stored in artifacts
+		if grep -qE 'actions/cache.*token|save-state.*token|GITHUB_TOKEN.*>>.*GITHUB_ENV' "$wf" 2>/dev/null; then
+			print_warn "$wf_name: Possible token caching pattern detected"
+			add_finding "warning" "workflows" "$wf_name: possible token caching"
+		fi
+
+		# Check 5: Overly broad permissions
+		if grep -qE '^\s*permissions:\s*write-all' "$wf" 2>/dev/null; then
+			print_warn "$wf_name: Uses write-all permissions (prefer least-privilege)"
+			add_finding "warning" "workflows" "$wf_name: write-all permissions"
+		fi
+
+		# Check 6: Third-party actions pinned to branch instead of SHA
+		local unpinned_actions
+		unpinned_actions=$(grep -oE 'uses:\s+[a-zA-Z0-9_-]+/[a-zA-Z0-9_.-]+@(main|master|v[0-9]+)' "$wf" 2>/dev/null | head -5) || true
+		if [[ -n "$unpinned_actions" ]]; then
+			local unpinned_count
+			unpinned_count=$(echo "$unpinned_actions" | wc -l | tr -d ' ')
+			print_warn "$wf_name: $unpinned_count action(s) pinned to branch/tag instead of SHA"
+			add_finding "warning" "workflows" "$wf_name: $unpinned_count actions not SHA-pinned"
+		fi
+
+	done <<<"$workflow_files"
+
+	if [[ "$unsafe_found" == "false" ]]; then
+		print_pass "No critical workflow security issues found"
+		add_finding "pass" "workflows" "No critical issues"
+	fi
+
+	return 0
+}
+
+# Phase 2: Check branch protection
+check_branch_protection() {
+	local repo_path="$1"
+
+	print_header "Phase 2: Branch Protection"
+
+	# Need gh CLI and a GitHub remote
+	if ! command -v gh &>/dev/null; then
+		print_skip "GitHub CLI (gh) not installed — cannot check branch protection"
+		add_finding "info" "branch_protection" "gh CLI not available"
+		return 0
+	fi
+
+	local slug
+	if ! slug=$(resolve_slug "$repo_path"); then
+		print_skip "No GitHub remote — branch protection check skipped"
+		add_finding "info" "branch_protection" "No GitHub remote"
+		return 0
+	fi
+
+	# Detect default branch
+	local default_branch
+	default_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || true
+	if [[ -z "$default_branch" ]]; then
+		default_branch="main"
+	fi
+
+	# Query branch protection rules via gh API
+	local protection_json
+	protection_json=$(gh api "repos/$slug/branches/$default_branch/protection" 2>/dev/null) || true
+
+	if [[ -z "$protection_json" || "$protection_json" == *"Not Found"* || "$protection_json" == *"Branch not protected"* ]]; then
+		print_crit "Default branch '$default_branch' has NO branch protection"
+		add_finding "critical" "branch_protection" "No branch protection on $default_branch"
+		return 0
+	fi
+
+	# Check: require PR reviews
+	local required_reviews
+	required_reviews=$(echo "$protection_json" | jq -r '.required_pull_request_reviews.required_approving_review_count // 0' 2>/dev/null) || required_reviews="0"
+
+	if [[ "$required_reviews" -gt 0 ]]; then
+		print_pass "PR reviews required ($required_reviews approving review(s))"
+		add_finding "pass" "branch_protection" "PR reviews required: $required_reviews"
+	else
+		print_warn "PR reviews not required on $default_branch"
+		add_finding "warning" "branch_protection" "PR reviews not required"
+	fi
+
+	# Check: require status checks
+	local required_checks
+	required_checks=$(echo "$protection_json" | jq -r '.required_status_checks.contexts // [] | length' 2>/dev/null) || required_checks="0"
+
+	if [[ "$required_checks" -gt 0 ]]; then
+		print_pass "Required status checks configured ($required_checks check(s))"
+		add_finding "pass" "branch_protection" "Status checks configured: $required_checks"
+	else
+		print_warn "No required status checks on $default_branch"
+		add_finding "warning" "branch_protection" "No required status checks"
+	fi
+
+	# Check: enforce for admins
+	local enforce_admins
+	enforce_admins=$(echo "$protection_json" | jq -r '.enforce_admins.enabled // false' 2>/dev/null) || enforce_admins="false"
+
+	if [[ "$enforce_admins" == "true" ]]; then
+		print_pass "Branch protection enforced for admins"
+		add_finding "pass" "branch_protection" "Enforced for admins"
+	else
+		print_info "Branch protection not enforced for admins (common for solo repos)"
+		add_finding "info" "branch_protection" "Not enforced for admins"
+	fi
+
+	return 0
+}
+
+# Phase 3: Check review-bot-gate
+check_review_bot_gate() {
+	local repo_path="$1"
+
+	print_header "Phase 3: Review Bot Gate"
+
+	# Check if review-bot-gate workflow exists locally
+	local gate_workflow="$repo_path/.github/workflows/review-bot-gate.yml"
+	if [[ -f "$gate_workflow" ]]; then
+		print_pass "review-bot-gate.yml workflow present"
+		add_finding "pass" "review_bot_gate" "Workflow file present"
+	else
+		print_warn "No review-bot-gate.yml workflow — AI review bots may not be gated"
+		add_finding "warning" "review_bot_gate" "No review-bot-gate.yml workflow"
+		print_info "  Suggestion: Copy from aidevops repo or add review-bot-gate as required check"
+	fi
+
+	# Check if review-bot-gate is a required status check (via branch protection)
+	if ! command -v gh &>/dev/null; then
+		return 0
+	fi
+
+	local slug
+	if ! slug=$(resolve_slug "$repo_path"); then
+		return 0
+	fi
+
+	local default_branch
+	default_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || true
+	default_branch="${default_branch:-main}"
+
+	local check_contexts
+	check_contexts=$(gh api "repos/$slug/branches/$default_branch/protection/required_status_checks" 2>/dev/null | jq -r '.contexts[]? // empty' 2>/dev/null) || true
+
+	if echo "$check_contexts" | grep -q "review-bot-gate" 2>/dev/null; then
+		print_pass "review-bot-gate is a required status check"
+		add_finding "pass" "review_bot_gate" "Required status check configured"
+	else
+		if [[ -f "$gate_workflow" ]]; then
+			print_warn "review-bot-gate workflow exists but is not a required status check"
+			add_finding "warning" "review_bot_gate" "Not configured as required status check"
+			print_info "  Add 'review-bot-gate' to branch protection required checks"
+		fi
+	fi
+
+	return 0
+}
+
+# Phase 4: Dependency scanning
+check_dependencies() {
+	local repo_path="$1"
+
+	print_header "Phase 4: Dependency Security"
+
+	local has_deps=false
+
+	# Check for package.json (npm/Node.js)
+	if [[ -f "$repo_path/package.json" ]]; then
+		has_deps=true
+		print_info "Found package.json — checking npm dependencies..."
+
+		# Try npm audit first (most common)
+		if command -v npm &>/dev/null && [[ -f "$repo_path/package-lock.json" ]]; then
+			local audit_output
+			audit_output=$(npm audit --json --prefix "$repo_path" 2>/dev/null) || true
+
+			if [[ -n "$audit_output" ]]; then
+				local vuln_total
+				vuln_total=$(echo "$audit_output" | jq -r '.metadata.vulnerabilities.total // 0' 2>/dev/null) || vuln_total="0"
+				local vuln_critical
+				vuln_critical=$(echo "$audit_output" | jq -r '.metadata.vulnerabilities.critical // 0' 2>/dev/null) || vuln_critical="0"
+				local vuln_high
+				vuln_high=$(echo "$audit_output" | jq -r '.metadata.vulnerabilities.high // 0' 2>/dev/null) || vuln_high="0"
+
+				if [[ "$vuln_critical" -gt 0 ]]; then
+					print_crit "npm audit: $vuln_critical critical, $vuln_high high ($vuln_total total vulnerabilities)"
+					add_finding "critical" "dependencies" "npm: $vuln_critical critical, $vuln_high high vulnerabilities"
+				elif [[ "$vuln_high" -gt 0 ]]; then
+					print_warn "npm audit: $vuln_high high ($vuln_total total vulnerabilities)"
+					add_finding "warning" "dependencies" "npm: $vuln_high high vulnerabilities"
+				elif [[ "$vuln_total" -gt 0 ]]; then
+					print_info "npm audit: $vuln_total low/moderate vulnerabilities"
+					add_finding "info" "dependencies" "npm: $vuln_total low/moderate vulnerabilities"
+				else
+					print_pass "npm audit: no known vulnerabilities"
+					add_finding "pass" "dependencies" "npm: clean audit"
+				fi
+			else
+				print_skip "npm audit returned no output"
+			fi
+		elif [[ ! -f "$repo_path/package-lock.json" ]]; then
+			print_warn "package.json exists but no package-lock.json — cannot run npm audit"
+			add_finding "warning" "dependencies" "Missing package-lock.json"
+		fi
+	fi
+
+	# Check for requirements.txt or pyproject.toml (Python)
+	if [[ -f "$repo_path/requirements.txt" ]] || [[ -f "$repo_path/pyproject.toml" ]]; then
+		has_deps=true
+		print_info "Found Python project — checking dependencies..."
+
+		if command -v pip-audit &>/dev/null; then
+			local pip_output
+			pip_output=$(pip-audit --requirement "$repo_path/requirements.txt" --format json 2>/dev/null) || true
+
+			if [[ -n "$pip_output" ]]; then
+				local pip_vulns
+				pip_vulns=$(echo "$pip_output" | jq 'length' 2>/dev/null) || pip_vulns="0"
+
+				if [[ "$pip_vulns" -gt 0 ]]; then
+					print_warn "pip-audit: $pip_vulns vulnerable package(s)"
+					add_finding "warning" "dependencies" "pip: $pip_vulns vulnerable packages"
+				else
+					print_pass "pip-audit: no known vulnerabilities"
+					add_finding "pass" "dependencies" "pip: clean audit"
+				fi
+			fi
+		else
+			print_skip "pip-audit not installed — install with: pip install pip-audit"
+			add_finding "info" "dependencies" "pip-audit not available"
+		fi
+	fi
+
+	# Check for Cargo.toml (Rust)
+	if [[ -f "$repo_path/Cargo.toml" ]]; then
+		has_deps=true
+		if command -v cargo-audit &>/dev/null; then
+			print_info "Found Cargo.toml — running cargo audit..."
+			local cargo_output
+			cargo_output=$(cargo audit --json 2>/dev/null) || true
+			if [[ -n "$cargo_output" ]]; then
+				local cargo_vulns
+				cargo_vulns=$(echo "$cargo_output" | jq '.vulnerabilities.found // 0' 2>/dev/null) || cargo_vulns="0"
+				if [[ "$cargo_vulns" -gt 0 ]]; then
+					print_warn "cargo audit: $cargo_vulns vulnerability(ies)"
+					add_finding "warning" "dependencies" "cargo: $cargo_vulns vulnerabilities"
+				else
+					print_pass "cargo audit: no known vulnerabilities"
+					add_finding "pass" "dependencies" "cargo: clean audit"
+				fi
+			fi
+		else
+			print_skip "cargo-audit not installed — install with: cargo install cargo-audit"
+			add_finding "info" "dependencies" "cargo-audit not available"
+		fi
+	fi
+
+	if [[ "$has_deps" == "false" ]]; then
+		print_skip "No dependency manifests found (package.json, requirements.txt, Cargo.toml)"
+		add_finding "info" "dependencies" "No dependency manifests found"
+	fi
+
+	return 0
+}
+
+# Phase 5: Check collaborators (per-repo, never cached globally)
+check_collaborators() {
+	local repo_path="$1"
+
+	print_header "Phase 5: Collaborator Access"
+
+	if ! command -v gh &>/dev/null; then
+		print_skip "GitHub CLI (gh) not installed"
+		add_finding "info" "collaborators" "gh CLI not available"
+		return 0
+	fi
+
+	local slug
+	if ! slug=$(resolve_slug "$repo_path"); then
+		print_skip "No GitHub remote"
+		add_finding "info" "collaborators" "No GitHub remote"
+		return 0
+	fi
+
+	# Per-repo collaborator check — never use a global cache
+	local collab_json
+	collab_json=$(gh api "repos/$slug/collaborators" --jq '.[] | {login: .login, role: .role_name}' 2>/dev/null) || true
+
+	if [[ -z "$collab_json" ]]; then
+		print_skip "Cannot access collaborator list (may require admin permissions)"
+		add_finding "info" "collaborators" "Cannot access collaborator list"
+		return 0
+	fi
+
+	local admin_count
+	admin_count=$(echo "$collab_json" | jq -s '[.[] | select(.role == "admin")] | length' 2>/dev/null) || admin_count="0"
+	local write_count
+	write_count=$(echo "$collab_json" | jq -s '[.[] | select(.role == "write" or .role == "maintain")] | length' 2>/dev/null) || write_count="0"
+	local total_count
+	total_count=$(echo "$collab_json" | jq -s 'length' 2>/dev/null) || total_count="0"
+
+	print_info "Collaborators: $total_count total ($admin_count admin, $write_count write)"
+	add_finding "info" "collaborators" "$total_count collaborators ($admin_count admin, $write_count write)"
+
+	if [[ "$admin_count" -gt 5 ]]; then
+		print_warn "High number of admin collaborators ($admin_count) — review access levels"
+		add_finding "warning" "collaborators" "High admin count: $admin_count"
+	else
+		print_pass "Admin collaborator count is reasonable ($admin_count)"
+		add_finding "pass" "collaborators" "Admin count OK: $admin_count"
+	fi
+
+	return 0
+}
+
+# Phase 6: General repo security checks
+check_repo_security() {
+	local repo_path="$1"
+
+	print_header "Phase 6: Repository Security"
+
+	# Check for SECURITY.md
+	if [[ -f "$repo_path/SECURITY.md" ]]; then
+		print_pass "SECURITY.md present"
+		add_finding "pass" "repo_security" "SECURITY.md present"
+	else
+		print_warn "No SECURITY.md — add a security policy for vulnerability reporting"
+		add_finding "warning" "repo_security" "Missing SECURITY.md"
+	fi
+
+	# Check for .gitignore with common secret patterns
+	if [[ -f "$repo_path/.gitignore" ]]; then
+		local missing_patterns=()
+		for pattern in ".env" "*.pem" "*.key" "credentials.json"; do
+			if ! grep -qF "$pattern" "$repo_path/.gitignore" 2>/dev/null; then
+				missing_patterns+=("$pattern")
+			fi
+		done
+
+		if [[ ${#missing_patterns[@]} -gt 0 ]]; then
+			print_warn ".gitignore missing common secret patterns: ${missing_patterns[*]}"
+			add_finding "warning" "repo_security" "gitignore missing: ${missing_patterns[*]}"
+		else
+			print_pass ".gitignore covers common secret file patterns"
+			add_finding "pass" "repo_security" "gitignore covers secret patterns"
+		fi
+	else
+		print_warn "No .gitignore file"
+		add_finding "warning" "repo_security" "No .gitignore"
+	fi
+
+	# Check for committed secrets (quick scan of tracked files)
+	local secret_files
+	secret_files=$(git -C "$repo_path" ls-files '*.env' '*.pem' '*.key' 'credentials.json' '.env.*' 2>/dev/null) || true
+
+	if [[ -n "$secret_files" ]]; then
+		local secret_count
+		secret_count=$(echo "$secret_files" | wc -l | tr -d ' ')
+		print_crit "$secret_count potential secret file(s) tracked by git"
+		add_finding "critical" "repo_security" "$secret_count secret files tracked: $(echo "$secret_files" | head -3 | tr '\n' ', ')"
+	else
+		print_pass "No obvious secret files tracked by git"
+		add_finding "pass" "repo_security" "No secret files tracked"
+	fi
+
+	# Check for Dependabot or Renovate config
+	if [[ -f "$repo_path/.github/dependabot.yml" ]] || [[ -f "$repo_path/.github/dependabot.yaml" ]]; then
+		print_pass "Dependabot configured"
+		add_finding "pass" "repo_security" "Dependabot configured"
+	elif [[ -f "$repo_path/renovate.json" ]] || [[ -f "$repo_path/.github/renovate.json" ]] || [[ -f "$repo_path/renovate.json5" ]]; then
+		print_pass "Renovate configured"
+		add_finding "pass" "repo_security" "Renovate configured"
+	else
+		print_warn "No automated dependency update tool (Dependabot/Renovate)"
+		add_finding "warning" "repo_security" "No dependency update automation"
+	fi
+
+	return 0
+}
+
+# Store security posture in .aidevops.json
+store_posture() {
+	local repo_path="$1"
+	local config_file="$repo_path/.aidevops.json"
+
+	if [[ ! -f "$config_file" ]]; then
+		print_info "No .aidevops.json found — skipping posture storage"
+		return 0
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		print_warn "jq not installed — cannot store posture in .aidevops.json"
+		return 0
+	fi
+
+	local timestamp
+	timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+	local total_findings
+	total_findings=$((FINDINGS_CRITICAL + FINDINGS_WARNING + FINDINGS_INFO + FINDINGS_PASS))
+
+	local posture_status="unknown"
+	if [[ "$FINDINGS_CRITICAL" -gt 0 ]]; then
+		posture_status="critical"
+	elif [[ "$FINDINGS_WARNING" -gt 0 ]]; then
+		posture_status="warning"
+	elif [[ "$total_findings" -gt 0 ]]; then
+		posture_status="good"
+	fi
+
+	local temp_file="${config_file}.tmp"
+	jq --arg status "$posture_status" \
+		--arg ts "$timestamp" \
+		--argjson critical "$FINDINGS_CRITICAL" \
+		--argjson warnings "$FINDINGS_WARNING" \
+		--argjson passed "$FINDINGS_PASS" \
+		--argjson findings "$FINDINGS_JSON" \
+		'.security_posture = {
+			"status": $status,
+			"last_audit": $ts,
+			"critical": $critical,
+			"warnings": $warnings,
+			"passed": $passed,
+			"findings": $findings
+		}' "$config_file" >"$temp_file" && mv "$temp_file" "$config_file"
+
+	print_info "Security posture stored in .aidevops.json (status: $posture_status)"
+	return 0
+}
+
+# Print summary (one-line for greeting)
+print_summary() {
+	local repo_path="$1"
+
+	# Try to read from stored posture first
+	local config_file="$repo_path/.aidevops.json"
+	if [[ -f "$config_file" ]] && command -v jq &>/dev/null; then
+		local stored_status
+		stored_status=$(jq -r '.security_posture.status // empty' "$config_file" 2>/dev/null) || true
+
+		if [[ -n "$stored_status" ]]; then
+			local stored_critical
+			stored_critical=$(jq -r '.security_posture.critical // 0' "$config_file" 2>/dev/null) || stored_critical="0"
+			local stored_warnings
+			stored_warnings=$(jq -r '.security_posture.warnings // 0' "$config_file" 2>/dev/null) || stored_warnings="0"
+			local stored_ts
+			stored_ts=$(jq -r '.security_posture.last_audit // "unknown"' "$config_file" 2>/dev/null) || stored_ts="unknown"
+
+			case "$stored_status" in
+			critical)
+				echo "Security: $stored_critical critical issue(s), $stored_warnings warning(s) — run \`aidevops security audit\` (last: $stored_ts)"
+				;;
+			warning)
+				echo "Security: $stored_warnings warning(s) — run \`aidevops security audit\` for details (last: $stored_ts)"
+				;;
+			good)
+				echo "Security: all checks passed (last: $stored_ts)"
+				;;
+			*)
+				echo "Security: run \`aidevops security audit\` for baseline assessment"
+				;;
+			esac
+			return 0
+		fi
+	fi
+
+	echo "Security: not yet audited — run \`aidevops security audit\`"
+	return 0
+}
+
+# Print final report
+print_report() {
+	echo ""
+	echo -e "${BOLD}═══════════════════════════════════════${NC}"
+	echo -e "${BOLD}  Security Posture Summary${NC}"
+	echo -e "${BOLD}═══════════════════════════════════════${NC}"
+	echo ""
+
+	if [[ "$FINDINGS_CRITICAL" -gt 0 ]]; then
+		echo -e "  ${RED}Critical:${NC}  $FINDINGS_CRITICAL"
+	fi
+	if [[ "$FINDINGS_WARNING" -gt 0 ]]; then
+		echo -e "  ${YELLOW}Warnings:${NC}  $FINDINGS_WARNING"
+	fi
+	echo -e "  ${GREEN}Passed:${NC}    $FINDINGS_PASS"
+	echo -e "  ${CYAN}Info/Skip:${NC} $FINDINGS_INFO"
+	echo ""
+
+	local total_issues=$((FINDINGS_CRITICAL + FINDINGS_WARNING))
+	if [[ "$total_issues" -eq 0 ]]; then
+		echo -e "  ${GREEN}${BOLD}Overall: GOOD${NC} — no critical or warning findings"
+	elif [[ "$FINDINGS_CRITICAL" -gt 0 ]]; then
+		echo -e "  ${RED}${BOLD}Overall: CRITICAL${NC} — $FINDINGS_CRITICAL critical issue(s) need attention"
+	else
+		echo -e "  ${YELLOW}${BOLD}Overall: WARNING${NC} — $FINDINGS_WARNING issue(s) to review"
+	fi
+	echo ""
+
+	return 0
+}
+
+# Run all checks
+run_all_checks() {
+	local repo_path="$1"
+
+	echo -e "${CYAN}"
+	echo "╔═══════════════════════════════════════════════════════════╗"
+	echo "║         Per-Repo Security Posture Assessment             ║"
+	echo "╚═══════════════════════════════════════════════════════════╝"
+	echo -e "${NC}"
+
+	print_info "Repository: $repo_path"
+
+	check_workflow_security "$repo_path"
+	check_branch_protection "$repo_path"
+	check_review_bot_gate "$repo_path"
+	check_dependencies "$repo_path"
+	check_collaborators "$repo_path"
+	check_repo_security "$repo_path"
+	print_report
+
+	return 0
+}
+
+# Print usage
+print_usage() {
+	cat <<EOF
+Usage: $(basename "$0") <command> [repo-path]
+
+Commands:
+  check [path]     Run all security posture checks (default: current dir)
+  audit [path]     Alias for check
+  store [path]     Run checks and store results in .aidevops.json
+  summary [path]   Print one-line summary (for session greeting)
+  help             Show this help message
+
+Examples:
+  $(basename "$0") check                    # Audit current repo
+  $(basename "$0") check ~/Git/myproject    # Audit specific repo
+  $(basename "$0") store                    # Audit and store in .aidevops.json
+  $(basename "$0") summary                  # One-line status for greeting
+
+Checks performed:
+  1. GitHub Actions workflows for unsafe AI patterns
+  2. Branch protection (PR reviews required)
+  3. Review-bot-gate as required status check
+  4. Dependency vulnerabilities (npm/pip/cargo audit)
+  5. Collaborator access levels (per-repo, never cached)
+  6. Repository security basics (SECURITY.md, .gitignore, secrets)
+
+Exit codes:
+  0 — All checks passed
+  1 — Findings detected
+  2 — Error
+EOF
+}
+
+# Main
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	local repo_path="${1:-.}"
+
+	# Resolve to git root if possible
+	if git -C "$repo_path" rev-parse --is-inside-work-tree &>/dev/null; then
+		repo_path=$(git -C "$repo_path" rev-parse --show-toplevel)
+	fi
+
+	case "$command" in
+	check | audit)
+		run_all_checks "$repo_path"
+		store_posture "$repo_path"
+		local exit_code=0
+		if [[ "$FINDINGS_CRITICAL" -gt 0 ]]; then
+			exit_code=1
+		fi
+		return "$exit_code"
+		;;
+	store)
+		run_all_checks "$repo_path"
+		store_posture "$repo_path"
+		return 0
+		;;
+	summary)
+		print_summary "$repo_path"
+		return 0
+		;;
+	help | --help | -h)
+		print_usage
+		return 0
+		;;
+	*)
+		echo "Unknown command: $command" >&2
+		print_usage >&2
+		return 2
+		;;
+	esac
+}
+
+main "$@"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1198,6 +1198,7 @@ cmd_init() {
 	local enable_database=false
 	local enable_beads=false
 	local enable_sops=false
+	local enable_security=false
 
 	case "$features" in
 	all)
@@ -1207,6 +1208,7 @@ cmd_init() {
 		enable_time_tracking=true
 		enable_database=true
 		enable_beads=true
+		enable_security=true
 		;;
 	planning)
 		enable_planning=true
@@ -1231,6 +1233,9 @@ cmd_init() {
 	sops)
 		enable_sops=true
 		;;
+	security)
+		enable_security=true
+		;;
 	*)
 		# Comma-separated list
 		IFS=',' read -ra FEATURE_LIST <<<"$features"
@@ -1249,6 +1254,7 @@ cmd_init() {
 				enable_planning=true
 				;;
 			sops) enable_sops=true ;;
+			security) enable_security=true ;;
 			esac
 		done
 		;;
@@ -1270,7 +1276,8 @@ cmd_init() {
     "code_quality": $enable_code_quality,
     "time_tracking": $enable_time_tracking,
     "database": $enable_database,
-    "beads": $enable_beads
+    "beads": $enable_beads,
+    "security": $enable_security
   },
   "time_tracking": {
     "enabled": $enable_time_tracking,
@@ -1749,6 +1756,21 @@ SOPSEOF
 		print_info "MODELS.md skipped (sqlite3 or generate script not available)"
 	fi
 
+	# Run security posture assessment if enabled (t1412.11)
+	if [[ "$enable_security" == "true" ]]; then
+		local security_posture_script="$AGENTS_DIR/scripts/security-posture-helper.sh"
+		if [[ -f "$security_posture_script" ]]; then
+			print_info "Running security posture assessment..."
+			if bash "$security_posture_script" store "$project_root" 2>/dev/null; then
+				print_success "Security posture assessed and stored in .aidevops.json"
+			else
+				print_warning "Security posture assessment found issues (review with: aidevops security audit)"
+			fi
+		else
+			print_info "Security posture check skipped (security-posture-helper.sh not available)"
+		fi
+	fi
+
 	# Build features string for registration
 	local features_list=""
 	[[ "$enable_planning" == "true" ]] && features_list="${features_list}planning,"
@@ -1758,6 +1780,7 @@ SOPSEOF
 	[[ "$enable_database" == "true" ]] && features_list="${features_list}database,"
 	[[ "$enable_beads" == "true" ]] && features_list="${features_list}beads,"
 	[[ "$enable_sops" == "true" ]] && features_list="${features_list}sops,"
+	[[ "$enable_security" == "true" ]] && features_list="${features_list}security,"
 	features_list="${features_list%,}" # Remove trailing comma
 
 	# Register repo in repos.json
@@ -1811,6 +1834,7 @@ SOPSEOF
 	[[ "$enable_database" == "true" ]] && echo "  ✓ Database (schemas/, migrations/, seeds/)"
 	[[ "$enable_beads" == "true" ]] && echo "  ✓ Beads (task graph visualization)"
 	[[ "$enable_sops" == "true" ]] && echo "  ✓ SOPS (encrypted config files with age backend)"
+	[[ "$enable_security" == "true" ]] && echo "  ✓ Security (per-repo posture assessment)"
 	[[ -f "$project_root/MODELS.md" ]] && echo "  ✓ MODELS.md (per-repo model performance leaderboard)"
 	echo ""
 	echo "Next steps:"
@@ -2229,6 +2253,14 @@ cmd_features() {
 	echo "                 - Patterns: *.secret.yaml, configs/*.enc.json"
 	echo "                 - See: .agents/tools/credentials/sops.md"
 	echo ""
+	echo "  security       Per-repo security posture assessment"
+	echo "                 - GitHub Actions workflow scanning (injection risks)"
+	echo "                 - Branch protection verification (PR reviews)"
+	echo "                 - Review-bot-gate status check"
+	echo "                 - Dependency vulnerability scanning (npm/pip/cargo)"
+	echo "                 - Collaborator access audit"
+	echo "                 - Re-run anytime: aidevops security audit"
+	echo ""
 	echo "Extensibility:"
 	echo ""
 	echo "  plugins        Third-party agent plugins (configured in .aidevops.json)"
@@ -2241,9 +2273,10 @@ cmd_features() {
 	echo "  aidevops init                    # Enable all features (except sops)"
 	echo "  aidevops init planning           # Enable only planning"
 	echo "  aidevops init sops               # Enable SOPS encryption"
+	echo "  aidevops init security           # Enable security posture checks"
 	echo "  aidevops init beads              # Enable beads (includes planning)"
 	echo "  aidevops init database           # Enable only database"
-	echo "  aidevops init planning,sops      # Enable multiple"
+	echo "  aidevops init planning,security  # Enable multiple"
 	echo ""
 }
 
@@ -3267,6 +3300,7 @@ cmd_help() {
 	echo "  repo-sync <cmd>    Daily git pull for repos in parent dirs (enable/disable/status/dirs)"
 	echo "  update-tools       Check for outdated tools (--update to auto-update)"
 	echo "  repos [cmd]        Manage registered projects (list/add/remove/clean)"
+	echo "  security <cmd>     Per-repo security posture (check/audit/summary)"
 	echo "  ip-check <cmd>     IP reputation checks (check/batch/report/providers)"
 	echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
 	echo "  config <cmd>       Feature toggles (list/get/set/reset/path/help)"
@@ -3289,6 +3323,11 @@ cmd_help() {
 	echo "  aidevops update-tools        # Check for outdated tools"
 	echo "  aidevops update-tools -u     # Update all outdated tools"
 	echo "  aidevops uninstall           # Remove aidevops"
+	echo ""
+	echo "Security:"
+	echo "  aidevops security check      # Run security posture assessment"
+	echo "  aidevops security audit      # Alias for check"
+	echo "  aidevops security summary    # One-line security status"
 	echo ""
 	echo "IP Reputation:"
 	echo "  aidevops ip-check check <ip> # Check IP reputation across providers"
@@ -3508,6 +3547,19 @@ main() {
 			bash "$pulse_session_helper" "$@"
 		else
 			print_error "pulse-session-helper.sh not found. Run: aidevops update"
+			exit 1
+		fi
+		;;
+	security)
+		shift
+		local security_posture_helper="$AGENTS_DIR/scripts/security-posture-helper.sh"
+		if [[ ! -f "$security_posture_helper" ]]; then
+			security_posture_helper="$INSTALL_DIR/.agents/scripts/security-posture-helper.sh"
+		fi
+		if [[ -f "$security_posture_helper" ]]; then
+			bash "$security_posture_helper" "$@"
+		else
+			print_error "security-posture-helper.sh not found. Run: aidevops update"
 			exit 1
 		fi
 		;;


### PR DESCRIPTION
## Summary

- Add `security-posture-helper.sh` with 6-phase per-repo security assessment (workflow scanning, branch protection, review-bot-gate, dependency audit, collaborator access, repo security basics)
- Integrate `security` as a new feature in `aidevops init` (enabled by default with `all`)
- Add `aidevops security audit/check/summary` CLI commands for on-demand re-assessment
- Store security posture results in `.aidevops.json` for session greeting integration

## Details

### New script: `.agents/scripts/security-posture-helper.sh`

Six assessment phases:

1. **GitHub Actions workflows** — scans for `github.event` context in shell steps (injection risk), `pull_request_target` with PR head checkout (pwn request), `write-all` permissions, unpinned third-party actions
2. **Branch protection** — checks default branch for required PR reviews, required status checks, admin enforcement
3. **Review-bot-gate** — verifies `review-bot-gate.yml` workflow exists and is configured as a required status check
4. **Dependency scanning** — runs `npm audit`, `pip-audit`, or `cargo-audit` depending on project type
5. **Collaborator access** — per-repo `gh api repos/{slug}/collaborators` check (never cached globally, per t1412 brief)
6. **Repository security** — checks for `SECURITY.md`, `.gitignore` secret patterns, tracked secret files, Dependabot/Renovate config

### Integration into `aidevops.sh`

- `security` feature flag in `cmd_init()` feature parsing
- `security` field added to `.aidevops.json` features object
- Security posture runs during init and stores results in `.aidevops.json`
- `aidevops security audit|check|summary` command routing in `main()`
- `cmd_features()` and `cmd_help()` updated with security documentation

### Verification

- ShellCheck clean on both modified files
- Smoke tested against the aidevops repo itself (found real issues: github.event injection in 2 workflows, no branch protection, 10+ unpinned actions)
- `help`, `check`, `summary` commands all produce correct output

Closes #3087