### PR TITLE
t3283: document intentional sh -c design in executeShellCommand

### DIFF
--- a/.agents/scripts/simplex-bot/src/approval.ts
+++ b/.agents/scripts/simplex-bot/src/approval.ts
@@ -230,11 +230,29 @@ export class ApprovalManager {
  * Execute a shell command and return the output.
  * Used after approval is granted.
  * Enforces a per-command timeout to prevent runaway processes.
+ *
+ * Security note — intentional use of `sh -c`:
+ * This bot's core purpose is to execute arbitrary approved shell commands
+ * (including pipes, redirects, compound expressions, and shell builtins).
+ * Array-based argument passing (e.g. `Bun.spawn([...args])`) cannot support
+ * this use case because it bypasses shell interpretation entirely.
+ *
+ * The security boundary is the three-tier approval flow in `ApprovalManager`:
+ *   1. Blocklist — patterns like `rm -rf`, `shutdown`, `dd` are always rejected.
+ *   2. Allowlist — safe read-only commands execute immediately.
+ *   3. Approval-required — everything else requires explicit human approval
+ *      via `/approve <id>` before execution.
+ *
+ * Commands only reach this function after passing classification AND receiving
+ * explicit approval. The `sh -c` pattern is therefore a deliberate design
+ * choice, not a vulnerability. See t1327.10 exec approval flow specification
+ * and the dismissal rationale in GH#3283.
  */
 export async function executeShellCommand(
   command: string,
   timeoutMs: number = 30_000,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  // sh -c is intentional — see JSDoc above for security rationale
   const proc = Bun.spawn(["sh", "-c", command], {
     stdout: "pipe",
     stderr: "pipe",


### PR DESCRIPTION
## Summary

- Addresses the critical quality-debt finding from PR #2371 review (GH#3283)
- Documents the intentional `sh -c` design decision in `executeShellCommand` with a full security rationale JSDoc comment
- Confirms finding 2 (generateId recursion) was already fixed in PR #2371 — current code uses `do/while`, not recursion

## Findings addressed

### CRITICAL (line 238) — `Bun.spawn(["sh", "-c", command])` flagged as command injection risk

**Resolution: documented as intentional by-design.**

The simplex bot's core purpose is to execute arbitrary approved shell commands, including pipes, redirects, compound expressions, and shell builtins. Array-based argument passing bypasses shell interpretation entirely and would break core functionality.

The security boundary is the three-tier `ApprovalManager` flow:
1. **Blocklist** — dangerous patterns (`rm -rf`, `shutdown`, `dd`) always rejected
2. **Allowlist** — safe read-only commands execute immediately
3. **Approval-required** — everything else requires explicit human `/approve <id>`

Commands only reach `executeShellCommand` after passing classification AND receiving explicit approval. The `sh -c` pattern is a deliberate design choice, not a vulnerability. This aligns with the dismissal rationale posted by @johnwaldo in GH#3283.

### MEDIUM (line 69) — `generateId` recursion risk

**Resolution: already fixed.** The current code at lines 60–68 already uses a `do/while` loop. No change needed.

## Changes

- `.agents/scripts/simplex-bot/src/approval.ts` — expanded JSDoc on `executeShellCommand` with security rationale and inline comment on the `Bun.spawn` call

Closes #3283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced internal documentation with detailed security rationale comments explaining the implementation approach and security boundaries for command execution processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->