### PR TITLE
GH#3556: fix(voice-bridge): correct misleading barge-in comment

### DIFF
--- a/.agents/scripts/voice-bridge.py
+++ b/.agents/scripts/voice-bridge.py
@@ -373,8 +373,11 @@ class VoiceBridge:
         audio = np.frombuffer(indata, dtype=np.int16).copy()
 
         # Mute mic during TTS playback to prevent speaker-to-mic feedback.
-        # Without hardware echo cancellation, the TTS audio bleeds into the
-        # mic and triggers false barge-in. Use headphones to enable barge-in.
+        # Voice barge-in is intentionally disabled: without acoustic echo
+        # cancellation (AEC), TTS audio bleeds into the mic and triggers
+        # false VAD detections regardless of whether headphones are used.
+        # TODO: enable barge-in when AEC is available (e.g. WebRTC AEC3 or
+        # a hardware device with built-in echo cancellation).
         if self.is_speaking:
             return
 


### PR DESCRIPTION
## Summary

Fixes the last unresolved finding from PR #416 review feedback (issue #3556).

The comment at `_audio_callback` (line 375) said:
> "Use headphones to enable barge-in"

This is **incorrect and misleading**: the early return at line 381 disables ALL audio processing during TTS playback regardless of whether headphones are used. Without acoustic echo cancellation (AEC), barge-in cannot work even with headphones — the TTS audio bleeds into the mic and triggers false VAD detections at the hardware level.

## Change

Updated the comment to accurately state that barge-in is **intentionally disabled** pending AEC support, and added a TODO for future implementation (e.g. WebRTC AEC3 or a hardware device with built-in echo cancellation).

## Status of all 6 findings from #3556

| Finding | Severity | Status |
|---------|----------|--------|
| Misleading barge-in comment (line 379) | HIGH | ✅ Fixed in this PR |
| SIGINT handler calling `sys.exit(0)` (line 815) | HIGH | ✅ Already fixed before merge |
| Unused imports: `io`, `json`, `wave`, `pathlib.Path`, `queue.Empty/Queue` | MEDIUM | ✅ Already fixed before merge |
| Dead `_start_server` method (line 306) | MEDIUM | ✅ Already fixed before merge |
| Fragile prefix stripping (line 322) | MEDIUM | ✅ Explanatory comment already present |
| Same unused imports (coderabbit, line 29) | MEDIUM | ✅ Already fixed before merge |

Closes #3556