### PR TITLE
GH#3453: fix(supervisor): add PPID guard to emergency kill loop to protect interactive sessions

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2714,6 +2714,13 @@ cmd_pulse() {
 				if echo " ${protected_pids} " | grep -q " ${epid} "; then
 					continue
 				fi
+				# Skip processes that still have a live parent (not reparented to init)
+				# — protects interactive sessions not tracked by the supervisor.
+				local eppid
+				eppid=$(ps -o ppid= -p "$epid" 2>/dev/null | tr -d ' ')
+				if [[ -n "$eppid" && "$eppid" != "1" ]]; then
+					continue
+				fi
 				local ecmd
 				ecmd=$(ps -o args= -p "$epid" 2>/dev/null | head -c 100)
 				log_warn "  Emergency kill PID $epid: $ecmd"


### PR DESCRIPTION
## Summary

- Fixes the critical quality-debt from PR #2089 (coderabbit review, GH#3453)
- The emergency-kill loop under high memory pressure was killing **any** non-`protected_pids` process matching `claude|opencode|shellcheck|bash-language-server`, regardless of whether it was an orphan or an interactive user session
- Adds a PPID check after the existing `protected_pids` guard: skips processes whose PPID ≠ 1 (i.e., still has a live parent), only targeting true orphans reparented to init — mirroring the existing orphan-sweep guard

## Changes

**File**: `.agents/scripts/supervisor-archived/pulse.sh`

After the `protected_pids` check in the emergency kill loop, added:

```bash
# Skip processes that still have a live parent (not reparented to init)
# — protects interactive sessions not tracked by the supervisor.
local eppid
eppid=$(ps -o ppid= -p "$epid" 2>/dev/null | tr -d ' ')
if [[ -n "$eppid" && "$eppid" != "1" ]]; then
    continue
fi
```

## Testing

- `bash -n` syntax check passes
- Logic: `ps -o ppid=` returns the parent PID; `tr -d ' '` strips whitespace; if PPID is non-empty and not `1`, the process is not an orphan and is skipped

## Closes

Closes #3453