### PR TITLE
GH#3547, GH#3625: quality-debt batch 10 — certificate parsing, OAuth hardening

### DIFF
--- a/.agents/scripts/email-test-suite-helper.sh
+++ b/.agents/scripts/email-test-suite-helper.sh
@@ -1021,16 +1021,20 @@ test_mail_tls() {
 	if [[ -n "$not_after" ]]; then
 		local expiry_epoch
 		expiry_epoch=$(date -j -f "%b %d %H:%M:%S %Y %Z" "$not_after" "+%s" 2>/dev/null || date -d "$not_after" "+%s" 2>/dev/null || echo "0")
-		local now_epoch
-		now_epoch=$(date "+%s")
-		local days_left=$(((expiry_epoch - now_epoch) / 86400))
-
-		if [[ "$days_left" -lt 0 ]]; then
-			print_error "Certificate EXPIRED ($days_left days ago)"
-		elif [[ "$days_left" -lt 30 ]]; then
-			print_warning "Certificate expires in $days_left days"
+		if [[ "$expiry_epoch" == "0" ]]; then
+			print_warning "Unable to parse certificate expiry date: $not_after"
 		else
-			print_success "Certificate valid for $days_left days"
+			local now_epoch
+			now_epoch=$(date "+%s")
+			local days_left=$(((expiry_epoch - now_epoch) / 86400))
+
+			if [[ "$days_left" -lt 0 ]]; then
+				print_error "Certificate EXPIRED ($days_left days ago)"
+			elif [[ "$days_left" -lt 30 ]]; then
+				print_warning "Certificate expires in $days_left days"
+			else
+				print_success "Certificate valid for $days_left days"
+			fi
 		fi
 	fi
 

--- a/.opencode/lib/ai-research.ts
+++ b/.opencode/lib/ai-research.ts
@@ -288,6 +288,8 @@ async function buildSystemPrompt(
 
 const AUTH_FILE = `${process.env.HOME || "~"}/.local/share/opencode/auth.json`
 const OAUTH_CLIENT_ID = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+const OAUTH_TOKEN_URL = "https://console.anthropic.com/v1/oauth/token"
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 
 interface OAuthAuth {
   type: "oauth"
@@ -323,18 +325,26 @@ async function readAuthFile(): Promise<AuthEntry | null> {
  * Updates auth.json with the new tokens.
  */
 async function refreshOAuthToken(auth: OAuthAuth): Promise<string> {
-  const response = await fetch(
-    "https://console.anthropic.com/v1/oauth/token",
-    {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        grant_type: "refresh_token",
-        refresh_token: auth.refresh,
-        client_id: OAUTH_CLIENT_ID,
-      }),
-    }
-  )
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 15_000)
+  let response: Response
+  try {
+    response = await fetch(
+      OAUTH_TOKEN_URL,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          grant_type: "refresh_token",
+          refresh_token: auth.refresh,
+          client_id: OAUTH_CLIENT_ID,
+        }),
+        signal: controller.signal,
+      }
+    )
+  } finally {
+    clearTimeout(timeout)
+  }
 
   if (!response.ok) {
     throw new Error(`OAuth token refresh failed (${response.status})`)
@@ -357,8 +367,10 @@ async function refreshOAuthToken(auth: OAuthAuth): Promise<string> {
       expires: Date.now() + json.expires_in * 1000,
     }
     await Bun.write(AUTH_FILE, JSON.stringify(data, null, 2))
-  } catch {
-    // Non-fatal: token still works for this request even if we can't persist
+  } catch (err) {
+    // Non-fatal: token still works for this request even if we can't persist.
+    // Log so persistent write failures are visible (e.g., permissions, disk full).
+    console.error(`[ai-research] Warning: failed to persist refreshed OAuth token: ${err}`)
   }
 
   return json.access_token
@@ -384,7 +396,9 @@ async function resolveAuth(): Promise<ResolvedAuth> {
 
   if (auth?.type === "oauth") {
     let accessToken = auth.access
-    if (!accessToken || auth.expires < Date.now()) {
+    // Refresh 5 minutes before expiry to avoid using near-expired tokens
+    const EXPIRY_BUFFER_MS = 5 * 60 * 1000
+    if (!accessToken || auth.expires < Date.now() + EXPIRY_BUFFER_MS) {
       accessToken = await refreshOAuthToken(auth)
     }
     return { method: "oauth", token: accessToken }
@@ -430,7 +444,7 @@ async function callAnthropic(
     "anthropic-version": "2023-06-01",
   }
 
-  let url = "https://api.anthropic.com/v1/messages"
+  let url = ANTHROPIC_API_URL
 
   if (auth.method === "oauth") {
     headers["authorization"] = `Bearer ${auth.token}`


### PR DESCRIPTION
## Summary

- Fix misleading certificate expiry messages when date parsing fails
- Harden OAuth token management with timeout, logging, and expiry buffer

## Commits

### 1. `fix: detect unparseable certificate expiry dates in email-test-suite`
When both macOS `date -j` and GNU `date -d` fail to parse the certificate expiry date, `expiry_epoch` falls back to `"0"`, producing a misleading "Certificate EXPIRED (-20454 days ago)" message. Now detects the parse failure and reports "Unable to parse certificate expiry date" instead.

Closes #3547

### 2. `fix: harden ai-research.ts OAuth token management`
- Add 15s `AbortController` timeout to OAuth token refresh fetch to prevent indefinite hangs
- Log token persistence failures instead of silently swallowing them (empty catch block)
- Add 5-minute expiry buffer to avoid using near-expired tokens
- Extract API endpoint URLs to constants for maintainability

Closes #3625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced certificate validation with clearer expiry status messages: errors for expired certificates, warnings for those expiring soon, and success confirmations for valid ones.
  * Added timeout protection (15 seconds) for authentication token refresh to prevent system hangs.
  * Implemented 5-minute token expiry buffer to refresh credentials before they expire.
  * Improved error visibility with detailed logging when authentication token persistence fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->