### PR TITLE
t1516: Outreach slash commands

### DIFF
--- a/.agents/scripts/commands/email-campaign.md
+++ b/.agents/scripts/commands/email-campaign.md
@@ -1,0 +1,123 @@
+---
+description: Create and manage newsletter or broadcast email campaigns
+agent: Build+
+mode: subagent
+---
+
+Manage newsletter and broadcast campaigns: list setup, send workflow, and analytics review.
+
+Arguments: $ARGUMENTS
+
+## Workflow
+
+### Step 1: Parse Campaign Intent
+
+Parse `$ARGUMENTS` into:
+
+- Campaign type: `newsletter`, `broadcast`, `sequence`, `help`
+- Action: `create`, `schedule`, `send`, `pause`, `status`, `analytics`
+- Optional audience segment/tag filter
+
+If campaign type is missing, request it and show examples.
+
+### Step 2: Validate Required Inputs
+
+For create/schedule/send actions, confirm:
+
+- Subject line and preview text
+- Audience segment/list
+- Single primary CTA
+- Send window/timezone
+- Compliance footer and unsubscribe handling
+
+Before sending, run preflight checks on content and delivery readiness.
+
+### Step 3: Execute Campaign Operation
+
+Use the appropriate helper workflow:
+
+```bash
+# Create campaign draft
+~/.aidevops/agents/scripts/email-agent-helper.sh send --mission "$MISSION_ID" --template "$TEMPLATE"
+
+# Content and infrastructure preflight
+~/.aidevops/agents/scripts/email-health-check-helper.sh precheck "$DOMAIN" "$HTML_FILE"
+
+# Delivery readiness checks
+~/.aidevops/agents/scripts/email-delivery-test-helper.sh report "$DOMAIN"
+```
+
+If the user asks for CRM-first campaign operations (segmentation, automations, broadcasts), route to the configured CRM tooling flow for contact/list operations.
+
+### Step 4: Return Campaign Report
+
+Include:
+
+- Campaign type, ID, and current state
+- Segment/list size and send count
+- Send window and cadence
+- Key metrics: open, click, reply, unsubscribe, spam complaint
+- Recommended optimization action
+
+### Step 5: Offer Follow-up Actions
+
+```text
+Actions:
+1. A/B test two subject lines
+2. Re-segment non-openers for resend
+3. Tune CTA placement and copy
+4. Schedule next campaign in sequence
+5. Export campaign performance summary
+```
+
+## Options
+
+| Command | Purpose |
+|---------|---------|
+| `/email-campaign newsletter create "Weekly AI Ops"` | Create newsletter draft |
+| `/email-campaign broadcast schedule campaign_101 tomorrow-09:00` | Schedule broadcast send |
+| `/email-campaign sequence status seq_77` | Show sequence state and progress |
+| `/email-campaign newsletter analytics campaign_101` | Show campaign metrics snapshot |
+| `/email-campaign broadcast pause campaign_101` | Pause pending or active campaign |
+
+## Examples
+
+**Create and schedule newsletter:**
+
+```text
+User: /email-campaign newsletter create "Friday Product Brief"
+AI: Creating newsletter campaign draft...
+
+    Campaign: Friday Product Brief (camp_101)
+    Type: Newsletter
+    Segment: Engaged subscribers (8,420 contacts)
+    State: Draft
+
+    Next steps:
+    1. Run precheck on content and domain
+    2. Schedule send window (Tue-Thu 09:00-11:00 local)
+```
+
+**Analytics review:**
+
+```text
+User: /email-campaign newsletter analytics camp_101
+AI: Campaign analytics for camp_101:
+
+    Delivered: 8,297
+    Open rate: 37.2%
+    Click rate: 4.8%
+    Reply rate: 1.3%
+    Unsubscribe: 0.21%
+    Complaints: 0.03%
+
+    Recommendation:
+    Keep audience/offer stable and test two new subject lines next send
+```
+
+## Related
+
+- `content/distribution/email.md` - Newsletter and sequence strategy
+- `services/email/email-testing.md` - Design and delivery testing workflow
+- `services/email/email-delivery-test.md` - Inbox placement and spam scoring
+- `services/email/email-health-check.md` - DNS and content precheck

