### PR TITLE
GH#4223: Fix phase count discrepancy in ai-search-readiness.md

### DIFF
--- a/.agents/seo/ai-search-readiness.md
+++ b/.agents/seo/ai-search-readiness.md
@@ -1,6 +1,6 @@
 ---
 name: ai-search-readiness
-description: Orchestrate AI search readiness across grounding triage, fan-out modeling, GEO, SRO, integrity hardening, discoverability checks, and citation monitoring
+description: Orchestrate end-to-end AI search readiness across seven phases from grounding eligibility through citation monitoring
 mode: subagent
 tools:
   read: true


### PR DESCRIPTION
## Summary

- Updated the YAML frontmatter `description` in `.agents/seo/ai-search-readiness.md` to accurately reflect the seven phases (0-6) defined in the Execution Sequence
- Old description enumerated individual phase names without stating the count; new description says "seven phases from grounding eligibility through citation monitoring"

Closes #4223