### PR TITLE
t3252: enforce --verify brief gate in task-complete-helper

### DIFF
--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -301,7 +301,9 @@ main() {
 	if [[ "$VERIFY_BRIEF" == "true" ]]; then
 		local brief_file="${REPO_PATH}/todo/tasks/${TASK_ID}-brief.md"
 		if [[ ! -f "$brief_file" ]]; then
-			log_warn "Brief file not found: $brief_file — skipping verification"
+			log_error "Brief file not found: $brief_file — cannot verify"
+			log_info "Remove --verify flag if this task has no brief"
+			return 1
 		else
 			local verify_script="${SCRIPT_DIR}/verify-brief.sh"
 			if [[ ! -x "$verify_script" ]]; then


### PR DESCRIPTION
## Summary
- make `task-complete-helper.sh` fail fast when `--verify` is requested and the brief file is missing
- preserve existing verification flow while preventing accidental task completion when the verification precondition is unmet
- verify behavior with syntax check and runtime gate test for missing brief handling

## Testing
- `bash -n .agents/scripts/task-complete-helper.sh`
- `.agents/scripts/task-complete-helper.sh t999999 --verified 2026-03-14 --verify --no-push` (expects exit code 1)

Closes #3252