### PR TITLE
GH#3153: Fix remaining PR #3067 review feedback — stderr suppression and loop efficiency

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -598,12 +598,20 @@ _Auto-updated by ${runner_role} stats process. Do not edit manually._"
 	local health_title="${runner_prefix} ${title_parts} at ${title_time} UTC"
 
 	# Only update title if stats changed
-	local current_title
-	current_title=$(gh issue view "$health_issue_number" --repo "$repo_slug" --json title --jq '.title' 2>>"$LOGFILE" || echo "")
+	local current_title=""
+	local view_output
+	if view_output=$(gh issue view "$health_issue_number" --repo "$repo_slug" --json title --jq '.title' 2>&1); then
+		current_title="$view_output"
+	else
+		echo "[stats] Health issue: failed to view title for #${health_issue_number}: ${view_output}" >>"$LOGFILE"
+	fi
 	local current_stats="${current_title% at [0-9][0-9]:[0-9][0-9] UTC}"
 	local new_stats="${health_title% at [0-9][0-9]:[0-9][0-9] UTC}"
 	if [[ "$current_stats" != "$new_stats" ]]; then
-		gh issue edit "$health_issue_number" --repo "$repo_slug" --title "$health_title" 2>>"$LOGFILE" >/dev/null || true
+		local title_edit_stderr
+		title_edit_stderr=$(gh issue edit "$health_issue_number" --repo "$repo_slug" --title "$health_title" 2>&1 >/dev/null) || {
+			echo "[stats] Health issue: failed to update title for #${health_issue_number}: ${title_edit_stderr}" >>"$LOGFILE"
+		}
 	fi
 
 	return 0

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -1584,10 +1584,16 @@ _update_quality_issue_body() {
 		prs_waiting="UNKNOWN"
 	fi
 	if [[ "$helper_available" == true ]]; then
-		local pr_numbers
-		pr_numbers=$(echo "$open_prs_json" | jq -r '.[].number')
-		while IFS= read -r pr_num; do
-			[[ -z "$pr_num" ]] && continue
+		# Parse open_prs_json once into per-PR objects to avoid re-parsing the
+		# full JSON array on every iteration (Gemini review feedback — GH#3153).
+		# Each line is a compact JSON object: {"number":N,"title":"...","createdAt":"..."}
+		local pr_objects
+		pr_objects=$(echo "$open_prs_json" | jq -c '.[]')
+		while IFS= read -r pr_obj; do
+			[[ -z "$pr_obj" ]] && continue
+			local pr_num
+			pr_num=$(echo "$pr_obj" | jq -r '.number')
+			[[ -z "$pr_num" || "$pr_num" == "null" ]] && continue
 			local gate_result
 			gate_result=$("$review_helper" check "$pr_num" "$repo_slug" 2>>"$LOGFILE" || echo "UNKNOWN")
 			case "$gate_result" in
@@ -1596,9 +1602,10 @@ _update_quality_issue_body() {
 				;;
 			WAITING* | UNKNOWN*)
 				prs_waiting=$((prs_waiting + 1))
-				# Check if PR is older than 2 hours (stale waiting)
+				# Check if PR is older than 2 hours (stale waiting).
+				# Fields already extracted from pr_obj — no re-parse of open_prs_json.
 				local pr_created
-				pr_created=$(echo "$open_prs_json" | jq -r --argjson n "$pr_num" '.[] | select(.number == $n) | .createdAt' || echo "")
+				pr_created=$(echo "$pr_obj" | jq -r '.createdAt // empty')
 				if [[ -n "$pr_created" ]]; then
 					local pr_epoch
 					pr_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$pr_created" +%s 2>/dev/null || date -d "$pr_created" +%s 2>/dev/null || echo "0")
@@ -1611,7 +1618,7 @@ _update_quality_issue_body() {
 						local pr_age_hours=$(((now_epoch - pr_epoch) / 3600))
 						if [[ "$pr_age_hours" -ge 2 ]]; then
 							local pr_title
-							pr_title=$(echo "$open_prs_json" | jq -r --argjson n "$pr_num" '.[] | select(.number == $n) | .title[:50]' || echo "")
+							pr_title=$(echo "$pr_obj" | jq -r '.title[:50] // empty')
 							# Sanitise PR title — untrusted GitHub content could
 							# contain @ mentions or markdown that leaks into the dashboard
 							pr_title=$(_sanitize_markdown "$pr_title")
@@ -1625,7 +1632,7 @@ _update_quality_issue_body() {
 				prs_with_reviews=$((prs_with_reviews + 1))
 				;;
 			esac
-		done <<<"$pr_numbers"
+		done <<<"$pr_objects"
 	fi
 
 	# Build bot coverage section — show N/A when helper is unavailable

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -579,9 +579,10 @@ ${cross_repo_person_stats_md:-_Cross-repo person stats unavailable._}
 ---
 _Auto-updated by ${runner_role} stats process. Do not edit manually._"
 
-	# Update the issue body
-	gh issue edit "$health_issue_number" --repo "$repo_slug" --body "$body" >/dev/null 2>&1 || {
-		echo "[stats] Health issue: failed to update body for #${health_issue_number}" >>"$LOGFILE"
+	# Update the issue body — capture stderr for debugging auth/API failures
+	local body_edit_stderr
+	body_edit_stderr=$(gh issue edit "$health_issue_number" --repo "$repo_slug" --body "$body" 2>&1 >/dev/null) || {
+		echo "[stats] Health issue: failed to update body for #${health_issue_number}: ${body_edit_stderr}" >>"$LOGFILE"
 		return 0
 	}
 
@@ -598,11 +599,11 @@ _Auto-updated by ${runner_role} stats process. Do not edit manually._"
 
 	# Only update title if stats changed
 	local current_title
-	current_title=$(gh issue view "$health_issue_number" --repo "$repo_slug" --json title --jq '.title' 2>/dev/null || echo "")
+	current_title=$(gh issue view "$health_issue_number" --repo "$repo_slug" --json title --jq '.title' 2>>"$LOGFILE" || echo "")
 	local current_stats="${current_title% at [0-9][0-9]:[0-9][0-9] UTC}"
 	local new_stats="${health_title% at [0-9][0-9]:[0-9][0-9] UTC}"
 	if [[ "$current_stats" != "$new_stats" ]]; then
-		gh issue edit "$health_issue_number" --repo "$repo_slug" --title "$health_title" >/dev/null 2>&1 || true
+		gh issue edit "$health_issue_number" --repo "$repo_slug" --title "$health_title" 2>>"$LOGFILE" >/dev/null || true
 	fi
 
 	return 0


### PR DESCRIPTION
## Summary

Addresses the remaining unactioned review findings from PR #3067 (GH#3153) in `stats-functions.sh` (code was extracted from `pulse-wrapper.sh` to `stats-functions.sh` in t1431/#4110).

## Changes

### Commit 1: remove blanket stderr suppression from gh calls in health issue update

`stats-functions.sh` `_update_runner_health_issue()`:
- `gh issue edit` body update: capture stderr into variable for error logging instead of `>/dev/null 2>&1`
- `gh issue view` title fetch: redirect stderr to LOGFILE instead of `/dev/null`
- `gh issue edit` title update: redirect stderr to LOGFILE instead of `/dev/null`

Addresses Gemini finding: _"Blanket suppression of stdout and stderr with `>/dev/null 2>&1` should be avoided."_

### Commit 2: parse open_prs_json once before loop to avoid O(n) re-parsing

`stats-functions.sh` `_update_quality_issue_body()`:
- Replace per-iteration `jq` re-parse of `open_prs_json` with a single `jq -c '.[]'` pass before the loop
- Each iteration reads `.createdAt` and `.title[:50]` from `pr_obj` directly, eliminating two O(n) `jq` invocations per WAITING/UNKNOWN PR
- Adds null guard: skip `pr_obj` entries where `.number` is empty or null

Addresses Gemini finding: _"This while loop is inefficient because it repeatedly parses the open_prs_json string with jq on each iteration."_

## Findings Status

All 8 findings from GH#3153 are now addressed:

| # | Severity | Reviewer | Finding | Status |
|---|----------|----------|---------|--------|
| 1 | MEDIUM | Gemini | `2>/dev/null` suppression in quality sweep | Fixed in t1431 extraction |
| 2 | MEDIUM | Gemini | Inefficient loop re-parsing JSON | **Fixed in this PR** |
| 3 | MEDIUM | Gemini | `>/dev/null 2>&1` on `gh issue edit` | **Fixed in this PR** |
| 4 | HIGH | CodeRabbit | `pr_epoch=0` causes huge age | Fixed in commit c1718c6 (PR #3067) |
| 5 | CRITICAL | CodeRabbit | Dashboard refresh decoupled from comment-post | Fixed in commit a01a0f1 (PR #3067) |
| 6 | HIGH | CodeRabbit | `debt_closed` truncates at 200 | Fixed in commits a01a0f1-e312a09 (PR #3067) |
| 7 | MEDIUM | CodeRabbit | `gh pr list --limit 20` | Fixed in commits a01a0f1-e312a09 (PR #3067) |
| 8 | MEDIUM | CodeRabbit | Missing helper shows false zeros | Fixed in commit a01a0f1 (PR #3067) |

Closes #3153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for health issue tracking to ensure failures are properly detected and reported.

* **Chores**
  * Optimized pull request processing logic for better performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->