### PR TITLE
GH#3565: fix(supervisor): replace eval with bash array in merge_task_pr

### DIFF
--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -2612,13 +2612,14 @@ merge_task_pr() {
 
 	# Squash merge without --delete-branch (worktree handles branch cleanup)
 	# t227: Add --admin flag if SonarCloud external gate failed
+	# GH#3565: Use bash array instead of eval to prevent command injection (style guide: no eval)
 	local merge_output
-	local merge_cmd="gh pr merge \"$pr_number\" --repo \"$repo_slug\" --squash"
+	local -a merge_args=("pr" "merge" "$pr_number" "--repo" "$repo_slug" "--squash")
 	if [[ "$use_admin_flag" == "true" ]]; then
-		merge_cmd="$merge_cmd --admin"
+		merge_args+=("--admin")
 	fi
 
-	if ! merge_output=$(eval "$merge_cmd" 2>&1); then
+	if ! merge_output=$(gh "${merge_args[@]}" 2>&1); then
 		log_error "Failed to merge PR #$pr_number. Output from gh:"
 		log_error "$merge_output"
 		return 1


### PR DESCRIPTION
## Summary

Fixes the critical security issue flagged in PR #947 review by Gemini Code Assist.

## Problem

`merge_task_pr()` in `supervisor-archived/deploy.sh` used `eval` to dynamically construct and execute the `gh pr merge` command:

```bash
local merge_cmd="gh pr merge \"$pr_number\" --repo \"$repo_slug\" --squash"
if [[ "$use_admin_flag" == "true" ]]; then
    merge_cmd="$merge_cmd --admin"
fi
if ! merge_output=$(eval "$merge_cmd" 2>&1); then
```

This violates the repository style guide (Rule #32: No `eval`) and introduces a command injection risk if any variable contains unexpected content.

## Fix

Replace the `eval`-based string construction with a bash array:

```bash
local -a merge_args=("pr" "merge" "$pr_number" "--repo" "$repo_slug" "--squash")
if [[ "$use_admin_flag" == "true" ]]; then
    merge_args+=("--admin")
fi
if ! merge_output=$(gh "${merge_args[@]}" 2>&1); then
```

The `--admin` flag (added in t227 for SonarCloud unstable PRs) is now appended to the array conditionally, with no string interpolation or `eval` involved.

## Notes

- The medium-severity JSON construction issue (also flagged in PR #947) was already addressed in a prior commit using `jq -n` with parameterized construction (line 371 of deploy.sh).
- ShellCheck passes with no issues on the modified file.

## Testing

- ✅ ShellCheck: No issues
- ✅ Bash syntax: Valid (`bash -n`)
- ✅ Logic preserved: `--admin` flag still appended when `use_admin_flag == "true"`

Closes #3565