### PR TITLE
t1439: fix pulse status drift and worker cap reporting

### DIFF
--- a/.agents/scripts/pulse-session-helper.sh
+++ b/.agents/scripts/pulse-session-helper.sh
@@ -21,13 +21,14 @@ export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
 
 # Source config-helper for _jsonc_get (shared JSONC config reader)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=config-helper.sh
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/config-helper.sh" 2>/dev/null || true
 
 # Configuration
 readonly SESSION_FLAG="${HOME}/.aidevops/logs/pulse-session.flag"
 readonly STOP_FLAG="${HOME}/.aidevops/logs/pulse-session.stop"
 readonly LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+readonly WRAPPER_LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
 readonly PIDFILE="${HOME}/.aidevops/logs/pulse.pid"
 readonly MAX_WORKERS_FILE="${HOME}/.aidevops/logs/pulse-max-workers"
 readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
@@ -135,14 +136,16 @@ get_pulse_repo_count() {
 # Get last pulse timestamp from log
 #######################################
 get_last_pulse_time() {
-	if [[ -f "$LOGFILE" ]]; then
-		local last_line
-		last_line=$(grep 'Starting pulse at' "$LOGFILE" | tail -1)
-		if [[ -n "$last_line" ]]; then
-			echo "$last_line" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' | tail -1
-			return 0
+	local candidate_log last_line
+	for candidate_log in "$WRAPPER_LOGFILE" "$LOGFILE"; do
+		if [[ -f "$candidate_log" ]]; then
+			last_line=$(grep 'Starting pulse at' "$candidate_log" | tail -1)
+			if [[ -n "$last_line" ]]; then
+				echo "$last_line" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' | tail -1
+				return 0
+			fi
 		fi
-	fi
+	done
 	echo "never"
 	return 0
 }

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -61,7 +61,7 @@ if ! type config_get >/dev/null 2>&1; then
 		local requested_key="$1"
 		local default_value="$2"
 		if [[ "$CONFIG_GET_FALLBACK_WARNED" -eq 0 ]]; then
-			printf '[pulse-wrapper] WARN: fallback config_get active (config-helper unavailable); defaulting key "%s"\n' "$requested_key" >&2
+			printf '[pulse-wrapper] WARN: config_get fallback active; config-helper unavailable, so default config values are being applied starting with key "%s"\n' "$requested_key" >&2
 			CONFIG_GET_FALLBACK_WARNED=1
 		fi
 		printf '%s\n' "$default_value"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -48,8 +48,21 @@ export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
 # resolves correctly whether the script is executed directly (bash) or sourced
 # from zsh. See GH#3931.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || return 2>/dev/null || exit
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/config-helper.sh" 2>/dev/null || true
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
+
+if ! type config_get >/dev/null 2>&1; then
+	config_get() {
+		local _key="$1"
+		local default_value="$2"
+		printf '%s\n' "$default_value"
+		return 0
+	}
+fi
 
 #######################################
 # Configuration

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -56,9 +56,14 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
 
 if ! type config_get >/dev/null 2>&1; then
+	CONFIG_GET_FALLBACK_WARNED=0
 	config_get() {
-		local _key="$1"
+		local requested_key="$1"
 		local default_value="$2"
+		if [[ "$CONFIG_GET_FALLBACK_WARNED" -eq 0 ]]; then
+			printf '[pulse-wrapper] WARN: fallback config_get active (config-helper unavailable); defaulting key "%s"\n' "$requested_key" >&2
+			CONFIG_GET_FALLBACK_WARNED=1
+		fi
 		printf '%s\n' "$default_value"
 		return 0
 	}
@@ -111,6 +116,7 @@ SESSION_COUNT_WARN=$(_validate_int SESSION_COUNT_WARN "$SESSION_COUNT_WARN" 5 1)
 
 PIDFILE="${HOME}/.aidevops/logs/pulse.pid"
 LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+WRAPPER_LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
 SESSION_FLAG="${HOME}/.aidevops/logs/pulse-session.flag"
 STOP_FLAG="${HOME}/.aidevops/logs/pulse-session.stop"
 OPENCODE_BIN="${OPENCODE_BIN:-$(command -v opencode 2>/dev/null || echo "opencode")}"
@@ -1273,7 +1279,7 @@ check_session_count() {
 run_pulse() {
 	local start_epoch
 	start_epoch=$(date +%s)
-	echo "[pulse-wrapper] Starting pulse at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$LOGFILE"
+	echo "[pulse-wrapper] Starting pulse at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$WRAPPER_LOGFILE"
 
 	# Build the prompt: /pulse + pre-fetched state
 	local prompt="/pulse"


### PR DESCRIPTION
## Summary
- read the wrapper log before the legacy pulse log so pulse status reflects the latest run metadata.
- load config helpers safely in the wrapper and fall back cleanly so max worker reporting stays available.

Closes #4139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved session pulse tracking by checking multiple log sources and reliably reporting "never" when no pulse timestamp is found.
  * Added separate wrapper-level logging to isolate wrapper start events from main logs.
  * Added a defensive fallback for missing configuration so the process continues with a one-time warning instead of failing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->