### PR TITLE
t3532: fix concurrency group in publish-packages and postflight workflows

### DIFF
--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -10,7 +10,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.tag || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -10,7 +10,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.version || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- Incorporates the `version`/`tag` workflow_dispatch input into the concurrency group key so distinct manual runs no longer cancel each other
- Falls back to `github.sha` for release-triggered runs (where no input is provided), preserving existing deduplication behaviour for automated triggers

## Changes

| File | Before | After |
|------|--------|-------|
| `publish-packages.yml` | `${{ github.workflow }}-${{ github.ref }}` | `${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.version || github.sha }}` |
| `postflight.yml` | `${{ github.workflow }}-${{ github.ref }}` | `${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.tag || github.sha }}` |

## Why

Two `workflow_dispatch` runs targeting different versions (e.g., re-publishing v2.51.0 while v2.52.0 is in flight) shared the same concurrency group and the second would cancel the first. The fix makes each distinct version/tag input produce a unique group key.

Closes #3532