### PR TITLE
t4273: fix routine-helper quality-debt from PR #4251 review

### DIFF
--- a/.agents/scripts/routine-helper.sh
+++ b/.agents/scripts/routine-helper.sh
@@ -70,8 +70,8 @@ validate_required() {
 
 validate_routine_name() {
 	local routine_name="$1"
-	if [[ ! "$routine_name" =~ ^[A-Za-z0-9_-]+$ ]]; then
-		die "Routine name must use only letters, digits, underscore, or hyphen"
+	if [[ ! "$routine_name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+		die "Routine name must use only letters, digits, dot, underscore, or hyphen"
 		return 1
 	fi
 	return 0


### PR DESCRIPTION
## Summary

Closes #4273

Addresses all three HIGH-severity findings from PR #4251 review feedback on `.agents/scripts/routine-helper.sh`.

Two of the three findings were already resolved in commit `c2bb03f` (merged in PR #4251). This PR adds the remaining gap: the `validate_routine_name` charset was missing dot (`.`) support, which the coderabbit suggestion explicitly included (`^[A-Za-z0-9._-]+$`).

## Findings

### ✅ HIGH (gemini): XML injection — `${command}` unescaped in plist heredoc

Resolved in `c2bb03f`. An `xml_escape()` helper was added and applied to `$command` before plist interpolation:

```bash
command_escaped=$(xml_escape "$command")
# <string>${command_escaped}</string>
```

### ✅ HIGH (coderabbit): `ROUTINE_NAME` not validated before use in paths/labels

Resolved in `c2bb03f` + **this PR**. `validate_routine_name()` enforces `^[A-Za-z0-9._-]+$` (dot added in this PR to match the suggested regex) and is called in `parse_common_args()` before any path interpolation.

### ✅ HIGH (coderabbit): XML escaping needed for all dynamic values in plist heredoc

Resolved in `c2bb03f`. All five dynamic values are pre-escaped:

```bash
label_escaped=$(xml_escape "sh.aidevops.routine-${ROUTINE_NAME}")
command_escaped=$(xml_escape "$command")
home_escaped=$(xml_escape "$HOME")
env_path_escaped=$(xml_escape "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}")
log_path_escaped=$(xml_escape "${HOME}/.aidevops/logs/routine-${ROUTINE_NAME}.log")
```

## Verification

```
shellcheck .agents/scripts/routine-helper.sh
# → zero issues
```