### PR TITLE
t3668: simplify gh repo view URL in Phase 13 — remove unnecessary sed

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -3348,8 +3348,7 @@ cmd_pulse() {
 				local viewer_permission=""
 				if [[ -n "$skill_update_repo_root" ]] && command -v gh &>/dev/null; then
 					viewer_permission=$(gh repo view --json viewerPermission --jq '.viewerPermission' \
-						-R "$(git -C "$skill_update_repo_root" remote get-url origin 2>/dev/null |
-							sed 's|.*github\.com[:/]\([^/]*/[^/]*\)\.git|\1|; s|.*github\.com[:/]\([^/]*/[^/]*\)$|\1|')" \
+						-R "$(git -C "$skill_update_repo_root" remote get-url origin 2>/dev/null)" \
 						2>/dev/null || echo "")
 				fi
 				if [[ "$viewer_permission" == "ADMIN" || "$viewer_permission" == "WRITE" ]]; then


### PR DESCRIPTION
## Summary

- Removes the complex `sed` extraction used to parse `owner/repo` from a git remote URL in Phase 13 of `supervisor-archived/pulse.sh`
- The `gh` CLI accepts full remote URLs directly via `-R`, making the sed pipeline redundant
- Passing the raw `git remote get-url origin` output is more robust (handles SSH, HTTPS, `.git` suffix variants) and more readable

## Change

```diff
-  viewer_permission=$(gh repo view --json viewerPermission --jq '.viewerPermission' \
-    -R "$(git -C "$skill_update_repo_root" remote get-url origin 2>/dev/null |
-      sed 's|.*github\.com[:/]\([^/]*/[^/]*\)\.git|\1|; s|.*github\.com[:/]\([^/]*/[^/]*\)$|\1|')" \
-    2>/dev/null || echo "")
+  viewer_permission=$(gh repo view --json viewerPermission --jq '.viewerPermission' \
+    -R "$(git -C "$skill_update_repo_root" remote get-url origin 2>/dev/null)" \
+    2>/dev/null || echo "")
```

## Verification

Tested `gh repo view -R "https://github.com/marcusquinn/aidevops.git" --json viewerPermission --jq '.viewerPermission'` — returns `ADMIN` correctly with a full git URL.

Closes #3668