### PR TITLE
t3223: fix high-severity review feedback on review-bot-gate-helper.sh

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -123,17 +123,17 @@ get_all_bot_commenters() {
 	# 1. PR reviews (formal GitHub reviews)
 	local reviews
 	reviews=$(gh api "repos/${repo}/pulls/${pr_number}/reviews" \
-		--paginate --jq '.[].user.login' 2>/dev/null || echo "")
+		--paginate --jq '.[].user.login' || echo "")
 
 	# 2. Issue comments (some bots post as comments, not reviews)
 	local comments
 	comments=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
-		--paginate --jq '.[].user.login' 2>/dev/null || echo "")
+		--paginate --jq '.[].user.login' || echo "")
 
 	# 3. Review comments (inline code comments)
 	local review_comments
 	review_comments=$(gh api "repos/${repo}/pulls/${pr_number}/comments" \
-		--paginate --jq '.[].user.login' 2>/dev/null || echo "")
+		--paginate --jq '.[].user.login' || echo "")
 
 	# Combine, deduplicate, lowercase
 	echo -e "${reviews}\n${comments}\n${review_comments}" |
@@ -174,7 +174,7 @@ bot_has_real_review() {
 
 	local endpoint encoded_bodies body
 	for endpoint in "${api_endpoints[@]}"; do
-		encoded_bodies=$(gh api "$endpoint" --paginate --jq "$jq_filter" 2>/dev/null || echo "")
+		encoded_bodies=$(gh api "$endpoint" --paginate --jq "$jq_filter" || echo "")
 		if [[ -n "$encoded_bodies" ]]; then
 			while IFS= read -r encoded; do
 				[[ -z "$encoded" ]] && continue
@@ -257,7 +257,7 @@ check_for_skip_label() {
 
 	local labels
 	labels=$(gh pr view "$pr_number" --repo "$repo" \
-		--json labels -q '.labels[].name' 2>/dev/null || echo "")
+		--json labels -q '.labels[].name' || echo "")
 
 	if echo "$labels" | grep -q "$SKIP_LABEL"; then
 		return 0
@@ -358,11 +358,22 @@ do_wait() {
 	local poll_interval="${REVIEW_BOT_POLL_INTERVAL:-60}"
 	local elapsed=0
 
+	# Validate that max_wait and poll_interval are positive integers to prevent
+	# command injection via arithmetic expansion (GH#3223).
+	if ! [[ "$max_wait" =~ ^[0-9]+$ ]]; then
+		echo "ERROR: max_wait must be a non-negative integer, got: '${max_wait}'" >&2
+		return 2
+	fi
+	if ! [[ "$poll_interval" =~ ^[0-9]+$ ]]; then
+		echo "ERROR: poll_interval must be a non-negative integer, got: '${poll_interval}'" >&2
+		return 2
+	fi
+
 	echo "Waiting up to ${max_wait}s for review bots on PR #${pr_number}..." >&2
 
 	while [[ "$elapsed" -lt "$max_wait" ]]; do
 		local result
-		result=$(do_check "$pr_number" "$repo" 2>/dev/null) || true
+		result=$(do_check "$pr_number" "$repo") || true
 
 		if [[ "$result" == "PASS" || "$result" == "PASS_RATE_LIMITED" || "$result" == "SKIP" ]]; then
 			echo "$result"
@@ -424,7 +435,7 @@ has_formal_reviews() {
 
 	local count
 	count=$(gh pr view "$pr_number" --repo "$repo" \
-		--json reviews --jq '.reviews | length' 2>/dev/null || echo "0")
+		--json reviews --jq '.reviews | length' || echo "0")
 	if [[ "$count" -gt 0 ]]; then
 		return 0
 	fi
@@ -440,7 +451,7 @@ has_retry_comment() {
 	local marker="<!-- review-bot-retry-requested -->"
 	local comments
 	comments=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
-		--paginate --jq '.[].body' 2>/dev/null || echo "")
+		--paginate --jq '.[].body' || echo "")
 	if echo "$comments" | grep -qF "$marker"; then
 		return 0
 	fi


### PR DESCRIPTION
## Summary

- Removes blanket `2>/dev/null` suppression from all `gh api` / `gh pr view` calls that were silently swallowing auth failures, invalid PR numbers, and network errors
- Adds integer validation for `max_wait` and `poll_interval` in `do_wait()` to prevent command injection via arithmetic expansion
- Removes `2>/dev/null` from the `do_check()` call inside `do_wait()` so diagnostic output is visible during polling

## Findings addressed

| Severity | Location | Finding |
|----------|----------|---------|
| HIGH | `get_all_bot_commenters()` L68 | `2>/dev/null` on 3 `gh api` calls silently hid auth/network errors |
| HIGH | `do_wait()` L157 | `max_wait`/`poll_interval` lacked integer validation (injection risk); `do_check` stderr suppressed |
| MEDIUM | `check_for_skip_label()` L81 | `2>/dev/null` on `gh pr view` hid errors, could cause silent wrong result |
| MEDIUM | `has_formal_reviews()` / `has_retry_comment()` | Same `2>/dev/null` pattern extended to these functions |

## What was intentionally kept

- `2>/dev/null` on GraphQL→REST fallback chains (`get_pr_age_seconds`, `any_bot_has_success_status`) — expected errors during fallback
- `2>/dev/null` on cross-platform `date` compatibility (macOS vs GNU) — one always fails
- `2>/dev/null` on `base64 -d` of potentially malformed data — decode failure handled by `|| echo ""`

## Verification

- `shellcheck .agents/scripts/review-bot-gate-helper.sh` — zero violations

Closes #3223