### PR TITLE
t3786: fix browser automation docs - PR #163 review feedback

### DIFF
--- a/.agents/tools/browser/browser-automation.md
+++ b/.agents/tools/browser/browser-automation.md
@@ -133,7 +133,7 @@ Tested 2026-01-24, macOS ARM64 (Apple Silicon), headless, warm daemon. Median of
 | **Form Fill** (4 fields) | **0.90s** | 1.34s | 1.37s | N/A | 2.24s | 2.58s |
 | **Data Extraction** (5 items) | 1.33s | **1.08s** | 1.53s | 2.53s | 2.68s | 3.48s |
 | **Multi-step** (click + nav) | **1.49s** | 1.49s | 3.06s | N/A | 4.37s | 4.48s |
-| **Reliability** (avg, 3 runs) | **0.64s** | 1.07s | 0.66s | 0.52s | 1.96s | 1.74s |
+| **Reliability** (avg, 3×nav+screenshot) | 0.64s | 1.07s | 0.66s | **0.52s** | 1.96s | 1.74s |
 
 **Key insight**: Playwright is the underlying engine for all tools except Crawl4AI. Screenshots are near-instant (~0.05s, 24-107KB) but rarely needed for AI automation - ARIA snapshots (~0.01s, 50-200 tokens) provide sufficient page understanding for form filling, clicking, and navigation. Use screenshots only for visual debugging or regression testing.
 
@@ -433,8 +433,9 @@ await page.screenshot({ path: '/tmp/screenshot.png' });
 await page.context().storageState({ path: 'state.json' });
 await browser.close();
 
-// Later: restore state
-const context = await browser.newContext({ storageState: 'state.json' });
+// Later, in a new browser session: restore state
+const browser2 = await chromium.launch({ headless: true });
+const context = await browser2.newContext({ storageState: 'state.json' });
 ```
 
 **Persistence**: Use `storageState` to save/load cookies and localStorage across sessions.
@@ -651,7 +652,7 @@ await stagehand.close();
 |--------|-----------|-------|
 | **Direct proxy config** | Playwright, Crawl4AI, Stagehand | Pass in launch/config options |
 | **SOCKS5 VPN** (IVPN/Mullvad) | Playwright, Crawl4AI, Stagehand | `proxy: { server: 'socks5://...' }` |
-| **System proxy** (macOS) | All tools | `networksetup -setsocksfirewallproxy "Wi-Fi" host port` |
+| **System proxy** (macOS only) | All tools | `networksetup -setsocksfirewallproxy "Wi-Fi" host port` |
 | **Browser extension** (FoxyProxy) | Playwriter | Install in your browser |
 | **Residential proxy** (sticky IP) | Playwright, Crawl4AI | Provider session ID for same IP |
 

--- a/.agents/tools/browser/browser-benchmark.md
+++ b/.agents/tools/browser/browser-benchmark.md
@@ -287,6 +287,7 @@ run();
 ```bash
 #!/bin/bash
 # bench-agent-browser.sh
+set -euo pipefail
 
 TESTS=("navigate" "formFill" "extract" "multiStep")
 declare -A RESULTS
