### PR TITLE
t1493: Email mailbox helper

### DIFF
--- a/.agents/scripts/email-mailbox-helper.sh
+++ b/.agents/scripts/email-mailbox-helper.sh
@@ -1,0 +1,861 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2034,SC2155
+set -euo pipefail
+
+# Email Mailbox Helper Script
+# IMAP/JMAP adapter and mailbox operations for AI assistants.
+# Connects to any email provider via IMAP (JMAP planned for Phase 4).
+#
+# Usage:
+#   email-mailbox-helper.sh accounts [--test]
+#   email-mailbox-helper.sh inbox [account] [--limit N] [--offset N] [--folder FOLDER]
+#   email-mailbox-helper.sh read [account] --uid UID [--folder FOLDER]
+#   email-mailbox-helper.sh folders [account]
+#   email-mailbox-helper.sh create-folder [account] --folder PATH
+#   email-mailbox-helper.sh send [account] --to ADDR --subject SUBJ --body TEXT
+#   email-mailbox-helper.sh move [account] --uid UID --dest FOLDER [--folder FOLDER]
+#   email-mailbox-helper.sh flag [account] --uid UID --flag NAME [--clear] [--folder FOLDER]
+#   email-mailbox-helper.sh search [account] --query "IMAP SEARCH" [--folder FOLDER] [--limit N]
+#   email-mailbox-helper.sh smart-mailbox [account] --name NAME --criteria "SEARCH"
+#   email-mailbox-helper.sh sync [account] [--folder FOLDER] [--full]
+#   email-mailbox-helper.sh help
+#
+# Requires: python3 (for IMAP operations), jq
+# Config: configs/email-providers.json (from .json.txt template)
+# Credentials: gopass show -o email-imap-{account} (via IMAP_PASSWORD env var)
+#
+# Part of aidevops email system (t1493)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+readonly CONFIG_DIR="${SCRIPT_DIR}/../configs"
+readonly PROVIDERS_TEMPLATE="${CONFIG_DIR}/email-providers.json.txt"
+readonly PROVIDERS_CONFIG="${CONFIG_DIR}/email-providers.json"
+readonly IMAP_ADAPTER="${SCRIPT_DIR}/email_imap_adapter.py"
+readonly MAILBOX_WORKSPACE="${HOME}/.aidevops/.agent-workspace/email-mailbox"
+
+# ============================================================================
+# Dependency checks
+# ============================================================================
+
+check_dependencies() {
+	local missing=0
+
+	if ! command -v python3 &>/dev/null; then
+		print_error "python3 is required for IMAP operations"
+		missing=1
+	fi
+
+	if ! command -v jq &>/dev/null; then
+		print_error "jq is required. Install: brew install jq (macOS) or apt install jq (Linux)"
+		missing=1
+	fi
+
+	if [[ ! -f "$IMAP_ADAPTER" ]]; then
+		print_error "IMAP adapter not found: $IMAP_ADAPTER"
+		missing=1
+	fi
+
+	if [[ "$missing" -eq 1 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+load_providers_config() {
+	# Try working config first, fall back to template
+	local config_file="$PROVIDERS_CONFIG"
+	if [[ ! -f "$config_file" ]]; then
+		config_file="$PROVIDERS_TEMPLATE"
+	fi
+
+	if [[ ! -f "$config_file" ]]; then
+		print_error "Provider config not found"
+		print_info "Expected: $PROVIDERS_CONFIG or $PROVIDERS_TEMPLATE"
+		return 1
+	fi
+
+	echo "$config_file"
+	return 0
+}
+
+# Get provider config for an account slug
+get_provider_config() {
+	local account="$1"
+	local config_file
+	config_file=$(load_providers_config) || return 1
+
+	local provider_json
+	provider_json=$(jq -r ".providers.\"$account\" // empty" "$config_file" 2>/dev/null)
+
+	if [[ -z "$provider_json" ]]; then
+		print_error "Account '$account' not found in provider config"
+		print_info "Available providers:"
+		jq -r '.providers | keys[]' "$config_file" 2>/dev/null | while IFS= read -r key; do
+			local name
+			name=$(jq -r ".providers.\"$key\".name" "$config_file" 2>/dev/null)
+			echo "  - $key ($name)" >&2
+		done
+		return 1
+	fi
+
+	echo "$provider_json"
+	return 0
+}
+
+# Get IMAP connection details from provider config
+get_imap_details() {
+	local provider_json="$1"
+
+	local host port security
+	host=$(echo "$provider_json" | jq -r '.imap.host // empty')
+	port=$(echo "$provider_json" | jq -r '.imap.port // 993')
+	security=$(echo "$provider_json" | jq -r '.imap.security // "TLS"')
+
+	if [[ -z "$host" ]]; then
+		print_error "No IMAP host configured for this provider"
+		return 1
+	fi
+
+	echo "${host}|${port}|${security}"
+	return 0
+}
+
+# Get SMTP connection details from provider config
+get_smtp_details() {
+	local provider_json="$1"
+
+	local host port security
+	host=$(echo "$provider_json" | jq -r '.smtp.host // empty')
+	port=$(echo "$provider_json" | jq -r '.smtp.port // 587')
+	security=$(echo "$provider_json" | jq -r '.smtp.security // "STARTTLS"')
+
+	if [[ -z "$host" ]]; then
+		print_error "No SMTP host configured for this provider"
+		return 1
+	fi
+
+	echo "${host}|${port}|${security}"
+	return 0
+}
+
+# Get IMAP password from gopass (never printed, passed as env var)
+get_imap_password() {
+	local account="$1"
+	local secret_name="email-imap-${account}"
+
+	if command -v gopass &>/dev/null; then
+		local password
+		password=$(gopass show -o "aidevops/${secret_name}" 2>/dev/null) || password=""
+		if [[ -n "$password" ]]; then
+			echo "$password"
+			return 0
+		fi
+	fi
+
+	# Try credentials.sh fallback
+	local cred_file="${HOME}/.config/aidevops/credentials.sh"
+	if [[ -f "$cred_file" ]]; then
+		local var_name
+		var_name="IMAP_PASSWORD_$(echo "$account" | tr '[:lower:]-' '[:upper:]_')"
+		local password
+		# Source in subshell to avoid polluting environment
+		password=$(
+			# shellcheck source=/dev/null
+			source "$cred_file" 2>/dev/null
+			eval "echo \"\${${var_name}:-}\""
+		)
+		if [[ -n "$password" ]]; then
+			echo "$password"
+			return 0
+		fi
+	fi
+
+	print_error "No IMAP password found for account '$account'"
+	print_info "Store via: aidevops secret set ${secret_name}"
+	print_info "Or set IMAP_PASSWORD_$(echo "$account" | tr '[:lower:]-' '[:upper:]_') in credentials.sh"
+	return 1
+}
+
+# Get IMAP username (email address) for an account
+get_imap_user() {
+	local account="$1"
+
+	# Try gopass for the username
+	if command -v gopass &>/dev/null; then
+		local user
+		user=$(gopass show "aidevops/email-imap-${account}" user 2>/dev/null) || user=""
+		if [[ -n "$user" ]]; then
+			echo "$user"
+			return 0
+		fi
+	fi
+
+	# Try credentials.sh
+	local cred_file="${HOME}/.config/aidevops/credentials.sh"
+	if [[ -f "$cred_file" ]]; then
+		local var_name
+		var_name="IMAP_USER_$(echo "$account" | tr '[:lower:]-' '[:upper:]_')"
+		local user
+		user=$(
+			# shellcheck source=/dev/null
+			source "$cred_file" 2>/dev/null
+			eval "echo \"\${${var_name}:-}\""
+		)
+		if [[ -n "$user" ]]; then
+			echo "$user"
+			return 0
+		fi
+	fi
+
+	# Try IMAP_USER env var
+	local env_var="IMAP_USER_$(echo "$account" | tr '[:lower:]-' '[:upper:]_')"
+	local user="${!env_var:-}"
+	if [[ -n "$user" ]]; then
+		echo "$user"
+		return 0
+	fi
+
+	print_error "No IMAP username found for account '$account'"
+	print_info "Store via: gopass edit aidevops/email-imap-${account} (add 'user: you@example.com')"
+	return 1
+}
+
+# Run the IMAP adapter with connection details
+run_imap_adapter() {
+	local account="$1"
+	local command="$2"
+	shift 2
+	local extra_args=("$@")
+
+	local provider_json
+	provider_json=$(get_provider_config "$account") || return 1
+
+	local imap_details
+	imap_details=$(get_imap_details "$provider_json") || return 1
+
+	local host port security
+	IFS='|' read -r host port security <<<"$imap_details"
+
+	local user
+	user=$(get_imap_user "$account") || return 1
+
+	local password
+	password=$(get_imap_password "$account") || return 1
+
+	# Pass password via environment variable (never as argv)
+	IMAP_PASSWORD="$password" python3 "$IMAP_ADAPTER" \
+		--host "$host" \
+		--port "$port" \
+		--user "$user" \
+		--security "$security" \
+		"$command" \
+		"${extra_args[@]}"
+
+	return $?
+}
+
+# ============================================================================
+# Commands
+# ============================================================================
+
+cmd_accounts() {
+	local test_connectivity=false
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--test)
+			test_connectivity=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+
+	local config_file
+	config_file=$(load_providers_config) || return 1
+
+	print_info "Configured email providers:"
+	echo ""
+
+	local providers
+	providers=$(jq -r '.providers | keys[]' "$config_file" 2>/dev/null)
+
+	while IFS= read -r slug; do
+		[[ -z "$slug" ]] && continue
+		local name type imap_host
+		name=$(jq -r ".providers.\"$slug\".name" "$config_file")
+		type=$(jq -r ".providers.\"$slug\".type" "$config_file")
+		imap_host=$(jq -r ".providers.\"$slug\".imap.host // \"none\"" "$config_file")
+
+		local status_icon="  "
+		if [[ "$test_connectivity" == "true" ]]; then
+			# Check if credentials exist (without printing them)
+			local has_creds="no"
+			if get_imap_user "$slug" >/dev/null 2>&1 && get_imap_password "$slug" >/dev/null 2>&1; then
+				has_creds="yes"
+				# Test actual connectivity
+				if run_imap_adapter "$slug" "connect" >/dev/null 2>&1; then
+					status_icon="OK"
+				else
+					status_icon="FAIL"
+				fi
+			else
+				status_icon="NO_CREDS"
+			fi
+		fi
+
+		printf "  %-20s %-30s %-12s %-25s %s\n" "$slug" "$name" "$type" "$imap_host" "$status_icon"
+	done <<<"$providers"
+
+	return 0
+}
+
+cmd_inbox() {
+	local account="${1:-}"
+	shift || true
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		print_info "Usage: $0 inbox <account> [--limit N] [--offset N] [--folder FOLDER]"
+		return 1
+	fi
+
+	local limit=50 offset=0 folder="INBOX"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--limit)
+			limit="$2"
+			shift 2
+			;;
+		--offset)
+			offset="$2"
+			shift 2
+			;;
+		--folder)
+			folder="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	run_imap_adapter "$account" "fetch_headers" \
+		--folder "$folder" --limit "$limit" --offset "$offset"
+
+	return $?
+}
+
+cmd_read() {
+	local account="${1:-}"
+	shift || true
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		return 1
+	fi
+
+	local uid="" folder="INBOX"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--uid)
+			uid="$2"
+			shift 2
+			;;
+		--folder)
+			folder="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$uid" ]]; then
+		print_error "--uid is required"
+		return 1
+	fi
+
+	run_imap_adapter "$account" "fetch_body" --uid "$uid" --folder "$folder"
+	return $?
+}
+
+cmd_folders() {
+	local account="${1:-}"
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		return 1
+	fi
+
+	local config_file
+	config_file=$(load_providers_config) || return 1
+
+	run_imap_adapter "$account" "list_folders" --provider-config "$config_file"
+	return $?
+}
+
+cmd_create_folder() {
+	local account="${1:-}"
+	shift || true
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		return 1
+	fi
+
+	local folder=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--folder)
+			folder="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$folder" ]]; then
+		print_error "--folder is required"
+		return 1
+	fi
+
+	run_imap_adapter "$account" "create_folder" --folder "$folder"
+	return $?
+}
+
+cmd_send() {
+	local account="${1:-}"
+	shift || true
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		return 1
+	fi
+
+	local to="" subject="" body_text="" body_file=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--to)
+			to="$2"
+			shift 2
+			;;
+		--subject)
+			subject="$2"
+			shift 2
+			;;
+		--body)
+			body_text="$2"
+			shift 2
+			;;
+		--body-file)
+			body_file="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$to" || -z "$subject" ]]; then
+		print_error "--to and --subject are required"
+		return 1
+	fi
+
+	if [[ -n "$body_file" && -f "$body_file" ]]; then
+		body_text=$(cat "$body_file")
+	fi
+
+	if [[ -z "$body_text" ]]; then
+		print_error "Message body is required (--body or --body-file)"
+		return 1
+	fi
+
+	local provider_json
+	provider_json=$(get_provider_config "$account") || return 1
+
+	local smtp_details
+	smtp_details=$(get_smtp_details "$provider_json") || return 1
+
+	local smtp_host smtp_port smtp_security
+	IFS='|' read -r smtp_host smtp_port smtp_security <<<"$smtp_details"
+
+	local user
+	user=$(get_imap_user "$account") || return 1
+
+	local password
+	password=$(get_imap_password "$account") || return 1
+
+	# Use Python for SMTP sending (pass password via env var)
+	SMTP_PASSWORD="$password" python3 -c "
+import os, sys, smtplib
+from email.mime.text import MIMEText
+
+msg = MIMEText('''${body_text//\'/\\\'}''')
+msg['Subject'] = '''${subject//\'/\\\'}'''
+msg['From'] = '$user'
+msg['To'] = '$to'
+
+password = os.environ['SMTP_PASSWORD']
+try:
+    if '$smtp_security' == 'TLS':
+        server = smtplib.SMTP_SSL('$smtp_host', $smtp_port)
+    else:
+        server = smtplib.SMTP('$smtp_host', $smtp_port)
+        server.starttls()
+    server.login('$user', password)
+    server.send_message(msg)
+    server.quit()
+    import json
+    print(json.dumps({'status': 'sent', 'to': '$to', 'subject': '''${subject//\'/\\\'}'''}))
+except Exception as e:
+    print(f'ERROR: Send failed: {e}', file=sys.stderr)
+    sys.exit(1)
+"
+	return $?
+}
+
+cmd_move() {
+	local account="${1:-}"
+	shift || true
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		return 1
+	fi
+
+	local uid="" dest="" folder="INBOX"
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--uid)
+			uid="$2"
+			shift 2
+			;;
+		--dest)
+			dest="$2"
+			shift 2
+			;;
+		--folder)
+			folder="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$uid" || -z "$dest" ]]; then
+		print_error "--uid and --dest are required"
+		return 1
+	fi
+
+	run_imap_adapter "$account" "move_message" --uid "$uid" --dest "$dest" --folder "$folder"
+	return $?
+}
+
+cmd_flag() {
+	local account="${1:-}"
+	shift || true
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		return 1
+	fi
+
+	local uid="" flag="" folder="INBOX" clear=false
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--uid)
+			uid="$2"
+			shift 2
+			;;
+		--flag)
+			flag="$2"
+			shift 2
+			;;
+		--folder)
+			folder="$2"
+			shift 2
+			;;
+		--clear)
+			clear=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$uid" || -z "$flag" ]]; then
+		print_error "--uid and --flag are required"
+		print_info "Available flags: Reminders, Tasks, Review, Filing, Ideas, Add-to-Contacts"
+		return 1
+	fi
+
+	local command="set_flag"
+	if [[ "$clear" == "true" ]]; then
+		command="clear_flag"
+	fi
+
+	run_imap_adapter "$account" "$command" --uid "$uid" --flag "$flag" --folder "$folder"
+	return $?
+}
+
+cmd_search() {
+	local account="${1:-}"
+	shift || true
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		return 1
+	fi
+
+	local query="" folder="INBOX" limit=50
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--query)
+			query="$2"
+			shift 2
+			;;
+		--folder)
+			folder="$2"
+			shift 2
+			;;
+		--limit)
+			limit="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$query" ]]; then
+		print_error "--query is required"
+		print_info "Examples:"
+		print_info "  --query 'FROM sender@example.com'"
+		print_info "  --query 'SUBJECT \"meeting notes\"'"
+		print_info "  --query 'UNSEEN SINCE 01-Mar-2026'"
+		print_info "  --query 'KEYWORD \$Task'"
+		return 1
+	fi
+
+	run_imap_adapter "$account" "search" --query "$query" --folder "$folder" --limit "$limit"
+	return $?
+}
+
+cmd_smart_mailbox() {
+	local account="${1:-}"
+	shift || true
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		return 1
+	fi
+
+	local name="" criteria=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--name)
+			name="$2"
+			shift 2
+			;;
+		--criteria)
+			criteria="$2"
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$name" || -z "$criteria" ]]; then
+		print_error "--name and --criteria are required"
+		print_info "Examples:"
+		print_info "  --name 'Action Required' --criteria 'KEYWORD \$Task OR KEYWORD \$Reminder'"
+		print_info "  --name 'VIP Inbox' --criteria 'FROM ceo@company.com'"
+		return 1
+	fi
+
+	# Smart mailboxes are saved searches stored locally
+	mkdir -p "$MAILBOX_WORKSPACE" 2>/dev/null || true
+	chmod 700 "$MAILBOX_WORKSPACE" 2>/dev/null || true
+
+	local smart_file="${MAILBOX_WORKSPACE}/smart-mailboxes.json"
+	local existing="[]"
+	if [[ -f "$smart_file" ]]; then
+		existing=$(cat "$smart_file")
+	fi
+
+	# Add or update the smart mailbox definition
+	local updated
+	updated=$(echo "$existing" | jq --arg name "$name" --arg criteria "$criteria" --arg account "$account" '
+		[.[] | select(.name != $name)] + [{
+			"name": $name,
+			"account": $account,
+			"criteria": $criteria,
+			"created": (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+		}]
+	')
+
+	echo "$updated" >"$smart_file"
+	chmod 600 "$smart_file" 2>/dev/null || true
+
+	# Execute the search to show current results
+	print_info "Smart mailbox '$name' saved. Running search..."
+	run_imap_adapter "$account" "search" --query "$criteria" --folder "INBOX" --limit 50
+	return $?
+}
+
+cmd_sync() {
+	local account="${1:-}"
+	shift || true
+
+	if [[ -z "$account" ]]; then
+		print_error "Account name is required"
+		return 1
+	fi
+
+	local folder="INBOX" full_sync=false
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--folder)
+			folder="$2"
+			shift 2
+			;;
+		--full)
+			full_sync=true
+			shift
+			;;
+		*) shift ;;
+		esac
+	done
+
+	local extra_args=(--folder "$folder")
+	if [[ "$full_sync" == "true" ]]; then
+		extra_args+=(--full)
+	fi
+
+	run_imap_adapter "$account" "index_sync" "${extra_args[@]}"
+	return $?
+}
+
+cmd_help() {
+	cat <<'HELP'
+Email Mailbox Helper - IMAP/JMAP adapter and mailbox operations
+
+Usage: email-mailbox-helper.sh <command> [account] [options]
+
+Commands:
+  accounts [--test]              List configured accounts (--test checks connectivity)
+  inbox <account> [opts]         Fetch message headers from inbox
+  read <account> --uid UID       Read a specific message body
+  folders <account>              List IMAP folders with provider mapping
+  create-folder <account> --folder PATH  Create a new IMAP folder
+  send <account> --to --subject --body   Send an email via SMTP
+  move <account> --uid --dest    Move a message to another folder
+  flag <account> --uid --flag    Set/clear a flag on a message
+  search <account> --query       Search messages using IMAP SEARCH
+  smart-mailbox <account> --name --criteria  Create a saved search
+  sync <account> [--folder] [--full]  Sync folder headers to local index
+  help                           Show this help
+
+Options:
+  --limit N       Max messages to return (default: 50)
+  --offset N      Skip N most recent messages (default: 0)
+  --folder NAME   IMAP folder name (default: INBOX)
+  --uid UID       Message UID for read/move/flag operations
+  --dest FOLDER   Destination folder for move
+  --flag NAME     Flag name: Reminders, Tasks, Review, Filing, Ideas, Add-to-Contacts
+  --clear         Clear a flag instead of setting it
+  --query SEARCH  IMAP SEARCH criteria string
+  --full          Full sync (not incremental)
+  --test          Test connectivity when listing accounts
+
+Flag Taxonomy:
+  Reminders       Time-sensitive, needs attention by a date
+  Tasks           Requires a concrete action (reply, approve, create)
+  Review          Read carefully (contract, proposal, technical doc)
+  Filing          Archive to a specific project/reference folder
+  Ideas           Inspiration, interesting link, future reference
+  Add-to-Contacts New contact, save their details
+
+Credentials:
+  Store IMAP password: aidevops secret set email-imap-<account>
+  Store IMAP username: gopass edit aidevops/email-imap-<account> (add 'user: you@example.com')
+
+Provider Config:
+  Template: .agents/configs/email-providers.json.txt
+  Working:  .agents/configs/email-providers.json (copy and customise)
+
+Examples:
+  email-mailbox-helper.sh accounts --test
+  email-mailbox-helper.sh inbox cloudron --limit 20
+  email-mailbox-helper.sh read cloudron --uid 12345
+  email-mailbox-helper.sh search cloudron --query 'FROM client@example.com UNSEEN'
+  email-mailbox-helper.sh flag cloudron --uid 12345 --flag Tasks
+  email-mailbox-helper.sh move cloudron --uid 12345 --dest Archive
+  email-mailbox-helper.sh sync cloudron --full
+HELP
+	return 0
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	check_dependencies || exit 1
+
+	case "$command" in
+	accounts)
+		cmd_accounts "$@"
+		;;
+	inbox)
+		cmd_inbox "$@"
+		;;
+	read)
+		cmd_read "$@"
+		;;
+	folders)
+		cmd_folders "$@"
+		;;
+	create-folder)
+		cmd_create_folder "$@"
+		;;
+	send)
+		cmd_send "$@"
+		;;
+	move)
+		cmd_move "$@"
+		;;
+	flag)
+		cmd_flag "$@"
+		;;
+	search)
+		cmd_search "$@"
+		;;
+	smart-mailbox)
+		cmd_smart_mailbox "$@"
+		;;
+	sync)
+		cmd_sync "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		print_error "Unknown command: $command"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/email_imap_adapter.py
+++ b/.agents/scripts/email_imap_adapter.py
@@ -1,0 +1,862 @@
+#!/usr/bin/env python3
+"""
+email_imap_adapter.py - IMAP adapter for mailbox operations.
+
+Provides IMAP connection, header fetching, body fetching, search, move,
+and flag operations. Uses BODY.PEEK to avoid marking messages as read.
+
+Part of the email mailbox helper (t1493). Called by email-mailbox-helper.sh.
+
+Usage:
+    python3 email_imap_adapter.py connect --host HOST --port PORT --user USER
+    python3 email_imap_adapter.py fetch_headers --folder INBOX [--limit 50] [--offset 0]
+    python3 email_imap_adapter.py fetch_body --uid UID [--folder INBOX]
+    python3 email_imap_adapter.py search --query "FROM sender@example.com" [--folder INBOX]
+    python3 email_imap_adapter.py list_folders
+    python3 email_imap_adapter.py create_folder --folder "Archive/Projects/acme"
+    python3 email_imap_adapter.py move_message --uid UID --dest "Archive" [--folder INBOX]
+    python3 email_imap_adapter.py set_flag --uid UID --flag "$Task" [--folder INBOX]
+    python3 email_imap_adapter.py clear_flag --uid UID --flag "$Task" [--folder INBOX]
+    python3 email_imap_adapter.py index_sync --folder INBOX [--full]
+
+Credentials: read from IMAP_PASSWORD environment variable (never from argv).
+Provider config: read from PROVIDER_CONFIG_JSON environment variable or --provider-config file.
+
+Output: JSON to stdout. Errors to stderr.
+"""
+
+import argparse
+import email
+import email.header
+import email.policy
+import email.utils
+import imaplib
+import json
+import os
+import re
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+INDEX_DIR = Path.home() / ".aidevops" / ".agent-workspace" / "email-mailbox"
+INDEX_DB = INDEX_DIR / "index.db"
+
+# Custom flag taxonomy mapping (from email-mailbox.md)
+FLAG_TAXONOMY = {
+    "Reminders": "$Reminder",
+    "Tasks": "$Task",
+    "Review": "$Review",
+    "Filing": "$Filing",
+    "Ideas": "$Idea",
+    "Add-to-Contacts": "$AddContact",
+}
+
+# IMAP date format for SEARCH commands
+IMAP_DATE_FMT = "%d-%b-%Y"
+
+
+# ---------------------------------------------------------------------------
+# SQLite metadata index
+# ---------------------------------------------------------------------------
+
+def _init_index_db(db_path=None):
+    """Initialise the SQLite metadata index. Never stores message bodies."""
+    if db_path is None:
+        db_path = INDEX_DB
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS messages (
+            account     TEXT NOT NULL,
+            folder      TEXT NOT NULL,
+            uid         INTEGER NOT NULL,
+            message_id  TEXT,
+            date        TEXT,
+            from_addr   TEXT,
+            to_addr     TEXT,
+            subject     TEXT,
+            flags       TEXT,
+            size        INTEGER DEFAULT 0,
+            indexed_at  TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+            PRIMARY KEY (account, folder, uid)
+        )
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_messages_date
+        ON messages (account, date DESC)
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_messages_from
+        ON messages (account, from_addr)
+    """)
+    conn.execute("""
+        CREATE INDEX IF NOT EXISTS idx_messages_subject
+        ON messages (account, subject)
+    """)
+    conn.commit()
+    # Secure permissions on the database file
+    try:
+        os.chmod(str(db_path), 0o600)
+    except OSError:
+        pass
+    return conn
+
+
+def _upsert_message(conn, account, folder, uid, headers):
+    """Insert or update a message in the metadata index."""
+    conn.execute("""
+        INSERT INTO messages (account, folder, uid, message_id, date,
+                              from_addr, to_addr, subject, flags, size)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (account, folder, uid) DO UPDATE SET
+            message_id = excluded.message_id,
+            date       = excluded.date,
+            from_addr  = excluded.from_addr,
+            to_addr    = excluded.to_addr,
+            subject    = excluded.subject,
+            flags      = excluded.flags,
+            size       = excluded.size,
+            indexed_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+    """, (
+        account, folder, uid,
+        headers.get("message_id", ""),
+        headers.get("date", ""),
+        headers.get("from", ""),
+        headers.get("to", ""),
+        headers.get("subject", ""),
+        headers.get("flags", ""),
+        headers.get("size", 0),
+    ))
+
+
+# ---------------------------------------------------------------------------
+# IMAP connection
+# ---------------------------------------------------------------------------
+
+def _get_password():
+    """Read IMAP password from environment variable. Never from argv."""
+    password = os.environ.get("IMAP_PASSWORD", "")
+    if not password:
+        print("ERROR: IMAP_PASSWORD environment variable not set", file=sys.stderr)
+        print("Set it via: IMAP_PASSWORD=$(gopass show -o email-imap-account) python3 ...",
+              file=sys.stderr)
+        sys.exit(1)
+    return password
+
+
+def connect(host, port, user, security="TLS"):
+    """Connect and authenticate to an IMAP server.
+
+    Args:
+        host: IMAP server hostname.
+        port: IMAP server port (993 for TLS, 143 for STARTTLS).
+        user: IMAP username (usually email address).
+        security: "TLS" (implicit) or "STARTTLS".
+
+    Returns:
+        Authenticated imaplib.IMAP4_SSL or IMAP4 connection.
+    """
+    password = _get_password()
+
+    try:
+        if security.upper() == "TLS":
+            conn = imaplib.IMAP4_SSL(host, int(port))
+        else:
+            conn = imaplib.IMAP4(host, int(port))
+            conn.starttls()
+
+        conn.login(user, password)
+        return conn
+    except imaplib.IMAP4.error as exc:
+        print(f"ERROR: IMAP connection failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as exc:
+        print(f"ERROR: Connection error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _parse_provider_config(provider_config_path=None):
+    """Load provider config from file or PROVIDER_CONFIG_JSON env var."""
+    config_json = os.environ.get("PROVIDER_CONFIG_JSON", "")
+    if config_json:
+        try:
+            return json.loads(config_json)
+        except json.JSONDecodeError as exc:
+            print(f"ERROR: Invalid PROVIDER_CONFIG_JSON: {exc}", file=sys.stderr)
+            sys.exit(1)
+
+    if provider_config_path and os.path.isfile(provider_config_path):
+        with open(provider_config_path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    return {}
+
+
+def _get_folder_mapping(provider_config):
+    """Extract folder name mapping from provider config."""
+    return provider_config.get("default_folders", {})
+
+
+# ---------------------------------------------------------------------------
+# Header parsing
+# ---------------------------------------------------------------------------
+
+def _decode_header_value(raw):
+    """Decode an RFC 2047 encoded header value."""
+    if raw is None:
+        return ""
+    parts = email.header.decode_header(raw)
+    decoded = []
+    for part_bytes, charset in parts:
+        if isinstance(part_bytes, bytes):
+            decoded.append(part_bytes.decode(charset or "utf-8", errors="replace"))
+        else:
+            decoded.append(str(part_bytes))
+    return " ".join(decoded)
+
+
+def _parse_envelope_from_fetch(fetch_data):
+    """Parse headers from an IMAP FETCH response.
+
+    Uses BODY.PEEK[HEADER.FIELDS (...)] to avoid marking as read.
+    """
+    results = []
+    # fetch_data is a list of (response_line, data) tuples
+    idx = 0
+    while idx < len(fetch_data):
+        item = fetch_data[idx]
+        if isinstance(item, tuple) and len(item) == 2:
+            response_line = item[0]
+            header_bytes = item[1]
+
+            # Extract UID from response line
+            uid_match = re.search(rb"UID (\d+)", response_line)
+            uid = int(uid_match.group(1)) if uid_match else 0
+
+            # Extract FLAGS from response line
+            flags_match = re.search(rb"FLAGS \(([^)]*)\)", response_line)
+            flags_str = flags_match.group(1).decode("utf-8", errors="replace") if flags_match else ""
+
+            # Extract RFC822.SIZE from response line
+            size_match = re.search(rb"RFC822\.SIZE (\d+)", response_line)
+            size = int(size_match.group(1)) if size_match else 0
+
+            # Parse headers
+            if isinstance(header_bytes, bytes):
+                msg = email.message_from_bytes(header_bytes, policy=email.policy.default)
+                date_str = ""
+                date_header = msg.get("Date", "")
+                if date_header:
+                    try:
+                        dt = email.utils.parsedate_to_datetime(str(date_header))
+                        date_str = dt.strftime("%Y-%m-%dT%H:%M:%S%z")
+                    except (ValueError, TypeError):
+                        date_str = str(date_header)
+
+                results.append({
+                    "uid": uid,
+                    "message_id": str(msg.get("Message-ID", "")),
+                    "date": date_str,
+                    "from": str(msg.get("From", "")),
+                    "to": str(msg.get("To", "")),
+                    "subject": str(msg.get("Subject", "")),
+                    "flags": flags_str,
+                    "size": size,
+                })
+        idx += 1
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+def cmd_connect(args):
+    """Test IMAP connectivity and report server capabilities."""
+    conn = connect(args.host, args.port, args.user, args.security)
+    # Get capabilities
+    caps = conn.capabilities
+    cap_list = [c.decode("utf-8") if isinstance(c, bytes) else str(c) for c in caps]
+
+    result = {
+        "status": "connected",
+        "host": args.host,
+        "port": args.port,
+        "user": args.user,
+        "capabilities": cap_list,
+    }
+    conn.logout()
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+def cmd_fetch_headers(args):
+    """Fetch message headers from a folder using BODY.PEEK (no read marking)."""
+    conn = connect(args.host, args.port, args.user, args.security)
+    folder = args.folder or "INBOX"
+    limit = args.limit or 50
+    offset = args.offset or 0
+
+    status, count_data = conn.select(f'"{folder}"', readonly=True)
+    if status != "OK":
+        print(f"ERROR: Cannot select folder '{folder}': {count_data}", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    total = int(count_data[0] or b"0")
+    if total == 0:
+        print(json.dumps({"folder": folder, "total": 0, "messages": []}))
+        conn.logout()
+        return 0
+
+    # Calculate range (most recent first)
+    end = max(1, total - offset)
+    start = max(1, end - limit + 1)
+
+    # Use UID FETCH with BODY.PEEK to avoid marking as read
+    fetch_range = f"{start}:{end}"
+    status, data = conn.fetch(
+        fetch_range,
+        "(UID FLAGS RFC822.SIZE BODY.PEEK[HEADER.FIELDS "
+        "(Date From To Subject Message-ID In-Reply-To References)])"
+    )
+
+    if status != "OK":
+        print(f"ERROR: FETCH failed: {data}", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    messages = _parse_envelope_from_fetch(data)
+    # Sort by UID descending (most recent first)
+    messages.sort(key=lambda m: m["uid"], reverse=True)
+
+    # Update SQLite index
+    account_key = f"{args.user}@{args.host}"
+    db_conn = _init_index_db()
+    for msg in messages:
+        _upsert_message(db_conn, account_key, folder, msg["uid"], msg)
+    db_conn.commit()
+    db_conn.close()
+
+    result = {
+        "folder": folder,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "returned": len(messages),
+        "messages": messages,
+    }
+    print(json.dumps(result, indent=2))
+    conn.logout()
+    return 0
+
+
+def cmd_fetch_body(args):
+    """Fetch a single message body by UID using BODY.PEEK."""
+    conn = connect(args.host, args.port, args.user, args.security)
+    folder = args.folder or "INBOX"
+
+    status, _ = conn.select(f'"{folder}"', readonly=True)
+    if status != "OK":
+        print(f"ERROR: Cannot select folder '{folder}'", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    # Fetch full message using BODY.PEEK (doesn't mark as read)
+    status, data = conn.uid("FETCH", str(args.uid), "(BODY.PEEK[])")
+    if status != "OK" or not data or data[0] is None:
+        print(f"ERROR: Message UID {args.uid} not found", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    raw_email = data[0][1] if isinstance(data[0], tuple) else b""
+    msg = email.message_from_bytes(raw_email, policy=email.policy.default)
+
+    # Extract text parts
+    text_body = ""
+    html_body = ""
+    attachments = []
+
+    if msg.is_multipart():
+        for part in msg.walk():
+            content_type = part.get_content_type()
+            disposition = str(part.get("Content-Disposition", ""))
+
+            if "attachment" in disposition:
+                attachments.append({
+                    "filename": part.get_filename() or "unnamed",
+                    "content_type": content_type,
+                    "size": len(part.get_payload(decode=True) or b""),
+                })
+            elif content_type == "text/plain" and not text_body:
+                raw_payload = part.get_payload(decode=True)
+                if isinstance(raw_payload, bytes):
+                    charset = part.get_content_charset() or "utf-8"
+                    text_body = raw_payload.decode(charset, errors="replace")
+            elif content_type == "text/html" and not html_body:
+                raw_payload = part.get_payload(decode=True)
+                if isinstance(raw_payload, bytes):
+                    charset = part.get_content_charset() or "utf-8"
+                    html_body = raw_payload.decode(charset, errors="replace")
+    else:
+        content_type = msg.get_content_type()
+        raw_payload = msg.get_payload(decode=True)
+        if isinstance(raw_payload, bytes):
+            charset = msg.get_content_charset() or "utf-8"
+            decoded = raw_payload.decode(charset, errors="replace")
+            if content_type == "text/plain":
+                text_body = decoded
+            elif content_type == "text/html":
+                html_body = decoded
+
+    result = {
+        "uid": args.uid,
+        "folder": folder,
+        "message_id": str(msg.get("Message-ID", "")),
+        "date": str(msg.get("Date", "")),
+        "from": str(msg.get("From", "")),
+        "to": str(msg.get("To", "")),
+        "cc": str(msg.get("Cc", "")),
+        "subject": str(msg.get("Subject", "")),
+        "in_reply_to": str(msg.get("In-Reply-To", "")),
+        "references": str(msg.get("References", "")),
+        "text_body": text_body,
+        "html_body_length": len(html_body),
+        "attachments": attachments,
+    }
+    print(json.dumps(result, indent=2))
+    conn.logout()
+    return 0
+
+
+def cmd_search(args):
+    """Search messages using IMAP SEARCH criteria."""
+    conn = connect(args.host, args.port, args.user, args.security)
+    folder = args.folder or "INBOX"
+
+    status, _ = conn.select(f'"{folder}"', readonly=True)
+    if status != "OK":
+        print(f"ERROR: Cannot select folder '{folder}'", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    # Build IMAP search criteria
+    criteria = args.query
+    if not criteria:
+        print("ERROR: --query is required for search", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    status, data = conn.uid("SEARCH", "CHARSET", "UTF-8", criteria)
+    if status != "OK":
+        print(f"ERROR: SEARCH failed: {data}", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    uid_list = data[0].split() if data[0] else []
+    # Limit results
+    limit = args.limit or 50
+    uid_list = uid_list[-limit:]  # Most recent UIDs
+
+    messages = []
+    if uid_list:
+        uid_str = b",".join(uid_list).decode("utf-8")
+        status, fetch_data = conn.uid(
+            "FETCH", uid_str,
+            "(UID FLAGS RFC822.SIZE BODY.PEEK[HEADER.FIELDS "
+            "(Date From To Subject Message-ID)])"
+        )
+        if status == "OK":
+            messages = _parse_envelope_from_fetch(fetch_data)
+            messages.sort(key=lambda m: m["uid"], reverse=True)
+
+    result = {
+        "folder": folder,
+        "query": criteria,
+        "total_matches": len(uid_list),
+        "returned": len(messages),
+        "messages": messages,
+    }
+    print(json.dumps(result, indent=2))
+    conn.logout()
+    return 0
+
+
+def cmd_list_folders(args):
+    """List all IMAP folders with provider-aware name mapping."""
+    conn = connect(args.host, args.port, args.user, args.security)
+
+    status, folder_data = conn.list()
+    if status != "OK":
+        print("ERROR: LIST failed", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    provider_config = _parse_provider_config(args.provider_config)
+    folder_mapping = _get_folder_mapping(provider_config)
+    # Invert mapping for display: imap_name -> logical_name
+    reverse_mapping = {v: k for k, v in folder_mapping.items()}
+
+    folders = []
+    for item in folder_data:
+        if item is None:
+            continue
+        decoded = item.decode("utf-8", errors="replace") if isinstance(item, bytes) else str(item)
+        # Parse IMAP LIST response: (flags) delimiter name
+        match = re.match(r'\(([^)]*)\)\s+"([^"]+)"\s+"?([^"]*)"?', decoded)
+        if match:
+            flags_str = match.group(1)
+            delimiter = match.group(2)
+            name = match.group(3).strip('"')
+            logical_name = reverse_mapping.get(name, "")
+            folders.append({
+                "name": name,
+                "logical_name": logical_name,
+                "flags": flags_str,
+                "delimiter": delimiter,
+            })
+
+    result = {
+        "total": len(folders),
+        "folder_mapping": folder_mapping,
+        "folders": folders,
+    }
+    print(json.dumps(result, indent=2))
+    conn.logout()
+    return 0
+
+
+def cmd_create_folder(args):
+    """Create an IMAP folder (mailbox)."""
+    conn = connect(args.host, args.port, args.user, args.security)
+    folder = args.folder
+    if not folder:
+        print("ERROR: --folder is required", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    status, data = conn.create(f'"{folder}"')
+    if status != "OK":
+        print(f"ERROR: CREATE failed: {data}", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    # Subscribe to the new folder
+    conn.subscribe(f'"{folder}"')
+
+    result = {"status": "created", "folder": folder}
+    print(json.dumps(result, indent=2))
+    conn.logout()
+    return 0
+
+
+def cmd_move_message(args):
+    """Move a message to a destination folder by UID."""
+    conn = connect(args.host, args.port, args.user, args.security)
+    folder = args.folder or "INBOX"
+    dest = args.dest
+    uid = str(args.uid)
+
+    if not dest:
+        print("ERROR: --dest is required", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    status, _ = conn.select(f'"{folder}"')
+    if status != "OK":
+        print(f"ERROR: Cannot select folder '{folder}'", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    # Try MOVE extension first (RFC 6851), fall back to COPY+DELETE
+    try:
+        # Check if server supports MOVE
+        if b"MOVE" in conn.capabilities or b"move" in conn.capabilities:
+            status, data = conn.uid("MOVE", uid, f'"{dest}"')
+        else:
+            # Copy then mark deleted
+            status, data = conn.uid("COPY", uid, f'"{dest}"')
+            if status == "OK":
+                conn.uid("STORE", uid, "+FLAGS", "(\\Deleted)")
+                conn.expunge()
+    except imaplib.IMAP4.error as exc:
+        # Fallback: COPY + DELETE
+        status, data = conn.uid("COPY", uid, f'"{dest}"')
+        if status == "OK":
+            conn.uid("STORE", uid, "+FLAGS", "(\\Deleted)")
+            conn.expunge()
+        else:
+            print(f"ERROR: MOVE/COPY failed: {exc}", file=sys.stderr)
+            conn.logout()
+            return 1
+
+    result = {
+        "status": "moved",
+        "uid": args.uid,
+        "from_folder": folder,
+        "to_folder": dest,
+    }
+    print(json.dumps(result, indent=2))
+    conn.logout()
+    return 0
+
+
+def cmd_set_flag(args):
+    """Set a flag (keyword) on a message by UID."""
+    conn = connect(args.host, args.port, args.user, args.security)
+    folder = args.folder or "INBOX"
+    uid = str(args.uid)
+    flag = args.flag
+
+    if not flag:
+        print("ERROR: --flag is required", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    # Map taxonomy name to IMAP keyword if needed
+    imap_flag = FLAG_TAXONOMY.get(flag, flag)
+
+    status, _ = conn.select(f'"{folder}"')
+    if status != "OK":
+        print(f"ERROR: Cannot select folder '{folder}'", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    status, data = conn.uid("STORE", uid, "+FLAGS", f"({imap_flag})")
+    if status != "OK":
+        print(f"ERROR: STORE +FLAGS failed: {data}", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    result = {
+        "status": "flag_set",
+        "uid": args.uid,
+        "folder": folder,
+        "flag": imap_flag,
+        "taxonomy_name": flag if flag in FLAG_TAXONOMY else "",
+    }
+    print(json.dumps(result, indent=2))
+    conn.logout()
+    return 0
+
+
+def cmd_clear_flag(args):
+    """Clear a flag (keyword) from a message by UID."""
+    conn = connect(args.host, args.port, args.user, args.security)
+    folder = args.folder or "INBOX"
+    uid = str(args.uid)
+    flag = args.flag
+
+    if not flag:
+        print("ERROR: --flag is required", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    imap_flag = FLAG_TAXONOMY.get(flag, flag)
+
+    status, _ = conn.select(f'"{folder}"')
+    if status != "OK":
+        print(f"ERROR: Cannot select folder '{folder}'", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    status, data = conn.uid("STORE", uid, "-FLAGS", f"({imap_flag})")
+    if status != "OK":
+        print(f"ERROR: STORE -FLAGS failed: {data}", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    result = {
+        "status": "flag_cleared",
+        "uid": args.uid,
+        "folder": folder,
+        "flag": imap_flag,
+    }
+    print(json.dumps(result, indent=2))
+    conn.logout()
+    return 0
+
+
+def cmd_index_sync(args):
+    """Sync folder headers to the local SQLite metadata index."""
+    conn = connect(args.host, args.port, args.user, args.security)
+    folder = args.folder or "INBOX"
+    account_key = f"{args.user}@{args.host}"
+
+    status, count_data = conn.select(f'"{folder}"', readonly=True)
+    if status != "OK":
+        print(f"ERROR: Cannot select folder '{folder}'", file=sys.stderr)
+        conn.logout()
+        return 1
+
+    total = int(count_data[0] or b"0")
+    if total == 0:
+        print(json.dumps({"folder": folder, "synced": 0, "total": 0}))
+        conn.logout()
+        return 0
+
+    db_conn = _init_index_db()
+
+    if args.full:
+        # Full sync: fetch all headers
+        fetch_range = "1:*"
+    else:
+        # Incremental: find highest UID in index, fetch newer
+        row = db_conn.execute(
+            "SELECT MAX(uid) FROM messages WHERE account = ? AND folder = ?",
+            (account_key, folder)
+        ).fetchone()
+        last_uid = row[0] if row and row[0] else 0
+        if last_uid > 0:
+            fetch_range = f"{last_uid + 1}:*"
+        else:
+            fetch_range = "1:*"
+
+    status, data = conn.uid(
+        "FETCH", fetch_range,
+        "(UID FLAGS RFC822.SIZE BODY.PEEK[HEADER.FIELDS "
+        "(Date From To Subject Message-ID)])"
+    )
+
+    synced = 0
+    if status == "OK" and data:
+        messages = _parse_envelope_from_fetch(data)
+        for msg in messages:
+            _upsert_message(db_conn, account_key, folder, msg["uid"], msg)
+            synced += 1
+        db_conn.commit()
+
+    db_conn.close()
+
+    result = {
+        "folder": folder,
+        "total": total,
+        "synced": synced,
+        "mode": "full" if args.full else "incremental",
+    }
+    print(json.dumps(result, indent=2))
+    conn.logout()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+def build_parser():
+    """Build the argument parser with all subcommands."""
+    parser = argparse.ArgumentParser(
+        description="IMAP adapter for email mailbox operations"
+    )
+
+    # Common connection arguments
+    parser.add_argument("--host", help="IMAP server hostname")
+    parser.add_argument("--port", type=int, default=993, help="IMAP server port")
+    parser.add_argument("--user", help="IMAP username (email address)")
+    parser.add_argument("--security", default="TLS", choices=["TLS", "STARTTLS"],
+                        help="Connection security (default: TLS)")
+    parser.add_argument("--provider-config", help="Path to provider config JSON file")
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+
+    # connect
+    subparsers.add_parser("connect", help="Test IMAP connectivity")
+
+    # fetch_headers
+    fh = subparsers.add_parser("fetch_headers", help="Fetch message headers")
+    fh.add_argument("--folder", default="INBOX", help="Folder to fetch from")
+    fh.add_argument("--limit", type=int, default=50, help="Max messages to fetch")
+    fh.add_argument("--offset", type=int, default=0, help="Offset from most recent")
+
+    # fetch_body
+    fb = subparsers.add_parser("fetch_body", help="Fetch a message body by UID")
+    fb.add_argument("--uid", type=int, required=True, help="Message UID")
+    fb.add_argument("--folder", default="INBOX", help="Folder containing the message")
+
+    # search
+    sr = subparsers.add_parser("search", help="Search messages")
+    sr.add_argument("--query", required=True, help="IMAP SEARCH criteria")
+    sr.add_argument("--folder", default="INBOX", help="Folder to search")
+    sr.add_argument("--limit", type=int, default=50, help="Max results")
+
+    # list_folders
+    subparsers.add_parser("list_folders", help="List all IMAP folders")
+
+    # create_folder
+    cf = subparsers.add_parser("create_folder", help="Create an IMAP folder")
+    cf.add_argument("--folder", required=True, help="Folder path to create")
+
+    # move_message
+    mv = subparsers.add_parser("move_message", help="Move a message to another folder")
+    mv.add_argument("--uid", type=int, required=True, help="Message UID")
+    mv.add_argument("--dest", required=True, help="Destination folder")
+    mv.add_argument("--folder", default="INBOX", help="Source folder")
+
+    # set_flag
+    sf = subparsers.add_parser("set_flag", help="Set a flag on a message")
+    sf.add_argument("--uid", type=int, required=True, help="Message UID")
+    sf.add_argument("--flag", required=True,
+                    help="Flag name (taxonomy name or IMAP keyword)")
+    sf.add_argument("--folder", default="INBOX", help="Folder containing the message")
+
+    # clear_flag
+    clf = subparsers.add_parser("clear_flag", help="Clear a flag from a message")
+    clf.add_argument("--uid", type=int, required=True, help="Message UID")
+    clf.add_argument("--flag", required=True, help="Flag name to clear")
+    clf.add_argument("--folder", default="INBOX", help="Folder containing the message")
+
+    # index_sync
+    ix = subparsers.add_parser("index_sync", help="Sync folder to local index")
+    ix.add_argument("--folder", default="INBOX", help="Folder to sync")
+    ix.add_argument("--full", action="store_true", help="Full sync (not incremental)")
+
+    return parser
+
+
+def main():
+    """Entry point."""
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    # Validate required connection args for commands that need them
+    if args.command != "help":
+        if not args.host or not args.user:
+            print("ERROR: --host and --user are required", file=sys.stderr)
+            return 1
+
+    commands = {
+        "connect": cmd_connect,
+        "fetch_headers": cmd_fetch_headers,
+        "fetch_body": cmd_fetch_body,
+        "search": cmd_search,
+        "list_folders": cmd_list_folders,
+        "create_folder": cmd_create_folder,
+        "move_message": cmd_move_message,
+        "set_flag": cmd_set_flag,
+        "clear_flag": cmd_clear_flag,
+        "index_sync": cmd_index_sync,
+    }
+
+    handler = commands.get(args.command)
+    if handler:
+        return handler(args)
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/.agents/services/email/email-mailbox.md
+++ b/.agents/services/email/email-mailbox.md
@@ -20,7 +20,8 @@ tools:
 
 - **Purpose**: Intelligent mailbox organization, triage, flagging, and shared mailbox workflows
 - **Protocols**: IMAP4rev1 (RFC 9051), JMAP (RFC 8621), ManageSieve (RFC 5804)
-- **Helper**: `scripts/email-agent-helper.sh` (mailbox operations via configured adapter)
+- **Helper**: `scripts/email-mailbox-helper.sh` (IMAP/JMAP mailbox operations)
+- **Adapter**: `scripts/email_imap_adapter.py` (IMAP protocol layer)
 - **Related**: `services/email/email-agent.md` (mission communication), `services/email/ses.md` (sending)
 
 **Key principle**: Every mailbox action follows a decision tree. Consistent organization beats ad-hoc sorting.

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -73,7 +73,7 @@ tools/local-models/,Local AI model inference - llama.cpp setup GGUF models usage
 services/accessibility/,Unified web and email accessibility auditing - WCAG compliance remediation and monitoring,accessibility-audit
 services/hosting/,Hosting providers - DNS and cloud servers and local dev,local-hosting|localhost|hostinger|hetzner|cloudflare|cloudflare-platform|cloudron|closte
 services/networking/,Networking - mesh VPN and secure device connectivity,tailscale|netbird
-services/email/,Email services - transactional email deliverability testing and autonomous mission communication,ses|email-agent|email-health-check|email-testing|email-delivery-test|email-design-test|email-delivery-testing|email-design-testing
+services/email/,Email services - mailbox operations transactional email deliverability testing and autonomous mission communication,ses|email-agent|email-mailbox|email-health-check|email-testing|email-delivery-test|email-design-test|email-delivery-testing|email-design-testing
 services/outreach/,Cold outreach strategy - warmup, compliance, platform selection, and mailbox scaling,cold-outreach
 services/communications/,Communications - SMS voice Discord bot Matrix bot multi-platform chat bridging encrypted messaging Bluetooth mesh and Web3 messaging,bitchat|convos|discord|google-chat|imessage|matrix-bot|matterbridge|msteams|nextcloud-talk|nostr|signal|simplex|slack|telegram|telfon|twilio|urbit|whatsapp|xmtp
 services/crm/,CRM integration - contact management,fluentcrm
@@ -176,6 +176,7 @@ paddleocr-helper.sh,PaddleOCR scene text OCR (install ocr serve stop status mode
 quickfile-helper.sh,QuickFile purchase/expense recording bridge - supplier resolution and MCP instruction generation (record-purchase record-expense supplier-resolve batch-record preview status)
 cloudron-package-helper.sh,Cloudron app packaging workflow (init scaffold build test)
 email-agent-helper.sh,Autonomous email agent for mission 3rd-party communication (send poll extract-codes thread conversations status)
+email-mailbox-helper.sh,Email mailbox IMAP/JMAP adapter (accounts inbox read folders send move flag search smart-mailbox sync)
 email-health-check-helper.sh,Email health check with scoring (SPF DKIM DMARC BIMI MTA-STS TLS-RPT DANE)
 email-test-suite-helper.sh,Email testing suite (design rendering delivery testing inbox placement)
 email-delivery-test-helper.sh,Email delivery testing (spam content analysis provider deliverability inbox placement warm-up)


### PR DESCRIPTION
## Summary
- add `.agents/scripts/email-mailbox-helper.sh` with mailbox operations (`accounts`, `inbox`, `read`, `folders`, `create-folder`, `send`, `move`, `flag`, `search`, `smart-mailbox`, `sync`)
- add `.agents/scripts/email_imap_adapter.py` implementing IMAP/SMTP operations and metadata-only SQLite indexing with `BODY.PEEK`
- update `.agents/services/email/email-mailbox.md` references to the new helper and adapter

## Verification
- `shellcheck .agents/scripts/email-mailbox-helper.sh`
- `python3 -m py_compile .agents/scripts/email_imap_adapter.py`

Closes #4974