### PR TITLE
fix(t3464): address quality-debt review feedback in resources.md

### DIFF
--- a/.agents/aidevops/resources.md
+++ b/.agents/aidevops/resources.md
@@ -40,12 +40,12 @@ tools:
 
 ### Deployment & Orchestration
 
-- **Coolify API**: https://coolify.io/.agents/api
+- **Coolify API**: https://coolify.io/docs/api-reference
 - **Coolify GitHub**: https://github.com/coollabsio/coolify
 
 ### Content Management
 
-- **MainWP API**: https://mainwp.com/help/.agents/mainwp-rest-api/
+- **MainWP API**: https://mainwp.com/help/mainwp-rest-api/
 - **MainWP Extensions**: https://mainwp.com/extensions/
 
 ### Security & Secrets
@@ -105,19 +105,19 @@ tools:
 ### CLI Tools
 
 - **jq (JSON processor)**: https://jqlang.github.io/jq/
-- **curl (HTTP client)**: https://curl.se/.agents/
+- **curl (HTTP client)**: https://curl.se/docs/
 - **git (Version control)**: https://git-scm.com/docs
 - **Bitwarden CLI**: https://bitwarden.com/help/cli/
 
 ### Package Managers
 
 - **Homebrew (macOS)**: https://brew.sh/
-- **APT (Ubuntu/Debian)**: https://ubuntu.com/server/.agents/package-management
+- **APT (Ubuntu/Debian)**: https://ubuntu.com/server/docs/package-management
 - **npm (Node.js)**: https://docs.npmjs.com/
 
 ### Security Tools
 
-- **OpenSSL**: https://www.openssl.org/.agents/
+- **OpenSSL**: https://www.openssl.org/docs/
 - **GPG**: https://gnupg.org/documentation/
 - **SSH**: https://www.openssh.com/manual.html
 
@@ -145,8 +145,8 @@ tools:
 
 ### Monitoring Tools
 
-- **Prometheus**: https://prometheus.io/.agents/
-- **Grafana**: https://grafana.com/.agents/
+- **Prometheus**: https://prometheus.io/docs/
+- **Grafana**: https://grafana.com/docs/
 - **Uptime Robot**: https://uptimerobot.com/api/
 
 ### Log Management
@@ -171,7 +171,7 @@ tools:
 
 ### Container Orchestration
 
-- **Kubernetes**: https://kubernetes.io/.agents/
+- **Kubernetes**: https://kubernetes.io/docs/
 - **Docker Compose**: https://docs.docker.com/compose/
 - **Portainer**: https://docs.portainer.io/
 


### PR DESCRIPTION
## Summary

- Fix all 8 corrupted URLs in `.agents/aidevops/resources.md` identified in PR #396 review feedback
- URLs were incorrectly modified by a prior search-and-replace that inserted `/.agents/` path segments into external documentation links
- Restore correct documentation paths for: Coolify API, MainWP API, curl docs, APT docs, OpenSSL docs, Prometheus docs, Grafana docs, and Kubernetes docs

## Fixes applied

| Line | Before | After |
|------|--------|-------|
| 43 | `https://coolify.io/.agents/api` | `https://coolify.io/docs/api-reference` |
| 48 | `https://mainwp.com/help/.agents/mainwp-rest-api/` | `https://mainwp.com/help/mainwp-rest-api/` |
| 108 | `https://curl.se/.agents/` | `https://curl.se/docs/` |
| 115 | `https://ubuntu.com/server/.agents/package-management` | `https://ubuntu.com/server/docs/package-management` |
| 120 | `https://www.openssl.org/.agents/` | `https://www.openssl.org/docs/` |
| 148 | `https://prometheus.io/.agents/` | `https://prometheus.io/docs/` |
| 149 | `https://grafana.com/.agents/` | `https://grafana.com/docs/` |
| 174 | `https://kubernetes.io/.agents/` | `https://kubernetes.io/docs/` |

Closes #3464