### PR TITLE
t1420: Add maintainer field to repos.json for code-simplifier assignment fallback

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -164,6 +164,7 @@ Planning files go direct to main. Code changes need worktree + PR. Workers NEVER
 - `pulse: false` — repos that exist but don't need task management (profile READMEs, forks for reference, archived projects)
 - `local_only: true` — repos with no remote (skip all `gh` operations)
 - `priority` — `"tooling"` (infrastructure/tools), `"product"` (user-facing), `"profile"` (GitHub profile, docs-only)
+- `maintainer` — GitHub username of the repo maintainer. Used by code-simplifier for issue assignment and other maintainer-gated workflows. Auto-detected from `gh api user` on registration; falls back to slug owner if missing.
 
 **Cross-repo task creation**: When a session creates a task in a *different* repo (e.g., adding an aidevops TODO while working in another project), follow the full workflow — not just the TODO edit:
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -173,31 +173,40 @@ register_repo() {
 		fi
 	fi
 
+	# Auto-detect maintainer from gh API (current authenticated user)
+	# Only runs once per registration — preserved on subsequent updates
+	local maintainer=""
+	if command -v gh &>/dev/null; then
+		maintainer=$(gh api user --jq '.login' 2>/dev/null) || maintainer=""
+	fi
+
 	# Check if repo already registered
 	if jq -e --arg path "$repo_path" '.initialized_repos[] | select(.path == $path)' "$REPOS_FILE" &>/dev/null; then
-		# Update existing entry, preserving pulse/priority/local_only if already set
+		# Update existing entry, preserving pulse/priority/local_only/maintainer if already set
 		local temp_file="${REPOS_FILE}.tmp"
 		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
-			--arg slug "$slug" --argjson local_only "$is_local_only" \
+			--arg slug "$slug" --argjson local_only "$is_local_only" --arg maintainer "$maintainer" \
 			'(.initialized_repos[] | select(.path == $path)) |= (
 				. + {path: $path, version: $version, features: ($features | split(",")), updated: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}
 				| if $slug != "" then .slug = $slug else . end
 				| if $local_only then .local_only = true else . end
+				| if (.maintainer == null or .maintainer == "") and $maintainer != "" then .maintainer = $maintainer else . end
 			)' \
 			"$REPOS_FILE" >"$temp_file" && mv "$temp_file" "$REPOS_FILE"
 	else
-		# Add new entry with slug
+		# Add new entry with slug and maintainer
 		local temp_file="${REPOS_FILE}.tmp"
 		local new_entry
 		# shellcheck disable=SC2016  # jq expressions use $var syntax, not shell expansion
 		if [[ -n "$slug" ]]; then
-			new_entry='{path: $path, slug: $slug, version: $version, features: ($features | split(",")), initialized: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}'
+			new_entry='{path: $path, slug: $slug, maintainer: $maintainer, version: $version, features: ($features | split(",")), initialized: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}'
 		elif [[ "$is_local_only" == "true" ]]; then
-			new_entry='{path: $path, local_only: true, version: $version, features: ($features | split(",")), initialized: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}'
+			new_entry='{path: $path, local_only: true, maintainer: $maintainer, version: $version, features: ($features | split(",")), initialized: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}'
 		else
-			new_entry='{path: $path, version: $version, features: ($features | split(",")), initialized: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}'
+			new_entry='{path: $path, maintainer: $maintainer, version: $version, features: ($features | split(",")), initialized: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}'
 		fi
-		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" --arg slug "$slug" \
+		jq --arg path "$repo_path" --arg version "$version" --arg features "$features" \
+			--arg slug "$slug" --arg maintainer "$maintainer" \
 			".initialized_repos += [$new_entry]" \
 			"$REPOS_FILE" >"$temp_file" && mv "$temp_file" "$REPOS_FILE"
 	fi
@@ -214,6 +223,37 @@ get_registered_repos() {
 	fi
 
 	jq -r '.initialized_repos[] | .path' "$REPOS_FILE" 2>/dev/null || echo ""
+	return 0
+}
+
+# Get the maintainer GitHub username for a repo
+# Fallback chain: maintainer field > slug owner > empty string
+# Usage: get_repo_maintainer <slug>
+get_repo_maintainer() {
+	local slug="$1"
+
+	if ! command -v jq &>/dev/null; then
+		echo ""
+		return 0
+	fi
+
+	local maintainer
+	maintainer=$(jq -r --arg slug "$slug" \
+		'.initialized_repos[] | select(.slug == $slug) | .maintainer // empty' \
+		"$REPOS_FILE" 2>/dev/null) || maintainer=""
+
+	if [[ -n "$maintainer" ]]; then
+		echo "$maintainer"
+		return 0
+	fi
+
+	# Fallback: extract owner from slug (owner/repo -> owner)
+	if [[ -n "$slug" && "$slug" == *"/"* ]]; then
+		echo "${slug%%/*}"
+		return 0
+	fi
+
+	echo ""
 	return 0
 }
 

