### PR TITLE
t3238: fix full-loop-helper.sh PR #2357 review feedback

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -57,7 +57,7 @@ load_state() {
 		case "$_key" in
 		PHASE | ACTIVE | ITERATION | MAX_TASK_ITERATIONS | MAX_PREFLIGHT_ITERATIONS | \
 			MAX_PR_ITERATIONS | SKIP_PREFLIGHT | SKIP_POSTFLIGHT | NO_AUTO_PR | \
-			NO_AUTO_DEPLOY | HEADLESS)
+			NO_AUTO_DEPLOY | HEADLESS | PR_NUMBER)
 			printf -v "$_key" '%s' "$_val"
 			;;
 		esac
@@ -68,6 +68,7 @@ load_state() {
 	CURRENT_PHASE="${PHASE:-}"
 	HEADLESS="${HEADLESS:-false}"
 	SAVED_PROMPT=$(sed -n '/^---$/,/^---$/d; p' "$STATE_FILE")
+	return 0
 }
 
 is_loop_active() { [[ -f "$STATE_FILE" ]] && grep -q '^active: true' "$STATE_FILE"; }
@@ -320,12 +321,22 @@ Phases: task -> preflight -> pr-create -> pr-review -> postflight -> deploy
 EOF
 }
 
+_run_foreground() {
+	local prompt="$1"
+	local pid_file="${STATE_DIR}/full-loop.pid"
+	# On exit (normal or error), clear the PID file so status/logs don't report
+	# a background loop that is no longer running.
+	trap 'rm -f "$pid_file"' EXIT
+	emit_task_phase "$prompt"
+	return 0
+}
+
 main() {
 	local command="${1:-help}"
 	shift || true
 	case "$command" in
 	start) cmd_start "$@" ;; resume) cmd_resume ;; status) cmd_status ;;
-	cancel) cmd_cancel ;; logs) cmd_logs "$@" ;; _run_foreground) emit_task_phase "$@" ;;
+	cancel) cmd_cancel ;; logs) cmd_logs "$@" ;; _run_foreground) _run_foreground "$@" ;;
 	help | --help | -h) show_help ;;
 	*)
 		print_error "Unknown command: $command"


### PR DESCRIPTION
## Summary

Addresses two medium-severity findings from the PR #2357 (t1337.1) code review on `.agents/scripts/full-loop-helper.sh`.

## Fixes

### Fix 1 — PR_NUMBER lost on resume (line 331)

`cmd_resume` called `save_state` with `${PR_NUMBER:-}`, but `load_state` did not include `PR_NUMBER` in its allowlist, so the variable was never populated from the state file. Every resume overwrote the saved PR number with an empty string, causing `status` and `cmd_complete` to show `PR: none/unknown` after the pr-create phase.

**Change:** Added `PR_NUMBER` to the `load_state` allowlist case statement.

### Fix 2 — Stale PID file after background subprocess exits (lines 292/294/307)

In `--background` mode, `nohup "$0" _run_foreground ...` spawned a subprocess that called `emit_task_phase` and exited immediately. The state file remained `active: true` and the PID file was never cleaned up, so `status`/`logs` falsely reported a running background loop.

**Change:** Extracted `_run_foreground()` as a named function with an `EXIT` trap that removes the PID file on process exit (normal or error). `main()` now dispatches to this function instead of calling `emit_task_phase` inline.

## Test plan

- [x] ShellCheck passes (only SC1091 info, same as original PR)
- [x] `full-loop-helper.sh help` works
- [x] `full-loop-helper.sh status` works
- [x] `full-loop-helper.sh start "test" --dry-run` works

Closes #3238