### PR TITLE
t3932: fix CodeRabbit rate-limit deadlock blocking all PR merges

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -115,12 +115,15 @@ Then skip to the next PR. The next pulse cycle will retry the permission check �
 
 **For maintainer PRs (admin/maintain/write permission):**
 
-- **Green CI + at least one review posted + no blocking reviews** → merge: `gh pr merge <number> --repo <slug> --squash`. If the PR resolves an issue, the issue should be closed with a comment linking to the merged PR.
-  - **CRITICAL (t2839):** Before merging, always verify at least one review exists using `gh pr view <number> --repo <slug> --json reviews --jq '.reviews | length'`. This is the mandatory gate — no PR merges with zero reviews.
-  - If `review-bot-gate-helper.sh check <number> <slug>` is available, use it as an additional bot-activity signal. `PASS` confirms bots have reviewed but does NOT replace the formal review-count check above.
-  - `WAITING` only means "no known bot activity" — it does NOT mean zero reviews. When `WAITING` is returned, check the formal review count (the `gh pr view` command above). If count > 0, proceed to merge.
-  - `SKIP` means the PR has a `skip-review-gate` label — it bypasses the bot gate only, NOT the review count requirement.
-  - Skip the PR when the formal review count is 0, regardless of bot gate status.
+- **Green CI + review gate passed + no blocking reviews** → merge: `gh pr merge <number> --repo <slug> --squash`. If the PR resolves an issue, the issue should be closed with a comment linking to the merged PR.
+  - **Review gate (t2839, GH#3932):** Run `review-bot-gate-helper.sh check <number> <slug>` first, then check formal review count with `gh pr view <number> --repo <slug> --json reviews --jq '.reviews | length'`.
+  - **Merge conditions (any one is sufficient):**
+    1. Formal review count > 0 (at least one bot or human submitted a review) — merge.
+    2. Bot gate returns `PASS` (a bot posted a real review comment, even if GitHub didn't record it as a formal review) — merge.
+    3. Bot gate returns `PASS_RATE_LIMITED` (bots posted rate-limit notices proving they're configured, and the PR exceeded the grace period) — merge. This is the designed escape valve for systemic rate limiting (GH#3932). The rate-limit grace period (default 4h) provides sufficient time for bots to recover; if they haven't reviewed after 4h, the PR has been adequately delayed.
+    4. Bot gate returns `SKIP` (PR has `skip-review-gate` label) — merge (label is an explicit human override).
+  - **Do NOT merge when:** formal review count is 0 AND bot gate returns `WAITING` (bots haven't posted anything yet, or rate-limit grace period hasn't elapsed). Skip this PR and let `request-retry` handle recovery (see below).
+  - **Rationale for PASS_RATE_LIMITED (GH#3932):** The previous rule ("skip when formal review count is 0, regardless of bot gate status") created a deadlock: CodeRabbit rate-limits prevented formal reviews, and the hard review-count gate prevented merging, so PRs accumulated indefinitely. The PASS_RATE_LIMITED status was designed specifically for this scenario but was being overridden by the review-count gate. Now the two checks work together: the bot gate determines whether the PR has been adequately reviewed OR has waited long enough, and the formal review count is one input to that determination, not an independent hard gate.
   - **Unresolved review suggestions check (pre-merge):** Before merging, check for unresolved inline review comments from bots. This prevents merging PRs where actionable feedback was posted but never addressed — the root cause of quality-debt backfill issues.
 
     ```bash
@@ -147,7 +150,7 @@ Then skip to the next PR. The next pulse cycle will retry the permission check �
     ```
 
     **Judgment call, not a hard block.** Not every bot suggestion is valid — bots hallucinate. The fix worker reads each suggestion, applies valid ones, and dismisses invalid ones with a reply. The goal is to prevent the pattern where feedback is silently ignored and becomes a quality-debt issue post-merge. If the PR already has the `needs-review-fixes` label (fix worker already dispatched), skip the check — the worker is handling it. If the PR has `skip-review-suggestions` label, bypass this check entirely (for cases where all suggestions were reviewed and intentionally declined).
-- **Green CI + zero reviews** → skip this cycle, but run `review-bot-gate-helper.sh request-retry <number> <slug>` to self-heal rate-limited bots. The helper checks whether bots posted rate-limit notices instead of real reviews and requests a retry if so (idempotent — safe to call every cycle). The next pulse will find the real review and merge normally. The formal review count gate still applies — this is recovery, not bypass.
+- **Green CI + bot gate returns WAITING** → skip this cycle, but run `review-bot-gate-helper.sh request-retry <number> <slug>` to self-heal rate-limited bots. The helper checks whether bots posted rate-limit notices instead of real reviews and requests a retry if so (idempotent — safe to call every cycle). The next pulse will either find a real review (merge via condition 1/2) or the grace period will elapse (merge via condition 3 PASS_RATE_LIMITED).
 - **Failing CI or changes requested** → before dispatching a fix worker, check whether this is a systemic failure (see "CI failure pattern detection" below). If systemic, skip the per-PR dispatch — the workflow-level issue covers it. If per-PR, dispatch a worker to fix it (counts against worker slots).
 
 **For all PRs (regardless of author):**

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -6,6 +6,7 @@
 #   review-bot-gate-helper.sh wait          <PR_NUMBER> [REPO] [MAX_WAIT_SECONDS]
 #   review-bot-gate-helper.sh list          <PR_NUMBER> [REPO]
 #   review-bot-gate-helper.sh request-retry <PR_NUMBER> [REPO]
+#   review-bot-gate-helper.sh batch-retry   [REPO]
 #
 # Commands:
 #   check          — Check once, return PASS/PASS_RATE_LIMITED/WAITING/SKIP
@@ -13,6 +14,9 @@
 #   list           — List all bot comments found on the PR
 #   request-retry  — If bots were rate-limited and no real review exists,
 #                     request a review retry (idempotent, safe to call every pulse)
+#   batch-retry    — Process all open PRs with 0 formal reviews, request retries
+#                     for rate-limited ones. Staggers requests to avoid re-triggering
+#                     rate limits. (GH#3932)
 #
 # Output values for check/wait:
 #   PASS              — At least one bot posted a real review
@@ -68,13 +72,14 @@ RATE_LIMIT_GRACE_SECONDS="${RATE_LIMIT_GRACE_SECONDS:-14400}"
 # --- Functions ---
 
 usage() {
-	echo "Usage: $(basename "$0") {check|wait|list|request-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
+	echo "Usage: $(basename "$0") {check|wait|list|request-retry|batch-retry} <PR_NUMBER> [REPO] [MAX_WAIT]"
 	echo ""
 	echo "Commands:"
 	echo "  check          Check once for bot reviews (returns PASS/PASS_RATE_LIMITED/WAITING/SKIP)"
 	echo "  wait           Poll until bot reviews appear or timeout"
 	echo "  list           List all bot comments found"
 	echo "  request-retry  Request review retry if bots were rate-limited (idempotent)"
+	echo "  batch-retry    Process all open PRs with 0 reviews, request retries (GH#3932)"
 	return 0
 }
 
@@ -501,6 +506,74 @@ Review bots were rate-limited when this PR was created (affected: ${rate_limited
 	fi
 }
 
+do_batch_retry() {
+	# GH#3932: Process all open PRs with 0 formal reviews, request retries
+	# for rate-limited ones. Staggers requests with a delay between each to
+	# avoid re-triggering CodeRabbit's hourly rate limit.
+	#
+	# Returns summary: REQUESTED_N (where N is the count of retries requested)
+	local repo="$1"
+	local stagger_seconds="${BATCH_RETRY_STAGGER:-5}"
+
+	echo "Scanning open PRs in ${repo} for rate-limited reviews..." >&2
+
+	# Get all open PRs with 0 formal reviews
+	local pr_numbers
+	pr_numbers=$(gh pr list --repo "$repo" --state open --limit 100 \
+		--json number,reviews \
+		--jq '[.[] | select((.reviews | length) == 0)] | .[].number' 2>/dev/null || echo "")
+
+	if [[ -z "$pr_numbers" ]]; then
+		echo "NO_ACTION"
+		echo "No open PRs with 0 formal reviews found." >&2
+		return 0
+	fi
+
+	local total=0
+	local requested=0
+	local already=0
+	local skipped=0
+	local pr_num result
+
+	while IFS= read -r pr_num; do
+		[[ -z "$pr_num" ]] && continue
+		total=$((total + 1))
+
+		# Run request-retry for each PR (it handles idempotency internally)
+		result=$(do_request_retry "$pr_num" "$repo" 2>/dev/null) || true
+
+		case "$result" in
+		REQUESTED)
+			requested=$((requested + 1))
+			echo "  PR #${pr_num}: retry requested" >&2
+			# Stagger to avoid re-triggering rate limits
+			if [[ "$stagger_seconds" -gt 0 ]]; then
+				sleep "$stagger_seconds"
+			fi
+			;;
+		ALREADY_REQUESTED)
+			already=$((already + 1))
+			echo "  PR #${pr_num}: already requested" >&2
+			;;
+		HAS_REVIEWS)
+			echo "  PR #${pr_num}: has formal reviews (skipped)" >&2
+			;;
+		NO_ACTION)
+			skipped=$((skipped + 1))
+			echo "  PR #${pr_num}: no rate-limited bots (skipped)" >&2
+			;;
+		*)
+			skipped=$((skipped + 1))
+			echo "  PR #${pr_num}: ${result:-error} (skipped)" >&2
+			;;
+		esac
+	done <<<"$pr_numbers"
+
+	echo "REQUESTED_${requested}"
+	echo "Batch retry complete: ${total} PRs scanned, ${requested} retries requested, ${already} already requested, ${skipped} skipped." >&2
+	return 0
+}
+
 # --- Main ---
 
 main() {
@@ -508,6 +581,20 @@ main() {
 	local pr_number="${2:-}"
 	local repo="${3:-}"
 	local max_wait="${4:-}"
+
+	# batch-retry only needs repo, not pr_number
+	if [[ "$command" == "batch-retry" ]]; then
+		local batch_repo="${2:-}"
+		if [[ -z "$batch_repo" ]]; then
+			batch_repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+			if [[ -z "$batch_repo" ]]; then
+				echo "ERROR: Could not determine repo. Pass REPO as argument." >&2
+				return 2
+			fi
+		fi
+		do_batch_retry "$batch_repo"
+		return $?
+	fi
 
 	if [[ -z "$command" || -z "$pr_number" ]]; then
 		usage
@@ -535,6 +622,9 @@ main() {
 		;;
 	request-retry)
 		do_request_retry "$pr_number" "$repo"
+		;;
+	batch-retry)
+		do_batch_retry "$repo"
 		;;
 	-h | --help | help)
 		usage

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -521,7 +521,7 @@ do_batch_retry() {
 	local pr_numbers
 	pr_numbers=$(gh pr list --repo "$repo" --state open --limit 100 \
 		--json number,reviews \
-		--jq '[.[] | select((.reviews | length) == 0)] | .[].number' 2>/dev/null || echo "")
+		--jq '[.[] | select((.reviews | length) == 0)] | .[].number' || echo "")
 
 	if [[ -z "$pr_numbers" ]]; then
 		echo "NO_ACTION"
