### PR TITLE
t3250: fix 4 gemini review findings on matterbridge-simplex-compose.yml

### DIFF
--- a/.agents/configs/matterbridge-simplex-compose.yml
+++ b/.agents/configs/matterbridge-simplex-compose.yml
@@ -53,29 +53,33 @@ services:
       retries: 3
     depends_on:
       simplex:
-        condition: service_started
+        condition: service_healthy
 
   # matterbridge-simplex — Node.js adapter connecting SimpleX to Matterbridge API
   node-app:
     build:
-      context: https://github.com/UnkwUsr/matterbridge-simplex.git
+      # Pinned to a specific commit for reproducible builds and supply-chain safety.
+      # To update: replace the hash with the latest commit from
+      # https://github.com/UnkwUsr/matterbridge-simplex/commits/master
+      context: https://github.com/UnkwUsr/matterbridge-simplex.git#7caded8bb3bb56b91f81b84d27c1c3bc4a4b1835
       dockerfile: Dockerfile.node-app
     restart: unless-stopped
     network_mode: host
     # Format: <MB_API_ADDR> <MB_GATEWAY> <SXC_WS_ADDR> <CHAT_ID> <CHAT_TYPE>
     # CHAT_ID: get via simplex-chat -e '/i #group_name' or list command
     # CHAT_TYPE: "contact" or "group"
-    command: >-
-      127.0.0.1:4242
-      gateway1
-      127.0.0.1:5225
-      ${SIMPLEX_CHAT_ID:-1}
-      ${SIMPLEX_CHAT_TYPE:-group}
+    # Must be a YAML list — a scalar string would be passed to /bin/sh -c and fail.
+    command:
+      - "127.0.0.1:4242"
+      - "gateway1"
+      - "127.0.0.1:5225"
+      - "${SIMPLEX_CHAT_ID}"
+      - "${SIMPLEX_CHAT_TYPE}"
     environment:
-      - SIMPLEX_CHAT_ID=${SIMPLEX_CHAT_ID:-1}
-      - SIMPLEX_CHAT_TYPE=${SIMPLEX_CHAT_TYPE:-group}
+      SIMPLEX_CHAT_ID: ${SIMPLEX_CHAT_ID:-1}
+      SIMPLEX_CHAT_TYPE: ${SIMPLEX_CHAT_TYPE:-group}
     depends_on:
       simplex:
-        condition: service_started
+        condition: service_healthy
       matterbridge:
-        condition: service_started
+        condition: service_healthy


### PR DESCRIPTION
## Summary

Addresses all 4 unactioned review findings from PR #2290 (gemini-code-assist) on `.agents/configs/matterbridge-simplex-compose.yml`.

- **CRITICAL**: `node-app` command was a multi-line scalar (`>-`), causing Docker to pass it to `/bin/sh -c` — which fails because `127.0.0.1:4242` is not a shell command. Converted to a YAML list so args go directly to the entrypoint.
- **MEDIUM**: `matterbridge` `depends_on` `simplex` upgraded from `service_started` → `service_healthy` (simplex has a healthcheck defined).
- **MEDIUM**: `node-app` build context pinned to commit `7caded8b` instead of floating on `master` branch — reproducible builds, supply-chain safety.
- **MEDIUM**: `node-app` `depends_on` both `simplex` and `matterbridge` upgraded from `service_started` → `service_healthy`.

Also consolidates the `environment` block from list to map format (canonical YAML) and moves `SIMPLEX_CHAT_ID`/`SIMPLEX_CHAT_TYPE` defaults to `environment` only (single source of truth), with bare variable references in the `command` list.

Closes #3250