### PR TITLE
GH#3596: fix(ai-actions): guard grep in JSON extraction against pipefail crash

### DIFF
--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -947,7 +947,7 @@ execute_action_plan() {
 		# (commit_and_push_todo) can leak stdout noise (e.g. "Updating ...",
 		# "Fast-forward", "Created autostash") before the final JSON line.
 		local exec_result_json
-		exec_result_json=$(printf '%s' "$exec_result" | (grep -E '^\{' || echo '{}') | tail -1)
+		exec_result_json=$(tac <<<"$exec_result" | grep -E -m 1 '^\{' || echo '{}')
 		if [[ -z "$exec_result_json" ]] || ! printf '%s' "$exec_result_json" | jq '.' &>/dev/null; then
 			# Not valid JSON — wrap the entire result as a JSON string value
 			exec_result_json=$(jq -Rn --arg v "$exec_result" '$v')

--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -947,7 +947,7 @@ execute_action_plan() {
 		# (commit_and_push_todo) can leak stdout noise (e.g. "Updating ...",
 		# "Fast-forward", "Created autostash") before the final JSON line.
 		local exec_result_json
-		exec_result_json=$(printf '%s' "$exec_result" | grep -E '^\{' | tail -1)
+		exec_result_json=$(printf '%s' "$exec_result" | (grep -E '^\{' || echo '{}') | tail -1)
 		if [[ -z "$exec_result_json" ]] || ! printf '%s' "$exec_result_json" | jq '.' &>/dev/null; then
 			# Not valid JSON — wrap the entire result as a JSON string value
 			exec_result_json=$(jq -Rn --arg v "$exec_result" '$v')


### PR DESCRIPTION
## Summary

- Guards the `grep -E '^\{'` pipeline in `execute_action_plan` with `|| echo '{}'` so it never exits non-zero under `set -euo pipefail`
- Ensures `exec_result_json` is always a valid JSON value (`{}`) when no JSON lines are found, preventing downstream `jq --argjson` failures

## Problem

The defensive JSON extraction added in PR #1654 introduced a new crash vector:

```bash
exec_result_json=$(printf '%s' "$exec_result" | grep -E '^\{' | tail -1)
```

When `exec_result` contains no lines starting with `{` (e.g. a pure git message or an empty string), `grep` exits with code 1. With `set -euo pipefail` active, `pipefail` propagates that non-zero exit through the pipeline, and `set -e` terminates the script immediately — exactly the crash the defensive extraction was meant to prevent.

Additionally, if `exec_result_json` ends up as an empty string, the subsequent `jq --argjson r "$exec_result_json"` call fails because an empty string is not valid JSON.

## Fix

Wrap `grep` in a subshell with a fallback:

```bash
exec_result_json=$(printf '%s' "$exec_result" | (grep -E '^\{' || echo '{}') | tail -1)
```

This ensures:
1. The pipeline always exits 0 — no crash under `set -euo pipefail`
2. `exec_result_json` is always `{}` (valid JSON) when no match is found
3. The existing `if [[ -z "$exec_result_json" ]] || ! ... jq '.'` guard still works as a second layer of validation

## Testing

Verified all three cases manually:

| Input | Result |
|-------|--------|
| No `{` lines (pure git noise) | `{}` |
| Mixed noise + JSON line | `{"status":"ok","task":"t123"}` |
| Clean JSON only | `{"status":"ok"}` |

Implements the exact suggestion from the Gemini reviewer on PR #1654 (`#pullrequestreview-3820400496`).

Closes #3596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling in internal automation processes to gracefully handle edge cases when processing command output, ensuring more robust execution and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->