### PR TITLE
GH#3746: Fix broken code block fences and add PATH note in Playwriter docs

### DIFF
--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -102,6 +102,8 @@ Add to your MCP client configuration:
 
 **Claude Desktop** (`claude_desktop_config.json`):
 
+> **Note**: If Claude Desktop runs with a restricted PATH, use the full `npx` path (e.g., `/opt/homebrew/bin/npx`).
+
 ```json
 {
   "mcpServers": {
@@ -156,7 +158,7 @@ const title = await page.textContent('h1')
 
 // Wait for element
 await page.waitForSelector('.loaded')
-```text
+```
 
 ### Multi-Tab Control
 
@@ -171,7 +173,7 @@ const page2 = pages[1]
 // Create new tab
 const newPage = await context.newPage()
 await newPage.goto('https://example.com')
-```text
+```
 
 ### Programmatic Usage
 
@@ -192,7 +194,7 @@ await page.screenshot({ path: 'screenshot.png' })
 
 await browser.close()
 server.close()
-```text
+```
 
 ## Comparison with Other Tools
 
@@ -245,7 +247,7 @@ server.close()
 |  | Tab 3 (gray)  |  |                               |  +-----------+  |
 |  +---------------+  |     Tab 3 not controlled      +-----------------+
 +---------------------+
-```text
+```
 
 ## Security
 
@@ -286,7 +288,7 @@ await page.click('button[type="submit"]')
 
 // Wait for redirect
 await page.waitForURL('**/dashboard')
-```text
+```
 
 ### Form Submission
 
@@ -302,7 +304,7 @@ await page.click('button[type="submit"]')
 
 // Wait for success
 await page.waitForSelector('.success-message')
-```text
+```
 
 ### Data Extraction
 
@@ -319,7 +321,7 @@ const rows = await page.$$eval('table tr', rows =>
     return Array.from(cells).map(cell => cell.textContent)
   })
 )
-```text
+```
 
 ### Screenshot and PDF
 
@@ -332,7 +334,7 @@ await page.locator('.chart').screenshot({ path: 'chart.png' })
 
 // PDF export
 await page.pdf({ path: 'page.pdf', format: 'A4' })
-```text
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Fix 8 code blocks in `playwriter.md` that used ` ```text ` as closing fence instead of ` ``` `, breaking syntax highlighting and rendering subsequent content as plain text blocks
- Add PATH guidance note to Claude Desktop MCP config example per CodeRabbit review feedback

## Details

The Playwriter documentation had a systematic bug where JavaScript code blocks were closed with ` ```text ` instead of ` ``` `. This caused:
1. The closing fence to be interpreted as an *opening* fence for a new `text` code block
2. The content between the broken closing and the next code block opening to render as plain text inside a code block
3. Loss of syntax highlighting for the affected JavaScript examples

Also addresses CodeRabbit feedback from PR #153 about the Claude Desktop config example not mentioning the full `npx` path, which is inconsistent with the OpenCode example that recommends it for reliability.

## Verification

- `markdownlint-cli2`: 0 errors
- Only remaining ` ```text ` is the legitimate opening fence for the ASCII architecture diagram (line 228)

Closes #3746