### PR TITLE
fix(audit): remove spaces in process substitution (follow-up to #4394)

### DIFF
--- a/todo/tasks/t316.1-setup-function-audit.md
+++ b/todo/tasks/t316.1-setup-function-audit.md
@@ -79,7 +79,7 @@ This audit catalogues all 87 functions in setup.sh, analyzes their dependencies,
 > eval "$(/opt/homebrew/bin/brew shellenv)"
 >
 > # Use:
-> source <( /opt/homebrew/bin/brew shellenv )
+> source <(/opt/homebrew/bin/brew shellenv)
 > ```
 >
 > **Refactoring action**: Update both functions in Phase 1/2 of the refactoring strategy to eliminate `eval`.


### PR DESCRIPTION
## Summary

Follow-up to PR #4394 addressing the 1 unresolved inline review suggestion from `gemini-code-assist[bot]`.

### Change

In `todo/tasks/t316.1-setup-function-audit.md` line 82, the process substitution example had non-standard spaces inside `<( ... )`:

```bash
# Before (non-standard):
source <( /opt/homebrew/bin/brew shellenv )

# After (standard idiom):
source <(/opt/homebrew/bin/brew shellenv)
```

The bot's suggestion is valid — spaces inside `<(...)` are not standard shell scripting practice and can be confusing, even though bash is lenient about them.

Closes #3502