### PR TITLE
t1481: refactor: centralize routing taxonomy tables into single canonical reference

### DIFF
--- a/.agents/reference/task-taxonomy.md
+++ b/.agents/reference/task-taxonomy.md
@@ -1,0 +1,73 @@
+# Task Taxonomy — Canonical Routing Reference
+
+Authoritative source for domain-routing and model-tier classification tables.
+Referenced by `scripts/commands/new-task.md`, `scripts/commands/save-todo.md`, and `scripts/commands/define.md`.
+
+Update this file when adding domains or changing tier criteria. All three command files will reflect the change automatically.
+
+---
+
+## Domain Routing
+
+Maps task signal words to the specialist agent that handles it at dispatch time.
+Add the TODO tag and GitHub label to the task entry when the domain matches.
+**Omit domain tags for code tasks** — Build+ is the default and needs no label.
+
+| Domain Signal | TODO Tag | GitHub Label | Agent |
+|--------------|----------|--------------|-------|
+| SEO audit, keywords, GSC, schema markup, rankings | `#seo` | `seo` | SEO |
+| Blog posts, articles, newsletters, video scripts, social copy | `#content` | `content` | Content |
+| Email campaigns, FluentCRM, landing pages | `#marketing` | `marketing` | Marketing |
+| Invoicing, receipts, financial ops, bookkeeping | `#accounts` | `accounts` | Accounts |
+| Compliance, terms of service, privacy policy, GDPR | `#legal` | `legal` | Legal |
+| Tech research, competitive analysis, market research, spikes | `#research` | `research` | Research |
+| CRM pipeline, proposals, outreach | `#sales` | `sales` | Sales |
+| Social media scheduling, posting, engagement | `#social-media` | `social-media` | Social-Media |
+| Video generation, editing, animation, prompts | `#video` | `video` | Video |
+| Health and wellness content, nutrition | `#health` | `health` | Health |
+| Code: features, bug fixes, refactors, CI, tests | *(none)* | *(none)* | Build+ (default) |
+
+---
+
+## Model Tier
+
+Maps task reasoning complexity to the worker intelligence level used at dispatch time.
+**Default to no tier tag** — most tasks are coding tasks that use sonnet.
+Only add a tier tag when the task clearly needs more reasoning power (thinking) or clearly needs less (simple).
+
+| Tier | TODO Tag | GitHub Label | When to Apply |
+|------|----------|--------------|---------------|
+| thinking | `tier:thinking` | `tier:thinking` | Architecture decisions, novel design with no existing patterns, complex multi-system trade-offs, security audits requiring deep reasoning |
+| simple | `tier:simple` | `tier:simple` | Docs-only changes, simple renames, formatting, config tweaks, label/tag updates |
+| *(coding)* | *(none)* | *(none)* | Standard implementation, bug fixes, refactors, tests — **default, no tag needed** |
+
+---
+
+## Usage
+
+In task creation commands, reference this file instead of maintaining inline copies:
+
+```text
+See `reference/task-taxonomy.md` for domain routing and model tier classification tables.
+```
+
+Apply labels to the GitHub issue when a task ref exists:
+
+```bash
+REPO_SLUG="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
+if [[ -n "$task_ref" && -n "$REPO_SLUG" ]]; then
+  ISSUE_NUM="${task_ref#GH#}"
+  # Apply tier label (only for non-default tiers)
+  if [[ -n "$tier_label" ]]; then
+    gh label create "$tier_label" --repo "$REPO_SLUG" >/dev/null 2>&1 || true
+    gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" --add-label "$tier_label" >/dev/null 2>&1 || \
+      echo "[task] WARN: failed to apply tier label '$tier_label' to ${task_ref}" >&2
+  fi
+  # Apply domain label (only for non-code domains)
+  if [[ -n "$domain_label" ]]; then
+    gh label create "$domain_label" --repo "$REPO_SLUG" >/dev/null 2>&1 || true
+    gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" --add-label "$domain_label" >/dev/null 2>&1 || \
+      echo "[task] WARN: failed to apply domain label '$domain_label' to ${task_ref}" >&2
+  fi
+fi
+```

--- a/.agents/scripts/commands/define.md
+++ b/.agents/scripts/commands/define.md
@@ -38,32 +38,9 @@ Parse `$ARGUMENTS` to classify the task. Use keyword signals:
 | **docs** | document, readme, guide, explain, describe | Accurate, concise, follows existing doc patterns |
 | **research** | investigate, explore, evaluate, compare, spike | Time-boxed, deliverable is a written recommendation |
 
