### PR TITLE
t4898: fix incorrect ssh package name in setup-modules/core.sh

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -437,10 +437,6 @@ check_requirements() {
 		missing_deps+=("curl")
 		missing_packages+=("curl")
 	fi
-	if ! command -v ssh >/dev/null 2>&1; then
-		missing_deps+=("ssh")
-		missing_packages+=("ssh")
-	fi
 	if ! command -v rg >/dev/null 2>&1; then
 		missing_deps+=("rg")
 		missing_packages+=("ripgrep")


### PR DESCRIPTION
## Summary

- Removes the `ssh` dependency check from `setup-modules/core.sh:429`
- The package name `ssh` doesn't exist on any major package manager (apt uses `openssh-client`, dnf uses `openssh-clients`, pacman/brew use `openssh`)
- SSH is pre-installed on virtually all Unix systems; if it's missing, the user has bigger problems than this installer can solve
- Implements CodeRabbit's recommended Option 1 (simpler and correct)

## Change

```diff
-	if ! command -v ssh >/dev/null 2>&1; then
-		missing_deps+=("ssh")
-		missing_packages+=("ssh")
-	fi
```

## Verification

- ShellCheck passes with zero violations
- Remaining deps (`jq`, `curl`, `rg`) all have correct package names

Closes #4898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the setup process by removing SSH as a required system dependency, reducing the number of prerequisites needed during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->