### PR TITLE
fix(t4628): replace non-existent openai/gpt-5.3-codex with openai/gpt-4o

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -15,7 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
-readonly DEFAULT_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-5.3-codex"
+readonly DEFAULT_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-4o"
 readonly STATE_DIR="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
 readonly STATE_DB="${STATE_DIR}/state.db"
 readonly OPENCODE_BIN_DEFAULT="${OPENCODE_BIN:-opencode}"
@@ -814,7 +814,7 @@ Usage:
   headless-runtime-helper.sh help
 
 Defaults:
-  AIDEVOPS_HEADLESS_MODELS defaults to anthropic/claude-sonnet-4-6,openai/gpt-5.3-codex
+  AIDEVOPS_HEADLESS_MODELS defaults to anthropic/claude-sonnet-4-6,openai/gpt-4o
   AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST can restrict selection to providers like: openai
   Gateway models (opencode/*) are rejected for headless runs.
 EOF


### PR DESCRIPTION
## Summary

Replaces `openai/gpt-5.3-codex` (non-existent model) with `openai/gpt-4o` in `DEFAULT_HEADLESS_MODELS`.

## Problem

`DEFAULT_HEADLESS_MODELS` in `.agents/scripts/headless-runtime-helper.sh` (line 18) included `openai/gpt-5.3-codex`, which does not exist. The round-robin alternates providers, so every other worker dispatch failed with `ProviderModelNotFoundError: Model not found: openai/gpt-5.3-codex`.

## Fix

Replace with `openai/gpt-4o` — the real OpenAI model used elsewhere in the codebase (e.g., `extraction_pipeline.py`).

## Verification

- `shellcheck` passes (SC1091 info-level only, pre-existing)
- Both occurrences updated: line 18 (constant) and line 817 (help text)

Closes #4628