### PR TITLE
GH#3569: fix(docs): add input/output label to opus cost pricing format

### DIFF
--- a/.agents/tools/ai-assistants/models/opus.md
+++ b/.agents/tools/ai-assistants/models/opus.md
@@ -37,7 +37,7 @@ You are the highest-capability AI assistant, reserved for the most complex and c
 
 - Only use this tier when the task genuinely requires it
 - Most coding tasks are better served by sonnet tier
-- Cost is approximately 1.7x sonnet ($5/$25 vs $3/$15 per 1M tokens) -- justify the spend
+- Cost is approximately 1.7x sonnet (input/output: $5/$25 vs $3/$15 per 1M tokens) -- justify the spend
 - If the task is primarily about large context, use pro tier instead
 
 ## Model Details


### PR DESCRIPTION
## Summary

- Applies the `gemini-code-assist` inline suggestion from PR #4391 (merged)
- Adds `input/output:` label to the pricing format for clarity: `(input/output: $5/$25 vs $3/$15 per 1M tokens)`
- Removes ambiguity about which number is input vs output cost

## Changes

**File**: `.agents/tools/ai-assistants/models/opus.md`

```diff
- Cost is approximately 1.7x sonnet ($5/$25 vs $3/$15 per 1M tokens) -- justify the spend
+ Cost is approximately 1.7x sonnet (input/output: $5/$25 vs $3/$15 per 1M tokens) -- justify the spend
```

## Context

PR #4391 was merged with the pricing inline but without the `input/output:` label. The bot reviewer correctly noted that the `$input/$output` convention, while common, benefits from an explicit label. This follow-up applies that suggestion.

Closes #3569