### PR TITLE
t3341: bump Google model tiers to Gemini 3 in MODEL_TIERS

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -240,8 +240,8 @@ MODEL_TIERS = {
     "haiku": "anthropic/claude-haiku-4-5",  # Triage, routing, simple tasks
     "sonnet": "anthropic/claude-sonnet-4-6",         # Code, review, implementation
     "opus": "anthropic/claude-opus-4-6",             # Architecture, complex reasoning
-    "flash": "google/gemini-2.5-flash", # Fast, cheap, large context
-    "pro": "google/gemini-2.5-pro",    # Capable, large context
+    "flash": "google/gemini-3-flash-preview", # Fast, cheap, large context
+    "pro": "google/gemini-3-pro-preview",    # Capable, large context
 }
 
 # Default model tier per agent (overridden by frontmatter 'model:' field)


### PR DESCRIPTION
## Summary

- Update `flash` tier: `google/gemini-2.5-flash` → `google/gemini-3-flash-preview`
- Update `pro` tier: `google/gemini-2.5-pro` → `google/gemini-3-pro-preview`

## Context

CodeRabbit left a nitpick on PR #2126 suggesting the Google model tier mappings be bumped to Gemini 3, as both `gemini-3-flash-preview` and `gemini-3-pro-preview` are present in OpenCode's default Google provider config and Gemini 3.1 Pro was released Feb 19 2026.

The Gemini review on the same PR approved the change as correct and complete — this PR addresses the optional improvement flagged by CodeRabbit.

Both models are confirmed available via OpenRouter and in OpenCode's provider config.

Closes #3341