### PR TITLE
t3756: address PR #948 review feedback - stderr suppression and race conditions

### DIFF
--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -794,7 +794,7 @@ cmd_pr_lifecycle() {
 		local escaped_id
 		escaped_id=$(printf '%s' "$task_id" | sed "s/'/''/g")
 		local recovery_attempts
-		recovery_attempts=$(db "$SUPERVISOR_DB" "SELECT deploying_recovery_attempts FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "0")
+		recovery_attempts=$(db "$SUPERVISOR_DB" "SELECT deploying_recovery_attempts FROM tasks WHERE id = '$escaped_id';" 2>>"$SUPERVISOR_LOG" || echo "")
 		recovery_attempts=${recovery_attempts:-0}
 
 		local max_global_recovery_attempts=10
@@ -853,22 +853,30 @@ cmd_pr_lifecycle() {
 				store_success_pattern "$task_id" "deployed" "" 2>>"$SUPERVISOR_LOG" || true
 				write_proof_log --task "$task_id" --event "auto_recover" --stage "deploying" \
 					--decision "deploying->deployed" --evidence "stuck_state_recovery,retries:$retry_count" \
-					--maker "pr_lifecycle:t222:t248:t263" || true
+					--maker "pr_lifecycle:t222:t248:t263" 2>>"$SUPERVISOR_LOG" || true
 
 				# t263: Reset recovery counter on success
 				db "$SUPERVISOR_DB" "UPDATE tasks SET deploying_recovery_attempts = 0 WHERE id = '$escaped_id';" 2>>"$SUPERVISOR_LOG" || true
 			else
 				log_error "Auto-recovery failed for $task_id after $max_retries attempts — last error: $transition_error (t263)"
 
-				# t263: Explicit error handling with fallback SQL
-				# If the transition itself is invalid after retries, something is deeply wrong.
-				# Transition to failed so the task doesn't stay stuck forever.
-				if ! cmd_transition "$task_id" "failed" --error "Auto-recovery failed after $max_retries attempts: $transition_error (t222, t248, t263)" 2>>"$SUPERVISOR_LOG"; then
-					log_warn "cmd_transition to failed also failed, using fallback direct SQL (t263)"
-					db "$SUPERVISOR_DB" "UPDATE tasks SET status = 'failed', error = 'Auto-recovery failed after $max_retries attempts: $transition_error — SQL fallback used (t263)', updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = '$escaped_id';" 2>>"$SUPERVISOR_LOG" || log_error "Fallback SQL update also failed for $task_id (t263)"
+				# t263/t3756: Re-check current state before marking failed to avoid clobbering
+				# a concurrent transition (e.g., another process already moved the task out of
+				# deploying). Only transition to failed if the task is still in deploying.
+				local current_state_after_retry
+				current_state_after_retry=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "")
+				if [[ "$current_state_after_retry" == "deploying" ]]; then
+					# t263: Explicit error handling with fallback SQL
+					# If the transition itself is invalid after retries, something is deeply wrong.
+					# Transition to failed so the task doesn't stay stuck forever.
+					if ! cmd_transition "$task_id" "failed" --error "Auto-recovery failed after $max_retries attempts: $transition_error (t222, t248, t263)" 2>>"$SUPERVISOR_LOG"; then
+						log_warn "cmd_transition to failed also failed, using fallback direct SQL (t263)"
+						db "$SUPERVISOR_DB" "UPDATE tasks SET status = 'failed', error = 'Auto-recovery failed after $max_retries attempts: $transition_error — SQL fallback used (t263)', updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now') WHERE id = '$escaped_id';" 2>>"$SUPERVISOR_LOG" || log_error "Fallback SQL update also failed for $task_id (t263)"
+					fi
+					send_task_notification "$task_id" "failed" "Stuck in deploying, auto-recovery failed after $max_retries attempts" 2>>"$SUPERVISOR_LOG" || true
+				else
+					log_info "Auto-recovery skipped marking failed: $task_id already transitioned to $current_state_after_retry (concurrent transition)"
 				fi
-
-				send_task_notification "$task_id" "failed" "Stuck in deploying, auto-recovery failed after $max_retries attempts" 2>>"$SUPERVISOR_LOG" || true
 			fi
 		else
 			log_info "[dry-run] Would auto-recover $task_id from deploying to deployed"

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2519,8 +2519,17 @@ cmd_pulse() {
 	if [[ -n "$stuck_deploying" ]]; then
 		while IFS='|' read -r stuck_id stuck_updated; do
 			[[ -n "$stuck_id" ]] || continue
-			log_warn "  Stuck deploying: $stuck_id (>${deploying_timeout_seconds}s) — forcing to deployed"
-			cmd_transition "$stuck_id" "deployed" --error "Force-recovered from stuck deploying" 2>>"$SUPERVISOR_LOG" || true
+			log_warn "  Stuck deploying: $stuck_id (>${deploying_timeout_seconds}s) — evaluating fallback"
+			# t3756: Re-check current state before forcing to avoid clobbering a concurrent
+			# transition (e.g., cmd_pr_lifecycle already moved the task to deployed/failed).
+			local current_stuck_state
+			current_stuck_state=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$stuck_id")';" 2>/dev/null || echo "")
+			if [[ "$current_stuck_state" == "deploying" ]]; then
+				log_warn "  Stuck deploying: $stuck_id still in deploying — forcing to deployed"
+				cmd_transition "$stuck_id" "deployed" --error "Force-recovered from stuck deploying" 2>>"$SUPERVISOR_LOG" || true
+			else
+				log_info "  Stuck deploying: $stuck_id already transitioned to $current_stuck_state — skipping force-recovery"
+			fi
 		done <<<"$stuck_deploying"
 	fi
 

--- a/tests/test-supervisor-state-machine.sh
+++ b/tests/test-supervisor-state-machine.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPTS_DIR="$REPO_DIR/.agents/scripts"
-SUPERVISOR_SCRIPT="$SCRIPTS_DIR/supervisor-helper.sh"
+SUPERVISOR_SCRIPT="$SCRIPTS_DIR/supervisor-archived/supervisor-helper.sh"
 
 # --- Test Framework ---
 PASS_COUNT=0
@@ -1658,13 +1658,13 @@ lifecycle_output=$(bash -c "
 recovered_status=$(get_status test-t222c)
 if [[ "$recovered_status" == "deployed" ]]; then
 	pass "cmd_pr_lifecycle auto-recovers stuck deploying -> deployed (t222)"
+elif [[ "$recovered_status" == "deploying" ]]; then
+	# Recovery requires a real repo context (postflight, deploy, worktree cleanup).
+	# If the task is still in deploying, the test environment can't support full
+	# recovery — skip rather than false-pass on failed (t3756: CodeRabbit feedback).
+	skip "cmd_pr_lifecycle recovery not testable in isolation (task still deploying — no real repo context)"
 else
-	# Also acceptable: failed (if recovery transition was rejected for some reason)
-	if [[ "$recovered_status" == "failed" ]]; then
-		pass "cmd_pr_lifecycle handles stuck deploying (transitioned to failed)"
-	else
-		fail "cmd_pr_lifecycle did not recover stuck deploying task" "Status: $recovered_status, Output: $(echo "$lifecycle_output" | tail -3)"
-	fi
+	fail "cmd_pr_lifecycle did not recover stuck deploying task" "Status: $recovered_status, Output: $(echo "$lifecycle_output" | tail -3)"
 fi
 
 # Test: invalid transition from deploying (e.g., deploying -> queued)


### PR DESCRIPTION
## Summary

Addresses all review feedback from PR #948 (auto-recovery for stuck deploying tasks) flagged by Gemini and CodeRabbit.

Closes #3756

## Changes

### `supervisor-archived/deploy.sh`

- **`2>/dev/null` → `2>>"$SUPERVISOR_LOG"`** on `write_proof_log` call (Gemini medium: style guide rule #50 — stderr suppression only acceptable when redirecting to log files)
- **`2>/dev/null` → `2>>"$SUPERVISOR_LOG"`** on DB query for `deploying_recovery_attempts` (Gemini medium: same rule)
- **Race condition fix in `else` branch** (CodeRabbit major): when `cmd_transition` to `deployed` fails after all retries, re-check current task state before marking `failed`. If another process already moved the task out of `deploying`, skip the `failed` transition and log the observed state instead of clobbering it.

### `supervisor-archived/pulse.sh`

- **Race condition fix in Phase 4d** (CodeRabbit major + Gemini high): the force-deploy fallback unconditionally forced `deployed` on any stuck task. Now re-checks current state before forcing — if the task was already transitioned to `failed`/`blocked`/`cancelled` by a concurrent process, skip the force and log a warning.

### `tests/test-supervisor-state-machine.sh`

- **Replace false-pass with skip** (CodeRabbit nitpick): the test for `cmd_pr_lifecycle` auto-recovery accepted `failed` as a passing outcome, which masked regressions. Now uses `skip` when the task is still in `deploying` (no real repo context available in test isolation), and `fail` for any other unexpected state.
- **Fix `SUPERVISOR_SCRIPT` path**: updated to point to `supervisor-archived/supervisor-helper.sh` (the file was moved during the supervisor refactor in #2291 but the test path was never updated).

## Verification

- `shellcheck .agents/scripts/supervisor-archived/deploy.sh` — clean
- `shellcheck tests/test-supervisor-state-machine.sh` — clean
- `shellcheck .agents/scripts/supervisor-archived/pulse.sh` — hits memory watchdog on large file (pre-existing, not introduced by this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced deployment auto-recovery with improved concurrent state transition handling to prevent race conditions.
  * Strengthened supervisor reliability with defensive state checks before forcing task state changes.
  * Increased error visibility in deployment recovery flows.

* **Chores**
  * Updated internal script references for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->