### PR TITLE
t3262: Address gemini review feedback on headless-dispatch.md parallelism guidance

### DIFF
--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -900,14 +900,14 @@ Workers are injected with an efficiency protocol via the supervisor dispatch pro
 
    **When to parallelise** (use Task tool with multiple concurrent calls):
    - Reading/analyzing multiple independent files or directories
-   - Running independent quality checks (lint + typecheck + test)
+   - Running independent read-only quality checks (e.g., lint, typecheck, tests) — note: auto-fixing linters (e.g., `lint --fix`) are write operations and must be sequential if they modify the same files
    - Generating tests for separate modules that don't share state
    - Researching multiple parts of the codebase simultaneously
    - Creating independent documentation sections
    - Any two+ operations where neither depends on the other's output
 
    **When to stay sequential** (do NOT parallelise):
-   - Operations that modify the same files (merge conflicts)
+   - Operations that write to the same files, or where one task reads a file modified by another (avoids write-write, read-write, and write-read race conditions)
    - Steps where output of one feeds input of the next
    - Git operations (add → commit → push must be sequential)
    - Operations that depend on a shared resource (same DB table, same API endpoint)


### PR DESCRIPTION
## Summary

Addresses 2 critical findings from the Gemini reviewer on PR #2621 that were not actioned before merge.

## Changes

### `.agents/tools/ai-assistants/headless-dispatch.md`

**Finding 1 (line 577 in PR diff):** Clarified that parallelisable quality checks are **read-only** operations. Auto-fixing linters (e.g. `lint --fix`) are write operations and must run sequentially if they modify the same files — to avoid ambiguity for AI workers who might otherwise parallelise destructive linter runs.

**Finding 2 (line 584 in PR diff):** Replaced the narrow `(merge conflicts)` parenthetical with a precise description covering all file-based race conditions: write-write, read-write, and write-read. The original phrasing could be misread as only applying to `git merge` conflicts rather than any concurrent file modification hazard.

## Closes

Closes #3262

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified parallelization guidance for quality checks, distinguishing between read-only and write operations.
  * Expanded sequential operation criteria to address write-to-same-files and read-write race condition scenarios.
  * Added implementation guidance for executing parallel tasks using multiple tool calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->