### PR TITLE
fix(issue3174): sanitize flag file reads in cmd_start and cmd_stop

### DIFF
--- a/.agents/scripts/pulse-session-helper.sh
+++ b/.agents/scripts/pulse-session-helper.sh
@@ -173,7 +173,7 @@ cmd_start() {
 
 	if is_session_active; then
 		local started_at
-		started_at=$(grep '^started_at=' "$SESSION_FLAG" | cut -d= -f2)
+		started_at=$(grep '^started_at=' "$SESSION_FLAG" | cut -d= -f2 | tr -cd '[:alnum:]T:Z.+-')
 		print_warning "Pulse session already active (started: ${started_at:-unknown})"
 		echo ""
 		echo "  To restart: aidevops pulse stop && aidevops pulse start"
@@ -251,7 +251,7 @@ cmd_stop() {
 
 	local started_at=""
 	if is_session_active; then
-		started_at=$(grep '^started_at=' "$SESSION_FLAG" | cut -d= -f2)
+		started_at=$(grep '^started_at=' "$SESSION_FLAG" | cut -d= -f2 | tr -cd '[:alnum:]T:Z.+-')
 	fi
 
 	# Create stop flag — this overrides all consent layers immediately


### PR DESCRIPTION
## Summary

- Applies `tr -cd '[:alnum:]T:Z.+-'` sanitization to `started_at` reads in `cmd_start()` and `cmd_stop()`, consistent with the existing pattern already in `cmd_status()`
- Prevents terminal escape injection via compromised session flag files (prompt-injection vector identified in PR #2943 review)
- Two-line change; ShellCheck passes clean

## Findings status

| Finding | Status |
|---------|--------|
| Finding 1 (fragile grep for supervisor_pulse) | Already fixed in PR #2943 — delegates to `config_enabled` |
| Finding 2 (unsanitized echo of flag file values) | `cmd_status` fixed in PR #2943; `cmd_start`/`cmd_stop` fixed in this PR |
| Finding 3 (2>/dev/null masking errors) | Already fixed in PR #2943 — only two legitimate uses remain |
| PR #4140 finding (WRAPPER_LOGFILE mismatch) | Fixed in commit ee29370 |

Closes #3174