### PR TITLE
GH#3581: fix quality-debt in hono.md — PR #3506 review feedback

### DIFF
--- a/.agents/tools/api/hono.md
+++ b/.agents/tools/api/hono.md
@@ -228,7 +228,7 @@ app.get("/api/stream", (c) => {
 app.post("/api/upload", async (c) => {
   const body = await c.req.parseBody();
   const file = body["file"] as File;
-  
+
   if (!file) {
     return c.json({ error: "No file" }, 400);
   }
@@ -244,7 +244,7 @@ app.post("/api/upload", async (c) => {
   if (!ALLOWED_TYPES.includes(file.type)) {
     return c.json({ error: "Invalid file type" }, 400);
   }
-  
+
   // Sanitize filename: strip path segments, normalize characters
   const sanitizedBase = file.name
     .replace(/[/\\]/g, "")           // Remove path separators
@@ -257,7 +257,7 @@ app.post("/api/upload", async (c) => {
 
   const buffer = await file.arrayBuffer();
   // Process file with safeName...
-  
+
   return c.json({ filename: safeName, size: file.size });
 });
 ```


### PR DESCRIPTION
## Summary

Resolves the two high-priority CodeRabbit findings from issue #3581 (PR #3506 review feedback) and cleans up trailing whitespace in the file upload code block.

## Findings Addressed

### Finding 1 (MEDIUM): Token verification exception handling

The `verifyToken(token)` call in the admin middleware was not wrapped in a try/catch, meaning thrown exceptions (malformed/expired tokens) would bubble to the global error handler and return 500 instead of 401.

**Fix**: Wrapped `verifyToken` in try/catch that returns `c.json({ error: "Invalid or expired token" }, 401)` on any verification failure. Applied in commit `d64428e8` (PR #3506), verified present in current file.

### Finding 2 (HIGH): Non-empty, unique stored filename

After sanitization, the filename could collapse to an empty string, and reusing it as the stored name invited collisions/overwrites.

**Fix**: Split into `sanitizedBase` (with `|| "upload"` fallback) and `safeName` prefixed with `crypto.randomUUID()` for guaranteed uniqueness. Applied in commit `d64428e8` (PR #3506), verified present in current file.

### Additional: Trailing whitespace cleanup

Removed 3 trailing whitespace characters from the file upload code block.

## Verification

- `markdownlint-cli2` passes with 0 errors
- Both CodeRabbit findings confirmed present and correct in current file
- No shell scripts modified (shellcheck N/A)

Closes #3581