### PR TITLE
fix(t3241): address critical/high review findings on matterbridge-helper.sh from PR #2396

### DIFF
--- a/.agents/scripts/matterbridge-helper.sh
+++ b/.agents/scripts/matterbridge-helper.sh
@@ -78,9 +78,17 @@ detect_os_arch() {
 
 is_running() {
 	if [ -f "$PID_FILE" ]; then
-		local pid
+		local pid kill_err
 		pid="$(cat "$PID_FILE")"
-		if kill -0 "$pid" 2>/dev/null; then
+		# Capture stderr to distinguish ESRCH (no such process) from EPERM (permission denied)
+		kill_err=$(kill -0 "$pid" 2>&1) && return 0
+		# ESRCH: process gone — normal case, not an error
+		if echo "$kill_err" | grep -qiE 'no such process|ESRCH'; then
+			return 1
+		fi
+		# EPERM or other: process exists but we can't signal it — treat as running
+		if [[ -n "$kill_err" ]]; then
+			log "WARNING: kill -0 $pid: $kill_err"
 			return 0
 		fi
 	fi


### PR DESCRIPTION
## Summary

Addresses the remaining unactioned review findings from PR #2396 on `.agents/scripts/matterbridge-helper.sh` (issue #3241).

## Findings status

| Severity | Reviewer | Finding | Status |
|----------|----------|---------|--------|
| CRITICAL | coderabbit | `timeout` not available on macOS — silent validation bypass | ✅ Already fixed (uses `timeout_sec` from `shared-constants.sh`) |
| HIGH | coderabbit | macOS ARM64 not handled — downloads Intel binary | ✅ Already fixed (`darwin-arm64` vs `darwin-64bit`) |
| HIGH | coderabbit | `--tail` shift count out of range under `set -euo pipefail` | ✅ Already fixed (conditional shift) |
| MEDIUM | coderabbit | Config validation runs `-version` not actual config parse | ✅ Already fixed (uses `timeout_sec` + TOML error detection) |
| MEDIUM | gemini | `get_latest_version` swallows curl errors with `2>/dev/null` | ✅ Already fixed (explicit `curl_status` check) |
| MEDIUM | gemini | `is_running` `kill -0 2>/dev/null` hides EPERM | **Fixed in this PR** |
| MEDIUM | gemini | `cmd_validate` blanket `>/dev/null 2>&1` suppression | ✅ Already fixed (binary check uses `-x` test, no suppression) |
| MEDIUM | gemini | `cmd_stop` `kill 2>/dev/null` hides errors | ✅ Already fixed (captures `kill_err` and logs) |
| MEDIUM | gemini | `cmd_stop` `kill -9 2>/dev/null` hides errors | ✅ Already fixed (pipes through `while read` logger) |
| MEDIUM | gemini | `cmd_start` daemon `2>&1` makes diagnosis hard | ✅ Intentional — daemon stdout+stderr both go to log file (standard pattern) |
| MEDIUM | gemini | `cmd_update` `2>&1` prevents error display | ✅ Already fixed (uses `version_err_file` to separate stderr) |

## Change

**`is_running` — distinguish EPERM from ESRCH in `kill -0` check** (`matterbridge-helper.sh:79-96`)

Previously `kill -0 "$pid" 2>/dev/null` silently swallowed all errors. If the process existed but was owned by another user (EPERM), the function would incorrectly return "not running", causing `cmd_stop` to skip the kill and `cmd_start` to launch a duplicate.

Now captures stderr and routes:
- `kill -0` succeeds → running (return 0)
- ESRCH (no such process) → not running (return 1) — expected normal case
- EPERM or other → logs warning, treats as running (return 0) — conservative, avoids duplicate starts

## Verification

- ShellCheck: zero violations (only SC1091 info for sourced file, expected)
- 1 file changed, max 5 files constraint satisfied

Closes #3241