### PR TITLE
fix: address quality-debt review feedback in mission-template.md

### DIFF
--- a/.agents/templates/mission-template.md
+++ b/.agents/templates/mission-template.md
@@ -50,8 +50,6 @@ preferences:
 - **POC**: Skip ceremony (briefs, PRs, reviews). Commit to main (dedicated repo) or single branch (existing repo). Fast iteration, exploration-first.
 - **Full**: Standard worktree + PR workflow. Briefs required. Code review. Production-quality output.
 
-**Selected mode:** `{poc|full}`
-
 ### Non-Goals
 
 - {Explicitly out of scope — prevents scope creep}
@@ -132,11 +130,11 @@ Milestones are sequential. Features within each milestone are parallelisable.
 
 | Category | Budget | Spent | Remaining | % Used |
 |----------|--------|-------|-----------|--------|
-| Time (hours) | {X}h | 0h | {X}h | 0% |
-| Money (USD) | ${X} | $0 | ${X} | 0% |
-| Tokens | {X} | 0 | {X} | 0% |
+| Time (hours) | 0h   | 0h | 0h   | 0% |
+| Money (USD)  | $0   | $0 | $0   | 0% |
+| Tokens       | 0    | 0  | 0    | 0% |
 
-**Alert threshold:** {80}% — pause and report when any category exceeds this.
+**Alert threshold:** 80% — pause and report when any category exceeds this.
 
 ### Spend Log
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -13,6 +13,7 @@
   },
   "MD013": false,
   "MD024": false,
+  "MD025": false,
   "MD026": false,
   "MD029": false,
   "MD032": false,


### PR DESCRIPTION
## Summary

- Remove redundant `**Selected mode:**` field (line 53) — duplicates the `mode:` field in YAML frontmatter, preventing inconsistencies via single source of truth
- Initialize budget tracking table with `0` values instead of `{X}` placeholders — clarifies the table tracks spending against the frontmatter-defined budget
- Remove braces from `{80}` alert threshold — indicates this is the default from frontmatter, not a user-editable placeholder here

## Markdownlint Fix

- Added `"MD025": false` to `.markdownlint.json` — the pre-existing MD025 violation was caused by markdownlint v0.40.0 treating the YAML frontmatter `title:` field as a document title, flagging the `# {Mission Title}` H1 as a duplicate. This is intentional template structure.

Closes #3360

## Files Changed

- `.agents/templates/mission-template.md` — 3 quality-debt fixes from PR #2507 Gemini review
- `.markdownlint.json` — disable MD025 for YAML-frontmatter templates