### PR TITLE
GH#4277: fix: harden JSON extraction in run_single_evaluator against braces in details

### DIFF
--- a/.agents/scripts/ai-judgment-helper.sh
+++ b/.agents/scripts/ai-judgment-helper.sh
@@ -891,7 +891,11 @@ ${user_message}"
 		raw_result=$("$AI_HELPER" --prompt "$full_prompt" --model haiku --max-tokens 200 || echo "")
 
 		if [[ -n "$raw_result" ]]; then
-			# Extract JSON from response: handle fenced blocks and embedded wrapper text
+			# Extract JSON from response: handle fenced blocks, wrapper text, and details
+			# containing braces. Three strategies in order:
+			#   1. Parse the whole response as JSON (plain response)
+			#   2. Strip fences, then try each line (JSON on its own line after wrapper text)
+			#   3. Strip fences, greedy capture (last resort; validated by fromjson?)
 			local json_result
 			json_result=$(printf '%s' "$raw_result" | jq -Rrs '
 				. as $text
@@ -901,8 +905,18 @@ ${user_message}"
 						$text
 						| gsub("(?m)^```[A-Za-z0-9_-]*\\n"; "")
 						| gsub("(?m)^```$"; "")
-						| capture("(?s)(?<json>\\{.*\\})").json
-						| fromjson?
+						| . as $stripped
+						| (
+							($stripped | fromjson?)
+							// (
+								($stripped | split("\n")
+								 | map(fromjson? | select(type == "object" and has("score")))
+								 | first)
+							)
+							// (
+								($stripped | capture("(?s)(?<json>\\{.*\\})").json | fromjson?)
+							)
+						)
 					)
 				) // empty
 				| select(type == "object" and has("score"))


### PR DESCRIPTION
Closes #4277

## Summary

Addresses the HIGH-severity finding from the Gemini review on PR #4236: the `capture("(?s)(?<json>\\{.*\\})")` regex in `run_single_evaluator` was fragile when the LLM response contained multiple JSON objects or when wrapper text preceded the score object on the same line.

## Root cause

The greedy `.*` in `capture("(?s)(?<json>\\{.*\\})")` captures from the first `{` to the **last** `}` in the entire response. When the response contains multiple JSON objects (e.g. `{"foo": "bar"} ... {"score": 0.8, "details": "..."}`) the captured string spans both objects and is not valid JSON, so `fromjson?` returns `empty` and the valid score object is silently discarded.

## Fix

Add a third extraction strategy between fence-stripping and the greedy capture: try each line of the stripped text as JSON. This handles the most common real-world case where the LLM wraps the JSON with prose on separate lines.

**Strategy order (unchanged strategies 1 & 4, new strategy 3):**
1. Parse whole response as JSON (plain response)
2. Strip fences → try whole stripped text as JSON
3. **NEW**: Strip fences → try each line as JSON (handles multi-object responses)
4. Strip fences → greedy capture (last resort, validated by `fromjson?`)

All strategies are validated by `fromjson?` so invalid captures are silently discarded.

## Verification

9 edge-case tests all pass:
- Plain JSON ✅
- Fenced JSON ✅
- Fenced JSON with `{` / `}` in `details` string ✅
- Wrapper text + JSON on its own line ✅
- Wrapper text + JSON inline (single line) ✅
- Multiple JSON objects — score object first ✅
- Multiple JSON objects — score object second ✅
- No JSON (returns empty) ✅
- JSON without `score` field (returns empty) ✅

## Findings status

| Finding | Severity | Status |
|---------|----------|--------|
| Fragile `grep`/`capture` regex fails when `details` contains `{`/`}` | HIGH | **Fixed in this PR** |
| Redundant `"$score" != "null"` check | MEDIUM | Already fixed in f9e675ef (PR #4236) |
| Human confirmation of MEDIUM fix | MEDIUM | Already fixed in f9e675ef (PR #4236) |