### PR TITLE
t1450: retry worker launches with same-cycle provider fallback

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -556,6 +556,8 @@ gh issue edit <number> --repo <slug> --add-assignee "$RUNNER_USER" --add-label "
 sleep 2
 ```
 
+If a dispatch attempt exits immediately with provider/auth failure (for example `Token refresh failed`, `authentication`, `401`, `403`, `400` in startup logs), do not wait for next cycle. Re-dispatch in the same cycle via `headless-runtime-helper.sh run` with an explicit alternate model/provider and continue filling remaining slots.
+
 9. **Fill-to-cap post-condition (t1449):** before ending the pulse cycle, compare active workers vs `MAX_WORKERS`. If below cap and runnable scoped issues/PR work exists in any repo class, continue dispatching until cap is reached or no runnable candidates remain. Do not leave slots idle because of class reservations when one class is PR-capped or empty.
 
 ### Candidate discovery baseline (t1443 + t1448)
@@ -586,6 +588,7 @@ If you dispatch an unassigned issue without `auto-dispatch`/`status:available`, 
 - Background with `&`, sleep 2 between dispatches
 - The helper alternates the default headless providers/models (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.3-codex`), persists session IDs per provider + session key, honors provider backoff, and rejects `opencode/*` gateway models (no Zen fallback for headless runs)
 - Do NOT add `--model` for first attempts — let the helper choose the alternating default. **Exception:** when escalating after 2+ failed attempts on the same issue, pass `--model anthropic/claude-opus-4-6` to the helper (see "Model escalation after repeated failures" above).
+- If helper-selected launch fails at startup with auth/provider errors, immediately retry with explicit alternate provider in the same cycle (for example `--model openai/gpt-5.3-codex` after anthropic auth failure) and log the fallback in an issue comment.
 - Use `--dir <path>` from repos.json
 - Route non-code tasks with `--agent`: SEO, Content, Marketing, Business, Research (see AGENTS.md "Agent Routing")
 - If a dispatched worker later looks stalled, `worker-watchdog.sh` now inspects the recent OpenCode transcript tail before killing it, includes that diagnostic evidence in the retry trail, and gives provider-wait evidence one extra timeout window before re-queueing the issue.


### PR DESCRIPTION
## Summary
- add explicit pulse dispatch guidance to treat startup auth/provider failures as immediate fallback events, not next-cycle work
- require same-cycle retry with alternate provider/model and continued fill-to-cap dispatching
- keep helper-only dispatch enforcement and require fallback traceability comments on issues

## Why
Pulse cycles were losing effective concurrency when workers failed to start with provider auth refresh errors (`Token refresh failed: 400`). Immediate alternate-provider retry in the same cycle prevents slot loss and improves throughput.

Closes #4188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic fallback: When dispatch attempts fail due to authentication or provider issues (token refresh failure, 401/403/400 errors), the system now automatically retries with an alternate provider/model to complete remaining slots.
  * Improved reliability: Failed dispatch operations no longer immediately halt processing; the system logs fallbacks and continues filling remaining processing slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->