### PR TITLE
fix: align merge-conflict error token with retry filter (GH#3524)

### DIFF
--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -427,7 +427,7 @@ cmd_pr_lifecycle() {
 						# Rebase failed (conflicts or other error)
 						log_warn "Auto-rebase failed for $task_id — transitioning to blocked:merge_conflict"
 						if [[ "$dry_run" == "false" ]]; then
-							cmd_transition "$task_id" "blocked" --error "Merge conflict — auto-rebase failed" 2>>"$SUPERVISOR_LOG" || true
+							cmd_transition "$task_id" "blocked" --error "merge_conflict:auto_rebase_failed" 2>>"$SUPERVISOR_LOG" || true
 							send_task_notification "$task_id" "blocked" "PR has merge conflicts that require manual resolution" 2>>"$SUPERVISOR_LOG" || true
 						fi
 						return 1


### PR DESCRIPTION
## Summary

Addresses quality-debt review feedback from PR #1203 (CodeRabbit finding).

### Fix 1: Merge-conflict error token alignment

**File**: `.agents/scripts/supervisor-archived/deploy.sh:430`

Changed the error string on auto-rebase failure from:
```
"Merge conflict — auto-rebase failed"
```
to:
```
"merge_conflict:auto_rebase_failed"
```

**Why**: `evaluate.sh:718` and `dispatch.sh:673` both match on the literal token `merge_conflict` (via `case` statement). The old human-readable string did not contain this token, so tasks blocked by auto-rebase failure were silently excluded from the retry filter — they would stay `blocked` indefinitely instead of being picked up for retry.

### Fix 2: git add before diff --check

**Status**: Already present in `deploy.sh` — `git add` at line 2248 precedes `diff --check` at line 2251. This was correctly implemented during the supervisor refactor (PR #2291). No change needed.

## Verification

- ShellCheck: zero violations on modified file
- Token `merge_conflict:auto_rebase_failed` contains `merge_conflict` substring, matching the case patterns in `evaluate.sh:718` and `dispatch.sh:673`

Closes #3524