### PR TITLE
GH#3798: Fix critical quality-debt from PR #38 review feedback

### DIFF
--- a/.agents/scripts/archived/ralph-loop-helper.sh
+++ b/.agents/scripts/archived/ralph-loop-helper.sh
@@ -41,7 +41,7 @@ readonly SCRIPT_NAME="ralph-loop-helper.sh"
 # Source shared loop infrastructure
 # shellcheck source=loop-common.sh
 if [[ -f "$SCRIPT_DIR/loop-common.sh" ]]; then
-    source "$SCRIPT_DIR/loop-common.sh"
+	source "$SCRIPT_DIR/loop-common.sh"
 fi
 
 # State directories
@@ -73,13 +73,13 @@ output_file=""
 # =============================================================================
 
 print_step() {
-    local message="$1"
-    echo -e "${CYAN}[ralph]${NC} ${message}"
-    return 0
+	local message="$1"
+	echo -e "${CYAN}[ralph]${NC} ${message}"
+	return 0
 }
 
 show_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 Ralph Loop Helper v2 - Cross-Tool Iterative AI Development
 
 USAGE:
@@ -144,225 +144,151 @@ LEARN MORE:
   flow-next reference: https://github.com/gmickel/gmickel-claude-marketplace
   Documentation: ~/.aidevops/agents/workflows/ralph-loop.md
 EOF
-    return 0
+	return 0
 }
 
 # =============================================================================
 # v2 Functions (Fresh Context Architecture)
 # =============================================================================
 
+# Custom tool runner for opencode with --format json and optional --model
+# Used as callback for loop_run_external's tool_runner_func parameter.
+# Arguments:
+#   $1 - output_file (path to write tool output)
+#   $2 - prompt (full re-anchor prompt)
+# Returns: tool exit code
+_ralph_opencode_runner() {
+	local out_file="$1"
+	local prompt_text="$2"
+
+	local opencode_args=("run" "$prompt_text" "--format" "json")
+	if [[ -n "${RALPH_MODEL:-}" ]]; then
+		opencode_args+=("--model" "$RALPH_MODEL")
+	fi
+	opencode "${opencode_args[@]}" >"$out_file" 2>&1
+}
+
 # Run v2 loop with fresh sessions per iteration
+# Thin wrapper: parses arguments, initializes state, then delegates to
+# loop_run_external (loop-common.sh) for the core loop logic.
 # Arguments:
 #   $@ - Prompt and options
 # Returns: 0 on completion, 1 on error/max iterations
 run_v2_loop() {
-    local prompt=""
-    local max_iterations=$DEFAULT_MAX_ITERATIONS
-    local completion_promise="TASK_COMPLETE"
-    local tool="opencode"
-    local max_attempts=$DEFAULT_MAX_ATTEMPTS
-    local task_id=""
-    local prompt_parts=()
+	local prompt=""
+	local max_iterations=$DEFAULT_MAX_ITERATIONS
+	local completion_promise="TASK_COMPLETE"
+	local tool="opencode"
+	local max_attempts=$DEFAULT_MAX_ATTEMPTS
+	local task_id=""
+	local prompt_parts=()
 
-    # Parse arguments
-    while [[ $# -gt 0 ]]; do
-        case $1 in
-            --max-iterations)
-                max_iterations="$2"
-                shift 2
-                ;;
-            --completion-promise)
-                completion_promise="$2"
-                shift 2
-                ;;
-            --tool)
-                tool="$2"
-                shift 2
-                ;;
-            --max-attempts)
-                max_attempts="$2"
-                shift 2
-                ;;
-            --task-id)
-                task_id="$2"
-                shift 2
-                ;;
-            *)
-                prompt_parts+=("$1")
-                shift
-                ;;
-        esac
-    done
+	# Parse arguments (with validation for required values)
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+		--max-iterations)
+			if [[ -z "${2:-}" || ! "$2" =~ ^[0-9]+$ ]]; then
+				print_error "--max-iterations requires a numeric argument"
+				return 1
+			fi
+			max_iterations="$2"
+			shift 2
+			;;
+		--completion-promise)
+			if [[ -z "${2:-}" ]]; then
+				print_error "--completion-promise requires an argument"
+				return 1
+			fi
+			completion_promise="$2"
+			shift 2
+			;;
+		--tool)
+			if [[ -z "${2:-}" ]]; then
+				print_error "--tool requires an argument"
+				return 1
+			fi
+			tool="$2"
+			shift 2
+			;;
+		--max-attempts)
+			if [[ -z "${2:-}" || ! "$2" =~ ^[0-9]+$ ]]; then
+				print_error "--max-attempts requires a numeric argument"
+				return 1
+			fi
+			max_attempts="$2"
+			shift 2
+			;;
+		--task-id)
+			if [[ -z "${2:-}" ]]; then
+				print_error "--task-id requires an argument"
+				return 1
+			fi
+			task_id="$2"
+			shift 2
+			;;
+		*)
+			prompt_parts+=("$1")
+			shift
+			;;
+		esac
+	done
 
-    prompt="${prompt_parts[*]}"
+	prompt="${prompt_parts[*]}"
 
-    if [[ -z "$prompt" ]]; then
-        print_error "No prompt provided"
-        echo "Usage: $SCRIPT_NAME run \"<prompt>\" --tool <tool> [options]"
-        return 1
-    fi
+	if [[ -z "$prompt" ]]; then
+		print_error "No prompt provided"
+		echo "Usage: $SCRIPT_NAME run \"<prompt>\" --tool <tool> [options]"
+		return 1
+	fi
 
-    # Validate tool
-    if ! command -v "$tool" &>/dev/null; then
-        print_error "Tool '$tool' not found. Install it or use --tool to specify another."
-        print_info "Available tools: opencode, claude, aider"
-        return 1
-    fi
+	# Validate tool
+	if ! command -v "$tool" &>/dev/null; then
+		print_error "Tool '$tool' not found. Install it or use --tool to specify another."
+		print_info "Available tools: opencode, claude, aider"
+		return 1
+	fi
 
-    # Check for jq (required for v2)
-    if ! command -v jq &>/dev/null; then
-        print_error "jq is required for v2 loops. Install with: brew install jq"
-        return 1
-    fi
+	# Check for jq (required for v2)
+	if ! command -v jq &>/dev/null; then
+		print_error "jq is required for v2 loops. Install with: brew install jq"
+		return 1
+	fi
 
-    # Initialize state using shared infrastructure
-    if type loop_create_state &>/dev/null; then
-        loop_create_state "ralph" "$prompt" "$max_iterations" "$completion_promise" "$task_id"
-    else
-        print_warning "loop-common.sh not loaded, using basic state"
-        mkdir -p "$RALPH_STATE_DIR"
-    fi
+	# Initialize state using shared infrastructure
+	if type loop_create_state &>/dev/null; then
+		loop_create_state "ralph" "$prompt" "$max_iterations" "$completion_promise" "$task_id"
+	else
+		print_warning "loop-common.sh not loaded, using basic state"
+		mkdir -p "$RALPH_STATE_DIR"
+	fi
 
-    print_info "Starting Ralph loop v2 with $tool"
-    print_info "Architecture: Fresh context per iteration"
-    echo ""
-    echo "Prompt: $prompt"
-    echo "Max iterations: $max_iterations"
-    echo "Completion promise: $completion_promise"
-    echo "Max attempts before block: $max_attempts"
-    echo ""
+	print_info "Starting Ralph loop v2 with $tool"
+	print_info "Architecture: Fresh context per iteration"
+	echo ""
+	echo "Prompt: $prompt"
+	echo "Max iterations: $max_iterations"
+	echo "Completion promise: $completion_promise"
+	echo "Max attempts before block: $max_attempts"
+	echo ""
 
-    local iteration=1
-    output_file="$(mktemp)"
-    local output_sizes_file
-    output_sizes_file="$(mktemp)"
-    _save_cleanup_scope; trap '_run_cleanups' RETURN
-    push_cleanup "rm -f '${output_file}'"
-    push_cleanup "rm -f '${output_sizes_file}'"
+	# Calculate adaptive delay for first iteration (used as base delay)
+	local delay_seconds
+	delay_seconds=$(calculate_delay 1)
 
-    while [[ $iteration -le $max_iterations ]]; do
-        print_step "=== Iteration $iteration/$max_iterations ==="
+	# Determine tool runner: use custom callback for opencode (--format json + --model)
+	local tool_runner_func=""
+	if [[ "$tool" == "opencode" ]]; then
+		tool_runner_func="_ralph_opencode_runner"
+	fi
 
-        # Update state
-        if type loop_set_state &>/dev/null; then
-            loop_set_state ".iteration" "$iteration"
-            loop_set_state ".last_iteration_at" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-        fi
-
-        # Generate re-anchor prompt (key v2 feature)
-        local reanchor_prompt=""
-        if type loop_generate_reanchor &>/dev/null; then
-            print_info "Generating re-anchor context..."
-            reanchor_prompt=$(loop_generate_reanchor "$prompt")
-        else
-            # Fallback: basic prompt with iteration
-            reanchor_prompt="[Ralph iteration $iteration/$max_iterations]
-
-$prompt
-
-To complete, output: <promise>$completion_promise</promise> (ONLY when TRUE)"
-        fi
-
-        # Run tool with fresh session
-        local exit_code=0
-        print_info "Spawning fresh $tool session..."
-        
-        case "$tool" in
-            opencode)
-                local opencode_args=("run" "$reanchor_prompt" "--format" "json")
-                if [[ -n "${RALPH_MODEL:-}" ]]; then
-                    opencode_args+=("--model" "$RALPH_MODEL")
-                fi
-                opencode "${opencode_args[@]}" > "$output_file" 2>&1 || exit_code=$?
-                ;;
-            claude)
-                echo "$reanchor_prompt" | claude --print > "$output_file" 2>&1 || exit_code=$?
-                ;;
-            aider)
-                aider --yes --message "$reanchor_prompt" > "$output_file" 2>&1 || exit_code=$?
-                ;;
-            *)
-                print_error "Unknown tool: $tool"
-                return 1
-                ;;
-        esac
-
-        if [[ $exit_code -ne 0 ]]; then
-            print_warning "Tool exited with code $exit_code (continuing)"
-            if [[ -s "$output_file" ]]; then
-                print_warning "Tool output (last 20 lines):"
-                tail -n 20 "$output_file"
-            fi
-        fi
-
-        # Check for completion promise
-        if grep -q "<promise>$completion_promise</promise>" "$output_file" 2>/dev/null; then
-            # opencode run emits JSON events; grep still works on raw output
-            print_success "Completion promise detected!"
-            
-            # Create success receipt
-            if type loop_create_receipt &>/dev/null; then
-                loop_create_receipt "task" "success" '{"promise_fulfilled": true}'
-            fi
-            
-            # Store success in memory
-            if type loop_store_success &>/dev/null; then
-                loop_store_success "Task completed after $iteration iterations"
-            fi
-            
-            print_success "Ralph loop completed successfully after $iteration iterations"
-            return 0
-        fi
-
-        # Context-remaining guard (t247.1): detect approaching context
-        # exhaustion and proactively signal + push before silent exit.
-        if type loop_context_guard &>/dev/null && \
-           loop_context_guard "$output_file" "$iteration" "$max_iterations" "$output_sizes_file"; then
-            print_success "Context guard: work preserved, signal emitted"
-            return 0
-        fi
-
-        # Track attempt and check for blocking
-        if type loop_track_attempt &>/dev/null; then
-            local attempts
-            attempts=$(loop_track_attempt)
-            
-            if type loop_should_block &>/dev/null && loop_should_block "$max_attempts"; then
-                print_error "Task blocked after $attempts failed attempts"
-                
-                if type loop_block_task &>/dev/null; then
-                    loop_block_task "Max attempts ($max_attempts) reached without completion"
-                fi
-                
-                if type loop_store_failure &>/dev/null; then
-                    loop_store_failure "Task blocked" "Exceeded $max_attempts attempts"
-                fi
-                
-                return 1
-            fi
-        fi
-
-        # Create retry receipt
-        if type loop_create_receipt &>/dev/null; then
-            loop_create_receipt "task" "retry" "{\"iteration\": $iteration, \"exit_code\": $exit_code}"
-        fi
-
-        iteration=$((iteration + 1))
-
-        # Adaptive delay
-        local delay
-        delay=$(calculate_delay "$iteration")
-        print_info "Waiting ${delay}s before next iteration..."
-        sleep "$delay"
-    done
-
-    print_warning "Max iterations ($max_iterations) reached without completion"
-    
-    if type loop_block_task &>/dev/null; then
-        loop_block_task "Max iterations reached"
-    fi
-    
-    return 1
+	# Delegate to shared loop infrastructure (DRY: core loop logic in loop-common.sh)
+	if type loop_run_external &>/dev/null; then
+		loop_run_external "$tool" "$prompt" "$max_iterations" "$completion_promise" \
+			"$max_attempts" "$delay_seconds" "$tool_runner_func"
+	else
+		print_error "loop-common.sh not loaded — cannot run v2 loop"
+		return 1
+	fi
 }
 
 # Calculate adaptive delay with exponential backoff
