### PR TITLE
t1424: Zero-config localdev — auto-register projects and localdev run wrapper

### DIFF
--- a/.agents/scripts/localdev-helper.sh
+++ b/.agents/scripts/localdev-helper.sh
@@ -388,6 +388,64 @@ restart_traefik_if_running() {
 }
 
 # =============================================================================
+# Project Name Inference
+# =============================================================================
+# Infer a localdev-compatible project name from the current directory.
+# Priority: 1) package.json "name" field, 2) git repo basename.
+# Sanitises to lowercase alphanumeric + hyphens (localdev add requirement).
+
+# Infer project name from the current directory or a given path.
+# Outputs a sanitised name suitable for localdev add.
+infer_project_name() {
+	local dir="${1:-.}"
+	local name=""
+
+	# Try package.json "name" field first (most explicit signal)
+	if [[ -f "$dir/package.json" ]]; then
+		if command -v jq >/dev/null 2>&1; then
+			name="$(jq -r '.name // empty' "$dir/package.json" 2>/dev/null)"
+		else
+			# Fallback: grep-based extraction
+			name="$(grep -m1 '"name"' "$dir/package.json" 2>/dev/null | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+		fi
+		# Strip npm scope prefix (@org/name -> name)
+		name="${name##*/}"
+	fi
+
+	# Fallback: git repo basename (strip worktree suffix)
+	if [[ -z "$name" ]]; then
+		local repo_root=""
+		if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+			repo_root="$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)"
+		fi
+		if [[ -n "$repo_root" ]]; then
+			name="$(basename "$repo_root")"
+			# If this is a worktree, get the main repo name
+			if [[ -f "$repo_root/.git" ]]; then
+				local main_worktree
+				main_worktree="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null | head -1 | cut -d' ' -f2-)"
+				if [[ -n "$main_worktree" ]]; then
+					name="$(basename "$main_worktree")"
+				fi
+			fi
+		else
+			# Last resort: directory basename
+			name="$(basename "$(cd "$dir" && pwd)")"
+		fi
+	fi
+
+	# Sanitise: lowercase, replace non-alphanumeric with hyphens, collapse, trim
+	name="$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//')"
+
+	if [[ -z "$name" ]]; then
+		return 1
+	fi
+
+	echo "$name"
+	return 0
+}
+
+# =============================================================================
 # Port Registry Helpers
 # =============================================================================
 # Port registry: ~/.local-dev-proxy/ports.json
