### PR TITLE
t1455: add non-code routine execution guidance and helper

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -42,6 +42,31 @@ Subagent write restrictions: on `main`/`master`, subagents may ONLY write to `RE
 
 ---
 
+## Operational Routines (Non-Code Work)
+
+Not every autonomous task should use `/full-loop`. Use this decision rule:
+- **Code change needed** (repo files, tests, PRs) → `/full-loop`
+- **Operational execution** (reports, audits, monitoring, outreach, client ops) → run a domain agent/command directly, with no branch/PR ceremony
+
+For recurring operational work, follow this sequence:
+1. **Design the operator first**: Create a custom agent for the SOP (`tools/build-agent/build-agent.md`)
+2. **Prove it ad-hoc**: Run it manually with representative inputs until output quality is stable
+3. **Harden guardrails**: Add clear output format, retries/timeouts, and privacy rules (never leak cross-client data)
+4. **Pilot safely**: Test on yourself/internal targets first, then one client, then a staged rollout
+5. **Schedule the command**: Run the proven command via launchd/cron using `opencode run`
+
+Scheduling pattern:
+
+```bash
+# aidevops: weekly SEO ranking report run
+opencode run --dir ~/Git/myproject --agent SEO --title "Weekly rankings" \
+  "/your-command client-set-a"
+```
+
+Use pulse for queue-based task pickup; use scheduled `opencode run` jobs for fixed-time operational routines.
+
+---
+
 ## Self-Improvement
 
 Every agent session — interactive, worker, or supervisor — should improve the system, not just complete its task. This is a universal principle, not specific to any one command.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -48,22 +48,7 @@ Not every autonomous task should use `/full-loop`. Use this decision rule:
 - **Code change needed** (repo files, tests, PRs) → `/full-loop`
 - **Operational execution** (reports, audits, monitoring, outreach, client ops) → run a domain agent/command directly, with no branch/PR ceremony
 
-For recurring operational work, follow this sequence:
-1. **Design the operator first**: Create a custom agent for the SOP (`tools/build-agent/build-agent.md`)
-2. **Prove it ad-hoc**: Run it manually with representative inputs until output quality is stable
-3. **Harden guardrails**: Add clear output format, retries/timeouts, and privacy rules (never leak cross-client data)
-4. **Pilot safely**: Test on yourself/internal targets first, then one client, then a staged rollout
-5. **Schedule the command**: Run the proven command via launchd/cron using `opencode run`
-
-Scheduling pattern:
-
-```bash
-# aidevops: weekly SEO ranking report run
-opencode run --dir ~/Git/myproject --agent SEO --title "Weekly rankings" \
-  "/your-command client-set-a"
-```
-
-Use pulse for queue-based task pickup; use scheduled `opencode run` jobs for fixed-time operational routines.
+For setup workflow, safety gates, and scheduling patterns, use `/routine` or read `.agents/scripts/commands/routine.md`.
 
 ---
 

--- a/.agents/scripts/commands/routine.md
+++ b/.agents/scripts/commands/routine.md
@@ -1,0 +1,114 @@
+---
+description: Design and schedule recurring non-code operational routines
+agent: Build+
+mode: subagent
+---
+
+Create a recurring operational routine (reports, audits, monitoring, outreach) without forcing `/full-loop`.
+
+Arguments: $ARGUMENTS
+
+## Goal
+
+Build a reliable routine from three independent dimensions:
+
+1. **SOP** - what to do
+2. **Targets** - who/what to apply it to
+3. **Schedule** - when to run
+
+Keep these separate so each can evolve independently.
+
+## Decision Rule
+
+- If the routine needs repo code changes and PR traceability, use `/full-loop`
+- If the routine is operational execution, run direct commands with `opencode run`
+
+## Workflow
+
+### Step 1: Define the SOP command
+
+Create or select the command that performs one run for one target.
+
+Examples:
+
+```bash
+/seo-export --account client-a --format summary
+/keyword-research --domain example.com --market uk
+/email-health-check --tenant client-a
+```
+
+Prefer deterministic helper/script commands over free-form prompts.
+
+### Step 2: Validate quality and safety manually
+
+Run ad-hoc before scheduling:
+
+```bash
+opencode run --dir ~/Git/<repo> --agent SEO --title "Routine dry run" \
+  "/seo-export --account client-a --format summary"
+```
+
+Required checks before rollout:
+
+- Output format is stable and client-safe
+- No cross-client data leakage
+- Retry and timeout behavior are acceptable
+- Human review exists for outbound communication
+
+### Step 3: Pilot rollout
+
+Roll out in this order:
+
+1. Internal/self target
+2. Single client
+3. Small client cohort
+4. Full target set
+
+Do not skip stages for outbound client-facing routines.
+
+### Step 4: Schedule the command
+
+Use launchd/cron to run the proven command on a fixed cadence.
+
+Use helper script (recommended):
+
+```bash
+~/.aidevops/agents/scripts/routine-helper.sh plan \
+  --name weekly-seo-rankings \
+  --schedule "0 9 * * 1" \
+  --dir ~/Git/aidev-ops-client-seo-reports \
+  --agent SEO \
+  --title "Weekly rankings" \
+  --prompt "/seo-export --account client-a --format summary"
+```
+
+```bash
+# macOS launchd/cron wrapper style
+# aidevops: weekly client rankings
+opencode run --dir ~/Git/<repo> --agent SEO --title "Weekly rankings" \
+  "/seo-export --account client-a --format summary"
+```
+
+For queue-driven development work, use `/pulse`. For fixed-time routines, use scheduler entries.
+
+## Routine Spec Template
+
+Store routine definitions in your repo (for example `routines/seo-weekly.yaml`):
+
+```yaml
+name: weekly-seo-rankings
+agent: SEO
+repo_dir: ~/Git/aidev-ops-client-seo-reports
+schedule: "0 9 * * 1"
+targets_cmd: "wp-helper --list-category client --jsonl"
+run_template: "/seo-export --account {{target.account}} --format summary"
+```
+
+`targets_cmd` should emit one JSON object per line so the scheduler can iterate targets.
+
+## Anti-Patterns
+
+- Repeating TODO items for routine execution
+- Running operational routines through `/full-loop`
+- Skipping pilot stages for outbound content
+- Mixing SOP logic, target selection, and schedule in one monolithic prompt

--- a/.agents/scripts/commands/routine.md
+++ b/.agents/scripts/commands/routine.md
@@ -104,7 +104,9 @@ targets_cmd: "wp-helper --list-category client --jsonl"
 run_template: "/seo-export --account {{target.account}} --format summary"
 ```
 
