### PR TITLE
t3290: docs(configuration): clarify tier alias design in model tiers table

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -221,17 +221,19 @@ Each tier maps to an ordered list of models. The first available model in the li
 
 **Default tiers:**
 
-| Tier | Models | Fallback |
-|------|--------|----------|
-| `local` | `local/llama.cpp` | `haiku` |
-| `haiku` | `anthropic/claude-haiku-4-5` | -- |
-| `flash` | `anthropic/claude-haiku-4-5` | -- |
-| `sonnet` | `anthropic/claude-sonnet-4-6` | -- |
-| `pro` | `anthropic/claude-sonnet-4-6` | -- |
-| `opus` | `anthropic/claude-opus-4-6` | -- |
-| `coding` | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6` | -- |
-| `eval` | `anthropic/claude-sonnet-4-6` | -- |
-| `health` | `anthropic/claude-sonnet-4-6` | -- |
+| Tier | Models | Fallback | Purpose |
+|------|--------|----------|---------|
+| `local` | `local/llama.cpp` | `haiku` | Offline / privacy-first tasks |
+| `haiku` | `anthropic/claude-haiku-4-5` | -- | Fast, low-cost tasks (primary name) |
+| `flash` | `anthropic/claude-haiku-4-5` | -- | Alias for `haiku` — use either name interchangeably |
+| `sonnet` | `anthropic/claude-sonnet-4-6` | -- | Balanced capability/cost (primary name) |
+| `pro` | `anthropic/claude-sonnet-4-6` | -- | Alias for `sonnet` — use either name interchangeably |
+| `opus` | `anthropic/claude-opus-4-6` | -- | Highest capability, highest cost |
+| `coding` | `anthropic/claude-opus-4-6`, `anthropic/claude-sonnet-4-6` | -- | Code tasks: tries opus first, falls back to sonnet |
+| `eval` | `anthropic/claude-sonnet-4-6` | -- | Evaluation and grading tasks |
+| `health` | `anthropic/claude-sonnet-4-6` | -- | Health/wellness domain tasks |
+
+> **Tier aliases:** `haiku` and `flash` resolve to the same model, as do `sonnet` and `pro`. These aliases exist so agent configs and user preferences can use either naming convention (Anthropic-style vs Google-style tier names) without requiring separate model entries. Changing the model for `haiku` automatically applies to `flash` and vice versa.
 
 **Example -- add a custom tier with OpenAI fallback:**
 


### PR DESCRIPTION
## Summary

- Add **Purpose** column to the default model tiers table in `docs/configuration.md`
- Add blockquote note explaining why `haiku`/`flash` and `sonnet`/`pro` are aliases pointing to the same model
- Clarifies that the aliasing allows agent configs to use either Anthropic-style or Google-style tier naming conventions interchangeably

## Context

Addresses the HIGH-severity finding from PR #2743 review (gemini-code-assist):

> "It's unclear why separate tiers like `flash` and `haiku` (or `sonnet` and `pro`) map to the exact same model. If these are intended as aliases, it would be helpful to clarify this for users."

The model identifiers (`claude-haiku-4-5`, `claude-sonnet-4-6`, `claude-opus-4-6`) are correct for this project — the human reviewer confirmed this in the PR thread. The only actionable change was adding the alias explanation.

The two MEDIUM findings (broken link at line 649, `"wordpress"` casing at line 592) were already fixed in commit c7634a43 on the original PR.

Closes #3290