### PR TITLE
t3364: Fix quality-debt from PR #1958 review — heartbeat cleanup scope and SUPERVISOR_EVAL_TIMEOUT validation

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -227,6 +227,10 @@ _diagnose_stale_root_cause() {
 		# suffice, but this wider window ensures Phase 0.7 does not fire if the
 		# heartbeat subshell is unexpectedly killed or stalled.
 		local eval_timeout_cfg="${SUPERVISOR_EVAL_TIMEOUT:-90}"
+		if ! [[ "$eval_timeout_cfg" =~ ^[0-9]+$ ]]; then
+			log_warn "SUPERVISOR_EVAL_TIMEOUT is non-numeric ('$eval_timeout_cfg'); defaulting to 90"
+			eval_timeout_cfg=90
+		fi
 		local heartbeat_window=$((eval_timeout_cfg * 2 + 60))
 		local db_updated_at
 		db_updated_at=$(db "$SUPERVISOR_DB" "SELECT updated_at FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "")


### PR DESCRIPTION
## Summary

Addresses the two findings from the CodeRabbit review of PR #1958 that were filed as issue #3364.

## Finding 1 — CRITICAL: heartbeat cleanup dropped on early exit (evaluate.sh)

**Status: Already fixed — no code change needed.**

The critical bug (heartbeat `push_cleanup` registered before `_save_cleanup_scope`, leaving the heartbeat orphaned on early RETURN) existed in `evaluate_with_ai()`. That function was **deleted in PR #2221** (t1312 dead code removal, commit `e59bc4c5`) before the supervisor was archived in PR #2291. The archived `evaluate.sh` does not contain the buggy code. The `_save_cleanup_scope` at line 137 of the archived file is in a different function (`_extract_log_signals`) and is correctly ordered (scope saved before cleanup registered).

## Finding 2 — NITPICK: non-numeric SUPERVISOR_EVAL_TIMEOUT crashes arithmetic (pulse.sh)

**Status: Fixed.**

`_diagnose_stale_root_cause()` in the archived `pulse.sh` computed:

```bash
local eval_timeout_cfg="${SUPERVISOR_EVAL_TIMEOUT:-90}"
local heartbeat_window=$((eval_timeout_cfg * 2 + 60))
```

If `SUPERVISOR_EVAL_TIMEOUT` is set to a non-integer (e.g. `90s`), bash emits an arithmetic error and `heartbeat_window` is undefined, degrading the stale-eval guardrail silently.

Fix: add a `[[ =~ ^[0-9]+$ ]]` guard that defaults to 90 and logs a warning via `log_warn`.

## Verification

- `bash -n .agents/scripts/supervisor-archived/evaluate.sh` — passes (0 errors)
- `bash -n .agents/scripts/supervisor-archived/pulse.sh` — passes (0 errors)
- `shellcheck .agents/scripts/supervisor-archived/evaluate.sh` — passes (0 violations)
- `shellcheck .agents/scripts/supervisor-archived/pulse.sh` — OOMs on the 3983-line archived file (pre-existing condition, unrelated to this change; the 4-line addition is syntactically trivial)

Closes #3364