### PR TITLE
t3219: fix PCRE2 Unicode portability in prompt-injection-patterns.yaml

### DIFF
--- a/.agents/configs/prompt-injection-patterns.yaml
+++ b/.agents/configs/prompt-injection-patterns.yaml
@@ -516,7 +516,10 @@ context_manipulation:
 
   - severity: LOW
     description: "Zero-width characters"
-    pattern: '[\xE2\x80\x8B\xE2\x80\x8C\xE2\x80\x8D\xEF\xBB\xBF]'
+    # Literal Unicode chars (U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM)
+    # for portability across rg/grep/ggrep — byte-level \xNN escapes match
+    # individual bytes, not multi-byte UTF-8 codepoints.
+    pattern: '[​‌‍﻿]'
 
   # --- Lasso net-new: False authority claims ---
   - severity: HIGH

--- a/.agents/scripts/prompt-guard-helper.sh
+++ b/.agents/scripts/prompt-guard-helper.sh
@@ -168,10 +168,6 @@ _pg_load_yaml_patterns() {
 		return 1
 	}
 
-	# Only mark loaded after successful file discovery (prevents transient failures
-	# from permanently disabling YAML loading on subsequent calls)
-	_PG_YAML_PATTERNS_LOADED="true"
-
 	local patterns=""
 	local current_category=""
 	local severity="" description="" pattern=""
@@ -228,8 +224,10 @@ _pg_load_yaml_patterns() {
 		return 1
 	fi
 
-	# Cache for subsequent calls
+	# Cache for subsequent calls — mark loaded only after successful parse+cache
+	# so transient parse failures do not permanently disable YAML loading.
 	_PG_YAML_PATTERNS_CACHE="$patterns"
+	_PG_YAML_PATTERNS_LOADED="true"
 
 	# Remove trailing newline
 	echo "${patterns%$'\n'}"


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from PR #2715 (issue #3219).

Two fixes:

- **YAML zero-width character pattern**: Replace byte-level `\xNN` hex escapes (`[\xE2\x80\x8B\xE2\x80\x8C\xE2\x80\x8D\xEF\xBB\xBF]`) with literal Unicode chars (U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM). Byte-level escapes match individual bytes, not multi-byte UTF-8 codepoints — the pattern silently failed to match zero-width characters under all grep backends.

- **`_PG_YAML_PATTERNS_LOADED` flag timing**: Move flag assignment to after successful parse+cache in `_pg_load_yaml_patterns()`. Previously set after file discovery but before parsing, so a transient parse failure would permanently disable YAML loading for the session lifetime.

## Verification

- Literal Unicode chars in character classes work across `rg`, `grep -P`, and `grep -E` (all handle UTF-8 natively)
- `\x{...}` PCRE2 code-point syntax confirmed working for `\x{200B}` etc. in inline patterns (separate from this fix)
- `\p{Cyrillic}` and `\p{Greek}` in inline patterns confirmed working with both `grep -P` and `rg`
- The homoglyph patterns at lines 332/336 already use literal Unicode chars (fixed in PR #2715 itself)

Closes #3219