### PR TITLE
t3257: fix quality-debt review feedback for simplex.md

### DIFF
--- a/.agents/services/communications/simplex.md
+++ b/.agents/services/communications/simplex.md
@@ -377,7 +377,7 @@ See: [TypeScript SDK README](https://github.com/simplex-chat/simplex-chat/tree/s
 // Subset of types from @simplex-chat/types — see upstream for full definitions.
 // Placeholders for types defined in @simplex-chat/types
 type LinkPreview = { uri: string; title: string; description: string; image: string }
-type CryptoFile = { filePath: string; cryptoArgs?: object }
+type CryptoFile = { filePath: string; cryptoArgs?: Record<string, unknown> }
 
 // MsgContent — discriminated union (common variants; upstream also has video, report, chat, unknown)
 type MsgContent =


### PR DESCRIPTION
## Summary

- Fix remaining quality-debt review feedback for `.agents/services/communications/simplex.md` from PRs #2266, #2309, #2317
- Replace `object` with `Record<string, unknown>` for `CryptoFile.cryptoArgs` type (PR #2317 finding)

## Findings addressed

All findings from issue #3257 are now resolved:

| Finding | Severity | Source | Status |
|---------|----------|--------|--------|
| `curl \| bash` security — download-then-review pattern | HIGH | PR #2266 | Fixed in prior session |
| `wget \| bash` security — download-then-review pattern | HIGH | PR #2266 | Fixed in prior session |
| SMP server `--no-password` in default example | MEDIUM | PR #2266 | Fixed in prior session |
| Path refs missing `.agents/` prefix | MEDIUM | PR #2266 | Fixed in prior session |
| Key Commands table — wrong command names | MEDIUM | PR #2266 | Already correct |
| `ChatType` import from wrong module | HIGH | PR #2309 | Fixed in prior session |
| `enableAddressAutoAccept(user.userId)` — wrong arg | CRITICAL | PR #2309 | Fixed in prior session |
| Hardcoded `1` in `sendChatCmd` | HIGH | PR #2309 | Fixed in prior session |
| `apiGetUserAddress`/`apiCreateUserAddress` missing `userId` | MEDIUM | PR #2309 | Fixed in prior session |
| `apiSendTextMessage` using string literals not `ChatType` enum | MEDIUM | PR #2309 | Fixed in prior session |
| TypeScript types using `int`/`int64`/`bool` primitives | HIGH | PR #2309 | Fixed in prior session |
| `LinkPreview`/`CryptoFile` undefined in type snippet | MEDIUM | PR #2309 | Fixed in prior session |
| `CryptoFile.cryptoArgs?: object` — use `Record<string, unknown>` | MEDIUM | PR #2317 | **Fixed in this PR** |
| `ChatType` import from `@simplex-chat/types` | MEDIUM | PR #2317 | Fixed in prior session |
| `enableAddressAutoAccept` missing `userId` | MEDIUM | PR #2317 | Fixed in prior session |

Closes #3257