### PR TITLE
GH#3817: Fix quality-debt from PR #12 review feedback

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -18,6 +18,8 @@ New to aidevops? Type `/onboarding`.
 
 ## Pre-Edit Git Check
 
+> **Skip this section if you don't have Edit/Write/Bash tools** (e.g., Plan+ agent). Instead, proceed directly to responding to the user.
+
 Rules: `prompts/build.txt`. Details: `workflows/pre-edit.md`.
 
 Subagent write restrictions: on `main`/`master`, subagents may ONLY write to `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. All other writes → proposed edits in a worktree.


### PR DESCRIPTION
## Summary

- Restores the pre-edit skip instruction for read-only agents (e.g., Plan+) that was lost during a section refactor
- Uses the single-line wording suggested by Gemini Code Assist in [PR #12 review](https://github.com/marcusquinn/aidevops/pull/12#pullrequestreview-3636910377), combining the condition and alternative action into one clear instruction

## Change

**File:** `.agents/AGENTS.md` (Pre-Edit Git Check section)

**Before:** No skip instruction — read-only agents would attempt to run `pre-edit-check.sh` and fail

**After:**
> **Skip this section if you don't have Edit/Write/Bash tools** (e.g., Plan+ agent). Instead, proceed directly to responding to the user.

This is the exact wording Gemini suggested — a single blockquote line that directly links the condition with the alternative action, reducing ambiguity for AI agents.

Closes #3817