### PR TITLE
t1496: Email template library with reusable templates for common email types

### DIFF
--- a/.agents/templates/email/email-attachments-manifest.json
+++ b/.agents/templates/email/email-attachments-manifest.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Common email attachments library manifest. Tracks frequently-sent files so the email agent can attach them by name rather than path. Files are stored in ~/.aidevops/.agent-workspace/email-attachments/ and referenced by their 'id' field.",
+  "attachments_directory": "~/.aidevops/.agent-workspace/email-attachments/",
+  "attachments": [
+    {
+      "id": "company-info",
+      "filename": "company-info.pdf",
+      "description": "Company overview document with key facts, team, and capabilities",
+      "category": "corporate",
+      "last_updated": null,
+      "notes": "Update quarterly or after major company changes"
+    },
+    {
+      "id": "rate-card",
+      "filename": "rate-card.pdf",
+      "description": "Current pricing and rate card for services",
+      "category": "sales",
+      "last_updated": null,
+      "notes": "Update when pricing changes. Remove outdated versions immediately."
+    },
+    {
+      "id": "brochure",
+      "filename": "brochure.pdf",
+      "description": "Marketing brochure with service descriptions and case studies",
+      "category": "marketing",
+      "last_updated": null,
+      "notes": "Update annually or when services change significantly"
+    },
+    {
+      "id": "terms-of-service",
+      "filename": "terms-of-service.pdf",
+      "description": "Current terms of service document",
+      "category": "legal",
+      "last_updated": null,
+      "notes": "Must match the version published on the website"
+    },
+    {
+      "id": "privacy-policy",
+      "filename": "privacy-policy.pdf",
+      "description": "Current privacy policy document",
+      "category": "legal",
+      "last_updated": null,
+      "notes": "Must match the version published on the website"
+    },
+    {
+      "id": "nda-template",
+      "filename": "nda-template.pdf",
+      "description": "Standard mutual NDA template for new business relationships",
+      "category": "legal",
+      "last_updated": null,
+      "notes": "Have legal review before sending to new counterparties"
+    },
+    {
+      "id": "onboarding-guide",
+      "filename": "onboarding-guide.pdf",
+      "description": "Client onboarding guide with setup steps and key contacts",
+      "category": "operations",
+      "last_updated": null,
+      "notes": "Update when onboarding process changes"
+    }
+  ],
+  "categories": [
+    "corporate",
+    "sales",
+    "marketing",
+    "legal",
+    "operations",
+    "technical"
+  ],
+  "usage": {
+    "add_attachment": "Add a new entry to the 'attachments' array with a unique 'id', then place the file in the attachments_directory.",
+    "reference_in_template": "Use {{ATTACHMENT:id}} in email templates to auto-attach the file. The email agent resolves the id to the file path via this manifest.",
+    "update_file": "Replace the file in the attachments_directory and update 'last_updated' to the current ISO date."
+  }
+}

