### PR TITLE
t3099: Fix github.event injection risks and pin all GitHub Actions to SHA

### DIFF
--- a/.github/workflows/auto-deploy-agents.yml
+++ b/.github/workflows/auto-deploy-agents.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
 
@@ -99,12 +99,15 @@ jobs:
           SCRIPTS_CHANGED: ${{ needs.detect-changes.outputs.scripts_changed }}
           CHANGED_COUNT: ${{ needs.detect-changes.outputs.changed_count }}
           CHANGED_FILES: ${{ needs.detect-changes.outputs.changed_files }}
+          COMMIT_SHA: ${{ github.sha }}
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.name }}
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           echo "## Agent Auto-Deploy Triggered" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Commit:** ${{ github.sha }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Author:** ${{ github.event.head_commit.author.name }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Message:** ${{ github.event.head_commit.message }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Commit:** ${COMMIT_SHA}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Author:** ${COMMIT_AUTHOR}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Message:** ${COMMIT_MESSAGE}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Changed Files ($CHANGED_COUNT)" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -146,7 +149,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install ShellCheck
         run: sudo apt-get install -y shellcheck

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Framework Structure Check
       run: |
@@ -138,7 +138,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0  # Shallow clones should be disabled for better analysis
 
@@ -149,8 +149,10 @@ jobs:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
     - name: Codacy Analysis
+      env:
+        CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
       run: |
-        if [[ -n "${{ secrets.CODACY_API_TOKEN }}" ]]; then
+        if [[ -n "$CODACY_API_TOKEN" ]]; then
           echo "🔍 Codacy Analysis Status..."
           echo "✅ Codacy API Token: Configured"
           echo "📊 Repository monitored at: https://app.codacy.com/gh/marcusquinn/aidevops"
@@ -163,11 +165,13 @@ jobs:
         fi
 
     - name: Quality Analysis Summary
+      env:
+        CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
       run: |
         echo "📊 Code Quality Analysis Summary"
         echo "================================"
         echo "✅ SonarCloud: Analysis completed"
-        if [[ -n "${{ secrets.CODACY_API_TOKEN }}" ]]; then
+        if [[ -n "$CODACY_API_TOKEN" ]]; then
           echo "✅ Codacy: Analysis completed"
         else
           echo "⚠️  Codacy: Skipped (token not configured)"

--- a/.github/workflows/code-review-monitoring.yml
+++ b/.github/workflows/code-review-monitoring.yml
@@ -27,13 +27,13 @@ jobs:
     
     steps:
     - name: 📥 Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
     
     - name: 🐍 Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.11'
     
@@ -97,7 +97,7 @@ jobs:
         echo "Generated on: $(date)" >> quality-report.md
     
     - name: 📤 Upload Quality Report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: quality-report
         path: quality-report.md
@@ -105,7 +105,7 @@ jobs:
     
     - name: 📤 Upload SARIF Results
       if: always() && hashFiles('codacy-results.sarif') != ''
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4
       with:
         sarif_file: codacy-results.sarif
         category: codacy
@@ -229,7 +229,7 @@ jobs:
     
     - name: 📝 Comment on PR
       if: github.event_name == 'pull_request'
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           const fs = require('fs');

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Checkout
         if: steps.check-author.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -166,7 +166,7 @@ jobs:
 
       - name: Checkout
         if: steps.check-issue.outputs.sync == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -179,22 +179,26 @@ jobs:
 
       - name: Sync issue ref to TODO.md
         if: steps.check-issue.outputs.sync == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TASK_ID: ${{ steps.check-issue.outputs.task_id }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           chmod +x .agents/scripts/issue-sync-helper.sh
           chmod +x .agents/scripts/shared-constants.sh
-          echo "=== New issue opened: ${{ steps.check-issue.outputs.task_id }} (#${{ github.event.issue.number }}) ==="
+          echo "=== New issue opened: ${TASK_ID} (#${ISSUE_NUMBER}) ==="
           bash .agents/scripts/issue-sync-helper.sh pull --verbose || true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit and push TODO.md updates
         if: steps.check-issue.outputs.sync == 'true'
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           if git diff --quiet TODO.md 2>/dev/null; then
             echo "No TODO.md changes to commit"
           else
             git add TODO.md
-            git commit -m "chore: sync ref:GH#${{ github.event.issue.number }} to TODO.md [skip ci]"
+            git commit -m "chore: sync ref:GH#${ISSUE_NUMBER} to TODO.md [skip ci]"
             for i in 1 2 3; do
               echo "Push attempt $i..."
               git pull --rebase origin main || true
@@ -222,7 +226,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -233,23 +237,25 @@ jobs:
           git config --global user.email "actions@github.com"
 
       - name: Run sync command
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SYNC_COMMAND: ${{ github.event.inputs.command }}
         run: |
           chmod +x .agents/scripts/issue-sync-helper.sh
           chmod +x .agents/scripts/shared-constants.sh
-          COMMAND="${{ github.event.inputs.command }}"
-          echo "=== Running: issue-sync-helper.sh $COMMAND ==="
-          bash .agents/scripts/issue-sync-helper.sh "$COMMAND" --verbose
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          echo "=== Running: issue-sync-helper.sh $SYNC_COMMAND ==="
+          bash .agents/scripts/issue-sync-helper.sh "$SYNC_COMMAND" --verbose
 
       - name: Commit and push TODO.md updates
         if: github.event.inputs.command == 'pull' || github.event.inputs.command == 'push'
+        env:
+          SYNC_COMMAND: ${{ github.event.inputs.command }}
         run: |
           if git diff --quiet TODO.md 2>/dev/null; then
             echo "No TODO.md changes to commit"
           else
             git add TODO.md
-            git commit -m "chore: manual issue sync (${{ github.event.inputs.command }}) [skip ci]"
+            git commit -m "chore: manual issue sync ($SYNC_COMMAND) [skip ci]"
             for i in 1 2 3; do
               git pull --rebase origin main || true
               if git push; then
@@ -396,7 +402,7 @@ jobs:
 
       - name: Checkout repo for TODO.md update
         if: steps.extract.outputs.task_id != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Validate trigger conditions
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const comment = context.payload.comment;
@@ -175,7 +175,7 @@ jobs:
     needs: security-check
     steps:
       - name: Log AI agent invocation
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const comment = context.payload.comment;
@@ -229,13 +229,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
           # Use default GITHUB_TOKEN, not a PAT with elevated permissions
       
       - name: Add processing indicator
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Handle both issue_comment and pull_request_review_comment events
@@ -260,7 +260,7 @@ jobs:
             }
       
       - name: Run OpenCode Agent
-        uses: sst/opencode/github@latest
+        uses: sst/opencode/github@0cf0294787322664c6d668fa5ab0a9ce26796f78 # latest
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -290,7 +290,7 @@ jobs:
       
       - name: Mark completion
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             // Handle both issue_comment and pull_request_review_comment events
@@ -323,5 +323,7 @@ jobs:
     if: needs.security-check.outputs.allowed == 'false'
     steps:
       - name: Log security block
+        env:
+          BLOCK_REASON: ${{ needs.security-check.outputs.reason }}
         run: |
-          echo "::warning::AI agent request blocked: ${{ needs.security-check.outputs.reason }}"
+          echo "::warning::AI agent request blocked: ${BLOCK_REASON}"

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -26,17 +26,21 @@ jobs:
     
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.inputs.tag || github.ref }}
         fetch-depth: 0
     
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
       with:
         bun-version: latest
     
     - name: Wait for CI/CD Pipelines
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        COMMIT_SHA: ${{ github.sha }}
       run: |
         echo "Waiting for all check runs to complete..."
         echo "Note: Excluding this workflow (Verify Release Health) to avoid circular dependency"
@@ -45,7 +49,7 @@ jobs:
         # Poll for completion, excluding this workflow to avoid circular dependency
         SELF_NAME="Verify Release Health"
         for i in {1..20}; do
-          PENDING=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs \
+          PENDING=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
             --jq "[.check_runs[] | select(.status != \"completed\" and .name != \"$SELF_NAME\")] | length")
           
           if [[ "$PENDING" == "0" ]]; then
