### PR TITLE
t3510: fix grep-count zero-match handling in setup modules

### DIFF
--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -512,7 +512,7 @@ setup_multi_tenant_credentials() {
 	# Check if there are existing credentials to migrate
 	if [[ -f "$HOME/.config/aidevops/credentials.sh" ]]; then
 		local key_count
-		key_count=$(grep -c "^export " "$HOME/.config/aidevops/credentials.sh" 2>/dev/null || echo "0")
+		key_count=$(grep -c "^export " "$HOME/.config/aidevops/credentials.sh" 2>/dev/null) || true
 		print_info "Found $key_count existing API keys in credentials.sh"
 		print_info "Multi-tenant enables managing separate credential sets for:"
 		echo "  - Multiple clients (agency/freelance work)"

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -866,8 +866,8 @@ setup_terminal_title() {
 	local tabby_config="$HOME/Library/Application Support/tabby/config.yaml"
 	if [[ -f "$tabby_config" ]]; then
 		local disabled_count
-		disabled_count=$(grep -c "disableDynamicTitle: true" "$tabby_config" || echo "0")
-		if [[ "$disabled_count" -gt 0 ]]; then
+		disabled_count=$(grep -c "disableDynamicTitle: true" "$tabby_config") || true
+		if [[ "${disabled_count:-0}" -gt 0 ]]; then
 			echo "  Tabby: detected, dynamic titles disabled in $disabled_count profile(s) (will fix)"
 		else
 			echo "  Tabby: detected, dynamic titles enabled"


### PR DESCRIPTION
## Summary
- Fix two `grep -c ... || echo \"0\"` call sites that can emit `0\n0` under `set -euo pipefail` when no matches are found.
- Apply the same safer pattern used elsewhere: run `grep -c` with `|| true` and guard numeric checks with `${var:-0}` where needed.
- Keep behavior unchanged while preventing non-numeric arithmetic comparisons and inconsistent status output.

Closes #3510