### PR TITLE
t1473: enforce worktree-first guidance in guardrails

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -34,7 +34,7 @@ Subagent write restrictions: on `main`/`master`, subagents may ONLY write to `RE
 2. Brief file at `todo/tasks/{task_id}-brief.md` is MANDATORY (see `templates/brief-template.md`)
 3. Brief must include: session origin, what, why, how, acceptance criteria, context
 4. Ask user: implement now or queue for runner?
-5. Full-loop: branch/worktree → implement → test → verify → commit/PR
+5. Full-loop: keep canonical repo on `main` → create/use linked worktree → implement → test → verify → commit/PR
 6. Queue: add to TODO.md for supervisor dispatch
 7. Never skip testing. Never declare "done" without verification.
 
@@ -46,7 +46,7 @@ Subagent write restrictions: on `main`/`master`, subagents may ONLY write to `RE
 
 Not every autonomous task should use `/full-loop`. Use this decision rule:
 - **Code change needed** (repo files, tests, PRs) → `/full-loop`
-- **Operational execution** (reports, audits, monitoring, outreach, client ops) → run a domain agent/command directly, with no branch/PR ceremony
+- **Operational execution** (reports, audits, monitoring, outreach, client ops) → run a domain agent/command directly, with no worktree/PR ceremony
 
 For setup workflow, safety gates, and scheduling patterns, use `/routine` or read `.agents/scripts/commands/routine.md`.
 
@@ -74,7 +74,7 @@ Every agent session — interactive, worker, or supervisor — should improve th
 
 If uncertain, ask: "Would this fix apply to every repo the framework manages, or only this one?" Framework-wide problems go to aidevops; project-specific problems stay local. Never create framework tasks in a project repo — they become invisible to framework maintainers and pollute the project's task namespace.
 
