### PR TITLE
t3481: fix(npm-postinstall): add error handling for tty write and close

### DIFF
--- a/scripts/npm-postinstall.cjs
+++ b/scripts/npm-postinstall.cjs
@@ -26,7 +26,14 @@ try {
 const log = (msg = '') => {
     const line = msg + '\n';
     if (ttyFd !== null) {
-        fs.writeSync(ttyFd, line);
+        try {
+            fs.writeSync(ttyFd, line);
+        } catch {
+            // TTY write failed. Fall back to stderr for this and subsequent calls.
+            try { fs.closeSync(ttyFd); } catch { /* best effort to close */ }
+            ttyFd = null;
+            process.stderr.write(line);
+        }
     } else {
         process.stderr.write(line);
     }
@@ -72,5 +79,9 @@ log('');
 
 // Clean up
 if (ttyFd !== null) {
-    fs.closeSync(ttyFd);
+    try {
+        fs.closeSync(ttyFd);
+    } catch {
+        // Ignore errors on close, as there's nothing more to do.
+    }
 }


### PR DESCRIPTION
## Summary

- Wrap `fs.writeSync()` in `log()` with try/catch: on failure, closes ttyFd, sets it to null, and falls back to stderr for the current and all subsequent log calls
- Wrap `fs.closeSync(ttyFd)` in cleanup with try/catch to prevent unhandled exception if close fails

## Why

Addresses two findings from Gemini Code Assist review on PR #84:
- **HIGH** (line 33): `log` function could crash the script if the TTY becomes unavailable mid-execution, preventing users from seeing installation instructions
- **MEDIUM** (line 75): unguarded `closeSync` could throw an unhandled exception during cleanup

Both fixes make the script resilient to I/O failures without changing any visible behaviour in the normal path.

Closes #3481