### PR TITLE
t3337: fix opencode haiku model ID to versioned form in model-availability-helper.sh

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -115,7 +115,7 @@ get_tier_models() {
 	if _is_opencode_available; then
 		case "$tier" in
 		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
-		haiku) echo "opencode/claude-haiku-4-5|opencode/gemini-3-flash" ;;
+		haiku) echo "opencode/claude-haiku-4-5-20251001|opencode/gemini-3-flash" ;;
 		flash) echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
 		sonnet) echo "opencode/claude-sonnet-4-6|anthropic/claude-sonnet-4-6" ;;
 		pro) echo "google/gemini-2.5-pro|opencode/gemini-3-pro" ;;


### PR DESCRIPTION
## Summary

- Updates `opencode/claude-haiku-4-5` → `opencode/claude-haiku-4-5-20251001` in `get_tier_models()` opencode branch (line 118)
- This was the only model ID missed during PR #2463's sweep — the `anthropic` provider haiku was correctly updated to `anthropic/claude-haiku-4-5-20251001` in the `else` branch, but the `opencode/` gateway prefix equivalent was left unversioned
- Prevents `ProviderModelNotFoundError` when routing haiku-tier tasks through OpenCode's gateway

## Root Cause

PR #2463 updated the `else` (non-opencode) branch haiku entry and the opencode branch `flash`/`sonnet`/`pro`/`health`/`eval` entries, but the opencode branch `haiku` line was not touched. Gemini code assist flagged this in the PR review at line 129 (now line 118 after subsequent commits).

## Verification

- ShellCheck: passes (only pre-existing SC1091 info on sourced file, unrelated to this change)
- Change is a 1-line string update with no logic impact

Closes #3337