### PR TITLE
t3442: fix Gemini review feedback from PR #2120 in pulse.sh

### DIFF
--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -2710,10 +2710,10 @@ cmd_pulse() {
 				if kill -0 "$sweep_pid" 2>/dev/null; then
 					protected_pids="${protected_pids} ${sweep_pid}"
 					local sweep_descendants
-					sweep_descendants=$(_list_descendants "$sweep_pid" 2>/dev/null || true)
-					if [[ -n "$sweep_descendants" ]]; then
-						protected_pids="${protected_pids} ${sweep_descendants}"
-					fi
+					sweep_descendants=$(_list_descendants "$sweep_pid" || true)
+					while IFS= read -r _desc_pid; do
+						[[ -n "$_desc_pid" ]] && protected_pids="${protected_pids} ${_desc_pid}"
+					done <<<"$sweep_descendants"
 				fi
 			done
 		fi
@@ -3409,8 +3409,9 @@ cmd_pulse() {
 			# Write a PID file for the AI session so Phase 4e does not kill
 			# opencode/claude processes spawned during reasoning or action execution
 			# (t1301: concurrent pulses can trigger Phase 4e while AI is running).
-			local ai_pid_file="${SUPERVISOR_DIR}/pids/ai-supervisor.pid"
-			echo "$$" >"$ai_pid_file" 2>/dev/null || true
+			local ai_pid_file
+			ai_pid_file="${SUPERVISOR_DIR}/pids/ai-supervisor.pid"
+			echo "$$" >"$ai_pid_file" || true
 
 			# Record start timestamp
 			local ai_start_ts
@@ -3426,7 +3427,7 @@ cmd_pulse() {
 			ai_result=$(run_ai_actions_pipeline "$ai_repo_path" "full" 2>>"$ai_log_file") || ai_rc=$?
 
 			# Remove AI session PID file now that the pipeline has completed
-			rm -f "$ai_pid_file" 2>/dev/null || true
+			rm -f "$ai_pid_file" || true
 
 			# Record completion timestamp
 			local ai_end_ts


### PR DESCRIPTION
## Summary

Addresses the unactioned Gemini code review feedback from PR #2120 (merged), tracked as quality-debt issue #3442.

**Changes in `.agents/scripts/supervisor-archived/pulse.sh`:**

- **Style: separate `local` declaration from assignment** for `ai_pid_file` — ensures exit code safety per repo style guide (`local var="$1"` pattern)
- **Remove blanket `2>/dev/null` suppression** on `echo "$$" >"$ai_pid_file"` and `rm -f "$ai_pid_file"` — replaced with `|| true` so filesystem errors (permission denied, missing directory) remain visible in logs for diagnosis
- **Remove `2>/dev/null` from `_list_descendants` call** — errors from this critical protection function should surface rather than be silently swallowed
- **Fix newline-delimited PID concatenation bug** (CodeRabbit finding from same PR): `_list_descendants` emits newline-separated PIDs; concatenating directly into space-delimited `protected_pids` caused `grep -q " ${pid} "` to miss PIDs preceded by `\n`. Fixed with `while IFS= read -r` loop to normalize each PID individually.

**Note on launchd.sh / cron finding:** The CodeRabbit finding about `SUPERVISOR_AI_TIMEOUT` not being passed to Linux cron installs is no longer applicable — `SUPERVISOR_AI_TIMEOUT` was removed from `launchd.sh` in a subsequent refactor (PR #2403). No change needed there.

## Testing

- `bash -n pulse.sh` — syntax OK
- Logic verified: `while IFS= read -r _desc_pid` correctly handles both empty and multi-line `_list_descendants` output; `|| true` on PID file operations preserves error visibility while preventing pulse abort

Closes #3442