### PR TITLE
t3404: fix versioning script review feedback (regex robustness, stdout pollution, misleading warnings)

### DIFF
--- a/.agents/scripts/auto-version-bump.sh
+++ b/.agents/scripts/auto-version-bump.sh
@@ -18,137 +18,142 @@ VERSION_MANAGER="$REPO_ROOT/.agents/scripts/version-manager.sh"
 
 # Function to determine version bump type from commit message
 determine_bump_type() {
-    local commit_message="$1"
-    
-    # Major version indicators (breaking changes)
-    if echo "$commit_message" | grep -qE "BREAKING|MAJOR|💥|🚨.*BREAKING"; then
-        echo "major"
-        return 0
-    fi
-    
-    # Minor version indicators (new features)
-    if echo "$commit_message" | grep -qE "FEATURE|FEAT|NEW|ADD|✨|🚀|📦|🎯.*NEW|🎯.*ADD"; then
-        echo "minor"
-        return 0
-    fi
-    
-    # Patch version indicators (bug fixes, improvements)
-    if echo "$commit_message" | grep -qE "FIX|PATCH|BUG|IMPROVE|UPDATE|ENHANCE|🔧|🐛|📝|🎨|♻️|⚡|🔒|📊"; then
-        echo "patch"
-        return 0
-    fi
-    
-    # Default to patch for any other changes
-    echo "patch"
-    return 0
+	local commit_message="$1"
+
+	# Major version indicators (breaking changes)
+	if echo "$commit_message" | grep -qE "BREAKING|MAJOR|💥|🚨.*BREAKING"; then
+		echo "major"
+		return 0
+	fi
+
+	# Minor version indicators (new features)
+	if echo "$commit_message" | grep -qE "FEATURE|FEAT|NEW|ADD|✨|🚀|📦|🎯.*NEW|🎯.*ADD"; then
+		echo "minor"
+		return 0
+	fi
+
+	# Patch version indicators (bug fixes, improvements)
+	if echo "$commit_message" | grep -qE "FIX|PATCH|BUG|IMPROVE|UPDATE|ENHANCE|🔧|🐛|📝|🎨|♻️|⚡|🔒|📊"; then
+		echo "patch"
+		return 0
+	fi
+
+	# Default to patch for any other changes
+	echo "patch"
+	return 0
 }
 
 # Function to check if version should be bumped
 should_bump_version() {
-    local commit_message="$1"
-    
-    # Skip version bump for certain commit types
-    if echo "$commit_message" | grep -qE "^(docs|style|test|chore|ci|build):|WIP|SKIP.*VERSION|NO.*VERSION"; then
-        return 1
-    fi
-    
-    return 0
+	local commit_message="$1"
+
+	# Skip version bump for certain commit types
+	if echo "$commit_message" | grep -qE "^(docs|style|test|chore|ci|build):|WIP|SKIP.*VERSION|NO.*VERSION"; then
+		return 1
+	fi
+
+	return 0
 }
 
 # Function to update version badge in README
 update_version_badge() {
-    local new_version="$1"
-    local readme_file="$REPO_ROOT/README.md"
+	local new_version="$1"
+	local readme_file="$REPO_ROOT/README.md"
 
-    if [[ -f "$readme_file" ]]; then
-        # Skip if using dynamic GitHub release badge
-        if grep -q "img.shields.io/github/v/release" "$readme_file"; then
-            print_success "README.md uses dynamic GitHub release badge (no update needed)"
-            return 0
-        fi
-        
-        # Use cross-platform sed for hardcoded badge
-        sed_inplace "s/Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue/Version-$new_version-blue/" "$readme_file"
+	if [[ -f "$readme_file" ]]; then
+		# Skip if using dynamic GitHub release badge
+		if grep -q "img.shields.io/github/v/release" "$readme_file"; then
+			print_success "README.md uses dynamic GitHub release badge (no update needed)"
+			return 0
+		fi
 
-        # Validate the update was successful
-        if grep -q "Version-$new_version-blue" "$readme_file"; then
-            print_success "Updated version badge in README.md to $new_version"
-        else
-            print_warning "README.md has no version badge (consider adding dynamic GitHub release badge)"
-        fi
-    fi
-    return 0
+		# Check whether a hardcoded version badge exists before attempting update
+		if grep -q "Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue" "$readme_file"; then
+			# Use cross-platform sed for hardcoded badge
+			sed_inplace "s/Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue/Version-$new_version-blue/" "$readme_file"
+
+			# Validate the update was successful
+			if grep -q "Version-$new_version-blue" "$readme_file"; then
+				print_success "Updated version badge in README.md to $new_version"
+			else
+				print_warning "README.md version badge exists but update failed (pattern mismatch)"
+			fi
+		else
+			print_warning "README.md has no version badge (consider adding dynamic GitHub release badge)"
+		fi
+	fi
+	return 0
 }
 
 # Main function
 main() {
-    local commit_message="$1"
-    
-    if [[ -z "$commit_message" ]]; then
-        # Get the last commit message
-        commit_message=$(git log -1 --pretty=%B 2>/dev/null)
-        if [[ -z "$commit_message" ]]; then
-            print_error "No commit message provided and unable to get last commit"
-            exit 1
-        fi
-    fi
-    
-    print_info "Analyzing commit message: $commit_message"
-    
-    if ! should_bump_version "$commit_message"; then
-        print_info "Skipping version bump for this commit type"
-        exit 0
-    fi
-    
-    local bump_type
-    bump_type=$(determine_bump_type "$commit_message")
-    
-    print_info "Determined bump type: $bump_type"
-    
-    if [[ -x "$VERSION_MANAGER" ]]; then
-        local current_version
-        current_version=$("$VERSION_MANAGER" get)
-        
-        local new_version
-        new_version=$("$VERSION_MANAGER" bump "$bump_type")
-        
-        if [[ $? -eq 0 ]]; then
-            print_success "Version bumped: $current_version → $new_version"
-            update_version_badge "$new_version"
-            
-            # Add updated files to git (all version-tracked files)
-            git add VERSION README.md sonar-project.properties setup.sh aidevops.sh package.json .claude-plugin/marketplace.json 2>/dev/null
-            
-            echo "$new_version"
-        else
-            print_error "Failed to bump version"
-            exit 1
-        fi
-    else
-        print_error "Version manager script not found or not executable"
-        exit 1
-    fi
-    return 0
+	local commit_message="$1"
+
+	if [[ -z "$commit_message" ]]; then
+		# Get the last commit message
+		commit_message=$(git log -1 --pretty=%B 2>/dev/null)
+		if [[ -z "$commit_message" ]]; then
+			print_error "No commit message provided and unable to get last commit"
+			exit 1
+		fi
+	fi
+
+	print_info "Analyzing commit message: $commit_message"
+
+	if ! should_bump_version "$commit_message"; then
+		print_info "Skipping version bump for this commit type"
+		exit 0
+	fi
+
+	local bump_type
+	bump_type=$(determine_bump_type "$commit_message")
+
+	print_info "Determined bump type: $bump_type"
+
+	if [[ -x "$VERSION_MANAGER" ]]; then
+		local current_version
+		current_version=$("$VERSION_MANAGER" get)
+
+		local new_version
+		new_version=$("$VERSION_MANAGER" bump "$bump_type")
+
+		if [[ $? -eq 0 ]]; then
+			print_success "Version bumped: $current_version → $new_version"
+			update_version_badge "$new_version"
+
+			# Add updated files to git (all version-tracked files)
+			git add VERSION README.md sonar-project.properties setup.sh aidevops.sh package.json .claude-plugin/marketplace.json 2>/dev/null
+
+			echo "$new_version"
+		else
+			print_error "Failed to bump version"
+			exit 1
+		fi
+	else
+		print_error "Version manager script not found or not executable"
+		exit 1
+	fi
+	return 0
 }
 
 # Show usage if no arguments and not in git repo
 if [[ $# -eq 0 && ! -d .git ]]; then
-    echo "Auto Version Bump for AI DevOps Framework"
-    echo ""
-    echo "Usage: $0 [commit_message]"
-    echo ""
-    echo "Automatically determines version bump type based on commit message:"
-    echo "  MAJOR: BREAKING, MAJOR, 💥, 🚨 BREAKING"
-    echo "  MINOR: FEATURE, FEAT, NEW, ADD, ✨, 🚀, 📦, 🎯 NEW/ADD"
-    echo "  PATCH: FIX, PATCH, BUG, IMPROVE, UPDATE, ENHANCE, 🔧, 🐛, 📝, 🎨, ♻️, ⚡, 🔒, 📊"
-    echo ""
-    echo "Skips version bump for: docs, style, test, chore, ci, build, WIP, SKIP VERSION, NO VERSION"
-    echo ""
-    echo "Examples:"
-    echo "  $0 '🚀 FEATURE: Add new Hetzner integration'"
-    echo "  $0 '🔧 FIX: Resolve badge display issue'"
-    echo "  $0 '💥 BREAKING: Change API structure'"
-    exit 0
+	echo "Auto Version Bump for AI DevOps Framework"
+	echo ""
+	echo "Usage: $0 [commit_message]"
+	echo ""
+	echo "Automatically determines version bump type based on commit message:"
+	echo "  MAJOR: BREAKING, MAJOR, 💥, 🚨 BREAKING"
+	echo "  MINOR: FEATURE, FEAT, NEW, ADD, ✨, 🚀, 📦, 🎯 NEW/ADD"
+	echo "  PATCH: FIX, PATCH, BUG, IMPROVE, UPDATE, ENHANCE, 🔧, 🐛, 📝, 🎨, ♻️, ⚡, 🔒, 📊"
+	echo ""
+	echo "Skips version bump for: docs, style, test, chore, ci, build, WIP, SKIP VERSION, NO VERSION"
+	echo ""
+	echo "Examples:"
+	echo "  $0 '🚀 FEATURE: Add new Hetzner integration'"
+	echo "  $0 '🔧 FIX: Resolve badge display issue'"
+	echo "  $0 '💥 BREAKING: Change API structure'"
+	exit 0
 fi
 
 main "$@"

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -723,17 +723,19 @@ validate_version_consistency() {
 }
 
 # Function to update version in files
+# All diagnostic output goes to stderr so callers that capture stdout
+# as a version string (e.g. auto-version-bump.sh) are not polluted.
 update_version_in_files() {
 	local new_version="$1"
 	local errors=0
 
-	print_info "Updating version references in files..."
+	print_info "Updating version references in files..." >&2
 
 	# Update VERSION file
 	if [[ -f "$VERSION_FILE" ]]; then
 		echo "$new_version" >"$VERSION_FILE"
 		if [[ "$(cat "$VERSION_FILE")" == "$new_version" ]]; then
-			print_success "Updated VERSION file"
+			print_success "Updated VERSION file" >&2
 		else
 			print_error "Failed to update VERSION file"
 			errors=$((errors + 1))
@@ -742,9 +744,9 @@ update_version_in_files() {
 
 	# Update package.json if it exists
 	if [[ -f "$REPO_ROOT/package.json" ]]; then
-		sed_inplace "s/\"version\": \"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/\"version\": \"$new_version\"/" "$REPO_ROOT/package.json"
+		sed_inplace "s/\"version\": *\"[^\"]*\"/\"version\": \"$new_version\"/" "$REPO_ROOT/package.json"
 		if grep -q "\"version\": \"$new_version\"" "$REPO_ROOT/package.json"; then
-			print_success "Updated package.json"
+			print_success "Updated package.json" >&2
 		else
 			print_error "Failed to update package.json"
 			errors=$((errors + 1))
@@ -755,7 +757,7 @@ update_version_in_files() {
 	if [[ -f "$REPO_ROOT/sonar-project.properties" ]]; then
 		sed_inplace "s/sonar\.projectVersion=.*/sonar.projectVersion=$new_version/" "$REPO_ROOT/sonar-project.properties"
 		if grep -q "sonar.projectVersion=$new_version" "$REPO_ROOT/sonar-project.properties"; then
-			print_success "Updated sonar-project.properties"
+			print_success "Updated sonar-project.properties" >&2
 		else
 			print_error "Failed to update sonar-project.properties"
 			errors=$((errors + 1))
@@ -775,24 +777,24 @@ update_version_in_files() {
 	if [[ -f "$REPO_ROOT/README.md" ]]; then
 		if grep -q "img.shields.io/github/v/release" "$REPO_ROOT/README.md"; then
 			# Dynamic badge - no update needed, GitHub handles it automatically
-			print_success "README.md uses dynamic GitHub release badge (no update needed)"
+			print_success "README.md uses dynamic GitHub release badge (no update needed)" >&2
 		elif grep -q "Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue" "$REPO_ROOT/README.md"; then
 			# Hardcoded badge - update it
 			sed_inplace "s/Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue/Version-$new_version-blue/" "$REPO_ROOT/README.md"
 
 			# Validate the update was successful
 			if grep -q "Version-$new_version-blue" "$REPO_ROOT/README.md"; then
-				print_success "Updated README.md version badge to $new_version"
+				print_success "Updated README.md version badge to $new_version" >&2
 			else
 				print_error "Failed to update README.md version badge"
 				errors=$((errors + 1))
 			fi
 		else
 			# No version badge found - that's okay, just warn
-			print_warning "README.md has no version badge (consider adding dynamic GitHub release badge)"
+			print_warning "README.md has no version badge (consider adding dynamic GitHub release badge)" >&2
 		fi
 	else
-		print_warning "README.md not found, skipping version badge update"
+		print_warning "README.md not found, skipping version badge update" >&2
 	fi
 
 	# Update Homebrew formula version (SHA256 is updated by CI publish-packages.yml)
@@ -801,7 +803,7 @@ update_version_in_files() {
 		sed_inplace "s|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.tar\.gz\"|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v${new_version}.tar.gz\"|" "$formula_file"
 
 		if grep -q "v${new_version}.tar.gz" "$formula_file"; then
-			print_success "Updated homebrew/aidevops.rb version URL"
+			print_success "Updated homebrew/aidevops.rb version URL" >&2
 		else
 			print_error "Failed to update homebrew/aidevops.rb"
 			errors=$((errors + 1))
@@ -810,11 +812,11 @@ update_version_in_files() {
 
 	# Update Claude Code plugin marketplace.json
 	if [[ -f "$REPO_ROOT/.claude-plugin/marketplace.json" ]]; then
-		sed_inplace "s/\"version\": \"[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\"/\"version\": \"$new_version\"/" "$REPO_ROOT/.claude-plugin/marketplace.json"
+		sed_inplace "s/\"version\": *\"[^\"]*\"/\"version\": \"$new_version\"/" "$REPO_ROOT/.claude-plugin/marketplace.json"
 
 		# Validate the update was successful
 		if grep -q "\"version\": \"$new_version\"" "$REPO_ROOT/.claude-plugin/marketplace.json"; then
-			print_success "Updated .claude-plugin/marketplace.json"
+			print_success "Updated .claude-plugin/marketplace.json" >&2
 		else
 			print_error "Failed to update .claude-plugin/marketplace.json"
 			errors=$((errors + 1))
@@ -827,7 +829,7 @@ update_version_in_files() {
 		return 1
 	fi
 
-	print_success "All version files updated to $new_version"
+	print_success "All version files updated to $new_version" >&2
 	return 0
 }
 
@@ -842,7 +844,7 @@ update_script_version_reference() {
 
 	sed_inplace "s/# Version: .*/# Version: $new_version/" "$script_path"
 	if grep -Fq "# Version: $new_version" "$script_path"; then
-		print_success "Updated $script_name"
+		print_success "Updated $script_name" >&2
 		return 0
 	fi
 


### PR DESCRIPTION
## Summary

Addresses Gemini and Augment code review feedback from PR #250 (merged), tracked in issue #3404.

## Changes

### `version-manager.sh`

- **Robust regex for JSON version fields**: Changed `sed` patterns for `package.json` and `.claude-plugin/marketplace.json` from exact `\"version\": \"X.Y.Z\"` to `\"version\": *\"[^\"]*\"` — tolerates whitespace variations and any version string format without brittle exact-match patterns (Gemini suggestion, lines 421 and 489 of original review)
- **Redirect diagnostic output to stderr**: All `print_success`, `print_info`, and `print_warning` calls in `update_version_in_files()` and `update_script_version_reference()` now redirect to stderr. This prevents stdout pollution when callers capture the function's output as a version string (e.g. `new_version=$("$VERSION_MANAGER" bump "$bump_type")` in `auto-version-bump.sh`). Augment finding at line 506.

### `auto-version-bump.sh`

- **Precise warning in `update_version_badge()`**: Pre-check whether a hardcoded version badge exists before attempting the `sed` update. Now distinguishes two cases: (1) badge exists but update failed → `"version badge exists but update failed (pattern mismatch)"`, (2) no badge found → existing `"no version badge"` message. Augment finding at line 96.

## Testing

- `shellcheck --severity=warning` passes on both modified scripts (zero violations)
- Logic verified against the three reviewer findings

Closes #3404