### PR TITLE
t1482: poll-based fetch timeout and reduced sub-helper timeouts

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -318,7 +318,6 @@ check_dedup() {
 			echo "IDLE:$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$PIDFILE"
 			return 0
 		fi
-
 		if [[ "$setup_pid" == "$$" ]]; then
 			# We wrote this ourselves — proceed
 			return 0
@@ -342,7 +341,6 @@ check_dedup() {
 			echo "IDLE:$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$PIDFILE"
 			return 0
 		fi
-
 		# SETUP wrapper is alive but we hold the instance lock — it's a zombie
 		# from a previous cycle. Kill it and proceed.
 		echo "[pulse-wrapper] check_dedup: killing zombie SETUP wrapper $setup_pid" >>"$LOGFILE"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -619,11 +619,14 @@ prefetch_state() {
 
 	# Append repo hygiene data for LLM triage (t1417)
 	# This includes pr-salvage-helper.sh which iterates all repos sequentially
-	# and can hang on gh API calls. Give it 120s since it does 8 repos.
+	# and can hang on gh API calls. 30s timeout — if it can't finish fast,
+	# the pulse proceeds without hygiene data (degraded but functional).
+	# Total prefetch budget: 60s (parallel) + 30s + 30s + 30s = 150s max,
+	# well within the 600s stage timeout.
 	local hygiene_tmp
 	hygiene_tmp=$(mktemp)
-	run_cmd_with_timeout 120 prefetch_hygiene >"$hygiene_tmp" 2>/dev/null || {
-		echo "[pulse-wrapper] prefetch_hygiene timed out after 120s (non-fatal)" >>"$LOGFILE"
+	run_cmd_with_timeout 30 prefetch_hygiene >"$hygiene_tmp" 2>/dev/null || {
+		echo "[pulse-wrapper] prefetch_hygiene timed out after 30s (non-fatal)" >>"$LOGFILE"
 	}
 	cat "$hygiene_tmp" >>"$STATE_FILE"
 	rm -f "$hygiene_tmp"
@@ -631,8 +634,8 @@ prefetch_state() {
 	# Append CI failure patterns from notification mining (GH#4480)
 	local ci_tmp
 	ci_tmp=$(mktemp)
-	run_cmd_with_timeout 90 prefetch_ci_failures >"$ci_tmp" 2>/dev/null || {
-		echo "[pulse-wrapper] prefetch_ci_failures timed out after 90s (non-fatal)" >>"$LOGFILE"
+	run_cmd_with_timeout 30 prefetch_ci_failures >"$ci_tmp" 2>/dev/null || {
+		echo "[pulse-wrapper] prefetch_ci_failures timed out after 30s (non-fatal)" >>"$LOGFILE"
 	}
 	cat "$ci_tmp" >>"$STATE_FILE"
 	rm -f "$ci_tmp"
@@ -649,8 +652,8 @@ prefetch_state() {
 	# Append failed-notification systemic summary (t3960)
 	local ghfail_tmp
 	ghfail_tmp=$(mktemp)
-	run_cmd_with_timeout 90 prefetch_gh_failure_notifications >"$ghfail_tmp" 2>/dev/null || {
-		echo "[pulse-wrapper] prefetch_gh_failure_notifications timed out after 90s (non-fatal)" >>"$LOGFILE"
+	run_cmd_with_timeout 30 prefetch_gh_failure_notifications >"$ghfail_tmp" 2>/dev/null || {
+		echo "[pulse-wrapper] prefetch_gh_failure_notifications timed out after 30s (non-fatal)" >>"$LOGFILE"
 	}
 	cat "$ghfail_tmp" >>"$STATE_FILE"
 	rm -f "$ghfail_tmp"

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -545,13 +545,16 @@ prefetch_state() {
 
 	# Wait for all parallel fetches with a hard timeout (t1482).
 	# Each repo does 3 gh API calls (pr list, pr list --state all, issue list).
-	# Normal completion: <30s. Timeout at 120s catches hung gh connections.
+	# Normal completion: <30s. Timeout at 60s catches hung gh connections.
+	# Must be well under launchd's 120s StartInterval — the wrapper spends
+	# ~20s on cleanup/normalize before reaching prefetch, so 60s leaves ~40s
+	# for sub-helpers and pulse launch.
 	# Uses poll-based approach (kill -0) instead of blocking wait — wait $pid
 	# blocks until the process exits, so a timeout check between waits is
 	# ineffective when a single wait hangs for minutes.
 	local wait_elapsed=0
 	local all_done=false
-	while [[ "$all_done" != "true" ]] && [[ "$wait_elapsed" -lt 120 ]]; do
+	while [[ "$all_done" != "true" ]] && [[ "$wait_elapsed" -lt 60 ]]; do
 		all_done=true
 		for pid in "${pids[@]}"; do
 			if kill -0 "$pid" 2>/dev/null; then


### PR DESCRIPTION
## Summary

Follow-up to PR #4575 (merged). Three additional fixes for the pulse dispatch hang:

- Replace blocking `wait $pid` loop with `kill -0` poll-based timeout in `prefetch_state()` parallel gh fetches — `wait` blocks until the process exits, so the elapsed-time check between waits never fires
- Reduce parallel fetch timeout from 120s to 60s — normal completion is <30s, and the wrapper spends ~20s on cleanup before reaching prefetch, so 120s exceeds launchd's cycle
- Reduce sub-helper timeouts from 90-120s to 30s each — total prefetch budget: 60s + 30s + 30s + 30s = 150s worst case

## Evidence

Production logs show `prefetch_state` taking 89-182s with the old code. The `wait $pid` timeout never fired because each `wait` blocked for the full duration of the hung process. New instances kept starting every 120s (launchd), correctly detecting dead SETUP wrappers, but never completing prefetch before the next cycle.

Closes #4576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Introduced timeout safeguards for setup and prefetch operations to prevent indefinite hangs and improve process reliability.
* Enhanced process cleanup logic with improved handling for setup-phase wrapper detection and stale zombie process termination.
* Added per-call execution timeouts to API fetch operations for more predictable behavior and bounded resource usage during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->