### PR TITLE
4157: harden quarantine-helper false-positive rate logic

### DIFF
--- a/.agents/scripts/quarantine-helper.sh
+++ b/.agents/scripts/quarantine-helper.sh
@@ -100,6 +100,16 @@ _q_validate_value() {
 	return 1
 }
 
+# Compute integer percentage with an internal divide-by-zero guard.
+_q_compute_percentage() {
+	local numerator="$1"
+	local denominator="$2"
+
+	awk -v numerator="$numerator" -v denominator="$denominator" \
+		'BEGIN { if (denominator > 0) printf "%.0f", (numerator / denominator) * 100; else print 0 }'
+	return 0
+}
+
 # =============================================================================
 # Add Command
 # =============================================================================
@@ -768,15 +778,15 @@ cmd_stats() {
 		deny_count="$(jq -r 'select(.decision=="deny") | .id' "$QUARANTINE_REVIEWED" 2>/dev/null | wc -l | tr -d ' ')"
 		trust_count="$(jq -r 'select(.decision=="trust") | .id' "$QUARANTINE_REVIEWED" 2>/dev/null | wc -l | tr -d ' ')"
 		dismiss_count="$(jq -r 'select(.decision=="dismiss") | .id' "$QUARANTINE_REVIEWED" 2>/dev/null | wc -l | tr -d ' ')"
+		local total_decisions
+		total_decisions=$((allow_count + deny_count + trust_count + dismiss_count))
 		echo "  Allowed (Tier 3):  ${allow_count}"
 		echo "  Denied (Tier 5):   ${deny_count}"
 		echo "  Trusted (MCP):     ${trust_count}"
 		echo "  Dismissed (FP):    ${dismiss_count}"
 
-		# reviewed_count > 0 already guaranteed by outer guard (line 758)
 		local fp_rate
-		fp_rate="$(awk -v dismissed="$dismiss_count" -v total="$reviewed_count" \
-			'BEGIN { if (total > 0) printf "%.0f", (dismissed / total) * 100; else print 0 }')"
+		fp_rate="$(_q_compute_percentage "$dismiss_count" "$total_decisions")"
 		echo "  False positive rate: ${fp_rate}%"
 	fi
 

--- a/tests/test-quarantine-helper.sh
+++ b/tests/test-quarantine-helper.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2317
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+QUARANTINE_HELPER="${REPO_DIR}/.agents/scripts/quarantine-helper.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+	local message="$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	printf "PASS %s\n" "$message"
+	return 0
+}
+
+fail() {
+	local message="$1"
+	local details="${2:-}"
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	printf "FAIL %s\n" "$message"
+	if [[ -n "$details" ]]; then
+		printf "  %s\n" "$details"
+	fi
+	return 0
+}
+
+cleanup() {
+	if [[ -n "${TEST_HOME:-}" ]] && [[ -d "$TEST_HOME" ]]; then
+		rm -rf "$TEST_HOME"
+	fi
+	return 0
+}
+trap cleanup EXIT
+
+if ! command -v jq >/dev/null 2>&1; then
+	echo "SKIP jq is required for quarantine stats checks"
+	exit 0
+fi
+
+if bash -n "$QUARANTINE_HELPER" 2>/dev/null; then
+	pass "quarantine-helper.sh passes bash -n"
+else
+	fail "quarantine-helper.sh has syntax errors"
+fi
+
+TEST_HOME="$(mktemp -d)"
+export HOME="$TEST_HOME"
+mkdir -p "$HOME/.aidevops/.agent-workspace/security/quarantine"
+
+reviewed_file="$HOME/.aidevops/.agent-workspace/security/quarantine/reviewed.jsonl"
+
+printf '{"id":"q1","timestamp":"2026-01-01T00:00:00Z"}\n' >"$reviewed_file"
+
+stats_output="$(bash "$QUARANTINE_HELPER" stats 2>&1 || true)"
+if printf '%s\n' "$stats_output" | grep -q "False positive rate: 0%"; then
+	pass "stats keeps false-positive rate safe at 0 when no decisions exist"
+else
+	fail "stats did not report 0% false-positive rate for decisionless records" "$stats_output"
+fi
+
+printf '{"id":"q2","decision":"dismiss"}\n{"id":"q3","decision":"allow"}\n' >"$reviewed_file"
+
+stats_output="$(bash "$QUARANTINE_HELPER" stats 2>&1 || true)"
+if printf '%s\n' "$stats_output" | grep -q "False positive rate: 50%"; then
+	pass "stats computes false-positive rate from reviewed decisions"
+else
+	fail "stats did not report expected 50% false-positive rate" "$stats_output"
+fi
+
+echo ""
+printf "Passed: %s\n" "$PASS_COUNT"
+printf "Failed: %s\n" "$FAIL_COUNT"
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/tests/test-quarantine-helper.sh
+++ b/tests/test-quarantine-helper.sh
@@ -55,7 +55,7 @@ reviewed_file="$HOME/.aidevops/.agent-workspace/security/quarantine/reviewed.jso
 printf '{"id":"q1","timestamp":"2026-01-01T00:00:00Z"}\n' >"$reviewed_file"
 
 stats_output="$(bash "$QUARANTINE_HELPER" stats 2>&1 || true)"
-if printf '%s\n' "$stats_output" | grep -q "False positive rate: 0%"; then
+if printf '%s\n' "$stats_output" | grep -qE 'False positive rate:[[:space:]]+0%'; then
 	pass "stats keeps false-positive rate safe at 0 when no decisions exist"
 else
 	fail "stats did not report 0% false-positive rate for decisionless records" "$stats_output"
@@ -64,7 +64,7 @@ fi
 printf '{"id":"q2","decision":"dismiss"}\n{"id":"q3","decision":"allow"}\n' >"$reviewed_file"
 
 stats_output="$(bash "$QUARANTINE_HELPER" stats 2>&1 || true)"
-if printf '%s\n' "$stats_output" | grep -q "False positive rate: 50%"; then
+if printf '%s\n' "$stats_output" | grep -qE 'False positive rate:[[:space:]]+50%'; then
 	pass "stats computes false-positive rate from reviewed decisions"
 else
 	fail "stats did not report expected 50% false-positive rate" "$stats_output"


### PR DESCRIPTION
## Goal
Resolve issue #4157 by addressing only quarantine-helper.sh quality-debt findings with shellcheck-safe, focused changes.

## Summary
- add `_q_compute_percentage()` to centralize guarded percentage math and keep divide-by-zero handling local to the computation
- update `cmd_stats` to compute false-positive rate from counted decisions and call the shared helper
- add targeted regression coverage in `tests/test-quarantine-helper.sh` for zero-decision and mixed-decision false-positive rate outputs

## Verification
- `shellcheck .agents/scripts/quarantine-helper.sh` (existing SC1091 info only for sourced constants file)
- `shellcheck tests/test-quarantine-helper.sh`
- `bash tests/test-quarantine-helper.sh`

Closes #4157