### PR TITLE
GH#3452: fix Continue.dev false detection in ai-cli-config.sh

### DIFF
--- a/.agents/scripts/ai-cli-config.sh
+++ b/.agents/scripts/ai-cli-config.sh
@@ -205,7 +205,9 @@ configure_openapi_search_mcp() {
 	# Continue.dev — ~/.continue/config.json (array-based mcpServers)
 	# -------------------------------------------------------------------------
 	local continue_config="$HOME/.continue/config.json"
-	if [[ -d "$HOME/.continue" ]] || command -v continue >/dev/null 2>&1; then
+	# Note: 'continue' is a bash builtin, so 'command -v continue' always succeeds.
+	# Use 'type -P' to search only the filesystem PATH for a real Continue.dev binary.
+	if [[ -d "$HOME/.continue" ]] || type -P continue >/dev/null 2>&1; then
 		print_info "Configuring OpenAPI Search for Continue.dev..."
 		mkdir -p "$HOME/.continue"
 		local continue_entry


### PR DESCRIPTION
## Summary

- Fix `command -v continue` always succeeding because `continue` is a bash builtin, causing the Continue.dev config block to execute unconditionally on all systems
- Replace with `type -P continue` which only searches the filesystem PATH for a real Continue.dev binary
- This was the only remaining unaddressed HIGH-severity finding from PR #2095 review feedback

## Details

**Problem:** `command -v continue >/dev/null 2>&1` exits 0 in every bash environment because `continue` is a shell builtin keyword. This means the OR condition at line 208 always evaluates true, causing:
- `~/.continue/` directory created silently via `mkdir -p`
- `~/.continue/config.json` written with MCP entry
- Success message logged — even without Continue.dev installed

**Fix:** Use `type -P continue` which searches only the filesystem PATH (excluding builtins), so the block only executes when a real Continue.dev binary exists or the `~/.continue/` directory is already present.

**Other findings from #3452:** All 17 other findings (MEDIUM severity) were already addressed in commit 4160fd1 or dismissed by the human reviewer with documented rationale. This PR addresses the sole remaining HIGH-severity finding.

Closes #3452