### PR TITLE
t3229: fix zvec.md review findings from PR #2685 (coderabbit + gemini)

### DIFF
--- a/.agents/tools/database/vector-search/zvec.md
+++ b/.agents/tools/database/vector-search/zvec.md
@@ -286,7 +286,7 @@ Zvec ships with embedding functions that run locally or call APIs. No separate e
 | Function | Provider | Dimensions | Env var |
 |----------|----------|------------|---------|
 | `OpenAIDenseEmbedding` | OpenAI | 1536 (default) | `OPENAI_API_KEY` |
-| `JinaDenseEmbedding` | Jina AI | 768 (nano) / 1024 (small) | `JINA_API_KEY` |
+| `JinaDenseEmbedding` | Jina AI | 768 (v2-base) / 1024 (v5-small) | `JINA_API_KEY` |
 | `QwenDenseEmbedding` | Alibaba Qwen | varies | `DASHSCOPE_API_KEY` |
 | `QwenSparseEmbedding` | Alibaba Qwen | sparse | `DASHSCOPE_API_KEY` |
 
@@ -764,7 +764,8 @@ collection.insert([
 
 // Query (synchronous -- Node.js bindings use querySync)
 const results = collection.querySync({
-  vectors: new zvec.VectorQuery({ fieldName: "embedding", vector: [0.1, 0.2, 0.3, ...] }),
+  fieldName: "embedding",
+  vector: [0.1, 0.2, 0.3, ...],
   topk: 10,
 });
 


### PR DESCRIPTION
## Summary

Addresses the remaining open review findings on `.agents/tools/database/vector-search/zvec.md` flagged in PR #2685.

### Findings fixed

| Severity | Reviewer | Finding | Fix |
|----------|----------|---------|-----|
| Medium | gemini | `JinaDenseEmbedding` table listed `768 (nano) / 1024 (small)` — Jina has no "nano" model | Updated to `768 (v2-base) / 1024 (v5-small)` |
| Major | coderabbit | Node.js query example used `new zvec.VectorQuery({fieldName, vector})` wrapper inside `querySync` — `@zvec/zvec` expects a plain `ZVecQuery`-style object | Replaced with `collection.querySync({ fieldName, vector, topk })` |

### Already-fixed findings (verified, no change needed)

- `QwenDenseEmbedding` positional arg order — `256` already first positional arg (L347-351) ✓
- `pip install zvec==v0.1.1` → `pip install zvec==0.1.1` — already correct (L861) ✓
- OpenAI table entry — no `text-embedding-4` reference present; code example already uses `text-embedding-3-small` ✓

Closes #3229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Jina Dense Embedding API documentation with revised model dimension specifications.
  * Simplified Node.js vector query construction example for improved clarity and ease of implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->