@@ -55,22 +59,24 @@ jobs:
           
           # Show which workflows are still pending
           echo "Waiting for $PENDING check runs... (attempt $i/20)"
-          gh api repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs \
+          gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
             --jq ".check_runs[] | select(.status != \"completed\" and .name != \"$SELF_NAME\") | \"  - \(.name): \(.status)\"" || true
           sleep 30
         done
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Verify CI/CD Status
       id: cicd
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        COMMIT_SHA: ${{ github.sha }}
       run: |
         echo "## CI/CD Pipeline Status" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
         # Get all check runs, excluding self to avoid counting our own status
         SELF_NAME="Verify Release Health"
-        CHECK_RUNS=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs \
+        CHECK_RUNS=$(gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
           --jq ".check_runs[] | select(.name != \"$SELF_NAME\") | {name, status, conclusion}")
         
         # Count results (excluding self)
@@ -83,7 +89,7 @@ jobs:
         echo "|-------|--------|------------|" >> $GITHUB_STEP_SUMMARY
         
         # Show all check runs including self for transparency
-        gh api repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs \
+        gh api "repos/${REPO}/commits/${COMMIT_SHA}/check-runs" \
           --jq '.check_runs[] | "| \(.name) | \(.status) | \(.conclusion // "pending") |"' >> $GITHUB_STEP_SUMMARY
         
         echo "" >> $GITHUB_STEP_SUMMARY
