### PR TITLE
t3814: Pin sst/opencode/github action to v1.2.21 SHA

### DIFF
--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -260,7 +260,7 @@ jobs:
             }
       
       - name: Run OpenCode Agent
-        uses: sst/opencode/github@0cf0294787322664c6d668fa5ab0a9ce26796f78 # latest
+        uses: sst/opencode/github@a52d640c8c56a5d9fb4623a1c601046c3d9a37b7 # v1.2.21
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:


### PR DESCRIPTION
## Summary

- Pin `sst/opencode/github` action from stale SHA (`0cf0294`, Jan 2026) to latest release v1.2.21 (`a52d640`, Mar 7 2026)
- Replace misleading `# latest` comment with actual version tag `# v1.2.21` for maintainability

## Context

Addresses critical quality-debt from PR #18 CodeRabbit + Codacy review feedback. The workflow has elevated permissions and uses `ANTHROPIC_API_KEY`, making supply chain security critical. All 6 action references in the file are now SHA-pinned with version comments.

Closes #3814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenCode Agent GitHub Action to the latest stable version for improved reliability and performance in automated workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->