### PR TITLE
3712: Address quality-debt feedback for parse_pr_url guard

### DIFF
--- a/.agents/scripts/supervisor-archived/state.sh
+++ b/.agents/scripts/supervisor-archived/state.sh
@@ -150,7 +150,7 @@ cmd_transition() {
 		if [[ -n "$existing_pr" && "$existing_pr" != "no_pr" && "$existing_pr" != "task_only" && "$existing_pr" != "verified_complete" ]]; then
 			# Real PR URL exists — check if it's actually merged
 			local parsed_guard pr_number_guard repo_slug_guard
-			parsed_guard=$(parse_pr_url "$existing_pr" 2>/dev/null) || parsed_guard=""
+			parsed_guard=$(parse_pr_url "$existing_pr" 2>/dev/null || true)
 			if [[ -n "$parsed_guard" ]]; then
 				repo_slug_guard="${parsed_guard%%|*}"
 				pr_number_guard="${parsed_guard##*|}"


### PR DESCRIPTION
## Summary
- Replace the `parse_pr_url` fallback pattern in `cmd_transition()` with `|| true` inside command substitution, matching the shell style guide recommendation under `set -e`
- Keep behavior unchanged: parse failures now still yield an empty `parsed_guard` while making the guard idiom explicit and easier to maintain
- Closes #3712 (quality-debt feedback from PR #1385)

## Testing
- `shellcheck .agents/scripts/supervisor-archived/state.sh`