### PR TITLE
t4205: auto-sync deployed agents after merge/release

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -60,10 +60,45 @@ log_error() {
 # Defaults
 REPO_DIR="${HOME}/Git/aidevops"
 TARGET_DIR="${HOME}/.aidevops/agents"
+PLUGINS_FILE="${HOME}/.config/aidevops/plugins.json"
 SCRIPTS_ONLY=false
 FULL_DEPLOY=false
 DRY_RUN=false
 DIFF_COMMIT=""
+PLUGIN_NAMESPACES=()
+
+sanitize_plugin_namespace() {
+	local namespace="$1"
+
+	if [[ -z "$namespace" ]]; then
+		return 1
+	fi
+
+	if [[ "$namespace" =~ ^[A-Za-z0-9._-]+$ ]]; then
+		printf '%s\n' "$namespace"
+		return 0
+	fi
+
+	return 1
+}
+
+collect_plugin_namespaces() {
+	PLUGIN_NAMESPACES=()
+
+	if [[ ! -f "$PLUGINS_FILE" ]] || ! command -v jq >/dev/null 2>&1; then
+		return 0
+	fi
+
+	local namespace
+	local safe_namespace
+	while IFS= read -r namespace; do
+		if [[ -n "$namespace" ]] && safe_namespace=$(sanitize_plugin_namespace "$namespace"); then
+			PLUGIN_NAMESPACES+=("$safe_namespace")
+		fi
+	done < <(jq -r '.plugins[].namespace // empty' "$PLUGINS_FILE" 2>/dev/null)
+
+	return 0
+}
 
 parse_args() {
 	while [[ $# -gt 0 ]]; do
@@ -241,25 +276,40 @@ deploy_all_agents() {
 
 	if [[ "$DRY_RUN" == "true" ]]; then
 		log_info "[dry-run] Would sync $source_dir/ -> $TARGET_DIR/"
-		log_info "[dry-run] Preserving: custom/, draft/"
+		local preserve_display="custom/, draft/, loop-state/"
+		if [[ ${#PLUGIN_NAMESPACES[@]} -gt 0 ]]; then
+			preserve_display+=", ${PLUGIN_NAMESPACES[*]}"
+		fi
+		log_info "[dry-run] Preserving: $preserve_display"
 		return 0
 	fi
 
 	log_info "Deploying all agents to $TARGET_DIR..."
 
 	if command -v rsync &>/dev/null; then
-		rsync -a \
-			--exclude='loop-state/' \
-			--exclude='custom/' \
-			--exclude='draft/' \
-			"$source_dir/" "$TARGET_DIR/"
+		local -a rsync_excludes=(
+			"--exclude=loop-state/"
+			"--exclude=custom/"
+			"--exclude=draft/"
+		)
+		local plugin_namespace
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+			rsync_excludes+=("--exclude=${plugin_namespace}/")
+		done
+		rsync -a "${rsync_excludes[@]}" "$source_dir/" "$TARGET_DIR/"
 	else
-		# Preserve custom and draft directories
+		# Preserve user and plugin namespace directories
 		local tmp_preserve
 		tmp_preserve=$(mktemp -d)
 		local preserve_ok=true
+		local -a preserved_dirs=("custom" "draft")
+		local plugin_namespace
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+			preserved_dirs+=("$plugin_namespace")
+		done
 
-		for pdir in custom draft; do
+		local pdir
+		for pdir in "${preserved_dirs[@]}"; do
 			if [[ -d "$TARGET_DIR/$pdir" ]] && ! cp -R "$TARGET_DIR/$pdir" "$tmp_preserve/$pdir"; then
 				preserve_ok=false
 			fi
@@ -277,20 +327,33 @@ deploy_all_agents() {
 			rm -rf "$tmp_preserve"
 			return 1
 		fi
-		if ! find "$TARGET_DIR" -mindepth 1 -maxdepth 1 \
-			! -name 'custom' ! -name 'draft' ! -name 'loop-state' \
-			-exec rm -rf {} +; then
+		local -a find_args=(
+			-mindepth 1
+			-maxdepth 1
+			! -name 'custom'
+			! -name 'draft'
+			! -name 'loop-state'
+		)
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+			find_args+=(! -name "$plugin_namespace")
+		done
+		find_args+=(-exec rm -rf {} +)
+		if ! find "$TARGET_DIR" "${find_args[@]}"; then
 			log_error "Failed to clean target directory: $TARGET_DIR"
 			rm -rf "$tmp_preserve"
 			return 1
 		fi
 
 		# Copy all agents
-		(cd "$source_dir" && tar cf - --exclude='loop-state' --exclude='custom' --exclude='draft' .) |
+		local -a tar_excludes=("--exclude=loop-state" "--exclude=custom" "--exclude=draft")
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+			tar_excludes+=("--exclude=$plugin_namespace")
+		done
+		(cd "$source_dir" && tar cf - "${tar_excludes[@]}" .) |
 			(cd "$TARGET_DIR" && tar xf -)
 
 		# Restore preserved directories
-		for pdir in custom draft; do
+		for pdir in "${preserved_dirs[@]}"; do
 			if [[ -d "$tmp_preserve/$pdir" ]]; then
 				cp -R "$tmp_preserve/$pdir" "$TARGET_DIR/$pdir"
 			fi
@@ -353,6 +416,15 @@ deploy_changed_files() {
 		custom/* | draft/* | loop-state/*) continue ;;
 		esac
 
+		local plugin_namespace
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+			case "$rel_path" in
+			"$plugin_namespace"/*)
+				continue 2
+				;;
+			esac
+		done
+
 		if [[ -f "$source_file" ]]; then
 			# Create target directory if needed
 			local target_parent
@@ -406,6 +478,7 @@ deploy_changed_files() {
 main() {
 	parse_args "$@" || return 1
 	validate_repo || return 1
+	collect_plugin_namespaces || return 1
 
 	# Full deploy: delegate to setup.sh
 	if [[ "$FULL_DEPLOY" == "true" ]]; then

--- a/.agents/scripts/github-cli-helper.sh
+++ b/.agents/scripts/github-cli-helper.sh
@@ -661,9 +661,12 @@ EOF
 
 main() {
 	local command="${1:-help}"
-	local account_name="$2"
-	local target="$3"
-	local options="$4"
+	local account_name="${2:-}"
+	local target="${3:-}"
+	local options="${4:-}"
+	local arg5="${5:-}"
+	local arg6="${6:-}"
+	local arg7="${7:-}"
 
 	case "$command" in
 	"list-repos")
@@ -671,8 +674,8 @@ main() {
 		;;
 	"create-repo")
 		local repo_desc="$options"
-		local repo_vis="$5"
-		local repo_init="$6"
+		local repo_vis="$arg5"
+		local repo_init="$arg6"
 		create_repo "$account_name" "$target" "$repo_desc" "$repo_vis" "$repo_init"
 		;;
 	"delete-repo")
@@ -685,7 +688,7 @@ main() {
 		list_issues "$account_name" "$target" "$options"
 		;;
 	"create-issue")
-		local issue_body="$5"
+		local issue_body="$arg5"
 		create_issue "$account_name" "$target" "$options" "$issue_body"
 		;;
 	"close-issue")
@@ -695,20 +698,20 @@ main() {
 		list_prs "$account_name" "$target" "$options"
 		;;
 	"create-pr")
-		local pr_base="$5"
-		local pr_head="$6"
-		local pr_body="$7"
+		local pr_base="$arg5"
+		local pr_head="$arg6"
+		local pr_body="$arg7"
 		create_pr "$account_name" "$target" "$options" "$pr_base" "$pr_head" "$pr_body"
 		;;
 	"merge-pr")
-		local merge_method="$5"
+		local merge_method="$arg5"
 		merge_pr "$account_name" "$target" "$options" "$merge_method"
 		;;
 	"list-branches")
 		list_branches "$account_name" "$target"
 		;;
 	"create-branch")
-		local source_branch="$5"
+		local source_branch="$arg5"
 		create_branch "$account_name" "$target" "$options" "$source_branch"
 		;;
 	"list-accounts")

--- a/.agents/scripts/github-cli-helper.sh
+++ b/.agents/scripts/github-cli-helper.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 # ------------------------------------------------------------------------------
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-source "${SCRIPT_DIR}/shared-constants.sh"
+source "${script_dir}/shared-constants.sh"
 
 readonly SCRIPT_DIR="$script_dir"
 
@@ -453,6 +453,7 @@ merge_pr() {
 
     if [[ $merge_exit -eq 0 ]]; then
         print_success "$SUCCESS_PR_MERGED"
+        trigger_aidevops_post_merge_sync "$owner/$repo_name"
         return 0
     fi
 
@@ -465,6 +466,60 @@ merge_pr() {
 
     print_error "Failed to merge pull request: $merge_output"
     return 1
+}
+
+resolve_aidevops_sync_repo_dir() {
+    if [[ -n "${AIDEVOPS_SYNC_REPO_PATH:-}" ]] && [[ -d "$AIDEVOPS_SYNC_REPO_PATH/.agents" ]]; then
+        printf '%s\n' "$AIDEVOPS_SYNC_REPO_PATH"
+        return 0
+    fi
+
+    local current_repo_root
+    current_repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    if [[ -n "$current_repo_root" ]] && [[ "$(basename "$current_repo_root")" == "aidevops" ]] && [[ -d "$current_repo_root/.agents" ]]; then
+        printf '%s\n' "$current_repo_root"
+        return 0
+    fi
+
+    local default_repo_path="$HOME/Git/aidevops"
+    if [[ -d "$default_repo_path/.agents" ]]; then
+        printf '%s\n' "$default_repo_path"
+        return 0
+    fi
+
+    return 1
+}
+
+trigger_aidevops_post_merge_sync() {
+    local repo_slug="$1"
+
+    if [[ "$repo_slug" != "marcusquinn/aidevops" ]]; then
+        return 0
+    fi
+
+    local repo_dir
+    if ! repo_dir=$(resolve_aidevops_sync_repo_dir); then
+        print_warning "Merged aidevops PR but could not locate local aidevops repo for sync"
+        return 0
+    fi
+
+    local deploy_script="${AIDEVOPS_SYNC_DEPLOY_SCRIPT:-$repo_dir/.agents/scripts/deploy-agents-on-merge.sh}"
+    if [[ ! -f "$deploy_script" ]]; then
+        print_warning "Post-merge sync script not found: $deploy_script"
+        return 0
+    fi
+
+    local sync_output=""
+    local sync_exit=0
+    sync_output=$(bash "$deploy_script" --repo "$repo_dir" --quiet 2>&1) || sync_exit=$?
+
+    if [[ "$sync_exit" -eq 0 || "$sync_exit" -eq 2 ]]; then
+        print_success "Post-merge aidevops agent sync completed"
+        return 0
+    fi
+
+    print_warning "Post-merge aidevops agent sync failed (non-blocking): $sync_output"
+    return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -672,9 +727,11 @@ main() {
     return 0
 }
 
-# Initialize
-check_dependencies
-load_config
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    # Initialize
+    check_dependencies
+    load_config
 
-# Execute main function
-main "$@"
+    # Execute main function
+    main "$@"
+fi

--- a/.agents/scripts/github-cli-helper.sh
+++ b/.agents/scripts/github-cli-helper.sh
@@ -57,27 +57,27 @@ readonly AUTH_HEADER_TOKEN="Authorization: token"
 # ------------------------------------------------------------------------------
 
 check_dependencies() {
-    if ! command -v gh &> /dev/null; then
-        print_error "$ERROR_GH_NOT_INSTALLED"
-        print_info "Install GitHub CLI:"
-        print_info "  macOS: brew install gh"
-        print_info "  Ubuntu: sudo apt install gh"
-        print_info "  Other: https://cli.github.com/manual/installation"
-        exit 1
-    fi
+	if ! command -v gh &>/dev/null; then
+		print_error "$ERROR_GH_NOT_INSTALLED"
+		print_info "Install GitHub CLI:"
+		print_info "  macOS: brew install gh"
+		print_info "  Ubuntu: sudo apt install gh"
+		print_info "  Other: https://cli.github.com/manual/installation"
+		exit 1
+	fi
 
-    if ! gh auth status &> /dev/null; then
-        print_error "$ERROR_NOT_LOGGED_IN"
-        print_info "Authenticate with: gh auth login"
-        exit 1
-    fi
+	if ! gh auth status &>/dev/null; then
+		print_error "$ERROR_NOT_LOGGED_IN"
+		print_info "Authenticate with: gh auth login"
+		exit 1
+	fi
 
-    if ! command -v jq &> /dev/null; then
-        print_error "jq is required but not installed"
-        print_info "Install: brew install jq (macOS) or sudo apt install jq (Ubuntu)"
-        exit 1
-    fi
-    return 0
+	if ! command -v jq &>/dev/null; then
+		print_error "jq is required but not installed"
+		print_info "Install: brew install jq (macOS) or sudo apt install jq (Ubuntu)"
+		exit 1
+	fi
+	return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -85,35 +85,35 @@ check_dependencies() {
 # ------------------------------------------------------------------------------
 
 load_config() {
-    if [[ ! -f "$CONFIG_FILE" ]]; then
-        print_error "$ERROR_CONFIG_MISSING"
-        print_info "Create configuration: cp configs/github-cli-config.json.txt $CONFIG_FILE"
-        return 1
-    fi
-    return 0
+	if [[ ! -f "$CONFIG_FILE" ]]; then
+		print_error "$ERROR_CONFIG_MISSING"
+		print_info "Create configuration: cp configs/github-cli-config.json.txt $CONFIG_FILE"
+		return 1
+	fi
+	return 0
 }
 
 get_account_config() {
-    local account_name="$1"
-    
-    if [[ -z "$account_name" ]]; then
-        print_error "$ERROR_ARGS_MISSING"
-        return 1
-    fi
+	local account_name="$1"
 
-    local config
-    if ! config=$(jq -r ".accounts.\"$account_name\"" "$CONFIG_FILE" 2>/dev/null); then
-        print_error "$ERROR_FAILED_TO_READ_CONFIG"
-        return 1
-    fi
+	if [[ -z "$account_name" ]]; then
+		print_error "$ERROR_ARGS_MISSING"
+		return 1
+	fi
 
-    if [[ "$config" == "null" ]]; then
-        print_error "$ERROR_ACCOUNT_MISSING: $account_name"
-        return 1
-    fi
+	local config
+	if ! config=$(jq -r ".accounts.\"$account_name\"" "$CONFIG_FILE" 2>/dev/null); then
+		print_error "$ERROR_FAILED_TO_READ_CONFIG"
+		return 1
+	fi
 
-    echo "$config"
-    return 0
+	if [[ "$config" == "null" ]]; then
+		print_error "$ERROR_ACCOUNT_MISSING: $account_name"
+		return 1
+	fi
+
+	echo "$config"
+	return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -121,144 +121,144 @@ get_account_config() {
 # ------------------------------------------------------------------------------
 
 list_repos() {
-    local account_name="$1"
-    local filter="${2:-}"
-    
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local account_name="$1"
+	local filter="${2:-}"
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "Owner not configured for account: $account_name"
-        return 1
-    fi
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    print_info "Listing repositories for $owner..."
-    
-    local query="owner:$owner"
-    if [[ -n "$filter" ]]; then
-        query="$query $filter"
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "Owner not configured for account: $account_name"
+		return 1
+	fi
 
-    if ! gh repo list "$owner" --limit 50 --search "$query"; then
-        print_error "$ERROR_API_FAILED"
-        return 1
-    fi
-    return 0
+	print_info "Listing repositories for $owner..."
+
+	local query="owner:$owner"
+	if [[ -n "$filter" ]]; then
+		query="$query $filter"
+	fi
+
+	if ! gh repo list "$owner" --limit 50 --search "$query"; then
+		print_error "$ERROR_API_FAILED"
+		return 1
+	fi
+	return 0
 }
 
 create_repo() {
-    local account_name="$1"
-    local repo_name="$2"
-    local repo_description="${3:-}"
-    local visibility="${4:-public}"
-    local auto_init="${5:-false}"
+	local account_name="$1"
+	local repo_name="$2"
+	local repo_description="${3:-}"
+	local visibility="${4:-public}"
+	local auto_init="${5:-false}"
 
-    if [[ -z "$repo_name" ]]; then
-        print_error "$ERROR_REPO_NAME_REQUIRED"
-        print_info "Usage: github-cli-helper.sh create-repo <account> <repo-name> [description] [visibility]"
-        return 1
-    fi
+	if [[ -z "$repo_name" ]]; then
+		print_error "$ERROR_REPO_NAME_REQUIRED"
+		print_info "Usage: github-cli-helper.sh create-repo <account> <repo-name> [description] [visibility]"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
+		return 1
+	fi
 
-    print_info "Creating repository: $owner/$repo_name"
+	print_info "Creating repository: $owner/$repo_name"
 
-    local gh_args=("$owner/$repo_name" --description "$repo_description" --visibility "$visibility")
-    if [[ "$auto_init" == "true" ]]; then
-        gh_args+=(--auto-init)
-    fi
+	local gh_args=("$owner/$repo_name" --description "$repo_description" --visibility "$visibility")
+	if [[ "$auto_init" == "true" ]]; then
+		gh_args+=(--auto-init)
+	fi
 
-    if gh repo create "${gh_args[@]}"; then
-        print_success "$SUCCESS_REPO_CREATED: $owner/$repo_name"
-        
-        # Add to configuration if not exists
-        if ! jq -e ".repos.\"$owner/$repo_name\"" "$CONFIG_FILE" &>/dev/null; then
-            jq --arg repo "$owner/$repo_name" --arg owner "$owner" --arg name "$repo_name" \
-               '.repos[$repo] = {owner: $owner, name: $name, account: $account_name}' \
-               "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
-        fi
-    else
-        print_error "Failed to create repository"
-        return 1
-    fi
-    return 0
+	if gh repo create "${gh_args[@]}"; then
+		print_success "$SUCCESS_REPO_CREATED: $owner/$repo_name"
+
+		# Add to configuration if not exists
+		if ! jq -e ".repos.\"$owner/$repo_name\"" "$CONFIG_FILE" &>/dev/null; then
+			jq --arg repo "$owner/$repo_name" --arg owner "$owner" --arg name "$repo_name" \
+				'.repos[$repo] = {owner: $owner, name: $name, account: $account_name}' \
+				"$CONFIG_FILE" >"$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+		fi
+	else
+		print_error "Failed to create repository"
+		return 1
+	fi
+	return 0
 }
 
 delete_repo() {
-    local account_name="$1"
-    local repo_name="$2"
+	local account_name="$1"
+	local repo_name="$2"
 
-    if [[ -z "$repo_name" ]]; then
-        print_error "$ERROR_ARGS_MISSING"
-        return 1
-    fi
+	if [[ -z "$repo_name" ]]; then
+		print_error "$ERROR_ARGS_MISSING"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "Owner not configured for account: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "Owner not configured for account: $account_name"
+		return 1
+	fi
 
-    print_warning "This will permanently delete repository: $owner/$repo_name"
-    print_info "To confirm, type 'DELETE':"
-    read -r confirmation
+	print_warning "This will permanently delete repository: $owner/$repo_name"
+	print_info "To confirm, type 'DELETE':"
+	read -r confirmation
 
-    if [[ "$confirmation" != "DELETE" ]]; then
-        print_info "Deletion cancelled"
-        return 0
-    fi
+	if [[ "$confirmation" != "DELETE" ]]; then
+		print_info "Deletion cancelled"
+		return 0
+	fi
 
-    print_info "Deleting repository: $owner/$repo_name"
-    
-    if gh repo delete "$owner/$repo_name" --confirm; then
-        print_success "Repository deleted successfully"
-        
-        # Remove from configuration
-        jq --arg repo "$owner/$repo_name" 'del(.repos[$repo])' \
-           "$CONFIG_FILE" > "$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
-    else
-        print_error "Failed to delete repository"
-        return 1
-    fi
-    return 0
+	print_info "Deleting repository: $owner/$repo_name"
+
+	if gh repo delete "$owner/$repo_name" --confirm; then
+		print_success "Repository deleted successfully"
+
+		# Remove from configuration
+		jq --arg repo "$owner/$repo_name" 'del(.repos[$repo])' \
+			"$CONFIG_FILE" >"$CONFIG_FILE.tmp" && mv "$CONFIG_FILE.tmp" "$CONFIG_FILE"
+	else
+		print_error "Failed to delete repository"
+		return 1
+	fi
+	return 0
 }
 
 get_repo_info() {
-    local account_name="$1"
-    local repo_name="$2"
+	local account_name="$1"
+	local repo_name="$2"
 
-    if [[ -z "$repo_name" ]]; then
-        print_error "$ERROR_ARGS_MISSING"
-        return 1
-    fi
+	if [[ -z "$repo_name" ]]; then
+		print_error "$ERROR_ARGS_MISSING"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "Owner not configured for account: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "Owner not configured for account: $account_name"
+		return 1
+	fi
 
-    print_info "Repository information for $owner/$repo_name:"
-    gh repo view "$owner/$repo_name"
-    return 0
+	print_info "Repository information for $owner/$repo_name:"
+	gh repo view "$owner/$repo_name"
+	return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -266,91 +266,91 @@ get_repo_info() {
 # ------------------------------------------------------------------------------
 
 list_issues() {
-    local account_name="$1"
-    local repo_name="$2"
-    local state="${3:-open}"
+	local account_name="$1"
+	local repo_name="$2"
+	local state="${3:-open}"
 
-    if [[ -z "$repo_name" ]]; then
-        print_error "$ERROR_ARGS_MISSING"
-        return 1
-    fi
+	if [[ -z "$repo_name" ]]; then
+		print_error "$ERROR_ARGS_MISSING"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "Owner not configured for account: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "Owner not configured for account: $account_name"
+		return 1
+	fi
 
-    print_info "Listing issues for $owner/$repo_name (state: $state)"
-    gh issue list --repo "$owner/$repo_name" --limit 50 --state "$state"
-    return 0
+	print_info "Listing issues for $owner/$repo_name (state: $state)"
+	gh issue list --repo "$owner/$repo_name" --limit 50 --state "$state"
+	return 0
 }
 
 create_issue() {
-    local account_name="$1"
-    local repo_name="$2"
-    local title="$3"
-    local body="${4:-}"
+	local account_name="$1"
+	local repo_name="$2"
+	local title="$3"
+	local body="${4:-}"
 
-    if [[ -z "$title" ]]; then
-        print_error "$ERROR_ISSUE_TITLE_REQUIRED"
-        return 1
-    fi
+	if [[ -z "$title" ]]; then
+		print_error "$ERROR_ISSUE_TITLE_REQUIRED"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
+		return 1
+	fi
 
-    print_info "Creating issue in $owner/$repo_name"
+	print_info "Creating issue in $owner/$repo_name"
 
-    if gh issue create --repo "$owner/$repo_name" --title "$title" --body "$body"; then
-        print_success "$SUCCESS_ISSUE_CREATED"
-    else
-        print_error "Failed to create issue"
-        return 1
-    fi
-    return 0
+	if gh issue create --repo "$owner/$repo_name" --title "$title" --body "$body"; then
+		print_success "$SUCCESS_ISSUE_CREATED"
+	else
+		print_error "Failed to create issue"
+		return 1
+	fi
+	return 0
 }
 
 close_issue() {
-    local account_name="$1"
-    local repo_name="$2"
-    local issue_number="$3"
+	local account_name="$1"
+	local repo_name="$2"
+	local issue_number="$3"
 
-    if [[ -z "$issue_number" ]]; then
-        print_error "$ERROR_ISSUE_NUMBER_REQUIRED"
-        return 1
-    fi
+	if [[ -z "$issue_number" ]]; then
+		print_error "$ERROR_ISSUE_NUMBER_REQUIRED"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
+		return 1
+	fi
 
-    print_info "Closing issue #$issue_number in $owner/$repo_name"
+	print_info "Closing issue #$issue_number in $owner/$repo_name"
 
-    if gh issue close --repo "$owner/$repo_name" "$issue_number"; then
-        print_success "$SUCCESS_ISSUE_CLOSED"
-    else
-        print_error "Failed to close issue"
-        return 1
-    fi
-    return 0
+	if gh issue close --repo "$owner/$repo_name" "$issue_number"; then
+		print_success "$SUCCESS_ISSUE_CLOSED"
+	else
+		print_error "Failed to close issue"
+		return 1
+	fi
+	return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -358,168 +358,168 @@ close_issue() {
 # ------------------------------------------------------------------------------
 
 list_prs() {
-    local account_name="$1"
-    local repo_name="$2"
-    local state="${3:-open}"
+	local account_name="$1"
+	local repo_name="$2"
+	local state="${3:-open}"
 
-    if [[ -z "$repo_name" ]]; then
-        print_error "$ERROR_ARGS_MISSING"
-        return 1
-    fi
+	if [[ -z "$repo_name" ]]; then
+		print_error "$ERROR_ARGS_MISSING"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "Owner not configured for account: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "Owner not configured for account: $account_name"
+		return 1
+	fi
 
-    print_info "Listing pull requests for $owner/$repo_name (state: $state)"
-    gh pr list --repo "$owner/$repo_name" --limit 50 --state "$state"
-    return 0
+	print_info "Listing pull requests for $owner/$repo_name (state: $state)"
+	gh pr list --repo "$owner/$repo_name" --limit 50 --state "$state"
+	return 0
 }
 
 create_pr() {
-    local account_name="$1"
-    local repo_name="$2"
-    local title="$3"
-    local base_branch="${4:-main}"
-    local head_branch="${5:-}"
-    local body="${6:-}"
+	local account_name="$1"
+	local repo_name="$2"
+	local title="$3"
+	local base_branch="${4:-main}"
+	local head_branch="${5:-}"
+	local body="${6:-}"
 
-    if [[ -z "$title" ]]; then
-        print_error "$ERROR_PR_TITLE_REQUIRED"
-        return 1
-    fi
+	if [[ -z "$title" ]]; then
+		print_error "$ERROR_PR_TITLE_REQUIRED"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
+		return 1
+	fi
 
-    print_info "Creating pull request in $owner/$repo_name"
+	print_info "Creating pull request in $owner/$repo_name"
 
-    local gh_args=("--repo" "$owner/$repo_name" "--title" "$title" "--base" "$base_branch")
-    if [[ -n "$head_branch" ]]; then
-        gh_args+=("--head" "$head_branch")
-    fi
-    if [[ -n "$body" ]]; then
-        gh_args+=("--body" "$body")
-    fi
+	local gh_args=("--repo" "$owner/$repo_name" "--title" "$title" "--base" "$base_branch")
+	if [[ -n "$head_branch" ]]; then
+		gh_args+=("--head" "$head_branch")
+	fi
+	if [[ -n "$body" ]]; then
+		gh_args+=("--body" "$body")
+	fi
 
-    if gh pr create "${gh_args[@]}"; then
-        print_success "$SUCCESS_PR_CREATED"
-    else
-        print_error "Failed to create pull request"
-        return 1
-    fi
-    return 0
+	if gh pr create "${gh_args[@]}"; then
+		print_success "$SUCCESS_PR_CREATED"
+	else
+		print_error "Failed to create pull request"
+		return 1
+	fi
+	return 0
 }
 
 merge_pr() {
-    local account_name="$1"
-    local repo_name="$2"
-    local pr_number="$3"
-    local merge_method="${4:-merge}"
+	local account_name="$1"
+	local repo_name="$2"
+	local pr_number="$3"
+	local merge_method="${4:-merge}"
 
-    if [[ -z "$pr_number" ]]; then
-        print_error "$ERROR_PR_NUMBER_REQUIRED"
-        return 1
-    fi
+	if [[ -z "$pr_number" ]]; then
+		print_error "$ERROR_PR_NUMBER_REQUIRED"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
+		return 1
+	fi
 
-    print_info "Merging pull request #$pr_number in $owner/$repo_name"
+	print_info "Merging pull request #$pr_number in $owner/$repo_name"
 
-    local merge_output
-    merge_output=$(gh pr merge --repo "$owner/$repo_name" "$pr_number" --"$merge_method" 2>&1)
-    local merge_exit=$?
+	local merge_output
+	merge_output=$(gh pr merge --repo "$owner/$repo_name" "$pr_number" --"$merge_method" 2>&1)
+	local merge_exit=$?
 
-    if [[ $merge_exit -eq 0 ]]; then
-        print_success "$SUCCESS_PR_MERGED"
-        trigger_aidevops_post_merge_sync "$owner/$repo_name"
-        return 0
-    fi
+	if [[ $merge_exit -eq 0 ]]; then
+		print_success "$SUCCESS_PR_MERGED"
+		trigger_aidevops_post_merge_sync "$owner/$repo_name"
+		return 0
+	fi
 
-    # Check for workflow scope error (t3934)
-    if echo "$merge_output" | grep -qiF 'workflow scope'; then
-        print_error "Merge failed: PR modifies workflow files but token lacks 'workflow' scope"
-        print_info "Fix: run 'gh auth refresh -s workflow' to add the workflow scope"
-        return 1
-    fi
+	# Check for workflow scope error (t3934)
+	if echo "$merge_output" | grep -qiF 'workflow scope'; then
+		print_error "Merge failed: PR modifies workflow files but token lacks 'workflow' scope"
+		print_info "Fix: run 'gh auth refresh -s workflow' to add the workflow scope"
+		return 1
+	fi
 
-    print_error "Failed to merge pull request: $merge_output"
-    return 1
+	print_error "Failed to merge pull request: $merge_output"
+	return 1
 }
 
 resolve_aidevops_sync_repo_dir() {
-    if [[ -n "${AIDEVOPS_SYNC_REPO_PATH:-}" ]] && [[ -d "$AIDEVOPS_SYNC_REPO_PATH/.agents" ]]; then
-        printf '%s\n' "$AIDEVOPS_SYNC_REPO_PATH"
-        return 0
-    fi
+	if [[ -n "${AIDEVOPS_SYNC_REPO_PATH:-}" ]] && [[ -d "$AIDEVOPS_SYNC_REPO_PATH/.agents" ]]; then
+		printf '%s\n' "$AIDEVOPS_SYNC_REPO_PATH"
+		return 0
+	fi
 
-    local current_repo_root
-    current_repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
-    if [[ -n "$current_repo_root" ]] && [[ "$(basename "$current_repo_root")" == "aidevops" ]] && [[ -d "$current_repo_root/.agents" ]]; then
-        printf '%s\n' "$current_repo_root"
-        return 0
-    fi
+	local current_repo_root
+	current_repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+	if [[ -n "$current_repo_root" ]] && [[ "$(basename "$current_repo_root")" == "aidevops" ]] && [[ -d "$current_repo_root/.agents" ]]; then
+		printf '%s\n' "$current_repo_root"
+		return 0
+	fi
 
-    local default_repo_path="$HOME/Git/aidevops"
-    if [[ -d "$default_repo_path/.agents" ]]; then
-        printf '%s\n' "$default_repo_path"
-        return 0
-    fi
+	local default_repo_path="$HOME/Git/aidevops"
+	if [[ -d "$default_repo_path/.agents" ]]; then
+		printf '%s\n' "$default_repo_path"
+		return 0
+	fi
 
-    return 1
+	return 1
 }
 
 trigger_aidevops_post_merge_sync() {
-    local repo_slug="$1"
+	local repo_slug="$1"
 
-    if [[ "$repo_slug" != "marcusquinn/aidevops" ]]; then
-        return 0
-    fi
+	if [[ "$repo_slug" != "marcusquinn/aidevops" ]]; then
+		return 0
+	fi
 
-    local repo_dir
-    if ! repo_dir=$(resolve_aidevops_sync_repo_dir); then
-        print_warning "Merged aidevops PR but could not locate local aidevops repo for sync"
-        return 0
-    fi
+	local repo_dir
+	if ! repo_dir=$(resolve_aidevops_sync_repo_dir); then
+		print_warning "Merged aidevops PR but could not locate local aidevops repo for sync"
+		return 0
+	fi
 
-    local deploy_script="${AIDEVOPS_SYNC_DEPLOY_SCRIPT:-$repo_dir/.agents/scripts/deploy-agents-on-merge.sh}"
-    if [[ ! -f "$deploy_script" ]]; then
-        print_warning "Post-merge sync script not found: $deploy_script"
-        return 0
-    fi
+	local deploy_script="${AIDEVOPS_SYNC_DEPLOY_SCRIPT:-$repo_dir/.agents/scripts/deploy-agents-on-merge.sh}"
+	if [[ ! -f "$deploy_script" ]]; then
+		print_warning "Post-merge sync script not found: $deploy_script"
+		return 0
+	fi
 
-    local sync_output=""
-    local sync_exit=0
-    sync_output=$(bash "$deploy_script" --repo "$repo_dir" --quiet 2>&1) || sync_exit=$?
+	local sync_output=""
+	local sync_exit=0
+	sync_output=$(bash "$deploy_script" --repo "$repo_dir" --quiet 2>&1) || sync_exit=$?
 
-    if [[ "$sync_exit" -eq 0 || "$sync_exit" -eq 2 ]]; then
-        print_success "Post-merge aidevops agent sync completed"
-        return 0
-    fi
+	if [[ "$sync_exit" -eq 0 || "$sync_exit" -eq 2 ]]; then
+		print_success "Post-merge aidevops agent sync completed"
+		return 0
+	fi
 
-    print_warning "Post-merge aidevops agent sync failed (non-blocking): $sync_output"
-    return 0
+	print_warning "Post-merge aidevops agent sync failed (non-blocking): $sync_output"
+	return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -527,63 +527,63 @@ trigger_aidevops_post_merge_sync() {
 # ------------------------------------------------------------------------------
 
 list_branches() {
-    local account_name="$1"
-    local repo_name="$2"
+	local account_name="$1"
+	local repo_name="$2"
 
-    if [[ -z "$repo_name" ]]; then
-        print_error "$ERROR_ARGS_MISSING"
-        return 1
-    fi
+	if [[ -z "$repo_name" ]]; then
+		print_error "$ERROR_ARGS_MISSING"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "Owner not configured for account: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "Owner not configured for account: $account_name"
+		return 1
+	fi
 
-    print_info "Listing branches for $owner/$repo_name"
-    gh repo list "$owner" --limit 1 "--json" "nameWithOwner" | jq -r '.[0].nameWithOwner' | \
-        xargs -I {} gh api "repos/{}/branches" --jq '.[] | .name'
-    return 0
+	print_info "Listing branches for $owner/$repo_name"
+	gh repo list "$owner" --limit 1 "--json" "nameWithOwner" | jq -r '.[0].nameWithOwner' |
+		xargs -I {} gh api "repos/{}/branches" --jq '.[] | .name'
+	return 0
 }
 
 create_branch() {
-    local account_name="$1"
-    local repo_name="$2"
-    local branch_name="$3"
-    local source_branch="${4:-main}"
+	local account_name="$1"
+	local repo_name="$2"
+	local branch_name="$3"
+	local source_branch="${4:-main}"
 
-    if [[ -z "$branch_name" ]]; then
-        print_error "$ERROR_BRANCH_NAME_REQUIRED"
-        return 1
-    fi
+	if [[ -z "$branch_name" ]]; then
+		print_error "$ERROR_BRANCH_NAME_REQUIRED"
+		return 1
+	fi
 
-    local config
-    config=$(get_account_config "$account_name") || exit 1
+	local config
+	config=$(get_account_config "$account_name") || exit 1
 
-    local owner
-    owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
-    if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
-        print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
-        return 1
-    fi
+	local owner
+	owner=$(echo "$config" | jq -r '.owner // "EMPTY"')
+	if [[ "$owner" == "EMPTY" || -z "$owner" ]]; then
+		print_error "$ERROR_OWNER_NOT_CONFIGURED: $account_name"
+		return 1
+	fi
 
-    print_info "Creating branch '$branch_name' in $owner/$repo_name from '$source_branch'"
+	print_info "Creating branch '$branch_name' in $owner/$repo_name from '$source_branch'"
 
-    # Use API to create branch reference
-    if gh api "repos/$owner/$repo_name/git/refs/heads/$source_branch" --jq '.object.sha' | \
-        xargs -I {} gh api --method POST "repos/$owner/$repo_name/git/refs" \
-           --field "ref=refs/heads/$branch_name" --field "sha={}"; then
-        print_success "$SUCCESS_BRANCH_CREATED"
-    else
-        print_error "Failed to create branch"
-        return 1
-    fi
-    return 0
+	# Use API to create branch reference
+	if gh api "repos/$owner/$repo_name/git/refs/heads/$source_branch" --jq '.object.sha' |
+		xargs -I {} gh api --method POST "repos/$owner/$repo_name/git/refs" \
+			--field "ref=refs/heads/$branch_name" --field "sha={}"; then
+		print_success "$SUCCESS_BRANCH_CREATED"
+	else
+		print_error "Failed to create branch"
+		return 1
+	fi
+	return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -591,17 +591,17 @@ create_branch() {
 # ------------------------------------------------------------------------------
 
 list_accounts() {
-    print_info "Configured GitHub accounts:"
-    if [[ -f "$CONFIG_FILE" ]]; then
-        jq -r '.accounts | keys[]' "$CONFIG_FILE" 2>/dev/null || print_warning "No accounts configured"
-    else
-        print_warning "Configuration file not found"
-    fi
-    return 0
+	print_info "Configured GitHub accounts:"
+	if [[ -f "$CONFIG_FILE" ]]; then
+		jq -r '.accounts | keys[]' "$CONFIG_FILE" 2>/dev/null || print_warning "No accounts configured"
+	else
+		print_warning "Configuration file not found"
+	fi
+	return 0
 }
 
 show_help() {
-    cat << EOF
+	cat <<EOF
 GitHub CLI Helper Script
 Usage: $0 [command] [account] [arguments]
 
@@ -652,7 +652,7 @@ REQUIREMENTS:
 
 For more information, see the GitHub CLI documentation: https://cli.github.com/manual/
 EOF
-    return 0
+	return 0
 }
 
 # ------------------------------------------------------------------------------
@@ -660,78 +660,78 @@ EOF
 # ------------------------------------------------------------------------------
 
 main() {
-    local command="${1:-help}"
-    local account_name="$2"
-    local target="$3"
-    local options="$4"
+	local command="${1:-help}"
+	local account_name="$2"
+	local target="$3"
+	local options="$4"
 
-    case "$command" in
-        "list-repos")
-            list_repos "$account_name" "$target"
-            ;;
-        "create-repo")
-            local repo_desc="$options"
-            local repo_vis="$5"
-            local repo_init="$6"
-            create_repo "$account_name" "$target" "$repo_desc" "$repo_vis" "$repo_init"
-            ;;
-        "delete-repo")
-            delete_repo "$account_name" "$target"
-            ;;
-        "get-repo")
-            get_repo_info "$account_name" "$target"
-            ;;
-        "list-issues")
-            list_issues "$account_name" "$target" "$options"
-            ;;
-        "create-issue")
-            local issue_body="$5"
-            create_issue "$account_name" "$target" "$options" "$issue_body"
-            ;;
-        "close-issue")
-            close_issue "$account_name" "$target" "$options"
-            ;;
-        "list-prs")
-            list_prs "$account_name" "$target" "$options"
-            ;;
-        "create-pr")
-            local pr_base="$5"
-            local pr_head="$6"
-            local pr_body="$7"
-            create_pr "$account_name" "$target" "$options" "$pr_base" "$pr_head" "$pr_body"
-            ;;
-        "merge-pr")
-            local merge_method="$5"
-            merge_pr "$account_name" "$target" "$options" "$merge_method"
-            ;;
-        "list-branches")
-            list_branches "$account_name" "$target"
-            ;;
-        "create-branch")
-            local source_branch="$5"
-            create_branch "$account_name" "$target" "$options" "$source_branch"
-            ;;
-        "list-accounts")
-            list_accounts
-            ;;
-        "help"|"-h"|"--help")
-            show_help
-            ;;
-        *)
-            print_error "$ERROR_UNKNOWN_COMMAND $command"
-            print_info "Use '$0 help' for usage information"
-            exit 1
-            ;;
-    esac
-    
-    return 0
+	case "$command" in
+	"list-repos")
+		list_repos "$account_name" "$target"
+		;;
+	"create-repo")
+		local repo_desc="$options"
+		local repo_vis="$5"
+		local repo_init="$6"
+		create_repo "$account_name" "$target" "$repo_desc" "$repo_vis" "$repo_init"
+		;;
+	"delete-repo")
+		delete_repo "$account_name" "$target"
+		;;
+	"get-repo")
+		get_repo_info "$account_name" "$target"
+		;;
+	"list-issues")
+		list_issues "$account_name" "$target" "$options"
+		;;
+	"create-issue")
+		local issue_body="$5"
+		create_issue "$account_name" "$target" "$options" "$issue_body"
+		;;
+	"close-issue")
+		close_issue "$account_name" "$target" "$options"
+		;;
+	"list-prs")
+		list_prs "$account_name" "$target" "$options"
+		;;
+	"create-pr")
+		local pr_base="$5"
+		local pr_head="$6"
+		local pr_body="$7"
+		create_pr "$account_name" "$target" "$options" "$pr_base" "$pr_head" "$pr_body"
+		;;
+	"merge-pr")
+		local merge_method="$5"
+		merge_pr "$account_name" "$target" "$options" "$merge_method"
+		;;
+	"list-branches")
+		list_branches "$account_name" "$target"
+		;;
+	"create-branch")
+		local source_branch="$5"
+		create_branch "$account_name" "$target" "$options" "$source_branch"
+		;;
+	"list-accounts")
+		list_accounts
+		;;
+	"help" | "-h" | "--help")
+		show_help
+		;;
+	*)
+		print_error "$ERROR_UNKNOWN_COMMAND $command"
+		print_info "Use '$0 help' for usage information"
+		exit 1
+		;;
+	esac
+
+	return 0
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-    # Initialize
-    check_dependencies
-    load_config
+	# Initialize
+	check_dependencies
+	load_config
 
-    # Execute main function
-    main "$@"
+	# Execute main function
+	main "$@"
 fi

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -33,6 +33,7 @@ print_result() {
 
 setup() {
 	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
 	mkdir -p "$TEST_DIR/repo/.agents/scripts"
 	cat >"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" <<'EOF'
 #!/usr/bin/env bash
@@ -146,6 +147,7 @@ main() {
 	test_release_sync_skips_other_remotes
 
 	teardown
+	trap - EXIT
 	echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
 
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-agent-auto-sync.sh
+++ b/.agents/scripts/tests/test-agent-auto-sync.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit
+GITHUB_HELPER="$REPO_ROOT/.agents/scripts/github-cli-helper.sh"
+VERSION_HELPER="$REPO_ROOT/.agents/scripts/version-manager.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		echo "PASS $test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $test_name"
+		if [[ -n "$message" ]]; then
+			echo "  $message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	mkdir -p "$TEST_DIR/repo/.agents/scripts"
+	cat >"$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${SYNC_LOG_PATH:?SYNC_LOG_PATH must be set}"
+exit "${MOCK_DEPLOY_EXIT_CODE:-0}"
+EOF
+	chmod +x "$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh"
+	: >"$TEST_DIR/sync.log"
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+invoke_github_sync() {
+	local repo_slug="$1"
+	AIDEVOPS_SYNC_REPO_PATH="$TEST_DIR/repo" \
+		AIDEVOPS_SYNC_DEPLOY_SCRIPT="$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" \
+		SYNC_LOG_PATH="$TEST_DIR/sync.log" \
+		MOCK_DEPLOY_EXIT_CODE="${MOCK_DEPLOY_EXIT_CODE:-0}" \
+		bash -c 'source "$1" && trigger_aidevops_post_merge_sync "$2"' _ "$GITHUB_HELPER" "$repo_slug"
+	return 0
+}
+
+invoke_release_sync() {
+	local repo_root="$1"
+	AIDEVOPS_SYNC_REPO_ROOT="$repo_root" \
+		AIDEVOPS_SYNC_DEPLOY_SCRIPT="$TEST_DIR/repo/.agents/scripts/deploy-agents-on-merge.sh" \
+		SYNC_LOG_PATH="$TEST_DIR/sync.log" \
+		MOCK_DEPLOY_EXIT_CODE="${MOCK_DEPLOY_EXIT_CODE:-0}" \
+		bash -c 'source "$1" && run_post_release_agent_sync' _ "$VERSION_HELPER"
+	return 0
+}
+
+create_fake_repo() {
+	local repo_name="$1"
+	local remote_url="$2"
+	local repo_path="$TEST_DIR/$repo_name"
+
+	mkdir -p "$repo_path"
+	git init -q "$repo_path"
+	git -C "$repo_path" remote add origin "$remote_url"
+	printf '%s\n' "$repo_path"
+	return 0
+}
+
+test_merge_sync_triggers_for_aidevops() {
+	: >"$TEST_DIR/sync.log"
+	invoke_github_sync "marcusquinn/aidevops"
+
+	if grep -q -- "--repo $TEST_DIR/repo --quiet" "$TEST_DIR/sync.log"; then
+		print_result "merge sync triggers for aidevops slug" 0
+	else
+		print_result "merge sync triggers for aidevops slug" 1 "Sync command was not recorded"
+	fi
+	return 0
+}
+
+test_merge_sync_skips_other_repos() {
+	: >"$TEST_DIR/sync.log"
+	invoke_github_sync "marcusquinn/another-repo"
+
+	if [[ ! -s "$TEST_DIR/sync.log" ]]; then
+		print_result "merge sync skips non-aidevops repos" 0
+	else
+		print_result "merge sync skips non-aidevops repos" 1 "Unexpected sync invocation recorded"
+	fi
+	return 0
+}
+
+test_release_sync_triggers_for_aidevops_remote() {
+	: >"$TEST_DIR/sync.log"
+	local repo_path
+	repo_path=$(create_fake_repo "release-aidevops" "https://github.com/marcusquinn/aidevops.git")
+	invoke_release_sync "$repo_path"
+
+	if grep -q -- "--repo $repo_path --quiet" "$TEST_DIR/sync.log"; then
+		print_result "release sync triggers for aidevops remote" 0
+	else
+		print_result "release sync triggers for aidevops remote" 1 "Release sync command was not recorded"
+	fi
+	return 0
+}
+
+test_release_sync_skips_other_remotes() {
+	: >"$TEST_DIR/sync.log"
+	local repo_path
+	repo_path=$(create_fake_repo "release-other" "https://github.com/marcusquinn/other.git")
+	invoke_release_sync "$repo_path"
+
+	if [[ ! -s "$TEST_DIR/sync.log" ]]; then
+		print_result "release sync skips non-aidevops remotes" 0
+	else
+		print_result "release sync skips non-aidevops remotes" 1 "Unexpected release sync invocation recorded"
+	fi
+	return 0
+}
+
+main() {
+	echo "Running agent auto-sync regression tests"
+	setup
+
+	test_merge_sync_triggers_for_aidevops
+	test_merge_sync_skips_other_repos
+	test_release_sync_triggers_for_aidevops_remote
+	test_release_sync_skips_other_remotes
+
+	teardown
+	echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -1143,6 +1143,35 @@ create_github_release() {
 	return 0
 }
 
+run_post_release_agent_sync() {
+	local sync_repo_root="${AIDEVOPS_SYNC_REPO_ROOT:-$REPO_ROOT}"
+	local remote_url
+	remote_url=$(git -C "$sync_repo_root" remote get-url origin 2>/dev/null || echo "")
+
+	if [[ "$remote_url" != *"marcusquinn/aidevops"* ]]; then
+		return 0
+	fi
+
+	local deploy_script="${AIDEVOPS_SYNC_DEPLOY_SCRIPT:-$sync_repo_root/.agents/scripts/deploy-agents-on-merge.sh}"
+	if [[ ! -f "$deploy_script" ]]; then
+		print_warning "Post-release sync skipped: deploy script not found at $deploy_script"
+		return 0
+	fi
+
+	print_info "Running post-release aidevops agent sync..."
+	local sync_output=""
+	local sync_exit=0
+	sync_output=$(bash "$deploy_script" --repo "$sync_repo_root" --quiet 2>&1) || sync_exit=$?
+
+	if [[ "$sync_exit" -eq 0 || "$sync_exit" -eq 2 ]]; then
+		print_success "Post-release aidevops agent sync completed"
+		return 0
+	fi
+
+	print_warning "Post-release aidevops agent sync failed (non-blocking): $sync_output"
+	return 0
+}
+
 # Function to generate release notes
 generate_release_notes() {
 	local version="$1"
@@ -1348,6 +1377,7 @@ main() {
 					exit 1
 				fi
 				create_github_release "$new_version"
+				run_post_release_agent_sync
 				print_success "Release $new_version created successfully!"
 			else
 				print_error "Version validation failed. Please fix inconsistencies before creating release."
@@ -1437,4 +1467,6 @@ main() {
 	return 0
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi


### PR DESCRIPTION
## Summary
- Trigger deployed-agent sync automatically after `github-cli-helper.sh merge-pr` succeeds for `marcusquinn/aidevops`.
- Trigger deployed-agent sync automatically at the end of `version-manager.sh release` to keep `~/.aidevops/agents/` aligned after releases.
- Preserve plugin namespace directories during merge-deploy sync and add regression coverage for merge/release auto-sync triggers.

Closes #4205

## Verification
- `shellcheck .agents/scripts/deploy-agents-on-merge.sh .agents/scripts/github-cli-helper.sh .agents/scripts/version-manager.sh .agents/scripts/tests/test-agent-auto-sync.sh`
- `bash -n .agents/scripts/deploy-agents-on-merge.sh .agents/scripts/github-cli-helper.sh .agents/scripts/version-manager.sh .agents/scripts/tests/test-agent-auto-sync.sh`
- `bash .agents/scripts/tests/test-agent-auto-sync.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added plugin namespace support for agent deployments.
  * Enabled automated post-merge synchronization workflows following pull request merges.
  * Enabled automated post-release synchronization for release workflows.

* **Tests**
  * New test coverage for agent auto-sync functionality.

* **Refactor**
  * Improved code style and readability across deployment and version management scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->