### PR TITLE
fix(email-test-suite): use empty-string check for cert expiry date parse failure (GH#4275)

### DIFF
--- a/.agents/scripts/email-test-suite-helper.sh
+++ b/.agents/scripts/email-test-suite-helper.sh
@@ -1020,8 +1020,8 @@ test_mail_tls() {
 	not_after=$(echo "$dates" | grep 'notAfter' | cut -d= -f2 || true)
 	if [[ -n "$not_after" ]]; then
 		local expiry_epoch
-		expiry_epoch=$(date -j -f "%b %d %H:%M:%S %Y %Z" "$not_after" "+%s" 2>/dev/null || date -d "$not_after" "+%s" 2>/dev/null || echo "0")
-		if [[ "$expiry_epoch" == "0" ]]; then
+		expiry_epoch=$(date -j -f "%b %d %H:%M:%S %Y %Z" "$not_after" "+%s" 2>/dev/null || date -d "$not_after" "+%s" 2>/dev/null)
+		if [[ -z "$expiry_epoch" ]]; then
 			print_warning "Unable to parse certificate expiry date: $not_after"
 		else
 			local now_epoch


### PR DESCRIPTION
## Summary

Fixes quality-debt issue #4275 — unactioned medium-severity review feedback from PR #4214.

## Problem

In `.agents/scripts/email-test-suite-helper.sh` (line 1023), the certificate expiry date parsing used `|| echo "0"` as a fallback when both `date` commands fail, then checked `if [[ "$expiry_epoch" == "0" ]]` to detect failure.

**Bug**: A certificate with an expiry date exactly at Unix epoch 0 (1970-01-01 00:00:00 UTC) would cause `date` to correctly return `"0"`, but the script would incorrectly report a parsing failure instead of computing days remaining.

## Fix

- Removed the `|| echo "0"` fallback
- Changed the failure check from `[[ "$expiry_epoch" == "0" ]]` to `[[ -z "$expiry_epoch" ]]`

When both `date` commands fail, the variable is empty (no output). When they succeed, the variable contains the epoch value — including `0` for epoch 0. This correctly distinguishes parse failure from a valid epoch value.

## Changes

- `.agents/scripts/email-test-suite-helper.sh`: 2-line change at line 1023-1024

## Verification

- `shellcheck` passes with no warnings
- Logic: empty string = parse failure; non-empty string (including `"0"`) = valid epoch

Closes #4275
Source: [PR #4214 review comment](https://github.com/marcusquinn/aidevops/pull/4214#discussion_r2925501865) by gemini-code-assist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error handling in email test suite certificate validation by refining how parsing failures for certificate expiry dates are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->