### PR TITLE
fix(docs): add server-side password validator to better-auth.md examples

### DIFF
--- a/.agents/tools/api/better-auth.md
+++ b/.agents/tools/api/better-auth.md
@@ -45,12 +45,26 @@ for (const envVar of requiredEnvVars) {
   }
 }
 
+// Server-side password validation — enforced on every signUp.email() call.
+// Client-side checks (e.g. Zod passwordSchema) are UX only; this is the
+// security boundary. Callers that bypass the client still hit this validator.
+const validatePassword = (password: string) => {
+  if (password.length < 8) return false;
+  if (!/[A-Z]/.test(password)) return false;
+  if (!/[a-z]/.test(password)) return false;
+  if (!/[0-9]/.test(password)) return false;
+  return true;
+};
+
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "pg",
   }),
   emailAndPassword: {
     enabled: true,
+    password: {
+      validate: validatePassword,
+    },
   },
   socialProviders: {
     google: {
@@ -142,10 +156,11 @@ import { signIn } from "@workspace/auth/client/react";
 import { signUp } from "@workspace/auth/client/react";
 import { z } from "zod";
 
-// Client-side password validation (UX only — server must also enforce)
-// IMPORTANT: This is not a security boundary. Callers can bypass the client
-// and hit signUp.email() directly. Your server-side auth handler must
-// revalidate password strength before creating accounts.
+// Client-side password validation — UX only, NOT a security boundary.
+// Callers can bypass this and call signUp.email() directly.
+// The server enforces the same rules via emailAndPassword.password.validate
+// in packages/auth/src/server.ts — signUp.email() returns an error if the
+// password fails server-side validation, regardless of client-side checks.
 const passwordSchema = z.string()
   .min(8, "Password must be at least 8 characters")
   .regex(/[A-Z]/, "Must contain an uppercase letter")
@@ -153,14 +168,15 @@ const passwordSchema = z.string()
   .regex(/[0-9]/, "Must contain a number");
 
 const handleSignUp = async (data: { email: string; password: string; name: string }) => {
+  // Early UX feedback — mirrors the server-side validatePassword function.
   const passwordCheck = passwordSchema.safeParse(data.password);
   if (!passwordCheck.success) {
     console.error("Weak password:", passwordCheck.error.flatten().formErrors);
     return;
   }
 
-  // Server-side: better-auth validates password in signUp.email() handler.
-  // Configure server-side password rules in your auth config (e.g., password.minLength).
+  // Server enforces password strength via emailAndPassword.password.validate.
+  // If validation fails server-side, result.error is set and no account is created.
   const result = await signUp.email({
     email: data.email,
     password: data.password,
@@ -168,7 +184,9 @@ const handleSignUp = async (data: { email: string; password: string; name: strin
   });
 
   if (result.error) {
-    console.error(result.error);
+    // Handles both server-side password validation failures and other errors
+    // (e.g., duplicate email). result.error.message contains the reason.
+    console.error("Sign-up failed:", result.error.message);
     return;
   }
 


### PR DESCRIPTION
## Summary

Addresses the medium-priority CodeRabbit finding from PR #3506 review (tracked in issue #3580): the `better-auth.md` sign-up example presented client-side password validation as if it were the security boundary, without showing the matching server-side enforcement.

## Changes

- **Server setup example**: Added `validatePassword` function wired into `emailAndPassword.password.validate` — this is the actual security boundary that enforces password rules on every `signUp.email()` call, including direct API calls that bypass the client
- **Client sign-up example**: Updated comments to explicitly reference the server-side validator and clarify that `signUp.email()` returns `result.error` on server-side validation failure regardless of client-side checks
- **Error handling**: Improved `result.error` handling to use `result.error.message` for clearer error reporting

## Security rationale

The previous example only had comments warning about the client-side limitation. The fix shows the actual server-side enforcement mechanism (`emailAndPassword.password.validate`) so developers implementing this pattern have a complete, working security model — not just a warning to "add server-side validation somehow".

Closes #3580