### PR TITLE
t3344: fix(privacy-filter-helper): remove stderr suppression from source

### DIFF
--- a/.agents/scripts/privacy-filter-helper.sh
+++ b/.agents/scripts/privacy-filter-helper.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 # Configuration
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
+source "$SCRIPT_DIR/shared-constants.sh" || true
 
 # Colors for output (fallback if shared-constants.sh not loaded)
 [[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'


### PR DESCRIPTION
## Summary

- Removes `2>/dev/null` from `source "$SCRIPT_DIR/shared-constants.sh"` on line 24
- The `|| true` fallback already handles a missing file gracefully under `set -e`
- Stderr suppression was hiding syntax errors and missing-file diagnostics, reducing debuggability

## Change

```diff
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
+source "$SCRIPT_DIR/shared-constants.sh" || true
```

## References

- Addresses gemini review feedback on PR #2172 (medium severity, line 24)
- ShellCheck passes (SC1091 info notice is pre-existing and expected)

Closes #3344