### PR TITLE
GH#3779: refactor(scripts): extract shared version-finding logic to lib/version.sh

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -6,26 +6,12 @@
 
 set -euo pipefail
 
-# VERSION file locations - check in order of preference:
-# 1. Deployed agents directory (setup.sh copies here)
-# 2. Legacy location (some older installs)
-# 3. Source repo for developers
-VERSION_FILE_AGENTS="$HOME/.aidevops/agents/VERSION"
-VERSION_FILE_LEGACY="$HOME/.aidevops/VERSION"
-VERSION_FILE_DEV="$HOME/Git/aidevops/VERSION"
+# Shared version-finding logic (avoids duplication with log-issue-helper.sh)
+# shellcheck source=lib/version.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/version.sh"
 
 get_version() {
-	# Use -r to check readability, not just existence (avoids cat failure under set -e)
-	if [[ -r "$VERSION_FILE_AGENTS" ]]; then
-		cat "$VERSION_FILE_AGENTS"
-	elif [[ -r "$VERSION_FILE_LEGACY" ]]; then
-		cat "$VERSION_FILE_LEGACY"
-	elif [[ -r "$VERSION_FILE_DEV" ]]; then
-		cat "$VERSION_FILE_DEV"
-	else
-		echo "unknown"
-	fi
-	return 0
+	aidevops_find_version
 }
 
 detect_app() {

--- a/.agents/scripts/lib/version.sh
+++ b/.agents/scripts/lib/version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# =============================================================================
+# aidevops Version Library
+# =============================================================================
+# Shared version-finding logic used by aidevops-update-check.sh and
+# log-issue-helper.sh. Source this file rather than duplicating the logic.
+#
+# Usage: source "$(dirname "${BASH_SOURCE[0]}")/lib/version.sh"
+#        local ver; ver=$(aidevops_find_version)
+
+# VERSION file locations - checked in order of preference:
+# 1. Deployed agents directory (setup.sh copies here for all install methods)
+# 2. Legacy location (some older installs)
+# 3. Source repo for developers working from a Git clone
+AIDEVOPS_VERSION_FILE_AGENTS="${HOME}/.aidevops/agents/VERSION"
+AIDEVOPS_VERSION_FILE_LEGACY="${HOME}/.aidevops/VERSION"
+AIDEVOPS_VERSION_FILE_DEV="${HOME}/Git/aidevops/VERSION"
+
+# aidevops_find_version - print the local aidevops version string, or "unknown"
+#
+# Checks three locations in priority order. Uses -r (readable) rather than -f
+# (exists) so that cat never fails under set -e on permission-denied files.
+aidevops_find_version() {
+	if [[ -r "$AIDEVOPS_VERSION_FILE_AGENTS" ]]; then
+		cat "$AIDEVOPS_VERSION_FILE_AGENTS"
+	elif [[ -r "$AIDEVOPS_VERSION_FILE_LEGACY" ]]; then
+		cat "$AIDEVOPS_VERSION_FILE_LEGACY"
+	elif [[ -r "$AIDEVOPS_VERSION_FILE_DEV" ]]; then
+		cat "$AIDEVOPS_VERSION_FILE_DEV"
+	else
+		echo "unknown"
+	fi
+}

--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -7,138 +7,128 @@
 
 set -euo pipefail
 
+# Shared version-finding logic (avoids duplication with aidevops-update-check.sh)
+# shellcheck source=lib/version.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/version.sh"
+
 # -----------------------------------------------------------------------------
 # Diagnostic Information Gathering
 # -----------------------------------------------------------------------------
 
 get_aidevops_version() {
-    # Check in order: deployed agents, legacy location, dev repo
-    # Use -r to check readability, not just existence (avoids cat failure under set -e)
-    local version_file_agents="$HOME/.aidevops/agents/VERSION"
-    local version_file_legacy="$HOME/.aidevops/VERSION"
-    local version_file_dev="$HOME/Git/aidevops/VERSION"
-    
-    if [[ -r "$version_file_agents" ]]; then
-        cat "$version_file_agents"
-    elif [[ -r "$version_file_legacy" ]]; then
-        cat "$version_file_legacy"
-    elif [[ -r "$version_file_dev" ]]; then
-        cat "$version_file_dev"
-    else
-        echo "unknown"
-    fi
-    return 0
+	# Delegate to shared library function (lib/version.sh)
+	aidevops_find_version
 }
 
 get_latest_version() {
-    curl --proto '=https' -fsSL \
-        "https://raw.githubusercontent.com/marcusquinn/aidevops/main/VERSION" \
-        2>/dev/null || echo "unknown"
-    return 0
+	curl --proto '=https' -fsSL \
+		"https://raw.githubusercontent.com/marcusquinn/aidevops/main/VERSION" \
+		2>/dev/null || echo "unknown"
+	return 0
 }
 
 detect_ai_assistant() {
-    # Detect which AI coding assistant is running
-    if [[ "${OPENCODE:-}" == "1" ]]; then
-        echo "OpenCode"
-    elif [[ -n "${CLAUDE_CODE:-}" ]] || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
-        echo "Claude Code"
-    elif [[ -n "${CURSOR_SESSION:-}" ]] || [[ "${TERM_PROGRAM:-}" == "cursor" ]]; then
-        echo "Cursor"
-    elif [[ -n "${WINDSURF_SESSION:-}" ]]; then
-        echo "Windsurf"
-    elif [[ -n "${CONTINUE_SESSION:-}" ]]; then
-        echo "Continue"
-    elif [[ -n "${AIDER_SESSION:-}" ]]; then
-        echo "Aider"
-    elif [[ -n "${AUGMENT_SESSION:-}" ]]; then
-        echo "Augment"
-    elif [[ -n "${COPILOT_SESSION:-}" ]]; then
-        echo "GitHub Copilot"
-    elif [[ -n "${CODY_SESSION:-}" ]]; then
-        echo "Cody"
-    elif [[ -n "${KILO_SESSION:-}" ]]; then
-        echo "Kilo Code"
-    else
-        # Check parent process
-        local parent
-        parent=$(ps -o comm= -p "${PPID:-0}" 2>/dev/null || echo "")
-        case "$parent" in
-            *opencode*) echo "OpenCode" ;;
-            *claude*) echo "Claude Code" ;;
-            *cursor*) echo "Cursor" ;;
-            *aider*) echo "Aider" ;;
-            *) echo "Unknown" ;;
-        esac
-    fi
-    return 0
+	# Detect which AI coding assistant is running
+	if [[ "${OPENCODE:-}" == "1" ]]; then
+		echo "OpenCode"
+	elif [[ -n "${CLAUDE_CODE:-}" ]] || [[ -n "${CLAUDE_SESSION_ID:-}" ]]; then
+		echo "Claude Code"
+	elif [[ -n "${CURSOR_SESSION:-}" ]] || [[ "${TERM_PROGRAM:-}" == "cursor" ]]; then
+		echo "Cursor"
+	elif [[ -n "${WINDSURF_SESSION:-}" ]]; then
+		echo "Windsurf"
+	elif [[ -n "${CONTINUE_SESSION:-}" ]]; then
+		echo "Continue"
+	elif [[ -n "${AIDER_SESSION:-}" ]]; then
+		echo "Aider"
+	elif [[ -n "${AUGMENT_SESSION:-}" ]]; then
+		echo "Augment"
+	elif [[ -n "${COPILOT_SESSION:-}" ]]; then
+		echo "GitHub Copilot"
+	elif [[ -n "${CODY_SESSION:-}" ]]; then
+		echo "Cody"
+	elif [[ -n "${KILO_SESSION:-}" ]]; then
+		echo "Kilo Code"
+	else
+		# Check parent process
+		local parent
+		parent=$(ps -o comm= -p "${PPID:-0}" 2>/dev/null || echo "")
+		case "$parent" in
+		*opencode*) echo "OpenCode" ;;
+		*claude*) echo "Claude Code" ;;
+		*cursor*) echo "Cursor" ;;
+		*aider*) echo "Aider" ;;
+		*) echo "Unknown" ;;
+		esac
+	fi
+	return 0
 }
 
 get_install_method() {
-    # Detect how aidevops was installed
-    local aidevops_path
-    aidevops_path=$(command -v aidevops 2>/dev/null || echo "")
-    
-    if [[ -z "$aidevops_path" ]]; then
-        echo "not in PATH"
-    elif [[ "$aidevops_path" == *"homebrew"* ]] || [[ "$aidevops_path" == "/opt/homebrew"* ]]; then
-        echo "Homebrew"
-    elif [[ "$aidevops_path" == *"node_modules"* ]] || [[ "$aidevops_path" == *"npm"* ]]; then
-        echo "npm"
-    elif [[ "$aidevops_path" == "$HOME/Git/aidevops"* ]]; then
-        echo "source (Git clone)"
-    else
-        echo "unknown ($aidevops_path)"
-    fi
-    return 0
+	# Detect how aidevops was installed
+	local aidevops_path
+	aidevops_path=$(command -v aidevops 2>/dev/null || echo "")
+
+	if [[ -z "$aidevops_path" ]]; then
+		echo "not in PATH"
+	elif [[ "$aidevops_path" == *"homebrew"* ]] || [[ "$aidevops_path" == "/opt/homebrew"* ]]; then
+		echo "Homebrew"
+	elif [[ "$aidevops_path" == *"node_modules"* ]] || [[ "$aidevops_path" == *"npm"* ]]; then
+		echo "npm"
+	elif [[ "$aidevops_path" == "$HOME/Git/aidevops"* ]]; then
+		echo "source (Git clone)"
+	else
+		echo "unknown ($aidevops_path)"
+	fi
+	return 0
 }
 
 get_git_context() {
-    local repo branch toplevel
-    toplevel=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
-    if [[ -n "$toplevel" ]]; then
-        repo=$(basename "$toplevel")
-        branch=$(git branch --show-current 2>/dev/null || echo "detached")
-    else
-        repo="none"
-        branch="n/a"
-    fi
-    echo "$repo ($branch)"
-    return 0
+	local repo branch toplevel
+	toplevel=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+	if [[ -n "$toplevel" ]]; then
+		repo=$(basename "$toplevel")
+		branch=$(git branch --show-current 2>/dev/null || echo "detached")
+	else
+		repo="none"
+		branch="n/a"
+	fi
+	echo "$repo ($branch)"
+	return 0
 }
 
 gather_diagnostics() {
-    local current_version latest_version ai_assistant install_method
-    local os_info shell_info git_context
-    
-    current_version=$(get_aidevops_version)
-    latest_version=$(get_latest_version)
-    ai_assistant=$(detect_ai_assistant)
-    install_method=$(get_install_method)
-    git_context=$(get_git_context)
-    
-    # OS info
-    if [[ "$(uname)" == "Darwin" ]]; then
-        os_info="macOS $(sw_vers -productVersion 2>/dev/null || echo 'unknown')"
-    elif [[ "$(uname)" == "Linux" ]]; then
-        # Use || true to prevent pipefail from exiting on missing PRETTY_NAME
-        os_info=$(grep PRETTY_NAME /etc/os-release 2>/dev/null | cut -d'"' -f2 || true)
-        # Fallback if PRETTY_NAME not found or empty
-        : "${os_info:=Linux $(uname -r)}"
-    else
-        os_info="$(uname -s) $(uname -r)"
-    fi
-    
-    # Shell info
-    shell_info="${SHELL:-unknown}"
-    if [[ -n "${ZSH_VERSION:-}" ]]; then
-        shell_info="zsh $ZSH_VERSION"
-    elif [[ -n "${BASH_VERSION:-}" ]]; then
-        shell_info="bash $BASH_VERSION"
-    fi
-    
-    # Output in markdown format
-    cat <<EOF
+	local current_version latest_version ai_assistant install_method
+	local os_info shell_info git_context
+
+	current_version=$(get_aidevops_version)
+	latest_version=$(get_latest_version)
+	ai_assistant=$(detect_ai_assistant)
+	install_method=$(get_install_method)
+	git_context=$(get_git_context)
+
+	# OS info
+	if [[ "$(uname)" == "Darwin" ]]; then
+		os_info="macOS $(sw_vers -productVersion 2>/dev/null || echo 'unknown')"
+	elif [[ "$(uname)" == "Linux" ]]; then
+		# Use || true to prevent pipefail from exiting on missing PRETTY_NAME
+		os_info=$(grep PRETTY_NAME /etc/os-release 2>/dev/null | cut -d'"' -f2 || true)
+		# Fallback if PRETTY_NAME not found or empty
+		: "${os_info:=Linux $(uname -r)}"
+	else
+		os_info="$(uname -s) $(uname -r)"
+	fi
+
+	# Shell info
+	shell_info="${SHELL:-unknown}"
+	if [[ -n "${ZSH_VERSION:-}" ]]; then
+		shell_info="zsh $ZSH_VERSION"
+	elif [[ -n "${BASH_VERSION:-}" ]]; then
+		shell_info="bash $BASH_VERSION"
+	fi
+
+	# Output in markdown format
+	cat <<EOF
 - **aidevops version**: $current_version
 - **Latest version**: $latest_version
 - **Install method**: $install_method
@@ -148,7 +138,7 @@ gather_diagnostics() {
 - **Working repo**: $git_context
 - **gh CLI**: $(gh --version 2>/dev/null | head -1 || echo "not installed")
 EOF
-    return 0
+	return 0
 }
 
 # -----------------------------------------------------------------------------
@@ -156,37 +146,37 @@ EOF
 # -----------------------------------------------------------------------------
 
 check_gh_auth() {
-    if ! command -v gh &>/dev/null; then
-        echo "ERROR: GitHub CLI (gh) not installed" >&2
-        echo "Install with: brew install gh (macOS) or apt install gh (Linux)" >&2
-        return 1
-    fi
-    
-    if ! gh auth status &>/dev/null; then
-        echo "ERROR: GitHub CLI not authenticated" >&2
-        echo "Run: gh auth login" >&2
-        return 1
-    fi
-    
-    echo "OK: GitHub CLI authenticated"
-    return 0
+	if ! command -v gh &>/dev/null; then
+		echo "ERROR: GitHub CLI (gh) not installed" >&2
+		echo "Install with: brew install gh (macOS) or apt install gh (Linux)" >&2
+		return 1
+	fi
+
+	if ! gh auth status &>/dev/null; then
+		echo "ERROR: GitHub CLI not authenticated" >&2
+		echo "Run: gh auth login" >&2
+		return 1
+	fi
+
+	echo "OK: GitHub CLI authenticated"
+	return 0
 }
 
 search_issues() {
-    local query="$1"
-    
-    # Verify gh CLI is available and authenticated before searching
-    if ! check_gh_auth >/dev/null 2>&1; then
-        check_gh_auth  # Run again to show error message
-        return 1
-    fi
-    
-    gh issue list -R marcusquinn/aidevops \
-        --state all \
-        --search "$query" \
-        --limit 10 \
-        --json number,title,state,url \
-        --jq '.[] | "#\(.number) [\(.state)] \(.title)\n   \(.url)"'
+	local query="$1"
+
+	# Verify gh CLI is available and authenticated before searching
+	if ! check_gh_auth >/dev/null 2>&1; then
+		check_gh_auth # Run again to show error message
+		return 1
+	fi
+
+	gh issue list -R marcusquinn/aidevops \
+		--state all \
+		--search "$query" \
+		--limit 10 \
+		--json number,title,state,url \
+		--jq '.[] | "#\(.number) [\(.state)] \(.title)\n   \(.url)"'
 }
 
 # -----------------------------------------------------------------------------
@@ -194,25 +184,25 @@ search_issues() {
 # -----------------------------------------------------------------------------
 
 main() {
-    local command="${1:-diagnostics}"
-    
-    case "$command" in
-        diagnostics)
-            gather_diagnostics
-            ;;
-        check-auth)
-            check_gh_auth
-            ;;
-        search)
-            local query="${2:-}"
-            if [[ -z "$query" ]]; then
-                echo "Usage: log-issue-helper.sh search \"query\""
-                return 1
-            fi
-            search_issues "$query"
-            ;;
-        help|--help|-h)
-            cat <<EOF
+	local command="${1:-diagnostics}"
+
+	case "$command" in
+	diagnostics)
+		gather_diagnostics
+		;;
+	check-auth)
+		check_gh_auth
+		;;
+	search)
+		local query="${2:-}"
+		if [[ -z "$query" ]]; then
+			echo "Usage: log-issue-helper.sh search \"query\""
+			return 1
+		fi
+		search_issues "$query"
+		;;
+	help | --help | -h)
+		cat <<EOF
 aidevops Issue Logger Helper
 
 Usage: log-issue-helper.sh [command]
