### PR TITLE
t4944: Use printf %q for wp_args logging to handle spaces

### DIFF
--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -380,7 +380,7 @@ run_wp_command() {
 	local site_type
 	site_type=$(echo "$site_config" | jq -r '.type')
 
-	print_info "Running on $site_name ($site_type): wp ${wp_args[*]}" >&2
+	print_info "Running on $site_name ($site_type): wp $(printf '%q ' "${wp_args[@]}")" >&2
 
 	# Execute directly without eval
 	execute_wp_via_ssh "$site_config" "${wp_args[@]}"

--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -380,7 +380,9 @@ run_wp_command() {
 	local site_type
 	site_type=$(echo "$site_config" | jq -r '.type')
 
-	print_info "Running on $site_name ($site_type): wp $(printf '%q ' "${wp_args[@]}")" >&2
+	local args_str
+	args_str=$(printf '%q ' "${wp_args[@]}")
+	print_info "Running on $site_name ($site_type): wp ${args_str% }" >&2
 
 	# Execute directly without eval
 	execute_wp_via_ssh "$site_config" "${wp_args[@]}"
@@ -400,8 +402,10 @@ run_on_category() {
 
 	load_config
 
+	local args_str
+	args_str=$(printf '%q ' "${wp_args[@]}")
 	print_info "Running on all sites in category: $category"
-	print_info "Command: wp ${wp_args[*]}"
+	print_info "Command: wp ${args_str% }"
 	echo ""
 
 	local site_keys
@@ -443,8 +447,10 @@ run_on_all() {
 
 	load_config
 
+	local args_str
+	args_str=$(printf '%q ' "${wp_args[@]}")
 	print_info "Running on ALL sites"
-	print_info "Command: wp ${wp_args[*]}"
+	print_info "Command: wp ${args_str% }"
 	echo ""
 
 	local site_keys


### PR DESCRIPTION
## Summary

- Replaces `${wp_args[*]}` with `$(printf '%q ' "${wp_args[@]}")` in `wp-helper.sh:383` so arguments containing spaces are logged with proper quoting, making debug output accurate and unambiguous.

Closes #4944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging safety in internal helper scripts to safely preserve command arguments without shell expansion, enhancing audit trail accuracy and preventing issues with special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->