### PR TITLE
t3837: Fix SonarCloud CI — move secrets to job-level env for correct if: evaluation

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -135,6 +135,11 @@ jobs:
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
+    # Job-level env so that step `if:` conditions can reference env.SONAR_TOKEN
+    # (step-level env: blocks are applied AFTER the if: is evaluated)
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
 
     steps:
     - name: Checkout code
@@ -147,48 +152,42 @@ jobs:
       uses: SonarSource/sonarqube-scan-action@40f5b61913e891f9d316696628698051136015be
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      continue-on-error: true
 
     - name: SonarCloud Scan Skipped
       if: env.SONAR_TOKEN == ''
-      env:
-        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       run: |
         echo "::warning::SONAR_TOKEN not configured — skipping SonarCloud scan"
         echo "Add SONAR_TOKEN to repository secrets to enable SonarCloud analysis"
 
     - name: Codacy Analysis
-      env:
-        CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
       run: |
         if [[ -n "$CODACY_API_TOKEN" ]]; then
-          echo "🔍 Codacy Analysis Status..."
-          echo "✅ Codacy API Token: Configured"
-          echo "📊 Repository monitored at: https://app.codacy.com/gh/marcusquinn/aidevops"
-          echo "🔧 Local CLI available for auto-fix: codacy-cli analyze --fix"
-          echo "⚡ Web-based analysis: Automatic on every commit"
-          echo "✅ Codacy integration: Active"
+          echo "Codacy Analysis Status..."
+          echo "Codacy API Token: Configured"
+          echo "Repository monitored at: https://app.codacy.com/gh/marcusquinn/aidevops"
+          echo "Codacy integration: Active"
         else
-          echo "⚠️  Codacy API token not configured, skipping analysis"
-          echo "   Add CODACY_API_TOKEN to repository secrets to enable Codacy analysis"
+          echo "::notice::Codacy API token not configured, skipping analysis"
+          echo "Add CODACY_API_TOKEN to repository secrets to enable Codacy analysis"
         fi
 
     - name: Quality Analysis Summary
-      env:
-        CODACY_API_TOKEN: ${{ secrets.CODACY_API_TOKEN }}
       run: |
-        echo "📊 Code Quality Analysis Summary"
+        echo "Code Quality Analysis Summary"
         echo "================================"
-        echo "✅ SonarCloud: Analysis completed"
-        if [[ -n "$CODACY_API_TOKEN" ]]; then
-          echo "✅ Codacy: Analysis completed"
+        if [[ -n "$SONAR_TOKEN" ]]; then
+          echo "SonarCloud: Analysis completed"
         else
-          echo "⚠️  Codacy: Skipped (token not configured)"
+          echo "SonarCloud: Skipped (SONAR_TOKEN not configured)"
+        fi
+        if [[ -n "$CODACY_API_TOKEN" ]]; then
+          echo "Codacy: Analysis completed"
+        else
+          echo "Codacy: Skipped (token not configured)"
         fi
         echo ""
-        echo "🔗 View Results:"
+        echo "View Results:"
         echo "   SonarCloud: https://sonarcloud.io/project/overview?id=marcusquinn_aidevops"
         echo "   Codacy: https://app.codacy.com/gh/marcusquinn/aidevops"
         echo ""
-        echo "🎯 Code Quality Pipeline: COMPLETE"
+        echo "Code Quality Pipeline: COMPLETE"


### PR DESCRIPTION
## Summary

- **Root cause:** `SONAR_TOKEN` was set in the step's `env:` block, but the step's `if: env.SONAR_TOKEN != ''` condition is evaluated *before* step-level env vars are applied. So `env.SONAR_TOKEN` was always empty, and the SonarCloud scan was always skipped.
- **Fix:** Move `SONAR_TOKEN` and `CODACY_API_TOKEN` to **job-level** `env:`, where they're available to all step `if:` conditions and `run:` blocks.
- **Also:** Remove `continue-on-error: true` (SonarCloud failures should be visible), fix the summary step to reflect actual scan status instead of always claiming success, and use `::notice::` annotations for skipped steps.

## Changes

| Before | After |
|--------|-------|
| `SONAR_TOKEN` in step-level `env:` | `SONAR_TOKEN` in job-level `env:` |
| `if: env.SONAR_TOKEN != ''` always false | `if: env.SONAR_TOKEN != ''` correctly evaluates |
| `continue-on-error: true` hides failures | Failures are visible |
| Summary always says "Analysis completed" | Summary reflects actual status |

## Manual step required

The `SONAR_TOKEN` secret must still be set in GitHub repo settings:
1. Generate a token at https://sonarcloud.io/account/security
2. Add it as `SONAR_TOKEN` in **Settings > Secrets and variables > Actions**

Once set, the workflow will correctly detect and use it. Without it, the workflow now gracefully skips with a `::warning::` annotation instead of failing.

Closes #3837