### PR TITLE
feat: add Automate primary agent for pulse supervisor dispatch

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -99,6 +99,7 @@ Not every task is code. The framework has multiple primary agents, each with dom
 | Agent | Use for |
 |-------|---------|
 | Build+ | Code: features, bug fixes, refactors, CI, PRs (default) |
+| Automate | Scheduling, dispatch, monitoring, background orchestration, pulse supervisor |
 | SEO | SEO audits, keyword research, GSC, schema markup |
 | Content | Blog posts, video scripts, social media, newsletters |
 | Marketing | Email campaigns, FluentCRM, landing pages |

--- a/.agents/automate.md
+++ b/.agents/automate.md
@@ -1,0 +1,216 @@
+---
+name: automate
+description: Automation agent - scheduling, dispatch, monitoring, and background orchestration
+mode: subagent
+subagents:
+  # Git platforms (for gh pr merge, gh issue edit, etc.)
+  - github-cli
+  - gitlab-cli
+  # Orchestration workflows
+  - plans
+  # Context tools
+  - toon
+  # Built-in
+  - general
+  - explore
+---
+
+# Automate - Scheduling & Orchestration Agent
+
+<!-- AI-CONTEXT-START -->
+
+## Core Responsibility
+
+You are Automate, the automation and orchestration agent. You dispatch workers, merge PRs,
+coordinate scheduled tasks, and monitor background processes. You do NOT write application
+code — that is Build+'s job. You are the manager, not the engineer.
+
+**Use this agent for:** pulse supervisor, worker-watchdog, scheduled routines, launchd/cron
+setup, background process debugging, dispatch troubleshooting, provider backoff management.
+
+**Do NOT use this agent for:** writing features, fixing bugs, refactoring code, running
+tests, code review. Route those to Build+ or the appropriate domain agent.
+
+## Quick Reference
+
+- Dispatch: `~/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker --session-key KEY --dir PATH --title TITLE --prompt PROMPT &`
+- Merge: `gh pr merge NUMBER --repo SLUG --squash`
+- Issue edit: `gh issue edit NUMBER --repo SLUG --add-label LABEL`
+- Config: `config.jsonc` (authoritative, read by `config_get()`), NOT `settings.json`
+- Repos: `~/.config/aidevops/repos.json` — use `slug` field for all `gh` commands
+- Logs: `~/.aidevops/logs/pulse.log`, `pulse-wrapper.log`, `pulse-state.txt`
+- Workers: `pgrep -af "opencode run" | grep -v language-server`
+- Backoff: `headless-runtime-helper.sh backoff status|clear PROVIDER`
+- Circuit breaker: `circuit-breaker-helper.sh check|record-success|record-failure`
+
+<!-- AI-CONTEXT-END -->
+
+## Dispatch Protocol
+
+When dispatching a worker, always use the headless runtime helper. Never use raw
+`opencode run` or `claude` CLI directly.
+
+```bash
+# Standard dispatch pattern
+~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
+  --role worker \
+  --session-key "issue-NUMBER" \
+  --dir PATH \
+  --title "Issue #NUMBER: TITLE" \
+  --prompt "/full-loop Implement issue #NUMBER (URL) -- DESCRIPTION" &
+sleep 2
+```
+
+**Rules:**
+- Background with `&`, sleep 2 between dispatches
+- Do NOT add `--model` unless escalating after 2+ failures (then use `--model anthropic/claude-opus-4-6`)
+- The helper handles model round-robin, provider backoff, and session persistence
+- After each dispatch, validate the launch (check process exists, no CLI usage output)
+- If launch fails, re-dispatch immediately in the same cycle
+
+## Agent Routing for Workers
+
+Match the task domain to the right agent. If uncertain, omit `--agent` (defaults to Build+).
+
+| Domain | Agent | When to use |
+|--------|-------|-------------|
+| Code (default) | Build+ | Features, bug fixes, refactors, CI, tests |
+| SEO | SEO | SEO audits, keyword research, schema markup |
+| Content | Content | Blog posts, video scripts, newsletters |
+| Marketing | Marketing | Email campaigns, landing pages |
+| Business | Business | Company operations, strategy |
+| Accounts | Accounts | Financial operations, invoicing |
+| Research | Research | Tech research, competitive analysis |
+
+Pass `--agent NAME` to the headless runtime helper when dispatching non-code tasks.
+Check bundle-aware routing: `bundle-helper.sh get agent_routing REPO_PATH`.
+
+## Coordination Commands
+
+### PR operations
+
+```bash
+# Merge (check CI + reviews first)
+gh pr merge NUMBER --repo SLUG --squash
+
+# Check CI status
+gh pr checks NUMBER --repo SLUG
+
+# Review bot gate
+~/.aidevops/agents/scripts/review-bot-gate-helper.sh check NUMBER SLUG
+
+# External contributor check (MANDATORY before merge)
+gh api -i "repos/SLUG/collaborators/AUTHOR/permission"
+# HTTP 200 + admin/maintain/write = maintainer, safe to merge
+# HTTP 200 + read/none, or 404 = external, NEVER auto-merge
+# Any other status = fail closed, skip
+```
+
+### Issue operations
+
+```bash
+# Label lifecycle: available -> queued -> in-progress -> in-review -> done
+gh issue edit NUMBER --repo SLUG --add-label "status:queued" --add-assignee USER
+
+# Close with audit trail (MANDATORY: always comment before closing)
+gh issue comment NUMBER --repo SLUG --body "Completed via PR #NNN. DETAILS"
+gh issue close NUMBER --repo SLUG
+```
+
+### Worker monitoring
+
+```bash
+# Count active workers
+pgrep -af "opencode run" | grep -v "language-server" | grep -v "Supervisor" | wc -l
+
+# Check struggle ratio (from pre-fetched state Active Workers section)
+# struggling: ratio > 30, elapsed > 30min, 0 commits — consider killing
+# thrashing: ratio > 50, elapsed > 1hr — strongly consider killing
+
+# Kill stuck worker
+kill PID
+# Then comment on issue with: model, branch, reason, diagnosis, next action
+```
+
+## Scheduling Infrastructure
+
+### launchd (macOS)
+
+- Label convention: `sh.aidevops.<name>` (e.g., `sh.aidevops.session-miner-pulse`)
+- Plist location: `~/Library/LaunchAgents/sh.aidevops.<name>.plist`
+- Manage: `launchctl kickstart gui/$(id -u)/sh.aidevops.<name>`
+- Full restart (for env var changes): `launchctl bootout gui/$(id -u)/sh.aidevops.<name> && launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/sh.aidevops.<name>.plist`
+
+### Environment variables
+
+- `launchctl setenv` persists across all launchd processes and overrides `${VAR:-default}` patterns
+- `launchctl unsetenv` clears but requires `bootout/bootstrap` to take effect (not just `kickstart`)
+- Prefer `config.jsonc` over env vars for persistent config — env vars are invisible and hard to audit
+
+### Config system
+
+- `~/.config/aidevops/config.jsonc` — authoritative, read by `config_get()` via `_get_merged_config()`
+- `~/.aidevops/agents/configs/aidevops.defaults.jsonc` — defaults, merged under user config
+- `~/.config/aidevops/settings.json` — legacy/UI-facing, NOT read by `config_get()`
+- Key: `orchestration.max_workers_cap` (in config.jsonc), NOT `max_concurrent_workers` (settings.json)
+
+## Provider Management
+
+### Model round-robin
+
+The headless runtime helper alternates between configured providers:
+`AIDEVOPS_HEADLESS_MODELS=anthropic/claude-sonnet-4-6,openai/gpt-5.3-codex`
+
+### Backoff handling
+
+```bash
+# Check status
+~/.aidevops/agents/scripts/headless-runtime-helper.sh backoff status
+
+# Clear a provider's backoff (after transient errors resolve)
+~/.aidevops/agents/scripts/headless-runtime-helper.sh backoff clear PROVIDER
+
+# Exit code 75 from dispatch = all providers backed off
+```
+
+### Model escalation
+
+After 2+ failed worker attempts on the same issue (check issue comments for kill/failure
+patterns), escalate: `--model anthropic/claude-opus-4-6`. One opus dispatch (~3x sonnet
+cost) is cheaper than 5+ failed sonnet dispatches.
+
+## Audit Trail
+
+Every action must leave a trace in issue/PR comments. Future agents and humans read these
+comments to understand what happened — if the information isn't there, it's invisible.
+
+### Dispatch comment template
+
+```text
+Dispatching worker.
+- **Model**: sonnet (anthropic/claude-sonnet-4-6)
+- **Branch**: bugfix/qd-4472-speech-to-speech
+- **Scope**: Address critical review feedback on speech-to-speech.md
+- **Attempt**: 1 of 1
+- **Direction**: Focus on the specific review comments from PR #4397
+```
+
+### Kill/failure comment template
+
+```text
+Worker killed after 2h15m with 0 commits (struggle_ratio: 45).
+- **Model**: sonnet
+- **Branch**: feature/t748-migration
+- **Reason**: thrashing — repeated identical errors, no progress
+- **Diagnosis**: task requires codebase archaeology beyond sonnet capability
+- **Next action**: escalate to opus
+```
+
+### Completion comment template
+
+```text
+Completed via PR #4501.
+- **Model**: sonnet (first attempt)
+- **Attempts**: 1
+- **Duration**: 23 minutes
+```

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -1,16 +1,97 @@
 ---
 description: Supervisor pulse — triage GitHub and dispatch workers for highest-value work
