### PR TITLE
fix: address review feedback — qlty dispatcher, jq dedup, multi-remote detection, gitignore

### DIFF
--- a/.agents/scripts/quality-cli-manager.sh
+++ b/.agents/scripts/quality-cli-manager.sh
@@ -40,456 +40,473 @@ readonly CLI_SNYK="snyk"
 
 # Print functions
 print_header() {
-    local message="$1"
-    echo -e "${PURPLE}🔧 $message${NC}"
-    return 0
+	local message="$1"
+	echo -e "${PURPLE}🔧 $message${NC}"
+	return 0
 }
 
 # Execute CLI command
 execute_cli_command() {
-    local cli="$1"
-    local command="$2"
-    shift 2
-    local args="$*"
-    
-    local script=""
-    local cli_name=""
-    
-    case "$cli" in
-        "$CLI_CODERABBIT")
-            script="$CODERABBIT_SCRIPT"
-            cli_name="CodeRabbit CLI"
-            ;;
-        "codacy")
-            script="$CODACY_SCRIPT"
-            cli_name="Codacy CLI"
-            ;;
-        "sonar")
-            script="$SONAR_SCRIPT"
-            cli_name="SonarScanner CLI"
-            ;;
-        "$CLI_SNYK")
-            script="$SNYK_SCRIPT"
-            cli_name="Snyk CLI"
-            ;;
-        *)
-            print_error "Unknown CLI: $cli"
-            return 1
-            ;;
-    esac
-    
-    if [[ ! -f "$script" ]]; then
-        print_error "$cli_name script not found: $script"
-        return 1
-    fi
-    
-    print_info "Executing: $cli_name $command $args"
-    bash "$script" "$command" "$args"
-    return $?
+	local cli="$1"
+	local command="$2"
+	shift 2
+	local args="$*"
+
+	local script=""
+	local cli_name=""
+
+	case "$cli" in
+	"$CLI_CODERABBIT")
+		script="$CODERABBIT_SCRIPT"
+		cli_name="CodeRabbit CLI"
+		;;
+	"codacy")
+		script="$CODACY_SCRIPT"
+		cli_name="Codacy CLI"
+		;;
+	"sonar")
+		script="$SONAR_SCRIPT"
+		cli_name="SonarScanner CLI"
+		;;
+	"$CLI_SNYK")
+		script="$SNYK_SCRIPT"
+		cli_name="Snyk CLI"
+		;;
+	"qlty")
+		# Qlty uses direct CLI commands, not a wrapper script
+		cli_name="Qlty CLI"
+		if ! command -v qlty &>/dev/null; then
+			if [[ "$command" == "install" ]]; then
+				print_info "Installing Qlty CLI..."
+				curl -fsSL https://qlty.sh | bash
+				return $?
+			fi
+			print_error "Qlty CLI not installed. Run: quality-cli-manager.sh install qlty"
+			return 1
+		fi
+		print_info "Executing: $cli_name $command $args"
+		# shellcheck disable=SC2086 # args is intentionally word-split
+		qlty "$command" $args
+		return $?
+		;;
+	*)
+		print_error "Unknown CLI: $cli"
+		return 1
+		;;
+	esac
+
+	if [[ ! -f "$script" ]]; then
+		print_error "$cli_name script not found: $script"
+		return 1
+	fi
+
+	print_info "Executing: $cli_name $command $args"
+	bash "$script" "$command" "$args"
+	return $?
 }
 
 # Install CLIs
 install_clis() {
-    local target_cli="$1"
-    
-    print_header "Installing Quality CLIs"
-    
-    local success_count=0
-    local total_count=0
-    
-    if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
-        print_info "Installing CodeRabbit CLI..."
-        if execute_cli_command "$CLI_CODERABBIT" "install"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
-    
-    if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
-        print_info "Installing Codacy CLI..."
-        if execute_cli_command "codacy" "install"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
-    
-    if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
-        print_info "Installing SonarScanner CLI..."
-        if execute_cli_command "sonar" "install"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	local target_cli="$1"
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
-        print_info "Installing Qlty CLI..."
-        if execute_cli_command "qlty" "install"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	print_header "Installing Quality CLIs"
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
-        print_info "Installing Snyk CLI..."
-        if execute_cli_command "$CLI_SNYK" "install"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	local success_count=0
+	local total_count=0
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "linters" ]]; then
-        print_info "Installing CodeFactor-inspired linters..."
-        if bash "$(dirname "$0")/linter-manager.sh" install-detected; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
-    
-    print_info "Installation Summary: $success_count/$total_count CLIs installed successfully"
-    
-    if [[ $success_count -eq $total_count ]]; then
-        print_success "All requested CLIs installed successfully"
-        return 0
-    else
-        print_warning "Some CLI installations failed"
-        return 1
-    fi
-    return 0
+	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
+		print_info "Installing CodeRabbit CLI..."
+		if execute_cli_command "$CLI_CODERABBIT" "install"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
+		print_info "Installing Codacy CLI..."
+		if execute_cli_command "codacy" "install"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
+		print_info "Installing SonarScanner CLI..."
+		if execute_cli_command "sonar" "install"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
+		print_info "Installing Qlty CLI..."
+		if execute_cli_command "qlty" "install"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
+		print_info "Installing Snyk CLI..."
+		if execute_cli_command "$CLI_SNYK" "install"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "linters" ]]; then
+		print_info "Installing CodeFactor-inspired linters..."
+		if bash "$(dirname "$0")/linter-manager.sh" install-detected; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	print_info "Installation Summary: $success_count/$total_count CLIs installed successfully"
+
+	if [[ $success_count -eq $total_count ]]; then
+		print_success "All requested CLIs installed successfully"
+		return 0
+	else
+		print_warning "Some CLI installations failed"
+		return 1
+	fi
+	return 0
 }
 
 # Initialize CLI configurations
 init_clis() {
-    local target_cli="$1"
-    
-    print_header "Initializing Quality CLI Configurations"
-    
-    local success_count=0
-    local total_count=0
-    
-    if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
-        print_info "Initializing CodeRabbit CLI..."
-        if execute_cli_command "$CLI_CODERABBIT" "setup"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
-    
-    if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
-        print_info "Initializing Codacy CLI..."
-        if execute_cli_command "codacy" "init"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
-    
-    if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
-        print_info "Initializing SonarScanner CLI..."
-        if execute_cli_command "sonar" "init"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	local target_cli="$1"
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
-        print_info "Initializing Qlty CLI..."
-        if execute_cli_command "qlty" "init"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	print_header "Initializing Quality CLI Configurations"
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
-        print_info "Initializing Snyk CLI..."
-        if execute_cli_command "$CLI_SNYK" "auth"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
-    
-    print_info "Initialization Summary: $success_count/$total_count CLIs initialized successfully"
-    
-    if [[ $success_count -eq $total_count ]]; then
-        print_success "All requested CLIs initialized successfully"
-        return 0
-    else
-        print_warning "Some CLI initializations failed"
-        return 1
-    fi
-    return 0
+	local success_count=0
+	local total_count=0
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
+		print_info "Initializing CodeRabbit CLI..."
+		if execute_cli_command "$CLI_CODERABBIT" "setup"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
+		print_info "Initializing Codacy CLI..."
+		if execute_cli_command "codacy" "init"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
+		print_info "Initializing SonarScanner CLI..."
+		if execute_cli_command "sonar" "init"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
+		print_info "Initializing Qlty CLI..."
+		if execute_cli_command "qlty" "init"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
+		print_info "Initializing Snyk CLI..."
+		if execute_cli_command "$CLI_SNYK" "auth"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
+
+	print_info "Initialization Summary: $success_count/$total_count CLIs initialized successfully"
+
+	if [[ $success_count -eq $total_count ]]; then
+		print_success "All requested CLIs initialized successfully"
+		return 0
+	else
+		print_warning "Some CLI initializations failed"
+		return 1
+	fi
+	return 0
 }
 
 # Run analysis with CLIs
 analyze_with_clis() {
-    local target_cli="$1"
-    shift
-    local args="$*"
+	local target_cli="$1"
+	shift
+	local args="$*"
 
-    print_header "Running Quality Analysis"
+	print_header "Running Quality Analysis"
 
-    local success_count=0
-    local total_count=0
+	local success_count=0
+	local total_count=0
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
-        print_info "Running CodeRabbit analysis..."
-        if execute_cli_command "$CLI_CODERABBIT" "review" "$args"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
+		print_info "Running CodeRabbit analysis..."
+		if execute_cli_command "$CLI_CODERABBIT" "review" "$args"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
-        print_info "Running Codacy analysis..."
-        if execute_cli_command "codacy" "analyze" "$args"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
+		print_info "Running Codacy analysis..."
+		if execute_cli_command "codacy" "analyze" "$args"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
 
-    # Add auto-fix option for Codacy
-    if [[ "$target_cli" == "codacy-fix" ]]; then
-        print_info "Running Codacy analysis with auto-fix..."
-        if execute_cli_command "codacy" "analyze" "--fix"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	# Add auto-fix option for Codacy
+	if [[ "$target_cli" == "codacy-fix" ]]; then
+		print_info "Running Codacy analysis with auto-fix..."
+		if execute_cli_command "codacy" "analyze" "--fix"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
-        print_info "Running SonarQube analysis..."
-        if execute_cli_command "sonar" "analyze" "$args"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
+		print_info "Running SonarQube analysis..."
+		if execute_cli_command "sonar" "analyze" "$args"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
-        print_info "Running Qlty analysis..."
-        # Add organization parameter if provided
-        local qlty_args="$args"
-        if [[ -n "$QLTY_ORG" ]]; then
-            qlty_args="$args $QLTY_ORG"
-        fi
-        if execute_cli_command "qlty" "check" "$qlty_args"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
+		print_info "Running Qlty analysis..."
+		# Add organization parameter if provided
+		local qlty_args="$args"
+		if [[ -n "$QLTY_ORG" ]]; then
+			qlty_args="$args $QLTY_ORG"
+		fi
+		if execute_cli_command "qlty" "check" "$qlty_args"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
-        print_info "Running Snyk security analysis..."
-        if execute_cli_command "$CLI_SNYK" "full" "$args"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
+		print_info "Running Snyk security analysis..."
+		if execute_cli_command "$CLI_SNYK" "full" "$args"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
 
-    # Add Snyk-specific scan options
-    if [[ "$target_cli" == "snyk-sca" ]]; then
-        print_info "Running Snyk SCA (dependency) scan..."
-        if execute_cli_command "$CLI_SNYK" "test" "$args"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	# Add Snyk-specific scan options
+	if [[ "$target_cli" == "snyk-sca" ]]; then
+		print_info "Running Snyk SCA (dependency) scan..."
+		if execute_cli_command "$CLI_SNYK" "test" "$args"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "snyk-code" ]]; then
-        print_info "Running Snyk Code (SAST) scan..."
-        if execute_cli_command "$CLI_SNYK" "code" "$args"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	if [[ "$target_cli" == "snyk-code" ]]; then
+		print_info "Running Snyk Code (SAST) scan..."
+		if execute_cli_command "$CLI_SNYK" "code" "$args"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "snyk-iac" ]]; then
-        print_info "Running Snyk IaC scan..."
-        if execute_cli_command "$CLI_SNYK" "iac" "$args"; then
-            ((success_count++)) || true
-        fi
-        ((total_count++)) || true
-        echo ""
-    fi
+	if [[ "$target_cli" == "snyk-iac" ]]; then
+		print_info "Running Snyk IaC scan..."
+		if execute_cli_command "$CLI_SNYK" "iac" "$args"; then
+			((success_count++)) || true
+		fi
+		((total_count++)) || true
+		echo ""
+	fi
 
