### PR TITLE
t3455: add Windows and Linux Claude Desktop config paths to mcp-integrations.md

### DIFF
--- a/.agents/aidevops/mcp-integrations.md
+++ b/.agents/aidevops/mcp-integrations.md
@@ -188,7 +188,11 @@ claude mcp add --scope user openapi-search --transport http https://openapi-mcp.
 }
 ```
 
-**For Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+**For Claude Desktop** (config path by OS):
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
 ```json
 {
@@ -223,7 +227,11 @@ No installation required — this is a remote MCP server authenticated via OAuth
 
 On first connection, your MCP client opens a browser OAuth flow to `dash.cloudflare.com`. After authorizing, the token is stored automatically — no manual API key setup needed.
 
-**For Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+**For Claude Desktop** (config path by OS):
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
 ```json
 {


### PR DESCRIPTION
## Summary

- Expand Claude Desktop config path from macOS-only to all three platforms in `mcp-integrations.md`
- Applies to both the **OpenAPI Search MCP** section and the **Cloudflare Code Mode MCP** section

## Change

Before (macOS-only):

```
**For Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
```

After (cross-platform):

```
**For Claude Desktop** (config path by OS):

- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
- **Linux**: `~/.config/Claude/claude_desktop_config.json`
```

## Files Changed

- `.agents/aidevops/mcp-integrations.md` (1 file, blast radius: 1/5)

## Review Feedback Addressed

Gemini review on PR #2077 (line 157): "The configuration path provided for Claude Desktop is specific to macOS. Since Claude Desktop is also available on Windows and Linux, it would be helpful to include the configuration paths for those operating systems as well."

Closes #3455