### PR TITLE
GH#3549: Fix quality-debt in auto-deploy-agents workflow

### DIFF
--- a/.github/workflows/auto-deploy-agents.yml
+++ b/.github/workflows/auto-deploy-agents.yml
@@ -77,9 +77,11 @@ jobs:
           fi
 
           # Store changed files list (truncated for output)
-          echo "changed_files<<EOF" >> "$GITHUB_OUTPUT"
+          # Use unique delimiter to prevent collision if a file path contains "EOF"
+          DELIM="EOF_$(date +%s)"
+          echo "changed_files<<$DELIM" >> "$GITHUB_OUTPUT"
           echo "$CHANGED" | head -50 >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "$DELIM" >> "$GITHUB_OUTPUT"
 
           echo "Detected $CHANGED_COUNT changed agent files ($SCRIPTS_CHANGED scripts)"
 
@@ -202,10 +204,10 @@ jobs:
             [[ -z "$script" ]] && continue
             [[ ! -f "$script" ]] && continue
 
-            if ! bash -n "$script" 2>/dev/null; then
-              echo "::error file=$script::Syntax error in $script"
+            SYNTAX_ERR=$(bash -n "$script" 2>&1) || {
+              echo "::error file=$script::Syntax error in $script: $SYNTAX_ERR"
               FAILED=$((FAILED + 1))
-            fi
+            }
           done <<< "$SCRIPTS"
 
           if [[ "$FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- **Heredoc delimiter collision**: Replace static `EOF` delimiter with `EOF_$(date +%s)` when writing multiline `changed_files` to `GITHUB_OUTPUT`, preventing truncation if a file path contains "EOF" on its own line
- **Syntax error visibility**: Remove `2>/dev/null` from `bash -n` check and capture stderr into the `::error` annotation so actual syntax error details appear in CI logs
- **Script injection (already fixed)**: The `notify-deploy` step already passes `github.event.head_commit.author.name` and `github.event.head_commit.message` through `env:` variables — no change needed

Closes #3549