### PR TITLE
GH#4150: align recovery test failure propagation with set -e semantics

### DIFF
--- a/.agents/scripts/tests/test-pr-3885-recovery.sh
+++ b/.agents/scripts/tests/test-pr-3885-recovery.sh
@@ -39,7 +39,7 @@ assert_contains() {
 	fi
 
 	fail "$message"
-	return 0
+	return 1
 }
 
 assert_line_exists() {


### PR DESCRIPTION
## Summary
- make `assert_contains()` return non-zero on failed matches so wrapper assertions propagate command failure semantics
- keep full-sweep behavior by relying on existing `set +e` guard in `run_checks()` while preserving final failure accounting via `TESTS_FAILED`
- verify the change with `shellcheck` and direct execution of `.agents/scripts/tests/test-pr-3885-recovery.sh`

Closes #4150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test failure handling to ensure proper error detection and reporting during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->