### PR TITLE
t3504: resolve PR #1219 quality-debt comment mismatch

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2271,8 +2271,8 @@ cmd_pulse() {
 	# t1196: Per-task-type hang timeout via get_task_timeout() — replaces single global value.
 	# Absolute max runtime: kill workers regardless of log activity.
 	# Prevents runaway workers (e.g., shellcheck on huge files) from accumulating
-	# and exhausting system memory. Default 4 hours.
-	local worker_max_runtime_seconds="${SUPERVISOR_WORKER_MAX_RUNTIME:-14400}" # 4 hour default (t314: restored after merge overwrite)
+	# and exhausting system memory. Default 4 hours (14400s).
+	local worker_max_runtime_seconds="${SUPERVISOR_WORKER_MAX_RUNTIME:-14400}" # Default 4 hours (t314: restored after merge overwrite)
 
 	if [[ -d "$SUPERVISOR_DIR/pids" ]]; then
 		for pid_file in "$SUPERVISOR_DIR/pids"/*.pid; do


### PR DESCRIPTION
## Summary
- Clarify the worker max runtime comment to explicitly document the 4-hour (14400s) default in the worker health-check section.
- Normalize inline wording so the assignment comment and surrounding context both state the same 4-hour default.

## Verification
- Ran `aidevops_quality_check` on `.agents/scripts/supervisor-archived/pulse.sh`.
- Confirmed only comment-text changes are present in the diff.

Closes #3504