### PR TITLE
t4082: Normalize path separators in email thread index for cross-platform portability

### DIFF
--- a/.agents/scripts/email-thread-reconstruction.py
+++ b/.agents/scripts/email-thread-reconstruction.py
@@ -241,9 +241,10 @@ def generate_thread_index(threads, output_file):
 
         for i, email in enumerate(emails, 1):
             # Compute relative path from index file location to email file
+            # Normalize separators to forward slashes for portable Markdown links
             file_path = os.path.relpath(
                 Path(email["file"]).resolve(), output_dir
-            )
+            ).replace(os.sep, "/")
             email_subject = email.get("subject", "No Subject")
             from_addr = email.get("from", "Unknown")
             date_sent = email.get("date_sent", "Unknown")

--- a/tests/test-email-thread-reconstruction.sh
+++ b/tests/test-email-thread-reconstruction.sh
@@ -230,6 +230,12 @@ test_relative_paths_cross_directory() {
 		return 1
 	fi
 
+	# Verify paths use forward slashes only (portable Markdown links)
+	if grep -qP '\(.*\\\\.*\.md\)' "$index_file"; then
+		print_error "Index links contain backslashes (not portable)"
+		return 1
+	fi
+
 	# Clean up the subdirectory output
 	rm -rf "$output_dir"
 


### PR DESCRIPTION
## Summary

- Chains `.replace(os.sep, '/')` to `os.path.relpath` output in `generate_thread_index()` so generated Markdown links always use forward slashes, regardless of OS
- Adds test assertion verifying no backslashes appear in generated index link paths

Addresses unactioned review feedback from Gemini on PR #4061 (medium severity).

Closes #4082