### PR TITLE
GH#3732: Fix stray :1 suffix and path style in enhancor.md

### DIFF
--- a/.agents/tools/video/enhancor.md
+++ b/.agents/tools/video/enhancor.md
@@ -255,7 +255,7 @@ Enhancor integrates into the content production pipeline as a post-processing st
 3. **Optimize** for web delivery (compression, format conversion)
 4. **Distribute** to target platforms
 
-**See**: `content/production/image.md` for full integration details.
+**See**: `.agents/content/production/image.md` for full integration details.
 
 ## Use Cases
 
@@ -344,8 +344,8 @@ enhancor-helper.sh enhance --img-url URL \
 
 - **Website**: https://www.enhancor.ai/
 - **API Docs**: https://github.com/rohan-kulkarni-25/enhancor-api-docs
-- **Helper Script**: `.agents/scripts/enhancor-helper.sh:1`
-- **Integration**: `content/production/image.md` (post-processing step)
+- **Helper Script**: `.agents/scripts/enhancor-helper.sh`
+- **Integration**: `.agents/content/production/image.md` (post-processing step)
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Removes stray `:1` line-number anchor from helper script path reference on line 347
- Adds missing `.agents/` prefix to `content/production/image.md` path references (lines 258, 348) for consistency with the repo-root path convention used elsewhere in the file

Addresses review feedback from CodeRabbit and Gemini Code Assist on PR #1194.

Closes #3732