### PR TITLE
t3277: wire upstream_watch config keys and document JSONC config for all numeric intervals

### DIFF
--- a/.agents/configs/aidevops-config.schema.json
+++ b/.agents/configs/aidevops-config.schema.json
@@ -63,6 +63,17 @@
           "default": 24,
           "minimum": 1,
           "description": "Hours between OpenClaw update checks. Env: AIDEVOPS_OPENCLAW_FRESHNESS_HOURS"
+        },
+        "upstream_watch": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically check upstream repos for new releases. Env: AIDEVOPS_UPSTREAM_WATCH"
+        },
+        "upstream_watch_hours": {
+          "type": "integer",
+          "default": 24,
+          "minimum": 1,
+          "description": "Hours between upstream repo watch checks. Env: AIDEVOPS_UPSTREAM_WATCH_HOURS"
         }
       },
       "additionalProperties": false

--- a/.agents/configs/aidevops.defaults.jsonc
+++ b/.agents/configs/aidevops.defaults.jsonc
@@ -64,7 +64,15 @@
 
     // Hours between OpenClaw update checks.
     // Env override: AIDEVOPS_OPENCLAW_FRESHNESS_HOURS
-    "openclaw_freshness_hours": 24
+    "openclaw_freshness_hours": 24,
+
+    // Automatically check upstream repos (inspiration/borrowed-from) for new releases.
+    // Env override: AIDEVOPS_UPSTREAM_WATCH
+    "upstream_watch": true,
+
+    // Hours between upstream repo watch checks.
+    // Env override: AIDEVOPS_UPSTREAM_WATCH_HOURS
+    "upstream_watch_hours": 24
   },
 
   // ---------------------------------------------------------------------------

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -26,17 +26,21 @@
 #   auto-update-helper.sh help             Show this help
 #
 # Configuration:
-#   AIDEVOPS_AUTO_UPDATE=true|false        Override enable/disable (env var)
-#   AIDEVOPS_UPDATE_INTERVAL=10           Minutes between checks (default: 10)
-#   AIDEVOPS_SKILL_AUTO_UPDATE=false      Disable daily skill freshness check
-#   AIDEVOPS_SKILL_FRESHNESS_HOURS=24     Hours between skill checks (default: 24)
-#   AIDEVOPS_OPENCLAW_AUTO_UPDATE=false   Disable daily OpenClaw update check
-#   AIDEVOPS_OPENCLAW_FRESHNESS_HOURS=24  Hours between OpenClaw checks (default: 24)
-#   AIDEVOPS_TOOL_AUTO_UPDATE=false       Disable 6-hourly tool freshness check
-#   AIDEVOPS_TOOL_FRESHNESS_HOURS=6       Hours between tool checks (default: 6)
-#   AIDEVOPS_TOOL_IDLE_HOURS=6            Required user idle hours before tool updates (default: 6)
-#   AIDEVOPS_UPSTREAM_WATCH=false         Disable daily upstream repo watch check
-#   AIDEVOPS_UPSTREAM_WATCH_HOURS=24      Hours between upstream watch checks (default: 24)
+#   All values can be set via JSONC config (aidevops config set <key> <value>)
+#   or overridden per-session via environment variables (higher priority).
+#
+#   JSONC key                          Env override                    Default
+#   updates.auto_update                AIDEVOPS_AUTO_UPDATE            true
+#   updates.update_interval_minutes    AIDEVOPS_UPDATE_INTERVAL        10
+#   updates.skill_auto_update          AIDEVOPS_SKILL_AUTO_UPDATE      true
+#   updates.skill_freshness_hours      AIDEVOPS_SKILL_FRESHNESS_HOURS  24
+#   updates.openclaw_auto_update       AIDEVOPS_OPENCLAW_AUTO_UPDATE   true
+#   updates.openclaw_freshness_hours   AIDEVOPS_OPENCLAW_FRESHNESS_HOURS 24
+#   updates.tool_auto_update           AIDEVOPS_TOOL_AUTO_UPDATE       true
+#   updates.tool_freshness_hours       AIDEVOPS_TOOL_FRESHNESS_HOURS   6
+#   updates.tool_idle_hours            AIDEVOPS_TOOL_IDLE_HOURS        6
+#   updates.upstream_watch             AIDEVOPS_UPSTREAM_WATCH         true
+#   updates.upstream_watch_hours       AIDEVOPS_UPSTREAM_WATCH_HOURS   24
 #
 # Logs: ~/.aidevops/logs/auto-update.log
 
