### PR TITLE
t4231: harden critical stats-wrapper dedup age validation

### DIFF
--- a/.agents/scripts/stats-wrapper.sh
+++ b/.agents/scripts/stats-wrapper.sh
@@ -34,6 +34,54 @@ STATS_LOGFILE="${HOME}/.aidevops/logs/stats.log"
 mkdir -p "$(dirname "$STATS_PIDFILE")"
 
 #######################################
+# Portable elapsed-seconds lookup for a running PID
+#######################################
+_stats_process_elapsed_seconds() {
+	local pid="$1"
+	local elapsed
+
+	elapsed=$(ps -p "$pid" -o etimes= 2>/dev/null | tr -d '[:space:]')
+	if [[ "$elapsed" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$elapsed"
+		return 0
+	fi
+
+	local etime
+	etime=$(ps -p "$pid" -o etime= 2>/dev/null | tr -d '[:space:]')
+	if [[ -z "$etime" ]]; then
+		return 1
+	fi
+
+	elapsed=$(awk -v value="$etime" '
+		BEGIN {
+			n = split(value, parts, /[-:]/)
+			if (index(value, "-") > 0) {
+				if (n != 4) {
+					print ""
+					exit
+				}
+				total = (parts[1] * 86400) + (parts[2] * 3600) + (parts[3] * 60) + parts[4]
+			} else if (n == 3) {
+				total = (parts[1] * 3600) + (parts[2] * 60) + parts[3]
+			} else if (n == 2) {
+				total = (parts[1] * 60) + parts[2]
+			} else {
+				print ""
+				exit
+			}
+			print total
+		}
+	')
+
+	if [[ "$elapsed" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' "$elapsed"
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
 # PID-based dedup — same pattern as pulse-wrapper check_dedup()
 #######################################
 check_stats_dedup() {
@@ -58,11 +106,18 @@ check_stats_dedup() {
 		return 0
 	fi
 
-	# Check age using stored epoch (portable — no date -d / _get_process_age)
-	old_epoch="${old_epoch:-0}"
-	local now
+	# Prefer stored epoch, but validate it before use. Invalid epochs used to
+	# compute huge elapsed values and incorrectly kill healthy stats workers.
+	local now elapsed
 	now=$(date +%s)
-	local elapsed=$((now - old_epoch))
+	if [[ "$old_epoch" =~ ^[0-9]+$ ]] && [[ "$old_epoch" -gt 0 ]] && [[ "$old_epoch" -le "$now" ]]; then
+		elapsed=$((now - old_epoch))
+	else
+		elapsed=$(_stats_process_elapsed_seconds "$old_pid") || {
+			rm -f "$STATS_PIDFILE"
+			return 0
+		}
+	fi
 
 	if [[ "$elapsed" -gt "$STATS_TIMEOUT" ]]; then
 		echo "[stats-wrapper] Killing stale stats process $old_pid (${elapsed}s)" >>"$STATS_LOGFILE"

--- a/.agents/scripts/stats-wrapper.sh
+++ b/.agents/scripts/stats-wrapper.sh
@@ -67,7 +67,7 @@ _stats_process_elapsed_seconds() {
 			}
 			print total
 		}
-	')
+	' || true)
 
 	if [[ "$elapsed" =~ ^[0-9]+$ ]]; then
 		printf '%s\n' "$elapsed"

--- a/.agents/scripts/stats-wrapper.sh
+++ b/.agents/scripts/stats-wrapper.sh
@@ -38,16 +38,16 @@ mkdir -p "$(dirname "$STATS_PIDFILE")"
 #######################################
 _stats_process_elapsed_seconds() {
 	local pid="$1"
-	local elapsed
+	local elapsed=""
 
-	elapsed=$(ps -p "$pid" -o etimes= 2>/dev/null | tr -d '[:space:]')
+	elapsed=$(ps -p "$pid" -o etimes= 2>/dev/null | tr -d '[:space:]' || true)
 	if [[ "$elapsed" =~ ^[0-9]+$ ]]; then
 		printf '%s\n' "$elapsed"
 		return 0
 	fi
 
-	local etime
-	etime=$(ps -p "$pid" -o etime= 2>/dev/null | tr -d '[:space:]')
+	local etime=""
+	etime=$(ps -p "$pid" -o etime= 2>/dev/null | tr -d '[:space:]' || true)
 	if [[ -z "$etime" ]]; then
 		return 1
 	fi
@@ -56,18 +56,14 @@ _stats_process_elapsed_seconds() {
 		BEGIN {
 			n = split(value, parts, /[-:]/)
 			if (index(value, "-") > 0) {
-				if (n != 4) {
-					print ""
-					exit
-				}
+				if (n != 4) { exit 1 }
 				total = (parts[1] * 86400) + (parts[2] * 3600) + (parts[3] * 60) + parts[4]
 			} else if (n == 3) {
 				total = (parts[1] * 3600) + (parts[2] * 60) + parts[3]
 			} else if (n == 2) {
 				total = (parts[1] * 60) + parts[2]
 			} else {
-				print ""
-				exit
+				exit 1
 			}
 			print total
 		}
@@ -114,6 +110,10 @@ check_stats_dedup() {
 		elapsed=$((now - old_epoch))
 	else
 		elapsed=$(_stats_process_elapsed_seconds "$old_pid") || {
+			if kill -0 "$old_pid" 2>/dev/null; then
+				echo "[stats-wrapper] Unable to determine elapsed time for live PID $old_pid; preserving pidfile and skipping." >>"$STATS_LOGFILE"
+				return 1
+			fi
 			rm -f "$STATS_PIDFILE"
 			return 0
 		}


### PR DESCRIPTION
## Summary
- validate pidfile epoch before elapsed-time math to prevent false stale-process kills when epoch data is missing/corrupt
- fall back to portable `ps` elapsed-time lookup (`etimes` first, then parsed `etime`) so dedup checks remain reliable on macOS and Linux
- preserve existing timeout kill/remove behavior while adding focused runtime validation for invalid and stale epoch paths

## Validation
- `shellcheck .agents/scripts/stats-wrapper.sh`
- `bash -lc 'source ".agents/scripts/stats-wrapper.sh"; tmpdir=$(mktemp -d); STATS_PIDFILE="$tmpdir/stats.pid"; STATS_LOGFILE="$tmpdir/stats.log"; STATS_TIMEOUT=600; sleep 30 & pid=$!; printf "%s 0\n" "$pid" >"$STATS_PIDFILE"; if check_stats_dedup; then rc=$?; else rc=$?; fi; alive=0; if kill -0 "$pid" 2>/dev/null; then alive=1; fi; kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; printf "invalid_epoch rc=%s alive=%s\n" "$rc" "$alive"'`
- `bash -lc 'source ".agents/scripts/stats-wrapper.sh"; tmpdir=$(mktemp -d); STATS_PIDFILE="$tmpdir/stats.pid"; STATS_LOGFILE="$tmpdir/stats.log"; STATS_TIMEOUT=2; sleep 30 & pid=$!; old_epoch=$(( $(date +%s) - 600 )); printf "%s %s\n" "$pid" "$old_epoch" >"$STATS_PIDFILE"; if check_stats_dedup; then rc=$?; else rc=$?; fi; alive=0; if kill -0 "$pid" 2>/dev/null; then alive=1; fi; kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; printf "stale_epoch rc=%s alive=%s\n" "$rc" "$alive"'`

Closes #4231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of internal process monitoring through improved elapsed time calculation validation.
  * Added safeguards to prevent edge-case issues from corrupt or invalid elapsed time data.
  * Implemented fallback validation mechanisms for more robust process status verification.
  * Maintains existing process timeout and logging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->