### PR TITLE
GH#3527: fix(supervisor-archived): add parameterized SQLite queries to prevent SQL injection

### DIFF
--- a/.agents/scripts/supervisor-archived/_common.sh
+++ b/.agents/scripts/supervisor-archived/_common.sh
@@ -27,6 +27,42 @@ db() {
 }
 
 #######################################
+# Parameterized SQLite query — prevents SQL injection (GH#3527)
+# Uses SQLite's .param mechanism to bind values separately from query logic.
+# Arguments:
+#   $1 - database path
+#   $2 - SQL query with :name placeholders (e.g. "SELECT * FROM t WHERE id = :id")
+#   $3+ - name=value pairs for each placeholder (e.g. "id=some-value")
+# Example:
+#   db_param "$DB" "SELECT id FROM tasks WHERE id = :tid" "tid=$task_id"
+#   db_param "$DB" "INSERT INTO batch_tasks VALUES (:bid, :tid, :pos)" \
+#       "bid=$batch_id" "tid=$task_id" "pos=$position"
+#######################################
+db_param() {
+	local db_path="$1"
+	local query="$2"
+	shift 2
+
+	# Build .param set commands for each name=value argument.
+	# Uses double-quoted values so single quotes (apostrophes) in task IDs,
+	# descriptions, and repo paths are handled safely without shell escaping
+	# issues. Double-quotes within values are escaped as \".
+	local param_cmds=()
+	local pair name value escaped
+	for pair in "$@"; do
+		name="${pair%%=*}"
+		value="${pair#*=}"
+		# Escape any double-quotes in the value
+		escaped="${value//\"/\\\"}"
+		param_cmds+=(-cmd ".param set :${name} \"${escaped}\"")
+	done
+
+	sqlite3 -cmd ".timeout 5000" "${param_cmds[@]}" "$db_path" "$query"
+	local rc=$?
+	return $rc
+}
+
+#######################################
 # Structured logging functions
 # All output to stderr with color-coded prefixes.
 # Uses printf to safely handle arbitrary message content (avoids echo -e

--- a/.agents/scripts/supervisor-archived/cron.sh
+++ b/.agents/scripts/supervisor-archived/cron.sh
@@ -959,13 +959,14 @@ cmd_auto_pickup() {
 
 		# Auto-batch: assign picked-up tasks to a batch (t296, t1314)
 		# Find unbatched queued tasks (just added by auto-pickup)
+		# Uses parameterized queries (db_param) to prevent SQL injection (GH#3527).
 		local unbatched_queued
 		unbatched_queued=$(db -separator '|' "$SUPERVISOR_DB" "
             SELECT t.id, t.repo FROM tasks t
             WHERE t.status = 'queued'
               AND t.id NOT IN (SELECT task_id FROM batch_tasks)
             ORDER BY t.created_at;
-        " 2>/dev/null || true)
+        " 2>>"${SUPERVISOR_LOG:-/dev/null}" || true)
 
 		if [[ -n "$unbatched_queued" ]]; then
 			# t1314: Batch affinity check — only absorb tasks into a batch if
@@ -978,34 +979,39 @@ cmd_auto_pickup() {
 			while IFS='|' read -r tid trepo_path; do
 				[[ -z "$tid" ]] && continue
 
-				# Find an active batch with repo affinity (same repo)
+				# Find an active batch with repo affinity (same repo).
+				# Uses :repo parameter to prevent SQL injection from repo paths
+				# sourced from the database (which may originate from TODO.md).
 				local affinity_batch_id
-				affinity_batch_id=$(db "$SUPERVISOR_DB" "
+				affinity_batch_id=$(db_param "$SUPERVISOR_DB" "
 					SELECT b.id FROM batches b
 					WHERE b.status IN ('active', 'running')
 					AND EXISTS (
 						SELECT 1 FROM batch_tasks bt
 						JOIN tasks t ON bt.task_id = t.id
 						WHERE bt.batch_id = b.id
-						AND t.repo = '$(sql_escape "${trepo_path:-}")'
+						AND t.repo = :repo
 						AND t.status NOT IN ('complete','deployed','verified','verify_failed','merged','cancelled','failed','blocked')
 					)
 					ORDER BY b.created_at DESC
 					LIMIT 1;
-				" 2>/dev/null || true)
+				" "repo=${trepo_path:-}" 2>>"${SUPERVISOR_LOG:-/dev/null}" || true)
 
 				if [[ -n "$affinity_batch_id" ]]; then
-					# Add to existing batch with repo affinity
+					# Add to existing batch with repo affinity.
+					# Uses :batch_id parameter to prevent SQL injection from
+					# batch IDs returned by the database query above.
 					local max_pos
-					max_pos=$(db "$SUPERVISOR_DB" "
+					max_pos=$(db_param "$SUPERVISOR_DB" "
 						SELECT COALESCE(MAX(position), -1) FROM batch_tasks
-						WHERE batch_id = '$(sql_escape "$affinity_batch_id")';
-					" 2>/dev/null || echo "-1")
+						WHERE batch_id = :batch_id;
+					" "batch_id=$affinity_batch_id" 2>>"${SUPERVISOR_LOG:-/dev/null}" || echo "-1")
 					local pos=$((max_pos + 1))
-					db "$SUPERVISOR_DB" "
+					db_param "$SUPERVISOR_DB" "
 						INSERT OR IGNORE INTO batch_tasks (batch_id, task_id, position)
-						VALUES ('$(sql_escape "$affinity_batch_id")', '$(sql_escape "$tid")', $pos);
-					"
+						VALUES (:batch_id, :task_id, $pos);
+					" "batch_id=$affinity_batch_id" "task_id=$tid" \
+						2>>"${SUPERVISOR_LOG:-/dev/null}"
 					added_to_existing=$((added_to_existing + 1))
 					log_verbose "  Auto-batch: $tid → batch $affinity_batch_id (repo affinity: $(basename "${trepo_path:-.}")) (t1314)"
 				fi
@@ -1022,7 +1028,7 @@ cmd_auto_pickup() {
 				WHERE t.status = 'queued'
 				AND t.id NOT IN (SELECT task_id FROM batch_tasks)
 				ORDER BY t.created_at;
-			" 2>/dev/null || true)
+			" 2>>"${SUPERVISOR_LOG:-/dev/null}" || true)
 
 			if [[ -n "$still_unbatched" ]]; then
 				# Create a new auto-batch for remaining unbatched tasks (t1314)
@@ -1043,7 +1049,7 @@ cmd_auto_pickup() {
 				local still_unbatched_count
 				still_unbatched_count=$(echo "$still_unbatched" | wc -l | tr -d ' ')
 				local auto_batch_id
-				auto_batch_id=$(cmd_batch "$auto_batch_name" --concurrency "$auto_base_concurrency" --tasks "$task_csv" 2>/dev/null)
+				auto_batch_id=$(cmd_batch "$auto_batch_name" --concurrency "$auto_base_concurrency" --tasks "$task_csv" 2>>"${SUPERVISOR_LOG:-/dev/null}")
 				if [[ -n "$auto_batch_id" ]]; then
 					log_success "Auto-batch: created '$auto_batch_name' ($auto_batch_id) with $still_unbatched_count tasks (t1314)"
 				fi


### PR DESCRIPTION
## Summary

- Add `db_param()` function to `supervisor-archived/_common.sh` that uses SQLite's `.param` mechanism to bind values separately from query logic
- Update `cron.sh` to use parameterized queries instead of string interpolation
- Prevents SQL injection via task IDs, descriptions, and repo paths containing special characters

Closes #3527