### PR TITLE
fix(docs): address PR #4393 inline review suggestions in wappalyzer.md

### DIFF
--- a/.agents/tools/research/providers/wappalyzer.md
+++ b/.agents/tools/research/providers/wappalyzer.md
@@ -45,7 +45,6 @@ The provider consists of three files:
 
 - Node.js 18+
 - npm
-- jq
 
 ### Install via helper script
 
@@ -53,7 +52,9 @@ The provider consists of three files:
 .agents/scripts/wappalyzer-helper.sh install
 ```
 
-This installs `jq` (via Homebrew if available) and `@ryntab/wappalyzer-node` globally via npm.
+This installs `@ryntab/wappalyzer-node` globally via npm. The helper script also requires `jq`
+and will attempt to install it via Homebrew on macOS. On other systems, install `jq` manually
+before running this command.
 
 ### Verify installation
 
@@ -176,7 +177,9 @@ Install Node.js 18+:
 brew install node
 
 # Linux (Debian/Ubuntu)
-sudo apt-get install nodejs npm
+# The 'nodejs' package in default repositories is often outdated.
+# Please follow official instructions to install Node.js 18+.
+# See: https://nodejs.org/en/download/package-manager
 ```
 
 ### Timeout errors
@@ -196,7 +199,7 @@ The helper sets `NODE_PATH` to the global npm modules directory automatically.
 
 If this provider doesn't meet your needs:
 
-- **Unbuilt.app** (t1064): Specialised in bundler/minifier detection
+- **Unbuilt.app** (t1064): Specialized in bundler/minifier detection
 - **CRFT Lookup** (t1065): Cloudflare Radar tech detection
 - **BuiltWith API** (t1066): Commercial service (requires API key)
 


### PR DESCRIPTION
## Summary

Addresses the 3 unresolved inline review suggestions from `gemini-code-assist[bot]` on PR #4393.

All 3 suggestions were valid and have been applied:

### Suggestion 1 — jq prerequisite clarity (line 56)
- Removed `jq` from the Prerequisites list (the install script handles it)
- Updated the Install section description to clarify: auto-installed via Homebrew on macOS, manual install required on other systems

### Suggestion 2 — Outdated Linux Node.js install command (line 179)
- Replaced `sudo apt-get install nodejs npm` (installs outdated Node.js 12 on Ubuntu 22.04) with a comment pointing to the official Node.js 18+ installation docs at https://nodejs.org/en/download/package-manager

### Suggestion 3 — British English spelling (line 199)
- Fixed `Specialised` → `Specialized` for consistency with American English used throughout the codebase

## Verification

- `markdownlint-cli2`: 0 errors

Closes the 3 unresolved review threads on #4393.