@@ -228,13 +218,13 @@ Examples:
   log-issue-helper.sh check-auth
   log-issue-helper.sh search "update check"
 EOF
-            ;;
-        *)
-            echo "Unknown command: $command"
-            echo "Run: log-issue-helper.sh help"
-            return 1
-            ;;
-    esac
+		;;
+	*)
+		echo "Unknown command: $command"
+		echo "Run: log-issue-helper.sh help"
+		return 1
+		;;
+	esac
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Addresses the Gemini code review finding from PR #248 (tracked as quality-debt issue #3779):

- The `get_aidevops_version()` function in `log-issue-helper.sh` was nearly identical to `get_version()` in `aidevops-update-check.sh`, creating a maintenance risk if the version-finding logic ever needs to change.

## Changes

- **New**: `.agents/scripts/lib/version.sh` — shared library exposing `aidevops_find_version()` with the canonical three-location priority order and `-r` readability checks
- **Updated**: `aidevops-update-check.sh` — sources `lib/version.sh`; `get_version()` now delegates to `aidevops_find_version()`
- **Updated**: `log-issue-helper.sh` — sources `lib/version.sh`; `get_aidevops_version()` now delegates to `aidevops_find_version()`

## Behaviour

No functional change. All existing behaviour is preserved:
- Three-location priority order: `~/.aidevops/agents/VERSION` → `~/.aidevops/VERSION` → `~/Git/aidevops/VERSION`
- Uses `-r` (readable) checks instead of `-f` (exists) to avoid `cat` failures under `set -e`
- Falls back to `"unknown"` when no VERSION file is found
- `lib/` directory is deployed automatically by `setup.sh` rsync (no setup changes needed)

## Testing

```bash
# Verify shared library works
bash -c 'source .agents/scripts/lib/version.sh && aidevops_find_version'

# Verify log-issue-helper.sh diagnostics still work
bash .agents/scripts/log-issue-helper.sh diagnostics

# Verify update check still works
bash .agents/scripts/aidevops-update-check.sh --interactive
```

Closes #3779