### PR TITLE
t3248: add missing executability check for simplex-helper.sh

### DIFF
--- a/.agents/scripts/tests/test-simplex-integration.sh
+++ b/.agents/scripts/tests/test-simplex-integration.sh
@@ -165,6 +165,13 @@ section_helper_script() {
 		print_result "helper script is valid bash" 1 "Syntax error in simplex-helper.sh"
 	fi
 
+	# Executable bit check (separate from syntax check)
+	if [[ -x "$HELPER" ]]; then
+		print_result "helper script is executable" 0
+	else
+		print_result "helper script is executable" 1 "simplex-helper.sh is not executable"
+	fi
+
 	# Help output
 	local help_output
 	help_output="$(bash "$HELPER" help 2>&1)" || true


### PR DESCRIPTION
## Summary

- Adds the missing `[[ -x "$HELPER" ]]` executability check as a separate `print_result` test in `section_helper_script()`
- The CodeRabbit CRITICAL finding on PR #2301 required splitting helper validation into two independent checks: syntax (`bash -n`) and executable bit (`[[ -x ]]`)
- The syntax check was fixed in the original PR; the executability check was not added as a separate test, leaving the CRITICAL finding partially unresolved

## Findings addressed

| Finding | Severity | Resolution |
|---------|----------|------------|
| Short-circuit `[[ -x ]] \|\| bash -n` skips syntax check on executable files | Critical | Syntax check fixed in PR #2301; **this PR adds the missing executability check** |
| `sc_output=... \|\| true` masks ShellCheck exit code (first occurrence) | Medium | Already fixed in PR #2301 |
| ShellCheck exit masking (second occurrence) | Medium | Already fixed in PR #2301 |
| Non-portable grep patterns (`\|` alternation, `\s` whitespace) | Medium | Already fixed in PR #2301 (all use `-E` flag and `[[:space:]]`) |

## Verification

- `shellcheck .agents/scripts/tests/test-simplex-integration.sh` — zero violations

Closes #3248