### PR TITLE
t3173: filter praise-only Gemini review-body findings

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -1024,6 +1024,7 @@ _scan_single_pr() {
 
 		($body | test(
 			"\\bsuccessfully addresses?\\b|\\beffectively\\b|\\bimproves?\\b|\\benhances?\\b|" +
+			"\\bcorrectly (removes?|implements?|fixes?|handles?|addresses?)\\b|\\bvaluable change\\b|" +
 			"\\bconsistent\\b|\\brobust(ness)?\\b|\\buser experience\\b|" +
 			"\\breduces? (external )?requirements?\\b|\\bwell-implemented\\b"; "i")) as $summary_praise_only |
 

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -1043,6 +1043,75 @@ JSON
 	return 0
 }
 
+test_scan_single_pr_filters_issue3173_positive_review_body() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+				repos/*/pulls/*/comments)
+					echo "[]"
+					return 0
+					;;
+				repos/*/pulls/*/reviews)
+					printf '%s' '[{"id":1,"user":{"login":"gemini-code-assist"},"state":"COMMENTED","body":"## Code Review\n\nThis pull request correctly removes the suppression of stderr from the version check command in `tool-version-check.sh`. This is a valuable change that improves debuggability by ensuring that error messages from underlying tool commands are no longer hidden. The implementation is correct and aligns with the project\u0027s general rules against blanket error suppression.","submitted_at":"2024-01-01T00:00:00Z","html_url":"https://github.com/example/repo/pull/1#pullrequestreview-1"}]'
+					return 0
+					;;
+				repos/*/git/trees/*)
+					echo '{"tree":[]}'
+					return 0
+					;;
+				repos/*)
+					echo "main"
+					return 0
+					;;
+				esac
+				shift
+			done
+			echo "[]"
+			return 0
+			;;
+		label | pr) return 0 ;;
+		esac
+		echo "[]"
+		return 0
+	}
+
+	local findings
+	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "issue #3173 review body is filtered as non-actionable" 0
+	else
+		print_result "issue #3173 review body is filtered as non-actionable" 1 "expected 0 findings, got ${count}"
+	fi
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			_mock_gh_api "$@"
+			return $?
+			;;
+		label) return 0 ;;
+		issue)
+			_mock_gh_issue "$@"
+			return $?
+			;;
+		esac
+		echo "unexpected gh call: ${command}" >&2
+		return 1
+	}
+	return 0
+}
+
 # Regression test for GH#4814 / incident: issue #3343 filed for PR #2166.
 # The exact Gemini review body that triggered the false-positive issue creation.
 # Review state: COMMENTED, no inline comments, bot reviewer.
@@ -1396,6 +1465,7 @@ main() {
 	test_scan_single_pr_filters_issue3188_review_body
 	test_scan_single_pr_filters_issue3363_review_body
 	test_scan_single_pr_filters_issue3303_review_body
+	test_scan_single_pr_filters_issue3173_positive_review_body
 	test_scan_single_pr_filters_issue3325_review_body
 	test_scan_single_pr_filters_pr2647_positive_review_body
 


### PR DESCRIPTION
## Summary
- expand the positive-summary detection in `quality-feedback-helper.sh` to treat Gemini phrasing like "correctly removes" and "valuable change" as praise-only sentiment when no actionable critique exists
- add a dedicated regression test that reproduces the PR #2959 review-body wording from issue #3173 and verifies `_scan_single_pr` returns zero findings by default
- keep existing behavior for actionable and `--include-positive` flows while preventing future false-positive quality-debt issues for this pattern

## Validation
- `shellcheck .agents/scripts/quality-feedback-helper.sh`
- `shellcheck .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `bash .agents/scripts/tests/test-quality-feedback-main-verification.sh`
- `bash -lc 'source .agents/scripts/quality-feedback-helper.sh && _scan_single_pr "marcusquinn/aidevops" "2959" "medium" "false" | jq "length"'` (returns `0`)

Closes #3173