### PR TITLE
GH#4007: Consolidate jq calls in screen-time-helper cmd_history()

### DIFF
--- a/.agents/scripts/screen-time-helper.sh
+++ b/.agents/scripts/screen-time-helper.sh
@@ -644,12 +644,12 @@ cmd_history() {
 		history_stats=$(jq -rs '
 			[
 				([.[].screen_hours] | add // 0 | . * 10 | round / 10),
-				(min_by(.date) | .date),
-				(max_by(.date) | .date)
+				(min_by(.date) | .date // "unknown"),
+				(max_by(.date) | .date // "unknown")
 			] | @tsv
 		' "$HISTORY_FILE" 2>/dev/null) || true
 		if [[ -n "$history_stats" ]]; then
-			read -r total_hours earliest latest <<<"$history_stats"
+			IFS=$'\t' read -r total_hours earliest latest <<<"$history_stats"
 		fi
 	fi
 

--- a/.agents/scripts/screen-time-helper.sh
+++ b/.agents/scripts/screen-time-helper.sh
@@ -633,13 +633,25 @@ cmd_history() {
 	fi
 
 	local total_days
-	local total_hours
-	local earliest
-	local latest
 	total_days=$(wc -l <"$HISTORY_FILE" | tr -d ' ')
-	total_hours=$(jq -s '[.[].screen_hours] | add | . * 10 | round / 10' "$HISTORY_FILE" 2>/dev/null || echo "0")
-	earliest=$(jq -s 'min_by(.date) | .date' "$HISTORY_FILE" 2>/dev/null || echo "unknown")
-	latest=$(jq -s 'max_by(.date) | .date' "$HISTORY_FILE" 2>/dev/null || echo "unknown")
+
+	# Single jq pass for all history stats (total_hours, earliest, latest)
+	local total_hours="0"
+	local earliest="unknown"
+	local latest="unknown"
+	if [[ "$total_days" -gt 0 ]]; then
+		local history_stats
+		history_stats=$(jq -rs '
+			[
+				([.[].screen_hours] | add // 0 | . * 10 | round / 10),
+				(min_by(.date) | .date),
+				(max_by(.date) | .date)
+			] | @tsv
+		' "$HISTORY_FILE" 2>/dev/null) || true
+		if [[ -n "$history_stats" ]]; then
+			read -r total_hours earliest latest <<<"$history_stats"
+		fi
+	fi
 
 	echo "Screen time history: ${total_days} days, ${total_hours}h total"
 	echo "Range: ${earliest} to ${latest}"


### PR DESCRIPTION
## Summary

- Consolidate 3 separate `jq` invocations in `cmd_history()` into a single pass using `@tsv` output
- Matches the pattern already used in `cmd_profile_stats()` (implemented in PR #3997)
- Avoids parsing the same JSONL history file 3 times, improving performance as the file grows

## Changes

### `.agents/scripts/screen-time-helper.sh`

**Before:** 3 separate `jq -s` calls each reading `$HISTORY_FILE` to compute `total_hours`, `earliest`, and `latest` independently.

**After:** Single `jq -rs` call computes all 3 values in one pass, outputs as TSV, parsed via `read -r`. Includes guard for empty files (`total_days > 0`) and graceful fallback defaults.

## Verification

- ShellCheck: zero violations
- `bash -n`: syntax OK

Closes #4007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized internal processing for screen-time statistics to improve efficiency.
  * Preserves existing output and messages; default values used when no data available.
  * Reduces errors when history data is absent by skipping unnecessary reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->