### PR TITLE
t3813: address PR #25 review feedback on ui-skills.md

### DIFF
--- a/.agents/tools/ui/ui-skills.md
+++ b/.agents/tools/ui/ui-skills.md
@@ -20,7 +20,7 @@ tools:
 
 - **Purpose**: Opinionated constraints for building better interfaces with agents
 - **Source**: https://www.ui-skills.com/llms.txt
-- **Stack**: Tailwind CSS, motion/react, tw-animate-css, clsx + tailwind-merge
+- **Stack**: Tailwind CSS, motion/react, tw-animate-css, `cn` utility (`clsx` + `tailwind-merge`)
 
 **When to apply these constraints**:
 - Building React/Next.js interfaces
@@ -85,8 +85,8 @@ tools:
 
 ## Layout
 
-- MUST use a fixed `z-index` scale (no arbitrary `z-x`)
-- SHOULD use `size-x` for square elements instead of `w-x` + `h-x`
+- MUST use a fixed `z-index` scale (e.g., `z-10`, `z-20`) and avoid arbitrary values (e.g., `z-[99]`)
+- SHOULD use `size-*` for square elements instead of `w-*` + `h-*`
 
 ## Performance
 
@@ -97,7 +97,7 @@ tools:
 ## Design
 
 - NEVER use gradients unless explicitly requested
-- NEVER use purple or multicolor gradients
+- SHOULD avoid purple or multicolor gradients even when gradients are requested (prefer subtle, single-hue gradients)
 - NEVER use glow effects as primary affordances
 - SHOULD use Tailwind CSS default shadow scale unless explicitly requested
 - MUST give empty states one clear next action


### PR DESCRIPTION
## Summary

- Address 5 unactioned review findings from PR #25 (Gemini Code Assist + CodeRabbit)
- Improve clarity of Tailwind utility patterns and terminology consistency in `ui-skills.md`
- Soften overly specific design constraint (purple gradient prohibition)

## Changes

| Finding | Reviewer | Fix |
|---------|----------|-----|
| `cn` utility not backtick-formatted in Quick Reference | Gemini | Use `cn` utility (`clsx` + `tailwind-merge`) — consistent with Stack section |
| `z-x` placeholder ambiguous | Gemini | Explicit examples: `z-10`, `z-20`, `z-[99]` |
| `size-x`/`w-x`/`h-x` unclear | Gemini | Idiomatic `*` wildcard: `size-*`, `w-*`, `h-*` |
| `cn` utility definition unclear | CodeRabbit | Quick Reference now mirrors Stack section terminology |
| Purple gradient hard ban unexplained | CodeRabbit | Softened from NEVER to SHOULD avoid with guidance |

Closes #3813