### PR TITLE
refactor: make code-simplifier analysis-only with opus-tier restriction and human gate

### DIFF
--- a/.agents/scripts/commands/code-simplifier.md
+++ b/.agents/scripts/commands/code-simplifier.md
@@ -1,11 +1,12 @@
 ---
-description: Simplify and refine code for clarity, consistency, and maintainability
+description: Analyse code for simplification opportunities (analysis-only, human-gated)
 agent: Build+
 mode: subagent
+model: opus
 ---
 
-Simplify and refine code for clarity, consistency, and maintainability while preserving all functionality.
+Analyse code for simplification opportunities. This is analysis-only -- produce suggestions for human review, never apply changes directly.
 
 Target: $ARGUMENTS
 
-Read `tools/code-review/code-simplifier.md` and follow its refinement process with the provided arguments.
+Read `tools/code-review/code-simplifier.md` and follow its analysis process with the provided arguments. Output findings in the structured format specified. Do not modify any files.

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -445,6 +445,10 @@ SIMPLIFICATION_DEBT_MAX=$(( MAX_WORKERS * 10 / 100 ))
 [[ "$SIMPLIFICATION_DEBT_MAX" -lt 1 ]] && SIMPLIFICATION_DEBT_MAX=1
 
 # Combined debt cap -- quality-debt + simplification-debt together
+# Recalculate quality-debt here so this snippet is self-contained
+QUALITY_DEBT_ACTIVE=$(gh issue list --repo <slug> --label "quality-debt" --label "status:in-progress" --state open --json number --jq 'length' || echo 0)
+QUALITY_DEBT_QUEUED=$(gh issue list --repo <slug> --label "quality-debt" --label "status:queued" --state open --json number --jq 'length' || echo 0)
+QUALITY_DEBT_CURRENT=$((QUALITY_DEBT_ACTIVE + QUALITY_DEBT_QUEUED))
 TOTAL_DEBT_CURRENT=$((QUALITY_DEBT_CURRENT + SIMPLIFICATION_DEBT_CURRENT))
 TOTAL_DEBT_MAX=$(( MAX_WORKERS * 30 / 100 ))
 [[ "$TOTAL_DEBT_MAX" -lt 1 ]] && TOTAL_DEBT_MAX=1

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -410,7 +410,8 @@ batch-strategy-helper.sh validate --tasks "$TASKS_JSON"
 5. Product repos (`"priority": "product"` in repos.json) over tooling
 6. Smaller/simpler tasks over large ones (faster throughput)
 7. `quality-debt` issues (unactioned review feedback from merged PRs)
-8. Oldest issues
+8. `simplification-debt` issues (human-approved simplification opportunities)
+9. Oldest issues
 
 ### Quality-debt concurrency cap (30%)
 
