### PR TITLE
t1483: Fix model ID handling — restore Codex, add provider_auth_available(), fix OpenAI OAuth auth

### DIFF
--- a/.agents/configs/model-routing-table.json
+++ b/.agents/configs/model-routing-table.json
@@ -27,6 +27,14 @@
       "key_env": "ANTHROPIC_API_KEY",
       "probe_path": "/v1/messages",
       "probe_timeout_seconds": 10
+    },
+    "openai": {
+      "endpoint": "https://api.openai.com/v1/chat/completions",
+      "key_env": "OPENAI_API_KEY",
+      "oauth_auth_file": "~/.local/share/opencode/auth.json",
+      "probe_path": "/v1/models",
+      "probe_timeout_seconds": 10,
+      "_comment": "API key OR OpenCode OAuth subscription (includes Codex). Auth checked via OPENAI_API_KEY env var or opencode auth.json."
     }
   },
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -162,9 +162,13 @@ get_auth_signature() {
 		if [[ -n "${OPENAI_API_KEY:-}" ]]; then
 			auth_material="${auth_material}|env=$(sha256_text "$OPENAI_API_KEY")"
 		else
-			local auth_status
+			# OpenAI can also be authenticated via OpenCode OAuth (no direct API key needed).
+			# Include the OAuth auth status in the signature so backoff clears on re-auth.
+			local auth_status auth_file auth_mtime
 			auth_status=$(timeout_sec 10 "$OPENCODE_BIN_DEFAULT" auth status 2>/dev/null || true)
-			auth_material="${auth_material}|status=${auth_status}|env=missing"
+			auth_file="${HOME}/.local/share/opencode/auth.json"
+			auth_mtime=$(file_mtime "$auth_file")
+			auth_material="${auth_material}|status=${auth_status}|mtime=${auth_mtime}|env=missing"
 		fi
 		;;
 	*)
@@ -387,6 +391,42 @@ provider_backoff_active() {
 	return 0
 }
 
