### PR TITLE
t3226: fix per-tenant-rag.md — address PR #2680 gemini review feedback

### DIFF
--- a/.agents/tools/vector-search/per-tenant-rag.md
+++ b/.agents/tools/vector-search/per-tenant-rag.md
@@ -546,7 +546,7 @@ async function rerankWithCrossEncoder(
 function reciprocalRankFusion(
   denseResults: ScoredChunk[],
   sparseResults: ScoredChunk[],
-  alpha: number = 0.7,
+  alpha: number,
   k: number = 60,
 ): ScoredChunk[] {
   const scores = new Map<string, number>();
@@ -606,15 +606,19 @@ function assembleContext(
   const includedChunks: string[] = [];
 
   for (const chunk of chunks) {
-    const chunkTokens = countTokens(chunk.content);
-    if (chunkTokens > budget) break;
-
     const attribution = config.includeAttribution
-      ? `[Source: ${chunk.metadata.sourceFile}, p.${chunk.metadata.pageNumber ?? '?'}]`
+      ? `\n[Source: ${chunk.metadata.sourceFile}, p.${chunk.metadata.pageNumber ?? '?'}]`
       : '';
+    const contentToPush = chunk.content + attribution;
 
-    includedChunks.push(`${chunk.content}\n${attribution}`);
-    budget -= chunkTokens;
+    const contentTokens = countTokens(contentToPush);
+    const separatorTokens = includedChunks.length > 0 ? countTokens('\n\n---\n\n') : 0;
+    const totalTokens = contentTokens + separatorTokens;
+
+    if (totalTokens > budget) break;
+
+    includedChunks.push(contentToPush);
+    budget -= totalTokens;
   }
 
   return [


### PR DESCRIPTION
## Summary

- Remove duplicate `alpha` default from `reciprocalRankFusion` signature — `DEFAULT_QUERY_CONFIG.hybridAlpha` is the single source of truth (line 453), eliminating the risk of the two values drifting out of sync
- Fix token budget in `assembleContext` to count tokens for the full content-to-push string (chunk + attribution) and the `\n\n---\n\n` separator, preventing the assembled prompt from silently exceeding the model's context window

## Changes

`.agents/tools/vector-search/per-tenant-rag.md`

- `reciprocalRankFusion`: `alpha: number = 0.7` → `alpha: number`
- `assembleContext` loop: compute `contentToPush = chunk.content + attribution`, count tokens on the full string plus separator, gate on `totalTokens > budget`, deduct `totalTokens` from budget

## Verification

Diff matches the two Gemini suggestions from PR #2680 verbatim. No logic changes beyond the two targeted fixes.

Closes #3226