### PR TITLE
t3461: fix add-skill-helper.sh comment clarity and diagram pattern specificity

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -275,13 +275,13 @@ determine_target_path() {
 		category="tools/architecture"
 	elif echo "$content" | grep -qi "feature.sliced\|feature-sliced\|fsd.architecture\|slice.organization"; then
 		category="tools/architecture"
-	# Database and ORM
+	# Database and ORM patterns (must come before more generic service patterns)
 	elif echo "$content" | grep -qi "postgresql\|postgres\|drizzle\|prisma\|typeorm\|sequelize\|knex\|database.orm"; then
 		category="services/database"
-	# Diagrams and visualization
-	elif echo "$content" | grep -qi "mermaid\|diagram\|flowchart\|sequence.diagram\|er.diagram\|uml"; then
+	# Diagrams and visualization patterns (must come before more generic tool patterns)
+	elif echo "$content" | grep -qi "mermaid\|flowchart\|sequence.diagram\|er.diagram\|uml"; then
 		category="tools/diagrams"
-	# Programming languages (specific patterns)
+	# Programming language patterns (must come before more generic tool patterns like browser)
 	elif echo "$content" | grep -qi "javascript\|typescript\|es6\|es2020\|es2022\|es2024\|ecmascript\|modern.js"; then
 		category="tools/programming"
 	elif echo "$content" | grep -qi "browser\|playwright\|puppeteer\|selenium"; then

--- a/.agents/tools/build-agent/add-skill.md
+++ b/.agents/tools/build-agent/add-skill.md
@@ -155,16 +155,22 @@ Cancel import. Best when:
 
 ## Category Detection
 
-The helper script analyzes skill content to determine placement:
+The helper script analyzes skill content to determine placement. Patterns are ordered from specific to generic — earlier matches take precedence.
 
 | Keywords | Category |
 |----------|----------|
 | deploy, vercel, coolify, docker, kubernetes | `tools/deployment/` |
+| cloudflare workers, cloudflare pages, wrangler | `services/hosting/` |
 | cloudflare, dns, hosting, domain | `services/hosting/` |
 | proxmox, hypervisor, virtualization | `services/hosting/` |
 | calendar, caldav, ical, scheduling | `tools/productivity/` |
+| clean architecture, hexagonal, ddd, domain-driven, cqrs, event sourcing | `tools/architecture/` |
+| feature-sliced, fsd architecture, slice organization | `tools/architecture/` |
+| postgresql, postgres, drizzle, prisma, typeorm, sequelize, knex | `services/database/` |
+| mermaid, flowchart, sequence diagram, ER diagram, UML | `tools/diagrams/` |
+| javascript, typescript, es6, es2020–es2024, ecmascript | `tools/programming/` |
 | browser, playwright, puppeteer | `tools/browser/` |
-| seo, search, ranking, keyword | `seo/` |
+| seo, search ranking, keyword research | `seo/` |
 | git, github, gitlab | `tools/git/` |
 | code review, lint, quality | `tools/code-review/` |
 | credential, secret, password | `tools/credentials/` |


### PR DESCRIPTION
## Summary

- Improve comment clarity in `add-skill-helper.sh` category detection block — add explicit ordering notes to database, diagrams, and programming language comments (Gemini PR #297 review suggestions)
- Remove overly broad `diagram` token from the diagrams grep pattern; retain specific alternatives (`mermaid`, `flowchart`, `sequence.diagram`, `er.diagram`, `uml`) to prevent false-positive matches in architecture docs that mention "diagram" incidentally (Augment PR #297 review)
- Update `add-skill.md` Category Detection table to list all new categories added in PR #297 (`tools/architecture`, `services/database`, `tools/diagrams`, `tools/programming`) so maintainer documentation stays in sync with the script (Augment PR #297 review)

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/add-skill-helper.sh` | Comment clarity + remove bare `diagram` token |
| `.agents/tools/build-agent/add-skill.md` | Category Detection table updated with new categories |

## Verification

- ShellCheck at `--severity=warning`: 0 violations
- Existing SC1091 info (sourced file) pre-dates this PR and is unrelated

Closes #3461