### PR TITLE
GH#4267: fix(docs): use mktemp for secure temp file in build-mcp key injection example

### DIFF
--- a/.agents/tools/build-mcp/build-mcp.md
+++ b/.agents/tools/build-mcp/build-mcp.md
@@ -254,10 +254,10 @@ Key fields: `type` (`local` | `remote`), `url` (Streamable HTTP endpoint), `head
 Never paste API keys into conversation context. Inject them into the config file from gopass:
 
 ```bash
+tmpfile=$(mktemp)
 jq --arg key "$(gopass show -o provider/api-key)" \
   '.mcp["provider-name"].headers.Authorization = "Bearer " + $key' \
-  ~/.config/opencode/opencode.json > /tmp/oc.json \
-  && mv /tmp/oc.json ~/.config/opencode/opencode.json
+  ~/.config/opencode/opencode.json > "$tmpfile" && mv "$tmpfile" ~/.config/opencode/opencode.json
 ```
 
 This keeps the key out of conversation transcripts and shell history (gopass prompts for GPG passphrase, not the key itself).


### PR DESCRIPTION
## Summary

Fixes the security issue flagged in PR #4247 review feedback (issue #4267).

**Changes in `.agents/tools/build-mcp/build-mcp.md`:**

- Replace hardcoded `/tmp/oc.json` with `mktemp` to create a secure, race-condition-free temporary file
- Fix the backslash syntax error on line 259 that would cause `&&` to be passed as an argument to `jq` instead of chaining commands
- Quote `"$tmpfile"` in the redirect for safety

**Before:**
```bash
jq --arg key "$(gopass show -o provider/api-key)" \
  '.mcp["provider-name"].headers.Authorization = "Bearer " + $key' \
  ~/.config/opencode/opencode.json > /tmp/oc.json \
  && mv /tmp/oc.json ~/.config/opencode/opencode.json
```

**After:**
```bash
tmpfile=$(mktemp)
jq --arg key "$(gopass show -o provider/api-key)" \
  '.mcp["provider-name"].headers.Authorization = "Bearer " + $key' \
  ~/.config/opencode/opencode.json > "$tmpfile" && mv "$tmpfile" ~/.config/opencode/opencode.json
```

Closes #4267