### PR TITLE
fix: revert incorrect anomalyco removal, add explicit marcusquinn/aidevops slug

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -140,9 +140,10 @@ When referencing specific functions or code include the pattern `file_path:line_
 - If Glob fails with permission error, switch to `git ls-files` or `fd` immediately — do not retry Glob.
 - If Glob fails with "No such directory", verify the directory exists before searching inside it.
 #
-# 6. repo slug hallucination (observed: agent fabricated "anomalyco/" org prefix)
+# 6. repo slug hallucination (observed: agent used "anomalyco/aidevops" instead of "marcusquinn/aidevops")
 #    Root cause: repos.json had no slug field, so agents guessed org names from
-#    unrelated context (e.g., OpenCode's org). Now repos.json stores the slug.
+#    unrelated context (e.g., anomalyco is OpenCode's org, not ours). Now repos.json stores the slug.
+#    The aidevops repo slug is marcusquinn/aidevops. NEVER use anomalyco/aidevops.
 - ALWAYS resolve repo slugs from `~/.config/aidevops/repos.json` (the `slug` field). NEVER guess or construct `owner/repo` from memory.
 - If a repo has no slug in repos.json, resolve it from `git -C <path> remote get-url origin` and parse `owner/repo`.
 - For pulse/supervisor operations, filter repos.json to entries with `"pulse": true`.

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -1,4 +1,4 @@
-# Upstream base: opencode-ai/opencode anthropic.txt @ 3c41e4e8f12b
+# Upstream base: anomalyco/opencode anthropic.txt @ 3c41e4e8f12b
 # Overrides: file discovery, code search, git workflow, security, agent framework
 
 # Mission
@@ -140,11 +140,9 @@ When referencing specific functions or code include the pattern `file_path:line_
 - If Glob fails with permission error, switch to `git ls-files` or `fd` immediately — do not retry Glob.
 - If Glob fails with "No such directory", verify the directory exists before searching inside it.
 #
-# 6. repo slug hallucination (observed: agent fabricated wrong org prefix for repos)
+# 6. repo slug hallucination (observed: agent fabricated "anomalyco/" org prefix)
 #    Root cause: repos.json had no slug field, so agents guessed org names from
-#    unrelated context in the system prompt. Now repos.json stores the slug.
-#    Secondary cause: mentioning the wrong org name in this file gave the model
-#    a string to pattern-match against. Removed all such references.
+#    unrelated context (e.g., OpenCode's org). Now repos.json stores the slug.
 - ALWAYS resolve repo slugs from `~/.config/aidevops/repos.json` (the `slug` field). NEVER guess or construct `owner/repo` from memory.
 - If a repo has no slug in repos.json, resolve it from `git -C <path> remote get-url origin` and parse `owner/repo`.
 - For pulse/supervisor operations, filter repos.json to entries with `"pulse": true`.
@@ -292,7 +290,7 @@ Git is the primary audit trail for all work. Every change should be discoverable
 # Write-Time Quality Enforcement
 # Inspired by Plankton (github.com/alexfazio/plankton) — adapted for runtime-agnostic use.
 # Plankton uses Claude Code PostToolUse hooks to lint on every edit. OpenCode does not yet
-# have equivalent hooks (feature requested upstream). Until then, enforce via
+# have equivalent hooks (feature requested: anomalyco/opencode). Until then, enforce via
 # prompt-level discipline and explicit tool calls.
 #
 # Linter config protection (soft rule):

--- a/.agents/scripts/opencode-prompt-drift-check.sh
+++ b/.agents/scripts/opencode-prompt-drift-check.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 PROMPTS_DIR="$(cd "$SCRIPT_DIR/../prompts" && pwd)" || exit
 BUILD_TXT="$PROMPTS_DIR/build.txt"
 
-UPSTREAM_REPO="opencode-ai/opencode"
+UPSTREAM_REPO="anomalyco/opencode"
 UPSTREAM_BRANCH="dev"
 UPSTREAM_FILE="packages/opencode/src/session/prompt/anthropic.txt"
 
