### PR TITLE
t3546: fix smtp command in email-test-suite.md workflow

### DIFF
--- a/.agents/scripts/commands/email-test-suite.md
+++ b/.agents/scripts/commands/email-test-suite.md
@@ -36,7 +36,7 @@ Parse `$ARGUMENTS` to determine what to test:
 **For SMTP testing:**
 
 ```bash
-~/.aidevops/agents/scripts/email-test-suite-helper.sh test-smtp-domain "$ARGUMENTS"
+~/.aidevops/agents/scripts/email-test-suite-helper.sh smtp "$ARGUMENTS"
 ```
 
 ### Step 3: Present Results


### PR DESCRIPTION
## Summary

- Corrects `test-smtp-domain` → `smtp` in the SMTP testing workflow section of `.agents/scripts/commands/email-test-suite.md:39`
- `test-smtp-domain` only accepts a domain; the Options table shows `/email-test-suite smtp mail.example.com 587` (host + port), which maps to the `smtp` command in the helper's dispatcher
- Eliminates the inconsistency flagged by Gemini in PR #923 review

## Change

**Before:** `email-test-suite-helper.sh test-smtp-domain "$ARGUMENTS"`
**After:** `email-test-suite-helper.sh smtp "$ARGUMENTS"`

The helper script's dispatcher (line 1275) maps `"test-smtp" | "smtp"` → `test_smtp()` (accepts server + port) and `"test-smtp-domain" | "smtp-domain"` → `test_smtp_domain()` (accepts domain only). The workflow section was using the domain-only variant, contradicting the Options table.

## Verification

- Markdown lint: no issues
- Single-line change, no logic affected — documentation-only fix

Closes #3546