### PR TITLE
t3780: fix: address PR #237 review feedback in generate-opencode-commands.sh

### DIFF
--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -8,7 +8,7 @@
 # Target: ~/.config/opencode/command/
 #
 # Commands are generated from:
-#   - build-agent/agent-review.md -> /agent-review
+#   - tools/build-agent/agent-review.md -> /agent-review
 #   - workflows/*.md -> /workflow-name
 #   - Other agents as needed
 # =============================================================================
@@ -87,7 +87,7 @@ create_command() {
 create_command "agent-review" \
 	"Systematic review and improvement of agent instructions" \
 	"$AGENT_BUILD" "true" <<'BODY'
-Read ~/.aidevops/agents/tools/build-agent/agent-review.md and follow its instructions.
+Read $HOME/.aidevops/agents/tools/build-agent/agent-review.md and follow its instructions.
 
 Review the agent file(s) specified: $ARGUMENTS
 


### PR DESCRIPTION
## Summary

- Replace \`~\` with \`\$HOME\` in the \`agent-review\` command body for POSIX portability (Gemini suggestion from PR #237)
- Update header comment path from \`build-agent/agent-review.md\` to \`tools/build-agent/agent-review.md\` for consistency with the actual path fixed in PR #237 (CodeRabbit suggestion)

## Changes

Both changes are in \`.agents/scripts/generate-opencode-commands.sh\`:

1. **Line 11** (header comment): \`build-agent/agent-review.md\` → \`tools/build-agent/agent-review.md\`
2. **Line 90** (command body): \`~/.aidevops/...\` → \`\$HOME/.aidevops/...\`

## Verification

- ShellCheck: zero new violations (pre-existing SC1091 info on sourced file, unrelated to this change)

Closes #3780