### PR TITLE
fix(issue3158): add regression test for non-actionable Gemini approval review

### DIFF
--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -1335,6 +1335,23 @@ test_scan_single_pr_positive_body_with_inline_comments_not_summary_only() {
 	return 0
 }
 
+test_scan_single_pr_filters_issue3158_review_body() {
+	# Regression: PR #3060 Gemini review — "The changes are correct and well-justified."
+	# with summary praise (effectively, improves, correct, well-justified) must be filtered
+	# as non-actionable. The scanner incorrectly created issue #3158 before the
+	# summary_praise_only filter was confirmed to handle this body.
+	local result
+	result=$(_test_approval_filter '## Code Review
+
+This pull request effectively addresses ShellCheck SC2034 warnings for unused variables across several scripts. The changes involve removing genuinely unused variables and adding appropriate `shellcheck disable` directives for variables that are used indirectly by sourced scripts. These modifications improve code cleanliness and maintainability by eliminating dead code and silencing irrelevant linter warnings. The changes are correct and well-justified.')
+	if [[ "$result" == "skip" ]]; then
+		print_result "issue #3158 PR #3060 Gemini approval review is filtered as non-actionable" 0
+	else
+		print_result "issue #3158 PR #3060 Gemini approval review is filtered as non-actionable" 1 "expected skip, got ${result}"
+	fi
+	return 0
+}
+
 main() {
 	source "$HELPER"
 
@@ -1375,6 +1392,7 @@ main() {
 	test_include_positive_keeps_no_suggestions_review
 	test_scan_single_pr_include_positive_returns_positive_review
 	test_scan_single_pr_default_filters_positive_review
+	test_scan_single_pr_filters_issue3158_review_body
 	test_scan_single_pr_filters_issue3188_review_body
 	test_scan_single_pr_filters_issue3363_review_body
 	test_scan_single_pr_filters_issue3303_review_body


### PR DESCRIPTION
## Summary

- Add regression test for PR #3060 Gemini review body in `test-quality-feedback-main-verification.sh`
- The review ("The changes are correct and well-justified.") was a false-positive quality-debt finding created before the `summary_praise_only` filter was confirmed to handle this body
- The filter already handles this body correctly (`summary_praise_only=true` via "effectively" and "improves"); this test prevents reintroduction

## Testing

```bash
bash .agents/scripts/tests/test-quality-feedback-main-verification.sh
# Results: 38/38 passed, 0 failed
```

Resolves #3158.