### PR TITLE
GH#3637: fix(supervisor): add eval checkpoint cleanup to Phase 1c and Phase 4b

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -1866,6 +1866,13 @@ cmd_pulse() {
 
 			# Clean up PID file
 			cleanup_worker_processes "$stuck_id" 2>>"$SUPERVISOR_LOG" || true
+
+			# t1256: Clean up eval checkpoint file (matches Phase 0.7 cleanup)
+			local stuck_eval_checkpoint="${SUPERVISOR_DIR}/eval-checkpoints/${stuck_id}.eval"
+			if [[ -f "$stuck_eval_checkpoint" ]]; then
+				rm -f "$stuck_eval_checkpoint" 2>/dev/null || true
+				log_verbose "  Phase 1c: removed eval checkpoint for $stuck_id"
+			fi
 		done <<<"$stuck_evaluating"
 	fi
 
@@ -2448,6 +2455,16 @@ cmd_pulse() {
 					escalate_model_on_failure "$orphan_id" 2>>"$SUPERVISOR_LOG" || true
 					attempt_self_heal "$orphan_id" "failed" "No worker process found" "${batch_id:-}" 2>>"$SUPERVISOR_LOG" || true
 				}
+
+				# t1256: Clean up eval checkpoint file if it exists (matches Phase 0.7 cleanup)
+				# Only evaluating tasks can have checkpoint files; cmd_evaluate may recreate them.
+				if [[ "$orphan_status" == "evaluating" ]]; then
+					local orphan_eval_checkpoint="${SUPERVISOR_DIR}/eval-checkpoints/${orphan_id}.eval"
+					if [[ -f "$orphan_eval_checkpoint" ]]; then
+						rm -f "$orphan_eval_checkpoint" 2>/dev/null || true
+						log_verbose "  Phase 4b: removed eval checkpoint for $orphan_id"
+					fi
+				fi
 			fi
 		done <<<"$db_orphans"
 	fi


### PR DESCRIPTION
## Summary

Fixes the high-severity checkpoint file cleanup issue identified by gemini-code-assist in PR #1963 review.

**Root cause:** Phase 0.7 (stale-state recovery) correctly cleans up `eval-checkpoints/{task_id}.eval` files after recovering a stale evaluating task (t1256). However, Phase 1c (stuck evaluating auto-reap) and Phase 4b (DB orphan recovery) both handle evaluating tasks but were missing the same cleanup, allowing checkpoint files to accumulate on disk unboundedly.

**Impact of the bug:** Stale checkpoint files cause `_diagnose_stale_root_cause()` to emit false `pulse_killed_mid_eval` diagnoses for tasks where eval completed normally, undermining the 26% diagnosis improvement target from t1256.

## Changes

- **Phase 1c** (`pulse.sh` ~line 1868): Add checkpoint cleanup after `cleanup_worker_processes()`, matching the Phase 0.7 pattern exactly
- **Phase 4b** (`pulse.sh` ~line 2455): Add checkpoint cleanup guarded by `orphan_status == "evaluating"` since only evaluating tasks can have checkpoint files; `cmd_evaluate` may recreate them for orphaned evaluating tasks

## Pattern consistency

All three recovery phases now follow the same cleanup pattern:

```bash
local <phase>_eval_checkpoint="${SUPERVISOR_DIR}/eval-checkpoints/${task_id}.eval"
if [[ -f "$<phase>_eval_checkpoint" ]]; then
    rm -f "$<phase>_eval_checkpoint" 2>/dev/null || true
    log_verbose "  Phase Xc: removed eval checkpoint for $task_id"
fi
```

Closes #3637