### PR TITLE
docs(yt-dlp): clarify audio format, convert scope, config destination, and format applicability

### DIFF
--- a/.agents/scripts/commands/yt-dlp.md
+++ b/.agents/scripts/commands/yt-dlp.md
@@ -17,15 +17,15 @@ Parse `$ARGUMENTS` to determine the mode and URL:
 ```text
 /yt-dlp <url>                          → Auto-detect (video/playlist/channel)
 /yt-dlp video <url> [options]          → Download video
-/yt-dlp audio <url> [options]          → Extract audio (MP3)
+/yt-dlp audio <url> [options]          → Extract audio (mp3 by default; use --format to change)
 /yt-dlp playlist <url> [options]       → Download playlist
 /yt-dlp channel <url> [options]        → Download channel
 /yt-dlp transcript <url> [options]     → Download subtitles only
 /yt-dlp info <url>                     → Show video info
-/yt-dlp convert <path> [options]       → Extract audio from local file(s)
+/yt-dlp convert <path> [options]       → Extract audio from a local file or directory of video files
 /yt-dlp install                        → Install yt-dlp + ffmpeg
 /yt-dlp status                         → Check installation
-/yt-dlp config                         → Generate default config
+/yt-dlp config                         → Write default config to ~/.config/yt-dlp/config
 ```
 
 If only a URL is provided (no subcommand), auto-detect:
@@ -72,7 +72,7 @@ Pass through to the helper script:
 | Option | Description |
 |--------|-------------|
 | `--output-dir <path>` | Custom output directory |
-| `--format <fmt>` | Format: `4k`, `1080p`, `720p`, `480p`, `mp3`, `m4a`, `opus`, `wav`, `flac` |
+| `--format <fmt>` | Video/audio: `4k`, `1080p`, `720p`, `480p`, `mp3`, `m4a`, `opus`; convert only: `wav`, `flac` |
 | `--cookies` | Use Chrome cookies (private/age-restricted content) |
 | `--no-archive` | Allow re-downloading already-fetched videos |
 | `--no-sponsorblock` | Keep sponsor segments |


### PR DESCRIPTION
## Summary

Address unactioned review feedback from PR #233 (tracked in GH#3781).

Four documentation clarity fixes in `.agents/scripts/commands/yt-dlp.md`:

- **audio subcommand**: Remove hardcoded `(MP3)` — the format is configurable via `--format m4a`, `--format opus`, etc. Now reads: `Extract audio (mp3 by default; use --format to change)`
- **convert subcommand**: Clarify that `<path>` accepts both a single file and a directory of video files (the helper script handles both). Now reads: `Extract audio from a local file or directory of video files`
- **config subcommand**: Replace vague `Generate default config` with the actual output path. Now reads: `Write default config to ~/.config/yt-dlp/config`
- **--format table**: Split format values to show which apply per subcommand. `wav`/`flac` are only handled by `convert` (via ffmpeg); using them with `audio`/`video` would fail. Now reads: `Video/audio: 4k, 1080p, 720p, 480p, mp3, m4a, opus; convert only: wav, flac`

Closes #3781

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified help text for audio export (default format is mp3, configurable via --format option)
  * Expanded convert command description to indicate it accepts both file and directory inputs
  * Updated config command documentation to specify config location
  * Distinguished between video/audio formats and convert-only formats in format option help

<!-- end of auto-generated comment: release notes by coderabbit.ai -->