### PR TITLE
t3399: fix session-miner/compress.py quality-debt from PR #2313 review

### DIFF
--- a/.agents/scripts/session-miner/compress.py
+++ b/.agents/scripts/session-miner/compress.py
@@ -41,8 +41,9 @@ def strip_file_content(text: str) -> str:
     # Remove <file>...</file> blocks
     text = re.sub(r'<file>.*?</file>', '[file content]', text, flags=re.DOTALL)
     
-    # Remove diff blocks
-    text = re.sub(r'diff --git.*?(?=\n[^\n+-@]|\Z)', '[diff]', text, flags=re.DOTALL)
+    # Remove diff blocks — match from "diff --git" to the next "diff --git" header
+    # or end of string, capturing the full block (index line, ---, +++, @@ hunks, etc.)
+    text = re.sub(r'diff --git .*?(?=\ndiff --git |\Z)', '[diff]', text, flags=re.DOTALL)
     
     # Remove lines that are clearly file content (numbered lines like "00001| ...")
     text = re.sub(r'\n\d{5}\|.*', '', text)
@@ -286,7 +287,10 @@ def main():
     stats_file = CHUNKS_DIR / "stats.json"
     stats = {}
     if stats_file.exists():
-        stats = json.loads(stats_file.read_text(encoding="utf-8")).get("data", {})
+        try:
+            stats = json.loads(stats_file.read_text(encoding="utf-8")).get("data", {})
+        except json.JSONDecodeError:
+            print(f"Warning: Could not parse {stats_file}, skipping stats.", file=sys.stderr)
 
     output = {
         "steerage": steerage,


### PR DESCRIPTION
## Summary

Addresses two medium-priority findings from the PR #2313 code review that were left unactioned.

- **Fix 1 (line 289):** Wrap `stats.json` read in `try/except json.JSONDecodeError` — empty or malformed file previously caused an unhandled crash; now prints a warning and continues with an empty stats dict, consistent with how other chunk files are handled.
- **Fix 2 (line 45):** Replace the diff-stripping regex `diff --git.*?(?=\n[^\n+-@]|\Z)` with `diff --git .*?(?=\ndiff --git |\Z)`. The old lookahead stopped at the first non-`+`/`-`/`@` line (typically `index abc..def 100644`), leaving the entire diff body intact and defeating the intended size reduction. The new pattern matches from `diff --git` to the next `diff --git` header or end of string, capturing the full block.

## Testing

- Python syntax verified: `ast.parse()` passes
- Regex functional test: two-block diff input → both blocks replaced with `[diff]`, zero `diff --git` remaining in output

Closes #3399