### PR TITLE
GH#3569: fix(docs): clarify opus cost multiplier with explicit pricing basis

### DIFF
--- a/.agents/tools/ai-assistants/models/opus.md
+++ b/.agents/tools/ai-assistants/models/opus.md
@@ -37,7 +37,7 @@ You are the highest-capability AI assistant, reserved for the most complex and c
 
 - Only use this tier when the task genuinely requires it
 - Most coding tasks are better served by sonnet tier
-- Cost is approximately 1.7x sonnet -- justify the spend
+- Cost is approximately 1.7x sonnet ($5/$25 vs $3/$15 per 1M tokens) -- justify the spend
 - If the task is primarily about large context, use pro tier instead
 
 ## Model Details


### PR DESCRIPTION
## Summary

- Adds inline pricing reference `($5/$25 vs $3/$15 per 1M tokens)` to the cost constraint line in `opus.md`
- Makes the multiplier self-verifying against the Model Details table, preventing future ambiguity
- The original 3x/5x mismatch from PR #758 was already resolved in commit `af7c55c3` (t1128: update model registry); this PR adds the explicit dollar amounts as a guard against regression

## Changes

**File**: `.agents/tools/ai-assistants/models/opus.md`

```diff
- Cost is approximately 1.7x sonnet -- justify the spend
+ Cost is approximately 1.7x sonnet ($5/$25 vs $3/$15 per 1M tokens) -- justify the spend
```

## Verification

The constraint line now explicitly cites the same prices shown in the Model Details table:
- Input: $5.00/1M (opus) vs $3.00/1M (sonnet) → 1.67x ✅
- Output: $25.00/1M (opus) vs $15.00/1M (sonnet) → 1.67x ✅

Closes #3569