### PR TITLE
t1428.1: Add DNS exfiltration detection patterns

### DIFF
--- a/.agents/configs/network-tiers.conf
+++ b/.agents/configs/network-tiers.conf
@@ -190,6 +190,8 @@ interact.sh
 *.oast.fun
 *.oast.me
 *.oast.live
+oastify.com
+*.oastify.com
 canarytokens.com
 *.canarytokens.com
 

--- a/.agents/configs/prompt-injection-patterns.yaml
+++ b/.agents/configs/prompt-injection-patterns.yaml
@@ -485,6 +485,18 @@ data_exfiltration_dns:
     description: "DNS exfil: DNS-over-HTTPS query with dynamic data"
     pattern: '(?i)(dns-query|dns\.google|cloudflare-dns\.com/dns-query|doh\.).*(\$\(|\$\{|`)'
 
+  # --- curl/wget to known DNS exfiltration services ---
+  # These services provide attacker-controlled DNS servers that log queries.
+  # Also blocked at Tier 5 in network-tiers.conf, but pattern detection
+  # catches them in prompt content before execution.
+  - severity: CRITICAL
+    description: "DNS exfil: HTTP request to known DNS exfil service"
+    pattern: '(?i)\b(curl|wget|fetch|http)\b.*\b(dnslog\.cn|ceye\.io|interact\.sh|burpcollaborator\.net|oastify\.com|oast\.fun|oast\.me|oast\.live)\b'
+
+  - severity: CRITICAL
+    description: "DNS exfil: known exfil service domain in DNS tool"
+    pattern: '(?i)\b(dig|nslookup|host)\b.*\b(dnslog\.cn|ceye\.io|interact\.sh|burpcollaborator\.net|oastify\.com|oast\.fun|oast\.me|oast\.live)\b'
+
 # ================================================================
 # CONTEXT MANIPULATION
 # ================================================================

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -201,6 +201,14 @@ _sandbox_check_dns_exfil() {
 		dns_exfil_detected=true
 	fi
 
+	# Pattern 5: Known DNS exfiltration service domains
+	# These are attacker-controlled DNS logging services. Any DNS query or
+	# HTTP request to these domains is a strong exfil indicator.
+	if printf '%s' "$command" | grep -qiE '\b(dnslog\.cn|ceye\.io|interact\.sh|burpcollaborator\.net|oastify\.com|oast\.(fun|me|live))\b'; then
+		log_sandbox "CRIT" "DNS EXFIL DETECTED: Known exfiltration service domain (worker=${wid})"
+		dns_exfil_detected=true
+	fi
+
 	if [[ "$dns_exfil_detected" == true ]]; then
 		# Log to audit trail if available
 		local audit_helper="${SCRIPT_DIR}/audit-log-helper.sh"


### PR DESCRIPTION
## Summary

- Add known DNS exfil service domain patterns (dnslog.cn, ceye.io, interact.sh, burpcollaborator.net, oastify.com, oast.*) to `prompt-injection-patterns.yaml` — CRITICAL severity for both HTTP requests and DNS tool usage targeting these services
- Add Pattern 5 (known exfil service domains) to `sandbox-exec-helper.sh` `_sandbox_check_dns_exfil()` function for runtime command blocking
- Add `oastify.com` / `*.oastify.com` to Tier 5 network blocklist in `network-tiers.conf`

Closes #4023

Part of t1428 security enhancements. Addresses CVE-2025-55284 (Claude Code DNS exfiltration attack).

### Context

The core DNS exfil shape-based detection (command substitution in dig/nslookup/host, base64-piped DNS queries, DNS-over-HTTPS, loop constructs) was already implemented. This PR completes the coverage by adding:

1. **Known-bad domain patterns** in the YAML pattern file — catches prompt content that references known DNS exfil services before any command is executed
2. **Runtime domain check** in the sandbox helper — catches commands that reference known exfil services even without command substitution patterns
3. **Missing Tier 5 entry** — `oastify.com` (PortSwigger/Burp Suite OAST) was missing from the network tier blocklist

### Files changed

- `.agents/configs/prompt-injection-patterns.yaml` — 2 new CRITICAL patterns in `data_exfiltration_dns`
- `.agents/scripts/sandbox-exec-helper.sh` — Pattern 5 in `_sandbox_check_dns_exfil()`
- `.agents/configs/network-tiers.conf` — `oastify.com` + `*.oastify.com` added to Tier 5