### PR TITLE
fix: address 4 quality-debt findings in plugin-loader-helper.sh

### DIFF
--- a/.agents/scripts/plugin-loader-helper.sh
+++ b/.agents/scripts/plugin-loader-helper.sh
@@ -208,7 +208,7 @@ validate_manifest() {
 	fi
 
 	# Validate version format (semver-like)
-	if [[ -n "$version" ]] && [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+	if [[ -n "$version" ]] && [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$ ]]; then
 		log_warning "Version '$version' is not semver format (expected: X.Y.Z)"
 	fi
 
@@ -249,7 +249,7 @@ validate_manifest() {
 	min_version=$(jq -r '.min_aidevops_version // empty' "$manifest" 2>/dev/null)
 	if [[ -n "$min_version" ]]; then
 		local current_version
-		current_version=$(cat "$HOME/.aidevops/version" 2>/dev/null || echo "0.0.0")
+		current_version=$(cat "$AGENTS_DIR/VERSION" 2>/dev/null || echo "0.0.0")
 		# Simple version comparison (major.minor only)
 		local min_major min_minor cur_major cur_minor
 		min_major=$(echo "$min_version" | cut -d. -f1)
@@ -398,9 +398,6 @@ cmd_load() {
 			return 1
 		fi
 
-		# Run init hook if available
-		run_hook "$target" "init" 2>/dev/null || true
-
 		local agents
 		agents=$(load_plugin_agents "$target")
 		if [[ -z "$agents" ]]; then
@@ -413,8 +410,8 @@ cmd_load() {
 			printf "  %-20s %-30s %s\n" "$name" "$file" "$desc"
 		done
 
-		# Run load hook if available
-		run_hook "$target" "load" 2>/dev/null || true
+		# Run load hook if available (init hook belongs in install/enable, not load)
+		run_hook "$target" "load" || true
 		return 0
 	fi
 
@@ -432,9 +429,6 @@ cmd_load() {
 	while IFS= read -r ns; do
 		[[ -z "$ns" ]] && continue
 
-		# Run init hook
-		run_hook "$ns" "init" 2>/dev/null || true
-
 		local agents
 		agents=$(load_plugin_agents "$ns")
 		if [[ -n "$agents" ]]; then
@@ -445,8 +439,8 @@ cmd_load() {
 			log_info "Loaded $count agent(s) from '$ns'"
 		fi
 
-		# Run load hook
-		run_hook "$ns" "load" 2>/dev/null || true
+		# Run load hook (init hook belongs in install/enable, not load)
+		run_hook "$ns" "load" || true
 	done <<<"$namespaces"
 
 	log_success "Loaded $total_agents agent(s) from $total_plugins plugin(s)"


### PR DESCRIPTION
## Summary

Addresses 4 of 5 findings from issue #3740 (1 finding — duplicate log functions — was already fixed on main).

### Changes

| Finding | Severity | Fix |
|---------|----------|-----|
| Semver regex missing hyphens | medium | Allow `-` in pre-release character class (`1.0.0-beta-1` now valid) |
| Wrong version file path | major | Read from `$AGENTS_DIR/VERSION` instead of nonexistent `~/.aidevops/version` |
| `cmd_load` runs init hook on every invocation | high | Remove init hook calls from `cmd_load` — init belongs in install/enable lifecycle, not session load |
| `2>/dev/null` on hook calls | medium | Remove blanket error suppression; `|| true` is sufficient to prevent exit |

### Verification

- ShellCheck passes (zero warnings/errors)
- Each fix verified against current `main` code

Closes #3740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced version validation to accept more flexible prerelease version formats.
  * Improved plugin load hook execution with enhanced error visibility for better troubleshooting.

* **Chores**
  * Refined plugin initialization lifecycle and loading workflow for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->