### PR TITLE
GH#3544: fix(comfy-cli-helper): guard empty array expansions for Bash < 4.4 compat

### DIFF
--- a/.agents/scripts/comfy-cli-helper.sh
+++ b/.agents/scripts/comfy-cli-helper.sh
@@ -188,7 +188,7 @@ cmd_launch() {
 	fi
 
 	log_info "Launching ComfyUI..."
-	comfy launch "${launch_args[@]}"
+	comfy launch "${launch_args[@]:-}"
 	return 0
 }
 
@@ -271,7 +271,7 @@ cmd_snapshot_save() {
 	[[ -n "$output" ]] && save_args+=("--output" "$output")
 
 	log_info "Saving environment snapshot..."
-	comfy node save-snapshot "${save_args[@]}"
+	comfy node save-snapshot "${save_args[@]:-}"
 	log_success "Snapshot saved"
 	return 0
 }


### PR DESCRIPTION
## Summary

Fixes the HIGH-severity finding from PR #1020 CodeRabbit review (tracked in issue #3544).

Under `set -u`, expanding an empty array with `"${array[@]}"` triggers an **unbound variable** error on Bash < 4.4 (including macOS's default Bash 3.2). This is a real portability risk for a DevOps tool that runs across diverse environments.

## Changes

- `.agents/scripts/comfy-cli-helper.sh` line 191: `"${launch_args[@]}"` → `"${launch_args[@]:-}"`
- `.agents/scripts/comfy-cli-helper.sh` line 274: `"${save_args[@]}"` → `"${save_args[@]:-}"`

The `:-` default-value syntax safely expands to nothing when the array is empty, avoiding the unbound variable error without changing runtime behaviour on Bash ≥ 4.4.

## Verification

- `shellcheck` passes cleanly with no warnings
- Both `cmd_launch` and `cmd_snapshot_save` are covered
- The MEDIUM finding (missing argument count guards for `--path`, `--port`, `--listen`, `--output`) was already fixed in the original PR #1020

Closes #3544