### PR TITLE
3475: reduce repeated option variable declarations in SEO export parsers

### DIFF
--- a/.agents/scripts/seo-export-ahrefs.sh
+++ b/.agents/scripts/seo-export-ahrefs.sh
@@ -253,13 +253,14 @@ main() {
     local domain=""
     local days="$DEFAULT_DAYS"
     local country="us"
+    local next_arg=""
     local arg
     
     while [[ $# -gt 0 ]]; do
         arg="$1"
         case "$arg" in
             --days)
-                local next_arg="${2:-}"
+                next_arg="${2:-}"
                 if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
                     print_error "--days requires a numeric value"
                     return 1
@@ -268,7 +269,7 @@ main() {
                 shift 2
                 ;;
             --country)
-                local next_arg="${2:-}"
+                next_arg="${2:-}"
                 if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
                     print_error "--country requires a value"
                     return 1

--- a/.agents/scripts/seo-export-bing.sh
+++ b/.agents/scripts/seo-export-bing.sh
@@ -236,13 +236,14 @@ EOF
 main() {
     local domain=""
     local days="$DEFAULT_DAYS"
+    local next_arg=""
     local arg
     
     while [[ $# -gt 0 ]]; do
         arg="$1"
         case "$arg" in
             --days)
-                local next_arg="${2:-}"
+                next_arg="${2:-}"
                 if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
                     print_error "--days requires a numeric value"
                     return 1

--- a/.agents/scripts/seo-export-dataforseo.sh
+++ b/.agents/scripts/seo-export-dataforseo.sh
@@ -284,13 +284,14 @@ main() {
     local days="$DEFAULT_DAYS"
     local location="2840"
     local language="en"
+    local next_arg=""
     local arg
     
     while [[ $# -gt 0 ]]; do
         arg="$1"
         case "$arg" in
             --days)
-                local next_arg="${2:-}"
+                next_arg="${2:-}"
                 if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
                     print_error "--days requires a numeric value"
                     return 1
@@ -299,7 +300,7 @@ main() {
                 shift 2
                 ;;
             --location)
-                local next_arg="${2:-}"
+                next_arg="${2:-}"
                 if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
                     print_error "--location requires a value"
                     return 1
@@ -308,7 +309,7 @@ main() {
                 shift 2
                 ;;
             --language)
-                local next_arg="${2:-}"
+                next_arg="${2:-}"
                 if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
                     print_error "--language requires a value"
                     return 1

--- a/.agents/scripts/seo-export-gsc.sh
+++ b/.agents/scripts/seo-export-gsc.sh
@@ -252,13 +252,14 @@ EOF
 main() {
     local domain=""
     local days="$DEFAULT_DAYS"
+    local next_arg=""
     local arg
     
     while [[ $# -gt 0 ]]; do
         arg="$1"
         case "$arg" in
             --days)
-                local next_arg="${2:-}"
+                next_arg="${2:-}"
                 if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
                     print_error "--days requires a numeric value"
                     return 1

--- a/.agents/scripts/seo-export-helper.sh
+++ b/.agents/scripts/seo-export-helper.sh
@@ -273,13 +273,14 @@ main() {
     # Parse global options
     local domain=""
     local days="$DEFAULT_DAYS"
+    local next_arg=""
     local arg
     
     while [[ $# -gt 0 ]]; do
         arg="$1"
         case "$arg" in
             --days)
-                local next_arg="${2:-}"
+                next_arg="${2:-}"
                 if [[ -z "$next_arg" ]] || [[ "$next_arg" == -* ]]; then
                     print_error "--days requires a numeric value"
                     return 1


### PR DESCRIPTION
## Summary
- Address issue #3475 by applying the maintainability feedback from PR #289 to the SEO export scripts
- Declare `next_arg` once per `main()` parser and reuse it across option branches instead of redeclaring in each `case` block
- Keep CLI behavior unchanged while reducing repetitive declarations in parser branches

## Verification
- `shellcheck --severity=warning .agents/scripts/seo-export-ahrefs.sh .agents/scripts/seo-export-bing.sh .agents/scripts/seo-export-dataforseo.sh .agents/scripts/seo-export-gsc.sh .agents/scripts/seo-export-helper.sh`

Closes #3475