### PR TITLE
t4075: Address quality-debt in codacy-collector-helper.sh

### DIFF
--- a/.agents/scripts/codacy-collector-helper.sh
+++ b/.agents/scripts/codacy-collector-helper.sh
@@ -41,6 +41,10 @@ readonly CODACY_RETRY_BACKOFF_BASE=2
 # Config file paths anchored to repo root (not CWD-dependent)
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 readonly REPO_ROOT
+[[ -d "$REPO_ROOT" ]] || {
+	echo "FATAL: Could not determine REPO_ROOT" >&2
+	exit 1
+}
 readonly AUDIT_CONFIG="${REPO_ROOT}/configs/code-audit-config.json"
 readonly AUDIT_CONFIG_TEMPLATE="${REPO_ROOT}/configs/code-audit-config.json.txt"
 
@@ -528,16 +532,22 @@ JQ_EOF
 	local count=0
 	if [[ -s "$sql_file" ]]; then
 		# Wrap in transaction for atomicity and performance (single fsync)
-		{
-			echo "BEGIN TRANSACTION;"
-			cat "$sql_file"
-			echo "COMMIT;"
-		} |
-			db "$AUDIT_DB" 2>/dev/null || log_warn "Some Codacy inserts may have failed"
-		count=$(wc -l <"$sql_file" | tr -d ' ')
+		# Use total_changes() for accurate committed row count instead of wc -l
+		count=$(
+			{
+				echo "BEGIN TRANSACTION;"
+				cat "$sql_file"
+				echo "COMMIT;"
+				echo "SELECT total_changes();"
+			} |
+				db "$AUDIT_DB" 2>/dev/null
+		) || {
+			log_warn "Some Codacy inserts may have failed"
+			count=0
+		}
 	fi
 
-	echo "$count"
+	echo "${count:-0}"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Add defensive `REPO_ROOT` validation to fail fast if path resolution fails, matching the `SCRIPT_DIR || exit` pattern on line 26
- Replace `wc -l` line count with SQLite `total_changes()` for accurate committed row count after transaction insert

Both fixes address unactioned CodeRabbit nitpick suggestions from PR #4067 review.

### Changes

**REPO_ROOT validation** (line 44): If `cd "${SCRIPT_DIR}/../.."` somehow fails silently (returns empty or non-directory), the script now exits immediately with a clear error instead of continuing with invalid config paths.

**Accurate row count** (line 536): Previously counted SQL lines via `wc -l`, which could overcount if any inserts failed silently within the transaction. Now uses SQLite's `total_changes()` to report the actual number of committed rows.

Closes #4075