### PR TITLE
GH#4361: fix review-bot-gate-helper.sh: REST API fallback for PR age when GraphQL is rate-limited

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -86,12 +86,20 @@ usage() {
 get_pr_age_seconds() {
 	# Return the age of a PR in seconds since creation.
 	# Falls back to 0 if the creation time cannot be determined.
+	# GH#4361: GraphQL (gh pr view --json) may be rate-limited independently
+	# of the REST API. Try GraphQL first; fall back to REST on empty result.
 	local pr_number="$1"
 	local repo="$2"
 
 	local created_at
 	created_at=$(gh pr view "$pr_number" --repo "$repo" \
 		--json createdAt -q '.createdAt' 2>/dev/null || echo "")
+	if [[ -z "$created_at" ]]; then
+		# GH#4361: GraphQL rate-limited — fall back to REST API which has a
+		# separate rate limit and is typically available when GraphQL is exhausted.
+		created_at=$(gh api "repos/${repo}/pulls/${pr_number}" \
+			--jq '.created_at' 2>/dev/null || echo "")
+	fi
 	if [[ -z "$created_at" ]]; then
 		echo "0"
 		return 0
@@ -195,7 +203,12 @@ any_bot_has_success_status() {
 
 	local head_sha
 	head_sha=$(gh pr view "$pr_number" --repo "$repo" \
-		--json headRefOid -q '.headRefOid' || echo "")
+		--json headRefOid -q '.headRefOid' 2>/dev/null || echo "")
+	if [[ -z "$head_sha" ]]; then
+		# GH#4361: GraphQL rate-limited — fall back to REST API.
+		head_sha=$(gh api "repos/${repo}/pulls/${pr_number}" \
+			--jq '.head.sha' 2>/dev/null || echo "")
+	fi
 	if [[ -z "$head_sha" ]]; then
 		return 1
 	fi


### PR DESCRIPTION
## Summary

- Fixes `get_pr_age_seconds()` to fall back to the REST API (`gh api repos/aidevops/pulls/{number}`) when GraphQL (`gh pr view --json createdAt`) returns empty due to rate-limiting
- Fixes `any_bot_has_success_status()` with the same REST fallback for the head SHA lookup (`headRefOid` → `.head.sha`)
- Both fallbacks are silent — GraphQL is tried first, REST is used only when GraphQL returns empty

## Root cause

`gh pr view --json` uses GraphQL. When GitHub's GraphQL API is rate-limited, it returns an error and the result is empty. The original code fell back to `echo 0` (age = 0 seconds), causing the grace period check to always report `WAITING` with the full grace period remaining — even for PRs hours past the threshold.

## Fix

```bash
# get_pr_age_seconds: after GraphQL empty result
created_at=$(gh api "repos/$aidevops/pulls/${pr_number}" \
    --jq '.created_at' 2>/dev/null || echo "")

# any_bot_has_success_status: after GraphQL empty result
head_sha=$(gh api "repos/$aidevops/pulls/${pr_number}" \
    --jq '.head.sha' 2>/dev/null || echo "")
```

REST API has a separate rate limit from GraphQL and is typically available when GraphQL is exhausted.

## Testing

- ShellCheck passes cleanly
- Verified the REST endpoint field names: `.created_at` (REST) vs `.createdAt` (GraphQL), `.head.sha` (REST) vs `.headRefOid` (GraphQL)

Closes #4361