### PR TITLE
GH#3624: fix critical quality-debt from PR #139 review feedback

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -436,8 +436,12 @@ register_skill() {
 		_save_cleanup_scope
 		trap '_run_cleanups' RETURN
 		push_cleanup "rm -f '${tmp_file}'"
-		jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" >"$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
-		rm -f "$tmp_file"
+		if ! jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" >"$tmp_file"; then
+			log_error "Failed to process skill sources JSON. Update aborted."
+			rm -f "$tmp_file"
+			return 1
+		fi
+		mv "$tmp_file" "$SKILL_SOURCES"
 	fi
 
 	local timestamp
@@ -1546,7 +1550,12 @@ cmd_remove() {
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
 	push_cleanup "rm -f '${tmp_file}'"
-	jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" >"$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
+	if ! jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" >"$tmp_file"; then
+		log_error "Failed to process skill sources JSON. Remove aborted."
+		rm -f "$tmp_file"
+		return 1
+	fi
+	mv "$tmp_file" "$SKILL_SOURCES"
 
 	log_success "Skill '$name' removed"
 


### PR DESCRIPTION
## Summary

Fixes the critical data-loss risk in `add-skill-helper.sh` identified by Gemini Code Assist in PR #139 review.

## Problem

In two places, the pattern:

```bash
jq ... "$SKILL_SOURCES" >"$tmp_file" && mv "$tmp_file" "$SKILL_SOURCES"
```

has a subtle data-loss risk: the shell redirect `>"$tmp_file"` creates (or truncates) the temp file **before** `jq` runs. If `jq` fails (e.g. malformed JSON in `skill-sources.json`, missing field, or any runtime error), the redirect has already created an empty `$tmp_file`. While the `&&` prevents `mv` from running in most cases, this pattern is fragile and leaves an empty temp file that could cause confusion or, in edge cases where `set -e` propagation is incomplete, could overwrite `SKILL_SOURCES` with an empty file — wiping all registered skills.

Affected locations:
- `register_skill()` — update path (line ~439): removes existing entry before re-adding
- `remove_skill()` — registry cleanup (line ~1549): removes entry on skill deletion

## Fix

Wrap both `jq` calls in explicit `if !` guards:

```bash
if ! jq --arg name "$name" '.skills = [.skills[] | select(.name != $name)]' "$SKILL_SOURCES" >"$tmp_file"; then
    log_error "Failed to process skill sources JSON. Update aborted."
    rm -f "$tmp_file"
    return 1
fi
mv "$tmp_file" "$SKILL_SOURCES"
```

This ensures:
1. If `jq` fails, the error is logged clearly
2. The empty temp file is cleaned up immediately
3. The operation aborts with `return 1` — `SKILL_SOURCES` is never touched
4. `mv` only runs after a confirmed successful `jq` execution

## Testing

- ShellCheck passes (only pre-existing SC1091 info about sourced file)
- Pattern matches Gemini's suggested fix from PR #139 review

Closes #3624