-    print_info "Analysis Summary: $success_count/$total_count analyses completed successfully"
+	print_info "Analysis Summary: $success_count/$total_count analyses completed successfully"
 
-    if [[ $success_count -eq $total_count ]]; then
-        print_success "All requested analyses completed successfully"
-        return 0
-    else
-        print_warning "Some analyses failed"
-        return 1
-    fi
-    return 0
+	if [[ $success_count -eq $total_count ]]; then
+		print_success "All requested analyses completed successfully"
+		return 0
+	else
+		print_warning "Some analyses failed"
+		return 1
+	fi
+	return 0
 }
 
 # Show CLI status
 show_cli_status() {
-    local target_cli="$1"
+	local target_cli="$1"
 
-    print_header "Quality CLI Status Report"
+	print_header "Quality CLI Status Report"
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
-        print_info "CodeRabbit CLI Status:"
-        execute_cli_command "$CLI_CODERABBIT" "status"
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
+		print_info "CodeRabbit CLI Status:"
+		execute_cli_command "$CLI_CODERABBIT" "status"
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
-        print_info "Codacy CLI Status:"
-        execute_cli_command "codacy" "status"
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
+		print_info "Codacy CLI Status:"
+		execute_cli_command "codacy" "status"
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
-        print_info "SonarScanner CLI Status:"
-        execute_cli_command "sonar" "status"
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
+		print_info "SonarScanner CLI Status:"
+		execute_cli_command "sonar" "status"
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
-        print_info "Qlty CLI Status:"
-        if command -v qlty &> /dev/null; then
-            echo "✅ Qlty CLI installed: $(qlty --version 2>/dev/null || echo 'version unknown')"
-            if [[ -f ".qlty/qlty.toml" ]]; then
-                echo "✅ Qlty initialized in repository"
-            else
-                echo "⚠️  Qlty not initialized (run 'qlty init')"
-            fi
-        else
-            echo "❌ Qlty CLI not installed"
-        fi
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
+		print_info "Qlty CLI Status:"
+		if command -v qlty &>/dev/null; then
+			echo "✅ Qlty CLI installed: $(qlty --version 2>/dev/null || echo 'version unknown')"
+			if [[ -f ".qlty/qlty.toml" ]]; then
+				echo "✅ Qlty initialized in repository"
+			else
+				echo "⚠️  Qlty not initialized (run 'qlty init')"
+			fi
+		else
+			echo "❌ Qlty CLI not installed"
+		fi
+		echo ""
+	fi
 
-    if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
-        print_info "Snyk CLI Status:"
-        if command -v snyk &> /dev/null; then
-            echo "✅ Snyk CLI installed: $(snyk --version 2>/dev/null || echo 'version unknown')"
-            if [[ -n "${SNYK_TOKEN:-}" ]] || snyk config get api &>/dev/null 2>&1; then
-                echo "✅ Snyk authenticated"
-            else
-                echo "⚠️  Snyk not authenticated (run 'snyk auth' or set SNYK_TOKEN)"
-            fi
-        else
-            echo "❌ Snyk CLI not installed"
-        fi
-        echo ""
-    fi
+	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
+		print_info "Snyk CLI Status:"
+		if command -v snyk &>/dev/null; then
+			echo "✅ Snyk CLI installed: $(snyk --version 2>/dev/null || echo 'version unknown')"
+			if [[ -n "${SNYK_TOKEN:-}" ]] || snyk config get api &>/dev/null 2>&1; then
+				echo "✅ Snyk authenticated"
+			else
+				echo "⚠️  Snyk not authenticated (run 'snyk auth' or set SNYK_TOKEN)"
+			fi
+		else
+			echo "❌ Snyk CLI not installed"
+		fi
+		echo ""
+	fi
 
-    return 0
+	return 0
 }
 
 # Show help message
 show_help() {
-    print_header "Quality CLI Manager Help"
-    echo ""
-    echo "Usage: $0 [command] [cli] [options]"
-    echo ""
-    echo "Commands:"
-    echo "  install [cli]        - Install specified CLI or all CLIs"
-    echo "  init [cli]           - Initialize configuration for specified CLI or all CLIs"
-    echo "  analyze [cli] [opts] - Run analysis with specified CLI or all CLIs"
-    echo "  status [cli]         - Check status of specified CLI or all CLIs"
-    echo "  help                 - Show this help message"
-    echo ""
-    echo "CLIs:"
-    echo "  coderabbit           - CodeRabbit CLI for AI-powered code review"
-    echo "  codacy               - Codacy CLI v2 for comprehensive code analysis"
-    echo "  codacy-fix           - Codacy CLI with auto-fix (applies fixes when available)"
-    echo "  sonar                - SonarScanner CLI for SonarQube Cloud analysis"
-    echo "  snyk                 - Snyk CLI for security vulnerability scanning"
-    echo "  snyk-sca             - Snyk dependency vulnerability scan only"
-    echo "  snyk-code            - Snyk source code scan (SAST) only"
-    echo "  snyk-iac             - Snyk Infrastructure as Code scan only"
-    echo "  qlty                 - Qlty CLI for universal linting and auto-formatting"
-    echo "  linters              - Linter Manager for CodeFactor-inspired multi-language linters"
-    echo "  all                  - All quality CLIs (default)"
-    echo ""
-    echo "Examples:"
-    echo "  $0 install all"
-    echo "  $0 init codacy"
-    echo "  $0 analyze coderabbit"
-    echo "  $0 analyze codacy-fix      # Auto-fix issues when possible"
-    echo "  $0 analyze qlty            # Universal linting and formatting"
-    echo "  $0 analyze snyk            # Full Snyk security scan (SCA + SAST + IaC)"
-    echo "  $0 analyze snyk-code       # Snyk source code scan only"
-    echo "  $0 install linters         # Install CodeFactor-inspired linters"
-    echo "  $0 analyze all"
-    echo "  $0 status sonar"
-    echo "  $0 status snyk"
-    echo ""
-    echo "Environment Variables:"
-    echo "  CodeRabbit:"
-    echo "    CODERABBIT_API_KEY   - CodeRabbit API key"
-    echo ""
-    echo "  Codacy:"
-    echo "    CODACY_API_TOKEN     - Codacy API token"
-    echo "    CODACY_PROJECT_TOKEN - Codacy project token"
-    echo "    CODACY_PROVIDER      - Provider (gh, gl, bb)"
-    echo "    CODACY_ORGANIZATION  - Organization name"
-    echo "    CODACY_REPOSITORY    - Repository name"
-    echo ""
-    echo "  SonarQube:"
-    echo "    SONAR_TOKEN          - SonarCloud authentication token"
-    echo "    SONAR_ORGANIZATION   - SonarCloud organization key"
-    echo "    SONAR_PROJECT_KEY    - Project key"
-    echo ""
-    echo "  Snyk:"
-    echo "    SNYK_TOKEN           - Snyk API token"
-    echo "    SNYK_ORG             - Snyk organization ID"
-    echo ""
-    echo "This script provides unified management for all quality analysis CLIs"
-    echo "in the AI DevOps Framework."
-    return 0
+	print_header "Quality CLI Manager Help"
+	echo ""
+	echo "Usage: $0 [command] [cli] [options]"
+	echo ""
+	echo "Commands:"
+	echo "  install [cli]        - Install specified CLI or all CLIs"
+	echo "  init [cli]           - Initialize configuration for specified CLI or all CLIs"
+	echo "  analyze [cli] [opts] - Run analysis with specified CLI or all CLIs"
+	echo "  status [cli]         - Check status of specified CLI or all CLIs"
+	echo "  help                 - Show this help message"
+	echo ""
+	echo "CLIs:"
+	echo "  coderabbit           - CodeRabbit CLI for AI-powered code review"
+	echo "  codacy               - Codacy CLI v2 for comprehensive code analysis"
+	echo "  codacy-fix           - Codacy CLI with auto-fix (applies fixes when available)"
+	echo "  sonar                - SonarScanner CLI for SonarQube Cloud analysis"
+	echo "  snyk                 - Snyk CLI for security vulnerability scanning"
+	echo "  snyk-sca             - Snyk dependency vulnerability scan only"
+	echo "  snyk-code            - Snyk source code scan (SAST) only"
+	echo "  snyk-iac             - Snyk Infrastructure as Code scan only"
+	echo "  qlty                 - Qlty CLI for universal linting and auto-formatting"
+	echo "  linters              - Linter Manager for CodeFactor-inspired multi-language linters"
+	echo "  all                  - All quality CLIs (default)"
+	echo ""
+	echo "Examples:"
+	echo "  $0 install all"
+	echo "  $0 init codacy"
+	echo "  $0 analyze coderabbit"
+	echo "  $0 analyze codacy-fix      # Auto-fix issues when possible"
+	echo "  $0 analyze qlty            # Universal linting and formatting"
+	echo "  $0 analyze snyk            # Full Snyk security scan (SCA + SAST + IaC)"
+	echo "  $0 analyze snyk-code       # Snyk source code scan only"
+	echo "  $0 install linters         # Install CodeFactor-inspired linters"
+	echo "  $0 analyze all"
+	echo "  $0 status sonar"
+	echo "  $0 status snyk"
+	echo ""
+	echo "Environment Variables:"
+	echo "  CodeRabbit:"
+	echo "    CODERABBIT_API_KEY   - CodeRabbit API key"
+	echo ""
+	echo "  Codacy:"
+	echo "    CODACY_API_TOKEN     - Codacy API token"
+	echo "    CODACY_PROJECT_TOKEN - Codacy project token"
+	echo "    CODACY_PROVIDER      - Provider (gh, gl, bb)"
+	echo "    CODACY_ORGANIZATION  - Organization name"
+	echo "    CODACY_REPOSITORY    - Repository name"
+	echo ""
+	echo "  SonarQube:"
+	echo "    SONAR_TOKEN          - SonarCloud authentication token"
+	echo "    SONAR_ORGANIZATION   - SonarCloud organization key"
+	echo "    SONAR_PROJECT_KEY    - Project key"
+	echo ""
+	echo "  Snyk:"
+	echo "    SNYK_TOKEN           - Snyk API token"
+	echo "    SNYK_ORG             - Snyk organization ID"
+	echo ""
+	echo "This script provides unified management for all quality analysis CLIs"
+	echo "in the AI DevOps Framework."
+	return 0
 }
 
 # Main function
 main() {
-    local command="${1:-help}"
-    local cli="${2:-all}"
-    shift 2 2>/dev/null || shift $# # Remove processed arguments
+	local command="${1:-help}"
+	local cli="${2:-all}"
+	shift 2 2>/dev/null || shift $# # Remove processed arguments
 
-    case "$command" in
-        "install")
-            install_clis "$cli"
-            ;;
-        "init")
-            init_clis "$cli"
-            ;;
-        "analyze")
-            analyze_with_clis "$cli" "$@"
-            ;;
-        "status")
-            show_cli_status "$cli"
-            ;;
-        "help"|"--help"|"-h")
-            show_help
-            ;;
-        *)
-            print_error "$ERROR_UNKNOWN_COMMAND $command"
-            show_help
-            return 1
-            ;;
-    esac
-    return 0
+	case "$command" in
+	"install")
+		install_clis "$cli"
+		;;
+	"init")
+		init_clis "$cli"
+		;;
+	"analyze")
+		analyze_with_clis "$cli" "$@"
+		;;
+	"status")
+		show_cli_status "$cli"
+		;;
+	"help" | "--help" | "-h")
+		show_help
+		;;
+	*)
+		print_error "$ERROR_UNKNOWN_COMMAND $command"
+		show_help
+		return 1
+		;;
+	esac
+	return 0
 }
 
 # Execute main function with all arguments

