### PR TITLE
feat: auto-update GitHub profile README with live stats

### DIFF
--- a/.agents/configs/aidevops-profile-readme-update.service
+++ b/.agents/configs/aidevops-profile-readme-update.service
@@ -1,0 +1,26 @@
+# systemd user service for profile README auto-update (Linux equivalent of launchd plist)
+#
+# Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp aidevops-profile-readme-update.service ~/.config/systemd/user/
+#   cp aidevops-profile-readme-update.timer ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now aidevops-profile-readme-update.timer
+#
+# Check status:
+#   systemctl --user status aidevops-profile-readme-update.timer
+#   journalctl --user -u aidevops-profile-readme-update.service
+
+[Unit]
+Description=aidevops profile README stats update
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/.aidevops/agents/scripts/profile-readme-helper.sh update
+StandardOutput=append:%h/.aidevops/.agent-workspace/logs/profile-readme-update.log
+StandardError=append:%h/.aidevops/.agent-workspace/logs/profile-readme-update.log
+
+[Install]
+WantedBy=default.target

--- a/.agents/configs/aidevops-profile-readme-update.timer
+++ b/.agents/configs/aidevops-profile-readme-update.timer
@@ -1,0 +1,18 @@
+# systemd user timer for profile README auto-update — runs daily at 06:00
+#
+# Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp aidevops-profile-readme-update.service ~/.config/systemd/user/
+#   cp aidevops-profile-readme-update.timer ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now aidevops-profile-readme-update.timer
+
+[Unit]
+Description=aidevops profile README update timer (daily at 06:00)
+
+[Timer]
+OnCalendar=*-*-* 06:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/.agents/configs/aidevops-screen-time-snapshot.service
+++ b/.agents/configs/aidevops-screen-time-snapshot.service
@@ -1,0 +1,25 @@
+# systemd user service for screen time snapshots (Linux equivalent of launchd plist)
+#
+# Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp aidevops-screen-time-snapshot.service ~/.config/systemd/user/
+#   cp aidevops-screen-time-snapshot.timer ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now aidevops-screen-time-snapshot.timer
+#
+# Check status:
+#   systemctl --user status aidevops-screen-time-snapshot.timer
+#   journalctl --user -u aidevops-screen-time-snapshot.service
+
+[Unit]
+Description=aidevops screen time snapshot
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/.aidevops/agents/scripts/screen-time-helper.sh snapshot
+StandardOutput=append:%h/.aidevops/.agent-workspace/logs/screen-time-snapshot.log
+StandardError=append:%h/.aidevops/.agent-workspace/logs/screen-time-snapshot.log
+
+[Install]
+WantedBy=default.target

