### PR TITLE
t3609: Address quality-debt review findings

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -991,6 +991,9 @@ _scan_single_pr() {
 		($body | test(
 			"\\blgtm\\b|\\blooks good( to me)?\\b|\\bgood work\\b|" +
 			"\\bno (further |more )?(comments?|issues?|concerns?|feedback)\\b|" +
+			"\\bfound no (issues?|problems?|concerns?)\\b|" +
+			"\\bno (issues?|problems?|concerns?) (found|detected)\\b|" +
+			"\\b(found|detected) nothing (to )?(fix|change|address)\\b|" +
 			"\\beverything (looks?|seems?) (good|fine|correct|great|solid|clean)\\b"; "i")) as $no_actionable_sentiment |
 
 		# Filter out review-body summaries that do not contain concrete fixes.

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -538,6 +538,17 @@ test_skips_no_issues_review() {
 	return 0
 }
 
+test_skips_found_no_issues_long_review() {
+	local result
+	result=$(_test_approval_filter "This pull request enhances the AI supervisor's reasoning capabilities by introducing self-improvement and efficiency analysis. It adds two new action types, create_improvement and escalate_model, along with corresponding analysis frameworks and examples in the system prompt. The updates to the prompt are clear and consistent with the stated goals. I've reviewed the changes and found no issues. The new capabilities are a strong step toward a more intelligent supervisor.")
+	if [[ "$result" == "skip" ]]; then
+		print_result "skip long summary review with 'found no issues'" 0
+	else
+		print_result "skip long summary review with 'found no issues'" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
 test_skips_no_further_recommendations_review() {
 	local result
 	result=$(_test_approval_filter "The pull request is well-documented and the fixes are implemented correctly. I have no further recommendations.")
@@ -621,6 +632,7 @@ main() {
 	test_skips_looks_good_review
 	test_skips_good_work_review
 	test_skips_no_issues_review
+	test_skips_found_no_issues_long_review
 	test_skips_no_further_recommendations_review
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review


### PR DESCRIPTION
## Goal
Prevent non-actionable positive review summaries from generating quality-debt issues.

## Changes
- Expand no-actionable sentiment detection in `quality-feedback-helper.sh` to catch long-form review text that says no issues were found.
- Add regression coverage for a long Gemini-style summary review containing "found no issues".

## Verification
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `shellcheck .agents/scripts/quality-feedback-helper.sh`
- `shellcheck .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `bash .agents/scripts/linters-local.sh` (fails due to pre-existing repo-wide baseline issues unrelated to this change)

Closes #3609