### PR TITLE
t3369: quality-debt: expo.md — deduplicate React.memo, clarify useDeferredValue

### DIFF
--- a/.agents/mobile-app-dev/expo.md
+++ b/.agents/mobile-app-dev/expo.md
@@ -179,7 +179,7 @@ Expo provides managed access to device capabilities:
 - Use `expo-image` instead of `Image` for optimised loading
 - Implement `FlatList` with `getItemLayout` for long lists
 - Use `React.memo` for expensive list items
-- Optimise heavy components with `React.memo` or `useDeferredValue`
+- Defer non-critical renders with `useDeferredValue` for heavy components
 - Profile with React DevTools and Flipper
 
 ## EAS Build and Submit


### PR DESCRIPTION
## Summary

- Removes redundant `React.memo` bullet in the Performance section of `.agents/mobile-app-dev/expo.md`
- Line 181 already covers `React.memo` for expensive list items; line 182 now distinctly covers `useDeferredValue` for heavy components
- Addresses the duplication introduced when PR #2011 review feedback was applied (Gemini suggestion replaced a `React.lazy`/`Suspense` bullet with `React.memo or useDeferredValue`, creating a near-duplicate of the existing line above)

## Change

```diff
- - Optimise heavy components with `React.memo` or `useDeferredValue`
+ - Defer non-critical renders with `useDeferredValue` for heavy components
```

Closes #3369