### PR TITLE
t3403: resolve setup-aidevops hardcoded repo path

### DIFF
--- a/.agents/scripts/generate-claude-agents.sh
+++ b/.agents/scripts/generate-claude-agents.sh
@@ -314,7 +314,15 @@ write_command "setup-aidevops" \
 	'Run the aidevops setup script to deploy the latest changes.
 
 ```bash
-cd ~/Git/aidevops && ./setup.sh || exit
+AIDEVOPS_REPO="${AIDEVOPS_REPO:-$(jq -r \".initialized_repos[]?.path | select(test(\\\"/aidevops$\\\"))\" ~/.config/aidevops/repos.json 2>/dev/null | head -n 1)}"
+if [[ -z "$AIDEVOPS_REPO" ]]; then
+  AIDEVOPS_REPO="$HOME/Git/aidevops"
+fi
+[[ -f "$AIDEVOPS_REPO/setup.sh" ]] || {
+  echo "Unable to find setup.sh. Set AIDEVOPS_REPO to your aidevops clone path." >&2
+  exit 1
+}
+cd "$AIDEVOPS_REPO" && ./setup.sh || exit
 ```
 
 This deploys agents, updates commands, regenerates configs.

--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -714,7 +714,15 @@ if should_generate "setup-aidevops"; then
 		'Run the aidevops setup script to deploy the latest changes.
 
 ```bash
-cd ~/Git/aidevops && ./setup.sh || exit
+AIDEVOPS_REPO="${AIDEVOPS_REPO:-$(jq -r ".initialized_repos[]?.path | select(test(\"/aidevops$\"))" ~/.config/aidevops/repos.json 2>/dev/null | head -n 1)}"
+if [[ -z "$AIDEVOPS_REPO" ]]; then
+  AIDEVOPS_REPO="$HOME/Git/aidevops"
+fi
+[[ -f "$AIDEVOPS_REPO/setup.sh" ]] || {
+  echo "Unable to find setup.sh. Set AIDEVOPS_REPO to your aidevops clone path." >&2
+  exit 1
+}
+cd "$AIDEVOPS_REPO" && ./setup.sh || exit
 ```
 
 **What this does:**

--- a/.agents/scripts/generate-opencode-commands.sh
+++ b/.agents/scripts/generate-opencode-commands.sh
@@ -949,7 +949,15 @@ Run the aidevops setup script to deploy the latest changes.
 
 **Command:**
 ```bash
-cd ~/Git/aidevops && ./setup.sh || exit
+AIDEVOPS_REPO="${AIDEVOPS_REPO:-$(jq -r '.initialized_repos[]?.path | select(test("/aidevops$"))' ~/.config/aidevops/repos.json 2>/dev/null | head -n 1)}"
+if [[ -z "$AIDEVOPS_REPO" ]]; then
+	AIDEVOPS_REPO="$HOME/Git/aidevops"
+fi
+[[ -f "$AIDEVOPS_REPO/setup.sh" ]] || {
+	echo "Unable to find setup.sh. Set AIDEVOPS_REPO to your aidevops clone path." >&2
+	exit 1
+}
+cd "$AIDEVOPS_REPO" && ./setup.sh || exit
 ```
 
 **What this does:**


### PR DESCRIPTION
## Summary
- replace hardcoded `~/Git/aidevops` usage in generated `/setup-aidevops` commands with dynamic repo path resolution via `~/.config/aidevops/repos.json`
- add a safe fallback to `$HOME/Git/aidevops` and explicit error handling when `setup.sh` cannot be found
- apply the same fix across OpenCode and Claude command generators for consistent behavior

Closes #3403