### PR TITLE
fix(t3421): add uv tool subcommand check to setup prerequisites

### DIFF
--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -68,13 +68,16 @@ install_mcp_packages() {
 		fi
 	fi
 
-	if command -v uv &>/dev/null; then
+	if command -v uv &>/dev/null && uv tool --help &>/dev/null; then
 		print_info "Installing/updating outscraper-mcp-server via uv..."
 		if command -v outscraper-mcp-server &>/dev/null; then
 			uv tool upgrade outscraper-mcp-server >/dev/null 2>&1 || true
 		else
 			uv tool install outscraper-mcp-server >/dev/null 2>&1 || print_warning "Failed to install outscraper-mcp-server"
 		fi
+	elif command -v uv &>/dev/null; then
+		print_warning "uv is installed but too old to support 'tool' subcommand — skipping outscraper-mcp-server"
+		print_info "Update uv with: curl -LsSf https://astral.sh/uv/install.sh | sh"
 	fi
 
 	# Update opencode.json with resolved full paths for all MCP binaries

--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -424,7 +424,7 @@ scan_imported_skills() {
 		local installed=false
 
 		# 1. uv tool install (preferred - fast, isolated, manages its own Python)
-		if [[ "$installed" == "false" ]] && command -v uv &>/dev/null; then
+		if [[ "$installed" == "false" ]] && command -v uv &>/dev/null && uv tool --help &>/dev/null; then
 			print_info "Installing Cisco Skill Scanner via uv..."
 			if run_with_spinner "Installing cisco-ai-skill-scanner" uv tool install cisco-ai-skill-scanner; then
 				print_success "Cisco Skill Scanner installed via uv"


### PR DESCRIPTION
## Summary

Addresses Gemini review feedback from PR #186: `command -v uv` alone is insufficient when `uv tool` is the actual invocation. Older `uv` installations lack the `tool` subcommand and would pass the presence check but fail at runtime.

## Changes

- **`setup-modules/mcp-setup.sh`**: Guard `outscraper-mcp-server` install with `uv tool --help &>/dev/null` check; add a descriptive warning with an update hint when `uv` is present but too old.
- **`setup-modules/plugins.sh`**: Guard `cisco-ai-skill-scanner` `uv`-path with the same `uv tool --help` check. The existing fallback chain (pipx → venv → pip3) still applies when `uv tool` is unavailable.

## Testing

- ShellCheck passes on both modified files with no warnings.
- Logic: `uv tool --help` exits 0 on any `uv` version that supports the `tool` subcommand; exits non-zero on versions that predate it.

Closes #3421