--- a/.agents/templates/email/faq-answer.md
+++ b/.agents/templates/email/faq-answer.md
@@ -1,0 +1,22 @@
+# FAQ Answer - templated response to a frequently asked question
+<!-- Use: when responding to a question you have answered before. Copy this template, -->
+<!-- replace the placeholders, and save as a named FAQ (e.g., faq-pricing.md, faq-onboarding.md). -->
+<!-- Tone: helpful, clear. Provide the answer directly, then offer further resources. -->
+<!-- Extensibility: create project-specific FAQ templates by copying this file and -->
+<!-- filling in the fixed content, leaving only RECIPIENT_NAME and SENDER fields as variables. -->
+Subject: Re: {{ORIGINAL_SUBJECT}}
+
+Dear {{RECIPIENT_NAME}},
+
+Thank you for your question about {{FAQ_TOPIC}}.
+
+{{FAQ_ANSWER}}
+
+For more information, you can also refer to {{RESOURCE_LINK}}.
+
+If you have any further questions, please do not hesitate to ask.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/follow-up-delayed.md
+++ b/.agents/templates/email/follow-up-delayed.md
@@ -1,0 +1,17 @@
+# Delayed Response Follow-up - apologise for a late reply and provide the answer
+<!-- Use: when you are replying to a message later than expected or promised. -->
+<!-- Tone: apologetic but brief, then move straight to substance. -->
+Subject: Re: {{ORIGINAL_SUBJECT}}
+
+Dear {{RECIPIENT_NAME}},
+
+Apologies for the delayed response on {{TOPIC}}.
+
+{{RESPONSE_BODY}}
+
+Please let me know if you have any questions or if anything has changed since your original message.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/follow-up-pending-casual.md
+++ b/.agents/templates/email/follow-up-pending-casual.md
@@ -1,0 +1,15 @@
+# Pending Response Follow-up (Casual) - informal check-in on an unanswered message
+<!-- Use: for colleagues, familiar contacts, or internal team communication. -->
+<!-- See also: follow-up-pending.md (standard), follow-up-pending-formal.md (external/legal). -->
+Subject: Re: {{ORIGINAL_SUBJECT}} - Quick Check-in
+
+Hi {{RECIPIENT_NAME}},
+
+Just circling back on my email from {{ORIGINAL_SEND_DATE}} about {{TOPIC}}.
+
+No worries if you have not had a chance to look at it yet -- just wanted to make sure it did not get buried.
+
+Let me know if you need anything from me.
+
+Thanks,
+{{SENDER_NAME}}

--- a/.agents/templates/email/follow-up-pending-formal.md
+++ b/.agents/templates/email/follow-up-pending-formal.md
@@ -1,0 +1,20 @@
+# Pending Response Follow-up (Formal) - formal follow-up on an unanswered message
+<!-- Use: for external contacts, vendors, or official correspondence where formality is expected. -->
+<!-- See also: follow-up-pending.md (standard), follow-up-pending-casual.md (internal/familiar). -->
+Subject: Re: {{ORIGINAL_SUBJECT}} - Follow-up Correspondence
+
+Dear {{RECIPIENT_TITLE}} {{RECIPIENT_LAST_NAME}},
+
+I am writing to follow up on my correspondence of {{ORIGINAL_SEND_DATE}} regarding {{TOPIC}}.
+
+As of this date, I have not yet received a response and would appreciate an update at your earliest convenience.
+
+If additional information is required from our side to facilitate a reply, please advise accordingly.
+
+I look forward to your response.
+
+Yours faithfully,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}
+{{COMPANY_ADDRESS}}

