### PR TITLE
t3391: address PR #2284 circuit breaker review feedback

### DIFF
--- a/.agents/scripts/supervisor-archived/circuit-breaker.sh
+++ b/.agents/scripts/supervisor-archived/circuit-breaker.sh
@@ -594,6 +594,33 @@ _cb_close_issue() {
 # ============================================================
 
 #######################################
+# Internal implementation for manual trip — must be called under state lock.
+# Args: $1 = task_id, $2 = reason
+# Returns: 0 on success, 1 on error
+#######################################
+_cb_trip_impl() {
+	local task_id="$1"
+	local reason="$2"
+	# Force trip by setting count to threshold
+	local now
+	now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	local state
+	state=$(jq -n \
+		--argjson count "$CIRCUIT_BREAKER_THRESHOLD" \
+		--arg now "$now" \
+		--arg task "$task_id" \
+		--arg reason "$reason" \
+		'{consecutive_failures: $count, tripped: true, tripped_at: $now, last_failure_at: $now, last_failure_task: $task, last_failure_reason: $reason}') || {
+		log_error "circuit-breaker: failed to build trip state JSON"
+		return 1
+	}
+	cb_write_state "$state" || return 1
+	log_warn "circuit-breaker: manually tripped (task: $task_id, reason: $reason)"
+	_cb_create_or_update_issue "$CIRCUIT_BREAKER_THRESHOLD" "$task_id" "$reason" || true
+	return 0
+}
+
+#######################################
 # Handle circuit-breaker subcommand from supervisor-helper.sh
 # Args: $1 = action (status|reset|trip|check)
 # Returns: 0 on success, 1 on error
@@ -621,22 +648,9 @@ cmd_circuit_breaker() {
 		# Manual trip for testing
 		local task_id="${1:-manual}"
 		local reason="${2:-manual_trip}"
-		# Force trip by setting count to threshold
-		local now
-		now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-		local state
-		state=$(jq -n \
-			--argjson count "$CIRCUIT_BREAKER_THRESHOLD" \
-			--arg now "$now" \
-			--arg task "$task_id" \
-			--arg reason "$reason" \
-			'{consecutive_failures: $count, tripped: true, tripped_at: $now, last_failure_at: $now, last_failure_task: $task, last_failure_reason: $reason}') || {
-			log_error "circuit-breaker: failed to build trip state JSON"
-			return 1
-		}
-		cb_write_state "$state" || return 1
-		log_warn "circuit-breaker: manually tripped (task: $task_id, reason: $reason)"
-		_cb_create_or_update_issue "$CIRCUIT_BREAKER_THRESHOLD" "$task_id" "$reason" || true
+		# Serialize the write with the state lock to prevent interleaving with
+		# concurrent pulse invocations (t3391 review feedback)
+		_cb_with_state_lock _cb_trip_impl "$task_id" "$reason" || return 1
 		;;
 	*)
 		echo "Usage: supervisor-helper.sh circuit-breaker <status|reset|check|trip>"

--- a/.agents/scripts/supervisor-archived/pulse.sh
+++ b/.agents/scripts/supervisor-archived/pulse.sh
@@ -1664,6 +1664,10 @@ cmd_pulse() {
 						--maker "pulse:phase1:t1113" 2>/dev/null || true
 					# Clean up worker process tree and PID file
 					cleanup_worker_processes "$tid"
+					# t1331: Count ENVIRONMENT failures for circuit-breaker too — repeated
+					# infra failures can loop without tripping the breaker otherwise.
+					# Prefix with "environment:" so downstream reporting can distinguish them.
+					cb_record_failure "$tid" "environment:$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 					# Transition back to queued (preserves current retry count)
 					cmd_transition "$tid" "queued" --error "environment:$outcome_detail" 2>>"$SUPERVISOR_LOG" || true
 					# Store pattern for diagnostics but don't mark as task failure


### PR DESCRIPTION
## Summary

- Serialize manual `trip` path with `_cb_with_state_lock` via new `_cb_trip_impl()` to prevent state interleaving with concurrent pulse writes
- Count ENVIRONMENT failures in circuit-breaker accounting so repeated infra failures can trip the breaker (prefixed `environment:` for downstream reporting distinction)

## Context

All other review findings from PR #2284 (numeric validation, lock wrapper, repo-scoping, jq hardening, tripped_at parse safety, `cb_record_success` on early-success path, jq empty-string fallbacks, elapsed helper deduplication) were already addressed in prior commits on this branch.

This PR addresses the two remaining unactioned findings:
1. **CodeRabbit (second review)**: ENVIRONMENT failure branch bypasses circuit-breaker — repeated infra failures could loop without tripping dispatch pause
2. **CodeRabbit (second review)**: Manual `trip` path writes state without holding the lock — concurrent pulse could interleave

Closes #3391