### PR TITLE
GH#3734: Fix command injection in post_blocked_comment_to_github

### DIFF
--- a/.agents/scripts/supervisor-archived/issue-sync.sh
+++ b/.agents/scripts/supervisor-archived/issue-sync.sh
@@ -360,6 +360,12 @@ sync_issue_status_label() {
 	local new_state="$2"
 	local old_state="${3:-}"
 
+	# Validate task_id format to prevent command/regex injection (GH#3734)
+	if [[ ! "$task_id" =~ ^t[0-9]+(\.[0-9]+)?$ ]]; then
+		log_warn "sync_issue_status_label: invalid task_id format, skipping"
+		return 1
+	fi
+
 	# Skip if gh CLI not available or not authenticated
 	command -v gh &>/dev/null || return 0
 	check_gh_auth || return 0
@@ -1394,6 +1400,11 @@ find_task_issue_number() {
 
 	if [[ -z "$task_id" ]]; then
 		return 0
+	fi
+
+	# Validate task_id format to prevent regex injection (GH#3734)
+	if [[ ! "$task_id" =~ ^t[0-9]+(\.[0-9]+)?$ ]]; then
+		return 1
 	fi
 
 	# Escape dots in task_id for regex (e.g. t128.10 -> t128\.10)
@@ -2905,6 +2916,13 @@ post_blocked_comment_to_github() {
 	local task_id="$1"
 	local reason="${2:-unknown}"
 	local repo_path="$3"
+
+	# Validate task_id format to prevent command/regex injection (GH#3734)
+	# Valid formats: t1, t001, t1234, t001.1, t004.21
+	if [[ ! "$task_id" =~ ^t[0-9]+(\.[0-9]+)?$ ]]; then
+		log_warn "Invalid task_id format: refusing to process '${task_id//[^a-zA-Z0-9._-]/}'"
+		return 1
+	fi
 
 	# Check if gh CLI is available
 	if ! command -v gh &>/dev/null; then

--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -1076,6 +1076,12 @@ update_todo_on_blocked() {
 	local task_id="$1"
 	local reason="${2:-unknown}"
 
+	# Validate task_id format to prevent command/regex injection (GH#3734)
+	if [[ ! "$task_id" =~ ^t[0-9]+(\.[0-9]+)?$ ]]; then
+		log_error "Invalid task_id format: refusing to process unsanitized input"
+		return 1
+	fi
+
 	ensure_db
 
 	local escaped_id


### PR DESCRIPTION
## Summary

- Adds `task_id` format validation (`^t[0-9]+(\.[0-9]+)?$`) to four functions that interpolate `task_id` into shell commands and grep regex patterns, preventing command/regex injection
- Addresses critical security finding from Gemini code review on PR #1167

## Changes

**`issue-sync.sh`** — 3 functions hardened:
- `post_blocked_comment_to_github()` — the primary vulnerability identified in the review. `task_id` was interpolated directly into `grep -E` pattern without sanitization
- `sync_issue_status_label()` — caller that passes `task_id` to `gh` CLI commands and to `post_blocked_comment_to_github`
- `find_task_issue_number()` — interpolates `task_id` into `grep -E` pattern (had dot-escaping but no format validation)

**`todo-sync.sh`** — 1 function hardened:
- `update_todo_on_blocked()` — interpolates `task_id` into `grep -E` and calls `post_blocked_comment_to_github`

## Verification

- ShellCheck passes clean on both modified files
- Validation regex matches all existing task ID formats in TODO.md (`t001`, `t001.1`, `t004.21`)
- Invalid inputs are rejected with a warning log and `return 1`
- The log message in `post_blocked_comment_to_github` sanitizes the invalid task_id before logging (`${task_id//[^a-zA-Z0-9._-]/}`) to prevent log injection

Closes #3734