### PR TITLE
fix(t4874): prevent false-positive issues when suggestion already applied before merge

### DIFF
--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -112,8 +112,10 @@ _extract_verification_snippet() {
 			candidate=$(_trim_whitespace "$line")
 			[[ -z "$candidate" ]] && continue
 
-			if [[ "$fence_type" == "diff" || "$fence_type" == "suggestion" ]]; then
-				# diff/suggestion fences: skip all diff markers and added/removed lines
+			if [[ "$fence_type" == "diff" ]]; then
+				# diff fences: skip unified-diff markers and added/removed lines.
+				# Lines starting with +/- are "add this" / "remove this" markers —
+				# they do not represent the post-fix file content.
 				[[ "$candidate" == "@@"* ]] && continue
 				[[ "$candidate" == "diff --git"* ]] && continue
 				[[ "$candidate" == "index "* ]] && continue
@@ -121,6 +123,18 @@ _extract_verification_snippet() {
 				[[ "$candidate" == "---"* ]] && continue
 				[[ "$candidate" == +* ]] && continue
 				[[ "$candidate" == -* ]] && continue
+			elif [[ "$fence_type" == "suggestion" ]]; then
+				# suggestion fences: the entire content is the proposed replacement
+				# text, verbatim.  Lines starting with '-' are literal content (e.g.
+				# a markdown list item "- **Enhances:** t1393"), NOT diff removal
+				# markers.  Do NOT skip them — they are the snippet we want to check
+				# against HEAD to determine whether the suggestion was already applied.
+				# Only skip unified-diff header lines that cannot appear in real code.
+				[[ "$candidate" == "@@"* ]] && continue
+				[[ "$candidate" == "diff --git"* ]] && continue
+				[[ "$candidate" == "index "* ]] && continue
+				[[ "$candidate" == "+++"* ]] && continue
+				[[ "$candidate" == "---"* ]] && continue
 			else
 				# non-diff fences: lines starting with +/- are diff markers too —
 				# skip them rather than stripping the prefix and using the content
@@ -169,6 +183,22 @@ _extract_verification_snippet() {
 	return 1
 }
 
+# _body_has_suggestion_fence: returns 0 (true) if body_full contains a
+# ```suggestion fence, 1 (false) otherwise.
+#
+# Used by _finding_still_exists_on_main to determine snippet semantics:
+# - suggestion fence → snippet is the proposed FIX text.  Finding is resolved
+#   when the snippet IS present in HEAD (fix already applied).
+# - all other sources → snippet is the PROBLEM text.  Finding is resolved
+#   when the snippet is ABSENT from HEAD (problem was fixed).
+_body_has_suggestion_fence() {
+	local body_full="$1"
+	if printf '%s\n' "$body_full" | grep -qE "^\`\`\`suggestion"; then
+		return 0
+	fi
+	return 1
+}
+
 _finding_still_exists_on_main() {
 	local repo_slug="$1"
 	local file_path="$2"
@@ -214,6 +244,16 @@ _finding_still_exists_on_main() {
 		return 0
 	fi
 
+	# Determine snippet semantics (GH#4874):
+	# - suggestion fence → snippet is the proposed FIX text.
+	#   Finding is resolved when the fix IS present in HEAD (suggestion applied).
+	# - all other sources → snippet is the PROBLEM text.
+	#   Finding is resolved when the problem is ABSENT from HEAD (problem fixed).
+	local is_suggestion_snippet="false"
+	if _body_has_suggestion_fence "$body_full"; then
+		is_suggestion_snippet="true"
+	fi
+
 	local found_in_window="false"
 	if [[ "$line_num" =~ ^[0-9]+$ && "$line_num" -gt 0 ]]; then
 		local total_lines
@@ -237,19 +277,34 @@ _finding_still_exists_on_main() {
 		fi
 	fi
 
+	local snippet_found="false"
 	if [[ "$found_in_window" == "true" ]]; then
-		echo '{"result":true,"status":"verified"}'
-		return 0
+		snippet_found="true"
+	elif printf '%s' "$file_content" | grep -Fq -e "$snippet"; then
+		snippet_found="true"
 	fi
 
-	if printf '%s' "$file_content" | grep -Fq "$snippet"; then
+	if [[ "$is_suggestion_snippet" == "true" ]]; then
+		# Suggestion snippet: found in HEAD → fix already applied → resolved → skip
+		if [[ "$snippet_found" == "true" ]]; then
+			echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - suggestion already applied on ${default_branch}" >&2
+			echo '{"result":false,"status":"resolved"}'
+			return 1
+		fi
+		# Suggestion not found in HEAD → fix not yet applied → still actionable → keep
 		echo '{"result":true,"status":"verified"}'
 		return 0
+	else
+		# Problem snippet: found in HEAD → problem still exists → keep
+		if [[ "$snippet_found" == "true" ]]; then
+			echo '{"result":true,"status":"verified"}'
+			return 0
+		fi
+		# Problem snippet not found → problem was fixed → resolved → skip
+		echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - snippet not found on ${default_branch}" >&2
+		echo '{"result":false,"status":"resolved"}'
+		return 1
 	fi
-
-	echo "[scan] Skipping resolved finding: ${file_path}:${line_num} - snippet not found on ${default_branch}" >&2
-	echo '{"result":false,"status":"resolved"}'
-	return 1
 }
 
 # Show status of all checks

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -282,8 +282,12 @@ test_handles_suggestion_fence_and_comments() {
 	# The finding body contains a ```suggestion fence with comment lines.
 	# The snippet extractor must skip comment-only lines (// and #) and extract
 	# the first substantive code line ("this is stable suggestion code").
-	# The file on main (GH_RAW_CONTENT) contains that line, so the finding is
-	# verified and an issue is created.
+	#
+	# Under GH#4874 semantics: suggestion fences contain the proposed FIX text.
+	# If the suggestion text IS present in the HEAD file, the fix was already
+	# applied before merge → finding is resolved → no issue created.
+	# This test verifies that the snippet extractor correctly skips comment lines
+	# AND that the resolved-suggestion logic fires correctly.
 	reset_mock_state
 	GH_RAW_CONTENT=$'#!/usr/bin/env bash\nthis is stable suggestion code\n'
 
@@ -302,10 +306,11 @@ test_handles_suggestion_fence_and_comments() {
 	rm -f "$GH_CREATE_LOG"
 	rm -f "$GH_API_LOG"
 
-	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
-		print_result "suggestion fences skip comments and keep code" 0
+	# Suggestion text already in file → fix applied before merge → no issue (GH#4874)
+	if [[ "$created" == "0" && "$created_count" -eq 0 ]]; then
+		print_result "suggestion fences: skip when fix already applied (GH#4874)" 0
 	else
-		print_result "suggestion fences skip comments and keep code" 1 "created=${created}, issues=${created_count}"
+		print_result "suggestion fences: skip when fix already applied (GH#4874)" 1 "created=${created}, issues=${created_count} (expected 0 — suggestion already in file)"
 	fi
 	return 0
 }
@@ -426,6 +431,86 @@ test_plain_fence_skips_diff_marker_lines() {
 		print_result "plain fence skips +/- lines instead of stripping prefix" 0
 	else
 		print_result "plain fence skips +/- lines instead of stripping prefix" 1 "created=${created}, issues=${created_count}"
+	fi
+	return 0
+}
+
+test_suggestion_fence_with_markdown_list_item_already_applied() {
+	# Regression test for GH#4874 / false-positive issue #3183.
+	#
+	# Scenario: Gemini flagged "- **Blocks:** t1393" in PR #2871 and suggested
+	# replacing it with "- **Enhances:** t1393 (...)".  The author applied the
+	# suggestion before merging.  The merge commit already contains the fix.
+	#
+	# The comment body contains a ```suggestion fence whose content is:
+	#   - **Enhances:** t1393 (bench --judge can delegate to these evaluators)
+	#
+	# The line starts with '-', which is a markdown list item prefix, NOT a
+	# unified-diff removal marker.  The old code treated suggestion fences the
+	# same as diff fences and skipped all '-' lines, so no snippet was extracted,
+	# the finding was marked "unverifiable", and an issue was created — a false
+	# positive.
+	#
+	# The fix: suggestion fences do NOT skip '-' lines.  The snippet
+	# "- **Enhances:** t1393 ..." is extracted and found in the HEAD file, so
+	# the finding is correctly marked "resolved" and no issue is created.
+	reset_mock_state
+	# File at HEAD already contains the suggested replacement text (fix applied)
+	GH_RAW_CONTENT=$'# t1394 brief\n\n- **Enhances:** t1393 (bench --judge can delegate to these evaluators)\n'
+
+	local findings
+	# Mirrors the actual Gemini comment from PR #2871 (truncated for test clarity)
+	findings='[{"file":"todo/tasks/t1394-brief.md","line":139,"body_full":"![medium](https://www.gstatic.com/codereviewagent/medium-priority.svg)\n\nConsider rephrasing to clarify the relationship.\n\n```suggestion\n- **Enhances:** t1393 (bench --judge can delegate to these evaluators)\n```","reviewer":"gemini","reviewer_login":"gemini-code-assist[bot]","severity":"medium","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "2871" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
+
+	# Suggestion was already applied — no issue should be created
+	if [[ "$created" == "0" && "$created_count" -eq 0 ]]; then
+		print_result "suggestion fence: skip finding when markdown list item already applied (GH#4874)" 0
+	else
+		print_result "suggestion fence: skip finding when markdown list item already applied (GH#4874)" 1 "created=${created}, issues=${created_count} (expected 0 — fix was already applied before merge)"
+	fi
+	return 0
+}
+
+test_suggestion_fence_with_markdown_list_item_not_yet_applied() {
+	# Counterpart to the GH#4874 regression test: when the suggestion has NOT
+	# been applied (the old text is still in the file), the finding must be kept
+	# and an issue created.
+	reset_mock_state
+	# File at HEAD still contains the OLD text (suggestion not applied)
+	GH_RAW_CONTENT=$'# t1394 brief\n\n- **Blocks:** t1393 (some description)\n'
+
+	local findings
+	findings='[{"file":"todo/tasks/t1394-brief.md","line":139,"body_full":"Consider rephrasing.\n\n```suggestion\n- **Enhances:** t1393 (bench --judge can delegate to these evaluators)\n```","reviewer":"gemini","reviewer_login":"gemini-code-assist[bot]","severity":"medium","url":"https://example.test/comment"}]'
+
+	local out_file
+	out_file=$(mktemp)
+	local created
+	_create_quality_debt_issues "owner/repo" "2871" "$findings" >"$out_file"
+	created=$(<"$out_file")
+	rm -f "$out_file"
+
+	local created_count
+	created_count=$(wc -l <"$GH_CREATE_LOG" | tr -d ' ')
+	rm -f "$GH_CREATE_LOG"
+	rm -f "$GH_API_LOG"
+
+	# Suggestion not applied — issue should be created
+	if [[ "$created" == "1" && "$created_count" -eq 1 ]]; then
+		print_result "suggestion fence: create issue when markdown list item not yet applied (GH#4874)" 0
+	else
+		print_result "suggestion fence: create issue when markdown list item not yet applied (GH#4874)" 1 "created=${created}, issues=${created_count} (expected 1 — fix not yet applied)"
 	fi
 	return 0
 }
@@ -946,6 +1031,11 @@ main() {
 	test_transient_api_error_keeps_finding_as_unverifiable
 	test_uses_default_branch_ref_for_contents_lookup
 	test_plain_fence_skips_diff_marker_lines
+
+	echo ""
+	echo "Running suggestion-fence false-positive regression tests (GH#4874)"
+	test_suggestion_fence_with_markdown_list_item_already_applied
+	test_suggestion_fence_with_markdown_list_item_not_yet_applied
 
 	echo ""
 	echo "Running approval/sentiment detection tests (GH#4604)"


### PR DESCRIPTION
## Summary

- `scan-merged` was creating quality-debt issues for review comments whose `suggestion` had already been applied by the author before merging (incident: false-positive issue #3183 from PR #2871, merge commit `d8d438a5`).
- Two interacting bugs in `_extract_verification_snippet` and `_finding_still_exists_on_main` caused this.
- Fix corrects both bugs and adds 2 regression tests + updates 1 existing test.

## Root Cause

**Bug 1 — snippet extraction:** `_extract_verification_snippet` treated `suggestion` fences the same as `diff` fences, skipping all lines starting with `-`. Markdown list items like `- **Enhances:** t1393` start with `-` and were silently dropped, leaving no extractable snippet → finding marked `unverifiable` → issue created.

**Bug 2 — inverted semantics:** Even when a snippet was extracted from a suggestion fence, the logic was inverted. The code treated "snippet found in file" as "problem still exists → keep". But for suggestion fences, the snippet IS the proposed fix text — finding it in HEAD means the fix was already applied → resolved → skip.

## Fix

- Split `diff` vs `suggestion` fence handling in `_extract_verification_snippet`: `diff` fences skip `+`/`-` lines (unified-diff markers); `suggestion` fences do NOT skip `-` lines (they are literal replacement content).
- Add `_body_has_suggestion_fence()` helper to detect suggestion fence presence.
- Invert snippet semantics in `_finding_still_exists_on_main` for suggestion fences: snippet found in HEAD → fix applied → resolved → skip; snippet absent → fix not yet applied → keep → create issue.
- Fix `grep -Fq "$snippet"` → `grep -Fq -e "$snippet"` so patterns starting with `-` are not misinterpreted as grep options (macOS BSD grep does not support `--`).

## Tests

31/31 passing, shellcheck clean.

New tests:
- `suggestion fence: skip finding when markdown list item already applied (GH#4874)`
- `suggestion fence: create issue when markdown list item not yet applied (GH#4874)`

Updated:
- `test_handles_suggestion_fence_and_comments` — updated expectation to reflect correct semantics (suggestion text in file → fix applied → no issue)

Closes #4874

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved suggestion verification logic to accurately differentiate between problem snippets and suggestion-based fixes, ensuring correct resolution status tracking.
  * Enhanced handling of markdown formatting within suggestions to prevent false positives when fixes are already applied.

* **Tests**
  * Added regression tests for suggestion handling with markdown list items to ensure proper detection of applied vs. pending fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->