### PR TITLE
t3766: fix(setup): use resolved python3_bin for dspy venv creation

### DIFF
--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1030,7 +1030,7 @@ setup_python_env() {
 		if [[ -d "python-env/dspy-env" ]] && [[ ! -f "python-env/dspy-env/bin/activate" ]]; then
 			rm -rf python-env/dspy-env
 		fi
-		if python3 -m venv python-env/dspy-env; then
+		if "$python3_bin" -m venv python-env/dspy-env; then
 			print_success "Python virtual environment created"
 		else
 			print_warning "Failed to create Python virtual environment - DSPy setup skipped"


### PR DESCRIPTION
## Summary

- Fixes inconsistency in `setup-modules/tool-install.sh` where `setup_python_env()` called `find_python3()` to resolve the best Python 3 binary into `$python3_bin`, but then used bare `python3` (from `$PATH`) when creating the dspy venv
- On systems where `python3` in `$PATH` differs from the resolved interpreter (e.g. Homebrew `/opt/homebrew/bin/python3` or pyenv shims), the venv could be created with the wrong interpreter
- One-line fix: `python3 -m venv` → `"$python3_bin" -m venv` at line 1033

## Change

```diff
-        if python3 -m venv python-env/dspy-env; then
+        if "$python3_bin" -m venv python-env/dspy-env; then
```

## Verification

- ShellCheck: zero violations on `setup-modules/tool-install.sh`
- `$python3_bin` is already used consistently for all other invocations in `setup_python_env()` (version check, version string extraction)

Closes #3766