### PR TITLE
fix(task-decompose-helper): address GH#3147 quality-debt — regex injection hardening + remove 2>/dev/null suppressions

### DIFF
--- a/.agents/scripts/task-decompose-helper.sh
+++ b/.agents/scripts/task-decompose-helper.sh
@@ -71,11 +71,12 @@ check_existing_subtasks() {
 		return 0
 	fi
 
-	# Escape regex metacharacters in task_id to prevent injection
+	# Escape regex metacharacters in task_id to prevent injection.
+	# Pattern covers all ERE special chars including ] and {}.
 	local escaped_id
 	# Single quotes intentional: sed pattern must not expand
 	# shellcheck disable=SC2016
-	escaped_id=$(printf '%s' "$task_id" | sed 's/[.[\*^$()+?{|\\]/\\&/g')
+	escaped_id=$(printf '%s' "$task_id" | sed 's/[][\\.^$*+?(){}|]/\\&/g')
 
 	local parent_pattern="^- \\[[ x-]\\] ${escaped_id} "
 	local child_pattern="^  - \\[[ x-]\\] ${escaped_id}\\."
@@ -204,7 +205,7 @@ Respond with ONLY a JSON object (no markdown, no explanation outside the JSON):
 {\"kind\": \"atomic\" or \"composite\", \"confidence\": 0.0-1.0, \"reasoning\": \"one sentence explanation\"}"
 
 		local result
-		result=$("$AI_HELPER" --prompt "$prompt" --model haiku --max-tokens 200 2>/dev/null || echo "")
+		result=$("$AI_HELPER" --prompt "$prompt" --model haiku --max-tokens 200 || echo "")
 
 		if [[ -n "$result" ]]; then
 			local json_result
@@ -450,7 +451,7 @@ Respond with ONLY a JSON object (no markdown, no explanation outside the JSON):
 }"
 
 		local result
-		result=$("$AI_HELPER" --prompt "$prompt" --model haiku --max-tokens 600 2>/dev/null || echo "")
+		result=$("$AI_HELPER" --prompt "$prompt" --model haiku --max-tokens 600 || echo "")
 
 		if [[ -n "$result" ]]; then
 			local json_result


### PR DESCRIPTION
## Summary

Fixes all 3 findings from issue #3147 (PR #3091 review feedback on `.agents/scripts/task-decompose-helper.sh`).

### HIGH: Regex injection hardening in `check_existing_subtasks`

The previous `sed` escape pattern `s/[.[\*^$()+?{|\\]/\\&/g` was missing `]` and `{}` from the ERE character class, leaving those characters unescaped and exploitable via crafted `task_id` values.

Updated to the complete pattern: `s/[][\\\\.\^\+?(){}|]/\\&/g` which covers all ERE metacharacters. Verified with a test covering all special chars.

### MEDIUM (×2): Remove `2>/dev/null` from `$AI_HELPER` calls

Removed blanket stderr suppression from both `cmd_classify` (line 207) and `cmd_decompose` (line 453). The `|| echo ""` guard already prevents `set -e` from exiting on failure, so `2>/dev/null` was only hiding authentication failures, API errors, and configuration problems from operators.

## Testing

- `shellcheck` passes (only pre-existing SC1091 info for sourced file)
- Regex escaping verified: all ERE special chars correctly escaped
- Behaviour unchanged for valid task IDs (e.g., `t1408`, `t042`)

Closes #3147