### PR TITLE
t3395: fix(leak-detector): address PR #2373 review feedback — 4 quality-debt findings

### DIFF
--- a/.agents/scripts/simplex-bot/src/index.ts
+++ b/.agents/scripts/simplex-bot/src/index.ts
@@ -296,7 +296,7 @@ export class SimplexAdapter {
       return text;
     }
 
-    const result = scanForLeaks(text);
+    const result = scanForLeaks(text, this.config.leakDetection);
     if (!result.hasLeaks) {
       return text;
     }

--- a/.agents/scripts/simplex-bot/src/leak-detector.test.ts
+++ b/.agents/scripts/simplex-bot/src/leak-detector.test.ts
@@ -15,6 +15,14 @@ import {
   formatLeakWarning,
   LEAK_PATTERNS,
 } from "./leak-detector";
+import type { LeakDetectionConfig } from "./types";
+
+/** Default config used across tests — mirrors DEFAULT_LEAK_DETECTION_CONFIG */
+const DEFAULT_CONFIG: LeakDetectionConfig = {
+  enabled: true,
+  entropyThreshold: 4.0,
+  minTokenLength: 20,
+};
 
 // =============================================================================
 // Shannon Entropy
@@ -449,5 +457,117 @@ describe("edge cases", () => {
     // Should have two [REDACTED] markers
     const count = (redacted.match(/\[REDACTED\]/g) ?? []).length;
     expect(count).toBe(2);
+  });
+});
+
+// =============================================================================
+// Config-Driven Thresholds (t3395 — HIGH finding)
+// =============================================================================
+
+describe("scanForLeaks — config-driven thresholds", () => {
+  test("uses entropyThreshold from config — high threshold suppresses detection", () => {
+    // A token with entropy ~4.2 — detected at default 4.0 but not at 4.5
+    const token = "xK9mB2nR7pL4qW8sT3vY6zA1cF5dG0hJ";
+    const text = `Token: ${token}`;
+    const strictConfig: LeakDetectionConfig = { ...DEFAULT_CONFIG, entropyThreshold: 5.5 };
+    const result = scanForLeaks(text, strictConfig);
+    // With a very high threshold, this token should not be flagged as high_entropy
+    expect(result.matches.some((m) => m.patternName === "high_entropy")).toBe(false);
+  });
+
+  test("uses entropyThreshold from config — low threshold increases detection", () => {
+    const token = "xK9mB2nR7pL4qW8sT3vY6zA1cF5dG0hJ";
+    const text = `Token: ${token}`;
+    const looseConfig: LeakDetectionConfig = { ...DEFAULT_CONFIG, entropyThreshold: 3.0 };
+    const result = scanForLeaks(text, looseConfig);
+    expect(result.matches.some((m) => m.patternName === "high_entropy")).toBe(true);
+  });
+
+  test("uses minTokenLength from config — longer minimum skips short tokens", () => {
+    // A 25-char high-entropy token — detected at default minTokenLength=20 but not at 30
+    const token = "aB3kL9mNpQ2rStUvWxYz12345";
+    const text = `Token: ${token}`;
+    const longMinConfig: LeakDetectionConfig = { ...DEFAULT_CONFIG, minTokenLength: 30 };
+    const result = scanForLeaks(text, longMinConfig);
+    expect(result.matches.some((m) => m.patternName === "high_entropy")).toBe(false);
+  });
+
+  test("default config (no arg) behaves identically to passing DEFAULT_CONFIG", () => {
+    const text = "Token: xK9mB2nR7pL4qW8sT3vY6zA1cF5dG0hJ";
+    const resultDefault = scanForLeaks(text);
+    const resultExplicit = scanForLeaks(text, DEFAULT_CONFIG);
+    expect(resultDefault.hasLeaks).toBe(resultExplicit.hasLeaks);
+    expect(resultDefault.matches.length).toBe(resultExplicit.matches.length);
+  });
+});
+
+// =============================================================================
+// AWS Secret Key — contextual keyword requirement (t3395 — MEDIUM finding)
+// =============================================================================
+
+describe("scanForLeaks — aws_secret_key contextual keyword", () => {
+  test("detects AWS secret key with contextual keyword", () => {
+    // 40-char high-entropy base64 string with keyword context
+    const text = "aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+    const result = scanForLeaks(text);
+    expect(result.matches.some((m) => m.patternName === "aws_secret_key")).toBe(true);
+  });
+
+  test("does NOT flag bare 40-char base64 without keyword context", () => {
+    // Same 40-char string but no surrounding keyword — should not match aws_secret_key
+    const text = "The value is wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY here";
+    const result = scanForLeaks(text);
+    expect(result.matches.some((m) => m.patternName === "aws_secret_key")).toBe(false);
+  });
+});
+
+// =============================================================================
+// Bearer Token — captures only token value, not prefix (t3395 — MEDIUM finding)
+// =============================================================================
+
+describe("scanForLeaks — bearer_token captures only token value", () => {
+  test("matchedText does not include 'Bearer ' prefix", () => {
+    const token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    const text = `Authorization: Bearer ${token}`;
+    const result = scanForLeaks(text);
+    const bearerMatch = result.matches.find((m) => m.patternName === "bearer_token");
+    expect(bearerMatch).toBeDefined();
+    expect(bearerMatch?.matchedText).not.toMatch(/^Bearer\s/i);
+    expect(bearerMatch?.matchedText).toBe(token);
+  });
+
+  test("detects bearer token case-insensitively", () => {
+    const token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    const text = `Authorization: bearer ${token}`;
+    const result = scanForLeaks(text);
+    expect(result.matches.some((m) => m.patternName === "bearer_token")).toBe(true);
+  });
+});
+
+// =============================================================================
+// High-Entropy Index Correctness (t3395 — HIGH finding)
+// =============================================================================
+
+describe("scanForLeaks — high-entropy token index correctness", () => {
+  test("index points to the correct occurrence when token appears multiple times", () => {
+    const token = "xK9mB2nR7pL4qW8sT3vY6zA1cF5dG0hJ";
+    // Place the token at a known position (not the start)
+    const prefix = "safe text here: ";
+    const text = `${prefix}${token}`;
+    const result = scanForLeaks(text);
+    const match = result.matches.find((m) => m.patternName === "high_entropy");
+    expect(match).toBeDefined();
+    // Index should point to where the token actually starts
+    expect(match?.index).toBe(prefix.length);
+  });
+
+  test("high-entropy token that is substring of a pattern match is not double-reported", () => {
+    // A GitHub token contains a high-entropy substring — should only appear as github_token
+    const token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl";
+    const text = `Token: ${token}`;
+    const result = scanForLeaks(text);
+    // Should be detected as github_token, not also as high_entropy
+    expect(result.matches.some((m) => m.patternName === "github_token")).toBe(true);
+    expect(result.matches.some((m) => m.patternName === "high_entropy")).toBe(false);
   });
 });

