### PR TITLE
feat: add ripgrep (rg) to required dependencies in setup

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -411,11 +411,26 @@ check_requirements() {
 	fi
 
 	local missing_deps=()
+	local missing_packages=()
 
 	# Check for required commands
-	command -v jq >/dev/null 2>&1 || missing_deps+=("jq")
-	command -v curl >/dev/null 2>&1 || missing_deps+=("curl")
-	command -v ssh >/dev/null 2>&1 || missing_deps+=("ssh")
+	# Format: command-name package-name (same when identical)
+	if ! command -v jq >/dev/null 2>&1; then
+		missing_deps+=("jq")
+		missing_packages+=("jq")
+	fi
+	if ! command -v curl >/dev/null 2>&1; then
+		missing_deps+=("curl")
+		missing_packages+=("curl")
+	fi
+	if ! command -v ssh >/dev/null 2>&1; then
+		missing_deps+=("ssh")
+		missing_packages+=("ssh")
+	fi
+	if ! command -v rg >/dev/null 2>&1; then
+		missing_deps+=("rg")
+		missing_packages+=("ripgrep")
+	fi
 
 	if [[ ${#missing_deps[@]} -gt 0 ]]; then
 		print_warning "Missing required dependencies: ${missing_deps[*]}"
@@ -427,12 +442,12 @@ check_requirements() {
 			print_error "Could not detect package manager"
 			echo ""
 			echo "Please install manually:"
-			echo "  macOS: brew install ${missing_deps[*]}"
-			echo "  Ubuntu/Debian: sudo apt-get install ${missing_deps[*]}"
-			echo "  Fedora: sudo dnf install ${missing_deps[*]}"
-			echo "  CentOS/RHEL: sudo yum install ${missing_deps[*]}"
-			echo "  Arch: sudo pacman -S ${missing_deps[*]}"
-			echo "  Alpine: sudo apk add ${missing_deps[*]}"
+			echo "  macOS: brew install ${missing_packages[*]}"
+			echo "  Ubuntu/Debian: sudo apt-get install ${missing_packages[*]}"
+			echo "  Fedora: sudo dnf install ${missing_packages[*]}"
+			echo "  CentOS/RHEL: sudo yum install ${missing_packages[*]}"
+			echo "  Arch: sudo pacman -S ${missing_packages[*]}"
+			echo "  Alpine: sudo apk add ${missing_packages[*]}"
 			exit 1
 		fi
 
@@ -446,8 +461,8 @@ check_requirements() {
 		read -r -p "Install missing dependencies using $pkg_manager? [Y/n]: " install_deps
 
 		if [[ "$install_deps" =~ ^[Yy]?$ ]]; then
-			print_info "Installing ${missing_deps[*]}..."
-			if install_packages "$pkg_manager" "${missing_deps[@]}"; then
+			print_info "Installing ${missing_packages[*]}..."
+			if install_packages "$pkg_manager" "${missing_packages[@]}"; then
 				print_success "Dependencies installed successfully"
 			else
 				print_error "Failed to install dependencies"


### PR DESCRIPTION
## Summary

- Adds `ripgrep` (`rg` command) to the required dependencies installed by `check_requirements()` in `setup-modules/core.sh`, alongside `jq`, `curl`, and `ssh`
- Introduces a `missing_packages` array to handle the command-to-package name mapping (`rg` binary -> `ripgrep` package name)
- The package name `ripgrep` is the same across all supported platforms: Homebrew, apt (Ubuntu/Debian), dnf (Fedora), yum (CentOS/RHEL), pacman (Arch), and apk (Alpine)

## Why

`rg` is used extensively by the framework and AI agents for fast content search (file discovery rules in `prompts/build.txt`, grep operations, codebase navigation). Previously it was only offered as an optional tool in the separate "Setup file discovery tools" step (`setup_file_discovery_tools`), meaning users could skip it. Making it a required dependency ensures it's always available when the framework needs it.

## Changes

- `setup-modules/core.sh`: `check_requirements()` now checks for `rg` and installs `ripgrep` if missing
- Refactored the dependency tracking to use separate `missing_deps` (command names for display) and `missing_packages` (package names for installation) arrays, since `rg` != `ripgrep`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package installation process to reference actual package names instead of command names, improving accuracy of missing package notifications and ensuring proper dependency resolution during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->