### PR TITLE
t3848: Fix code-review-monitoring CI 403 by adding top-level permissions

### DIFF
--- a/.github/workflows/code-review-monitoring.yml
+++ b/.github/workflows/code-review-monitoring.yml
@@ -10,6 +10,16 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
+# Top-level permissions required for GITHUB_TOKEN to post PR comments.
+# Job-level permissions alone are insufficient when the repository default
+# token permissions are set to read-only (GitHub Actions ignores job-level
+# elevation in that case). See: github.com/marcusquinn/aidevops/issues/3848
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  security-events: write
+
 # Cancel in-progress runs when a new run is triggered
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds top-level `permissions` block to `code-review-monitoring.yml` with `contents: write`, `issues: write`, `pull-requests: write`, and `security-events: write`
- Fixes HTTP 403 "Resource not accessible by integration" when the workflow tries to post PR comments via `github.rest.issues.createComment`

## Root Cause

The workflow had job-level `permissions` but no top-level `permissions` block. When the repository default token permissions are set to read-only, GitHub Actions does not elevate the GITHUB_TOKEN beyond the repo default using job-level permissions alone — a top-level workflow `permissions` block is required.

**Evidence from failing run 22814339504:**
```
GITHUB_TOKEN Permissions
Contents: read
Issues: read
PullRequests: read
SecurityEvents: read
```

All `read` despite the job declaring `write`. The "Comment on PR" step then fails:
```
RequestError [HttpError]: Resource not accessible by integration
  status: 403
  url: https://api.github.com/repos/marcusquinn/aidevops/issues/3844/comments
```

## Verification

- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- The workflow will self-test on this PR — the "Comment on PR" step should now succeed instead of 403ing

Closes #3848