### PR TITLE
t3212: address Cloudron packaging doc quality-debt feedback

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -491,9 +491,12 @@ exec /usr/bin/supervisord --configuration /app/code/supervisord.conf
 
 ## Addon Environment Variables
 
-For the full environment variable reference for all addons (mysql, postgresql, mongodb, redis, ldap, oidc, sendmail, recvmail, email, proxyauth, scheduler, tls, turn, docker) including addon-specific options, see [addons-ref.md](cloudron-app-packaging-skill/addons-ref.md).
+For the full environment variable reference for all addons (`mysql`, `postgresql`, `mongodb`, `redis`, `ldap`, `oidc`, `sendmail`, `recvmail`, `email`, `proxyauth`, `scheduler`, `tls`, `turn`, `docker`) including addon-specific options, see [addons-ref.md](cloudron-app-packaging-skill/addons-ref.md).
 
-**Key pattern**: Read env vars at runtime on every start — values can change across restarts. Run DB migrations on each start.
+**Key patterns**:
+
+- Read env vars at runtime on every start — values can change across restarts.
+- Run DB migrations on each start.
 
 ### General Variables (Always Available)
 


### PR DESCRIPTION
## Summary
- Apply the two outstanding medium review findings from PR #2652 in `.agents/tools/deployment/cloudron-app-packaging.md`
- Improve readability by backticking addon names in the consolidated reference list and splitting the runtime guidance into bullet points
- Keep scope limited to documentation quality debt with no behavior changes

Closes #3212