### PR TITLE
t3350: fix DOM style extraction — representative set with deduplication

### DIFF
--- a/.agents/tools/design/ui-ux-inspiration.md
+++ b/.agents/tools/design/ui-ux-inspiration.md
@@ -181,9 +181,10 @@ Use Playwright (`tools/browser/browser-automation.md`) to visit the URL and extr
 1. Navigate to URL with Playwright (headed mode for full render)
 2. Wait for fonts and images to load (networkidle)
 3. Take full-page screenshot for reference
-4. Extract computed styles from key elements:
-   - document.querySelectorAll('h1,h2,h3,h4,h5,h6,p,a,button,input,select,textarea')
-   - getComputedStyle() for each: font-family, font-size, font-weight,
+4. Extract computed styles from representative elements:
+   - Traverse the DOM to find a small, representative set of styled elements (not limited to a fixed tag list).
+   - Group elements by similar computed styles to identify unique patterns efficiently.
+   - For each unique pattern, record: font-family, font-size, font-weight,
      line-height, letter-spacing, color, background-color, border,
      border-radius, padding, margin, box-shadow
 5. Extract CSS custom properties (design tokens):


### PR DESCRIPTION
## Summary

- Replaces the fixed `querySelectorAll('h1,h2,...')` tag-list approach with a representative-set DOM traversal + style grouping strategy
- Groups elements by similar computed styles to identify unique patterns efficiently, avoiding redundant `getComputedStyle()` calls on every matching element
- Captures styled elements beyond the original fixed tag list (e.g. `div` cards and other non-semantic containers)

## Changes

- `.agents/tools/design/ui-ux-inspiration.md` — step 4 of the Extraction Method rewritten per Gemini reviewer suggestion

## References

Closes #3350
Source review comment: https://github.com/marcusquinn/aidevops/pull/2693#discussion_r2870056696