### PR TITLE
t3424: address PR #2243 medium quality-debt feedback

### DIFF
--- a/.agents/scripts/supervisor-archived/issue-sync.sh
+++ b/.agents/scripts/supervisor-archived/issue-sync.sh
@@ -683,26 +683,26 @@ update_queue_health_issue() {
 		label_search_results=$(gh issue list --repo "$repo_slug" \
 			--label "supervisor" --label "$runner_user" \
 			--state open --json number,title \
-			--jq '[.[] | select(.title | startswith("[Supervisor:"))] | sort_by(.number) | reverse' 2>/dev/null || echo "[]")
+			--jq 'sort_by(.number) | reverse' || echo "[]")
 
 		# Extract the newest issue (highest number)
-		health_issue_number=$(printf '%s' "$label_search_results" | jq -r '.[0].number // empty' 2>/dev/null || echo "")
+		health_issue_number=$(printf '%s' "$label_search_results" | jq -r '.[0].number // empty' || echo "")
 
 		# Dedup guard: if multiple supervisor issues exist for this runner,
 		# close all but the newest one. This prevents accumulation from transient
 		# API failures that caused the search to miss the existing issue.
 		local dup_count
-		dup_count=$(printf '%s' "$label_search_results" | jq 'length' 2>/dev/null || echo "0")
+		dup_count=$(printf '%s' "$label_search_results" | jq 'length' || echo "0")
 		if [[ "${dup_count:-0}" -gt 1 ]]; then
 			log_warn "  Phase 8c: Found $dup_count duplicate health issues for ${runner_user} — closing stale ones"
 			local dup_numbers
-			dup_numbers=$(printf '%s' "$label_search_results" | jq -r '.[1:][].number' 2>/dev/null || echo "")
+			dup_numbers=$(printf '%s' "$label_search_results" | jq -r '.[1:][].number' || echo "")
 			while IFS= read -r dup_num; do
 				[[ -z "$dup_num" ]] && continue
 				# Unpin before closing so stale issues don't remain pinned
 				_unpin_health_issue "$dup_num" "$repo_slug"
 				gh issue close "$dup_num" --repo "$repo_slug" \
-					--comment "Closing duplicate supervisor health issue — superseded by #${health_issue_number}." 2>/dev/null || true
+					--comment "Closing duplicate supervisor health issue — superseded by #${health_issue_number}." || true
 				log_info "  Phase 8c: Closed duplicate health issue #$dup_num (kept #$health_issue_number)"
 			done <<<"$dup_numbers"
 		fi
@@ -714,12 +714,13 @@ update_queue_health_issue() {
 		health_issue_number=$(gh issue list --repo "$repo_slug" \
 			--search "in:title ${runner_prefix}" \
 			--state open --json number,title \
-			--jq "[.[] | select(.title | startswith(\"${runner_prefix}\"))][0].number" 2>/dev/null || echo "")
+			--jq "[.[] | select(.title | startswith(\"${runner_prefix}\"))][0].number" || echo "")
 		# Backfill labels on issues found by title search so future lookups use labels
 		if [[ -n "$health_issue_number" ]]; then
-			gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" --description "Supervisor runner: ${runner_user}" --force 2>/dev/null || true
+			gh label create "supervisor" --repo "$repo_slug" --color "0052CC" --description "Supervisor queue health and orchestration issues" --force || true
+			gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" --description "Supervisor runner: ${runner_user}" --force || true
 			gh issue edit "$health_issue_number" --repo "$repo_slug" \
-				--add-label "supervisor" --add-label "$runner_user" 2>/dev/null || true
+				--add-label "supervisor" --add-label "$runner_user" || true
 			log_info "  Phase 8c: Backfilled labels on health issue #$health_issue_number"
 		fi
 	fi
@@ -733,32 +734,34 @@ update_queue_health_issue() {
 		legacy_issue=$(gh issue list --repo "$repo_slug" \
 			--search "in:title ${legacy_prefix}" \
 			--state open --json number,title \
-			--jq "[.[] | select(.title | startswith(\"${legacy_prefix}\"))][0].number" 2>/dev/null || echo "")
+			--jq "[.[] | select(.title | startswith(\"${legacy_prefix}\"))][0].number" || echo "")
 		if [[ -n "$legacy_issue" ]]; then
 			health_issue_number="$legacy_issue"
 			# Rename to new format so future lookups find it directly
 			local legacy_title
-			legacy_title=$(gh issue view "$legacy_issue" --repo "$repo_slug" --json title --jq '.title' 2>/dev/null || echo "")
+			legacy_title=$(gh issue view "$legacy_issue" --repo "$repo_slug" --json title --jq '.title' || echo "")
 			if [[ -n "$legacy_title" ]]; then
 				local migrated_title="${legacy_title/\[Supervisor\]/${runner_prefix}}"
 				gh issue edit "$legacy_issue" --repo "$repo_slug" --title "$migrated_title" >/dev/null 2>&1 || true
 				log_info "  Phase 8c: Migrated legacy health issue #$legacy_issue to ${runner_prefix} format (t1036)"
 			fi
 			# Backfill labels on migrated issue
-			gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" --description "Supervisor runner: ${runner_user}" --force 2>/dev/null || true
+			gh label create "supervisor" --repo "$repo_slug" --color "0052CC" --description "Supervisor queue health and orchestration issues" --force || true
+			gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" --description "Supervisor runner: ${runner_user}" --force || true
 			gh issue edit "$health_issue_number" --repo "$repo_slug" \
-				--add-label "supervisor" --add-label "$runner_user" 2>/dev/null || true
+				--add-label "supervisor" --add-label "$runner_user" || true
 		fi
 	fi
 
 	# Create the issue if it doesn't exist
 	if [[ -z "$health_issue_number" ]]; then
 		# Ensure username label exists
-		gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" --description "Supervisor runner: ${runner_user}" --force 2>/dev/null || true
+		gh label create "supervisor" --repo "$repo_slug" --color "0052CC" --description "Supervisor queue health and orchestration issues" --force || true
+		gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" --description "Supervisor runner: ${runner_user}" --force || true
 		health_issue_number=$(gh issue create --repo "$repo_slug" \
 			--title "${runner_prefix} starting..." \
 			--body "Live supervisor queue status for **${runner_user}**. Updated when stats change. Pin this issue for at-a-glance monitoring." \
-			--label "supervisor" --label "$runner_user" 2>/dev/null | grep -oE '[0-9]+$' || echo "")
+			--label "supervisor" --label "$runner_user" | grep -oE '[0-9]+$' || echo "")
 		if [[ -z "$health_issue_number" ]]; then
 			log_verbose "  Phase 8c: Could not create health issue"
 			return 0


### PR DESCRIPTION
## Summary
- remove stderr suppression from gh/jq calls in supervisor health-issue lookup and dedup logic so operational failures remain visible
- make label-based lookup title-agnostic by sorting label matches directly instead of filtering on issue title prefix
- ensure the supervisor label is created/backfilled alongside runner labels before adding labels or creating health issues

## Verification
- shellcheck .agents/scripts/supervisor-archived/issue-sync.sh
- .agents/scripts/linters-local.sh (fails due to pre-existing repo-wide baseline issues unrelated to this change)

Closes #3424