--- a/.agents/scripts/simplex-bot/src/leak-detector.ts
+++ b/.agents/scripts/simplex-bot/src/leak-detector.ts
@@ -15,17 +15,12 @@
  * Reference: t1327.9 outbound leak detection specification
  */
 
-import type { LeakDetectionResult, LeakMatch, LeakPatternName } from "./types";
+import type { LeakDetectionConfig, LeakDetectionResult, LeakMatch, LeakPatternName } from "./types";
+import { DEFAULT_LEAK_DETECTION_CONFIG } from "./types";
 
 // =============================================================================
 // Shannon Entropy
 // =============================================================================
-
-/** Minimum token length to evaluate for entropy (shorter strings have unreliable entropy) */
-const MIN_ENTROPY_TOKEN_LENGTH = 20;
-
-/** Entropy threshold in bits/char — English text ~3.5, base64 random ~5.5 */
-const ENTROPY_THRESHOLD = 4.0;
 
 /**
  * Calculate Shannon entropy of a string in bits per character.
@@ -75,8 +70,8 @@ export const LEAK_PATTERNS: ReadonlyArray<{
   },
   {
     name: "aws_secret_key",
-    pattern: /\b([0-9a-zA-Z/+]{40})\b/g,
-    description: "AWS Secret Access Key (40-char base64)",
+    pattern: /(?:aws_secret_access_key|aws_secret|secret_access_key|secret|key)\s*[:=]\s*["']?([0-9a-zA-Z/+]{40})["']?/gi,
+    description: "AWS Secret Access Key (40-char base64 with contextual keyword)",
   },
 
   // --- Git platform tokens ---
@@ -116,7 +111,7 @@ export const LEAK_PATTERNS: ReadonlyArray<{
   },
   {
     name: "bearer_token",
-    pattern: /\b(Bearer\s+[A-Za-z0-9_\-/.+]{20,})\b/g,
+    pattern: /\bBearer\s+([A-Za-z0-9_\-/.+=]{20,})\b/gi,
     description: "Bearer authentication token",
   },
 
@@ -170,10 +165,18 @@ export const LEAK_PATTERNS: ReadonlyArray<{
 /**
  * Scan text for potential credential/secret leaks.
  *
+ * Accepts an optional LeakDetectionConfig to allow runtime customisation of
+ * entropy thresholds and minimum token length. Defaults to
+ * DEFAULT_LEAK_DETECTION_CONFIG when not provided.
+ *
  * Returns a result with all matches found. The caller decides whether
  * to redact, block, or warn based on the results.
  */
