### PR TITLE
fix: add error tolerance to hang-warned rm cleanup in pulse.sh

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2288,7 +2288,7 @@ cmd_pulse() {
 				# Dead worker: PID no longer exists
 				rm -f "$pid_file"
 				# t1222: Clean up hang warning marker for dead workers
-				rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned" || true
+				rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned" 2>/dev/null || true
 				if [[ "$health_status" == "running" || "$health_status" == "dispatched" ]]; then
 					log_warn "  Dead worker for $health_task (PID $health_pid gone, was $health_status) — evaluating"
 					cmd_evaluate "$health_task" --no-ai 2>>"$SUPERVISOR_LOG" || {
@@ -2419,7 +2419,7 @@ cmd_pulse() {
 						fi
 						rm -f "$pid_file"
 						# t1222: Clean up hang warning marker on kill
-						rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned" || true
+						rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned" 2>/dev/null || true
 
 						# t1074: Auto-retry timed-out workers up to max_retries before marking failed.
 						# Check if the task has a PR already (worker may have created one before timeout).

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2288,7 +2288,7 @@ cmd_pulse() {
 				# Dead worker: PID no longer exists
 				rm -f "$pid_file"
 				# t1222: Clean up hang warning marker for dead workers
-				rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned"
+				rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned" || true
 				if [[ "$health_status" == "running" || "$health_status" == "dispatched" ]]; then
 					log_warn "  Dead worker for $health_task (PID $health_pid gone, was $health_status) — evaluating"
 					cmd_evaluate "$health_task" --no-ai 2>>"$SUPERVISOR_LOG" || {
@@ -2419,7 +2419,7 @@ cmd_pulse() {
 						fi
 						rm -f "$pid_file"
 						# t1222: Clean up hang warning marker on kill
-						rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned"
+						rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned" || true
 
 						# t1074: Auto-retry timed-out workers up to max_retries before marking failed.
 						# Check if the task has a PR already (worker may have created one before timeout).


### PR DESCRIPTION
## Summary

- Adds `|| true` after both `rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned"` commands in `.agents/scripts/supervisor-archived/pulse.sh` (lines 2291 and 2422)
- Prevents `set -e` from aborting the supervisor health-check loop on permission or I/O errors during marker file cleanup
- No functional change to the cleanup logic — errors are suppressed, not ignored in a way that affects task state

Closes #3640