### PR TITLE
t3120: remove jq stderr suppression in bench dataset parsing

### DIFF
--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -2754,7 +2754,7 @@ cmd_bench() {
 			[[ -z "$line" ]] && continue
 			local p
 			# Support both dataset convention (.input) and legacy (.prompt)
-			p=$(echo "$line" | jq -r '(.input // .prompt) // empty' 2>/dev/null || echo "")
+			p=$(printf '%s' "$line" | jq -r '(.input // .prompt) // empty' || true)
 			if [[ -n "$p" ]]; then
 				prompts+=("$p")
 			fi


### PR DESCRIPTION
## Summary
- Remove blanket `2>/dev/null` suppression from JSONL prompt extraction in `cmd_bench` so malformed dataset lines surface actionable `jq` errors
- Switch from `echo` to `printf '%s'` when piping dataset lines to `jq` to avoid shell interpretation edge cases
- Keep non-fatal parsing behavior by using `|| true`, preserving iteration across lines under `set -e`

## Verification
- `shellcheck .agents/scripts/compare-models-helper.sh`
- `aidevops_quality_check --file .agents/scripts/compare-models-helper.sh` (reports existing baseline issues unrelated to this one-line fix)

Closes #3120