### PR TITLE
t3617: generalize OmO disabled-tools log guidance

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -730,7 +730,7 @@ omo_tool_patterns = ['grep_app_*', 'websearch_*', 'gh_grep_*']
 for tool_pattern in omo_tool_patterns:
     if config['tools'].get(tool_pattern) is not False:
         config['tools'][tool_pattern] = False
-        print(f"  Disabled {tool_pattern} tools globally (use @github-search subagent)")
+        print(f"  Disabled {tool_pattern} tools globally (use matching subagent/CLI workflow)")
 
 if config_loaded:
     with open(config_path, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
## Summary
- Generalizes the Oh-My-OpenCode disabled-tool log message so it no longer points only to `@github-search` when other tool patterns are being disabled.
- Keeps behavior unchanged while improving operator guidance clarity in setup output.

## Verification
- `shellcheck .agents/scripts/generate-opencode-agents.sh` (SC1091 info-only existing include warning)
- `bash -n .agents/scripts/generate-opencode-agents.sh`

Closes #3617