### PR TITLE
t3393: Address PR #2258 review feedback on t1327.1-research.md

### DIFF
--- a/todo/tasks/t1327.1-research.md
+++ b/todo/tasks/t1327.1-research.md
@@ -243,11 +243,11 @@ chatItem.content.type === "rcvMsgContent"
   fileSource?: CryptoFile,
   quotedItemId?: number,
   msgContent: MsgContent,
-  mentions: {string: number}  // displayName → groupMemberId
+  mentions: Record<string, number>  // displayName -> groupMemberId
 }
 ```
 
-> **Type note:** The Haskell source uses `Int64` for IDs and `Int` for small values like `duration`. In TypeScript/JSON all are represented as `number`. IDs are unlikely to exceed `Number.MAX_SAFE_INTEGER` (2^53−1) in practice, but if you need strict safety for very large IDs, use `bigint` and parse with `BigInt(value)`.
+> **Type note:** The Haskell source uses `Int64` for IDs and `Int` for small values like `duration`. In TypeScript/JSON these are commonly represented as `number`. If strict safety is required for IDs beyond `Number.MAX_SAFE_INTEGER` (2^53-1), serialize IDs as JSON strings and parse with `BigInt(idString)` to avoid precision loss.
 
 ### 5.2 ChatBotCommand (for bot menus)
 

--- a/todo/tasks/t1327.1-research.md
+++ b/todo/tasks/t1327.1-research.md
@@ -243,11 +243,11 @@ chatItem.content.type === "rcvMsgContent"
   fileSource?: CryptoFile,
   quotedItemId?: number,
   msgContent: MsgContent,
-  mentions: Record<string, number>  // displayName -> groupMemberId
+  mentions: { [displayName: string]: number }  // displayName -> groupMemberId
 }
 ```
 
-> **Type note:** The Haskell source uses `Int64` for IDs and `Int` for small values like `duration`. In TypeScript/JSON these are commonly represented as `number`. If strict safety is required for IDs beyond `Number.MAX_SAFE_INTEGER` (2^53-1), serialize IDs as JSON strings and parse with `BigInt(idString)` to avoid precision loss.
+> **Type note:** The Haskell source uses `Int64` for IDs and `Int` for small values like `duration`. To avoid precision loss, serialize large `Int64` IDs as JSON strings and parse with `BigInt(idString)` on the TypeScript side. Small values such as `duration` can remain TypeScript `number`.
 
 ### 5.2 ChatBotCommand (for bot menus)
 

--- a/todo/tasks/t1327.1-research.md
+++ b/todo/tasks/t1327.1-research.md
@@ -27,6 +27,11 @@ wget -qO- https://raw.githubusercontent.com/simplex-chat/simplex-chat/stable/ins
 # Result: simplex-chat binary on PATH
 ```
 
+> **Supply-chain note:** Piping a remote script directly into `bash` executes untrusted code without inspection. For production deployments, prefer one of these safer alternatives:
+> - Download the script first, inspect it, then run: `curl -o install.sh <url> && less install.sh && bash install.sh`
+> - Download a tagged release binary directly from [GitHub Releases](https://github.com/simplex-chat/simplex-chat/releases) and verify the SHA-256 checksum published alongside each release
+> - Pin to a specific tagged release URL (e.g., `stable` → `v6.4.3`) to avoid tracking a moving ref
+
 ### 1.2 Running as WebSocket Server
 
 ```bash
@@ -112,16 +117,18 @@ simplex-chat -p 5225 -d ~/.config/simplex-bot/db
 
 ### 3.1 Command Categories
 
-| Category | Key Commands | Use Case |
-|----------|-------------|----------|
-| Address | `APICreateMyAddress`, `APIShowMyAddress`, `APISetAddressSettings` | Bot address lifecycle |
-| Message | `APISendMessages`, `APIUpdateChatItem`, `APIDeleteChatItem`, `APIChatItemReaction` | Core messaging |
-| File | `ReceiveFile`, `CancelFile` | File handling |
-| Group | `APINewGroup`, `APIAddMember`, `APIRemoveMembers`, `APIMembersRole`, `APIBlockMembersForAll` | Group management |
-| Group Link | `APICreateGroupLink`, `APIGetGroupLink`, `APIDeleteGroupLink` | Public group links |
-| Connection | `APIAddContact`, `APIConnect`, `APIAcceptContact`, `APIRejectContact` | Contact management |
-| Chat | `APIListContacts`, `APIListGroups`, `APIDeleteChat` | Chat listing |
-| User Profile | `ShowActiveUser`, `APIUpdateProfile`, `APISetContactPrefs` | Profile/bot config |
+> **Note:** The names below are Haskell ADT constructor names from `COMMANDS.md` (the internal command type). They differ from both the CLI syntax (Section 3.2, e.g., `/_address`) and the TypeScript SDK method names (Section 6.2, e.g., `chat.apiCreateUserAddress()`). Use Section 3.2 for raw WebSocket commands and Section 6.2 for SDK usage.
+
+| Category | COMMANDS.md Constructor | CLI Equivalent | Use Case |
+|----------|------------------------|----------------|----------|
+| Address | `APICreateMyAddress`, `APIShowMyAddress`, `APISetAddressSettings` | `/_address`, `/_show_address`, `/_address_settings` | Bot address lifecycle |
+| Message | `APISendMessages`, `APIUpdateChatItem`, `APIDeleteChatItem`, `APIChatItemReaction` | `/_send`, `/_update_item`, `/_delete_item` | Core messaging |
+| File | `APIReceiveFile`, `APICancelFile` | `/_receive_file`, `/_cancel_file` | File handling |
+| Group | `APINewGroup`, `APIAddMember`, `APIRemoveMembers`, `APIMembersRole`, `APIBlockMembersForAll` | `/_group`, `/_add`, `/_remove`, `/_role`, `/_block_for_all` | Group management |
+| Group Link | `APICreateGroupLink`, `APIGetGroupLink`, `APIDeleteGroupLink` | `/_create_link`, `/_get_link`, `/_delete_link` | Public group links |
+| Connection | `APIAddContact`, `APIConnect`, `APIAcceptContact`, `APIRejectContact` | `/_add`, `/_connect`, `/_accept`, `/_reject` | Contact management |
+| Chat | `APIListContacts`, `APIListGroups`, `APIDeleteChat` | `/_contacts`, `/_groups`, `/_delete` | Chat listing |
+| User Profile | `APIGetActiveUser`, `APIUpdateProfile`, `APISetContactPrefs` | `/_profile`, `/_set_prefs` | Profile/bot config |
 
 ### 3.2 Key Command Syntax Patterns
 