@@ -24,58 +24,58 @@ QUIET="${1:-}"
 
 # Extract our tracked commit hash from build.txt header
 get_local_hash() {
-	local hash
-	hash=$(head -1 "$BUILD_TXT" | grep -oE '[0-9a-f]{12}' || echo "")
-	echo "$hash"
+    local hash
+    hash=$(head -1 "$BUILD_TXT" | grep -oE '[0-9a-f]{12}' || echo "")
+    echo "$hash"
 }
 
 # Get latest commit hash for the upstream file
 get_upstream_hash() {
-	local response
-	response=$(curl -sf --max-time 10 \
-		"https://api.github.com/repos/${UPSTREAM_REPO}/commits?path=${UPSTREAM_FILE}&sha=${UPSTREAM_BRANCH}&per_page=1" \
-		-H "Accept: application/vnd.github.v3+json" 2>/dev/null) || return 1
+    local response
+    response=$(curl -sf --max-time 10 \
+        "https://api.github.com/repos/${UPSTREAM_REPO}/commits?path=${UPSTREAM_FILE}&sha=${UPSTREAM_BRANCH}&per_page=1" \
+        -H "Accept: application/vnd.github.v3+json" 2>/dev/null) || return 1
 
-	local hash
-	hash=$(echo "$response" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['sha'][:12])" 2>/dev/null) || return 1
-	echo "$hash"
+    local hash
+    hash=$(echo "$response" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0]['sha'][:12])" 2>/dev/null) || return 1
+    echo "$hash"
 }
 
 main() {
-	if [[ ! -f "$BUILD_TXT" ]]; then
-		[[ "$QUIET" != "--quiet" ]] && echo "ERROR: build.txt not found at $BUILD_TXT"
-		return 2
-	fi
+    if [[ ! -f "$BUILD_TXT" ]]; then
+        [[ "$QUIET" != "--quiet" ]] && echo "ERROR: build.txt not found at $BUILD_TXT"
+        return 2
+    fi
 
-	local local_hash
-	local_hash=$(get_local_hash)
-	if [[ -z "$local_hash" ]]; then
-		[[ "$QUIET" != "--quiet" ]] && echo "WARNING: No upstream hash found in build.txt header"
-		return 2
-	fi
+    local local_hash
+    local_hash=$(get_local_hash)
+    if [[ -z "$local_hash" ]]; then
+        [[ "$QUIET" != "--quiet" ]] && echo "WARNING: No upstream hash found in build.txt header"
+        return 2
+    fi
 
-	local upstream_hash
-	upstream_hash=$(get_upstream_hash) || {
-		[[ "$QUIET" != "--quiet" ]] && echo "WARNING: Could not fetch upstream commit (network issue?)"
-		return 2
-	}
+    local upstream_hash
+    upstream_hash=$(get_upstream_hash) || {
+        [[ "$QUIET" != "--quiet" ]] && echo "WARNING: Could not fetch upstream commit (network issue?)"
+        return 2
+    }
 
-	if [[ "$local_hash" == "$upstream_hash" ]]; then
-		[[ "$QUIET" != "--quiet" ]] && echo "OK: build.txt is in sync with upstream ($local_hash)"
-		return 0
-	else
-		if [[ "$QUIET" == "--quiet" ]]; then
-			echo "PROMPT_DRIFT|${local_hash}|${upstream_hash}"
-		else
-			echo "DRIFT DETECTED: upstream prompt has changed"
-			echo "  Local:    $local_hash"
-			echo "  Upstream: $upstream_hash"
-			echo ""
-			echo "  View diff: https://github.com/${UPSTREAM_REPO}/compare/${local_hash}...${upstream_hash}"
-			echo "  To update: review changes and update .agents/prompts/build.txt"
-		fi
-		return 1
-	fi
+    if [[ "$local_hash" == "$upstream_hash" ]]; then
+        [[ "$QUIET" != "--quiet" ]] && echo "OK: build.txt is in sync with upstream ($local_hash)"
+        return 0
+    else
+        if [[ "$QUIET" == "--quiet" ]]; then
+            echo "PROMPT_DRIFT|${local_hash}|${upstream_hash}"
+        else
+            echo "DRIFT DETECTED: upstream prompt has changed"
+            echo "  Local:    $local_hash"
+            echo "  Upstream: $upstream_hash"
+            echo ""
+            echo "  View diff: https://github.com/${UPSTREAM_REPO}/compare/${local_hash}...${upstream_hash}"
+            echo "  To update: review changes and update .agents/prompts/build.txt"
+        fi
+        return 1
+    fi
 }
 
 main "$@"

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -195,7 +195,7 @@ mcp_requirements:
 ---
 ```
 
-This convention documents which specific tools an agent needs from an MCP server. Currently informational only - OpenCode doesn't yet support `includeTools` filtering (see [OpenCode #7399](https://github.com/opencode-ai/opencode/issues/7399)). When supported, our agent generator can use this to configure filtered MCP access.
+This convention documents which specific tools an agent needs from an MCP server. Currently informational only - OpenCode doesn't yet support `includeTools` filtering (see [OpenCode #7399](https://github.com/anomalyco/opencode/issues/7399)). When supported, our agent generator can use this to configure filtered MCP access.
 
 **Why document MCP requirements?**
 - Prepares agents for future `includeTools` support

--- a/.agents/tools/context/mcp-discovery.md
+++ b/.agents/tools/context/mcp-discovery.md
@@ -293,7 +293,7 @@ The savings compound over a conversation as context accumulates.
 
 ## Future: OpenCode includeTools Support
 
-When OpenCode implements `includeTools` filtering ([#7399](https://github.com/opencode-ai/opencode/issues/7399)), agents can specify exactly which tools they need:
+When OpenCode implements `includeTools` filtering ([#7399](https://github.com/anomalyco/opencode/issues/7399)), agents can specify exactly which tools they need:
 
 ```yaml
 ---

