### PR TITLE
t3592: fix batch conversion examples in document-creation.md

### DIFF
--- a/.agents/tools/document/document-creation.md
+++ b/.agents/tools/document/document-creation.md
@@ -425,9 +425,9 @@ document-creation-helper.sh convert report.md --to pdf --engine xelatex
 document-creation-helper.sh convert letter.odt --to pdf --tool libreoffice
 document-creation-helper.sh convert complex.pdf --to md --tool mineru
 
-# Batch conversion
-document-creation-helper.sh convert ./documents/*.docx --to pdf
-document-creation-helper.sh convert ./reports/*.md --to odt
+# Batch conversion (use a for loop — the script processes one file at a time)
+for f in ./documents/*.docx; do document-creation-helper.sh convert "$f" --to pdf; done
+for f in ./reports/*.md; do document-creation-helper.sh convert "$f" --to odt; done
 
 # Force a specific tool
 document-creation-helper.sh convert file.odt --to pdf --tool pandoc


### PR DESCRIPTION
## Summary

- Replace misleading glob-expansion batch conversion examples with correct `for` loop patterns
- The `document-creation-helper.sh` script processes one file at a time; passing `*.docx` via shell glob silently discards all files after the first
- Adds an inline comment explaining the constraint so future readers understand why the loop is necessary

## Changes

- `.agents/tools/document/document-creation.md:428-430` — batch conversion examples now use `for f in ./*.ext; do ... done` pattern

## Testing

Documentation-only change. Verified the corrected examples are syntactically valid bash and match the suggested fix from the Gemini review.

Closes #3592
Ref: PR #1405 review comment by gemini-code-assist