### PR TITLE
t1421: Comment-based approval for simplification-debt issues

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -227,6 +227,58 @@ Issues and PRs from non-maintainers (check `authorAssociation`: `NONE`, `FIRST_T
 
 The principle: fix our bugs, but don't commit to supporting external tools without maintainer sign-off. Compatibility is best-effort, not guaranteed.
 
+### Comment-based approval for needs-maintainer-review issues (t1421)
+
+Issues with the `needs-maintainer-review` label (e.g., `simplification-debt` from `/code-simplifier`, or external feature requests) can be approved or declined by the maintainer commenting on the issue instead of manually editing labels. The pulse scans these comments each cycle.
+
+**How to scan:** For each open issue with `needs-maintainer-review` in the pre-fetched state, fetch comments and check for approval/decline keywords from the repo maintainer:
+
+```bash
+# Get the maintainer for this repo
+MAINTAINER=$(jq -r '.initialized_repos[] | select(.slug == "<slug>") | .maintainer // empty' ~/.config/aidevops/repos.json)
+if [[ -z "$MAINTAINER" ]]; then
+  MAINTAINER=$(echo "<slug>" | cut -d/ -f1)
+fi
+
+# Fetch comments and check for maintainer approval/decline
+# Look for the LAST comment from the maintainer that matches
+COMMENT_DATA=$(gh api "repos/<slug>/issues/<number>/comments" \
+  --jq "[.[] | select(.user.login == \"$MAINTAINER\")] | last | {body: .body, id: .id}")
+COMMENT_BODY=$(echo "$COMMENT_DATA" | jq -r '.body // empty' | tr '[:upper:]' '[:lower:]' | xargs)
+```
+
+**Three outcomes:**
+
+1. **Comment starts with `approved`** (case-insensitive) — the maintainer wants this dispatched:
+
+```bash
+gh issue edit <number> --repo <slug> \
+  --remove-label "needs-maintainer-review" \
+  --add-label "auto-dispatch"
+gh issue comment <number> --repo <slug> \
+  --body "Maintainer approved via comment. Removed \`needs-maintainer-review\`, added \`auto-dispatch\`. Issue is now in the dispatch queue."
+```
+
+The issue becomes dispatchable this cycle (priority 8 for `simplification-debt`, normal priority for other issue types).
+
+2. **Comment starts with `declined`** (case-insensitive) — the maintainer rejects this:
+
+```bash
+# Extract the reason (everything after "declined" or "declined:")
+REASON=$(echo "$COMMENT_BODY" | sed -E 's/^declined:?\s*//')
+gh issue close <number> --repo <slug> \
+  -c "Closed per maintainer decision. Reason: ${REASON:-no reason given}"
+```
+
+3. **No matching comment from maintainer** — skip, check again next cycle.
+
+**Guard rails:**
+
+- Only process comments from the repo maintainer (from `repos.json` or slug owner). Ignore comments from bots, other contributors, or the agent itself.
+- Only check the maintainer's **most recent** comment — earlier comments may have been superseded.
+- This is additive — direct label manipulation still works. If the maintainer has already removed `needs-maintainer-review` via labels, the issue won't appear in this scan.
+- Keep this lightweight — one API call per `needs-maintainer-review` issue per cycle. These issues are low-volume by design.
+
 ### Kill stuck workers
 
 Check `ps axo pid,etime,command | grep '/full-loop' | grep '\.opencode'`. Any worker running 3+ hours with no open PR is likely stuck. Kill it: `kill <pid>`. Comment on the issue with the full audit-quality fields (model, branch, reason, diagnosis, next action — see "Audit-quality state in issue and PR comments" below). This frees a slot. If the worker has recent commits or an open PR with activity, leave it alone — it's making progress.

--- a/.agents/tools/code-review/code-simplifier.md
+++ b/.agents/tools/code-review/code-simplifier.md
@@ -318,10 +318,15 @@ gh issue create --repo <slug> \
   --title "simplification: <brief description>" \
   --label "simplification-debt" --label "needs-maintainer-review" \
   --assignee "$MAINTAINER" \
-  --body "<structured finding>"
+  --body "<structured finding>
+
+---
+**To approve or decline**, comment on this issue:
+- \`approved\` — removes the review gate and queues for automated dispatch
+- \`declined: <reason>\` — closes this issue (include your reason after the colon)"
 ```
 
-GitHub sends a notification to the assignee on creation. The `needs-maintainer-review` label prevents the pulse from dispatching a worker.
+GitHub sends a notification to the assignee on creation. The `needs-maintainer-review` label prevents the pulse from dispatching a worker. The footer tells the maintainer exactly how to act — no label commands needed.
 
 ### Maintainer review (interactive)
 
@@ -331,24 +336,26 @@ The maintainer reviews pending simplification issues via any of:
 - **Label filter** -- `gh issue list --label simplification-debt --label needs-maintainer-review`
 - **Dashboard** -- `/dashboard --pending-review` shows all items awaiting maintainer decision (see dashboard.md)
 
-For each issue, the maintainer either:
+For each issue, the maintainer comments on the issue:
 
-**Approves** (issue becomes dispatchable):
+**Approves** -- comment `approved` (case-insensitive). The pulse scans for this keyword from the maintainer, removes `needs-maintainer-review`, adds `auto-dispatch`, and the issue enters the dispatch queue.
+
+**Declines** -- comment `declined: <reason>` (e.g., `declined: this verbosity is intentional, see t1345`). The pulse closes the issue with the maintainer's reason preserved.
+
+**Defers** -- no comment needed. The issue stays in `needs-maintainer-review` for later review.
+
+**Label fallback** -- maintainers who prefer direct label manipulation can still use:
 
 ```bash
+# Approve via labels
 gh issue edit <number> --repo <slug> \
   --remove-label "needs-maintainer-review" \
   --add-label "auto-dispatch"
-```
 
-**Declines** (issue is closed):
-
-```bash
+# Decline via labels
 gh issue close <number> --repo <slug> \
-  -c "Declined: <reason — e.g., 'this verbosity is intentional, see t1345'>"
+  -c "Declined: <reason>"
 ```
-
-**Defers** (leave as-is for later review — no action needed).
 
 ### Pulse behaviour
 
@@ -357,12 +364,15 @@ The pulse already skips `needs-maintainer-review` issues (see pulse.md "External
 ### Label lifecycle
 
 ```text
-/code-simplifier creates issue
+/code-simplifier creates issue (with approval instructions in footer)
     |
     v
 [simplification-debt] + [needs-maintainer-review] + assigned to maintainer
     |
-    +--> Maintainer approves --> remove [needs-maintainer-review], add [auto-dispatch]
+    +--> Maintainer comments "approved"
+    |       |
+    |       v
+    |    Pulse scans comment --> remove [needs-maintainer-review], add [auto-dispatch]
     |       |
     |       v
     |    Pulse dispatches worker --> [status:queued] --> [status:in-progress]
@@ -370,9 +380,9 @@ The pulse already skips `needs-maintainer-review` issues (see pulse.md "External
     |       v
     |    Worker opens PR --> [status:in-review] --> PR merged --> [status:done]
     |
-    +--> Maintainer declines --> issue closed with reason
+    +--> Maintainer comments "declined: <reason>" --> pulse closes issue
     |
-    +--> Maintainer defers --> no change (reviewed on next pass)
+    +--> Maintainer defers (no comment) --> no change (reviewed on next pass)
 ```
 
 ## Integration with Quality Workflow
@@ -384,7 +394,9 @@ Periodic review --> /code-simplifier (analyse)
                         |
                     Issues created (needs-maintainer-review)
                         |
-                    Maintainer approves/declines via labels
+                    Maintainer comments "approved" or "declined: reason"
+                        |
+                    Pulse processes comment (labels + close)
                         |
                     Approved items dispatched (priority 8)
                         |


### PR DESCRIPTION
## Summary

- Maintainers can now comment `approved` or `declined: <reason>` on `needs-maintainer-review` issues instead of manually editing labels
- Issue descriptions include a footer with approval instructions
- Pulse scans maintainer comments each cycle and acts accordingly (relabel + dispatch, or close)
- Direct label manipulation still works as a fallback

## Changes

- **`.agents/tools/code-review/code-simplifier.md`**: Updated issue creation to include approval instruction footer, updated maintainer review docs to make comment-based approval primary (labels as fallback), updated lifecycle diagrams
- **`.agents/scripts/commands/pulse.md`**: Added "Comment-based approval for needs-maintainer-review issues" section with scanning logic, guard rails, and three outcomes (approved/declined/no match)

Closes #3950