### PR TITLE
t4004: Replace echo|bc pipes with bc here-strings in OCR test script

### DIFF
--- a/.agents/scripts/test-ocr-extraction-pipeline.sh
+++ b/.agents/scripts/test-ocr-extraction-pipeline.sh
@@ -693,7 +693,7 @@ create_large_invoice() {
 		local amount=$((i * 10))
 		subtotal=$((subtotal + amount))
 		local vat_amt
-		vat_amt=$(echo "$amount * 0.2" | bc || echo "$((amount / 5))")
+		vat_amt=$(bc <<<"$amount * 0.2" || echo "$((amount / 5))")
 		if [[ -n "$items" ]]; then
 			items="${items},"
 		fi
@@ -708,9 +708,9 @@ create_large_invoice() {
     }"
 	done
 	local vat_total
-	vat_total=$(echo "$subtotal * 0.2" | bc || echo "$((subtotal / 5))")
+	vat_total=$(bc <<<"$subtotal * 0.2" || echo "$((subtotal / 5))")
 	local total
-	total=$(echo "$subtotal + $vat_total" | bc || echo "$((subtotal + subtotal / 5))")
+	total=$(bc <<<"$subtotal + $vat_total" || echo "$((subtotal + subtotal / 5))")
 
 	cat >"$output_file" <<FIXTURE
 {


### PR DESCRIPTION
## Summary

- Replace `echo "..." | bc` with `bc <<< "..."` here-strings in `create_large_invoice()` to avoid unnecessary subshell spawning (3 occurrences)
- Addresses unactioned Gemini review feedback from PR #3979

## Changes

All 3 changes are in `.agents/scripts/test-ocr-extraction-pipeline.sh`, function `create_large_invoice()`:

| Line | Before | After |
|------|--------|-------|
| 696 | `echo "$amount * 0.2" \| bc` | `bc <<< "$amount * 0.2"` |
| 711 | `echo "$subtotal * 0.2" \| bc` | `bc <<< "$subtotal * 0.2"` |
| 713 | `echo "$subtotal + $vat_total" \| bc` | `bc <<< "$subtotal + $vat_total"` |

## Verification

- ShellCheck: zero violations
- CodeRabbit finding (stderr consistency) was already addressed in commit f8ae637

Closes #4004