### PR TITLE
t4929: Fix Bash 3.2 bad substitution in config_get

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -330,7 +330,10 @@ config_get() {
 	local env_var
 	env_var=$(_config_env_map "$dotpath")
 	if [[ -n "$env_var" ]]; then
-		local env_val="${!env_var:-}"
+		local env_val=""
+		if [[ -n "${!env_var+x}" ]]; then
+			env_val="${!env_var}"
+		fi
 		if [[ -n "$env_val" ]]; then
 			echo "$env_val"
 			return 0


### PR DESCRIPTION
## Summary
- replace Bash 4-style indirect expansion (`${!name:-}`) in `config_get` with a Bash 3.2-safe check and read path
- preserve env override precedence while avoiding `bad substitution` when `pulse-wrapper.sh` sources `config-helper.sh` on macOS `/bin/bash`
- validated with `shellcheck` and a `/bin/bash` source repro

Closes #4929

## Verification
- `shellcheck .agents/scripts/config-helper.sh`
- `/bin/bash -lc 'source .agents/scripts/pulse-wrapper.sh'`
- `/bin/bash -lc 'source .agents/scripts/config-helper.sh; AIDEVOPS_MAX_WORKERS_CAP=11; config_get orchestration.max_workers_cap 8'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment variable override handling to properly distinguish between unset and set (empty) variables, ensuring more reliable configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->