### PR TITLE
GH#3552: fix(quality-loop): separate preflight execution from output parsing

### DIFF
--- a/.agents/scripts/archived/quality-loop-helper.sh
+++ b/.agents/scripts/archived/quality-loop-helper.sh
@@ -500,8 +500,16 @@ preflight_loop() {
 		echo ""
 		print_info "=== Preflight Iteration $iteration / $max_iterations ==="
 
-		local result_status
-		result_status=$(run_preflight_checks "$auto_fix" 2>/dev/null | tail -n 1 | tr -d '\r')
+		local output exit_code result_status
+		output=$(run_preflight_checks "$auto_fix" 2>/dev/null) || exit_code=$?
+		exit_code="${exit_code:-0}"
+
+		if ((exit_code != 0)); then
+			print_error "Preflight checks failed to run (exit code: $exit_code)."
+			continue
+		fi
+
+		result_status=$(printf '%s' "$output" | tail -n 1 | tr -d '\r')
 
 		if [[ "$result_status" == "PASS" ]]; then
 			echo ""


### PR DESCRIPTION
## Summary

- Fixes silent pipeline failure in `preflight_loop` where `run_preflight_checks | tail | tr` masked non-zero exit codes
- `tr` always exits 0, so even with `set -o pipefail`, a crash in `run_preflight_checks` was treated as a normal FAIL result rather than an execution error
- Fix: capture output and exit code separately; parse output only when the command succeeded; surface real execution failures with a clear error message

## Root Cause

```bash
# Before — exit code of run_preflight_checks is lost
result_status=$(run_preflight_checks "$auto_fix" 2>/dev/null | tail -n 1 | tr -d '\r')
```

`pipefail` propagates the rightmost non-zero exit in a pipeline. `tr` succeeds regardless, so the pipeline always exits 0. A crash in `run_preflight_checks` was silently treated as a FAIL result, not an execution error.

## Fix

```bash
# After — exit code captured explicitly
output=$(run_preflight_checks "$auto_fix" 2>/dev/null) || exit_code=$?
exit_code="${exit_code:-0}"

if (( exit_code != 0 )); then
    print_error "Preflight checks failed to run (exit code: $exit_code)."
    continue
fi

result_status=$(printf '%s' "$output" | tail -n 1 | tr -d '\r')
```

## Verification

- ShellCheck passes with zero violations (`--severity=warning`)
- Matches Gemini code review recommendation from PR #106

Closes #3552