@@ -294,47 +295,47 @@ declare -A RESULTS
 bench_navigate() {
   local start end
   start=$(python3 -c 'import time; print(time.time())')
-  agent-browser open "https://the-internet.herokuapp.com/" 2>/dev/null
-  agent-browser screenshot /tmp/bench-ab-nav.png 2>/dev/null
+  agent-browser open "https://the-internet.herokuapp.com/"
+  agent-browser screenshot /tmp/bench-ab-nav.png
   end=$(python3 -c 'import time; print(time.time())')
   echo "$(python3 -c "print(f'{$end - $start:.2f}')")"
-  agent-browser close 2>/dev/null
+  agent-browser close
 }
 
 bench_formFill() {
   local start end
   start=$(python3 -c 'import time; print(time.time())')
-  agent-browser open "https://the-internet.herokuapp.com/login" 2>/dev/null
-  agent-browser snapshot -i 2>/dev/null
-  agent-browser fill '#username' 'tomsmith' 2>/dev/null
-  agent-browser fill '#password' 'SuperSecretPassword!' 2>/dev/null
-  agent-browser click 'button[type="submit"]' 2>/dev/null
-  agent-browser wait url '**/secure' 2>/dev/null
+  agent-browser open "https://the-internet.herokuapp.com/login"
+  agent-browser snapshot -i
+  agent-browser fill '@username' 'tomsmith'
+  agent-browser fill '@password' 'SuperSecretPassword!'
+  agent-browser click '@submit'
+  agent-browser wait --url '**/secure'
   end=$(python3 -c 'import time; print(time.time())')
   echo "$(python3 -c "print(f'{$end - $start:.2f}')")"
-  agent-browser close 2>/dev/null
+  agent-browser close
 }
 
 bench_extract() {
   local start end
   start=$(python3 -c 'import time; print(time.time())')
-  agent-browser open "https://the-internet.herokuapp.com/challenging_dom" 2>/dev/null
-  agent-browser eval "JSON.stringify([...document.querySelectorAll('table tbody tr')].slice(0,5).map(r=>r.textContent.trim()))" 2>/dev/null
+  agent-browser open "https://the-internet.herokuapp.com/challenging_dom"
+  agent-browser eval "JSON.stringify([...document.querySelectorAll('table tbody tr')].slice(0,5).map(r=>r.textContent.trim()))"
   end=$(python3 -c 'import time; print(time.time())')
   echo "$(python3 -c "print(f'{$end - $start:.2f}')")"
-  agent-browser close 2>/dev/null
+  agent-browser close
 }
 
 bench_multiStep() {
   local start end
   start=$(python3 -c 'import time; print(time.time())')
-  agent-browser open "https://the-internet.herokuapp.com/" 2>/dev/null
-  agent-browser click 'a[href="/abtest"]' 2>/dev/null
-  agent-browser wait url '**/abtest' 2>/dev/null
-  agent-browser get url 2>/dev/null
+  agent-browser open "https://the-internet.herokuapp.com/"
+  agent-browser click 'a[href="/abtest"]'
+  agent-browser wait --url '**/abtest'
+  agent-browser get url
   end=$(python3 -c 'import time; print(time.time())')
   echo "$(python3 -c "print(f'{$end - $start:.2f}')")"
-  agent-browser close 2>/dev/null
+  agent-browser close
 }
 
 echo "=== agent-browser Benchmark ==="
@@ -585,22 +586,23 @@ benchParallel();
 ```bash
 #!/bin/bash
 # bench-parallel-ab.sh
+set -euo pipefail
 start=$(python3 -c 'import time; print(time.time())')
-agent-browser --session s1 open "https://the-internet.herokuapp.com/login" 2>/dev/null &
-agent-browser --session s2 open "https://the-internet.herokuapp.com/checkboxes" 2>/dev/null &
-agent-browser --session s3 open "https://the-internet.herokuapp.com/dropdown" 2>/dev/null &
+agent-browser --session s1 open "https://the-internet.herokuapp.com/login" &
+agent-browser --session s2 open "https://the-internet.herokuapp.com/checkboxes" &
+agent-browser --session s3 open "https://the-internet.herokuapp.com/dropdown" &
 wait
 end=$(python3 -c 'import time; print(time.time())')
 echo "3 parallel sessions: $(python3 -c "print(f'{$end - $start:.2f}')")s"
 
 # Verify isolation
-echo "s1: $(agent-browser --session s1 get url 2>/dev/null)"
-echo "s2: $(agent-browser --session s2 get url 2>/dev/null)"
-echo "s3: $(agent-browser --session s3 get url 2>/dev/null)"
+echo "s1: $(agent-browser --session s1 get url)"
+echo "s2: $(agent-browser --session s2 get url)"
+echo "s3: $(agent-browser --session s3 get url)"
 
-agent-browser --session s1 close 2>/dev/null
-agent-browser --session s2 close 2>/dev/null
-agent-browser --session s3 close 2>/dev/null
+agent-browser --session s1 close
+agent-browser --session s2 close
+agent-browser --session s3 close
 ```
 
 ### Crawl4AI Parallel Test

