### PR TITLE
t3176: fix newline-injection vulnerability in shellcheck-wrapper arg filtering

### DIFF
--- a/.agents/scripts/shellcheck-wrapper.sh
+++ b/.agents/scripts/shellcheck-wrapper.sh
@@ -124,20 +124,25 @@ _find_real_shellcheck() {
 }
 
 # --- Filter arguments and extract target file ---
+# Populates the global _FILTERED_ARGS array directly to avoid newline-based
+# serialization, which is vulnerable to argument splitting when any argument
+# contains a newline character (e.g., an attacker could embed a newline in a
+# filename to inject a second argument and bypass --external-sources stripping).
+_FILTERED_ARGS=()
 _filter_args() {
-	local args=()
+	_FILTERED_ARGS=()
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--external-sources | -x)
 			# Strip this flag — it causes unbounded source chain expansion
 			;;
 		*)
-			args+=("$1")
+			_FILTERED_ARGS+=("$1")
 			;;
 		esac
 		shift
 	done
-	printf '%s\n' "${args[@]}"
+	return 0
 }
 
 # --- Respawn rate limiter ---
@@ -280,11 +285,10 @@ main() {
 	local real_shellcheck
 	real_shellcheck="$(_find_real_shellcheck)" || exit 1
 
-	# Read filtered args into array
-	local filtered_args=()
-	while IFS= read -r arg; do
-		filtered_args+=("$arg")
-	done < <(_filter_args "$@")
+	# Filter args into _FILTERED_ARGS global array (avoids newline-injection
+	# vulnerability from printf/read serialization round-trip)
+	_filter_args "$@"
+	local filtered_args=("${_FILTERED_ARGS[@]}")
 
 	# Check respawn rate limit — if we were recently killed, return empty
 	# results instead of running (prevents kill-respawn-grow cycle)


### PR DESCRIPTION
## Summary

Addresses quality-debt review feedback from PR #2918 (Gemini finding at `shellcheck-wrapper.sh:93`).

- Eliminates newline-injection vulnerability in `_filter_args` / `main()` argument serialization
- Replaces `printf '%s\n'` + `while IFS= read -r` round-trip with direct global array population
- The previous pattern was vulnerable: an attacker could embed a newline in a filename to inject a second argument and bypass `--external-sources` stripping, re-introducing the 11 GB RSS memory explosion risk

## Changes

**`.agents/scripts/shellcheck-wrapper.sh`**

- `_filter_args()`: now populates `_FILTERED_ARGS` global array directly instead of printing to stdout
- `main()`: calls `_filter_args "$@"` then reads `local filtered_args=("${_FILTERED_ARGS[@]}")` — no process substitution, no newline deserialization
- ShellCheck: zero violations

## Notes on Finding 2 (PATH parsing, line 39)

The second Gemini finding (`for dir in $PATH` word-splitting) was already addressed in a prior commit — the current code uses `while IFS= read -r -d ':' dir || [[ -n "$dir" ]]; do ... done <<<"$PATH"` which is safe. No change needed.

Closes #3176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shell script argument handling to improve reliability and prevent potential failures when processing commands with special characters or edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->