### PR TITLE
GH#3641: Fix SQL injection in cache_get/cache_put

### DIFF
--- a/.agents/scripts/ip-reputation-helper.sh
+++ b/.agents/scripts/ip-reputation-helper.sh
@@ -186,8 +186,8 @@ sanitize_provider() {
 }
 
 # Get cached result for ip+provider; returns empty string if miss/expired
-# ip is validated as IPv4 (digits/dots only) by callers; provider is validated
-# by sanitize_provider ([a-zA-Z0-9_-]+) — neither can contain SQL metacharacters.
+# Defense-in-depth: escape single quotes in all interpolated values even though
+# ip is validated as IPv4 and provider is validated by sanitize_provider.
 cache_get() {
 	local ip="$1"
 	local provider="$2"
@@ -201,16 +201,19 @@ cache_get() {
 	fi
 	local now
 	now=$(date +%s)
+	# Escape single quotes in all interpolated values (SQL standard: ' → '')
+	local safe_ip="${ip//\'/\'\'}"
+	local safe_provider="${provider//\'/\'\'}"
 	local result
 	result=$(sqlite3 "$IP_REP_CACHE_DB" \
-		"SELECT result FROM ip_cache WHERE ip='${ip}' AND provider='${provider}' AND (cached_at + ttl) > ${now} LIMIT 1;" \
+		"SELECT result FROM ip_cache WHERE ip='${safe_ip}' AND provider='${safe_provider}' AND (cached_at + ttl) > ${now} LIMIT 1;" \
 		2>/dev/null || true)
 	echo "$result"
 	return 0
 }
 
 # Store result in cache
-# ip and provider are validated before this call; result (JSON) has single quotes escaped.
+# Defense-in-depth: escape single quotes in all interpolated values consistently.
 cache_put() {
 	local ip="$1"
 	local provider="$2"
@@ -224,11 +227,12 @@ cache_put() {
 	fi
 	local now
 	now=$(date +%s)
-	# Escape single quotes in result JSON by doubling them (SQL standard)
-	local escaped_result
-	escaped_result=$(printf '%s' "$result" | sed "s/'/''/g")
+	# Escape single quotes in all interpolated values (SQL standard: ' → '')
+	local safe_ip="${ip//\'/\'\'}"
+	local safe_provider="${provider//\'/\'\'}"
+	local safe_result="${result//\'/\'\'}"
 	sqlite3 "$IP_REP_CACHE_DB" \
-		"INSERT OR REPLACE INTO ip_cache (ip, provider, result, cached_at, ttl) VALUES ('${ip}', '${provider}', '${escaped_result}', ${now}, ${ttl});" \
+		"INSERT OR REPLACE INTO ip_cache (ip, provider, result, cached_at, ttl) VALUES ('${safe_ip}', '${safe_provider}', '${safe_result}', ${now}, ${ttl});" \
 		2>/dev/null || true
 	return 0
 }


### PR DESCRIPTION
## Summary

- Escape all SQL-interpolated values (`$ip`, `$provider`, `$result`) consistently in `cache_get()` and `cache_put()` using single-quote doubling (SQL standard: `'` → `''`)
- Eliminates inconsistent trust boundary where `$result` was escaped but `$ip` and `$provider` were not
- Replaces `sed`-based escaping in `cache_put` with the same bash parameter expansion pattern used in `cache_get`

## Issue Analysis

Issue #3641 contained 8 findings from PR #1860 CodeRabbit review. Analysis of current code shows:

| Finding | Severity | Status |
|---------|----------|--------|
| SQL injection in `cache_get`/`cache_put` — `$ip`/`$provider` not escaped | CRITICAL | **Fixed in this PR** |
| SQL injection in `cmd_cache_clear` — direct interpolation | CRITICAL | Already fixed (parameterized queries) |
| `dnsbl_overlap_check` misleading `email-health-check-helper.sh` guard | HIGH | Already fixed (`dig` check) |
| Non-integer `--rate-limit` causes bash arithmetic error | HIGH | Already fixed (integer validation) |

The remaining 4 findings were human confirmations/bot acknowledgements of the above fixes.

## Verification

- ShellCheck: zero violations
- Diff is minimal and focused on the security fix

Closes #3641

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced security protections for data validation and caching operations to prevent potential vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->