### PR TITLE
t3615: filter non-actionable praise-only quality-debt findings

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -579,6 +579,7 @@ cmd_scan_merged() {
 
 	# Parse flags
 	while [[ $# -gt 0 ]]; do
+		local flag="$1"
 		case "$1" in
 		--repo)
 			repo_slug="${2:-}"
@@ -613,7 +614,7 @@ cmd_scan_merged() {
 			shift
 			;;
 		*)
-			echo "Unknown option for scan-merged: $1" >&2
+			echo "Unknown option for scan-merged: ${flag}" >&2
 			return 1
 			;;
 		esac
@@ -993,6 +994,11 @@ _scan_single_pr() {
 			"\\bno (further |more )?(comments?|issues?|concerns?|feedback)\\b|" +
 			"\\beverything (looks?|seems?) (good|fine|correct|great|solid|clean)\\b"; "i")) as $no_actionable_sentiment |
 
+		($body | test(
+			"\\bsuccessfully addresses?\\b|\\beffectively\\b|\\bimproves?\\b|\\benhances?\\b|" +
+			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
+			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
+
 		# Filter out review-body summaries that do not contain concrete fixes.
 		# Bots frequently post high-level walkthroughs that mention suggestions
 		# but do not include actionable details tied to a file/line.
@@ -1009,8 +1015,9 @@ _scan_single_pr() {
 		# Skip purely approving reviews: no actionable critique AND body matches
 		# approval-only patterns. This catches "LGTM", "good work", "no further
 		# comments", and "no further recommendations" (even in long summary
-		# reviews) regardless of reviewer type or review state.
-		select((($approval_only or $no_actionable_recommendation or $no_actionable_sentiment) and ($actionable | not)) | not) |
+		# reviews), plus non-actionable praise-only summaries, regardless of
+		# reviewer type or review state.
+		select((($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not)) | not) |
 
 		(if $reviewer == "human" then
 			true
@@ -1533,14 +1540,17 @@ main() {
 
 	# scan-merged handles its own flags — pass remaining args through
 	if [[ "$command" == "scan-merged" ]]; then
-		cmd_scan_merged "$@"
-		return $?
+		if cmd_scan_merged "$@"; then
+			return 0
+		fi
+		return 1
 	fi
 
 	local pr_number=""
 	local commit_sha=""
 
 	while [[ $# -gt 0 ]]; do
+		local flag="$1"
 		case "$1" in
 		--pr)
 			pr_number="${2:-}"
@@ -1555,7 +1565,7 @@ main() {
 			exit 0
 			;;
 		*)
-			echo "Unknown option: $1" >&2
+			echo "Unknown option: ${flag}" >&2
 			show_help
 			exit 1
 			;;

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -76,12 +76,13 @@ _mock_gh_api() {
 	local endpoint=""
 
 	while [[ $# -gt 0 ]]; do
+		local token="$1"
 		case "$1" in
 		-H | --jq)
 			shift 2
 			;;
 		repos/*)
-			endpoint="$1"
+			endpoint="$token"
 			shift
 			;;
 		*)
@@ -465,6 +466,11 @@ _test_approval_filter() {
 			"\\beverything (looks?|seems?) (good|fine|correct|great|solid|clean)\\b"; "i")) as $no_actionable_sentiment |
 
 		($body | test(
+			"\\bsuccessfully addresses?\\b|\\beffectively\\b|\\bimproves?\\b|\\benhances?\\b|" +
+			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
+			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
+
+		($body | test(
 			"\\bshould\\b|\\bconsider\\b|\\binstead\\b|\\bsuggest|\\brecommend(ed|ing)?\\b|" +
 			"\\bwarning\\b|\\bcaution\\b|\\bavoid\\b|\\b(don ?'"'"'?t|do not)\\b|" +
 			"\\bvulnerab|\\binsecure|\\binjection\\b|\\bxss\\b|\\bcsrf\\b|" +
@@ -474,8 +480,8 @@ _test_approval_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $actionable |
 
-		# skip = approval-only/no-recommendation AND NOT actionable
-		if (($approval_only or $no_actionable_recommendation or $no_actionable_sentiment) and ($actionable | not)) then "skip"
+		# skip = approval-only/no-recommendation/summary-praise AND NOT actionable
+		if (($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not)) then "skip"
 		else "keep"
 		end
 	')
@@ -545,6 +551,17 @@ test_skips_no_further_recommendations_review() {
 		print_result "skip 'no further recommendations' review" 0
 	else
 		print_result "skip 'no further recommendations' review" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
+test_skips_gemini_style_positive_summary_review() {
+	local result
+	result=$(_test_approval_filter "This pull request successfully addresses the issue by removing an external dependency and improves robustness. The addition of no-data messaging enhances user experience.")
+	if [[ "$result" == "skip" ]]; then
+		print_result "skip Gemini-style positive summary review" 0
+	else
+		print_result "skip Gemini-style positive summary review" 1 "expected skip, got ${result}"
 	fi
 	return 0
 }
@@ -622,6 +639,7 @@ main() {
 	test_skips_good_work_review
 	test_skips_no_issues_review
 	test_skips_no_further_recommendations_review
+	test_skips_gemini_style_positive_summary_review
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary
- extend `quality-feedback-helper.sh` review-body filtering to skip praise-only summary comments (including Gemini-style "successfully addresses/improves/enhances" text) when no actionable cues are present
- keep actionable reviews unaffected by preserving the existing actionable-signal check path
- add regression coverage in `test-quality-feedback-main-verification.sh` for Gemini-style positive summary reviews and align parser code with shell quality rules

## Testing
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `aidevops_quality_check file=.agents/scripts/quality-feedback-helper.sh`
- `aidevops_quality_check file=.agents/scripts/tests/test-quality-feedback-main-verification.sh`

Closes #3615