### PR TITLE
fix(auto-update): detect script drift when VERSION matches to prevent stale pulse (GH#4727)

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -1073,6 +1073,28 @@ cmd_check() {
 			else
 				log_error "setup.sh failed during stale-agent re-deploy (exit code: $?)"
 			fi
+		else
+			# VERSION matches but scripts may still differ — a script fix merged without
+			# a version bump leaves the deployed copy stale until setup.sh is run manually.
+			# Detect this by comparing SHA-256 of a sentinel script that is frequently
+			# patched (gh-failure-miner-helper.sh). If it drifts, re-deploy all agents.
+			# GH#4727: Codacy not_collected false-positive recurred because the fix in
+			# PR #4704 was not deployed to ~/.aidevops/ before the next pulse cycle.
+			local sentinel_repo="$INSTALL_DIR/.agents/scripts/gh-failure-miner-helper.sh"
+			local sentinel_deployed="$HOME/.aidevops/agents/scripts/gh-failure-miner-helper.sh"
+			if [[ -f "$sentinel_repo" && -f "$sentinel_deployed" ]]; then
+				local hash_repo hash_deployed
+				hash_repo=$(sha256sum "$sentinel_repo" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$sentinel_repo" 2>/dev/null | awk '{print $1}' || echo "")
+				hash_deployed=$(sha256sum "$sentinel_deployed" 2>/dev/null | awk '{print $1}' || shasum -a 256 "$sentinel_deployed" 2>/dev/null | awk '{print $1}' || echo "")
+				if [[ -n "$hash_repo" && -n "$hash_deployed" && "$hash_repo" != "$hash_deployed" ]]; then
+					log_warn "Script drift detected (sentinel hash mismatch at v$current) — re-deploying agents..."
+					if bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1; then
+						log_info "Agents re-deployed after script drift (v$current)"
+					else
+						log_error "setup.sh failed during script-drift re-deploy (exit code: $?)"
+					fi
+				fi
+			fi
 		fi
 
 		run_freshness_checks


### PR DESCRIPTION
## Summary

- Adds a sentinel-based script drift check to `auto-update-helper.sh` that detects when deployed scripts differ from the repo even when VERSION matches
- Prevents the \"fix merged but not deployed\" gap that caused Codacy false-positive issues to recur

## Root Cause (GH#4727)

The Codacy `not_collected` false-positive issue recurred despite being fixed in PR #4704 because:

1. PR #4704 fixed `gh-failure-miner-helper.sh` (merged 07:43 today)
2. `setup.sh` was not run after the merge — no auto-deploy on merge
3. The pulse ran at 08:40 using the **old deployed version** from `~/.aidevops/`
4. The old script still treated Codacy `ACTION_REQUIRED` as a CI failure
5. The pulse LLM saw the systemic cluster and created duplicate issue #4727

The existing stale check only compared `VERSION` files. Since the fix in PR #4704 was a script change without a version bump, the stale check did not trigger.

## Fix

Added an `else` branch to the existing VERSION stale check that:
- Compares SHA-256 of `gh-failure-miner-helper.sh` between repo and deployed
- If hashes differ (script drift), runs `setup.sh --non-interactive` to re-deploy
- Uses `sha256sum` (Linux) with `shasum -a 256` (macOS) fallback
- Skips silently if either file is missing (safe for fresh installs)

## Immediate Mitigation

The fixed `gh-failure-miner-helper.sh` was manually deployed to `~/.aidevops/` in this session. The pulse will now correctly report 0 failed events for Codacy.

## Verification

- ShellCheck: zero violations
- `gh-failure-miner-helper.sh prefetch --pulse-repos --since-hours 24`: reports `failed events: 0, systemic clusters: 0`
- Sentinel hash check logic tested: `sha256sum` comparison works on Linux; `shasum -a 256` fallback for macOS

Closes #4727

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automatic drift detection for deployed agents. The system now detects when agent deployments are out of sync with the repository and automatically triggers a re-deployment to restore consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->