### PR TITLE
4958: address full-loop auto-release review feedback

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -837,12 +837,12 @@ if [[ "$REPO_SLUG" == "marcusquinn/aidevops" ]]; then
   git -C "$CANONICAL_DIR" pull origin main
 
   # Bump patch version (updates VERSION, package.json, setup.sh, etc.)
-  "$HOME/.aidevops/agents/scripts/version-manager.sh" bump patch
+  (cd "$CANONICAL_DIR" && "$HOME/.aidevops/agents/scripts/version-manager.sh" bump patch)
   NEW_VERSION=$(cat "$CANONICAL_DIR/VERSION")
 
   # Commit, tag, push, create release
   git -C "$CANONICAL_DIR" add -A
-  git -C "$CANONICAL_DIR" commit -m "chore(release): bump version to ${NEW_VERSION}"
+  git -C "$CANONICAL_DIR" commit -m "chore(release): bump version to v${NEW_VERSION}"
   git -C "$CANONICAL_DIR" push origin main
   git -C "$CANONICAL_DIR" tag "v${NEW_VERSION}"
   git -C "$CANONICAL_DIR" push origin "v${NEW_VERSION}"
@@ -853,7 +853,7 @@ if [[ "$REPO_SLUG" == "marcusquinn/aidevops" ]]; then
     --generate-notes
 
   # Deploy locally
-  "$CANONICAL_DIR/setup.sh" 2>/dev/null || true
+  "$CANONICAL_DIR/setup.sh" --non-interactive || true
 fi
 ```
 


### PR DESCRIPTION
## Summary
- update the auto-release snippet to run `version-manager.sh` from the canonical repo directory to avoid worktree-local version bumps
- align release commit message with tag format by using the `v` prefix in `NEW_VERSION`
- make local deployment explicitly non-interactive and keep failures non-blocking without suppressing output

## Verification
- `markdown-formatter check .agents/scripts/commands/full-loop.md`

Closes #4958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version bump execution context during releases.
  * Updated deployment setup invocation to use non-interactive mode.
  * Enhanced commit message formatting for version tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->