### PR TITLE
GH#4412: fix(pulse): count all PRs for daily cap, not just open

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -335,13 +335,18 @@ prefetch_state() {
 
 				echo ""
 
-				# Daily PR cap (GH#3821) — count PRs created today to prevent
-				# CodeRabbit quota exhaustion from too many PRs in one day.
-				# Reuses pr_json already fetched above (no extra API call).
+				# Daily PR cap (GH#3821, GH#4412) — count ALL PRs created today
+				# (open, merged, and closed) to prevent CodeRabbit quota exhaustion.
+				# Must use --state all because PRs merged/closed earlier today are
+				# excluded from the open-only pr_json, causing an undercount that
+				# lets the pulse dispatch workers past the real cap.
 				local today_utc
 				today_utc=$(date -u +%Y-%m-%d)
+				local daily_cap_json
+				daily_cap_json=$(gh pr list --repo "$slug" --state all \
+					--json createdAt --limit 200 2>/dev/null) || daily_cap_json="[]"
 				local daily_pr_count
-				daily_pr_count=$(echo "$pr_json" | jq --arg today "$today_utc" \
+				daily_pr_count=$(echo "$daily_cap_json" | jq --arg today "$today_utc" \
 					'[.[] | select(.createdAt | startswith($today))] | length') || daily_pr_count=0
 				[[ "$daily_pr_count" =~ ^[0-9]+$ ]] || daily_pr_count=0
 				local daily_pr_remaining=$((DAILY_PR_CAP - daily_pr_count))
@@ -2670,7 +2675,8 @@ calculate_priority_allocations() {
 		while IFS= read -r slug; do
 			[[ -n "$slug" ]] || continue
 			local pr_json daily_pr_count
-			pr_json=$(gh pr list --repo "$slug" --state open --json createdAt --limit 100 2>/dev/null) || pr_json="[]"
+			# GH#4412: use --state all to count merged/closed PRs too
+			pr_json=$(gh pr list --repo "$slug" --state all --json createdAt --limit 200 2>/dev/null) || pr_json="[]"
 			daily_pr_count=$(echo "$pr_json" | jq --arg today "$today_utc" '[.[] | select(.createdAt | startswith($today))] | length' 2>/dev/null) || daily_pr_count=0
 			[[ "$daily_pr_count" =~ ^[0-9]+$ ]] || daily_pr_count=0
 			if [[ "$daily_pr_count" -lt "$DAILY_PR_CAP" ]]; then


### PR DESCRIPTION
## Summary

- Fix daily PR cap counter to query `--state all` instead of `--state open`, so merged and closed PRs created today are included in the count
- Fix applies to both `prefetch_state()` (pulse-state.txt output) and `calculate_priority_allocations()` (product repo dispatchability check)
- Increase `--limit` from 100 to 200 to match `PULSE_PREFETCH_PR_LIMIT` and avoid truncation on busy days

## Root Cause

The daily PR cap counter reused the open-only PR JSON (`gh pr list --state open`), which excludes PRs created today that were already merged or closed. On a busy day with many merged PRs, the count showed e.g. 1/5 when the actual count was 30, allowing the pulse to dispatch workers far past the real cap.

## Verification

- ShellCheck: zero violations
- Existing tests: all 7 pass (worker count + worker detection)
- Manual review: both affected code paths now use `--state all`

Closes #4412

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated daily pull request cap calculation to count all pull request states (open, merged, and closed) instead of only open ones, improving accuracy of capacity management and repository allocation decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->