### PR TITLE
fix: bash 3.2 compatibility — unblock pulse dispatch and add automated checker

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -347,6 +347,37 @@ Git is the primary audit trail for all work. Every change should be discoverable
 - Explicit returns in all functions
 - Conventional commits: feat:, fix:, docs:, refactor:, chore:, perf:
 
+# Bash 3.2 Compatibility (macOS default shell)
+# macOS ships bash 3.2.57. All shell scripts MUST work on this version.
+# Bash 4.0+ features silently crash or produce wrong results on 3.2 — no
+# error message, just broken behaviour. This has caused repeated production
+# failures (pulse dispatch, worktree cleanup, dataset helpers, routine scheduler).
+#
+# Forbidden features (bash 4.0+):
+- `declare -A` / `local -A` (associative arrays) — use parallel indexed arrays or grep-based lookup
+- `mapfile` / `readarray` — use `while IFS= read -r line; do arr+=("$line"); done < <(cmd)`
+- `${var,,}` / `${var^^}` (case conversion) — use `tr '[:upper:]' '[:lower:]'` or `tr '[:lower:]' '[:upper:]'`
+- `${var:offset:length}` negative offsets — use `${var: -N}` (space before minus) or string manipulation
+- `|&` (pipe stderr) — use `2>&1 |`
+- `&>>` (append both) — use `>> file 2>&1`
+- `declare -n` / `local -n` (namerefs) — use eval or indirect expansion `${!var}`
+- `[[ $var =~ regex ]]` with stored regex in variables works differently — test on 3.2
+#
+# Subshell and command substitution traps:
+- `$()` captures ALL stdout — never mix `tee` or command output with exit code capture in `$()`. Write exit codes to a temp file instead: `printf '%s' "$?" > "$exit_code_file"`
+- `local -a arr=()` inside `$()` subshells — `local` in a subshell not inside a function is undefined in 3.2
+- `PIPESTATUS` — available in 3.2 but only for the immediately preceding pipeline in the current shell. Inside `$()` it reflects the subshell's pipeline, not the parent's. Capture it immediately: `cmd1 | cmd2; local ps=("${PIPESTATUS[@]}")`
+#
+# Array passing across process boundaries:
+- Arrays cannot cross subshell, `$()`, or pipe boundaries as arrays. They flatten to strings.
+- To pass an array to a subprocess: pass elements as separate positional arguments (`"${arr[@]}"`), never as a single escaped string (`printf -v str '%q ' "${arr[@]}"` then `"$str"` — the subprocess receives one argument, not many)
+- To receive array results from a subprocess: write to a temp file (one element per line), then read back with `while read` loop
+#
+# Safe patterns:
+- Test scripts with `/bin/bash` (not `/opt/homebrew/bin/bash`) to catch 4.0+ usage
+- When in doubt, check: `bash --version` on macOS gives 3.2.57
+- ShellCheck does NOT catch most bash version incompatibilities — manual review required
+
 # Write-Time Quality Enforcement
 # Inspired by Plankton (github.com/alexfazio/plankton) — adapted for runtime-agnostic use.
 # Plankton uses Claude Code PostToolUse hooks to lint on every edit. OpenCode does not yet

