### PR TITLE
fix(quality): add explicit return 0 to get_domain() in eeat-score-helper.sh

### DIFF
--- a/.agents/scripts/eeat-score-helper.sh
+++ b/.agents/scripts/eeat-score-helper.sh
@@ -122,6 +122,7 @@ check_api_key() {
 get_domain() {
 	local url="$1"
 	echo "$url" | sed -E 's|^https?://||' | sed -E 's|/.*||' | sed -E 's|:.*||'
+	return 0
 }
 
 # Create output directory structure


### PR DESCRIPTION
## Summary

- Add explicit `return 0` to `get_domain()` function in `.agents/scripts/eeat-score-helper.sh` (line 125)
- Addresses high-severity quality-debt flagged in PR #2118 review: function was missing an explicit return statement

## Changes

- `.agents/scripts/eeat-score-helper.sh` — added `return 0` after the `echo` pipeline in `get_domain()`

## Verification

- ShellCheck: zero new violations (only pre-existing SC1091 info about `source`, suppressed by project convention)
- Blast radius: 1 file changed, 1 line inserted

Closes #3292