### PR TITLE
refactor: standardize on pre-increment ((++var)) across all shell scripts

### DIFF
--- a/.agents/scripts/agent-sources-helper.sh
+++ b/.agents/scripts/agent-sources-helper.sh
@@ -354,7 +354,7 @@ cmd_list() {
 		# Shorten home path
 		path="${path/#${HOME}/~}"
 		printf "  %-25s %-45s %s\n" "${name}" "${path}" "${synced}"
-		((i++))
+		((++i))
 	done
 	return 0
 }
@@ -425,7 +425,7 @@ cmd_status() {
 			fi
 		fi
 		echo ""
-		((i++))
+		((++i))
 	done
 	return 0
 }
@@ -458,13 +458,13 @@ cmd_sync() {
 
 		if [[ ! -d "${path}" ]]; then
 			warn "  Source directory missing: ${path}"
-			((i++))
+			((++i))
 			continue
 		fi
 
 		if [[ ! -d "${path}/.agents" ]]; then
 			warn "  No .agents/ directory in ${path}"
-			((i++))
+			((++i))
 			continue
 		fi
 
@@ -491,7 +491,7 @@ cmd_sync() {
 
 			# rsync the agent directory (preserves permissions, handles deletions)
 			rsync -a --delete "${agent_dir}" "${dest_dir}/${agent_name}/"
-			((agent_count++))
+			((++agent_count))
 
 			# Post-sync: register primary agents and deploy slash commands
 			sync_primary_agent "${dest_dir}/${agent_name}" "${agent_name}"
@@ -501,8 +501,8 @@ cmd_sync() {
 		update_last_synced "${name}" "${agent_count}"
 		success "  Synced ${agent_count} agent(s) to custom/${name}/"
 		total_agents=$((total_agents + agent_count))
-		((total_sources++))
-		((i++))
+		((++total_sources))
+		((++i))
 	done
 
 	echo ""
@@ -539,7 +539,7 @@ sync_primary_agent() {
 
 	ln -s "${agent_md}" "${link_target}"
 	info "  Registered primary agent: ${agent_name}"
-	((total_primary++)) || true
+	((++total_primary))
 	return 0
 }
 
@@ -578,7 +578,7 @@ sync_slash_commands() {
 
 		# Symlink rather than copy — stays in sync without re-running
 		ln -sf "${md_file}" "${target}"
-		((total_commands++)) || true
+		((++total_commands))
 	done
 	return 0
 }

--- a/.agents/scripts/ampcode-cli.sh
+++ b/.agents/scripts/ampcode-cli.sh
@@ -434,7 +434,7 @@ show_status() {
 			size=$(du -h "$file" 2>/dev/null | cut -f1 || echo "unknown")
 			ext="${file##*.}"
 			print_info "  $(basename "$file") (${ext} - $size)"
-			((shown++)) || true
+			((++shown))
 		done
 	fi
 

--- a/.agents/scripts/anti-detect-helper.sh
+++ b/.agents/scripts/anti-detect-helper.sh
@@ -15,7 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 show_help() {
-    cat <<'EOF'
+	cat <<'EOF'
 Anti-Detect Browser Helper
 
 USAGE:
@@ -72,164 +72,179 @@ EXAMPLES:
     anti-detect-helper.sh warmup "my-account" --duration 30m
     anti-detect-helper.sh profile list
 EOF
-    return 0
+	return 0
 }
 
 # ─── Setup ───────────────────────────────────────────────────────────────────
 
 setup_all() {
-    local engine="${1:-all}"
+	local engine="${1:-all}"
 
-    echo -e "${BLUE}Setting up anti-detect tools (engine: $engine)...${NC}"
+	echo -e "${BLUE}Setting up anti-detect tools (engine: $engine)...${NC}"
 
-    # Create directories
-    mkdir -p "$PROFILES_DIR"/{persistent,clean/default,warmup,disposable}
-    mkdir -p "$VENV_DIR"
+	# Create directories
+	mkdir -p "$PROFILES_DIR"/{persistent,clean/default,warmup,disposable}
+	mkdir -p "$VENV_DIR"
 
-    if [[ "$engine" == "all" || "$engine" == "firefox" ]]; then
-        setup_camoufox
-    fi
+	if [[ "$engine" == "all" || "$engine" == "firefox" ]]; then
+		setup_camoufox
+	fi
 
-    if [[ "$engine" == "all" || "$engine" == "chromium" ]]; then
-        setup_rebrowser
-    fi
+	if [[ "$engine" == "all" || "$engine" == "chromium" ]]; then
+		setup_rebrowser
+	fi
 
-    # Create default clean profile template
-    if [[ ! -f "$PROFILES_DIR/clean/default/fingerprint.json" ]]; then
-        echo '{"mode": "random"}' > "$PROFILES_DIR/clean/default/fingerprint.json"
-    fi
+	# Create default clean profile template
+	if [[ ! -f "$PROFILES_DIR/clean/default/fingerprint.json" ]]; then
+		echo '{"mode": "random"}' >"$PROFILES_DIR/clean/default/fingerprint.json"
+	fi
 
-    # Create profiles index if not exists
-    if [[ ! -f "$PROFILES_DIR/profiles.json" ]]; then
-        echo '{"profiles": []}' > "$PROFILES_DIR/profiles.json"
-    fi
+	# Create profiles index if not exists
+	if [[ ! -f "$PROFILES_DIR/profiles.json" ]]; then
+		echo '{"profiles": []}' >"$PROFILES_DIR/profiles.json"
+	fi
 
-    echo -e "${GREEN}Setup complete.${NC}"
-    return 0
+	echo -e "${GREEN}Setup complete.${NC}"
+	return 0
 }
 
 setup_camoufox() {
-    echo -e "${BLUE}Setting up Camoufox (Firefox anti-detect)...${NC}"
+	echo -e "${BLUE}Setting up Camoufox (Firefox anti-detect)...${NC}"
 
-    # Create/use venv
-    if [[ ! -d "$VENV_DIR" ]]; then
-        python3 -m venv "$VENV_DIR"
-    fi
+	# Create/use venv
+	if [[ ! -d "$VENV_DIR" ]]; then
+		python3 -m venv "$VENV_DIR"
+	fi
 
-    # Install camoufox + browserforge
-    source "$VENV_DIR/bin/activate"
-    pip install --quiet --upgrade camoufox browserforge 2>/dev/null || {
-        echo -e "${YELLOW}Warning: pip install failed. Trying with --break-system-packages...${NC}"
-        pip install --quiet --upgrade --break-system-packages camoufox browserforge 2>/dev/null || true
-    }
+	# Install camoufox + browserforge
+	source "$VENV_DIR/bin/activate"
+	pip install --quiet --upgrade camoufox browserforge 2>/dev/null || {
+		echo -e "${YELLOW}Warning: pip install failed. Trying with --break-system-packages...${NC}"
+		pip install --quiet --upgrade --break-system-packages camoufox browserforge 2>/dev/null || true
+	}
 
-    # Fetch browser binary
-    python3 -m camoufox fetch 2>/dev/null || {
-        echo -e "${YELLOW}Warning: Camoufox binary fetch failed. May need manual download.${NC}"
-    }
+	# Fetch browser binary
+	python3 -m camoufox fetch 2>/dev/null || {
+		echo -e "${YELLOW}Warning: Camoufox binary fetch failed. May need manual download.${NC}"
+	}
 
-    deactivate 2>/dev/null || true
-    echo -e "${GREEN}Camoufox installed.${NC}"
-    return 0
+	deactivate 2>/dev/null || true
+	echo -e "${GREEN}Camoufox installed.${NC}"
+	return 0
 }
 
 setup_rebrowser() {
-    echo -e "${BLUE}Setting up rebrowser-patches (Chromium stealth)...${NC}"
+	echo -e "${BLUE}Setting up rebrowser-patches (Chromium stealth)...${NC}"
 
-    # Check if playwright is installed
-    if ! command -v npx &>/dev/null; then
-        echo -e "${RED}Error: npx not found. Install Node.js first.${NC}" >&2
-        return 1
-    fi
+	# Check if playwright is installed
+	if ! command -v npx &>/dev/null; then
+		echo -e "${RED}Error: npx not found. Install Node.js first.${NC}" >&2
+		return 1
+	fi
 
-    # Patch playwright
-    npx rebrowser-patches@latest patch 2>/dev/null || {
-        echo -e "${YELLOW}Warning: rebrowser-patches failed. Playwright may not be installed.${NC}"
-        echo -e "${YELLOW}Run: npm install playwright && npx rebrowser-patches patch${NC}"
-    }
+	# Patch playwright
+	npx rebrowser-patches@latest patch 2>/dev/null || {
+		echo -e "${YELLOW}Warning: rebrowser-patches failed. Playwright may not be installed.${NC}"
+		echo -e "${YELLOW}Run: npm install playwright && npx rebrowser-patches patch${NC}"
+	}
 
-    echo -e "${GREEN}rebrowser-patches applied.${NC}"
-    return 0
+	echo -e "${GREEN}rebrowser-patches applied.${NC}"
+	return 0
 }
 
 # ─── Profile Management ─────────────────────────────────────────────────────
 
 validate_profile_name() {
-    local name="$1"
-    if [[ -z "$name" ]]; then
-        echo -e "${RED}Error: Profile name cannot be empty.${NC}" >&2
-        return 1
-    fi
-    if [[ "$name" =~ [/\\] || "$name" == *..* ]]; then
-        echo -e "${RED}Error: Profile name cannot contain '/', '\\', or '..'.${NC}" >&2
-        return 1
-    fi
-    if [[ "$name" == -* ]]; then
-        echo -e "${RED}Error: Profile name cannot start with '-'.${NC}" >&2
-        return 1
-    fi
-    if ! [[ "$name" =~ ^[A-Za-z0-9._-]+$ ]]; then
-        echo -e "${RED}Error: Profile name must only contain letters, numbers, '.', '_', or '-'.${NC}" >&2
-        return 1
-    fi
-    if [[ ${#name} -gt 64 ]]; then
-        echo -e "${RED}Error: Profile name must be 64 characters or fewer.${NC}" >&2
-        return 1
-    fi
-    return 0
+	local name="$1"
+	if [[ -z "$name" ]]; then
+		echo -e "${RED}Error: Profile name cannot be empty.${NC}" >&2
+		return 1
+	fi
+	if [[ "$name" =~ [/\\] || "$name" == *..* ]]; then
+		echo -e "${RED}Error: Profile name cannot contain '/', '\\', or '..'.${NC}" >&2
+		return 1
+	fi
+	if [[ "$name" == -* ]]; then
+		echo -e "${RED}Error: Profile name cannot start with '-'.${NC}" >&2
+		return 1
+	fi
+	if ! [[ "$name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+		echo -e "${RED}Error: Profile name must only contain letters, numbers, '.', '_', or '-'.${NC}" >&2
+		return 1
+	fi
+	if [[ ${#name} -gt 64 ]]; then
+		echo -e "${RED}Error: Profile name must be 64 characters or fewer.${NC}" >&2
+		return 1
+	fi
+	return 0
 }
 
 profile_create() {
-    local name="$1"
-    local profile_type="persistent"
-    local proxy=""
-    local target_os="random"
-    local browser_type="firefox"
-    local notes=""
+	local name="$1"
+	local profile_type="persistent"
+	local proxy=""
+	local target_os="random"
+	local browser_type="firefox"
+	local notes=""
 
-    local arg
-    shift
-    while [[ $# -gt 0 ]]; do
-        arg="$1"
-        case "$arg" in
-            --type) profile_type="$2"; shift 2 ;;
-            --proxy) proxy="$2"; shift 2 ;;
-            --os) target_os="$2"; shift 2 ;;
-            --browser) browser_type="$2"; shift 2 ;;
-            --notes) notes="$2"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	local arg
+	shift
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		case "$arg" in
+		--type)
+			profile_type="$2"
+			shift 2
+			;;
+		--proxy)
+			proxy="$2"
+			shift 2
+			;;
+		--os)
+			target_os="$2"
+			shift 2
+			;;
+		--browser)
+			browser_type="$2"
+			shift 2
+			;;
+		--notes)
+			notes="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    validate_profile_name "$name" || return 1
+	validate_profile_name "$name" || return 1
 
-    # Map profile type to directory name
-    local dir_type="$profile_type"
-    [[ "$profile_type" == "warm" ]] && dir_type="warmup"
+	# Map profile type to directory name
+	local dir_type="$profile_type"
+	[[ "$profile_type" == "warm" ]] && dir_type="warmup"
 
-    local profile_dir="$PROFILES_DIR/$dir_type/$name"
+	local profile_dir="$PROFILES_DIR/$dir_type/$name"
 
-    if [[ -d "$profile_dir" ]]; then
-        echo -e "${RED}Error: Profile '$name' already exists.${NC}" >&2
-        return 1
-    fi
+	if [[ -d "$profile_dir" ]]; then
+		echo -e "${RED}Error: Profile '$name' already exists.${NC}" >&2
+		return 1
+	fi
 
-    mkdir -p "$profile_dir"
+	mkdir -p "$profile_dir"
 
-    # Generate fingerprint
-    local fingerprint
-    fingerprint=$(generate_fingerprint "$target_os" "$browser_type")
-    echo "$fingerprint" > "$profile_dir/fingerprint.json"
+	# Generate fingerprint
+	local fingerprint
+	fingerprint=$(generate_fingerprint "$target_os" "$browser_type")
+	echo "$fingerprint" >"$profile_dir/fingerprint.json"
 
-    # Save proxy config
-    if [[ -n "$proxy" ]]; then
-        local proxy_json
-        proxy_json=$(parse_proxy_url "$proxy")
-        echo "$proxy_json" > "$profile_dir/proxy.json"
-    fi
+	# Save proxy config
+	if [[ -n "$proxy" ]]; then
+		local proxy_json
+		proxy_json=$(parse_proxy_url "$proxy")
+		echo "$proxy_json" >"$profile_dir/proxy.json"
+	fi
 
-    # Save metadata
-    cat > "$profile_dir/metadata.json" <<METADATA
+	# Save metadata
+	cat >"$profile_dir/metadata.json" <<METADATA
 {
   "name": "$name",
   "type": "$profile_type",
@@ -241,131 +256,131 @@ profile_create() {
 }
 METADATA
 
-    # Update profiles index
-    update_profiles_index "$name" "$profile_type" "add"
+	# Update profiles index
+	update_profiles_index "$name" "$profile_type" "add"
 
-    echo -e "${GREEN}Profile '$name' created (type: $profile_type, os: $target_os, browser: $browser_type).${NC}"
-    return 0
+	echo -e "${GREEN}Profile '$name' created (type: $profile_type, os: $target_os, browser: $browser_type).${NC}"
+	return 0
 }
 
 profile_list() {
-    local format="${1:-text}"
+	local format="${1:-text}"
 
-    if [[ "$format" == "json" ]]; then
-        cat "$PROFILES_DIR/profiles.json"
-        return 0
-    fi
+	if [[ "$format" == "json" ]]; then
+		cat "$PROFILES_DIR/profiles.json"
+		return 0
+	fi
 
-    echo -e "${BLUE}Browser Profiles:${NC}"
-    echo "─────────────────────────────────────────────────────────────"
-    printf "%-20s %-12s %-10s %-10s %s\n" "NAME" "TYPE" "OS" "ENGINE" "PROXY"
-    echo "─────────────────────────────────────────────────────────────"
+	echo -e "${BLUE}Browser Profiles:${NC}"
+	echo "─────────────────────────────────────────────────────────────"
+	printf "%-20s %-12s %-10s %-10s %s\n" "NAME" "TYPE" "OS" "ENGINE" "PROXY"
+	echo "─────────────────────────────────────────────────────────────"
 
-    for type_dir in "$PROFILES_DIR"/{persistent,clean,warmup,disposable}/*/; do
-        [[ -d "$type_dir" ]] || continue
-        local name
-        name=$(basename "$type_dir")
-        [[ "$name" == "default" ]] && continue
+	for type_dir in "$PROFILES_DIR"/{persistent,clean,warmup,disposable}/*/; do
+		[[ -d "$type_dir" ]] || continue
+		local name
+		name=$(basename "$type_dir")
+		[[ "$name" == "default" ]] && continue
 
-        local metadata="$type_dir/metadata.json"
-        [[ -f "$metadata" ]] || continue
+		local metadata="$type_dir/metadata.json"
+		[[ -f "$metadata" ]] || continue
 
-        local ptype pos pengine pproxy
-        ptype=$(python3 -c "import json; d=json.load(open('$metadata')); print(d.get('type','?'))" 2>/dev/null || echo "?")
-        pos=$(python3 -c "import json; d=json.load(open('$metadata')); print(d.get('target_os','?'))" 2>/dev/null || echo "?")
-        pengine=$(python3 -c "import json; d=json.load(open('$metadata')); print(d.get('browser','?'))" 2>/dev/null || echo "?")
+		local ptype pos pengine pproxy
+		ptype=$(python3 -c "import json; d=json.load(open('$metadata')); print(d.get('type','?'))" 2>/dev/null || echo "?")
+		pos=$(python3 -c "import json; d=json.load(open('$metadata')); print(d.get('target_os','?'))" 2>/dev/null || echo "?")
+		pengine=$(python3 -c "import json; d=json.load(open('$metadata')); print(d.get('browser','?'))" 2>/dev/null || echo "?")
 
-        if [[ -f "$type_dir/proxy.json" ]]; then
-            pproxy="yes"
-        else
-            pproxy="none"
-        fi
+		if [[ -f "$type_dir/proxy.json" ]]; then
+			pproxy="yes"
+		else
+			pproxy="none"
+		fi
 
-        printf "%-20s %-12s %-10s %-10s %s\n" "$name" "$ptype" "$pos" "$pengine" "$pproxy"
-    done
-    return 0
+		printf "%-20s %-12s %-10s %-10s %s\n" "$name" "$ptype" "$pos" "$pengine" "$pproxy"
+	done
+	return 0
 }
 
 profile_show() {
-    local name="$1"
-    local profile_dir
-    profile_dir=$(find_profile_dir "$name")
+	local name="$1"
+	local profile_dir
+	profile_dir=$(find_profile_dir "$name")
 
-    if [[ -z "$profile_dir" ]]; then
-        echo -e "${RED}Error: Profile '$name' not found.${NC}" >&2
-        return 1
-    fi
+	if [[ -z "$profile_dir" ]]; then
+		echo -e "${RED}Error: Profile '$name' not found.${NC}" >&2
+		return 1
+	fi
 
-    echo -e "${BLUE}Profile: $name${NC}"
-    echo "─────────────────────────────────────────"
+	echo -e "${BLUE}Profile: $name${NC}"
+	echo "─────────────────────────────────────────"
 
-    if [[ -f "$profile_dir/metadata.json" ]]; then
-        echo -e "${YELLOW}Metadata:${NC}"
-        python3 -c "import json; d=json.load(open('$profile_dir/metadata.json')); [print(f'  {k}: {v}') for k,v in d.items()]" 2>/dev/null
-    fi
+	if [[ -f "$profile_dir/metadata.json" ]]; then
+		echo -e "${YELLOW}Metadata:${NC}"
+		python3 -c "import json; d=json.load(open('$profile_dir/metadata.json')); [print(f'  {k}: {v}') for k,v in d.items()]" 2>/dev/null
+	fi
 
-    if [[ -f "$profile_dir/fingerprint.json" ]]; then
-        echo -e "${YELLOW}Fingerprint:${NC}"
-        python3 -c "import json; d=json.load(open('$profile_dir/fingerprint.json')); [print(f'  {k}: {v}') for k,v in list(d.items())[:10]]" 2>/dev/null
-    fi
+	if [[ -f "$profile_dir/fingerprint.json" ]]; then
+		echo -e "${YELLOW}Fingerprint:${NC}"
+		python3 -c "import json; d=json.load(open('$profile_dir/fingerprint.json')); [print(f'  {k}: {v}') for k,v in list(d.items())[:10]]" 2>/dev/null
+	fi
 
-    if [[ -f "$profile_dir/proxy.json" ]]; then
-        echo -e "${YELLOW}Proxy:${NC}"
-        python3 -c "import json; d=json.load(open('$profile_dir/proxy.json')); print(f'  server: {d.get(\"server\",\"?\")}')" 2>/dev/null
-    fi
+	if [[ -f "$profile_dir/proxy.json" ]]; then
+		echo -e "${YELLOW}Proxy:${NC}"
+		python3 -c "import json; d=json.load(open('$profile_dir/proxy.json')); print(f'  server: {d.get(\"server\",\"?\")}')" 2>/dev/null
+	fi
 
-    if [[ -f "$profile_dir/storage-state.json" ]]; then
-        local cookie_count
-        cookie_count=$(python3 -c "import json; d=json.load(open('$profile_dir/storage-state.json')); print(len(d.get('cookies',[])))" 2>/dev/null || echo "0")
-        echo -e "${YELLOW}State:${NC}"
-        echo "  cookies: $cookie_count saved"
-    fi
+	if [[ -f "$profile_dir/storage-state.json" ]]; then
+		local cookie_count
+		cookie_count=$(python3 -c "import json; d=json.load(open('$profile_dir/storage-state.json')); print(len(d.get('cookies',[])))" 2>/dev/null || echo "0")
+		echo -e "${YELLOW}State:${NC}"
+		echo "  cookies: $cookie_count saved"
+	fi
 
-    return 0
+	return 0
 }
 
 profile_delete() {
-    local name="$1"
-    validate_profile_name "$name" || return 1
-    local profile_dir
-    profile_dir=$(find_profile_dir "$name")
+	local name="$1"
+	validate_profile_name "$name" || return 1
+	local profile_dir
+	profile_dir=$(find_profile_dir "$name")
 
-    if [[ -z "$profile_dir" ]]; then
-        echo -e "${RED}Error: Profile '$name' not found.${NC}" >&2
-        return 1
-    fi
+	if [[ -z "$profile_dir" ]]; then
+		echo -e "${RED}Error: Profile '$name' not found.${NC}" >&2
+		return 1
+	fi
 
-    rm -rf "$profile_dir"
-    update_profiles_index "$name" "" "remove"
-    echo -e "${GREEN}Profile '$name' deleted.${NC}"
-    return 0
+	rm -rf "$profile_dir"
+	update_profiles_index "$name" "" "remove"
+	echo -e "${GREEN}Profile '$name' deleted.${NC}"
+	return 0
 }
 
 profile_clone() {
-    local src="$1"
-    local dst="$2"
-    local src_dir
-    src_dir=$(find_profile_dir "$src")
+	local src="$1"
+	local dst="$2"
+	local src_dir
+	src_dir=$(find_profile_dir "$src")
 
-    if [[ -z "$src_dir" ]]; then
-        echo -e "${RED}Error: Source profile '$src' not found.${NC}" >&2
-        return 1
-    fi
+	if [[ -z "$src_dir" ]]; then
+		echo -e "${RED}Error: Source profile '$src' not found.${NC}" >&2
+		return 1
+	fi
 
-    local parent_dir
-    parent_dir=$(dirname "$src_dir")
-    local dst_dir="$parent_dir/$dst"
+	local parent_dir
+	parent_dir=$(dirname "$src_dir")
+	local dst_dir="$parent_dir/$dst"
 
-    if [[ -d "$dst_dir" ]]; then
-        echo -e "${RED}Error: Destination profile '$dst' already exists.${NC}" >&2
-        return 1
-    fi
+	if [[ -d "$dst_dir" ]]; then
+		echo -e "${RED}Error: Destination profile '$dst' already exists.${NC}" >&2
+		return 1
+	fi
 
-    cp -r "$src_dir" "$dst_dir"
+	cp -r "$src_dir" "$dst_dir"
 
-    # Update metadata name
-    if [[ -f "$dst_dir/metadata.json" ]]; then
-        python3 -c "
+	# Update metadata name
+	if [[ -f "$dst_dir/metadata.json" ]]; then
+		python3 -c "
 import json
 with open('$dst_dir/metadata.json', 'r+') as f:
     d = json.load(f)
@@ -375,48 +390,48 @@ with open('$dst_dir/metadata.json', 'r+') as f:
     json.dump(d, f, indent=2)
     f.truncate()
 " 2>/dev/null
-    fi
+	fi
 
-    # Generate new fingerprint (don't share with source)
-    local target_os
-    target_os=$(python3 -c "import json; print(json.load(open('$dst_dir/metadata.json')).get('target_os','random'))" 2>/dev/null || echo "random")
-    local browser_type
-    browser_type=$(python3 -c "import json; print(json.load(open('$dst_dir/metadata.json')).get('browser','firefox'))" 2>/dev/null || echo "firefox")
-    generate_fingerprint "$target_os" "$browser_type" > "$dst_dir/fingerprint.json"
+	# Generate new fingerprint (don't share with source)
+	local target_os
+	target_os=$(python3 -c "import json; print(json.load(open('$dst_dir/metadata.json')).get('target_os','random'))" 2>/dev/null || echo "random")
+	local browser_type
+	browser_type=$(python3 -c "import json; print(json.load(open('$dst_dir/metadata.json')).get('browser','firefox'))" 2>/dev/null || echo "firefox")
+	generate_fingerprint "$target_os" "$browser_type" >"$dst_dir/fingerprint.json"
 
-    # Remove saved state (fresh start)
-    rm -f "$dst_dir/storage-state.json" "$dst_dir/cookies.json"
-    rm -rf "$dst_dir/user-data"
+	# Remove saved state (fresh start)
+	rm -f "$dst_dir/storage-state.json" "$dst_dir/cookies.json"
+	rm -rf "$dst_dir/user-data"
 
-    update_profiles_index "$dst" "persistent" "add"
-    echo -e "${GREEN}Profile '$src' cloned to '$dst' (new fingerprint, no saved state).${NC}"
-    return 0
+	update_profiles_index "$dst" "persistent" "add"
+	echo -e "${GREEN}Profile '$src' cloned to '$dst' (new fingerprint, no saved state).${NC}"
+	return 0
 }
 
 profile_update() {
-    local name="$1"
-    shift
-    local profile_dir
-    profile_dir=$(find_profile_dir "$name")
+	local name="$1"
+	shift
+	local profile_dir
+	profile_dir=$(find_profile_dir "$name")
 
-    if [[ -z "$profile_dir" ]]; then
-        echo -e "${RED}Error: Profile '$name' not found.${NC}" >&2
-        return 1
-    fi
+	if [[ -z "$profile_dir" ]]; then
+		echo -e "${RED}Error: Profile '$name' not found.${NC}" >&2
+		return 1
+	fi
 
-    local arg
-    while [[ $# -gt 0 ]]; do
-        arg="$1"
-        case "$arg" in
-            --proxy)
-                local proxy_json
-                proxy_json=$(parse_proxy_url "$2")
-                echo "$proxy_json" > "$profile_dir/proxy.json"
-                echo -e "${GREEN}Proxy updated for '$name'.${NC}"
-                shift 2
-                ;;
-            --notes)
-                PROFILE_NOTES="$2" PROFILE_META="$profile_dir/metadata.json" python3 -c "
+	local arg
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		case "$arg" in
+		--proxy)
+			local proxy_json
+			proxy_json=$(parse_proxy_url "$2")
+			echo "$proxy_json" >"$profile_dir/proxy.json"
+			echo -e "${GREEN}Proxy updated for '$name'.${NC}"
+			shift 2
+			;;
+		--notes)
+			PROFILE_NOTES="$2" PROFILE_META="$profile_dir/metadata.json" python3 -c "
 import json, os
 meta_path = os.environ['PROFILE_META']
 notes_val = os.environ['PROFILE_NOTES']
@@ -427,52 +442,67 @@ with open(meta_path, 'r+') as f:
     json.dump(d, f, indent=2)
     f.truncate()
 " 2>/dev/null
-                echo -e "${GREEN}Notes updated for '$name'.${NC}"
-                shift 2
-                ;;
-            *) shift ;;
-        esac
-    done
-    return 0
+			echo -e "${GREEN}Notes updated for '$name'.${NC}"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+	return 0
 }
 
 # ─── Launch ──────────────────────────────────────────────────────────────────
 
 launch_browser() {
-    local profile_name=""
-    local engine="firefox"
-    local headless=""
-    local disposable=""
-    local url=""
+	local profile_name=""
+	local engine="firefox"
+	local headless=""
+	local disposable=""
+	local url=""
 
-    local arg
-    while [[ $# -gt 0 ]]; do
-        arg="$1"
-        case "$arg" in
-            --profile) profile_name="$2"; shift 2 ;;
-            --engine) engine="$2"; shift 2 ;;
-            --headless) headless="true"; shift ;;
-            --disposable) disposable="true"; shift ;;
-            --url) url="$2"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	local arg
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		case "$arg" in
+		--profile)
+			profile_name="$2"
+			shift 2
+			;;
+		--engine)
+			engine="$2"
+			shift 2
+			;;
+		--headless)
+			headless="true"
+			shift
+			;;
+		--disposable)
+			disposable="true"
+			shift
+			;;
+		--url)
+			url="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    if [[ -z "$profile_name" && -z "$disposable" ]]; then
-        echo -e "${RED}Error: --profile <name> or --disposable required.${NC}" >&2
-        return 1
-    fi
+	if [[ -z "$profile_name" && -z "$disposable" ]]; then
+		echo -e "${RED}Error: --profile <name> or --disposable required.${NC}" >&2
+		return 1
+	fi
 
