### PR TITLE
fix: replace bash 4.0+ features with portable alternatives in 5 scripts

### DIFF
--- a/.agents/scripts/bundle-helper.sh
+++ b/.agents/scripts/bundle-helper.sh
@@ -413,8 +413,10 @@ cmd_resolve() {
 	fi
 
 	if [[ -n "$detected" ]]; then
-		local detected_array
-		mapfile -t detected_array <<<"$detected"
+		local detected_array=()
+		while IFS= read -r _line; do
+			[[ -n "$_line" ]] && detected_array+=("$_line")
+		done <<<"$detected"
 
 		if [[ ${#detected_array[@]} -eq 1 ]]; then
 			cmd_load "${detected_array[0]}"

--- a/.agents/scripts/linter-manager.sh
+++ b/.agents/scripts/linter-manager.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Linter Manager - CodeFactor-Inspired Multi-Language Linter Installation
 # Based on CodeFactor's comprehensive linter collection
-# 
+#
 # Author: AI DevOps Framework
 # Version: 1.1.1
 # Reference: https://docs.codefactor.io/bootcamp/analysis-tools/
@@ -13,557 +13,559 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 # Common constants
 print_header() {
-    local message="$1"
-    echo -e "${PURPLE}🔧 $message${NC}"
-    echo "=========================================="
-    return 0
+	local message="$1"
+	echo -e "${PURPLE}🔧 $message${NC}"
+	echo "=========================================="
+	return 0
 }
 
 # Install global npm package (prefers Bun if available)
 install_npm_global() {
-    local packages=("$@")
-    if command -v bun &>/dev/null; then
-        bun install -g "${packages[@]}" &>/dev/null
-    elif command -v npm &>/dev/null; then
-        npm install -g --ignore-scripts "${packages[@]}" &>/dev/null
-    else
-        return 1
-    fi
+	local packages=("$@")
+	if command -v bun &>/dev/null; then
+		bun install -g "${packages[@]}" &>/dev/null
+	elif command -v npm &>/dev/null; then
+		npm install -g --ignore-scripts "${packages[@]}" &>/dev/null
+	else
+		return 1
+	fi
 }
 
 # Detect project languages and frameworks
 detect_project_languages() {
-    local languages=()
-    
-    # Python
-    if [[ -f "requirements.txt" || -f "setup.py" || -f "pyproject.toml" || -f "Pipfile" ]]; then
-        languages+=("python")
-    fi
-    
-    # JavaScript/TypeScript/Node.js
-    if [[ -f "package.json" || -f "tsconfig.json" ]]; then
-        languages+=("javascript")
-    fi
-    
-    # CSS/SCSS/Less
-    if find . -name "*.css" -o -name "*.scss" -o -name "*.less" -o -name "*.sass" | head -1 | grep -q .; then
-        languages+=("css")
-    fi
-    
-    # Shell scripts
-    if find . -name "*.sh" -o -name "*.bash" -o -name "*.zsh" | head -1 | grep -q .; then
-        languages+=("shell")
-    fi
-    
-    # Docker
-    if [[ -f "Dockerfile" ]] || find . -name "Dockerfile*" | head -1 | grep -q .; then
-        languages+=("docker")
-    fi
-    
-    # YAML
-    if find . -name "*.yml" -o -name "*.yaml" | head -1 | grep -q .; then
-        languages+=("yaml")
-    fi
-    
-    # Go
-    if [[ -f "go.mod" || -f "go.sum" ]]; then
-        languages+=("go")
-    fi
-    
-    # PHP
-    if [[ -f "composer.json" ]] || find . -name "*.php" | head -1 | grep -q .; then
-        languages+=("php")
-    fi
-    
-    # Ruby
-    if [[ -f "Gemfile" || -f "Rakefile" ]] || find . -name "*.rb" | head -1 | grep -q .; then
-        languages+=("ruby")
-    fi
-    
-    # Java
-    if [[ -f "pom.xml" || -f "build.gradle" ]] || find . -name "*.java" | head -1 | grep -q .; then
-        languages+=("java")
-    fi
-    
-    # C#
-    if find . -name "*.cs" -o -name "*.csproj" -o -name "*.sln" | head -1 | grep -q .; then
-        languages+=("csharp")
-    fi
-    
-    # Swift
-    if find . -name "*.swift" -o -name "Package.swift" | head -1 | grep -q .; then
-        languages+=("swift")
-    fi
-    
-    # Kotlin
-    if find . -name "*.kt" -o -name "*.kts" | head -1 | grep -q .; then
-        languages+=("kotlin")
-    fi
-    
-    # Dart/Flutter
-    if [[ -f "pubspec.yaml" ]] || find . -name "*.dart" | head -1 | grep -q .; then
-        languages+=("dart")
-    fi
-    
-    # R
-    if find . -name "*.R" -o -name "*.r" -o -name "DESCRIPTION" | head -1 | grep -q .; then
-        languages+=("r")
-    fi
-    
-    # C/C++
-    if find . -name "*.c" -o -name "*.cpp" -o -name "*.cc" -o -name "*.h" -o -name "*.hpp" | head -1 | grep -q .; then
-        languages+=("cpp")
-    fi
-    
-    # Haskell
-    if find . -name "*.hs" -o -name "*.lhs" -o -name "*.cabal" | head -1 | grep -q .; then
-        languages+=("haskell")
-    fi
-    
-    # Groovy
-    if find . -name "*.groovy" -o -name "*.gradle" | head -1 | grep -q .; then
-        languages+=("groovy")
-    fi
-    
-    # PowerShell
-    if find . -name "*.ps1" -o -name "*.psm1" -o -name "*.psd1" | head -1 | grep -q .; then
-        languages+=("powershell")
-    fi
-    
-    # Security scanning (always relevant)
-    languages+=("security")
-    
-    printf '%s\n' "${languages[@]}"
-    return 0
+	local languages=()
+
+	# Python
+	if [[ -f "requirements.txt" || -f "setup.py" || -f "pyproject.toml" || -f "Pipfile" ]]; then
+		languages+=("python")
+	fi
+
+	# JavaScript/TypeScript/Node.js
+	if [[ -f "package.json" || -f "tsconfig.json" ]]; then
+		languages+=("javascript")
+	fi
+
+	# CSS/SCSS/Less
+	if find . -name "*.css" -o -name "*.scss" -o -name "*.less" -o -name "*.sass" | head -1 | grep -q .; then
+		languages+=("css")
+	fi
+
+	# Shell scripts
+	if find . -name "*.sh" -o -name "*.bash" -o -name "*.zsh" | head -1 | grep -q .; then
+		languages+=("shell")
+	fi
+
+	# Docker
+	if [[ -f "Dockerfile" ]] || find . -name "Dockerfile*" | head -1 | grep -q .; then
+		languages+=("docker")
+	fi
+
+	# YAML
+	if find . -name "*.yml" -o -name "*.yaml" | head -1 | grep -q .; then
+		languages+=("yaml")
+	fi
+
+	# Go
+	if [[ -f "go.mod" || -f "go.sum" ]]; then
+		languages+=("go")
+	fi
+
+	# PHP
+	if [[ -f "composer.json" ]] || find . -name "*.php" | head -1 | grep -q .; then
+		languages+=("php")
+	fi
+
+	# Ruby
+	if [[ -f "Gemfile" || -f "Rakefile" ]] || find . -name "*.rb" | head -1 | grep -q .; then
+		languages+=("ruby")
+	fi
+
+	# Java
+	if [[ -f "pom.xml" || -f "build.gradle" ]] || find . -name "*.java" | head -1 | grep -q .; then
+		languages+=("java")
+	fi
+
+	# C#
+	if find . -name "*.cs" -o -name "*.csproj" -o -name "*.sln" | head -1 | grep -q .; then
+		languages+=("csharp")
+	fi
+
+	# Swift
+	if find . -name "*.swift" -o -name "Package.swift" | head -1 | grep -q .; then
+		languages+=("swift")
+	fi
+
+	# Kotlin
+	if find . -name "*.kt" -o -name "*.kts" | head -1 | grep -q .; then
+		languages+=("kotlin")
+	fi
+
+	# Dart/Flutter
+	if [[ -f "pubspec.yaml" ]] || find . -name "*.dart" | head -1 | grep -q .; then
+		languages+=("dart")
+	fi
+
+	# R
+	if find . -name "*.R" -o -name "*.r" -o -name "DESCRIPTION" | head -1 | grep -q .; then
+		languages+=("r")
+	fi
+
+	# C/C++
+	if find . -name "*.c" -o -name "*.cpp" -o -name "*.cc" -o -name "*.h" -o -name "*.hpp" | head -1 | grep -q .; then
+		languages+=("cpp")
+	fi
+
+	# Haskell
+	if find . -name "*.hs" -o -name "*.lhs" -o -name "*.cabal" | head -1 | grep -q .; then
+		languages+=("haskell")
+	fi
+
+	# Groovy
+	if find . -name "*.groovy" -o -name "*.gradle" | head -1 | grep -q .; then
+		languages+=("groovy")
+	fi
+
+	# PowerShell
+	if find . -name "*.ps1" -o -name "*.psm1" -o -name "*.psd1" | head -1 | grep -q .; then
+		languages+=("powershell")
+	fi
+
+	# Security scanning (always relevant)
+	languages+=("security")
+
+	printf '%s\n' "${languages[@]}"
+	return 0
 }
 
 # Install Python linters (CodeFactor: pycodestyle, Pylint, Bandit, Ruff)
 install_python_linters() {
-    print_header "Installing Python Linters (CodeFactor-inspired)"
-    
-    local success=0
-    local total=0
-    
-    # pycodestyle (PEP 8 style guide checker)
-    print_info "Installing pycodestyle..."
-    if pip install pycodestyle &>/dev/null; then
-        print_success "pycodestyle installed"
-        ((++success))
-    else
-        print_error "Failed to install pycodestyle"
-    fi
-    ((++total))
-    
-    # Pylint (comprehensive Python linter)
-    print_info "Installing Pylint..."
-    if pip install pylint &>/dev/null; then
-        print_success "Pylint installed"
-        ((++success))
-    else
-        print_error "Failed to install Pylint"
-    fi
-    ((++total))
-    
-    # Bandit (security linter)
-    print_info "Installing Bandit..."
-    if pip install bandit &>/dev/null; then
-        print_success "Bandit installed"
-        ((++success))
-    else
-        print_error "Failed to install Bandit"
-    fi
-    ((++total))
-    
-    # Ruff (fast Python linter)
-    print_info "Installing Ruff..."
-    if pip install ruff &>/dev/null; then
-        print_success "Ruff installed"
-        ((++success))
-    else
-        print_error "Failed to install Ruff"
-    fi
-    ((++total))
-    
-    print_info "Python linters: $success/$total installed successfully"
-    return $((total - success))
+	print_header "Installing Python Linters (CodeFactor-inspired)"
+
+	local success=0
+	local total=0
+
+	# pycodestyle (PEP 8 style guide checker)
+	print_info "Installing pycodestyle..."
+	if pip install pycodestyle &>/dev/null; then
+		print_success "pycodestyle installed"
+		((++success))
+	else
+		print_error "Failed to install pycodestyle"
+	fi
+	((++total))
+
+	# Pylint (comprehensive Python linter)
+	print_info "Installing Pylint..."
+	if pip install pylint &>/dev/null; then
+		print_success "Pylint installed"
+		((++success))
+	else
+		print_error "Failed to install Pylint"
+	fi
+	((++total))
+
+	# Bandit (security linter)
+	print_info "Installing Bandit..."
+	if pip install bandit &>/dev/null; then
+		print_success "Bandit installed"
+		((++success))
+	else
+		print_error "Failed to install Bandit"
+	fi
+	((++total))
+
+	# Ruff (fast Python linter)
+	print_info "Installing Ruff..."
+	if pip install ruff &>/dev/null; then
+		print_success "Ruff installed"
+		((++success))
+	else
+		print_error "Failed to install Ruff"
+	fi
+	((++total))
+
+	print_info "Python linters: $success/$total installed successfully"
+	return $((total - success))
 }
 
 # Install JavaScript/TypeScript linters (CodeFactor: Oxlint, ESLint)
 install_javascript_linters() {
-    print_header "Installing JavaScript/TypeScript Linters (CodeFactor-inspired)"
+	print_header "Installing JavaScript/TypeScript Linters (CodeFactor-inspired)"
 
-    local success=0
-    local total=0
+	local success=0
+	local total=0
 
-    # ESLint (JavaScript/TypeScript linter)
-    print_info "Installing ESLint..."
-    if install_npm_global eslint; then
-        print_success "ESLint installed"
-        ((++success))
-    else
-        print_error "Failed to install ESLint"
-    fi
-    ((++total))
+	# ESLint (JavaScript/TypeScript linter)
+	print_info "Installing ESLint..."
+	if install_npm_global eslint; then
+		print_success "ESLint installed"
+		((++success))
+	else
+		print_error "Failed to install ESLint"
+	fi
+	((++total))
 
-    # TypeScript ESLint parser and plugin
-    print_info "Installing TypeScript ESLint support..."
-    if install_npm_global @typescript-eslint/parser @typescript-eslint/eslint-plugin; then
-        print_success "TypeScript ESLint support installed"
-        ((++success))
-    else
-        print_error "Failed to install TypeScript ESLint support"
-    fi
-    ((++total))
+	# TypeScript ESLint parser and plugin
+	print_info "Installing TypeScript ESLint support..."
+	if install_npm_global @typescript-eslint/parser @typescript-eslint/eslint-plugin; then
+		print_success "TypeScript ESLint support installed"
+		((++success))
+	else
+		print_error "Failed to install TypeScript ESLint support"
+	fi
+	((++total))
 
-    print_info "JavaScript/TypeScript linters: $success/$total installed successfully"
-    return $((total - success))
+	print_info "JavaScript/TypeScript linters: $success/$total installed successfully"
+	return $((total - success))
 }
 
 # Install CSS linters (CodeFactor: Stylelint)
 install_css_linters() {
-    print_header "Installing CSS/SCSS/Less Linters (CodeFactor-inspired)"
+	print_header "Installing CSS/SCSS/Less Linters (CodeFactor-inspired)"
 
-    local success=0
-    local total=0
+	local success=0
+	local total=0
 
-    # Stylelint (CSS/SCSS/Less linter)
-    print_info "Installing Stylelint..."
-    if install_npm_global stylelint stylelint-config-standard; then
-        print_success "Stylelint installed"
-        ((++success))
-    else
-        print_error "Failed to install Stylelint"
-    fi
-    ((++total))
+	# Stylelint (CSS/SCSS/Less linter)
+	print_info "Installing Stylelint..."
+	if install_npm_global stylelint stylelint-config-standard; then
+		print_success "Stylelint installed"
+		((++success))
+	else
+		print_error "Failed to install Stylelint"
+	fi
+	((++total))
 
-    print_info "CSS linters: $success/$total installed successfully"
-    return $((total - success))
+	print_info "CSS linters: $success/$total installed successfully"
+	return $((total - success))
 }
 
 # Install Shell linters (CodeFactor: ShellCheck)
 install_shell_linters() {
-    print_header "Installing Shell Script Linters (CodeFactor-inspired)"
+	print_header "Installing Shell Script Linters (CodeFactor-inspired)"
 
-    local success=0
-    local total=0
+	local success=0
+	local total=0
 
-    # ShellCheck (shell script linter)
-    print_info "Installing ShellCheck..."
-    if command -v shellcheck &>/dev/null; then
-        print_success "ShellCheck already installed"
-        ((++success))
-    elif brew install shellcheck &>/dev/null; then
-        print_success "ShellCheck installed via Homebrew"
-        ((++success))
-    elif apt-get install -y shellcheck &>/dev/null; then
-        print_success "ShellCheck installed via apt"
-        ((++success))
-    else
-        print_error "Failed to install ShellCheck"
-    fi
-    ((++total))
+	# ShellCheck (shell script linter)
+	print_info "Installing ShellCheck..."
+	if command -v shellcheck &>/dev/null; then
+		print_success "ShellCheck already installed"
+		((++success))
+	elif brew install shellcheck &>/dev/null; then
+		print_success "ShellCheck installed via Homebrew"
+		((++success))
+	elif apt-get install -y shellcheck &>/dev/null; then
+		print_success "ShellCheck installed via apt"
+		((++success))
+	else
+		print_error "Failed to install ShellCheck"
+	fi
+	((++total))
 
-    print_info "Shell linters: $success/$total installed successfully"
-    return $((total - success))
+	print_info "Shell linters: $success/$total installed successfully"
+	return $((total - success))
 }
 
 # Install Docker linters (CodeFactor: Hadolint)
 install_docker_linters() {
-    print_header "Installing Docker Linters (CodeFactor-inspired)"
+	print_header "Installing Docker Linters (CodeFactor-inspired)"
 
-    local success=0
-    local total=0
+	local success=0
+	local total=0
 
-    # Hadolint (Dockerfile linter)
-    print_info "Installing Hadolint..."
-    if command -v hadolint &>/dev/null; then
-        print_success "Hadolint already installed"
-        ((++success))
-    elif brew install hadolint &>/dev/null; then
-        print_success "Hadolint installed via Homebrew"
-        ((++success))
-    else
-        print_error "Failed to install Hadolint"
-    fi
-    ((++total))
+	# Hadolint (Dockerfile linter)
+	print_info "Installing Hadolint..."
+	if command -v hadolint &>/dev/null; then
+		print_success "Hadolint already installed"
+		((++success))
+	elif brew install hadolint &>/dev/null; then
+		print_success "Hadolint installed via Homebrew"
+		((++success))
+	else
+		print_error "Failed to install Hadolint"
+	fi
+	((++total))
 
-    print_info "Docker linters: $success/$total installed successfully"
-    return $((total - success))
+	print_info "Docker linters: $success/$total installed successfully"
+	return $((total - success))
 }
 
 # Install YAML linters (CodeFactor: Yamllint)
 install_yaml_linters() {
-    print_header "Installing YAML Linters (CodeFactor-inspired)"
+	print_header "Installing YAML Linters (CodeFactor-inspired)"
 
-    local success=0
-    local total=0
+	local success=0
+	local total=0
 
-    # yamllint (YAML linter)
-    print_info "Installing yamllint..."
-    if pip install yamllint &>/dev/null; then
-        print_success "yamllint installed"
-        ((++success))
-    else
-        print_error "Failed to install yamllint"
-    fi
-    ((++total))
+	# yamllint (YAML linter)
+	print_info "Installing yamllint..."
+	if pip install yamllint &>/dev/null; then
+		print_success "yamllint installed"
+		((++success))
+	else
+		print_error "Failed to install yamllint"
+	fi
+	((++total))
 
-    print_info "YAML linters: $success/$total installed successfully"
-    return $((total - success))
+	print_info "YAML linters: $success/$total installed successfully"
+	return $((total - success))
 }
 
 # Install Security linters (CodeFactor: Trivy, Secretlint)
 install_security_linters() {
-    print_header "Installing Security Linters (CodeFactor-inspired)"
+	print_header "Installing Security Linters (CodeFactor-inspired)"
 
-    local success=0
-    local total=0
+	local success=0
+	local total=0
 
-    # Trivy (vulnerability scanner)
-    print_info "Installing Trivy..."
-    if command -v trivy &>/dev/null; then
-        print_success "Trivy already installed"
-        ((++success))
-    elif brew install trivy &>/dev/null; then
-        print_success "Trivy installed via Homebrew"
-        ((++success))
-    else
-        print_error "Failed to install Trivy"
-    fi
-    ((++total))
+	# Trivy (vulnerability scanner)
+	print_info "Installing Trivy..."
+	if command -v trivy &>/dev/null; then
+		print_success "Trivy already installed"
+		((++success))
+	elif brew install trivy &>/dev/null; then
+		print_success "Trivy installed via Homebrew"
+		((++success))
+	else
+		print_error "Failed to install Trivy"
+	fi
+	((++total))
 
-    # Secretlint (secret detection)
-    print_info "Installing Secretlint..."
-    if command -v secretlint &>/dev/null; then
-        print_success "Secretlint already installed"
-        ((++success))
-    elif install_npm_global secretlint @secretlint/secretlint-rule-preset-recommend; then
-        print_success "Secretlint installed"
-        ((++success))
-    else
-        print_error "Failed to install Secretlint"
-    fi
-    ((++total))
+	# Secretlint (secret detection)
+	print_info "Installing Secretlint..."
+	if command -v secretlint &>/dev/null; then
+		print_success "Secretlint already installed"
+		((++success))
+	elif install_npm_global secretlint @secretlint/secretlint-rule-preset-recommend; then
+		print_success "Secretlint installed"
+		((++success))
+	else
+		print_error "Failed to install Secretlint"
+	fi
+	((++total))
 
-    print_info "Security linters: $success/$total installed successfully"
-    return $((total - success))
+	print_info "Security linters: $success/$total installed successfully"
+	return $((total - success))
 }
 
 # Install linters for detected languages
 install_detected_linters() {
-    print_header "Auto-Installing Linters for Detected Languages"
+	print_header "Auto-Installing Linters for Detected Languages"
 
-    local languages_output
-    languages_output=$(detect_project_languages)
+	local languages_output
+	languages_output=$(detect_project_languages)
 
-    if [[ -z "$languages_output" ]]; then
-        print_warning "No supported languages detected in current directory"
-        return 1
-    fi
+	if [[ -z "$languages_output" ]]; then
+		print_warning "No supported languages detected in current directory"
+		return 1
+	fi
 
-    # Convert output to array
-    local -a languages
-    mapfile -t languages <<< "$languages_output"
+	# Convert output to array (bash 3.2 compatible — no mapfile)
+	local -a languages=()
+	while IFS= read -r _line; do
+		[[ -n "$_line" ]] && languages+=("$_line")
+	done <<<"$languages_output"
 
-    print_info "Detected languages: ${languages[*]}"
-    echo ""
+	print_info "Detected languages: ${languages[*]}"
+	echo ""
 
-    local total_failures=0
+	local total_failures=0
 
-    for lang in "${languages[@]}"; do
-        case "$lang" in
-            "python")
-                install_python_linters
-                ((total_failures += $?))
-                ;;
-            "javascript")
-                install_javascript_linters
-                ((total_failures += $?))
-                ;;
-            "css")
-                install_css_linters
-                ((total_failures += $?))
-                ;;
-            "shell")
-                install_shell_linters
-                ((total_failures += $?))
-                ;;
-            "docker")
-                install_docker_linters
-                ((total_failures += $?))
-                ;;
-            "yaml")
-                install_yaml_linters
-                ((total_failures += $?))
-                ;;
-            "security")
-                install_security_linters
-                ((total_failures += $?))
-                ;;
-            *)
-                print_warning "Unknown language: $lang - skipping"
-                ;;
-        esac
-        echo ""
-    done
+	for lang in "${languages[@]}"; do
+		case "$lang" in
+		"python")
+			install_python_linters
+			((total_failures += $?))
+			;;
+		"javascript")
+			install_javascript_linters
+			((total_failures += $?))
+			;;
+		"css")
+			install_css_linters
+			((total_failures += $?))
+			;;
+		"shell")
+			install_shell_linters
+			((total_failures += $?))
+			;;
+		"docker")
+			install_docker_linters
+			((total_failures += $?))
+			;;
+		"yaml")
+			install_yaml_linters
+			((total_failures += $?))
+			;;
+		"security")
+			install_security_linters
+			((total_failures += $?))
+			;;
+		*)
+			print_warning "Unknown language: $lang - skipping"
+			;;
+		esac
+		echo ""
+	done
 
