### PR TITLE
GH#4002: Fix OpenCode AI Agent and Review Bot Gate workflows showing action_required on PRs

### DIFF
--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -29,6 +29,18 @@ jobs:
   security-check:
     name: Security Validation
     runs-on: ubuntu-latest
+    # GH#4002: Skip when triggered by known review bots. Bot review comments
+    # (from CodeRabbit, Gemini, etc.) never contain /oc or /opencode triggers,
+    # but GitHub requires manual approval for workflow runs triggered by bot
+    # accounts, causing permanent action_required status on PRs.
+    if: >
+      github.actor != 'coderabbitai' &&
+      github.actor != 'gemini-code-assist[bot]' &&
+      github.actor != 'augment-code[bot]' &&
+      github.actor != 'augmentcode[bot]' &&
+      github.actor != 'copilot[bot]' &&
+      github.actor != 'github-actions[bot]' &&
+      github.actor != 'dependabot[bot]'
     # Needs write permissions to post rejection replies on untrusted comments.
     # Without this, the GITHUB_TOKEN defaults to read-only and the
     # createReplyForReviewComment/createComment calls fail with 403. GH#2973.

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -71,8 +71,12 @@ jobs:
         run: |
           echo "Checking PR #${PR_NUMBER} for AI review bot activity..."
 
-          # Known review bot patterns (case-insensitive matching on login)
-          # Add new bots here as they are configured
+          # Known review bot patterns (case-insensitive matching on login).
+          # Add new bots here as they are configured.
+          # NOTE: This list differs from the job-level if-condition which also
+          # excludes github-actions[bot] and dependabot[bot]. Those bots are
+          # excluded from triggering this workflow but are NOT code review bots
+          # whose reviews we wait for.
           KNOWN_BOTS=(
             "coderabbitai"
             "gemini-code-assist[bot]"

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -32,11 +32,29 @@ jobs:
   review-bot-gate:
     name: Wait for AI Review Bots
     runs-on: ubuntu-latest
-    # Only run on PRs (issue_comment fires for PR comments too)
+    # Only run on PRs (issue_comment fires for PR comments too).
+    # GH#4002: Skip pull_request_review events from known review bots.
+    # GitHub requires manual approval for workflow runs triggered by bot
+    # accounts on pull_request_review and pull_request_review_comment events,
+    # causing permanent action_required status on PRs. The issue_comment
+    # event from bots does NOT require approval, so we allow it — this is
+    # the primary re-trigger path when a bot posts its review as a comment.
     if: >
-      github.event_name == 'pull_request' ||
-      github.event_name == 'pull_request_review' ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+      (
+        github.event_name == 'pull_request' ||
+        github.event_name == 'pull_request_review' ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+      ) && !(
+        github.event_name == 'pull_request_review' && (
+          github.actor == 'coderabbitai' ||
+          github.actor == 'gemini-code-assist[bot]' ||
+          github.actor == 'augment-code[bot]' ||
+          github.actor == 'augmentcode[bot]' ||
+          github.actor == 'copilot[bot]' ||
+          github.actor == 'github-actions[bot]' ||
+          github.actor == 'dependabot[bot]'
+        )
+      )
 
     permissions:
       pull-requests: read

--- a/configs/mcp-templates/opencode-github-workflow.yml
+++ b/configs/mcp-templates/opencode-github-workflow.yml
@@ -22,10 +22,20 @@ on:
 
 jobs:
   opencode:
-    # Only run if comment contains /oc or /opencode
-    if: |
-      contains(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, '/opencode')
+    # Only run if comment contains /oc or /opencode.
+    # GH#4002: Also skip known review bots — their comments never contain
+    # trigger commands, and bot-triggered runs require manual approval,
+    # causing permanent action_required status on PRs.
+    if: >
+      (
+        contains(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, '/opencode')
+      ) &&
+      github.actor != 'coderabbitai' &&
+      github.actor != 'gemini-code-assist[bot]' &&
+      github.actor != 'copilot[bot]' &&
+      github.actor != 'github-actions[bot]' &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     
     permissions:

--- a/configs/mcp-templates/opencode-github-workflow.yml
+++ b/configs/mcp-templates/opencode-github-workflow.yml
@@ -33,6 +33,8 @@ jobs:
       ) &&
       github.actor != 'coderabbitai' &&
       github.actor != 'gemini-code-assist[bot]' &&
+      github.actor != 'augment-code[bot]' &&
+      github.actor != 'augmentcode[bot]' &&
       github.actor != 'copilot[bot]' &&
       github.actor != 'github-actions[bot]' &&
       github.actor != 'dependabot[bot]'


### PR DESCRIPTION
## Summary

- Add job-level `if` conditions to skip workflow execution when the triggering actor is a known review bot (CodeRabbit, Gemini Code Assist, Augment, Copilot, GitHub Actions, Dependabot)
- For the Review Bot Gate, only filter `pull_request_review` events from bots (the `issue_comment` path from bots works fine and is the primary re-trigger mechanism)
- Also updates the `opencode-github-workflow.yml` template with the same fix

## Problem

GitHub requires manual approval for workflow runs triggered by bot accounts on `pull_request_review` and `pull_request_review_comment` events. When review bots post reviews, both workflows fire but get stuck at `action_required`, creating **87 stale status checks** across PRs. This causes the pulse to report PRs as FAIL/PENDING even when the code is mergeable.

## Root Cause

The `github.actor` for bot-triggered events is the bot account (e.g., `gemini-code-assist[bot]`). GitHub's security model requires manual approval for workflow runs from accounts without write access. The workflows had no actor filtering, so every bot review comment triggered a workflow run that immediately got stuck.

## Verification

- `issue_comment` events from bots do NOT cause `action_required` (confirmed: 0 action_required runs from issue_comment events)
- `pull_request_review` and `pull_request_review_comment` events from bots DO cause `action_required` (confirmed: 87 stale runs, all from these event types)
- The Review Bot Gate preserves the `issue_comment` trigger path from bots, ensuring the gate still re-evaluates when bots post their reviews as comments
- All YAML files validated syntactically

Closes #4002

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflows to prevent known review bots from triggering security checks and review gates.
  * Expanded and clarified the list of excluded bot accounts and refined gating logic to avoid bot-triggered workflow runs while preserving existing behavior for human-triggered events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->