### PR TITLE
t3261: fix path inconsistency for version-manager.sh in AGENTS.md Quick Reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 ## Quick Reference
 
 - **User Guide**: `.agents/AGENTS.md` (deployed to `~/.aidevops/agents/`)
-- **Commands**: `./setup.sh` (deploy) | `.agents/scripts/linters-local.sh` (quality) | `version-manager.sh release [major|minor|patch]`
+- **Commands**: `./setup.sh` (deploy) | `.agents/scripts/linters-local.sh` (quality) | `.agents/scripts/version-manager.sh release [major|minor|patch]`
 - **Config**: `~/.config/opencode/opencode.json`, `~/.claude/settings.json`
 - **Quality**: `prompts/build.txt`
 


### PR DESCRIPTION
## Summary

- Adds the missing `.agents/scripts/` prefix to `version-manager.sh` in the Quick Reference section of `AGENTS.md` (line 8)
- Aligns with the full path already used in the Quality Workflow section (line 69)
- Prevents contributors from running the script from the wrong directory

## Changes

Single-line fix in `AGENTS.md`:

```diff
-- **Commands**: `./setup.sh` (deploy) | `.agents/scripts/linters-local.sh` (quality) | `version-manager.sh release [major|minor|patch]`
+- **Commands**: `./setup.sh` (deploy) | `.agents/scripts/linters-local.sh` (quality) | `.agents/scripts/version-manager.sh release [major|minor|patch]`
```

## Source

Quality-debt finding from CodeRabbit review on PR #2048.

Closes #3261