### PR TITLE
t3260: fix quality-debt review feedback for .agents/build-plus.md

### DIFF
--- a/.agents/build-plus.md
+++ b/.agents/build-plus.md
@@ -129,7 +129,7 @@ Before implementing, check AGENTS.md domain index. If the task touches a special
 | SEO/blog posts | `seo/` + `content/distribution/` |
 | WordPress | `tools/wordpress/wp-dev.md` |
 | UI/layout/design/CSS | `workflows/ui-verification.md` + `tools/browser/playwright-emulation.md` + `tools/browser/chrome-devtools.md` |
-| Design system/brand identity/style | `tools/design/ui-ux-inspiration.md` + `tools/design/ui-ux-catalogue.toon` + `tools/design/brand-identity.md` |
+| Design system/brand identity/style | `tools/design/design-inspiration.md` + `tools/design/ui-ux-inspiration.md` + `tools/design/ui-ux-catalogue.toon` + `tools/design/brand-identity.md` |
 | Browser automation | `tools/browser/browser-automation.md` |
 | Accessibility | `services/accessibility/accessibility-audit.md` |
 | Local dev / .local domains / ports / proxy / HTTPS / LocalWP | `services/hosting/local-hosting.md` |


### PR DESCRIPTION
## Summary

Addresses unactioned review feedback from PR #2048 (and cross-PR findings aggregated in issue #3260).

- Add `tools/design/design-inspiration.md` to the Design system row in the domain expertise table (gemini finding from PR #2691 — file exists but was missing from the index)
- All other findings in issue #3260 were already resolved in `main` prior to this PR:
  - MD022 blank-line violations (PR #2048 CodeRabbit): fixed
  - FTS5 `<2-3 keywords>` hint (PR #2048 gemini): fixed
  - `scan-file`/`scan-stdin` documentation (PR #2710): fixed
  - Stray `+` in `gh api` command (PR #2462 gemini): already absent

## Verification

- `npx markdownlint-cli2 .agents/build-plus.md` → 0 errors
- `tools/design/design-inspiration.md` confirmed present in `~/.aidevops/agents/tools/design/`

Closes #3260