### PR TITLE
t3249: fix: surface scanner and jq stderr in skill-scan

### DIFF
--- a/.agents/scripts/security-helper.sh
+++ b/.agents/scripts/security-helper.sh
@@ -581,7 +581,7 @@ cmd_skill_scan() {
 			fi
 
 			# Launch scan in background, write output to indexed temp file
-			$scanner_cmd scan "$scan_target" --format json >"$scan_tmpdir/$scan_index.json" 2>/dev/null &
+			$scanner_cmd scan "$scan_target" --format json >"$scan_tmpdir/$scan_index.json" 2>"$scan_tmpdir/$scan_index.err" &
 			scan_pids+=($!)
 			scan_names+=("$name")
 			scan_paths+=("$local_path")
@@ -594,6 +594,11 @@ cmd_skill_scan() {
 			wait "${scan_pids[$i]}" 2>/dev/null || true
 
 			echo -e "${CYAN}Scanning${NC}: ${scan_names[$i]} (${scan_paths[$i]})"
+
+			if [[ -s "$scan_tmpdir/$i.err" ]]; then
+				echo -e "${RED}Error scanning skill '${scan_names[$i]}':${NC}" >&2
+				cat "$scan_tmpdir/$i.err" >&2
+			fi
 
 			local scan_output=""
 			if [[ -s "$scan_tmpdir/$i.json" ]]; then
@@ -683,7 +688,7 @@ cmd_skill_scan() {
 					vt_issues=$((vt_issues + 1))
 					echo -e "  ${YELLOW}VT flagged issues${NC} for $name"
 				}
-			done < <(jq -c '.skills[]' "$skill_sources" 2>/dev/null)
+			done < <(jq -c '.skills[]' "$skill_sources")
 
 			if [[ $vt_issues -gt 0 ]]; then
 				echo ""


### PR DESCRIPTION
## Summary

Addresses the two MEDIUM findings from the Gemini review of PR #2493 on `.agents/scripts/security-helper.sh`.

- **Line 584**: Redirect skill-scanner background process stderr to an indexed `.err` file (`$scan_tmpdir/$scan_index.err`) instead of `/dev/null`. Silent failures (missing Python env, missing dependencies, syntax errors in the scanner) were previously invisible and would cause a skill to be reported as "0 findings" when the scan never ran.
- **Line 596** (collection loop): Report `.err` file contents to stderr when non-empty, so scan errors surface immediately alongside the skill name.
- **Line 589**: Remove `2>/dev/null` from the `jq` parse of `skill_sources`. With `set -e` active, a `jq` error on malformed JSON will now abort correctly instead of silently producing 0 skills scanned.

## Testing

- ShellCheck: zero new violations (pre-existing SC1091 info notice on `source` is unrelated).
- Logic: `.err` files are written to the same `scan_tmpdir` as `.json` files, cleaned up by the existing `rm -rf "$scan_tmpdir"` at function exit.

Closes #3249