### PR TITLE
t3306: fix(tool-install): use install -d -m 700 for ~/.ssh directory creation

### DIFF
--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -989,7 +989,7 @@ setup_ssh_key() {
 
 		if [[ "$generate_key" =~ ^[Yy]?$ ]]; then
 			read -r -p "Enter your email address: " email
-			mkdir -p ~/.ssh && chmod 700 ~/.ssh
+			install -d -m 700 ~/.ssh
 			ssh-keygen -t ed25519 -C "$email" -f ~/.ssh/id_ed25519
 			print_success "SSH key generated"
 		else


### PR DESCRIPTION
## Summary

- Replace `mkdir -p ~/.ssh && chmod 700 ~/.ssh` with `install -d -m 700 ~/.ssh` in `setup_ssh_key()`
- `install -d -m 700` is more concise, idiomatic, and portable — creates the directory and sets permissions atomically in a single command
- Addresses Gemini Code Assist review feedback from PR #2742

## Changes

- `setup-modules/tool-install.sh:992` — one-line change, no behaviour difference

## Verification

- ShellCheck: zero violations
- Semantically equivalent: `install -d -m 700 <dir>` creates the directory with the specified permissions, same as `mkdir -p <dir> && chmod 700 <dir>`, but atomic and portable across Linux and macOS

Closes #3306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized SSH directory setup during installation for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->