### PR TITLE
t3231: fix high-severity review feedback on ocr/overview.md

### DIFF
--- a/.agents/tools/ocr/overview.md
+++ b/.agents/tools/ocr/overview.md
@@ -81,7 +81,7 @@ What is your input?
 
 ### Detailed Comparison
 
-| Feature | PaddleOCR | MinerU | Docling + ET | GLM-OCR | LibPDF |
+| Feature | PaddleOCR | MinerU | Docling + ExtractThinker | GLM-OCR | LibPDF |
 |---------|-----------|--------|--------------|---------|--------|
 | **Primary use** | Scene text OCR | PDF to markdown | Structured extraction | Quick local OCR | PDF manipulation |
 | **Input types** | Any image | PDF only | PDF, DOCX, images | Any image | PDF only |
@@ -164,6 +164,7 @@ Docling (IBM, 52.7k stars, MIT) parses document layout, then ExtractThinker uses
 - Privacy modes (fully local via Ollama, edge via Cloudflare, cloud)
 - PII detection and redaction (Presidio)
 - UK VAT-aware schemas with QuickFile integration
+- Native MCP server for agent framework integration
 
 **Weaknesses**:
 


### PR DESCRIPTION
## Summary

Addresses the high-severity (and one medium-severity) review findings from PR #2667 flagged in issue #3231.

### Changes

- **HIGH fix**: Add `Native MCP server for agent framework integration` to Docling + ExtractThinker Strengths list — the comparison table and integration diagram both already reference Docling's MCP server; the tool profile was inconsistent by omitting it
- **MEDIUM fix**: Expand `ET` abbreviation to `ExtractThinker` in the Detailed Comparison table header for clarity and consistency with all other references in the document

### Not applied

- **MEDIUM date finding** (Jan 2026 → Jan 2024): Rejected. PaddleOCR v3.4.0 was released 2026-01-29 (verified via GitHub API). The reviewer flagged it as "future" because the PR was merged 2026-03-01, but the date is factually correct and should be kept.

## Verification

- `markdownlint-cli2`: 0 errors
- Diff is minimal (2 lines changed, 1 added)

Closes #3231