-    if [[ "$engine" == "random" ]]; then
-        engine=$(python3 -c "import random; print(random.choice(['chromium','firefox','mullvad']))")
-    fi
+	if [[ "$engine" == "random" ]]; then
+		engine=$(python3 -c "import random; print(random.choice(['chromium','firefox','mullvad']))")
+	fi
 
-    # Update last_used timestamp
-    if [[ -n "$profile_name" ]]; then
-        local profile_dir
-        profile_dir=$(find_profile_dir "$profile_name")
-        if [[ -n "$profile_dir" && -f "$profile_dir/metadata.json" ]]; then
-            python3 -c "
+	# Update last_used timestamp
+	if [[ -n "$profile_name" ]]; then
+		local profile_dir
+		profile_dir=$(find_profile_dir "$profile_name")
+		if [[ -n "$profile_dir" && -f "$profile_dir/metadata.json" ]]; then
+			python3 -c "
 import json
 with open('$profile_dir/metadata.json', 'r+') as f:
     d = json.load(f)
@@ -481,50 +511,50 @@ with open('$profile_dir/metadata.json', 'r+') as f:
     json.dump(d, f, indent=2)
     f.truncate()
 " 2>/dev/null
-        fi
-    fi
+		fi
+	fi
 
-    if [[ "$engine" == "firefox" ]]; then
-        launch_camoufox "$profile_name" "$headless" "$url" "$disposable"
-    elif [[ "$engine" == "mullvad" ]]; then
-        launch_mullvad "$profile_name" "$headless" "$url" "$disposable"
-    else
-        launch_chromium_stealth "$profile_name" "$headless" "$url" "$disposable"
-    fi
-    return $?
+	if [[ "$engine" == "firefox" ]]; then
+		launch_camoufox "$profile_name" "$headless" "$url" "$disposable"
+	elif [[ "$engine" == "mullvad" ]]; then
+		launch_mullvad "$profile_name" "$headless" "$url" "$disposable"
+	else
+		launch_chromium_stealth "$profile_name" "$headless" "$url" "$disposable"
+	fi
+	return $?
 }
 
 launch_camoufox() {
-    local profile_name="$1"
-    local headless="$2"
-    local url="$3"
-    local disposable="$4"
+	local profile_name="$1"
+	local headless="$2"
+	local url="$3"
+	local disposable="$4"
 
-    source "$VENV_DIR/bin/activate" 2>/dev/null || {
-        echo -e "${RED}Error: Camoufox venv not found. Run: anti-detect-helper.sh setup${NC}" >&2
-        return 1
-    }
+	source "$VENV_DIR/bin/activate" 2>/dev/null || {
+		echo -e "${RED}Error: Camoufox venv not found. Run: anti-detect-helper.sh setup${NC}" >&2
+		return 1
+	}
 
-    local profile_dir=""
-    local config_arg=""
-    local proxy_arg=""
+	local profile_dir=""
+	local config_arg=""
+	local proxy_arg=""
 
-    if [[ -n "$profile_name" ]]; then
-        profile_dir=$(find_profile_dir "$profile_name")
-        if [[ -n "$profile_dir" && -f "$profile_dir/fingerprint.json" ]]; then
-            config_arg="$profile_dir/fingerprint.json"
-        fi
-        if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
-            proxy_arg="$profile_dir/proxy.json"
-        fi
-    fi
+	if [[ -n "$profile_name" ]]; then
+		profile_dir=$(find_profile_dir "$profile_name")
+		if [[ -n "$profile_dir" && -f "$profile_dir/fingerprint.json" ]]; then
+			config_arg="$profile_dir/fingerprint.json"
+		fi
+		if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
+			proxy_arg="$profile_dir/proxy.json"
+		fi
+	fi
 
-    local headless_flag="True"
-    [[ "$headless" != "true" ]] && headless_flag="False"
+	local headless_flag="True"
+	[[ "$headless" != "true" ]] && headless_flag="False"
 
-    local target_url="${url:-https://www.browserscan.net/bot-detection}"
+	local target_url="${url:-https://www.browserscan.net/bot-detection}"
 
-    python3 -c "
+	python3 -c "
 import json
 from camoufox.sync_api import Camoufox
 
@@ -590,57 +620,57 @@ with Camoufox(**kwargs) as browser:
         input('Press Enter to close browser...')
 " 2>&1
 
-    deactivate 2>/dev/null || true
-    return 0
+	deactivate 2>/dev/null || true
+	return 0
 }
 
 launch_mullvad() {
-    local profile_name="$1"
-    local headless="$2"
-    local url="$3"
-    local disposable="$4"
+	local profile_name="$1"
+	local headless="$2"
+	local url="$3"
+	local disposable="$4"
 
-    # Find Mullvad Browser executable
-    local mullvad_path=""
-    if [[ -f "/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser" ]]; then
-        mullvad_path="/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser"
-    elif [[ -f "/usr/bin/mullvad-browser" ]]; then
-        mullvad_path="/usr/bin/mullvad-browser"
-    elif [[ -f "$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser" ]]; then
-        mullvad_path="$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser"
-    elif [[ -f "/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe" ]]; then
-        mullvad_path="/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe"
-    else
-        echo -e "${RED}Error: Mullvad Browser not found. Install from https://mullvad.net/browser${NC}" >&2
-        return 1
-    fi
+	# Find Mullvad Browser executable
+	local mullvad_path=""
+	if [[ -f "/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser" ]]; then
+		mullvad_path="/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser"
+	elif [[ -f "/usr/bin/mullvad-browser" ]]; then
+		mullvad_path="/usr/bin/mullvad-browser"
+	elif [[ -f "$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser" ]]; then
+		mullvad_path="$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser"
+	elif [[ -f "/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe" ]]; then
+		mullvad_path="/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe"
+	else
+		echo -e "${RED}Error: Mullvad Browser not found. Install from https://mullvad.net/browser${NC}" >&2
+		return 1
+	fi
 
-    local profile_dir=""
-    local user_data_dir=""
-    local proxy_server=""
+	local profile_dir=""
+	local user_data_dir=""
+	local proxy_server=""
 
-    if [[ -n "$profile_name" ]]; then
-        profile_dir=$(find_profile_dir "$profile_name")
-        if [[ -n "$profile_dir" ]]; then
-            user_data_dir="$profile_dir/mullvad-data"
-            mkdir -p "$user_data_dir"
-        fi
-        if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
-            proxy_server=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('server',''))" 2>/dev/null)
-        fi
-    fi
+	if [[ -n "$profile_name" ]]; then
+		profile_dir=$(find_profile_dir "$profile_name")
+		if [[ -n "$profile_dir" ]]; then
+			user_data_dir="$profile_dir/mullvad-data"
+			mkdir -p "$user_data_dir"
+		fi
+		if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
+			proxy_server=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('server',''))" 2>/dev/null)
+		fi
+	fi
 
-    local headless_flag="true"
-    [[ "$headless" != "true" ]] && headless_flag="false"
+	local headless_flag="true"
+	[[ "$headless" != "true" ]] && headless_flag="false"
 
-    local target_url="${url:-https://www.browserscan.net/bot-detection}"
+	local target_url="${url:-https://www.browserscan.net/bot-detection}"
 
-    echo -e "${BLUE}Launching Mullvad Browser (headless=$headless_flag)...${NC}"
-    echo -e "${YELLOW}Note: Mullvad Browser uses Tor Browser's uniform fingerprint (no rotation).${NC}"
-    echo -e "${YELLOW}For fingerprint rotation, use --engine firefox (Camoufox) instead.${NC}"
+	echo -e "${BLUE}Launching Mullvad Browser (headless=$headless_flag)...${NC}"
+	echo -e "${YELLOW}Note: Mullvad Browser uses Tor Browser's uniform fingerprint (no rotation).${NC}"
+	echo -e "${YELLOW}For fingerprint rotation, use --engine firefox (Camoufox) instead.${NC}"
 
-    # Use Node.js with Playwright Firefox driver
-    node -e "
+	# Use Node.js with Playwright Firefox driver
+	node -e "
 const { firefox } = require('playwright');
 
 (async () => {
@@ -687,39 +717,39 @@ const { firefox } = require('playwright');
 })().catch(e => { console.error(e.message); process.exit(1); });
 " 2>&1
 
