### PR TITLE
t3379: fix POSIX portability of ttsr_trigger regex in no-hardcoded-secrets rule

### DIFF
--- a/.agents/rules/no-hardcoded-secrets.md
+++ b/.agents/rules/no-hardcoded-secrets.md
@@ -1,6 +1,6 @@
 ---
 id: no-hardcoded-secrets
-ttsr_trigger: (api[_-]?key|password|secret|token)\s*[:=]\s*['"][A-Za-z0-9+/=_-]{16,}
+ttsr_trigger: (api[_-]?key|password|secret|token)[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9+/=_-]{16,}
 severity: error
 repeat_policy: always
 tags: [security]


### PR DESCRIPTION
## Summary

- Replace `\s` ERE escape with POSIX `[[:space:]]` character class in `.agents/rules/no-hardcoded-secrets.md` `ttsr_trigger` regex
- `\s` is a GNU grep extension, not POSIX ERE — it silently fails on macOS BSD grep, meaning the security rule could miss hardcoded secrets on stricter systems
- `[[:space:]]` is portable across all POSIX-compliant ERE implementations (GNU grep, BSD grep, macOS)

## Change

```diff
-ttsr_trigger: (api[_-]?key|password|secret|token)\s*[:=]\s*['"][A-Za-z0-9+/=_-]{16,}
+ttsr_trigger: (api[_-]?key|password|secret|token)[[:space:]]*[:=][[:space:]]*['"][A-Za-z0-9+/=_-]{16,}
```

## Verification

Tested with `grep -E` on Linux (GNU grep) — all cases pass:
- `api_key = "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234"` → MATCH
- `api_key="ABCDEFGHIJKLMNOPQRSTUVWXYZ1234"` → MATCH (no-space variant)
- `password = "my-long-secret-password-value-here"` → MATCH
- `some_other_var = "short"` → NO MATCH (value too short, correct)

Closes #3379