### PR TITLE
t3374: fix(docs): remove tautology 'CLI interface' in VERIFY.md

### DIFF
--- a/VERIFY.md
+++ b/VERIFY.md
@@ -14,7 +14,7 @@ t1200 (IP reputation check agent) was broken into 6 subtasks, all of which merge
 | t1200.2 Keyed providers + SQLite cache + batch mode | #1860 | MERGED |
 | t1200.3 Agent doc + slash command + index updates | #1867 | MERGED |
 | t1200.4 Core IP reputation lookup module | #1871 | MERGED |
-| t1200.5 CLI interface and agent framework integration | #1883 | MERGED |
+| t1200.5 CLI and agent framework integration | #1883 | MERGED |
 | t1200.6 Output formatting, caching layer, rate limit handling | #1911 | MERGED |
 
 **Deliverables verified on main:**


### PR DESCRIPTION
## Summary

- Remove redundant 'CLI interface' tautology — CLI already means Command Line Interface
- 1-line fix in VERIFY.md line 17

Closes #3374