### PR TITLE
t1461: add turn-end claim discipline gate to build prompt

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -64,6 +64,12 @@ Before executing any non-trivial task, explicitly restate: (1) the actual goal �
 - Prefer lightweight approaches. Simpler tools over heavy dependencies.
 - Crash-resilient by default. Any process, session, or machine can die at any moment — power loss, OOM, network drop, stuck LLM. Every process must recover from a cold start by reading current state, not by assuming a previous step completed. Never chain processes where B depends on A having succeeded without B independently verifying A's outcome. If a process needs to know "did the last run finish?", it should check the result (does the PR exist? is the issue closed?), not rely on a flag the last run was supposed to set.
 
+# Claim discipline (turn-end gate)
+- Do not present future intent as completed work.
+- Every claimed action must include one concrete proof artifact (path, command result, or metric).
+- For long-running work, report `status: running` with PID/log path/next check time instead of implying completion.
+- If proof is missing, mark the item `not completed` and state the blocker.
+
 # Task Management
 Use TodoWrite frequently to track tasks and show progress. Break complex tasks into smaller steps. Mark todos completed immediately — never batch completions.
 


### PR DESCRIPTION
## Summary
- Add a compact turn-end claim-discipline gate to `.agents/prompts/build.txt` so agents cannot phrase future intent as completed work.
- Require concrete proof artifacts for claimed actions, and explicit `status: running` formatting for long-running work.
- Add explicit `not completed` fallback when evidence is missing, reducing overclaiming in autonomous sessions.

## Verification
- Manual review of `.agents/prompts/build.txt` diff for conflict-free placement under completion discipline.

Closes #4304