### PR TITLE
bugfix/4585: Enforce finding-to-task conversion for all multi-finding reports

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -63,6 +63,7 @@ Before executing any non-trivial task, explicitly restate: (1) the actual goal â
 - Build for change. Don't hardcode what should be parameterized. Design for variation.
 - Prefer lightweight approaches. Simpler tools over heavy dependencies.
 - Crash-resilient by default. Any process, session, or machine can die at any moment â€” power loss, OOM, network drop, stuck LLM. Every process must recover from a cold start by reading current state, not by assuming a previous step completed. Never chain processes where B depends on A having succeeded without B independently verifying A's outcome. If a process needs to know "did the last run finish?", it should check the result (does the PR exist? is the issue closed?), not rely on a flag the last run was supposed to set.
+- Finding-to-task completeness: when producing a multi-finding audit/review report (security, code review, SEO, accessibility, performance, etc.), every actionable finding must be converted to a tracked task before declaring completion. Findings fixed in the current PR are tracked by that PR; each deferred actionable finding must get its own task ID and linked issue. A report with untracked actionable findings is incomplete.
 
 # Claim discipline (turn-end gate)
 - Do not present future intent as completed work.

--- a/.agents/scripts/commands/findings-to-tasks.md
+++ b/.agents/scripts/commands/findings-to-tasks.md
@@ -1,0 +1,56 @@
+---
+description: Convert actionable report findings into tracked tasks and issues
+agent: Build+
+mode: subagent
+---
+
+Convert deferred actionable findings from an audit/review report into tracked TODO tasks and linked GitHub issues.
+
+Input file: `$ARGUMENTS`
+
+## Required Format
+
+Create a text file with one actionable finding per line:
+
+```text
+severity|title|details
+```
+
+Examples:
+
+```text
+high|Harden prompt-guard fallback on malformed markdown|Reject malformed HTML comments before rendering summary
+medium|Add retries for Codacy API timeout|Use capped exponential backoff in codacy-cli.sh
+low|Improve stale worker log wording|Clarify blocked vs failed in watchdog output
+```
+
+If severity is omitted, it defaults to `medium`.
+
+## Command
+
+Run:
+
+```bash
+~/.aidevops/agents/scripts/findings-to-tasks-helper.sh create \
+  --input <path/to/actionable-findings.txt> \
+  --repo-path "$(git rev-parse --show-toplevel)" \
+  --source <security-audit|code-review|seo-audit|accessibility|performance>
+```
+
+Optional flags:
+
+- `--labels "label1,label2"` add extra issue labels
+- `--tags "tag1,tag2"` add extra TODO hashtags
+- `--dry-run` preview without allocating task IDs
+- `--no-issue` allocate task IDs without creating GitHub issues
+- `--allow-partial` allow non-100% conversion (normally treated as failure)
+
+## Completion Rule
+
+A multi-finding report is complete only when helper output confirms full conversion coverage:
+
+- `actionable_findings_total=<N>`
+- `deferred_tasks_created=<N>`
+- `coverage=100%`
+
+If `coverage` is below 100%, continue task creation until all actionable findings are tracked.

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -505,6 +505,32 @@ The AI will iterate on the task until outputting:
 5. **README gate passed** — required if task adds/changes user-facing features (see below)
 6. Conventional commits used — required for all commits (enables auto-changelog)
 7. **Headless rules observed** (see below)
