### PR TITLE
GH#3741: Namespace plugin template subagent name to avoid collisions

### DIFF
--- a/.agents/templates/plugin-template/plugin.json
+++ b/.agents/templates/plugin-template/plugin.json
@@ -12,7 +12,7 @@
     },
     {
       "file": "{{NAMESPACE}}/example.md",
-      "name": "example",
+      "name": "{{NAMESPACE}}.example",
       "description": "Example subagent",
       "model": "sonnet"
     }


### PR DESCRIPTION
## Summary

- Namespace the example subagent `name` field in the plugin template from `"example"` to `"{{NAMESPACE}}.example"` to prevent collisions in shared subagent indexes when multiple plugins are installed.

## Details

The `file` field already used `{{NAMESPACE}}/example.md` (slash for filesystem paths), but the `name` field — which is the identifier used in shared indexes — was just `"example"`. This could collide with other plugins' subagents. Now uses dot notation (`{{NAMESPACE}}.example`) consistent with how the main agent's name uses `{{NAMESPACE}}`.

Closes #3741

Source: CodeRabbit review on PR #1138.