### PR TITLE
GH#3111: Fix quality-debt in content-classifier-helper.sh

### DIFF
--- a/.agents/scripts/content-classifier-helper.sh
+++ b/.agents/scripts/content-classifier-helper.sh
@@ -150,7 +150,7 @@ _cc_cache_set() {
 	local result="$2"
 	local cache_file="${CONTENT_CLASSIFIER_CACHE_DIR}/classifications/${hash}"
 
-	printf '%s' "$result" >"$cache_file" || true
+	printf '%s' "$result" >"$cache_file"
 	return 0
 }
 
@@ -196,7 +196,7 @@ _cc_collab_cache_set() {
 	safe_key=$(printf '%s_%s' "$repo" "$user" | tr '/' '_')
 	local cache_file="${CONTENT_CLASSIFIER_CACHE_DIR}/collaborators/${safe_key}"
 
-	printf '%s' "$result" >"$cache_file" || true
+	printf '%s' "$result" >"$cache_file"
 	return 0
 }
 
@@ -693,7 +693,7 @@ cmd_test() {
 	# Test 10: Dry-run classification
 	total=$((total + 1))
 	local dry_result
-	dry_result=$(CONTENT_CLASSIFIER_DRY_RUN=true CONTENT_CLASSIFIER_QUIET=true _cc_classify "test content" 2>/dev/null) || true
+	dry_result=$(CONTENT_CLASSIFIER_DRY_RUN=true CONTENT_CLASSIFIER_QUIET=true _cc_classify "test content") || true
 	if printf '%s' "$dry_result" | grep -q 'UNKNOWN.*dry-run'; then
 		echo "  PASS: Dry-run returns UNKNOWN"
 		passed=$((passed + 1))


### PR DESCRIPTION
## Summary

- Remove `|| true` from cache file write operations (`_cc_cache_set`, `_cc_collab_cache_set`) so write failures (permissions, disk full, invalid path) surface visibly instead of being silently swallowed
- Remove `2>/dev/null` from dry-run test classification call — `CONTENT_CLASSIFIER_QUIET=true` already controls verbosity without hiding diagnostic errors

## Context

Addresses unactioned review feedback from PR #3101 (Gemini code review). The issue tracked 5 findings; 3 were already resolved in the merged code (source `2>/dev/null`, AI helper error handling, `cmd_check_author` stderr suppression). The remaining 2 findings are fixed here:

1. **Cache writes** (lines 153, 199): `|| true` silently swallowed write failures, making cache inconsistencies hard to debug
2. **Test suite** (line 696): `2>/dev/null` hid all stderr from `_cc_classify` during dry-run test, making test failures harder to diagnose

## Verification

- ShellCheck: clean (only SC1091 info for external source)
- Built-in test suite: 10/10 passed, 0 failed

Closes #3111