### PR TITLE
t4265: improve jq audit assertions with diagnostic failure output

### DIFF
--- a/tests/test-worker-sandbox-helper.sh
+++ b/tests/test-worker-sandbox-helper.sh
@@ -81,11 +81,15 @@ test_create_records_audit_event() {
 		fail "sentinel missing expected task id"
 	fi
 
+	local audit_log="$TEST_TMPDIR/audit/audit.jsonl"
 	if jq -e 'select(.msg == "worker_sandbox_created" and .detail.task_id == "t1412-create")' \
-		"$TEST_TMPDIR/audit/audit.jsonl" >/dev/null 2>&1; then
+		"$audit_log" >/dev/null 2>&1; then
 		pass "audit log contains sandbox create event with correct task_id"
 	else
-		fail "missing sandbox create audit event or incorrect task_id"
+		local actual_events
+		actual_events="$(jq -r '.msg // "no msg field"' "$audit_log" 2>/dev/null | tr '\n' ' ' || echo "(unreadable)")"
+		fail "missing sandbox create audit event or incorrect task_id" \
+			"actual events in log: ${actual_events}"
 	fi
 
 	run_sandbox_cmd cleanup "$sandbox_dir" >/dev/null
@@ -107,11 +111,15 @@ test_cleanup_records_audit_event() {
 		fail "sandbox directory still exists after cleanup"
 	fi
 
+	local audit_log="$TEST_TMPDIR/audit/audit.jsonl"
 	if jq -e 'select(.msg == "worker_sandbox_cleaned" and .detail.task_id == "t1412-cleanup")' \
-		"$TEST_TMPDIR/audit/audit.jsonl" >/dev/null 2>&1; then
+		"$audit_log" >/dev/null 2>&1; then
 		pass "audit log contains sandbox cleanup event with correct task_id"
 	else
-		fail "missing sandbox cleanup audit event or incorrect task_id"
+		local actual_events
+		actual_events="$(jq -r '.msg // "no msg field"' "$audit_log" 2>/dev/null | tr '\n' ' ' || echo "(unreadable)")"
+		fail "missing sandbox cleanup audit event or incorrect task_id" \
+			"actual events in log: ${actual_events}"
 	fi
 
 	cleanup


### PR DESCRIPTION
## Summary

Addresses quality-debt issue #4265 (PR #4212 review feedback).

The `jq`-based audit log assertions in `tests/test-worker-sandbox-helper.sh` already use structured JSON parsing (not `grep`) with the correct field names (`.msg` and `.detail.task_id` matching the actual audit log schema). However, on assertion failure they emit no diagnostic context, making it hard to understand what went wrong.

## Changes

- Extract `audit_log` path into a local variable (avoids repeating the long path)
- On `jq` assertion failure, run a second `jq` pass to extract and display the actual event names present in the log
- Failure message now includes: `actual events in log: worker_sandbox_created worker_sandbox_cleaned` (or `(unreadable)` if the file is missing/corrupt)

## Note on Gemini suggestion

The review suggestion used `.event` and `.details.task_id` — these field names do not match the actual audit log schema (which uses `.msg` and `.detail.task_id` per `audit-log-helper.sh` line 392). The existing `jq` field names are correct and have been preserved.

## Verification

```
shellcheck tests/test-worker-sandbox-helper.sh  # clean
bash tests/test-worker-sandbox-helper.sh        # 5/5 pass
```

Closes #4265