### PR TITLE
t3164: clarify headless dispatch lineage command docs

### DIFF
--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -850,7 +850,7 @@ classify(task, lineage)
 
 ### Helper Script
 
-`task-decompose-helper.sh` provides three subcommands:
+`task-decompose-helper.sh` provides these subcommands (`format-lineage`, not `lineage`):
 
 ```bash
 # Classify: atomic or composite? (~$0.001, haiku tier)
@@ -865,6 +865,10 @@ task-decompose-helper.sh decompose "Build auth with login and OAuth" --max-subta
 task-decompose-helper.sh format-lineage --parent "Build auth" \
   --children '[{"description": "login"}, {"description": "OAuth"}]' --current 1
 # → formatted hierarchy with sibling tasks
+
+# Check if task already has child subtasks in TODO.md
+task-decompose-helper.sh has-subtasks t1408 --todo-file ./TODO.md
+# → true|false
 ```
 
 ### Configuration


### PR DESCRIPTION
## Summary
- updates `headless-dispatch.md` helper script section to explicitly call out that the correct subcommand is `format-lineage` (not `lineage`)
- adds a `has-subtasks` usage example so documented subcommands match the current helper implementation
- keeps the existing `format-lineage` example with valid flags aligned to `.agents/scripts/task-decompose-helper.sh`

Closes #3164.