### PR TITLE
t3501: fix Homebrew bin wrapper not executable after install

### DIFF
--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -17,9 +17,11 @@ class Aidevops < Formula
   def install
     # Install the CLI script to libexec (not bin, to avoid double-write conflict)
     libexec.install "aidevops.sh"
+    (libexec/"aidevops.sh").chmod 0755
     
     # Install setup script for manual setup
     libexec.install "setup.sh"
+    (libexec/"setup.sh").chmod 0755
     
     # Install agent files
     (share/"aidevops").install ".agents"
@@ -31,6 +33,7 @@ class Aidevops < Formula
       export AIDEVOPS_SHARE="#{share}/aidevops"
       exec "#{libexec}/aidevops.sh" "$@"
     EOS
+    (bin/"aidevops").chmod 0755
   end
 
   def post_install


### PR DESCRIPTION
## Summary

- Add `chmod 0755` after `(bin/"aidevops").write` — `.write` creates files with `0644` permissions by default, causing "permission denied" when users run `aidevops` after `brew install`
- Add defensive `chmod 0755` for `libexec/aidevops.sh` and `libexec/setup.sh` in case tarball permissions are stripped during packaging

## Context

Addresses review feedback from PR #146 (CodeRabbit + Augment). The CodeRabbit review also suggested `bin.write_exec_script` as an alternative, but this is not a real Homebrew Formula API method — `chmod 0755` is the standard Homebrew pattern.

Closes #3501