### PR TITLE
t3243: fix simplex-bot package.json — pin @types/bun and typescript to semver ranges

### DIFF
--- a/.agents/scripts/simplex-bot/package.json
+++ b/.agents/scripts/simplex-bot/package.json
@@ -11,8 +11,8 @@
     "test": "bun test"
   },
   "devDependencies": {
-    "@types/bun": "1.3.9",
-    "typescript": "5.9.3"
+    "@types/bun": "^1.3.10",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "bun": ">=1.0.0"


### PR DESCRIPTION
## Summary

- Pin `@types/bun` from exact `1.3.9` to `^1.3.10` (latest) — semver range for reproducible builds
- Pin `typescript` from exact `5.9.3` to `^5.9.3` — consistent semver range pattern
- `simplex-chat` dependency was already removed in PR #2301 (commits 5d48fab–bcc5171)

## Findings addressed (PR #2301 review)

| Severity | Reviewer | Finding | Status |
|----------|----------|---------|--------|
| Critical | coderabbit | `@types/bun: "latest"` unpinned — use semver range | Fixed (was exact pin, now `^1.3.10`) |
| Medium | gemini | Same — pin for build stability | Fixed |
| Medium | coderabbit | Remove unused `simplex-chat` dep | Already fixed in PR #2301 |

## Verification

- `package.json` has no `simplex-chat` dependency
- `@types/bun` and `typescript` use `^` semver ranges
- No `simplex-chat` imports in source (only doc/string references to the CLI binary)

Closes #3243