### PR TITLE
fix(t3393): fix mentions type to Record<string, number> and add BigInt/Int64 JSON string encoding note

### DIFF
--- a/todo/tasks/t1327.1-research.md
+++ b/todo/tasks/t1327.1-research.md
@@ -234,11 +234,13 @@ chatItem.content.type === "rcvMsgContent"
 // ComposedMessage (for APISendMessages)
 {
   fileSource?: CryptoFile,
-  quotedItemId?: int64,
+  quotedItemId?: number,
   msgContent: MsgContent,
-  mentions: {string: int64}  // displayName → groupMemberId
+  mentions: Record<string, number>  // displayName → groupMemberId
 }
 ```
+
+> **Type note:** The Haskell source uses `Int64` for IDs and `Int` for small values like `duration`. In TypeScript/JSON these are represented as `number`. For IDs that may exceed `Number.MAX_SAFE_INTEGER` (2^53−1), serialize them as JSON strings and parse with `BigInt(idString)` — converting a JSON `number` with `BigInt(value)` is unsafe because precision is already lost at parse time. Small values such as `duration` can remain TypeScript `number`.
 
 ### 5.2 ChatBotCommand (for bot menus)
 


### PR DESCRIPTION
## Summary

Addresses CodeRabbit CHANGES_REQUESTED on PR #4788 for `todo/tasks/t1327.1-research.md`.

## Changes

- **`mentions` type** (line 239): Replace `{string: int64}` with `Record<string, number>` — the original syntax used a literal property named `string`, not a dynamic string-key index map. `Record<string, number>` is the correct TypeScript utility type for a displayName→groupMemberId map.
- **`quotedItemId` type** (line 237): Replace `int64` with `number` (TypeScript/JSON representation).
- **Type note added** (after line 241): Explains the Haskell `Int64`/`Int` → TypeScript `number` mapping and explicitly recommends serializing large IDs as JSON strings and parsing with `BigInt(idString)` — clarifying that `BigInt(value)` on an already-parsed JSON `number` is unsafe because precision is lost at parse time, not at BigInt conversion.

## CodeRabbit findings addressed

1. `mentions: {string: number}` → `mentions: Record<string, number>` (wrong TypeScript syntax for index map)
2. BigInt note updated to recommend JSON string encoding for Int64 values (not `BigInt(jsonNumber)`)

Closes #3393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type definitions for message composition elements, including quoted message identifiers and user mention tracking, for improved consistency.

* **Documentation**
  * Added detailed documentation clarifying identifier handling and mapping behavior across system components, with guidance for serialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->