### PR TITLE
t3748: Fix quality-debt from PR #128 review feedback

### DIFF
--- a/.agents/content.md
+++ b/.agents/content.md
@@ -13,6 +13,8 @@ subagents:
   - production/video
   - production/audio
   - production/characters
+  # Humanise (post-production)
+  - humanise
   # Distribution (multi-channel)
   - distribution/youtube
   - distribution/short-form
@@ -25,7 +27,6 @@ subagents:
   # Legacy content tools
   - guidelines
   - platform-personas
-  - humanise
   - seo-writer
   - meta-creator
   - editor
@@ -43,7 +44,7 @@ subagents:
 ## Quick Reference
 
 - **Purpose**: Multi-media multi-channel content production at scale
-- **Architecture**: Diamond pipeline (Research → Story → Production fan-out → Distribution fan-out)
+- **Architecture**: Diamond pipeline (Research → Story → Production fan-out → Humanise → Distribution fan-out)
 - **Multiplier**: One researched story → 10+ outputs across media types and channels
 
 **The Diamond Pipeline**:
@@ -57,6 +58,9 @@ subagents:
             Production (multi-media)
            /    |    |    |    \
        Writing Image Video Audio Characters
+          \    |    |    |    /
+           \   |    |    |   /
+                 Humanise
           \    |    |    |    /
            \   |    |    |   /
         Distribution (multi-channel)

--- a/.agents/content.md
+++ b/.agents/content.md
@@ -355,7 +355,6 @@ Traditional content creation is linear: research → write → publish. This pip
 
 - `content/seo-writer.md` - SEO-optimized writing
 - `content/editor.md` - Human voice transformation
-- `content/humanise.md` - Remove AI patterns
 - `content/meta-creator.md` - Meta titles/descriptions
 - `content/internal-linker.md` - Strategic internal linking
 
@@ -399,7 +398,6 @@ Traditional content creation is linear: research → write → publish. This pip
 
 - `content/guidelines.md` - Content standards and style guide
 - `content/platform-personas.md` - Platform-specific voice adaptations
-- `content/humanise.md` - Remove AI writing patterns
 - `content/seo-writer.md` - SEO-optimized content writing
 - `content/meta-creator.md` - Meta titles and descriptions
 - `content/editor.md` - Transform AI content into human-sounding articles

--- a/.agents/content.md
+++ b/.agents/content.md
@@ -76,14 +76,15 @@ subagents:
    - `video.md` - Sora 2, Veo 3.1, Higgsfield, seed bracketing
    - `audio.md` - Voice pipeline, sound design, emotional cues
    - `characters.md` - Facial engineering, character bibles, personas
-4. **Distribution** (`content/distribution/`) - Multi-channel publishing
+4. **Humanise** (`content/humanise.md`, `/humanise`) - Remove AI writing patterns, add natural voice
+5. **Distribution** (`content/distribution/`) - Multi-channel publishing
    - `youtube/` - Long-form YouTube (channel-intel, topic-research, script-writer, optimizer, pipeline)
    - `short-form.md` - TikTok, Reels, Shorts (9:16, 1-3s cuts)
    - `social.md` - X, LinkedIn, Reddit (platform-native tone)
    - `blog.md` - SEO-optimized articles (references `seo/`)
    - `email.md` - Newsletters, sequences
    - `podcast.md` - Audio-first distribution
-5. **Optimization** (`content/optimization.md`) - A/B testing, variant generation, analytics loops
+6. **Optimization** (`content/optimization.md`) - A/B testing, variant generation, analytics loops
 
 **Invocation Examples**:
 

--- a/.agents/content/humanise.md
+++ b/.agents/content/humanise.md
@@ -250,11 +250,15 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 **Before:**
 
+>
 > ## Strategic Negotiations And Global Partnerships
+>
 
 **After:**
 
+>
 > ## Strategic negotiations and global partnerships
