### PR TITLE
fix: add missing GITHUB_TOKEN permissions to CI workflows

### DIFF
--- a/.github/workflows/code-review-monitoring.yml
+++ b/.github/workflows/code-review-monitoring.yml
@@ -22,6 +22,7 @@ jobs:
     
     permissions:
       contents: write
+      issues: write
       pull-requests: write
       security-events: write
     

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -473,6 +473,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
+      contents: read
+      issues: write
       pull-requests: write
 
     steps:
@@ -531,6 +533,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
+      contents: read
+      issues: read
       pull-requests: write
 
     steps:


### PR DESCRIPTION
## Summary

- Add `issues: write` and `contents: read` to the `label-pr` job in `issue-sync.yml` — fixes `addLabelsToLabelable: Resource not accessible by integration` when applying conventional-commit labels to PRs
- Add `issues: read` and `contents: read` to the `check-issue-link` job in `issue-sync.yml` — fixes `HttpError: Resource not accessible by integration` when searching for linked issues
- Add `issues: write` to the `code-review-monitoring` job in `code-review-monitoring.yml` — fixes comment posting via `github.rest.issues.createComment` (PR comments use the issues API)

## Root Cause

GitHub Actions' `GITHUB_TOKEN` defaults to restrictive permissions when `permissions:` is declared at the job level. The `label-pr` job only declared `pull-requests: write`, but `gh label create` and the GraphQL `addLabelsToLabelable` mutation require `issues: write`. Similarly, `check-issue-link` uses `gh issue list` which needs `issues: read`, and `code-review-monitoring` posts PR comments via the issues API.

## Evidence

- Run 22811519068 (batch4): Label step fails with `addLabelsToLabelable: Resource not accessible by integration`
- Run 22811526019 (batch1): Comment step fails with `HttpError: Resource not accessible by integration`

Closes #3836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions for internal automation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->