### PR TITLE
fix: separate local declarations from assignments in setup-modules

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -374,7 +374,7 @@ install_beads_binary() {
 
 	local tmp_dir
 	tmp_dir=$(mktemp -d)
-	# shellcheck disable=SC2064
+	# shellcheck disable=SC2064  # Intentional: $tmp_dir must expand at trap definition time, not execution time
 	trap "rm -rf '$tmp_dir'" RETURN
 
 	if ! curl -fsSL "$download_url" -o "$tmp_dir/$tarball_name" 2>/dev/null; then

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -85,7 +85,8 @@ install_mcp_packages() {
 }
 
 resolve_mcp_binary_path() {
-	local bin_name="$1"
+	local bin_name
+	bin_name="$1"
 	local resolved=""
 
 	# Check common locations in priority order
@@ -419,9 +420,10 @@ setup_browser_tools() {
 }
 
 add_opencode_plugin() {
-	local plugin_name="$1"
-	local plugin_spec="$2"
-	local opencode_config="$3"
+	local plugin_name plugin_spec opencode_config
+	plugin_name="$1"
+	plugin_spec="$2"
+	opencode_config="$3"
 
 	# Check if plugin array exists and if plugin is already configured
 	local has_plugin_array


### PR DESCRIPTION
## Summary

- Split `local var="$1"` into separate `local var; var="$1"` declarations in `setup-modules/mcp-setup.sh` (`resolve_mcp_binary_path`, `add_opencode_plugin`) to preserve exit code safety per shell style guide
- Add justification comment to `SC2064` shellcheck disable in `setup-modules/agent-deploy.sh` (`install_beads_binary`)
- Both files already had `set -Eeuo pipefail` (stricter than `set -euo pipefail`), so the shebang findings from the original review were already resolved

Closes #3500
Closes #3499