### PR TITLE
t3217: fix strategic review scheduling claims in onboarding.md

### DIFF
--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -1145,8 +1145,9 @@ aidevops includes autonomous orchestration features that can work in the backgro
 1. Supervisor pulse    - Dispatches AI workers every 2 min to implement tasks from TODO.md
 2. Auto-pickup         - Workers claim #auto-dispatch tasks automatically
 3. Cross-repo visibility - Manages tasks, issues, and PRs across all repos in repos.json
-4. Strategic review    - Every 4h, an opus-tier review checks queue health, finds stuck
-                         chains, identifies root causes, and creates self-improvement tasks
+4. Strategic review    - Separate scheduled process (every 4h) — opus-tier review checks
+                         queue health, finds stuck chains, identifies root causes, and
+                         creates self-improvement tasks (see scripts/commands/runners.md)
 5. Model routing       - Cost-aware dispatch: local > haiku > flash > sonnet > pro > opus
 6. Budget tracking     - Per-provider spend limits, subscription-aware routing
 7. Session miner       - Daily extraction of learning signals from past sessions
@@ -1169,9 +1170,10 @@ Here's how it works:
 - Cross-repo: the supervisor sees tasks, issues, and PRs across all repos in repos.json
 - Model routing picks the cheapest model that can handle each task (haiku for simple, opus for complex)
 - Budget tracking prevents overspend — set daily limits per provider
-- Every 4 hours, an opus-tier strategic review assesses the whole operation:
-  finds blocked chains, stale state, idle capacity, and systemic issues
-- It creates self-improvement tasks when it finds root causes in the framework
+- Every 4 hours, a separate opus-tier strategic review assesses the whole operation:
+  finds blocked chains, stale state, idle capacity, and systemic issues.
+  This runs as its own scheduled process (see scripts/commands/runners.md for setup),
+  not as a step within the pulse itself.
 
 Cost depends on how you access the models:
 
@@ -1212,8 +1214,9 @@ If **no**:
 No problem. You can enable it anytime — see scripts/commands/runners.md
 for setup instructions (launchd on macOS, cron on Linux).
 
-The strategic review, session miner, and circuit breaker all run as steps
-within the pulse — enabling the pulse enables everything.
+The session miner and circuit breaker run as exit steps within the pulse.
+The strategic review runs as a separate scheduled process — see
+scripts/commands/runners.md for setup instructions for both.
 ```
 
 ## Settings File


### PR DESCRIPTION
## Summary

Addresses PR #2344 review feedback filed as issue #3217.

- Corrects the claim that strategic review runs "as a step within the pulse" — it is a separate scheduled process (`/strategic-review` command, scheduled independently via runners.md)
- Fixes the "enabling the pulse enables everything" statement — session miner and circuit breaker are pulse exit steps, but strategic review requires separate scheduling
- Adds `runners.md` reference so users know where to find setup instructions for the strategic review scheduler

## Changes

- `.agents/aidevops/onboarding.md`: 3 targeted text corrections at lines 1148–1150, 1173–1176, and 1217–1219

## Verification

Checked against:
- `pulse-wrapper.sh` — no invocation of `session-miner-pulse.sh` or strategic review (confirmed)
- `scripts/commands/pulse.md` line 140 — session miner runs as pulse exit step (confirmed)
- `scripts/commands/strategic-review.md` — strategic review is a standalone command with its own cadence via `opus-review-helper.sh` (confirmed)

Closes #3217