### PR TITLE
t3407: resolve quality-debt feedback for cloudron error logging

### DIFF
--- a/.agents/scripts/cloudron-package-helper.sh
+++ b/.agents/scripts/cloudron-package-helper.sh
@@ -22,6 +22,12 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 set -euo pipefail
 
 # Logging: uses shared log_* from shared-constants.sh
+# Override log_error to return non-zero so error chains remain detectable.
+log_error() {
+	local label="${LOG_PREFIX:+${LOG_PREFIX}}"
+	echo -e "${RED}[${label:-ERROR}]${NC} $*" >&2
+	return 1
+}
 
 # Check if cloudron CLI is installed
 check_cloudron_cli() {


### PR DESCRIPTION
## Summary
- Override `log_error` in `cloudron-package-helper.sh` to return `1` so failed operations are not masked in conditional/error chains.
- Keep output format and stderr routing unchanged while making the error signal semantically correct.
- Validate the updated script with `bash -n` and `shellcheck -e SC1091`.

Closes #3407