### PR TITLE
t3373: fix missing payment endpoints in muapi.md

### DIFF
--- a/.agents/tools/video/muapi.md
+++ b/.agents/tools/video/muapi.md
@@ -284,7 +284,9 @@ Asset generation uses models like Flux and Runway. Storyboard assets can feed in
 Credit-based consumption system with Stripe integration.
 
 ```bash
-GET /api/payments/create_credits_checkout_session   # Purchase credits via Stripe
+POST /api/v1/payments/create_credits_checkout_session   # Purchase credits via Stripe
+GET  /api/v1/payments/credits                           # Check credit balance
+GET  /api/v1/payments/usage                             # Check usage history
 ```
 
 - **Credit Wallet** — Every user has a `CreditWallet`; generations deduct credits based on model cost and duration


### PR DESCRIPTION
## Summary

- Adds missing `GET /api/v1/payments/credits` (balance check) and `GET /api/v1/payments/usage` (usage history) endpoints to the `Payments & Credits` section of `.agents/tools/video/muapi.md`
- Corrects the checkout session endpoint: `GET` → `POST` and adds the `/api/v1/` version prefix for consistency with the rest of the document
- Both endpoints are already implemented in `muapi-helper.sh` (`cmd_balance` and `cmd_usage` functions) — this brings the documentation into alignment with the CLI tool

## Source

Addresses quality-debt review feedback from gemini-code-assist on PR #2013, line 288.

Closes #3373