### PR TITLE
GH#4087: Remove return 0 statements that mask subcommand exit codes

### DIFF
--- a/.agents/scripts/real-video-enhancer-helper.sh
+++ b/.agents/scripts/real-video-enhancer-helper.sh
@@ -260,8 +260,6 @@ cmd_install() {
 	print_info "  1. Upscale video: real-video-enhancer-helper.sh upscale input.mp4 output.mp4 --scale 2"
 	print_info "  2. Interpolate: real-video-enhancer-helper.sh interpolate input.mp4 output.mp4 --fps 60"
 	print_info "  3. Full enhance: real-video-enhancer-helper.sh enhance input.mp4 output.mp4 --scale 2 --fps 60"
-
-	return 0
 }
 
 # =============================================================================
@@ -367,7 +365,6 @@ cmd_upscale() {
 	fi
 
 	print_success "Upscaling complete: $output"
-	return 0
 }
 
 cmd_interpolate() {
@@ -462,7 +459,6 @@ cmd_interpolate() {
 	fi
 
 	print_success "Interpolation complete: $output"
-	return 0
 }
 
 cmd_denoise() {
@@ -550,7 +546,6 @@ cmd_denoise() {
 	fi
 
 	print_success "Denoising complete: $output"
-	return 0
 }
 
 cmd_enhance() {
@@ -717,7 +712,6 @@ cmd_enhance() {
 	fi
 
 	print_success "Enhancement complete: $output"
-	return 0
 }
 
 cmd_batch() {
@@ -860,7 +854,6 @@ cmd_batch() {
 	fi
 
 	print_success "Batch processing complete: $output_dir"
-	return 0
 }
 
 # =============================================================================
@@ -912,8 +905,6 @@ cmd_models() {
 		return 1
 		;;
 	esac
-
-	return 0
 }
 
 cmd_backends() {
@@ -985,8 +976,6 @@ cmd_backends() {
 	local recommended
 	recommended=$(detect_backend)
 	print_info "Recommended backend: $recommended"
-
-	return 0
 }
 
 cmd_gui() {
@@ -1004,8 +993,6 @@ cmd_gui() {
 		print_info "Try running directly: cd ${RVE_DIR} && python3 main.py --gui"
 		return 1
 	fi
-
-	return 0
 }
 
 cmd_help() {
@@ -1053,8 +1040,6 @@ Examples:
 
 For more information, see: .agents/tools/video/real-video-enhancer.md
 EOF
-
-	return 0
 }
 
 # =============================================================================
@@ -1110,8 +1095,6 @@ main() {
 		exit 1
 		;;
 	esac
-
-	return 0
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Remove 11 redundant `return 0` statements from `real-video-enhancer-helper.sh` that mask the exit status of dispatched subcommands
- The critical instance in `main()` (line 1114) prevented callers from detecting failures in `cmd_*` functions — the specific finding from Gemini code review on PR #4058
- Extends the fix to all 10 other functions with the same anti-pattern (`cmd_install`, `cmd_upscale`, `cmd_interpolate`, `cmd_denoise`, `cmd_enhance`, `cmd_batch`, `cmd_models`, `cmd_backends`, `cmd_gui`, `cmd_help`)
- Retains `return 0` only in validation/detection functions (`check_installation`, `detect_python`, `detect_backend`) where it serves as an explicit success indicator after guard clauses

## Verification

- ShellCheck: zero violations (only SC1091 info about external source, expected)
- All error paths still use explicit `return 1`
- Functions now propagate the exit code of their last command naturally

Closes #4087