### PR TITLE
GH#3735: Fix Node.js version string parsing robustness

### DIFF
--- a/.agents/scripts/agno-setup.sh
+++ b/.agents/scripts/agno-setup.sh
@@ -39,8 +39,12 @@ check_prerequisites() {
         print_success "Bun $(bun --version) found (preferred)"
     elif command -v node &> /dev/null; then
         local node_version
-        node_version=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
-        if [[ $node_version -lt 18 ]]; then
+        node_version=$(node --version 2>/dev/null | cut -d'v' -f2 | cut -d'.' -f1)
+        if [[ -z "$node_version" ]] || ! [[ "$node_version" =~ ^[0-9]+$ ]]; then
+            print_error "Could not determine Node.js version"
+            return 1
+        fi
+        if [[ "$node_version" -lt 18 ]]; then
             print_error "Node.js 18+ is required, found v$node_version"
             return 1
         fi

--- a/.agents/scripts/dspyground-helper.sh
+++ b/.agents/scripts/dspyground-helper.sh
@@ -39,8 +39,12 @@ check_nodejs() {
     fi
     
     local node_version
-    node_version=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
-    if [[ $node_version -lt 18 ]]; then
+    node_version=$(node --version 2>/dev/null | cut -d'v' -f2 | cut -d'.' -f1)
+    if [[ -z "$node_version" ]] || ! [[ "$node_version" =~ ^[0-9]+$ ]]; then
+        print_error "Could not determine Node.js version"
+        exit 1
+    fi
+    if [[ "$node_version" -lt 18 ]]; then
         print_error "Node.js 18+ is required, found v$node_version"
         exit 1
     fi

--- a/.agents/scripts/secretlint-helper.sh
+++ b/.agents/scripts/secretlint-helper.sh
@@ -230,8 +230,10 @@ install_secretlint() {
     fi
 
     local node_version
-    node_version=$(node -v | sed 's/v//' | cut -d. -f1)
-    if [[ $node_version -lt 18 ]]; then
+    node_version=$(node -v 2>/dev/null | sed 's/v//' | cut -d. -f1)
+    if [[ -z "$node_version" ]] || ! [[ "$node_version" =~ ^[0-9]+$ ]]; then
+        print_warning "Could not determine Node.js version"
+    elif [[ "$node_version" -lt 18 ]]; then
         print_warning "Node.js 20+ recommended. Current version: $(node -v)"
     fi
 

--- a/.agents/scripts/watercrawl-helper.sh
+++ b/.agents/scripts/watercrawl-helper.sh
@@ -158,7 +158,11 @@ check_node() {
 	fi
 
 	local node_version
-	node_version=$(node -v | sed 's/v//' | cut -d. -f1)
+	node_version=$(node -v 2>/dev/null | sed 's/v//' | cut -d. -f1)
+	if [[ -z "$node_version" ]] || ! [[ "$node_version" =~ ^[0-9]+$ ]]; then
+		print_error "Could not determine Node.js version"
+		return 1
+	fi
 
 	if [[ "$node_version" -lt 14 ]]; then
 		print_error "Node.js 14+ is required. Current version: $(node -v)"

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -261,8 +261,12 @@ setup_augment_context_engine() {
 	fi
 
 	local node_version
-	node_version=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
-	if [[ $node_version -lt 22 ]]; then
+	node_version=$(node --version 2>/dev/null | cut -d'v' -f2 | cut -d'.' -f1)
+	if [[ -z "$node_version" ]] || ! [[ "$node_version" =~ ^[0-9]+$ ]]; then
+		print_warning "Could not determine Node.js version - Augment Context Engine setup skipped"
+		return
+	fi
+	if [[ "$node_version" -lt 22 ]]; then
 		print_warning "Node.js 22+ required for Augment Context Engine, found v$node_version"
 		print_info "Install: brew install node@22 (macOS) or nvm install 22"
 		return

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -992,8 +992,12 @@ setup_nodejs_env() {
 	fi
 
 	local node_version
-	node_version=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
-	if [[ $node_version -lt 18 ]]; then
+	node_version=$(node --version 2>/dev/null | cut -d'v' -f2 | cut -d'.' -f1)
+	if [[ -z "$node_version" ]] || ! [[ "$node_version" =~ ^[0-9]+$ ]]; then
+		print_warning "Could not determine Node.js version - DSPyGround setup skipped"
+		return
+	fi
+	if [[ "$node_version" -lt 18 ]]; then
 		print_warning "Node.js 18+ required for DSPyGround, found v$node_version - DSPyGround setup skipped"
 		return
 	fi


### PR DESCRIPTION
## Summary

- Adds validation guards to all Node.js version parsing code to prevent bash arithmetic errors when `node --version` returns unexpected output
- Redirects stderr to `/dev/null` on version commands and validates the parsed value is non-empty and numeric before `-lt` comparisons
- Fixes the same vulnerable pattern across 6 files (the 2 flagged by gemini-code-assist on PR #1158, plus 4 additional scripts with identical patterns)

## Files Changed

| File | Change |
|------|--------|
| `setup-modules/tool-install.sh` | Guard `setup_nodejs_env()` version check |
| `setup-modules/mcp-setup.sh` | Guard `setup_augment_context_engine()` version check |
| `.agents/scripts/agno-setup.sh` | Guard `check_prerequisites()` version check |
| `.agents/scripts/dspyground-helper.sh` | Guard `check_nodejs()` version check |
| `.agents/scripts/watercrawl-helper.sh` | Guard `check_node()` version check |
| `.agents/scripts/secretlint-helper.sh` | Guard `install_secretlint()` version check |

## Pattern Applied

Before (vulnerable):
```bash
node_version=$(node --version | cut -d'v' -f2 | cut -d'.' -f1)
if [[ $node_version -lt 18 ]]; then
```

After (robust):
```bash
node_version=$(node --version 2>/dev/null | cut -d'v' -f2 | cut -d'.' -f1)
if [[ -z "$node_version" ]] || ! [[ "$node_version" =~ ^[0-9]+$ ]]; then
    print_warning "Could not determine Node.js version"
    return
fi
if [[ "$node_version" -lt 18 ]]; then
```

## Verification

- All 6 modified files pass `shellcheck -x -S warning` with zero violations
- `peekaboo-helper.sh` already had this guard pattern — used as reference

Closes #3735