### PR TITLE
t3777: address PR #353 review feedback (consistency fixes)

### DIFF
--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -1062,8 +1062,8 @@ For complex workflows, combine both:
 
 ```bash
 # Phase 1: Parallel analysis
-runner-helper.sh run security-reviewer "Audit src/" --attach :4096 &
-runner-helper.sh run perf-analyzer "Profile src/" --attach :4096 &
+runner-helper.sh run security-reviewer "Audit src/" --attach http://localhost:4096 &
+runner-helper.sh run perf-analyzer "Profile src/" --attach http://localhost:4096 &
 wait
 
 # Phase 2: Sequential implementation (based on analysis)

--- a/.agents/tools/ai-assistants/runners/code-reviewer.md
+++ b/.agents/tools/ai-assistants/runners/code-reviewer.md
@@ -54,7 +54,7 @@ For each issue found:
 |----------|-----------|-------|-----|
 | CRITICAL | src/auth.ts:42 | Raw SQL query with string interpolation | Use parameterized query |
 | WARNING | src/api.ts:15 | Missing input validation on user ID | Add zod schema validation |
-| INFO | src/utils.ts:88 | Function exceeds 60 lines | Extract helper functions |
+| INFO | src/utils.ts:88 | Function exceeds 50 lines | Extract helper functions |
 
 ## Summary Format
 


### PR DESCRIPTION
## Summary

- Fix \`--attach\` flag examples in \`headless-dispatch.md\` to use full URL \`http://localhost:4096\` instead of shorthand \`:4096\`, consistent with all other examples in the file
- Fix \`code-reviewer.md\` output table example to show "Function exceeds 50 lines" matching the checklist rule on line 43 (was incorrectly showing 60 lines)

## Changes

- \`.agents/tools/ai-assistants/headless-dispatch.md\` — lines 1065-1066: \`:4096\` → \`http://localhost:4096\`
- \`.agents/tools/ai-assistants/runners/code-reviewer.md\` — line 57: \`exceeds 60 lines\` → \`exceeds 50 lines\`

## Source

Gemini inline review suggestions from PR #353 (merged). Tracked as quality-debt issue.

Closes #3777