### PR TITLE
t4154: make email thread reconstruction test grep portable

### DIFF
--- a/tests/test-email-thread-reconstruction.sh
+++ b/tests/test-email-thread-reconstruction.sh
@@ -231,7 +231,7 @@ test_relative_paths_cross_directory() {
 	fi
 
 	# Verify paths use forward slashes only (portable Markdown links)
-	if grep '\.md)' "$index_file" | grep -q "\\\\"; then
+	if grep -qE '\(.*\\.*\.md\)' "$index_file"; then
 		print_error "Index links contain backslashes (not portable)"
 		return 1
 	fi

--- a/tests/test-email-thread-reconstruction.sh
+++ b/tests/test-email-thread-reconstruction.sh
@@ -231,7 +231,7 @@ test_relative_paths_cross_directory() {
 	fi
 
 	# Verify paths use forward slashes only (portable Markdown links)
-	if grep -qP '\(.*\\\\.*\.md\)' "$index_file"; then
+	if grep '\.md)' "$index_file" | grep -q "\\\\"; then
 		print_error "Index links contain backslashes (not portable)"
 		return 1
 	fi


### PR DESCRIPTION
## Summary
- Replace GNU-specific `grep -P` usage in `tests/test-email-thread-reconstruction.sh` with a portable grep pipeline.
- Keep test intent unchanged: fail when markdown links in the generated index contain backslashes.
- Verify with `shellcheck tests/test-email-thread-reconstruction.sh` and `bash tests/test-email-thread-reconstruction.sh`.

Closes #4154