### PR TITLE
fix: improve health dashboard table clarity and add contributor output section

### DIFF
--- a/.agents/scripts/contributor-activity-helper.sh
+++ b/.agents/scripts/contributor-activity-helper.sh
@@ -544,21 +544,17 @@ else:
     if not data or all(d['data'].get('total_sessions', 0) == 0 for d in data):
         print('_No session data available._')
     else:
-        print('| Period | Interactive | Human Hours | Machine Hours | Workers | Machine Hours |')
+        print('| Period | Human Hours | AI Hours | Total Work | Sessions | Workers |')
         print('| --- | ---: | ---: | ---: | ---: | ---: |')
         for entry in data:
             p = entry['period'].capitalize()
             d = entry['data']
+            human_h = d.get('total_human_hours', 0)
+            ai_h = d.get('total_machine_hours', 0)
+            total_h = round(human_h + ai_h, 1)
             i_sess = d.get('interactive_sessions', 0)
-            i_human = d.get('interactive_human_hours', 0)
-            i_machine = d.get('interactive_machine_hours', 0)
             w_sess = d.get('worker_sessions', 0)
-            w_machine = d.get('worker_machine_hours', 0)
-            print(f'| {p} | {i_sess} | {i_human}h | {i_machine}h | {w_sess} | {w_machine}h |')
-        total = data[-1]['data']  # year is the largest period
-        t_human = total.get('total_human_hours', 0)
-        t_machine = total.get('total_machine_hours', 0)
-        t_sess = total.get('total_sessions', 0)
+            print(f'| {p} | {human_h}h | {ai_h}h | {total_h}h | {i_sess} | {w_sess} |')
 " "$format"
 		return 0
 	fi
@@ -708,11 +704,12 @@ else:
     if total_sessions == 0:
         print(f'_No session data for the last {period_name}._')
     else:
-        print(f'| Type | Sessions | Human Hours | Machine Hours |')
-        print(f'| --- | ---: | ---: | ---: |')
-        print(f'| Interactive | {i[\"count\"]} | {i_human_h}h | {i_machine_h}h |')
-        print(f'| Workers/Runners | {w[\"count\"]} | — | {w_machine_h}h |')
-        print(f'| **Total** | **{total_sessions}** | **{total_human_h}h** | **{total_machine_h}h** |')
+        total_work_h = round(total_human_h + total_machine_h, 1)
+        print(f'| Type | Human Hours | AI Hours | Total Work | Sessions |')
+        print(f'| --- | ---: | ---: | ---: | ---: |')
+        print(f'| Interactive | {i_human_h}h | {i_machine_h}h | {round(i_human_h + i_machine_h, 1)}h | {i[\"count\"]} |')
+        print(f'| Workers/Runners | {w_human_h}h | {w_machine_h}h | {round(w_human_h + w_machine_h, 1)}h | {w[\"count\"]} |')
+        print(f'| **Total** | **{total_human_h}h** | **{total_machine_h}h** | **{total_work_h}h** | **{total_sessions}** |')
 " "$format" "$period"
 
 	return 0
@@ -792,17 +789,17 @@ else:
     else:
         print(f'_Across {repo_count} managed repos:_')
         print()
-        print('| Period | Interactive | Human Hours | Machine Hours | Workers | Machine Hours |')
+        print('| Period | Human Hours | AI Hours | Total Work | Sessions | Workers |')
         print('| --- | ---: | ---: | ---: | ---: | ---: |')
         for entry in data:
             p = entry['period'].capitalize()
             d = entry['data']
+            human_h = d.get('total_human_hours', 0)
+            ai_h = d.get('total_machine_hours', 0)
+            total_h = round(human_h + ai_h, 1)
             i_sess = d.get('interactive_sessions', 0)
-            i_human = d.get('interactive_human_hours', 0)
-            i_machine = d.get('interactive_machine_hours', 0)
             w_sess = d.get('worker_sessions', 0)
