### PR TITLE
GH#3513: fix(supervisor): use explicit uname check for stat mtime

### DIFF
--- a/.agents/scripts/supervisor-archived/ai-reason.sh
+++ b/.agents/scripts/supervisor-archived/ai-reason.sh
@@ -129,7 +129,13 @@ run_ai_reasoning() {
 	if [[ -f "$lock_file" ]]; then
 		local lock_pid lock_age
 		lock_pid=$(head -1 "$lock_file" 2>/dev/null || echo 0)
-		lock_age=$(($(date +%s) - $(stat -f %m "$lock_file" 2>/dev/null || stat -c %Y "$lock_file" 2>/dev/null || echo 0)))
+		local lock_mtime
+		if [[ "$(uname)" == "Darwin" ]]; then
+			lock_mtime=$(stat -f '%m' "$lock_file" 2>/dev/null || echo "0")
+		else
+			lock_mtime=$(stat -c '%Y' "$lock_file" 2>/dev/null || echo "0")
+		fi
+		lock_age=$(($(date +%s) - lock_mtime))
 		# If lock holder is still alive and lock is not stale (< 5 min), skip
 		if kill -0 "$lock_pid" 2>/dev/null && [[ "$lock_age" -lt 300 ]]; then
 			log_info "AI Reasoning: already running (PID $lock_pid, ${lock_age}s old) — skipping"

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2332,7 +2332,11 @@ cmd_pulse() {
 						if [[ -n "$log_file" && -f "$log_file" ]]; then
 							local log_age_seconds=0
 							local log_mtime
-							log_mtime=$(stat -c %Y "$log_file" 2>/dev/null || stat -f %m "$log_file" 2>/dev/null || echo "0")
+							if [[ "$(uname)" == "Darwin" ]]; then
+								log_mtime=$(stat -f '%m' "$log_file" 2>/dev/null || echo "0")
+							else
+								log_mtime=$(stat -c '%Y' "$log_file" 2>/dev/null || echo "0")
+							fi
 							local now_epoch
 							now_epoch=$(date +%s)
 							log_age_seconds=$((now_epoch - log_mtime))

--- a/.agents/scripts/supervisor-archived/utility.sh
+++ b/.agents/scripts/supervisor-archived/utility.sh
@@ -204,7 +204,11 @@ check_gh_auth() {
 	if [[ -f "$cache_file" ]]; then
 		local cache_age
 		local cache_mtime
-		cache_mtime=$(stat -c '%Y' "$cache_file" 2>/dev/null || stat -f '%m' "$cache_file" 2>/dev/null || echo "0")
+		if [[ "$(uname)" == "Darwin" ]]; then
+			cache_mtime=$(stat -f '%m' "$cache_file" 2>/dev/null || echo "0")
+		else
+			cache_mtime=$(stat -c '%Y' "$cache_file" 2>/dev/null || echo "0")
+		fi
 		cache_age=$(($(date +%s) - cache_mtime))
 		if [[ "$cache_age" -lt "$cache_ttl" ]]; then
 			local cached_result


### PR DESCRIPTION
## Summary

Addresses Gemini review feedback from PR #1267 (quality-debt issue #3513).

The reviewer suggested refactoring `stat`-based mtime calls to use explicit `uname` platform detection instead of relying on command failure for cross-platform compatibility. This pattern is already used correctly at `utility.sh:253` (the `lock_mtime` check) — this PR applies the same pattern to the remaining three occurrences.

## Changes

Three `stat` calls refactored from brittle fallback pattern to explicit `uname` check:

| File | Variable | Context |
|------|----------|---------|
| `supervisor-archived/utility.sh:207` | `cache_mtime` | `check_gh_auth()` cache freshness |
| `supervisor-archived/pulse.sh:2335` | `log_mtime` | Hung-worker log age detection |
| `supervisor-archived/ai-reason.sh:132` | `lock_mtime` | AI reasoning concurrency guard |

**Before** (brittle — relies on command failure):
```bash
cache_mtime=$(stat -c '%Y' "$cache_file" 2>/dev/null || stat -f '%m' "$cache_file" 2>/dev/null || echo "0")
```

**After** (explicit — matches reference pattern at utility.sh:253):
```bash
if [[ "$(uname)" == "Darwin" ]]; then
    cache_mtime=$(stat -f '%m' "$cache_file" 2>/dev/null || echo "0")
else
    cache_mtime=$(stat -c '%Y' "$cache_file" 2>/dev/null || echo "0")
fi
```

## Why This Matters

The fallback pattern is brittle because on some platforms the "wrong" `stat` variant may succeed with unexpected output rather than failing cleanly (exactly the bug that PR #1267 fixed on Linux). An explicit `uname` check makes the platform-specific logic transparent and resilient to future `stat` behaviour changes.

## Testing

- `bash -n` syntax check passes on all three files
- Logic is functionally equivalent to the existing reference pattern at `utility.sh:253`

Closes #3513