### PR TITLE
GH#3610: fix critical quality-debt from PR #1640 review feedback

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -174,6 +174,13 @@ readonly SECURE_PORT=443
 # Usage: timeout_sec 5 your_command arg1 arg2
 # Returns: command exit code, or 124 on timeout (matches coreutils convention)
 #
+# Exit code mapping (POSIX: signal exits are 128 + signal number):
+#   124  — timeout (GNU coreutils convention; returned by all paths below)
+#   137  — killed by SIGKILL  (128 + 9)  — hard kill, process did not exit cleanly
+#   143  — killed by SIGTERM  (128 + 15) — graceful termination signal
+# Callers that check for timeout should test for 124. Codes 137/143 indicate
+# the process was killed externally (e.g., by the OS or a concurrent pulse).
+#
 # NOTE: Do NOT pipe timeout_sec to head/grep — on macOS the background
 # process may not be properly cleaned up when the pipe closes early.
 # Instead, redirect to a temp file and process afterward.
@@ -204,11 +211,11 @@ timeout_sec() {
 		local half_secs_remaining=$((secs * 2))
 		while kill -0 "$cmd_pid" 2>/dev/null; do
 			if ((half_secs_remaining <= 0)); then
-				kill -TERM "$cmd_pid" 2>/dev/null
+				kill -TERM "$cmd_pid" 2>/dev/null # SIGTERM (15) — graceful shutdown
 				sleep 0.2
-				kill -KILL "$cmd_pid" 2>/dev/null || true
+				kill -KILL "$cmd_pid" 2>/dev/null || true # SIGKILL (9) — hard kill
 				wait "$cmd_pid" 2>/dev/null || true
-				return 124
+				return 124 # Normalise to GNU timeout convention
 			fi
 			sleep 0.5
 			((half_secs_remaining--)) || true

--- a/.agents/scripts/supervisor-archived/_common.sh
+++ b/.agents/scripts/supervisor-archived/_common.sh
@@ -178,6 +178,7 @@ get_task_hung_timeout() {
 
 # portable_timeout delegates to timeout_sec from shared-constants.sh (t1504).
 # Kept as a wrapper for backward compatibility with archived supervisor modules.
+# Exit codes: 124 = timeout (GNU convention); 137 = 128+SIGKILL; 143 = 128+SIGTERM.
 portable_timeout() {
 	timeout_sec "$@"
 	return $?

--- a/.agents/scripts/supervisor-archived/ai-reason.sh
+++ b/.agents/scripts/supervisor-archived/ai-reason.sh
@@ -20,6 +20,7 @@ AI_REASON_LOG_DIR="${AI_REASON_LOG_DIR:-$HOME/.aidevops/logs/ai-supervisor}"
 # Portable timeout: uses portable_timeout from _common.sh (which delegates to
 # timeout_sec from shared-constants.sh). For standalone execution, source
 # shared-constants.sh directly to get timeout_sec.
+# Exit codes: 124 = timeout (GNU convention); 137 = 128+SIGKILL; 143 = 128+SIGTERM.
 if ! declare -f portable_timeout &>/dev/null; then
 	_AI_REASON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 	source "${_AI_REASON_DIR}/../shared-constants.sh"

--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -1650,7 +1650,9 @@ check_cli_health() {
 	eval "version_cmd=($(build_cli_cmd --cli "$ai_cli" --action version --output array))"
 	version_output=$(timeout_sec 10 "${version_cmd[@]}" 2>&1) || version_exit=$?
 
-	# If version command succeeded (exit 0) or produced output, CLI is working
+	# If version command succeeded (exit 0) or produced output, CLI is working.
+	# Exit codes 124 (timeout) and 137 (128+SIGKILL — hard-killed) both indicate
+	# the CLI did not respond in time and should not be treated as healthy output.
 	if [[ "$version_exit" -eq 0 ]] || [[ -n "$version_output" && "$version_exit" -ne 124 && "$version_exit" -ne 137 ]]; then
 		# Cache the healthy result
 		date +%s >"$cli_cache_file" 2>/dev/null || true
@@ -1659,7 +1661,8 @@ check_cli_health() {
 		return 0
 	fi
 
-	# Version check failed
+	# Version check failed — distinguish timeout from other errors.
+	# 124 = GNU timeout convention; 137 = 128+SIGKILL (process hard-killed by OS or watchdog)
 	if [[ "$version_exit" -eq 124 || "$version_exit" -eq 137 ]]; then
 		log_error "CLI health check FAILED: '$ai_cli' timed out (10s)"
 		echo "cli_timeout:${ai_cli}"


### PR DESCRIPTION
## Summary

Addresses the critical quality-debt flagged by Gemini in PR #1640 review: exit codes 137 and 143 were used in `portable_timeout` without any explanation of their derivation, making the code opaque to readers.

## Root Cause

POSIX convention: when a process is killed by a signal, its exit code is `128 + signal_number`. The original code checked for these values silently:
- `137` = `128 + 9` (SIGKILL — hard kill, process did not exit cleanly)
- `143` = `128 + 15` (SIGTERM — graceful termination signal)

Without comments, it was unclear why these magic numbers were chosen or what they represented.

## Changes

- **`shared-constants.sh`**: Added an exit code mapping table to the `timeout_sec` function header; annotated `kill -TERM`, `kill -KILL`, and `return 124` inline
- **`supervisor-archived/_common.sh`**: Added exit code note to `portable_timeout` backward-compat wrapper
- **`supervisor-archived/ai-reason.sh`**: Added exit code note to standalone fallback definition
- **`supervisor-archived/dispatch.sh`**: Added comments at both `137`-check sites explaining the `128+SIGKILL` derivation

## Verification

- `shellcheck` passes on all 4 modified files (only pre-existing SC1091 info-level warnings for sourced files, unchanged)
- No logic changes — comments only

Closes #3610