### PR TITLE
t3934: Fix pulse cannot merge PRs that modify workflow files

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -135,6 +135,20 @@ Then skip to the next PR. The next pulse cycle will retry the permission check �
 **For maintainer PRs (admin/maintain/write permission):**
 
 - **Green CI + review gate passed + no blocking reviews** → merge: `gh pr merge <number> --repo <slug> --squash`. If the PR resolves an issue, the issue should be closed with a comment linking to the merged PR.
+  - **Workflow file merge guard (t3934):** Before merging, check if the PR modifies `.github/workflows/` files. PRs that modify workflow files require the `workflow` scope on the GitHub OAuth token — without it, `gh pr merge` fails with a GraphQL error. Use the deterministic helper:
+
+    ```bash
+    source ~/.aidevops/agents/scripts/pulse-wrapper.sh || true
+    check_workflow_merge_guard <number> <slug>
+    wf_guard=$?
+    if [[ $wf_guard -eq 1 ]]; then
+      # Blocked — comment posted, skip merge this cycle
+      continue
+    fi
+    # wf_guard 0 or 2 = safe to proceed (no workflow files, has scope, or API error — fail open)
+    ```
+
+    If blocked, the comment tells the user to run `gh auth refresh -s workflow`. Once the scope is added, the next pulse cycle merges normally. If the PR already has a `needs-workflow-scope` label, skip the check — the comment was already posted.
   - **Review gate (t2839, GH#3932):** Run `review-bot-gate-helper.sh check <number> <slug>` first, then check formal review count with `gh pr view <number> --repo <slug> --json reviews --jq '.reviews | length'`.
   - **Merge conditions (any one is sufficient):**
     1. Formal review count > 0 (at least one bot or human submitted a review) — merge.

--- a/.agents/scripts/github-cli-helper.sh
+++ b/.agents/scripts/github-cli-helper.sh
@@ -447,13 +447,24 @@ merge_pr() {
 
     print_info "Merging pull request #$pr_number in $owner/$repo_name"
 
-    if gh pr merge --repo "$owner/$repo_name" "$pr_number" --"$merge_method"; then
+    local merge_output
+    merge_output=$(gh pr merge --repo "$owner/$repo_name" "$pr_number" --"$merge_method" 2>&1)
+    local merge_exit=$?
+
+    if [[ $merge_exit -eq 0 ]]; then
         print_success "$SUCCESS_PR_MERGED"
-    else
-        print_error "Failed to merge pull request"
+        return 0
+    fi
+
+    # Check for workflow scope error (t3934)
+    if echo "$merge_output" | grep -qiF 'workflow scope'; then
+        print_error "Merge failed: PR modifies workflow files but token lacks 'workflow' scope"
+        print_info "Fix: run 'gh auth refresh -s workflow' to add the workflow scope"
         return 1
     fi
-    return 0
+
+    print_error "Failed to merge pull request: $merge_output"
+    return 1
 }
 
 # ------------------------------------------------------------------------------

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -688,7 +688,7 @@ check_pr_modifies_workflows() {
 	fi
 
 	local files_output
-	files_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json files --jq '.files[].path' 2>/dev/null)
+	files_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json files --jq '.files[].path')
 	local files_exit=$?
 
 	if [[ $files_exit -ne 0 ]]; then
