### PR TITLE
GH#3112: Fix Tier 2 classifier stderr capture in prompt-guard-helper.sh

### DIFF
--- a/.agents/scripts/prompt-guard-helper.sh
+++ b/.agents/scripts/prompt-guard-helper.sh
@@ -1431,11 +1431,21 @@ cmd_classify_deep() {
 	fi
 
 	local tier2_result
+	local tier2_stderr
 	local tier2_exit=0
+	local stderr_tmpfile
+	stderr_tmpfile=$(mktemp "${TMPDIR:-/tmp}/pg-tier2-stderr.XXXXXX")
 	if [[ -n "$repo" && -n "$author" ]]; then
-		tier2_result=$("$classifier" classify-if-external "$repo" "$author" "$content") || tier2_exit=$?
+		tier2_result=$("$classifier" classify-if-external "$repo" "$author" "$content" 2>"$stderr_tmpfile") || tier2_exit=$?
 	else
-		tier2_result=$("$classifier" classify "$content") || tier2_exit=$?
+		tier2_result=$("$classifier" classify "$content" 2>"$stderr_tmpfile") || tier2_exit=$?
+	fi
+	tier2_stderr=$(<"$stderr_tmpfile")
+	rm -f "$stderr_tmpfile"
+
+	# Log classifier stderr if non-empty (captures API errors, timeouts, etc.)
+	if [[ -n "$tier2_stderr" ]]; then
+		_pg_log_warn "Tier 2 classifier stderr: ${tier2_stderr}"
 	fi
 
 	local tier2_class
@@ -1452,7 +1462,7 @@ cmd_classify_deep() {
 
 	# Fail securely: if Tier 2 errored or returned UNKNOWN, do not treat as clean
 	if [[ "$tier2_exit" -ne 0 || "$tier2_class" == "UNKNOWN" || -z "$tier2_class" ]]; then
-		_pg_log_error "Tier 2 classification failed or returned UNKNOWN (exit ${tier2_exit}): ${tier2_result}"
+		_pg_log_error "Tier 2 classification failed or returned UNKNOWN (exit ${tier2_exit}, stderr: ${tier2_stderr}): ${tier2_result}"
 		if [[ -n "$tier1_results" ]]; then
 			_pg_print_findings "$tier1_results"
 			echo "TIER1_WARN_T2_FAIL"


### PR DESCRIPTION
## Summary

- Captures Tier 2 LLM classifier stderr to a tmpfile instead of letting it flow to the caller's stderr (which may be suppressed with `2>/dev/null`)
- Logs captured stderr via `_pg_log_warn` for debugging API errors, timeouts, and execution failures
- Includes stderr content in the fail-secure error message for full diagnostic context

## Context

Addresses review feedback from PR #3101 (Gemini code review). The reviewer flagged a "fail-open" vulnerability, but the fail-secure logic was already correct — `tier2_exit` is checked and non-zero exits return 1 or 2, never CLEAN/0. The valid secondary finding was that classifier stderr was not captured, making failures invisible when callers suppress stderr.

## Verification

- ShellCheck: zero new violations
- Built-in test suite: all tests pass (pre-existing unrelated failure unchanged)
- Functional tests: `scan` and `check` commands work correctly

Closes #3112