### PR TITLE
GH#4070: Fix 11 Matrix bot bugs from first-time setup

### DIFF
--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -211,11 +211,13 @@ cmd_setup() {
 	existing_token=$(config_get "accessToken")
 	if [[ -n "$existing_token" ]]; then
 		echo -n "Bot access token [****${existing_token: -8}]: "
-		read -r access_token </dev/tty
+		read -rs access_token </dev/tty
+		echo ""
 		access_token="${access_token:-$existing_token}"
 	else
 		echo -n "Bot access token: "
-		read -r access_token </dev/tty
+		read -rs access_token </dev/tty
+		echo ""
 	fi
 
 	if [[ -z "$access_token" ]]; then
@@ -387,14 +389,14 @@ cmd_setup() {
 				done <<<"$mappings"
 
 				if ((${#missing_runners[@]} > 0)); then
-					log_warn "The following mapped runners do not exist yet:"
+					log_info "Creating missing runners for mapped rooms..."
 					for mr in "${missing_runners[@]}"; do
-						echo "  - $mr"
-					done
-					echo ""
-					echo "Create them with:"
-					for mr in "${missing_runners[@]}"; do
-						echo "  runner-helper.sh create $mr --description \"Description\" --workdir /path/to/project"
+						if "$runner_helper" create "$mr" --description "Matrix bot runner for $mr" 2>/dev/null; then
+							log_success "Created runner: $mr"
+						else
+							log_warn "Failed to create runner: $mr"
+							echo "  Create manually: runner-helper.sh create $mr --description \"Description\" --workdir /path/to/project"
+						fi
 					done
 					echo ""
 				fi
@@ -1090,21 +1092,7 @@ async function dispatchViaAPI(prompt, runnerName) {
     if (!msgRes.ok) throw new Error(`Failed to send message: ${msgRes.status}`);
     const rawText = await msgRes.text();
 
-    // Parse JSONL stream — extract text parts from streaming response
-    const textParts = [];
-    for (const line of rawText.split("\n")) {
-        if (!line.trim()) continue;
-        try {
-            const event = JSON.parse(line);
-            if (event.type === "text" && event.part?.text) {
-                textParts.push(event.part.text);
-            }
-        } catch {
-            // Skip non-JSON lines
-        }
-    }
-
-    return { sessionId: session.id, text: textParts.join("\n") || "(no response)" };
+    return { sessionId: session.id, text: parseJsonlText(rawText) || "(no response)" };
 }
 
 // Truncate long messages for Matrix
@@ -2686,11 +2674,27 @@ cmd_auto_setup() {
 
 	# ── Step 7: Create rooms and map to runners ──
 	if [[ -n "$runners" ]]; then
-		log_info "Step 7/8: Creating rooms and mapping to runners..."
+		log_info "Step 7/8: Creating rooms, runners, and mapping..."
 
+		local runner_helper="$HOME/.aidevops/agents/scripts/runner-helper.sh"
 		IFS=',' read -ra runner_list <<<"$runners"
 		for runner in "${runner_list[@]}"; do
 			runner=$(echo "$runner" | tr -d ' ')
+
+			# Create the runner if it doesn't exist
+			if [[ -x "$runner_helper" ]]; then
+				if ! "$runner_helper" status "$runner" &>/dev/null; then
+					log_info "Creating runner: $runner"
+					"$runner_helper" create "$runner" --description "Matrix bot runner for $runner" 2>/dev/null || {
+						log_warn "Failed to create runner: $runner"
+					}
+				else
+					log_info "Runner already exists: $runner"
+				fi
+			else
+				log_warn "runner-helper.sh not found — create runners manually: runner-helper.sh create $runner"
+			fi
+
 			local room_name="AI: ${runner}"
 			local room_alias="${runner}"
 
@@ -2965,7 +2969,7 @@ cmd_cleanup_invites() {
 	local rejected=0
 	while IFS= read -r room_id; do
 		# Check if this room is in our mappings
-		if echo "$mapped_rooms" | grep -qF "$room_id"; then
+		if echo "$mapped_rooms" | grep -qxF "$room_id"; then
 			log_info "Keeping invite for mapped room: $room_id"
 			continue
 		fi
@@ -2977,22 +2981,29 @@ cmd_cleanup_invites() {
 
 		log_info "Rejecting stale invite: $room_id ($room_name)"
 
+		# URL-encode room_id safely — pass as argument, not interpolated into code
 		local encoded_room
-		encoded_room=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$room_id'))")
+		encoded_room=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$room_id")
 
-		# Leave (reject invite)
-		curl -sf -X POST "${homeserver}/_matrix/client/v3/rooms/${encoded_room}/leave" \
+		# Leave (reject invite) — check exit code before counting
+		local leave_ok=false
+		if curl -sf -X POST "${homeserver}/_matrix/client/v3/rooms/${encoded_room}/leave" \
 			-H "Authorization: Bearer $access_token" \
 			-H "Content-Type: application/json" \
-			-d '{}' >/dev/null 2>&1
+			-d '{}' >/dev/null 2>&1; then
+			leave_ok=true
+		fi
 
 		# Forget the room
-		curl -sf -X POST "${homeserver}/_matrix/client/v3/rooms/${encoded_room}/forget" \
-			-H "Authorization: Bearer $access_token" \
-			-H "Content-Type: application/json" \
-			-d '{}' >/dev/null 2>&1
-
-		((++rejected))
+		if [[ "$leave_ok" == "true" ]]; then
+			curl -sf -X POST "${homeserver}/_matrix/client/v3/rooms/${encoded_room}/forget" \
+				-H "Authorization: Bearer $access_token" \
+				-H "Content-Type: application/json" \
+				-d '{}' >/dev/null 2>&1
+			((++rejected))
+		else
+			log_error "Failed to leave room: $room_id"
+		fi
 	done <<<"$invited_rooms"
 
 	if ((rejected > 0)); then

--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -183,15 +183,15 @@ cmd_setup() {
 		existing_hs=$(config_get "homeserverUrl")
 		if [[ -n "$existing_hs" ]]; then
 			echo -n "Matrix homeserver URL [$existing_hs]: "
-			read -r homeserver
+			read -r homeserver </dev/tty
 			homeserver="${homeserver:-$existing_hs}"
 		else
 			echo -n "Matrix homeserver URL (e.g., https://matrix.example.com): "
-			read -r homeserver
+			read -r homeserver </dev/tty
 		fi
 	else
 		echo -n "Matrix homeserver URL (e.g., https://matrix.example.com): "
-		read -r homeserver
+		read -r homeserver </dev/tty
 	fi
 
 	if [[ -z "$homeserver" ]]; then
@@ -211,12 +211,11 @@ cmd_setup() {
 	existing_token=$(config_get "accessToken")
 	if [[ -n "$existing_token" ]]; then
 		echo -n "Bot access token [****${existing_token: -8}]: "
-		read -r access_token
+		read -r access_token </dev/tty
 		access_token="${access_token:-$existing_token}"
 	else
 		echo -n "Bot access token: "
-		read -rs access_token
-		echo ""
+		read -r access_token </dev/tty
 	fi
 
 	if [[ -z "$access_token" ]]; then
@@ -236,11 +235,11 @@ cmd_setup() {
 	existing_users=$(config_get "allowedUsers")
 	if [[ -n "$existing_users" ]]; then
 		echo -n "Allowed users [$existing_users]: "
-		read -r allowed_users
+		read -r allowed_users </dev/tty
 		allowed_users="${allowed_users:-$existing_users}"
 	else
 		echo -n "Allowed users (empty = all): "
-		read -r allowed_users
+		read -r allowed_users </dev/tty
 	fi
 
 	# Default runner
@@ -254,11 +253,11 @@ cmd_setup() {
 	existing_runner=$(config_get "defaultRunner")
 	if [[ -n "$existing_runner" ]]; then
 		echo -n "Default runner [$existing_runner]: "
-		read -r default_runner
+		read -r default_runner </dev/tty
 		default_runner="${default_runner:-$existing_runner}"
 	else
 		echo -n "Default runner (empty = ignore unmapped rooms): "
-		read -r default_runner
+		read -r default_runner </dev/tty
 	fi
 
 	# Session idle timeout
@@ -273,11 +272,11 @@ cmd_setup() {
 	existing_timeout=$(config_get "sessionIdleTimeout")
 	if [[ -n "$existing_timeout" ]]; then
 		echo -n "Session idle timeout [${existing_timeout}s]: "
-		read -r idle_timeout
+		read -r idle_timeout </dev/tty
 		idle_timeout="${idle_timeout:-$existing_timeout}"
 	else
 		echo -n "Session idle timeout [300]: "
-		read -r idle_timeout
+		read -r idle_timeout </dev/tty
 		idle_timeout="${idle_timeout:-300}"
 	fi
 
@@ -373,14 +372,46 @@ cmd_setup() {
 	else
 		log_success "Setup complete!"
 		echo ""
+
+		# Check for existing room mappings and warn about missing runners
+		local runner_helper="$HOME/.aidevops/agents/scripts/runner-helper.sh"
+		if config_exists && [[ -x "$runner_helper" ]]; then
+			local mappings
+			mappings=$(jq -r '.roomMappings // {} | values[]' "$CONFIG_FILE" 2>/dev/null)
+			if [[ -n "$mappings" ]]; then
+				local missing_runners=()
+				while IFS= read -r runner_name; do
+					if ! "$runner_helper" status "$runner_name" &>/dev/null; then
+						missing_runners+=("$runner_name")
+					fi
+				done <<<"$mappings"
+
+				if ((${#missing_runners[@]} > 0)); then
+					log_warn "The following mapped runners do not exist yet:"
+					for mr in "${missing_runners[@]}"; do
+						echo "  - $mr"
+					done
+					echo ""
+					echo "Create them with:"
+					for mr in "${missing_runners[@]}"; do
+						echo "  runner-helper.sh create $mr --description \"Description\" --workdir /path/to/project"
+					done
+					echo ""
+				fi
+			fi
+		fi
+
 		echo "Next steps:"
 		echo "  1. Map rooms to runners:"
 		echo "     matrix-dispatch-helper.sh map '!roomid:server' my-runner"
 		echo ""
-		echo "  2. Start the bot:"
+		echo "  2. Create runners for each mapped room:"
+		echo "     runner-helper.sh create <name> --description \"desc\" --workdir /path/to/project"
+		echo ""
+		echo "  3. Start the bot:"
 		echo "     matrix-dispatch-helper.sh start"
 		echo ""
-		echo "  3. In a mapped Matrix room, type:"
+		echo "  4. In a mapped Matrix room, type:"
 		echo "     !ai Review the auth module for security issues"
 	fi
 
@@ -863,7 +894,7 @@ generate_bot_script() {
 // - Loads entity profile + conversation context for prompts
 // - Privacy-aware: filters cross-channel information
 
-import { MatrixClient, SimpleFsStorageProvider, AutojoinRoomsMixin } from "matrix-bot-sdk";
+import { MatrixClient, SimpleFsStorageProvider } from "matrix-bot-sdk";
 import { readFileSync } from "fs";
 import { spawn } from "child_process";
 import * as store from "./session-store.mjs";
@@ -982,6 +1013,23 @@ function buildCompactionPrompt(roomId, entityId = "") {
     return parts.join("\n");
 }
 
+// Parse JSONL output to extract text parts from OpenCode streaming responses
+function parseJsonlText(raw) {
+    const textParts = [];
+    for (const line of raw.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+            const event = JSON.parse(line);
+            if (event.type === "text" && event.part?.text) {
+                textParts.push(event.part.text);
+            }
+        } catch {
+            // Skip non-JSON lines (log output, stderr mixed in, etc.)
+        }
+    }
+    return textParts.join("\n") || raw.trim();
+}
+
 // Dispatch to runner via runner-helper.sh
 async function dispatchToRunner(runnerName, prompt) {
     return new Promise((resolve, reject) => {
@@ -1003,7 +1051,7 @@ async function dispatchToRunner(runnerName, prompt) {
 
         proc.on("close", (code) => {
             if (code === 0) {
-                resolve(stdout.trim());
+                resolve(parseJsonlText(stdout));
             } else {
                 reject(new Error(`Runner exited with code ${code}: ${stderr}`));
             }
@@ -1040,12 +1088,21 @@ async function dispatchViaAPI(prompt, runnerName) {
     });
 
     if (!msgRes.ok) throw new Error(`Failed to send message: ${msgRes.status}`);
-    const response = await msgRes.json();
+    const rawText = await msgRes.text();
 
-    // Extract text from response
-    const textParts = (response.parts || [])
-        .filter(p => p.type === "text")
-        .map(p => p.text);
+    // Parse JSONL stream — extract text parts from streaming response
+    const textParts = [];
+    for (const line of rawText.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+            const event = JSON.parse(line);
+            if (event.type === "text" && event.part?.text) {
+                textParts.push(event.part.text);
+            }
+        } catch {
+            // Skip non-JSON lines
+        }
+    }
 
     return { sessionId: session.id, text: textParts.join("\n") || "(no response)" };
 }
@@ -1216,8 +1273,16 @@ async function main() {
     const matrixStorage = new SimpleFsStorageProvider(`${process.env.HOME}/.aidevops/.agent-workspace/matrix-bot/bot-storage.json`);
     const client = new MatrixClient(config.homeserverUrl, config.accessToken, matrixStorage);
 
-    // Auto-join rooms when invited
-    AutojoinRoomsMixin.setupOnClient(client);
+    // Auto-join rooms when invited (with error handling to prevent crashes on stale invites)
+    client.on("room.invite", async (roomId, inviteEvent) => {
+        try {
+            console.log(`[MATRIX-BOT] Invited to room ${roomId}, attempting to join...`);
+            await client.joinRoom(roomId);
+            console.log(`[MATRIX-BOT] Joined room ${roomId}`);
+        } catch (err) {
+            console.warn(`[MATRIX-BOT] Failed to join room ${roomId}: ${err.message} — skipping`);
+        }
+    });
 
     // Track active dispatches to prevent flooding
     const activeDispatches = new Set();
@@ -1279,7 +1344,7 @@ async function main() {
         console.log(`[MATRIX-BOT] Dispatching to runner '${runnerName}' from ${event.sender} in ${roomId}`);
 
         // Send typing indicator
-        await client.sendTyping(roomId, true, 30000).catch(() => {});
+        await client.setTyping(roomId, true, 30000).catch(() => {});
 
         // React with hourglass to acknowledge
         await client.sendEvent(roomId, "m.reaction", {
@@ -1357,13 +1422,24 @@ async function main() {
             }).catch(() => {});
         } finally {
             activeDispatches.delete(dispatchKey);
-            await client.sendTyping(roomId, false).catch(() => {});
+            await client.setTyping(roomId, false).catch(() => {});
         }
     });
 
     // Start syncing
     await client.start();
     console.log("[MATRIX-BOT] Bot started and syncing");
+
+    // Join all mapped rooms on startup (ensures bot is in rooms created while it was offline)
+    const mappedRooms = Object.keys(config.roomMappings || {});
+    for (const roomId of mappedRooms) {
+        try {
+            await client.joinRoom(roomId);
+            console.log(`[MATRIX-BOT] Joined mapped room ${roomId}`);
+        } catch (err) {
+            console.warn(`[MATRIX-BOT] Could not join mapped room ${roomId}: ${err.message}`);
+        }
+    }
 
     // Graceful shutdown: compact all active sessions, then exit
     async function shutdown() {
@@ -2841,6 +2917,94 @@ EOF
 }
 
 #######################################
+#######################################
+# Cleanup stale invites
+# Rejects pending invites to rooms not in the room mappings
+#######################################
+cmd_cleanup_invites() {
+	if ! config_exists; then
+		log_error "Bot not configured. Run: matrix-dispatch-helper.sh setup"
+		return 1
+	fi
+
+	local access_token
+	access_token=$(config_get "accessToken")
+	local homeserver
+	homeserver=$(config_get "homeserverUrl")
+
+	if [[ -z "$access_token" || -z "$homeserver" ]]; then
+		log_error "Missing accessToken or homeserverUrl in config"
+		return 1
+	fi
+
+	log_info "Fetching pending invites..."
+
+	# Get sync data to find pending invites
+	local sync_data
+	sync_data=$(curl -sf "${homeserver}/_matrix/client/v3/sync?filter=%7B%22room%22%3A%7B%22timeline%22%3A%7B%22limit%22%3A0%7D%7D%7D" \
+		-H "Authorization: Bearer $access_token" 2>/dev/null)
+
+	if [[ -z "$sync_data" ]]; then
+		log_error "Failed to fetch sync data from homeserver"
+		return 1
+	fi
+
+	# Get invited room IDs
+	local invited_rooms
+	invited_rooms=$(echo "$sync_data" | jq -r '.rooms.invite // {} | keys[]' 2>/dev/null)
+
+	if [[ -z "$invited_rooms" ]]; then
+		log_info "No pending invites"
+		return 0
+	fi
+
+	# Get mapped room IDs
+	local mapped_rooms
+	mapped_rooms=$(jq -r '.roomMappings // {} | keys[]' "$CONFIG_FILE" 2>/dev/null)
+
+	local rejected=0
+	while IFS= read -r room_id; do
+		# Check if this room is in our mappings
+		if echo "$mapped_rooms" | grep -qF "$room_id"; then
+			log_info "Keeping invite for mapped room: $room_id"
+			continue
+		fi
+
+		# Get room name from invite state
+		local room_name
+		room_name=$(echo "$sync_data" | jq -r --arg rid "$room_id" \
+			'.rooms.invite[$rid].invite_state.events[] | select(.type == "m.room.name") | .content.name // "unknown"' 2>/dev/null)
+
+		log_info "Rejecting stale invite: $room_id ($room_name)"
+
+		local encoded_room
+		encoded_room=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$room_id'))")
+
+		# Leave (reject invite)
+		curl -sf -X POST "${homeserver}/_matrix/client/v3/rooms/${encoded_room}/leave" \
+			-H "Authorization: Bearer $access_token" \
+			-H "Content-Type: application/json" \
+			-d '{}' >/dev/null 2>&1
+
+		# Forget the room
+		curl -sf -X POST "${homeserver}/_matrix/client/v3/rooms/${encoded_room}/forget" \
+			-H "Authorization: Bearer $access_token" \
+			-H "Content-Type: application/json" \
+			-d '{}' >/dev/null 2>&1
+
+		((++rejected))
+	done <<<"$invited_rooms"
+
+	if ((rejected > 0)); then
+		log_success "Rejected $rejected stale invite(s)"
+		echo "Restart the bot to apply: matrix-dispatch-helper.sh stop && matrix-dispatch-helper.sh start"
+	else
+		log_info "All pending invites are for mapped rooms"
+	fi
+
+	return 0
+}
+
 # Main
 #######################################
 main() {
@@ -2859,6 +3023,7 @@ main() {
 	sessions) cmd_sessions "$@" ;;
 	test) cmd_test "$@" ;;
 	logs) cmd_logs "$@" ;;
+	cleanup-invites) cmd_cleanup_invites "$@" ;;
 	help | --help | -h) cmd_help ;;
 	*)
 		log_error "Unknown command: $command"

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -544,6 +544,9 @@ cmd_run() {
 			fi
 		fi
 
+		# Working directory
+		cmd_args+=("--dir" "$workdir")
+
 		# Output format
 		if [[ -n "$format" ]]; then
 			cmd_args+=("--format" "$format")
@@ -576,6 +579,9 @@ cmd_run() {
 				log_warn "No previous session found for $name, starting fresh"
 			fi
 		fi
+
+		# Working directory
+		cmd_args+=("--dir" "$workdir")
 
 		# Claude CLI does not support --attach (server mode)
 		if [[ -n "$attach" ]]; then

--- a/.agents/services/communications/matrix-bot.md
+++ b/.agents/services/communications/matrix-bot.md
@@ -454,7 +454,7 @@ runner-helper.sh edit code-reviewer
 | Access denied | Check `allowedUsers` in config |
 | Bot not joining rooms | Invite the bot user to the room via Element |
 | Bot crashes on startup | Run `matrix-dispatch-helper.sh cleanup-invites` to reject stale invites |
-| Raw JSON in responses | Regenerate bot script: `matrix-dispatch-helper.sh setup` |
+| Raw JSON in responses | Regenerate bot script: `matrix-dispatch-helper.sh setup`, then restart: `matrix-dispatch-helper.sh stop && matrix-dispatch-helper.sh start` |
 | Stale PID file | Run `matrix-dispatch-helper.sh stop` to clean up |
 | Wrong working directory | Check runner config: `runner-helper.sh status <name>` (verify workdir) |
 

--- a/.agents/services/communications/matrix-bot.md
+++ b/.agents/services/communications/matrix-bot.md
@@ -135,35 +135,68 @@ Cloudron provides one-click Synapse installation with automatic SSL and updates.
 ```bash
 # 1. Install Synapse on Cloudron
 # Dashboard > App Store > Matrix Synapse > Install
+# Set user management to "Leave user management to the app"
 # Or via CLI: cloudron-helper.sh install-app production matrix synapse.yourdomain.com
 
-# 2. Create bot user
-# Synapse Admin Console > Users > Create User
-# Username: aibot
-# Password: (generate secure password)
-# Admin: No (bots don't need admin)
+# 2. Create bot user via Cloudron terminal (App > Terminal)
+/app/code/env/bin/register_new_matrix_user -c /app/data/configs/homeserver.yaml http://localhost:8008
+# Username: aibot, Admin: No
 
-# 3. Get access token
-# Login as bot via Element (https://app.element.io)
-# Settings > Help & About > Advanced > Access Token
-# Copy the token (starts with syt_)
+# 3. Get access token via login API (from Cloudron terminal)
+curl -s -X POST "http://localhost:8008/_matrix/client/v3/login" \
+  -H "Content-Type: application/json" \
+  -d '{"type":"m.login.password","identifier":{"type":"m.id.user","user":"aibot"},"password":"YOUR_PASSWORD"}' \
+  | python3 -m json.tool
+# Copy the access_token value
 
-# 4. Configure the bot (use --dry-run to test first)
+# 4. Disable federation and registration (in Cloudron terminal)
+# Edit /app/data/configs/homeserver.yaml:
+#   enable_registration: false
+#   enable_registration_without_verification: false
+#   resources: - names: [client]  (remove 'federation')
+# Then restart the app from Cloudron dashboard
+
+# 5. Create unencrypted rooms
+# IMPORTANT: Use Element client (web/desktop) — NOT FluffyChat.
+# FluffyChat forces encryption on all new rooms with no toggle to disable.
+# Element has an explicit encryption toggle during room creation.
+# Alternative: create rooms via Synapse API (see below)
+
+# 6. Configure the bot (use --dry-run to test first)
 matrix-dispatch-helper.sh setup --dry-run  # Preview configuration
 matrix-dispatch-helper.sh setup            # Apply configuration
 # Enter: https://synapse.yourdomain.com
-# Enter: syt_your_access_token_here
+# Enter: access token from step 3
 # Enter allowed users (optional)
 # Enter default runner (optional)
 
-# 5. Invite bot to rooms
+# 7. Create runners for each room mapping
+runner-helper.sh create code-reviewer --description "Code review bot" --workdir ~/Git/myproject
+
+# 8. Invite bot to rooms
 # In Element: Invite @aibot:yourdomain.com to your rooms
 
-# 6. Map rooms to runners
+# 9. Map rooms to runners
 matrix-dispatch-helper.sh map '!roomid:yourdomain.com' code-reviewer
 
-# 7. Start the bot
+# 10. Start the bot
 matrix-dispatch-helper.sh start --daemon
+```
+
+**Creating unencrypted rooms via API** (alternative to Element):
+
+```bash
+TOKEN="<admin-access-token>"
+curl -s -X POST "http://localhost:8008/_matrix/client/v3/createRoom" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"room-name","room_alias_name":"room-name","visibility":"private","preset":"private_chat","initial_state":[]}'
+```
+
+**Cleaning up stale invites** (if bot crashes on startup due to deleted rooms):
+
+```bash
+matrix-dispatch-helper.sh cleanup-invites
 ```
 
 ### Manual Synapse Setup
@@ -407,6 +440,8 @@ runner-helper.sh edit code-reviewer
 4. **No admin access**: Bot account should not have Synapse admin privileges
 5. **Network**: OpenCode server should be localhost-only unless secured
 6. **Concurrency**: One dispatch per room prevents resource exhaustion
+7. **OpenCode server password**: Set `OPENCODE_SERVER_PASSWORD` env var to secure the server. Without it, any local process can dispatch to the AI. Low risk on single-user machines (localhost-only), but recommended for shared systems.
+8. **Encryption**: The bot cannot read encrypted messages. All rooms used with the bot must have encryption disabled. Use Element (not FluffyChat) to create rooms with encryption off.
 
 ## Troubleshooting
 
@@ -415,9 +450,13 @@ runner-helper.sh edit code-reviewer
 | Bot not responding | Check `matrix-dispatch-helper.sh status` and logs |
 | "Not mapped" error | Map the room: `matrix-dispatch-helper.sh map '!room:server' runner` |
 | Runner dispatch fails | Ensure OpenCode server is running: `opencode serve` |
+| Runner not found | Create the runner: `runner-helper.sh create <name> --workdir /path` |
 | Access denied | Check `allowedUsers` in config |
 | Bot not joining rooms | Invite the bot user to the room via Element |
+| Bot crashes on startup | Run `matrix-dispatch-helper.sh cleanup-invites` to reject stale invites |
+| Raw JSON in responses | Regenerate bot script: `matrix-dispatch-helper.sh setup` |
 | Stale PID file | Run `matrix-dispatch-helper.sh stop` to clean up |
+| Wrong working directory | Check runner config: `runner-helper.sh status <name>` (verify workdir) |
 
 ## Related
 


### PR DESCRIPTION
## Summary

Fixes all 11 bugs identified during first-time Matrix Synapse + bot setup on Cloudron (GH#4070).

- **Bug 1**: `sendTyping` crash — SDK exposes `setTyping`, not `sendTyping`
- **Bug 2**: `AutojoinRoomsMixin` crashes on stale/deleted room invites — replaced with error-handling invite handler
- **Bug 3**: Bot doesn't join mapped rooms on startup — added startup join loop
- **Bug 4**: Setup wizard silently exits after homeserver URL — fixed stdin reads to use `/dev/tty`
- **Bug 5**: FluffyChat forces encryption — documented Element as primary room creation client
- **Bug 6**: No stale invite cleanup — added `cleanup-invites` command
- **Bug 7**: Setup doesn't warn about missing runners — added post-setup runner check
- **Bug 8**: OpenCode server security — documented `OPENCODE_SERVER_PASSWORD` env var
- **Bug 9/11**: Raw JSONL returned instead of parsed text — added `parseJsonlText()` for both dispatch paths
- **Bug 10**: Runner workdir not passed to dispatch — added `--dir` to both OpenCode and Claude CLI backends

### Files changed

- `.agents/scripts/matrix-dispatch-helper.sh` — bot script generation fixes, cleanup-invites command, setup wizard stdin fix
- `.agents/scripts/runner-helper.sh` — pass `--dir $workdir` to dispatch commands
- `.agents/services/communications/matrix-bot.md` — updated Cloudron setup guide, security notes, troubleshooting

Closes #4070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cleanup-invites command to remove stale Matrix invites for unmapped rooms
  * Bot now automatically joins all configured rooms at startup

* **Improvements**
  * Interactive setup now prompts for homeserver, token, allowed users, default runner and idle timeout; includes post-setup runner-creation check
  * Runner dispatch now passes the configured working directory to backends

* **Documentation**
  * Updated Cloudron setup workflow, security guidance and troubleshooting with new cleanup and runner-mapping steps
<!-- end of auto-generated comment: release notes by coderabbit.ai -->