### PR TITLE
fix(rosetta-audit-helper): use += to append to cleanup file registry (PR #4396 follow-up)

### DIFF
--- a/.agents/scripts/rosetta-audit-helper.sh
+++ b/.agents/scripts/rosetta-audit-helper.sh
@@ -163,7 +163,7 @@ cmd_scan() {
 	local migratable_file non_migratable_file
 	migratable_file=$(mktemp "${TMPDIR:-/tmp}/rosetta-migrate.XXXXXX")
 	non_migratable_file=$(mktemp "${TMPDIR:-/tmp}/rosetta-nomigrate.XXXXXX")
-	_SCAN_CLEANUP_FILES=("$migratable_file" "$non_migratable_file")
+	_SCAN_CLEANUP_FILES+=("$migratable_file" "$non_migratable_file")
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
 	push_cleanup "rm -f '$migratable_file' '$non_migratable_file'"


### PR DESCRIPTION
## Summary

Follow-up to PR #4396 — applies the unresolved inline suggestion from `gemini-code-assist[bot]`.

### Change

In `cmd_scan`, change the assignment operator when registering temp files in `_SCAN_CLEANUP_FILES`:

```diff
-	_SCAN_CLEANUP_FILES=("$migratable_file" "$non_migratable_file")
+	_SCAN_CLEANUP_FILES+=("$migratable_file" "$non_migratable_file")
```

### Why

The `_SCAN_CLEANUP_FILES` array is initialized as empty at script top (line 27) and the EXIT trap reads from it. Using `+=` (append) instead of `=` (assign) is the correct pattern for a registry-style array:

- **Robustness**: If the array is ever populated from multiple call sites, `=` would silently overwrite prior entries, causing temp file leaks. `+=` is safe regardless.
- **Consistency**: Matches the append-style pattern expected for cleanup registries.
- **Gemini suggestion**: This was the one unresolved inline suggestion on PR #4396 (comment ID 2929632384).

The existing `push_cleanup` / `_save_cleanup_scope` / RETURN trap pattern (lines 167–169) is unchanged — this only fixes the EXIT-trap registry population.

Closes #3525