### PR TITLE
GH#4294: fix: add file existence checks in session-miner to reduce file_not_found failures

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -149,12 +149,16 @@ When referencing specific functions or code include the pattern `file_path:line_
 - markdown-formatter supports actions: format, fix, lint, check, advanced, cleanup.
 - If markdown-formatter still fails, check that .agents/scripts/markdown-formatter.sh exists and is executable.
 #
-# 3. read:file_not_found (53x observed)
+# 3. read:file_not_found (376x observed — partial fix in GH#4294)
 #    Root cause: assuming file paths from memory, AGENTS.md references, or prior
 #    sessions. Files move between releases and worktrees have different paths.
+#    Script-level fix: session-miner extract.py and compress.py now check file
+#    existence before stat()/read_text() calls; pulse script verifies compressed
+#    output exists before passing it to downstream functions.
 - Before Read: run `git ls-files '<pattern>'` or `fd -g '<pattern>'` to confirm the file exists at the expected path.
 - In worktrees: the path prefix changes (e.g., `~/Git/repo.branch-name/` not `~/Git/repo/`). Always use the worktree path.
 - AGENTS.md references like `prompts/build.txt` are relative — resolve against the actual repo root, which may be `.agents/prompts/build.txt`.
+- Before reading any file produced by a prior step (e.g., compressed output, extraction results), verify it exists with `[[ -f path ]]` (shell) or `Path.exists()` (Python) — do not assume a successful prior step always produces output.
 #
 # 4. edit:other (14x observed)
 #    Root causes: (a) identical oldString/newString (no-op), (b) permission denied

--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -644,6 +644,13 @@ main() {
 	local feedback_report_file="${MINER_DIR}/feedback_actions.md"
 	local feedback_metrics_file="${MINER_DIR}/feedback_metrics.json"
 
+	# Verify compressed output exists before proceeding
+	if [[ ! -f "${compressed_file}" ]]; then
+		log_error "Compressed signals file not produced at ${compressed_file}"
+		release_lock
+		return 1
+	fi
+
 	# Generate summary
 	local summary
 	summary=$(generate_summary "${compressed_file}" 2>&1)

--- a/.agents/scripts/session-miner/compress.py
+++ b/.agents/scripts/session-miner/compress.py
@@ -25,6 +25,11 @@ from pathlib import Path
 CHUNKS_DIR = Path(sys.argv[1]) if len(sys.argv) > 1 else (
     Path.home() / ".aidevops/.agent-workspace/work/session-miner"
 )
+
+if not CHUNKS_DIR.exists():
+    print(f"Error: Chunks directory not found at {CHUNKS_DIR}", file=sys.stderr)
+    sys.exit(1)
+
 OUTPUT = CHUNKS_DIR.parent / "compressed_signals.json"
 
 
@@ -291,6 +296,7 @@ def main():
         "git_correlation": git_correlation,
     }
 
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
     OUTPUT.write_text(json.dumps(output, indent=2, ensure_ascii=False), encoding="utf-8")
 
     total_steerage = sum(len(v) for v in steerage.values())

--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -894,6 +894,9 @@ def main():
     args = parser.parse_args()
 
     print(f"Session Miner — Extracting from {args.db}", file=sys.stderr)
+    if not args.db.exists():
+        print(f"Error: Database not found at {args.db}", file=sys.stderr)
+        sys.exit(1)
     print(f"  DB size: {args.db.stat().st_size / 1024 / 1024:.1f} MB", file=sys.stderr)
 
     conn = connect_db(args.db)


### PR DESCRIPTION
## Summary

Fixes GH#4294 — `read:file_not_found` pattern observed 376x across 11 models in session-miner feedback loop.

### Root causes identified

1. **`extract.py` line 897**: `args.db.stat().st_size` was called before `connect_db()`, which has the existence check. If the DB path doesn't exist, Python raises an unhandled `FileNotFoundError` before the helpful error message fires.

2. **`compress.py` module-level code**: `CHUNKS_DIR` was used without checking if it exists. If extraction failed or produced no chunks dir, compress.py would fail with a confusing `FileNotFoundError` deep in glob calls.

3. **`compress.py` `main()`**: `OUTPUT.write_text()` assumed the parent directory exists. On a fresh install or after a workspace wipe, the parent dir may not exist yet.

4. **`session-miner-pulse.sh`**: After `run_compression` succeeded (exit 0), the script assumed `compressed_signals.json` was produced. If compression ran but produced no output (e.g., empty chunks), downstream `generate_summary` and `generate_feedback_actions` would fail with "Compressed signals file not found".

### Changes

- **`extract.py`**: Add explicit `args.db.exists()` check before `stat()` call, with a clear error message and `sys.exit(1)`.
- **`compress.py`**: Add `CHUNKS_DIR.exists()` check at module level (before any processing); add `OUTPUT.parent.mkdir(parents=True, exist_ok=True)` before `write_text()`.
- **`session-miner-pulse.sh`**: Add `[[ -f "${compressed_file}" ]]` guard after compression, before passing the path to `generate_summary` and `generate_feedback_actions`.
- **`prompts/build.txt`**: Update `read:file_not_found` frequency (53x → 376x), document the script-level fix, and add a new rule: *"Before reading any file produced by a prior step, verify it exists — do not assume a successful prior step always produces output."*

### Verification

Re-run session-miner pulse and compare `read:file_not_found` frequency against the 376x baseline. The script-level fixes eliminate the cases where the miner itself was the source of these errors.

Closes #4294