### PR TITLE
t3678: limit GIT_EDITOR scope with trap RETURN in rebase_sibling_pr

### DIFF
--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -2398,7 +2398,10 @@ rebase_sibling_pr() {
 	# Prevent git rebase --continue from opening an editor (nano/vim) for
 	# commit messages — in cron/headless environments TERM is unset, causing
 	# "error: there was a problem with the editor 'nano'" and aborting the rebase.
+	# Limit scope to this function to avoid side effects on callers.
 	export GIT_EDITOR=true
+	# shellcheck disable=SC2064
+	trap "unset GIT_EDITOR" RETURN
 
 	# Fetch latest base branch
 	if ! git -C "$trepo" fetch origin "$rebase_target" 2>>"$SUPERVISOR_LOG"; then


### PR DESCRIPTION
## Summary

- Addresses medium-severity Gemini code review feedback from PR #1555
- `export GIT_EDITOR=true` in `rebase_sibling_pr()` was correct for headless rebase but leaked the variable into the caller's environment after the function returned
- Added `trap "unset GIT_EDITOR" RETURN` immediately after the export to clean up on any exit path (normal return, early `return 1`, etc.)

## Change

`.agents/scripts/supervisor-archived/deploy.sh` — `rebase_sibling_pr()` function:

```bash
export GIT_EDITOR=true
# shellcheck disable=SC2064
trap "unset GIT_EDITOR" RETURN
```

## Verification

- ShellCheck: zero violations
- Logic: `trap RETURN` fires on all function exit paths in bash, ensuring cleanup regardless of success/failure path

Closes #3678