### PR TITLE
t3414: fix $git_dir vs $trepo bug and stderr suppression in rebase_sibling_pr

### DIFF
--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -2453,8 +2453,8 @@ rebase_sibling_pr() {
 	# If a separate 'github' remote exists (e.g. Gitea-primary repos with GitHub
 	# mirror), push there too so GitHub PRs see the updated branch immediately
 	# instead of waiting for mirror sync.
-	if git -C "$trepo" remote get-url github &>/dev/null; then
-		if ! git -C "$git_dir" push --force-with-lease github "$tbranch" 2>>"$SUPERVISOR_LOG"; then
+	if git -C "$trepo" remote get-url github 2>>"$SUPERVISOR_LOG"; then
+		if ! git -C "$trepo" push --force-with-lease github "$tbranch" 2>>"$SUPERVISOR_LOG"; then
 			# Non-fatal — GitHub push may fail due to OAuth scope limitations
 			# (e.g. workflow file restrictions). The mirror will eventually sync.
 			log_warn "rebase_sibling_pr: github remote push failed for $task_id ($tbranch) — mirror will sync"


### PR DESCRIPTION
## Summary

Addresses critical review feedback from PR #2117 (Gemini Code Assist review).

Two bugs fixed in `rebase_sibling_pr()` in `.agents/scripts/supervisor-archived/deploy.sh`:

- **`$git_dir` vs `$trepo` bug**: The `remote get-url github` check correctly used `$trepo` (canonical repo), but the subsequent push used `$git_dir` (which may be a worktree path). Remotes are a property of the canonical repo — using `$git_dir` was semantically incorrect. While git worktrees share remotes with the parent repo (so it would work in practice), the inconsistency was confusing and a latent correctness risk. Fixed to use `$trepo` for both operations.

- **`&>/dev/null` output suppression**: The `remote get-url github` check used `&>/dev/null` to suppress all output, violating repo guidelines that prohibit blanket error suppression. Fixed to redirect stderr to `$SUPERVISOR_LOG` so errors are logged rather than silently discarded.

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/supervisor-archived/deploy.sh` | Use `$trepo` (not `$git_dir`) for github remote push; replace `&>/dev/null` with `2>>"$SUPERVISOR_LOG"` |

## Verification

- ShellCheck: zero violations
- Logic: `$trepo` is always the canonical repo path (validated at line 2356 with `[[ -d "$trepo/.git" ]]`); using it for both the remote check and push is consistent and correct

Closes #3414