### PR TITLE
t3528: address PR #317 review feedback (node-helpers.md + FTS5 probe)

### DIFF
--- a/.agents/scripts/onboarding-helper.sh
+++ b/.agents/scripts/onboarding-helper.sh
@@ -334,9 +334,13 @@ check_context_tools() {
 	# Context7 is MCP-only, no auth needed
 	print_service "Context7" "ready" "MCP (no auth needed)"
 
-	# sqlite3 is required for memory system
+	# sqlite3 is required for memory system (FTS5 required for full-text search)
 	if is_installed "sqlite3"; then
-		print_service "sqlite3" "ready" "memory system ready"
+		if sqlite3 :memory: 'CREATE VIRTUAL TABLE t USING fts5(content);' &>/dev/null; then
+			print_service "sqlite3" "ready" "memory system ready"
+		else
+			print_service "sqlite3" "partial" "installed, missing FTS5 (required for memory)"
+		fi
 	else
 		print_service "sqlite3" "needs-setup" "required for memory system"
 	fi
@@ -1123,9 +1127,15 @@ output_json() {
 	is_installed "auggie" && json+='true' || json+='false'
 	json+=',"authenticated":'
 	is_cli_authenticated "auggie" && json+='true' || json+='false'
-	json+='},"sqlite3":{"installed":'
-	is_installed "sqlite3" && json+='true' || json+='false'
-	json+='}},'
+	local _sqlite3_installed=false _sqlite3_fts5=false
+	if is_installed "sqlite3"; then
+		_sqlite3_installed=true
+		sqlite3 :memory: 'CREATE VIRTUAL TABLE t USING fts5(content);' &>/dev/null && _sqlite3_fts5=true
+	fi
+	json+="},"
+	json+="$(jq -n --argjson inst "$_sqlite3_installed" --argjson fts5 "$_sqlite3_fts5" \
+		'"sqlite3":{"installed":$inst,"fts5":$fts5}')"
+	json+='},'
 
 	# Containers
 	json+='"containers":{'

--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -501,14 +501,8 @@ Where agents reference `npm` or `npx`, consider if `bun` would be faster:
 - Prefer `bunx` over `npx` for one-off executions
 
 **Node.js-based helper scripts:**
-If your helper script uses `node -e` with globally installed npm packages, add this near the top:
-
-```bash
-# Set NODE_PATH so Node.js can find globally installed modules
-export NODE_PATH="$(npm root -g):$NODE_PATH"
-```
-
-This is required because Node.js doesn't automatically search the global npm prefix when using inline evaluation (`node -e`).
+If your helper script uses `node -e` with globally installed npm packages, set `NODE_PATH` near the top of the script.
+See `tools/build-agent/node-helpers.md:13` for the snippet and explanation.
 
 ### Information Quality (All Domains)
 

--- a/.agents/tools/build-agent/node-helpers.md
+++ b/.agents/tools/build-agent/node-helpers.md
@@ -1,0 +1,30 @@
+# Node.js Helper Script Patterns
+
+Reference for common patterns used in Node.js-based helper scripts.
+
+## NODE_PATH for globally installed npm packages
+
+When a helper script uses `node -e` with globally installed npm packages, Node.js
+does not automatically search the global npm prefix for inline evaluation. Set
+`NODE_PATH` near the top of the script so CommonJS `require()` can resolve global
+modules:
+
+```bash
+# Set NODE_PATH so Node.js can find globally installed modules
+export NODE_PATH="$(npm root -g):$NODE_PATH"
+```
+
+This is required because `node -e` evaluates code in CommonJS mode, and without
+`NODE_PATH` pointing at the global prefix, `require('some-global-package')` will
+fail with `MODULE_NOT_FOUND` even when the package is installed globally.
+
+> **Note:** `NODE_PATH` only affects CommonJS `require()`. ESM `import` specifiers
+> are not resolved via `NODE_PATH` — use explicit paths or local installs for ESM.
+
+## Prefer bun for performance
+
+Where scripts reference `npm` or `npx`, consider `bun` for faster execution:
+
+- `bun` is significantly faster for package operations
+- Compatible with most npm packages
+- Prefer `bunx` over `npx` for one-off executions


### PR DESCRIPTION
## Summary

Addresses quality-debt issue #3528 — unactioned review feedback from merged PR #317.

### Changes

1. **`node-helpers.md` (new file)** — Extracts the inline `NODE_PATH` snippet from `build-agent.md` into a dedicated helper doc at `.agents/tools/build-agent/node-helpers.md`. Includes the export snippet, explanation of why it's needed for `node -e`, and a note about ESM limitations.

2. **`build-agent.md`** — Replaces the 6-line inline code block with a single `file:line` reference to `node-helpers.md:13`, following the progressive-disclosure pattern required by the agent design guidelines.

3. **`onboarding-helper.sh`** — Adds an FTS5 capability probe to the sqlite3 status check. A system with `sqlite3` installed but without FTS5 support now reports `partial` (not `ready`), since FTS5 is a hard requirement for the memory system. The JSON output gains a `fts5` boolean field, constructed via `jq` for type-safe boolean handling (addresses Gemini's JSON robustness feedback).

### Files touched (3 of 5 max)

- `.agents/tools/build-agent/node-helpers.md` (new)
- `.agents/tools/build-agent/build-agent.md` (modified)
- `.agents/scripts/onboarding-helper.sh` (modified)

### Verification

- `shellcheck .agents/scripts/onboarding-helper.sh` — only pre-existing SC1091 info
- `markdownlint-cli2` on both markdown files — 0 errors

Closes #3528