### PR TITLE
3246: fix simplex-bot Bun types configuration

### DIFF
--- a/.agents/scripts/simplex-bot/tsconfig.json
+++ b/.agents/scripts/simplex-bot/tsconfig.json
@@ -10,7 +10,8 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": ["bun-types"]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add an explicit `types` entry in `.agents/scripts/simplex-bot/tsconfig.json` so TypeScript resolves Bun globals through `bun-types`
- align the project config with the existing `@types/bun` dev dependency to address PR #2301 review follow-up quality debt

Closes #3246