### PR TITLE
t4962: clarify temp-file secret handling guidance

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -264,7 +264,7 @@ When referencing specific functions or code include the pattern `file_path:line_
   - SAFE: `aidevops secret NAME -- cmd` — injects as env var with automatic output redaction
   - SAFE: `SSH_AUTH_SOCK=... ssh ...` — env-based auth, no secret in argv
   - The subprocess must read the value from its environment (`getenv()` in C/PHP, `process.env` in Node, `os.environ` in Python, `ENV[]` in Ruby), not from `$1`/`argv`.
-  - When the target program only accepts secrets as arguments (no env var support), write the secret to a temporary file (e.g., using `mktemp`, with mode 0600), pass the file path as the argument, and ensure the file is deleted immediately after (e.g., using a `trap` command for cleanup on exit or error). This is a last resort — prefer programs that support env var or stdin input.
+  - When the target program only accepts secrets as arguments (no env var support), write the secret to a temporary file (e.g., using `mktemp` to create it and `chmod 0600` to set permissions), pass the file path as the argument, and ensure robust cleanup on script exit (e.g., using a `trap` command on the `EXIT` signal). This is a last resort — prefer programs that support env var or stdin input.
   - For SSH/remote commands: `ssh host "ENV_VAR='value' command"` passes the secret in the remote shell's environment, not as an argument to `ssh` itself. Alternatively, use `ssh -o SendEnv=VAR` with server-side `AcceptEnv` configuration.
 #
 # 8.3 Post-execution secret detection (t4939, layer 2)


### PR DESCRIPTION
## Summary
- Updates `.agents/prompts/build.txt` to match the remaining Gemini medium-severity review feedback from PR #4951.
- Clarifies portability by explicitly naming `mktemp` creation plus `chmod 0600` permission hardening.
- Clarifies cleanup intent by describing `trap` on `EXIT` for robust script-exit cleanup semantics.

Closes #4962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for secure secret handling to enhance privacy and reliability when passing secrets to programs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->