### PR TITLE
GH#3554: fix(speech-to-speech): elevate API key security note to blockquote

### DIFF
--- a/.agents/tools/voice/speech-to-speech.md
+++ b/.agents/tools/voice/speech-to-speech.md
@@ -81,7 +81,11 @@ Model selection: `--stt_model_name <model>` (any Whisper checkpoint on HF Hub)
 
 Model selection: `--lm_model_name <model>` or `--mlx_lm_model_name <model>`
 
-API keys: Store `OPENAI_API_KEY` via `aidevops secret set OPENAI_API_KEY` (gopass encrypted) or in `~/.config/aidevops/credentials.sh` (600 permissions). See `tools/credentials/api-key-setup.md`.
+> **Security:** When using `--llm open_api`, store `OPENAI_API_KEY` via
+> `aidevops secret set OPENAI_API_KEY` (gopass encrypted, preferred) or in
+> `~/.config/aidevops/credentials.sh` (600 permissions, plaintext fallback).
+> Never hardcode API keys in scripts or config files.
+> See `tools/credentials/api-key-setup.md` for setup.
 
 ### TTS (Text to Speech)
 


### PR DESCRIPTION
## Summary

Closes #3554

Addresses the 10 review findings from PR #403 on `.agents/tools/voice/speech-to-speech.md`.

### Findings Status

All 10 findings from PR #403 review are now addressed:

| # | Severity | Reviewer | Finding | Status |
|---|----------|----------|---------|--------|
| 1 | HIGH | gemini | `transcribe` command reference (non-existent) | ✅ Fixed in commit fd2aa84 |
| 2 | MEDIUM | gemini | PyTorch version typo `2.10+` → should be `2.4+` | ✅ Fixed in commit e8e1448 |
| 3 | HIGH | coderabbit | API key storage guidance missing for `--llm open_api` | ✅ Fixed — elevated to blockquote in this PR |
| 4 | HIGH | coderabbit | `transcribe` command docs reference non-existent command | ✅ Fixed in commit fd2aa84 |
| 5–10 | MEDIUM | human/bot | Confirmations of fixes 1–4 | ✅ All confirmed |

### Change in This PR

The API key security note added in PR #403 was a plain inline sentence. This PR elevates it to a `> **Security:**` blockquote, making it:
- Visually distinct and harder to miss
- Explicitly warns against hardcoding API keys
- Consistent with security guidance patterns in other agent docs

```diff
-API keys: Store `OPENAI_API_KEY` via `aidevops secret set OPENAI_API_KEY` (gopass encrypted) or in `~/.config/aidevops/credentials.sh` (600 permissions). See `tools/credentials/api-key-setup.md`.
+> **Security:** When using `--llm open_api`, store `OPENAI_API_KEY` via
+> `aidevops secret set OPENAI_API_KEY` (gopass encrypted, preferred) or in
+> `~/.config/aidevops/credentials.sh` (600 permissions, plaintext fallback).
+> Never hardcode API keys in scripts or config files.
+> See `tools/credentials/api-key-setup.md` for setup.
```

### Quality

- Markdownlint: 0 violations