### PR TITLE
t3518: fix PR #254 review feedback — worktree cleanup doc + divergence guidance

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -872,15 +872,7 @@ COMMENT
 
 **Worktree cleanup after merge:**
 
-```bash
-# When in a worktree, merge without --delete-branch
-gh pr merge --squash
-
-# Then clean up from main repo
-cd ~/Git/$(basename "$PWD" | cut -d. -f1)  # Return to main repo
-git pull origin main                        # Get merged changes
-wt prune                                    # Clean merged worktrees
-```
+See [`worktree-cleanup.md`](worktree-cleanup.md) for the full cleanup sequence (merge without `--delete-branch`, pull main, prune worktrees). Key constraint: never pass `--delete-branch` to `gh pr merge` when running from inside a worktree.
 
 ### Step 5: Human Decision Points
 

--- a/.agents/scripts/commands/worktree-cleanup.md
+++ b/.agents/scripts/commands/worktree-cleanup.md
@@ -1,0 +1,30 @@
+# Worktree Cleanup After Merge
+
+After a PR is merged, clean up the linked worktree and return the canonical repo to a clean state.
+
+## Commands
+
+```bash
+# Merge the PR without --delete-branch (required when working from a worktree)
+gh pr merge --squash
+
+# Return to the canonical repo directory
+cd ~/Git/$(basename "$PWD" | cut -d. -f1)
+
+# Pull the merged changes into main
+git pull origin main
+
+# Remove merged worktrees
+wt prune
+```
+
+## Notes
+
+- **Do not use `--delete-branch`** with `gh pr merge` when running from inside a worktree — it will fail because the branch is checked out in the worktree, not the canonical repo.
+- `wt prune` removes worktrees whose branches have been merged and deleted on the remote. Run it from the canonical repo directory (on `main`), not from inside the worktree.
+- If `wt prune` is unavailable, use `git worktree prune` to remove stale worktree entries, then manually delete the worktree directory.
+
+## See Also
+
+- `workflows/git-workflow.md` — full worktree lifecycle
+- `reference/session.md` — session and worktree conventions

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -912,7 +912,12 @@ verify_remote_sync() {
 			print_info "  Remote: $remote_sha"
 			echo ""
 			print_info "This commonly happens after a squash merge on GitHub."
-			print_info "Fix with: git fetch origin && git reset --hard origin/$branch"
+			print_info "Inspect the divergence before deciding how to proceed:"
+			print_info "  git log --oneline origin/$branch...$branch"
+			print_info "If local commits are already merged upstream (squash merge), reset is safe:"
+			print_info "  git fetch origin && git reset --hard origin/$branch"
+			print_info "If local commits are NOT yet merged, rebase instead:"
+			print_info "  git fetch origin && git rebase origin/$branch"
 			return 1
 		fi
 	fi


### PR DESCRIPTION
## Summary

Addresses the two CodeRabbit findings from PR #254 review (tracked in issue #3518).

- **`full-loop.md`**: Extract inline bash block from "Worktree cleanup after merge" section into a new `worktree-cleanup.md` subagent doc. Replace the inline snippet with a progressive-disclosure pointer linking to the new doc. This follows the framework's progressive-disclosure pattern and keeps `full-loop.md` focused on orchestration logic rather than embedding operational commands.

- **`version-manager.sh`**: Replace the unconditional `git reset --hard` suggestion in the truly-diverged branch path with safer, context-aware guidance. The new message instructs users to inspect the divergence first (`git log --oneline origin/$branch...$branch`), then choose the appropriate recovery: reset only if commits are already merged upstream (squash merge), rebase if local commits are not yet merged. Avoids recommending a destructive operation without context.

## Files changed (3 of 5 cap)

- `.agents/scripts/commands/worktree-cleanup.md` — new subagent doc (created)
- `.agents/scripts/commands/full-loop.md` — inline block replaced with pointer
- `.agents/scripts/version-manager.sh` — diverged-path guidance improved

## Verification

- ShellCheck: zero violations on `version-manager.sh`
- markdownlint-cli2: zero errors on both `.md` files

Closes #3518