+8. **Actionable finding coverage** — if this task produces a multi-finding report (audit/review/scan), every deferred actionable finding has a tracked follow-up (`task_id` + issue ref)
+
+**Actionable finding coverage procedure (mandatory when output includes multiple findings):**
+
+1. Build an actionable list for deferred items (one line per finding) in a temp file using this format:
+
+   ```text
+   severity|title|details
+   ```
+
+2. Convert that list into tracked tasks and issues with:
+
+   ```bash
+   ~/.aidevops/agents/scripts/findings-to-tasks-helper.sh create \
+     --input <path/to/actionable-findings.txt> \
+     --repo-path "$(git rev-parse --show-toplevel)" \
+     --source <audit|review|seo|accessibility|performance>
+   ```
+
+3. Include proof in your PR body or final report:
+   - `actionable_findings_total=<N>`
+   - `fixed_in_pr=<N>`
+   - `deferred_tasks_created=<N>`
+   - `coverage=100%`
+
+If coverage is below 100%, the task is not complete.
 
 **Parallelism rule (t217)**: When your task involves multiple independent operations (reading several files, running lint + typecheck + tests, researching separate modules), use the Task tool to run them concurrently in a single message — not one at a time. Serial execution of independent work wastes wall-clock time proportional to the number of subtasks. See `tools/ai-assistants/headless-dispatch.md` "Worker Efficiency Protocol" point 5 for criteria and examples.
 

