### PR TITLE
t3351: fix imported_at timestamps for Cloudron skills

### DIFF
--- a/.agents/configs/skill-sources.json
+++ b/.agents/configs/skill-sources.json
@@ -100,8 +100,8 @@
       "upstream_commit": "b247b124d168730051186aa63afad87c0c1f5a52",
       "local_path": ".agents/tools/deployment/cloudron-app-packaging-skill.md",
       "format_detected": "skill-md-nested",
-      "imported_at": "2026-03-01T18:00:00Z",
-      "last_checked": "2026-03-01T18:00:00Z",
+      "imported_at": "2026-03-01T16:19:15Z",
+      "last_checked": "2026-03-01T16:19:15Z",
       "merge_strategy": "added",
       "notes": "Official Cloudron skill from git.cloudron.io/docs/skills. Includes manifest-ref.md and addons-ref.md in cloudron-app-packaging-skill/"
     },
@@ -111,8 +111,8 @@
       "upstream_commit": "b247b124d168730051186aa63afad87c0c1f5a52",
       "local_path": ".agents/tools/deployment/cloudron-app-publishing-skill.md",
       "format_detected": "skill-md",
-      "imported_at": "2026-03-01T18:00:00Z",
-      "last_checked": "2026-03-01T18:00:00Z",
+      "imported_at": "2026-03-01T16:19:15Z",
+      "last_checked": "2026-03-01T16:19:15Z",
       "merge_strategy": "added",
       "notes": "Official Cloudron skill for CloudronVersions.json publishing and community packages (9.1+)"
     },
@@ -122,8 +122,8 @@
       "upstream_commit": "b247b124d168730051186aa63afad87c0c1f5a52",
       "local_path": ".agents/tools/deployment/cloudron-server-ops-skill.md",
       "format_detected": "skill-md",
-      "imported_at": "2026-03-01T18:00:00Z",
-      "last_checked": "2026-03-01T18:00:00Z",
+      "imported_at": "2026-03-01T16:19:15Z",
+      "last_checked": "2026-03-01T16:19:15Z",
       "merge_strategy": "added",
       "notes": "Official Cloudron skill for CLI server operations (logs, exec, backups, env vars, CI/CD)"
     },


### PR DESCRIPTION
## Summary

- Corrects `imported_at` and `last_checked` timestamps for three Cloudron skill entries in `.agents/configs/skill-sources.json`
- Placeholder value `2026-03-01T18:00:00Z` replaced with actual PR merge time `2026-03-01T16:19:15Z` for `cloudron-app-packaging`, `cloudron-app-publishing`, and `cloudron-server-ops`
- Addresses medium quality-debt finding from gemini code review on PR #2651

## Root Cause

When PR #2651 was authored, the Cloudron skill entries used a round-number placeholder timestamp (`18:00:00Z`) rather than the actual import time. The PR merged at `16:19:15Z` — the correct authoritative timestamp.

## Verification

- JSON remains valid (`python3 -c "import json; json.load(open(...))"` passes)
- No `18:00:00Z` placeholder remains in the file
- All three entries now reflect the actual merge commit time

Closes #3351