### PR TITLE
fix: address quality-debt in memory-audit-pulse, route.md (GH#3983, GH#3771, GH#3765)

### DIFF
--- a/.agents/scripts/commands/route.md
+++ b/.agents/scripts/commands/route.md
@@ -9,6 +9,12 @@ Analyze the task description and recommend the optimal model tier.
 
 Task: $ARGUMENTS
 
+<!-- NOTE: $ARGUMENTS is raw free-form text from the user, not necessarily a --task-type
+     value. The recommend command (cmd_recommend in model-routing) only filters by
+     --task-type. When called with free-form text, recommend shows global model stats
+     (not task-type-specific). For task-specific routing, extract a task type (e.g.,
+     "code", "triage", "research") from ARGUMENTS before calling recommend. -->
+
 ## Instructions
 
 1. First, check pattern history from cross-session memory:

--- a/.agents/scripts/memory-audit-pulse.sh
+++ b/.agents/scripts/memory-audit-pulse.sh
@@ -748,9 +748,9 @@ cmd_status() {
 	echo ""
 	if [[ -f "$MEMORY_DB" ]]; then
 		local total
-		total=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings;" 2>/dev/null || echo "0")
+		total=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings;" || echo "0")
 		local consolidations
-		consolidations=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM memory_consolidations;" 2>/dev/null || echo "0")
+		consolidations=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM memory_consolidations;" || echo "0")
 		local db_size
 		db_size=$(du -h "$MEMORY_DB" | cut -f1)
 		log_info "Memory DB: $total memories, $consolidations consolidations, $db_size"


### PR DESCRIPTION
## Summary

- **GH#3983**: Remove `2>/dev/null` from `db` calls in `memory-audit-pulse.sh` (lines 751, 753). The `|| echo "0"` fallback already handles failures; suppressing stderr hides useful diagnostic messages.
- **GH#3771**: Already fixed — `skip()` in `test-memory-mail.sh` already prints an optional second argument (lines 46-48). No code change needed.
- **GH#3765**: Add HTML comment to `route.md` clarifying that `$ARGUMENTS` is raw free-form text, not a `--task-type` value. The agent should extract a task type from ARGUMENTS before calling `cmd_recommend` for task-specific routing.

Also fixed the adjacent line 751 which had the same `2>/dev/null` anti-pattern as line 753.

Fixes #3983
Fixes #3771
Fixes #3765