### PR TITLE
GH#4266: fix(seo): restore explicit phase list in ai-search-readiness description

### DIFF
--- a/.agents/seo/ai-search-readiness.md
+++ b/.agents/seo/ai-search-readiness.md
@@ -1,6 +1,6 @@
 ---
 name: ai-search-readiness
-description: Orchestrate end-to-end AI search readiness across seven phases from grounding eligibility through citation monitoring
+description: "Orchestrate end-to-end AI search readiness across seven phases: grounding eligibility, query decomposition, criteria alignment (GEO), snippet survivability (SRO), integrity hardening, autonomous discoverability, and citation monitoring."
 mode: subagent
 tools:
   read: true


### PR DESCRIPTION
## Summary

- Restores the explicit list of all seven phases in the YAML `description` frontmatter of `.agents/seo/ai-search-readiness.md`
- Addresses PR #4246 review feedback from Gemini: the description was made too concise, losing the enumerated phase names that served as self-contained documentation

## Change

**Before:**
```yaml
description: Orchestrate end-to-end AI search readiness across seven phases from grounding eligibility through citation monitoring
```

**After:**
```yaml
description: "Orchestrate end-to-end AI search readiness across seven phases: grounding eligibility, query decomposition, criteria alignment (GEO), snippet survivability (SRO), integrity hardening, autonomous discoverability, and citation monitoring."
```

Phase names match the actual section headers in the file body (Phases 0-6).

Closes #4266