### PR TITLE
GH#4077: Simplify concurrency validation in batch.sh

### DIFF
--- a/.agents/scripts/supervisor-archived/batch.sh
+++ b/.agents/scripts/supervisor-archived/batch.sh
@@ -246,7 +246,7 @@ cmd_batch() {
 				return 1
 			}
 			# GH#3716: Validate concurrency is a positive integer before SQL interpolation
-			if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -eq 0 ]]; then
+			if ! [[ "$2" =~ ^[1-9][0-9]*$ ]]; then
 				log_error "--concurrency must be a positive integer, got: $2"
 				return 1
 			fi


### PR DESCRIPTION
## Summary

- Simplifies `--concurrency` positive integer validation in `batch.sh` from a two-part check (`^[0-9]+$` + `-eq 0`) to a single regex `^[1-9][0-9]*$` that inherently excludes zero
- Addresses unactioned review feedback from PR #4062 (Gemini code review, medium severity)
- More concise, readable, and robust against injection when parsing numeric data from untrusted sources

## Changes

**File**: `.agents/scripts/supervisor-archived/batch.sh:249`

Before:
```bash
if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -eq 0 ]]; then
```

After:
```bash
if ! [[ "$2" =~ ^[1-9][0-9]*$ ]]; then
```

## Verification

- ShellCheck: zero violations
- Behaviour unchanged: rejects `0`, negative numbers, non-numeric input; accepts `1`, `2`, `10`, etc.

Closes #4077