### PR TITLE
t4285: fix(setup): deploy from current worktree path instead of canonical main checkout

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -37,7 +37,9 @@ export PLATFORM_MACOS PLATFORM_ARM64
 readonly PLATFORM_MACOS PLATFORM_ARM64
 # Repo constants — exported; consumed by setup-modules/core.sh, agent-deploy.sh
 REPO_URL="https://github.com/marcusquinn/aidevops.git"
-INSTALL_DIR="$HOME/Git/aidevops"
+# INSTALL_DIR: resolve from the directory where setup.sh is executed (supports worktrees)
+# For bootstrap (curl install), this will be /dev/fd/NN and trigger re-exec after clone
+INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export REPO_URL INSTALL_DIR
 
 # Source modular setup functions (t316.2)
@@ -506,32 +508,34 @@ if [[ ! -d "$_setup_script_dir/setup-modules" ]]; then
 		fi
 	fi
 
-	# Clone or update the repo
-	mkdir -p "$(dirname "$INSTALL_DIR")"
-	if [[ -d "$INSTALL_DIR/.git" ]]; then
+	# Clone or update the repo (use hardcoded path for bootstrap)
+	# After clone, INSTALL_DIR will be set correctly by the re-exec
+	_bootstrap_install_dir="$HOME/Git/aidevops"
+	mkdir -p "$(dirname "$_bootstrap_install_dir")"
+	if [[ -d "$_bootstrap_install_dir/.git" ]]; then
 		print_info "Existing installation found — updating..."
-		cd "$INSTALL_DIR" || exit 1
+		cd "$_bootstrap_install_dir" || exit 1
 		git pull --ff-only || {
 			print_warning "Git pull failed — resetting to origin/main"
 			git fetch origin
 			git reset --hard origin/main
 		}
 	else
-		if [[ -d "$INSTALL_DIR" ]]; then
+		if [[ -d "$_bootstrap_install_dir" ]]; then
 			print_warning "Directory exists but is not a git repo — backing up"
-			mv "$INSTALL_DIR" "$INSTALL_DIR.backup.$(date +%Y%m%d_%H%M%S)"
+			mv "$_bootstrap_install_dir" "$_bootstrap_install_dir.backup.$(date +%Y%m%d_%H%M%S)"
 		fi
-		print_info "Cloning aidevops to $INSTALL_DIR..."
-		git clone "$REPO_URL" "$INSTALL_DIR" || {
+		print_info "Cloning aidevops to $_bootstrap_install_dir..."
+		git clone "$REPO_URL" "$_bootstrap_install_dir" || {
 			print_error "Failed to clone repository"
 			exit 1
 		}
 	fi
 
-	print_success "Repository ready at $INSTALL_DIR"
+	print_success "Repository ready at $_bootstrap_install_dir"
 
 	# Re-execute the local copy (which has setup-modules/ available)
-	cd "$INSTALL_DIR" || exit 1
+	cd "$_bootstrap_install_dir" || exit 1
 	exec bash "./setup.sh" "$@"
 fi
 unset _setup_script_dir


### PR DESCRIPTION
## Summary

Fixes GH#4285 - setup.sh now deploys from the directory where it is executed (supporting worktrees) instead of always deploying from the hardcoded canonical main checkout at `$HOME/Git/aidevops`.

## Changes

**setup.sh:**
- Changed `INSTALL_DIR` from hardcoded `$HOME/Git/aidevops` to dynamically resolved from `BASH_SOURCE[0]` directory
- Updated bootstrap logic to use a local variable `_bootstrap_install_dir` with the hardcoded path (only used during curl install before re-exec)
- After re-exec, `INSTALL_DIR` correctly points to the cloned repo

## Technical Details

**Before:**
```bash
INSTALL_DIR="$HOME/Git/aidevops"
```

**After:**
```bash
INSTALL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
```

This allows setup.sh to:
1. Deploy from worktrees for live validation of branch changes
2. Still work correctly during bootstrap (curl install) by using a hardcoded fallback that gets replaced on re-exec
3. Support any repo location, not just `$HOME/Git/aidevops`

## Verification

1. Created a worktree: `bugfix/t4285-setup-worktree-deploy`
2. Added a test marker file in the worktree: `.agents/scripts/test-worktree-deploy.sh`
3. Ran `./setup.sh --non-interactive` from the worktree
4. Verified the test marker was deployed to `~/.aidevops/agents/scripts/`
5. Confirmed the test marker does NOT exist in the main checkout
6. ShellCheck passes with no errors

## Testing

- [x] ShellCheck passes
- [x] Deployment from worktree verified
- [x] Bootstrap logic unchanged (curl install still works)
- [x] Test marker file deployed from worktree, not main

Closes #4285