### PR TITLE
t3330: document shebang portability exception in issue-sync helper

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Intentionally using /bin/bash (not /usr/bin/env bash) for headless compatibility.
+# Some MCP/headless runners provide a stripped PATH where env cannot resolve bash.
+# Keep this exception aligned with issue #2610 and t135.14 standardization context.
 # shellcheck disable=SC2155
 # =============================================================================
 # aidevops Issue Sync Helper (Simplified)


### PR DESCRIPTION
## Summary
- Add explicit header comments in `.agents/scripts/issue-sync-helper.sh` explaining why this script intentionally uses `#!/bin/bash`.
- Document the headless/MCP PATH constraint so future standardization work does not accidentally revert the fix.
- Reference issue context from #2610 and t135.14 so the exception is auditable.

Closes #3330