### PR TITLE
GH#3793: Standardize post-increment to pre-increment across 50 shell scripts

### DIFF
--- a/.agents/scripts/agent-sources-helper.sh
+++ b/.agents/scripts/agent-sources-helper.sh
@@ -354,7 +354,7 @@ cmd_list() {
 		# Shorten home path
 		path="${path/#${HOME}/~}"
 		printf "  %-25s %-45s %s\n" "${name}" "${path}" "${synced}"
-		((i++))
+		((++i))
 	done
 	return 0
 }
@@ -425,7 +425,7 @@ cmd_status() {
 			fi
 		fi
 		echo ""
-		((i++))
+		((++i))
 	done
 	return 0
 }
@@ -458,13 +458,13 @@ cmd_sync() {
 
 		if [[ ! -d "${path}" ]]; then
 			warn "  Source directory missing: ${path}"
-			((i++))
+			((++i))
 			continue
 		fi
 
 		if [[ ! -d "${path}/.agents" ]]; then
 			warn "  No .agents/ directory in ${path}"
-			((i++))
+			((++i))
 			continue
 		fi
 
@@ -491,7 +491,7 @@ cmd_sync() {
 
 			# rsync the agent directory (preserves permissions, handles deletions)
 			rsync -a --delete "${agent_dir}" "${dest_dir}/${agent_name}/"
-			((agent_count++))
+			((++agent_count))
 
 			# Post-sync: register primary agents and deploy slash commands
 			sync_primary_agent "${dest_dir}/${agent_name}" "${agent_name}"
@@ -501,8 +501,8 @@ cmd_sync() {
 		update_last_synced "${name}" "${agent_count}"
 		success "  Synced ${agent_count} agent(s) to custom/${name}/"
 		total_agents=$((total_agents + agent_count))
-		((total_sources++))
-		((i++))
+		((++total_sources))
+		((++i))
 	done
 
 	echo ""
@@ -539,7 +539,7 @@ sync_primary_agent() {
 
 	ln -s "${agent_md}" "${link_target}"
 	info "  Registered primary agent: ${agent_name}"
-	((total_primary++)) || true
+	((++total_primary)) || true
 	return 0
 }
 
@@ -578,7 +578,7 @@ sync_slash_commands() {
 
 		# Symlink rather than copy — stays in sync without re-running
 		ln -sf "${md_file}" "${target}"
-		((total_commands++)) || true
+		((++total_commands)) || true
 	done
 	return 0
 }

--- a/.agents/scripts/ampcode-cli.sh
+++ b/.agents/scripts/ampcode-cli.sh
@@ -434,7 +434,7 @@ show_status() {
 			size=$(du -h "$file" 2>/dev/null | cut -f1 || echo "unknown")
 			ext="${file##*.}"
 			print_info "  $(basename "$file") (${ext} - $size)"
-			((shown++)) || true
+			((++shown)) || true
 		done
 	fi
 

--- a/.agents/scripts/anti-detect-helper.sh
+++ b/.agents/scripts/anti-detect-helper.sh
@@ -1092,7 +1092,7 @@ show_status() {
     # Profiles
     local profile_count=0
     for dir in "$PROFILES_DIR"/{persistent,clean,warmup}/*/; do
-        [[ -d "$dir" ]] && [[ "$(basename "$dir")" != "default" ]] && ((profile_count++)) || true || true
+        [[ -d "$dir" ]] && [[ "$(basename "$dir")" != "default" ]] && ((++profile_count)) || true || true
     done
     echo -e "  Profiles:          ${GREEN}$profile_count${NC} configured"
 

--- a/.agents/scripts/archived/quality-loop-helper.sh
+++ b/.agents/scripts/archived/quality-loop-helper.sh
@@ -167,7 +167,7 @@ calculate_backoff_wait() {
             wait_time=$BACKOFF_MAX
             break
         fi
-        ((i++))
+        ((++i))
     done
     
     echo "$wait_time"

--- a/.agents/scripts/archived/ralph-loop-helper.sh
+++ b/.agents/scripts/archived/ralph-loop-helper.sh
@@ -384,7 +384,7 @@ calculate_delay() {
         local i=1
         while [[ $i -lt $iteration ]] && [[ $delay -lt $RALPH_DELAY_MAX ]]; do
             delay=$((delay * 2))
-            ((i++))
+            ((++i))
         done
         [[ $delay -gt $RALPH_DELAY_MAX ]] && delay=$RALPH_DELAY_MAX
     fi

--- a/.agents/scripts/autogen-helper.sh
+++ b/.agents/scripts/autogen-helper.sh
@@ -59,7 +59,7 @@ get_available_port() {
     # Find next available port
     local port="$desired_port"
     while lsof -i :"$port" >/dev/null 2>&1 && [[ $port -lt 65535 ]]; do
-        ((port++))
+        ((++port))
     done
     
     if [[ $port -lt 65535 ]]; then
@@ -283,7 +283,7 @@ else
     if lsof -i :"$DESIRED_PORT" >/dev/null 2>&1; then
         echo "[WARNING] Port $DESIRED_PORT is in use, finding alternative..."
         while lsof -i :"$DESIRED_PORT" >/dev/null 2>&1 && [[ $DESIRED_PORT -lt 65535 ]]; do
-            ((DESIRED_PORT++))
+            ((++DESIRED_PORT))
         done
         echo "[INFO] Using port: $DESIRED_PORT"
     fi

--- a/.agents/scripts/beads-sync-helper.sh
+++ b/.agents/scripts/beads-sync-helper.sh
@@ -231,16 +231,16 @@ cmd_push() {
 			if [[ "$verbose" == "true" ]]; then
 				log_info "Updating: $id - $desc"
 			fi
-			# bd update "$id" --title "$desc" --json &>/dev/null || ((error_count++))
+			# bd update "$id" --title "$desc" --json &>/dev/null || ((++error_count))
 		else
 			# Create new
 			if [[ "$verbose" == "true" ]]; then
 				log_info "Creating: $id - $desc"
 			fi
 			# For now, just count - actual creation would use bd create
-			# bd create "$desc" --json &>/dev/null || ((error_count++))
+			# bd create "$desc" --json &>/dev/null || ((++error_count))
 		fi
-		((task_count++))
+		((++task_count))
 	done < <(parse_todo_md "$project_root")
 
 	# Verify checksums after
@@ -486,7 +486,7 @@ cmd_ready() {
 
 		# Check for blocked-by
 		if [[ "$line" =~ blocked-by: ]]; then
-			((blocked_count++))
+			((++blocked_count))
 			# Extract task ID and blocker
 			local task_id
 			task_id=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1)
@@ -494,7 +494,7 @@ cmd_ready() {
 			blocker=$(echo "$line" | grep -oE 'blocked-by:[^ ]+' | cut -d: -f2)
 			echo "  BLOCKED: $task_id (waiting on: $blocker)"
 		else
-			((ready_count++))
+			((++ready_count))
 			# Extract task ID and description
 			local task_info
 			task_info=$(echo "$line" | sed 's/^- \[ \] //' | cut -d'#' -f1 | head -c 60)

--- a/.agents/scripts/codacy-cli-chunked.sh
+++ b/.agents/scripts/codacy-cli-chunked.sh
@@ -188,7 +188,7 @@ run_quick_analysis() {
 	# Count tools
 	for tool in $fast_tools; do
 		if get_configured_tools | grep -q "^$tool$"; then
-			((total_tools++)) || true
+			((++total_tools)) || true
 		fi
 	done
 
@@ -205,7 +205,7 @@ run_quick_analysis() {
 
 	for tool in $fast_tools; do
 		if get_configured_tools | grep -q "^$tool$"; then
-			((completed_tools++)) || true
+			((++completed_tools)) || true
 			print_progress $completed_tools $total_tools "$tool"
 
 			print_info "Running: $tool"
@@ -350,7 +350,7 @@ run_chunked_analysis() {
 
 		# Update progress
 		completed_tools=$chunk_end
-		((chunk_num++)) || true
+		((++chunk_num)) || true
 
 		# Brief pause between chunks
 		if [[ $chunk_end -lt ${#tool_array[@]} ]]; then

--- a/.agents/scripts/crawl4ai-examples.sh
+++ b/.agents/scripts/crawl4ai-examples.sh
@@ -154,7 +154,7 @@ example_batch_processing() {
             print_warning "Failed to process: $url"
         fi
         
-        ((i++)) || true
+        ((++i)) || true
         sleep 1  # Rate limiting
     done
     
@@ -264,7 +264,7 @@ example_captcha_demo() {
             print_warning "CAPTCHA demo $i failed - this may be due to site changes or API limits"
         fi
 
-        ((i++)) || true
+        ((++i)) || true
 
         # Add delay between requests to respect rate limits
         if [[ $i -le ${#demo_configs[@]} ]]; then

--- a/.agents/scripts/credential-helper.sh
+++ b/.agents/scripts/credential-helper.sh
@@ -651,7 +651,7 @@ cmd_copy() {
 			fi
 
 			echo "$line" >>"$dest_env"
-			((copied++))
+			((++copied))
 		fi
 	done <"$source_env"
 

--- a/.agents/scripts/crewai-helper.sh
+++ b/.agents/scripts/crewai-helper.sh
@@ -61,7 +61,7 @@ get_available_port() {
     # Find next available port
     local port="$desired_port"
     while lsof -i :"$port" >/dev/null 2>&1 && [[ $port -lt 65535 ]]; do
-        ((port++))
+        ((++port))
     done
     
     if [[ $port -lt 65535 ]]; then
@@ -398,7 +398,7 @@ else
     if lsof -i :"$DESIRED_PORT" >/dev/null 2>&1; then
         echo "[WARNING] Port $DESIRED_PORT is in use, finding alternative..."
         while lsof -i :"$DESIRED_PORT" >/dev/null 2>&1 && [[ $DESIRED_PORT -lt 65535 ]]; do
-            ((DESIRED_PORT++))
+            ((++DESIRED_PORT))
         done
         echo "[INFO] Using port: $DESIRED_PORT"
     fi

--- a/.agents/scripts/dev-browser-helper.sh
+++ b/.agents/scripts/dev-browser-helper.sh
@@ -154,7 +154,7 @@ start_server() {
     
     while ! curl -s "http://localhost:${SERVER_PORT}" > /dev/null 2>&1; do
         sleep 1
-        ((waited++))
+        ((++waited))
         if [[ ${waited} -ge ${max_wait} ]]; then
             print_error "Server failed to start within ${max_wait}s"
             print_info "Check logs: cat ${DEV_BROWSER_DIR}/server.log"

--- a/.agents/scripts/generate-skills.sh
+++ b/.agents/scripts/generate-skills.sh
@@ -215,7 +215,7 @@ if [[ "$CLEAN" == true ]]; then
 			rm -f "$skill_file"
 			log_success "Removed: $skill_file"
 		fi
-		((count++)) || true
+		((++count)) || true
 	done < <(find "$AGENTS_DIR" -name "SKILL.md" -type f 2>/dev/null)
 
 	if [[ $count -eq 0 ]]; then
@@ -263,7 +263,7 @@ while IFS= read -r folder; do
 			generate_folder_skill "$folder" "$parent_md" >"$skill_file"
 			log_success "Generated: $skill_file"
 		fi
-		((generated++)) || true
+		((++generated)) || true
 	fi
 done < <(find "$AGENTS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 
@@ -303,7 +303,7 @@ while IFS= read -r folder; do
 			} >"$skill_file"
 			log_success "Generated: $skill_file"
 		fi
-		((generated++)) || true
+		((++generated)) || true
 	fi
 done < <(find "$AGENTS_DIR" -mindepth 2 -type d 2>/dev/null | sort)
 
@@ -348,7 +348,7 @@ while IFS= read -r md_file; do
 		generate_leaf_skill "$md_file" >"$skill_file"
 		log_success "Generated: $skill_file"
 	fi
-	((generated++)) || true
+	((++generated)) || true
 done < <(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -not -name "SKILL.md" -not -name "AGENTS.md" -not -name "README.md" -type f 2>/dev/null | sort)
 
 # =============================================================================

--- a/.agents/scripts/langflow-helper.sh
+++ b/.agents/scripts/langflow-helper.sh
@@ -62,7 +62,7 @@ get_available_port() {
     # Find next available port
     local port="$desired_port"
     while lsof -i :"$port" >/dev/null 2>&1 && [[ $port -lt 65535 ]]; do
-        ((port++))
+        ((++port))
     done
     
     if [[ $port -lt 65535 ]]; then
@@ -248,7 +248,7 @@ else
     if lsof -i :"$DESIRED_PORT" >/dev/null 2>&1; then
         echo "[WARNING] Port $DESIRED_PORT is in use, finding alternative..."
         while lsof -i :"$DESIRED_PORT" >/dev/null 2>&1 && [[ $DESIRED_PORT -lt 65535 ]]; do
-            ((DESIRED_PORT++))
+            ((++DESIRED_PORT))
         done
         echo "[INFO] Using port: $DESIRED_PORT"
     fi
@@ -432,7 +432,7 @@ import_flows() {
         if [[ -f "$flow_file" ]]; then
             if langflow import --file "$flow_file" 2>/dev/null; then
                 print_success "Imported: $(basename "$flow_file")"
-                ((count++))
+                ((++count))
             else
                 print_warning "Failed to import: $(basename "$flow_file")"
             fi

--- a/.agents/scripts/linter-manager.sh
+++ b/.agents/scripts/linter-manager.sh
@@ -148,41 +148,41 @@ install_python_linters() {
     print_info "Installing pycodestyle..."
     if pip install pycodestyle &>/dev/null; then
         print_success "pycodestyle installed"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install pycodestyle"
     fi
-    ((total++)) || true
+    ((++total)) || true
     
     # Pylint (comprehensive Python linter)
     print_info "Installing Pylint..."
     if pip install pylint &>/dev/null; then
         print_success "Pylint installed"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install Pylint"
     fi
-    ((total++)) || true
+    ((++total)) || true
     
     # Bandit (security linter)
     print_info "Installing Bandit..."
     if pip install bandit &>/dev/null; then
         print_success "Bandit installed"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install Bandit"
     fi
-    ((total++)) || true
+    ((++total)) || true
     
     # Ruff (fast Python linter)
     print_info "Installing Ruff..."
     if pip install ruff &>/dev/null; then
         print_success "Ruff installed"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install Ruff"
     fi
-    ((total++)) || true
+    ((++total)) || true
     
     print_info "Python linters: $success/$total installed successfully"
     return $((total - success))
@@ -199,21 +199,21 @@ install_javascript_linters() {
     print_info "Installing ESLint..."
     if install_npm_global eslint; then
         print_success "ESLint installed"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install ESLint"
     fi
-    ((total++)) || true
+    ((++total)) || true
 
     # TypeScript ESLint parser and plugin
     print_info "Installing TypeScript ESLint support..."
     if install_npm_global @typescript-eslint/parser @typescript-eslint/eslint-plugin; then
         print_success "TypeScript ESLint support installed"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install TypeScript ESLint support"
     fi
-    ((total++)) || true
+    ((++total)) || true
 
     print_info "JavaScript/TypeScript linters: $success/$total installed successfully"
     return $((total - success))
@@ -230,11 +230,11 @@ install_css_linters() {
     print_info "Installing Stylelint..."
     if install_npm_global stylelint stylelint-config-standard; then
         print_success "Stylelint installed"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install Stylelint"
     fi
-    ((total++)) || true
+    ((++total)) || true
 
     print_info "CSS linters: $success/$total installed successfully"
     return $((total - success))
@@ -251,17 +251,17 @@ install_shell_linters() {
     print_info "Installing ShellCheck..."
     if command -v shellcheck &>/dev/null; then
         print_success "ShellCheck already installed"
-        ((success++)) || true
+        ((++success)) || true
     elif brew install shellcheck &>/dev/null; then
         print_success "ShellCheck installed via Homebrew"
-        ((success++)) || true
+        ((++success)) || true
     elif apt-get install -y shellcheck &>/dev/null; then
         print_success "ShellCheck installed via apt"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install ShellCheck"
     fi
-    ((total++)) || true
+    ((++total)) || true
 
     print_info "Shell linters: $success/$total installed successfully"
     return $((total - success))
@@ -278,14 +278,14 @@ install_docker_linters() {
     print_info "Installing Hadolint..."
     if command -v hadolint &>/dev/null; then
         print_success "Hadolint already installed"
-        ((success++)) || true
+        ((++success)) || true
     elif brew install hadolint &>/dev/null; then
         print_success "Hadolint installed via Homebrew"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install Hadolint"
     fi
-    ((total++)) || true
+    ((++total)) || true
 
     print_info "Docker linters: $success/$total installed successfully"
     return $((total - success))
@@ -302,11 +302,11 @@ install_yaml_linters() {
     print_info "Installing yamllint..."
     if pip install yamllint &>/dev/null; then
         print_success "yamllint installed"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install yamllint"
     fi
-    ((total++)) || true
+    ((++total)) || true
 
     print_info "YAML linters: $success/$total installed successfully"
     return $((total - success))
@@ -323,27 +323,27 @@ install_security_linters() {
     print_info "Installing Trivy..."
     if command -v trivy &>/dev/null; then
         print_success "Trivy already installed"
-        ((success++)) || true
+        ((++success)) || true
     elif brew install trivy &>/dev/null; then
         print_success "Trivy installed via Homebrew"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install Trivy"
     fi
-    ((total++)) || true
+    ((++total)) || true
 
     # Secretlint (secret detection)
     print_info "Installing Secretlint..."
     if command -v secretlint &>/dev/null; then
         print_success "Secretlint already installed"
-        ((success++)) || true
+        ((++success)) || true
     elif install_npm_global secretlint @secretlint/secretlint-rule-preset-recommend; then
         print_success "Secretlint installed"
-        ((success++)) || true
+        ((++success)) || true
     else
         print_error "Failed to install Secretlint"
     fi
-    ((total++)) || true
+    ((++total)) || true
 
     print_info "Security linters: $success/$total installed successfully"
     return $((total - success))

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -104,7 +104,7 @@ check_return_statements() {
 
 	for file in "${ALL_SH_FILES[@]}"; do
 		[[ -f "$file" ]] || continue
-		((files_checked++))
+		((++files_checked))
 
 		# Count multi-line functions (exclude one-liners like: func() { echo "x"; })
 		# One-liners don't need explicit return statements
@@ -131,7 +131,7 @@ check_return_statements() {
 		local total_returns=$((return_statements + exit_statements))
 
 		if [[ $total_returns -lt $functions_count ]]; then
-			((violations++))
+			((++violations))
 			print_warning "Missing return statements in $file"
 		fi
 	done
@@ -565,7 +565,7 @@ check_toon_syntax() {
 				result=$(toon-lsp check "$file" 2>&1)
 				local exit_code=$?
 				if [[ $exit_code -ne 0 ]] || [[ "$result" == *"error"* ]]; then
-					((violations++))
+					((++violations))
 					print_warning "TOON syntax issue in $file"
 				fi
 			fi
@@ -574,7 +574,7 @@ check_toon_syntax() {
 		# Fallback: basic structure validation (non-empty check)
 		while IFS= read -r file; do
 			if [[ -f "$file" ]] && [[ ! -s "$file" ]]; then
-				((violations++))
+				((++violations))
 				print_warning "TOON: Empty file $file"
 			fi
 		done <<<"$toon_files"
@@ -695,7 +695,7 @@ check_skill_frontmatter() {
 	while IFS='|' read -r name local_path; do
 		if [[ ! -f "$local_path" ]]; then
 			print_warning "Skill file missing: $local_path (skill: $name)"
-			((errors++)) || true
+			((++errors)) || true
 			continue
 		fi
 
@@ -715,13 +715,13 @@ check_skill_frontmatter() {
 
 		if [[ -z "$fm_name" ]]; then
 			print_error "Missing 'name' field in frontmatter: $local_path (expected: $name)"
-			((errors++)) || true
+			((++errors)) || true
 		elif [[ "$fm_name" != "$name" ]]; then
 			print_error "Name mismatch in $local_path: got '$fm_name', expected '$name'"
-			((errors++)) || true
+			((++errors)) || true
 		fi
 
-		((checked++)) || true
+		((++checked)) || true
 	done <<<"$skill_entries"
 
 	if [[ $errors -eq 0 ]]; then

--- a/.agents/scripts/list-keys-helper.sh
+++ b/.agents/scripts/list-keys-helper.sh
@@ -36,7 +36,7 @@ print_source() {
     # Shorten home directory paths for readability
     source="${source/#$HOME/~}"
     echo -e "${BLUE}Source:${NC} $source"
-    ((total_sources++)) || true
+    ((++total_sources)) || true
     return 0
 }
 
@@ -62,7 +62,7 @@ print_key() {
     
     # Simple format: "  KEY_NAME [status]" - no fixed width padding
     echo -e "  ${key_name} ${status_color}[${status}]${NC}"
-    ((total_keys++)) || true
+    ((++total_keys)) || true
     return 0
 }
 

--- a/.agents/scripts/list-todo-helper.sh
+++ b/.agents/scripts/list-todo-helper.sh
@@ -434,12 +434,12 @@ output_markdown() {
     # Count tasks
     while IFS='|' read -r status id desc est tags owner logged blocked_by is_plan; do
         case "$status" in
-            in-progress|in-review) ((in_progress_count++)) ;;
+            in-progress|in-review) ((++in_progress_count)) ;;
             pending) 
-                ((pending_count++))
-                [[ -n "$blocked_by" ]] && ((blocked_count++))
+                ((++pending_count))
+                [[ -n "$blocked_by" ]] && ((++blocked_count))
                 ;;
-            done) ((done_count++)) ;;
+            done) ((++done_count)) ;;
         esac
     done < "$tasks_file"
     
@@ -476,7 +476,7 @@ output_markdown() {
             local num=0
             while IFS='|' read -r status id desc est tags owner logged blocked_by is_plan; do
                 [[ "$status" != "in-progress" && "$status" != "in-review" ]] && continue
-                ((num++))
+                ((++num))
                 echo "| $num | $id | $desc | $est | $tags | ${owner:--} |"
             done < "$tasks_file"
         fi
@@ -495,7 +495,7 @@ output_markdown() {
         local num=0
         while IFS='|' read -r status id desc est tags owner logged blocked_by is_plan; do
             [[ "$status" != "pending" ]] && continue
-            ((num++))
+            ((++num))
             [[ $LIMIT -gt 0 && $num -gt $LIMIT ]] && break
             local blocked_marker=""
             [[ -n "$blocked_by" ]] && blocked_marker=" [BLOCKED by $blocked_by]"
@@ -507,7 +507,7 @@ output_markdown() {
         local num=0
         while IFS='|' read -r status id desc est tags owner logged blocked_by is_plan; do
             [[ "$status" != "pending" ]] && continue
-            ((num++))
+            ((++num))
             [[ $LIMIT -gt 0 && $num -gt $LIMIT ]] && break
             echo "| $num | $id | $desc | $est | $tags | ${owner:--} | $logged |"
         done < "$tasks_file"

--- a/.agents/scripts/list-verify-helper.sh
+++ b/.agents/scripts/list-verify-helper.sh
@@ -198,9 +198,9 @@ output_markdown() {
 	# Count entries
 	while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
 		case "$status" in
-		pending) ((pending_count++)) ;;
-		passed) ((passed_count++)) ;;
-		failed) ((failed_count++)) ;;
+		pending) ((++pending_count)) ;;
+		passed) ((++passed_count)) ;;
+		failed) ((++failed_count)) ;;
 		esac
 	done <"$entries_file"
 
@@ -235,7 +235,7 @@ output_markdown() {
 			local num=0
 			while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
 				[[ "$status" != "failed" ]] && continue
-				((num++))
+				((++num))
 				echo "| $num | $vid | $tid | $desc | $pr | $merged | ${failed_reason:--} |"
 			done <"$entries_file"
 		fi
@@ -264,7 +264,7 @@ output_markdown() {
 			local num=0
 			while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
 				[[ "$status" != "pending" ]] && continue
-				((num++))
+				((++num))
 				local check_count
 				if [[ -n "$checks" ]]; then
 					check_count=$(echo "$checks" | tr ';' '\n' | wc -l | xargs)
@@ -299,7 +299,7 @@ output_markdown() {
 			local num=0
 			while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
 				[[ "$status" != "passed" ]] && continue
-				((num++))
+				((++num))
 				echo "| $num | $vid | $tid | $desc | $pr | $merged | ${verified:--} |"
 			done <"$entries_file"
 		fi

--- a/.agents/scripts/localhost-helper.sh
+++ b/.agents/scripts/localhost-helper.sh
@@ -67,7 +67,7 @@ find_available_port() {
             echo "$port"
             return 0
         fi
-        ((port++)) || true
+        ((++port)) || true
     done
     
     print_error "No available ports found in range $start_port-$PORT_RANGE_END"

--- a/.agents/scripts/markdown-formatter.sh
+++ b/.agents/scripts/markdown-formatter.sh
@@ -99,13 +99,13 @@ process_directory() {
 
 	# Find all markdown files
 	while IFS= read -r -d '' file; do
-		((total_files++)) || true
+		((++total_files)) || true
 		local before_hash after_hash
 		before_hash=$(sha256sum "$file" | awk '{print $1}')
 		fix_markdown_file "$file"
 		after_hash=$(sha256sum "$file" | awk '{print $1}')
 		if [[ "$before_hash" != "$after_hash" ]]; then
-			((changed_files++)) || true
+			((++changed_files)) || true
 		fi
 	done < <(find "$dir" -name "*.md" -type f -print0)
 
@@ -317,7 +317,7 @@ main() {
 				fix_markdown_file "$temp_file"
 				if ! cmp -s "$file" "$temp_file"; then
 					print_warning "Formatting issues found in: $file"
-					((lint_issues++)) || true
+					((++lint_issues)) || true
 				fi
 				rm -f "$temp_file" "${temp_file}.bak"
 			done < <(find "$target" -name "*.md" -type f -print0)

--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -1496,7 +1496,7 @@ cmd_stop() {
 		local wait_count=0
 		while kill -0 "$pid" 2>/dev/null && ((wait_count < 10)); do
 			sleep 1
-			((wait_count++))
+			((++wait_count))
 		done
 
 		if kill -0 "$pid" 2>/dev/null; then

--- a/.agents/scripts/mcp-register-claude.sh
+++ b/.agents/scripts/mcp-register-claude.sh
@@ -342,7 +342,7 @@ run_command() {
 
 	if [[ "$DRY_RUN" == true ]]; then
 		echo "  ${cmd}"
-		((registered++))
+		((++registered))
 		return 0
 	fi
 
@@ -356,10 +356,10 @@ run_command() {
 
 	if "${cmd_parts[@]}" "$json_payload"; then
 		print_success "${template_name}: registered"
-		((registered++))
+		((++registered))
 	else
 		print_error "${template_name}: registration failed"
-		((failed++))
+		((++failed))
 	fi
 	return 0
 }
@@ -428,7 +428,7 @@ register_all() {
 
 		# Check skip list (includes default skips)
 		if should_skip "$stem"; then
-			((skipped++))
+			((++skipped))
 			continue
 		fi
 
@@ -440,14 +440,14 @@ register_all() {
 		fi
 
 		if [[ -z "$cmd" ]]; then
-			((skipped++))
+			((++skipped))
 			continue
 		fi
 
 		# Skip commands with placeholders (unless forced)
 		if has_placeholders "$cmd" && [[ "$FORCE" != true ]]; then
 			print_warning "${stem}: skipped (contains placeholders — use --force to override)"
-			((skipped++))
+			((++skipped))
 			continue
 		fi
 
@@ -458,7 +458,7 @@ register_all() {
 		# Check if already registered
 		if [[ -n "$server_name" ]] && is_registered "$server_name" "$registered_list" && [[ "$FORCE" != true ]]; then
 			print_info "${stem}: already registered as '${server_name}'"
-			((already++))
+			((++already))
 			continue
 		fi
 

--- a/.agents/scripts/migrate-pr-backfill.sh
+++ b/.agents/scripts/migrate-pr-backfill.sh
@@ -316,7 +316,7 @@ main() {
 
 		if [[ -z "$candidate_urls" ]]; then
 			log_verbose "No merged PR found for $task_id"
-			((unmatched++)) || true
+			((++unmatched)) || true
 
 			if [[ "$DRY_RUN" != "true" ]]; then
 				write_proof_log "$task_id" "pr_backfill" \
@@ -353,7 +353,7 @@ main() {
 
 			if [[ -n "$existing_task" ]]; then
 				log "SKIP $task_id: PR $validated_url already linked to $existing_task"
-				((already_linked++)) || true
+				((++already_linked)) || true
 
 				if [[ "$DRY_RUN" != "true" ]]; then
 					write_proof_log "$task_id" "pr_backfill" \
@@ -385,7 +385,7 @@ main() {
 					break
 				else
 					log "ERROR: Failed to update DB for $task_id: $db_err"
-					((errors++)) || true
+					((++errors)) || true
 					linked="error"
 					break
 				fi
@@ -393,10 +393,10 @@ main() {
 		done <<<"$candidate_urls"
 
 		case "$linked" in
-		true) ((matched++)) || true ;;
+		true) ((++matched)) || true ;;
 		skip) ;;  # already counted in already_linked
 		error) ;; # already counted in errors
-		*) ((unmatched++)) || true ;;
+		*) ((++unmatched)) || true ;;
 		esac
 
 		# Rate limit: small delay between GitHub API calls to avoid rate limiting

--- a/.agents/scripts/network-tier-helper.sh
+++ b/.agents/scripts/network-tier-helper.sh
@@ -547,63 +547,63 @@ _self_test() {
 	result=$(classify_domain "github.com")
 	if [[ "$result" != "1" ]]; then
 		log_error "Self-test: github.com expected tier 1, got tier ${result}"
-		((failures++)) || true
+		((++failures)) || true
 	fi
 
 	# Tier 1: api.github.com (wildcard *.github.com)
 	result=$(classify_domain "api.github.com")
 	if [[ "$result" != "1" ]]; then
 		log_error "Self-test: api.github.com expected tier 1, got tier ${result}"
-		((failures++)) || true
+		((++failures)) || true
 	fi
 
 	# Tier 2: registry.npmjs.org
 	result=$(classify_domain "registry.npmjs.org")
 	if [[ "$result" != "2" ]]; then
 		log_error "Self-test: registry.npmjs.org expected tier 2, got tier ${result}"
-		((failures++)) || true
+		((++failures)) || true
 	fi
 
 	# Tier 3: sonarcloud.io
 	result=$(classify_domain "sonarcloud.io")
 	if [[ "$result" != "3" ]]; then
 		log_error "Self-test: sonarcloud.io expected tier 3, got tier ${result}"
-		((failures++)) || true
+		((++failures)) || true
 	fi
 
 	# Tier 4: unknown domain
 	result=$(classify_domain "totally-unknown-domain.example.net")
 	if [[ "$result" != "4" ]]; then
 		log_error "Self-test: unknown domain expected tier 4, got tier ${result}"
-		((failures++)) || true
+		((++failures)) || true
 	fi
 
 	# Tier 5: ngrok.io (deny list)
 	result=$(classify_domain "evil.ngrok.io")
 	if [[ "$result" != "5" ]]; then
 		log_error "Self-test: evil.ngrok.io expected tier 5, got tier ${result}"
-		((failures++)) || true
+		((++failures)) || true
 	fi
 
 	# Tier 5: raw IP
 	result=$(classify_domain "192.168.1.1")
 	if [[ "$result" != "5" ]]; then
 		log_error "Self-test: raw IP expected tier 5, got tier ${result}"
-		((failures++)) || true
+		((++failures)) || true
 	fi
 
 	# Tier 5: .onion TLD
 	result=$(classify_domain "hidden.onion")
 	if [[ "$result" != "5" ]]; then
 		log_error "Self-test: .onion expected tier 5, got tier ${result}"
-		((failures++)) || true
+		((++failures)) || true
 	fi
 
 	# URL normalization: strip protocol and port
 	result=$(classify_domain "https://github.com:443/foo/bar")
 	if [[ "$result" != "1" ]]; then
 		log_error "Self-test: URL normalization expected tier 1, got tier ${result}"
-		((failures++)) || true
+		((++failures)) || true
 	fi
 
 	if [[ $failures -gt 0 ]]; then

--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -43,7 +43,7 @@ print_header() {
 print_skip() {
     local message="$1"
     echo -e "${BLUE}SKIPPED${NC} $message"
-    ((SKIPPED++))
+    ((++SKIPPED))
     return 0
 }
 
@@ -148,7 +148,7 @@ check_cicd_status() {
         local attempt=0
         while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
             sleep "$POLL_INTERVAL"
-            ((attempt++))
+            ((++attempt))
             
             local current_status
             current_status=$(gh run view "$run_id" --repo "$repo" --json status,conclusion 2>/dev/null || echo "")

--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -62,7 +62,7 @@ validate_return_statements() {
 
 			if [[ $functions -gt 0 && $returns -lt $functions ]]; then
 				print_error "Missing return statements in $file"
-				((violations++))
+				((++violations))
 			fi
 		fi
 	done
@@ -82,7 +82,7 @@ validate_positional_parameters() {
 		if [[ -f "$file" ]] && grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' | grep -vE '\$[1-9][0-9.,/]' | grep -vE '\$[1-9]\s*\|' | grep -vE '\$[1-9]\s+(per|mo(nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)\b' >/dev/null; then
 			print_error "Direct positional parameter usage in $file"
 			grep -n '\$[1-9]' "$file" | grep -v 'local.*=.*\$[1-9]' | grep -vE '\$[1-9][0-9.,/]' | grep -vE '\$[1-9]\s*\|' | grep -vE '\$[1-9]\s+(per|mo(nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)\b' | head -3
-			((violations++))
+			((++violations))
 		fi
 	done
 
@@ -103,7 +103,7 @@ validate_string_literals() {
 			if [[ $repeated -gt 0 ]]; then
 				print_warning "Repeated string literals in $file (consider using constants)"
 				grep -o '"[^"]*"' "$file" | sort | uniq -c | awk '$1 >= 3 {print "  " $1 "x: " $2}' | head -3
-				((violations++))
+				((++violations))
 			fi
 		fi
 	done
@@ -119,7 +119,7 @@ run_shellcheck() {
 	for file in "$@"; do
 		if [[ -f "$file" ]] && ! shellcheck "$file"; then
 			print_error "ShellCheck violations in $file"
-			((violations++))
+			((++violations))
 		fi
 	done
 
@@ -150,21 +150,21 @@ check_secrets() {
 			print_info "  1. Remove the secrets from your code"
 			print_info "  2. Add to .secretlintignore if false positive"
 			print_info "  3. Use // secretlint-disable-line comment"
-			((violations++))
+			((++violations))
 		fi
 	elif [[ -f "node_modules/.bin/secretlint" ]]; then
 		if echo "$staged_files" | xargs ./node_modules/.bin/secretlint --format compact 2>/dev/null; then
 			print_success "No secrets detected in staged files"
 		else
 			print_error "Potential secrets detected in staged files!"
-			((violations++))
+			((++violations))
 		fi
 	elif command -v npx &>/dev/null && [[ -f ".secretlintrc.json" ]]; then
 		if echo "$staged_files" | xargs npx secretlint --format compact 2>/dev/null; then
 			print_success "No secrets detected in staged files"
 		else
 			print_error "Potential secrets detected in staged files!"
-			((violations++))
+			((++violations))
 		fi
 	else
 		print_warning "Secretlint not available (install: npm install secretlint --save-dev)"
@@ -251,7 +251,7 @@ validate_todo_completions() {
 
 		if [[ "$has_evidence" == "false" ]]; then
 			failed_tasks+=("$task_id")
-			((fail_count++))
+			((++fail_count))
 		fi
 	done <<<"$newly_completed"
 
@@ -337,7 +337,7 @@ validate_parent_subtask_blocking() {
 			local open_count
 			open_count=$(echo "$explicit_subtasks" | wc -l | tr -d ' ')
 			failed_tasks+=("$task_id (has $open_count open subtask(s) by ID)")
-			((fail_count++))
+			((++fail_count))
 			continue
 		fi
 
@@ -371,7 +371,7 @@ validate_parent_subtask_blocking() {
 			local open_count
 			open_count=$(echo "$open_subtasks" | wc -l | tr -d ' ')
 			failed_tasks+=("$task_id (has $open_count open subtask(s) by indentation)")
-			((fail_count++))
+			((++fail_count))
 		fi
 	done <<<"$newly_completed"
 
@@ -470,7 +470,7 @@ validate_repo_root_files() {
 
 		if [[ "$allowed" == "false" ]]; then
 			rejected_files+=("$file")
-			((violations++))
+			((++violations))
 		fi
 	done <<<"$new_root_files"
 

--- a/.agents/scripts/quality-cli-manager.sh
+++ b/.agents/scripts/quality-cli-manager.sh
@@ -100,54 +100,54 @@ install_clis() {
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
         print_info "Installing CodeRabbit CLI..."
         if execute_cli_command "$CLI_CODERABBIT" "install"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
     
     if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
         print_info "Installing Codacy CLI..."
         if execute_cli_command "codacy" "install"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
     
     if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
         print_info "Installing SonarScanner CLI..."
         if execute_cli_command "sonar" "install"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
         print_info "Installing Qlty CLI..."
         if execute_cli_command "qlty" "install"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
         print_info "Installing Snyk CLI..."
         if execute_cli_command "$CLI_SNYK" "install"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "linters" ]]; then
         print_info "Installing CodeFactor-inspired linters..."
         if bash "$(dirname "$0")/linter-manager.sh" install-detected; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
     
@@ -175,45 +175,45 @@ init_clis() {
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
         print_info "Initializing CodeRabbit CLI..."
         if execute_cli_command "$CLI_CODERABBIT" "setup"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
     
     if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
         print_info "Initializing Codacy CLI..."
         if execute_cli_command "codacy" "init"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
     
     if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
         print_info "Initializing SonarScanner CLI..."
         if execute_cli_command "sonar" "init"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
         print_info "Initializing Qlty CLI..."
         if execute_cli_command "qlty" "init"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
         print_info "Initializing Snyk CLI..."
         if execute_cli_command "$CLI_SNYK" "auth"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
     
@@ -243,18 +243,18 @@ analyze_with_clis() {
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
         print_info "Running CodeRabbit analysis..."
         if execute_cli_command "$CLI_CODERABBIT" "review" "$args"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
         print_info "Running Codacy analysis..."
         if execute_cli_command "codacy" "analyze" "$args"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
@@ -262,18 +262,18 @@ analyze_with_clis() {
     if [[ "$target_cli" == "codacy-fix" ]]; then
         print_info "Running Codacy analysis with auto-fix..."
         if execute_cli_command "codacy" "analyze" "--fix"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
         print_info "Running SonarQube analysis..."
         if execute_cli_command "sonar" "analyze" "$args"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
@@ -285,18 +285,18 @@ analyze_with_clis() {
             qlty_args="$args $QLTY_ORG"
         fi
         if execute_cli_command "qlty" "check" "$qlty_args"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
         print_info "Running Snyk security analysis..."
         if execute_cli_command "$CLI_SNYK" "full" "$args"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
@@ -304,27 +304,27 @@ analyze_with_clis() {
     if [[ "$target_cli" == "snyk-sca" ]]; then
         print_info "Running Snyk SCA (dependency) scan..."
         if execute_cli_command "$CLI_SNYK" "test" "$args"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "snyk-code" ]]; then
         print_info "Running Snyk Code (SAST) scan..."
         if execute_cli_command "$CLI_SNYK" "code" "$args"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 
     if [[ "$target_cli" == "snyk-iac" ]]; then
         print_info "Running Snyk IaC scan..."
         if execute_cli_command "$CLI_SNYK" "iac" "$args"; then
-            ((success_count++)) || true
+            ((++success_count)) || true
         fi
-        ((total_count++)) || true
+        ((++total_count)) || true
         echo ""
     fi
 

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -109,7 +109,7 @@ cmd_failed() {
 	local failed_count=0
 
 	while IFS=$'\t' read -r name summary url; do
-		((failed_count++)) || true
+		((++failed_count)) || true
 		echo -e "${RED}✗ ${name}${NC}"
 		[[ -n "$summary" && "$summary" != "null" ]] && echo "  Summary: ${summary}"
 		[[ -n "$url" && "$url" != "null" ]] && echo "  Details: ${url}"

--- a/.agents/scripts/quality-fix.sh
+++ b/.agents/scripts/quality-fix.sh
@@ -110,7 +110,7 @@ fix_return_statements() {
 							sed_inplace '$ d' "$temp_file"
 							echo "    return 0" >>"$temp_file"
 							echo "}" >>"$temp_file"
-							((fixed_functions++))
+							((++fixed_functions))
 							print_info "Fixed function: $function_name"
 						fi
 
@@ -122,7 +122,7 @@ fix_return_statements() {
 
 			if [[ $fixed_functions -gt 0 ]]; then
 				mv "$temp_file" "$file"
-				((files_fixed++))
+				((++files_fixed))
 				print_success "Fixed $fixed_functions functions in $file"
 			else
 				rm -f "$temp_file"
@@ -161,7 +161,7 @@ fix_positional_parameters() {
 
 				if ! diff -q "$file" "$temp_file" >/dev/null; then
 					mv "$temp_file" "$file"
-					((files_fixed++))
+					((++files_fixed))
 					print_success "Fixed positional parameters in main() function of $file"
 				else
 					rm -f "$temp_file"
@@ -219,7 +219,7 @@ validate_fixes() {
 
 	while IFS= read -r -d '' file; do
 		if [[ -f "$file" ]] && ! shellcheck "$file" >/dev/null 2>&1; then
-			((validation_errors++))
+			((++validation_errors))
 			print_warning "ShellCheck issues remain in $file"
 		fi
 	done < <(find .agents/scripts -name "*.sh" -not -path "*/_archive/*" -print0 2>/dev/null)

--- a/.agents/scripts/rosetta-audit-helper.sh
+++ b/.agents/scripts/rosetta-audit-helper.sh
@@ -282,20 +282,20 @@ cmd_migrate() {
 
 			if ! has_arm_formula "$pkg"; then
 				print_warning "Skipped: $pkg (no ARM formula available)"
-				((skipped++))
+				((++skipped))
 				continue
 			fi
 
 			if [[ "$dry_run" = true ]]; then
 				echo "  [DRY RUN] Would install ARM: $pkg"
-				((migrated++))
+				((++migrated))
 			else
 				if "$ARM_BREW" install "$pkg" 2>&1 | tail -1; then
 					print_success "Installed ARM: $pkg"
-					((migrated++))
+					((++migrated))
 				else
 					print_error "Failed to install ARM: $pkg"
-					((failed++))
+					((++failed))
 				fi
 			fi
 		done <<<"$x86_only"

--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -472,7 +472,7 @@ _import_credential_file() {
 
 			# Skip empty/placeholder values
 			if [[ -z "$val" || "$val" == "YOUR_"* || "$val" == "CHANGE_ME"* ]]; then
-				((skipped++))
+				((++skipped))
 				continue
 			fi
 
@@ -485,13 +485,13 @@ _import_credential_file() {
 			# Check if already in gopass
 			if gopass show -o "$gopass_path" &>/dev/null; then
 				print_info "Skipping $name (already in gopass${tenant:+ [$tenant]})"
-				((skipped++))
+				((++skipped))
 				continue
 			fi
 
 			# Import to gopass
 			echo "$val" | gopass insert --force "$gopass_path"
-			((imported++))
+			((++imported))
 			print_success "Imported $name${tenant:+ (tenant: $tenant)}"
 		fi
 	done <"$file"

--- a/.agents/scripts/security-posture-helper.sh
+++ b/.agents/scripts/security-posture-helper.sh
@@ -61,19 +61,19 @@ FINDINGS_JSON="[]"
 print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 print_pass() {
 	echo -e "${GREEN}[PASS]${NC} $1"
-	((FINDINGS_PASS++)) || true
+	((++FINDINGS_PASS)) || true
 }
 print_warn() {
 	echo -e "${YELLOW}[WARN]${NC} $1"
-	((FINDINGS_WARNING++)) || true
+	((++FINDINGS_WARNING)) || true
 }
 print_crit() {
 	echo -e "${RED}[CRIT]${NC} $1"
-	((FINDINGS_CRITICAL++)) || true
+	((++FINDINGS_CRITICAL)) || true
 }
 print_skip() {
 	echo -e "${CYAN}[SKIP]${NC} $1"
-	((FINDINGS_INFO++)) || true
+	((++FINDINGS_INFO)) || true
 }
 print_header() { echo -e "\n${BOLD}${CYAN}$1${NC}"; }
 

--- a/.agents/scripts/setup-linters-wizard.sh
+++ b/.agents/scripts/setup-linters-wizard.sh
@@ -248,7 +248,7 @@ install_selected_linters() {
             print_success "$lang linters installed successfully"
         else
             print_warning "Some $lang linters failed to install"
-            ((total_failures++)) || true
+            ((++total_failures)) || true
         fi
         echo ""
     done

--- a/.agents/scripts/setup-local-api-keys.sh
+++ b/.agents/scripts/setup-local-api-keys.sh
@@ -66,7 +66,7 @@ setup_shell_integration() {
 			echo "# AI DevOps API Keys (single source of truth)" >>"$config"
 			echo "$source_line" >>"$config"
 			print_success "Added credentials.sh sourcing to $config"
-			((updated++)) || true
+			((++updated)) || true
 		fi
 	done
 

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -211,7 +211,7 @@ timeout_sec() {
 				return 124
 			fi
 			sleep 0.5
-			((half_secs_remaining--)) || true
+			((--half_secs_remaining)) || true
 		done
 		wait "$cmd_pid" 2>/dev/null
 		return $?
@@ -980,7 +980,7 @@ prune_worktree_registry() {
 
 			if [[ "$should_prune" == "true" ]]; then
 				unregister_worktree "$wt_path"
-				((pruned_count++))
+				((++pruned_count))
 				[[ -n "${VERBOSE:-}" ]] && echo "  Pruned: $wt_path ($prune_reason)"
 			fi
 		done <<<"$entries"

--- a/.agents/scripts/show-plan-helper.sh
+++ b/.agents/scripts/show-plan-helper.sh
@@ -480,7 +480,7 @@ list_plans() {
 
 		# Detect plan header
 		if [[ "$line" =~ ^###[[:space:]]+\[([0-9-]+)\][[:space:]]+(.+)$ ]]; then
-			((num++))
+			((++num))
 			local title="${BASH_REMATCH[2]}"
 			title="${title% ✓}"
 			local status=""

--- a/.agents/scripts/site-crawler-helper.sh
+++ b/.agents/scripts/site-crawler-helper.sh
@@ -470,7 +470,7 @@ crawl_with_crawl4ai() {
             fi
             batch_urls+=("$queue_url")
             echo "$queue_url" >> "$visited_file"
-            ((batch_count++))
+            ((++batch_count))
         done < "$queue_file"
         
         # Remove processed URLs from queue
@@ -534,7 +534,7 @@ crawl_with_crawl4ai() {
                 
                 # Append to results file
                 echo "$result" >> "$results_file"
-                ((crawled_count++))
+                ((++crawled_count))
                 
                 local page_url status_code
                 page_url=$(printf '%s' "$result" | jq -r '.url // empty')
@@ -572,7 +572,7 @@ crawl_with_crawl4ai() {
             done
         fi
         
-        ((current_depth++))
+        ((++current_depth))
     done
     
     print_info "Crawl complete. Processing results..."
@@ -700,12 +700,12 @@ crawl4ai_generate_reports() {
     local code_200=0 code_301=0 code_302=0 code_404=0 code_500=0 code_other=0
     for code in "${status_codes[@]}"; do
         case "$code" in
-            200) ((code_200++)) ;;
-            301) ((code_301++)) ;;
-            302) ((code_302++)) ;;
-            404) ((code_404++)) ;;
-            500) ((code_500++)) ;;
-            *) ((code_other++)) ;;
+            200) ((++code_200)) ;;
+            301) ((++code_301)) ;;
+            302) ((++code_302)) ;;
+            404) ((++code_404)) ;;
+            500) ((++code_500)) ;;
+            *) ((++code_other)) ;;
         esac
     done
     

--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -361,7 +361,7 @@ cmd_check() {
 			local latest_hash
 			if ! latest_hash=$(fetch_url_hash "$upstream_url"); then
 				log_warning "Could not fetch URL for $name: $upstream_url"
-				((check_failed++)) || true
+				((++check_failed)) || true
 				continue
 			fi
 
@@ -377,7 +377,7 @@ cmd_check() {
 					echo ""
 				fi
 				log_info "UNKNOWN: $name (no hash recorded) latest_hash=${latest_hash:0:12}"
-				((updates_available++)) || true
+				((++updates_available)) || true
 				results+=("{\"name\":\"$name\",\"status\":\"unknown\",\"latest\":\"${latest_hash}\"}")
 			elif [[ "$latest_hash" != "$stored_hash" ]]; then
 				if [[ "$NON_INTERACTIVE" != true ]]; then
@@ -388,7 +388,7 @@ cmd_check() {
 					echo ""
 				fi
 				log_info "UPDATE AVAILABLE: $name prev_hash=${stored_hash:0:12} new_hash=${latest_hash:0:12}"
-				((updates_available++)) || true
+				((++updates_available)) || true
 				results+=("{\"name\":\"$name\",\"status\":\"update_available\",\"current\":\"${stored_hash}\",\"latest\":\"${latest_hash}\"}")
 
 				# Auto-update if enabled
@@ -413,7 +413,7 @@ cmd_check() {
 					echo -e "${GREEN}Up to date${NC}: $name"
 				fi
 				log_info "Up to date: $name hash=${stored_hash:0:12}"
-				((up_to_date++)) || true
+				((++up_to_date)) || true
 				results+=("{\"name\":\"$name\",\"status\":\"up_to_date\",\"commit\":\"${stored_hash}\"}")
 			fi
 			continue
@@ -430,7 +430,7 @@ cmd_check() {
 
 		if [[ -z "$owner_repo" || "$owner_repo" == "/" ]]; then
 			log_warning "Could not parse URL for $name: $upstream_url"
-			((check_failed++)) || true
+			((++check_failed)) || true
 			continue
 		fi
 
@@ -438,7 +438,7 @@ cmd_check() {
 		local latest_commit
 		if ! latest_commit=$(get_latest_commit "$owner_repo"); then
 			log_warning "Could not fetch latest commit for $name ($owner_repo)"
-			((check_failed++)) || true
+			((++check_failed)) || true
 			continue
 		fi
 
@@ -455,7 +455,7 @@ cmd_check() {
 				echo ""
 			fi
 			log_info "UNKNOWN: $name (no commit recorded) latest=${latest_commit:0:7}"
-			((updates_available++)) || true
+			((++updates_available)) || true
 			results+=("{\"name\":\"$name\",\"status\":\"unknown\",\"latest\":\"$latest_commit\"}")
 		elif [[ "$latest_commit" != "$current_commit" ]]; then
 			if [[ "$NON_INTERACTIVE" != true ]]; then
@@ -466,7 +466,7 @@ cmd_check() {
 				echo ""
 			fi
 			log_info "UPDATE AVAILABLE: $name current=${current_commit:0:7} latest=${latest_commit:0:7}"
-			((updates_available++)) || true
+			((++updates_available)) || true
 			results+=("{\"name\":\"$name\",\"status\":\"update_available\",\"current\":\"$current_commit\",\"latest\":\"$latest_commit\"}")
 
 			# Auto-update if enabled
@@ -490,7 +490,7 @@ cmd_check() {
 				echo -e "${GREEN}Up to date${NC}: $name"
 			fi
 			log_info "Up to date: $name commit=${current_commit:0:7}"
-			((up_to_date++)) || true
+			((++up_to_date)) || true
 			results+=("{\"name\":\"$name\",\"status\":\"up_to_date\",\"commit\":\"$current_commit\"}")
 		fi
 
@@ -1631,7 +1631,7 @@ cmd_pr() {
 			local latest_hash
 			if ! latest_hash=$(fetch_url_hash "$upstream_url"); then
 				log_warning "Could not fetch URL for $name: $upstream_url — skipping"
-				((prs_skipped++)) || true
+				((++prs_skipped)) || true
 				continue
 			fi
 
@@ -1646,9 +1646,9 @@ cmd_pr() {
 
 			# URL skill has an update (or no stored hash) — create PR
 			if cmd_pr_single "$name" "$upstream_url" "$stored_hash" "$latest_hash" "url"; then
-				((prs_created++)) || true
+				((++prs_created)) || true
 			else
-				((prs_failed++)) || true
+				((++prs_failed)) || true
 			fi
 			continue
 		fi
@@ -1658,7 +1658,7 @@ cmd_pr() {
 			if [[ "$QUIET" != true ]]; then
 				log_info "Skipping $name (non-GitHub source: ${upstream_url})"
 			fi
-			((prs_skipped++)) || true
+			((++prs_skipped)) || true
 			continue
 		fi
 
@@ -1669,7 +1669,7 @@ cmd_pr() {
 
 		if [[ -z "$owner_repo" || "$owner_repo" == "/" ]]; then
 			log_warning "Could not parse URL for $name: $upstream_url — skipping"
-			((prs_skipped++)) || true
+			((++prs_skipped)) || true
 			continue
 		fi
 
@@ -1677,7 +1677,7 @@ cmd_pr() {
 		local latest_commit
 		if ! latest_commit=$(get_latest_commit "$owner_repo"); then
 			log_warning "Could not fetch latest commit for $name ($owner_repo) — skipping"
-			((prs_skipped++)) || true
+			((++prs_skipped)) || true
 			continue
 		fi
 
@@ -1694,9 +1694,9 @@ cmd_pr() {
 
 		# Skill has an update — create PR
 		if cmd_pr_single "$name" "$upstream_url" "$current_commit" "$latest_commit" "github"; then
-			((prs_created++)) || true
+			((++prs_created)) || true
 		else
-			((prs_failed++)) || true
+			((++prs_failed)) || true
 		fi
 
 	done < <(jq -c '.skills[]' "$SKILL_SOURCES")

--- a/.agents/scripts/skills-helper.sh
+++ b/.agents/scripts/skills-helper.sh
@@ -321,7 +321,7 @@ cmd_search() {
 		done
 
 		if [[ "$matched" == true ]]; then
-			((found++)) || true
+			((++found)) || true
 
 			local is_imported="false"
 			if [[ "$filename" == *-skill ]]; then
@@ -458,7 +458,7 @@ cmd_browse() {
 			if [[ -n "$desc" ]]; then
 				echo "    $desc"
 			fi
-			((found++)) || true
+			((++found)) || true
 		fi
 	done < <(find "$AGENTS_DIR" -name "*.md" -type f | sort)
 
@@ -784,7 +784,7 @@ cmd_list() {
 			fi
 			printf "  %-35s %-25s %s\n" "$filename" "[$category]" "($type_label)"
 		fi
-		((count++)) || true
+		((++count)) || true
 	done < <(find "$AGENTS_DIR" -name "*.md" -type f | sort)
 
 	if [[ "$json_output" == true ]]; then
@@ -996,8 +996,8 @@ receipt=tools/accounts"
 				local desc
 				desc=$(extract_description "$md_file")
 				echo -e "    ${GREEN}-${NC} $filename: ${desc:-<no description>}"
-				((found_in_cat++)) || true
-				((total_found++)) || true
+				((++found_in_cat)) || true
+				((++total_found)) || true
 			fi
 		done < <(find "$AGENTS_DIR" -name "*.md" -type f | sort)
 

--- a/.agents/scripts/sonarcloud-collector-helper.sh
+++ b/.agents/scripts/sonarcloud-collector-helper.sh
@@ -233,7 +233,7 @@ collect_issues() {
 			# Store in database (run_id, severity, category, rule_id, description, path, line)
 			store_finding "$run_id" "$mapped_severity" "issue" "$rule" "$message" "$path" "$line"
 
-			((total_collected++))
+			((++total_collected))
 		done <<<"$issues"
 
 		# Check if there are more pages
@@ -243,7 +243,7 @@ collect_issues() {
 			break
 		fi
 
-		((page++))
+		((++page))
 	done
 
 	log_success "Collected $total_collected issues"
@@ -327,7 +327,7 @@ collect_hotspots() {
 			# Store in database (run_id, severity, category, rule_id, description, path, line)
 			store_finding "$run_id" "$mapped_severity" "security_hotspot" "$rule" "$message" "$path" "$line"
 
-			((total_collected++))
+			((++total_collected))
 		done <<<"$hotspots"
 
 		# Check if there are more pages
@@ -339,7 +339,7 @@ collect_hotspots() {
 			break
 		fi
 
-		((page++))
+		((++page))
 	done
 
 	log_success "Collected $total_collected security hotspots"

--- a/.agents/scripts/supervisor-archived/backfill-blocked-comments.sh
+++ b/.agents/scripts/supervisor-archived/backfill-blocked-comments.sh
@@ -86,7 +86,7 @@ main() {
 			echo "  [DRY RUN] Would post blocked comment"
 		else
 			post_blocked_comment_to_github "$task_id" "$blocked_error" "$repo_path"
-			((count++))
+			((++count))
 		fi
 	done <<< "$issues"
 	

--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -1493,7 +1493,7 @@ dismiss_bot_reviews() {
 			if gh api -X PUT "repos/${repo_slug}/pulls/${pr_number}/reviews/${review_id}/dismissals" \
 				-f message="Auto-dismissed: bot review does not block autonomous pipeline" \
 				-f event="DISMISS" 2>>"$SUPERVISOR_LOG"; then
-				((dismissed_count++))
+				((++dismissed_count))
 				log_success "Dismissed bot review #${review_id}"
 			else
 				log_warn "Failed to dismiss bot review #${review_id}"

--- a/.agents/scripts/thumbnail-helper.sh
+++ b/.agents/scripts/thumbnail-helper.sh
@@ -564,7 +564,7 @@ cmd_batch_score() {
 
 	# Find all image files
 	while IFS= read -r -d '' image_file; do
-		((image_count++))
+		((++image_count))
 
 		echo ""
 		print_info "=== Image $image_count: $(basename "$image_file") ==="
@@ -581,7 +581,7 @@ cmd_batch_score() {
 
 			if (($(echo "$existing_score >= $MIN_SCORE_THRESHOLD" | bc -l))); then
 				print_success "✓ PASS"
-				((pass_count++))
+				((++pass_count))
 			else
 				print_warning "✗ FAIL"
 			fi
@@ -593,7 +593,7 @@ cmd_batch_score() {
 			local new_score
 			new_score=$(grep "Weighted Score:" "$score_file" | awk '{print $3}')
 			if (($(echo "$new_score >= $MIN_SCORE_THRESHOLD" | bc -l))); then
-				((pass_count++))
+				((++pass_count))
 			fi
 		fi
 	done < <(find "$dir" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \) -print0)

--- a/.agents/scripts/todo-ready.sh
+++ b/.agents/scripts/todo-ready.sh
@@ -83,14 +83,14 @@ output_text() {
     while IFS='|' read -r status id desc est blocker; do
         case "$status" in
             READY)
-                ((ready_count++))
+                ((++ready_count))
                 echo "  $ready_count. $id: $desc ${est:+($est)}"
                 ;;
             BLOCKED)
-                ((blocked_count++))
+                ((++blocked_count))
                 ;;
             IN_PROGRESS)
-                ((in_progress_count++))
+                ((++in_progress_count))
                 ;;
             *)
                 # Ignore unknown status
@@ -173,17 +173,17 @@ output_json() {
             READY)
                 [[ $ready_count -gt 0 ]] && ready_json+=","
                 ready_json+="{\"id\":\"$id\",\"desc\":\"$desc\",\"est\":\"$est\"}"
-                ((ready_count++))
+                ((++ready_count))
                 ;;
             BLOCKED)
                 [[ $blocked_count -gt 0 ]] && blocked_json+=","
                 blocked_json+="{\"id\":\"$id\",\"desc\":\"$desc\",\"est\":\"$est\",\"blocked_by\":\"$blocker\"}"
-                ((blocked_count++))
+                ((++blocked_count))
                 ;;
             IN_PROGRESS)
                 [[ $in_progress_count -gt 0 ]] && in_progress_json+=","
                 in_progress_json+="{\"id\":\"$id\",\"desc\":\"$desc\",\"est\":\"$est\"}"
-                ((in_progress_count++))
+                ((++in_progress_count))
                 ;;
             *)
                 # Ignore unknown status

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -226,25 +226,25 @@ check_tool() {
 		status="not_installed"
 		icon="○"
 		color="$YELLOW"
-		((NOT_INSTALLED_COUNT++)) || true
+		((++NOT_INSTALLED_COUNT)) || true
 	elif [[ "$installed" == "timeout" ]]; then
 		status="timeout"
 		icon="⏱"
 		color="$RED"
-		((INSTALLED_COUNT++)) || true
+		((++INSTALLED_COUNT)) || true
 	elif [[ "$installed" == "unknown" || "$latest" == "unknown" ]]; then
 		status="unknown"
 		icon="?"
 		color="$YELLOW"
-		((INSTALLED_COUNT++)) || true
+		((++INSTALLED_COUNT)) || true
 	elif [[ "$installed" != "$latest" ]] && version_lt "$installed" "$latest"; then
 		status="outdated"
 		icon="⬆"
 		color="$RED"
-		((OUTDATED_COUNT++)) || true
+		((++OUTDATED_COUNT)) || true
 		OUTDATED_PACKAGES+=("$update_cmd")
 	else
-		((INSTALLED_COUNT++)) || true
+		((++INSTALLED_COUNT)) || true
 	fi
 
 	# JSON output (escape special characters for valid JSON)

--- a/.agents/scripts/toon-helper.sh
+++ b/.agents/scripts/toon-helper.sh
@@ -208,9 +208,9 @@ batch_convert() {
                     basename=$(basename "$file" .json)
                     local target_file="$target_dir/$basename.toon"
                     
-                    ((count++)) || true
+                    ((++count)) || true
                     if json_to_toon "$file" "$target_file" "$delimiter" "false"; then
-                        ((success_count++)) || true
+                        ((++success_count)) || true
                     fi
                 fi
             done
@@ -222,9 +222,9 @@ batch_convert() {
                     basename=$(basename "$file" .toon)
                     local target_file="$target_dir/$basename.json"
                     
-                    ((count++)) || true
+                    ((++count)) || true
                     if toon_to_json "$file" "$target_file" "true"; then
-                        ((success_count++)) || true
+                        ((++success_count)) || true
                     fi
                 fi
             done

--- a/.agents/scripts/validate-mcp-integrations.sh
+++ b/.agents/scripts/validate-mcp-integrations.sh
@@ -24,16 +24,16 @@ run_test() {
 	local test_name="$1"
 	local test_command="$2"
 
-	((total_tests++))
+	((++total_tests))
 	print_info "Testing: $test_name"
 
 	if bash -c "$test_command" &>/dev/null; then
 		print_success "$test_name: PASSED"
-		((passed_tests++))
+		((++passed_tests))
 		return 0
 	else
 		print_error "$test_name: FAILED"
-		((failed_tests++))
+		((++failed_tests))
 		return 1
 	fi
 	return 0

--- a/.agents/scripts/verify-mirrors.sh
+++ b/.agents/scripts/verify-mirrors.sh
@@ -139,7 +139,7 @@ main() {
         local link_path="${entry%%:*}"
         local target="${entry##*:}"
         if ! verify_symlink "$link_path" "$target"; then
-            ((issues++)) || true
+            ((++issues)) || true
         fi
     done
     

--- a/.agents/scripts/worker-token-helper.sh
+++ b/.agents/scripts/worker-token-helper.sh
@@ -579,7 +579,7 @@ cmd_cleanup() {
 			if [[ "$expires_epoch" -gt 0 ]] && [[ "$now_epoch" -gt "$expires_epoch" ]]; then
 				local token_file="${meta_file%.meta}.token"
 				cmd_revoke --token-file "$token_file" 2>/dev/null || true
-				((cleaned++))
+				((++cleaned))
 			fi
 		fi
 	done
@@ -645,9 +645,9 @@ cmd_status() {
 				date -d "$expires_at" +%s 2>/dev/null || echo "0")
 
 			if [[ "$expires_epoch" -gt 0 ]] && [[ "$now_epoch" -gt "$expires_epoch" ]]; then
-				((expired_count++))
+				((++expired_count))
 			else
-				((active_count++))
+				((++active_count))
 				echo "  Active: ${repo} (${strategy}, expires: ${expires_at})"
 			fi
 		done


### PR DESCRIPTION
## Summary

- Converts all `((var++))` post-increment patterns to `((++var))` pre-increment across 50 shell scripts (~250 occurrences)
- Also converts 1 post-decrement `((var--))` to pre-decrement `((--var))` in `shared-constants.sh`
- Prevents premature script termination under `set -e` / `set -euo pipefail` when counter variables start at 0

## Problem

Under `set -e`, bash arithmetic `((var++))` returns the **old** value. When `var` is 0, the expression evaluates to 0 (falsy), producing exit code 1 and terminating the script. Pre-increment `((++var))` returns the **new** value (non-zero = truthy = safe).

This was identified as **critical** quality-debt from PR #70 review feedback by CodeRabbit, which found the pattern in 15+ scripts. Full audit found **50 affected scripts**.

## Affected Scripts

All 50 files under `.agents/scripts/` that used post-increment arithmetic, including the specific files called out in the review: `beads-sync-helper.sh`, `dev-browser-helper.sh`, `quality-loop-helper.sh`, `todo-ready.sh`, `site-crawler-helper.sh`, `pre-commit-hook.sh`, `postflight-check.sh`, `linters-local.sh`, and 42 others.

## Verification

- `rg '\(\([a-zA-Z_]+\+\+\)\)' .agents/scripts/ -g '*.sh'` returns zero matches after the fix
- ShellCheck passes on key files with no new violations introduced
- The transformation is mechanical (regex substitution) with no logic changes

Closes #3793