-Also classify the **agent domain** — this determines which specialist agent handles the task at dispatch time:
-
-| Domain | Signal Words | Agent |
-|--------|-------------|-------|
-| **seo** | SEO, keywords, rankings, GSC, schema markup | SEO |
-| **content** | blog, article, newsletter, video script, copy | Content |
-| **marketing** | campaign, email blast, landing page, FluentCRM | Marketing |
-| **accounts** | invoice, receipt, financial, bookkeeping | Accounts |
-| **legal** | compliance, terms, privacy policy, GDPR | Legal |
-| **research** | market research, competitive analysis, tech spike | Research |
-| **sales** | CRM, proposal, outreach, pipeline | Sales |
-| **social-media** | social post, scheduling, engagement | Social-Media |
-| **video** | video generation, editing, animation | Video |
-| **health** | wellness, health content, nutrition | Health |
-| *(code)* | implement, fix, refactor, CI, test | Build+ (default — no label needed) |
+Also classify the **agent domain** and **model tier** — see `reference/task-taxonomy.md` for the full classification tables (domain signal words, TODO tags, GitHub labels, agents, and tier criteria).
 
 Include the domain tag (e.g., `#seo`, `#content`) in the TODO.md entry and as a GitHub label on the issue. Omit for code tasks.
-
-Also classify the **model tier** — this determines the intelligence level of the worker dispatched for this task:
-
-| Tier | Tag | Signals |
-|------|-----|---------|
-| **thinking** | `tier:thinking` | Architecture decisions, novel design with no existing patterns, complex multi-system trade-offs, security audits requiring deep reasoning |
-| **simple** | `tier:simple` | Docs-only changes, simple renames/formatting, config tweaks, label/tag updates |
-| *(coding)* | *(none)* | Standard implementation, bug fixes, refactors, tests — **default, no tag needed** |
-
 Default to no tier tag — most tasks are coding (sonnet). Only tag when the task clearly needs more reasoning power or clearly needs less.
 
 If ambiguous, ask:

--- a/.agents/scripts/commands/new-task.md
+++ b/.agents/scripts/commands/new-task.md
@@ -185,61 +185,10 @@ If the brief is too thin for auto-dispatch, omit the tag and note why.
 
 ### Step 6.5: Apply Model Tier and Agent Routing Labels
 
-**Model tier label** — Evaluate the task's reasoning complexity and add a tier tag. This tells the pulse which model intelligence level to use at dispatch time:
+Classify the task using the domain routing and model tier tables in `reference/task-taxonomy.md`.
+Add the matching TODO tag to the entry and apply the GitHub label to the issue (if `task_ref` exists).
 
-| Tier | TODO Tag | GitHub Label | When to Apply |
-|------|----------|--------------|---------------|
-| thinking | `tier:thinking` | `tier:thinking` | Architecture decisions, novel design, complex trade-offs, security audits, multi-system reasoning |
-| simple | `tier:simple` | `tier:simple` | Docs-only, simple renames, formatting, config changes, label/tag updates |
-| *(coding)* | *(none)* | *(none)* | Standard implementation, bug fixes, refactors, tests — **default, no label needed** |
-
-**Default to no tier label** — most tasks are coding tasks that use sonnet. Only add a tier label when the task clearly needs more reasoning power (thinking) or clearly needs less (simple). When uncertain, omit the label — sonnet handles the vast majority of work well.
-
-**Agent routing label** — Evaluate whether the task maps to a specialist agent domain. If it does, add the corresponding tag to the TODO.md entry AND apply the matching GitHub label to the issue (if `task_ref` exists).
-
-| Domain Signal | TODO Tag | GitHub Label | Agent |
-|--------------|----------|--------------|-------|
-| SEO audit, keywords, GSC, schema markup, rankings | `#seo` | `seo` | SEO |
-| Blog posts, video scripts, newsletters, social copy | `#content` | `content` | Content |
-| Email campaigns, FluentCRM, landing pages | `#marketing` | `marketing` | Marketing |
-| Invoicing, receipts, financial ops | `#accounts` | `accounts` | Accounts |
-| Compliance, terms of service, privacy policy | `#legal` | `legal` | Legal |
-| Tech research, competitive analysis, market research | `#research` | `research` | Research |
-| CRM pipeline, proposals, outreach | `#sales` | `sales` | Sales |
-| Social media scheduling, posting | `#social-media` | `social-media` | Social-Media |
-| Video generation, editing, prompts | `#video` | `video` | Video |
-| Health and wellness content | `#health` | `health` | Health |
-| Code: features, bug fixes, refactors, CI | *(none)* | *(none)* | Build+ (default) |
-
-**Omit the domain tag for code tasks** — Build+ is the default and needs no label.
-
-If the task clearly matches a domain, apply the label:
-
-```bash
-# Apply labels if task_ref exists (issue was created)
-REPO_SLUG="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)"
-if [[ -n "$task_ref" && -n "$REPO_SLUG" ]]; then
-  ISSUE_NUM="${task_ref#GH#}"
-  # Apply tier label (only for non-default tiers)
-  if [[ -n "$tier_label" ]]; then
-    gh label create "$tier_label" --repo "$REPO_SLUG" >/dev/null 2>&1 || true
-    if ! gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" --add-label "$tier_label" >/dev/null 2>&1; then
-      echo "[new-task] WARN: failed to apply tier label '$tier_label' to ${task_ref}" >&2
-    fi
-  fi
-  # Apply domain label (only for non-code domains)
-  if [[ -n "$domain_label" ]]; then
-    gh label create "$domain_label" --repo "$REPO_SLUG" >/dev/null 2>&1 || true
-    if ! gh issue edit "$ISSUE_NUM" --repo "$REPO_SLUG" --add-label "$domain_label" >/dev/null 2>&1; then
-      echo "[new-task] WARN: failed to apply domain label '$domain_label' to ${task_ref}" >&2
-    fi
-  fi
-else
-  if [[ -n "$task_ref" ]]; then
-    echo "[new-task] WARN: unable to resolve repo slug for label application" >&2
-  fi
-fi
-```
+See `reference/task-taxonomy.md` for the label application bash snippet and full classification criteria.
 
 ### Step 7: Commit and Push
 

