### PR TITLE
t3573: clarify MD031 incorrect markdown example

### DIFF
--- a/.agents/tools/code-review/code-standards.md
+++ b/.agents/tools/code-review/code-standards.md
@@ -333,11 +333,13 @@ echo "hello"
 
 More text.
 
-<!-- INCORRECT - Missing blank line -->
+<!-- INCORRECT - Missing blank line before code block -->
 Some text.
 ```bash
 echo "hello"
 ```
+
+More text.
 ````
 
 **Validation**:


### PR DESCRIPTION
## Summary
- Clarifies the MD031 invalid example in `code-standards.md` by explicitly showing a missing blank line **before** a fenced code block.
- Adds trailing prose after the incorrect block so the example isolates one specific MD031 violation and is easier to interpret.

## Verification
- `npx markdownlint-cli2 ".agents/tools/code-review/code-standards.md"`
- `.agents/scripts/linters-local.sh` (shows existing repository-wide baseline issues unrelated to this change)

Closes #3573