### PR TITLE
t3320: fix(tests): expand security-helper.sh test coverage to match plugins.sh parity

### DIFF
--- a/tests/test-batch-quality-hardening.sh
+++ b/tests/test-batch-quality-hardening.sh
@@ -514,10 +514,27 @@ else
 fi
 
 # Test: security-helper.sh has Python version pre-check (t1351)
-if grep -q 'check_python_for_skill_scanner' "$SCRIPTS_DIR/security-helper.sh"; then
-	pass "security-helper.sh has Python version pre-check for skill scanner"
+SECURITY_HELPER_SH="$SCRIPTS_DIR/security-helper.sh"
+if [[ -f "$SECURITY_HELPER_SH" ]]; then
+	if grep -q 'check_python_for_skill_scanner' "$SECURITY_HELPER_SH"; then
+		pass "security-helper.sh has Python version pre-check for skill scanner"
+	else
+		fail "security-helper.sh missing Python version pre-check"
+	fi
+
+	if grep -q 'Python >= 3.10' "$SECURITY_HELPER_SH"; then
+		pass "security-helper.sh shows clear Python version requirement in error message"
+	else
+		fail "security-helper.sh missing clear Python version requirement message"
+	fi
+
+	if grep -qE 'brew install python|uv python install' "$SECURITY_HELPER_SH"; then
+		pass "security-helper.sh shows fix instructions for missing Python"
+	else
+		fail "security-helper.sh missing fix instructions for Python version"
+	fi
 else
-	fail "security-helper.sh missing Python version pre-check"
+	skip "security-helper.sh not found (tests may need updating after modularization)"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

- Expands the `security-helper.sh` test block in `tests/test-batch-quality-hardening.sh` to match the comprehensiveness of the `plugins.sh` tests
- Adds two additional assertions: Python version requirement message (`Python >= 3.10`) and fix instructions (`brew install python` / `uv python install`)
- Wraps the block in a file-existence guard (matching the `plugins.sh` pattern) for graceful skip when the file is missing

## Problem

PR #2472 added Python pre-check tests but the `security-helper.sh` block (line 521) only verified function existence. Gemini flagged this inconsistency: the `plugins.sh` block (lines 501-511) also checks for the version requirement message and fix instructions, but `security-helper.sh` did not.

## Verification

All three assertions pass against the current `security-helper.sh`:
- `check_python_for_skill_scanner` — present
- `Python >= 3.10` — present in error message
- `brew install python` / `uv python install` — present as fix instructions

ShellCheck: zero violations on modified file.

Closes #3320