### PR TITLE
t5072: fix worker count — deduplicate opencode process chain

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1219,11 +1219,25 @@ This PR modifies \`.github/workflows/\` files but the GitHub OAuth token used by
 # Output: worker summary to stdout (appended to STATE_FILE by caller)
 #######################################
 list_active_worker_processes() {
+	# t5072: Count logical workers (one per session/issue), not OS process tree nodes.
+	# A single opencode worker spawns a 3-process chain:
+	#   bash sandbox-exec-helper.sh run ... -- opencode run ...  (top-level launcher)
+	#   node /opt/homebrew/bin/opencode run ...                  (node child)
+	#   /path/to/.opencode run ...                               (binary grandchild)
+	# All three contain /full-loop and opencode in their command line.
+	# Fix: match only the top-level launcher process per logical worker:
+	#   1. Lines containing sandbox-exec-helper.sh (normal production path)
+	#   2. Direct opencode run invocations that are NOT node/binary children
+	#      (sandbox-disabled path and test fixtures)
+	# Exclude: lines starting with "node " (node child) or whose command
+	# starts with a path ending in "/.opencode " (binary grandchild).
 	ps axo pid,etime,command | awk '
 		/\/full-loop/ &&
 		$0 !~ /(^|[[:space:]])\/pulse([[:space:]]|$)/ &&
 		$0 !~ /Supervisor Pulse/ &&
-		$0 ~ /(^|[[:space:]\/])\.?opencode([[:space:]]|$)/ {
+		$0 ~ /(^|[[:space:]\/])\.?opencode([[:space:]]|$)/ &&
+		$0 !~ /[[:space:]]node[[:space:]].*opencode/ &&
+		$0 !~ /\/\.opencode[[:space:]]/ {
 			print
 		}
 	'

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -157,6 +157,49 @@ test_counts_plain_and_dot_prefixed_opencode_workers() {
 	return 0
 }
 
+test_deduplicates_process_chain_to_one_logical_worker() {
+	# t5072: A single opencode worker spawns a 3-process chain:
+	#   bash sandbox-exec-helper.sh run ... -- opencode run ...  (top-level launcher)
+	#   node /opt/homebrew/bin/opencode run ...                  (node child)
+	#   /path/to/.opencode run ...                               (binary grandchild)
+	# All three contain /full-loop and opencode — only the launcher must be counted.
+	set_ps_fixture "200 00:30 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5072\" --dir /tmp/aidevops --title Issue #5072
+201 00:30 node /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5072\" --dir /tmp/aidevops --title Issue #5072
+202 00:30 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #5072\" --dir /tmp/aidevops --title Issue #5072"
+
+	local count
+	count=$(count_active_workers)
+	# Only line 200 (sandbox launcher) should be counted; 201 and 202 are child processes
+	if [[ "$count" != "1" ]]; then
+		print_result "count_active_workers deduplicates 3-process chain to 1 logical worker" 1 "Expected 1, got ${count} (process chain not deduplicated)"
+		return 0
+	fi
+
+	print_result "count_active_workers deduplicates 3-process chain to 1 logical worker" 0
+	return 0
+}
+
+test_deduplicates_multiple_workers_with_process_chains() {
+	# t5072: Two logical workers, each spawning a 3-process chain = 6 OS processes.
+	# count_active_workers must return 2, not 6.
+	set_ps_fixture "300 01:00 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5001\" --dir /tmp/aidevops --title Issue #5001
+301 01:00 node /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5001\" --dir /tmp/aidevops --title Issue #5001
+302 01:00 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #5001\" --dir /tmp/aidevops --title Issue #5001
+310 00:20 bash /home/user/.aidevops/agents/scripts/sandbox-exec-helper.sh run --timeout 3600 --allow-secret-io -- /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5002\" --dir /tmp/aidevops --title Issue #5002
+311 00:20 node /opt/homebrew/bin/opencode run \"/full-loop Implement issue #5002\" --dir /tmp/aidevops --title Issue #5002
+312 00:20 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run \"/full-loop Implement issue #5002\" --dir /tmp/aidevops --title Issue #5002"
+
+	local count
+	count=$(count_active_workers)
+	if [[ "$count" != "2" ]]; then
+		print_result "count_active_workers counts 2 logical workers from 6 process-chain entries" 1 "Expected 2, got ${count}"
+		return 0
+	fi
+
+	print_result "count_active_workers counts 2 logical workers from 6 process-chain entries" 0
+	return 0
+}
+
 test_repo_issue_detection_uses_filtered_worker_list() {
 	set_ps_fixture "211 00:31 opencode run --dir /tmp/aidevops --session-key issue-4342 --title Issue #4342: fix \"/full-loop Implement issue #4342\"
 212 00:31 opencode run --dir /tmp/other --session-key issue-4342 --title Issue #4342: other \"/full-loop Implement issue #4342\"
@@ -251,6 +294,8 @@ main() {
 	source "$PULSE_WRAPPER_SCRIPT"
 
 	test_counts_plain_and_dot_prefixed_opencode_workers
+	test_deduplicates_process_chain_to_one_logical_worker
+	test_deduplicates_multiple_workers_with_process_chains
 	test_repo_issue_detection_uses_filtered_worker_list
 	test_has_merged_pr_for_issue_detects_closing_keyword
 	test_has_merged_pr_for_issue_detects_task_id_fallback


### PR DESCRIPTION
## Summary

- `list_active_worker_processes()` was matching all 3 OS processes spawned by a single opencode worker (bash sandbox launcher + node child + `.opencode` binary grandchild), inflating `WORKER_COUNT` by 3x per logical worker
- Fix: exclude node child processes and `.opencode` binary grandchild processes from the awk filter; only the top-level `sandbox-exec-helper.sh` launcher (or direct `opencode run` when sandbox is disabled) is counted
- A single worker now reports as `1` in `WORKER_COUNT` regardless of process tree depth

## Changes

- `pulse-wrapper.sh`: updated `list_active_worker_processes()` awk pattern to exclude `node .*/opencode` and `/.opencode ` lines
- `test-pulse-wrapper-worker-detection.sh`: added 2 new test cases — single worker 3-process chain (expect 1) and two workers with 6 total processes (expect 2)

## Verification

All 9 tests pass, ShellCheck zero violations:

```
PASS count_active_workers excludes supervisor /pulse but counts worker with /pulse in args
PASS count_active_workers deduplicates 3-process chain to 1 logical worker
PASS count_active_workers counts 2 logical workers from 6 process-chain entries
PASS has_worker_for_repo_issue matches scoped worker process
PASS has_worker_for_repo_issue rejects unrelated issues
PASS has_worker_for_repo_issue does not match prefix-sibling repo path
PASS has_merged_pr_for_issue detects merged PR via closes keyword
PASS has_merged_pr_for_issue detects merged PR via task-id fallback
PASS check_dispatch_dedup skips dispatch when merged PR exists

Ran 9 tests, 0 failed.
```

Closes #5072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of worker process detection by refining the filtering logic to exclude child processes and ensure only top-level launcher processes are counted correctly.

* **Tests**
  * Added comprehensive test coverage for multi-process worker chain detection and deduplication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->