--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -20,7 +20,7 @@ tools:
 
 - **Purpose**: OAuth authentication for Claude Pro/Max accounts in OpenCode
 - **Status**: **DEPRECATED** — built into OpenCode v1.1.36+, do not install as external plugin
-- **Repository**: https://github.com/opencode-ai/opencode-anthropic-auth
+- **Repository**: https://github.com/anomalyco/opencode-anthropic-auth
 - **Installation**: Built-in to OpenCode v1.1.36+ (no installation needed)
 
 **Authentication Methods**:
@@ -424,7 +424,7 @@ aidevops follows OpenCode's credential storage:
 
 - **0.0.9** (latest): Current version in repository
   - **DEPRECATED** — functionality now built into OpenCode v1.1.36+
-  - Maintained by OpenCode (opencode-ai)
+  - Maintained by Anomaly (anomalyco)
   - Dependencies: `@opencode-ai/plugin`, `@openauthjs/openauth`
 - **0.0.8**: Updated dependencies and compatibility
   - Updated from `@openauthjs/openauth@^0.4.3` to latest
@@ -436,7 +436,7 @@ aidevops follows OpenCode's credential storage:
 
 ## References
 
-- **Plugin Repository**: https://github.com/opencode-ai/opencode-anthropic-auth
+- **Plugin Repository**: https://github.com/anomalyco/opencode-anthropic-auth
 - **OpenCode Plugins**: https://opencode.ai/docs/plugins
 - **Anthropic OAuth**: https://docs.anthropic.com/en/api/oauth
 - **OpenAuth Library**: https://openauth.js.org/

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -47,7 +47,7 @@ check_opencode_prompt_drift() {
 			local_hash=$(echo "$output" | cut -d'|' -f2)
 			upstream_hash=$(echo "$output" | cut -d'|' -f3)
 			print_warning "OpenCode upstream prompt has changed (${local_hash} → ${upstream_hash})"
-			print_info "  Review: https://github.com/opencode-ai/opencode/compare/${local_hash}...${upstream_hash}"
+			print_info "  Review: https://github.com/anomalyco/opencode/compare/${local_hash}...${upstream_hash}"
 			print_info "  Update .agents/prompts/build.txt if needed"
 		elif [[ "$exit_code" -eq 0 ]]; then
 			print_success "OpenCode prompt in sync with upstream"


### PR DESCRIPTION
## Summary

- Reverts PR #3999 which incorrectly replaced `anomalyco/opencode` references — that's the correct org for OpenCode, not a hallucination
- The actual problem: the error prevention comment in `build.txt` warned about the wrong slug but never stated the **correct** one (`marcusquinn/aidevops`)
- Now explicitly states `The aidevops repo slug is marcusquinn/aidevops. NEVER use anomalyco/aidevops.`
- Gives the model a positive anchor (correct answer) rather than just a negative warning

**Net change:** 3 lines in `build.txt` — the comment now has the correct slug and a clear prohibition.