### PR TITLE
GH#3601: fix(generate-opencode-agents): replace unquoted heredocs with printf to prevent shell injection

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -801,38 +801,28 @@ generate_subagent_stub() {
 	*) ;; # No extra tools for other agents
 	esac
 
-	if [[ -n "$extra_tools" ]]; then
-		cat >"$OPENCODE_AGENT_DIR/$name.md" <<EOF
----
-description: ${src_desc}
-mode: subagent
-temperature: 0.2
-permission:
-  external_directory: allow
-tools:
-  read: true
-  bash: true
-$extra_tools
----
-
-**MANDATORY**: Your first action MUST be to read ~/.aidevops/agents/${rel_path} and follow ALL rules within it.
-EOF
-	else
-		cat >"$OPENCODE_AGENT_DIR/$name.md" <<EOF
----
-description: ${src_desc}
-mode: subagent
-temperature: 0.2
-permission:
-  external_directory: allow
-tools:
-  read: true
-  bash: true
----
-
-**MANDATORY**: Your first action MUST be to read ~/.aidevops/agents/${rel_path} and follow ALL rules within it.
-EOF
-	fi
+	# GH#3601: Use printf to write stub content — avoids unquoted heredoc expansion.
+	# src_desc and rel_path come from filesystem (frontmatter sed extraction / path
+	# stripping) and could contain shell metacharacters that would execute inside
+	# an unquoted <<EOF heredoc. printf '%s\n' treats its argument as literal data,
+	# so $(…) or backticks in a description field are never executed.
+	{
+		printf '%s\n' \
+			"---" \
+			"description: ${src_desc}" \
+			"mode: subagent" \
+			"temperature: 0.2" \
+			"permission:" \
+			"  external_directory: allow" \
+			"tools:" \
+			"  read: true" \
+			"  bash: true"
+		[[ -n "$extra_tools" ]] && printf '%s\n' "$extra_tools"
+		printf '%s\n' \
+			"---" \
+			"" \
+			"**MANDATORY**: Your first action MUST be to read ~/.aidevops/agents/${rel_path} and follow ALL rules within it."
+	} >"$OPENCODE_AGENT_DIR/$name.md"
 	echo 1 # Return 1 for counting
 }
 


### PR DESCRIPTION
## Summary

Addresses the critical quality-debt from PR #259 review feedback (issue #3601).

- **Root cause**: `generate_subagent_stub()` used unquoted `<<EOF` heredocs to write subagent stub files. Variables `src_desc` (extracted from frontmatter via `sed`) and `rel_path` (derived from filesystem paths) are written directly into the heredoc body. An unquoted heredoc expands `$(...)`, backticks, and other shell metacharacters — meaning a malicious or malformed description field in any agent's frontmatter could execute arbitrary commands during stub generation.
- **Fix**: Replace both heredoc branches with a single `printf '%s\n'` block. `printf` treats its arguments as literal data, so metacharacters in `src_desc` or `rel_path` are never interpreted as shell syntax.
- **Bonus**: Eliminates the duplicated if/else heredoc structure (32 lines → 22 lines, -31% code).

## Connection to PR #259 Review

PR #259 fixed `((subagent_count++))` → `subagent_count=$((subagent_count + 1))` to prevent silent exit under `set -e`. Gemini Code Assist suggested `((++subagent_count))` as a more concise alternative. The code has since been refactored to use `find | xargs | awk` (no loop counter), making that specific suggestion moot.

However, the same function contained a heredoc injection vulnerability that is the actionable critical finding for this issue.

## Verification

- ShellCheck: zero new violations (only pre-existing SC1091 info on sourced file)
- The `printf '%s\n'` pattern is safe: arguments are treated as literal strings, not shell syntax
- Functionally equivalent output — same YAML frontmatter structure, same mandatory read instruction

Closes #3601