### PR TITLE
t3294: include .sh in security-audit AI framework glob

### DIFF
--- a/.agents/tools/code-review/security-audit.md
+++ b/.agents/tools/code-review/security-audit.md
@@ -314,7 +314,7 @@ rg -in '(webfetch|fetch|requests\.get|urllib|curl)' \
 
 # Check for LLM/AI framework usage (indicates prompt injection risk)
 rg -in '(openai|anthropic|langchain|llama|ollama|ai\.run|completion)' \
-  --glob '*.{js,ts,py,go,rs}' -l | head -10
+  --glob '*.{js,ts,py,go,rs,sh}' -l | head -10
 ```
 
 For aidevops projects, verify `prompt-guard-helper.sh` integration. See `tools/security/prompt-injection-defender.md` for defense patterns and integration guidance.


### PR DESCRIPTION
## Summary
- Add `.sh` to the LLM/AI framework detection glob in `.agents/tools/code-review/security-audit.md` so shell-based integrations are included in prompt-injection risk detection.
- Align the detection command with related scans in the same section that already include shell scripts.

Closes #3294