### PR TITLE
t3331: document /bin/bash shebang exception in issue-sync-lib.sh

### DIFF
--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Using /bin/bash directly (not #!/usr/bin/env bash) for compatibility with
+# headless environments where a stripped PATH can prevent env from finding bash.
+# See issue #2610. This is an intentional exception to the repo's env-bash standard (t135.14).
 # =============================================================================
 # aidevops Issue Sync Library — Platform-Agnostic Functions (t1120.1)
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds a 3-line comment after the `#!/bin/bash` shebang in `.agents/scripts/issue-sync-lib.sh` explaining why `#!/usr/bin/env bash` is intentionally NOT used here
- References issue #2610 (headless PATH stripping bug) and the repo's env-bash standard (t135.14)
- Addresses the MEDIUM finding from gemini-code-assist on PR #2611

## Change

```bash
#!/bin/bash
# Using /bin/bash directly (not #!/usr/bin/env bash) for compatibility with
# headless environments where a stripped PATH can prevent env from finding bash.
# See issue #2610. This is an intentional exception to the repo's env-bash standard (t135.14).
```

No functional change — comment only.

Closes #3331