### PR TITLE
t4263: fix(tests): use non-greedy [^)]* in backslash-check regex

### DIFF
--- a/tests/test-email-thread-reconstruction.sh
+++ b/tests/test-email-thread-reconstruction.sh
@@ -231,7 +231,8 @@ test_relative_paths_cross_directory() {
 	fi
 
 	# Verify paths use forward slashes only (portable Markdown links)
-	if grep -qE '\(.*\\.*\.md\)' "$index_file"; then
+	# Use [^)]* instead of .* to prevent greedy matching across multiple links
+	if grep -qE '\([^)]*\\[^)]*\.md\)' "$index_file"; then
 		print_error "Index links contain backslashes (not portable)"
 		return 1
 	fi


### PR DESCRIPTION
## Summary

- Replaces greedy `.*` with `[^)]*` in the `grep -E` pattern at `tests/test-email-thread-reconstruction.sh:234` that checks for backslashes in Markdown link paths
- Prevents over-matching across multiple links on the same line, making the check more precise and avoiding false positives if the file format changes
- ShellCheck passes with zero violations

## Changes

`tests/test-email-thread-reconstruction.sh:234`:
```diff
-	if grep -qE '\(.*\\.*\.md\)' "$index_file"; then
+	# Use [^)]* instead of .* to prevent greedy matching across multiple links
+	if grep -qE '\([^)]*\\[^)]*\.md\)' "$index_file"; then
```

## Verification

```
shellcheck tests/test-email-thread-reconstruction.sh
# → zero violations
```

Closes #4263