### PR TITLE
fix: move formatting description before example in dashboard.md

### DIFF
--- a/.agents/scripts/commands/dashboard.md
+++ b/.agents/scripts/commands/dashboard.md
@@ -77,6 +77,8 @@ Raw output (one line per issue, tab-separated):
 
 Formatted display (produced by the dashboard agent):
 
+The agent converts ISO timestamps to relative times (e.g., "2d ago"), aligns columns, and groups issues by repo. This formatting is done at display time, not by the shell script.
+
 ```text
 Pending Maintainer Review
 =========================
@@ -94,8 +96,6 @@ Actions:
   Approve:  gh issue edit <N> --repo <slug> --remove-label needs-maintainer-review --add-label auto-dispatch
   Decline:  gh issue close <N> --repo <slug> -c "Declined: <reason>"
 ```
-
-The formatted display converts ISO timestamps to relative times (e.g., "2d ago"), aligns columns, and groups issues by repo. This formatting is done by the agent at display time, not by the shell script.
 
 ## Browser View
 


### PR DESCRIPTION
## Summary

- Restructures the "Formatted display" section in `dashboard.md` so the description of the formatting logic (timestamp conversion, column alignment, repo grouping) appears **before** the example output block, not after it
- Addresses disconnected content noted in [PR #4037 review](https://github.com/marcusquinn/aidevops/pull/4037#discussion_r2908938578) — the heading → description → example flow is now logical

Closes #4091