### PR TITLE
GH#3693: fix(docs): remove non-existent status fields from chrome-webstore-release docs

### DIFF
--- a/.agents/tools/browser/chrome-webstore-release.md
+++ b/.agents/tools/browser/chrome-webstore-release.md
@@ -291,10 +291,7 @@ Create a script dedicated to "what is the latest submission state?".
   - `localVersion`
   - `publishedVersion`
   - `publishedState`
-  - `submittedVersion`
-  - `submittedState`
   - `upToDate`
-  - `pendingReview`
 - Exits non-zero on auth/API/input errors
 
 **Helpful checks to include**:


### PR DESCRIPTION
## Summary

- Remove `submittedVersion`, `submittedState`, and `pendingReview` from the documented status output fields in `chrome-webstore-release.md`
- These fields are not produced by `cmd_status()` in `chrome-webstore-helper.sh` — the actual implementation outputs only: `itemId`, `localVersion`, `publishedVersion`, `publishedState`, `upToDate`
- Addresses unactioned PR #1500 review feedback from Gemini Code Assist (the human noted "Fixed in be58e29" but the fix was lost during squash merge)

Closes #3693