### PR TITLE
GH#3689: fix voice-helper.sh examples in qwen3-tts.md to use positional args

### DIFF
--- a/.agents/tools/voice/qwen3-tts.md
+++ b/.agents/tools/voice/qwen3-tts.md
@@ -25,7 +25,7 @@ tools:
 - **Latency**: 97ms streaming latency (first chunk)
 - **Models**: 1.7B and 0.6B variants (CustomVoice, VoiceDesign, Base)
 - **Install**: `pip install qwen-tts` or vLLM-Omni
-- **Helper**: `voice-helper.sh talk --tts qwen3-tts` (integration with voice bridge)
+- **Helper**: `voice-helper.sh talk whisper-mlx qwen3-tts` (integration with voice bridge)
 
 **When to Use**: Read this when you need multi-language TTS with voice cloning (3s reference), custom voice control (9 speakers + instruction), or voice design (natural language persona description). Ideal for production voice agents, content creation, and accessibility applications.
 
@@ -192,12 +192,16 @@ Add Qwen3-TTS to the aidevops voice bridge:
 # Use Qwen3-TTS as TTS engine
 voice-helper.sh talk whisper-mlx qwen3-tts
 
-# With custom voice
-voice-helper.sh talk whisper-mlx qwen3-tts --voice-ref path/to/reference.wav
+# With custom voice (positional: stt tts voice)
+voice-helper.sh talk whisper-mlx qwen3-tts path/to/reference.wav
 
-# With persona
-voice-helper.sh talk whisper-mlx qwen3-tts --persona "Friendly British female, professional"
+# With custom voice and model (positional: stt tts voice model)
+voice-helper.sh talk whisper-mlx qwen3-tts path/to/reference.wav opencode/claude-sonnet-4-6
 ```
+
+> **Note**: `voice-helper.sh talk` uses positional arguments (`stt tts voice model`). Named flags like
+> `--voice-ref` and `--persona` are not supported. Voice design (persona descriptions) must be
+> configured via the Qwen3-TTS Python API directly — see the Voice Design section above.
 
 See `voice-helper.sh` for full integration details.
 


### PR DESCRIPTION
## Summary

Fixes high-priority quality debt flagged in PR #1517 review by Gemini.

The `cmd_talk` function in `voice-helper.sh` uses **positional arguments** (`stt tts voice model`), not named flags. The examples in `qwen3-tts.md` were using `--voice-ref` and `--persona` which are not supported — these would be silently misinterpreted as positional values, causing incorrect behaviour.

## Changes

- **Quick Reference (line 28)**: Fixed `voice-helper.sh talk --tts qwen3-tts` → `voice-helper.sh talk whisper-mlx qwen3-tts` (named `--tts` flag doesn't exist; `tts` is positional `$2`)
- **Integration section (lines 196–199)**: Replaced incorrect `--voice-ref` and `--persona` examples with correct positional syntax
- Added a note clarifying that `voice-helper.sh talk` uses positional args and that voice design (persona descriptions) must be configured via the Qwen3-TTS Python API directly

## Root Cause

The examples were written assuming a named-argument interface that doesn't exist in `cmd_talk`. The function signature is:

```bash
cmd_talk() {
    local stt="${1:-whisper-mlx}"
    local tts="${2:-edge-tts}"
    local voice="${3:-}"
    local model="${4:-opencode/claude-sonnet-4-6}"
    ...
}
```

Closes #3689