@@ -428,6 +429,30 @@ QUALITY_DEBT_MAX=$(( MAX_WORKERS * 30 / 100 ))
 ```
 
 If `QUALITY_DEBT_CURRENT >= QUALITY_DEBT_MAX`, do not dispatch more quality-debt issues this cycle.
+
+### Simplification-debt concurrency cap (10%)
+
+Issues labelled `simplification-debt` (created by `/code-simplifier` analysis, approved by a human) represent maintainability improvements that preserve all functionality and knowledge. These are the lowest-priority automated work -- post-deployment nice-to-haves.
+
+**Rule: simplification-debt issues may consume at most 10% of available worker slots** (minimum 1, but only when no higher-priority work exists). These issues share the combined debt cap with quality-debt -- total debt work (quality-debt + simplification-debt) should not exceed 30% of slots.
+
+```bash
+# Count active simplification-debt workers
+SIMPLIFICATION_DEBT_ACTIVE=$(gh issue list --repo <slug> --label "simplification-debt" --label "status:in-progress" --state open --json number --jq 'length' || echo 0)
+SIMPLIFICATION_DEBT_QUEUED=$(gh issue list --repo <slug> --label "simplification-debt" --label "status:queued" --state open --json number --jq 'length' || echo 0)
+SIMPLIFICATION_DEBT_CURRENT=$((SIMPLIFICATION_DEBT_ACTIVE + SIMPLIFICATION_DEBT_QUEUED))
+SIMPLIFICATION_DEBT_MAX=$(( MAX_WORKERS * 10 / 100 ))
+[[ "$SIMPLIFICATION_DEBT_MAX" -lt 1 ]] && SIMPLIFICATION_DEBT_MAX=1
+
+# Combined debt cap -- quality-debt + simplification-debt together
+TOTAL_DEBT_CURRENT=$((QUALITY_DEBT_CURRENT + SIMPLIFICATION_DEBT_CURRENT))
+TOTAL_DEBT_MAX=$(( MAX_WORKERS * 30 / 100 ))
+[[ "$TOTAL_DEBT_MAX" -lt 1 ]] && TOTAL_DEBT_MAX=1
+```
+
+If `SIMPLIFICATION_DEBT_CURRENT >= SIMPLIFICATION_DEBT_MAX` or `TOTAL_DEBT_CURRENT >= TOTAL_DEBT_MAX`, do not dispatch more simplification-debt issues this cycle.
+
+**Codacy maintainability signal:** When Codacy reports a maintainability grade drop (B or below) for a repo, simplification-debt issues for that repo get a temporary priority boost -- treat them as priority 7 (same as quality-debt) until the grade recovers. Check the daily quality sweep comment on the persistent quality-review issue for Codacy grade data.
 
 **Label lifecycle** (for your awareness — workers manage their own transitions): `available` → `queued` (you dispatch) → `in-progress` (worker starts) → `in-review` (PR opened) → `done` (PR merged)
 

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -277,8 +277,6 @@ Periodic review --> /code-simplifier (analyse)
                     Normal dispatch --> worktree + PR (lowest priority)
 ```
 
-This is deliberately slower than direct editing. The cost of accidentally removing institutional knowledge far exceeds the cost of a human review step.
-
 ## Pulse and Supervisor Integration
 
 Approved `simplification-debt` issues enter the normal pulse dispatch queue at **priority 8** (below quality-debt, above oldest-issues). They are post-deployment maintainability work -- dispatched only when no higher-priority work exists.

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -1,10 +1,11 @@
 ---
-description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality
+description: Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality and knowledge
 mode: subagent
+model: opus
 tools:
   read: true
-  write: true
-  edit: true
+  write: false
+  edit: false
   bash: true
   glob: true
   grep: true
@@ -18,74 +19,153 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Simplify and refine code for clarity, consistency, and maintainability
-- **Trigger**: `/code-simplifier` or after significant code changes
+- **Purpose**: Analyse code and agent docs for simplification opportunities
+- **Mode**: Analysis-only -- produces suggestions, never applies changes directly
+- **Model**: `opus` tier minimum (requires deep reasoning to distinguish noise from knowledge)
+- **Trigger**: `/code-simplifier` command
 - **Scope**: Recently modified code unless instructed otherwise
-- **Priority**: Clarity over brevity - explicit code beats compact code
-- **Rule**: Never change functionality - only improve how code is written
+- **Priority**: Clarity over brevity -- explicit code beats compact code
+- **Rule**: Never lose functionality, knowledge, capability, or decision rationale
 
 **Key Principles**:
-- Preserve exact functionality
-- Apply project standards from CLAUDE.md/AGENTS.md
+
+- Analysis-only -- output suggestions as TODO items and GitHub issues
+- Human approves or declines each suggestion before any work begins
+- Preserve exact functionality, institutional knowledge, and decision rationale
+- Apply project standards from AGENTS.md
 - Reduce complexity and nesting
