### PR TITLE
t3459: fix empty eval array guards and _emit_token leak in dispatch.sh

### DIFF
--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -1651,6 +1651,10 @@ check_cli_health() {
 	# t1160.1: Build version command via build_cli_cmd abstraction
 	local -a version_cmd=()
 	eval "version_cmd=($(build_cli_cmd --cli "$ai_cli" --action version --output array))"
+	if [[ ${#version_cmd[@]} -eq 0 ]]; then
+		log_error "check_cli_health: build_cli_cmd produced empty command for cli=$ai_cli action=version"
+		return 1
+	fi
 	version_output=$(timeout_sec 10 "${version_cmd[@]}" 2>&1) || version_exit=$?
 
 	# If version command succeeded (exit 0) or produced output, CLI is working.
@@ -1777,6 +1781,10 @@ check_model_health() {
 	# t1160.1: Build probe command via build_cli_cmd abstraction
 	local -a probe_cmd=()
 	eval "probe_cmd=($(build_cli_cmd --cli "$ai_cli" --action probe --output array --model "$model"))"
+	if [[ ${#probe_cmd[@]} -eq 0 ]]; then
+		log_error "check_model_health: build_cli_cmd produced empty command for cli=$ai_cli action=probe model=$model"
+		return 1
+	fi
 	probe_result=$(timeout_sec 15 "${probe_cmd[@]}" 2>&1)
 	probe_exit=$?
 
@@ -2157,6 +2165,8 @@ build_cli_cmd() {
 		;;
 	esac
 
+	# Clean up nested helper to prevent global function namespace leak
+	unset -f _emit_token
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from PR #2053 (tracked as issue #3459).

Three targeted fixes to `build_cli_cmd()` and its call sites in `.agents/scripts/supervisor-archived/dispatch.sh`:

- **`check_cli_health`**: guard against empty `version_cmd` after `eval` — if `build_cli_cmd` returns non-zero or produces no tokens, log an error and return 1 instead of executing an empty command
- **`check_model_health`**: same guard for `probe_cmd` — prevents silent empty `exec` when `build_cli_cmd` fails for the probe action
- **`build_cli_cmd`**: `unset -f _emit_token` before returning — the nested helper leaked into the global function namespace after first invocation; cleanup prevents unexpected collisions with future callers

## Verification

- `shellcheck -x -S warning dispatch.sh` — zero violations
- `bash -n dispatch.sh` — syntax OK

Closes #3459