### PR TITLE
t3295: remove Docling from PDF overview OCR list

### DIFF
--- a/.agents/tools/pdf/overview.md
+++ b/.agents/tools/pdf/overview.md
@@ -143,7 +143,7 @@ const { bytes: signed } = await pdf.sign({
 - `libpdf.md` - Detailed LibPDF usage guide
 - `../document/document-creation.md` - Unified document format conversion and creation
 - `../conversion/mineru.md` - PDF to markdown/JSON (layout-aware, OCR)
-- `../ocr/overview.md` - OCR tool selection guide (PaddleOCR, GLM-OCR, MinerU, Docling)
+- `../ocr/overview.md` - OCR tool selection guide (PaddleOCR, GLM-OCR, MinerU)
 - `../ocr/paddleocr.md` - PaddleOCR scene text OCR for scanned PDFs and images
 - `../conversion/pandoc.md` - General document format conversion
 - `../browser/playwright.md` - For PDF rendering/screenshots


### PR DESCRIPTION
## Summary
- Removes `Docling` from the OCR tools parenthetical in `.agents/tools/pdf/overview.md` for consistency with other OCR docs.
- Addresses Gemini review feedback captured in issue #3295 from source PR #2672.

Closes #3295