### PR TITLE
t3354: fix redundant 2>/dev/null in localdev-helper.sh grep

### DIFF
--- a/.agents/scripts/localdev-helper.sh
+++ b/.agents/scripts/localdev-helper.sh
@@ -222,7 +222,7 @@ migrate_dynamic_yml() {
 	print_info "Backed up dynamic.yml to $BACKUP_DIR/$backup_name"
 
 	# Check if webapp route exists in dynamic.yml
-	if grep -q 'webapp' "$dynamic_yml" 2>/dev/null; then
+	if grep -q 'webapp' "$dynamic_yml"; then
 		# Extract and create webapp conf.d file
 		if [[ ! -f "$CONFD_DIR/webapp.yml" ]]; then
 			create_webapp_confd


### PR DESCRIPTION
## Summary

- Removes redundant `2>/dev/null` from `grep -q 'webapp' "$dynamic_yml"` in `migrate_traefik_to_confd` (`.agents/scripts/localdev-helper.sh:225`)
- File existence is already verified earlier in the function via `[[ -f "$dynamic_yml" ]]`; the suppression was masking potential permission errors and making debugging harder
- No behaviour change for the happy path; improves debuggability on error paths

## Verification

- `shellcheck .agents/scripts/localdev-helper.sh` — no new violations (pre-existing SC1091 info notice is unrelated)

Closes #3354