### PR TITLE
fix: update Quick Reference config path to OpenCode in context7.md (GH#3468)

### DIFF
--- a/.agents/tools/context/context7.md
+++ b/.agents/tools/context/context7.md
@@ -49,7 +49,7 @@ npx ctx7 skills install /anthropics/skills pdf  # Install a skill
 
 Skills found in the Context7 registry can be imported into aidevops using `/add-skill`. See "Skill Discovery and Import" section below.
 
-**Config Location**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Config Location**: `~/.config/opencode/opencode.json`
 <!-- AI-CONTEXT-END -->
 
 Context7 MCP provides AI assistants with real-time access to the latest documentation for thousands of development tools, frameworks, and libraries.


### PR DESCRIPTION
## Summary

- Updates the Quick Reference `Config Location` in `.agents/tools/context/context7.md` from the Claude Desktop path to the OpenCode path (`~/.config/opencode/opencode.json`)
- Resolves the inconsistency flagged in PR #412 review by CodeRabbit where the prerequisite recommended OpenCode but the Quick Reference still pointed to the Claude Desktop config path

## Changes

Single-line fix in the Quick Reference block (line 52):

```diff
-**Config Location**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**Config Location**: `~/.config/opencode/opencode.json`
```

## Notes

- The "For Claude Desktop" setup section (lines 120–133) is retained intentionally as an MCP config format reference, consistent with PR #412's stated intent to keep "MCP config reference sections in deployment.md (useful for MCP developers)". The guarding note at line 112 makes this intent clear.
- markdownlint passes with no errors.

Closes #3468