### PR TITLE
t3539: fix remaining blanket 2>/dev/null suppressions in pagespeed-helper.sh

### DIFF
--- a/.agents/scripts/pagespeed-helper.sh
+++ b/.agents/scripts/pagespeed-helper.sh
@@ -155,7 +155,7 @@ parse_pagespeed_report() {
 	print_header "Optimization Opportunities"
 
 	local opportunities
-	opportunities=$(jq -r '.lighthouseResult.audits | to_entries[] | select(.value.details.overallSavingsMs > 0) | "\(.key): \(.value.title) - Potential savings: \(.value.details.overallSavingsMs)ms"' "$report_file" 2>/dev/null || echo "No specific opportunities found")
+	opportunities=$(jq -r '.lighthouseResult.audits | to_entries[] | select(.value.details.overallSavingsMs > 0) | "\(.key): \(.value.title) - Potential savings: \(.value.details.overallSavingsMs)ms"' "$report_file" || echo "No specific opportunities found")
 
 	if [[ "$opportunities" != "No specific opportunities found" ]]; then
 		echo "$opportunities" | head -10
@@ -177,7 +177,7 @@ format_score() {
 
 	# Convert to percentage
 	local percentage
-	percentage=$(echo "$score * 100" | bc -l 2>/dev/null || echo "0")
+	percentage=$(echo "$score * 100" | bc -l || echo "0")
 	local int_percentage
 	int_percentage=${percentage%.*}
 
@@ -444,7 +444,7 @@ generate_actionable_report() {
                     elif .value.details.overallSavingsMs > 500 then "MEDIUM"
                     else "LOW" end)
         }
-    ' "$report_file" 2>/dev/null)
+    ' "$report_file")
 
 	if [[ -n "$recommendations" ]]; then
 		echo "$recommendations" | jq -r '"🔧 \(.title) (\(.impact) IMPACT)\n   💡 \(.description)\n   ⏱️  Potential savings: \(.savings)ms\n"'


### PR DESCRIPTION
## Summary

- Removes 3 remaining `2>/dev/null` blanket error suppressions from `pagespeed-helper.sh` that violate the repository style guide
- The `|| fallback` guards already handle failure cases gracefully; stderr suppression only hides useful debugging information
- Completes the quality-debt cleanup started in PR #936 (commit `bbd1151a` fixed the accessibility functions; this fixes the remaining 3 in other functions)

## Changes

| Location | Fix |
|----------|-----|
| `parse_lighthouse_json()` line 158 — jq opportunities query | Removed `2>/dev/null`; `\|\| echo "No specific opportunities found"` handles failure |
| `format_score()` line 180 — `bc -l` call | Removed `2>/dev/null`; `\|\| echo "0"` handles failure |
| `generate_actionable_report()` line 447 — jq recommendations query | Removed `2>/dev/null`; jq errors now surface visibly (correct — malformed report should fail loudly) |

## Verification

- `shellcheck` passes (SC1091 info notice is pre-existing, suppressed by directive)
- Zero `2>/dev/null` occurrences remain in the file

Closes #3539