### PR TITLE
fix: address PR #327 review feedback on blank line and phrasing clarity

### DIFF
--- a/.agents/scripts/setup-mcp-integrations.sh
+++ b/.agents/scripts/setup-mcp-integrations.sh
@@ -187,7 +187,7 @@ install_mcp() {
 		print_info "Grep by Vercel MCP (grep.app) is no longer installed by aidevops"
 		print_info "Use @github-search subagent instead (CLI-based, zero token overhead)"
 		print_info "If you have Oh-My-OpenCode, it provides grep_app MCP"
-		print_info ""
+		echo
 		print_info "Usage: @github-search 'search pattern'"
 		print_info "Or directly: gh search code 'pattern' --language typescript"
 		;;

--- a/.agents/tools/context/github-search.md
+++ b/.agents/tools/context/github-search.md
@@ -160,4 +160,4 @@ rg '"scripts"' package.json -A 10
 
 This subagent provides the same functionality as `grep_app` (Oh-My-OpenCode) or `gh_grep` MCPs without the token overhead.
 
-**Note**: aidevops does not install GitHub search MCPs. If you have Oh-My-OpenCode installed, it provides `grep_app`. Use this `@github-search` subagent instead for zero-overhead GitHub code search.
+**Note**: aidevops does not install GitHub search MCPs. If you have Oh-My-OpenCode installed, it provides `grep_app`. This `@github-search` subagent is the built-in aidevops tool for zero-overhead GitHub code search — use it when you don't have Oh-My-OpenCode, or prefer a CLI-native approach.


### PR DESCRIPTION
## Summary

Addresses the two medium-severity findings from Gemini's review of PR #327 (refactor: remove gh_grep MCP entirely).

## Changes

- **`setup-mcp-integrations.sh` line 190**: Replace `print_info ""` with `echo` for blank line spacing. `print_info` adds an `[INFO]` prefix, so `print_info ""` outputs `[INFO] ` rather than a blank line — `echo` is the correct idiom for vertical spacing.
- **`github-search.md` line 163**: Rephrase the `@github-search` note to clarify it is the built-in aidevops tool, not a replacement for `grep_app` when Oh-My-OpenCode is installed. Previous phrasing "Use this `@github-search` subagent instead" could be read as recommending against `grep_app` even when OmO is present.

## Verification

- `shellcheck` on `setup-mcp-integrations.sh`: only pre-existing SC1091 info notice (sourced file), no new violations.

Closes #3463