### PR TITLE
t3602: fix runner-helper pipeline exit code handling

### DIFF
--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -686,11 +686,8 @@ $full_prompt"
 	local start_time
 	start_time=$(date +%s)
 
-	if timeout_sec "$cmd_timeout" "${cmd_args[@]}" 2>&1 | tee "$log_file"; then
-		exit_code=0
-	else
-		exit_code=$?
-	fi
+	timeout_sec "$cmd_timeout" "${cmd_args[@]}" 2>&1 | tee "$log_file"
+	exit_code=${PIPESTATUS[0]}
 
 	local end_time duration
 	end_time=$(date +%s)


### PR DESCRIPTION
## Summary
- update `runner-helper.sh` to capture the executed command's exit code from the timeout/logging pipeline using `PIPESTATUS[0]`
- remove duplicated success/failure branching around `timeout_sec ... | tee`, keeping behavior the same while making status handling robust
- addresses Gemini review feedback from PR #349

Closes #3602

## Testing
- `bash -n .agents/scripts/runner-helper.sh`