### PR TITLE
GH#3594: fix critical quality-debt in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "bin/",
     "aidevops.sh",
     "setup.sh",
+    "setup-modules/",
     "VERSION",
     "scripts/npm-postinstall.cjs",
     "templates/"


### PR DESCRIPTION
## Summary

Addresses the quality-debt tracked in issue #3594 (CodeRabbit review feedback from PR #73).

### Fixes

**CRITICAL (new fix in this PR):** Add `setup-modules/` to npm package `files` manifest.

`setup.sh` is included in the npm package and sources `setup-modules/` at runtime (lines 545–559). Without `setup-modules/` in the `files` array, running `setup.sh` from an npm install directory triggers the bootstrap guard (line 477) and clones the full repo unnecessarily — defeating the purpose of the npm package.

**MEDIUM + CRITICAL (confirmed already resolved in PR #73):**
- `.agent/` removed from `files` array — done in PR #73, commit `0a59352`
- `templates/` added to `files` array — done in PR #73, commits `5a8d1c7`–`155b230`

### Change

```diff
  "files": [
    "bin/",
    "aidevops.sh",
    "setup.sh",
+   "setup-modules/",
    "VERSION",
    "scripts/npm-postinstall.cjs",
    "templates/"
  ],
```

Closes #3594