### PR TITLE
fix(t3287): address PR #2154 review feedback in setup-modules/core.sh

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -219,16 +219,24 @@ install_packages() {
 	shift
 	local packages=("$@")
 
+	# Cache sudo credentials before backgrounding any sudo commands.
+	# run_with_spinner redirects output to /dev/null, so a sudo password prompt
+	# would be hidden and the script would appear to hang indefinitely.
+	[[ "$pkg_manager" =~ ^(apt|dnf|yum|pacman|apk)$ ]] && sudo -v
+
 	case "$pkg_manager" in
 	brew)
 		# Run brew update with spinner (Homebrew auto-update is slow and silent)
-		run_with_spinner "Updating Homebrew" brew update
-		# Install with auto-update disabled (we just ran it)
 		# Note: run_with_spinner auto-exports HOMEBREW_NO_AUTO_UPDATE for brew commands
+		if ! run_with_spinner "Updating Homebrew" brew update; then
+			print_warning "brew update failed — attempting install with existing package index"
+		fi
 		run_with_spinner "Installing ${packages[*]}" brew install "${packages[@]}"
 		;;
 	apt)
-		run_with_spinner "Updating package lists" sudo apt-get update -qq
+		if ! run_with_spinner "Updating package lists" sudo apt-get update -qq; then
+			print_warning "apt-get update failed — attempting install with existing package index"
+		fi
 		run_with_spinner "Installing ${packages[*]}" sudo apt-get install -y -qq "${packages[@]}"
 		;;
 	dnf)
@@ -247,6 +255,7 @@ install_packages() {
 		return 1
 		;;
 	esac
+	return 0
 }
 
 # Offer to install Homebrew (Linuxbrew) on Linux when brew is not available


### PR DESCRIPTION
## Summary

Addresses all 3 unactioned review findings from PR #2154 flagged in issue #3287.

### Fixes applied

**HIGH (gemini) — sudo credential caching before spinner**
Added `sudo -v` before the `case` statement for package managers that require root (`apt`, `dnf`, `yum`, `pacman`, `apk`). `run_with_spinner` backgrounds the command with output redirected to `/dev/null`, so a `sudo` password prompt would be hidden and the script would appear to hang indefinitely. Caching credentials first prevents this.

**HIGH (coderabbit) — propagate update failures with warning**
`brew update` and `apt-get update` failures are now caught with `if !` and a `print_warning` message is shown. The install still proceeds (the user may have a usable local index), but they get a clear diagnostic instead of a confusing downstream install error.

**MEDIUM (gemini) — explicit `return 0` at end of `install_packages()`**
Added `return 0` after the `case` block to satisfy the repository style guide requiring explicit return statements in all functions.

### Verification

- `shellcheck setup-modules/core.sh` — zero violations
- All three findings from the issue body are addressed

Closes #3287