### PR TITLE
t3230: fix root-commit crash in session miner git diff shortstat

### DIFF
--- a/.agents/scripts/session-miner/extract.py
+++ b/.agents/scripts/session-miner/extract.py
@@ -488,10 +488,26 @@ def _git_log_in_window(
 
         # Get aggregate diff stats for the commit range
         hash_list = [c["hash"] for c in commits]
+        oldest_commit = hash_list[-1]
+        newest_commit = hash_list[0]
+
+        # Check if the oldest commit is a root commit (has no parent).
+        # If so, diff against the empty tree to capture initial-commit changes.
+        parent_check = subprocess.run(
+            ["git", "-C", repo_path, "rev-parse", "--verify", "--quiet", f"{oldest_commit}^"],
+            capture_output=True,
+        )
+        if parent_check.returncode == 0:
+            from_commit = f"{oldest_commit}~1"
+        else:
+            # Root commit — diff from git's canonical empty tree object.
+            from_commit = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
         stat_result = subprocess.run(
             [
                 "git", "-C", repo_path, "diff", "--shortstat",
-                f"{hash_list[-1]}~1..{hash_list[0]}",
+                from_commit,
+                newest_commit,
             ],
             capture_output=True, text=True, timeout=15,
         )


### PR DESCRIPTION
## Summary

- Fixes silent failure in `_git_log_in_window()` when the oldest commit in a session window is a root commit (no parent)
- `git diff --shortstat <hash>~1` fails with an invalid ref on root commits; diff stats were silently dropped for those sessions
- Fix: check for a parent via `rev-parse --verify --quiet <hash>^`; if none, diff from the canonical empty-tree object (`4b825dc642cb6eb9a060e54bf8d69288fbee4904`) to correctly capture initial-commit insertions

## Changes

- `.agents/scripts/session-miner/extract.py:489-513` — root-commit guard before `git diff --shortstat`

## Verification

- `python3 -c "import ast; ast.parse(...)"` → syntax OK
- `git diff --shortstat 4b825dc642cb6eb9a060e54bf8d69288fbee4904 HEAD` → produces valid shortstat output

Closes #3230
Addresses PR #2658 review feedback (gemini-code-assist, line 494)