-            w_machine = d.get('worker_machine_hours', 0)
-            print(f'| {p} | {i_sess} | {i_human}h | {i_machine}h | {w_sess} | {w_machine}h |')
+            print(f'| {p} | {human_h}h | {ai_h}h | {total_h}h | {i_sess} | {w_sess} |')
 " "$format"
 		return 0
 	fi
@@ -875,12 +872,15 @@ else:
     else:
         print(f'_Across {repo_count} managed repos:_')
         print()
-        print(f'| Type | Sessions | Human Hours | Machine Hours |')
-        print(f'| --- | ---: | ---: | ---: |')
+        total_work_h = round(total_human_h + total_machine_h, 1)
         i = totals
-        print(f'| Interactive | {i[\"interactive_sessions\"]} | {i[\"interactive_human_hours\"]}h | {i[\"interactive_machine_hours\"]}h |')
-        print(f'| Workers/Runners | {i[\"worker_sessions\"]} | — | {i[\"worker_machine_hours\"]}h |')
-        print(f'| **Total** | **{total_sessions}** | **{total_human_h}h** | **{total_machine_h}h** |')
+        i_work = round(i['interactive_human_hours'] + i['interactive_machine_hours'], 1)
+        w_work = round(i['worker_human_hours'] + i['worker_machine_hours'], 1)
+        print(f'| Type | Human Hours | AI Hours | Total Work | Sessions |')
+        print(f'| --- | ---: | ---: | ---: | ---: |')
+        print(f'| Interactive | {i[\"interactive_human_hours\"]}h | {i[\"interactive_machine_hours\"]}h | {i_work}h | {i[\"interactive_sessions\"]} |')
+        print(f'| Workers/Runners | {i[\"worker_human_hours\"]}h | {i[\"worker_machine_hours\"]}h | {w_work}h | {i[\"worker_sessions\"]} |')
+        print(f'| **Total** | **{total_human_h}h** | **{total_machine_h}h** | **{total_work_h}h** | **{total_sessions}** |')
 " "$format" "$period" "$repo_count"
 
 	return 0
@@ -1071,10 +1071,12 @@ else:
     if not data:
         print(f'_No GitHub activity for the last {period_name}._')
     else:
-        print(f'| Contributor | Issues | PRs | Merged | Commented On |')
-        print(f'| --- | ---: | ---: | ---: | ---: |')
+        grand_total = sum(d['total_output'] for d in data) or 1
+        print(f'| Contributor | Issues | PRs | Merged | Commented | % of Total |')
+        print(f'| --- | ---: | ---: | ---: | ---: | ---: |')
         for d in data:
-            print(f'| {d[\"login\"]} | {d[\"issues_created\"]} | {d[\"prs_created\"]} | {d[\"prs_merged\"]} | {d[\"commented_on\"]} |')
+            pct = round(d['total_output'] / grand_total * 100, 1)
+            print(f'| {d[\"login\"]} | {d[\"issues_created\"]} | {d[\"prs_created\"]} | {d[\"prs_merged\"]} | {d[\"commented_on\"]} | {pct}% |')
 " "$format" "$period"
 
 	return 0
