### PR TITLE
t4958: Address critical review findings in full-loop.md auto-release snippet

### DIFF
--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -837,7 +837,7 @@ if [[ "$REPO_SLUG" == "marcusquinn/aidevops" ]]; then
   git -C "$CANONICAL_DIR" pull origin main
 
   # Bump patch version (updates VERSION, package.json, setup.sh, etc.)
-  "$HOME/.aidevops/agents/scripts/version-manager.sh" bump patch
+  (cd "$CANONICAL_DIR" && "$HOME/.aidevops/agents/scripts/version-manager.sh" bump patch)
   NEW_VERSION=$(cat "$CANONICAL_DIR/VERSION")
 
   # Commit, tag, push, create release
@@ -853,7 +853,7 @@ if [[ "$REPO_SLUG" == "marcusquinn/aidevops" ]]; then
     --generate-notes
 
   # Deploy locally
-  "$CANONICAL_DIR/setup.sh" 2>/dev/null || true
+  "$CANONICAL_DIR/setup.sh" --non-interactive || true
 fi
 ```
 


### PR DESCRIPTION
## Summary

- **CRITICAL fix**: `version-manager.sh` now runs inside `(cd "$CANONICAL_DIR" && ...)` subshell so the version bump targets the main repo checkout, not the worktree
- **HIGH fix**: `setup.sh` now passes `--non-interactive` flag and no longer suppresses stderr with `2>/dev/null`
- **MEDIUM dismissed**: Commit message `v`-prefix suggestion conflicts with established repo convention (`git log --grep='chore(release)'` shows bare versions in commits, `v`-prefix only on tags)

## Motivation

PR #4957 introduced auto-release after merge. Gemini Code Assist flagged 3 issues in the bash snippet. Two are genuine bugs that would cause the version bump to write to the wrong directory and `setup.sh` to hang in headless mode. The third is a style suggestion that contradicts the existing convention.

## Verification

- Markdown lint: clean (no violations)
- Single file changed: `.agents/scripts/commands/full-loop.md`
- Diff is minimal (2 lines changed) — easy to review

Closes #4958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment and versioning automation robustness through enhanced script execution environment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->