### PR TITLE
t3410: centralize supervisor terminal status SQL lists

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -165,6 +165,18 @@ readonly DEFAULT_PORT=80
 readonly SECURE_PORT=443
 
 # =============================================================================
+# Supervisor Task Status SQL Fragments
+# =============================================================================
+# Keep frequently reused status lists in one place to avoid drift between
+# supervisor modules.
+
+# Terminal states for TODO/DB reconciliation checks.
+readonly TASK_RECONCILIATION_TERMINAL_STATES_SQL="'complete', 'deployed', 'verified', 'verify_failed', 'failed', 'blocked', 'cancelled'"
+
+# States treated as non-active when checking sibling in-flight limits.
+readonly TASK_SIBLING_NON_ACTIVE_STATES_SQL="'verified','cancelled','deployed','complete','failed','blocked','queued'"
+
+# =============================================================================
 # Portable timeout function (macOS + Linux)
 # =============================================================================
 # macOS has no native `timeout` command. This function provides a portable

--- a/.agents/scripts/supervisor-archived/state.sh
+++ b/.agents/scripts/supervisor-archived/state.sh
@@ -1038,7 +1038,7 @@ cmd_next() {
 				SELECT count(*) FROM tasks
 				WHERE id LIKE '$(sql_escape "$parent_id").%'
 				  AND id != '$(sql_escape "$cid")'
-				  AND status NOT IN ('verified','cancelled','deployed','complete','failed','blocked','queued');
+				  AND status NOT IN (${TASK_SIBLING_NON_ACTIVE_STATES_SQL});
 			" 2>/dev/null || echo "0")
 
 			if [[ "$siblings_active" -ge "$effective_max_siblings" ]]; then

--- a/.agents/scripts/supervisor-archived/todo-sync.sh
+++ b/.agents/scripts/supervisor-archived/todo-sync.sh
@@ -1778,7 +1778,7 @@ cmd_reconcile_db_todo() {
 	local all_db_tasks
 	all_db_tasks=$(db -separator '|' "$SUPERVISOR_DB" "
 		SELECT t.id, t.status FROM tasks t
-		WHERE t.status NOT IN ('complete', 'deployed', 'verified', 'verify_failed', 'failed', 'blocked', 'cancelled')
+		WHERE t.status NOT IN (${TASK_RECONCILIATION_TERMINAL_STATES_SQL})
 		$batch_filter
 		ORDER BY t.id;
 	")


### PR DESCRIPTION
## Summary
- centralize repeated supervisor SQL status lists in shared constants to prevent drift between modules
- switch `state.sh` sibling-activity filtering and `todo-sync.sh` reconciliation filtering to consume shared constants
- preserve existing behavior while addressing maintainability feedback from PR #1959 review

Closes #3410