### PR TITLE
t1412: add auditable worker sandbox lifecycle slice

### DIFF
--- a/.agents/scripts/worker-sandbox-helper.sh
+++ b/.agents/scripts/worker-sandbox-helper.sh
@@ -30,6 +30,40 @@ set -euo pipefail
 # Resolve real HOME before anything else — workers may already have HOME overridden
 readonly REAL_HOME="${REAL_HOME:-$HOME}"
 readonly SANDBOX_BASE="${WORKER_SANDBOX_BASE:-/tmp/aidevops-worker}"
+WORKER_SANDBOX_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly WORKER_SANDBOX_HELPER_DIR
+
+#######################################
+# Best-effort sandbox audit logging
+#
+# Emits tamper-evident security.event records when worker sandboxes are
+# created or cleaned up. This is best-effort: worker sandboxing must still
+# function when audit logging is unavailable.
+#
+# Args:
+#   $1 = action (created|cleaned)
+#   $2 = task_id
+#   $3 = sandbox_dir
+#
+# Returns: 0 always
+#######################################
+log_worker_sandbox_event() {
+	local action="$1"
+	local task_id="$2"
+	local sandbox_dir="$3"
+	local audit_helper="${WORKER_SANDBOX_HELPER_DIR}/audit-log-helper.sh"
+
+	if [[ ! -x "$audit_helper" ]]; then
+		return 0
+	fi
+
+	"$audit_helper" log security.event "worker_sandbox_${action}" \
+		--detail task_id="$task_id" \
+		--detail sandbox_dir="$sandbox_dir" \
+		>/dev/null 2>&1 || true
+
+	return 0
+}
 
 #######################################
 # Create a sandboxed HOME directory for a worker
@@ -150,6 +184,8 @@ create_worker_sandbox() {
 		real_home=${REAL_HOME}
 	SENTINEL
 
+	log_worker_sandbox_event "created" "$task_id" "$sandbox_dir"
+
 	echo "$sandbox_dir"
 	return 0
 }
