### PR TITLE
GH#3931: fix pulse-wrapper.sh BASH_SOURCE undefined in zsh

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -42,7 +42,11 @@ set -euo pipefail
 #######################################
 export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# Use ${BASH_SOURCE[0]:-$0} for shell portability — BASH_SOURCE is undefined
+# in zsh, which is the MCP shell environment. This fallback ensures SCRIPT_DIR
+# resolves correctly whether the script is executed directly (bash) or sourced
+# from zsh. See GH#3931.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
 
@@ -2998,6 +3002,20 @@ calculate_max_workers() {
 # The pulse agent sources this file to access helper functions
 # (check_external_contributor_pr, check_permission_failure_pr)
 # without triggering the full pulse lifecycle.
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+#
+# Shell-portable source detection (GH#3931):
+#   bash: BASH_SOURCE[0] differs from $0 when sourced
+#   zsh:  BASH_SOURCE is undefined; use ZSH_EVAL_CONTEXT instead
+#         (contains "file" when sourced, "toplevel" when executed)
+_pulse_is_sourced() {
+	if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+		[[ "${BASH_SOURCE[0]}" != "${0}" ]]
+	elif [[ -n "${ZSH_EVAL_CONTEXT:-}" ]]; then
+		[[ "$ZSH_EVAL_CONTEXT" == *":file:"* || "$ZSH_EVAL_CONTEXT" == *":file" ]]
+	else
+		return 1
+	fi
+}
+if ! _pulse_is_sourced; then
 	main "$@"
 fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -46,7 +46,7 @@ export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
 # in zsh, which is the MCP shell environment. This fallback ensures SCRIPT_DIR
 # resolves correctly whether the script is executed directly (bash) or sourced
 # from zsh. See GH#3931.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || return 2>/dev/null || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
 
@@ -3011,7 +3011,7 @@ _pulse_is_sourced() {
 	if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
 		[[ "${BASH_SOURCE[0]}" != "${0}" ]]
 	elif [[ -n "${ZSH_EVAL_CONTEXT:-}" ]]; then
-		[[ "$ZSH_EVAL_CONTEXT" == *":file:"* || "$ZSH_EVAL_CONTEXT" == *":file" ]]
+		[[ ":${ZSH_EVAL_CONTEXT}:" == *":file:"* ]]
 	else
 		return 1
 	fi


### PR DESCRIPTION
## Summary

- Replace `BASH_SOURCE[0]` with `${BASH_SOURCE[0]:-$0}` for SCRIPT_DIR resolution — falls back to `$0` when sourced from zsh (MCP shell)
- Replace naive `BASH_SOURCE[0] == $0` main guard with `_pulse_is_sourced()` function that uses `ZSH_EVAL_CONTEXT` in zsh — the naive check always evaluates true in zsh because `$0` equals the sourced file path

## Problem

When `pulse-wrapper.sh` is sourced from the MCP shell (zsh), `BASH_SOURCE[0]` is undefined, causing:
- `SCRIPT_DIR` to resolve to the wrong directory
- `shared-constants.sh` and `worker-lifecycle-common.sh` fail to source
- 17 `command not found` errors for `_validate_int`, `_sanitize_markdown`, etc.
- Degraded pulse functionality (exit code 0 but helper functions missing)

## Verification

- `bash -n pulse-wrapper.sh` — syntax OK
- `shellcheck --norc -S warning` — clean (only pre-existing SC2034 warnings)
- Tested `_pulse_is_sourced()` in all 4 scenarios: bash direct, bash sourced, zsh direct, zsh sourced — all correct

Closes #3931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced shell script reliability by improving portability across different shell environments.
  * Fixed script detection to properly handle both direct execution and sourcing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->