### PR TITLE
#3492: Restore Sentry MCP config context and token troubleshooting note

### DIFF
--- a/.agents/services/monitoring/sentry.md
+++ b/.agents/services/monitoring/sentry.md
@@ -64,6 +64,20 @@ chmod 600 ~/.config/aidevops/credentials.sh
 
 ### 3. Configure OpenCode MCP
 
+`~/.config/opencode/opencode.json` should contain an `mcpServers` object similar to:
+
+```json
+{
+  "mcpServers": {
+    "sentry": {
+      "command": "npx",
+      "args": ["@sentry/mcp-server@latest", "--access-token", "${SENTRY_YOURNAME}"],
+      "enabled": true
+    }
+  }
+}
+```
+
 ```bash
 source ~/.config/aidevops/credentials.sh
 tmp_json="$(mktemp)"
@@ -119,7 +133,7 @@ If you manually configure SDK options, keep `sendDefaultPii` disabled unless you
 
 ### Token returns empty organizations
 
-Create a new Personal Auth Token **after** the organization exists.
+Create a new Personal Auth Token **after** the organization exists. Tokens created before the org don't inherit access.
 
 ### "Not authenticated"
 


### PR DESCRIPTION
## Summary
- Re-add an explicit `opencode.json` `mcpServers.sentry` example so the Step 3 `jq` command has clear expected structure.
- Restore the troubleshooting rationale that tokens created before org creation do not inherit org access.
- Keep the document slim while reducing setup ambiguity flagged in PR #285 review feedback.

Closes #3492