### PR TITLE
fix: address 5 quality-debt findings (batch 4)

### DIFF
--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -57,7 +57,7 @@ _log_to_file() {
 	local timestamp
 	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 	mkdir -p "$(dirname "$SKILL_LOG_FILE")" 2>/dev/null || true
-	echo "[$timestamp] [skill-update] [$level] $*" >>"$SKILL_LOG_FILE"
+	printf '%s\n' "[$timestamp] [skill-update] [$level] $*" >>"$SKILL_LOG_FILE"
 	return 0
 }
 

--- a/.agents/scripts/skills-helper.sh
+++ b/.agents/scripts/skills-helper.sh
@@ -196,7 +196,7 @@ cmd_search_registry() {
 
 	local raw_output
 	# Strip ANSI escape codes for parsing, but capture raw for display
-	raw_output=$(npx --yes skills find "$query" 2>&1 || true)
+	raw_output=$(npx --yes skills find "$query" || true)
 
 	if [[ -z "$raw_output" ]]; then
 		log_warning "No results from skills.sh registry for '$query'"

--- a/.agents/scripts/skills-helper.sh
+++ b/.agents/scripts/skills-helper.sh
@@ -196,7 +196,7 @@ cmd_search_registry() {
 
 	local raw_output
 	# Strip ANSI escape codes for parsing, but capture raw for display
-	raw_output=$(npx --yes skills find "$query" 2>/dev/null || true)
+	raw_output=$(npx --yes skills find "$query" 2>&1 || true)
 
 	if [[ -z "$raw_output" ]]; then
 		log_warning "No results from skills.sh registry for '$query'"

--- a/.agents/scripts/test-pr-task-check.sh
+++ b/.agents/scripts/test-pr-task-check.sh
@@ -24,7 +24,9 @@ log() {
 	return 0
 }
 verbose() {
-	[[ "$VERBOSE" == "--verbose" ]] && echo -e "  ${YELLOW}$1${NC}" || true
+	if [[ "$VERBOSE" == "--verbose" ]]; then
+		echo -e "  ${YELLOW}$1${NC}"
+	fi
 	return 0
 }
 

--- a/tests/entity-extraction-test-fixtures/date-formats.md
+++ b/tests/entity-extraction-test-fixtures/date-formats.md
@@ -12,6 +12,6 @@ Here are the key dates for the project:
 - Phase 1 deadline: 2026-03-15
 - Phase 2 deadline: 28 Feb 2026
 - Final delivery: March 30, 2026
-- Board review: Monday, 5 April 2026
+- Board review: Sunday, 5 April 2026
 
 Please confirm availability for all dates.

--- a/tests/test-memory-mail.sh
+++ b/tests/test-memory-mail.sh
@@ -43,6 +43,9 @@ skip() {
 	SKIP_COUNT=$((SKIP_COUNT + 1))
 	TOTAL_COUNT=$((TOTAL_COUNT + 1))
 	printf "  \033[0;33mSKIP\033[0m %s\n" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf "       %s\n" "$2"
+	fi
 }
 
 section() {


### PR DESCRIPTION
## Summary

Addresses 5 quality-debt findings from open issues, respecting the 5-file-per-PR cap.

### Changes

| File | Issue | Fix |
|------|-------|-----|
| `date-formats.md` | #3700 (medium) | Correct weekday — 5 April 2026 is Sunday, not Monday |
| `test-memory-mail.sh` | #3771 (medium) | Extend `skip()` to accept and print optional detail message (2nd arg was silently discarded) |
| `skills-helper.sh` | #3627 (high) | Redirect npx stderr to stdout (`2>&1`) instead of `/dev/null` so errors are visible |
| `skill-update-helper.sh` | #3661 (medium) | Use `printf '%s\n'` instead of `echo` to prevent `-n` interpretation and word splitting |
| `test-pr-task-check.sh` | #3691 (high) | Refactor `verbose()` from SC2015 `A && B || C` pattern to proper `if/then` |

### Verification

- All modified `.sh` files pass ShellCheck (zero warnings/errors)
- Each fix verified against current `main` code

Closes #3700, #3771, #3627, #3661, #3691