-    return 0
+	return 0
 }
 
 launch_chromium_stealth() {
-    local profile_name="$1"
-    local headless="$2"
-    local url="$3"
-    local disposable="$4"
+	local profile_name="$1"
+	local headless="$2"
+	local url="$3"
+	local disposable="$4"
 
-    local profile_dir=""
-    local user_data_dir=""
-    local proxy_server=""
+	local profile_dir=""
+	local user_data_dir=""
+	local proxy_server=""
 
-    if [[ -n "$profile_name" ]]; then
-        profile_dir=$(find_profile_dir "$profile_name")
-        if [[ -n "$profile_dir" ]]; then
-            user_data_dir="$profile_dir/user-data"
-            mkdir -p "$user_data_dir"
-        fi
-        if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
-            proxy_server=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('server',''))" 2>/dev/null)
-            proxy_username=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('username',''))" 2>/dev/null)
-            proxy_password=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('password',''))" 2>/dev/null)
-        fi
-    fi
+	if [[ -n "$profile_name" ]]; then
+		profile_dir=$(find_profile_dir "$profile_name")
+		if [[ -n "$profile_dir" ]]; then
+			user_data_dir="$profile_dir/user-data"
+			mkdir -p "$user_data_dir"
+		fi
+		if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
+			proxy_server=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('server',''))" 2>/dev/null)
+			proxy_username=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('username',''))" 2>/dev/null)
+			proxy_password=$(python3 -c "import json; print(json.load(open('$profile_dir/proxy.json')).get('password',''))" 2>/dev/null)
+		fi
+	fi
 
-    local headless_flag="true"
-    [[ "$headless" != "true" ]] && headless_flag="false"
+	local headless_flag="true"
+	[[ "$headless" != "true" ]] && headless_flag="false"
 
-    local target_url="${url:-https://www.browserscan.net/bot-detection}"
+	local target_url="${url:-https://www.browserscan.net/bot-detection}"
 
-    # Use Node.js with patched Playwright
-    node -e "
+	# Use Node.js with patched Playwright
+	node -e "
 const { chromium } = require('playwright');
 
 (async () => {
@@ -775,46 +805,55 @@ const { chromium } = require('playwright');
 })().catch(e => { console.error(e.message); process.exit(1); });
 " 2>&1
 
-    return 0
+	return 0
 }
 
 # ─── Testing ─────────────────────────────────────────────────────────────────
 
 test_detection() {
-    local profile_name=""
-    local engine="firefox"
-    local sites="browserscan,sannysoft"
-    local arg
+	local profile_name=""
+	local engine="firefox"
+	local sites="browserscan,sannysoft"
+	local arg
 
-    while [[ $# -gt 0 ]]; do
-        arg="$1"
-        case "$arg" in
-            --profile) profile_name="$2"; shift 2 ;;
-            --engine) engine="$2"; shift 2 ;;
-            --sites) sites="$2"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		case "$arg" in
+		--profile)
+			profile_name="$2"
+			shift 2
+			;;
+		--engine)
+			engine="$2"
+			shift 2
+			;;
+		--sites)
+			sites="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    echo -e "${BLUE}Testing bot detection (engine: $engine)...${NC}"
+	echo -e "${BLUE}Testing bot detection (engine: $engine)...${NC}"
 
-    source "$VENV_DIR/bin/activate" 2>/dev/null || true
+	source "$VENV_DIR/bin/activate" 2>/dev/null || true
 
-    local config_arg=""
-    local proxy_arg=""
+	local config_arg=""
+	local proxy_arg=""
 
-    if [[ -n "$profile_name" ]]; then
-        local profile_dir
-        profile_dir=$(find_profile_dir "$profile_name")
-        if [[ -n "$profile_dir" && -f "$profile_dir/fingerprint.json" ]]; then
-            config_arg="$profile_dir/fingerprint.json"
-        fi
-        if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
-            proxy_arg="$profile_dir/proxy.json"
-        fi
-    fi
+	if [[ -n "$profile_name" ]]; then
+		local profile_dir
+		profile_dir=$(find_profile_dir "$profile_name")
+		if [[ -n "$profile_dir" && -f "$profile_dir/fingerprint.json" ]]; then
+			config_arg="$profile_dir/fingerprint.json"
+		fi
+		if [[ -n "$profile_dir" && -f "$profile_dir/proxy.json" ]]; then
+			proxy_arg="$profile_dir/proxy.json"
+		fi
+	fi
 
-    python3 -c "
+	python3 -c "
 import json
 import sys
 
@@ -887,55 +926,55 @@ else:
     print('Chromium testing requires Node.js - use: anti-detect-helper.sh launch --engine chromium --url <test-url>')
 " 2>&1
 
-    deactivate 2>/dev/null || true
-    return 0
+	deactivate 2>/dev/null || true
+	return 0
 }
 
 # ─── Warmup ──────────────────────────────────────────────────────────────────
 
 warmup_profile() {
-    local profile_name="$1"
-    shift
-    local duration="30"  # minutes
-    local arg
+	local profile_name="$1"
+	shift
+	local duration="30" # minutes
+	local arg
 
-    while [[ $# -gt 0 ]]; do
-        arg="$1"
-        case "$arg" in
-            --duration)
-                duration="${2%m}"  # Strip 'm' suffix
-                shift 2
-                ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		case "$arg" in
+		--duration)
+			duration="${2%m}" # Strip 'm' suffix
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    local profile_dir
-    profile_dir=$(find_profile_dir "$profile_name")
+	local profile_dir
+	profile_dir=$(find_profile_dir "$profile_name")
 
-    if [[ -z "$profile_dir" ]]; then
-        echo -e "${RED}Error: Profile '$profile_name' not found.${NC}" >&2
-        return 1
-    fi
+	if [[ -z "$profile_dir" ]]; then
+		echo -e "${RED}Error: Profile '$profile_name' not found.${NC}" >&2
+		return 1
+	fi
 
-    echo -e "${BLUE}Warming up profile '$profile_name' for ${duration}m...${NC}"
+	echo -e "${BLUE}Warming up profile '$profile_name' for ${duration}m...${NC}"
 
-    source "$VENV_DIR/bin/activate" 2>/dev/null || {
-        echo -e "${RED}Error: Camoufox venv not found. Run: anti-detect-helper.sh setup${NC}" >&2
-        return 1
-    }
+	source "$VENV_DIR/bin/activate" 2>/dev/null || {
+		echo -e "${RED}Error: Camoufox venv not found. Run: anti-detect-helper.sh setup${NC}" >&2
+		return 1
+	}
 
-    local config_arg=""
-    local proxy_arg=""
+	local config_arg=""
+	local proxy_arg=""
 
-    if [[ -f "$profile_dir/fingerprint.json" ]]; then
-        config_arg="$profile_dir/fingerprint.json"
-    fi
-    if [[ -f "$profile_dir/proxy.json" ]]; then
-        proxy_arg="$profile_dir/proxy.json"
-    fi
+	if [[ -f "$profile_dir/fingerprint.json" ]]; then
+		config_arg="$profile_dir/fingerprint.json"
+	fi
+	if [[ -f "$profile_dir/proxy.json" ]]; then
+		proxy_arg="$profile_dir/proxy.json"
+	fi
 
-    python3 -c "
+	python3 -c "
 import json
 import asyncio
 import random
@@ -1036,154 +1075,159 @@ async def warmup():
 asyncio.run(warmup())
 " 2>&1
 
-    deactivate 2>/dev/null || true
-    echo -e "${GREEN}Warmup complete for '$profile_name'.${NC}"
-    return 0
+	deactivate 2>/dev/null || true
+	echo -e "${GREEN}Warmup complete for '$profile_name'.${NC}"
+	return 0
 }
 
 # ─── Status ──────────────────────────────────────────────────────────────────
 
 show_status() {
-    echo -e "${BLUE}Anti-Detect Browser Status:${NC}"
-    echo "─────────────────────────────────────────"
+	echo -e "${BLUE}Anti-Detect Browser Status:${NC}"
+	echo "─────────────────────────────────────────"
 
-    # Camoufox
-    if [[ -d "$VENV_DIR" ]]; then
-        local camoufox_version
-        camoufox_version=$("$VENV_DIR/bin/python3" -c "from camoufox.__version__ import __version__; print(__version__)" 2>/dev/null || echo "unknown")
-        echo -e "  Camoufox:          ${GREEN}installed${NC} (v$camoufox_version)"
-    else
-        echo -e "  Camoufox:          ${RED}not installed${NC}"
-    fi
+	# Camoufox
+	if [[ -d "$VENV_DIR" ]]; then
+		local camoufox_version
+		camoufox_version=$("$VENV_DIR/bin/python3" -c "from camoufox.__version__ import __version__; print(__version__)" 2>/dev/null || echo "unknown")
+		echo -e "  Camoufox:          ${GREEN}installed${NC} (v$camoufox_version)"
+	else
+		echo -e "  Camoufox:          ${RED}not installed${NC}"
+	fi
 
-    # Mullvad Browser
-    local mullvad_path=""
-    if [[ -f "/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser" ]]; then
-        mullvad_path="/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser"
-    elif [[ -f "/usr/bin/mullvad-browser" ]]; then
-        mullvad_path="/usr/bin/mullvad-browser"
-    elif [[ -f "$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser" ]]; then
-        mullvad_path="$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser"
-    elif [[ -f "/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe" ]]; then
-        mullvad_path="/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe"
-    fi
-    if [[ -n "$mullvad_path" ]]; then
-        echo -e "  Mullvad Browser:   ${GREEN}installed${NC} ($mullvad_path)"
-    else
-        echo -e "  Mullvad Browser:   ${YELLOW}not installed${NC} (https://mullvad.net/browser)"
-    fi
+	# Mullvad Browser
+	local mullvad_path=""
+	if [[ -f "/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser" ]]; then
+		mullvad_path="/Applications/Mullvad Browser.app/Contents/MacOS/mullvadbrowser"
+	elif [[ -f "/usr/bin/mullvad-browser" ]]; then
+		mullvad_path="/usr/bin/mullvad-browser"
+	elif [[ -f "$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser" ]]; then
+		mullvad_path="$HOME/.local/share/mullvad-browser/Browser/start-mullvad-browser"
+	elif [[ -f "/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe" ]]; then
+		mullvad_path="/mnt/c/Program Files/Mullvad Browser/Browser/mullvadbrowser.exe"
+	fi
+	if [[ -n "$mullvad_path" ]]; then
+		echo -e "  Mullvad Browser:   ${GREEN}installed${NC} ($mullvad_path)"
+	else
+		echo -e "  Mullvad Browser:   ${YELLOW}not installed${NC} (https://mullvad.net/browser)"
+	fi
 
-    # rebrowser-patches
-    if npx rebrowser-patches@latest --version &>/dev/null 2>&1; then
-        echo -e "  rebrowser-patches: ${GREEN}available${NC}"
-    else
-        echo -e "  rebrowser-patches: ${YELLOW}not patched${NC} (run: npx rebrowser-patches patch)"
-    fi
+	# rebrowser-patches
+	if npx rebrowser-patches@latest --version &>/dev/null 2>&1; then
+		echo -e "  rebrowser-patches: ${GREEN}available${NC}"
+	else
+		echo -e "  rebrowser-patches: ${YELLOW}not patched${NC} (run: npx rebrowser-patches patch)"
+	fi
 
-    # Playwright
-    if command -v npx &>/dev/null && npx playwright --version &>/dev/null 2>&1; then
-        local pw_version
-        pw_version=$(npx playwright --version 2>/dev/null || echo "unknown")
-        echo -e "  Playwright:        ${GREEN}installed${NC} ($pw_version)"
-    else
-        echo -e "  Playwright:        ${RED}not installed${NC}"
-    fi
+	# Playwright
+	if command -v npx &>/dev/null && npx playwright --version &>/dev/null 2>&1; then
+		local pw_version
+		pw_version=$(npx playwright --version 2>/dev/null || echo "unknown")
+		echo -e "  Playwright:        ${GREEN}installed${NC} ($pw_version)"
+	else
+		echo -e "  Playwright:        ${RED}not installed${NC}"
+	fi
 
-    # Profiles
-    local profile_count=0
-    for dir in "$PROFILES_DIR"/{persistent,clean,warmup}/*/; do
-        [[ -d "$dir" ]] && [[ "$(basename "$dir")" != "default" ]] && ((++profile_count)) || true
-    done
-    echo -e "  Profiles:          ${GREEN}$profile_count${NC} configured"
+	# Profiles
+	local profile_count=0
+	for dir in "$PROFILES_DIR"/{persistent,clean,warmup}/*/; do
+		if [[ -d "$dir" ]] && [[ "$(basename "$dir")" != "default" ]]; then
+			((++profile_count))
+		fi
+	done
+	echo -e "  Profiles:          ${GREEN}$profile_count${NC} configured"
 
-    # Profile directory
-    echo -e "  Profile dir:       $PROFILES_DIR"
-    echo -e "  Venv dir:          $VENV_DIR"
+	# Profile directory
+	echo -e "  Profile dir:       $PROFILES_DIR"
+	echo -e "  Venv dir:          $VENV_DIR"
 
-    return 0
+	return 0
 }
 
 # ─── Proxy Operations ────────────────────────────────────────────────────────
 
 proxy_check() {
-    local proxy_url="$1"
+	local proxy_url="$1"
 
-    echo -e "${BLUE}Checking proxy: $proxy_url${NC}"
+	echo -e "${BLUE}Checking proxy: $proxy_url${NC}"
 
-    local result
-    result=$(curl -s --proxy "$proxy_url" --max-time 15 "https://httpbin.org/ip" 2>/dev/null)
+	local result
+	result=$(curl -s --proxy "$proxy_url" --max-time 15 "https://httpbin.org/ip" 2>/dev/null)
 
-    if [[ $? -eq 0 && -n "$result" ]]; then
-        local ip
-        ip=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('origin','unknown'))" 2>/dev/null || echo "unknown")
-        echo -e "  Status: ${GREEN}OK${NC}"
-        echo "  IP: $ip"
+	if [[ $? -eq 0 && -n "$result" ]]; then
+		local ip
+		ip=$(echo "$result" | python3 -c "import json,sys; print(json.load(sys.stdin).get('origin','unknown'))" 2>/dev/null || echo "unknown")
+		echo -e "  Status: ${GREEN}OK${NC}"
+		echo "  IP: $ip"
 
-        # Get geo info
-        local geo
-        geo=$(curl -s --max-time 10 "https://ipinfo.io/$ip/json" 2>/dev/null)
-        if [[ -n "$geo" ]]; then
-            local country city isp
-            country=$(echo "$geo" | python3 -c "import json,sys; print(json.load(sys.stdin).get('country','?'))" 2>/dev/null || echo "?")
-            city=$(echo "$geo" | python3 -c "import json,sys; print(json.load(sys.stdin).get('city','?'))" 2>/dev/null || echo "?")
-            isp=$(echo "$geo" | python3 -c "import json,sys; print(json.load(sys.stdin).get('org','?'))" 2>/dev/null || echo "?")
-            echo "  Location: $city, $country"
-            echo "  ISP: $isp"
-        fi
-    else
-        echo -e "  Status: ${RED}FAIL${NC} (connection timeout or refused)"
-    fi
-    return 0
+		# Get geo info
+		local geo
+		geo=$(curl -s --max-time 10 "https://ipinfo.io/$ip/json" 2>/dev/null)
+		if [[ -n "$geo" ]]; then
+			local country city isp
+			country=$(echo "$geo" | python3 -c "import json,sys; print(json.load(sys.stdin).get('country','?'))" 2>/dev/null || echo "?")
+			city=$(echo "$geo" | python3 -c "import json,sys; print(json.load(sys.stdin).get('city','?'))" 2>/dev/null || echo "?")
+			isp=$(echo "$geo" | python3 -c "import json,sys; print(json.load(sys.stdin).get('org','?'))" 2>/dev/null || echo "?")
+			echo "  Location: $city, $country"
+			echo "  ISP: $isp"
+		fi
+	else
+		echo -e "  Status: ${RED}FAIL${NC} (connection timeout or refused)"
+	fi
+	return 0
 }
 
 proxy_check_all() {
-    echo -e "${BLUE}Checking all profile proxies...${NC}"
+	echo -e "${BLUE}Checking all profile proxies...${NC}"
 
-    for type_dir in "$PROFILES_DIR"/{persistent,clean,warmup}/*/; do
-        [[ -d "$type_dir" ]] || continue
-        local name
-        name=$(basename "$type_dir")
-        [[ "$name" == "default" ]] && continue
+	for type_dir in "$PROFILES_DIR"/{persistent,clean,warmup}/*/; do
+		[[ -d "$type_dir" ]] || continue
+		local name
+		name=$(basename "$type_dir")
+		[[ "$name" == "default" ]] && continue
 
-        if [[ -f "$type_dir/proxy.json" ]]; then
-            local server
-            server=$(python3 -c "import json; print(json.load(open('$type_dir/proxy.json')).get('server',''))" 2>/dev/null)
-            if [[ -n "$server" ]]; then
-                echo -e "\n${YELLOW}Profile: $name${NC}"
-                proxy_check "$server"
-            fi
-        fi
-    done
-    return 0
+		if [[ -f "$type_dir/proxy.json" ]]; then
+			local server
+			server=$(python3 -c "import json; print(json.load(open('$type_dir/proxy.json')).get('server',''))" 2>/dev/null)
+			if [[ -n "$server" ]]; then
+				echo -e "\n${YELLOW}Profile: $name${NC}"
+				proxy_check "$server"
+			fi
+		fi
+	done
+	return 0
 }
 
 # ─── Cookie Operations ───────────────────────────────────────────────────────
 
 cookies_export() {
-    local profile_name="$1"
-    shift
-    local output=""
-    local arg
+	local profile_name="$1"
+	shift
+	local output=""
+	local arg
 
-    while [[ $# -gt 0 ]]; do
-        arg="$1"
-        case "$arg" in
-            --output) output="$2"; shift 2 ;;
-            *) shift ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		arg="$1"
+		case "$arg" in
+		--output)
+			output="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
 
-    local profile_dir
-    profile_dir=$(find_profile_dir "$profile_name")
+	local profile_dir
+	profile_dir=$(find_profile_dir "$profile_name")
 
-    if [[ -z "$profile_dir" || ! -f "$profile_dir/storage-state.json" ]]; then
-        echo -e "${RED}Error: No saved state for profile '$profile_name'.${NC}" >&2
-        return 1
-    fi
+	if [[ -z "$profile_dir" || ! -f "$profile_dir/storage-state.json" ]]; then
+		echo -e "${RED}Error: No saved state for profile '$profile_name'.${NC}" >&2
+		return 1
+	fi
 
-    local out_file="${output:-/tmp/${profile_name}-cookies.txt}"
+	local out_file="${output:-/tmp/${profile_name}-cookies.txt}"
 
-    python3 -c "
+	python3 -c "
 import json
 
 with open('$profile_dir/storage-state.json') as f:
@@ -1208,47 +1252,47 @@ with open('$out_file', 'w') as f:
 print(f'Exported {len(cookies)} cookies to $out_file')
 " 2>&1
 
