### PR TITLE
t3638: fix PR #1955 review feedback — stale eval_duration_secs and hardcoded watchdog threshold

### DIFF
--- a/.agents/scripts/supervisor-archived/assess-task.sh
+++ b/.agents/scripts/supervisor-archived/assess-task.sh
@@ -301,6 +301,13 @@ assess_task_with_metadata() {
 	local task_id="$1"
 	local _skip_ai="${2:-false}" # ignored — we always use our own AI path
 
+	# t3638: Reset eval_duration_secs to NULL at evaluation start so non-AI paths
+	# (retry, skip-AI) don't carry a stale value from a previous run into the
+	# pattern record description/tags (coderabbit review feedback on PR #1955).
+	if [[ -n "${SUPERVISOR_DB:-}" ]]; then
+		db "$SUPERVISOR_DB" "UPDATE tasks SET eval_duration_secs = NULL WHERE id = '$(sql_escape "$task_id")';" 2>/dev/null || true
+	fi
+
 	local verdict
 	verdict=$(assess_task "$task_id")
 

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -486,14 +486,17 @@ cmd_stale_gc_report() {
 		AND updated_at >= strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-${days} days');
 	" 2>/dev/null || echo "0")
 	if [[ "$has_eval_duration_data" -gt 0 ]]; then
-		echo "--- Eval Duration Analysis (t1252: AI evaluation step timing) ---"
+		# t3638: Use configured watchdog threshold so the report stays aligned with
+		# SUPERVISOR_EVAL_WATCHDOG (coderabbit review feedback on PR #1955).
+		local eval_watchdog="${SUPERVISOR_EVAL_WATCHDOG:-60}"
+		echo "--- Eval Duration Analysis (t1252: AI evaluation step timing, watchdog >= ${eval_watchdog}s) ---"
 		db -column -header "$SUPERVISOR_DB" "
 			SELECT
 				count(*) AS Evals,
 				printf('%.1f', avg(eval_duration_secs)) AS 'Avg Duration (s)',
 				max(eval_duration_secs) AS 'Max Duration (s)',
 				min(eval_duration_secs) AS 'Min Duration (s)',
-				sum(CASE WHEN eval_duration_secs >= 60 THEN 1 ELSE 0 END) AS 'Watchdog Threshold Exceeded'
+				sum(CASE WHEN eval_duration_secs >= ${eval_watchdog} THEN 1 ELSE 0 END) AS 'Watchdog Threshold Exceeded'
 			FROM tasks
 			WHERE eval_duration_secs IS NOT NULL
 			AND updated_at >= strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-${days} days');


### PR DESCRIPTION
## Summary

Addresses the unactioned review feedback from PR #1955 (t1252 eval watchdog/duration metrics), tracked in issue #3638.

## Findings addressed

### 1. Stale `eval_duration_secs` on retry/skip-AI paths (`assess-task.sh`)

**Finding**: coderabbit — `eval_duration_secs` is read from the DB in `record_evaluation_metadata()` but never reset at evaluation start. On retry or skip-AI paths, a stale value from a previous evaluation leaks into the current task's pattern record description and tags, corrupting trend data.

**Fix**: Reset `eval_duration_secs = NULL` at the start of `assess_task_with_metadata()` (before the AI call) so only a freshly-written value is included in the pattern record.

### 2. Hardcoded watchdog threshold in `pulse.sh` SQL (`pulse.sh`)

**Finding**: coderabbit — The eval duration report hardcodes `60` in the SQL `CASE WHEN eval_duration_secs >= 60` expression. If an operator tunes `SUPERVISOR_EVAL_WATCHDOG`, the 'Watchdog Threshold Exceeded' count drifts from the actual configured threshold.

**Fix**: Read `SUPERVISOR_EVAL_WATCHDOG` (default 60) into `eval_watchdog` and substitute it into the SQL and the section header.

## Findings not actioned (with rationale)

- **gemini HIGH — trap cleanup for watchdog sentinel/pid**: Already addressed in commit `93c6ed46` during the original PR review (author noted this in the review thread). The watchdog code was subsequently removed in t1312 when `evaluate_with_ai()` was replaced by `assess-task.sh`.
- **coderabbit — watchdog delay >= eval_timeout guard**: Moot — watchdog subshell code removed in t1312.
- **coderabbit — negative `eval_duration_secs` guard**: Moot — `eval_duration_secs` calculation removed in t1312 (no longer computed from epoch subtraction).

## Files changed

- `.agents/scripts/supervisor-archived/assess-task.sh` — reset `eval_duration_secs` to NULL at evaluation start
- `.agents/scripts/supervisor-archived/pulse.sh` — use `SUPERVISOR_EVAL_WATCHDOG` env var in SQL threshold

Closes #3638