### PR TITLE
fix: address PR #352 review feedback — atomic DELETEs and env-var path (GH#3776)

### DIFF
--- a/.agents/scripts/memory/maintenance.sh
+++ b/.agents/scripts/memory/maintenance.sh
@@ -1325,12 +1325,17 @@ EOF
 	log_success "Migrated $count entries from '$from_ns' to '$to_ns'"
 
 	# If --move, delete from source (with backup — t188)
+	# All DELETEs in a single transaction for atomicity (GH#3776)
 	if [[ "$move" == true ]]; then
 		backup_sqlite_db "$from_db" "pre-move-to-${to_ns}" >/dev/null 2>&1 || log_warn "Backup of source failed before move"
-		db "$from_db" "DELETE FROM learning_relations;"
-		db "$from_db" "DELETE FROM learning_access;"
-		db "$from_db" "DELETE FROM learnings;"
-		db "$from_db" "INSERT INTO learnings(learnings) VALUES('rebuild');"
+		db "$from_db" <<'EOF'
+BEGIN TRANSACTION;
+DELETE FROM learning_relations;
+DELETE FROM learning_access;
+DELETE FROM learnings;
+INSERT INTO learnings(learnings) VALUES('rebuild');
+COMMIT;
+EOF
 		log_info "Cleared source: $from_ns"
 	fi
 

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -1084,7 +1084,7 @@ cmd_destroy() {
 	rm -rf "$dir"
 
 	# Clean up memory namespace if it exists
-	local ns_dir="$HOME/.aidevops/.agent-workspace/memory/namespaces/$name"
+	local ns_dir="${AIDEVOPS_MEMORY_DIR:-$HOME/.aidevops/.agent-workspace/memory}/namespaces/$name"
 	if [[ -d "$ns_dir" ]]; then
 		rm -rf "$ns_dir"
 		log_info "Removed memory namespace: $name"


### PR DESCRIPTION
## Summary

Addresses two medium-severity findings from the Gemini code review on PR #352 (memory namespace maintenance).

- **`memory/maintenance.sh`**: Wrap `--move` source DELETEs in a single `BEGIN/COMMIT` transaction. Previously four separate `sqlite3` calls could leave the source DB in a partial state if interrupted mid-way (e.g., power loss between `DELETE FROM learning_access` and `DELETE FROM learnings`).
- **`runner-helper.sh`**: Replace hardcoded `$HOME/.aidevops/.agent-workspace/memory` path with `${AIDEVOPS_MEMORY_DIR:-$HOME/.aidevops/.agent-workspace/memory}`, consistent with how `memory-helper.sh` resolves `MEMORY_BASE_DIR`.

## Status of all three findings

| # | Finding | Status |
|---|---------|--------|
| 1 | Batch shared-access tracking updates (recall.sh) | Already fixed in t311.4 modularisation (#1208) — `recall.sh` uses a single batched `INSERT...VALUES` |
| 2 | Atomic `--move` DELETEs (maintenance.sh) | Fixed in this PR |
| 3 | Hardcoded memory path (runner-helper.sh) | Fixed in this PR |

## ShellCheck

Zero new violations on both modified files.

Closes #3776