### PR TITLE
t3167: align grep -c pattern in setup_terminal_title with || : convention

### DIFF
--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -867,7 +867,8 @@ setup_terminal_title() {
 	local tabby_config="$HOME/Library/Application Support/tabby/config.yaml"
 	if [[ -f "$tabby_config" ]]; then
 		local disabled_count
-		disabled_count=$(grep -c "disableDynamicTitle: true" "$tabby_config") || true
+		# grep -c exits 1 on no match; || : inside subshell prevents ERR trap noise
+		disabled_count=$(grep -c "disableDynamicTitle: true" "$tabby_config" || :)
 		if [[ "${disabled_count:-0}" -gt 0 ]]; then
 			echo "  Tabby: detected, dynamic titles disabled in $disabled_count profile(s) (will fix)"
 		else


### PR DESCRIPTION
## Summary

- Aligns `grep -c` error handling in `setup_terminal_title` (line 870) with the established `|| :` pattern used at lines 214-219
- Moves `|| :` inside the command substitution subshell so `grep -c` exit-1 (no matches) is suppressed at the source, consistent with the rest of the file
- `${disabled_count:-0}` already handles the empty-string case correctly

## Root Cause

PR #3003 review feedback (Gemini): the Tabby `disabled_count` assignment used `|| true` on the outer assignment statement rather than `|| :` inside the command substitution. Both prevent ERR trap propagation, but `|| :` inside the subshell is the established pattern in this file and more precisely scoped.

## Verification

- ShellCheck: zero violations
- No functional behaviour change — `${disabled_count:-0}` guard was already correct

Closes #3167