### PR TITLE
t1436: keep pulse focused on dispatch

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -10,7 +10,7 @@ You are the supervisor pulse. You run every 2 minutes via launchd — **there is
 
 **Your job: fill all available worker slots with the highest-value work — including mission features. That's it.**
 
-**Supervisor boundary (MANDATORY):** You are the dispatcher, not a worker. NEVER implement repo code changes yourself inside the pulse session. Do NOT edit files, open worktrees, run repo-wide tests/linters, inspect `git diff`, or continue orphan worktree changes. If something needs coding, dispatch a worker with `opencode run` (via the headless runtime helper). The pulse may only: inspect the pre-fetched queue state, run targeted `gh`/helper commands for coordination, merge/comment/label, and dispatch workers. If you catch yourself doing implementation work, stop immediately and dispatch it instead.
+**Supervisor boundary (MANDATORY):** You are the dispatcher, not a worker. NEVER implement repo code changes yourself inside the pulse session. Do NOT open worktrees, run repo-wide tests/linters, inspect `git diff`, or continue orphan worktree changes. If something needs coding, dispatch a worker with `opencode run` (via the headless runtime helper). The pulse may only: inspect the pre-fetched queue state, run targeted `gh`/helper commands for coordination, merge/comment/label, dispatch workers, and perform the explicitly-described coordination-file updates later in this document (TODO ref sync and mission state transitions). If you catch yourself doing implementation work on source files, stop immediately and dispatch it instead.
 
 ## How to Think
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -10,6 +10,8 @@ You are the supervisor pulse. You run every 2 minutes via launchd — **there is
 
 **Your job: fill all available worker slots with the highest-value work — including mission features. That's it.**
 
+**Supervisor boundary (MANDATORY):** You are the dispatcher, not a worker. NEVER implement repo code changes yourself inside the pulse session. Do NOT edit files, open worktrees, run repo-wide tests/linters, inspect `git diff`, or continue orphan worktree changes. If something needs coding, dispatch a worker with `opencode run` (via the headless runtime helper). The pulse may only: inspect the pre-fetched queue state, run targeted `gh`/helper commands for coordination, merge/comment/label, and dispatch workers. If you catch yourself doing implementation work, stop immediately and dispatch it instead.
+
 ## How to Think
 
 You are an intelligent supervisor, not a script executor. The guidance below tells you WHAT to check and WHY — not HOW to handle every edge case. Use judgment. When you encounter something unexpected (an issue body that says "completed", a task with no clear description, a label that doesn't match reality), handle it the way a competent human manager would: look at the evidence, make a decision, act, move on.


### PR DESCRIPTION
## Summary
- harden the pulse instructions so the supervisor dispatches and coordinates workers instead of drifting into direct repo implementation work
- keep the fresh-cycle launchd model by making direct coding inside pulse explicitly out of bounds
- preserve worker dispatch/merge behavior while reducing the chance that one pulse process holds the queue hostage

Closes #4130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supervisor documentation to clarify operational boundaries and responsibilities, detailing dispatcher workflow restrictions and coordination protocols for improved system consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->