### PR TITLE
GH#3769: Combine separate SQLite queries in supervisor scripts

### DIFF
--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -2733,9 +2733,8 @@ cmd_dispatch() {
 		local escaped_batch
 		escaped_batch=$(sql_escape "$batch_id")
 		local base_concurrency max_load_factor batch_max_concurrency
-		base_concurrency=$(db "$SUPERVISOR_DB" "SELECT concurrency FROM batches WHERE id = '$escaped_batch';")
-		max_load_factor=$(db "$SUPERVISOR_DB" "SELECT max_load_factor FROM batches WHERE id = '$escaped_batch';")
-		batch_max_concurrency=$(db "$SUPERVISOR_DB" "SELECT COALESCE(max_concurrency, 0) FROM batches WHERE id = '$escaped_batch';" 2>/dev/null || echo "0")
+		# Single query for all batch concurrency fields (GH#3769: combine separate DB lookups)
+		IFS='|' read -r base_concurrency max_load_factor batch_max_concurrency < <(db "$SUPERVISOR_DB" "SELECT concurrency || '|' || COALESCE(max_load_factor, '') || '|' || COALESCE(max_concurrency, 0) FROM batches WHERE id = '$escaped_batch';" 2>/dev/null || echo "||0")
 		local concurrency
 		concurrency=$(calculate_adaptive_concurrency "${base_concurrency:-4}" "${max_load_factor:-2}" "${batch_max_concurrency:-0}")
 		local active_count

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2564,9 +2564,8 @@ cmd_pulse() {
 			local display_base display_max display_load_factor display_adaptive
 			local escaped_display_batch
 			escaped_display_batch=$(sql_escape "$batch_id")
-			display_base=$(db "$SUPERVISOR_DB" "SELECT concurrency FROM batches WHERE id = '$escaped_display_batch';" 2>/dev/null || echo "?")
-			display_max=$(db "$SUPERVISOR_DB" "SELECT COALESCE(max_concurrency, 0) FROM batches WHERE id = '$escaped_display_batch';" 2>/dev/null || echo "0")
-			display_load_factor=$(db "$SUPERVISOR_DB" "SELECT COALESCE(max_load_factor, 2) FROM batches WHERE id = '$escaped_display_batch';" 2>/dev/null || echo "2")
+			# Single query for all batch concurrency fields (GH#3769: combine separate DB lookups)
+			IFS='|' read -r display_base display_max display_load_factor < <(db "$SUPERVISOR_DB" "SELECT COALESCE(concurrency, '?') || '|' || COALESCE(max_concurrency, 0) || '|' || COALESCE(max_load_factor, 2) FROM batches WHERE id = '$escaped_display_batch';" 2>/dev/null || echo "?|0|2")
 			display_adaptive=$(calculate_adaptive_concurrency "${display_base:-4}" "${display_load_factor:-2}" "${display_max:-0}")
 			local adaptive_label="base:${display_base}"
 			if [[ "$display_adaptive" -gt "${display_base:-0}" ]]; then

--- a/.agents/scripts/supervisor-archived/state.sh
+++ b/.agents/scripts/supervisor-archived/state.sh
@@ -420,18 +420,16 @@ cmd_status() {
 
 	# Check if target is a batch
 	local batch_row
+	# Single query includes max_concurrency and max_load_factor (GH#3769: combine separate DB lookups)
 	batch_row=$(db -separator '|' "$SUPERVISOR_DB" "
-        SELECT id, name, concurrency, status, created_at, release_on_complete, release_type
+        SELECT id, name, concurrency, status, created_at, release_on_complete, release_type,
+               COALESCE(max_concurrency, 0), COALESCE(max_load_factor, 2)
         FROM batches WHERE id = '$(sql_escape "$target")' OR name = '$(sql_escape "$target")';
     ")
 
 	if [[ -n "$batch_row" ]]; then
-		local bid bname bconc bstatus bcreated brelease_flag brelease_type
-		IFS='|' read -r bid bname bconc bstatus bcreated brelease_flag brelease_type <<<"$batch_row"
-		local bmax_conc
-		bmax_conc=$(db "$SUPERVISOR_DB" "SELECT COALESCE(max_concurrency, 0) FROM batches WHERE id = '$(sql_escape "$bid")';" 2>/dev/null || echo "0")
-		local bmax_load
-		bmax_load=$(db "$SUPERVISOR_DB" "SELECT COALESCE(max_load_factor, 2) FROM batches WHERE id = '$(sql_escape "$bid")';" 2>/dev/null || echo "2")
+		local bid bname bconc bstatus bcreated brelease_flag brelease_type bmax_conc bmax_load
+		IFS='|' read -r bid bname bconc bstatus bcreated brelease_flag brelease_type bmax_conc bmax_load <<<"$batch_row"
 		local badaptive
 		badaptive=$(calculate_adaptive_concurrency "${bconc:-4}" "${bmax_load:-2}" "${bmax_conc:-0}")
 		local cap_display="auto"


### PR DESCRIPTION
## Summary

- Addresses PR #465 Gemini review feedback: combine multiple `sqlite3` process invocations into single queries when fetching different columns from the same `batches` row
- Reduces 8 separate DB calls across 3 files down to 3 calls total (net -5 process spawns per execution path)

## Changes

| File | Before | After | Technique |
|------|--------|-------|-----------|
| `dispatch.sh:2736` | 3 separate queries | 1 query | `IFS='\|' read` with pipe-delimited `SELECT` |
| `pulse.sh:2567` | 3 separate queries | 1 query | `IFS='\|' read` with pipe-delimited `SELECT` |
| `state.sh:423` | 1 query + 2 follow-ups | 1 query | Added `max_concurrency`, `max_load_factor` to existing `batch_row` SELECT |

## Verification

- `bash -n`: all 3 files pass syntax check
- `shellcheck`: no new violations (only pre-existing SC1091 info on dispatch.sh)
- Default values preserved via `COALESCE()` in SQL and `${var:-default}` in bash
- Downstream variable usage unchanged — same names, same defaults

Closes #3769