### PR TITLE
fix: add explicit return 0 to add_opencode_plugin() per coding standards

### DIFF
--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -465,6 +465,8 @@ add_opencode_plugin() {
 		jq --arg p "$plugin_spec" '. + {plugin: [$p]}' "$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
 		print_success "Created plugin array with $plugin_name"
 	fi
+
+	return 0
 }
 
 setup_opencode_plugins() {


### PR DESCRIPTION
## Summary

- Adds missing explicit `return 0` to `add_opencode_plugin()` in `setup-modules/mcp-setup.sh`, per project shell coding standards

## Details

CodeRabbit review on PR #20 flagged that `add_opencode_plugin()` was missing an explicit return statement at the end of the function. The project's coding guidelines require every shell function to have an explicit `return 0` or `return 1`.

Closes #3809

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code quality improvements to ensure proper function exit handling during setup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->