### PR TITLE
GH#3706: Fix critical security findings in code-audit-helper.sh

### DIFF
--- a/.agents/scripts/code-audit-helper.sh
+++ b/.agents/scripts/code-audit-helper.sh
@@ -172,6 +172,10 @@ get_head_sha() {
 sql_escape() {
 	local val
 	val="$1"
+	# Replace newlines and carriage returns with spaces to prevent
+	# multi-line SQL corruption in line-by-line INSERT generation
+	val="${val//$'\n'/ }"
+	val="${val//$'\r'/}"
 	val="${val//\'/\'\'}"
 	echo "$val"
 	return 0
@@ -621,6 +625,10 @@ cmd_audit() {
 	# Auto-detect PR if not specified
 	if [[ "$pr_number" -eq 0 ]]; then
 		pr_number=$(gh pr view --json number -q .number 2>/dev/null || echo "0")
+		if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+			log_warn "Could not auto-detect PR number, defaulting to 0"
+			pr_number=0
+		fi
 	fi
 
 	local head_sha


### PR DESCRIPTION
## Summary

- Validate auto-detected PR number from `gh pr view` to prevent SQL injection when `gh` returns unexpected non-numeric output (CodeRabbit HIGH finding from PR #1376)
- Harden `sql_escape()` with newline/CR stripping to prevent multi-line SQL corruption in `import_coderabbit_findings` line-by-line INSERT generation (CodeRabbit nitpick from PR #1376)

## Details

**Fix 1 — SQL injection via unvalidated auto-detected PR number (HIGH)**

Line 623 calls `gh pr view --json number -q .number` and assigns the result directly to `pr_number`. While the `--pr` CLI argument was already validated (line 611), the auto-detected path bypassed validation entirely. If `gh` returned unexpected output (error string leaking to stdout), it would flow directly into SQL interpolation on line 638.

Added numeric regex validation (`^[0-9]+$`) immediately after the `gh pr view` assignment, defaulting to 0 on failure.

**Fix 2 — SQL file corruption from multi-line descriptions (MEDIUM)**

`sql_escape()` only escaped single quotes for SQLite. Multi-line descriptions (from API responses or code comments) containing literal newlines would split INSERT statements across multiple lines in the SQL file generated by `import_coderabbit_findings`, causing parse errors.

Added `$'\n'` and `$'\r'` replacement with spaces before the quote escaping step.

## Verification

- `bash -n`: PASS
- `shellcheck -x`: zero violations
- Both fixes are minimal, targeted, and consistent with existing validation patterns in the file

Closes #3706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data handling to prevent corruption from multiline input
  * Enhanced PR auto-detection with validation and fallback handling for edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->