### PR TITLE
t4346: fix Codacy CI failures - add .codacy.yml config

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,32 @@
+# Codacy Static Analysis Configuration
+# Aligns Codacy's analysis with the project's existing shellcheck and quality settings.
+#
+# Reference: https://docs.codacy.com/repositories-configure/codacy-configuration-file/
+#
+# Root cause context (GH#4346):
+# - Codacy flagged SC2086 (unquoted variable) in code that was being REMOVED by a PR fix.
+# - Codacy also returned "not_collected" on a transient service issue.
+# - This config excludes archived/ (same as CI shellcheck) and aligns tool settings.
+
+---
+engines:
+  shellcheck:
+    enabled: true
+  semgrep:
+    enabled: true
+  trivy:
+    enabled: true
+  pylint:
+    enabled: true
+  eslint:
+    enabled: true
+
+exclude_paths:
+  # Archived code is versioned for reference but not actively maintained.
+  # Matches the shellcheck exclusion in .github/workflows/code-quality.yml.
+  - "archived/**"
+  # Generated/vendor files
+  - "node_modules/**"
+  - ".git/**"
+  # Config templates (not executable code)
+  - "configs/*.json.txt"


### PR DESCRIPTION
## Summary

- Adds `.codacy.yml` to configure Codacy's static analysis engine for this repo
- Excludes `archived/` directory (matches existing CI shellcheck exclusion in `code-quality.yml`)
- Excludes non-code paths (`node_modules/`, `.git/`, `configs/*.json.txt`)
- Explicitly enables relevant analysis engines (shellcheck, semgrep, trivy, pylint, eslint)

## Root Cause (GH#4346)

Two distinct failure modes were observed:

1. **PR #4335** (`not_collected`): Transient Codacy service issue — no code problems, but Codacy returned `action_required` with empty summary. This is a Codacy service-level issue; the `.codacy.yml` exclude paths reduce analysis surface and may reduce timeout risk.

2. **PR #4338** (1 new issue): Codacy flagged SC2086 (`Double quote to prevent globbing`) in the **old code being removed** by the PR. The PR was actually fixing that exact issue (replacing unquoted `$wp_command` with array-based `"${wp_args[@]}"`). Codacy's diff analysis picked up the base branch code as a new issue.

Both PRs were already merged; the current codebase is clean (PR #4343 passes Codacy). This PR adds the config to prevent recurrence.

## Why `.codacy.yml` and not a workflow change

Codacy is an **external check** (not a GitHub Actions workflow we control). Its behavior is configured via:
1. Codacy's web UI (threshold settings)
2. `.codacy.yml` in the repo root (analysis scope, engine config)

The `.codacy.yml` approach is the correct lever — it is version-controlled, reviewable, and does not require UI access.

## Verification

- Codacy will pick up `.codacy.yml` automatically on the next PR analysis
- The `archived/` exclusion matches the existing shellcheck exclusion in `.github/workflows/code-quality.yml` line 125
- Existing `.shellcheckrc` disable rules (SC1091, SC2329, etc.) are read by Codacy's shellcheck engine automatically

Closes #4346