-`targets_cmd` should emit one JSON object per line so the scheduler can iterate targets.
+`targets_cmd` should emit one JSON object per line so a scheduler can iterate targets.
+
+Note: this template is architectural guidance. `routine-helper.sh` currently schedules a literal `--prompt` command and does not parse `targets_cmd` or `run_template` directly.
 
 ## Anti-Patterns
 

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -4,7 +4,10 @@ agent: Build+
 mode: subagent
 ---
 
-Dispatch one or more workers to handle tasks. Each worker runs `/full-loop` in its own session.
+Dispatch one or more workers to handle tasks. Pick the execution mode per task type:
+
+- **Code-change work** (repo edits, tests, PRs) -> `/full-loop`
+- **Operational work** (reports, audits, monitoring, outreach) -> direct command execution (no PR ceremony)
 
 Arguments: $ARGUMENTS
 
@@ -13,11 +16,12 @@ Arguments: $ARGUMENTS
 The runners system is intentionally simple:
 
 1. **You tell it what to work on** (task IDs, PR numbers, issue URLs, or descriptions)
-2. **It dispatches `opencode run "/full-loop ..."` for each item** — one worker per task
-3. **Each worker handles everything end-to-end** — branching, implementation, PR, CI, merge, deploy
+2. **It dispatches `opencode run` for each item** — one worker per task
+3. **Code workers** handle branch -> implementation -> PR -> CI -> merge
+4. **Ops workers** execute the requested SOP/command and report outcomes
 4. **No databases, no state machines, no complex bash pipelines**
 
-The `/full-loop` command is the worker. It already works. Runners just launches it.
+The supervisor handles dispatch. The worker command depends on the work type.
 
 ## Automated Mode: `/pulse`
 
@@ -27,7 +31,7 @@ For unattended operation, the `/pulse` command runs every 2 minutes via launchd.
 2. Fetches open issues and PRs from managed repos via `gh`
 3. Observes outcomes — files improvement issues for stuck/failed work
 4. Uses AI (sonnet) to pick the highest-value items to fill available slots
