### PR TITLE
fix: address quality-debt from PR #21 CodeRabbit review feedback

### DIFF
--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -423,8 +423,16 @@ aidevops follows OpenCode's credential storage:
 ## Version History
 
 - **0.0.9** (latest): Current version in repository
-- Maintained by Anomaly (anomalyco)
-- Dependencies: `@opencode-ai/plugin`, `@openauthjs/openauth`
+  - **DEPRECATED** — functionality now built into OpenCode v1.1.36+
+  - Maintained by Anomaly (anomalyco)
+  - Dependencies: `@opencode-ai/plugin`, `@openauthjs/openauth`
+- **0.0.8**: Updated dependencies and compatibility
+  - Updated from `@openauthjs/openauth@^0.4.3` to latest
+- **0.0.7**: Previous stable release
+- **0.0.6**: Initial public release with core OAuth support
+  - OAuth 2.0 with PKCE for Anthropic Console
+  - Claude Pro/Max subscription support
+  - Automatic token refresh
 
 ## References
 


### PR DESCRIPTION
## Summary

- Expanded version history section in `opencode-anthropic-auth.md` to include prior releases (0.0.6-0.0.8) with brief descriptions
- Marked v0.0.9 as deprecated (functionality built into OpenCode v1.1.36+)
- Addresses CodeRabbit nitpick from PR #21 about changelog clarity

Closes #3808