### PR TITLE
fix(GH#3200): prevent raw error.message leak to Teams chat users

### DIFF
--- a/.agents/services/communications/msteams.md
+++ b/.agents/services/communications/msteams.md
@@ -721,7 +721,8 @@ async function dispatchToRunner(prompt, context) {
     );
     return stdout.trim();
   } catch (error) {
-    return `Runner dispatch failed: ${error.message}`;
+    console.error("Runner dispatch failed", { error });
+    return "Runner dispatch failed. Please try again later or contact an administrator.";
   }
 }
 ```


### PR DESCRIPTION
## Summary

- **Security hardening**: The `dispatchToRunner` catch block in `msteams.md` was returning `Runner dispatch failed: ${error.message}` directly to Teams chat users, potentially leaking internal runtime/command details (file paths, stack traces, process errors).
- **Fix**: Log the full error object server-side via `console.error()` for debugging, and return a generic user-facing message: `"Runner dispatch failed. Please try again later or contact an administrator."`

## Changes

- `.agents/services/communications/msteams.md:723-726` — replaced raw `error.message` interpolation with server-side logging + generic response.

Closes #3200