### PR TITLE
fix: add comma thousands separators to token counts

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -85,17 +85,21 @@ _format_cost() {
 	return 0
 }
 
-# --- Format token count (K/M suffix) ---
+# --- Format token count (K/M suffix, with comma thousands separators) ---
 _format_tokens() {
 	local tokens="$1"
 	if [[ "$tokens" -ge 1000000 ]]; then
 		local m
 		m=$(echo "scale=1; $tokens / 1000000" | bc)
-		echo "${m}M"
+		local formatted
+		formatted=$(_format_number "$m")
+		echo "${formatted}M"
 	elif [[ "$tokens" -ge 1000 ]]; then
 		local k
 		k=$(echo "scale=0; $tokens / 1000" | bc)
-		echo "${k}K"
+		local formatted
+		formatted=$(_format_number "$k")
+		echo "${formatted}K"
 	else
 		echo "$tokens"
 	fi


### PR DESCRIPTION
## Summary

Adds comma thousands separators to `_format_tokens()` output so large token counts like `10425.3M` render as `10,425.3M`.

Affects all token count displays: table cells (Input, Output, Cache read columns) and footer totals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced readability of large number formatting by adding thousand separators (commas) to token counts and similar metrics displayed in reports and outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->