### PR TITLE
GH#3587: fix critical quality-debt in fluentcrm.json

### DIFF
--- a/configs/mcp-templates/fluentcrm.json
+++ b/configs/mcp-templates/fluentcrm.json
@@ -1,4 +1,8 @@
 {
+  "_comment": "FluentCRM MCP template. NOTE: @netflyapp/fluentcrm-mcp-server is not published on npm. Requires local build from https://github.com/netflyapp/fluentcrm-mcp-server before enabling.",
+  "_setup": "git clone https://github.com/netflyapp/fluentcrm-mcp-server ~/.local/share/mcp-servers/fluentcrm-mcp-server && cd ~/.local/share/mcp-servers/fluentcrm-mcp-server && npm install && npm run build",
+  "_env": "Set FLUENTCRM_API_URL, FLUENTCRM_API_USERNAME, FLUENTCRM_API_PASSWORD in ~/.config/aidevops/credentials.sh",
+  "_docs": ".agents/services/crm/fluentcrm.md",
   "fluentcrm": {
     "type": "local",
     "command": [
@@ -7,6 +11,6 @@
       "source ~/.config/aidevops/credentials.sh && node ~/.local/share/mcp-servers/fluentcrm-mcp-server/dist/fluentcrm-mcp-server.js"
     ],
     "enabled": false,
-    "_comment": "Disabled globally. Enabled via fluentcrm_*: true in services/crm/fluentcrm.md subagent. Requires local build - see .agents/services/crm/fluentcrm.md for setup."
+    "_comment": "Disabled by default. Enable after completing local build (see _setup above). Docs: .agents/services/crm/fluentcrm.md"
   }
 }


### PR DESCRIPTION
## Summary

Closes #3587

Addresses the critical CodeRabbit finding from PR #64 review: `@netflyapp/fluentcrm-mcp-server` does not exist on the npm registry, making the original `npx` command non-functional at runtime.

## Changes

**`configs/mcp-templates/fluentcrm.json`**

- Adds top-level `_comment` explicitly noting the npm package is not published and a local build is required
- Adds `_setup` field with the exact `git clone` + `npm install` + `npm run build` command sequence
- Adds `_env` field documenting the required environment variables (`FLUENTCRM_API_URL`, `FLUENTCRM_API_USERNAME`, `FLUENTCRM_API_PASSWORD`)
- Adds `_docs` field pointing to `.agents/services/crm/fluentcrm.md`
- Updates the inner `_comment` to reference the top-level `_setup` field for clarity
- Retains the already-correct `node ~/.local/share/mcp-servers/fluentcrm-mcp-server/dist/fluentcrm-mcp-server.js` command (fixed in PR #64 commit a43e412) and `"enabled": false` default

## Verification

- JSON syntax validated ✅
- `enabled: false` preserved — template remains safe to copy without accidental activation ✅
- Setup instructions are self-contained in the template file ✅
- Consistent with other templates (e.g., `ahrefs-seo.json`, `twilio.json`) that document setup inline ✅