### PR TITLE
feat: show all periods in health dashboard session time

### DIFF
--- a/.agents/scripts/contributor-activity-helper.sh
+++ b/.agents/scripts/contributor-activity-helper.sh
@@ -756,6 +756,57 @@ cross_repo_session_time() {
 		return 1
 	fi
 
+	# Handle --period all: call cross_repo_session_time for each period and combine
+	if [[ "$period" == "all" ]]; then
+		local all_periods=("day" "week" "month" "quarter" "year")
+		local combined_json="["
+		local first_period=true
+		for p in "${all_periods[@]}"; do
+			local p_json
+			p_json=$(cross_repo_session_time "${repo_paths[@]}" --period "$p" --format json) || p_json="{}"
+			if [[ "$first_period" == "true" ]]; then
+				first_period=false
+			else
+				combined_json+=","
+			fi
+			combined_json+="{\"period\":\"${p}\",\"data\":${p_json}}"
+		done
+		combined_json+="]"
+
+		echo "$combined_json" | python3 -c "
+import sys
+import json
+
+format_type = sys.argv[1]
+data = json.load(sys.stdin)
+
+if format_type == 'json':
+    result = {}
+    for entry in data:
+        result[entry['period']] = entry['data']
+    print(json.dumps(result, indent=2))
+else:
+    repo_count = data[0]['data'].get('repo_count', 0) if data else 0
+    if not data or all(d['data'].get('total_sessions', 0) == 0 for d in data):
+        print(f'_No session data across {repo_count} repos._')
+    else:
+        print(f'_Across {repo_count} managed repos:_')
+        print()
+        print('| Period | Interactive | Human Hours | Machine Hours | Workers | Machine Hours |')
+        print('| --- | ---: | ---: | ---: | ---: | ---: |')
+        for entry in data:
+            p = entry['period'].capitalize()
+            d = entry['data']
+            i_sess = d.get('interactive_sessions', 0)
+            i_human = d.get('interactive_human_hours', 0)
+            i_machine = d.get('interactive_machine_hours', 0)
+            w_sess = d.get('worker_sessions', 0)
+            w_machine = d.get('worker_machine_hours', 0)
+            print(f'| {p} | {i_sess} | {i_human}h | {i_machine}h | {w_sess} | {w_machine}h |')
+" "$format"
+		return 0
+	fi
+
 	# Collect JSON from each repo — use jq to assemble a valid JSON array.
 	# This is robust against non-JSON responses from session_time (e.g., error strings).
 	# Skip invalid repo paths to avoid inflating the repo count.

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1689,7 +1689,7 @@ ${worker_table}"
 	local activity_helper="${HOME}/.aidevops/agents/scripts/contributor-activity-helper.sh"
 	if [[ -x "$activity_helper" ]]; then
 		activity_md=$(bash "$activity_helper" summary "$repo_path" --period month --format markdown || echo "_Activity data unavailable._")
-		session_time_md=$(bash "$activity_helper" session-time "$repo_path" --period month --format markdown || echo "_Session data unavailable._")
+		session_time_md=$(bash "$activity_helper" session-time "$repo_path" --period all --format markdown || echo "_Session data unavailable._")
 	else
 		activity_md="_Activity helper not installed._"
 		session_time_md="_Activity helper not installed._"
@@ -1731,11 +1731,11 @@ ${activity_md}
 
 ${cross_repo_md:-_Single repo or cross-repo data unavailable._}
 
-### Session Time (last 30 days)
+### Session Time
 
 ${session_time_md}
 
-### Cross-Repo Session Time (last 30 days)
+### Cross-Repo Session Time
 
 ${cross_repo_session_time_md:-_Single repo or cross-repo session data unavailable._}
 
@@ -1902,7 +1902,7 @@ update_health_issues() {
 			done <<<"$all_repo_paths"
 			if [[ ${#cross_args[@]} -gt 1 ]]; then
 				cross_repo_md=$(bash "$activity_helper" cross-repo-summary "${cross_args[@]}" --period month --format markdown || echo "_Cross-repo data unavailable._")
-				cross_repo_session_time_md=$(bash "$activity_helper" cross-repo-session-time "${cross_args[@]}" --period month --format markdown || echo "_Cross-repo session data unavailable._")
+				cross_repo_session_time_md=$(bash "$activity_helper" cross-repo-session-time "${cross_args[@]}" --period all --format markdown || echo "_Cross-repo session data unavailable._")
 			fi
 		fi
 	fi


### PR DESCRIPTION
## Summary

- Update pulse-wrapper to use `--period all` for session time sections in health dashboard
- Add `--period all` support to `cross_repo_session_time()` 
- Health dashboard now shows day/week/month/quarter/year in one table instead of only "last 30 days"
- Section headers updated from "Session Time (last 30 days)" to "Session Time"

## Before (issue #2645)

```
### Session Time (last 30 days)
| Type | Sessions | Human Hours | Machine Hours |
| Interactive | 1465 | 141.2h | 342.7h |
| Workers/Runners | 1784 | — | 101.4h |
```

## After

```
### Session Time
| Period | Interactive | Human Hours | Machine Hours | Workers | Machine Hours |
| Day | 151 | 6.4h | 25.6h | 188 | 17.8h |
| Week | 322 | 20.5h | 52.7h | 740 | 67.0h |
| Month | 1465 | 142.0h | 342.7h | 1791 | 101.9h |
| Quarter | 1884 | 293.8h | 472.5h | 1792 | 102.2h |
| Year | 1956 | 315.5h | 485.3h | 1792 | 102.2h |
```

## Testing

- `session-time <repo> --period all` ✅
- `cross-repo-session-time <repos> --period all` ✅  
- ShellCheck clean ✅