### PR TITLE
t1462: rename model cost heading to API Cost

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -638,7 +638,7 @@ EOF
 
 ## AI Model Usage (last 30 days)
 
-| Model | Requests | Input | Output | Cache read | Cost | Cache savings | Model savings |
+| Model | Requests | Input | Output | Cache read | API Cost | Cache savings | Model savings |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
 ${model_rows}| **Total** | **${f_total_req}** | **${f_total_in}** | **${f_total_out}** | **${f_total_cache}** | **\$${total_cost}** | **\$${f_total_csavings}** | **\$${f_total_msavings}** |
 


### PR DESCRIPTION
## Summary
- rename the profile model usage table column heading from `Cost` to `API Cost` in generated README stats
- keep all values and calculations unchanged; this is a clarity-only wording update

## Validation
- `shellcheck .agents/scripts/profile-readme-helper.sh`
- `bash .agents/scripts/profile-readme-helper.sh generate` (verified new heading appears)

Closes #4307