### PR TITLE
t1444: fail closed on secretlint runtime errors

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -397,17 +397,26 @@ capture_secretlint_findings() {
 	local output_file="$2"
 	local canonical_scan_root=""
 	local raw_output=""
+	local secretlint_exit=0
 
 	canonical_scan_root=$(cd "$scan_root" && pwd -P)
 
 	raw_output=$(
 		cd "$canonical_scan_root" || exit 1
 		"${SECRETLINT_CMD[@]}" "**/*" --format compact 2>&1
-	) || true
+	)
+	secretlint_exit=$?
 
-	if [[ "$raw_output" == *"AggregationError"* ]] || [[ "$raw_output" == *"Failed to load rule module"* ]]; then
+	if [[ "$raw_output" == *"AggregationError"* ]] || [[ "$raw_output" == *"Failed to load rule module"* ]] || [[ "$raw_output" == *"at async file://"* ]]; then
 		print_error "Secretlint failed to load its configured rules"
 		return 1
+	fi
+
+	if [[ $secretlint_exit -ne 0 ]]; then
+		if ! printf '%s\n' "$raw_output" | grep -Eq ': line [0-9]+, col [0-9]+, '; then
+			print_error "Secretlint execution failed with non-finding output"
+			return 1
+		fi
 	fi
 
 	if [[ -z "$raw_output" ]]; then


### PR DESCRIPTION
## Summary
- keep patch preflight fail-closed for secret scanning while distinguishing scanner runtime failures from actual findings output
- capture secretlint exit status and reject non-finding stack traces (for example `at async file://...`) as execution failures
- preserve finding-based comparison logic so any real new secret finding still blocks release

## Why
Release preflight was intermittently misclassifying secretlint runtime output as \"new findings\". This creates noisy failures and obscures root cause. The fix improves classification without relaxing safety checks.

Closes #4168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and reporting in secret scanning process to catch additional failure scenarios.
  * Enhanced handling of edge cases where scanning encounters unexpected output patterns, providing clearer error messages for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->