### PR TITLE
t1406: Filter out approving reviews from quality-debt issue creation

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -722,12 +722,12 @@ _scan_single_pr() {
 		(if .state == "APPROVED" then
 			($body | test(
 				"\\bshould\\b|\\bconsider\\b|\\binstead\\b|\\bsuggest|\\brecommend|" +
-				"\\bwarning\\b|\\bcaution\\b|\\bavoid\\b|\\bdon.t\\b|\\bdo not\\b|" +
+				"\\bwarning\\b|\\bcaution\\b|\\bavoid\\b|\\b(don ?'?t|do not)\\b|" +
 				"\\bvulnerab|\\binsecure|\\binjection\\b|\\bxss\\b|\\bcsrf\\b|" +
 				"\\bnit:|\\btodo:|\\bfixme|\\bhardcoded|\\bdeprecated|" +
 				"\\brace.condition|\\bdeadlock|\\bleak|\\boverflow|" +
 				"\\bworkaround\\b|\\bhack\\b|" +
-				"```(suggestion|diff)"; "i"))
+				"```\\s*(suggestion|diff)"; "i"))
 		 else true
 		 end) |
 		select(.) |

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -722,7 +722,7 @@ _scan_single_pr() {
 		(if .state == "APPROVED" then
 			($body | test(
 				"\\bshould\\b|\\bconsider\\b|\\binstead\\b|\\bsuggest|\\brecommend|" +
-				"\\bwarning\\b|\\bcaution\\b|\\bavoid\\b|\\b(don ?'?t|do not)\\b|" +
+				"\\bwarning\\b|\\bcaution\\b|\\bavoid\\b|\\b(don ?'"'"'?t|do not)\\b|" +
 				"\\bvulnerab|\\binsecure|\\binjection\\b|\\bxss\\b|\\bcsrf\\b|" +
 				"\\bnit:|\\btodo:|\\bfixme|\\bhardcoded|\\bdeprecated|" +
 				"\\brace.condition|\\bdeadlock|\\bleak|\\boverflow|" +

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -714,8 +714,23 @@ _scan_single_pr() {
 
 		select($sev_num >= $min_num) |
 
-		# Skip approval-only reviews with no substantive body
-		select(.state != "APPROVED" or (.body | length) > 100) |
+		# Filter out approving reviews with no actionable feedback (t1406).
+		# APPROVED reviews from bots often contain long summaries/walkthroughs
+		# that are purely positive — these should not create quality-debt issues.
+		# Keep the review only if: (a) not APPROVED, or (b) body contains
+		# actionable language (suggestions, warnings, bugs, fix proposals).
+		(if .state == "APPROVED" then
+			($body | test(
+				"\\bshould\\b|\\bconsider\\b|\\binstead\\b|\\bsuggest|\\brecommend|" +
+				"\\bwarning\\b|\\bcaution\\b|\\bavoid\\b|\\bdon.t\\b|\\bdo not\\b|" +
+				"\\bvulnerab|\\binsecure|\\binjection\\b|\\bxss\\b|\\bcsrf\\b|" +
+				"\\bnit:|\\btodo:|\\bfixme|\\bhardcoded|\\bdeprecated|" +
+				"\\brace.condition|\\bdeadlock|\\bleak|\\boverflow|" +
+				"\\bworkaround\\b|\\bhack\\b|" +
+				"```(suggestion|diff)"; "i"))
+		 else true
+		 end) |
+		select(.) |
 
 		{
 			pr: ($pr | tonumber),


### PR DESCRIPTION
## Summary

- Replaces the weak body-length filter (`> 100` chars) for APPROVED reviews with content analysis that detects actionable language
- APPROVED reviews without suggestions, warnings, security concerns, or code fix proposals are now excluded from quality-debt issue creation
- Non-APPROVED reviews (CHANGES_REQUESTED, COMMENTED, DISMISSED) are unaffected — always kept

## Problem

`scan-merged` creates quality-debt issues for ALL review feedback, including purely positive APPROVED reviews from bots (CodeRabbit, Gemini). Example false positive: [#3900](https://github.com/marcusquinn/aidevops/issues/3900) — Gemini's review was entirely positive ("well-executed and improve both documentation clarity") but generated a medium-severity quality-debt issue.

The previous filter (`select(.state != "APPROVED" or (.body | length) > 100)`) only skipped APPROVED reviews with short bodies (≤100 chars). Bot reviews typically have 500-2000 char bodies even when purely positive.

## Fix

For APPROVED reviews, scan the body for actionable language patterns before creating a finding:

**Kept (actionable):** should, consider, instead, suggest, recommend, warning, caution, avoid, don't, do not, vulnerable, insecure, injection, xss, csrf, nit:, todo:, fixme, hardcoded, deprecated, race condition, deadlock, leak, overflow, workaround, hack, ` ```suggestion `, ` ```diff `

**Removed from filter (ambiguous in positive context):** bug, error, fix, patch, missing, incorrect, wrong, broken — these commonly appear in positive descriptions of what a PR accomplishes ("This PR fixes the bug", "corrects the error").

## Testing

Verified with jq against 4 scenarios:
1. Purely positive APPROVED review → filtered out (correct)
2. APPROVED with actionable suggestion ("you should consider...") → kept (correct)
3. CHANGES_REQUESTED review → always kept regardless of content (correct)
4. APPROVED with security concern ("vulnerable to injection") → kept (correct)

ShellCheck clean (only SC1091 external source, pre-existing).

Closes #2958