### PR TITLE
t3276: clarify milestone validation blocking vs diagnostics wording

### DIFF
--- a/.agents/workflows/milestone-validation.md
+++ b/.agents/workflows/milestone-validation.md
@@ -44,7 +44,7 @@ You are a QA engineer validating a milestone. Your job is to run every check tha
 
 **Validation is pass/fail, not subjective.** Every check must have a clear criterion. "Looks good" is not a validation result. "All 5 pages render without console errors, all links return 2xx, hero image loads in <3s" is.
 
-**Fail fast, report everything.** Don't stop at the first failure. Run all checks, collect all failures, then report them together. The orchestrator needs the full picture to create targeted fix tasks.
+**Block quickly, diagnose fully.** Treat the first blocking failure as a failed milestone, but continue running remaining checks to collect diagnostics. Report the full failure set together so the orchestrator can create targeted fix tasks.
 
 **Use the cheapest tool that works.** For most checks, `curl` + status codes is sufficient. Use Playwright only when you need to verify rendered output, JavaScript-dependent content, or visual layout. Use Stagehand only when page structure is unknown and you need AI to interpret it.
 


### PR DESCRIPTION
## Summary
- update `milestone-validation.md` language to match the worker behavior: first blocking failure marks milestone failed, but remaining checks still run for diagnostics
- remove the ambiguous "Fail fast" phrasing that conflicted with the explicit "report everything" guidance

## Validation
- `markdown-formatter lint .agents/workflows/milestone-validation.md`

Closes #3276