--- a/.agents/scripts/findings-to-tasks-helper.sh
+++ b/.agents/scripts/findings-to-tasks-helper.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+# =============================================================================
+# findings-to-tasks-helper.sh
+# =============================================================================
+# Convert actionable findings into tracked TODO tasks + GitHub issues.
+#
+# Input format (pipe-delimited, one finding per line):
+#   severity|title|details
+#
+# Severity is optional; if omitted, defaults to medium:
+#   title only
+#
+# Usage:
+#   findings-to-tasks-helper.sh create --input findings.txt [options]
+#   findings-to-tasks-helper.sh help
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck disable=SC1091
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+readonly DEFAULT_SOURCE="review"
+readonly DEFAULT_SEVERITY="medium"
+readonly CLAIM_SCRIPT="${SCRIPT_DIR}/claim-task-id.sh"
+
+trim() {
+	local input="${1:-}"
+	input="${input#"${input%%[![:space:]]*}"}"
+	input="${input%"${input##*[![:space:]]}"}"
+	printf '%s' "$input"
+	return 0
+}
+
+is_valid_severity() {
+	local severity=""
+	severity="$(trim "${1:-}")"
+	case "$severity" in
+	critical | high | medium | low | info)
+		return 0
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+normalize_tag_list() {
+	local tags_csv="${1:-}"
+	local source="${2:-$DEFAULT_SOURCE}"
+	local severity="${3:-$DEFAULT_SEVERITY}"
+
+	local out="#actionable-finding #${source} #${severity}"
+	local token=""
+	local token_trimmed=""
+
+	if [[ -n "$tags_csv" ]]; then
+		while IFS=',' read -r token; do
+			token_trimmed="$(trim "$token")"
+			if [[ -z "$token_trimmed" ]]; then
+				continue
+			fi
+			if [[ "$token_trimmed" == \#* ]]; then
+				out+=" ${token_trimmed}"
+			else
+				out+=" #${token_trimmed}"
+			fi
+		done <<<"$tags_csv"
+	fi
+
+	printf '%s' "$out"
+	return 0
+}
+
+normalize_label_list() {
+	local labels_csv="${1:-}"
+	local source="${2:-$DEFAULT_SOURCE}"
+	local severity="${3:-$DEFAULT_SEVERITY}"
+
+	local out="actionable-finding,${source},severity:${severity}"
+	local token=""
+	local token_trimmed=""
+
+	if [[ -n "$labels_csv" ]]; then
+		while IFS=',' read -r token; do
+			token_trimmed="$(trim "$token")"
+			if [[ -z "$token_trimmed" ]]; then
+				continue
+			fi
+			out+=",${token_trimmed}"
+		done <<<"$labels_csv"
+	fi
+
+	printf '%s' "$out"
+	return 0
+}
+
+show_help() {
+	cat <<'EOF'
+findings-to-tasks-helper.sh - Create tracked tasks from actionable findings
+
+Usage:
+  findings-to-tasks-helper.sh create --input <file> [options]
+  findings-to-tasks-helper.sh help
+
+Input format (one finding per line):
+  severity|title|details
+
+Examples:
+  findings-to-tasks-helper.sh create --input findings.txt --source security-audit
+  findings-to-tasks-helper.sh create --input findings.txt --dry-run --no-issue
+
+Options:
+  --input PATH          Required. File containing actionable findings.
+  --repo-path PATH      Git repo root (default: git root or current directory).
+  --source NAME         Source tag/label (default: review).
+  --labels CSV          Extra issue labels (comma-separated).
+  --tags CSV            Extra TODO hashtags (comma-separated).
+  --output PATH         Write generated TODO lines to file.
+  --offline             Force offline ID allocation.
+  --no-issue            Allocate task IDs only; skip issue creation.
+  --dry-run             Preview allocations without changing state.
+  --allow-partial       Exit 0 even if some findings fail conversion.
+EOF
+	return 0
+}
+
+resolve_repo_path() {
+	local requested_path="${1:-}"
+	local repo_path=""
+
+	if [[ -n "$requested_path" ]]; then
+		repo_path="$requested_path"
+	else
+		repo_path="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+	fi
+
+	if [[ ! -d "$repo_path" ]]; then
+		log_error "Repo path does not exist: $repo_path"
+		return 1
+	fi
+
+	printf '%s' "$repo_path"
+	return 0
+}
+
+parse_finding_line() {
+	local line="${1:-}"
+	local parsed_severity=""
+	local parsed_title=""
+	local parsed_details=""
+
+	local field1=""
+	local field2=""
+	local field3=""
+
+	IFS='|' read -r field1 field2 field3 <<<"$line"
+	field1="$(trim "$field1")"
+	field2="$(trim "$field2")"
+	field3="$(trim "$field3")"
+
+	if [[ -n "$field2" ]]; then
+		parsed_severity="$field1"
+		parsed_title="$field2"
+		parsed_details="$field3"
+	else
+		parsed_severity="$DEFAULT_SEVERITY"
+		parsed_title="$field1"
+		parsed_details=""
+	fi
+
+	if ! is_valid_severity "$parsed_severity"; then
+		parsed_details="$parsed_title${parsed_details:+ - $parsed_details}"
+		parsed_title="$field1${field2:+ | $field2}${field3:+ | $field3}"
+		parsed_title="$(trim "$parsed_title")"
+		parsed_severity="$DEFAULT_SEVERITY"
+	fi
+
+	printf '%s\t%s\t%s' "$parsed_severity" "$parsed_title" "$parsed_details"
+	return 0
+}
+
+create_task_for_finding() {
+	local repo_path="${1:-}"
+	local source="${2:-$DEFAULT_SOURCE}"
+	local severity="${3:-$DEFAULT_SEVERITY}"
+	local title="${4:-}"
+	local details="${5:-}"
+	local extra_labels="${6:-}"
+	local extra_tags="${7:-}"
+	local offline_mode="${8:-false}"
+	local no_issue_mode="${9:-false}"
+	local dry_run_mode="${10:-false}"
+
+	local labels=""
+	local tags=""
+	labels="$(normalize_label_list "$extra_labels" "$source" "$severity")"
+	tags="$(normalize_tag_list "$extra_tags" "$source" "$severity")"
+
+	local cmd=("$CLAIM_SCRIPT" --title "$title" --repo-path "$repo_path" --labels "$labels")
+	if [[ -n "$details" ]]; then
+		cmd+=(--description "$details")
+	fi
+	if [[ "$offline_mode" == "true" ]]; then
+		cmd+=(--offline)
+	fi
+	if [[ "$no_issue_mode" == "true" ]]; then
+		cmd+=(--no-issue)
+	fi
+	if [[ "$dry_run_mode" == "true" ]]; then
+		cmd+=(--dry-run)
+	fi
+
+	local claim_output=""
+	local claim_rc=0
+	claim_output=$("${cmd[@]}" 2>&1) || claim_rc=$?
+	if [[ "$claim_rc" -ne 0 && "$claim_rc" -ne 2 ]]; then
+		log_error "Failed to create task for finding: $title"
+		log_error "$claim_output"
+		return 1
+	fi
+
+	local task_id=""
+	local issue_ref=""
+	task_id=$(printf '%s\n' "$claim_output" | sed -n 's/^task_id=//p' | head -1)
+	issue_ref=$(printf '%s\n' "$claim_output" | sed -n 's/^ref=//p' | head -1)
+
+	if [[ -z "$task_id" ]]; then
+		log_error "claim-task-id.sh returned no task_id for: $title"
+		return 1
+	fi
+
+	local today=""
+	today="$(date +%Y-%m-%d)"
+
+	local todo_line="- [ ] ${task_id} ${title} ${tags}"
+	if [[ -n "$issue_ref" && "$issue_ref" != "offline" ]]; then
+		todo_line+=" ref:${issue_ref}"
+	fi
+	todo_line+=" logged:${today}"
+
+	printf '%s\n' "$todo_line"
+	return 0
+}
+
+cmd_create() {
+	local input_file=""
+	local repo_path_arg=""
+	local source="$DEFAULT_SOURCE"
+	local extra_labels=""
+	local extra_tags=""
+	local output_file=""
+	local offline_mode="false"
+	local no_issue_mode="false"
+	local dry_run_mode="false"
+	local allow_partial="false"
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--input)
+			input_file="${2:-}"
+			shift 2
+			;;
+		--repo-path)
+			repo_path_arg="${2:-}"
+			shift 2
+			;;
+		--source)
+			source="${2:-$DEFAULT_SOURCE}"
+			shift 2
+			;;
+		--labels)
+			extra_labels="${2:-}"
+			shift 2
+			;;
+		--tags)
+			extra_tags="${2:-}"
+			shift 2
+			;;
+		--output)
+			output_file="${2:-}"
+			shift 2
+			;;
+		--offline)
+			offline_mode="true"
+			shift
+			;;
+		--no-issue)
+			no_issue_mode="true"
+			shift
+			;;
+		--dry-run)
+			dry_run_mode="true"
+			shift
+			;;
+		--allow-partial)
+			allow_partial="true"
+			shift
+			;;
+		help | --help | -h)
+			show_help
+			return 0
+			;;
+		*)
+			log_error "Unknown argument: $arg"
+			show_help
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$input_file" ]]; then
+		log_error "--input is required"
+		show_help
+		return 1
+	fi
+
+	if [[ ! -f "$input_file" ]]; then
+		log_error "Input file not found: $input_file"
+		return 1
+	fi
+
+	if [[ ! -r "$input_file" ]]; then
+		log_error "Input file is not readable: $input_file"
+		return 1
+	fi
+
+	if [[ ! -x "$CLAIM_SCRIPT" ]]; then
+		log_error "claim-task-id.sh is missing or not executable: $CLAIM_SCRIPT"
+		return 1
+	fi
+
+	local repo_path=""
+	repo_path="$(resolve_repo_path "$repo_path_arg")" || return 1
+
+	local actionable_findings_total=0
+	local deferred_tasks_created=0
+	local skipped_empty=0
+	local failed=0
+
+	local line=""
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		local clean_line=""
+		clean_line="$(trim "$line")"
+
+		if [[ -z "$clean_line" ]]; then
+			skipped_empty=$((skipped_empty + 1))
+			continue
+		fi
+		if [[ "$clean_line" == \#* ]]; then
+			continue
+		fi
+
+		actionable_findings_total=$((actionable_findings_total + 1))
+
+		local parsed=""
+		local severity=""
+		local title=""
+		local details=""
+		parsed="$(parse_finding_line "$clean_line")"
+		severity="$(printf '%s' "$parsed" | cut -f1)"
+		title="$(printf '%s' "$parsed" | cut -f2)"
+		details="$(printf '%s' "$parsed" | cut -f3)"
+
+		if [[ -z "$title" ]]; then
+			log_warn "Skipping actionable finding with empty title: $clean_line"
+			failed=$((failed + 1))
+			continue
+		fi
+
+		local todo_line=""
+		if ! todo_line=$(create_task_for_finding \
+			"$repo_path" \
+			"$source" \
+			"$severity" \
+			"$title" \
+			"$details" \
+			"$extra_labels" \
+			"$extra_tags" \
+			"$offline_mode" \
+			"$no_issue_mode" \
+			"$dry_run_mode"); then
+			failed=$((failed + 1))
+			continue
+		fi
+
+		deferred_tasks_created=$((deferred_tasks_created + 1))
+		printf '%s\n' "$todo_line"
+		if [[ -n "$output_file" ]]; then
+			printf '%s\n' "$todo_line" >>"$output_file"
+		fi
+	done <"$input_file"
+
+	local coverage="0"
+	if [[ "$actionable_findings_total" -gt 0 ]]; then
+		coverage=$((deferred_tasks_created * 100 / actionable_findings_total))
+	fi
+
+	printf 'actionable_findings_total=%s\n' "$actionable_findings_total"
+	printf 'deferred_tasks_created=%s\n' "$deferred_tasks_created"
+	printf 'failed=%s\n' "$failed"
+	printf 'skipped_empty=%s\n' "$skipped_empty"
+	printf 'coverage=%s%%\n' "$coverage"
+
+	if [[ "$failed" -gt 0 && "$allow_partial" != "true" ]]; then
+		log_error "Some actionable findings were not converted. Re-run with --allow-partial only if intentionally deferring conversion."
+		return 1
+	fi
+
+	if [[ "$actionable_findings_total" -gt 0 && "$coverage" -lt 100 && "$allow_partial" != "true" ]]; then
+		log_error "Coverage below 100%. Every actionable finding must map to a tracked task."
+		return 1
+	fi
+
+	return 0
+}
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	create)
+		cmd_create "$@"
+		return $?
+		;;
+	help | --help | -h)
+		show_help
+		return 0
+		;;
+	*)
+		log_error "Unknown command: $command"
+		show_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-findings-to-tasks-helper.sh
+++ b/.agents/scripts/tests/test-findings-to-tasks-helper.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../findings-to-tasks-helper.sh"
+
+PASS=0
+FAIL=0
+TEST_DIR=""
+
+pass() {
+	local message="$1"
+	echo "PASS: ${message}"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local message="$1"
+	echo "FAIL: ${message}"
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+cleanup() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+setup_repo() {
+	local repo_path="$1"
+	mkdir -p "$repo_path"
+	(
+		cd "$repo_path"
+		git init -q
+		git config user.email "test@example.com"
+		git config user.name "Test Runner"
+		cat >.task-counter <<'EOF'
+100
+EOF
+		cat >TODO.md <<'EOF'
+# Tasks
+
+## Active
+
+- [ ] t099 Existing task
+EOF
+		git add .task-counter TODO.md
+		git commit -q -m "test: init repo"
+	)
+	return 0
+}
+
+test_successful_conversion() {
+	local repo_path="$1"
+	local findings_file="$2"
+	local output_file="$3"
+
+	cat >"$findings_file" <<'EOF'
+# actionable findings
+high|Fix race in worker lock|Use atomic lock file writes before dispatch
+medium|Document retry strategy|Add retry policy section in workflows/pulse.md
+EOF
+
+	local status=0
+	"$HELPER" create \
+		--input "$findings_file" \
+		--repo-path "$repo_path" \
+		--source security-audit \
+		--offline \
+		--no-issue \
+		--output "$output_file" >/tmp/findings-helper-success.out 2>&1 || status=$?
+
+	if [[ "$status" -ne 0 ]]; then
+		fail "create command should succeed for valid findings"
+		return 0
+	fi
+
+	if [[ $(wc -l <"$output_file" | tr -d ' ') -eq 2 ]]; then
+		pass "creates one TODO line per actionable finding"
+	else
+		fail "expected exactly 2 generated TODO lines"
+	fi
+
+	if grep -q "coverage=100%" /tmp/findings-helper-success.out; then
+		pass "reports full coverage for converted findings"
+	else
+		fail "expected coverage=100% in command output"
+	fi
+
+	if grep -q "deferred_tasks_created=2" /tmp/findings-helper-success.out; then
+		pass "reports deferred task creation count"
+	else
+		fail "expected deferred_tasks_created=2 in command output"
+	fi
+
+	return 0
+}
+
+test_fails_when_untracked_finding_remains() {
+	local repo_path="$1"
+	local findings_file="$2"
+
+	cat >"$findings_file" <<'EOF'
+||missing title should fail conversion
+EOF
+
+	local status=0
+	"$HELPER" create \
+		--input "$findings_file" \
+		--repo-path "$repo_path" \
+		--source review \
+		--offline \
+		--no-issue >/tmp/findings-helper-fail.out 2>&1 || status=$?
+
+	if [[ "$status" -ne 0 ]]; then
+		pass "fails when a finding cannot be converted"
+	else
+		fail "expected non-zero exit when conversion fails"
+	fi
+
+	if grep -q "coverage=0%" /tmp/findings-helper-fail.out; then
+		pass "reports non-100% coverage for failed conversion"
+	else
+		fail "expected coverage=0% in failed conversion output"
+	fi
+
+	return 0
+}
+
+main() {
+	trap cleanup EXIT
+
+	TEST_DIR="$(mktemp -d)"
+	local repo_path="${TEST_DIR}/repo"
+	local findings_file="${TEST_DIR}/findings.txt"
+	local output_file="${TEST_DIR}/todo-lines.txt"
+
+	if [[ ! -x "$HELPER" ]]; then
+		echo "Helper not executable: $HELPER"
+		exit 1
+	fi
+
+	setup_repo "$repo_path"
+	test_successful_conversion "$repo_path" "$findings_file" "$output_file"
+	test_fails_when_untracked_finding_remains "$repo_path" "$findings_file"
+
+	echo ""
+	echo "Tests passed: $PASS"
+	echo "Tests failed: $FAIL"
+
+	if [[ "$FAIL" -gt 0 ]]; then
+		return 1
+	fi
+
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Agents producing multi-finding audit/review/scan reports were fixing easy items in the current PR but leaving deferred actionable findings untracked, causing them to silently drop from the task queue (observed: ILDS t068 security audit — 3 medium findings not tracked until user explicitly asked)
- Adds a framework-level rule and helper script so every deferred actionable finding is converted to a tracked task before a report is declared complete
- ShellCheck: zero violations on both new scripts

## Changes

### `prompts/build.txt`
Added finding-to-task completeness rule to the "Completion and quality discipline" section. Every deferred actionable finding must become a tracked task (TODO entry + GitHub issue) before a report is declared complete.

### `scripts/commands/full-loop.md`
Added criterion 8 — **Actionable finding coverage** — to the `TASK_COMPLETE` gate. Includes mandatory procedure: build a `severity|title|details` file for deferred items, run `findings-to-tasks-helper.sh create`, and include coverage proof in the PR body. Coverage below 100% = task not complete.

### `scripts/commands/findings-to-tasks.md` (new)
New `/findings-to-tasks` command doc. Documents the pipe-delimited input format, helper invocation with all flags, and the completion rule.

### `scripts/findings-to-tasks-helper.sh` (new)
New helper script. Reads `severity|title|details` lines from an input file, calls `claim-task-id.sh` per finding to allocate a task ID and optionally create a GitHub issue, emits TODO-format lines, and prints coverage metrics (`actionable_findings_total`, `deferred_tasks_created`, `coverage`). Exits non-zero if coverage < 100% unless `--allow-partial` is passed.

### `scripts/tests/test-findings-to-tasks-helper.sh` (new)
Unit tests: successful 2-finding conversion (coverage=100%, correct line count), and failure path when a finding has an empty title (coverage=0%, non-zero exit).

## Verification

```
shellcheck .agents/scripts/findings-to-tasks-helper.sh        # zero violations
shellcheck .agents/scripts/tests/test-findings-to-tasks-helper.sh  # zero violations
```

Closes #4585