### PR TITLE
fix(t3422): remove 2>/dev/null suppression from resolve_model calls

### DIFF
--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -2012,7 +2012,7 @@ _exec_escalate_model() {
 	# Resolve bare tier name to full model string before DB update
 	local resolved_to_tier="$to_tier"
 	if [[ -n "$to_tier" && "$to_tier" != *"/"* ]]; then
-		resolved_to_tier=$(resolve_model "$to_tier" "opencode" 2>/dev/null) || resolved_to_tier="$to_tier"
+		resolved_to_tier=$(resolve_model "$to_tier" "opencode") || resolved_to_tier="$to_tier"
 	fi
 
 	# Update model tier in supervisor DB if task exists there

--- a/.agents/scripts/supervisor-archived/batch.sh
+++ b/.agents/scripts/supervisor-archived/batch.sh
@@ -129,7 +129,7 @@ cmd_add() {
 	# cause model_config_error when passed to the CLI at dispatch time.
 	if [[ -n "$model" && "$model" != *"/"* ]]; then
 		local resolved_model
-		resolved_model=$(resolve_model "$model" "opencode" 2>/dev/null) || resolved_model=""
+		resolved_model=$(resolve_model "$model" "opencode") || resolved_model=""
 		if [[ -n "$resolved_model" ]]; then
 			log_info "Task $task_id: resolved tier '$model' to '$resolved_model' for DB storage"
 			model="$resolved_model"

--- a/.agents/scripts/supervisor-archived/dispatch.sh
+++ b/.agents/scripts/supervisor-archived/dispatch.sh
@@ -2762,7 +2762,7 @@ cmd_dispatch() {
 	# it discovers the work is incomplete, but starts cheap.
 	local resolved_model
 	if [[ "$verify_mode" == "true" ]]; then
-		resolved_model=$(resolve_model "coding" "$ai_cli" 2>/dev/null) || resolved_model=""
+		resolved_model=$(resolve_model "coding" "$ai_cli") || resolved_model=""
 		log_info "Verify mode: using coding-tier model ($resolved_model) instead of task-specific model"
 	else
 		resolved_model=$(resolve_task_model "$task_id" "$tmodel" "${trepo:-.}" "$ai_cli")


### PR DESCRIPTION
## Summary

Addresses Gemini review feedback from PR #2256. Three `2>/dev/null` redirections on `resolve_model()` calls were suppressing potentially important error messages (syntax errors in helper scripts, configuration issues). The `|| fallback` constructs already handle failure safely — stderr suppression was providing no benefit while hiding real errors.

## Changes

- `.agents/scripts/supervisor-archived/ai-actions.sh`: `resolve_model` in `_exec_escalate_model()` — tier resolution before DB update
- `.agents/scripts/supervisor-archived/batch.sh`: `resolve_model` in `cmd_add()` — tier resolution before DB insert
- `.agents/scripts/supervisor-archived/dispatch.sh`: `resolve_model` in verify-mode dispatch branch

## Verification

- ShellCheck passes (exit 0) on all three files
- No functional change: `|| resolved_model=""` / `|| resolved_to_tier="$to_tier"` fallbacks remain intact
- Errors from `resolve_model` (e.g., misconfigured fallback chain, missing helper scripts) will now surface to stderr/logs instead of being silently swallowed

Closes #3422