@@ -371,26 +297,26 @@ To complete, output: <promise>$completion_promise</promise> (ONLY when TRUE)"
 # Returns: 0
 # Output: delay in seconds
 calculate_delay() {
-    local iteration="$1"
-    local delay
+	local iteration="$1"
+	local delay
 
-    if command -v bc &>/dev/null; then
-        delay=$(echo "scale=0; $RALPH_DELAY_BASE * ($RALPH_DELAY_MULTIPLIER ^ ($iteration - 1))" | bc 2>/dev/null || echo "$RALPH_DELAY_BASE")
-        if [[ $(echo "$delay > $RALPH_DELAY_MAX" | bc 2>/dev/null || echo "0") -eq 1 ]]; then
-            delay=$RALPH_DELAY_MAX
-        fi
-    else
-        delay=$RALPH_DELAY_BASE
-        local i=1
-        while [[ $i -lt $iteration ]] && [[ $delay -lt $RALPH_DELAY_MAX ]]; do
-            delay=$((delay * 2))
-            ((i++))
-        done
-        [[ $delay -gt $RALPH_DELAY_MAX ]] && delay=$RALPH_DELAY_MAX
-    fi
+	if command -v bc &>/dev/null; then
+		delay=$(echo "scale=0; $RALPH_DELAY_BASE * ($RALPH_DELAY_MULTIPLIER ^ ($iteration - 1))" | bc 2>/dev/null || echo "$RALPH_DELAY_BASE")
+		if [[ $(echo "$delay > $RALPH_DELAY_MAX" | bc 2>/dev/null || echo "0") -eq 1 ]]; then
+			delay=$RALPH_DELAY_MAX
+		fi
+	else
+		delay=$RALPH_DELAY_BASE
+		local i=1
+		while [[ $i -lt $iteration ]] && [[ $delay -lt $RALPH_DELAY_MAX ]]; do
+			delay=$((delay * 2))
+			((i++))
+		done
+		[[ $delay -gt $RALPH_DELAY_MAX ]] && delay=$RALPH_DELAY_MAX
+	fi
 
-    echo "$delay"
-    return 0
+	echo "$delay"
+	return 0
 }
 
 # =============================================================================
@@ -399,46 +325,46 @@ calculate_delay() {
 
 # Setup a new Ralph loop (legacy mode - same session)
 setup_loop() {
-    local prompt=""
-    local max_iterations=0
-    local completion_promise="null"
-    local prompt_parts=()
+	local prompt=""
+	local max_iterations=0
+	local completion_promise="null"
+	local prompt_parts=()
 
-    while [[ $# -gt 0 ]]; do
-        case $1 in
-            --max-iterations)
-                max_iterations="$2"
-                shift 2
-                ;;
-            --completion-promise)
-                completion_promise="$2"
-                shift 2
-                ;;
-            *)
-                prompt_parts+=("$1")
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+		--max-iterations)
+			max_iterations="$2"
+			shift 2
+			;;
+		--completion-promise)
+			completion_promise="$2"
+			shift 2
+			;;
+		*)
+			prompt_parts+=("$1")
+			shift
+			;;
+		esac
+	done
 
-    prompt="${prompt_parts[*]}"
+	prompt="${prompt_parts[*]}"
 
-    if [[ -z "$prompt" ]]; then
-        print_error "No prompt provided"
-        echo "Usage: $SCRIPT_NAME setup \"<prompt>\" [--max-iterations N] [--completion-promise \"TEXT\"]"
-        return 1
-    fi
+	if [[ -z "$prompt" ]]; then
+		print_error "No prompt provided"
+		echo "Usage: $SCRIPT_NAME setup \"<prompt>\" [--max-iterations N] [--completion-promise \"TEXT\"]"
+		return 1
+	fi
 
-    mkdir -p "$RALPH_STATE_DIR"
+	mkdir -p "$RALPH_STATE_DIR"
 
-    local completion_promise_yaml
-    if [[ -n "$completion_promise" ]] && [[ "$completion_promise" != "null" ]]; then
-        completion_promise_yaml="\"$completion_promise\""
-    else
-        completion_promise_yaml="null"
-    fi
+	local completion_promise_yaml
+	if [[ -n "$completion_promise" ]] && [[ "$completion_promise" != "null" ]]; then
+		completion_promise_yaml="\"$completion_promise\""
+	else
+		completion_promise_yaml="null"
+	fi
 
-    cat > "$RALPH_STATE_FILE" << EOF
+	cat >"$RALPH_STATE_FILE" <<EOF
 ---
 active: true
 iteration: 1
@@ -451,323 +377,325 @@ mode: legacy
 $prompt
 EOF
 
-    check_other_loops
+	check_other_loops
 
-    echo ""
-    print_success "Ralph loop activated (legacy mode)"
-    print_warning "Note: Consider using 'run' command for v2 fresh-context architecture"
-    echo ""
-    echo "Iteration: 1"
-    echo "Max iterations: $(if [[ $max_iterations -gt 0 ]]; then echo "$max_iterations"; else echo "unlimited"; fi)"
-    echo "Completion promise: $(if [[ "$completion_promise" != "null" ]]; then echo "$completion_promise"; else echo "none"; fi)"
-    echo ""
-    echo "State file: $RALPH_STATE_FILE"
+	echo ""
+	print_success "Ralph loop activated (legacy mode)"
+	print_warning "Note: Consider using 'run' command for v2 fresh-context architecture"
+	echo ""
+	echo "Iteration: 1"
+	echo "Max iterations: $(if [[ $max_iterations -gt 0 ]]; then echo "$max_iterations"; else echo "unlimited"; fi)"
+	echo "Completion promise: $(if [[ "$completion_promise" != "null" ]]; then echo "$completion_promise"; else echo "none"; fi)"
+	echo ""
+	echo "State file: $RALPH_STATE_FILE"
 
-    if [[ "$completion_promise" != "null" ]]; then
-        echo ""
-        echo "================================================================"
-        echo "To complete this loop, output: <promise>$completion_promise</promise>"
-        echo "================================================================"
-    fi
+	if [[ "$completion_promise" != "null" ]]; then
+		echo ""
+		echo "================================================================"
+		echo "To complete this loop, output: <promise>$completion_promise</promise>"
+		echo "================================================================"
+	fi
 
-    echo ""
-    echo "$prompt"
+	echo ""
+	echo "$prompt"
 
-    return 0
+	return 0
 }
 
 # Cancel the active Ralph loop
 cancel_loop() {
-    local cancelled=false
+	local cancelled=false
 
-    # Cancel v2 state
-    if type loop_cancel &>/dev/null && [[ -f "${RALPH_STATE_DIR}/loop-state.json" ]]; then
-        loop_cancel
-        cancelled=true
-    fi
+	# Cancel v2 state
+	if type loop_cancel &>/dev/null && [[ -f "${RALPH_STATE_DIR}/loop-state.json" ]]; then
+		loop_cancel
+		cancelled=true
+	fi
 
-    # Cancel legacy state
-    if [[ -f "$RALPH_STATE_FILE" ]]; then
-        local iteration
-        iteration=$(grep '^iteration:' "$RALPH_STATE_FILE" | sed 's/iteration: *//' || echo "unknown")
-        rm "$RALPH_STATE_FILE"
-        print_success "Cancelled legacy Ralph loop (was at iteration $iteration)"
-        cancelled=true
-    fi
+	# Cancel legacy state
+	if [[ -f "$RALPH_STATE_FILE" ]]; then
+		local iteration
+		iteration=$(grep '^iteration:' "$RALPH_STATE_FILE" | sed 's/iteration: *//' || echo "unknown")
+		rm "$RALPH_STATE_FILE"
+		print_success "Cancelled legacy Ralph loop (was at iteration $iteration)"
+		cancelled=true
+	fi
 
-    if [[ "$cancelled" == "false" ]]; then
-        print_warning "No active Ralph loop found"
-    fi
+	if [[ "$cancelled" == "false" ]]; then
+		print_warning "No active Ralph loop found"
+	fi
 
-    return 0
+	return 0
 }
 
 # Show status
 show_status() {
-    local show_all=false
+	local show_all=false
 
-    while [[ $# -gt 0 ]]; do
-        case $1 in
-            --all|-a)
-                show_all=true
-                shift
-                ;;
-            *)
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case $1 in
+		--all | -a)
+			show_all=true
+			shift
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
 
-    if [[ "$show_all" == "true" ]]; then
-        show_status_all
-        return 0
-    fi
+	if [[ "$show_all" == "true" ]]; then
+		show_status_all
+		return 0
+	fi
 
-    # Check v2 state first
-    if type loop_show_status &>/dev/null && [[ -f "${RALPH_STATE_DIR}/loop-state.json" ]]; then
-        echo "=== Ralph Loop v2 Status ==="
-        loop_show_status
-        return 0
-    fi
+	# Check v2 state first
+	if type loop_show_status &>/dev/null && [[ -f "${RALPH_STATE_DIR}/loop-state.json" ]]; then
+		echo "=== Ralph Loop v2 Status ==="
+		loop_show_status
+		return 0
+	fi
 
-    # Fall back to legacy state
-    if [[ -f "$RALPH_STATE_FILE" ]]; then
-        echo "=== Ralph Loop Status (Legacy) ==="
-        echo ""
+	# Fall back to legacy state
+	if [[ -f "$RALPH_STATE_FILE" ]]; then
+		echo "=== Ralph Loop Status (Legacy) ==="
+		echo ""
 
-        local frontmatter
-        frontmatter=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
+		local frontmatter
+		frontmatter=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
 
