### PR TITLE
t3670: fix 4-space indentation in detect_cli() of agent-test-helper.sh

### DIFF
--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -64,16 +64,16 @@ readonly REPO_SUITES_DIR="${SCRIPT_DIR}/../tests"
 
 # CLI detection - opencode is the only supported CLI
 detect_cli() {
-	local cli="${AGENT_TEST_CLI:-}"
-	if [[ -n "$cli" ]]; then
-		echo "$cli"
-		return 0
-	fi
-	if command -v opencode >/dev/null 2>&1; then
-		echo "opencode"
-	else
-		echo ""
-	fi
+    local cli="${AGENT_TEST_CLI:-}"
+    if [[ -n "$cli" ]]; then
+        echo "$cli"
+        return 0
+    fi
+    if command -v opencode >/dev/null 2>&1; then
+        echo "opencode"
+    else
+        echo ""
+    fi
 }
 
 AI_CLI="$(detect_cli)"


### PR DESCRIPTION
## Summary

- Restores 4-space indentation in `detect_cli()` function of `.agents/scripts/agent-test-helper.sh`
- The function had tab indentation introduced during the `claude-sonnet-4-6` model update batch (PR #1594), inconsistent with the rest of the file and project convention
- No logic changes — formatting only

## Root Cause

PR #1594 included a batch reformatting of several shell scripts from 4-space to tab indentation. The `detect_cli()` function in `agent-test-helper.sh` was affected but the rest of the file was not, creating an inconsistency flagged by Gemini code review.

Closes #3670