### PR TITLE
t3655: refactor new_priority validation to use regex in adjust_priority

### DIFF
--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -1124,13 +1124,10 @@ validate_action_fields() {
 		# The executor infers priority from reasoning text when the field is absent,
 		# but if the field IS present it must be a valid value (t1197).
 		if [[ -n "$new_priority" && "$new_priority" != "null" ]]; then
-			case "$new_priority" in
-			high | medium | low | critical) ;;
-			*)
+			if ! [[ "$new_priority" =~ ^(high|medium|low|critical)$ ]]; then
 				echo "invalid new_priority: $new_priority (must be high|medium|low|critical)"
 				return 0
-				;;
-			esac
+			fi
 		fi
 		;;
 	close_verified)


### PR DESCRIPTION
## Summary

- Replaces the `case` statement in `validate_action_fields()` for `adjust_priority` with a concise `=~ ^(high|medium|low|critical)$` regex check
- Addresses the medium-severity suggestion from Gemini's review of PR #1703

## Design note

The `return 0` is intentionally preserved. `validate_action_fields()` uses a stdout-as-error-signal pattern: callers capture output via `$()` and check `[[ -n "$validation_error" ]]`. Changing to `return 1` would be incorrect — it would not change the caller's behaviour (stdout is still captured) but could interact badly with `set -e` in subshells. Gemini's `return 1` suggestion was evaluated and rejected as incorrect for this design.

## Changes

- `.agents/scripts/supervisor-archived/ai-actions.sh`: regex replaces case statement (7 lines → 4 lines)

## Verification

- ShellCheck: zero violations (only pre-existing SC1091 info notices for sourced files)
- Existing tests in `tests/test-ai-actions.sh` cover all valid/invalid `new_priority` values including `critical`

Closes #3655