### PR TITLE
fix: guard SUPERVISOR_EVAL_TIMEOUT against non-numeric values (PR #1958 quality-debt)

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -227,6 +227,10 @@ _diagnose_stale_root_cause() {
 		# suffice, but this wider window ensures Phase 0.7 does not fire if the
 		# heartbeat subshell is unexpectedly killed or stalled.
 		local eval_timeout_cfg="${SUPERVISOR_EVAL_TIMEOUT:-90}"
+		if ! [[ "$eval_timeout_cfg" =~ ^[0-9]+$ ]]; then
+			log_warn "SUPERVISOR_EVAL_TIMEOUT is non-numeric ('$eval_timeout_cfg'); defaulting to 90"
+			eval_timeout_cfg=90
+		fi
 		local heartbeat_window=$((eval_timeout_cfg * 2 + 60))
 		local db_updated_at
 		db_updated_at=$(db "$SUPERVISOR_DB" "SELECT updated_at FROM tasks WHERE id = '$escaped_id';" 2>/dev/null || echo "")

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -228,7 +228,7 @@ _diagnose_stale_root_cause() {
 		# heartbeat subshell is unexpectedly killed or stalled.
 		local eval_timeout_cfg="${SUPERVISOR_EVAL_TIMEOUT:-90}"
 		if ! [[ "$eval_timeout_cfg" =~ ^[0-9]+$ ]]; then
-			log_warn "SUPERVISOR_EVAL_TIMEOUT is non-numeric ('$eval_timeout_cfg'); defaulting to 90"
+			log_warn "_diagnose_stale_root_cause: SUPERVISOR_EVAL_TIMEOUT is non-numeric ('$eval_timeout_cfg'); defaulting to 90"
 			eval_timeout_cfg=90
 		fi
 		local heartbeat_window=$((eval_timeout_cfg * 2 + 60))


### PR DESCRIPTION
## Summary

Applies the fix from PR #4581 (which conflicted with main) to a clean branch off the current main.

Cherry-picks two commits:
- `f21579d7` — add numeric validation guard block for `SUPERVISOR_EVAL_TIMEOUT` in `supervisor-archived/pulse.sh`
- `f5104661` — add function name prefix `_diagnose_stale_root_cause:` to the `log_warn` message (the one-line fix from PR #4581)

The arithmetic expansion at line 230 (`heartbeat_window=$((eval_timeout_cfg * 2 + 60))`) would emit a bash arithmetic error if `SUPERVISOR_EVAL_TIMEOUT` is set to a non-integer (e.g. `90s`). The guard defaults to 90 and emits a `log_warn` with the function name prefix so the misconfiguration is visible in logs.

## Verification

- `bash -n .agents/scripts/supervisor-archived/pulse.sh` — clean (no syntax errors)
- ShellCheck OOMs on the 3,983-line archived file (pre-existing known limitation, consistent with original PR #4581 notes)

Supersedes PR #4581 (conflicted with main).

Closes #3364