### PR TITLE
4209: fix NeuronWriter endpoint references in docs

### DIFF
--- a/.agents/scripts/commands/neuronwriter.md
+++ b/.agents/scripts/commands/neuronwriter.md
@@ -44,6 +44,9 @@ fi
 
 Read `seo/neuronwriter.md` for full API reference, then execute the appropriate endpoint.
 
+Use NeuronWriter API base `https://app.neuronwriter.com/neuron-api/0.5/writer` with POST methods.
+Do not use `https://app.neuronwriter.com/api/v1/` for this command flow.
+
 ### Step 4: Execute Action
 
 **For `analyze` (default):**

--- a/.agents/seo/neuronwriter.md
+++ b/.agents/seo/neuronwriter.md
@@ -19,7 +19,7 @@ tools:
 - **API**: `https://app.neuronwriter.com/neuron-api/0.5/writer`
 - **Auth**: API key in `X-API-KEY` header, stored in `~/.config/aidevops/credentials.sh` as `NEURONWRITER_API_KEY`
 - **Plan**: Gold plan or higher required
-- **Docs**: https://neuronwriter.com/faqs/neuronwriter-api-how-to-use/
+- **Docs**: https://neuronwriter.com/faq/
 - **No MCP required** - uses curl directly
 
 **API requests consume monthly limits** (same cost as using the NeuronWriter UI).
@@ -35,6 +35,7 @@ source ~/.config/aidevops/credentials.sh
 ## API Endpoints
 
 All endpoints use POST. All require the `X-API-KEY` header.
+Do not use `https://app.neuronwriter.com/api/v1/` for Neuron API calls.
 
 ### List Projects
 
@@ -316,7 +317,7 @@ curl -s -X POST "https://app.neuronwriter.com/neuron-api/0.5/writer/list-project
 
 ## Resources
 
-- **Official Docs**: https://neuronwriter.com/faqs/neuronwriter-api-how-to-use/
+- **Official Docs**: https://neuronwriter.com/faq/
 - **Roadmap**: https://roadmap.neuronwriter.com/p/neuron-api-HOPZZB
 - **Dashboard**: https://app.neuronwriter.com/
 - **Plan Required**: Gold or higher


### PR DESCRIPTION
## Summary
- update NeuronWriter SEO docs to point to the current FAQ hub and explicitly warn against the deprecated `/api/v1/` base
- update `/neuronwriter` command flow docs to enforce the `neuron-api/0.5/writer` POST endpoint pattern
- keep endpoint guidance aligned across API reference and command usage so valid API keys do not fail due to incorrect base URL assumptions

Closes #4209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated NeuronWriter API documentation to clarify the correct base endpoint for API requests, providing clear guidance on proper endpoint usage.
  * Refreshed documentation links to point to current FAQ resources.
  * Added best practice guidance directing developers to use the correct API endpoint and avoid deprecated paths for improved integration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->