### PR TITLE
t3270: fix SIGPIPE false negatives in repo-sync-helper.sh old-label migration

### DIFF
--- a/.agents/scripts/repo-sync-helper.sh
+++ b/.agents/scripts/repo-sync-helper.sh
@@ -568,7 +568,10 @@ cmd_enable() {
 		# Migrate from old label if present (com.aidevops -> sh.aidevops)
 		local old_label="com.aidevops.aidevops-repo-sync"
 		local old_plist="${LAUNCHD_DIR}/${old_label}.plist"
-		if launchctl list 2>/dev/null | grep -qF "$old_label"; then
+		# Capture output first to avoid SIGPIPE (141) under set -o pipefail (t3270)
+		local launchctl_list
+		launchctl_list=$(launchctl list 2>/dev/null) || true
+		if echo "$launchctl_list" | grep -qF "$old_label"; then
 			launchctl unload -w "$old_plist" 2>/dev/null || true
 			log_info "Unloaded old LaunchAgent: $old_label"
 		fi
@@ -685,7 +688,10 @@ cmd_disable() {
 		# Also clean up old label if present (com.aidevops -> sh.aidevops migration)
 		local old_label="com.aidevops.aidevops-repo-sync"
 		local old_plist="${LAUNCHD_DIR}/${old_label}.plist"
-		if launchctl list 2>/dev/null | grep -qF "$old_label"; then
+		# Capture output first to avoid SIGPIPE (141) under set -o pipefail (t3270)
+		local launchctl_list_disable
+		launchctl_list_disable=$(launchctl list 2>/dev/null) || true
+		if echo "$launchctl_list_disable" | grep -qF "$old_label"; then
 			launchctl unload -w "$old_plist" 2>/dev/null || true
 			had_entry=true
 		fi


### PR DESCRIPTION
## Summary

- Fixes two `launchctl list | grep -qF` pipelines in `cmd_enable` and `cmd_disable` that could return exit code 141 (SIGPIPE) under `set -o pipefail`, silently skipping the old-label migration/unload path even when the label is present
- Applies the same variable-capture pattern already established in `_launchd_is_loaded` (captures `launchctl list` output into a local variable, then pipes to `grep`)

## Root Cause

`grep -q` exits immediately after the first match, which can cause the upstream `launchctl list` to receive SIGPIPE (141). With `set -o pipefail`, this non-zero exit propagates and the `if` condition evaluates as false — a false negative that skips the migration.

## Changes

- `.agents/scripts/repo-sync-helper.sh` — two locations fixed (previously flagged at lines 571 and 688 in PR #2365 review)

## Verification

- `shellcheck` passes with no new violations (only pre-existing SC1091 info for sourced file)
- Pattern matches the existing `_launchd_is_loaded` implementation

Closes #3270