-    if [[ $total_failures -eq 0 ]]; then
-        print_success "All linters installed successfully!"
-    else
-        print_warning "Some linters failed to install ($total_failures failures)"
-    fi
+	if [[ $total_failures -eq 0 ]]; then
+		print_success "All linters installed successfully!"
+	else
+		print_warning "Some linters failed to install ($total_failures failures)"
+	fi
 
-    return $total_failures
+	return $total_failures
 }
 
 # Install all supported linters
 install_all_linters() {
-    print_header "Installing All Supported Linters (CodeFactor Collection)"
+	print_header "Installing All Supported Linters (CodeFactor Collection)"
 
-    local total_failures=0
+	local total_failures=0
 
-    install_python_linters
-    ((total_failures += $?))
-    echo ""
+	install_python_linters
+	((total_failures += $?))
+	echo ""
 
-    install_javascript_linters
-    ((total_failures += $?))
-    echo ""
+	install_javascript_linters
+	((total_failures += $?))
+	echo ""
 
-    install_css_linters
-    ((total_failures += $?))
-    echo ""
+	install_css_linters
+	((total_failures += $?))
+	echo ""
 
-    install_shell_linters
-    ((total_failures += $?))
-    echo ""
+	install_shell_linters
+	((total_failures += $?))
+	echo ""
 
-    install_docker_linters
-    ((total_failures += $?))
-    echo ""
+	install_docker_linters
+	((total_failures += $?))
+	echo ""
 
-    install_yaml_linters
-    ((total_failures += $?))
-    echo ""
+	install_yaml_linters
+	((total_failures += $?))
+	echo ""
 
-    install_security_linters
-    ((total_failures += $?))
-    echo ""
+	install_security_linters
+	((total_failures += $?))
+	echo ""
 
-    if [[ $total_failures -eq 0 ]]; then
-        print_success "All linters installed successfully!"
-    else
-        print_warning "Some linters failed to install ($total_failures failures)"
-    fi
+	if [[ $total_failures -eq 0 ]]; then
+		print_success "All linters installed successfully!"
+	else
+		print_warning "Some linters failed to install ($total_failures failures)"
+	fi
 
-    return $total_failures
+	return $total_failures
 }
 
 # Show help
 show_help() {
-    echo "Linter Manager - CodeFactor-Inspired Multi-Language Linter Installation"
-    echo ""
-    echo "Usage: $0 <command> [language]"
-    echo ""
-    echo "Commands:"
-    echo "  detect               - Detect languages in current project"
-    echo "  install-detected     - Install linters for detected languages"
-    echo "  install-all          - Install all supported linters"
-    echo "  install <language>   - Install linters for specific language"
-    echo "  help                 - Show this help message"
-    echo ""
-    echo "Supported Languages:"
-    echo "  python               - pycodestyle, Pylint, Bandit, Ruff"
-    echo "  javascript           - ESLint, TypeScript ESLint"
-    echo "  css                  - Stylelint"
-    echo "  shell                - ShellCheck"
-    echo "  docker               - Hadolint"
-    echo "  yaml                 - yamllint"
-    echo "  security             - Trivy, Secretlint"
-    echo ""
-    echo "Examples:"
-    echo "  $0 detect"
-    echo "  $0 install-detected"
-    echo "  $0 install-all"
-    echo "  $0 install python"
-    echo "  $0 install javascript"
-    echo ""
-    echo "Based on CodeFactor's comprehensive linter collection:"
-    echo "https://docs.codefactor.io/bootcamp/analysis-tools/"
-    return 0
+	echo "Linter Manager - CodeFactor-Inspired Multi-Language Linter Installation"
+	echo ""
+	echo "Usage: $0 <command> [language]"
+	echo ""
+	echo "Commands:"
+	echo "  detect               - Detect languages in current project"
+	echo "  install-detected     - Install linters for detected languages"
+	echo "  install-all          - Install all supported linters"
+	echo "  install <language>   - Install linters for specific language"
+	echo "  help                 - Show this help message"
+	echo ""
+	echo "Supported Languages:"
+	echo "  python               - pycodestyle, Pylint, Bandit, Ruff"
+	echo "  javascript           - ESLint, TypeScript ESLint"
+	echo "  css                  - Stylelint"
+	echo "  shell                - ShellCheck"
+	echo "  docker               - Hadolint"
+	echo "  yaml                 - yamllint"
+	echo "  security             - Trivy, Secretlint"
+	echo ""
+	echo "Examples:"
+	echo "  $0 detect"
+	echo "  $0 install-detected"
+	echo "  $0 install-all"
+	echo "  $0 install python"
+	echo "  $0 install javascript"
+	echo ""
+	echo "Based on CodeFactor's comprehensive linter collection:"
+	echo "https://docs.codefactor.io/bootcamp/analysis-tools/"
+	return 0
 }
 
 # Main execution
 main() {
-    local command="$1"
-    local language="$2"
+	local command="$1"
+	local language="$2"
 
-    case "$command" in
-        "detect")
-            print_header "Detecting Project Languages"
-            local languages_output
-            languages_output=$(detect_project_languages)
-            if [[ -n "$languages_output" ]]; then
-                print_info "Detected languages: $languages_output"
-            else
-                print_warning "No supported languages detected"
-            fi
-            ;;
-        "install-detected")
-            install_detected_linters
-            ;;
-        "install-all")
-            install_all_linters
-            ;;
-        "install")
-            if [[ -z "$language" ]]; then
-                print_error "Language required for install command"
-                echo ""
-                show_help
-                return 1
-            fi
+	case "$command" in
+	"detect")
+		print_header "Detecting Project Languages"
+		local languages_output
+		languages_output=$(detect_project_languages)
+		if [[ -n "$languages_output" ]]; then
+			print_info "Detected languages: $languages_output"
+		else
+			print_warning "No supported languages detected"
+		fi
+		;;
+	"install-detected")
+		install_detected_linters
+		;;
+	"install-all")
+		install_all_linters
+		;;
+	"install")
+		if [[ -z "$language" ]]; then
+			print_error "Language required for install command"
+			echo ""
+			show_help
+			return 1
+		fi
 