@@ -795,7 +795,7 @@ check_workflow_merge_guard() {
 
 	# Step 3: PR modifies workflows AND token lacks scope — check for existing comment
 	local comments_output
-	comments_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body' 2>/dev/null)
+	comments_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body')
 	local comments_exit=$?
 
 	if [[ $comments_exit -ne 0 ]]; then
@@ -819,12 +819,12 @@ This PR modifies \`.github/workflows/\` files but the GitHub OAuth token used by
 1. Run \`gh auth refresh -s workflow\` to add the \`workflow\` scope to your token
 2. The next pulse cycle will merge this PR automatically
 
-**Alternatively:** Merge manually via the GitHub UI." \
-		2>/dev/null || true
+**Alternatively:** Merge manually via the GitHub UI." ||
+		true
 
 	# Add a label for visibility
 	gh api --silent "repos/${repo_slug}/issues/${pr_number}/labels" \
-		-X POST -f 'labels[]=needs-workflow-scope' 2>/dev/null || true
+		-X POST -f 'labels[]=needs-workflow-scope' || true
 
 	echo "[pulse-wrapper] check_workflow_merge_guard: blocked PR #$pr_number in $repo_slug — workflow files + missing scope" >>"$LOGFILE"
 	return 1

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -659,6 +659,178 @@ check_permission_failure_pr() {
 }
 
 #######################################
+# Check if a PR modifies GitHub Actions workflow files (t3934)
+#
+# PRs that modify .github/workflows/ files require the `workflow` scope
+# on the GitHub OAuth token. Without it, `gh pr merge` fails with:
+#   "refusing to allow an OAuth App to create or update workflow ... without workflow scope"
+#
+# This function checks the PR's changed files for workflow modifications
+# so the pulse can skip auto-merge and post a helpful comment instead of
+# failing with a cryptic GraphQL error.
+#
+# Arguments:
+#   $1 - PR number
+#   $2 - repo slug (owner/repo)
+#
+# Exit codes:
+#   0 - PR modifies workflow files
+#   1 - PR does NOT modify workflow files
+#   2 - API error (fail open — let merge attempt proceed)
+#######################################
+check_pr_modifies_workflows() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	if [[ -z "$pr_number" || -z "$repo_slug" ]]; then
+		echo "[pulse-wrapper] check_pr_modifies_workflows: missing arguments" >>"$LOGFILE"
+		return 2
+	fi
+
+	local files_output
+	files_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json files --jq '.files[].path' 2>/dev/null)
+	local files_exit=$?
+
+	if [[ $files_exit -ne 0 ]]; then
+		echo "[pulse-wrapper] check_pr_modifies_workflows: API error (exit=$files_exit) for PR #$pr_number in $repo_slug — failing open" >>"$LOGFILE"
+		return 2
+	fi
+
+	if echo "$files_output" | grep -qE '^\.github/workflows/'; then
+		echo "[pulse-wrapper] check_pr_modifies_workflows: PR #$pr_number in $repo_slug modifies workflow files" >>"$LOGFILE"
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
+# Check if the current GitHub token has the `workflow` scope (t3934)
+#
+# The `workflow` scope is required to merge PRs that modify
+# .github/workflows/ files. This function checks the current
+# token's scopes via `gh auth status`.
+#
+# Exit codes:
+#   0 - token HAS workflow scope
+#   1 - token does NOT have workflow scope
+#   2 - unable to determine (fail open)
+#######################################
+check_gh_workflow_scope() {
+	local auth_output
+	auth_output=$(gh auth status 2>&1)
+	local auth_exit=$?
+
+	if [[ $auth_exit -ne 0 ]]; then
+		echo "[pulse-wrapper] check_gh_workflow_scope: gh auth status failed (exit=$auth_exit) — failing open" >>"$LOGFILE"
+		return 2
+	fi
+
+	if echo "$auth_output" | grep -q "'workflow'"; then
+		return 0
+	fi
+
+	# Also check for the scope without quotes (format varies by gh version)
+	if echo "$auth_output" | grep -qiE 'Token scopes:.*workflow'; then
+		return 0
+	fi
+
+	echo "[pulse-wrapper] check_gh_workflow_scope: token lacks workflow scope" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
+# Guard merge of PRs that modify workflow files (t3934)
+#
+# Combines check_pr_modifies_workflows() and check_gh_workflow_scope()
+# into a single pre-merge guard. If the PR modifies workflow files and
+# the token lacks the workflow scope, posts a comment explaining the
+# issue and how to fix it. Idempotent — checks for existing comment.
+#
+# Arguments:
+#   $1 - PR number
+#   $2 - repo slug (owner/repo)
+#
+# Exit codes:
+#   0 - safe to merge (no workflow files, or token has scope)
+#   1 - blocked (workflow files + missing scope, comment posted)
+#   2 - API error (fail open — let merge attempt proceed)
+#######################################
+check_workflow_merge_guard() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	if [[ -z "$pr_number" || -z "$repo_slug" ]]; then
+		echo "[pulse-wrapper] check_workflow_merge_guard: missing arguments" >>"$LOGFILE"
+		return 2
+	fi
+
+	# Step 1: Check if PR modifies workflow files
+	check_pr_modifies_workflows "$pr_number" "$repo_slug"
+	local wf_exit=$?
+
+	if [[ $wf_exit -eq 1 ]]; then
+		# No workflow files modified — safe to merge
+		return 0
+	fi
+
+	if [[ $wf_exit -eq 2 ]]; then
+		# API error — fail open, let merge attempt proceed
+		return 2
+	fi
+
+	# Step 2: PR modifies workflow files — check token scope
+	check_gh_workflow_scope
+	local scope_exit=$?
+
+	if [[ $scope_exit -eq 0 ]]; then
+		# Token has workflow scope — safe to merge
+		return 0
+	fi
+
+	if [[ $scope_exit -eq 2 ]]; then
+		# Unable to determine — fail open
+		return 2
+	fi
+
+	# Step 3: PR modifies workflows AND token lacks scope — check for existing comment
+	local comments_output
+	comments_output=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body' 2>/dev/null)
+	local comments_exit=$?
+
+	if [[ $comments_exit -ne 0 ]]; then
+		echo "[pulse-wrapper] check_workflow_merge_guard: API error reading comments for PR #$pr_number — failing open" >>"$LOGFILE"
+		return 2
+	fi
+
+	if echo "$comments_output" | grep -qF 'workflow scope'; then
+		# Already commented — still blocked
+		echo "[pulse-wrapper] check_workflow_merge_guard: PR #$pr_number already has workflow scope comment — skipping merge" >>"$LOGFILE"
+		return 1
+	fi
+
+	# Post comment explaining the issue
+	gh pr comment "$pr_number" --repo "$repo_slug" \
+		--body "**Cannot auto-merge: workflow scope required** (GH#3934)
+
+This PR modifies \`.github/workflows/\` files but the GitHub OAuth token used by the pulse lacks the \`workflow\` scope. GitHub requires this scope to merge PRs that modify workflow files.
+
+**To fix:**
+1. Run \`gh auth refresh -s workflow\` to add the \`workflow\` scope to your token
+2. The next pulse cycle will merge this PR automatically
+
+**Alternatively:** Merge manually via the GitHub UI." \
+		2>/dev/null || true
+
+	# Add a label for visibility
+	gh api --silent "repos/${repo_slug}/issues/${pr_number}/labels" \
+		-X POST -f 'labels[]=needs-workflow-scope' 2>/dev/null || true
+
+	echo "[pulse-wrapper] check_workflow_merge_guard: blocked PR #$pr_number in $repo_slug — workflow files + missing scope" >>"$LOGFILE"
+	return 1
+}
+
+#######################################
 # Pre-fetch active worker processes (t216, t1367)
 #
 # Captures a snapshot of running worker processes so the pulse agent


### PR DESCRIPTION
## Summary

- Add pre-merge guard in `pulse-wrapper.sh` that detects when a PR modifies `.github/workflows/` files and the OAuth token lacks the `workflow` scope
- Post a clear comment with fix instructions (`gh auth refresh -s workflow`) instead of failing with a cryptic GraphQL error
- Improve `merge_pr()` in `github-cli-helper.sh` to detect and report workflow scope errors with actionable guidance

## Problem

PR #3850 failed to merge with:
```
GraphQL: refusing to allow an OAuth App to create or update workflow
.github/workflows/code-review-monitoring.yml without `workflow` scope
```

Any PR modifying GitHub Actions workflow files accumulates without auto-merge, requiring manual intervention.

## Solution

Three-layer defense:

1. **Pre-merge guard** (`check_workflow_merge_guard()` in `pulse-wrapper.sh`): Checks PR files for `.github/workflows/` paths AND checks token scopes before attempting merge. If blocked, posts a comment explaining the fix and adds `needs-workflow-scope` label. Idempotent — won't duplicate comments.

2. **Pulse instructions** (`pulse.md`): Added workflow file merge guard step before the merge command, with code example calling the deterministic helper.

3. **Fallback error handling** (`github-cli-helper.sh`): If the guard is bypassed (direct `merge_pr()` call), the improved error handling detects the "workflow scope" error message and provides actionable guidance.

## Testing

- Verified `check_pr_modifies_workflows()` correctly detects PR #3850 (workflow files) and PR #3831 (no workflow files)
- Verified `check_gh_workflow_scope()` correctly reports missing `workflow` scope on current token
- All functions pass ShellCheck with zero violations
- Functions follow existing patterns (idempotent comments, fail-open on API errors, `local var="$1"` convention)

Closes #3934