### PR TITLE
t3681: batch duplicate TODO line deletion in dedup pass

### DIFF
--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -1605,11 +1605,15 @@ dedup_todo_task_ids() {
 		# Sort line numbers in descending order for safe deletion
 		local sorted_lines
 		sorted_lines=$(echo "$lines_to_delete" | tr ' ' '\n' | sort -rn | grep -v '^$')
+		local sed_expr=""
 
 		while IFS= read -r line_num; do
 			[[ -z "$line_num" ]] && continue
-			sed_inplace "${line_num}d" "$todo_file"
+			sed_expr+="${line_num}d;"
 		done <<<"$sorted_lines"
+
+		sed_expr="${sed_expr%;}"
+		sed_inplace "$sed_expr" "$todo_file"
 
 		log_success "Phase 0.5b: Removed $changes_made duplicate task line(s) from TODO.md"
 		commit_and_push_todo "$repo_path" "chore: remove $changes_made duplicate task line(s) from TODO.md (t1069)"


### PR DESCRIPTION
## Summary
- Batch duplicate TODO line deletions into a single `sed_inplace` call in `dedup_todo_task_ids`.
- Keep existing descending sort behavior while reducing repeated full-file rewrites during duplicate cleanup.
- Preserve existing dedup semantics (keep first occurrence, remove subsequent duplicates).

## Verification
- `shellcheck .agents/scripts/supervisor-archived/todo-sync.sh`
- `bash .agents/scripts/test-task-id-collision.sh`

Closes #3681