### PR TITLE
GH#3818: Fix quality-debt from PR #10 review feedback

### DIFF
--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -506,7 +506,7 @@ Additional context: $ARGUMENTS
    - Any TODO.md/PLANS.md task references
    - User-provided context (if any)
 6. Create PR using `gh pr create`
-7. Return PR URL
+7. If creation succeeds, return PR URL; otherwise show error and suggest fixes
 
 **Example:**
 - `/create-pr` → Creates PR with auto-generated title/description

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -127,7 +127,7 @@ When work evolves significantly from the branch name/purpose:
 git stash --include-untracked -m "WIP: {description}"
 git checkout main && git pull origin main
 git checkout -b {type}/{description}
-git stash pop
+git stash pop || echo "Stash conflicts detected - resolve before continuing"
 ```
 
 **Self-check trigger**: Before each file edit, briefly consider: "Does this change align with `{branch-name}`?"


### PR DESCRIPTION
## Summary

- Add stash conflict detection to git-workflow.md stash workflow (`git stash pop || echo "Stash conflicts detected..."`) so failures are surfaced instead of silently ignored
- Improve `/create-pr` command step 7 to document error handling when `gh pr create` fails

## Source

Addresses CodeRabbit review feedback from PR #10 (nitpick comments on `.agents/workflows/git-workflow.md` and `.agents/scripts/generate-opencode-commands.sh`).

Closes #3818