### PR TITLE
t3445: docs(remote-dispatch): address PR #2109 review feedback

### DIFF
--- a/.agents/tools/containers/remote-dispatch.md
+++ b/.agents/tools/containers/remote-dispatch.md
@@ -140,8 +140,10 @@ The remote dispatch system forwards credentials to remote workers:
 **Security notes**:
 
 - SSH agent forwarding (`-A`) passes the local SSH agent socket, not the keys themselves
-- API keys are passed as environment variables to the remote command
-- Keys are NOT written to disk on the remote host
+- API keys are embedded as `export KEY=VALUE` lines in a shell script uploaded via SSH stdin piping — this does NOT rely on `AcceptEnv`/`SendEnv` SSH config, so env propagation cannot silently fail due to SSH server settings
+- Keys are NOT written to disk on the remote host as standalone files; they exist only within the generated dispatch script in the remote workspace
+- On Linux, environment variables of a running process are readable from `/proc/<pid>/environ` by the same user and by root — keys are not on disk but can still be read by processes with appropriate privileges while the worker is running
+- For security-conscious deployments, consider restricting remote host access to trusted users only, or use short-lived credentials (e.g., scoped tokens) that can be rotated after the task completes
 - The remote workspace is cleaned up after task completion
 
 ## Log Collection
@@ -256,10 +258,13 @@ tailscale ping hostname
 The remote host needs `opencode` or `claude` CLI installed. Install via:
 
 ```bash
-# On the remote host
-npm install -g @anthropic-ai/claude-code
+# opencode (preferred)
+npm install -g opencode-ai
 # or
 curl -fsSL https://opencode.ai/install | bash
+
+# claude CLI (alternative)
+npm install -g @anthropic-ai/claude-code
 ```
 
 ### Logs Not Collected


### PR DESCRIPTION
## Summary

Addresses the two medium-severity CodeRabbit findings from PR #2109 on `.agents/tools/containers/remote-dispatch.md`.

### Finding 1 — `/proc/<pid>/environ` exposure (line 140)

- Clarified the actual credential transport mechanism: API keys are embedded as `export KEY=VALUE` lines in a shell script uploaded via SSH stdin piping — **not** via `AcceptEnv`/`SendEnv`, so SSH server env config cannot cause silent failures
- Added explicit note that on Linux, env vars of a running process are readable from `/proc/<pid>/environ` by the same user and root
- Added mitigation guidance for security-conscious deployments (restrict host access, use short-lived/scoped tokens)

### Finding 2 — npm package name (line 262)

- Added `npm install -g opencode-ai` as the preferred install option for opencode
- Retained `npm install -g @anthropic-ai/claude-code` as the alternative for the claude CLI
- Both packages verified to exist on npm (opencode-ai@1.2.26, @anthropic-ai/claude-code@2.1.76)

Closes #3445