### PR TITLE
fix: screen time shows 0h when launchd job lacks Knowledge DB access

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -94,7 +94,7 @@ _format_tokens() {
 # --- Gather screen time data ---
 _get_screen_time() {
 	local screen_json
-	screen_json=$("${SCRIPT_DIR}/screen-time-helper.sh" profile-stats 2>/dev/null) || screen_json="{}"
+	screen_json=$("${SCRIPT_DIR}/screen-time-helper.sh" profile-stats) || screen_json="{}"
 	echo "$screen_json"
 	return 0
 }
@@ -468,7 +468,7 @@ cmd_generate() {
 	cat <<EOF
 ## Work with AI
 
-| Metric | Today | 7 Days | 28 Days | 365 Days |
+| Metric | 24h | 7 Days | 28 Days | 365 Days |
 | --- | ---: | ---: | ---: | ---: |
 | ${screen_label} | ${screen_today}h | ${screen_week}h | ${f_screen_month}h | ${year_prefix}${f_screen_year}h${year_suffix} |
 | User AI session hours | ${day_human}h | ${week_human}h | ${month_human}h | ${year_human}h |
@@ -608,7 +608,7 @@ EOF
 
 ## Top Apps by Screen Time
 
-| App | Today | 7 Days | 28 Days |
+| App | 24h | 7 Days | 28 Days |
 | --- | ---: | ---: | ---: |
 ${app_rows}
 _Top 10 apps by foreground time share. Mac only._

--- a/.agents/scripts/screen-time-helper.sh
+++ b/.agents/scripts/screen-time-helper.sh
@@ -666,31 +666,38 @@ cmd_profile_stats() {
 	# This happens when the launchd job runs without Knowledge DB access
 	# (TCC/Full Disk Access not granted in non-interactive context)
 	local history_days=0
-	local history_total=0
+	local history_total=0 hist_1d=0 hist_7d=0 hist_28d=0 hist_365d=0
 	if [[ -f "$HISTORY_FILE" ]]; then
 		history_days=$(wc -l <"$HISTORY_FILE" | tr -d ' ')
-		history_total=$(jq -s '[.[].screen_hours] | add // 0' "$HISTORY_FILE" 2>/dev/null || echo "0")
+		if [[ "$history_days" -gt 0 ]]; then
+			# Single jq pass for all history stats
+			local history_stats
+			history_stats=$(jq -rs '
+				. as $all |
+				[
+					([$all[].screen_hours] | add // 0),
+					([$all[-1:][].screen_hours] | add // 0 | . * 10 | round / 10),
+					([$all[-7:][].screen_hours] | add // 0 | . * 10 | round / 10),
+					([$all[-28:][].screen_hours] | add // 0 | . * 10 | round / 10),
+					([$all[-365:][].screen_hours] | add // 0 | . * 10 | round / 10)
+				] | @tsv
+			' "$HISTORY_FILE" 2>/dev/null) || true
+			if [[ -n "$history_stats" ]]; then
+				read -r history_total hist_1d hist_7d hist_28d hist_365d <<<"$history_stats"
+			fi
+		fi
 	fi
 
-	# If live 7d/28d returned 0 but we have history, use history instead
+	# If live queries returned 0 but we have history, use history instead
 	if [[ "$history_days" -gt 0 ]]; then
+		if [[ "$(echo "$day_hours == 0" | bc)" -eq 1 ]]; then
+			day_hours="${hist_1d:-0}"
+		fi
 		if [[ "$(echo "$week_hours == 0" | bc)" -eq 1 ]]; then
-			# Sum last 7 days from history (or all if fewer)
-			local hist_7d
-			hist_7d=$(jq -s '[.[-7:][].screen_hours] | add // 0 | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
-			week_hours="$hist_7d"
+			week_hours="${hist_7d:-0}"
 		fi
 		if [[ "$(echo "$month_hours == 0" | bc)" -eq 1 ]]; then
-			# Sum last 28 days from history (or all if fewer)
-			local hist_28d
-			hist_28d=$(jq -s '[.[-28:][].screen_hours] | add // 0 | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
-			month_hours="$hist_28d"
-		fi
-		if [[ "$(echo "$day_hours == 0" | bc)" -eq 1 ]]; then
-			# Use last day from history as fallback for 24h
-			local hist_1d
-			hist_1d=$(jq -s '[.[-1:][].screen_hours] | add // 0 | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
-			day_hours="$hist_1d"
+			month_hours="${hist_28d:-0}"
 		fi
 	fi
 
@@ -698,10 +705,9 @@ cmd_profile_stats() {
 	local year_hours
 	if [[ "$history_days" -gt 0 ]]; then
 		local daily_avg
-		daily_avg=$(echo "scale=2; $history_total / $history_days" | bc)
+		daily_avg=$(echo "scale=2; ${history_total:-0} / $history_days" | bc)
 		if [[ "$history_days" -ge 365 ]]; then
-			# Have a full year of data — use last 365 days from history
-			year_hours=$(jq -s '[.[-365:][].screen_hours] | add // 0 | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
+			year_hours="${hist_365d:-0}"
 		else
 			# Extrapolate from available data
 			year_hours=$(echo "scale=1; $daily_avg * 365" | bc)

--- a/.agents/scripts/screen-time-helper.sh
+++ b/.agents/scripts/screen-time-helper.sh
@@ -652,37 +652,59 @@ cmd_history() {
 # Returns: 0
 #######################################
 cmd_profile_stats() {
-	# Live data
-	local today_hours
+	# Live data — rolling 24h window instead of "today since midnight"
+	local day_hours
 	local week_hours
-	today_hours=$(_query_screen_hours 1)
+	day_hours=$(_query_screen_hours 1)
 	week_hours=$(_query_screen_hours 7)
 
 	# For 28 days: use live query
 	local month_hours
 	month_hours=$(_query_screen_hours 28)
 
+	# Fallback to accumulated history when live queries return 0
+	# This happens when the launchd job runs without Knowledge DB access
+	# (TCC/Full Disk Access not granted in non-interactive context)
+	local history_days=0
+	local history_total=0
+	if [[ -f "$HISTORY_FILE" ]]; then
+		history_days=$(wc -l <"$HISTORY_FILE" | tr -d ' ')
+		history_total=$(jq -s '[.[].screen_hours] | add // 0' "$HISTORY_FILE" 2>/dev/null || echo "0")
+	fi
+
+	# If live 7d/28d returned 0 but we have history, use history instead
+	if [[ "$history_days" -gt 0 ]]; then
+		if [[ "$(echo "$week_hours == 0" | bc)" -eq 1 ]]; then
+			# Sum last 7 days from history (or all if fewer)
+			local hist_7d
+			hist_7d=$(jq -s '[.[-7:][].screen_hours] | add // 0 | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
+			week_hours="$hist_7d"
+		fi
+		if [[ "$(echo "$month_hours == 0" | bc)" -eq 1 ]]; then
+			# Sum last 28 days from history (or all if fewer)
+			local hist_28d
+			hist_28d=$(jq -s '[.[-28:][].screen_hours] | add // 0 | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
+			month_hours="$hist_28d"
+		fi
+		if [[ "$(echo "$day_hours == 0" | bc)" -eq 1 ]]; then
+			# Use last day from history as fallback for 24h
+			local hist_1d
+			hist_1d=$(jq -s '[.[-1:][].screen_hours] | add // 0 | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
+			day_hours="$hist_1d"
+		fi
+	fi
+
 	# For 365 days: use accumulated history if available, else extrapolate
 	local year_hours
-	if [[ -f "$HISTORY_FILE" ]]; then
-		local history_days
-		local history_total
-		history_days=$(wc -l <"$HISTORY_FILE" | tr -d ' ')
-		history_total=$(jq -s '[.[].screen_hours] | add' "$HISTORY_FILE" 2>/dev/null || echo "0")
-
-		if [[ "$history_days" -gt 0 ]]; then
-			# Use actual accumulated data + extrapolate remaining days
-			local daily_avg
-			daily_avg=$(echo "scale=2; $history_total / $history_days" | bc)
-			if [[ "$history_days" -ge 365 ]]; then
-				# Have a full year of data — use last 365 days from history
-				year_hours=$(jq -s '[.[-365:][].screen_hours] | add | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
-			else
-				# Extrapolate from available data
-				year_hours=$(echo "scale=1; $daily_avg * 365" | bc)
-			fi
+	if [[ "$history_days" -gt 0 ]]; then
+		local daily_avg
+		daily_avg=$(echo "scale=2; $history_total / $history_days" | bc)
+		if [[ "$history_days" -ge 365 ]]; then
+			# Have a full year of data — use last 365 days from history
+			year_hours=$(jq -s '[.[-365:][].screen_hours] | add // 0 | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
 		else
-			year_hours=$(echo "scale=1; $month_hours / 28 * 365" | bc 2>/dev/null || echo "0")
+			# Extrapolate from available data
+			year_hours=$(echo "scale=1; $daily_avg * 365" | bc)
 		fi
 	else
 		# No history — extrapolate from 28-day data
@@ -697,13 +719,13 @@ cmd_profile_stats() {
 	esac
 
 	jq -n \
-		--arg today "$today_hours" \
+		--arg day "$day_hours" \
 		--arg week "$week_hours" \
 		--arg month "$month_hours" \
 		--arg year "$year_hours" \
 		--arg note "$platform_note" \
 		'{
-			today_hours: ($today | tonumber),
+			today_hours: ($day | tonumber),
 			week_hours: ($week | tonumber),
 			month_hours: ($month | tonumber),
 			year_hours: ($year | tonumber),


### PR DESCRIPTION
## Summary

- Screen time columns (24h, 7 Days, 28 Days) showed 0h on the live profile README because the scheduled launchd job runs without macOS TCC/Full Disk Access, causing the Knowledge DB query to silently fail
- Added fallback to accumulated history file (`screen-time.jsonl`) when live queries return 0
- Renamed "Today" column to "24h" — a rolling 24-hour window is more meaningful than "since midnight"

## Root Cause

The `sh.aidevops.profile-readme-update` launchd job runs at 06:00 UTC via `/bin/bash`. In this non-interactive context, macOS TCC (Transparency, Consent, and Control) may not grant Full Disk Access to read `~/Library/Application Support/Knowledge/knowledgeC.db`. The sqlite3 query returns empty/error, `2>/dev/null` suppresses it, and the `|| echo "0"` fallback produces 0 for all periods.

## Changes

### `screen-time-helper.sh`
- `cmd_profile_stats()`: when live `_query_screen_hours` returns 0 for 24h/7d/28d, fall back to summing the last N days from `screen-time.jsonl` history file (populated by the `snapshot` command in interactive sessions)

### `profile-readme-helper.sh`
- Rename "Today" column header to "24h" in both Work with AI and Top Apps tables
- Remove `2>/dev/null` from `_get_screen_time()` so errors are visible in the launchd log

## Testing

- ShellCheck: zero violations on both files
- Live `generate` output: correct values (13h / 107.8h / 368.1h)
- Simulated launchd failure (overriding `_query_screen_hours` to return 0): fallback produces 15.4h / 103.9h / 365h from history

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Use a rolling 24-hour window for day calculations and fall back to historical data when live values are missing, improving day/week/month and year estimates.

* **Style**
  * Updated report column labels from "Today" to "24h" for clearer reporting (applies to multiple tables).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->