### PR TITLE
fix(t3649): address gemini review feedback on build_exclusion_context

### DIFF
--- a/.agents/scripts/supervisor-archived/ai-context.sh
+++ b/.agents/scripts/supervisor-archived/ai-context.sh
@@ -180,8 +180,8 @@ build_exclusion_context() {
 	local log_dir="${AI_REASON_LOG_DIR:-$HOME/.aidevops/logs/ai-supervisor}"
 	if [[ -d "$log_dir" ]]; then
 		local action_logs
-		action_logs=$(find "$log_dir" -maxdepth 1 -name 'actions-*.md' -print0 2>/dev/null |
-			xargs -0 ls -t 2>/dev/null | head -5)
+		action_logs=$(find "$log_dir" -maxdepth 1 -name 'actions-*.md' -print0 |
+			xargs -0 ls -t | head -5)
 
 		if [[ -n "$action_logs" ]]; then
 			while IFS= read -r log_file; do
@@ -189,8 +189,7 @@ build_exclusion_context() {
 
 				# Extract issue numbers from action logs
 				local issue_nums
-				issue_nums=$(grep -oE '"issue_number":[0-9]+' "$log_file" 2>/dev/null |
-					grep -oE '[0-9]+' || true)
+				issue_nums=$(sed -n 's/.*"issue_number":\([0-9]\+\).*/\1/p' "$log_file" || true)
 				if [[ -n "$issue_nums" ]]; then
 					while IFS= read -r inum; do
 						[[ -n "$inum" ]] && excluded_issues+="$inum\n"
@@ -199,8 +198,7 @@ build_exclusion_context() {
 
 				# Extract task IDs from action logs
 				local task_ids
-				task_ids=$(grep -oE '"task_id":"t[0-9]+"' "$log_file" 2>/dev/null |
-					grep -oE 't[0-9]+' || true)
+				task_ids=$(sed -n 's/.*"task_id":"\(t[0-9]\+\)".*/\1/p' "$log_file" || true)
 				if [[ -n "$task_ids" ]]; then
 					while IFS= read -r tid; do
 						[[ -n "$tid" ]] && excluded_tasks+="$tid\n"


### PR DESCRIPTION
## Summary

Addresses the 3 medium-severity findings from Gemini's review of PR #1768 that were left unactioned.

All changes are in `.agents/scripts/supervisor-archived/ai-context.sh`, `build_exclusion_context()`.

### Fixes

**1. Remove redundant `2>/dev/null` from `find` pipeline**

The `if [[ -d "$log_dir" ]]` guard already prevents `find` from failing when the directory doesn't exist. Suppressing stderr hides real permission errors and violates the style guide (line 50), which only permits `2>/dev/null` when redirecting to a log file.

**2. Single `sed` for `issue_number` extraction (was two `grep` processes)**

Replaces `grep -oE '"issue_number":[0-9]+' | grep -oE '[0-9]+'` with `sed -n 's/.*"issue_number":\([0-9]\+\).*/\1/p'` — one process instead of two.

**3. Single `sed` for `task_id` extraction (was two `grep` processes)**

Replaces `grep -oE '"task_id":"t[0-9]+"' | grep -oE 't[0-9]+'` with `sed -n 's/.*"task_id":"\(t[0-9]\+\)".*/\1/p'` — one process instead of two.

### Verification

- `shellcheck` passes with zero new violations (pre-existing SC1091 info notice on sourced file is unchanged)

Closes #3649