--- a/todo/tasks/t1420-brief.md
+++ b/todo/tasks/t1420-brief.md
@@ -1,0 +1,37 @@
+# t1420: Add maintainer field to repos.json for code-simplifier assignment fallback
+
+## Session Origin
+
+Interactive session, `/full-loop` dispatch from GH#3937.
+
+## What
+
+Add a `maintainer` field to each repo entry in `~/.config/aidevops/repos.json`. This field stores the GitHub username of the person responsible for reviewing code-simplifier issues and other maintainer-gated workflows for that repo.
+
+## Why
+
+The code-simplifier agent (`.agents/tools/code-review/code-simplifier.md`) already references `repos.json`'s `maintainer` field in its Human Gate Workflow (line 311), but the field doesn't exist in any repo entry. Currently the fallback is to parse the owner from the slug (`cut -d/ -f1`), which breaks when the repo owner org differs from the actual maintainer (e.g., `awardsapp/awardsapp` is maintained by `marcusquinn`, not `awardsapp`).
+
+## How
+
+1. Add `"maintainer": "<github-username>"` to each repo entry in repos.json
+2. Add a `get_repo_maintainer` helper function to `aidevops.sh` that reads the field with slug-owner fallback
+3. Update `register_repo` in `aidevops.sh` to auto-detect maintainer from `gh api` when registering new repos
+4. Update AGENTS.md repo registration docs to mention the maintainer field
+5. Verify code-simplifier.md's existing jq example works with the new field
+
+## Acceptance Criteria
+
+- [ ] Every repo entry in repos.json has a `maintainer` field
+- [ ] `get_repo_maintainer` function exists in aidevops.sh and returns the correct username
+- [ ] Fallback chain: maintainer field > slug owner > empty string
+- [ ] code-simplifier.md jq example works against the updated repos.json
+- [ ] ShellCheck passes on modified shell scripts
+- [ ] No breaking changes to existing repos.json consumers
+
+## Context
+
+- code-simplifier.md lines 306-313: existing reference to maintainer field
+- repos.json: `~/.config/aidevops/repos.json` (user config, not committed)
+- aidevops.sh: `register_repo` function (lines 147-204)
+- pulse-wrapper.sh: reads repos.json for pulse-enabled repos


### PR DESCRIPTION
## Summary

- Adds a `maintainer` field to `repos.json` entries so the code-simplifier agent and other maintainer-gated workflows can assign issues to the correct person
- Adds `get_repo_maintainer()` function to `aidevops.sh` with fallback chain: maintainer field > slug owner > empty string
- Updates `register_repo()` to auto-detect maintainer from `gh api user` on registration and backfill for existing entries missing the field

## Problem

The code-simplifier agent (`code-simplifier.md:311`) already referenced a `maintainer` field in repos.json, but the field didn't exist. The fallback was to parse the owner from the slug (`cut -d/ -f1`), which returns the wrong person when the repo owner org differs from the actual maintainer (e.g., `webapp/webapp` is maintained by `marcusquinn`, not `webapp`).

## Changes

| File | Change |
|------|--------|
| `aidevops.sh` | Add `get_repo_maintainer()` function; update `register_repo()` to auto-detect and backfill maintainer |
| `.agents/AGENTS.md` | Document `maintainer` field in repo registration docs |
| `todo/tasks/t1420-brief.md` | Task brief |

## Verification

- ShellCheck passes clean on `aidevops.sh`
- jq query from code-simplifier.md tested against updated repos.json: returns `marcusquinn` for `webapp/webapp` (previously would have returned `webapp`)
- All existing repos.json entries updated with `maintainer` field (user config, not committed)

Closes #3937

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Repositories now include a maintainer field for identifying repo maintainers, automatically detected during registration and preserved during updates.
  * Added fallback mechanisms to gracefully handle cases where auto-detection is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->