### PR TITLE
GH#3730: Fix video enhancer docs — remove unimplemented models download example

### DIFF
--- a/.agents/tools/video/real-video-enhancer.md
+++ b/.agents/tools/video/real-video-enhancer.md
@@ -354,12 +354,13 @@ Models are downloaded automatically on first use to `~/.cache/real-video-enhance
 # List available models
 real-video-enhancer-helper.sh models list
 
-# Download specific model
-real-video-enhancer-helper.sh models download rife-4.6
-
 # Clear model cache (re-download on next use)
 real-video-enhancer-helper.sh models clear
 ```
+
+> **Note**: Manual model download is not yet implemented. Models are downloaded
+> automatically on first use when running `enhance`, `upscale`, `interpolate`,
+> or `denoise` commands.
 
 **Model sizes**:
 - RIFE: ~200MB


### PR DESCRIPTION
## Summary

- Removed the `models download rife-4.6` example from `real-video-enhancer.md` that documented unimplemented functionality (`cmd_models download` returns error: "not yet implemented")
- Added a blockquote note clarifying that models are downloaded automatically on first use
- Kept the working `models list` and `models clear` examples intact

Closes #3730