### PR TITLE
fix: address medium-priority quality-debt — SQL performance, test helpers, stale comments

### DIFF
--- a/.agents/scripts/response-scoring-helper.sh
+++ b/.agents/scripts/response-scoring-helper.sh
@@ -388,18 +388,21 @@ _sync_score_to_patterns() {
 	fi
 
 	# Get response metadata including per-criterion scores and token usage (t1094)
+	# Uses LEFT JOIN + conditional aggregation instead of correlated subqueries (GH#3631)
 	local result
 	result=$(sqlite3 -separator '|' "$SCORING_DB" "
         SELECT r.model_id, p.category, p.difficulty,
                ${WEIGHTED_AVG_SQL} as weighted_avg,
                r.token_count, r.cost_estimate,
-               (SELECT score FROM scores s WHERE s.response_id = r.response_id AND s.criterion = 'correctness' LIMIT 1) as corr,
-               (SELECT score FROM scores s WHERE s.response_id = r.response_id AND s.criterion = 'completeness' LIMIT 1) as comp,
-               (SELECT score FROM scores s WHERE s.response_id = r.response_id AND s.criterion = 'code_quality' LIMIT 1) as cq,
-               (SELECT score FROM scores s WHERE s.response_id = r.response_id AND s.criterion = 'clarity' LIMIT 1) as clar
+               MAX(CASE WHEN s.criterion = 'correctness' THEN s.score END) as corr,
+               MAX(CASE WHEN s.criterion = 'completeness' THEN s.score END) as comp,
+               MAX(CASE WHEN s.criterion = 'code_quality' THEN s.score END) as cq,
+               MAX(CASE WHEN s.criterion = 'clarity' THEN s.score END) as clar
         FROM responses r
         JOIN prompts p ON r.prompt_id = p.prompt_id
-        WHERE r.response_id = ${response_id};
+        LEFT JOIN scores s ON r.response_id = s.response_id
+        WHERE r.response_id = ${response_id}
+        GROUP BY r.response_id;
     ") || return 0
 
 	if [[ -z "$result" ]]; then

--- a/.agents/scripts/response-scoring-helper.sh
+++ b/.agents/scripts/response-scoring-helper.sh
@@ -389,6 +389,12 @@ _sync_score_to_patterns() {
 
 	# Get response metadata including per-criterion scores and token usage (t1094)
 	# Uses LEFT JOIN + conditional aggregation instead of correlated subqueries (GH#3631)
+	# Note: WEIGHTED_AVG_SQL is a correlated subquery that computes a weighted sum across
+	# all scorers, while MAX(CASE...) picks the highest score per criterion. In practice
+	# the scores table has one scorer per criterion for automated scoring (UNIQUE constraint
+	# on response_id+criterion+scored_by). The MAX() is deterministic vs the original
+	# LIMIT 1 (no ORDER BY) which was arbitrary. Unifying both aggregation paths is a
+	# valid follow-up refactor but out of scope for this fix (see PR #3884 discussion).
 	local result
 	result=$(sqlite3 -separator '|' "$SCORING_DB" "
         SELECT r.model_id, p.category, p.difficulty,

--- a/tests/test-ai-actions.sh
+++ b/tests/test-ai-actions.sh
@@ -2164,10 +2164,9 @@ TODOEOF
 
 		# Test 4: Recently completed tasks should also be found
 		# t102 is [x] with completed:2026-02-19 — should appear as candidate
-		# We need to test _check_similar_open_task which includes completed tasks
-		# But _keyword_prefilter_open_tasks only scans open tasks by design
-		# The completed task scanning is in _check_similar_open_task via the
-		# recently-completed scan added in this fix
+		# _keyword_prefilter_open_tasks now scans both open and recently completed
+		# tasks directly (completed-task scanning was moved into the prefilter).
+		# Test 31 covers the completed-task path explicitly.
 
 		rm -rf "$tmp_dir" "/tmp/test-ai-actions-logs-$$" "$SUPERVISOR_DB" 2>/dev/null || true
 		exit "$failures"

--- a/tests/test-ai-actions.sh
+++ b/tests/test-ai-actions.sh
@@ -23,15 +23,19 @@ FAIL=0
 TOTAL=0
 
 pass() {
+	local msg="$1"
 	PASS=$((PASS + 1))
 	TOTAL=$((TOTAL + 1))
-	echo "  PASS: $1"
+	echo "  PASS: $msg"
+	return 0
 }
 
 fail() {
+	local msg="$1"
 	FAIL=$((FAIL + 1))
 	TOTAL=$((TOTAL + 1))
-	echo "  FAIL: $1"
+	echo "  FAIL: $msg"
+	return 0
 }
 
 echo "=== AI Actions Executor Tests (t1085.3) ==="

--- a/tests/test-ai-actions.sh
+++ b/tests/test-ai-actions.sh
@@ -22,6 +22,8 @@ PASS=0
 FAIL=0
 TOTAL=0
 
+# Record a passing test result and print status.
+# Args: $1 - test description message
 pass() {
 	local msg="$1"
 	PASS=$((PASS + 1))
@@ -30,6 +32,8 @@ pass() {
 	return 0
 }
 
+# Record a failing test result and print status.
+# Args: $1 - test description message
 fail() {
 	local msg="$1"
 	FAIL=$((FAIL + 1))

--- a/tests/test-ai-supervisor-e2e.sh
+++ b/tests/test-ai-supervisor-e2e.sh
@@ -60,21 +60,27 @@ done
 
 # Test helpers
 pass() {
+	local msg="$1"
 	PASS=$((PASS + 1))
 	TOTAL=$((TOTAL + 1))
-	echo "  PASS: $1"
+	echo "  PASS: $msg"
+	return 0
 }
 
 fail() {
+	local msg="$1"
 	FAIL=$((FAIL + 1))
 	TOTAL=$((TOTAL + 1))
-	echo "  FAIL: $1"
+	echo "  FAIL: $msg"
+	return 0
 }
 
 skip() {
+	local msg="$1"
 	SKIP=$((SKIP + 1))
 	TOTAL=$((TOTAL + 1))
-	echo "  SKIP: $1"
+	echo "  SKIP: $msg"
+	return 0
 }
 
 # Temp directory for test artifacts

--- a/tests/test-ai-supervisor-e2e.sh
+++ b/tests/test-ai-supervisor-e2e.sh
@@ -59,6 +59,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Test helpers
+
+# Record a passing test result and print status.
+# Args: $1 - test description message
 pass() {
 	local msg="$1"
 	PASS=$((PASS + 1))
@@ -67,6 +70,8 @@ pass() {
 	return 0
 }
 
+# Record a failing test result and print status.
+# Args: $1 - test description message
 fail() {
 	local msg="$1"
 	FAIL=$((FAIL + 1))
@@ -75,6 +80,8 @@ fail() {
 	return 0
 }
 
+# Record a skipped test result and print status.
+# Args: $1 - test description message
 skip() {
 	local msg="$1"
 	SKIP=$((SKIP + 1))


### PR DESCRIPTION
## Summary

Address 3 medium-priority quality-debt issues on active (non-archived) code:

### Fixes
- **GH#3631**: `response-scoring-helper.sh` — replace 4 correlated subqueries with a single `LEFT JOIN` + `MAX(CASE WHEN ...)` conditional aggregation for per-criterion score lookup. More efficient single-pass query.
- **GH#3665**: `test-ai-supervisor-e2e.sh` — add `local msg="$1"` pattern and explicit `return 0` to `pass()`, `fail()`, `skip()` test helpers per coding standards.
- **GH#3598**: `test-ai-actions.sh` — update misleading comment that said `_keyword_prefilter_open_tasks` only scans open tasks; it now scans recently completed tasks directly.

### Triage Summary (128 issues reviewed)

As part of this batch, all 128 remaining unaddressed quality-debt issues (#3593-#3807) were triaged with comments recommending closure:

| Category | Count | Action |
|----------|-------|--------|
| Targets archived/dead code (`supervisor-archived/`, `scripts/archived/`) | ~65 | Commented: recommend close |
| No issues found / no suggestions / summary praise | ~20 | Commented: recommend close |
| Already fixed (commit referenced in issue body) | ~10 | Commented: recommend close as completed |
| Low-value refactoring suggestions (style, wording) | ~25 | Commented: recommend close |
| False positives (e.g., wp-helper.sh "injection" is trusted user input) | ~5 | Commented: recommend close with analysis |
| **Actionable fixes (this PR)** | **3** | **Fixed** |

Closes #3631, closes #3665, closes #3598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized response scoring query execution for improved efficiency.

* **Tests**
  * Enhanced test documentation to clarify coverage paths for task filtering and completion handling.
  * Improved message handling in test helper functions for consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->