@@ -222,6 +258,7 @@ generate_sandbox_env() {
 #######################################
 cleanup_worker_sandbox() {
 	local sandbox_dir="$1"
+	local sandbox_task_id="unknown"
 
 	if [[ -z "$sandbox_dir" ]]; then
 		echo "ERROR: sandbox_dir required" >&2
@@ -241,7 +278,13 @@ cleanup_worker_sandbox() {
 		return 1
 	fi
 
+	sandbox_task_id=$(grep '^task_id=' "$sandbox_dir/.aidevops-sandbox" 2>/dev/null | cut -d= -f2 || true)
+	if [[ -z "$sandbox_task_id" ]]; then
+		sandbox_task_id="unknown"
+	fi
+
 	rm -rf "$sandbox_dir"
+	log_worker_sandbox_event "cleaned" "$sandbox_task_id" "$sandbox_dir"
 	return 0
 }
 

--- a/.agents/scripts/worker-sandbox-helper.sh
+++ b/.agents/scripts/worker-sandbox-helper.sh
@@ -278,10 +278,8 @@ cleanup_worker_sandbox() {
 		return 1
 	fi
 
-	sandbox_task_id=$(grep '^task_id=' "$sandbox_dir/.aidevops-sandbox" 2>/dev/null | cut -d= -f2 || true)
-	if [[ -z "$sandbox_task_id" ]]; then
-		sandbox_task_id="unknown"
-	fi
+	sandbox_task_id=$(grep '^task_id=' "$sandbox_dir/.aidevops-sandbox" 2>/dev/null | cut -d= -f2- || true)
+	sandbox_task_id="${sandbox_task_id:-unknown}"
 
 	rm -rf "$sandbox_dir"
 	log_worker_sandbox_event "cleaned" "$sandbox_task_id" "$sandbox_dir"

--- a/tests/test-worker-sandbox-helper.sh
+++ b/tests/test-worker-sandbox-helper.sh
@@ -81,10 +81,11 @@ test_create_records_audit_event() {
 		fail "sentinel missing expected task id"
 	fi
 
-	if grep -q 'worker_sandbox_created' "$TEST_TMPDIR/audit/audit.jsonl"; then
-		pass "audit log contains sandbox create event"
+	if jq -e 'select(.msg == "worker_sandbox_created" and .detail.task_id == "t1412-create")' \
+		"$TEST_TMPDIR/audit/audit.jsonl" >/dev/null 2>&1; then
+		pass "audit log contains sandbox create event with correct task_id"
 	else
-		fail "missing sandbox create audit event"
+		fail "missing sandbox create audit event or incorrect task_id"
 	fi
 
 	run_sandbox_cmd cleanup "$sandbox_dir" >/dev/null
@@ -106,16 +107,11 @@ test_cleanup_records_audit_event() {
 		fail "sandbox directory still exists after cleanup"
 	fi
 
-	if grep -q 'worker_sandbox_cleaned' "$TEST_TMPDIR/audit/audit.jsonl"; then
-		pass "audit log contains sandbox cleanup event"
+	if jq -e 'select(.msg == "worker_sandbox_cleaned" and .detail.task_id == "t1412-cleanup")' \
+		"$TEST_TMPDIR/audit/audit.jsonl" >/dev/null 2>&1; then
+		pass "audit log contains sandbox cleanup event with correct task_id"
 	else
-		fail "missing sandbox cleanup audit event"
-	fi
-
-	if grep -q '"task_id":"t1412-cleanup"' "$TEST_TMPDIR/audit/audit.jsonl"; then
-		pass "audit log stores task id detail"
-	else
-		fail "audit log missing expected task id detail"
+		fail "missing sandbox cleanup audit event or incorrect task_id"
 	fi
 
 	cleanup

--- a/tests/test-worker-sandbox-helper.sh
+++ b/tests/test-worker-sandbox-helper.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# test-worker-sandbox-helper.sh — sandbox lifecycle + auditability checks (t1412)
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO_DIR}/.agents/scripts/worker-sandbox-helper.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TEST_TMPDIR=""
+
+pass() {
+	local name="$1"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	echo "  PASS: $name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	echo "  FAIL: $name"
+	if [[ -n "$detail" ]]; then
+		echo "        $detail"
+	fi
+	return 0
+}
+
+cleanup() {
+	if [[ -n "$TEST_TMPDIR" && -d "$TEST_TMPDIR" ]]; then
+		rm -rf "$TEST_TMPDIR"
+	fi
+	return 0
+}
+trap cleanup EXIT
+
+setup() {
+	TEST_TMPDIR="$(mktemp -d)"
+	mkdir -p "$TEST_TMPDIR/real-home/.config/opencode"
+	mkdir -p "$TEST_TMPDIR/real-home/.claude"
+	mkdir -p "$TEST_TMPDIR/audit"
+	echo '{"mcpServers":{}}' >"$TEST_TMPDIR/real-home/.config/opencode/opencode.json"
+	echo '{}' >"$TEST_TMPDIR/real-home/.claude/settings.json"
+	return 0
+}
+
+run_sandbox_cmd() {
+	local action="$1"
+	shift
+
+	HOME="$TEST_TMPDIR/real-home" \
+		REAL_HOME="$TEST_TMPDIR/real-home" \
+		WORKER_SANDBOX_BASE="$TEST_TMPDIR/sandbox-base" \
+		AUDIT_LOG_DIR="$TEST_TMPDIR/audit" \
+		AUDIT_LOG_FILE="$TEST_TMPDIR/audit/audit.jsonl" \
+		AUDIT_QUIET="true" \
+		bash "$SCRIPT" "$action" "$@"
+	return $?
+}
+
+test_create_records_audit_event() {
+	echo "Test: sandbox create records audit event"
+	setup
+
+	local sandbox_dir
+	sandbox_dir="$(run_sandbox_cmd create t1412-create)"
+
+	if [[ -d "$sandbox_dir" && -f "$sandbox_dir/.aidevops-sandbox" ]]; then
+		pass "sandbox directory and sentinel created"
+	else
+		fail "sandbox directory or sentinel missing"
+		cleanup
+		return 0
+	fi
+
+	if grep -q '^task_id=t1412-create$' "$sandbox_dir/.aidevops-sandbox"; then
+		pass "sentinel stores task id"
+	else
+		fail "sentinel missing expected task id"
+	fi
+
+	if grep -q 'worker_sandbox_created' "$TEST_TMPDIR/audit/audit.jsonl"; then
+		pass "audit log contains sandbox create event"
+	else
+		fail "missing sandbox create audit event"
+	fi
+
+	run_sandbox_cmd cleanup "$sandbox_dir" >/dev/null
+	cleanup
+	return 0
+}
+
+test_cleanup_records_audit_event() {
+	echo "Test: sandbox cleanup records audit event"
+	setup
+
+	local sandbox_dir
+	sandbox_dir="$(run_sandbox_cmd create t1412-cleanup)"
+	run_sandbox_cmd cleanup "$sandbox_dir" >/dev/null
+
+	if [[ ! -d "$sandbox_dir" ]]; then
+		pass "sandbox directory removed"
+	else
+		fail "sandbox directory still exists after cleanup"
+	fi
+
+	if grep -q 'worker_sandbox_cleaned' "$TEST_TMPDIR/audit/audit.jsonl"; then
+		pass "audit log contains sandbox cleanup event"
+	else
+		fail "missing sandbox cleanup audit event"
+	fi
+
+	if grep -q '"task_id":"t1412-cleanup"' "$TEST_TMPDIR/audit/audit.jsonl"; then
+		pass "audit log stores task id detail"
+	else
+		fail "audit log missing expected task id detail"
+	fi
+
+	cleanup
+	return 0
+}
+
+main() {
+	echo "=== test-worker-sandbox-helper.sh ==="
+	test_create_records_audit_event
+	test_cleanup_records_audit_event
+	echo ""
+	echo "Passed: ${PASS_COUNT}"
+	echo "Failed: ${FAIL_COUNT}"
+
+	if [[ "$FAIL_COUNT" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main


### PR DESCRIPTION
## Goal
Deliver the smallest validated worker-sandboxing slice for #4197 by adding tamper-evident audit trail coverage to sandbox lifecycle operations.

## Summary
- add best-effort `security.event` audit entries in `worker-sandbox-helper.sh` for sandbox create and cleanup events
- preserve fail-open behavior when `audit-log-helper.sh` is unavailable so worker dispatch does not break
- add `tests/test-worker-sandbox-helper.sh` to validate sandbox creation, cleanup, and audit log details end-to-end

## Verification
- `shellcheck .agents/scripts/worker-sandbox-helper.sh`
- `shellcheck tests/test-worker-sandbox-helper.sh`
- `bash tests/test-worker-sandbox-helper.sh`
- `bash tests/test-audit-log-helper.sh`

Closes #4197