### PR TITLE
fix: address 5 quality-debt findings from closed batch PRs (batch 3)

### DIFF
--- a/.agents/scripts/document-creation-helper.sh
+++ b/.agents/scripts/document-creation-helper.sh
@@ -71,9 +71,9 @@ human_filesize() {
 	local file="$1"
 	local bytes
 	if [[ "$(uname)" == "Darwin" ]]; then
-		bytes=$(stat -f%z -- "$file" 2>/dev/null || echo "0")
+		bytes=$(stat -f%z -- "$file" || echo "0")
 	else
-		bytes=$(stat -c%s -- "$file" 2>/dev/null || echo "0")
+		bytes=$(stat -c%s -- "$file" || echo "0")
 	fi
 	if [[ "$bytes" -ge 1073741824 ]]; then
 		printf '%s.%sG' "$((bytes / 1073741824))" "$(((bytes % 1073741824) * 10 / 1073741824))"

--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -72,7 +72,11 @@ parse_args() {
 		arg="$1"
 		case "$arg" in
 		--pr)
-			val="$2"
+			val="${2:-}"
+			if [[ -z "$val" || "$val" == --* ]]; then
+				echo "Error: --pr requires a PR number" >&2
+				exit 1
+			fi
 			PR_NUMBER="$val"
 			shift 2
 			;;
@@ -87,7 +91,11 @@ parse_args() {
 			fi
 			;;
 		--repo-path)
-			val="$2"
+			val="${2:-}"
+			if [[ -z "$val" || "$val" == --* ]]; then
+				echo "Error: --repo-path requires a path" >&2
+				exit 1
+			fi
 			REPO_PATH="$val"
 			shift 2
 			;;

--- a/.agents/scripts/task-decompose-helper.sh
+++ b/.agents/scripts/task-decompose-helper.sh
@@ -71,8 +71,12 @@ check_existing_subtasks() {
 		return 0
 	fi
 
-	local parent_pattern="^- \\[[ x-]\\] ${task_id} "
-	local child_pattern="^  - \\[[ x-]\\] ${task_id}\\."
+	# Escape regex metacharacters in task_id to prevent injection
+	local escaped_id
+	escaped_id=$(printf '%s' "$task_id" | sed 's/[.[\*^$()+?{|\\]/\\&/g')
+
+	local parent_pattern="^- \\[[ x-]\\] ${escaped_id} "
+	local child_pattern="^  - \\[[ x-]\\] ${escaped_id}\\."
 
 	if grep -qE "$parent_pattern" "$todo_file" && grep -qE "$child_pattern" "$todo_file"; then
 		echo "true"

--- a/.agents/scripts/task-decompose-helper.sh
+++ b/.agents/scripts/task-decompose-helper.sh
@@ -73,6 +73,8 @@ check_existing_subtasks() {
 
 	# Escape regex metacharacters in task_id to prevent injection
 	local escaped_id
+	# Single quotes intentional: sed pattern must not expand
+	# shellcheck disable=SC2016
 	escaped_id=$(printf '%s' "$task_id" | sed 's/[.[\*^$()+?{|\\]/\\&/g')
 
 	local parent_pattern="^- \\[[ x-]\\] ${escaped_id} "

--- a/.agents/services/communications/google-chat.md
+++ b/.agents/services/communications/google-chat.md
@@ -230,7 +230,7 @@ google-chat-helper.sh setup
 | `maxResponseLength` | `4096` | Max response text length before truncation |
 | `responseTimeout` | `30` | Seconds before returning async acknowledgment |
 | `asyncResponseTimeout` | `600` | Max seconds for async runner response |
-| `verifyGoogleTokens` | `true` | Verify inbound request bearer tokens against Google JWKS |
+| `verifyGoogleTokens` | `true` | Verify inbound request bearer tokens against Google JWKS. **Must remain `true` in production** — disable only for local development without Google connectivity |
 
 ## Authentication
 

--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -48,7 +48,7 @@ check_python_for_skill_scanner() {
 	# 3. If uv is available, install Python 3.11 and retry
 	if command -v uv &>/dev/null; then
 		print_info "No Python >= 3.10 found. Installing Python 3.11 via uv..."
-		if uv python install 3.11 2>/dev/null; then
+		if uv python install 3.11; then
 			# uv installs to its managed path; check if python3.11 is now available
 			if command -v python3.11 &>/dev/null && _python_version_ok python3.11; then
 				print_success "Python 3.11 installed via uv"
@@ -61,6 +61,9 @@ check_python_for_skill_scanner() {
 				print_success "Python 3.11 installed via uv (at $uv_py)"
 				return 0
 			fi
+			print_warning "uv installed Python 3.11 but it could not be found on PATH"
+		else
+			print_warning "uv python install 3.11 failed — see errors above"
 		fi
 	fi
 


### PR DESCRIPTION
## Summary

Resubmits 5 quality-debt fixes from previously closed batch PRs, respecting the 5-file-per-PR cap.

### Changes

| File | Issue | Fix |
|------|-------|-----|
| `google-chat.md` | #3199 (critical) | Clarify `verifyGoogleTokens` must remain `true` in production — aligns mandatory language with config option |
| `plugins.sh` | #3319 (critical) | Remove `2>/dev/null` from `uv python install` so errors are visible; add failure feedback messages |
| `task-decompose-helper.sh` | #3147 (high) | Escape regex metacharacters in `task_id` before using in `grep -E` to prevent regex injection |
| `document-creation-helper.sh` | #3157 (high) | Remove `2>/dev/null` from `stat` calls to surface permission/disk errors |
| `task-complete-helper.sh` | #3252 (high) | Guard `--pr` and `--repo-path` with `${2:-}` to prevent crash under `set -u` when no value provided |

### Verification

- All modified `.sh` files pass ShellCheck (zero warnings/errors)
- Each fix verified against current `main` code — all findings still present before this PR

Closes #3199, #3319, #3147, #3157, #3252