### PR TITLE
t3372: fix(muapi-helper): address PR #2013 quality-debt review feedback

### DIFF
--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -106,7 +106,7 @@ Reply with numbers (e.g., "1, 2, 5") or "all" if you're comfortable with everyth
 If they're unfamiliar with **Git**:
 
 ```text
-Git is a version control system that tracks changes to your code. Think of it like 
+Git is a version control system that tracks changes to your code. Think of it like
 "save points" in a video game - you can always go back. Key concepts:
 - **Repository (repo)**: A project folder tracked by Git
 - **Commit**: A saved snapshot of your changes
@@ -152,7 +152,7 @@ aidevops can help manage servers across multiple providers from one conversation
 If they're unfamiliar with **SEO**:
 
 ```text
-SEO (Search Engine Optimization) is how you help people find your website through 
+SEO (Search Engine Optimization) is how you help people find your website through
 search engines like Google. Key concepts:
 - **Keywords**: Words people type when searching (e.g., "best coffee shops near me")
 - **SERP**: Search Engine Results Page - what Google shows for a search
@@ -167,7 +167,7 @@ aidevops has powerful SEO capabilities:
 - Discover what keywords competitors rank for
 - Automate SEO audits and reporting
 
-Even if you're not an SEO expert, I can help you understand and improve your 
+Even if you're not an SEO expert, I can help you understand and improve your
 site's search visibility through natural conversation.
 ```
 
@@ -188,8 +188,8 @@ If they're **new to everything**:
 
 ```text
 No problem! Everyone starts somewhere. I'll explain each concept as we go.
-The key thing to know: aidevops lets you manage complex technical tasks through 
-natural conversation. You tell me what you want to accomplish, and I'll handle 
+The key thing to know: aidevops lets you manage complex technical tasks through
+natural conversation. You tell me what you want to accomplish, and I'll handle
 the technical details - explaining each step along the way.
 
 Let's start simple and build up from there.
