### PR TITLE
fix(t3252): hard-fail when --verify brief file is missing

### DIFF
--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -301,7 +301,9 @@ main() {
 	if [[ "$VERIFY_BRIEF" == "true" ]]; then
 		local brief_file="${REPO_PATH}/todo/tasks/${TASK_ID}-brief.md"
 		if [[ ! -f "$brief_file" ]]; then
-			log_warn "Brief file not found: $brief_file — skipping verification"
+			log_error "Brief file not found: $brief_file — cannot verify"
+			log_info "Remove --verify flag if this task has no brief"
+			return 1
 		else
 			local verify_script="${SCRIPT_DIR}/verify-brief.sh"
 			if [[ ! -x "$verify_script" ]]; then


### PR DESCRIPTION
## Summary

- Fixes the high-severity CodeRabbit finding from PR #2187: when `--verify` is passed but the brief file doesn't exist, the script previously logged a warning and silently continued to mark the task complete — defeating the purpose of the verification gate.
- Changed `log_warn` + continue to `log_error` + `return 1`, matching the behaviour of the `verify-brief.sh` failure path immediately below it.
- Added a clear hint message: `Remove --verify flag if this task has no brief`.
- Finding 1 (`--pr`/`--repo-path` `$2` guarding) was already addressed in the current code via `${2:-}` guards with explicit empty-value checks — no change needed.

## Changes

- `.agents/scripts/task-complete-helper.sh`: 3-line change in `main()` — warn-and-continue → hard error when `VERIFY_BRIEF=true` and brief file is absent.

## Verification

- `shellcheck` passes (zero violations; SC1091 info note is pre-existing and expected for sourced files).
- Behaviour: `task-complete-helper.sh t123 --verify` with no brief file now exits 1 with a clear error instead of silently completing the task.

Closes #3252