### PR TITLE
t4153: use as_posix for email thread index links

### DIFF
--- a/.agents/scripts/email-thread-reconstruction.py
+++ b/.agents/scripts/email-thread-reconstruction.py
@@ -242,9 +242,9 @@ def generate_thread_index(threads, output_file):
         for i, email in enumerate(emails, 1):
             # Compute relative path from index file location to email file
             # Normalize separators to forward slashes for portable Markdown links
-            file_path = os.path.relpath(
-                Path(email["file"]).resolve(), output_dir
-            ).replace(os.sep, "/")
+            file_path = Path(
+                os.path.relpath(Path(email["file"]).resolve(), output_dir)
+            ).as_posix()
             email_subject = email.get("subject", "No Subject")
             from_addr = email.get("from", "Unknown")
             date_sent = email.get("date_sent", "Unknown")


### PR DESCRIPTION
## Summary
- replace separator normalization via `replace(os.sep, '/')` with `Path(...).as_posix()` in thread index link generation
- keep behavior unchanged otherwise and limit scope to `.agents/scripts/email-thread-reconstruction.py`

## Verification
- `python3 -m py_compile .agents/scripts/email-thread-reconstruction.py`
- `ruff check .agents/scripts/email-thread-reconstruction.py` (when available)

Closes #4153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path normalization in email thread reconstruction to consistently use forward slashes, ensuring more reliable file link handling across different operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->