### PR TITLE
fix(audit): correct function counts and flag eval style violations in t316.1

### DIFF
--- a/todo/tasks/t316.1-setup-function-audit.md
+++ b/todo/tasks/t316.1-setup-function-audit.md
@@ -32,7 +32,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ---
 
-### 2. Shell Environment (10 functions)
+### 2. Shell Environment (11 functions)
 
 **Purpose**: Shell detection, configuration, and PATH management
 
@@ -45,6 +45,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 | `setup_oh_my_zsh` | 1626 | main | zsh, chsh |
 | `setup_shell_compatibility` | 1698 | main | zsh, bash, grep, chmod |
 | `add_local_bin_to_path` | 2754 | install_aidevops_cli | mkdir, touch, grep |
+| `install_aidevops_cli` | 2803 | main | bash, chmod, ln |
 | `setup_aliases` | 2847 | main | grep, mkdir, touch |
 | `setup_terminal_title` | 2951 | main | grep, bash |
 | `find_opencode_config` | 138 | 6 functions | none |
@@ -71,9 +72,21 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 **Module Recommendation**: `lib/bootstrap.sh`  
 **Rationale**: System-level setup, runs early in setup flow, clear boundaries
 
+> **⚠️ Style Guide Violation — `eval` usage**: `ensure_homebrew` and `check_requirements` both use `eval` (e.g., `eval "$(/opt/homebrew/bin/brew shellenv)"`). The repository style guide explicitly forbids `eval` for security reasons. These must be refactored before or during module extraction. Use `source <(command)` as a safer alternative:
+>
+> ```bash
+> # Instead of:
+> eval "$(/opt/homebrew/bin/brew shellenv)"
+>
+> # Use:
+> source <( /opt/homebrew/bin/brew shellenv )
+> ```
+>
+> **Refactoring action**: Update both functions in Phase 1/2 of the refactoring strategy to eliminate `eval`.
+
 ---
 
-### 4. Migrations (6 functions)
+### 4. Migrations (7 functions)
 
 **Purpose**: Version-to-version migration logic, cleanup of deprecated paths/configs
 
@@ -121,7 +134,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ---
 
-### 6. MCP Setup (9 functions)
+### 6. MCP Setup (11 functions)
 
 **Purpose**: MCP server installation, configuration, and path resolution
 
@@ -166,7 +179,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ---
 
-### 8. Configuration Management (6 functions)
+### 8. Configuration Management (8 functions)
 
 **Purpose**: Managing configs, credentials, and OpenCode integration
 
@@ -200,7 +213,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ---
 
-### 10. Specialized Tools (7 functions)
+### 10. Specialized Tools (5 functions)
 
 **Purpose**: Domain-specific tool setups (browser, beads UI, AI orchestration)
 
@@ -273,15 +286,15 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 | Module | Functions | LOC Est. | Dependencies | Priority |
 |--------|-----------|----------|--------------|----------|
 | `lib/core-utils.sh` | 9 | ~400 | None (base layer) | P0 |
-| `lib/shell-env.sh` | 10 | ~600 | core-utils | P1 |
+| `lib/shell-env.sh` | 11 | ~650 | core-utils | P1 |
 | `lib/bootstrap.sh` | 7 | ~500 | core-utils, shell-env | P0 |
-| `lib/migrations.sh` | 6 | ~700 | core-utils, shell-env | P2 |
+| `lib/migrations.sh` | 7 | ~750 | core-utils, shell-env | P2 |
 | `lib/tool-install.sh` | 15 | ~1200 | core-utils, bootstrap | P1 |
-| `lib/mcp-setup.sh` | 9 | ~800 | core-utils, tool-install | P1 |
+| `lib/mcp-setup.sh` | 11 | ~950 | core-utils, tool-install | P1 |
 | `lib/agent-deploy.sh` | 10 | ~900 | core-utils, shell-env | P1 |
-| `lib/config.sh` | 6 | ~400 | core-utils, shell-env | P1 |
+| `lib/config.sh` | 8 | ~500 | core-utils, shell-env | P1 |
 | `lib/plugins.sh` | 2 | ~100 | core-utils, config | P2 |
