### PR TITLE
t3571: replace non-portable \b task-id matching in supervisor PR checks

### DIFF
--- a/.agents/scripts/migrate-pr-backfill.sh
+++ b/.agents/scripts/migrate-pr-backfill.sh
@@ -162,13 +162,13 @@ validate_pr_belongs_to_task() {
 	pr_title=$(echo "$pr_info" | jq -r '.title // ""' 2>/dev/null || echo "")
 	pr_branch=$(echo "$pr_info" | jq -r '.headRefName // ""' 2>/dev/null || echo "")
 
-	# Word boundary match: "t195" matches "feature/t195" but not "t1950"
-	if echo "$pr_title" | grep -qi "\b${task_id}\b" 2>/dev/null; then
+	# Portable ERE token boundary match: "t195" matches "feature/t195" but not "t1950"
+	if echo "$pr_title" | grep -Eqi "(^|[^[:alnum:]_])${task_id}([^[:alnum:]_]|$)" 2>/dev/null; then
 		echo "$pr_url"
 		return 0
 	fi
 
-	if echo "$pr_branch" | grep -qi "\b${task_id}\b" 2>/dev/null; then
+	if echo "$pr_branch" | grep -Eqi "(^|[^[:alnum:]_])${task_id}([^[:alnum:]_]|$)" 2>/dev/null; then
 		echo "$pr_url"
 		return 0
 	fi

--- a/.agents/scripts/supervisor-archived/evaluate.sh
+++ b/.agents/scripts/supervisor-archived/evaluate.sh
@@ -230,14 +230,14 @@ validate_pr_belongs_to_task() {
 	pr_branch=$(echo "$pr_info" | jq -r '.headRefName // ""' 2>/dev/null || echo "")
 
 	# Check if task ID appears in title or branch (case-insensitive).
-	# Uses word boundary \b so "t195" matches "feature/t195", "(t195)",
+	# Use portable ERE token boundaries so "t195" matches "feature/t195", "(t195)",
 	# "t195-fix-auth" but NOT "t1950" or "t1195".
-	if echo "$pr_title" | grep -qi "\b${task_id}\b" 2>/dev/null; then
+	if echo "$pr_title" | grep -Eqi "(^|[^[:alnum:]_])${task_id}([^[:alnum:]_]|$)" 2>/dev/null; then
 		echo "$pr_url"
 		return 0
 	fi
 
-	if echo "$pr_branch" | grep -qi "\b${task_id}\b" 2>/dev/null; then
+	if echo "$pr_branch" | grep -Eqi "(^|[^[:alnum:]_])${task_id}([^[:alnum:]_]|$)" 2>/dev/null; then
 		echo "$pr_url"
 		return 0
 	fi


### PR DESCRIPTION
## Summary
- replace non-portable `grep -qi "\\b${task_id}\\b"` checks with portable extended-regex token-boundary matching in supervisor PR ownership validation
- apply the same fix in the migration backfill script so historical and live paths use consistent task-id matching behavior
- preserve existing behavior (`echo \"$pr_url\"` + `return 0`) while avoiding false positives like `t1950`

Closes #3571