### PR TITLE
fix(t3529): refactor build_curl_args to accept protocol param, add SSL warning

### DIFF
--- a/.agents/scripts/cron-dispatch.sh
+++ b/.agents/scripts/cron-dispatch.sh
@@ -78,9 +78,12 @@ log_success() {
 
 #######################################
 # Build curl arguments array for secure requests
+# Arguments:
+#   $1 - protocol (http|https), already resolved by caller
 # Populates CURL_ARGS array with auth and SSL options
 #######################################
 build_curl_args() {
+	local protocol="${1:-http}"
 	CURL_ARGS=(-sf)
 
 	# Add authentication if configured
@@ -90,12 +93,10 @@ build_curl_args() {
 	fi
 
 	# Add SSL options for HTTPS
-	local protocol
-	protocol=$(get_protocol "$OPENCODE_HOST")
 	if [[ "$protocol" == "https" ]] && [[ -n "$OPENCODE_INSECURE" ]]; then
 		# Allow insecure connections (self-signed certs) - use with caution
 		CURL_ARGS+=(-k)
-		log_info "WARNING: SSL verification disabled (OPENCODE_INSECURE=1)"
+		log_warn "WARNING: SSL verification disabled (OPENCODE_INSECURE=1)"
 	fi
 	return 0
 }
@@ -108,7 +109,7 @@ check_server() {
 	protocol=$(get_protocol "$OPENCODE_HOST")
 	local url="${protocol}://${OPENCODE_HOST}:${OPENCODE_PORT}/global/health"
 
-	build_curl_args
+	build_curl_args "$protocol"
 
 	if curl "${CURL_ARGS[@]}" "$url" &>/dev/null; then
 		return 0
@@ -158,7 +159,7 @@ create_session() {
 	protocol=$(get_protocol "$OPENCODE_HOST")
 	local url="${protocol}://${OPENCODE_HOST}:${OPENCODE_PORT}/session"
 
-	build_curl_args
+	build_curl_args "$protocol"
 
 	curl "${CURL_ARGS[@]}" -X POST "$url" \
 		-H "Content-Type: application/json" \
@@ -198,7 +199,7 @@ send_prompt() {
             parts: [{type: "text", text: $task}]
         }')
 
-	build_curl_args
+	build_curl_args "$protocol"
 
 	# Send with timeout
 	timeout "$cmd_timeout" curl "${CURL_ARGS[@]}" -X POST "$url" \
@@ -217,7 +218,7 @@ delete_session() {
 	protocol=$(get_protocol "$OPENCODE_HOST")
 	local url="${protocol}://${OPENCODE_HOST}:${OPENCODE_PORT}/session/${session_id}"
 
-	build_curl_args
+	build_curl_args "$protocol"
 
 	curl "${CURL_ARGS[@]}" -X DELETE "$url" &>/dev/null || true
 	return 0

--- a/.agents/scripts/cron-helper.sh
+++ b/.agents/scripts/cron-helper.sh
@@ -47,17 +47,17 @@ LOG_PREFIX="CRON"
 # Ensure directories and config exist
 #######################################
 ensure_setup() {
-    mkdir -p "$CONFIG_DIR" "$CRON_LOG_DIR"
+	mkdir -p "$CONFIG_DIR" "$CRON_LOG_DIR"
 
-    if [[ ! -f "$CONFIG_FILE" ]]; then
-        cat > "$CONFIG_FILE" << 'EOF'
+	if [[ ! -f "$CONFIG_FILE" ]]; then
+		cat >"$CONFIG_FILE" <<'EOF'
 {
   "version": "1.0",
   "jobs": []
 }
 EOF
-        log_info "Created config file: $CONFIG_FILE"
-    fi
+		log_info "Created config file: $CONFIG_FILE"
+	fi
 }
 
 #######################################
@@ -96,8 +96,12 @@ get_protocol() {
 
 #######################################
 # Build curl arguments array for secure requests
+# Arguments:
+#   $1 - protocol (http|https), already resolved by caller
+# Populates CURL_ARGS array with auth and SSL options
 #######################################
 build_curl_args() {
+	local protocol="${1:-http}"
 	CURL_ARGS=(-sf)
 
 	# Add authentication if configured
@@ -107,12 +111,12 @@ build_curl_args() {
 	fi
 
 	# Add SSL options for HTTPS
-	local protocol
-	protocol=$(get_protocol "$OPENCODE_HOST")
 	if [[ "$protocol" == "https" ]] && [[ -n "$OPENCODE_INSECURE" ]]; then
 		# Allow insecure connections (self-signed certs) - use with caution
 		CURL_ARGS+=(-k)
+		log_warn "WARNING: SSL verification disabled (OPENCODE_INSECURE=1)"
 	fi
+	return 0
 }
 
 #######################################
@@ -123,7 +127,7 @@ check_server() {
 	protocol=$(get_protocol "$OPENCODE_HOST")
 	local url="${protocol}://${OPENCODE_HOST}:${OPENCODE_PORT}/global/health"
 
-	build_curl_args
+	build_curl_args "$protocol"
 
 	if curl "${CURL_ARGS[@]}" "$url" &>/dev/null; then
 		return 0


### PR DESCRIPTION
## Summary

Addresses gemini review feedback from PR #305 (merged).

- **Eliminate redundant `get_protocol()` calls**: `build_curl_args()` in both `cron-dispatch.sh` and `cron-helper.sh` previously called `get_protocol()` internally, even though every caller had already computed `protocol` to construct the URL. Refactored to accept `protocol` as a parameter — callers pass their already-resolved value, removing the duplicate subshell fork.
- **Add SSL warning in `cron-helper.sh`**: When `OPENCODE_INSECURE=1` is set, `cron-helper.sh` now emits `log_warn "WARNING: SSL verification disabled (OPENCODE_INSECURE=1)"` to match the existing behaviour in `cron-dispatch.sh`. Operators get consistent visibility of insecure mode across both scripts.
- **Fix log level in `cron-dispatch.sh`**: The SSL warning was previously emitted via `log_info` (stdout); changed to `log_warn` (stderr) for correct severity routing.

## Files changed (2 of 5 max)

| File | Change |
|------|--------|
| `.agents/scripts/cron-dispatch.sh` | `build_curl_args` accepts `protocol` param; all 4 callers pass it; SSL warning uses `log_warn` |
| `.agents/scripts/cron-helper.sh` | Same param refactor; add `log_warn` on insecure SSL; add `return 0` |

## Verification

- `shellcheck -S warning` on both files: **0 violations**
- Logic unchanged — callers already computed `protocol` before calling `build_curl_args`; the parameter just threads the value through instead of recomputing it

Closes #3529