### PR TITLE
t4219: clarify secret set terminal-only warning flow

### DIFF
--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -288,10 +288,24 @@ cmd_set() {
 		print_success "Stored $name in gopass"
 	else
 		print_warning "gopass not available, falling back to credentials.sh"
-		print_info "Now enter the raw secret value for $name (input hidden):"
 		local value
-		read -rs value
-		echo ""
+		while true; do
+			print_info "Now enter the raw secret value for $name (input hidden):"
+			read -rs value
+			echo ""
+
+			if [[ -z "$value" ]]; then
+				print_error "Empty input detected. Paste the secret value and press Enter."
+				continue
+			fi
+
+			if [[ "$value" =~ ^[[:space:]]*(aidevops[[:space:]]+secret|export[[:space:]]+[A-Z_][A-Z0-9_]*=|cmd:[[:space:]]*) ]]; then
+				print_error "Input looks like a command. Paste only the raw secret value."
+				continue
+			fi
+
+			break
+		done
 
 		ensure_credentials_file "$CREDENTIALS_FILE"
 		if [[ -f "$CREDENTIALS_FILE" ]] && grep -q "^export ${name}=" "$CREDENTIALS_FILE" 2>/dev/null; then

--- a/.agents/scripts/secret-helper.sh
+++ b/.agents/scripts/secret-helper.sh
@@ -273,13 +273,22 @@ cmd_set() {
 	# Normalize to uppercase
 	name=$(echo "$name" | tr '[:lower:]-' '[:upper:]_')
 
+	print_info "Setting secret: $name"
+	print_warning "WARNING: Never paste secret values into AI chat"
+	print_warning "Run this command in your terminal and enter the value at the hidden prompt"
+	echo ""
+	echo "  1) When prompted, paste ONLY the secret value"
+	echo "  2) Do NOT paste the command, key name, or an export line"
+	echo "  3) Input is hidden; press Enter when done"
+	echo ""
+
 	if has_gopass; then
-		print_info "Enter value for $name (input hidden):"
+		print_info "Now enter the raw secret value for $name (input hidden):"
 		gopass insert "${GOPASS_PREFIX}/${name}"
 		print_success "Stored $name in gopass"
 	else
 		print_warning "gopass not available, falling back to credentials.sh"
-		print_info "Enter value for $name (input hidden):"
+		print_info "Now enter the raw secret value for $name (input hidden):"
 		local value
 		read -rs value
 		echo ""
@@ -297,6 +306,7 @@ cmd_set() {
 		print_success "Stored $name in credentials.sh"
 		print_info "Recommend: aidevops secret init (to enable encrypted storage)"
 	fi
+	print_info "Verify key name only: aidevops secret list"
 
 	return 0
 }
@@ -613,8 +623,18 @@ cmd_help() {
 	echo ""
 	print_info "Examples:"
 	echo ""
+	echo "  # WARNING: Never paste secret values into AI chat"
+	echo "  # Run secret set in your terminal and enter the value at hidden prompt"
+	echo ""
 	echo "  # Store a secret (value entered at terminal, hidden)"
 	echo "  aidevops secret set STRIPE_KEY"
+	echo ""
+	echo "  # Secret set flow"
+	echo "  # 1) Run set command"
+	echo "  # 2) At hidden prompt, paste only the secret value"
+	echo "  # 3) Press Enter"
+	echo "  # 4) Verify key name only"
+	echo "  aidevops secret list"
 	echo ""
 	echo "  # Run a command with secrets injected (output redacted)"
 	echo "  aidevops secret run curl -H 'Authorization: Bearer \$STRIPE_KEY' https://api.stripe.com/v1/charges"

--- a/.agents/tools/credentials/gopass.md
+++ b/.agents/tools/credentials/gopass.md
@@ -87,6 +87,14 @@ aidevops secret status
 
 ### Storing Secrets
 
+Exact flow for each key:
+
+1. Run `aidevops secret set SECRET_NAME` in your own terminal
+2. Wait for hidden input prompt
+3. Paste only the raw secret value (not a command, not `export KEY=...`, not the key name)
+4. Press Enter once
+5. Verify key names only with `aidevops secret list`
+
 ```bash
 # Interactive hidden input (value never visible)
 aidevops secret set GITHUB_TOKEN
@@ -136,6 +144,10 @@ gopass sync
 ## Agent Instructions
 
 When an AI agent needs a secret:
+
+Agent should start with this warning in chat:
+
+`WARNING: Never paste secret values into AI chat. Run aidevops secret set SECRET_NAME in your terminal, then enter the value at the hidden prompt.`
 
 1. Agent instructs user: "Please run: `aidevops secret set SECRET_NAME`"
 2. User runs command at terminal (value entered with hidden input)


### PR DESCRIPTION
## Summary
- add explicit WARNING messaging in `aidevops secret set` so users do not paste secrets into AI chat
- add step-by-step hidden-prompt instructions to reduce command-literal/input mistakes
- document a standard agent warning line and terminal-only secret entry flow

Closes #4219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced user guidance with security warnings for the secret management workflow
  * Added step-by-step prompts with clear instructions for entering and storing secret values
  * Added post-configuration verification instructions to confirm successful secret setup
  * Expanded help documentation with detailed examples of the complete secret setting process

* **Chores**
  * Improved user-facing prompts and messaging during secret configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->