### PR TITLE
fix(playwright-automator): correct Grok model name to Grok Imagine in UI-only comment

### DIFF
--- a/.agents/scripts/higgsfield/playwright-automator.mjs
+++ b/.agents/scripts/higgsfield/playwright-automator.mjs
@@ -440,7 +440,7 @@ const API_POLL_MAX_WAIT_MS = 10 * 60 * 1000; // 10 minutes max wait
 // Discovered from docs + cloud dashboard model gallery.
 // Not all web UI models have API equivalents — only those listed here.
 // Verified 2026-02-10 by probing platform.higgsfield.ai (404 = not found, else exists).
-// Web-UI-only models (no API): Nano Banana Pro, GPT Image, Flux Kontext, Seedream 4.5, Wan, Sora, Veo, Minimax Hailuo, Grok Video.
+// Web-UI-only models (no API): Nano Banana Pro, GPT Image, Flux Kontext, Seedream 4.5, Wan, Sora, Veo, Minimax Hailuo, Grok Imagine.
 const API_MODEL_MAP = {
   // Text-to-image models (verified: 403 "Not enough credits" = exists)
   'soul':           'higgsfield-ai/soul/standard',


### PR DESCRIPTION
## Summary

- Corrects the Web-UI-only models comment in `playwright-automator.mjs` (line 443) to use the proper Higgsfield platform name **Grok Imagine** instead of the incorrect **Grok Video**
- Seedream 4.5 and Minimax Hailuo were already correct in the current file; only the Grok name remained misaligned

## Changes

```diff
-// Web-UI-only models (no API): Nano Banana Pro, GPT Image, Flux Kontext, Seedream 4.5, Wan, Sora, Veo, Minimax Hailuo, Grok Video.
+// Web-UI-only models (no API): Nano Banana Pro, GPT Image, Flux Kontext, Seedream 4.5, Wan, Sora, Veo, Minimax Hailuo, Grok Imagine.
```

## Why

Keeping this comment aligned with actual platform model naming prevents confusion when maintaining `API_MODEL_MAP` — a developer looking up "Grok Video" on the Higgsfield platform would not find it.

Closes #3558