### PR TITLE
fix(docs): remove tautological 'SEO optimization' in accessibility.md

### DIFF
--- a/.agents/tools/accessibility/accessibility.md
+++ b/.agents/tools/accessibility/accessibility.md
@@ -376,5 +376,5 @@ Reports from `accessibility-audit-helper.sh` are saved to `~/.aidevops/reports/a
 
 - `tools/browser/pagespeed.md` — Performance testing (includes accessibility score)
 - `tools/performance/performance.md` — Core Web Vitals
-- `seo/` — SEO optimization (overlapping concerns)
+- `seo/` — SEO (overlapping concerns)
 - `tools/browser/browser-automation.md` — Browser tool selection for dynamic testing


### PR DESCRIPTION
## Summary

- Removes the tautological phrase "SEO optimization" (SEO already stands for Search Engine Optimization) from `.agents/tools/accessibility/accessibility.md` line 379
- Replaces with simply "SEO" per the LanguageTool `ACRONYM_TAUTOLOGY` finding flagged in PR #919

## Change

```diff
- - `seo/` — SEO optimization (overlapping concerns)
+ - `seo/` — SEO (overlapping concerns)
```

Closes #3531