### PR TITLE
fix(speech-to-speech-helper): verify and document HIGH findings from GH#3553 (PR #403 review)

### DIFF
--- a/.agents/scripts/speech-to-speech-helper.sh
+++ b/.agents/scripts/speech-to-speech-helper.sh
@@ -363,7 +363,7 @@ cmd_stop() {
         print_info "No PID file found"
     fi
 
-    # Stop Docker if running
+    # Stop Docker if running (guard docker availability to avoid set -e failures on non-Docker hosts)
     if command -v docker &>/dev/null && [[ -f "${S2S_DIR}/docker-compose.yml" ]] && \
        docker compose -f "${S2S_DIR}/docker-compose.yml" ps --quiet 2>>"$S2S_LOG_FILE" | grep -q .; then
         print_info "Stopping Docker containers..."


### PR DESCRIPTION
## Summary

Closes #3553

Verifies all three HIGH-severity findings from the PR #403 code review are present in the current file, and adds a self-documenting comment to the docker guard in `cmd_stop`.

## HIGH findings verified (all already fixed in PR #447)

| Finding | Location | Status |
|---------|----------|--------|
| CPU-only host falls back to CUDA (crashes) | `cmd_start` lines 187-191 | ✅ Fixed — `cpu` → `server` with warning; `*` → `server` |
| `docker compose` called without Docker availability guard in `cmd_stop` | `cmd_stop` line 367 | ✅ Fixed — `command -v docker &>/dev/null` guard present |
| Concrete IP `192.168.1.100` in help examples | `cmd_help` line 521 | ✅ Fixed — replaced with `<server-ip>` placeholder |

## Change in this PR

Adds an explanatory comment to the docker guard in `cmd_stop` to make the rationale self-documenting:

```diff
-    # Stop Docker if running
+    # Stop Docker if running (guard docker availability to avoid set -e failures on non-Docker hosts)
```

## Verification

- `shellcheck` passes (only SC1091 info for sourced file, expected and pre-existing)
- All three HIGH findings confirmed present in current file