### PR TITLE
t1480: fix pulse sessions overlapping — run wrapper from repo path (GH#4513)

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -39,7 +39,10 @@
 #   where launchd fires between rm -f and the next write, which caused the
 #   82-concurrent-pulse incident (2026-03-13T02:06:01Z, issue #4318).
 #
-# Called by launchd every 120s via the supervisor-pulse plist.
+# Called by cron (Linux) or launchd (macOS) every 120s.
+# GH#4513: The cron/launchd entry now runs this script directly from the
+# repo (not the deployed copy at ~/.aidevops/agents/scripts/), so fixes
+# are effective immediately after merge without needing setup.sh.
 
 set -euo pipefail
 

--- a/setup.sh
+++ b/setup.sh
@@ -857,11 +857,19 @@ main() {
 	#   - Consent persisted: written to config.jsonc so it survives updates
 	#   - Never silently re-enabled: if config says false, skip entirely
 	#   - Non-interactive: only installs if config explicitly says true
-	local wrapper_script="$HOME/.aidevops/agents/scripts/pulse-wrapper.sh"
+	#
 	local pulse_label="com.aidevops.aidevops-supervisor-pulse"
 	local _aidevops_dir _pulse_repo_dir
 	_aidevops_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 	_pulse_repo_dir=$(_resolve_main_worktree_dir "$_aidevops_dir")
+	# GH#4513: Use the repo version of pulse-wrapper.sh directly instead of
+	# the deployed copy at ~/.aidevops/agents/scripts/. The canonical repo
+	# directory is always on main (worktree-first workflow), so the repo
+	# version is always the latest merged code. This eliminates the
+	# deployment gap where fixes are merged but not deployed until the next
+	# setup.sh run — which caused 6 concurrent pulse sessions (GH#4513)
+	# because the flock guard (GH#4409) was merged but not deployed.
+	local wrapper_script="${_pulse_repo_dir}/.agents/scripts/pulse-wrapper.sh"
 
 	# Read explicit user consent from config.jsonc (not merged defaults).
 	# Empty = user never configured this; "true"/"false" = explicit choice.
@@ -930,9 +938,9 @@ main() {
 		fi
 	fi
 
-	# Guard: wrapper must exist
+	# Guard: wrapper must exist in the repo
 	if [[ "$_do_install" == "true" && ! -f "$wrapper_script" ]]; then
-		# Wrapper not deployed yet — skip (will install on next run after rsync)
+		# Wrapper not found in repo — skip (repo may be in a broken state)
 		_do_install=false
 	fi
 


### PR DESCRIPTION
## Summary

- **Root cause**: The cron entry ran the deployed `~/.aidevops/agents/scripts/pulse-wrapper.sh` instead of the repo version. Fixes merged to main (like the flock guard from GH#4409/t1478) were not effective until the next `setup.sh` run, creating a deployment gap that allowed 6 concurrent pulse sessions.
- **Fix**: Change `wrapper_script` in `setup.sh` to point to `${_pulse_repo_dir}/.agents/scripts/pulse-wrapper.sh` (the repo version). Since the canonical repo directory is always on `main` per the worktree-first workflow, this ensures fixes are immediately effective after merge.
- **After merge**: Run `./setup.sh` once to update the cron entry to use the new repo path. Future fixes will be effective immediately without needing `setup.sh`.

## Changes

| File | Change |
|------|--------|
| `setup.sh` | Changed `wrapper_script` from deployed path to repo path; updated guard comment |
| `.agents/scripts/pulse-wrapper.sh` | Updated header comment to reflect new invocation path |

## Verification

- `shellcheck setup.sh` — zero violations
- `shellcheck .agents/scripts/pulse-wrapper.sh` — zero violations
- The cron entry will now reference the repo version, ensuring the flock guard (GH#4409) and all future fixes are immediately effective

Closes #4513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pulse wrapper configuration to execute directly from the repository, enabling immediate deployment of fixes after merge without requiring setup.sh re-execution.
  * Updated documentation clarifying that the pulse wrapper is invoked by cron (Linux) or launchd (macOS) every 120 seconds, now running from the repo source directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->