### PR TITLE
fix: remove openai/gpt-4o from DEFAULT_HEADLESS_MODELS — only anthropic configured

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -15,7 +15,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
-readonly DEFAULT_HEADLESS_MODELS="anthropic/claude-sonnet-4-6,openai/gpt-4o"
+readonly DEFAULT_HEADLESS_MODELS="anthropic/claude-sonnet-4-6"
 readonly STATE_DIR="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}"
 readonly STATE_DB="${STATE_DIR}/state.db"
 readonly OPENCODE_BIN_DEFAULT="${OPENCODE_BIN:-opencode}"


### PR DESCRIPTION
## Summary

- Removes `openai/gpt-4o` from `DEFAULT_HEADLESS_MODELS` in `headless-runtime-helper.sh`
- Only `anthropic` provider is configured in `opencode.json`; including an OpenAI model caused `ProviderModelNotFoundError` on every other worker dispatch
- Observed live during pulse cycle 2026-03-14: ~50% of dispatches were failing with this error

## Root Cause

`DEFAULT_HEADLESS_MODELS` was set to `anthropic/claude-sonnet-4-6,openai/gpt-4o` but the `openai` provider block is absent from `~/.config/opencode/opencode.json`. The runtime alternates between models, so every second dispatch failed.

## Fix

Set `DEFAULT_HEADLESS_MODELS="anthropic/claude-sonnet-4-6"` — single model, matching the only configured provider.

Closes #4755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default model configuration for headless runtime operations. OpenAI GPT-4o is no longer included among the default model options available, with Anthropic Claude Sonnet continuing to serve as the primary default choice. Users who explicitly configure their model selections will be unaffected by this default configuration adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->