### PR TITLE
t3789: Fix quality-debt in CHANGELOG.md — remove MD012 violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,7 +165,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.151.2] - 2026-03-05
 
 ### Added
@@ -457,7 +456,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.134.1] - 2026-02-27
 
@@ -1350,13 +1348,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.115.20] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.115.19] - 2026-02-15
 
@@ -1364,13 +1360,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.115.18] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.115.17] - 2026-02-15
 
@@ -1378,13 +1372,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.115.16] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.115.15] - 2026-02-15
 
@@ -1392,13 +1384,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.115.14] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.115.13] - 2026-02-15
 
@@ -1406,13 +1396,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.115.12] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.115.11] - 2026-02-15
 
@@ -1420,13 +1408,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.115.10] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.115.9] - 2026-02-15
 
@@ -1434,13 +1420,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.115.8] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.115.7] - 2026-02-15
 
@@ -1448,13 +1432,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.115.6] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.115.5] - 2026-02-15
 
@@ -1462,20 +1444,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Version bump and maintenance updates
 
-
 ## [2.115.4] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
 
-
 ## [2.115.3] - 2026-02-15
 
 ### Changed
 
 - Version bump and maintenance updates
-
 
 ## [2.115.2] - 2026-02-15
 


### PR DESCRIPTION
## Summary

- Removes 21 double-blank-line violations (MD012) in CHANGELOG.md
- The original MD022 violation from PR #92 review was already fixed; this cleans up all remaining markdown lint errors
- CHANGELOG.md now passes `markdownlint-cli2` with 0 errors

Closes #3789