### PR TITLE
fix(t3419): address PR #156 review feedback in video-prompt-design

### DIFF
--- a/.agents/tools/video/video-prompt-design.md
+++ b/.agents/tools/video/video-prompt-design.md
@@ -40,8 +40,8 @@ Technical: [Negative prompt - elements to exclude]
 ```
 
 **Critical Techniques**:
-- Camera positioning: Include `(thats where the camera is)` for spatial anchoring
-- Dialogue format: Use colon syntax to prevent subtitle generation
+- Camera positioning: Include `(that's where the camera is)` for spatial anchoring
+- Dialogue format: `(Character Name): "Speech" (Tone: descriptor)` — colon syntax prevents subtitle generation
 - Audio: Always specify environment audio to prevent hallucinations
 - Character consistency: Use identical descriptions across a series
 - Duration: 12-15 words / 20-25 syllables for 8-second dialogue
@@ -92,7 +92,7 @@ Build characters with 15+ specific attributes for consistency across generations
 Always include spatial context for the camera:
 
 ```text
-"Close-up shot with camera positioned at counter level (thats where the camera is)
+"Close-up shot with camera positioned at counter level (that's where the camera is)
 as the character demonstrates the product"
 ```
 


### PR DESCRIPTION
## Summary

- Fix typo: `thats` → `that's` in camera positioning instruction (line 43) — CodeRabbit + Gemini finding
- Fix typo: `thats` → `that's` in camera positioning code example (line 95) — CodeRabbit finding
- Align dialogue format in quick-reference block with the detailed example at lines 112-113: `(Character Name): "Speech" (Tone: descriptor)` — Gemini suggestion for clarity/consistency

## Changes

- **`.agents/tools/video/video-prompt-design.md`**: 3 line edits — 2 typo fixes, 1 dialogue format alignment

## Review Findings Addressed

| Reviewer | Severity | Finding | Resolution |
|----------|----------|---------|------------|
| CodeRabbit | medium | Typo `thats` in line 94-95 example | Fixed both occurrences |
| Gemini | medium | Typo `thats` in line 42-43 instruction | Fixed |
| Gemini | medium | Dialogue format inconsistency between quick-ref and detailed section | Aligned quick-ref to use full `(Character Name): "Speech" (Tone: descriptor)` format |

Closes #3419