--- a/.agents/templates/email/follow-up-pending.md
+++ b/.agents/templates/email/follow-up-pending.md
@@ -1,0 +1,19 @@
+# Pending Response Follow-up - check in on a message that has not received a reply
+<!-- Use: when you sent a message and have not heard back within a reasonable timeframe. -->
+<!-- Tone: polite, assumes good intent (they may have missed it). -->
+Subject: Re: {{ORIGINAL_SUBJECT}} - Following Up
+
+Dear {{RECIPIENT_NAME}},
+
+I hope this message finds you well.
+
+I am following up on my previous email from {{ORIGINAL_SEND_DATE}} regarding {{TOPIC}}.
+
+I wanted to check whether you had a chance to review it and if there is any additional information I can provide.
+
+I appreciate your time and look forward to hearing from you.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/holding-response.md
+++ b/.agents/templates/email/holding-response.md
@@ -1,0 +1,20 @@
+# Holding Response - manage expectations when a full answer is not yet available
+<!-- Use: when you need more time, information, or input from others before you can give a complete answer. -->
+<!-- Tone: transparent, professional. Explains the reason for the delay without over-apologising. -->
+Subject: Re: {{ORIGINAL_SUBJECT}} - Update
+
+Dear {{RECIPIENT_NAME}},
+
+Thank you for your patience regarding {{TOPIC}}.
+
+I am still working on this and wanted to give you a brief update.
+{{STATUS_UPDATE}}
+
+I expect to have a complete response for you by {{EXPECTED_COMPLETION_DATE}}.
+
+Please let me know if your timeline has changed or if there is anything I can address in the interim.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/introduction-referral.md
+++ b/.agents/templates/email/introduction-referral.md
@@ -1,0 +1,21 @@
+# Introduction / Referral - introduce two parties who should connect
+<!-- Use: when connecting two people who would benefit from knowing each other. -->
+<!-- Tone: warm, brief. Give each party enough context to continue the conversation without you. -->
+Subject: Introduction: {{PERSON_A_NAME}} <> {{PERSON_B_NAME}}
+
+Dear {{PERSON_A_NAME}} and {{PERSON_B_NAME}},
+
+I would like to introduce you to each other.
+
+{{PERSON_A_NAME}} -- {{PERSON_A_DESCRIPTION}}
+
+{{PERSON_B_NAME}} -- {{PERSON_B_DESCRIPTION}}
+
+{{REASON_FOR_INTRODUCTION}}
+
+I will leave it to you both to find a time to connect.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/meeting-confirm.md
+++ b/.agents/templates/email/meeting-confirm.md
@@ -1,0 +1,24 @@
+# Meeting Confirmation - confirm agreed meeting details
+<!-- Use: after a meeting time has been agreed upon, to confirm all details in writing. -->
+<!-- Tone: concise, confirmatory. Include all logistics so the recipient has everything in one email. -->
+Subject: Confirmed: {{MEETING_TOPIC}} - {{MEETING_DATE}}
+
+Dear {{RECIPIENT_NAME}},
+
+This is to confirm our meeting with the following details:
+
+**Topic:** {{MEETING_TOPIC}}
+**Date:** {{MEETING_DATE}}
+**Time:** {{MEETING_TIME}} ({{TIMEZONE}})
+**Duration:** {{ESTIMATED_DURATION}}
+**Location:** {{MEETING_LOCATION_OR_LINK}}
+
+**Agenda:**
+{{AGENDA_ITEMS}}
+
+Please let me know if anything needs to change before then.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/meeting-propose-times.md
+++ b/.agents/templates/email/meeting-propose-times.md
@@ -1,0 +1,24 @@
+# Meeting - Propose Times - suggest available slots for a meeting
+<!-- Use: when initiating a meeting request and offering time options. -->
+<!-- Tone: accommodating, efficient. Offer 2-3 options to reduce back-and-forth. -->
+Subject: Meeting Request: {{MEETING_TOPIC}}
+
+Dear {{RECIPIENT_NAME}},
+
+I would like to schedule a meeting to discuss {{MEETING_TOPIC}}.
+
+I have the following times available:
+
+1. {{OPTION_1}}
+2. {{OPTION_2}}
+3. {{OPTION_3}}
+
+The meeting should take approximately {{ESTIMATED_DURATION}}.
+{{MEETING_LOCATION_OR_LINK}}
+
+Please let me know which time works best for you, or suggest an alternative if none of these are convenient.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/project-update-casual.md
+++ b/.agents/templates/email/project-update-casual.md
@@ -1,0 +1,25 @@
+# Project Update (Casual) - quick status update for internal team or familiar contacts
+<!-- Use: for team standups, internal Slack-to-email summaries, or informal check-ins. -->
+<!-- See also: project-update.md (standard), project-update-formal.md (executive/external). -->
+Subject: {{PROJECT_NAME}} Update - {{UPDATE_DATE}}
+
+Hi {{RECIPIENT_NAME}},
+
+Quick update on {{PROJECT_NAME}}:
+
+**Done:**
+{{COMPLETED_ITEMS}}
+
+**In progress:**
+{{IN_PROGRESS_ITEMS}}
+
+**Up next:**
+{{UPCOMING_ITEMS}}
+
+**Blockers:**
+{{BLOCKERS}}
+
+Let me know if anything looks off or if priorities have shifted.
+
+Cheers,
+{{SENDER_NAME}}

