### PR TITLE
t3254: fix incorrect script path in brief-template.md

### DIFF
--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -28,7 +28,7 @@ mode: subagent
 ## Acceptance Criteria
 
 Each criterion may include an optional `verify:` block (YAML in a fenced code block)
-that defines how to machine-check the criterion. See `scripts/verify-brief.sh` for the runner.
+that defines how to machine-check the criterion. See `.agents/scripts/verify-brief.sh` for the runner.
 
 - [ ] {Specific, testable criterion — e.g., "User can toggle sidebar with Cmd+B"}
   ```yaml


### PR DESCRIPTION
## Summary

- Corrects the `verify-brief.sh` path reference on line 31 of `.agents/templates/brief-template.md` from `scripts/verify-brief.sh` to `.agents/scripts/verify-brief.sh`
- The script exists at `.agents/scripts/verify-brief.sh` — the old path would cause agents and humans to fail to locate the runner
- The comment block at line 78 already had the correct path; this aligns the prose description above it

## Finding

**Source**: CodeRabbit review on PR #2187 (merged 2026-02-23)
**Severity**: High (incorrect path reference breaks discoverability)

Closes #3254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated verification configuration to correct the execution path for quality assurance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->