### PR TITLE
fix(t1327): address PR #2255 review feedback on t1327-brief.md

### DIFF
--- a/todo/tasks/t1327-brief.md
+++ b/todo/tasks/t1327-brief.md
@@ -75,6 +75,7 @@ aidevops SimpleX Bot (TypeScript/Bun process)
 
 **CLI** (from docs/CLI.md):
 - Install: `curl -o- https://raw.githubusercontent.com/simplex-chat/simplex-chat/stable/install.sh | bash`
+  > ⚠️ **Opsec note:** Inspect the script before executing (`curl ... | cat`), or prefer the verified binary from [GitHub Releases](https://github.com/simplex-chat/simplex-chat/releases) with checksum verification.
 - Database: SQLite files (`simplex_v1_chat.db`, `simplex_v1_agent.db`)
 - Tor support: `-x` flag or `--socks-proxy`
 - Custom SMP servers: `-s smp://fingerprint@host`
@@ -262,7 +263,7 @@ Key decisions from the conversation:
 | Opsec agent (opsec.md) | 3h | Security guidance cross-referencing existing agents |
 | Chat security (t1327.8-10) | 6h | Prompt injection, leak detection, exec approval |
 | Integration/testing | 4h | Index updates, end-to-end tests, linting |
-| **Total** | **~29h** | (ai:22h test:4h read:3h) |
+| **Total** | **~29h** | (ai:21h test:5h read:3h) |
 
 ## Research Notes
 


### PR DESCRIPTION
## Summary

Addresses the two unactioned review findings from PR #2255 on `todo/tasks/t1327-brief.md`.

- **CodeRabbit (HIGH):** Added opsec caveat to the `curl | bash` install command at line 77. The note recommends inspecting the script before piping to bash, or using the verified binary from GitHub Releases with checksum verification — consistent with the opsec-first posture of the project being built.
- **Gemini (MEDIUM):** Corrected the estimate breakdown totals annotation from `(ai:22h test:4h read:3h)` to `(ai:21h test:5h read:3h)` to match the reviewed suggestion and align with the phase breakdown.

Closes #3308