### PR TITLE
fix(t3353): replace python3 JSON parsing with jq in clawdhub/add-skill helpers

### DIFF
--- a/.agents/scripts/add-skill-helper.sh
+++ b/.agents/scripts/add-skill-helper.sh
@@ -1255,17 +1255,17 @@ cmd_add_clawdhub() {
 	local api_response
 	api_response=$(curl -s --connect-timeout 10 --max-time 30 "${CLAWDHUB_API:-https://clawdhub.com/api/v1}/skills/${slug}" 2>/dev/null)
 
-	if [[ -z "$api_response" ]] || ! echo "$api_response" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+	if [[ -z "$api_response" ]] || ! echo "$api_response" | jq -e . >/dev/null 2>&1; then
 		log_error "Could not fetch skill info from ClawdHub API: $slug"
 		return 1
 	fi
 
 	# Extract metadata
 	local display_name summary owner_handle version
-	display_name=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('skill',{}).get('displayName',''))" 2>/dev/null)
-	summary=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('skill',{}).get('summary',''))" 2>/dev/null)
-	owner_handle=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('owner',{}).get('handle',''))" 2>/dev/null)
-	version=$(echo "$api_response" | python3 -c "import sys,json; print(json.load(sys.stdin).get('latestVersion',{}).get('version',''))" 2>/dev/null)
+	display_name=$(echo "$api_response" | jq -r '.skill.displayName // ""')
+	summary=$(echo "$api_response" | jq -r '.skill.summary // ""')
+	owner_handle=$(echo "$api_response" | jq -r '.owner.handle // ""')
+	version=$(echo "$api_response" | jq -r '.latestVersion.version // ""')
 
 	log_info "Found: $display_name v${version} by @${owner_handle}"
 
