### PR TITLE
fix: replace shellcheck binary with wrapper to prevent memory explosions (GH#2915)

### DIFF
--- a/.agents/scripts/quality-fix.sh
+++ b/.agents/scripts/quality-fix.sh
@@ -218,7 +218,7 @@ validate_fixes() {
 	local validation_errors=0
 
 	while IFS= read -r -d '' file; do
-		if [[ -f "$file" ]] && ! shellcheck -x -P SCRIPTDIR "$file" >/dev/null 2>&1; then
+		if [[ -f "$file" ]] && ! shellcheck "$file" >/dev/null 2>&1; then
 			((validation_errors++))
 			print_warning "ShellCheck issues remain in $file"
 		fi

--- a/.agents/scripts/shellcheck-wrapper.sh
+++ b/.agents/scripts/shellcheck-wrapper.sh
@@ -48,9 +48,9 @@ _find_real_shellcheck() {
 		fi
 	done <<<"$PATH"
 
-	# Common locations
+	# Common locations (including .real suffix for binary-replacement installs)
 	local loc
-	for loc in /opt/homebrew/bin/shellcheck /usr/local/bin/shellcheck /usr/bin/shellcheck; do
+	for loc in /opt/homebrew/bin/shellcheck.real /opt/homebrew/bin/shellcheck /usr/local/bin/shellcheck.real /usr/local/bin/shellcheck /usr/bin/shellcheck; do
 		if [[ -x "$loc" ]]; then
 			local resolved
 			resolved="$(realpath "$loc" 2>/dev/null || readlink -f "$loc" 2>/dev/null || echo "$loc")"
@@ -99,7 +99,7 @@ main() {
 	local vmem_kb=$((vmem_mb * 1024))
 	ulimit -v "$vmem_kb" 2>/dev/null || true
 
-	exec "$real_shellcheck" "${filtered_args[@]}"
+	exec "$real_shellcheck" "${filtered_args[@]+"${filtered_args[@]}"}"
 }
 
 main "$@"

--- a/.opencode/tool/parallel-quality.ts
+++ b/.opencode/tool/parallel-quality.ts
@@ -43,7 +43,7 @@ function getSafeCommands(scriptDir: string, rootDir: string): SafeCommand[] {
     {
       name: "ShellCheck",
       key: "shellcheck",
-      args: ['bash', '-c', `find "${scriptDir}" -name "*.sh" -print0 | xargs -0 shellcheck 2>&1 | head -100`],
+      args: ['bash', '-c', `find "${scriptDir}" -name "*.sh" -print0 | xargs -0 -n 1 -P 4 timeout 30 shellcheck 2>&1 | head -100`],
       cwd: rootDir,
     },
     {

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -302,6 +302,79 @@ setup_shell_linting_tools() {
 	return 0
 }
 
+setup_shellcheck_wrapper() {
+	# Replace the real shellcheck binary with our wrapper script to prevent
+	# --external-sources from causing exponential memory growth (GH#2915).
+	# This intercepts ALL callers including compiled binaries (e.g., OpenCode)
+	# that invoke shellcheck by absolute path rather than via PATH.
+
+	local wrapper_src="${INSTALL_DIR:-.}/.agents/scripts/shellcheck-wrapper.sh"
+	if [[ ! -f "$wrapper_src" ]]; then
+		print_info "shellcheck-wrapper.sh not found — skipping binary replacement"
+		return 0
+	fi
+
+	# Find the real shellcheck binary
+	local sc_path
+	sc_path="$(command -v shellcheck 2>/dev/null || true)"
+	if [[ -z "$sc_path" ]]; then
+		print_info "shellcheck not installed — wrapper not needed yet"
+		return 0
+	fi
+
+	# Resolve symlinks to get the actual binary path
+	local sc_resolved
+	sc_resolved="$(realpath "$sc_path" 2>/dev/null || readlink -f "$sc_path" 2>/dev/null || echo "$sc_path")"
+
+	# Check if the binary is already our wrapper (idempotent)
+	if head -5 "$sc_resolved" 2>/dev/null | grep -q "shellcheck-wrapper" 2>/dev/null; then
+		# Already replaced — check that .real exists
+		local real_path="${sc_resolved}.real"
+		if [[ -x "$real_path" ]]; then
+			print_success "shellcheck wrapper already installed at $sc_resolved"
+		else
+			print_warning "shellcheck wrapper installed but .real binary missing at $real_path"
+			print_info "Reinstall shellcheck (brew reinstall shellcheck) then re-run setup"
+		fi
+		return 0
+	fi
+
+	# The binary at sc_resolved is the real shellcheck — replace it
+	local real_dest="${sc_resolved}.real"
+
+	print_info "Installing shellcheck wrapper at $sc_resolved"
+	print_info "  Real binary will be moved to $real_dest"
+
+	# Move real binary to .real suffix
+	if ! mv "$sc_resolved" "$real_dest" 2>/dev/null; then
+		# May need sudo (e.g., /usr/local/bin on some systems)
+		if ! sudo mv "$sc_resolved" "$real_dest" 2>/dev/null; then
+			print_warning "Cannot move shellcheck binary — insufficient permissions"
+			print_info "Run manually: sudo mv '$sc_resolved' '$real_dest'"
+			return 0
+		fi
+	fi
+
+	# Copy wrapper to the original path
+	if ! cp "$wrapper_src" "$sc_resolved" 2>/dev/null; then
+		if ! sudo cp "$wrapper_src" "$sc_resolved" 2>/dev/null; then
+			# Rollback
+			mv "$real_dest" "$sc_resolved" 2>/dev/null || sudo mv "$real_dest" "$sc_resolved" 2>/dev/null || true
+			print_warning "Cannot install wrapper — insufficient permissions"
+			return 0
+		fi
+	fi
+
+	# Ensure wrapper is executable
+	chmod +x "$sc_resolved" 2>/dev/null || sudo chmod +x "$sc_resolved" 2>/dev/null || true
+
+	print_success "shellcheck wrapper installed — --external-sources will be stripped"
+	print_info "  Real binary: $real_dest"
+	print_info "  Wrapper:     $sc_resolved"
+
+	return 0
+}
+
 setup_qlty_cli() {
 	print_info "Setting up Qlty CLI (multi-linter code quality)..."
 

--- a/setup.sh
+++ b/setup.sh
@@ -665,6 +665,7 @@ main() {
 		confirm_step "Setup Git CLIs (gh, glab, tea)" && setup_git_clis
 		confirm_step "Setup file discovery tools (fd, ripgrep, ripgrep-all)" && setup_file_discovery_tools
 		confirm_step "Setup shell linting tools (shellcheck, shfmt)" && setup_shell_linting_tools
+		setup_shellcheck_wrapper
 		confirm_step "Setup Qlty CLI (multi-linter code quality)" && setup_qlty_cli
 		confirm_step "Rosetta audit (Apple Silicon x86 migration)" && setup_rosetta_audit
 		confirm_step "Setup Worktrunk (git worktree management)" && setup_worktrunk


### PR DESCRIPTION
## Summary

Fixes the recurring shellcheck memory explosion that crashes macOS systems (64GB RAM exhausted). The `--external-sources` flag causes exponential memory growth via recursive source-following in codebases with many cross-sourcing shell scripts (400+ in aidevops).

**Root cause**: Compiled tools (OpenCode's Go binary) call `/opt/homebrew/bin/shellcheck` by absolute path with `--external-sources`, bypassing any PATH-based wrapper. Each process grows to 500MB-6GB within minutes. Multiple concurrent pulse workers spawn dozens simultaneously.

**Fix**: Binary replacement — `setup.sh` now moves the real shellcheck binary to `shellcheck.real` and copies our wrapper script to the original path. The wrapper strips `--external-sources` and enforces a 2GB memory limit via `ulimit`. This intercepts ALL callers including compiled binaries.

## Changes

- **`setup-modules/tool-install.sh`**: New `setup_shellcheck_wrapper()` function that replaces the shellcheck binary with our wrapper during setup (idempotent, handles permissions, rollback on failure)
- **`setup.sh`**: Calls `setup_shellcheck_wrapper()` unconditionally after `setup_shell_linting_tools`
- **`.agents/scripts/shellcheck-wrapper.sh`**: Added `.real` suffix to binary search paths; fixed `set -u` crash when args array is empty
- **`.agents/scripts/quality-fix.sh`**: Removed `-x -P SCRIPTDIR` flags from shellcheck invocation (the exact flags that caused GH#2915)
- **`.opencode/tool/parallel-quality.ts`**: Added per-file execution (`-n 1`), parallelism limit (`-P 4`), and 30s timeout to prevent unbounded shellcheck spawning

## Verification

- Manually applied binary replacement on production system — shellcheck processes now run at ~1MB RSS instead of 500MB-6GB
- All modified shell scripts pass shellcheck cleanly
- Fix is idempotent — re-running setup detects the wrapper and skips replacement
- Handles `brew upgrade shellcheck` by re-applying on next `setup.sh` run

Closes #2915