### PR TITLE
fix(t3244): align /role description and usage with all 5 valid roles

### DIFF
--- a/.agents/scripts/simplex-bot/src/commands.ts
+++ b/.agents/scripts/simplex-bot/src/commands.ts
@@ -376,14 +376,14 @@ const inviteCommand: CommandDefinition = {
 /** Set a member's role in a group (group only) */
 const roleCommand: CommandDefinition = {
   name: "role",
-  description: "Set member role (observer/member/admin)",
+  description: "Set member role (observer/author/member/moderator/admin)",
   groupEnabled: true,
   dmEnabled: false,
   handler: async (ctx: CommandContext): Promise<string> => {
     const user = ctx.args[0];
     const role = ctx.args[1];
     if (!user || !role) {
-      return "Usage: /role @username [observer|member|admin]";
+      return "Usage: /role @username [observer|author|member|moderator|admin]";
     }
     const validRoles = ["observer", "author", "member", "moderator", "admin"];
     if (!validRoles.includes(role.toLowerCase())) {


### PR DESCRIPTION
## Summary

- Fixes inconsistency in `/role` command where `description` and usage message only listed `observer/member/admin` but `validRoles` also included `author` and `moderator`
- Users querying `/help` or receiving a usage error would not discover the full set of valid roles

## Changes

- `.agents/scripts/simplex-bot/src/commands.ts`: Updated `roleCommand.description` and usage string to list all 5 valid roles: `observer/author/member/moderator/admin`

## Source

Review feedback from PR #2375 (Gemini, medium severity), tracked in issue #3244.

Closes #3244