### PR TITLE
t4904: fix pulse-wrapper.sh source-safe in zsh/supervisor sessions

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -23,13 +23,24 @@
 #   User config: ~/.config/aidevops/config.jsonc
 #   Old config:  ~/.config/aidevops/feature-toggles.conf (migrated on first use)
 
-# Apply strict mode only when executed directly (not when sourced by another script)
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# Apply strict mode only when executed directly (not when sourced by another script).
+# Shell portability note (GH#4904):
+#   bash: BASH_SOURCE[0] == $0 when executed directly; differs when sourced.
+#   zsh:  BASH_SOURCE is always unset — the script is always being sourced when
+#         this file is loaded via `source`. Never run main() in zsh.
+# Guard: only check BASH_SOURCE when it is set (bash). In zsh, skip the check
+# entirely (we are always being sourced, never executed directly as zsh).
+_CH_SELF="${BASH_SOURCE[0]:-}"
+if [[ -n "${_CH_SELF}" && "${_CH_SELF}" == "${0}" ]]; then
 	set -euo pipefail
 fi
 
-# Resolve script directory (works when sourced or executed)
-_CONFIG_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || {
+# Resolve script directory (works when sourced or executed).
+# Fall back to $0 when BASH_SOURCE is unset (zsh). In zsh this gives the
+# shell name ("zsh"), which is wrong for path resolution — but the deployed
+# path fallback in _load_model_pricing_json covers that case. See GH#4904.
+_CH_SELF_DIR="${BASH_SOURCE[0]:-${0:-}}"
+_CONFIG_HELPER_DIR="$(cd "$(dirname "${_CH_SELF_DIR}")" && pwd)" || {
 	echo "[config] Failed to resolve script directory" >&2
 	return 1 2>/dev/null || exit 1
 }
@@ -1008,7 +1019,10 @@ main() {
 	return 0
 }
 
-# Only run main if executed directly (not sourced)
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+# Only run main if executed directly (not sourced).
+# In bash: BASH_SOURCE[0] == $0 when executed directly.
+# In zsh: BASH_SOURCE is always unset — never run main when sourced from zsh.
+# See GH#4904 for the full portability rationale.
+if [[ -n "${_CH_SELF:-}" && "${_CH_SELF}" == "${0}" ]]; then
 	main "$@"
 fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -3033,10 +3033,14 @@ cleanup_orphans() {
 			continue
 		fi
 
-		# Skip active workers, pulse, strategic reviews, and language servers
-		if [[ "$cmd" =~ /full-loop|Supervisor\ Pulse|Strategic\ Review|language-server|eslintServer ]]; then
+		# Skip active workers, pulse, strategic reviews, and language servers.
+		# Use case instead of [[ =~ ]] with | alternation — zsh parses the |
+		# as a pipe operator inside [[ ]], causing a parse error. See GH#4904.
+		case "$cmd" in
+		*"/full-loop"* | *"Supervisor Pulse"* | *"Strategic Review"* | *"language-server"* | *"eslintServer"*)
 			continue
-		fi
+			;;
+		esac
 
 		# Skip young processes
 		local age_seconds
@@ -3059,7 +3063,12 @@ cleanup_orphans() {
 		read -r pid tty etime rss cmd <<<"$line"
 
 		[[ "$tty" != "?" && "$tty" != "??" ]] && continue
-		[[ "$cmd" =~ /full-loop|Supervisor\ Pulse|Strategic\ Review|language-server|eslintServer ]] && continue
+		# Use case instead of [[ =~ ]] with | alternation — zsh parse error. See GH#4904.
+		case "$cmd" in
+		*"/full-loop"* | *"Supervisor Pulse"* | *"Strategic Review"* | *"language-server"* | *"eslintServer"*)
+			continue
+			;;
+		esac
 
 		local age_seconds
 		age_seconds=$(_get_process_age "$pid")

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1251,7 +1251,11 @@ resolve_model_tier() {
 	fi
 
 	# Try fallback-chain-helper.sh for availability-aware resolution
-	local chain_helper="${BASH_SOURCE[0]%/*}/fallback-chain-helper.sh"
+	# Use ${BASH_SOURCE[0]:-$0} for shell portability — BASH_SOURCE is undefined
+	# in zsh (the MCP shell environment). The :-$0 fallback ensures SCRIPT_DIR
+	# resolves correctly whether sourced from bash or zsh. See GH#4904.
+	local _sc_self="${BASH_SOURCE[0]:-${0:-}}"
+	local chain_helper="${_sc_self%/*}/fallback-chain-helper.sh"
 	if [[ -x "$chain_helper" ]]; then
 		local resolved
 		resolved=$("$chain_helper" resolve "$tier" --quiet 2>/dev/null) || true
@@ -1335,7 +1339,10 @@ _load_model_pricing_json() {
 	_MODEL_PRICING_JSON_LOADED="attempted"
 	local json_file
 	# Try repo-relative path first (works in dev), then deployed path
-	local script_dir="${BASH_SOURCE[0]%/*}"
+	# Use ${BASH_SOURCE[0]:-$0} for shell portability — BASH_SOURCE is undefined
+	# in zsh (the MCP shell environment). See GH#4904.
+	local script_dir="${BASH_SOURCE[0]:-${0:-}}"
+	script_dir="${script_dir%/*}"
 	for json_file in \
 		"${script_dir}/../configs/model-pricing.json" \
 		"${HOME}/.aidevops/agents/configs/model-pricing.json"; do
@@ -1441,7 +1448,11 @@ get_provider_from_model() {
 # The include guard (_SHARED_CONSTANTS_LOADED at line 14) prevents infinite recursion
 # at execution time, but ShellCheck is a static analyzer and ignores runtime guards.
 # GH#3981: https://github.com/marcusquinn/aidevops/issues/3981
-_CONFIG_HELPER="${BASH_SOURCE[0]%/*}/config-helper.sh"
+# Use ${BASH_SOURCE[0]:-$0} for shell portability — BASH_SOURCE is undefined
+# in zsh (the MCP shell environment). Without this guard, sourcing from zsh
+# with set -u (nounset) fails with "BASH_SOURCE[0]: parameter not set". See GH#4904.
+_SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
+_CONFIG_HELPER="${_SC_SELF%/*}/config-helper.sh"
 if [[ -r "$_CONFIG_HELPER" ]]; then
 	# shellcheck source=/dev/null
 	source "$_CONFIG_HELPER"


### PR DESCRIPTION
## Summary

- **`shared-constants.sh`**: Guard all `BASH_SOURCE[0]` references with `:-` fallback — sourcing from zsh (where `BASH_SOURCE` is unset) with `set -u` aborted with `BASH_SOURCE[0]: parameter not set`
- **`config-helper.sh`**: Same `BASH_SOURCE` guard; fix `main()` guard to check `BASH_SOURCE` is non-empty before comparing to `$0`, preventing `main()` from running when sourced from zsh
- **`pulse-wrapper.sh`**: Replace `[[ $cmd =~ /full-loop|Supervisor Pulse|... ]]` with `case` statement at lines 3037 and 3062 — zsh parses `|` as a pipe operator inside `[[ ]]`, causing `parse error near '|'`

## Root Cause

Two distinct failures when sourcing `pulse-wrapper.sh` in a zsh supervisor session:

1. **`BASH_SOURCE[0]: parameter not set`** — zsh does not define `BASH_SOURCE`. Three locations in `shared-constants.sh` used `${BASH_SOURCE[0]%/*}` without a `:-` fallback. With `set -u` (nounset), this aborts sourcing.

2. **`parse error near '|'`** — zsh parses `|` as a pipe operator inside `[[ ]]` conditional expressions, even when it appears inside a regex pattern for `=~`. Two locations in `pulse-wrapper.sh` used `[[ "$cmd" =~ /full-loop|Supervisor Pulse|... ]]`.

## Verification

```
# zsh (MCP shell environment)
zsh -c 'source .agents/scripts/pulse-wrapper.sh; echo "SOURCE OK"; type list_active_worker_processes; type check_worker_launch'
# → SOURCE OK, both functions available

# bash 3.2 (macOS default)
/bin/bash -c 'set -euo pipefail; source .agents/scripts/pulse-wrapper.sh; echo "SOURCE OK"'
# → SOURCE OK

# Tests
/bin/bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh      # 7/7 PASS
/bin/bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh  # 7/7 PASS

# ShellCheck
shellcheck .agents/scripts/pulse-wrapper.sh    # 0 violations
shellcheck .agents/scripts/shared-constants.sh # 0 violations
shellcheck .agents/scripts/config-helper.sh    # 0 violations
```

Closes #4904