### PR TITLE
fix: suppress SC2031 in test-ai-supervisor-e2e.sh

### DIFF
--- a/tests/test-ai-supervisor-e2e.sh
+++ b/tests/test-ai-supervisor-e2e.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034,SC1090,SC2030,SC2317,SC2329
+# shellcheck disable=SC2034,SC1090,SC2030,SC2031,SC2317,SC2329
 # SC2034: Variables set for sourced scripts (BLUE, SUPERVISOR_DB, etc.)
 # SC1090: Non-constant source paths (test harness pattern)
 # SC2030: PATH modification inside subshells is intentional — each test
 #         runs in a ( ... ) subshell for isolation, and export PATH is
 #         needed so sourced scripts and child processes see mock binaries.
+# SC2031: Companion to SC2030 — PATH changes in subshells are intentional;
+#         each test subshell is isolated by design, so the change not
+#         persisting to the parent is the expected and desired behaviour.
 # SC2317: Commands inside subshell test functions appear unreachable to ShellCheck
 # SC2329: _test_* functions defined and called inline; ShellCheck cannot trace subshell calls
 #


### PR DESCRIPTION
## Summary

- Adds `SC2031` to the existing `shellcheck disable` directive in `tests/test-ai-supervisor-e2e.sh`
- SC2031 ("PATH was modified in a subshell. That change might be lost.") is the companion warning to SC2030, which was already suppressed
- Documents the rationale: each test runs in a `( ... )` subshell for isolation — PATH changes not persisting to the parent is intentional and desired behaviour

## Root cause

The daily quality sweep runs ShellCheck without the inline disable directives (or with `--norc`), which surfaces SC2031 separately from SC2030. Both codes are raised by the same pattern; both need to be suppressed together.

## Verification

```
shellcheck tests/test-ai-supervisor-e2e.sh  # exit 0
```

Closes #4475