@@ -1564,16 +1568,22 @@ COMMANDS:
     logs --follow       Follow log output in real-time
     help                Show this help
 
-ENVIRONMENT:
-    AIDEVOPS_AUTO_UPDATE=false           Disable auto-update (overrides scheduler)
-    AIDEVOPS_UPDATE_INTERVAL=10          Minutes between checks (default: 10)
-    AIDEVOPS_SKILL_AUTO_UPDATE=false     Disable daily skill freshness check
-    AIDEVOPS_SKILL_FRESHNESS_HOURS=24    Hours between skill checks (default: 24)
-    AIDEVOPS_OPENCLAW_AUTO_UPDATE=false  Disable daily OpenClaw update check
-    AIDEVOPS_OPENCLAW_FRESHNESS_HOURS=24 Hours between OpenClaw checks (default: 24)
-    AIDEVOPS_TOOL_AUTO_UPDATE=false      Disable 6-hourly tool freshness check
-    AIDEVOPS_TOOL_FRESHNESS_HOURS=6      Hours between tool checks (default: 6)
-    AIDEVOPS_TOOL_IDLE_HOURS=6           Required user idle hours before tool updates (default: 6)
+CONFIGURATION:
+    Persistent settings: aidevops config set <key> <value>
+    Per-session overrides: set the corresponding environment variable.
+
+    JSONC key                          Env override                     Default
+    updates.auto_update                AIDEVOPS_AUTO_UPDATE             true
+    updates.update_interval_minutes    AIDEVOPS_UPDATE_INTERVAL         10
+    updates.skill_auto_update          AIDEVOPS_SKILL_AUTO_UPDATE       true
+    updates.skill_freshness_hours      AIDEVOPS_SKILL_FRESHNESS_HOURS   24
+    updates.openclaw_auto_update       AIDEVOPS_OPENCLAW_AUTO_UPDATE    true
+    updates.openclaw_freshness_hours   AIDEVOPS_OPENCLAW_FRESHNESS_HOURS 24
+    updates.tool_auto_update           AIDEVOPS_TOOL_AUTO_UPDATE        true
+    updates.tool_freshness_hours       AIDEVOPS_TOOL_FRESHNESS_HOURS    6
+    updates.tool_idle_hours            AIDEVOPS_TOOL_IDLE_HOURS         6
+    updates.upstream_watch             AIDEVOPS_UPSTREAM_WATCH          true
+    updates.upstream_watch_hours       AIDEVOPS_UPSTREAM_WATCH_HOURS    24
 
 SCHEDULER BACKENDS:
     macOS:  launchd LaunchAgent (~/Library/LaunchAgents/com.aidevops.aidevops-auto-update.plist)
@@ -1612,9 +1622,10 @@ HOW IT WORKS:
 RATE LIMITS:
     GitHub API: 60 requests/hour (unauthenticated)
     10-min interval = 6 requests/hour (well within limits)
-    Skill check: once per 24h per user (configurable via AIDEVOPS_SKILL_FRESHNESS_HOURS)
-    OpenClaw check: once per 24h per user (configurable via AIDEVOPS_OPENCLAW_FRESHNESS_HOURS)
-    Tool check: once per 6h per user, only when idle (configurable via AIDEVOPS_TOOL_FRESHNESS_HOURS)
+    Skill check: once per 24h per user (configurable via updates.skill_freshness_hours)
+    OpenClaw check: once per 24h per user (configurable via updates.openclaw_freshness_hours)
+    Tool check: once per 6h per user, only when idle (configurable via updates.tool_freshness_hours)
+    Upstream watch: once per 24h per user (configurable via updates.upstream_watch_hours)
 
 LOGS:
     ~/.aidevops/logs/auto-update.log