-        local iteration max_iterations completion_promise started_at
-        iteration=$(echo "$frontmatter" | grep '^iteration:' | sed 's/iteration: *//')
-        max_iterations=$(echo "$frontmatter" | grep '^max_iterations:' | sed 's/max_iterations: *//')
-        completion_promise=$(echo "$frontmatter" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
-        started_at=$(echo "$frontmatter" | grep '^started_at:' | sed 's/started_at: *//' | sed 's/^"\(.*\)"$/\1/')
+		local iteration max_iterations completion_promise started_at
+		iteration=$(echo "$frontmatter" | grep '^iteration:' | sed 's/iteration: *//')
+		max_iterations=$(echo "$frontmatter" | grep '^max_iterations:' | sed 's/max_iterations: *//')
+		completion_promise=$(echo "$frontmatter" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/')
+		started_at=$(echo "$frontmatter" | grep '^started_at:' | sed 's/started_at: *//' | sed 's/^"\(.*\)"$/\1/')
 
-        echo "Mode: legacy (same-session)"
-        echo "Active: yes"
-        echo "Iteration: $iteration"
-        echo "Max iterations: $(if [[ "$max_iterations" == "0" ]]; then echo "unlimited"; else echo "$max_iterations"; fi)"
-        echo "Completion promise: $(if [[ "$completion_promise" == "null" ]]; then echo "none"; else echo "$completion_promise"; fi)"
-        echo "Started: $started_at"
-        echo ""
-        print_warning "Consider migrating to v2: ralph-loop-helper.sh run ..."
-        return 0
-    fi
+		echo "Mode: legacy (same-session)"
+		echo "Active: yes"
+		echo "Iteration: $iteration"
+		echo "Max iterations: $(if [[ "$max_iterations" == "0" ]]; then echo "unlimited"; else echo "$max_iterations"; fi)"
+		echo "Completion promise: $(if [[ "$completion_promise" == "null" ]]; then echo "none"; else echo "$completion_promise"; fi)"
+		echo "Started: $started_at"
+		echo ""
+		print_warning "Consider migrating to v2: ralph-loop-helper.sh run ..."
+		return 0
+	fi
 
-    echo "No active Ralph loop in current directory."
-    echo ""
-    echo "Tip: Use 'status --all' to check all worktrees"
-    return 0
+	echo "No active Ralph loop in current directory."
+	echo ""
+	echo "Tip: Use 'status --all' to check all worktrees"
+	return 0
 }
 
 # Show status across all worktrees
 show_status_all() {
-    echo "Ralph Loop Status - All Worktrees"
-    echo "=================================="
-    echo ""
+	echo "Ralph Loop Status - All Worktrees"
+	echo "=================================="
+	echo ""
 
-    if ! git rev-parse --git-dir &>/dev/null; then
-        print_error "Not in a git repository"
-        return 1
-    fi
+	if ! git rev-parse --git-dir &>/dev/null; then
+		print_error "Not in a git repository"
+		return 1
+	fi
 
-    local found_any=false
-    local current_dir
-    current_dir=$(pwd)
+	local found_any=false
+	local current_dir
+	current_dir=$(pwd)
 
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
-            local worktree_path="${BASH_REMATCH[1]}"
-            
-            # Check for v2 state (new location first, then legacy)
-            local v2_state="$worktree_path/.agents/loop-state/loop-state.json"
-            local v2_state_legacy="$worktree_path/.claude/loop-state.json"
-            local legacy_state="$worktree_path/.agents/loop-state/ralph-loop.local.state"
-            local legacy_state_old="$worktree_path/.claude/ralph-loop.local.state"
-            
-            # Check any of the state file locations
-            if [[ -f "$v2_state" ]] || [[ -f "$v2_state_legacy" ]] || [[ -f "$legacy_state" ]] || [[ -f "$legacy_state_old" ]]; then
-                found_any=true
-                
-                local branch
-                branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || echo "unknown")
-                
-                local marker=""
-                if [[ "$worktree_path" == "$current_dir" ]]; then
-                    marker=" ${GREEN}(current)${NC}"
-                fi
-                
-                echo -e "${BOLD}$branch${NC}$marker"
-                echo "  Path: $worktree_path"
-                
-                # Determine which state file to read (prefer new location)
-                local active_v2_state=""
-                local active_legacy_state=""
-                [[ -f "$v2_state" ]] && active_v2_state="$v2_state"
-                [[ -z "$active_v2_state" && -f "$v2_state_legacy" ]] && active_v2_state="$v2_state_legacy"
-                [[ -f "$legacy_state" ]] && active_legacy_state="$legacy_state"
-                [[ -z "$active_legacy_state" && -f "$legacy_state_old" ]] && active_legacy_state="$legacy_state_old"
-                
-                if [[ -n "$active_v2_state" ]]; then
-                    local iteration max_iterations
-                    iteration=$(jq -r '.iteration // 0' "$active_v2_state" 2>/dev/null || echo "?")
-                    max_iterations=$(jq -r '.max_iterations // 0' "$active_v2_state" 2>/dev/null || echo "?")
-                    echo "  Mode: v2 (fresh context)"
-                    echo "  Iteration: $iteration / $max_iterations"
-                elif [[ -n "$active_legacy_state" ]]; then
-                    local iteration max_iterations
-                    iteration=$(grep '^iteration:' "$active_legacy_state" | sed 's/iteration: *//')
-                    max_iterations=$(grep '^max_iterations:' "$active_legacy_state" | sed 's/max_iterations: *//')
-                    echo "  Mode: legacy (same session)"
-                    echo "  Iteration: $iteration / $(if [[ "$max_iterations" == "0" ]]; then echo "unlimited"; else echo "$max_iterations"; fi)"
-                fi
-                echo ""
-            fi
-        fi
-    done < <(git worktree list --porcelain)
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
+			local worktree_path="${BASH_REMATCH[1]}"
 
-    if [[ "$found_any" == "false" ]]; then
-        echo -e "${GREEN}No active Ralph loops in any worktree${NC}"
-    fi
+			# Check for v2 state (new location first, then legacy)
+			local v2_state="$worktree_path/.agents/loop-state/loop-state.json"
+			local v2_state_legacy="$worktree_path/.claude/loop-state.json"
+			local legacy_state="$worktree_path/.agents/loop-state/ralph-loop.local.state"
+			local legacy_state_old="$worktree_path/.claude/ralph-loop.local.state"
 
-    return 0
+			# Check any of the state file locations
+			if [[ -f "$v2_state" ]] || [[ -f "$v2_state_legacy" ]] || [[ -f "$legacy_state" ]] || [[ -f "$legacy_state_old" ]]; then
+				found_any=true
+
+				local branch
+				branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || echo "unknown")
+
+				local marker=""
+				if [[ "$worktree_path" == "$current_dir" ]]; then
+					marker=" ${GREEN}(current)${NC}"
+				fi
+
+				echo -e "${BOLD}$branch${NC}$marker"
+				echo "  Path: $worktree_path"
+
+				# Determine which state file to read (prefer new location)
+				local active_v2_state=""
+				local active_legacy_state=""
+				[[ -f "$v2_state" ]] && active_v2_state="$v2_state"
+				[[ -z "$active_v2_state" && -f "$v2_state_legacy" ]] && active_v2_state="$v2_state_legacy"
+				[[ -f "$legacy_state" ]] && active_legacy_state="$legacy_state"
+				[[ -z "$active_legacy_state" && -f "$legacy_state_old" ]] && active_legacy_state="$legacy_state_old"
+
+				if [[ -n "$active_v2_state" ]]; then
+					local iteration max_iterations
+					iteration=$(jq -r '.iteration // 0' "$active_v2_state" 2>/dev/null || echo "?")
+					max_iterations=$(jq -r '.max_iterations // 0' "$active_v2_state" 2>/dev/null || echo "?")
+					echo "  Mode: v2 (fresh context)"
+					echo "  Iteration: $iteration / $max_iterations"
+				elif [[ -n "$active_legacy_state" ]]; then
+					local iteration max_iterations
+					iteration=$(grep '^iteration:' "$active_legacy_state" | sed 's/iteration: *//')
+					max_iterations=$(grep '^max_iterations:' "$active_legacy_state" | sed 's/max_iterations: *//')
+					echo "  Mode: legacy (same session)"
+					echo "  Iteration: $iteration / $(if [[ "$max_iterations" == "0" ]]; then echo "unlimited"; else echo "$max_iterations"; fi)"
+				fi
+				echo ""
+			fi
+		fi
+	done < <(git worktree list --porcelain)
+
+	if [[ "$found_any" == "false" ]]; then
+		echo -e "${GREEN}No active Ralph loops in any worktree${NC}"
+	fi
+
+	return 0
 }
 
 # Check for other active loops
 check_other_loops() {
-    if ! git rev-parse --git-dir &>/dev/null; then
-        return 0
-    fi
+	if ! git rev-parse --git-dir &>/dev/null; then
+		return 0
+	fi
 
-    local current_dir
-    current_dir=$(pwd)
-    local other_loops=()
+	local current_dir
+	current_dir=$(pwd)
+	local other_loops=()
 
-    while IFS= read -r line; do
-        if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
-            local worktree_path="${BASH_REMATCH[1]}"
-            
-            if [[ "$worktree_path" == "$current_dir" ]]; then
-                continue
-            fi
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
+			local worktree_path="${BASH_REMATCH[1]}"
 
-            # Check all possible state file locations (new and legacy)
-            local v2_state="$worktree_path/.agents/loop-state/loop-state.json"
-            local v2_state_legacy="$worktree_path/.claude/loop-state.json"
-            local legacy_state="$worktree_path/.agents/loop-state/ralph-loop.local.state"
-            local legacy_state_old="$worktree_path/.claude/ralph-loop.local.state"
+			if [[ "$worktree_path" == "$current_dir" ]]; then
+				continue
+			fi
 
-            if [[ -f "$v2_state" ]] || [[ -f "$v2_state_legacy" ]] || [[ -f "$legacy_state" ]] || [[ -f "$legacy_state_old" ]]; then
-                local branch
-                branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || echo "unknown")
-                local iteration="?"
-                
-                if [[ -f "$v2_state" ]]; then
-                    iteration=$(jq -r '.iteration // 0' "$v2_state" 2>/dev/null || echo "?")
-                elif [[ -f "$v2_state_legacy" ]]; then
-                    iteration=$(jq -r '.iteration // 0' "$v2_state_legacy" 2>/dev/null || echo "?")
-                elif [[ -f "$legacy_state" ]]; then
-                    iteration=$(grep '^iteration:' "$legacy_state" | sed 's/iteration: *//')
-                elif [[ -f "$legacy_state_old" ]]; then
-                    iteration=$(grep '^iteration:' "$legacy_state_old" | sed 's/iteration: *//')
-                fi
-                
-                other_loops+=("$branch (iteration $iteration)")
-            fi
-        fi
-    done < <(git worktree list --porcelain)
+			# Check all possible state file locations (new and legacy)
+			local v2_state="$worktree_path/.agents/loop-state/loop-state.json"
+			local v2_state_legacy="$worktree_path/.claude/loop-state.json"
+			local legacy_state="$worktree_path/.agents/loop-state/ralph-loop.local.state"
+			local legacy_state_old="$worktree_path/.claude/ralph-loop.local.state"
 
-    if [[ ${#other_loops[@]} -gt 0 ]]; then
-        echo ""
-        print_warning "Other active Ralph loops detected:"
-        for loop in "${other_loops[@]}"; do
-            echo "  - $loop"
-        done
-        echo ""
-    fi
+			if [[ -f "$v2_state" ]] || [[ -f "$v2_state_legacy" ]] || [[ -f "$legacy_state" ]] || [[ -f "$legacy_state_old" ]]; then
+				local branch
+				branch=$(git -C "$worktree_path" branch --show-current 2>/dev/null || echo "unknown")
+				local iteration="?"
 
-    return 0
+				if [[ -f "$v2_state" ]]; then
+					iteration=$(jq -r '.iteration // 0' "$v2_state" 2>/dev/null || echo "?")
+				elif [[ -f "$v2_state_legacy" ]]; then
+					iteration=$(jq -r '.iteration // 0' "$v2_state_legacy" 2>/dev/null || echo "?")
+				elif [[ -f "$legacy_state" ]]; then
+					iteration=$(grep '^iteration:' "$legacy_state" | sed 's/iteration: *//')
+				elif [[ -f "$legacy_state_old" ]]; then
+					iteration=$(grep '^iteration:' "$legacy_state_old" | sed 's/iteration: *//')
+				fi
+
+				other_loops+=("$branch (iteration $iteration)")
+			fi
+		fi
+	done < <(git worktree list --porcelain)
+
+	if [[ ${#other_loops[@]} -gt 0 ]]; then
+		echo ""
+		print_warning "Other active Ralph loops detected:"
+		for loop in "${other_loops[@]}"; do
+			echo "  - $loop"
+		done
+		echo ""
+	fi
+
+	return 0
 }
 
 # Generate re-anchor prompt
 generate_reanchor() {
-    if type loop_generate_reanchor &>/dev/null; then
-        local keywords="${1:-}"
-        loop_generate_reanchor "$keywords"
-    else
-        print_error "loop-common.sh not loaded"
-        return 1
-    fi
+	if type loop_generate_reanchor &>/dev/null; then
+		local keywords="${1:-}"
+		loop_generate_reanchor "$keywords"
+	else
+		print_error "loop-common.sh not loaded"
+		return 1
+	fi
 }
 
 # Check completion (legacy)
 check_completion() {
-    local output="$1"
-    local completion_promise="${2:-}"
+	local output="$1"
+	local completion_promise="${2:-}"
 
-    if [[ -z "$completion_promise" ]] || [[ "$completion_promise" == "null" ]]; then
-        echo "NO_PROMISE"
-        return 0
-    fi
+	if [[ -z "$completion_promise" ]] || [[ "$completion_promise" == "null" ]]; then
+		echo "NO_PROMISE"
+		return 0
+	fi
 
-    if grep -q "<promise>$completion_promise</promise>" <<< "$output" 2>/dev/null; then
-        echo "COMPLETE"
-        return 0
-    fi
+	# Whitespace-tolerant matching: allow spaces/newlines inside promise tags
+	if grep -qP "<promise>\s*\Q$completion_promise\E\s*</promise>" <<<"$output" 2>/dev/null ||
+		grep -q "<promise>$completion_promise</promise>" <<<"$output" 2>/dev/null; then
+		echo "COMPLETE"
+		return 0
+	fi
 
-    echo "NOT_COMPLETE"
-    return 0
+	echo "NOT_COMPLETE"
+	return 0
 }
 
 # Increment iteration (legacy)
 increment_iteration() {
-    if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-        print_error "No active Ralph loop to increment"
-        return 1
-    fi
+	if [[ ! -f "$RALPH_STATE_FILE" ]]; then
+		print_error "No active Ralph loop to increment"
+		return 1
+	fi
 
-    local current_iteration
-    current_iteration=$(grep '^iteration:' "$RALPH_STATE_FILE" | sed 's/iteration: *//')
+	local current_iteration
+	current_iteration=$(grep '^iteration:' "$RALPH_STATE_FILE" | sed 's/iteration: *//')
 
-    if [[ ! "$current_iteration" =~ ^[0-9]+$ ]]; then
-        print_error "State file corrupted"
-        return 1
-    fi
+	if [[ ! "$current_iteration" =~ ^[0-9]+$ ]]; then
+		print_error "State file corrupted"
+		return 1
+	fi
 
-    local next_iteration=$((current_iteration + 1))
+	local next_iteration=$((current_iteration + 1))
 
-    local temp_file
-    temp_file=$(mktemp)
-    sed "s/^iteration: .*/iteration: $next_iteration/" "$RALPH_STATE_FILE" > "$temp_file"
-    mv "$temp_file" "$RALPH_STATE_FILE"
+	local temp_file
+	temp_file=$(mktemp)
+	sed "s/^iteration: .*/iteration: $next_iteration/" "$RALPH_STATE_FILE" >"$temp_file"
+	mv "$temp_file" "$RALPH_STATE_FILE"
 
-    echo "$next_iteration"
-    return 0
+	echo "$next_iteration"
+	return 0
 }
 
 # Get prompt (legacy)
 get_prompt() {
-    if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-        print_error "No active Ralph loop"
-        return 1
-    fi
+	if [[ ! -f "$RALPH_STATE_FILE" ]]; then
+		print_error "No active Ralph loop"
+		return 1
+	fi
 
-    awk '/^---$/{i++; next} i>=2' "$RALPH_STATE_FILE"
-    return 0
+	awk '/^---$/{i++; next} i>=2' "$RALPH_STATE_FILE"
+	return 0
 }
 
 # Get completion promise (legacy)
 get_completion_promise() {
-    if [[ ! -f "$RALPH_STATE_FILE" ]]; then
-        echo "null"
-        return 0
-    fi
+	if [[ ! -f "$RALPH_STATE_FILE" ]]; then
+		echo "null"
+		return 0
+	fi
 
-    local frontmatter
-    frontmatter=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
-    echo "$frontmatter" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/'
-    return 0
+	local frontmatter
+	frontmatter=$(sed -n '/^---$/,/^---$/{ /^---$/d; p; }' "$RALPH_STATE_FILE")
+	echo "$frontmatter" | grep '^completion_promise:' | sed 's/completion_promise: *//' | sed 's/^"\(.*\)"$/\1/'
+	return 0
 }
 
 # =============================================================================
@@ -775,57 +703,57 @@ get_completion_promise() {
 # =============================================================================
 
 main() {
-    local command="${1:-help}"
-    shift || true
+	local command="${1:-help}"
+	shift || true
 
-    case "$command" in
-        run)
-            run_v2_loop "$@"
-            ;;
-        external)
-            # Legacy alias for 'run'
-            run_v2_loop "$@"
-            ;;
-        setup)
-            setup_loop "$@"
-            ;;
-        cancel)
-            cancel_loop
-            ;;
-        status)
-            show_status "$@"
-            ;;
-        reanchor)
-            generate_reanchor "$@"
-            ;;
-        check|check-completion)
-            if [[ $# -lt 1 ]]; then
-                print_error "check requires output text as argument"
-                return 1
-            fi
-            local output="$1"
-            local promise="${2:-$(get_completion_promise)}"
-            check_completion "$output" "$promise"
-            ;;
-        increment)
-            increment_iteration
-            ;;
-        get-prompt)
-            get_prompt
-            ;;
-        get-completion-promise)
-            get_completion_promise
-            ;;
-        help|--help|-h)
-            show_help
-            ;;
-        *)
-            print_error "Unknown command: $command"
-            echo ""
-            show_help
-            return 1
-            ;;
-    esac
+	case "$command" in
+	run)
+		run_v2_loop "$@"
+		;;
+	external)
+		# Legacy alias for 'run'
+		run_v2_loop "$@"
+		;;
+	setup)
+		setup_loop "$@"
+		;;
+	cancel)
+		cancel_loop
+		;;
+	status)
+		show_status "$@"
+		;;
+	reanchor)
+		generate_reanchor "$@"
+		;;
+	check | check-completion)
+		if [[ $# -lt 1 ]]; then
+			print_error "check requires output text as argument"
+			return 1
+		fi
+		local output="$1"
+		local promise="${2:-$(get_completion_promise)}"
+		check_completion "$output" "$promise"
+		;;
+	increment)
+		increment_iteration
+		;;
+	get-prompt)
+		get_prompt
+		;;
+	get-completion-promise)
+		get_completion_promise
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		echo ""
+		show_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -66,33 +66,33 @@ export LC_NC='\033[0m'
 # =============================================================================
 
 loop_log_error() {
-    local message="$1"
-    echo -e "${LC_RED}[loop] Error:${LC_NC} ${message}" >&2
-    return 0
+	local message="$1"
+	echo -e "${LC_RED}[loop] Error:${LC_NC} ${message}" >&2
+	return 0
 }
 
 loop_log_success() {
-    local message="$1"
-    echo -e "${LC_GREEN}[loop]${LC_NC} ${message}"
-    return 0
+	local message="$1"
+	echo -e "${LC_GREEN}[loop]${LC_NC} ${message}"
+	return 0
 }
 
 loop_log_warn() {
-    local message="$1"
-    echo -e "${LC_YELLOW}[loop]${LC_NC} ${message}"
-    return 0
+	local message="$1"
+	echo -e "${LC_YELLOW}[loop]${LC_NC} ${message}"
+	return 0
 }
 
 loop_log_info() {
-    local message="$1"
-    echo -e "${LC_BLUE}[loop]${LC_NC} ${message}"
-    return 0
+	local message="$1"
+	echo -e "${LC_BLUE}[loop]${LC_NC} ${message}"
+	return 0
 }
 
 loop_log_step() {
-    local message="$1"
-    echo -e "${LC_CYAN}[loop]${LC_NC} ${message}"
-    return 0
+	local message="$1"
+	echo -e "${LC_CYAN}[loop]${LC_NC} ${message}"
+	return 0
 }
 
 # =============================================================================