--- a/.agents/tools/browser/chrome-devtools.md
+++ b/.agents/tools/browser/chrome-devtools.md
@@ -50,7 +50,7 @@ npx chrome-devtools-mcp@latest --autoConnect
 
 **Capabilities**:
 - Performance: `lighthouse()`, `measureWebVitals()` (LCP, FID, CLS, TTFB)
-- Network: `monitorNetwork()`, `throttleRequest()` (individual request throttling, Chrome 136+)
+- Network: `monitorNetwork()`, global network throttling via `emulate` tool with `networkConditions`
 - Scraping: `extractData()`, `screenshot()` (fullPage, element)
 - Debug: `captureConsole()`, CSS coverage, visual regression
 - Mobile: `emulateDevice()`, `simulateTouch()` (tap, swipe)

--- a/.agents/tools/browser/crawl4ai.md
+++ b/.agents/tools/browser/crawl4ai.md
@@ -50,7 +50,7 @@ Purpose-built for extraction. Limited interaction via `js_code` parameter or C4A
 
 **AI Page Understanding**: Returns LLM-ready markdown by default. Use `JsonCssExtractionStrategy` for structured data or `LLMExtractionStrategy` for AI-parsed content. No need for screenshots or ARIA - output is already AI-optimized.
 
-**Limitations**: No extensions, no form filling, no interactive automation. No Chrome DevTools MCP pairing.
+**Limitations**: No extensions. Limited interaction via `js_code` parameter or C4A-Script DSL (CLICK, TYPE, PRESS commands) — for complex interactive flows, use Playwright. No Chrome DevTools MCP pairing.
 
 **Install**: `python3 -m venv ~/.aidevops/crawl4ai-venv && source ~/.aidevops/crawl4ai-venv/bin/activate && pip install crawl4ai && crawl4ai-setup`
 


### PR DESCRIPTION
## Summary

Addresses unactioned review feedback from PR #163 (browser automation docs overhaul), tracked in issue #3786.

## Changes

### `browser-automation.md`
- **Fix broken Playwright state restore example**: `browser.close()` was called then `browser.newContext()` used on the same (closed) object. Fixed to launch a new browser instance in the restore snippet.
- **Fix Reliability benchmark row**: Renamed label to "avg, 3×nav+screenshot" to clarify the metric. Fixed bold to Crawl4AI (0.52s) which is actually fastest, not Playwright (0.64s).
- **Annotate `networksetup` as macOS-only** in the proxy table.

### `browser-benchmark.md`
- **Remove `2>/dev/null` from agent-browser commands**: Suppressing stderr hides failures and skews timing results. Added `set -euo pipefail` so failures surface immediately.
- **Fix `agent-browser wait` syntax**: Changed `wait url '**/...'` to `wait --url '**/...'` to match documented CLI syntax.
- **Use snapshot refs for form fill**: Changed CSS selectors to `@username`/`@password` refs (via `snapshot -i`) per agent-browser best practices.
- **Same fixes applied to parallel benchmark script**.

### `chrome-devtools.md`
- **Remove non-existent `throttleRequest()` MCP method**: This method does not exist in `chrome-devtools-mcp`. Replaced with accurate description of global network throttling via the `emulate` tool.

### `crawl4ai.md`
- **Correct false claim about Crawl4AI capabilities**: The doc stated "No extensions, no form filling, no interactive automation." Crawl4AI v0.8.0 does support interaction via `CrawlerRunConfig(js_code=...)` and the C4A-Script DSL (CLICK, TYPE, CLEAR, SET, PRESS commands). Updated to reflect actual capabilities.

Closes #3786