### PR TITLE
t4960: Address quality-debt findings in gh-failure-miner-helper.sh

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -545,11 +545,10 @@ create_systemic_issues() {
 
 	# Ensure source label exists on repos that will receive issues
 	if [[ "$dry_run" != "true" ]]; then
-		local seen_repos=""
 		local repo_entry
 		for repo_entry in $(printf '%s\n' "$clusters_json" | jq -r '.[].repo' | sort -u); do
 			gh label create "source:ci-failure-miner" --repo "$repo_entry" \
-				--description "Auto-created by gh-failure-miner-helper.sh" --color "C2E0C6" --force 2>/dev/null || true
+				--description "Auto-created by gh-failure-miner-helper.sh" --color "C2E0C6" --force || true
 		done
 	fi
 


### PR DESCRIPTION
## Summary

- Remove unused `seen_repos` variable (initialized but never read)
- Replace `2>/dev/null || true` with `|| true` on `gh label create` so auth/permission errors remain visible for debugging

## Source

Review findings from PR #4955 (Gemini Code Assist), tracked in #4960.

## Verification

- ShellCheck passes clean (zero violations)
- Both findings independently verified before fix

Closes #4960