### PR TITLE
t1474: align headless pre-edit wording with worktree guidance

### DIFF
--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -307,7 +307,7 @@ if [[ "$current_branch" == "main" || "$current_branch" == "master" ]]; then
 	# In headless mode, output a concise machine-readable error and exit 2
 	# (worktree needed) instead of the verbose interactive prompt.
 	if [[ ! -t 0 ]] || [[ "${FULL_LOOP_HEADLESS:-false}" == "true" ]]; then
-		echo -e "${RED}BLOCKED${NC}: On protected branch '$current_branch' — cannot edit."
+		echo -e "${RED}BLOCKED${NC}: Canonical repo directory is on protected '$current_branch'; move code edits into a linked worktree."
 		echo "HEADLESS_BLOCKED=true"
 		echo "ACTION_REQUIRED=create_worktree"
 		echo "HINT: Use --loop-mode --task 'description' to auto-create a worktree,"


### PR DESCRIPTION
## Summary
- replace the remaining headless blocked message in `pre-edit-check.sh` with canonical-repo and linked-worktree wording
- keep the non-interactive failure path aligned with the same worktree-first guidance used in the interactive and prompt layers

## Verification
- `shellcheck .agents/scripts/pre-edit-check.sh`
- `bash -n .agents/scripts/pre-edit-check.sh`

Closes #3193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error messaging for protected branch operations to provide clearer guidance on using linked worktrees for code edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->