### PR TITLE
t1508: Email-to-action agent doc

### DIFF
--- a/.agents/services/email/email-actions.md
+++ b/.agents/services/email/email-actions.md
@@ -1,0 +1,507 @@
+---
+description: Email-to-action agent — convert inbound emails into todos, reports, opportunities, and legal case files
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: false
+  grep: true
+  webfetch: false
+  task: true
+---
+
+# Email-to-Action Agent
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Bridge between inbound email and the rest of the system — todos, reports, legal case files, opportunities, support escalations
+- **Helper**: `scripts/email-triage-helper.sh [command] [options]`
+- **Config**: `configs/email-actions-config.json` (from `.json.txt` template)
+- **IMAP folders**: `Projects/`, `Legal/`, `Reports/`, `Opportunities/`, `Support/`
+- **Database**: `~/.aidevops/.agent-workspace/email-agent/actions.db` (SQLite)
+
+**Decision rule**: Every inbound email falls into one of five action categories. Classify first, then act.
+
+| Category | Action | IMAP folder |
+|----------|--------|-------------|
+| Task trigger | Create TODO entry | `Projects/` |
+| Report | Triage and file | `Reports/` |
+| Opportunity | Flag for review | `Opportunities/` |
+| Legal/compliance | Assemble case file | `Legal/` |
+| Support | Escalate or resolve | `Support/` |
+
+**Quick commands:**
+
+```bash
+# Triage a single email
+email-triage-helper.sh triage --message-id <id>
+
+# Batch triage inbox
+email-triage-helper.sh batch --folder INBOX --since 24h
+
+# Assemble legal case file
+email-triage-helper.sh legal-case --thread-id <id> --output ~/cases/
+
+# Extract newsletter training material
+email-triage-helper.sh extract-training --sender newsletter@domain.com
+```
+
+<!-- AI-CONTEXT-END -->
+
+## Classification Decision Tree
+
+Before acting on any email, classify it. Classification drives the action — wrong classification wastes time or loses signal.
+
+```text
+Inbound email
+    │
+    ├── Is it from a known automated sender (report, alert, notification)?
+    │       YES → Report triage (see "Report Triage" section)
+    │       NO  ↓
+    │
+    ├── Does it contain a legal notice, contract, dispute, or compliance requirement?
+    │       YES → Legal case file (see "Legal Case Files" section)
+    │       NO  ↓
+    │
+    ├── Does it describe a business opportunity, partnership, or lead?
+    │       YES → Opportunity flag (see "Opportunities" section)
+    │       NO  ↓
+    │
+    ├── Is it a support request, complaint, or escalation from a customer/user?
+    │       YES → Support escalation (see "Support Communication" section)
+    │       NO  ↓
+    │
+    ├── Does it require a concrete action (deadline, deliverable, decision)?
+    │       YES → Create TODO (see "Email-to-Todo Patterns" section)
+    │       NO  ↓
+    │
+    └── Archive or unsubscribe (no action required)
+```
+
+## Email-to-Todo Patterns
+
+### When to Create a Task
+
+Create a TODO entry when the email contains:
+
+- An explicit deadline ("please respond by...", "renewal on...", "expires...")
+- A deliverable you own ("can you send...", "please review...", "we need...")
+- A decision that blocks someone else
+- A follow-up you promised in a previous thread
+
+Do **not** create a task for:
+- FYI emails with no action required
+- Automated reports (file under Reports instead)
+- Newsletters (extract training material instead)
+- Emails you've already acted on in the same session
+
+### Task Creation Pattern
+
+```bash
+# Claim a task ID atomically
+task_id=$(claim-task-id.sh --repo-path ~/Git/aidevops --title "Email: <subject>")
+
+# Add to TODO.md with email reference
+# Format: - [ ] tNNN Description ~Xh ref=email:<message-id>
+```
+
+### Task Brief from Email
+
+Every task created from an email needs a brief at `todo/tasks/{task_id}-brief.md`. Populate it from the email:
+
+| Brief field | Source |
+|-------------|--------|
+| Origin | Email subject + sender + date |
+| What | The action requested |
+| Why | Context from the email body |
+| How | Your planned approach |
+| Acceptance criteria | The email's stated requirements or deadline |
+
+### IMAP Archiving
+
+After creating the task, move the email to `Projects/` in IMAP:
+
+```bash
+email-triage-helper.sh move --message-id <id> --folder Projects/ \
+  --tag "task:tNNN"
+```
+
+## Report Triage
+
+Automated reports arrive from SEO tools, domain registrars, hosting providers, analytics platforms, and monitoring services. Most require no action — but some contain time-sensitive signals.
+
+### Source Authentication
+
+Before acting on any report email, verify the sender is legitimate:
+
+```bash
+# Check SPF/DKIM/DMARC alignment
+email-triage-helper.sh verify-sender --message-id <id>
+
+# Check against known sender list
+email-triage-helper.sh check-sender --from "reports@domain.com"
+```
+
+**Known-sender validation**: Maintain a list of expected report senders in `configs/email-actions-config.json` under `trusted_report_senders`. Any report from an unknown sender should be treated as suspicious until DNS checks pass.
+
+**DNS checks to run:**
+
+```bash
+# Verify SPF record
+dig TXT <sender-domain> | grep "v=spf1"
+
+# Verify DMARC policy
+dig TXT _dmarc.<sender-domain>
+
+# Check if domain is recently registered (phishing signal)
+whois <sender-domain> | grep "Creation Date"
+```
+
+### Report Categories and Actions
+
+| Report type | Signal to act on | Action |
+|-------------|-----------------|--------|
+| SEO ranking report | Significant drop (>10 positions) or new opportunity | Create task, tag `#seo` |
+| Domain expiry notice | Expiry within 60 days | Create task with deadline, tag `#renewal` |
+| SSL certificate expiry | Expiry within 30 days | Create task with deadline, tag `#infra` |
+| Hosting/server alert | Downtime, capacity warning | Create task immediately, tag `#infra` |
+| Analytics anomaly | Traffic spike or drop >20% | Flag for review, tag `#analytics` |
+| Optimization suggestion | Actionable recommendation | Add to backlog, tag `#optimization` |
+| Renewal invoice | Payment due | Create task with deadline, tag `#billing` |
+| Compliance notification | Regulatory requirement | Legal case file (see below) |
+
+### Report Filing
+
+Reports that require no immediate action should still be filed for reference:
+
+```bash
+# File report with metadata
+email-triage-helper.sh file-report \
+  --message-id <id> \
+  --category seo \
+  --folder Reports/SEO/ \
+  --summary "Ranking report: 3 drops, 1 new opportunity"
+```
+
+### Renewal and Expiry Tracking
+
+Domain, SSL, and subscription renewals are high-value signals — missing them causes outages or data loss.
+
+```bash
+# Extract expiry dates from email body
+email-triage-helper.sh extract-dates --message-id <id>
+
+# Add to renewal tracker
+email-triage-helper.sh track-renewal \
+  --service "domain.com" \
+  --expiry "2026-12-01" \
+  --source-email <message-id>
+```
+
+Renewal tasks should be created 60 days before expiry (domains), 30 days (SSL), and 14 days (subscriptions). Set `blocked-by:` to the renewal task on any task that depends on the service.
+
+## Legal Case Files
+
+Legal emails include: contracts, disputes, GDPR/DMCA/legal notices, court documents, compliance requirements, and any email from a lawyer or legal department.
+
+### Chain of Custody
+
+Legal case files must preserve chain of custody metadata:
+
+- Original email headers (From, To, Date, Message-ID, Received)
+- Timestamp of receipt (server-side, not client-side)
+- Any attachments in original format
+- Thread context (all prior messages in the thread)
+
+**Never modify the original email.** Export a read-only copy; keep the original in IMAP under `Legal/`.
+
+### Case File Assembly
+
+```bash
+# Assemble a case file from a thread
+email-triage-helper.sh legal-case \
+  --thread-id <id> \
+  --output ~/cases/case-$(date +%Y%m%d)-<description>/ \
+  --format pdf \
+  --include-headers \
+  --include-attachments
+
+# Output structure:
+# case-20260316-vendor-dispute/
+# ├── thread-export.pdf       (full thread, headers visible)
+# ├── thread-export.txt       (plain text, machine-readable)
+# ├── metadata.json           (message IDs, timestamps, participants)
+# ├── attachments/            (original files, unchanged)
+# └── chain-of-custody.txt    (hash of each file + timestamp)
+```
+
+### Chain of Custody File Format
+
+```text
+Case: <description>
+Assembled: <ISO timestamp>
+Assembler: <agent session ID>
+
+Files:
+  thread-export.pdf   SHA256: <hash>
+  thread-export.txt   SHA256: <hash>
+  metadata.json       SHA256: <hash>
+  attachments/<file>  SHA256: <hash>
+
+Original IMAP folder: Legal/<subfolder>
+Original Message-IDs: <list>
+```
+
+### IMAP Folder Structure for Legal
+
+```text
+Legal/
+├── Active/          # Ongoing matters
+├── Resolved/        # Closed matters
+├── Contracts/       # Signed agreements
+├── Notices/         # GDPR, DMCA, compliance
+└── Disputes/        # Vendor, customer, IP disputes
+```
+
+### Legal Task Creation
+
+Every legal email requires a task, even if the action is "review and decide":
+
+```bash
+# Create legal task with high priority
+claim-task-id.sh --repo-path ~/Git/aidevops \
+  --title "Legal: <subject>" \
+  --priority high \
+  --tag legal
+```
+
+Legal tasks should never be auto-dispatched to workers without human review. Add `assignee:human` to the TODO entry.
+
+## Opportunities
+
+Business opportunities include: partnership proposals, inbound sales leads, collaboration requests, press/media inquiries, and investor outreach.
+
+### Opportunity Qualification
+
+Not every opportunity email deserves a response. Qualify before acting:
+
+| Signal | Weight |
+|--------|--------|
+| Personalised (references your work specifically) | High |
+| From a known company or individual | High |
+| Clear value proposition | Medium |
+| Specific ask (not a mass blast) | Medium |
+| Generic template, no personalisation | Low |
+| No company name or verifiable identity | Low |
+
+```bash
+# Flag opportunity for review
+email-triage-helper.sh flag-opportunity \
+  --message-id <id> \
+  --score <1-5> \
+  --notes "Partnership proposal from Acme — references our SEO work"
+```
+
+### Opportunity IMAP Folders
+
+```text
+Opportunities/
+├── Hot/             # Score 4-5, respond within 24h
+├── Warm/            # Score 2-3, respond within 1 week
+├── Cold/            # Score 1, archive after 30 days
+└── Responded/       # Awaiting reply
+```
+
+### CRM Integration
+
+High-score opportunities should be added to the CRM pipeline:
+
+```bash
+# Add to CRM (FluentCRM or equivalent)
+email-triage-helper.sh crm-add \
+  --message-id <id> \
+  --pipeline "Inbound Opportunities" \
+  --stage "New Lead" \
+  --contact-email <sender>
+```
+
+## Support Communication
+
+Support emails come from customers, users, or partners who need help. The goal is to understand the receiver's capabilities and route to the right resolution path.
+
+### Understanding Receiver Capabilities
+
+Before responding to a support email, assess what the receiver can actually do:
+
+| Receiver type | Capabilities | Escalation path |
+|---------------|-------------|-----------------|
+| End user (non-technical) | UI actions only | Step-by-step guide, screenshots |
+| Technical user | CLI, config files | Direct instructions |
+| Business contact | Decisions, approvals | Executive summary, options |
+| Legal/compliance | Formal process | Structured response, documentation |
+
+### Escalation Patterns
+
+```text
+Support email received
+    │
+    ├── Can it be resolved with information? → Draft response, no task needed
+    │
+    ├── Does it require a code fix or config change? → Create task, tag #support
+    │
+    ├── Is it a billing or account issue? → Route to accounts agent
+    │
+    ├── Is it a legal or compliance issue? → Route to legal case file workflow
+    │
+    └── Is it a complaint that could escalate? → Flag for human review
+```
+
+### Response Drafting
+
+```bash
+# Draft a support response
+email-triage-helper.sh draft-response \
+  --message-id <id> \
+  --template support-reply \
+  --tone professional \
+  --output draft.md
+```
+
+Review all drafted responses before sending. The agent drafts; a human (or the email-agent with explicit approval) sends.
+
+### Support IMAP Folders
+
+```text
+Support/
+├── Open/            # Awaiting resolution
+├── Pending/         # Waiting for customer reply
+├── Resolved/        # Closed tickets
+└── Escalated/       # Requires human or specialist review
+```
+
+## Newsletter Training Material Extraction
+
+Newsletters from domain experts, industry publications, and thought leaders contain high-value training material: writing style, domain knowledge, terminology, and content patterns.
+
+### Which Newsletters to Extract From
+
+Extract training material from newsletters that demonstrate:
+
+- **Domain expertise**: Deep technical or industry knowledge relevant to your work
+- **Writing style**: Tone, structure, or format you want to emulate
+- **Content patterns**: How they structure arguments, explain concepts, or present data
+
+Do **not** extract from:
+- Mass-market newsletters with generic content
+- Newsletters you're subscribed to for news only (not style/knowledge)
+- Newsletters with paywalled or proprietary content (check terms)
+
+### Extraction Workflow
+
+```bash
+# Extract domain knowledge from a newsletter
+email-triage-helper.sh extract-training \
+  --message-id <id> \
+  --type domain-knowledge \
+  --output ~/.aidevops/.agent-workspace/training/newsletters/
+
+# Extract writing style examples
+email-triage-helper.sh extract-training \
+  --message-id <id> \
+  --type writing-style \
+  --output ~/.aidevops/.agent-workspace/training/style/
+
+# Batch extract from a sender
+email-triage-helper.sh extract-training \
+  --sender "newsletter@domain.com" \
+  --since 90d \
+  --type domain-knowledge
+```
+
+### Training Material Format
+
+Extracted material is stored as structured markdown:
+
+```markdown
+---
+source: newsletter@domain.com
+date: 2026-03-16
+type: domain-knowledge
+topics: [seo, content-strategy]
+---
+
+# Key concepts extracted
+
+- <concept 1>
+- <concept 2>
+
+# Notable phrasing
+
+> <quote worth preserving>
+
+# Writing patterns
+
+- <structural pattern observed>
+```
+
+### Newsletter IMAP Folders
+
+```text
+Newsletters/
+├── Training/        # High-value, extract from these
+├── Reference/       # Keep for reference, don't extract
+└── Unsubscribe/     # Queue for unsubscription
+```
+
+## Configuration
+
+### Config Template
+
+`configs/email-actions-config.json.txt` — copy to `configs/email-actions-config.json` and customise.
+
+Key settings:
+
+```json
+{
+  "trusted_report_senders": [
+    "reports@semrush.com",
+    "noreply@google.com",
+    "alerts@cloudflare.com"
+  ],
+  "renewal_warning_days": {
+    "domain": 60,
+    "ssl": 30,
+    "subscription": 14
+  },
+  "opportunity_auto_crm_threshold": 4,
+  "legal_folder": "Legal/Active/",
+  "training_output_dir": "~/.aidevops/.agent-workspace/training/newsletters/",
+  "support_escalation_keywords": [
+    "legal action", "refund", "complaint", "GDPR", "data breach"
+  ]
+}
+```
+
+## Security
+
+- **Sender verification before action**: Always run DNS checks before acting on report emails
+- **Legal files are read-only**: Never modify exported case files after assembly
+- **Chain of custody hashes**: Verify file hashes before submitting legal case files
+- **No credential logging**: Support responses must never include credentials or internal system details
+- **Opportunity scoring is local**: Scores and notes stay in the local database, not in email replies
+- **Training material**: Respect newsletter terms of service; do not redistribute extracted content
+
+## Related
+
+- `services/email/email-agent.md` — Outbound mission email (sending, verification codes)
+- `services/email/mission-email.md` — Mission-scoped email threading
+- `services/email/ses.md` — SES configuration and management
+- `services/email/email-health-check.md` — Email deliverability health
+- `tools/document/document-creation.md` — PDF generation for legal case files
+- `workflows/plans.md` — Task creation workflow
+- `scripts/claim-task-id.sh` — Atomic task ID allocation
+- `services/payments/procurement.md` — Renewal and billing management


### PR DESCRIPTION
## Summary

- Adds `services/email/email-actions.md` — the action bridge between inbound email and the rest of the system
- Covers all five action categories: todos, report triage, legal case files, opportunities, and support escalation
- Includes source authentication (DNS checks), chain of custody for legal files, newsletter training material extraction, and IMAP folder conventions

## Acceptance Criteria

- [x] `services/email/email-actions.md` exists with `AI-CONTEXT-START`/`AI-CONTEXT-END` markers
- [x] Report triage guidance documented (with source authentication and DNS checks)
- [x] Legal case file assembly workflow documented (chain of custody, IMAP folders, hash verification)
- [x] Support communication escalation patterns documented

Closes #4989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Email-to-Action Agent documentation describing email classification workflows, action routing for tasks/reports/opportunities, configuration guidance, and security/compliance requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->