### PR TITLE
t4158: address supervisor-archived deploy quality debt

### DIFF
--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -2133,21 +2133,23 @@ resolve_rebase_conflicts() {
 		# File content from external branches is untrusted input.
 		# Fail-closed: if scanner is missing or fails, skip AI resolution for safety.
 		local prompt_guard_script="${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/prompt-guard-helper.sh"
+		local skip_ai_resolution=false
 		if [[ -x "$prompt_guard_script" ]]; then
 			local scan_result
-			if ! scan_result=$("$prompt_guard_script" scan-file "$full_path" 2>/dev/null); then
+			if ! scan_result=$("$prompt_guard_script" scan-file "$full_path"); then
 				log_warn "resolve_rebase_conflicts: scanner failed for $conflict_file — skipping AI resolution for safety"
-				failed_files="${failed_files}${failed_files:+, }${conflict_file}"
-				continue
-			fi
-			if [[ "$scan_result" == *"SUSPICIOUS"* || "$scan_result" == *"BLOCKED"* ]]; then
+				skip_ai_resolution=true
+			elif [[ "$scan_result" == *"SUSPICIOUS"* || "$scan_result" == *"BLOCKED"* ]]; then
 				log_warn "resolve_rebase_conflicts: prompt injection detected in $conflict_file — skipping AI resolution"
 				log_warn "  Scan result: $scan_result"
-				failed_files="${failed_files}${failed_files:+, }${conflict_file}"
-				continue
+				skip_ai_resolution=true
 			fi
 		else
 			log_warn "resolve_rebase_conflicts: scanner missing — skipping AI resolution for safety"
+			skip_ai_resolution=true
+		fi
+
+		if [[ "$skip_ai_resolution" == true ]]; then
 			failed_files="${failed_files}${failed_files:+, }${conflict_file}"
 			continue
 		fi


### PR DESCRIPTION
## Goal
Address medium quality debt from issue #4158 in the supervisor archived deploy script by removing repeated fail-closed skip handling and keeping behavior unchanged.

## Summary
- Consolidate scanner failure/suspicious/missing paths into a single `skip_ai_resolution` decision point in `resolve_rebase_conflicts`
- Keep fail-closed behavior intact by appending to `failed_files` and continuing from one shared branch
- Remove unnecessary stderr suppression from prompt-guard scan invocation to avoid masking scanner errors

## Verification
- `shellcheck .agents/scripts/supervisor-archived/deploy.sh`

Closes #4158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal deployment script improvements to enhance control flow and decision-making processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->