### PR TITLE
fix: narrow pulse suggestion filter to match only code blocks, not prose

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -128,7 +128,7 @@ Then skip to the next PR. The next pulse cycle will retry the permission check â
     UNRESOLVED=$(gh api "repos/<slug>/pulls/<number>/comments" \
       --jq '[.[] | select(
         (.user.login | test("coderabbit|gemini-code-assist|copilot|augment"; "i")) and
-        (.body | test("suggestion|```suggestion"; "i"))
+        (.body | test("```suggestion"; "i"))
       )] | length')
 
     if [[ "$UNRESOLVED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- Fixes false positive in the pulse pre-merge suggestion check where the jq filter `test("suggestion|```suggestion")` matched the word "suggestion" in bot prose comments, not just actual GitHub `suggestion` code blocks
- Changed to `test("```suggestion")` which only matches actionable inline suggestion blocks

## Verification

Tested the fixed filter against:
- **PR #836 (webapp)** — returns 1 (true positive, has real suggestion block) ✅
- **PR #3892 (aidevops)** — returns 1 (true positive, Gemini posted a real suggestion block) ✅
- **20+ recent PRs** — old and new filters produce identical counts (no regressions), confirming real suggestions always use code blocks

The fix prevents future false positives where bots write "suggestion" in prose without an actionable code block.

Closes #3893