### PR TITLE
t3491: group local declarations in supervisor-cron auto-batch block

### DIFF
--- a/.agents/scripts/supervisor-archived/cron.sh
+++ b/.agents/scripts/supervisor-archived/cron.sh
@@ -1032,23 +1032,24 @@ cmd_auto_pickup() {
 
 			if [[ -n "$still_unbatched" ]]; then
 				# Create a new auto-batch for remaining unbatched tasks (t1314)
-				local auto_batch_name
+				# Declarations grouped; assigned separately per SC2155.
+				local auto_batch_name auto_cores auto_base_concurrency
+				local task_csv still_unbatched_count auto_batch_id
+
 				auto_batch_name="auto-$(date +%Y%m%d-%H%M%S)"
-				local task_csv
 				task_csv=$(echo "$still_unbatched" | tr '\n' ',' | sed 's/,$//')
+
 				# Derive base concurrency from CPU cores (cores / 2, min 2)
 				# A 10-core Mac gets 5, a 32-core server gets 16, etc.
 				# The adaptive scaling in calculate_adaptive_concurrency() then
 				# adjusts up/down from this base depending on actual load.
-				local auto_cores
 				auto_cores="$(get_cpu_cores)"
-				local auto_base_concurrency=$((auto_cores / 2))
+				auto_base_concurrency=$((auto_cores / 2))
 				if [[ "$auto_base_concurrency" -lt 2 ]]; then
 					auto_base_concurrency=2
 				fi
-				local still_unbatched_count
+
 				still_unbatched_count=$(echo "$still_unbatched" | wc -l | tr -d ' ')
-				local auto_batch_id
 				auto_batch_id=$(cmd_batch "$auto_batch_name" --concurrency "$auto_base_concurrency" --tasks "$task_csv" 2>>"${SUPERVISOR_LOG:-/dev/null}")
 				if [[ -n "$auto_batch_id" ]]; then
 					log_success "Auto-batch: created '$auto_batch_name' ($auto_batch_id) with $still_unbatched_count tasks (t1314)"


### PR DESCRIPTION
## Summary

- Groups all `local` variable declarations at the top of the auto-batch block in `cron.sh`, replacing 6 scattered `local` lines with 2 grouped declarations
- Keeps assignments separate from declarations per ShellCheck SC2155 (avoids masking return values)
- Adds whitespace between logical groups for readability

## Review Feedback Addressed

**Source**: PR #1265 review feedback (CodeRabbit HIGH + Gemini MEDIUM)

| Finding | Resolution |
|---------|-----------|
| CodeRabbit HIGH: local vars declared without assignment, use `local var="..."` pattern | Grouped declarations at block top. Did NOT combine `local` with `$(cmd)` assignments — that would introduce SC2155 violations. The split pattern is correct per ShellCheck. |
| Gemini MEDIUM: group local variable declarations for readability | Done — 2 grouped `local` lines replace 6 scattered ones |
| CodeRabbit nitpick: move concurrency description out of AGENTS.md | Dismissed — PR #1265 only changed a 6-word parenthetical (`concurrency = cores/2, min 2`), not a detailed section. Moving it would fragment the auto-dispatch docs for no benefit. |

## Verification

- `shellcheck --shell=bash -S style` — zero violations
- Behaviour unchanged — only declaration grouping and whitespace

Closes #3491