### PR TITLE
GH#3155: use .param set for FTS5 MATCH to prevent SQL injection in recall.sh

### DIFF
--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -176,7 +176,7 @@ cmd_recall() {
 		return $?
 	fi
 
-	# Escape query for FTS5 — tokenise into individual words joined by AND.
+	# Build FTS5 query — tokenise into individual words joined by AND.
 	# Previous approach wrapped the entire query in double quotes, making it a
 	# phrase search (words must appear adjacent and in order). This caused most
 	# multi-word queries to return zero results — e.g., "shellcheck memory"
@@ -186,14 +186,16 @@ cmd_recall() {
 	# each word must appear somewhere in the document, but not necessarily
 	# adjacent. Special characters (hyphens, asterisks) are handled by
 	# quoting individual tokens that contain them.
-	local escaped_query="${query//"'"/"''"}"
+	#
+	# The tokenised query is passed to sqlite3 via .param set (parameterized
+	# binding) rather than string interpolation to prevent SQL injection.
 	# Quote each token individually to handle special chars (hyphens = NOT in FTS5)
 	# "foo-bar baz" → "\"foo-bar\" \"baz\"" (each token quoted, joined by implicit AND)
 	local tokenised_query=""
 	local token
 	set -f # Disable globbing during tokenization (SC2086)
-	for token in $escaped_query; do
-		# Escape embedded double quotes within each token
+	for token in $query; do
+		# Escape embedded double quotes within each token for FTS5 syntax
 		token="${token//\"/\"\"}"
 		if [[ -n "$tokenised_query" ]]; then
 			tokenised_query="$tokenised_query \"$token\""
@@ -202,7 +204,7 @@ cmd_recall() {
 		fi
 	done
 	set +f # Re-enable globbing
-	escaped_query="$tokenised_query"
+	local escaped_query="$tokenised_query"
 
 	# Build filters with validation
 	local extra_filters=""
@@ -253,9 +255,11 @@ cmd_recall() {
 
 	# Search using FTS5 with BM25 ranking
 	# Note: FTS5 tables require special handling - can't use table alias in bm25()
+	# The FTS5 query is bound via .param set to prevent SQL injection (GH#3155).
 	local results
 	results=$(
 		db -json "$MEMORY_DB" <<EOF
+.param set :query "$escaped_query"
 SELECT 
     learnings.id,
     learnings.content,
@@ -270,7 +274,7 @@ SELECT
 FROM learnings
 LEFT JOIN learning_access ON learnings.id = learning_access.id
 $entity_fts_join
-WHERE learnings MATCH '$escaped_query' $extra_filters $auto_join_filter $entity_fts_where
+WHERE learnings MATCH :query $extra_filters $auto_join_filter $entity_fts_where
 ORDER BY score
 LIMIT $limit;
 EOF


### PR DESCRIPTION
## Summary

Fixes the critical SQL injection vulnerability in `.agents/scripts/memory/recall.sh` flagged by Gemini in PR #3064 review (GH#3155).

## Problem

The FTS5 MATCH clause used direct string interpolation of the user-supplied query:

```bash
WHERE learnings MATCH '$escaped_query' ...
```

While single-quote escaping was applied, this pattern is inherently fragile and was flagged as a critical SQL injection risk by Gemini code review.

## Fix

Replace string interpolation with sqlite3 parameterized binding via `.param set`:

```bash
.param set :query "$escaped_query"
SELECT ... WHERE learnings MATCH :query ...
```

This is the approach recommended by Gemini in the original review. The `.param set` dot-command binds the value safely before the SQL executes, eliminating the injection vector entirely.

## Changes

- `recall.sh`: Use `.param set :query` + `:query` parameter in MATCH clause instead of `'$escaped_query'` string interpolation
- Remove now-redundant single-quote escaping of `$query` since `.param set` handles binding safely
- Preserve `set -f`/`set +f` glob guards (SC2086 fix from PR #3064) and per-token double-quote escaping for FTS5 syntax

## Testing

- ShellCheck passes with no warnings
- FTS5 multi-token queries work correctly
- Hyphenated tokens work correctly
- Injection attempts produce FTS5 syntax errors, not SQL execution

Closes #3155