### PR TITLE
GH#3607: fix quality-debt from PR #1566 review — named constants and supervisor log redirects

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -58,7 +58,7 @@ _iso_to_epoch() {
 #######################################
 _record_stale_recovery() {
 	local task_id="" phase="" from_state="" to_state="" stale_secs=0
-	local root_cause="" had_pr=0 retries=0 max_retries=3 batch_id=""
+	local root_cause="" had_pr=0 retries=0 max_retries="${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}" batch_id=""
 	local worker_completed_at="" eval_started_at="" eval_lag_secs="NULL"
 
 	while [[ $# -gt 0 ]]; do
@@ -1098,7 +1098,7 @@ cmd_pulse() {
 
 			local stale_retries stale_max_retries stale_pr_url
 			stale_retries=$(db "$SUPERVISOR_DB" "SELECT retries FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "0")
-			stale_max_retries=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "3")
+			stale_max_retries=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}")
 			stale_pr_url=$(db "$SUPERVISOR_DB" "SELECT pr_url FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "")
 
 			local had_pr_flag=0
@@ -1576,7 +1576,7 @@ cmd_pulse() {
 					local current_retries
 					current_retries=$(db "$SUPERVISOR_DB" "SELECT retries FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo 0)
 					local max_retries_val
-					max_retries_val=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo 3)
+					max_retries_val=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo "${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}")
 					if [[ "$current_retries" -ge "$max_retries_val" ]]; then
 						log_error "  $tid: max retries exceeded ($current_retries/$max_retries_val), marking blocked"
 						cmd_transition "$tid" "blocked" --error "Max retries exceeded: $outcome_detail" 2>>"$SUPERVISOR_LOG" || true
@@ -1723,7 +1723,7 @@ cmd_pulse() {
 				local current_retries
 				current_retries=$(db "$SUPERVISOR_DB" "SELECT retries FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo 0)
 				local max_retries_val
-				max_retries_val=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo 3)
+				max_retries_val=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$tid")';" 2>/dev/null || echo "${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}")
 				if [[ "$current_retries" -ge "$max_retries_val" ]]; then
 					cmd_transition "$tid" "blocked" --error "Max retries exceeded during deferred re-prompt" 2>>"$SUPERVISOR_LOG" || true
 					attempt_self_heal "$tid" "blocked" "Max retries exceeded during deferred re-prompt" "${batch_id:-}" 2>>"$SUPERVISOR_LOG" || true
@@ -1833,7 +1833,7 @@ cmd_pulse() {
 				# Check retry count
 				local stuck_retries stuck_max_retries
 				stuck_retries=$(db "$SUPERVISOR_DB" "SELECT retries FROM tasks WHERE id = '$(sql_escape "$stuck_id")';" 2>/dev/null || echo 0)
-				stuck_max_retries=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$stuck_id")';" 2>/dev/null || echo 3)
+				stuck_max_retries=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$stuck_id")';" 2>/dev/null || echo "${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}")
 
 				if [[ "$stuck_retries" -lt "$stuck_max_retries" ]]; then
 					# Transition to retrying so it gets re-dispatched
@@ -1853,7 +1853,7 @@ cmd_pulse() {
 			local stuck_retries_val
 			stuck_retries_val=$(db "$SUPERVISOR_DB" "SELECT retries FROM tasks WHERE id = '$(sql_escape "$stuck_id")';" 2>/dev/null || echo 0)
 			local stuck_max_val
-			stuck_max_val=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$stuck_id")';" 2>/dev/null || echo 3)
+			stuck_max_val=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$stuck_id")';" 2>/dev/null || echo "${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}")
 			_record_stale_recovery \
 				--task "$stuck_id" --phase "1c" \
 				--from "evaluating" --to "$stuck_to_state" \
@@ -2222,7 +2222,7 @@ cmd_pulse() {
 		WHERE status IN ('blocked', 'verify_failed')
 		  AND pr_url IN ('task_obsolete')
 		ORDER BY id;
-	" 2>/dev/null || echo "")
+	" 2>>"$SUPERVISOR_LOG" || echo "")
 
 	if [[ -n "$obsolete_tasks" ]]; then
 		while IFS='|' read -r obs_id obs_status obs_pr; do
@@ -2401,7 +2401,7 @@ cmd_pulse() {
 						# If so, transition to pr_review instead of re-queuing from scratch.
 						local task_retries task_max_retries task_pr_url
 						task_retries=$(db "$SUPERVISOR_DB" "SELECT retries FROM tasks WHERE id = '$(sql_escape "$health_task")';" 2>/dev/null || echo "0")
-						task_max_retries=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$health_task")';" 2>/dev/null || echo "3")
+						task_max_retries=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$health_task")';" 2>/dev/null || echo "${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}")
 						task_pr_url=$(db "$SUPERVISOR_DB" "SELECT pr_url FROM tasks WHERE id = '$(sql_escape "$health_task")';" 2>/dev/null || echo "")
 
 						if [[ -n "$task_pr_url" && "$task_pr_url" != "null" ]]; then

--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -590,30 +590,32 @@ process_verify_queue() {
 
 	# Recover tasks stuck in 'verifying' state (t1075)
 	# If a pulse crashes mid-verification, tasks stay in 'verifying' forever.
-	# Reset any task that has been in 'verifying' for more than 5 minutes back to 'deployed'.
+	# Reset any task stuck in 'verifying' beyond the timeout back to 'deployed'.
+	# Configurable via SUPERVISOR_STUCK_VERIFYING_TIMEOUT_MINUTES (default: 5).
+	local stuck_verifying_timeout_minutes="${SUPERVISOR_STUCK_VERIFYING_TIMEOUT_MINUTES:-5}"
 	local stuck_verifying
 	stuck_verifying=$(db -separator '|' "$SUPERVISOR_DB" "
 		SELECT id FROM tasks
 		WHERE status = 'verifying'
-		  AND updated_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-5 minutes')
+		  AND updated_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-${stuck_verifying_timeout_minutes} minutes')
 		ORDER BY id;
-	" || echo "")
+	" 2>>"${SUPERVISOR_LOG:-/dev/stderr}" || echo "")
 
 	if [[ -n "$stuck_verifying" ]]; then
 		while IFS='|' read -r stuck_id; do
 			[[ -z "$stuck_id" ]] && continue
-			log_warn "  $stuck_id: stuck in 'verifying' for >5min — resetting to 'deployed'"
+			log_warn "  $stuck_id: stuck in 'verifying' for >${stuck_verifying_timeout_minutes}min — resetting to 'deployed'"
 			local escaped_stuck_id
 			escaped_stuck_id=$(sql_escape "$stuck_id")
 			db "$SUPERVISOR_DB" "UPDATE tasks SET
 				status = 'deployed',
 				error = NULL,
 				updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
-		WHERE id = '$escaped_stuck_id';" || true
+		WHERE id = '$escaped_stuck_id';" 2>>"${SUPERVISOR_LOG:-/dev/stderr}" || true
 			db "$SUPERVISOR_DB" "INSERT INTO state_log (task_id, from_state, to_state, timestamp, reason)
 		VALUES ('$escaped_stuck_id', 'verifying', 'deployed',
 			strftime('%Y-%m-%dT%H:%M:%SZ','now'),
-			'process_verify_queue: recovered from stuck verifying state (>5min timeout)');" || true
+			'process_verify_queue: recovered from stuck verifying state (>${stuck_verifying_timeout_minutes}min timeout)');" 2>>"${SUPERVISOR_LOG:-/dev/stderr}" || true
 		done <<<"$stuck_verifying"
 	fi
 


### PR DESCRIPTION
## Summary

Addresses the two quality-debt items flagged in the PR #1566 review (issue #3607):

1. **Magic numbers → named constants** — hardcoded retry counts and timeouts are now configurable `SUPERVISOR_*` env vars with the same defaults, following the existing naming convention (`SUPERVISOR_STALE_CLAIM_SECONDS`, `SUPERVISOR_EVAL_TIMEOUT`, etc.)

2. **`2>/dev/null` → supervisor log** — error output that was silently discarded is now redirected to `$SUPERVISOR_LOG` so failures surface in the supervisor log for debuggability

## Changes

### `supervisor-archived/todo-sync.sh`

- `process_verify_queue()`: replace hardcoded `5 minutes` stuck-verifying timeout with `${SUPERVISOR_STUCK_VERIFYING_TIMEOUT_MINUTES:-5}` (configurable, backward-compatible default)
- Add `2>>"${SUPERVISOR_LOG:-/dev/stderr}"` to the three `db()` calls in the stuck-verifying recovery block (SELECT query + UPDATE + INSERT into state_log)
- Update log message and SQL reason string to use the variable so they stay in sync with the configured value

### `supervisor-archived/pulse.sh`

- Replace hardcoded `3` max-retries fallback with `${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}` across all six call sites:
  - `_record_stale_recovery()` local default
  - Phase 0.7 stale recovery (`stale_max_retries` fallback)
  - Phase 1b outcome handling (`max_retries_val` fallback)
  - Deferred re-prompt retry check (`max_retries_val` fallback)
  - Phase 1c stuck-evaluating recovery (`stuck_max_retries` + `stuck_max_val` fallbacks)
  - Phase 4 worker health timeout (`task_max_retries` fallback)
- Phase 3b2 obsolete-task query: redirect `2>/dev/null` → `2>>"$SUPERVISOR_LOG"`

## Backward compatibility

Both new constants use the same numeric defaults as the previous literals (`5` and `3`). No behaviour change unless the env vars are explicitly set.

Closes #3607