### PR TITLE
fix: remove 2>/dev/null from check_permission_failure_pr (GH#3195)

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -978,7 +978,7 @@ check_permission_failure_pr() {
 
 	# Check for existing permission-failure comment (fail closed on API error)
 	local perm_comments
-	perm_comments=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body' 2>/dev/null)
+	perm_comments=$(gh pr view "$pr_number" --repo "$repo_slug" --json comments --jq '.comments[].body')
 	local perm_exit=$?
 
 	if [[ $perm_exit -ne 0 ]]; then
@@ -993,8 +993,7 @@ check_permission_failure_pr() {
 
 	# Safe to post — no existing comment and API call succeeded
 	gh pr comment "$pr_number" --repo "$repo_slug" \
-		--body "Permission check failed for this PR (HTTP ${http_status} from collaborator permission API). Unable to determine if @${pr_author} is a maintainer or external contributor. **A maintainer must review and merge this PR manually.** This is a fail-closed safety measure — the pulse will not auto-merge until the permission API succeeds." \
-		2>/dev/null || true
+		--body "Permission check failed for this PR (HTTP ${http_status} from collaborator permission API). Unable to determine if @${pr_author} is a maintainer or external contributor. **A maintainer must review and merge this PR manually.** This is a fail-closed safety measure — the pulse will not auto-merge until the permission API succeeds." || true
 
 	echo "[pulse-wrapper] check_permission_failure_pr: posted permission-failure comment on PR #$pr_number in $repo_slug (HTTP $http_status)" >>"$LOGFILE"
 	return 0


### PR DESCRIPTION
## Summary

- Removes `2>/dev/null` from `gh pr view` in `check_permission_failure_pr` (line 981) — exit code is already captured separately via `$?`, so stderr suppression only hides auth/network/API errors needed for debugging
- Removes `2>/dev/null` from `gh pr comment` in `check_permission_failure_pr` (line 997) — `|| true` is retained to keep the non-fatal behaviour

## Context

PR #2825 fixed the same pattern in `check_external_contributor_pr`. This PR extends that fix to the sibling function `check_permission_failure_pr`, which was missed.

The Gemini review on PR #2825 flagged a discrepancy between the PR title (which described the `pulse-wrapper.sh` changes) and the diff it saw (which showed `pulse.md` changes). Both changes were correct and present in the merged PR. This PR addresses the remaining `2>/dev/null` instance that was not covered by #2825.

Closes #3195