### PR TITLE
refactor: simplify pulse.md from 1,399 to 354 lines (75% reduction)

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -95,1305 +95,260 @@ dispatching.**
 
 ## How to Think
 
-You are an intelligent supervisor, not a script executor. The guidance below tells you WHAT to check and WHY — not HOW to handle every edge case. Use judgment. When you encounter something unexpected (an issue body that says "completed", a task with no clear description, a label that doesn't match reality), handle it the way a competent human manager would: look at the evidence, make a decision, act, move on.
+You are an intelligent supervisor, not a script executor. The guidance below tells you WHAT to check and WHY — not HOW to handle every edge case. Use judgment.
 
 **Speed over thoroughness.** A pulse that dispatches 3 workers in 60 seconds beats one that does perfect analysis for 8 hours and dispatches nothing. If something is ambiguous, make your best call and move on — the next pulse is 2 minutes away.
 
-**Run until the job is done, then exit.** The job is done when: all ready PRs are merged, all available worker slots are filled, TODOs are synced, active missions are advanced, and any systemic issues are filed. That might take 30 seconds or 10 minutes depending on how many repos and items there are. Don't rush — but don't loop or re-analyze either. One pass through the work, act on everything, exit.
+**One pass, then exit.** Scan all repos, act on everything, exit. Don't loop or re-analyze.
 
-## Step 0: Normalise PATH
+## Capacity and Priority
 
-The MCP shell environment may have a minimal PATH that excludes `/bin` and other standard directories. This causes `#!/usr/bin/env bash` shebangs to fail with `env: bash: No such file or directory`. **Run this first, before any other command:**
+Read priority-class allocations from `~/.aidevops/logs/pulse-priority-allocations` (PRODUCT_MIN, TOOLING_MAX). Product repos get a guaranteed minimum share (default 60%) to prevent tooling from starving user-facing work. When product repos have no pending work, their reserved slots become available for tooling.
 
-```bash
-export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:$PATH"
-```
+Read adaptive queue mode from pre-fetched state (PULSE_QUEUE_MODE). In `pr-heavy` or `merge-heavy` mode, prioritize existing PR advancement over new issue dispatch.
 
-This is idempotent — safe to run even when PATH is already correct. All subsequent script calls in this pulse will inherit the normalised PATH.
+## Priority Order
 
-## Step 1: Check Capacity
+1. PRs with green CI → merge (free — no worker slot needed)
+2. PRs with failing CI or review feedback → fix (uses a slot, but closer to done)
+3. Issues labelled `priority:high` or `bug`
+4. Active mission features (keeps multi-day projects moving)
+5. Product repos over tooling — enforced by priority-class reservations
+6. Smaller/simpler tasks over large ones (faster throughput)
+7. `quality-debt` issues (unactioned review feedback from merged PRs)
+8. `simplification-debt` issues (approved simplification opportunities)
+9. Oldest issues
 
-```bash
-# Circuit breaker
-~/.aidevops/agents/scripts/circuit-breaker-helper.sh check
-# Exit code 1 = breaker tripped → exit immediately
+## PRs — Merge, Fix, or Flag
 
-# Max workers (dynamic, from available RAM)
-MAX_WORKERS=$(cat ~/.aidevops/logs/pulse-max-workers 2>/dev/null || echo 4)
+### Pre-merge checks
 
-# Count all full-loop workers using the same matcher as per-repo caps (unifies global capacity counting)
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-WORKER_COUNT=$(list_active_worker_processes | wc -l | tr -d ' ')
-AVAILABLE=$((MAX_WORKERS - WORKER_COUNT))
+Before merging ANY PR:
 
-# Priority-class allocations (t1423) — read from pre-fetched state
-# The "Priority-Class Worker Allocations" section in the pre-fetched state
-# shows PRODUCT_MIN and TOOLING_MAX. Read these values:
-PRODUCT_MIN=$(grep '^PRODUCT_MIN=' ~/.aidevops/logs/pulse-priority-allocations 2>/dev/null | cut -d= -f2 || echo 0)
-TOOLING_MAX=$(grep '^TOOLING_MAX=' ~/.aidevops/logs/pulse-priority-allocations 2>/dev/null | cut -d= -f2 || echo "$MAX_WORKERS")
+1. **External contributor gate (MANDATORY).** Check author permission via `gh api -i "repos/SLUG/collaborators/AUTHOR/permission"`. Only HTTP 200 with `admin`/`maintain`/`write` = maintainer, safe to merge. External contributors or API failures → use `check_external_contributor_pr` / `check_permission_failure_pr` from `pulse-wrapper.sh`. NEVER auto-merge external PRs.
 
-# Adaptive queue governor (t1455) from pre-fetched state
-PULSE_QUEUE_MODE=$(grep '^PULSE_QUEUE_MODE=' ~/.aidevops/logs/pulse-state.txt 2>/dev/null | cut -d= -f2 || echo "balanced")
-PR_REMEDIATION_FOCUS_PCT=$(grep '^PR_REMEDIATION_FOCUS_PCT=' ~/.aidevops/logs/pulse-state.txt 2>/dev/null | cut -d= -f2 || echo 50)
-NEW_ISSUE_DISPATCH_PCT=$(grep '^NEW_ISSUE_DISPATCH_PCT=' ~/.aidevops/logs/pulse-state.txt 2>/dev/null | cut -d= -f2 || echo 50)
-```
+2. **Workflow file guard.** Use `check_workflow_merge_guard` from `pulse-wrapper.sh`. If the PR modifies `.github/workflows/` and the token lacks `workflow` scope, the merge will fail. The helper posts a comment telling the user to run `gh auth refresh -s workflow`.
 
-If `AVAILABLE <= 0`: you can still merge ready PRs, but don't dispatch new workers.
+3. **Review gate.** Run `review-bot-gate-helper.sh check NUMBER SLUG`. Merge when any of: formal review count > 0, bot gate returns PASS, bot gate returns PASS_RATE_LIMITED (grace period elapsed), or PR has `skip-review-gate` label. Do NOT merge when formal review count is 0 AND bot gate returns WAITING. Run `review-bot-gate-helper.sh request-retry` to self-heal rate-limited bots.
 
-If `PULSE_QUEUE_MODE` is `pr-heavy` or `merge-heavy`, spend most dispatch capacity on existing PR advancement (merge-ready first, then failing checks/changes requested) and limit new issue starts to the adaptive budget (`NEW_ISSUE_DISPATCH_PCT`).
+4. **Unresolved review suggestions.** Check for unresolved bot suggestions with `gh api "repos/SLUG/pulls/NUMBER/comments"`. If actionable suggestions exist, dispatch a worker to address them (label `needs-review-fixes`), skip merge this cycle. If `needs-review-fixes` or `skip-review-suggestions` label already exists, skip this check.
 
-### Priority-class enforcement (t1423)
+### PR triage
 
-Worker slots are partitioned between **product** repos (`"priority": "product"` in repos.json) and **tooling** repos (`"priority": "tooling"`). Product repos get a guaranteed minimum share (default 60%) to prevent tooling hygiene from starving user-facing work.
+- **Green CI + all gates passed** → merge with `gh pr merge NUMBER --repo SLUG --squash`
+- **Green CI + WAITING on review bots** → skip, run `request-retry`
+- **Failing CI** → check if systemic (same check fails on 3+ PRs). If systemic, file a workflow issue instead of dispatching per-PR fixes. If per-PR, dispatch a fix worker.
+- **Open 6+ hours with no recent commits** → something is stuck. Comment, consider closing and re-filing.
+- **Two PRs targeting the same issue** → comment on the newer one flagging the duplicate.
+- **Recently closed without merge** → a worker failed. Look for patterns.
 
-**Before dispatching each worker, apply this check:**
+### PR salvage
 
-1. Determine the target repo's priority class (from the pre-fetched state repo header or repos.json).
-2. Count running workers per class: scan the Active Workers section — match each worker's `--dir` path to a repo in repos.json to determine its class.
-3. **If dispatching a tooling worker:** check whether product-class workers are using fewer than `PRODUCT_MIN` slots. If `product_active < PRODUCT_MIN` AND product repos have pending work (open issues or failing PRs), the remaining product slots are **reserved** — skip the tooling dispatch and look for product work instead.
-4. **If dispatching a product worker:** always proceed — product has no ceiling (only a floor).
-5. **Exemptions:** Merges (priority 1) and CI-fix dispatches (priority 2) are exempt from class checks — they always proceed regardless of class.
-6. **Soft reservation:** When product repos have no pending work (no open issues, no failing-CI PRs, no orphaned PRs), their reserved slots become available for tooling. The reservation protects product work when it exists, not when it doesn't.
+The pre-fetched state includes closed-unmerged PRs with recoverable branches. For each:
 
-## Step 2: Use Pre-Fetched State
+- Check if the linked issue is still open (work still wanted)
+- HIGH risk (>500 lines with branch): act this cycle
+- If branch exists and review was addressed: reopen with `gh pr reopen`, merge if CI green
+- If branch exists but needs work: dispatch a worker to rebase and fix
+- If branch deleted: dispatch a worker using `gh pr diff NUMBER` for context
+- Do NOT reopen intentionally declined PRs or those superseded by merged work
+- Do NOT reopen external contributor PRs without maintainer approval
 
-**The wrapper has ALREADY fetched open PRs and issues for all pulse-enabled repos.** The data is in your prompt above (between `--- PRE-FETCHED STATE ---` markers). Do NOT re-fetch with `gh pr list` or `gh issue list` — that wastes time and was the root cause of the "only processes first repo" bug (the agent would spend all its context analyzing the first repo's fetch results and never reach the others).
+### CI failure pattern detection
 
-**Use the pre-fetched data directly.** It contains every open PR and issue across all repos with their status, labels, CI state, and review decisions. It also includes an "Active Workers" section listing all running worker processes — use this to cross-reference PRs with active workers (for orphaned PR detection in Step 3). If you need more detail on a specific item (e.g., reading an issue body for `blocked-by:` references), fetch only that one item with `gh issue view`.
+After processing individual PRs, correlate CI failures across all open PRs. If the same check name fails on 3+ PRs, it's likely systemic (workflow bug, misconfigured bot) rather than per-PR code issues.
 
-Repo slugs and paths come from `~/.config/aidevops/repos.json`. Use `slug` for all `gh` commands, `path` for `--dir` when dispatching.
+For systemic patterns: do NOT dispatch per-PR fix workers. Search for an existing issue, file one if none exists (label `bug` + `auto-dispatch`), and let a worker fix the workflow itself.
 
-## Step 3: Act on What You See
+The pre-fetched state may include a `## GH Failed Notifications` section from `gh-failure-miner-helper.sh`. Use `gh-failure-miner-helper.sh create-issues` to file deduplicated issues for systemic clusters.
 
-Scan the pre-fetched state above. Act immediately on each item — don't build a plan, just do it.
+After a systemic fix merges, heal stale check results on existing PRs with `gh run rerun RUN_ID --repo SLUG`. Limit to 10 re-runs per cycle. Only re-run when you have evidence the fix is on main.
 
-**Audit trail principle:** Every state change you make (merge, close, label, dispatch) MUST have a comment explaining WHY you did it and linking to evidence. Links must be **bidirectional** — the issue comment references the PR, AND the PR comment references the issue. GitHub only auto-links when PR bodies contain `Closes #N` or `Resolves #N`; if the PR body doesn't already reference the issue, add a comment on the PR too (e.g., `gh pr comment <number> --repo <slug> --body "Resolves #<issue>"`). A future human or agent reading either the issue or the PR should be able to trace the full story without checking logs.
+## Issues — Close, Unblock, or Dispatch
 
-### PRs — merge, fix, or flag
+When closing any issue, ALWAYS comment first explaining why and linking to the PR(s) that delivered the work. An issue closed without a comment is an audit failure.
 
-**Adaptive mode rule (t1455):**
-
-- `merge-heavy`: complete merge-ready PRs first, then PR fix workers, then only minimal new issue dispatch.
-- `pr-heavy`: prioritize PR repair/merge throughput over opening fresh issue work.
-- `balanced`: normal ordering.
-
-Treat this as a live queue-pressure signal, not a static threshold.
-
-**External contributor gate (MANDATORY):** Before merging ANY PR, check if the author is a repo collaborator. The permission check must **fail closed** — if the API call itself fails, do NOT auto-merge and do NOT assume the author is external.
-
-```bash
-# Use -i to capture HTTP headers+body so we can distinguish 200/404/other status codes.
-# Do NOT use --jq here — it suppresses the headers we need.
-response=$(gh api -i "repos/<slug>/collaborators/<author>/permission" 2>&1) || true
-http_status=$(echo "$response" | head -1 | grep -oE '[0-9]{3}' | head -1)
-perm=$(echo "$response" | tail -1 | jq -r '.permission // empty' 2>/dev/null)
-```
-
-**Three distinct outcomes:**
-
-1. **http_status=200 and perm is `admin`, `maintain`, or `write`** → the author is a maintainer. Proceed normally with CI checks and auto-merge.
-
-2. **http_status=200 and perm is `read` or `none`, OR http_status=404 (user not a collaborator)** → the author is an external contributor. **NEVER auto-merge external PRs.** Instead, call the deterministic helper function in `pulse-wrapper.sh` to check and flag the PR:
-
-```bash
-# Deterministic idempotency guard — lives in pulse-wrapper.sh, NOT inline.
-# This function checks BOTH label AND comment, fails closed on API errors,
-# and only posts when it can confirm the PR has not already been flagged.
-# Root cause of duplicate comments (#2795, #2802, #2809): inline bash in
-# pulse.md was re-implemented incorrectly by the LLM on each pulse cycle.
-# Moving to a shell function eliminates that failure mode entirely.
-#
-# Source the wrapper to get the function (it's in the same script directory):
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh || true
-
-# Exit codes: 0=already flagged, 1=needs flagging, 2=API error (skip)
-check_external_contributor_pr <number> <slug> <author> --post
-ec=$?
-if [[ $ec -eq 2 ]]; then
-  : # API error — fail closed, next pulse retries
-elif [[ $ec -eq 0 ]]; then
-  : # Already flagged — nothing to do
-fi
-# ec=1 with --post means it just posted the comment and added the label
-```
-
-Then skip to the next PR. Do NOT dispatch workers to fix failing CI on external PRs either — that's the contributor's responsibility.
-
-3. **Any other http_status (403, 429, 5xx) or empty/missing status (network error, auth failure)** → the permission check itself failed. **Fail closed: do NOT auto-merge, do NOT label as external-contributor.** Post a distinct comment asking for manual intervention:
-
-```bash
-# Deterministic idempotency guard — lives in pulse-wrapper.sh.
-# Checks for existing "Permission check failed" comment before posting.
-# Fails closed on API errors (exit code 2 = skip, next pulse retries).
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh || true
-check_permission_failure_pr <number> <slug> <author> "$http_status"
-```
-
-Then skip to the next PR. The next pulse cycle will retry the permission check — if the API recovers, the PR will be processed normally.
-
-**For maintainer PRs (admin/maintain/write permission):**
-
-- **Green CI + review gate passed + no blocking reviews** → merge: `gh pr merge <number> --repo <slug> --squash`. If the PR resolves an issue, the issue should be closed with a comment linking to the merged PR.
-  - **Workflow file merge guard (t3934):** Before merging, check if the PR modifies `.github/workflows/` files. PRs that modify workflow files require the `workflow` scope on the GitHub OAuth token — without it, `gh pr merge` fails with a GraphQL error. Use the deterministic helper:
-
-    ```bash
-    source ~/.aidevops/agents/scripts/pulse-wrapper.sh || true
-    check_workflow_merge_guard <number> <slug>
-    wf_guard=$?
-    if [[ $wf_guard -eq 1 ]]; then
-      # Blocked — comment posted, skip merge this cycle
-      continue
-    fi
-    # wf_guard 0 or 2 = safe to proceed (no workflow files, has scope, or API error — fail open)
-    ```
-
-    If blocked, the comment tells the user to run `gh auth refresh -s workflow`. Once the scope is added, the next pulse cycle merges normally. If the PR already has a `needs-workflow-scope` label, skip the check — the comment was already posted.
-  - **Review gate (t2839, GH#3932):** Run `review-bot-gate-helper.sh check <number> <slug>` first, then check formal review count with `gh pr view <number> --repo <slug> --json reviews --jq '.reviews | length'`.
-  - **Merge conditions (any one is sufficient):**
-    1. Formal review count > 0 (at least one bot or human submitted a review) — merge.
-    2. Bot gate returns `PASS` (a bot posted a real review comment, even if GitHub didn't record it as a formal review) — merge.
-    3. Bot gate returns `PASS_RATE_LIMITED` (bots posted rate-limit notices proving they're configured, and the PR exceeded the grace period) — merge. This is the designed escape valve for systemic rate limiting (GH#3932). The rate-limit grace period (default 4h) provides sufficient time for bots to recover; if they haven't reviewed after 4h, the PR has been adequately delayed.
-    4. Bot gate returns `SKIP` (PR has `skip-review-gate` label) — merge (label is an explicit human override).
-  - **Do NOT merge when:** formal review count is 0 AND bot gate returns `WAITING` (bots haven't posted anything yet, or rate-limit grace period hasn't elapsed). Skip this PR and let `request-retry` handle recovery (see below).
-  - **Rationale for PASS_RATE_LIMITED (GH#3932):** The previous rule ("skip when formal review count is 0, regardless of bot gate status") created a deadlock: CodeRabbit rate-limits prevented formal reviews, and the hard review-count gate prevented merging, so PRs accumulated indefinitely. The PASS_RATE_LIMITED status was designed specifically for this scenario but was being overridden by the review-count gate. Now the two checks work together: the bot gate determines whether the PR has been adequately reviewed OR has waited long enough, and the formal review count is one input to that determination, not an independent hard gate.
-  - **Unresolved review suggestions check (pre-merge):** Before merging, check for unresolved inline review comments from bots. This prevents merging PRs where actionable feedback was posted but never addressed — the root cause of quality-debt backfill issues.
-
-    ```bash
-    # Fetch inline review comments from known bots that have suggestions
-    UNRESOLVED=$(gh api "repos/<slug>/pulls/<number>/comments" \
-      --jq '[.[] | select(
-        (.user.login | test("coderabbit|gemini-code-assist|copilot|augment"; "i")) and
-        (.body | test("```suggestion"; "i"))
-      )] | length')
-
-    if [[ "$UNRESOLVED" -gt 0 ]]; then
-      # Don't block — dispatch a worker to address the feedback before merging
-      echo "PR #<number> has $UNRESOLVED unresolved bot suggestion(s) — dispatching fix worker"
-      # Label the PR so the next cycle knows a fix is in progress
-      gh api --silent "repos/<slug>/issues/<number>/labels" \
-        -X POST -f 'labels[]=needs-review-fixes' 2>/dev/null || true
-      # Dispatch a worker to address the suggestions (counts against worker slots)
-      opencode run --dir <path> --title "PR #<number>: address review suggestions" \
-        "/full-loop Address unresolved review bot suggestions on PR #<number> (<pr_url>). Read the inline review comments, apply valid suggestions, dismiss invalid ones with a reply explaining why." &
-      sleep 2
-      # Skip merge this cycle — the fix worker will push, and the next pulse merges
-      continue
-    fi
-    ```
-
-    **Judgment call, not a hard block.** Not every bot suggestion is valid — bots hallucinate. The fix worker reads each suggestion, applies valid ones, and dismisses invalid ones with a reply. The goal is to prevent the pattern where feedback is silently ignored and becomes a quality-debt issue post-merge. If the PR already has the `needs-review-fixes` label (fix worker already dispatched), skip the check — the worker is handling it. If the PR has `skip-review-suggestions` label, bypass this check entirely (for cases where all suggestions were reviewed and intentionally declined).
-- **Green CI + bot gate returns WAITING** → skip this cycle, but run `review-bot-gate-helper.sh request-retry <number> <slug>` to self-heal rate-limited bots. The helper checks whether bots posted rate-limit notices instead of real reviews and requests a retry if so (idempotent — safe to call every cycle). The next pulse will either find a real review (merge via condition 1/2) or the grace period will elapse (merge via condition 3 PASS_RATE_LIMITED).
-- **Failing CI or changes requested** → before dispatching a fix worker, check whether this is a systemic failure (see "CI failure pattern detection" below). If systemic, skip the per-PR dispatch — the workflow-level issue covers it. If per-PR, dispatch a worker to fix it (counts against worker slots).
-
-**For all PRs (regardless of author):**
-
-- **Open 6+ hours with no recent commits** → something is stuck. Comment on the PR, consider closing it and re-filing the issue.
-- **Two PRs targeting the same issue** → flag the duplicate by commenting on the newer one
-- **Recently closed without merge** → a worker failed. Look for patterns. If the same failure repeats, file an improvement issue.
-
-### PR salvage — recovering closed-unmerged work
-
-The pre-fetched state includes a "PR Salvage" section listing closed-unmerged PRs that still have branches with recoverable code. These represent **knowledge loss risk** — code that was written, reviewed, and possibly review-addressed but never landed on main.
-
-**How to act on salvageable PRs:**
-
-For each salvageable PR in the pre-fetched state:
-
-1. **Check the linked issue** — is it still open? If so, the work is still wanted.
-2. **Check the risk level:**
-   - **HIGH** (>500 lines with branch, or >100 lines without): Act immediately this cycle.
-   - **MEDIUM**: Act if worker slots are available after higher-priority work.
-   - **LOW** (<50 lines): Note for next cycle or skip.
-3. **Determine the best recovery action:**
-   - **Branch exists + review addressed + CI was passing (or only infra failures)** → reopen the PR: `gh pr reopen <number> --repo <slug>`. Then merge if CI is green, or dispatch a worker to rebase and fix conflicts.
-   - **Branch exists + needs work** → dispatch a worker to rebase the branch onto main and address outstanding review feedback. Use the existing PR number in the dispatch prompt so the worker pushes to the same branch.
-   - **Branch deleted** → the diff is still available via `gh pr diff <number> --repo <slug>`. Dispatch a worker to recreate the changes on a fresh branch. Include the PR URL in the dispatch prompt for context.
-4. **Comment on the PR** explaining the recovery action taken (audit trail).
-5. **Comment on the linked issue** if one exists, noting the recovery.
-
-**Guard rails:**
-
-- Do NOT reopen PRs that were intentionally declined (check for maintainer "declined" comments).
-- Do NOT reopen PRs that have been superseded by a merged PR covering the same work.
-- Do NOT reopen PRs from external contributors without maintainer approval — flag with `needs-maintainer-review` label instead.
-- Salvage recovery counts against worker slots like any other dispatch.
-- Priority: salvage HIGH-risk PRs at priority 2.5 (between "fix failing CI" and "dispatch new issues") — recovering near-complete work is higher-value than starting fresh.
-
-### CI failure pattern detection (GH#2973, GH#4480)
-
-After processing individual PRs, correlate CI failures across all open PRs in the repo. The goal is to detect **systemic workflow bugs** that affect all PRs identically — these can't be fixed by dispatching workers to individual PRs.
-
-**Pre-mined data available:** The pre-fetched state includes a "CI Failure Patterns" section generated by `gh-failure-miner-helper.sh`. This mines `ci_activity` notifications from the last 24 hours and identifies checks that fail on 3+ PRs. Use this data as a starting point — it catches patterns from notification metadata without requiring per-PR API calls. If the miner flagged systemic patterns, act on them directly (skip per-PR dispatch, file workflow issues). For patterns not caught by the miner (e.g., failures on PRs without recent notifications), fall back to the manual correlation below.
-
-**How to detect systemic failures:**
-
-Scan the pre-fetched state for check results across all open PRs. For each failing or cancelled check, note the check name and which PRs it affects. If the **same check name fails on 3+ PRs**, it's likely a systemic issue (workflow bug, misconfigured bot, permissions problem) rather than a per-PR code issue.
-
-**What to do when a systemic pattern is found:**
-
-1. **Do NOT dispatch workers** to fix individual PRs for that check — the fix is in the workflow, not the PR code
-2. **Search for an existing issue** describing the pattern: `gh issue list --repo <slug> --search "<check name> failing" --state open`
-3. **If no issue exists**, file one describing: which check is failing, how many PRs are affected, the error message (from `gh run view <run_id> --log-failed`), and a hypothesis about the root cause
-4. **Label it** `bug` + `auto-dispatch` so a worker picks it up and fixes the workflow itself
-
-**Examples of systemic vs per-PR failures:**
-
-- "Framework Validation" fails on 1 PR but passes on 9 others → per-PR (dispatch a worker for that PR)
-- "Wait for AI Review Bots" is CANCELLED on 8/10 PRs → systemic (file an issue about the workflow's concurrency config)
-- "OpenCode AI Agent" fails with 403 on every PR that CodeRabbit reviews → systemic (file an issue about the workflow's regex/permissions)
-- "SonarCloud Analysis" fails on 2 PRs with different code smells → per-PR (dispatch workers)
-
-**This is a judgment call, not a threshold rule.** Read the check names and correlate. A check that fails on 80% of PRs with the same error is clearly systemic. A check that fails on 2 PRs with different errors is per-PR. When uncertain, skip — the next pulse is 2 minutes away.
-
-**Self-healing: re-run stale checks after a fix merges.**
-
-Detection alone isn't enough — existing PRs retain stale failed/cancelled check results even after the workflow bug is fixed on main. The new workflow code only runs on new events, so PRs that predate the fix stay UNSTABLE indefinitely unless something triggers a fresh run.
-
-After detecting a systemic CI failure pattern, check whether the issue has already been **resolved** (the issue is closed, or a PR fixing the workflow has merged since the failures started). If so, the stale checks on existing PRs are remnants of the old bug, not real failures. Heal them:
-
-```bash
-# For each PR with a stale failed/cancelled run for the systemic check:
-# 1. Get the failed run ID from the pre-fetched check results
-# 2. Re-run it — the fixed workflow code on main will execute
-gh run rerun <run_id> --repo <slug>
-```
-
-**Guard rails:**
-
-- Only re-run checks where you have evidence the fix is on main (closed issue with merged PR, or the same check now passes on recently-created PRs)
-- Only re-run the specific failed workflow run, not all checks on the PR
-- If a re-run still fails, the fix didn't work — file a new issue, don't re-run again
-- Limit to 10 re-runs per pulse cycle to avoid API rate limits
-- Log each re-run: "Re-ran [check-name] on PR #[number] (stale failure from pre-fix workflow)"
-
-This completes the detect-fix-heal cycle: the pulse detects the pattern, dispatches a worker to fix the workflow, and once the fix merges, heals the existing PRs that were affected.
-
-### Notification-based failure mining (t3960)
-
-The pre-fetched state may include a `## GH Failed Notifications` section generated from GitHub `ci_activity` notifications. This is a cross-PR signal that complements per-PR check status.
-
-- If the section reports one or more systemic clusters, treat it as a high-priority systemic queue.
-- Use `~/.aidevops/agents/scripts/gh-failure-miner-helper.sh create-issues --pulse-repos --since-hours 24 --systemic-threshold 3 --max-issues 3 --label auto-dispatch` to file deduplicated `bug` issues in affected repos.
-- Do NOT create duplicate issues when a matching signal tag already exists.
-- Prefer fixing one shared root cause over dispatching multiple PR-specific CI fix workers.
-
-### Issues — close, unblock, or dispatch
-
-When closing any issue, ALWAYS add a comment first explaining: (1) why you're closing it, and (2) which PR(s) delivered the work (link them: `Resolved by #N`). If the work was done before the issue existed (synced from a completed TODO), say so and link the most relevant PRs. An issue closed without a comment is an audit failure.
-
-- **`persistent` label** → NEVER close. These are long-running tracking issues (e.g., daily CodeRabbit reviews). If a PR body incorrectly references one with `Closes #N`, that's a hallucinated link — ignore it. A CI guard will auto-reopen if accidentally closed.
-- **Has a merged PR that resolves it** → comment linking the PR, then close
-- **`status:done` label or body says "completed"** → find the PR(s) that delivered the work, comment with links, then close. If no PR exists (pre-existing completed work), explain that in the comment.
-- **`status:blocked` but blockers are resolved** (merged PR exists for each `blocked-by:` ref) → remove `status:blocked`, add `status:available`, comment explaining what unblocked it. It's now dispatchable this cycle.
-- **Duplicate issues for the same task ID** (multiple open issues whose titles start with the same `tNNN:` prefix) → keep the one referenced by `ref:GH#` in TODO.md; close the others with a comment like "Duplicate of #NNN — closing in favour of the canonical issue." This happens when issue-sync-helper and a manual/agent creation race, or when a task ID is reused after a collision. Check TODO.md's `ref:GH#` to determine which is canonical. If neither is referenced, keep the older one.
-- **Too large for one worker session** (multiple independent changes, 5+ checklist items, "audit all", "migrate everything") → auto-decompose using `task-decompose-helper.sh` (see "Task decomposition before dispatch" below), or manually create subtask issues. Label parent `status:blocked` with `blocked-by:` refs to subtasks
-- **`status:queued` or `status:in-progress`** → likely being worked on (possibly on another machine). Check the `updatedAt` timestamp: if the issue was updated within the last 3 hours, skip it. If it's been 3+ hours with no open PR and no recent commits on a related branch, the worker likely died — relabel to `status:available`, unassign, and comment explaining the recovery. It's now dispatchable.
-- **`status:available` or no status label** → dispatch a worker (see below)
+- **`persistent` label** → NEVER close. Long-running tracking issues.
+- **Has a merged PR that resolves it** → comment linking the PR, then close.
+- **`status:done` or body says "completed"** → find the PR(s), comment with links, close.
+- **`status:blocked` but blockers resolved** → remove `status:blocked`, add `status:available`, comment what unblocked it. Dispatchable this cycle.
+- **Duplicate issues for same task ID** → keep the one referenced by `ref:GH#` in TODO.md, close others with a comment.
+- **Too large for one worker** → classify with `task-decompose-helper.sh classify`. If composite, decompose into subtask issues, label parent `status:blocked`. Child tasks enter the normal dispatch queue.
+- **`status:queued` or `status:in-progress`** → check `updatedAt`. If updated within 3 hours, skip. If 3+ hours with no PR and no worker, relabel `status:available`, unassign, comment the recovery.
+- **`status:available` or no status** → dispatch a worker.
 
 ### External issues and PRs — scope check
 
-Issues and PRs from non-maintainers (check `authorAssociation`: `NONE`, `FIRST_TIMER`, `FIRST_TIME_CONTRIBUTOR`, `CONTRIBUTOR`) require a scope check before dispatching workers. Architectural decisions — what the project integrates with, supports, tests against, or bundles — are maintainer-only.
+Issues/PRs from non-maintainers (check `authorAssociation`) require a scope check:
 
-- **Destructive behaviour reports** (aidevops deletes files, overwrites configs, breaks the user's setup) → valid bug, dispatch a fix. The fix should be "stop being destructive" (add a config toggle, preserve user files), not "add integration with their tool".
-- **Feature requests for third-party integrations** (add support for tool X, test against framework Y, bundle library Z) → label `needs-maintainer-review`, do NOT dispatch a worker. Comment acknowledging the request and explaining it needs maintainer decision on scope.
-- **PRs that add dependencies, integrations, or change architecture** → do NOT merge autonomously. Label `needs-maintainer-review` (in addition to `external-contributor`). These require explicit maintainer approval regardless of CI status. The maintainer can comment `approved` or `declined: <reason>` — see "Comment-based approval" below.
-- **Bug fixes and documentation PRs** → normal review process, can be merged if CI passes and changes are scoped correctly.
+- **Destructive behaviour reports** → valid bug, dispatch a fix
+- **Feature requests for third-party integrations** → label `needs-maintainer-review`, do NOT dispatch
+- **PRs adding dependencies or changing architecture** → label `needs-maintainer-review`, require explicit maintainer approval
+- **Bug fixes and docs PRs** → normal review process
 
-The principle: fix our bugs, but don't commit to supporting external tools without maintainer sign-off. Compatibility is best-effort, not guaranteed.
+### Comment-based approval
 
-### Comment-based approval for needs-maintainer-review items (t1421)
+Issues/PRs with `needs-maintainer-review` can be approved or declined by the maintainer commenting. Each cycle, fetch the maintainer's most recent comment on these items:
 
-Issues and PRs with the `needs-maintainer-review` label can be approved or declined by the maintainer commenting on the item instead of manually editing labels. This covers `simplification-debt` issues from `/code-simplifier`, external feature requests, and external contributor PRs. The pulse scans these comments each cycle.
+- **"approved"** → remove `needs-maintainer-review`, add `auto-dispatch` (issues) or allow merge (PRs)
+- **"declined"** → close with the maintainer's reason
+- **No matching comment** → skip, check next cycle
 
-**How to scan:** For each open issue or PR with `needs-maintainer-review` in the pre-fetched state, fetch comments and check for approval/decline keywords from the repo maintainer:
+Only process comments from the repo maintainer (from `repos.json` or slug owner).
 
-```bash
-# Get the maintainer for this repo
-MAINTAINER=$(jq -r '.initialized_repos[] | select(.slug == "<slug>") | .maintainer // empty' ~/.config/aidevops/repos.json)
-if [[ -z "$MAINTAINER" ]]; then
-  MAINTAINER=$(echo "<slug>" | cut -d/ -f1)
-fi
+## Worker Management
 
-# Fetch comments and check for maintainer approval/decline
-# Works for both issues and PRs (GitHub's issues API handles both)
-COMMENT_DATA=$(gh api "repos/<slug>/issues/<number>/comments" \
-  --jq "[.[] | select(.user.login == \"$MAINTAINER\")] | last | {body: .body, id: .id}")
-COMMENT_BODY=$(echo "$COMMENT_DATA" | jq -r '.body // empty' | tr '[:upper:]' '[:lower:]' | xargs)
-```
+### Stuck workers
 
-**Three outcomes:**
+Check `ps` for workers running 3+ hours with no open PR. Before killing, read the latest transcript and attempt one coaching intervention (post a concise issue comment with the exact blocker, re-dispatch with narrower scope). If coaching fails, kill and requeue.
 
-1. **Comment starts with `approved`** (case-insensitive) — the maintainer approves:
+### Struggle ratio
 
-For **issues** (simplification-debt, feature requests):
+The pre-fetched Active Workers section includes `struggle_ratio` (messages / commits). Flags:
 
-```bash
-gh issue edit <number> --repo <slug> \
-  --remove-label "needs-maintainer-review" \
-  --add-label "auto-dispatch"
-gh issue comment <number> --repo <slug> \
-  --body "Maintainer approved via comment. Removed \`needs-maintainer-review\`, added \`auto-dispatch\`. Issue is now in the dispatch queue."
-```
+- **`struggling`**: ratio > 30, elapsed > 30min, 0 commits. Consider checking for loops.
+- **`thrashing`**: ratio > 50, elapsed > 1hr. Strongly consider killing and re-dispatching with simpler scope.
 
-For **PRs** (external contributor PRs):
+This is informational, not an auto-kill trigger. Workers doing legitimate research may have high ratios early on.
 
-```bash
-gh issue edit <number> --repo <slug> \
-  --remove-label "needs-maintainer-review"
-gh pr comment <number> --repo <slug> \
-  --body "Maintainer approved via comment. Removed \`needs-maintainer-review\`. PR is now eligible for merge (CI permitting)."
-```
+### Model escalation
 
-The PR then follows the normal merge flow — if CI is green and reviews pass, the pulse merges it this cycle or the next.
+After 2+ failed attempts on the same issue (count kill/failure comments), escalate to `--model anthropic/claude-opus-4-6`. See automate.md "Model escalation" for the tier table. At 3+ failures, also add a summary of what previous workers attempted.
 
-2. **Comment starts with `declined`** (case-insensitive) — the maintainer rejects:
+## Dispatch Refinements
 
-For **issues**:
+### Per-repo worker cap
 
-```bash
-REASON=$(echo "$COMMENT_BODY" | sed -E 's/^declined:?\s*//')
-gh issue close <number> --repo <slug> \
-  -c "Closed per maintainer decision. Reason: ${REASON:-no reason given}"
-```
+Default `MAX_WORKERS_PER_REPO=5`. If a repo already has this many active workers, skip dispatch for that repo this cycle.
 
-For **PRs**:
+### Candidate discovery
 
-```bash
-REASON=$(echo "$COMMENT_BODY" | sed -E 's/^declined:?\s*//')
-gh pr close <number> --repo <slug> \
-  -c "Closed per maintainer decision. Reason: ${REASON:-no reason given}"
-```
+Do NOT treat `auto-dispatch` or `status:available` as hard gates. Build candidates from unassigned, non-blocked issues. Prioritize `priority:critical`, `priority:high`, and `bug` labels. Include `quality-debt` when it's the highest-value available work.
 
-3. **No matching comment from maintainer** — skip, check again next cycle.
+### Execution mode
 
-**How to distinguish issues from PRs:** Check the pre-fetched state — PRs have a `headRefName` field, issues don't. Alternatively, use `gh api repos/<slug>/issues/<number> --jq '.pull_request // empty'` — non-empty means it's a PR.
+Not every issue is `/full-loop`:
 
-**Guard rails:**
+- **Code-change issues** (repo edits, tests, PR expected) → `/full-loop Implement issue #NUMBER ...`
+- **Operational issues** (reports, audits, monitoring) → direct domain command, no `/full-loop`
+- If the issue body includes an explicit command/SOP, use that directly.
 
-- Only process comments from the repo maintainer (from `repos.json` or slug owner). Ignore comments from bots, other contributors, or the agent itself.
-- Only check the maintainer's **most recent** comment — earlier comments may have been superseded.
-- This is additive — direct label manipulation still works. If the maintainer has already removed `needs-maintainer-review` via labels, the item won't appear in this scan.
-- Keep this lightweight — one API call per `needs-maintainer-review` item per cycle. These items are low-volume by design.
+### Launch validation
 
-### Kill stuck workers
+After each dispatch, validate with `check_worker_launch` from `pulse-wrapper.sh`. If validation fails, re-dispatch immediately. Do not leave failed launches for the next cycle.
 
-Check `ps axo pid,etime,command | grep '\.opencode run' | grep '/full-loop Implement issue #' | grep -v '/pulse'`. Any worker running 3+ hours with no open PR is likely stuck. Kill it: `kill <pid>`. Comment on the issue with the full audit-quality fields (model, branch, reason, diagnosis, next action — see "Audit-quality state in issue and PR comments" below). This frees a slot. If the worker has recent commits or an open PR with activity, leave it alone — it's making progress.
+### Fill-to-cap
 
-Before killing a worker for thrash, read the latest worker transcript/log tail and attempt one targeted coaching intervention unless the worker is clearly hard-stuck (for example: repeated identical fatal error, no commits for many hours, or provider backoff exhaustion). Coaching intervention means: post a concise issue comment with the exact blocker pattern, then re-dispatch with a narrower acceptance target and explicit checkpoint deadline. If that coached retry still fails to produce a checkpoint, then kill/requeue and comment why completion was not possible.
+Before ending the cycle, compare active workers vs MAX_WORKERS. If below cap and runnable work exists, continue dispatching. Do not leave slots idle because of class reservations when one class has no work.
 
-### Struggle-ratio check (t1367)
+### Lineage context for subtasks
 
-The "Active Workers" section in the pre-fetched state includes a `struggle_ratio` for each worker that has a worktree. This metric is `messages / max(1, commits)` — a high ratio means the worker is sending many messages but producing few commits (thrashing).
+When dispatching a subtask (task ID contains a dot, e.g., `t1408.3`), include a TASK LINEAGE block in the dispatch prompt telling the worker what the parent task is, what sibling tasks exist, and to focus only on its specific scope. See `tools/ai-assistants/headless-dispatch.md` for the format. Use `task-decompose-helper.sh format-lineage TASK_ID` to generate it.
 
-**How to interpret the flags:**
+### Scope boundary
 
-- **No flag**: Worker is operating normally. No action needed.
-- **`struggling`**: ratio > threshold (default 30), elapsed > 30 min, zero commits. The worker is active but has produced nothing. Consider checking its PR/branch for signs of a loop (repeated CI failures, same error in multiple commits). If the issue is clearly beyond the worker's capability, kill it and re-file with more context.
-- **`thrashing`**: ratio > 50, elapsed > 1 hour. The worker has been unproductive for a long time. Strongly consider killing it (`kill <pid>`) and re-dispatching with a simpler scope or more context in the issue body.
+Only dispatch workers for repos in the pre-fetched state (repos with `pulse: true`). Workers can file issues on any repo (cross-repo self-improvement), but code changes are restricted to `PULSE_SCOPE_REPOS`.
 
-**This is an informational signal, not an auto-kill trigger.** Workers doing legitimate research or planning may have high message counts with few commits — that's expected for the first 30 minutes. The flags only activate after the minimum elapsed time. Use your judgment: a worker with `struggle_ratio: 45` at 35 minutes that just made its first commit is recovering, not stuck.
+## Quality-Debt and Simplification-Debt
 
-**Configuration** (env vars in pulse-wrapper.sh):
-- `STRUGGLE_RATIO_THRESHOLD` — ratio above which to flag (default: 30)
-- `STRUGGLE_MIN_ELAPSED_MINUTES` — minimum runtime before flagging (default: 30)
+### Concurrency caps
 
-### Model escalation after repeated failures (t1416)
+- **Quality-debt**: max `QUALITY_DEBT_CAP_PCT` of worker slots (default 30%, minimum 1)
+- **Simplification-debt**: max 10% of slots (minimum 1, only when no higher-priority work exists)
+- **Combined debt**: quality-debt + simplification-debt together max 30% of slots
+- When Codacy reports maintainability grade B or below, temporarily boost simplification-debt to priority 7
 
-When a worker fails on an issue (killed for thrashing, PR closed without merge, or 0 commits after timeout), the supervisor must track the failure count and escalate the model tier after 2 failed attempts. Blindly re-dispatching at the same tier wastes compute — the t748 incident burned 7 workers over 30+ hours on a task that required codebase archaeology beyond sonnet's capability.
+### Worktree dispatch (MANDATORY for quality-debt)
 
-**How to count failures:** Read the issue comments. Each kill/re-dispatch comment from the supervisor counts as one failure. Count comments matching patterns like "Worker killed", "Worker (PID", "Re-opening for dispatch", "Re-dispatching". If the count is >= 2, escalate.
+Quality-debt workers MUST be dispatched to a pre-created worktree, not the canonical repo directory. Multiple workers dispatched to the same canonical dir race for branch creation, causing struggle ratios in the thousands.
 
-**Escalation tiers:**
+Before dispatching: verify canonical repo is on `main` (skip all quality-debt for that repo if not). Generate a branch name from the issue, pre-create a worktree with `git -C PATH worktree add -b BRANCH WT_PATH`, and pass `--dir WT_PATH` to the dispatch helper.
 
-| Failures | Action |
-|----------|--------|
-| 0-1 | Dispatch at default tier (bundle default or sonnet) |
-| 2 | Escalate to opus: add `--model anthropic/claude-opus-4-6` to the dispatch command |
-| 3+ | Escalate to opus AND simplify scope — add a comment on the issue summarising what previous workers attempted and where they got stuck, so the next worker doesn't repeat the same analysis |
+### Blast radius cap
 
-**Override the no-model dispatch rule:** The default dispatch rule says "Do NOT add `--model`". This escalation rule overrides it — when failure count >= 2, you MUST add `--model anthropic/claude-opus-4-6`. The cost of one opus dispatch (~3x sonnet) is far less than the cost of 5+ failed sonnet dispatches. Do NOT post a separate escalation comment — the dispatch comment's "Attempt" field captures escalation context (e.g., "Attempt: 3 of 3 (escalated to opus after 2 failed sonnet attempts)").
+Quality-debt PRs must touch at most 5 files. Create one issue per file or per tightly-coupled file group (max 5). Before dispatching, check whether any open PR already touches the same files — if overlap exists, skip this cycle.
 
-**This is a judgment call, not a hard threshold.** If the first failure was clearly a transient issue (OOM, network timeout, CI flake) rather than a capability gap, resetting the counter is appropriate. But if the worker thrashed with high struggle ratio and 0 commits, that's a capability signal — escalate.
+Serial merge for quality-debt: do not dispatch a second quality-debt worker for the same repo while a quality-debt PR is open and mergeable. Wait for the first to merge.
 
-### Audit-quality state in issue and PR comments (t1416)
+### Stale cleanup
 
-Every comment the supervisor posts on an issue or PR must be **sufficient for a human or future agent to audit and understand the work without reading logs**. The issue timeline and PR comments are the primary audit trail — if the information isn't there, it's invisible.
+Close quality-debt PRs that have been CONFLICTING for 24+ hours with a comment explaining they'll be superseded by smaller PRs. Relabel corresponding issues `status:available`.
 
-**Required fields in dispatch comments:**
+## Cross-Repo TODO Sync
 
-When dispatching a worker, comment on the issue with:
+Issue creation (push) is handled exclusively by CI. The pulse runs pull and close only:
 
 ```bash
-gh issue comment <number> --repo <slug> --body "Dispatching worker.
-- **Model**: <tier and full model ID, e.g., sonnet (anthropic/claude-sonnet-4-6)>
-- **Branch**: <branch name, e.g., fix/t748-ai-migration>
-- **Scope**: <1-line description of what the worker should do>
-- **Attempt**: <N of M, e.g., 1 of 1, or 3 of 3 (escalated to opus)>
-- **Direction**: <any specific guidance, e.g., 'focus on migration chain from PR #213'>"
-```
-
-**Required fields in kill/failure comments:**
-
-When killing a worker or closing a failed PR, comment with:
-
-```bash
-gh issue comment <number> --repo <slug> --body "Worker killed after <duration> with <N> commits (struggle_ratio: <ratio>).
-- **Model**: <tier used>
-- **Branch**: <branch name>
-- **Reason**: <why it was killed — thrashing, timeout, CI loop, etc.>
-- **Diagnosis**: <1-line hypothesis of what went wrong>
-- **Next action**: <re-dispatch at same tier / escalate to opus / needs manual review>"
-```
-
-**Required fields in merge/completion comments:**
-
-When merging a PR or closing an issue as done:
-
-```bash
-gh issue comment <number> --repo <slug> --body "Completed via PR #<N>.
-- **Model**: <tier that succeeded>
-- **Attempts**: <total attempts including failures>
-- **Duration**: <wall-clock from first dispatch to merge>"
-```
-
-**Why this matters:** Without these fields, auditing a task requires reading pulse logs, cross-referencing `ps` output timestamps, and guessing which model was used. The t748 incident had 7 kill comments that all said "Worker killed after Xh with 0 commits" but none recorded the model tier, making it impossible to determine whether escalation was attempted. Issue comments are the state dashboard — they must be self-contained.
-
-### Self-improvement on information gaps (t1416)
-
-When the supervisor encounters a situation where it cannot determine what happened (missing model tier, unclear failure reason, no branch name in comments, ambiguous state labels), this is an **information gap**. Information gaps cause audit failures and prevent effective re-dispatch.
-
-**Response:** File a self-improvement issue in the aidevops repo describing:
-1. What information was missing
-2. Where it should have been recorded
-3. What went wrong because it was missing (e.g., "could not determine if model was escalated, re-dispatched at same tier 5 more times")
-
-This is a one-time observation — don't file duplicate issues for the same gap. Check existing issues first: `gh issue list --repo <aidevops-slug> --search "information gap" --state open`.
-
-### Task decomposition before dispatch (t1408.2)
-
-Before dispatching a worker for an issue, classify the task to determine if it's too large for a single worker session. This catches over-scoped tasks before they waste a worker slot.
-
-**When to classify:** For each dispatchable issue (after passing the skip checks below), run the classify step. Skip classification for issues that already have subtask issues (check if issues with `tNNN.1`, `tNNN.2` etc. exist in the title search).
-
-**How to classify:**
-
-```bash
-# Extract task description from the issue title/body
-TASK_DESC="<issue title and first paragraph of body>"
-
-# Classify — uses haiku-tier LLM call (~$0.001)
-CLASSIFY_RESULT=$(/bin/bash ~/.aidevops/agents/scripts/task-decompose-helper.sh classify \
-  "$TASK_DESC" --depth 0) || CLASSIFY_RESULT=""
-
-# Parse result
-TASK_KIND=$(echo "$CLASSIFY_RESULT" | jq -r '.kind // "atomic"' || echo "atomic")
-```
-
-**If atomic:** Dispatch the worker directly (unchanged flow — proceed to step 6 below).
-
-**If composite:** Auto-decompose and create child tasks instead of dispatching:
-
-```bash
-# Decompose into subtasks
-DECOMPOSE_RESULT=$(/bin/bash ~/.aidevops/agents/scripts/task-decompose-helper.sh decompose \
-  "$TASK_DESC" --max-subtasks "${DECOMPOSE_MAX_SUBTASKS:-5}") || DECOMPOSE_RESULT=""
-
-SUBTASK_COUNT=$(echo "$DECOMPOSE_RESULT" | jq '.subtasks | length' || echo 0)
-```
-
-If decomposition succeeds (`SUBTASK_COUNT >= 2`):
-
-1. For each subtask, create a child task using `claim-task-id.sh`:
-
-   ```bash
-   for i in $(seq 0 $((SUBTASK_COUNT - 1))); do
-     SUB_DESC=$(echo "$DECOMPOSE_RESULT" | jq -r ".subtasks[$i].description")
-     SUB_ESTIMATE=$(echo "$DECOMPOSE_RESULT" | jq -r ".subtasks[$i].estimate // \"~2h\"")
-     SUB_DEPS=$(echo "$DECOMPOSE_RESULT" | jq -r ".subtasks[$i].depends_on | map(\"blocked-by:${TASK_ID}.\" + tostring) | join(\" \")" || echo "")
-
-     # Claim child task ID
-     CHILD_OUTPUT=$(/bin/bash ~/.aidevops/agents/scripts/claim-task-id.sh \
-       --repo-path "$path" --title "${TASK_ID}.${i+1}: $SUB_DESC" --parent "$TASK_ID")
-     CHILD_ID=$(echo "$CHILD_OUTPUT" | grep '^TASK_ID=' | cut -d= -f2)
-
-     # Add to TODO.md (planning-commit-helper handles commit+push)
-     # Format: - [ ] tNNN.N Description ~Nh blocked-by:tNNN.M ref:GH#NNN
-   done
-   ```
-
-2. Label the parent issue `status:blocked` with a comment explaining the decomposition
-3. Create a brief for each child task from the parent brief + decomposition context
-4. The child tasks enter the normal dispatch queue — the next pulse cycle picks up the leaves (tasks with no unresolved `blocked-by:` refs)
-
-**Depth limit:** `DECOMPOSE_MAX_DEPTH` env var (default: 3). Tasks at depth 3+ are always treated as atomic. This prevents infinite decomposition.
-
-**Skip decomposition when:**
-
-- The issue already has subtask issues (titles matching `tNNN.N:`)
-- The issue body contains `skip-decompose` or `atomic` markers
-- Classification fails (API unavailable) — default to atomic and dispatch directly
-- The task is a bug fix, CI fix, or docs update (these are almost always atomic)
-
-**Cost:** ~$0.001-0.005 per classify+decompose call (haiku tier). A single avoided over-scoped worker failure saves $0.50-5.00 in wasted compute.
-
-### Dispatch workers for open issues
-
-For each dispatchable issue (intelligence-first):
-
-When `PULSE_QUEUE_MODE` is `pr-heavy` or `merge-heavy`, limit issue dispatches to the current cycle budget:
-
-```bash
-ISSUE_DISPATCH_BUDGET=$(((AVAILABLE * NEW_ISSUE_DISPATCH_PCT) / 100))
-```
-
-If budget is exhausted, stop opening new issue workers and continue PR advancement work.
-
-1. **Dedup guard (MANDATORY, GH#4400):** Before dispatching, check if a worker is already running for this issue using the deterministic helper. This prevents the duplicate-dispatch thrashing pattern where multiple workers compete for the same issue/worktree.
-
-```bash
-# Source once per pulse run (provides has_worker_for_repo_issue and dispatch-dedup)
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-
-# Check 1: exact repo+issue match via process list
-if has_worker_for_repo_issue <number> <slug>; then
-  echo "Worker already running for #<number> in <slug> — skipping"
-  continue
-fi
-
-# Check 2: normalized dedup via dispatch-dedup-helper (catches title variants)
-if ~/.aidevops/agents/scripts/dispatch-dedup-helper.sh is-duplicate "Issue #<number>: <title>"; then
-  echo "Duplicate dispatch detected for #<number> — skipping"
-  continue
-fi
-```
-
-Both checks MUST pass before dispatch. The first catches exact repo+issue matches; the second catches title variants (e.g., `issue-3502` vs `Issue #3502: description`). Skipping these checks was the root cause of the 26-worker thrashing incident (GH#4400).
-
-1.5. **Apply per-repo worker cap before dispatch:** default `MAX_WORKERS_PER_REPO=5` (override via env var only when you have a clear reason). If the target repo already has `MAX_WORKERS_PER_REPO` active workers, skip dispatch for that repo this cycle and continue with other repos.
-
-```bash
-MAX_WORKERS_PER_REPO=${MAX_WORKERS_PER_REPO:-5}
-ACTIVE_FOR_REPO=$(list_active_worker_processes | awk -v path="<path>" '
-  BEGIN { esc=path; gsub(/[][(){}.^$*+?|\\]/, "\\\\&", esc) }
-  $0 ~ ("--dir[[:space:]]+" esc "([[:space:]]|$)") { count++ }
-  END { print count + 0 }
-')
-if [[ "$ACTIVE_FOR_REPO" -ge "$MAX_WORKERS_PER_REPO" ]]; then
-  echo "Repo at worker cap (${ACTIVE_FOR_REPO}/${MAX_WORKERS_PER_REPO}) — skipping dispatch for <slug> this cycle"
-  continue
-fi
-```
-
-2. Skip if an open PR already exists for it (check PR list)
-3. Treat labels as hints, not gates. `status:queued`, `status:in-progress`, and `status:in-review` suggest active work, but verify with evidence (active worker, recent PR updates, recent commits) before skipping.
-4. Treat unassigned + non-blocked issues as available by default. `status:available` is optional metadata, not a requirement.
-5. If an issue is assigned and recently updated (<3h), usually skip it. If assigned but stale (3+h, no active PR/worker evidence), treat it as abandoned: unassign and comment the recovery; make it dispatchable this cycle.
-6. Read the issue body briefly — if it has `blocked-by:` references, check if those are resolved (merged PR exists). If not, skip it.
-6.5. **Classify and decompose (t1408.2):** Run the task decomposition check described in "Task decomposition before dispatch" above. If the task is composite, create child tasks and skip direct dispatch. If atomic (or classification unavailable), proceed to dispatch.
-7. Prioritize by value density and flow efficiency, not label perfection: unblock merge-ready PRs first, then critical/high issues, then best-next backlog items that keep worker slots full.
-7.5. **Choose execution mode per issue type (code vs ops):** Ad-hoc issue dispatch is not always `/full-loop`.
-
-   - **Code-change issue** (repo edits/tests/PR expected): use `/full-loop Implement issue #<number> ...`
-   - **Operational issue** (reports, audits, monitoring, outreach, account ops): use a direct domain command (no `/full-loop`), for example `/seo-export ...` or another issue-defined SOP command
-   - If the issue body includes an explicit command/SOP, run that command directly. If not, infer the best direct command from the issue domain + assigned agent.
-8. Dispatch:
-
-> **Quality-debt issues:** Do NOT use the standard `--dir <path>` dispatch below. Instead, follow the "Quality-debt worktree dispatch" protocol (see below) — pre-create a worktree and pass `--dir <worktree_path>`. This is mandatory to prevent branch conflicts in the canonical repo directory (t1479).
-
-```bash
-# Assign the issue to prevent duplicate work by other runners/humans
-RUNNER_USER=$(gh api user --jq '.login' 2>/dev/null || whoami)
-gh issue edit <number> --repo <slug> --add-assignee "$RUNNER_USER" --add-label "status:queued" --remove-label "status:available" 2>/dev/null || gh issue edit <number> --repo <slug> --add-assignee "$RUNNER_USER" --add-label "status:queued" 2>/dev/null || true
-
-DISPATCH_PROMPT="/full-loop Implement issue #<number> (<url>) -- <brief description>"
-# For ops issues, replace DISPATCH_PROMPT with a direct command (no /full-loop)
-# Example: DISPATCH_PROMPT="/seo-export all <domain> --days 30"
-[[ -n "$DISPATCH_PROMPT" ]] || DISPATCH_PROMPT="/full-loop Implement issue #<number> (<url>) -- <brief description>"
-
-~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-  --role worker \
-  --session-key "issue-<number>" \
-  --dir <path> \
-  --title "Issue #<number>: <title>" \
-  --prompt "$DISPATCH_PROMPT" &
-sleep 2
-```
-
-If a dispatch attempt exits immediately with provider/auth failure (for example `Token refresh failed`, `authentication`, `401`, `403`, `400` in startup logs), do not wait for next cycle. Re-dispatch in the same cycle via `headless-runtime-helper.sh run` with an explicit alternate model/provider and continue filling remaining slots.
-
-**Launch validation is mandatory (t1452/t1453):** after each dispatch, validate the launch with the wrapper helper. This keeps the gate deterministic and aligned with wrapper-side enforcement.
-
-```bash
-# Source wrapper helper once per pulse run (safe when sourced)
-source ~/.aidevops/agents/scripts/pulse-wrapper.sh
-
-# check_worker_launch returns 0 only when the worker process appears
-# and no CLI usage-output markers are detected in known startup logs.
-if ! check_worker_launch <number> <slug>; then
-  echo "Invalid worker launch for #<number>"
-  # Relaunch immediately via helper (never leave this for next pulse)
-fi
-```
-
-If validation fails, re-dispatch immediately via `headless-runtime-helper.sh run`, add a short issue comment noting the failed launch and correction, and continue filling slots.
-
-9. **Fill-to-cap post-condition (t1449/t1453):** before ending the pulse cycle, compare active workers vs `MAX_WORKERS`. If below cap and runnable scoped issues/PR work exists in any repo class, continue dispatching until cap is reached or no runnable candidates remain. Do not leave slots idle because of class reservations when one class is PR-capped or empty.
-
-   `pulse-wrapper.sh` now enforces this invariant after the LLM pulse pass via bounded backfill cycles (until max workers or no runnable work) and treats queued issues without live workers as launch-validation failures to backfill immediately.
-
-### Candidate discovery baseline (t1443 + t1448)
-
-Do NOT treat `auto-dispatch` or `status:available` as hard gates. They are hints only.
-
-In every pulse cycle, build candidates from unassigned, non-blocked issues first, then apply judgment and safeguards.
-
-1. Search for open issues in scoped repos that are not blocked and have no active PR/worker evidence.
-2. Prioritize `priority:critical`, `priority:high`, and `bug` labels first.
-3. Include `quality-debt` candidates when they are the highest-value available work, even without `auto-dispatch`/`status:available` labels.
-4. Respect existing caps and safeguards (quality-debt concurrency cap, blast-radius guidance, stale-label recovery).
-
-Example discovery query:
-
-```bash
-gh issue list --repo <slug> --state open \
-  --search "(label:priority:critical OR label:priority:high OR label:bug OR label:quality-debt) -label:status:blocked no:assignee" \
-  --limit 100
-```
-
-If you dispatch an unassigned issue without `auto-dispatch`/`status:available`, add a short issue comment such as:
-
-"Dispatching via intelligence-first backlog selection (t1448): issue is unassigned, non-blocked, and highest-value available work this cycle."
-
-**Dispatch rules:**
-- ALWAYS use `~/.aidevops/agents/scripts/headless-runtime-helper.sh run` for headless dispatches — NEVER `claude`, `claude -p`, or raw `opencode run`
-- Background with `&`, sleep 2 between dispatches
-- The helper alternates the default headless providers/models (`anthropic/claude-sonnet-4-6`, `openai/gpt-5.3-codex`), persists session IDs per provider + session key, honors provider backoff, and rejects `opencode/*` gateway models (no Zen fallback for headless runs)
-- Do NOT add `--model` for first attempts — let the helper choose the alternating default. **Exception:** when escalating after 2+ failed attempts on the same issue, pass `--model anthropic/claude-opus-4-6` to the helper (see "Model escalation after repeated failures" above).
-- If you must run raw `opencode run` for diagnosis, use only documented flags from `opencode run --help` and NEVER pass unsupported options (for example `--max-iterations`); unsupported flags cause usage-output false starts that burn worker slots.
-- If helper-selected launch fails at startup with auth/provider errors, immediately retry with explicit alternate provider in the same cycle (for example `--model openai/gpt-5.3-codex` after anthropic auth failure) and log the fallback in an issue comment.
-- After every dispatch, run launch validation (live process + no CLI usage output in startup log) before counting the slot as filled.
-- Use `--dir <path>` from repos.json
-- Route non-code tasks with `--agent`: SEO, Content, Marketing, Business, Research (see AGENTS.md "Agent Routing")
-- If a dispatched worker later looks stalled, `worker-watchdog.sh` now inspects the recent OpenCode transcript tail before killing it, includes that diagnostic evidence in the retry trail, and gives provider-wait evidence one extra timeout window before re-queueing the issue.
-- Product/tooling reservations are soft optimization targets. When product repos are at daily PR cap (or otherwise non-dispatchable), immediately reallocate those slots to tooling/system work.
-- **Bundle-aware agent routing (t1364.6):** Before dispatching, check if the target repo has a bundle with `agent_routing` overrides. Run `bundle-helper.sh get agent_routing <repo-path>` — if the task domain (code, seo, content, marketing) has a non-default agent, use `--agent <name>`. Example: a content-site bundle routes `marketing` tasks to the Marketing agent instead of Build+. Explicit `--agent` flags in the issue body always override bundle defaults.
-- **Scope boundary (t1405, GH#2928):** ONLY dispatch workers for repos in the pre-fetched state (i.e., repos with `pulse: true` in repos.json). The `PULSE_SCOPE_REPOS` env var (set by `pulse-wrapper.sh`) contains the comma-separated list of in-scope repo slugs. Workers inherit this env var and use it to restrict code changes (branches, PRs) to scoped repos. Workers CAN still file issues on any repo (cross-repo self-improvement), but the pulse must NEVER dispatch a worker to implement a fix on a repo outside this scope — even if an issue exists there. Issues on non-pulse repos enter that repo's queue for their own maintainers to handle.
-- **Lineage context for subtasks (t1408.3):** When dispatching a subtask (task ID contains a dot, e.g., `t1408.3`), include a lineage context block in the dispatch prompt. This tells the worker what the parent task is, what sibling tasks exist, and to focus only on its specific scope. See `tools/ai-assistants/headless-dispatch.md` "Lineage Context for Subtask Workers" for the full format and assembly instructions. Example dispatch with lineage:
-
-  ```bash
-  # Subtask dispatch with lineage context
-  PARENT_ID="${TASK_ID%.*}"
-  PARENT_DESC=$(grep -E "^- \[.\] ${PARENT_ID} " "$path/TODO.md" | head -1 \
-    | sed -E 's/^- \[.\] [^ ]+ //' | sed -E 's/ #[^ ]+//g' | cut -c1-120)
-  SIBLINGS=$(grep -E "^  - \[.\] ${PARENT_ID}\.[0-9]+" "$path/TODO.md" \
-    | sed -E 's/^  - \[.\] ([^ ]+) (.*)/\1: \2/' | sed -E 's/ #[^ ]+//g')
-
-  # Build lineage block (see headless-dispatch.md for full assembly)
-  # Or use: LINEAGE_BLOCK=$(task-decompose-helper.sh format-lineage "$TASK_ID")
-
-  DISPATCH_PROMPT="/full-loop Implement issue #<number> (<url>) -- <brief description>"
-  # For operational subtasks, set DISPATCH_PROMPT to a direct command instead.
-  [[ -n "$DISPATCH_PROMPT" ]] || DISPATCH_PROMPT="/full-loop Implement issue #<number> (<url>) -- <brief description>"
-
-  ~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-    --role worker \
-    --session-key "issue-<number>" \
-    --dir <path> \
-    --title "Issue #<number>: <title>" \
-    --prompt "$DISPATCH_PROMPT
-
-  TASK LINEAGE:
-    0. [parent] ${PARENT_DESC} (${PARENT_ID})
-      1. <sibling 1 desc> (${PARENT_ID}.1)
-      2. <sibling 2 desc> (${PARENT_ID}.2)  <-- THIS TASK
-      3. <sibling 3 desc> (${PARENT_ID}.3)
-
-  LINEAGE RULES:
-  - You are one of several agents working in parallel on sibling tasks under the same parent.
-  - Focus ONLY on your specific task (marked with '<-- THIS TASK').
-  - Do NOT duplicate work that sibling tasks would handle.
-  - If your task depends on interfaces or APIs from sibling tasks, define reasonable stubs.
-  - If blocked by a sibling task, exit with BLOCKED and specify which sibling." &
-  sleep 2
-  ```
-
-### Batch execution strategies for decomposed tasks (t1408.4)
-
-When the task decomposition pipeline (t1408) produces subtasks grouped under parent tasks, use `batch-strategy-helper.sh` to determine dispatch order. This integrates with the existing `MAX_WORKERS` concurrency limit — batch sizes never exceed available worker slots.
-
-**Two strategies:**
-
-- **depth-first** (default): Complete all subtasks under one parent branch before starting the next. Tasks within each branch run concurrently up to the concurrency limit. Good for dependent work where branch B builds on branch A's output.
-- **breadth-first**: One subtask from each parent branch per batch, spreading progress evenly across all branches. Good for independent work where all branches can proceed in parallel.
-
-**When to use batch strategies:**
-
-Only when dispatching subtasks from a decomposed parent task (tasks sharing a `parent_id` in their issue body or TODO.md hierarchy). For regular unrelated issues, use the standard priority-based dispatch above — batch strategies add no value for independent tasks.
-
-**How to use:**
-
-```bash
-# Build the tasks JSON from decomposed subtasks in TODO.md or issue bodies.
-# Each task needs: id, parent_id, status, blocked_by, depth.
-TASKS_JSON='[{"id":"t1408.1","parent_id":"t1408","status":"pending","depth":1,"blocked_by":[]}, ...]'
-
-# Get the next batch to dispatch (respects blocked_by dependencies)
-NEXT_BATCH=$(batch-strategy-helper.sh next-batch \
-  --strategy "${BATCH_STRATEGY:-depth-first}" \
-  --tasks "$TASKS_JSON" \
-  --concurrency "$AVAILABLE")
-
-# Dispatch each task in the batch
-# Use the same mode-selection rule as standard issue dispatch:
-# code tasks => /full-loop, operational tasks => direct command
-echo "$NEXT_BATCH" | jq -r '.[]' | while read -r task_id; do
-  # Look up the issue number and repo for this task_id
-  # Then dispatch as normal (see dispatch rules above)
-  DISPATCH_PROMPT="/full-loop Implement issue #<number> (<url>) -- <brief description>"
-  # For operational tasks in the batch, set DISPATCH_PROMPT to a direct command.
-  [[ -n "$DISPATCH_PROMPT" ]] || DISPATCH_PROMPT="/full-loop Implement issue #<number> (<url>) -- <brief description>"
-  ~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-    --role worker \
-    --session-key "task-${task_id}" \
-    --dir <path> \
-    --title "Issue #<number>: <title>" \
-    --prompt "$DISPATCH_PROMPT" &
-  sleep 2
-done
-```
-
-**Configuration:**
-
-- `BATCH_STRATEGY` env var: `depth-first` (default) or `breadth-first`. Set in `pulse-wrapper.sh` or per-repo via bundle config.
-- Concurrency per batch is capped by `AVAILABLE` worker slots (from Step 1) and the helper's `MAX_BATCH_SIZE` (8).
-- The helper automatically skips blocked tasks (`blocked_by:` references to non-completed siblings).
-
-**Validation:** Before dispatching, optionally validate the dependency graph:
-
-```bash
-batch-strategy-helper.sh validate --tasks "$TASKS_JSON"
-# Returns JSON with {valid: bool, errors: [...], warnings: [...]}
-# Detects: circular dependencies, missing blocker references, excessive depth
-```
-
-**This is guidance, not enforcement.** The batch strategy is a recommendation for the pulse supervisor's dispatch ordering. Use judgment — if a breadth-first batch would dispatch 5 tasks but only 2 worker slots are available, dispatch the 2 highest-priority tasks regardless of strategy. The helper respects concurrency limits, but the supervisor has final say on what to dispatch.
-
-### Priority order
-
-1. PRs with green CI → merge (free — no worker slot needed)
-2. PRs with failing CI or review feedback → fix (uses a slot, but closer to done than new issues)
-3. Issues labelled `priority:high` or `bug`
-4. Active mission features (keeps multi-day projects moving — see Step 3.5)
-5. Product repos (`"priority": "product"` in repos.json) over tooling — **enforced by priority-class reservations (t1423)**. Product repos have `PRODUCT_MIN` reserved slots; tooling cannot consume them when product work is pending. See "Priority-class enforcement" in Step 1.
-6. Smaller/simpler tasks over large ones (faster throughput)
-7. `quality-debt` issues (unactioned review feedback from merged PRs) — **use worktree dispatch** (see "Quality-debt worktree dispatch" below)
-8. `simplification-debt` issues (human-approved simplification opportunities)
-9. Oldest issues
-
-### Quality-debt concurrency cap (configurable, default 30%)
-
-Issues labelled `quality-debt` (created by `quality-feedback-helper.sh scan-merged`) represent unactioned review feedback from merged PRs. These are important but should not crowd out new feature work.
-
-**Rule: quality-debt issues may consume at most `QUALITY_DEBT_CAP_PCT` of available worker slots.** Default is 30%. Pulse pre-fetched state includes the active cap as `Quality-debt cap: **X%** of worker pool` from `pulse-wrapper.sh`. Calculate: `QUALITY_DEBT_MAX = floor(MAX_WORKERS * QUALITY_DEBT_CAP_PCT / 100)` (minimum 1). Count running workers whose command line contains a `quality-debt` issue number, plus open `quality-debt` issues with `status:in-progress` or `status:queued` labels. If the count >= `QUALITY_DEBT_MAX`, skip remaining quality-debt issues and dispatch higher-priority work instead.
-
-```bash
-# Count active quality-debt workers
-QUALITY_DEBT_ACTIVE=$(gh issue list --repo <slug> --label "quality-debt" --label "status:in-progress" --state open --json number --jq 'length' || echo 0)
-QUALITY_DEBT_QUEUED=$(gh issue list --repo <slug> --label "quality-debt" --label "status:queued" --state open --json number --jq 'length' || echo 0)
-QUALITY_DEBT_CURRENT=$((QUALITY_DEBT_ACTIVE + QUALITY_DEBT_QUEUED))
-# Read from pre-fetched state section (default 30 if unavailable)
-QUALITY_DEBT_CAP_PCT=<from pre-fetched "Quality-debt cap: **X%**" line, default 30>
-QUALITY_DEBT_MAX=$(( MAX_WORKERS * QUALITY_DEBT_CAP_PCT / 100 ))
-[[ "$QUALITY_DEBT_MAX" -lt 1 ]] && QUALITY_DEBT_MAX=1
-```
-
-If `QUALITY_DEBT_CURRENT >= QUALITY_DEBT_MAX`, do not dispatch more quality-debt issues this cycle.
-
-### Pre-dispatch canonical-repo check for quality-debt (t1479, MANDATORY)
-
-**Before dispatching any quality-debt worker**, verify the canonical repo directory is on `main`. If it is not, skip all quality-debt dispatches for that repo this cycle and log a warning. This prevents the branch-conflict cascade where multiple workers race to create branches in the same canonical directory, leaving it on a non-main branch.
-
-```bash
-# Check canonical repo is on main before any quality-debt dispatch
-CANONICAL_BRANCH=$(git -C <path> rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
-if [[ "$CANONICAL_BRANCH" != "main" && "$CANONICAL_BRANCH" != "master" ]]; then
-  echo "WARN: Skipping quality-debt dispatch for <slug> — canonical repo is on branch '$CANONICAL_BRANCH', not main. Manual cleanup required before quality-debt workers can be dispatched."
-  # Skip all quality-debt dispatches for this repo this cycle
-  continue
-fi
-```
-
-### Quality-debt worktree dispatch (t1479, MANDATORY)
-
-**Quality-debt workers MUST be dispatched to a pre-created worktree, not the canonical repo directory.** Dispatching multiple workers to the same canonical dir causes them to race for branch creation, leaving the canonical repo on a non-main branch and producing struggle ratios in the thousands.
-
-**For each quality-debt issue dispatch:**
-
-1. Generate a branch name from the issue number and title slug.
-2. Pre-create a worktree for that branch using `worktree-helper.sh`.
-3. Pass `--dir <worktree_path>` (not `--dir <canonical_path>`) to the headless runtime helper.
-
-```bash
-# 1. Generate branch name from issue number + title slug (max 40 chars)
-QD_BRANCH_SLUG=$(echo "<title>" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | cut -c1-30)
-QD_BRANCH="bugfix/qd-<number>-${QD_BRANCH_SLUG}"
-
-# 2. Pre-create worktree (idempotent — if branch already exists, reuse it)
-QD_WT_PATH=$(git -C <path> worktree list --porcelain \
-  | grep -B2 "branch refs/heads/${QD_BRANCH}$" \
-  | grep "^worktree " | cut -d' ' -f2- 2>/dev/null || true)
-
-if [[ -z "$QD_WT_PATH" ]]; then
-  # Worktree does not exist — create it using git -C to target the correct repo
-  # (worktree-helper.sh uses cwd; use git directly to avoid cwd dependency)
-  REPO_NAME=$(basename <path>)
-  PARENT_DIR=$(dirname <path>)
-  QD_WT_SLUG=$(echo "$QD_BRANCH" | tr '/' '-' | tr '[:upper:]' '[:lower:]')
-  QD_WT_PATH="${PARENT_DIR}/${REPO_NAME}-${QD_WT_SLUG}"
-  git -C <path> worktree add -b "$QD_BRANCH" "$QD_WT_PATH" 2>/dev/null || {
-    echo "WARN: Failed to create worktree for quality-debt #<number> — skipping dispatch"
-    continue
-  }
-fi
-
-if [[ -z "$QD_WT_PATH" || ! -d "$QD_WT_PATH" ]]; then
-  echo "WARN: Could not determine worktree path for quality-debt #<number> — skipping dispatch"
-  continue
-fi
-
-# 3. Dispatch worker to the worktree path, not the canonical repo path
-~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-  --role worker \
-  --session-key "issue-<number>" \
-  --dir "$QD_WT_PATH" \
-  --title "Issue #<number>: <title>" \
-  --prompt "/full-loop Implement issue #<number> (<url>) -- <brief description>" &
-sleep 2
-```
-
-**Why worktrees, not canonical dir:** When the pulse dispatches N quality-debt workers all pointing to the same canonical repo path, each worker's `full-loop.md` Step 1 tries to create a branch in that directory. The first worker succeeds; subsequent workers find the repo already on a non-main branch and either fail or compound the problem. Worktrees give each worker an isolated directory with its own branch, so they never interfere with each other or with the canonical repo.
-
-**`git -C <path>` for worktree creation:** The pulse runs from its own working directory (not the target repo). Use `git -C <path>` to create worktrees in the correct repo without changing the pulse's cwd. Do NOT call `worktree-helper.sh` for this — it uses `get_repo_root()` which depends on cwd and would target the wrong repo.
-
-### Quality-debt PR blast radius cap (t1422)
-
-Quality-debt PRs that touch many files conflict with every other PR in flight. When multiple large-batch quality-debt PRs are created concurrently, they cascade into merge conflicts — each merge moves main, invalidating the next PR's base. This was observed in March 2026: 19 of 30 open PRs were conflicting, with individual PRs touching up to 69 files.
-
-**Rule: quality-debt PRs must touch at most 5 files.** This is a hard cap enforced by the worker (see `full-loop.md` "Quality-debt blast radius cap"). The pulse enforces it at dispatch time by scoping issue descriptions:
-
-1. **Per-file issues preferred.** When creating quality-debt issues (via `quality-feedback-helper.sh`, code-simplifier, or manual filing), create one issue per file or per tightly-coupled file group (max 5 files). An issue titled "Fix shellcheck violations in dispatch.sh" will produce a 1-file PR that conflicts with nothing. An issue titled "Fix shellcheck violations across 20 scripts" will produce a 20-file PR that conflicts with everything.
-
-2. **File-level dedup before dispatch.** Before dispatching a quality-debt worker, check whether any open PR already touches the same files. If overlap exists, skip the issue this cycle — the existing PR must merge first.
-
-   ```bash
-   # Get files that would be touched by this issue (from issue body or title)
-   # Then check open PRs for overlap
-   OPEN_PR_FILES=$(gh pr list --repo <slug> --state open --json number,files \
-     --jq '[.[].files[].path] | unique | .[]')
-
-   # If the issue mentions specific files, check for overlap
-   # This is a judgment call — read the issue body for file paths
-   # If overlap is found, skip: "Skipping quality-debt #NNN — files overlap with open PR #MMM"
-   ```
-
-3. **Serial merge for quality-debt.** Do not dispatch a second quality-debt worker for the same repo while a quality-debt PR is open and mergeable. Wait for the first to merge, then dispatch the next. This prevents the conflict cascade at the source. Feature PRs are unaffected — they touch different files by nature.
-
-   ```bash
-   # Check for open quality-debt PRs in this repo
-   OPEN_DEBT_PRS=$(gh pr list --repo <slug> --state open \
-     --json number,title,labels \
-     --jq '[.[] | select(.labels[]?.name == "quality-debt" or (.title | test("quality.debt|fix:.*batch|fix:.*harden"; "i")))] | length' \
-     || echo 0)
-
-   # If there's already an open quality-debt PR, skip dispatching more
-   if [[ "$OPEN_DEBT_PRS" -gt 0 ]]; then
-     echo "Skipping quality-debt dispatch — $OPEN_DEBT_PRS quality-debt PR(s) already open for <slug>"
-     # Focus on merging the existing PR instead
-   fi
-   ```
-
-**Why 5 files?** A 5-file PR has a ~10% chance of conflicting with another random 5-file PR in a 200-file repo. A 50-file PR has a ~95% chance. The conflict probability scales quadratically with file count — small PRs are exponentially safer.
-
-### Stale quality-debt PR cleanup
-
-When the pulse detects quality-debt PRs that have been `CONFLICTING` for 24+ hours, close them with a comment explaining they'll be superseded by smaller, atomic PRs:
-
-```bash
-# For each conflicting quality-debt PR older than 24 hours:
-gh pr close <number> --repo <slug> \
-  -c "Closing — this PR has merge conflicts and touches too many files (blast radius issue, see t1422). The underlying fixes will be re-created as smaller PRs (max 5 files each) to prevent conflict cascades."
-```
-
-After closing, ensure the corresponding issues are relabelled `status:available` so they re-enter the dispatch queue. The next dispatch cycle will create properly-scoped PRs.
-
-### Simplification-debt concurrency cap (10%)
-
-Issues labelled `simplification-debt` (created by `/code-simplifier` analysis, approved by a human) represent maintainability improvements that preserve all functionality and knowledge. These are the lowest-priority automated work -- post-deployment nice-to-haves.
-
-**Rule: simplification-debt issues may consume at most 10% of available worker slots** (minimum 1, but only when no higher-priority work exists). These issues share the combined debt cap with quality-debt -- total debt work (quality-debt + simplification-debt) should not exceed 30% of slots.
-
-```bash
-# Count active simplification-debt workers
-SIMPLIFICATION_DEBT_ACTIVE=$(gh issue list --repo <slug> --label "simplification-debt" --label "status:in-progress" --state open --json number --jq 'length' || echo 0)
-SIMPLIFICATION_DEBT_QUEUED=$(gh issue list --repo <slug> --label "simplification-debt" --label "status:queued" --state open --json number --jq 'length' || echo 0)
-SIMPLIFICATION_DEBT_CURRENT=$((SIMPLIFICATION_DEBT_ACTIVE + SIMPLIFICATION_DEBT_QUEUED))
-SIMPLIFICATION_DEBT_MAX=$(( MAX_WORKERS * 10 / 100 ))
-[[ "$SIMPLIFICATION_DEBT_MAX" -lt 1 ]] && SIMPLIFICATION_DEBT_MAX=1
-
-# Combined debt cap -- quality-debt + simplification-debt together
-# Recalculate quality-debt here so this snippet is self-contained
-QUALITY_DEBT_ACTIVE=$(gh issue list --repo <slug> --label "quality-debt" --label "status:in-progress" --state open --json number --jq 'length' || echo 0)
-QUALITY_DEBT_QUEUED=$(gh issue list --repo <slug> --label "quality-debt" --label "status:queued" --state open --json number --jq 'length' || echo 0)
-QUALITY_DEBT_CURRENT=$((QUALITY_DEBT_ACTIVE + QUALITY_DEBT_QUEUED))
-TOTAL_DEBT_CURRENT=$((QUALITY_DEBT_CURRENT + SIMPLIFICATION_DEBT_CURRENT))
-TOTAL_DEBT_MAX=$(( MAX_WORKERS * 30 / 100 ))
-[[ "$TOTAL_DEBT_MAX" -lt 1 ]] && TOTAL_DEBT_MAX=1
-```
-
-If `SIMPLIFICATION_DEBT_CURRENT >= SIMPLIFICATION_DEBT_MAX` or `TOTAL_DEBT_CURRENT >= TOTAL_DEBT_MAX`, do not dispatch more simplification-debt issues this cycle.
-
-**Codacy maintainability signal:** When Codacy reports a maintainability grade drop (B or below) for a repo, simplification-debt issues for that repo get a temporary priority boost -- treat them as priority 7 (same as quality-debt) until the grade recovers. Check the daily quality sweep comment on the persistent quality-review issue for Codacy grade data.
-
-**Label lifecycle** (for your awareness — workers manage their own transitions): `available` → `queued` (you dispatch) → `in-progress` (worker starts) → `in-review` (PR opened) → `done` (PR merged)
-
-### Cross-repo TODO sync
-
-Sync GitHub issue refs and close completed issues. **Issue creation (push) is handled
-exclusively by CI** (GitHub Actions `issue-sync.yml` on TODO.md push to main) to prevent
-duplicate issues from concurrent local + CI execution. Local sessions use `pull` (sync
-refs back to TODO.md) and `close` (close issues for completed tasks).
-
-**Note:** Helper scripts use `#!/usr/bin/env bash` shebangs which fail in the MCP shell if PATH is incomplete. Step 0's `export PATH=...` fixes this for the session. If you still see `env: bash: No such file or directory`, call scripts with an explicit `/bin/bash` prefix as shown below:
-
-```bash
-# Pull: sync issue refs from GitHub to TODO.md (safe, idempotent)
 /bin/bash ~/.aidevops/agents/scripts/issue-sync-helper.sh pull --repo "$slug" 2>&1 || true
-# Close: close issues for completed tasks (safe, idempotent)
 /bin/bash ~/.aidevops/agents/scripts/issue-sync-helper.sh close --repo "$slug" 2>&1 || true
-# Commit any ref changes
 git -C "$path" diff --quiet TODO.md 2>/dev/null || {
   git -C "$path" add TODO.md && git -C "$path" commit -m "chore: sync GitHub issue refs to TODO.md [skip ci]" && git -C "$path" push
 } 2>/dev/null || true
 ```
 
-**Why not push locally?** When TODO.md merges to main, CI runs `push` to create issues.
-If the local pulse also runs `push`, both see "no existing issue" and both create one —
-producing duplicates. Single-task issue creation still works via `claim-task-id.sh` (which
-creates issues at claim time, before TODO.md hits main).
+## Orphaned PR Scanner
 
-### Orphaned PR scanner (t216)
+After processing PRs and issues, scan for orphaned PRs — open PRs with no active worker and no updates for 6+ hours.
 
-After processing PRs and issues above, scan for **orphaned PRs** — open PRs with no active worker and no recent activity. These occur when a worker process dies (OOM, SIGKILL, context exhaustion) after creating a PR but before completing the full-loop. Without this scan, orphaned PRs sit open indefinitely, blocking re-dispatch of their issues.
+- Cross-reference with Active Workers section. If a worker is running, the PR is NOT orphaned.
+- If updated within 2 hours, skip (give workers time to complete).
+- If already labelled `status:orphaned` and older than 24 hours since flagged, close it.
+- For orphaned PRs: comment explaining the situation, add `status:orphaned` label, relabel the corresponding issue to `status:available` for re-dispatch.
+- NEVER flag PRs with `persistent` label, passing CI + approved reviews, or active workers.
 
-**How to detect orphaned PRs:**
+## Repo Hygiene
 
-For each open PR in the pre-fetched state:
+The pre-fetched state includes a Repo Hygiene section with cleanup candidates that the shell layer couldn't handle automatically (deterministic cleanup already ran).
 
-1. **Check for an active worker.** Use the "Active Workers" section in the pre-fetched state above. Look for a worker process whose command line contains the PR's issue number or branch name. If a worker is running, the PR is NOT orphaned — skip it. If the Active Workers section shows "No active workers", all PRs without recent activity are candidates.
-2. **Check recency.** Parse the PR's `updatedAt` from the pre-fetched state. If the PR was updated within the last 2 hours, it's likely still being worked on (worker may have just exited and the next pulse will evaluate it). Skip it.
-3. **Check for `status:orphaned` label.** If the PR already has this label, it was flagged in a previous pulse. Don't re-comment — but check if it's now older than 24 hours since being flagged. If so, close it.
+- **Orphan worktrees** (0 commits ahead, no PR, no worker): cross-reference with Active Workers. If clean and matches a task pattern, it's likely a crashed worker — flag but do NOT auto-remove. Only the user removes worktrees.
+- **Stale PRs** (failing CI 7+ days, no commits, no worker): close with a comment, relabel linked issue `status:available`.
+- **Uncommitted changes on main**: flag in output for user awareness. Do NOT commit or discard.
+- **Remaining stashes**: note count, take no action.
 
-**What counts as orphaned:** An open PR that has had no updates for 6+ hours AND has no active worker process. The 6-hour threshold matches the existing "stuck PR" heuristic in the PRs section above, but this scanner specifically handles the re-dispatch path.
+## Mission Awareness
 
-**Actions for orphaned PRs:**
+If the pre-fetched state includes an Active Missions section, process each mission. Skip this section entirely if no missions appear.
 
-1. **Comment on the PR** explaining it appears orphaned:
+For each active mission:
 
-```bash
-gh pr comment <number> --repo <slug> --body "This PR appears orphaned — no active worker process found and no activity for 6+ hours. Flagging for re-dispatch. If work is still in progress, remove the \`status:orphaned\` label."
-```
+1. **Check current milestone** — identify the first milestone with status `active`.
+2. **Dispatch undispatched features** — for each `pending` feature in the current milestone with no active worker and no open PR, dispatch it. Use `--session-key "mission-ID-TASK_ID"`. Include lineage context (milestone as parent, features as siblings). Mission dispatches count against MAX_WORKERS.
+3. **Detect milestone completion** — if ALL features in the current milestone are `completed`, set milestone to `validating` and dispatch a validation worker.
+4. **Advance milestones** — if a milestone has status `passed`, activate the next one. If ALL milestones passed, set mission to `completed`.
+5. **Track budget** — if any category exceeds 80%, pause the mission. Do not dispatch more features until the user increases the budget.
+6. **Handle paused/blocked** — skip paused missions. For blocked missions, check if the blocking condition resolved; if so, reactivate.
 
-2. **Add the `status:orphaned` label:**
+Update the mission state file and commit/push after any changes.
 
-```bash
-gh api --silent "repos/<slug>/issues/<number>/labels" -X POST -f 'labels[]=status:orphaned' || true
-```
+## Quality Review Findings
 
-3. **Flag the corresponding issue for re-dispatch.** Find the issue referenced in the PR title (task ID pattern `tNNN:` or `Issue #NNN`). If the issue exists and is labelled `status:in-progress` or `status:in-review`, relabel it to `status:available` so the next dispatch cycle picks it up:
+Each repo has a persistent "Daily Code Quality Review" issue (labels: `quality-review` + `persistent`). The wrapper posts findings from ShellCheck, Qlty, SonarCloud, Codacy, and CodeRabbit.
 
-```bash
-gh issue edit <issue_number> --repo <slug> --add-label "status:available" --remove-label "status:in-progress" --remove-label "status:in-review" 2>/dev/null || true
-gh issue comment <issue_number> --repo <slug> --body "Re-opened for dispatch — PR #<number> appears orphaned (no worker, no activity for 6+ hours). See PR comment for details."
-```
+Check the latest comment on each repo's quality review issue. Triage findings using judgment:
 
-**False positive prevention:**
+- **Create issues for**: security vulnerabilities, bugs, significant code smells
+- **Skip**: style nits, vendored code warnings, SC1091, cosmetic suggestions
+- **Batch related findings** sharing a root cause into a single issue
 
-- NEVER flag a PR as orphaned if a worker process is running for it (even if the PR hasn't been updated recently — the worker may be running tests or waiting for CI)
-- NEVER flag a PR that was updated in the last 2 hours — give workers time to complete
-- NEVER flag a PR that has the `persistent` label
-- NEVER flag a PR that has passing CI and approved reviews — it should be merged, not flagged (handle it in the PRs section above instead)
-- If uncertain whether a PR is truly orphaned, skip it — the next pulse is 2 minutes away
+Dedup before creating (search existing issues). Max 3 issues per repo per cycle. NEVER close the quality review issue itself.
 
-### Repo Hygiene Triage (t1417)
-
-After processing PRs, issues, and orphaned PRs, check the **"Repo Hygiene"** section in the pre-fetched state. This section contains non-deterministic cleanup candidates that the shell layer could not handle automatically — they require your judgment.
-
-The shell layer already handled deterministic cleanup before you started:
-- Worktrees for merged/closed PRs → removed by `worktree-helper.sh clean --auto --force-merged`
-- Stashes whose content is already in HEAD → dropped by `stash-audit-helper.sh auto-clean`
-
-What remains in the hygiene section needs intelligence:
-
-**Orphan worktrees** (0 commits ahead of main, no PR, no active worker):
-
-These are typically branches created by workers that crashed or were killed before producing any commits. However, they could also be:
-- A user's manual experiment they intend to return to
-- A worker that was just dispatched and hasn't committed yet (check Active Workers)
-- A branch with uncommitted work that would be lost if removed
-
-**Assessment approach:**
-1. Cross-reference with Active Workers — if a worker is running on this branch, skip it
-2. Check if the worktree has uncommitted files (noted in the hygiene data as "N uncommitted files") — if dirty, flag but do NOT recommend removal
-3. If the worktree is clean (0 commits, 0 uncommitted files, no PR, no worker) AND the branch name matches a known task pattern (feature/tNNN, bugfix/*, etc.), it's likely a crashed worker — comment on the associated issue if one exists, noting the orphan branch
-4. If uncertain, skip — the next pulse is 2 minutes away
-
-**Do NOT auto-remove orphan worktrees.** Only flag them. The user or a future pulse with more context can decide. Post a comment on the repo's health issue if one exists, listing the orphan worktrees found.
-
-**Stale PRs** (failing CI, no progress):
-
-For each open PR in the pre-fetched state, check:
-- Has CI been failing for 7+ days? (Compare `updatedAt` with current time — if no commits pushed in 7 days and CI is FAIL, it's stale)
-- Is there an active worker? (Check Active Workers section)
-- Is there a `needs-review-fixes` label? (A fix worker may be dispatched)
-
-If a PR has been failing CI for 7+ days with no new commits and no active worker:
-1. Close the PR with a comment explaining why:
+## Record and Exit
 
 ```bash
-gh pr close <number> --repo <slug> --comment "Closing — CI has been failing for 7+ days with no new commits or active worker. The linked issue will be relabelled for re-dispatch. If this work is still viable, reopen the PR and push fixes."
-```
-
-2. Relabel the linked issue to `status:available` for re-dispatch
-3. Log the closure in your output
-
-**Uncommitted changes on main:**
-
-If the hygiene data shows uncommitted files on a repo's main branch, this is unusual — main should always be clean. Possible causes:
-- A stash pop that failed (conflict left working tree dirty)
-- Manual edits the user forgot to commit
-- A script that modified files without committing
-
-**Do NOT commit or discard these changes.** Flag them in your output so the user is aware. Example: "aidevops: 2 uncommitted files on main (loop-common.sh, worktree-helper.sh) — likely from a failed stash pop. Manual resolution needed."
-
-**Remaining stashes:**
-
-If the hygiene data shows stashes remaining after auto-clean, these contain changes NOT in HEAD (the safe ones were already dropped). Note the count in your output but take no action — stash management beyond safe-to-drop requires user judgment.
-
-## Step 3.5: Mission Awareness
-
-If the pre-fetched state includes an "Active Missions" section, process each mission. Missions are autonomous multi-day projects with milestones and features — see `workflows/mission-orchestrator.md` for the full orchestrator spec. The pulse's job is lightweight: check status, dispatch undispatched features, detect milestone completion, and advance state. Heavy reasoning (re-planning, validation design) is the orchestrator's job — the pulse just keeps the pipeline moving.
-
-**Skip this step entirely if no "Active Missions" section appears in the pre-fetched state.**
-
-### For each active mission
-
-Read the mission state file path from the pre-fetched summary. For each mission with `status: active`:
-
-#### 1. Check current milestone status
-
-The pre-fetched summary shows each milestone's status and each feature's status. Identify the current milestone (the first one with status `active`).
-
-#### 2. Dispatch undispatched features
-
-For each feature in the current milestone with status `pending`:
-
-- Check if a worker is already running for its task ID (`ps axo command | grep '{task_id}'`)
-- Check if an open PR already exists for it
-- If neither, dispatch it as a regular worker:
-
-```bash
-# Full mode — standard worktree + PR workflow
-~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-  --role worker \
-  --session-key "mission-<mission_id>-<task_id>" \
-  --dir <repo_path> \
-  --title "Mission <mission_id> - <feature_title>" \
-  --prompt "/full-loop Implement <task_id> -- <feature_description>. Mission context: <mission_goal>. Milestone: <milestone_name>." &
-sleep 2
-```
-
-```bash
-# POC mode — commit directly, skip ceremony
-~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-  --role worker \
-  --session-key "mission-<mission_id>-<feature_title>" \
-  --dir <repo_path> \
-  --title "Mission <mission_id> - <feature_title>" \
-  --prompt "/full-loop --poc <feature_description>. Mission context: <mission_goal>." &
-sleep 2
-```
-
-- **Lineage context for mission features (t1408.3):** When dispatching mission features that are part of a milestone with multiple features, include lineage context so each worker knows what sibling features exist. The milestone is the "parent" and features are "siblings":
-
-  ```bash
-  # Mission dispatch with lineage — milestone as parent, features as siblings
-  ~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-    --role worker \
-    --session-key "mission-<mission_id>-<task_id>" \
-    --dir <repo_path> \
-    --title "Mission <mission_id> - <feature_title>" \
-    --prompt "/full-loop Implement <task_id> -- <feature_description>. Mission context: <mission_goal>.
-
-  TASK LINEAGE:
-    0. [milestone] <milestone_name>: <milestone_description> (mission:<mission_id>)
-      1. <feature_1_title> (<feature_1_task_id>)
-      2. <feature_2_title> (<feature_2_task_id>)  <-- THIS TASK
-      3. <feature_3_title> (<feature_3_task_id>)
-
-  LINEAGE RULES:
-  - You are one of several agents working in parallel on sibling features within the same milestone.
-  - Focus ONLY on your specific feature (marked with '<-- THIS TASK').
-  - Do NOT duplicate work that sibling features would handle.
-  - If your feature depends on interfaces or APIs from sibling features, define reasonable stubs.
-  - If blocked by a sibling feature, exit with BLOCKED and specify which sibling." &
-  sleep 2
-  ```
-
-- Update the feature status to `dispatched` in the mission state file
-- Mission feature dispatches count against the same `MAX_WORKERS` limit as regular dispatches
-- Respect the mission's `max_parallel_workers` setting if present (default: same as `MAX_WORKERS`)
-
-#### 3. Detect milestone completion
-
-If ALL features in the current milestone have status `completed` (merged PRs exist for Full mode, or commits landed for POC mode):
-
-- Set the milestone status to `validating` in the mission state file
-- Dispatch a validation worker using the milestone's validation criteria:
-
-```bash
-~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
-  --role worker \
-  --session-key "mission-<mission_id>-validate-<N>" \
-  --dir <repo_path> \
-  --title "Mission <mission_id> - Validate Milestone <N>" \
-  --prompt "/full-loop Validate milestone <N> of mission <mission_id>. Validation criteria: <criteria>. Run tests, check build, verify integration. Update mission state file at <path> with pass/fail result." &
-sleep 2
-```
-
-#### 4. Advance milestones
-
-If a milestone has status `passed`:
-
-- Set the next milestone to `active`
-- Commit and push the mission state file update
-- The next pulse cycle will dispatch that milestone's features
-
-If ALL milestones have status `passed`:
-
-- Set mission status to `completed` with completion date
-- Commit and push the state file
-- Log: "Mission {id} completed"
-
-#### 5. Track budget spend
-
-After updating feature statuses, check the mission's budget tracking section. If any category exceeds the alert threshold (default 80%):
-
-- Set mission status to `paused`
-- Log: "Mission {id} paused — {category} budget at {pct}%"
-- Do NOT dispatch more features for this mission until the user increases the budget or resumes
-
-#### 6. Handle paused/blocked missions
-
-- **`paused`**: Skip — do not dispatch features. Log that it's paused.
-- **`blocked`**: Check if the blocking condition is resolved (external dependency available, credential configured). If resolved, set status to `active` and proceed. If not, skip.
-- **`validating`**: Check if the validation worker has completed. If validation passed, advance. If failed, create fix tasks in the current milestone and set milestone back to `active`.
-
-### Mission features as TODO entries
-
-In Full mode, mission features are regular TODO entries tagged with `mission:mNNN` (where `mNNN` is the mission ID). This means:
-
-- They appear in `gh issue list` like any other task
-- They follow the standard label lifecycle (`available` → `queued` → `in-progress` → `done`)
-- The `mission:mNNN` tag lets the pulse correlate features back to their mission
-- Issue sync works normally — CI creates GitHub issues when TODO.md is pushed to main
-
-In POC mode, features are tracked only in the mission state file (no TODO entries, no GitHub issues). The pulse dispatches them directly from the state file.
-
-### Mission state file updates
-
-When the pulse modifies a mission state file (feature status, milestone status, mission status), commit and push immediately:
-
-```bash
-git -C <repo_path> add <mission_state_file>
-git -C <repo_path> commit -m "chore: pulse update mission <mission_id> state [skip ci]"
-git -C <repo_path> push
-```
-
-This ensures the next pulse cycle (and any concurrent sessions) see the updated state.
-
-## Step 3.7: Act on Quality Review Findings
-
-Each pulse-enabled repo has a persistent "Daily Code Quality Review" issue (labels: `quality-review` + `persistent`). The `pulse-wrapper.sh` daily sweep posts findings from ShellCheck, Qlty, SonarCloud, Codacy, and CodeRabbit as comments on these issues.
-
-**Check for new findings once per pulse.** For each repo, read the latest comment on the quality review issue:
-
-```bash
-# Get the quality review issue number (cached by the sweep)
-QUALITY_ISSUE=$(gh issue list --repo <slug> --label "quality-review" --label "persistent" --state open --json number --jq '.[0].number' 2>/dev/null)
-
-# Read the latest comment
-LATEST_COMMENT=$(gh api "repos/<slug>/issues/${QUALITY_ISSUE}/comments" --jq '.[-1].body' 2>/dev/null)
-```
-
-**Triage findings using judgment.** Read the comment and decide which findings are worth creating issues for. Not every finding warrants action — use these guidelines:
-
-- **Create an issue** for: security vulnerabilities, bugs, errors (ShellCheck errors, SonarCloud bugs/vulnerabilities), significant code smells that affect maintainability
-- **Skip** (don't create issues for): style nits, informational warnings in vendored/third-party code, SC1091 (source not found — these are expected for sourced scripts), findings in archived directories, CodeRabbit suggestions that are purely cosmetic
-- **Batch related findings** into a single issue when they share a root cause (e.g., "10 scripts missing `local` for variables" = 1 issue, not 10)
-
-**Create issues for actionable findings:**
-
-```bash
-gh issue create --repo <slug> \
-  --title "quality: <concise description of the finding>" \
-  --label "auto-dispatch" \
-  --body "Found by daily quality sweep on <date>.
-
-**Source**: <tool name> (ShellCheck/Qlty/SonarCloud/Codacy/CodeRabbit)
-**Severity**: <high/medium/low>
-**Files affected**: <list>
-
-**Finding**: <description>
-
-**Recommended fix**: <what to do>
-
-Ref: quality review issue #${QUALITY_ISSUE}"
-```
-
-**Dedup rule (Hard Rule 9 applies):** Before creating, search for existing issues: `gh issue list --repo <slug> --search "quality: <description>" --state open`. If a similar issue exists, skip it.
-
-**Rate limit:** Create at most 3 issues per repo per pulse cycle from quality findings. The sweep runs daily — there's no rush. Prioritise high-severity findings.
-
-**NEVER close the quality review issue itself** — it has the `persistent` label (Hard Rule from Step 3).
-
-## Step 4: Record and Exit
-
-```bash
-# Record success/failure for circuit breaker
-~/.aidevops/agents/scripts/circuit-breaker-helper.sh record-success  # or record-failure
-
-# Session miner (has its own 20h interval guard — usually a no-op)
+~/.aidevops/agents/scripts/circuit-breaker-helper.sh record-success
 ~/.aidevops/agents/scripts/session-miner-pulse.sh 2>&1 || true
-
-# Optional: auto-file model-agnostic self-improvement issues from high-signal
-# common+outlier lanes (dedup + cap guarded in script)
-SESSION_MINER_AUTO_ISSUES=1 SESSION_MINER_MAX_ISSUES=3 \
-  ~/.aidevops/agents/scripts/session-miner-pulse.sh --force --create-issues 2>&1 || true
 ```
 
-Output a brief summary of what you did (past tense), then exit.
+## Hard Rules
 
-## Hard Rules (the few that matter)
-
-1. **NEVER modify closed issues.** Check state before any label/comment change. If state is not `OPEN`, skip it.
-2. **NEVER dispatch for closed issues.** Verify with `gh issue view` if uncertain.
-3. **NEVER close an issue without a comment.** The comment must explain why and link to the PR(s) or evidence. Silent closes are audit failures.
-4. **NEVER use `claude` CLI.** Always `opencode run`.
-5. **NEVER include private repo names** in public issue titles/bodies/comments.
-6. **NEVER exceed MAX_WORKERS or violate priority-class reservations.** Count before dispatching. Check class allocations (Step 1) — tooling workers must not consume product-reserved slots when product work is pending.
-7. **Do your job completely, then exit.** Don't loop or re-analyze — one pass through all repos, act on everything, exit.
-8. **NEVER create "pulse summary" or "supervisor log" issues.** The pulse runs every 2 minutes — creating an issue per cycle produces hundreds of spam issues per day. Your output text IS the log (it's captured by the wrapper to `~/.aidevops/logs/pulse.log`). The audit trail lives in PR/issue comments on the items you acted on, not in separate summary issues.
-9. **NEVER create an issue if one already exists for the same task ID.** Before `gh issue create`, check `gh issue list --repo <slug> --search "tNNN" --state all` to see if an issue with that task ID prefix already exists. If it does (open or closed), use the existing one — don't create a duplicate. This applies to both issue-sync-helper and manual issue creation.
-10. **NEVER ask the user anything.** You are headless. Decide and act.
-11. **NEVER close or modify issues with the `supervisor` or `contributor` label.** These are health dashboard issues managed by `pulse-wrapper.sh` — one per runner per repo. Maintainers get `[Supervisor:user]` issues (pinned); non-maintainers get `[Contributor:user]` issues (not pinned). The wrapper handles dedup (closing old ones when creating new ones). If you close them, the wrapper creates replacements on the next cycle, producing churn. Similarly, NEVER create new `[Supervisor:*]` or `[Contributor:*]` issues — the wrapper creates and updates them automatically. Your job is to act on task/PR issues, not manage health dashboard infrastructure.
-12. **NEVER auto-merge PRs from external contributors or when the permission check fails.** Check author permission via `gh api -i repos/<slug>/collaborators/<author>/permission` before ANY merge — use `-i` to capture the HTTP status code. Only HTTP 200 with `admin`, `maintain`, or `write` permission = maintainer. HTTP 200 with `read`/`none`, or HTTP 404 = external contributor — call `check_external_contributor_pr` from `pulse-wrapper.sh`. Any other HTTP status (403/429/5xx) or network failure = fail closed — call `check_permission_failure_pr` from `pulse-wrapper.sh`. NEVER write inline idempotency checks — always use the helper functions. See "External contributor gate" in Step 3.
+1. NEVER modify or dispatch for closed issues. Check state first.
+2. NEVER close an issue without a comment explaining why and linking evidence.
+3. NEVER use `claude` CLI. Always dispatch via `headless-runtime-helper.sh run`.
+4. NEVER include private repo names in public issue titles/bodies/comments.
+5. NEVER exceed MAX_WORKERS. Count before dispatching.
+6. One pass through all repos, act on everything, then exit. Don't loop.
+7. NEVER create "pulse summary" or "supervisor log" issues. Your output IS the log.
+8. NEVER create duplicate issues. Search before creating: `gh issue list --search "tNNN" --state all`.
+9. NEVER ask the user anything. You are headless. Decide and act.
+10. NEVER close or modify `supervisor` or `contributor` labelled issues. The wrapper manages these.
+11. NEVER auto-merge external contributor PRs or when the permission check fails. Use helper functions from `pulse-wrapper.sh`.


### PR DESCRIPTION
## Summary

- Reduce pulse.md from 1,399 to 354 lines (75% reduction) by removing duplicated bash, conflicting instructions, and deterministic logic that constrains intelligence
- Resolve 2 conflicting instruction pairs (priority-class enforcement, dispatch CLI identity)
- Eliminate 6 duplicate dispatch command templates, keeping only the one in the dispatch-first header

## Problem

pulse.md accumulated to 1,399 lines over time. It contained:
- **~500 lines of duplicated bash** — the same dispatch command template appeared 6 times, the lineage context block was duplicated verbatim, dedup guards were stated 3 times
- **~150 lines duplicating automate.md** — audit trail templates, model escalation tiers, worker monitoring guidance already in the Automate agent prompt
- **Conflicting instructions** — priority-class reservations described as both "enforced" (Hard Rule 6) and "soft optimization targets" (dispatch rules); Hard Rule 4 said "always `opencode run`" while dispatch rules said "NEVER raw `opencode run`"
- **Fragile deterministic logic** — 60 lines of `batch-strategy-helper.sh` invocation, 74 lines of bash for comment-based approval label manipulation, 50 lines of external contributor gate bash (already in `pulse-wrapper.sh` helper functions)

Step 3 alone was 1,190 lines — an LLM agent processing this loses early context by the time it reaches later sections.

## What Changed

**Removed:**
- 6 duplicate dispatch code blocks → show template once in header, reference elsewhere
- Duplicate lineage blocks → reference `headless-dispatch.md`
- Content already in `automate.md` (audit templates, model escalation, worker monitoring)
- Deterministic bash for label manipulation (agent can figure out `gh issue edit`)
- Batch execution strategy section (60 lines of fragile determinism)
- Steps 0/1/2 duplicated from the dispatch-first header
- Hard Rules expanded to multi-paragraph restatements

**Kept (all concepts preserved):**
- Dispatch-first header (steps 1-5, self-contained)
- All triage guidance (priority order, PR merge gates, issue lifecycle)
- All edge-case concepts (systemic CI detection, PR salvage, orphaned PRs, quality-debt worktree dispatch)
- Mission awareness lifecycle
- Hard Rules as single-sentence constraints

**Conflicts resolved:**
- Priority-class: "enforced with exemptions" (not contradictory "enforced" + "soft")
- Dispatch CLI: consistently "headless-runtime-helper.sh run" throughout

## Design Principle

The pulse is a high-level triage agent. It reads pre-fetched state, makes judgment calls about priority, and dispatches workers. It should contain:
- **What to look for** and **why** (triage guidance)
- **Priority ordering** (which work is highest-value)
- **Guard rails** (what NOT to do)

It should NOT contain:
- Deterministic bash scripts (those belong in helper scripts)
- Dispatch mechanics (already in `automate.md`)
- Repeated code blocks
- Fragile if/then rules that constrain intelligence