### PR TITLE
GH#4072: Fix carriage return handling in sql_escape()

### DIFF
--- a/.agents/scripts/code-audit-helper.sh
+++ b/.agents/scripts/code-audit-helper.sh
@@ -175,7 +175,7 @@ sql_escape() {
 	# Replace newlines and carriage returns with spaces to prevent
 	# multi-line SQL corruption in line-by-line INSERT generation
 	val="${val//$'\n'/ }"
-	val="${val//$'\r'/}"
+	val="${val//$'\r'/ }"
 	val="${val//\'/\'\'}"
 	echo "$val"
 	return 0

--- a/.agents/scripts/code-audit-helper.sh
+++ b/.agents/scripts/code-audit-helper.sh
@@ -174,8 +174,7 @@ sql_escape() {
 	val="$1"
 	# Replace newlines and carriage returns with spaces to prevent
 	# multi-line SQL corruption in line-by-line INSERT generation
-	val="${val//$'\n'/ }"
-	val="${val//$'\r'/ }"
+	val="${val//[$'\r\n']/ }"
 	val="${val//\'/\'\'}"
 	echo "$val"
 	return 0


### PR DESCRIPTION
## Summary

- Replace `\r` removal with `\r`→space substitution in `sql_escape()` (`code-audit-helper.sh:178`)
- Prevents word merging when carriage returns appear in input (e.g., `word1\rword2` → `word1 word2` instead of `word1word2`)
- Consistent with existing `\n`→space handling on the preceding line

## Source

Review feedback from Gemini on PR #4069: [comment](https://github.com/marcusquinn/aidevops/pull/4069#discussion_r2911553572)

Closes #4072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved special character handling in data processing. Carriage return characters are now preserved as spaces instead of being completely removed. This change enhances data consistency, maintains data integrity, and prevents unintended information loss when processing strings with special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->