### PR TITLE
t3117: fix mcporter security doc path in MCP setup warning

### DIFF
--- a/.agents/scripts/setup-mcp-integrations.sh
+++ b/.agents/scripts/setup-mcp-integrations.sh
@@ -119,7 +119,7 @@ print_mcp_security_warning() {
 	print_info "  2. Scan dependencies: npx @socketsecurity/cli npm info <package>"
 	print_info "  3. Use scoped API keys with minimal permissions"
 	print_info "  4. Pin versions -- avoid @latest in production configs"
-	print_info "  See: ~/.aidevops/agents/tools/mcp-toolkit/mcporter.md 'Security Considerations'"
+	print_info "  See: ~/.aidevops/.agents/tools/mcp-toolkit/mcporter.md 'Security Considerations'"
 	echo ""
 	return 0
 }


### PR DESCRIPTION
## Summary
- Fixes the security warning link in `.agents/scripts/setup-mcp-integrations.sh` to use the correct `~/.aidevops/.agents/...` path.
- Addresses the unactioned medium-severity review comment from PR #3090 tracked by issue #3117.
- Validated with `shellcheck .agents/scripts/setup-mcp-integrations.sh` and `aidevops_quality_check`.

Closes #3117