-    return 0
+	return 0
 }
 
 cookies_clear() {
-    local profile_name="$1"
-    local profile_dir
-    profile_dir=$(find_profile_dir "$profile_name")
+	local profile_name="$1"
+	local profile_dir
+	profile_dir=$(find_profile_dir "$profile_name")
 
-    if [[ -z "$profile_dir" ]]; then
-        echo -e "${RED}Error: Profile '$profile_name' not found.${NC}" >&2
-        return 1
-    fi
+	if [[ -z "$profile_dir" ]]; then
+		echo -e "${RED}Error: Profile '$profile_name' not found.${NC}" >&2
+		return 1
+	fi
 
-    rm -f "$profile_dir/storage-state.json" "$profile_dir/cookies.json"
-    rm -rf "$profile_dir/user-data"
-    echo -e "${GREEN}Cookies cleared for '$profile_name'.${NC}"
-    return 0
+	rm -f "$profile_dir/storage-state.json" "$profile_dir/cookies.json"
+	rm -rf "$profile_dir/user-data"
+	echo -e "${GREEN}Cookies cleared for '$profile_name'.${NC}"
+	return 0
 }
 
 # ─── Utility Functions ───────────────────────────────────────────────────────
 
 find_profile_dir() {
-    local name="$1"
-    for type in persistent clean warmup disposable; do
-        local dir="$PROFILES_DIR/$type/$name"
-        if [[ -d "$dir" ]]; then
-            echo "$dir"
-            return 0
-        fi
-    done
-    echo ""
-    return 1
+	local name="$1"
+	for type in persistent clean warmup disposable; do
+		local dir="$PROFILES_DIR/$type/$name"
+		if [[ -d "$dir" ]]; then
+			echo "$dir"
+			return 0
+		fi
+	done
+	echo ""
+	return 1
 }
 
 generate_fingerprint() {
-    local target_os="${1:-random}"
-    local browser_type="${2:-firefox}"
+	local target_os="${1:-random}"
+	local browser_type="${2:-firefox}"
 
-    # Generate fingerprint metadata (Camoufox handles actual fingerprint via BrowserForge)
-    # We store OS/screen constraints that Camoufox uses to generate consistent fingerprints
-    python3 -c "
+	# Generate fingerprint metadata (Camoufox handles actual fingerprint via BrowserForge)
+	# We store OS/screen constraints that Camoufox uses to generate consistent fingerprints
+	python3 -c "
 import json
 import random
 
@@ -1285,8 +1329,8 @@ print(json.dumps(config, indent=2))
 }
 
 parse_proxy_url() {
-    local url="$1"
-    python3 -c "
+	local url="$1"
+	python3 -c "
 import json
 from urllib.parse import urlparse
 
@@ -1307,11 +1351,11 @@ print(json.dumps(result, indent=2))
 }
 
 update_profiles_index() {
-    local name="$1"
-    local profile_type="$2"
-    local action="$3"
+	local name="$1"
+	local profile_type="$2"
+	local action="$3"
 
-    python3 -c "
+	python3 -c "
 import json
 from pathlib import Path
 
@@ -1335,72 +1379,84 @@ index_file.write_text(json.dumps(data, indent=2))
 # ─── Main ────────────────────────────────────────────────────────────────────
 
 main() {
-    local command="${1:-help}"
-    shift 2>/dev/null || true
+	local command="${1:-help}"
+	shift 2>/dev/null || true
 
-    case "$command" in
-        setup)
-            local engine="all"
-            while [[ $# -gt 0 ]]; do
-                case "$1" in
-                    --engine) engine="$2"; shift 2 ;;
-                    *) shift ;;
-                esac
-            done
-            setup_all "$engine"
-            ;;
-        launch)
-            launch_browser "$@"
-            ;;
-        profile)
-            local subcmd="${1:-list}"
-            shift 2>/dev/null || true
-            case "$subcmd" in
-                create) profile_create "$@" ;;
-                list) profile_list "$@" ;;
-                show) profile_show "$@" ;;
-                delete) profile_delete "$@" ;;
-                clone) profile_clone "$@" ;;
-                update) profile_update "$@" ;;
-                *) echo -e "${RED}Unknown profile command: $subcmd${NC}"; show_help ;;
-            esac
-            ;;
-        cookies)
-            local subcmd="${1:-}"
-            shift 2>/dev/null || true
-            case "$subcmd" in
-                export) cookies_export "$@" ;;
-                clear) cookies_clear "$@" ;;
-                *) echo -e "${RED}Unknown cookies command: $subcmd${NC}"; show_help ;;
-            esac
-            ;;
-        proxy)
-            local subcmd="${1:-}"
-            shift 2>/dev/null || true
-            case "$subcmd" in
-                check) proxy_check "$@" ;;
-                check-all) proxy_check_all ;;
-                *) echo -e "${RED}Unknown proxy command: $subcmd${NC}"; show_help ;;
-            esac
-            ;;
-        test)
-            test_detection "$@"
-            ;;
-        warmup)
-            warmup_profile "$@"
-            ;;
-        status)
-            show_status
-            ;;
-        help|--help|-h)
-            show_help
-            ;;
-        *)
-            echo -e "${RED}Unknown command: $command${NC}"
-            show_help
-            return 1
-            ;;
-    esac
+	case "$command" in
+	setup)
+		local engine="all"
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+			--engine)
+				engine="$2"
+				shift 2
+				;;
+			*) shift ;;
+			esac
+		done
+		setup_all "$engine"
+		;;
+	launch)
+		launch_browser "$@"
+		;;
+	profile)
+		local subcmd="${1:-list}"
+		shift 2>/dev/null || true
+		case "$subcmd" in
+		create) profile_create "$@" ;;
+		list) profile_list "$@" ;;
+		show) profile_show "$@" ;;
+		delete) profile_delete "$@" ;;
+		clone) profile_clone "$@" ;;
+		update) profile_update "$@" ;;
+		*)
+			echo -e "${RED}Unknown profile command: $subcmd${NC}"
+			show_help
+			;;
+		esac
+		;;
+	cookies)
+		local subcmd="${1:-}"
+		shift 2>/dev/null || true
+		case "$subcmd" in
+		export) cookies_export "$@" ;;
+		clear) cookies_clear "$@" ;;
+		*)
+			echo -e "${RED}Unknown cookies command: $subcmd${NC}"
+			show_help
+			;;
+		esac
+		;;
+	proxy)
+		local subcmd="${1:-}"
+		shift 2>/dev/null || true
+		case "$subcmd" in
+		check) proxy_check "$@" ;;
+		check-all) proxy_check_all ;;
+		*)
+			echo -e "${RED}Unknown proxy command: $subcmd${NC}"
+			show_help
+			;;
+		esac
+		;;
+	test)
+		test_detection "$@"
+		;;
+	warmup)
+		warmup_profile "$@"
+		;;
+	status)
+		show_status
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		echo -e "${RED}Unknown command: $command${NC}"
+		show_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/anti-detect-helper.sh
+++ b/.agents/scripts/anti-detect-helper.sh
@@ -1092,7 +1092,7 @@ show_status() {
     # Profiles
     local profile_count=0
     for dir in "$PROFILES_DIR"/{persistent,clean,warmup}/*/; do
-        [[ -d "$dir" ]] && [[ "$(basename "$dir")" != "default" ]] && ((profile_count++)) || true || true
+        [[ -d "$dir" ]] && [[ "$(basename "$dir")" != "default" ]] && ((++profile_count)) || true
     done
     echo -e "  Profiles:          ${GREEN}$profile_count${NC} configured"
 

--- a/.agents/scripts/archived/quality-loop-helper.sh
+++ b/.agents/scripts/archived/quality-loop-helper.sh
@@ -167,7 +167,7 @@ calculate_backoff_wait() {
 			wait_time=$BACKOFF_MAX
 			break
 		fi
-		((++i))
+		((i++))
 	done
 
 	echo "$wait_time"

--- a/.agents/scripts/archived/quality-loop-helper.sh
+++ b/.agents/scripts/archived/quality-loop-helper.sh
@@ -167,7 +167,7 @@ calculate_backoff_wait() {
 			wait_time=$BACKOFF_MAX
 			break
 		fi
-		((i++))
+		((++i))
 	done
 
 	echo "$wait_time"

--- a/.agents/scripts/archived/ralph-loop-helper.sh
+++ b/.agents/scripts/archived/ralph-loop-helper.sh
@@ -384,7 +384,7 @@ calculate_delay() {
         local i=1
         while [[ $i -lt $iteration ]] && [[ $delay -lt $RALPH_DELAY_MAX ]]; do
             delay=$((delay * 2))
-            ((++i))
+            ((i++))
         done
         [[ $delay -gt $RALPH_DELAY_MAX ]] && delay=$RALPH_DELAY_MAX
     fi

--- a/.agents/scripts/archived/ralph-loop-helper.sh
+++ b/.agents/scripts/archived/ralph-loop-helper.sh
@@ -384,7 +384,7 @@ calculate_delay() {
         local i=1
         while [[ $i -lt $iteration ]] && [[ $delay -lt $RALPH_DELAY_MAX ]]; do
             delay=$((delay * 2))
-            ((i++))
+            ((++i))
         done
         [[ $delay -gt $RALPH_DELAY_MAX ]] && delay=$RALPH_DELAY_MAX
     fi

--- a/.agents/scripts/autogen-helper.sh
+++ b/.agents/scripts/autogen-helper.sh
@@ -59,7 +59,7 @@ get_available_port() {
     # Find next available port
     local port="$desired_port"
     while lsof -i :"$port" >/dev/null 2>&1 && [[ $port -lt 65535 ]]; do
-        ((port++))
+        ((++port))
     done
     
     if [[ $port -lt 65535 ]]; then
@@ -283,7 +283,7 @@ else
     if lsof -i :"$DESIRED_PORT" >/dev/null 2>&1; then
         echo "[WARNING] Port $DESIRED_PORT is in use, finding alternative..."
         while lsof -i :"$DESIRED_PORT" >/dev/null 2>&1 && [[ $DESIRED_PORT -lt 65535 ]]; do
-            ((DESIRED_PORT++))
+            ((++DESIRED_PORT))
         done
         echo "[INFO] Using port: $DESIRED_PORT"
     fi

--- a/.agents/scripts/beads-sync-helper.sh
+++ b/.agents/scripts/beads-sync-helper.sh
@@ -231,16 +231,16 @@ cmd_push() {
 			if [[ "$verbose" == "true" ]]; then
 				log_info "Updating: $id - $desc"
 			fi
-			# bd update "$id" --title "$desc" --json &>/dev/null || ((error_count++))
+			# bd update "$id" --title "$desc" --json &>/dev/null || ((++error_count))
 		else
 			# Create new
 			if [[ "$verbose" == "true" ]]; then
 				log_info "Creating: $id - $desc"
 			fi
 			# For now, just count - actual creation would use bd create
-			# bd create "$desc" --json &>/dev/null || ((error_count++))
+			# bd create "$desc" --json &>/dev/null || ((++error_count))
 		fi
-		((task_count++))
+		((++task_count))
 	done < <(parse_todo_md "$project_root")
 
 	# Verify checksums after
@@ -486,7 +486,7 @@ cmd_ready() {
 
 		# Check for blocked-by
 		if [[ "$line" =~ blocked-by: ]]; then
-			((blocked_count++))
+			((++blocked_count))
 			# Extract task ID and blocker
 			local task_id
 			task_id=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1)
@@ -494,7 +494,7 @@ cmd_ready() {
 			blocker=$(echo "$line" | grep -oE 'blocked-by:[^ ]+' | cut -d: -f2)
 			echo "  BLOCKED: $task_id (waiting on: $blocker)"
 		else
-			((ready_count++))
+			((++ready_count))
 			# Extract task ID and description
 			local task_info
 			task_info=$(echo "$line" | sed 's/^- \[ \] //' | cut -d'#' -f1 | head -c 60)

--- a/.agents/scripts/codacy-cli-chunked.sh
+++ b/.agents/scripts/codacy-cli-chunked.sh
@@ -188,7 +188,7 @@ run_quick_analysis() {
 	# Count tools
 	for tool in $fast_tools; do
 		if get_configured_tools | grep -q "^$tool$"; then
-			((total_tools++)) || true
+			((++total_tools))
 		fi
 	done
 
@@ -205,7 +205,7 @@ run_quick_analysis() {
 
 	for tool in $fast_tools; do
 		if get_configured_tools | grep -q "^$tool$"; then
-			((completed_tools++)) || true
+			((++completed_tools))
 			print_progress $completed_tools $total_tools "$tool"
 
 			print_info "Running: $tool"
@@ -350,7 +350,7 @@ run_chunked_analysis() {
 
 		# Update progress
 		completed_tools=$chunk_end
-		((chunk_num++)) || true
+		((++chunk_num))
 
 		# Brief pause between chunks
 		if [[ $chunk_end -lt ${#tool_array[@]} ]]; then

--- a/.agents/scripts/crawl4ai-examples.sh
+++ b/.agents/scripts/crawl4ai-examples.sh
@@ -154,7 +154,7 @@ example_batch_processing() {
             print_warning "Failed to process: $url"
         fi
         
-        ((i++)) || true
+        ((++i))
         sleep 1  # Rate limiting
     done
     
@@ -264,7 +264,7 @@ example_captcha_demo() {
             print_warning "CAPTCHA demo $i failed - this may be due to site changes or API limits"
         fi
 
-        ((i++)) || true
+        ((++i))
 
         # Add delay between requests to respect rate limits
         if [[ $i -le ${#demo_configs[@]} ]]; then

--- a/.agents/scripts/credential-helper.sh
+++ b/.agents/scripts/credential-helper.sh
@@ -672,7 +672,7 @@ cmd_copy() {
 			fi
 
 			echo "$line" >>"$dest_env"
-			((copied++))
+			((++copied))
 		fi
 	done <"$source_env"
 

--- a/.agents/scripts/crewai-helper.sh
+++ b/.agents/scripts/crewai-helper.sh
@@ -61,7 +61,7 @@ get_available_port() {
     # Find next available port
     local port="$desired_port"
     while lsof -i :"$port" >/dev/null 2>&1 && [[ $port -lt 65535 ]]; do
-        ((port++))
+        ((++port))
     done
     
     if [[ $port -lt 65535 ]]; then
@@ -398,7 +398,7 @@ else
     if lsof -i :"$DESIRED_PORT" >/dev/null 2>&1; then
         echo "[WARNING] Port $DESIRED_PORT is in use, finding alternative..."
         while lsof -i :"$DESIRED_PORT" >/dev/null 2>&1 && [[ $DESIRED_PORT -lt 65535 ]]; do
-            ((DESIRED_PORT++))
+            ((++DESIRED_PORT))
         done
         echo "[INFO] Using port: $DESIRED_PORT"
     fi

--- a/.agents/scripts/dev-browser-helper.sh
+++ b/.agents/scripts/dev-browser-helper.sh
@@ -154,7 +154,7 @@ start_server() {
     
     while ! curl -s "http://localhost:${SERVER_PORT}" > /dev/null 2>&1; do
         sleep 1
-        ((waited++))
+        ((++waited))
         if [[ ${waited} -ge ${max_wait} ]]; then
             print_error "Server failed to start within ${max_wait}s"
             print_info "Check logs: cat ${DEV_BROWSER_DIR}/server.log"

--- a/.agents/scripts/generate-skills.sh
+++ b/.agents/scripts/generate-skills.sh
@@ -215,7 +215,7 @@ if [[ "$CLEAN" == true ]]; then
 			rm -f "$skill_file"
 			log_success "Removed: $skill_file"
 		fi
-		((count++)) || true
+		((++count))
 	done < <(find "$AGENTS_DIR" -name "SKILL.md" -type f 2>/dev/null)
 
 	if [[ $count -eq 0 ]]; then
@@ -263,7 +263,7 @@ while IFS= read -r folder; do
 			generate_folder_skill "$folder" "$parent_md" >"$skill_file"
 			log_success "Generated: $skill_file"
 		fi
-		((generated++)) || true
+		((++generated))
 	fi
 done < <(find "$AGENTS_DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort)
 
@@ -303,7 +303,7 @@ while IFS= read -r folder; do
 			} >"$skill_file"
 			log_success "Generated: $skill_file"
 		fi
-		((generated++)) || true
+		((++generated))
 	fi
 done < <(find "$AGENTS_DIR" -mindepth 2 -type d 2>/dev/null | sort)
 
@@ -348,7 +348,7 @@ while IFS= read -r md_file; do
 		generate_leaf_skill "$md_file" >"$skill_file"
 		log_success "Generated: $skill_file"
 	fi
-	((generated++)) || true
+	((++generated))
 done < <(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -not -name "SKILL.md" -not -name "AGENTS.md" -not -name "README.md" -type f 2>/dev/null | sort)
 
 # =============================================================================

--- a/.agents/scripts/langflow-helper.sh
+++ b/.agents/scripts/langflow-helper.sh
@@ -62,7 +62,7 @@ get_available_port() {
     # Find next available port
     local port="$desired_port"
     while lsof -i :"$port" >/dev/null 2>&1 && [[ $port -lt 65535 ]]; do
-        ((port++))
+        ((++port))
     done
     
     if [[ $port -lt 65535 ]]; then
@@ -248,7 +248,7 @@ else
     if lsof -i :"$DESIRED_PORT" >/dev/null 2>&1; then
         echo "[WARNING] Port $DESIRED_PORT is in use, finding alternative..."
         while lsof -i :"$DESIRED_PORT" >/dev/null 2>&1 && [[ $DESIRED_PORT -lt 65535 ]]; do
-            ((DESIRED_PORT++))
+            ((++DESIRED_PORT))
         done
         echo "[INFO] Using port: $DESIRED_PORT"
     fi
@@ -432,7 +432,7 @@ import_flows() {
         if [[ -f "$flow_file" ]]; then
             if langflow import --file "$flow_file" 2>/dev/null; then
                 print_success "Imported: $(basename "$flow_file")"
-                ((count++))
+                ((++count))
             else
                 print_warning "Failed to import: $(basename "$flow_file")"
             fi

--- a/.agents/scripts/linter-manager.sh
+++ b/.agents/scripts/linter-manager.sh
@@ -148,41 +148,41 @@ install_python_linters() {
     print_info "Installing pycodestyle..."
     if pip install pycodestyle &>/dev/null; then
         print_success "pycodestyle installed"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install pycodestyle"
     fi
-    ((total++)) || true
+    ((++total))
     
     # Pylint (comprehensive Python linter)
     print_info "Installing Pylint..."
     if pip install pylint &>/dev/null; then
         print_success "Pylint installed"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install Pylint"
     fi
-    ((total++)) || true
+    ((++total))
     
     # Bandit (security linter)
     print_info "Installing Bandit..."
     if pip install bandit &>/dev/null; then
         print_success "Bandit installed"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install Bandit"
     fi
-    ((total++)) || true
+    ((++total))
     
     # Ruff (fast Python linter)
     print_info "Installing Ruff..."
     if pip install ruff &>/dev/null; then
         print_success "Ruff installed"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install Ruff"
     fi
-    ((total++)) || true
+    ((++total))
     
     print_info "Python linters: $success/$total installed successfully"
     return $((total - success))
@@ -199,21 +199,21 @@ install_javascript_linters() {
     print_info "Installing ESLint..."
     if install_npm_global eslint; then
         print_success "ESLint installed"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install ESLint"
     fi
-    ((total++)) || true
+    ((++total))
 
     # TypeScript ESLint parser and plugin
     print_info "Installing TypeScript ESLint support..."
     if install_npm_global @typescript-eslint/parser @typescript-eslint/eslint-plugin; then
         print_success "TypeScript ESLint support installed"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install TypeScript ESLint support"
     fi
-    ((total++)) || true
+    ((++total))
 
     print_info "JavaScript/TypeScript linters: $success/$total installed successfully"
     return $((total - success))
@@ -230,11 +230,11 @@ install_css_linters() {
     print_info "Installing Stylelint..."
     if install_npm_global stylelint stylelint-config-standard; then
         print_success "Stylelint installed"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install Stylelint"
     fi
-    ((total++)) || true
+    ((++total))
 
     print_info "CSS linters: $success/$total installed successfully"
     return $((total - success))
@@ -251,17 +251,17 @@ install_shell_linters() {
     print_info "Installing ShellCheck..."
     if command -v shellcheck &>/dev/null; then
         print_success "ShellCheck already installed"
-        ((success++)) || true
+        ((++success))
     elif brew install shellcheck &>/dev/null; then
         print_success "ShellCheck installed via Homebrew"
-        ((success++)) || true
+        ((++success))
     elif apt-get install -y shellcheck &>/dev/null; then
         print_success "ShellCheck installed via apt"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install ShellCheck"
     fi
-    ((total++)) || true
+    ((++total))
 
     print_info "Shell linters: $success/$total installed successfully"
     return $((total - success))
@@ -278,14 +278,14 @@ install_docker_linters() {
     print_info "Installing Hadolint..."
     if command -v hadolint &>/dev/null; then
         print_success "Hadolint already installed"
-        ((success++)) || true
+        ((++success))
     elif brew install hadolint &>/dev/null; then
         print_success "Hadolint installed via Homebrew"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install Hadolint"
     fi
-    ((total++)) || true
+    ((++total))
 
     print_info "Docker linters: $success/$total installed successfully"
     return $((total - success))
@@ -302,11 +302,11 @@ install_yaml_linters() {
     print_info "Installing yamllint..."
     if pip install yamllint &>/dev/null; then
         print_success "yamllint installed"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install yamllint"
     fi
-    ((total++)) || true
+    ((++total))
 
     print_info "YAML linters: $success/$total installed successfully"
     return $((total - success))
@@ -323,27 +323,27 @@ install_security_linters() {
     print_info "Installing Trivy..."
     if command -v trivy &>/dev/null; then
         print_success "Trivy already installed"
-        ((success++)) || true
+        ((++success))
     elif brew install trivy &>/dev/null; then
         print_success "Trivy installed via Homebrew"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install Trivy"
     fi
-    ((total++)) || true
+    ((++total))
 
     # Secretlint (secret detection)
     print_info "Installing Secretlint..."
     if command -v secretlint &>/dev/null; then
         print_success "Secretlint already installed"
-        ((success++)) || true
+        ((++success))
     elif install_npm_global secretlint @secretlint/secretlint-rule-preset-recommend; then
         print_success "Secretlint installed"
-        ((success++)) || true
+        ((++success))
     else
         print_error "Failed to install Secretlint"
     fi
-    ((total++)) || true
+    ((++total))
 
     print_info "Security linters: $success/$total installed successfully"
     return $((total - success))

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -104,7 +104,7 @@ check_return_statements() {
 
 	for file in "${ALL_SH_FILES[@]}"; do
 		[[ -f "$file" ]] || continue
-		((files_checked++))
+		((++files_checked))
 
 		# Count multi-line functions (exclude one-liners like: func() { echo "x"; })
 		# One-liners don't need explicit return statements
@@ -131,7 +131,7 @@ check_return_statements() {
 		local total_returns=$((return_statements + exit_statements))
 
 		if [[ $total_returns -lt $functions_count ]]; then
-			((violations++))
+			((++violations))
 			print_warning "Missing return statements in $file"
 		fi
 	done
@@ -565,7 +565,7 @@ check_toon_syntax() {
 				result=$(toon-lsp check "$file" 2>&1)
 				local exit_code=$?
 				if [[ $exit_code -ne 0 ]] || [[ "$result" == *"error"* ]]; then
-					((violations++))
+					((++violations))
 					print_warning "TOON syntax issue in $file"
 				fi
 			fi
@@ -574,7 +574,7 @@ check_toon_syntax() {
 		# Fallback: basic structure validation (non-empty check)
 		while IFS= read -r file; do
 			if [[ -f "$file" ]] && [[ ! -s "$file" ]]; then
-				((violations++))
+				((++violations))
 				print_warning "TOON: Empty file $file"
 			fi
 		done <<<"$toon_files"
@@ -695,7 +695,7 @@ check_skill_frontmatter() {
 	while IFS='|' read -r name local_path; do
 		if [[ ! -f "$local_path" ]]; then
 			print_warning "Skill file missing: $local_path (skill: $name)"
-			((errors++)) || true
+			((++errors))
 			continue
 		fi
 
@@ -715,13 +715,13 @@ check_skill_frontmatter() {
 
 		if [[ -z "$fm_name" ]]; then
 			print_error "Missing 'name' field in frontmatter: $local_path (expected: $name)"
-			((errors++)) || true
+			((++errors))
 		elif [[ "$fm_name" != "$name" ]]; then
 			print_error "Name mismatch in $local_path: got '$fm_name', expected '$name'"
-			((errors++)) || true
+			((++errors))
 		fi
 
-		((checked++)) || true
+		((++checked))
 	done <<<"$skill_entries"
 
 	if [[ $errors -eq 0 ]]; then

--- a/.agents/scripts/list-keys-helper.sh
+++ b/.agents/scripts/list-keys-helper.sh
@@ -36,7 +36,7 @@ print_source() {
     # Shorten home directory paths for readability
     source="${source/#$HOME/~}"
     echo -e "${BLUE}Source:${NC} $source"
-    ((total_sources++)) || true
+    ((++total_sources))
     return 0
 }
 
@@ -62,7 +62,7 @@ print_key() {
     
     # Simple format: "  KEY_NAME [status]" - no fixed width padding
     echo -e "  ${key_name} ${status_color}[${status}]${NC}"
-    ((total_keys++)) || true
+    ((++total_keys))
     return 0
 }
 

--- a/.agents/scripts/list-todo-helper.sh
+++ b/.agents/scripts/list-todo-helper.sh
@@ -434,12 +434,12 @@ output_markdown() {
     # Count tasks
     while IFS='|' read -r status id desc est tags owner logged blocked_by is_plan; do
         case "$status" in
-            in-progress|in-review) ((in_progress_count++)) ;;
+            in-progress|in-review) ((++in_progress_count)) ;;
             pending) 
-                ((pending_count++))
-                [[ -n "$blocked_by" ]] && ((blocked_count++))
+                ((++pending_count))
+                [[ -n "$blocked_by" ]] && ((++blocked_count))
                 ;;
-            done) ((done_count++)) ;;
+            done) ((++done_count)) ;;
         esac
     done < "$tasks_file"
     
@@ -476,7 +476,7 @@ output_markdown() {
             local num=0
             while IFS='|' read -r status id desc est tags owner logged blocked_by is_plan; do
                 [[ "$status" != "in-progress" && "$status" != "in-review" ]] && continue
-                ((num++))
+                ((++num))
                 echo "| $num | $id | $desc | $est | $tags | ${owner:--} |"
             done < "$tasks_file"
         fi
@@ -495,7 +495,7 @@ output_markdown() {
         local num=0
         while IFS='|' read -r status id desc est tags owner logged blocked_by is_plan; do
             [[ "$status" != "pending" ]] && continue
-            ((num++))
+            ((++num))
             [[ $LIMIT -gt 0 && $num -gt $LIMIT ]] && break
             local blocked_marker=""
             [[ -n "$blocked_by" ]] && blocked_marker=" [BLOCKED by $blocked_by]"
@@ -507,7 +507,7 @@ output_markdown() {
         local num=0
         while IFS='|' read -r status id desc est tags owner logged blocked_by is_plan; do
             [[ "$status" != "pending" ]] && continue
-            ((num++))
+            ((++num))
             [[ $LIMIT -gt 0 && $num -gt $LIMIT ]] && break
             echo "| $num | $id | $desc | $est | $tags | ${owner:--} | $logged |"
         done < "$tasks_file"

--- a/.agents/scripts/list-verify-helper.sh
+++ b/.agents/scripts/list-verify-helper.sh
@@ -198,9 +198,9 @@ output_markdown() {
 	# Count entries
 	while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
 		case "$status" in
-		pending) ((pending_count++)) ;;
-		passed) ((passed_count++)) ;;
-		failed) ((failed_count++)) ;;
+		pending) ((++pending_count)) ;;
+		passed) ((++passed_count)) ;;
+		failed) ((++failed_count)) ;;
 		esac
 	done <"$entries_file"
 
@@ -235,7 +235,7 @@ output_markdown() {
 			local num=0
 			while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
 				[[ "$status" != "failed" ]] && continue
-				((num++))
+				((++num))
 				echo "| $num | $vid | $tid | $desc | $pr | $merged | ${failed_reason:--} |"
 			done <"$entries_file"
 		fi
@@ -264,7 +264,7 @@ output_markdown() {
 			local num=0
 			while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
 				[[ "$status" != "pending" ]] && continue
-				((num++))
+				((++num))
 				local check_count
 				if [[ -n "$checks" ]]; then
 					check_count=$(echo "$checks" | tr ';' '\n' | wc -l | xargs)
@@ -299,7 +299,7 @@ output_markdown() {
 			local num=0
 			while IFS='|' read -r status vid tid desc pr merged files checks verified failed_reason; do
 				[[ "$status" != "passed" ]] && continue
-				((num++))
+				((++num))
 				echo "| $num | $vid | $tid | $desc | $pr | $merged | ${verified:--} |"
 			done <"$entries_file"
 		fi

--- a/.agents/scripts/localhost-helper.sh
+++ b/.agents/scripts/localhost-helper.sh
@@ -67,7 +67,7 @@ find_available_port() {
             echo "$port"
             return 0
         fi
-        ((port++)) || true
+        ((++port))
     done
     
     print_error "No available ports found in range $start_port-$PORT_RANGE_END"

--- a/.agents/scripts/markdown-formatter.sh
+++ b/.agents/scripts/markdown-formatter.sh
@@ -99,13 +99,13 @@ process_directory() {
 
 	# Find all markdown files
 	while IFS= read -r -d '' file; do
-		((total_files++)) || true
+		((++total_files))
 		local before_hash after_hash
 		before_hash=$(sha256sum "$file" | awk '{print $1}')
 		fix_markdown_file "$file"
 		after_hash=$(sha256sum "$file" | awk '{print $1}')
 		if [[ "$before_hash" != "$after_hash" ]]; then
-			((changed_files++)) || true
+			((++changed_files))
 		fi
 	done < <(find "$dir" -name "*.md" -type f -print0)
 
@@ -317,7 +317,7 @@ main() {
 				fix_markdown_file "$temp_file"
 				if ! cmp -s "$file" "$temp_file"; then
 					print_warning "Formatting issues found in: $file"
-					((lint_issues++)) || true
+					((++lint_issues))
 				fi
 				rm -f "$temp_file" "${temp_file}.bak"
 			done < <(find "$target" -name "*.md" -type f -print0)

--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -1496,7 +1496,7 @@ cmd_stop() {
 		local wait_count=0
 		while kill -0 "$pid" 2>/dev/null && ((wait_count < 10)); do
 			sleep 1
-			((wait_count++))
+			((++wait_count))
 		done
 
 		if kill -0 "$pid" 2>/dev/null; then

--- a/.agents/scripts/mcp-register-claude.sh
+++ b/.agents/scripts/mcp-register-claude.sh
@@ -342,7 +342,7 @@ run_command() {
 
 	if [[ "$DRY_RUN" == true ]]; then
 		echo "  ${cmd}"
-		((registered++))
+		((++registered))
 		return 0
 	fi
 
@@ -356,10 +356,10 @@ run_command() {
 
 	if "${cmd_parts[@]}" "$json_payload"; then
 		print_success "${template_name}: registered"
-		((registered++))
+		((++registered))
 	else
 		print_error "${template_name}: registration failed"
-		((failed++))
+		((++failed))
 	fi
 	return 0
 }
@@ -428,7 +428,7 @@ register_all() {
 
 		# Check skip list (includes default skips)
 		if should_skip "$stem"; then
-			((skipped++))
+			((++skipped))
 			continue
 		fi
 
@@ -440,14 +440,14 @@ register_all() {
 		fi
 
 		if [[ -z "$cmd" ]]; then
-			((skipped++))
+			((++skipped))
 			continue
 		fi
 
 		# Skip commands with placeholders (unless forced)
 		if has_placeholders "$cmd" && [[ "$FORCE" != true ]]; then
 			print_warning "${stem}: skipped (contains placeholders — use --force to override)"
-			((skipped++))
+			((++skipped))
 			continue
 		fi
 
@@ -458,7 +458,7 @@ register_all() {
 		# Check if already registered
 		if [[ -n "$server_name" ]] && is_registered "$server_name" "$registered_list" && [[ "$FORCE" != true ]]; then
 			print_info "${stem}: already registered as '${server_name}'"
-			((already++))
+			((++already))
 			continue
 		fi
 

--- a/.agents/scripts/migrate-pr-backfill.sh
+++ b/.agents/scripts/migrate-pr-backfill.sh
@@ -316,7 +316,7 @@ main() {
 
 		if [[ -z "$candidate_urls" ]]; then
 			log_verbose "No merged PR found for $task_id"
-			((unmatched++)) || true
+			((++unmatched))
 
 			if [[ "$DRY_RUN" != "true" ]]; then
 				write_proof_log "$task_id" "pr_backfill" \
@@ -353,7 +353,7 @@ main() {
 
 			if [[ -n "$existing_task" ]]; then
 				log "SKIP $task_id: PR $validated_url already linked to $existing_task"
-				((already_linked++)) || true
+				((++already_linked))
 
 				if [[ "$DRY_RUN" != "true" ]]; then
 					write_proof_log "$task_id" "pr_backfill" \
@@ -385,7 +385,7 @@ main() {
 					break
 				else
 					log "ERROR: Failed to update DB for $task_id: $db_err"
-					((errors++)) || true
+					((++errors))
 					linked="error"
 					break
 				fi
@@ -393,10 +393,10 @@ main() {
 		done <<<"$candidate_urls"
 
 		case "$linked" in
-		true) ((matched++)) || true ;;
+		true) ((++matched)) ;;
 		skip) ;;  # already counted in already_linked
 		error) ;; # already counted in errors
-		*) ((unmatched++)) || true ;;
+		*) ((++unmatched)) ;;
 		esac
 
 		# Rate limit: small delay between GitHub API calls to avoid rate limiting

--- a/.agents/scripts/network-tier-helper.sh
+++ b/.agents/scripts/network-tier-helper.sh
@@ -547,63 +547,63 @@ _self_test() {
 	result=$(classify_domain "github.com")
 	if [[ "$result" != "1" ]]; then
 		log_error "Self-test: github.com expected tier 1, got tier ${result}"
-		((failures++)) || true
+		((++failures))
 	fi
 
 	# Tier 1: api.github.com (wildcard *.github.com)
 	result=$(classify_domain "api.github.com")
 	if [[ "$result" != "1" ]]; then
 		log_error "Self-test: api.github.com expected tier 1, got tier ${result}"
-		((failures++)) || true
+		((++failures))
 	fi
 
 	# Tier 2: registry.npmjs.org
 	result=$(classify_domain "registry.npmjs.org")
 	if [[ "$result" != "2" ]]; then
 		log_error "Self-test: registry.npmjs.org expected tier 2, got tier ${result}"
-		((failures++)) || true
+		((++failures))
 	fi
 
 	# Tier 3: sonarcloud.io
 	result=$(classify_domain "sonarcloud.io")
 	if [[ "$result" != "3" ]]; then
 		log_error "Self-test: sonarcloud.io expected tier 3, got tier ${result}"
-		((failures++)) || true
+		((++failures))
 	fi
 
 	# Tier 4: unknown domain
 	result=$(classify_domain "totally-unknown-domain.example.net")
 	if [[ "$result" != "4" ]]; then
 		log_error "Self-test: unknown domain expected tier 4, got tier ${result}"
-		((failures++)) || true
+		((++failures))
 	fi
 
 	# Tier 5: ngrok.io (deny list)
 	result=$(classify_domain "evil.ngrok.io")
 	if [[ "$result" != "5" ]]; then
 		log_error "Self-test: evil.ngrok.io expected tier 5, got tier ${result}"
-		((failures++)) || true
+		((++failures))
 	fi
 
 	# Tier 5: raw IP
 	result=$(classify_domain "192.168.1.1")
 	if [[ "$result" != "5" ]]; then
 		log_error "Self-test: raw IP expected tier 5, got tier ${result}"
-		((failures++)) || true
+		((++failures))
 	fi
 
 	# Tier 5: .onion TLD
 	result=$(classify_domain "hidden.onion")
 	if [[ "$result" != "5" ]]; then
 		log_error "Self-test: .onion expected tier 5, got tier ${result}"
-		((failures++)) || true
+		((++failures))
 	fi
 
 	# URL normalization: strip protocol and port
 	result=$(classify_domain "https://github.com:443/foo/bar")
 	if [[ "$result" != "1" ]]; then
 		log_error "Self-test: URL normalization expected tier 1, got tier ${result}"
-		((failures++)) || true
+		((++failures))
 	fi
 
 	if [[ $failures -gt 0 ]]; then

--- a/.agents/scripts/postflight-check.sh
+++ b/.agents/scripts/postflight-check.sh
@@ -43,7 +43,7 @@ print_header() {
 print_skip() {
     local message="$1"
     echo -e "${BLUE}SKIPPED${NC} $message"
-    ((SKIPPED++))
+    ((++SKIPPED))
     return 0
 }
 
@@ -148,7 +148,7 @@ check_cicd_status() {
         local attempt=0
         while [[ $attempt -lt $MAX_ATTEMPTS ]]; do
             sleep "$POLL_INTERVAL"
-            ((attempt++))
+            ((++attempt))
             
             local current_status
             current_status=$(gh run view "$run_id" --repo "$repo" --json status,conclusion 2>/dev/null || echo "")

--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -62,7 +62,7 @@ validate_return_statements() {
 
 			if [[ $functions -gt 0 && $returns -lt $functions ]]; then
 				print_error "Missing return statements in $file"
-				((violations++))
+				((++violations))
 			fi
 		fi
 	done
@@ -107,7 +107,7 @@ validate_string_literals() {
 			if [[ $repeated -gt 0 ]]; then
 				print_warning "Repeated string literals in $file (consider using constants)"
 				grep -o '"[^"]*"' "$file" | sort | uniq -c | awk '$1 >= 3 {print "  " $1 "x: " $2}' | head -3
-				((violations++))
+				((++violations))
 			fi
 		fi
 	done
@@ -123,7 +123,7 @@ run_shellcheck() {
 	for file in "$@"; do
 		if [[ -f "$file" ]] && ! shellcheck "$file"; then
 			print_error "ShellCheck violations in $file"
-			((violations++))
+			((++violations))
 		fi
 	done
 
@@ -154,21 +154,21 @@ check_secrets() {
 			print_info "  1. Remove the secrets from your code"
 			print_info "  2. Add to .secretlintignore if false positive"
 			print_info "  3. Use // secretlint-disable-line comment"
-			((violations++))
+			((++violations))
 		fi
 	elif [[ -f "node_modules/.bin/secretlint" ]]; then
 		if echo "$staged_files" | xargs ./node_modules/.bin/secretlint --format compact 2>/dev/null; then
 			print_success "No secrets detected in staged files"
 		else
 			print_error "Potential secrets detected in staged files!"
-			((violations++))
+			((++violations))
 		fi
 	elif command -v npx &>/dev/null && [[ -f ".secretlintrc.json" ]]; then
 		if echo "$staged_files" | xargs npx secretlint --format compact 2>/dev/null; then
 			print_success "No secrets detected in staged files"
 		else
 			print_error "Potential secrets detected in staged files!"
-			((violations++))
+			((++violations))
 		fi
 	else
 		print_warning "Secretlint not available (install: npm install secretlint --save-dev)"
@@ -255,7 +255,7 @@ validate_todo_completions() {
 
 		if [[ "$has_evidence" == "false" ]]; then
 			failed_tasks+=("$task_id")
-			((fail_count++))
+			((++fail_count))
 		fi
 	done <<<"$newly_completed"
 
@@ -341,7 +341,7 @@ validate_parent_subtask_blocking() {
 			local open_count
 			open_count=$(echo "$explicit_subtasks" | wc -l | tr -d ' ')
 			failed_tasks+=("$task_id (has $open_count open subtask(s) by ID)")
-			((fail_count++))
+			((++fail_count))
 			continue
 		fi
 
@@ -375,7 +375,7 @@ validate_parent_subtask_blocking() {
 			local open_count
 			open_count=$(echo "$open_subtasks" | wc -l | tr -d ' ')
 			failed_tasks+=("$task_id (has $open_count open subtask(s) by indentation)")
-			((fail_count++))
+			((++fail_count))
 		fi
 	done <<<"$newly_completed"
 
@@ -474,7 +474,7 @@ validate_repo_root_files() {
 
 		if [[ "$allowed" == "false" ]]; then
 			rejected_files+=("$file")
-			((violations++))
+			((++violations))
 		fi
 	done <<<"$new_root_files"
 

--- a/.agents/scripts/quality-cli-manager.sh
+++ b/.agents/scripts/quality-cli-manager.sh
@@ -104,54 +104,54 @@ install_clis() {
 	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
 		print_info "Installing CodeRabbit CLI..."
 		if execute_cli_command "$CLI_CODERABBIT" "install"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
 		print_info "Installing Codacy CLI..."
 		if execute_cli_command "codacy" "install"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
 		print_info "Installing SonarScanner CLI..."
 		if execute_cli_command "sonar" "install"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
 		print_info "Installing Qlty CLI..."
 		if execute_cli_command "qlty" "install"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
 		print_info "Installing Snyk CLI..."
 		if execute_cli_command "$CLI_SNYK" "install"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "linters" ]]; then
 		print_info "Installing CodeFactor-inspired linters..."
 		if bash "$(dirname "$0")/linter-manager.sh" install-detected; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
@@ -178,45 +178,45 @@ init_clis() {
 	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
 		print_info "Initializing CodeRabbit CLI..."
 		if execute_cli_command "$CLI_CODERABBIT" "setup"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
 		print_info "Initializing Codacy CLI..."
 		if execute_cli_command "codacy" "init"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
 		print_info "Initializing SonarScanner CLI..."
 		if execute_cli_command "sonar" "init"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "qlty" ]]; then
 		print_info "Initializing Qlty CLI..."
 		if execute_cli_command "qlty" "init"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
 		print_info "Initializing Snyk CLI..."
 		if execute_cli_command "$CLI_SNYK" "auth"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
@@ -245,18 +245,18 @@ analyze_with_clis() {
 	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_CODERABBIT" ]]; then
 		print_info "Running CodeRabbit analysis..."
 		if execute_cli_command "$CLI_CODERABBIT" "review" "$args"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "codacy" ]]; then
 		print_info "Running Codacy analysis..."
 		if execute_cli_command "codacy" "analyze" "$args"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
@@ -264,18 +264,18 @@ analyze_with_clis() {
 	if [[ "$target_cli" == "codacy-fix" ]]; then
 		print_info "Running Codacy analysis with auto-fix..."
 		if execute_cli_command "codacy" "analyze" "--fix"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "sonar" ]]; then
 		print_info "Running SonarQube analysis..."
 		if execute_cli_command "sonar" "analyze" "$args"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
@@ -284,18 +284,18 @@ analyze_with_clis() {
 		# Qlty organization context is configured via env vars in qlty-cli.sh's load_api_config(),
 		# not as a CLI positional argument (qlty check only accepts [OPTIONS] [PATHS])
 		if execute_cli_command "qlty" "check" "$args"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "all" || "$target_cli" == "$CLI_SNYK" ]]; then
 		print_info "Running Snyk security analysis..."
 		if execute_cli_command "$CLI_SNYK" "full" "$args"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
@@ -303,27 +303,27 @@ analyze_with_clis() {
 	if [[ "$target_cli" == "snyk-sca" ]]; then
 		print_info "Running Snyk SCA (dependency) scan..."
 		if execute_cli_command "$CLI_SNYK" "test" "$args"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "snyk-code" ]]; then
 		print_info "Running Snyk Code (SAST) scan..."
 		if execute_cli_command "$CLI_SNYK" "code" "$args"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 
 	if [[ "$target_cli" == "snyk-iac" ]]; then
 		print_info "Running Snyk IaC scan..."
 		if execute_cli_command "$CLI_SNYK" "iac" "$args"; then
-			((success_count++)) || true
+			((++success_count))
 		fi
-		((total_count++)) || true
+		((++total_count))
 		echo ""
 	fi
 

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -109,7 +109,7 @@ cmd_failed() {
 	local failed_count=0
 
 	while IFS=$'\t' read -r name summary url; do
-		((failed_count++)) || true
+		((++failed_count))
 		echo -e "${RED}✗ ${name}${NC}"
 		[[ -n "$summary" && "$summary" != "null" ]] && echo "  Summary: ${summary}"
 		[[ -n "$url" && "$url" != "null" ]] && echo "  Details: ${url}"

--- a/.agents/scripts/quality-fix.sh
+++ b/.agents/scripts/quality-fix.sh
@@ -110,7 +110,7 @@ fix_return_statements() {
 							sed_inplace '$ d' "$temp_file"
 							echo "    return 0" >>"$temp_file"
 							echo "}" >>"$temp_file"
-							((fixed_functions++))
+							((++fixed_functions))
 							print_info "Fixed function: $function_name"
 						fi
 
@@ -122,7 +122,7 @@ fix_return_statements() {
 
 			if [[ $fixed_functions -gt 0 ]]; then
 				mv "$temp_file" "$file"
-				((files_fixed++))
+				((++files_fixed))
 				print_success "Fixed $fixed_functions functions in $file"
 			else
 				rm -f "$temp_file"
@@ -161,7 +161,7 @@ fix_positional_parameters() {
 
 				if ! diff -q "$file" "$temp_file" >/dev/null; then
 					mv "$temp_file" "$file"
-					((files_fixed++))
+					((++files_fixed))
 					print_success "Fixed positional parameters in main() function of $file"
 				else
 					rm -f "$temp_file"
@@ -219,7 +219,7 @@ validate_fixes() {
 
 	while IFS= read -r -d '' file; do
 		if [[ -f "$file" ]] && ! shellcheck "$file" >/dev/null 2>&1; then
-			((validation_errors++))
+			((++validation_errors))
 			print_warning "ShellCheck issues remain in $file"
 		fi
 	done < <(find .agents/scripts -name "*.sh" -not -path "*/_archive/*" -print0 2>/dev/null)

--- a/.agents/scripts/rosetta-audit-helper.sh
+++ b/.agents/scripts/rosetta-audit-helper.sh
@@ -282,20 +282,20 @@ cmd_migrate() {
 
 			if ! has_arm_formula "$pkg"; then
 				print_warning "Skipped: $pkg (no ARM formula available)"
-				((skipped++))
+				((++skipped))
 				continue
 			fi
 
 			if [[ "$dry_run" = true ]]; then
 				echo "  [DRY RUN] Would install ARM: $pkg"
-				((migrated++))
+				((++migrated))
 			else
 				if "$ARM_BREW" install "$pkg" 2>&1 | tail -1; then
 					print_success "Installed ARM: $pkg"
-					((migrated++))
+					((++migrated))
 				else
 					print_error "Failed to install ARM: $pkg"
-					((failed++))
+					((++failed))
 				fi
 			fi
 		done <<<"$x86_only"

--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -472,7 +472,7 @@ _import_credential_file() {
 
 			# Skip empty/placeholder values
 			if [[ -z "$val" || "$val" == "YOUR_"* || "$val" == "CHANGE_ME"* ]]; then
-				((skipped++))
+				((++skipped))
 				continue
 			fi
 
@@ -485,13 +485,13 @@ _import_credential_file() {
 			# Check if already in gopass
 			if gopass show -o "$gopass_path" &>/dev/null; then
 				print_info "Skipping $name (already in gopass${tenant:+ [$tenant]})"
-				((skipped++))
+				((++skipped))
 				continue
 			fi
 
 			# Import to gopass
 			echo "$val" | gopass insert --force "$gopass_path"
-			((imported++))
+			((++imported))
 			print_success "Imported $name${tenant:+ (tenant: $tenant)}"
 		fi
 	done <"$file"

--- a/.agents/scripts/security-posture-helper.sh
+++ b/.agents/scripts/security-posture-helper.sh
@@ -75,19 +75,19 @@ FINDINGS_JSON="[]"
 print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 print_pass() {
 	echo -e "${GREEN}[PASS]${NC} $1"
-	((FINDINGS_PASS++)) || true
+	((++FINDINGS_PASS))
 }
 print_warn() {
 	echo -e "${YELLOW}[WARN]${NC} $1"
-	((FINDINGS_WARNING++)) || true
+	((++FINDINGS_WARNING))
 }
 print_crit() {
 	echo -e "${RED}[CRIT]${NC} $1"
-	((FINDINGS_CRITICAL++)) || true
+	((++FINDINGS_CRITICAL))
 }
 print_skip() {
 	echo -e "${CYAN}[SKIP]${NC} $1"
-	((FINDINGS_INFO++)) || true
+	((++FINDINGS_INFO))
 }
 print_header() { echo -e "\n${BOLD}${CYAN}$1${NC}"; }
 

--- a/.agents/scripts/setup-linters-wizard.sh
+++ b/.agents/scripts/setup-linters-wizard.sh
@@ -248,7 +248,7 @@ install_selected_linters() {
             print_success "$lang linters installed successfully"
         else
             print_warning "Some $lang linters failed to install"
-            ((total_failures++)) || true
+            ((++total_failures))
         fi
         echo ""
     done

--- a/.agents/scripts/setup-local-api-keys.sh
+++ b/.agents/scripts/setup-local-api-keys.sh
@@ -66,7 +66,7 @@ setup_shell_integration() {
 			echo "# AI DevOps API Keys (single source of truth)" >>"$config"
 			echo "$source_line" >>"$config"
 			print_success "Added credentials.sh sourcing to $config"
-			((updated++)) || true
+			((++updated))
 		fi
 	done
 

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -980,7 +980,7 @@ prune_worktree_registry() {
 
 			if [[ "$should_prune" == "true" ]]; then
 				unregister_worktree "$wt_path"
-				((pruned_count++))
+				((++pruned_count))
 				[[ -n "${VERBOSE:-}" ]] && echo "  Pruned: $wt_path ($prune_reason)"
 			fi
 		done <<<"$entries"

--- a/.agents/scripts/show-plan-helper.sh
+++ b/.agents/scripts/show-plan-helper.sh
@@ -480,7 +480,7 @@ list_plans() {
 
 		# Detect plan header
 		if [[ "$line" =~ ^###[[:space:]]+\[([0-9-]+)\][[:space:]]+(.+)$ ]]; then
-			((num++))
+			((++num))
 			local title="${BASH_REMATCH[2]}"
 			title="${title% ✓}"
 			local status=""

--- a/.agents/scripts/site-crawler-helper.sh
+++ b/.agents/scripts/site-crawler-helper.sh
@@ -700,11 +700,11 @@ crawl4ai_generate_reports() {
     local code_200=0 code_301=0 code_302=0 code_404=0 code_500=0 code_other=0
     for code in "${status_codes[@]}"; do
         case "$code" in
-            200) ((code_200++)) ;;
-            301) ((code_301++)) ;;
-            302) ((code_302++)) ;;
-            404) ((code_404++)) ;;
-            500) ((code_500++)) ;;
+            200) ((++code_200)) ;;
+            301) ((++code_301)) ;;
+            302) ((++code_302)) ;;
+            404) ((++code_404)) ;;
+            500) ((++code_500)) ;;
             *) ((++code_other)) ;;
         esac
     done

--- a/.agents/scripts/site-crawler-helper.sh
+++ b/.agents/scripts/site-crawler-helper.sh
@@ -470,7 +470,7 @@ crawl_with_crawl4ai() {
             fi
             batch_urls+=("$queue_url")
             echo "$queue_url" >> "$visited_file"
-            ((batch_count++))
+            ((++batch_count))
         done < "$queue_file"
         
         # Remove processed URLs from queue
@@ -534,7 +534,7 @@ crawl_with_crawl4ai() {
                 
                 # Append to results file
                 echo "$result" >> "$results_file"
-                ((crawled_count++))
+                ((++crawled_count))
                 
                 local page_url status_code
                 page_url=$(printf '%s' "$result" | jq -r '.url // empty')
@@ -572,7 +572,7 @@ crawl_with_crawl4ai() {
             done
         fi
         
-        ((current_depth++))
+        ((++current_depth))
     done
     
     print_info "Crawl complete. Processing results..."
@@ -705,7 +705,7 @@ crawl4ai_generate_reports() {
             302) ((code_302++)) ;;
             404) ((code_404++)) ;;
             500) ((code_500++)) ;;
-            *) ((code_other++)) ;;
+            *) ((++code_other)) ;;
         esac
     done
     

--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -480,7 +480,7 @@ cmd_check() {
 			if [[ -n "$stored_etag" || -n "$stored_last_modified" ]]; then
 				if ! latest_hash=$(fetch_url_conditional "$upstream_url" "$stored_etag" "$stored_last_modified"); then
 					log_warning "Could not fetch URL for $name: $upstream_url"
-					((check_failed++)) || true
+					((++check_failed))
 					continue
 				fi
 
@@ -491,7 +491,7 @@ cmd_check() {
 						echo -e "${GREEN}Up to date${NC}: $name (304 Not Modified)"
 					fi
 					log_info "Up to date: $name (304 Not Modified, skipped download)"
-					((up_to_date++)) || true
+					((++up_to_date))
 					results+=("{\"name\":\"$name\",\"status\":\"up_to_date\",\"commit\":\"${stored_hash}\"}")
 					continue
 				fi
@@ -503,7 +503,7 @@ cmd_check() {
 				# but capture headers for future conditional requests
 				if ! latest_hash=$(fetch_url_conditional "$upstream_url" "" ""); then
 					log_warning "Could not fetch URL for $name: $upstream_url"
-					((check_failed++)) || true
+					((++check_failed))
 					continue
 				fi
 
@@ -523,7 +523,7 @@ cmd_check() {
 					echo ""
 				fi
 				log_info "UNKNOWN: $name (no hash recorded) latest_hash=${latest_hash:0:12}"
-				((updates_available++)) || true
+				((++updates_available))
 				results+=("{\"name\":\"$name\",\"status\":\"unknown\",\"latest\":\"${latest_hash}\"}")
 			elif [[ "$latest_hash" != "$stored_hash" ]]; then
 				if [[ "$NON_INTERACTIVE" != true ]]; then
@@ -534,7 +534,7 @@ cmd_check() {
 					echo ""
 				fi
 				log_info "UPDATE AVAILABLE: $name prev_hash=${stored_hash:0:12} new_hash=${latest_hash:0:12}"
-				((updates_available++)) || true
+				((++updates_available))
 				results+=("{\"name\":\"$name\",\"status\":\"update_available\",\"current\":\"${stored_hash}\",\"latest\":\"${latest_hash}\"}")
 
 				# Auto-update if enabled
@@ -559,7 +559,7 @@ cmd_check() {
 					echo -e "${GREEN}Up to date${NC}: $name"
 				fi
 				log_info "Up to date: $name hash=${stored_hash:0:12}"
-				((up_to_date++)) || true
+				((++up_to_date))
 				results+=("{\"name\":\"$name\",\"status\":\"up_to_date\",\"commit\":\"${stored_hash}\"}")
 			fi
 			continue
@@ -576,7 +576,7 @@ cmd_check() {
 
 		if [[ -z "$owner_repo" || "$owner_repo" == "/" ]]; then
 			log_warning "Could not parse URL for $name: $upstream_url"
-			((check_failed++)) || true
+			((++check_failed))
 			continue
 		fi
 
@@ -584,7 +584,7 @@ cmd_check() {
 		local latest_commit
 		if ! latest_commit=$(get_latest_commit "$owner_repo"); then
 			log_warning "Could not fetch latest commit for $name ($owner_repo)"
-			((check_failed++)) || true
+			((++check_failed))
 			continue
 		fi
 
@@ -601,7 +601,7 @@ cmd_check() {
 				echo ""
 			fi
 			log_info "UNKNOWN: $name (no commit recorded) latest=${latest_commit:0:7}"
-			((updates_available++)) || true
+			((++updates_available))
 			results+=("{\"name\":\"$name\",\"status\":\"unknown\",\"latest\":\"$latest_commit\"}")
 		elif [[ "$latest_commit" != "$current_commit" ]]; then
 			if [[ "$NON_INTERACTIVE" != true ]]; then
@@ -612,7 +612,7 @@ cmd_check() {
 				echo ""
 			fi
 			log_info "UPDATE AVAILABLE: $name current=${current_commit:0:7} latest=${latest_commit:0:7}"
-			((updates_available++)) || true
+			((++updates_available))
 			results+=("{\"name\":\"$name\",\"status\":\"update_available\",\"current\":\"$current_commit\",\"latest\":\"$latest_commit\"}")
 
 			# Auto-update if enabled
@@ -636,7 +636,7 @@ cmd_check() {
 				echo -e "${GREEN}Up to date${NC}: $name"
 			fi
 			log_info "Up to date: $name commit=${current_commit:0:7}"
-			((up_to_date++)) || true
+			((++up_to_date))
 			results+=("{\"name\":\"$name\",\"status\":\"up_to_date\",\"commit\":\"$current_commit\"}")
 		fi
 
@@ -1796,7 +1796,7 @@ cmd_pr() {
 			local latest_hash
 			if ! latest_hash=$(fetch_url_conditional "$upstream_url" "$stored_etag" "$stored_last_modified"); then
 				log_warning "Could not fetch URL for $name: $upstream_url — skipping"
-				((prs_skipped++)) || true
+				((++prs_skipped))
 				continue
 			fi
 
@@ -1821,9 +1821,9 @@ cmd_pr() {
 
 			# URL skill has an update (or no stored hash) — create PR
 			if cmd_pr_single "$name" "$upstream_url" "$stored_hash" "$latest_hash" "url"; then
-				((prs_created++)) || true
+				((++prs_created))
 			else
-				((prs_failed++)) || true
+				((++prs_failed))
 			fi
 			continue
 		fi
@@ -1833,7 +1833,7 @@ cmd_pr() {
 			if [[ "$QUIET" != true ]]; then
 				log_info "Skipping $name (non-GitHub source: ${upstream_url})"
 			fi
-			((prs_skipped++)) || true
+			((++prs_skipped))
 			continue
 		fi
 
@@ -1844,7 +1844,7 @@ cmd_pr() {
 
 		if [[ -z "$owner_repo" || "$owner_repo" == "/" ]]; then
 			log_warning "Could not parse URL for $name: $upstream_url — skipping"
-			((prs_skipped++)) || true
+			((++prs_skipped))
 			continue
 		fi
 
@@ -1852,7 +1852,7 @@ cmd_pr() {
 		local latest_commit
 		if ! latest_commit=$(get_latest_commit "$owner_repo"); then
 			log_warning "Could not fetch latest commit for $name ($owner_repo) — skipping"
-			((prs_skipped++)) || true
+			((++prs_skipped))
 			continue
 		fi
 
@@ -1869,9 +1869,9 @@ cmd_pr() {
 
 		# Skill has an update — create PR
 		if cmd_pr_single "$name" "$upstream_url" "$current_commit" "$latest_commit" "github"; then
-			((prs_created++)) || true
+			((++prs_created))
 		else
-			((prs_failed++)) || true
+			((++prs_failed))
 		fi
 
 	done < <(jq -c '.skills[]' "$SKILL_SOURCES")

--- a/.agents/scripts/skills-helper.sh
+++ b/.agents/scripts/skills-helper.sh
@@ -321,7 +321,7 @@ cmd_search() {
 		done
 
 		if [[ "$matched" == true ]]; then
-			((found++)) || true
+			((++found))
 
 			local is_imported="false"
 			if [[ "$filename" == *-skill ]]; then
@@ -458,7 +458,7 @@ cmd_browse() {
 			if [[ -n "$desc" ]]; then
 				echo "    $desc"
 			fi
-			((found++)) || true
+			((++found))
 		fi
 	done < <(find "$AGENTS_DIR" -name "*.md" -type f | sort)
 
@@ -784,7 +784,7 @@ cmd_list() {
 			fi
 			printf "  %-35s %-25s %s\n" "$filename" "[$category]" "($type_label)"
 		fi
-		((count++)) || true
+		((++count))
 	done < <(find "$AGENTS_DIR" -name "*.md" -type f | sort)
 
 	if [[ "$json_output" == true ]]; then
@@ -996,8 +996,8 @@ receipt=tools/accounts"
 				local desc
 				desc=$(extract_description "$md_file")
 				echo -e "    ${GREEN}-${NC} $filename: ${desc:-<no description>}"
-				((found_in_cat++)) || true
-				((total_found++)) || true
+				((++found_in_cat))
+				((++total_found))
 			fi
 		done < <(find "$AGENTS_DIR" -name "*.md" -type f | sort)
 

--- a/.agents/scripts/sonarcloud-collector-helper.sh
+++ b/.agents/scripts/sonarcloud-collector-helper.sh
@@ -233,7 +233,7 @@ collect_issues() {
 			# Store in database (run_id, severity, category, rule_id, description, path, line)
 			store_finding "$run_id" "$mapped_severity" "issue" "$rule" "$message" "$path" "$line"
 
-			((total_collected++))
+			((++total_collected))
 		done <<<"$issues"
 
 		# Check if there are more pages
@@ -243,7 +243,7 @@ collect_issues() {
 			break
 		fi
 
-		((page++))
+		((++page))
 	done
 
 	log_success "Collected $total_collected issues"
@@ -327,7 +327,7 @@ collect_hotspots() {
 			# Store in database (run_id, severity, category, rule_id, description, path, line)
 			store_finding "$run_id" "$mapped_severity" "security_hotspot" "$rule" "$message" "$path" "$line"
 
-			((total_collected++))
+			((++total_collected))
 		done <<<"$hotspots"
 
 		# Check if there are more pages
@@ -339,7 +339,7 @@ collect_hotspots() {
 			break
 		fi
 
-		((page++))
+		((++page))
 	done
 
 	log_success "Collected $total_collected security hotspots"

--- a/.agents/scripts/supervisor-archived/backfill-blocked-comments.sh
+++ b/.agents/scripts/supervisor-archived/backfill-blocked-comments.sh
@@ -86,7 +86,7 @@ main() {
 			echo "  [DRY RUN] Would post blocked comment"
 		else
 			post_blocked_comment_to_github "$task_id" "$blocked_error" "$repo_path"
-			((++count))
+			((count++))
 		fi
 	done <<< "$issues"
 	

--- a/.agents/scripts/supervisor-archived/backfill-blocked-comments.sh
+++ b/.agents/scripts/supervisor-archived/backfill-blocked-comments.sh
@@ -86,7 +86,7 @@ main() {
 			echo "  [DRY RUN] Would post blocked comment"
 		else
 			post_blocked_comment_to_github "$task_id" "$blocked_error" "$repo_path"
-			((count++))
+			((++count))
 		fi
 	done <<< "$issues"
 	

--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -1493,7 +1493,7 @@ dismiss_bot_reviews() {
 			if gh api -X PUT "repos/${repo_slug}/pulls/${pr_number}/reviews/${review_id}/dismissals" \
 				-f message="Auto-dismissed: bot review does not block autonomous pipeline" \
 				-f event="DISMISS" 2>>"$SUPERVISOR_LOG"; then
-				((++dismissed_count))
+				((dismissed_count++))
 				log_success "Dismissed bot review #${review_id}"
 			else
 				log_warn "Failed to dismiss bot review #${review_id}"

--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -1493,7 +1493,7 @@ dismiss_bot_reviews() {
 			if gh api -X PUT "repos/${repo_slug}/pulls/${pr_number}/reviews/${review_id}/dismissals" \
 				-f message="Auto-dismissed: bot review does not block autonomous pipeline" \
 				-f event="DISMISS" 2>>"$SUPERVISOR_LOG"; then
-				((dismissed_count++))
+				((++dismissed_count))
 				log_success "Dismissed bot review #${review_id}"
 			else
 				log_warn "Failed to dismiss bot review #${review_id}"

--- a/.agents/scripts/thumbnail-helper.sh
+++ b/.agents/scripts/thumbnail-helper.sh
@@ -564,7 +564,7 @@ cmd_batch_score() {
 
 	# Find all image files
 	while IFS= read -r -d '' image_file; do
-		((image_count++))
+		((++image_count))
 
 		echo ""
 		print_info "=== Image $image_count: $(basename "$image_file") ==="
@@ -581,7 +581,7 @@ cmd_batch_score() {
 
 			if (($(echo "$existing_score >= $MIN_SCORE_THRESHOLD" | bc -l))); then
 				print_success "✓ PASS"
-				((pass_count++))
+				((++pass_count))
 			else
 				print_warning "✗ FAIL"
 			fi
@@ -593,7 +593,7 @@ cmd_batch_score() {
 			local new_score
 			new_score=$(grep "Weighted Score:" "$score_file" | awk '{print $3}')
 			if (($(echo "$new_score >= $MIN_SCORE_THRESHOLD" | bc -l))); then
-				((pass_count++))
+				((++pass_count))
 			fi
 		fi
 	done < <(find "$dir" -type f \( -name "*.png" -o -name "*.jpg" -o -name "*.jpeg" \) -print0)

--- a/.agents/scripts/todo-ready.sh
+++ b/.agents/scripts/todo-ready.sh
@@ -83,14 +83,14 @@ output_text() {
     while IFS='|' read -r status id desc est blocker; do
         case "$status" in
             READY)
-                ((ready_count++))
+                ((++ready_count))
                 echo "  $ready_count. $id: $desc ${est:+($est)}"
                 ;;
             BLOCKED)
-                ((blocked_count++))
+                ((++blocked_count))
                 ;;
             IN_PROGRESS)
-                ((in_progress_count++))
+                ((++in_progress_count))
                 ;;
             *)
                 # Ignore unknown status
@@ -173,17 +173,17 @@ output_json() {
             READY)
                 [[ $ready_count -gt 0 ]] && ready_json+=","
                 ready_json+="{\"id\":\"$id\",\"desc\":\"$desc\",\"est\":\"$est\"}"
-                ((ready_count++))
+                ((++ready_count))
                 ;;
             BLOCKED)
                 [[ $blocked_count -gt 0 ]] && blocked_json+=","
                 blocked_json+="{\"id\":\"$id\",\"desc\":\"$desc\",\"est\":\"$est\",\"blocked_by\":\"$blocker\"}"
-                ((blocked_count++))
+                ((++blocked_count))
                 ;;
             IN_PROGRESS)
                 [[ $in_progress_count -gt 0 ]] && in_progress_json+=","
                 in_progress_json+="{\"id\":\"$id\",\"desc\":\"$desc\",\"est\":\"$est\"}"
-                ((in_progress_count++))
+                ((++in_progress_count))
                 ;;
             *)
                 # Ignore unknown status

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -102,6 +102,8 @@ PIP_TOOLS=(
 OUTDATED_COUNT=0
 INSTALLED_COUNT=0
 NOT_INSTALLED_COUNT=0
+TIMEOUT_COUNT=0
+UNKNOWN_COUNT=0
 declare -a OUTDATED_PACKAGES=()
 declare -a JSON_RESULTS=()
 
@@ -274,12 +276,12 @@ check_tool() {
 		status="timeout"
 		icon="⏱"
 		color="$RED"
-		((++INSTALLED_COUNT))
+		((++TIMEOUT_COUNT))
 	elif [[ "$installed" == "unknown" || "$latest" == "unknown" ]]; then
 		status="unknown"
 		icon="?"
 		color="$YELLOW"
-		((++INSTALLED_COUNT))
+		((++UNKNOWN_COUNT))
 	elif [[ "$installed" != "$latest" ]] && version_lt "$installed" "$latest"; then
 		status="outdated"
 		icon="⬆"
@@ -386,7 +388,9 @@ main() {
 		echo "  \"summary\": {"
 		echo "    \"installed\": $INSTALLED_COUNT,"
 		echo "    \"outdated\": $OUTDATED_COUNT,"
-		echo "    \"not_installed\": $NOT_INSTALLED_COUNT"
+		echo "    \"not_installed\": $NOT_INSTALLED_COUNT,"
+		echo "    \"timeout\": $TIMEOUT_COUNT,"
+		echo "    \"unknown\": $UNKNOWN_COUNT"
 		echo "  },"
 		echo "  \"tools\": ["
 		local first=true
@@ -415,6 +419,12 @@ main() {
 		echo "  Installed & up to date: $INSTALLED_COUNT"
 		echo "  Outdated: $OUTDATED_COUNT"
 		echo "  Not installed: $NOT_INSTALLED_COUNT"
+		if [[ $TIMEOUT_COUNT -gt 0 ]]; then
+			echo "  Timeout (version check hung): $TIMEOUT_COUNT"
+		fi
+		if [[ $UNKNOWN_COUNT -gt 0 ]]; then
+			echo "  Unknown (could not verify): $UNKNOWN_COUNT"
+		fi
 		echo ""
 	fi
 

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -269,25 +269,25 @@ check_tool() {
 		status="not_installed"
 		icon="○"
 		color="$YELLOW"
-		((NOT_INSTALLED_COUNT++)) || true
+		((++NOT_INSTALLED_COUNT))
 	elif [[ "$installed" == "timeout" ]]; then
 		status="timeout"
 		icon="⏱"
 		color="$RED"
-		((INSTALLED_COUNT++)) || true
+		((++INSTALLED_COUNT))
 	elif [[ "$installed" == "unknown" || "$latest" == "unknown" ]]; then
 		status="unknown"
 		icon="?"
 		color="$YELLOW"
-		((INSTALLED_COUNT++)) || true
+		((++INSTALLED_COUNT))
 	elif [[ "$installed" != "$latest" ]] && version_lt "$installed" "$latest"; then
 		status="outdated"
 		icon="⬆"
 		color="$RED"
-		((OUTDATED_COUNT++)) || true
+		((++OUTDATED_COUNT))
 		OUTDATED_PACKAGES+=("$update_cmd")
 	else
-		((INSTALLED_COUNT++)) || true
+		((++INSTALLED_COUNT))
 	fi
 
 	# JSON output (escape special characters for valid JSON)

--- a/.agents/scripts/toon-helper.sh
+++ b/.agents/scripts/toon-helper.sh
@@ -208,9 +208,9 @@ batch_convert() {
                     basename=$(basename "$file" .json)
                     local target_file="$target_dir/$basename.toon"
                     
-                    ((count++)) || true
+                    ((++count))
                     if json_to_toon "$file" "$target_file" "$delimiter" "false"; then
-                        ((success_count++)) || true
+                        ((++success_count))
                     fi
                 fi
             done
@@ -222,9 +222,9 @@ batch_convert() {
                     basename=$(basename "$file" .toon)
                     local target_file="$target_dir/$basename.json"
                     
-                    ((count++)) || true
+                    ((++count))
                     if toon_to_json "$file" "$target_file" "true"; then
-                        ((success_count++)) || true
+                        ((++success_count))
                     fi
                 fi
             done

--- a/.agents/scripts/validate-mcp-integrations.sh
+++ b/.agents/scripts/validate-mcp-integrations.sh
@@ -24,16 +24,16 @@ run_test() {
 	local test_name="$1"
 	local test_command="$2"
 
-	((total_tests++))
+	((++total_tests))
 	print_info "Testing: $test_name"
 
 	if bash -c "$test_command" &>/dev/null; then
 		print_success "$test_name: PASSED"
-		((passed_tests++))
+		((++passed_tests))
 		return 0
 	else
 		print_error "$test_name: FAILED"
-		((failed_tests++))
+		((++failed_tests))
 		return 1
 	fi
 	return 0

--- a/.agents/scripts/verify-mirrors.sh
+++ b/.agents/scripts/verify-mirrors.sh
@@ -139,7 +139,7 @@ main() {
         local link_path="${entry%%:*}"
         local target="${entry##*:}"
         if ! verify_symlink "$link_path" "$target"; then
-            ((issues++)) || true
+            ((++issues))
         fi
     done
     

--- a/.agents/scripts/worker-token-helper.sh
+++ b/.agents/scripts/worker-token-helper.sh
@@ -618,7 +618,7 @@ cmd_cleanup() {
 			if [[ "$expires_epoch" -gt 0 ]] && [[ "$now_epoch" -gt "$expires_epoch" ]]; then
 				local token_file="${meta_file%.meta}.token"
 				cmd_revoke --token-file "$token_file" 2>/dev/null || true
-				((cleaned++))
+				((++cleaned))
 			fi
 		fi
 	done
@@ -684,9 +684,9 @@ cmd_status() {
 				date -d "$expires_at" +%s 2>/dev/null || echo "0")
 
 			if [[ "$expires_epoch" -gt 0 ]] && [[ "$now_epoch" -gt "$expires_epoch" ]]; then
-				((expired_count++))
+				((++expired_count))
 			else
-				((active_count++))
+				((++active_count))
 				echo "  Active: ${repo} (${strategy}, expires: ${expires_at})"
 			fi
 		done

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -913,7 +913,7 @@ cmd_update() {
 
 			if [[ "$installed" != "$latest" ]]; then
 				stale_tools="${stale_tools:+$stale_tools, }$cmd_name ($installed -> $latest)"
-				((stale_count++)) || true
+				((++stale_count))
 			fi
 		done
 
@@ -1076,7 +1076,7 @@ scaffold_repo_courtesy_files() {
 			readme_content="$readme_content"$'\n\n'"## Licence"$'\n\n'"See [LICENCE](LICENCE) for details."
 		fi
 		printf '%s\n' "$readme_content" >"$project_root/README.md"
-		((created++))
+		((++created))
 	fi
 
 	# LICENCE (MIT default)
@@ -1105,7 +1105,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 LICEOF
-		((created++))
+		((++created))
 	fi
 
 	# CHANGELOG.md
@@ -1120,7 +1120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 CHEOF
-		((created++))
+		((++created))
 	fi
 
 	# CONTRIBUTING.md
@@ -1141,7 +1141,7 @@ CHEOF
 		contrib_content="$contrib_content"$'\n'"- \`refactor:\` - Code change that neither fixes a bug nor adds a feature"
 		contrib_content="$contrib_content"$'\n'"- \`chore:\` - Maintenance tasks"
 		printf '%s\n' "$contrib_content" >"$project_root/CONTRIBUTING.md"
-		((created++))
+		((++created))
 	fi
 
 	# SECURITY.md
@@ -1167,7 +1167,7 @@ SECEOF
 Please do not open public issues for security vulnerabilities.
 SECEOF
 		fi
-		((created++))
+		((++created))
 	fi
 
 	# CODE_OF_CONDUCT.md
@@ -1194,7 +1194,7 @@ Examples of behavior that contributes to a positive environment:
 This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
 version 2.1.
 COCEOF
-		((created++))
+		((++created))
 	fi
 
 	if [[ $created -gt 0 ]]; then
@@ -1942,7 +1942,7 @@ SOPSEOF
 		if [[ ! -f "$pf_path" ]]; then
 			mkdir -p "$(dirname "$pf_path")"
 			echo "$pointer_content" >"$pf_path"
-			((pointer_created++))
+			((++pointer_created))
 		fi
 	done
 	if [[ $pointer_created -gt 0 ]]; then
@@ -2052,27 +2052,27 @@ SOPSEOF
 	local step=1
 	if [[ "$committed" != "true" ]]; then
 		echo "  ${step}. Commit the initialized files: git add -A && git commit -m 'chore: initialize aidevops'"
-		((step++))
+		((++step))
 	fi
 	if [[ "$enable_beads" == "true" ]]; then
 		echo "  ${step}. Add tasks to TODO.md with dependencies (blocked-by:t001)"
-		((step++))
+		((++step))
 		echo "  ${step}. Run /ready to see unblocked tasks"
-		((step++))
+		((++step))
 		echo "  ${step}. Run /sync-beads to sync with Beads graph"
-		((step++))
+		((++step))
 		echo "  ${step}. Use 'bd' CLI for graph visualization"
 	elif [[ "$enable_database" == "true" ]]; then
 		echo "  ${step}. Add schema files to schemas/"
-		((step++))
+		((++step))
 		echo "  ${step}. Run diff to generate migrations"
-		((step++))
+		((++step))
 		echo "  ${step}. See .agents/workflows/sql-migrations.md"
 	else
 		echo "  ${step}. Add tasks to TODO.md"
-		((step++))
+		((++step))
 		echo "  ${step}. Use /create-prd for complex features"
-		((step++))
+		((++step))
 		echo "  ${step}. Use /feature to start development"
 	fi
 

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -297,7 +297,7 @@ inject_agents_reference() {
 					cat "$agents_file" >>"$temp_file"
 					mv "$temp_file" "$agents_file"
 					print_success "Added reference to $agents_file"
-					((updated_count++)) || true
+					((++updated_count))
 				else
 					print_info "Reference already exists in $agents_file"
 				fi
@@ -305,7 +305,7 @@ inject_agents_reference() {
 				# Create new file with just the reference
 				echo "$reference_line" >"$agents_file"
 				print_success "Created $agents_file with aidevops reference"
-				((updated_count++)) || true
+				((++updated_count))
 			fi
 		fi
 	done
@@ -520,7 +520,7 @@ setup_beads_ui() {
 			# brew install user/tap/formula auto-taps
 			if run_with_spinner "Installing bv via Homebrew" brew install dicklesworthstone/tap/bv; then
 				print_info "Run: bv (in a beads-enabled project)"
-				((installed_count++)) || true
+				((++installed_count))
 			else
 				print_warning "Homebrew install failed - try manually:"
 				print_info "  brew install dicklesworthstone/tap/bv"
@@ -532,7 +532,7 @@ setup_beads_ui() {
 				# Go available - use go install
 				if run_with_spinner "Installing bv via Go" go install github.com/Dicklesworthstone/beads_viewer/cmd/bv@latest; then
 					print_info "Run: bv (in a beads-enabled project)"
-					((installed_count++)) || true
+					((++installed_count))
 				else
 					print_warning "Go install failed"
 				fi
@@ -542,7 +542,7 @@ setup_beads_ui() {
 				if [[ "$use_script" =~ ^[Yy]?$ ]]; then
 					if verified_install "bv (beads viewer)" "https://raw.githubusercontent.com/Dicklesworthstone/beads_viewer/main/install.sh"; then
 						print_info "Run: bv (in a beads-enabled project)"
-						((installed_count++)) || true
+						((++installed_count))
 					else
 						print_warning "Install script failed - try manually:"
 						print_info "  Homebrew: brew tap dicklesworthstone/tap && brew install dicklesworthstone/tap/bv"
@@ -562,7 +562,7 @@ setup_beads_ui() {
 		if [[ "$install_web" =~ ^[Yy]?$ ]]; then
 			if run_with_spinner "Installing beads-ui" npm_global_install beads-ui; then
 				print_info "Run: beads-ui"
-				((installed_count++)) || true
+				((++installed_count))
 			fi
 		fi
 
@@ -570,7 +570,7 @@ setup_beads_ui() {
 		if [[ "$install_bdui" =~ ^[Yy]?$ ]]; then
 			if run_with_spinner "Installing bdui" npm_global_install bdui; then
 				print_info "Run: bdui"
-				((installed_count++)) || true
+				((++installed_count))
 			fi
 		fi
 	fi
@@ -581,7 +581,7 @@ setup_beads_ui() {
 		if [[ "$install_perles" =~ ^[Yy]?$ ]]; then
 			if run_with_spinner "Installing perles (Rust compile)" cargo install perles; then
 				print_info "Run: perles"
-				((installed_count++)) || true
+				((++installed_count))
 			fi
 		fi
 	fi

--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -51,7 +51,7 @@ bootstrap_repo() {
 					local wait_count=0
 					while ! command -v orb >/dev/null 2>&1 && [[ $wait_count -lt 30 ]]; do
 						sleep 2
-						((wait_count++)) || true
+						((++wait_count))
 					done
 					if ! command -v orb >/dev/null 2>&1; then
 						print_error "OrbStack CLI not found after installation"

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -44,9 +44,9 @@ install_mcp_packages() {
 	for pkg in "${node_mcps[@]}"; do
 		local short_name="${pkg##*/}" # Strip @scope/ prefix for display
 		if run_with_spinner "Installing $short_name" npm_global_install "${pkg}@latest"; then
