### PR TITLE
t3288: fix XMTP npm module init command

### DIFF
--- a/.agents/services/communications/xmtp.md
+++ b/.agents/services/communications/xmtp.md
@@ -145,7 +145,8 @@ Protocol-level consent system:
 ```bash
 # Create project
 mkdir my-agent && cd my-agent
-npm init --init-type=module -y
+npm init -y
+npm pkg set type=module
 
 # Install SDK and TypeScript tooling
 npm i @xmtp/agent-sdk


### PR DESCRIPTION
## Summary
- Replace invalid `npm init --init-type=module -y` command in XMTP install instructions
- Add explicit `npm pkg set type=module` step so the project is configured for ESM before TypeScript examples

Closes #3288