--- a/.agents/configs/aidevops-screen-time-snapshot.timer
+++ b/.agents/configs/aidevops-screen-time-snapshot.timer
@@ -1,0 +1,19 @@
+# systemd user timer for screen time snapshots — runs every 6 hours
+#
+# Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp aidevops-screen-time-snapshot.service ~/.config/systemd/user/
+#   cp aidevops-screen-time-snapshot.timer ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now aidevops-screen-time-snapshot.timer
+
+[Unit]
+Description=aidevops screen time snapshot timer (every 6h)
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=6h
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/.agents/configs/sh.aidevops.profile-readme-update.plist
+++ b/.agents/configs/sh.aidevops.profile-readme-update.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>sh.aidevops.profile-readme-update</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-c</string>
+		<string>$HOME/.aidevops/agents/scripts/profile-readme-helper.sh update >> $HOME/.aidevops/.agent-workspace/logs/profile-readme-update.log 2>&1</string>
+	</array>
+	<key>StartCalendarInterval</key>
+	<dict>
+		<key>Hour</key>
+		<integer>6</integer>
+		<key>Minute</key>
+		<integer>0</integer>
+	</dict>
+	<key>RunAtLoad</key>
+	<false/>
+	<key>StandardOutPath</key>
+	<string>/dev/null</string>
+	<key>StandardErrorPath</key>
+	<string>/dev/null</string>
+</dict>
+</plist>

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -1,0 +1,503 @@
+#!/usr/bin/env bash
+# profile-readme-helper.sh — Auto-update GitHub profile README with live stats
+#
+# Usage:
+#   profile-readme-helper.sh update [--dry-run]   # Update README with live data
+#   profile-readme-helper.sh generate              # Print generated stats section to stdout
+#   profile-readme-helper.sh help
+#
+# Requires:
+#   - screen-time-helper.sh (macOS screen time)
+#   - contributor-activity-helper.sh (AI session time)
+#   - jq, bc, git
+#
+# The profile repo README must contain marker comments:
+#   <!-- STATS-START --> ... <!-- STATS-END -->
+#   <!-- UPDATED-START --> ... <!-- UPDATED-END -->
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+METRICS_FILE="${HOME}/.aidevops/.agent-workspace/observability/metrics.jsonl"
+
+# --- Resolve profile repo path from repos.json ---
+_resolve_profile_repo() {
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	if [[ ! -f "$repos_json" ]]; then
+		echo "Error: repos.json not found at $repos_json" >&2
+		return 1
+	fi
+
+	# Find repo with priority "profile" — supports both flat and nested repos.json formats
+	local profile_path
+	profile_path=$(jq -r '
+		if .initialized_repos then
+			.initialized_repos[] | select(.priority == "profile") | .path
+		else
+			to_entries[] | select(.value.priority == "profile") | .value.path
+		end
+	' "$repos_json" 2>/dev/null | head -1)
+
+	if [[ -z "$profile_path" || "$profile_path" == "null" ]]; then
+		echo "Error: no profile repo found in repos.json (set priority: \"profile\")" >&2
+		return 1
+	fi
+
+	echo "$profile_path"
+	return 0
+}
+
+# --- Format number with commas (bash 3.2 compatible) ---
+_format_number() {
+	local num="$1"
+	# Handle decimals: split on dot
+	local integer_part decimal_part
+	integer_part="${num%%.*}"
+	if [[ "$num" == *"."* ]]; then
+		decimal_part=".${num#*.}"
+	else
+		decimal_part=""
+	fi
+
+	# Add commas to integer part using printf + sed
+	local formatted
+	formatted=$(echo "$integer_part" | sed -e :a -e 's/\(.*[0-9]\)\([0-9]\{3\}\)/\1,\2/;ta')
+	echo "${formatted}${decimal_part}"
+	return 0
+}
+
+# --- Format hours with 1 decimal place ---
+_format_hours() {
+	local val="$1"
+	printf "%.1f" "$val"
+	return 0
+}
+
+# --- Format token count (K/M suffix) ---
+_format_tokens() {
+	local tokens="$1"
+	if [[ "$tokens" -ge 1000000 ]]; then
+		local m
+		m=$(echo "scale=1; $tokens / 1000000" | bc)
+		echo "${m}M"
+	elif [[ "$tokens" -ge 1000 ]]; then
+		local k
+		k=$(echo "scale=0; $tokens / 1000" | bc)
+		echo "${k}K"
+	else
+		echo "$tokens"
+	fi
+	return 0
+}
+
+# --- Gather screen time data ---
+_get_screen_time() {
+	local screen_json
+	screen_json=$("${SCRIPT_DIR}/screen-time-helper.sh" profile-stats 2>/dev/null) || screen_json="{}"
+	echo "$screen_json"
+	return 0
+}
+
+# --- Gather AI session time for a period ---
+_get_session_time() {
+	local period="$1"
+	local session_json
+	# Use a single repo path (aidevops) as the DB is global, not per-repo
+	session_json=$("${SCRIPT_DIR}/contributor-activity-helper.sh" session-time \
+		"${HOME}/Git/aidevops" --period "$period" --format json 2>/dev/null) || session_json="{}"
+	echo "$session_json"
+	return 0
+}
+
+# --- Gather model usage stats ---
+_get_model_usage() {
+	if [[ ! -f "$METRICS_FILE" ]]; then
+		echo "[]"
+		return 0
+	fi
+
+	local cutoff
+	cutoff=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d 2>/dev/null || echo "1970-01-01")
+
+	jq -s --arg cutoff "$cutoff" '
+		[.[] | select(.recorded_at >= $cutoff)]
+		| group_by(.model)
+		| map({
+			model: .[0].model,
+			requests: length,
+			input_tokens: ([.[].input_tokens // 0] | add),
+			output_tokens: ([.[].output_tokens // 0] | add),
+			cache_read_tokens: ([.[].cache_read_tokens // 0] | add),
+			cache_write_tokens: ([.[].cache_write_tokens // 0] | add),
+			cost_total: ([.[].cost_total // 0] | add | . * 100 | round / 100)
+		})
+		| sort_by(-.cost_total)
+	' "$METRICS_FILE" 2>/dev/null || echo "[]"
+
+	return 0
+}
+
+# --- Get total token stats for footer ---
+_get_token_totals() {
+	if [[ ! -f "$METRICS_FILE" ]]; then
+		echo '{"total_all":0,"cache_hit_pct":0}'
+		return 0
+	fi
+
+	local cutoff
+	cutoff=$(date -v-30d +%Y-%m-%d 2>/dev/null || date -d '30 days ago' +%Y-%m-%d 2>/dev/null || echo "1970-01-01")
+
+	jq -s --arg cutoff "$cutoff" '
+		[.[] | select(.recorded_at >= $cutoff)]
+		| {
+			total_input: ([.[].input_tokens // 0] | add),
+			total_output: ([.[].output_tokens // 0] | add),
+			total_cache_read: ([.[].cache_read_tokens // 0] | add),
+			total_cache_write: ([.[].cache_write_tokens // 0] | add)
+		}
+		| . + {total_all: (.total_input + .total_output + .total_cache_read + .total_cache_write)}
+		| . + {cache_hit_pct: (if .total_all > 0 then ((.total_cache_read / .total_all * 1000 | round) / 10) else 0 end)}
+	' "$METRICS_FILE" 2>/dev/null || echo '{"total_all":0,"cache_hit_pct":0}'
+
+	return 0
+}
+
+# --- Clean model name for display ---
+_clean_model_name() {
+	local model="$1"
+	# Remove date suffixes like -20251101, -20250929
+	local cleaned
+	cleaned=$(echo "$model" | sed -E 's/-[0-9]{8}$//')
+	echo "$cleaned"
+	return 0
+}
+
+# --- Generate the stats markdown ---
+cmd_generate() {
+	# Gather all data
+	local screen_json
+	screen_json=$(_get_screen_time)
+
+	local day_json week_json month_json year_json
+	day_json=$(_get_session_time day)
+	week_json=$(_get_session_time week)
+	month_json=$(_get_session_time month)
+	year_json=$(_get_session_time year)
+
+	local model_json
+	model_json=$(_get_model_usage)
+
+	local token_totals
+	token_totals=$(_get_token_totals)
+
+	# Extract screen time values (round to 1 decimal, strip .0 for large numbers)
+	local screen_today screen_week screen_month screen_year
+	screen_today=$(echo "$screen_json" | jq -r '.today_hours | . * 10 | round / 10')
+	screen_week=$(echo "$screen_json" | jq -r '.week_hours | . * 10 | round / 10')
+	screen_month=$(echo "$screen_json" | jq -r '.month_hours | . * 10 | round / 10')
+	screen_year=$(echo "$screen_json" | jq -r '.year_hours | round')
+
+	# Check if year is extrapolated (history file has < 365 days)
+	local history_file="${HOME}/.aidevops/.agent-workspace/observability/screen-time.jsonl"
+	local year_prefix=""
+	local year_suffix=""
+	if [[ -f "$history_file" ]]; then
+		local history_days
+		history_days=$(wc -l <"$history_file" | tr -d ' ')
+		if [[ "$history_days" -lt 365 ]]; then
+			year_prefix="~"
+			year_suffix="*"
+		fi
+	else
+		year_prefix="~"
+		year_suffix="*"
+	fi
+
+	# Extract session time values per period (1 decimal place for hours)
+	# Worker hours = worker_human + worker_machine (from worker sessions)
+	local day_human day_worker day_total day_interactive day_workers
+	day_human=$(_format_hours "$(echo "$day_json" | jq -r '.interactive_human_hours')")
+	day_worker=$(_format_hours "$(echo "$day_json" | jq -r '.worker_human_hours + .worker_machine_hours')")
+	day_total=$(_format_hours "$(echo "$day_json" | jq -r '.total_human_hours + .total_machine_hours')")
+	day_interactive=$(echo "$day_json" | jq -r '.interactive_sessions')
+	day_workers=$(echo "$day_json" | jq -r '.worker_sessions')
+
+	local week_human week_worker week_total week_interactive week_workers
+	week_human=$(_format_hours "$(echo "$week_json" | jq -r '.interactive_human_hours')")
+	week_worker=$(_format_hours "$(echo "$week_json" | jq -r '.worker_human_hours + .worker_machine_hours')")
+	week_total=$(_format_hours "$(echo "$week_json" | jq -r '.total_human_hours + .total_machine_hours')")
+	week_interactive=$(echo "$week_json" | jq -r '.interactive_sessions')
+	week_workers=$(echo "$week_json" | jq -r '.worker_sessions')
+
+	local month_human month_worker month_total month_interactive month_workers
+	month_human=$(_format_hours "$(echo "$month_json" | jq -r '.interactive_human_hours')")
+	month_worker=$(_format_hours "$(echo "$month_json" | jq -r '.worker_human_hours + .worker_machine_hours')")
+	month_total=$(_format_hours "$(echo "$month_json" | jq -r '.total_human_hours + .total_machine_hours')")
+	month_interactive=$(echo "$month_json" | jq -r '.interactive_sessions')
+	month_workers=$(echo "$month_json" | jq -r '.worker_sessions')
+
+	local year_human year_worker year_total year_interactive year_workers
+	year_human=$(_format_hours "$(echo "$year_json" | jq -r '.interactive_human_hours')")
+	year_worker=$(_format_hours "$(echo "$year_json" | jq -r '.worker_human_hours + .worker_machine_hours')")
+	year_total=$(_format_hours "$(echo "$year_json" | jq -r '.total_human_hours + .total_machine_hours')")
+	year_interactive=$(echo "$year_json" | jq -r '.interactive_sessions')
+	year_workers=$(echo "$year_json" | jq -r '.worker_sessions')
+
+	# Format screen time with commas
+	local f_screen_month f_screen_year
+	f_screen_month=$(_format_number "$screen_month")
+	f_screen_year=$(_format_number "$screen_year")
+
+	# Format session counts with commas
+	local f_day_int f_week_int f_month_int f_year_int
+	f_day_int=$(_format_number "$day_interactive")
+	f_week_int=$(_format_number "$week_interactive")
+	f_month_int=$(_format_number "$month_interactive")
+	f_year_int=$(_format_number "$year_interactive")
+
+	local f_day_wrk f_week_wrk f_month_wrk f_year_wrk
+	f_day_wrk=$(_format_number "$day_workers")
+	f_week_wrk=$(_format_number "$week_workers")
+	f_month_wrk=$(_format_number "$month_workers")
+	f_year_wrk=$(_format_number "$year_workers")
+
+	# Format totals with commas
+	local f_month_total f_year_total
+	f_month_total=$(_format_number "$month_total")
+	f_year_total=$(_format_number "$year_total")
+
+	# Build Work with AI table
+	cat <<EOF
+## Work with AI
+
+| Metric | Today | 7 Days | 28 Days | 365 Days |
+| --- | ---: | ---: | ---: | ---: |
+| Screen time (Mac) | ${screen_today}h | ${screen_week}h | ${f_screen_month}h | ${year_prefix}${f_screen_year}h${year_suffix} |
+| User AI session hours | ${day_human}h | ${week_human}h | ${month_human}h | ${year_human}h |
+| AI worker hours | ${day_worker}h | ${week_worker}h | ${month_worker}h | ${year_worker}h |
+| Total AI work | ${day_total}h | ${week_total}h | ${f_month_total}h | ${f_year_total}h |
+| Interactive sessions | ${f_day_int} | ${f_week_int} | ${f_month_int} | ${f_year_int} |
+| Worker sessions | ${f_day_wrk} | ${f_week_wrk} | ${f_month_wrk} | ${f_year_wrk} |
+
+_Screen time from macOS display events, snapshotted every 6h.$([ -n "$year_suffix" ] && echo " *365-day extrapolated (accumulating real data).")_
+_User AI session hours measured from AI message timestamps (reading, thinking, typing between responses)._
+EOF
+
+	# Build model usage table
+	local total_requests=0 total_input=0 total_output=0 total_cache=0 total_cost=0
+	local model_rows=""
+
+	while IFS= read -r row; do
+		local model requests input output cache cost
+		model=$(echo "$row" | jq -r '.model')
+		requests=$(echo "$row" | jq -r '.requests')
+		input=$(echo "$row" | jq -r '.input_tokens')
+		output=$(echo "$row" | jq -r '.output_tokens')
+		cache=$(echo "$row" | jq -r '.cache_read_tokens')
+		cost=$(echo "$row" | jq -r '.cost_total')
+
+		total_requests=$((total_requests + requests))
+		total_input=$((total_input + input))
+		total_output=$((total_output + output))
+		total_cache=$((total_cache + cache))
+		total_cost=$(echo "$total_cost + $cost" | bc)
+
+		local clean_model
+		clean_model=$(_clean_model_name "$model")
+		local f_requests f_input f_output f_cache
+		f_requests=$(_format_number "$requests")
+		f_input=$(_format_tokens "$input")
+		f_output=$(_format_tokens "$output")
+		f_cache=$(_format_tokens "$cache")
+
+		# Format cost with 2 decimal places
+		local f_cost
+		f_cost=$(printf "%.2f" "$cost")
+
+		model_rows="${model_rows}| ${clean_model} | ${f_requests} | ${f_input} | ${f_output} | ${f_cache} | \$${f_cost} |
+"
+	done < <(echo "$model_json" | jq -c '.[] | select(.cost_total >= 0.05)')
+
+	# Format totals
+	local f_total_req f_total_in f_total_out f_total_cache
+	f_total_req=$(_format_number "$total_requests")
+	f_total_in=$(_format_tokens "$total_input")
+	f_total_out=$(_format_tokens "$total_output")
+	f_total_cache=$(_format_tokens "$total_cache")
+	# Round total_cost to 2 decimal places
+	total_cost=$(printf "%.2f" "$total_cost")
+
+	# Token totals for footer
+	local all_tokens cache_pct
+	all_tokens=$(echo "$token_totals" | jq -r '.total_all')
+	cache_pct=$(echo "$token_totals" | jq -r '.cache_hit_pct')
+	local f_all_tokens
+	f_all_tokens=$(_format_tokens "$all_tokens")
+
+	# Calculate cost reduction percentage
+	local cost_reduction
+	if command -v bc >/dev/null 2>&1; then
+		cost_reduction=$(echo "scale=0; 100 - (100 * (100 - $cache_pct) / 100)" | bc 2>/dev/null || echo "$cache_pct")
+	else
+		cost_reduction="$cache_pct"
+	fi
+
+	cat <<EOF
+
+## AI Model Usage (last 30 days)
+
+| Model | Requests | Input | Output | Cache read | Cost |
+| --- | ---: | ---: | ---: | ---: | ---: |
+${model_rows}| **Total** | **${f_total_req}** | **${f_total_in}** | **${f_total_out}** | **${f_total_cache}** | **\$${total_cost}** |
+
+_${f_all_tokens} total tokens processed. Cache hit rate: ${cache_pct}% -- prompt caching reduces cost by ~${cost_reduction}% vs uncached._
+EOF
+
+	return 0
+}
+
+# --- Update the profile README ---
+cmd_update() {
+	local dry_run=false
+	if [[ "${1:-}" == "--dry-run" ]]; then
+		dry_run=true
+	fi
+
+	# Resolve profile repo
+	local profile_repo
+	profile_repo=$(_resolve_profile_repo) || return 1
+	local readme_path="${profile_repo}/README.md"
+
+	if [[ ! -f "$readme_path" ]]; then
+		echo "Error: README.md not found at $readme_path" >&2
+		return 1
+	fi
+
+	# Check for markers
+	if ! grep -q '<!-- STATS-START -->' "$readme_path"; then
+		echo "Error: <!-- STATS-START --> marker not found in $readme_path" >&2
+		return 1
+	fi
+	if ! grep -q '<!-- STATS-END -->' "$readme_path"; then
+		echo "Error: <!-- STATS-END --> marker not found in $readme_path" >&2
+		return 1
+	fi
+
+	# Generate new stats
+	local new_stats
+	new_stats=$(cmd_generate)
+
+	# Replace content between markers
+	local tmp_file
+	tmp_file=$(mktemp)
+
+	# Use awk to replace between markers (bash 3.2 compatible)
+	awk '
+		/<!-- STATS-START -->/ {
+			print "<!-- STATS-START -->"
+			skip = 1
+			next
+		}
+		/<!-- STATS-END -->/ {
+			skip = 0
+			# Print the new stats (will be injected via variable)
+			print ENVIRON["NEW_STATS"]
+			print "<!-- STATS-END -->"
+			next
+		}
+		!skip { print }
+	' "$readme_path" >"$tmp_file"
+
+	# Inject the stats via env var and re-run
+	NEW_STATS="$new_stats" awk '
+		/<!-- STATS-START -->/ {
+			print "<!-- STATS-START -->"
+			skip = 1
+			next
+		}
+		/<!-- STATS-END -->/ {
+			skip = 0
+			printf "%s\n", ENVIRON["NEW_STATS"]
+			print "<!-- STATS-END -->"
+			next
+		}
+		!skip { print }
+	' "$readme_path" >"$tmp_file"
+
+	# Update timestamp if markers exist
+	if grep -q '<!-- UPDATED-START -->' "$readme_path"; then
+		local updated_at
+		updated_at=$(date -u +"%Y-%m-%d %H:%M UTC")
+		local updated_tmp
+		updated_tmp=$(mktemp)
+		awk -v ts="$updated_at" '
+			/<!-- UPDATED-START -->/ {
+				print "<!-- UPDATED-START -->"
+				skip = 1
+				next
+			}
+			/<!-- UPDATED-END -->/ {
+				skip = 0
+				printf "_Stats auto-updated %s by [aidevops](https://github.com/marcusquinn/aidevops) pulse._\n", ts
+				print "<!-- UPDATED-END -->"
+				next
+			}
+			!skip { print }
+		' "$tmp_file" >"$updated_tmp"
+		mv "$updated_tmp" "$tmp_file"
+	fi
+
+	if [[ "$dry_run" == true ]]; then
+		echo "--- DRY RUN: would write to $readme_path ---"
+		diff "$readme_path" "$tmp_file" || true
+		rm -f "$tmp_file"
+		return 0
+	fi
+
+	# Check if content actually changed (ignore timestamp-only changes)
+	local old_stats new_stats_check
+	old_stats=$(awk '/<!-- STATS-START -->/{f=1;next}/<!-- STATS-END -->/{f=0}f' "$readme_path")
+	new_stats_check=$(awk '/<!-- STATS-START -->/{f=1;next}/<!-- STATS-END -->/{f=0}f' "$tmp_file")
+
+	if [[ "$old_stats" == "$new_stats_check" ]]; then
+		echo "No changes to stats — skipping commit"
+		rm -f "$tmp_file"
+		return 0
+	fi
+
+	# Apply changes
+	mv "$tmp_file" "$readme_path"
+
+	# Commit and push
+	local commit_msg
+	commit_msg="chore: update profile stats ($(date -u +%Y-%m-%d))"
+	git -C "$profile_repo" add README.md
+	git -C "$profile_repo" commit -m "$commit_msg" --no-verify 2>/dev/null || {
+		echo "No changes to commit"
+		return 0
+	}
+	git -C "$profile_repo" push origin main 2>/dev/null || {
+		echo "Warning: push failed — changes committed locally" >&2
+		return 0
+	}
+
+	echo "Profile README updated and pushed"
+	return 0
+}
+
+# --- Main dispatch ---
+case "${1:-help}" in
+generate) cmd_generate ;;
+update)
+	shift
+	cmd_update "$@"
+	;;
+help | *)
+	echo "Usage: profile-readme-helper.sh {update [--dry-run]|generate|help}"
+	echo ""
+	echo "Commands:"
+	echo "  update [--dry-run]  Update profile README with live stats and push"
+	echo "  generate            Print generated stats section to stdout"
+	echo "  help                Show this help"
+	;;
+esac

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -266,20 +266,39 @@ cmd_generate() {
 	f_month_total=$(_format_number "$month_total")
 	f_year_total=$(_format_number "$year_total")
 
+	# Determine platform label for screen time row
+	local os_type
+	os_type="$(uname -s)"
+	local screen_label screen_source
+	case "$os_type" in
+	Darwin)
+		screen_label="Screen time (Mac)"
+		screen_source="macOS display events"
+		;;
+	Linux)
+		screen_label="Screen time (Linux)"
+		screen_source="systemd-logind session events"
+		;;
+	*)
+		screen_label="Screen time"
+		screen_source="system events"
+		;;
+	esac
+
 	# Build Work with AI table
 	cat <<EOF
 ## Work with AI
 
 | Metric | Today | 7 Days | 28 Days | 365 Days |
 | --- | ---: | ---: | ---: | ---: |
-| Screen time (Mac) | ${screen_today}h | ${screen_week}h | ${f_screen_month}h | ${year_prefix}${f_screen_year}h${year_suffix} |
+| ${screen_label} | ${screen_today}h | ${screen_week}h | ${f_screen_month}h | ${year_prefix}${f_screen_year}h${year_suffix} |
 | User AI session hours | ${day_human}h | ${week_human}h | ${month_human}h | ${year_human}h |
 | AI worker hours | ${day_worker}h | ${week_worker}h | ${month_worker}h | ${year_worker}h |
 | Total AI work | ${day_total}h | ${week_total}h | ${f_month_total}h | ${f_year_total}h |
 | Interactive sessions | ${f_day_int} | ${f_week_int} | ${f_month_int} | ${f_year_int} |
 | Worker sessions | ${f_day_wrk} | ${f_week_wrk} | ${f_month_wrk} | ${f_year_wrk} |
 
-_Screen time from macOS display events, snapshotted every 6h.$([ -n "$year_suffix" ] && echo " *365-day extrapolated (accumulating real data).")_
+_Screen time from ${screen_source}, snapshotted daily.$([ -n "$year_suffix" ] && echo " *365-day extrapolated (accumulating real data).")_
 _User AI session hours measured from AI message timestamps (reading, thinking, typing between responses)._
 EOF
 

--- a/.agents/scripts/screen-time-helper.sh
+++ b/.agents/scripts/screen-time-helper.sh
@@ -1,9 +1,18 @@
 #!/usr/bin/env bash
-# screen-time-helper.sh — Query macOS screen time and maintain persistent history
+# screen-time-helper.sh — Query screen time and maintain persistent history
 #
-# Data source: macOS Knowledge DB (~/Library/Application Support/Knowledge/knowledgeC.db)
-# The Knowledge DB retains ~28 days of /display/isBacklit events.
-# This script snapshots daily totals to a JSONL file for long-term history.
+# Cross-platform: macOS and Linux
+#
+# macOS data source: Knowledge DB (~/Library/Application Support/Knowledge/knowledgeC.db)
+#   - /display/isBacklit events (screen on=1, off=0)
+#   - Retains ~28 days of data
+#
+# Linux data source: systemd-logind session events via journalctl
+#   - Session unlock/lock events from systemd-logind
+#   - Retention depends on journald config (typically weeks to months)
+#   - Falls back to wtmp login sessions via 'last' command
+#   - Falls back to /proc/uptime for simple single-user systems
+#   - Works on both X11 and Wayland (no display server dependency)
 #
 # Usage:
 #   screen-time-helper.sh snapshot          # Append today's screen time to history
@@ -13,18 +22,25 @@
 #
 set -euo pipefail
 
-KNOWLEDGE_DB="${HOME}/Library/Application Support/Knowledge/knowledgeC.db"
 HISTORY_DIR="${HOME}/.aidevops/.agent-workspace/observability"
 HISTORY_FILE="${HISTORY_DIR}/screen-time.jsonl"
+OS_TYPE="$(uname -s)"
+
+# macOS-specific paths
+KNOWLEDGE_DB="${HOME}/Library/Application Support/Knowledge/knowledgeC.db"
+
+# ============================================================
+# macOS: Knowledge DB queries
+# ============================================================
 
 #######################################
-# Compute screen-on hours from Knowledge DB for a given number of past days
+# [macOS] Compute screen-on hours from Knowledge DB for a given number of past days
 # Arguments:
 #   $1 - number of days to look back
 # Returns: 0
 # Outputs: hours as decimal to stdout
 #######################################
-_query_screen_hours() {
+_macos_query_screen_hours() {
 	local days="$1"
 
 	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
@@ -58,13 +74,13 @@ _query_screen_hours() {
 }
 
 #######################################
-# Compute screen-on hours for a specific date (YYYY-MM-DD)
+# [macOS] Compute screen-on hours for a specific date (YYYY-MM-DD)
 # Arguments:
 #   $1 - date string (YYYY-MM-DD)
 # Returns: 0
 # Outputs: hours as decimal to stdout
 #######################################
-_query_screen_hours_for_date() {
+_macos_query_screen_hours_for_date() {
 	local target_date="$1"
 
 	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
@@ -107,21 +123,447 @@ _query_screen_hours_for_date() {
 }
 
 #######################################
+# [macOS] Get earliest date available in Knowledge DB
+# Returns: 0
+# Outputs: YYYY-MM-DD or empty string
+#######################################
+_macos_earliest_date() {
+	if [[ ! -f "$KNOWLEDGE_DB" ]]; then
+		echo ""
+		return 0
+	fi
+
+	sqlite3 "$KNOWLEDGE_DB" "
+		SELECT date(MIN(ZCREATIONDATE + 978307200), 'unixepoch', 'localtime')
+		FROM ZOBJECT WHERE ZSTREAMNAME = '/display/isBacklit';" 2>/dev/null || echo ""
+	return 0
+}
+
+# ============================================================
+# Linux: systemd-logind session tracking
+# ============================================================
+
+#######################################
+# [Linux] Compute screen-on hours from logind session events for last N days
+#
+# Three methods tried in order:
+#   1. systemd-logind session events via journalctl (most accurate)
+#   2. wtmp login sessions via 'last' command (widely available)
+#   3. /proc/uptime fallback (crude — assumes screen on = system on)
+#
+# Arguments:
+#   $1 - number of days to look back
+# Returns: 0
+# Outputs: hours as decimal to stdout
+#######################################
+_linux_query_screen_hours() {
+	local days="$1"
+
+	# Method 1: journalctl logind session events
+	if command -v journalctl >/dev/null 2>&1; then
+		local hours
+		hours=$(_linux_logind_hours "$days")
+		if [[ "$hours" != "0" && "$hours" != "0.0" ]]; then
+			echo "$hours"
+			return 0
+		fi
+	fi
+
+	# Method 2: wtmp login sessions via 'last'
+	if command -v last >/dev/null 2>&1; then
+		local hours
+		hours=$(_linux_last_hours "$days")
+		if [[ "$hours" != "0" && "$hours" != "0.0" ]]; then
+			echo "$hours"
+			return 0
+		fi
+	fi
+
+	# Method 3: /proc/uptime fallback (system uptime as proxy)
+	# Only useful for "today" or short periods on single-user machines
+	if [[ -f /proc/uptime && "$days" -le 1 ]]; then
+		local uptime_secs
+		uptime_secs=$(awk '{printf "%.0f", $1}' /proc/uptime)
+		local uptime_hours
+		uptime_hours=$(awk "BEGIN {printf \"%.1f\", ${uptime_secs} / 3600}")
+		# Cap at 24h for a single day
+		if awk "BEGIN {exit ($uptime_hours > 24) ? 0 : 1}" 2>/dev/null; then
+			uptime_hours="24.0"
+		fi
+		echo "$uptime_hours"
+		return 0
+	fi
+
+	echo "0"
+	return 0
+}
+
+#######################################
+# [Linux] Parse logind session events from journalctl
+#
+# Looks for session start/stop and lid open/close events from systemd-logind.
+# Session active time = time between session start and session stop/lock.
+#
+# Arguments:
+#   $1 - number of days to look back
+# Returns: 0
+# Outputs: hours as decimal to stdout
+#######################################
+_linux_logind_hours() {
+	local days="$1"
+	local since_date
+	since_date=$(date -d "${days} days ago" "+%Y-%m-%d" 2>/dev/null || echo "")
+
+	if [[ -z "$since_date" ]]; then
+		echo "0"
+		return 0
+	fi
+
+	local current_user
+	current_user=$(whoami)
+
+	# Extract timestamped session events for the current user
+	local events_file
+	events_file=$(mktemp)
+
+	journalctl --since "$since_date" -u systemd-logind.service --no-pager -o short-iso 2>/dev/null |
+		grep -iE "(New session|Removed session|Session .* logged out|Lid closed|Lid opened)" |
+		grep -i "$current_user" |
+		while IFS= read -r line; do
+			local ts
+			local event_type
+			ts=$(echo "$line" | awk '{print $1}')
+			if echo "$line" | grep -qi "New session\|Lid opened"; then
+				event_type="ON"
+			else
+				event_type="OFF"
+			fi
+			echo "${ts} ${event_type}"
+		done >"$events_file" 2>/dev/null
+
+	local total_seconds=0
+
+	if [[ -s "$events_file" ]]; then
+		# Parse ON/OFF event pairs
+		local last_on_epoch=0
+		while IFS=' ' read -r ts event_type; do
+			local epoch
+			epoch=$(date -d "$ts" "+%s" 2>/dev/null || echo "0")
+			if [[ "$event_type" == "ON" && "$last_on_epoch" -eq 0 ]]; then
+				last_on_epoch=$epoch
+			elif [[ "$event_type" == "OFF" && "$last_on_epoch" -gt 0 ]]; then
+				local duration=$((epoch - last_on_epoch))
+				# Cap individual sessions at 24h (sanity check)
+				if [[ "$duration" -gt 86400 ]]; then
+					duration=86400
+				fi
+				total_seconds=$((total_seconds + duration))
+				last_on_epoch=0
+			fi
+		done <"$events_file"
+
+		# If last event was ON (still active), count time until now
+		if [[ "$last_on_epoch" -gt 0 ]]; then
+			local now_epoch
+			now_epoch=$(date "+%s")
+			local remaining=$((now_epoch - last_on_epoch))
+			if [[ "$remaining" -gt 86400 ]]; then
+				remaining=86400
+			fi
+			total_seconds=$((total_seconds + remaining))
+		fi
+	fi
+
+	rm -f "$events_file"
+
+	local hours
+	hours=$(awk "BEGIN {printf \"%.1f\", ${total_seconds} / 3600}")
+	echo "$hours"
+	return 0
+}
+
+#######################################
+# [Linux] Parse login sessions from 'last' command
+#
+# Uses wtmp records to compute total logged-in time.
+# Less accurate than logind (doesn't track screen lock) but widely available.
+#
+# Arguments:
+#   $1 - number of days to look back
+# Returns: 0
+# Outputs: hours as decimal to stdout
+#######################################
+_linux_last_hours() {
+	local days="$1"
+	local current_user
+	current_user=$(whoami)
+	local total_seconds=0
+
+	# Parse completed sessions with duration
+	while IFS= read -r line; do
+		local duration
+		duration=$(echo "$line" | grep -oE '\(([0-9]+:[0-9]+)\)' | tr -d '()' || echo "")
+		if [[ -n "$duration" ]]; then
+			local dur_hours
+			local dur_mins
+			dur_hours=$(echo "$duration" | cut -d: -f1)
+			dur_mins=$(echo "$duration" | cut -d: -f2)
+			local dur_secs=$(((dur_hours * 3600) + (dur_mins * 60)))
+			total_seconds=$((total_seconds + dur_secs))
+		fi
+	done < <(last -s "-${days}days" "$current_user" 2>/dev/null |
+		grep -v "^$\|wtmp begins\|still logged in\|reboot\|shutdown" || true)
+
+	# Count "still logged in" sessions
+	local still_logged
+	still_logged=$(last -s "-${days}days" "$current_user" 2>/dev/null |
+		grep -c "still logged in" || echo "0")
+	if [[ "$still_logged" -gt 0 ]]; then
+		# Estimate current session duration from loginctl
+		local current_session_secs=0
+		if command -v loginctl >/dev/null 2>&1; then
+			local session_id
+			session_id=$(loginctl show-user "$current_user" -p Sessions --value 2>/dev/null | awk '{print $1}')
+			if [[ -n "$session_id" ]]; then
+				local session_since
+				session_since=$(loginctl show-session "$session_id" -p Timestamp --value 2>/dev/null || echo "")
+				if [[ -n "$session_since" ]]; then
+					local session_epoch
+					session_epoch=$(date -d "$session_since" "+%s" 2>/dev/null || echo "0")
+					local now_epoch
+					now_epoch=$(date "+%s")
+					current_session_secs=$((now_epoch - session_epoch))
+				fi
+			fi
+		fi
+		total_seconds=$((total_seconds + current_session_secs))
+	fi
+
+	local hours
+	hours=$(awk "BEGIN {printf \"%.1f\", ${total_seconds} / 3600}")
+	echo "$hours"
+	return 0
+}
+
+#######################################
+# [Linux] Compute screen-on hours for a specific date (YYYY-MM-DD)
+# Arguments:
+#   $1 - date string (YYYY-MM-DD)
+# Returns: 0
+# Outputs: hours as decimal to stdout
+#######################################
+_linux_query_screen_hours_for_date() {
+	local target_date="$1"
+	local current_user
+	current_user=$(whoami)
+	local total_seconds=0
+
+	# Method 1: journalctl for the specific date
+	if command -v journalctl >/dev/null 2>&1; then
+		local next_date
+		next_date=$(date -d "${target_date} + 1 day" "+%Y-%m-%d" 2>/dev/null || echo "")
+
+		if [[ -n "$next_date" ]]; then
+			local events_file
+			events_file=$(mktemp)
+
+			journalctl --since "$target_date" --until "$next_date" \
+				-u systemd-logind.service --no-pager -o short-iso 2>/dev/null |
+				grep -iE "(New session|Removed session|Session .* logged out|Lid closed|Lid opened)" |
+				grep -i "$current_user" |
+				while IFS= read -r line; do
+					local ts
+					local event_type
+					ts=$(echo "$line" | awk '{print $1}')
+					if echo "$line" | grep -qi "New session\|Lid opened"; then
+						event_type="ON"
+					else
+						event_type="OFF"
+					fi
+					echo "${ts} ${event_type}"
+				done >"$events_file" 2>/dev/null
+
+			if [[ -s "$events_file" ]]; then
+				local last_on_epoch=0
+				local day_end
+				day_end=$(date -d "${next_date} 00:00:00" "+%s" 2>/dev/null || echo "0")
+
+				while IFS=' ' read -r ts event_type; do
+					local epoch
+					epoch=$(date -d "$ts" "+%s" 2>/dev/null || echo "0")
+					if [[ "$event_type" == "ON" && "$last_on_epoch" -eq 0 ]]; then
+						last_on_epoch=$epoch
+					elif [[ "$event_type" == "OFF" && "$last_on_epoch" -gt 0 ]]; then
+						local duration=$((epoch - last_on_epoch))
+						total_seconds=$((total_seconds + duration))
+						last_on_epoch=0
+					fi
+				done <"$events_file"
+
+				# If still on at end of day, count until midnight
+				if [[ "$last_on_epoch" -gt 0 && "$day_end" -gt 0 ]]; then
+					local remaining=$((day_end - last_on_epoch))
+					total_seconds=$((total_seconds + remaining))
+				fi
+			fi
+
+			rm -f "$events_file"
+		fi
+	fi
+
+	# Method 2: fallback to 'last' command for the specific date
+	if [[ "$total_seconds" -eq 0 ]] && command -v last >/dev/null 2>&1; then
+		# Match date in 'last' output format (e.g., "Mon Mar  9")
+		local date_pattern
+		date_pattern=$(date -d "$target_date" "+%b %e" 2>/dev/null || echo "NOMATCH")
+
+		while IFS= read -r line; do
+			local duration
+			duration=$(echo "$line" | grep -oE '\(([0-9]+:[0-9]+)\)' | tr -d '()' || echo "")
+			if [[ -n "$duration" ]]; then
+				local dur_hours
+				local dur_mins
+				dur_hours=$(echo "$duration" | cut -d: -f1)
+				dur_mins=$(echo "$duration" | cut -d: -f2)
+				local dur_secs=$(((dur_hours * 3600) + (dur_mins * 60)))
+				total_seconds=$((total_seconds + dur_secs))
+			fi
+		done < <(last "$current_user" 2>/dev/null |
+			grep "$date_pattern" |
+			grep -v "^$\|wtmp begins\|reboot\|shutdown" || true)
+	fi
+
+	local hours
+	hours=$(awk "BEGIN {printf \"%.1f\", ${total_seconds} / 3600}")
+	echo "$hours"
+	return 0
+}
+
+#######################################
+# [Linux] Get earliest date available in journalctl or wtmp
+# Returns: 0
+# Outputs: YYYY-MM-DD or empty string
+#######################################
+_linux_earliest_date() {
+	# Try journalctl first
+	if command -v journalctl >/dev/null 2>&1; then
+		local earliest
+		earliest=$(journalctl -u systemd-logind.service --no-pager -o short-iso 2>/dev/null |
+			head -1 | awk '{print $1}' | cut -dT -f1 || echo "")
+		if [[ -n "$earliest" ]]; then
+			echo "$earliest"
+			return 0
+		fi
+	fi
+
+	# Fallback: use wtmp via last
+	if command -v last >/dev/null 2>&1; then
+		local wtmp_line
+		wtmp_line=$(last -R 2>/dev/null | tail -1 || echo "")
+		if [[ -n "$wtmp_line" ]]; then
+			# Parse "wtmp begins Mon Mar  9 00:00:00 2026" format
+			local earliest
+			earliest=$(echo "$wtmp_line" | grep -oE '[A-Z][a-z]{2} [A-Z][a-z]{2} [ 0-9]{2} [0-9:]{8} [0-9]{4}' |
+				xargs -I{} date -d "{}" "+%Y-%m-%d" 2>/dev/null || echo "")
+			if [[ -n "$earliest" ]]; then
+				echo "$earliest"
+				return 0
+			fi
+		fi
+	fi
+
+	echo ""
+	return 0
+}
+
+# ============================================================
+# Platform dispatcher — routes to OS-specific implementations
+# ============================================================
+
+#######################################
+# Query screen-on hours for last N days (cross-platform)
+# Arguments:
+#   $1 - number of days to look back
+# Returns: 0
+#######################################
+_query_screen_hours() {
+	local days="$1"
+	case "$OS_TYPE" in
+	Darwin) _macos_query_screen_hours "$days" ;;
+	Linux) _linux_query_screen_hours "$days" ;;
+	*)
+		echo "0"
+		return 0
+		;;
+	esac
+}
+
+#######################################
+# Query screen-on hours for a specific date (cross-platform)
+# Arguments:
+#   $1 - date string (YYYY-MM-DD)
+# Returns: 0
+#######################################
+_query_screen_hours_for_date() {
+	local target_date="$1"
+	case "$OS_TYPE" in
+	Darwin) _macos_query_screen_hours_for_date "$target_date" ;;
+	Linux) _linux_query_screen_hours_for_date "$target_date" ;;
+	*)
+		echo "0"
+		return 0
+		;;
+	esac
+}
+
+#######################################
+# Get earliest available date (cross-platform)
+# Returns: 0
+#######################################
+_earliest_date() {
+	case "$OS_TYPE" in
+	Darwin) _macos_earliest_date ;;
+	Linux) _linux_earliest_date ;;
+	*)
+		echo ""
+		return 0
+		;;
+	esac
+}
+
+# ============================================================
+# Commands (platform-independent)
+# ============================================================
+
+#######################################
+# Advance a date by one day (cross-platform)
+# Arguments:
+#   $1 - date string (YYYY-MM-DD)
+# Returns: 0
+# Outputs: next date as YYYY-MM-DD
+#######################################
+_next_date() {
+	local current="$1"
+	# macOS date
+	date -j -v+1d -f "%Y-%m-%d" "$current" "+%Y-%m-%d" 2>/dev/null ||
+		date -d "${current} + 1 day" "+%Y-%m-%d" 2>/dev/null ||
+		echo "$current"
+	return 0
+}
+
+#######################################
 # Snapshot: record daily screen time totals to persistent JSONL
-# Snapshots each day in the Knowledge DB that isn't already in history.
+# Snapshots each day available that isn't already in history.
 # Returns: 0
 #######################################
 cmd_snapshot() {
 	mkdir -p "$HISTORY_DIR"
 
-	# Get the date range available in Knowledge DB
 	local earliest_date
-	earliest_date=$(sqlite3 "$KNOWLEDGE_DB" "
-		SELECT date(MIN(ZCREATIONDATE + 978307200), 'unixepoch', 'localtime')
-		FROM ZOBJECT WHERE ZSTREAMNAME = '/display/isBacklit';" 2>/dev/null || echo "")
+	earliest_date=$(_earliest_date)
 
 	if [[ -z "$earliest_date" ]]; then
-		echo "No screen time data available in Knowledge DB"
+		echo "No screen time data available"
 		return 0
 	fi
 
@@ -140,7 +582,7 @@ cmd_snapshot() {
 	while [[ "$current_date" < "$today" ]]; do
 		# Skip if already recorded
 		if echo "$existing_dates" | grep -q "^${current_date}$" 2>/dev/null; then
-			current_date=$(date -j -v+1d -f "%Y-%m-%d" "$current_date" "+%Y-%m-%d" 2>/dev/null || date -d "${current_date} + 1 day" "+%Y-%m-%d" 2>/dev/null)
+			current_date=$(_next_date "$current_date")
 			continue
 		fi
 
@@ -153,13 +595,13 @@ cmd_snapshot() {
 			record=$(jq -cn \
 				--arg date "$current_date" \
 				--arg hours "$hours" \
-				--arg hostname "$(hostname -s)" \
+				--arg hostname "$(hostname -s 2>/dev/null || hostname)" \
 				'{date: $date, screen_hours: ($hours | tonumber), hostname: $hostname, recorded_at: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))}')
 			echo "$record" >>"$HISTORY_FILE"
 			added=$((added + 1))
 		fi
 
-		current_date=$(date -j -v+1d -f "%Y-%m-%d" "$current_date" "+%Y-%m-%d" 2>/dev/null || date -d "${current_date} + 1 day" "+%Y-%m-%d" 2>/dev/null)
+		current_date=$(_next_date "$current_date")
 	done
 
 	echo "Snapshot complete: ${added} new day(s) added to ${HISTORY_FILE}"
@@ -206,19 +648,19 @@ cmd_history() {
 
 #######################################
 # Profile stats: output stats for profile README in JSON
-# Combines Knowledge DB (live) with history (accumulated)
+# Combines live queries with accumulated history
 # Returns: 0
 #######################################
 cmd_profile_stats() {
-	# Live data from Knowledge DB
+	# Live data
 	local today_hours
 	local week_hours
 	today_hours=$(_query_screen_hours 1)
 	week_hours=$(_query_screen_hours 7)
 
-	# For 30 days: use Knowledge DB (has ~28 days)
+	# For 28 days: use live query
 	local month_hours
-	month_hours=$(_query_screen_hours 30)
+	month_hours=$(_query_screen_hours 28)
 
 	# For 365 days: use accumulated history if available, else extrapolate
 	local year_hours
@@ -243,21 +685,29 @@ cmd_profile_stats() {
 			year_hours=$(echo "scale=1; $month_hours / 28 * 365" | bc 2>/dev/null || echo "0")
 		fi
 	else
-		# No history — extrapolate from 28-day Knowledge DB data
+		# No history — extrapolate from 28-day data
 		year_hours=$(echo "scale=1; $month_hours / 28 * 365" | bc 2>/dev/null || echo "0")
 	fi
+
+	local platform_note
+	case "$OS_TYPE" in
+	Darwin) platform_note="from macOS Knowledge DB (~28 days retention)" ;;
+	Linux) platform_note="from systemd-logind session events" ;;
+	*) platform_note="unsupported platform" ;;
+	esac
 
 	jq -n \
 		--arg today "$today_hours" \
 		--arg week "$week_hours" \
 		--arg month "$month_hours" \
 		--arg year "$year_hours" \
+		--arg note "$platform_note" \
 		'{
 			today_hours: ($today | tonumber),
 			week_hours: ($week | tonumber),
 			month_hours: ($month | tonumber),
 			year_hours: ($year | tonumber),
-			month_note: "from ~28 days of macOS Knowledge DB data"
+			month_note: $note
 		}'
 
 	return 0
@@ -277,6 +727,13 @@ help | *)
 	echo "  query [days]   Query screen-on hours for last N days (default: 1)"
 	echo "  history        Show accumulated history summary"
 	echo "  profile-stats  Output stats for profile README (JSON)"
+	echo ""
+	echo "Platform: ${OS_TYPE}"
+	case "$OS_TYPE" in
+	Darwin) echo "  Source: macOS Knowledge DB (display backlit events)" ;;
+	Linux) echo "  Source: systemd-logind (session events) + wtmp (login sessions)" ;;
+	*) echo "  Source: unsupported (will return 0 for all queries)" ;;
+	esac
 	return 0 2>/dev/null || exit 0
 	;;
 esac


### PR DESCRIPTION
## Summary

- Adds `profile-readme-helper.sh` — gathers live data from screen time, AI session hours, and model usage metrics, then updates the GitHub profile README between marker comments
- Adds `sh.aidevops.profile-readme-update.plist` — daily launchd job (06:00) that runs the update, commits and pushes only when stats change
- Profile README now has `<!-- STATS-START/END -->` and `<!-- UPDATED-START/END -->` markers for safe section replacement
- **Linux support** — `screen-time-helper.sh` is now cross-platform:
  - macOS: Knowledge DB display backlit events (unchanged)
  - Linux: systemd-logind session events via journalctl (primary), wtmp via `last` (fallback), `/proc/uptime` (last resort)
  - Works on both X11 and Wayland (no display server dependency)
- Adds systemd user service + timer files for Linux users (equivalent to launchd plists)

## Data sources

| Source | macOS | Linux | What it provides |
|--------|-------|-------|-----------------|
| Knowledge DB / logind | Yes | Yes | Screen-on time (today, 7d, 28d, 365d) |
| `contributor-activity-helper.sh` | Yes | Yes | AI session hours per period |
| `metrics.jsonl` | Yes | Yes | Model usage, tokens, costs (last 30 days) |

## Linux setup

```bash
# Screen time snapshots (every 6h)
mkdir -p ~/.config/systemd/user
cp .agents/configs/aidevops-screen-time-snapshot.{service,timer} ~/.config/systemd/user/
systemctl --user daemon-reload
systemctl --user enable --now aidevops-screen-time-snapshot.timer

# Profile README auto-update (daily at 06:00)
cp .agents/configs/aidevops-profile-readme-update.{service,timer} ~/.config/systemd/user/
systemctl --user daemon-reload
systemctl --user enable --now aidevops-profile-readme-update.timer
```

## Verified

- `generate` command produces correctly formatted markdown tables
- `update --dry-run` shows correct diff against current README
- `update` successfully committed and pushed to `marcusquinn/marcusquinn`
- macOS path fully tested (profile-stats, query, help all work)
- ShellCheck clean on all scripts
- Bash 3.2 compatible (macOS), bash 4+ compatible (Linux)
- Launchd job installed and loaded on macOS
- systemd service/timer files created for Linux