### PR TITLE
GH#3118: Fix command injection and error handling in dispatch.sh sandbox cleanup

### DIFF
--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -1032,7 +1032,11 @@ do_prompt_repeat() {
 		if [[ -x "$sandbox_helper" ]]; then
 			# shellcheck source=../worker-sandbox-helper.sh
 			source "$sandbox_helper"
-			sandbox_dir=$(create_worker_sandbox "$task_id") || sandbox_dir=""
+			# GH#3118: Log warning on failure for consistency with cmd_dispatch
+			sandbox_dir=$(create_worker_sandbox "$task_id") || {
+				log_warn "Failed to create worker sandbox for $task_id prompt-repeat — proceeding without isolation (t1412.1)"
+				sandbox_dir=""
+			}
 			if [[ -n "$sandbox_dir" ]]; then
 				sandbox_env_lines=$(generate_sandbox_env "$sandbox_dir") || sandbox_env_lines=""
 				log_info "Worker sandbox created for $task_id prompt-repeat: $sandbox_dir (t1412.1)"
@@ -1119,11 +1123,14 @@ do_prompt_repeat() {
 		echo "  echo \"WORKER_DISPATCH_ERROR: prompt-repeat script exited with code \${rc}\" >> '${new_log_file}'"
 		echo "fi"
 		# t1412.1: Clean up sandbox HOME directory after worker exits
+		# GH#3118: Use printf %q to prevent command injection from sandbox_dir
+		# containing shell metacharacters. Remove 2>/dev/null to preserve error
+		# visibility — || true is sufficient to prevent script exit.
 		if [[ -n "$sandbox_dir" ]]; then
 			echo "# t1412.1: Sandbox cleanup"
-			echo "if [[ -f '${sandbox_dir}/.aidevops-sandbox' ]]; then"
-			echo "  rm -rf '${sandbox_dir}' 2>/dev/null || true"
-			echo "  echo 'SANDBOX_CLEANED: ${sandbox_dir}' >> '${new_log_file}' 2>/dev/null || true"
+			printf 'if [[ -f %q ]]; then\n' "${sandbox_dir}/.aidevops-sandbox"
+			printf '  rm -rf %q || true\n' "${sandbox_dir}"
+			printf '  echo %q >> %q || true\n' "SANDBOX_CLEANED: ${sandbox_dir}" "${new_log_file}"
 			echo "fi"
 		fi
 	} >"$wrapper_script"
@@ -3205,11 +3212,14 @@ cmd_dispatch() {
 		echo "  echo \"WORKER_DISPATCH_ERROR: dispatch script exited with code \${rc}\" >> '${log_file}'"
 		echo "fi"
 		# t1412.1: Clean up sandbox HOME directory after worker exits
+		# GH#3118: Use printf %q to prevent command injection from sandbox_dir
+		# containing shell metacharacters. Remove 2>/dev/null to preserve error
+		# visibility — || true is sufficient to prevent script exit.
 		if [[ -n "$sandbox_dir" ]]; then
 			echo "# t1412.1: Sandbox cleanup"
-			echo "if [[ -f '${sandbox_dir}/.aidevops-sandbox' ]]; then"
-			echo "  rm -rf '${sandbox_dir}' 2>/dev/null || true"
-			echo "  echo 'SANDBOX_CLEANED: ${sandbox_dir}' >> '${log_file}' 2>/dev/null || true"
+			printf 'if [[ -f %q ]]; then\n' "${sandbox_dir}/.aidevops-sandbox"
+			printf '  rm -rf %q || true\n' "${sandbox_dir}"
+			printf '  echo %q >> %q || true\n' "SANDBOX_CLEANED: ${sandbox_dir}" "${log_file}"
 			echo "fi"
 		fi
 	} >"$wrapper_script"
@@ -3686,7 +3696,11 @@ Task description: ${tdesc:-$task_id}"
 		if [[ -x "$sandbox_helper" ]]; then
 			# shellcheck source=../worker-sandbox-helper.sh
 			source "$sandbox_helper"
-			sandbox_dir=$(create_worker_sandbox "$task_id") || sandbox_dir=""
+			# GH#3118: Log warning on failure for consistency with cmd_dispatch
+			sandbox_dir=$(create_worker_sandbox "$task_id") || {
+				log_warn "Failed to create worker sandbox for $task_id reprompt — proceeding without isolation (t1412.1)"
+				sandbox_dir=""
+			}
 			if [[ -n "$sandbox_dir" ]]; then
 				sandbox_env_lines=$(generate_sandbox_env "$sandbox_dir") || sandbox_env_lines=""
 				log_info "Worker sandbox created for $task_id reprompt: $sandbox_dir (t1412.1)"
@@ -3766,11 +3780,14 @@ Task description: ${tdesc:-$task_id}"
 		echo "  echo \"WORKER_DISPATCH_ERROR: reprompt script exited with code \${rc}\" >> '${new_log_file}'"
 		echo "fi"
 		# t1412.1: Clean up sandbox HOME directory after worker exits
+		# GH#3118: Use printf %q to prevent command injection from sandbox_dir
+		# containing shell metacharacters. Remove 2>/dev/null to preserve error
+		# visibility — || true is sufficient to prevent script exit.
 		if [[ -n "$sandbox_dir" ]]; then
 			echo "# t1412.1: Sandbox cleanup"
-			echo "if [[ -f '${sandbox_dir}/.aidevops-sandbox' ]]; then"
-			echo "  rm -rf '${sandbox_dir}' 2>/dev/null || true"
-			echo "  echo 'SANDBOX_CLEANED: ${sandbox_dir}' >> '${new_log_file}' 2>/dev/null || true"
+			printf 'if [[ -f %q ]]; then\n' "${sandbox_dir}/.aidevops-sandbox"
+			printf '  rm -rf %q || true\n' "${sandbox_dir}"
+			printf '  echo %q >> %q || true\n' "SANDBOX_CLEANED: ${sandbox_dir}" "${new_log_file}"
 			echo "fi"
 		fi
 	} >"$wrapper_script"


