### PR TITLE
t3612: filter non-actionable 'no suggestions' review summaries

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
 # quality-feedback-helper.sh - Retrieve code quality feedback via GitHub API
 # Consolidates feedback from Codacy, CodeRabbit, SonarCloud, CodeFactor, etc.
 #
@@ -24,6 +25,7 @@
 #   quality-feedback-helper.sh scan-merged --repo owner/repo --batch 20 --create-issues
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=./shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
@@ -990,6 +992,11 @@ _scan_single_pr() {
 			"\\bnothing (further|more) to recommend\\b"; "i")) as $no_actionable_recommendation |
 
 		($body | test(
+			"\\bno suggestions? (at this time|for now|currently)?\\b|" +
+			"\\bwithout suggestions?\\b|" +
+			"\\bhas no suggestions?\\b"; "i")) as $no_actionable_suggestion |
+
+		($body | test(
 			"\\blgtm\\b|\\blooks good( to me)?\\b|\\bgood work\\b|" +
 			"\\bno (further |more )?(comments?|issues?|concerns?|feedback)\\b|" +
 			"\\bfound no (issues?|problems?|concerns?)\\b|" +
@@ -1015,12 +1022,12 @@ _scan_single_pr() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $actionable |
 
-		# Skip purely approving reviews: no actionable critique AND body matches
-		# approval-only patterns. This catches "LGTM", "good work", "no further
-		# comments", and "no further recommendations" (even in long summary
-		# reviews), plus non-actionable praise-only summaries, regardless of
-		# reviewer type or review state.
-		select((($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not)) | not) |
+		# Skip purely approving reviews. Explicit "no suggestions" statements are
+		# always non-actionable and should be skipped even though they contain the
+		# token "suggest", which would otherwise trip the actionable heuristic.
+		# Other approval/sentiment patterns are skipped only when no actionable
+		# critique appears in the body.
+		select(($no_actionable_suggestion or ((($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not))) ) | not) |
 
 		(if $reviewer == "human" then
 			true

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -461,6 +461,11 @@ _test_approval_filter() {
 			"\\bnothing (further|more) to recommend\\b"; "i")) as $no_actionable_recommendation |
 
 		($body | test(
+			"\\bno suggestions? (at this time|for now|currently)?\\b|" +
+			"\\bwithout suggestions?\\b|" +
+			"\\bhas no suggestions?\\b"; "i")) as $no_actionable_suggestion |
+
+		($body | test(
 			"\\blgtm\\b|\\blooks good( to me)?\\b|\\bgood work\\b|" +
 			"\\bno (further |more )?(comments?|issues?|concerns?|feedback)\\b|" +
 			"\\beverything (looks?|seems?) (good|fine|correct|great|solid|clean)\\b"; "i")) as $no_actionable_sentiment |
@@ -480,8 +485,8 @@ _test_approval_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $actionable |
 
-		# skip = approval-only/no-recommendation/summary-praise AND NOT actionable
-		if (($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not)) then "skip"
+		# skip = explicit no-suggestions OR approval-only/no-recommendation/summary-praise with no actionable critique
+		if ($no_actionable_suggestion or (($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not))) then "skip"
 		else "keep"
 		end
 	')
@@ -577,6 +582,17 @@ test_skips_gemini_style_positive_summary_review() {
 	return 0
 }
 
+test_skips_no_suggestions_at_this_time_review() {
+	local result
+	result=$(_test_approval_filter "Review completed. No suggestions at this time.")
+	if [[ "$result" == "skip" ]]; then
+		print_result "skip 'no suggestions at this time' review" 0
+	else
+		print_result "skip 'no suggestions at this time' review" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result
@@ -652,6 +668,7 @@ main() {
 	test_skips_found_no_issues_long_review
 	test_skips_no_further_recommendations_review
 	test_skips_gemini_style_positive_summary_review
+	test_skips_no_suggestions_at_this_time_review
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report


### PR DESCRIPTION
## Summary
- prevent false-positive quality-debt issues when a review body says there are no suggestions (for example, "Review completed. No suggestions at this time.")
- treat explicit no-suggestions phrasing as non-actionable even if the text contains the word "suggest"
- add regression coverage to the quality-feedback approval filter tests for this phrasing

## Verification
- `shellcheck .agents/scripts/quality-feedback-helper.sh .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh`

Closes #3612