### PR TITLE
#4937: fix(wp-helper): replace bash -lc with bash -c to stop SSH stdout being swallowed

### DIFF
--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -336,15 +336,16 @@ execute_wp_via_ssh() {
 		fi
 
 		# Pass wp args as positional parameters to avoid shell interpolation issues
+		# Use bash -c (not -lc) to avoid login shell startup files that may redirect/swallow stdout
 		# shellcheck disable=SC2016 # $1/$@ expand on the remote shell, not locally
-		sshpass -f "$expanded_password_file" ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" bash -lc 'cd "$1" && shift && wp "$@"' _ "$wp_path" "${wp_args[@]}"
+		sshpass -f "$expanded_password_file" ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" bash -c 'cd "$1" && shift && wp "$@"' _ "$wp_path" "${wp_args[@]}"
 		return $?
 		;;
 	hetzner | cloudways | cloudron)
 		# SSH key-based authentication (preferred, -n prevents stdin consumption in loops)
-		# Pass wp args as positional parameters to avoid shell interpolation issues
+		# Use bash -c (not -lc) to avoid login shell startup files that may redirect/swallow stdout
 		# shellcheck disable=SC2016 # $1/$@ expand on the remote shell, not locally
-		ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" bash -lc 'cd "$1" && shift && wp "$@"' _ "$wp_path" "${wp_args[@]}"
+		ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" bash -c 'cd "$1" && shift && wp "$@"' _ "$wp_path" "${wp_args[@]}"
 		return $?
 		;;
 	*)
@@ -379,7 +380,7 @@ run_wp_command() {
 	local site_type
 	site_type=$(echo "$site_config" | jq -r '.type')
 
-	print_info "Running on $site_name ($site_type): wp ${wp_args[*]}"
+	print_info "Running on $site_name ($site_type): wp ${wp_args[*]}" >&2
 
 	# Execute directly without eval
 	execute_wp_via_ssh "$site_config" "${wp_args[@]}"


### PR DESCRIPTION
## Summary

- Replaces `bash -lc` with `bash -c` in both SSH execution paths (`hostinger|closte` and `hetzner|cloudways|cloudron`) so remote login shell startup files (`~/.bash_profile`, `~/.bashrc`) are not sourced — these files on managed hosting servers commonly redirect or close stdout before `wp` runs, causing all WP-CLI output to be silently discarded.
- Redirects the `[INFO] Running on ...` diagnostic line in `run_wp_command` to stderr, so callers can capture clean WP-CLI stdout without mixing it with log output.

## Root cause

`bash -lc` invokes a login shell on the remote server. Cloudways (and other managed hosts) source startup files that include guards like `mesg n` or `tty -s && mesg n`, or other interactive-shell redirections that close/redirect fd1 before the `wp` command runs. The `-n` SSH flag (stdin from `/dev/null`) is unrelated — the issue is the login shell, not stdin.

Direct SSH without `bash -lc` (as in the reporter's working example) bypasses this entirely.

## Changes

- `.agents/scripts/wp-helper.sh` — two `bash -lc` → `bash -c` substitutions (lines 340, 347 pre-patch); one `print_info` redirected to stderr (line 382 pre-patch)

## Verification

ShellCheck: zero new violations (SC1091 info pre-existing, unrelated to this change).

Functional verification requires a live Cloudways/Hetzner/Cloudron site — the reporter can confirm with:

```bash
wp-helper.sh <any-cloudways-site> "option get siteurl"
# Expected: [INFO] line on stderr + site URL on stdout
```

Closes #4937