### PR TITLE
t3311: fix Pattern 3 SKILL.md regeneration after clean

### DIFF
--- a/.agents/scripts/generate-skills.sh
+++ b/.agents/scripts/generate-skills.sh
@@ -319,8 +319,8 @@ while IFS= read -r md_file; do
 	target_dir="${parent_dir}/${filename}"
 	skill_file="${target_dir}/SKILL.md"
 
-	# Skip if a matching folder already exists (handled by Pattern 1 or 2)
-	if [[ -d "$target_dir" ]]; then
+	# Skip if SKILL.md already exists (directory may exist after --clean)
+	if [[ -f "$skill_file" ]]; then
 		continue
 	fi
 


### PR DESCRIPTION
## Summary
- fix Pattern 3 guard in `.agents/scripts/generate-skills.sh` to skip only when `SKILL.md` already exists
- preserve idempotent directory creation so `--clean` followed by generation recreates standalone skill stubs
- add regression validation by running the script through generate -> clean -> regenerate cycle in a temporary fixture

Closes #3311