### PR TITLE
GH#3107: fix(opsec): replace curl|sh with safer download-review-execute pattern

### DIFF
--- a/.agents/tools/security/opsec.md
+++ b/.agents/tools/security/opsec.md
@@ -171,8 +171,16 @@ Platforms that use or may use your data for AI training:
 [NetBird](https://netbird.io) (Apache-2.0, Go) creates encrypted peer-to-peer overlays using WireGuard:
 
 ```bash
-# Install
-curl -fsSL https://pkgs.netbird.io/install.sh | sh
+# Install — download and review before executing (never pipe curl directly to sh)
+curl -fsSL https://pkgs.netbird.io/install.sh -o netbird-install.sh
+# Review the script before running:
+less netbird-install.sh
+# Then execute only if satisfied:
+sh netbird-install.sh
+rm netbird-install.sh
+
+# Alternative: use the official package repository for your distro
+# (avoids script execution entirely — see https://pkgs.netbird.io)
 
 # Connect
 netbird up --setup-key YOUR_SETUP_KEY


### PR DESCRIPTION
## Summary

Addresses the remaining unresolved finding from issue #3107 (quality-debt for `opsec.md`).

**Finding**: PR #2268 review feedback (augmentcode[bot], medium severity)
- **File**: `.agents/tools/security/opsec.md:189` (now ~L175)
- **Issue**: The NetBird install example used `curl -fsSL ... | sh` — executing a remote script without review. This is a risky pattern, especially in an OpSec guide.

## Changes

- Replaced `curl ... | sh` with a download-first, review-then-execute pattern
- Added a comment noting the package repository alternative (avoids script execution entirely)
- Kept the rest of the NetBird section intact

## Status of all findings in GH#3107

| Finding | Severity | Status |
|---------|----------|--------|
| CodeRabbit (PR #3088): Pin action examples to full SHA | HIGH | ✅ Already fixed (commit f146ebf) |
| Gemini (PR #3088): Use `allowed_non_write_users` not `allowed_users` | MEDIUM | ✅ Already fixed (verified by @johnwaldo) |
| augmentcode (PR #2268): `curl | sh` in OpSec guide | MEDIUM | ✅ Fixed in this PR |

Closes #3107