### PR TITLE
t4585: Add finding-to-task rule to Completion and quality discipline

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -63,6 +63,7 @@ Before executing any non-trivial task, explicitly restate: (1) the actual goal â
 - Build for change. Don't hardcode what should be parameterized. Design for variation.
 - Prefer lightweight approaches. Simpler tools over heavy dependencies.
 - Crash-resilient by default. Any process, session, or machine can die at any moment â€” power loss, OOM, network drop, stuck LLM. Every process must recover from a cold start by reading current state, not by assuming a previous step completed. Never chain processes where B depends on A having succeeded without B independently verifying A's outcome. If a process needs to know "did the last run finish?", it should check the result (does the PR exist? is the issue closed?), not rely on a flag the last run was supposed to set.
+- Finding-to-task rule: When producing any multi-finding report (security audit, code review, SEO scan, accessibility check, performance review, etc.), every actionable finding must become a tracked task (TODO.md entry + GitHub issue) before the report is declared complete. Findings fixed in the current PR are tracked by the PR itself. Findings deferred for later must each get their own task ID. A report with untracked actionable findings is incomplete. This applies to all agent types and all report-producing workflows.
 
 # Claim discipline (turn-end gate)
 - Do not present future intent as completed work.


### PR DESCRIPTION
## Summary

- Adds a **finding-to-task rule** to the `# Completion and quality discipline` section in `.agents/prompts/build.txt`
- Every actionable finding from any multi-finding report (security audit, code review, SEO scan, accessibility check, performance review, etc.) must become a tracked task (TODO.md entry + GitHub issue) before the report is declared complete
- Findings fixed in the current PR are tracked by the PR itself; findings deferred for later each get their own task ID
- A report with untracked actionable findings is incomplete
- Applies to all agent types and all report-producing workflows

## Root cause addressed

Agents were treating the report itself as the deliverable rather than treating each actionable finding as a task requiring tracking. This caused deferred findings to silently drop out of the task queue (observed in ILDS t068 security audit session).

## Change

Single rule added to `.agents/prompts/build.txt:66` in the `Completion and quality discipline` section — framework-level, applies on every agent update/deploy via `setup.sh`.

Closes #4585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal guidelines for handling multi-finding reports and task tracking procedures across all agent workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->