### PR TITLE
chore(new-task): remove redundant env-var prefix in shell examples

### DIFF
--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -28,12 +28,12 @@ Run the wrapper function or script directly, passing the title via an environmen
 
 ```bash
 # Via planning-commit-helper.sh wrapper (preferred)
-# Pass title as env var — never interpolate user input directly into the command string
+# Assign user input to a variable first — never interpolate it directly into the command string
 TASK_TITLE="<sanitized title from user input>"
-output=$(TASK_TITLE="$TASK_TITLE" ~/.aidevops/agents/scripts/planning-commit-helper.sh next-id --title "$TASK_TITLE")
+output=$(~/.aidevops/agents/scripts/planning-commit-helper.sh next-id --title "$TASK_TITLE")
 
 # Or directly via claim-task-id.sh
-output=$(TASK_TITLE="$TASK_TITLE" ~/.aidevops/agents/scripts/claim-task-id.sh --title "$TASK_TITLE" --repo-path "$(git rev-parse --show-toplevel)")
+output=$(~/.aidevops/agents/scripts/claim-task-id.sh --title "$TASK_TITLE" --repo-path "$(git rev-parse --show-toplevel)")
 ```
 
 > **Security note**: Always assign the user-supplied title to a variable first (`TASK_TITLE="..."`), then pass `"$TASK_TITLE"` as the argument. Never interpolate user input directly into a command string (e.g., `--title "$(user input)"`) — this allows shell metacharacters to execute arbitrary commands.


### PR DESCRIPTION
## Summary

Addresses the unresolved inline review suggestion from Gemini on PR #4388.

The `TASK_TITLE="$TASK_TITLE" command` pattern was redundant — the variable is already in scope after the shell assignment, so prefixing it as an environment variable to the same subshell adds no security benefit and reduces readability.

**Before:**
```bash
TASK_TITLE="<sanitized title from user input>"
output=$(TASK_TITLE="$TASK_TITLE" ~/.aidevops/agents/scripts/planning-commit-helper.sh next-id --title "$TASK_TITLE")
output=$(TASK_TITLE="$TASK_TITLE" ~/.aidevops/agents/scripts/claim-task-id.sh --title "$TASK_TITLE" --repo-path "$(git rev-parse --show-toplevel)")
```

**After:**
```bash
TASK_TITLE="<sanitized title from user input>"
output=$(~/.aidevops/agents/scripts/planning-commit-helper.sh next-id --title "$TASK_TITLE")
output=$(~/.aidevops/agents/scripts/claim-task-id.sh --title "$TASK_TITLE" --repo-path "$(git rev-parse --show-toplevel)")
```

The security protection (assigning user input to a variable first, then passing the quoted variable as an argument) is fully preserved — only the redundant env-var prefix is removed.

Closes the inline suggestion: https://github.com/marcusquinn/aidevops/pull/4388#discussion_r2929631563