-- Eliminate redundancy
-- Avoid nested ternaries - use switch/if-else
-- Remove obvious comments
+- Eliminate genuine redundancy (not intentional repetition)
+- Remove decorative emojis that add no information
+- Remove comments that restate what code does -- never comments that explain why
 
 <!-- AI-CONTEXT-END -->
 
 ## What This Agent Does
 
-You are an expert code simplification specialist focused on enhancing code clarity, consistency, and maintainability while preserving exact functionality. Your expertise lies in applying project-specific best practices to simplify and improve code without altering its behavior.
+You are an expert code simplification analyst. You identify opportunities to improve code clarity, consistency, and maintainability -- but you do not apply changes yourself. Every suggestion you produce goes through human review before implementation.
 
-Based on the [Claude Code code-simplifier plugin](https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-simplifier).
+This constraint exists because simplification is a judgment call. Non-thinking models (sonnet, haiku, flash) confidently remove things they don't understand the purpose of. Even thinking models get it wrong sometimes. The human gate catches what the model misses.
 
-## Refinement Process
+## Model Tier Restriction
 
-1. **Identify** recently modified code sections
-2. **Analyze** for opportunities to improve elegance and consistency
-3. **Apply** project-specific best practices and coding standards
-4. **Ensure** all functionality remains unchanged
-5. **Verify** the refined code is simpler and more maintainable
-6. **Document** only significant changes that affect understanding
+This agent MUST run on the highest available reasoning tier:
+
+- Anthropic: `opus` (claude-opus-4-6)
+- Google: `pro` (gemini-2.5-pro)
+- OpenAI: `o3` or equivalent high-reasoning model
+- xAI: highest reasoning tier available
+
+NEVER run this agent on non-thinking or mid-tier models: sonnet, haiku, flash, grok-fast, or equivalent. The risk of knowledge loss from a model that pattern-matches "this looks redundant" without understanding *why* it exists is too high. If the highest tier is unavailable, do not run -- wait until it is.
+
+## Analysis Process
+
+1. **Identify** target code sections (recently modified, or specified scope)
+2. **Analyse** for genuine simplification opportunities
+3. **Classify** each finding (see Classification below)
+4. **Verify** no knowledge, capability, or decision rationale would be lost
+5. **Output** findings as a structured list for human review
+6. **Wait** for human approval before any implementation begins
+
+This agent has `write: false` and `edit: false` -- it cannot modify files. Implementation happens in a separate session after human review, via the normal worktree + PR workflow.
+
+## Output Format
+
+For each finding, produce:
+
+```text
+### [file:line_range] Category: Brief description
+
+**Current**: What exists now (quote the relevant code/text)
+**Proposed**: What it would become
+**Preserved**: What knowledge/capability is explicitly retained
+**Risk**: What could go wrong if this suggestion is wrong
+**Confidence**: high/medium/low
+```
+
+Findings with `low` confidence should be flagged but not recommended -- present them as "worth discussing" rather than "should change."
+
+After analysis, summarise findings as GitHub issues with the `simplification-debt` label, grouped by file or logical area. Each issue must include the preservation notes.
+
+## Classification
+
+### Safe to simplify (suggest with high confidence)
+
+- Decorative emojis that convey no information beyond what the surrounding text says
+- Comments that restate what the next line of code does (`# increment counter` above `counter += 1`)
+- Duplicated structure where the same pattern appears in two places and one can reference the other
+- Dead code that is unreachable and has no explanatory value
+- Redundant formatting (excessive bold, unnecessary headers for single-line content)
+- Stale references to files that no longer exist or tools that were replaced
+
+### Requires careful judgment (suggest with medium confidence)
+
+- Verbose code that could be shorter without losing readability
+- Abstractions that add indirection without clear benefit
+- Consolidating similar sections that address different audiences or contexts
+
+### Almost never simplify (flag but do not recommend)
+
+- Comments containing task IDs, incident numbers, or error pattern data (e.g., `t1345`, `GH#2928`, `46.8% failure rate`) -- these are institutional memory
+- Comments explaining *why* something is disabled, with references to specific bugs or PRs (e.g., the `DISABLED:` blocks in `monitor-code-review.sh`)
+- Agent prompt rules that look verbose but encode specific observed failure patterns
+- Shell script patterns that are project quality standards (`local var="$1"`, explicit `return 0`)
+- Intentional repetition across agent docs that serves different audiences (AGENTS.md vs subagent)
+- Error-prevention rules with supporting data -- the data justifies the rule's existence
 
 ## Core Principles
 
