### PR TITLE
t3309: fix: use <PLACEHOLDER> style values in matterbridge config examples

### DIFF
--- a/.agents/scripts/matterbridge-helper.sh
+++ b/.agents/scripts/matterbridge-helper.sh
@@ -125,22 +125,28 @@ cmd_setup() {
 # Matterbridge configuration
 # Docs: https://github.com/42wim/matterbridge/wiki
 # Security: chmod 600 this file — it contains credentials
+#
+# IMPORTANT: Replace all <PLACEHOLDER> values with real credentials.
+# Store secrets securely — never hardcode tokens in this file:
+#   aidevops secret set MATTERBRIDGE_MATRIX_PASSWORD
+#   aidevops secret set MATTERBRIDGE_DISCORD_TOKEN
+# See: tools/credentials/gopass.md and tools/credentials/encryption-stack.md
 
 [general]
 RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 
 # Example: Matrix <-> Discord bridge
-# Uncomment and fill in credentials to use
+# Uncomment and replace <PLACEHOLDER> values with real credentials
 
 # [matrix]
 #   [matrix.home]
 #   Server="https://matrix.example.com"
 #   Login="bridgebot"
-#   Password="secret"
+#   Password="<MATRIX_PASSWORD>"
 
 # [discord]
 #   [discord.myserver]
-#   Token="Bot YOUR_DISCORD_BOT_TOKEN"
+#   Token="Bot <DISCORD_BOT_TOKEN>"
 #   Server="My Server Name"
 
 # [[gateway]]

--- a/.agents/services/communications/matterbridge.md
+++ b/.agents/services/communications/matterbridge.md
@@ -134,23 +134,25 @@ Every config has three sections:
 2. **`[general]`** — global settings (nick format, etc.)
 3. **`[[gateway]]`** — bridge definitions connecting accounts to channels
 
+> **Security**: All credential values below are `<PLACEHOLDER>` examples. Store actual tokens and passwords via `aidevops secret set NAME` (gopass) or the credentials agents in `tools/credentials/`. See `tools/credentials/gopass.md` and `tools/security/opsec.md`.
+
 ```toml
 # Protocol block: one per platform instance
 [matrix]
   [matrix.home]
   Server="https://matrix.example.com"
   Login="bridgebot"
-  Password="secret"
+  Password="<MATRIX_PASSWORD>"
   RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 
 [discord]
   [discord.myserver]
-  Token="Bot YOUR_DISCORD_BOT_TOKEN"
+  Token="Bot <DISCORD_BOT_TOKEN>"
   Server="My Discord Server"
 
 [telegram]
   [telegram.main]
-  Token="YOUR_TELEGRAM_BOT_TOKEN"
+  Token="<TELEGRAM_BOT_TOKEN>"
 
 [irc]
   [irc.libera]
@@ -224,9 +226,9 @@ enable=true
   [matrix.home]
   Server="https://matrix.example.com"
   Login="bridgebot"
-  Password="secret"
-  # Or use access token (preferred)
-  # Token="syt_..."
+  Password="<MATRIX_PASSWORD>"
+  # Or use access token (preferred — store via: aidevops secret set MATTERBRIDGE_MATRIX_TOKEN)
+  # Token="<MATRIX_ACCESS_TOKEN>"
   RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
   # Preserve threading
   PreserveThreading=true
@@ -237,10 +239,11 @@ enable=true
 ```toml
 [discord]
   [discord.myserver]
-  Token="Bot YOUR_BOT_TOKEN"
+  Token="Bot <DISCORD_BOT_TOKEN>"
   Server="My Server Name"
   # Use webhooks for better username/avatar spoofing
-  WebhookURL="https://discord.com/api/webhooks/..."
+  # Store webhook URL via: aidevops secret set MATTERBRIDGE_DISCORD_WEBHOOK
+  WebhookURL="<DISCORD_WEBHOOK_URL>"
   RemoteNickFormat="{NICK} [{PROTOCOL}]"
 ```
 
@@ -249,7 +252,8 @@ enable=true
 ```toml
 [telegram]
   [telegram.main]
-  Token="YOUR_BOT_TOKEN"
+  # Store via: aidevops secret set MATTERBRIDGE_TELEGRAM_TOKEN
+  Token="<TELEGRAM_BOT_TOKEN>"
   # For supergroups, use negative ID
   # Get ID: add @userinfobot to group
 ```
@@ -259,7 +263,8 @@ enable=true
 ```toml
 [slack]
   [slack.workspace]
-  Token="xoxb-YOUR-BOT-TOKEN"
+  # Store via: aidevops secret set MATTERBRIDGE_SLACK_TOKEN
+  Token="<SLACK_BOT_TOKEN>"
   # Legacy token (deprecated): xoxp-...
   # Bot token (recommended): xoxb-...
   PrefixMessagesWithNick=true
@@ -276,7 +281,8 @@ enable=true
   UseTLS=true
   SkipTLSVerify=false
   NickServNick="NickServ"
-  NickServPassword="your-nickserv-password"
+  # Store via: aidevops secret set MATTERBRIDGE_IRC_NICKSERV_PASSWORD
+  NickServPassword="<IRC_NICKSERV_PASSWORD>"
 ```
 
 #### XMPP
@@ -286,7 +292,8 @@ enable=true
   [xmpp.jabber]
   Server="jabber.example.com:5222"
   Jid="bridgebot@jabber.example.com"
-  Password="secret"
+  # Store via: aidevops secret set MATTERBRIDGE_XMPP_PASSWORD
+  Password="<XMPP_PASSWORD>"
   Muc="conference.jabber.example.com"
   Nick="matterbridge"
 ```
@@ -299,7 +306,8 @@ enable=true
   Server="mattermost.example.com"
   Team="myteam"
   Login="bridgebot@example.com"
-  Password="secret"
+  # Store via: aidevops secret set MATTERBRIDGE_MATTERMOST_PASSWORD
+  Password="<MATTERMOST_PASSWORD>"
   PrefixMessagesWithNick=true
   RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 ```
@@ -321,10 +329,11 @@ matterbridge-simplex --port 4242 --profile simplex-bridge
 
 ```toml
 # Matterbridge config: use API bridge to connect to adapter
+# Store the API token via: aidevops secret set MATTERBRIDGE_SIMPLEX_API_TOKEN
 [api]
   [api.simplex]
   BindAddress="0.0.0.0:4243"
-  Token="your-api-token"
+  Token="<SIMPLEX_API_TOKEN>"
 
 [[gateway]]
 name="simplex-matrix"
@@ -410,23 +419,25 @@ sudo journalctl -fu matterbridge
 Matterbridge exposes a simple REST API for custom integrations:
 
 ```toml
+# Store the API token via: aidevops secret set MATTERBRIDGE_API_TOKEN
 [api]
   [api.myapi]
   BindAddress="127.0.0.1:4242"
-  Token="your-secret-token"
+  Token="<MATTERBRIDGE_API_TOKEN>"
   Buffer=1000
 ```
 
 ```bash
 # Send message to bridge
+# Retrieve token: aidevops secret get MATTERBRIDGE_API_TOKEN
 curl -X POST http://localhost:4242/api/message \
-  -H "Authorization: Bearer your-secret-token" \
+  -H "Authorization: Bearer <MATTERBRIDGE_API_TOKEN>" \
   -H "Content-Type: application/json" \
   -d '{"text": "Hello from API", "username": "bot", "gateway": "mybridge"}'
 
 # Receive messages (long-poll)
 curl http://localhost:4242/api/messages \
-  -H "Authorization: Bearer your-secret-token"
+  -H "Authorization: Bearer <MATTERBRIDGE_API_TOKEN>"
 ```
 
 ## Troubleshooting

--- a/todo/tasks/t1328-brief.md
+++ b/todo/tasks/t1328-brief.md
@@ -121,6 +121,13 @@ SimpleX (matterbridge-simplex), Delta Chat, Minecraft
     pattern: "matterbridge"
     path: "subagent-index.toon"
   ```
+- [ ] All config examples in `matterbridge.md` and `matterbridge-helper.sh` use `<PLACEHOLDER>` style values for tokens/credentials (e.g., `<DISCORD_BOT_TOKEN>`, `<MATRIX_PASSWORD>`), with a note directing users to `tools/credentials/` agents (gopass, Bitwarden, SOPS) for secure storage
+  ```yaml
+  verify:
+    method: codebase
+    pattern: "<[A-Z_]+>"
+    path: ".agents/services/communications/matterbridge.md"
+  ```
 - [ ] Lint clean (`shellcheck` for scripts, markdown lint for docs)
 
 ## Context & Decisions


### PR DESCRIPTION
## Summary

Addresses CodeRabbit review feedback from PR #2255 (issue #3309).

- **`todo/tasks/t1328-brief.md`**: Added explicit acceptance criterion requiring all config examples in `matterbridge.md` and `matterbridge-helper.sh` use `<PLACEHOLDER>` style values for tokens/credentials, with a note referencing `tools/credentials/` agents for secure storage.
- **`.agents/services/communications/matterbridge.md`**: Replaced all bare credential values (`Password="secret"`, `Token="YOUR_BOT_TOKEN"`, etc.) with `<PLACEHOLDER>` tokens (`<MATRIX_PASSWORD>`, `<DISCORD_BOT_TOKEN>`, `<TELEGRAM_BOT_TOKEN>`, `<SLACK_BOT_TOKEN>`, `<IRC_NICKSERV_PASSWORD>`, `<XMPP_PASSWORD>`, `<MATTERMOST_PASSWORD>`, `<SIMPLEX_API_TOKEN>`, `<MATTERBRIDGE_API_TOKEN>`). Added inline `aidevops secret set` guidance and a security note at the top of the Basic Structure section.
- **`.agents/scripts/matterbridge-helper.sh`**: Updated the config template generated by `cmd_setup` to use `<PLACEHOLDER>` values and added a header comment directing users to `tools/credentials/` agents.

Closes #3309