### PR TITLE
t1349: fix: MD031 blank lines around fenced code blocks in t1349-brief.md

### DIFF
--- a/todo/tasks/t1349-brief.md
+++ b/todo/tasks/t1349-brief.md
@@ -63,6 +63,7 @@ Strengthen agent guidance across build-plus.md, context-guardrails.md, and conte
     method: bash
     run: "rg 'raw\\.githubusercontent\\.com' .agents/ --type md -l | grep -v 'build.txt' | xargs -I{} rg -c 'NEVER|CAUTION|avoid|bad|wrong|DON.T' {} | grep ':0$' && exit 1 || exit 0"
   ```
+
 - [ ] Lint clean (shellcheck / markdownlint)
 
 ## Context & Decisions


### PR DESCRIPTION
## Summary

- Adds missing blank lines around fenced code blocks in `todo/tasks/t1349-brief.md` to satisfy MD031 (blanks-around-fences)
- Resolves 8 markdownlint warnings flagged by CodeRabbit in PR #2462 review
- The brief's own "Lint clean" acceptance criterion is now met

## Changes

Single file: `todo/tasks/t1349-brief.md` — added one blank line between the last fenced code block in the Acceptance Criteria section and the following list item (`- [ ] Lint clean`). All fenced blocks now have blank lines before and after.

## Verification

```
markdownlint-cli2 "todo/tasks/t1349-brief.md"
# Summary: 0 error(s)
```

Closes #3315