### PR TITLE
GH#3568: Fix quality-debt in flash.md from PR #758 CodeRabbit review

### DIFF
--- a/.agents/tools/ai-assistants/models/flash.md
+++ b/.agents/tools/ai-assistants/models/flash.md
@@ -1,9 +1,9 @@
 ---
 description: Large-context model for summarization, bulk processing, and research sweeps
 mode: subagent
-model: google/gemini-2.5-flash-preview-05-20
+model: google/gemini-2.5-flash
 model-tier: flash
-model-fallback: openai/gpt-4.1-mini
+model-fallback: openai/gpt-4o-mini
 tools:
   read: true
   write: false
@@ -29,7 +29,7 @@ You are a fast, large-context AI assistant optimized for processing large amount
 
 ## Constraints
 
-- Prioritize throughness of coverage over depth of analysis
+- Prioritize thoroughness of coverage over depth of analysis
 - For complex reasoning tasks, recommend escalation to sonnet or pro tier
 - Leverage your large context window (1M tokens) for comprehensive reads
 - Keep output structured and scannable
@@ -41,6 +41,6 @@ You are a fast, large-context AI assistant optimized for processing large amount
 | Provider | Google |
 | Model | gemini-2.5-flash |
 | Context | 1M tokens |
-| Input cost | $0.15/1M tokens |
-| Output cost | $0.60/1M tokens |
+| Input cost | $0.30/1M tokens |
+| Output cost | $2.50/1M tokens |
 | Tier | flash (low cost, large context) |


### PR DESCRIPTION
## Summary

- Update flash tier model identifier from deprecated `google/gemini-2.5-flash-preview-05-20` (retired July 2025) to GA endpoint `google/gemini-2.5-flash`
- Correct pricing: Input $0.15 → $0.30/1M tokens, Output $0.60 → $2.50/1M tokens (per current Google pricing)
- Update fallback model from `openai/gpt-4.1-mini` (retired from ChatGPT Feb 2026) to `openai/gpt-4o-mini`
- Fix typo: "throughness" → "thoroughness"

## CodeRabbit Findings Addressed

| # | Severity | Finding | Status |
|---|----------|---------|--------|
| 1 | Critical | Model ID uses retired preview endpoint | Fixed |
| 2 | Critical | Pricing table significantly incorrect | Fixed |
| 3 | Minor | Typo in constraints section | Fixed |
| 4 | Minor | Fallback model being phased out | Fixed |

Closes #3568