### PR TITLE
t3214: fix blanket 2>/dev/null suppression in cleanup_osgrep

### DIFF
--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -92,13 +92,13 @@ cleanup_osgrep() {
 	# 0. Kill running osgrep processes first (MCP servers, indexers)
 	# These are Node.js processes already loaded in memory — removing the
 	# binary and data won't stop them, and they may try to rebuild indexes.
-	if pgrep -f 'osgrep' >/dev/null 2>&1; then
+	if pgrep -f 'osgrep' >/dev/null; then
 		print_info "Killing running osgrep processes..."
-		pkill -f 'osgrep' 2>/dev/null || true
+		pkill -f 'osgrep' || true
 		# Give processes a moment to exit gracefully
 		sleep 1
 		# Force-kill any stragglers
-		pkill -9 -f 'osgrep' 2>/dev/null || true
+		pkill -9 -f 'osgrep' || true
 		cleaned=true
 	fi
 


### PR DESCRIPTION
## Summary

- Removes `2>/dev/null` blanket stderr suppression from `pgrep` and `pkill` calls in `cleanup_osgrep()` per style guide (`.gemini/styleguide.md` line 50)
- `pgrep -f 'osgrep' >/dev/null` — stdout redirect is sufficient for existence check; stderr should remain visible for auth/system errors
- `pkill -f 'osgrep' || true` and `pkill -9 -f 'osgrep' || true` — `|| true` already guards non-zero exits; `2>/dev/null` was masking legitimate error output

## Changes

`setup-modules/migrations.sh:95-101` — 3-line change, no logic change

## Verification

- `shellcheck setup-modules/migrations.sh` — zero violations

Closes #3214
Addresses review feedback from #2170