### PR TITLE
t4275: fix(email-test-suite): use empty-string sentinel for expiry_epoch parse failure

### DIFF
--- a/.agents/scripts/email-test-suite-helper.sh
+++ b/.agents/scripts/email-test-suite-helper.sh
@@ -1020,7 +1020,9 @@ test_mail_tls() {
 	not_after=$(echo "$dates" | grep 'notAfter' | cut -d= -f2 || true)
 	if [[ -n "$not_after" ]]; then
 		local expiry_epoch
-		expiry_epoch=$(date -j -f "%b %d %H:%M:%S %Y %Z" "$not_after" "+%s" 2>/dev/null || date -d "$not_after" "+%s" 2>/dev/null)
+		# Use empty string as the error sentinel — "0" is a valid epoch (1970-01-01 UTC)
+		# and would be misidentified as a parse failure if used as a sentinel value.
+		expiry_epoch=$(date -j -f "%b %d %H:%M:%S %Y %Z" "$not_after" "+%s" 2>/dev/null || date -d "$not_after" "+%s" 2>/dev/null || true)
 		if [[ -z "$expiry_epoch" ]]; then
 			print_warning "Unable to parse certificate expiry date: $not_after"
 		else


### PR DESCRIPTION
Closes #4275

## Summary
- Fixes expiry_epoch parse failure handling in email-test-suite-helper.sh per Gemini review feedback from PR #4214
- Uses empty-string sentinel instead of silent failure

## Changes
- `.agents/scripts/email-test-suite-helper.sh`: handle expiry_epoch parse failure with empty-string sentinel