### PR TITLE
t3606: surface shell secret findings as ERROR-level alerts

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1067,6 +1067,16 @@ async function toolExecuteBefore(input, output) {
   if (filePath.endsWith(".sh")) {
     const result = runShellQualityPipeline(filePath);
     logQualityGateResult("Quality gate", filePath, result.totalViolations, result.report);
+    const secretResult = scanForSecrets(filePath);
+    if (secretResult.violations > 0) {
+      logQualityGateResult(
+        "SECURITY",
+        filePath,
+        secretResult.violations,
+        secretResult.details.join("\n"),
+        "ERROR",
+      );
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- Ensure shell-file edits still emit visible security alerts when secrets are detected.
- Keep existing shell quality checks intact while adding dedicated ERROR-level SECURITY logging for secret matches.

## Testing
- `node --check .agents/plugins/opencode-aidevops/index.mjs`
- `bun test` *(fails locally: `bun: command not found`)*

Closes #3606