### PR TITLE
t4166: verify findings on main before creating quality-debt issues

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -111,6 +111,7 @@ _extract_verification_snippet() {
 			[[ -z "$candidate" ]] && continue
 
 			if [[ "$fence_type" == "diff" || "$fence_type" == "suggestion" ]]; then
+				# diff/suggestion fences: skip all diff markers and added/removed lines
 				[[ "$candidate" == "@@"* ]] && continue
 				[[ "$candidate" == "diff --git"* ]] && continue
 				[[ "$candidate" == "index "* ]] && continue
@@ -118,10 +119,11 @@ _extract_verification_snippet() {
 				[[ "$candidate" == "---"* ]] && continue
 				[[ "$candidate" == +* ]] && continue
 				[[ "$candidate" == -* ]] && continue
-			fi
-
-			if [[ "$candidate" == +* || "$candidate" == -* ]]; then
-				candidate=$(_trim_whitespace "${candidate:1}")
+			else
+				# non-diff fences: lines starting with +/- are diff markers too —
+				# skip them rather than stripping the prefix and using the content
+				[[ "$candidate" == +* ]] && continue
+				[[ "$candidate" == -* ]] && continue
 			fi
 
 			[[ "$candidate" == "Suggestion:"* ]] && continue

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -1138,28 +1138,39 @@ _create_quality_debt_issues() {
 	while IFS= read -r finding; do
 		[[ -z "$finding" ]] && continue
 
-		local file_path
-		local line_num
-		local body_full
-		local verification_json
-		local verification_result
-		local verification_status
-		local verification_fields
-		local finding_with_status
+		local file_path=""
+		local line_num=""
+		local body_full=""
+		local verification_json=""
+		local verification_result=""
+		local verification_status=""
+		local finding_fields=""
+		local finding_with_status=""
 
-		file_path=$(echo "$finding" | jq -r '.file // ""')
-		line_num=$(echo "$finding" | jq -r '.line // "?"')
-		body_full=$(echo "$finding" | jq -r '.body_full // .body // ""')
+		# Single jq call to extract all three fields (body_full base64-encoded to preserve newlines)
+		finding_fields=$(printf '%s' "$finding" | jq -r '"\(.file // "")\t\(.line // "?")\t\(.body_full // .body // "" | @base64)"')
+		IFS=$'\t' read -r file_path line_num body_full <<<"$finding_fields"
+		body_full=$(printf '%s' "$body_full" | base64 -d)
 
 		verification_json=$(_finding_still_exists_on_main "$repo_slug" "$file_path" "$line_num" "$body_full" || true)
-		verification_fields=$(echo "$verification_json" | jq -r '[(.result // false), (.status // "verified")] | @tsv')
-		IFS=$'\t' read -r verification_result verification_status <<<"$verification_fields"
+
+		# Parse fixed-format JSON without jq — format is {"result":bool,"status":"str"}
+		verification_result="false"
+		verification_status="verified"
+		if [[ "$verification_json" == *'"result":true'* ]]; then
+			verification_result="true"
+		fi
+		if [[ "$verification_json" == *'"status":"unverifiable"'* ]]; then
+			verification_status="unverifiable"
+		elif [[ "$verification_json" == *'"status":"resolved"'* ]]; then
+			verification_status="resolved"
+		fi
 
 		if [[ "$verification_result" == "true" ]]; then
-			finding_with_status=$(echo "$finding" | jq --arg status "$verification_status" '. + {verification_status: $status}')
+			finding_with_status=$(printf '%s' "$finding" | jq --arg status "$verification_status" '. + {verification_status: $status}')
 			verified_findings_stream+="${finding_with_status}"$'\n'
 		fi
-	done < <(echo "$findings" | jq -c '.[]')
+	done < <(printf '%s' "$findings" | jq -c '.[]')
 
 	if [[ -n "$verified_findings_stream" ]]; then
 		findings=$(printf '%s' "$verified_findings_stream" | jq -s '.')

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -138,8 +138,23 @@ _extract_verification_snippet() {
 	done <<<"$body_full"
 
 	while IFS= read -r line; do
-		line="${line#> }"
-		line="${line#- }"
+		case "$line" in
+		'> '*)
+			line="${line#> }"
+			;;
+		'    '* | '	'*)
+			# indented code block (4 spaces or tab)
+			line="${line#    }"
+			line="${line#	}"
+			;;
+		'`'*)
+			# inline backtick code — strip surrounding backticks
+			line="${line//\`/}"
+			;;
+		*)
+			continue
+			;;
+		esac
 		line=$(_trim_whitespace "$line")
 		if [[ -n "$line" && ${#line} -ge 12 ]]; then
 			echo "$line"
@@ -165,8 +180,22 @@ _finding_still_exists_on_main() {
 	default_branch=$(_get_default_branch "$repo_slug")
 
 	local file_content
-	file_content=$(gh api -H "Accept: application/vnd.github.raw" \
-		"repos/${repo_slug}/contents/${file_path}?ref=${default_branch}" 2>/dev/null || true)
+	local api_err
+	api_err="$(mktemp)"
+	if ! file_content=$(gh api -H "Accept: application/vnd.github.raw" \
+		"repos/${repo_slug}/contents/${file_path}?ref=${default_branch}" 2>"$api_err"); then
+		if grep -q "404" "$api_err"; then
+			echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - file missing on ${default_branch}" >&2
+			rm -f "$api_err"
+			echo '{"result":false,"status":"resolved"}'
+			return 1
+		fi
+		echo "[scan] Keeping unverifiable finding: ${file_path}:${line_num} - failed to fetch ${default_branch}" >&2
+		rm -f "$api_err"
+		echo '{"result":true,"status":"unverifiable"}'
+		return 0
+	fi
+	rm -f "$api_err"
 
 	if [[ -z "$file_content" ]]; then
 		echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - file missing on ${default_branch}" >&2

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -1144,14 +1144,16 @@ _create_quality_debt_issues() {
 		local verification_json
 		local verification_result
 		local verification_status
+		local verification_fields
 		local finding_with_status
+
 		file_path=$(echo "$finding" | jq -r '.file // ""')
 		line_num=$(echo "$finding" | jq -r '.line // "?"')
 		body_full=$(echo "$finding" | jq -r '.body_full // .body // ""')
 
 		verification_json=$(_finding_still_exists_on_main "$repo_slug" "$file_path" "$line_num" "$body_full" || true)
-		verification_result=$(echo "$verification_json" | jq -r '.result // false')
-		verification_status=$(echo "$verification_json" | jq -r '.status // "verified"')
+		verification_fields=$(echo "$verification_json" | jq -r '[(.result // false), (.status // "verified")] | @tsv')
+		IFS=$'\t' read -r verification_result verification_status <<<"$verification_fields"
 
 		if [[ "$verification_result" == "true" ]]; then
 			finding_with_status=$(echo "$finding" | jq --arg status "$verification_status" '. + {verification_status: $status}')

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -1131,7 +1131,7 @@ _create_quality_debt_issues() {
 	local repo_slug="$1"
 	local pr_num="$2"
 	local findings="$3"
-	local verified_findings="[]"
+	local verified_findings_stream=""
 
 	while IFS= read -r finding; do
 		[[ -z "$finding" ]] && continue
@@ -1153,11 +1153,15 @@ _create_quality_debt_issues() {
 
 		if [[ "$verification_result" == "true" ]]; then
 			finding_with_status=$(echo "$finding" | jq --arg status "$verification_status" '. + {verification_status: $status}')
-			verified_findings=$(echo "$verified_findings" "$finding_with_status" | jq -s '.[0] + [.[1]]')
+			verified_findings_stream+="${finding_with_status}"$'\n'
 		fi
 	done < <(echo "$findings" | jq -c '.[]')
 
-	findings="$verified_findings"
+	if [[ -n "$verified_findings_stream" ]]; then
+		findings=$(printf '%s' "$verified_findings_stream" | jq -s '.')
+	else
+		findings="[]"
+	fi
 
 	local finding_count
 	finding_count=$(echo "$findings" | jq 'length' 2>/dev/null || echo "0")

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -90,20 +90,48 @@ _extract_verification_snippet() {
 	local body_full="$1"
 	local line=""
 	local in_fence="false"
+	local fence_type=""
+	local candidate=""
 
 	while IFS= read -r line; do
 		if [[ "$line" =~ ^\`\`\` ]]; then
 			if [[ "$in_fence" == "false" ]]; then
 				in_fence="true"
+				fence_type=""
+				if [[ "$line" =~ ^\`\`\`([[:alnum:]_-]+) ]]; then
+					fence_type="${BASH_REMATCH[1],,}"
+				fi
 				continue
 			fi
 			break
 		fi
 
 		if [[ "$in_fence" == "true" ]]; then
-			line=$(_trim_whitespace "$line")
-			if [[ -n "$line" ]]; then
-				echo "$line"
+			candidate=$(_trim_whitespace "$line")
+			[[ -z "$candidate" ]] && continue
+
+			if [[ "$fence_type" == "diff" || "$fence_type" == "suggestion" ]]; then
+				[[ "$candidate" == "@@"* ]] && continue
+				[[ "$candidate" == "diff --git"* ]] && continue
+				[[ "$candidate" == "index "* ]] && continue
+				[[ "$candidate" == "+++"* ]] && continue
+				[[ "$candidate" == "---"* ]] && continue
+				[[ "$candidate" == +* ]] && continue
+				[[ "$candidate" == -* ]] && continue
+			fi
+
+			if [[ "$candidate" == +* || "$candidate" == -* ]]; then
+				candidate=$(_trim_whitespace "${candidate:1}")
+			fi
+
+			[[ "$candidate" == "Suggestion:"* ]] && continue
+			[[ "$candidate" == "//"* ]] && continue
+			[[ "$candidate" == "# "* ]] && continue
+			[[ "$candidate" == "/*"* ]] && continue
+			[[ "$candidate" == "*"* ]] && continue
+
+			if [[ -n "$candidate" && ${#candidate} -ge 12 ]]; then
+				echo "$candidate"
 				return 0
 			fi
 		fi
@@ -129,6 +157,7 @@ _finding_still_exists_on_main() {
 	local body_full="$4"
 
 	if [[ -z "$file_path" || "$file_path" == "null" ]]; then
+		echo '{"result":true,"status":"unverifiable"}'
 		return 0
 	fi
 
@@ -141,20 +170,52 @@ _finding_still_exists_on_main() {
 
 	if [[ -z "$file_content" ]]; then
 		echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - file missing on ${default_branch}" >&2
+		echo '{"result":false,"status":"resolved"}'
 		return 1
 	fi
 
 	local snippet
 	if ! snippet=$(_extract_verification_snippet "$body_full"); then
 		echo "[scan] Keeping unverifiable finding: ${file_path}:${line_num} - no snippet extracted" >&2
+		echo '{"result":true,"status":"unverifiable"}'
+		return 0
+	fi
+
+	local found_in_window="false"
+	if [[ "$line_num" =~ ^[0-9]+$ && "$line_num" -gt 0 ]]; then
+		local total_lines
+		total_lines=$(printf '%s\n' "$file_content" | wc -l | tr -d ' ')
+
+		if [[ "$line_num" -le "$total_lines" ]]; then
+			local start_line=$((line_num - 20))
+			local end_line=$((line_num + 20))
+			((start_line < 1)) && start_line=1
+			((end_line > total_lines)) && end_line=$total_lines
+
+			local current_line=0
+			local file_line=""
+			while IFS= read -r file_line; do
+				current_line=$((current_line + 1))
+				if [[ "$current_line" -ge "$start_line" && "$current_line" -le "$end_line" && "$file_line" == *"$snippet"* ]]; then
+					found_in_window="true"
+					break
+				fi
+			done <<<"$file_content"
+		fi
+	fi
+
+	if [[ "$found_in_window" == "true" ]]; then
+		echo '{"result":true,"status":"verified"}'
 		return 0
 	fi
 
 	if printf '%s' "$file_content" | grep -Fq "$snippet"; then
+		echo '{"result":true,"status":"verified"}'
 		return 0
 	fi
 
 	echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - snippet not found on ${default_branch}" >&2
+	echo '{"result":false,"status":"resolved"}'
 	return 1
 }
 
@@ -1049,12 +1110,21 @@ _create_quality_debt_issues() {
 		local file_path
 		local line_num
 		local body_full
+		local verification_json
+		local verification_result
+		local verification_status
+		local finding_with_status
 		file_path=$(echo "$finding" | jq -r '.file // ""')
 		line_num=$(echo "$finding" | jq -r '.line // "?"')
 		body_full=$(echo "$finding" | jq -r '.body_full // .body // ""')
 
-		if _finding_still_exists_on_main "$repo_slug" "$file_path" "$line_num" "$body_full"; then
-			verified_findings=$(echo "$verified_findings" "$finding" | jq -s '.[0] + [.[1]]')
+		verification_json=$(_finding_still_exists_on_main "$repo_slug" "$file_path" "$line_num" "$body_full" || true)
+		verification_result=$(echo "$verification_json" | jq -r '.result // false')
+		verification_status=$(echo "$verification_json" | jq -r '.status // "verified"')
+
+		if [[ "$verification_result" == "true" ]]; then
+			finding_with_status=$(echo "$finding" | jq --arg status "$verification_status" '. + {verification_status: $status}')
+			verified_findings=$(echo "$verified_findings" "$finding_with_status" | jq -s '.[0] + [.[1]]')
 		fi
 	done < <(echo "$findings" | jq -c '.[]')
 
@@ -1133,6 +1203,7 @@ _create_quality_debt_issues() {
 		finding_details=$(echo "$file_findings" | jq -r '.[] |
 			"### \(.severity | ascii_upcase): \(.reviewer) (\(.reviewer_login))\n" +
 			(if .file != null and .line != null then "**File**: `\(.file):\(.line)`\n" else "" end) +
+			(if .verification_status == "unverifiable" then "**Verification**: kept as unverifiable (no stable snippet extracted)\n" else "" end) +
 			"\(.body_full)\n\n" +
 			(if .url != null then "[View comment](\(.url))\n" else "" end) +
 			"---\n"

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -54,6 +54,110 @@ get_sha() {
 	return 0
 }
 
+# Resolve default branch for repo (cached per process)
+_QF_DEFAULT_BRANCH=""
+_QF_DEFAULT_BRANCH_REPO=""
+
+_get_default_branch() {
+	local repo_slug="$1"
+
+	if [[ -n "$_QF_DEFAULT_BRANCH" && "$_QF_DEFAULT_BRANCH_REPO" == "$repo_slug" ]]; then
+		echo "$_QF_DEFAULT_BRANCH"
+		return 0
+	fi
+
+	local branch
+	branch=$(gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null || echo "main")
+	if [[ -z "$branch" || "$branch" == "null" ]]; then
+		branch="main"
+	fi
+
+	_QF_DEFAULT_BRANCH="$branch"
+	_QF_DEFAULT_BRANCH_REPO="$repo_slug"
+	echo "$branch"
+	return 0
+}
+
+_trim_whitespace() {
+	local text="$1"
+	text="${text#"${text%%[![:space:]]*}"}"
+	text="${text%"${text##*[![:space:]]}"}"
+	echo "$text"
+	return 0
+}
+
+_extract_verification_snippet() {
+	local body_full="$1"
+	local line=""
+	local in_fence="false"
+
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^\`\`\` ]]; then
+			if [[ "$in_fence" == "false" ]]; then
+				in_fence="true"
+				continue
+			fi
+			break
+		fi
+
+		if [[ "$in_fence" == "true" ]]; then
+			line=$(_trim_whitespace "$line")
+			if [[ -n "$line" ]]; then
+				echo "$line"
+				return 0
+			fi
+		fi
+	done <<<"$body_full"
+
+	while IFS= read -r line; do
+		line="${line#> }"
+		line="${line#- }"
+		line=$(_trim_whitespace "$line")
+		if [[ -n "$line" && ${#line} -ge 12 ]]; then
+			echo "$line"
+			return 0
+		fi
+	done <<<"$body_full"
+
+	return 1
+}
+
+_finding_still_exists_on_main() {
+	local repo_slug="$1"
+	local file_path="$2"
+	local line_num="$3"
+	local body_full="$4"
+
+	if [[ -z "$file_path" || "$file_path" == "null" ]]; then
+		return 0
+	fi
+
+	local default_branch
+	default_branch=$(_get_default_branch "$repo_slug")
+
+	local file_content
+	file_content=$(gh api -H "Accept: application/vnd.github.raw" \
+		"repos/${repo_slug}/contents/${file_path}?ref=${default_branch}" 2>/dev/null || true)
+
+	if [[ -z "$file_content" ]]; then
+		echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - file missing on ${default_branch}" >&2
+		return 1
+	fi
+
+	local snippet
+	if ! snippet=$(_extract_verification_snippet "$body_full"); then
+		echo "[scan] Keeping unverifiable finding: ${file_path}:${line_num} - no snippet extracted" >&2
+		return 0
+	fi
+
+	if printf '%s' "$file_content" | grep -Fq "$snippet"; then
+		return 0
+	fi
+
+	echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - snippet not found on ${default_branch}" >&2
+	return 1
+}
+
 # Show status of all checks
 cmd_status() {
 	local pr_number="${1:-}"
@@ -937,6 +1041,24 @@ _create_quality_debt_issues() {
 	local repo_slug="$1"
 	local pr_num="$2"
 	local findings="$3"
+	local verified_findings="[]"
+
+	while IFS= read -r finding; do
+		[[ -z "$finding" ]] && continue
+
+		local file_path
+		local line_num
+		local body_full
+		file_path=$(echo "$finding" | jq -r '.file // ""')
+		line_num=$(echo "$finding" | jq -r '.line // "?"')
+		body_full=$(echo "$finding" | jq -r '.body_full // .body // ""')
+
+		if _finding_still_exists_on_main "$repo_slug" "$file_path" "$line_num" "$body_full"; then
+			verified_findings=$(echo "$verified_findings" "$finding" | jq -s '.[0] + [.[1]]')
+		fi
+	done < <(echo "$findings" | jq -c '.[]')
+
+	findings="$verified_findings"
 
 	local finding_count
 	finding_count=$(echo "$findings" | jq 'length' 2>/dev/null || echo "0")
@@ -1235,4 +1357,6 @@ main() {
 	return 0
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC2016
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../quality-feedback-helper.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+GH_RAW_CONTENT=""
+GH_ISSUE_CREATE_COUNT=0
+GH_CREATE_LOG=""
+
+print_result() {
+	local test_name="$1"
+	local result="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$result" -eq 0 ]]; then
+		echo "PASS $test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $test_name"
+		[[ -n "$message" ]] && echo "  $message"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+reset_mock_state() {
+	GH_RAW_CONTENT=""
+	GH_ISSUE_CREATE_COUNT=0
+	GH_CREATE_LOG=$(mktemp)
+	_QF_DEFAULT_BRANCH=""
+	_QF_DEFAULT_BRANCH_REPO=""
+	return 0
+}
+
+gh() {
+	local command="$1"
+	shift
+
+	case "$command" in
+	api)
+		_mock_gh_api "$@"
+		return $?
+		;;
+	label)
+		return 0
+		;;
+	issue)
+		_mock_gh_issue "$@"
+		return $?
+		;;
+	esac
+
+	echo "unexpected gh call: ${command}" >&2
+	return 1
+}
+
+_mock_gh_api() {
+	local endpoint=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		-H | --jq)
+			shift 2
+			;;
+		repos/*)
+			endpoint="$1"
+			shift
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ "$endpoint" == repos/*/contents/* ]]; then
+		[[ -n "$GH_RAW_CONTENT" ]] || return 1
+		printf '%s' "$GH_RAW_CONTENT"
+		return 0
+	fi
+
+	if [[ "$endpoint" == repos/* ]]; then
+		echo "main"
+		return 0
+	fi
+
+	echo "[]"
+	return 0
+}
+
+_mock_gh_issue() {
+	local subcommand="$1"
+	shift
+
+	case "$subcommand" in
+	list)
+		echo "[]"
+		return 0
+		;;
+	create)
+		GH_ISSUE_CREATE_COUNT=$((GH_ISSUE_CREATE_COUNT + 1))
+		if [[ -n "$GH_CREATE_LOG" ]]; then
+			echo "create" >>"$GH_CREATE_LOG"
+		fi
+		echo "https://github.com/example/repo/issues/999"
+		return 0
+		;;
+	comment | edit)
+		return 0
+		;;
+	esac
+
+	return 1
+}
+
+test_skips_resolved_finding_when_snippet_missing() {
+	reset_mock_state
+	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nreturn 0\n'
+
+	local findings
+	findings='[{"file":".agents/scripts/example.sh","line":42,"body_full":"```bash\nreturn 1\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+
+	if [[ "$created" == "0" && "$created_count" -eq 0 ]]; then
+		print_result "skip resolved finding when snippet not on main" 0
+	else
+		print_result "skip resolved finding when snippet not on main" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
+test_creates_issue_when_snippet_still_exists() {
+	reset_mock_state
+	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nreturn 1\n'
+
+	local findings
+	findings='[{"file":".agents/scripts/example.sh","line":42,"body_full":"```bash\nreturn 1\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+
+	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
+		print_result "create issue when finding snippet exists on main" 0
+	else
+		print_result "create issue when finding snippet exists on main" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
+main() {
+	source "$HELPER"
+
+	echo "Running quality-feedback main-branch verification tests"
+	test_skips_resolved_finding_when_snippet_missing
+	test_creates_issue_when_snippet_still_exists
+
+	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -95,6 +95,14 @@ _mock_gh_api() {
 		[[ -n "$GH_API_LOG" ]] && printf '%s\n' "$endpoint" >>"$GH_API_LOG"
 
 		if [[ "$GH_DELETED" == "1" ]]; then
+			# Simulate a 404 — write "404" to stderr so the caller can detect it
+			echo "404 Not Found" >&2
+			return 1
+		fi
+
+		if [[ "$GH_DELETED" == "transient" ]]; then
+			# Simulate a transient API error (non-404) — no "404" in stderr
+			echo "500 Internal Server Error" >&2
 			return 1
 		fi
 
@@ -336,6 +344,34 @@ test_keeps_unverifiable_finding() {
 	return 0
 }
 
+test_transient_api_error_keeps_finding_as_unverifiable() {
+	reset_mock_state
+	GH_DELETED="transient"
+
+	local findings
+	findings='[{"file":".agents/scripts/example.sh","line":42,"body_full":"```bash\nsome code snippet here\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
+
+	# Transient API error should keep finding as unverifiable → issue created
+	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
+		print_result "transient API error keeps finding as unverifiable" 0
+	else
+		print_result "transient API error keeps finding as unverifiable" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
 test_uses_default_branch_ref_for_contents_lookup() {
 	reset_mock_state
 	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nverification marker present\nreturn 0\n'
@@ -369,6 +405,7 @@ main() {
 	test_handles_diff_fence_without_false_positive
 	test_handles_suggestion_fence_and_comments
 	test_keeps_unverifiable_finding
+	test_transient_api_error_keeps_finding_as_unverifiable
 	test_uses_default_branch_ref_for_contents_lookup
 
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -395,6 +395,48 @@ test_uses_default_branch_ref_for_contents_lookup() {
 	return 0
 }
 
+test_plain_fence_skips_diff_marker_lines() {
+	# Regression: a plain ```bash fence whose first line starts with '+' or '-'
+	# must NOT strip the marker and use the remainder as a snippet.  The old code
+	# did `candidate="${candidate:1}"` which turned "+ new code" into "new code"
+	# and then matched it against the file, producing a false "verified" result.
+	# The fix skips +/- lines in non-diff fences entirely, so the snippet falls
+	# through to the fallback extractor (or returns unverifiable if nothing else
+	# matches), preventing the false positive.
+	reset_mock_state
+	# File contains "new code" — the stripped version of "+ new code"
+	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nnew code\nreturn 0\n'
+
+	local findings
+	# Body has a plain bash fence whose only substantive line is "+ new code".
+	# With the old strip logic this would extract "new code", find it in the file,
+	# and mark the finding verified.  With the fix it skips the +/- line and falls
+	# through to unverifiable (no other qualifying line), so the issue is still
+	# created (unverifiable → kept), but the snippet is NOT "new code".
+	findings='[{"file":".agents/scripts/example.sh","line":2,"body_full":"```bash\n+ new code\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
+
+	# Finding must be kept (unverifiable — no snippet extracted from +/- only fence)
+	# rather than falsely resolved by matching the stripped "new code" in the file.
+	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
+		print_result "plain fence skips +/- lines instead of stripping prefix" 0
+	else
+		print_result "plain fence skips +/- lines instead of stripping prefix" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
 main() {
 	source "$HELPER"
 
@@ -407,6 +449,7 @@ main() {
 	test_keeps_unverifiable_finding
 	test_transient_api_error_keeps_finding_as_unverifiable
 	test_uses_default_branch_ref_for_contents_lookup
+	test_plain_fence_skips_diff_marker_lines
 
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -14,8 +14,10 @@ GH_RAW_CONTENT=""
 GH_DIFF=""
 GH_SUGGESTION=""
 GH_DELETED=""
+GH_LAST_CONTENT_ENDPOINT=""
 GH_ISSUE_CREATE_COUNT=0
 GH_CREATE_LOG=""
+GH_API_LOG=""
 
 print_result() {
 	local test_name="$1"
@@ -39,8 +41,10 @@ reset_mock_state() {
 	GH_DIFF=""
 	GH_SUGGESTION=""
 	GH_DELETED=""
+	GH_LAST_CONTENT_ENDPOINT=""
 	GH_ISSUE_CREATE_COUNT=0
 	GH_CREATE_LOG=$(mktemp)
+	GH_API_LOG=$(mktemp)
 	_QF_DEFAULT_BRANCH=""
 	_QF_DEFAULT_BRANCH_REPO=""
 	return 0
@@ -87,8 +91,26 @@ _mock_gh_api() {
 	done
 
 	if [[ "$endpoint" == repos/*/contents/* ]]; then
+		GH_LAST_CONTENT_ENDPOINT="$endpoint"
+		[[ -n "$GH_API_LOG" ]] && printf '%s\n' "$endpoint" >>"$GH_API_LOG"
+
 		if [[ "$GH_DELETED" == "1" ]]; then
 			return 1
+		fi
+
+		if [[ "$endpoint" == *"diff"* && -n "$GH_DIFF" ]]; then
+			printf '%s' "$GH_DIFF"
+			return 0
+		fi
+
+		if [[ "$endpoint" == *"suggestion"* && -n "$GH_SUGGESTION" ]]; then
+			printf '%s' "$GH_SUGGESTION"
+			return 0
+		fi
+
+		if [[ -n "$GH_RAW_CONTENT" ]]; then
+			printf '%s' "$GH_RAW_CONTENT"
+			return 0
 		fi
 
 		if [[ -n "$GH_DIFF" ]]; then
@@ -98,11 +120,6 @@ _mock_gh_api() {
 
 		if [[ -n "$GH_SUGGESTION" ]]; then
 			printf '%s' "$GH_SUGGESTION"
-			return 0
-		fi
-
-		if [[ -n "$GH_RAW_CONTENT" ]]; then
-			printf '%s' "$GH_RAW_CONTENT"
 			return 0
 		fi
 
@@ -174,6 +191,7 @@ test_skips_resolved_finding_when_snippet_missing() {
 	local created_count
 	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
 	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
 
 	if [[ "$created" == "0" && "$created_count" -eq 0 ]]; then
 		print_result "skip resolved finding when snippet not on main" 0
@@ -200,6 +218,7 @@ test_creates_issue_when_snippet_still_exists() {
 	local created_count
 	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
 	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
 
 	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
 		print_result "create issue when finding snippet exists on main" 0
@@ -226,6 +245,7 @@ test_skips_deleted_file() {
 	local created_count
 	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
 	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
 
 	if [[ "$created" == "0" && "$created_count" -eq 0 ]]; then
 		print_result "skip finding when file deleted on main" 0
@@ -240,7 +260,7 @@ test_handles_diff_fence_without_false_positive() {
 	GH_DIFF=$'#!/usr/bin/env bash\ncontext stable verification marker\nreturn 0\n'
 
 	local findings
-	findings='[{"file":".agents/scripts/example.sh","line":2,"body_full":"```diff\n- return 1\n+ return 2\n context stable verification marker\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+	findings='[{"file":".agents/scripts/diff-example.sh","line":2,"body_full":"```diff\n- return 1\n+ return 2\n context stable verification marker\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
 
 	local out_file
 	out_file=$(mktemp)
@@ -252,6 +272,7 @@ test_handles_diff_fence_without_false_positive() {
 	local created_count
 	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
 	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
 
 	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
 		print_result "diff fences verify using substantive context line" 0
@@ -266,7 +287,7 @@ test_handles_suggestion_fence_and_comments() {
 	GH_SUGGESTION=$'#!/usr/bin/env bash\nthis is stable suggestion code\n'
 
 	local findings
-	findings='[{"file":".agents/scripts/example.sh","line":2,"body_full":"```suggestion\n// reviewer note\n# inline comment\nthis is stable suggestion code\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+	findings='[{"file":".agents/scripts/suggestion-example.sh","line":2,"body_full":"```suggestion\n// reviewer note\n# inline comment\nthis is stable suggestion code\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
 
 	local out_file
 	out_file=$(mktemp)
@@ -278,6 +299,7 @@ test_handles_suggestion_fence_and_comments() {
 	local created_count
 	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
 	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
 
 	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
 		print_result "suggestion fences skip comments and keep code" 0
@@ -304,12 +326,36 @@ test_keeps_unverifiable_finding() {
 	local created_count
 	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
 	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
 
 	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
 		print_result "keep unverifiable findings for manual review" 0
 	else
 		print_result "keep unverifiable findings for manual review" 1 "created=${created}, issues=${created_count}"
 	fi
+	return 0
+}
+
+test_uses_default_branch_ref_for_contents_lookup() {
+	reset_mock_state
+	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nverification marker present\nreturn 0\n'
+
+	local findings
+	findings='[{"file":".agents/scripts/ref-check.sh","line":2,"body_full":"```bash\nverification marker present\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	rm -f "$out_file"
+
+	rm -f "$GH_CREATE_LOG"
+
+	if [[ -f "$GH_API_LOG" ]] && grep -Fq '?ref=main' "$GH_API_LOG"; then
+		print_result "contents lookup uses default-branch ref" 0
+	else
+		print_result "contents lookup uses default-branch ref" 1 "endpoint=${GH_LAST_CONTENT_ENDPOINT}"
+	fi
+	rm -f "$GH_API_LOG"
 	return 0
 }
 
@@ -323,6 +369,7 @@ main() {
 	test_handles_diff_fence_without_false_positive
 	test_handles_suggestion_fence_and_comments
 	test_keeps_unverifiable_finding
+	test_uses_default_branch_ref_for_contents_lookup
 
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -11,6 +11,9 @@ TESTS_PASSED=0
 TESTS_FAILED=0
 
 GH_RAW_CONTENT=""
+GH_DIFF=""
+GH_SUGGESTION=""
+GH_DELETED=""
 GH_ISSUE_CREATE_COUNT=0
 GH_CREATE_LOG=""
 
@@ -33,6 +36,9 @@ print_result() {
 
 reset_mock_state() {
 	GH_RAW_CONTENT=""
+	GH_DIFF=""
+	GH_SUGGESTION=""
+	GH_DELETED=""
 	GH_ISSUE_CREATE_COUNT=0
 	GH_CREATE_LOG=$(mktemp)
 	_QF_DEFAULT_BRANCH=""
@@ -81,8 +87,39 @@ _mock_gh_api() {
 	done
 
 	if [[ "$endpoint" == repos/*/contents/* ]]; then
-		[[ -n "$GH_RAW_CONTENT" ]] || return 1
-		printf '%s' "$GH_RAW_CONTENT"
+		if [[ "$GH_DELETED" == "1" ]]; then
+			return 1
+		fi
+
+		if [[ -n "$GH_DIFF" ]]; then
+			printf '%s' "$GH_DIFF"
+			return 0
+		fi
+
+		if [[ -n "$GH_SUGGESTION" ]]; then
+			printf '%s' "$GH_SUGGESTION"
+			return 0
+		fi
+
+		if [[ -n "$GH_RAW_CONTENT" ]]; then
+			printf '%s' "$GH_RAW_CONTENT"
+			return 0
+		fi
+
+		return 1
+	fi
+
+	if [[ "$endpoint" == repos/*/pulls/*/files ]]; then
+		if [[ -n "$GH_DIFF" ]]; then
+			printf '%s' "$GH_DIFF"
+			return 0
+		fi
+
+		if [[ -n "$GH_SUGGESTION" ]]; then
+			printf '%s' "$GH_SUGGESTION"
+			return 0
+		fi
+
 		return 0
 	fi
 
@@ -122,10 +159,10 @@ _mock_gh_issue() {
 
 test_skips_resolved_finding_when_snippet_missing() {
 	reset_mock_state
-	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nreturn 0\n'
+	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nverification marker present\nreturn 0\n'
 
 	local findings
-	findings='[{"file":".agents/scripts/example.sh","line":42,"body_full":"```bash\nreturn 1\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+	findings='[{"file":".agents/scripts/example.sh","line":42,"body_full":"```bash\nverification marker missing\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
 
 	local out_file
 	out_file=$(mktemp)
@@ -148,10 +185,10 @@ test_skips_resolved_finding_when_snippet_missing() {
 
 test_creates_issue_when_snippet_still_exists() {
 	reset_mock_state
-	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nreturn 1\n'
+	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nverification marker present\nreturn 1\n'
 
 	local findings
-	findings='[{"file":".agents/scripts/example.sh","line":42,"body_full":"```bash\nreturn 1\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+	findings='[{"file":".agents/scripts/example.sh","line":42,"body_full":"```bash\nverification marker present\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
 
 	local out_file
 	out_file=$(mktemp)
@@ -172,12 +209,120 @@ test_creates_issue_when_snippet_still_exists() {
 	return 0
 }
 
+test_skips_deleted_file() {
+	reset_mock_state
+	GH_DELETED="1"
+
+	local findings
+	findings='[{"file":".agents/scripts/deleted.sh","line":42,"body_full":"```bash\nreturn 1\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+
+	if [[ "$created" == "0" && "$created_count" -eq 0 ]]; then
+		print_result "skip finding when file deleted on main" 0
+	else
+		print_result "skip finding when file deleted on main" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
+test_handles_diff_fence_without_false_positive() {
+	reset_mock_state
+	GH_DIFF=$'#!/usr/bin/env bash\ncontext stable verification marker\nreturn 0\n'
+
+	local findings
+	findings='[{"file":".agents/scripts/example.sh","line":2,"body_full":"```diff\n- return 1\n+ return 2\n context stable verification marker\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+
+	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
+		print_result "diff fences verify using substantive context line" 0
+	else
+		print_result "diff fences verify using substantive context line" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
+test_handles_suggestion_fence_and_comments() {
+	reset_mock_state
+	GH_SUGGESTION=$'#!/usr/bin/env bash\nthis is stable suggestion code\n'
+
+	local findings
+	findings='[{"file":".agents/scripts/example.sh","line":2,"body_full":"```suggestion\n// reviewer note\n# inline comment\nthis is stable suggestion code\n```","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+
+	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
+		print_result "suggestion fences skip comments and keep code" 0
+	else
+		print_result "suggestion fences skip comments and keep code" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
+test_keeps_unverifiable_finding() {
+	reset_mock_state
+	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nreturn 0\n'
+
+	local findings
+	findings='[{"file":".agents/scripts/example.sh","line":2,"body_full":"tiny\n- short\n> mini","reviewer":"coderabbit","reviewer_login":"coderabbitai","severity":"high","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "123" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+
+	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
+		print_result "keep unverifiable findings for manual review" 0
+	else
+		print_result "keep unverifiable findings for manual review" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
 main() {
 	source "$HELPER"
 
 	echo "Running quality-feedback main-branch verification tests"
 	test_skips_resolved_finding_when_snippet_missing
 	test_creates_issue_when_snippet_still_exists
+	test_skips_deleted_file
+	test_handles_diff_fence_without_false_positive
+	test_handles_suggestion_fence_and_comments
+	test_keeps_unverifiable_finding
 
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- add a main/default-branch verification guard that checks each finding's snippet against the current file content before issue creation
- skip resolved findings (deleted files or missing snippets) while keeping unverifiable findings to avoid false negatives
- add a targeted regression test script covering both skip and create paths for the new verification gate

Closes #4166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added verification that checks whether reported findings still exist on the main branch before creating issues; findings that can’t be verified are marked as unverifiable and excluded from issue creation.
  * Issue details now include verification status for each finding.

* **Tests**
  * Added comprehensive tests for main-branch verification covering missing/existing snippets, deleted files, fence handling, and default-branch lookup.

* **Chores**
  * Guarded script to avoid running when sourced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->