--- a/.agents/templates/email/project-update-formal.md
+++ b/.agents/templates/email/project-update-formal.md
@@ -1,0 +1,35 @@
+# Project Update (Formal) - structured status report for executive or external stakeholders
+<!-- Use: for board members, investors, external clients, or contractual reporting obligations. -->
+<!-- See also: project-update.md (standard), project-update-casual.md (internal team). -->
+Subject: {{PROJECT_NAME}} - Formal Status Report ({{UPDATE_DATE}})
+
+Dear {{RECIPIENT_TITLE}} {{RECIPIENT_LAST_NAME}},
+
+Please find below the status report for {{PROJECT_NAME}} as of {{UPDATE_DATE}}.
+
+**Overall Status:** {{OVERALL_STATUS}}
+**Reporting Period:** {{PERIOD_START}} to {{PERIOD_END}}
+
+**1. Accomplishments**
+{{COMPLETED_ITEMS}}
+
+**2. Work in Progress**
+{{IN_PROGRESS_ITEMS}}
+
+**3. Planned Activities**
+{{UPCOMING_ITEMS}}
+
+**4. Risks and Mitigations**
+{{BLOCKERS}}
+
+**5. Budget and Timeline**
+{{BUDGET_TIMELINE_STATUS}}
+
+The next report is scheduled for {{NEXT_UPDATE_DATE}}.
+
+Please do not hesitate to contact me should you require additional detail on any of the above.
+
+Yours sincerely,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/project-update.md
+++ b/.agents/templates/email/project-update.md
@@ -1,0 +1,31 @@
+# Project Update - notify stakeholders of project status
+<!-- Use: periodic status updates to clients, team members, or stakeholders. -->
+<!-- Tone: informative, structured. Adapt frequency (weekly, milestone-based) to the audience. -->
+Subject: {{PROJECT_NAME}} - Status Update ({{UPDATE_DATE}})
+
+Dear {{RECIPIENT_NAME}},
+
+Here is the latest update on {{PROJECT_NAME}}.
+
+**Status:** {{OVERALL_STATUS}}
+
+**Completed since last update:**
+{{COMPLETED_ITEMS}}
+
+**Currently in progress:**
+{{IN_PROGRESS_ITEMS}}
+
+**Upcoming:**
+{{UPCOMING_ITEMS}}
+
+**Blockers or risks:**
+{{BLOCKERS}}
+
+The next update is scheduled for {{NEXT_UPDATE_DATE}}.
+
+Please let me know if you have any questions or would like to discuss any of these items.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/receipt-acknowledgement-casual.md
+++ b/.agents/templates/email/receipt-acknowledgement-casual.md
@@ -1,0 +1,15 @@
+# Receipt Acknowledgement (Casual) - quick confirmation for colleagues or familiar contacts
+<!-- Use: for internal team members, long-standing contacts, or informal communication. -->
+<!-- See also: receipt-acknowledgement.md (standard), receipt-acknowledgement-formal.md (external/legal). -->
+Subject: Re: {{ORIGINAL_SUBJECT}}
+
+Hi {{RECIPIENT_NAME}},
+
+Got your message about {{TOPIC}} -- thanks for sending it over.
+
+I will take a look and get back to you by {{EXPECTED_RESPONSE_DATE}}.
+
+Ping me if anything is urgent before then.
+
+Cheers,
+{{SENDER_NAME}}

--- a/.agents/templates/email/receipt-acknowledgement-formal.md
+++ b/.agents/templates/email/receipt-acknowledgement-formal.md
@@ -1,0 +1,20 @@
+# Receipt Acknowledgement (Formal) - confirm receipt with formal/legal-adjacent tone
+<!-- Use: for external contacts, new business relationships, legal or contractual correspondence. -->
+<!-- See also: receipt-acknowledgement.md (standard), receipt-acknowledgement-casual.md (internal/familiar). -->
+Subject: Re: {{ORIGINAL_SUBJECT}} - Acknowledgement of Receipt
+
+Dear {{RECIPIENT_TITLE}} {{RECIPIENT_LAST_NAME}},
+
+I write to acknowledge receipt of your correspondence dated {{ORIGINAL_DATE}} regarding {{TOPIC}}.
+
+Your message has been received and is currently under review.
+
+I anticipate providing a substantive response no later than {{EXPECTED_RESPONSE_DATE}}.
+
+Should the matter require immediate attention prior to that date, please do not hesitate to contact me directly at {{SENDER_PHONE}} or via this email address.
+
+Yours sincerely,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}
+{{COMPANY_ADDRESS}}

