### PR TITLE
fix: add explicit return 0 to all success paths in wappalyzer-helper.sh

### DIFF
--- a/.agents/scripts/wappalyzer-helper.sh
+++ b/.agents/scripts/wappalyzer-helper.sh
@@ -179,6 +179,7 @@ cache_set() {
 	local cache_file="$WAPPALYZER_CACHE_DIR/$key.json"
 
 	echo "$data" >"$cache_file"
+	return 0
 }
 
 # ============================================================================
@@ -194,6 +195,7 @@ cmd_detect() {
 	fi
 
 	wappalyzer_detect "$url"
+	return 0
 }
 
 cmd_detect_cached() {
@@ -223,6 +225,7 @@ cmd_detect_cached() {
 
 cmd_install() {
 	install_deps
+	return 0
 }
 
 cmd_status() {
@@ -249,12 +252,14 @@ cmd_status() {
 	local cache_count
 	cache_count=$(find "$WAPPALYZER_CACHE_DIR" -name "*.json" 2>/dev/null | wc -l | tr -d ' ')
 	print_info "Cached results: $cache_count"
+	return 0
 }
 
 cmd_cache_clear() {
 	print_info "Clearing Wappalyzer cache..."
 	rm -rf "${WAPPALYZER_CACHE_DIR:?}"/*
 	print_success "Cache cleared"
+	return 0
 }
 
 cmd_help() {
@@ -305,6 +310,7 @@ Related:
   - Task: t1067
 
 EOF
+	return 0
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Fixes quality-debt from PR #1536 review feedback (issue #3684).

### Findings addressed

**HIGH (already fixed prior to this PR):**
- ✅ `wappalyzer-detect.js` → `wappalyzer-detect.mjs` filename (line 103) — already correct in current `main`
- ✅ `mktemp` temp file cleanup via `trap 'rm -f -- "$temp_output"' RETURN` (line 115) — already correct in current `main`

**MEDIUM (fixed in this PR):**
- ✅ Added explicit `return 0` to all success paths per style guide (line 12: "All functions must have explicit `return` statements")
  - `cache_set`
  - `cmd_detect`
  - `cmd_install`
  - `cmd_status`
  - `cmd_cache_clear`
  - `cmd_help`

### Verification

ShellCheck passes (only pre-existing SC1091 info about sourced file, not an error).

Closes #3684