### PR TITLE
fix: address PR #2079 review feedback for Cloudflare Code Mode docs

### DIFF
--- a/.agents/services/hosting/cloudflare-platform.md
+++ b/.agents/services/hosting/cloudflare-platform.md
@@ -29,10 +29,10 @@ imported_from: external
 
 | Task | Tool |
 |------|------|
-| Manage DNS records, zones | Code Mode MCP |
-| Configure WAF, DDoS, firewall rules | Code Mode MCP |
-| Manage R2 buckets, Workers deployments | Code Mode MCP |
-| Zero Trust, Access, Tunnel management | Code Mode MCP |
+| Manage DNS records, zones | Code Mode MCP (`tools/mcp/cloudflare-code-mode.md`) |
+| Configure WAF, DDoS, firewall rules | Code Mode MCP (`tools/mcp/cloudflare-code-mode.md`) |
+| Manage R2 buckets, Workers deployments | Code Mode MCP (`tools/mcp/cloudflare-code-mode.md`) |
+| Zero Trust, Access, Tunnel management | Code Mode MCP (`tools/mcp/cloudflare-code-mode.md`) |
 | Build a Worker (SDK, bindings, types) | This skill |
 | Configure wrangler.toml, local dev | This skill |
 | Debug Workers runtime issues | This skill |

--- a/.agents/tools/mcp/cloudflare-code-mode.md
+++ b/.agents/tools/mcp/cloudflare-code-mode.md
@@ -53,8 +53,7 @@ On first connection, you are redirected to Cloudflare to authorize and select pe
 
 Create a Cloudflare API token with required permissions, then pass as bearer token:
 
-```bash
-# Authorization header
+```text
 Authorization: Bearer <your-cloudflare-api-token>
 ```
 
@@ -99,6 +98,7 @@ Executes JavaScript against the Cloudflare API. The sandbox provides a `cloudfla
 ```javascript
 // List rulesets on a zone
 async () => {
+  const zoneId = "<YOUR_ZONE_ID>"; // replace with actual zone ID
   const response = await cloudflare.request({
     method: "GET",
     path: `/zones/${zoneId}/rulesets`
@@ -110,6 +110,7 @@ async () => {
 ```javascript
 // Chain multiple API calls in one execution
 async () => {
+  const zoneId = "<YOUR_ZONE_ID>"; // replace with actual zone ID
   const ddos = await cloudflare.request({
     method: "GET",
     path: `/zones/${zoneId}/rulesets/phases/ddos_l7/entrypoint`
@@ -146,6 +147,7 @@ async () => {
 
 // execute: list DNS records
 async () => {
+  const zoneId = "<YOUR_ZONE_ID>"; // replace with actual zone ID
   const res = await cloudflare.request({
     method: "GET",
     path: `/zones/${zoneId}/dns_records`
@@ -159,6 +161,7 @@ async () => {
 ```javascript
 // execute: enable managed WAF ruleset
 async () => {
+  const zoneId = "<YOUR_ZONE_ID>"; // replace with actual zone ID
   return await cloudflare.request({
     method: "PUT",
     path: `/zones/${zoneId}/rulesets/phases/http_request_firewall_managed/entrypoint`,
@@ -178,6 +181,7 @@ async () => {
 ```javascript
 // execute: list R2 buckets
 async () => {
+  const accountId = "<YOUR_ACCOUNT_ID>"; // replace with actual account ID
   const res = await cloudflare.request({
     method: "GET",
     path: `/accounts/${accountId}/r2/buckets`
@@ -189,6 +193,6 @@ async () => {
 ## References
 
 - Blog post: https://blog.cloudflare.com/code-mode-mcp/
-- GitHub: https://github.com/cloudflare/mcp
+- GitHub: https://github.com/cloudflare/mcp-server-cloudflare
 - Cloudflare API docs: https://developers.cloudflare.com/api/
 - Code Mode SDK (open source): https://github.com/cloudflare/agents/tree/main/packages/codemode

--- a/configs/mcp-templates/cloudflare-api.json
+++ b/configs/mcp-templates/cloudflare-api.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Cloudflare Code Mode MCP — remote server, OAuth-authenticated (no API tokens needed)",
+  "_comment": "Cloudflare Code Mode MCP — remote server, OAuth-authenticated (no API tokens needed). For clients without native remote MCP support (e.g. Cursor), use mcp-remote proxy: { \"command\": \"npx\", \"args\": [\"mcp-remote\", \"https://mcp.cloudflare.com/mcp\"] }",
   "_source": "https://developers.cloudflare.com/agents/guides/remote-mcp-server/",
   "_remote_url": "https://mcp.cloudflare.com/mcp",
 


### PR DESCRIPTION
## Summary

Addresses remaining quality issues from CodeRabbit review on PR #2079 (issue #3259).

**What was already fixed** (in subsequent PRs after #2079 merged):
- All ~96 `api.md` and `configuration.md` stub files were removed entirely
- Product Index API row was updated to point to Code Mode MCP doc

**What this PR fixes** (remaining actionable feedback):
- **Code fence**: Changed `bash` to `text` for HTTP header fragment in `cloudflare-code-mode.md` (not valid shell syntax)
- **Undeclared variables**: Added `const zoneId`/`const accountId` declarations to all `execute()` examples to prevent `ReferenceError` at runtime
- **Incorrect URL**: Fixed GitHub repo URL from `cloudflare/mcp` to `cloudflare/mcp-server-cloudflare`
- **Routing table**: Added explicit `tools/mcp/cloudflare-code-mode.md` path to routing table entries for deterministic agent navigation
- **MCP template**: Added `mcp-remote` proxy fallback note for clients without native remote MCP support (e.g. Cursor)

Closes #3259