### PR TITLE
GH#3698: Fix quality-debt findings in email-thread-reconstruction.py

### DIFF
--- a/.agents/scripts/email-thread-reconstruction.py
+++ b/.agents/scripts/email-thread-reconstruction.py
@@ -14,6 +14,7 @@ message_id and in_reply_to headers, and adds thread metadata to frontmatter:
 Also generates a thread index file listing all emails in chronological order per thread.
 """
 
+import os
 import sys
 import re
 from pathlib import Path
@@ -215,6 +216,9 @@ def generate_thread_index(threads, output_file):
     lines.append(f"Total threads: {len(threads)}")
     lines.append("")
 
+    # Resolve the output directory for computing relative paths to email files
+    output_dir = Path(output_file).resolve().parent
+
     # Sort threads by date of first message
     sorted_threads = sorted(
         threads.items(),
@@ -236,7 +240,10 @@ def generate_thread_index(threads, output_file):
         lines.append("")
 
         for i, email in enumerate(emails, 1):
-            file_path = Path(email["file"]).name
+            # Compute relative path from index file location to email file
+            file_path = os.path.relpath(
+                Path(email["file"]).resolve(), output_dir
+            )
             email_subject = email.get("subject", "No Subject")
             from_addr = email.get("from", "Unknown")
             date_sent = email.get("date_sent", "Unknown")
@@ -251,7 +258,7 @@ def generate_thread_index(threads, output_file):
         lines.append("")
 
     with open(output_file, "w", encoding="utf-8") as f:
-        f.write("\n".join(lines))
+        f.write("\n".join(lines) + "\n")
 
     return output_file
 

--- a/tests/test-email-thread-reconstruction.sh
+++ b/tests/test-email-thread-reconstruction.sh
@@ -193,6 +193,50 @@ test_thread_index_content() {
 	return 0
 }
 
+test_trailing_newline() {
+	print_info "Test: Generated index ends with trailing newline"
+
+	local index_file="${TEST_DIR}/thread-index.md"
+
+	# POSIX: text files must end with a newline
+	local last_byte
+	last_byte=$(tail -c 1 "$index_file" | xxd -p)
+	if [[ "$last_byte" != "0a" ]]; then
+		print_error "Thread index does not end with trailing newline"
+		return 1
+	fi
+
+	print_success "Trailing newline present"
+	return 0
+}
+
+test_relative_paths_cross_directory() {
+	print_info "Test: Index links use relative paths (cross-directory output)"
+
+	local output_dir="${TEST_DIR}/subdir"
+	mkdir -p "$output_dir"
+
+	# Run reconstruction with output in a subdirectory
+	if ! python3 "$THREAD_RECON_SCRIPT" "$TEST_DIR" --output "${output_dir}/index.md" >/dev/null 2>&1; then
+		print_error "Thread reconstruction with cross-directory output failed"
+		return 1
+	fi
+
+	local index_file="${output_dir}/index.md"
+
+	# Links should use relative paths back to parent (e.g., ../email1.md)
+	if ! grep -q '\.\./email' "$index_file"; then
+		print_error "Index links do not use relative paths to parent directory"
+		return 1
+	fi
+
+	# Clean up the subdirectory output
+	rm -rf "$output_dir"
+
+	print_success "Relative paths correct for cross-directory output"
+	return 0
+}
+
 # =============================================================================
 # Main
 # =============================================================================
@@ -207,6 +251,8 @@ main() {
 	test_thread_reconstruction || failed=$((failed + 1))
 	test_frontmatter_updates || failed=$((failed + 1))
 	test_thread_index_content || failed=$((failed + 1))
+	test_trailing_newline || failed=$((failed + 1))
+	test_relative_paths_cross_directory || failed=$((failed + 1))
 
 	cleanup_test_data
 


### PR DESCRIPTION
## Summary

- Fix thread index links to use relative paths (`os.path.relpath`) from the index file location to each email file, so `--output` to a different directory produces working markdown links (MEDIUM severity finding)
- Add POSIX-compliant trailing newline to generated thread index files (HIGH severity finding)
- Finding #1 (singular/plural grammar) was already resolved in the original PR #1461

## Tests

- Added `test_trailing_newline` — verifies generated index ends with `\n`
- Added `test_relative_paths_cross_directory` — verifies links use `../` when index is written to a subdirectory

All 5 tests pass.

Closes #3698