--- a/.agents/scripts/commands/save-todo.md
+++ b/.agents/scripts/commands/save-todo.md
@@ -47,31 +47,9 @@ Every task MUST be evaluated for these pipeline tags:
 
 **`#plan`** — Add when the task needs decomposition into subtasks before implementation (multi-phase, >2h, research/design needed).
 
-**Model tier tags** — Evaluate the task's reasoning complexity:
-
-| Tier | Tag | When to Apply |
-|------|-----|---------------|
-| thinking | `tier:thinking` | Architecture, novel design, complex trade-offs, security audits |
-| simple | `tier:simple` | Docs-only, simple renames, formatting, config changes |
-| *(coding)* | *(none)* | Standard implementation, bug fixes, refactors — **default, no tag needed** |
+**Model tier tags** and **agent domain tags** — See `reference/task-taxonomy.md` for the full classification tables and criteria.
 
 Default to no tier tag. Most tasks are coding tasks (sonnet). Only tag exceptions.
-
-**Agent domain tags** — If the task maps to a specialist agent domain, add the corresponding tag. This enables the pulse to route dispatch to the correct agent without guessing from the title:
-
-| Domain | Tag | Agent |
-|--------|-----|-------|
-| SEO, keywords, rankings, GSC | `#seo` | SEO |
-| Blog posts, newsletters, video scripts | `#content` | Content |
-| Email campaigns, landing pages | `#marketing` | Marketing |
-| Invoicing, financial ops | `#accounts` | Accounts |
-| Compliance, legal docs | `#legal` | Legal |
-| Research, analysis, spikes | `#research` | Research |
-| CRM, proposals, outreach | `#sales` | Sales |
-| Social media management | `#social-media` | Social-Media |
-| Video generation/editing | `#video` | Video |
-| Health/wellness content | `#health` | Health |
-
 Omit domain tags for code tasks — Build+ is the default.
 
 **Default to `#auto-dispatch`** — only omit when a specific exclusion applies. This keeps the autonomous pipeline moving. See `workflows/plans.md` "Auto-Dispatch Tagging" for full criteria.


### PR DESCRIPTION
## Summary

- Creates `reference/task-taxonomy.md` as the single authoritative source for domain-routing (10 rows) and model-tier (2 rows) classification tables
- Removes inline table copies from `new-task.md`, `save-todo.md`, and `define.md` — each now references the canonical file
- Canonical tables are a superset of all three versions (merged column structures and wording)

## Motivation

PR #4573 added agent routing and model tier labels to three task creation commands. CodeRabbit flagged that all three files now maintain their own copies of the same tables with minor wording differences. One update point prevents drift.

## Changes

| File | Change |
|------|--------|
| `.agents/reference/task-taxonomy.md` | **New** — canonical domain + tier tables with full column set |
| `.agents/scripts/commands/new-task.md` | Replaced inline tables + bash block with reference pointer |
| `.agents/scripts/commands/save-todo.md` | Replaced inline tables with reference pointer |
| `.agents/scripts/commands/define.md` | Replaced inline tables with reference pointer |

## Verification

- Markdown lint clean on all four files (markdownlint-cli2)
- No information lost — canonical tables include all columns and rows from all three source versions
- No shell files changed (ShellCheck not applicable)

Closes #4574