### PR TITLE
t3278: fix(config-helper): address remaining CodeRabbit/Gemini review findings from PR #2731

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -29,7 +29,10 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
 fi
 
 # Resolve script directory (works when sourced or executed)
-_CONFIG_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 2>/dev/null || exit
+_CONFIG_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || {
+	echo "[config] Failed to resolve script directory" >&2
+	return 1 2>/dev/null || exit 1
+}
 
 # Only source shared-constants.sh when running standalone (not when sourced by it).
 # IMPORTANT: source=/dev/null tells ShellCheck NOT to follow this source directive.
@@ -557,6 +560,9 @@ cmd_get() {
 
 	# Support legacy flat keys
 	dotpath=$(_legacy_key_to_dotpath "$dotpath")
+
+	# Validate dotpath contains only safe characters
+	_validate_dotpath "$dotpath" || return 1
 
 	local value
 	value=$(config_get "$dotpath" "")


### PR DESCRIPTION
## Summary

Addresses the remaining unresolved findings from PR #2731 review (issue #3278).

**Audit result**: 5 of 7 findings were already resolved in subsequent PRs (#2931, #3002, #4000). Two genuine gaps remained in the merged code.

## Changes

### Fix 1: Explicit exit codes in `_CONFIG_HELPER_DIR` resolution (CodeRabbit CRITICAL, line 35)

**Before:**
```bash
_CONFIG_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 2>/dev/null || exit
```

**After:**
```bash
_CONFIG_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || {
	echo "[config] Failed to resolve script directory" >&2
	return 1 2>/dev/null || exit 1
}
```

- Uses explicit `return 1` / `exit 1` instead of bare `return` / `exit` (which inherit the last exit status, potentially 0)
- Adds a clear diagnostic error message to stderr
- Correctly uses `return 1 2>/dev/null` so `return` in non-function context fails silently, then falls through to `exit 1`

### Fix 2: Validate dotpath in `cmd_get` (Gemini HIGH, line 192 — defense-in-depth)

Adds `_validate_dotpath` call in `cmd_get` before passing the dotpath to `config_get`. The `_validate_dotpath` function was already added in the 9fae74d fix and applied in `cmd_set`/`cmd_reset`, but was missing from `cmd_get`. While jq injection is already prevented via `--arg`/`--argjson`, the validation provides defense-in-depth and consistent error messages.

## Verification

- ShellCheck passes with no warnings
- All 7 findings from issue #3278 now addressed

Closes #3278