### PR TITLE
fix: add wrapper-level forced recycle when pulse LLM exits early while underfilled

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2920,11 +2920,89 @@ main() {
 		initial_underfill_pct=0
 	fi
 
+	local pulse_start_epoch
+	pulse_start_epoch=$(date +%s)
 	run_pulse "$initial_underfilled_mode" "$initial_underfill_pct"
-	# enforce_utilization_invariants removed — the LLM pulse session now runs
-	# a monitoring loop (sleep 60s, check slots, backfill) for up to 60 minutes,
-	# making the wrapper's backfill loop redundant. The wrapper's watchdog still
-	# enforces the hard 60-minute ceiling via PULSE_STALE_THRESHOLD.
+
+	# Early-exit recycle: if the LLM exited quickly without entering the
+	# monitoring loop (< 5 min runtime) and the pool is still underfilled
+	# with runnable work, restart the pulse immediately. This catches models
+	# that treat the dispatch as single-turn and stop instead of looping.
+	# Capped at PULSE_BACKFILL_MAX_ATTEMPTS to prevent infinite restarts.
+	local pulse_end_epoch
+	pulse_end_epoch=$(date +%s)
+	local pulse_duration=$((pulse_end_epoch - pulse_start_epoch))
+	local recycle_attempt=0
+
+	while [[ "$recycle_attempt" -lt "$PULSE_BACKFILL_MAX_ATTEMPTS" ]]; do
+		# Only recycle if the pulse ran for less than 5 minutes — a pulse
+		# that ran longer likely entered the monitoring loop and exited
+		# normally (all slots filled, no runnable work, or stale threshold).
+		if [[ "$pulse_duration" -ge 300 ]]; then
+			break
+		fi
+
+		# Check if stop flag was set during the pulse
+		if [[ -f "$STOP_FLAG" ]]; then
+			echo "[pulse-wrapper] Stop flag set — skipping early-exit recycle" >>"$LOGFILE"
+			break
+		fi
+
+		# Re-check worker state
+		local post_max post_active post_runnable post_queued
+		post_max=$(get_max_workers_target)
+		post_active=$(count_active_workers)
+		post_runnable=$(count_runnable_candidates)
+		post_queued=$(count_queued_without_worker)
+		[[ "$post_max" =~ ^[0-9]+$ ]] || post_max=1
+		[[ "$post_active" =~ ^[0-9]+$ ]] || post_active=0
+		[[ "$post_runnable" =~ ^[0-9]+$ ]] || post_runnable=0
+		[[ "$post_queued" =~ ^[0-9]+$ ]] || post_queued=0
+
+		# Exit if pool is full or no runnable work
+		if [[ "$post_active" -ge "$post_max" ]]; then
+			break
+		fi
+		if [[ "$post_runnable" -eq 0 && "$post_queued" -eq 0 ]]; then
+			break
+		fi
+
+		local post_deficit_pct=$(((post_max - post_active) * 100 / post_max))
+		recycle_attempt=$((recycle_attempt + 1))
+		echo "[pulse-wrapper] Early-exit recycle attempt ${recycle_attempt}/${PULSE_BACKFILL_MAX_ATTEMPTS}: pulse ran ${pulse_duration}s (<300s), pool underfilled (active ${post_active}/${post_max}, deficit ${post_deficit_pct}%, runnable=${post_runnable}, queued=${post_queued})" >>"$LOGFILE"
+
+		# Re-run the underfill recycler to clear stale workers before restarting
+		run_underfill_worker_recycler "$post_max" "$post_active" "$post_runnable" "$post_queued"
+
+		# Re-prefetch state for the new pulse attempt
+		if ! run_stage_with_timeout "prefetch_state" "$PRE_RUN_STAGE_TIMEOUT" prefetch_state; then
+			echo "[pulse-wrapper] Early-exit recycle: prefetch_state failed — aborting recycle" >>"$LOGFILE"
+			break
+		fi
+
+		# Recalculate underfill for the new pulse
+		post_active=$(count_active_workers)
+		[[ "$post_active" =~ ^[0-9]+$ ]] || post_active=0
+		local recycle_underfilled_mode=0
+		local recycle_underfill_pct=0
+		if [[ "$post_active" -lt "$post_max" ]]; then
+			recycle_underfilled_mode=1
+			recycle_underfill_pct=$(((post_max - post_active) * 100 / post_max))
+		fi
+
+		local recycle_start_epoch
+		recycle_start_epoch=$(date +%s)
+		run_pulse "$recycle_underfilled_mode" "$recycle_underfill_pct"
+
+		local recycle_end_epoch
+		recycle_end_epoch=$(date +%s)
+		pulse_duration=$((recycle_end_epoch - recycle_start_epoch))
+	done
+
+	if [[ "$recycle_attempt" -gt 0 ]]; then
+		echo "[pulse-wrapper] Early-exit recycle completed after ${recycle_attempt} attempt(s)" >>"$LOGFILE"
+	fi
+
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Adds a backup recycle mechanism to `pulse-wrapper.sh` that detects when the pulse LLM exits early (< 5 min) without entering the monitoring loop, and immediately restarts the pulse instead of waiting for the next launchd cycle (120s)
- Prevents the scenario where the LLM dispatches a few workers then stops, leaving the pool severely underfilled with hundreds of runnable issues and no slot-refilling mechanism active

## Root Cause

Some models (observed with `openai/gpt-5.3-codex`) treat the `/pulse` dispatch as a single-turn task — they dispatch workers, emit a "next check in ~60s" message, then hit `reason:"stop"` instead of continuing into the monitoring loop. The pulse process stays alive but at 0% CPU, doing nothing. Workers finish and slots go unfilled until the next launchd cycle.

## How It Works

After `run_pulse()` returns, the wrapper checks:
1. Did the pulse run for less than 300 seconds? (If longer, it likely entered the monitoring loop normally)
2. Is the pool still underfilled with runnable work?
3. If both true, restart the pulse (up to `PULSE_BACKFILL_MAX_ATTEMPTS`, default 3)

Each recycle attempt:
- Re-runs the underfill worker recycler to clear stale workers
- Re-prefetches state for fresh dispatch decisions
- Recalculates underfill metrics
- Launches a new pulse session

## Companion Change

The launchd plist now sets `PULSE_MODEL=anthropic/claude-sonnet-4-6` to force Claude for the pulse supervisor (Claude correctly maintains the monitoring loop). This wrapper-level recycle is the backup in case any model still exits early.

Closes #4604