### PR TITLE
t3208: fix: sort communications keywords alphabetically in subagent-index.toon

### DIFF
--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -74,7 +74,7 @@ services/accessibility/,Unified web and email accessibility auditing - WCAG comp
 services/hosting/,Hosting providers - DNS and cloud servers and local dev,local-hosting|localhost|hostinger|hetzner|cloudflare|cloudflare-platform|cloudron|closte
 services/networking/,Networking - mesh VPN and secure device connectivity,tailscale|netbird
 services/email/,Email services - transactional email deliverability testing and autonomous mission communication,ses|email-agent|email-health-check|email-testing|email-delivery-test|email-design-test|email-delivery-testing|email-design-testing
-services/communications/,Communications - SMS voice Matrix bot multi-platform chat bridging encrypted messaging Bluetooth mesh and Web3 messaging,twilio|telfon|matrix-bot|matterbridge|simplex|signal|telegram|whatsapp|imessage|nostr|slack|discord|google-chat|msteams|nextcloud-talk|urbit|bitchat|xmtp|convos
+services/communications/,Communications - SMS voice Discord bot Matrix bot multi-platform chat bridging encrypted messaging Bluetooth mesh and Web3 messaging,bitchat|convos|discord|google-chat|imessage|matrix-bot|matterbridge|msteams|nextcloud-talk|nostr|signal|simplex|slack|telegram|telfon|twilio|urbit|whatsapp|xmtp
 services/crm/,CRM integration - contact management,fluentcrm
 services/analytics/,Website analytics - GA4 reporting,google-analytics
 services/monitoring/,Error monitoring and LLM observability,sentry|socket|langwatch


### PR DESCRIPTION
## Summary

- Sort `services/communications/` keywords alphabetically in `.agents/subagent-index.toon`
- Improve description to list bot types consistently (Discord bot, Matrix bot)

## Change

**Before:**
```
services/communications/,...,twilio|telfon|matrix-bot|matterbridge|simplex|signal|telegram|whatsapp|imessage|nostr|slack|discord|google-chat|msteams|nextcloud-talk|urbit|bitchat|xmtp|convos
```

**After:**
```
services/communications/,...,bitchat|convos|discord|google-chat|imessage|matrix-bot|matterbridge|msteams|nextcloud-talk|nostr|signal|simplex|slack|telegram|telfon|twilio|urbit|whatsapp|xmtp
```

## Source

Addresses unactioned review feedback from PR #2765 (gemini-code-assist, medium severity, line 75 of original diff).

Closes #3208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated communications service metadata and keyword tags to improve service discoverability and descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->