### PR TITLE
t3314: harden launchd plist generation failure handling

### DIFF
--- a/.agents/scripts/supervisor-archived/launchd.sh
+++ b/.agents/scripts/supervisor-archived/launchd.sh
@@ -348,13 +348,16 @@ launchd_install_supervisor_pulse() {
 
 	# Generate plist content
 	local new_content
-	new_content=$(_generate_supervisor_pulse_plist \
+	if ! new_content=$(_generate_supervisor_pulse_plist \
 		"$display_link" \
 		"$interval_seconds" \
 		"$log_path" \
 		"$batch_arg" \
 		"$env_path" \
-		"")
+		""); then
+		log_error "Failed to generate LaunchAgent plist: $label"
+		return 1
+	fi
 
 	# Skip if already loaded with identical config (t1265 — avoids macOS notification)
 	if _launchd_is_loaded "$label" && _plist_unchanged "$plist_path" "$new_content"; then


### PR DESCRIPTION
## Summary
- add explicit error handling when `_generate_supervisor_pulse_plist` fails so launchd install cannot continue with invalid/empty plist content
- log a clear failure message and return non-zero from `launchd_install_supervisor_pulse` to make wrapper-path validation failures observable and actionable
- preserve existing behavior for successful installs while tightening failure-path safety in the archived launchd backend

Closes #3314