### PR TITLE
t3316: fix validatePositionalParams — add pipe-delimited cell exclusion

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -809,11 +809,13 @@ function validatePositionalParams(filePath) {
         //   - $N/billing-unit (e.g. $5/mo, $9/year) — but NOT $1/config (path)
         //   - $N followed by space + pricing/unit word (e.g. $5 flat, $3 fee, $9 per month)
         //   - Markdown table rows (lines starting with |)
+        //   - $N followed by pipe (pipe-delimited cells, e.g. $5 | next column)
         if (
           /\$[1-9][0-9.,]/.test(stripped) ||
           /\$[1-9]\/(?:mo(?:nth)?|yr|year|day|week|hr|hour)\b/.test(stripped) ||
           /\$[1-9]\s+(?:per|mo(?:nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)\b/.test(stripped) ||
-          /^\s*\|/.test(line)
+          /^\s*\|/.test(line) ||
+          /\$[1-9]\s*\|/.test(stripped)
         ) {
           continue;
         }


### PR DESCRIPTION
## Summary

- Adds `$[1-9]\s*\|` pattern to the false-positive exclusion block in `validatePositionalParams()`, covering pipe-delimited table cells where `$N` appears before a `|` character (e.g. `echo "$5 | next column"`)
- The existing `^\s*\|` check only caught markdown table rows that *start* with `|`; this adds coverage for cells where `$N` precedes a pipe mid-line
- JS syntax verified; 5 targeted test cases all pass

## Findings addressed

- **Gemini (medium)**: Consolidate consecutive `if` statements — the suggestion also included the missing `$[1-9]\s*\|` pattern; that pattern is the actionable fix (the `if` blocks were already consolidated in the prior PR)
- **CodeRabbit (medium)**: Already addressed in commit `07b8c65` (line-wide escaped-dollar skip replaced with strip-then-check approach); no further change needed

Closes #3316