### PR TITLE
GH#4011: Fix quality-debt in worker-watchdog.sh from PR #3919 review feedback

### DIFF
--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -145,7 +145,7 @@ find_workers() {
 
 		# Output: PID|ELAPSED|COMMAND
 		echo "${pid}|${elapsed_seconds}|${cmd}"
-	done < <(ps axo pid,command 2>/dev/null | grep "$grep_pattern" | grep '/full-loop' || true)
+	done < <(ps axo pid,command | grep "$grep_pattern" | grep '/full-loop' || true)
 
 	return 0
 }
@@ -202,7 +202,7 @@ extract_repo_slug() {
 
 	# Get remote URL and extract slug
 	local remote_url
-	remote_url=$(git -C "$worktree_dir" remote get-url origin 2>/dev/null) || remote_url=""
+	remote_url=$(git -C "$worktree_dir" remote get-url origin) || true
 
 	if [[ -z "$remote_url" ]]; then
 		echo ""
@@ -307,7 +307,7 @@ check_progress_stall() {
 				JOIN session s ON m.session_id = s.id
 				WHERE s.title LIKE '%${escaped_title}%'
 				AND m.created_at > datetime('now', '-${WORKER_PROGRESS_TIMEOUT} seconds')
-			" 2>/dev/null) || recent_count=0
+			" || echo 0)
 
 			if [[ "$recent_count" -gt 0 ]]; then
 				has_recent_activity=true


### PR DESCRIPTION
## Summary

- Fix 3 `set -e` incompatible error handling patterns and blanket `2>/dev/null` stderr suppression in `worker-watchdog.sh`, addressing all 4 findings from PR #3919 Gemini code review

## Changes

| # | Severity | Line | Fix |
|---|----------|------|-----|
| 1 | HIGH | 205 | `var=$(...) \|\| var=""` → `\|\| true` — prevents `set -e` exit on git failure; removed `2>/dev/null` |
| 2 | HIGH | 310 | `var=$(...) \|\| var=0` → `$(... \|\| echo 0)` — fallback inside subshell is `set -e` safe; removed `2>/dev/null` |
| 3 | MEDIUM | ~140 | Already addressed in original PR — code already uses parameter expansion |
| 4 | MEDIUM | 148 | Removed `2>/dev/null` from `ps` command — `\|\| true` already prevents exit |

## Verification

- `bash -n` syntax check: pass
- ShellCheck: clean (only SC1091 info for external sources)
- Single file touched: `.agents/scripts/worker-watchdog.sh`

Closes #4011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error visibility in background worker monitoring by surfacing previously suppressed system errors, enhancing troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->