### PR TITLE
fix: add blank line between tagline quote and subtitle

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ See `.agents/tools/git/opencode-github-security.md` for the full security docume
 
 Your terminal tab/window title automatically shows `repo/branch` context when working in git repositories. This helps identify which codebase and branch you're working on across multiple terminal sessions.
 
-**Supported terminals:** Tabby, iTerm2, Windows Terminal, Kitty, Alacritty, WezTerm, Hyper, and most xterm-compatible terminals.
+**Supported terminals:** [Tabby](https://tabby.sh/), [tmux](https://github.com/tmux/tmux), [iTerm2](https://iterm2.com/), [Windows Terminal](https://github.com/microsoft/terminal), [Kitty](https://sw.kovidgoyal.net/kitty/), [Alacritty](https://alacritty.org/), [WezTerm](https://wezfurlong.org/wezterm/), [Hyper](https://hyper.is/), and most xterm-compatible terminals.
 
 **How it works:** The `pre-edit-check.sh` script's primary role is enforcing git workflow protection (blocking edits on main/master branches). As a secondary, non-blocking action, it updates the terminal title via escape sequences. No configuration needed - it's automatic.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 *"Scope a mission to redesign the landing pages — break it into milestones, dispatch workers in parallel, validate each milestone, and track budget across the whole project"*
 
-**One conversation, autonomous multi-day project execution.**
+**One conversation, autonomous project delivery — with enterprise-level security & quality-control.**
 
 ## **The Philosophy**
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,8 @@ See `.agents/tools/git/opencode-github-security.md` for the full security docume
 **Recommended stack:**
 
 - **[OpenCode](https://opencode.ai/)** - The recommended AI coding agent. Powerful agentic TUI/CLI with native MCP support, Tab-based agent switching, LSP integration, plugin ecosystem, and excellent DX. All aidevops features are designed and tested for OpenCode first.
-- **[Claude models](https://claude.ai/)** - Recommended AI models. Claude haiku, sonnet, and opus deliver the best results across all aidevops agent tiers and workflows.
+- **[OpenCode Zen](https://opencode.ai/)** - Free tier of OpenCode with included models. Start working with AI straight away at no cost -- no API keys or subscriptions required.
+- **[Claude](https://claude.ai/)** (Anthropic) - Our most-used and tested model provider. Claude haiku, sonnet, and opus deliver the best results across all aidevops agent tiers and workflows. Recommended for users who want the highest quality output.
 - **[Tabby](https://tabby.sh/)** - Recommended terminal. Colour-coded Profiles per project/repo, **auto-syncs tab title with git repo/branch.**
 - **[Zed](https://zed.dev/)** - Recommended editor. High-performance with AI integration (use with the OpenCode Agent Extension).
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 > **Recommended setup:** [OpenCode](https://opencode.ai/) + [Claude](https://claude.ai/) models (Anthropic). All features, agents, and workflows are designed and tested for OpenCode first. Claude models (haiku, sonnet, opus) deliver the best results across all agent tiers.
 
 *"Scope a mission to redesign the landing pages — break it into milestones, dispatch workers in parallel, validate each milestone, and track budget across the whole project"*
+
 **One conversation, autonomous multi-day project execution.**
 
 ## **The Philosophy**


### PR DESCRIPTION
## Summary

- Markdown requires a blank line between blocks to render them as separate paragraphs
- Without it, the italic quote and bold subtitle were collapsing into a single line on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated product messaging to emphasize enterprise-level security and quality controls
  * Reorganized stack recommendations introducing OpenCode Zen as free-tier option with updated Claude positioning
  * Enhanced terminal compatibility documentation with links to Tabby, tmux, iTerm2, Windows Terminal, Kitty, Alacritty, and more

<!-- end of auto-generated comment: release notes by coderabbit.ai -->