### PR TITLE
t3575: clarify gh_grep documentation guidance

### DIFF
--- a/.agents/tools/context/mcp-discovery.md
+++ b/.agents/tools/context/mcp-discovery.md
@@ -73,7 +73,7 @@ npx mcporter call context7.resolve-library-id libraryName=react
 
 | MCP | Subagent | Notes |
 |-----|----------|-------|
-| `grep_app` / `gh_grep` | `@github-search` | CLI-based, zero tokens |
+| `grep_app` / `gh_grep` | `@github-search` | For GitHub code search (no MCP used) |
 
 **Primary search**: `rg`/`fd` (local, instant). Use `@augment-context-engine` for semantic search.
 


### PR DESCRIPTION
## Summary
- Clarifies the `gh_grep`/`grep_app` note in MCP discovery docs with user-facing wording
- Explicitly states that GitHub code search is provided via `@github-search` without MCP usage

## Verification
- `markdown-formatter check .agents/tools/context/mcp-discovery.md`

Closes #3575