### PR TITLE
fix: use GitHub API fallback for gh version check when brew unavailable

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -921,10 +921,15 @@ cmd_update() {
 			fi
 			[[ -z "$installed" ]] && continue
 
-			# Get latest version (npm or brew) — timeout prevents hangs on slow registries
+			# Get latest version (npm, brew, or GitHub API) — timeout prevents hangs on slow registries
 			if [[ "$pkg_ref" == brew:* ]]; then
 				local brew_pkg="${pkg_ref#brew:}"
-				latest=$(_timeout_cmd 30 brew info --json=v2 "$brew_pkg" | jq -r '.formulae[0].versions.stable // empty' || true)
+				if command -v brew &>/dev/null; then
+					latest=$(_timeout_cmd 30 brew info --json=v2 "$brew_pkg" | jq -r '.formulae[0].versions.stable // empty' || true)
+				elif [[ "$brew_pkg" == "gh" ]] && command -v gh &>/dev/null; then
+					# Fallback: get latest gh version from GitHub API (works without brew)
+					latest=$(_timeout_cmd 15 gh api repos/cli/cli/releases/latest --jq '.tag_name' 2>/dev/null | sed 's/^v//' || true)
+				fi
 			else
 				latest=$(_timeout_cmd 30 npm view "$pkg_ref" version || true)
 			fi


### PR DESCRIPTION
## Summary

- On Linux without Homebrew, `aidevops update` printed `timeout: failed to run command 'brew': No such file or directory` during the "Checking Key Tools" phase
- The `gh` version staleness check used `brew info` exclusively — now falls back to `gh api repos/cli/cli/releases/latest` when brew is not installed
- Both brew (macOS) and API (Linux) paths verified locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package version resolution to support GitHub API lookups as a fallback when Brew is unavailable. The "gh" package now fetches the latest release tag from GitHub API with built-in timeout protection and improved resilience for version detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->