### PR TITLE
fix: remove blanket error suppression in OCR test pipeline

### DIFF
--- a/.agents/scripts/test-ocr-extraction-pipeline.sh
+++ b/.agents/scripts/test-ocr-extraction-pipeline.sh
@@ -693,7 +693,7 @@ create_large_invoice() {
 		local amount=$((i * 10))
 		subtotal=$((subtotal + amount))
 		local vat_amt
-		vat_amt=$(echo "$amount * 0.2" | bc 2>/dev/null || echo "$((amount / 5))")
+		vat_amt=$(echo "$amount * 0.2" | bc || echo "$((amount / 5))")
 		if [[ -n "$items" ]]; then
 			items="${items},"
 		fi
@@ -708,9 +708,9 @@ create_large_invoice() {
     }"
 	done
 	local vat_total
-	vat_total=$(echo "$subtotal * 0.2" | bc 2>/dev/null || echo "$((subtotal / 5))")
+	vat_total=$(echo "$subtotal * 0.2" | bc || echo "$((subtotal / 5))")
 	local total
-	total=$(echo "$subtotal + $vat_total" | bc 2>/dev/null || echo "$((subtotal + subtotal / 5))")
+	total=$(echo "$subtotal + $vat_total" | bc || echo "$((subtotal + subtotal / 5))")
 
 	cat >"$output_file" <<FIXTURE
 {
@@ -742,7 +742,7 @@ test_pipeline_classify() {
 		local text_file="${TEST_WORKSPACE}/invoice-text.txt"
 		create_invoice_text "$text_file"
 		local output
-		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file" 2>/dev/null)" || true
+		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file")" || true
 		if echo "$output" | grep -q '"purchase_invoice"'; then
 			log_test "PASS" "${group}/invoice-text"
 		else

--- a/.agents/scripts/test-ocr-extraction-pipeline.sh
+++ b/.agents/scripts/test-ocr-extraction-pipeline.sh
@@ -755,7 +755,7 @@ test_pipeline_classify() {
 		local text_file="${TEST_WORKSPACE}/receipt-text.txt"
 		create_receipt_text "$text_file"
 		local output
-		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file" 2>/dev/null)" || true
+		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file")" || true
 		if echo "$output" | grep -q '"expense_receipt"'; then
 			log_test "PASS" "${group}/receipt-text"
 		else
@@ -768,7 +768,7 @@ test_pipeline_classify() {
 		local text_file="${TEST_WORKSPACE}/credit-note-text.txt"
 		create_credit_note_text "$text_file"
 		local output
-		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file" 2>/dev/null)" || true
+		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file")" || true
 		if echo "$output" | grep -q '"credit_note"'; then
 			log_test "PASS" "${group}/credit-note-text"
 		else
@@ -781,7 +781,7 @@ test_pipeline_classify() {
 		local text_file="${TEST_WORKSPACE}/ambiguous-text.txt"
 		create_ambiguous_text "$text_file"
 		local output
-		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file" 2>/dev/null)" || true
+		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file")" || true
 		if echo "$output" | grep -q '"purchase_invoice"'; then
 			log_test "PASS" "${group}/ambiguous-text"
 		else
@@ -792,7 +792,7 @@ test_pipeline_classify() {
 	# Test 5: Classify inline string (no file)
 	if should_run "${group}/inline-string"; then
 		local output
-		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "Invoice No: 12345 Due Date: 2025-01-15 Payment Terms: Net 30" 2>/dev/null)" || true
+		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "Invoice No: 12345 Due Date: 2025-01-15 Payment Terms: Net 30")" || true
 		if echo "$output" | grep -q '"purchase_invoice"'; then
 			log_test "PASS" "${group}/inline-string"
 		else
@@ -805,7 +805,7 @@ test_pipeline_classify() {
 		local text_file="${TEST_WORKSPACE}/invoice-text.txt"
 		create_invoice_text "$text_file"
 		local output
-		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file" 2>/dev/null)" || true
+		output="$("$PYTHON_CMD" "$PIPELINE_PY" classify "$text_file")" || true
 		if echo "$output" | grep -q '"scores"'; then
 			log_test "PASS" "${group}/scores-output"
 		else


### PR DESCRIPTION
## Summary

Addresses 3 of 5 findings from issue #3718. The remaining 2 findings are architectural refactors (rewrite tests to call CLI as black box instead of reimplementing detection logic) — deferred to a future PR.

### Changes

| Line | Fix |
|------|-----|
| 696 | Remove `2>/dev/null` from `bc` VAT calculation — `|| echo` fallback is sufficient |
| 711, 713 | Remove `2>/dev/null` from `bc` subtotal/total calculations |
| 745 | Remove `2>/dev/null` from Python classify call — `|| true` is sufficient |

### Verification

- ShellCheck passes (zero warnings/errors)
- Each fix verified against current `main` code

Partially closes #3718

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased error visibility in the test suite by removing output suppression so calculation- and classification-related errors surface during test runs; normal success paths remain unchanged, though error conditions may now affect test control flow for improved debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->