### PR TITLE
t3747: fix(agents): clarify version check instructions for OpenCode agents

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -39,12 +39,12 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 ## aidevops Framework Status
 
 **On interactive conversation start** (skip this section entirely for headless/command sessions like `/pulse`, `/full-loop`, etc.):
-1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive`
-2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash)
+1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive` — the output is either a plain version string (e.g., `v2.50.0`) or `UPDATE_AVAILABLE|current|latest`. Parse the version from the first `|`-delimited field if present, otherwise use the full output as the version.
+2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash). If that file does not exist, read `~/.aidevops/agents/VERSION` for the version. If neither exists, use `unknown` as the version.
 3. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message
 
-If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter."
+If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." This check does not apply when falling back to reading the cache or VERSION file (step 2).
 
 ## Pre-Edit Git Check
 

--- a/templates/opencode-config-agents.md
+++ b/templates/opencode-config-agents.md
@@ -3,12 +3,12 @@
 ## aidevops Framework Status
 
 **On conversation start**:
-1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive`
-2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash)
-3. Parse the first line of output (format: `aidevops v{version} running in {app} v{app_version} | {repo}`). Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version} in {app} v{app_version}.\n\nWhat would you like to work on?"
+1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive` — the output is either a status line (format: `aidevops v{version} running in {app} v{app_version} | {repo}`) or `UPDATE_AVAILABLE|current|latest|AppName`. Parse `{version}` from the output accordingly.
+2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash). If that file does not exist, read `~/.aidevops/agents/VERSION` for the version. If neither exists, use `unknown` as the version.
+3. Greet with: "Hi!\n\nWe're running https://aidevops.sh v{version} in {app} v{app_version}.\n\nWhat would you like to work on?"
 4. Then respond to the user's actual message
 
-If update check output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest|AppName`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter."
+If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest|AppName`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." This check does not apply when falling back to reading the cache or VERSION file (step 2).
 
 ## Pre-Edit Git Check
 


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #223 (Gemini Code Assist + Augment Code):

- **Gemini (medium)**: The `UPDATE_AVAILABLE|` check instruction was ambiguous — it could be read as applying even when the agent fell back to reading the cache file (step 2), where no update check was run. Now explicitly scoped to step 1 (Bash script path only).
- **Augment**: `{version}` in the greeting was undefined for the Bash-tool case — `aidevocs-update-check.sh` outputs a status line, not a raw version. Now documents the output format and how to parse the version from it.
- **Augment**: No fallback when `~/.aidevops/cache/session-greeting.txt` doesn't exist (e.g., fresh install, no prior Bash-tool session). Now adds fallback chain: `session-greeting.txt` → `~/.aidevops/agents/VERSION` → `unknown`.

Files changed:
- `.agents/scripts/generate-opencode-agents.sh` — the heredoc that generates `~/.config/opencode/AGENTS.md`
- `templates/opencode-config-agents.md` — the template source for the same content

Closes #3747