### PR TITLE
4213: implement vision-size guardrails for browser QA screenshots

### DIFF
--- a/.agents/scripts/browser-qa-helper.sh
+++ b/.agents/scripts/browser-qa-helper.sh
@@ -12,8 +12,10 @@ init_log_file
 
 readonly SCREENSHOTS_DIR="${HOME}/.aidevops/.agent-workspace/tmp/browser-qa"
 readonly QA_RESULTS_DIR="${HOME}/.aidevops/.agent-workspace/tmp/browser-qa/results"
-readonly DEFAULT_TIMEOUT=30000
-readonly DEFAULT_VIEWPORTS="desktop,mobile"
+readonly BROWSER_QA_DEFAULT_TIMEOUT=30000
+readonly BROWSER_QA_DEFAULT_VIEWPORTS="desktop,mobile"
+readonly BROWSER_QA_DEFAULT_MAX_IMAGE_DIM=4000
+readonly BROWSER_QA_ANTHROPIC_MAX_IMAGE_DIM=8000
 
 # =============================================================================
 # Viewport Definitions
@@ -45,6 +47,149 @@ js_escape_string() {
 	raw="${raw//\$/\\\$}"
 	raw="${raw//$'\n'/\\n}"
 	printf '%s' "$raw"
+	return 0
+}
+
+# Resolve max image dimension guardrail from optional user input.
+# Args: $1 = requested max dimension (optional)
+# Output: validated max dimension integer
+resolve_max_image_dim() {
+	local requested="${1:-}"
+	local resolved="$BROWSER_QA_DEFAULT_MAX_IMAGE_DIM"
+
+	if [[ -n "$requested" ]]; then
+		if [[ "$requested" =~ ^[0-9]+$ ]] && [[ "$requested" -gt 0 ]]; then
+			resolved="$requested"
+		else
+			log_warn "Invalid --max-dim '${requested}', using default ${BROWSER_QA_DEFAULT_MAX_IMAGE_DIM}"
+		fi
+	fi
+
+	if [[ "$resolved" -gt "$BROWSER_QA_ANTHROPIC_MAX_IMAGE_DIM" ]]; then
+		log_warn "--max-dim ${resolved} exceeds Anthropic limit ${BROWSER_QA_ANTHROPIC_MAX_IMAGE_DIM}; clamping to ${BROWSER_QA_ANTHROPIC_MAX_IMAGE_DIM}"
+		resolved="$BROWSER_QA_ANTHROPIC_MAX_IMAGE_DIM"
+	fi
+
+	echo "$resolved"
+	return 0
+}
+
+# Get image dimensions as "widthxheight".
+# Args: $1 = image path
+# Output: widthxheight
+get_image_dimensions() {
+	local image_path="$1"
+	local width=""
+	local height=""
+
+	if command -v sips &>/dev/null; then
+		local sips_output
+		sips_output=$(sips -g pixelWidth -g pixelHeight "$image_path" 2>/dev/null) || return 1
+		while IFS= read -r line; do
+			case "$line" in
+			*pixelWidth:*) width="${line##*: }" ;;
+			*pixelHeight:*) height="${line##*: }" ;;
+			esac
+		done <<<"$sips_output"
+	elif command -v magick &>/dev/null; then
+		local identify_output
+		identify_output=$(magick identify -format '%w %h' "$image_path" 2>/dev/null) || return 1
+		width="${identify_output%% *}"
+		height="${identify_output##* }"
+	else
+		return 1
+	fi
+
+	if [[ -z "$width" || -z "$height" || ! "$width" =~ ^[0-9]+$ || ! "$height" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+
+	echo "${width}x${height}"
+	return 0
+}
+
+# Resize an image down to a max dimension.
+# Args: $1 = image path, $2 = max dimension
+resize_image_to_max_dim() {
+	local image_path="$1"
+	local max_dim="$2"
+
+	if command -v sips &>/dev/null; then
+		sips --resampleHeightWidthMax "$max_dim" "$image_path" --out "$image_path" >/dev/null
+		return 0
+	fi
+
+	if command -v magick &>/dev/null; then
+		magick "$image_path" -resize "${max_dim}x${max_dim}>" "$image_path"
+		return 0
+	fi
+
+	return 1
+}
+
+# Enforce screenshot size guardrails for Anthropic vision compatibility.
+# Args: $1 = output directory, $2 = target max dimension
+enforce_screenshot_size_guardrails() {
+	local output_dir="$1"
+	local max_dim="$2"
+	local checked_count=0
+	local resized_count=0
+	local hard_limit_violations=0
+
+	if ! command -v sips &>/dev/null && ! command -v magick &>/dev/null; then
+		log_error "No supported image tool found for guardrails (need sips or magick)"
+		return 1
+	fi
+
+	local image_found=0
+	for image_path in "$output_dir"/*.png; do
+		if [[ ! -f "$image_path" ]]; then
+			continue
+		fi
+		image_found=1
+		checked_count=$((checked_count + 1))
+
+		local dimensions
+		dimensions=$(get_image_dimensions "$image_path") || {
+			log_error "Failed to read image dimensions: ${image_path}"
+			return 1
+		}
+
+		local width="${dimensions%%x*}"
+		local height="${dimensions##*x}"
+
+		if [[ "$width" -gt "$max_dim" || "$height" -gt "$max_dim" ]]; then
+			if ! resize_image_to_max_dim "$image_path" "$max_dim"; then
+				log_error "Failed to resize screenshot: ${image_path}"
+				return 1
+			fi
+			resized_count=$((resized_count + 1))
+			local resized_dimensions
+			resized_dimensions=$(get_image_dimensions "$image_path") || {
+				log_error "Failed to read resized image dimensions: ${image_path}"
+				return 1
+			}
+			width="${resized_dimensions%%x*}"
+			height="${resized_dimensions##*x}"
+		fi
+
+		if [[ "$width" -gt "$BROWSER_QA_ANTHROPIC_MAX_IMAGE_DIM" || "$height" -gt "$BROWSER_QA_ANTHROPIC_MAX_IMAGE_DIM" ]]; then
+			hard_limit_violations=$((hard_limit_violations + 1))
+			log_error "Image exceeds Anthropic hard limit (${BROWSER_QA_ANTHROPIC_MAX_IMAGE_DIM}px): ${image_path} (${width}x${height})"
+		fi
+	done
+
+	if [[ "$image_found" -eq 0 ]]; then
+		log_warn "No PNG screenshots found in ${output_dir} to guardrail-check"
+		return 0
+	fi
+
+	log_info "Screenshot guardrails checked ${checked_count} image(s), resized ${resized_count}, max dimension ${max_dim}px"
+
+	if [[ "$hard_limit_violations" -gt 0 ]]; then
+		return 1
+	fi
+
 	return 0
 }
 
@@ -97,10 +242,11 @@ wait_for_url() {
 cmd_screenshot() {
 	local url=""
 	local pages="/"
-	local viewports="$DEFAULT_VIEWPORTS"
+	local viewports="$BROWSER_QA_DEFAULT_VIEWPORTS"
 	local output_dir="$SCREENSHOTS_DIR"
-	local timeout="$DEFAULT_TIMEOUT"
+	local timeout="$BROWSER_QA_DEFAULT_TIMEOUT"
 	local full_page="false"
+	local max_dim=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -128,6 +274,10 @@ cmd_screenshot() {
 			full_page="true"
 			shift
 			;;
+		--max-dim)
+			max_dim="$2"
+			shift 2
+			;;
 		*)
 			log_error "Unknown option: $1"
 			return 1
@@ -139,6 +289,8 @@ cmd_screenshot() {
 		log_error "URL is required. Use --url http://localhost:3000"
 		return 1
 	fi
+
+	max_dim=$(resolve_max_image_dim "$max_dim")
 
 	mkdir -p "$output_dir"
 
@@ -221,7 +373,17 @@ SCRIPT
 	local exit_code=0
 	node "$script_file" || exit_code=$?
 	rm -f "$script_file"
-	return $exit_code
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		return "$exit_code"
+	fi
+
+	if ! enforce_screenshot_size_guardrails "$output_dir" "$max_dim"; then
+		log_error "Screenshot guardrail enforcement failed"
+		return 1
+	fi
+
+	return 0
 }
 
 # =============================================================================
@@ -234,7 +396,7 @@ SCRIPT
 cmd_links() {
 	local url=""
 	local depth=2
-	local timeout="$DEFAULT_TIMEOUT"
+	local timeout="$BROWSER_QA_DEFAULT_TIMEOUT"
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -577,7 +739,7 @@ cmd_smoke() {
 	local url=""
 	local pages="/"
 	local format="json"
-	local timeout="$DEFAULT_TIMEOUT"
+	local timeout="$BROWSER_QA_DEFAULT_TIMEOUT"
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -729,10 +891,11 @@ SCRIPT
 cmd_run() {
 	local url=""
 	local pages="/"
-	local viewports="$DEFAULT_VIEWPORTS"
+	local viewports="$BROWSER_QA_DEFAULT_VIEWPORTS"
 	local format="json"
 	local output_dir="$QA_RESULTS_DIR"
-	local timeout="$DEFAULT_TIMEOUT"
+	local timeout="$BROWSER_QA_DEFAULT_TIMEOUT"
+	local max_dim=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -758,6 +921,10 @@ cmd_run() {
 			;;
 		--timeout)
 			timeout="$2"
+			shift 2
+			;;
+		--max-dim)
+			max_dim="$2"
 			shift 2
 			;;
 		*)
@@ -791,7 +958,7 @@ cmd_run() {
 	log_info "--- Phase 2: Screenshots ---"
 	local screenshot_dir="${output_dir}/screenshots-${timestamp}"
 	local screenshot_result
-	screenshot_result=$(cmd_screenshot --url "$url" --pages "$pages" --viewports "$viewports" --output-dir "$screenshot_dir" --timeout "$timeout" 2>/dev/null) || screenshot_result='{"error": "screenshot capture failed"}'
+	screenshot_result=$(cmd_screenshot --url "$url" --pages "$pages" --viewports "$viewports" --output-dir "$screenshot_dir" --timeout "$timeout" --max-dim "$max_dim" 2>/dev/null) || screenshot_result='{"error": "screenshot capture failed"}'
 
 	# Phase 3: Broken links
 	log_info "--- Phase 3: Broken Link Check ---"
@@ -906,10 +1073,11 @@ Common Options:
   --format FMT        Output format: json or markdown (default: json)
   --timeout MS        Navigation timeout in milliseconds (default: 30000)
   --output-dir DIR    Directory for screenshots and reports
+  --max-dim PX        Resize screenshots to this max dimension (default: 4000, Anthropic hard limit: 8000)
 
 Examples:
   browser-qa-helper.sh run --url http://localhost:3000 --pages "/ /about /dashboard"
-  browser-qa-helper.sh screenshot --url http://localhost:3000 --viewports desktop,tablet,mobile
+  browser-qa-helper.sh screenshot --url http://localhost:3000 --viewports desktop,tablet,mobile --max-dim 4000
   browser-qa-helper.sh links --url http://localhost:3000 --depth 3
   browser-qa-helper.sh a11y --url http://localhost:3000 --level AAA
   browser-qa-helper.sh smoke --url http://localhost:3000 --pages "/ /login"
@@ -948,4 +1116,6 @@ main() {
 	esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-browser-qa-helper.sh
+++ b/.agents/scripts/tests/test-browser-qa-helper.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../browser-qa-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local result="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$result" -eq 0 ]]; then
+		echo -e "${TEST_GREEN}PASS${TEST_RESET} ${test_name}"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+		return 0
+	fi
+
+	echo -e "${TEST_RED}FAIL${TEST_RESET} ${test_name}"
+	if [[ -n "$message" ]]; then
+		echo "       ${message}"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+test_resolve_default_max_dim() {
+	local value
+	value=$(resolve_max_image_dim "")
+	if [[ "$value" == "4000" ]]; then
+		print_result "resolve default max dimension" 0
+	else
+		print_result "resolve default max dimension" 1 "expected 4000, got ${value}"
+	fi
+	return 0
+}
+
+test_resolve_invalid_max_dim_falls_back() {
+	local value
+	value=$(resolve_max_image_dim "not-a-number")
+	if [[ "$value" == "4000" ]]; then
+		print_result "invalid max dimension falls back to default" 0
+	else
+		print_result "invalid max dimension falls back to default" 1 "expected 4000, got ${value}"
+	fi
+	return 0
+}
+
+test_resolve_clamps_to_anthropic_limit() {
+	local value
+	value=$(resolve_max_image_dim "12000")
+	if [[ "$value" == "8000" ]]; then
+		print_result "max dimension clamps to Anthropic limit" 0
+	else
+		print_result "max dimension clamps to Anthropic limit" 1 "expected 8000, got ${value}"
+	fi
+	return 0
+}
+
+test_guardrail_resizes_oversized_images() {
+	local tmp_dir
+	tmp_dir=$(mktemp -d)
+	touch "${tmp_dir}/small.png"
+	touch "${tmp_dir}/large.png"
+
+	get_image_dimensions() {
+		local image_path="$1"
+		case "$(basename "$image_path")" in
+		small.png) echo "1200x900" ;;
+		large.png)
+			if [[ -f "${image_path}.resized" ]]; then
+				echo "4000x2500"
+			else
+				echo "9000x5000"
+			fi
+			;;
+		*) return 1 ;;
+		esac
+		return 0
+	}
+
+	resize_image_to_max_dim() {
+		local image_path="$1"
+		local max_dim="$2"
+		if [[ "$max_dim" != "4000" ]]; then
+			return 1
+		fi
+		touch "${image_path}.resized"
+		return 0
+	}
+
+	if enforce_screenshot_size_guardrails "$tmp_dir" "4000"; then
+		print_result "guardrail resizes oversized screenshots" 0
+	else
+		print_result "guardrail resizes oversized screenshots" 1 "expected enforcement success"
+	fi
+
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+test_guardrail_fails_hard_limit_violation() {
+	local tmp_dir
+	tmp_dir=$(mktemp -d)
+	touch "${tmp_dir}/too-large.png"
+
+	get_image_dimensions() {
+		local image_path="$1"
+		if [[ "$(basename "$image_path")" == "too-large.png" ]]; then
+			echo "9001x9001"
+			return 0
+		fi
+		return 1
+	}
+
+	resize_image_to_max_dim() {
+		local image_path="$1"
+		local max_dim="$2"
+		if [[ -z "$image_path" || -z "$max_dim" ]]; then
+			return 1
+		fi
+		return 0
+	}
+
+	if enforce_screenshot_size_guardrails "$tmp_dir" "8000"; then
+		print_result "guardrail fails when hard limit remains exceeded" 1 "expected failure for image > 8000px"
+	else
+		print_result "guardrail fails when hard limit remains exceeded" 0
+	fi
+
+	rm -rf "$tmp_dir"
+	return 0
+}
+
+main() {
+	# Source after function declarations so helper functions are available here.
+	# main() in helper is guarded and will not auto-run when sourced.
+	# shellcheck source=../browser-qa-helper.sh
+	source "$HELPER"
+
+	echo "============================================="
+	echo "  browser-qa-helper.sh guardrail tests"
+	echo "============================================="
+
+	test_resolve_default_max_dim
+	test_resolve_invalid_max_dim_falls_back
+	test_resolve_clamps_to_anthropic_limit
+	test_guardrail_resizes_oversized_images
+	test_guardrail_fails_hard_limit_violation
+
+	echo "============================================="
+	echo "  Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
+	echo "============================================="
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/tools/browser/browser-qa.md
+++ b/.agents/tools/browser/browser-qa.md
@@ -100,8 +100,16 @@ browser-qa-helper.sh screenshot --url http://localhost:3000 \
 browser-qa-helper.sh screenshot --url http://localhost:3000 \
   --pages "/ /about /dashboard" \
   --viewports desktop,tablet,mobile \
-  --full-page
+  --full-page \
+  --max-dim 4000
 ```
+
+**Vision-size guardrails**:
+- `browser-qa-helper.sh screenshot` now enforces a post-capture image-size guardrail
+- Default resize target is `4000px` max dimension (`--max-dim` to override)
+- Anthropic hard limit is `8000px` per dimension; values above this are rejected
+- The helper uses `sips` (macOS) or `magick` (ImageMagick) to inspect/resize screenshots
+- If guardrail checks fail, the command exits non-zero instead of passing oversized images downstream
 
 **Viewport definitions**:
 

--- a/.agents/tools/vision/image-understanding.md
+++ b/.agents/tools/vision/image-understanding.md
@@ -136,6 +136,24 @@ curl https://api.anthropic.com/v1/messages \
 
 **Supported formats**: JPEG, PNG, GIF, WebP. Max 5MB per image (API), 10MB (Claude.ai).
 
+**Dimension limit (critical)**: Anthropic rejects base64 images where any dimension exceeds `8000px`.
+
+Recommended safety margin for screenshots:
+
+```bash
+# macOS (built-in)
+sips --resampleHeightWidthMax 4000 input.png --out output.png
+
+# Cross-platform (ImageMagick)
+magick input.png -resize '4000x4000>' output.png
+```
+
+The Browser QA helper enforces this by default:
+
+```bash
+browser-qa-helper.sh screenshot --url http://localhost:3000 --full-page --max-dim 4000
+```
+
 ### Google (Gemini Vision)
 
 ```bash


### PR DESCRIPTION
## Summary
- add post-capture screenshot guardrails in `browser-qa-helper.sh` with `--max-dim` support, default `4000`, and Anthropic hard-limit enforcement at `8000`
- add guardrail regression tests in `.agents/scripts/tests/test-browser-qa-helper.sh` for defaulting, clamping, resize behavior, and hard-limit failure paths
- document Anthropic image dimension limits and the helper's resize behavior in browser QA and vision docs

## Verification
- `shellcheck .agents/scripts/browser-qa-helper.sh .agents/scripts/tests/test-browser-qa-helper.sh`
- `.agents/scripts/tests/test-browser-qa-helper.sh`
- `markdown-formatter check` on updated markdown docs

Closes #4213