### PR TITLE
fix(issue3313): restore portable proof-log and dedup regressions

### DIFF
--- a/.agents/scripts/email-signature-parser-helper.sh
+++ b/.agents/scripts/email-signature-parser-helper.sh
@@ -510,48 +510,52 @@ resolve_contact_filename() {
 	local safe_email
 	safe_email=$(echo "$email" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9@._-]/_/g')
 	local base_file="${contacts_dir}/${safe_email}.toon"
+	local file
+	local existing_email
+	local existing_name
 
-	# If file doesn't exist, use it
-	if [[ ! -f "$base_file" ]]; then
-		echo "$base_file"
-		return 0
-	fi
+	# If this contact already exists (base or suffixed), reuse that file.
+	for file in "${contacts_dir}/${safe_email}"*.toon; do
+		if [[ ! -f "$file" ]]; then
+			continue
+		fi
 
-	# File exists — check if it's the same person (same email or same name)
-	local existing_email existing_name
-	while IFS= read -r _line; do
-		case "$_line" in
-		"  email: "*) existing_email="${_line#  email: }" ;;
-		"  name: "*) existing_name="${_line#  name: }" ;;
-		esac
-	done <"$base_file"
+		existing_email=$(grep -m1 "^  email: " "$file" | sed 's/^  email: //')
+		if [[ "$existing_email" == "$email" ]]; then
+			echo "$file"
+			return 0
+		fi
+	done
 
-	# Same email = same person, use existing file
-	if [[ "$existing_email" == "$email" ]]; then
-		echo "$base_file"
-		return 0
-	fi
-
-	# Different email but same name = name collision
-	# Check if name matches (case-insensitive)
-	if [[ -n "$name" && -n "$existing_name" ]]; then
+	# Different email but same name = name collision.
+	# Scan all contacts, not just the base filename, so collisions are detected
+	# even when this email has not been seen before.
+	if [[ -n "$name" ]]; then
 		local name_lower existing_name_lower
 		name_lower=$(echo "$name" | tr '[:upper:]' '[:lower:]')
-		existing_name_lower=$(echo "$existing_name" | tr '[:upper:]' '[:lower:]')
 
