### PR TITLE
t3600: Fix PR #1974 review feedback — portable sed and orphan metrics

### DIFF
--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -1401,7 +1401,10 @@ _exec_create_task() {
 			local escaped_task_id
 			# shellcheck disable=SC2016 # sed replacement pattern is intentionally literal
 			escaped_task_id=$(printf '%s' "$task_id" | sed 's/[.[\*^$()+?{|\\]/\\&/g')
-			sed -i '' "/^- \[ \] ${escaped_task_id} /d" "$todo_file" 2>/dev/null || true
+			# Use sed_inplace (portable macOS/Linux wrapper from shared-constants.sh).
+			# Match task ID followed by space or end-of-line to avoid prefix collisions
+			# (e.g. t1 matching t10). Error suppression removed per style guide.
+			sed_inplace "/^- \[ \] ${escaped_task_id}\([[:space:]]\|$\)/d" "$todo_file"
 		fi
 	fi
 

--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -2016,12 +2016,13 @@ cmd_reconcile_queue_dispatchability() {
 			# The next git pull removes the local-only line, leaving a DB-only
 			# task that can never be dispatched (dispatch requires TODO.md claim).
 			# Cancel these orphans to prevent permanent dispatch stall.
+			phantom_count=$((phantom_count + 1))
 			if [[ "$dry_run" == "true" ]]; then
 				log_warn "[dry-run] Phase 0.6: $tid queued in DB but not in TODO.md — would cancel (orphaned, t1261)"
 			else
 				log_warn "Phase 0.6: $tid queued in DB but not in TODO.md — cancelling orphan (t1261)"
 				db "$SUPERVISOR_DB" "UPDATE tasks SET status='cancelled', error='Orphaned: queued in DB but not found in TODO.md (t1261)' WHERE id='$(sql_escape "$tid")' AND status='queued';" || true
-				phantom_count=$((phantom_count + 1))
+				cancelled_count=$((cancelled_count + 1))
 			fi
 			continue
 		fi


### PR DESCRIPTION
## Summary

Addresses the two actionable findings from the Gemini and CodeRabbit reviews on PR #1974.

### Fix 1 — `ai-actions.sh`: portable `sed` + tighter regex

**File**: `.agents/scripts/supervisor-archived/ai-actions.sh` ~line 1404

The revert logic used `sed -i ''` (macOS/BSD only) with `2>/dev/null || true` (blanket error suppression). Both violate the project style guide.

Changes:
- Replace `sed -i '' ... 2>/dev/null || true` with `sed_inplace` (the portable wrapper defined in `shared-constants.sh`, already available via `_common.sh` sourcing chain)
- Tighten the deletion regex from `/${escaped_task_id} /d` to `/${escaped_task_id}\([[:space:]]\|$\)/d` — matches task ID followed by whitespace **or** end-of-line, preventing prefix collisions (e.g. `t1` matching `t10`)
- Remove `2>/dev/null || true` — errors now propagate as intended

### Fix 2 — `todo-sync.sh`: consistent orphan metrics in Phase 0.6

**File**: `.agents/scripts/supervisor-archived/todo-sync.sh` ~line 2011

The orphan detection block incremented `phantom_count` only in the real-run branch (after the DB UPDATE), and never incremented `cancelled_count`. This meant:
- Dry-run summary showed 0 orphans even when orphans were found
- Real-run summary showed orphan count but not cancellation count

Changes:
- Move `phantom_count` increment before the `if/else` so it fires in both dry-run and real-run
- Add `cancelled_count` increment in the real-run branch after the DB UPDATE

Closes #3600