### PR TITLE
t3546: fix SMTP command in email-test-suite.md workflow

### DIFF
--- a/.agents/scripts/commands/email-test-suite.md
+++ b/.agents/scripts/commands/email-test-suite.md
@@ -36,7 +36,7 @@ Parse `$ARGUMENTS` to determine what to test:
 **For SMTP testing:**
 
 ```bash
-~/.aidevops/agents/scripts/email-test-suite-helper.sh test-smtp-domain "$ARGUMENTS"
+~/.aidevops/agents/scripts/email-test-suite-helper.sh smtp "$ARGUMENTS"
 ```
 
 ### Step 3: Present Results


### PR DESCRIPTION
## Summary

- Corrects the SMTP testing workflow block in `.agents/scripts/commands/email-test-suite.md` (line 39)
- Replaces `test-smtp-domain` (domain-only, uses MX discovery) with `smtp` (server+port, direct connectivity test)
- Aligns the workflow doc with the Options table (`/email-test-suite smtp mail.example.com 587`) and the helper script dispatcher (`"smtp"` → `test_smtp()`)

## Root Cause

The `test-smtp-domain` command only accepts a domain and performs MX record discovery. The SMTP testing section in the workflow is for direct SMTP connectivity tests (server + port), which maps to the `smtp` command alias in the helper script. Using `test-smtp-domain` here would fail when passed `mail.example.com 587` as arguments.

## Verification

- Helper script (`email-test-suite-helper.sh:1275`): `"test-smtp" | "smtp")` → `test_smtp "$arg1" "$arg2"` ✓
- Options table (line 69): `/email-test-suite smtp mail.example.com 587` ✓
- Workflow block now consistent with both ✓

Closes #3546