### PR TITLE
t3435: fix quality-debt from PR #2184 review feedback (container-pool)

### DIFF
--- a/.agents/scripts/supervisor-archived/container-pool.sh
+++ b/.agents/scripts/supervisor-archived/container-pool.sh
@@ -187,8 +187,12 @@ pool_spawn() {
 			token_value=$(gopass show "$token_ref" 2>/dev/null || echo "")
 		fi
 		if [[ -z "$token_value" ]]; then
-			# Try as env var name
-			token_value="${!token_ref:-}"
+			# Try as env var name only when token_ref is a valid identifier
+			# (indirect expansion ${!token_ref} aborts under set -u if token_ref
+			# contains path characters like "foo/bar")
+			if [[ "$token_ref" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+				token_value="${!token_ref:-}"
+			fi
 		fi
 		if [[ -n "$token_value" ]]; then
 			docker_args+=("-e" "CLAUDE_CODE_OAUTH_TOKEN=$token_value")
@@ -567,6 +571,13 @@ pool_record_completion() {
 pool_mark_rate_limited() {
 	local container_id="$1"
 	local cooldown="${2:-$CONTAINER_POOL_RATE_LIMIT_COOLDOWN}"
+
+	# Validate cooldown is a non-negative integer to prevent SQL injection
+	# via malformed timestamp expressions
+	if ! [[ "$cooldown" =~ ^[0-9]+$ ]]; then
+		log_warn "Invalid cooldown '$cooldown' — falling back to default ($CONTAINER_POOL_RATE_LIMIT_COOLDOWN)"
+		cooldown="$CONTAINER_POOL_RATE_LIMIT_COOLDOWN"
+	fi
 
 	db "$SUPERVISOR_DB" "
 		UPDATE container_pool

--- a/.agents/scripts/supervisor-archived/database.sh
+++ b/.agents/scripts/supervisor-archived/database.sh
@@ -771,8 +771,14 @@ CONTEST_SQL
 	has_container_pool=$(db "$SUPERVISOR_DB" "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='container_pool';" 2>/dev/null || echo "0")
 	if [[ "$has_container_pool" -eq 0 ]]; then
 		log_info "Creating container_pool tables (t1165.2)..."
-		_create_container_pool_schema
-		log_success "Created container_pool and container_dispatch_log tables (t1165.2)"
+		# _create_container_pool_schema is defined in container-pool.sh; guard
+		# against callers that source database.sh without container-pool.sh
+		if declare -f _create_container_pool_schema >/dev/null 2>&1; then
+			_create_container_pool_schema
+			log_success "Created container_pool and container_dispatch_log tables (t1165.2)"
+		else
+			log_warn "_create_container_pool_schema not defined — source container-pool.sh before database.sh to create container_pool tables (t1165.2)"
+		fi
 	fi
 
 	# Migrate: create stuck_detection_log table if missing (t1332)
@@ -940,7 +946,12 @@ SQL
 	_create_action_dedup_log_schema
 
 	# Container pool — schema defined in _create_container_pool_schema() (t1165.2)
-	_create_container_pool_schema
+	# Guard against callers that source database.sh without container-pool.sh
+	if declare -f _create_container_pool_schema >/dev/null 2>&1; then
+		_create_container_pool_schema
+	else
+		log_warn "_create_container_pool_schema not defined — source container-pool.sh before database.sh (t1165.2)"
+	fi
 
 	# Stuck detection log — schema defined in _create_stuck_detection_schema() (t1332)
 	_create_stuck_detection_schema

--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -3233,7 +3233,7 @@ cmd_dispatch() {
 		pool_container_id=$(pool_select_container 2>/dev/null) || pool_container_id=""
 		if [[ -n "$pool_container_id" ]]; then
 			log_info "Container pool: selected $pool_container_id for $task_id (t1165.2)"
-			pool_record_dispatch "$pool_container_id" "$task_id" 2>/dev/null || true
+			pool_record_dispatch "$pool_container_id" "$task_id" || true
 		fi
 	fi
 


### PR DESCRIPTION
## Summary

- **CRITICAL**: Remove `2>/dev/null` from `pool_record_dispatch` call in `dispatch.sh` — DB errors from pool dispatch recording were silently swallowed, hiding database lock, disk-full, and schema-mismatch failures
- **MAJOR**: Guard `${!token_ref}` indirect expansion in `container-pool.sh` behind an identifier-validity regex — path-style token refs (e.g. `gopass/path/to/key`) caused `set -u` abort in `pool_spawn`
- **MAJOR**: Validate `cooldown` as a non-negative integer in `pool_mark_rate_limited` before interpolating into SQL `strftime` expression — non-numeric values could produce malformed timestamps or SQL injection
- **MINOR**: Add `declare -f` guard around `_create_container_pool_schema` calls in `ensure_db`/`init_db` in `database.sh` — callers that source `database.sh` without `container-pool.sh` now get a clear `log_warn` instead of an undefined-function error

## Verification

- All three modified files pass `shellcheck` with zero violations
- Changes are minimal and targeted — 3 files, 28 lines added / 6 removed
- Each fix matches the exact suggestion from the gemini reviewer on PR #2184

Closes #3435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input validation for rate-limiting parameters to prevent unexpected errors.
  * Enhanced error handling for missing dependencies, allowing graceful fallback instead of failures.
  
* **Chores**
  * Enhanced error visibility for dispatch operations to aid troubleshooting and monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->