### PR TITLE
GH#3742: Fix OCR research doc — canonical PyPI name, dismiss bot hallucinations

### DIFF
--- a/.agents/tools/ocr/ocr-research.md
+++ b/.agents/tools/ocr/ocr-research.md
@@ -225,7 +225,7 @@ docling invoice.pdf --output markdown
 ### ExtractThinker (LLM Extraction)
 
 ```bash
-pip install extract_thinker
+pip install extract-thinker
 # Supports: OpenAI, Anthropic, Google, Ollama, Azure
 # ORM-style: define Pydantic contract, call extractor.extract()
 ```


### PR DESCRIPTION
## Summary

- Fix `extract_thinker` → `extract-thinker` (canonical PyPI package name with hyphen) in installation docs
- **Dismiss model version name findings** from Gemini Code Assist review bot — the bot suggested changing `Gemini 2.5 Flash/Pro` to `1.5` and `Claude Sonnet 4` to `Claude 3 Sonnet`, but these are **hallucinations from stale training data**. Gemini 2.5 Flash (March 2025), Gemini 2.5 Pro (May 2025), and Claude Sonnet 4 (May 2025) are all real, current model names.

## Findings

| Finding | Severity | Action | Rationale |
|---------|----------|--------|-----------|
| `extract_thinker` → `extract-thinker` | Medium | **Fixed** | Canonical PyPI name uses hyphen per PEP 503 |
| Gemini 2.5 Flash/Pro → 1.5 | High | **Dismissed** | Bot hallucination — 2.5 models released March/May 2025 |
| Claude Sonnet 4 → Claude 3 Sonnet | High | **Dismissed** | Bot hallucination — Claude Sonnet 4 released May 2025 |

## Verification

Independent verification confirms the original model names are correct. The review bot (Gemini Code Assist) was running on training data that predated these model releases.

Closes #3742