### PR TITLE
t3205: Address PR #2771 review feedback (quality-debt)

### DIFF
--- a/.agents/services/communications/discord.md
+++ b/.agents/services/communications/discord.md
@@ -487,7 +487,7 @@ Map Discord roles to aidevops runners. Users with specific roles get routed to t
 
 `~/.config/aidevops/discord-bot.json` (600 permissions):
 
-> **Security**: Store `botToken` in gopass (`aidevops secret set discord-bot-token`), not in this JSON file. Reference it via environment variables or `credentials.sh`. The value below is a placeholder only.
+> **Security**: Store `botToken` in gopass (`aidevops secret set DISCORD_BOT_TOKEN`), not in this JSON file. Reference it via environment variables or `credentials.sh`. The value below is a placeholder only.
 
 ```json
 {

--- a/.agents/services/communications/discord.md
+++ b/.agents/services/communications/discord.md
@@ -485,6 +485,10 @@ Map Discord roles to aidevops runners. Users with specific roles get routed to t
 
 ### Configuration
 
+`~/.config/aidevops/discord-bot.json` (600 permissions):
+
+> **Security**: Store `botToken` in gopass (`aidevops secret set discord-bot-token`), not in this JSON file. Reference it via environment variables or `credentials.sh`. The value below is a placeholder only.
+
 ```json
 {
   "guildId": "YOUR_GUILD_ID",

--- a/.agents/services/communications/msteams.md
+++ b/.agents/services/communications/msteams.md
@@ -741,7 +741,7 @@ Same pattern as Matrix room mappings:
 
 Matterbridge has native Microsoft Teams support via the Graph API. This is the simplest way to bridge Teams to other platforms without building a custom bot.
 
-> **Security**: Store `ClientSecret` in gopass (`aidevops secret set msteams-client-secret`) and inject it via environment variable substitution or a templating step. Never commit the actual secret value to `matterbridge.toml`. The value below is a placeholder only.
+> **Security**: Store `ClientSecret` in gopass (`aidevops secret set MSTEAMS_CLIENT_SECRET`) and inject it via environment variable substitution or a templating step. Never commit the actual secret value to `matterbridge.toml`. The value below is a placeholder only.
 
 ```toml
 # matterbridge.toml — Teams bridge configuration

--- a/.agents/services/communications/msteams.md
+++ b/.agents/services/communications/msteams.md
@@ -741,6 +741,8 @@ Same pattern as Matrix room mappings:
 
 Matterbridge has native Microsoft Teams support via the Graph API. This is the simplest way to bridge Teams to other platforms without building a custom bot.
 
+> **Security**: Store `ClientSecret` in gopass (`aidevops secret set msteams-client-secret`) and inject it via environment variable substitution or a templating step. Never commit the actual secret value to `matterbridge.toml`. The value below is a placeholder only.
+
 ```toml
 # matterbridge.toml — Teams bridge configuration
 [msteams]

--- a/.agents/services/communications/urbit.md
+++ b/.agents/services/communications/urbit.md
@@ -445,16 +445,19 @@ sse.listen({
       if (data.json?.["add-nodes"]) {
         const nodes = data.json["add-nodes"].nodes
         for (const [index, node] of Object.entries(nodes)) {
-          // Runtime type check instead of unsafe type assertion
+          // Runtime type guard — validate structure before accessing properties
           const nodeObj = node as Record<string, unknown>
           if (!nodeObj?.post || typeof nodeObj.post !== "object") continue
-          const post = nodeObj.post as { author: string; contents: { text?: string }[] }
-          if (post.author !== SHIP_NAME) {
-            const textContent = post.contents
-              .filter((c: { text?: string }) => c.text)
-              .map((c: { text?: string }) => c.text)
+          const rawPost = nodeObj.post as Record<string, unknown>
+          if (typeof rawPost.author !== "string" || !Array.isArray(rawPost.contents)) continue
+          const author = rawPost.author
+          const contents = rawPost.contents as Array<Record<string, unknown>>
+          if (author !== SHIP_NAME) {
+            const textContent = contents
+              .filter((c) => typeof c.text === "string")
+              .map((c) => c.text as string)
               .join(" ")
-            console.log(`Message from ~${post.author}: ${textContent}`)
+            console.log(`Message from ~${author}: ${textContent}`)
             // Handle command and send response...
           }
         }

--- a/.agents/services/communications/urbit.md
+++ b/.agents/services/communications/urbit.md
@@ -454,7 +454,7 @@ sse.listen({
           const contents = rawPost.contents as Array<Record<string, unknown>>
           if (author !== SHIP_NAME) {
             const textContent = contents
-              .filter((c) => typeof c.text === "string")
+              .filter((c) => c != null && typeof c === "object" && typeof c.text === "string")
               .map((c) => c.text as string)
               .join(" ")
             console.log(`Message from ~${author}: ${textContent}`)


### PR DESCRIPTION
## Summary

- Fix unsafe TypeScript type assertion in urbit.md bot example — replace `as { post: ... }` with runtime type guard that validates `author` (string) and `contents` (array) before access
- Add security notes near credential config examples in discord.md and msteams.md, emphasizing gopass storage over plaintext

## Review Findings Assessment

Of the 15 findings from Gemini's review of PR #2771:

| Status | Count | Details |
|--------|-------|---------|
| Already fixed | 12 | telegram.md command injection, google-chat.md webhook auth + docs, discord.md env vars, google-chat.md env vars, imessage.md auth header + null check, msteams.md env vars + fontType, slack.md env vars + token config |
| Fixed in this PR | 3 | urbit.md type safety, discord.md security note, msteams.md security note |

All critical and high-severity findings (command injection, webhook auth) were already addressed in the original PR before merge.

Closes #3205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Discord bot configuration documentation with comprehensive security best practices for token management and storage.
  * Enhanced MS Teams integration documentation with credential security guidance and recommendations for secure credential handling.

* **Bug Fixes**
  * Strengthened Urbit service reliability with improved input validation and enhanced runtime type safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->