### PR TITLE
fix(t3420): address PR #219 review feedback

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -50,9 +50,12 @@ detect_app() {
 		app_name="Warp"
 	else
 		# Fallback: check parent process name
-		local parent
+		# Normalize to lowercase for case-insensitive matching (ps -o comm= can
+		# return capitalized names on some platforms, e.g. "Cursor" not "cursor")
+		local parent parent_lower
 		parent=$(ps -o comm= -p "${PPID:-0}" 2>/dev/null || echo "")
-		case "$parent" in
+		parent_lower="${parent,,}"
+		case "$parent_lower" in
 		*opencode*)
 			app_name="OpenCode"
 			# Try CLI first, then npm global package.json
@@ -66,6 +69,8 @@ detect_app() {
 			app_version=$(claude --version 2>/dev/null | head -1 | sed 's/ (Claude Code)//' || echo "")
 			;;
 		*cursor*) app_name="Cursor" ;;
+		*windsurf*) app_name="Windsurf" ;;
+		*continue*) app_name="Continue" ;;
 		*aider*)
 			app_name="Aider"
 			app_version=$(aider --version 2>/dev/null | head -1 || echo "")
@@ -99,8 +104,15 @@ get_remote_version() {
 
 get_git_context() {
 	# Get current repo and branch for context
-	local repo branch
-	repo=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null || echo "")
+	# Note: basename on an empty string returns "." — capture toplevel first
+	# and only call basename when non-empty to avoid emitting "." outside a repo.
+	local repo branch toplevel
+	toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
+	if [[ -n "$toplevel" ]]; then
+		repo=$(basename "$toplevel" 2>/dev/null || echo "")
+	else
+		repo=""
+	fi
 	branch=$(git branch --show-current 2>/dev/null || echo "")
 
 	if [[ -n "$repo" && -n "$branch" ]]; then

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -43,7 +43,7 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash) and greet with: "Hi!\n\n{content of file}.\n\nWhat would you like to work on?". If the file doesn't exist, read `~/.aidevops/agents/VERSION` to get the `{version}` and greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
 3. Then respond to the user's actual message
 
-If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|current|latest`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." This check does not apply when falling back to reading the cache or VERSION file (step 2).
+If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|2.41.1|2.41.2|OpenCode`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." This check does not apply when falling back to reading the cache or VERSION file (step 2).
 
 ## Pre-Edit Git Check
 


### PR DESCRIPTION
## Summary

Addresses unactioned review feedback from merged PR #219 (feat: detect app name in session greeting).

## Changes

### `.agents/scripts/aidevops-update-check.sh`

- **`get_git_context()` — fix "." output outside git repos** (CodeRabbit): `basename ""` returns `"."`, so the function could emit `"."` or `"./branch"` when run outside a git repo. Fixed by capturing `git rev-parse --show-toplevel` into a variable first and only calling `basename` when non-empty.

- **`detect_app()` fallback — lowercase normalization** (Augment): `ps -o comm=` can return capitalized process names on some platforms (e.g., `"Cursor"` not `"cursor"`). Fixed by lowercasing the parent process name before the `case` match.

- **`detect_app()` fallback — add windsurf/continue patterns** (Gemini): The env-var detection handled Windsurf and Continue but the process-name fallback did not. Added matching `case` entries for completeness.

### `.agents/scripts/generate-opencode-agents.sh`

- **Update `UPDATE_AVAILABLE` example to 4-field format** (CodeRabbit): The generated AGENTS.md example showed `UPDATE_AVAILABLE|current|latest` (3 fields) but the script now outputs `UPDATE_AVAILABLE|current|remote|app` (4 fields). Updated the example to `UPDATE_AVAILABLE|2.41.1|2.41.2|OpenCode`.

## Dismissed findings

- **Gemini: `check_ralph_upstream` behavior change** — this function no longer exists in the codebase; the finding is stale.
- **Gemini: output simplification** — the current multi-variable approach is clearer for the runtime hint and cache-write logic that follows; no functional benefit to collapsing it.

Closes #3420