### PR TITLE
t3671: address cron-helper review feedback from PR #1594

### DIFF
--- a/.agents/scripts/cron-helper.sh
+++ b/.agents/scripts/cron-helper.sh
@@ -47,17 +47,17 @@ LOG_PREFIX="CRON"
 # Ensure directories and config exist
 #######################################
 ensure_setup() {
-	mkdir -p "$CONFIG_DIR" "$CRON_LOG_DIR"
+    mkdir -p "$CONFIG_DIR" "$CRON_LOG_DIR"
 
-	if [[ ! -f "$CONFIG_FILE" ]]; then
-		cat >"$CONFIG_FILE" <<'EOF'
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        cat > "$CONFIG_FILE" << 'EOF'
 {
   "version": "1.0",
   "jobs": []
 }
 EOF
-		log_info "Created config file: $CONFIG_FILE"
-	fi
+        log_info "Created config file: $CONFIG_FILE"
+    fi
 }
 
 #######################################


### PR DESCRIPTION
## Summary
- Apply the medium-priority PR #1594 feedback to `.agents/scripts/cron-helper.sh` by reformatting `ensure_setup()` to use 4-space indentation and spacing exactly as suggested.
- Keep behavior unchanged while aligning the function block style with the review recommendation recorded in issue #3671.
- Validate the updated script with `shellcheck` and `bash -n` after the edit.

Closes #3671