### PR TITLE
GH#3583: fix(pipecat-helper): remove unused server_port param from generate_bot_template

### DIFF
--- a/.agents/scripts/pipecat-helper.sh
+++ b/.agents/scripts/pipecat-helper.sh
@@ -196,9 +196,7 @@ check_pipecat_installed() {
 # Generate the bot.py file with the specified LLM provider
 generate_bot_template() {
 	local llm_provider="${1:-${DEFAULT_LLM_PROVIDER}}"
-	# $2 (server_port) is accepted for API compatibility but not used in the template
-	# (the heredoc uses single-quoted delimiter, so the bot reads --port from argparse)
-	local voice_id="${3:-${DEFAULT_CARTESIA_VOICE_ID}}"
+	local voice_id="${2:-${DEFAULT_CARTESIA_VOICE_ID}}"
 
 	mkdir -p "$(dirname "${PIPECAT_BOT}")"
 
@@ -574,7 +572,7 @@ cmd_setup() {
 
 	# Generate bot template
 	print_info "Generating bot template..."
-	generate_bot_template "${llm_provider}" "${DEFAULT_SERVER_PORT}" "${DEFAULT_CARTESIA_VOICE_ID}"
+	generate_bot_template "${llm_provider}" "${DEFAULT_CARTESIA_VOICE_ID}"
 
 	# Create .env template (without actual keys)
 	if [[ ! -f "${PIPECAT_DIR}/.env" ]]; then
@@ -827,7 +825,7 @@ cmd_start() {
 
 	# Regenerate bot if needed
 	if [[ ! -f "${PIPECAT_BOT}" ]]; then
-		generate_bot_template "${llm_provider}" "${server_port}" "${voice_id}"
+		generate_bot_template "${llm_provider}" "${voice_id}"
 	fi
 
 	echo ""


### PR DESCRIPTION
## Summary

Fixes quality-debt from PR #1286 review feedback (issue #3583).

- **HIGH (CodeRabbit)**: `sed -i ''` macOS-only syntax — already fixed in commit `4ff5aa9` via portable `mktemp`+`mv` approach. This PR confirms the fix is present and adds the Gemini cleanup on top.
- **MEDIUM (Gemini)**: `generate_bot_template()` accepted `$2` (server_port) for API compatibility but never used it — the bot template reads `--port` from argparse at runtime. This left `voice_id` at `$3`, making the function signature misleading and error-prone.

## Changes

- Remove the dead `$2` (server_port) parameter from `generate_bot_template()`
- Promote `voice_id` to `$2` (accurate function signature)
- Update both call sites (`cmd_setup`, `cmd_start`) to drop the unused `server_port` argument
- Portable sed fix (mktemp+mv) was already applied in commit `4ff5aa9` — no change needed there

## Testing

- ShellCheck passes (only SC1091 info-level for sourced file, pre-existing)
- No functional change to bot generation behaviour — `voice_id` value is unchanged at both call sites

Closes #3583