### PR TITLE
t1521: Multi-channel conversation continuity

### DIFF
--- a/.agents/scripts/entity-helper.sh
+++ b/.agents/scripts/entity-helper.sh
@@ -240,6 +240,72 @@ SCHEMA
 sql_escape() {
 	local val="$1"
 	echo "${val//\'/\'\'}"
+	return 0
+}
+
+#######################################
+# Normalize channel identifier for storage/lookup
+# Email addresses are case-insensitive and often include plus aliases.
+#######################################
+normalize_channel_id() {
+	local channel="$1"
+	local channel_id="$2"
+
+	if [[ "$channel" != "email" ]]; then
+		echo "$channel_id"
+		return 0
+	fi
+
+	local normalized
+	normalized=$(printf '%s' "$channel_id" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//' | tr '[:upper:]' '[:lower:]')
+
+	if [[ "$normalized" != *"@"* ]]; then
+		echo "$normalized"
+		return 0
+	fi
+
+	local local_part
+	local_part="${normalized%@*}"
+	local_part="${local_part%%+*}"
+	local domain_part
+	domain_part="${normalized#*@}"
+
+	echo "${local_part}@${domain_part}"
+	return 0
+}
+
+#######################################
+# Resolve email identity against historical non-normalized entries
+#######################################
+resolve_email_entity_fallback() {
+	local normalized_email="$1"
+	local result=""
+
+	local rows
+	rows=$(entity_db "$ENTITY_MEMORY_DB" "SELECT entity_id || '|' || channel_id FROM entity_channels WHERE channel = 'email';")
+	if [[ -z "$rows" ]]; then
+		return 1
+	fi
+
+	while IFS='|' read -r candidate_entity candidate_channel_id; do
+		if [[ -z "$candidate_entity" || -z "$candidate_channel_id" ]]; then
+			continue
+		fi
+
+		local normalized_candidate
+		normalized_candidate=$(normalize_channel_id "email" "$candidate_channel_id")
+		if [[ "$normalized_candidate" == "$normalized_email" ]]; then
+			result="$candidate_entity"
+			break
+		fi
+	done <<<"$rows"
+
+	if [[ -z "$result" ]]; then
+		return 1
+	fi
+
+	echo "$result"
+	return 0
 }
 
 #######################################
@@ -322,13 +388,15 @@ EOF
 		if [[ ! " $VALID_CHANNELS " =~ $channel_pattern ]]; then
 			log_warn "Invalid channel: $channel. Skipping channel link."
 		else
+			local normalized_channel_id
+			normalized_channel_id=$(normalize_channel_id "$channel" "$channel_id")
 			local esc_channel_id
-			esc_channel_id=$(sql_escape "$channel_id")
+			esc_channel_id=$(sql_escape "$normalized_channel_id")
 			entity_db "$ENTITY_MEMORY_DB" <<EOF
 INSERT INTO entity_channels (entity_id, channel, channel_id, display_name, confidence)
 VALUES ('$id', '$channel', '$esc_channel_id', '$esc_display', 'confirmed');
 EOF
-			log_info "Linked to $channel: $channel_id"
+			log_info "Linked to $channel: $normalized_channel_id"
 		fi
 	fi
 
@@ -763,7 +831,9 @@ cmd_link() {
 
 	local esc_id esc_channel_id esc_display
 	esc_id=$(sql_escape "$entity_id")
-	esc_channel_id=$(sql_escape "$channel_id")
+	local normalized_channel_id
+	normalized_channel_id=$(normalize_channel_id "$channel" "$channel_id")
+	esc_channel_id=$(sql_escape "$normalized_channel_id")
 	esc_display=$(sql_escape "$display_name")
 
 	# Check entity exists
@@ -779,8 +849,8 @@ cmd_link() {
 	existing_entity=$(entity_db "$ENTITY_MEMORY_DB" \
 		"SELECT entity_id FROM entity_channels WHERE channel = '$channel' AND channel_id = '$esc_channel_id';" 2>/dev/null || echo "")
 	if [[ -n "$existing_entity" && "$existing_entity" != "$entity_id" ]]; then
-		log_error "Channel identity $channel:$channel_id is already linked to entity $existing_entity"
-		log_error "Unlink it first with: entity-helper.sh unlink $existing_entity --channel $channel --channel-id \"$channel_id\""
+		log_error "Channel identity $channel:$normalized_channel_id is already linked to entity $existing_entity"
+		log_error "Unlink it first with: entity-helper.sh unlink $existing_entity --channel $channel --channel-id \"$normalized_channel_id\""
 		return 1
 	fi
 
@@ -801,7 +871,7 @@ ON CONFLICT(channel, channel_id) DO UPDATE SET
     verified_at = $verified_at;
 EOF
 
-	log_success "Linked $channel:$channel_id -> entity $entity_id ($confidence)"
+	log_success "Linked $channel:$normalized_channel_id -> entity $entity_id ($confidence)"
 	return 0
 }
 
@@ -837,6 +907,7 @@ cmd_unlink() {
 
 	local esc_id esc_channel_id
 	esc_id=$(sql_escape "$entity_id")
+	channel_id=$(normalize_channel_id "$channel" "$channel_id")
 	esc_channel_id=$(sql_escape "$channel_id")
 
 	local deleted
@@ -872,8 +943,10 @@ cmd_suggest() {
 
 	init_entity_db
 
+	local normalized_channel_id
+	normalized_channel_id=$(normalize_channel_id "$channel" "$channel_id")
 	local esc_channel_id
-	esc_channel_id=$(sql_escape "$channel_id")
+	esc_channel_id=$(sql_escape "$normalized_channel_id")
 
 	# 1. Exact match on channel_id
 	local exact_match
@@ -913,15 +986,15 @@ EOF
 	)
 
 	if [[ -z "$suggestions" || "$suggestions" == "[]" ]]; then
-		log_info "No matching entities found for $channel:$channel_id"
-		log_info "Create one with: entity-helper.sh create --name \"Name\" --channel $channel --channel-id \"$channel_id\""
+		log_info "No matching entities found for $channel:$normalized_channel_id"
+		log_info "Create one with: entity-helper.sh create --name \"Name\" --channel $channel --channel-id \"$normalized_channel_id\""
 		return 0
 	fi
 
-	echo "Suggested matches for $channel:$channel_id:"
+	echo "Suggested matches for $channel:$normalized_channel_id:"
 	echo "$suggestions"
 	echo ""
-	log_info "To link: entity-helper.sh link <entity_id> --channel $channel --channel-id \"$channel_id\" --verified"
+	log_info "To link: entity-helper.sh link <entity_id> --channel $channel --channel-id \"$normalized_channel_id\" --verified"
 	return 0
 }
 
@@ -957,6 +1030,7 @@ cmd_verify() {
 
 	local esc_id esc_channel_id
 	esc_id=$(sql_escape "$entity_id")
+	channel_id=$(normalize_channel_id "$channel" "$channel_id")
 	esc_channel_id=$(sql_escape "$channel_id")
 
 	entity_db "$ENTITY_MEMORY_DB" <<EOF
@@ -1636,6 +1710,7 @@ cmd_resolve() {
 
 	local esc_channel
 	esc_channel=$(sql_escape "$channel")
+	channel_id=$(normalize_channel_id "$channel" "$channel_id")
 	local esc_channel_id
 	esc_channel_id=$(sql_escape "$channel_id")
 
@@ -1643,6 +1718,10 @@ cmd_resolve() {
 	entity_id=$(entity_db "$ENTITY_MEMORY_DB" \
 		"SELECT entity_id FROM entity_channels WHERE channel = '$esc_channel' AND channel_id = '$esc_channel_id' LIMIT 1;" \
 		2>/dev/null || echo "")
+
+	if [[ -z "$entity_id" && "$channel" == "email" ]]; then
+		entity_id=$(resolve_email_entity_fallback "$channel_id" 2>/dev/null || true)
+	fi
 
 	if [[ -z "$entity_id" ]]; then
 		return 1
@@ -1815,6 +1894,11 @@ CONTEXT OPTIONS:
     --limit <n>             Max interactions to show (default: 20)
     --privacy-filter        Redact emails, IPs, API keys in output
     --json                  Output as JSON
+
+EMAIL RESOLUTION:
+    Email channel IDs are normalized on create/link/suggest/resolve/verify/unlink:
+    - Trim whitespace and lowercase address
+    - Remove plus alias from local part (name+tag@example.com -> name@example.com)
 
 ARCHITECTURE:
     Layer 0: Raw interaction log (immutable, append-only)

--- a/.agents/services/communications/cross-channel-conversation-continuity.md
+++ b/.agents/services/communications/cross-channel-conversation-continuity.md
@@ -1,0 +1,104 @@
+---
+description: Entity-aware conversation continuity guidance across email and messenger channels
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: false
+  glob: true
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# Cross-Channel Conversation Continuity
+
+## Goal
+
+Maintain one coherent relationship history per person across channels (email, Matrix, SimpleX, Slack, CLI) without leaking private context between unrelated identities.
+
+The continuity key is the entity ID in `memory.db`:
+
+- Layer 2 identity: `entities` + `entity_channels`
+- Layer 1 threads: `conversations`
+- Layer 0 evidence: `interactions`
+
+## Core Principle
+
+Resolve identity first, then continue the conversation.
+
+Do not infer continuity from display name alone. Use explicit channel mapping and confidence levels.
+
+## Continuity Workflow
+
+1. Resolve incoming sender/channel to an entity.
+2. If no entity exists, suggest candidates and require confirmation.
+3. Reuse existing conversation when topic + participants align.
+4. Start a new conversation when topic or audience has changed.
+5. Log the interaction to Layer 0 with channel metadata.
+6. Load context from the same entity before responding.
+
+## Email-Specific Identity Rules
+
+Use `entity-helper.sh` email normalization behavior for stable matching:
+
+- trim whitespace
+- lowercase address
+- strip plus aliases from local part
+
+Examples:
+
+- ` User+alerts@Example.COM ` -> `user@example.com`
+- `sales+q1@company.com` -> `sales@company.com`
+
+This normalization improves continuity when the same person uses tagged aliases for filtering.
+
+## Recommended Command Pattern
+
+```bash
+# Resolve sender to known entity
+entity-helper.sh resolve --channel email --channel-id "sender@example.com"
+
+# If unresolved, check suggestions
+entity-helper.sh suggest email "sender@example.com"
+
+# Confirm link once validated
+entity-helper.sh link <entity_id> --channel email --channel-id "sender@example.com" --verified
+
+# Log message on the resolved entity
+entity-helper.sh log-interaction <entity_id> --channel email --channel-id "sender@example.com" --content "..."
+
+# Load continuity context before replying
+entity-helper.sh context <entity_id> --channel email --limit 20 --privacy-filter
+```
+
+## Channel Boundary Guardrails
+
+- Never merge entities automatically.
+- Keep confidence explicit: `suggested` until verified.
+- Use `--privacy-filter` when rendering context to shared or lower-trust channels.
+- Keep irreversible decisions (identity merges, external sends) human-verifiable.
+
+## Threading Decision Guide
+
+Reply in existing thread when:
+
+- same topic
+- recent history (roughly <= 30 days)
+- recipient set is stable
+
+Start a new thread when:
+
+- new decision/request topic
+- long dormant thread
+- materially different audience
+
+When starting new thread, reference the old thread in the first line for continuity.
+
+## Verification Checklist
+
+- `entity-helper.sh resolve` returns the expected entity for known email aliases.
+- `entity-helper.sh suggest email` proposes known candidates for partial matches.
+- Context output includes relevant multi-channel interactions for the same entity.
+- No unverified identity assumptions are introduced automatically.

--- a/.agents/services/email/email-mailbox.md
+++ b/.agents/services/email/email-mailbox.md
@@ -664,6 +664,7 @@ SEARCH OR (FROM "alice@example.com" SUBJECT "report") (FROM "bob@example.com" SU
 - `services/email/ses.md` -- Amazon SES sending configuration
 - `services/email/email-testing.md` -- Email deliverability testing
 - `services/email/email-health-check.md` -- Email infrastructure health checks
+- `services/communications/cross-channel-conversation-continuity.md` -- Entity-aware continuity patterns across email and chat channels
 - `scripts/email-agent-helper.sh` -- Helper script for mailbox operations
 - `scripts/email-to-markdown.py` -- Email parsing pipeline
 - `scripts/email-thread-reconstruction.py` -- Thread building from raw messages

--- a/tests/test-entity-memory-integration.sh
+++ b/tests/test-entity-memory-integration.sh
@@ -561,6 +561,42 @@ test_cross_channel_identity() {
 }
 
 # ===========================================================================
+# Test: Email identity normalization and fallback resolution
+# ===========================================================================
+test_email_identity_normalization() {
+	echo -e "\n${YELLOW}Test: Email identity normalization and fallback resolution${NC}"
+
+	local entity_id
+	entity_id=$(create_entity "Email Normalize" "person")
+	assert_not_empty "$entity_id" "Entity created"
+
+	local rc=0
+	"$ENTITY_HELPER" link "$entity_id" --channel email \
+		--channel-id "  Normalize.Entity+alerts@Example.COM  " --verified >/dev/null 2>&1 || rc=$?
+	assert_exit_code 0 "$rc" "Email link with spaces/case/plus alias succeeds"
+
+	local stored_channel_id
+	stored_channel_id=$(db_query "SELECT channel_id FROM entity_channels WHERE entity_id = '$entity_id' AND channel = 'email' LIMIT 1;")
+	assert_eq "normalize.entity@example.com" "$stored_channel_id" "Stored email channel ID is normalized"
+
+	local resolved_json
+	resolved_json=$("$ENTITY_HELPER" resolve --channel email --channel-id "NORMALIZE.ENTITY+OPS@example.com" 2>/dev/null || true)
+	assert_contains "$resolved_json" "$entity_id" "Resolve matches normalized variant with plus alias"
+
+	# Simulate historical pre-normalization data and ensure fallback still resolves.
+	local legacy_entity
+	legacy_entity=$(create_entity "Legacy Email" "person")
+	assert_not_empty "$legacy_entity" "Legacy entity created"
+
+	db_query "INSERT INTO entity_channels (entity_id, channel, channel_id, confidence) VALUES ('$legacy_entity', 'email', 'Legacy+Tag@Example.COM', 'suggested');" >/dev/null
+
+	resolved_json=$("$ENTITY_HELPER" resolve --channel email --channel-id "legacy@example.com" 2>/dev/null || true)
+	assert_contains "$resolved_json" "$legacy_entity" "Resolve fallback matches legacy non-normalized email"
+
+	return 0
+}
+
+# ===========================================================================
 # Test: Conversation lifecycle — full cycle
 # ===========================================================================
 test_conversation_lifecycle() {
@@ -1002,6 +1038,7 @@ main() {
 	test_privacy_filtering_ingest
 	test_privacy_filtering_output
 	test_cross_channel_identity
+	test_email_identity_normalization
 	test_conversation_lifecycle
 	test_auto_resume
 	test_entity_deletion_cascade


### PR DESCRIPTION
## Summary
- Normalize `email` channel IDs in `entity-helper.sh` (trim + lowercase + plus-alias stripping) so the same person resolves consistently across tagged addresses.
- Extend `resolve` with email fallback matching against legacy non-normalized channel records to preserve continuity for historical data.
- Add integration coverage for normalized/fallback email resolution and add a cross-channel continuity guidance doc, then wire that doc into the mailbox docs.

## Verification
- `shellcheck .agents/scripts/entity-helper.sh tests/test-entity-memory-integration.sh` (SC1091 info only for sourced constants)
- `bash tests/test-entity-memory-integration.sh` (existing pre-existing failures in `test_privacy_filtering_output`; new `test_email_identity_normalization` added and validated separately)
- Focused regression check passed:
  - create/link/resolve normalized email aliases
  - resolve fallback for legacy non-normalized email channel IDs

Closes #5002