-| `lib/specialized-tools.sh` | 7 | ~600 | core-utils, tool-install | P2 |
+| `lib/specialized-tools.sh` | 5 | ~450 | core-utils, tool-install | P2 |
 | `setup.sh` (orchestrator) | 2 | ~500 | All modules | P0 |
 
 **Total**: 87 functions, ~5700 LOC
@@ -298,24 +311,25 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ### Phase 2: Extract Bootstrap & Shell (P0-P1)
 1. Create `lib/bootstrap.sh` (7 functions, ~500 LOC)
-2. Create `lib/shell-env.sh` (10 functions, ~600 LOC)
-3. Update setup.sh to source both
-4. Test: Run bootstrap and shell setup steps
-5. **Benefit**: Reduces main file by ~1100 LOC, isolates system-level logic
+2. **Fix `eval` violations**: Replace `eval "$(...)"` with `source <(...)` in `ensure_homebrew` and `check_requirements` (style guide compliance — see note in §3 above)
+3. Create `lib/shell-env.sh` (11 functions, ~650 LOC)
+4. Update setup.sh to source both
+5. Test: Run bootstrap and shell setup steps
+6. **Benefit**: Reduces main file by ~1150 LOC, isolates system-level logic, eliminates `eval` security risk
 
 ### Phase 3: Extract Domain Modules (P1)
 1. Create `lib/tool-install.sh` (15 functions, ~1200 LOC)
-2. Create `lib/mcp-setup.sh` (9 functions, ~800 LOC)
+2. Create `lib/mcp-setup.sh` (11 functions, ~950 LOC)
 3. Create `lib/agent-deploy.sh` (10 functions, ~900 LOC)
-4. Create `lib/config.sh` (6 functions, ~400 LOC)
+4. Create `lib/config.sh` (8 functions, ~500 LOC)
 5. Update setup.sh to source all
 6. Test: Run full setup with all domains
-7. **Benefit**: Reduces main file by ~3300 LOC, clear domain boundaries
+7. **Benefit**: Reduces main file by ~3550 LOC, clear domain boundaries
 
 ### Phase 4: Extract Remaining Modules (P2)
-1. Create `lib/migrations.sh` (6 functions, ~700 LOC)
+1. Create `lib/migrations.sh` (7 functions, ~750 LOC)
 2. Create `lib/plugins.sh` (2 functions, ~100 LOC)
-3. Create `lib/specialized-tools.sh` (7 functions, ~600 LOC)
+3. Create `lib/specialized-tools.sh` (5 functions, ~450 LOC)
 4. Update setup.sh to source all
 5. Test: Full integration test
 6. **Benefit**: setup.sh reduced to ~500 LOC orchestrator


### PR DESCRIPTION
## Summary

Fixes the two HIGH-severity findings from PR #1233 review feedback (issue #3502).

### Finding 1: Function count inconsistencies

All section headers now match their actual table row counts:

| Section | Before | After | Actual rows |
|---------|--------|-------|-------------|
| Shell Environment | 10 | **11** | 11 (added missing `install_aidevops_cli`) |
| Migrations | 6 | **7** | 7 |
| MCP Setup | 9 | **11** | 11 |
| Configuration Management | 6 | **8** | 8 |
| Specialized Tools | 7 | **5** | 5 |

- `install_aidevops_cli` (line 2803) was in the appendix but uncategorized — added to Shell Environment (sits between `add_local_bin_to_path` at 2754 and `setup_aliases` at 2847)
- Module Assignment Table LOC estimates updated to reflect corrected counts
- Refactoring strategy phases updated with corrected function/LOC figures
- All totals now consistently sum to **87 functions** across sections, appendix, and module table

### Finding 2: `eval` usage not flagged as style guide violation

Added an explicit warning block in §3 (System Bootstrap & Requirements) noting that `ensure_homebrew` and `check_requirements` use `eval` in violation of the repository style guide, with the recommended `source <(...)` alternative and a refactoring action item. Also added an explicit step to Phase 2 of the refactoring strategy to eliminate `eval` during module extraction.

Closes #3502