### PR TITLE
t1475: enforce transcript-first pulse and worker intervention gating

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -229,37 +229,18 @@ check_dedup() {
 		return 0
 	fi
 
-	# Underfilled stale recovery: if the pulse process has been running long
-	# enough and worker pool is below target, recycle now instead of waiting
-	# for the full stale threshold. Adapt timeout by underfill severity to
-	# recover capacity faster during deep underfill while keeping tolerance
-	# for minor underfill blips.
-	local max_workers active_workers deficit_pct adaptive_timeout
+	# Underfill is now intelligence-managed by the pulse session itself.
+	# Do not recycle running pulse processes based only on elapsed time while
+	# underfilled — that creates churn loops and suppresses transcript analysis.
+	local max_workers active_workers deficit_pct
 	max_workers=$(get_max_workers_target)
 	active_workers=$(count_active_workers)
 	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
 	deficit_pct=0
-	adaptive_timeout="$PULSE_UNDERFILLED_STALE_RECOVERY_TIMEOUT"
-
 	if [[ "$active_workers" -lt "$max_workers" ]]; then
 		deficit_pct=$(((max_workers - active_workers) * 100 / max_workers))
-		if [[ "$deficit_pct" -ge 50 ]]; then
-			adaptive_timeout=300
-		elif [[ "$deficit_pct" -ge 25 ]]; then
-			adaptive_timeout=450
-		fi
-	fi
-
-	if [[ "$elapsed_seconds" -gt "$adaptive_timeout" && "$active_workers" -lt "$max_workers" ]]; then
-		echo "[pulse-wrapper] Recycling stale pulse process $old_pid early (running ${elapsed_seconds}s, underfilled ${active_workers}/${max_workers} [${deficit_pct}%], threshold ${adaptive_timeout}s)" >>"$LOGFILE"
-		_kill_tree "$old_pid" || true
-		sleep 2
-		if kill -0 "$old_pid" 2>/dev/null; then
-			_force_kill_tree "$old_pid" || true
-		fi
-		rm -f "$PIDFILE"
-		return 0
+		echo "[pulse-wrapper] Underfilled ${active_workers}/${max_workers} (${deficit_pct}%) but preserving active pulse PID $old_pid for transcript-driven decisions" >>"$LOGFILE"
 	fi
 
 	# Process is running and within time limit — genuine dedup
@@ -1452,13 +1433,8 @@ run_pulse() {
 	local effective_cold_start_timeout="$PULSE_COLD_START_TIMEOUT"
 	if [[ "$underfilled_mode" == "1" ]]; then
 		effective_cold_start_timeout="$PULSE_COLD_START_TIMEOUT_UNDERFILLED"
-		[[ "$underfill_pct" =~ ^[0-9]+$ ]] || underfill_pct=0
-		if [[ "$underfill_pct" -ge 50 ]]; then
-			effective_cold_start_timeout=300
-		elif [[ "$underfill_pct" -ge 25 ]]; then
-			effective_cold_start_timeout=450
-		fi
 	fi
+	[[ "$underfill_pct" =~ ^[0-9]+$ ]] || underfill_pct=0
 	if [[ "$effective_cold_start_timeout" -gt "$PULSE_COLD_START_TIMEOUT" ]]; then
 		effective_cold_start_timeout="$PULSE_COLD_START_TIMEOUT"
 	fi

--- a/.agents/scripts/tests/test-worker-stall-diagnosis.sh
+++ b/.agents/scripts/tests/test-worker-stall-diagnosis.sh
@@ -367,6 +367,56 @@ test_post_kill_marks_runtime_as_available() {
 	return 0
 }
 
+test_extract_session_title_handles_unquoted_multiword_titles() {
+	reset_fixture
+	local cmd='opencode run --dir /tmp/aidevops --title Issue #999: Multi Word Session Title --format json /full-loop "Implement issue #999"'
+	local extracted
+	local expected='Issue #999: Multi Word Session Title'
+	extracted=$(_extract_session_title "$cmd")
+
+	if [[ "$extracted" == "$expected" ]]; then
+		print_result "session title parser preserves multiword unquoted title" 0
+		return 0
+	fi
+
+	print_result "session title parser preserves multiword unquoted title" 1 "Expected '${expected}', got '${extracted}'"
+	return 0
+}
+
+test_transcript_gate_defers_active_sessions() {
+	reset_fixture
+
+	_get_session_tail_evidence() {
+		printf '%s' 'active|session="Issue #500"; recent_messages=4; newest_part_age=8s; tail=tool:bash(completed) "Run tests"'
+		return 0
+	}
+
+	if transcript_allows_intervention "runtime" "cmd" 7200; then
+		print_result "transcript gate defers active sessions" 1 "Expected active transcript evidence to defer intervention"
+		return 0
+	fi
+
+	print_result "transcript gate defers active sessions" 0
+	return 0
+}
+
+test_transcript_gate_allows_stalled_sessions() {
+	reset_fixture
+
+	_get_session_tail_evidence() {
+		printf '%s' 'stalled|session="Issue #501"; recent_messages=0; newest_part_age=1210s; tail=text:"No progress"'
+		return 0
+	}
+
+	if ! transcript_allows_intervention "stall" "cmd" 1900; then
+		print_result "transcript gate allows stalled sessions" 1 "Expected stalled transcript evidence to allow intervention"
+		return 0
+	fi
+
+	print_result "transcript gate allows stalled sessions" 0
+	return 0
+}
+
 main() {
 	setup_test_env
 	test_recent_message_clears_stall
@@ -377,6 +427,9 @@ main() {
 	test_thrashing_guard_skips_workers_with_commits
 	test_post_kill_marks_thrash_as_blocked
 	test_post_kill_marks_runtime_as_available
+	test_extract_session_title_handles_unquoted_multiword_titles
+	test_transcript_gate_defers_active_sessions
+	test_transcript_gate_allows_stalled_sessions
 	teardown_test_env
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -443,24 +443,22 @@ _resolve_session_id_from_cmd() {
 		return 0
 	}
 
-	local escaped_title="${session_title//\'/\'\'}"
-	session_id=$(sqlite3 "$db_path" "
-		SELECT id
-		FROM session
-		WHERE title = '${escaped_title}'
-		ORDER BY time_created DESC
-		LIMIT 1
-	" 2>/dev/null || printf '%s' "")
-
-	if [[ -z "$session_id" ]]; then
-		session_id=$(sqlite3 "$db_path" "
-			SELECT id
-			FROM session
-			WHERE title LIKE '%${escaped_title}%'
-			ORDER BY time_created DESC
-			LIMIT 1
-		" 2>/dev/null || printf '%s' "")
-	fi
+	session_id=$(
+		DB_PATH="$db_path" TITLE="$session_title" python3 - <<'PY'
+import os, sqlite3
+db = os.environ["DB_PATH"]
+title = os.environ["TITLE"]
+conn = sqlite3.connect(db)
+conn.execute("PRAGMA busy_timeout=5000")
+cur = conn.cursor()
+cur.execute("SELECT id FROM session WHERE title = ? ORDER BY time_created DESC LIMIT 1", (title,))
+row = cur.fetchone()
+if not row:
+    cur.execute("SELECT id FROM session WHERE title LIKE ? ORDER BY time_created DESC LIMIT 1", (f"%{title}%",))
+    row = cur.fetchone()
+print(row[0] if row else "")
+PY
+	) 2>/dev/null || session_id=""
 
 	printf '%s' "$session_id"
 	return 0
@@ -489,15 +487,23 @@ _count_recent_opencode_messages() {
 		return 0
 	fi
 
-	local escaped_match="${session_match//\'/\'\'}"
 	local recent_count
-	recent_count=$(sqlite3 "$db_path" "
-		SELECT COUNT(*)
-		FROM message m
-		JOIN session s ON m.session_id = s.id
-		WHERE s.title LIKE '%${escaped_match}%'
-		AND (CASE WHEN m.time_created > 20000000000 THEN m.time_created / 1000 ELSE m.time_created END) >= strftime('%s', 'now') - ${recent_window}
-	" 2>/dev/null || printf '%s' "0")
+	recent_count=$(
+		DB_PATH="$db_path" MATCH="$session_match" WINDOW="$recent_window" python3 - <<'PY'
+import os, sqlite3
+conn = sqlite3.connect(os.environ["DB_PATH"])
+conn.execute("PRAGMA busy_timeout=5000")
+cur = conn.cursor()
+cur.execute(
+    "SELECT COUNT(*) FROM message m JOIN session s ON m.session_id = s.id"
+    " WHERE s.title LIKE ?"
+    " AND (CASE WHEN m.time_created > 20000000000 THEN m.time_created / 1000 ELSE m.time_created END)"
+    " >= strftime('%s', 'now') - ?",
+    (f"%{os.environ['MATCH']}%", int(os.environ["WINDOW"])),
+)
+print(cur.fetchone()[0] or 0)
+PY
+	) 2>/dev/null || recent_count=0
 	[[ "$recent_count" =~ ^[0-9]+$ ]] || recent_count=0
 
 	printf '%s' "$recent_count"
@@ -706,13 +712,22 @@ _compute_struggle_ratio() {
 		session_id=$(_resolve_session_id_from_cmd "$cmd")
 
 		if [[ -n "$session_id" ]]; then
-			local escaped_session_id="${session_id//\'/\'\'}"
-			messages=$(sqlite3 "$db_path" "
-				SELECT COUNT(*)
-				FROM message m
-				WHERE m.session_id = '${escaped_session_id}'
-				AND (CASE WHEN m.time_created > 20000000000 THEN m.time_created / 1000 ELSE m.time_created END) > strftime('%s', 'now') - ${elapsed_seconds}
-			" || echo 0)
+			messages=$(
+				DB_PATH="$db_path" SID="$session_id" ELAPSED="$elapsed_seconds" python3 - <<'PY'
+import os, sqlite3
+conn = sqlite3.connect(os.environ["DB_PATH"])
+conn.execute("PRAGMA busy_timeout=5000")
+cur = conn.cursor()
+cur.execute(
+    "SELECT COUNT(*) FROM message m"
+    " WHERE m.session_id = ?"
+    " AND (CASE WHEN m.time_created > 20000000000 THEN m.time_created / 1000 ELSE m.time_created END)"
+    " > strftime('%s', 'now') - ?",
+    (os.environ["SID"], int(os.environ["ELAPSED"])),
+)
+print(cur.fetchone()[0] or 0)
+PY
+			) 2>/dev/null || messages=0
 		fi
 	fi
 

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -422,10 +422,11 @@ _extract_session_title_from_cmd() {
 #######################################
 _resolve_session_id_from_cmd() {
 	local cmd="$1"
-	local db_path="${HOME}/.local/share/opencode/opencode.db"
+	local db_path
+	db_path=$(_opencode_db_path)
 	local session_id=""
 
-	if [[ "$cmd" =~ --session[[:space:]]+([^[:space:]]+) ]]; then
+	if [[ "$cmd" =~ --session[[:space:]]+([^[:space:]]+) ]] || [[ "$cmd" =~ --session=([^[:space:]]+) ]]; then
 		session_id="${BASH_REMATCH[1]}"
 		printf '%s' "$session_id"
 		return 0

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -48,11 +48,36 @@ _extract_session_title() {
 	local cmd="$1"
 	local session_title=""
 
-	if [[ "$cmd" =~ --title[[:space:]]+\"([^\"]+)\" ]] || [[ "$cmd" =~ --title[[:space:]]+([^[:space:]]+) ]]; then
-		session_title="${BASH_REMATCH[1]}"
-	fi
+	session_title=$(
+		SESSION_CMD="$cmd" python3 - <<'PY'
+import os
+import shlex
 
-	printf '%s' "$session_title"
+cmd = os.environ.get("SESSION_CMD", "")
+title = ""
+
+try:
+    tokens = shlex.split(cmd)
+except Exception:
+    tokens = cmd.split()
+
+for idx, token in enumerate(tokens):
+    if token == "--title" and idx + 1 < len(tokens):
+        collected = []
+        for next_token in tokens[idx + 1 :]:
+            if next_token.startswith("--"):
+                break
+            if next_token == "/full-loop":
+                break
+            collected.append(next_token)
+        title = " ".join(collected).strip()
+        break
+
+print(title)
+PY
+	)
+
+	printf '%s' "${session_title:-}"
 	return 0
 }
 
@@ -147,7 +172,7 @@ try:
         SELECT COUNT(*)
         FROM message
         WHERE session_id = ?
-          AND time_created > strftime('%s', 'now') - ?
+          AND (CASE WHEN time_created > 20000000000 THEN time_created / 1000 ELSE time_created END) > strftime('%s', 'now') - ?
         """,
         (session_id, timeout_seconds),
     )
@@ -385,15 +410,59 @@ _get_process_tree_cpu() {
 #######################################
 _extract_session_title_from_cmd() {
 	local cmd="$1"
-	local session_title=""
+	_extract_session_title "$cmd"
+	return 0
+}
 
-	if [[ "$cmd" =~ --title[[:space:]]+\"([^\"]+)\" ]]; then
-		session_title="${BASH_REMATCH[1]}"
-	elif [[ "$cmd" =~ --title[[:space:]]+([^[:space:]]+) ]]; then
-		session_title="${BASH_REMATCH[1]}"
+#######################################
+# Resolve OpenCode session ID from a worker command line
+# Arguments:
+#   $1 - command line string
+# Returns: session id via stdout, or empty string
+#######################################
+_resolve_session_id_from_cmd() {
+	local cmd="$1"
+	local db_path="${HOME}/.local/share/opencode/opencode.db"
+	local session_id=""
+
+	if [[ "$cmd" =~ --session[[:space:]]+([^[:space:]]+) ]]; then
+		session_id="${BASH_REMATCH[1]}"
+		printf '%s' "$session_id"
+		return 0
 	fi
 
-	printf '%s' "$session_title"
+	[[ -f "$db_path" ]] || {
+		printf '%s' ""
+		return 0
+	}
+
+	local session_title
+	session_title=$(_extract_session_title_from_cmd "$cmd")
+	[[ -n "$session_title" ]] || {
+		printf '%s' ""
+		return 0
+	}
+
+	local escaped_title="${session_title//\'/\'\'}"
+	session_id=$(sqlite3 "$db_path" "
+		SELECT id
+		FROM session
+		WHERE title = '${escaped_title}'
+		ORDER BY time_created DESC
+		LIMIT 1
+	" 2>/dev/null || printf '%s' "")
+
+	if [[ -z "$session_id" ]]; then
+		session_id=$(sqlite3 "$db_path" "
+			SELECT id
+			FROM session
+			WHERE title LIKE '%${escaped_title}%'
+			ORDER BY time_created DESC
+			LIMIT 1
+		" 2>/dev/null || printf '%s' "")
+	fi
+
+	printf '%s' "$session_id"
 	return 0
 }
 
@@ -427,7 +496,7 @@ _count_recent_opencode_messages() {
 		FROM message m
 		JOIN session s ON m.session_id = s.id
 		WHERE s.title LIKE '%${escaped_match}%'
-		AND m.time_created >= strftime('%s', 'now') - ${recent_window}
+		AND (CASE WHEN m.time_created > 20000000000 THEN m.time_created / 1000 ELSE m.time_created END) >= strftime('%s', 'now') - ${recent_window}
 	" 2>/dev/null || printf '%s' "0")
 	[[ "$recent_count" =~ ^[0-9]+$ ]] || recent_count=0
 
@@ -633,21 +702,16 @@ _compute_struggle_ratio() {
 	local db_path="${HOME}/.local/share/opencode/opencode.db"
 
 	if [[ -f "$db_path" ]]; then
-		local session_title=""
-		session_title=$(_extract_session_title_from_cmd "$cmd")
+		local session_id
+		session_id=$(_resolve_session_id_from_cmd "$cmd")
 
-		if [[ -n "$session_title" ]]; then
-			# Query message count for the most recent session matching this title
-			# Use sqlite3 with a LIKE match on session title
-			local escaped_title="${session_title//\'/\'\'}"
-			# Use (cmd || echo 0) pattern for set -e safety — ensures the
-			# assignment always succeeds and stderr remains visible (GH#4010)
+		if [[ -n "$session_id" ]]; then
+			local escaped_session_id="${session_id//\'/\'\'}"
 			messages=$(sqlite3 "$db_path" "
 				SELECT COUNT(*)
 				FROM message m
-				JOIN session s ON m.session_id = s.id
-				WHERE s.title LIKE '%${escaped_title}%'
-				AND s.time_created > strftime('%s', 'now') - ${elapsed_seconds}
+				WHERE m.session_id = '${escaped_session_id}'
+				AND (CASE WHEN m.time_created > 20000000000 THEN m.time_created / 1000 ELSE m.time_created END) > strftime('%s', 'now') - ${elapsed_seconds}
 			" || echo 0)
 		fi
 	fi

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -88,6 +88,8 @@ readonly IDLE_STATE_DIR="${STATE_DIR}/worker-idle-tracking"
 
 STALL_EVIDENCE_CLASS=""
 STALL_EVIDENCE_SUMMARY=""
+INTERVENTION_EVIDENCE_CLASS=""
+INTERVENTION_EVIDENCE_SUMMARY=""
 THRASH_RATIO=""
 THRASH_COMMITS=""
 THRASH_MESSAGES=""
@@ -317,18 +319,18 @@ check_progress_stall() {
 	local has_recent_activity=false
 
 	if [[ -f "$db_path" ]]; then
-		local session_title=""
-		session_title=$(_extract_session_title "$cmd")
+		local session_id=""
+		session_id=$(_resolve_session_id_from_cmd "$cmd")
 
-		if [[ -n "$session_title" ]]; then
+		if [[ -n "$session_id" ]]; then
 			local recent_count
 			recent_count=$(
-				SESSION_WATCHDOG_DB_PATH="$db_path" SESSION_WATCHDOG_TITLE="$session_title" SESSION_WATCHDOG_TIMEOUT="$WORKER_PROGRESS_TIMEOUT" python3 - <<'PY'
+				SESSION_WATCHDOG_DB_PATH="$db_path" SESSION_WATCHDOG_ID="$session_id" SESSION_WATCHDOG_TIMEOUT="$WORKER_PROGRESS_TIMEOUT" python3 - <<'PY'
 import os
 import sqlite3
 
 db_path = os.environ["SESSION_WATCHDOG_DB_PATH"]
-session_title = os.environ["SESSION_WATCHDOG_TITLE"]
+session_id = os.environ["SESSION_WATCHDOG_ID"]
 timeout_seconds = int(os.environ["SESSION_WATCHDOG_TIMEOUT"])
 
 conn = sqlite3.connect(db_path)
@@ -337,12 +339,11 @@ cursor = conn.cursor()
 cursor.execute(
     """
     SELECT COUNT(*)
-    FROM message m
-    JOIN session s ON m.session_id = s.id
-    WHERE s.title LIKE ?
-      AND m.time_created > strftime('%s', 'now') - ?
+    FROM message
+    WHERE session_id = ?
+      AND (CASE WHEN time_created > 20000000000 THEN time_created / 1000 ELSE time_created END) > strftime('%s', 'now') - ?
     """,
-    (f"%{session_title}%", timeout_seconds),
+    (session_id, timeout_seconds),
 )
 row = cursor.fetchone()
 print(int(row[0] or 0))
@@ -409,6 +410,53 @@ PY
 		return 0 # Stalled long enough — kill
 	fi
 	return 1
+}
+
+#######################################
+# Transcript-first intervention gate
+#
+# Every kill action must be justified by transcript evidence. Metrics can
+# propose candidates, but transcript evidence decides whether intervention
+# is permitted in this cycle.
+#
+# Arguments:
+#   $1 - signal type (runtime|thrash|idle|stall)
+#   $2 - worker command line
+#   $3 - elapsed seconds
+# Returns: 0 if intervention is allowed, 1 if it should be deferred
+#######################################
+transcript_allows_intervention() {
+	local signal_type="$1"
+	local cmd="$2"
+	local elapsed_seconds="$3"
+
+	INTERVENTION_EVIDENCE_CLASS=""
+	INTERVENTION_EVIDENCE_SUMMARY=""
+
+	local evidence_result
+	evidence_result=$(_get_session_tail_evidence "$cmd" "$WORKER_PROGRESS_TIMEOUT" 12)
+	IFS='|' read -r INTERVENTION_EVIDENCE_CLASS INTERVENTION_EVIDENCE_SUMMARY <<<"$evidence_result"
+
+	local safe_evidence
+	safe_evidence=$(_sanitize_log_field "$INTERVENTION_EVIDENCE_SUMMARY")
+
+	if [[ -z "$INTERVENTION_EVIDENCE_CLASS" || "$INTERVENTION_EVIDENCE_CLASS" == "none" ]]; then
+		log_msg "TRANSCRIPT DEFER: signal=${signal_type} elapsed=${elapsed_seconds}s reason=no-session-evidence evidence=${safe_evidence}"
+		return 1
+	fi
+
+	case "$INTERVENTION_EVIDENCE_CLASS" in
+	active)
+		log_msg "TRANSCRIPT DEFER: signal=${signal_type} elapsed=${elapsed_seconds}s reason=active-session evidence=${safe_evidence}"
+		return 1
+		;;
+	provider-waiting)
+		log_msg "TRANSCRIPT DEFER: signal=${signal_type} elapsed=${elapsed_seconds}s reason=provider-wait evidence=${safe_evidence}"
+		return 1
+		;;
+	esac
+
+	return 0
 }
 
 #######################################
@@ -626,21 +674,30 @@ cmd_check() {
 		local duration
 		duration=$(_format_duration "$elapsed_seconds")
 
-		# Check 1: Runtime ceiling (highest priority — unconditional kill)
+		# Check 1: Runtime ceiling candidate (transcript gate decides kill/defer)
 		if [[ "$elapsed_seconds" -ge "$WORKER_MAX_RUNTIME" ]]; then
+			if ! transcript_allows_intervention "runtime" "$cmd" "$elapsed_seconds"; then
+				continue
+			fi
 			log_msg "RUNTIME CEILING: PID=${pid} elapsed=${duration} (max=$(_format_duration "$WORKER_MAX_RUNTIME"))"
-			kill_worker "$pid" "runtime" "$cmd" "$elapsed_seconds"
+			kill_worker "$pid" "runtime" "$cmd" "$elapsed_seconds" "$INTERVENTION_EVIDENCE_SUMMARY"
 			killed_count=$((killed_count + 1))
 			continue
 		fi
 
 		# Check 2: zero-commit high-message thrash detection
 		if check_zero_commit_thrashing "$pid" "$cmd" "$elapsed_seconds"; then
+			if ! transcript_allows_intervention "thrash" "$cmd" "$elapsed_seconds"; then
+				continue
+			fi
 			local thrash_evidence="ratio=${THRASH_RATIO} messages=${THRASH_MESSAGES} commits=${THRASH_COMMITS} flag=${THRASH_FLAG:-none}"
 			local session_title
 			session_title=$(_extract_session_title "$cmd")
 			if [[ -n "$session_title" ]]; then
 				thrash_evidence="${thrash_evidence}; objective=${session_title}"
+			fi
+			if [[ -n "$INTERVENTION_EVIDENCE_SUMMARY" ]]; then
+				thrash_evidence="${thrash_evidence}; transcript=${INTERVENTION_EVIDENCE_SUMMARY}"
 			fi
 			log_msg "THRASH DETECTED: PID=${pid} elapsed=${duration} ${thrash_evidence}"
 			kill_worker "$pid" "thrash" "$cmd" "$elapsed_seconds" "$thrash_evidence"
@@ -650,14 +707,20 @@ cmd_check() {
 
 		# Check 3: CPU idle detection
 		if check_idle "$pid" "$tree_cpu"; then
+			if ! transcript_allows_intervention "idle" "$cmd" "$elapsed_seconds"; then
+				continue
+			fi
 			log_msg "IDLE DETECTED: PID=${pid} cpu=${tree_cpu}% elapsed=${duration}"
-			kill_worker "$pid" "idle" "$cmd" "$elapsed_seconds"
+			kill_worker "$pid" "idle" "$cmd" "$elapsed_seconds" "$INTERVENTION_EVIDENCE_SUMMARY"
 			killed_count=$((killed_count + 1))
 			continue
 		fi
 
 		# Check 4: Progress stall detection
 		if check_progress_stall "$pid" "$cmd" "$elapsed_seconds"; then
+			if ! transcript_allows_intervention "stall" "$cmd" "$elapsed_seconds"; then
+				continue
+			fi
 			local sanitized_evidence=""
 			if [[ -n "$STALL_EVIDENCE_SUMMARY" ]]; then
 				sanitized_evidence=$(_sanitize_log_field "$STALL_EVIDENCE_SUMMARY")


### PR DESCRIPTION
## Summary
- Replace metric-only watchdog intervention with transcript-first gating so kill/defer decisions require session evidence.
- Fix worker session attribution to prefer exact OpenCode session IDs and robust multiword `--title` parsing, plus seconds/milliseconds timestamp normalization.
- Remove underfill-driven early pulse recycle/cold-start compression that preempted pulse intelligence under queue pressure.

## Verification
- `shellcheck .agents/scripts/worker-lifecycle-common.sh .agents/scripts/worker-watchdog.sh .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-worker-stall-diagnosis.sh`
- `bash .agents/scripts/tests/test-worker-stall-diagnosis.sh` (11 passed)
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh` (4 passed)
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh` (3 passed)
- `bash .agents/scripts/worker-watchdog.sh --status`

Closes #4446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More conservative handling of underfilled workers—processes are no longer recycled early based on underfill.
  * Improved timestamp normalization for consistent activity queries.

* **New Features**
  * Transcript-driven intervention gate influences whether the system defers or allows automated intervention; evidence summaries are now included in decisions and logs.

* **Tests**
  * Added tests covering stall diagnosis, session title extraction, and transcript-based gating.

* **Chores**
  * Session resolution and ID-based querying refactored for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->