### PR TITLE
t3632: address quality-debt review findings

### DIFF
--- a/.agents/scripts/supervisor-archived/cron.sh
+++ b/.agents/scripts/supervisor-archived/cron.sh
@@ -602,10 +602,8 @@ cmd_auto_pickup() {
 				continue
 			fi
 
-			# Skip tasks with assignee: or started: metadata fields (t1062, t1263)
-			# Match actual metadata fields, not description text containing these words.
-			# assignee: must be followed by a username (word chars), started: by ISO timestamp.
-			if [[ "$line" =~ (assignee:[a-zA-Z0-9_-]+|started:[0-9]{4}-[0-9]{2}-[0-9]{2}T) ]]; then
+			# Skip tasks already claimed or being worked on interactively (t1062, t1263).
+			if [[ "$line" =~ [[:space:]](assignee|started): ]]; then
 				log_info "  $task_id: already claimed or in progress — skipping auto-pickup"
 				continue
 			fi
@@ -654,14 +652,6 @@ cmd_auto_pickup() {
 				continue
 			fi
 
-			# Skip tasks already claimed or being worked on interactively (t1062).
-			# assignee: means someone claimed it; started: means work has begun.
-			# Without this check, the supervisor races with interactive sessions.
-			if [[ "$line" =~ [[:space:]](assignee|started): ]]; then
-				log_info "  $task_id: already claimed/started — skipping auto-pickup"
-				continue
-			fi
-
 			# Add to supervisor
 			if cmd_add "$task_id" --repo "$repo"; then
 				picked_up=$((picked_up + 1))
@@ -703,10 +693,8 @@ cmd_auto_pickup() {
 				continue
 			fi
 
-			# Skip tasks with assignee: or started: metadata fields (t1062, t1263)
-			# Match actual metadata fields, not description text containing these words.
-			# assignee: must be followed by a username (word chars), started: by ISO timestamp.
-			if [[ "$line" =~ (assignee:[a-zA-Z0-9_-]+|started:[0-9]{4}-[0-9]{2}-[0-9]{2}T) ]]; then
+			# Skip tasks already claimed or being worked on interactively (t1062, t1263).
+			if [[ "$line" =~ [[:space:]](assignee|started): ]]; then
 				log_info "  $task_id: already claimed or in progress — skipping auto-pickup"
 				continue
 			fi
@@ -747,12 +735,6 @@ cmd_auto_pickup() {
 			# Pre-pickup check: skip tasks with merged PRs (t224).
 			if check_task_already_done "$task_id" "$repo"; then
 				log_info "  $task_id: already completed (merged PR) — skipping auto-pickup"
-				continue
-			fi
-
-			# Skip tasks already claimed or being worked on interactively (t1062).
-			if [[ "$line" =~ [[:space:]](assignee|started): ]]; then
-				log_info "  $task_id: already claimed/started — skipping auto-pickup"
 				continue
 			fi
 


### PR DESCRIPTION
## What changed
- Simplified auto-pickup claimed-task detection in `cmd_auto_pickup()` by using Bash regex once per strategy (`tagged_tasks` and `Dispatch Queue`) instead of duplicated checks.
- Removed redundant second-pass claimed/started checks that were re-evaluating the same task line before `cmd_add`.

## Why
- Addresses issue #3632 quality-debt from PR #1519 review by keeping the built-in regex approach and reducing duplicate logic/per-task checks.

## Verification
- `shellcheck .agents/scripts/supervisor-archived/cron.sh`
- `bash tests/test-supervisor-state-machine.sh`

Closes #3632