### PR TITLE
t3651: fix Phase 0.7 pulse.sh — consolidate DB queries and safe arithmetic

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -1029,7 +1029,7 @@ cmd_pulse() {
 	local fast_path_evaluating_grace="${SUPERVISOR_FAST_PATH_EVALUATING_GRACE_SECONDS:-30}"
 	local fast_path_evaluating_tasks
 	fast_path_evaluating_tasks=$(db -separator '|' "$SUPERVISOR_DB" "
-		SELECT id, status, updated_at FROM tasks
+		SELECT id, status, updated_at, retries, max_retries, pr_url FROM tasks
 		WHERE status = 'evaluating'
 		AND pr_url IS NOT NULL
 		AND pr_url != ''
@@ -1043,7 +1043,7 @@ cmd_pulse() {
 	# Query evaluating tasks without PR URL — use standard grace period
 	local stale_evaluating_tasks
 	stale_evaluating_tasks=$(db -separator '|' "$SUPERVISOR_DB" "
-		SELECT id, status, updated_at FROM tasks
+		SELECT id, status, updated_at, retries, max_retries, pr_url FROM tasks
 		WHERE status = 'evaluating'
 		AND (pr_url IS NULL OR pr_url = '' OR pr_url = 'no_pr' OR pr_url = 'task_only' OR pr_url = 'task_obsolete')
 		AND updated_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-${evaluating_grace_seconds} seconds')
@@ -1065,7 +1065,7 @@ cmd_pulse() {
 		local stale_recovered=0
 		local stale_skipped=0
 
-		while IFS='|' read -r stale_id stale_status stale_updated; do
+		while IFS='|' read -r stale_id stale_status stale_updated stale_retries stale_max_retries stale_pr_url; do
 			[[ -z "$stale_id" ]] && continue
 
 			# Check if a live worker process exists for this task
@@ -1118,10 +1118,11 @@ cmd_pulse() {
 			local diag_eval_started_at="${_DIAG_EVAL_STARTED_AT:-}"
 			local diag_eval_lag_secs="${_DIAG_EVAL_LAG_SECS:-NULL}"
 
-			local stale_retries stale_max_retries stale_pr_url
-			stale_retries=$(db "$SUPERVISOR_DB" "SELECT retries FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "0")
-			stale_max_retries=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}")
-			stale_pr_url=$(db "$SUPERVISOR_DB" "SELECT pr_url FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "")
+			# stale_retries, stale_max_retries, stale_pr_url are parsed from the initial
+			# query (fetched upfront to avoid per-task DB calls inside the loop).
+			# Apply defaults in case the DB returned empty strings.
+			stale_retries="${stale_retries:-0}"
+			stale_max_retries="${stale_max_retries:-${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}}"
 
 			local had_pr_flag=0
 			[[ -n "$stale_pr_url" && "$stale_pr_url" != "no_pr" && "$stale_pr_url" != "task_only" ]] && had_pr_flag=1


### PR DESCRIPTION
## Summary

Addresses unactioned Gemini review feedback from PR #1733 on the Phase 0.7 stale-state detection block in `supervisor-archived/pulse.sh`.

## Changes

**Performance fix (medium):** `retries`, `max_retries`, and `pr_url` were fetched with 3 separate `db()` calls per stale task inside the recovery loop. These are now included in the two initial `SELECT` queries (`fast_path_evaluating_tasks` and `stale_evaluating_tasks`), the `read` command is updated to parse the new fields, and the 3 redundant per-task `db()` calls are removed. For N stale tasks, this reduces DB queries from `3N` to `0` inside the loop.

**Safety fix (high):** The arithmetic comparison `[[ "$stale_retries" -lt "$stale_max_retries" ]]` was unsafe under `set -e` — if the DB returned an empty string, the comparison would cause a script-terminating error. Parameter expansion defaults (`${stale_retries:-0}`, `${stale_max_retries:-${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}}`) are now applied immediately after the `read` command, guaranteeing non-empty values before any arithmetic.

## Verification

- `bash -n` passes (no syntax errors)
- Diff is minimal and surgical — no logic changes, only query consolidation and defensive defaults

Closes #3651