-			((updated++)) || true
+			((++updated))
 		else
-			((failed++)) || true
+			((++failed))
 			print_warning "Failed to install/update $pkg"
 		fi
 	done
@@ -155,7 +155,7 @@ update_mcp_paths_in_opencode() {
 				new_path=$(resolve_mcp_binary_path "$bin_name")
 				if [[ -n "$new_path" && "$new_path" != "$current_cmd" ]]; then
 					jq --arg k "$mcp_key" --arg p "$new_path" '.mcp[$k].command[0] = $p' "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-					((updated++)) || true
+					((++updated))
 				fi
 			fi
 			continue
@@ -172,7 +172,7 @@ update_mcp_paths_in_opencode() {
 
 		if [[ -n "$full_path" && "$full_path" != "$current_cmd" ]]; then
 			jq --arg k "$mcp_key" --arg p "$full_path" '.mcp[$k].command[0] = $p' "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-			((updated++)) || true
+			((++updated))
 		fi
 	done <<<"$mcp_keys"
 
@@ -186,7 +186,7 @@ update_mcp_paths_in_opencode() {
 		while IFS= read -r mcp_key; do
 			[[ -z "$mcp_key" ]] && continue
 			jq --arg k "$mcp_key" --arg p "$node_path" '.mcp[$k].command[0] = $p' "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-			((updated++)) || true
+			((++updated))
 		done <<<"$node_mcp_keys"
 	fi
 

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -537,6 +537,7 @@ disable_ondemand_mcps() {
 	)
 
 	local disabled=0
+	local changed=0
 	local tmp_config
 	tmp_config=$(mktemp)
 	trap 'rm -f "${tmp_config:-}"' RETURN
@@ -565,7 +566,7 @@ disable_ondemand_mcps() {
 		if jq -e ".mcp[\"$mcp\"].type == \"stdio\" or .mcp[\"$mcp\"].command[0] == \"echo\"" "$tmp_config" >/dev/null 2>&1; then
 			jq "del(.mcp[\"$mcp\"])" "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
 			print_info "Removed invalid MCP entry: $mcp"
-			disabled=1 # Mark as changed
+			changed=1
 		fi
 	done
 
@@ -575,14 +576,16 @@ disable_ondemand_mcps() {
 		if jq -e ".mcp[\"$mcp\"].enabled == false" "$tmp_config" >/dev/null 2>&1; then
 			jq ".mcp[\"$mcp\"].enabled = true" "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
 			print_info "Re-enabled $mcp MCP"
-			disabled=1 # Mark as changed
+			changed=1
 		fi
 	done
 
-	if [[ $disabled -gt 0 ]]; then
+	if [[ $disabled -gt 0 || $changed -gt 0 ]]; then
 		create_backup_with_rotation "$opencode_config" "opencode"
 		mv "$tmp_config" "$opencode_config"
-		print_info "Disabled $disabled MCP(s) globally (use subagents to enable on-demand)"
+		if [[ $disabled -gt 0 ]]; then
+			print_info "Disabled $disabled MCP(s) globally (use subagents to enable on-demand)"
+		fi
 	else
 		rm -f "$tmp_config"
 	fi

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -42,7 +42,7 @@ cleanup_deprecated_paths() {
 	for path in "${deprecated_paths[@]}"; do
 		if [[ -e "$path" ]]; then
 			rm -rf "$path"
-			((cleaned++)) || true
+			((++cleaned))
 		fi
 	done
 
@@ -238,13 +238,13 @@ migrate_agent_to_agents_folder() {
 					mkdir -p "$repo_path/.agents"
 				fi
 				print_info "  Removed legacy .agent symlink in $(basename "$repo_path")"
-				((migrated++)) || true
+				((++migrated))
 			elif [[ -d "$repo_path/.agent" && ! -L "$repo_path/.agent" ]]; then
 				# Real directory (not symlink) - rename it
 				if [[ ! -e "$repo_path/.agents" ]]; then
 					mv "$repo_path/.agent" "$repo_path/.agents"
 					print_info "  Renamed directory: $repo_path/.agent -> .agents"
-					((migrated++)) || true
+					((++migrated))
 				fi
 			fi
 
@@ -253,7 +253,7 @@ migrate_agent_to_agents_folder() {
 				rm -f "$repo_path/.agents"
 				mkdir -p "$repo_path/.agents"
 				print_info "  Replaced .agents symlink with real directory in $(basename "$repo_path")"
-				((migrated++)) || true
+				((++migrated))
 			fi
 
 			# Update .gitignore: remove legacy bare ".agents" (now tracked),
@@ -324,13 +324,13 @@ migrate_agent_to_agents_folder() {
 					mkdir -p "$repo_dir/.agents"
 				fi
 				print_info "  Removed legacy .agent symlink: $agent_path"
-				((migrated++)) || true
+				((++migrated))
 			elif [[ -d "$agent_path" ]]; then
 				# Directory: rename to .agents if .agents doesn't exist
 				if [[ ! -e "$repo_dir/.agents" ]]; then
 					mv "$agent_path" "$repo_dir/.agents"
 					print_info "  Renamed directory: $agent_path -> .agents"
-					((migrated++)) || true
+					((++migrated))
 				fi
 			fi
 		done < <(find "$HOME/Git" -maxdepth 3 -name ".agent" \( -type l -o -type d \) -print0 2>/dev/null)
@@ -350,7 +350,7 @@ migrate_agent_to_agents_folder() {
 				sed -i '' 's|\.agent/|.agents/|g' "$config_file" 2>/dev/null ||
 					sed -i 's|\.agent/|.agents/|g' "$config_file" 2>/dev/null || true
 				print_info "  Updated references in $config_file"
-				((migrated++)) || true
+				((++migrated))
 			fi
 		fi
 	done
@@ -422,7 +422,7 @@ cleanup_deprecated_mcps() {
 	for mcp in "${deprecated_mcps[@]}"; do
 		if jq -e ".mcp[\"$mcp\"]" "$tmp_config" >/dev/null 2>&1; then
 			jq "del(.mcp[\"$mcp\"])" "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-			((cleaned++)) || true
+			((++cleaned))
 		fi
 	done
 
@@ -470,7 +470,7 @@ cleanup_deprecated_mcps() {
 			full_path=$(resolve_mcp_binary_path "$bin_name")
 			if [[ -n "$full_path" ]]; then
 				jq --arg k "$mcp_key" --arg p "$full_path" '.mcp[$k].command = [$p]' "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-				((cleaned++)) || true
+				((++cleaned))
 			fi
 		fi
 	done
@@ -487,7 +487,7 @@ cleanup_deprecated_mcps() {
 				outscraper_key=$(source "$HOME/.config/aidevops/credentials.sh" && echo "${OUTSCRAPER_API_KEY:-}")
 			fi
 			jq --arg p "$outscraper_path" --arg key "$outscraper_key" '.mcp.outscraper.command = [$p] | .mcp.outscraper.environment = {"OUTSCRAPER_API_KEY": $key}' "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-			((cleaned++)) || true
+			((++cleaned))
 		fi
 	fi
 
@@ -551,7 +551,7 @@ disable_ondemand_mcps() {
 			current_enabled=$(jq -r ".mcp[\"$mcp\"].enabled // \"true\"" "$tmp_config")
 			if [[ "$current_enabled" != "false" ]]; then
 				jq ".mcp[\"$mcp\"].enabled = false" "$tmp_config" >"${tmp_config}.new" && mv "${tmp_config}.new" "$tmp_config"
-				((disabled++)) || true
+				((++disabled))
 			fi
 		fi
 	done
@@ -700,7 +700,7 @@ migrate_mcp_env_to_credentials() {
 		if [[ ! -f "$new_file" ]]; then
 			mv "$old_file" "$new_file"
 			chmod 600 "$new_file"
-			((migrated++)) || true
+			((++migrated))
 			print_info "Renamed mcp-env.sh to credentials.sh"
 		fi
 		# Create backward-compatible symlink
@@ -721,7 +721,7 @@ migrate_mcp_env_to_credentials() {
 				if [[ ! -f "$tenant_new" ]]; then
 					mv "$tenant_old" "$tenant_new"
 					chmod 600 "$tenant_new"
-					((migrated++)) || true
+					((++migrated))
 				fi
 				if [[ ! -L "$tenant_old" ]]; then
 					ln -sf "credentials.sh" "$tenant_old"
@@ -736,7 +736,7 @@ migrate_mcp_env_to_credentials() {
 			# shellcheck disable=SC2016
 			sed -i '' 's|source.*\.config/aidevops/mcp-env\.sh|source "$HOME/.config/aidevops/credentials.sh"|g' "$rc_file" 2>/dev/null ||
 				sed -i 's|source.*\.config/aidevops/mcp-env\.sh|source "$HOME/.config/aidevops/credentials.sh"|g' "$rc_file" 2>/dev/null || true
-			((migrated++)) || true
+			((++migrated))
 			print_info "Updated $rc_file to source credentials.sh"
 		fi
 	done
@@ -784,11 +784,11 @@ migrate_old_backups() {
 		# Check if it contains agents folder (most common)
 		if [[ -d "$backup/agents" ]]; then
 			mv "$backup" "$HOME/.aidevops/agents-backups/$backup_name"
-			((migrated++)) || true
+			((++migrated))
 		# Check if it contains opencode.json
 		elif [[ -f "$backup/opencode.json" ]]; then
 			mv "$backup" "$HOME/.aidevops/opencode-backups/$backup_name"
-			((migrated++)) || true
+			((++migrated))
 		fi
 	done
 
@@ -862,7 +862,7 @@ migrate_loop_state_directories() {
 					print_warning "  .claude/ has other files, not removing"
 				fi
 
-				((migrated++)) || true
+				((++migrated))
 			fi
 		fi
 
@@ -876,7 +876,7 @@ migrate_loop_state_directories() {
 				cp -R "$legacy_state_dir"/* "$new_state_dir/" 2>/dev/null || true
 				rm -rf "$legacy_state_dir"
 				print_info "  Migrated .agents/loop-state/ -> .agents/loop-state/"
-				((migrated++)) || true
+				((++migrated))
 			fi
 		fi
 
@@ -936,14 +936,14 @@ migrate_pulse_repos_to_repos_json() {
 			jq --arg path "$expanded_path" --arg slug "$slug" --arg priority "$priority" \
 				'(.initialized_repos[] | select(.path == $path)) |= . + {slug: $slug, pulse: true, priority: $priority}' \
 				"$repos_file" >"$temp_file" && mv "$temp_file" "$repos_file"
-			((migrated++)) || true
+			((++migrated))
 		else
 			# Add new entry from pulse-repos.json
 			local temp_file="${repos_file}.tmp"
 			jq --arg path "$expanded_path" --arg slug "$slug" --arg priority "$priority" \
 				'.initialized_repos += [{path: $path, slug: $slug, pulse: true, priority: $priority}]' \
 				"$repos_file" >"$temp_file" && mv "$temp_file" "$repos_file"
-			((migrated++)) || true
+			((++migrated))
 		fi
 	done < <(jq -r '(.repos? // .)[] | [.slug, .path, .priority] | @tsv' "$pulse_file" 2>/dev/null)
 

--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -285,7 +285,7 @@ create_skill_symlinks() {
 			# Create symlink (remove existing first)
 			rm -f "$target_file" 2>/dev/null || true
 			if ln -sf "$full_path" "$target_file" 2>/dev/null; then
-				((created_count++)) || true
+				((++created_count))
 			fi
 		done
 	done < <(jq -c '.skills[]' "$skill_sources" 2>/dev/null)
@@ -367,7 +367,7 @@ check_skill_updates() {
 		fi
 
 		if [[ -n "$latest_commit" && "$latest_commit" != "$upstream_commit" ]]; then
-			((updates_available++)) || true
+			((++updates_available))
 			update_list="${update_list}\n  - $name (${upstream_commit:0:7} → ${latest_commit:0:7})"
 		fi
 	done < <(jq -c '.skills[]' "$skill_sources" 2>/dev/null)

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -329,7 +329,7 @@ setup_shell_compatibility() {
 				fi
 				echo "$line" >>"$shared_profile"
 				seen_lines+=("$line")
-				((extracted++)) || true
+				((++extracted))
 			fi
 		done <"$src_file"
 	done

--- a/tests/entity-extraction-test-fixtures/date-formats.md
+++ b/tests/entity-extraction-test-fixtures/date-formats.md
@@ -12,6 +12,6 @@ Here are the key dates for the project:
 - Phase 1 deadline: 2026-03-15
 - Phase 2 deadline: 28 Feb 2026
 - Final delivery: March 30, 2026
-- Board review: Monday, 5 April 2026
+- Board review: Sunday, 5 April 2026
 
 Please confirm availability for all dates.

--- a/tests/test-memory-mail.sh
+++ b/tests/test-memory-mail.sh
@@ -43,6 +43,9 @@ skip() {
 	SKIP_COUNT=$((SKIP_COUNT + 1))
 	TOTAL_COUNT=$((TOTAL_COUNT + 1))
 	printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
 }
 
 section() {


### PR DESCRIPTION
## Summary

- Replace 299 `((var++))` patterns with `((++var))` across 57 shell scripts
- Remove 184 now-unnecessary `|| true` guards that were protecting against the post-increment falsy-return issue
- Prevents `set -e` early exit bugs when counter starts at 0 (post-increment of 0 returns 0/falsy)

## Background

PR #70 fixed a critical bug where `((command_count++))` with `set -e` caused script exit when `command_count=0`. This applies the same fix systematically across the entire codebase.

Pre-increment `((++var))` is semantically identical to `((var++))` when the return value isn't used (all standalone increment statements), but returns the new value (always >= 1 for counters starting at 0), avoiding the `set -e` trap.

`for ((...))` loop increments are NOT affected by `set -e` and were left unchanged.

Closes #3970

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal script increment operations for consistency and maintainability across build and management utilities.

* **Bug Fixes**
  * Enhanced version checking to properly track and report timeout and unknown status conditions in tool compatibility reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->