### PR TITLE
t3498: refactor(dispatch): replace while-read NUL loops with mapfile

### DIFF
--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -1020,10 +1020,8 @@ do_prompt_repeat() {
 	if [[ "$ai_cli" == "claude" && -n "$worker_mcp_config" ]]; then
 		build_cmd_args+=(--mcp-config "$worker_mcp_config")
 	fi
-	local -a cmd_parts=()
-	while IFS= read -r -d '' part; do
-		cmd_parts+=("$part")
-	done < <(build_cli_cmd "${build_cmd_args[@]}")
+	local -a cmd_parts
+	mapfile -d '' -t cmd_parts < <(build_cli_cmd "${build_cmd_args[@]}")
 
 	# t1412.1: Create sandboxed HOME for prompt-repeat worker
 	local sandbox_dir="" sandbox_env_lines=""
@@ -3070,15 +3068,11 @@ cmd_dispatch() {
 		claude_mcp_config="$worker_mcp_config"
 	fi
 
-	local -a cmd_parts=()
+	local -a cmd_parts
 	if [[ "$verify_mode" == "true" ]]; then
-		while IFS= read -r -d '' part; do
-			cmd_parts+=("$part")
-		done < <(build_verify_dispatch_cmd "$task_id" "$worktree_path" "$log_file" "$ai_cli" "$memory_context" "$resolved_model" "$tdesc" "$verify_reason" "$claude_mcp_config")
+		mapfile -d '' -t cmd_parts < <(build_verify_dispatch_cmd "$task_id" "$worktree_path" "$log_file" "$ai_cli" "$memory_context" "$resolved_model" "$tdesc" "$verify_reason" "$claude_mcp_config")
 	else
-		while IFS= read -r -d '' part; do
-			cmd_parts+=("$part")
-		done < <(build_dispatch_cmd "$task_id" "$worktree_path" "$log_file" "$ai_cli" "$memory_context" "$resolved_model" "$tdesc" "$claude_mcp_config")
+		mapfile -d '' -t cmd_parts < <(build_dispatch_cmd "$task_id" "$worktree_path" "$log_file" "$ai_cli" "$memory_context" "$resolved_model" "$tdesc" "$claude_mcp_config")
 	fi
 
 	# Set FULL_LOOP_HEADLESS for all supervisor-dispatched workers (t174)
@@ -3686,10 +3680,8 @@ Task description: ${tdesc:-$task_id}"
 	if [[ "$ai_cli" == "claude" && -n "$worker_mcp_config" ]]; then
 		build_cmd_args+=(--mcp-config "$worker_mcp_config")
 	fi
-	local -a cmd_parts=()
-	while IFS= read -r -d '' part; do
-		cmd_parts+=("$part")
-	done < <(build_cli_cmd "${build_cmd_args[@]}")
+	local -a cmd_parts
+	mapfile -d '' -t cmd_parts < <(build_cli_cmd "${build_cmd_args[@]}")
 
 	# t1412.1: Create sandboxed HOME for reprompt worker
 	local sandbox_dir="" sandbox_env_lines=""


### PR DESCRIPTION
## Summary

Addresses unactioned review feedback from PR #654 (gemini-code-assist, medium severity, filed as quality-debt issue #3498).

Replaces all four `while IFS= read -r -d '' part; do ... done < <(build_*_cmd ...)` patterns in `dispatch.sh` with the idiomatic `mapfile -d '' -t cmd_parts < <(build_*_cmd ...)` form.

## Changes

**File**: `.agents/scripts/supervisor-archived/dispatch.sh`

Four sites refactored:
- `do_prompt_repeat()` — prompt-repeat worker command build
- `cmd_dispatch()` verify branch — verification dispatch
- `cmd_dispatch()` normal branch — standard dispatch
- `do_reprompt()` — reprompt worker command build

**Before:**
```bash
local -a cmd_parts=()
while IFS= read -r -d '' part; do
    cmd_parts+=("$part")
done < <(build_dispatch_cmd ...)
```

**After:**
```bash
local -a cmd_parts
mapfile -d '' -t cmd_parts < <(build_dispatch_cmd ...)
```

## Why

`mapfile` (aka `readarray`) is the idiomatic bash builtin for reading a stream into an array. It:
- Eliminates the loop variable `part` and the append step
- Is shorter and more readable
- Is semantically equivalent — both read NUL-delimited tokens into an array

The NUL delimiter (`-d ''`) is preserved, maintaining the correctness fix from PR #654 that prevents multi-line prompts from being split into multiple arguments.

## Verification

- **ShellCheck**: zero violations (`shellcheck -x -S warning dispatch.sh`)
- **Bash syntax**: `bash -n dispatch.sh` → OK
- **Functional equivalence**: `mapfile -d '' -t` correctly preserves multi-line content as single array elements (verified with inline test)

Closes #3498