### PR TITLE
t3773: add INP to webpagetest metrics table with lab support caveat

### DIFF
--- a/.agents/tools/performance/webpagetest.md
+++ b/.agents/tools/performance/webpagetest.md
@@ -109,6 +109,7 @@ Key metrics in the response at `data.median.firstView`:
 | `firstContentfulPaint` | First Contentful Paint (ms) |
 | `chromeUserTiming.LargestContentfulPaint` | LCP (ms) |
 | `chromeUserTiming.CumulativeLayoutShift` | CLS |
+| `chromeUserTiming.InteractionToNextPaint` | INP (ms) — lab support varies by WPT version |
 | `TotalBlockingTime` | Total Blocking Time (ms) |
 | `SpeedIndex` | Speed Index |
 | `fullyLoaded` | Fully Loaded Time (ms) |


### PR DESCRIPTION
## Summary

- Add `chromeUserTiming.InteractionToNextPaint` (INP) to the metrics table in `tools/performance/webpagetest.md`
- Include a note that lab INP support varies by WPT version, matching the reviewer's framing

## Context

PR #388 review (marcusquinn) noted: *"INP is mentioned in the overview as a Core Web Vital but isn't in the metrics table — acceptable since WPT's lab INP support varies and the field is still evolving."*

The gap was marked acceptable but not dismissed — the field path exists in WPT's JSON output when supported, so documenting it with the caveat is accurate and useful.

## Changes

| File | Change |
|------|--------|
| `.agents/tools/performance/webpagetest.md` | Added INP row to metrics table (line 112) |

Closes #3773