### PR TITLE
fix: verify and document GH#4271 quality-debt findings in stats-wrapper.sh

### DIFF
--- a/.agents/scripts/stats-wrapper.sh
+++ b/.agents/scripts/stats-wrapper.sh
@@ -35,6 +35,14 @@ mkdir -p "$(dirname "$STATS_PIDFILE")"
 
 #######################################
 # Portable elapsed-seconds lookup for a running PID
+#
+# Robustness notes (GH#4271 — PR #4232 review findings):
+# - Both ps probes use `|| true` so set -euo pipefail cannot abort the
+#   function before the etime fallback runs (critical finding, coderabbit).
+# - awk uses `exit 1` for all invalid-input branches (medium finding, gemini).
+#   The `|| true` on the awk command substitution is intentional — it prevents
+#   set -euo pipefail from aborting on awk parse failure; the ^[0-9]+$ guard
+#   below handles the empty-result case cleanly.
 #######################################
 _stats_process_elapsed_seconds() {
 	local pid="$1"

--- a/.agents/scripts/stats-wrapper.sh
+++ b/.agents/scripts/stats-wrapper.sh
@@ -36,13 +36,13 @@ mkdir -p "$(dirname "$STATS_PIDFILE")"
 #######################################
 # Portable elapsed-seconds lookup for a running PID
 #
-# Robustness notes (GH#4271 — PR #4232 review findings):
-# - Both ps probes use `|| true` so set -euo pipefail cannot abort the
-#   function before the etime fallback runs (critical finding, coderabbit).
-# - awk uses `exit 1` for all invalid-input branches (medium finding, gemini).
-#   The `|| true` on the awk command substitution is intentional — it prevents
-#   set -euo pipefail from aborting on awk parse failure; the ^[0-9]+$ guard
-#   below handles the empty-result case cleanly.
+# Robustness notes:
+# - The `ps` commands use `|| true` to prevent `set -euo pipefail` from
+#   aborting the script if the process disappears. This allows the `etime`
+#   fallback logic to execute.
+# - The `awk` command substitution also uses `|| true`. `awk` is scripted to
+#   `exit 1` on invalid input, and this guard prevents script termination.
+#   The subsequent `^[0-9]+$` check handles the empty output case.
 #######################################
 _stats_process_elapsed_seconds() {
 	local pid="$1"


### PR DESCRIPTION
## Summary

Closes #4271

Verifies all 3 review findings from PR #4232 are fully addressed in `.agents/scripts/stats-wrapper.sh`, and adds an inline comment documenting the design rationale so future reviewers understand the `|| true` guard is intentional.

## Findings Status

### CRITICAL — Guard `ps` probes so fallback can run (coderabbit, line 43/50)

**Status: ✅ Already fixed** (commit `80ee81f` in PR #4232)

Both `ps` probes use `|| true` guards so `set -euo pipefail` cannot abort the function before the `etime` fallback runs:

```bash
elapsed=$(ps -p "$pid" -o etimes= 2>/dev/null | tr -d '[:space:]' || true)
etime=$(ps -p "$pid" -o etime= 2>/dev/null | tr -d '[:space:]' || true)
```

### HIGH — Don't drop pidfile on ambiguous elapsed-time lookup failure (coderabbit, line 118)

**Status: ✅ Already fixed** (commit `80ee81f` in PR #4232)

The failure path checks process liveness with `kill -0` before removing the pidfile. If the process is still alive, the pidfile is preserved and the function returns 1 (skip):

```bash
elapsed=$(_stats_process_elapsed_seconds "$old_pid") || {
    if kill -0 "$old_pid" 2>/dev/null; then
        echo "[stats-wrapper] Unable to determine elapsed time for live PID $old_pid; preserving pidfile and skipping." >>"$STATS_LOGFILE"
        return 1
    fi
    rm -f "$STATS_PIDFILE"
    return 0
}
```

### MEDIUM — Use `exit 1` in awk for invalid input (gemini, line 74)

**Status: ✅ Already fixed** (commit `268ad841` in PR #4232)

The awk command uses `exit 1` for all invalid-input branches. The `|| true` guard on the command substitution is intentional — it prevents `set -euo pipefail` from aborting the function on awk parse failure (this is the critical fix from `80ee81f`). Removing `|| true` as the gemini suggestion proposed would reintroduce the critical bug; the current code correctly incorporates both fixes.

## Change in This PR

Adds an inline comment to `_stats_process_elapsed_seconds()` explaining the `|| true` design rationale, so future reviewers understand it is a deliberate guard rather than an error suppression:

```bash
# Robustness notes (GH#4271 — PR #4232 review findings):
# - Both ps probes use `|| true` so set -euo pipefail cannot abort the
#   function before the etime fallback runs (critical finding, coderabbit).
# - awk uses `exit 1` for all invalid-input branches (medium finding, gemini).
#   The `|| true` on the awk command substitution is intentional — it prevents
#   set -euo pipefail from aborting on awk parse failure; the ^[0-9]+$ guard
#   below handles the empty-result case cleanly.
```

## Verification

```
shellcheck .agents/scripts/stats-wrapper.sh
```

Result: Only SC1091 info-level warnings (not following sourced files — expected, pre-existing, not actionable). No errors or warnings.