### PR TITLE
t3402: fix PR #140 critical helper script vulnerabilities

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -853,8 +853,11 @@ echo -e "${BLUE}Syncing MCP tool index for on-demand discovery...${NC}"
 
 MCP_INDEX_HELPER="$AGENTS_DIR/scripts/mcp-index-helper.sh"
 if [[ -x "$MCP_INDEX_HELPER" ]]; then
-	"$MCP_INDEX_HELPER" sync 2>/dev/null || echo -e "  ${YELLOW}⚠${NC} MCP index sync skipped (non-critical)"
-	echo -e "  ${GREEN}✓${NC} MCP tool index updated"
+	if "$MCP_INDEX_HELPER" sync 2>/dev/null; then
+		echo -e "  ${GREEN}✓${NC} MCP tool index updated"
+	else
+		echo -e "  ${YELLOW}⚠${NC} MCP index sync skipped (non-critical)"
+	fi
 else
 	echo -e "  ${YELLOW}⚠${NC} MCP index helper not found (install with setup.sh)"
 fi

--- a/.agents/scripts/memory/maintenance.sh
+++ b/.agents/scripts/memory/maintenance.sh
@@ -705,6 +705,10 @@ cmd_consolidate() {
 			shift
 			;;
 		--threshold)
+			if [[ $# -lt 2 ]]; then
+				log_error "--threshold requires a value"
+				return 1
+			fi
 			similarity_threshold="$2"
 			shift 2
 			;;
@@ -715,6 +719,11 @@ cmd_consolidate() {
 	# Validate similarity_threshold is a valid decimal
 	if ! [[ "$similarity_threshold" =~ ^[0-9]*\.?[0-9]+$ ]]; then
 		log_error "--threshold must be a decimal number (e.g., 0.5)"
+		return 1
+	fi
+
+	if ! awk "BEGIN { exit !($similarity_threshold >= 0 && $similarity_threshold <= 1) }"; then
+		log_error "--threshold must be between 0 and 1"
 		return 1
 	fi
 
@@ -836,6 +845,7 @@ EOF
 		# Clean up old backups (t188)
 		cleanup_sqlite_backups "$MEMORY_DB" 5
 	fi
+	return 0
 }
 
 #######################################

--- a/.agents/scripts/session-distill-helper.sh
+++ b/.agents/scripts/session-distill-helper.sh
@@ -183,23 +183,15 @@ extract_learnings() {
 		done <<<"$doc_commits"
 	fi
 
-	# Build learnings JSON
-	local learnings_json="["
-	local first=true
-	for learning in "${learnings[@]}"; do
-		if [[ "$first" == "true" ]]; then
-			first=false
-		else
-			learnings_json+=","
-		fi
-		learnings_json+="$learning"
-	done
-	learnings_json+="]"
-
-	echo "$learnings_json" | jq '.' >"$learnings_file"
+	# Build learnings JSON safely without string concatenation
+	if [[ ${#learnings[@]} -eq 0 ]]; then
+		printf '%s\n' '[]' >"$learnings_file"
+	else
+		printf '%s\n' "${learnings[@]}" | jq -s '.' >"$learnings_file"
+	fi
 
 	local count
-	count=$(echo "$learnings_json" | jq 'length')
+	count=$(jq 'length' "$learnings_file")
 	log_success "Extracted $count learnings to $learnings_file"
 
 	cat "$learnings_file"


### PR DESCRIPTION
## Summary
- Convert `mcp-index-helper.sh` dynamic SQL interpolation to parameterized SQLite queries for `search`, `list`, and `get-mcp` paths.
- Harden MCP search handling by normalizing hostile FTS input and joining against `mcp_tools` for correctness when selecting global-enabled metadata.
- Replace manual JSON string concatenation in `session-distill-helper.sh` with `jq -s` assembly, tighten `memory` consolidate threshold validation, and fix false-success reporting in `generate-opencode-agents.sh` MCP sync output.

## Verification
- `bash -n .agents/scripts/mcp-index-helper.sh .agents/scripts/session-distill-helper.sh .agents/scripts/memory/maintenance.sh .agents/scripts/generate-opencode-agents.sh`
- `.agents/scripts/mcp-index-helper.sh search "test' OR 1=1 --" 1`
- `.agents/scripts/mcp-index-helper.sh list "context7' OR 'x'='x"`
- `.agents/scripts/mcp-index-helper.sh get-mcp "tool' OR 1=1 --"`
- `bash .agents/scripts/memory-helper.sh consolidate --threshold` (expected validation error)

Closes #3402