### PR TITLE
t1489: raise Codacy quality gate to 10 Warning+ to allow extract-function refactoring

### DIFF
--- a/.agents/tools/code-review/codacy.md
+++ b/.agents/tools/code-review/codacy.md
@@ -26,6 +26,35 @@ tools:
 - Cannot fix: Complex logic, architecture, context-dependent, breaking changes
 - Best practices: Always review, test after, incremental batches, clean git state
 - Workflow: quality-check -> analyze --fix -> quality-check -> commit with metrics
+
+## Quality Gate Settings
+
+**Current gate (PR and commits):** max 10 new issues, minimum severity Warning.
+
+**Rationale (GH#4910, t1489):** The gate was originally set to 0 max new issues. This
+tripped 4x during extract-function refactoring sessions — new helper functions count as
+added complexity, and subprocess calls in new functions count as new Bandit warnings.
+The project grade stays A throughout; these are not real regressions. Threshold raised
+to 10 Warning+ to absorb refactoring noise while still blocking genuine security/error issues.
+
+**Do not revert to 0.** A threshold of 0 makes extract-function refactoring impossible
+without manual Codacy dashboard intervention on every PR. The project grade (A) is the
+meaningful quality signal, not the per-PR new-issue count.
+
+**Updating via API:**
+```bash
+# Update PR gate
+curl -s -H "api-token: $CODACY_API_TOKEN" \
+  "https://app.codacy.com/api/v3/organizations/gh/marcusquinn/repositories/aidevops/settings/quality/pull-requests" \
+  -X PUT -H "Content-Type: application/json" \
+  -d '{"issueThreshold":{"threshold":10,"minimumSeverity":"Warning"}}'
+
+# Update commits gate
+curl -s -H "api-token: $CODACY_API_TOKEN" \
+  "https://app.codacy.com/api/v3/organizations/gh/marcusquinn/repositories/aidevops/settings/quality/commits" \
+  -X PUT -H "Content-Type: application/json" \
+  -d '{"issueThreshold":{"threshold":10,"minimumSeverity":"Warning"}}'
+```
 <!-- AI-CONTEXT-END -->
 
 ## Automated Code Quality Fixes

--- a/.agents/tools/code-review/codacy.md
+++ b/.agents/tools/code-review/codacy.md
@@ -42,6 +42,7 @@ without manual Codacy dashboard intervention on every PR. The project grade (A) 
 meaningful quality signal, not the per-PR new-issue count.
 
 **Updating via API:**
+
 ```bash
 # Update PR gate
 curl -s -H "api-token: $CODACY_API_TOKEN" \

--- a/.agents/tools/code-review/codacy.md
+++ b/.agents/tools/code-review/codacy.md
@@ -56,6 +56,7 @@ curl -s -H "api-token: $CODACY_API_TOKEN" \
   -X PUT -H "Content-Type: application/json" \
   -d '{"issueThreshold":{"threshold":10,"minimumSeverity":"Warning"}}'
 ```
+
 <!-- AI-CONTEXT-END -->
 
 ## Automated Code Quality Fixes

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -9,6 +9,18 @@
 #   Codacy's action_required conclusion (= "issues found") was treated as a CI failure
 #   by gh-failure-miner-helper.sh. Fixed in GH#4696.
 # - This config excludes archived/ (same as CI shellcheck) and aligns tool settings.
+#
+# Quality gate settings (GH#4910, t1489):
+# - PR and commit gates: max 10 new issues, minimum severity Warning.
+# - Rationale: gate was set to 0 max new issues, which tripped 4x during extract-function
+#   refactoring. New helper functions count as added complexity; subprocess calls in new
+#   functions count as new Bandit warnings. Project grade stays A throughout — these are
+#   not real regressions. Threshold raised to 10 Warning+ to absorb refactoring noise
+#   while still blocking genuine security/error issues.
+# - Gate settings are managed via Codacy API (not this file). This comment documents the
+#   rationale so the setting is not silently reverted to 0 in the dashboard.
+#   API endpoint: PUT /api/v3/organizations/gh/marcusquinn/repositories/aidevops/settings/quality/pull-requests
+#   Current value: {"issueThreshold":{"threshold":10,"minimumSeverity":"Warning"}}
 
 ---
 engines:


### PR DESCRIPTION
## Summary

- Codacy quality gate was set to 0 max new issues, tripping 4x during extract-function refactoring sessions (PRs #4914, #4915 and others)
- New helper functions count as added complexity; subprocess calls in new functions count as new Bandit warnings — neither is a real regression (project grade stays A)
- Gate updated via Codacy API to threshold=10, minimumSeverity=Warning for both PR and commit gates

## Changes

- **Codacy API** (live): PR and commit gates updated to `threshold=10, minimumSeverity=Warning`
- **`.codacy.yml`**: Added rationale comment documenting the gate setting and why it must not be reverted to 0
- **`.agents/tools/code-review/codacy.md`**: Documented gate settings, rationale, and API update commands for future reference

## Why threshold=10 and not 0

A threshold of 0 makes extract-function refactoring impossible without manual Codacy dashboard intervention on every PR. The project grade (A) is the meaningful quality signal. Threshold of 10 Warning+ absorbs refactoring noise while still blocking genuine security/error issues.

## Verification

Gate settings confirmed via API after update:
```json
{"issueThreshold":{"threshold":10,"minimumSeverity":"Warning"}}
```

Closes #4910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Codacy quality gate configuration documentation with detailed information on current thresholds (10 new issues, minimum severity Warning) and configuration management via API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->