@@ -860,6 +918,190 @@ cmd_add() {
 	print_info "  Route:   $CONFD_DIR/${name}.yml"
 	print_info "  Registry: $PORTS_FILE"
 	return 0
+}
+
+# =============================================================================
+# Run Command — Zero-config dev server wrapper
+# =============================================================================
+# Wraps a dev command (e.g., npm run dev) with automatic:
+#   1. Project registration (if not already registered)
+#   2. Port resolution (main or branch)
+#   3. PORT/HOST env var injection
+#   4. Signal passthrough (SIGINT/SIGTERM forwarded to child)
+#
+# Usage: localdev run [options] <command...>
+#   Options:
+#     --name <name>   Override inferred project name
+#     --port <port>   Override auto-assigned port
+#     --no-host       Don't set HOST=0.0.0.0
+#
+# Examples:
+#   localdev run npm run dev
+#   localdev run --name myapp pnpm dev
+#   localdev run bun run dev
+
+cmd_run() {
+	local name_override=""
+	local port_override=""
+	local set_host=1
+	local cmd_args=()
+
+	# Parse options before the command
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--name)
+			name_override="${2:-}"
+			if [[ -z "$name_override" ]]; then
+				print_error "Usage: localdev run --name <name> <command...>"
+				return 1
+			fi
+			shift 2
+			;;
+		--port)
+			port_override="${2:-}"
+			if [[ -z "$port_override" ]]; then
+				print_error "Usage: localdev run --port <port> <command...>"
+				return 1
+			fi
+			shift 2
+			;;
+		--no-host)
+			set_host=0
+			shift
+			;;
+		--)
+			shift
+			cmd_args+=("$@")
+			break
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			print_info "Usage: localdev run [--name <name>] [--port <port>] [--no-host] <command...>"
+			return 1
+			;;
+		*)
+			cmd_args+=("$@")
+			break
+			;;
+		esac
+	done
+
+	if [[ ${#cmd_args[@]} -eq 0 ]]; then
+		print_error "Usage: localdev run [options] <command...>"
+		print_info ""
+		print_info "Wraps a dev command with automatic project registration and port injection."
+		print_info ""
+		print_info "Examples:"
+		print_info "  localdev run npm run dev"
+		print_info "  localdev run --name myapp pnpm dev"
+		print_info "  localdev run bun run dev"
+		print_info ""
+		print_info "Options:"
+		print_info "  --name <name>   Override inferred project name"
+		print_info "  --port <port>   Override auto-assigned port"
+		print_info "  --no-host       Don't set HOST=0.0.0.0"
+		return 1
+	fi
+
+	# Step 1: Determine project name
+	local name=""
+	if [[ -n "$name_override" ]]; then
+		name="$name_override"
+	else
+		name="$(infer_project_name ".")" || {
+			print_error "Cannot infer project name from current directory"
+			print_info "  Use --name <name> to specify explicitly"
+			return 1
+		}
+	fi
+
+	# Step 2: Detect if we're in a worktree (branch context)
+	local is_worktree=0
+	local branch_name=""
+	if [[ -f ".git" ]]; then
+		is_worktree=1
+		branch_name="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+	fi
+
+	# Step 3: Auto-register if not already registered
+	if ! is_app_registered "$name"; then
+		print_info "Project '$name' not registered — auto-registering..."
+		echo ""
+
+		if [[ -n "$port_override" ]]; then
+			cmd_add "$name" "$port_override"
+		else
+			cmd_add "$name"
+		fi
+
+		local add_exit=$?
+		if [[ "$add_exit" -ne 0 ]]; then
+			print_error "Auto-registration failed for '$name'"
+			return 1
+		fi
+		echo ""
+	fi
+
+	# Step 4: Resolve the correct port
+	local port=""
+	if [[ -n "$port_override" ]]; then
+		port="$port_override"
+	elif [[ "$is_worktree" -eq 1 ]] && [[ -n "$branch_name" ]] && [[ "$branch_name" != "main" ]] && [[ "$branch_name" != "master" ]]; then
+		# In a worktree on a feature branch — check for branch port
+		local sanitised_branch
+		sanitised_branch="$(sanitise_branch_name "$branch_name")"
+		if is_branch_registered "$name" "$sanitised_branch"; then
+			port="$(get_branch_port "$name" "$sanitised_branch")"
+			print_info "Using branch port: $port (${sanitised_branch}.${name}.local)"
+		else
+			# Auto-create branch route
+			print_info "Creating branch route for $sanitised_branch..."
+			cmd_branch "$name" "$branch_name"
+			port="$(get_branch_port "$name" "$sanitised_branch")"
+			if [[ -z "$port" ]]; then
+				# Fallback to main port if branch registration failed
+				port="$(get_app_port "$name")"
+				print_warning "Branch route creation failed — using main port: $port"
+			else
+				print_info "Using branch port: $port (${sanitised_branch}.${name}.local)"
+			fi
+		fi
+	else
+		# Main repo — use the app's main port
+		port="$(get_app_port "$name")"
+	fi
+
+	if [[ -z "$port" ]]; then
+		print_error "Cannot determine port for '$name'"
+		return 1
+	fi
+
+	# Step 5: Build the environment and exec
+	local domain="${name}.local"
+	if [[ "$is_worktree" -eq 1 ]] && [[ -n "$branch_name" ]] && [[ "$branch_name" != "main" ]] && [[ "$branch_name" != "master" ]]; then
+		local sanitised
+		sanitised="$(sanitise_branch_name "$branch_name")"
+		domain="${sanitised}.${name}.local"
+	fi
+
+	echo ""
+	print_success "localdev run: $name"
+	print_info "  URL:     https://$domain"
+	print_info "  PORT:    $port"
+	if [[ "$set_host" -eq 1 ]]; then
+		print_info "  HOST:    0.0.0.0"
+	fi
+	print_info "  Command: ${cmd_args[*]}"
+	echo ""
+
+	# Export PORT and optionally HOST, then exec the command
+	# exec replaces this process — signals go directly to the child
+	export PORT="$port"
+	if [[ "$set_host" -eq 1 ]]; then
+		export HOST="0.0.0.0"
+	fi
+
+	exec "${cmd_args[@]}"
 }
 
 # =============================================================================
@@ -2279,6 +2521,7 @@ cmd_help() {
 	echo "Usage: localdev-helper.sh <command> [options]"
 	echo ""
 	echo "Commands:"
+	echo "  run <command...>   Zero-config: auto-register + inject PORT + exec command"
 	echo "  init               One-time setup: dnsmasq, resolver, Traefik conf.d migration"
 	echo "  add <name> [port]  Register app: cert + Traefik route + port registry"
 	echo "  rm <name>          Remove app: reverses all add operations (incl. branches)"
@@ -2289,6 +2532,13 @@ cmd_help() {
 	echo "  list               Dashboard: all projects, URLs, certs, health, LocalWP"
 	echo "  status             Infrastructure health: dnsmasq, Traefik, certs, ports"
 	echo "  help               Show this help message"
+	echo ""
+	echo "Run performs (zero-config):"
+	echo "  1. Infer project name from package.json or git repo basename"
+	echo "  2. Auto-register if not already registered (cert, route, port, /etc/hosts)"
+	echo "  3. Detect worktree/branch and create branch subdomain if needed"
+	echo "  4. Set PORT and HOST=0.0.0.0 environment variables"
+	echo "  5. Exec the command (signals pass through directly)"
 	echo ""
 	echo "Add performs:"
 	echo "  1. Collision detection (LocalWP, registry, port)"
@@ -2333,6 +2583,10 @@ main() {
 	case "$command" in
 	init)
 		cmd_init
+		;;
+	run)
+		shift
+		cmd_run "$@"
 		;;
 	add)
 		shift

--- a/.agents/scripts/localdev-helper.sh
+++ b/.agents/scripts/localdev-helper.sh
@@ -959,8 +959,8 @@ cmd_run() {
 			;;
 		--port)
 			port_override="${2:-}"
-			if [[ -z "$port_override" ]]; then
-				print_error "Usage: localdev run --port <port> <command...>"
+			if [[ ! "$port_override" =~ ^[0-9]+$ ]]; then
+				print_error "Invalid port: ${port_override:-<empty>} (must be numeric)"
 				return 1
 			fi
 			shift 2
@@ -1006,7 +1006,12 @@ cmd_run() {
 	# Step 1: Determine project name
 	local name=""
 	if [[ -n "$name_override" ]]; then
-		name="$name_override"
+		# Sanitise: lowercase, replace non-alphanumeric with hyphens, collapse, trim
+		name="$(echo "$name_override" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//')"
+		if [[ -z "$name" ]]; then
+			print_error "Invalid project name after sanitisation: $name_override"
+			return 1
+		fi
 	else
 		name="$(infer_project_name ".")" || {
 			print_error "Cannot infer project name from current directory"
@@ -1018,9 +1023,13 @@ cmd_run() {
 	# Step 2: Detect if we're in a worktree (branch context)
 	local is_worktree=0
 	local branch_name=""
+	local is_feature_branch=0
 	if [[ -f ".git" ]]; then
 		is_worktree=1
 		branch_name="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+		if [[ -n "$branch_name" ]] && [[ "$branch_name" != "main" ]] && [[ "$branch_name" != "master" ]]; then
+			is_feature_branch=1
+		fi
 	fi
 
 	# Step 3: Auto-register if not already registered
@@ -1046,7 +1055,7 @@ cmd_run() {
 	local port=""
 	if [[ -n "$port_override" ]]; then
 		port="$port_override"
-	elif [[ "$is_worktree" -eq 1 ]] && [[ -n "$branch_name" ]] && [[ "$branch_name" != "main" ]] && [[ "$branch_name" != "master" ]]; then
+	elif [[ "$is_feature_branch" -eq 1 ]]; then
 		# In a worktree on a feature branch — check for branch port
 		local sanitised_branch
 		sanitised_branch="$(sanitise_branch_name "$branch_name")"
@@ -1078,7 +1087,7 @@ cmd_run() {
 
 	# Step 5: Build the environment and exec
 	local domain="${name}.local"
-	if [[ "$is_worktree" -eq 1 ]] && [[ -n "$branch_name" ]] && [[ "$branch_name" != "main" ]] && [[ "$branch_name" != "master" ]]; then
+	if [[ "$is_feature_branch" -eq 1 ]]; then
 		local sanitised
 		sanitised="$(sanitise_branch_name "$branch_name")"
 		domain="${sanitised}.${name}.local"
@@ -2609,6 +2618,11 @@ main() {
 		;;
 	status)
 		cmd_status
+		;;
+	infer-name)
+		# Internal: infer project name for a directory (used by worktree-helper.sh)
+		shift
+		infer_project_name "${1:-.}"
 		;;
 	help | -h | --help | "")
 		cmd_help

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -100,10 +100,45 @@ detect_localdev_project() {
 
 # Auto-create localdev branch route after worktree creation.
 # Called from cmd_add after successful worktree creation.
+# If the project is not registered, auto-registers it first (t1424.1).
 localdev_auto_branch() {
 	local branch="$1"
 	local project
-	project="$(detect_localdev_project)" || return 0
+
+	# Check if localdev-helper.sh exists
+	[[ ! -x "$LOCALDEV_HELPER" ]] && return 0
+
+	if ! project="$(detect_localdev_project)" || [[ -z "$project" ]]; then
+		# Project not registered — try to auto-register (t1424.1)
+		# Source infer_project_name from localdev-helper.sh
+		local inferred_name=""
+		local repo_root
+		repo_root="$(get_repo_root)"
+		[[ -z "$repo_root" ]] && return 0
+
+		# Infer name: try package.json first, then repo basename
+		if [[ -f "$repo_root/package.json" ]] && command -v jq >/dev/null 2>&1; then
+			inferred_name="$(jq -r '.name // empty' "$repo_root/package.json" 2>/dev/null)"
+			# Strip npm scope prefix (@org/name -> name)
+			inferred_name="${inferred_name##*/}"
+		fi
+		if [[ -z "$inferred_name" ]]; then
+			inferred_name="$(basename "$repo_root")"
+		fi
+		# Sanitise for DNS
+		inferred_name="$(echo "$inferred_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//')"
+
+		[[ -z "$inferred_name" ]] && return 0
+
+		echo ""
+		echo -e "${BLUE}Localdev integration: auto-registering project '$inferred_name'...${NC}"
+		if "$LOCALDEV_HELPER" add "$inferred_name" 2>&1; then
+			project="$inferred_name"
+		else
+			echo -e "${YELLOW}Localdev auto-registration failed (non-fatal)${NC}"
+			return 0
+		fi
+	fi
 
 	echo ""
 	echo -e "${BLUE}Localdev integration: creating branch route for $project...${NC}"

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -110,24 +110,9 @@ localdev_auto_branch() {
 
 	if ! project="$(detect_localdev_project)" || [[ -z "$project" ]]; then
 		# Project not registered — try to auto-register (t1424.1)
-		# Source infer_project_name from localdev-helper.sh
+		# Delegate name inference to localdev-helper.sh to avoid logic duplication
 		local inferred_name=""
-		local repo_root
-		repo_root="$(get_repo_root)"
-		[[ -z "$repo_root" ]] && return 0
-
-		# Infer name: try package.json first, then repo basename
-		if [[ -f "$repo_root/package.json" ]] && command -v jq >/dev/null 2>&1; then
-			inferred_name="$(jq -r '.name // empty' "$repo_root/package.json" 2>/dev/null)"
-			# Strip npm scope prefix (@org/name -> name)
-			inferred_name="${inferred_name##*/}"
-		fi
-		if [[ -z "$inferred_name" ]]; then
-			inferred_name="$(basename "$repo_root")"
-		fi
-		# Sanitise for DNS
-		inferred_name="$(echo "$inferred_name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/--*/-/g; s/^-//; s/-$//')"
-
+		inferred_name="$("$LOCALDEV_HELPER" infer-name "$(get_repo_root)" 2>/dev/null)" || true
 		[[ -z "$inferred_name" ]] && return 0
 
 		echo ""

--- a/.agents/services/hosting/local-hosting.md
+++ b/.agents/services/hosting/local-hosting.md
@@ -18,7 +18,7 @@ tools:
 ## Quick Reference
 
 - **Purpose**: Production-like local development with `.local` domains, HTTPS, and port management
-- **Primary CLI**: `localdev-helper.sh [init|add|rm|branch|db|list|status|help]`
+- **Primary CLI**: `localdev-helper.sh [run|init|add|rm|branch|db|list|status|help]`
 - **Legacy CLI**: `localhost-helper.sh [check-port|find-port|list-ports|kill-port|generate-cert|setup-dns|setup-proxy|create-app|start-mcp]`
 - **Port registry**: `~/.local-dev-proxy/ports.json`
 - **Certs**: `~/.local-ssl-certs/`
@@ -27,12 +27,24 @@ tools:
 - **Docker Compose**: `~/.local-dev-proxy/docker-compose.yml`
 - **Shared Postgres**: `local-postgres` container on port 5432
 
-**Standard workflow — register a new project:**
+**Zero-config workflow (recommended):**
 
 ```bash
 # One-time system setup (dnsmasq, resolver, Traefik conf.d)
 localdev-helper.sh init
 
+# In any project directory — auto-registers, injects PORT, runs command
+cd ~/Git/myapp
+localdev-helper.sh run npm run dev
+# → Auto-registers myapp (cert, Traefik route, /etc/hosts, port 3100)
+# → Sets PORT=3100 HOST=0.0.0.0
+# → Runs: npm run dev
+# → https://myapp.local just works
+```
+
+**Manual workflow — register then start separately:**
+
+```bash
 # Register app: generates cert, creates Traefik route, assigns port
 localdev-helper.sh add myapp
 
@@ -147,6 +159,59 @@ Performs:
 6. Restart Traefik if running
 
 Note: `init` sets up dnsmasq for CLI tool resolution (`dig`, `curl`). Browser resolution requires per-app `/etc/hosts` entries, which `add` handles automatically.
+
+### run
+
+Zero-config dev server wrapper. Auto-registers the project if needed, resolves the correct port (main or branch), injects `PORT` and `HOST` environment variables, and execs the command. Signals (SIGINT/SIGTERM) pass through directly to the child process.
+
+```bash
+localdev-helper.sh run [options] <command...>
+```
+
+Options:
+
+- `--name <name>`: Override inferred project name
+- `--port <port>`: Override auto-assigned port
+- `--no-host`: Don't set `HOST=0.0.0.0`
+
+Examples:
+
+```bash
+# In ~/Git/myapp/ (not yet registered)
+localdev-helper.sh run npm run dev
+# → Auto-registers myapp (cert, Traefik route, /etc/hosts, port 3100)
+# → Sets PORT=3100 HOST=0.0.0.0
+# → Runs: npm run dev
+# → https://myapp.local just works
+
+# In a worktree ~/Git/myapp-bugfix-fix-thing/
+localdev-helper.sh run npm run dev
+# → Auto-detects worktree, creates branch subdomain
+# → Sets PORT=3101
+# → Runs: npm run dev
+# → https://bugfix-fix-thing.myapp.local just works
+
+# Override project name
+localdev-helper.sh run --name my-custom-name pnpm dev
+
+# Override port
+localdev-helper.sh run --port 3200 bun run dev
+```
+
+Performs:
+
+1. Infer project name from `package.json` `name` field (stripping npm scope) or git repo basename
+2. Auto-register if not already in port registry (runs full `add` workflow)
+3. Detect worktree/branch context and create branch subdomain route if needed
+4. Set `PORT={assigned_port}` and `HOST=0.0.0.0` environment variables
+5. `exec` the command (replaces the shell process — signals go directly to the child)
+
+Project name inference priority:
+
+1. `--name` flag (explicit override)
+2. `package.json` `name` field (strips `@scope/` prefix)
+3. Git repo basename (strips worktree suffix for worktrees)
+4. Current directory basename (last resort)
 
 ### add
 
@@ -399,7 +464,20 @@ networks:
 
 The branch subdomain system enables running multiple versions of an app simultaneously — useful for PR reviews, A/B testing, or parallel feature development.
 
-### Full Workflow
+### Zero-Config Workflow (recommended)
+
+```bash
+# In a worktree — localdev run handles everything
+cd ~/Git/myapp-feature-user-auth/
+localdev-helper.sh run npm run dev
+# → Auto-registers myapp if needed
+# → Auto-creates branch subdomain feature-user-auth.myapp.local
+# → Sets PORT=3101 HOST=0.0.0.0
+# → Runs: npm run dev
+# → https://feature-user-auth.myapp.local just works
+```
+
+### Manual Workflow
 
 ```bash
 # 1. Register the main app (one-time)
@@ -423,7 +501,16 @@ localdev-helper.sh branch list myapp
 
 ### Integration with Git Worktrees
 
-Branch subdomains pair naturally with git worktrees:
+Branch subdomains pair naturally with git worktrees. With `localdev run`, the worktree integration is automatic:
+
+```bash
+# Create worktree and start dev server — zero config
+cd ~/Git/myapp-feature-login/
+localdev-helper.sh run npm run dev
+# → Everything handled automatically
+```
+
+Manual approach:
 
 ```bash
 # Create worktree for feature branch


### PR DESCRIPTION
## Summary

- Add `localdev run <command>` — zero-config wrapper that auto-registers projects, resolves ports (main or branch), injects `PORT`/`HOST` env vars, and execs the dev command
- Add `infer_project_name()` — infers project name from `package.json` name field (stripping npm scope) or git repo basename (handling worktrees correctly)
- Update `localdev_auto_branch()` in worktree-helper.sh to auto-register unregistered projects before creating branch routes (t1424.1)
- Document `localdev run` as the recommended zero-config workflow in local-hosting.md

## How it works

```bash
# In ~/Git/myapp/ (not yet registered)
localdev run npm run dev
# → Auto-registers myapp (cert, Traefik route, /etc/hosts, port 3100)
# → Sets PORT=3100 HOST=0.0.0.0
# → Runs: npm run dev
# → https://myapp.local just works

# In a worktree ~/Git/myapp-bugfix-fix-thing/
localdev run npm run dev
# → Auto-detects worktree, creates branch subdomain
# → Sets PORT=3101
# → https://bugfix-fix-thing.myapp.local just works
```

## Verification

- ShellCheck clean (both localdev-helper.sh and worktree-helper.sh)
- markdownlint clean (local-hosting.md)
- `localdev run` help output verified
- `localdev help` shows run as first command
- `infer_project_name` tested: correctly resolves worktree paths to main repo name

Closes #3998