### PR TITLE
fix: avoid reconstructing session ID in executeCommand (GH#3266)

### DIFF
--- a/.agents/scripts/simplex-bot/src/handlers/command-executor.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/command-executor.ts
@@ -41,6 +41,7 @@ export function buildCommandContext(
   parsed: { command: string; args: string[] },
   chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
   deps: MessageHandlerDeps,
+  sessionId?: string,
 ): CommandContext {
   return {
     command: parsed.command,
@@ -55,6 +56,7 @@ export function buildCommandContext(
       chatDir.groupId !== undefined
         ? deps.buildGroupInfo(chatDir.groupId)
         : undefined,
+    sessionId,
     reply: async (replyText: string) => {
       await deps.replyToItem(item, replyText);
     },
@@ -70,14 +72,10 @@ export async function executeCommand(
   try {
     deps.logger.info(`Executing command: /${cmdDef.name}`);
 
-    // Track last command in session metadata
-    const sessionId = ctx.contact
-      ? `direct:${ctx.contact.contactId}`
-      : ctx.group
-        ? `group:${ctx.group.groupId}`
-        : null;
-    if (sessionId) {
-      deps.sessions.updateMetadata(sessionId, {
+    // Track last command in session metadata using the session ID sourced from
+    // SessionStore (via ctx.sessionId) — avoids reconstructing the ID format here.
+    if (ctx.sessionId) {
+      deps.sessions.updateMetadata(ctx.sessionId, {
         lastCommand: `/${cmdDef.name}`,
       });
     }

--- a/.agents/scripts/simplex-bot/src/handlers/message.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/message.ts
@@ -101,6 +101,7 @@ export async function routeCommand(
   text: string,
   chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
   deps: MessageHandlerDeps,
+  sessionId?: string,
 ): Promise<void> {
   const parsed = deps.router.parse(text);
   if (!parsed) {
@@ -124,7 +125,7 @@ export async function routeCommand(
     return;
   }
 
-  const ctx = buildCommandContext(item, parsed, chatDir, deps);
+  const ctx = buildCommandContext(item, parsed, chatDir, deps, sessionId);
   await executeCommand(cmdDef, ctx, deps);
 }
 
@@ -140,15 +141,15 @@ export async function processItem(
   cacheContactDisplayName(chatDir, deps);
   cacheGroupDisplayName(chatDir, deps);
 
-  // Track session activity
-  trackSession(chatDir, deps);
+  // Track session activity; capture the session ID to pass to command context
+  const sessionId = trackSession(chatDir, deps);
 
   // Extract text content (routes non-text messages internally)
   const text = await extractTextContent(item, deps);
   if (!text) return;
 
   deps.logger.debug(`Received message: ${text.substring(0, 100)}`);
-  await routeCommand(item, text, chatDir, deps);
+  await routeCommand(item, text, chatDir, deps, sessionId);
 }
 
 /** Cache a contact display name if present in the chat direction */
@@ -171,22 +172,29 @@ export function cacheGroupDisplayName(
   if (name) deps.cacheGroupName(chatDir.groupId, name);
 }
 
-/** Track session activity for the chat */
+/**
+ * Track session activity for the chat.
+ * Returns the session ID so callers can pass it to command context
+ * without reconstructing the ID format.
+ */
 export function trackSession(
   chatDir: NonNullable<ChatItem["chatItem"]["chatDir"]>,
   deps: MessageHandlerDeps,
-): void {
+): string | undefined {
   if (chatDir.contactId !== undefined) {
     const session = deps.sessions.getContactSession(
       chatDir.contactId,
       chatDir.contact?.localDisplayName,
     );
     deps.sessions.recordMessage(session.id);
+    return session.id;
   } else if (chatDir.groupId !== undefined) {
     const session = deps.sessions.getGroupSession(
       chatDir.groupId,
       chatDir.groupInfo?.localDisplayName,
     );
     deps.sessions.recordMessage(session.id);
+    return session.id;
   }
+  return undefined;
 }

--- a/.agents/scripts/simplex-bot/src/types.ts
+++ b/.agents/scripts/simplex-bot/src/types.ts
@@ -183,6 +183,11 @@ export interface CommandContext {
   group?: GroupInfo;
   /** The chat item that triggered this command */
   chatItem: ChatItem;
+  /**
+   * Session ID for this chat context (e.g., "direct:42" or "group:7").
+   * Sourced directly from SessionStore to avoid duplicating the ID format.
+   */
+  sessionId?: string;
   /** Send a reply to the sender */
   reply: (text: string) => Promise<void>;
 }


### PR DESCRIPTION
## Summary

Addresses quality-debt from PR #2375 review feedback (gemini, medium severity).

**Finding**: `sessionId` was reconstructed in `command-executor.ts` using hardcoded `direct:<id>` / `group:<id>` string patterns, duplicating the format defined in `session.ts:117`. A format change would break this silently.

## Changes

- `trackSession()` in `message.ts` now returns `string | undefined` (the session ID from `SessionStore`) instead of `void`
- `routeCommand()` and `buildCommandContext()` accept an optional `sessionId` parameter
- `CommandContext` type gains a `sessionId?: string` field
- `executeCommand()` uses `ctx.sessionId` directly — no reconstruction

## How it works

The session ID flows from `SessionStore` through the call chain:

```
processItem
  → trackSession()          ← returns session.id from SessionStore
  → routeCommand(sessionId)
    → buildCommandContext(sessionId)  ← sets ctx.sessionId
      → executeCommand(ctx)           ← uses ctx.sessionId
```

The ID format (`direct:<n>` / `group:<n>`) is now defined in exactly one place: `session.ts`.

## Verification

- TypeScript: zero errors in modified files (`message.ts`, `command-executor.ts`, `types.ts`)
- Pre-existing `@types/bun` install errors in other files are unrelated to this change

Closes #3266