@@ -103,9 +103,9 @@ loop_log_step() {
 # Arguments: none
 # Returns: 0
 loop_init_state_dir() {
-    mkdir -p "$LOOP_STATE_DIR"
-    mkdir -p "$LOOP_RECEIPTS_DIR"
-    return 0
+	mkdir -p "$LOOP_STATE_DIR"
+	mkdir -p "$LOOP_RECEIPTS_DIR"
+	return 0
 }
 
 # Create new loop state
@@ -117,24 +117,24 @@ loop_init_state_dir() {
 #   $5 - task_id (optional)
 # Returns: 0 on success, 1 on error
 loop_create_state() {
-    local loop_type="$1"
-    local prompt="$2"
-    local max_iterations="${3:-50}"
-    local completion_promise="${4:-TASK_COMPLETE}"
-    local task_id="${5:-}"
-    
-    loop_init_state_dir
-    
-    # Generate task_id if not provided
-    if [[ -z "$task_id" ]]; then
-        task_id="loop_$(date +%Y%m%d%H%M%S)"
-    fi
-    
-    local started_at
-    started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    
-    # Create JSON state file
-    cat > "$LOOP_STATE_FILE" << EOF
+	local loop_type="$1"
+	local prompt="$2"
+	local max_iterations="${3:-50}"
+	local completion_promise="${4:-TASK_COMPLETE}"
+	local task_id="${5:-}"
+
+	loop_init_state_dir
+
+	# Generate task_id if not provided
+	if [[ -z "$task_id" ]]; then
+		task_id="loop_$(date +%Y%m%d%H%M%S)"
+	fi
+
+	local started_at
+	started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	# Create JSON state file
+	cat >"$LOOP_STATE_FILE" <<EOF
 {
   "loop_type": "$loop_type",
   "prompt": $(echo "$prompt" | jq -Rs .),
@@ -151,9 +151,9 @@ loop_create_state() {
   "active": true
 }
 EOF
-    
-    loop_log_success "Loop state created: $LOOP_STATE_FILE"
-    return 0
+
+	loop_log_success "Loop state created: $LOOP_STATE_FILE"
+	return 0
 }
 
 # Read loop state value
@@ -162,15 +162,15 @@ EOF
 # Returns: 0
 # Output: Value to stdout
 loop_get_state() {
-    local key="$1"
-    
-    if [[ ! -f "$LOOP_STATE_FILE" ]]; then
-        echo ""
-        return 0
-    fi
-    
-    jq -r "$key // empty" "$LOOP_STATE_FILE" 2>/dev/null || echo ""
-    return 0
+	local key="$1"
+
+	if [[ ! -f "$LOOP_STATE_FILE" ]]; then
+		echo ""
+		return 0
+	fi
+
+	jq -r "$key // empty" "$LOOP_STATE_FILE" 2>/dev/null || echo ""
+	return 0
 }
 
 # Update loop state value
@@ -179,36 +179,37 @@ loop_get_state() {
 #   $2 - New value (will be auto-typed: number, string, bool)
 # Returns: 0 on success, 1 on error
 loop_set_state() {
-    local key="$1"
-    local value="$2"
-    
-    if [[ ! -f "$LOOP_STATE_FILE" ]]; then
-        loop_log_error "No active loop state"
-        return 1
-    fi
-    
-    local temp_file
-    temp_file=$(mktemp)
-    _save_cleanup_scope; trap '_run_cleanups' RETURN
-    push_cleanup "rm -f '${temp_file}'"
-    
-    # Determine value type and update
-    if [[ "$value" =~ ^[0-9]+$ ]]; then
-        # Integer
-        jq "$key = $value" "$LOOP_STATE_FILE" > "$temp_file"
-    elif [[ "$value" == "true" || "$value" == "false" ]]; then
-        # Boolean
-        jq "$key = $value" "$LOOP_STATE_FILE" > "$temp_file"
-    elif [[ "$value" == "null" ]]; then
-        # Null
-        jq "$key = null" "$LOOP_STATE_FILE" > "$temp_file"
-    else
-        # String
-        jq "$key = \"$value\"" "$LOOP_STATE_FILE" > "$temp_file"
-    fi
-    
-    mv "$temp_file" "$LOOP_STATE_FILE"
-    return 0
+	local key="$1"
+	local value="$2"
+
+	if [[ ! -f "$LOOP_STATE_FILE" ]]; then
+		loop_log_error "No active loop state"
+		return 1
+	fi
+
+	local temp_file
+	temp_file=$(mktemp)
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	push_cleanup "rm -f '${temp_file}'"
+
+	# Determine value type and update
+	if [[ "$value" =~ ^[0-9]+$ ]]; then
+		# Integer
+		jq "$key = $value" "$LOOP_STATE_FILE" >"$temp_file"
+	elif [[ "$value" == "true" || "$value" == "false" ]]; then
+		# Boolean
+		jq "$key = $value" "$LOOP_STATE_FILE" >"$temp_file"
+	elif [[ "$value" == "null" ]]; then
+		# Null
+		jq "$key = null" "$LOOP_STATE_FILE" >"$temp_file"
+	else
+		# String - use --arg to handle special characters safely
+		jq --arg val "$value" "$key = \$val" "$LOOP_STATE_FILE" >"$temp_file"
+	fi
+
+	mv "$temp_file" "$LOOP_STATE_FILE"
+	return 0
 }
 
 # Increment iteration counter
@@ -216,52 +217,52 @@ loop_set_state() {
 # Returns: 0
 # Output: New iteration number
 loop_increment_iteration() {
-    local current
-    current=$(loop_get_state ".iteration")
-    local next=$((current + 1))
-    
-    loop_set_state ".iteration" "$next"
-    loop_set_state ".last_iteration_at" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-    
-    echo "$next"
-    return 0
+	local current
+	current=$(loop_get_state ".iteration")
+	local next=$((current + 1))
+
+	loop_set_state ".iteration" "$next"
+	loop_set_state ".last_iteration_at" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+	echo "$next"
+	return 0
 }
 
 # Check if loop is active
 # Arguments: none
 # Returns: 0 if active, 1 if not
 loop_is_active() {
-    if [[ ! -f "$LOOP_STATE_FILE" ]]; then
-        return 1
-    fi
-    
-    local active
-    active=$(loop_get_state ".active")
-    [[ "$active" == "true" ]]
+	if [[ ! -f "$LOOP_STATE_FILE" ]]; then
+		return 1
+	fi
+
+	local active
+	active=$(loop_get_state ".active")
+	[[ "$active" == "true" ]]
 }
 
 # Cancel loop
 # Arguments: none
 # Returns: 0
 loop_cancel() {
-    if [[ -f "$LOOP_STATE_FILE" ]]; then
-        loop_set_state ".active" "false"
-        loop_log_success "Loop cancelled"
-    else
-        loop_log_warn "No active loop to cancel"
-    fi
-    return 0
+	if [[ -f "$LOOP_STATE_FILE" ]]; then
+		loop_set_state ".active" "false"
+		loop_log_success "Loop cancelled"
+	else
+		loop_log_warn "No active loop to cancel"
+	fi
+	return 0
 }
 
 # Clean up loop state
 # Arguments: none
 # Returns: 0
 loop_cleanup() {
-    rm -f "$LOOP_STATE_FILE"
-    rm -f "$LOOP_REANCHOR_FILE"
-    # Keep receipts for audit trail
-    loop_log_info "Loop state cleaned up (receipts preserved)"
-    return 0
+	rm -f "$LOOP_STATE_FILE"
+	rm -f "$LOOP_REANCHOR_FILE"
+	# Keep receipts for audit trail
+	loop_log_info "Loop state cleaned up (receipts preserved)"
+	return 0
 }
 
 # =============================================================================
@@ -277,35 +278,35 @@ loop_cleanup() {
 # Returns: 0
 # Output: Guardrails markdown to stdout
 loop_generate_guardrails() {
-    local max_signs="${1:-5}"
-    local task_id
-    task_id=$(loop_get_state ".task_id")
-    
-    # Check if memory helper is available
-    if ! command -v "$LOOP_MEMORY_HELPER" &>/dev/null; then
-        echo "No guardrails (memory system unavailable)"
-        return 0
-    fi
-    
-    # Query memory for FAILED_APPROACH entries from this loop
-    local failures
-    failures=$("$LOOP_MEMORY_HELPER" recall \
-        "failure retry loop $task_id" \
-        --limit "$max_signs" \
-        --format json 2>/dev/null || echo "[]")
-    
-    # Check if we have any failures
-    local count
-    count=$(echo "$failures" | jq 'length' 2>/dev/null || echo "0")
-    
-    if [[ "$count" == "0" || "$count" == "null" ]]; then
-        echo "No guardrails yet (no recorded failures)."
-        return 0
-    fi
-    
-    # Transform failures to guardrail format
-    # Format: "Failed: X. Reason: Y" -> sign with trigger and instruction
-    echo "$failures" | jq -r '
+	local max_signs="${1:-5}"
+	local task_id
+	task_id=$(loop_get_state ".task_id")
+
+	# Check if memory helper is available
+	if ! command -v "$LOOP_MEMORY_HELPER" &>/dev/null; then
+		echo "No guardrails (memory system unavailable)"
+		return 0
+	fi
+
+	# Query memory for FAILED_APPROACH entries from this loop
+	local failures
+	failures=$("$LOOP_MEMORY_HELPER" recall \
+		"failure retry loop $task_id" \
+		--limit "$max_signs" \
+		--format json 2>/dev/null || echo "[]")
+
+	# Check if we have any failures
+	local count
+	count=$(echo "$failures" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" == "0" || "$count" == "null" ]]; then
+		echo "No guardrails yet (no recorded failures)."
+		return 0
+	fi
+
+	# Transform failures to guardrail format
+	# Format: "Failed: X. Reason: Y" -> sign with trigger and instruction
+	echo "$failures" | jq -r '
         .[] | 
         "### Sign: " + (
             .content // .memory // "" | 
@@ -319,8 +320,8 @@ loop_generate_guardrails() {
             gsub("^ "; "")
         ) + "\n"
     ' 2>/dev/null || echo "No guardrails (parse error)."
-    
-    return 0
+
+	return 0
 }
 
 # =============================================================================
@@ -333,82 +334,82 @@ loop_generate_guardrails() {
 # Returns: 0
 # Output: Re-anchor prompt to stdout and file
 loop_generate_reanchor() {
-    local task_keywords="${1:-}"
-    local task_id
-    task_id=$(loop_get_state ".task_id")
-    local iteration
-    iteration=$(loop_get_state ".iteration")
-    local prompt
-    prompt=$(loop_get_state ".prompt")
-    
-    loop_init_state_dir
-    
-    # Get git state
-    local git_status
-    git_status=$(git status --short 2>/dev/null || echo "Not a git repo")
-    local git_log
-    git_log=$(git log -5 --oneline 2>/dev/null || echo "No git history")
-    local git_branch
-    git_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
-    
-    # Detect headless worker mode (t173: workers must not interact with TODO.md)
-    local is_headless="false"
-    if [[ "${FULL_LOOP_HEADLESS:-false}" == "true" ]]; then
-        is_headless="true"
-    fi
+	local task_keywords="${1:-}"
+	local task_id
+	task_id=$(loop_get_state ".task_id")
+	local iteration
+	iteration=$(loop_get_state ".iteration")
+	local prompt
+	prompt=$(loop_get_state ".prompt")
 
-    # Get TODO.md in-progress tasks (read-only context, skip in headless mode - t173)
-    local todo_in_progress=""
-    if [[ "$is_headless" == "false" && -f "TODO.md" ]]; then
-        todo_in_progress=$(grep -A10 "## In Progress" TODO.md 2>/dev/null | head -15 || echo "No tasks in progress")
-    fi
-    
-    # Extract single next task (the "pin" concept from Loom)
-    # Focus on ONE task per iteration to reduce context drift
-    # Skip in headless mode — workers work on their assigned task only (t173)
-    local next_task=""
-    if [[ "$is_headless" == "false" && -f "TODO.md" ]]; then
-        # Get first unchecked task from In Progress section, or first from Backlog
-        next_task=$(awk '
+	loop_init_state_dir
+
+	# Get git state
+	local git_status
+	git_status=$(git status --short 2>/dev/null || echo "Not a git repo")
+	local git_log
+	git_log=$(git log -5 --oneline 2>/dev/null || echo "No git history")
+	local git_branch
+	git_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+
+	# Detect headless worker mode (t173: workers must not interact with TODO.md)
+	local is_headless="false"
+	if [[ "${FULL_LOOP_HEADLESS:-false}" == "true" ]]; then
+		is_headless="true"
+	fi
+
+	# Get TODO.md in-progress tasks (read-only context, skip in headless mode - t173)
+	local todo_in_progress=""
+	if [[ "$is_headless" == "false" && -f "TODO.md" ]]; then
+		todo_in_progress=$(grep -A10 "## In Progress" TODO.md 2>/dev/null | head -15 || echo "No tasks in progress")
+	fi
+
+	# Extract single next task (the "pin" concept from Loom)
+	# Focus on ONE task per iteration to reduce context drift
+	# Skip in headless mode — workers work on their assigned task only (t173)
+	local next_task=""
+	if [[ "$is_headless" == "false" && -f "TODO.md" ]]; then
+		# Get first unchecked task from In Progress section, or first from Backlog
+		next_task=$(awk '
             /^## In Progress/,/^##/ { if (/^- \[ \]/) { print; exit } }
         ' TODO.md 2>/dev/null || echo "")
-        
-        if [[ -z "$next_task" ]]; then
-            next_task=$(awk '
+
+		if [[ -z "$next_task" ]]; then
+			next_task=$(awk '
                 /^## Backlog/,/^##/ { if (/^- \[ \]/) { print; exit } }
             ' TODO.md 2>/dev/null || echo "")
-        fi
-    fi
-    
-    # Get relevant memories
-    local memories=""
-    if [[ -n "$task_keywords" ]] && command -v "$LOOP_MEMORY_HELPER" &>/dev/null; then
-        memories=$("$LOOP_MEMORY_HELPER" recall "$task_keywords" --limit 5 --format text 2>/dev/null || echo "No relevant memories")
-    fi
-    
-    # Check mailbox for pending messages
-    local mailbox_messages=""
-    if [[ -x "$LOOP_MAIL_HELPER" ]]; then
-        mailbox_messages=$("$LOOP_MAIL_HELPER" check --unread-only 2>/dev/null || echo "No mailbox messages")
-    fi
-    
-    # Generate guardrails from failures (the "signs" concept)
-    # These are actionable rules derived from past failures - "same mistake never happens twice"
-    local guardrails
-    guardrails=$(loop_generate_guardrails 5)
-    
-    # Get latest receipt
-    local latest_receipt=""
-    local latest_receipt_file
-    latest_receipt_file=$(find "$LOOP_RECEIPTS_DIR" -name "*.json" -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || echo "")
-    if [[ -n "$latest_receipt_file" && -f "$latest_receipt_file" ]]; then
-        latest_receipt=$(cat "$latest_receipt_file")
-    fi
-    
-    # Build headless worker restriction block (t173)
-    local headless_restriction=""
-    if [[ "$is_headless" == "true" ]]; then
-        headless_restriction="
+		fi
+	fi
+
+	# Get relevant memories
+	local memories=""
+	if [[ -n "$task_keywords" ]] && command -v "$LOOP_MEMORY_HELPER" &>/dev/null; then
+		memories=$("$LOOP_MEMORY_HELPER" recall "$task_keywords" --limit 5 --format text 2>/dev/null || echo "No relevant memories")
+	fi
+
+	# Check mailbox for pending messages
+	local mailbox_messages=""
+	if [[ -x "$LOOP_MAIL_HELPER" ]]; then
+		mailbox_messages=$("$LOOP_MAIL_HELPER" check --unread-only 2>/dev/null || echo "No mailbox messages")
+	fi
+
+	# Generate guardrails from failures (the "signs" concept)
+	# These are actionable rules derived from past failures - "same mistake never happens twice"
+	local guardrails
+	guardrails=$(loop_generate_guardrails 5)
+
+	# Get latest receipt
+	local latest_receipt=""
+	local latest_receipt_file
+	latest_receipt_file=$(find "$LOOP_RECEIPTS_DIR" -name "*.json" -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || echo "")
+	if [[ -n "$latest_receipt_file" && -f "$latest_receipt_file" ]]; then
+		latest_receipt=$(cat "$latest_receipt_file")
+	fi
+
+	# Build headless worker restriction block (t173)
+	local headless_restriction=""
+	if [[ "$is_headless" == "true" ]]; then
+		headless_restriction="
 ## MANDATORY Worker Restrictions (t173 - Headless Mode)
 
 - **Do NOT edit, commit, or push TODO.md** — the supervisor owns all TODO.md updates.
@@ -418,19 +419,19 @@ loop_generate_reanchor() {
 - Work ONLY on the assigned task described above. Do not pick tasks from TODO.md.
 - **ShellCheck before push (t234)**: Before every \`git push\`, if any committed .sh files changed, run \`shellcheck -x -S warning\` on them. Fix violations before pushing. Skip if shellcheck is not installed.
 "
-    fi
+	fi
 
-    # Build TODO.md section (omitted in headless mode - t173)
-    local todo_section=""
-    if [[ "$is_headless" == "false" ]]; then
-        todo_section="### TODO.md In Progress
+	# Build TODO.md section (omitted in headless mode - t173)
+	local todo_section=""
+	if [[ "$is_headless" == "false" ]]; then
+		todo_section="### TODO.md In Progress
 \`\`\`
 $todo_in_progress
 \`\`\`"
-    fi
+	fi
 
-    # Generate re-anchor prompt with single-task focus
-    cat > "$LOOP_REANCHOR_FILE" << EOF
+	# Generate re-anchor prompt with single-task focus
+	cat >"$LOOP_REANCHOR_FILE" <<EOF
 # Re-Anchor Context (MANDATORY - Read Before Any Work)
 
 **Loop:** $task_id | **Iteration:** $iteration | **Branch:** $git_branch
@@ -488,9 +489,9 @@ complete the next step), IMMEDIATELY: (1) \`git add -A && git commit -m "wip: co
 (2) \`git push\`, (3) output: <promise>$(loop_get_state ".completion_promise")</promise>.
 Do NOT attempt complex work when context is low — preserve what you have.
 EOF
-    
-    cat "$LOOP_REANCHOR_FILE"
-    return 0
+
+	cat "$LOOP_REANCHOR_FILE"
+	return 0
 }
 
 # =============================================================================
@@ -505,26 +506,26 @@ EOF
 # Returns: 0
 # Output: Receipt file path
 loop_create_receipt() {
-    local receipt_type="$1"
-    local outcome="$2"
-    local evidence="${3:-{}}"
-    
-    local task_id
-    task_id=$(loop_get_state ".task_id")
-    local iteration
-    iteration=$(loop_get_state ".iteration")
-    local timestamp
-    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-    
-    loop_init_state_dir
-    
-    local receipt_file="${LOOP_RECEIPTS_DIR}/${receipt_type}-${task_id}-iter${iteration}.json"
-    
-    # Get commit hash if available
-    local commit_hash
-    commit_hash=$(git rev-parse --short HEAD 2>/dev/null || echo "none")
-    
-    cat > "$receipt_file" << EOF
+	local receipt_type="$1"
+	local outcome="$2"
+	local evidence="${3:-{}}"
+
+	local task_id
+	task_id=$(loop_get_state ".task_id")
+	local iteration
+	iteration=$(loop_get_state ".iteration")
+	local timestamp
+	timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	loop_init_state_dir
+
+	local receipt_file="${LOOP_RECEIPTS_DIR}/${receipt_type}-${task_id}-iter${iteration}.json"
+
+	# Get commit hash if available
+	local commit_hash
+	commit_hash=$(git rev-parse --short HEAD 2>/dev/null || echo "none")
+
+	cat >"$receipt_file" <<EOF
 {
   "type": "$receipt_type",
   "id": "$task_id",
@@ -535,22 +536,16 @@ loop_create_receipt() {
   "evidence": $evidence
 }
 EOF
-    
-    # Add receipt to state
-    local receipts
-    receipts=$(loop_get_state ".receipts")
-    if [[ -z "$receipts" || "$receipts" == "null" ]]; then
-        receipts="[]"
-    fi
-    
-    local temp_file
-    temp_file=$(mktemp)
-    jq ".receipts += [\"$(basename "$receipt_file")\"]" "$LOOP_STATE_FILE" > "$temp_file"
-    mv "$temp_file" "$LOOP_STATE_FILE"
-    
-    loop_log_success "Receipt created: $receipt_file"
-    echo "$receipt_file"
-    return 0
+
+	# Add receipt to state
+	local temp_file
+	temp_file=$(mktemp)
+	jq --arg receipt "$(basename "$receipt_file")" '.receipts += [$receipt]' "$LOOP_STATE_FILE" >"$temp_file"
+	mv "$temp_file" "$LOOP_STATE_FILE"
+
+	loop_log_success "Receipt created: $receipt_file"
+	echo "$receipt_file"
+	return 0
 }
 
 # Verify receipt exists for current iteration
@@ -558,21 +553,21 @@ EOF
 #   $1 - type (task|preflight|pr-review|postflight)
 # Returns: 0 if receipt exists, 1 if not
 loop_verify_receipt() {
-    local receipt_type="$1"
-    local task_id
-    task_id=$(loop_get_state ".task_id")
-    local iteration
-    iteration=$(loop_get_state ".iteration")
-    
-    local receipt_file="${LOOP_RECEIPTS_DIR}/${receipt_type}-${task_id}-iter${iteration}.json"
-    
-    if [[ -f "$receipt_file" ]]; then
-        loop_log_success "Receipt verified: $receipt_file"
-        return 0
-    else
-        loop_log_warn "Missing receipt: $receipt_file"
-        return 1
-    fi
+	local receipt_type="$1"
+	local task_id
+	task_id=$(loop_get_state ".task_id")
+	local iteration
+	iteration=$(loop_get_state ".iteration")
+
+	local receipt_file="${LOOP_RECEIPTS_DIR}/${receipt_type}-${task_id}-iter${iteration}.json"
+
+	if [[ -f "$receipt_file" ]]; then
+		loop_log_success "Receipt verified: $receipt_file"
+		return 0
+	else
+		loop_log_warn "Missing receipt: $receipt_file"
+		return 1
+	fi
 }
 
 # Get latest receipt for a type
@@ -581,17 +576,17 @@ loop_verify_receipt() {
 # Returns: 0
 # Output: Receipt JSON to stdout
 loop_get_latest_receipt() {
-    local receipt_type="$1"
-    
-    local latest
-    latest=$(find "$LOOP_RECEIPTS_DIR" -name "${receipt_type}-*.json" -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || echo "")
-    
-    if [[ -n "$latest" && -f "$latest" ]]; then
-        cat "$latest"
-    else
-        echo "{}"
-    fi
-    return 0
+	local receipt_type="$1"
+
+	local latest
+	latest=$(find "$LOOP_RECEIPTS_DIR" -name "${receipt_type}-*.json" -type f -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || echo "")
+
+	if [[ -n "$latest" && -f "$latest" ]]; then
+		cat "$latest"
+	else
+		echo "{}"
+	fi
+	return 0
 }
 
 # =============================================================================
@@ -605,22 +600,22 @@ loop_get_latest_receipt() {
 #   $3 - tags (comma-separated)
 # Returns: 0
 loop_store_memory() {
-    local memory_type="$1"
-    local content="$2"
-    local tags="${3:-loop}"
-    
-    local task_id
-    task_id=$(loop_get_state ".task_id")
-    
-    if command -v "$LOOP_MEMORY_HELPER" &>/dev/null; then
-        "$LOOP_MEMORY_HELPER" store \
-            --type "$memory_type" \
-            --content "$content" \
-            --tags "$tags,loop,$task_id" \
-            --session-id "$task_id" 2>/dev/null || true
-        loop_log_info "Memory stored: $memory_type"
-    fi
-    return 0
+	local memory_type="$1"
+	local content="$2"
+	local tags="${3:-loop}"
+
+	local task_id
+	task_id=$(loop_get_state ".task_id")
+
+	if command -v "$LOOP_MEMORY_HELPER" &>/dev/null; then
+		"$LOOP_MEMORY_HELPER" store \
+			--type "$memory_type" \
+			--content "$content" \
+			--tags "$tags,loop,$task_id" \
+			--session-id "$task_id" 2>/dev/null || true
+		loop_log_info "Memory stored: $memory_type"
+	fi
+	return 0
 }
 
 # Store failed approach (called on retry)
@@ -629,11 +624,11 @@ loop_store_memory() {
 #   $2 - why it failed (optional)
 # Returns: 0
 loop_store_failure() {
-    local what_failed="$1"
-    local why="${2:-Unknown reason}"
-    
-    loop_store_memory "FAILED_APPROACH" "Failed: $what_failed. Reason: $why" "failure,retry"
-    return 0
+	local what_failed="$1"
+	local why="${2:-Unknown reason}"
+
+	loop_store_memory "FAILED_APPROACH" "Failed: $what_failed. Reason: $why" "failure,retry"
+	return 0
 }
 
 # Store successful solution (called on completion)
@@ -641,10 +636,10 @@ loop_store_failure() {
 #   $1 - what worked
 # Returns: 0
 loop_store_success() {
-    local what_worked="$1"
-    
-    loop_store_memory "WORKING_SOLUTION" "Success: $what_worked" "success,solution"
-    return 0
+	local what_worked="$1"
+
+	loop_store_memory "WORKING_SOLUTION" "Success: $what_worked" "success,solution"
+	return 0
 }
 
 # =============================================================================
@@ -657,23 +652,23 @@ loop_store_success() {
 # Returns: 0
 # Output: New attempt count
 loop_track_attempt() {
-    local task_id="${1:-$(loop_get_state ".task_id")}"
-    
-    local attempts
-    attempts=$(jq -r ".attempts[\"$task_id\"] // 0" "$LOOP_STATE_FILE" 2>/dev/null || echo "0")
-    local new_attempts=$((attempts + 1))
-    
-    local temp_file
-    temp_file=$(mktemp)
-    jq ".attempts[\"$task_id\"] = $new_attempts" "$LOOP_STATE_FILE" > "$temp_file"
-    mv "$temp_file" "$LOOP_STATE_FILE"
-    
-    echo "$new_attempts"
-    return 0
+	local task_id="${1:-$(loop_get_state ".task_id")}"
+
+	local attempts
+	attempts=$(jq -r ".attempts[\"$task_id\"] // 0" "$LOOP_STATE_FILE" 2>/dev/null || echo "0")
+	local new_attempts=$((attempts + 1))
+
+	local temp_file
+	temp_file=$(mktemp)
+	jq ".attempts[\"$task_id\"] = $new_attempts" "$LOOP_STATE_FILE" >"$temp_file"
+	mv "$temp_file" "$LOOP_STATE_FILE"
+
+	echo "$new_attempts"
+	return 0
 }
 
 # Check if task should be blocked (gutter detection)
-# When the same task fails repeatedly, it's likely "in the gutter" - 
+# When the same task fails repeatedly, it's likely "in the gutter" -
 # adding more iterations won't help, need a different approach.
 #
 # Arguments:
@@ -681,20 +676,20 @@ loop_track_attempt() {
 #   $2 - task_id (optional)
 # Returns: 0 if should block, 1 if not
 loop_should_block() {
-    local max_attempts="${1:-5}"
-    local task_id="${2:-$(loop_get_state ".task_id")}"
-    
-    local attempts
-    attempts=$(jq -r ".attempts[\"$task_id\"] // 0" "$LOOP_STATE_FILE" 2>/dev/null || echo "0")
-    
-    # Warn at 80% of max attempts (gutter warning)
-    local warn_threshold=$(( (max_attempts * 4) / 5 ))
-    if [[ "$attempts" -ge "$warn_threshold" && "$attempts" -lt "$max_attempts" ]]; then
-        loop_log_warn "Possible gutter: $attempts/$max_attempts attempts on task $task_id"
-        loop_log_warn "Consider: different approach, smaller scope, or human review"
-    fi
-    
-    [[ "$attempts" -ge "$max_attempts" ]]
+	local max_attempts="${1:-5}"
+	local task_id="${2:-$(loop_get_state ".task_id")}"
+
+	local attempts
+	attempts=$(jq -r ".attempts[\"$task_id\"] // 0" "$LOOP_STATE_FILE" 2>/dev/null || echo "0")
+
+	# Warn at 80% of max attempts (gutter warning)
+	local warn_threshold=$(((max_attempts * 4) / 5))
+	if [[ "$attempts" -ge "$warn_threshold" && "$attempts" -lt "$max_attempts" ]]; then
+		loop_log_warn "Possible gutter: $attempts/$max_attempts attempts on task $task_id"
+		loop_log_warn "Consider: different approach, smaller scope, or human review"
+	fi
+
+	[[ "$attempts" -ge "$max_attempts" ]]
 }
 
 # Block a task
@@ -703,17 +698,21 @@ loop_should_block() {
 #   $2 - task_id (optional)
 # Returns: 0
 loop_block_task() {
-    local reason="$1"
-    local task_id="${2:-$(loop_get_state ".task_id")}"
-    
-    local temp_file
-    temp_file=$(mktemp)
-    jq ".blocked_tasks += [{\"id\": \"$task_id\", \"reason\": \"$reason\", \"blocked_at\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\"}]" "$LOOP_STATE_FILE" > "$temp_file"
-    mv "$temp_file" "$LOOP_STATE_FILE"
-    
-    loop_store_failure "Task blocked after multiple attempts" "$reason"
-    loop_log_warn "Task $task_id blocked: $reason"
-    return 0
+	local reason="$1"
+	local task_id="${2:-$(loop_get_state ".task_id")}"
+
+	local temp_file
+	temp_file=$(mktemp)
+	local blocked_at
+	blocked_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+	jq --arg task_id "$task_id" --arg reason "$reason" --arg blocked_at "$blocked_at" \
+		'.blocked_tasks += [{"id": $task_id, "reason": $reason, "blocked_at": $blocked_at}]' \
+		"$LOOP_STATE_FILE" >"$temp_file"
+	mv "$temp_file" "$LOOP_STATE_FILE"
+
+	loop_store_failure "Task blocked after multiple attempts" "$reason"
+	loop_log_warn "Task $task_id blocked: $reason"
+	return 0
 }
 
 # =============================================================================
@@ -739,73 +738,73 @@ loop_block_task() {
 # Returns: 0 if context exhaustion detected, 1 if not
 # Output: Reason string to stdout if exhaustion detected
 loop_check_context_exhaustion() {
-    local output_file="$1"
-    local iteration="$2"
-    local max_iterations="$3"
-    local output_sizes_file="$4"
+	local output_file="$1"
+	local iteration="$2"
+	local max_iterations="$3"
+	local output_sizes_file="$4"
 
-    local output_size=0
-    if [[ -f "$output_file" ]]; then
-        output_size=$(wc -c < "$output_file" 2>/dev/null | tr -d ' ')
-    fi
+	local output_size=0
+	if [[ -f "$output_file" ]]; then
+		output_size=$(wc -c <"$output_file" 2>/dev/null | tr -d ' ')
+	fi
 
-    # Track output size for rolling average
-    echo "$output_size" >> "$output_sizes_file"
+	# Track output size for rolling average
+	echo "$output_size" >>"$output_sizes_file"
 
-    # Heuristic 1: Iteration threshold (approaching max iterations)
-    local iter_threshold
-    iter_threshold=$(( (max_iterations * LOOP_CONTEXT_ITER_THRESHOLD) / 100 ))
-    if [[ "$iteration" -ge "$iter_threshold" ]]; then
-        echo "iteration_threshold:${iteration}/${max_iterations}"
-        return 0
-    fi
+	# Heuristic 1: Iteration threshold (approaching max iterations)
+	local iter_threshold
+	iter_threshold=$(((max_iterations * LOOP_CONTEXT_ITER_THRESHOLD) / 100))
+	if [[ "$iteration" -ge "$iter_threshold" ]]; then
+		echo "iteration_threshold:${iteration}/${max_iterations}"
+		return 0
+	fi
 
-    # Heuristic 2: Explicit context exhaustion markers in output
-    # These are strings that AI tools emit when hitting context limits
-    if [[ -f "$output_file" ]]; then
-        if grep -qiE \
-            'context.*(window|limit|length).*(exceed|reach|exhaust|full)|token.*(limit|budget).*(exceed|reach)|maximum.*context.*length|conversation.*too.*long|context.*truncat|running.*out.*of.*(context|tokens)' \
-            "$output_file" 2>/dev/null; then
-            echo "explicit_context_signal"
-            return 0
-        fi
-    fi
+	# Heuristic 2: Explicit context exhaustion markers in output
+	# These are strings that AI tools emit when hitting context limits
+	if [[ -f "$output_file" ]]; then
+		if grep -qiE \
+			'context.*(window|limit|length).*(exceed|reach|exhaust|full)|token.*(limit|budget).*(exceed|reach)|maximum.*context.*length|conversation.*too.*long|context.*truncat|running.*out.*of.*(context|tokens)' \
+			"$output_file" 2>/dev/null; then
+			echo "explicit_context_signal"
+			return 0
+		fi
+	fi
 
-    # Heuristic 3: Empty or near-empty output (tool couldn't produce work)
-    if [[ "$output_size" -lt "$LOOP_CONTEXT_MIN_OUTPUT_BYTES" ]]; then
-        # Only trigger after first iteration (first might legitimately be short)
-        if [[ "$iteration" -gt 1 ]]; then
-            echo "empty_output:${output_size}bytes"
-            return 0
-        fi
-    fi
+	# Heuristic 3: Empty or near-empty output (tool couldn't produce work)
+	if [[ "$output_size" -lt "$LOOP_CONTEXT_MIN_OUTPUT_BYTES" ]]; then
+		# Only trigger after first iteration (first might legitimately be short)
+		if [[ "$iteration" -gt 1 ]]; then
+			echo "empty_output:${output_size}bytes"
+			return 0
+		fi
+	fi
 
-    # Heuristic 4: Output shrinkage (dramatic drop from rolling average)
-    if [[ "$iteration" -ge "$LOOP_CONTEXT_SHRINK_MIN_ITERS" ]]; then
-        local total_size=0
-        local count=0
-        while IFS= read -r size; do
-            total_size=$((total_size + size))
-            count=$((count + 1))
-        done < "$output_sizes_file"
+	# Heuristic 4: Output shrinkage (dramatic drop from rolling average)
+	if [[ "$iteration" -ge "$LOOP_CONTEXT_SHRINK_MIN_ITERS" ]]; then
+		local total_size=0
+		local count=0
+		while IFS= read -r size; do
+			total_size=$((total_size + size))
+			count=$((count + 1))
+		done <"$output_sizes_file"
 
-        if [[ "$count" -gt 1 ]]; then
-            # Exclude current iteration from average (compare against prior)
-            local prior_total=$((total_size - output_size))
-            local prior_count=$((count - 1))
-            local avg_size=$((prior_total / prior_count))
+		if [[ "$count" -gt 1 ]]; then
+			# Exclude current iteration from average (compare against prior)
+			local prior_total=$((total_size - output_size))
+			local prior_count=$((count - 1))
+			local avg_size=$((prior_total / prior_count))
 
-            if [[ "$avg_size" -gt 0 ]]; then
-                local shrink_pct=$(( (output_size * 100) / avg_size ))
-                if [[ "$shrink_pct" -lt "$LOOP_CONTEXT_SHRINK_THRESHOLD" ]]; then
-                    echo "output_shrinkage:${shrink_pct}%_of_avg(${avg_size}bytes)"
-                    return 0
-                fi
-            fi
-        fi
-    fi
+			if [[ "$avg_size" -gt 0 ]]; then
+				local shrink_pct=$(((output_size * 100) / avg_size))
+				if [[ "$shrink_pct" -lt "$LOOP_CONTEXT_SHRINK_THRESHOLD" ]]; then
+					echo "output_shrinkage:${shrink_pct}%_of_avg(${avg_size}bytes)"
+					return 0
+				fi
+			fi
+		fi
+	fi
 
-    return 1
+	return 1
 }
 
 # Emergency push: commit and push any uncommitted work before exit
@@ -813,49 +812,49 @@ loop_check_context_exhaustion() {
 # Arguments: none
 # Returns: 0 on success, 1 on failure (non-fatal)
 loop_emergency_push() {
-    local branch
-    branch=$(git branch --show-current 2>/dev/null || echo "")
+	local branch
+	branch=$(git branch --show-current 2>/dev/null || echo "")
 
-    if [[ -z "$branch" ]]; then
-        loop_log_warn "Context guard: not in a git repo, skipping emergency push"
-        return 1
-    fi
+	if [[ -z "$branch" ]]; then
+		loop_log_warn "Context guard: not in a git repo, skipping emergency push"
+		return 1
+	fi
 
-    # Check for uncommitted changes
-    if git diff --quiet HEAD 2>/dev/null && git diff --cached --quiet HEAD 2>/dev/null; then
-        # No uncommitted changes — just push existing commits
-        if git log --oneline "origin/${branch}..HEAD" 2>/dev/null | grep -q .; then
-            loop_log_info "Context guard: pushing unpushed commits on $branch"
-            git push origin "$branch" 2>/dev/null || {
-                loop_log_warn "Context guard: push failed, trying with --force-with-lease"
-                git push --force-with-lease origin "$branch" 2>/dev/null || true
-            }
-        fi
-        return 0
-    fi
+	# Check for uncommitted changes
+	if git diff --quiet HEAD 2>/dev/null && git diff --cached --quiet HEAD 2>/dev/null; then
+		# No uncommitted changes — just push existing commits
+		if git log --oneline "origin/${branch}..HEAD" 2>/dev/null | grep -q .; then
+			loop_log_info "Context guard: pushing unpushed commits on $branch"
+			git push origin "$branch" 2>/dev/null || {
+				loop_log_warn "Context guard: push failed, trying with --force-with-lease"
+				git push --force-with-lease origin "$branch" 2>/dev/null || true
+			}
+		fi
+		return 0
+	fi
 
-    # Stage and commit uncommitted work
-    loop_log_info "Context guard: committing uncommitted work before exit"
-    git add -A 2>/dev/null || true
+	# Stage and commit uncommitted work
+	loop_log_info "Context guard: committing uncommitted work before exit"
+	git add -A 2>/dev/null || true
 
-    local task_id
-    task_id=$(loop_get_state ".task_id" 2>/dev/null || echo "unknown")
-    git commit -m "wip: emergency commit before context exhaustion ($task_id)" \
-        --no-verify 2>/dev/null || {
-        loop_log_warn "Context guard: commit failed"
-        return 1
-    }
+	local task_id
+	task_id=$(loop_get_state ".task_id" 2>/dev/null || echo "unknown")
+	git commit -m "wip: emergency commit before context exhaustion ($task_id)" \
+		--no-verify 2>/dev/null || {
+		loop_log_warn "Context guard: commit failed"
+		return 1
+	}
 
-    # Push
-    loop_log_info "Context guard: pushing to $branch"
-    git push origin "$branch" 2>/dev/null || {
-        git push -u origin "$branch" 2>/dev/null || {
-            loop_log_warn "Context guard: push failed, trying with --force-with-lease"
-            git push --force-with-lease origin "$branch" 2>/dev/null || true
-        }
-    }
+	# Push
+	loop_log_info "Context guard: pushing to $branch"
+	git push origin "$branch" 2>/dev/null || {
+		git push -u origin "$branch" 2>/dev/null || {
+			loop_log_warn "Context guard: push failed, trying with --force-with-lease"
+			git push --force-with-lease origin "$branch" 2>/dev/null || true
+		}
+	}
 
-    return 0
+	return 0
 }
 
 # Emit completion signal to stdout (captured in worker log for supervisor)
@@ -863,15 +862,15 @@ loop_emergency_push() {
 #   $1 - reason (why the guard triggered)
 # Returns: 0
 loop_emit_completion_signal() {
-    local reason="$1"
+	local reason="$1"
 
-    loop_log_warn "Context guard triggered: $reason"
-    loop_log_info "Emitting FULL_LOOP_COMPLETE signal to prevent clean_exit_no_signal retry"
+	loop_log_warn "Context guard triggered: $reason"
+	loop_log_info "Emitting FULL_LOOP_COMPLETE signal to prevent clean_exit_no_signal retry"
 
-    # This is the signal the supervisor's extract_log_metadata() looks for
-    echo "<promise>FULL_LOOP_COMPLETE</promise>"
+	# This is the signal the supervisor's extract_log_metadata() looks for
+	echo "<promise>FULL_LOOP_COMPLETE</promise>"
 
-    return 0
+	return 0
 }
 
 # Full context guard: check, push, and signal in one call
@@ -883,38 +882,38 @@ loop_emit_completion_signal() {
 #   $4 - output_sizes_file
 # Returns: 0 if guard triggered (caller should exit), 1 if safe to continue
 loop_context_guard() {
-    local output_file="$1"
-    local iteration="$2"
-    local max_iterations="$3"
-    local output_sizes_file="$4"
+	local output_file="$1"
+	local iteration="$2"
+	local max_iterations="$3"
+	local output_sizes_file="$4"
 
-    local reason
-    reason=$(loop_check_context_exhaustion "$output_file" "$iteration" "$max_iterations" "$output_sizes_file") || return 1
+	local reason
+	reason=$(loop_check_context_exhaustion "$output_file" "$iteration" "$max_iterations" "$output_sizes_file") || return 1
 
-    # Guard triggered — save work and signal
-    loop_log_warn "=== CONTEXT GUARD ACTIVATED (t247.1) ==="
-    loop_log_warn "Reason: $reason"
+	# Guard triggered — save work and signal
+	loop_log_warn "=== CONTEXT GUARD ACTIVATED (t247.1) ==="
+	loop_log_warn "Reason: $reason"
 
-    # Create receipt documenting the guard activation
-    if type loop_create_receipt &>/dev/null; then
-        loop_create_receipt "task" "context_guard" \
-            "{\"reason\": \"$reason\", \"iteration\": $iteration, \"max_iterations\": $max_iterations}"
-    fi
+	# Create receipt documenting the guard activation
+	if type loop_create_receipt &>/dev/null; then
+		loop_create_receipt "task" "context_guard" \
+			"{\"reason\": \"$reason\", \"iteration\": $iteration, \"max_iterations\": $max_iterations}"
+	fi
 
-    # Store in memory for pattern tracking
-    if type loop_store_memory &>/dev/null; then
-        loop_store_memory "CODEBASE_PATTERN" \
-            "Context guard triggered at iteration $iteration/$max_iterations: $reason" \
-            "context_guard,reliability"
-    fi
+	# Store in memory for pattern tracking
+	if type loop_store_memory &>/dev/null; then
+		loop_store_memory "CODEBASE_PATTERN" \
+			"Context guard triggered at iteration $iteration/$max_iterations: $reason" \
+			"context_guard,reliability"
+	fi
 
-    # Emergency push to preserve work
-    loop_emergency_push
+	# Emergency push to preserve work
+	loop_emergency_push
 
-    # Emit the signal
-    loop_emit_completion_signal "$reason"
+	# Emit the signal
+	loop_emit_completion_signal "$reason"
 
-    return 0
+	return 0
 }
 
 # =============================================================================
@@ -925,129 +924,141 @@ loop_context_guard() {
 # Arguments:
 #   $1 - tool (opencode|claude|aider)
 #   $2 - prompt
-#   $3 - max_iterations
-#   $4 - completion_promise
+#   $3 - max_iterations (default: 50)
+#   $4 - completion_promise (default: TASK_COMPLETE)
+#   $5 - max_attempts before blocking (default: 5)
+#   $6 - delay_seconds between iterations (default: 2)
+#   $7 - tool_runner_func (optional callback: func output_file prompt; overrides default tool dispatch)
 # Returns: 0 on completion, 1 on max iterations
 loop_run_external() {
-    local tool="$1"
-    local prompt="$2"
-    local max_iterations="${3:-50}"
-    local completion_promise="${4:-TASK_COMPLETE}"
-    
-    # Validate tool
-    if ! command -v "$tool" &>/dev/null; then
-        loop_log_error "Tool not found: $tool"
-        return 1
-    fi
-    
-    loop_log_info "Starting external loop with $tool"
-    loop_log_info "Max iterations: $max_iterations"
-    loop_log_info "Completion promise: $completion_promise"
-    
-    # Register agent in mailbox system (if available)
-    if [[ -x "$LOOP_MAIL_HELPER" ]]; then
-        "$LOOP_MAIL_HELPER" register \
-            --role "worker" \
-            --branch "$(git branch --show-current 2>/dev/null || echo unknown)" \
-            2>/dev/null || true
-    fi
-    
-    local iteration=1
-    local output_file
-    output_file=$(mktemp)
-    local output_sizes_file
-    output_sizes_file=$(mktemp)
-    trap 'rm -f "$output_file" "$output_sizes_file"' EXIT
-    
-    while [[ $iteration -le $max_iterations ]]; do
-        loop_log_step "=== Iteration $iteration/$max_iterations ==="
-        
-        # Update state
-        loop_set_state ".iteration" "$iteration"
-        loop_set_state ".last_iteration_at" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-        
-        # Generate re-anchor prompt
-        local reanchor
-        reanchor=$(loop_generate_reanchor "$prompt")
-        
-        # Build full prompt with re-anchor
-        local full_prompt="$reanchor"
-        
-        # Run tool (fresh session each time)
-        local exit_code=0
-        case "$tool" in
-            opencode)
-                echo "$full_prompt" | opencode --print > "$output_file" 2>&1 || exit_code=$?
-                ;;
-            claude)
-                echo "$full_prompt" | claude --print > "$output_file" 2>&1 || exit_code=$?
-                ;;
-            aider)
-                aider --yes --message "$full_prompt" > "$output_file" 2>&1 || exit_code=$?
-                ;;
-            *)
-                loop_log_error "Unknown tool: $tool"
-                return 1
-                ;;
-        esac
-        
-        # Check for completion promise
-        if grep -q "<promise>$completion_promise</promise>" "$output_file" 2>/dev/null; then
-            loop_log_success "Completion promise detected!"
-            loop_create_receipt "task" "success" '{"promise_fulfilled": true}'
-            loop_store_success "Task completed after $iteration iterations"
-            
-            # Send status report via mailbox (if available)
-            if [[ -x "$LOOP_MAIL_HELPER" ]]; then
-                local agent_id
-                # Identify current agent by matching worktree path in registry
-                local current_dir
-                current_dir=$(pwd)
-                agent_id=$("$LOOP_MAIL_HELPER" agents 2>/dev/null | grep "$current_dir" | cut -d',' -f1 | head -1 || echo "")
-                # Fallback: use first registered agent if no worktree match
-                if [[ -z "$agent_id" ]]; then
-                    agent_id=$("$LOOP_MAIL_HELPER" agents 2>/dev/null | grep -o '^[^,]*' | head -1 || echo "")
-                fi
-                if [[ -n "$agent_id" ]]; then
-                    "$LOOP_MAIL_HELPER" send \
-                        --to "coordinator" \
-                        --type status_report \
-                        --payload "Task completed: $(loop_get_state ".prompt" | head -c 100). Iterations: $iteration. Branch: $(git branch --show-current 2>/dev/null || echo unknown)" \
-                        2>/dev/null || true
-                fi
-            fi
-            
-            return 0
-        fi
-        
-        # Context-remaining guard (t247.1): detect approaching context
-        # exhaustion and proactively signal + push before the tool exits
-        # silently. This prevents the clean_exit_no_signal retry pattern.
-        if loop_context_guard "$output_file" "$iteration" "$max_iterations" "$output_sizes_file"; then
-            loop_log_success "Context guard: work preserved, signal emitted"
-            return 0
-        fi
-        
-        # Track attempt and check for blocking
-        local attempts
-        attempts=$(loop_track_attempt)
-        if loop_should_block 5; then
-            loop_block_task "Max attempts reached after $attempts tries"
-            return 1
-        fi
-        
-        # Create retry receipt
-        loop_create_receipt "task" "retry" "{\"iteration\": $iteration, \"exit_code\": $exit_code}"
-        
-        iteration=$((iteration + 1))
-        
-        # Brief delay between iterations
-        sleep 2
-    done
-    
-    loop_log_warn "Max iterations ($max_iterations) reached without completion"
-    loop_block_task "Max iterations reached"
-    return 1
+	local tool="$1"
+	local prompt="$2"
+	local max_iterations="${3:-50}"
+	local completion_promise="${4:-TASK_COMPLETE}"
+	local max_attempts="${5:-5}"
+	local delay_seconds="${6:-2}"
+	local tool_runner_func="${7:-}"
+
+	# Validate tool
+	if ! command -v "$tool" &>/dev/null; then
+		loop_log_error "Tool not found: $tool"
+		return 1
+	fi
+
+	loop_log_info "Starting external loop with $tool"
+	loop_log_info "Max iterations: $max_iterations"
+	loop_log_info "Completion promise: $completion_promise"
+
+	# Register agent in mailbox system (if available)
+	if [[ -x "$LOOP_MAIL_HELPER" ]]; then
+		"$LOOP_MAIL_HELPER" register \
+			--role "worker" \
+			--branch "$(git branch --show-current 2>/dev/null || echo unknown)" \
+			2>/dev/null || true
+	fi
+
+	local iteration=1
+	local output_file
+	output_file=$(mktemp)
+	local output_sizes_file
+	output_sizes_file=$(mktemp)
+	trap 'rm -f "$output_file" "$output_sizes_file"' EXIT
+
+	while [[ $iteration -le $max_iterations ]]; do
+		loop_log_step "=== Iteration $iteration/$max_iterations ==="
+
+		# Update state
+		loop_set_state ".iteration" "$iteration"
+		loop_set_state ".last_iteration_at" "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+		# Generate re-anchor prompt
+		local reanchor
+		reanchor=$(loop_generate_reanchor "$prompt")
+
+		# Build full prompt with re-anchor
+		local full_prompt="$reanchor"
+
+		# Run tool (fresh session each time)
+		local exit_code=0
+		if [[ -n "$tool_runner_func" ]]; then
+			# Use custom tool runner callback (e.g., for opencode run with --format json)
+			"$tool_runner_func" "$output_file" "$full_prompt" || exit_code=$?
+		else
+			case "$tool" in
+			opencode)
+				echo "$full_prompt" | opencode --print >"$output_file" 2>&1 || exit_code=$?
+				;;
+			claude)
+				echo "$full_prompt" | claude --print >"$output_file" 2>&1 || exit_code=$?
+				;;
+			aider)
+				aider --yes --message "$full_prompt" >"$output_file" 2>&1 || exit_code=$?
+				;;
+			*)
+				loop_log_error "Unknown tool: $tool"
+				return 1
+				;;
+			esac
+		fi
+
+		# Check for completion promise (whitespace-tolerant matching)
+		if grep -qP "<promise>\s*\Q$completion_promise\E\s*</promise>" "$output_file" 2>/dev/null ||
+			grep -q "<promise>$completion_promise</promise>" "$output_file" 2>/dev/null; then
+			loop_log_success "Completion promise detected!"
+			loop_create_receipt "task" "success" '{"promise_fulfilled": true}'
+			loop_store_success "Task completed after $iteration iterations"
+
+			# Send status report via mailbox (if available)
+			if [[ -x "$LOOP_MAIL_HELPER" ]]; then
+				local agent_id
+				# Identify current agent by matching worktree path in registry
+				local current_dir
+				current_dir=$(pwd)
+				agent_id=$("$LOOP_MAIL_HELPER" agents 2>/dev/null | grep "$current_dir" | cut -d',' -f1 | head -1 || echo "")
+				# Fallback: use first registered agent if no worktree match
+				if [[ -z "$agent_id" ]]; then
+					agent_id=$("$LOOP_MAIL_HELPER" agents 2>/dev/null | grep -o '^[^,]*' | head -1 || echo "")
+				fi
+				if [[ -n "$agent_id" ]]; then
+					"$LOOP_MAIL_HELPER" send \
+						--to "coordinator" \
+						--type status_report \
+						--payload "Task completed: $(loop_get_state ".prompt" | head -c 100). Iterations: $iteration. Branch: $(git branch --show-current 2>/dev/null || echo unknown)" \
+						2>/dev/null || true
+				fi
+			fi
+
+			return 0
+		fi
+
+		# Context-remaining guard (t247.1): detect approaching context
+		# exhaustion and proactively signal + push before the tool exits
+		# silently. This prevents the clean_exit_no_signal retry pattern.
+		if loop_context_guard "$output_file" "$iteration" "$max_iterations" "$output_sizes_file"; then
+			loop_log_success "Context guard: work preserved, signal emitted"
+			return 0
+		fi
+
+		# Track attempt and check for blocking
+		local attempts
+		attempts=$(loop_track_attempt)
+		if loop_should_block "$max_attempts"; then
+			loop_block_task "Max attempts reached after $attempts tries"
+			return 1
+		fi
+
+		# Create retry receipt
+		loop_create_receipt "task" "retry" "{\"iteration\": $iteration, \"exit_code\": $exit_code}"
+
+		iteration=$((iteration + 1))
+
+		# Delay between iterations (callers can customize via delay_seconds param)
+		sleep "$delay_seconds"
+	done
+
+	loop_log_warn "Max iterations ($max_iterations) reached without completion"
+	loop_block_task "Max iterations reached"
+	return 1
 }
 
 # =============================================================================
@@ -1058,55 +1069,43 @@ loop_run_external() {
 # Arguments: none
 # Returns: 0
 loop_show_status() {
-    if [[ ! -f "$LOOP_STATE_FILE" ]]; then
-        echo "No active loop"
-        return 0
-    fi
-    
-    echo ""
-    echo "=== Loop Status ==="
-    echo ""
-    
-    local loop_type
-    loop_type=$(loop_get_state ".loop_type")
-    local task_id
-    task_id=$(loop_get_state ".task_id")
-    local iteration
-    iteration=$(loop_get_state ".iteration")
-    local max_iterations
-    max_iterations=$(loop_get_state ".max_iterations")
-    local phase
-    phase=$(loop_get_state ".phase")
-    local started_at
-    started_at=$(loop_get_state ".started_at")
-    local active
-    active=$(loop_get_state ".active")
-    local completion_promise
-    completion_promise=$(loop_get_state ".completion_promise")
-    
-    echo "Type: $loop_type"
-    echo "Task ID: $task_id"
-    echo "Phase: $phase"
-    echo "Iteration: $iteration / $max_iterations"
-    echo "Active: $active"
-    echo "Started: $started_at"
-    echo "Promise: $completion_promise"
-    echo ""
-    
-    # Show receipts
-    local receipt_count
-    receipt_count=$(find "$LOOP_RECEIPTS_DIR" -name "*.json" -type f 2>/dev/null | wc -l | tr -d ' ')
-    echo "Receipts: $receipt_count"
-    
-    # Show blocked tasks
-    local blocked
-    blocked=$(jq -r '.blocked_tasks | length' "$LOOP_STATE_FILE" 2>/dev/null || echo "0")
-    if [[ "$blocked" -gt 0 ]]; then
-        echo ""
-        echo "Blocked tasks:"
-        jq -r '.blocked_tasks[] | "  - \(.id): \(.reason)"' "$LOOP_STATE_FILE" 2>/dev/null
-    fi
-    
-    echo ""
-    return 0
+	if [[ ! -f "$LOOP_STATE_FILE" ]]; then
+		echo "No active loop"
+		return 0
+	fi
+
+	echo ""
+	echo "=== Loop Status ==="
+	echo ""
+
+	# Read all state values in a single jq call for efficiency
+	local loop_type task_id iteration max_iterations phase started_at active completion_promise
+	read -r loop_type task_id iteration max_iterations phase started_at active completion_promise \
+		< <(jq -r '[.loop_type, .task_id, .iteration, .max_iterations, .phase, .started_at, .active, .completion_promise] | @tsv' "$LOOP_STATE_FILE" 2>/dev/null || echo "unknown unknown 0 0 unknown unknown false unknown")
+
+	echo "Type: $loop_type"
+	echo "Task ID: $task_id"
+	echo "Phase: $phase"
+	echo "Iteration: $iteration / $max_iterations"
+	echo "Active: $active"
+	echo "Started: $started_at"
+	echo "Promise: $completion_promise"
+	echo ""
+
+	# Show receipts
+	local receipt_count
+	receipt_count=$(find "$LOOP_RECEIPTS_DIR" -name "*.json" -type f 2>/dev/null | grep -c . || echo "0")
+	echo "Receipts: $receipt_count"
+
+	# Show blocked tasks
+	local blocked
+	blocked=$(jq -r '.blocked_tasks | length' "$LOOP_STATE_FILE" 2>/dev/null || echo "0")
+	if [[ "$blocked" -gt 0 ]]; then
+		echo ""
+		echo "Blocked tasks:"
+		jq -r '.blocked_tasks[] | "  - \(.id): \(.reason)"' "$LOOP_STATE_FILE" 2>/dev/null
+	fi
+
+	echo ""
+	return 0
 }


### PR DESCRIPTION
## Summary

Addresses all unactioned review feedback from PR #38 (Gemini + Augment Code reviews) flagged as critical quality-debt in #3798.

### Critical fixes (security/correctness)
- **jq string injection in `loop_set_state()`** — raw `$value` was interpolated into jq expressions, enabling state corruption or jq-expression injection when values contain quotes/backslashes/newlines. Now uses `jq --arg` for safe string passing.
- **jq string injection in `loop_block_task()`** — same vulnerability for `$task_id`, `$reason`, and timestamp. Now uses `jq --arg` for all three values.

### High-priority refactor (maintainability)
- **DRY: `run_v2_loop` → `loop_run_external` delegation** — `run_v2_loop` was a near-duplicate of `loop_run_external` (~150 lines of duplicated core loop logic). Refactored to a thin wrapper that parses arguments and delegates to the shared function. Added `max_attempts`, `delay_seconds`, and `tool_runner_func` callback parameters to `loop_run_external` to support ralph's custom opencode invocation and adaptive delay.

### Medium-priority improvements (efficiency/robustness)
- **Removed unused `receipts` variable** in `loop_create_receipt()` — was assigned but never used; also switched receipt filename to `jq --arg` for consistency.
- **Optimized `loop_show_status()`** — replaced 8 separate `loop_get_state` calls (each parsing the JSON file) with a single `jq` call using `@tsv` output.
- **Fixed fragile `wc -l` receipt counting** — replaced with `grep -c .` which is portable and doesn't produce leading whitespace.
- **Added argument validation** for all `--option` handlers in `run_v2_loop` — prevents `shift 2` / integer-comparison errors when arguments are missing under `set -euo pipefail`.
- **Whitespace-tolerant completion promise matching** — added `grep -P` with `\s*` around the promise text as primary check, falling back to exact match. Prevents loops from never terminating if the tool formats promise tags with whitespace.

### Verification
- Both files pass `shellcheck -x -S warning` with zero violations
- Net reduction of ~73 lines of code (89 added, 162 removed)

Closes #3798