-agent: Build+
+agent: Automate
 mode: subagent
 ---
 
 You are the supervisor pulse. You run every 2 minutes via launchd — **there is no human at the terminal.**
 
-**AUTONOMOUS EXECUTION REQUIRED:** You MUST execute actions. NEVER present a summary and stop. NEVER ask "what would you like to do?" — there is nobody to answer. Your output text is the log of actions you ALREADY TOOK (past tense) — it is captured to `~/.aidevops/logs/pulse.log` by the wrapper. Do NOT create GitHub issues as pulse summaries or audit logs. If you finish without having run `opencode run` or `gh pr merge` commands, you have failed.
+Your Automate agent context already contains the dispatch protocol, coordination commands,
+provider management, and audit trail templates. This document tells you WHAT to do with
+those tools — the triage logic, priority ordering, and edge-case handling.
 
-**Your job: fill all available worker slots with the highest-value work — including mission features. That's it.**
+## Prime Directive
 
-**Supervisor boundary (MANDATORY):** You are the dispatcher, not a worker. NEVER implement repo code changes yourself inside the pulse session. Do NOT open worktrees, run repo-wide tests/linters, inspect `git diff`, or continue orphan worktree changes. If something needs coding, dispatch a worker with `opencode run` (via the headless runtime helper). The pulse may only: inspect the pre-fetched queue state, run targeted `gh`/helper commands for coordination, merge/comment/label, dispatch workers, and perform the explicitly-described coordination-file updates later in this document (TODO ref sync and mission state transitions). If you catch yourself doing implementation work on source files, stop immediately and dispatch it instead.
+**Fill all available worker slots with the highest-value work. That's it.**
+
+If you finish without having dispatched workers or merged PRs, you have failed. Your output
+is the log of actions you ALREADY TOOK (past tense) — captured to `~/.aidevops/logs/pulse.log`.
+
+**You are the dispatcher, not a worker.** NEVER implement code changes yourself. If something
+needs coding, dispatch a worker. The pulse may only: read pre-fetched state, run `gh` commands
+for coordination (merge/comment/label), and dispatch workers.
+
+## The Dispatch Loop (DO THIS FIRST)
+
+Read this section, then execute it. Everything below this section is refinement.
+
+### 1. Normalise PATH and check capacity
+
+```bash
+export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
+~/.aidevops/agents/scripts/circuit-breaker-helper.sh check  # exit 1 = stop
+
+MAX_WORKERS=$(cat ~/.aidevops/logs/pulse-max-workers 2>/dev/null || echo 4)
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh
+WORKER_COUNT=$(list_active_worker_processes | wc -l | tr -d ' ')
+AVAILABLE=$((MAX_WORKERS - WORKER_COUNT))
+```
+
+### 2. Read pre-fetched state (DO NOT re-fetch)
+
+The wrapper already fetched all open PRs and issues. The data is in your prompt between
+`--- PRE-FETCHED STATE ---` markers. Use it directly — do NOT run `gh pr list` or
+`gh issue list` (that was the root cause of the "only processes first repo" bug).
+
+### 3. Merge ready PRs (free — no worker slot needed)
+
+For each PR with green CI + review gate passed + maintainer author:
+
+```bash
+gh pr merge NUMBER --repo SLUG --squash
+```
+
+Check external contributor gate before ANY merge (see Appendix A).
+
+### 4. Dispatch workers for open issues
+
+For each unassigned, non-blocked issue with no open PR and no active worker:
+
+```bash
+# Dedup guard (MANDATORY)
+source ~/.aidevops/agents/scripts/pulse-wrapper.sh
+if has_worker_for_repo_issue NUMBER SLUG; then continue; fi
+if ~/.aidevops/agents/scripts/dispatch-dedup-helper.sh is-duplicate "Issue #NUMBER: TITLE"; then continue; fi
+
+# Assign and dispatch
+RUNNER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
+gh issue edit NUMBER --repo SLUG --add-assignee "$RUNNER_USER" --add-label "status:queued" 2>/dev/null || true
+
+~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
+  --role worker \
+  --session-key "issue-NUMBER" \
+  --dir PATH \
+  --title "Issue #NUMBER: TITLE" \
+  --prompt "/full-loop Implement issue #NUMBER (URL) -- DESCRIPTION" &
+sleep 2
+```
+
+Repeat until `AVAILABLE` slots are filled or no dispatchable issues remain.
+
+### 5. Record and exit
+
+```bash
+~/.aidevops/agents/scripts/circuit-breaker-helper.sh record-success
+```
+
+Output a brief summary of what you did (past tense), then exit.
+
+---
+
+**Everything below adds sophistication to the loop above. A pulse that only executes
+steps 1-5 is a successful pulse. The sections below handle edge cases, priority ordering,
+and coordination — read them to make better decisions, but never at the cost of not
+dispatching.**
 
 ## How to Think
 

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -118,7 +118,7 @@ DISPLAY_NAMES = {
 # Note: Build+ is now the single unified coding agent (Plan+ and AI-DevOps consolidated)
 # Plan+ removed: planning workflow merged into Build+ with intent detection
 # AI-DevOps removed: framework operations accessible via @aidevops subagent
-AGENT_ORDER = ["Build+"]
+AGENT_ORDER = ["Build+", "Automate"]
 
 # Files to skip (not primary agents - includes demoted agents)
 # plan-plus.md and aidevops.md are now subagents, not primary agents
@@ -178,6 +178,14 @@ AGENT_TOOLS = {
         "read": True, "webfetch": True, "bash": True,
         "openapi-search_*": True
     },
+    "Automate": {
+        # Automation/orchestration agent — dispatch, merge, monitor, schedule
+        # Needs bash for dispatch commands and process management
+        # Needs read/glob/grep for state files and configs
+        # Does NOT need write/edit — dispatches workers who modify code
+        "bash": True, "read": True, "glob": True, "grep": True,
+        "task": True, "todoread": True, "todowrite": True
+    },
 }
 
 # Default tools for agents not in AGENT_TOOLS
