### PR TITLE
t3375: fix quality-debt in _common.sh from PR #1240 review

### DIFF
--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -23,9 +23,13 @@ run_with_spinner() {
 	local pid
 	local spin_chars='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
 	local i=0
+	local output_file
+	output_file=$(mktemp)
+	# shellcheck disable=SC2064
+	trap "rm -f '$output_file'" RETURN
 
-	# Start command in background
-	"$@" &>/dev/null &
+	# Start command in background, capturing output for failure diagnosis
+	"$@" &>"$output_file" &
 	pid=$!
 
 	# Show spinner while command runs
@@ -44,7 +48,8 @@ run_with_spinner() {
 	if [[ $exit_code -eq 0 ]]; then
 		print_success "$message done"
 	else
-		print_error "$message failed"
+		print_error "$message failed. Output:"
+		cat "$output_file"
 	fi
 
 	return $exit_code
@@ -258,7 +263,9 @@ ensure_homebrew() {
 		# Add Homebrew to PATH for this session
 		local brew_prefix="/home/linuxbrew/.linuxbrew"
 		if [[ -x "$brew_prefix/bin/brew" ]]; then
-			eval "$("$brew_prefix/bin/brew" shellenv)"
+			# Use source with process substitution instead of eval (style guide: eval is forbidden)
+			# shellcheck disable=SC1090
+			source <("$brew_prefix/bin/brew" shellenv)
 		fi
 
 		# Persist to shell rc files


### PR DESCRIPTION
## Summary

Addresses two unactioned review findings from PR #1240 in `.agents/scripts/setup/_common.sh`.

## Findings Fixed

### HIGH (PR #1240): Replace `eval` with `source <(...)` in `ensure_homebrew`

**File**: `.agents/scripts/setup/_common.sh:261`

The style guide explicitly forbids `eval`. The `eval "$("$brew_prefix/bin/brew" shellenv)"` pattern was replaced with `source <("$brew_prefix/bin/brew" shellenv)`, which achieves the same effect (setting environment variables in the current shell) without using `eval`.

### MEDIUM (PR #1240): Capture `run_with_spinner` output instead of suppressing to `/dev/null`

**File**: `.agents/scripts/setup/_common.sh:28`

`run_with_spinner` was discarding all command output with `&>/dev/null`, making failure diagnosis impossible. The fix captures output to a temp file (cleaned up via `RETURN` trap), suppresses it on success, and prints it on failure — giving users actionable context when an installation step fails.

## Not Fixed (by design)

**MEDIUM**: Moving `get_all_shell_rcs` from `_shell.sh` to `_common.sh` — this is an architectural refactor beyond the scope of this quality-debt fix and would require coordinated changes across multiple setup modules.

## Verification

- `shellcheck --shell=bash .agents/scripts/setup/_common.sh` → zero violations

Closes #3375