### PR TITLE
t3772: wrap meta-instruction in HTML comment in opencode-config-agents template

### DIFF
--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -1,4 +1,4 @@
-Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
+<!-- Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities. -->
 
 ## aidevops Framework Status
 


### PR DESCRIPTION
## Summary

- Wraps the plain-text meta-instruction on line 1 of `templates/opencode-config-agents.md` in an HTML comment (`<!-- ... -->`) so AI agents don't misinterpret it as an instruction
- Addresses unactioned Gemini review feedback from PR #419 (medium severity)
- The HIGH severity finding (UPDATE_AVAILABLE format mismatch) was already fixed in the original PR (commit ed8e0d2)

Closes #3772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration template formatting to modify an instruction reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->