### PR TITLE
t4265: extract _fail_with_audit_events helper (Gemini review follow-up)

### DIFF
--- a/tests/test-worker-sandbox-helper.sh
+++ b/tests/test-worker-sandbox-helper.sh
@@ -28,6 +28,14 @@ fail() {
 	return 0
 }
 
+_fail_with_audit_events() {
+	local fail_message="$1"
+	local audit_log="$2"
+	local actual_events
+	actual_events="$(jq -r '.msg // "no msg field"' "$audit_log" | tr '\n' ' ' || echo "(unreadable)")"
+	fail "$fail_message" "actual events in log: ${actual_events% }"
+}
+
 cleanup() {
 	if [[ -n "$TEST_TMPDIR" && -d "$TEST_TMPDIR" ]]; then
 		rm -rf "$TEST_TMPDIR"
@@ -86,10 +94,7 @@ test_create_records_audit_event() {
 		"$audit_log" >/dev/null 2>&1; then
 		pass "audit log contains sandbox create event with correct task_id"
 	else
-		local actual_events
-		actual_events="$(jq -r '.msg // "no msg field"' "$audit_log" 2>/dev/null | tr '\n' ' ' || echo "(unreadable)")"
-		fail "missing sandbox create audit event or incorrect task_id" \
-			"actual events in log: ${actual_events}"
+		_fail_with_audit_events "missing sandbox create audit event or incorrect task_id" "$audit_log"
 	fi
 
 	run_sandbox_cmd cleanup "$sandbox_dir" >/dev/null
@@ -116,10 +121,7 @@ test_cleanup_records_audit_event() {
 		"$audit_log" >/dev/null 2>&1; then
 		pass "audit log contains sandbox cleanup event with correct task_id"
 	else
-		local actual_events
-		actual_events="$(jq -r '.msg // "no msg field"' "$audit_log" 2>/dev/null | tr '\n' ' ' || echo "(unreadable)")"
-		fail "missing sandbox cleanup audit event or incorrect task_id" \
-			"actual events in log: ${actual_events}"
+		_fail_with_audit_events "missing sandbox cleanup audit event or incorrect task_id" "$audit_log"
 	fi
 
 	cleanup


### PR DESCRIPTION
## Summary

Addresses the Gemini code review suggestion left on PR #4287 that was merged before the suggestion could be applied.

**Gemini suggestion (line 92 of `tests/test-worker-sandbox-helper.sh`):**
> This logic for generating a detailed failure message is duplicated in `test_cleanup_records_audit_event` (lines 119-122). Extract this logic into a helper function. Also avoid suppressing stderr with `2>/dev/null` as this can hide diagnostic information.

## Changes

- Extracted duplicated failure message logic into `_fail_with_audit_events()` helper function
- Removed `2>/dev/null` stderr suppression from the `jq` call inside the helper (diagnostic errors now visible)
- Added `% ` parameter expansion to trim trailing space from `tr '\n' ' '` output
- Replaced both duplicated `else` blocks in `test_create_records_audit_event` and `test_cleanup_records_audit_event` with calls to the new helper

## Quality

- `shellcheck tests/test-worker-sandbox-helper.sh` → ✅ no violations

Ref: PR #4287 (merged), Gemini review comment at line 92