### PR TITLE
t4943: Add mktemp and trap guidance to secret-as-argument fallback

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -264,7 +264,7 @@ When referencing specific functions or code include the pattern `file_path:line_
   - SAFE: `aidevops secret NAME -- cmd` — injects as env var with automatic output redaction
   - SAFE: `SSH_AUTH_SOCK=... ssh ...` — env-based auth, no secret in argv
   - The subprocess must read the value from its environment (`getenv()` in C/PHP, `process.env` in Node, `os.environ` in Python, `ENV[]` in Ruby), not from `$1`/`argv`.
-  - When the target program only accepts secrets as arguments (no env var support), write the secret to a temporary file (mode 0600), pass the file path as the argument, and delete the file immediately after. This is a last resort — prefer programs that support env var or stdin input.
+  - When the target program only accepts secrets as arguments (no env var support), write the secret to a temporary file (e.g., using `mktemp`, with mode 0600), pass the file path as the argument, and ensure the file is deleted immediately after (e.g., using a `trap` command for cleanup on exit or error). This is a last resort — prefer programs that support env var or stdin input.
   - For SSH/remote commands: `ssh host "ENV_VAR='value' command"` passes the secret in the remote shell's environment, not as an argument to `ssh` itself. Alternatively, use `ssh -o SendEnv=VAR` with server-side `AcceptEnv` configuration.
 #
 # 8.3 Post-execution secret detection (t4939, layer 2)


### PR DESCRIPTION
## Summary

- Adds explicit `mktemp` and `trap` guidance to the secret-as-argument fallback pattern in `build.txt:267`, making the temporary file pattern more specific and secure.
- Addresses unactioned review feedback from PR #4941 (Gemini Code Assist, medium severity).

## Changes

Single prose edit to `.agents/prompts/build.txt` line 267:
- **Before**: "write the secret to a temporary file (mode 0600)... and delete the file immediately after"
- **After**: "write the secret to a temporary file (e.g., using `mktemp`, with mode 0600)... and ensure the file is deleted immediately after (e.g., using a `trap` command for cleanup on exit or error)"

Closes #4943