### PR TITLE
t3522: chore(version-manager): extract badge patterns into local variables

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -774,13 +774,15 @@ update_version_in_files() {
 	fi
 
 	# Update README version badge (skip if using dynamic GitHub release badge)
+	local dynamic_badge_pattern="img.shields.io/github/v/release"
+	local hardcoded_badge_pattern="Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue"
 	if [[ -f "$REPO_ROOT/README.md" ]]; then
-		if grep -q "img.shields.io/github/v/release" "$REPO_ROOT/README.md"; then
+		if grep -q "$dynamic_badge_pattern" "$REPO_ROOT/README.md"; then
 			# Dynamic badge - no update needed, GitHub handles it automatically
 			print_success "README.md uses dynamic GitHub release badge (no update needed)" >&2
-		elif grep -q "Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue" "$REPO_ROOT/README.md"; then
+		elif grep -q "$hardcoded_badge_pattern" "$REPO_ROOT/README.md"; then
 			# Hardcoded badge - update it
-			sed_inplace "s/Version-[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*-blue/Version-$new_version-blue/" "$REPO_ROOT/README.md"
+			sed_inplace "s/$hardcoded_badge_pattern/Version-$new_version-blue/" "$REPO_ROOT/README.md"
 
 			# Validate the update was successful
 			if grep -q "Version-$new_version-blue" "$REPO_ROOT/README.md"; then


### PR DESCRIPTION
## Summary

- Extracts the two README badge grep patterns (`img.shields.io/github/v/release` and `Version-[0-9]...-blue`) into named local variables in `update_version_in_files()`
- Eliminates pattern string duplication between the `grep -q` and `sed_inplace` calls
- No behaviour change — purely a maintainability improvement

## Motivation

Addresses the medium-severity suggestion from Gemini Code Assist on PR #134 (review comment [#2710706932](https://github.com/marcusquinn/aidevops/pull/134#discussion_r2710706932)): using variables for badge patterns makes the code easier to read and update if the patterns change in future.

## Verification

- `shellcheck .agents/scripts/version-manager.sh` — zero violations

Closes #3522

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version management script with improved badge detection in documentation, now emits warnings when badges cannot be automatically found instead of silently proceeding—providing clearer feedback on version update operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->