### PR TITLE
chore: address PR #4020 review bot suggestions

### DIFF
--- a/.agents/scripts/contributor-activity-helper.sh
+++ b/.agents/scripts/contributor-activity-helper.sh
@@ -633,7 +633,7 @@ else:
 	") || query_result="[]"
 
 	# t1427: sqlite3 -json returns "" (not "[]") when no rows match.
-	if [[ -z "$query_result" || "${query_result:0:1}" != "[" ]]; then
+	if [[ "$query_result" != "["* ]]; then
 		query_result="[]"
 	fi
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1962,7 +1962,6 @@ ${worker_table}"
 		session_time_md="_Activity helper not installed._"
 	fi
 	# t1426: person-stats from hourly cache (see _refresh_person_stats_cache)
-	local slug_safe="${repo_slug//\//-}"
 	local ps_cache="${PERSON_STATS_CACHE_DIR}/person-stats-cache-${slug_safe}.md"
 	if [[ -f "$ps_cache" ]]; then
 		person_stats_md=$(cat "$ps_cache")


### PR DESCRIPTION
## Summary

- Simplify JSON array validation check in `contributor-activity-helper.sh` to a single glob match `[[ "$query_result" != "["* ]]` (Gemini suggestion -- functionally equivalent, more concise)
- Remove redundant `slug_safe` variable redefinition in `pulse-wrapper.sh` `_update_health_issue_for_repo()` -- reuses the one already defined earlier in the same function (CodeRabbit nitpick)

**Dismissed:** Gemini's DRY helper function suggestion for rate limit checks -- the original duplication was already eliminated in c044f237; remaining checks are in different contexts with different comparison values.

Follow-up to #4020.