### PR TITLE
t1456: refresh profile README hourly with dynamic sections

### DIFF
--- a/.agents/configs/aidevops-profile-readme-update.timer
+++ b/.agents/configs/aidevops-profile-readme-update.timer
@@ -1,4 +1,4 @@
-# systemd user timer for profile README auto-update — runs daily at 06:00
+# systemd user timer for profile README auto-update — runs hourly
 #
 # Install:
 #   mkdir -p ~/.config/systemd/user
@@ -8,10 +8,10 @@
 #   systemctl --user enable --now aidevops-profile-readme-update.timer
 
 [Unit]
-Description=aidevops profile README update timer (daily at 06:00)
+Description=aidevops profile README update timer (hourly)
 
 [Timer]
-OnCalendar=*-*-* 06:00:00
+OnCalendar=hourly
 Persistent=true
 
 [Install]

--- a/.agents/configs/sh.aidevops.profile-readme-update.plist
+++ b/.agents/configs/sh.aidevops.profile-readme-update.plist
@@ -10,13 +10,8 @@
 		<string>-c</string>
 		<string>$HOME/.aidevops/agents/scripts/profile-readme-helper.sh update >> $HOME/.aidevops/.agent-workspace/logs/profile-readme-update.log 2>&1</string>
 	</array>
-	<key>StartCalendarInterval</key>
-	<dict>
-		<key>Hour</key>
-		<integer>6</integer>
-		<key>Minute</key>
-		<integer>0</integer>
-	</dict>
+	<key>StartInterval</key>
+	<integer>3600</integer>
 	<key>RunAtLoad</key>
 	<false/>
 	<key>StandardOutPath</key>

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -682,6 +682,48 @@ _sanitize_url() {
 	return 0
 }
 
