### PR TITLE
t4315: fix: guard PLUGIN_NAMESPACES array expansion against unbound variable

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -417,7 +417,7 @@ deploy_changed_files() {
 		esac
 
 		local plugin_namespace
-		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]+"${PLUGIN_NAMESPACES[@]}"}"; do
 			case "$rel_path" in
 			"$plugin_namespace"/*)
 				continue 2

--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -293,7 +293,7 @@ deploy_all_agents() {
 			"--exclude=draft/"
 		)
 		local plugin_namespace
-		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]+"${PLUGIN_NAMESPACES[@]}"}"; do
 			rsync_excludes+=("--exclude=${plugin_namespace}/")
 		done
 		rsync -a "${rsync_excludes[@]}" "$source_dir/" "$TARGET_DIR/"
@@ -304,7 +304,7 @@ deploy_all_agents() {
 		local preserve_ok=true
 		local -a preserved_dirs=("custom" "draft")
 		local plugin_namespace
-		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]+"${PLUGIN_NAMESPACES[@]}"}"; do
 			preserved_dirs+=("$plugin_namespace")
 		done
 
@@ -334,7 +334,7 @@ deploy_all_agents() {
 			! -name 'draft'
 			! -name 'loop-state'
 		)
-		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]+"${PLUGIN_NAMESPACES[@]}"}"; do
 			find_args+=(! -name "$plugin_namespace")
 		done
 		find_args+=(-exec rm -rf {} +)
@@ -346,7 +346,7 @@ deploy_all_agents() {
 
 		# Copy all agents
 		local -a tar_excludes=("--exclude=loop-state" "--exclude=custom" "--exclude=draft")
-		for plugin_namespace in "${PLUGIN_NAMESPACES[@]}"; do
+		for plugin_namespace in "${PLUGIN_NAMESPACES[@]+"${PLUGIN_NAMESPACES[@]}"}"; do
 			tar_excludes+=("--exclude=$plugin_namespace")
 		done
 		(cd "$source_dir" && tar cf - "${tar_excludes[@]}" .) |


### PR DESCRIPTION
## Summary

Closes #4315

Guards all three `PLUGIN_NAMESPACES` array iterations in `deploy-agents-on-merge.sh` against unbound variable warnings under `set -u`.

## Change

Uses the `${arr[@]+"${arr[@]}"}` pattern (safe array expansion) instead of bare `${arr[@]}` in `for` loops. This is the standard bash idiom for iterating over arrays that may be empty or unset when `set -u` is active.

## Files Changed

- `.agents/scripts/deploy-agents-on-merge.sh` — 3 loop guards (lines ~296, ~307, ~337)

## Verification

The fix prevents the unbound variable warning emitted during post-release agent sync when `PLUGIN_NAMESPACES` is empty.