### PR TITLE
t3406: address remaining PR #191 review feedback

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -545,10 +545,15 @@ LAZY_MCPS = {'claude-code-mcp', 'outscraper', 'dataforseo', 'shadcn', 'macos-aut
 # Apply loading policy to existing MCPs and warn about uncategorized ones
 uncategorized = []
 for mcp_name in list(config.get('mcp', {}).keys()):
+    mcp_cfg = config['mcp'].get(mcp_name, {})
+    if not isinstance(mcp_cfg, dict):
+        print(f"  Warning: MCP '{mcp_name}' has non-dict config ({type(mcp_cfg).__name__}), skipping", file=sys.stderr)
+        continue
+
     if mcp_name in EAGER_MCPS:
-        config['mcp'][mcp_name]['enabled'] = True
+        mcp_cfg['enabled'] = True
     elif mcp_name in LAZY_MCPS:
-        config['mcp'][mcp_name]['enabled'] = False
+        mcp_cfg['enabled'] = False
     else:
         uncategorized.append(mcp_name)
 
@@ -709,7 +714,7 @@ if 'openapi-search_*' not in config['tools']:
 # MCPs are disabled via LAZY_MCPS above, but we also need to disable tools
 omo_tool_patterns = ['grep_app_*', 'websearch_*', 'gh_grep_*']
 for tool_pattern in omo_tool_patterns:
-    if tool_pattern not in config.get('tools', {}):
+    if config['tools'].get(tool_pattern) is not False:
         config['tools'][tool_pattern] = False
         print(f"  Disabled {tool_pattern} tools globally (use @github-search subagent)")
 
@@ -869,7 +874,8 @@ echo "Tab order: Build+ → (alphabetical)"
 echo "  Note: Plan+ and AI-DevOps consolidated into Build+ (available as @plan-plus, @aidevops)"
 echo ""
 echo "MCP Loading Strategy:"
-echo "  - MCPs disabled globally, enabled per-agent (reduces context tokens)"
+echo "  - Eager MCPs: Start at launch when explicitly categorized"
+echo "  - Lazy MCPs: Start on-demand via subagents (default policy)"
 echo "  - Use 'mcp-index-helper.sh search <query>' to discover tools on-demand"
 echo "  - Subagents enable specific MCPs via frontmatter tools: section"
 echo ""

--- a/.agents/tools/ai-assistants/claude-code.md
+++ b/.agents/tools/ai-assistants/claude-code.md
@@ -59,7 +59,7 @@ When this subagent is invoked, these tools become available:
 
 | Tool | Description |
 |------|-------------|
-| `claude_code` | Execute a prompt via Claude Code CLI |
+| `claude-code-mcp_*` | MCP-exposed Claude Code tools (use the generated tool name from your runtime) |
 
 ## Example Prompts
 
@@ -87,7 +87,7 @@ The MCP is configured in `opencode.json`:
   "mcp": {
     "claude-code-mcp": {
       "type": "local",
-      "command": ["npx", "-y", "@steipete/claude-code-mcp"],
+      "command": ["npx", "-y", "github:marcusquinn/claude-code-mcp"],
       "enabled": false
     }
   },
@@ -104,7 +104,7 @@ The MCP starts on-demand when this subagent is invoked, avoiding startup overhea
 1. **Be specific**: Provide clear, detailed prompts for best results
 2. **Scope appropriately**: Don't use for trivial tasks
 3. **Check results**: Review sub-agent output before proceeding
-4. **Avoid loops**: Don't have sub-agents spawn more sub-agents
+4. **Avoid loops**: Don't have sub-agents spawn more sub-agents; nested invocations multiply token usage and cost quickly
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Harden MCP loading policy enforcement in the OpenCode generator by handling malformed MCP config entries defensively.
- Ensure OmO MCP tool patterns (`grep_app_*`, `websearch_*`, `gh_grep_*`) are always forced off globally, even on upgraded configs where they were previously true.
- Update `@claude-code` docs to match the current fork-based command and clarify tool naming plus nested-invocation cost impact.

## Verification
- `shellcheck .agents/scripts/generate-opencode-agents.sh` (SC1091 info-only existing repo behavior)
- `markdown-formatter lint .agents/tools/ai-assistants/claude-code.md`
- `bash .agents/scripts/generate-opencode-agents.sh`

Closes #3406