### PR TITLE
t3474: fix(clawdhub-helper): remove 2>/dev/null suppressions to improve debuggability

### DIFF
--- a/.agents/scripts/clawdhub-helper.sh
+++ b/.agents/scripts/clawdhub-helper.sh
@@ -270,9 +270,9 @@ PLAYWRIGHT_SCRIPT
 
 	# Install playwright and run the fetch script
 	log_info "Installing Playwright (temporary)..."
-	if (cd "$pw_dir" && npm install --silent 2>/dev/null && npx playwright install chromium --with-deps 2>/dev/null); then
+	if (cd "$pw_dir" && npm install --silent && npx playwright install chromium --with-deps); then
 		log_info "Running browser extraction..."
-		if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file" 2>/dev/null); then
+		if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file"); then
 			rm -rf "$pw_dir"
 			if [[ -f "$output_file" && -s "$output_file" ]]; then
 				log_success "Extracted SKILL.md ($(wc -c <"$output_file" | tr -d ' ') bytes)"
@@ -287,7 +287,7 @@ PLAYWRIGHT_SCRIPT
 	# Fallback: try clawdhub CLI
 	if command -v npx &>/dev/null; then
 		log_info "Trying: npx clawdhub install $slug"
-		if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force 2>/dev/null); then
+		if (cd "$output_dir" && npx --yes clawdhub@latest install "$slug" --force); then
 			# clawdhub installs to ./skills/<slug>/SKILL.md
 			local installed_skill
 			installed_skill=$(find "$output_dir" -name "SKILL.md" -type f 2>/dev/null | head -1)


### PR DESCRIPTION
## Summary

- Removes three `2>/dev/null` stderr suppressions from `clawdhub-helper.sh` that were hiding error output from the Playwright/CLI skill-fetch fallback chain
- Affected commands: `npm install`, `npx playwright install chromium`, `node fetch.mjs`, and `npx clawdhub@latest install`
- The `find 2>/dev/null` on line 293 is intentionally retained — it suppresses filesystem permission-denied noise, not operational errors

## Motivation

Gemini code review on PR #288 correctly identified that suppressing stderr makes it impossible to diagnose why skill fetching fails. When these commands fail silently, the only visible signal is the `log_warning`/`log_error` message with no root cause.

## Verification

- `shellcheck .agents/scripts/clawdhub-helper.sh` — passes (only pre-existing SC1091 info for sourced file)
- No functional behaviour change — error output now flows to stderr as expected

Closes #3474