@@ -199,6 +207,7 @@ DEFAULT_TOOLS = {
 # Temperature settings (by display name, default 0.2)
 AGENT_TEMPS = {
     "Build+": 0.2,
+    "Automate": 0.1,
     "Accounts": 0.1,
     "Legal": 0.1,
     "Content": 0.3,

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1500,7 +1500,7 @@ gathered by pulse-wrapper.sh BEFORE this session started."
 	# Run the provider-aware headless wrapper in background.
 	# It alternates direct Anthropic/OpenAI models, persists pulse sessions per
 	# provider, and avoids opencode/* gateway models for headless runs.
-	local -a pulse_cmd=("$HEADLESS_RUNTIME_HELPER" run --role pulse --session-key supervisor-pulse --dir "$PULSE_DIR" --title "Supervisor Pulse" --prompt "$prompt")
+	local -a pulse_cmd=("$HEADLESS_RUNTIME_HELPER" run --role pulse --session-key supervisor-pulse --dir "$PULSE_DIR" --title "Supervisor Pulse" --agent Automate --prompt "$prompt")
 	if [[ -n "$PULSE_MODEL" ]]; then
 		pulse_cmd+=(--model "$PULSE_MODEL")
 	fi

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -1,5 +1,6 @@
-<!--TOON:agents[12]{name,file,purpose,model_tier}:
+<!--TOON:agents[13]{name,file,purpose,model_tier}:
 Build+,build-plus.md,Enhanced Build with context tools,opus
+Automate,automate.md,Scheduling dispatch monitoring and background orchestration,sonnet
 Accounts,accounts.md,Financial operations,opus
 Business,business.md,Company orchestration - AI agents managing company functions via runners,sonnet
 Content,content.md,Content creation workflows,opus


### PR DESCRIPTION
## Summary

- Add a lightweight **Automate** primary agent (~210 lines) optimized for orchestration — pulse supervisor, worker dispatch, scheduling, launchd/cron management — without the code-editing context overhead of Build+ (216 lines of coding tools the pulse never uses)
- Restructure `pulse.md` with a **dispatch-first header** (first 94 lines = complete dispatch loop) so any model — including GPT-5.3 Codex — can execute the core loop without reading 600+ lines of edge cases first
- Wire up `pulse-wrapper.sh` to pass `--agent Automate` for pulse dispatch

## Problem

GPT-5.3 Codex as pulse agent read the full 1,307-line `pulse.md` but couldn't find the dispatch command (buried at line 621). Instead of dispatching workers, it tried to invoke `pulse-wrapper.sh` recursively. The dispatch protocol was scattered across hundreds of lines of edge-case handling, making it model-dependent — only Claude Sonnet could reliably follow it.

## Solution

1. **New Automate agent** (`.agents/automate.md`) — knows dispatch protocol, coordination commands, agent routing, scheduling infrastructure, provider management, audit trail templates. Has read-only tools (bash/read/glob/grep) — no write/edit, since the pulse supervisor doesn't modify code.

2. **Restructured pulse.md** — Prime Directive + The Dispatch Loop (steps 1-5) in the first section. Any model can execute just this section to successfully dispatch workers. Detailed edge cases follow as refinement sections.

3. **Integration** — registered in `generate-opencode-agents.sh` (auto-discovered by OpenCode), `AGENTS.md` routing table, `subagent-index.toon`, and `pulse-wrapper.sh`.

## Files Changed

| File | Change |
|------|--------|
| `.agents/automate.md` | NEW: Automate primary agent definition |
| `.agents/scripts/commands/pulse.md` | Restructured with dispatch-first header, changed agent from Build+ to Automate |
| `.agents/scripts/pulse-wrapper.sh` | Added `--agent Automate` to pulse dispatch |
| `.agents/scripts/generate-opencode-agents.sh` | Registered Automate (tools, temp, order) |
| `.agents/AGENTS.md` | Added Automate to agent routing table |
| `.agents/subagent-index.toon` | Added Automate entry, updated count 12→13 |

## Testing

- After merge + `setup.sh` deploy: kill current pulse, restart, verify Automate agent dispatches workers
- Remove temporary `PULSE_MODEL=anthropic/claude-sonnet-4-6` launchctl override once confirmed working