### PR TITLE
t3372: fix explicit return propagation and jq stderr suppression in muapi-helper.sh

### DIFF
--- a/.agents/scripts/muapi-helper.sh
+++ b/.agents/scripts/muapi-helper.sh
@@ -674,6 +674,7 @@ submit_specialized() {
 	payload=$(echo "${extra_payload}" | jq --arg url "${image_url}" '. + {image_url: $url}')
 
 	submit_and_poll "${endpoint}" "${payload}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Face swap (image or video)
@@ -757,6 +758,7 @@ cmd_face_swap() {
 	extra=$(jq -n --arg face "${face_url}" '{face_image: $face}')
 
 	submit_specialized "${endpoint}" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Image upscaling
@@ -801,6 +803,7 @@ cmd_upscale() {
 	done
 
 	submit_specialized "ai-image-upscale" "${image_url}" "{}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Background removal
@@ -845,6 +848,7 @@ cmd_bg_remove() {
 	done
 
 	submit_specialized "ai-background-remover" "${image_url}" "{}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Dress change
@@ -900,6 +904,7 @@ cmd_dress_change() {
 	fi
 
 	submit_specialized "ai-dress-change" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Stylization (Ghibli/Anime)
@@ -959,6 +964,7 @@ cmd_stylize() {
 	esac
 
 	submit_specialized "${endpoint}" "${image_url}" "{}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Product shot
@@ -1014,6 +1020,7 @@ cmd_product_shot() {
 	fi
 
 	submit_specialized "ai-product-shot" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Object eraser
@@ -1070,6 +1077,7 @@ cmd_object_erase() {
 	fi
 
 	submit_specialized "ai-object-eraser" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Image extension (outpainting)
@@ -1125,6 +1133,7 @@ cmd_image_extend() {
 	fi
 
 	submit_specialized "ai-image-extension" "${image_url}" "${extra}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # Skin enhancer
@@ -1169,6 +1178,7 @@ cmd_skin_enhance() {
 	done
 
 	submit_specialized "ai-skin-enhancer" "${image_url}" "{}" "${poll_interval}" "${timeout}" "${output_file}" "${webhook}"
+	return $?
 }
 
 # --- Credits & Usage ---
@@ -1180,7 +1190,7 @@ cmd_balance() {
 	local response
 	response=$(api_request GET "${MUAPI_BASE}/payments/credits")
 
-	echo "${response}" | jq . 2>/dev/null || echo "${response}"
+	echo "${response}" | jq . || echo "${response}"
 	return 0
 }
 
@@ -1191,7 +1201,7 @@ cmd_usage() {
 	local response
 	response=$(api_request GET "${MUAPI_BASE}/payments/usage")
 
-	echo "${response}" | jq . 2>/dev/null || echo "${response}"
+	echo "${response}" | jq . || echo "${response}"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Addresses quality-debt review feedback from PR #2013 (issue #3372).

**3 findings fixed:**

1. **Explicit `return $?` in `submit_specialized()`** (line 677) — function was implicitly returning the exit code of `submit_and_poll` without an explicit `return` statement, violating style guide rule #12.

2. **Explicit `return $?` in all `cmd_*` functions calling `submit_specialized`** — `cmd_face_swap`, `cmd_upscale`, `cmd_bg_remove`, `cmd_dress_change`, `cmd_stylize`, `cmd_product_shot`, `cmd_object_erase`, `cmd_image_extend`, `cmd_skin_enhance` — all now explicitly propagate the exit code.

3. **Remove `2>/dev/null` from `jq` calls in `cmd_balance()` and `cmd_usage()`** (lines 1183, 1194) — stderr suppression was hiding `jq` parse errors. Changed to `echo "${response}" | jq . || echo "${response}"` per the reviewer's suggestion.

**Blast radius**: 1 file changed, 12 insertions, 2 deletions.

Closes #3372