+>
 
 ### 17. Emojis
 
@@ -269,10 +273,10 @@ Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as
 
 ### 18. Curly Quotation Marks
 
-**Problem:** ChatGPT uses curly quotes ("...") instead of straight quotes ("...").
+**Problem:** ChatGPT uses curly quotes (“…”) instead of straight quotes ("...").
 
 **Before:**
-> He said "the project is on track" but others disagreed.
+> He said “the project is on track” but others disagreed.
 
 **After:**
 > He said "the project is on track" but others disagreed.

--- a/.agents/scripts/humanise-update-helper.sh
+++ b/.agents/scripts/humanise-update-helper.sh
@@ -24,239 +24,276 @@ readonly SOURCE_SUBAGENT="${SCRIPT_DIR}/../content/humanise.md"
 readonly CACHE_DIR="${HOME}/.aidevops/.agent-workspace/cache"
 readonly CACHE_FILE="${CACHE_DIR}/humanizer-upstream.md"
 readonly CACHE_VERSION_FILE="${CACHE_DIR}/humanizer-version.txt"
-readonly CACHE_TTL=86400  # 24 hours in seconds
+readonly CACHE_TTL=86400 # 24 hours in seconds
 
 readonly BOLD='\033[1m'
 
 # Get local version from subagent frontmatter
 get_local_version() {
-    local subagent_file="$1"
-    if [[ -f "$subagent_file" ]]; then
-        grep -E '^version:' "$subagent_file" | head -1 | sed 's/version:[[:space:]]*//' | tr -d '"'"'"
-    else
-        echo "not found"
-    fi
-    return 0
+	local subagent_file="$1"
+	if [[ -f "$subagent_file" ]]; then
+		grep -E '^version:' "$subagent_file" | head -1 | sed 's/version:[[:space:]]*//' | tr -d '"'"'"
+	else
+		echo "not found"
+	fi
+	return 0
 }
 
 # Get upstream version from subagent frontmatter
 get_upstream_version() {
-    local subagent_file="$1"
-    if [[ -f "$subagent_file" ]]; then
-        grep -E '^upstream_version:' "$subagent_file" | head -1 | sed 's/upstream_version:[[:space:]]*//' | tr -d '"'"'"
-    else
-        echo "not found"
-    fi
-    return 0
+	local subagent_file="$1"
+	if [[ -f "$subagent_file" ]]; then
+		grep -E '^upstream_version:' "$subagent_file" | head -1 | sed 's/upstream_version:[[:space:]]*//' | tr -d '"'"'"
+	else
+		echo "not found"
+	fi
+	return 0
 }
 
 # Fetch upstream SKILL.md
 fetch_upstream() {
-    mkdir -p "$CACHE_DIR"
-    
-    # Check cache freshness
-    if [[ -f "$CACHE_FILE" && -f "$CACHE_VERSION_FILE" ]]; then
-        local cache_age
-        cache_age=$(( $(date +%s) - $(stat -c %Y "$CACHE_FILE" 2>/dev/null || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0) ))
-        if [[ $cache_age -lt $CACHE_TTL ]]; then
-            echo "Using cached upstream ($(( cache_age / 60 )) minutes old)"
-            return 0
-        fi
-    fi
-    
-    echo "Fetching upstream from ${UPSTREAM_REPO}..."
-    if curl -fsSL "$UPSTREAM_RAW" -o "$CACHE_FILE"; then
-        # Extract version from fetched file
-        local version
-        version=$(grep -E '^version:' "$CACHE_FILE" | head -1 | sed 's/version:[[:space:]]*//' | tr -d '"'"'" || echo "unknown")
-        echo "$version" > "$CACHE_VERSION_FILE"
-        echo -e "${GREEN}Fetched upstream version: ${version}${NC}"
-        return 0
-    else
-        echo -e "${RED}Failed to fetch upstream${NC}"
-        return 1
-    fi
+	mkdir -p "$CACHE_DIR"
+
+	# Check cache freshness
+	if [[ -f "$CACHE_FILE" && -f "$CACHE_VERSION_FILE" ]]; then
+		local cache_age
+		cache_age=$(($(date +%s) - $(stat -c %Y "$CACHE_FILE" 2>/dev/null || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)))
+		if [[ $cache_age -lt $CACHE_TTL ]]; then
+			echo "Using cached upstream ($((cache_age / 60)) minutes old)"
+			return 0
+		fi
+	fi
+
+	echo "Fetching upstream from ${UPSTREAM_REPO}..."
+	if curl -fsSL "$UPSTREAM_RAW" -o "$CACHE_FILE"; then
+		# Extract version from fetched file
+		local version
+		version=$(grep -E '^version:' "$CACHE_FILE" | head -1 | sed 's/version:[[:space:]]*//' | tr -d '"'"'" || echo "unknown")
+		echo "$version" >"$CACHE_VERSION_FILE"
+		echo -e "${GREEN}Fetched upstream version: ${version}${NC}"
+		return 0
+	else
+		echo -e "${RED}Failed to fetch upstream${NC}"
+		return 1
+	fi
+}
+
+# Portable version comparison (no GNU sort -V dependency)
+# Returns 0 if left <= right, 1 otherwise
+version_leq() {
+	local left="$1"
+	local right="$2"
+	local -a a b
+	IFS='.' read -ra a <<<"$left"
+	IFS='.' read -ra b <<<"$right"
+	local i
+	local max=$((${#a[@]} > ${#b[@]} ? ${#a[@]} : ${#b[@]}))
+	for ((i = 0; i < max; i++)); do
+		local ai="${a[i]:-0}"
+		local bi="${b[i]:-0}"
+		if ((10#$ai < 10#$bi)); then return 0; fi
+		if ((10#$ai > 10#$bi)); then return 1; fi
+	done
+	return 0
 }
 
 # Compare versions
+# Returns: 0 = same, 1 = local older, 2 = local newer
 compare_versions() {
-    local local_ver="$1"
-    local upstream_ver="$2"
-    
-    if [[ "$local_ver" == "$upstream_ver" ]]; then
-        return 0  # Same version
-    fi
-    
-    # Use sort -V for version comparison
-    local lowest
-    lowest=$(printf '%s\n%s' "$local_ver" "$upstream_ver" | sort -V | head -1)
-    if [[ "$lowest" == "$local_ver" ]]; then
-        return 1  # Local is older
-    else
-        return 2  # Local is newer (shouldn't happen normally)
-    fi
+	local local_ver="$1"
+	local upstream_ver="$2"
+
+	if [[ "$local_ver" == "$upstream_ver" ]]; then
+		return 0 # Same version
+	fi
+
+	if version_leq "$local_ver" "$upstream_ver"; then
+		return 1 # Local is older
+	else
+		return 2 # Local is newer (shouldn't happen normally)
+	fi
 }
 
 # Show version info
 cmd_version() {
-    local subagent_file="$LOCAL_SUBAGENT"
-    if [[ -f "$SOURCE_SUBAGENT" ]]; then
-        subagent_file="$SOURCE_SUBAGENT"
-    fi
-    
-    local local_ver
-    local_ver=$(get_local_version "$subagent_file")
-    local upstream_tracked
-    upstream_tracked=$(get_upstream_version "$subagent_file")
-    
-    echo -e "${BOLD}Humanise Subagent Versions${NC}"
-    echo "=========================="
-    echo ""
-    echo -e "Local version:    ${CYAN}${local_ver}${NC}"
-    echo -e "Tracking upstream: ${CYAN}${upstream_tracked}${NC}"
-    echo -e "Upstream repo:    ${BLUE}https://github.com/${UPSTREAM_REPO}${NC}"
-    echo ""
-    
-    if [[ -f "$CACHE_VERSION_FILE" ]]; then
-        local cached_ver
-        cached_ver=$(cat "$CACHE_VERSION_FILE")
-        echo -e "Cached upstream:  ${CYAN}${cached_ver}${NC}"
-    fi
+	local subagent_file="$LOCAL_SUBAGENT"
+	if [[ -f "$SOURCE_SUBAGENT" ]]; then
+		subagent_file="$SOURCE_SUBAGENT"
+	fi
+
+	local local_ver
+	local_ver=$(get_local_version "$subagent_file")
+	local upstream_tracked
+	upstream_tracked=$(get_upstream_version "$subagent_file")
+
+	echo -e "${BOLD}Humanise Subagent Versions${NC}"
+	echo "=========================="
+	echo ""
+	echo -e "Local version:    ${CYAN}${local_ver}${NC}"
+	echo -e "Tracking upstream: ${CYAN}${upstream_tracked}${NC}"
+	echo -e "Upstream repo:    ${BLUE}https://github.com/${UPSTREAM_REPO}${NC}"
+	echo ""
+
+	if [[ -f "$CACHE_VERSION_FILE" ]]; then
+		local cached_ver
+		cached_ver=$(cat "$CACHE_VERSION_FILE")
+		echo -e "Cached upstream:  ${CYAN}${cached_ver}${NC}"
+	fi
+	return 0
 }
 
 # Check for updates
 cmd_check() {
-    local subagent_file="$LOCAL_SUBAGENT"
-    if [[ -f "$SOURCE_SUBAGENT" ]]; then
-        subagent_file="$SOURCE_SUBAGENT"
-    fi
-    
-    if [[ ! -f "$subagent_file" ]]; then
-        echo -e "${RED}Humanise subagent not found at: ${subagent_file}${NC}"
-        echo "Run setup.sh to deploy agents."
-        return 1
-    fi
-    
-    local upstream_tracked
-    upstream_tracked=$(get_upstream_version "$subagent_file")
-    
-    if ! fetch_upstream; then
-        return 1
-    fi
-    
-    local upstream_latest
-    upstream_latest=$(cat "$CACHE_VERSION_FILE")
-    
-    echo ""
-    echo -e "${BOLD}Update Check${NC}"
-    echo "============"
-    echo ""
-    echo -e "Tracking version: ${CYAN}${upstream_tracked}${NC}"
-    echo -e "Latest upstream:  ${CYAN}${upstream_latest}${NC}"
-    echo ""
-    
-    if compare_versions "$upstream_tracked" "$upstream_latest"; then
-        echo -e "${GREEN}Up to date with upstream.${NC}"
-        return 0
-    else
-        echo -e "${YELLOW}UPDATE AVAILABLE${NC}"
-        echo ""
-        echo "The upstream humanizer skill has been updated."
-        echo "Review changes and incorporate into the subagent:"
-        echo ""
-        echo "  1. Run: humanise-update-helper.sh diff"
-        echo "  2. Review changes at: https://github.com/${UPSTREAM_REPO}/commits/main"
-        echo "  3. Update .agents/content/humanise.md with relevant changes"
-        echo "  4. Update upstream_version in frontmatter to: ${upstream_latest}"
-        echo ""
-        return 1
-    fi
+	local subagent_file="$LOCAL_SUBAGENT"
+	if [[ -f "$SOURCE_SUBAGENT" ]]; then
+		subagent_file="$SOURCE_SUBAGENT"
+	fi
+
+	if [[ ! -f "$subagent_file" ]]; then
+		echo -e "${RED}Humanise subagent not found at: ${subagent_file}${NC}"
+		echo "Run setup.sh to deploy agents."
+		return 1
+	fi
+
+	local upstream_tracked
+	upstream_tracked=$(get_upstream_version "$subagent_file")
+
+	if ! fetch_upstream; then
+		return 1
+	fi
+
+	local upstream_latest
+	upstream_latest=$(cat "$CACHE_VERSION_FILE")
+
+	echo ""
+	echo -e "${BOLD}Update Check${NC}"
+	echo "============"
+	echo ""
+	echo -e "Tracking version: ${CYAN}${upstream_tracked}${NC}"
+	echo -e "Latest upstream:  ${CYAN}${upstream_latest}${NC}"
+	echo ""
+
+	if compare_versions "$upstream_tracked" "$upstream_latest"; then
+		echo -e "${GREEN}Up to date with upstream.${NC}"
+		return 0
+	else
+		echo -e "${YELLOW}UPDATE AVAILABLE${NC}"
+		echo ""
+		echo "The upstream humanizer skill has been updated."
+		echo "Review changes and incorporate into the subagent:"
+		echo ""
+		echo "  1. Run: humanise-update-helper.sh diff"
+		echo "  2. Review changes at: https://github.com/${UPSTREAM_REPO}/commits/main"
+		echo "  3. Update .agents/content/humanise.md with relevant changes"
+		echo "  4. Update upstream_version in frontmatter to: ${upstream_latest}"
+		echo ""
+		return 1
+	fi
 }
 
 # Show diff between local and upstream
 cmd_diff() {
-    local subagent_file="$LOCAL_SUBAGENT"
-    if [[ -f "$SOURCE_SUBAGENT" ]]; then
-        subagent_file="$SOURCE_SUBAGENT"
-    fi
-    
-    if ! fetch_upstream; then
-        return 1
-    fi
-    
-    if [[ ! -f "$CACHE_FILE" ]]; then
-        echo -e "${RED}No cached upstream file. Run 'check' first.${NC}"
-        return 1
-    fi
-    
-    echo -e "${BOLD}Diff: Local Subagent vs Upstream SKILL.md${NC}"
-    echo "=========================================="
-    echo ""
-    echo "Note: Local subagent has aidevops-specific adaptations."
-    echo "Focus on content changes in the upstream patterns."
-    echo ""
-    
-    # Show diff (ignore frontmatter differences)
-    if command -v delta &>/dev/null; then
-        diff -u "$subagent_file" "$CACHE_FILE" | delta --side-by-side || true
-    elif command -v colordiff &>/dev/null; then
-        diff -u "$subagent_file" "$CACHE_FILE" | colordiff || true
-    else
-        diff -u "$subagent_file" "$CACHE_FILE" || true
-    fi
-    
-    echo ""
-    echo -e "${BLUE}Upstream commits: https://github.com/${UPSTREAM_REPO}/commits/main${NC}"
+	local subagent_file="$LOCAL_SUBAGENT"
+	if [[ -f "$SOURCE_SUBAGENT" ]]; then
+		subagent_file="$SOURCE_SUBAGENT"
+	fi
+
+	if [[ ! -f "$subagent_file" ]]; then
+		echo -e "${RED}Humanise subagent not found at: ${subagent_file}${NC}"
+		echo "Run setup.sh to deploy agents."
+		return 1
+	fi
+
+	if ! fetch_upstream; then
+		return 1
+	fi
+
+	if [[ ! -f "$CACHE_FILE" ]]; then
+		echo -e "${RED}No cached upstream file. Run 'check' first.${NC}"
+		return 1
+	fi
+
+	echo -e "${BOLD}Diff: Local Subagent vs Upstream SKILL.md${NC}"
+	echo "=========================================="
+	echo ""
+	echo "Note: Local subagent has aidevops-specific adaptations."
+	echo "Focus on content changes in the upstream patterns."
+	echo ""
+
+	# Strip YAML frontmatter (between --- markers) before diffing
+	# Local subagent has aidevops-specific frontmatter that differs from upstream
+	local tmp_local tmp_upstream
+	tmp_local=$(mktemp)
+	tmp_upstream=$(mktemp)
+	# shellcheck disable=SC2064
+	trap "rm -f '$tmp_local' '$tmp_upstream'" EXIT
+
+	sed '1{/^---$/d}; 1,/^---$/d' "$subagent_file" >"$tmp_local"
+	sed '1{/^---$/d}; 1,/^---$/d' "$CACHE_FILE" >"$tmp_upstream"
+
+	# Show diff with best available tool
+	if command -v delta &>/dev/null; then
+		diff -u "$tmp_local" "$tmp_upstream" | delta --side-by-side || true
+	elif command -v colordiff &>/dev/null; then
+		diff -u "$tmp_local" "$tmp_upstream" | colordiff || true
+	else
+		diff -u "$tmp_local" "$tmp_upstream" || true
+	fi
+
+	echo ""
+	echo -e "${BLUE}Upstream commits: https://github.com/${UPSTREAM_REPO}/commits/main${NC}"
+	return 0
 }
 
 # Show help
 cmd_help() {
-    echo "Humanise Update Helper"
-    echo "======================"
-    echo ""
-    echo "Checks for updates to the upstream humanizer skill from:"
-    echo "  https://github.com/${UPSTREAM_REPO}"
-    echo ""
-    echo "Usage:"
-    echo "  humanise-update-helper.sh check     Check for upstream updates"
-    echo "  humanise-update-helper.sh diff      Show diff between local and upstream"
-    echo "  humanise-update-helper.sh version   Show current versions"
-    echo "  humanise-update-helper.sh help      Show this help"
-    echo ""
-    echo "The humanise subagent is adapted from the upstream skill with:"
-    echo "  - British English spelling (humanise, colour, etc.)"
-    echo "  - aidevops frontmatter format"
-    echo "  - Integration with content.md main agent"
-    echo ""
-    echo "When updates are available:"
-    echo "  1. Review the diff and upstream commits"
-    echo "  2. Incorporate relevant changes into .agents/content/humanise.md"
-    echo "  3. Update the upstream_version field in frontmatter"
+	echo "Humanise Update Helper"
+	echo "======================"
+	echo ""
+	echo "Checks for updates to the upstream humanizer skill from:"
+	echo "  https://github.com/${UPSTREAM_REPO}"
+	echo ""
+	echo "Usage:"
+	echo "  humanise-update-helper.sh check     Check for upstream updates"
+	echo "  humanise-update-helper.sh diff      Show diff between local and upstream"
+	echo "  humanise-update-helper.sh version   Show current versions"
+	echo "  humanise-update-helper.sh help      Show this help"
+	echo ""
+	echo "The humanise subagent is adapted from the upstream skill with:"
+	echo "  - British English spelling (humanise, colour, etc.)"
+	echo "  - aidevops frontmatter format"
+	echo "  - Integration with content.md main agent"
+	echo ""
+	echo "When updates are available:"
+	echo "  1. Review the diff and upstream commits"
+	echo "  2. Incorporate relevant changes into .agents/content/humanise.md"
+	echo "  3. Update the upstream_version field in frontmatter"
+	return 0
 }
 
 # Main
 main() {
-    local cmd="${1:-check}"
-    
-    case "$cmd" in
-        check)
-            cmd_check
-            ;;
-        diff)
-            cmd_diff
-            ;;
-        version|ver|-v|--version)
-            cmd_version
-            ;;
-        help|-h|--help)
-            cmd_help
-            ;;
-        *)
-            echo "Unknown command: $cmd"
-            echo "Run 'humanise-update-helper.sh help' for usage."
-            exit 1
-            ;;
-    esac
+	local cmd="${1:-check}"
+
+	case "$cmd" in
+	check)
+		cmd_check
+		;;
+	diff)
+		cmd_diff
+		;;
+	version | ver | -v | --version)
+		cmd_version
+		;;
+	help | -h | --help)
+		cmd_help
+		;;
+	*)
+		echo "Unknown command: $cmd"
+		echo "Run 'humanise-update-helper.sh help' for usage."
+		exit 1
+		;;
+	esac
 }
 
 main "$@"