@@ -540,7 +540,7 @@ do_batch_retry() {
 		total=$((total + 1))
 
 		# Run request-retry for each PR (it handles idempotency internally)
-		result=$(do_request_retry "$pr_num" "$repo" 2>/dev/null) || true
+		result=$(do_request_retry "$pr_num" "$repo") || true
 
 		case "$result" in
 		REQUESTED)
@@ -586,7 +586,7 @@ main() {
 	if [[ "$command" == "batch-retry" ]]; then
 		local batch_repo="${2:-}"
 		if [[ -z "$batch_repo" ]]; then
-			batch_repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+			batch_repo=$(gh repo view --json nameWithOwner -q .nameWithOwner || echo "")
 			if [[ -z "$batch_repo" ]]; then
 				echo "ERROR: Could not determine repo. Pass REPO as argument." >&2
 				return 2
@@ -603,7 +603,7 @@ main() {
 
 	# Default repo from current git context
 	if [[ -z "$repo" ]]; then
-		repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+		repo=$(gh repo view --json nameWithOwner -q .nameWithOwner || echo "")
 		if [[ -z "$repo" ]]; then
 			echo "ERROR: Could not determine repo. Pass REPO as third argument." >&2
 			return 2
@@ -622,9 +622,6 @@ main() {
 		;;
 	request-retry)
 		do_request_retry "$pr_number" "$repo"
-		;;
-	batch-retry)
-		do_batch_retry "$repo"
 		;;
 	-h | --help | help)
 		usage

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -47,8 +47,17 @@ reviews:
     labels:
       - "!no-review"
 
