### PR TITLE
fix: bash escape quoting — "\t" produces literal backslash-t, not tab

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -373,10 +373,24 @@ Git is the primary audit trail for all work. Every change should be discoverable
 - To pass an array to a subprocess: pass elements as separate positional arguments (`"${arr[@]}"`), never as a single escaped string (`printf -v str '%q ' "${arr[@]}"` then `"$str"` — the subprocess receives one argument, not many)
 - To receive array results from a subprocess: write to a temp file (one element per line), then read back with `while read` loop
 #
+# Escape sequence quoting (recurring production-breaking bug):
+# Bash double quotes do NOT interpret \t \n \r as whitespace. They are literal
+# two-character sequences (backslash + letter). This is unlike C, Python, JS,
+# and most other languages. Agents repeatedly write `"\t"` expecting a tab —
+# this produces broken XML/plist/JSON/YAML and is invisible until runtime.
+- `"\t"` → literal backslash-t (TWO characters). Use `$'\t'` for actual tab.
+- `"\n"` → literal backslash-n (TWO characters). Use `$'\n'` for actual newline.
+- For string concatenation with variables: `var+=$'\t'"${value}"` (ANSI-C quote for the tab, then double-quote for the variable expansion)
+- Inside heredocs (`<<EOF`), tabs are literal tab characters (typed or pasted) — `\t` is NOT interpreted. This is correct and safe.
+- `echo -e "\t"` interprets escapes but is non-portable. Prefer `printf '\t'`.
+- `printf '%s\t%s' "$a" "$b"` is the safest portable way to embed tabs.
+- When building XML/plist/JSON via string concatenation, ALWAYS use `$'\t'` for indentation — never `"\t"`. A single `"\t"` in a plist makes it unparseable and silently kills launchd jobs.
+#
 # Safe patterns:
 - Test scripts with `/bin/bash` (not `/opt/homebrew/bin/bash`) to catch 4.0+ usage
 - When in doubt, check: `bash --version` on macOS gives 3.2.57
 - ShellCheck does NOT catch most bash version incompatibilities — manual review required
+- ShellCheck does NOT catch `"\t"` vs `$'\t'` — both are valid bash, just different semantics
 
 # Write-Time Quality Enforcement
 # Inspired by Plankton (github.com/alexfazio/plankton) — adapted for runtime-agnostic use.

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -939,6 +939,15 @@ check_bash32_compat() {
 		grep -n '&>>' "$file" 2>/dev/null | grep -vE '^[0-9]+:[[:space:]]*#' | while IFS= read -r line; do
 			printf '%s:%s [&>> append — bash 4.0+]\n' "$file" "$line" >>"$tmp_file"
 		done
+
+		# "\t" or "\n" in string concatenation (likely wants $'\t' or $'\n')
+		# Only flag += or = assignments, not awk/sed/printf/echo -e/python contexts
+		grep -nE '\+="\\[tn]|="\\[tn]' "$file" 2>/dev/null |
+			grep -vE '^[0-9]+:[[:space:]]*#' |
+			grep -vE 'awk|sed|printf|echo.*-e|python|f\.write|gsub|join|split|print |replace|coords|excerpt|delimiter|regex|pattern' |
+			while IFS= read -r line; do
+				printf '%s:%s ["\t"/"\n" — use $'"'"'\\t'"'"' or $'"'"'\\n'"'"' for actual whitespace]\n' "$file" "$line" >>"$tmp_file"
+			done
 	done
 
 	if [[ -s "$tmp_file" ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -1021,7 +1021,7 @@ main() {
 				_headless_xml_env+=$'\n'
 				_headless_xml_env+=$'\t\t<key>AIDEVOPS_HEADLESS_MODELS</key>'
 				_headless_xml_env+=$'\n'
-				_headless_xml_env+="\t\t<string>${_xml_headless_models}</string>"
+				_headless_xml_env+=$'\t\t'"<string>${_xml_headless_models}</string>"
 			fi
 			if [[ -n "${AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST:-}" ]]; then
 				local _xml_headless_allowlist
@@ -1029,7 +1029,7 @@ main() {
 				_headless_xml_env+=$'\n'
 				_headless_xml_env+=$'\t\t<key>AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST</key>'
 				_headless_xml_env+=$'\n'
-				_headless_xml_env+="\t\t<string>${_xml_headless_allowlist}</string>"
+				_headless_xml_env+=$'\t\t'"<string>${_xml_headless_allowlist}</string>"
 			fi
 
 			# Write the plist (always regenerated to pick up config changes)


### PR DESCRIPTION
## Summary

- **Root cause**: `setup.sh` line 1024 used `"\t\t<string>..."` (double quotes) to build plist XML. In bash, `"\t"` is a literal two-character sequence (backslash + t), NOT a tab. The generated plist contained `\t\t<string>` as text, making it invalid XML.
- **Trigger**: The v2.172.30 auto-update regenerated the plist, exposing this latent bug. launchd rejected the invalid XML with I/O error, silently killing the supervisor pulse.
- **Impact**: Pulse launchd job disappeared entirely — no workers dispatched after the auto-update.

## Changes

- `setup.sh`: replace `"\t\t<string>..."` with `$'\t\t'"<string>..."` (ANSI-C quoting) for both HEADLESS_MODELS and HEADLESS_PROVIDER_ALLOWLIST
- `build.txt`: add "Escape sequence quoting" section explaining that bash double quotes do NOT interpret `\t` `\n` `\r` (unlike C/Python/JS), with safe patterns
- `linters-local.sh`: add `"\t"`/`"\n"` detection in string concatenation context to the bash 3.2 compat checker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Bash escape sequence documentation, covering proper handling of tabs, newlines, and invisible characters in string concatenation and shell constructs.

* **Improvements**
  * Added linting checks to detect problematic whitespace patterns in shell scripts and recommend portable alternatives.
  * Refined shell script formatting for improved consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->