### PR TITLE
t3219: fix CodeRabbit review feedback on prompt-guard patterns

### DIFF
--- a/.agents/configs/prompt-injection-patterns.yaml
+++ b/.agents/configs/prompt-injection-patterns.yaml
@@ -516,7 +516,10 @@ context_manipulation:
 
   - severity: LOW
     description: "Zero-width characters"
-    pattern: '[\xE2\x80\x8B\xE2\x80\x8C\xE2\x80\x8D\xEF\xBB\xBF]'
+    # Literal Unicode chars (U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM)
+    # for portability across rg/grep/ggrep — byte-level \xNN escapes match
+    # individual bytes, not multi-byte UTF-8 codepoints.
+    pattern: '[​‌‍﻿]'
 
   # --- Lasso net-new: False authority claims ---
   - severity: HIGH

--- a/.agents/scripts/prompt-guard-helper.sh
+++ b/.agents/scripts/prompt-guard-helper.sh
@@ -168,10 +168,6 @@ _pg_load_yaml_patterns() {
 		return 1
 	}
 
-	# Only mark loaded after successful file discovery (prevents transient failures
-	# from permanently disabling YAML loading on subsequent calls)
-	_PG_YAML_PATTERNS_LOADED="true"
-
 	local patterns=""
 	local current_category=""
 	local severity="" description="" pattern=""
@@ -228,8 +224,10 @@ _pg_load_yaml_patterns() {
 		return 1
 	fi
 
-	# Cache for subsequent calls
+	# Cache for subsequent calls — mark loaded only after successful parse+cache
+	# so transient parse failures do not permanently disable YAML loading.
 	_PG_YAML_PATTERNS_CACHE="$patterns"
+	_PG_YAML_PATTERNS_LOADED="true"
 
 	# Remove trailing newline
 	echo "${patterns%$'\n'}"


### PR DESCRIPTION
## Summary

Addresses unactioned CodeRabbit review feedback from PR #2715 (issue #3219).

## Changes

### `_PG_YAML_PATTERNS_LOADED` flag moved after successful parse+cache

**Bug**: `_PG_YAML_PATTERNS_LOADED="true"` was set after file discovery succeeds but before parsing. If parsing produced no patterns (e.g., malformed YAML, empty file), the flag was already set to `true` with an empty cache. Subsequent calls would hit the cache check, find `_PG_YAML_PATTERNS_CACHE` empty, and return 1 — permanently disabling YAML loading for the session.

**Fix**: Move the flag assignment to after `_PG_YAML_PATTERNS_CACHE="$patterns"` so it is only set on a successful parse+cache. Transient parse failures now allow retries.

### Zero-width character pattern uses literal Unicode chars

**Bug**: The YAML pattern `'[\xE2\x80\x8B\xE2\x80\x8C\xE2\x80\x8D\xEF\xBB\xBF]'` used byte-level `\xNN` hex escapes. In a character class, these match individual bytes (0xE2, 0x80, 0x8B, etc.), not the multi-byte UTF-8 codepoints U+200B/U+200C/U+200D/U+FEFF.

**Fix**: Replace with literal Unicode characters (U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM) — same approach used for the homoglyph patterns. Verified: `rg` correctly matches the literal chars against test input.

## Verification

- `shellcheck`: SC1091 info only (pre-existing, not a violation)
- `prompt-guard-helper.sh status`: 119 YAML patterns loaded correctly
- `prompt-guard-helper.sh test`: all PASS

Closes #3219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where failed pattern parsing would permanently disable pattern loading. Patterns will now correctly reload on subsequent attempts.

* **Updates**
  * Enhanced zero-width character detection patterns for improved accuracy in pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->