### PR TITLE
fix: address remaining quality-debt from PR #14 review feedback

### DIFF
--- a/.agents/scripts/terminal-title-helper.sh
+++ b/.agents/scripts/terminal-title-helper.sh
@@ -141,7 +141,9 @@ get_repo_name() {
 	# realpath may not exist on all systems, use cd/pwd as fallback
 	local abs_path=""
 	if command -v realpath &>/dev/null; then
-		abs_path=$(realpath "$git_common_dir" 2>/dev/null)
+		# || true prevents set -e from aborting when realpath fails
+		# (e.g., path doesn't exist yet); fallback below handles it
+		abs_path=$(realpath "$git_common_dir" 2>/dev/null) || true
 	fi
 
 	# Fallback to cd/pwd if realpath failed or doesn't exist


### PR DESCRIPTION
## Summary

Addresses the remaining unactioned review feedback from PR #14 (issue #3816).

### What was fixed

- **terminal-title-helper.sh**: `get_repo_name()` — `realpath` command substitution could abort the script under `set -e` when `realpath` fails (e.g., path doesn't exist). Added `|| true` to ensure the fallback `cd/pwd` path is reached instead of unexpected script termination.

### What was already fixed (verified)

Most of the PR #14 review findings were already addressed in subsequent commits or are no longer applicable:

- **quality-loop-helper.sh** — archived (dead code), all 5 findings no longer apply
- **ralph-loop-helper.sh** — archived (dead code), all 5 findings no longer apply
- **ralph-upstream-check.sh** — deleted entirely, grep `\s` finding no longer applies
- **aidevops-update-check.sh** — already uses `BASH_SOURCE[0]` (not `dirname $0`)
- **worktree-helper.sh** — already has `get_default_branch()` function and uses it throughout; removal failures already logged properly with descriptive error messages

### Verification

- ShellCheck passes (only SC1091 info for sourced files, expected)
- The fix is minimal and targeted — prevents a `set -e` abort path

Closes #3816