### PR TITLE
t3562: clarify supervisor unclaim behavior in plans workflow

### DIFF
--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -770,7 +770,7 @@ An "always switch branches for TODO.md" rule fails the 80% universal applicabili
 
 | Actor | Before work | During work | After work |
 |-------|-------------|-------------|------------|
-| **Supervisor** | `claim` before dispatch (auto) | Worker runs | Manual `unclaim` or task completion |
+| **Supervisor** | `claim` before dispatch (auto) | Worker runs | Manual `unclaim` (task completion alone does not auto-unclaim) |
 | **Human** | `claim` or add `assignee:name` manually | Edit code | PR merge, mark `[x]` |
 | **Pre-edit check** | Warns if claimed by another | — | — |
 


### PR DESCRIPTION
## Summary
- Clarifies the `Who claims` table in `.agents/workflows/plans.md` so it no longer implies automatic unclaim on task completion.
- Explicitly states that supervisor unclaiming is manual unless a separate implementation handles it.
- Resolves medium quality-debt feedback from PR #621 review comments.

Closes #3562