### PR TITLE
fix: address PR #2336 review feedback in strategic-review.md

### DIFF
--- a/.agents/scripts/commands/strategic-review.md
+++ b/.agents/scripts/commands/strategic-review.md
@@ -41,8 +41,11 @@ gh issue list --repo <owner/repo> --state open --json number,title,labels,update
 Then gather system-wide state:
 
 ```bash
-# Active worktrees (all repos share the worktree namespace)
-git worktree list
+# Active worktrees — scoped per repo; iterate over all managed repos
+jq -r '[.initialized_repos[] | select(.pulse == true and .local_only != true)] | .[].path' ~/.config/aidevops/repos.json | while read -r repo_path; do
+  echo "=== $repo_path ==="
+  git -C "$repo_path" worktree list 2>/dev/null || echo "(not a git repo or path missing)"
+done
 
 # Running workers
 pgrep -f '/full-loop' 2>/dev/null | wc -l | tr -d ' '
@@ -97,7 +100,7 @@ Based on your assessment, take action — but distinguish between safe mechanica
 ### Act directly (mechanical, reversible, no judgment needed):
 
 1. **`git worktree prune`** — safe, only removes worktrees whose directories are already gone.
-2. **Merge CI-green PRs with approved reviews** — `gh pr merge --squash`. Same as the pulse does.
+2. **Merge CI-green PRs with approved reviews** — `gh pr merge <PR_NUMBER> --squash --repo <owner/repo>`. Always supply the PR number and `--repo` explicitly; omitting them risks acting on the wrong PR in a cross-repo context. Same as the pulse does.
 3. **File GitHub issues for systemic problems** — if you see a pattern (same CI failure, same type of worker failure, same blocked chain), create an issue describing the pattern and proposed fix.
 4. **Record observations** — the report itself is the primary output.
 


### PR DESCRIPTION
## Summary

Addresses two medium-severity findings from the PR #2336 review of `.agents/scripts/commands/strategic-review.md`.

### Finding 1 — Incorrect worktree namespace claim (line 44)

`git worktree list` is scoped to the current Git repository. The previous comment claimed "all repos share the worktree namespace", which is incorrect and would cause the strategic review to miss stale worktrees in other repos.

**Fix**: replaced the single `git worktree list` call with a loop that iterates over all pulse-enabled managed repos from `repos.json` and runs `git -C "$repo_path" worktree list` per repo.

### Finding 2 — Unsafe `gh pr merge --squash` without identifiers (line 100)

`gh pr merge --squash` without a PR number or `--repo` flag can silently act on the current-branch PR or fail, which is risky in a cross-repo workflow.

**Fix**: updated the instruction to require `gh pr merge <PR_NUMBER> --squash --repo <owner/repo>` with both arguments explicit.

Closes #3216