--- a/.agents/scripts/quality-cli-manager.sh
+++ b/.agents/scripts/quality-cli-manager.sh
@@ -73,21 +73,8 @@ execute_cli_command() {
 		cli_name="Snyk CLI"
 		;;
 	"qlty")
-		# Qlty uses direct CLI commands, not a wrapper script
+		script=".agents/scripts/qlty-cli.sh"
 		cli_name="Qlty CLI"
-		if ! command -v qlty &>/dev/null; then
-			if [[ "$command" == "install" ]]; then
-				print_info "Installing Qlty CLI..."
-				curl -fsSL https://qlty.sh | bash
-				return $?
-			fi
-			print_error "Qlty CLI not installed. Run: quality-cli-manager.sh install qlty"
-			return 1
-		fi
-		print_info "Executing: $cli_name $command $args"
-		# shellcheck disable=SC2086 # args is intentionally word-split
-		qlty "$command" $args
-		return $?
 		;;
 	*)
 		print_error "Unknown CLI: $cli"
@@ -177,7 +164,6 @@ install_clis() {
 		print_warning "Some CLI installations failed"
 		return 1
 	fi
-	return 0
 }
 
 # Initialize CLI configurations
@@ -243,7 +229,6 @@ init_clis() {
 		print_warning "Some CLI initializations failed"
 		return 1
 	fi
-	return 0
 }
 
 # Run analysis with CLIs
