### PR TITLE
t3763: perf(db): consolidate multiple SQLite queries into single calls

### DIFF
--- a/.agents/scripts/mail-helper.sh
+++ b/.agents/scripts/mail-helper.sh
@@ -1259,15 +1259,23 @@ cmd_status() {
 		local escaped_id
 		escaped_id=$(sql_escape "$agent_id")
 		local inbox_count unread_count
-		inbox_count=$(db "$MAIL_DB" "SELECT count(*) FROM messages WHERE to_agent='$escaped_id' AND status != 'archived';")
-		unread_count=$(db "$MAIL_DB" "SELECT count(*) FROM messages WHERE to_agent='$escaped_id' AND status = 'unread';")
+		IFS='|' read -r inbox_count unread_count < <(db -separator '|' "$MAIL_DB" "
+            SELECT
+                COALESCE(SUM(CASE WHEN status != 'archived' THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN status = 'unread' THEN 1 ELSE 0 END), 0)
+            FROM messages WHERE to_agent='$escaped_id';
+        ")
 		echo "Agent: $agent_id"
 		echo "  Inbox: $inbox_count messages ($unread_count unread)"
 	else
 		local total_unread total_read total_archived total_agents
-		total_unread=$(db "$MAIL_DB" "SELECT count(*) FROM messages WHERE status = 'unread';")
-		total_read=$(db "$MAIL_DB" "SELECT count(*) FROM messages WHERE status = 'read';")
-		total_archived=$(db "$MAIL_DB" "SELECT count(*) FROM messages WHERE status = 'archived';")
+		IFS='|' read -r total_unread total_read total_archived < <(db -separator '|' "$MAIL_DB" "
+            SELECT
+                COALESCE(SUM(CASE WHEN status = 'unread' THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN status = 'read' THEN 1 ELSE 0 END), 0),
+                COALESCE(SUM(CASE WHEN status = 'archived' THEN 1 ELSE 0 END), 0)
+            FROM messages;
+        ")
 		total_agents=$(db "$MAIL_DB" "SELECT count(*) FROM agents WHERE status = 'active';")
 
 		local total_inbox=$((total_unread + total_read))

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2527,19 +2527,17 @@ cmd_pulse() {
 	# Phase 5: Summary
 	local total_running
 	total_running=$(cmd_running_count "${batch_id:-}")
-	local total_queued
-	total_queued=$(db "$SUPERVISOR_DB" "SELECT count(*) FROM tasks WHERE status = 'queued';")
-	local total_complete
-	total_complete=$(db "$SUPERVISOR_DB" "SELECT count(*) FROM tasks WHERE status IN ('complete', 'deployed', 'verified');")
-	local total_pr_review
-	total_pr_review=$(db "$SUPERVISOR_DB" "SELECT count(*) FROM tasks WHERE status IN ('pr_review', 'review_triage', 'merging', 'merged', 'deploying');")
-	local total_verifying
-	total_verifying=$(db "$SUPERVISOR_DB" "SELECT count(*) FROM tasks WHERE status IN ('verifying', 'verify_failed');")
-
-	local total_failed
-	total_failed=$(db "$SUPERVISOR_DB" "SELECT count(*) FROM tasks WHERE status IN ('failed', 'blocked');")
-	local total_tasks
-	total_tasks=$(db "$SUPERVISOR_DB" "SELECT count(*) FROM tasks;")
+	local total_queued total_complete total_pr_review total_verifying total_failed total_tasks
+	IFS='|' read -r total_queued total_complete total_pr_review total_verifying total_failed total_tasks < <(db -separator '|' "$SUPERVISOR_DB" "
+        SELECT
+            COALESCE(SUM(CASE WHEN status = 'queued' THEN 1 ELSE 0 END), 0),
+            COALESCE(SUM(CASE WHEN status IN ('complete', 'deployed', 'verified') THEN 1 ELSE 0 END), 0),
+            COALESCE(SUM(CASE WHEN status IN ('pr_review', 'review_triage', 'merging', 'merged', 'deploying') THEN 1 ELSE 0 END), 0),
+            COALESCE(SUM(CASE WHEN status IN ('verifying', 'verify_failed') THEN 1 ELSE 0 END), 0),
+            COALESCE(SUM(CASE WHEN status IN ('failed', 'blocked') THEN 1 ELSE 0 END), 0),
+            COUNT(*)
+        FROM tasks;
+    ")
 
 	# System resource snapshot (t135.15.3)
 	local resource_output


### PR DESCRIPTION
## Summary

Addresses Gemini code review feedback from PR #433 — consolidates multiple separate `sqlite3` invocations into single queries using `SUM(CASE ...)` expressions.

## Changes

### `.agents/scripts/mail-helper.sh`

- **Lines 1261-1267**: `inbox_count` + `unread_count` combined from 2 queries → 1 query using `IFS='|' read -r` pattern
- **Lines 1271-1279**: `total_unread` + `total_read` + `total_archived` combined from 3 queries → 1 query (4 db calls → 2 db calls total in the status function)

### `.agents/scripts/supervisor-archived/pulse.sh`

- **Lines 2530-2540**: `total_queued`, `total_complete`, `total_pr_review`, `total_verifying`, `total_failed`, `total_tasks` combined from 5 separate queries → 1 query with `SUM(CASE ...)` expressions (5 db calls → 1 db call)

## Performance Impact

Reduces `sqlite3` process invocations by 7 per status check cycle. Uses `IFS='|' read -r` pattern already established in the codebase (consistent with lines 1104, 1114, 1123, etc.).

## Verification

- ShellCheck on `mail-helper.sh`: only pre-existing SC1091 info (external source file), no new violations
- Logic preserved: all variable values and downstream usage unchanged

Closes #3763