### PR TITLE
t3621: harden triage PR URL parsing for URL suffixes

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -3836,7 +3836,7 @@ cmd_triage() {
 
 		# Extract PR number and repo slug from URL
 		local pr_num="" triage_repo_slug=""
-		if [[ "$tpr" =~ github\.com/([^/]+/[^/]+)/pull/([0-9]+)$ ]]; then
+		if [[ "$tpr" =~ github\.com/([^/]+/[^/]+)/pull/([0-9]+)(/)?([?#].*)?$ ]]; then
 			triage_repo_slug="${BASH_REMATCH[1]}"
 			pr_num="${BASH_REMATCH[2]}"
 		fi


### PR DESCRIPTION
## Summary
- Expand triage PR URL parsing to accept optional trailing `/` and URL query/fragment suffixes.
- Prevent false `unparseable` classification for valid GitHub PR URLs that include suffixes.
- Keep existing owner/repo and PR-number extraction behavior unchanged.

## Verification
- `bash -n .agents/scripts/supervisor-archived/pulse.sh`
- `bash tests/test-supervisor-state-machine.sh > /tmp/t3621-state-machine.log 2>&1`

Closes #3621