--- a/.agents/scripts/commands/email-outreach.md
+++ b/.agents/scripts/commands/email-outreach.md
@@ -1,0 +1,129 @@
+---
+description: Launch and manage cold outreach campaigns across supported platforms
+agent: Build+
+mode: subagent
+---
+
+Launch or operate outbound cold email campaigns.
+
+Arguments: $ARGUMENTS
+
+## Workflow
+
+### Step 1: Determine Platform and Action
+
+Parse `$ARGUMENTS` into two parts:
+
+- Platform: `smartlead`, `instantly`, `manyreach`, or `help`
+- Action: `launch`, `warmup`, `leads`, `pause`, `status`, `analytics`
+
+If no platform is provided, ask for one and show supported options.
+
+### Step 2: Validate Campaign Inputs
+
+Before launching, require:
+
+- Campaign objective and offer
+- Sending mailbox/domain to use
+- Lead source or lead list path
+- Daily volume target and warmup status
+
+Enforce safety defaults from outreach policy:
+
+- New mailbox ramp: `5-8/day` to `17-20/day` over 4 weeks
+- Hard cap: `100/day` per mailbox including follow-ups
+- Include unsubscribe and legal footer controls
+
+### Step 3: Run Platform Action
+
+Use the relevant helper command based on chosen platform:
+
+```bash
+# Smartlead
+~/.aidevops/agents/scripts/smartlead-helper.sh create-campaign "$CAMPAIGN_NAME"
+
+# Instantly
+~/.aidevops/agents/scripts/instantly-helper.sh create-campaign "$CAMPAIGN_NAME"
+
+# ManyReach
+~/.aidevops/agents/scripts/manyreach-helper.sh create-campaign "$CAMPAIGN_NAME"
+
+# Add leads (platform-specific helper)
+~/.aidevops/agents/scripts/<platform>-helper.sh import-leads "$LEADS_FILE"
+
+# Configure warmup and sending limits
+~/.aidevops/agents/scripts/<platform>-helper.sh set-limits "$CAMPAIGN_ID" "$DAILY_LIMIT"
+```
+
+### Step 4: Present Campaign State
+
+Return a concise operations report with:
+
+- Platform, campaign ID, and status
+- Mailboxes attached and current warmup stage
+- Lead count and sequence status
+- Risk flags (bounce, complaint, reply handling)
+- Recommended next action
+
+### Step 5: Offer Follow-up Actions
+
+```text
+Actions:
+1. Add another lead segment
+2. Adjust daily volume and warmup settings
+3. Pause mailbox with low health
+4. View reply classifications
+5. Export campaign analytics
+```
+
+## Options
+
+| Command | Purpose |
+|---------|---------|
+| `/email-outreach smartlead launch "UK SaaS Founders"` | Create and launch campaign in Smartlead |
+| `/email-outreach instantly leads campaign_123 leads.csv` | Import leads into an Instantly campaign |
+| `/email-outreach manyreach warmup campaign_456 20` | Set warmup/daily volume in ManyReach |
+| `/email-outreach smartlead pause campaign_123` | Pause campaign immediately |
+| `/email-outreach instantly analytics campaign_123` | Show campaign analytics snapshot |
+
+## Examples
+
+**Launch campaign:**
+
+```text
+User: /email-outreach smartlead launch "US agency owners"
+AI: Launching Smartlead campaign...
+
+    Platform: Smartlead
+    Campaign: US agency owners (cmp_98321)
+    Status: Draft created
+
+    Mailboxes:
+    - send1@outreach-domain.com (week 2 warmup, 12/day)
+    - send2@outreach-domain.com (week 1 warmup, 8/day)
+
+    Next steps:
+    1. Import lead segment
+    2. Activate sequence after compliance check
+```
+
+**Operational status check:**
+
+```text
+User: /email-outreach instantly status campaign_123
+AI: Campaign status for campaign_123:
+
+    State: Running
+    Leads: 1,240 total, 118 contacted today
+    Replies: 37 (positive: 9, neutral: 18, objection: 10)
+    Risk: Low (bounce 1.4%, complaints 0.05%)
+
+    Recommendation:
+    Keep volume stable for 48h before increasing
+```
+
+## Related
+
+- `services/outreach/cold-outreach.md` - Strategy and guardrails
+- `services/email/email-health-check.md` - Authentication and infrastructure checks
+- `content/distribution/email.md` - Email copy and campaign performance guidance


### PR DESCRIPTION
## Summary
- add `/email-outreach` command documentation for cold outreach platform selection, launch workflows, safety guardrails, and operational reporting
- add `/email-campaign` command documentation for newsletter/broadcast lifecycle management, preflight checks, and analytics workflows
- align both commands with existing email command patterns and related strategy/testing docs for discoverable follow-up actions

## Verification
- `bash .agents/scripts/markdown-formatter.sh lint ".agents/scripts/commands/email-outreach.md"`
- `bash .agents/scripts/markdown-formatter.sh lint ".agents/scripts/commands/email-campaign.md"`

Closes #4997