### PR TITLE
t1414.3: Register convos in skill-sources.json with URL-based tracking

### DIFF
--- a/.agents/configs/skill-sources.json
+++ b/.agents/configs/skill-sources.json
@@ -126,6 +126,17 @@
       "last_checked": "2026-03-01T18:00:00Z",
       "merge_strategy": "added",
       "notes": "Official Cloudron skill for CLI server operations (logs, exec, backups, env vars, CI/CD)"
+    },
+    {
+      "name": "convos",
+      "upstream_url": "https://convos.org/skill.md",
+      "upstream_commit": "",
+      "local_path": ".agents/services/communications/convos.md",
+      "format_detected": "url",
+      "imported_at": "2026-03-07T18:12:47Z",
+      "last_checked": "2026-03-07T18:12:47Z",
+      "merge_strategy": "added",
+      "notes": "Encrypted messaging agent built on XMTP. URL-based tracking — no GitHub repo hosts the skill file. Requires t1415 for content-hash update detection."
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Adds `convos` entry to `.agents/configs/skill-sources.json` with `format_detected: "url"` and `upstream_url: "https://convos.org/skill.md"`
- This is the final subtask of t1414 (Add Convos encrypted messaging agent) — the agent file (t1414.1, PR #3140) and index updates (t1414.2, PR #3143) are already merged
- URL-based tracking requires t1415 for the update checker to handle content-hash comparison (no GitHub repo hosts the skill file)

Closes #3132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new skill capability to the agent system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->