### PR TITLE
t3667: fix parent_ids extraction in Strategy 4 — extract only leading task ID

### DIFF
--- a/.agents/scripts/supervisor-archived/cron.sh
+++ b/.agents/scripts/supervisor-archived/cron.sh
@@ -839,7 +839,7 @@ cmd_auto_pickup() {
 	# Previous head -50 limit caused parents beyond the 50th to be silently skipped.
 	local parent_ids
 	parent_ids=$(grep -E '^[[:space:]]*- \[ \] (t[0-9]+) .*#auto-dispatch' "$todo_file" 2>/dev/null |
-		grep -oE 't[0-9]+' | sort -u || true)
+		sed -E 's/^[[:space:]]*- \[[ ]\] (t[0-9]+).*/\1/' | sort -u || true)
 
 	if [[ -n "$parent_ids" ]]; then
 		while IFS= read -r parent_id; do


### PR DESCRIPTION
## Summary

Fixes the CodeRabbit **major** finding from PR #1616 review (unactioned feedback tracked in issue #3667).

### Problem

In Strategy 4 of `cmd_auto_pickup()`, the `parent_ids` pipeline used `grep -oE 't[0-9]+'` which matched **all** `tNNN` tokens in each matching line — not just the primary task ID. For a line like:

```
- [ ] t100 Fix t200 integration `#auto-dispatch`
```

both `t100` and `t200` were extracted. If `t200` happened to have open subtasks but was not tagged `#auto-dispatch`, those subtasks would be incorrectly picked up via Strategy 4.

### Fix

Replace the second `grep -oE` with a targeted `sed` that extracts only the leading task ID after the checklist prefix:

```diff
 parent_ids=$(grep -E '^[[:space:]]*- \[ \] (t[0-9]+) .*#auto-dispatch' "$todo_file" 2>/dev/null |
-    grep -oE 't[0-9]+' | sort -u || true)
+    sed -E 's/^[[:space:]]*- \[[ ]\] (t[0-9]+).*/\1/' | sort -u || true)
```

### Verification

- ShellCheck: zero violations (only pre-existing SC1091 info note on sourced file)
- Logic: `sed` captures only capture group 1 (the leading `tNNN`), discarding the rest of the line

### Context

A previous attempt (PR #4653, branch `bugfix/t3667-cron-guard-helper`) was closed without merging. This PR applies the same targeted fix to the current HEAD of the archived file.

Closes #3667