### PR TITLE
feat: pre-merge unresolved review suggestions check for pulse

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -121,6 +121,32 @@ Then skip to the next PR. The next pulse cycle will retry the permission check �
   - `WAITING` only means "no known bot activity" — it does NOT mean zero reviews. When `WAITING` is returned, check the formal review count (the `gh pr view` command above). If count > 0, proceed to merge.
   - `SKIP` means the PR has a `skip-review-gate` label — it bypasses the bot gate only, NOT the review count requirement.
   - Skip the PR when the formal review count is 0, regardless of bot gate status.
+  - **Unresolved review suggestions check (pre-merge):** Before merging, check for unresolved inline review comments from bots. This prevents merging PRs where actionable feedback was posted but never addressed — the root cause of quality-debt backfill issues.
+
+    ```bash
+    # Fetch inline review comments from known bots that have suggestions
+    UNRESOLVED=$(gh api "repos/<slug>/pulls/<number>/comments" \
+      --jq '[.[] | select(
+        (.user.login | test("coderabbit|gemini-code-assist|copilot|augment"; "i")) and
+        (.body | test("suggestion|```suggestion"; "i"))
+      )] | length')
+
+    if [[ "$UNRESOLVED" -gt 0 ]]; then
+      # Don't block — dispatch a worker to address the feedback before merging
+      echo "PR #<number> has $UNRESOLVED unresolved bot suggestion(s) — dispatching fix worker"
+      # Label the PR so the next cycle knows a fix is in progress
+      gh api --silent "repos/<slug>/issues/<number>/labels" \
+        -X POST -f 'labels[]=needs-review-fixes' 2>/dev/null || true
+      # Dispatch a worker to address the suggestions (counts against worker slots)
+      opencode run --dir <path> --title "PR #<number>: address review suggestions" \
+        "/full-loop Address unresolved review bot suggestions on PR #<number> (<pr_url>). Read the inline review comments, apply valid suggestions, dismiss invalid ones with a reply explaining why." &
+      sleep 2
+      # Skip merge this cycle — the fix worker will push, and the next pulse merges
+      continue
+    fi
+    ```
+
+    **Judgment call, not a hard block.** Not every bot suggestion is valid — bots hallucinate. The fix worker reads each suggestion, applies valid ones, and dismisses invalid ones with a reply. The goal is to prevent the pattern where feedback is silently ignored and becomes a quality-debt issue post-merge. If the PR already has the `needs-review-fixes` label (fix worker already dispatched), skip the check — the worker is handling it. If the PR has `skip-review-suggestions` label, bypass this check entirely (for cases where all suggestions were reviewed and intentionally declined).
 - **Green CI + zero reviews** → skip this cycle, but run `review-bot-gate-helper.sh request-retry <number> <slug>` to self-heal rate-limited bots. The helper checks whether bots posted rate-limit notices instead of real reviews and requests a retry if so (idempotent — safe to call every cycle). The next pulse will find the real review and merge normally. The formal review count gate still applies — this is recovery, not bypass.
 - **Failing CI or changes requested** → before dispatching a fix worker, check whether this is a systemic failure (see "CI failure pattern detection" below). If systemic, skip the per-PR dispatch — the workflow-level issue covers it. If per-PR, dispatch a worker to fix it (counts against worker slots).
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2424,7 +2424,7 @@ _Monitoring: ${sweep_total_issues} issues (delta: ${issue_delta}), gate ${sweep_
 		local scan_output
 		scan_output=$("$review_helper" scan-merged \
 			--repo "$repo_slug" \
-			--batch 10 \
+			--batch 30 \
 			--create-issues \
 			--min-severity medium \
 			--json) || scan_output=""


### PR DESCRIPTION
## Summary

- Adds a pre-merge gate in `pulse.md` that checks for unresolved inline review comments from bots (CodeRabbit, Gemini, Copilot, Augment) before merging PRs
- When unresolved suggestions are found, the pulse dispatches a worker to address them instead of merging — preventing the pattern where feedback is silently ignored and becomes a quality-debt backfill issue
- Increases `scan-merged` batch size from 10 to 30 in `pulse-wrapper.sh` so the daily quality sweep keeps pace with active repos

## Problem

The review-bot-gate checks whether bots **posted** (presence), but nothing checks whether the feedback was **addressed** (action). This was observed on [webapp PR #836](https://github.com/webapp/webapp/pull/836) where Gemini posted a valid suggestion at 11:43 and the PR was merged at 11:48 with zero follow-up commits. The suggestion was ignored, and the repo now has 10+ open `quality-debt` backfill issues from the same pattern.

The `scan-merged` batch size of 10 PRs/day also couldn't keep pace with repos merging 10+ PRs/day, causing the backfill queue to grow faster than workers resolve it.

## Changes

### `pulse.md` — Pre-merge unresolved suggestions check

Added between the review-bot-gate check and the merge decision. The pulse:

1. Fetches inline review comments from known bots
2. Filters for comments containing `suggestion` or ` ```suggestion ` blocks
3. If unresolved suggestions exist, labels the PR `needs-review-fixes` and dispatches a worker to address them
4. Skips merge this cycle — the fix worker pushes, and the next pulse merges

This is guidance for the LLM supervisor, not a hard CI gate. The pulse uses judgment — if the PR already has `needs-review-fixes` (worker dispatched) or `skip-review-suggestions` (intentionally declined), it skips the check.

### `pulse-wrapper.sh` — Batch size increase

Changed `--batch 10` to `--batch 30` for the `scan-merged` call in the daily quality sweep. This allows scanning up to 30 merged PRs per sweep cycle instead of 10, keeping pace with active repos.

## Testing

- ShellCheck: clean (only SC1091 — expected for sourced files)
- Markdown lint: clean
- The pulse.md change is agent guidance (prose + example code), not executable code — it's consumed by the LLM supervisor at runtime
- The pulse-wrapper.sh change is a single integer parameter change with no logic impact

## Files changed

- `.agents/scripts/commands/pulse.md` — added unresolved suggestions check section
- `.agents/scripts/pulse-wrapper.sh` — increased scan-merged batch from 10 to 30