### PR TITLE
t3696: resolve gemini review feedback on auto-verify logic in todo-sync.sh

### DIFF
--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -639,19 +639,14 @@ process_verify_queue() {
 	local verified_count=0
 	local failed_count=0
 	local auto_verified_count=0
-	local max_auto_verify_per_pulse=50
+	local MAX_AUTO_VERIFY_PER_PULSE=50
 
 	while IFS='|' read -r tid trepo; do
 		[[ -z "$tid" ]] && continue
 
 		local verify_file="$trepo/todo/VERIFY.md"
-		local has_entry=false
 
 		if [[ -f "$verify_file" ]] && grep -q -- "^- \[ \] v[0-9]* $tid " "$verify_file" 2>/dev/null; then
-			has_entry=true
-		fi
-
-		if [[ "$has_entry" == "true" ]]; then
 			# Has VERIFY.md entry — run the defined checks
 			log_info "  $tid: running verification checks"
 			cmd_transition "$tid" "verifying" 2>>"$SUPERVISOR_LOG" || {
@@ -672,7 +667,7 @@ process_verify_queue() {
 		else
 			# No VERIFY.md entry — auto-verify (PR merged + CI passed is sufficient)
 			# Rate-limit to avoid overwhelming the state machine in one pulse
-			if [[ "$auto_verified_count" -ge "$max_auto_verify_per_pulse" ]]; then
+			if [[ "$auto_verified_count" -ge "$MAX_AUTO_VERIFY_PER_PULSE" ]]; then
 				continue
 			fi
 			cmd_transition "$tid" "verified" 2>>"$SUPERVISOR_LOG" || {
@@ -680,6 +675,7 @@ process_verify_queue() {
 				continue
 			}
 			auto_verified_count=$((auto_verified_count + 1))
+			log_info "  $tid: auto-verified (no VERIFY.md entry)"
 		fi
 	done <<<"$deployed_tasks"
 


### PR DESCRIPTION
## Summary

Resolves the three medium-severity findings from Gemini's review of PR #1494 (`process_verify_queue` auto-verify logic in `.agents/scripts/supervisor-archived/todo-sync.sh`).

## Changes

- **UPPER_SNAKE_CASE constant**: Renamed `max_auto_verify_per_pulse` → `MAX_AUTO_VERIFY_PER_PULSE` per repository style guide (constants/env vars use UPPER_SNAKE_CASE)
- **Simplified control flow**: Removed the `has_entry` temporary flag variable; inlined the condition directly into the `if`/`else` structure, making the logic more direct
- **Observability**: Added `log_info "  $tid: auto-verified (no VERIFY.md entry)"` after each auto-verification, matching the log verbosity of the manual verification path

## Verification

- ShellCheck: zero violations
- Logic unchanged — only style, variable naming, and log output affected

Closes #3696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code maintainability through internal refactoring.

* **Chores**
  * Enhanced logging for auto-verified tasks to provide clearer observability and better traceability during verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->