### PR TITLE
GH#4267: fix insecure temp file and syntax error in build-mcp key injection example

### DIFF
--- a/.agents/tools/build-mcp/build-mcp.md
+++ b/.agents/tools/build-mcp/build-mcp.md
@@ -254,10 +254,10 @@ Key fields: `type` (`local` | `remote`), `url` (Streamable HTTP endpoint), `head
 Never paste API keys into conversation context. Inject them into the config file from gopass:
 
 ```bash
+tmpfile=$(mktemp)
 jq --arg key "$(gopass show -o provider/api-key)" \
   '.mcp["provider-name"].headers.Authorization = "Bearer " + $key' \
-  ~/.config/opencode/opencode.json > /tmp/oc.json \
-  && mv /tmp/oc.json ~/.config/opencode/opencode.json
+  ~/.config/opencode/opencode.json > "$tmpfile" && mv "$tmpfile" ~/.config/opencode/opencode.json
 ```
 
 This keeps the key out of conversation transcripts and shell history (gopass prompts for GPG passphrase, not the key itself).


### PR DESCRIPTION
## Summary

- Replace hardcoded `/tmp/oc.json` with `mktemp` in the Secure Key Injection code example to prevent race conditions and symlink attacks
- Fix backslash-before-`&&` syntax error that caused `&&` to be passed as a `jq` argument instead of acting as a command separator

Addresses review feedback from gemini-code-assist on PR #4247.

Closes #4267