### PR TITLE
t3175: address session-count-helper quality-debt feedback

### DIFF
--- a/.agents/scripts/session-count-helper.sh
+++ b/.agents/scripts/session-count-helper.sh
@@ -146,7 +146,7 @@ count_interactive_sessions() {
 	cursor_pids=$(pgrep -f 'Cursor\.app' || true)
 	if [[ -n "$cursor_pids" ]]; then
 		local cursor_count
-		cursor_count=$(echo "$cursor_pids" | wc -l | tr -d ' ')
+		cursor_count=$(echo "$cursor_pids" | wc -l)
 		count=$((count + cursor_count))
 	fi
 
@@ -155,7 +155,7 @@ count_interactive_sessions() {
 	windsurf_pids=$(pgrep -f 'Windsurf' || true)
 	if [[ -n "$windsurf_pids" ]]; then
 		local windsurf_count
-		windsurf_count=$(echo "$windsurf_pids" | wc -l | tr -d ' ')
+		windsurf_count=$(echo "$windsurf_pids" | wc -l)
 		count=$((count + windsurf_count))
 	fi
 
@@ -164,7 +164,7 @@ count_interactive_sessions() {
 	aider_pids=$(pgrep -f 'aider' || true)
 	if [[ -n "$aider_pids" ]]; then
 		local aider_count
-		aider_count=$(echo "$aider_pids" | wc -l | tr -d ' ')
+		aider_count=$(echo "$aider_pids" | wc -l)
 		count=$((count + aider_count))
 	fi
 


### PR DESCRIPTION
## Summary
- remove redundant `tr -d ' '` pipes from three PID count assignments in `count_interactive_sessions`
- rely on arithmetic expansion (`$((...))`) to safely consume `wc -l` output with leading whitespace
- keep behavior unchanged while aligning with PR #2945 review guidance

Closes #3175