### PR TITLE
chore(runway-helper): remove redundant jq identity pipe in cmd_usage

### DIFF
--- a/.agents/scripts/runway-helper.sh
+++ b/.agents/scripts/runway-helper.sh
@@ -768,8 +768,7 @@ cmd_usage() {
 			--arg startDate "$start_date" \
 			--arg beforeDate "$end_date" \
 			'if $startDate != "" then {startDate: $startDate} else {} end
-         + if $beforeDate != "" then {beforeDate: $beforeDate} else {} end
-         | if . == {} then {} else . end'
+         + if $beforeDate != "" then {beforeDate: $beforeDate} else {} end'
 	)"
 
 	local result


### PR DESCRIPTION
## Summary

Addresses the unresolved inline review suggestion from Gemini Code Assist on PR #4399 (merged).

- Removes the redundant `| if . == {} then {} else . end` pipe in `cmd_usage`'s `jq` expression
- The preceding expression already produces either an object with properties or `{}`, so the pipe was a no-op
- ShellCheck: zero violations

## Related

- Inline suggestion: https://github.com/marcusquinn/aidevops/pull/4399#discussion_r2929636341
- Original PR: #4399 (merged)
- Original issue: #3543

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal script optimization with no user-visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->