### PR TITLE
t3548: Fix critical quality-debt in deploy-agents-on-merge.sh

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -34,27 +34,27 @@ NC='\033[0m'
 QUIET=false
 
 log_info() {
-    if [[ "$QUIET" == "false" ]]; then
-        echo -e "${BLUE}[deploy]${NC} $1"
-    fi
-    return 0
+	if [[ "$QUIET" == "false" ]]; then
+		echo -e "${BLUE}[deploy]${NC} $1"
+	fi
+	return 0
 }
 
 log_success() {
-    if [[ "$QUIET" == "false" ]]; then
-        echo -e "${GREEN}[deploy]${NC} $1"
-    fi
-    return 0
+	if [[ "$QUIET" == "false" ]]; then
+		echo -e "${GREEN}[deploy]${NC} $1"
+	fi
+	return 0
 }
 
 log_warn() {
-    echo -e "${YELLOW}[deploy]${NC} $1" >&2
-    return 0
+	echo -e "${YELLOW}[deploy]${NC} $1" >&2
+	return 0
 }
 
 log_error() {
-    echo -e "${RED}[deploy]${NC} $1" >&2
-    return 0
+	echo -e "${RED}[deploy]${NC} $1" >&2
+	return 0
 }
 
 # Defaults
@@ -66,363 +66,388 @@ DRY_RUN=false
 DIFF_COMMIT=""
 
 parse_args() {
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --repo)
-                [[ $# -lt 2 ]] && { log_error "--repo requires a path"; return 1; }
-                REPO_DIR="$2"
-                shift 2
-                ;;
-            --scripts-only)
-                SCRIPTS_ONLY=true
-                shift
-                ;;
-            --full)
-                FULL_DEPLOY=true
-                shift
-                ;;
-            --dry-run)
-                DRY_RUN=true
-                shift
-                ;;
-            --diff)
-                [[ $# -lt 2 ]] && { log_error "--diff requires a commit"; return 1; }
-                DIFF_COMMIT="$2"
-                shift 2
-                ;;
-            --quiet)
-                QUIET=true
-                shift
-                ;;
-            --help|-h)
-                head -25 "$0" | tail -20
-                return 0
-                ;;
-            *)
-                log_error "Unknown option: $1"
-                return 1
-                ;;
-        esac
-    done
-    return 0
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo)
+			[[ $# -lt 2 ]] && {
+				log_error "--repo requires a path"
+				return 1
+			}
+			REPO_DIR="$2"
+			shift 2
+			;;
+		--scripts-only)
+			SCRIPTS_ONLY=true
+			shift
+			;;
+		--full)
+			FULL_DEPLOY=true
+			shift
+			;;
+		--dry-run)
+			DRY_RUN=true
+			shift
+			;;
+		--diff)
+			[[ $# -lt 2 ]] && {
+				log_error "--diff requires a commit"
+				return 1
+			}
+			DIFF_COMMIT="$2"
+			shift 2
+			;;
+		--quiet)
+			QUIET=true
+			shift
+			;;
+		--help | -h)
+			head -25 "$0" | tail -20
+			exit 0
+			;;
+		*)
+			log_error "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+	return 0
 }
 
 # Validate the repo directory
 validate_repo() {
-    # Support both regular repos (.git dir) and worktrees (.git file)
-    if [[ ! -d "$REPO_DIR/.git" && ! -f "$REPO_DIR/.git" ]]; then
-        log_error "Not a git repo: $REPO_DIR"
-        return 1
-    fi
+	# Support both regular repos (.git dir) and worktrees (.git file)
+	if [[ ! -d "$REPO_DIR/.git" && ! -f "$REPO_DIR/.git" ]]; then
+		log_error "Not a git repo: $REPO_DIR"
+		return 1
+	fi
 
-    if [[ ! -d "$REPO_DIR/.agents" ]]; then
-        log_error "No .agents/ directory in $REPO_DIR"
-        return 1
-    fi
+	if [[ ! -d "$REPO_DIR/.agents" ]]; then
+		log_error "No .agents/ directory in $REPO_DIR"
+		return 1
+	fi
 
-    return 0
+	return 0
 }
 
 # Pull latest main (fast-forward only)
 pull_latest() {
-    local current_branch
-    current_branch=$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || echo "")
+	local current_branch
+	current_branch=$(git -C "$REPO_DIR" branch --show-current 2>/dev/null || echo "")
 
