### PR TITLE
t4946: eliminate redundant detect_package_manager call in check_requirements

### DIFF
--- a/setup-modules/core.sh
+++ b/setup-modules/core.sh
@@ -427,6 +427,10 @@ check_requirements() {
 	local missing_deps=()
 	local missing_packages=()
 
+	# Detect package manager once for both package-name resolution and installation
+	local pkg_manager
+	pkg_manager=$(detect_package_manager)
+
 	# Check for required commands
 	# Format: command-name package-name (same when identical)
 	if ! command -v jq >/dev/null 2>&1; then
@@ -443,10 +447,8 @@ check_requirements() {
 	fi
 	if ! command -v sqlite3 >/dev/null 2>&1; then
 		missing_deps+=("sqlite3")
-		# Package name varies: sqlite3 on Debian/Ubuntu/apt, sqlite on brew/Fedora/Arch/Alpine
-		local pkg_mgr
-		pkg_mgr=$(detect_package_manager)
-		case "$pkg_mgr" in
+		# Package name varies: sqlite3 on Debian/Ubuntu (apt), sqlite on Homebrew/Fedora/Arch/Alpine
+		case "$pkg_manager" in
 		apt) missing_packages+=("sqlite3") ;;
 		*) missing_packages+=("sqlite") ;;
 		esac
@@ -454,9 +456,6 @@ check_requirements() {
 
 	if [[ ${#missing_deps[@]} -gt 0 ]]; then
 		print_warning "Missing required dependencies: ${missing_deps[*]}"
-
-		local pkg_manager
-		pkg_manager=$(detect_package_manager)
 
 		if [[ "$pkg_manager" == "unknown" ]]; then
 			print_error "Could not detect package manager"


### PR DESCRIPTION
## Summary

- Call `detect_package_manager` once at the top of `check_requirements()` instead of twice (once inside the sqlite3 check, once in the install block)
- Unifies the variable name from `pkg_mgr` / `pkg_manager` to a single `pkg_manager` used throughout

## Findings addressed

| Severity | Reviewer | Finding | Status |
|----------|----------|---------|--------|
| HIGH | CodeRabbit | Homebrew formula is `sqlite`, not `sqlite3` | Already fixed in PR #4935 commit 13f05ab |
| MEDIUM | Gemini | Redundant `detect_package_manager` call | **Fixed in this PR** |

The HIGH finding was already addressed during PR #4935 — the current code correctly maps `apt` to `sqlite3` and everything else (including `brew`) to `sqlite`. This PR addresses the remaining MEDIUM finding.

## Changes

- `setup-modules/core.sh`: Hoist `detect_package_manager` call to the top of the dependency-check block, remove the two redundant calls downstream

Closes #4946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved package manager detection logic in the setup process for better efficiency and code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->