### PR TITLE
fix: address PR #2397 review feedback in t1337.1 audit report

### DIFF
--- a/todo/tasks/t1337.1-audit-report.md
+++ b/todo/tasks/t1337.1-audit-report.md
@@ -66,7 +66,7 @@ The 5 Tier 3 scripts have **already been substantially simplified** since the t1
 |----------|-----------------|---------|
 | `cmd_record` | 3 scripts | Log a spend event |
 | `cmd_status` | 5+ scripts | Summarise spend |
-| `get_model_pricing` | 1 (observability-helper) | Model cost lookup |
+| ~~`get_model_pricing`~~ | — | Moved to `shared-constants.sh` (t1337.2) |
 
 **Internal-only:** `calculate_cost`, `cmd_burn_rate`, `cmd_tail`, `init_cost_log`
 
@@ -98,7 +98,7 @@ The 5 Tier 3 scripts have **already been substantially simplified** since the t1
 | `check_rate_limit_risk` | 1 (model-availability-helper) | Rate limit risk assessment |
 | `cmd_rate_limits` | 1 (model-availability-helper) | Rate limit dashboard |
 | `cmd_record` | 3 scripts | Manually record LLM request |
-| `get_model_pricing` | 1 (budget-tracker-helper) | Model cost lookup (DUPLICATE) |
+| ~~`get_model_pricing`~~ | — | Moved to `shared-constants.sh` (t1337.2) |
 
 **Internal-only (15 functions):** `_calc_costs`, `cmd_ingest`, `_count_usage_in_window`, `_get_config_val`, `get_offset`, `get_project_from_path`, `get_provider_from_model`, `_get_rate_limits_config`, `_get_rl_field`, `init_storage`, `parse_jsonl_file`, `set_offset`, `_write_metric`
 
@@ -129,6 +129,8 @@ The observability version is a superset. Both have the same model matching logic
 
 **Recommendation:** Extract to `shared-constants.sh` or a new `model-pricing.sh`. Use the 4-field version. Budget-tracker can ignore fields 3-4.
 
+**Performance note (from review):** The additional `cache_read` and `cache_write` fields in the 4-field version add negligible overhead — they are static string lookups in a case statement, not computed values. The budget-tracker caller already destructures only the fields it needs (`IFS='|' read -r input_price output_price _ _ <<< "$pricing"`), so the extra fields are silently discarded. No graceful-handling changes are needed in budget-tracker. If a future caller requires only 2 fields and the lookup table grows significantly, a separate 2-field function could be justified — but at current scale this is premature optimisation.
+
 **Savings:** ~25 lines (one copy removed + callers updated).
 
 ### 2. Backward-compat stubs (MEDIUM — remove after grace period)
@@ -144,7 +146,9 @@ These were added during the t1337.3/t1337.5 simplification. If no callers remain
 
 ### 3. Dead functions in issue-sync-lib.sh (MEDIUM)
 
-`find_closing_pr` and `task_has_completion_evidence` are dead — superseded by inline versions in `issue-sync-helper.sh`. Remove them.
+`find_closing_pr` and `task_has_completion_evidence` are dead in active code — superseded by inline versions in `issue-sync-helper.sh`. Remove them.
+
+**Caveat (from review):** `supervisor-archived/issue-audit.sh` still calls both functions directly (not the `_`-prefixed replacements). This is archived code and not executed in production, but it confirms the functions are not universally dead. Before removing, verify: (1) `issue-audit.sh` is truly archived and will not be revived, (2) no other archived or experimental scripts source `issue-sync-lib.sh` and call these functions. Run: `rg 'find_closing_pr|task_has_completion_evidence' .agents/scripts/ --type sh` and review all hits, including `supervisor-archived/`. If the archived script is the only caller, removal is safe — but document the decision in the commit message.
 
 **Savings:** ~80 lines from issue-sync-lib.sh.
 
@@ -195,7 +199,7 @@ observability-helper.sh
 
 Priority-ordered consolidation work:
 
-1. **Merge `get_model_pricing`** into a shared location (e.g., `shared-constants.sh` or new `model-pricing-lib.sh`). Use the 4-field version from observability-helper. Update budget-tracker to use it. (~25 lines saved)
+1. ~~**Merge `get_model_pricing`**~~ **DONE (t1337.2):** Consolidated into `shared-constants.sh` using the 4-field version. Both `budget-tracker-helper.sh` and `observability-helper.sh` now delegate to it. Budget-tracker discards fields 3-4 via `IFS='|' read -r input output _ _`. (~25 lines saved)
 
 2. **Remove backward-compat stubs** from budget-tracker-helper.sh and observability-helper.sh after verifying no active callers. (~22 lines saved)
 
@@ -232,5 +236,6 @@ grep -rn '^get_model_pricing()' .agents/scripts/*.sh
 
 # Dead function check in issue-sync-lib.sh
 rg 'find_closing_pr|task_has_completion_evidence' .agents/scripts/ --type sh | grep -v 'issue-sync-lib.sh' | grep -v 'archived/'
-# Returns 0 hits — confirmed dead
+# Returns 0 hits in active code — but supervisor-archived/issue-audit.sh calls both.
+# Archived callers do not affect production; removal is safe if issue-audit.sh stays archived.
 ```


### PR DESCRIPTION
## Summary

Addresses the two unactioned review findings from PR #2397 on `todo/tasks/t1337.1-audit-report.md`.

### HIGH (line 121) — `get_model_pricing` performance consideration

Added a **Performance note** to Consolidation Target #1 explaining:
- The extra `cache_read`/`cache_write` fields are static case-statement lookups — negligible overhead
- `budget-tracker-helper.sh` already discards them via `IFS='|' read -r input output _ _` destructuring
- No graceful-handling changes are needed; a separate 2-field function would be premature optimisation at current scale

Also marked this item as **DONE (t1337.2)** since the consolidation into `shared-constants.sh` was already completed.

### MEDIUM (line 149) — Dead function verification

Added a **Caveat** to Consolidation Target #3 noting:
- `supervisor-archived/issue-audit.sh` calls both `find_closing_pr` and `task_has_completion_evidence` directly
- These are archived (not production) callers, but the original "confirmed dead" claim was inaccurate
- Updated the verification comment to reflect this; added guidance to confirm archived status before removal

Closes #3387