### PR TITLE
t3639: fix remaining PR #1948 review feedback in worktrunk.md and worktree-helper.sh

### DIFF
--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -144,7 +144,8 @@ localdev_auto_branch_rm() {
 
 	echo ""
 	echo -e "${BLUE}Localdev integration: removing branch route for $project/$branch...${NC}"
-	"$LOCALDEV_HELPER" branch rm "$project" "$branch" 2>&1 || true
+	"$LOCALDEV_HELPER" branch rm "$project" "$branch" 2>&1 ||
+		echo -e "${YELLOW}Localdev branch route removal failed (non-fatal)${NC}"
 	return 0
 }
 

--- a/.agents/tools/git/worktrunk.md
+++ b/.agents/tools/git/worktrunk.md
@@ -211,11 +211,11 @@ When creating a worktree for a project registered with `localdev add`, `worktree
 
 1. Detects the project name from the repo path
 2. Runs `localdev branch <project> <branch>` to create a subdomain route
-3. Outputs the branch-specific URL (e.g., `https://feature-xyz.myapp.local`)
+3. Outputs the branch-specific URL (e.g., `http://feature-xyz.myapp.local` — `https://` if mkcert/local CA is configured)
 
 When removing a worktree, the corresponding branch route is auto-cleaned.
 
-This works with both `worktree-helper.sh` and Worktrunk's `post-create` hook:
+Route creation works with both `worktree-helper.sh` (auto-detected) and Worktrunk's `post-create` hook (see below). **Route removal is only automatic when using `worktree-helper.sh`**; Worktrunk users should add a `pre-remove` hook for cleanup.
 
 ```bash
 # .worktrunk/hooks/post-create — add to your project repo
@@ -225,6 +225,16 @@ project="$(basename "$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)
 # Adjust LOCALDEV_HELPER if aidevops is installed to a custom path
 LOCALDEV_HELPER="${AIDEVOPS_HOME:-$HOME/.aidevops}/agents/scripts/localdev-helper.sh"
 "$LOCALDEV_HELPER" branch "$project" "$branch" 2>/dev/null || true
+```
+
+```bash
+# .worktrunk/hooks/pre-remove — add to your project repo
+#!/bin/bash
+branch="$(git branch --show-current)"
+project="$(basename "$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)")"
+# Adjust LOCALDEV_HELPER if aidevops is installed to a custom path
+LOCALDEV_HELPER="${AIDEVOPS_HOME:-$HOME/.aidevops}/agents/scripts/localdev-helper.sh"
+"$LOCALDEV_HELPER" branch rm "$project" "$branch" 2>/dev/null || true
 ```
 
 ### Session Naming


### PR DESCRIPTION
## Summary

Addresses the remaining unactioned review feedback from PR #1948 that was tracked as quality-debt in issue #3639.

**Changes:**

- **`worktree-helper.sh`**: `localdev_auto_branch_rm` now emits a non-fatal yellow warning on helper failure, matching the observability parity of `localdev_auto_branch` (which already had this). Previously `|| true` silently swallowed failures.

- **`worktrunk.md`**: Fixed example URL scheme from `https://` to `http://` with a note that `https://` requires mkcert/local CA configuration — avoids misleading users who haven't set up TLS locally.

- **`worktrunk.md`**: Added `pre-remove` hook snippet so Worktrunk users get route cleanup on `wt remove`. Previously only `post-create` was documented, leaving stale routes when using Worktrunk without `worktree-helper.sh`.

- **`worktrunk.md`**: Clarified that auto-removal only applies when using `worktree-helper.sh`; Worktrunk users need the `pre-remove` hook explicitly.

## Verification

- `shellcheck`: no new violations (SC1091 info pre-existing, not caused by this change)
- `markdownlint-cli2`: 0 errors

Closes #3639