### PR TITLE
GH#3629: fix critical quality-debt in wp-helper.sh

### DIFF
--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -99,6 +99,9 @@ resolve_server_ref() {
 	server_def=$(jq -r --arg ref "$server_ref" '.servers[$ref] // empty' "$CONFIG_FILE" 2>/dev/null)
 
 	if [[ -z "$server_def" ]]; then
+		# >&2 is required: resolve_server_ref() is called via $() in execute_wp_via_ssh().
+		# Without >&2, the warning text is captured into the substitution, prepended to the
+		# JSON output, and causes downstream jq parse errors (stdout pollution bug).
 		print_warning "server_ref '$server_ref' not found in servers section — using site config as-is" >&2
 		echo "$site_config"
 		return 0
@@ -351,6 +354,10 @@ run_wp_command() {
 		exit 1
 	fi
 
+	# load_config must be called before get_site_config() to ensure CONFIG_FILE is set
+	# in the current shell. get_site_config() runs in a subshell via $(); any CONFIG_FILE
+	# assignment inside that subshell is lost when it exits, leaving CONFIG_FILE empty
+	# for the subsequent execute_wp_via_ssh() → resolve_server_ref() call.
 	load_config
 
 	local site_config


### PR DESCRIPTION
## Summary

Resolves the two critical quality-debt findings from PR #2028 review (gemini-code-assist) that were tracked in issue #3629.

Both fixes were already implemented in PR #2028 but the `quality-feedback-helper.sh scan-merged` tool created this issue as unactioned feedback. This PR adds explanatory comments to document the intent of each fix and prevent future regressions.

## Fixes

### Fix 1 — `print_warning` stdout pollution in `resolve_server_ref()` (line ~102)

`print_warning` is called inside `execute_wp_via_ssh` via `$()` substitution. Without `>&2`, the warning text is captured into the substitution, prepended to the JSON output, and causes downstream `jq` parse errors. The `>&2` redirect ensures warnings go to stderr and do not pollute the captured JSON.

Added comment explaining why `>&2` is required to prevent future removal.

### Fix 2 — Missing `load_config` before subshell call in `run_wp_command()` (line ~354)

`load_config` must be called before `get_site_config()` to ensure `CONFIG_FILE` is set in the current shell. `get_site_config()` runs in a subshell via `$()`; any `CONFIG_FILE` assignment inside that subshell is lost on exit, leaving `CONFIG_FILE` empty for the subsequent `execute_wp_via_ssh()` → `resolve_server_ref()` call.

Added comment explaining the subshell scoping constraint.

## Verification

- ShellCheck: zero violations (`shellcheck -x -S warning .agents/scripts/wp-helper.sh`)
- Both fixes match patterns already established in the codebase (`run_on_category()` and `run_on_all()` both call `load_config` before subshell operations)

Closes #3629