### PR TITLE
fix(npm-postinstall): add error handling for TTY write and close failures

### DIFF
--- a/scripts/npm-postinstall.cjs
+++ b/scripts/npm-postinstall.cjs
@@ -26,7 +26,14 @@ try {
 const log = (msg = '') => {
     const line = msg + '\n';
     if (ttyFd !== null) {
-        fs.writeSync(ttyFd, line);
+        try {
+            fs.writeSync(ttyFd, line);
+        } catch {
+            // TTY write failed. Fall back to stderr for this and subsequent calls.
+            try { fs.closeSync(ttyFd); } catch { /* best effort to close */ }
+            ttyFd = null;
+            process.stderr.write(line);
+        }
     } else {
         process.stderr.write(line);
     }
@@ -72,5 +79,9 @@ log('');
 
 // Clean up
 if (ttyFd !== null) {
-    fs.closeSync(ttyFd);
+    try {
+        fs.closeSync(ttyFd);
+    } catch {
+        // Ignore errors on close, as there's nothing more to do.
+    }
 }


### PR DESCRIPTION
## Summary

Fixes high-severity review feedback from PR #84 on `scripts/npm-postinstall.cjs`.

- **HIGH** (`scripts/npm-postinstall.cjs:33`): The `log` function now wraps `fs.writeSync()` in a `try-catch`. If the TTY write fails (e.g. terminal closed mid-install), the TTY fd is closed (best-effort) and `ttyFd` is set to `null`, causing all subsequent log calls to fall back to `process.stderr`. This prevents a crash that would hide important installation instructions.
- **MEDIUM** (`scripts/npm-postinstall.cjs:76`): The `fs.closeSync(ttyFd)` call in the cleanup block is now wrapped in a `try-catch` to prevent an unhandled exception if closing the fd fails for any reason.

Closes #3481