### PR TITLE
t3256: fix: capitalize Markdown as proper noun in t1313-brief.md

### DIFF
--- a/todo/tasks/t1313-brief.md
+++ b/todo/tasks/t1313-brief.md
@@ -102,7 +102,7 @@ Defining verification at brief-creation time means the person/AI who understands
 
 ## Context & Decisions
 
-- Verification blocks use YAML inside fenced code blocks (not inline YAML frontmatter) to avoid breaking existing markdown parsers
+- Verification blocks use YAML inside fenced code blocks (not inline YAML frontmatter) to avoid breaking existing Markdown parsers
 - `manual` method never blocks automated completion — it reports "SKIP (manual)" and succeeds
 - `subagent` method uses ai-research MCP tool for lightweight review (not full agent dispatch)
 - Verification is optional — briefs without verify blocks still work normally


### PR DESCRIPTION
## Summary

- Capitalize `markdown` → `Markdown` at line 105 of `todo/tasks/t1313-brief.md`
- Markdown is a proper noun (the formatting language created by John Gruber)

## Source

Quality-debt review feedback from PR #2187, flagged by CodeRabbit (LanguageTool rule `MARKDOWN_NNP`).

## Change

```diff
-- Verification blocks use YAML inside fenced code blocks (not inline YAML frontmatter) to avoid breaking existing markdown parsers
+- Verification blocks use YAML inside fenced code blocks (not inline YAML frontmatter) to avoid breaking existing Markdown parsers
```

Closes #3256