### PR TITLE
t3234: fix high-severity review feedback on issue-sync.yml

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -312,7 +312,7 @@ jobs:
           # Collect linked issue numbers from PR body (Closes #NNN, Fixes #NNN, Resolves #NNN)
           LINKED_ISSUES=""
           if [[ -n "$PR_BODY" ]]; then
-            LINKED_ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes?|fixes?|resolves?)\s*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
+            LINKED_ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes?|fixes?|resolves?)[[:space:]]*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
           fi
           echo "linked_issues=$LINKED_ISSUES" >> "$GITHUB_OUTPUT"
 
@@ -364,7 +364,7 @@ jobs:
         run: |
           # Merge all issue numbers (from PR body + fallback search)
           ALL_ISSUES="$LINKED_ISSUES $FOUND_ISSUES"
-          ALL_ISSUES=$(echo "$ALL_ISSUES" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')
+          ALL_ISSUES=$(echo "$ALL_ISSUES" | tr ' ' '\n' | sort -u | { grep -v '^$' || true; } | tr '\n' ' ')
 
           if [[ -z "$ALL_ISSUES" ]]; then
             echo "No linked issues found — skipping closing hygiene"
@@ -574,7 +574,7 @@ jobs:
           fi
 
           # Check for GitHub closing keywords or ref:GH# pattern
-          if echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves)\s+#[0-9]+'; then
+          if echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+'; then
             echo "PR body contains issue closing keyword"
             exit 0
           fi


### PR DESCRIPTION
## Summary

- Replace `\s*` / `\s+` with `[[:space:]]*` / `[[:space:]]+` in `grep -E` patterns — POSIX ERE does not support `\s`, so `Closes #123` (with a space) was never matched, leaving `linked_issues` empty and preventing `sync-on-pr-merge` from running
- Guard `grep -v '^$'` with `|| true` to prevent `pipefail` from aborting the step when `ALL_ISSUES` is empty (grep exits 1 on no output, which fires before the `[[ -z "$ALL_ISSUES" ]]` guard)
- Same `\s+` → `[[:space:]]+` fix in the `check-issue-link` job's closing-keyword pattern

## Findings addressed

| Severity | Line | Finding |
|----------|------|---------|
| HIGH | 315 | `grep -E` with `\s*` — POSIX ERE doesn't treat `\s` as whitespace |
| MEDIUM | 367 | `grep -v '^$'` exits 1 on empty input under `pipefail`, aborting step |
| MEDIUM | 577 | Same `\s+` issue in `check-issue-link` closing-keyword pattern |

Closes #3234