### PR TITLE
fix: pulse monitoring loop heartbeat prevents watchdog kill

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -104,7 +104,12 @@ After the initial dispatch, enter a monitoring loop. Each cycle:
    The last todo is always "Monitor cycle N+1" — this anchors the loop. Complete it by
    sleeping, checking state, and creating the next batch.
 
-2. **Sleep 60 seconds**: `sleep 60`
+2. **Sleep 60 seconds** — write a heartbeat log line first so the wrapper's progress detector doesn't kill the session during the sleep:
+
+   ```bash
+   echo "[pulse] Monitoring cycle $N: sleeping 60s (active $WORKER_COUNT/$MAX_WORKERS, elapsed ${ELAPSED}s)"
+   sleep 60
+   ```
 
 3. **Check capacity**:
 


### PR DESCRIPTION
## Summary

The wrapper's progress detector kills the pulse LLM session if the log file doesn't grow for 600s. The monitoring loop's `sleep 60` produces no output, so after ~10 minutes of sleeping + checking slots, the detector sees "no progress" and kills a productive session. This causes the batch-and-idle pattern where workers dispatch, finish, and then nothing refills slots until the next full cycle.

**Fix:** Add an `echo` heartbeat line before each `sleep 60` in the monitoring loop instructions (`pulse.md`). The LLM writes a one-liner with cycle number, active workers, and elapsed time — giving the watchdog the progress signal it needs while keeping all dispatch intelligence in the LLM.

## Evidence

Production logs show repeated `Pulse cold-start stalled for 600s — no first output — killing` entries, followed by `active 0/24, deficit 100%` on the next cycle. The monitoring loop was being killed before it could refill slots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added heartbeat logging to the monitoring loop that displays cycle number, active worker count, and elapsed time before each pause interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->