### PR TITLE
t4266: docs(ai-search-readiness): restore explicit phase list in description

### DIFF
--- a/.agents/seo/ai-search-readiness.md
+++ b/.agents/seo/ai-search-readiness.md
@@ -1,6 +1,6 @@
 ---
 name: ai-search-readiness
-description: Orchestrate end-to-end AI search readiness across seven phases from grounding eligibility through citation monitoring
+description: Orchestrate end-to-end AI search readiness across seven phases: grounding eligibility, fan-out modeling, GEO, SRO, integrity hardening, discoverability checks, and citation monitoring.
 mode: subagent
 tools:
   read: true


### PR DESCRIPTION
## Summary

- Restores the enumerated seven-phase list in the YAML `description` field of `.agents/seo/ai-search-readiness.md`
- Replaces the vague `from grounding eligibility through citation monitoring` form with the full named sequence: `grounding eligibility, fan-out modeling, GEO, SRO, integrity hardening, discoverability checks, and citation monitoring`
- Phase names verified against the actual Phase 0–6 headings in the file body

## Motivation

PR #4246 review feedback (Gemini, medium severity) flagged that the shortened description lost self-contained documentation value. The explicit list makes the agent's scope immediately clear without requiring the reader to open the file body.

Closes #4266