### PR TITLE
t3984: Fix quality-debt in profile-readme-helper.sh from PR #3963 review feedback

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -666,8 +666,10 @@ _sanitize_md() {
 # Rejects javascript: URIs, non-http(s) schemes, and markdown-breaking chars
 _sanitize_url() {
 	local url="$1"
-	# Must start with http:// or https://
-	if [[ "$url" != http://* && "$url" != https://* ]]; then
+	# Must start with http:// or https:// (case-insensitive)
+	local url_lower
+	url_lower=$(printf '%s' "$url" | tr '[:upper:]' '[:lower:]')
+	if [[ "$url_lower" != http://* && "$url_lower" != https://* ]]; then
 		echo ""
 		return 0
 	fi
@@ -708,7 +710,7 @@ _generate_rich_readme() {
 
 	# Fetch repos and detect languages
 	local repos_json
-	repos_json=$(gh api "users/${gh_user}/repos?per_page=100&sort=updated") || repos_json="[]"
+	repos_json=$(gh api "users/${gh_user}/repos?per_page=100&sort=updated" --paginate) || repos_json="[]"
 
 	# Unique languages from all repos (sorted)
 	local languages
@@ -731,7 +733,7 @@ _generate_rich_readme() {
 	local own_repos
 	own_repos=$(echo "$repos_json" | jq -r --arg user "$gh_user" '
 		[.[] | select(.fork == false and .name != $user)] |
-		map("- **[\(.name | gsub("[\\[\\]()]"; ""))](\(.html_url))** -- \(.description // "No description" | gsub("[\\[\\]()]"; ""))") |
+		map("- **[\(.name | gsub("[\\[\\]()`]"; ""))](\(.html_url))** -- \((.description // "No description") | gsub("[\\[\\]()`]"; ""))") |
 		.[]
 	')
 
@@ -743,12 +745,17 @@ _generate_rich_readme() {
 		# Fetch all fork details in parallel (up to 6 concurrent) to get parent URLs
 		local fork_details
 		fork_details=$(echo "$fork_names" | xargs -P 6 -I{} gh api "repos/${gh_user}/{}" --jq '
-			"\(.name)\t\(.description // "No description" | gsub("[\\t\\n]"; " "))\t\(.parent.html_url // .html_url)"
+			"\(.name | gsub("[\\[\\]()`]"; ""))\t\((.description // "No description") | gsub("[\\t\\n]"; " ") | gsub("[\\[\\]()`]"; ""))\t\(.parent.html_url // .html_url)"
 		' || true)
 		while IFS=$'\t' read -r rname rdesc rurl; do
 			[[ -z "$rname" ]] && continue
+			# Names and descriptions already sanitized in jq above;
+			# apply _sanitize_md as defense-in-depth for any residual chars
 			rname=$(_sanitize_md "$rname")
 			rdesc=$(_sanitize_md "$rdesc")
+			# Validate fork URL before embedding in markdown
+			rurl=$(_sanitize_url "$rurl")
+			[[ -z "$rurl" ]] && continue
 			contrib_repos="${contrib_repos}- **[${rname}](${rurl})** -- ${rdesc}"$'\n'
 		done <<<"$fork_details"
 	fi
@@ -788,7 +795,7 @@ _generate_rich_readme() {
 		if [[ -n "$own_repos" ]]; then
 			echo "## Projects"
 			echo ""
-			printf '%s\n' "$own_repos"
+			printf '%s' "$own_repos"
 			echo ""
 		fi
 		# Contributions

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -744,6 +744,8 @@ _generate_rich_readme() {
 	if [[ -n "$fork_names" ]]; then
 		# Fetch all fork details in parallel (up to 6 concurrent) to get parent URLs
 		local fork_details
+		# Backticks in jq gsub pattern are literal, not shell expansion
+		# shellcheck disable=SC2016
 		fork_details=$(echo "$fork_names" | xargs -P 6 -I{} gh api "repos/${gh_user}/{}" --jq '
 			"\(.name | gsub("[\\[\\]()`]"; ""))\t\((.description // "No description") | gsub("[\\t\\n]"; " ") | gsub("[\\[\\]()`]"; ""))\t\(.parent.html_url // .html_url)"
 		' || true)


### PR DESCRIPTION
## Summary

Addresses all 8 findings from coderabbit and gemini code reviewers on PR #3963. Of the 8 findings, 5 were already resolved in the merged PR; this PR fixes the 3 remaining issues plus 2 bonus improvements from nitpick-level suggestions.

### Fixes applied

- **Backtick stripping in jq sanitization** (findings #4, #7): `gsub("[\\[\\]()]"; "")` now includes backticks: `gsub("[\\[\\]()\`]"; "")` — prevents markdown injection via backtick characters in repo names and descriptions
- **jq operator precedence fix** (findings #4, #7): `.description // "No description" | gsub(...)` had incorrect precedence — `|` bound tighter than `//`, so gsub only applied to the fallback string. Now correctly wrapped: `((.description // "No description") | gsub(...))`
- **Extra newline in Projects section** (finding #6): `printf '%s\n'` reverted to `printf '%s'` — jq output already includes a trailing newline; the extra `\n` caused a blank line in the generated README
- **Fork description sanitization in jq** (finding #5 enhancement): Added backtick + markdown char stripping in the fork_details jq expression for defense-in-depth alongside the existing `_sanitize_md` calls
- **Fork URL validation** (defense-in-depth): Fork parent URLs from the API are now validated through `_sanitize_url` before markdown embedding

### Bonus improvements (from nitpick suggestions)

- **Case-insensitive URL scheme matching**: `_sanitize_url` now accepts `HTTPS://` and `HTTP://` (uses `tr '[:upper:]' '[:lower:]'` for bash 3.2 compatibility)
- **Pagination for >100 repos**: Added `--paginate` to `gh api` repos fetch so users with >100 repositories get complete project/contribution lists

### Verification

- ShellCheck: clean (only pre-existing SC2016 info about jq single-quote expressions)
- All changes are in `.agents/scripts/profile-readme-helper.sh`

Closes #3984