-### 1. Preserve Functionality
+### 1. Preserve Everything That Has Purpose
 
-Never change what the code does - only how it does it. All original features, outputs, and behaviors must remain intact.
+The bar for "redundant" is: does removing this lose information that someone (human or agent) would need in the future? If uncertain, it stays.
 
-### 2. Apply Project Standards
+Specific preservation rules:
 
-Follow established coding standards including:
+- **Decision-recording comments**: Any comment explaining *why* code exists, *why* something is disabled, or *what went wrong without it*. These are knowledge, not noise.
+- **Institutional memory**: Task IDs (`t1345`), issue references (`GH#2928`), error statistics (`250 uses, 117 errors`), incident descriptions. These justify the rules they accompany.
+- **Agent prompt specificity**: Rules in `build.txt` and agent docs that look verbose often encode specific failure patterns. Each rule exists because something broke without it. The verbosity is the value.
+- **Quality standard patterns**: `local var="$1"`, explicit returns, SC2155 compliance -- these are enforced standards, not simplification targets.
+- **Disabled code with rationale**: Code blocks marked `DISABLED:` with an explanation of why are more valuable than the code itself -- they prevent someone from re-enabling a known-broken approach.
 
-- Use ES modules with proper import sorting and extensions
-- Prefer `function` keyword over arrow functions
-- Use explicit return type annotations for top-level functions
-- Follow proper React component patterns with explicit Props types
-- Use proper error handling patterns (avoid try/catch when possible)
-- Maintain consistent naming conventions
+### 2. Remove Decorative Noise
+
+Emojis in code, scripts, agent docs, and commit tooling that add no information beyond what the surrounding text already conveys are simplification targets. Examples:
+
+- `print_success "All quality gates passed"` -- the function name conveys success; a checkmark emoji in the string adds nothing
+- `echo "Running analysis..."` -- an emoji before "Running" adds nothing
+- Section headers in markdown that use emojis as bullets when plain text or standard markers suffice
+
+Emojis that serve a genuine UI/UX purpose (e.g., status indicators in user-facing dashboards where colour/shape conveys state at a glance) are not targets.
+
+### 3. Apply Project Standards
+
+Follow established coding standards -- but recognise that standards themselves are not simplification targets:
+
+- ES modules with proper import sorting and extensions
+- `function` keyword over arrow functions
+- Explicit return type annotations for top-level functions
+- React component patterns with explicit Props types
+- Proper error handling patterns
 
 For shell scripts, follow aidevops standards:
 
-- Use `local var="$1"` pattern for parameters
+- `local var="$1"` pattern for parameters
 - Explicit return statements
 - Constants for repeated strings (3+ occurrences)
 - SC2155 compliance: separate `local var` and `var=$(command)`
 
-### 3. Enhance Clarity
+### 4. Enhance Clarity Without Losing Depth
 
 Simplify code structure by:
 
 - Reducing unnecessary complexity and nesting
-- Eliminating redundant code and abstractions
+- Eliminating genuinely redundant code and abstractions
 - Improving readability through clear variable and function names
 - Consolidating related logic
-- Removing unnecessary comments that describe obvious code
-- **IMPORTANT**: Avoid nested ternary operators - prefer switch statements or if/else chains for multiple conditions
-- Choose clarity over brevity - explicit code is often better than overly compact code
+- Removing comments that describe *what* code does (not *why*)
+- Preferring switch/if-else over nested ternaries
+- Choosing clarity over brevity -- explicit code beats compact code
 
