### PR TITLE
GH#4229: Add pipefail to codacy-collector SQL pipeline subshell

### DIFF
--- a/.agents/scripts/codacy-collector-helper.sh
+++ b/.agents/scripts/codacy-collector-helper.sh
@@ -534,6 +534,7 @@ JQ_EOF
 		# Wrap in transaction for atomicity and performance (single fsync)
 		# Use total_changes() for accurate committed row count instead of wc -l
 		count=$(
+			set -o pipefail
 			{
 				echo "BEGIN TRANSACTION;"
 				cat "$sql_file"


### PR DESCRIPTION
## Summary

- Adds `set -o pipefail` inside the command substitution subshell at line ~536 of `codacy-collector-helper.sh`, so that if `cat "$sql_file"` fails mid-pipeline, the failure propagates to the `|| { ... }` error handler instead of being masked by the exit status of the final `db` command.

Closes #4229