### PR TITLE
t3178: address timeout fallback kill stderr suppression

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -223,9 +223,11 @@ timeout_sec() {
 		local half_secs_remaining=$((secs * 2))
 		while kill -0 "$cmd_pid" 2>/dev/null; do
 			if ((half_secs_remaining <= 0)); then
-				kill -TERM "$cmd_pid" 2>/dev/null # SIGTERM (15) — graceful shutdown
+				kill -TERM "$cmd_pid" # SIGTERM (15) — graceful shutdown
 				sleep 0.2
-				kill -KILL "$cmd_pid" 2>/dev/null || true # SIGKILL (9) — hard kill
+				if kill -0 "$cmd_pid" 2>/dev/null; then
+					kill -KILL "$cmd_pid" || true # SIGKILL (9) — hard kill
+				fi
 				wait "$cmd_pid" 2>/dev/null || true
 				return 124 # Normalise to GNU timeout convention
 			fi


### PR DESCRIPTION
## Summary
- removes blanket `2>/dev/null` suppression from timeout fallback kill calls so real termination failures remain visible
- keeps race-safe behavior by checking process liveness before issuing SIGKILL
- preserves existing timeout semantics (`124` on timeout, wrapped command exit code otherwise)

## Verification
- `shellcheck .agents/scripts/shared-constants.sh`
- `bash -lc 'source .agents/scripts/shared-constants.sh; timeout_sec 1 sleep 2 >/dev/null 2>&1; rc=$?; [[ $rc -eq 124 ]]'`
- `bash -lc 'source .agents/scripts/shared-constants.sh; timeout_sec 2 bash -lc "exit 7" >/dev/null 2>&1; rc=$?; [[ $rc -eq 7 ]]'`

Closes #3178