### PR TITLE
fix: add sqlite3 to setup.sh required dependencies

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -443,11 +443,11 @@ check_requirements() {
 	fi
 	if ! command -v sqlite3 >/dev/null 2>&1; then
 		missing_deps+=("sqlite3")
-		# Package name varies: sqlite3 on Debian/Ubuntu/brew, sqlite on Fedora/Arch/Alpine
+		# Package name varies: sqlite3 on Debian/Ubuntu/apt, sqlite on brew/Fedora/Arch/Alpine
 		local pkg_mgr
 		pkg_mgr=$(detect_package_manager)
 		case "$pkg_mgr" in
-		apt | brew) missing_packages+=("sqlite3") ;;
+		apt) missing_packages+=("sqlite3") ;;
 		*) missing_packages+=("sqlite") ;;
 		esac
 	fi

--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -441,6 +441,16 @@ check_requirements() {
 		missing_deps+=("rg")
 		missing_packages+=("ripgrep")
 	fi
+	if ! command -v sqlite3 >/dev/null 2>&1; then
+		missing_deps+=("sqlite3")
+		# Package name varies: sqlite3 on Debian/Ubuntu/brew, sqlite on Fedora/Arch/Alpine
+		local pkg_mgr
+		pkg_mgr=$(detect_package_manager)
+		case "$pkg_mgr" in
+		apt | brew) missing_packages+=("sqlite3") ;;
+		*) missing_packages+=("sqlite") ;;
+		esac
+	fi
 
 	if [[ ${#missing_deps[@]} -gt 0 ]]; then
 		print_warning "Missing required dependencies: ${missing_deps[*]}"


### PR DESCRIPTION
## Summary

- Add `sqlite3` to `check_requirements()` in `setup-modules/core.sh` so it is installed during `setup.sh`
- sqlite3 is used by 700+ callsites (memory system, worktree registry, supervisor, observability) but was never installed, causing silent failures on Linux systems without it pre-installed
- Handles cross-distro package name mapping: `sqlite3` for Debian/Ubuntu/brew, `sqlite` for Fedora/Arch/Alpine

## Changes

- `setup-modules/core.sh`: Added sqlite3 check to `check_requirements()` with distro-aware package name resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced setup dependency validation to detect sqlite3 presence and automatically resolve the appropriate package name across different package managers, integrating this into the non-interactive install flow to ensure smoother cross-distro handling and fewer manual interventions during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->