### PR TITLE
t3705: Fix misplaced rebase_sibling_pr() header comment (quality-debt PR #1478)

### DIFF
--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -2328,9 +2328,9 @@ _resolve_rebase_loop() {
 }
 
 #######################################
-# Rebase a single PR branch onto updated main (t225, t302, t1048)
+# Rebase a single PR branch onto the PR's base ref (or 'main' if absent).
 # Used after merging a sibling's PR to prevent cascading conflicts.
-# Operates on the worktree if available, otherwise creates a temp worktree.
+# Prefers using an existing worktree; creates a temporary worktree only when necessary.
 # On conflict, uses escalating resolution via _resolve_rebase_loop (AI CLI).
 # Detects AI-completed rebases via rebase-merge/rebase-apply directory checks
 # to avoid "fatal: no rebase in progress" on git rebase --continue.

--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -2328,9 +2328,9 @@ _resolve_rebase_loop() {
 }
 
 #######################################
-# Rebase a single PR branch onto the PR's base ref (or 'main' if absent).
-# Used after merging a sibling's PR to prevent cascading conflicts.
-# Prefers using an existing worktree; creates a temporary worktree only when necessary.
+# Rebase a single PR branch onto its PR base branch (fallback: main) (t225, t302, t1048)
+# Used after merging sibling PRs and by the auto-rebase path for BEHIND/DIRTY PRs.
+# Operates on the worktree if available; otherwise temporarily checks out the branch in the main repo.
 # On conflict, uses escalating resolution via _resolve_rebase_loop (AI CLI).
 # Detects AI-completed rebases via rebase-merge/rebase-apply directory checks
 # to avoid "fatal: no rebase in progress" on git rebase --continue.

--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -2269,15 +2269,6 @@ TASK:
 	return 0
 }
 #######################################
-# Rebase a single PR branch onto updated main (t225, t302)
-# Used after merging a sibling's PR to prevent cascading conflicts.
-# Operates on the worktree if available, otherwise creates a temp worktree.
-# On conflict, uses escalating resolution: plain -> -Xtheirs -> AI CLI (t302).
-# Args: task_id
-# Returns: 0 on success, 1 on rebase failure, 2 on force-push failure
-#######################################
-
-#######################################
 # t1072: Resolve rebase conflicts in a loop for multi-commit branches.
 # When a branch has N commits and multiple conflict with main, we need
 # to resolve each one and continue until the rebase completes.
@@ -2336,6 +2327,16 @@ _resolve_rebase_loop() {
 	return 1
 }
 
+#######################################
+# Rebase a single PR branch onto updated main (t225, t302, t1048)
+# Used after merging a sibling's PR to prevent cascading conflicts.
+# Operates on the worktree if available, otherwise creates a temp worktree.
+# On conflict, uses escalating resolution via _resolve_rebase_loop (AI CLI).
+# Detects AI-completed rebases via rebase-merge/rebase-apply directory checks
+# to avoid "fatal: no rebase in progress" on git rebase --continue.
+# Args: task_id
+# Returns: 0 on success, 1 on rebase failure, 2 on force-push failure
+#######################################
 rebase_sibling_pr() {
 	local task_id="$1"
 


### PR DESCRIPTION
## Summary

Addresses quality-debt from PR #1478 review (issue #3705).

The gemini reviewer confirmed PR #1478 correctly handled the auto-rebase race condition. On reviewing the code, one genuine quality issue was found: the `rebase_sibling_pr()` function header comment was orphaned above `_resolve_rebase_loop()` after t1072 inserted the helper function between the comment and its target.

## Changes

- **`.agents/scripts/supervisor-archived/deploy.sh`**: Moved the `rebase_sibling_pr()` header comment to sit directly above the function it describes. Updated the comment to reference t1048 and the `rebase-merge`/`rebase-apply` directory detection approach introduced in PR #1478 (replacing the original `REBASE_HEAD` check with the more robust directory check).

## Verification

- ShellCheck: 0 violations (unchanged)
- No logic changes — documentation only

## Context

The gemini review on PR #1478 was positive with no actionable code changes. Two contributors had already recommended closing #3705 as not actionable. The only genuine improvement found was this misplaced comment, which is a real (if minor) documentation bug that would confuse future readers of the archived code.

Closes #3705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-assisted conflict resolution during automated PR rebases to reduce manual intervention.
  * Dynamic detection of PR base branch (fallback to main) for more accurate rebase targets.

* **Chores**
  * Improved rebase automation with safer force-push and optional mirror-push behavior.
  * Better handling of dirty worktrees, stash/cleanup, and post-merge sibling PR rebases.
  * Enhanced logging and error handling for more reliable deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->