-**Scope boundary for code changes (t1405, GH#2928).** Separate "observe and report" from "observe and fix". When dispatched by the pulse, the `PULSE_SCOPE_REPOS` env var lists the repo slugs where you may create branches and PRs. Filing issues is always allowed on any repo — cross-repo bug reports are valuable. But code changes (branches, PRs, commits) are restricted to repos in `PULSE_SCOPE_REPOS`. If the target repo is not in scope, file the issue and stop. The issue enters that repo's queue for their maintainers (or their own pulse) to handle. If `PULSE_SCOPE_REPOS` is empty or unset (interactive mode), no scope restriction applies.
+**Scope boundary for code changes (t1405, GH#2928).** Separate "observe and report" from "observe and fix". When dispatched by the pulse, the `PULSE_SCOPE_REPOS` env var lists the repo slugs where you may create worktrees and PRs. Filing issues is always allowed on any repo — cross-repo bug reports are valuable. But code changes (worktrees, PRs, commits) are restricted to repos in `PULSE_SCOPE_REPOS`. If the target repo is not in scope, file the issue and stop. The issue enters that repo's queue for their maintainers (or their own pulse) to handle. If `PULSE_SCOPE_REPOS` is empty or unset (interactive mode), no scope restriction applies.
 
 **What counts as self-improvement:**
 - Filing issues for repeated failure patterns
@@ -190,11 +190,11 @@ Full rules: `reference/planning-detail.md`
 
 ## Git Workflow
 
-Branches: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
+Worktree naming prefixes: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
 
 PR title: `{task-id}: {description}`. Create TODO entry first for unplanned work.
 
-Worktrees: `wt switch -c {type}/{name}`. Re-read files at worktree path before editing. NEVER remove others' worktrees.
+Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `main`, and treat the Git ref as an internal detail inside the linked worktree. User-facing guidance should talk about the worktree path, not "using a branch". Re-read files at worktree path before editing. NEVER remove others' worktrees.
 
 Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -275,7 +275,7 @@ When referencing specific functions or code include the pattern `file_path:line_
 - Full docs: `tools/security/tamper-evident-audit.md`.
 
 # Git Workflow and Traceability
-Git is the primary audit trail for all work. Every change should be discoverable through the chain: TODO task -> GitHub issue -> branch -> PR -> merge commit. A PR without a TODO entry, or an issue closed without a PR link, is an audit gap.
+Git is the primary audit trail for all work. Every change should be discoverable through the chain: TODO task -> GitHub issue -> worktree/ref -> PR -> merge commit. A PR without a TODO entry, or an issue closed without a PR link, is an audit gap.
 
 **Traceability rules:**
 - Every PR MUST have a task ID in the title (`{task-id}: {description}`). No exceptions — even 1-line fixes. For unplanned work, create the TODO entry first, then the PR.
@@ -333,8 +333,9 @@ Git is the primary audit trail for all work. Every change should be discoverable
 
 **Pre-edit rules:**
 - Before ANY file modification: run `~/.aidevops/agents/scripts/pre-edit-check.sh`
-- Exit 0 = proceed, Exit 1 = STOP (on main), Exit 2 = create worktree, Exit 3 = warn
-- NEVER edit on main/master. Main repo stays on `main`; feature work in worktrees (`~/Git/{repo}-{type}-{name}/`)
+- Exit 0 = proceed, Exit 1 = STOP (on main), Exit 2 = create worktree, Exit 3 = warn that the canonical repo directory is off main
+- NEVER edit on main/master. The canonical repo directory stays on `main`; all code work happens from linked worktree paths (`~/Git/{repo}-{type}-{name}/`)
+- In user-facing output, describe the workflow as `worktree-first`. Do not tell the user to "create a branch" or to keep working in the canonical repo directory on a non-main ref. If a Git ref name must be mentioned, frame it as implementation detail inside the worktree.
 - Loop mode: `pre-edit-check.sh --loop-mode --task "description"`
 - NEVER revert others' changes or use `git reset --hard` / `git checkout -- <file>` without explicit user request
 

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # =============================================================================
-# Pre-Edit Git Branch Check
+# Pre-Edit Git Worktree Check
 # =============================================================================
-# Run this BEFORE any file edit to enforce the git workflow.
-# Returns exit code 1 if on main/master branch (should create branch first).
+# Run this BEFORE any file edit to enforce the canonical-repo-on-main + linked-worktree workflow.
+# Returns exit code 1 if on main/master (should create a dedicated worktree first).
 #
 # Usage:
 #   ~/.aidevops/agents/scripts/pre-edit-check.sh
@@ -12,10 +12,10 @@
 #   ~/.aidevops/agents/scripts/pre-edit-check.sh --verify-op "git push --force origin main"
 #
 # Exit codes:
-#   0 - OK to proceed (on feature branch in worktree, or docs-only on main)
-#   1 - STOP (on protected branch main/master, interactive mode)
+#   0 - OK to proceed (in a linked worktree, or docs-only on main)
+#   1 - STOP (on protected main/master, interactive mode)
 #   2 - Create worktree (loop mode detected code task on main)
-#   3 - WARNING (on feature branch in main repo - should use worktree instead)
+#   3 - WARNING (canonical repo directory is not on main - move it back and continue from a linked worktree)
 #
 # High-stakes detection (--check-command):
 #   When --check-command is passed, the script checks the command against
@@ -29,8 +29,8 @@
 #   verification for high-stakes operations.
 #
 # AI assistants should call this before any Edit/Write tool and:
-# - Exit 1: STOP and present branch creation options
-# - Exit 3: Present options to user (continue, create worktree, or switch main back)
+# - Exit 1: STOP and present worktree creation instructions
+# - Exit 3: Warn that the canonical repo directory is off main and move work to a linked worktree path
 # - Exit 0: Proceed with edits
 # =============================================================================
 
@@ -97,7 +97,7 @@ is_docs_only() {
 		return 0 # Is docs-only
 	fi
 
-	# Default: not docs-only (safer to create branch)
+	# Default: not docs-only (safer to require a worktree)
 	return 1
 }
 
@@ -273,15 +273,15 @@ run_operation_verification() {
 
 # Check if we're in a git repository
 if ! git rev-parse --is-inside-work-tree &>/dev/null; then
-	echo -e "${YELLOW}Not in a git repository - no branch check needed${NC}"
+	echo -e "${YELLOW}Not in a git repository - no worktree check needed${NC}"
 	exit 0
 fi
 
-# Get current branch
+# Get current ref name
 current_branch=$(git branch --show-current 2>/dev/null || echo "")
 
 if [[ -z "$current_branch" ]]; then
-	echo -e "${YELLOW}Detached HEAD state - consider creating a branch${NC}"
+	echo -e "${YELLOW}Detached HEAD state - prefer creating a dedicated worktree before editing${NC}"
 	exit 0
 fi
 
@@ -304,17 +304,10 @@ if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
 	# Interactive mode: show warning and exit
 	echo ""
 	echo -e "${RED}${BOLD}======================================================${NC}"
-	echo -e "${RED}${BOLD}  STOP - ON PROTECTED BRANCH: $current_branch${NC}"
+	echo -e "${RED}${BOLD}  STOP - ON PROTECTED MAIN WORKTREE: $current_branch${NC}"
 	echo -e "${RED}${BOLD}======================================================${NC}"
 	echo ""
-	echo -e "${YELLOW}You must create a branch before making changes.${NC}"
-	echo ""
-	echo "Suggested branch names based on change type:"
-	echo "  feature/description  - New functionality"
-	echo "  bugfix/description   - Bug fixes"
-	echo "  chore/description    - Maintenance, docs, config"
-	echo "  hotfix/description   - Urgent production fixes"
-	echo "  refactor/description - Code restructuring"
+	echo -e "${YELLOW}Leave the canonical repo on 'main' and create a linked worktree before making code changes here.${NC}"
 	echo ""
 	echo -e "${BOLD}Create a worktree (keeps main repo on main):${NC}"
 	echo ""
@@ -333,11 +326,11 @@ if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
 	echo -e "${YELLOW}Using 'git checkout -b' here leaves the repo on a feature branch,${NC}"
 	echo -e "${YELLOW}which breaks parallel sessions and causes merge conflicts.${NC}"
 	echo ""
-	echo -e "${RED}DO NOT proceed with edits until on a feature branch.${NC}"
+	echo -e "${RED}DO NOT proceed with edits until you are inside a linked worktree.${NC}"
 	echo ""
 	exit 1
 else
-	# Check if this is the main repo directory (not a worktree) on a feature branch
+	# Check if this is the main repo directory (not a linked worktree) on a non-main ref
 	# This is a warning - the main repo should stay on main
 	git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null)
 	git_dir=$(git rev-parse --git-dir 2>/dev/null)
@@ -350,6 +343,7 @@ else
 
 	# Sync terminal tab title with repo/branch (silent, non-blocking)
 	SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+	# shellcheck source=/dev/null
 	source "${SCRIPT_DIR}/shared-constants.sh"
 
 	if [[ -x "$SCRIPT_DIR/terminal-title-helper.sh" ]]; then
@@ -357,15 +351,15 @@ else
 	fi
 
 	if [[ "$is_main_worktree" == "true" ]]; then
-		# Loop mode: auto-decide for feature branch in main repo
+		# Loop mode: auto-decide for canonical repo directory off main
 		if [[ "$LOOP_MODE" == "true" ]]; then
 			if is_docs_only "$TASK_DESC"; then
-				echo -e "${YELLOW}LOOP-AUTO${NC}: Docs-only task on feature branch, continuing"
+				echo -e "${YELLOW}LOOP-AUTO${NC}: Docs-only task in main repo directory, continuing"
 				echo "LOOP_DECISION=continue"
 				exit 0
 			else
-				# For code tasks, warn but continue (already on feature branch)
-				echo -e "${YELLOW}LOOP-AUTO${NC}: On feature branch in main repo (not ideal but continuing)"
+				# For code tasks, warn but continue so the caller can relocate into a worktree.
+				echo -e "${YELLOW}LOOP-AUTO${NC}: Main repo directory is off main (not ideal - relocate to a linked worktree)"
 				echo "LOOP_DECISION=continue_warning"
 				exit 0
 			fi
@@ -374,20 +368,20 @@ else
 		# Interactive mode: show warning with options
 		echo ""
 		echo -e "${YELLOW}${BOLD}======================================================${NC}"
-		echo -e "${YELLOW}${BOLD}  WARNING - MAIN REPO ON FEATURE BRANCH${NC}"
+		echo -e "${YELLOW}${BOLD}  WARNING - MAIN REPO DIRECTORY IS OFF MAIN${NC}"
 		echo -e "${YELLOW}${BOLD}======================================================${NC}"
 		echo ""
-		echo -e "Current branch: ${BOLD}$current_branch${NC}"
+		echo -e "Current ref: ${BOLD}$current_branch${NC}"
 		echo ""
-		echo -e "${YELLOW}The main repo directory should stay on 'main' for parallel safety.${NC}"
-		echo -e "${YELLOW}Working directly here can cause issues with parallel sessions.${NC}"
+		echo -e "${YELLOW}The canonical repo directory should stay on 'main' for parallel safety.${NC}"
+		echo -e "${YELLOW}Move code work into a linked worktree path, not this canonical repo directory.${NC}"
 		echo ""
 		echo "Options:"
 		echo "  1. Create worktree for this task (recommended)"
-		echo "  2. Continue on current branch (not recommended for code)"
-		echo "  3. Switch main repo back to main, then create worktree"
+		echo "  2. Switch the canonical repo directory back to main"
+		echo "  3. Continue here temporarily (not recommended for code)"
 		echo ""
-		echo "FEATURE_BRANCH_WARNING=$current_branch"
+		echo "MAIN_REPO_OFF_MAIN_WARNING=$current_branch"
 		exit 3
 	else
 		# Check if task is claimed by someone else via TODO.md assignee: field (t165)
@@ -425,7 +419,7 @@ else
 			fi
 		fi
 
-		echo -e "${GREEN}OK${NC} - On branch: ${BOLD}$current_branch${NC} (in worktree)"
+		echo -e "${GREEN}OK${NC} - In linked worktree on ref: ${BOLD}$current_branch${NC}"
 		exit 0
 	fi
 fi


### PR DESCRIPTION
## Summary
- update pre-edit-check messaging to require the canonical repo directory to stay on `main` and move code work into linked worktree paths
- revise shared agent guidance so user-facing workflow language is worktree-first and treats Git refs as internal details inside the linked worktree
- tighten traceability wording from branch-centric to worktree/ref-centric where it affects operator guidance

## Verification
- `shellcheck .agents/scripts/pre-edit-check.sh`
- `bash -n .agents/scripts/pre-edit-check.sh`
- `markdown-formatter check .agents/AGENTS.md`

Closes #4443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Transitioned Git workflow documentation from branch-centric to linked worktree approach for code changes.
  * Updated all operational guidance and terminology to reflect worktree-first methodology.

* **Chores**
  * Modified workflow validation and automation scripts to support the new worktree-based development process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->