### PR TITLE
t3517: convert status label lists to bash arrays

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -138,11 +138,19 @@ ensure_labels_exist() {
 	IFS="$_saved_ifs"
 }
 
+# Status labels to remove when marking an issue done (t3517: array for safe iteration).
+_DONE_REMOVE_LABELS=("status:available" "status:queued" "status:claimed" "status:in-review" "status:blocked" "status:verify-failed")
+
 _mark_issue_done() {
 	local repo="$1" num="$2"
+	local -a remove_args=()
+	local lbl
+	for lbl in "${_DONE_REMOVE_LABELS[@]}"; do
+		remove_args+=("--remove-label" "$lbl")
+	done
 	gh_create_label "$repo" "status:done" "6F42C1" "Task is complete"
 	_gh_edit_labels "add" "$repo" "$num" "status:done"
-	_gh_edit_labels "remove" "$repo" "$num" "status:available,status:queued,status:claimed,status:in-review,status:blocked,status:verify-failed"
+	[[ ${#remove_args[@]} -gt 0 ]] && gh issue edit "$num" --repo "$repo" "${remove_args[@]}" 2>/dev/null || true
 }
 
 # =============================================================================

--- a/.agents/scripts/supervisor-archived/issue-sync.sh
+++ b/.agents/scripts/supervisor-archived/issue-sync.sh
@@ -342,8 +342,9 @@ state_to_status_label() {
 # All status labels that can be set on an issue (t1009)
 # Used to remove stale labels before applying the new one.
 # Restored from pre-modularisation supervisor-helper.sh (t1035).
+# Defined as a bash array for safe iteration without IFS/word-splitting (t3517).
 #######################################
-ALL_STATUS_LABELS="status:available,status:queued,status:claimed,status:in-review,status:blocked,status:verify-failed,status:needs-testing,status:done"
+ALL_STATUS_LABELS=("status:available" "status:queued" "status:claimed" "status:in-review" "status:blocked" "status:verify-failed" "status:needs-testing" "status:done")
 
 #######################################
 # Sync GitHub issue status label on state transition (t1009)
@@ -402,13 +403,11 @@ sync_issue_status_label() {
 	# Build remove args for all status labels except the new one
 	local -a remove_args=()
 	local label
-	while IFS=',' read -ra labels; do
-		for label in "${labels[@]}"; do
-			if [[ "$label" != "$new_label" ]]; then
-				remove_args+=("--remove-label" "$label")
-			fi
-		done
-	done <<<"$ALL_STATUS_LABELS"
+	for label in "${ALL_STATUS_LABELS[@]}"; do
+		if [[ "$label" != "$new_label" ]]; then
+			remove_args+=("--remove-label" "$label")
+		fi
+	done
 
 	# Handle terminal states that close the issue
 	case "$new_state" in


### PR DESCRIPTION
## Summary

- Converts `ALL_STATUS_LABELS` in `supervisor-archived/issue-sync.sh` from a comma-separated string to a bash array, eliminating the `while IFS=',' read -ra` here-string loop
- Adds `_DONE_REMOVE_LABELS` array constant in `issue-sync-helper.sh` and updates `_mark_issue_done()` to iterate it directly with `gh issue edit` args, removing the comma-separated string passed to `_gh_edit_labels`

## Motivation

Addresses Gemini code review feedback on PR #1375 (comment on line 343 of `supervisor-archived/issue-sync.sh`). Bash arrays are safer than comma-separated strings: no IFS manipulation, no word-splitting risk, and cleaner iteration.

## Verification

- ShellCheck: zero new violations on both files
- Logic unchanged: same labels, same filtering behaviour, same `gh issue edit` call structure

Closes #3517