### PR TITLE
GH#4006: Harden shell injection defenses in tools.mjs

### DIFF
--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -197,13 +197,15 @@ const VALID_HOOK_ACTIONS = new Set(["install", "uninstall", "status", "test"]);
  * @returns {string}
  */
 function runHookHelper(helperScript, action) {
-  const safeAction = String(action);
-  if (!VALID_HOOK_ACTIONS.has(safeAction)) {
-    return `Invalid action: ${safeAction}. Valid actions: ${[...VALID_HOOK_ACTIONS].join(", ")}`;
+  // Look up the action in the allowlist — returns an allowlist-owned string,
+  // breaking the taint chain from the function parameter to execSync.
+  const validAction = [...VALID_HOOK_ACTIONS].find((a) => a === String(action));
+  if (!validAction) {
+    return `Invalid action: ${String(action)}. Valid actions: ${[...VALID_HOOK_ACTIONS].join(", ")}`;
   }
   try {
     const result = execSync(
-      `bash "${helperScript}" ${safeAction}`,
+      `bash "${helperScript}" ${validAction}`,
       {
         encoding: "utf-8",
         timeout: 15000,
@@ -213,7 +215,7 @@ function runHookHelper(helperScript, action) {
     return result.trim();
   } catch (err) {
     const cmdOutput = (err.stdout || "") + (err.stderr || "");
-    return `Hook ${safeAction} failed:\n${cmdOutput.trim()}`;
+    return `Hook ${validAction} failed:\n${cmdOutput.trim()}`;
   }
 }
 

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -42,6 +42,18 @@ function createMemoryTool({ scriptsDir, run, action, description, buildArgs }) {
 }
 
 /**
+ * Validate that a CLI command string contains only safe characters.
+ * Allows alphanumeric, spaces, hyphens, underscores, dots, forward slashes,
+ * and colons — sufficient for all aidevops subcommands and file path arguments.
+ * Rejects shell metacharacters ($, `, ;, |, &, (, ), etc.).
+ * @param {string} command
+ * @returns {boolean}
+ */
+function isSafeCommand(command) {
+  return /^[a-zA-Z0-9 _\-./:#@]+$/.test(command);
+}
+
+/**
  * Create the aidevops CLI tool.
  * @param {function} run - Shell command runner
  * @returns {object} Tool definition
@@ -51,7 +63,11 @@ function createAidevopsTool(run) {
     description:
       'Run aidevops CLI commands (status, repos, features, secret, etc.). Pass command as string e.g. "status", "repos", "features"',
     async execute(args) {
-      const cmd = `aidevops ${args.command || args}`;
+      const rawCmd = String(args.command || args);
+      if (!isSafeCommand(rawCmd)) {
+        return `Error: command contains disallowed characters. Only alphanumeric, spaces, hyphens, underscores, dots, slashes, colons, # and @ are permitted.`;
+      }
+      const cmd = `aidevops ${rawCmd}`;
       const result = run(cmd, 15000);
       return result || `Command completed: ${cmd}`;
     },
@@ -79,7 +95,7 @@ function createPreEditCheckTool(scriptsDir) {
         return "pre-edit-check.sh not found — cannot verify git safety";
       }
       const taskFlag = args.task
-        ? ` --loop-mode --task "${args.task}"`
+        ? ` --loop-mode --task ${shellEscape(args.task)}`
         : "";
       try {
         const result = execSync(`bash "${script}"${taskFlag}`, {
@@ -171,6 +187,9 @@ function createQualityCheckTool(scriptsDir, pipelines) {
   };
 }
 
+/** Valid actions for the install-hooks-helper.sh script. */
+const VALID_HOOK_ACTIONS = new Set(["install", "uninstall", "status", "test"]);
+
 /**
  * Run the install-hooks-helper.sh script.
  * @param {string} helperScript
@@ -178,9 +197,13 @@ function createQualityCheckTool(scriptsDir, pipelines) {
  * @returns {string}
  */
 function runHookHelper(helperScript, action) {
+  const safeAction = String(action);
+  if (!VALID_HOOK_ACTIONS.has(safeAction)) {
+    return `Invalid action: ${safeAction}. Valid actions: ${[...VALID_HOOK_ACTIONS].join(", ")}`;
+  }
   try {
     const result = execSync(
-      `bash "${helperScript}" ${action}`,
+      `bash "${helperScript}" ${safeAction}`,
       {
         encoding: "utf-8",
         timeout: 15000,
@@ -190,7 +213,7 @@ function runHookHelper(helperScript, action) {
     return result.trim();
   } catch (err) {
     const cmdOutput = (err.stdout || "") + (err.stderr || "");
-    return `Hook ${action} failed:\n${cmdOutput.trim()}`;
+    return `Hook ${safeAction} failed:\n${cmdOutput.trim()}`;
   }
 }
 

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -187,8 +187,17 @@ function createQualityCheckTool(scriptsDir, pipelines) {
   };
 }
 
-/** Valid actions for the install-hooks-helper.sh script. */
-const VALID_HOOK_ACTIONS = new Set(["install", "uninstall", "status", "test"]);
+/**
+ * Allowlist map for install-hooks-helper.sh actions.
+ * Object-literal lookup severs the taint chain — the value returned is from
+ * this constant, not derived from the caller's input.
+ */
+const HOOK_ACTION_MAP = {
+  install: "install",
+  uninstall: "uninstall",
+  status: "status",
+  test: "test",
+};
 
 /**
  * Run the install-hooks-helper.sh script.
@@ -197,11 +206,11 @@ const VALID_HOOK_ACTIONS = new Set(["install", "uninstall", "status", "test"]);
  * @returns {string}
  */
 function runHookHelper(helperScript, action) {
-  // Look up the action in the allowlist — returns an allowlist-owned string,
-  // breaking the taint chain from the function parameter to execSync.
-  const validAction = [...VALID_HOOK_ACTIONS].find((a) => a === String(action));
+  // Object-property lookup returns a string owned by HOOK_ACTION_MAP,
+  // completely severing the taint chain from the function parameter.
+  const validAction = HOOK_ACTION_MAP[String(action)];
   if (!validAction) {
-    return `Invalid action: ${String(action)}. Valid actions: ${[...VALID_HOOK_ACTIONS].join(", ")}`;
+    return `Invalid action: ${String(action)}. Valid actions: ${Object.keys(HOOK_ACTION_MAP).join(", ")}`;
   }
   try {
     const result = execSync(

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -188,18 +188,27 @@ function createQualityCheckTool(scriptsDir, pipelines) {
 }
 
 /**
- * Allowlist map for install-hooks-helper.sh actions.
- * Object.create(null) eliminates the prototype chain, preventing inherited
- * properties (toString, constructor, __proto__) from bypassing validation.
- * Object-literal lookup severs the taint chain — the value returned is from
- * this constant, not derived from the caller's input.
+ * Sanitize a hook action string into a known-safe literal.
+ * Uses a switch statement so static taint analyzers (Codacy/Semgrep) can
+ * prove the returned value is a constant — completely severing the data flow
+ * from the function parameter to the shell command. Object-property lookups
+ * and Array.find() do not satisfy Semgrep's taint tracking because the
+ * analyzer cannot prove the returned value is independent of the input.
+ * @param {string} action - Raw action string from caller
+ * @returns {string|undefined} Sanitized action literal, or undefined if invalid
  */
-const HOOK_ACTION_MAP = Object.freeze(Object.assign(Object.create(null), {
-  install: "install",
-  uninstall: "uninstall",
-  status: "status",
-  test: "test",
-}));
+function sanitizeHookAction(action) {
+  switch (String(action)) {
+    case "install": return "install";
+    case "uninstall": return "uninstall";
+    case "status": return "status";
+    case "test": return "test";
+    default: return undefined;
+  }
+}
+
+/** Valid hook actions for display in error messages. */
+const VALID_HOOK_ACTIONS = ["install", "uninstall", "status", "test"];
 
 /**
  * Run the install-hooks-helper.sh script.
@@ -208,16 +217,9 @@ const HOOK_ACTION_MAP = Object.freeze(Object.assign(Object.create(null), {
  * @returns {string}
  */
 function runHookHelper(helperScript, action) {
-  // Own-property check + lookup returns a string owned by HOOK_ACTION_MAP,
-  // completely severing the taint chain from the function parameter.
-  // Object.hasOwn guards against any inherited properties even if
-  // Object.create(null) is accidentally reverted.
-  const actionKey = String(action);
-  const validAction = Object.hasOwn(HOOK_ACTION_MAP, actionKey)
-    ? HOOK_ACTION_MAP[actionKey]
-    : undefined;
+  const validAction = sanitizeHookAction(action);
   if (!validAction) {
-    return `Invalid action: ${String(action)}. Valid actions: ${Object.keys(HOOK_ACTION_MAP).join(", ")}`;
+    return `Invalid action: ${String(action)}. Valid actions: ${VALID_HOOK_ACTIONS.join(", ")}`;
   }
   try {
     const result = execSync(

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -44,7 +44,7 @@ function createMemoryTool({ scriptsDir, run, action, description, buildArgs }) {
 /**
  * Validate that a CLI command string contains only safe characters.
  * Allows alphanumeric, spaces, hyphens, underscores, dots, forward slashes,
- * and colons — sufficient for all aidevops subcommands and file path arguments.
+ * colons, hash signs (#), and at-signs (@) — sufficient for all aidevops subcommands and file path arguments.
  * Rejects shell metacharacters ($, `, ;, |, &, (, ), etc.).
  * @param {string} command
  * @returns {boolean}

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
 
@@ -212,8 +212,12 @@ const VALID_HOOK_ACTIONS = ["install", "uninstall", "status", "test"];
 
 /**
  * Run the install-hooks-helper.sh script.
- * @param {string} helperScript
- * @param {string} action
+ * Uses execFileSync with argument array instead of execSync with string
+ * interpolation — eliminates shell interpretation entirely, which is both
+ * more secure and satisfies static taint analyzers (Codacy/Semgrep) that
+ * flag parameter-to-child_process data flows in execSync template strings.
+ * @param {string} helperScript - Path to the helper script
+ * @param {string} action - Hook action to run
  * @returns {string}
  */
 function runHookHelper(helperScript, action) {
@@ -222,14 +226,11 @@ function runHookHelper(helperScript, action) {
     return `Invalid action: ${String(action)}. Valid actions: ${VALID_HOOK_ACTIONS.join(", ")}`;
   }
   try {
-    const result = execSync(
-      `bash "${helperScript}" ${validAction}`,
-      {
-        encoding: "utf-8",
-        timeout: 15000,
-        stdio: ["pipe", "pipe", "pipe"],
-      },
-    );
+    const result = execFileSync("bash", [helperScript, validAction], {
+      encoding: "utf-8",
+      timeout: 15000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
     return result.trim();
   } catch (err) {
     const cmdOutput = (err.stdout || "") + (err.stderr || "");

--- a/.agents/plugins/opencode-aidevops/tools.mjs
+++ b/.agents/plugins/opencode-aidevops/tools.mjs
@@ -189,15 +189,17 @@ function createQualityCheckTool(scriptsDir, pipelines) {
 
 /**
  * Allowlist map for install-hooks-helper.sh actions.
+ * Object.create(null) eliminates the prototype chain, preventing inherited
+ * properties (toString, constructor, __proto__) from bypassing validation.
  * Object-literal lookup severs the taint chain — the value returned is from
  * this constant, not derived from the caller's input.
  */
-const HOOK_ACTION_MAP = {
+const HOOK_ACTION_MAP = Object.freeze(Object.assign(Object.create(null), {
   install: "install",
   uninstall: "uninstall",
   status: "status",
   test: "test",
-};
+}));
 
 /**
  * Run the install-hooks-helper.sh script.
@@ -206,9 +208,14 @@ const HOOK_ACTION_MAP = {
  * @returns {string}
  */
 function runHookHelper(helperScript, action) {
-  // Object-property lookup returns a string owned by HOOK_ACTION_MAP,
+  // Own-property check + lookup returns a string owned by HOOK_ACTION_MAP,
   // completely severing the taint chain from the function parameter.
-  const validAction = HOOK_ACTION_MAP[String(action)];
+  // Object.hasOwn guards against any inherited properties even if
+  // Object.create(null) is accidentally reverted.
+  const actionKey = String(action);
+  const validAction = Object.hasOwn(HOOK_ACTION_MAP, actionKey)
+    ? HOOK_ACTION_MAP[actionKey]
+    : undefined;
   if (!validAction) {
     return `Invalid action: ${String(action)}. Valid actions: ${Object.keys(HOOK_ACTION_MAP).join(", ")}`;
   }


### PR DESCRIPTION
## Summary

- **Harden `createAidevopsTool`**: `args.command` was interpolated directly into a shell command string. Added `isSafeCommand()` allowlist validator that rejects shell metacharacters (`$`, backtick, `;`, `|`, `&`, etc.) while permitting all valid aidevops subcommand characters.
- **Fix `createPreEditCheckTool`**: `args.task` used double-quote interpolation (`"${args.task}"`) which allows `$(cmd)` and backtick expansion. Replaced with `shellEscape()` (single-quote wrapping).
- **Harden `runHookHelper`**: `action` parameter was passed unsanitized to `execSync`. Added `VALID_HOOK_ACTIONS` Set allowlist validation — only `install`, `uninstall`, `status`, `test` are accepted.

These are three additional shell injection vectors in the same file beyond the two flagged by Gemini in PR #3975 (which were already fixed via `shellEscape()` on memory tool args).

Closes #4006

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of CLI commands to block unsafe input and prevent injection.
  * Added escaping for task arguments to ensure safer command execution.
  * Enforced a whitelist of allowed hook actions (install, uninstall, status, test) with clearer error messages for invalid actions.
  * Applied consistent safety checks across all tooling paths for more reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->