### PR TITLE
bugfix/3437: Address quality-debt in define.md from PR #2183

### DIFF
--- a/.agents/scripts/commands/define.md
+++ b/.agents/scripts/commands/define.md
@@ -91,7 +91,7 @@ How will you know this is done? Pick the verification approach:
 **Type-specific questions** — load from `reference/define-probes/{type}.md`:
 
 ```bash
-probe_file="$HOME/.aidevops/agents/reference/define-probes/${task_type}.md"
+probe_file=".agents/reference/define-probes/${task_type}.md"
 ```
 
 Read the probe file for the classified type and ask 1-2 additional questions from it.
@@ -127,7 +127,7 @@ Read `templates/brief-template.md` and populate every section from interview ans
 
 ```bash
 # Read the template
-cat ~/.aidevops/agents/reference/../templates/brief-template.md
+cat templates/brief-template.md
 ```
 
 Map interview answers to brief sections:


### PR DESCRIPTION
## Summary

- Addresses medium priority quality-debt review feedback from PR #2183
- Fixes two hardcoded absolute path references in `.agents/scripts/commands/define.md`
- All markdownlint checks pass after fixes (0 errors)

## Changes

**Line 94** — `probe_file` bash variable: replaced `$HOME/.aidevops/agents/reference/define-probes/${task_type}.md` with relative path `.agents/reference/define-probes/${task_type}.md` for portability

**Line 130** — template cat command: replaced `~/.aidevops/agents/reference/../templates/brief-template.md` (absolute + redundant `reference/../`) with simple `cat templates/brief-template.md`, consistent with relative path usage on lines 12 and 126

Closes #3437