### PR TITLE
fix(t3170): address PR #2995 review feedback on setup-modules/shell-env.sh

### DIFF
--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -29,7 +29,8 @@ detect_default_shell() {
 
 # Usage: get_shell_rc "zsh" or get_shell_rc "bash"
 get_shell_rc() {
-	local shell_name="$1"
+	local shell_name
+	shell_name="$1"
 	case "$shell_name" in
 	zsh)
 		echo "$HOME/.zshrc"


### PR DESCRIPTION
## Summary

- Separates `local` declaration from assignment in `get_shell_rc()` per styleguide rule (Gemini cross-PR finding from PR #1253)
- All other findings from issue #3170 were already addressed in the merged PR #2995 (HIGH: `launchctl setenv PATH`, MEDIUM: fish shell syntax, MEDIUM: `grep 2>/dev/null` — none present in current code)

## Findings status

| Finding | Severity | Status |
|---|---|---|
| `launchctl setenv PATH` missing for GUI PATH (CodeRabbit) | HIGH | Already fixed in PR #2995 (lines 577-591) |
| `grep 2>/dev/null` in .zshenv block (Gemini) | MEDIUM | Already fixed — no suppression on grep |
| `grep 2>/dev/null` in rc files block (Gemini) | MEDIUM | Already fixed — no suppression on grep |
| Fish shell invalid bash syntax (CodeRabbit) | MEDIUM | Already fixed in PR #2995 (lines 648-660) |
| `local shell_name="$1"` combined form (Gemini cross-PR) | MEDIUM | **Fixed in this PR** |

## Verification

- ShellCheck passes with zero violations
- No functional behaviour change — purely styleguide compliance

Closes #3170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor code formatting refinement to improve readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->