### PR TITLE
fix(t3767): preserve self-heal diagnostics and harden stale_diags SQL

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2485,16 +2485,18 @@ cmd_pulse() {
 
 	# Phase 4c: Cancel stale diagnostic subtasks whose parent is already resolved
 	# Diagnostic tasks (diagnostic_of != NULL) become stale when the parent task
-	# reaches a terminal state (deployed, cancelled, failed) before the diagnostic
-	# is dispatched. Cancel them to free queue slots.
+	# reaches a truly terminal state before the diagnostic is dispatched.
+	# 'failed' is intentionally excluded: diagnostics exist to self-heal failed
+	# tasks, so cancelling them when the parent is 'failed' would break self-heal.
+	# Cancel them to free queue slots only when the parent is definitively done.
 	local stale_diags
-	stale_diags=$(db "$SUPERVISOR_DB" "
+	stale_diags=$(db -separator '|' "$SUPERVISOR_DB" "
         SELECT d.id, d.diagnostic_of, p.status AS parent_status
         FROM tasks d
         JOIN tasks p ON d.diagnostic_of = p.id
         WHERE d.diagnostic_of IS NOT NULL
           AND d.status IN ('queued', 'retrying')
-          AND p.status IN ('deployed', 'cancelled', 'failed', 'complete', 'merged');
+          AND p.status IN ('deployed', 'cancelled', 'complete', 'merged');
     " 2>/dev/null || echo "")
 
 	if [[ -n "$stale_diags" ]]; then


### PR DESCRIPTION
## Summary

- Removes `'failed'` from the Phase 4c `stale_diags` terminal states `IN` list so diagnostic subtasks for failed parents are **not** cancelled, preserving the self-heal flow (`failed` → diagnostic → re-queue)
- Adds `-separator '|'` to the `stale_diags` `db()` invocation to force a deterministic field separator regardless of `~/.sqliterc` settings, matching the established pattern used throughout `pulse.sh`

## Problem

From PR #678 CodeRabbit review (issue #3767):

1. **Logic bug**: `'failed'` was included in the terminal states that trigger diagnostic cancellation. Diagnostics exist specifically to self-heal failed tasks — cancelling them when the parent is `failed` breaks the self-heal cycle.
2. **Brittle parsing**: The `db()` call populating `stale_diags` did not pass `-separator '|'`, so the `while IFS='|' read -r diag_id parent_id parent_status` loop could silently misparse fields if `~/.sqliterc` overrides the default separator.

## Changes

- `.agents/scripts/supervisor-archived/pulse.sh`: Phase 4c block — remove `'failed'` from IN list, add `-separator '|'` to `db()` call

## Testing

- Bash syntax check: `bash -n pulse.sh` → OK
- Pattern consistency: `-separator '|'` is used in 13+ other `db()` calls in the same file that feed `IFS='|'` read loops

Closes #3767