### PR TITLE
fix(t3351): correct imported_at timestamps for Cloudron skills to actual merge time

### DIFF
--- a/.agents/configs/skill-sources.json
+++ b/.agents/configs/skill-sources.json
@@ -100,8 +100,8 @@
       "upstream_commit": "b247b124d168730051186aa63afad87c0c1f5a52",
       "local_path": ".agents/tools/deployment/cloudron-app-packaging-skill.md",
       "format_detected": "skill-md-nested",
-      "imported_at": "2026-03-01T18:00:00Z",
-      "last_checked": "2026-03-01T18:00:00Z",
+      "imported_at": "2026-03-01T16:19:15Z",
+      "last_checked": "2026-03-01T16:19:15Z",
       "merge_strategy": "added",
       "notes": "Official Cloudron skill from git.cloudron.io/docs/skills. Includes manifest-ref.md and addons-ref.md in cloudron-app-packaging-skill/"
     },
@@ -111,8 +111,8 @@
       "upstream_commit": "b247b124d168730051186aa63afad87c0c1f5a52",
       "local_path": ".agents/tools/deployment/cloudron-app-publishing-skill.md",
       "format_detected": "skill-md",
-      "imported_at": "2026-03-01T18:00:00Z",
-      "last_checked": "2026-03-01T18:00:00Z",
+      "imported_at": "2026-03-01T16:19:15Z",
+      "last_checked": "2026-03-01T16:19:15Z",
       "merge_strategy": "added",
       "notes": "Official Cloudron skill for CloudronVersions.json publishing and community packages (9.1+)"
     },
@@ -122,8 +122,8 @@
       "upstream_commit": "b247b124d168730051186aa63afad87c0c1f5a52",
       "local_path": ".agents/tools/deployment/cloudron-server-ops-skill.md",
       "format_detected": "skill-md",
-      "imported_at": "2026-03-01T18:00:00Z",
-      "last_checked": "2026-03-01T18:00:00Z",
+      "imported_at": "2026-03-01T16:19:15Z",
+      "last_checked": "2026-03-01T16:19:15Z",
       "merge_strategy": "added",
       "notes": "Official Cloudron skill for CLI server operations (logs, exec, backups, env vars, CI/CD)"
     },


### PR DESCRIPTION
## Summary

- Corrects `imported_at` and `last_checked` timestamps for the three Cloudron skill entries in `.agents/configs/skill-sources.json` from placeholder values (`18:00:00Z`) to the actual PR #2651 merge time (`2026-03-01T16:19:15Z`)
- Addresses Gemini code review feedback flagged in PR #2651 (issue #3351): future/placeholder timestamps are semantically incorrect and could cause unexpected behaviour in time-based logic

## Changes

`.agents/configs/skill-sources.json` — updated `imported_at` and `last_checked` for:
- `cloudron-app-packaging`: `18:00:00Z` → `16:19:15Z`
- `cloudron-app-publishing`: `18:00:00Z` → `16:19:15Z`
- `cloudron-server-ops`: `18:00:00Z` → `16:19:15Z`

All three now reflect the actual merge timestamp of PR #2651 (`2026-03-01T16:19:15Z`).

Closes #3351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated timestamp metadata in skill source configurations to reflect current synchronization status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->