### PR TITLE
t1419: Standalone worker watchdog for hung/idle headless workers

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -44,6 +44,7 @@ export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
+source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
 
 #######################################
 # Configuration
@@ -66,29 +67,7 @@ SHELLCHECK_RSS_LIMIT_KB="${SHELLCHECK_RSS_LIMIT_KB:-1048576}" # 1 GB — ShellCh
 SHELLCHECK_RUNTIME_LIMIT="${SHELLCHECK_RUNTIME_LIMIT:-300}"   # 5 min — ShellCheck-specific
 SESSION_COUNT_WARN="${SESSION_COUNT_WARN:-5}"                 # Warn when >N concurrent sessions detected
 
-# Validate numeric configuration — prevent command injection via $(( )) expansion.
-# Bash arithmetic evaluates variable contents as expressions, so unsanitised strings
-# like "a[$(cmd)]" would execute arbitrary commands.
-_validate_int() {
-	local name="$1" value="$2" default="$3" min="${4:-0}"
-	if ! [[ "$value" =~ ^[0-9]+$ ]]; then
-		echo "[pulse-wrapper] Invalid ${name}: ${value} — using default ${default}" >&2
-		printf '%s' "$default"
-		return 0
-	fi
-	# Canonicalize to base-10: strip leading zeros to prevent bash octal interpretation
-	# e.g., "08" (invalid octal) or "01024" (octal 532) become "8" and "1024"
-	local canonical
-	canonical=$(printf '%d' "$((10#$value))")
-	# Enforce minimum to prevent divide-by-zero for divisor-backed settings
-	if ((canonical < min)); then
-		echo "[pulse-wrapper] ${name}=${canonical} below minimum ${min} — using default ${default}" >&2
-		printf '%s' "$default"
-		return 0
-	fi
-	printf '%s' "$canonical"
-	return 0
-}
+# Validate numeric configuration (uses _validate_int from worker-lifecycle-common.sh)
 PULSE_STALE_THRESHOLD=$(_validate_int PULSE_STALE_THRESHOLD "$PULSE_STALE_THRESHOLD" 3600)
 PULSE_IDLE_TIMEOUT=$(_validate_int PULSE_IDLE_TIMEOUT "$PULSE_IDLE_TIMEOUT" 300 60)
 PULSE_IDLE_CPU_THRESHOLD=$(_validate_int PULSE_IDLE_CPU_THRESHOLD "$PULSE_IDLE_CPU_THRESHOLD" 5)
