### PR TITLE
t3726: Add set -euo pipefail to _backup.sh

### DIFF
--- a/.agents/scripts/setup/_backup.sh
+++ b/.agents/scripts/setup/_backup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # Backup and rotation functions for setup.sh
 
 # Create a backup with rotation (keeps last N backups)


### PR DESCRIPTION
## Summary

- Adds `set -euo pipefail` to `.agents/scripts/setup/_backup.sh` per repository style guide requirement
- Addresses unactioned Gemini review feedback from PR #1240 (medium severity)

## Details

The Gemini code review on PR #1240 flagged that all new setup module scripts should include `set -euo pipefail` for strict error handling, even when sourced from a parent script that already sets it. This ensures each module can be run independently and makes the error handling explicit.

Single file change: `.agents/scripts/setup/_backup.sh` line 2.

ShellCheck: zero violations.

Closes #3726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backup script reliability by implementing stricter error handling, ensuring the script fails fast when encountering errors or undefined variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->