### PR TITLE
t3287: address setup-modules core review findings

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -219,16 +219,28 @@ install_packages() {
 	shift
 	local packages=("$@")
 
+	# Cache sudo credentials before spinner commands.
+	# Backgrounded processes cannot safely prompt for passwords.
+	if [[ "$pkg_manager" =~ ^(apt|dnf|yum|pacman|apk)$ ]]; then
+		sudo -v
+	fi
+
 	case "$pkg_manager" in
 	brew)
 		# Run brew update with spinner (Homebrew auto-update is slow and silent)
-		run_with_spinner "Updating Homebrew" brew update
+		if ! run_with_spinner "Updating Homebrew" brew update; then
+			print_error "Homebrew update failed"
+			return 1
+		fi
 		# Install with auto-update disabled (we just ran it)
 		# Note: run_with_spinner auto-exports HOMEBREW_NO_AUTO_UPDATE for brew commands
 		run_with_spinner "Installing ${packages[*]}" brew install "${packages[@]}"
 		;;
 	apt)
-		run_with_spinner "Updating package lists" sudo apt-get update -qq
+		if ! run_with_spinner "Updating package lists" sudo apt-get update -qq; then
+			print_error "apt-get update failed"
+			return 1
+		fi
 		run_with_spinner "Installing ${packages[*]}" sudo apt-get install -y -qq "${packages[@]}"
 		;;
 	dnf)
@@ -247,6 +259,8 @@ install_packages() {
 		return 1
 		;;
 	esac
+
+	return 0
 }
 
 # Offer to install Homebrew (Linuxbrew) on Linux when brew is not available


### PR DESCRIPTION
## Summary
- Cache sudo credentials before spinner-based package manager commands to prevent hidden background prompts from hanging installs.
- Propagate failures from `brew update` and `apt-get update` in `install_packages` so setup stops on stale package index errors.
- Add explicit `return 0` at the end of `install_packages` to satisfy shell function style requirements.

Closes #3287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed installation interruptions caused by password prompts from background package manager operations.
  * Enhanced error detection and reporting when package updates fail in Homebrew and apt-get.
  * Improved installation reliability with consistent and predictable exit code handling across all package manager paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->