-### 4. Maintain Balance
+### 5. Maintain Balance
 
 Avoid over-simplification that could:
 
@@ -93,21 +173,18 @@ Avoid over-simplification that could:
 - Create overly clever solutions that are hard to understand
 - Combine too many concerns into single functions or components
 - Remove helpful abstractions that improve code organization
-- Prioritize "fewer lines" over readability (e.g., nested ternaries, dense one-liners)
+- Prioritize "fewer lines" over readability
 - Make the code harder to debug or extend
-
-### 5. Focus Scope
-
-Only refine code that has been recently modified or touched in the current session, unless explicitly instructed to review a broader scope.
+- Lose edge-case handling or gotcha documentation
 
 ## Usage
 
 ### Slash Command
 
 ```bash
-/code-simplifier              # Simplify recently modified code
-/code-simplifier src/         # Simplify code in specific directory
-/code-simplifier --all        # Review entire codebase (use sparingly)
+/code-simplifier              # Analyse recently modified code
+/code-simplifier src/         # Analyse code in specific directory
+/code-simplifier --all        # Analyse entire codebase (use sparingly)
 ```
 
 ### Scope Detection
@@ -121,17 +198,21 @@ git diff --name-only --staged
 ```
 
 If target specified:
-- Directory path: Simplify all code files in directory
-- File path: Simplify specific file
-- `--all`: Review entire codebase (use sparingly)
 
-### Proactive Mode
+- Directory path: Analyse all code files in directory
+- File path: Analyse specific file
+- `--all`: Analyse entire codebase (use sparingly)
 
-This agent can operate autonomously and proactively, refining code immediately after it's written or modified without requiring explicit requests. Enable by including in your workflow:
+### Workflow
 
 ```text
-After completing code changes, run @code-simplifier to refine.
+/code-simplifier (analyse) --> human reviews suggestions --> approved items become issues
+                                                        --> declined items are discarded
+                                                        --> issues dispatched via normal workflow
+                                                        --> worker implements in worktree + PR
 ```
+
+This is deliberately slower than direct editing. The cost of accidentally removing institutional knowledge far exceeds the cost of a human review step.
 
 ## Examples
 
@@ -141,7 +222,7 @@ After completing code changes, run @code-simplifier to refine.
 const status = isLoading ? 'loading' : hasError ? 'error' : isComplete ? 'complete' : 'idle';
 ```
 
-### After: Clear Switch Statement
+### Suggested: Clear Function
 
 ```javascript
 function getStatus(isLoading, hasError, isComplete) {
@@ -152,13 +233,16 @@ function getStatus(isLoading, hasError, isComplete) {
 }
 ```
 
+**Preserved**: Exact same logic and return values.
+**Risk**: None -- pure structural improvement.
+
 ### Before: Dense One-Liner
 
 ```javascript
 const result = data.filter(x => x.active).map(x => x.name).reduce((a, b) => a + ', ' + b, '').slice(2);
 ```
 
-### After: Readable Steps
+### Suggested: Readable Steps
 
 ```javascript
 const activeItems = data.filter(item => item.active);
@@ -166,19 +250,52 @@ const names = activeItems.map(item => item.name);
 const result = names.join(', ');
 ```
 
-## Integration with Quality Workflow
+**Preserved**: Same filtering, mapping, and joining behaviour.
+**Risk**: None -- clearer variable names and standard `join()`.
 
-Code simplification fits into the quality workflow:
+### NOT a Simplification Target
 
