### PR TITLE
fix: correct BigQuery HTTP Archive query to use UNNEST for technologies array

### DIFF
--- a/.agents/tools/research/tech-stack-lookup.md
+++ b/.agents/tools/research/tech-stack-lookup.md
@@ -415,7 +415,7 @@ SELECT
   region,
   traffic_tier
 FROM `httparchive.technologies.2026_02_01`
-WHERE technologies LIKE '%React%'
+WHERE EXISTS(SELECT 1 FROM UNNEST(technologies) tech WHERE tech.name = 'React')
   AND region = 'US'
   AND traffic_tier = 'high'
 LIMIT 100


### PR DESCRIPTION
## Summary

Fixes the BigQuery example query in `.agents/tools/research/tech-stack-lookup.md` that used an incorrect `LIKE '%React%'` string comparison on the `technologies` column.

## Problem

The HTTP Archive `technologies` column is an **array of structs**, not a plain string. The original query:

```sql
WHERE technologies LIKE '%React%'
```

Has two critical issues:
1. **Schema mismatch** — `LIKE` on a struct array will fail or produce incorrect results
2. **Semantic error** — even if it were a string, `LIKE '%React%'` would incorrectly match `React Native` when searching for `React`

## Fix

Replace with `EXISTS` + `UNNEST` to correctly query the array elements:

```sql
WHERE EXISTS(SELECT 1 FROM UNNEST(technologies) tech WHERE tech.name = 'React')
```

This matches exactly on the `name` field of each struct in the array, avoiding both the schema mismatch and the false-positive matching problem.

## Source

- Issue: #3687
- Original review feedback: PR #1531 (gemini-code-assist[bot], `discussion_r2814037693`)

Closes #3687