### PR TITLE
t4472: clarify critical OPENAI_API_KEY security note in speech-to-speech docs

### DIFF
--- a/.agents/tools/voice/speech-to-speech.md
+++ b/.agents/tools/voice/speech-to-speech.md
@@ -81,11 +81,12 @@ Model selection: `--stt_model_name <model>` (any Whisper checkpoint on HF Hub)
 
 Model selection: `--lm_model_name <model>` or `--mlx_lm_model_name <model>`
 
-> **Security:** When using `--llm open_api`, store `OPENAI_API_KEY` via
-> `aidevops secret set OPENAI_API_KEY` (gopass encrypted, preferred) or in
-> `~/.config/aidevops/credentials.sh` (600 permissions, plaintext fallback).
+> **Security:** When using `--llm open_api`, store `OPENAI_API_KEY` with
+> `aidevops secret set OPENAI_API_KEY` (gopass encrypted, preferred). Use
+> `~/.config/aidevops/credentials.sh` only as a 600-permission plaintext fallback.
 >
-> Never hardcode API keys in scripts or config files.
+> Never hardcode API keys in scripts or config files; if a key is committed or
+> shared in logs/transcripts, treat it as compromised and rotate it immediately.
 >
 > See `tools/credentials/api-key-setup.md` for setup.
 


### PR DESCRIPTION
## Summary
- Reworked the `--llm open_api` security blockquote in `.agents/tools/voice/speech-to-speech.md` so secure storage preference is clearer (`aidevops secret set` first, plaintext fallback second).
- Split and strengthened the warning language to explicitly call out compromise handling when keys are committed or exposed in logs/transcripts.
- Preserved the setup reference while making the critical guidance easier to scan.

## Verification
- `markdown-formatter lint /Users/marcusquinn/Git/aidevops-bugfix-4472-pr4397-review-feedback/.agents/tools/voice/speech-to-speech.md`

Closes #4472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated security guidance with expanded recommendations for secure API key storage, avoiding hardcoded keys, and key rotation procedures when keys are compromised.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->