-		if [[ "$name_lower" == "$existing_name_lower" ]]; then
-			# Name collision detected — find next available suffix
-			local suffix=1
-			local collision_file
-			while true; do
-				collision_file="${contacts_dir}/${safe_email}-$(printf '%03d' $suffix).toon"
-				if [[ ! -f "$collision_file" ]]; then
-					echo "$collision_file"
-					return 0
-				fi
-				suffix=$((suffix + 1))
-			done
-		fi
+		for file in "$contacts_dir"/*.toon; do
+			if [[ ! -f "$file" ]]; then
+				continue
+			fi
+
+			existing_name=$(grep -m1 "^  name: " "$file" | sed 's/^  name: //')
+			existing_email=$(grep -m1 "^  email: " "$file" | sed 's/^  email: //')
+			existing_name_lower=$(echo "$existing_name" | tr '[:upper:]' '[:lower:]')
+
+			if [[ -n "$existing_name" && "$existing_name_lower" == "$name_lower" && "$existing_email" != "$email" ]]; then
+				local suffix=1
+				local collision_file
+				while true; do
+					collision_file="${contacts_dir}/${safe_email}-$(printf '%03d' "$suffix").toon"
+					if [[ ! -f "$collision_file" ]]; then
+						echo "$collision_file"
+						return 0
+					fi
+					suffix=$((suffix + 1))
+				done
+			fi
+		done
 	fi
 
 	# No collision, use base file

--- a/tests/test-email-signature-parser.sh
+++ b/tests/test-email-signature-parser.sh
@@ -53,6 +53,21 @@ assert_contains() {
 	return 0
 }
 
+assert_not_contains() {
+	local file="$1"
+	local pattern="$2"
+	local description="$3"
+
+	if grep -q "$pattern" "$file" 2>/dev/null; then
+		echo -e "  ${RED}FAIL${NC}: $description (unexpected pattern '$pattern' found in $file)"
+		FAIL=$((FAIL + 1))
+	else
+		echo -e "  ${GREEN}PASS${NC}: $description"
+		PASS=$((PASS + 1))
+	fi
+	return 0
+}
+
 assert_file_exists() {
 	local file="$1"
 	local description="$2"
@@ -359,6 +374,140 @@ test_merge_existing_contact() {
 	return 0
 }
 
+test_field_change_history_tracking() {
+	echo "Test: field changes are tracked in history"
+	setup
+
+	local email_v1 email_v2
+	email_v1=$(mktemp)
+	email_v2=$(mktemp)
+
+	cat >"$email_v1" <<'EOF'
+Hi team,
+
+Best regards,
+Jane Smith
+Developer
+StartupCo
+jane.smith@startup.com
++1 (555) 987-6543
+EOF
+
+	cat >"$email_v2" <<'EOF'
+Hi team,
+
+Best regards,
+Jane Smith
+Senior Developer
+BigCorp Inc.
+jane.smith@startup.com
++1 (555) 987-6543
+EOF
+
+	"$PARSER" parse "$email_v1" "$CONTACTS_DIR" >/dev/null 2>&1 || true
+	"$PARSER" parse "$email_v2" "$CONTACTS_DIR" >/dev/null 2>&1 || true
+
+	local contact_file="${CONTACTS_DIR}/jane.smith@startup.com.toon"
+	assert_file_exists "$contact_file" "Contact file exists after updates"
+	assert_contains "$contact_file" "history:" "History section created"
+	assert_contains "$contact_file" "field: title" "Title change logged"
+	assert_contains "$contact_file" "old: Developer" "Old title value recorded"
+	assert_contains "$contact_file" "new: Senior Developer" "New title value recorded"
+	assert_contains "$contact_file" "field: company" "Company change logged"
+	assert_contains "$contact_file" "old: StartupCo" "Old company value recorded"
+	assert_contains "$contact_file" "new: BigCorp Inc." "New company value recorded"
+	assert_contains "$contact_file" "title: Senior Developer" "Current title updated"
+	assert_contains "$contact_file" "company: BigCorp Inc." "Current company updated"
+
+	rm -f "$email_v1" "$email_v2"
+	teardown
+	return 0
+}
+
+test_name_collision_suffixing() {
+	echo "Test: same-name contacts with different emails use suffixes"
+	setup
+
+	local email_a email_b
+	email_a=$(mktemp)
+	email_b=$(mktemp)
+
+	cat >"$email_a" <<'EOF'
+Hi,
+
+Best regards,
+Bob Johnson
+Engineer
+Company A
+bob.johnson@companya.com
+EOF
+
+	cat >"$email_b" <<'EOF'
+Hi,
+
+Best regards,
+Bob Johnson
+Manager
+Company B
+bob.johnson@companyb.com
+EOF
+
+	"$PARSER" parse "$email_a" "$CONTACTS_DIR" >/dev/null 2>&1 || true
+	"$PARSER" parse "$email_b" "$CONTACTS_DIR" >/dev/null 2>&1 || true
+
+	assert_file_exists "${CONTACTS_DIR}/bob.johnson@companya.com.toon" "First contact file created"
+	assert_file_exists "${CONTACTS_DIR}/bob.johnson@companyb.com-001.toon" "Second contact gets collision suffix"
+
+	rm -f "$email_a" "$email_b"
+	teardown
+	return 0
+}
+
+test_last_seen_update_without_history_on_reparse() {
+	echo "Test: reparse updates last_seen without creating history"
+	setup
+
+	local email_file
+	email_file=$(mktemp)
+
+	cat >"$email_file" <<'EOF'
+Hi,
+
+Best regards,
+Charlie Brown
+Analyst
+DataCo
+charlie.brown@dataco.com
+EOF
+
+	"$PARSER" parse "$email_file" "$CONTACTS_DIR" >/dev/null 2>&1 || true
+	local contact_file="${CONTACTS_DIR}/charlie.brown@dataco.com.toon"
+	assert_file_exists "$contact_file" "Contact file created"
+
+	local first_seen
+	first_seen=$(grep "^  last_seen:" "$contact_file" | sed 's/^  last_seen: //')
+
+	sleep 1
+	"$PARSER" parse "$email_file" "$CONTACTS_DIR" >/dev/null 2>&1 || true
+
+	local second_seen
+	second_seen=$(grep "^  last_seen:" "$contact_file" | sed 's/^  last_seen: //')
+
+	if [[ -n "$first_seen" && -n "$second_seen" && "$first_seen" != "$second_seen" ]]; then
+		echo -e "  ${GREEN}PASS${NC}: last_seen timestamp updated"
+		PASS=$((PASS + 1))
+	else
+		echo -e "  ${RED}FAIL${NC}: last_seen timestamp did not update"
+		FAIL=$((FAIL + 1))
+	fi
+
+	assert_not_contains "$contact_file" "history:" "History not added when fields are unchanged"
+
+	rm -f "$email_file"
+	teardown
+	return 0
+}
+
 # =============================================================================
 # Main
 # =============================================================================
@@ -407,6 +556,12 @@ main() {
 	test_show_command
 	echo ""
 	test_merge_existing_contact
+	echo ""
+	test_field_change_history_tracking
+	echo ""
+	test_name_collision_suffixing
+	echo ""
+	test_last_seen_update_without_history_on_reparse
 	echo ""
 
 	echo "============================================"

--- a/tests/test-proof-log-enforcement.sh
+++ b/tests/test-proof-log-enforcement.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+set -euo pipefail
+
+# Proof-log enforcement regression tests.
+# Ensures completion helpers keep requiring verifiable evidence.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+TASK_COMPLETE_HELPER="${REPO_DIR}/.agents/scripts/task-complete-helper.sh"
+PRE_COMMIT_HOOK="${REPO_DIR}/.agents/scripts/pre-commit-hook.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() {
+	local description="$1"
+	echo -e "  ${GREEN}PASS${NC}: ${description}"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local description="$1"
+	echo -e "  ${RED}FAIL${NC}: ${description}"
+	FAIL=$((FAIL + 1))
+	return 0
+}
+
+assert_exit_code() {
+	local expected="$1"
+	local actual="$2"
+	local description="$3"
+
+	if [[ "$actual" -eq "$expected" ]]; then
+		pass "$description"
+	else
+		fail "$description (expected exit ${expected}, got ${actual})"
+	fi
+	return 0
+}
+
+assert_file_contains() {
+	local file="$1"
+	local pattern="$2"
+	local description="$3"
+
+	if grep -qE "$pattern" "$file" 2>/dev/null; then
+		pass "$description"
+	else
+		fail "$description"
+	fi
+	return 0
+}
+
+test_required_scripts_exist() {
+	echo "Test: required scripts exist"
+
+	if [[ -x "$TASK_COMPLETE_HELPER" ]]; then
+		pass "task-complete helper is executable"
+	else
+		fail "task-complete helper missing or not executable"
+	fi
+
+	if [[ -f "$PRE_COMMIT_HOOK" ]]; then
+		pass "pre-commit hook script exists"
+	else
+		fail "pre-commit hook script missing"
+	fi
+	return 0
+}
+
+test_requires_proof_log_argument() {
+	echo "Test: task-complete requires --pr or --verified"
+
+	local output=""
+	local rc=0
+	output=$("$TASK_COMPLETE_HELPER" t999 --repo-path "$REPO_DIR" --no-push 2>&1) || rc=$?
+
+	assert_exit_code 1 "$rc" "helper exits non-zero without proof-log"
+	if echo "$output" | grep -q "Missing required proof-log"; then
+		pass "missing proof-log error message shown"
+	else
+		fail "missing proof-log error message not shown"
+	fi
+	return 0
+}
+
+test_verified_completion_updates_todo() {
+	echo "Test: --verified marks task complete with proof-log"
+
+	local temp_repo
+	temp_repo=$(mktemp -d)
+
+	git init "$temp_repo" >/dev/null 2>&1
+	git -C "$temp_repo" config user.name "AI DevOps Test"
+	git -C "$temp_repo" config user.email "aidevops-test@example.com"
+
+	cat >"${temp_repo}/TODO.md" <<'EOF'
+- [ ] t100 Test completion path #test
+EOF
+
+	git -C "$temp_repo" add TODO.md
+	git -C "$temp_repo" commit -m "test: seed todo" >/dev/null 2>&1
+
+	local rc=0
+	"$TASK_COMPLETE_HELPER" t100 --verified 2026-03-14 --repo-path "$temp_repo" --no-push >/dev/null 2>&1 || rc=$?
+	assert_exit_code 0 "$rc" "helper succeeds with verified proof-log"
+
+	assert_file_contains "${temp_repo}/TODO.md" "^- \[x\] t100 " "task marked complete"
+	assert_file_contains "${temp_repo}/TODO.md" "verified:2026-03-14" "verified proof-log appended"
+	assert_file_contains "${temp_repo}/TODO.md" "completed:[0-9]{4}-[0-9]{2}-[0-9]{2}" "completed date appended"
+
+	rm -rf "$temp_repo"
+	return 0
+}
+
+test_pre_commit_script_enforces_proof_log() {
+	echo "Test: pre-commit script includes proof-log checks"
+
+	assert_file_contains "$PRE_COMMIT_HOOK" "pr:#" "hook checks pr:# format"
+	assert_file_contains "$PRE_COMMIT_HOOK" "verified:" "hook checks verified: format"
+	assert_file_contains "$PRE_COMMIT_HOOK" "return 1" "hook rejects invalid completion"
+	return 0
+}
+
+main() {
+	echo "============================================"
+	echo "Proof-Log Enforcement - Test Suite"
+	echo "============================================"
+	echo ""
+
+	test_required_scripts_exist
+	echo ""
+	test_requires_proof_log_argument
+	echo ""
+	test_verified_completion_updates_todo
+	echo ""
+	test_pre_commit_script_enforces_proof_log
+	echo ""
+
+	echo "============================================"
+	echo -e "Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+	echo "============================================"
+
+	if [[ "$FAIL" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- restore in-repo regression coverage for the quality-debt noted on PR #2192 by adding a new proof-log enforcement test suite
- expand email signature parser tests to cover field-change history tracking, same-name collision suffixing, and last_seen updates without history churn
- harden `resolve_contact_filename()` so same-name contacts with different emails consistently resolve to suffixed filenames

## Testing
- `bash tests/test-proof-log-enforcement.sh`
- `bash tests/test-email-signature-parser.sh`
- `shellcheck tests/test-proof-log-enforcement.sh tests/test-email-signature-parser.sh .agents/scripts/email-signature-parser-helper.sh`

Closes #3313
