### PR TITLE
t3519: refactor(dispatch): consolidate pro tier into sonnet case statement

### DIFF
--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -243,14 +243,11 @@ resolve_model() {
 	opus | coding)
 		echo "anthropic/claude-opus-4-6"
 		;;
-	sonnet | eval | health)
+	sonnet | eval | health | pro)
 		echo "anthropic/claude-sonnet-4-6"
 		;;
 	haiku | flash)
 		echo "anthropic/claude-haiku-4-5"
-		;;
-	pro)
-		echo "anthropic/claude-sonnet-4-6"
 		;;
 	*)
 		# Unknown tier — treat as coding tier default


### PR DESCRIPTION
## Summary

- Merges the redundant `pro` case into `sonnet | eval | health | pro` in `resolve_model()` since both resolved to `anthropic/claude-sonnet-4-6`
- Removes 4 lines of duplication, improving maintainability
- No behaviour change — `pro` tier still resolves to `anthropic/claude-sonnet-4-6`

## Motivation

Gemini Code Assist flagged this in PR #799 review: the `pro` case was a separate branch returning the same model as `sonnet | eval | health`. Consolidating them makes the intent explicit and reduces the risk of future drift where `pro` accidentally gets a different value.

Closes #3519