### PR TITLE
GH#3800: Fix quality-debt review feedback from PR #41

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -502,8 +502,8 @@ The AI will iterate on the task until outputting:
 2. Tests passing (if applicable)
 3. Code quality acceptable (lint, shellcheck, type-check)
 4. **Generalization check** — solution works for varying inputs, not just current state
-5. **README gate passed** (see below)
-6. Conventional commits used (for auto-changelog)
+5. **README gate passed** — required if task adds/changes user-facing features (see below)
+6. Conventional commits used — required for all commits (enables auto-changelog)
 7. **Headless rules observed** (see below)
 
 **Parallelism rule (t217)**: When your task involves multiple independent operations (reading several files, running lint + typecheck + tests, researching separate modules), use the Task tool to run them concurrently in a single message — not one at a time. Serial execution of independent work wastes wall-clock time proportional to the number of subtasks. See `tools/ai-assistants/headless-dispatch.md` "Worker Efficiency Protocol" point 5 for criteria and examples.

--- a/.agents/workflows/ralph-loop.md
+++ b/.agents/workflows/ralph-loop.md
@@ -271,15 +271,14 @@ When complete:
 
 **Changelog via commits** - Use conventional commit messages for auto-generated changelogs:
 
-```text
-# Good commit messages (auto-included in changelog)
-feat: add user authentication
-fix: resolve memory leak in connection pool
-docs: update API documentation
-
-# Excluded from changelog
-chore: update dependencies
-```
+| Prefix | Changelog Section | Example |
+|--------|-------------------|---------|
+| `feat:` | Added | `feat: add JWT authentication` |
+| `fix:` | Fixed | `fix: resolve memory leak in connection pool` |
+| `docs:` | Changed | `docs: update API documentation` |
+| `perf:` | Changed | `perf: optimize database queries` |
+| `refactor:` | Changed | `refactor: simplify auth middleware` |
+| `chore:` | (excluded) | `chore: update dependencies` |
 
 The release workflow auto-generates CHANGELOG.md from conventional commits. See `workflows/changelog.md`.
 
@@ -632,13 +631,7 @@ The loop is designed for maximum AI autonomy while preserving human control at s
 
 This is a gate between task development and preflight, not a suggestion. See `scripts/commands/full-loop.md` Step 3 completion criteria.
 
-**Changelog**: Auto-generated from conventional commits during release. Use proper prefixes:
-- `feat:` → Added section
-- `fix:` → Fixed section
-- `docs:` → Changed section
-- `chore:` → Excluded from changelog
-
-See `workflows/changelog.md` for details.
+**Changelog**: Auto-generated from conventional commits during release. See the commit prefix table in Section 4 "Documentation Updates" above, and `workflows/changelog.md` for full details.
 
 ### Options
 


### PR DESCRIPTION
## Summary

- Align conventional commit prefix documentation between `ralph-loop.md` and `full-loop.md` by adding missing `perf:` and `refactor:` prefixes
- Consolidate duplicated commit prefix guidance to reduce maintenance burden
- Clarify completion criteria language to distinguish conditional vs mandatory requirements

## Changes

### `.agents/workflows/ralph-loop.md`

**Section 4 "Documentation Updates"**: Replaced plain text commit examples with the full markdown table format matching `full-loop.md`, adding the missing `perf:` and `refactor:` prefixes (Gemini review feedback).

**"Documentation in Loops" section**: Replaced duplicated commit prefix bullet list with a cross-reference to Section 4, addressing both the missing prefixes (Gemini) and the maintenance burden from duplication (CodeRabbit nitpick).

### `.agents/scripts/commands/full-loop.md`

**Completion criteria**: Clarified that the README gate is conditional ("required if task adds/changes user-facing features") and conventional commits are mandatory ("required for all commits"), addressing CodeRabbit's feedback about ambiguous language.

## Review Feedback Addressed

| Reviewer | Finding | Resolution |
|----------|---------|------------|
| Gemini | Missing `perf:` and `refactor:` prefixes in ralph-loop.md Section 4 | Added full table with all 6 prefixes |
| Gemini | Missing `perf:` and `refactor:` in "Documentation in Loops" section | Consolidated into cross-reference to Section 4 |
| CodeRabbit | Duplication between Section 4 and "Documentation in Loops" | "Documentation in Loops" now cross-references Section 4 |
| CodeRabbit | Ambiguous completion criteria (conditional vs mandatory) | Clarified with inline annotations |

Closes #3800