### PR TITLE
t3681: fix(supervisor): batch TODO duplicate deletions into one sed pass

### DIFF
--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -1605,11 +1605,15 @@ dedup_todo_task_ids() {
 		# Sort line numbers in descending order for safe deletion
 		local sorted_lines
 		sorted_lines=$(echo "$lines_to_delete" | tr ' ' '\n' | sort -rn | grep -v '^$')
+		local sed_expr=""
 
 		while IFS= read -r line_num; do
 			[[ -z "$line_num" ]] && continue
-			sed_inplace "${line_num}d" "$todo_file"
+			sed_expr+="${line_num}d;"
 		done <<<"$sorted_lines"
+
+		sed_expr="${sed_expr%;}"
+		sed_inplace "$sed_expr" "$todo_file"
 
 		log_success "Phase 0.5b: Removed $changes_made duplicate task line(s) from TODO.md"
 		commit_and_push_todo "$repo_path" "chore: remove $changes_made duplicate task line(s) from TODO.md (t1069)"


### PR DESCRIPTION
## Summary

Addresses medium review feedback from PR #1549 (Gemini + CodeRabbit).

The `dedup_todo_task_ids()` function in `todo-sync.sh` previously called `sed_inplace` once per duplicate line, rewriting the entire file N times. This consolidates all deletions into a single `sed` expression (e.g., `95d;87d;42d`) and applies it in one pass.

## Changes

- `.agents/scripts/supervisor-archived/todo-sync.sh`: Build `sed_expr` string in the existing loop (no file I/O per iteration), strip trailing `;`, then call `sed_inplace` once with the full expression.

## Verification

- ShellCheck: zero violations
- Logic: `sorted_lines` is already in descending order (from `sort -rn`), so the single-pass deletion is safe — higher line numbers are deleted first, keeping lower line numbers valid.
- Edge case: if `lines_to_delete` is empty the `if` guard prevents the `sed_inplace` call entirely (unchanged behaviour).

Closes #3681