### PR TITLE
GH#3664: fix quality-debt from PR #1619 review — add set -euo pipefail to routine-scheduler.sh

### DIFF
--- a/.agents/scripts/supervisor-archived/routine-scheduler.sh
+++ b/.agents/scripts/supervisor-archived/routine-scheduler.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # routine-scheduler.sh - AI-driven routine scheduling for supervisor pulse (t1093, t1317)
 #
 # Phase 14: AI-driven routine scheduling that adapts frequency and priority


### PR DESCRIPTION
Fixes quality-debt from PR #1619 review for issue #3664.

**routine-scheduler.sh**: Added missing `set -euo pipefail` safety header. This was the only supervisor script missing the standard bash safety flags. Without it, unbound variable references silently expand to empty string, failed pipeline commands are ignored, and subshell errors don't propagate.

**Verification of routine_record_run calls**: The `routine_record_run` calls for Phase 12 (models_md) and Phase 13 (skill_update) are already correctly present in pulse.sh at lines 3210 and 3326 respectively. All phases (9, 10, 10b, 12, 13) have their routine_record_run calls correctly placed inside their respective 'run' branches.

Closes #3664