### PR TITLE
GH#3680: fix high-priority quality-debt from PR #1551 review feedback

### DIFF
--- a/.agents/scripts/supervisor-archived/backfill-blocked-comments.sh
+++ b/.agents/scripts/supervisor-archived/backfill-blocked-comments.sh
@@ -11,26 +11,30 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
 # Source required modules
 source "$SCRIPT_DIR/issue-sync.sh"
-source "$SCRIPT_DIR/../database.sh" 2>/dev/null || source "$SCRIPT_DIR/../../supervisor-helper.sh"
+if [[ -f "$SCRIPT_DIR/../database.sh" ]]; then
+	source "$SCRIPT_DIR/../database.sh"
+else
+	source "$SCRIPT_DIR/../../supervisor-helper.sh"
+fi
 
 main() {
 	local repo_path="${1:-$REPO_ROOT}"
 	local dry_run="${2:-false}"
-	
+
 	echo "Backfilling blocked comments for repo: $repo_path"
-	
+
 	# Check if gh CLI is available
 	if ! command -v gh &>/dev/null; then
 		echo "Error: gh CLI not available"
 		exit 1
 	fi
-	
+
 	# Check gh auth
 	if ! gh auth status &>/dev/null; then
 		echo "Error: gh CLI not authenticated"
 		exit 1
 	fi
-	
+
 	# Detect repo slug
 	local repo_slug
 	repo_slug=$(detect_repo_slug "$repo_path" 2>/dev/null || echo "")
@@ -38,65 +42,68 @@ main() {
 		echo "Error: Could not detect repo slug"
 		exit 1
 	fi
-	
+
 	echo "Repo slug: $repo_slug"
-	
+
 	# Find all open issues with status:blocked label
 	local issues
 	issues=$(gh issue list --repo "$repo_slug" --label "status:blocked" --state open --json number,title --jq '.[] | "\(.number)|\(.title)"' 2>/dev/null || echo "")
-	
+
 	if [[ -z "$issues" ]]; then
 		echo "No blocked issues found"
 		return 0
 	fi
-	
+
 	local count=0
 	while IFS='|' read -r issue_number issue_title; do
 		# Extract task ID from title (format: "tXXX: description")
 		local task_id
 		task_id=$(echo "$issue_title" | grep -oE '^t[0-9]+' || echo "")
-		
+
 		if [[ -z "$task_id" ]]; then
 			echo "Skipping issue #$issue_number (no task ID in title)"
 			continue
 		fi
-		
+
 		# Check if issue already has a blocked comment
 		local has_blocked_comment
 		has_blocked_comment=$(gh issue view "$issue_number" --repo "$repo_slug" --json comments --jq '.comments[] | select(.body | contains("Worker Blocked")) | .body' 2>/dev/null || echo "")
-		
+
 		if [[ -n "$has_blocked_comment" ]]; then
 			echo "Issue #$issue_number ($task_id) already has blocked comment, skipping"
 			continue
 		fi
-		
+
 		# Read error from supervisor DB
 		local blocked_error=""
 		if [[ -f "$SUPERVISOR_DB" ]]; then
-			blocked_error=$(db "$SUPERVISOR_DB" "SELECT error FROM tasks WHERE id='$(sql_escape "$task_id")';" 2>/dev/null || echo "")
+			local escaped_id
+			escaped_id=$(sql_escape "$task_id")
+			blocked_error=$(db "$SUPERVISOR_DB" "SELECT error FROM tasks WHERE id='${escaped_id}';" 2>/dev/null || echo "")
 		fi
-		
+
 		if [[ -z "$blocked_error" || "$blocked_error" == "null" ]]; then
 			blocked_error="Task blocked — reason not specified in supervisor DB"
 		fi
-		
+
 		echo "Processing issue #$issue_number ($task_id): $blocked_error"
-		
+
 		if [[ "$dry_run" == "true" ]]; then
 			echo "  [DRY RUN] Would post blocked comment"
 		else
 			post_blocked_comment_to_github "$task_id" "$blocked_error" "$repo_path"
 			((count++))
 		fi
-	done <<< "$issues"
-	
+	done <<<"$issues"
+
 	echo ""
 	echo "Backfill complete: $count comments posted"
+	return 0
 }
 
 # Show usage
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-	cat << 'USAGE'
+	cat <<'USAGE'
 Usage: backfill-blocked-comments.sh [REPO_PATH] [--dry-run]
 
 Backfills blocked comments on GitHub issues with status:blocked label.
@@ -114,10 +121,20 @@ USAGE
 fi
 
 # Parse args
-REPO_PATH="${1:-$REPO_ROOT}"
+REPO_PATH="$REPO_ROOT"
 DRY_RUN="false"
-if [[ "${2:-}" == "--dry-run" ]]; then
-	DRY_RUN="true"
-fi
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--dry-run)
+		DRY_RUN="true"
+		shift
+		;;
+	*)
+		REPO_PATH="$1"
+		shift
+		;;
+	esac
+done
 
 main "$REPO_PATH" "$DRY_RUN"

--- a/.agents/scripts/supervisor-archived/issue-sync.sh
+++ b/.agents/scripts/supervisor-archived/issue-sync.sh
@@ -498,7 +498,9 @@ sync_issue_status_label() {
 	blocked)
 		# Read the error/blocked reason from DB
 		local blocked_error=""
-		blocked_error=$(db "$SUPERVISOR_DB" "SELECT error FROM tasks WHERE id='$(sql_escape "$task_id")';" 2>/dev/null || echo "")
+		local escaped_task_id
+		escaped_task_id=$(sql_escape "$task_id")
+		blocked_error=$(db "$SUPERVISOR_DB" "SELECT error FROM tasks WHERE id='${escaped_task_id}';" 2>/dev/null || echo "")
 		if [[ -z "$blocked_error" || "$blocked_error" == "null" ]]; then
 			blocked_error="Task blocked — reason not specified"
 		fi


### PR DESCRIPTION
## Summary

Fixes #3680 — addresses all findings from Gemini's review of PR #1551 (`backfill-blocked-comments.sh` and `issue-sync.sh`).

## Changes

### HIGH: Fix argument parsing in `backfill-blocked-comments.sh`

The original positional argument parsing was broken: running `--dry-run` alone would assign `"--dry-run"` to `REPO_PATH` and leave `DRY_RUN=false`. Replaced with a `while/case` loop that handles flags and positional args in any order.

### MEDIUM: Replace blanket `2>/dev/null` source suppression

Replaced `source ... 2>/dev/null || source ...` with an explicit `[[ -f ... ]]` file existence check before sourcing. Complies with style guide line 50 (no blanket stderr suppression).

### MEDIUM: Pre-escape task_id before SQL interpolation (both files)

In both `backfill-blocked-comments.sh` and `issue-sync.sh`, the SQL query now uses a pre-escaped variable (`escaped_id`/`escaped_task_id`) rather than inline `$(sql_escape ...)` substitution. Complies with style guide line 25 (parameterized queries where possible).

### MEDIUM: Add explicit `return 0` to `main()` function

Added `return 0` at the end of `main()` per style guide line 12 (all functions must have explicit return statements).

## Verification

- `bash -n` syntax check: both files pass
- `shellcheck`: no new errors (only pre-existing SC1091 info-level for sourced files)

Closes #3680