### PR TITLE
GH#3827: Fix systemic CodeRabbit rate-limiting blocking all PRs from getting reviews

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -408,17 +408,19 @@ Short, concise, GitHub-flavored markdown. Numbered options for prompts (never "[
 # AI Suggestion Verification
 Never apply AI tool suggestions (review bots, linters, PR reviewers) without independent verification. AI reviewers hallucinate. Verify claims against runtime, docs, or project conventions.
 
-# Review Bot Gate (t1382)
+# Review Bot Gate (t1382, GH#3827)
 # Before merging any PR, wait for AI code review bots (CodeRabbit, Gemini Code Assist,
 # etc.) to post their reviews. PRs merged before bots post lose security findings.
 # Three enforcement layers:
 # 1. CI: `.github/workflows/review-bot-gate.yml` — required status check
-# 2. Agent: `review-bot-gate-helper.sh check <PR> [REPO]` — returns PASS/WAITING/SKIP
+# 2. Agent: `review-bot-gate-helper.sh check <PR> [REPO]` — returns PASS/PASS_RATE_LIMITED/WAITING/SKIP
 # 3. Branch protection: add `review-bot-gate` as required check per repo
 - Before merging: run `review-bot-gate-helper.sh check <PR_NUMBER>`. If WAITING, poll up to 10 minutes. Most bots post within 2-5 minutes.
 - If the PR has `skip-review-gate` label, bypass the gate (for docs-only PRs or repos without bots).
 - In headless mode: if still WAITING after timeout, proceed but log a warning. The CI required check is the hard gate.
 - ALWAYS read bot reviews before merging. Address critical/security findings; note non-critical suggestions for follow-up.
+- PASS_RATE_LIMITED means bots are rate-limited but the PR exceeded the grace period (default 4h). Safe to merge — bot reviews will arrive later and can be addressed in follow-up PRs. Use `request-retry` to trigger a re-review once rate limits clear.
+- When many PRs are rate-limited simultaneously, use `request-retry` on the highest-priority PRs first. Stagger retries to avoid re-triggering rate limits.
 
 # Context Compaction Survival
 # On compaction, ALWAYS preserve: (1) task IDs + states, (2) active batch/concurrency,

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -8,11 +8,17 @@
 #   review-bot-gate-helper.sh request-retry <PR_NUMBER> [REPO]
 #
 # Commands:
-#   check          — Check once, return PASS/WAITING/SKIP
+#   check          — Check once, return PASS/PASS_RATE_LIMITED/WAITING/SKIP
 #   wait           — Poll until a bot posts or timeout (default 600s)
 #   list           — List all bot comments found on the PR
 #   request-retry  — If bots were rate-limited and no real review exists,
 #                     request a review retry (idempotent, safe to call every pulse)
+#
+# Output values for check/wait:
+#   PASS              — At least one bot posted a real review
+#   PASS_RATE_LIMITED  — Bots are rate-limited but grace period exceeded (GH#3827)
+#   WAITING           — No real reviews yet, still within grace period
+#   SKIP              — PR has skip-review-gate label
 #
 # Exit codes:
 #   0 — PASS/SKIP/REQUESTED/ALREADY_REQUESTED/NO_ACTION
@@ -22,8 +28,12 @@
 # Environment:
 #   REVIEW_BOT_WAIT_MAX  — Max seconds to wait in 'wait' mode (default: 600)
 #   REVIEW_BOT_POLL_INTERVAL — Seconds between polls (default: 60)
+#   RATE_LIMIT_GRACE_SECONDS — How long to wait before passing rate-limited PRs
+#                              (default: 14400 = 4 hours). Set to 0 to disable.
 #
 # t1382: https://github.com/marcusquinn/aidevops/issues/2735
+# GH#3827: Rate-limit grace period — pass gate after timeout when bots are
+#          rate-limited, preventing indefinite PR blockage.
 
 set -euo pipefail
 
@@ -49,16 +59,46 @@ RATE_LIMIT_PATTERNS=(
 
 SKIP_LABEL="skip-review-gate"
 
+# GH#3827: Grace period for rate-limited bots. If bots posted rate-limit
+# notices (proving they're configured) but the PR has been open longer than
+# this threshold, pass the gate with a warning. Default: 4 hours (14400s).
+# Set RATE_LIMIT_GRACE_SECONDS=0 to disable (block indefinitely).
+RATE_LIMIT_GRACE_SECONDS="${RATE_LIMIT_GRACE_SECONDS:-14400}"
+
 # --- Functions ---
 
 usage() {
 	echo "Usage: $(basename "$0") {check|wait|list|request-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
 	echo ""
 	echo "Commands:"
-	echo "  check          Check once for bot reviews (returns PASS/WAITING/SKIP)"
+	echo "  check          Check once for bot reviews (returns PASS/PASS_RATE_LIMITED/WAITING/SKIP)"
 	echo "  wait           Poll until bot reviews appear or timeout"
 	echo "  list           List all bot comments found"
 	echo "  request-retry  Request review retry if bots were rate-limited (idempotent)"
+	return 0
+}
+
+get_pr_age_seconds() {
+	# Return the age of a PR in seconds since creation.
+	# Falls back to 0 if the creation time cannot be determined.
+	local pr_number="$1"
+	local repo="$2"
+
+	local created_at
+	created_at=$(gh pr view "$pr_number" --repo "$repo" \
+		--json createdAt -q '.createdAt' 2>/dev/null || echo "")
+	if [[ -z "$created_at" ]]; then
+		echo "0"
+		return 0
+	fi
+
+	local created_epoch now_epoch
+	# macOS date vs GNU date
+	created_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$created_at" +%s 2>/dev/null ||
+		date -d "$created_at" +%s 2>/dev/null ||
+		echo "0")
+	now_epoch=$(date +%s)
+	echo $((now_epoch - created_epoch))
 	return 0
 }
 
@@ -262,9 +302,29 @@ do_check() {
 		echo "Status check fallback: bots rate-limited but have SUCCESS status checks" >&2
 		return 0
 	elif [[ -n "$rate_limited_bots" ]]; then
+		# GH#3827: Rate-limit grace period. If bots posted rate-limit notices
+		# (proving they're configured and aware of the PR) but the PR has been
+		# open longer than RATE_LIMIT_GRACE_SECONDS, pass with a warning.
+		# This prevents indefinite blockage when bots are systemically rate-limited.
+		local pr_age
+		pr_age=$(get_pr_age_seconds "$pr_number" "$repo")
+		if [[ "$RATE_LIMIT_GRACE_SECONDS" -gt 0 ]] && [[ "$pr_age" -ge "$RATE_LIMIT_GRACE_SECONDS" ]]; then
+			local grace_hours=$((RATE_LIMIT_GRACE_SECONDS / 3600))
+			local age_hours=$((pr_age / 3600))
+			echo "PASS_RATE_LIMITED"
+			echo "Rate-limit grace period exceeded (PR is ${age_hours}h old, threshold: ${grace_hours}h)." >&2
+			echo "Bots are rate-limited: ${rate_limited_bots}" >&2
+			echo "Passing gate — bot reviews will be addressed post-merge if needed." >&2
+			return 0
+		fi
 		echo "WAITING"
 		echo "Bots posted rate-limit notices only (not real reviews): ${rate_limited_bots}" >&2
 		echo "No SUCCESS status checks found as fallback." >&2
+		if [[ "$RATE_LIMIT_GRACE_SECONDS" -gt 0 ]]; then
+			local grace_hours=$((RATE_LIMIT_GRACE_SECONDS / 3600))
+			local remaining=$(((RATE_LIMIT_GRACE_SECONDS - pr_age) / 60))
+			echo "Rate-limit grace period: ${grace_hours}h (${remaining}min remaining)." >&2
+		fi
 		return 1
 	else
 		echo "WAITING"
@@ -286,7 +346,7 @@ do_wait() {
 		local result
 		result=$(do_check "$pr_number" "$repo" 2>/dev/null) || true
 
-		if [[ "$result" == "PASS" || "$result" == "SKIP" ]]; then
+		if [[ "$result" == "PASS" || "$result" == "PASS_RATE_LIMITED" || "$result" == "SKIP" ]]; then
 			echo "$result"
 			return 0
 		fi

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -78,6 +78,13 @@ jobs:
           # Gives bots time to start their analysis
           MIN_WAIT_SECONDS=120
 
+          # GH#3827: Grace period for rate-limited bots. If bots posted
+          # rate-limit notices but the PR has been open longer than this,
+          # pass the gate with a warning instead of blocking indefinitely.
+          # Default: 4 hours (14400s). Prevents systemic rate-limiting from
+          # blocking all PRs when many are opened in a short window.
+          RATE_LIMIT_GRACE_SECONDS=14400
+
           # Get PR creation time
           PR_CREATED=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
             --json createdAt -q '.createdAt')
@@ -274,6 +281,22 @@ jobs:
             echo "missing_bots=${MISSING_BOTS}" >> "$GITHUB_OUTPUT"
             echo "rate_limited_bots=${RATE_LIMITED_BOTS}" >> "$GITHUB_OUTPUT"
             echo "status_fallback=true" >> "$GITHUB_OUTPUT"
+          elif [[ -n "$RATE_LIMITED_BOTS" ]] && [[ "$ELAPSED" -ge "$RATE_LIMIT_GRACE_SECONDS" ]]; then
+            # GH#3827: Rate-limit grace period exceeded. Bots posted rate-limit
+            # notices (proving they're configured) but the PR has been open long
+            # enough that blocking further provides no value. Pass with a warning.
+            GRACE_HOURS=$((RATE_LIMIT_GRACE_SECONDS / 3600))
+            AGE_HOURS=$((ELAPSED / 3600))
+            echo ""
+            echo "PASS (rate-limit grace): PR is ${AGE_HOURS}h old (threshold: ${GRACE_HOURS}h)."
+            echo "Bots are rate-limited but grace period exceeded. Passing gate."
+            echo "Bot reviews will be addressed post-merge if needed."
+            echo "gate_passed=true" >> "$GITHUB_OUTPUT"
+            echo "found_bots=" >> "$GITHUB_OUTPUT"
+            echo "missing_bots=${MISSING_BOTS}" >> "$GITHUB_OUTPUT"
+            echo "rate_limited_bots=${RATE_LIMITED_BOTS}" >> "$GITHUB_OUTPUT"
+            echo "status_fallback=false" >> "$GITHUB_OUTPUT"
+            echo "rate_limit_grace=true" >> "$GITHUB_OUTPUT"
           elif [[ "$ELAPSED" -lt "$MIN_WAIT_SECONDS" ]]; then
             echo ""
             echo "PASS (pending): PR is ${ELAPSED}s old (< ${MIN_WAIT_SECONDS}s minimum)."
@@ -357,6 +380,7 @@ jobs:
         env:
           GATE_PASSED: ${{ steps.check.outputs.gate_passed }}
           STATUS_FALLBACK: ${{ steps.check.outputs.status_fallback }}
+          RATE_LIMIT_GRACE: ${{ steps.check.outputs.rate_limit_grace }}
           FOUND_BOTS: ${{ steps.check.outputs.found_bots }}
           MISSING_BOTS: ${{ steps.check.outputs.missing_bots }}
           RATE_LIMITED_BOTS: ${{ steps.check.outputs.rate_limited_bots }}
@@ -376,6 +400,15 @@ jobs:
                 echo ""
                 echo "**Bots not yet reviewed**: ${MISSING_BOTS}"
               fi
+            elif [[ "$GATE_PASSED" == "true" && "$RATE_LIMIT_GRACE" == "true" ]]; then
+              echo "**Status**: PASSED (rate-limit grace period)"
+              echo ""
+              echo "Bots are rate-limited and the PR has been open longer than the"
+              echo "grace period threshold. Passing to prevent indefinite blockage. (GH#3827)"
+              echo ""
+              echo "**Rate-limited bots**: ${RATE_LIMITED_BOTS}"
+              echo ""
+              echo "Bot reviews will be addressed post-merge if needed."
             elif [[ "$GATE_PASSED" == "true" && -n "$FOUND_BOTS" ]]; then
               echo "**Status**: PASSED"
               echo ""


### PR DESCRIPTION
## Summary

- Adds a configurable rate-limit grace period (default 4 hours) to both the CI workflow (`review-bot-gate.yml`) and the agent helper script (`review-bot-gate-helper.sh`)
- When bots post rate-limit notices (proving they're configured) but the PR exceeds the grace period, the gate passes with a warning instead of blocking indefinitely
- Updates agent guidance in `build.txt` to handle the new `PASS_RATE_LIMITED` state and provide staggered retry guidance

## Problem

When many PRs are opened in a short window, CodeRabbit hits its hourly commit review rate limit. All affected PRs get rate-limit notices instead of real reviews, and the review-bot-gate blocks indefinitely because:
1. No real reviews exist (only rate-limit notices)
2. No SUCCESS status checks are available as fallback
3. There is no timeout — the gate waits forever

This caused 14+ PRs to be stuck simultaneously (see issue for full list).

## Solution

**Rate-limit grace period**: If bots posted rate-limit notices (proving they're configured and aware of the PR) but the PR has been open longer than `RATE_LIMIT_GRACE_SECONDS` (default: 4 hours / 14400s), pass the gate with a warning. The rationale:
- Rate-limited bots have acknowledged the PR — they just can't review it yet
- Blocking indefinitely provides no value; the bot will review when capacity frees up
- Reviews can be addressed post-merge in follow-up PRs if needed
- The grace period is configurable via environment variable and can be disabled by setting to 0

**Changes:**
- `review-bot-gate-helper.sh`: New `get_pr_age_seconds()` function, `RATE_LIMIT_GRACE_SECONDS` env var, `PASS_RATE_LIMITED` output state, remaining time reporting
- `review-bot-gate.yml`: Same grace period logic in CI, new `rate_limit_grace` output, updated summary step
- `build.txt`: Updated agent guidance for `PASS_RATE_LIMITED` handling and staggered retry strategy

## Testing

- ShellCheck passes clean on the helper script
- Grace period logic is additive — existing PASS/WAITING/SKIP paths are unchanged
- The `RATE_LIMIT_GRACE_SECONDS` env var defaults to 4h but can be overridden per-environment

Closes #3827