### PR TITLE
t3456: fix cross-platform Claude Desktop paths and clarify --transport http in cloudflare-mcp.md

### DIFF
--- a/.agents/tools/api/cloudflare-mcp.md
+++ b/.agents/tools/api/cloudflare-mcp.md
@@ -50,7 +50,11 @@ Cloudflare Code Mode MCP uses OAuth 2.0 — no API tokens to manage manually.
 
 ### Config
 
-**Claude Desktop** (`~/Library/Application Support/Claude/claude_desktop_config.json`):
+**Claude Desktop** — config file location by OS:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/Claude/claude_desktop_config.json`
 
 ```json
 {
@@ -80,6 +84,8 @@ Cloudflare Code Mode MCP uses OAuth 2.0 — no API tokens to manage manually.
 ```bash
 claude mcp add cloudflare-api --transport http https://mcp.cloudflare.com/mcp
 ```
+
+> **Note**: `--transport http` refers to the MCP transport type (streamable HTTP), not the URL scheme. The value `http` is correct even though the endpoint URL uses HTTPS — the flag selects the protocol framing, not the TLS layer.
 
 ## Security Model
 


### PR DESCRIPTION
## Summary

Addresses the two medium-severity findings from Gemini's review of PR #2077 (`.agents/tools/api/cloudflare-mcp.md`).

- **Finding 1 (line 53)**: Claude Desktop config path was macOS-only. Added Windows (`%APPDATA%\Claude\`) and Linux (`~/.config/Claude/`) paths.
- **Finding 2 (line 81)**: `--transport http` flag was potentially confusing alongside an `https://` URL. Added an explanatory note: `http` is the MCP transport type name (streamable HTTP), not the URL scheme — it is correct even for HTTPS endpoints.

Note: Gemini's suggestion to change `--transport http` to `--transport https` was **not applied** — `http` is the correct value for the Claude Code CLI flag (it names the transport framing, not the TLS layer). The fix is a clarifying note instead.

Closes #3456