### PR TITLE
fix: profile README tagline paragraph break and website globe icon

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -1075,7 +1075,7 @@ _generate_rich_readme() {
 		local blog_display
 		blog_display="${blog##*//}"
 		blog_display=$(_sanitize_md "$blog_display")
-		connect="${connect}[![Website](https://img.shields.io/badge/-${blog_display}-FF5722?style=flat-square&logo=hugo&logoColor=white)](${blog})"$'\n'
+		connect="${connect}[![Website](https://img.shields.io/badge/-${blog_display}-FF5722?style=flat-square&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyQzYuNDggMiAyIDYuNDggMiAxMnM0LjQ4IDEwIDEwIDEwIDEwLTQuNDggMTAtMTBTMTcuNTIgMiAxMiAyem0tMSAxNy45M2MtMy45NS0uNDktNy0zLjg1LTctNy45MyAwLS42Mi4wOC0xLjIxLjIxLTEuNzlMOSAxNXY1YzAgLjU1LjQ1IDEgMSAxdjEuOTN6bTYuOS0yLjU0Yy0uMjYtLjgxLTEtMS4zOS0xLjktMS4zOWgtMXYtM2MwLS41NS0uNDUtMS0xLTFIOHYtMmgyYy41NSAwIDEtLjQ1IDEtMVY3aDJjMS4xIDAgMi0uOSAyLTJ2LS40MWMyLjkzIDEuMTkgNSA0LjA2IDUgNy40MSAwIDIuMDgtLjggMy45Ny0yLjEgNS4zOXoiLz48L3N2Zz4=&logoColor=white)](${blog})"$'\n'
 	fi
 	if [[ -n "$twitter" ]]; then
 		connect="${connect}[![X](https://img.shields.io/badge/-@${twitter}-000000?style=flat-square&logo=x&logoColor=white)](https://twitter.com/${twitter})"$'\n'
@@ -1094,6 +1094,7 @@ _generate_rich_readme() {
 		printf '%s' "$badges"
 		echo ""
 		echo "> Shipping with AI agents around the clock -- human hours for thinking, machine hours for doing."
+		echo ">"
 		echo "> Stats auto-updated by [aidevops](https://aidevops.sh)."
 		echo ""
 		echo "<!-- STATS-START -->"


### PR DESCRIPTION
## Summary

- Add paragraph break between tagline sentences (blank `>` line in blockquote)
- Replace `logo=hugo` with inline SVG globe icon for the website badge -- Hugo is a static site generator, not a generic website symbol