### PR TITLE
t316.1: fix function count inconsistencies and flag eval style guide violation (GH#3502)

### DIFF
--- a/todo/tasks/t316.1-setup-function-audit.md
+++ b/todo/tasks/t316.1-setup-function-audit.md
@@ -79,7 +79,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
 # Compliant replacement:
-source <( /opt/homebrew/bin/brew shellenv )
+source <( "$(command -v brew)" shellenv )
 ```
 
 This must be addressed in Phase 2 when `lib/bootstrap.sh` is extracted.
@@ -384,7 +384,7 @@ This must be addressed in Phase 2 when `lib/bootstrap.sh` is extracted.
 ### Risk 6: `eval` Style Guide Violation in Bootstrap Functions
 **Affected functions**: `ensure_homebrew` (line 1287), `check_requirements` (line 1366)  
 **Violation**: Both functions use `eval "$(/opt/homebrew/bin/brew shellenv)"`, which is explicitly forbidden by the repository style guide.  
-**Mitigation**: Replace with `source <( /opt/homebrew/bin/brew shellenv )` when extracting `lib/bootstrap.sh` in Phase 2. Verify behaviour is identical on macOS (Homebrew's `shellenv` output is POSIX-compatible with `source`).
+**Mitigation**: Replace with `source <( "$(command -v brew)" shellenv )` when extracting `lib/bootstrap.sh` in Phase 2. Verify behaviour is identical on macOS (Homebrew's `shellenv` output is POSIX-compatible with `source`). Using `command -v brew` avoids hardcoding the Homebrew prefix, supporting both Intel (`/usr/local`) and Apple Silicon (`/opt/homebrew`) installations.
 
 ---
 

--- a/todo/tasks/t316.1-setup-function-audit.md
+++ b/todo/tasks/t316.1-setup-function-audit.md
@@ -32,7 +32,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ---
 
-### 2. Shell Environment (10 functions)
+### 2. Shell Environment (11 functions)
 
 **Purpose**: Shell detection, configuration, and PATH management
 
@@ -45,6 +45,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 | `setup_oh_my_zsh` | 1626 | main | zsh, chsh |
 | `setup_shell_compatibility` | 1698 | main | zsh, bash, grep, chmod |
 | `add_local_bin_to_path` | 2754 | install_aidevops_cli | mkdir, touch, grep |
+| `install_aidevops_cli` | 2803 | main | bash, chmod |
 | `setup_aliases` | 2847 | main | grep, mkdir, touch |
 | `setup_terminal_title` | 2951 | main | grep, bash |
 | `find_opencode_config` | 138 | 6 functions | none |
@@ -71,9 +72,21 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 **Module Recommendation**: `lib/bootstrap.sh`  
 **Rationale**: System-level setup, runs early in setup flow, clear boundaries
 
+**Style Guide Violation — `eval` usage**: `ensure_homebrew` and `check_requirements` both use `eval` to activate Homebrew's shell environment (e.g., `eval "$(/opt/homebrew/bin/brew shellenv)"`). The repository style guide explicitly forbids `eval` for security reasons. During modularisation, replace with the safer `source` form:
+
+```bash
+# Non-compliant (current):
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# Compliant replacement:
+source <( /opt/homebrew/bin/brew shellenv )
+```
+
+This must be addressed in Phase 2 when `lib/bootstrap.sh` is extracted.
+
 ---
 
-### 4. Migrations (6 functions)
+### 4. Migrations (7 functions)
 
 **Purpose**: Version-to-version migration logic, cleanup of deprecated paths/configs
 
@@ -121,7 +134,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ---
 
-### 6. MCP Setup (9 functions)
+### 6. MCP Setup (11 functions)
 
 **Purpose**: MCP server installation, configuration, and path resolution
 
@@ -166,7 +179,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ---
 
-### 8. Configuration Management (6 functions)
+### 8. Configuration Management (8 functions)
 
 **Purpose**: Managing configs, credentials, and OpenCode integration
 
@@ -200,7 +213,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ---
 
-### 10. Specialized Tools (7 functions)
+### 10. Specialized Tools (5 functions)
 
 **Purpose**: Domain-specific tool setups (browser, beads UI, AI orchestration)
 
@@ -273,15 +286,15 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 | Module | Functions | LOC Est. | Dependencies | Priority |
 |--------|-----------|----------|--------------|----------|
 | `lib/core-utils.sh` | 9 | ~400 | None (base layer) | P0 |
-| `lib/shell-env.sh` | 10 | ~600 | core-utils | P1 |
+| `lib/shell-env.sh` | 11 | ~650 | core-utils | P1 |
 | `lib/bootstrap.sh` | 7 | ~500 | core-utils, shell-env | P0 |
-| `lib/migrations.sh` | 6 | ~700 | core-utils, shell-env | P2 |
+| `lib/migrations.sh` | 7 | ~750 | core-utils, shell-env | P2 |
 | `lib/tool-install.sh` | 15 | ~1200 | core-utils, bootstrap | P1 |
-| `lib/mcp-setup.sh` | 9 | ~800 | core-utils, tool-install | P1 |
+| `lib/mcp-setup.sh` | 11 | ~950 | core-utils, tool-install | P1 |
 | `lib/agent-deploy.sh` | 10 | ~900 | core-utils, shell-env | P1 |
-| `lib/config.sh` | 6 | ~400 | core-utils, shell-env | P1 |
+| `lib/config.sh` | 8 | ~500 | core-utils, shell-env | P1 |
 | `lib/plugins.sh` | 2 | ~100 | core-utils, config | P2 |
-| `lib/specialized-tools.sh` | 7 | ~600 | core-utils, tool-install | P2 |
+| `lib/specialized-tools.sh` | 5 | ~450 | core-utils, tool-install | P2 |
 | `setup.sh` (orchestrator) | 2 | ~500 | All modules | P0 |
 
 **Total**: 87 functions, ~5700 LOC
@@ -298,24 +311,24 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ### Phase 2: Extract Bootstrap & Shell (P0-P1)
 1. Create `lib/bootstrap.sh` (7 functions, ~500 LOC)
-2. Create `lib/shell-env.sh` (10 functions, ~600 LOC)
+2. Create `lib/shell-env.sh` (11 functions, ~650 LOC)
 3. Update setup.sh to source both
 4. Test: Run bootstrap and shell setup steps
 5. **Benefit**: Reduces main file by ~1100 LOC, isolates system-level logic
 
 ### Phase 3: Extract Domain Modules (P1)
 1. Create `lib/tool-install.sh` (15 functions, ~1200 LOC)
-2. Create `lib/mcp-setup.sh` (9 functions, ~800 LOC)
+2. Create `lib/mcp-setup.sh` (11 functions, ~950 LOC)
 3. Create `lib/agent-deploy.sh` (10 functions, ~900 LOC)
-4. Create `lib/config.sh` (6 functions, ~400 LOC)
+4. Create `lib/config.sh` (8 functions, ~500 LOC)
 5. Update setup.sh to source all
 6. Test: Run full setup with all domains
 7. **Benefit**: Reduces main file by ~3300 LOC, clear domain boundaries
 
 ### Phase 4: Extract Remaining Modules (P2)
-1. Create `lib/migrations.sh` (6 functions, ~700 LOC)
+1. Create `lib/migrations.sh` (7 functions, ~750 LOC)
 2. Create `lib/plugins.sh` (2 functions, ~100 LOC)
-3. Create `lib/specialized-tools.sh` (7 functions, ~600 LOC)
+3. Create `lib/specialized-tools.sh` (5 functions, ~450 LOC)
 4. Update setup.sh to source all
 5. Test: Full integration test
 6. **Benefit**: setup.sh reduced to ~500 LOC orchestrator
@@ -367,6 +380,11 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 
 ### Risk 5: Testing Coverage Gaps
 **Mitigation**: Incremental rollout with extensive CI testing at each phase
+
+### Risk 6: `eval` Style Guide Violation in Bootstrap Functions
+**Affected functions**: `ensure_homebrew` (line 1287), `check_requirements` (line 1366)  
+**Violation**: Both functions use `eval "$(/opt/homebrew/bin/brew shellenv)"`, which is explicitly forbidden by the repository style guide.  
+**Mitigation**: Replace with `source <( /opt/homebrew/bin/brew shellenv )` when extracting `lib/bootstrap.sh` in Phase 2. Verify behaviour is identical on macOS (Homebrew's `shellenv` output is POSIX-compatible with `source`).
 
 ---
 
@@ -497,6 +515,6 @@ verify_location (3793)
 
 ---
 
-**Document Version**: 1.0  
-**Last Updated**: 2026-02-12  
+**Document Version**: 1.1  
+**Last Updated**: 2026-03-13  
 **Maintainer**: AI DevOps Team


### PR DESCRIPTION
## Summary

Fixes the 2 high-severity findings from PR #1233 review (gemini-code-assist) in `todo/tasks/t316.1-setup-function-audit.md`.

## Finding 1: Function count inconsistencies (line 10)

Reconciled all section header counts to match actual table entries:

| Section | Was | Now | Reason |
|---------|-----|-----|--------|
| Shell Environment | 10 | 11 | Added missing `install_aidevops_cli` |
| Migrations | 6 | 7 | Table had 7 rows |
| MCP Setup | 9 | 11 | Table had 11 rows |
| Configuration Management | 6 | 8 | Table had 8 rows |
| Specialized Tools | 7 | 5 | Table had 5 rows |

**Root cause of the discrepancy**: `install_aidevops_cli (2803)` appeared in the appendix function list but was not assigned to any domain table. It has been added to Shell Environment (it installs the aidevops CLI and depends on `add_local_bin_to_path`).

**Total**: 87 functions confirmed (9+11+7+7+15+11+10+8+2+5+2 = 87).

Module Assignment Table and Refactoring Strategy phase descriptions updated to reflect corrected counts and LOC estimates.

## Finding 2: `eval` not flagged as style guide violation (line 67)

Added explicit style guide violation notice to the Bootstrap section and a new Risk 6 entry in Migration Risks:

- **Affected functions**: `ensure_homebrew` (line 1287), `check_requirements` (line 1366)
- **Violation**: Both use `eval "$(/opt/homebrew/bin/brew shellenv)"` — forbidden by the repo style guide
- **Recommended fix** (to be applied in Phase 2 when `lib/bootstrap.sh` is extracted):

```bash
# Non-compliant (current):
eval "$(/opt/homebrew/bin/brew shellenv)"

# Compliant replacement:
source <( /opt/homebrew/bin/brew shellenv )
```

## Closes

Closes #3502