### PR TITLE
fix(docs): address PR #364 gemini review — batch script guard + relative paths

### DIFF
--- a/.agents/tools/conversion/mineru.md
+++ b/.agents/tools/conversion/mineru.md
@@ -197,7 +197,7 @@ cat ./converted/paper/paper.md
 ```bash
 # Convert all PDFs in a directory
 for pdf in ./documents/*.pdf; do
-  mineru -p "$pdf" -o ./markdown
+  [ -f "$pdf" ] && mineru -p "$pdf" -o ./markdown
 done
 ```
 
@@ -258,6 +258,6 @@ mineru -p input.pdf -o output_dir --lang zh  # Chinese
 ## Related
 
 - `pandoc.md` - General-purpose document conversion (broader format support)
-- `tools/pdf/overview.md` - PDF manipulation tools (form filling, signing)
-- `tools/data-extraction/` - Data extraction from web sources
-- `tools/ocr/` - OCR-specific tools
+- `../pdf/overview.md` - PDF manipulation tools (form filling, signing)
+- `../data-extraction/` - Data extraction from web sources
+- `../ocr/` - OCR-specific tools

--- a/.agents/tools/pdf/overview.md
+++ b/.agents/tools/pdf/overview.md
@@ -42,7 +42,7 @@ tools:
 | File | Purpose |
 |------|---------|
 | `libpdf.md` | LibPDF library - form filling, signing, manipulation |
-| `tools/conversion/mineru.md` | MinerU - PDF to markdown/JSON for LLM workflows |
+| `../conversion/mineru.md` | MinerU - PDF to markdown/JSON for LLM workflows |
 
 <!-- AI-CONTEXT-END -->
 
@@ -141,9 +141,9 @@ const { bytes: signed } = await pdf.sign({
 ## Related
 
 - `libpdf.md` - Detailed LibPDF usage guide
-- `tools/document/document-creation.md` - Unified document format conversion and creation
-- `tools/conversion/mineru.md` - PDF to markdown/JSON (layout-aware, OCR)
-- `tools/ocr/overview.md` - OCR tool selection guide (PaddleOCR, GLM-OCR, MinerU, Docling)
-- `tools/ocr/paddleocr.md` - PaddleOCR scene text OCR for scanned PDFs and images
-- `tools/conversion/pandoc.md` - General document format conversion
-- `tools/browser/playwright.md` - For PDF rendering/screenshots
+- `../document/document-creation.md` - Unified document format conversion and creation
+- `../conversion/mineru.md` - PDF to markdown/JSON (layout-aware, OCR)
+- `../ocr/overview.md` - OCR tool selection guide (PaddleOCR, GLM-OCR, MinerU, Docling)
+- `../ocr/paddleocr.md` - PaddleOCR scene text OCR for scanned PDFs and images
+- `../conversion/pandoc.md` - General document format conversion
+- `../browser/playwright.md` - For PDF rendering/screenshots


### PR DESCRIPTION
## Summary

Addresses all findings from the Gemini code review on PR #364 (MinerU subagent), tracked in issue #3774.

## Changes

### `.agents/tools/conversion/mineru.md`

- **Batch script robustness** (Gemini MEDIUM, line 201): Added `[ -f "$pdf" ]` guard to the batch processing loop. Without this, when `./documents/` contains no `.pdf` files, the shell passes the literal glob string `./documents/*.pdf` to `mineru`, causing an error.
- **Relative paths in Related section** (Gemini MEDIUM, line 263): Fixed `tools/pdf/overview.md` → `../pdf/overview.md`, `tools/data-extraction/` → `../data-extraction/`, `tools/ocr/` → `../ocr/` — all relative to the file's location at `.agents/tools/conversion/`.

### `.agents/tools/pdf/overview.md`

- **Subagents table path** (Gemini MEDIUM, line 44): Fixed `tools/conversion/mineru.md` → `../conversion/mineru.md` for consistency with `libpdf.md` which uses a relative path.
- **Related section paths** (Gemini MEDIUM, line 144): Fixed all `tools/...` absolute-style paths to `../...` relative paths: `tools/document/document-creation.md`, `tools/conversion/mineru.md`, `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/conversion/pandoc.md`, `tools/browser/playwright.md`.

## Not addressed

- **Broken GitHub link** (Gemini HIGH, line 22): Verified `https://github.com/opendatalab/MinerU` returns HTTP 200 — the link is valid. The Gemini reviewer may have confused it with another project at the time of review. No change needed.

Closes #3774