--- a/.agents/templates/email/receipt-acknowledgement.md
+++ b/.agents/templates/email/receipt-acknowledgement.md
@@ -1,0 +1,19 @@
+# Receipt Acknowledgement - confirm receipt of a message and set expectations for a full response
+<!-- Use: when you receive an email that needs a substantive reply but you cannot respond immediately. -->
+<!-- Tone: professional, reassuring. Use the formal variant for external/new contacts. -->
+Subject: Re: {{ORIGINAL_SUBJECT}}
+
+Dear {{RECIPIENT_NAME}},
+
+Thank you for your message regarding {{TOPIC}}.
+
+I wanted to confirm that I have received your email and it is on my radar.
+
+I will review the details and get back to you with a full response by {{EXPECTED_RESPONSE_DATE}}.
+
+If anything is urgent in the meantime, please do not hesitate to reach out directly.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/reminder-final-notice.md
+++ b/.agents/templates/email/reminder-final-notice.md
@@ -1,0 +1,21 @@
+# Final Notice Reminder - last reminder before escalation or alternative action (Level 3 of 3)
+<!-- Use: when two prior reminders have gone unanswered and you need to take action. -->
+<!-- Tone: formal, clear consequences. Not hostile, but unambiguous. -->
+Subject: Final Notice: {{REQUEST_SUBJECT}}
+
+Dear {{RECIPIENT_NAME}},
+
+This is my final follow-up regarding {{REQUEST_DESCRIPTION}}.
+
+I have previously contacted you on {{FIRST_REMINDER_DATE}} and {{SECOND_REMINDER_DATE}} without receiving a response.
+
+The original deadline of {{ORIGINAL_DEADLINE}} has now passed by {{DAYS_OVERDUE}} days.
+
+If I do not hear from you by {{FINAL_DEADLINE}}, I will need to {{ALTERNATIVE_ACTION}}.
+
+I would prefer to resolve this directly and remain available to discuss at your convenience.
+
+Regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/reminder-firm.md
+++ b/.agents/templates/email/reminder-firm.md
@@ -1,0 +1,22 @@
+# Firm Reminder - second reminder with increased urgency (Level 2 of 3)
+<!-- Use: when the polite reminder received no response and the matter is becoming time-sensitive. -->
+<!-- Tone: direct, professional. States the impact of further delay. -->
+<!-- Escalation: if no response, use reminder-final-notice.md next. -->
+Subject: Follow-up Required: {{REQUEST_SUBJECT}}
+
+Dear {{RECIPIENT_NAME}},
+
+I am writing to follow up again on {{REQUEST_DESCRIPTION}}.
+
+I previously reached out on {{FIRST_REMINDER_DATE}} and have not yet received a response.
+
+This item is now {{DAYS_OVERDUE}} days past the original deadline of {{ORIGINAL_DEADLINE}}, and the delay is beginning to impact {{IMPACT_DESCRIPTION}}.
+
+Could you please provide an update or confirm a revised timeline by {{RESPONSE_NEEDED_BY}}?
+
+Thank you for your attention to this matter.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/reminder-polite.md
+++ b/.agents/templates/email/reminder-polite.md
@@ -1,0 +1,20 @@
+# Polite Reminder - first reminder for an outstanding request (Level 1 of 3)
+<!-- Use: first follow-up when a deadline has passed or a response is overdue. -->
+<!-- Tone: friendly, assumes the recipient is busy. No pressure. -->
+<!-- Escalation: if no response, use reminder-firm.md next. -->
+Subject: Friendly Reminder: {{REQUEST_SUBJECT}}
+
+Dear {{RECIPIENT_NAME}},
+
+I hope you are doing well.
+
+I wanted to send a gentle reminder about {{REQUEST_DESCRIPTION}}.
+
+The original deadline was {{ORIGINAL_DEADLINE}}, and I wanted to check on the status.
+
+No rush if you need a bit more time -- just let me know an updated timeline and I will plan accordingly.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/thank-you-post-delivery.md
+++ b/.agents/templates/email/thank-you-post-delivery.md
@@ -1,0 +1,19 @@
+# Thank You - Post Delivery - express appreciation after receiving work or a deliverable
+<!-- Use: when someone has completed work for you, delivered a product, or provided a service. -->
+<!-- Tone: genuine, specific. Mention what was delivered and its impact. -->
+Subject: Thank You for {{DELIVERABLE_NAME}}
+
+Dear {{RECIPIENT_NAME}},
+
+I wanted to take a moment to thank you for delivering {{DELIVERABLE_NAME}}.
+
+{{SPECIFIC_APPRECIATION}}
+
+The quality of the work is excellent and it will help us {{IMPACT_DESCRIPTION}}.
+
+We look forward to continuing to work together.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}

