### PR TITLE
t3485: fix: standardize Claude Code terminology in mcp-integrations.md

### DIFF
--- a/.agents/aidevops/mcp-integrations.md
+++ b/.agents/aidevops/mcp-integrations.md
@@ -138,7 +138,7 @@ See `tools/mobile/ios-simulator-mcp.md` for detailed documentation.
 ### **Claude Code MCP (Fork)**
 
 ```bash
-# Add forked MCP server via Claude Code CLI
+# Add forked MCP server via Claude Code
 claude mcp add claude-code-mcp "npx -y github:marcusquinn/claude-code-mcp"
 ```
 


### PR DESCRIPTION
## Summary

- Removes 'CLI' suffix from the comment `# Add forked MCP server via Claude Code CLI` → `# Add forked MCP server via Claude Code` in `.agents/aidevops/mcp-integrations.md:141`
- Addresses the one unactioned finding from Gemini's review of PR #217 (product name consistency)

## Change

Single-line doc fix: `Claude Code CLI` → `Claude Code` in a bash comment.

The remaining `Claude CLI` occurrences in the codebase are in scripts that distinguish between the `claude` binary and `opencode` as CLI backends — those are technically accurate and out of scope for this fix.

Closes #3485

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Claude Code documentation to improve clarity and accuracy of guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->