### PR DESCRIPTION
## Summary

- Fix **HIGH-severity command injection** in sandbox cleanup across all 3 dispatch paths (`do_prompt_repeat`, `cmd_dispatch`, `cmd_reprompt`) by replacing single-quote string interpolation with `printf %q` for safe shell escaping
- Remove `2>/dev/null` from cleanup commands — `|| true` is sufficient to prevent script exit, and suppressing stderr hides debugging-critical errors
- Fix **MEDIUM-severity silent failure** in `do_prompt_repeat` and `cmd_reprompt` sandbox creation by adding `log_warn` on failure, matching `cmd_dispatch`'s existing pattern

## Problem

Variables like `sandbox_dir` were echoed into wrapper scripts using single-quote interpolation (`'${sandbox_dir}'`), which is vulnerable to command injection if the path contains single quotes or other shell metacharacters. A crafted `sandbox_dir` could break out of quoting and execute arbitrary commands during `rm -rf` cleanup.

Additionally, `do_prompt_repeat` and `cmd_reprompt` silently swallowed sandbox creation failures (falling back to `sandbox_dir=""`), while `cmd_dispatch` properly logged a warning. This inconsistency made debugging harder.

## Solution

- Use `printf %q` to safely escape all interpolated variables in generated wrapper scripts — handles single quotes, backticks, semicolons, spaces, and all other shell metacharacters
- Remove `2>/dev/null` from `rm -rf` and `echo` cleanup commands (error visibility)
- Add `log_warn` with descriptive message on sandbox creation failure in both `do_prompt_repeat` and `cmd_reprompt`

## Verification

Tested `printf %q` output with adversarial inputs:
- Path with single quote: `t'123; rm -rf /` → properly escaped as `t\'123\;\ rm\ -rf\ /`
- Path with backtick: `` t`whoami` `` → properly escaped as `` t\`whoami\` ``
- Normal path: passes through unmodified

Closes #3118