### PR TITLE
t3352: address HIGH mysql debug credential exposure in addons reference

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md
@@ -32,7 +32,7 @@ Options:
 
 Default charset: `utf8mb4` / `utf8mb4_unicode_ci`.
 
-Debug: `cloudron exec` then `mysql --user=$CLOUDRON_MYSQL_USERNAME --password=$CLOUDRON_MYSQL_PASSWORD --host=$CLOUDRON_MYSQL_HOST $CLOUDRON_MYSQL_DATABASE`
+Debug: `cloudron exec` then `MYSQL_PWD=$CLOUDRON_MYSQL_PASSWORD mysql --user=$CLOUDRON_MYSQL_USERNAME --host=$CLOUDRON_MYSQL_HOST $CLOUDRON_MYSQL_DATABASE`
 
 ## postgresql
 


### PR DESCRIPTION
## Summary
- Replace the MySQL debug example in `addons-ref.md` to use `MYSQL_PWD` instead of passing the password with `--password`.
- Keep the command functional while preventing credential exposure via process arguments.
- Preserve previously fixed MD040 fenced code language tags and scope this PR to the remaining HIGH feedback item from PR #2651.

## Verification
- `markdown-formatter check .agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md`
- Confirmed no `--password=$CLOUDRON_MYSQL_PASSWORD` pattern remains in the file.

Closes #3352