--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -292,6 +292,8 @@ _config_env_map() {
 	updates.tool_idle_hours) echo "AIDEVOPS_TOOL_IDLE_HOURS" ;;
 	updates.openclaw_auto_update) echo "AIDEVOPS_OPENCLAW_AUTO_UPDATE" ;;
 	updates.openclaw_freshness_hours) echo "AIDEVOPS_OPENCLAW_FRESHNESS_HOURS" ;;
+	updates.upstream_watch) echo "AIDEVOPS_UPSTREAM_WATCH" ;;
+	updates.upstream_watch_hours) echo "AIDEVOPS_UPSTREAM_WATCH_HOURS" ;;
 	orchestration.supervisor_pulse) echo "AIDEVOPS_SUPERVISOR_PULSE" ;;
 	orchestration.repo_sync) echo "AIDEVOPS_REPO_SYNC" ;;
 	orchestration.max_workers_cap) echo "AIDEVOPS_MAX_WORKERS_CAP" ;;
@@ -357,6 +359,8 @@ _legacy_key_to_dotpath() {
 	tool_idle_hours) echo "updates.tool_idle_hours" ;;
 	openclaw_auto_update) echo "updates.openclaw_auto_update" ;;
 	openclaw_freshness_hours) echo "updates.openclaw_freshness_hours" ;;
+	upstream_watch) echo "updates.upstream_watch" ;;
+	upstream_watch_hours) echo "updates.upstream_watch_hours" ;;
 	manage_opencode_config) echo "integrations.manage_opencode_config" ;;
 	manage_claude_config) echo "integrations.manage_claude_config" ;;
 	supervisor_pulse) echo "orchestration.supervisor_pulse" ;;


### PR DESCRIPTION
## Summary

Addresses the critical quality-debt finding from PR #2731 (CodeRabbit review): numeric update config values from JSONC were not applied — only environment variable overrides worked.

**Root cause confirmed:** `upstream_watch` and `upstream_watch_hours` were the only keys used by `auto-update-helper.sh` that were **not** wired into the config system. All other numeric keys (`skill_freshness_hours`, `tool_freshness_hours`, `tool_idle_hours`, `openclaw_freshness_hours`, `update_interval_minutes`) were already correctly mapped in `_config_env_map` and `_legacy_key_to_dotpath` in `config-helper.sh`, and present in `aidevops.defaults.jsonc` and `aidevops-config.schema.json`. The code already used `get_feature_toggle` which routes through `config_get` in JSONC mode.

## Changes

- **`config-helper.sh`**: Add `upstream_watch → updates.upstream_watch` and `upstream_watch_hours → updates.upstream_watch_hours` to both `_config_env_map` (dotpath → env var) and `_legacy_key_to_dotpath` (flat key → dotpath). This completes the config routing chain for all numeric update intervals.
- **`aidevops.defaults.jsonc`**: Add `upstream_watch: true` and `upstream_watch_hours: 24` to the `updates` section with env-override hints.
- **`aidevops-config.schema.json`**: Add `upstream_watch` (boolean) and `upstream_watch_hours` (integer, minimum: 1) to the `updates` object schema. Removes `additionalProperties: false` violation that would have rejected these keys.
- **`auto-update-helper.sh`**: Replace the env-var-only `Configuration:` header with a three-column table (JSONC key | env override | default) covering all 10 update settings, making JSONC config discoverable. Update `RATE LIMITS` section to reference JSONC dotpaths and add upstream watch entry.

## Verification

- `shellcheck` passes on all modified shell scripts (zero violations)
- `get_feature_toggle upstream_watch_hours` now routes through `config_get "updates.upstream_watch_hours"` in JSONC mode, which checks `AIDEVOPS_UPSTREAM_WATCH_HOURS` env var first, then JSONC user config, then defaults — matching the pattern used by all other numeric intervals

Closes #3277