### PR TITLE
t3204: fix Nostr and Matrix AI training policy accuracy in privacy-comparison.md

### DIFF
--- a/.agents/services/communications/privacy-comparison.md
+++ b/.agents/services/communications/privacy-comparison.md
@@ -97,9 +97,9 @@ tools:
 | **Signal** | None (non-profit) | None | N/A | None |
 | **Bitchat** | None | None | N/A | None |
 | **Urbit** | None (self-hosted) | None | N/A | None |
-| **Nostr** | None (protocol-level) | None | N/A | None |
+| **Nostr** | Relay-dependent (public notes) | None | N/A | Relay-dependent |
 | **XMTP** | None | None | N/A | None |
-| **Matrix** | None (Foundation) | None | N/A | None |
+| **Matrix** | Server-dependent | Optional (bots, bridges) | Server admin control | None |
 | **Nextcloud Talk** | None (self-hosted) | Optional local AI only | Full control | None |
 | **iMessage** | None (Apple policy) | Apple Intelligence (on-device) | Yes | None |
 | **Telegram** | Unclear | Translation, AI chatbot (Premium) | Limited | Ads (channels) |


### PR DESCRIPTION
## Summary

- Nostr AI training policy corrected from `None (protocol-level)` to `Relay-dependent (public notes)` — relay operators can process and monetize any public data they handle; the protocol itself has no policy, but relay operators set their own
- Matrix AI training policy corrected from `None (Foundation)` to `Server-dependent` — homeserver admins can access unencrypted messages and could use them for AI training; also adds `Optional (bots, bridges)` for AI features and `Server admin control` for opt-out, aligning with the more nuanced description already in `opsec.md`

Both changes apply the exact suggestions from the Gemini code review on PR #2776.

Closes #3204