### PR TITLE
t1524: Fix aidevops update to detect and deploy stale agents

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -903,6 +903,27 @@ cmd_check() {
 	if [[ "$current" == "$remote" ]]; then
 		log_info "Already up to date (v$current)"
 		update_state "check" "$current" "up_to_date"
+
+		# Even when repo matches remote, deployed agents may be stale
+		# (e.g., previous setup.sh was interrupted or failed silently)
+		# See: https://github.com/marcusquinn/aidevops/issues/3980
+		local deployed_version
+		deployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
+		if [[ "$current" != "$deployed_version" ]]; then
+			log_warn "Deployed agents stale ($deployed_version), re-deploying..."
+			if bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1; then
+				local redeployed_version
+				redeployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
+				if [[ "$current" == "$redeployed_version" ]]; then
+					log_info "Agents re-deployed successfully ($deployed_version -> $redeployed_version)"
+				else
+					log_error "Agent re-deploy incomplete: repo=$current, deployed=$redeployed_version"
+				fi
+			else
+				log_error "setup.sh failed during stale-agent re-deploy (exit code: $?)"
+			fi
+		fi
+
 		check_skill_freshness
 		check_openclaw_freshness
 		check_tool_freshness
@@ -947,8 +968,18 @@ cmd_check() {
 	if bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1; then
 		local new_version
 		new_version=$(get_local_version)
-		log_info "Update complete: v$current -> v$new_version"
-		update_state "update" "$new_version" "success"
+
+		# Verify agents were actually deployed (setup.sh may exit 0 without deploying)
+		# See: https://github.com/marcusquinn/aidevops/issues/3980
+		local deployed_version
+		deployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
+		if [[ "$new_version" != "$deployed_version" ]]; then
+			log_warn "Update pulled v$new_version but agents at v$deployed_version — deployment incomplete"
+			update_state "update" "$new_version" "agents_stale"
+		else
+			log_info "Update complete: v$current -> v$new_version (agents deployed)"
+			update_state "update" "$new_version" "success"
+		fi
 	else
 		log_error "setup.sh failed (exit code: $?)"
 		update_state "update" "$remote" "setup_failed"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -721,7 +721,6 @@ cmd_update() {
 			local new_version new_hash
 			new_version=$(get_version)
 			new_hash=$(git rev-parse HEAD)
-			print_success "Updated to version $new_version"
 
 			# Print bounded summary of meaningful changes
 			if [[ "$old_hash" != "$new_hash" ]]; then
@@ -741,12 +740,32 @@ cmd_update() {
 
 			echo ""
 			print_info "Running setup to apply changes..."
-			bash "$INSTALL_DIR/setup.sh" --non-interactive
+			local setup_exit=0
+			bash "$INSTALL_DIR/setup.sh" --non-interactive || setup_exit=$?
 
 			# Safety net: discard any working tree changes setup.sh may have introduced
 			# (e.g. chmod on tracked scripts, scan results written to repo)
 			# See: https://github.com/marcusquinn/aidevops/issues/2286
 			git checkout -- . 2>/dev/null || true
+
+			# Verify deployment: compare repo VERSION with deployed agents VERSION
+			# This catches silent setup.sh failures (e.g., non-interactive mode in
+			# environments where setup.sh exits early without deploying agents)
+			# See: https://github.com/marcusquinn/aidevops/issues/3980
+			local repo_version deployed_version
+			repo_version=$(cat "$INSTALL_DIR/VERSION" 2>/dev/null || echo "unknown")
+			deployed_version=$(cat "$HOME/.aidevops/agents/VERSION" 2>/dev/null || echo "none")
+
+			if [[ "$setup_exit" -ne 0 ]]; then
+				print_warning "Setup exited with code $setup_exit"
+			fi
+
+			if [[ "$repo_version" != "$deployed_version" ]]; then
+				print_warning "Agent deployment incomplete: repo=$repo_version, deployed=$deployed_version"
+				print_info "Run 'bash $INSTALL_DIR/setup.sh' manually to deploy agents"
+			else
+				print_success "Updated to version $new_version (agents deployed)"
+			fi
 		fi
 	else
 		print_warning "Repository not found, performing fresh install..."


### PR DESCRIPTION
## Summary

- **`cmd_update()` in `aidevops.sh`**: Moved success message from before `setup.sh` to after deployment verification. Captures `setup.sh` exit code and compares repo VERSION with deployed `~/.aidevops/agents/VERSION`. Warns user with manual recovery instructions if agents are stale.
- **`cmd_check()` in `auto-update-helper.sh` ("up to date" path)**: After confirming repo=remote, now checks deployed agent VERSION. If stale, re-runs `setup.sh --non-interactive` and verifies the result — self-heals the permanent mismatch the poller previously couldn't detect.
- **`cmd_check()` normal update path**: After `setup.sh` succeeds, verifies deployed agents actually match the new version. Logs `agents_stale` state if mismatch detected instead of falsely reporting success.

Closes #3980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment validation to ensure agents are properly deployed after updates.
  * Added verification checks and clearer status reporting if deployment is incomplete, with guidance for resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->