--- a/.agents/scripts/humanise-update-helper.sh
+++ b/.agents/scripts/humanise-update-helper.sh
@@ -32,7 +32,9 @@ readonly BOLD='\033[1m'
 get_local_version() {
 	local subagent_file="$1"
 	if [[ -f "$subagent_file" ]]; then
-		grep -E '^version:' "$subagent_file" | head -1 | sed 's/version:[[:space:]]*//' | tr -d '"'"'"
+		local version
+		version=$(grep -E '^version:' "$subagent_file" | head -1 | sed 's/version:[[:space:]]*//' | tr -d '"'"'" || echo "unknown")
+		echo "${version:-unknown}"
 	else
 		echo "not found"
 	fi
@@ -43,7 +45,9 @@ get_local_version() {
 get_upstream_version() {
 	local subagent_file="$1"
 	if [[ -f "$subagent_file" ]]; then
-		grep -E '^upstream_version:' "$subagent_file" | head -1 | sed 's/upstream_version:[[:space:]]*//' | tr -d '"'"'"
+		local version
+		version=$(grep -E '^upstream_version:' "$subagent_file" | head -1 | sed 's/upstream_version:[[:space:]]*//' | tr -d '"'"'" || echo "unknown")
+		echo "${version:-unknown}"
 	else
 		echo "not found"
 	fi
@@ -173,10 +177,14 @@ cmd_check() {
 	echo -e "Latest upstream:  ${CYAN}${upstream_latest}${NC}"
 	echo ""
 
-	if compare_versions "$upstream_tracked" "$upstream_latest"; then
+	local rc=0
+	compare_versions "$upstream_tracked" "$upstream_latest" || rc=$?
+	case $rc in
+	0)
 		echo -e "${GREEN}Up to date with upstream.${NC}"
 		return 0
-	else
+		;;
+	1)
 		echo -e "${YELLOW}UPDATE AVAILABLE${NC}"
 		echo ""
 		echo "The upstream humanizer skill has been updated."
@@ -188,7 +196,13 @@ cmd_check() {
 		echo "  4. Update upstream_version in frontmatter to: ${upstream_latest}"
 		echo ""
 		return 1
-	fi
+		;;
+	2)
+		echo -e "${YELLOW}Tracked version (${upstream_tracked}) is ahead of upstream (${upstream_latest}).${NC}"
+		echo "Check whether upstream_version was bumped incorrectly or upstream rolled back."
+		return 2
+		;;
+	esac
 }
 
 # Show diff between local and upstream

--- a/.agents/scripts/humanise-update-helper.sh
+++ b/.agents/scripts/humanise-update-helper.sh
@@ -169,6 +169,15 @@ cmd_check() {
 	local upstream_latest
 	upstream_latest=$(cat "$CACHE_VERSION_FILE")
 
+	# Guard against non-numeric version strings that would cause arithmetic errors in version_leq()
+	if [[ "$upstream_tracked" == "unknown" || "$upstream_latest" == "unknown" ]]; then
+		echo ""
+		echo -e "${YELLOW}Could not determine versions (tracked=${upstream_tracked}, upstream=${upstream_latest}).${NC}"
+		echo "Check that the subagent file has upstream_version: in its frontmatter"
+		echo "and that the upstream repo is accessible."
+		return 3
+	fi
+
 	echo ""
 	echo -e "${BOLD}Update Check${NC}"
 	echo "============"
@@ -242,16 +251,40 @@ cmd_diff() {
 	# shellcheck disable=SC2064
 	trap "rm -f '$tmp_local' '$tmp_upstream'" EXIT
 
-	sed '1{/^---$/d}; 1,/^---$/d' "$subagent_file" >"$tmp_local"
-	sed '1{/^---$/d}; 1,/^---$/d' "$CACHE_FILE" >"$tmp_upstream"
+	# Strip YAML frontmatter only when file starts with '---'
+	# Using awk to avoid sed's range deletion eating content when no frontmatter exists
+	strip_frontmatter() {
+		local file="$1"
+		awk '
+			NR == 1 && $0 == "---" { in_fm = 1; next }
+			in_fm && $0 == "---" { in_fm = 0; next }
+			!in_fm { print }
+		' "$file"
+		return 0
+	}
+	strip_frontmatter "$subagent_file" >"$tmp_local"
+	strip_frontmatter "$CACHE_FILE" >"$tmp_upstream"
 
 	# Show diff with best available tool
+	# diff exits 0 (identical), 1 (differences found), >1 (real error)
+	# Only suppress exit 1; propagate real failures
+	local diff_rc=0
+	set +e
 	if command -v delta &>/dev/null; then
-		diff -u "$tmp_local" "$tmp_upstream" | delta --side-by-side || true
+		diff -u "$tmp_local" "$tmp_upstream" | delta --side-by-side
+		diff_rc=$?
 	elif command -v colordiff &>/dev/null; then
-		diff -u "$tmp_local" "$tmp_upstream" | colordiff || true
+		diff -u "$tmp_local" "$tmp_upstream" | colordiff
+		diff_rc=$?
 	else
-		diff -u "$tmp_local" "$tmp_upstream" || true
+		diff -u "$tmp_local" "$tmp_upstream"
+		diff_rc=$?
+	fi
+	set -e
+
+	if [[ $diff_rc -gt 1 ]]; then
+		echo -e "${RED}Failed to generate diff (exit code ${diff_rc}).${NC}"
+		return "$diff_rc"
 	fi
 
 	echo ""


### PR DESCRIPTION
## Summary

Addresses all unactioned review feedback from PR #128 (humanise subagent introduction), filed as quality-debt issue #3748.

### Changes

**Shell script (`humanise-update-helper.sh`):**
- Replace GNU-only `sort -V` with portable `version_leq()` function using bash arithmetic — fixes cross-platform compatibility on macOS/BSD where `sort -V` is unavailable
- Add missing-file guard in `cmd_diff()` — previously could proceed silently when the subagent file was missing, masking errors
- Strip YAML frontmatter before diffing — the comment said "ignore frontmatter differences" but `diff -u` was comparing full files including frontmatter
- Add explicit `return 0` to `cmd_version`, `cmd_diff`, `cmd_help` per project shell conventions

**Markdown (`humanise.md`):**
- Fix MD022: add blank `>` lines around blockquote headings in "Title Case in Headings" section
- Fix curly quotes example: "Before" now shows actual curly quotes (`"..."`) to demonstrate the pattern, "After" shows straight quotes

**Documentation (`content.md`):**
- Add Humanise as step 4 in the pipeline stages (Research → Story → Production → **Humanise** → Distribution → Optimization), renumbering subsequent steps

### Review feedback sources
- CodeRabbit: 4 actionable comments (sort -V, missing-file guard, blockquote MD022, workflow list)
- Augment: 2 suggestions (curly quotes example, diff frontmatter comment)
- Gemini: 1 suggestion (curl stderr — already fixed in merged PR)

Closes #3748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Humanise entry and route, inserted into the content pipeline between Production and Distribution.

* **Documentation**
  * Updated Humanise doc with sentence-style headings and consistent typographic quotation marks.
  * Updated pipeline diagram, quick-reference text, and step numbering to reflect Humanise as step 4 (Distribution → step 5, Optimization → step 6).

* **Chores**
  * Improved CLI helper for version checks, commands/aliases, and diffs that ignore frontmatter.
* **Cleanup**
  * Removed Humanise from legacy tools listing and updated public declarations ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->