### PR TITLE
t3572: scope MD010 to code_blocks only in .markdownlint.json

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,9 @@
 {
   "default": true,
   "MD001": false,
-  "MD010": false,
+  "MD010": {
+    "code_blocks": false
+  },
   "MD003": {
     "style": "atx"
   },


### PR DESCRIPTION
## Summary

Addresses quality-debt from PR #245 review feedback (Gemini + CodeRabbit nitpick).

- `MD010` was set to `false` (globally disabled), silently allowing hard tabs anywhere in markdown prose
- Scoped to `{ "code_blocks": false }` — tabs permitted inside code fences (needed for TOON format and bash script examples) but enforced absent in markdown prose
- Verified: zero MD010 violations on all existing markdown files with the new config

## Rationale

The original `MD010: false` was added in PR #245 to accommodate TOON format examples (tab-separated) in code blocks. The correct fix is to scope the exception to code blocks only, not disable the rule globally. This preserves the intent while maintaining prose quality.

Closes #3572