### PR TITLE
t3418: fix missing enabled:false and APITOKEN rename in mcp-servers-config.json.txt

### DIFF
--- a/configs/mcp-servers-config.json.txt
+++ b/configs/mcp-servers-config.json.txt
@@ -2,13 +2,15 @@
   "mcpServers": {
     "hostinger-api": {
       "command": "hostinger-api-mcp",
+      "enabled": false,
       "env": {
-        "APITOKEN": "YOUR_HOSTINGER_API_TOKEN_HERE"
+        "HOSTINGER_API_TOKEN": "YOUR_HOSTINGER_API_TOKEN_HERE"
       },
       "description": "Hostinger API MCP server for managing shared hosting"
     },
     "hetzner-main": {
       "command": "mcp-hetzner",
+      "enabled": false,
       "env": {
         "HCLOUD_TOKEN": "YOUR_MAIN_HETZNER_API_TOKEN_HERE"
       },


### PR DESCRIPTION
## Summary

Addresses critical CodeRabbit review feedback from PR #172 on `configs/mcp-servers-config.json.txt`.

- **hostinger-api**: add `"enabled": false` (migrated to curl-based subagent in #172)
- **hostinger-api**: rename env var `APITOKEN` → `HOSTINGER_API_TOKEN` (avoid generic name collision)
- **hetzner-main**: add `"enabled": false` (migrated to curl-based subagent in #172)

The PR #172 design decision stated: "Leave MCP configs present but set `enabled: false` for optional re-enablement." These two entries were left without the flag.

Closes #3418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled Hostinger API and Hetzner main server integrations.
  * Standardized environment variable naming for Hostinger API credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->