### PR TITLE
t3245: fix(simplex-bot): use contactId/groupId for welcome messages

### DIFF
--- a/.agents/scripts/simplex-bot/src/handlers/contact.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/contact.ts
@@ -71,12 +71,18 @@ export async function handleContactConnected(
   // Create or update session
   deps.sessions.getContactSession(contactId, name);
 
-  // Send welcome message if configured
+  // Send welcome message if configured.
+  // Use contactId (not localDisplayName) as the target — display names may
+  // contain spaces or special characters that break the CLI command format.
   if (deps.config.autoAcceptContacts && deps.config.welcomeMessage) {
-    try {
-      await deps.sendCommand(`@${name} ${deps.config.welcomeMessage}`);
-    } catch (err) {
-      deps.logger.error(`Failed to send welcome message to ${name}:`, err);
+    if (contactId !== undefined) {
+      try {
+        await deps.sendCommand(`@${contactId} ${deps.config.welcomeMessage}`);
+      } catch (err) {
+        deps.logger.error(`Failed to send welcome message to ${name} (id: ${contactId}):`, err);
+      }
+    } else {
+      deps.logger.warn(`Cannot send welcome message to ${name}: contactId missing`);
     }
   }
 }
@@ -148,13 +154,15 @@ export async function handleBusinessRequest(
   const session = deps.sessions.getGroupSession(groupId, name);
   deps.sessions.updateMetadata(session.id, { businessChat: true });
 
-  // Send welcome message to the business group
+  // Send welcome message to the business group.
+  // Use groupId as the target — group display names may contain spaces that
+  // break the CLI command format.
   if (deps.config.welcomeMessage) {
     try {
-      await deps.sendCommand(`#${name} ${deps.config.welcomeMessage}`);
+      await deps.sendCommand(`#${groupId} ${deps.config.welcomeMessage}`);
     } catch (err) {
       deps.logger.error(
-        `Failed to send welcome to business group ${name}:`,
+        `Failed to send welcome to business group ${name} (id: ${groupId}):`,
         err,
       );
     }


### PR DESCRIPTION
## Summary

- Fix `handleContactConnected`: welcome message target changed from `@${localDisplayName}` to `@${contactId}` — display names may contain spaces that break the SimpleX CLI command format
- Fix `handleBusinessRequest`: welcome message target changed from `#${name}` to `#${groupId}` for the same reason
- Add explicit guard for missing `contactId` with a warn log instead of silently skipping

## Findings addressed

All 12 findings from issue #3245 (PR #2301 review feedback) are now resolved:

| Finding | Severity | Status |
|---------|----------|--------|
| `handleContactConnected` uses `localDisplayName` for welcome target | HIGH (Gemini, augment) | **Fixed in this PR** |
| `onerror` suppresses reconnect for all errors | HIGH (coderabbit) | Already fixed in PR #2375 (`!hasConnected` guard) |
| `connect()` promise can hang on reconnect | HIGH (augment) | Already fixed in PR #2375 (`settled` flag + `onclose` reject) |
| Missing `await` on `executeCommand` | HIGH (coderabbit) | Already fixed in PR #2375 |
| Floating promise on `sendMessage` welcome | HIGH (coderabbit) | Already fixed in PR #2375 (try/catch) |
| Message content logged at INFO level | HIGH (coderabbit) | Already fixed in PR #2375 (`logger.debug`) |
| `handleNewChatItems` executes without checking `dmEnabled`/`groupEnabled` | HIGH (augment) | Already fixed in PR #2375 (`checkCommandPermission`) |
| `CommandContext` missing `contact`/`group` fields | MEDIUM (coderabbit) | Already fixed in PR #2375 |
| DM reply uses `@${contactId}` (numeric) | MEDIUM (coderabbit) | Already fixed in PR #2375 (cached display names) |
| `handleNewChatItems` invoked without `.catch()` | MEDIUM (augment) | Already fixed in PR #2375 |
| `ws.onclose` always calls `scheduleReconnect()` | MEDIUM (augment) | Already fixed in PR #2375 (`intentionalDisconnect` flag) |
| `handleContactConnected` welcome may target wrong contact | MEDIUM (augment) | **Fixed in this PR** |

## Verification

- `bun test`: 84/84 pass
- Integration tests: 59/59 pass
- `tsc --noEmit`: no new errors (pre-existing environment-level type errors unchanged)

Closes #3245