### PR TITLE
t3299: fix PR #2326 review feedback on model-routing.md

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -114,6 +114,7 @@ get_tier_models() {
 	# Check if OpenCode is available (CLI installed and models cache exists)
 	if _is_opencode_available; then
 		case "$tier" in
+		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
 		haiku) echo "opencode/claude-haiku-4-5|opencode/gemini-3-flash" ;;
 		flash) echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
 		sonnet) echo "opencode/claude-sonnet-4-6|anthropic/claude-sonnet-4-6" ;;
@@ -126,8 +127,8 @@ get_tier_models() {
 		esac
 	else
 		case "$tier" in
+		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
 		haiku) echo "anthropic/claude-haiku-4-5|google/gemini-2.5-flash" ;;
-
 		flash) echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
 		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-4.1" ;;
 		pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;
@@ -145,7 +146,7 @@ get_tier_models() {
 is_known_tier() {
 	local tier="$1"
 	case "$tier" in
-	haiku | flash | sonnet | pro | opus | health | eval | coding) return 0 ;;
+	local | haiku | flash | sonnet | pro | opus | health | eval | coding) return 0 ;;
 	*) return 1 ;;
 	esac
 }

--- a/.agents/scripts/model-label-helper.sh
+++ b/.agents/scripts/model-label-helper.sh
@@ -31,7 +31,7 @@ set -euo pipefail
 readonly VALID_ACTIONS="planned researched implemented reviewed verified documented failed retried"
 
 # Valid model tiers (matches model-routing.md and pattern-tracker)
-readonly VALID_MODELS="haiku flash sonnet pro opus"
+readonly VALID_MODELS="local haiku flash sonnet pro opus"
 
 #######################################
 # Show help
@@ -56,7 +56,7 @@ ACTIONS:
     planned, researched, implemented, reviewed, verified, documented, failed, retried
 
 MODELS:
-    haiku, flash, sonnet, pro, opus (or concrete model names like claude-sonnet-4-6)
+    local, haiku, flash, sonnet, pro, opus (or concrete model names like claude-sonnet-4-6)
 
 EXAMPLES:
     # Add label when dispatching a task

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -22,7 +22,7 @@ model: haiku
 - **Purpose**: Route tasks to the cheapest model that can handle them well
 - **Philosophy**: Use the smallest model that produces acceptable quality
 - **Default**: sonnet (best balance of cost/capability for most tasks)
-- **Cost spectrum**: local (free) -> haiku -> flash -> sonnet -> pro -> opus (highest)
+- **Cost spectrum**: local (free) -> flash -> haiku -> sonnet -> pro -> opus (highest)
 
 ## Model Tiers
 


### PR DESCRIPTION
## Summary

Addresses all 5 findings from the PR #2326 review (gemini + augmentcode bots) on `.agents/tools/context/model-routing.md`.

## Changes

| Finding | Severity | Fix |
|---------|----------|-----|
| Cost spectrum lists haiku before flash, but flash is cheaper (~0.20x vs ~0.25x) | HIGH | Corrected order to `local -> flash -> haiku -> sonnet -> pro -> opus` in Quick Reference |
| Limitations and fallback behaviour mixed in one paragraph | MEDIUM | Already resolved in the merged PR (separate `**Limitations**` and `**Fallback behaviour**` paragraphs exist) |
| `model: local` valid in frontmatter but `local` excluded from tier validation in scripts | MEDIUM | Added `local` to `VALID_MODELS` in `model-label-helper.sh` and to `is_known_tier()` + `get_tier_models()` in `model-availability-helper.sh` |
| `tools/local-models/local-models.md` referenced but not yet in repo | MEDIUM | File now exists (created in t1338.2-6 after PR #2326 merged) — no doc change needed |
| `local-model-helper.sh` referenced but not yet in repo | MEDIUM | Script now exists with `status` and `models` commands — no doc change needed |

## Files changed (3 of 5 max)

- `.agents/tools/context/model-routing.md` — cost spectrum order fix
- `.agents/scripts/model-label-helper.sh` — add `local` to VALID_MODELS
- `.agents/scripts/model-availability-helper.sh` — add `local` to tier validation and model resolution

## Verification

- `shellcheck` on both modified scripts: 0 new violations (pre-existing SC1091 info only)
- `git ls-files` confirms `tools/local-models/local-models.md`, `tools/local-models/huggingface.md`, and `scripts/local-model-helper.sh` all exist

Closes #3299