@@ -105,32 +84,7 @@ SHELLCHECK_RSS_LIMIT_KB=$(_validate_int SHELLCHECK_RSS_LIMIT_KB "$SHELLCHECK_RSS
 SHELLCHECK_RUNTIME_LIMIT=$(_validate_int SHELLCHECK_RUNTIME_LIMIT "$SHELLCHECK_RUNTIME_LIMIT" 300 1)
 SESSION_COUNT_WARN=$(_validate_int SESSION_COUNT_WARN "$SESSION_COUNT_WARN" 5 1)
 
-# Sanitise untrusted strings before embedding in GitHub markdown comments.
-# Strips @ mentions (prevents unwanted notifications) and backtick sequences
-# (prevents markdown injection). Used for API response data that gets posted
-# as issue/PR comments.
-_sanitize_markdown() {
-	local input="$1"
-	# Remove @ mentions to prevent notification spam
-	input="${input//@/}"
-	# Remove backtick sequences that could break markdown fencing
-	input="${input//\`/}"
-	printf '%s' "$input"
-	return 0
-}
-
-# Sanitise untrusted strings before writing to log files.
-# Strips control characters (newlines, carriage returns, tabs, and non-printable
-# chars) to prevent log injection attacks where a crafted process name could
-# insert fake log entries or mislead administrators. (Gemini review, PR #2881)
-_sanitize_log_field() {
-	local input="$1"
-	# Strip all control characters (ASCII 0x00-0x1F and 0x7F) except space.
-	# The tr octal range is intentional (not a glob).
-	# shellcheck disable=SC2060
-	printf '%s' "$input" | tr -d '\000-\037\177'
-	return 0
-}
+# _sanitize_markdown and _sanitize_log_field provided by worker-lifecycle-common.sh
 
 PIDFILE="${HOME}/.aidevops/logs/pulse.pid"
 LOGFILE="${HOME}/.aidevops/logs/pulse.log"
@@ -198,156 +152,8 @@ check_dedup() {
 	return 1
 }
 
-#######################################
-# Kill a process and all its children (macOS-compatible)
-# Arguments:
-#   $1 - PID to kill
-#######################################
-_kill_tree() {
-	local pid="$1"
-	# Find all child processes recursively (bash 3.2 compatible — no mapfile)
-	local child
-	while IFS= read -r child; do
-		[[ -n "$child" ]] && _kill_tree "$child"
-	done < <(pgrep -P "$pid" 2>/dev/null || true)
-	kill "$pid" 2>/dev/null || true
-	return 0
-}
-
-#######################################
-# Force kill a process and all its children
-# Arguments:
-#   $1 - PID to kill
-#######################################
-_force_kill_tree() {
-	local pid="$1"
-	local child
-	while IFS= read -r child; do
-		[[ -n "$child" ]] && _force_kill_tree "$child"
-	done < <(pgrep -P "$pid" 2>/dev/null || true)
-	kill -9 "$pid" 2>/dev/null || true
-	return 0
-}
-
-#######################################
-# Get process age in seconds
-# Arguments:
-#   $1 - PID
-# Returns: elapsed seconds via stdout
-#######################################
-_get_process_age() {
-	local pid="$1"
-	local etime
-	# macOS ps etime format: MM:SS or HH:MM:SS or D-HH:MM:SS
-	etime=$(ps -p "$pid" -o etime= 2>/dev/null | tr -d ' ') || etime=""
-
-	if [[ -z "$etime" ]]; then
-		echo "0"
-		return 0
-	fi
-
-	local days=0 hours=0 minutes=0 seconds=0
-
-	# Parse D-HH:MM:SS format
-	if [[ "$etime" == *-* ]]; then
-		days="${etime%%-*}"
-		etime="${etime#*-}"
-	fi
-
-	# Count colons to determine format
-	local colon_count
-	colon_count=$(echo "$etime" | tr -cd ':' | wc -c | tr -d ' ')
-
-	if [[ "$colon_count" -eq 2 ]]; then
-		# HH:MM:SS
-		IFS=':' read -r hours minutes seconds <<<"$etime"
-	elif [[ "$colon_count" -eq 1 ]]; then
-		# MM:SS
-		IFS=':' read -r minutes seconds <<<"$etime"
-	else
-		seconds="$etime"
-	fi
-
-	# Validate components are numeric before arithmetic expansion
-	[[ "$days" =~ ^[0-9]+$ ]] || days=0
-	[[ "$hours" =~ ^[0-9]+$ ]] || hours=0
-	[[ "$minutes" =~ ^[0-9]+$ ]] || minutes=0
-	[[ "$seconds" =~ ^[0-9]+$ ]] || seconds=0
-
-	# Remove leading zeros to avoid octal interpretation
-	days=$((10#${days}))
-	hours=$((10#${hours}))
-	minutes=$((10#${minutes}))
-	seconds=$((10#${seconds}))
-
-	echo $((days * 86400 + hours * 3600 + minutes * 60 + seconds))
-	return 0
-}
-
-#######################################
-# Get integer CPU% for a single PID (helper for _get_process_tree_cpu)
-#
-# Extracts %CPU via ps, truncates to integer, validates numeric.
-# Returns 0 if the process doesn't exist or ps fails.
-#
-# Arguments:
-#   $1 - PID
-# Returns: integer CPU percentage via stdout
-#######################################
-_get_pid_cpu() {
-	local pid="$1"
-	local cpu_str
-	cpu_str=$(ps -p "$pid" -o %cpu= 2>/dev/null | tr -d ' ') || cpu_str="0"
-	# ps returns float like "12.3" — extract integer part
-	local cpu_int="${cpu_str%%.*}"
-	[[ "$cpu_int" =~ ^[0-9]+$ ]] || cpu_int=0
-	echo "$cpu_int"
-	return 0
-}
-
-#######################################
-# Get CPU usage percentage for a process tree (t1398.3)
-#
-# Iteratively walks the full descendant tree (BFS) using pgrep -P at
-# each level. Previous implementation only checked direct children,
-# missing grandchildren and deeper descendants — this caused incorrect
-# CPU calculations when active processes were nested deeper than one
-# level (e.g., node -> shell -> language-server).
-#
-# Arguments:
-#   $1 - PID
-# Returns: integer CPU percentage via stdout (0-N, summed across cores)
-#######################################
-_get_process_tree_cpu() {
-	local pid="$1"
-	local total_cpu=0
-
-	# Iteratively find the initial PID and all its descendants (BFS).
-	# pgrep -P only returns direct children, so we expand level by level.
-	local pids_to_scan=("$pid")
-	local all_pids=()
-	local i=0
-	while [[ $i -lt ${#pids_to_scan[@]} ]]; do
-		local current_pid="${pids_to_scan[$i]}"
-		all_pids+=("$current_pid")
-		local child
-		while IFS= read -r child; do
-			[[ -n "$child" ]] && pids_to_scan+=("$child")
-		done < <(pgrep -P "$current_pid" 2>/dev/null || true)
-		i=$((i + 1))
-	done
-
-	# Sum CPU for all unique PIDs in the process tree.
-	local p
-	for p in $(printf "%s\n" "${all_pids[@]}" | sort -u); do
-		local cpu
-		cpu=$(_get_pid_cpu "$p")
-		total_cpu=$((total_cpu + cpu))
-	done
-
-	echo "$total_cpu"
-	return 0
-}
+# Process lifecycle functions (_kill_tree, _force_kill_tree, _get_process_age,
+# _get_pid_cpu, _get_process_tree_cpu) provided by worker-lifecycle-common.sh
 
 #######################################
 # Pre-fetch state for ALL pulse-enabled repos
@@ -696,100 +502,7 @@ _extract_milestone_summary() {
 	return 0
 }
 
-#######################################
-# Compute struggle ratio for a single worker (t1367)
-#
-# struggle_ratio = messages / max(1, commits)
-# High ratio with elapsed time indicates a worker that is active but
-# not producing useful output (thrashing). This is an informational
-# signal — the supervisor LLM decides what to do with it.
-#
-# Arguments:
-#   $1 - worker PID
-#   $2 - worker elapsed seconds
-#   $3 - worker command line
-# Output: "ratio|commits|messages|flag" to stdout
-#   flag: "" (normal), "struggling", or "thrashing"
-#######################################
-_compute_struggle_ratio() {
-	local pid="$1"
-	local elapsed_seconds="$2"
-	local cmd="$3"
-
-	local threshold="${STRUGGLE_RATIO_THRESHOLD:-30}"
-	local min_elapsed="${STRUGGLE_MIN_ELAPSED_MINUTES:-30}"
-	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=30
-	[[ "$min_elapsed" =~ ^[0-9]+$ ]] || min_elapsed=30
-	local min_elapsed_seconds=$((min_elapsed * 60))
-
-	# Extract --dir from command line
-	local worktree_dir=""
-	if [[ "$cmd" =~ --dir[[:space:]]+([^[:space:]]+) ]]; then
-		worktree_dir="${BASH_REMATCH[1]}"
-	fi
-
-	# No worktree — can't compute
-	if [[ -z "$worktree_dir" || ! -d "$worktree_dir" ]]; then
-		echo "n/a|0|0|"
-		return 0
-	fi
-
-	# Count commits since worker start
-	local commits=0
-	if [[ -d "${worktree_dir}/.git" || -f "${worktree_dir}/.git" ]]; then
-		local since_seconds_ago="${elapsed_seconds}"
-		commits=$(git -C "$worktree_dir" log --oneline --since="${since_seconds_ago} seconds ago" 2>/dev/null | wc -l | tr -d ' ') || commits=0
-	fi
-
-	# Estimate message count from OpenCode session DB
-	local messages=0
-	local db_path="${HOME}/.local/share/opencode/opencode.db"
-
-	if [[ -f "$db_path" ]]; then
-		# Extract title from command to match session
-		local session_title=""
-		if [[ "$cmd" =~ --title[[:space:]]+\"([^\"]+)\" ]] || [[ "$cmd" =~ --title[[:space:]]+([^[:space:]]+) ]]; then
-			session_title="${BASH_REMATCH[1]}"
-		fi
-
-		if [[ -n "$session_title" ]]; then
-			# Query message count for the most recent session matching this title
-			# Use sqlite3 with a LIKE match on session title
-			local escaped_title="${session_title//\'/\'\'}"
-			messages=$(sqlite3 "$db_path" "
-				SELECT COUNT(*)
-				FROM message m
-				JOIN session s ON m.session_id = s.id
-				WHERE s.title LIKE '%${escaped_title}%'
-				AND s.time_created > strftime('%s', 'now') - ${elapsed_seconds}
-			" 2>/dev/null) || messages=0
-		fi
-	fi
-
-	# Fallback: estimate from elapsed time if DB query failed
-	# Conservative heuristic: ~2 messages per minute for an active worker
-	if [[ "$messages" -eq 0 && "$elapsed_seconds" -gt 300 ]]; then
-		local elapsed_minutes=$((elapsed_seconds / 60))
-		messages=$((elapsed_minutes * 2))
-	fi
-
-	# Compute ratio
-	local denominator=$((commits > 0 ? commits : 1))
-	local ratio=$((messages / denominator))
-
-	# Determine flag
-	local flag=""
-	if [[ "$elapsed_seconds" -ge "$min_elapsed_seconds" ]]; then
-		if [[ "$ratio" -gt 50 && "$elapsed_seconds" -ge 3600 ]]; then
-			flag="thrashing"
-		elif [[ "$ratio" -gt "$threshold" && "$commits" -eq 0 ]]; then
-			flag="struggling"
-		fi
-	fi
-
-	echo "${ratio}|${commits}|${messages}|${flag}"
-	return 0
-}
+# _compute_struggle_ratio provided by worker-lifecycle-common.sh
 
 #######################################
 # Check and flag external-contributor PRs (t1391)

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -15,6 +15,7 @@
 #   _sanitize_markdown()      Strip @ mentions and backticks from markdown
 #   _validate_int()           Validate and sanitize integer config values
 #   _compute_struggle_ratio() Compute messages/commits ratio for a worker
+#   _format_duration()        Format seconds into human-readable duration
 #
 # Usage: source worker-lifecycle-common.sh
 #

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+# worker-lifecycle-common.sh — Shared process lifecycle functions
+#
+# Extracted from pulse-wrapper.sh (t1419) so that both pulse-wrapper.sh and
+# worker-watchdog.sh can reuse the same battle-tested process management
+# primitives without duplication.
+#
+# Functions provided:
+#   _kill_tree()              Kill a process and all its children (SIGTERM)
+#   _force_kill_tree()        Force kill a process tree (SIGKILL)
+#   _get_process_age()        Get process age in seconds from ps etime
+#   _get_pid_cpu()            Get integer CPU% for a single PID
+#   _get_process_tree_cpu()   Get CPU% summed across a process tree (BFS)
+#   _sanitize_log_field()     Strip control characters from log fields
+#   _sanitize_markdown()      Strip @ mentions and backticks from markdown
+#   _validate_int()           Validate and sanitize integer config values
+#   _compute_struggle_ratio() Compute messages/commits ratio for a worker
+#
+# Usage: source worker-lifecycle-common.sh
+#
+# Include guard prevents double-loading (readonly errors, function redefinition).
+
+# Include guard
+[[ -n "${_WORKER_LIFECYCLE_COMMON_LOADED:-}" ]] && return 0
+_WORKER_LIFECYCLE_COMMON_LOADED=1
+
+#######################################
+# Kill a process and all its children (macOS-compatible)
+# Arguments:
+#   $1 - PID to kill
+#######################################
+_kill_tree() {
+	local pid="$1"
+	# Find all child processes recursively (bash 3.2 compatible — no mapfile)
+	local child
+	while IFS= read -r child; do
+		[[ -n "$child" ]] && _kill_tree "$child"
+	done < <(pgrep -P "$pid" 2>/dev/null || true)
+	kill "$pid" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Force kill a process and all its children
+# Arguments:
+#   $1 - PID to kill
+#######################################
+_force_kill_tree() {
+	local pid="$1"
+	local child
+	while IFS= read -r child; do
+		[[ -n "$child" ]] && _force_kill_tree "$child"
+	done < <(pgrep -P "$pid" 2>/dev/null || true)
+	kill -9 "$pid" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Get process age in seconds
+# Arguments:
+#   $1 - PID
+# Returns: elapsed seconds via stdout
+#######################################
+_get_process_age() {
+	local pid="$1"
+	local etime
+	# macOS ps etime format: MM:SS or HH:MM:SS or D-HH:MM:SS
+	etime=$(ps -p "$pid" -o etime= 2>/dev/null | tr -d ' ') || etime=""
+
+	if [[ -z "$etime" ]]; then
+		echo "0"
+		return 0
+	fi
+
+	local days=0 hours=0 minutes=0 seconds=0
+
+	# Parse D-HH:MM:SS format
+	if [[ "$etime" == *-* ]]; then
+		days="${etime%%-*}"
+		etime="${etime#*-}"
+	fi
+
+	# Count colons to determine format
+	local colon_count
+	colon_count=$(echo "$etime" | tr -cd ':' | wc -c | tr -d ' ')
+
+	if [[ "$colon_count" -eq 2 ]]; then
+		# HH:MM:SS
+		IFS=':' read -r hours minutes seconds <<<"$etime"
+	elif [[ "$colon_count" -eq 1 ]]; then
+		# MM:SS
+		IFS=':' read -r minutes seconds <<<"$etime"
+	else
+		seconds="$etime"
+	fi
+
+	# Validate components are numeric before arithmetic expansion
+	[[ "$days" =~ ^[0-9]+$ ]] || days=0
+	[[ "$hours" =~ ^[0-9]+$ ]] || hours=0
+	[[ "$minutes" =~ ^[0-9]+$ ]] || minutes=0
+	[[ "$seconds" =~ ^[0-9]+$ ]] || seconds=0
+
+	# Remove leading zeros to avoid octal interpretation
+	days=$((10#${days}))
+	hours=$((10#${hours}))
+	minutes=$((10#${minutes}))
+	seconds=$((10#${seconds}))
+
+	echo $((days * 86400 + hours * 3600 + minutes * 60 + seconds))
+	return 0
+}
+
+#######################################
+# Get integer CPU% for a single PID (helper for _get_process_tree_cpu)
+#
+# Extracts %CPU via ps, truncates to integer, validates numeric.
+# Returns 0 if the process doesn't exist or ps fails.
+#
+# Arguments:
+#   $1 - PID
+# Returns: integer CPU percentage via stdout
+#######################################
+_get_pid_cpu() {
+	local pid="$1"
+	local cpu_str
+	cpu_str=$(ps -p "$pid" -o %cpu= 2>/dev/null | tr -d ' ') || cpu_str="0"
+	# ps returns float like "12.3" — extract integer part
+	local cpu_int="${cpu_str%%.*}"
+	[[ "$cpu_int" =~ ^[0-9]+$ ]] || cpu_int=0
+	echo "$cpu_int"
+	return 0
+}
+
+#######################################
+# Get CPU usage percentage for a process tree (t1398.3)
+#
+# Iteratively walks the full descendant tree (BFS) using pgrep -P at
+# each level. Previous implementation only checked direct children,
+# missing grandchildren and deeper descendants — this caused incorrect
+# CPU calculations when active processes were nested deeper than one
+# level (e.g., node -> shell -> language-server).
+#
+# Arguments:
+#   $1 - PID
+# Returns: integer CPU percentage via stdout (0-N, summed across cores)
+#######################################
+_get_process_tree_cpu() {
+	local pid="$1"
+	local total_cpu=0
+
+	# Iteratively find the initial PID and all its descendants (BFS).
+	# pgrep -P only returns direct children, so we expand level by level.
+	local pids_to_scan=("$pid")
+	local all_pids=()
+	local i=0
+	while [[ $i -lt ${#pids_to_scan[@]} ]]; do
+		local current_pid="${pids_to_scan[$i]}"
+		all_pids+=("$current_pid")
+		local child
+		while IFS= read -r child; do
+			[[ -n "$child" ]] && pids_to_scan+=("$child")
+		done < <(pgrep -P "$current_pid" 2>/dev/null || true)
+		i=$((i + 1))
+	done
+
+	# Sum CPU for all unique PIDs in the process tree.
+	local p
+	for p in $(printf "%s\n" "${all_pids[@]}" | sort -u); do
+		local cpu
+		cpu=$(_get_pid_cpu "$p")
+		total_cpu=$((total_cpu + cpu))
+	done
+
+	echo "$total_cpu"
+	return 0
+}
+
+# Sanitise untrusted strings before embedding in GitHub markdown comments.
+# Strips @ mentions (prevents unwanted notifications) and backtick sequences
+# (prevents markdown injection). Used for API response data that gets posted
+# as issue/PR comments.
+_sanitize_markdown() {
+	local input="$1"
+	# Remove @ mentions to prevent notification spam
+	input="${input//@/}"
+	# Remove backtick sequences that could break markdown fencing
+	input="${input//\`/}"
+	printf '%s' "$input"
+	return 0
+}
+
+# Sanitise untrusted strings before writing to log files.
+# Strips control characters (newlines, carriage returns, tabs, and non-printable
+# chars) to prevent log injection attacks where a crafted process name could
+# insert fake log entries or mislead administrators. (Gemini review, PR #2881)
+_sanitize_log_field() {
+	local input="$1"
+	# Strip all control characters (ASCII 0x00-0x1F and 0x7F) except space.
+	# The tr octal range is intentional (not a glob).
+	# shellcheck disable=SC2060
+	printf '%s' "$input" | tr -d '\000-\037\177'
+	return 0
+}
+
+#######################################
+# Validate numeric configuration values
+#
+# Prevents command injection via $(( )) expansion. Bash arithmetic
+# evaluates variable contents as expressions, so unsanitised strings
+# like "a[$(cmd)]" would execute arbitrary commands.
+#
+# Arguments:
+#   $1 - variable name (for error messages)
+#   $2 - value to validate
+#   $3 - default value if invalid
+#   $4 - minimum value (optional, default: 0)
+# Returns: validated integer via stdout
+#######################################
+_validate_int() {
+	local name="$1" value="$2" default="$3" min="${4:-0}"
+	if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+		echo "[worker-lifecycle] Invalid ${name}: ${value} — using default ${default}" >&2
+		printf '%s' "$default"
+		return 0
+	fi
+	# Canonicalize to base-10: strip leading zeros to prevent bash octal interpretation
+	# e.g., "08" (invalid octal) or "01024" (octal 532) become "8" and "1024"
+	local canonical
+	canonical=$(printf '%d' "$((10#$value))")
+	# Enforce minimum to prevent divide-by-zero for divisor-backed settings
+	if ((canonical < min)); then
+		echo "[worker-lifecycle] ${name}=${canonical} below minimum ${min} — using default ${default}" >&2
+		printf '%s' "$default"
+		return 0
+	fi
+	printf '%s' "$canonical"
+	return 0
+}
+
+#######################################
+# Compute struggle ratio for a single worker (t1367)
+#
+# struggle_ratio = messages / max(1, commits)
+# High ratio with elapsed time indicates a worker that is active but
+# not producing useful output (thrashing). This is an informational
+# signal — the supervisor LLM decides what to do with it.
+#
+# Arguments:
+#   $1 - worker PID
+#   $2 - worker elapsed seconds
+#   $3 - worker command line
+# Output: "ratio|commits|messages|flag" to stdout
+#   flag: "" (normal), "struggling", or "thrashing"
+#######################################
+_compute_struggle_ratio() {
+	local pid="$1"
+	local elapsed_seconds="$2"
+	local cmd="$3"
+
+	local threshold="${STRUGGLE_RATIO_THRESHOLD:-30}"
+	local min_elapsed="${STRUGGLE_MIN_ELAPSED_MINUTES:-30}"
+	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=30
+	[[ "$min_elapsed" =~ ^[0-9]+$ ]] || min_elapsed=30
+	local min_elapsed_seconds=$((min_elapsed * 60))
+
+	# Extract --dir from command line
+	local worktree_dir=""
+	if [[ "$cmd" =~ --dir[[:space:]]+([^[:space:]]+) ]]; then
+		worktree_dir="${BASH_REMATCH[1]}"
+	fi
+
+	# No worktree — can't compute
+	if [[ -z "$worktree_dir" || ! -d "$worktree_dir" ]]; then
+		echo "n/a|0|0|"
+		return 0
+	fi
+
+	# Count commits since worker start
+	local commits=0
+	if [[ -d "${worktree_dir}/.git" || -f "${worktree_dir}/.git" ]]; then
+		local since_seconds_ago="${elapsed_seconds}"
+		commits=$(git -C "$worktree_dir" log --oneline --since="${since_seconds_ago} seconds ago" 2>/dev/null | wc -l | tr -d ' ') || commits=0
+	fi
+
+	# Estimate message count from OpenCode session DB
+	local messages=0
+	local db_path="${HOME}/.local/share/opencode/opencode.db"
+
+	if [[ -f "$db_path" ]]; then
+		# Extract title from command to match session
+		local session_title=""
+		if [[ "$cmd" =~ --title[[:space:]]+\"([^\"]+)\" ]] || [[ "$cmd" =~ --title[[:space:]]+([^[:space:]]+) ]]; then
+			session_title="${BASH_REMATCH[1]}"
+		fi
+
+		if [[ -n "$session_title" ]]; then
+			# Query message count for the most recent session matching this title
+			# Use sqlite3 with a LIKE match on session title
+			local escaped_title="${session_title//\'/\'\'}"
+			messages=$(sqlite3 "$db_path" "
+				SELECT COUNT(*)
+				FROM message m
+				JOIN session s ON m.session_id = s.id
+				WHERE s.title LIKE '%${escaped_title}%'
+				AND s.time_created > strftime('%s', 'now') - ${elapsed_seconds}
+			" 2>/dev/null) || messages=0
+		fi
+	fi
+
+	# Fallback: estimate from elapsed time if DB query failed
+	# Conservative heuristic: ~2 messages per minute for an active worker
+	if [[ "$messages" -eq 0 && "$elapsed_seconds" -gt 300 ]]; then
+		local elapsed_minutes=$((elapsed_seconds / 60))
+		messages=$((elapsed_minutes * 2))
+	fi
+
+	# Compute ratio
+	local denominator=$((commits > 0 ? commits : 1))
+	local ratio=$((messages / denominator))
+
+	# Determine flag
+	local flag=""
+	if [[ "$elapsed_seconds" -ge "$min_elapsed_seconds" ]]; then
+		if [[ "$ratio" -gt 50 && "$elapsed_seconds" -ge 3600 ]]; then
+			flag="thrashing"
+		elif [[ "$ratio" -gt "$threshold" && "$commits" -eq 0 ]]; then
+			flag="struggling"
+		fi
+	fi
+
+	echo "${ratio}|${commits}|${messages}|${flag}"
+	return 0
+}
+
+#######################################
+# Format seconds into human-readable duration
+# Arguments:
+#   $1 - seconds
+# Returns: formatted string via stdout (e.g., "2h 15m", "45m 30s")
+#######################################
+_format_duration() {
+	local total_seconds="$1"
+	[[ "$total_seconds" =~ ^[0-9]+$ ]] || total_seconds=0
+
+	local hours=$((total_seconds / 3600))
+	local minutes=$(((total_seconds % 3600) / 60))
+	local seconds=$((total_seconds % 60))
+
+	if [[ "$hours" -gt 0 ]]; then
+		echo "${hours}h ${minutes}m"
+	elif [[ "$minutes" -gt 0 ]]; then
+		echo "${minutes}m ${seconds}s"
+	else
+		echo "${seconds}s"
+	fi
+	return 0
+}

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -34,6 +34,7 @@
 #   WORKER_MAX_RUNTIME           Hard ceiling in seconds (default: 10800 = 3h)
 #   WORKER_DRY_RUN               Set to "true" to log but not kill (default: false)
 #   WORKER_WATCHDOG_NOTIFY       Set to "false" to disable macOS notifications
+#   WORKER_PROCESS_PATTERN       CLI name to match (default: opencode)
 
 set -euo pipefail
 
@@ -58,6 +59,7 @@ WORKER_PROGRESS_TIMEOUT="${WORKER_PROGRESS_TIMEOUT:-600}"   # 10 min no log outp
 WORKER_MAX_RUNTIME="${WORKER_MAX_RUNTIME:-10800}"           # 3 hour hard ceiling
 WORKER_DRY_RUN="${WORKER_DRY_RUN:-false}"
 WORKER_WATCHDOG_NOTIFY="${WORKER_WATCHDOG_NOTIFY:-true}"
+WORKER_PROCESS_PATTERN="${WORKER_PROCESS_PATTERN:-opencode}" # CLI name to match (update if CLI changes)
 
 # Validate numeric config
 WORKER_IDLE_TIMEOUT=$(_validate_int WORKER_IDLE_TIMEOUT "$WORKER_IDLE_TIMEOUT" 300 60)
@@ -113,30 +115,29 @@ notify() {
 #######################################
 # Find all headless worker processes
 #
-# Workers are identified by: opencode processes running with /full-loop
-# in their command line (headless dispatch pattern).
+# Workers are identified by: processes matching WORKER_PROCESS_PATTERN
+# running with /full-loop in their command line (headless dispatch pattern).
 #
 # Output: one line per worker: "PID|ELAPSED_SECS|COMMAND"
 #######################################
 find_workers() {
-	# Match opencode processes with /full-loop (headless workers)
-	# Exclude grep itself and this script
-	local workers=""
+	# Match worker processes with /full-loop (headless workers)
+	# Build grep pattern: bracket-trick on first char excludes grep from results
+	local pattern_char="${WORKER_PROCESS_PATTERN:0:1}"
+	local pattern_rest="${WORKER_PROCESS_PATTERN:1}"
+	local grep_pattern="[${pattern_char}]${pattern_rest}"
 	local line pid cmd elapsed_seconds
 
 	while IFS= read -r line; do
 		[[ -z "$line" ]] && continue
-		# Skip grep/watchdog processes
-		[[ "$line" == *"grep"* ]] && continue
+		# Skip watchdog processes
 		[[ "$line" == *"worker-watchdog"* ]] && continue
 
-		# Extract PID (first field)
-		pid=$(echo "$line" | awk '{print $1}')
+		# Extract PID (first field) and command (rest of line)
+		pid="${line%%[[:space:]]*}"
+		cmd="${line#*[[:space:]]}"
 		[[ -z "$pid" ]] && continue
 		[[ "$pid" =~ ^[0-9]+$ ]] || continue
-
-		# Get full command
-		cmd=$(ps -p "$pid" -o command= 2>/dev/null) || continue
 		[[ -z "$cmd" ]] && continue
 
 		# Get elapsed time
@@ -144,7 +145,7 @@ find_workers() {
 
 		# Output: PID|ELAPSED|COMMAND
 		echo "${pid}|${elapsed_seconds}|${cmd}"
-	done < <(ps axo pid,command 2>/dev/null | grep '[o]pencode' | grep '/full-loop' || true)
+	done < <(ps axo pid,command 2>/dev/null | grep "$grep_pattern" | grep '/full-loop' || true)
 
 	return 0
 }
@@ -737,6 +738,7 @@ Environment variables:
   WORKER_MAX_RUNTIME           Hard runtime ceiling (default: 10800s = 3h)
   WORKER_DRY_RUN               Log but don't kill (default: false)
   WORKER_WATCHDOG_NOTIFY       macOS notifications (default: true)
+  WORKER_PROCESS_PATTERN       CLI name to match (default: opencode)
 HELP
 	return 0
 }

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -1,0 +1,774 @@
+#!/usr/bin/env bash
+# worker-watchdog.sh — Detect and kill hung/idle headless AI workers (t1419)
+#
+# Solves: Headless workers dispatched manually (outside the pulse supervisor)
+# have no monitoring. Workers that crash, hang, or enter the OpenCode idle-state
+# bug sit indefinitely consuming resources and blocking issue re-dispatch.
+#
+# Three failure modes detected:
+#   1. CPU idle: Worker completed but sits in file-watcher (OpenCode idle bug).
+#      Signal: tree CPU < WORKER_IDLE_CPU_THRESHOLD for WORKER_IDLE_TIMEOUT.
+#   2. Progress stall: Worker is running but producing no output (stuck on API,
+#      rate-limited, spinning). Signal: no log growth for WORKER_PROGRESS_TIMEOUT.
+#   3. Runtime ceiling: Worker has been running too long regardless of activity.
+#      Signal: elapsed > WORKER_MAX_RUNTIME. Prevents infinite loops.
+#
+# On kill:
+#   - Posts a comment on the associated GitHub issue explaining the kill reason
+#   - Removes the worker's status:in-progress label
+#   - Adds status:available label so the issue is re-queued for dispatch
+#   - Logs the action to the watchdog log file
+#
+# Usage:
+#   worker-watchdog.sh                  # Single check (for launchd)
+#   worker-watchdog.sh --check          # Same as above
+#   worker-watchdog.sh --status         # Show current worker state
+#   worker-watchdog.sh --install        # Install launchd plist (runs every 120s)
+#   worker-watchdog.sh --uninstall      # Remove launchd plist
+#   worker-watchdog.sh --help           # Show usage
+#
+# Environment:
+#   WORKER_IDLE_TIMEOUT          Seconds of low CPU before kill (default: 300)
+#   WORKER_IDLE_CPU_THRESHOLD    CPU% below this = idle (default: 5)
+#   WORKER_PROGRESS_TIMEOUT      Seconds without log growth = stuck (default: 600)
+#   WORKER_MAX_RUNTIME           Hard ceiling in seconds (default: 10800 = 3h)
+#   WORKER_DRY_RUN               Set to "true" to log but not kill (default: false)
+#   WORKER_WATCHDOG_NOTIFY       Set to "false" to disable macOS notifications
+
+set -euo pipefail
+
+#######################################
+# PATH normalisation
+#######################################
+export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
+
+#######################################
+# Configuration
+#######################################
+readonly SCRIPT_NAME="worker-watchdog"
+readonly SCRIPT_VERSION="1.0.0"
+
+WORKER_IDLE_TIMEOUT="${WORKER_IDLE_TIMEOUT:-300}"           # 5 min idle = completed, sitting in file watcher
+WORKER_IDLE_CPU_THRESHOLD="${WORKER_IDLE_CPU_THRESHOLD:-5}" # CPU% below this = idle
+WORKER_PROGRESS_TIMEOUT="${WORKER_PROGRESS_TIMEOUT:-600}"   # 10 min no log output = stuck
+WORKER_MAX_RUNTIME="${WORKER_MAX_RUNTIME:-10800}"           # 3 hour hard ceiling
+WORKER_DRY_RUN="${WORKER_DRY_RUN:-false}"
+WORKER_WATCHDOG_NOTIFY="${WORKER_WATCHDOG_NOTIFY:-true}"
+
+# Validate numeric config
+WORKER_IDLE_TIMEOUT=$(_validate_int WORKER_IDLE_TIMEOUT "$WORKER_IDLE_TIMEOUT" 300 60)
+WORKER_IDLE_CPU_THRESHOLD=$(_validate_int WORKER_IDLE_CPU_THRESHOLD "$WORKER_IDLE_CPU_THRESHOLD" 5)
+WORKER_PROGRESS_TIMEOUT=$(_validate_int WORKER_PROGRESS_TIMEOUT "$WORKER_PROGRESS_TIMEOUT" 600 120)
+WORKER_MAX_RUNTIME=$(_validate_int WORKER_MAX_RUNTIME "$WORKER_MAX_RUNTIME" 10800 600)
+
+# Paths
+readonly LOG_DIR="${HOME}/.aidevops/logs"
+readonly LOG_FILE="${LOG_DIR}/worker-watchdog.log"
+readonly STATE_DIR="${HOME}/.aidevops/.agent-workspace/tmp"
+readonly IDLE_STATE_DIR="${STATE_DIR}/worker-idle-tracking"
+
+readonly LAUNCHD_LABEL="sh.aidevops.worker-watchdog"
+readonly PLIST_PATH="${HOME}/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
+
+#######################################
+# Ensure directories exist
+#######################################
+ensure_dirs() {
+	mkdir -p "$LOG_DIR" "$STATE_DIR" "$IDLE_STATE_DIR" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Log a message with timestamp
+# Arguments:
+#   $1 - message
+#######################################
+log_msg() {
+	local msg="$1"
+	local timestamp
+	timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+	echo "[${timestamp}] [${SCRIPT_NAME}] ${msg}" >>"$LOG_FILE"
+	return 0
+}
+
+#######################################
+# Send macOS notification
+# Arguments:
+#   $1 - title
+#   $2 - message
+#######################################
+notify() {
+	local title="$1"
+	local message="$2"
+	if [[ "$WORKER_WATCHDOG_NOTIFY" == "true" ]] && command -v osascript &>/dev/null; then
+		osascript -e "display notification \"${message}\" with title \"${title}\"" 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
+# Find all headless worker processes
+#
+# Workers are identified by: opencode processes running with /full-loop
+# in their command line (headless dispatch pattern).
+#
+# Output: one line per worker: "PID|ELAPSED_SECS|COMMAND"
+#######################################
+find_workers() {
+	# Match opencode processes with /full-loop (headless workers)
+	# Exclude grep itself and this script
+	local workers=""
+	local line pid cmd elapsed_seconds
+
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		# Skip grep/watchdog processes
+		[[ "$line" == *"grep"* ]] && continue
+		[[ "$line" == *"worker-watchdog"* ]] && continue
+
+		# Extract PID (first field)
+		pid=$(echo "$line" | awk '{print $1}')
+		[[ -z "$pid" ]] && continue
+		[[ "$pid" =~ ^[0-9]+$ ]] || continue
+
+		# Get full command
+		cmd=$(ps -p "$pid" -o command= 2>/dev/null) || continue
+		[[ -z "$cmd" ]] && continue
+
+		# Get elapsed time
+		elapsed_seconds=$(_get_process_age "$pid")
+
+		# Output: PID|ELAPSED|COMMAND
+		echo "${pid}|${elapsed_seconds}|${cmd}"
+	done < <(ps axo pid,command 2>/dev/null | grep '[o]pencode' | grep '/full-loop' || true)
+
+	return 0
+}
+
+#######################################
+# Extract issue number from worker command line
+#
+# Workers are dispatched with commands like:
+#   opencode run --title "Issue #42: Fix auth" "/full-loop Implement issue #42 ..."
+#
+# Arguments:
+#   $1 - command line string
+# Output: issue number or empty string
+#######################################
+extract_issue_number() {
+	local cmd="$1"
+
+	# Try patterns: "Issue #NNN", "issue #NNN", "#NNN:", "GH#NNN"
+	if [[ "$cmd" =~ [Ii]ssue[[:space:]]+#([0-9]+) ]]; then
+		echo "${BASH_REMATCH[1]}"
+	elif [[ "$cmd" =~ GH#([0-9]+) ]]; then
+		echo "${BASH_REMATCH[1]}"
+	elif [[ "$cmd" =~ \#([0-9]+): ]]; then
+		echo "${BASH_REMATCH[1]}"
+	else
+		echo ""
+	fi
+	return 0
+}
+
+#######################################
+# Extract repo slug from worker command line
+#
+# Workers are dispatched with --dir pointing to a worktree.
+# We resolve the repo slug from the git remote.
+#
+# Arguments:
+#   $1 - command line string
+# Output: owner/repo slug or empty string
+#######################################
+extract_repo_slug() {
+	local cmd="$1"
+
+	# Extract --dir from command line
+	local worktree_dir=""
+	if [[ "$cmd" =~ --dir[[:space:]]+([^[:space:]]+) ]]; then
+		worktree_dir="${BASH_REMATCH[1]}"
+	fi
+
+	if [[ -z "$worktree_dir" || ! -d "$worktree_dir" ]]; then
+		echo ""
+		return 0
+	fi
+
+	# Get remote URL and extract slug
+	local remote_url
+	remote_url=$(git -C "$worktree_dir" remote get-url origin 2>/dev/null) || remote_url=""
+
+	if [[ -z "$remote_url" ]]; then
+		echo ""
+		return 0
+	fi
+
+	# Parse slug from SSH or HTTPS URL
+	local slug=""
+	if [[ "$remote_url" =~ github\.com[:/]([^/]+/[^/.]+) ]]; then
+		slug="${BASH_REMATCH[1]}"
+		# Remove .git suffix if present
+		slug="${slug%.git}"
+	fi
+
+	echo "$slug"
+	return 0
+}
+
+#######################################
+# Check if a worker is idle (CPU below threshold)
+#
+# Tracks consecutive idle checks via state files. A worker is only
+# killed after being idle for WORKER_IDLE_TIMEOUT seconds, not on
+# a single low-CPU reading.
+#
+# Arguments:
+#   $1 - PID
+#   $2 - current tree CPU%
+# Returns: 0 if idle long enough to kill, 1 if not yet
+#######################################
+check_idle() {
+	local pid="$1"
+	local tree_cpu="$2"
+	local idle_file="${IDLE_STATE_DIR}/idle-${pid}"
+
+	if [[ "$tree_cpu" -lt "$WORKER_IDLE_CPU_THRESHOLD" ]]; then
+		# Worker is idle — track when idle started
+		if [[ ! -f "$idle_file" ]]; then
+			date +%s >"$idle_file"
+			return 1
+		fi
+
+		local idle_since
+		idle_since=$(cat "$idle_file" 2>/dev/null || echo "0")
+		[[ "$idle_since" =~ ^[0-9]+$ ]] || idle_since=0
+
+		local now
+		now=$(date +%s)
+		local idle_duration=$((now - idle_since))
+
+		if [[ "$idle_duration" -ge "$WORKER_IDLE_TIMEOUT" ]]; then
+			return 0 # Idle long enough — kill
+		fi
+		return 1
+	else
+		# Worker is active — reset idle tracking
+		rm -f "$idle_file" 2>/dev/null || true
+		return 1
+	fi
+}
+
+#######################################
+# Check if a worker's log output has stalled
+#
+# Uses the OpenCode session DB to check for recent messages.
+# Falls back to checking process tree CPU if DB is unavailable.
+#
+# Arguments:
+#   $1 - PID
+#   $2 - command line
+#   $3 - elapsed seconds
+# Returns: 0 if stalled, 1 if making progress
+#######################################
+check_progress_stall() {
+	local pid="$1"
+	local cmd="$2"
+	local elapsed_seconds="$3"
+	local stall_file="${IDLE_STATE_DIR}/stall-${pid}"
+
+	# Skip progress check for very young workers (< 10 min)
+	if [[ "$elapsed_seconds" -lt 600 ]]; then
+		rm -f "$stall_file" 2>/dev/null || true
+		return 1
+	fi
+
+	# Check OpenCode session DB for recent messages
+	local db_path="${HOME}/.local/share/opencode/opencode.db"
+	local has_recent_activity=false
+
+	if [[ -f "$db_path" ]]; then
+		local session_title=""
+		if [[ "$cmd" =~ --title[[:space:]]+\"([^\"]+)\" ]] || [[ "$cmd" =~ --title[[:space:]]+([^[:space:]]+) ]]; then
+			session_title="${BASH_REMATCH[1]}"
+		fi
+
+		if [[ -n "$session_title" ]]; then
+			local escaped_title="${session_title//\'/\'\'}"
+			local recent_count
+			recent_count=$(sqlite3 "$db_path" "
+				SELECT COUNT(*)
+				FROM message m
+				JOIN session s ON m.session_id = s.id
+				WHERE s.title LIKE '%${escaped_title}%'
+				AND m.created_at > datetime('now', '-${WORKER_PROGRESS_TIMEOUT} seconds')
+			" 2>/dev/null) || recent_count=0
+
+			if [[ "$recent_count" -gt 0 ]]; then
+				has_recent_activity=true
+			fi
+		fi
+	fi
+
+	if [[ "$has_recent_activity" == "true" ]]; then
+		# Activity detected — reset stall tracking
+		rm -f "$stall_file" 2>/dev/null || true
+		return 1
+	fi
+
+	# No recent activity — track when stall started
+	if [[ ! -f "$stall_file" ]]; then
+		date +%s >"$stall_file"
+		return 1
+	fi
+
+	local stall_since
+	stall_since=$(cat "$stall_file" 2>/dev/null || echo "0")
+	[[ "$stall_since" =~ ^[0-9]+$ ]] || stall_since=0
+
+	local now
+	now=$(date +%s)
+	local stall_duration=$((now - stall_since))
+
+	if [[ "$stall_duration" -ge "$WORKER_PROGRESS_TIMEOUT" ]]; then
+		return 0 # Stalled long enough — kill
+	fi
+	return 1
+}
+
+#######################################
+# Kill a worker and handle cleanup
+#
+# Arguments:
+#   $1 - PID
+#   $2 - reason (idle|stall|runtime)
+#   $3 - command line
+#   $4 - elapsed seconds
+#######################################
+kill_worker() {
+	local pid="$1"
+	local reason="$2"
+	local cmd="$3"
+	local elapsed_seconds="$4"
+
+	local duration
+	duration=$(_format_duration "$elapsed_seconds")
+	local sanitized_cmd
+	sanitized_cmd=$(_sanitize_log_field "$cmd")
+
+	if [[ "$WORKER_DRY_RUN" == "true" ]]; then
+		log_msg "DRY RUN: Would kill worker PID=${pid} reason=${reason} elapsed=${duration} cmd=${sanitized_cmd}"
+		echo "  DRY RUN: Would kill PID ${pid} (${reason}, running ${duration})"
+		return 0
+	fi
+
+	log_msg "Killing worker PID=${pid} reason=${reason} elapsed=${duration} cmd=${sanitized_cmd}"
+
+	# Graceful kill first
+	_kill_tree "$pid" || true
+	sleep 2
+
+	# Force kill if still alive
+	if kill -0 "$pid" 2>/dev/null; then
+		_force_kill_tree "$pid" || true
+		log_msg "Force-killed worker PID=${pid}"
+	fi
+
+	# Clean up idle/stall tracking files
+	rm -f "${IDLE_STATE_DIR}/idle-${pid}" "${IDLE_STATE_DIR}/stall-${pid}" 2>/dev/null || true
+
+	# Post-kill: update GitHub issue labels and comment
+	post_kill_github_update "$cmd" "$reason" "$duration"
+
+	# Notify
+	notify "Worker Watchdog" "Killed worker (${reason}) after ${duration}"
+
+	return 0
+}
+
+#######################################
+# Post-kill GitHub issue update
+#
+# Comments on the issue and swaps labels so the issue is re-queued.
+#
+# Arguments:
+#   $1 - command line
+#   $2 - kill reason
+#   $3 - formatted duration
+#######################################
+post_kill_github_update() {
+	local cmd="$1"
+	local reason="$2"
+	local duration="$3"
+
+	# Extract issue number and repo slug
+	local issue_number
+	issue_number=$(extract_issue_number "$cmd")
+	local repo_slug
+	repo_slug=$(extract_repo_slug "$cmd")
+
+	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
+		log_msg "Cannot update GitHub: issue=${issue_number:-unknown} repo=${repo_slug:-unknown}"
+		return 0
+	fi
+
+	# Map reason to human-readable description
+	local reason_desc=""
+	case "$reason" in
+	idle) reason_desc="Worker process became idle (CPU below ${WORKER_IDLE_CPU_THRESHOLD}% for ${WORKER_IDLE_TIMEOUT}s) — likely completed or hit the OpenCode idle-state bug." ;;
+	stall) reason_desc="Worker stopped producing output for ${WORKER_PROGRESS_TIMEOUT}s — likely stuck on API rate limiting or an unrecoverable error." ;;
+	runtime) reason_desc="Worker exceeded the ${duration} runtime ceiling — killed to prevent infinite loops." ;;
+	*) reason_desc="Worker killed by watchdog (reason: ${reason})." ;;
+	esac
+
+	# Post comment
+	local comment_body="## Worker Watchdog Kill
+
+**Reason:** ${reason_desc}
+
+**Runtime:** ${duration}
+
+This issue has been re-labeled \`status:available\` for re-dispatch. The next pulse or manual dispatch will pick it up.
+
+_Automated by \`worker-watchdog.sh\` (t1419)_"
+
+	if gh issue comment "$issue_number" --repo "$repo_slug" --body "$comment_body" 2>>"$LOG_FILE"; then
+		log_msg "Posted kill comment on ${repo_slug}#${issue_number}"
+	else
+		log_msg "Failed to post comment on ${repo_slug}#${issue_number}"
+	fi
+
+	# Remove in-progress label, add available label
+	gh issue edit "$issue_number" --repo "$repo_slug" \
+		--remove-label "status:in-progress" \
+		--add-label "status:available" 2>>"$LOG_FILE" || {
+		log_msg "Failed to update labels on ${repo_slug}#${issue_number}"
+	}
+
+	return 0
+}
+
+#######################################
+# Main check: scan all workers and apply detection signals
+#######################################
+cmd_check() {
+	ensure_dirs
+
+	local workers
+	workers=$(find_workers)
+
+	if [[ -z "$workers" ]]; then
+		# No workers running — clean up stale tracking files
+		rm -f "${IDLE_STATE_DIR}"/idle-* "${IDLE_STATE_DIR}"/stall-* 2>/dev/null || true
+		return 0
+	fi
+
+	local worker_count=0
+	local killed_count=0
+
+	while IFS='|' read -r pid elapsed_seconds cmd; do
+		[[ -z "$pid" ]] && continue
+		worker_count=$((worker_count + 1))
+
+		local tree_cpu
+		tree_cpu=$(_get_process_tree_cpu "$pid")
+
+		local duration
+		duration=$(_format_duration "$elapsed_seconds")
+
+		# Check 1: Runtime ceiling (highest priority — unconditional kill)
+		if [[ "$elapsed_seconds" -ge "$WORKER_MAX_RUNTIME" ]]; then
+			log_msg "RUNTIME CEILING: PID=${pid} elapsed=${duration} (max=$(_format_duration "$WORKER_MAX_RUNTIME"))"
+			kill_worker "$pid" "runtime" "$cmd" "$elapsed_seconds"
+			killed_count=$((killed_count + 1))
+			continue
+		fi
+
+		# Check 2: CPU idle detection
+		if check_idle "$pid" "$tree_cpu"; then
+			log_msg "IDLE DETECTED: PID=${pid} cpu=${tree_cpu}% elapsed=${duration}"
+			kill_worker "$pid" "idle" "$cmd" "$elapsed_seconds"
+			killed_count=$((killed_count + 1))
+			continue
+		fi
+
+		# Check 3: Progress stall detection
+		if check_progress_stall "$pid" "$cmd" "$elapsed_seconds"; then
+			log_msg "PROGRESS STALL: PID=${pid} elapsed=${duration}"
+			kill_worker "$pid" "stall" "$cmd" "$elapsed_seconds"
+			killed_count=$((killed_count + 1))
+			continue
+		fi
+
+	done <<<"$workers"
+
+	if [[ "$killed_count" -gt 0 ]]; then
+		log_msg "Check complete: ${worker_count} workers scanned, ${killed_count} killed"
+	fi
+
+	# Clean up tracking files for PIDs that no longer exist
+	local tracking_file
+	for tracking_file in "${IDLE_STATE_DIR}"/idle-* "${IDLE_STATE_DIR}"/stall-*; do
+		[[ -f "$tracking_file" ]] || continue
+		local tracked_pid
+		tracked_pid=$(basename "$tracking_file" | sed 's/^idle-//;s/^stall-//')
+		if [[ "$tracked_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$tracked_pid" 2>/dev/null; then
+			rm -f "$tracking_file" 2>/dev/null || true
+		fi
+	done
+
+	return 0
+}
+
+#######################################
+# Status: show current worker state
+#######################################
+cmd_status() {
+	ensure_dirs
+
+	echo "=== Worker Watchdog Status ==="
+	echo ""
+	echo "--- Configuration ---"
+	echo ""
+	echo "  Idle timeout:        $(_format_duration "$WORKER_IDLE_TIMEOUT") (CPU < ${WORKER_IDLE_CPU_THRESHOLD}%)"
+	echo "  Progress timeout:    $(_format_duration "$WORKER_PROGRESS_TIMEOUT")"
+	echo "  Runtime ceiling:     $(_format_duration "$WORKER_MAX_RUNTIME")"
+	echo "  Dry run:             ${WORKER_DRY_RUN}"
+	echo "  Notifications:       ${WORKER_WATCHDOG_NOTIFY}"
+
+	echo ""
+	echo "--- Active Workers ---"
+	echo ""
+
+	local workers
+	workers=$(find_workers)
+
+	if [[ -z "$workers" ]]; then
+		echo "  No headless workers running"
+	else
+		local count=0
+		while IFS='|' read -r pid elapsed_seconds cmd; do
+			[[ -z "$pid" ]] && continue
+			count=$((count + 1))
+
+			local tree_cpu
+			tree_cpu=$(_get_process_tree_cpu "$pid")
+			local duration
+			duration=$(_format_duration "$elapsed_seconds")
+			local issue_number
+			issue_number=$(extract_issue_number "$cmd")
+			local repo_slug
+			repo_slug=$(extract_repo_slug "$cmd")
+
+			echo "  Worker #${count}:"
+			echo "    PID:      ${pid}"
+			echo "    Runtime:  ${duration}"
+			echo "    Tree CPU: ${tree_cpu}%"
+			[[ -n "$issue_number" ]] && echo "    Issue:    ${repo_slug:-unknown}#${issue_number}"
+
+			# Show idle tracking state
+			if [[ -f "${IDLE_STATE_DIR}/idle-${pid}" ]]; then
+				local idle_since
+				idle_since=$(cat "${IDLE_STATE_DIR}/idle-${pid}" 2>/dev/null || echo "0")
+				local now
+				now=$(date +%s)
+				local idle_for=$((now - idle_since))
+				echo "    Idle for: $(_format_duration "$idle_for") / $(_format_duration "$WORKER_IDLE_TIMEOUT")"
+			fi
+
+			# Show stall tracking state
+			if [[ -f "${IDLE_STATE_DIR}/stall-${pid}" ]]; then
+				local stall_since
+				stall_since=$(cat "${IDLE_STATE_DIR}/stall-${pid}" 2>/dev/null || echo "0")
+				local now
+				now=$(date +%s)
+				local stall_for=$((now - stall_since))
+				echo "    Stalled:  $(_format_duration "$stall_for") / $(_format_duration "$WORKER_PROGRESS_TIMEOUT")"
+			fi
+
+			# Struggle ratio
+			local sr_result
+			sr_result=$(_compute_struggle_ratio "$pid" "$elapsed_seconds" "$cmd")
+			local sr_ratio sr_commits sr_messages sr_flag
+			IFS='|' read -r sr_ratio sr_commits sr_messages sr_flag <<<"$sr_result"
+			if [[ "$sr_ratio" != "n/a" ]]; then
+				echo "    Struggle: ratio=${sr_ratio} commits=${sr_commits} messages=${sr_messages} ${sr_flag:+[${sr_flag}]}"
+			fi
+
+			echo ""
+		done <<<"$workers"
+		echo "  Total: ${count} worker(s)"
+	fi
+
+	echo ""
+	echo "--- Launchd ---"
+	echo ""
+	if [[ -f "${PLIST_PATH}" ]]; then
+		if launchctl list 2>/dev/null | grep -q "${LAUNCHD_LABEL}"; then
+			echo "  Status: installed and loaded"
+		else
+			echo "  Status: installed but NOT loaded"
+		fi
+	else
+		echo "  Status: not installed (run --install)"
+	fi
+
+	echo ""
+	return 0
+}
+
+#######################################
+# Install launchd plist
+#######################################
+cmd_install() {
+	local script_path
+	script_path="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+	local installed_path="${HOME}/.aidevops/agents/scripts/${SCRIPT_NAME}.sh"
+	if [[ -x "${installed_path}" ]]; then
+		script_path="${installed_path}"
+	fi
+
+	ensure_dirs
+	mkdir -p "$(dirname "${PLIST_PATH}")"
+
+	local home_escaped="${HOME}"
+
+	cat >"${PLIST_PATH}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${LAUNCHD_LABEL}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>${script_path}</string>
+		<string>--check</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>120</integer>
+	<key>StandardOutPath</key>
+	<string>${home_escaped}/.aidevops/logs/worker-watchdog-launchd.log</string>
+	<key>StandardErrorPath</key>
+	<string>${home_escaped}/.aidevops/logs/worker-watchdog-launchd.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<key>HOME</key>
+		<string>${home_escaped}</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityBackgroundIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+</dict>
+</plist>
+EOF
+
+	launchctl bootout "gui/$(id -u)" "${PLIST_PATH}" 2>/dev/null || true
+	launchctl bootstrap "gui/$(id -u)" "${PLIST_PATH}"
+
+	echo "Installed and loaded: ${LAUNCHD_LABEL}"
+	echo "Plist: ${PLIST_PATH}"
+	echo "Log: ${LOG_FILE}"
+	echo "Check interval: 120 seconds"
+	return 0
+}
+
+#######################################
+# Uninstall launchd plist
+#######################################
+cmd_uninstall() {
+	if [[ -f "${PLIST_PATH}" ]]; then
+		launchctl bootout "gui/$(id -u)" "${PLIST_PATH}" 2>/dev/null || true
+		rm -f "${PLIST_PATH}"
+		echo "Uninstalled: ${LAUNCHD_LABEL}"
+	else
+		echo "Not installed"
+	fi
+
+	# Clean up state files
+	rm -rf "${IDLE_STATE_DIR}" 2>/dev/null || true
+	echo "Cleaned up state files"
+	return 0
+}
+
+#######################################
+# Help
+#######################################
+cmd_help() {
+	cat <<HELP
+Usage: ${SCRIPT_NAME}.sh [COMMAND]
+
+Commands:
+  --check, -c       Single check (default, for launchd)
+  --status, -s      Show current worker state
+  --install, -i     Install launchd plist (runs every 120s)
+  --uninstall, -u   Remove launchd plist and state files
+  --help, -h        Show this help
+
+Detection signals:
+  CPU idle:         Tree CPU < ${WORKER_IDLE_CPU_THRESHOLD}% for $(_format_duration "$WORKER_IDLE_TIMEOUT")
+  Progress stall:   No session messages for $(_format_duration "$WORKER_PROGRESS_TIMEOUT")
+  Runtime ceiling:  Hard kill after $(_format_duration "$WORKER_MAX_RUNTIME")
+
+On kill:
+  - Posts comment on associated GitHub issue
+  - Removes status:in-progress label
+  - Adds status:available label for re-dispatch
+  - Logs to ${LOG_FILE}
+
+Environment variables:
+  WORKER_IDLE_TIMEOUT          Idle detection window (default: 300s)
+  WORKER_IDLE_CPU_THRESHOLD    CPU% idle threshold (default: 5)
+  WORKER_PROGRESS_TIMEOUT      Stall detection window (default: 600s)
+  WORKER_MAX_RUNTIME           Hard runtime ceiling (default: 10800s = 3h)
+  WORKER_DRY_RUN               Log but don't kill (default: false)
+  WORKER_WATCHDOG_NOTIFY       macOS notifications (default: true)
+HELP
+	return 0
+}
+
+#######################################
+# Main
+#######################################
+main() {
+	local cmd="${1:-check}"
+
+	case "${cmd}" in
+	--check | -c | check)
+		cmd_check
+		;;
+	--status | -s | status)
+		cmd_status
+		;;
+	--install | -i | install)
+		cmd_install
+		;;
+	--uninstall | -u | uninstall)
+		cmd_uninstall
+		;;
+	--help | -h | help)
+		cmd_help
+		;;
+	*)
+		echo "Unknown command: ${cmd}" >&2
+		echo "Run with --help for usage" >&2
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -217,6 +217,33 @@ opencode run --attach http://localhost:4096 --title "Docs" \
 wait  # Wait for all to complete
 ```
 
+### Stagger Protection for Manual Dispatch (t1419)
+
+When dispatching multiple workers manually (outside the pulse supervisor), **stagger launches by 30-60 seconds** to avoid thundering herd resource contention. Simultaneous cold boots cause:
+
+- **RAM exhaustion**: Each worker spawns Node.js + language servers + MCP servers. 6 simultaneous startups can consume 6+ GB in the first 60 seconds.
+- **API rate limiting**: Multiple workers hitting the same API provider simultaneously trigger rate limits, causing buffering and eventual stalls.
+- **MCP cold boot storms**: MCP servers (especially Node-based ones) have expensive startup. Concurrent initialization competes for CPU and I/O.
+
+```bash
+# WRONG: Thundering herd — all 4 workers cold-boot simultaneously
+for issue in 42 43 44 45; do
+  opencode run --dir ~/Git/myproject --title "Issue #${issue}" \
+    "/full-loop Implement issue #${issue}" &
+done
+
+# RIGHT: Staggered launch — 30s between each worker
+for issue in 42 43 44 45; do
+  opencode run --dir ~/Git/myproject --title "Issue #${issue}" \
+    "/full-loop Implement issue #${issue}" &
+  sleep 30
+done
+```
+
+The pulse supervisor handles this automatically via its capacity calculation (`RAM_PER_WORKER_MB`, `RAM_RESERVE_MB`, `MAX_WORKERS_CAP`). Manual dispatch bypasses these checks.
+
+**Worker monitoring**: Use `worker-watchdog.sh --status` to check active workers, or install the launchd service (`worker-watchdog.sh --install`) for automatic detection and cleanup of hung/idle workers. See `scripts/worker-watchdog.sh` for details.
+
 ### SDK Parallel (Promise.all)
 
 ```typescript

--- a/todo/tasks/t1419-brief.md
+++ b/todo/tasks/t1419-brief.md
@@ -1,0 +1,45 @@
+# t1419: Standalone Worker Watchdog
+
+## Session Origin
+
+Interactive session. User manually dispatched 6 workers (pulse was disabled). 4 crashed/hung within 5 minutes (thundering herd on MCP cold boot). 1 buffered (API rate limiting). 1 kept working. A second interactive session later hung indefinitely. No automated cleanup existed outside the pulse supervisor.
+
+## What
+
+Create `worker-watchdog.sh` — a standalone launchd service that automatically detects and kills hung/idle headless AI workers, then re-queues their GitHub issues for re-dispatch.
+
+## Why
+
+The pulse supervisor (`pulse-wrapper.sh`) has a sophisticated 3-layer watchdog (wall-clock, CPU idle, progress stall) but ONLY for the pulse process itself. No monitoring exists for independently dispatched workers. When workers crash, hang, or enter the OpenCode idle-state bug, they sit indefinitely consuming resources and blocking issue re-dispatch. This is a systemic gap — the pulse's "Kill stuck workers" section is LLM guidance, not automated enforcement, and only fires when pulse is enabled.
+
+## How
+
+Three deliverables:
+
+1. **`worker-lifecycle-common.sh`** — Extract shared process lifecycle functions from `pulse-wrapper.sh` (`_kill_tree`, `_force_kill_tree`, `_get_process_age`, `_get_pid_cpu`, `_get_process_tree_cpu`, `_sanitize_log_field`, `_sanitize_markdown`, `_validate_int`, `_compute_struggle_ratio`) into a shared library. Update `pulse-wrapper.sh` to source it.
+
+2. **`worker-watchdog.sh`** — Standalone watchdog with three detection signals:
+   - CPU idle: tree CPU < 5% for 5 minutes (catches OpenCode idle-state bug)
+   - Progress stall: no session messages for 10 minutes (catches API rate limiting, stuck workers)
+   - Runtime ceiling: 3-hour hard kill (prevents infinite loops)
+   On kill: posts GitHub issue comment, swaps labels (`status:in-progress` -> `status:available`), logs action.
+   CLI: `--check` (single scan), `--status` (show workers), `--install`/`--uninstall` (launchd plist).
+
+3. **Stagger protection guidance** in `headless-dispatch.md` — Document the thundering herd problem and recommend 30-60s stagger for manual multi-worker dispatch.
+
+## Acceptance Criteria
+
+- [ ] `worker-watchdog.sh --check` scans all headless opencode workers and applies three detection signals
+- [ ] `worker-watchdog.sh --status` shows active workers with CPU, runtime, idle/stall tracking, and struggle ratio
+- [ ] `worker-watchdog.sh --install` creates and loads a launchd plist at `sh.aidevops.worker-watchdog`
+- [ ] `worker-watchdog.sh --uninstall` removes the plist and cleans up state files
+- [ ] On kill: GitHub issue gets a comment explaining the reason and labels are swapped for re-dispatch
+- [ ] `pulse-wrapper.sh` sources `worker-lifecycle-common.sh` and no longer defines the extracted functions inline
+- [ ] ShellCheck passes on all new and modified scripts
+- [ ] `headless-dispatch.md` includes stagger protection guidance with correct/incorrect examples
+
+## Context
+
+- GitHub issue: GH#3918
+- Branch: `feature/t1419-worker-watchdog`
+- Key reference files: `pulse-wrapper.sh` (lines 206-350, 714-792), `memory-pressure-monitor.sh` (launchd CLI pattern), `shared-constants.sh`


### PR DESCRIPTION
## Summary

- Extract shared process lifecycle functions (`_kill_tree`, `_force_kill_tree`, `_get_process_age`, `_get_pid_cpu`, `_get_process_tree_cpu`, `_sanitize_log_field`, `_sanitize_markdown`, `_validate_int`, `_compute_struggle_ratio`) from `pulse-wrapper.sh` into `worker-lifecycle-common.sh` to eliminate duplication
- Create `worker-watchdog.sh` — a standalone launchd service that detects and kills hung/idle headless workers using three signals: CPU idle (5min), progress stall (10min), and runtime ceiling (3h), with automatic GitHub issue re-labeling for re-dispatch
- Add stagger protection guidance to `headless-dispatch.md` to prevent thundering herd resource contention on manual multi-worker dispatch

## Problem

When workers are dispatched manually (pulse disabled), no monitoring exists. Workers that crash, hang, or enter the OpenCode idle-state bug sit indefinitely consuming resources. The pulse supervisor's watchdog only monitors the pulse process itself — not independently dispatched workers.

## Solution

### New files
- **`.agents/scripts/worker-lifecycle-common.sh`** — Shared library with include guard, sourced by both `pulse-wrapper.sh` and `worker-watchdog.sh`
- **`.agents/scripts/worker-watchdog.sh`** — Standalone watchdog with CLI (`--check`, `--status`, `--install`, `--uninstall`, `--help`)
- **`todo/tasks/t1419-brief.md`** — Task brief

### Modified files
- **`.agents/scripts/pulse-wrapper.sh`** — Sources `worker-lifecycle-common.sh`, removes ~293 lines of inline function definitions
- **`.agents/tools/ai-assistants/headless-dispatch.md`** — Adds stagger protection section with correct/incorrect examples

### Detection signals
| Signal | Threshold | Catches |
|--------|-----------|---------|
| CPU idle | Tree CPU < 5% for 5 min | OpenCode idle-state bug |
| Progress stall | No session messages for 10 min | API rate limiting, stuck workers |
| Runtime ceiling | 3 hour hard kill | Infinite loops |

### On kill
1. Posts explanatory comment on the GitHub issue
2. Removes `status:in-progress` label
3. Adds `status:available` label for re-dispatch
4. Logs to `~/.aidevops/logs/worker-watchdog.log`

## Testing

- `bash -n` syntax check passes on all three scripts
- ShellCheck clean (only SC1091 info for external sources)
- `worker-watchdog.sh --help` and `--status` verified working
- `worker-watchdog.sh --check` handles no-workers case cleanly

Closes #3918