### PR TITLE
t1465: Fix PLUGIN_NAMESPACES unbound variable in deploy-agents-on-merge.sh

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -277,9 +277,10 @@ deploy_all_agents() {
 	if [[ "$DRY_RUN" == "true" ]]; then
 		log_info "[dry-run] Would sync $source_dir/ -> $TARGET_DIR/"
 		local preserve_display="custom/, draft/, loop-state/"
-		if [[ ${#PLUGIN_NAMESPACES[@]} -gt 0 ]]; then
-			preserve_display+=", ${PLUGIN_NAMESPACES[*]}"
-		fi
+		local plugin_namespace
+		for plugin_namespace in ${PLUGIN_NAMESPACES+"${PLUGIN_NAMESPACES[@]}"}; do
+			preserve_display+=", $plugin_namespace"
+		done
 		log_info "[dry-run] Preserving: $preserve_display"
 		return 0
 	fi


### PR DESCRIPTION
## Summary
- make plugin namespace iteration nounset-safe for Bash 3 empty arrays
- preserve existing deploy behavior for configured namespaces across full and selective sync paths
- validate dry-run deploy flows with and without namespace config

Closes #4478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved deployment script reliability by making plugin-namespace handling robust during dry-run deployments—preserves existing behavior when plugins are present and safely handles cases with no plugins configured, reducing potential failures and confusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->