### PR TITLE
t3661: fix printf format specifiers in _log_to_file (skill-update-helper.sh)

### DIFF
--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -57,7 +57,7 @@ _log_to_file() {
 	local timestamp
 	timestamp="$(date '+%Y-%m-%d %H:%M:%S')"
 	mkdir -p "$(dirname "$SKILL_LOG_FILE")" 2>/dev/null || true
-	printf '%s\n' "[$timestamp] [skill-update] [$level] $*" >>"$SKILL_LOG_FILE"
+	printf "[%s] [skill-update] [%s] %s\n" "$timestamp" "$level" "$*" >>"$SKILL_LOG_FILE"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Replaces `printf '%s\n' "...interpolated $*..."` with `printf "[%s] [skill-update] [%s] %s\n" "$timestamp" "$level" "$*"` in `_log_to_file()`
- Each variable is now a separate `printf` argument with `$*` properly quoted, preventing word splitting from altering message spacing
- Eliminates the theoretical risk of a log message starting with a hyphen being misinterpreted as a `printf` format option

## Changes

**`.agents/scripts/skill-update-helper.sh:60`** — one-line fix in `_log_to_file()`

## Verification

- ShellCheck: zero violations (`shellcheck -x -S warning`)
- Syntax: `bash -n .agents/scripts/skill-update-helper.sh` passes

Closes #3661
Ref #1630 (gemini-code-assist review comment at discussion_r2820026274)