### PR TITLE
t3559: remove redundant Homebrew update guidance

### DIFF
--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -1,6 +1,6 @@
 # Homebrew formula for aidevops
-# To install: brew install marcusquinn/tap/aidevops && aidevops update
-# Or: brew tap marcusquinn/tap && brew install aidevops && aidevops update
+# To install: brew install marcusquinn/tap/aidevops
+# Or: brew tap marcusquinn/tap && brew install aidevops
 
 class Aidevops < Formula
   desc "AI DevOps Framework - AI-assisted development workflows and automation"


### PR DESCRIPTION
## Summary
- Remove `&& aidevops update` from Homebrew install comments in `homebrew/aidevops.rb` because formula `post_install` already deploys agents
- Align formula guidance with PR #87 Gemini review feedback to avoid redundant setup step

## Testing
- `ruby -c homebrew/aidevops.rb`

Closes #3559