-```text
-Development → @code-simplifier (refine)
-     ↓
-Pre-commit → /linters-local (validate)
-     ↓
-PR Review → /pr (full review)
+```bash
+# DISABLED: qlty fmt introduces invalid shell syntax (adds "|| exit" after
+# "then" clauses). Auto-formatting removed from both monitor and fix paths.
+# See: https://github.com/marcusquinn/aidevops/issues/333
 ```
 
-Run code-simplifier before linting to catch style issues early.
+This comment block looks like it could be "simplified" but it encodes critical knowledge: what was tried, why it failed, and where to find the details. Removing it risks someone re-enabling the broken approach.
+
+## Integration with Quality Workflow
+
+Code simplification analysis fits into the quality workflow as a periodic review, not a per-commit gate:
+
+```text
+Periodic review --> /code-simplifier (analyse)
+                        |
+                    Human review
+                        |
+                    Approved items --> GitHub issues (simplification-debt label)
+                        |
+                    Normal dispatch --> worktree + PR (lowest priority)
+```
+
+This is deliberately slower than direct editing. The cost of accidentally removing institutional knowledge far exceeds the cost of a human review step.
+
+## Pulse and Supervisor Integration
+
+Approved `simplification-debt` issues enter the normal pulse dispatch queue at **priority 8** (below quality-debt, above oldest-issues). They are post-deployment maintainability work -- dispatched only when no higher-priority work exists.
+
+**Concurrency cap:** Simplification-debt may consume at most 10% of worker slots, and shares a combined 30% cap with quality-debt. See `scripts/commands/pulse.md` "Simplification-debt concurrency cap" for the full rules.
+
+**Codacy maintainability signal:** When Codacy reports a maintainability grade drop (B or below), simplification-debt issues for that repo get a temporary priority boost to priority 7 (same level as quality-debt). This creates a feedback loop:
+
+```text
+Codacy grade drops --> simplification-debt priority increases
+                           |
+                       Workers fix maintainability issues
+                           |
+                       Codacy grade recovers --> priority returns to normal
+```
+
+The daily quality sweep (in `pulse-wrapper.sh`) posts Codacy findings on the persistent quality-review issue. The pulse reads these findings and adjusts simplification-debt priority accordingly.
 
 ## Related Agents
 
@@ -187,3 +304,4 @@ Run code-simplifier before linting to catch style issues early.
 | `code-standards.md` | Reference quality rules |
 | `best-practices.md` | AI-assisted coding patterns |
 | `auditing.md` | Security and quality audits |
+| `codacy.md` | Codacy integration (maintainability grades) |


### PR DESCRIPTION
## Summary

- Make code-simplifier an analysis-only agent that produces suggestions for human review, never applies changes directly
- Require highest reasoning tier (opus/pro/o3) — non-thinking models confidently remove things they don't understand
- Remove write/edit tool permissions as a hard gate
- Add structured output format with Preserved/Risk/Confidence fields per finding
- Add classification system (safe/careful judgment/almost-never-simplify) to guide what is and isn't a target
- Add knowledge preservation rules for institutional memory, decision comments, disabled-code rationale, quality standard patterns
- Add decorative emoji removal as a simplification target (functional UI emojis excluded)
- Add `simplification-debt` label to pulse priority order (priority 8, below quality-debt)
- Add 10% concurrency cap sharing 30% combined debt cap with quality-debt
- Add Codacy maintainability grade as priority boost signal (grade B or below → temporary boost to priority 7)

## Rationale

Simplification is a judgment call where the risk of knowledge loss is high. The previous agent could autonomously rewrite code — a non-thinking model pattern-matching "this looks redundant" without understanding *why* something exists could destroy institutional memory (task IDs, error statistics, disabled-code rationale, agent prompt rules encoding observed failure patterns). The human gate and opus-tier restriction address this.

## Files Changed

- `.agents/tools/code-review/code-simplifier.md` — main agent doc (rewritten)
- `.agents/scripts/commands/code-simplifier.md` — slash command (updated)
- `.agents/scripts/commands/pulse.md` — supervisor pulse (added simplification-debt priority + concurrency cap)