### PR TITLE
fix(t3448): address quality-debt in test-dispatch-claude-cli.sh

### DIFF
--- a/tests/test-dispatch-claude-cli.sh
+++ b/tests/test-dispatch-claude-cli.sh
@@ -1271,7 +1271,7 @@ else
 fi
 
 # ============================================================
-# SECTION 11: Worker MCP Config Generation (t1162)
+# SECTION 12: Worker MCP Config Generation (t1162)
 # ============================================================
 section "Worker MCP Config Generation (t1162)"
 


### PR DESCRIPTION
Closes #3448

## Summary
- Fixed duplicate SECTION 11 header — renamed the second occurrence to SECTION 12 (Worker MCP Config Generation, t1162), making all 12 sections uniquely numbered
- Confirmed `/tmp/test-mcp-config.json` was already replaced with `$TEST_DIR/test-mcp-config.json` for test isolation (lines 1371, 1423)
- Confirmed `command -v jq >/dev/null 2>&1` prerequisite guard was already in place at line 1279, ensuring graceful skip when jq is unavailable
- Shellcheck passes with zero violations