### PR TITLE
t1491: fix Bash 3.2 bad substitution in config_get indirect expansion

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -330,7 +330,9 @@ config_get() {
 	local env_var
 	env_var=$(_config_env_map "$dotpath")
 	if [[ -n "$env_var" ]]; then
-		local env_val="${!env_var:-}"
+		# Use eval for Bash 3.2 compat — ${!var:-} causes "bad substitution" on 3.2
+		local env_val=""
+		eval "env_val=\${$env_var:-}"
 		if [[ -n "$env_val" ]]; then
 			echo "$env_val"
 			return 0
@@ -524,7 +526,8 @@ cmd_list() {
 		local env_var
 		env_var=$(_config_env_map "$dotpath")
 		if [[ -n "$env_var" ]]; then
-			env_val="${!env_var:-}"
+			# Use eval for Bash 3.2 compat — ${!var:-} causes "bad substitution" on 3.2
+			eval "env_val=\${$env_var:-}"
 		fi
 
 		# Determine source and effective value
@@ -725,11 +728,12 @@ HEADER
 	echo "[OK] Set ${dotpath}=${value}" >&2
 
 	# Show if an env var would override this
-	local env_val
+	local env_val=""
 	local env_var
 	env_var=$(_config_env_map "$dotpath")
 	if [[ -n "$env_var" ]]; then
-		env_val="${!env_var:-}"
+		# Use eval for Bash 3.2 compat — ${!var:-} causes "bad substitution" on 3.2
+		eval "env_val=\${$env_var:-}"
 		if [[ -n "$env_val" ]]; then
 			echo "[WARN] Environment variable ${env_var}=${env_val} will override this setting" >&2
 		fi


### PR DESCRIPTION
## Summary

- Replace `${!env_var:-}` with `eval "env_val=\${$env_var:-}"` at 3 locations in `config-helper.sh` (lines 333, 527, 732)
- The `${!var:-default}` indirect expansion syntax causes "bad substitution" on macOS `/bin/bash` 3.2.57
- This caused `config_get` to fail silently during `pulse-wrapper.sh` startup, making `MAX_WORKERS_CAP` and `QUALITY_DEBT_CAP_PCT` fall back to hardcoded defaults instead of reading from `settings.json`

## Verification

- ShellCheck clean (zero violations)
- Tested `config_get` with env var override set → returns override value
- Tested `config_get` with env var unset → falls through to JSONC config value
- No remaining `${!env_var:-}` instances in the file

Closes #4929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved compatibility with older Bash versions for environment variable configuration handling.
  * Fixed issues with environment override initialization to prevent errors when configuration variables are not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->