### PR TITLE
fix(t3709): address gemini review feedback in pulse.sh (PR #1377)

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2990,10 +2990,11 @@ cmd_pulse() {
 				# CodeFactor findings into a unified audit_findings table.
 				# Skip if the script is a stub or not yet implemented.
 				if [[ -x "$audit_collect_script" ]]; then
+					local MIN_AUDIT_SCRIPT_SIZE=100
 					local collect_size
-					collect_size=$(wc -c <"$audit_collect_script" 2>/dev/null || echo "0")
-					# Only run if the script has substantive content (>100 bytes, not a stub)
-					if [[ "$collect_size" -gt 100 ]]; then
+					collect_size=$(wc -c <"$audit_collect_script" 2>>"$SUPERVISOR_LOG" || echo "0")
+					# Only run if the script has substantive content (not a stub)
+					if [[ "$collect_size" -gt "$MIN_AUDIT_SCRIPT_SIZE" ]]; then
 						log_info "    Phase 10b: Collecting findings from all audit services"
 						bash "$audit_collect_script" collect --repo "$task_repo" 2>>"$SUPERVISOR_LOG" || {
 							log_warn "    Phase 10b: Audit collection returned non-zero (continuing with task creation)"


### PR DESCRIPTION
## Summary

Addresses the medium-severity Gemini code review finding from PR #1377 on `.agents/scripts/supervisor-archived/pulse.sh`.

**Two changes per reviewer suggestion:**

1. **Error suppression** (style guide violation): Replace `2>/dev/null` with `2>>"$SUPERVISOR_LOG"` on the `wc -c` call — errors are now captured in the supervisor log for debugging rather than silently discarded.

2. **Magic number** (style guide violation): Extract the stub-detection threshold `100` into a named constant `local MIN_AUDIT_SCRIPT_SIZE=100` — improves readability and makes the threshold self-documenting.

## Changes

- `.agents/scripts/supervisor-archived/pulse.sh` — lines 2993–2997 (Phase 10b Step 1 stub detection)

Closes #3709