### PR TITLE
fix: replace bash 4.0+ features with portable alternatives in 2 scripts

### DIFF
--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -2869,14 +2869,16 @@ cmd_bench() {
 		done
 
 		# Collect judge scores if enabled
-		declare -A judge_scores=()
+		local judge_models=()
+		local judge_scores_vals=()
 		if [[ "$judge_flag" == true ]]; then
 			echo "  Scoring with judge (haiku)..."
 			local judge_output
 			judge_output=$(_bench_judge_score "$p" "$bench_dir")
 			while IFS='|' read -r jm js; do
 				[[ -z "$jm" ]] && continue
-				judge_scores["$jm"]="$js"
+				judge_models+=("$jm")
+				judge_scores_vals+=("$js")
 			done <<<"$judge_output"
 		fi
 
@@ -2933,7 +2935,14 @@ cmd_bench() {
 			local cost_fmt
 			cost_fmt=$(printf "\$%.4f" "$cost")
 
-			local judge_score="${judge_scores[$m]:-}"
+			# Look up judge score from parallel arrays
+			local judge_score=""
+			for i in "${!judge_models[@]}"; do
+				if [[ "${judge_models[$i]}" == "$m" ]]; then
+					judge_score="${judge_scores_vals[$i]}"
+					break
+				fi
+			done
 
 			# Store result
 			_store_bench_result "$m" "$p" "$latency" "$tokens_in" "$tokens_out" "$cost" \

--- a/.agents/scripts/eeat-score-helper.sh
+++ b/.agents/scripts/eeat-score-helper.sh
@@ -810,10 +810,14 @@ do_analyze() {
 	local urls=()
 	if [[ "$input_file" == *.json ]]; then
 		# JSON format - extract URLs with status 200
-		mapfile -t urls < <(jq -r '.[] | select(.status_code == 200) | .url' "$input_file" 2>/dev/null)
+		while IFS= read -r _url; do
+			[[ -n "$_url" ]] && urls+=("$_url")
+		done < <(jq -r '.[] | select(.status_code == 200) | .url' "$input_file" 2>/dev/null)
 	elif [[ "$input_file" == *.csv ]]; then
 		# CSV format - extract URLs from first column where status is 200
-		mapfile -t urls < <(tail -n +2 "$input_file" | awk -F',' '$2 == "200" || $2 == 200 {gsub(/"/, "", $1); print $1}')
+		while IFS= read -r _url; do
+			[[ -n "$_url" ]] && urls+=("$_url")
+		done < <(tail -n +2 "$input_file" | awk -F',' '$2 == "200" || $2 == 200 {gsub(/"/, "", $1); print $1}')
 	fi
 
 	if [[ ${#urls[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Summary

- Replace `declare -A judge_scores` associative array in compare-models-helper.sh with parallel arrays (judge_models, judge_scores_vals) and loop-based lookup
- Replace `mapfile -t urls` (2 occurrences) in eeat-score-helper.sh with `while IFS= read -r` loops

## Context

Follow-up to PR #4601 which fixed the same class of bug in 5 other scripts. These bash 4.0+ features cause silent crashes on macOS default bash (3.2), which is the standard environment for all aidevops users.

## Impact

These scripts silently crash on macOS default bash (3.2.57), which is the standard environment for all aidevops users. The crashes are silent because callers typically use `|| true` or `2>/dev/null`.

## Testing

- All portable replacements verified on `/bin/bash` 3.2.57 (macOS arm64)
- ShellCheck clean (only pre-existing SC1091 for external source)
- Parallel arrays and while-read loops all pass on bash 3.2

## Closes

Closes #4602