@@ -296,12 +281,9 @@ analyze_with_clis() {
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
 		print_info "Running Qlty analysis..."
-		# Add organization parameter if provided
-		local qlty_args="$args"
-		if [[ -n "$QLTY_ORG" ]]; then
-			qlty_args="$args $QLTY_ORG"
-		fi
-		if execute_cli_command "qlty" "check" "$qlty_args"; then
+		# Qlty organization context is configured via env vars in qlty-cli.sh's load_api_config(),
+		# not as a CLI positional argument (qlty check only accepts [OPTIONS] [PATHS])
+		if execute_cli_command "qlty" "check" "$args"; then
 			((success_count++)) || true
 		fi
 		((total_count++)) || true
@@ -354,7 +336,6 @@ analyze_with_clis() {
 		print_warning "Some analyses failed"
 		return 1
 	fi
-	return 0
 }
 
 # Show CLI status

--- a/.agents/scripts/stuck-detection-helper.sh
+++ b/.agents/scripts/stuck-detection-helper.sh
@@ -345,7 +345,7 @@ ${suggested_actions}
 		--arg issue "$issue_number" \
 		--arg repo "$repo_slug" \
 		--arg now "$now" \
-		'.labeled_issues = ((.labeled_issues // []) + [{"issue": $issue, "repo": $repo, "labeled_at": $now}] | unique_by(.issue + .repo))') || true
+		'.labeled_issues = ((.labeled_issues // []) + [{"issue": $issue, "repo": $repo, "labeled_at": $now}] | unique_by([.issue, .repo]))') || true
 	if [[ -n "$new_state" ]]; then
 		_sd_write_state "$new_state" || true
 	fi

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -183,8 +183,8 @@ branch_was_pushed() {
 	if git config "branch.$branch.remote" &>/dev/null; then
 		return 0
 	fi
-	# Has remote tracking branch
-	if git show-ref --verify --quiet "refs/remotes/origin/$branch" 2>/dev/null; then
+	# Has remote tracking branch on any remote (not just origin)
+	if git for-each-ref --format='%(refname)' "refs/remotes/*/$branch" 2>/dev/null | grep -q .; then
 		return 0
 	fi
 	return 1

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -184,7 +184,7 @@ branch_was_pushed() {
 		return 0
 	fi
 	# Has remote tracking branch on any remote (not just origin)
-	if git for-each-ref --format='%(refname)' "refs/remotes/*/$branch" 2>/dev/null | grep -q .; then
+	if git for-each-ref --format='%(refname)' "refs/remotes/*/$branch" | grep -q .; then
 		return 0
 	fi
 	return 1

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ configs/*.json
 *.password
 *_password
 closte_*
+hostinger
+hostinger.*
 hostinger_*
 .env
 *.key


### PR DESCRIPTION
## Summary

Fixes 4 bugs found during quality-debt triage and PR review feedback analysis, plus addresses all review feedback from CodeRabbit and Gemini on #3885.

Closes #3885

## Changes

### 1. `quality-cli-manager.sh` — Qlty dispatcher uses wrapper script
The `execute_cli_command()` qlty case previously invoked the `qlty` binary directly, bypassing the `qlty-cli.sh` wrapper's `load_api_config()` auth setup. This meant `QLTY_API_TOKEN`, `QLTY_COVERAGE_TOKEN`, and `QLTY_WORKSPACE_ID` were never exported before qlty commands ran.

**Fix:** Route qlty through `qlty-cli.sh` wrapper (same pattern as coderabbit, codacy, sonar, snyk). This also eliminates the `curl | bash` security concern since the wrapper already uses the safe download-to-temp-file pattern.

### 2. `quality-cli-manager.sh` — Remove invalid QLTY_ORG positional argument
`analyze_with_clis()` appended `$QLTY_ORG` as a positional argument to `qlty check`, but `qlty check` only accepts `[OPTIONS] [PATHS]...` — not an organization argument. Organization context is configured via environment variables in `qlty-cli.sh`'s `load_api_config()`.

**Fix:** Removed the `QLTY_ORG` conditional and pass only `$args` to `execute_cli_command`.

### 3. `quality-cli-manager.sh` — Remove unreachable return statements
Three functions (`install_clis`, `init_clis`, `analyze_with_clis`) had unreachable `return 0` after `if/else` blocks where both branches already return.

**Fix:** Removed the 3 unreachable `return 0` statements.

### 4. `stuck-detection-helper.sh` — jq `unique_by` string concatenation collision
`unique_by(.issue + .repo)` concatenates strings, so issue `"12"` + repo `"3"` produces the same key as issue `"1"` + repo `"23"`. This could silently drop valid entries.

**Fix:** `unique_by([.issue, .repo])` uses array comparison, which is collision-free.

### 5. `worktree-helper.sh` — Multi-remote branch detection
`branch_was_pushed()` only checked `origin` remote. In fork workflows, this returns false even when the branch exists on another remote.

**Fix:** `git for-each-ref "refs/remotes/*/$branch"` checks all remotes. Also removed unnecessary `2>/dev/null` (per Gemini review — `git for-each-ref` exits successfully with no output for non-matching patterns).

### 6. `.gitignore` — hostinger SSH key pattern gap
Existing pattern `hostinger_*` didn't match `hostinger` or `hostinger.pub`.

**Fix:** Added `hostinger` and `hostinger.*` patterns.

## Review Feedback Addressed

| Reviewer | Finding | Status |
|----------|---------|--------|
| CodeRabbit | Critical: qlty bypasses wrapper auth setup | Fixed — routes through qlty-cli.sh |
| CodeRabbit | Critical: QLTY_ORG invalid positional arg | Fixed — removed |
| CodeRabbit | Nitpick: 3x unreachable return 0 | Fixed — removed |
| CodeRabbit | Nitpick: curl\|bash security | Fixed — wrapper uses safe pattern |
| Gemini | High: curl\|bash security risk | Fixed — wrapper uses safe pattern |
| Gemini | Medium: remove 2>/dev/null from for-each-ref | Fixed |
| Gemini | High: unquoted $args fragile | Noted — refactoring entire call chain out of scope |
| Codacy | curl piped to bash | Fixed — wrapper uses safe pattern |

## CI Failures (not code-related)

- **SonarCloud**: Missing `SONAR_TOKEN` (infrastructure config issue)
- **Monitor & Auto-Fix**: 403 permissions error (GitHub Actions token scope)

## Testing

- ShellCheck passes on all modified scripts
- Changes are minimal and targeted — no functional regressions expected