### PR TITLE
GH#3605: fix critical quality-debt from PR #796 review — unsafe echo -e in supervisor log functions

### DIFF
--- a/.agents/scripts/supervisor-archived/_common.sh
+++ b/.agents/scripts/supervisor-archived/_common.sh
@@ -28,30 +28,32 @@ db() {
 
 #######################################
 # Structured logging functions
-# All output to stderr with color-coded prefixes
+# All output to stderr with color-coded prefixes.
+# Uses printf to safely handle arbitrary message content (avoids echo -e
+# interpreting backslash sequences in $* and word-splitting on unquoted args).
 #######################################
 log_info() {
-	echo -e "${BLUE}[SUPERVISOR]${NC} $*" >&2
+	printf "%b %s\n" "${BLUE}[SUPERVISOR]${NC}" "$*" >&2
 	return 0
 }
 
 log_success() {
-	echo -e "${GREEN}[SUPERVISOR]${NC} $*" >&2
+	printf "%b %s\n" "${GREEN}[SUPERVISOR]${NC}" "$*" >&2
 	return 0
 }
 
 log_warn() {
-	echo -e "${YELLOW}[SUPERVISOR]${NC} $*" >&2
+	printf "%b %s\n" "${YELLOW}[SUPERVISOR]${NC}" "$*" >&2
 	return 0
 }
 
 log_error() {
-	echo -e "${RED}[SUPERVISOR]${NC} $*" >&2
+	printf "%b %s\n" "${RED}[SUPERVISOR]${NC}" "$*" >&2
 	return 0
 }
 
 log_verbose() {
-	[[ "${SUPERVISOR_VERBOSE:-}" == "true" ]] && echo -e "${BLUE}[SUPERVISOR]${NC} $*" >&2 || true
+	[[ "${SUPERVISOR_VERBOSE:-}" == "true" ]] && printf "%b %s\n" "${BLUE}[SUPERVISOR]${NC}" "$*" >&2 || true
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes the two issues flagged by the Gemini code review on PR #796:

1. **Unsafe argument handling** (`echo -e` with `$*`): `echo -e` interprets backslash sequences in the message string. If a log message contains `\n`, `\t`, or other escape sequences, they would be silently transformed, corrupting log output. Switching to `printf "%b %s\n"` passes the caller's message as a `%s` argument — backslash sequences in `$*` are never interpreted.

2. **Explicit `return 0` statements**: Already present in the multi-line form in `_common.sh` (added during the supervisor modularisation in #1359). This commit preserves them and adds a block comment documenting the `printf` rationale.

## Changes

- `.agents/scripts/supervisor-archived/_common.sh`: Replace `echo -e "... $*"` with `printf "%b %s\n" "..." "$*"` in all five logging functions (`log_info`, `log_success`, `log_warn`, `log_error`, `log_verbose`). Preserve existing `return 0` statements.

## Verification

- ShellCheck passes (only SC1091 info for sourced file, expected)
- Manual test confirms: backslash sequences in messages are printed literally, not interpreted; ANSI color codes in the format string still render correctly; `log_verbose` only outputs when `SUPERVISOR_VERBOSE=true`; all functions return 0

Closes #3605