-export function scanForLeaks(text: string): LeakDetectionResult {
+export function scanForLeaks(
+  text: string,
+  config: LeakDetectionConfig = DEFAULT_LEAK_DETECTION_CONFIG,
+): LeakDetectionResult {
+  const { entropyThreshold, minTokenLength } = config;
   const matches: LeakMatch[] = [];
 
   // --- Pattern-based detection ---
@@ -188,7 +191,7 @@ export function scanForLeaks(text: string): LeakDetectionResult {
 
       // For aws_secret_key (40-char base64), require high entropy to reduce false positives
       if (name === "aws_secret_key") {
-        if (shannonEntropy(value) < ENTROPY_THRESHOLD) {
+        if (shannonEntropy(value) < entropyThreshold) {
           continue;
         }
       }
@@ -204,31 +207,29 @@ export function scanForLeaks(text: string): LeakDetectionResult {
   }
 
   // --- High-entropy token detection (catch-all for unknown formats) ---
-  // Split on whitespace and common delimiters, check each token
-  const tokens = text.split(/[\s"'`=:,;{}[\]()]+/);
-  for (const token of tokens) {
-    if (token.length < MIN_ENTROPY_TOKEN_LENGTH) {
-      continue;
-    }
+  // Use RegExp.exec() in a loop to get both the token and its correct index,
+  // avoiding the unreliable text.indexOf() approach when tokens repeat.
+  const tokenRegex = new RegExp(`[A-Za-z0-9_\\-/.+=]{${minTokenLength},}`, "g");
+  let tokenMatch: RegExpExecArray | null;
+  while ((tokenMatch = tokenRegex.exec(text)) !== null) {
+    const token = tokenMatch[0];
+    const index = tokenMatch.index;
 
-    // Skip tokens already caught by pattern matching
-    const alreadyCaught = matches.some((m) => m.matchedText === token);
+    // Skip tokens that overlap with an already-found pattern match by checking index ranges
+    const alreadyCaught = matches.some(
+      (m) => index >= m.index && index < m.index + m.matchedText.length,
+    );
     if (alreadyCaught) {
       continue;
     }
 
-    // Only flag tokens that look like secrets (alphanumeric + special chars, no spaces)
-    if (!/^[A-Za-z0-9_\-/.+=]{20,}$/.test(token)) {
-      continue;
-    }
-
     const entropy = shannonEntropy(token);
-    if (entropy >= ENTROPY_THRESHOLD) {
+    if (entropy >= entropyThreshold) {
       matches.push({
         patternName: "high_entropy",
         description: `High-entropy token (${entropy.toFixed(2)} bits/char)`,
         matchedText: token,
-        index: text.indexOf(token),
+        index,
         entropy,
       });
     }


### PR DESCRIPTION
## Summary

Fixes all 4 findings from the Gemini code review on PR #2373 that were tracked as quality-debt in issue #3395.

## Changes

### HIGH: Config-driven entropy thresholds (line 176)

`scanForLeaks` now accepts an optional `LeakDetectionConfig` parameter instead of relying on module-level hardcoded constants `MIN_ENTROPY_TOKEN_LENGTH` and `ENTROPY_THRESHOLD`. The call site in `index.ts` passes `this.config.leakDetection` so runtime configuration is respected.

### HIGH: Correct high-entropy token index via RegExp.exec() loop (line 235)

Replaced the `text.split()` + `text.indexOf(token)` approach with a `RegExp.exec()` loop. This gives the correct `index` for every occurrence (not just the first), and the overlap check now uses index ranges (`index >= m.index && index < m.index + m.matchedText.length`) instead of `matchedText === token` equality, correctly suppressing high-entropy sub-tokens of already-matched patterns.

### MEDIUM: aws_secret_key requires contextual keyword (line 78)

The bare `[0-9a-zA-Z/+]{40}` pattern was too broad (matched Git SHAs, etc.). Now requires a contextual keyword (`aws_secret_access_key`, `aws_secret`, `secret_access_key`, `secret`, `key`) before the 40-char value, consistent with how `generic_api_key` works.

### MEDIUM: bearer_token captures only the token value (line 119)

Pattern changed from `/\b(Bearer\s+[A-Za-z0-9_\-/.+]{20,})\b/g` to `/\bBearer\s+([A-Za-z0-9_\-/.+=]{20,})\b/gi` — the capture group now excludes the `Bearer ` prefix (consistent with `generic_api_key` and `password_in_url`), and the `i` flag makes it case-insensitive.

## Tests

- 10 new tests added covering all 4 findings
- All 58 tests pass (48 original + 10 new), 0 fail
- No new TypeScript errors in modified files

Closes #3395