### PR TITLE
GH#3623: fix(docs): replace hard-coded 200K context window with generic reference

### DIFF
--- a/.agents/tools/context/context-guardrails.md
+++ b/.agents/tools/context/context-guardrails.md
@@ -32,7 +32,7 @@ tools:
 
 ## The Problem
 
-Claude's context window is 200K tokens. Context-heavy operations can easily exceed this:
+The active model's context window has a finite limit (refer to the current model's documented capacity). Context-heavy operations can easily exceed it:
 
 | Tool | Typical Output | Risk Level |
 |------|----------------|------------|


### PR DESCRIPTION
## Summary

Addresses the remaining unactioned review feedback from PR #117 (GH#3623).

- Replaces hard-coded `"Claude's context window is 200K tokens"` in `context-guardrails.md` with a generic reference to the active model's documented capacity
- The 200K figure is model-specific and creates documentation drift — Claude supports 200K standard, 500K enterprise, and 1M select high-tier deployments
- The other two findings from PR #117 were already resolved in prior commits: `webfetch: true` was already set in `context-builder.md` frontmatter, and the File Discovery section in `AGENTS.md` was already a brief pointer only

## Changes

- `.agents/tools/context/context-guardrails.md`: Replace `"Claude's context window is 200K tokens"` with `"The active model's context window has a finite limit (refer to the current model's documented capacity)"`

Closes #3623