### PR TITLE
GH#3736: Fix security findings in quickfile-helper.sh

### DIFF
--- a/.agents/scripts/quickfile-helper.sh
+++ b/.agents/scripts/quickfile-helper.sh
@@ -44,7 +44,7 @@ readonly DEFAULT_CURRENCY="GBP"
 
 # Ensure workspace exists
 ensure_workspace() {
-	if ! mkdir -p "$QF_WORKSPACE" 2>/dev/null; then
+	if ! mkdir -p "$QF_WORKSPACE"; then
 		print_error "Failed to create workspace: ${QF_WORKSPACE}"
 		return 1
 	fi
@@ -200,7 +200,7 @@ if raw_items:
         qty = float(item.get('quantity', 1) or 1)
         unit_cost = float(item.get('unit_price', item.get('price', 0)) or 0)
         nominal = nominal_override or item.get('nominal_code', default_nominal)
-        vat_pct = item.get('vat_rate', '20')
+        vat_pct = item.get('vat_rate')
         if vat_pct is None:
             vat_pct = '20'
         lines.append({
@@ -235,7 +235,9 @@ if due_date:
 
 print(f'  quickfile_purchase_create({json.dumps(request, indent=4, ensure_ascii=False)})')
 print()
-print(f'  Summary: {supplier} | {inv_date} | {currency} {total:.2f} (net {subtotal:.2f} + VAT {vat:.2f})')
+# Sanitise supplier name for summary output to prevent LLM instruction injection
+safe_supplier = supplier.replace('\\n', ' ').replace('\\r', ' ')[:100]
+print(f'  Summary: {safe_supplier} | {inv_date} | {currency} {total:.2f} (net {subtotal:.2f} + VAT {vat:.2f})')
 " 2>/dev/null || {
 		print_error "Failed to generate purchase instructions"
 		return 1


### PR DESCRIPTION
## Summary

- Addresses all 6 findings from Gemini code review on PR #1156 for `.agents/scripts/quickfile-helper.sh`
- 4 CRITICAL Python code injection vulnerabilities (findings 1-4) were **already remediated** in the current codebase — all Python invocations use `os.environ[]` instead of shell variable interpolation
- Fixes 3 remaining issues: `mkdir -p` error suppression, unreachable `vat_pct` None check, and LLM instruction injection in summary output

## Changes

| Finding | Severity | Status | Fix |
|---------|----------|--------|-----|
| Python injection in `validate_extraction_json` (line 92) | CRITICAL | Already fixed | Uses `os.environ['JSON_FILE']` |
| Python injection in `generate_purchase_instructions` (line 234) | CRITICAL | Already fixed | Uses `os.environ['JSON_FILE']` + env vars |
| Python injection in `cmd_record_purchase` (line 266) | CRITICAL | Already fixed | Uses `os.environ['JSON_FILE']` |
| Python injection in `cmd_record_expense` (line 379) | CRITICAL | Already fixed | Uses `os.environ['JSON_FILE']` |
| LLM instruction injection in summary output (line 231) | MEDIUM | **Fixed in this PR** | Sanitise supplier name (strip newlines, truncate to 100 chars) |
| `mkdir -p` with `2>/dev/null` (line 48) | MEDIUM | **Fixed in this PR** | Remove error suppression; let `set -e` handle real failures |
| Unreachable `vat_pct is None` check (line 204) | LOW | **Fixed in this PR** | Use `.get('vat_rate')` without default so None check is reachable (preserves 0 as valid zero-rated VAT) |

## Verification

- ShellCheck: clean (only SC1091 info about external sources — pre-existing, expected)
- No functional changes to the happy path — all fixes are defensive hardening

Closes #3736