@@ -845,7 +845,7 @@ opencode
 
 ```bash
 # Check config is valid JSON
-jq . ~/.config/opencode/opencode.json > /dev/null && echo "Valid JSON"
+jq . ~/.config/opencode/opencode.json > /dev/null && echo "Valid JSON" || echo "Invalid JSON"
 
 # List configured agents
 jq '.agent | keys' ~/.config/opencode/opencode.json

--- a/.agents/configs/prompt-injection-patterns.yaml
+++ b/.agents/configs/prompt-injection-patterns.yaml
@@ -516,7 +516,10 @@ context_manipulation:
 
   - severity: LOW
     description: "Zero-width characters"
-    pattern: '[\xE2\x80\x8B\xE2\x80\x8C\xE2\x80\x8D\xEF\xBB\xBF]'
+    # Literal Unicode chars (U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+FEFF BOM)
+    # for portability across rg/grep/ggrep — byte-level \xNN escapes match
+    # individual bytes, not multi-byte UTF-8 codepoints.
+    pattern: '[​‌‍﻿]'
 
   # --- Lasso net-new: False authority claims ---
   - severity: HIGH

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1067,6 +1067,16 @@ async function toolExecuteBefore(input, output) {
   if (filePath.endsWith(".sh")) {
     const result = runShellQualityPipeline(filePath);
     logQualityGateResult("Quality gate", filePath, result.totalViolations, result.report);
+    const secretResult = scanForSecrets(filePath);
+    if (secretResult.violations > 0) {
+      logQualityGateResult(
+        "SECURITY",
+        filePath,
+        secretResult.violations,
+        secretResult.details.join("\n"),
+        "ERROR",
+      );
+    }
     return;
   }
 

--- a/.agents/reference/planning-detail.md
+++ b/.agents/reference/planning-detail.md
@@ -62,7 +62,7 @@ The supervisor updates a `status:` tag on each task's TODO.md line at every deci
 | `status:changes-requested` | Human reviewer requested changes |
 | `status:blocked:<reason>` | Cannot proceed, reason given |
 
-The AI lifecycle engine (`SUPERVISOR_AI_LIFECYCLE=true`, default) replaces hardcoded bash heuristics with intelligence-first decision making. For each active task, it gathers real-world state (DB, GitHub PR, CI, git), decides the next action, executes it, and updates the status tag. Set `SUPERVISOR_AI_LIFECYCLE=false` to fall back to the legacy `cmd_pr_lifecycle` bash heuristics.
+The AI lifecycle engine (`SUPERVISOR_AI_LIFECYCLE=true`, default) replaces hardcoded bash heuristics with intelligence-first decision-making. For each active task, it gathers real-world state (DB, GitHub PR, CI, git), decides the next action, executes it, and updates the status tag. Set `SUPERVISOR_AI_LIFECYCLE=false` to fall back to the legacy `cmd_pr_lifecycle` bash heuristics.
 
 ## Blocker Statuses
 

--- a/.agents/scripts/archived/batch-cleanup-helper.sh
+++ b/.agents/scripts/archived/batch-cleanup-helper.sh
@@ -74,8 +74,12 @@ parse_estimate_minutes() {
 	if [[ "$estimate" =~ ^([0-9]+)\.([0-9]+)h$ ]]; then
 		local hours="${BASH_REMATCH[1]}"
 		local frac="${BASH_REMATCH[2]}"
-		# Convert fractional hours: 0.5h = 30m, 1.5h = 90m
-		echo $((hours * 60 + frac * 6))
+		# Convert fractional hours using proper decimal arithmetic.
+		# Pad frac to 2 digits so 0.5h → frac=50, 0.25h → frac=25, 0.75h → frac=75.
+		# Then minutes = hours*60 + round(frac_padded * 60 / 100).
+		local frac_padded
+		frac_padded=$(printf '%-2s' "$frac" | tr ' ' '0')
+		echo $((hours * 60 + (frac_padded * 60 + 50) / 100))
 		return 0
 	fi
 
@@ -94,7 +98,7 @@ is_task_unblocked() {
 
 	# Extract blocked-by: field
 	local blocked_by
-	blocked_by=$(echo "$task_line" | grep -oE 'blocked-by:[^ ]+' | sed 's/blocked-by://' || true)
+	blocked_by=$(echo "$task_line" | sed -nE 's/.*blocked-by:([^ ]+).*/\1/p')
 
 	if [[ -z "$blocked_by" ]]; then
 		return 0 # No dependencies — unblocked
@@ -109,7 +113,7 @@ is_task_unblocked() {
 
 		# Check if dependency is complete ([x]) in TODO.md
 		local dep_line
-		dep_line=$(grep -E "^[[:space:]]*- \[x\] ${dep} " "$todo_file" 2>/dev/null | head -1 || true)
+		dep_line=$(grep -E "^[[:space:]]*- \[x\] ${dep} " "$todo_file" 2>>"$SUPERVISOR_LOG" | head -1 || true)
 		if [[ -z "$dep_line" ]]; then
 			# Dependency not complete — task is blocked
 			return 1
@@ -138,7 +142,7 @@ scan_eligible_tasks() {
 
 	# Find all pending #chore tasks
 	local chore_tasks
-	chore_tasks=$(grep -E '^[[:space:]]*- \[ \] (t[0-9]+(\.[0-9]+)*) .*#chore' "$todo_file" 2>/dev/null || true)
+	chore_tasks=$(grep -E '^[[:space:]]*- \[ \] (t[0-9]+(\.[0-9]+)*) .*#chore' "$todo_file" 2>>"$SUPERVISOR_LOG" || true)
 
 	if [[ -z "$chore_tasks" ]]; then
 		log_info "No pending #chore tasks found"
@@ -149,8 +153,8 @@ scan_eligible_tasks() {
 	while IFS= read -r line; do
 		[[ -z "$line" ]] && continue
 
-		local task_id
-		task_id=$(echo "$line" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1)
+		local task_id=""
+		[[ "$line" =~ (t[0-9]+(\.[0-9]+)*) ]] && task_id="${BASH_REMATCH[1]}"
 		if [[ -z "$task_id" ]]; then
 			continue
 		fi
@@ -162,8 +166,8 @@ scan_eligible_tasks() {
 		fi
 
 		# Check estimate — must be <=15m
-		local estimate
-		estimate=$(echo "$line" | grep -oE '~[0-9]+(\.[0-9]+)?[mh]' | head -1 || true)
+		local estimate=""
+		[[ "$line" =~ (~[0-9]+(\.[0-9]+)?[mh]) ]] && estimate="${BASH_REMATCH[1]}"
 		if [[ -z "$estimate" ]]; then
 			log_info "  $task_id: no estimate found — skipping (batch-cleanup requires explicit estimate)"
 			continue
@@ -191,7 +195,7 @@ scan_eligible_tasks() {
 		if [[ -f "$SUPERVISOR_DB" ]]; then
 			local existing
 			existing=$(db "$SUPERVISOR_DB" "SELECT status FROM tasks WHERE id = '$(sql_escape "$task_id")';" 2>/dev/null || true)
-			if [[ -n "$existing" && "$existing" != "cancelled" && "$existing" != "complete" ]]; then
+			if [[ -n "$existing" && "$existing" != "cancelled" ]]; then
 				log_info "  $task_id: already tracked in supervisor (status: $existing) — skipping"
 				continue
 			fi
@@ -255,7 +259,7 @@ dispatch_batch_cleanup_worker() {
 	local task_id
 	for task_id in "${task_ids[@]}"; do
 		local task_line
-		task_line=$(grep -E "^[[:space:]]*- \[ \] ${task_id} " "$todo_file" 2>/dev/null | head -1 || true)
+		task_line=$(grep -E "^[[:space:]]*- \[ \] ${task_id} " "$todo_file" 2>>"$SUPERVISOR_LOG" | head -1 || true)
 		if [[ -n "$task_line" ]]; then
 			task_list+="- ${task_id}: $(echo "$task_line" | sed -E 's/^[[:space:]]*- \[ \] [^ ]+ //' | head -c 120)"$'\n'
 		else
@@ -351,6 +355,12 @@ PROMPT
 
 	log_info "Dispatching batch-cleanup worker for ${#task_ids[@]} tasks: ${task_csv}"
 	log_info "Log: $log_file"
+
+	# Ensure worker runs in the target repository so TODO.md and todo/ are found
+	cd "$repo" || {
+		log_error "Failed to cd to repo: $repo"
+		return 1
+	}
 
 	# Dispatch headless worker
 	local dispatch_cmd=("$ai_cli" run --format json)

--- a/.agents/scripts/archived/pattern-tracker-helper.sh
+++ b/.agents/scripts/archived/pattern-tracker-helper.sh
@@ -364,7 +364,7 @@ cmd_record() {
 		[[ -n "$tokens_out" ]] && sql_tokens_out="$tokens_out"
 		[[ -n "$estimated_cost" ]] && sql_estimated_cost="$estimated_cost"
 
-		sqlite3 "$MEMORY_DB" "INSERT OR REPLACE INTO pattern_metadata (id, strategy, quality, failure_mode, tokens_in, tokens_out, estimated_cost) VALUES ('$mem_id', '$sql_strategy', $sql_quality, $sql_failure_mode, $sql_tokens_in, $sql_tokens_out, $sql_estimated_cost);" 2>/dev/null || log_warn "Failed to store pattern metadata for $mem_id"
+		sqlite3 -cmd ".timeout 5000" "$MEMORY_DB" "INSERT OR REPLACE INTO pattern_metadata (id, strategy, quality, failure_mode, tokens_in, tokens_out, estimated_cost) VALUES ('$mem_id', '$sql_strategy', $sql_quality, $sql_failure_mode, $sql_tokens_in, $sql_tokens_out, $sql_estimated_cost);" 2>/dev/null || log_warn "Failed to store pattern metadata for $mem_id"
 	fi
 
 	log_success "Recorded $outcome pattern: $description"

--- a/.agents/scripts/email-signature-parser-helper.sh
+++ b/.agents/scripts/email-signature-parser-helper.sh
@@ -417,21 +417,18 @@ merge_toon_contact() {
 	local existing
 	existing=$(cat "$toon_file")
 
-	# Extract existing field values using parameter expansion (avoids grep|sed pipe)
+	# Extract existing field values in a single pass (avoids repeated grep per field)
 	local existing_name existing_title existing_company existing_phone existing_website existing_address
-	local _field_line
-	_field_line=$(echo "$existing" | grep -E "^  name: " || true)
-	existing_name="${_field_line#  name: }"
-	_field_line=$(echo "$existing" | grep -E "^  title: " || true)
-	existing_title="${_field_line#  title: }"
-	_field_line=$(echo "$existing" | grep -E "^  company: " || true)
-	existing_company="${_field_line#  company: }"
-	_field_line=$(echo "$existing" | grep -E "^  phone: " || true)
-	existing_phone="${_field_line#  phone: }"
-	_field_line=$(echo "$existing" | grep -E "^  website: " || true)
-	existing_website="${_field_line#  website: }"
-	_field_line=$(echo "$existing" | grep -E "^  address: " || true)
-	existing_address="${_field_line#  address: }"
+	while IFS= read -r _line; do
+		case "$_line" in
+		"  name: "*) existing_name="${_line#  name: }" ;;
+		"  title: "*) existing_title="${_line#  title: }" ;;
+		"  company: "*) existing_company="${_line#  company: }" ;;
+		"  phone: "*) existing_phone="${_line#  phone: }" ;;
+		"  website: "*) existing_website="${_line#  website: }" ;;
+		"  address: "*) existing_address="${_line#  address: }" ;;
+		esac
+	done <<<"$existing"
 
 	# Update last_seen
 	existing=$(echo "$existing" | sed "s/^  last_seen: .*/  last_seen: ${now}/")
@@ -521,11 +518,13 @@ resolve_contact_filename() {
 	fi
 
 	# File exists — check if it's the same person (same email or same name)
-	local existing_email existing_name _field_line
-	_field_line=$(grep -E "^  email: " "$base_file" || true)
-	existing_email="${_field_line#  email: }"
-	_field_line=$(grep -E "^  name: " "$base_file" || true)
-	existing_name="${_field_line#  name: }"
+	local existing_email existing_name
+	while IFS= read -r _line; do
+		case "$_line" in
+		"  email: "*) existing_email="${_line#  email: }" ;;
+		"  name: "*) existing_name="${_line#  name: }" ;;
+		esac
+	done <"$base_file"
 
 	# Same email = same person, use existing file
 	if [[ "$existing_email" == "$email" ]]; then
@@ -960,11 +959,15 @@ list_contacts() {
 	local count=0
 	while IFS= read -r -d '' toon_file; do
 		count=$((count + 1))
-		local email name _field_line
-		_field_line=$(grep -E "^  email: " "$toon_file" | head -1 || true)
-		email="${_field_line#  email: }"
-		_field_line=$(grep -E "^  name: " "$toon_file" | head -1 || true)
-		name="${_field_line#  name: }"
+		local email name
+		email=""
+		name=""
+		while IFS= read -r _line; do
+			case "$_line" in
+			"  email: "*) email="${_line#  email: }" ;;
+			"  name: "*) name="${_line#  name: }" ;;
+			esac
+		done <"$toon_file"
 		printf "%-40s %s\n" "${email:-<unknown>}" "${name:-<no name>}"
 	done < <(find "$contacts_dir" -name "*.toon" -type f -print0 2>/dev/null | sort -z)
 

--- a/.agents/scripts/generate-claude-agents.sh
+++ b/.agents/scripts/generate-claude-agents.sh
@@ -304,7 +304,7 @@ Show In Progress tasks, top 5 Backlog, and Active Plans with progress.'
 # --- Onboarding ---
 write_command "onboarding" \
 	"Interactive onboarding wizard - discover services, configure integrations" \
-	'Read ~/.aidevops/agents/aidevops/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions — go straight to the Welcome Flow conversation.
+	'Read ${AIDEVOPS_HOME:-$HOME/.aidevops}/agents/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions — go straight to the Welcome Flow conversation.
 
 Arguments: $ARGUMENTS'
 

--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -702,7 +702,7 @@ fi
 if should_generate "onboarding"; then
 	write_command "onboarding" \
 		"Interactive onboarding wizard - discover services, configure integrations" \
-		'Read ~/.aidevops/agents/aidevops/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions — go straight to the Welcome Flow conversation.
+		'Read ${AIDEVOPS_HOME:-$HOME/.aidevops}/agents/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions — go straight to the Welcome Flow conversation.
 
 Arguments: $ARGUMENTS'
 fi

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -730,7 +730,7 @@ omo_tool_patterns = ['grep_app_*', 'websearch_*', 'gh_grep_*']
 for tool_pattern in omo_tool_patterns:
     if config['tools'].get(tool_pattern) is not False:
         config['tools'][tool_pattern] = False
-        print(f"  Disabled {tool_pattern} tools globally (use @github-search subagent)")
+        print(f"  Disabled {tool_pattern} tools globally (use matching subagent/CLI workflow)")
 
 if config_loaded:
     with open(config_path, 'w', encoding='utf-8') as f:

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -546,14 +546,32 @@ EAGER_MCPS = set()
 # Lazy-loaded (enabled: False): Subagent-only, start on-demand
 # sentry/socket: Remote MCPs requiring auth, disable until configured
 # These save ~7K+ tokens on session startup
-LAZY_MCPS = {'claude-code-mcp', 'outscraper', 'dataforseo', 'shadcn', 'macos-automator', 
-             'gsc', 'localwp', 'chrome-devtools', 'quickfile', 'amazon-order-history', 
-             'google-analytics-mcp', 'MCP_DOCKER', 'ahrefs',
-             'playwriter', 'augment-context-engine', 'context7',
-             'sentry', 'socket', 'ios-simulator',
-             'openapi-search',
-             # Oh-My-OpenCode MCPs - disable globally, use @github-search/@context7 subagents
-             'grep_app', 'websearch', 'gh_grep'}
+LAZY_MCPS = {
+    'MCP_DOCKER',
+    'ahrefs',
+    'amazon-order-history',
+    'augment-context-engine',
+    'chrome-devtools',
+    'claude-code-mcp',
+    'context7',
+    'dataforseo',
+    'gh_grep',
+    'google-analytics-mcp',
+    # Oh-My-OpenCode MCPs - disable globally, use @github-search/@context7 subagents
+    'grep_app',
+    'gsc',
+    'ios-simulator',
+    'localwp',
+    'macos-automator',
+    'openapi-search',
+    'outscraper',
+    'playwriter',
+    'quickfile',
+    'sentry',
+    'shadcn',
+    'socket',
+    'websearch',
+}
 # Note: gh_grep removed from aidevops but may exist from old configs or OmO
 
 # Apply loading policy to existing MCPs and warn about uncategorized ones

--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -936,7 +936,7 @@ BODY
 create_command "onboarding" \
 	"Interactive onboarding wizard - discover services, configure integrations" \
 	"" "" <<'BODY'
-Read ~/.aidevops/agents/aidevops/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions -- go straight to the Welcome Flow conversation.
+Read ${AIDEVOPS_HOME:-$HOME/.aidevops}/agents/onboarding.md and follow its Welcome Flow instructions to guide the user through setup. Do NOT repeat these instructions -- go straight to the Welcome Flow conversation.
 
 Arguments: $ARGUMENTS
 BODY

--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -283,8 +283,19 @@ extract_failed_events_json() {
 		local checks_json
 		checks_json=$(gh api "repos/${repo_slug}/commits/${head_sha}/check-runs?per_page=100" 2>/dev/null || printf '{"check_runs":[]}')
 
+		# Filter check runs for failures. Two-pass approach:
+		# 1. Hard failures (failure, cancelled, timed_out, startup_failure) — always collected
+		# 2. action_required — only from GitHub Actions runs. External apps (Codacy, SonarCloud)
+		#    use action_required to mean "issues found for developer review", which is informational
+		#    not a CI failure. Including these creates false systemic clusters (GH#4696).
 		local failed_runs_json
-		failed_runs_json=$(printf '%s\n' "$checks_json" | jq '[.check_runs[] | select((.conclusion // "" | ascii_downcase) as $c | ["failure","cancelled","timed_out","action_required","startup_failure"] | index($c))]')
+		failed_runs_json=$(printf '%s\n' "$checks_json" | jq '[.check_runs[] | select(
+			((.conclusion // "" | ascii_downcase) as $c |
+				["failure","cancelled","timed_out","startup_failure"] | index($c))
+			or
+			((.conclusion // "" | ascii_downcase) == "action_required"
+				and (.app.slug // "" | ascii_downcase) == "github-actions")
+		)]')
 
 		local failed_count
 		failed_count=$(printf '%s\n' "$failed_runs_json" | jq 'length')
@@ -306,10 +317,20 @@ extract_failed_events_json() {
 			local run_id
 			run_id=$(parse_run_id_from_details_url "$details_url")
 
-			local signature="not_collected"
-			if [[ "$include_logs" == "true" ]] && [[ -n "$run_id" ]] && [[ "$run_logs_checked" -lt "$max_run_logs" ]]; then
+			# For non-GitHub-Actions check runs (e.g., Codacy, SonarCloud), the details_url
+			# points to the external app, not a GH Actions run — so run_id is empty and logs
+			# can't be extracted. Use the conclusion as the signature instead of "not_collected"
+			# to produce meaningful cluster grouping (GH#4696).
+			local signature
+			if [[ -z "$run_id" ]]; then
+				local app_name
+				app_name=$(printf '%s\n' "$run_json" | jq -r '.app.name // "external"')
+				signature="${conclusion}:${app_name}"
+			elif [[ "$include_logs" == "true" ]] && [[ "$run_logs_checked" -lt "$max_run_logs" ]]; then
 				signature=$(extract_failure_signature "$repo_slug" "$run_id")
 				run_logs_checked=$((run_logs_checked + 1))
+			else
+				signature="not_collected"
 			fi
 
 			jq -n \

--- a/.agents/scripts/migrate-pr-backfill.sh
+++ b/.agents/scripts/migrate-pr-backfill.sh
@@ -162,13 +162,13 @@ validate_pr_belongs_to_task() {
 	pr_title=$(echo "$pr_info" | jq -r '.title // ""' 2>/dev/null || echo "")
 	pr_branch=$(echo "$pr_info" | jq -r '.headRefName // ""' 2>/dev/null || echo "")
 
-	# Word boundary match: "t195" matches "feature/t195" but not "t1950"
-	if echo "$pr_title" | grep -qi "\b${task_id}\b" 2>/dev/null; then
+	# Portable ERE token boundary match: "t195" matches "feature/t195" but not "t1950"
+	if echo "$pr_title" | grep -Eqi "(^|[^[:alnum:]_])${task_id}([^[:alnum:]_]|$)" 2>/dev/null; then
 		echo "$pr_url"
 		return 0
 	fi
 
-	if echo "$pr_branch" | grep -qi "\b${task_id}\b" 2>/dev/null; then
+	if echo "$pr_branch" | grep -Eqi "(^|[^[:alnum:]_])${task_id}([^[:alnum:]_]|$)" 2>/dev/null; then
 		echo "$pr_url"
 		return 0
 	fi

--- a/.agents/scripts/muapi-helper.sh
+++ b/.agents/scripts/muapi-helper.sh
@@ -674,6 +674,7 @@ submit_specialized() {
 	payload=$(echo "${extra_payload}" | jq --arg url "${image_url}" '. + {image_url: $url}')
 
 	submit_and_poll "${endpoint}" "${payload}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Face swap (image or video)
@@ -1180,7 +1181,7 @@ cmd_balance() {
 	local response
 	response=$(api_request GET "${MUAPI_BASE}/payments/credits")
 
-	echo "${response}" | jq . 2>/dev/null || echo "${response}"
+	echo "${response}" | jq . || echo "${response}"
 	return 0
 }
 
@@ -1191,7 +1192,7 @@ cmd_usage() {
 	local response
 	response=$(api_request GET "${MUAPI_BASE}/payments/usage")
 
-	echo "${response}" | jq . 2>/dev/null || echo "${response}"
+	echo "${response}" | jq . || echo "${response}"
 	return 0
 }
 

--- a/.agents/scripts/muapi-helper.sh
+++ b/.agents/scripts/muapi-helper.sh
@@ -758,6 +758,7 @@ cmd_face_swap() {
 	extra=$(jq -n --arg face "${face_url}" '{face_image: $face}')
 
 	submit_specialized "${endpoint}" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Image upscaling
@@ -802,6 +803,7 @@ cmd_upscale() {
 	done
 
 	submit_specialized "ai-image-upscale" "${image_url}" "{}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Background removal
@@ -846,6 +848,7 @@ cmd_bg_remove() {
 	done
 
 	submit_specialized "ai-background-remover" "${image_url}" "{}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Dress change
@@ -901,6 +904,7 @@ cmd_dress_change() {
 	fi
 
 	submit_specialized "ai-dress-change" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Stylization (Ghibli/Anime)
@@ -960,6 +964,7 @@ cmd_stylize() {
 	esac
 
 	submit_specialized "${endpoint}" "${image_url}" "{}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Product shot
@@ -1015,6 +1020,7 @@ cmd_product_shot() {
 	fi
 
 	submit_specialized "ai-product-shot" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Object eraser
@@ -1071,6 +1077,7 @@ cmd_object_erase() {
 	fi
 
 	submit_specialized "ai-object-eraser" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Image extension (outpainting)
@@ -1126,6 +1133,7 @@ cmd_image_extend() {
 	fi
 
 	submit_specialized "ai-image-extension" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Skin enhancer
@@ -1170,6 +1178,7 @@ cmd_skin_enhance() {
 	done
 
 	submit_specialized "ai-skin-enhancer" "${image_url}" "{}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # --- Credits & Usage ---

--- a/.agents/scripts/paddleocr-helper.sh
+++ b/.agents/scripts/paddleocr-helper.sh
@@ -476,81 +476,57 @@ if not results:
         print("[]")
     sys.exit(0)
 
+# Normalize both API paths into a common entries list to avoid output duplication
+entries = []
 if use_new_api:
     # New API: OCRResult with rec_texts, rec_scores, rec_polys (list of 4-point polygons)
     for result in results:
         texts = result.get("rec_texts", [])
         scores = result.get("rec_scores", [])
         polys = result.get("rec_polys", [])
-
-        if not texts:
-            continue
-
-        if output_format == "json":
-            entries = []
-            for i, text in enumerate(texts):
-                entry = {
-                    "text": text,
-                    "confidence": round(float(scores[i]), 4) if i < len(scores) else 0.0,
-                }
-                if i < len(polys):
-                    box = polys[i].tolist() if hasattr(polys[i], "tolist") else polys[i]
-                    entry["box"] = box
-                entries.append(entry)
-            print(json.dumps(entries, ensure_ascii=False, indent=2))
-
-        elif output_format == "tsv":
-            print("text\tconfidence\tx1\ty1\tx2\ty2\tx3\ty3\tx4\ty4")
-            for i, text in enumerate(texts):
-                score = float(scores[i]) if i < len(scores) else 0.0
-                if i < len(polys):
-                    box = polys[i].tolist() if hasattr(polys[i], "tolist") else polys[i]
-                    coords = "\t".join(f"{p[0]:.0f}\t{p[1]:.0f}" for p in box)
-                else:
-                    coords = "\t".join(["0"] * 8)
-                print(f"{text}\t{score:.4f}\t{coords}")
-
-        else:
-            for text in texts:
-                print(text)
-
+        for i, text in enumerate(texts):
+            entry = {
+                "text": text,
+                "confidence": float(scores[i]) if i < len(scores) else 0.0,
+            }
+            if i < len(polys):
+                box = polys[i].tolist() if hasattr(polys[i], "tolist") else polys[i]
+                entry["box"] = box
+            entries.append(entry)
 else:
     # Legacy API: [[box, (text, confidence)], ...]
-    if output_format == "json":
-        entries = []
-        for page in results:
-            if page is None:
-                continue
-            for line in page:
-                box = line[0]
-                text = line[1][0]
-                confidence = line[1][1]
-                entries.append({
-                    "text": text,
-                    "confidence": round(confidence, 4),
-                    "box": box,
-                })
-        print(json.dumps(entries, ensure_ascii=False, indent=2))
+    for page in results:
+        if page is None:
+            continue
+        for line in page:
+            entries.append({
+                "text": line[1][0],
+                "confidence": line[1][1],
+                "box": line[0],
+            })
 
-    elif output_format == "tsv":
-        print("text\tconfidence\tx1\ty1\tx2\ty2\tx3\ty3\tx4\ty4")
-        for page in results:
-            if page is None:
-                continue
-            for line in page:
-                box = line[0]
-                text = line[1][0]
-                confidence = line[1][1]
-                coords = "\t".join(f"{p[0]:.0f}\t{p[1]:.0f}" for p in box)
-                print(f"{text}\t{confidence:.4f}\t{coords}")
+if output_format == "json":
+    for entry in entries:
+        if "confidence" in entry:
+            entry["confidence"] = round(entry["confidence"], 4)
+    print(json.dumps(entries, ensure_ascii=False, indent=2))
 
-    else:
-        for page in results:
-            if page is None:
-                continue
-            for line in page:
-                text = line[1][0]
-                print(text)
+elif output_format == "tsv":
+    print("text\tconfidence\tx1\ty1\tx2\ty2\tx3\ty3\tx4\ty4")
+    for entry in entries:
+        text = entry.get("text", "")
+        confidence = entry.get("confidence", 0.0)
+        box = entry.get("box")
+        if box:
+            coords = "\t".join(f"{p[0]:.0f}\t{p[1]:.0f}" for p in box)
+        else:
+            coords = "\t".join(["0"] * 8)
+        print(f"{text}\t{confidence:.4f}\t{coords}")
+
+else:
+    # Plain text output
+    for entry in entries:
+        print(entry.get("text", ""))
 PYEOF
 	)"
 

--- a/.agents/scripts/prompt-guard-helper.sh
+++ b/.agents/scripts/prompt-guard-helper.sh
@@ -168,10 +168,6 @@ _pg_load_yaml_patterns() {
 		return 1
 	}
 
-	# Only mark loaded after successful file discovery (prevents transient failures
-	# from permanently disabling YAML loading on subsequent calls)
-	_PG_YAML_PATTERNS_LOADED="true"
-
 	local patterns=""
 	local current_category=""
 	local severity="" description="" pattern=""
@@ -228,8 +224,10 @@ _pg_load_yaml_patterns() {
 		return 1
 	fi
 
-	# Cache for subsequent calls
+	# Cache for subsequent calls — mark loaded only after successful parse+cache
+	# so transient parse failures do not permanently disable YAML loading.
 	_PG_YAML_PATTERNS_CACHE="$patterns"
+	_PG_YAML_PATTERNS_LOADED="true"
 
 	# Remove trailing newline
 	echo "${patterns%$'\n'}"

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -992,6 +992,9 @@ _scan_single_pr() {
 		($body | test(
 			"\\blgtm\\b|\\blooks good( to me)?\\b|\\bgood work\\b|" +
 			"\\bno (further |more )?(comments?|issues?|concerns?|feedback)\\b|" +
+			"\\bfound no (issues?|problems?|concerns?)\\b|" +
+			"\\bno (issues?|problems?|concerns?) (found|detected)\\b|" +
+			"\\b(found|detected) nothing (to )?(fix|change|address)\\b|" +
 			"\\beverything (looks?|seems?) (good|fine|correct|great|solid|clean)\\b"; "i")) as $no_actionable_sentiment |
 
 		($body | test(

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -579,6 +579,7 @@ cmd_scan_merged() {
 
 	# Parse flags
 	while [[ $# -gt 0 ]]; do
+		local flag="$1"
 		case "$1" in
 		--repo)
 			repo_slug="${2:-}"
@@ -613,7 +614,7 @@ cmd_scan_merged() {
 			shift
 			;;
 		*)
-			echo "Unknown option for scan-merged: $1" >&2
+			echo "Unknown option for scan-merged: ${flag}" >&2
 			return 1
 			;;
 		esac
@@ -993,6 +994,11 @@ _scan_single_pr() {
 			"\\bno (further |more )?(comments?|issues?|concerns?|feedback)\\b|" +
 			"\\beverything (looks?|seems?) (good|fine|correct|great|solid|clean)\\b"; "i")) as $no_actionable_sentiment |
 
+		($body | test(
+			"\\bsuccessfully addresses?\\b|\\beffectively\\b|\\bimproves?\\b|\\benhances?\\b|" +
+			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
+			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
+
 		# Filter out review-body summaries that do not contain concrete fixes.
 		# Bots frequently post high-level walkthroughs that mention suggestions
 		# but do not include actionable details tied to a file/line.
@@ -1009,8 +1015,9 @@ _scan_single_pr() {
 		# Skip purely approving reviews: no actionable critique AND body matches
 		# approval-only patterns. This catches "LGTM", "good work", "no further
 		# comments", and "no further recommendations" (even in long summary
-		# reviews) regardless of reviewer type or review state.
-		select((($approval_only or $no_actionable_recommendation or $no_actionable_sentiment) and ($actionable | not)) | not) |
+		# reviews), plus non-actionable praise-only summaries, regardless of
+		# reviewer type or review state.
+		select((($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not)) | not) |
 
 		(if $reviewer == "human" then
 			true
@@ -1533,14 +1540,17 @@ main() {
 
 	# scan-merged handles its own flags — pass remaining args through
 	if [[ "$command" == "scan-merged" ]]; then
-		cmd_scan_merged "$@"
-		return $?
+		if cmd_scan_merged "$@"; then
+			return 0
+		fi
+		return 1
 	fi
 
 	local pr_number=""
 	local commit_sha=""
 
 	while [[ $# -gt 0 ]]; do
+		local flag="$1"
 		case "$1" in
 		--pr)
 			pr_number="${2:-}"
@@ -1555,7 +1565,7 @@ main() {
 			exit 0
 			;;
 		*)
-			echo "Unknown option: $1" >&2
+			echo "Unknown option: ${flag}" >&2
 			show_help
 			exit 1
 			;;

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
 # quality-feedback-helper.sh - Retrieve code quality feedback via GitHub API
 # Consolidates feedback from Codacy, CodeRabbit, SonarCloud, CodeFactor, etc.
 #
@@ -24,6 +25,7 @@
 #   quality-feedback-helper.sh scan-merged --repo owner/repo --batch 20 --create-issues
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=./shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
@@ -990,6 +992,11 @@ _scan_single_pr() {
 			"\\bnothing (further|more) to recommend\\b"; "i")) as $no_actionable_recommendation |
 
 		($body | test(
+			"\\bno suggestions? (at this time|for now|currently)?\\b|" +
+			"\\bwithout suggestions?\\b|" +
+			"\\bhas no suggestions?\\b"; "i")) as $no_actionable_suggestion |
+
+		($body | test(
 			"\\blgtm\\b|\\blooks good( to me)?\\b|\\bgood work\\b|" +
 			"\\bno (further |more )?(comments?|issues?|concerns?|feedback)\\b|" +
 			"\\bfound no (issues?|problems?|concerns?)\\b|" +
@@ -1015,12 +1022,12 @@ _scan_single_pr() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $actionable |
 
-		# Skip purely approving reviews: no actionable critique AND body matches
-		# approval-only patterns. This catches "LGTM", "good work", "no further
-		# comments", and "no further recommendations" (even in long summary
-		# reviews), plus non-actionable praise-only summaries, regardless of
-		# reviewer type or review state.
-		select((($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not)) | not) |
+		# Skip purely approving reviews. Explicit "no suggestions" statements are
+		# always non-actionable and should be skipped even though they contain the
+		# token "suggest", which would otherwise trip the actionable heuristic.
+		# Other approval/sentiment patterns are skipped only when no actionable
+		# critique appears in the body.
+		select(($no_actionable_suggestion or ((($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not))) ) | not) |
 
 		(if $reviewer == "human" then
 			true

--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -123,17 +123,17 @@ get_all_bot_commenters() {
 	# 1. PR reviews (formal GitHub reviews)
 	local reviews
 	reviews=$(gh api "repos/${repo}/pulls/${pr_number}/reviews" \
-		--paginate --jq '.[].user.login' 2>/dev/null || echo "")
+		--paginate --jq '.[].user.login' || echo "")
 
 	# 2. Issue comments (some bots post as comments, not reviews)
 	local comments
 	comments=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
-		--paginate --jq '.[].user.login' 2>/dev/null || echo "")
+		--paginate --jq '.[].user.login' || echo "")
 
 	# 3. Review comments (inline code comments)
 	local review_comments
 	review_comments=$(gh api "repos/${repo}/pulls/${pr_number}/comments" \
-		--paginate --jq '.[].user.login' 2>/dev/null || echo "")
+		--paginate --jq '.[].user.login' || echo "")
 
 	# Combine, deduplicate, lowercase
 	echo -e "${reviews}\n${comments}\n${review_comments}" |
@@ -174,7 +174,7 @@ bot_has_real_review() {
 
 	local endpoint encoded_bodies body
 	for endpoint in "${api_endpoints[@]}"; do
-		encoded_bodies=$(gh api "$endpoint" --paginate --jq "$jq_filter" 2>/dev/null || echo "")
+		encoded_bodies=$(gh api "$endpoint" --paginate --jq "$jq_filter" || echo "")
 		if [[ -n "$encoded_bodies" ]]; then
 			while IFS= read -r encoded; do
 				[[ -z "$encoded" ]] && continue
@@ -257,7 +257,7 @@ check_for_skip_label() {
 
 	local labels
 	labels=$(gh pr view "$pr_number" --repo "$repo" \
-		--json labels -q '.labels[].name' 2>/dev/null || echo "")
+		--json labels -q '.labels[].name' || echo "")
 
 	if echo "$labels" | grep -q "$SKIP_LABEL"; then
 		return 0
@@ -358,11 +358,22 @@ do_wait() {
 	local poll_interval="${REVIEW_BOT_POLL_INTERVAL:-60}"
 	local elapsed=0
 
+	# Validate that max_wait and poll_interval are positive integers to prevent
+	# command injection via arithmetic expansion (GH#3223).
+	if ! [[ "$max_wait" =~ ^[0-9]+$ ]]; then
+		echo "ERROR: max_wait must be a non-negative integer, got: '${max_wait}'" >&2
+		return 2
+	fi
+	if ! [[ "$poll_interval" =~ ^[0-9]+$ ]]; then
+		echo "ERROR: poll_interval must be a non-negative integer, got: '${poll_interval}'" >&2
+		return 2
+	fi
+
 	echo "Waiting up to ${max_wait}s for review bots on PR #${pr_number}..." >&2
 
 	while [[ "$elapsed" -lt "$max_wait" ]]; do
 		local result
-		result=$(do_check "$pr_number" "$repo" 2>/dev/null) || true
+		result=$(do_check "$pr_number" "$repo") || true
 
 		if [[ "$result" == "PASS" || "$result" == "PASS_RATE_LIMITED" || "$result" == "SKIP" ]]; then
 			echo "$result"
@@ -424,7 +435,7 @@ has_formal_reviews() {
 
 	local count
 	count=$(gh pr view "$pr_number" --repo "$repo" \
-		--json reviews --jq '.reviews | length' 2>/dev/null || echo "0")
+		--json reviews --jq '.reviews | length' || echo "0")
 	if [[ "$count" -gt 0 ]]; then
 		return 0
 	fi
@@ -440,7 +451,7 @@ has_retry_comment() {
 	local marker="<!-- review-bot-retry-requested -->"
 	local comments
 	comments=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
-		--paginate --jq '.[].body' 2>/dev/null || echo "")
+		--paginate --jq '.[].body' || echo "")
 	if echo "$comments" | grep -qF "$marker"; then
 		return 0
 	fi

--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -686,11 +686,8 @@ $full_prompt"
 	local start_time
 	start_time=$(date +%s)
 
-	if timeout_sec "$cmd_timeout" "${cmd_args[@]}" 2>&1 | tee "$log_file"; then
-		exit_code=0
-	else
-		exit_code=$?
-	fi
+	timeout_sec "$cmd_timeout" "${cmd_args[@]}" 2>&1 | tee "$log_file"
+	exit_code=${PIPESTATUS[0]}
 
 	local end_time duration
 	end_time=$(date +%s)

--- a/.agents/scripts/sandbox-exec-helper.sh
+++ b/.agents/scripts/sandbox-exec-helper.sh
@@ -13,14 +13,18 @@
 # See network-tier-helper.sh for the full tier model.
 #
 # Usage:
-#   sandbox-exec-helper.sh run "command args"
-#   sandbox-exec-helper.sh run --timeout 60 --no-network "curl example.com"
-#   sandbox-exec-helper.sh run --network-tiering --worker-id w123 "curl example.com"
-#   sandbox-exec-helper.sh run --allow-secret-io "gopass show path"  # explicit override
-#   sandbox-exec-helper.sh run --passthrough "GITHUB_TOKEN,NPM_TOKEN" "npm publish"
+#   sandbox-exec-helper.sh run command [args...]
+#   sandbox-exec-helper.sh run --timeout 60 --no-network curl example.com
+#   sandbox-exec-helper.sh run --network-tiering --worker-id w123 curl example.com
+#   sandbox-exec-helper.sh run --allow-secret-io gopass show path  # explicit override
+#   sandbox-exec-helper.sh run --passthrough "GITHUB_TOKEN,NPM_TOKEN" npm publish
 #   sandbox-exec-helper.sh audit [--last N]
 #   sandbox-exec-helper.sh config --show
 #   sandbox-exec-helper.sh help
+#
+# Note: command and its arguments are passed as separate shell words (not a
+# single quoted string). This avoids bash -c eval and correctly handles
+# arguments containing spaces.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
@@ -77,15 +81,21 @@ log_execution() {
 	# Truncate command for logging (no secrets, max 500 chars)
 	local logged_cmd="${command:0:500}"
 
-	printf '{"ts":"%s","cmd":"%s","exit":%d,"duration_s":%.1f,"timeout":%d,"network_blocked":%s,"passthrough":"%s"}\n' \
-		"$timestamp" \
-		"$(printf '%s' "$logged_cmd" | sed 's/"/\\"/g')" \
-		"$exit_code" \
-		"$duration" \
-		"$timeout_used" \
-		"$network_blocked" \
-		"$passthrough_vars" \
-		>>"$SANDBOX_LOG"
+	# Use jq to safely generate the JSON log entry — prevents JSON/log injection
+	# via backslashes, newlines, or other special characters in the command string.
+	local log_entry
+	log_entry=$(jq -n \
+		--arg ts "$timestamp" \
+		--arg cmd "$logged_cmd" \
+		--argjson exit "$exit_code" \
+		--argjson duration "$duration" \
+		--argjson timeout "$timeout_used" \
+		--argjson network_blocked "$network_blocked" \
+		--arg passthrough "$passthrough_vars" \
+		'{ts: $ts, cmd: $cmd, exit: $exit, duration_s: $duration, timeout: $timeout, network_blocked: $network_blocked, passthrough: $passthrough}')
+
+	printf '%s\n' "$log_entry" >>"$SANDBOX_LOG"
+	return 0
 }
 
 # Detect high-risk commands that could expose secret values in transcript output.
@@ -421,8 +431,13 @@ sandbox_run() {
 	local allow_secret_io=false
 	local worker_id="sandbox-$$"
 	local extra_passthrough=""
-	local command=""
 	local secret_io_guard="${AIDEVOPS_BLOCK_SECRET_IO:-$SECRET_IO_GUARD_DEFAULT}"
+
+	# Capture command and its arguments as an array to avoid bash -c eval risks:
+	# - Preserves arguments with spaces correctly (no word-splitting on expansion)
+	# - Eliminates shell injection via unquoted arguments
+	# - Avoids the eval-equivalent behaviour of bash -c "$string"
+	local -a cmd_args=()
 
 	# Parse arguments
 	while [[ $# -gt 0 ]]; do
@@ -457,27 +472,32 @@ sandbox_run() {
 			;;
 		--)
 			shift
-			command="$*"
+			cmd_args=("$@")
 			break
 			;;
 		*)
-			command="$*"
+			cmd_args=("$@")
 			break
 			;;
 		esac
 	done
 
-	if [[ -z "$command" ]]; then
+	if [[ ${#cmd_args[@]} -eq 0 ]]; then
 		log_sandbox "ERROR" "No command provided"
 		return 1
 	fi
 
+	# For pattern-matching helpers (secret guard, taint check, network tiering),
+	# pass a space-joined string representation — these functions do text matching
+	# only and do not execute the command.
+	local cmd_str="${cmd_args[*]}"
+
 	if [[ "$secret_io_guard" == "true" ]] && [[ "$allow_secret_io" != "true" ]]; then
 		local block_reason
-		if block_reason="$(_sandbox_secret_block_reason "$command")"; then
+		if block_reason="$(_sandbox_secret_block_reason "$cmd_str")"; then
 			log_sandbox "ERROR" "Blocked command due to secret leak risk: ${block_reason}"
 			log_sandbox "ERROR" "Use --allow-secret-io only for explicit user-approved local operations"
-			log_execution "$command" 126 0 "$timeout_secs" "$block_network" "$extra_passthrough"
+			log_execution "$cmd_str" 126 0 "$timeout_secs" "$block_network" "$extra_passthrough"
 			return 126
 		fi
 	fi
@@ -521,7 +541,7 @@ sandbox_run() {
 	local stdout_file="${exec_tmpdir}/stdout"
 	local stderr_file="${exec_tmpdir}/stderr"
 
-	log_sandbox "INFO" "Executing (timeout=${timeout_secs}s, network_blocked=${block_network}, tiering=${network_tiering}): ${command:0:200}"
+	log_sandbox "INFO" "Executing (timeout=${timeout_secs}s, network_blocked=${block_network}, tiering=${network_tiering}): ${cmd_str:0:200}"
 
 	# Network tiering pre-check (t1412.3): extract domains from the command
 	# and check them against the tier classification before execution.
@@ -529,25 +549,28 @@ sandbox_run() {
 	# "curl evil.ngrok.io" but cannot intercept runtime DNS resolution.
 	# The primary value is logging + post-session review, not hard blocking.
 	if [[ "$network_tiering" == true ]] && [[ -x "$NET_TIER_HELPER" ]]; then
-		_sandbox_check_network_tiers "$command" "$worker_id"
+		_sandbox_check_network_tiers "$cmd_str" "$worker_id"
 	fi
 
 	local start_time
 	start_time="$(date +%s)"
 	local exit_code=0
 	local command_tainted=false
-	if _sandbox_is_secret_tainted_command "$command"; then
+	if _sandbox_is_secret_tainted_command "$cmd_str"; then
 		command_tainted=true
 	fi
 
-	# Execute with timeout and clean environment
+	# Execute with timeout and clean environment.
+	# cmd_args is expanded as an array — each element is a separate argument,
+	# preserving spaces and avoiding any additional shell interpretation.
 	if [[ "$block_network" == true ]] && command -v sandbox-exec &>/dev/null; then
-		# macOS seatbelt: deny network access
+		# macOS seatbelt: deny network access.
+		# sandbox-exec accepts program + args directly (no shell wrapper needed).
 		local seatbelt_profile="(version 1)(allow default)(deny network*)"
 		timeout_sec "$timeout_secs" \
 			sandbox-exec -p "$seatbelt_profile" \
 			"${env_args[@]}" \
-			bash -c "$command" \
+			"${cmd_args[@]}" \
 			>"$stdout_file" 2>"$stderr_file" || exit_code=$?
 	else
 		if [[ "$block_network" == true ]]; then
@@ -555,7 +578,7 @@ sandbox_run() {
 		fi
 		timeout_sec "$timeout_secs" \
 			"${env_args[@]}" \
-			bash -c "$command" \
+			"${cmd_args[@]}" \
 			>"$stdout_file" 2>"$stderr_file" || exit_code=$?
 	fi
 
@@ -573,10 +596,12 @@ sandbox_run() {
 	_sandbox_emit_redacted_output "$stderr_file" "stderr" "$command_tainted"
 
 	# Audit log
-	log_execution "$command" "$exit_code" "$duration" "$timeout_secs" "$block_network" "$extra_passthrough"
+	log_execution "$cmd_str" "$exit_code" "$duration" "$timeout_secs" "$block_network" "$extra_passthrough"
 
-	# Async cleanup of old temp dirs (older than 60 minutes)
-	find "$SANDBOX_TMP_BASE" -maxdepth 1 -type d -mmin +60 -exec rm -rf {} + 2>/dev/null &
+	# Async cleanup of old temp dirs (older than 60 minutes).
+	# stderr is not suppressed so permission errors or other persistent failures
+	# remain visible for debugging rather than silently consuming disk space.
+	find "$SANDBOX_TMP_BASE" -maxdepth 1 -type d -mmin +60 -exec rm -rf {} + &
 
 	return "$exit_code"
 }
@@ -605,14 +630,19 @@ sandbox_audit() {
 
 	echo "Last ${last_n} sandboxed executions:"
 	echo "---"
+	# Single jq call per line extracts all four fields at once via @tsv,
+	# replacing four separate jq invocations and significantly reducing overhead
+	# for large log files.
 	tail -n "$last_n" "$SANDBOX_LOG" | while IFS= read -r line; do
 		local ts cmd exit_code duration
-		ts="$(printf '%s' "$line" | jq -r '.ts // "?"')"
-		cmd="$(printf '%s' "$line" | jq -r '.cmd // "?"' | head -c 80)"
-		exit_code="$(printf '%s' "$line" | jq -r '.exit // "?"')"
-		duration="$(printf '%s' "$line" | jq -r '.duration_s // "?"')"
+		IFS=$'\t' read -r ts cmd exit_code duration < <(
+			printf '%s' "$line" | jq -r '[.ts, .cmd, .exit, .duration_s] | map(. // "?") | @tsv'
+		)
+		# Truncate command display to 80 chars
+		cmd="${cmd:0:80}"
 		printf '%s  exit=%s  %ss  %s\n' "$ts" "$exit_code" "$duration" "$cmd"
 	done
+	return 0
 }
 
 # =============================================================================
@@ -647,7 +677,7 @@ sandbox_help() {
 sandbox-exec-helper.sh — Lightweight execution sandbox
 
 Commands:
-  run "command"              Execute command in sandboxed environment
+  run command [args...]      Execute command in sandboxed environment
   audit [--last N]           Show recent sandboxed executions
   config --show              Show sandbox configuration
   help                       Show this help
@@ -660,13 +690,17 @@ Run options:
   --worker-id ID             Worker identifier for network tier logs
   --passthrough "VAR1,VAR2"  Additional env vars to pass through
 
+  Command and its arguments are passed as separate shell words — not a single
+  quoted string. This correctly handles arguments containing spaces and avoids
+  shell injection via bash -c evaluation.
+
 Examples:
-  sandbox-exec-helper.sh run "ls -la /tmp"
-  sandbox-exec-helper.sh run --timeout 60 "npm test"
-  sandbox-exec-helper.sh run --no-network "python3 script.py"
-  sandbox-exec-helper.sh run --network-tiering --worker-id w123 "curl https://api.github.com/repos"
-  sandbox-exec-helper.sh run --allow-secret-io "gopass show aidevops/EXAMPLE"
-  sandbox-exec-helper.sh run --passthrough "GITHUB_TOKEN" "gh pr list"
+  sandbox-exec-helper.sh run ls -la /tmp
+  sandbox-exec-helper.sh run --timeout 60 npm test
+  sandbox-exec-helper.sh run --no-network python3 script.py
+  sandbox-exec-helper.sh run --network-tiering --worker-id w123 curl https://api.github.com/repos
+  sandbox-exec-helper.sh run --allow-secret-io gopass show aidevops/EXAMPLE
+  sandbox-exec-helper.sh run --passthrough "GITHUB_TOKEN" gh pr list
   sandbox-exec-helper.sh audit --last 10
 
 Security model:
@@ -676,9 +710,10 @@ Security model:
   - Secret-output command guard blocks likely credential leakage patterns
   - Optional network blocking (macOS seatbelt)
   - Network domain tiering: classify, log, flag unknown domains (t1412.3)
-  - All executions logged to JSONL audit trail
+  - All executions logged to JSONL audit trail (jq-safe JSON, injection-proof)
   - Output capped at 10MB per stream
 HELP
+	return 0
 }
 
 # =============================================================================

--- a/.agents/scripts/supervisor-archived/_common.sh
+++ b/.agents/scripts/supervisor-archived/_common.sh
@@ -221,3 +221,42 @@ portable_timeout() {
 	timeout_sec "$@"
 	return $?
 }
+
+#######################################
+# Extract token counts from a worker log file (t1114)
+# Supports camelCase (opencode JSON) and snake_case (claude CLI JSON) formats.
+# Results are stored in module-level globals _EXTRACT_TOKENS_IN and
+# _EXTRACT_TOKENS_OUT. Callers copy these into their own local variables.
+#
+# Usage:
+#   local tokens_in="" tokens_out=""
+#   extract_tokens_from_log "$log_file"
+#   tokens_in="$_EXTRACT_TOKENS_IN"
+#   tokens_out="$_EXTRACT_TOKENS_OUT"
+#
+# $1: log_file path (may be empty or non-existent — handled gracefully)
+#######################################
+_EXTRACT_TOKENS_IN=""
+_EXTRACT_TOKENS_OUT=""
+extract_tokens_from_log() {
+	local log_file="$1"
+	_EXTRACT_TOKENS_IN=""
+	_EXTRACT_TOKENS_OUT=""
+
+	if [[ -z "$log_file" || ! -f "$log_file" ]]; then
+		return 0
+	fi
+
+	local raw_in raw_out
+	raw_in=$(grep -oE '"inputTokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
+	raw_out=$(grep -oE '"outputTokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
+	if [[ -z "$raw_in" ]]; then
+		raw_in=$(grep -oE '"input_tokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
+	fi
+	if [[ -z "$raw_out" ]]; then
+		raw_out=$(grep -oE '"output_tokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
+	fi
+	[[ -n "$raw_in" ]] && _EXTRACT_TOKENS_IN="$raw_in"
+	[[ -n "$raw_out" ]] && _EXTRACT_TOKENS_OUT="$raw_out"
+	return 0
+}

--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -1398,7 +1398,10 @@ _exec_create_task() {
 			local escaped_task_id
 			# shellcheck disable=SC2016 # sed replacement pattern is intentionally literal
 			escaped_task_id=$(printf '%s' "$task_id" | sed 's/[.[\*^$()+?{|\\]/\\&/g')
-			sed -i '' "/^- \[ \] ${escaped_task_id} /d" "$todo_file" 2>/dev/null || true
+			# Use sed_inplace (portable macOS/Linux wrapper from shared-constants.sh).
+			# Match task ID followed by space or end-of-line to avoid prefix collisions
+			# (e.g. t1 matching t10). Error suppression removed per style guide.
+			sed_inplace "/^- \[ \] ${escaped_task_id}\([[:space:]]\|$\)/d" "$todo_file"
 		fi
 	fi
 

--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -1649,16 +1649,21 @@ _exec_create_subtasks() {
 	# makes this an || list — an excepted context for set -e — so no set -e abort occurs.
 	verified_count=$(grep -c "^[[:space:]]*- \[.\] ${parent_task_id}\." "$todo_file" 2>/dev/null) || verified_count=0
 	verified_count="${verified_count:-0}"
-	if [[ "$verified_count" -lt "$subtask_count" ]]; then
+	# Compare against expected_total (pre-existing + newly added) so the mismatch warning
+	# fires correctly when pre-existing subtasks are present (not just against new count).
+	local expected_total=$((existing_subtask_count + subtask_count))
+	if [[ "$verified_count" -lt "$expected_total" ]]; then
 		jq -n --arg parent "$parent_task_id" --arg ids "$created_ids" \
 			--argjson count "$subtask_count" --argjson verified "$verified_count" \
-			'{"created":true,"parent_task_id":$parent,"subtask_ids":$ids,"count":$count,"verified_count":$verified,"warning":"subtask_count_mismatch"}'
+			--argjson expected "$expected_total" \
+			'{"created":true,"parent_task_id":$parent,"subtask_ids":$ids,"count":$count,"verified_count":$verified,"expected_total":$expected,"warning":"subtask_count_mismatch"}'
 		return 0
 	fi
 
 	jq -n --arg parent "$parent_task_id" --arg ids "$created_ids" \
 		--argjson count "$subtask_count" --argjson verified "$verified_count" \
-		'{"created":true,"parent_task_id":$parent,"subtask_ids":$ids,"count":$count,"verified_count":$verified}'
+		--argjson expected "$expected_total" \
+		'{"created":true,"parent_task_id":$parent,"subtask_ids":$ids,"count":$count,"verified_count":$verified,"expected_total":$expected}'
 	return 0
 }
 

--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -1124,13 +1124,10 @@ validate_action_fields() {
 		# The executor infers priority from reasoning text when the field is absent,
 		# but if the field IS present it must be a valid value (t1197).
 		if [[ -n "$new_priority" && "$new_priority" != "null" ]]; then
-			case "$new_priority" in
-			high | medium | low | critical) ;;
-			*)
+			if ! [[ "$new_priority" =~ ^(high|medium|low|critical)$ ]]; then
 				echo "invalid new_priority: $new_priority (must be high|medium|low|critical)"
 				return 0
-				;;
-			esac
+			fi
 		fi
 		;;
 	close_verified)

--- a/.agents/scripts/supervisor-archived/ai-context.sh
+++ b/.agents/scripts/supervisor-archived/ai-context.sh
@@ -180,8 +180,8 @@ build_exclusion_context() {
 	local log_dir="${AI_REASON_LOG_DIR:-$HOME/.aidevops/logs/ai-supervisor}"
 	if [[ -d "$log_dir" ]]; then
 		local action_logs
-		action_logs=$(find "$log_dir" -maxdepth 1 -name 'actions-*.md' -print0 2>/dev/null |
-			xargs -0 ls -t 2>/dev/null | head -5)
+		action_logs=$(find "$log_dir" -maxdepth 1 -name 'actions-*.md' -print0 |
+			xargs -0 ls -t | head -5)
 
 		if [[ -n "$action_logs" ]]; then
 			while IFS= read -r log_file; do
@@ -189,8 +189,7 @@ build_exclusion_context() {
 
 				# Extract issue numbers from action logs
 				local issue_nums
-				issue_nums=$(grep -oE '"issue_number":[0-9]+' "$log_file" 2>/dev/null |
-					grep -oE '[0-9]+' || true)
+				issue_nums=$(sed -n 's/.*"issue_number":\([0-9]\+\).*/\1/p' "$log_file" || true)
 				if [[ -n "$issue_nums" ]]; then
 					while IFS= read -r inum; do
 						[[ -n "$inum" ]] && excluded_issues+="$inum\n"
@@ -199,8 +198,7 @@ build_exclusion_context() {
 
 				# Extract task IDs from action logs
 				local task_ids
-				task_ids=$(grep -oE '"task_id":"t[0-9]+"' "$log_file" 2>/dev/null |
-					grep -oE 't[0-9]+' || true)
+				task_ids=$(sed -n 's/.*"task_id":"\(t[0-9]\+\)".*/\1/p' "$log_file" || true)
 				if [[ -n "$task_ids" ]]; then
 					while IFS= read -r tid; do
 						[[ -n "$tid" ]] && excluded_tasks+="$tid\n"

--- a/.agents/scripts/supervisor-archived/ai-reason.sh
+++ b/.agents/scripts/supervisor-archived/ai-reason.sh
@@ -156,8 +156,12 @@ run_ai_reasoning() {
 	# Acquire lock
 	printf '%s %s\n' "$$" "$(date +%s)" >"$lock_file"
 
-	# Helper to release lock — called before every return
-	_release_ai_lock() { rm -f "$lock_file"; }
+	# Release lock on function return (success, failure, early-return)
+	_release_ai_lock() {
+		rm -f "$lock_file"
+		return 0
+	}
+	trap '_release_ai_lock; trap - RETURN' RETURN
 
 	local timestamp
 	timestamp=$(date -u '+%Y%m%d-%H%M%S')
@@ -169,7 +173,6 @@ run_ai_reasoning() {
 	local context
 	context=$(build_ai_context "$repo_path" "full" 2>/dev/null) || {
 		log_error "AI Reasoning: failed to build context"
-		_release_ai_lock
 		return 1
 	}
 
@@ -213,7 +216,6 @@ PROMPT
 	# Step 4: In dry-run mode, stop here
 	if [[ "$mode" == "dry-run" ]]; then
 		log_info "AI Reasoning: dry-run complete (log: $reason_log)"
-		_release_ai_lock
 		echo '{"mode":"dry-run","actions":[]}'
 		return 0
 	fi
@@ -223,7 +225,6 @@ PROMPT
 	ai_cli=$(resolve_ai_cli 2>/dev/null) || {
 		log_error "AI Reasoning: no AI CLI available"
 		echo '{"error":"no_ai_cli","actions":[]}' >>"$reason_log"
-		_release_ai_lock
 		return 1
 	}
 
@@ -232,7 +233,6 @@ PROMPT
 		log_warn "AI Reasoning: opus model unavailable, falling back to sonnet"
 		ai_model=$(resolve_model "sonnet" "$ai_cli" 2>/dev/null) || {
 			log_error "AI Reasoning: no model available"
-			_release_ai_lock
 			return 1
 		}
 	}
@@ -284,7 +284,6 @@ ${user_prompt}"
 			echo "Status: EMPTY — treated as empty action plan []"
 		} >>"$reason_log"
 		printf '%s' "[]"
-		_release_ai_lock
 		return 0
 	fi
 
@@ -416,7 +415,6 @@ SIMPLIFIED_PROMPT
 		} >>"$reason_log"
 		log_warn "AI Reasoning: raw response logged to $reason_log (${response_len} bytes, ${json_block_count} json blocks)"
 		printf '%s' "[]"
-		_release_ai_lock
 		return 0
 	fi
 
@@ -446,7 +444,6 @@ SIMPLIFIED_PROMPT
 
 	# Output the action plan
 	printf '%s' "$action_plan"
-	_release_ai_lock
 	return 0
 }
 

--- a/.agents/scripts/supervisor-archived/cron.sh
+++ b/.agents/scripts/supervisor-archived/cron.sh
@@ -602,10 +602,8 @@ cmd_auto_pickup() {
 				continue
 			fi
 
-			# Skip tasks with assignee: or started: metadata fields (t1062, t1263)
-			# Match actual metadata fields, not description text containing these words.
-			# assignee: must be followed by a username (word chars), started: by ISO timestamp.
-			if [[ "$line" =~ (assignee:[a-zA-Z0-9_-]+|started:[0-9]{4}-[0-9]{2}-[0-9]{2}T) ]]; then
+			# Skip tasks already claimed or being worked on interactively (t1062, t1263).
+			if [[ "$line" =~ [[:space:]](assignee|started): ]]; then
 				log_info "  $task_id: already claimed or in progress — skipping auto-pickup"
 				continue
 			fi
@@ -654,14 +652,6 @@ cmd_auto_pickup() {
 				continue
 			fi
 
-			# Skip tasks already claimed or being worked on interactively (t1062).
-			# assignee: means someone claimed it; started: means work has begun.
-			# Without this check, the supervisor races with interactive sessions.
-			if [[ "$line" =~ [[:space:]](assignee|started): ]]; then
-				log_info "  $task_id: already claimed/started — skipping auto-pickup"
-				continue
-			fi
-
 			# Add to supervisor
 			if cmd_add "$task_id" --repo "$repo"; then
 				picked_up=$((picked_up + 1))
@@ -703,10 +693,8 @@ cmd_auto_pickup() {
 				continue
 			fi
 
-			# Skip tasks with assignee: or started: metadata fields (t1062, t1263)
-			# Match actual metadata fields, not description text containing these words.
-			# assignee: must be followed by a username (word chars), started: by ISO timestamp.
-			if [[ "$line" =~ (assignee:[a-zA-Z0-9_-]+|started:[0-9]{4}-[0-9]{2}-[0-9]{2}T) ]]; then
+			# Skip tasks already claimed or being worked on interactively (t1062, t1263).
+			if [[ "$line" =~ [[:space:]](assignee|started): ]]; then
 				log_info "  $task_id: already claimed or in progress — skipping auto-pickup"
 				continue
 			fi
@@ -747,12 +735,6 @@ cmd_auto_pickup() {
 			# Pre-pickup check: skip tasks with merged PRs (t224).
 			if check_task_already_done "$task_id" "$repo"; then
 				log_info "  $task_id: already completed (merged PR) — skipping auto-pickup"
-				continue
-			fi
-
-			# Skip tasks already claimed or being worked on interactively (t1062).
-			if [[ "$line" =~ [[:space:]](assignee|started): ]]; then
-				log_info "  $task_id: already claimed/started — skipping auto-pickup"
 				continue
 			fi
 

--- a/.agents/scripts/supervisor-archived/cron.sh
+++ b/.agents/scripts/supervisor-archived/cron.sh
@@ -821,7 +821,7 @@ cmd_auto_pickup() {
 	# Previous head -50 limit caused parents beyond the 50th to be silently skipped.
 	local parent_ids
 	parent_ids=$(grep -E '^[[:space:]]*- \[ \] (t[0-9]+) .*#auto-dispatch' "$todo_file" 2>/dev/null |
-		grep -oE 't[0-9]+' | sort -u || true)
+		sed -E 's/^[[:space:]]*- \[[ ]\] (t[0-9]+).*/\1/' | sort -u || true)
 
 	if [[ -n "$parent_ids" ]]; then
 		while IFS= read -r parent_id; do

--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -2289,12 +2289,12 @@ fi
 This catches CI failures 5-10 min earlier. Do NOT push .sh files with ShellCheck violations.
 If \`shellcheck\` is not installed, skip this gate and note it in the PR body.
 
-**3b. PR title MUST contain task ID (MANDATORY — t318.2)**
+**PR title MUST contain task ID (MANDATORY — t318.2)**
 When creating a PR, the title MUST start with the task ID: \`<task-id>: <description>\`.
 Example: \`t318.2: Verify supervisor worker PRs include task ID\`
 The CI pipeline and supervisor both validate this. PRs without task IDs fail the check.
 If you used \`gh pr create --draft --title '<task-id>: <description>'\` as instructed above,
-this is already handled. This note reinforces: NEVER omit the task ID from the PR title.
+this is already handled. This note reinforces step 3: NEVER omit the task ID from the PR title.
 
 **4. Offload research to ai_research tool (saves context for implementation)**
 Reading large files (500+ lines) consumes your context budget fast. Instead of reading

--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -566,9 +566,11 @@ record_dispatch_model_tiers() {
 
 	# Store to DB (non-blocking)
 	if [[ -n "${SUPERVISOR_DB:-}" ]]; then
-		local escaped_id
-		escaped_id=$(sql_escape "$task_id")
-		db "$SUPERVISOR_DB" "UPDATE tasks SET requested_tier = '$(sql_escape "$requested_tier")', actual_tier = '$(sql_escape "$actual_tier")' WHERE id = '$escaped_id';" 2>/dev/null || true
+		db_param "$SUPERVISOR_DB" \
+			"UPDATE tasks SET requested_tier = :requested_tier, actual_tier = :actual_tier WHERE id = :task_id;" \
+			"requested_tier=$requested_tier" \
+			"actual_tier=$actual_tier" \
+			"task_id=$task_id" 2>/dev/null || true
 	fi
 
 	# Log tier delta for immediate visibility

--- a/.agents/scripts/supervisor-archived/evaluate.sh
+++ b/.agents/scripts/supervisor-archived/evaluate.sh
@@ -230,14 +230,14 @@ validate_pr_belongs_to_task() {
 	pr_branch=$(echo "$pr_info" | jq -r '.headRefName // ""' 2>/dev/null || echo "")
 
 	# Check if task ID appears in title or branch (case-insensitive).
-	# Uses word boundary \b so "t195" matches "feature/t195", "(t195)",
+	# Use portable ERE token boundaries so "t195" matches "feature/t195", "(t195)",
 	# "t195-fix-auth" but NOT "t1950" or "t1195".
-	if echo "$pr_title" | grep -qi "\b${task_id}\b" 2>/dev/null; then
+	if echo "$pr_title" | grep -Eqi "(^|[^[:alnum:]_])${task_id}([^[:alnum:]_]|$)" 2>/dev/null; then
 		echo "$pr_url"
 		return 0
 	fi
 
-	if echo "$pr_branch" | grep -qi "\b${task_id}\b" 2>/dev/null; then
+	if echo "$pr_branch" | grep -Eqi "(^|[^[:alnum:]_])${task_id}([^[:alnum:]_]|$)" 2>/dev/null; then
 		echo "$pr_url"
 		return 0
 	fi

--- a/.agents/scripts/supervisor-archived/evaluate.sh
+++ b/.agents/scripts/supervisor-archived/evaluate.sh
@@ -812,7 +812,10 @@ record_evaluation_metadata() {
 	local quality_score="${5:-0}"
 	local ai_evaluated="${6:-false}"
 
-	local pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+	local pattern_helper="${SCRIPT_DIR}/../pattern-tracker-helper.sh"
+	if [[ ! -x "$pattern_helper" ]]; then
+		pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+	fi
 	if [[ ! -x "$pattern_helper" ]]; then
 		pattern_helper="$HOME/.aidevops/agents/scripts/pattern-tracker-helper.sh"
 	fi
@@ -847,21 +850,11 @@ record_evaluation_metadata() {
 	fi
 
 	# Extract token counts from worker log for cost tracking (t1114, t1117)
-	# Supports camelCase (opencode JSON) and snake_case (claude CLI JSON) formats.
+	# Shared extraction logic lives in supervisor-archived/_common.sh (extract_tokens_from_log).
 	local tokens_in="" tokens_out=""
-	if [[ -n "$task_log_file" && -f "$task_log_file" ]]; then
-		local raw_in raw_out
-		raw_in=$(grep -oE '"inputTokens":[0-9]+' "$task_log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		raw_out=$(grep -oE '"outputTokens":[0-9]+' "$task_log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		if [[ -z "$raw_in" ]]; then
-			raw_in=$(grep -oE '"input_tokens":[0-9]+' "$task_log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		fi
-		if [[ -z "$raw_out" ]]; then
-			raw_out=$(grep -oE '"output_tokens":[0-9]+' "$task_log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		fi
-		[[ -n "$raw_in" ]] && tokens_in="$raw_in"
-		[[ -n "$raw_out" ]] && tokens_out="$raw_out"
-	fi
+	extract_tokens_from_log "$task_log_file"
+	tokens_in="$_EXTRACT_TOKENS_IN"
+	tokens_out="$_EXTRACT_TOKENS_OUT"
 
 	# Look up task type from DB tags if available, fallback to "unknown"
 	# TODO(t1096): extract real task type from TODO.md tags or DB metadata

--- a/.agents/scripts/supervisor-archived/memory-integration.sh
+++ b/.agents/scripts/supervisor-archived/memory-integration.sh
@@ -227,20 +227,11 @@ store_success_pattern() {
 
 	# Extract token counts from worker log for cost tracking (t1114)
 	# opencode/claude --format json logs emit usage stats in the final JSON entry.
+	# Shared extraction logic lives in supervisor-archived/_common.sh (extract_tokens_from_log).
 	local tokens_in="" tokens_out=""
-	if [[ -n "$log_file" && -f "$log_file" ]]; then
-		local raw_in raw_out
-		raw_in=$(grep -oE '"inputTokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		raw_out=$(grep -oE '"outputTokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		if [[ -z "$raw_in" ]]; then
-			raw_in=$(grep -oE '"input_tokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		fi
-		if [[ -z "$raw_out" ]]; then
-			raw_out=$(grep -oE '"output_tokens":[0-9]+' "$log_file" 2>/dev/null | tail -1 | grep -oE '[0-9]+' || true)
-		fi
-		[[ -n "$raw_in" ]] && tokens_in="$raw_in"
-		[[ -n "$raw_out" ]] && tokens_out="$raw_out"
-	fi
+	extract_tokens_from_log "$log_file"
+	tokens_in="$_EXTRACT_TOKENS_IN"
+	tokens_out="$_EXTRACT_TOKENS_OUT"
 
 	# Build tags with model and duration info for pattern-tracker queries
 	local tags="supervisor,pattern,$task_id,complete"
@@ -252,7 +243,10 @@ store_success_pattern() {
 	tags="$tags,quality:${quality_score},failure_mode:NONE"
 
 	# Use pattern-tracker-helper.sh directly when available for richer metadata (t1114)
-	local pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+	local pattern_helper="${SCRIPT_DIR}/../pattern-tracker-helper.sh"
+	if [[ ! -x "$pattern_helper" ]]; then
+		pattern_helper="${SCRIPT_DIR}/pattern-tracker-helper.sh"
+	fi
 	if [[ ! -x "$pattern_helper" ]]; then
 		pattern_helper="$HOME/.aidevops/agents/scripts/pattern-tracker-helper.sh"
 	fi

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -3836,7 +3836,7 @@ cmd_triage() {
 
 		# Extract PR number and repo slug from URL
 		local pr_num="" triage_repo_slug=""
-		if [[ "$tpr" =~ github\.com/([^/]+/[^/]+)/pull/([0-9]+)$ ]]; then
+		if [[ "$tpr" =~ github\.com/([^/]+/[^/]+)/pull/([0-9]+)(/)?([?#].*)?$ ]]; then
 			triage_repo_slug="${BASH_REMATCH[1]}"
 			pr_num="${BASH_REMATCH[2]}"
 		fi

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2289,7 +2289,7 @@ cmd_pulse() {
 				# Dead worker: PID no longer exists
 				rm -f "$pid_file"
 				# t1222: Clean up hang warning marker for dead workers
-				rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned"
+				rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned" 2>/dev/null || true
 				if [[ "$health_status" == "running" || "$health_status" == "dispatched" ]]; then
 					log_warn "  Dead worker for $health_task (PID $health_pid gone, was $health_status) — evaluating"
 					cmd_evaluate "$health_task" --no-ai 2>>"$SUPERVISOR_LOG" || {
@@ -2420,7 +2420,7 @@ cmd_pulse() {
 						fi
 						rm -f "$pid_file"
 						# t1222: Clean up hang warning marker on kill
-						rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned"
+						rm -f "$SUPERVISOR_DIR/pids/${health_task}.hang-warned" 2>/dev/null || true
 
 						# t1074: Auto-retry timed-out workers up to max_retries before marking failed.
 						# Check if the task has a PR already (worker may have created one before timeout).

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -1029,7 +1029,7 @@ cmd_pulse() {
 	local fast_path_evaluating_grace="${SUPERVISOR_FAST_PATH_EVALUATING_GRACE_SECONDS:-30}"
 	local fast_path_evaluating_tasks
 	fast_path_evaluating_tasks=$(db -separator '|' "$SUPERVISOR_DB" "
-		SELECT id, status, updated_at FROM tasks
+		SELECT id, status, updated_at, retries, max_retries, pr_url FROM tasks
 		WHERE status = 'evaluating'
 		AND pr_url IS NOT NULL
 		AND pr_url != ''
@@ -1043,7 +1043,7 @@ cmd_pulse() {
 	# Query evaluating tasks without PR URL — use standard grace period
 	local stale_evaluating_tasks
 	stale_evaluating_tasks=$(db -separator '|' "$SUPERVISOR_DB" "
-		SELECT id, status, updated_at FROM tasks
+		SELECT id, status, updated_at, retries, max_retries, pr_url FROM tasks
 		WHERE status = 'evaluating'
 		AND (pr_url IS NULL OR pr_url = '' OR pr_url = 'no_pr' OR pr_url = 'task_only' OR pr_url = 'task_obsolete')
 		AND updated_at < strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '-${evaluating_grace_seconds} seconds')
@@ -1065,7 +1065,7 @@ cmd_pulse() {
 		local stale_recovered=0
 		local stale_skipped=0
 
-		while IFS='|' read -r stale_id stale_status stale_updated; do
+		while IFS='|' read -r stale_id stale_status stale_updated stale_retries stale_max_retries stale_pr_url; do
 			[[ -z "$stale_id" ]] && continue
 
 			# Check if a live worker process exists for this task
@@ -1118,10 +1118,11 @@ cmd_pulse() {
 			local diag_eval_started_at="${_DIAG_EVAL_STARTED_AT:-}"
 			local diag_eval_lag_secs="${_DIAG_EVAL_LAG_SECS:-NULL}"
 
-			local stale_retries stale_max_retries stale_pr_url
-			stale_retries=$(db "$SUPERVISOR_DB" "SELECT retries FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "0")
-			stale_max_retries=$(db "$SUPERVISOR_DB" "SELECT max_retries FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}")
-			stale_pr_url=$(db "$SUPERVISOR_DB" "SELECT pr_url FROM tasks WHERE id = '$(sql_escape "$stale_id")';" 2>/dev/null || echo "")
+			# stale_retries, stale_max_retries, stale_pr_url are parsed from the initial
+			# query (fetched upfront to avoid per-task DB calls inside the loop).
+			# Apply defaults in case the DB returned empty strings.
+			stale_retries="${stale_retries:-0}"
+			stale_max_retries="${stale_max_retries:-${SUPERVISOR_DEFAULT_MAX_RETRIES:-3}}"
 
 			local had_pr_flag=0
 			[[ -n "$stale_pr_url" && "$stale_pr_url" != "no_pr" && "$stale_pr_url" != "task_only" ]] && had_pr_flag=1

--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -2016,12 +2016,13 @@ cmd_reconcile_queue_dispatchability() {
 			# The next git pull removes the local-only line, leaving a DB-only
 			# task that can never be dispatched (dispatch requires TODO.md claim).
 			# Cancel these orphans to prevent permanent dispatch stall.
+			phantom_count=$((phantom_count + 1))
 			if [[ "$dry_run" == "true" ]]; then
 				log_warn "[dry-run] Phase 0.6: $tid queued in DB but not in TODO.md — would cancel (orphaned, t1261)"
 			else
 				log_warn "Phase 0.6: $tid queued in DB but not in TODO.md — cancelling orphan (t1261)"
 				db "$SUPERVISOR_DB" "UPDATE tasks SET status='cancelled', error='Orphaned: queued in DB but not found in TODO.md (t1261)' WHERE id='$(sql_escape "$tid")' AND status='queued';" || true
-				phantom_count=$((phantom_count + 1))
+				cancelled_count=$((cancelled_count + 1))
 			fi
 			continue
 		fi

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -461,6 +461,11 @@ _test_approval_filter() {
 			"\\bnothing (further|more) to recommend\\b"; "i")) as $no_actionable_recommendation |
 
 		($body | test(
+			"\\bno suggestions? (at this time|for now|currently)?\\b|" +
+			"\\bwithout suggestions?\\b|" +
+			"\\bhas no suggestions?\\b"; "i")) as $no_actionable_suggestion |
+
+		($body | test(
 			"\\blgtm\\b|\\blooks good( to me)?\\b|\\bgood work\\b|" +
 			"\\bno (further |more )?(comments?|issues?|concerns?|feedback)\\b|" +
 			"\\beverything (looks?|seems?) (good|fine|correct|great|solid|clean)\\b"; "i")) as $no_actionable_sentiment |
@@ -480,8 +485,8 @@ _test_approval_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $actionable |
 
-		# skip = approval-only/no-recommendation/summary-praise AND NOT actionable
-		if (($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not)) then "skip"
+		# skip = explicit no-suggestions OR approval-only/no-recommendation/summary-praise with no actionable critique
+		if ($no_actionable_suggestion or (($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not))) then "skip"
 		else "keep"
 		end
 	')
@@ -577,6 +582,17 @@ test_skips_gemini_style_positive_summary_review() {
 	return 0
 }
 
+test_skips_no_suggestions_at_this_time_review() {
+	local result
+	result=$(_test_approval_filter "Review completed. No suggestions at this time.")
+	if [[ "$result" == "skip" ]]; then
+		print_result "skip 'no suggestions at this time' review" 0
+	else
+		print_result "skip 'no suggestions at this time' review" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
 test_keeps_actionable_approved_review() {
 	# APPROVED review that also contains actionable critique — must be kept
 	local result
@@ -652,6 +668,7 @@ main() {
 	test_skips_found_no_issues_long_review
 	test_skips_no_further_recommendations_review
 	test_skips_gemini_style_positive_summary_review
+	test_skips_no_suggestions_at_this_time_review
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -76,12 +76,13 @@ _mock_gh_api() {
 	local endpoint=""
 
 	while [[ $# -gt 0 ]]; do
+		local token="$1"
 		case "$1" in
 		-H | --jq)
 			shift 2
 			;;
 		repos/*)
-			endpoint="$1"
+			endpoint="$token"
 			shift
 			;;
 		*)
@@ -465,6 +466,11 @@ _test_approval_filter() {
 			"\\beverything (looks?|seems?) (good|fine|correct|great|solid|clean)\\b"; "i")) as $no_actionable_sentiment |
 
 		($body | test(
+			"\\bsuccessfully addresses?\\b|\\beffectively\\b|\\bimproves?\\b|\\benhances?\\b|" +
+			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
+			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
+
+		($body | test(
 			"\\bshould\\b|\\bconsider\\b|\\binstead\\b|\\bsuggest|\\brecommend(ed|ing)?\\b|" +
 			"\\bwarning\\b|\\bcaution\\b|\\bavoid\\b|\\b(don ?'"'"'?t|do not)\\b|" +
 			"\\bvulnerab|\\binsecure|\\binjection\\b|\\bxss\\b|\\bcsrf\\b|" +
@@ -474,8 +480,8 @@ _test_approval_filter() {
 			"\\bworkaround\\b|\\bhack\\b|" +
 			"```\\s*(suggestion|diff)"; "i")) as $actionable |
 
