### PR TITLE
t1456: count all full-loop workers in pulse utilization

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -40,9 +40,8 @@ This is idempotent — safe to run even when PATH is already correct. All subseq
 # Max workers (dynamic, from available RAM)
 MAX_WORKERS=$(cat ~/.aidevops/logs/pulse-max-workers 2>/dev/null || echo 4)
 
-# Count running issue workers only (exclude supervisor /pulse processes whose
-# command payload can contain '/full-loop' text from pre-fetched state)
-WORKER_COUNT=$(ps axo command | grep '\.opencode run' | grep '/full-loop Implement issue #' | grep -v '/pulse' | grep -v grep | wc -l | tr -d ' ')
+# Count all full-loop workers (issue + PR advancement), excluding supervisor /pulse noise
+WORKER_COUNT=$(ps axo command | grep '\.opencode run' | grep '/full-loop' | grep -v '/pulse' | grep -v 'Supervisor Pulse' | grep -v grep | wc -l | tr -d ' ')
 AVAILABLE=$((MAX_WORKERS - WORKER_COUNT))
 
 # Priority-class allocations (t1423) — read from pre-fetched state

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1682,7 +1682,7 @@ prefetch_contribution_watch() {
 #######################################
 count_active_workers() {
 	local count
-	count=$(ps axo command | grep '\.opencode run' | grep '/full-loop Implement issue #' | grep -v '/pulse' | grep -c -v grep) || count=0
+	count=$(ps axo command | grep '\.opencode run' | grep '/full-loop' | grep -v '/pulse' | grep -v 'Supervisor Pulse' | grep -c -v grep) || count=0
 	echo "$count"
 	return 0
 }


### PR DESCRIPTION
## Summary
- update pulse wrapper active-worker matcher to count all `.opencode run` full-loop workers, including PR advancement workers
- keep supervisor exclusion by filtering `/pulse` and `Supervisor Pulse` command noise
- align pulse.md capacity snippet with the same all-full-loop matcher

## Verification
- `shellcheck .agents/scripts/pulse-wrapper.sh`
- `markdown-formatter check .agents/scripts/commands/pulse.md`

Closes #4233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker counting logic to include all full-loop workers (issue and PR advancement), refining system capacity calculations to more accurately reflect available processing capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->