### PR TITLE
fix(t3423): runner-helper.sh — address medium quality-debt from PR #2231 review

### DIFF
--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -560,21 +560,21 @@ cmd_run() {
 		claude_model=$(model_for_claude_cli "$model")
 		cmd_args+=("--model" "$claude_model")
 
-		# Output format (Claude CLI supports --output-format)
-		if [[ -n "$format" ]]; then
-			cmd_args+=("--output-format" "$format")
-		else
-			cmd_args+=("--output-format" "text")
-		fi
+		# Output format (Claude CLI only accepts: text, json, stream-json)
+		# Normalize format to a Claude-valid value; default to text for
+		# OpenCode-only values (e.g. "terminal") that would fail at runtime.
+		local claude_format
+		case "${format:-text}" in
+		text | json | stream-json) claude_format="${format:-text}" ;;
+		*) claude_format="text" ;;
+		esac
+		cmd_args+=("--output-format" "$claude_format")
 
 		# Continue previous session if requested
 		if [[ "$continue_session" == "true" ]]; then
-			local session_id=""
-			if [[ -f "$dir/session.id" ]]; then
-				session_id=$(cat "$dir/session.id")
-			fi
-			if [[ -n "$session_id" ]]; then
-				cmd_args+=("--resume" "$session_id")
+			local session_file="$dir/session.id"
+			if [[ -s "$session_file" ]]; then
+				cmd_args+=("--resume" "$(cat "$session_file")")
 			else
 				log_warn "No previous session found for $name, starting fresh"
 			fi


### PR DESCRIPTION
## Summary

Addresses all 3 medium-severity review findings from PR #2231 on `.agents/scripts/runner-helper.sh`.

Closes #3423

## Findings fixed

### 1. Format normalization for Claude CLI backend (line 566, human/augmentcode finding)

The `--output-format` flag on the `claude` CLI only accepts `text`, `json`, or `stream-json`. The `format` variable is shared with the OpenCode path which accepts additional values (e.g. `terminal`). Passing an OpenCode-only value to the `claude` backend would silently fail at runtime.

**Fix**: Added a `case` statement that validates `format` against the allowed Claude CLI values and falls back to `text` for any unrecognised value.

### 2. Simplified output-format if/else (line 569, gemini finding)

Replaced the 5-line `if [[ -n "$format" ]]; then ... else ... fi` block with a single `cmd_args+=(\"--output-format\" \"$claude_format\")` after the normalization case statement, using `${format:-text}` parameter expansion for the default.

### 3. Simplified session continuation block (line 582, gemini finding)

Replaced the two-step `[[ -f session.id ]]` + read + `[[ -n $session_id ]]` pattern with a single `-s` test (`[[ -s "$session_file" ]]`), which checks both file existence and non-emptiness in one condition — as suggested in the review.

## Verification

```
shellcheck .agents/scripts/runner-helper.sh
# → Only pre-existing SC1091 info (external source not followed) — no new errors or warnings
```