-            case "$language" in
-                "python")
-                    install_python_linters
-                    ;;
-                "javascript")
-                    install_javascript_linters
-                    ;;
-                "css")
-                    install_css_linters
-                    ;;
-                "shell")
-                    install_shell_linters
-                    ;;
-                "docker")
-                    install_docker_linters
-                    ;;
-                "yaml")
-                    install_yaml_linters
-                    ;;
-                "security")
-                    install_security_linters
-                    ;;
-                *)
-                    print_error "Unsupported language: $language"
-                    echo ""
-                    show_help
-                    return 1
-                    ;;
-            esac
-            ;;
-        "help"|"--help"|"-h"|"")
-            show_help
-            ;;
-        *)
-            print_error "$ERROR_UNKNOWN_COMMAND $command"
-            echo ""
-            show_help
-            return 1
-            ;;
-    esac
-    return 0
+		case "$language" in
+		"python")
+			install_python_linters
+			;;
+		"javascript")
+			install_javascript_linters
+			;;
+		"css")
+			install_css_linters
+			;;
+		"shell")
+			install_shell_linters
+			;;
+		"docker")
+			install_docker_linters
+			;;
+		"yaml")
+			install_yaml_linters
+			;;
+		"security")
+			install_security_linters
+			;;
+		*)
+			print_error "Unsupported language: $language"
+			echo ""
+			show_help
+			return 1
+			;;
+		esac
+		;;
+	"help" | "--help" | "-h" | "")
+		show_help
+		;;
+	*)
+		print_error "$ERROR_UNKNOWN_COMMAND $command"
+		echo ""
+		show_help
+		return 1
+		;;
+	esac
+	return 0
 }
 
 main "$@"

