### PR TITLE
fix: address quality-debt review feedback (#4221, #4222, #4224)

### DIFF
--- a/.agents/scripts/email-thread-reconstruction.py
+++ b/.agents/scripts/email-thread-reconstruction.py
@@ -14,7 +14,6 @@ message_id and in_reply_to headers, and adds thread metadata to frontmatter:
 Also generates a thread index file listing all emails in chronological order per thread.
 """
 
-import os
 import sys
 import re
 from pathlib import Path
@@ -242,9 +241,7 @@ def generate_thread_index(threads, output_file):
         for i, email in enumerate(emails, 1):
             # Compute relative path from index file location to email file
             # Normalize separators to forward slashes for portable Markdown links
-            file_path = Path(
-                os.path.relpath(Path(email["file"]).resolve(), output_dir)
-            ).as_posix()
+            file_path = Path(email["file"]).resolve().relative_to(output_dir).as_posix()
             email_subject = email.get("subject", "No Subject")
             from_addr = email.get("from", "Unknown")
             date_sent = email.get("date_sent", "Unknown")

--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -2136,7 +2136,9 @@ resolve_rebase_conflicts() {
 		local skip_ai_resolution=false
 		if [[ -x "$prompt_guard_script" ]]; then
 			local scan_result
-			if ! scan_result=$("$prompt_guard_script" scan-file "$full_path"); then
+			scan_result=$("$prompt_guard_script" scan-file "$full_path")
+			local rc=$?
+			if [[ $rc -ne 0 ]]; then
 				log_warn "resolve_rebase_conflicts: scanner failed for $conflict_file — skipping AI resolution for safety"
 				skip_ai_resolution=true
 			elif [[ "$scan_result" == *"SUSPICIOUS"* || "$scan_result" == *"BLOCKED"* ]]; then

--- a/.agents/tools/context/context7-cli.md
+++ b/.agents/tools/context/context7-cli.md
@@ -56,7 +56,11 @@ npx -y ctx7 docs /facebook/react "useEffect examples" --json
 
 ```bash
 LIB_ID=$(npx -y ctx7 library react --json | jq -r '.library.id // empty')
-npx -y ctx7 docs "$LIB_ID" "how to memoize expensive renders" --json
+if [ -n "$LIB_ID" ]; then
+  npx -y ctx7 docs "$LIB_ID" "how to memoize expensive renders" --json
+else
+  echo "Error: Library 'react' not found." >&2
+fi
 ```
 
 ## Backend Selection Guidance


### PR DESCRIPTION
## Summary

- **#4221** — Replace `os.path.relpath()` + `Path()` with idiomatic `pathlib` `relative_to()` in `email-thread-reconstruction.py`, removing the now-unused `import os`
- **#4222** — Separate `local` declaration from command-substitution assignment and capture exit code in a `local rc` variable in `deploy.sh` (aligns with SC2181 best practice)
- **#4224** — Guard the one-shot lookup example in `context7-cli.md` with an empty-check on `LIB_ID` before calling `ctx7 docs`

All three are quality-debt items from merged-PR review feedback.

Closes #4221
Closes #4222
Closes #4224