### PR TITLE
GH#3531: fix(docs): remove SEO tautology in accessibility.md

### DIFF
--- a/.agents/tools/accessibility/accessibility.md
+++ b/.agents/tools/accessibility/accessibility.md
@@ -376,5 +376,5 @@ Reports from `accessibility-audit-helper.sh` are saved to `~/.aidevops/reports/a
 
 - `tools/browser/pagespeed.md` — Performance testing (includes accessibility score)
 - `tools/performance/performance.md` — Core Web Vitals
-- `seo/` — SEO optimization (overlapping concerns)
+- `seo/` — SEO (overlapping concerns)
 - `tools/browser/browser-automation.md` — Browser tool selection for dynamic testing


### PR DESCRIPTION
## Summary

- Fix tautological phrase "SEO optimization" → "SEO" in `.agents/tools/accessibility/accessibility.md` line 379
- "SEO" already stands for "Search Engine Optimization", so "SEO optimization" is redundant

## Root Cause

Flagged by LanguageTool static analysis in the CodeRabbit review of PR #919 (comment on `.agents/tools/accessibility/accessibility.md` line 218 in the original diff). The PR was merged with the review dismissed as "suggestions noted for future improvement", creating issue #3531 to track the fix.

## Change

```diff
- - `seo/` — SEO optimization (overlapping concerns)
+ - `seo/` — SEO (overlapping concerns)
```

## Verification

Single-line documentation fix. No functional changes. LanguageTool rule `ACRONYM_TAUTOLOGY` satisfied.

Closes #3531