### PR TITLE
t3110: refresh checkout SHA in opencode workflow template

### DIFF
--- a/configs/mcp-templates/opencode-github-workflow.yml
+++ b/configs/mcp-templates/opencode-github-workflow.yml
@@ -48,7 +48,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@a440291f7473037a3a31e8432d77a9785f9f838b # v4.1.7
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary
- Update `actions/checkout` in `configs/mcp-templates/opencode-github-workflow.yml` to the newer v4.1.7 commit SHA from the Gemini review finding.
- Keep the action immutably pinned while aligning the inline version comment with the actual pinned revision.

## Verification
- `aidevops_quality_check file=configs/mcp-templates/opencode-github-workflow.yml` (secrets scan: no issues)
- `python3 -c \"import yaml; yaml.safe_load(open('configs/mcp-templates/opencode-github-workflow.yml', encoding='utf-8')); print('YAML syntax OK')\"`
- `.agents/scripts/linters-local.sh` (fails on pre-existing repository-wide quality debt unrelated to this change)

Closes #3110