### PR TITLE
fix(voice-bridge): correct misleading barge-in comment — AEC limitation

### DIFF
--- a/.agents/scripts/voice-bridge.py
+++ b/.agents/scripts/voice-bridge.py
@@ -373,8 +373,9 @@ class VoiceBridge:
         audio = np.frombuffer(indata, dtype=np.int16).copy()
 
         # Mute mic during TTS playback to prevent speaker-to-mic feedback.
-        # Without hardware echo cancellation, the TTS audio bleeds into the
-        # mic and triggers false barge-in. Use headphones to enable barge-in.
+        # Without acoustic echo cancellation (AEC), TTS audio bleeds into the
+        # mic and triggers false speech detection. Barge-in is not supported;
+        # implementing it would require hardware AEC or a software AEC library.
         if self.is_speaking:
             return
 


### PR DESCRIPTION
## Summary

- Fixes the misleading comment in `_audio_callback` that implied headphones would enable barge-in
- The mic is unconditionally muted during TTS playback (`is_speaking` guard) regardless of headphone use
- Barge-in is not supported without acoustic echo cancellation (AEC); the comment now accurately states this

## Context

The HIGH severity finding from PR #416 review (gemini-code-assist) flagged that the comment `# Use headphones to enable barge-in.` was misleading because the code returns immediately during TTS playback regardless of whether headphones are used. The reviewer recommended either removing the non-functional barge-in code or clearly documenting the AEC requirement.

The non-functional barge-in code was already removed in commit `b1b817b` (part of PR #416). This PR fixes the remaining misleading comment to accurately describe the limitation.

## Changes

- `.agents/scripts/voice-bridge.py`: Updated comment in `_audio_callback` to state that barge-in is not supported and would require hardware AEC or a software AEC library

Closes #3556