### PR TITLE
t1417: feat(pulse): add hygiene layer — stash cleanup, orphan worktree detection, stale PR triage

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -597,6 +597,61 @@ gh issue comment <issue_number> --repo <slug> --body "Re-opened for dispatch —
 - NEVER flag a PR that has passing CI and approved reviews — it should be merged, not flagged (handle it in the PRs section above instead)
 - If uncertain whether a PR is truly orphaned, skip it — the next pulse is 2 minutes away
 
+### Repo Hygiene Triage (t1417)
+
+After processing PRs, issues, and orphaned PRs, check the **"Repo Hygiene"** section in the pre-fetched state. This section contains non-deterministic cleanup candidates that the shell layer could not handle automatically — they require your judgment.
+
+The shell layer already handled deterministic cleanup before you started:
+- Worktrees for merged/closed PRs → removed by `worktree-helper.sh clean --auto --force-merged`
+- Stashes whose content is already in HEAD → dropped by `stash-audit-helper.sh auto-clean`
+
+What remains in the hygiene section needs intelligence:
+
+**Orphan worktrees** (0 commits ahead of main, no PR, no active worker):
+
+These are typically branches created by workers that crashed or were killed before producing any commits. However, they could also be:
+- A user's manual experiment they intend to return to
+- A worker that was just dispatched and hasn't committed yet (check Active Workers)
+- A branch with uncommitted work that would be lost if removed
+
+**Assessment approach:**
+1. Cross-reference with Active Workers — if a worker is running on this branch, skip it
+2. Check if the worktree has uncommitted files (noted in the hygiene data as "N uncommitted files") — if dirty, flag but do NOT recommend removal
+3. If the worktree is clean (0 commits, 0 uncommitted files, no PR, no worker) AND the branch name matches a known task pattern (feature/tNNN, bugfix/*, etc.), it's likely a crashed worker — comment on the associated issue if one exists, noting the orphan branch
+4. If uncertain, skip — the next pulse is 2 minutes away
+
+**Do NOT auto-remove orphan worktrees.** Only flag them. The user or a future pulse with more context can decide. Post a comment on the repo's health issue if one exists, listing the orphan worktrees found.
+
+**Stale PRs** (failing CI, no progress):
+
+For each open PR in the pre-fetched state, check:
+- Has CI been failing for 7+ days? (Compare `updatedAt` with current time — if no commits pushed in 7 days and CI is FAIL, it's stale)
+- Is there an active worker? (Check Active Workers section)
+- Is there a `needs-review-fixes` label? (A fix worker may be dispatched)
+
+If a PR has been failing CI for 7+ days with no new commits and no active worker:
+1. Close the PR with a comment explaining why:
+
+```bash
+gh pr close <number> --repo <slug> --comment "Closing — CI has been failing for 7+ days with no new commits or active worker. The linked issue will be relabelled for re-dispatch. If this work is still viable, reopen the PR and push fixes."
+```
+
+2. Relabel the linked issue to `status:available` for re-dispatch
+3. Log the closure in your output
+
+**Uncommitted changes on main:**
+
+If the hygiene data shows uncommitted files on a repo's main branch, this is unusual — main should always be clean. Possible causes:
+- A stash pop that failed (conflict left working tree dirty)
+- Manual edits the user forgot to commit
+- A script that modified files without committing
+
+**Do NOT commit or discard these changes.** Flag them in your output so the user is aware. Example: "aidevops: 2 uncommitted files on main (loop-common.sh, worktree-helper.sh) — likely from a failed stash pop. Manual resolution needed."
+
+**Remaining stashes:**
+
+If the hygiene data shows stashes remaining after auto-clean, these contain changes NOT in HEAD (the safe ones were already dropped). Note the count in your output but take no action — stash management beyond safe-to-drop requires user judgment.
+
 ## Step 3.5: Mission Awareness
 
 If the pre-fetched state includes an "Active Missions" section, process each mission. Missions are autonomous multi-day projects with milestones and features — see `workflows/mission-orchestrator.md` for the full orchestrator spec. The pulse's job is lightweight: check status, dispatch undispatched features, detect milestone completion, and advance state. Heavy reasoning (re-planning, validation design) is the orchestrator's job — the pulse just keeps the pipeline moving.

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -499,6 +499,9 @@ prefetch_state() {
 	# Append active worker snapshot for orphaned PR detection (t216)
 	prefetch_active_workers >>"$STATE_FILE"
 
+	# Append repo hygiene data for LLM triage (t1417)
+	prefetch_hygiene >>"$STATE_FILE"
+
 	# Export PULSE_SCOPE_REPOS — comma-separated list of repo slugs that
 	# workers are allowed to create PRs/branches on (t1405, GH#2928).
 	# Workers CAN file issues on any repo (cross-repo self-improvement),
@@ -991,6 +994,133 @@ prefetch_active_workers() {
 }
 
 #######################################
+# Pre-fetch repo hygiene data for LLM triage (t1417)
+#
+# Appends a "Repo Hygiene" section to the state file with:
+#   1. Orphan worktrees — branches with 0 commits ahead of main,
+#      no PR (open or merged), and no active worker process.
+#   2. Stash summary — count of needs-review stashes per repo.
+#   3. Uncommitted changes on main — repos with dirty main worktree.
+#
+# This data enables the pulse LLM to make intelligent triage decisions
+# about cleanup. Deterministic cleanup (merged-PR worktrees, safe stashes)
+# is handled by cleanup_worktrees() and cleanup_stashes() before this runs.
+# What remains here requires judgment.
+#
+# Output: hygiene summary to stdout (appended to STATE_FILE by caller)
+#######################################
+prefetch_hygiene() {
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+
+	echo ""
+	echo "# Repo Hygiene"
+	echo ""
+	echo "Non-deterministic cleanup candidates requiring LLM assessment."
+	echo "Merged-PR worktrees and safe-to-drop stashes were already cleaned by the shell layer."
+	echo ""
+
+	if [[ ! -f "$repos_json" ]] || ! command -v jq &>/dev/null; then
+		echo "- repos.json not available — skipping hygiene prefetch"
+		echo ""
+		return 0
+	fi
+
+	local repo_paths
+	repo_paths=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path' "$repos_json" || echo "")
+
+	local found_any=false
+
+	local repo_path
+	while IFS= read -r repo_path; do
+		[[ -z "$repo_path" ]] && continue
+		[[ ! -d "$repo_path/.git" ]] && continue
+
+		local repo_name
+		repo_name=$(basename "$repo_path")
+		local repo_issues=""
+
+		# 1. Orphan worktrees: 0 commits ahead of default branch, no PR
+		local default_branch
+		default_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || default_branch="main"
+		[[ -z "$default_branch" ]] && default_branch="main"
+
+		local wt_branch wt_path
+		while IFS= read -r line; do
+			if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
+				wt_path="${BASH_REMATCH[1]}"
+			elif [[ "$line" =~ ^branch\ refs/heads/(.+)$ ]]; then
+				wt_branch="${BASH_REMATCH[1]}"
+			elif [[ -z "$line" && -n "$wt_branch" ]]; then
+				# Skip the default branch
+				if [[ "$wt_branch" != "$default_branch" ]]; then
+					local commits_ahead
+					commits_ahead=$(git -C "$repo_path" rev-list --count "${default_branch}..${wt_branch}" 2>/dev/null) || commits_ahead="?"
+
+					if [[ "$commits_ahead" == "0" ]]; then
+						# Check if any PR exists (open or merged)
+						local has_pr="false"
+						if command -v gh &>/dev/null; then
+							local pr_check
+							pr_check=$(gh pr list --repo "$(jq -r --arg p "$repo_path" '.initialized_repos[] | select(.path == $p) | .slug' "$repos_json" 2>/dev/null)" \
+								--head "$wt_branch" --state all --json number --jq 'length' 2>/dev/null) || pr_check="0"
+							[[ "${pr_check:-0}" -gt 0 ]] && has_pr="true"
+						fi
+
+						if [[ "$has_pr" == "false" ]]; then
+							# Check for dirty state
+							local dirty=""
+							local change_count
+							change_count=$(git -C "${wt_path:-$repo_path}" status --porcelain 2>/dev/null | wc -l | tr -d ' ') || change_count=0
+							[[ "${change_count:-0}" -gt 0 ]] && dirty=" (${change_count} uncommitted files)"
+
+							repo_issues="${repo_issues}  - Orphan worktree: \`${wt_branch}\` — 0 commits, no PR${dirty} (${wt_path})\n"
+						fi
+					fi
+				fi
+				wt_path=""
+				wt_branch=""
+			fi
+		done < <(
+			git -C "$repo_path" worktree list --porcelain 2>/dev/null
+			echo ""
+		)
+
+		# 2. Stash summary (needs-review count)
+		local stash_count
+		stash_count=$(git -C "$repo_path" stash list 2>/dev/null | wc -l | tr -d ' ')
+		if [[ "${stash_count:-0}" -gt 0 ]]; then
+			repo_issues="${repo_issues}  - ${stash_count} stash(es) remaining (safe-to-drop already cleaned; these need review)\n"
+		fi
+
+		# 3. Uncommitted changes on main worktree
+		local main_wt_path="$repo_path"
+		local current_branch
+		current_branch=$(git -C "$main_wt_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || current_branch=""
+		if [[ "$current_branch" == "$default_branch" ]]; then
+			local main_dirty
+			main_dirty=$(git -C "$main_wt_path" status --porcelain 2>/dev/null | wc -l | tr -d ' ') || main_dirty=0
+			if [[ "${main_dirty:-0}" -gt 0 ]]; then
+				repo_issues="${repo_issues}  - ${main_dirty} uncommitted file(s) on ${default_branch} branch\n"
+			fi
+		fi
+
+		# Output repo section if any issues found
+		if [[ -n "$repo_issues" ]]; then
+			found_any=true
+			echo "### ${repo_name}"
+			echo -e "$repo_issues"
+		fi
+	done <<<"$repo_paths"
+
+	if [[ "$found_any" == "false" ]]; then
+		echo "- All repos clean — no hygiene issues detected"
+		echo ""
+	fi
+
+	return 0
+}
+
+#######################################
 # Process guard: kill child processes exceeding RSS or runtime limits (t1398)
 #
 # Scans all child processes of the current pulse (and their descendants)
@@ -1371,6 +1501,73 @@ cleanup_worktrees() {
 
 	if [[ "$total_removed" -gt 0 ]]; then
 		echo "[pulse-wrapper] Worktree cleanup total: $total_removed worktree(s) removed across all repos" >>"$LOGFILE"
+	fi
+
+	return 0
+}
+
+#######################################
+# Clean up safe-to-drop stashes across ALL managed repos (t1417)
+#
+# Iterates repos.json (.initialized_repos[]) and runs
+# stash-audit-helper.sh auto-clean in each repo directory.
+# Only drops stashes whose content is already in HEAD — safe
+# and deterministic, no judgment needed.
+#
+# Stashes classified as "needs-review" or "obsolete" are left
+# for the LLM hygiene triage (see prefetch_hygiene + pulse.md).
+#######################################
+cleanup_stashes() {
+	local helper="${HOME}/.aidevops/agents/scripts/stash-audit-helper.sh"
+	if [[ ! -x "$helper" ]]; then
+		return 0
+	fi
+
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	local total_dropped=0
+
+	if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
+		local repo_paths
+		repo_paths=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path' "$repos_json" || echo "")
+
+		local repo_path
+		while IFS= read -r repo_path; do
+			[[ -z "$repo_path" ]] && continue
+			[[ ! -d "$repo_path/.git" ]] && continue
+
+			# Skip repos with no stashes
+			local stash_count
+			stash_count=$(git -C "$repo_path" stash list 2>/dev/null | wc -l | tr -d ' ')
+			if [[ "${stash_count:-0}" -eq 0 ]]; then
+				continue
+			fi
+
+			local clean_result
+			clean_result=$(cd "$repo_path" && bash "$helper" auto-clean 2>&1) || true
+
+			local count
+			count=$(echo "$clean_result" | grep -c 'Dropped') || count=0
+			if [[ "$count" -gt 0 ]]; then
+				local repo_name
+				repo_name=$(basename "$repo_path")
+				echo "[pulse-wrapper] Stash cleanup ($repo_name): $count stash(es) dropped" >>"$LOGFILE"
+				total_dropped=$((total_dropped + count))
+			fi
+		done <<<"$repo_paths"
+	else
+		# Fallback: just clean the current repo
+		local clean_result
+		clean_result=$(bash "$helper" auto-clean 2>&1) || true
+		local fallback_count
+		fallback_count=$(echo "$clean_result" | grep -c 'Dropped') || fallback_count=0
+		if [[ "$fallback_count" -gt 0 ]]; then
+			echo "[pulse-wrapper] Stash cleanup: $fallback_count stash(es) dropped" >>"$LOGFILE"
+			total_dropped=$((total_dropped + fallback_count))
+		fi
+	fi
+
+	if [[ "$total_dropped" -gt 0 ]]; then
+		echo "[pulse-wrapper] Stash cleanup total: $total_dropped stash(es) dropped across all repos" >>"$LOGFILE"
 	fi
 
 	return 0
@@ -2796,6 +2993,7 @@ main() {
 
 	cleanup_orphans
 	cleanup_worktrees
+	cleanup_stashes
 	calculate_max_workers
 	check_session_count >/dev/null
 


### PR DESCRIPTION
## Summary

- Wire `stash-audit-helper.sh auto-clean` into the pulse cycle for deterministic stash cleanup across all managed repos
- Add `prefetch_hygiene()` to surface orphan worktrees, stash counts, and uncommitted changes on main to the pulse LLM
- Add "Repo Hygiene Triage" section to `pulse.md` with intelligent assessment guidance for non-deterministic cleanup

## Problem

Workers crash, apps quit, systems reboot — leaving orphan worktrees, stale stashes, and abandoned PRs. Without systemic cleanup, these accumulate (76 worktrees observed in a single session). The pulse already handles merged-PR worktree cleanup deterministically, but three gaps existed:

1. **Stash cleanup not wired into pulse** — `stash-audit-helper.sh` existed but wasn't called
2. **No hygiene data for LLM** — the pulse couldn't see orphan worktrees or dirty main branches
3. **No triage instructions** — the LLM had no guidance for assessing ambiguous cleanup candidates

## Architecture

| Layer | What it handles | How |
|-------|----------------|-----|
| **Shell (deterministic)** | Merged-PR worktrees, safe-to-drop stashes | `cleanup_worktrees()`, `cleanup_stashes()` — runs every pulse cycle, no LLM needed |
| **LLM (intelligence)** | Orphan worktrees, stale PRs, uncommitted changes | `prefetch_hygiene()` data + `pulse.md` triage instructions — LLM reads state, applies judgment |

Key design decision: **orphan worktrees are flagged, not auto-removed**. A 0-commit branch might be a crashed worker (safe to remove) or a user's manual experiment (not safe). The LLM assesses context; the user decides.

## Files Changed

- `.agents/scripts/pulse-wrapper.sh` — Added `cleanup_stashes()` (deterministic, follows `cleanup_worktrees()` pattern), `prefetch_hygiene()` (data collection for LLM), wired both into `main()` and `prefetch_state()`
- `.agents/scripts/commands/pulse.md` — Added "Repo Hygiene Triage" section with assessment guidance for orphan worktrees, stale PRs, uncommitted changes, and remaining stashes

## Testing

- ShellCheck clean (SC1091 suppressed globally per `.shellcheckrc`)
- No existing tests broken — additions only, no modifications to existing logic
- `cleanup_stashes()` follows identical pattern to `cleanup_worktrees()` (proven in production)
- `prefetch_hygiene()` is read-only (git status, git rev-list, gh pr list) — no destructive operations

Closes #3894