-    if [[ "$current_branch" != "main" ]]; then
-        log_warn "Repo is on branch '$current_branch', not main — skipping pull"
-        return 0
-    fi
+	if [[ "$current_branch" != "main" ]]; then
+		log_warn "Repo is on branch '$current_branch', not main — skipping pull"
+		return 0
+	fi
 
-    log_info "Pulling latest main..."
-    if ! git -C "$REPO_DIR" pull --ff-only origin main --quiet 2>/dev/null; then
-        log_warn "Fast-forward pull failed — trying regular pull"
-        git -C "$REPO_DIR" pull origin main --quiet 2>/dev/null || true
-    fi
+	log_info "Pulling latest main..."
+	if ! git -C "$REPO_DIR" pull --ff-only origin main --quiet 2>/dev/null; then
+		log_warn "Fast-forward pull failed — trying regular pull"
+		git -C "$REPO_DIR" pull origin main --quiet 2>/dev/null || true
+	fi
 
-    return 0
+	return 0
 }
 
 # Detect which agent files changed since a commit
 detect_changes() {
-    local since_commit="$1"
-    local changed_files
+	local since_commit="$1"
+	local changed_files
 
-    if [[ -n "$since_commit" ]]; then
-        changed_files=$(git -C "$REPO_DIR" diff --name-only "$since_commit" HEAD -- '.agents/' 2>/dev/null || echo "")
-    else
-        # Compare deployed VERSION with repo VERSION to detect staleness
-        local repo_version deployed_version
-        repo_version=$(cat "$REPO_DIR/VERSION" 2>/dev/null || echo "unknown")
-        deployed_version=$(cat "$TARGET_DIR/VERSION" 2>/dev/null || echo "none")
+	if [[ -n "$since_commit" ]]; then
+		changed_files=$(git -C "$REPO_DIR" diff --name-only "$since_commit" HEAD -- '.agents/' 2>/dev/null || echo "")
+	else
+		# Compare deployed VERSION with repo VERSION to detect staleness
+		local repo_version deployed_version
+		repo_version=$(cat "$REPO_DIR/VERSION" 2>/dev/null || echo "unknown")
+		deployed_version=$(cat "$TARGET_DIR/VERSION" 2>/dev/null || echo "none")
 
-        if [[ "$repo_version" == "$deployed_version" ]]; then
-            log_info "Deployed agents ($deployed_version) match repo ($repo_version)"
-            echo ""
-            return 0
-        fi
+		if [[ "$repo_version" == "$deployed_version" ]]; then
+			log_info "Deployed agents ($deployed_version) match repo ($repo_version)"
+			echo ""
+			return 0
+		fi
 
-        log_info "Version mismatch: deployed=$deployed_version repo=$repo_version"
-        # Return all agent files as changed (version mismatch = full sync needed)
-        changed_files=$(git -C "$REPO_DIR" ls-files '.agents/' 2>/dev/null || echo "")
-    fi
+		log_info "Version mismatch: deployed=$deployed_version repo=$repo_version"
+		# Return all agent files as changed (version mismatch = full sync needed)
+		changed_files=$(git -C "$REPO_DIR" ls-files '.agents/' 2>/dev/null || echo "")
+	fi
 
-    echo "$changed_files"
-    return 0
+	echo "$changed_files"
+	return 0
 }
 
 # Deploy scripts only (fastest path)
 deploy_scripts_only() {
-    local source_dir="$REPO_DIR/.agents/scripts"
-    local target_scripts_dir="$TARGET_DIR/scripts"
+	local source_dir="$REPO_DIR/.agents/scripts"
+	local target_scripts_dir="$TARGET_DIR/scripts"
 
-    if [[ ! -d "$source_dir" ]]; then
-        log_error "Source scripts directory not found: $source_dir"
-        return 1
-    fi
+	if [[ ! -d "$source_dir" ]]; then
+		log_error "Source scripts directory not found: $source_dir"
+		return 1
+	fi
 
-    mkdir -p "$target_scripts_dir"
+	mkdir -p "$target_scripts_dir"
 
-    if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[dry-run] Would sync $source_dir/ -> $target_scripts_dir/"
-        local count
-        count=$(find "$source_dir" -type f | wc -l | tr -d ' ')
-        log_info "[dry-run] $count files would be deployed"
-        return 0
-    fi
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "[dry-run] Would sync $source_dir/ -> $target_scripts_dir/"
+		local count
+		count=$(find "$source_dir" -type f | wc -l | tr -d ' ')
+		log_info "[dry-run] $count files would be deployed"
+		return 0
+	fi
 
-    log_info "Deploying scripts to $target_scripts_dir..."
+	log_info "Deploying scripts to $target_scripts_dir..."
 
-    if command -v rsync &>/dev/null; then
-        rsync -a --delete "$source_dir/" "$target_scripts_dir/"
-    else
-        # Fallback: tar-based copy
-        (cd "$source_dir" && tar cf - .) | (cd "$target_scripts_dir" && tar xf -)
-    fi
+	if command -v rsync &>/dev/null; then
+		rsync -a --delete "$source_dir/" "$target_scripts_dir/"
+	else
+		# Fallback: tar-based copy
+		# Remove existing target contents first to match rsync --delete behavior
+		find "$target_scripts_dir" -mindepth 1 -delete 2>/dev/null || true
+		(cd "$source_dir" && tar cf - .) | (cd "$target_scripts_dir" && tar xf -)
+	fi
 
-    # Set executable permissions
-    chmod +x "$target_scripts_dir/"*.sh 2>/dev/null || true
+	# Set executable permissions
+	chmod +x "$target_scripts_dir/"*.sh 2>/dev/null || true
 
-    local count
-    count=$(find "$target_scripts_dir" -name "*.sh" -type f | wc -l | tr -d ' ')
-    log_success "Deployed $count scripts"
+	local count
+	count=$(find "$target_scripts_dir" -name "*.sh" -type f | wc -l | tr -d ' ')
+	log_success "Deployed $count scripts"
 
-    return 0
+	return 0
 }
 
 # Deploy all agent files (selective sync, preserving custom/draft)
 deploy_all_agents() {
-    local source_dir="$REPO_DIR/.agents"
+	local source_dir="$REPO_DIR/.agents"
 
-    if [[ ! -d "$source_dir" ]]; then
-        log_error "Source agents directory not found: $source_dir"
-        return 1
-    fi
+	if [[ ! -d "$source_dir" ]]; then
+		log_error "Source agents directory not found: $source_dir"
+		return 1
+	fi
 
-    mkdir -p "$TARGET_DIR"
+	mkdir -p "$TARGET_DIR"
 
-    if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[dry-run] Would sync $source_dir/ -> $TARGET_DIR/"
-        log_info "[dry-run] Preserving: custom/, draft/"
-        return 0
-    fi
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "[dry-run] Would sync $source_dir/ -> $TARGET_DIR/"
+		log_info "[dry-run] Preserving: custom/, draft/"
+		return 0
+	fi
 
-    log_info "Deploying all agents to $TARGET_DIR..."
+	log_info "Deploying all agents to $TARGET_DIR..."
 
-    if command -v rsync &>/dev/null; then
-        rsync -a \
-            --exclude='loop-state/' \
-            --exclude='custom/' \
-            --exclude='draft/' \
-            "$source_dir/" "$TARGET_DIR/"
-    else
-        # Preserve custom and draft directories
-        local tmp_preserve
-        tmp_preserve=$(mktemp -d)
-        local preserve_ok=true
+	if command -v rsync &>/dev/null; then
+		rsync -a \
+			--exclude='loop-state/' \
+			--exclude='custom/' \
+			--exclude='draft/' \
+			"$source_dir/" "$TARGET_DIR/"
+	else
+		# Preserve custom and draft directories
+		local tmp_preserve
+		tmp_preserve=$(mktemp -d)
+		local preserve_ok=true
 
-        for pdir in custom draft; do
-            if [[ -d "$TARGET_DIR/$pdir" ]] && ! cp -R "$TARGET_DIR/$pdir" "$tmp_preserve/$pdir"; then
-                preserve_ok=false
-            fi
-        done
+		for pdir in custom draft; do
+			if [[ -d "$TARGET_DIR/$pdir" ]] && ! cp -R "$TARGET_DIR/$pdir" "$tmp_preserve/$pdir"; then
+				preserve_ok=false
+			fi
+		done
 
-        if [[ "$preserve_ok" == "false" ]]; then
-            log_error "Failed to preserve custom/draft directories"
-            rm -rf "$tmp_preserve"
-            return 1
-        fi
+		if [[ "$preserve_ok" == "false" ]]; then
+			log_error "Failed to preserve custom/draft directories"
+			rm -rf "$tmp_preserve"
+			return 1
+		fi
 
-        # Copy all agents
-        (cd "$source_dir" && tar cf - --exclude='loop-state' --exclude='custom' --exclude='draft' .) | \
-            (cd "$TARGET_DIR" && tar xf -)
+		# Remove existing target contents (except custom/draft) to match rsync --delete behavior
+		find "$TARGET_DIR" -mindepth 1 -maxdepth 1 \
+			! -name 'custom' ! -name 'draft' ! -name 'loop-state' \
+			-exec rm -rf {} + 2>/dev/null || true
 
-        # Restore preserved directories
-        for pdir in custom draft; do
-            if [[ -d "$tmp_preserve/$pdir" ]]; then
-                cp -R "$tmp_preserve/$pdir" "$TARGET_DIR/$pdir"
-            fi
-        done
-        rm -rf "$tmp_preserve"
-    fi
+		# Copy all agents
+		(cd "$source_dir" && tar cf - --exclude='loop-state' --exclude='custom' --exclude='draft' .) |
+			(cd "$TARGET_DIR" && tar xf -)
 
-    # Set executable permissions on scripts
-    chmod +x "$TARGET_DIR/scripts/"*.sh 2>/dev/null || true
+		# Restore preserved directories
+		for pdir in custom draft; do
+			if [[ -d "$tmp_preserve/$pdir" ]]; then
+				cp -R "$tmp_preserve/$pdir" "$TARGET_DIR/$pdir"
+			fi
+		done
+		rm -rf "$tmp_preserve"
+	fi
 
-    # Copy VERSION file
-    if [[ -f "$REPO_DIR/VERSION" ]]; then
-        cp "$REPO_DIR/VERSION" "$TARGET_DIR/VERSION"
-    fi
+	# Set executable permissions on scripts
+	chmod +x "$TARGET_DIR/scripts/"*.sh 2>/dev/null || true
 
-    local agent_count script_count
-    agent_count=$(find "$TARGET_DIR" -name "*.md" -type f | wc -l | tr -d ' ')
-    script_count=$(find "$TARGET_DIR/scripts" -name "*.sh" -type f 2>/dev/null | wc -l | tr -d ' ')
-    log_success "Deployed $agent_count agent files and $script_count scripts"
+	# Copy VERSION file
+	if [[ -f "$REPO_DIR/VERSION" ]]; then
+		cp "$REPO_DIR/VERSION" "$TARGET_DIR/VERSION"
+	fi
 
-    return 0
+	local agent_count script_count
+	agent_count=$(find "$TARGET_DIR" -name "*.md" -type f | wc -l | tr -d ' ')
+	script_count=$(find "$TARGET_DIR/scripts" -name "*.sh" -type f 2>/dev/null | wc -l | tr -d ' ')
+	log_success "Deployed $agent_count agent files and $script_count scripts"
+
+	return 0
 }
 
 # Deploy only specific changed files (most targeted)
 deploy_changed_files() {
-    local changed_files="$1"
+	local changed_files="$1"
 
-    if [[ -z "$changed_files" ]]; then
-        log_info "No changed files to deploy"
-        return 2
-    fi
+	if [[ -z "$changed_files" ]]; then
+		log_info "No changed files to deploy"
+		return 2
+	fi
 
-    local count
-    count=$(echo "$changed_files" | wc -l | tr -d ' ')
+	local count
+	count=$(echo "$changed_files" | wc -l | tr -d ' ')
 
-    if [[ "$DRY_RUN" == "true" ]]; then
-        log_info "[dry-run] Would deploy $count changed files:"
-        echo "$changed_files" | head -20
-        if [[ "$count" -gt 20 ]]; then
-            log_info "[dry-run] ... and $((count - 20)) more"
-        fi
-        return 0
-    fi
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "[dry-run] Would deploy $count changed files:"
+		echo "$changed_files" | head -20
+		if [[ "$count" -gt 20 ]]; then
+			log_info "[dry-run] ... and $((count - 20)) more"
+		fi
+		return 0
+	fi
 
-    log_info "Deploying $count changed files..."
+	log_info "Deploying $count changed files..."
 
-    local deployed=0
-    local failed=0
+	local deployed=0
+	local failed=0
 
-    while IFS= read -r file; do
-        [[ -z "$file" ]] && continue
+	while IFS= read -r file; do
+		[[ -z "$file" ]] && continue
 
-        # Strip .agents/ prefix to get relative path within target
-        local rel_path="${file#.agents/}"
-        local source_file="$REPO_DIR/$file"
-        local target_file="$TARGET_DIR/$rel_path"
+		# Strip .agents/ prefix to get relative path within target
+		local rel_path="${file#.agents/}"
+		local source_file="$REPO_DIR/$file"
+		local target_file="$TARGET_DIR/$rel_path"
 
-        # Skip custom/draft/loop-state
-        case "$rel_path" in
-            custom/*|draft/*|loop-state/*) continue ;;
-        esac
+		# Skip custom/draft/loop-state
+		case "$rel_path" in
+		custom/* | draft/* | loop-state/*) continue ;;
+		esac
 
-        if [[ -f "$source_file" ]]; then
-            # Create target directory if needed
-            local target_parent
-            target_parent=$(dirname "$target_file")
-            mkdir -p "$target_parent"
+		if [[ -f "$source_file" ]]; then
+			# Create target directory if needed
+			local target_parent
+			target_parent=$(dirname "$target_file")
+			mkdir -p "$target_parent"
 
-            # Copy file
-            cp "$source_file" "$target_file"
+			# Copy file (catch errors instead of letting set -e abort)
+			if ! cp "$source_file" "$target_file"; then
+				log_warn "Failed to copy: $rel_path"
+				failed=$((failed + 1))
+				continue
+			fi
 
-            # Set executable if it's a script
-            if [[ "$target_file" == *.sh ]]; then
-                chmod +x "$target_file"
-            fi
+			# Set executable if it's a script
+			if [[ "$target_file" == *.sh ]]; then
+				if ! chmod +x "$target_file"; then
+					log_warn "Failed to set executable: $rel_path"
+					failed=$((failed + 1))
+					continue
+				fi
+			fi
 
-            deployed=$((deployed + 1))
-        elif [[ ! -e "$source_file" ]]; then
-            # File was deleted in source — remove from target
-            if [[ -f "$target_file" ]]; then
-                rm -f "$target_file"
-                log_info "Removed deleted file: $rel_path"
-            fi
-        fi
-    done <<< "$changed_files"
+			deployed=$((deployed + 1))
+		elif [[ ! -e "$source_file" ]]; then
+			# File was deleted in source — remove from target
+			if [[ -f "$target_file" ]]; then
+				if ! rm -f "$target_file"; then
+					log_warn "Failed to remove deleted file: $rel_path"
+					failed=$((failed + 1))
+					continue
+				fi
+				log_info "Removed deleted file: $rel_path"
+			fi
+		fi
+	done <<<"$changed_files"
 
-    if [[ "$failed" -gt 0 ]]; then
-        log_warn "Deployed $deployed files, $failed failed"
-        return 1
-    fi
+	if [[ "$failed" -gt 0 ]]; then
+		log_warn "Deployed $deployed files, $failed failed"
+		return 1
+	fi
 
-    # Update VERSION
-    if [[ -f "$REPO_DIR/VERSION" ]]; then
-        cp "$REPO_DIR/VERSION" "$TARGET_DIR/VERSION"
-    fi
+	# Update VERSION
+	if [[ -f "$REPO_DIR/VERSION" ]]; then
+		cp "$REPO_DIR/VERSION" "$TARGET_DIR/VERSION"
+	fi
 
-    log_success "Deployed $deployed changed files"
-    return 0
+	log_success "Deployed $deployed changed files"
+	return 0
 }
 
 main() {
-    parse_args "$@" || return 1
-    validate_repo || return 1
+	parse_args "$@" || return 1
+	validate_repo || return 1
 
-    # Full deploy: delegate to setup.sh
-    if [[ "$FULL_DEPLOY" == "true" ]]; then
-        log_info "Running full deploy via setup.sh --non-interactive..."
-        if [[ "$DRY_RUN" == "true" ]]; then
-            log_info "[dry-run] Would run: AIDEVOPS_NON_INTERACTIVE=true $REPO_DIR/setup.sh --non-interactive"
-            return 0
-        fi
-        AIDEVOPS_NON_INTERACTIVE=true bash "$REPO_DIR/setup.sh" --non-interactive
-        return $?
-    fi
+	# Full deploy: delegate to setup.sh
+	if [[ "$FULL_DEPLOY" == "true" ]]; then
+		log_info "Running full deploy via setup.sh --non-interactive..."
+		if [[ "$DRY_RUN" == "true" ]]; then
+			log_info "[dry-run] Would run: AIDEVOPS_NON_INTERACTIVE=true $REPO_DIR/setup.sh --non-interactive"
+			return 0
+		fi
+		AIDEVOPS_NON_INTERACTIVE=true bash "$REPO_DIR/setup.sh" --non-interactive
+		return $?
+	fi
 
-    # Pull latest (only if on main)
-    pull_latest
+	# Pull latest (only if on main)
+	pull_latest
 
-    # Scripts-only deploy
-    if [[ "$SCRIPTS_ONLY" == "true" ]]; then
-        deploy_scripts_only
-        return $?
-    fi
+	# Scripts-only deploy
+	if [[ "$SCRIPTS_ONLY" == "true" ]]; then
+		deploy_scripts_only
+		return $?
+	fi
 
-    # Diff-based deploy
-    if [[ -n "$DIFF_COMMIT" ]]; then
-        local changed
-        changed=$(detect_changes "$DIFF_COMMIT")
-        if [[ -z "$changed" ]]; then
-            log_info "No agent changes since $DIFF_COMMIT"
-            return 2
-        fi
+	# Diff-based deploy
+	if [[ -n "$DIFF_COMMIT" ]]; then
+		local changed
+		changed=$(detect_changes "$DIFF_COMMIT")
+		if [[ -z "$changed" ]]; then
+			log_info "No agent changes since $DIFF_COMMIT"
+			return 2
+		fi
 
-        # If many files changed, do a full agent sync instead of file-by-file
-        local change_count
-        change_count=$(echo "$changed" | wc -l | tr -d ' ')
-        if [[ "$change_count" -gt 50 ]]; then
-            log_info "Large changeset ($change_count files) — doing full agent sync"
-            deploy_all_agents
-            return $?
-        fi
+		# If many files changed, do a full agent sync instead of file-by-file
+		local change_count
+		change_count=$(echo "$changed" | wc -l | tr -d ' ')
+		if [[ "$change_count" -gt 50 ]]; then
+			log_info "Large changeset ($change_count files) — doing full agent sync"
+			deploy_all_agents
+			return $?
+		fi
 
-        # Check if only scripts changed
-        local non_script_changes
-        non_script_changes=$(echo "$changed" | grep -cv '^\.agents/scripts/' || echo "0")
-        if [[ "$non_script_changes" -eq 0 ]]; then
-            log_info "Only scripts changed — using fast scripts-only deploy"
-            deploy_scripts_only
-            return $?
-        fi
+		# Check if only scripts changed
+		local non_script_changes
+		non_script_changes=$(echo "$changed" | grep -cv '^\.agents/scripts/' || echo "0")
+		if [[ "$non_script_changes" -eq 0 ]]; then
+			log_info "Only scripts changed — using fast scripts-only deploy"
+			deploy_scripts_only
+			return $?
+		fi
 
-        deploy_changed_files "$changed"
-        return $?
-    fi
+		deploy_changed_files "$changed"
+		return $?
+	fi
 
-    # Default: version-based detection
-    local changed
-    changed=$(detect_changes "")
-    if [[ -z "$changed" ]]; then
-        return 2
-    fi
+	# Default: version-based detection
+	local changed
+	changed=$(detect_changes "")
+	if [[ -z "$changed" ]]; then
+		return 2
+	fi
 
-    # Version mismatch detected — full agent sync
-    deploy_all_agents
-    return $?
+	# Version mismatch detected — full agent sync
+	deploy_all_agents
+	return $?
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Fix `--help` flag continuing execution into `validate_repo`/deploy by using `exit 0` instead of `return 0` in `parse_args`
- Fix tar fallback diverging from `rsync --delete` by cleaning target directories before extracting (both `deploy_scripts_only` and `deploy_all_agents`)
- Fix dead error path where `failed` counter was initialized but never incremented — `cp`/`chmod`/`rm` errors now caught and counted for graceful partial-failure reporting

## Details

All three findings from CodeRabbit review on PR #916:

| Severity | Finding | Fix |
|----------|---------|-----|
| HIGH | `--help` returns 0 but `main()` continues past `parse_args` | `return 0` → `exit 0` |
| HIGH | `rsync --delete` vs tar fallback behavioral divergence | Added `find -delete` cleanup before tar extract |
| CRITICAL | `failed` counter never incremented — error path is dead code | Wrapped `cp`/`chmod`/`rm` in `if !` guards with `failed++` |

## Verification

- ShellCheck: zero violations
- `bash -n`: syntax OK
- `--help` tested: exits immediately with code 0, does not reach `validate_repo`

Closes #3548