### PR TITLE
fix: pass state file path instead of inlining content to avoid Linux E2BIG

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1291,16 +1291,18 @@ run_pulse() {
 	start_epoch=$(date +%s)
 	echo "[pulse-wrapper] Starting pulse at $(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$WRAPPER_LOGFILE"
 
-	# Build the prompt: /pulse + pre-fetched state
+	# Build the prompt: /pulse + reference to pre-fetched state file.
+	# The state is NOT inlined into the prompt — on Linux, execve() enforces
+	# MAX_ARG_STRLEN (128KB per argument) and the state routinely exceeds this,
+	# causing "Argument list too long" on every pulse invocation. The agent
+	# reads the file via its Read tool instead. See: #4257
 	local prompt="/pulse"
 	if [[ -f "$STATE_FILE" ]]; then
-		local state_content
-		state_content=$(cat "$STATE_FILE")
 		prompt="/pulse
 
---- PRE-FETCHED STATE (from pulse-wrapper.sh) ---
-${state_content}
---- END PRE-FETCHED STATE ---"
+Pre-fetched state file: ${STATE_FILE}
+Read this file before proceeding — it contains the current repo/PR/issue state
+gathered by pulse-wrapper.sh BEFORE this session started."
 	fi
 
 	# Run the provider-aware headless wrapper in background.


### PR DESCRIPTION
## Summary

- Stop inlining 135KB+ pre-fetched state into the pulse prompt argument
- Pass a file path reference instead — agent reads the file via Read tool

## Problem

On Linux, `execve()` enforces `MAX_ARG_STRLEN` = 128KB per argument. The pre-fetched state (currently 135,606 bytes) was embedded in `$prompt` and passed through **two** `execve()` calls:

1. `pulse-wrapper.sh` → `headless-runtime-helper.sh --prompt "$prompt"` → **E2BIG**
2. `headless-runtime-helper.sh` → `opencode run "$prompt"` → **also E2BIG**

Every pulse invocation on Linux failed instantly with `Argument list too long`, producing only "Starting pulse" log entries. Backfill amplified this to ~120 failed starts per hour.

macOS has no per-argument limit (only total ARG_MAX), so this was never hit during development.

## Fix

Instead of `cat "$STATE_FILE"` into the prompt variable, pass a reference:

```
/pulse

Pre-fetched state file: ~/.aidevops/logs/pulse-state.txt
Read this file before proceeding — it contains the current repo/PR/issue state
gathered by pulse-wrapper.sh BEFORE this session started.
```

Prompt drops from 135KB to ~200 bytes. The agent reads the file via its Read tool — one extra tool call per pulse, but:
- Works on any state size (no 128KB ceiling)
- Works on both Linux and macOS
- State file was already on disk (`prefetch_state()` creates it)

## Verification

- `bash -n`: pass
- `shellcheck`: clean
- Prompt size: ~200 bytes (well under 128KB limit)
- `STATE_FILE` path unchanged: `~/.aidevops/logs/pulse-state.txt`

Closes #4257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved argument-length limitations in state handling by optimizing how state information is communicated. The system now provides file path references instead of embedding full state content in prompts, enabling agents to access pre-fetched state information separately. This prevents potential argument-length overflow issues while maintaining complete state availability and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->