--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -54,7 +54,8 @@ detect_app() {
 		# return capitalized names on some platforms, e.g. "Cursor" not "cursor")
 		local parent parent_lower
 		parent=$(ps -o comm= -p "${PPID:-0}" 2>/dev/null || echo "")
-		parent_lower="${parent,,}"
+		# Bash 3.2 compat: no ${var,,} — use tr for case conversion
+		parent_lower=$(printf '%s' "$parent" | tr '[:upper:]' '[:lower:]')
 		case "$parent_lower" in
 		*opencode*)
 			app_name="OpenCode"

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -779,27 +779,37 @@ cmd_run() {
 
 		local output_file
 		output_file=$(mktemp)
+		local exit_code_file
+		exit_code_file=$(mktemp)
 		local exit_code=0
 		# Run in subshell to avoid fragile set +e/set -e toggling (GH#4225).
 		# Subshell localises errexit so main shell state is never modified.
-		exit_code=$(
+		# Exit code is written to a temp file — NOT captured via $() — because
+		# tee stdout would contaminate the $() capture (bash 3.2 has no clean
+		# way to separate tee output from the exit code in a single $()).
+		(
 			set +e
 			if [[ -x "$SANDBOX_EXEC_HELPER" ]]; then
-				local escaped_cmd passthrough_csv
-				printf -v escaped_cmd '%q ' "${cmd[@]}"
-				escaped_cmd="${escaped_cmd% }"
+				# Pass cmd array elements as separate arguments after --.
+				# Previous code used printf -v to build a single escaped string,
+				# which the sandbox received as one argument and passed to env as
+				# a single executable path — causing "No such file or directory".
+				# Bash 3.2 compat: no local -a in subshells, no printf -v tricks.
+				local passthrough_csv
 				passthrough_csv="$(build_sandbox_passthrough_csv)"
-				local sandbox_args=()
 				if [[ -n "$passthrough_csv" ]]; then
-					sandbox_args=(--passthrough "$passthrough_csv")
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io --passthrough "$passthrough_csv" -- "${cmd[@]}" 2>&1 | tee "$output_file"
+				else
+					"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io -- "${cmd[@]}" 2>&1 | tee "$output_file"
 				fi
-				"$SANDBOX_EXEC_HELPER" run --timeout "$HEADLESS_SANDBOX_TIMEOUT_DEFAULT" --allow-secret-io "${sandbox_args[@]}" -- "$escaped_cmd" 2>&1 | tee "$output_file"
-				echo "${PIPESTATUS[0]}"
+				printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 			else
 				"${cmd[@]}" 2>&1 | tee "$output_file"
-				echo "${PIPESTATUS[0]}"
+				printf '%s' "${PIPESTATUS[0]}" >"$exit_code_file"
 			fi
 		) || true
+		exit_code=$(cat "$exit_code_file" 2>/dev/null) || exit_code=1
+		rm -f "$exit_code_file"
 
 		local discovered_session
 		discovered_session=$(extract_session_id_from_output "$output_file")

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -880,6 +880,90 @@ check_secret_policy() {
 }
 
 # =============================================================================
+# Bash 3.2 Compatibility Check
+# =============================================================================
+# macOS ships bash 3.2.57. Bash 4.0+ features silently crash or produce wrong
+# results — no error message, just broken behaviour. ShellCheck does NOT catch
+# most version incompatibilities, so this is a dedicated scanner.
+
+check_bash32_compat() {
+	echo -e "${BLUE}Checking Bash 3.2 Compatibility...${NC}"
+
+	local violations=0
+	local tmp_file
+	tmp_file=$(mktemp)
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	push_cleanup "rm -f '${tmp_file}'"
+
+	# Use grep -nE (ERE) — NOT grep -nP (PCRE) — because macOS BSD grep
+	# does not support -P. This check itself must be bash 3.2 / macOS compatible.
+	# Skip this file (linters-local.sh) — its grep patterns contain the
+	# forbidden strings as search targets, not as bash code.
+	local self_basename
+	self_basename=$(basename "${BASH_SOURCE[0]}")
+	for file in "${ALL_SH_FILES[@]}"; do
+		[[ -f "$file" ]] || continue
+		[[ "$(basename "$file")" == "$self_basename" ]] && continue
+
+		# declare -A / local -A (associative arrays — bash 4.0+)
+		grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-A[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
+			printf '%s:%s [associative array — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+		done
+
+		# mapfile / readarray (bash 4.0+)
+		grep -nE '^[[:space:]]*(mapfile|readarray)[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
+			printf '%s:%s [mapfile/readarray — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+		done
+
+		# ${var,,} / ${var^^} case conversion (bash 4.0+)
+		# Exclude comments — grep -n prefixes "NNN:" so comments appear as "NNN:\s*#"
+		grep -n ',,}' "$file" 2>/dev/null | grep '\${' | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
+			printf '%s:%s [case conversion ,,} — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+		done
+		grep -n '^^}' "$file" 2>/dev/null | grep '\${' | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
+			printf '%s:%s [case conversion ^^} — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+		done
+
+		# declare -n / local -n namerefs (bash 4.3+)
+		grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-n[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
+			printf '%s:%s [nameref — bash 4.3+]\n' "$file" "$line" >>"$tmp_file"
+		done
+
+		# coproc (bash 4.0+)
+		grep -nE '^[[:space:]]*coproc[[:space:]]' "$file" 2>/dev/null | while IFS= read -r line; do
+			printf '%s:%s [coproc — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+		done
+
+		# &>> append-both (bash 4.0+)
+		grep -n '&>>' "$file" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
+			printf '%s:%s [&>> append — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
+		done
+	done
+
+	if [[ -s "$tmp_file" ]]; then
+		violations=$(wc -l <"$tmp_file")
+		violations=${violations//[^0-9]/}
+		violations=${violations:-0}
+
+		if [[ "$violations" -gt 0 ]]; then
+			print_error "Bash 3.2 compatibility: $violations violations (macOS default bash)"
+			head -20 "$tmp_file"
+			if [[ "$violations" -gt 20 ]]; then
+				echo "... and $((violations - 20)) more"
+			fi
+			rm -f "$tmp_file"
+			return 1
+		fi
+	fi
+
+	rm -f "$tmp_file"
+	print_success "Bash 3.2 compatibility: no violations"
+
+	return 0
+}
+
+# =============================================================================
 # Bundle-Aware Gate Filtering (t1364.6)
 # =============================================================================
 # Resolves the project bundle and checks whether a gate should be skipped.
@@ -1002,6 +1086,11 @@ main() {
 
 	if ! should_skip_gate "secret-policy"; then
 		check_secret_policy || exit_code=1
+		echo ""
+	fi
+
+	if ! should_skip_gate "bash32-compat"; then
+		check_bash32_compat || exit_code=1
 		echo ""
 	fi
 

--- a/.agents/scripts/mission-dashboard-helper.sh
+++ b/.agents/scripts/mission-dashboard-helper.sh
@@ -55,12 +55,13 @@ find_mission_files() {
 	fi
 
 	# Deduplicate by realpath
-	local -A seen=()
+	# Bash 3.2 compat: no associative arrays — use string-based seen list
+	local seen=" "
 	for p in "${paths[@]}"; do
 		local rp
 		rp=$(realpath "$p" 2>/dev/null) || rp="$p"
-		if [[ -z "${seen[$rp]:-}" ]]; then
-			seen[$rp]=1
+		if [[ "$seen" != *" ${rp} "* ]]; then
+			seen="${seen}${rp} "
 			echo "$p"
 		fi
 	done

--- a/.agents/scripts/quality-feedback-helper.sh
+++ b/.agents/scripts/quality-feedback-helper.sh
@@ -101,7 +101,8 @@ _extract_verification_snippet() {
 				in_fence="true"
 				fence_type=""
 				if [[ "$line" =~ ^\`\`\`([[:alnum:]_-]+) ]]; then
-					fence_type="${BASH_REMATCH[1],,}"
+					# Bash 3.2 compat: no ${var,,} — use tr for case conversion
+					fence_type=$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')
 				fi
 				continue
 			fi

--- a/setup.sh
+++ b/setup.sh
@@ -141,12 +141,13 @@ _ensure_cron_path() {
 	current_crontab=$(crontab -l 2>/dev/null) || current_crontab=""
 
 	# Deduplicate PATH entries (preserving order)
+	# Bash 3.2 compat: no associative arrays — use string-based seen list
 	local deduped_path=""
-	local -A seen_dirs=()
+	local seen_dirs=" "
 	local IFS=':'
 	for dir in $PATH; do
-		if [[ -n "$dir" && -z "${seen_dirs[$dir]:-}" ]]; then
-			seen_dirs[$dir]=1
+		if [[ -n "$dir" && "$seen_dirs" != *" ${dir} "* ]]; then
+			seen_dirs="${seen_dirs}${dir} "
 			deduped_path="${deduped_path:+${deduped_path}:}${dir}"
 		fi
 	done


### PR DESCRIPTION
## Summary

- **Root cause**: `headless-runtime-helper.sh` passed the opencode command array as a single `printf -v` escaped string to `sandbox-exec-helper.sh`. The sandbox received one argument and passed it to `env` as a single executable path → `No such file or directory` on every pulse cycle. Additionally, `tee` stdout contaminated the `$()` exit code capture → arithmetic parse errors on the exit code check.
- **Impact**: Pulse has been unable to dispatch any workers — 0 active workers despite 25 runnable tasks and 12+ available slots. Every 3-minute pulse cycle starts, prefetches state, launches opencode, and immediately fails.

## Changes

### Bug fixes (4 scripts + setup.sh)
- `headless-runtime-helper.sh`: pass `cmd[@]` as separate args to sandbox (not single escaped string); write exit code to temp file instead of `$()` capture
- `setup.sh`: replace `local -A seen_dirs` with string-based dedup
- `mission-dashboard-helper.sh`: replace `local -A seen` with string-based dedup
- `aidevops-update-check.sh`: replace `${parent,,}` with `tr` case conversion
- `quality-feedback-helper.sh`: replace `${BASH_REMATCH[1],,}` with `tr`

### Prevention (2 files)
- `build.txt`: comprehensive bash 3.2 compatibility rules — forbidden features, subshell traps, array passing across process boundaries
- `linters-local.sh`: new `check_bash32_compat()` gate that scans all shell scripts for `declare -A`, `mapfile`, `${var,,}`, namerefs, `coproc`, and `&>>` patterns. Runs as part of the standard quality pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compatibility with Bash 3.2 (macOS default shell) to ensure scripts run properly across all systems.

* **Chores**
  * Added automated compatibility verification for shell scripts.
  * Updated internal scripts to use features compatible with older Bash versions.
  * Extended compatibility guidance documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->