@@ -216,29 +223,31 @@ chatItem.content.type === "rcvMsgContent"
 
 ```typescript
 // User
-{ userId: int64, localDisplayName: string, profile: LocalProfile, ... }
+{ userId: number, localDisplayName: string, profile: LocalProfile, ... }
 
 // Contact
-{ contactId: int64, localDisplayName: string, profile: LocalProfile, ... }
+{ contactId: number, localDisplayName: string, profile: LocalProfile, ... }
 
 // GroupInfo
-{ groupId: int64, localDisplayName: string, groupProfile: GroupProfile, ... }
+{ groupId: number, localDisplayName: string, groupProfile: GroupProfile, ... }
 
 // MsgContent (discriminated union)
 { type: "text", text: string }
 { type: "image", text: string, image: string }  // base64 image
 { type: "file", text: string }
-{ type: "voice", text: string, duration: int }
+{ type: "voice", text: string, duration: number }
 { type: "link", text: string, preview: LinkPreview }
 
 // ComposedMessage (for APISendMessages)
 {
   fileSource?: CryptoFile,
-  quotedItemId?: int64,
+  quotedItemId?: number,
   msgContent: MsgContent,
-  mentions: {string: int64}  // displayName → groupMemberId
+  mentions: {string: number}  // displayName → groupMemberId
 }
 ```
+
+> **Type note:** The Haskell source uses `Int64` for IDs and `Int` for small values like `duration`. In TypeScript/JSON all are represented as `number`. IDs are unlikely to exceed `Number.MAX_SAFE_INTEGER` (2^53−1) in practice, but if you need strict safety for very large IDs, use `bigint` and parse with `BigInt(value)`.
 
 ### 5.2 ChatBotCommand (for bot menus)
 
@@ -477,7 +486,7 @@ mail-helper.sh send --to agent-b --type task_dispatch \
 | Unknown events | MUST ignore unknown event types (forward-compat) |
 | AGPL license | SDK is AGPL-3.0; bot code that uses it must be AGPL or compatible |
 | CLI version | Bot API requires v6.4.3+ for bot profile/commands feature |
-| Bun WebSocket | `isomorphic-ws` works; alternatively use `Bun.connect()` directly |
+| Bun WebSocket | `isomorphic-ws` works; alternatively use `new WebSocket()` (Bun native) — note: `Bun.connect()` is a TCP socket API, not WebSocket |
 | No voice API | Voice notes are received as files; sending voice requires encoding |
 
 ---


### PR DESCRIPTION
## Summary

Addresses 4 medium-severity review findings from PR #2258 on `todo/tasks/t1327.1-research.md`.

## Changes

- **Supply-chain risk note** (line 22): Added guidance on safer alternatives to `curl | bash` — inspect-first, pinned release binary with checksum verification, or tagged release URL
- **Bun.connect() accuracy** (line 480): Corrected misleading note — `Bun.connect()` is a TCP socket API, not WebSocket; updated to reference `new WebSocket()` (Bun native)
- **Command table clarity** (line 124): Added explanatory note distinguishing COMMANDS.md Haskell ADT constructors from CLI syntax (Section 3.2) and TypeScript SDK methods (Section 6.2); added CLI equivalent column; fixed `ShowActiveUser` → `APIGetActiveUser` casing inconsistency
- **Type consistency** (line 241): Replaced `int64`/`int` with `number` throughout TypeScript type examples; added note explaining the Haskell→TypeScript mapping and when `bigint` would be appropriate

Closes #3393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added supply-chain security guidance for CLI installation with safer script execution alternatives
  * Clarified and expanded type specifications documentation for ID fields and message properties
  * Reworked Bot Commands presentation with mapping tables and concrete TypeScript code examples
  * Added explanatory notes distinguishing internal constructors from CLI and SDK representations
  * Enhanced WebSocket compatibility documentation for framework-specific behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->