### PR TITLE
t3341: bump Google model tiers to Gemini 3 in MODEL_TIERS

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -240,8 +240,8 @@ MODEL_TIERS = {
     "haiku": "anthropic/claude-haiku-4-5",  # Triage, routing, simple tasks
     "sonnet": "anthropic/claude-sonnet-4-6",         # Code, review, implementation
     "opus": "anthropic/claude-opus-4-6",             # Architecture, complex reasoning
-    "flash": "google/gemini-2.5-flash", # Fast, cheap, large context
-    "pro": "google/gemini-2.5-pro",    # Capable, large context
+    "flash": "google/gemini-3-flash-preview", # Fast, cheap, large context
+    "pro": "google/gemini-3-pro-preview",    # Capable, large context
 }
 
 # Default model tier per agent (overridden by frontmatter 'model:' field)


### PR DESCRIPTION
## Summary

- Updates `flash` tier: `google/gemini-2.5-flash` → `google/gemini-3-flash-preview`
- Updates `pro` tier: `google/gemini-2.5-pro` → `google/gemini-3-pro-preview`

## Context

Addresses the CodeRabbit nitpick from PR #2126 review: the `flash` and `pro` tier mappings in `MODEL_TIERS` were pointing to Gemini 2.5 models, one generation behind. Gemini 3 preview models are confirmed available in:
- OpenCode's Google provider config (`~/.config/opencode/opencode.json`)
- OpenRouter model list (`google/gemini-3-flash-preview`, `google/gemini-3-pro-preview`)

Gemini 3.1 Pro was released Feb 19 2026; these preview identifiers are the current stable references for the Gemini 3 generation.

## Verification

- `shellcheck` passes (SC1091 info pre-existing, not introduced)
- Both model IDs confirmed in local OpenCode config and OpenRouter API

Closes #3341