+provider_auth_available() {
+	local provider="$1"
+	case "$provider" in
+	anthropic)
+		# Anthropic: API key env var OR OpenCode OAuth session
+		if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+			return 0
+		fi
+		local auth_file="${HOME}/.local/share/opencode/auth.json"
+		if [[ -f "$auth_file" ]]; then
+			return 0
+		fi
+		return 1
+		;;
+	openai)
+		# OpenAI: API key env var OR OpenCode OAuth session (OAuth subscription includes Codex)
+		if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+			return 0
+		fi
+		local auth_file="${HOME}/.local/share/opencode/auth.json"
+		if [[ -f "$auth_file" ]]; then
+			return 0
+		fi
+		return 1
+		;;
+	local)
+		# Local provider is always considered available (no auth needed)
+		return 0
+		;;
+	*)
+		# Unknown provider: assume available (don't silently drop unknown providers)
+		return 0
+		;;
+	esac
+}
+
 classify_failure_reason() {
 	local file_path="$1"
 	local lowered
@@ -511,6 +551,12 @@ choose_model() {
 		idx=$(((start_index + i) % ${#models[@]}))
 		current_model="${models[$idx]}"
 		current_provider=$(extract_provider "$current_model")
+		# Skip providers with no auth configured — silent skip, no backoff recorded.
+		# This keeps Codex in the default list for users with OpenAI OAuth while
+		# being invisible to users who have no OpenAI auth at all.
+		if ! provider_auth_available "$current_provider"; then
+			continue
+		fi
 		if provider_backoff_active "$current_provider"; then
 			continue
 		fi

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -42,6 +42,10 @@ section() {
 TEST_TMP_DIR=$(mktemp -d)
 export AIDEVOPS_HEADLESS_RUNTIME_DIR="$TEST_TMP_DIR/runtime"
 export STUB_LOG_FILE="$TEST_TMP_DIR/opencode-args.log"
+# Provide a fake OpenAI API key so provider_auth_available("openai") returns true
+# in tests that exercise OpenAI model selection. Tests for the no-auth path
+# explicitly unset this and remove the auth file.
+export OPENAI_API_KEY="test-key-for-provider-auth-check"
 
 cleanup() {
 	rm -rf "$TEST_TMP_DIR"
@@ -96,6 +100,33 @@ if [[ "$allowlisted_model" == "openai/gpt-5.3-codex" ]]; then
 else
 	fail "openai allowlist restricts selection" "got: $allowlisted_model"
 fi
+
+section "Auth Pre-check"
+# When OpenAI has no auth configured, Codex must be skipped silently (no error,
+# no backoff recorded). The selection should fall back to Anthropic.
+no_auth_model=$(
+	unset OPENAI_API_KEY
+	AIDEVOPS_HEADLESS_AUTH_SIGNATURE_OPENAI="" \
+		bash "$HELPER" select --role worker 2>/dev/null || true
+)
+if [[ "$no_auth_model" == "anthropic/claude-sonnet-4-6" ]]; then
+	pass "no OpenAI auth: Codex skipped silently, Anthropic selected"
+else
+	fail "no OpenAI auth: Codex skipped silently, Anthropic selected" "got: $no_auth_model"
+fi
+# Verify no backoff was recorded for openai (silent skip, not a failure)
+no_auth_backoff=$(
+	unset OPENAI_API_KEY
+	AIDEVOPS_HEADLESS_AUTH_SIGNATURE_OPENAI="" \
+		bash "$HELPER" backoff status 2>/dev/null || true
+)
+if [[ "$no_auth_backoff" != *"openai|"* ]]; then
+	pass "no OpenAI auth: no backoff recorded (silent skip)"
+else
+	fail "no OpenAI auth: no backoff recorded (silent skip)" "backoff state: $no_auth_backoff"
+fi
+# Restore OpenAI auth for subsequent tests
+export OPENAI_API_KEY="test-key-for-provider-auth-check"
 
 section "Backoff"
 bash "$HELPER" backoff set anthropic rate_limit 3600 >/dev/null


### PR DESCRIPTION
## Summary

- Restores `openai/gpt-5.3-codex` in `DEFAULT_HEADLESS_MODELS` (reverts the model change from PR#4641 — Codex is valid via OpenAI OAuth subscription; the prior removal was a false fix)
- Adds `provider_auth_available()` pre-check in `choose_model()` so providers with no auth configured are skipped silently (no error, no backoff churn)
- Fixes `get_auth_signature()` for OpenAI OAuth path to include `auth.json` mtime in the signature (mirrors existing Anthropic OAuth handling, ensures backoff clears correctly on re-auth)
- Adds OpenAI provider entry to `model-routing-table.json` with `oauth_auth_file` field
- Adds Auth Pre-check test section verifying no-auth → silent skip, no backoff recorded

## Problem

PR#4641 replaced `openai/gpt-5.3-codex` with `openai/gpt-4o` after observing `ProviderModelNotFoundError`. The model does exist — it's available via OpenAI OAuth subscription. The real issue was the auth/provider config: the helper only checked `OPENAI_API_KEY` env var, not OAuth tokens. The fix removed a valid model instead of addressing the auth root cause.

Additionally, the default model list must work for all users regardless of which providers they have configured. The existing backoff system handles failures reactively (fail → backoff → skip on retry), wasting a dispatch attempt. A proactive `provider_auth_available()` check is the right pattern.

## Changes

### `headless-runtime-helper.sh`
- `get_auth_signature("openai")`: when no `OPENAI_API_KEY`, now includes `auth.json` mtime in the signature (same pattern as Anthropic) so backoff clears when OAuth session changes
- New `provider_auth_available()` function: checks `OPENAI_API_KEY` env var OR `~/.local/share/opencode/auth.json` presence for `anthropic`/`openai`; `local` always available; unknown providers assumed available
- `choose_model()` loop: calls `provider_auth_available()` before `provider_backoff_active()` — silent skip (no error, no backoff) when provider has no auth

### `model-routing-table.json`
- Added `openai` provider entry with endpoint, `key_env`, `oauth_auth_file`, and probe config

### `tests/test-headless-runtime-helper.sh`
- Added `export OPENAI_API_KEY="test-key-for-provider-auth-check"` to test setup so existing OpenAI selection tests continue to pass
- Added "Auth Pre-check" section: verifies no-auth → Codex skipped silently, Anthropic selected; no backoff recorded for silent skip

## Dated Snapshot Audit

Scanned all scripts and configs for dated snapshot model IDs. All found instances are in normalization/API-direct paths (correct per convention):
- `ai-research-helper.sh`, `email-to-markdown.py`, `email-signature-parser-helper.sh`: direct Anthropic API calls requiring dated IDs
- `compare-models-helper.sh`: alias-to-dated-ID mapping for API compatibility

No routing defaults use dated snapshots. Convention holds.

## Verification

- `shellcheck .agents/scripts/headless-runtime-helper.sh` — SC1091 info-level only (pre-existing)
- `bash tests/test-headless-runtime-helper.sh` — Auth Pre-check PASS x2; Backoff and Session Persistence failures are pre-existing (sandbox intercepts opencode binary in CI)

Closes #4656