### PR TITLE
t3589: fix PR #197 review feedback on repomix CLI migration

### DIFF
--- a/.agents/tools/context/context-builder.md
+++ b/.agents/tools/context/context-builder.md
@@ -28,22 +28,22 @@ note: Uses repomix CLI directly (not MCP) for better control and reliability
 
 ```bash
 # Compress mode (recommended) - extracts code structure only
-context-builder-helper.sh compress [path]
+~/.aidevops/agents/scripts/context-builder-helper.sh compress [path]
 
 # Full pack with smart defaults
-context-builder-helper.sh pack [path] [xml|markdown|json]
+~/.aidevops/agents/scripts/context-builder-helper.sh pack [path] [xml|markdown|json]
 
 # Quick mode - auto-copies to clipboard
-context-builder-helper.sh quick [path] [pattern]
+~/.aidevops/agents/scripts/context-builder-helper.sh quick [path] [pattern]
 
 # Analyze token usage per file
-context-builder-helper.sh analyze [path] [threshold]
+~/.aidevops/agents/scripts/context-builder-helper.sh analyze [path] [threshold]
 
 # Pack remote GitHub repo
-context-builder-helper.sh remote user/repo [branch]
+~/.aidevops/agents/scripts/context-builder-helper.sh remote user/repo [branch]
 
 # Compare full vs compressed
-context-builder-helper.sh compare [path]
+~/.aidevops/agents/scripts/context-builder-helper.sh compare [path]
 ```
 
 **Direct CLI Commands** (when helper unavailable):

--- a/.agents/tools/context/context-guardrails.md
+++ b/.agents/tools/context/context-guardrails.md
@@ -22,7 +22,7 @@ tools:
 | Repo Size (KB) | Est. Tokens | Action |
 |----------------|-------------|--------|
 | < 500 | < 50K | Safe for compressed pack |
-| 500-2000 | 50-200K | Use `includePatterns` only |
+| 500-2000 | 50-200K | Use `--include` patterns only |
 | > 2000 | > 200K | **NEVER full pack** - targeted files only |
 
 **Self-check before context-heavy operations**:
@@ -67,7 +67,7 @@ START
   |
   +-- < 500 KB --> Safe for compressed pack
   |
-  +-- 500KB-2MB --> Use includePatterns only
+  +-- 500KB-2MB --> Use --include patterns only
   |
   +-- > 2MB --> STOP - targeted files only
 ```
@@ -98,7 +98,7 @@ npx repomix@latest --remote https://github.com/small/repo --compress
 npx repomix@latest --remote https://github.com/large/repo --include "README.md,src/**/*.ts,docs/**" --compress
 
 # Or use helper script:
-context-builder-helper.sh remote large/repo main  # Auto-compresses
+~/.aidevops/agents/scripts/context-builder-helper.sh remote large/repo main  # Auto-compresses
 ```
 
 ### Searching packed output
@@ -143,7 +143,7 @@ If you hit "prompt is too long":
 
    ```text
    /remember FAILED_APPROACH: Attempted to pack {repo} without size check. 
-   Repo was {size}KB (~{tokens} tokens). Use includePatterns next time.
+   Repo was {size}KB (~{tokens} tokens). Use --include patterns next time.
    ```
 
 ## File Discovery Guardrails


### PR DESCRIPTION
## Summary

Addresses unactioned medium-priority review feedback from PR #197 (repomix MCP → CLI migration).

## Changes

- **`context-builder.md`**: Quick Reference commands now use full path `~/.aidevops/agents/scripts/context-builder-helper.sh` instead of bare `context-builder-helper.sh`. The bare name assumes the scripts dir is on `PATH`, which `setup.sh` does not configure — copy/paste users would hit "command not found" (Gemini + Augment findings).

- **`context-guardrails.md`**:
  - Same full-path fix for the helper script example in the `npx repomix --remote` section (Gemini finding, line 101).
  - Replace deprecated MCP parameter name `` `includePatterns` `` with CLI flag `` `--include` `` in three locations: size threshold table, flow diagram, and `/remember` template. The MCP is gone; keeping the old param name confuses readers about which flag to use (Augment finding, lines 25/70).

## Not actioned

- `aidevops-plugin.md` repomix reference (Augment finding): repomix is already absent from the plugin's MCP registry table — the merged PR already removed it. No change needed.

Closes #3589