### PR TITLE
t1476: add regression checks for worktree-first pre-edit guidance

### DIFF
--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../pre-edit-check.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_repo() {
+	TEST_ROOT=$(mktemp -d)
+	git -C "$TEST_ROOT" init -b main >/dev/null 2>&1 || {
+		git -C "$TEST_ROOT" init >/dev/null 2>&1
+		git -C "$TEST_ROOT" checkout -b main >/dev/null 2>&1
+	}
+	git -C "$TEST_ROOT" config user.name "Aidevops Test"
+	git -C "$TEST_ROOT" config user.email "test@example.com"
+	printf 'test\n' >"${TEST_ROOT}/README.md"
+	git -C "$TEST_ROOT" add README.md
+	git -C "$TEST_ROOT" commit -m "test: seed repo" >/dev/null 2>&1
+	return 0
+}
+
+teardown_test_repo() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+run_helper() {
+	local target_dir="$1"
+	shift
+	(
+		cd "$target_dir" || exit 1
+		"$HELPER" "$@"
+	)
+	return $?
+}
+
+test_blocks_headless_edits_on_main_with_worktree_guidance() {
+	local output=""
+	local exit_code=0
+	output=$(FULL_LOOP_HEADLESS=true run_helper "$TEST_ROOT" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 2 ]] && [[ "$output" == *"Canonical repo directory is on protected 'main'; move code edits into a linked worktree."* ]] && [[ "$output" == *"HEADLESS_BLOCKED=true"* ]] && [[ "$output" == *"ACTION_REQUIRED=create_worktree"* ]]; then
+		print_result "blocks headless edits on main with worktree guidance" 0
+		return 0
+	fi
+
+	print_result "blocks headless edits on main with worktree guidance" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_allows_linked_worktree_edits() {
+	local worktree_path="${TEST_ROOT}/linked-worktree"
+	git -C "$TEST_ROOT" worktree add "$worktree_path" -b bugfix/test-linked-worktree >/dev/null 2>&1
+
+	local output=""
+	local exit_code=0
+	output=$(run_helper "$worktree_path" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"OK"* ]] && [[ "$output" == *"In linked worktree on ref: "* ]]; then
+		print_result "allows edits from linked worktree paths" 0
+		return 0
+	fi
+
+	print_result "allows edits from linked worktree paths" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+test_warns_when_canonical_repo_is_off_main() {
+	git -C "$TEST_ROOT" switch -c bugfix/off-main >/dev/null 2>&1
+
+	local output=""
+	local exit_code=0
+	output=$(run_helper "$TEST_ROOT" 2>&1) || exit_code=$?
+
+	if [[ "$exit_code" -eq 3 ]] && [[ "$output" == *"WARNING - MAIN REPO DIRECTORY IS OFF MAIN"* ]] && [[ "$output" == *"MAIN_REPO_OFF_MAIN_WARNING=bugfix/off-main"* ]]; then
+		print_result "warns when canonical repo directory is off main" 0
+		return 0
+	fi
+
+	print_result "warns when canonical repo directory is off main" 1 "exit=${exit_code} output=${output}"
+	return 0
+}
+
+main() {
+	trap teardown_test_repo EXIT
+	setup_test_repo
+
+	test_blocks_headless_edits_on_main_with_worktree_guidance
+	test_allows_linked_worktree_edits
+	test_warns_when_canonical_repo_is_off_main
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 
 # Source shared constants (provides sed_inplace, print_*, color constants)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 # Repository root directory
@@ -591,6 +592,7 @@ run_patch_release_preflight() {
 
 	local changed_files=""
 	changed_files=$(git diff --name-only "$baseline_ref"..HEAD 2>/dev/null || echo "")
+	local pre_edit_test_script="$REPO_ROOT/.agents/scripts/tests/test-pre-edit-check.sh"
 
 	if ! configure_secretlint_command; then
 		return 1
@@ -655,6 +657,21 @@ run_patch_release_preflight() {
 		fi
 	else
 		print_info "ShellCheck: no shell files changed since $baseline_ref"
+	fi
+
+	if [[ "$changed_files" == *".agents/scripts/pre-edit-check.sh"* ]] || [[ "$changed_files" == *".agents/scripts/tests/test-pre-edit-check.sh"* ]]; then
+		if [[ ! -x "$pre_edit_test_script" ]]; then
+			print_error "Pre-edit regression test missing or not executable: $pre_edit_test_script"
+			return 1
+		fi
+
+		print_info "Running pre-edit regression test..."
+		if bash "$pre_edit_test_script"; then
+			print_success "Pre-edit regression test passed"
+		else
+			print_error "Pre-edit regression test failed"
+			return 1
+		fi
 	fi
 
 	print_success "Patch release regression preflight passed"


### PR DESCRIPTION
## Summary
- add a focused `test-pre-edit-check.sh` regression test for canonical-main, linked-worktree, and off-main warning behavior
- run that regression test automatically during patch release preflight whenever `pre-edit-check.sh` or its test changes
- keep the release guard itself lint-clean with an explicit ShellCheck source directive

## Verification
- `shellcheck .agents/scripts/version-manager.sh .agents/scripts/tests/test-pre-edit-check.sh`
- `bash -n .agents/scripts/version-manager.sh && bash -n .agents/scripts/tests/test-pre-edit-check.sh`
- `bash .agents/scripts/tests/test-pre-edit-check.sh`
- `.agents/scripts/version-manager.sh preflight patch`

Closes #2208