### PR TITLE
t3325: add regression coverage for non-actionable Gemini reviews

### DIFF
--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -1015,6 +1015,75 @@ JSON
 	return 0
 }
 
+test_scan_single_pr_filters_issue3325_review_body() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+				repos/*/pulls/*/comments)
+					echo "[]"
+					return 0
+					;;
+				repos/*/pulls/*/reviews)
+					printf '%s\n' '[{"id":1,"user":{"login":"gemini-code-assist[bot]"},"state":"COMMENTED","body":"## Code Review\n\nThis pull request addresses an issue where headless command sessions were incorrectly receiving an interactive greeting. The fix modifies the `generate-opencode-agents.sh` script to add a condition that skips the greeting for non-interactive sessions like `/pulse` and `/full-loop`. The change is clear, targeted, and effectively resolves the described problem. I have no further comments.","submitted_at":"2024-01-01T00:00:00Z","html_url":"https://github.com/example/repo/pull/1#pullrequestreview-1"}]'
+					return 0
+					;;
+				repos/*/git/trees/*)
+					echo '{"tree":[]}'
+					return 0
+					;;
+				repos/*)
+					echo "main"
+					return 0
+					;;
+				esac
+				shift
+			done
+			echo "[]"
+			return 0
+			;;
+		label | pr) return 0 ;;
+		esac
+		echo "[]"
+		return 0
+	}
+
+	local findings
+	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "issue #3325 review body is filtered as non-actionable" 0
+	else
+		print_result "issue #3325 review body is filtered as non-actionable" 1 "expected 0 findings, got ${count}"
+	fi
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			_mock_gh_api "$@"
+			return $?
+			;;
+		label) return 0 ;;
+		issue)
+			_mock_gh_issue "$@"
+			return $?
+			;;
+		esac
+		echo "unexpected gh call: ${command}" >&2
+		return 1
+	}
+	return 0
+}
+
 main() {
 	source "$HELPER"
 
@@ -1056,6 +1125,7 @@ main() {
 	test_scan_single_pr_default_filters_positive_review
 	test_scan_single_pr_filters_issue3363_review_body
 	test_scan_single_pr_filters_issue3303_review_body
+	test_scan_single_pr_filters_issue3325_review_body
 
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- add an integration regression test that reproduces the PR #2377 Gemini review body captured in issue #3325
- verify `_scan_single_pr` filters this non-actionable COMMENTED review so scan-merged does not create false-positive quality-debt issues
- keep the existing positive-review filtering behavior under test with a concrete fixture tied to the incident

Closes #3325