### PR TITLE
t3657: address PR #1688 review feedback — path resolution, sqlite busy_timeout, shared token extraction

### DIFF
--- a/.agents/scripts/archived/pattern-tracker-helper.sh
+++ b/.agents/scripts/archived/pattern-tracker-helper.sh
@@ -364,7 +364,7 @@ cmd_record() {
 		[[ -n "$tokens_out" ]] && sql_tokens_out="$tokens_out"
 		[[ -n "$estimated_cost" ]] && sql_estimated_cost="$estimated_cost"
 
-		sqlite3 "$MEMORY_DB" "INSERT OR REPLACE INTO pattern_metadata (id, strategy, quality, failure_mode, tokens_in, tokens_out, estimated_cost) VALUES ('$mem_id', '$sql_strategy', $sql_quality, $sql_failure_mode, $sql_tokens_in, $sql_tokens_out, $sql_estimated_cost);" 2>/dev/null || log_warn "Failed to store pattern metadata for $mem_id"
+		sqlite3 -cmd ".timeout 5000" "$MEMORY_DB" "INSERT OR REPLACE INTO pattern_metadata (id, strategy, quality, failure_mode, tokens_in, tokens_out, estimated_cost) VALUES ('$mem_id', '$sql_strategy', $sql_quality, $sql_failure_mode, $sql_tokens_in, $sql_tokens_out, $sql_estimated_cost);" 2>/dev/null || log_warn "Failed to store pattern metadata for $mem_id"
 	fi
 
 	log_success "Recorded $outcome pattern: $description"

--- a/.agents/scripts/supervisor-archived/_common.sh
+++ b/.agents/scripts/supervisor-archived/_common.sh
@@ -221,3 +221,42 @@ portable_timeout() {
 	timeout_sec "$@"
 	return $?
 }
+
+#######################################
+# Extract token counts from a worker log file (t1114)
+# Supports camelCase (opencode JSON) and snake_case (claude CLI JSON) formats.
+# Results are stored in module-level globals _EXTRACT_TOKENS_IN and
+# _EXTRACT_TOKENS_OUT. Callers copy these into their own local variables.
+#
+# Usage:
+#   local tokens_in="" tokens_out=""
+#   extract_tokens_from_log "$log_file"
+#   tokens_in="$_EXTRACT_TOKENS_IN"
+#   tokens_out="$_EXTRACT_TOKENS_OUT"
+#
+# $1: log_file path (may be empty or non-existent — handled gracefully)
+#######################################
+_EXTRACT_TOKENS_IN=""
+_EXTRACT_TOKENS_OUT=""
+extract_tokens_from_log() {
+	local log_file="$1"
+	_EXTRACT_TOKENS_IN=""
+	_EXTRACT_TOKENS_OUT=""
+
+	if [[ -z "$log_file" || ! -f "$log_file" ]]; then
+		return 0
+	fi
+
+	local raw_in raw_out
+	raw_in=$(grep -oE '"inputTokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
+	raw_out=$(grep -oE '"outputTokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
+	if [[ -z "$raw_in" ]]; then
+		raw_in=$(grep -oE '"input_tokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
+	fi
+	if [[ -z "$raw_out" ]]; then
+		raw_out=$(grep -oE '"output_tokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
+	fi
+	[[ -n "$raw_in" ]] && _EXTRACT_TOKENS_IN="$raw_in"
+	[[ -n "$raw_out" ]] && _EXTRACT_TOKENS_OUT="$raw_out"
+	return 0
+}

--- a/.agents/scripts/supervisor-archived/evaluate.sh
+++ b/.agents/scripts/supervisor-archived/evaluate.sh
@@ -812,7 +812,10 @@ record_evaluation_metadata() {
 	local quality_score="${5:-0}"
 	local ai_evaluated="${6:-false}"
 
-	local pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+	local pattern_helper="${SCRIPT_DIR}/../pattern-tracker-helper.sh"
+	if [[ ! -x "$pattern_helper" ]]; then
+		pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+	fi
 	if [[ ! -x "$pattern_helper" ]]; then
 		pattern_helper="$HOME/.aidevops/agents/scripts/pattern-tracker-helper.sh"
 	fi
@@ -847,21 +850,11 @@ record_evaluation_metadata() {
 	fi
 
 	# Extract token counts from worker log for cost tracking (t1114, t1117)
-	# Supports camelCase (opencode JSON) and snake_case (claude CLI JSON) formats.
+	# Shared extraction logic lives in supervisor-archived/_common.sh (extract_tokens_from_log).
 	local tokens_in="" tokens_out=""
-	if [[ -n "$task_log_file" && -f "$task_log_file" ]]; then
-		local raw_in raw_out
-		raw_in=$(grep -oE '"inputTokens":[0-9]+' "$task_log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		raw_out=$(grep -oE '"outputTokens":[0-9]+' "$task_log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		if [[ -z "$raw_in" ]]; then
-			raw_in=$(grep -oE '"input_tokens":[0-9]+' "$task_log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		fi
-		if [[ -z "$raw_out" ]]; then
-			raw_out=$(grep -oE '"output_tokens":[0-9]+' "$task_log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		fi
-		[[ -n "$raw_in" ]] && tokens_in="$raw_in"
-		[[ -n "$raw_out" ]] && tokens_out="$raw_out"
-	fi
+	extract_tokens_from_log "$task_log_file"
+	tokens_in="$_EXTRACT_TOKENS_IN"
+	tokens_out="$_EXTRACT_TOKENS_OUT"
 
 	# Look up task type from DB tags if available, fallback to "unknown"
 	# TODO(t1096): extract real task type from TODO.md tags or DB metadata

--- a/.agents/scripts/supervisor-archived/memory-integration.sh
+++ b/.agents/scripts/supervisor-archived/memory-integration.sh
@@ -227,20 +227,11 @@ store_success_pattern() {
 
 	# Extract token counts from worker log for cost tracking (t1114)
 	# opencode/claude --format json logs emit usage stats in the final JSON entry.
+	# Shared extraction logic lives in supervisor-archived/_common.sh (extract_tokens_from_log).
 	local tokens_in="" tokens_out=""
-	if [[ -n "$log_file" && -f "$log_file" ]]; then
-		local raw_in raw_out
-		raw_in=$(grep -oE '"inputTokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		raw_out=$(grep -oE '"outputTokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		if [[ -z "$raw_in" ]]; then
-			raw_in=$(grep -oE '"input_tokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		fi
-		if [[ -z "$raw_out" ]]; then
-			raw_out=$(grep -oE '"output_tokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		fi
-		[[ -n "$raw_in" ]] && tokens_in="$raw_in"
-		[[ -n "$raw_out" ]] && tokens_out="$raw_out"
-	fi
+	extract_tokens_from_log "$log_file"
+	tokens_in="$_EXTRACT_TOKENS_IN"
+	tokens_out="$_EXTRACT_TOKENS_OUT"
 
 	# Build tags with model and duration info for pattern-tracker queries
 	local tags="supervisor,pattern,$task_id,complete"
@@ -252,7 +243,10 @@ store_success_pattern() {
 	tags="$tags,quality:${quality_score},failure_mode:NONE"
 
 	# Use pattern-tracker-helper.sh directly when available for richer metadata (t1114)
-	local pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+	local pattern_helper="${SCRIPT_DIR}/../pattern-tracker-helper.sh"
+	if [[ ! -x "$pattern_helper" ]]; then
+		pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+	fi
 	if [[ ! -x "$pattern_helper" ]]; then
 		pattern_helper="$HOME/.aidevops/agents/scripts/pattern-tracker-helper.sh"
 	fi


### PR DESCRIPTION
## Summary

Addresses unactioned review feedback from PR #1688 (t1114 ROI cost tracking feature). All findings verified against current code before applying.

### Fixes applied

**CodeRabbit — `pattern-tracker-helper.sh` L353-368**
- Added `.timeout 5000` to the raw `sqlite3` INSERT in `cmd_record` to prevent `SQLITE_BUSY` failures under concurrent access. Other `sqlite3` calls in this file use the same pattern; this brings the new INSERT into line.

**Gemini — `evaluate.sh` L793-796 and `memory-integration.sh` L254-258**
- Both scripts set `pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"` as the primary lookup. In the supervisor context, `SCRIPT_DIR` resolves to `.agents/scripts/supervisor-archived/`, so this path never exists. Fixed by trying `${SCRIPT_DIR}/../pattern-tracker-helper.sh` first (sibling directory), then the original `${SCRIPT_DIR}/` path, then the `$HOME` fallback.

**CodeRabbit — `memory-integration.sh` L228-243 (duplicated token extraction)**
- The camelCase/snake_case token extraction block was identical in `evaluate.sh` and `memory-integration.sh`. Extracted into `extract_tokens_from_log()` in `supervisor-archived/_common.sh` (which is sourced before both modules). Uses module-level globals `_EXTRACT_TOKENS_IN`/`_EXTRACT_TOKENS_OUT` for bash 3.2 compatibility (macOS ships bash 3.2; `local -n` namerefs require bash 4.3+). Verified with unit tests covering empty path, non-existent file, camelCase, and snake_case formats.

**Note:** The awk variable rename (`or` → `outr`) flagged by CodeRabbit was already applied in the original PR commit — confirmed at `pattern-tracker-helper.sh:69`.

Closes #3657