--- a/.agents/templates/email/thank-you-post-meeting.md
+++ b/.agents/templates/email/thank-you-post-meeting.md
@@ -1,0 +1,22 @@
+# Thank You - Post Meeting - follow up after a meeting with appreciation and next steps
+<!-- Use: within 24 hours of a meeting to reinforce key points and maintain momentum. -->
+<!-- Tone: appreciative, action-oriented. Summarise outcomes, not the entire discussion. -->
+Subject: Thank You - {{MEETING_TOPIC}}
+
+Dear {{RECIPIENT_NAME}},
+
+Thank you for taking the time to meet today regarding {{MEETING_TOPIC}}.
+
+I appreciated the discussion, particularly around {{KEY_DISCUSSION_POINT}}.
+
+**Agreed next steps:**
+{{NEXT_STEPS}}
+
+I will follow up on my action items by {{FOLLOW_UP_DATE}}.
+
+Please let me know if I have missed anything or if your priorities have shifted.
+
+Best regards,
+{{SENDER_NAME}}
+{{SENDER_TITLE}}
+{{COMPANY_NAME}}


### PR DESCRIPTION
## Summary

- Add 20 reusable email templates in `.agents/templates/email/` covering 10 communication patterns: acknowledgements, holding responses, follow-ups, escalating reminders (3 levels), project updates, FAQ answers, meeting scheduling, introductions/referrals, and thank-you messages
- Include formal and casual variants for 3 template types (receipt-acknowledgement, follow-up-pending, project-update) with guidance comments on when to use each tone
- Add common attachments library manifest (`email-attachments-manifest.json`) defining the structure for frequently-sent files (company info, rate cards, NDAs, etc.)

## Template Categories

| Category | Templates | Variants |
|----------|-----------|----------|
| Holding patterns | receipt-acknowledgement, holding-response | formal, casual |
| Follow-ups | follow-up-delayed, follow-up-pending | formal, casual |
| Reminders (escalating) | reminder-polite, reminder-firm, reminder-final-notice | - |
| Project updates | project-update | formal, casual |
| FAQ answers | faq-answer | - |
| Meeting scheduling | meeting-propose-times, meeting-confirm | - |
| Introductions | introduction-referral | - |
| Thank you | thank-you-post-meeting, thank-you-post-delivery | - |

## Acceptance Criteria

- [x] 20 template files created (requirement: 10+)
- [x] Every template has `Subject:` line and `{{VARIABLE}}` placeholders
- [x] Formal and casual variants for 3 template types (6 variant files)
- [x] Common attachments manifest structure documented
- [x] Templates follow one-paragraph-per-sentence rule
- [x] Compatible with existing `email-agent-helper.sh` `{{VAR}}` syntax

Closes #4977