@@ -127,8 +133,6 @@ jobs:
           echo "cicd_status=passed" >> $GITHUB_OUTPUT
         fi
         echo "CI/CD critical checks passed"
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Check SonarCloud Quality Gate
       if: always()
@@ -174,8 +178,8 @@ jobs:
         bun install -g snyk
         
         # Authenticate if token available
-        if [[ -n "${{ secrets.SNYK_TOKEN }}" ]]; then
-          snyk auth ${{ secrets.SNYK_TOKEN }}
+        if [[ -n "$SNYK_TOKEN" ]]; then
+          snyk auth "$SNYK_TOKEN"
           
           # Run security scan
           if snyk test --severity-threshold=high --json > snyk-results.json 2>/dev/null; then
@@ -223,6 +227,13 @@ jobs:
     - name: Generate Final Report
       id: report
       if: always()
+      env:
+        CICD_STATUS: ${{ steps.cicd.outputs.cicd_status }}
+        SONAR_STATUS: ${{ steps.sonarcloud.outputs.sonar_status }}
+        SNYK_STATUS: ${{ steps.snyk.outputs.snyk_status }}
+        SECRETS_STATUS: ${{ steps.secrets.outputs.secrets_status }}
+        RELEASE_TAG: ${{ github.event.release.tag_name || github.ref_name }}
+        COMMIT_SHA: ${{ github.sha }}
       run: |
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "---" >> $GITHUB_STEP_SUMMARY
@@ -230,16 +241,11 @@ jobs:
         echo "## Postflight Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         
-        CICD="${{ steps.cicd.outputs.cicd_status }}"
-        SONAR="${{ steps.sonarcloud.outputs.sonar_status }}"
-        SNYK="${{ steps.snyk.outputs.snyk_status }}"
-        SECRETS="${{ steps.secrets.outputs.secrets_status }}"
-        
         # Default unset outputs to 'skipped' (step didn't produce output)
-        CICD="${CICD:-skipped}"
-        SONAR="${SONAR:-skipped}"
-        SNYK="${SNYK:-skipped}"
-        SECRETS="${SECRETS:-skipped}"
+        CICD="${CICD_STATUS:-skipped}"
+        SONAR="${SONAR_STATUS:-skipped}"
+        SNYK="${SNYK_STATUS:-skipped}"
+        SECRETS="${SECRETS_STATUS:-skipped}"
         
         echo "| Check | Status |" >> $GITHUB_STEP_SUMMARY
         echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
@@ -248,8 +254,8 @@ jobs:
         echo "| Snyk Security | ${SNYK} |" >> $GITHUB_STEP_SUMMARY
         echo "| Secret Detection | ${SECRETS} |" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Release**: ${{ github.event.release.tag_name || github.ref_name }}" >> $GITHUB_STEP_SUMMARY
