### PR TITLE
t4078: Simplify --interval validation to single positive integer regex

### DIFF
--- a/.agents/scripts/supervisor-archived/cron.sh
+++ b/.agents/scripts/supervisor-archived/cron.sh
@@ -35,7 +35,7 @@ cmd_cron() {
 				return 1
 			}
 			# GH#3716: Validate interval is a positive integer before use in cron/launchd commands
-			if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -eq 0 ]]; then
+			if ! [[ "$2" =~ ^[1-9][0-9]*$ ]]; then
 				log_error "--interval must be a positive integer (minutes), got: $2"
 				return 1
 			fi


### PR DESCRIPTION
## Summary

- Replace two-part `--interval` validation (`^[0-9]+$` + `-eq 0` check) with single regex `^[1-9][0-9]*$` for defense-in-depth against injection when parsing numeric data from untrusted sources
- Consistent with `--concurrency` validation pattern in the same codebase

## Details

**File**: `.agents/scripts/supervisor-archived/cron.sh:38-42`

**Before**: `if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -eq 0 ]]; then`
**After**: `if ! [[ "$2" =~ ^[1-9][0-9]*$ ]]; then`

The single regex rejects `0`, `00`, `007`-style inputs, and non-numeric strings in one check. The `-eq 0` arithmetic comparison is no longer needed, which also avoids potential issues if the value somehow bypasses the first regex check.

Closes #4078