### PR TITLE
t3471: use generic placeholders in file discovery table

### DIFF
--- a/.agents/tools/context/context-guardrails.md
+++ b/.agents/tools/context/context-guardrails.md
@@ -152,9 +152,9 @@ Before using `mcp_glob`, check if faster alternatives work:
 
 | Use Case | Preferred Tool | Fallback |
 |----------|---------------|----------|
-| Git-tracked files | `git ls-files '*.md'` | `mcp_glob` |
-| Untracked files | `fd -e md` | `mcp_glob` |
-| System-wide search | `fd -g '*.md' ~/.config/` | `mcp_glob` |
+| Git-tracked files | `git ls-files '<pattern>'` | `mcp_glob` |
+| Untracked files | `fd -e <ext>` or `fd -g '<pattern>'` | `mcp_glob` |
+| System-wide search | `fd -g '<pattern>' <dir>` | `mcp_glob` |
 | Search text file contents | `rg 'pattern'` | `mcp_grep` |
 | Search inside PDFs/DOCX/zips | `rga 'pattern'` | None (unique capability) |
 


### PR DESCRIPTION
## Summary

- Replace `'*.md'` / `-e md` examples in the `context-guardrails.md` file discovery table with generic placeholders (`'<pattern>'`, `<ext>`, `<dir>`)
- Ensures AI agents understand the commands apply to any file type, not just Markdown files
- Aligns with the pattern already used in `.agents/rules/no-glob-for-discovery.md` and the new mandatory section added by PR #125

## Changes

- `.agents/tools/context/context-guardrails.md` — 3 lines updated in the File Discovery Guardrails table (1 file, max 5 files constraint satisfied)

## Verification

- `markdownlint-cli2`: 0 errors
- Change is purely cosmetic/documentation — no logic affected

Closes #3471