@@ -1137,7 +1139,7 @@ cross_repo_person_stats() {
 		if [[ -n "$logins_override" ]]; then
 			extra_args+=(--logins "$logins_override")
 		fi
-		repo_json=$(person_stats "$rp" --period "$period" --format json "${extra_args[@]}") || repo_json="[]"
+		repo_json=$(person_stats "$rp" --period "$period" --format json ${extra_args[@]+"${extra_args[@]}"}) || repo_json="[]"
 		if echo "$repo_json" | jq -e . >/dev/null 2>&1; then
 			all_json+="${repo_json}"$'\n'
 		fi
@@ -1181,10 +1183,12 @@ else:
     else:
         print(f'_Across {repo_count} managed repos:_')
         print()
-        print(f'| Contributor | Issues | PRs | Merged | Commented On |')
-        print(f'| --- | ---: | ---: | ---: | ---: |')
+        grand_total = sum(r['total_output'] for r in results) or 1
+        print(f'| Contributor | Issues | PRs | Merged | Commented | % of Total |')
+        print(f'| --- | ---: | ---: | ---: | ---: | ---: |')
         for r in results:
-            print(f'| {r[\"login\"]} | {r[\"issues_created\"]} | {r[\"prs_created\"]} | {r[\"prs_merged\"]} | {r[\"commented_on\"]} |')
+            pct = round(r['total_output'] / grand_total * 100, 1)
+            print(f'| {r[\"login\"]} | {r[\"issues_created\"]} | {r[\"prs_created\"]} | {r[\"prs_merged\"]} | {r[\"commented_on\"]} | {pct}% |')
 " "$format" "$period" "$repo_count"
 
 	return 0

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1686,13 +1686,16 @@ ${worker_table}"
 	# Session time stats are passed via $4 (also pre-computed once).
 	local activity_md=""
 	local session_time_md=""
+	local person_stats_md=""
 	local activity_helper="${HOME}/.aidevops/agents/scripts/contributor-activity-helper.sh"
 	if [[ -x "$activity_helper" ]]; then
 		activity_md=$(bash "$activity_helper" summary "$repo_path" --period month --format markdown || echo "_Activity data unavailable._")
 		session_time_md=$(bash "$activity_helper" session-time "$repo_path" --period all --format markdown || echo "_Session data unavailable._")
+		person_stats_md=$(bash "$activity_helper" person-stats "$repo_path" --period month --format markdown || echo "_Person stats unavailable._")
 	else
 		activity_md="_Activity helper not installed._"
 		session_time_md="_Activity helper not installed._"
+		person_stats_md="_Activity helper not installed._"
 	fi
 
 	# --- Assemble body ---
@@ -1731,13 +1734,17 @@ ${activity_md}
 
 ${cross_repo_md:-_Single repo or cross-repo data unavailable._}
 
-### Session Time
+### Session Time (${runner_user})
 
 ${session_time_md}
 
-### Cross-Repo Session Time
+### Cross-Repo Session Time (${runner_user})
 
 ${cross_repo_session_time_md:-_Single repo or cross-repo session data unavailable._}
+
+### Contributor Output (last 30 days)
+
+${person_stats_md:-_Person stats unavailable._}
 
 ### System Resources
 


### PR DESCRIPTION
## Summary

- Renamed duplicate "Machine Hours" column to "Total Work" (= human + AI hours combined) across all 4 table formats (single-period, all-periods, cross-repo single, cross-repo all)
- Reordered columns: **Human Hours first** (primary question being answered), then AI Hours, Total Work, Sessions, Workers
- Added `% of Total` column to `person-stats` and `cross-repo-person-stats` markdown tables showing each contributor's share of total GitHub output
- Added runner attribution `(runner_user)` to "Session Time" and "Cross-Repo Session Time" section headers in health dashboard
- Added new "Contributor Output (last 30 days)" section to health dashboard showing per-person GitHub output with percentages
- Fixed bash 3.2 unbound variable error in `cross_repo_person_stats` — empty `extra_args` array with `set -u` required `${arr[@]+"${arr[@]}"}` workaround

## Testing

All commands verified:
- `session-time --period day/month/all` — correct column order and Total Work column
- `person-stats --period month` — % of Total column renders correctly
- `cross-repo-session-time --period month` — correct format
- `cross-repo-person-stats --period month` — fixed unbound variable, renders with percentages
- JSON output unchanged (backward compatible)
- ShellCheck clean on both files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Contributor Output (last 30 days)" section to the queue health dashboard displaying contributor statistics.

* **Improvements**
  * Updated dashboard metrics to display Human Hours, AI Hours, and Total Work alongside session information.
  * Enhanced dashboard headers to include runner user context for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->