### PR TITLE
t3377: fix operationIdOrRoute label in openapi-search.md overview table

### DIFF
--- a/.agents/tools/context/openapi-search.md
+++ b/.agents/tools/context/openapi-search.md
@@ -69,7 +69,7 @@ OpenAPI documents into context. It uses a 3-step process:
 |------|------|---------|
 | 0 | `searchAPIs(query)` | Find APIs relevant to a use case via semantic search |
 | 1 | `getAPIOverview(apiId)` | Get a plain-language summary of all endpoints |
-| 2 | `getOperationDetails(apiId, operationId)` | Get full details for a specific endpoint |
+| 2 | `getOperationDetails(apiId, operationIdOrRoute)` | Get full details for a specific endpoint |
 
 The server converts OpenAPI specs (including Swagger 2.x) to simple language, making
 even the largest APIs navigable without overwhelming context.


### PR DESCRIPTION
## Summary

- Addresses medium-priority review feedback from PR #2078 (gemini-code-assist)
- Updates the overview table at line 72 of `.agents/tools/context/openapi-search.md` to use `operationIdOrRoute` instead of `operationId` as the parameter label
- The parameter accepts route-style values like `"POST /mail/send"` — the new label makes this dual-purpose nature self-documenting at a glance

## Change

```diff
-| 2 | `getOperationDetails(apiId, operationId)` | Get full details for a specific endpoint |
+| 2 | `getOperationDetails(apiId, operationIdOrRoute)` | Get full details for a specific endpoint |
```

## Verification

- markdownlint: no issues
- Single-line change, no functional impact

Closes #3377