### PR TITLE
t3274: Fix /mission command review feedback from PR #2508

### DIFF
--- a/.agents/scripts/commands/mission.md
+++ b/.agents/scripts/commands/mission.md
@@ -282,9 +282,9 @@ The budget analysis engine uses model pricing from `shared-constants.sh`, task c
 
 ```bash
 # Check if we're in a git repo
-if git rev-parse --show-toplevel 2>/dev/null; then
+if top_level=$(git rev-parse --show-toplevel 2>/dev/null); then
   # Repo-attached mission
-  MISSION_HOME="$(git rev-parse --show-toplevel)/todo/missions"
+  MISSION_HOME="$top_level/todo/missions"
 else
   # Homeless mission (no repo yet)
   MISSION_HOME="$HOME/.aidevops/missions"
@@ -401,10 +401,11 @@ REPO_NAME="{sanitized mission desc or user input}"
 REPO_DIR="$HOME/Git/$REPO_NAME"
 
 mkdir -p "$REPO_DIR"
-git -C "$REPO_DIR" init
+git -C "$REPO_DIR" init -q
 
 # Move mission from homeless to repo-attached
-mv "$MISSION_DIR" "$REPO_DIR/todo/missions/$MISSION_ID"
+mkdir -p "$REPO_DIR/todo/missions" || { echo "ERROR: Failed to create $REPO_DIR/todo/missions" >&2; exit 1; }
+mv "$MISSION_DIR" "$REPO_DIR/todo/missions/$MISSION_ID" || { echo "ERROR: Failed to move mission to repo" >&2; exit 1; }
 MISSION_DIR="$REPO_DIR/todo/missions/$MISSION_ID"
 
 # Initialise aidevops in the new repo
@@ -418,11 +419,15 @@ If option 2, move the mission directory into the specified repo's `todo/missions
 In Full mode, create TODO.md entries and task briefs for each feature:
 
 ```bash
-for feature in features; do
+# Resolve repo path once before the loop
+repo_path=$(git rev-parse --show-toplevel)
+
+# Read features from mission state file (lines matching "- [ ] F<N>: <title>")
+while IFS= read -r feature_title; do
   # Claim task ID
   output=$(~/.aidevops/agents/scripts/claim-task-id.sh \
     --title "$feature_title" \
-    --repo-path "$(git rev-parse --show-toplevel)")
+    --repo-path "$repo_path")
 
   task_id=$(echo "$output" | grep '^TASK_ID=' | cut -d= -f2)
 
@@ -432,7 +437,7 @@ for feature in features; do
 
   # Add to TODO.md
   # Format: - [ ] {task_id} {feature_title} #mission:{mission_id} ~{est} ref:{ref}
-done
+done < <(awk '/^- \[ \] F[0-9]+:/{sub(/^- \[ \] F[0-9]+: /,""); print}' "$MISSION_DIR/mission.md")
 ```
 
 In POC mode, skip task creation. The mission orchestrator dispatches features directly from the mission state file without TODO.md entries.


### PR DESCRIPTION
## Summary

- Fixes all 5 unactioned review findings from PR #2508 (CodeRabbit + Gemini) on `.agents/scripts/commands/mission.md`
- Addresses 1 critical bug (mv fails on first run), 1 high bug (feature loop never iterates), and 3 medium efficiency improvements

## Changes

| Severity | Fix | Lines |
|----------|-----|-------|
| **CRITICAL** | Add `mkdir -p` before `mv` in repo bootstrap — destination parent directory was never created, causing first-run failure | ~407 |
| **HIGH** | Replace literal `for feature in features` (iterates the word "features") with `while IFS= read` that parses actual feature titles from mission state file via `awk` | ~421 |
| **MEDIUM** | Capture `git rev-parse --show-toplevel` output in the `if` condition to eliminate redundant second call | ~285 |
| **MEDIUM** | Add `-q` flag to `git init` for cleaner automated output | ~404 |
| **MEDIUM** | Hoist `git rev-parse --show-toplevel` out of the feature dispatch loop into a variable resolved once before iteration | ~425 |

Closes #3274