### PR TITLE
t3611: make onboarding command path configurable

### DIFF
--- a/.agents/scripts/generate-claude-agents.sh
+++ b/.agents/scripts/generate-claude-agents.sh
@@ -304,7 +304,7 @@ Show In Progress tasks, top 5 Backlog, and Active Plans with progress.'
 # --- Onboarding ---
 write_command "onboarding" \
 	"Interactive onboarding wizard - discover services, configure integrations" \
-	'Read ~/.aidevops/agents/aidevops/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions — go straight to the Welcome Flow conversation.
+	'Read ${AIDEVOPS_HOME:-$HOME/.aidevops}/agents/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions — go straight to the Welcome Flow conversation.
 
 Arguments: $ARGUMENTS'
 

--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -702,7 +702,7 @@ fi
 if should_generate "onboarding"; then
 	write_command "onboarding" \
 		"Interactive onboarding wizard - discover services, configure integrations" \
-		'Read ~/.aidevops/agents/aidevops/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions — go straight to the Welcome Flow conversation.
+		'Read ${AIDEVOPS_HOME:-$HOME/.aidevops}/agents/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions — go straight to the Welcome Flow conversation.
 
 Arguments: $ARGUMENTS'
 fi

--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -936,7 +936,7 @@ BODY
 create_command "onboarding" \
 	"Interactive onboarding wizard - discover services, configure integrations" \
 	"" "" <<'BODY'
-Read ~/.aidevops/agents/aidevops/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions -- go straight to the Welcome Flow conversation.
+Read ${AIDEVOPS_HOME:-$HOME/.aidevops}/agents/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions -- go straight to the Welcome Flow conversation.
 
 Arguments: $ARGUMENTS
 BODY


### PR DESCRIPTION
## Summary
- Replace hardcoded onboarding path references with `${AIDEVOPS_HOME:-$HOME/.aidevops}` fallback in all command generator scripts.
- Keep onboarding command behavior unchanged while allowing installations that store agent files outside `~/.aidevops`.
- Apply the same path logic consistently across OpenCode and Claude command generators.

## Testing
- `shellcheck -e SC1091 .agents/scripts/generate-opencode-commands.sh .agents/scripts/generate-claude-commands.sh .agents/scripts/generate-claude-agents.sh`
- Verified no remaining `~/.aidevops/agents/aidevops/onboarding.md` references in `generate-*.sh`.

Closes #3611