### PR TITLE
t1416: feat(pulse): escalate model tier after 2 failed workers, enforce audit-quality state

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -70,6 +70,7 @@ If uncertain, ask: "Would this fix apply to every repo the framework manages, or
 - Identifying missing automation (e.g., a manual step that could be a `gh` command)
 - Flagging stale tasks that are blocked but not marked as such
 - Running the session miner pulse (`scripts/session-miner-pulse.sh`) to extract learning from past sessions
+- **Filing issues for information gaps (t1416):** When you cannot determine what happened on a task because comments lack model tier, branch name, failure diagnosis, or other audit-critical fields, file a self-improvement issue. Information gaps cause cascading waste — without knowing what was tried, the next attempt repeats the same failure. The issue/PR comment timeline is the primary audit trail; if the information isn't there, it's invisible.
 
 **Intelligence over determinism:** The harness gives you goals, tools, and boundaries — not scripts for every scenario. Deterministic rules are for things with exactly one correct answer (CLI syntax, file paths, security). Everything else — prioritisation, triage, stuck detection, what to work on — is a judgment call. If a rule says "if X then Y" but there are cases where X is true and Y is wrong, it's guidance not a rule. Use the cheapest model that can handle the decision (haiku for triage, sonnet for implementation, opus for strategy) — but never use a regex where a model call would handle outliers better. See `prompts/build.txt` "Intelligence Over Determinism" for the full principle.
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -235,13 +235,7 @@ When a worker fails on an issue (killed for thrashing, PR closed without merge, 
 | 2 | Escalate to opus: add `--model anthropic/claude-opus-4-6` to the dispatch command |
 | 3+ | Escalate to opus AND simplify scope — add a comment on the issue summarising what previous workers attempted and where they got stuck, so the next worker doesn't repeat the same analysis |
 
-**When escalating, comment on the issue:**
-
-```bash
-gh issue comment <number> --repo <slug> --body "Escalating to opus after <N> failed worker attempts. Previous workers were dispatched at sonnet tier and failed with 0 commits. Model: anthropic/claude-opus-4-6. See previous comments for failure details."
-```
-
-**Override the no-model dispatch rule:** The default dispatch rule says "Do NOT add `--model`". This escalation rule overrides it — when failure count >= 2, you MUST add `--model anthropic/claude-opus-4-6`. The cost of one opus dispatch (~3x sonnet) is far less than the cost of 5+ failed sonnet dispatches.
+**Override the no-model dispatch rule:** The default dispatch rule says "Do NOT add `--model`". This escalation rule overrides it — when failure count >= 2, you MUST add `--model anthropic/claude-opus-4-6`. The cost of one opus dispatch (~3x sonnet) is far less than the cost of 5+ failed sonnet dispatches. Do NOT post a separate escalation comment — the dispatch comment's "Attempt" field captures escalation context (e.g., "Attempt: 3 of 3 (escalated to opus after 2 failed sonnet attempts)").
 
 **This is a judgment call, not a hard threshold.** If the first failure was clearly a transient issue (OOM, network timeout, CI flake) rather than a capability gap, resetting the counter is appropriate. But if the worker thrashed with high struggle ratio and 0 commits, that's a capability signal — escalate.
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -203,7 +203,7 @@ The principle: fix our bugs, but don't commit to supporting external tools witho
 
 ### Kill stuck workers
 
-Check `ps axo pid,etime,command | grep '/full-loop' | grep '\.opencode'`. Any worker running 3+ hours with no open PR is likely stuck. Kill it: `kill <pid>`. Comment on the issue explaining why. This frees a slot. If the worker has recent commits or an open PR with activity, leave it alone — it's making progress.
+Check `ps axo pid,etime,command | grep '/full-loop' | grep '\.opencode'`. Any worker running 3+ hours with no open PR is likely stuck. Kill it: `kill <pid>`. Comment on the issue with the full audit-quality fields (model, branch, reason, diagnosis, next action — see "Audit-quality state in issue and PR comments" below). This frees a slot. If the worker has recent commits or an open PR with activity, leave it alone — it's making progress.
 
 ### Struggle-ratio check (t1367)
 
@@ -220,6 +220,84 @@ The "Active Workers" section in the pre-fetched state includes a `struggle_ratio
 **Configuration** (env vars in pulse-wrapper.sh):
 - `STRUGGLE_RATIO_THRESHOLD` — ratio above which to flag (default: 30)
 - `STRUGGLE_MIN_ELAPSED_MINUTES` — minimum runtime before flagging (default: 30)
+
+### Model escalation after repeated failures (t1416)
+
+When a worker fails on an issue (killed for thrashing, PR closed without merge, or 0 commits after timeout), the supervisor must track the failure count and escalate the model tier after 2 failed attempts. Blindly re-dispatching at the same tier wastes compute — the t748 incident burned 7 workers over 30+ hours on a task that required codebase archaeology beyond sonnet's capability.
+
+**How to count failures:** Read the issue comments. Each kill/re-dispatch comment from the supervisor counts as one failure. Count comments matching patterns like "Worker killed", "Worker (PID", "Re-opening for dispatch", "Re-dispatching". If the count is >= 2, escalate.
+
+**Escalation tiers:**
+
+| Failures | Action |
+|----------|--------|
+| 0-1 | Dispatch at default tier (bundle default or sonnet) |
+| 2 | Escalate to opus: add `--model anthropic/claude-opus-4-6` to the dispatch command |
+| 3+ | Escalate to opus AND simplify scope — add a comment on the issue summarising what previous workers attempted and where they got stuck, so the next worker doesn't repeat the same analysis |
+
+**When escalating, comment on the issue:**
+
+```bash
+gh issue comment <number> --repo <slug> --body "Escalating to opus after <N> failed worker attempts. Previous workers were dispatched at sonnet tier and failed with 0 commits. Model: anthropic/claude-opus-4-6. See previous comments for failure details."
+```
+
+**Override the no-model dispatch rule:** The default dispatch rule says "Do NOT add `--model`". This escalation rule overrides it — when failure count >= 2, you MUST add `--model anthropic/claude-opus-4-6`. The cost of one opus dispatch (~3x sonnet) is far less than the cost of 5+ failed sonnet dispatches.
+
+**This is a judgment call, not a hard threshold.** If the first failure was clearly a transient issue (OOM, network timeout, CI flake) rather than a capability gap, resetting the counter is appropriate. But if the worker thrashed with high struggle ratio and 0 commits, that's a capability signal — escalate.
+
+### Audit-quality state in issue and PR comments (t1416)
+
+Every comment the supervisor posts on an issue or PR must be **sufficient for a human or future agent to audit and understand the work without reading logs**. The issue timeline and PR comments are the primary audit trail — if the information isn't there, it's invisible.
+
+**Required fields in dispatch comments:**
+
+When dispatching a worker, comment on the issue with:
+
+```bash
+gh issue comment <number> --repo <slug> --body "Dispatching worker.
+- **Model**: <tier and full model ID, e.g., sonnet (anthropic/claude-sonnet-4-6)>
+- **Branch**: <branch name, e.g., fix/t748-ai-migration>
+- **Scope**: <1-line description of what the worker should do>
+- **Attempt**: <N of M, e.g., 1 of 1, or 3 of 3 (escalated to opus)>
+- **Direction**: <any specific guidance, e.g., 'focus on migration chain from PR #213'>"
+```
+
+**Required fields in kill/failure comments:**
+
+When killing a worker or closing a failed PR, comment with:
+
+```bash
+gh issue comment <number> --repo <slug> --body "Worker killed after <duration> with <N> commits (struggle_ratio: <ratio>).
+- **Model**: <tier used>
+- **Branch**: <branch name>
+- **Reason**: <why it was killed — thrashing, timeout, CI loop, etc.>
+- **Diagnosis**: <1-line hypothesis of what went wrong>
+- **Next action**: <re-dispatch at same tier / escalate to opus / needs manual review>"
+```
+
+**Required fields in merge/completion comments:**
+
+When merging a PR or closing an issue as done:
+
+```bash
+gh issue comment <number> --repo <slug> --body "Completed via PR #<N>.
+- **Model**: <tier that succeeded>
+- **Attempts**: <total attempts including failures>
+- **Duration**: <wall-clock from first dispatch to merge>"
+```
+
+**Why this matters:** Without these fields, auditing a task requires reading pulse logs, cross-referencing `ps` output timestamps, and guessing which model was used. The t748 incident had 7 kill comments that all said "Worker killed after Xh with 0 commits" but none recorded the model tier, making it impossible to determine whether escalation was attempted. Issue comments are the state dashboard — they must be self-contained.
+
+### Self-improvement on information gaps (t1416)
+
+When the supervisor encounters a situation where it cannot determine what happened (missing model tier, unclear failure reason, no branch name in comments, ambiguous state labels), this is an **information gap**. Information gaps cause audit failures and prevent effective re-dispatch.
+
+**Response:** File a self-improvement issue in the aidevops repo describing:
+1. What information was missing
+2. Where it should have been recorded
+3. What went wrong because it was missing (e.g., "could not determine if model was escalated, re-dispatched at same tier 5 more times")
+
+This is a one-time observation — don't file duplicate issues for the same gap. Check existing issues first: `gh issue list --repo <aidevops-slug> --search "information gap" --state open`.
 
 ### Task decomposition before dispatch (t1408.2)
 
@@ -313,7 +391,7 @@ sleep 2
 **Dispatch rules:**
 - ALWAYS use `opencode run` — NEVER `claude` or `claude -p`
 - Background with `&`, sleep 2 between dispatches
-- Do NOT add `--model` — let `/full-loop` use its default. Bundle presets (t1364.6) handle per-project model defaults automatically.
+- Do NOT add `--model` for first attempts — let `/full-loop` use its default. Bundle presets (t1364.6) handle per-project model defaults automatically. **Exception:** when escalating after 2+ failed attempts on the same issue, add `--model anthropic/claude-opus-4-6` (see "Model escalation after repeated failures" above).
 - Use `--dir <path>` from repos.json
 - Route non-code tasks with `--agent`: SEO, Content, Marketing, Business, Research (see AGENTS.md "Agent Routing")
 - **Bundle-aware agent routing (t1364.6):** Before dispatching, check if the target repo has a bundle with `agent_routing` overrides. Run `bundle-helper.sh get agent_routing <repo-path>` — if the task domain (code, seo, content, marketing) has a non-default agent, use `--agent <name>`. Example: a content-site bundle routes `marketing` tasks to the Marketing agent instead of Build+. Explicit `--agent` flags in the issue body always override bundle defaults.

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -374,6 +374,18 @@ bundle-helper.sh list
 - **pulse.md**: Supervisor uses bundle `agent_routing` to select the right agent for non-code tasks
 - **linters-local.sh**: Reads bundle `skip_gates` to skip irrelevant quality checks (e.g., ShellCheck on a pure web-app)
 
+## Failure-Based Escalation (t1416)
+
+When a worker fails on a task (killed for thrashing, 0 commits, PR closed without merge), the supervisor escalates to a higher model tier. This is cost-effective: one opus dispatch (~3x sonnet) costs far less than 5+ failed sonnet dispatches.
+
+**Escalation rule:** After 2 failed worker attempts on the same issue, escalate from the current tier to the next tier up. In practice this means sonnet -> opus for most tasks (sonnet is the default dispatch tier).
+
+**How to escalate:** Add `--model anthropic/claude-opus-4-6` to the `opencode run` dispatch command. This overrides the default "do not add --model" rule in pulse.md.
+
+**Recording:** Every dispatch and kill comment on the issue MUST include the model tier used. Without this, it's impossible to audit whether escalation was attempted. See pulse.md "Audit-quality state in issue and PR comments" (t1416).
+
+**Cost justification:** The t748 incident dispatched 7 sonnet workers over 30+ hours, all thrashing. A single opus dispatch would have cost ~3x one sonnet attempt but saved 6 failed attempts. The break-even point is 1 failed re-dispatch — escalation after 2 failures is always cheaper than a 3rd attempt at the same tier.
+
 ## Tier Drift Detection (t1191)
 
 When tasks are requested at one tier but executed at another (e.g., `model:sonnet` in


### PR DESCRIPTION
## Summary

- Adds model escalation rule: after 2 failed worker attempts on the same issue, escalate from sonnet to opus (`--model anthropic/claude-opus-4-6`)
- Requires audit-quality fields in all supervisor dispatch/kill/completion comments (model tier, branch, scope, attempt count, diagnosis, next action)
- Adds self-improvement trigger for information gaps that prevent auditing
- Adds failure-based escalation section to model-routing.md with cost justification

## Root cause

The t748 incident (webapp/webapp#748) dispatched 7 sonnet workers over 30+ hours, all thrashing with 0 commits. No worker was escalated to opus. Kill comments recorded duration and struggle ratio but not the model tier used, making it impossible to audit whether escalation was attempted. The issue was re-opened 7 times with identical scope — no accumulated context from previous failures was passed to the next worker.

## What changed

| File | Change |
|------|--------|
| `.agents/scripts/commands/pulse.md` | Added "Model escalation after repeated failures", "Audit-quality state in issue and PR comments", and "Self-improvement on information gaps" sections. Updated kill-worker and dispatch-rules sections to reference new requirements. |
| `.agents/tools/context/model-routing.md` | Added "Failure-Based Escalation" section with cost justification |
| `.agents/AGENTS.md` | Added information gap detection to self-improvement checklist |

## Validation

- All changes are agent prompt guidance (no code changes to validate with tests)
- Markdown lint: 0 new errors (2 pre-existing in pulse.md from unrelated content)
- Changes are additive — no existing behaviour modified, only new guidance added

Closes #3889