### PR TITLE
t3192: fix remaining grep stderr suppression in sanity-check

### DIFF
--- a/.agents/scripts/supervisor-archived/sanity-check.sh
+++ b/.agents/scripts/supervisor-archived/sanity-check.sh
@@ -360,7 +360,7 @@ _build_sanity_state_snapshot() {
 	if [[ -f "$log_file" ]]; then
 		# Phase 3: check last ai-lifecycle summary line
 		local last_lifecycle
-		last_lifecycle=$(grep 'ai-lifecycle.*evaluated.*actioned' "$log_file" 2>/dev/null | tail -1 || echo "")
+		last_lifecycle=$(grep 'ai-lifecycle.*evaluated.*actioned' "$log_file" | tail -1 || echo "")
 		if [[ -n "$last_lifecycle" ]]; then
 			local eval_count action_count
 			eval_count=$(echo "$last_lifecycle" | grep -oE 'evaluated [0-9]+' | grep -oE '[0-9]+' || echo "0")
@@ -369,7 +369,7 @@ _build_sanity_state_snapshot() {
 			if [[ "$eval_count" == "0" ]]; then
 				# Count how many consecutive 0-evaluated runs
 				local zero_streak
-				zero_streak=$(grep -c 'ai-lifecycle.*evaluated 0' "$log_file" 2>/dev/null | tr -d '[:space:]' || echo "0")
+				zero_streak=$(grep -c 'ai-lifecycle.*evaluated 0' "$log_file" | tr -d '[:space:]' || echo "0")
 				snapshot+="WARNING: Phase 3 evaluated 0 tasks ($zero_streak consecutive zero-runs in log)\n"
 			fi
 		else
@@ -378,15 +378,15 @@ _build_sanity_state_snapshot() {
 
 		# Check for repeated "could not gather state" errors
 		local gather_failures
-		gather_failures=$(grep -c 'could not gather state' "$log_file" 2>/dev/null | tr -d '[:space:]' || echo "0")
+		gather_failures=$(grep -c 'could not gather state' "$log_file" | tr -d '[:space:]' || echo "0")
 		if [[ "$gather_failures" -gt 10 ]]; then
 			snapshot+="WARNING: $gather_failures 'could not gather state' errors in log — possible schema drift or query bug\n"
 		fi
 
 		# Phase 2b: check for stall/underutilisation entries
 		local stall_count underutil_count
-		stall_count=$(grep -c 'Dispatch stall detected' "$log_file" 2>/dev/null | tr -d '[:space:]' || echo "0")
-		underutil_count=$(grep -c 'Concurrency underutilised' "$log_file" 2>/dev/null | tr -d '[:space:]' || echo "0")
+		stall_count=$(grep -c 'Dispatch stall detected' "$log_file" | tr -d '[:space:]' || echo "0")
+		underutil_count=$(grep -c 'Concurrency underutilised' "$log_file" | tr -d '[:space:]' || echo "0")
 		if [[ "$stall_count" -gt 5 ]]; then
 			snapshot+="WARNING: $stall_count dispatch stalls in log\n"
 		fi


### PR DESCRIPTION
## Goal
Address issue #3192 by implementing the missed review feedback from PR #2870 in `.agents/scripts/supervisor-archived/sanity-check.sh`.

## Changes
- Removed the remaining `2>/dev/null` suppression from pipeline health `grep` checks in `_build_sanity_state_snapshot`
- Kept existing `[[ -f "$log_file" ]]` guard in place so file-not-found is already handled explicitly
- Preserved current behavior while making permission and I/O errors visible for debugging consistency

## Verification
- `shellcheck .agents/scripts/supervisor-archived/sanity-check.sh`
- `bash -n .agents/scripts/supervisor-archived/sanity-check.sh`

Closes #3192