### PR TITLE
t3820: Pin dependency versions in GitLab CI template

### DIFF
--- a/configs/mcp-templates/opencode-gitlab-ci.yml
+++ b/configs/mcp-templates/opencode-gitlab-ci.yml
@@ -29,17 +29,18 @@ opencode:
     - when: never
   
   before_script:
-    # Install OpenCode CLI
-    - npm install --global opencode-ai
+    # Install OpenCode CLI (pin version for reproducible builds)
+    - npm install --global opencode-ai@1.2.21
     
     # Install system dependencies
     - apt-get update && apt-get install -y git curl
     
-    # Install glab CLI for GitLab operations
+    # Install glab CLI for GitLab operations (pin version for reproducible builds)
     - |
-      GLAB_VERSION=$(curl -s https://api.github.com/repos/profclems/glab/releases/latest | grep tag_name | cut -d '"' -f 4)
+      GLAB_VERSION="v1.22.0"
       curl -sL "https://github.com/profclems/glab/releases/download/${GLAB_VERSION}/glab_${GLAB_VERSION#v}_Linux_x86_64.tar.gz" | tar xz
-      mv glab /usr/local/bin/
+      mv bin/glab /usr/local/bin/
+      glab version || { echo "glab installation failed"; exit 1; }
     
     # Configure git identity
     - git config --global user.email "opencode@gitlab.com"
@@ -106,7 +107,7 @@ opencode:
   stage: opencode
   image: node:22-slim
   script:
-    - npm install --global opencode-ai
+    - npm install --global opencode-ai@1.2.21
     - mkdir -p ~/.local/share/opencode
     - echo '{"anthropic":{"apiKey":"'$ANTHROPIC_API_KEY'"}}' > ~/.local/share/opencode/auth.json
     - opencode run "$AI_FLOW_INPUT"


### PR DESCRIPTION
## Summary

- Pin `opencode-ai` to `@1.2.21` for reproducible npm installs (main + minimal configs)
- Pin `glab` CLI to `v1.22.0` — removes fragile `curl | grep | cut` GitHub API parsing that could break on API changes or rate limits
- Fix glab tarball extraction path from `glab` to `bin/glab` (the tarball nests the binary under `bin/`)
- Add `glab version` verification step after installation

## Review Feedback Addressed

All findings from PR #5 Gemini code review on `configs/mcp-templates/opencode-gitlab-ci.yml`:

| Line | Severity | Finding | Fix |
|------|----------|---------|-----|
| 33 | HIGH | `npm install --global opencode-ai` unpinned | Pinned to `@1.2.21` |
| 39-42 | HIGH | `glab` fetches `latest` + fragile JSON parsing | Pinned to `v1.22.0`, removed API call |
| 41 | MEDIUM | Tarball extracts to `bin/glab` not `glab` | Fixed `mv` path |

Closes #3820