### PR TITLE
fix(fallback-chain-helper): is_model_available returns failure for unknown providers

### DIFF
--- a/.agents/scripts/fallback-chain-helper.sh
+++ b/.agents/scripts/fallback-chain-helper.sh
@@ -109,8 +109,10 @@ is_model_available() {
 		return 1
 	fi
 
-	# Unknown provider — assume available (AI will handle errors)
-	return 0
+	# Unknown provider — fail explicitly so resolve_chain skips to the next model
+	# rather than emitting a model string with no credential/health verification.
+	[[ "$quiet" != "true" ]] && print_warning "Unknown provider: $provider (no availability check available)" >&2
+	return 1
 }
 
 # Walk the tier's model list and return the first available model.


### PR DESCRIPTION
## Summary

- Fixes PR #2366 review feedback tracked in issue #3210
- `is_model_available()` previously returned `0` (success) for unknown providers, allowing `resolve_chain` to emit a model string with no credential or health verification
- Changed to return `1` with a warning, consistent with the existing behaviour for known providers with missing API keys

## Root Cause

Line 112-113 of `.agents/scripts/fallback-chain-helper.sh` had a comment "Unknown provider — assume available (AI will handle errors)" and returned `0`. This silently passes unknown provider models through the resolver, producing hard-to-debug runtime failures when the routing table is extended beyond `anthropic`, `openai`, and `google`.

## Change

```diff
-	# Unknown provider — assume available (AI will handle errors)
-	return 0
+	# Unknown provider — fail explicitly so resolve_chain skips to the next model
+	# rather than emitting a model string with no credential/health verification.
+	[[ "$quiet" != "true" ]] && print_warning "Unknown provider: $provider (no availability check available)" >&2
+	return 1
```

The `model-availability-helper.sh` delegation path (lines 80-83) is unaffected — if that helper is present, it handles the check. This fix only affects the lightweight fallback path.

## Verification

- `shellcheck .agents/scripts/fallback-chain-helper.sh` — no new violations (SC1091 info pre-existing)
- Behaviour: unknown providers now cause `resolve_chain` to skip to the next model in the list, or exhaust and return `1` if no known provider is available

Closes #3210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model provider validation now correctly identifies unknown providers as unavailable rather than treating them as valid, improving fallback resolution robustness.
  * Added warning notifications for unknown providers to provide better visibility into provider availability checks (suppressible via quiet mode).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->