-5. Dispatches workers via `opencode run "/full-loop ..."`, routing to the right agent
+5. Dispatches workers via `opencode run`, routing to the right agent and execution mode
 
 See `scripts/commands/pulse.md` for the full spec.
 
@@ -172,16 +176,23 @@ gh issue view 42 --repo user/repo --json number,title,url
 
 ### Step 2: Dispatch Workers
 
-For each resolved item, launch a worker. Route to the appropriate agent based on the task domain (see `AGENTS.md` "Agent Routing"):
+For each resolved item, launch a worker. Route to the appropriate agent based on the task domain (see `AGENTS.md` "Agent Routing") and pick the execution mode:
 
 ```bash
 # For code tasks (Build+ is default — omit --agent)
 opencode run --dir ~/Git/<repo> --title "t083: <description>" \
   "/full-loop t083 -- <description>" &
 
-# For domain-specific tasks (route to specialist agent)
+# For code tasks in a specialist domain
 opencode run --dir ~/Git/<repo> --agent SEO --title "t084: <description>" \
   "/full-loop t084 -- <description>" &
+
+# For non-code operational tasks (no /full-loop)
+opencode run --dir ~/Git/<repo> --agent SEO --title "Weekly rankings" \
+  "/seo-export --account client-a --format summary" &
+
+# For recurring operations, schedule this command via launchd/cron
+# instead of queueing repeating TODO items
 
 # For PRs
 opencode run --dir ~/Git/<repo> --title "PR #382: <title>" \
@@ -196,9 +207,11 @@ opencode run --dir ~/Git/<repo> --title "Issue #42: <title>" \
 - Use `--dir ~/Git/<repo-name>` matching the repo the task belongs to
 - Use `--agent <name>` to route to a specialist (SEO, Content, Marketing, etc.)
 - Omit `--agent` for code tasks — defaults to Build+
-- Do NOT add `--model` — let `/full-loop` use its default (opus)
+- Use `/full-loop` only when the task needs repo code changes and PR traceability
+- For non-code operations, run the task command directly (for example `/seo-export ...`)
+- Do NOT add `--model` unless escalation is required by workflow policy
 - **Background each dispatch with `&`** so multiple workers launch concurrently
-- Workers handle everything: branching, implementation, PR, CI, merge, deploy
+- Code workers handle branch/PR lifecycle; ops workers execute and report outcomes
 
 ### Step 3: Monitor
 
@@ -227,8 +240,8 @@ The supervisor (whether `/pulse` or `/runners`) NEVER does task work itself:
 - **Always** dispatches workers via `opencode run "/full-loop ..."`
 - **Always** routes to the right agent — not every task is code
 
-If a worker fails, the fix is to improve the worker's instructions (`/full-loop`),
-not to do the work for it. Each failure that gets fixed makes the next run more reliable.
+If a worker fails, improve the worker instructions/command definition,
+not the supervisor role. Each fixed failure improves the next run.
 
 **Self-improvement:** The supervisor observes outcomes from GitHub state (PRs, issues, timelines) and files improvement issues for systemic problems. See `AGENTS.md` "Self-Improvement" for the universal principle. The supervisor never maintains separate state — TODO.md, PLANS.md, and GitHub are the database.
 

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -237,7 +237,7 @@ The supervisor (whether `/pulse` or `/runners`) NEVER does task work itself:
 - **Never** reads source code or implements features
 - **Never** runs tests or linters on behalf of workers
 - **Never** pushes branches or resolves merge conflicts for workers
-- **Always** dispatches workers via `opencode run "/full-loop ..."`
+- **Always** dispatches workers via `opencode run` with the command chosen by task type
 - **Always** routes to the right agent — not every task is code
 
 If a worker fails, improve the worker instructions/command definition,

--- a/.agents/scripts/routine-helper.sh
+++ b/.agents/scripts/routine-helper.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# routine-helper.sh - Plan and install scheduled non-code routine runs
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+readonly DEFAULT_AGENT="Build+"
+readonly DEFAULT_TITLE="Scheduled routine"
+
+print_usage() {
+	cat <<'EOF'
+routine-helper.sh - Plan and install scheduled opencode routines
+
+Usage:
+  routine-helper.sh plan --name NAME --schedule "CRON" --dir PATH --prompt "..." [options]
+  routine-helper.sh install-launchd --name NAME --schedule "CRON" --dir PATH --prompt "..." [options]
+  routine-helper.sh install-cron --name NAME --schedule "CRON" --dir PATH --prompt "..." [options]
+
+Options:
+  --name NAME       Routine name (used in labels/markers)
+  --schedule CRON   Cron schedule expression (five fields)
+  --dir PATH        Repository working directory for opencode run
+  --prompt TEXT     Command/prompt to execute (non-code ops should NOT use /full-loop)
+  --agent NAME      Agent name (default: Build+)
+  --title TEXT      Session title (default: Scheduled routine)
+  --model MODEL     Optional explicit model (default: runtime default)
+
+Examples:
+  routine-helper.sh plan --name seo-weekly --schedule "0 9 * * 1" \
+    --dir ~/Git/aidev-ops-client-seo-reports --agent SEO \
+    --title "Weekly rankings" --prompt "/seo-export --account client-a --format summary"
+
+  routine-helper.sh install-cron --name seo-weekly --schedule "0 9 * * 1" \
+    --dir ~/Git/aidev-ops-client-seo-reports --agent SEO \
+    --title "Weekly rankings" --prompt "/seo-export --account client-a --format summary"
+EOF
+	return 0
+}
+
+die() {
+	local message="$1"
+	printf '[ERROR] %s\n' "$message" >&2
+	return 1
+}
+
+validate_cron_expression() {
+	local schedule="$1"
+	local fields
+	fields=$(printf '%s' "$schedule" | awk '{print NF}')
+	if [[ "$fields" -ne 5 ]]; then
+		die "Schedule must have five cron fields: '$schedule'"
+		return 1
+	fi
+	return 0
+}
+
+validate_required() {
+	local value="$1"
+	local flag_name="$2"
+	if [[ -z "$value" ]]; then
+		die "Missing required option: $flag_name"
+		return 1
+	fi
+	return 0
+}
+
+require_option_value() {
+	local argc_remaining="$1"
+	local flag_name="$2"
+	if [[ "$argc_remaining" -lt 2 ]]; then
+		die "$flag_name requires a value"
+		return 1
+	fi
+	return 0
+}
+
+validate_routine_prompt() {
+	local prompt="$1"
+	if [[ "$prompt" == *"/full-loop"* ]]; then
+		printf '[WARN] Prompt includes /full-loop. For non-code routines, use direct task commands.\n' >&2
+	fi
+	return 0
+}
+
+shell_quote() {
+	local value="$1"
+	printf "'%s'" "${value//\'/\'\\\'\'}"
+	return 0
+}
+
+build_opencode_command() {
+	local dir="$1"
+	local prompt="$2"
+	local agent="$3"
+	local title="$4"
+	local model="$5"
+
+	local cmd
+	cmd="opencode run --dir $(shell_quote "$dir")"
+	if [[ -n "$agent" ]]; then
+		cmd+=" --agent $(shell_quote "$agent")"
+	fi
+	if [[ -n "$title" ]]; then
+		cmd+=" --title $(shell_quote "$title")"
+	fi
+	if [[ -n "$model" ]]; then
+		cmd+=" --model $(shell_quote "$model")"
+	fi
+	cmd+=" $(shell_quote "$prompt")"
+
+	printf '%s\n' "$cmd"
+	return 0
+}
+
+parse_cron_to_launchd_xml() {
+	local schedule="$1"
+	local minute=""
+	local hour=""
+	local day_of_month=""
+	local month=""
+	local weekday=""
+
+	read -r minute hour day_of_month month weekday <<<"$schedule"
+
+	local -a fields=("$minute" "$hour" "$day_of_month" "$month" "$weekday")
+	local value
+	for value in "${fields[@]}"; do
+		if [[ "$value" != "*" && ! "$value" =~ ^[0-9]+$ ]]; then
+			die "launchd install supports only '*' or numeric cron fields"
+			return 1
+		fi
+	done
+
+	printf '  <key>StartCalendarInterval</key>\n'
+	printf '  <array>\n'
+	printf '    <dict>\n'
+	if [[ "$minute" != "*" ]]; then
+		printf '      <key>Minute</key>\n'
+		printf '      <integer>%s</integer>\n' "$minute"
+	fi
+	if [[ "$hour" != "*" ]]; then
+		printf '      <key>Hour</key>\n'
+		printf '      <integer>%s</integer>\n' "$hour"
+	fi
+	if [[ "$day_of_month" != "*" ]]; then
+		printf '      <key>Day</key>\n'
+		printf '      <integer>%s</integer>\n' "$day_of_month"
+	fi
+	if [[ "$month" != "*" ]]; then
+		printf '      <key>Month</key>\n'
+		printf '      <integer>%s</integer>\n' "$month"
+	fi
+	if [[ "$weekday" != "*" ]]; then
+		# cron weekday: 0-7 (Sun), launchd: 0-7 (Sun)
+		printf '      <key>Weekday</key>\n'
+		printf '      <integer>%s</integer>\n' "$weekday"
+	fi
+	printf '    </dict>\n'
+	printf '  </array>\n'
+	return 0
+}
+
+parse_common_args() {
+	ROUTINE_NAME=""
+	ROUTINE_SCHEDULE=""
+	ROUTINE_DIR=""
+	ROUTINE_PROMPT=""
+	ROUTINE_AGENT="$DEFAULT_AGENT"
+	ROUTINE_TITLE="$DEFAULT_TITLE"
+	ROUTINE_MODEL=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--name)
+			require_option_value "$#" "$1" || return 1
+			ROUTINE_NAME="$2"
+			shift 2
+			;;
+		--schedule)
+			require_option_value "$#" "$1" || return 1
+			ROUTINE_SCHEDULE="$2"
+			shift 2
+			;;
+		--dir)
+			require_option_value "$#" "$1" || return 1
+			ROUTINE_DIR="$2"
+			shift 2
+			;;
+		--prompt)
+			require_option_value "$#" "$1" || return 1
+			ROUTINE_PROMPT="$2"
+			shift 2
+			;;
+		--agent)
+			require_option_value "$#" "$1" || return 1
+			ROUTINE_AGENT="$2"
+			shift 2
+			;;
+		--title)
+			require_option_value "$#" "$1" || return 1
+			ROUTINE_TITLE="$2"
+			shift 2
+			;;
+		--model)
+			require_option_value "$#" "$1" || return 1
+			ROUTINE_MODEL="$2"
+			shift 2
+			;;
+		--help | -h)
+			print_usage
+			return 2
+			;;
+		*)
+			die "Unknown option: $1"
+			return 1
+			;;
+		esac
+	done
+
+	validate_required "$ROUTINE_NAME" "--name" || return 1
+	validate_required "$ROUTINE_SCHEDULE" "--schedule" || return 1
+	validate_required "$ROUTINE_DIR" "--dir" || return 1
+	validate_required "$ROUTINE_PROMPT" "--prompt" || return 1
+	validate_cron_expression "$ROUTINE_SCHEDULE" || return 1
+	validate_routine_prompt "$ROUTINE_PROMPT" || return 1
+
+	return 0
+}
+
+cmd_plan() {
+	parse_common_args "$@" || {
+		local rc=$?
+		[[ $rc -eq 2 ]] && return 0
+		return 1
+	}
+
+	local command
+	command=$(build_opencode_command "$ROUTINE_DIR" "$ROUTINE_PROMPT" "$ROUTINE_AGENT" "$ROUTINE_TITLE" "$ROUTINE_MODEL")
+
+	local launchd_schedule_xml=""
+	launchd_schedule_xml=$(parse_cron_to_launchd_xml "$ROUTINE_SCHEDULE" 2>/dev/null || true)
+
+	printf 'Routine Name: %s\n' "$ROUTINE_NAME"
+	printf 'Schedule: %s\n' "$ROUTINE_SCHEDULE"
+	printf 'Command: %s\n\n' "$command"
+
+	printf 'Cron entry:\n'
+	printf "%s %s >> \$HOME/.aidevops/logs/routine-%s.log 2>&1 # aidevops: routine-%s\n\n" \
+		"$ROUTINE_SCHEDULE" "$command" "$ROUTINE_NAME" "$ROUTINE_NAME"
+
+	printf 'launchd label: sh.aidevops.routine-%s\n' "$ROUTINE_NAME"
+	printf 'launchd plist: ~/Library/LaunchAgents/sh.aidevops.routine-%s.plist\n' "$ROUTINE_NAME"
+	if [[ -n "$launchd_schedule_xml" ]]; then
+		printf 'launchd schedule conversion: supported\n'
+	else
+		printf 'launchd schedule conversion: unsupported (use cron for this expression)\n'
+	fi
+	return 0
+}
+
+cmd_install_cron() {
+	parse_common_args "$@" || {
+		local rc=$?
+		[[ $rc -eq 2 ]] && return 0
+		return 1
+	}
+
+	local command
+	command=$(build_opencode_command "$ROUTINE_DIR" "$ROUTINE_PROMPT" "$ROUTINE_AGENT" "$ROUTINE_TITLE" "$ROUTINE_MODEL")
+
+	mkdir -p "$HOME/.aidevops/logs"
+	local marker="# aidevops: routine-${ROUTINE_NAME}"
+	local entry
+	entry="$ROUTINE_SCHEDULE $command >> $HOME/.aidevops/logs/routine-${ROUTINE_NAME}.log 2>&1 $marker"
+
+	local current
+	current=$(crontab -l 2>/dev/null || true)
+	if printf '%s\n' "$current" | grep -Fq "$marker"; then
+		die "Cron entry already exists for routine '${ROUTINE_NAME}'"
+		return 1
+	fi
+
+	(
+		printf '%s\n' "$current"
+		printf '%s\n' "$entry"
+	) | crontab -
+	printf '[OK] Installed cron routine: %s\n' "$ROUTINE_NAME"
+	return 0
+}
+
+cmd_install_launchd() {
+	parse_common_args "$@" || {
+		local rc=$?
+		[[ $rc -eq 2 ]] && return 0
+		return 1
+	}
+
+	local command
+	command=$(build_opencode_command "$ROUTINE_DIR" "$ROUTINE_PROMPT" "$ROUTINE_AGENT" "$ROUTINE_TITLE" "$ROUTINE_MODEL")
+
+	local launchd_schedule_xml
+	launchd_schedule_xml=$(parse_cron_to_launchd_xml "$ROUTINE_SCHEDULE") || return 1
+
+	local plist_dir="$HOME/Library/LaunchAgents"
+	local plist_name="sh.aidevops.routine-${ROUTINE_NAME}.plist"
+	local plist_path="$plist_dir/$plist_name"
+
+	mkdir -p "$plist_dir" "$HOME/.aidevops/logs"
+
+	cat >"$plist_path" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>sh.aidevops.routine-${ROUTINE_NAME}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-lc</string>
+    <string>${command}</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>HOME</key>
+    <string>${HOME}</string>
+    <key>PATH</key>
+    <string>/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}</string>
+  </dict>
+${launchd_schedule_xml}
+  <key>StandardOutPath</key>
+  <string>${HOME}/.aidevops/logs/routine-${ROUTINE_NAME}.log</string>
+  <key>StandardErrorPath</key>
+  <string>${HOME}/.aidevops/logs/routine-${ROUTINE_NAME}.log</string>
+  <key>RunAtLoad</key>
+  <false/>
+</dict>
+</plist>
+EOF
+
+	printf '[OK] Wrote launchd plist: %s\n' "$plist_path"
+	printf '[INFO] launchd schedule mapped from cron: %s\n' "$ROUTINE_SCHEDULE"
+	printf '[INFO] Then load with: launchctl load %s\n' "$plist_path"
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	plan)
+		cmd_plan "$@"
+		return $?
+		;;
+	install-cron)
+		cmd_install_cron "$@"
+		return $?
+		;;
+	install-launchd)
+		cmd_install_launchd "$@"
+		return $?
+		;;
+	help | --help | -h)
+		print_usage
+		return 0
+		;;
+	*)
+		die "Unknown command: $command"
+		print_usage
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/routine-helper.sh
+++ b/.agents/scripts/routine-helper.sh
@@ -68,6 +68,15 @@ validate_required() {
 	return 0
 }
 
+validate_routine_name() {
+	local routine_name="$1"
+	if [[ ! "$routine_name" =~ ^[A-Za-z0-9_-]+$ ]]; then
+		die "Routine name must use only letters, digits, underscore, or hyphen"
+		return 1
+	fi
+	return 0
+}
+
 require_option_value() {
 	local argc_remaining="$1"
 	local flag_name="$2"
@@ -81,8 +90,20 @@ require_option_value() {
 validate_routine_prompt() {
 	local prompt="$1"
 	if [[ "$prompt" == *"/full-loop"* ]]; then
-		printf '[WARN] Prompt includes /full-loop. For non-code routines, use direct task commands.\n' >&2
+		die "Prompt must not include /full-loop for routine-helper workflows"
+		return 1
 	fi
+	return 0
+}
+
+xml_escape() {
+	local value="$1"
+	value="${value//&/&amp;}"
+	value="${value//</&lt;}"
+	value="${value//>/&gt;}"
+	value="${value//\"/&quot;}"
+	value="${value//\'/&apos;}"
+	printf '%s' "$value"
 	return 0
 }
 
@@ -225,6 +246,7 @@ parse_common_args() {
 	validate_required "$ROUTINE_SCHEDULE" "--schedule" || return 1
 	validate_required "$ROUTINE_DIR" "--dir" || return 1
 	validate_required "$ROUTINE_PROMPT" "--prompt" || return 1
+	validate_routine_name "$ROUTINE_NAME" || return 1
 	validate_cron_expression "$ROUTINE_SCHEDULE" || return 1
 	validate_routine_prompt "$ROUTINE_PROMPT" || return 1
 
@@ -304,6 +326,19 @@ cmd_install_launchd() {
 
 	local launchd_schedule_xml
 	launchd_schedule_xml=$(parse_cron_to_launchd_xml "$ROUTINE_SCHEDULE") || return 1
+	# launchd_schedule_xml is generated from validated numeric/* cron tokens only
+	# and emits fixed XML tags, so this block is already XML-safe.
+
+	local label_escaped
+	label_escaped=$(xml_escape "sh.aidevops.routine-${ROUTINE_NAME}")
+	local command_escaped
+	command_escaped=$(xml_escape "$command")
+	local home_escaped
+	home_escaped=$(xml_escape "$HOME")
+	local env_path_escaped
+	env_path_escaped=$(xml_escape "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}")
+	local log_path_escaped
+	log_path_escaped=$(xml_escape "${HOME}/.aidevops/logs/routine-${ROUTINE_NAME}.log")
 
 	local plist_dir="$HOME/Library/LaunchAgents"
 	local plist_name="sh.aidevops.routine-${ROUTINE_NAME}.plist"
@@ -317,25 +352,25 @@ cmd_install_launchd() {
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>sh.aidevops.routine-${ROUTINE_NAME}</string>
+  <string>${label_escaped}</string>
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
     <string>-lc</string>
-    <string>${command}</string>
+    <string>${command_escaped}</string>
   </array>
   <key>EnvironmentVariables</key>
   <dict>
     <key>HOME</key>
-    <string>${HOME}</string>
+    <string>${home_escaped}</string>
     <key>PATH</key>
-    <string>/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}</string>
+    <string>${env_path_escaped}</string>
   </dict>
 ${launchd_schedule_xml}
   <key>StandardOutPath</key>
-  <string>${HOME}/.aidevops/logs/routine-${ROUTINE_NAME}.log</string>
+  <string>${log_path_escaped}</string>
   <key>StandardErrorPath</key>
-  <string>${HOME}/.aidevops/logs/routine-${ROUTINE_NAME}.log</string>
+  <string>${log_path_escaped}</string>
   <key>RunAtLoad</key>
   <false/>
 </dict>


### PR DESCRIPTION
## Summary
- clarify that `/full-loop` is for code-change tasks while recurring operational tasks should run direct agent commands
- add `/routine` command guidance covering SOP/targets/schedule design, pilot rollout, and safety gates
- add `routine-helper.sh` to plan and install scheduled `opencode run` routines for cron/launchd usage

## Verification
- `shellcheck .agents/scripts/routine-helper.sh`
- `markdown-formatter check` for updated/new command docs and `.agents/AGENTS.md`
- `.agents/scripts/routine-helper.sh plan --name seo-weekly --schedule "0 9 * * 1" --dir "/tmp" --agent "SEO" --title "Weekly rankings" --prompt "/seo-export --account client-a --format summary"`

Closes #4250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guides for designing and scheduling recurring operational routines with workflow patterns
  * Clarified distinct execution modes for code changes versus operational tasks

* **New Features**
  * Introduced utility for planning and installing scheduled operational routines with customizable scheduling options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->