### PR TITLE
t3703: make AI reasoning lock timestamp parsing atomic

### DIFF
--- a/.agents/scripts/supervisor-archived/ai-reason.sh
+++ b/.agents/scripts/supervisor-archived/ai-reason.sh
@@ -127,15 +127,22 @@ run_ai_reasoning() {
 	# Concurrency guard — prevent overlapping AI reasoning sessions
 	local lock_file="$AI_REASON_LOG_DIR/.ai-reason.lock"
 	if [[ -f "$lock_file" ]]; then
-		local lock_pid lock_age
-		lock_pid=$(head -1 "$lock_file" 2>/dev/null || echo 0)
-		local lock_mtime
-		if [[ "$(uname)" == "Darwin" ]]; then
-			lock_mtime=$(stat -f '%m' "$lock_file" 2>/dev/null || echo "0")
-		else
-			lock_mtime=$(stat -c '%Y' "$lock_file" 2>/dev/null || echo "0")
+		local lock_pid lock_ts lock_age
+		read -r lock_pid lock_ts <"$lock_file" 2>/dev/null || true
+		lock_pid="${lock_pid:-0}"
+		if ! [[ "${lock_ts:-}" =~ ^[0-9]+$ ]]; then
+			local lock_mtime
+			if [[ "$(uname)" == "Darwin" ]]; then
+				lock_mtime=$(stat -f '%m' "$lock_file" 2>/dev/null || echo "0")
+			else
+				lock_mtime=$(stat -c '%Y' "$lock_file" 2>/dev/null || echo "0")
+			fi
+			lock_ts="$lock_mtime"
 		fi
-		lock_age=$(($(date +%s) - lock_mtime))
+		lock_age=$(($(date +%s) - lock_ts))
+		if [[ "$lock_age" -lt 0 ]]; then
+			lock_age=0
+		fi
 		# If lock holder is still alive and lock is not stale (< 5 min), skip
 		if kill -0 "$lock_pid" 2>/dev/null && [[ "$lock_age" -lt 300 ]]; then
 			log_info "AI Reasoning: already running (PID $lock_pid, ${lock_age}s old) — skipping"
@@ -147,7 +154,7 @@ run_ai_reasoning() {
 		rm -f "$lock_file"
 	fi
 	# Acquire lock
-	echo "$$" >"$lock_file"
+	printf '%s %s\n' "$$" "$(date +%s)" >"$lock_file"
 
 	# Helper to release lock — called before every return
 	_release_ai_lock() { rm -f "$lock_file"; }


### PR DESCRIPTION
## Summary
- Read lock PID and timestamp atomically from `.ai-reason.lock` to avoid mixed metadata reads during concurrency checks.
- Write lock files in `PID TIMESTAMP` format and keep a legacy mtime fallback so existing single-field lock files still behave correctly.
- Preserve stale-lock cleanup behavior while ensuring lock age never goes negative.

## Verification
- `shellcheck .agents/scripts/supervisor-archived/ai-reason.sh` (SC1091 infos only; no new lint issues)
- Focused behavior test command validating new-format lock, legacy lock, and stale lock flows

Closes #3703