### PR TITLE
t1457: enforce secret-safe command airlock

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -191,6 +191,15 @@ When referencing specific functions or code include the pattern `file_path:line_
 - NEVER expose credentials in output/logs
 - Store secrets via `aidevops secret set NAME` (gopass encrypted) or `~/.config/aidevops/credentials.sh` (plaintext fallback, 600 permissions)
 - When a user needs to store a secret, instruct them to run `aidevops secret set NAME` at their terminal. NEVER accept secret values in conversation.
+# 8.1 Session transcript exposure model (t1457)
+#    Threat: users assume "terminal command" means private, but commands run by
+#    AI tools and their output are usually captured in session transcripts and
+#    may be sent to a remote model provider in cloud-model mode.
+- Treat command input + stdout/stderr as transcript-visible by default. If printing it would be a secret leak in chat, it is also a leak in tool output.
+- When giving secret setup instructions, start with an explicit warning line: `WARNING: Never paste secret values into AI chat. Run the command in your terminal and enter the value at the hidden prompt.`
+- Prefer secret-safe patterns that avoid printing values: key-name listings, masked previews, one-way fingerprints, and exit-code checks.
+- Avoid workflows that write raw secrets to temporary files (for example `/tmp/*.json`) unless there is no alternative and cleanup is immediate; prefer in-memory piping when possible.
+- If a command can expose secrets and no safe alternative exists, do not run it via AI tools. Instruct the user to run it locally and do not request pasted output.
 #
 # 8. Secret value leaking in conversation (t2846)
 #    Threat: agent suggests or runs commands whose output contains secret values,

--- a/.agents/scripts/generate-claude-agents.sh
+++ b/.agents/scripts/generate-claude-agents.sh
@@ -777,6 +777,8 @@ deny_rules = [
 
     # --- Secret exposure prevention ---
     "Bash(gopass show *)",
+    "Bash(pass show *)",
+    "Bash(op read *)",
     "Bash(cat ~/.config/aidevops/credentials.sh)",
 ]
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -19,6 +19,33 @@ readonly DEFAULT_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-cod
 readonly STATE_DIR="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
 readonly STATE_DB="${STATE_DIR}/state.db"
 readonly OPENCODE_BIN_DEFAULT="${OPENCODE_BIN:-opencode}"
+readonly SANDBOX_EXEC_HELPER="${SCRIPT_DIR}/sandbox-exec-helper.sh"
+readonly HEADLESS_SANDBOX_TIMEOUT_DEFAULT="${AIDEVOPS_HEADLESS_SANDBOX_TIMEOUT:-3600}"
+
+build_sandbox_passthrough_csv() {
+	local passthrough_csv=""
+	local seen_names=" "
+	local name
+
+	while IFS='=' read -r name _; do
+		case "$name" in
+		AIDEVOPS_* | PULSE_* | GH_* | GITHUB_* | OPENAI_* | ANTHROPIC_* | GOOGLE_* | OPENCODE_* | CLAUDE_* | XDG_* | REAL_HOME | TMPDIR | TMP | TEMP | RTK_* | VERIFY_*)
+			if [[ "$seen_names" == *" ${name} "* ]]; then
+				continue
+			fi
+			seen_names+="${name} "
+			if [[ -z "$passthrough_csv" ]]; then
+				passthrough_csv="$name"
+			else
+				passthrough_csv+=",$name"
+			fi
+			;;
+		esac
+	done < <(env)
+
+	printf '%s' "$passthrough_csv"
+	return 0
+}
 
 init_state_db() {
 	mkdir -p "$STATE_DIR" 2>/dev/null || true
@@ -714,8 +741,21 @@ cmd_run() {
 		# Subshell localises errexit so main shell state is never modified.
 		exit_code=$(
 			set +e
-			"${cmd[@]}" 2>&1 | tee "$output_file"
-			echo "${PIPESTATUS[0]}"
+			if [[ -x "$SANDBOX_EXEC_HELPER" ]]; then
+				local escaped_cmd passthrough_csv
+				printf -v escaped_cmd '%q ' "${cmd[@]}"
+				escaped_cmd="${escaped_cmd% }"
+				passthrough_csv="$(build_sandbox_passthrough_csv)"
+				if [[ -n "$passthrough_csv" ]]; then
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "$escaped_cmd" 2>&1 | tee "$output_file"
+				else
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "$escaped_cmd" 2>&1 | tee "$output_file"
+				fi
+				echo "${PIPESTATUS[0]}"
+			else
+				"${cmd[@]}" 2>&1 | tee "$output_file"
+				echo "${PIPESTATUS[0]}"
+			fi
 		) || true
 
 		local discovered_session

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -737,7 +737,7 @@ check_skill_frontmatter() {
 check_secret_policy() {
 	echo -e "${BLUE}Checking Secret Safety Policy...${NC}"
 
-	local policy_script=".agents/scripts/secret-policy-check.sh"
+	local policy_script=".agents/scripts/safety-policy-check.sh"
 	if [[ ! -x "$policy_script" ]]; then
 		print_error "Missing executable policy checker: $policy_script"
 		return 1

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -734,6 +734,24 @@ check_skill_frontmatter() {
 	return 0
 }
 
+check_secret_policy() {
+	echo -e "${BLUE}Checking Secret Safety Policy...${NC}"
+
+	local policy_script=".agents/scripts/secret-policy-check.sh"
+	if [[ ! -x "$policy_script" ]]; then
+		print_error "Missing executable policy checker: $policy_script"
+		return 1
+	fi
+
+	if bash "$policy_script"; then
+		print_success "Secret safety policy checks passed"
+		return 0
+	fi
+
+	print_error "Secret safety policy check failed"
+	return 1
+}
+
 # =============================================================================
 # Bundle-Aware Gate Filtering (t1364.6)
 # =============================================================================
@@ -847,6 +865,11 @@ main() {
 
 	if ! should_skip_gate "skill-frontmatter"; then
 		check_skill_frontmatter || exit_code=1
+		echo ""
+	fi
+
+	if ! should_skip_gate "secret-policy"; then
+		check_secret_policy || exit_code=1
 		echo ""
 	fi
 

--- a/.agents/scripts/safety-policy-check.sh
+++ b/.agents/scripts/safety-policy-check.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+
+check_generator_rules() {
+	local generator_file="${SCRIPT_DIR}/generate-claude-agents.sh"
+	if [[ ! -f "$generator_file" ]]; then
+		echo "FAIL: generator file missing: $generator_file" >&2
+		return 1
+	fi
+
+	python3 - "$generator_file" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8", errors="replace")
+
+def extract_block(name: str) -> str:
+    m = re.search(rf"{name}\s*=\s*\[(.*?)\]\n", text, re.S)
+    return m.group(1) if m else ""
+
+allow_block = extract_block("allow_rules")
+deny_block = extract_block("deny_rules")
+
+forbidden_in_allow = [
+    "Bash(gopass show *)",
+    "Bash(pass show *)",
+    "Bash(op read *)",
+    "Bash(cat ~/.config/aidevops/credentials.sh)",
+    "Read(~/.config/aidevops/credentials.sh)",
+]
+
+required_in_deny = [
+    "Bash(gopass show *)",
+    "Bash(pass show *)",
+    "Bash(op read *)",
+    "Bash(cat ~/.config/aidevops/credentials.sh)",
+    "Read(~/.config/aidevops/credentials.sh)",
+]
+
+errors = []
+for rule in forbidden_in_allow:
+    if rule in allow_block:
+        errors.append(f"forbidden rule in allow_rules: {rule}")
+
+for rule in required_in_deny:
+    if rule not in deny_block:
+        errors.append(f"required deny rule missing: {rule}")
+
+if errors:
+    for err in errors:
+        print(f"FAIL: {err}", file=sys.stderr)
+    sys.exit(1)
+
+print("PASS: generator deny/allow secret rules")
+PY
+
+	return $?
+}
+
+check_policy_markers() {
+	local build_prompt="${SCRIPT_DIR}/../prompts/build.txt"
+	local sandbox_helper="${SCRIPT_DIR}/sandbox-exec-helper.sh"
+
+	if ! rg -q "Session transcript exposure model" "$build_prompt"; then
+		echo "FAIL: transcript exposure policy missing from build prompt" >&2
+		return 1
+	fi
+
+	if ! rg -q "Never paste secret values into AI chat" "$build_prompt"; then
+		echo "FAIL: mandatory warning guidance missing from build prompt" >&2
+		return 1
+	fi
+
+	if ! rg -q "_sandbox_emit_redacted_output" "$sandbox_helper"; then
+		echo "FAIL: sandbox output redaction function missing" >&2
+		return 1
+	fi
+
+	if ! rg -q "_sandbox_is_secret_tainted_command" "$sandbox_helper"; then
+		echo "FAIL: sandbox taint handling function missing" >&2
+		return 1
+	fi
+
+	echo "PASS: policy markers present"
+	return 0
+}
+
+main() {
+	check_generator_rules
+	check_policy_markers
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/safety-policy-check.sh
+++ b/.agents/scripts/safety-policy-check.sh
@@ -4,6 +4,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 
+pattern_exists() {
+	local pattern="$1"
+	local file_path="$2"
+
+	if command -v rg >/dev/null 2>&1; then
+		rg -q --fixed-strings "$pattern" "$file_path"
+		return $?
+	fi
+
+	grep -qF "$pattern" "$file_path"
+	return $?
+}
+
 check_generator_rules() {
 	local generator_file="${SCRIPT_DIR}/generate-claude-agents.sh"
 	if [[ ! -f "$generator_file" ]]; then
@@ -66,22 +79,22 @@ check_policy_markers() {
 	local build_prompt="${SCRIPT_DIR}/../prompts/build.txt"
 	local sandbox_helper="${SCRIPT_DIR}/sandbox-exec-helper.sh"
 
-	if ! rg -q "Session transcript exposure model" "$build_prompt"; then
+	if ! pattern_exists "Session transcript exposure model" "$build_prompt"; then
 		echo "FAIL: transcript exposure policy missing from build prompt" >&2
 		return 1
 	fi
 
-	if ! rg -q "Never paste secret values into AI chat" "$build_prompt"; then
+	if ! pattern_exists "Never paste secret values into AI chat" "$build_prompt"; then
 		echo "FAIL: mandatory warning guidance missing from build prompt" >&2
 		return 1
 	fi
 
-	if ! rg -q "_sandbox_emit_redacted_output" "$sandbox_helper"; then
+	if ! pattern_exists "_sandbox_emit_redacted_output" "$sandbox_helper"; then
 		echo "FAIL: sandbox output redaction function missing" >&2
 		return 1
 	fi
 
-	if ! rg -q "_sandbox_is_secret_tainted_command" "$sandbox_helper"; then
+	if ! pattern_exists "_sandbox_is_secret_tainted_command" "$sandbox_helper"; then
 		echo "FAIL: sandbox taint handling function missing" >&2
 		return 1
 	fi

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -16,6 +16,7 @@
 #   sandbox-exec-helper.sh run "command args"
 #   sandbox-exec-helper.sh run --timeout 60 --no-network "curl example.com"
 #   sandbox-exec-helper.sh run --network-tiering --worker-id w123 "curl example.com"
+#   sandbox-exec-helper.sh run --allow-secret-io "gopass show path"  # explicit override
 #   sandbox-exec-helper.sh run --passthrough "GITHUB_TOKEN,NPM_TOKEN" "npm publish"
 #   sandbox-exec-helper.sh audit [--last N]
 #   sandbox-exec-helper.sh config --show
@@ -35,9 +36,10 @@ LOG_PREFIX="SANDBOX"
 readonly SANDBOX_DIR="${HOME}/.aidevops/.agent-workspace/sandbox"
 readonly SANDBOX_LOG="${SANDBOX_DIR}/executions.jsonl"
 readonly SANDBOX_TMP_BASE="${SANDBOX_DIR}/tmp"
-readonly DEFAULT_TIMEOUT=120
-readonly MAX_TIMEOUT=3600
-readonly MAX_OUTPUT_BYTES=10485760 # 10MB per stream
+readonly SANDBOX_DEFAULT_TIMEOUT=120
+readonly SANDBOX_MAX_TIMEOUT=3600
+readonly SANDBOX_MAX_OUTPUT_BYTES=10485760 # 10MB per stream
+readonly SECRET_IO_GUARD_DEFAULT="true"
 
 # Minimal environment passthrough — only what's needed for basic operation
 readonly DEFAULT_PASSTHROUGH="PATH HOME USER LANG TERM SHELL"
@@ -84,6 +86,177 @@ log_execution() {
 		"$network_blocked" \
 		"$passthrough_vars" \
 		>>"$SANDBOX_LOG"
+}
+
+# Detect high-risk commands that could expose secret values in transcript output.
+# Returns 0 and prints a reason when command should be blocked.
+# Returns 1 when command appears safe.
+_sandbox_secret_block_reason() {
+	local command="$1"
+	local normalized
+	normalized="$(printf '%s' "$command" | tr '[:upper:]' '[:lower:]')"
+
+	if [[ "$normalized" =~ (^|[[:space:];|&])(gopass|pass)[[:space:]]+(show|cat)([[:space:]]|$) ]]; then
+		echo "password manager value read command"
+		return 0
+	fi
+
+	if [[ "$normalized" =~ (^|[[:space:];|&])op[[:space:]]+read([[:space:]]|$) ]]; then
+		echo "1Password secret read command"
+		return 0
+	fi
+
+	if [[ "$normalized" =~ (^|[[:space:];|&])cat[[:space:]]+([^[:space:]]*/)?(\.env([^[:space:]]*)?|credentials\.sh|[^[:space:]]*secret[^[:space:]]*)($|[[:space:];|&]) ]]; then
+		echo "file read command targeting likely secret material"
+		return 0
+	fi
+
+	if [[ "$normalized" =~ (^|[[:space:];|&])(echo|printenv)[[:space:]]+\$?[a-z_][a-z0-9_]*(secret|token|key|password|passwd|pwd|credential|client_secret|access_token)([[:space:];|&]|$) ]]; then
+		echo "environment variable value print command"
+		return 0
+	fi
+
+	if [[ "$normalized" =~ (^|[[:space:];|&])env[[:space:]]*\|[[:space:]]*(grep|rg)([[:space:];|&]|$) ]]; then
+		echo "environment dump piped to search command"
+		return 0
+	fi
+
+	if [[ "$normalized" =~ (^|[[:space:];|&])kubectl[[:space:]]+get[[:space:]]+secret([[:space:]]|$) ]]; then
+		echo "kubernetes secret read command"
+		return 0
+	fi
+
+	if [[ "$normalized" =~ (^|[[:space:];|&])docker[[:space:]]+inspect([[:space:]]|$) ]] || [[ "$normalized" =~ (^|[[:space:];|&])docker[[:space:]]+exec[[:space:]].*[[:space:]]env([[:space:];|&]|$) ]]; then
+		echo "docker environment inspection command"
+		return 0
+	fi
+
+	if [[ "$normalized" =~ (^|[[:space:];|&])pm2[[:space:]]+env([[:space:]]|$) ]]; then
+		echo "pm2 environment dump command"
+		return 0
+	fi
+
+	return 1
+}
+
+# Determine whether command/output should be treated as secret-tainted.
+# Tainted commands get stronger output handling (warning + redaction).
+_sandbox_is_secret_tainted_command() {
+	local command="$1"
+	local normalized
+	normalized="$(printf '%s' "$command" | tr '[:upper:]' '[:lower:]')"
+
+	if _sandbox_secret_block_reason "$command" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	if [[ "$normalized" =~ oauth/access_token|client_secret|access_token|refresh_token|authorization:[[:space:]]*bearer ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+# Redact likely secret values from a captured output file.
+# Arguments: $1=file path, $2=stream name (stdout|stderr)
+_sandbox_emit_redacted_output() {
+	local output_file="$1"
+	local stream_name="$2"
+	local tainted_flag="$3"
+
+	if [[ ! -f "$output_file" ]] || [[ ! -s "$output_file" ]]; then
+		return 0
+	fi
+
+	local truncated_file
+	truncated_file="$(mktemp)"
+	head -c "$SANDBOX_MAX_OUTPUT_BYTES" "$output_file" >"$truncated_file"
+
+	if [[ "$tainted_flag" == "true" ]]; then
+		local warning_msg="[sandbox] WARNING: secret-tainted command detected — output is redacted"
+		if [[ "$stream_name" == "stderr" ]]; then
+			printf '%s\n' "$warning_msg" >&2
+		else
+			printf '%s\n' "$warning_msg"
+		fi
+	fi
+
+	if command -v python3 >/dev/null 2>&1; then
+		if [[ "$stream_name" == "stderr" ]]; then
+			python3 - "$truncated_file" <<'PY' >&2
+import os
+import re
+import sys
+
+path = sys.argv[1]
+try:
+    text = open(path, "r", encoding="utf-8", errors="replace").read()
+except Exception:
+    sys.exit(0)
+
+candidate_values = []
+for key, value in os.environ.items():
+    upper = key.upper()
+    if any(token in upper for token in ["SECRET", "TOKEN", "PASSWORD", "API_KEY", "ACCESS_KEY", "PRIVATE_KEY", "CLIENT_SECRET", "AUTH"]):
+        if value and len(value) >= 8:
+            candidate_values.append(value)
+
+for value in sorted(set(candidate_values), key=len, reverse=True):
+    text = text.replace(value, "[REDACTED_SECRET]")
+
+patterns = [
+    (re.compile(r'(?i)(authorization\s*:\s*bearer\s+)([A-Za-z0-9._~+/=-]+)'), r'\1[REDACTED_SECRET]'),
+    (re.compile(r'(?i)(access_token|refresh_token|client_secret|api[_-]?key|password|token|secret)(\s*[:=]\s*)("?[^"\s,}]+"?)'), r'\1\2"[REDACTED_SECRET]"'),
+]
+
+for pattern, repl in patterns:
+    text = pattern.sub(repl, text)
+
+sys.stdout.write(text)
+PY
+		else
+			python3 - "$truncated_file" <<'PY'
+import os
+import re
+import sys
+
+path = sys.argv[1]
+try:
+    text = open(path, "r", encoding="utf-8", errors="replace").read()
+except Exception:
+    sys.exit(0)
+
+candidate_values = []
+for key, value in os.environ.items():
+    upper = key.upper()
+    if any(token in upper for token in ["SECRET", "TOKEN", "PASSWORD", "API_KEY", "ACCESS_KEY", "PRIVATE_KEY", "CLIENT_SECRET", "AUTH"]):
+        if value and len(value) >= 8:
+            candidate_values.append(value)
+
+for value in sorted(set(candidate_values), key=len, reverse=True):
+    text = text.replace(value, "[REDACTED_SECRET]")
+
+patterns = [
+    (re.compile(r'(?i)(authorization\s*:\s*bearer\s+)([A-Za-z0-9._~+/=-]+)'), r'\1[REDACTED_SECRET]'),
+    (re.compile(r'(?i)(access_token|refresh_token|client_secret|api[_-]?key|password|token|secret)(\s*[:=]\s*)("?[^"\s,}]+"?)'), r'\1\2"[REDACTED_SECRET]"'),
+]
+
+for pattern, repl in patterns:
+    text = pattern.sub(repl, text)
+
+sys.stdout.write(text)
+PY
+		fi
+	else
+		if [[ "$stream_name" == "stderr" ]]; then
+			cat "$truncated_file" >&2
+		else
+			cat "$truncated_file"
+		fi
+	fi
+
+	rm -f "$truncated_file"
+	return 0
 }
 
 # =============================================================================
@@ -242,21 +415,23 @@ _sandbox_check_dns_exfil() {
 # =============================================================================
 
 sandbox_run() {
-	local timeout_secs="$DEFAULT_TIMEOUT"
+	local timeout_secs="$SANDBOX_DEFAULT_TIMEOUT"
 	local block_network=false
 	local network_tiering=false
+	local allow_secret_io=false
 	local worker_id="sandbox-$$"
 	local extra_passthrough=""
 	local command=""
+	local secret_io_guard="${AIDEVOPS_BLOCK_SECRET_IO:-$SECRET_IO_GUARD_DEFAULT}"
 
 	# Parse arguments
 	while [[ $# -gt 0 ]]; do
 		case $1 in
 		--timeout)
 			timeout_secs="$2"
-			if ((timeout_secs > MAX_TIMEOUT)); then
-				log_sandbox "WARN" "Timeout capped at ${MAX_TIMEOUT}s (requested ${timeout_secs}s)"
-				timeout_secs=$MAX_TIMEOUT
+			if ((timeout_secs > SANDBOX_MAX_TIMEOUT)); then
+				log_sandbox "WARN" "Timeout capped at ${SANDBOX_MAX_TIMEOUT}s (requested ${timeout_secs}s)"
+				timeout_secs=$SANDBOX_MAX_TIMEOUT
 			fi
 			shift 2
 			;;
@@ -266,6 +441,10 @@ sandbox_run() {
 			;;
 		--network-tiering)
 			network_tiering=true
+			shift
+			;;
+		--allow-secret-io)
+			allow_secret_io=true
 			shift
 			;;
 		--worker-id)
@@ -291,6 +470,16 @@ sandbox_run() {
 	if [[ -z "$command" ]]; then
 		log_sandbox "ERROR" "No command provided"
 		return 1
+	fi
+
+	if [[ "$secret_io_guard" == "true" ]] && [[ "$allow_secret_io" != "true" ]]; then
+		local block_reason
+		if block_reason="$(_sandbox_secret_block_reason "$command")"; then
+			log_sandbox "ERROR" "Blocked command due to secret leak risk: ${block_reason}"
+			log_sandbox "ERROR" "Use --allow-secret-io only for explicit user-approved local operations"
+			log_execution "$command" 126 0 "$timeout_secs" "$block_network" "$extra_passthrough"
+			return 126
+		fi
 	fi
 
 	# Create isolated temp directory
@@ -346,6 +535,10 @@ sandbox_run() {
 	local start_time
 	start_time="$(date +%s)"
 	local exit_code=0
+	local command_tainted=false
+	if _sandbox_is_secret_tainted_command "$command"; then
+		command_tainted=true
+	fi
 
 	# Execute with timeout and clean environment
 	if [[ "$block_network" == true ]] && command -v sandbox-exec &>/dev/null; then
@@ -375,13 +568,9 @@ sandbox_run() {
 		log_sandbox "WARN" "Command timed out after ${timeout_secs}s"
 	fi
 
-	# Output results (truncated to MAX_OUTPUT_BYTES)
-	if [[ -f "$stdout_file" ]] && [[ -s "$stdout_file" ]]; then
-		head -c "$MAX_OUTPUT_BYTES" "$stdout_file"
-	fi
-	if [[ -f "$stderr_file" ]] && [[ -s "$stderr_file" ]]; then
-		head -c "$MAX_OUTPUT_BYTES" "$stderr_file" >&2
-	fi
+	# Output results with redaction and taint-aware handling
+	_sandbox_emit_redacted_output "$stdout_file" "stdout" "$command_tainted"
+	_sandbox_emit_redacted_output "$stderr_file" "stderr" "$command_tainted"
 
 	# Audit log
 	log_execution "$command" "$exit_code" "$duration" "$timeout_secs" "$block_network" "$extra_passthrough"
@@ -434,8 +623,9 @@ sandbox_config() {
 	echo "Sandbox configuration:"
 	echo "  Log:          ${SANDBOX_LOG}"
 	echo "  Tmp base:     ${SANDBOX_TMP_BASE}"
-	echo "  Timeout:      ${DEFAULT_TIMEOUT}s (max ${MAX_TIMEOUT}s)"
-	echo "  Max output:   $((MAX_OUTPUT_BYTES / 1048576))MB per stream"
+	echo "  Timeout:      ${SANDBOX_DEFAULT_TIMEOUT}s (max ${SANDBOX_MAX_TIMEOUT}s)"
+	echo "  Max output:   $((SANDBOX_MAX_OUTPUT_BYTES / 1048576))MB per stream"
+	echo "  Secret guard: ${AIDEVOPS_BLOCK_SECRET_IO:-$SECRET_IO_GUARD_DEFAULT}"
 	echo "  Passthrough:  ${DEFAULT_PASSTHROUGH}"
 	echo "  Net tiering:  $([ -x "$NET_TIER_HELPER" ] && echo "available" || echo "not found")"
 	echo ""
@@ -466,6 +656,7 @@ Run options:
   --timeout N                Timeout in seconds (default: 120, max: 3600)
   --no-network               Block network access (macOS only, uses seatbelt)
   --network-tiering          Enable domain classification and logging (t1412.3)
+  --allow-secret-io          Bypass secret-output guard for this command only
   --worker-id ID             Worker identifier for network tier logs
   --passthrough "VAR1,VAR2"  Additional env vars to pass through
 
@@ -474,6 +665,7 @@ Examples:
   sandbox-exec-helper.sh run --timeout 60 "npm test"
   sandbox-exec-helper.sh run --no-network "python3 script.py"
   sandbox-exec-helper.sh run --network-tiering --worker-id w123 "curl https://api.github.com/repos"
+  sandbox-exec-helper.sh run --allow-secret-io "gopass show aidevops/EXAMPLE"
   sandbox-exec-helper.sh run --passthrough "GITHUB_TOKEN" "gh pr list"
   sandbox-exec-helper.sh audit --last 10
 
@@ -481,6 +673,7 @@ Security model:
   - Environment cleared (env -i) with minimal passthrough
   - Each execution gets isolated TMPDIR
   - Configurable timeout with hard kill
+  - Secret-output command guard blocks likely credential leakage patterns
   - Optional network blocking (macOS seatbelt)
   - Network domain tiering: classify, log, flag unknown domains (t1412.3)
   - All executions logged to JSONL audit trail

--- a/.agents/scripts/tests/test-sandbox-sensitive-output-guard.sh
+++ b/.agents/scripts/tests/test-sandbox-sensitive-output-guard.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../sandbox-exec-helper.sh"
+
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+readonly RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_HOME="${HOME}"
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$GREEN" "$RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$RED" "$RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT="$(mktemp -d)"
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "$HOME"
+	return 0
+}
+
+teardown_test_env() {
+	export HOME="$ORIGINAL_HOME"
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+test_blocks_risky_env_print_command() {
+	local output
+	local exit_code
+
+	set +e
+	output="$($HELPER run "echo \$SHOPIFY_CLIENT_SECRET" 2>&1)"
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 126 ]] && [[ "$output" == *"Blocked command due to secret leak risk"* ]]; then
+		print_result "blocks risky env var print command" 0
+	else
+		print_result "blocks risky env var print command" 1 "exit=$exit_code output=$output"
+	fi
+	return 0
+}
+
+test_allows_safe_command() {
+	local output
+	local exit_code
+
+	set +e
+	output="$($HELPER run "printf safe" 2>&1)"
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"safe"* ]]; then
+		print_result "allows safe command" 0
+	else
+		print_result "allows safe command" 1 "exit=$exit_code output=$output"
+	fi
+	return 0
+}
+
+test_override_flag_allows_blocked_pattern() {
+	local output
+	local exit_code
+
+	set +e
+	output="$($HELPER run --allow-secret-io "echo \$SHOPIFY_CLIENT_SECRET" 2>&1)"
+	exit_code=$?
+	set -e
+
+	if [[ "$exit_code" -eq 0 ]]; then
+		print_result "allow-secret-io bypass works" 0
+	else
+		print_result "allow-secret-io bypass works" 1 "exit=$exit_code output=$output"
+	fi
+	return 0
+}
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+
+	test_blocks_risky_env_print_command
+	test_allows_safe_command
+	test_override_flag_allows_blocked_pattern
+
+	echo ""
+	printf 'Tests run: %d\n' "$TESTS_RUN"
+	printf 'Failures:  %d\n' "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/.agents/tools/security/opsec.md
+++ b/.agents/tools/security/opsec.md
@@ -70,6 +70,17 @@ AI agents that process untrusted content (web pages, MCP tool outputs, user uplo
 
 **Full reference**: `tools/security/prompt-injection-defender.md` — detailed threat model, integration patterns for any agentic app, pattern database, credential isolation, and developer guidance for building injection-resistant applications.
 
+## Secret-Safe Command Policy
+
+Session safety model for AI-assisted terminals:
+
+- Treat tool commands and tool output as transcript-visible. If stdout/stderr contains a secret, assume it is exposed.
+- In cloud-model mode, transcript-visible content may be sent to the model provider.
+- Start secret setup instructions with: `WARNING: Never paste secret values into AI chat. Run the command in your terminal and enter the value at the hidden prompt.`
+- Prefer key-name checks, masked previews, or fingerprints over raw value display.
+- Avoid writing raw secrets to temporary files (`/tmp/*`) where possible; prefer in-memory handling and immediate cleanup.
+- If a command cannot be made secret-safe, do not run it via AI tools. Instruct the user to run it locally and never ask them to paste the output.
+
 ## Platform Trust Matrix
 
 ### Messaging Platforms — Privacy Comparison

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -135,7 +135,7 @@ jobs:
     - name: Secret Safety Policy Check
       run: |
         echo "Running secret safety policy checks..."
-        bash .agents/scripts/secret-policy-check.sh
+        bash .agents/scripts/safety-policy-check.sh
         echo "Secret safety policy checks passed"
 
   sonarcloud:

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -132,6 +132,12 @@ jobs:
         echo ""
         echo "All shell scripts passed ShellCheck"
 
+    - name: Secret Safety Policy Check
+      run: |
+        echo "Running secret safety policy checks..."
+        bash .agents/scripts/secret-policy-check.sh
+        echo "Secret safety policy checks passed"
+
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- route provider-aware headless runtime launches through `sandbox-exec-helper.sh` with controlled env passthrough
- add secret-taint detection plus stdout/stderr redaction in sandbox execution
- enforce deny-rule and policy-marker checks via `safety-policy-check.sh` in both local linting and CI
- extend deny rules for `pass show` and `op read`, and document transcript exposure model

## Validation
- `shellcheck -e SC1091 .agents/scripts/sandbox-exec-helper.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/generate-claude-agents.sh .agents/scripts/linters-local.sh .agents/scripts/safety-policy-check.sh .agents/scripts/tests/test-sandbox-sensitive-output-guard.sh`
- `bash .agents/scripts/tests/test-sandbox-sensitive-output-guard.sh`
- `bash .agents/scripts/safety-policy-check.sh`
- `bash .agents/scripts/headless-runtime-helper.sh help >/dev/null`
- `bash .agents/scripts/sandbox-exec-helper.sh config --show >/dev/null`

Closes #4254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced sandboxed command execution with configurable timeouts and selective environment variable pass-through
  * Added sensitive output redaction and automatic secret detection for command outputs
  * Implemented automatic security policy validation checks integrated into CI/CD workflows

* **Documentation**
  * Expanded security guidance covering session transcript exposure scenarios and secret-safe command patterns

* **Tests**
  * Added comprehensive tests for sensitive output handling and redaction capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->