-        echo "**Commit**: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Release**: ${RELEASE_TAG}" >> $GITHUB_STEP_SUMMARY
+        echo "**Commit**: ${COMMIT_SHA}" >> $GITHUB_STEP_SUMMARY
         echo "**Time**: $(date -u)" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "*Generated by AI DevOps Framework Postflight Verification*" >> $GITHUB_STEP_SUMMARY
@@ -272,7 +278,7 @@ jobs:
         fi
         
         if [[ "$HAS_CRITICAL" == "true" ]]; then
-          echo "::error::Postflight verification failed for release ${{ github.event.release.tag_name || github.ref_name }}"
+          echo "::error::Postflight verification failed for release ${RELEASE_TAG}"
           echo ""
           echo "Recommended actions:"
           echo "1. Review the failed checks in the workflow summary"
@@ -280,8 +286,8 @@ jobs:
           echo "3. See: .agents/workflows/postflight.md#rollback-procedures"
           exit 1
         elif [[ "$HAS_WARNING" == "true" ]]; then
-          echo "::warning::Postflight completed with warnings for release ${{ github.event.release.tag_name || github.ref_name }}"
+          echo "::warning::Postflight completed with warnings for release ${RELEASE_TAG}"
           echo "Review advisory warnings above and address in next release if needed."
         else
-          echo "Postflight verification passed for release ${{ github.event.release.tag_name || github.ref_name }}"
+          echo "Postflight verification passed for release ${RELEASE_TAG}"
         fi

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -23,10 +23,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
@@ -79,7 +79,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       
       - name: Get version and SHA
         id: release

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -325,11 +325,14 @@ jobs:
 
       - name: Gate result
         if: steps.check.outputs.gate_passed != 'true' && steps.skip.outputs.skip != 'true'
+        env:
+          RATE_LIMITED_BOTS: ${{ steps.check.outputs.rate_limited_bots }}
+          MISSING_BOTS: ${{ steps.check.outputs.missing_bots }}
         run: |
-          if [[ -n "${{ steps.check.outputs.rate_limited_bots }}" ]]; then
+          if [[ -n "$RATE_LIMITED_BOTS" ]]; then
             echo "::error::Review bots posted rate-limit notices only — no real reviews or SUCCESS status checks."
             echo ""
-            echo "Rate-limited bots: ${{ steps.check.outputs.rate_limited_bots }}"
+            echo "Rate-limited bots: ${RATE_LIMITED_BOTS}"
             echo ""
             echo "The bots are rate-limited and did not perform actual code review."
             echo "No SUCCESS commit status checks were found as fallback."
@@ -346,51 +349,58 @@ jobs:
           echo "  2. This check re-runs automatically when a bot posts"
           echo "  3. If no bots are configured, add 'skip-review-gate' label"
           echo ""
-          echo "Missing bots: ${{ steps.check.outputs.missing_bots }}"
+          echo "Missing bots: ${MISSING_BOTS}"
           exit 1
 
       - name: Summary
         if: always()