@@ -1456,6 +1456,12 @@ cmd_check_updates() {
 
 	local name url commit owner repo
 	while IFS='|' read -r name url commit; do
+		# Skip ClawdHub skills — update checks not yet supported for clawdhub.com URLs
+		if [[ "$url" == *clawdhub.com/* ]]; then
+			log_info "Skipping ClawdHub skill ($name) — update checks not yet supported"
+			continue
+		fi
+
 		# Extract owner/repo from URL
 		local parsed
 		parsed=$(parse_github_url "$url")

--- a/.agents/scripts/clawdhub-helper.sh
+++ b/.agents/scripts/clawdhub-helper.sh
@@ -103,9 +103,12 @@ fetch_skill_info() {
 	local slug="$1"
 
 	local response
-	response=$(curl -s --connect-timeout 10 --max-time 30 "${CLAWDHUB_API}/skills/${slug}")
+	response=$(curl -fsS --connect-timeout 10 --max-time 30 "${CLAWDHUB_API}/skills/${slug}") || {
+		log_error "Failed to fetch skill info (HTTP/network) for: $slug"
+		return 1
+	}
 
-	if echo "$response" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+	if echo "$response" | jq -e . >/dev/null 2>&1; then
 		echo "$response"
 	else
 		log_error "Failed to fetch skill info for: $slug"
@@ -128,7 +131,7 @@ fetch_skill_content_playwright() {
 	info=$(fetch_skill_info "$slug") || return 1
 
 	local owner
-	owner=$(echo "$info" | python3 -c "import sys,json; print(json.load(sys.stdin).get('owner',{}).get('handle',''))" 2>/dev/null)
+	owner=$(echo "$info" | jq -r '.owner.handle // ""')
 
 	if [[ -z "$owner" ]]; then
 		log_error "Could not determine owner for skill: $slug"
@@ -141,6 +144,7 @@ fetch_skill_content_playwright() {
 	# Create a temporary Node.js project with Playwright to extract SKILL.md
 	local pw_dir
 	pw_dir=$(mktemp -d "${TMPDIR:-/tmp}/clawdhub-pw-XXXXXX")
+	trap 'rm -rf "$pw_dir"' EXIT
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
 	push_cleanup "rm -rf '${pw_dir}'"
@@ -270,7 +274,7 @@ PLAYWRIGHT_SCRIPT
 
 	# Install playwright and run the fetch script
 	log_info "Installing Playwright (temporary)..."
-	if (cd "$pw_dir" && npm install --silent && npx playwright install chromium --with-deps); then
+	if (cd "$pw_dir" && npm install --silent && npx playwright install chromium --with-deps 2>&1); then
 		log_info "Running browser extraction..."
 		if (cd "$pw_dir" && node fetch.mjs "$skill_url" "$output_file"); then
 			rm -rf "$pw_dir"
@@ -360,33 +364,24 @@ cmd_search() {
 	log_info "Searching ClawdHub for: $query"
 
 	local encoded_query
-	encoded_query=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$query'))" 2>/dev/null || echo "$query")
+	encoded_query=$(python3 -c "import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1]))" "$query" 2>/dev/null || echo "$query")
 
 	local response
 	response=$(curl -s --connect-timeout 10 --max-time 30 "${CLAWDHUB_API}/search?q=${encoded_query}")
 
-	if ! echo "$response" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+	if ! echo "$response" | jq -e . >/dev/null 2>&1; then
 		log_error "Search failed"
 		return 1
 	fi
 
-	echo "$response" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-results = data.get('results', [])
-if not results:
-    print('  No results found')
-else:
-    for r in results:
-        score = r.get('score', 0)
-        slug = r.get('slug', '?')
-        name = r.get('displayName', slug)
-        summary = r.get('summary', '')[:60]
-        print(f'  {name} ({slug}) - score: {score:.2f}')
-        if summary:
-            print(f'    {summary}')
-        print()
-"
+	local results_count
+	results_count=$(echo "$response" | jq '.results | length' 2>/dev/null || echo "0")
+
+	if [[ "$results_count" -eq 0 ]]; then
+		echo "  No results found"
+	else
+		echo "$response" | jq -r '.results[] | "  \(.displayName // .slug // "?") (\(.slug // "?")) - score: \(.score // 0)\n\(if (.summary // "" | length) > 0 then "    \(.summary[:60])" else "" end)\n"'
+	fi
 	return 0
 }
 
@@ -406,24 +401,18 @@ cmd_info() {
 	local response
 	response=$(fetch_skill_info "$slug") || return 1
 
-	echo "$response" | python3 -c "
-import sys, json
-data = json.load(sys.stdin)
-skill = data.get('skill', {})
-owner = data.get('owner', {})
-version = data.get('latestVersion', {})
-stats = skill.get('stats', {})
-
-print(f'  Name: {skill.get(\"displayName\", \"?\")}')
-print(f'  Slug: {skill.get(\"slug\", \"?\")}')
-print(f'  Owner: @{owner.get(\"handle\", \"?\")}')
-print(f'  Version: {version.get(\"version\", \"?\")}')
-print(f'  Summary: {skill.get(\"summary\", \"\")}')
-print(f'  Stars: {stats.get(\"stars\", 0)}')
-print(f'  Downloads: {stats.get(\"downloads\", 0)}')
-print(f'  Installs: {stats.get(\"installsCurrent\", 0)}')
-print()
-"
+	echo "$response" | jq -r '
+      . as $data |
+      "  Name: \($data.skill.displayName // "?")",
+      "  Slug: \($data.skill.slug // "?")",
+      "  Owner: @\($data.owner.handle // "?")",
+      "  Version: \($data.latestVersion.version // "?")",
+      "  Summary: \($data.skill.summary // "")",
+      "  Stars: \($data.skill.stats.stars // 0)",
+      "  Downloads: \($data.skill.stats.downloads // 0)",
+      "  Installs: \($data.skill.stats.installsCurrent // 0)",
+      ""
+    '
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Addresses medium quality-debt review feedback from PR #183 (Gemini code review).

- Replace all `python3` JSON parsing/extraction with `jq` in `clawdhub-helper.sh` and `add-skill-helper.sh` — `jq` is already a project dependency, more performant (no Python interpreter spawn), and consistent with the rest of the codebase
- Surface HTTP/network errors in `fetch_skill_info` by switching `curl -s` to `curl -fsS` with explicit error handling
- Add `EXIT` trap for guaranteed temp dir cleanup in `fetch_skill_content_playwright`
- Redirect npm/playwright install stderr to stdout so installation failures are visible
- Pass URL-encode query as `sys.argv[1]` in `cmd_search` to avoid shell injection
- Skip ClawdHub URLs in `cmd_check_updates` with an informational log (update checks not yet supported for clawdhub.com)

Closes #3353