### PR TITLE
t1442: add unreleased changelog entries for patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- harden update checks when Homebrew is missing or GitHub auth refresh fails (#4143)
+- fix pulse status drift and preserve worker cap reporting in the wrapper path (#4140)
+- unblock patch releases from historical preflight debt with tag-aware checks (#4146)
+
 ## [2.171.5] - 2026-03-11
 
 ### Fixed


### PR DESCRIPTION
## Summary
- add an `[Unreleased]` changelog section for the just-merged patch release fixes from PRs #4143, #4140, and #4146
- keep the entry concise and aligned with the existing changelog style

Closes #4147

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved robustness of update checks when Homebrew is missing or GitHub authentication fails
* Fixed pulse status drift and improved worker capacity reporting accuracy
* Enabled patch releases from historical preflight debt with tag-aware version checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->