### PR TITLE
t4264: fix(worker-sandbox): replace grep|cut with while IFS= read loop for task_id parsing

### DIFF
--- a/.agents/scripts/worker-sandbox-helper.sh
+++ b/.agents/scripts/worker-sandbox-helper.sh
@@ -278,7 +278,12 @@ cleanup_worker_sandbox() {
 		return 1
 	fi
 
-	sandbox_task_id=$(grep '^task_id=' "$sandbox_dir/.aidevops-sandbox" 2>/dev/null | cut -d= -f2- || true)
+	sandbox_task_id=$(while IFS='=' read -r key value; do
+		if [[ "$key" == "task_id" ]]; then
+			echo "$value"
+			break
+		fi
+	done <"$sandbox_dir/.aidevops-sandbox")
 	sandbox_task_id="${sandbox_task_id:-unknown}"
 
 	rm -rf "$sandbox_dir"


### PR DESCRIPTION
## Summary

- Replaces `grep '^task_id=' | cut -d= -f2-` pipeline with a `while IFS='=' read -r key value` loop for parsing `task_id` from the `.aidevops-sandbox` sentinel file
- Addresses HIGH severity finding from PR #4212 review (gemini-code-assist)
- The `while` loop pattern is more robust, handles `=` in values correctly, and is extensible for future key additions

## Changes

- `.agents/scripts/worker-sandbox-helper.sh:281` — replaced `grep|cut` pipeline with `while IFS='=' read -r key value` loop

## Verification

- `shellcheck .agents/scripts/worker-sandbox-helper.sh` → zero violations

Closes #4264