### PR TITLE
t3564: fix jq stderr suppression in dismiss_bot_reviews

### DIFF
--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -1488,7 +1488,7 @@ dismiss_bot_reviews() {
 
 	# Find bot reviews with CHANGES_REQUESTED state
 	local bot_reviews
-	bot_reviews=$(echo "$reviews_json" | jq -r '.[] | select(.state == "CHANGES_REQUESTED" and (.user.login | test("^(coderabbitai|gemini-code-assist|copilot)"))) | .id' 2>/dev/null || echo "")
+	bot_reviews=$(echo "$reviews_json" | jq -r '.[] | select(.state == "CHANGES_REQUESTED" and (.user.login | test("^(coderabbitai|gemini-code-assist|copilot)"))) | .id' 2>>"${SUPERVISOR_LOG:-/dev/null}" || echo "")
 
 	if [[ -z "$bot_reviews" ]]; then
 		log_debug "dismiss_bot_reviews: no blocking bot reviews found for PR #${pr_number}"
@@ -1706,7 +1706,7 @@ check_pr_status() {
 
 	# Check review status
 	local review_decision
-	review_decision=$(echo "$pr_json" | jq -r '.reviewDecision // "NONE"' 2>/dev/null || echo "NONE")
+	review_decision=$(echo "$pr_json" | jq -r '.reviewDecision // "NONE"' 2>>"${SUPERVISOR_LOG:-/dev/null}" || echo "NONE")
 
 	if [[ "$review_decision" == "CHANGES_REQUESTED" ]]; then
 		# t226: Try to auto-dismiss bot reviews before declaring changes_requested
@@ -1715,7 +1715,7 @@ check_pr_status() {
 			# Re-fetch PR status after dismissal
 			log_info "Re-checking PR #${pr_number} status after dismissing bot reviews"
 			pr_json=$(gh pr view "$pr_number" --repo "$repo_slug" --json state,isDraft,reviewDecision,statusCheckRollup 2>>"$SUPERVISOR_LOG" || echo "")
-			review_decision=$(echo "$pr_json" | jq -r '.reviewDecision // "NONE"' 2>/dev/null || echo "NONE")
+			review_decision=$(echo "$pr_json" | jq -r '.reviewDecision // "NONE"' 2>>"${SUPERVISOR_LOG:-/dev/null}" || echo "NONE")
 
 			# If still CHANGES_REQUESTED after dismissal, there are human reviews blocking
 			if [[ "$review_decision" == "CHANGES_REQUESTED" ]]; then


### PR DESCRIPTION
## Summary

- Replace `2>/dev/null` with `2>>"${SUPERVISOR_LOG:-/dev/null}"` on three `jq` commands in `supervisor-archived/deploy.sh`
- Affects `dismiss_bot_reviews()` (line 1491) and `check_pr_status()` (lines 1709, 1718)
- Aligns with the repo style guide: `2>/dev/null` is not acceptable for blanket stderr suppression; errors should be redirected to the log file

## Motivation

Gemini Code Assist flagged this in PR #952 review. Silently discarding `jq` stderr means malformed JSON from `gh api` calls goes undetected. Redirecting to `$SUPERVISOR_LOG` preserves debuggability while keeping the same fallback behaviour (`|| echo ""`).

The `${SUPERVISOR_LOG:-/dev/null}` pattern is already used elsewhere in `deploy.sh` (lines 323, 330, 353) — this change makes the three affected lines consistent with the rest of the file.

## Verification

- ShellCheck: zero violations
- No logic change — only stderr destination changes

Closes #3564