### PR TITLE
GH#3803: Fix print_warning in archived quality-loop-helper default case

### DIFF
--- a/.agents/scripts/archived/quality-loop-helper.sh
+++ b/.agents/scripts/archived/quality-loop-helper.sh
@@ -936,7 +936,7 @@ pr_review_loop() {
 			fi
 			;;
 		*)
-			print_warning "Unknown PR status: $status"
+			echo "WARNING: Unknown PR status: $status" >&2
 			;;
 		esac
 


### PR DESCRIPTION
## Summary

- Replace `print_warning` with `echo ... >&2` in the default case of the PR status handler in `quality-loop-helper.sh` (archived)
- `print_warning` is sourced from `shared-constants.sh` via `SCRIPT_DIR`, but in the `archived/` location `SCRIPT_DIR` resolves to `archived/` where `shared-constants.sh` does not exist — causing a `command not found` runtime error
- Single-line fix in an archived file, per Gemini's critical review feedback on PR #44

## Previous attempt

PR #3847 was closed due to merge conflicts from a batch PR blast radius issue. This is a clean re-creation from current main with only the targeted fix.

Closes #3803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal error handling in development scripts by adjusting warning output routing for better diagnostic visibility during automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->