### PR TITLE
t3462: address PR #216 quality-debt extraction feedback

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -956,47 +956,48 @@ extract_task_ids_from_commits() {
 		commits=$(git log --oneline -50 --pretty=format:"%s" 2>/dev/null)
 	fi
 
-	local task_ids=""
+	local -a task_ids=()
 
 	while IFS= read -r commit; do
 		[[ -z "$commit" ]] && continue
 
 		# Pattern 1: Conventional commits with task ID in scope
 		# e.g., feat(t001):, fix(t002):, docs(t003.1):, refactor(t004):
-		if [[ "$commit" =~ ^(feat|fix|docs|refactor|perf|test|chore|style|build|ci)\(t[0-9]{3}(\.[0-9]+)*\): ]]; then
-			local id
-			id=$(echo "$commit" | grep -oE '\(t[0-9]{3}(\.[0-9]+)*\)' | tr -d '()' || true)
-			task_ids="$task_ids $id"
+		if [[ "$commit" =~ ^(feat|fix|docs|refactor|perf|test|chore|style|build|ci)\((t[0-9]{3}(\.[0-9]+)*)\): ]]; then
+			task_ids+=("${BASH_REMATCH[2]}")
 		fi
 
 		# Pattern 2: "mark tXXX done/complete" - extract task IDs between "mark" and "done/complete"
 		# e.g., "mark t004, t048, t069 done" -> t004, t048, t069
 		if [[ "$commit" =~ mark[[:space:]]+(.*)[[:space:]]+(done|complete) ]]; then
 			local segment="${BASH_REMATCH[1]}"
-			local ids
-			ids=$(echo "$segment" | grep -oE '\bt[0-9]{3}(\.[0-9]+)*\b' || true)
-			task_ids="$task_ids $ids"
+			local id
+			while IFS= read -r id; do
+				[[ -n "$id" ]] || continue
+				task_ids+=("$id")
+			done < <(printf '%s\n' "$segment" | grep -oE 't[0-9]{3}(\.[0-9]+)*' || true)
 		fi
 
 		# Pattern 3: "complete/completes/closes tXXX" - task ID immediately after keyword
 		# e.g., "complete t037", "closes t001"
-		local ids
-		ids=$(echo "$commit" | grep -oE '(completes?|closes?)[[:space:]]+t[0-9]{3}(\.[0-9]+)*' 2>/dev/null | grep -oE 't[0-9]{3}(\.[0-9]+)*' || true)
-		if [[ -n "$ids" ]]; then
-			task_ids="$task_ids $ids"
+		if [[ "$commit" =~ (^|[^[:alnum:]_])(completes?|closes?)[[:space:]]+(t[0-9]{3}(\.[0-9]+)*)([^[:alnum:]_]|$) ]]; then
+			task_ids+=("${BASH_REMATCH[3]}")
 		fi
 
 		# Pattern 4: "tXXX complete/done/finished" - task ID before completion word
 		# e.g., "t001 complete", "t002 done"
-		ids=$(echo "$commit" | grep -oE 't[0-9]{3}(\.[0-9]+)*[[:space:]]+(complete|done|finished)' 2>/dev/null | grep -oE 't[0-9]{3}(\.[0-9]+)*' || true)
-		if [[ -n "$ids" ]]; then
-			task_ids="$task_ids $ids"
+		if [[ "$commit" =~ (t[0-9]{3}(\.[0-9]+)*)[[:space:]]+(complete|done|finished)($|[^[:alnum:]_]) ]]; then
+			task_ids+=("${BASH_REMATCH[1]}")
 		fi
 
 	done <<<"$commits"
 
 	# Deduplicate and sort
-	echo "$task_ids" | tr ' ' '\n' | grep -E '^t[0-9]{3}' | sort -u
+	if [[ ${#task_ids[@]} -eq 0 ]]; then
+		return 0
+	fi
+
+	printf '%s\n' "${task_ids[@]}" | grep -E '^t[0-9]{3}(\.[0-9]+)*$' | sort -u
 	return 0
 }
 


### PR DESCRIPTION
## Summary
- Refactor `extract_task_ids_from_commits` to use Bash regex captures and arrays instead of repeated command pipelines.
- Tighten matching so only complete task IDs (`tNNN` with optional `.subtask`) are accepted in final output.
- Preserve the existing completion patterns while improving readability and reducing false-positive substring matches.

## Verification
- `shellcheck .agents/scripts/version-manager.sh`
- `bash .agents/scripts/version-manager.sh list-task-ids`

Closes #3462