### PR TITLE
t3488: parameterize review-triage fix-cycle queries

### DIFF
--- a/.agents/scripts/supervisor-archived/deploy.sh
+++ b/.agents/scripts/supervisor-archived/deploy.sh
@@ -568,12 +568,12 @@ cmd_pr_lifecycle() {
 			# infinite loop where fix workers address feedback but threads stay
 			# unresolved because only the author/admin can resolve them.
 			local prior_fix_cycles=0
-			prior_fix_cycles=$(db "$SUPERVISOR_DB" "
+			prior_fix_cycles=$(db_param "$SUPERVISOR_DB" "
 				SELECT COUNT(*) FROM state_log
-				WHERE task_id = '$escaped_id'
+				WHERE task_id = :task_id
 				  AND from_state = 'review_triage'
 				  AND to_state = 'dispatched';
-			" 2>>"$SUPERVISOR_LOG" || echo "0")
+			" "task_id=$task_id" 2>>"$SUPERVISOR_LOG" || echo "0")
 
 			if [[ "$prior_fix_cycles" -gt 0 ]]; then
 				log_info "Fix cycle $prior_fix_cycles for $task_id — resolving bot threads before re-triage"
@@ -640,12 +640,12 @@ cmd_pr_lifecycle() {
 					# review_triage→dispatched cycles this task has been through.
 					# Cap at 3 fix cycles — after that, block for human review.
 					local fix_cycle_count=0
-					fix_cycle_count=$(db "$SUPERVISOR_DB" "
+					fix_cycle_count=$(db_param "$SUPERVISOR_DB" "
 						SELECT COUNT(*) FROM state_log
-						WHERE task_id = '$escaped_id'
+						WHERE task_id = :task_id
 						  AND from_state = 'review_triage'
 						  AND to_state = 'dispatched';
-					" 2>/dev/null || echo "0")
+					" "task_id=$task_id" 2>/dev/null || echo "0")
 					local max_fix_cycles=3
 					if [[ "$fix_cycle_count" -ge "$max_fix_cycles" ]]; then
 						log_warn "Fix worker cycle limit reached ($fix_cycle_count/$max_fix_cycles) for $task_id — blocking"


### PR DESCRIPTION
## Summary
- Replace two interpolated SQL `task_id` filters in review-triage fix-cycle counting with `db_param` bindings.
- Keep existing transition logic unchanged while aligning the query style with Gemini feedback from source PR #1388.
- Reduce SQL injection risk surface for task IDs used in state_log cycle checks.

## Verification
- `shellcheck .agents/scripts/supervisor-archived/deploy.sh`
- `bash -x tests/test-supervisor-state-machine.sh` *(fails at baseline: `.agents/scripts/supervisor-archived/shared-constants.sh` missing in this worktree for supervisor init path)*

Closes #3488