### PR TITLE
GH#3752: Fix quality-debt in remotion render.mjs from PR #926 review feedback

### DIFF
--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -5,7 +5,7 @@
 //   node render.mjs --still --text "Title" --aspect 9:16 --output title.png
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, existsSync, copyFileSync, mkdirSync } from "node:fs";
+import { readFileSync, existsSync, copyFileSync, mkdirSync, realpathSync } from "node:fs";
 import { resolve, dirname, join, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -29,20 +29,25 @@ const ASPECT_DIMS = {
 function copyMusicToPublic(brief, briefPath, publicDir) {
   if (!brief.music) return undefined;
 
-  const musicAbsPath = resolve(brief.music);
+  // Resolve relative music paths against the brief file's directory (not cwd),
+  // since brief.music is authored relative to the brief's location.
+  const briefDir = dirname(briefPath);
+  const musicAbsPath = resolve(briefDir, brief.music);
   // Path traversal guard: only allow music files within the brief's directory tree
   // or the project directory. Prevents arbitrary file read via crafted brief.music paths.
-  const briefDir = dirname(briefPath);
-  const projectDir = resolve(__dirname, "..", "..");
-  if (!musicAbsPath.startsWith(briefDir + "/") && !musicAbsPath.startsWith(projectDir + "/")) {
-    console.warn(
-      `Warning: music path "${musicAbsPath}" is outside the brief directory ` +
-      `("${briefDir}") and project directory ("${projectDir}"), skipping for security`
-    );
-    return undefined;
-  }
+  // Check existence first so realpathSync can resolve symlinks for the security check.
   if (!existsSync(musicAbsPath)) {
     console.warn(`Warning: music file not found: ${musicAbsPath}, skipping`);
+    return undefined;
+  }
+  // Resolve symlinks to prevent symlink-based directory escapes
+  const musicRealPath = realpathSync(musicAbsPath);
+  const projectDir = resolve(__dirname, "..", "..");
+  if (!musicRealPath.startsWith(briefDir + "/") && !musicRealPath.startsWith(projectDir + "/")) {
+    console.warn(
+      `Warning: music path "${musicRealPath}" resolves outside the brief directory ` +
+      `("${briefDir}") and project directory ("${projectDir}"), skipping for security`
+    );
     return undefined;
   }
   // Use timestamp prefix to avoid filename collisions across renders

--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -11,6 +11,91 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// Aspect ratio to pixel dimensions lookup (shared by renderVideo and renderStill)
+const ASPECT_DIMS = {
+  "16:9": [1920, 1080],
+  "9:16": [1080, 1920],
+  "1:1": [1080, 1080],
+  "4:3": [1440, 1080],
+  "3:4": [1080, 1440],
+  "4:5": [1080, 1350],
+  "5:4": [1350, 1080],
+};
+
+/**
+ * Copy a music file to Remotion's public/ directory with path traversal protection.
+ * Returns the public-relative filename, or undefined if skipped.
+ */
+function copyMusicToPublic(brief, briefPath, publicDir) {
+  if (!brief.music) return undefined;
+
+  const musicAbsPath = resolve(brief.music);
+  // Path traversal guard: only allow music files within the brief's directory tree
+  // or the project directory. Prevents arbitrary file read via crafted brief.music paths.
+  const briefDir = dirname(briefPath);
+  const projectDir = resolve(__dirname, "..", "..");
+  if (!musicAbsPath.startsWith(briefDir + "/") && !musicAbsPath.startsWith(projectDir + "/")) {
+    console.warn(
+      `Warning: music path "${musicAbsPath}" is outside the brief directory ` +
+      `("${briefDir}") and project directory ("${projectDir}"), skipping for security`
+    );
+    return undefined;
+  }
+  if (!existsSync(musicAbsPath)) {
+    console.warn(`Warning: music file not found: ${musicAbsPath}, skipping`);
+    return undefined;
+  }
+  // Use timestamp prefix to avoid filename collisions across renders
+  const musicFilename = `music-${Date.now()}-${basename(musicAbsPath)}`;
+  const musicDest = join(publicDir, musicFilename);
+  copyFileSync(musicAbsPath, musicDest);
+  console.log(`  Copied ${basename(musicAbsPath)} -> public/${musicFilename}`);
+  return musicFilename;
+}
+
+/**
+ * Calculate total duration and frame count for the composition.
+ * Uses only scenes that have corresponding video files to avoid empty frames.
+ */
+function calculateFrames(scenes, sceneVideoFilenames, transitionDuration, fps) {
+  const sceneCount = Math.min(scenes.length, sceneVideoFilenames.length);
+  const totalSceneDuration = scenes.slice(0, sceneCount).reduce((sum, s) => sum + (s.duration || 5), 0);
+  const transitionOverlap = Math.max(0, (sceneCount - 1)) * transitionDuration;
+  const totalFrames = Math.max(1, totalSceneDuration * fps - transitionOverlap);
+  return { sceneCount, totalSceneDuration, totalFrames };
+}
+
+/**
+ * Normalize captions from brief format to FullVideo.tsx format.
+ * Maps startFrame-based captions to scene indices and clamps out-of-range values.
+ */
+function normalizeCaptions(rawCaptions, scenes, fps) {
+  const lastSceneIndex = Math.max(0, scenes.length - 1);
+  return rawCaptions.map((cap) => {
+    if (typeof cap.scene === "number") {
+      // Clamp to last scene so out-of-range indices don't silently drop captions
+      return { ...cap, scene: Math.min(cap.scene, lastSceneIndex) };
+    }
+    // Derive scene index from startFrame
+    let frameOffset = 0;
+    let sceneIdx = scenes.length - 1; // Default to last scene (fallback for beyond-end frames)
+    for (let s = 0; s < scenes.length; s++) {
+      const sceneDur = (scenes[s].duration || 5) * fps;
+      if ((cap.startFrame || 0) >= frameOffset && (cap.startFrame || 0) < frameOffset + sceneDur) {
+        sceneIdx = s;
+        break;
+      }
+      frameOffset += sceneDur;
+    }
+    return {
+      scene: sceneIdx,
+      text: cap.text || "",
+      position: cap.position || "bottom",
+      style: cap.style || "bold-white",
+    };
+  });
+}
+
 function parseArgs() {
   const args = process.argv.slice(2);
   const opts = {};
@@ -58,101 +143,32 @@ function renderVideo(opts) {
     return filename;
   });
 
-  // Normalize captions: the brief may use startFrame/endFrame format,
-  // but FullVideo.tsx expects { scene, text, position, style }.
-  // Map startFrame to scene index based on scene durations.
   const fps = 30;
-  const rawCaptions = brief.captions || [];
   const scenes = brief.scenes || [];
-  const lastSceneIndex = Math.max(0, scenes.length - 1);
-  const normalizedCaptions = rawCaptions.map((cap) => {
-    if (typeof cap.scene === "number") {
-      // Clamp to last scene so out-of-range indices don't silently drop captions
-      return { ...cap, scene: Math.min(cap.scene, lastSceneIndex) };
-    }
-    // Derive scene index from startFrame
-    let frameOffset = 0;
-    let sceneIdx = scenes.length - 1; // Default to last scene (fallback for beyond-end frames)
-    for (let s = 0; s < scenes.length; s++) {
-      const sceneDur = (scenes[s].duration || 5) * fps;
-      if ((cap.startFrame || 0) >= frameOffset && (cap.startFrame || 0) < frameOffset + sceneDur) {
-        sceneIdx = s;
-        break;
-      }
-      frameOffset += sceneDur;
-    }
-    return {
-      scene: sceneIdx,
-      text: cap.text || "",
-      position: cap.position || "bottom",
-      style: cap.style || "bold-white",
-    };
-  });
 
   // Build props for Remotion
   const props = {
     title: brief.title || "Untitled",
     scenes,
     aspect: brief.aspect || "9:16",
-    captions: normalizedCaptions,
+    captions: normalizeCaptions(brief.captions || [], scenes, fps),
     sceneVideos: sceneVideoFilenames,
     transitionStyle: brief.transitionStyle || opts.transition || "fade",
     transitionDuration: parseInt(opts["transition-duration"] || "15", 10),
-    musicPath: undefined, // set below after copy-to-public
+    musicPath: copyMusicToPublic(brief, briefPath, publicDir),
   };
 
-  // Copy music file to public/ so staticFile() can resolve it (same pattern as sceneVideos).
-  // Remotion's <Audio> cannot resolve absolute filesystem paths in a browser rendering context.
-  if (brief.music) {
-    const musicAbsPath = resolve(brief.music);
-    // Path traversal guard: only allow music files within the brief's directory tree
-    // or the project directory. Prevents arbitrary file read via crafted brief.music paths.
-    const briefDir = dirname(briefPath);
-    const projectDir = resolve(__dirname, "..", "..");
-    if (!musicAbsPath.startsWith(briefDir + "/") && !musicAbsPath.startsWith(projectDir + "/")) {
-      console.warn(
-        `Warning: music path "${musicAbsPath}" is outside the brief directory ` +
-        `("${briefDir}") and project directory ("${projectDir}"), skipping for security`
-      );
-    } else if (!existsSync(musicAbsPath)) {
-      console.warn(`Warning: music file not found: ${musicAbsPath}, skipping`);
-    } else {
-      // Use timestamp prefix to avoid filename collisions across renders
-      const musicFilename = `music-${Date.now()}-${basename(musicAbsPath)}`;
-      const musicDest = join(publicDir, musicFilename);
-      copyFileSync(musicAbsPath, musicDest);
-      console.log(`  Copied ${basename(musicAbsPath)} -> public/${musicFilename}`);
-      props.musicPath = musicFilename;
-    }
-  }
-
-  // Validate scene/video count consistency — these are derived from different sources
-  // (brief metadata vs actual video files) and can diverge, causing incorrect frame math.
+  // Warn on scene/video count mismatch (different sources can diverge)
   if (sceneVideoFilenames.length !== scenes.length) {
     console.warn(
       `Warning: ${sceneVideoFilenames.length} videos provided but brief defines ${scenes.length} scenes`
     );
   }
 
-  // Calculate duration — use only scenes that have corresponding video files.
-  // When scene count and video count diverge, rendering is constrained to the minimum,
-  // so duration must match to avoid empty frames or negative totalFrames.
-  const sceneCount = Math.min(scenes.length, sceneVideoFilenames.length);
-  const totalSceneDuration = props.scenes.slice(0, sceneCount).reduce((sum, s) => sum + (s.duration || 5), 0);
-  const transitionOverlap = Math.max(0, (sceneCount - 1)) * props.transitionDuration;
-  const totalFrames = Math.max(1, totalSceneDuration * fps - transitionOverlap);
-
-  // Aspect dimensions
-  const dims = {
-    "16:9": [1920, 1080],
-    "9:16": [1080, 1920],
-    "1:1": [1080, 1080],
-    "4:3": [1440, 1080],
-    "3:4": [1080, 1440],
-    "4:5": [1080, 1350],
-    "5:4": [1350, 1080],
-  };
-  const [width, height] = dims[props.aspect] || dims["9:16"];
+  const { totalSceneDuration, totalFrames } = calculateFrames(
+    scenes, sceneVideoFilenames, props.transitionDuration, fps
+  );
+  const [width, height] = ASPECT_DIMS[props.aspect] || ASPECT_DIMS["9:16"];
 
   const propsJson = JSON.stringify(props);
 
@@ -191,12 +207,7 @@ function renderVideo(opts) {
 function renderStill(opts) {
   const output = opts.output ? resolve(opts.output) : resolve("graphic.png");
   const aspect = opts.aspect || "9:16";
-  const dims = {
-    "16:9": [1920, 1080],
-    "9:16": [1080, 1920],
-    "1:1": [1080, 1080],
-  };
-  const [width, height] = dims[aspect] || dims["9:16"];
+  const [width, height] = ASPECT_DIMS[aspect] || ASPECT_DIMS["9:16"];
 
   const props = {
     text: opts.text || "Title",

--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -98,13 +98,38 @@ function renderVideo(opts) {
     sceneVideos: sceneVideoFilenames,
     transitionStyle: brief.transitionStyle || opts.transition || "fade",
     transitionDuration: parseInt(opts["transition-duration"] || "15", 10),
-    musicPath: brief.music ? resolve(brief.music) : undefined,
+    musicPath: undefined, // set below after copy-to-public
   };
 
-  // Calculate duration
+  // Copy music file to public/ so staticFile() can resolve it (same pattern as sceneVideos).
+  // Remotion's <Audio> cannot resolve absolute filesystem paths in a browser rendering context.
+  if (brief.music) {
+    const musicAbsPath = resolve(brief.music);
+    if (!existsSync(musicAbsPath)) {
+      console.warn(`Warning: music file not found: ${musicAbsPath}, skipping`);
+    } else {
+      const musicFilename = `music-${basename(musicAbsPath)}`;
+      const musicDest = join(publicDir, musicFilename);
+      copyFileSync(musicAbsPath, musicDest);
+      console.log(`  Copied ${basename(musicAbsPath)} -> public/${musicFilename}`);
+      props.musicPath = musicFilename;
+    }
+  }
+
+  // Validate scene/video count consistency — these are derived from different sources
+  // (brief metadata vs actual video files) and can diverge, causing incorrect frame math.
+  if (sceneVideoFilenames.length !== scenes.length) {
+    console.warn(
+      `Warning: ${sceneVideoFilenames.length} videos provided but brief defines ${scenes.length} scenes`
+    );
+  }
+
+  // Calculate duration — use consistent source (scenes) for both components.
+  // Clamp transitionOverlap to scene count to avoid negative frames when counts diverge.
+  const sceneCount = Math.min(scenes.length, sceneVideoFilenames.length);
   const totalSceneDuration = props.scenes.reduce((sum, s) => sum + (s.duration || 5), 0);
-  const transitionOverlap = Math.max(0, (sceneVideoFilenames.length - 1)) * props.transitionDuration;
-  const totalFrames = totalSceneDuration * fps - transitionOverlap;
+  const transitionOverlap = Math.max(0, (sceneCount - 1)) * props.transitionDuration;
+  const totalFrames = Math.max(1, totalSceneDuration * fps - transitionOverlap);
 
   // Aspect dimensions
   const dims = {

--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -83,7 +83,7 @@ function normalizeCaptions(rawCaptions, scenes, fps) {
     }
     // Derive scene index from startFrame
     let frameOffset = 0;
-    let sceneIdx = scenes.length - 1; // Default to last scene (fallback for beyond-end frames)
+    let sceneIdx = lastSceneIndex; // Default to last scene (fallback for beyond-end frames)
     for (let s = 0; s < scenes.length; s++) {
       const sceneDur = (scenes[s].duration || 5) * fps;
       if ((cap.startFrame || 0) >= frameOffset && (cap.startFrame || 0) < frameOffset + sceneDur) {

--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -105,10 +105,20 @@ function renderVideo(opts) {
   // Remotion's <Audio> cannot resolve absolute filesystem paths in a browser rendering context.
   if (brief.music) {
     const musicAbsPath = resolve(brief.music);
-    if (!existsSync(musicAbsPath)) {
+    // Path traversal guard: only allow music files within the brief's directory tree
+    // or the project directory. Prevents arbitrary file read via crafted brief.music paths.
+    const briefDir = dirname(briefPath);
+    const projectDir = resolve(__dirname, "..", "..");
+    if (!musicAbsPath.startsWith(briefDir + "/") && !musicAbsPath.startsWith(projectDir + "/")) {
+      console.warn(
+        `Warning: music path "${musicAbsPath}" is outside the brief directory ` +
+        `("${briefDir}") and project directory ("${projectDir}"), skipping for security`
+      );
+    } else if (!existsSync(musicAbsPath)) {
       console.warn(`Warning: music file not found: ${musicAbsPath}, skipping`);
     } else {
-      const musicFilename = `music-${basename(musicAbsPath)}`;
+      // Use timestamp prefix to avoid filename collisions across renders
+      const musicFilename = `music-${Date.now()}-${basename(musicAbsPath)}`;
       const musicDest = join(publicDir, musicFilename);
       copyFileSync(musicAbsPath, musicDest);
       console.log(`  Copied ${basename(musicAbsPath)} -> public/${musicFilename}`);
@@ -124,10 +134,11 @@ function renderVideo(opts) {
     );
   }
 
-  // Calculate duration — use consistent source (scenes) for both components.
-  // Clamp transitionOverlap to scene count to avoid negative frames when counts diverge.
+  // Calculate duration — use only scenes that have corresponding video files.
+  // When scene count and video count diverge, rendering is constrained to the minimum,
+  // so duration must match to avoid empty frames or negative totalFrames.
   const sceneCount = Math.min(scenes.length, sceneVideoFilenames.length);
-  const totalSceneDuration = props.scenes.reduce((sum, s) => sum + (s.duration || 5), 0);
+  const totalSceneDuration = props.scenes.slice(0, sceneCount).reduce((sum, s) => sum + (s.duration || 5), 0);
   const transitionOverlap = Math.max(0, (sceneCount - 1)) * props.transitionDuration;
   const totalFrames = Math.max(1, totalSceneDuration * fps - transitionOverlap);
 

--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -101,6 +101,11 @@ function normalizeCaptions(rawCaptions, scenes, fps) {
   });
 }
 
+/**
+ * Parse CLI arguments into a key-value options object.
+ * Supports --key value and --flag (boolean) patterns.
+ * @returns {Record<string, string | boolean>} Parsed options
+ */
 function parseArgs() {
   const args = process.argv.slice(2);
   const opts = {};
@@ -114,6 +119,11 @@ function parseArgs() {
   return opts;
 }
 
+/**
+ * Render a multi-scene video composition from a brief JSON and scene video files.
+ * Copies assets to public/, builds Remotion props, and invokes npx remotion render.
+ * @param {Record<string, string | boolean>} opts - CLI options (brief, videos, output, transition, etc.)
+ */
 function renderVideo(opts) {
   const briefPath = resolve(opts.brief);
   if (!existsSync(briefPath)) {
@@ -209,6 +219,10 @@ function renderVideo(opts) {
   }
 }
 
+/**
+ * Render a single still image (title card / graphic) via Remotion.
+ * @param {Record<string, string | boolean>} opts - CLI options (text, subtitle, aspect, bg, color, font, output)
+ */
 function renderStill(opts) {
   const output = opts.output ? resolve(opts.output) : resolve("graphic.png");
   const aspect = opts.aspect || "9:16";

--- a/.agents/scripts/higgsfield/remotion/src/FullVideo.tsx
+++ b/.agents/scripts/higgsfield/remotion/src/FullVideo.tsx
@@ -86,10 +86,10 @@ export const FullVideo: React.FC<BriefProps> = ({
           })}
         </TransitionSeries>
 
-        {/* Background music */}
+        {/* Background music — resolve via staticFile() like scene videos */}
         {musicPath && (
           <Audio
-            src={musicPath}
+            src={toVideoSrc(musicPath)}
             volume={0.3}
           />
         )}
@@ -134,7 +134,7 @@ export const FullVideo: React.FC<BriefProps> = ({
 
       {musicPath && (
         <Audio
-          src={musicPath}
+          src={toVideoSrc(musicPath)}
           volume={0.3}
         />
       )}


### PR DESCRIPTION
## Summary

Addresses all 3 findings from PR #926 review feedback (CodeRabbit + Gemini) on `.agents/scripts/higgsfield/remotion/render.mjs`:

- **HIGH (Gemini) — scene index fallback bug**: Already fixed in the merged PR. Current code at line 75 correctly defaults `sceneIdx` to `scenes.length - 1` (last scene). No change needed.
- **MEDIUM (CodeRabbit) — `musicPath` uses absolute filesystem path**: Remotion's `<Audio>` cannot resolve absolute paths in a browser rendering context. Fixed by copying the music file to `public/` (same pattern as `sceneVideos`) and passing only the filename. Also updated `FullVideo.tsx` to route `musicPath` through `toVideoSrc()` → `staticFile()` for consistent resolution.
- **MEDIUM (CodeRabbit) — scene/video count mismatch**: `totalSceneDuration` derived from `props.scenes.length` (brief metadata) while `transitionOverlap` derived from `sceneVideoFilenames.length` (actual files). If these diverge, frame math becomes inconsistent and `totalFrames` could go negative. Fixed by adding a warning log, using `Math.min(scenes, videos)` for transition overlap, and clamping `totalFrames` to minimum 1.

## Changes

| File | Change |
|------|--------|
| `render.mjs` | Copy music to `public/`, add count mismatch guard, clamp `totalFrames` |
| `FullVideo.tsx` | Route `musicPath` through `toVideoSrc()` for `staticFile()` resolution |

Closes #3752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed music file resolution and handling so local audio is reliably used and copied safely to the public assets area.
  * Corrected frame/duration calculations to avoid zero-frame issues and improve timing consistency.

* **Improvements**
  * Added aspect-ratio based sizing with a sensible fallback for unknown aspects.
  * Normalized captions mapping and improved scene/video count validation with a warning when mismatched.
  * Prepared public asset placement and clarified rendering logs/documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->