-  # Request changes for critical issues
+  # Request changes for critical issues — this is the setting that controls
+  # whether CodeRabbit submits formal APPROVED/CHANGES_REQUESTED reviews.
+  # Without this, CodeRabbit only posts comments (no formal review).
+  # GH#3932: Confirmed via schema that review_status only controls status
+  # messages in walkthrough comments, NOT formal review submission.
   request_changes_workflow: true
+
+  # GH#3932: Enable commit status checks so review-bot-gate-helper.sh can
+  # detect CodeRabbit activity via status API when formal reviews are missing
+  # due to rate limiting. This provides a fallback signal for the merge gate.
+  commit_status: true
 
   # Exclude certain files from review — expanded to reduce review scope
   # and conserve rate-limit budget (GH#3827).


### PR DESCRIPTION
## Summary

- **Root cause:** CodeRabbit rate-limits prevented formal reviews on 23+ maintainer PRs, and the pulse merge gate required `reviews | length > 0` regardless of bot gate status — creating a deadlock where PRs accumulated indefinitely
- **Fix:** Accept `PASS_RATE_LIMITED` as a valid merge condition in pulse.md (the 4h grace period was designed for exactly this scenario but was being overridden by the hard review-count gate)
- **New capability:** `batch-retry` command in review-bot-gate-helper.sh processes all rate-limited PRs at once with staggered requests

## Investigation Findings

1. `review_status: true` does NOT control formal review submission — it only controls status messages in walkthrough comments (confirmed via CodeRabbit schema)
2. `request_changes_workflow: true` IS the correct setting for formal reviews — already configured correctly
3. The issue is NOT maintainer vs external contributor — both get rate-limited. External PRs appeared to work because they were created at different times when quota was available
4. 13 open PRs had 0 formal reviews, all with "Rate limit exceeded" comments from CodeRabbit

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/commands/pulse.md` | Replace hard review-count gate with 4-condition merge logic that accepts `PASS_RATE_LIMITED` |
| `.agents/scripts/review-bot-gate-helper.sh` | Add `batch-retry` command for bulk processing of rate-limited PRs |
| `.coderabbit.yaml` | Add `commit_status: true` for status check fallback; document `review_status` vs `request_changes_workflow` |

## Verification

- `batch-retry` tested live: found 13 PRs with 0 reviews, requested 2 new retries, correctly identified 11 already-requested
- ShellCheck: zero violations
- YAML: validated syntax

Closes #3932