### PR TITLE
fix: critical quality-debt — security fixes and workflow hardening (batch 3)

### DIFF
--- a/.agents/scripts/chrome-webstore-helper.sh
+++ b/.agents/scripts/chrome-webstore-helper.sh
@@ -78,7 +78,7 @@ print_info() {
 
 print_warning() {
 	local message="$1"
-	echo -e "\033[1;33m[WARN]\033[0m $message"
+	echo -e "\033[1;33m[WARN]\033[0m $message" >&2
 	return 0
 }
 
@@ -499,7 +499,9 @@ cmd_publish() {
 	# Build extension if build command provided
 	if [[ -n "$build_cmd" ]]; then
 		print_info "Running build command: $build_cmd"
-		if ! bash -c "$build_cmd"; then
+		local build_cmd_arr
+		read -r -a build_cmd_arr <<<"$build_cmd"
+		if ! "${build_cmd_arr[@]}"; then
 			print_error "$ERROR_BUILD_FAILED"
 			return 1
 		fi
@@ -510,7 +512,9 @@ cmd_publish() {
 
 	if [[ -n "$zip_cmd" ]]; then
 		print_info "Running zip command: $zip_cmd"
-		if ! bash -c "$zip_cmd"; then
+		local zip_cmd_arr
+		read -r -a zip_cmd_arr <<<"$zip_cmd"
+		if ! "${zip_cmd_arr[@]}"; then
 			print_error "$ERROR_ZIP_FAILED"
 			return 1
 		fi

--- a/.agents/scripts/codacy-collector-helper.sh
+++ b/.agents/scripts/codacy-collector-helper.sh
@@ -62,8 +62,6 @@ db() {
 
 sql_escape() {
 	local val="$1"
-	val="${val//\\\'/\'}"
-	val="${val//\\\"/\"}"
 	val="${val//\'/\'\'}"
 	echo "$val"
 	return 0
@@ -606,6 +604,12 @@ cmd_query() {
 			;;
 		esac
 	done
+
+	# Validate numeric inputs to prevent SQL injection
+	if ! [[ "$limit" =~ ^[0-9]+$ ]]; then
+		log_error "Invalid limit: $limit (must be numeric)"
+		return 1
+	fi
 
 	ensure_db
 

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -302,7 +302,7 @@ print_shared_success() {
 # Print warning message with consistent formatting
 print_shared_warning() {
 	local msg="$1"
-	echo -e "${COLOR_YELLOW}[WARNING]${COLOR_RESET} $msg"
+	echo -e "${COLOR_YELLOW}[WARNING]${COLOR_RESET} $msg" >&2
 	return 0
 }
 

--- a/.agents/scripts/sonarcloud-collector-helper.sh
+++ b/.agents/scripts/sonarcloud-collector-helper.sh
@@ -418,11 +418,14 @@ cmd_collect() {
 	log_info "Starting collection for project: $project_key"
 
 	# Create audit run (using existing schema from t1032.1)
+	# sql_escape repo to prevent SQL injection via repo name
+	local escaped_repo
+	escaped_repo=$(printf '%s' "$repo" | sed "s/'/''/g")
 	local run_id
 	run_id=$(
 		db "$COLLECTOR_DB" <<SQL
 INSERT INTO audit_runs (repo, pr_number, head_sha, services_run, status)
-VALUES ('$repo', 0, '', 'sonarcloud', 'running');
+VALUES ('$escaped_repo', 0, '', 'sonarcloud', 'running');
 SELECT last_insert_rowid();
 SQL
 	)
@@ -442,13 +445,8 @@ SQL
 		total_findings=$((total_findings + hotspot_count))
 	fi
 
-	# Update run status
-	db "$COLLECTOR_DB" <<SQL >/dev/null
-UPDATE audit_runs
-SET status = 'complete',
-    completed_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
-WHERE id = $run_id;
-SQL
+	# Update run status (run_id is from last_insert_rowid, guaranteed numeric)
+	db "$COLLECTOR_DB" "UPDATE audit_runs SET status = 'complete', completed_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = $run_id;" >/dev/null
 
 	log_success "Collection complete. Total findings: $total_findings"
 	return 0
@@ -478,9 +476,18 @@ cmd_query() {
 
 	ensure_db
 
+	# Validate severity to prevent SQL injection
 	local where_clause=""
 	if [[ -n "$severity" ]]; then
-		where_clause="WHERE severity='$severity'"
+		case "$severity" in
+		critical | high | medium | low | info)
+			where_clause="AND severity='$severity'"
+			;;
+		*)
+			log_error "Invalid severity value: $severity (must be: critical, high, medium, low, info)"
+			return 1
+			;;
+		esac
 	fi
 
 	if [[ "$format" == "json" ]]; then
@@ -526,6 +533,12 @@ cmd_summary() {
 			;;
 		esac
 	done
+
+	# Validate last_n is numeric to prevent SQL injection
+	if ! [[ "$last_n" =~ ^[0-9]+$ ]]; then
+		log_error "Invalid value for --last: $last_n (must be numeric)"
+		return 1
+	fi
 
 	ensure_db
 

--- a/.agents/scripts/tests/test-matterbridge-helper.sh
+++ b/.agents/scripts/tests/test-matterbridge-helper.sh
@@ -151,7 +151,13 @@ test_simplex_bridge_init() {
 	if [[ -f "$config_path" ]]; then
 		local perms
 		# stat -c '%a' is Linux; stat -f '%Lp' is macOS
-		perms="$(stat -c '%a' "$config_path" 2>/dev/null || stat -f '%Lp' "$config_path" 2>/dev/null || echo "unknown")"
+		if stat -c '%a' / >/dev/null 2>&1; then
+			# GNU stat (Linux)
+			perms="$(stat -c '%a' "$config_path")"
+		else
+			# BSD stat (macOS)
+			perms="$(stat -f '%Lp' "$config_path")"
+		fi
 		if [[ "$perms" == "600" ]]; then
 			print_result "simplex-bridge init: config has 600 permissions" 0
 		else

--- a/.github/workflows/auto-deploy-agents.yml
+++ b/.github/workflows/auto-deploy-agents.yml
@@ -77,9 +77,10 @@ jobs:
           fi
 
           # Store changed files list (truncated for output)
-          echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
+          # Use unique delimiter to avoid collision with file content
+          echo "changed_files<<EOF_CHANGED_FILES" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | head -50 >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "EOF_CHANGED_FILES" >> "$GITHUB_OUTPUT"
 
           echo "Detected $CHANGED_COUNT changed agent files ($SCRIPTS_CHANGED scripts)"
 

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -83,7 +83,7 @@ jobs:
         TOTAL=$(echo "$CHECK_RUNS" | jq -s 'length')
         PASSED=$(echo "$CHECK_RUNS" | jq -s '[.[] | select(.conclusion == "success")] | length')
         SKIPPED=$(echo "$CHECK_RUNS" | jq -s '[.[] | select(.conclusion == "skipped")] | length')
-        FAILED=$(echo "$CHECK_RUNS" | jq -s '[.[] | select(.conclusion == "failure")] | length')
+        FAILED=$(echo "$CHECK_RUNS" | jq -s '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length')
         
         echo "| Check | Status | Conclusion |" >> $GITHUB_STEP_SUMMARY
         echo "|-------|--------|------------|" >> $GITHUB_STEP_SUMMARY
@@ -106,23 +106,23 @@ jobs:
         
         CRITICAL_FAILED=$(echo "$CHECK_RUNS" | jq -s --arg names "$ADVISORY_NAMES" \
           '($names | split("|")) as $adv |
-           [.[] | select(.conclusion == "failure") | select(.name as $n | $adv | index($n) | not)] | length')
+           [.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | select(.name as $n | $adv | index($n) | not)] | length')
         ADVISORY_FAILED=$(echo "$CHECK_RUNS" | jq -s --arg names "$ADVISORY_NAMES" \
           '($names | split("|")) as $adv |
-           [.[] | select(.conclusion == "failure") | select(.name as $n | $adv | index($n))] | length')
+           [.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | select(.name as $n | $adv | index($n))] | length')
         
         if [[ "$ADVISORY_FAILED" != "0" ]]; then
           echo "::warning::$ADVISORY_FAILED advisory check(s) failed (non-blocking)"
           echo "$CHECK_RUNS" | jq -rs --arg names "$ADVISORY_NAMES" \
             '($names | split("|")) as $adv |
-             .[] | select(.conclusion == "failure") | select(.name as $n | $adv | index($n)) | "  Advisory failure: \(.name)"'
+             .[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | select(.name as $n | $adv | index($n)) | "  Advisory failure: \(.name) (\(.conclusion))"'
         fi
         
         if [[ "$CRITICAL_FAILED" != "0" ]]; then
           echo "::error::$CRITICAL_FAILED critical check run(s) failed"
           echo "$CHECK_RUNS" | jq -rs --arg names "$ADVISORY_NAMES" \
             '($names | split("|")) as $adv |
-             .[] | select(.conclusion == "failure") | select(.name as $n | $adv | index($n) | not) | "  Critical failure: \(.name)"'
+             .[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | select(.name as $n | $adv | index($n) | not) | "  Critical failure: \(.name) (\(.conclusion))"'
           echo "cicd_status=failed" >> $GITHUB_OUTPUT
           exit 1
         fi


### PR DESCRIPTION
## Summary

Batch 3 of the quality-debt sprint. Focuses on security vulnerabilities (SQL injection, shell injection) and CI workflow hardening.

### Security fixes

| File | Issue | Fix |
|------|-------|-----|
| `sonarcloud-collector-helper.sh` | GH#3710 | Escape repo in SQL INSERT, validate severity/limit inputs |
| `codacy-collector-helper.sh` | GH#3711 | Remove incorrect un-escape in `sql_escape()`, validate limit |
| `chrome-webstore-helper.sh` | GH#3692 | Replace `bash -c` with array execution (shell injection prevention) |
| `shared-constants.sh` | GH#3629 | Redirect `print_shared_warning` to stderr (fixes JSON pollution in wp-helper) |

### Workflow hardening

| File | Issue | Fix |
|------|-------|-----|
| `postflight.yml` | GH#3327 | jq filters now check `cancelled`/`timed_out`/`action_required` |
| `auto-deploy-agents.yml` | GH#3549 | Unique heredoc delimiter prevents EOF collision |

### Other

| File | Issue | Fix |
|------|-------|-----|
| `test-matterbridge-helper.sh` | GH#3392 | Platform-aware `stat` without blanket `2>/dev/null` |

### Verified already fixed (no code changes)
- GH#3706 (`code-audit-helper.sh`) — SQL injection guards already present
- GH#3457 (`business.md`) — `company-runners` already in subagents list
- GH#3540 (`accessibility/package.json`) — Playwright 1.58.2 is valid

Closes #3710, closes #3711, closes #3692, closes #3629, closes #3327, closes #3549, closes #3392, closes #3706, closes #3457, closes #3540
<!-- CI re-trigger: t3862 -->