+# --- Resolve GitHub username for profile repo ---
+_resolve_profile_user() {
+	local profile_repo="$1"
+
+	# Try origin remote first (owner/repo)
+	local origin_url
+	origin_url=$(git -C "$profile_repo" remote get-url origin 2>/dev/null || true)
+	if [[ -n "$origin_url" ]]; then
+		local slug
+		slug=$(echo "$origin_url" | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')
+		local owner repo
+		owner="${slug%%/*}"
+		repo="${slug##*/}"
+		if [[ -n "$owner" && "$owner" == "$repo" ]]; then
+			echo "$owner"
+			return 0
+		fi
+	fi
+
+	# Fallback to directory basename
+	local base
+	base=$(basename "$profile_repo")
+	if [[ -n "$base" ]]; then
+		echo "$base"
+		return 0
+	fi
+
+	echo ""
+	return 0
+}
+
+# --- Normalize README for no-op comparison ---
+_normalize_readme_for_compare() {
+	local file="$1"
+	awk '
+		/<!-- UPDATED-START -->/ { print; skip = 1; next }
+		/<!-- UPDATED-END -->/ { skip = 0; print; next }
+		!skip { print }
+	' "$file"
+	return 0
+}
+
 # --- Generate rich profile README from GitHub data ---
 _generate_rich_readme() {
 	local gh_user="$1"
@@ -944,7 +986,7 @@ cmd_init() {
 	echo "  https://github.com/${repo_slug}"
 	echo "and click the 'Show on profile' button if prompted."
 	echo ""
-	echo "Stats will auto-update daily at 06:00 (configured by setup.sh)."
+	echo "Stats will auto-update hourly (configured by setup.sh)."
 
 	return 0
 }
@@ -966,40 +1008,42 @@ cmd_update() {
 		return 1
 	fi
 
-	# Check for markers
-	if ! grep -q '<!-- STATS-START -->' "$readme_path"; then
-		echo "Error: <!-- STATS-START --> marker not found in $readme_path" >&2
-		return 1
-	fi
-	if ! grep -q '<!-- STATS-END -->' "$readme_path"; then
-		echo "Error: <!-- STATS-END --> marker not found in $readme_path" >&2
-		return 1
-	fi
-
-	# Generate new stats
+	# Generate new stats section
 	local new_stats
 	new_stats=$(cmd_generate)
+
+	# Build dynamic README first (badges, projects, contributions), then inject stats
+	# Fallback to existing README if GitHub API/auth is unavailable.
+	local source_file
+	local dynamic_tmp
+	dynamic_tmp=$(mktemp)
+	source_file="$readme_path"
+
+	if command -v gh &>/dev/null && gh auth status &>/dev/null; then
+		local gh_user
+		gh_user=$(_resolve_profile_user "$profile_repo")
+		if [[ -n "$gh_user" ]]; then
+			if _generate_rich_readme "$gh_user" "$dynamic_tmp"; then
+				source_file="$dynamic_tmp"
+			fi
+		fi
+	fi
+
+	# Ensure markers exist in the source content
+	if ! grep -q '<!-- STATS-START -->' "$source_file"; then
+		echo "Error: <!-- STATS-START --> marker not found in source content" >&2
+		rm -f "$dynamic_tmp"
+		return 1
+	fi
+	if ! grep -q '<!-- STATS-END -->' "$source_file"; then
+		echo "Error: <!-- STATS-END --> marker not found in source content" >&2
+		rm -f "$dynamic_tmp"
+		return 1
+	fi
 
 	# Replace content between markers
 	local tmp_file
 	tmp_file=$(mktemp)
-
-	# Use awk to replace between markers (bash 3.2 compatible)
-	awk '
-		/<!-- STATS-START -->/ {
-			print "<!-- STATS-START -->"
-			skip = 1
-			next
-		}
-		/<!-- STATS-END -->/ {
-			skip = 0
-			# Print the new stats (will be injected via variable)
-			print ENVIRON["NEW_STATS"]
-			print "<!-- STATS-END -->"
-			next
-		}
-		!skip { print }
-	' "$readme_path" >"$tmp_file"
 
 	# Inject the stats via env var and re-run
 	NEW_STATS="$new_stats" awk '
@@ -1015,10 +1059,20 @@ cmd_update() {
 			next
 		}
 		!skip { print }
-	' "$readme_path" >"$tmp_file"
+	' "$source_file" >"$tmp_file"
+
+	# Check if content changed, ignoring UPDATED marker block
+	local old_normalized new_normalized
+	old_normalized=$(_normalize_readme_for_compare "$readme_path")
+	new_normalized=$(_normalize_readme_for_compare "$tmp_file")
+	if [[ "$old_normalized" == "$new_normalized" ]]; then
+		echo "No changes to profile content — skipping commit"
+		rm -f "$tmp_file" "$dynamic_tmp"
+		return 0
+	fi
 
 	# Update timestamp if markers exist
-	if grep -q '<!-- UPDATED-START -->' "$readme_path"; then
+	if grep -q '<!-- UPDATED-START -->' "$tmp_file"; then
 		local updated_at
 		updated_at=$(date -u +"%Y-%m-%d %H:%M UTC")
 		local updated_tmp
@@ -1043,23 +1097,13 @@ cmd_update() {
 	if [[ "$dry_run" == true ]]; then
 		echo "--- DRY RUN: would write to $readme_path ---"
 		diff "$readme_path" "$tmp_file" || true
-		rm -f "$tmp_file"
-		return 0
-	fi
-
-	# Check if content actually changed (ignore timestamp-only changes)
-	local old_stats new_stats_check
-	old_stats=$(awk '/<!-- STATS-START -->/{f=1;next}/<!-- STATS-END -->/{f=0}f' "$readme_path")
-	new_stats_check=$(awk '/<!-- STATS-START -->/{f=1;next}/<!-- STATS-END -->/{f=0}f' "$tmp_file")
-
-	if [[ "$old_stats" == "$new_stats_check" ]]; then
-		echo "No changes to stats — skipping commit"
-		rm -f "$tmp_file"
+		rm -f "$tmp_file" "$dynamic_tmp"
 		return 0
 	fi
 
 	# Apply changes
 	mv "$tmp_file" "$readme_path"
+	rm -f "$dynamic_tmp"
 
 	# Commit and push
 	local commit_msg

--- a/setup.sh
+++ b/setup.sh
@@ -1489,7 +1489,7 @@ ST_PLIST
 
 	# Profile README auto-update scheduled job.
 	# Only installed if user has a profile repo (priority: "profile") in repos.json.
-	# macOS: launchd plist (daily at 06:00) | Linux: cron (daily at 06:00)
+	# macOS: launchd plist (hourly) | Linux: cron (hourly)
 	if [[ -x "$pr_script" ]] && [[ "$has_profile_repo" == "true" ]]; then
 		mkdir -p "$HOME/.aidevops/.agent-workspace/logs"
 
@@ -1519,13 +1519,8 @@ ST_PLIST
 		<string>${_xml_pr_script}</string>
 		<string>update</string>
 	</array>
-	<key>StartCalendarInterval</key>
-	<dict>
-		<key>Hour</key>
-		<integer>6</integer>
-		<key>Minute</key>
-		<integer>0</integer>
-	</dict>
+	<key>StartInterval</key>
+	<integer>3600</integer>
 	<key>StandardOutPath</key>
 	<string>${_xml_pr_home}/.aidevops/.agent-workspace/logs/profile-readme-update.log</string>
 	<key>StandardErrorPath</key>
@@ -1552,20 +1547,20 @@ ST_PLIST
 PR_PLIST
 
 			if launchctl load "$pr_plist" 2>/dev/null; then
-				print_info "Profile README update enabled (launchd, daily at 06:00)"
+				print_info "Profile README update enabled (launchd, hourly)"
 			else
 				print_warning "Failed to load profile README update LaunchAgent"
 			fi
 		else
-			# Linux: cron entry (daily at 06:00)
+			# Linux: cron entry (hourly)
 			local _cron_pr_script
 			_cron_pr_script=$(_cron_escape "$pr_script")
 			(
 				crontab -l 2>/dev/null | grep -v 'aidevops: profile-readme-update'
-				echo "0 6 * * * /bin/bash ${_cron_pr_script} update >> \"\$HOME/.aidevops/.agent-workspace/logs/profile-readme-update.log\" 2>&1 # aidevops: profile-readme-update"
+				echo "0 * * * * /bin/bash ${_cron_pr_script} update >> \"\$HOME/.aidevops/.agent-workspace/logs/profile-readme-update.log\" 2>&1 # aidevops: profile-readme-update"
 			) | crontab - 2>/dev/null || true
 			if crontab -l 2>/dev/null | grep -qF "aidevops: profile-readme-update" 2>/dev/null; then
-				print_info "Profile README update enabled (cron, daily at 06:00)"
+				print_info "Profile README update enabled (cron, hourly)"
 			else
 				print_warning "Failed to install profile README update cron entry"
 			fi


### PR DESCRIPTION
## Summary
- switch profile README auto-update cadence from daily to hourly across setup-generated schedulers (launchd, cron, systemd template)
- update `profile-readme-helper.sh update` to regenerate dynamic sections (badges, projects, contributions, connect) from GitHub data before injecting fresh stats
- keep no-op protection by skipping commits when profile content is unchanged (ignoring timestamp marker block)

## Validation
- `shellcheck .agents/scripts/profile-readme-helper.sh`
- `shellcheck setup.sh`
- `bash .agents/scripts/profile-readme-helper.sh help`
- `bash .agents/scripts/profile-readme-helper.sh generate`
- `bash .agents/scripts/profile-readme-helper.sh update --dry-run`

Closes #4259