### PR TITLE
fix: propagate exit status in terminal-title-setup.sh cmd_install/cmd_uninstall

### DIFF
--- a/.agents/scripts/terminal-title-setup.sh
+++ b/.agents/scripts/terminal-title-setup.sh
@@ -392,11 +392,11 @@ cmd_install() {
 	# Remove existing integration if present
 	if is_installed "$rc_file"; then
 		log_info "Existing integration found, updating..."
-		remove_integration "$rc_file"
+		remove_integration "$rc_file" || return 1
 	fi
 
 	# Install new integration
-	install_integration "$shell_name" "$rc_file"
+	install_integration "$shell_name" "$rc_file" || return 1
 
 	# Check and fix Tabby configuration if needed
 	check_and_fix_tabby
@@ -409,6 +409,7 @@ cmd_install() {
 	echo "  2. Run: source $rc_file"
 	echo ""
 	echo "Your terminal tab will now show: repo/branch (e.g., aidevops/feature/xyz)"
+	return 0
 }
 
 cmd_uninstall() {
@@ -427,11 +428,12 @@ cmd_uninstall() {
 		return 0
 	fi
 
-	remove_integration "$rc_file"
+	remove_integration "$rc_file" || return 1
 
 	echo ""
 	log_success "Terminal title integration removed!"
 	echo "Restart your terminal or run: source $rc_file"
+	return 0
 }
 
 cmd_status() {


### PR DESCRIPTION
## Summary

- Propagate non-zero exit codes from `remove_integration` and `install_integration` in `cmd_install()` and `cmd_uninstall()` using `|| return 1`
- Add explicit `return 0` on success paths for both functions
- Addresses Augment review feedback from PR #30: previously, failures in critical operations were masked by subsequent `echo`/`log_success` statements that always succeed

## Context

**Issue**: #3810 (quality-debt: PR #30 review feedback)

Two review findings from PR #30:
1. **Gemini (dev-browser-helper.sh)**: Already addressed in PR #30 itself — the `find` command output format was fixed at merge time. No further action needed.
2. **Augment (terminal-title-setup.sh)**: `main()` unconditionally returned success because `cmd_install`/`cmd_uninstall` ended with `echo` statements that masked failures from `remove_integration`/`install_integration`. Fixed by adding `|| return 1` guards and explicit `return 0` on success.

## Testing

- ShellCheck passes with zero violations
- Logic verified: if `install_integration` or `remove_integration` returns non-zero, the function now immediately returns 1 instead of continuing to print success messages

Closes #3810