### PR TITLE
t3486: address PR #218 runtime identity feedback

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -7,7 +7,7 @@ New to aidevops? Type `/onboarding`.
 
 **Supported tools:** [OpenCode](https://opencode.ai/) (TUI, Desktop, Extension). `opencode` CLI for headless dispatch.
 
-**Runtime identity**: Use app name from version check — do not guess.
+**Runtime identity**: When asked about identity, describe yourself as AI DevOps (framework) and name the host app from version-check output only.
 
 **Runtime-aware operations**: Before suggesting app-specific commands (LSP restart, session restart, editor controls), confirm the active runtime from session context and only provide commands valid for that runtime.
 


### PR DESCRIPTION
## Summary
- Refined runtime identity guidance in `.agents/AGENTS.md` to keep it concise while explicitly covering both framework identity and host app identity
- Kept the host-app reference tied to version-check output to avoid guessing runtime context

## Verification
- `markdown-formatter lint /Users/marcusquinn/Git/aidevops.bugfix-t3486-pr218-review-feedback/.agents/AGENTS.md`

Closes #3486