### PR TITLE
t3820: Pin CI dependency versions for reproducible builds

### DIFF
--- a/configs/mcp-templates/opencode-gitlab-ci.yml
+++ b/configs/mcp-templates/opencode-gitlab-ci.yml
@@ -29,15 +29,15 @@ opencode:
     - when: never
   
   before_script:
-    # Install OpenCode CLI
-    - npm install --global opencode-ai
+    # Install OpenCode CLI (pin version for reproducible builds)
+    - npm install --global opencode-ai@1.2.21
     
     # Install system dependencies
     - apt-get update && apt-get install -y git curl
     
-    # Install glab CLI for GitLab operations
+    # Install glab CLI for GitLab operations (pin version for reproducible builds)
     - |
-      GLAB_VERSION=$(curl -s https://api.github.com/repos/profclems/glab/releases/latest | grep tag_name | cut -d '"' -f 4)
+      GLAB_VERSION="v1.22.0"
       curl -sL "https://github.com/profclems/glab/releases/download/${GLAB_VERSION}/glab_${GLAB_VERSION#v}_Linux_x86_64.tar.gz" | tar xz
       mv glab /usr/local/bin/
     
@@ -106,7 +106,7 @@ opencode:
   stage: opencode
   image: node:22-slim
   script:
-    - npm install --global opencode-ai
+    - npm install --global opencode-ai@1.2.21
     - mkdir -p ~/.local/share/opencode
     - echo '{"anthropic":{"apiKey":"'$ANTHROPIC_API_KEY'"}}' > ~/.local/share/opencode/auth.json
     - opencode run "$AI_FLOW_INPUT"


### PR DESCRIPTION
## Summary

Fixes quality-debt from PR #5 CodeRabbit/Gemini review feedback (2 high-severity findings).

### Changes

- **Pin `opencode-ai` to `@1.2.21`** — prevents breaking changes from unpinned `npm install --global opencode-ai` (line 33, line 109 minimal config)
- **Pin `glab` CLI to `v1.22.0`** — replaces dynamic `latest` version fetch with a fixed version string (line 40)
- **Remove fragile JSON parsing** — eliminates `grep tag_name | cut -d '"' -f 4` parsing of GitHub API response, which could break on API output changes

### Review findings addressed

| Severity | Reviewer | Line | Issue | Fix |
|----------|----------|------|-------|-----|
| HIGH | gemini | 33 | `npm install` without version pin | Pinned to `@1.2.21` |
| HIGH | gemini | 42 | `latest` version fetch + fragile `grep`/`cut` parsing | Pinned to `v1.22.0`, direct download URL |

Closes #3820