### PR TITLE
fix(t3389): add shellcheck disable=SC1091 directive for runtime-resolved source path

### DIFF
--- a/.agents/scripts/coderabbit-collector-helper.sh
+++ b/.agents/scripts/coderabbit-collector-helper.sh
@@ -24,6 +24,7 @@ set -euo pipefail
 # =============================================================================
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck disable=SC1091  # shared-constants path resolved at runtime
 source "${SCRIPT_DIR}/shared-constants.sh"
 init_log_file
 


### PR DESCRIPTION
## Summary

- Adds `# shellcheck disable=SC1091  # shared-constants path resolved at runtime` directive to `.agents/scripts/coderabbit-collector-helper.sh` (line 27), matching the project convention used in `enhancor-helper.sh` and other scripts.
- Shellcheck now passes with zero violations.

## Context

Issue #3389 was generated from Gemini's review of PR #2392. The bot's finding was a **process concern** (mixing formatting + functional changes in one PR), not a code defect in the current file. The file's bash code uses consistent tab indentation throughout; the only shellcheck finding was SC1091 (info-level) for the `source` call whose path is resolved at runtime.

This PR resolves the one actionable item (SC1091) and closes the issue.

Closes #3389