### PR TITLE
GH#4079: Use validate_positive_int for task_row_id in finding-to-task-helper.sh

### DIFF
--- a/.agents/scripts/archived/finding-to-task-helper.sh
+++ b/.agents/scripts/archived/finding-to-task-helper.sh
@@ -604,8 +604,8 @@ cmd_create() {
 			local task_row_id
 			task_row_id=$(db "$TASK_DB" "SELECT id FROM generated_tasks WHERE group_key='${escaped_key}' AND group_by='${group_by}';")
 
-			# Validate task_row_id is an integer before using in SQL
-			if ! [[ "$task_row_id" =~ ^[0-9]+$ ]]; then
+			# Validate task_row_id is a positive integer before using in SQL
+			if ! validate_positive_int "$task_row_id"; then
 				print_warning "Invalid task row ID for ${group_by}=${group_key}, skipping findings link"
 				i=$((i + 1))
 				continue


### PR DESCRIPTION
## Summary

- Replace inline regex `^[0-9]+$` with the existing `validate_positive_int()` helper at line 608 for consistency and correctness
- The regex allowed `0`, which is invalid for a `PRIMARY KEY AUTOINCREMENT` column (always >= 1)
- Addresses Gemini review feedback from PR #4064

## Changes

**`.agents/scripts/archived/finding-to-task-helper.sh:608`** — 2-line change:
- Comment: "an integer" → "a positive integer"
- Condition: `[[ "$task_row_id" =~ ^[0-9]+$ ]]` → `validate_positive_int "$task_row_id"`

## Verification

- ShellCheck: zero new violations (only pre-existing SC1091 info)
- `validate_positive_int()` already defined at line 72, uses `^[1-9][0-9]*$` (rejects 0)
- Function already used at lines 260, 483, 598 — this makes line 608 consistent

Closes #4079