### PR TITLE
fix: address quality-debt in real-video-enhancer-helper.sh (GH#3729)

### DIFF
--- a/.agents/scripts/real-video-enhancer-helper.sh
+++ b/.agents/scripts/real-video-enhancer-helper.sh
@@ -33,13 +33,13 @@ readonly RVE_PYTHON_MIN="3.10"
 readonly RVE_PYTHON_MAX="3.12"
 
 # Default settings
-DEFAULT_SCALE=2
-DEFAULT_FPS=60
-DEFAULT_INTERPOLATE_MODEL="rife"
-DEFAULT_UPSCALE_MODEL="span"
-DEFAULT_DENOISE_MODEL="drunet"
-DEFAULT_TILE_SIZE=1024
-DEFAULT_BACKEND="auto"
+readonly DEFAULT_SCALE=2
+readonly DEFAULT_FPS=60
+readonly DEFAULT_INTERPOLATE_MODEL="rife"
+readonly DEFAULT_UPSCALE_MODEL="span"
+readonly DEFAULT_DENOISE_MODEL="drunet"
+readonly DEFAULT_TILE_SIZE=1024
+readonly DEFAULT_BACKEND="auto"
 
 # =============================================================================
 # Helper Functions
@@ -675,7 +675,6 @@ cmd_enhance() {
 	fi
 
 	if ! cmd_upscale "${upscale_args[@]}"; then
-		rm -rf "$temp_dir"
 		return 1
 	fi
 
@@ -693,7 +692,6 @@ cmd_enhance() {
 	fi
 
 	if ! cmd_interpolate "${interpolate_args[@]}"; then
-		rm -rf "$temp_dir"
 		return 1
 	fi
 
@@ -711,16 +709,12 @@ cmd_enhance() {
 		fi
 
 		if ! cmd_denoise "${denoise_args[@]}"; then
-			rm -rf "$temp_dir"
 			return 1
 		fi
 	else
 		print_info "[3/3] Skipping denoising"
 		mv "$temp_interpolated" "$output"
 	fi
-
-	# Cleanup
-	rm -rf "$temp_dir"
 
 	print_success "Enhancement complete: $output"
 	return 0
@@ -1059,6 +1053,8 @@ Examples:
 
 For more information, see: .agents/tools/video/real-video-enhancer.md
 EOF
+
+	return 0
 }
 
 # =============================================================================
@@ -1114,6 +1110,8 @@ main() {
 		exit 1
 		;;
 	esac
+
+	return 0
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Addresses all 4 unactioned review findings from PR #1193 on `.agents/scripts/real-video-enhancer-helper.sh`.

Closes #3729

## Changes

### HIGH: Remove redundant temp directory cleanup (line 662)
- The `trap 'rm -rf -- "$temp_dir"' RETURN` already guarantees cleanup when `cmd_enhance` returns (normal or error)
- Removed 4 redundant `rm -rf "$temp_dir"` calls that were duplicating the trap's work
- This makes the cleanup path simpler and less error-prone

### MEDIUM: Declare DEFAULT_* variables as readonly (line 42)
- All 7 `DEFAULT_*` constants (`DEFAULT_SCALE`, `DEFAULT_FPS`, `DEFAULT_INTERPOLATE_MODEL`, `DEFAULT_UPSCALE_MODEL`, `DEFAULT_DENOISE_MODEL`, `DEFAULT_TILE_SIZE`, `DEFAULT_BACKEND`) now use `readonly` per style guide

### MEDIUM: Add explicit return 0 to cmd_help (line 1065)
- Function now has explicit `return 0` per style guide requirement

### MEDIUM: Add explicit return 0 to main (line 1120)
- Function now has explicit `return 0` per style guide requirement

## Verification

- ShellCheck: zero violations (only SC1091 info about external source, expected)
- Bash syntax validation: passes