### PR TITLE
t1350: close quality-debt loop — MD031 already fixed in PR #2468

### DIFF
--- a/todo/tasks/t1350-brief.md
+++ b/todo/tasks/t1350-brief.md
@@ -45,3 +45,9 @@ Agents running `setup.sh` without `--non-interactive` flag get stuck or fail sil
 - Uses `[[ ! -t 0 ]]` (stdin not a tty) as the detection signal — standard POSIX approach
 - `AIDEVOPS_NON_INTERACTIVE` env var already supported (line 30 of setup.sh)
 - Codacy/SonarCloud: documentation-only changes in other PRs may flag advisory issues; these are not blocking
+
+## Resolution
+
+- **PR #2468** merged with blank lines around the fenced code block in the How section (MD031 compliant as merged)
+- **Issue #3321**: Quality-debt scanner flagged this as unactioned; the fix was included in the original PR — confirmed by `markdownlint-cli2` (0 errors)
+- No additional code changes required; brief updated to close the quality-debt loop


### PR DESCRIPTION
## Summary

- The markdownlint MD031 finding (fenced code blocks without surrounding blank lines in `todo/tasks/t1350-brief.md`) was **already fixed before PR #2468 was merged** — blank lines are present in the merged file, and `markdownlint-cli2` confirms 0 errors
- The quality-feedback scanner (issue #3321) flagged it as unactioned because it tracks PR review comments by existence, not by whether the fix was applied
- Added a `## Resolution` section to the brief to document this finding and close the quality-debt loop

## Verification

```
markdownlint-cli2: 0 error(s) on todo/tasks/t1350-brief.md
```

## Files Changed

- `todo/tasks/t1350-brief.md` — added Resolution section (1 file, 6 lines added)

Closes #3321