### PR TITLE
t3329: fix eligible task count line-counting bug in ai-lifecycle.sh

### DIFF
--- a/.agents/scripts/supervisor-archived/ai-lifecycle.sh
+++ b/.agents/scripts/supervisor-archived/ai-lifecycle.sh
@@ -763,7 +763,7 @@ process_ai_lifecycle() {
 	local merged_parents=""
 
 	local total_eligible
-	total_eligible=$(printf '%s\n' "$eligible_tasks" | grep -c '.' || echo "0")
+	total_eligible=$(grep -c . <<<"$eligible_tasks" || true)
 	log_info "ai-lifecycle: $total_eligible tasks to evaluate"
 
 	while IFS='|' read -r tid tstatus tpr trepo; do


### PR DESCRIPTION
## Summary

- Fixes the buggy `total_eligible` line-counting logic in `.agents/scripts/supervisor-archived/ai-lifecycle.sh` flagged by Gemini in PR #2113 review
- Replaces `printf '%s\n' "$eligible_tasks" | grep -c '.' || echo "0"` with `grep -c . <<< "$eligible_tasks" || true`
- Aligns with repo style guide: use `|| true` (not `|| echo`) under `set -e`

## Root Cause

When `$eligible_tasks` is empty, the old pattern:
```bash
total_eligible=$(printf '%s\n' "$eligible_tasks" | grep -c '.' || echo "0")
```
produces a **multi-line value** (`0\n0`) because:
1. `printf '%s\n' ""` outputs a single newline
2. `grep -c '.'` returns `0` with exit code 1 (no match)
3. `|| echo "0"` appends a second `0` to the subshell output

This causes arithmetic errors and malformed log messages when `eligible_tasks` is empty.

## Fix

```bash
total_eligible=$(grep -c . <<< "$eligible_tasks" || true)
```

The here-string correctly handles the empty case — `grep -c .` returns `0` (single value), and `|| true` prevents `set -e` from aborting on the non-zero exit code.

## Verification

- `shellcheck` passes with zero violations on the modified file
- Behaviour confirmed: empty string → `0`, non-empty multi-line → correct count

Closes #3329