### PR TITLE
4216: fix qlty/codacy install fail-open in CI

### DIFF
--- a/.github/workflows/code-review-monitoring.yml
+++ b/.github/workflows/code-review-monitoring.yml
@@ -58,16 +58,42 @@ jobs:
     
     - name: 🔍 Install Quality Tools
       run: |
-        # Install Qlty CLI
-        curl -sSL https://github.com/qltysh/qlty/releases/latest/download/qlty-x86_64-unknown-linux-gnu.tar.xz -o qlty.tar.xz
-        tar xf qlty.tar.xz
-        sudo mv qlty-*/qlty /usr/local/bin/
-        rm -rf qlty*
-        
-        # Install Codacy CLI
-        curl -L https://github.com/codacy/codacy-analysis-cli/releases/latest/download/codacy-analysis-cli-linux -o codacy-analysis-cli
-        chmod +x codacy-analysis-cli
-        sudo mv codacy-analysis-cli /usr/local/bin/
+        # Install Qlty CLI — fail-open: transient download failures must not block CI.
+        # Root cause of GH#4216: curl sometimes returns a truncated/rate-limited
+        # response (9 bytes) from GitHub releases; tar then exits 2, killing the job.
+        # Fix: validate download size before extracting; skip qlty gracefully if unavailable.
+        QLTY_URL="https://github.com/qltysh/qlty/releases/latest/download/qlty-x86_64-unknown-linux-gnu.tar.xz"
+        if curl -sSL --retry 3 --retry-delay 5 "$QLTY_URL" -o qlty.tar.xz 2>&1; then
+          QLTY_SIZE=$(stat -c%s qlty.tar.xz 2>/dev/null || echo 0)
+          if [ "$QLTY_SIZE" -gt 100000 ]; then
+            if tar xf qlty.tar.xz 2>&1; then
+              sudo mv qlty-*/qlty /usr/local/bin/ 2>/dev/null || true
+              echo "Qlty CLI installed: $(qlty --version 2>/dev/null || echo 'version unknown')"
+            else
+              echo "::warning::Qlty tar extraction failed — skipping qlty analysis"
+            fi
+          else
+            echo "::warning::Qlty download incomplete (${QLTY_SIZE} bytes) — skipping qlty analysis"
+          fi
+        else
+          echo "::warning::Qlty download failed — skipping qlty analysis"
+        fi
+        rm -rf qlty.tar.xz qlty-* 2>/dev/null || true
+
+        # Install Codacy CLI — also fail-open
+        if curl -L --retry 3 --retry-delay 5 https://github.com/codacy/codacy-analysis-cli/releases/latest/download/codacy-analysis-cli-linux -o codacy-analysis-cli 2>&1; then
+          CODACY_SIZE=$(stat -c%s codacy-analysis-cli 2>/dev/null || echo 0)
+          if [ "$CODACY_SIZE" -gt 100000 ]; then
+            chmod +x codacy-analysis-cli
+            sudo mv codacy-analysis-cli /usr/local/bin/
+            echo "Codacy CLI installed"
+          else
+            echo "::warning::Codacy download incomplete (${CODACY_SIZE} bytes) — skipping codacy analysis"
+            rm -f codacy-analysis-cli
+          fi
+        else
+          echo "::warning::Codacy download failed — skipping codacy analysis"
+        fi
     
     - name: 🏃 Run Code Review Monitoring
       env:


### PR DESCRIPTION
Root cause: curl -sSL on GitHub releases sometimes returns a truncated response (9 bytes) due to rate limiting. tar xf then exits 2, killing the job under set -e. Fix: size-validated fail-open install with --retry 3. Closes #4216