### PR TITLE
GH#3530: Fix accessibility-helper lighthouse preset, bc, and read loop bugs

### DIFF
--- a/.agents/scripts/accessibility-helper.sh
+++ b/.agents/scripts/accessibility-helper.sh
@@ -410,11 +410,12 @@ run_lighthouse_a11y() {
 	local report_file="${A11Y_REPORTS_DIR}/lighthouse_a11y_${timestamp}.json"
 
 	local chrome_flags="--headless --no-sandbox --disable-gpu"
+	# Lighthouse --preset only accepts: desktop, perf, experimental.
+	# Mobile is the default (no preset flag needed).
 	local preset_flag="--preset=desktop"
 	local screen_emulation="--screenEmulation.disabled"
 
 	if [[ "$strategy" == "mobile" ]]; then
-		# Mobile is Lighthouse's default — no --preset flag needed
 		preset_flag=""
 		screen_emulation=""
 	fi
@@ -426,7 +427,7 @@ run_lighthouse_a11y() {
 		--chrome-flags="$chrome_flags" \
 		${preset_flag:+"$preset_flag"} \
 		${screen_emulation:+"$screen_emulation"} \
-		--quiet 2>>"$LOG_FILE"; then
+		--quiet 2>/dev/null; then
 
 		print_success "Report saved: $report_file"
 		parse_lighthouse_a11y "$report_file"
@@ -450,7 +451,7 @@ parse_lighthouse_a11y() {
 	if [[ "$score" != "N/A" ]]; then
 		local pct
 		pct=$(awk -v s="$score" 'BEGIN { printf "%.0f", s * 100 }')
-		local int_pct="$pct"
+		local int_pct="${pct%.*}"
 
 		if [[ "$int_pct" -ge 90 ]]; then
 			echo -e "  Score: ${GREEN}${int_pct}%${NC} (Good)"

--- a/.agents/scripts/accessibility-helper.sh
+++ b/.agents/scripts/accessibility-helper.sh
@@ -435,7 +435,7 @@ run_lighthouse_a11y() {
 		--output=json \
 		--output-path="$report_file" \
 		--chrome-flags="$chrome_flags" \
-		"${lighthouse_args[@]}" \
+		${lighthouse_args[@]+"${lighthouse_args[@]}"} \
 		--quiet; then
 
 		print_success "Report saved: $report_file"

--- a/.agents/scripts/accessibility-helper.sh
+++ b/.agents/scripts/accessibility-helper.sh
@@ -322,6 +322,12 @@ wave_docs() {
 		return 1
 	}
 
+	# Validate JSON before parsing
+	if ! echo "$result" | jq empty 2>/dev/null; then
+		print_error "WAVE API returned invalid JSON (possible HTML error page)"
+		return 1
+	fi
+
 	echo ""
 	print_header_line "WAVE Documentation: $item_id"
 
@@ -374,6 +380,12 @@ wave_credits() {
 		print_error "Failed to reach WAVE API"
 		return 1
 	}
+
+	# Validate JSON before parsing
+	if ! echo "$result" | jq empty 2>/dev/null; then
+		print_error "WAVE API returned invalid JSON (possible HTML error page)"
+		return 1
+	fi
 
 	local success
 	success=$(echo "$result" | jq -r '.status.success // false')
@@ -548,12 +560,13 @@ run_pa11y_audit() {
 		fi
 	fi
 
-	parse_pa11y_report "$report_file"
+	parse_pa11y_report "$report_file" "$standard"
 	return 0
 }
 
 parse_pa11y_report() {
 	local report_file="$1"
+	local standard="${2:-$A11Y_WCAG_LEVEL}"
 
 	check_jq || return 1
 
@@ -570,7 +583,7 @@ parse_pa11y_report() {
 	notices=$(jq '[.[] | select(.type == "notice")] | length' "$report_file" 2>/dev/null || echo "0")
 
 	echo ""
-	print_header_line "pa11y Results ($A11Y_WCAG_LEVEL)"
+	print_header_line "pa11y Results ($standard)"
 	echo "  Total issues: $total"
 
 	if [[ "$errors" -gt 0 ]]; then
@@ -1137,7 +1150,7 @@ main() {
 	"install-deps")
 		install_deps
 		;;
-	"help" | *)
+	"help")
 		print_header_line "Accessibility & Contrast Testing Helper"
 		echo "Usage: $0 [command] [options]"
 		echo ""
@@ -1182,6 +1195,11 @@ main() {
 		echo "  $0 bulk websites.txt"
 		echo ""
 		echo "Reports saved to: $A11Y_REPORTS_DIR"
+		;;
+	*)
+		print_error "Unknown command: $command"
+		print_info "Run: $0 help"
+		return 1
 		;;
 	esac
 }

--- a/.agents/scripts/accessibility-helper.sh
+++ b/.agents/scripts/accessibility-helper.sh
@@ -412,12 +412,10 @@ run_lighthouse_a11y() {
 	local chrome_flags="--headless --no-sandbox --disable-gpu"
 	# Lighthouse --preset only accepts: desktop, perf, experimental.
 	# Mobile is the default (no preset flag needed).
-	local preset_flag="--preset=desktop"
-	local screen_emulation="--screenEmulation.disabled"
-
-	if [[ "$strategy" == "mobile" ]]; then
-		preset_flag=""
-		screen_emulation=""
+	local lighthouse_args=()
+	if [[ "$strategy" == "desktop" ]]; then
+		lighthouse_args+=(--preset=desktop)
+		lighthouse_args+=(--screenEmulation.disabled)
 	fi
 
 	if lighthouse "$url" \
@@ -425,9 +423,8 @@ run_lighthouse_a11y() {
 		--output=json \
 		--output-path="$report_file" \
 		--chrome-flags="$chrome_flags" \
-		${preset_flag:+"$preset_flag"} \
-		${screen_emulation:+"$screen_emulation"} \
-		--quiet 2>/dev/null; then
+		"${lighthouse_args[@]}" \
+		--quiet; then
 
 		print_success "Report saved: $report_file"
 		parse_lighthouse_a11y "$report_file"

--- a/.agents/scripts/accessibility-helper.sh
+++ b/.agents/scripts/accessibility-helper.sh
@@ -410,6 +410,15 @@ run_lighthouse_a11y() {
 	local url="$1"
 	local strategy="${2:-desktop}"
 
+	case "$strategy" in
+	desktop | mobile) ;;
+	*)
+		print_error "Invalid Lighthouse strategy: $strategy"
+		print_info "Use: desktop or mobile"
+		return 1
+		;;
+	esac
+
 	check_lighthouse || return 1
 	check_jq || return 1
 
@@ -641,8 +650,12 @@ check_email_a11y() {
 		return 0
 	}
 
-	# grep -c exits non-zero when count is 0; this wrapper returns "0" cleanly
-	_grep_count() { grep -ciE "$@" 2>/dev/null || true; }
+	# Count matched occurrences (not matching lines) so minified HTML is handled correctly
+	_grep_count() {
+		local pattern="$1"
+		local file="$2"
+		(grep -oiE "$pattern" "$file" 2>/dev/null || true) | awk 'END { print NR }'
+	}
 
 	_append "Email Accessibility Report"
 	_append "File: $file"
@@ -775,6 +788,11 @@ hex_to_rgb() {
 	local hex="$1"
 	hex="${hex#\#}"
 
+	if [[ ! "$hex" =~ ^([[:xdigit:]]{3}|[[:xdigit:]]{6})$ ]]; then
+		print_error "Invalid hex color: $1"
+		return 1
+	fi
+
 	# Expand shorthand (e.g., #fff -> #ffffff)
 	if [[ ${#hex} -eq 3 ]]; then
 		hex="${hex:0:1}${hex:0:1}${hex:1:1}${hex:1:1}${hex:2:1}${hex:2:1}"
@@ -814,8 +832,12 @@ check_contrast() {
 	local bg="$2"
 
 	local fg_rgb bg_rgb
-	fg_rgb=$(hex_to_rgb "$fg")
-	bg_rgb=$(hex_to_rgb "$bg")
+	if ! fg_rgb=$(hex_to_rgb "$fg"); then
+		return 1
+	fi
+	if ! bg_rgb=$(hex_to_rgb "$bg"); then
+		return 1
+	fi
 
 	local fg_r fg_g fg_b bg_r bg_g bg_b
 	read -r fg_r fg_g fg_b <<<"$fg_rgb"

--- a/.agents/scripts/accessibility-helper.sh
+++ b/.agents/scripts/accessibility-helper.sh
@@ -97,8 +97,13 @@ load_wave_api_key() {
 	fi
 
 	# Try gopass (encrypted, preferred)
+	# secret-helper.sh normalizes names to uppercase (wave-api-key -> WAVE_API_KEY)
+	# Try normalized path first, then legacy lowercase for backward compatibility
 	if command -v gopass &>/dev/null; then
-		WAVE_API_KEY=$(gopass show -o "aidevops/wave-api-key" 2>/dev/null || echo "")
+		WAVE_API_KEY=$(gopass show -o "aidevops/WAVE_API_KEY" 2>/dev/null || echo "")
+		if [[ -z "$WAVE_API_KEY" ]]; then
+			WAVE_API_KEY=$(gopass show -o "aidevops/wave-api-key" 2>/dev/null || echo "")
+		fi
 		if [[ -n "$WAVE_API_KEY" ]]; then
 			export WAVE_API_KEY
 			return 0


### PR DESCRIPTION
## Summary

Fixes 3 confirmed bugs in `accessibility-helper.sh` from quality-debt issue #3530 (PR #919 review feedback).

### CRITICAL: Invalid `--preset=mobile` (line 426)

Lighthouse CLI `--preset` only accepts `desktop`, `perf`, or `experimental`. Mobile is the default behavior (no preset flag needed). Passing `--preset=mobile` causes Lighthouse to reject or ignore the flag, breaking mobile audits.

**Fix:** Use `--preset=desktop` for desktop strategy, omit the flag entirely for mobile.

### HIGH: `bc` inconsistency (line 451)

Line 451 used `bc -l` for score percentage calculation, but line 782 already comments "Using awk for floating-point math (bc may not be available)". When `bc` is absent, the `|| echo "0"` fallback silently reports 0% for every score.

**Fix:** Replace `bc -l` with `awk -v s="$score" 'BEGIN { printf "%.0f", s * 100 }'` for consistency.

### Minor: Read loop skips last URL (line 911)

Classic bash `read` gotcha — if the URL file doesn't end with `\n`, the last line is consumed but `read` returns non-zero, so the loop body never executes for it.

**Fix:** Add `|| [[ -n "$url" ]]` to the while condition.

## Verification

- ShellCheck clean (only SC1091 external source, pre-existing)
- All 3 findings verified against current code on main

Closes #3530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Accessibility/audit scripts rewritten for clearer flow, consistent syntax, and standardized output formatting.
* **Bug Fixes**
  * Hardened input validation and JSON handling to reduce parsing errors and improve failure messaging.
* **User-facing Changes**
  * Audit reports and CLI output show clearer headers, reordered fields, consistent score displays, and better desktop/mobile handling.
* **New Features**
  * Improved integrations and a transcript-style email accessibility report for clearer, consolidated results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->