### PR TITLE
GH#3806: Fix quality-debt from PR #26 review feedback

### DIFF
--- a/.agents/workflows/ralph-loop.md
+++ b/.agents/workflows/ralph-loop.md
@@ -529,46 +529,16 @@ The check runs automatically when starting an OpenCode session in the aidevops r
 
 ## Session Completion & Spawning
 
-Loop agents should detect completion and suggest next steps.
+Loop agents should detect completion and suggest next steps. See `workflows/session-manager.md` for the canonical reference on session lifecycle, completion detection, spawning patterns (terminal tabs, background sessions, worktrees), and handoff templates.
 
-### Loop Completion Detection
-
-When a loop completes successfully (promise fulfilled), suggest:
-
-```text
-<promise>PR_MERGED</promise>
-
----
-Loop complete. PR #123 merged successfully.
-
-Suggestions:
-1. Run @agent-review to capture learnings
-2. Start new session for next task
-3. Spawn parallel session for related work
----
-```
-
-### Spawning New Sessions from Loops
-
-Loops can spawn new OpenCode sessions for parallel work. See `workflows/session-manager.md` for full spawning patterns (background sessions, terminal tabs, worktrees).
-
-**Quick reference:**
-
-```bash
-# Background session
-opencode run "Continue with next task" --agent Build+ &
-
-# With worktree (recommended for parallel branches)
-~/.aidevops/agents/scripts/worktree-helper.sh add feature/parallel-task
-```
-
-### Session Spawning on Completion
-
-After a successful loop, the AI can spawn new sessions for follow-up work:
+**Quick reference for loop completion:**
 
 ```bash
 # After successful loop, start next task
 /full-loop "Next task description"
+
+# Or spawn a background session
+opencode run "Continue with next task" --agent Build+ &
 ```
 
 ## Full Development Loop

--- a/.agents/workflows/session-manager.md
+++ b/.agents/workflows/session-manager.md
@@ -46,31 +46,35 @@ tools:
 ```bash
 # Check session completion status
 check_session_status() {
-    echo "=== Session Status ==="
-    
-    # Check incomplete tasks
     local incomplete
-    incomplete=$(grep -c '^\s*- \[ \]' TODO.md 2>/dev/null || echo "0")
-    echo "Incomplete tasks: $incomplete"
-    
-    # Check recent PR
     local pr_state
+    local version
+    local latest_tag
+
+    echo "=== Session Status ==="
+
+    # Check incomplete tasks
+    incomplete=$(grep -c '^\s*- \[ \]' TODO.md 2>/dev/null || echo "0")
+    echo "Incomplete tasks: ${incomplete}"
+
+    # Check recent PR (requires gh CLI)
     pr_state=$(gh pr view --json state --jq '.state' 2>/dev/null || echo "none")
-    echo "Current PR state: $pr_state"
-    
+    echo "Current PR state: ${pr_state}"
+
     # Check latest release vs VERSION
-    local version latest_tag
-    version=$(cat VERSION 2>/dev/null || echo "unknown")
+    version=$(<VERSION 2>/dev/null || echo "unknown")
     latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
-    echo "VERSION: $version, Latest tag: $latest_tag"
-    
+    echo "VERSION: ${version}, Latest tag: ${latest_tag}"
+
     # Suggest if complete
-    if [[ "$incomplete" == "0" && "$pr_state" == "MERGED" ]]; then
+    if [[ "${incomplete}" == "0" && "${pr_state}" == "MERGED" ]]; then
         echo ""
         echo "Session appears complete. Consider:"
         echo "  1. Run @agent-review"
         echo "  2. Start new session"
     fi
+
+    return 0
 }
 ```
 
@@ -131,18 +135,20 @@ Suggestions:
 spawn_terminal_tab() {
     local dir="${1:-$(pwd)}"
     local cmd="${2:-opencode}"
-    osascript -e "tell application \"Terminal\" to do script \"cd '$dir' && $cmd\""
+    osascript -e "tell application \"Terminal\" to do script \"cd '${dir}' && ${cmd}\""
+    return 0
 }
 