--- a/.agents/scripts/privacy-filter-helper.sh
+++ b/.agents/scripts/privacy-filter-helper.sh
@@ -221,8 +221,11 @@ scan_privacy() {
 	fi
 	echo ""
 
-	# Load all patterns
-	mapfile -t patterns < <(get_all_patterns)
+	# Load all patterns (bash 3.2 compatible — no mapfile)
+	local patterns=()
+	while IFS= read -r _line; do
+		[[ -n "$_line" ]] && patterns+=("$_line")
+	done < <(get_all_patterns)
 
 	print_header "Scanning for privacy patterns..."
 	print_info "Checking ${#patterns[@]} patterns"
@@ -294,8 +297,11 @@ filter_preview() {
 	print_info "Target: $target"
 	echo ""
 
-	# Load all patterns
-	mapfile -t patterns < <(get_all_patterns)
+	# Load all patterns (bash 3.2 compatible — no mapfile)
+	local patterns=()
+	while IFS= read -r _line; do
+		[[ -n "$_line" ]] && patterns+=("$_line")
+	done < <(get_all_patterns)
 
 	print_info "Showing what would be redacted..."
 	echo ""
@@ -351,8 +357,11 @@ apply_redactions() {
 		return 1
 	fi
 
-	# Load all patterns
-	mapfile -t patterns < <(get_all_patterns)
+	# Load all patterns (bash 3.2 compatible — no mapfile)
+	local patterns=()
+	while IFS= read -r _line; do
+		[[ -n "$_line" ]] && patterns+=("$_line")
+	done < <(get_all_patterns)
 
 	# Apply redactions
 	for pattern in "${patterns[@]}"; do

--- a/.agents/scripts/procurement-helper.sh
+++ b/.agents/scripts/procurement-helper.sh
@@ -238,7 +238,7 @@ stripe_create_card() {
 		-u "${api_key}:" \
 		-d "type=virtual" \
 		-d "cardholder=${cardholder_id}" \
-		-d "currency=${currency,,}" \
+		-d "currency=$(echo "$currency" | tr '[:upper:]' '[:lower:]')" \
 		-d "spending_controls[spending_limits][0][amount]=$(echo "$amount * 100" | bc | cut -d. -f1)" \
 		-d "spending_controls[spending_limits][0][interval]=all_time" \
 		-d "metadata[description]=${description}" \

--- a/.agents/scripts/transcription-helper.sh
+++ b/.agents/scripts/transcription-helper.sh
@@ -43,168 +43,168 @@ readonly DEFAULT_LANGUAGE="auto"
 # ─── Utility Functions ────────────────────────────────────────────────
 
 print_header() {
-    local message="$1"
-    echo -e "${PURPLE}=== $message ===${NC}"
-    return 0
+	local message="$1"
+	echo -e "${PURPLE}=== $message ===${NC}"
+	return 0
 }
 
 # Load configuration or return defaults
 load_config() {
-    local key="$1"
-    local default="$2"
+	local key="$1"
+	local default="$2"
 
-    if [[ -f "$CONFIG_FILE" ]] && command -v jq &>/dev/null; then
-        local value
-        value=$(jq -r ".$key // empty" "$CONFIG_FILE" 2>/dev/null)
-        if [[ -n "$value" ]]; then
-            echo "$value"
-            return 0
-        fi
-    fi
-    echo "$default"
-    return 0
+	if [[ -f "$CONFIG_FILE" ]] && command -v jq &>/dev/null; then
+		local value
+		value=$(jq -r ".$key // empty" "$CONFIG_FILE" 2>/dev/null)
+		if [[ -n "$value" ]]; then
+			echo "$value"
+			return 0
+		fi
+	fi
+	echo "$default"
+	return 0
 }
 
 # Detect input source type
 detect_source() {
-    local input="$1"
+	local input="$1"
 
-    if [[ "$input" =~ youtu\.be/ ]] || [[ "$input" =~ youtube\.com/watch ]]; then
-        echo "youtube"
-    elif [[ "$input" =~ ^https?:// ]]; then
-        echo "url"
-    elif [[ -f "$input" ]]; then
-        local ext="${input##*.}"
-        ext="${ext,,}"
-        if [[ "$ext" =~ ^($AUDIO_EXTENSIONS)$ ]]; then
-            echo "audio"
-        elif [[ "$ext" =~ ^($VIDEO_EXTENSIONS)$ ]]; then
-            echo "video"
-        else
-            echo "unknown"
-        fi
-    else
-        echo "not_found"
-    fi
-    return 0
+	if [[ "$input" =~ youtu\.be/ ]] || [[ "$input" =~ youtube\.com/watch ]]; then
+		echo "youtube"
+	elif [[ "$input" =~ ^https?:// ]]; then
+		echo "url"
+	elif [[ -f "$input" ]]; then
+		local ext="${input##*.}"
+		ext=$(echo "$ext" | tr '[:upper:]' '[:lower:]')
+		if [[ "$ext" =~ ^($AUDIO_EXTENSIONS)$ ]]; then
+			echo "audio"
+		elif [[ "$ext" =~ ^($VIDEO_EXTENSIONS)$ ]]; then
+			echo "video"
+		else
+			echo "unknown"
+		fi
+	else
+		echo "not_found"
+	fi
+	return 0
 }
 
 # Find the best available Python with transcription deps
 find_python() {
-    # Prefer the speech-to-speech venv if it exists
-    if [[ -x "${VENV_DIR}/bin/python" ]]; then
-        echo "${VENV_DIR}/bin/python"
-        return 0
-    fi
-    # Fall back to system python
-    if command -v python3 &>/dev/null; then
-        echo "python3"
-        return 0
-    fi
-    print_error "Python 3 not found. Install Python 3.10+ or run: speech-to-speech-helper.sh setup"
-    return 1
+	# Prefer the speech-to-speech venv if it exists
+	if [[ -x "${VENV_DIR}/bin/python" ]]; then
+		echo "${VENV_DIR}/bin/python"
+		return 0
+	fi
+	# Fall back to system python
+	if command -v python3 &>/dev/null; then
+		echo "python3"
+		return 0
+	fi
+	print_error "Python 3 not found. Install Python 3.10+ or run: speech-to-speech-helper.sh setup"
+	return 1
 }
 
 # Check if faster-whisper is available
 has_faster_whisper() {
-    local python_bin
-    python_bin=$(find_python 2>/dev/null) || return 1
-    "$python_bin" -c "from faster_whisper import WhisperModel" 2>/dev/null
-    return $?
+	local python_bin
+	python_bin=$(find_python 2>/dev/null) || return 1
+	"$python_bin" -c "from faster_whisper import WhisperModel" 2>/dev/null
+	return $?
 }
 
 # Check if whisper.cpp CLI is available
 has_whisper_cpp() {
-    command -v whisper-cli &>/dev/null || command -v whisper.cpp &>/dev/null
-    return $?
+	command -v whisper-cli &>/dev/null || command -v whisper.cpp &>/dev/null
+	return $?
 }
 
 # Check if Buzz CLI is available
 has_buzz() {
-    command -v buzz &>/dev/null
-    return $?
+	command -v buzz &>/dev/null
+	return $?
 }
 
 # ─── Audio Extraction ─────────────────────────────────────────────────
 
 # Extract audio from video file to WAV for transcription
 extract_audio() {
-    local input="$1"
-    local output="$2"
+	local input="$1"
+	local output="$2"
 
-    if ! command -v ffmpeg &>/dev/null; then
-        print_error "ffmpeg is required for audio extraction."
-        print_info "Install: brew install ffmpeg (macOS) or apt install ffmpeg (Linux)"
-        return 1
-    fi
+	if ! command -v ffmpeg &>/dev/null; then
+		print_error "ffmpeg is required for audio extraction."
+		print_info "Install: brew install ffmpeg (macOS) or apt install ffmpeg (Linux)"
+		return 1
+	fi
 
-    print_info "Extracting audio from: $(basename "$input")"
-    ffmpeg -i "$input" -vn -acodec pcm_s16le -ar 16000 -ac 1 -y "$output" 2>/dev/null
-    return $?
+	print_info "Extracting audio from: $(basename "$input")"
+	ffmpeg -i "$input" -vn -acodec pcm_s16le -ar 16000 -ac 1 -y "$output" 2>/dev/null
+	return $?
 }
 
 # Download YouTube audio via yt-dlp
 download_youtube_audio() {
-    local url="$1"
-    local output="$2"
+	local url="$1"
+	local output="$2"
 
-    if ! command -v yt-dlp &>/dev/null; then
-        print_error "yt-dlp is required for YouTube downloads."
-        print_info "Install: brew install yt-dlp (macOS) or pip install yt-dlp"
-        return 1
-    fi
+	if ! command -v yt-dlp &>/dev/null; then
+		print_error "yt-dlp is required for YouTube downloads."
+		print_info "Install: brew install yt-dlp (macOS) or pip install yt-dlp"
+		return 1
+	fi
 
-    print_info "Downloading audio from YouTube..."
-    yt-dlp -x --audio-format wav --audio-quality 0 \
-        -o "$output" --no-playlist "$url" 2>&1 | tail -5
-    return $?
+	print_info "Downloading audio from YouTube..."
+	yt-dlp -x --audio-format wav --audio-quality 0 \
+		-o "$output" --no-playlist "$url" 2>&1 | tail -5
+	return $?
 }
 
 # Download audio from a direct URL
 download_url_audio() {
-    local url="$1"
-    local output="$2"
+	local url="$1"
+	local output="$2"
 
-    print_info "Downloading from URL..."
-    if ! curl -sL -o "${output}.tmp" "$url"; then
-        print_error "Failed to download: $url"
-        return 1
-    fi
+	print_info "Downloading from URL..."
+	if ! curl -sL -o "${output}.tmp" "$url"; then
+		print_error "Failed to download: $url"
+		return 1
+	fi
 
-    # Check if it's a video that needs audio extraction
-    local mime_type
-    mime_type=$(file -b --mime-type "${output}.tmp" 2>/dev/null || echo "unknown")
+	# Check if it's a video that needs audio extraction
+	local mime_type
+	mime_type=$(file -b --mime-type "${output}.tmp" 2>/dev/null || echo "unknown")
 
-    if [[ "$mime_type" == video/* ]]; then
-        extract_audio "${output}.tmp" "$output"
-        rm -f "${output}.tmp"
-    else
-        mv "${output}.tmp" "$output"
-    fi
-    return 0
+	if [[ "$mime_type" == video/* ]]; then
+		extract_audio "${output}.tmp" "$output"
+		rm -f "${output}.tmp"
+	else
+		mv "${output}.tmp" "$output"
+	fi
+	return 0
 }
 
 # ─── Transcription Backends ──────────────────────────────────────────
 
 # Transcribe using faster-whisper (local, recommended)
 transcribe_faster_whisper() {
-    local audio_file="$1"
-    local model="$2"
-    local language="$3"
-    local output_format="$4"
-    local output_file="$5"
+	local audio_file="$1"
+	local model="$2"
+	local language="$3"
+	local output_format="$4"
+	local output_file="$5"
 
-    local python_bin
-    python_bin=$(find_python) || return 1
+	local python_bin
+	python_bin=$(find_python) || return 1
 
-    print_info "Transcribing with faster-whisper (model: $model)..."
+	print_info "Transcribing with faster-whisper (model: $model)..."
 
-    local lang_arg=""
-    if [[ "$language" != "auto" ]]; then
-        lang_arg="language=\"$language\","
-    fi
+	local lang_arg=""
+	if [[ "$language" != "auto" ]]; then
+		lang_arg="language=\"$language\","
+	fi
 
-    "$python_bin" -c "
+	"$python_bin" -c "
 import sys
 from faster_whisper import WhisperModel
 
@@ -270,123 +270,123 @@ else:
 
 print(f'Transcription complete: {output_file}', file=sys.stderr)
 "
-    return $?
+	return $?
 }
 
 # Transcribe using whisper.cpp CLI
 transcribe_whisper_cpp() {
-    local audio_file="$1"
-    local model="$2"
-    local language="$3"
-    local output_format="$4"
-    local output_file="$5"
+	local audio_file="$1"
+	local model="$2"
+	local language="$3"
+	local output_format="$4"
+	local output_file="$5"
 
-    local whisper_bin=""
-    if command -v whisper-cli &>/dev/null; then
-        whisper_bin="whisper-cli"
-    elif command -v whisper.cpp &>/dev/null; then
-        whisper_bin="whisper.cpp"
-    else
-        print_error "whisper.cpp CLI not found."
-        return 1
-    fi
+	local whisper_bin=""
+	if command -v whisper-cli &>/dev/null; then
+		whisper_bin="whisper-cli"
+	elif command -v whisper.cpp &>/dev/null; then
+		whisper_bin="whisper.cpp"
+	else
+		print_error "whisper.cpp CLI not found."
+		return 1
+	fi
 
-    # Resolve model file path
-    local model_dir="$HOME/.cache/whisper.cpp/models"
-    local model_file="$model_dir/ggml-${model}.bin"
+	# Resolve model file path
+	local model_dir="$HOME/.cache/whisper.cpp/models"
+	local model_file="$model_dir/ggml-${model}.bin"
 
-    if [[ ! -f "$model_file" ]]; then
-        print_warning "Model file not found: $model_file"
-        print_info "Download models from: https://huggingface.co/ggerganov/whisper.cpp/tree/main"
-        return 1
-    fi
+	if [[ ! -f "$model_file" ]]; then
+		print_warning "Model file not found: $model_file"
+		print_info "Download models from: https://huggingface.co/ggerganov/whisper.cpp/tree/main"
+		return 1
+	fi
 
-    print_info "Transcribing with whisper.cpp (model: $model)..."
+	print_info "Transcribing with whisper.cpp (model: $model)..."
 
-    local lang_args=()
-    if [[ "$language" != "auto" ]]; then
-        lang_args=(-l "$language")
-    fi
+	local lang_args=()
+	if [[ "$language" != "auto" ]]; then
+		lang_args=(-l "$language")
+	fi
 
-    local format_args=()
-    case "$output_format" in
-        txt) format_args=(-otxt) ;;
-        srt) format_args=(-osrt) ;;
-        vtt) format_args=(-ovtt) ;;
-        json) format_args=(-ojson) ;;
-        *) format_args=(-otxt) ;;
-    esac
+	local format_args=()
+	case "$output_format" in
+	txt) format_args=(-otxt) ;;
+	srt) format_args=(-osrt) ;;
+	vtt) format_args=(-ovtt) ;;
+	json) format_args=(-ojson) ;;
+	*) format_args=(-otxt) ;;
+	esac
 
-    local output_base="${output_file%.*}"
+	local output_base="${output_file%.*}"
 
-    "$whisper_bin" -m "$model_file" -f "$audio_file" \
-        "${lang_args[@]}" "${format_args[@]}" \
-        -of "$output_base" 2>&1 | tail -5
+	"$whisper_bin" -m "$model_file" -f "$audio_file" \
+		"${lang_args[@]}" "${format_args[@]}" \
+		-of "$output_base" 2>&1 | tail -5
 
-    return $?
+	return $?
 }
 
 # Transcribe using Groq cloud API
 transcribe_groq() {
-    local audio_file="$1"
-    local language="$3"
-    local output_format="$4"
-    local output_file="$5"
+	local audio_file="$1"
+	local language="$3"
+	local output_format="$4"
+	local output_file="$5"
 
-    local api_key="${GROQ_API_KEY:-}"
-    if [[ -z "$api_key" ]]; then
-        print_error "GROQ_API_KEY not set."
-        print_info "Set via: aidevops secret set GROQ_API_KEY"
-        return 1
-    fi
+	local api_key="${GROQ_API_KEY:-}"
+	if [[ -z "$api_key" ]]; then
+		print_error "GROQ_API_KEY not set."
+		print_info "Set via: aidevops secret set GROQ_API_KEY"
+		return 1
+	fi
 
-    print_info "Transcribing with Groq API (model: whisper-large-v3-turbo)..."
+	print_info "Transcribing with Groq API (model: whisper-large-v3-turbo)..."
 
-    local lang_args=()
-    if [[ "$language" != "auto" ]]; then
-        lang_args=(-F "language=$language")
-    fi
+	local lang_args=()
+	if [[ "$language" != "auto" ]]; then
+		lang_args=(-F "language=$language")
+	fi
 
-    local response_format="verbose_json"
-    if [[ "$output_format" == "txt" ]]; then
-        response_format="text"
-    fi
+	local response_format="verbose_json"
+	if [[ "$output_format" == "txt" ]]; then
+		response_format="text"
+	fi
 
-    local response
-    response=$(curl -s -X POST "https://api.groq.com/openai/v1/audio/transcriptions" \
-        -H "Authorization: Bearer ${api_key}" \
-        -H "Content-Type: multipart/form-data" \
-        -F "file=@${audio_file}" \
-        -F "model=whisper-large-v3-turbo" \
-        -F "response_format=${response_format}" \
-        "${lang_args[@]}")
+	local response
+	response=$(curl -s -X POST "https://api.groq.com/openai/v1/audio/transcriptions" \
+		-H "Authorization: Bearer ${api_key}" \
+		-H "Content-Type: multipart/form-data" \
+		-F "file=@${audio_file}" \
+		-F "model=whisper-large-v3-turbo" \
+		-F "response_format=${response_format}" \
+		"${lang_args[@]}")
 
-    if [[ -z "$response" ]]; then
-        print_error "Empty response from Groq API"
-        return 1
-    fi
+	if [[ -z "$response" ]]; then
+		print_error "Empty response from Groq API"
+		return 1
+	fi
 
-    # Check for API errors
-    if echo "$response" | jq -e '.error' &>/dev/null 2>&1; then
-        local error_msg
-        error_msg=$(echo "$response" | jq -r '.error.message // .error // "Unknown error"')
-        print_error "Groq API error: $error_msg"
-        return 1
-    fi
+	# Check for API errors
+	if echo "$response" | jq -e '.error' &>/dev/null 2>&1; then
+		local error_msg
+		error_msg=$(echo "$response" | jq -r '.error.message // .error // "Unknown error"')
+		print_error "Groq API error: $error_msg"
+		return 1
+	fi
 
-    # Write output based on format
-    case "$output_format" in
-        txt)
-            echo "$response" > "$output_file"
-            ;;
-        json)
-            echo "$response" | jq '.' > "$output_file"
-            ;;
-        srt)
-            # Convert verbose_json segments to SRT
-            local python_bin
-            python_bin=$(find_python 2>/dev/null || echo "python3")
-            echo "$response" | "$python_bin" -c "
+	# Write output based on format
+	case "$output_format" in
+	txt)
+		echo "$response" >"$output_file"
+		;;
+	json)
+		echo "$response" | jq '.' >"$output_file"
+		;;
+	srt)
+		# Convert verbose_json segments to SRT
+		local python_bin
+		python_bin=$(find_python 2>/dev/null || echo "python3")
+		echo "$response" | "$python_bin" -c "
 import json, sys
 data = json.load(sys.stdin)
 segments = data.get('segments', [])
@@ -400,12 +400,12 @@ for i, seg in enumerate(segments, 1):
     print(f'{sh:02d}:{sm:02d}:{ss:02d},{sms:03d} --> {eh:02d}:{em:02d}:{es:02d},{ems:03d}')
     print(f'{text}')
     print()
-" > "$output_file"
-            ;;
-        vtt)
-            local python_bin
-            python_bin=$(find_python 2>/dev/null || echo "python3")
-            echo "$response" | "$python_bin" -c "
+" >"$output_file"
+		;;
+	vtt)
+		local python_bin
+		python_bin=$(find_python 2>/dev/null || echo "python3")
+		echo "$response" | "$python_bin" -c "
 import json, sys
 data = json.load(sys.stdin)
 segments = data.get('segments', [])
@@ -420,556 +420,571 @@ for seg in segments:
     print(f'{sh:02d}:{sm:02d}:{ss:02d}.{sms:03d} --> {eh:02d}:{em:02d}:{es:02d}.{ems:03d}')
     print(f'{text}')
     print()
-" > "$output_file"
-            ;;
-    esac
+" >"$output_file"
+		;;
+	esac
 
-    return 0
+	return 0
 }
 
 # Transcribe using OpenAI Whisper API
 transcribe_openai() {
-    local audio_file="$1"
-    local language="$3"
-    local output_format="$4"
-    local output_file="$5"
+	local audio_file="$1"
+	local language="$3"
+	local output_format="$4"
+	local output_file="$5"
 
-    local api_key="${OPENAI_API_KEY:-}"
-    if [[ -z "$api_key" ]]; then
-        print_error "OPENAI_API_KEY not set."
-        print_info "Set via: aidevops secret set OPENAI_API_KEY"
-        return 1
-    fi
+	local api_key="${OPENAI_API_KEY:-}"
+	if [[ -z "$api_key" ]]; then
+		print_error "OPENAI_API_KEY not set."
+		print_info "Set via: aidevops secret set OPENAI_API_KEY"
+		return 1
+	fi
 
-    print_info "Transcribing with OpenAI Whisper API..."
+	print_info "Transcribing with OpenAI Whisper API..."
 
-    local lang_args=()
-    if [[ "$language" != "auto" ]]; then
-        lang_args=(-F "language=$language")
-    fi
+	local lang_args=()
+	if [[ "$language" != "auto" ]]; then
+		lang_args=(-F "language=$language")
+	fi
 
-    local response_format="verbose_json"
-    if [[ "$output_format" == "txt" ]]; then
-        response_format="text"
-    elif [[ "$output_format" == "srt" ]]; then
-        response_format="srt"
-    elif [[ "$output_format" == "vtt" ]]; then
-        response_format="vtt"
-    fi
+	local response_format="verbose_json"
+	if [[ "$output_format" == "txt" ]]; then
+		response_format="text"
+	elif [[ "$output_format" == "srt" ]]; then
+		response_format="srt"
+	elif [[ "$output_format" == "vtt" ]]; then
+		response_format="vtt"
+	fi
 
-    local response
-    response=$(curl -s -X POST "https://api.openai.com/v1/audio/transcriptions" \
-        -H "Authorization: Bearer ${api_key}" \
-        -H "Content-Type: multipart/form-data" \
-        -F "file=@${audio_file}" \
-        -F "model=whisper-1" \
-        -F "response_format=${response_format}" \
-        "${lang_args[@]}")
+	local response
+	response=$(curl -s -X POST "https://api.openai.com/v1/audio/transcriptions" \
+		-H "Authorization: Bearer ${api_key}" \
+		-H "Content-Type: multipart/form-data" \
+		-F "file=@${audio_file}" \
+		-F "model=whisper-1" \
+		-F "response_format=${response_format}" \
+		"${lang_args[@]}")
 
-    if [[ -z "$response" ]]; then
-        print_error "Empty response from OpenAI API"
-        return 1
-    fi
+	if [[ -z "$response" ]]; then
+		print_error "Empty response from OpenAI API"
+		return 1
+	fi
 
-    # Check for API errors
-    if echo "$response" | jq -e '.error' &>/dev/null 2>&1; then
-        local error_msg
-        error_msg=$(echo "$response" | jq -r '.error.message // .error // "Unknown error"')
-        print_error "OpenAI API error: $error_msg"
-        return 1
-    fi
+	# Check for API errors
+	if echo "$response" | jq -e '.error' &>/dev/null 2>&1; then
+		local error_msg
+		error_msg=$(echo "$response" | jq -r '.error.message // .error // "Unknown error"')
+		print_error "OpenAI API error: $error_msg"
+		return 1
+	fi
 
-    # Write output
-    if [[ "$output_format" == "json" ]]; then
-        echo "$response" | jq '.' > "$output_file"
-    else
-        echo "$response" > "$output_file"
-    fi
+	# Write output
+	if [[ "$output_format" == "json" ]]; then
+		echo "$response" | jq '.' >"$output_file"
+	else
+		echo "$response" >"$output_file"
+	fi
 
-    return 0
+	return 0
 }
 
 # ─── Backend Selection ───────────────────────────────────────────────
 
 # Auto-select the best available backend
 select_backend() {
-    local preferred="$1"
+	local preferred="$1"
 
-    # If user specified a backend, validate it
-    if [[ -n "$preferred" ]]; then
-        case "$preferred" in
-            faster-whisper)
-                if has_faster_whisper; then echo "faster-whisper"; return 0; fi
-                print_error "faster-whisper not available. Install: pip install faster-whisper"
-                return 1
-                ;;
-            whisper-cpp|whisper.cpp)
-                if has_whisper_cpp; then echo "whisper-cpp"; return 0; fi
-                print_error "whisper.cpp not available. Build from: https://github.com/ggml-org/whisper.cpp"
-                return 1
-                ;;
-            groq)
-                if [[ -n "${GROQ_API_KEY:-}" ]]; then echo "groq"; return 0; fi
-                print_error "GROQ_API_KEY not set. Run: aidevops secret set GROQ_API_KEY"
-                return 1
-                ;;
-            openai)
-                if [[ -n "${OPENAI_API_KEY:-}" ]]; then echo "openai"; return 0; fi
-                print_error "OPENAI_API_KEY not set. Run: aidevops secret set OPENAI_API_KEY"
-                return 1
-                ;;
-            buzz)
-                if has_buzz; then echo "buzz"; return 0; fi
-                print_error "Buzz not available. Install: brew install --cask buzz"
-                return 1
-                ;;
-            *)
-                print_error "Unknown backend: $preferred"
-                print_info "Available: faster-whisper, whisper-cpp, groq, openai, buzz"
-                return 1
-                ;;
-        esac
-    fi
+	# If user specified a backend, validate it
+	if [[ -n "$preferred" ]]; then
+		case "$preferred" in
+		faster-whisper)
+			if has_faster_whisper; then
+				echo "faster-whisper"
+				return 0
+			fi
+			print_error "faster-whisper not available. Install: pip install faster-whisper"
+			return 1
+			;;
+		whisper-cpp | whisper.cpp)
+			if has_whisper_cpp; then
+				echo "whisper-cpp"
+				return 0
+			fi
+			print_error "whisper.cpp not available. Build from: https://github.com/ggml-org/whisper.cpp"
+			return 1
+			;;
+		groq)
+			if [[ -n "${GROQ_API_KEY:-}" ]]; then
+				echo "groq"
+				return 0
+			fi
+			print_error "GROQ_API_KEY not set. Run: aidevops secret set GROQ_API_KEY"
+			return 1
+			;;
+		openai)
+			if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+				echo "openai"
+				return 0
+			fi
+			print_error "OPENAI_API_KEY not set. Run: aidevops secret set OPENAI_API_KEY"
+			return 1
+			;;
+		buzz)
+			if has_buzz; then
+				echo "buzz"
+				return 0
+			fi
+			print_error "Buzz not available. Install: brew install --cask buzz"
+			return 1
+			;;
+		*)
+			print_error "Unknown backend: $preferred"
+			print_info "Available: faster-whisper, whisper-cpp, groq, openai, buzz"
+			return 1
+			;;
+		esac
+	fi
 
-    # Auto-select: local first (free, private), then cloud
-    if has_faster_whisper; then
-        echo "faster-whisper"
-        return 0
-    fi
-    if has_whisper_cpp; then
-        echo "whisper-cpp"
-        return 0
-    fi
-    if has_buzz; then
-        echo "buzz"
-        return 0
-    fi
-    if [[ -n "${GROQ_API_KEY:-}" ]]; then
-        echo "groq"
-        return 0
-    fi
-    if [[ -n "${OPENAI_API_KEY:-}" ]]; then
-        echo "openai"
-        return 0
-    fi
+	# Auto-select: local first (free, private), then cloud
+	if has_faster_whisper; then
+		echo "faster-whisper"
+		return 0
+	fi
+	if has_whisper_cpp; then
+		echo "whisper-cpp"
+		return 0
+	fi
+	if has_buzz; then
+		echo "buzz"
+		return 0
+	fi
+	if [[ -n "${GROQ_API_KEY:-}" ]]; then
+		echo "groq"
+		return 0
+	fi
+	if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+		echo "openai"
+		return 0
+	fi
 
-    print_error "No transcription backend available."
-    print_info "Install one of:"
-    print_info "  pip install faster-whisper    (recommended, local)"
-    print_info "  brew install --cask buzz      (GUI + CLI, local)"
-    print_info "  aidevops secret set GROQ_API_KEY  (cloud, free tier)"
-    return 1
+	print_error "No transcription backend available."
+	print_info "Install one of:"
+	print_info "  pip install faster-whisper    (recommended, local)"
+	print_info "  brew install --cask buzz      (GUI + CLI, local)"
+	print_info "  aidevops secret set GROQ_API_KEY  (cloud, free tier)"
+	return 1
 }
 
 # ─── Main Commands ───────────────────────────────────────────────────
 
 # Parse transcription options
 parse_transcribe_options() {
-    TRANSCRIBE_INPUT=""
-    TRANSCRIBE_MODEL=""
-    TRANSCRIBE_BACKEND=""
-    TRANSCRIBE_LANGUAGE=""
-    TRANSCRIBE_FORMAT=""
-    TRANSCRIBE_OUTPUT=""
-    TRANSCRIBE_OUTPUT_DIR=""
+	TRANSCRIBE_INPUT=""
+	TRANSCRIBE_MODEL=""
+	TRANSCRIBE_BACKEND=""
+	TRANSCRIBE_LANGUAGE=""
+	TRANSCRIBE_FORMAT=""
+	TRANSCRIBE_OUTPUT=""
+	TRANSCRIBE_OUTPUT_DIR=""
 
-    while [[ $# -gt 0 ]]; do
-        case "$1" in
-            --model|-m)
-                TRANSCRIBE_MODEL="$2"
-                shift 2
-                ;;
-            --backend|-b)
-                TRANSCRIBE_BACKEND="$2"
-                shift 2
-                ;;
-            --language|-l)
-                TRANSCRIBE_LANGUAGE="$2"
-                shift 2
-                ;;
-            --format|-f)
-                TRANSCRIBE_FORMAT="$2"
-                shift 2
-                ;;
-            --output|-o)
-                TRANSCRIBE_OUTPUT="$2"
-                shift 2
-                ;;
-            --output-dir)
-                TRANSCRIBE_OUTPUT_DIR="$2"
-                shift 2
-                ;;
-            -*)
-                print_error "Unknown option: $1"
-                return 1
-                ;;
-            *)
-                if [[ -z "$TRANSCRIBE_INPUT" ]]; then
-                    TRANSCRIBE_INPUT="$1"
-                else
-                    print_error "Unexpected argument: $1"
-                    return 1
-                fi
-                shift
-                ;;
-        esac
-    done
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--model | -m)
+			TRANSCRIBE_MODEL="$2"
+			shift 2
+			;;
+		--backend | -b)
+			TRANSCRIBE_BACKEND="$2"
+			shift 2
+			;;
+		--language | -l)
+			TRANSCRIBE_LANGUAGE="$2"
+			shift 2
+			;;
+		--format | -f)
+			TRANSCRIBE_FORMAT="$2"
+			shift 2
+			;;
+		--output | -o)
+			TRANSCRIBE_OUTPUT="$2"
+			shift 2
+			;;
+		--output-dir)
+			TRANSCRIBE_OUTPUT_DIR="$2"
+			shift 2
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		*)
+			if [[ -z "$TRANSCRIBE_INPUT" ]]; then
+				TRANSCRIBE_INPUT="$1"
+			else
+				print_error "Unexpected argument: $1"
+				return 1
+			fi
+			shift
+			;;
+		esac
+	done
 
-    # Apply defaults from config
-    TRANSCRIBE_MODEL="${TRANSCRIBE_MODEL:-$(load_config model "$DEFAULT_MODEL")}"
-    TRANSCRIBE_LANGUAGE="${TRANSCRIBE_LANGUAGE:-$(load_config language "$DEFAULT_LANGUAGE")}"
-    TRANSCRIBE_FORMAT="${TRANSCRIBE_FORMAT:-$(load_config format "$DEFAULT_OUTPUT_FORMAT")}"
+	# Apply defaults from config
+	TRANSCRIBE_MODEL="${TRANSCRIBE_MODEL:-$(load_config model "$DEFAULT_MODEL")}"
+	TRANSCRIBE_LANGUAGE="${TRANSCRIBE_LANGUAGE:-$(load_config language "$DEFAULT_LANGUAGE")}"
+	TRANSCRIBE_FORMAT="${TRANSCRIBE_FORMAT:-$(load_config format "$DEFAULT_OUTPUT_FORMAT")}"
 
-    return 0
+	return 0
 }
 
 # Main transcribe command
 cmd_transcribe() {
-    if [[ $# -eq 0 ]]; then
-        print_error "Input file or URL required."
-        print_info "Usage: transcription-helper.sh transcribe <file|url> [options]"
-        return 1
-    fi
+	if [[ $# -eq 0 ]]; then
+		print_error "Input file or URL required."
+		print_info "Usage: transcription-helper.sh transcribe <file|url> [options]"
+		return 1
+	fi
 
-    parse_transcribe_options "$@" || return 1
+	parse_transcribe_options "$@" || return 1
 
-    if [[ -z "$TRANSCRIBE_INPUT" ]]; then
-        print_error "Input file or URL required."
-        return 1
-    fi
+	if [[ -z "$TRANSCRIBE_INPUT" ]]; then
+		print_error "Input file or URL required."
+		return 1
+	fi
 
-    # Detect source type
-    local source_type
-    source_type=$(detect_source "$TRANSCRIBE_INPUT")
+	# Detect source type
+	local source_type
+	source_type=$(detect_source "$TRANSCRIBE_INPUT")
 
-    case "$source_type" in
-        not_found)
-            print_error "File not found: $TRANSCRIBE_INPUT"
-            return 1
-            ;;
-        unknown)
-            print_error "Unsupported file type: $TRANSCRIBE_INPUT"
-            print_info "Supported audio: $AUDIO_EXTENSIONS"
-            print_info "Supported video: $VIDEO_EXTENSIONS"
-            return 1
-            ;;
-    esac
+	case "$source_type" in
+	not_found)
+		print_error "File not found: $TRANSCRIBE_INPUT"
+		return 1
+		;;
+	unknown)
+		print_error "Unsupported file type: $TRANSCRIBE_INPUT"
+		print_info "Supported audio: $AUDIO_EXTENSIONS"
+		print_info "Supported video: $VIDEO_EXTENSIONS"
+		return 1
+		;;
+	esac
 
-    # Select backend
-    local backend
-    backend=$(select_backend "$TRANSCRIBE_BACKEND") || return 1
+	# Select backend
+	local backend
+	backend=$(select_backend "$TRANSCRIBE_BACKEND") || return 1
 
-    # Prepare temp directory for intermediate files
-    mkdir -p "$CACHE_DIR"
-    local temp_audio=""
-    local cleanup_temp=false
+	# Prepare temp directory for intermediate files
+	mkdir -p "$CACHE_DIR"
+	local temp_audio=""
+	local cleanup_temp=false
 
-    # Prepare audio file based on source type
-    local audio_file=""
-    case "$source_type" in
-        youtube)
-            temp_audio="$CACHE_DIR/yt-audio-$$.wav"
-            download_youtube_audio "$TRANSCRIBE_INPUT" "$temp_audio" || return 1
-            # yt-dlp may add extension, find the actual file
-            if [[ ! -f "$temp_audio" ]]; then
-                temp_audio=$(find "$CACHE_DIR" -name "yt-audio-$$.*" -type f | head -1)
-            fi
-            audio_file="$temp_audio"
-            cleanup_temp=true
-            ;;
-        url)
-            temp_audio="$CACHE_DIR/url-audio-$$.wav"
-            download_url_audio "$TRANSCRIBE_INPUT" "$temp_audio" || return 1
-            audio_file="$temp_audio"
-            cleanup_temp=true
-            ;;
-        video)
-            temp_audio="$CACHE_DIR/extracted-audio-$$.wav"
-            extract_audio "$TRANSCRIBE_INPUT" "$temp_audio" || return 1
-            audio_file="$temp_audio"
-            cleanup_temp=true
-            ;;
-        audio)
-            audio_file="$TRANSCRIBE_INPUT"
-            ;;
-    esac
+	# Prepare audio file based on source type
+	local audio_file=""
+	case "$source_type" in
+	youtube)
+		temp_audio="$CACHE_DIR/yt-audio-$$.wav"
+		download_youtube_audio "$TRANSCRIBE_INPUT" "$temp_audio" || return 1
+		# yt-dlp may add extension, find the actual file
+		if [[ ! -f "$temp_audio" ]]; then
+			temp_audio=$(find "$CACHE_DIR" -name "yt-audio-$$.*" -type f | head -1)
+		fi
+		audio_file="$temp_audio"
+		cleanup_temp=true
+		;;
+	url)
+		temp_audio="$CACHE_DIR/url-audio-$$.wav"
+		download_url_audio "$TRANSCRIBE_INPUT" "$temp_audio" || return 1
+		audio_file="$temp_audio"
+		cleanup_temp=true
+		;;
+	video)
+		temp_audio="$CACHE_DIR/extracted-audio-$$.wav"
+		extract_audio "$TRANSCRIBE_INPUT" "$temp_audio" || return 1
+		audio_file="$temp_audio"
+		cleanup_temp=true
+		;;
+	audio)
+		audio_file="$TRANSCRIBE_INPUT"
+		;;
+	esac
 
-    if [[ ! -f "$audio_file" ]]; then
-        print_error "Audio file not available after preparation."
-        return 1
-    fi
+	if [[ ! -f "$audio_file" ]]; then
+		print_error "Audio file not available after preparation."
+		return 1
+	fi
 
-    # Determine output file path
-    local output_file="$TRANSCRIBE_OUTPUT"
-    if [[ -z "$output_file" ]]; then
-        local base_name=""
-        if [[ "$source_type" == "youtube" ]] || [[ "$source_type" == "url" ]]; then
-            base_name="transcription-$(date '+%Y%m%d-%H%M%S')"
-        else
-            base_name="$(basename "${TRANSCRIBE_INPUT%.*}")"
-        fi
-        local out_dir="${TRANSCRIBE_OUTPUT_DIR:-$DEFAULT_OUTPUT_DIR}"
-        mkdir -p "$out_dir"
-        output_file="$out_dir/${base_name}.${TRANSCRIBE_FORMAT}"
-    fi
+	# Determine output file path
+	local output_file="$TRANSCRIBE_OUTPUT"
+	if [[ -z "$output_file" ]]; then
+		local base_name=""
+		if [[ "$source_type" == "youtube" ]] || [[ "$source_type" == "url" ]]; then
+			base_name="transcription-$(date '+%Y%m%d-%H%M%S')"
+		else
+			base_name="$(basename "${TRANSCRIBE_INPUT%.*}")"
+		fi
+		local out_dir="${TRANSCRIBE_OUTPUT_DIR:-$DEFAULT_OUTPUT_DIR}"
+		mkdir -p "$out_dir"
+		output_file="$out_dir/${base_name}.${TRANSCRIBE_FORMAT}"
+	fi
 
-    print_header "Transcription"
-    print_info "Input:    $TRANSCRIBE_INPUT ($source_type)"
-    print_info "Backend:  $backend"
-    print_info "Model:    $TRANSCRIBE_MODEL"
-    print_info "Language: $TRANSCRIBE_LANGUAGE"
-    print_info "Format:   $TRANSCRIBE_FORMAT"
-    print_info "Output:   $output_file"
-    echo ""
+	print_header "Transcription"
+	print_info "Input:    $TRANSCRIBE_INPUT ($source_type)"
+	print_info "Backend:  $backend"
+	print_info "Model:    $TRANSCRIBE_MODEL"
+	print_info "Language: $TRANSCRIBE_LANGUAGE"
+	print_info "Format:   $TRANSCRIBE_FORMAT"
+	print_info "Output:   $output_file"
+	echo ""
 
-    # Run transcription
-    local exit_code=0
-    case "$backend" in
-        faster-whisper)
-            transcribe_faster_whisper "$audio_file" "$TRANSCRIBE_MODEL" \
-                "$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
-            ;;
-        whisper-cpp)
-            transcribe_whisper_cpp "$audio_file" "$TRANSCRIBE_MODEL" \
-                "$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
-            ;;
-        groq)
-            transcribe_groq "$audio_file" "$TRANSCRIBE_MODEL" \
-                "$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
-            ;;
-        openai)
-            transcribe_openai "$audio_file" "$TRANSCRIBE_MODEL" \
-                "$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
-            ;;
-        buzz)
-            print_info "Transcribing with Buzz CLI..."
-            local buzz_args=(transcribe "$audio_file" --model "$TRANSCRIBE_MODEL")
-            if [[ "$TRANSCRIBE_LANGUAGE" != "auto" ]]; then
-                buzz_args+=(--language "$TRANSCRIBE_LANGUAGE")
-            fi
-            buzz_args+=(--output-format "$TRANSCRIBE_FORMAT")
-            buzz "${buzz_args[@]}" > "$output_file" || exit_code=$?
-            ;;
-    esac
+	# Run transcription
+	local exit_code=0
+	case "$backend" in
+	faster-whisper)
+		transcribe_faster_whisper "$audio_file" "$TRANSCRIBE_MODEL" \
+			"$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
+		;;
+	whisper-cpp)
+		transcribe_whisper_cpp "$audio_file" "$TRANSCRIBE_MODEL" \
+			"$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
+		;;
+	groq)
+		transcribe_groq "$audio_file" "$TRANSCRIBE_MODEL" \
+			"$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
+		;;
+	openai)
+		transcribe_openai "$audio_file" "$TRANSCRIBE_MODEL" \
+			"$TRANSCRIBE_LANGUAGE" "$TRANSCRIBE_FORMAT" "$output_file" || exit_code=$?
+		;;
+	buzz)
+		print_info "Transcribing with Buzz CLI..."
+		local buzz_args=(transcribe "$audio_file" --model "$TRANSCRIBE_MODEL")
+		if [[ "$TRANSCRIBE_LANGUAGE" != "auto" ]]; then
+			buzz_args+=(--language "$TRANSCRIBE_LANGUAGE")
+		fi
+		buzz_args+=(--output-format "$TRANSCRIBE_FORMAT")
+		buzz "${buzz_args[@]}" >"$output_file" || exit_code=$?
+		;;
+	esac
 
-    # Cleanup temp files
-    if [[ "$cleanup_temp" == true ]] && [[ -n "$temp_audio" ]]; then
-        rm -f "$temp_audio"
-    fi
+	# Cleanup temp files
+	if [[ "$cleanup_temp" == true ]] && [[ -n "$temp_audio" ]]; then
+		rm -f "$temp_audio"
+	fi
 
-    if [[ $exit_code -eq 0 ]]; then
-        echo ""
-        print_success "Transcription saved to: $output_file"
+	if [[ $exit_code -eq 0 ]]; then
+		echo ""
+		print_success "Transcription saved to: $output_file"
 
-        # Show file size and preview
-        if [[ -f "$output_file" ]]; then
-            local file_size
-            file_size=$(wc -c < "$output_file" | tr -d ' ')
-            local line_count
-            line_count=$(wc -l < "$output_file" | tr -d ' ')
-            print_info "Size: ${file_size} bytes, ${line_count} lines"
+		# Show file size and preview
+		if [[ -f "$output_file" ]]; then
+			local file_size
+			file_size=$(wc -c <"$output_file" | tr -d ' ')
+			local line_count
+			line_count=$(wc -l <"$output_file" | tr -d ' ')
+			print_info "Size: ${file_size} bytes, ${line_count} lines"
 
-            if [[ "$TRANSCRIBE_FORMAT" == "txt" ]] && [[ $line_count -gt 0 ]]; then
-                echo ""
-                print_info "Preview (first 5 lines):"
-                head -5 "$output_file"
-            fi
-        fi
-    else
-        print_error "Transcription failed (exit code: $exit_code)"
-    fi
+			if [[ "$TRANSCRIBE_FORMAT" == "txt" ]] && [[ $line_count -gt 0 ]]; then
+				echo ""
+				print_info "Preview (first 5 lines):"
+				head -5 "$output_file"
+			fi
+		fi
+	else
+		print_error "Transcription failed (exit code: $exit_code)"
+	fi
 
-    return $exit_code
+	return $exit_code
 }
 
 # List available models
 cmd_models() {
-    print_header "Available Transcription Models"
+	print_header "Available Transcription Models"
 
-    echo ""
-    echo -e "${CYAN}Local Models (Whisper Family):${NC}"
-    echo "  tiny              75MB    Speed: 9.5  Accuracy: 6.0  Draft/preview only"
-    echo "  base              142MB   Speed: 8.5  Accuracy: 7.3  Quick transcription"
-    echo "  small             461MB   Speed: 7.0  Accuracy: 8.5  Good balance, multilingual"
-    echo "  medium            1.5GB   Speed: 5.0  Accuracy: 9.0  Solid quality"
-    echo "  large-v3          2.9GB   Speed: 3.0  Accuracy: 9.8  Best quality"
-    echo "  large-v3-turbo    1.5GB   Speed: 7.5  Accuracy: 9.7  Recommended default"
+	echo ""
+	echo -e "${CYAN}Local Models (Whisper Family):${NC}"
+	echo "  tiny              75MB    Speed: 9.5  Accuracy: 6.0  Draft/preview only"
+	echo "  base              142MB   Speed: 8.5  Accuracy: 7.3  Quick transcription"
+	echo "  small             461MB   Speed: 7.0  Accuracy: 8.5  Good balance, multilingual"
+	echo "  medium            1.5GB   Speed: 5.0  Accuracy: 9.0  Solid quality"
+	echo "  large-v3          2.9GB   Speed: 3.0  Accuracy: 9.8  Best quality"
+	echo "  large-v3-turbo    1.5GB   Speed: 7.5  Accuracy: 9.7  Recommended default"
 
-    echo ""
-    echo -e "${CYAN}Other Local Models:${NC}"
-    echo "  parakeet-v2       474MB   Speed: 9.9  Accuracy: 9.4  English-only, fastest"
-    echo "  parakeet-v3       494MB   Speed: 9.9  Accuracy: 9.4  Multilingual, experimental"
+	echo ""
+	echo -e "${CYAN}Other Local Models:${NC}"
+	echo "  parakeet-v2       474MB   Speed: 9.9  Accuracy: 9.4  English-only, fastest"
+	echo "  parakeet-v3       494MB   Speed: 9.9  Accuracy: 9.4  Multilingual, experimental"
 
-    echo ""
-    echo -e "${CYAN}Cloud APIs:${NC}"
-    echo "  groq              -       Speed: 10   Accuracy: 9.6  Free tier available"
-    echo "  openai            -       Speed: 8    Accuracy: 9.5  \$0.006/min"
-    echo "  elevenlabs        -       Speed: 8    Accuracy: 9.9  Pay per minute"
-    echo "  deepgram          -       Speed: 10   Accuracy: 9.5  Pay per minute"
+	echo ""
+	echo -e "${CYAN}Cloud APIs:${NC}"
+	echo "  groq              -       Speed: 10   Accuracy: 9.6  Free tier available"
+	echo "  openai            -       Speed: 8    Accuracy: 9.5  \$0.006/min"
+	echo "  elevenlabs        -       Speed: 8    Accuracy: 9.9  Pay per minute"
+	echo "  deepgram          -       Speed: 10   Accuracy: 9.5  Pay per minute"
 
-    echo ""
-    echo -e "${CYAN}Available Backends:${NC}"
-    local check_mark="${GREEN}available${NC}"
-    local cross_mark="${RED}not installed${NC}"
+	echo ""
+	echo -e "${CYAN}Available Backends:${NC}"
+	local check_mark="${GREEN}available${NC}"
+	local cross_mark="${RED}not installed${NC}"
 
-    printf "  %-20s " "faster-whisper:"
-    if has_faster_whisper; then echo -e "$check_mark"; else echo -e "$cross_mark"; fi
+	printf "  %-20s " "faster-whisper:"
+	if has_faster_whisper; then echo -e "$check_mark"; else echo -e "$cross_mark"; fi
 
-    printf "  %-20s " "whisper.cpp:"
-    if has_whisper_cpp; then echo -e "$check_mark"; else echo -e "$cross_mark"; fi
+	printf "  %-20s " "whisper.cpp:"
+	if has_whisper_cpp; then echo -e "$check_mark"; else echo -e "$cross_mark"; fi
 
-    printf "  %-20s " "buzz:"
-    if has_buzz; then echo -e "$check_mark"; else echo -e "$cross_mark"; fi
+	printf "  %-20s " "buzz:"
+	if has_buzz; then echo -e "$check_mark"; else echo -e "$cross_mark"; fi
 
-    printf "  %-20s " "groq:"
-    if [[ -n "${GROQ_API_KEY:-}" ]]; then echo -e "$check_mark (API key set)"; else echo -e "$cross_mark (no API key)"; fi
+	printf "  %-20s " "groq:"
+	if [[ -n "${GROQ_API_KEY:-}" ]]; then echo -e "$check_mark (API key set)"; else echo -e "$cross_mark (no API key)"; fi
 
-    printf "  %-20s " "openai:"
-    if [[ -n "${OPENAI_API_KEY:-}" ]]; then echo -e "$check_mark (API key set)"; else echo -e "$cross_mark (no API key)"; fi
+	printf "  %-20s " "openai:"
+	if [[ -n "${OPENAI_API_KEY:-}" ]]; then echo -e "$check_mark (API key set)"; else echo -e "$cross_mark (no API key)"; fi
 
-    echo ""
-    return 0
+	echo ""
+	return 0
 }
 
 # Configure defaults
 cmd_configure() {
-    print_header "Configure Transcription Defaults"
+	print_header "Configure Transcription Defaults"
 
-    mkdir -p "$CONFIG_DIR"
+	mkdir -p "$CONFIG_DIR"
 
-    local model="${1:-$DEFAULT_MODEL}"
-    local format="${2:-$DEFAULT_OUTPUT_FORMAT}"
-    local language="${3:-$DEFAULT_LANGUAGE}"
+	local model="${1:-$DEFAULT_MODEL}"
+	local format="${2:-$DEFAULT_OUTPUT_FORMAT}"
+	local language="${3:-$DEFAULT_LANGUAGE}"
 
-    if ! command -v jq &>/dev/null; then
-        print_error "jq is required for configuration. Install: brew install jq"
-        return 1
-    fi
+	if ! command -v jq &>/dev/null; then
+		print_error "jq is required for configuration. Install: brew install jq"
+		return 1
+	fi
 
-    jq -n \
-        --arg model "$model" \
-        --arg format "$format" \
-        --arg language "$language" \
-        '{model: $model, format: $format, language: $language}' > "$CONFIG_FILE"
+	jq -n \
+		--arg model "$model" \
+		--arg format "$format" \
+		--arg language "$language" \
+		'{model: $model, format: $format, language: $language}' >"$CONFIG_FILE"
 
-    print_success "Configuration saved to: $CONFIG_FILE"
-    print_info "  Model:    $model"
-    print_info "  Format:   $format"
-    print_info "  Language: $language"
-    return 0
+	print_success "Configuration saved to: $CONFIG_FILE"
+	print_info "  Model:    $model"
+	print_info "  Format:   $format"
+	print_info "  Language: $language"
+	return 0
 }
 
 # Install dependencies
 cmd_install() {
-    print_header "Installing Transcription Dependencies"
+	print_header "Installing Transcription Dependencies"
 
-    local os_type
-    os_type=$(uname -s)
+	local os_type
+	os_type=$(uname -s)
 
-    # Install ffmpeg and yt-dlp
-    echo ""
-    print_info "Installing system dependencies..."
-    case "$os_type" in
-        "Darwin")
-            if command -v brew &>/dev/null; then
-                brew install ffmpeg yt-dlp 2>&1 | tail -5
-            else
-                print_warning "Homebrew not found. Install manually: ffmpeg, yt-dlp"
-            fi
-            ;;
-        "Linux")
-            if command -v apt-get &>/dev/null; then
-                sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg 2>&1 | tail -3
-                pip3 install -U yt-dlp 2>&1 | tail -3
-            elif command -v pacman &>/dev/null; then
-                sudo pacman -S --noconfirm ffmpeg yt-dlp 2>&1 | tail -3
-            else
-                print_warning "Unknown package manager. Install manually: ffmpeg, yt-dlp"
-            fi
-            ;;
-    esac
+	# Install ffmpeg and yt-dlp
+	echo ""
+	print_info "Installing system dependencies..."
+	case "$os_type" in
+	"Darwin")
+		if command -v brew &>/dev/null; then
+			brew install ffmpeg yt-dlp 2>&1 | tail -5
+		else
+			print_warning "Homebrew not found. Install manually: ffmpeg, yt-dlp"
+		fi
+		;;
+	"Linux")
+		if command -v apt-get &>/dev/null; then
+			sudo apt-get update -qq && sudo apt-get install -y -qq ffmpeg 2>&1 | tail -3
+			pip3 install -U yt-dlp 2>&1 | tail -3
+		elif command -v pacman &>/dev/null; then
+			sudo pacman -S --noconfirm ffmpeg yt-dlp 2>&1 | tail -3
+		else
+			print_warning "Unknown package manager. Install manually: ffmpeg, yt-dlp"
+		fi
+		;;
+	esac
 
-    # Install faster-whisper
-    echo ""
-    print_info "Installing faster-whisper (recommended local backend)..."
-    local python_bin
-    python_bin=$(find_python 2>/dev/null || echo "python3")
-    "$python_bin" -m pip install faster-whisper 2>&1 | tail -5
+	# Install faster-whisper
+	echo ""
+	print_info "Installing faster-whisper (recommended local backend)..."
+	local python_bin
+	python_bin=$(find_python 2>/dev/null || echo "python3")
+	"$python_bin" -m pip install faster-whisper 2>&1 | tail -5
 
-    echo ""
-    cmd_status
-    return 0
+	echo ""
+	cmd_status
+	return 0
 }
 
 # Check installation status
 cmd_status() {
-    print_header "Transcription Installation Status"
+	print_header "Transcription Installation Status"
 
-    # ffmpeg
-    if command -v ffmpeg &>/dev/null; then
-        local ffmpeg_version
-        ffmpeg_version=$(ffmpeg -version 2>/dev/null | head -1 | awk '{print $3}')
-        print_success "ffmpeg: $ffmpeg_version"
-    else
-        print_error "ffmpeg: not installed"
-    fi
+	# ffmpeg
+	if command -v ffmpeg &>/dev/null; then
+		local ffmpeg_version
+		ffmpeg_version=$(ffmpeg -version 2>/dev/null | head -1 | awk '{print $3}')
+		print_success "ffmpeg: $ffmpeg_version"
+	else
+		print_error "ffmpeg: not installed"
+	fi
 
-    # yt-dlp
-    if command -v yt-dlp &>/dev/null; then
-        local ytdlp_version
-        ytdlp_version=$(yt-dlp --version 2>/dev/null)
-        print_success "yt-dlp: $ytdlp_version"
-    else
-        print_warning "yt-dlp: not installed (needed for YouTube)"
-    fi
+	# yt-dlp
+	if command -v yt-dlp &>/dev/null; then
+		local ytdlp_version
+		ytdlp_version=$(yt-dlp --version 2>/dev/null)
+		print_success "yt-dlp: $ytdlp_version"
+	else
+		print_warning "yt-dlp: not installed (needed for YouTube)"
+	fi
 
-    # faster-whisper
-    if has_faster_whisper; then
-        print_success "faster-whisper: available"
-    else
-        print_warning "faster-whisper: not installed (pip install faster-whisper)"
-    fi
+	# faster-whisper
+	if has_faster_whisper; then
+		print_success "faster-whisper: available"
+	else
+		print_warning "faster-whisper: not installed (pip install faster-whisper)"
+	fi
 
-    # whisper.cpp
-    if has_whisper_cpp; then
-        print_success "whisper.cpp: available"
-    else
-        print_info "whisper.cpp: not installed (optional)"
-    fi
+	# whisper.cpp
+	if has_whisper_cpp; then
+		print_success "whisper.cpp: available"
+	else
+		print_info "whisper.cpp: not installed (optional)"
+	fi
 
-    # Buzz
-    if has_buzz; then
-        print_success "buzz: available"
-    else
-        print_info "buzz: not installed (optional, brew install --cask buzz)"
-    fi
+	# Buzz
+	if has_buzz; then
+		print_success "buzz: available"
+	else
+		print_info "buzz: not installed (optional, brew install --cask buzz)"
+	fi
 
-    # Cloud API keys
-    if [[ -n "${GROQ_API_KEY:-}" ]]; then
-        print_success "Groq API: key configured"
-    else
-        print_info "Groq API: no key (aidevops secret set GROQ_API_KEY)"
-    fi
+	# Cloud API keys
+	if [[ -n "${GROQ_API_KEY:-}" ]]; then
+		print_success "Groq API: key configured"
+	else
+		print_info "Groq API: no key (aidevops secret set GROQ_API_KEY)"
+	fi
 
-    if [[ -n "${OPENAI_API_KEY:-}" ]]; then
-        print_success "OpenAI API: key configured"
-    else
-        print_info "OpenAI API: no key (aidevops secret set OPENAI_API_KEY)"
-    fi
+	if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+		print_success "OpenAI API: key configured"
+	else
+		print_info "OpenAI API: no key (aidevops secret set OPENAI_API_KEY)"
+	fi
 
-    # Config
-    if [[ -f "$CONFIG_FILE" ]]; then
-        print_success "Config: $CONFIG_FILE"
-    else
-        print_info "Config: using defaults (run: transcription-helper.sh configure)"
-    fi
+	# Config
+	if [[ -f "$CONFIG_FILE" ]]; then
+		print_success "Config: $CONFIG_FILE"
+	else
+		print_info "Config: using defaults (run: transcription-helper.sh configure)"
+	fi
 
-    return 0
+	return 0
 }
 
 # Show help
 show_help() {
-    cat << 'EOF'
+	cat <<'EOF'
 Transcription Helper - Audio/Video Transcription
 
 Usage: transcription-helper.sh <command> [options]
@@ -1015,40 +1030,40 @@ Backends (auto-selected if not specified):
   groq             Cloud, free tier, lightning fast
   openai           Cloud, $0.006/min
 EOF
-    return 0
+	return 0
 }
 
 # ─── Main Entry Point ────────────────────────────────────────────────
 
 main() {
-    local command="${1:-help}"
-    shift 2>/dev/null || true
+	local command="${1:-help}"
+	shift 2>/dev/null || true
 
-    case "$command" in
-        transcribe)
-            cmd_transcribe "$@"
-            ;;
-        models)
-            cmd_models
-            ;;
-        configure)
-            cmd_configure "$@"
-            ;;
-        install)
-            cmd_install
-            ;;
-        status)
-            cmd_status
-            ;;
-        help|-h|--help|"")
-            show_help
-            ;;
-        *)
-            print_error "$ERROR_UNKNOWN_COMMAND: $command"
-            show_help
-            return 1
-            ;;
-    esac
+	case "$command" in
+	transcribe)
+		cmd_transcribe "$@"
+		;;
+	models)
+		cmd_models
+		;;
+	configure)
+		cmd_configure "$@"
+		;;
+	install)
+		cmd_install
+		;;
+	status)
+		cmd_status
+		;;
+	help | -h | --help | "")
+		show_help
+		;;
+	*)
+		print_error "$ERROR_UNKNOWN_COMMAND: $command"
+		show_help
+		return 1
+		;;
+	esac
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

- Replace `mapfile` (bash 4.0+) with `while IFS= read -r` loops in bundle-helper.sh, linter-manager.sh, privacy-filter-helper.sh
- Replace `${var,,}` case modification (bash 4.0+) with `tr '[:upper:]' '[:lower:]'` in procurement-helper.sh, transcription-helper.sh
- All replacements verified working on bash 3.2.57 (macOS default)

## Context

Follow-up to PR #4592 which fixed the same class of bug in worktree-helper.sh (`declare -A` + `[[ -v ]]`). That fix revealed 7 more scripts using bash 4.0+ features. This PR fixes 5 (per the 5-file quality-debt cap); the remaining 2 (compare-models-helper.sh, eeat-score-helper.sh) are deferred to a follow-up issue.

## Impact

These scripts silently crash on macOS default bash (3.2), which is the standard environment for all aidevops users. The crashes are silent because callers typically use `|| true` or `2>/dev/null`.

## Testing

- All portable replacements verified on `/bin/bash` 3.2.57 (macOS arm64)
- ShellCheck clean (only pre-existing SC1091 for external source)
- `tr` lowercase, `while-read` array building, and process substitution all pass on bash 3.2

## Follow-up

- compare-models-helper.sh: uses `declare -A` (associative arrays)
- eeat-score-helper.sh: uses `mapfile` (2 occurrences)