### PR TITLE
t3773: add INP to webpagetest metrics table with lab support caveat

### DIFF
--- a/.agents/tools/performance/webpagetest.md
+++ b/.agents/tools/performance/webpagetest.md
@@ -109,6 +109,7 @@ Key metrics in the response at `data.median.firstView`:
 | `firstContentfulPaint` | First Contentful Paint (ms) |
 | `chromeUserTiming.LargestContentfulPaint` | LCP (ms) |
 | `chromeUserTiming.CumulativeLayoutShift` | CLS |
+| `chromeUserTiming.InteractionToNextPaint` | INP (ms) — lab support varies by WPT version; not always present |
 | `TotalBlockingTime` | Total Blocking Time (ms) |
 | `SpeedIndex` | Speed Index |
 | `fullyLoaded` | Fully Loaded Time (ms) |


### PR DESCRIPTION
## Summary

- Add `chromeUserTiming.InteractionToNextPaint` (INP) to the metrics table in `tools/performance/webpagetest.md`
- Include a caveat that lab support varies by WPT version and the field is not always present

## Context

PR #388 review feedback noted that INP was mentioned in the overview as a Core Web Vital but was absent from the metrics table. The reviewer marked it "acceptable since WPT's lab INP support varies and the field is still evolving" — this PR makes the table complete and self-consistent by documenting the field with the appropriate caveat.

## Changes

| File | Change |
|------|--------|
| `.agents/tools/performance/webpagetest.md` | Added INP row to metrics table (line 112) |

Closes #3773