### PR TITLE
t4602: fix bash 3.2 compatibility regressions

### DIFF
--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -2868,15 +2868,17 @@ cmd_bench() {
 			wait "$pid" 2>/dev/null || true
 		done
 
-		# Collect judge scores if enabled
-		declare -A judge_scores=()
+		# Collect judge scores if enabled (bash 3.2 compatible)
+		local judge_scores_data=""
+		local judge_models=""
 		if [[ "$judge_flag" == true ]]; then
 			echo "  Scoring with judge (haiku)..."
 			local judge_output
 			judge_output=$(_bench_judge_score "$p" "$bench_dir")
 			while IFS='|' read -r jm js; do
 				[[ -z "$jm" ]] && continue
-				judge_scores["$jm"]="$js"
+				judge_scores_data+="${jm}|${js}"$'\n'
+				judge_models+="${jm}"$'\n'
 			done <<<"$judge_output"
 		fi
 
@@ -2933,7 +2935,15 @@ cmd_bench() {
 			local cost_fmt
 			cost_fmt=$(printf "\$%.4f" "$cost")
 
-			local judge_score="${judge_scores[$m]:-}"
+			local judge_score=""
+			if [[ -n "$judge_models" ]] && echo "$judge_models" | grep -Fxq "$m"; then
+				while IFS='|' read -r stored_model stored_score; do
+					if [[ "$stored_model" == "$m" ]]; then
+						judge_score="$stored_score"
+						break
+					fi
+				done <<<"$judge_scores_data"
+			fi
 
 			# Store result
 			_store_bench_result "$m" "$p" "$latency" "$tokens_in" "$tokens_out" "$cost" \

--- a/.agents/scripts/eeat-score-helper.sh
+++ b/.agents/scripts/eeat-score-helper.sh
@@ -810,10 +810,14 @@ do_analyze() {
 	local urls=()
 	if [[ "$input_file" == *.json ]]; then
 		# JSON format - extract URLs with status 200
-		mapfile -t urls < <(jq -r '.[] | select(.status_code == 200) | .url' "$input_file" 2>/dev/null)
+		while IFS= read -r url; do
+			[[ -n "$url" ]] && urls+=("$url")
+		done < <(jq -r '.[] | select(.status_code == 200) | .url' "$input_file" 2>/dev/null)
 	elif [[ "$input_file" == *.csv ]]; then
 		# CSV format - extract URLs from first column where status is 200
-		mapfile -t urls < <(tail -n +2 "$input_file" | awk -F',' '$2 == "200" || $2 == 200 {gsub(/"/, "", $1); print $1}')
+		while IFS= read -r url; do
+			[[ -n "$url" ]] && urls+=("$url")
+		done < <(tail -n +2 "$input_file" | awk -F',' '$2 == "200" || $2 == 200 {gsub(/"/, "", $1); print $1}')
 	fi
 
 	if [[ ${#urls[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Replace bash 4-only `declare -A` usage in `compare-models-helper.sh` with bash 3.2-safe newline-delimited storage and exact-match lookup.
- Replace both `mapfile -t` usages in `eeat-score-helper.sh` with `while IFS= read -r` loops for macOS default bash compatibility.
- Preserve existing behavior while removing two known bash 3.2 crash points tracked in issue #4602.

## Verification
- `shellcheck .agents/scripts/compare-models-helper.sh`
- `shellcheck .agents/scripts/eeat-score-helper.sh`
- `/bin/bash -n .agents/scripts/compare-models-helper.sh .agents/scripts/eeat-score-helper.sh`
- `rg -n \"declare -A|mapfile -t\" .agents/scripts/compare-models-helper.sh .agents/scripts/eeat-score-helper.sh` (no matches)

Closes #4602