-		# skip = approval-only/no-recommendation AND NOT actionable
-		if (($approval_only or $no_actionable_recommendation or $no_actionable_sentiment) and ($actionable | not)) then "skip"
+		# skip = approval-only/no-recommendation/summary-praise AND NOT actionable
+		if (($approval_only or $no_actionable_recommendation or $no_actionable_sentiment or $summary_praise_only) and ($actionable | not)) then "skip"
 		else "keep"
 		end
 	')
@@ -545,6 +551,17 @@ test_skips_no_further_recommendations_review() {
 		print_result "skip 'no further recommendations' review" 0
 	else
 		print_result "skip 'no further recommendations' review" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
+test_skips_gemini_style_positive_summary_review() {
+	local result
+	result=$(_test_approval_filter "This pull request successfully addresses the issue by removing an external dependency and improves robustness. The addition of no-data messaging enhances user experience.")
+	if [[ "$result" == "skip" ]]; then
+		print_result "skip Gemini-style positive summary review" 0
+	else
+		print_result "skip Gemini-style positive summary review" 1 "expected skip, got ${result}"
 	fi
 	return 0
 }
@@ -622,6 +639,7 @@ main() {
 	test_skips_good_work_review
 	test_skips_no_issues_review
 	test_skips_no_further_recommendations_review
+	test_skips_gemini_style_positive_summary_review
 	test_keeps_actionable_approved_review
 	test_keeps_changes_requested_review
 	test_keeps_review_with_bug_report

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -544,6 +544,17 @@ test_skips_no_issues_review() {
 	return 0
 }
 
+test_skips_found_no_issues_long_review() {
+	local result
+	result=$(_test_approval_filter "This pull request enhances the AI supervisor's reasoning capabilities by introducing self-improvement and efficiency analysis. It adds two new action types, create_improvement and escalate_model, along with corresponding analysis frameworks and examples in the system prompt. The updates to the prompt are clear and consistent with the stated goals. I've reviewed the changes and found no issues. The new capabilities are a strong step toward a more intelligent supervisor.")
+	if [[ "$result" == "skip" ]]; then
+		print_result "skip long summary review with 'found no issues'" 0
+	else
+		print_result "skip long summary review with 'found no issues'" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
 test_skips_no_further_recommendations_review() {
 	local result
 	result=$(_test_approval_filter "The pull request is well-documented and the fixes are implemented correctly. I have no further recommendations.")
@@ -638,6 +649,7 @@ main() {
 	test_skips_looks_good_review
 	test_skips_good_work_review
 	test_skips_no_issues_review
+	test_skips_found_no_issues_long_review
 	test_skips_no_further_recommendations_review
 	test_skips_gemini_style_positive_summary_review
 	test_keeps_actionable_approved_review

--- a/.agents/services/analytics/google-analytics.md
+++ b/.agents/services/analytics/google-analytics.md
@@ -9,7 +9,7 @@ tools:
   glob: true
   grep: true
   webfetch: true
-  google-analytics-mcp_*: true
+  google_analytics_mcp_*: true
 ---
 
 # Google Analytics MCP Integration
@@ -100,7 +100,7 @@ Add to `~/.config/opencode/opencode.json` (disabled globally for token efficienc
 }
 ```
 
-**Per-Agent Enablement**: Google Analytics tools are enabled via `google-analytics-mcp_*: true` in this subagent's `tools:` section. Main agents (`seo.md`, `marketing.md`, `sales.md`) reference this subagent for analytics operations, ensuring the MCP is only loaded when needed.
+**Per-Agent Enablement**: Google Analytics tools are enabled via `google_analytics_mcp_*: true` in this subagent's `tools:` section. Main agents (`seo.md`, `marketing.md`, `sales.md`) reference this subagent for analytics operations, ensuring the MCP is only loaded when needed.
 
 ### Gemini CLI Configuration
 

--- a/.agents/services/communications/discord.md
+++ b/.agents/services/communications/discord.md
@@ -519,8 +519,8 @@ Map Discord roles to aidevops runners. Users with specific roles get routed to t
 import { ChatInputCommandInteraction, GuildMember, TextChannel } from "discord.js";
 
 interface BotConfig {
-  channelRouting: Record<string, string>;
-  roleRouting: Record<string, string>;
+  channelRouting: { [key: string]: string };
+  roleRouting: { [key: string]: string };
   defaultRunner: string;
   allowedGuilds?: string[];
   allowedChannels?: string[];
@@ -564,7 +564,7 @@ function resolveRunner(
 
 ```typescript
 import { ChatInputCommandInteraction, GuildMember } from "discord.js";
-// BotConfig defined in Role-Based Routing section above
+
 
 function checkAccess(
   interaction: ChatInputCommandInteraction,
@@ -682,18 +682,13 @@ Users should assume:
 ### Dispatch Pattern
 
 ```typescript
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
+import { spawnSync } from "node:child_process";
 
-const execFileAsync = promisify(execFile);
-
-async function dispatchToRunner(
-  runner: string,
-  prompt: string
-): Promise<string> {
-  // Use execFile with array args to prevent command injection
-  // (never use execSync with string interpolation)
-  const { stdout } = await execFileAsync(
+function dispatchToRunner(runner: string, prompt: string): string {
+  // Use spawnSync with argument array — bypasses the shell entirely,
+  // preventing injection via ;, |, &&, $(), backticks, and all other
+  // shell metacharacters. Never use execSync with string interpolation.
+  const child = spawnSync(
     "runner-helper.sh",
     ["dispatch", runner, prompt],
     {
@@ -703,7 +698,16 @@ async function dispatchToRunner(
     }
   );
 
-  return stdout.trim();
+  if (child.error) {
+    throw child.error;
+  }
+
+  if (child.status !== 0) {
+    // Note: stderr may contain sensitive info — sanitize before surfacing to users
+    throw new Error(`Runner failed with exit code ${child.status}: ${child.stderr}`);
+  }
+
+  return child.stdout.trim();
 }
 ```
 
@@ -775,9 +779,11 @@ import {
   createAudioResource,
 } from "@discordjs/voice";
 
-// Obtain the guild from the client cache
+// Fetch the guild from the client (assuming 'client' is your Discord.js Client instance)
 const guild = client.guilds.cache.get("GUILD_ID");
-if (!guild) throw new Error("Guild not found");
+if (!guild) {
+  throw new Error("Guild not found");
+}
 
 // Join voice channel
 const connection = joinVoiceChannel({

--- a/.agents/services/communications/discord.md
+++ b/.agents/services/communications/discord.md
@@ -52,7 +52,7 @@ tools:
 │  Browser)        │     │                  │     │                  │
 │                  │────▶│ Events:          │────▶│ 1. Parse event   │
 │ User sends:      │     │ - messageCreate  │     │ 2. Check perms   │
-│ /ask Review auth │     │ - interactionCr. │     │ 3. Route command  │
+│ /ask Review auth │     │ - interactionCreate │  │ 3. Route command  │
 │                  │◀────│ - guildMemberAdd │◀────│ 4. Dispatch       │
 │ Bot response     │     │ - threadCreate   │     │ 5. Respond        │
 └──────────────────┘     └──────────────────┘     └──────────────────┘
@@ -443,6 +443,8 @@ if (channel.isTextBased() && "threads" in channel) {
 ### Forum Channels
 
 ```typescript
+import { ChannelType } from "discord.js";
+
 // Post to a forum channel
 const forum = await client.channels.fetch("FORUM_CHANNEL_ID");
 if (forum?.type === ChannelType.GuildForum) {
@@ -514,6 +516,21 @@ Map Discord roles to aidevops runners. Users with specific roles get routed to t
 ### Routing Logic
 
 ```typescript
+import { ChatInputCommandInteraction, GuildMember, TextChannel } from "discord.js";
+
+interface BotConfig {
+  channelRouting: Record<string, string>;
+  roleRouting: Record<string, string>;
+  defaultRunner: string;
+  allowedGuilds?: string[];
+  allowedChannels?: string[];
+  allowedUsers?: string[];
+  allowedRoles?: string[];
+  adminRoles?: string[];
+  maxPromptLength?: number;
+  responseTimeout?: number;
+}
+
 function resolveRunner(
   interaction: ChatInputCommandInteraction,
   config: BotConfig
@@ -546,6 +563,9 @@ function resolveRunner(
 ### Guild/Channel/User/Role Allowlists
 
 ```typescript
+import { ChatInputCommandInteraction, GuildMember } from "discord.js";
+// BotConfig defined in Role-Based Routing section above
+
 function checkAccess(
   interaction: ChatInputCommandInteraction,
   config: BotConfig
@@ -755,10 +775,14 @@ import {
   createAudioResource,
 } from "@discordjs/voice";
 
+// Obtain the guild from the client cache
+const guild = client.guilds.cache.get("GUILD_ID");
+if (!guild) throw new Error("Guild not found");
+
 // Join voice channel
 const connection = joinVoiceChannel({
   channelId: "VOICE_CHANNEL_ID",
-  guildId: "GUILD_ID",
+  guildId: guild.id,
   adapterCreator: guild.voiceAdapterCreator,
 });
 
@@ -831,7 +855,7 @@ After=network.target
 Type=simple
 User=discord-bot
 WorkingDirectory=/opt/discord-bot
-ExecStart=/usr/bin/node --import tsx src/bot.ts
+ExecStart=/opt/discord-bot/node_modules/.bin/tsx src/bot.ts
 Restart=on-failure
 RestartSec=5
 Environment=NODE_ENV=production
@@ -852,7 +876,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev
 COPY . .
-CMD ["node", "--import", "tsx", "src/bot.ts"]
+CMD ["./node_modules/.bin/tsx", "src/bot.ts"]
 ```
 
 ### Health Monitoring

--- a/.agents/services/communications/msteams.md
+++ b/.agents/services/communications/msteams.md
@@ -721,7 +721,8 @@ async function dispatchToRunner(prompt, context) {
     );
     return stdout.trim();
   } catch (error) {
-    return `Runner dispatch failed: ${error.message}`;
+    console.error("Runner dispatch failed", { error });
+    return "Runner dispatch failed. Please try again later or contact an administrator.";
   }
 }
 ```

--- a/.agents/services/communications/nostr.md
+++ b/.agents/services/communications/nostr.md
@@ -235,7 +235,10 @@ import {
 } from "nostr-tools";
 
 // Load bot private key from secure storage (never hardcode)
-const sk = hexToBytes(process.env.NOSTR_BOT_SK_HEX!);
+// Store as nsec via: aidevops secret set NOSTR_BOT_NSEC
+const botNsec = process.env.NOSTR_BOT_NSEC;
+if (!botNsec) throw new Error("NOSTR_BOT_NSEC not set");
+const { data: sk } = nip19.decode(botNsec) as { data: Uint8Array };
 const pk = getPublicKey(sk);
 
 console.log(`Bot pubkey: ${nip19.npubEncode(pk)}`);
@@ -306,7 +309,7 @@ NOSTR_ALLOWED_PUBKEYS="<hex-pubkey-1>,<hex-pubkey-2>"
 
 ```json
 {
-  "botSkHex": "DO_NOT_STORE_HERE_USE_GOPASS",
+  "botNsecPath": "aidevops/nostr-bot/nsec",
   "allowedPubkeys": [
     "abc123...",
     "def456..."
@@ -321,7 +324,7 @@ NOSTR_ALLOWED_PUBKEYS="<hex-pubkey-1>,<hex-pubkey-2>"
 }
 ```
 
-**Note**: The `botSkHex` field should reference a gopass secret or environment variable, not contain the actual key. The config template shows the field for documentation; the actual implementation reads from `NOSTR_BOT_SK_HEX` env var or `aidevops secret get NOSTR_BOT_SK_HEX`.
+**Note**: The `botNsecPath` field is a gopass path — the actual `nsec` value is stored in gopass and never written to disk. Store it via `aidevops secret set NOSTR_BOT_NSEC`, then set `NOSTR_BOT_NSEC` in your environment from gopass at runtime. The config template shows the path for documentation; the actual implementation reads from the `NOSTR_BOT_NSEC` env var.
 
 ### NIP-17 Gift-Wrapped DMs (Planned)
 

--- a/.agents/services/monitoring/langwatch.md
+++ b/.agents/services/monitoring/langwatch.md
@@ -222,7 +222,7 @@ Docker Compose stack:
   langwatch/opensearch-lite      → Trace storage + search on :9200
 ```
 
-**Port conflicts**: The default ports (5432, 6379) may conflict with existing local services. If using the shared localdev Postgres, update `DATABASE_URL` in `.env` to point at the shared instance and remove the `postgres` service from `compose.yml`.
+**Port conflicts**: The default ports (5432, 6379) may conflict with existing local services. If using the shared localdev Postgres, update `DATABASE_URL` in `.env` to point at the shared instance and remove the `postgres` service from `docker-compose.yml`.
 
 ## Troubleshooting
 
@@ -235,14 +235,14 @@ lsof -i :6379  # Redis
 lsof -i :9200  # OpenSearch
 ```
 
-Either stop the conflicting service or remap ports in `compose.yml`.
+Either stop the conflicting service or remap ports in `docker-compose.yml`.
 
 ### OpenSearch out of memory
 
 The default config limits OpenSearch to 256MB. If it OOMs on large trace volumes:
 
 ```yaml
-# In compose.yml, increase the limit
+# In docker-compose.yml, increase the limit
 environment:
   - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
 deploy:

--- a/.agents/services/monitoring/sentry.md
+++ b/.agents/services/monitoring/sentry.md
@@ -66,10 +66,13 @@ chmod 600 ~/.config/aidevops/credentials.sh
 
 ```bash
 source ~/.config/aidevops/credentials.sh
+tmp_json="$(mktemp)"
 jq --arg token "$SENTRY_YOURNAME" \
-  '.mcp.sentry = {"type": "local", "command": ["npx", "@sentry/mcp-server@latest", "--access-token", $token], "enabled": false}' \
-  ~/.config/opencode/opencode.json > /tmp/oc.json && mv /tmp/oc.json ~/.config/opencode/opencode.json
+  '.mcpServers.sentry = {"command": "npx", "args": ["@sentry/mcp-server@latest", "--access-token", $token], "enabled": true}' \
+  ~/.config/opencode/opencode.json > "$tmp_json" && mv "$tmp_json" ~/.config/opencode/opencode.json
 ```
+
+`~/.config/opencode/opencode.json` is local machine config and should never be committed.
 
 ### 4. Test Connection
 
@@ -110,6 +113,8 @@ npx @sentry/wizard@latest -i react   # React
 
 The wizard creates all required config files. See [Sentry Docs](https://docs.sentry.io/) for platform-specific guides.
 
+If you manually configure SDK options, keep `sendDefaultPii` disabled unless you explicitly need user/IP metadata and have privacy coverage for it.
+
 ## Troubleshooting
 
 ### Token returns empty organizations
@@ -118,7 +123,7 @@ Create a new Personal Auth Token **after** the organization exists.
 
 ### "Not authenticated"
 
-1. Verify token: `source ~/.config/aidevops/credentials.sh && echo $SENTRY_YOURNAME`
+1. Verify key exists: `source ~/.config/aidevops/credentials.sh && printenv | cut -d= -f1 | grep '^SENTRY_YOURNAME$'`
 2. Test API: `curl -H "Authorization: Bearer $SENTRY_YOURNAME" https://sentry.io/api/0/`
 3. Restart OpenCode after config changes
 

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -850,7 +850,7 @@ classify(task, lineage)
 
 ### Helper Script
 
-`task-decompose-helper.sh` provides three subcommands:
+`task-decompose-helper.sh` provides these subcommands (`format-lineage`, not `lineage`):
 
 ```bash
 # Classify: atomic or composite? (~$0.001, haiku tier)
@@ -865,6 +865,10 @@ task-decompose-helper.sh decompose "Build auth with login and OAuth" --max-subta
 task-decompose-helper.sh format-lineage --parent "Build auth" \
   --children '[{"description": "login"}, {"description": "OAuth"}]' --current 1
 # → formatted hierarchy with sibling tasks
+
+# Check if task already has child subtasks in TODO.md
+task-decompose-helper.sh has-subtasks t1408 --todo-file ./TODO.md
+# → true|false
 ```
 
 ### Configuration

--- a/.agents/tools/browser/chrome-devtools.md
+++ b/.agents/tools/browser/chrome-devtools.md
@@ -50,7 +50,7 @@ npx chrome-devtools-mcp@latest --autoConnect
 
 **Capabilities**:
 - Performance: `lighthouse()`, `measureWebVitals()` (LCP, FID, CLS, TTFB)
-- Network: `monitorNetwork()`, global network throttling via `emulate` tool with `networkConditions`
+- Network: `monitorNetwork()`, global throttling via `emulate` with `networkConditions`, individual request throttling via `throttleRequest()` / `throttleRequests()` (Chrome 144+)
 - Scraping: `extractData()`, `screenshot()` (fullPage, element)
 - Debug: `captureConsole()`, CSS coverage, visual regression
 - Mobile: `emulateDevice()`, `simulateTouch()` (tap, swipe)
@@ -175,7 +175,72 @@ await chromeDevTools.emulate({
 });
 ```
 
-**Note**: Per-request throttling is available in Chrome DevTools UI (right-click request → "Throttle request") but is not exposed via the MCP tool API. Use global network throttling above for programmatic testing.
+### **Individual Request Throttling** (Chrome 144+)
+
+Chrome 144+ supports throttling individual network requests rather than the entire page. This enables precise testing of how your application handles slow-loading specific resources.
+
+**Manual DevTools usage**: Right-click any request in the Network panel → "Throttle request URL" (Chrome 144+).
+
+**Use cases:**
+- Test lazy-loading behavior when specific images load slowly
+- Simulate slow API responses without affecting other requests
+- Debug race conditions when certain scripts load out of order
+- Test error handling for slow third-party resources
+
+> **Note**: The `url` parameter specifies the page to navigate to before applying throttling rules. These functions first navigate to the specified `url`, then apply the throttling rules for the duration of that page load.
+
+```javascript
+// Throttle a specific API endpoint
+await chromeDevTools.throttleRequest({
+  url: "https://your-website.com",  // page to navigate to
+  requestPattern: "**/api/slow-endpoint",
+  latency: 3000,  // Add 3 second delay
+  downloadThroughput: 50 * 1024  // 50 KB/s
+});
+
+// Throttle specific image requests
+await chromeDevTools.throttleRequest({
+  url: "https://your-website.com",
+  requestPattern: "*.jpg",
+  latency: 2000,
+  downloadThroughput: 100 * 1024  // 100 KB/s
+});
+
+// Throttle multiple patterns with different conditions
+// Rules are evaluated in order — the first matching rule wins.
+// In the example below, **/api/critical matches the first rule (no throttling)
+// and is NOT further matched by the second **/api/* rule.
+await chromeDevTools.throttleRequests({
+  url: "https://your-website.com",
+  rules: [
+    {
+      pattern: "**/api/critical",
+      latency: 0,
+      downloadThroughput: -1  // No throttling (priority)
+    },
+    {
+      pattern: "**/api/*",
+      latency: 1500,
+      downloadThroughput: 200 * 1024
+    },
+    {
+      pattern: "*.woff2",
+      latency: 500,
+      downloadThroughput: 50 * 1024
+    }
+  ]
+});
+```
+
+**Comparison: Page-Level vs Individual Request Throttling**
+
+| Feature | Page-Level (`emulate`) | Individual Request (`throttleRequest`) |
+|---------|----------------------|---------------------------------------|
+| Scope | All requests | Specific URL patterns |
+| Precision | Coarse | Fine-grained |
+| Use case | General slow network | Targeted resource testing |
+| Chrome version | All versions | Chrome 144+ |
+| MCP API | `emulate` tool | `throttleRequest` / `throttleRequests` |
 
 ## 📱 **Mobile Testing**
 

--- a/.agents/tools/code-review/code-standards.md
+++ b/.agents/tools/code-review/code-standards.md
@@ -333,11 +333,13 @@ echo "hello"
 
 More text.
 
-<!-- INCORRECT - Missing blank line -->
+<!-- INCORRECT - Missing blank line before code block -->
 Some text.
 ```bash
 echo "hello"
 ```
+
+More text.
 ````
 
 **Validation**:

--- a/.agents/tools/context/context-builder.md
+++ b/.agents/tools/context/context-builder.md
@@ -28,22 +28,22 @@ note: Uses repomix CLI directly (not MCP) for better control and reliability
 
 ```bash
 # Compress mode (recommended) - extracts code structure only
-context-builder-helper.sh compress [path]
+~/.aidevops/agents/scripts/context-builder-helper.sh compress [path]
 
 # Full pack with smart defaults
-context-builder-helper.sh pack [path] [xml|markdown|json]
+~/.aidevops/agents/scripts/context-builder-helper.sh pack [path] [xml|markdown|json]
 
 # Quick mode - auto-copies to clipboard
-context-builder-helper.sh quick [path] [pattern]
+~/.aidevops/agents/scripts/context-builder-helper.sh quick [path] [pattern]
 
 # Analyze token usage per file
-context-builder-helper.sh analyze [path] [threshold]
+~/.aidevops/agents/scripts/context-builder-helper.sh analyze [path] [threshold]
 
 # Pack remote GitHub repo
-context-builder-helper.sh remote user/repo [branch]
+~/.aidevops/agents/scripts/context-builder-helper.sh remote user/repo [branch]
 
 # Compare full vs compressed
-context-builder-helper.sh compare [path]
+~/.aidevops/agents/scripts/context-builder-helper.sh compare [path]
 ```
 
 **Direct CLI Commands** (when helper unavailable):

--- a/.agents/tools/context/context-guardrails.md
+++ b/.agents/tools/context/context-guardrails.md
@@ -22,7 +22,7 @@ tools:
 | Repo Size (KB) | Est. Tokens | Action |
 |----------------|-------------|--------|
 | < 500 | < 50K | Safe for compressed pack |
-| 500-2000 | 50-200K | Use `includePatterns` only |
+| 500-2000 | 50-200K | Use `--include` patterns only |
 | > 2000 | > 200K | **NEVER full pack** - targeted files only |
 
 **Self-check before context-heavy operations**:
@@ -67,7 +67,7 @@ START
   |
   +-- < 500 KB --> Safe for compressed pack
   |
-  +-- 500KB-2MB --> Use includePatterns only
+  +-- 500KB-2MB --> Use --include patterns only
   |
   +-- > 2MB --> STOP - targeted files only
 ```
@@ -98,7 +98,7 @@ npx repomix@latest --remote https://github.com/small/repo --compress
 npx repomix@latest --remote https://github.com/large/repo --include "README.md,src/**/*.ts,docs/**" --compress
 
 # Or use helper script:
-context-builder-helper.sh remote large/repo main  # Auto-compresses
+~/.aidevops/agents/scripts/context-builder-helper.sh remote large/repo main  # Auto-compresses
 ```
 
 ### Searching packed output
@@ -143,7 +143,7 @@ If you hit "prompt is too long":
 
    ```text
    /remember FAILED_APPROACH: Attempted to pack {repo} without size check. 
-   Repo was {size}KB (~{tokens} tokens). Use includePatterns next time.
+   Repo was {size}KB (~{tokens} tokens). Use --include patterns next time.
    ```
 
 ## File Discovery Guardrails

--- a/.agents/tools/context/dspyground.md
+++ b/.agents/tools/context/dspyground.md
@@ -34,7 +34,7 @@ tools:
 
 DSPyGround is a visual prompt optimization playground powered by the GEPA (Genetic-Pareto Evolutionary Algorithm) optimizer. It provides an intuitive web interface for iterative prompt optimization with real-time feedback and multi-dimensional metrics.
 
-**Note**: DSPyGround is an optional tool installed separately from the aidevops CLI. Install it when you need visual prompt optimization capabilities.
+**Note**: DSPyGround is an optional tool installed separately from the aidevops CLI. You can install it via `npm install -g dspyground` when you need visual prompt optimization capabilities.
 
 ## 🚀 **Quick Start**
 

--- a/.agents/tools/context/mcp-discovery.md
+++ b/.agents/tools/context/mcp-discovery.md
@@ -73,7 +73,7 @@ npx mcporter call context7.resolve-library-id libraryName=react
 
 | MCP | Subagent | Notes |
 |-----|----------|-------|
-| `grep_app` / `gh_grep` | `@github-search` | CLI-based, zero tokens |
+| `grep_app` / `gh_grep` | `@github-search` | For GitHub code search (no MCP used) |
 
 **Primary search**: `rg`/`fd` (local, instant). Use `@augment-context-engine` for semantic search.
 

--- a/.agents/tools/database/vector-search/zvec.md
+++ b/.agents/tools/database/vector-search/zvec.md
@@ -286,7 +286,7 @@ Zvec ships with embedding functions that run locally or call APIs. No separate e
 | Function | Provider | Dimensions | Env var |
 |----------|----------|------------|---------|
 | `OpenAIDenseEmbedding` | OpenAI | 1536 (default) | `OPENAI_API_KEY` |
-| `JinaDenseEmbedding` | Jina AI | 768 (nano) / 1024 (small) | `JINA_API_KEY` |
+| `JinaDenseEmbedding` | Jina AI | 768 (v2-base) / 1024 (v5-small) | `JINA_API_KEY` |
 | `QwenDenseEmbedding` | Alibaba Qwen | varies | `DASHSCOPE_API_KEY` |
 | `QwenSparseEmbedding` | Alibaba Qwen | sparse | `DASHSCOPE_API_KEY` |
 
@@ -764,7 +764,8 @@ collection.insert([
 
 // Query (synchronous -- Node.js bindings use querySync)
 const results = collection.querySync({
-  vectors: new zvec.VectorQuery({ fieldName: "embedding", vector: [0.1, 0.2, 0.3, ...] }),
+  fieldName: "embedding",
+  vector: [0.1, 0.2, 0.3, ...],
   topk: 10,
 });
 

--- a/.agents/tools/ocr/glm-ocr.md
+++ b/.agents/tools/ocr/glm-ocr.md
@@ -14,6 +14,8 @@ tools:
 
 # GLM-OCR - Local Document OCR
 
+> **Note:** The command examples in this guide are primarily for macOS. On Linux, use equivalent commands where needed (for example, `apt` instead of `brew`).
+
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
@@ -95,6 +97,8 @@ done > extracted_text.txt
 
 ### PDF to Text (via ImageMagick)
 
+> **Note:** This workflow requires [ImageMagick](https://imagemagick.org/). On macOS, install with `brew install imagemagick`.
+
 ```bash
 # Convert PDF pages to images, then OCR
 convert -density 300 document.pdf -quality 90 /tmp/page-%03d.png
@@ -175,7 +179,7 @@ ollama list
 ### Slow Performance
 
 ```bash
-# Check available memory (model needs ~4GB RAM)
+# Check available memory (model needs at least 8GB RAM)
 vm_stat | head -5
 
 # For large batches, process sequentially to avoid memory pressure

--- a/.agents/tools/ocr/overview.md
+++ b/.agents/tools/ocr/overview.md
@@ -81,7 +81,7 @@ What is your input?
 
 ### Detailed Comparison
 
-| Feature | PaddleOCR | MinerU | Docling + ET | GLM-OCR | LibPDF |
+| Feature | PaddleOCR | MinerU | Docling + ExtractThinker | GLM-OCR | LibPDF |
 |---------|-----------|--------|--------------|---------|--------|
 | **Primary use** | Scene text OCR | PDF to markdown | Structured extraction | Quick local OCR | PDF manipulation |
 | **Input types** | Any image | PDF only | PDF, DOCX, images | Any image | PDF only |
@@ -164,6 +164,7 @@ Docling (IBM, 52.7k stars, MIT) parses document layout, then ExtractThinker uses
 - Privacy modes (fully local via Ollama, edge via Cloudflare, cloud)
 - PII detection and redaction (Presidio)
 - UK VAT-aware schemas with QuickFile integration
+- Native MCP server for agent framework integration
 
 **Weaknesses**:
 

--- a/.agents/workflows/ui-verification.md
+++ b/.agents/workflows/ui-verification.md
@@ -294,9 +294,21 @@ Every UI change must be evaluated against these principles. They are not suggest
 | **Clear information hierarchy** | Visual hierarchy must be established through layout position, font size, font weight, and whitespace -- not colour alone. The most important content should be the most visually prominent | Screenshot check; verify primary content/CTA is the first thing the eye is drawn to |
 | **Standard naming conventions** | CSS classes, component names, and design tokens should follow clear, hierarchical naming (e.g., BEM, utility-first, or design-token conventions). Names should be descriptive and consider future extensibility | Code review; verify naming is consistent and self-documenting |
 
+### Checklist Violation Severity
+
+All checklist violations (typography, layout, interaction/accessibility, colour/theming, information architecture, and usability) use this unified severity rubric:
+
+| Level | Label | Definition | Examples | Action |
+|-------|-------|------------|---------|--------|
+| **S1** | Blocker | Prevents use or causes legal/compliance risk | Text invisible (contrast fail), interactive element unreachable by keyboard, missing `alt` on informational image, touch target below 24px | Must fix before task is complete |
+| **S2** | Major | Significantly degrades usability or brand quality | Paragraph text wider than 740px, body text below 16px, missing hover state, broken path reference, logo not linking to home | Must fix before task is complete |
+| **S3** | Minor | Noticeable but does not block use | Single orphaned word in a heading, fourth font family, inconsistent icon sizing, widow in a paragraph | Fix if low effort; otherwise log as follow-up |
+
+Report violations in the verification report (step 6) using the format: `[S1/S2/S3] <principle> — <description>`.
+
 ### Usability (Mom Test)
 
-After all technical checks pass, evaluate the page against the Mom Test heuristic (see `seo/mom-test-ux.md`):
+After all technical checks pass, evaluate the page against the Mom Test heuristic (see `.agents/seo/mom-test-ux.md`):
 
 - **Clarity**: Can a non-technical user understand what the page wants them to do within 10 seconds?
 - **Simplicity**: Is there unnecessary complexity, clutter, or cognitive load?
@@ -305,7 +317,7 @@ After all technical checks pass, evaluate the page against the Mom Test heuristi
 - **Discoverability**: Can users find what they need without instructions?
 - **Forgiveness**: Can users recover from mistakes easily?
 
-If the page fails any Mom Test principle at severity S1 (blocker) or S2 (major), it must be fixed before the task is considered complete.
+If the page fails any Mom Test principle at S1 (blocker) or S2 (major) per the severity rubric above, it must be fixed before the task is considered complete.
 
 ## Quick Verification (Minimal)
 

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -3,9 +3,11 @@
 #
 # Reference: https://docs.codacy.com/repositories-configure/codacy-configuration-file/
 #
-# Root cause context (GH#4346):
+# Root cause context (GH#4346, GH#4696):
 # - Codacy flagged SC2086 (unquoted variable) in code that was being REMOVED by a PR fix.
-# - Codacy also returned "not_collected" on a transient service issue.
+# - "not_collected" reports were a failure-miner misclassification, not a Codacy issue.
+#   Codacy's action_required conclusion (= "issues found") was treated as a CI failure
+#   by gh-failure-miner-helper.sh. Fixed in GH#4696.
 # - This config excludes archived/ (same as CI shellcheck) and aligns tool settings.
 
 ---

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -175,16 +175,19 @@ jobs:
         echo "::warning::SONAR_TOKEN not configured — skipping SonarCloud scan"
         echo "Add SONAR_TOKEN to repository secrets to enable SonarCloud analysis"
 
-    - name: Codacy Analysis
+    - name: Codacy Integration Check
+      # Codacy analysis runs via the Codacy Production GitHub App (not this workflow).
+      # This step only verifies the API token is configured for Codacy API access.
+      # The "Codacy Static Code Analysis" check run is posted by the Codacy App
+      # independently on each PR commit.
       run: |
         if [[ -n "$CODACY_API_TOKEN" ]]; then
-          echo "Codacy Analysis Status..."
-          echo "Codacy API Token: Configured"
-          echo "Repository monitored at: https://app.codacy.com/gh/marcusquinn/aidevops"
-          echo "Codacy integration: Active"
+          echo "Codacy API token: configured"
+          echo "Codacy GitHub App: runs analysis independently on PRs"
+          echo "Dashboard: https://app.codacy.com/gh/marcusquinn/aidevops"
         else
-          echo "::notice::Codacy API token not configured, skipping analysis"
-          echo "Add CODACY_API_TOKEN to repository secrets to enable Codacy analysis"
+          echo "::notice::CODACY_API_TOKEN not configured — Codacy API access unavailable"
+          echo "Note: Codacy GitHub App analysis still runs if the app is installed"
         fi
 
     - name: Quality Analysis Summary
@@ -192,15 +195,11 @@ jobs:
         echo "Code Quality Analysis Summary"
         echo "================================"
         if [[ -n "$SONAR_TOKEN" ]]; then
-          echo "SonarCloud: Analysis completed"
+          echo "SonarCloud: Analysis completed (via workflow action)"
         else
           echo "SonarCloud: Skipped (SONAR_TOKEN not configured)"
         fi
-        if [[ -n "$CODACY_API_TOKEN" ]]; then
-          echo "Codacy: Analysis completed"
-        else
-          echo "Codacy: Skipped (token not configured)"
-        fi
+        echo "Codacy: Runs via GitHub App (independent of this workflow)"
         echo ""
         echo "View Results:"
         echo "   SonarCloud: https://sonarcloud.io/project/overview?id=marcusquinn_aidevops"

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -312,7 +312,7 @@ jobs:
           # Collect linked issue numbers from PR body (Closes #NNN, Fixes #NNN, Resolves #NNN)
           LINKED_ISSUES=""
           if [[ -n "$PR_BODY" ]]; then
-            LINKED_ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes?|fixes?|resolves?)\s*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
+            LINKED_ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes?|fixes?|resolves?)[[:space:]]*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
           fi
           echo "linked_issues=$LINKED_ISSUES" >> "$GITHUB_OUTPUT"
 
@@ -364,7 +364,7 @@ jobs:
         run: |
           # Merge all issue numbers (from PR body + fallback search)
           ALL_ISSUES="$LINKED_ISSUES $FOUND_ISSUES"
-          ALL_ISSUES=$(echo "$ALL_ISSUES" | tr ' ' '\n' | sort -u | grep -v '^$' | tr '\n' ' ')
+          ALL_ISSUES=$(echo "$ALL_ISSUES" | tr ' ' '\n' | sort -u | { grep -v '^$' || true; } | tr '\n' ' ')
 
           if [[ -z "$ALL_ISSUES" ]]; then
             echo "No linked issues found — skipping closing hygiene"
@@ -574,7 +574,7 @@ jobs:
           fi
 
           # Check for GitHub closing keywords or ref:GH# pattern
-          if echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves)\s+#[0-9]+'; then
+          if echo "$PR_BODY" | grep -qiE '(closes|fixes|resolves)[[:space:]]+#[0-9]+'; then
             echo "PR body contains issue closing keyword"
             exit 0
           fi

--- a/.github/workflows/postflight.yml
+++ b/.github/workflows/postflight.yml
@@ -10,7 +10,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.tag || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -10,7 +10,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.version || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -29,7 +29,8 @@ detect_default_shell() {
 
 # Usage: get_shell_rc "zsh" or get_shell_rc "bash"
 get_shell_rc() {
-	local shell_name="$1"
+	local shell_name
+	shell_name="$1"
 	case "$shell_name" in
 	zsh)
 		echo "$HOME/.zshrc"


### PR DESCRIPTION
## Summary

Addresses 3 medium-severity findings from Gemini's review of PR #2013 on `.agents/scripts/muapi-helper.sh`.

- **`submit_specialized()` (line 676)**: Added explicit `return $?` after `submit_and_poll` call to comply with style guide rule #12 (all functions must have explicit return statements). The function was implicitly propagating the exit code, which is correct behaviour, but the style guide requires it to be explicit.
- **`cmd_balance()` (line 1183)**: Removed `2>/dev/null` stderr suppression from `jq` call. `jq` parse errors are now visible for debugging; the `|| echo "${response}"` fallback still handles non-JSON responses gracefully.
- **`cmd_usage()` (line 1194)**: Same fix as `cmd_balance()`.

## Verification

- `shellcheck`: zero violations (SC1091 info note is pre-existing, unrelated to these changes)
- `bash -n`: syntax OK

Closes #3372