### PR TITLE
fix(#3383): replace ps+grep with pgrep -af in dispatch-dedup-helper.sh

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -126,9 +126,8 @@ normalize_title() {
 list_running_keys() {
 	local worker_procs
 	# Get full command lines of running worker processes
-	# macOS ps -eo pid,args works; Linux ps -eo pid,args works too
-	# shellcheck disable=SC2009  # Need ps+grep for full cmdline; pgrep can't return args
-	worker_procs=$(ps -eo pid,args 2>/dev/null | grep -E '/full-loop|opencode run|claude.*run' | grep -v grep || true)
+	# pgrep -af matches against the full command line and excludes itself from results
+	worker_procs=$(pgrep -af '/full-loop|opencode run|claude.*run' || true)
 
 	if [[ -z "$worker_procs" ]]; then
 		return 0

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -85,7 +85,7 @@ extract_keys() {
 
 	# Pattern 4: Branch-style "issue-NNN-" or "pr-NNN-" (from worktree names)
 	local branch_issue_nums
-	branch_issue_nums=$(printf '%s' "$lower_title" | grep -oE 'issue-([0-9]+)' | grep -oE '[0-9]+' || true)
+	branch_issue_nums=$(printf '%s' "$lower_title" | grep -oP 'issue-\K[0-9]+' || true)
 	if [[ -n "$branch_issue_nums" ]]; then
 		while IFS= read -r num; do
 			[[ -n "$num" ]] && keys+=("issue-${num}")

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -84,10 +84,11 @@ extract_keys() {
 	fi
 
 	# Pattern 4: Branch-style "issue-NNN-" or "pr-NNN-" (from worktree names)
+	# Use a portable fallback chain: rg (ripgrep) → ggrep -P (GNU grep on macOS) → grep -E
 	local branch_issue_nums
 	if command -v rg &>/dev/null; then
 		branch_issue_nums=$(printf '%s' "$lower_title" | rg -o 'issue-([0-9]+)' | grep -oE '[0-9]+' || true)
-	elif command -v ggrep &>/dev/null; then
+	elif command -v ggrep &>/dev/null && ggrep -P '' /dev/null 2>/dev/null; then
 		branch_issue_nums=$(printf '%s' "$lower_title" | ggrep -oP 'issue-\K[0-9]+' || true)
 	else
 		branch_issue_nums=$(printf '%s' "$lower_title" | grep -oE 'issue-([0-9]+)' | grep -oE '[0-9]+' || true)
@@ -130,44 +131,32 @@ normalize_title() {
 # Returns: one "pid|key" pair per line on stdout
 #######################################
 list_running_keys() {
-	local worker_procs
-	local worker_pids
-	local worker_pattern='/full-loop|opencode run|claude.*run'
+	# Get PIDs of running worker processes using portable pgrep -f (no -a flag).
+	# pgrep -f matches against the full command line on both Linux and macOS.
+	# We then resolve the full command line per PID via ps -p <pid> -o args=
+	# which is POSIX-compatible and works on Linux, macOS, and BSD.
+	local worker_pids=""
+	worker_pids=$(pgrep -f '/full-loop|opencode run|claude.*run' || true)
 
-	# Get matching worker PIDs from the full command line, then read command per PID
-	worker_pids=$(pgrep -f "$worker_pattern" || true)
 	if [[ -z "$worker_pids" ]]; then
 		return 0
 	fi
 
 	while IFS= read -r pid; do
 		[[ -z "$pid" ]] && continue
-		local cmdline
+		local cmdline=""
+		# ps -p <pid> -o args= prints only the command line (no header, no PID prefix)
 		cmdline=$(ps -p "$pid" -o args= 2>/dev/null || true)
 		[[ -z "$cmdline" ]] && continue
-		worker_procs+="${pid} ${cmdline}"
-		worker_procs+=$'\n'
-	done <<<"$worker_pids"
 
-	if [[ -z "$worker_procs" ]]; then
-		return 0
-	fi
-
-	while IFS= read -r proc_line; do
-		[[ -z "$proc_line" ]] && continue
-		local pid
-		pid=$(printf '%s' "$proc_line" | awk '{print $1}')
-		local cmdline
-		cmdline=$(printf '%s' "$proc_line" | sed 's/^[[:space:]]*[0-9]*[[:space:]]*//')
-
-		local keys
-		keys=$(extract_keys "$cmdline")
-		if [[ -n "$keys" ]]; then
+		local extracted_keys=""
+		extracted_keys=$(extract_keys "$cmdline")
+		if [[ -n "$extracted_keys" ]]; then
 			while IFS= read -r key; do
 				[[ -n "$key" ]] && printf '%s|%s\n' "$pid" "$key"
-			done <<<"$keys"
+			done <<<"$extracted_keys"
 		fi
-	done <<<"$worker_procs"
+	done <<<"$worker_pids"
 
 	return 0
 }

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -85,7 +85,13 @@ extract_keys() {
 
 	# Pattern 4: Branch-style "issue-NNN-" or "pr-NNN-" (from worktree names)
 	local branch_issue_nums
-	branch_issue_nums=$(printf '%s' "$lower_title" | grep -oP 'issue-\K[0-9]+' || true)
+	if command -v rg &>/dev/null; then
+		branch_issue_nums=$(printf '%s' "$lower_title" | rg -o 'issue-([0-9]+)' | grep -oE '[0-9]+' || true)
+	elif command -v ggrep &>/dev/null; then
+		branch_issue_nums=$(printf '%s' "$lower_title" | ggrep -oP 'issue-\K[0-9]+' || true)
+	else
+		branch_issue_nums=$(printf '%s' "$lower_title" | grep -oE 'issue-([0-9]+)' | grep -oE '[0-9]+' || true)
+	fi
 	if [[ -n "$branch_issue_nums" ]]; then
 		while IFS= read -r num; do
 			[[ -n "$num" ]] && keys+=("issue-${num}")
@@ -125,9 +131,23 @@ normalize_title() {
 #######################################
 list_running_keys() {
 	local worker_procs
-	# Get full command lines of running worker processes
-	# pgrep -af matches against the full command line and excludes itself from results
-	worker_procs=$(pgrep -af '/full-loop|opencode run|claude.*run' || true)
+	local worker_pids
+	local worker_pattern='/full-loop|opencode run|claude.*run'
+
+	# Get matching worker PIDs from the full command line, then read command per PID
+	worker_pids=$(pgrep -f "$worker_pattern" || true)
+	if [[ -z "$worker_pids" ]]; then
+		return 0
+	fi
+
+	while IFS= read -r pid; do
+		[[ -z "$pid" ]] && continue
+		local cmdline
+		cmdline=$(ps -p "$pid" -o args= 2>/dev/null || true)
+		[[ -z "$cmdline" ]] && continue
+		worker_procs+="${pid} ${cmdline}"
+		worker_procs+=$'\n'
+	done <<<"$worker_pids"
 
 	if [[ -z "$worker_procs" ]]; then
 		return 0


### PR DESCRIPTION
## Summary

- Replaces the fragile `ps -eo pid,args | grep ... | grep -v grep` pattern in `list_running_keys()` with `pgrep -af`, which matches against the full command line and automatically excludes its own process from results.
- Removes the `# shellcheck disable=SC2009` suppression comment that was needed to silence the SC2009 warning about ps+grep usage.
- No functional change — `pgrep -af` produces the same `PID args` output format, so the downstream `awk`/`sed` parsing is unaffected.

## Testing

- `shellcheck .agents/scripts/dispatch-dedup-helper.sh` passes clean (no warnings).

## References

- Closes #3383
- Addresses gemini-code-assist review feedback on PR #2389 (line 131 finding)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal script behavior for more robust and portable process discovery and pattern matching.
  * Enhanced per-process key extraction and handling to reduce false positives when identifying running workers.
  * Added clearer in-script documentation and control flow refinements to make maintenance and troubleshooting easier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->