### PR TITLE
t4268: fix(audit-task-creator): base64-encode jq values to prevent shell injection in declare

### DIFF
--- a/.agents/scripts/archived/audit-task-creator-helper.sh
+++ b/.agents/scripts/archived/audit-task-creator-helper.sh
@@ -863,8 +863,8 @@ scan_legacy_pulse_findings() {
 	while IFS= read -r finding; do
 		local finding_id file severity description
 		while IFS='=' read -r key value; do
-			declare "$key=$value"
-		done <<<"$(jq -r '{finding_id: .id, file, severity, description} | to_entries | .[] | "\(.key)=\(.value)"' <<<"$finding")"
+			declare "$key=$(base64 -d <<<"$value")"
+		done <<<"$(jq -r '{finding_id: .id, file, severity, description} | to_entries | .[] | "\(.key)=\(.value | @base64)"' <<<"$finding")"
 
 		local existing
 		existing=$(db "$active_db" "
@@ -1148,8 +1148,8 @@ cmd_create() {
 	while IFS= read -r finding; do
 		local finding_id severity category path description pr_number source_tool
 		while IFS='=' read -r key value; do
-			declare "$key=$value"
-		done <<<"$(jq -r '{finding_id: .id, severity, category, path: (.path // ""), description, pr_number: (.pr_number // ""), source_tool: (.source_tool // "unknown")} | to_entries | .[] | "\(.key)=\(.value)"' <<<"$finding")"
+			declare "$key=$(base64 -d <<<"$value")"
+		done <<<"$(jq -r '{finding_id: .id, severity, category, path: (.path // ""), description, pr_number: (.pr_number // ""), source_tool: (.source_tool // "unknown")} | to_entries | .[] | "\(.key)=\(.value | @base64)"' <<<"$finding")"
 
 		# Validate finding_id is an integer (defense-in-depth)
 		if ! [[ "$finding_id" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary

Fixes GH#4268 — quality-debt from PR #4249 CodeRabbit review feedback.

- Replace bare `declare "$key=$value"` with base64-encoded values in two locations in `audit-task-creator-helper.sh`
- Prevents shell injection when jq output contains special characters, newlines, or `=` signs in values
- Pattern: `jq ... | "\(.key)=\(.value | @base64)"` + `declare "$key=$(base64 -d <<<"$value")"`

Closes #4268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of field value processing when special characters or newlines are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->