### PR TITLE
fix: replace bash 4.2+ associative arrays with portable grep in worktree cleanup

### DIFF
--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -817,17 +817,13 @@ cmd_clean() {
 		fi
 	done
 
-	# Build an associative array of merged PR branches for squash-merge detection.
+	# Build a newline-delimited list of merged PR branches for squash-merge detection.
 	# gh pr list catches squash-merged PRs that git branch --merged misses.
-	# Using an associative array gives O(1) lookup and avoids regex injection from
-	# branch names containing grep metacharacters.
-	declare -A merged_pr_lookup=()
+	# Uses grep -Fxq for exact-line matching (no regex injection risk).
+	# NOTE: bash 3.2 (macOS default) lacks declare -A — do NOT use associative arrays.
+	local merged_pr_branches=""
 	if command -v gh &>/dev/null; then
-		local merged_pr_branches_raw=""
-		merged_pr_branches_raw=$(gh pr list --state merged --limit 200 --json headRefName --jq '.[].headRefName' 2>/dev/null || echo "")
-		while IFS= read -r branch_name; do
-			[[ -n "$branch_name" ]] && merged_pr_lookup["$branch_name"]=1
-		done <<<"$merged_pr_branches_raw"
+		merged_pr_branches=$(gh pr list --state merged --limit 200 --json headRefName --jq '.[].headRefName' 2>/dev/null || echo "")
 	fi
 
 	while IFS= read -r line; do
@@ -856,8 +852,8 @@ cmd_clean() {
 				# GitHub squash merges create a new commit — the original branch is NOT
 				# an ancestor of the target, so git branch --merged misses it. The remote
 				# branch may still exist if "auto-delete head branches" is off.
-				# Use associative array lookup (O(1), no regex injection risk).
-				elif [[ -v "merged_pr_lookup[$worktree_branch]" ]]; then
+				# grep -Fxq: exact fixed-string line match (no regex injection risk).
+				elif [[ -n "$merged_pr_branches" ]] && echo "$merged_pr_branches" | grep -Fxq "$worktree_branch"; then
 					is_merged=true
 					merge_type="squash-merged PR"
 				fi
@@ -944,8 +940,8 @@ cmd_clean() {
 					# Skip if fetch failed — stale refs could cause false-positive deletion
 					elif [[ "$remote_state_unknown" == "false" ]] && branch_was_pushed "$worktree_branch" && ! _branch_exists_on_any_remote "$worktree_branch"; then
 						should_remove=true
-					# Check 3: Squash-merged PR — use associative array (O(1), no regex injection)
-					elif [[ -v "merged_pr_lookup[$worktree_branch]" ]]; then
+					# Check 3: Squash-merged PR — grep -Fxq exact-line match (no regex injection)
+					elif [[ -n "$merged_pr_branches" ]] && echo "$merged_pr_branches" | grep -Fxq "$worktree_branch"; then
 						should_remove=true
 					fi
 


### PR DESCRIPTION
## Summary

- **Root cause**: `worktree-helper.sh` used `declare -A` (associative arrays) and `[[ -v ]]` (variable existence test) — both require bash 4.2+. macOS ships bash 3.2, causing `cleanup_worktrees()` to silently crash on every pulse cycle.
- **Impact**: 66 stale worktrees accumulated (39 with merged PRs), `prefetch_hygiene` timed out every cycle (O(n) API calls on uncleaned worktrees), and disk space leaked continuously.
- **Fix**: Replace associative array with newline-delimited string + `grep -Fxq` for exact-line matching. Same safety guarantees (no regex injection), works on bash 3.2+.

## Evidence

Before fix: `worktree-helper.sh clean --auto --force-merged` crashed with:
```
line 860: conditional binary operator expected
```

After fix: 39 stale worktrees cleaned on first run (66 → 28 remaining, all active).

## Testing

- Verified `grep -Fxq` correctly handles: exact matches, non-matches, and partial-string rejection
- Tested with `/bin/bash` (3.2.57) on macOS
- ShellCheck clean (only SC1091 for external source, pre-existing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved compatibility of the worktree helper script to support a wider range of system environments while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->