### PR TITLE
t3576: address PR #281 maintainability feedback

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -546,14 +546,32 @@ EAGER_MCPS = set()
 # Lazy-loaded (enabled: False): Subagent-only, start on-demand
 # sentry/socket: Remote MCPs requiring auth, disable until configured
 # These save ~7K+ tokens on session startup
-LAZY_MCPS = {'claude-code-mcp', 'outscraper', 'dataforseo', 'shadcn', 'macos-automator', 
-             'gsc', 'localwp', 'chrome-devtools', 'quickfile', 'amazon-order-history', 
-             'google-analytics-mcp', 'MCP_DOCKER', 'ahrefs',
-             'playwriter', 'augment-context-engine', 'context7',
-             'sentry', 'socket', 'ios-simulator',
-             'openapi-search',
-             # Oh-My-OpenCode MCPs - disable globally, use @github-search/@context7 subagents
-             'grep_app', 'websearch', 'gh_grep'}
+LAZY_MCPS = {
+    'MCP_DOCKER',
+    'ahrefs',
+    'amazon-order-history',
+    'augment-context-engine',
+    'chrome-devtools',
+    'claude-code-mcp',
+    'context7',
+    'dataforseo',
+    'gh_grep',
+    'google-analytics-mcp',
+    # Oh-My-OpenCode MCPs - disable globally, use @github-search/@context7 subagents
+    'grep_app',
+    'gsc',
+    'ios-simulator',
+    'localwp',
+    'macos-automator',
+    'openapi-search',
+    'outscraper',
+    'playwriter',
+    'quickfile',
+    'sentry',
+    'shadcn',
+    'socket',
+    'websearch',
+}
 # Note: gh_grep removed from aidevops but may exist from old configs or OmO
 
 # Apply loading policy to existing MCPs and warn about uncategorized ones


### PR DESCRIPTION
## Summary
- Reformat `LAZY_MCPS` in `.agents/scripts/generate-opencode-agents.sh` into one-entry-per-line style.
- Alphabetize entries to make MCP membership easier to scan and update during future policy changes.
- Keep the existing lazy-loading policy and comments intact while resolving the outstanding Gemini review suggestion from PR #281.

## Verification
- `shellcheck .agents/scripts/generate-opencode-agents.sh` (SC1091 info only for sourced local helper)
- `aidevops_quality_check` on `.agents/scripts/generate-opencode-agents.sh` (reports one pre-existing positional-parameter finding at line 876)

Closes #3576