### PR TITLE
GH#3297: Remove blanket error suppression from kill command in local-hosting docs

### DIFF
--- a/.agents/services/hosting/local-hosting.md
+++ b/.agents/services/hosting/local-hosting.md
@@ -614,7 +614,7 @@ rm -f apps/web/.next/dev/lock && pnpm dev:web
 "dev": "rm -f .next/dev/lock && next dev --port 3100"
 
 # Terminal profile / Tabby start command (includes lock cleanup + port kill)
-rm -f apps/web/.next/dev/lock; lsof -ti:3100 | xargs kill -9 2>/dev/null; pnpm dev:web
+rm -f apps/web/.next/dev/lock; lsof -ti:3100 | xargs kill -9; pnpm dev:web
 ```
 
 ### Docker Compose Projects


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from `xargs kill -9` in the Turbostarter terminal profile example at line 617 of `.agents/services/hosting/local-hosting.md`
- The blanket stderr suppression masked important system errors (e.g., "Operation not permitted" when lacking kill permissions), violating the rule against blanket error suppression
- Addresses critical review feedback from PR #2482 (Gemini code review)

Closes #3297