-# iTerm
+# iTerm (responds to both "iTerm" and "iTerm2" in AppleScript)
 spawn_iterm_tab() {
     local dir="${1:-$(pwd)}"
     local cmd="${2:-opencode}"
-    osascript -e "tell application \"iTerm\" to tell current window to create tab with default profile command \"cd '$dir' && $cmd\""
+    osascript -e "tell application \"iTerm\" to tell current window to create tab with default profile command \"cd '${dir}' && ${cmd}\""
+    return 0
 }
 
-# Usage
-spawn_terminal_tab ~/Git/project-feature-auth
+# Usage (replace <your-project> with your actual project path)
+spawn_terminal_tab ~/Git/<your-project>
 ```
 
 ### Option 2: Background Session
@@ -163,23 +169,23 @@ Best for parallel branch work:
 ```bash
 # Create worktree
 ~/.aidevops/agents/scripts/worktree-helper.sh add feature/parallel-task
-# Output: ~/Git/project-feature-parallel-task/
+# Output: ~/Git/<your-project>-feature-parallel-task/
 
 # Spawn session in worktree (macOS)
-osascript -e 'tell application "Terminal" to do script "cd ~/Git/project-feature-parallel-task && opencode"'
+osascript -e 'tell application "Terminal" to do script "cd ~/Git/<your-project>-feature-parallel-task && opencode"'
 ```
 
 ### Linux Terminal Spawning
 
 ```bash
 # GNOME Terminal
-gnome-terminal --tab -- bash -c "cd ~/Git/project && opencode; exec bash"
+gnome-terminal --tab -- bash -c "cd ~/Git/<your-project> && opencode; exec bash"
 
 # Konsole
-konsole --new-tab -e bash -c "cd ~/Git/project && opencode"
+konsole --new-tab -e bash -c "cd ~/Git/<your-project> && opencode"
 
 # Kitty
-kitty @ launch --type=tab --cwd=~/Git/project opencode
+kitty @ launch --type=tab --cwd=~/Git/<your-project> opencode
 ```
 
 ## Session Handoff Pattern
@@ -213,12 +219,12 @@ opencode run "Read .session-handoff.md and continue the work" --agent Build+
 
 Agents should suggest `@agent-review` at these points:
 
-1. **After PR merge** - Capture what worked in the PR process
-2. **After release** - Capture release learnings
+1. **After PR merge** - Document what worked in the PR process
+2. **After release** - Document release learnings
 3. **After fixing multiple issues** - Pattern recognition opportunity
 4. **After user correction** - Immediate improvement opportunity
 5. **Before starting unrelated work** - Clean context boundary
-6. **After long session** - Capture accumulated learnings
+6. **After long session** - Document accumulated learnings
 
 ## Integration with Loop Agents
 


### PR DESCRIPTION
## Summary

- Improve shell script examples in `session-manager.md` for robustness (local declarations upfront, `${var}` quoting, explicit `return 0`, `$(<file)` instead of `cat`)
- Consolidate duplicated session completion/spawning guidance in `ralph-loop.md` to reference `session-manager.md` as the canonical source (SSoT)
- Replace hardcoded `~/Git/project` paths with `<your-project>` placeholders for clarity
- Use more formal "Document" wording instead of "Capture" in `@agent-review` suggestion list

## Review Findings Addressed

| Finding | Severity | Reviewer | Action |
|---------|----------|----------|--------|
| Script robustness + shell consistency + placeholder paths | MEDIUM | Gemini | Fixed |
| iTerm → iTerm2 in AppleScript | HIGH | CodeRabbit | Dismissed by human reviewer (both names work) — added clarifying comment |
| Consolidate duplicated session/spawn guidance | MEDIUM | CodeRabbit | Consolidated ralph-loop.md, kept opencode.md (already well-structured) |
| "Capture" → "Document" wording | Nitpick | CodeRabbit | Fixed |

Closes #3806