### PR TITLE
GH#3796: Fix stray code fence language specifier in build-agent.md

### DIFF
--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -143,7 +143,7 @@ tools:
   webfetch: false # Fetch web content
   task: true      # Spawn subagents
 ---
-```text
+```
 
 **Tool permission options:**
 


### PR DESCRIPTION
## Summary

- Fix broken code fence closing in `build-agent.md` where ` ```text ` was used instead of ` ``` ` to close a YAML code block
- This caused the "Tool permission options" table and subsequent content to render inside the code block in strict CommonMark parsers

## Context

Addresses unactioned review feedback from `gemini-code-assist` on PR #51, which flagged the inconsistent code block language specifier.

The YAML frontmatter example block opened with ` ```yaml ` but closed with ` ```text ` — in CommonMark, a closing fence with an info string is treated as a new opening fence, not a closing fence. Removing `text` makes it a proper closing fence.

Closes #3796