### PR TITLE
fix(t3412): remove 2>/dev/null suppression from gh/jq calls in supervisor scripts

### DIFF
--- a/.agents/scripts/supervisor-archived/ai-lifecycle.sh
+++ b/.agents/scripts/supervisor-archived/ai-lifecycle.sh
@@ -76,7 +76,7 @@ gather_task_state() {
 
 	if [[ -n "$tpr" && "$tpr" != "no_pr" && "$tpr" != "task_only" && "$tpr" != "verified_complete" ]]; then
 		local parsed_pr
-		parsed_pr=$(parse_pr_url "$tpr" 2>/dev/null) || parsed_pr=""
+		parsed_pr=$(parse_pr_url "$tpr") || parsed_pr=""
 		if [[ -n "$parsed_pr" ]]; then
 			pr_repo_slug="${parsed_pr%%|*}"
 			pr_number="${parsed_pr##*|}"
@@ -344,7 +344,7 @@ execute_action() {
 	local pr_number="" pr_repo_slug="" pr_base_branch="main"
 	if [[ -n "$tpr" && "$tpr" != "no_pr" && "$tpr" != "task_only" && "$tpr" != "verified_complete" ]]; then
 		local parsed_pr
-		parsed_pr=$(parse_pr_url "$tpr" 2>/dev/null) || parsed_pr=""
+		parsed_pr=$(parse_pr_url "$tpr") || parsed_pr=""
 		if [[ -n "$parsed_pr" ]]; then
 			pr_repo_slug="${parsed_pr%%|*}"
 			pr_number="${parsed_pr##*|}"
@@ -825,8 +825,8 @@ process_ai_lifecycle() {
 				# Pull base so subsequent PRs can merge cleanly
 				if [[ -n "$trepo" && -d "$trepo" ]]; then
 					local base_ref
-					base_ref=$(gh pr view "$tpr" --repo "$(detect_repo_slug "$trepo" 2>/dev/null || echo "")" \
-						--json baseRefName --jq '.baseRefName' 2>/dev/null) || base_ref="main"
+					base_ref=$(gh pr view "$tpr" --repo "$(detect_repo_slug "$trepo" || echo "")" \
+						--json baseRefName --jq '.baseRefName' 2>>"$SUPERVISOR_LOG") || base_ref="main"
 					git -C "$trepo" pull --rebase origin "$base_ref" 2>>"$SUPERVISOR_LOG" || true
 				fi
 				;;

--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -2381,12 +2381,12 @@ rebase_sibling_pr() {
 	local rebase_target="main"
 	if [[ -n "$tpr" && "$tpr" != "no_pr" && "$tpr" != "task_only" && "$tpr" != "verified_complete" ]]; then
 		local parsed_pr_info pr_repo_slug_local pr_number_local pr_base_ref
-		parsed_pr_info=$(parse_pr_url "$tpr" 2>/dev/null) || parsed_pr_info=""
+		parsed_pr_info=$(parse_pr_url "$tpr") || parsed_pr_info=""
 		if [[ -n "$parsed_pr_info" ]]; then
 			pr_repo_slug_local="${parsed_pr_info%%|*}"
 			pr_number_local="${parsed_pr_info##*|}"
 			pr_base_ref=$(gh pr view "$pr_number_local" --repo "$pr_repo_slug_local" \
-				--json baseRefName --jq '.baseRefName' 2>/dev/null) || pr_base_ref=""
+				--json baseRefName --jq '.baseRefName' 2>>"$SUPERVISOR_LOG") || pr_base_ref=""
 			if [[ -n "$pr_base_ref" ]]; then
 				rebase_target="$pr_base_ref"
 			fi


### PR DESCRIPTION
## Summary

- Removes `2>/dev/null` blanket stderr suppression from `parse_pr_url()`, `gh pr view`, and `detect_repo_slug()` calls introduced in PR #2114
- Stderr from `gh` and `jq` commands is now routed to `$SUPERVISOR_LOG` for diagnostics
- The existing `|| fallback` constructs already handle failure safely under `set -e` — the `2>/dev/null` was never needed for correctness, only hiding errors

## Files changed

- `.agents/scripts/supervisor-archived/ai-lifecycle.sh` — 3 occurrences (lines 79, 347, 829)
- `.agents/scripts/supervisor-archived/deploy.sh` — 2 occurrences (lines 2384, 2389)

## Verification

- ShellCheck: zero violations on both files
- No logic changes — only stderr routing updated

Closes #3412