### PR TITLE
GH#4077: Simplify concurrency validation regex in batch.sh

### DIFF
--- a/.agents/scripts/supervisor-archived/batch.sh
+++ b/.agents/scripts/supervisor-archived/batch.sh
@@ -246,7 +246,7 @@ cmd_batch() {
 				return 1
 			}
 			# GH#3716: Validate concurrency is a positive integer before SQL interpolation
-			if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -eq 0 ]]; then
+			if ! [[ "$2" =~ ^[1-9][0-9]*$ ]]; then
 				log_error "--concurrency must be a positive integer, got: $2"
 				return 1
 			fi


### PR DESCRIPTION
## Summary

- Replace two-part positive integer check (`^[0-9]+$` + `-eq 0`) with single regex `^[1-9][0-9]*$` that inherently excludes zero
- More concise, readable, and robust against injection when parsing numeric data from untrusted sources
- Addresses Gemini review feedback from PR #4062

Closes #4077