### PR TITLE
fix(quality-debt): correct compose.yml to docker-compose.yml in langwatch.md

### DIFF
--- a/.agents/services/monitoring/langwatch.md
+++ b/.agents/services/monitoring/langwatch.md
@@ -222,7 +222,7 @@ Docker Compose stack:
   langwatch/opensearch-lite      → Trace storage + search on :9200
 ```
 
-**Port conflicts**: The default ports (5432, 6379) may conflict with existing local services. If using the shared localdev Postgres, update `DATABASE_URL` in `.env` to point at the shared instance and remove the `postgres` service from `compose.yml`.
+**Port conflicts**: The default ports (5432, 6379) may conflict with existing local services. If using the shared localdev Postgres, update `DATABASE_URL` in `.env` to point at the shared instance and remove the `postgres` service from `docker-compose.yml`.
 
 ## Troubleshooting
 
@@ -235,14 +235,14 @@ lsof -i :6379  # Redis
 lsof -i :9200  # OpenSearch
 ```
 
-Either stop the conflicting service or remap ports in `compose.yml`.
+Either stop the conflicting service or remap ports in `docker-compose.yml`.
 
 ### OpenSearch out of memory
 
 The default config limits OpenSearch to 256MB. If it OOMs on large trace volumes:
 
 ```yaml
-# In compose.yml, increase the limit
+# In docker-compose.yml, increase the limit
 environment:
   - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
 deploy:


### PR DESCRIPTION
## Summary

Fixes 3 references to `compose.yml` that should be `docker-compose.yml` — the standard filename used by the LangWatch repository. Using the wrong filename would cause confusion when users try to edit the file directly.

## Changes

- `.agents/services/monitoring/langwatch.md`: 3 occurrences of `compose.yml` → `docker-compose.yml`

## Quality Debt

Closes #3180

Addresses gemini review feedback from PR #2871: "The documentation refers to `compose.yml` in several places (lines 225, 238, 245), but the standard filename is `docker-compose.yml`, which is also what the LangWatch repository uses."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration file references in monitoring setup documentation.
  * Expanded memory configuration guidance for OpenSearch setup with specific limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->