### PR TITLE
GH#3679: fix critical quality-debt from PR #1553 review feedback

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -3807,7 +3807,7 @@ cmd_triage() {
 		fi
 
 		local pr_state
-		pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4 || echo "")
+		pr_state=$(echo "$pr_json" | grep -o '"state":"[^"]*"' | cut -d'"' -f4 || true)
 
 		case "$pr_state" in
 		MERGED)


### PR DESCRIPTION
## Summary

- Replace `|| echo ""` with `|| true` for the `grep -o` PR state extraction in `cmd_triage()` of `supervisor-archived/pulse.sh`
- Aligns with the repository style guide (`.gemini/styleguide.md` line 13) which specifies `|| true` as the preferred idiom for guarding commands that may fail under `set -e`
- Both `|| true` and `|| echo ""` produce an empty string in command substitution when `grep` finds no match, but `|| true` is the codebase convention

## Context

PR #1553 (`t1071: Fix pulse Phase 3b2 crash on mergedAt:null`) correctly fixed a critical crash by adding `|| echo ""` fallbacks to `grep -o` PR field extractions. Gemini code review flagged that the repository style guide prefers `|| true` over `|| echo ""` for this pattern. This PR addresses that unactioned review feedback.

**Source review comment**: https://github.com/marcusquinn/aidevops/pull/1553#pullrequestreview-3811050747

## Changes

- `.agents/scripts/supervisor-archived/pulse.sh` line 3810: `|| echo ""` → `|| true`

Closes #3679