+        env:
+          GATE_PASSED: ${{ steps.check.outputs.gate_passed }}
+          STATUS_FALLBACK: ${{ steps.check.outputs.status_fallback }}
+          FOUND_BOTS: ${{ steps.check.outputs.found_bots }}
+          MISSING_BOTS: ${{ steps.check.outputs.missing_bots }}
+          RATE_LIMITED_BOTS: ${{ steps.check.outputs.rate_limited_bots }}
+          SKIP_GATE: ${{ steps.skip.outputs.skip }}
         run: |
           {
             echo "## Review Bot Gate"
             echo ""
-            if [[ "${{ steps.check.outputs.gate_passed }}" == "true" && "${{ steps.check.outputs.status_fallback }}" == "true" ]]; then
+            if [[ "$GATE_PASSED" == "true" && "$STATUS_FALLBACK" == "true" ]]; then
               echo "**Status**: PASSED (status check fallback)"
               echo ""
               echo "Bots posted rate-limit notices but have SUCCESS commit status checks."
               echo "The bots completed their analysis — treating as reviewed. (GH#3005)"
               echo ""
-              echo "**Bots with SUCCESS status**: ${{ steps.check.outputs.found_bots }}"
-              if [[ -n "${{ steps.check.outputs.missing_bots }}" ]]; then
+              echo "**Bots with SUCCESS status**: ${FOUND_BOTS}"
+              if [[ -n "$MISSING_BOTS" ]]; then
                 echo ""
-                echo "**Bots not yet reviewed**: ${{ steps.check.outputs.missing_bots }}"
+                echo "**Bots not yet reviewed**: ${MISSING_BOTS}"
               fi
-            elif [[ "${{ steps.check.outputs.gate_passed }}" == "true" && -n "${{ steps.check.outputs.found_bots }}" ]]; then
+            elif [[ "$GATE_PASSED" == "true" && -n "$FOUND_BOTS" ]]; then
               echo "**Status**: PASSED"
               echo ""
-              echo "**Bots that reviewed**: ${{ steps.check.outputs.found_bots }}"
-              if [[ -n "${{ steps.check.outputs.rate_limited_bots }}" ]]; then
+              echo "**Bots that reviewed**: ${FOUND_BOTS}"
+              if [[ -n "$RATE_LIMITED_BOTS" ]]; then
                 echo ""
-                echo "**Bots rate-limited (not counted)**: ${{ steps.check.outputs.rate_limited_bots }}"
+                echo "**Bots rate-limited (not counted)**: ${RATE_LIMITED_BOTS}"
               fi
-              if [[ -n "${{ steps.check.outputs.missing_bots }}" ]]; then
+              if [[ -n "$MISSING_BOTS" ]]; then
                 echo ""
-                echo "**Bots not yet reviewed**: ${{ steps.check.outputs.missing_bots }}"
+                echo "**Bots not yet reviewed**: ${MISSING_BOTS}"
               fi
-            elif [[ "${{ steps.check.outputs.gate_passed }}" == "true" ]]; then
+            elif [[ "$GATE_PASSED" == "true" ]]; then
               echo "**Status**: PASSED (pending bot reviews)"
               echo ""
               echo "PR is too young to enforce the gate. Bots will re-trigger this"
               echo "check when they post their reviews."
-            elif [[ "${{ steps.skip.outputs.skip }}" == "true" ]]; then
+            elif [[ "$SKIP_GATE" == "true" ]]; then
               echo "**Status**: SKIPPED (skip-review-gate label)"
             else
               echo "**Status**: WAITING"
               echo ""
-              if [[ -n "${{ steps.check.outputs.rate_limited_bots }}" ]]; then
+              if [[ -n "$RATE_LIMITED_BOTS" ]]; then
                 echo "Bots posted rate-limit notices only (not real reviews):"
-                echo "${{ steps.check.outputs.rate_limited_bots }}"
+                echo "${RATE_LIMITED_BOTS}"
                 echo ""
               fi
               echo "No real AI review bot feedback yet. This check will re-run"

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure Git
         run: |
@@ -27,10 +27,16 @@ jobs:
           git config --global user.email "actions@github.com"
 
       - name: Clone wiki repository
+        env:
+          REPO: ${{ github.repository }}
         run: |
-          git clone https://github.com/${{ github.repository }}.wiki.git wiki
+          git clone "https://github.com/${REPO}.wiki.git" wiki
 
       - name: Sync wiki content
+        env:
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Remove all files from wiki repository except .git
           find wiki -mindepth 1 -maxdepth 1 -not -name '.git' -exec rm -rf {} \;
@@ -54,7 +60,7 @@ jobs:
           git commit -m "Sync wiki from source repository"
 
           # Retry loop to handle concurrent pushes (up to 3 attempts)
-          PUSH_URL="https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git"
+          PUSH_URL="https://${ACTOR}:${GH_TOKEN}@github.com/${REPO}.wiki.git"
           for i in 1 2 3; do
             echo "Push attempt $i..."
             git pull --rebase origin master || true

--- a/.github/workflows/update-website-docs.yml
+++ b/.github/workflows/update-website-docs.yml
@@ -19,10 +19,10 @@ jobs:
     
     steps:
       - name: Checkout aidevops repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
         with:
           bun-version: latest
 
@@ -200,13 +200,16 @@ jobs:
           FOOTER
 
       - name: Checkout website repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           repository: marcusquinn/aidevops.sh
           path: website
           token: ${{ secrets.WEBSITE_PAT }}
 
       - name: Update docs.html in website repo
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           cp docs.html website/docs.html
           cd website
@@ -224,8 +227,8 @@ jobs:
           git commit -m "docs: sync from aidevops README.md
 
           Auto-generated from marcusquinn/aidevops README.md
-          Triggered by: ${{ github.event_name }}
-          Source commit: ${{ github.sha }}"
+          Triggered by: ${EVENT_NAME}
+          Source commit: ${COMMIT_SHA}"
           
           # Retry loop to handle concurrent pushes (up to 3 attempts)
           for i in 1 2 3; do
@@ -243,9 +246,12 @@ jobs:
           exit 1
 
       - name: Summary
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           echo "## Docs Update Summary" >> $GITHUB_STEP_SUMMARY
           echo "- Source: \`marcusquinn/aidevops/README.md\`" >> $GITHUB_STEP_SUMMARY
           echo "- Target: \`marcusquinn/aidevops.sh/docs.html\`" >> $GITHUB_STEP_SUMMARY
-          echo "- Trigger: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "- Commit: ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Trigger: ${EVENT_NAME}" >> $GITHUB_STEP_SUMMARY
+          echo "- Commit: ${COMMIT_SHA}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/version-validation.yml
+++ b/.github/workflows/version-validation.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 

--- a/configs/mcp-templates/opencode-github-workflow.yml
+++ b/configs/mcp-templates/opencode-github-workflow.yml
@@ -36,12 +36,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run OpenCode
-        uses: sst/opencode/github@latest
+        uses: sst/opencode/github@0cf0294787322664c6d668fa5ab0a9ce26796f78 # latest
         env:
           # Use your preferred AI provider
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- **CRITICAL**: Fix shell injection vulnerabilities in 8 workflow files where `github.event.*` values were interpolated directly in `run:` steps via `${{ }}` expressions. All untrusted context values now pass through `env:` blocks before use in shell.
- **Security hardening**: Pin all third-party GitHub Actions across 12 files (11 workflows + 1 template) from mutable tags (`@v4`, `@v7`, `@latest`) to immutable full SHA commit hashes, preventing supply-chain attacks via tag mutation.
- **Consistency**: Also moved `github.sha`, `github.event_name`, `github.repository`, and `secrets.*` references from direct `${{ }}` interpolation in shell to `env:` vars for defense-in-depth.

## Injection Fixes (CRITICAL)

| File | Fixed expressions |
|------|-------------------|
| `issue-sync.yml` | `github.event.inputs.command`, `github.event.issue.number` |
| `review-bot-gate.yml` | `steps.check.outputs.*` in Gate result + Summary steps |
| `auto-deploy-agents.yml` | `github.event.head_commit.author.name`, `.message` |
| `opencode-agent.yml` | `needs.security-check.outputs.reason` |
| `postflight.yml` | `steps.*.outputs.*`, `github.event.release.tag_name`, `secrets.SNYK_TOKEN` |
| `code-quality.yml` | `secrets.CODACY_API_TOKEN` |
| `sync-wiki.yml` | `github.actor`, `secrets.GITHUB_TOKEN`, `github.repository` |
| `update-website-docs.yml` | `github.event_name`, `github.sha` |

## SHA Pinning

| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v4 | `34e1148` |
| `actions/github-script` | v7 | `f28e40c` |
| `actions/setup-node` | v4 | `49933ea` |
| `actions/setup-python` | v5 | `a26af69` |
| `actions/upload-artifact` | v4 | `ea165f8` |
| `github/codeql-action/upload-sarif` | v4 | `0d579ff` |
| `oven-sh/setup-bun` | v2 | `ecf28dd` |
| `sst/opencode/github` | latest | `0cf0294` |

Two actions were already SHA-pinned: `SonarSource/sonarqube-scan-action` and `dmnemec/copy_file_to_another_repo_action`.

## Verification

- All 11 YAML workflow files pass `yaml.safe_load()` validation
- Zero remaining `${{ }}` expressions in `run:` blocks (all moved to `env:`, `with:`, or `if:` where they're safe)
- Zero remaining tag-pinned actions (`@v*` or `@latest`)

Closes #3099