### PR TITLE
t1533: auto-label issues on closure with reason (duplicate, not-planned, already-fixed, wontfix)

### DIFF
--- a/.agents/scripts/backfill-closure-labels.sh
+++ b/.agents/scripts/backfill-closure-labels.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# backfill-closure-labels.sh — Apply closure reason labels to existing closed issues
+#
+# Usage: bash backfill-closure-labels.sh [--repo owner/repo] [--dry-run] [--limit N]
+#
+# Scans closed issues missing closure reason labels and applies:
+#   - duplicate: state_reason=not_planned + closing comment mentions duplicate
+#   - already-fixed: closed with "already fixed/resolved/done" in comments
+#   - not-planned: state_reason=not_planned (catch-all)
+#   - wontfix: closing comment mentions wontfix/won't fix
+#
+# Issues with status:done (closed by merged PR) are skipped.
+# t1533 — one-time backfill, safe to re-run (idempotent).
+
+set -euo pipefail
+
+_repo=""
+_dry_run=false
+_limit=500
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--repo)
+		_repo="$2"
+		shift 2
+		;;
+	--dry-run)
+		_dry_run=true
+		shift
+		;;
+	--limit)
+		_limit="$2"
+		shift 2
+		;;
+	*)
+		echo "Unknown option: $1" >&2
+		exit 1
+		;;
+	esac
+done
+
+if [[ -z "$_repo" ]]; then
+	_repo=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || echo "")
+	if [[ -z "$_repo" ]]; then
+		echo "ERROR: Could not detect repo. Use --repo owner/repo" >&2
+		exit 1
+	fi
+fi
+
+echo "Backfilling closure reason labels for $_repo (limit: $_limit, dry-run: $_dry_run)"
+
+# Ensure labels exist
+if [[ "$_dry_run" == "false" ]]; then
+	gh label create "not-planned" --repo "$_repo" --force --description "Closed without implementation — not planned" --color "ffffff" 2>/dev/null || true
+	gh label create "already-fixed" --repo "$_repo" --force --description "Already fixed by another change" --color "e4e669" 2>/dev/null || true
+	# duplicate and wontfix already exist as GitHub defaults
+fi
+
+_applied=0
+_skipped=0
+_page=1
+_per_page=100
+
+while [[ "$_applied" -lt "$_limit" && "$_skipped" -lt 2000 ]]; do
+	# Fetch closed issues in batches
+	_issues=$(gh api "repos/${_repo}/issues?state=closed&per_page=${_per_page}&page=${_page}&direction=desc" \
+		--jq '.[] | {number, state_reason, title: .title[:80], labels: [.labels[].name]}' 2>/dev/null || echo "")
+
+	if [[ -z "$_issues" ]]; then
+		echo "No more issues to process (page $_page)"
+		break
+	fi
+
+	# Process each issue
+	while IFS= read -r _issue; do
+		local_number=$(echo "$_issue" | jq -r '.number')
+		local_reason=$(echo "$_issue" | jq -r '.state_reason // "completed"')
+		local_title=$(echo "$_issue" | jq -r '.title')
+		local_labels=$(echo "$_issue" | jq -r '.labels | join(",")')
+
+		# Skip if already has a closure reason label
+		if echo "$local_labels" | grep -qE 'duplicate|not-planned|already-fixed|wontfix|status:done'; then
+			_skipped=$((_skipped + 1))
+			continue
+		fi
+
+		# Determine label
+		local_label=""
+		case "$local_reason" in
+		not_planned)
+			# Check last comment for specifics
+			local_comment=$(gh api "repos/${_repo}/issues/${local_number}/comments" \
+				--jq 'last | .body // ""' 2>/dev/null || echo "")
+
+			if echo "$local_comment" | grep -qiE 'duplicate|dupe|already exists'; then
+				local_label="duplicate"
+			elif echo "$local_comment" | grep -qiE 'already.*(fixed|resolved|done|merged|implemented)'; then
+				local_label="already-fixed"
+			elif echo "$local_comment" | grep -qiE 'wontfix|won'\''t fix|will not'; then
+				local_label="wontfix"
+			else
+				local_label="not-planned"
+			fi
+			;;
+		completed)
+			# Check if there's a closing comment indicating already-fixed
+			local_comment=$(gh api "repos/${_repo}/issues/${local_number}/comments" \
+				--jq 'last | .body // ""' 2>/dev/null || echo "")
+			if echo "$local_comment" | grep -qiE 'already.*(fixed|resolved|done|merged|implemented)'; then
+				local_label="already-fixed"
+			fi
+			# Otherwise skip — completed without status:done is ambiguous
+			;;
+		esac
+
+		if [[ -n "$local_label" ]]; then
+			if [[ "$_dry_run" == "true" ]]; then
+				echo "[DRY-RUN] #$local_number ($local_reason) -> $local_label — $local_title"
+			else
+				gh issue edit "$local_number" --repo "$_repo" --add-label "$local_label" 2>/dev/null || true
+				echo "#$local_number ($local_reason) -> $local_label — $local_title"
+			fi
+			_applied=$((_applied + 1))
+		else
+			_skipped=$((_skipped + 1))
+		fi
+
+		# Rate limit: 1 API call per issue for comments, be gentle
+		sleep 0.2
+
+	done < <(echo "$_issues" | jq -c '.')
+
+	_page=$((_page + 1))
+done
+
+echo ""
+echo "Done. Applied: $_applied, Skipped: $_skipped"
+exit 0

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -638,3 +638,101 @@ jobs:
           else
             echo "Issue #$ISSUE_NUMBER is not persistent — closure allowed"
           fi
+
+  label-closure-reason:
+    name: Label Issue Closure Reason
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      issues: write
+
+    steps:
+      - name: Apply closure reason label
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_LABELS: ${{ join(github.event.issue.labels.*.name, ',') }}
+          REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch state_reason from the API (not available in event payload)
+          STATE_REASON=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '.state_reason // "completed"' 2>/dev/null || echo "completed")
+          echo "Issue #$ISSUE_NUMBER closed with reason: $STATE_REASON"
+
+          # Skip if already closed by a merged PR (sync-on-pr-merge handles those)
+          if echo "$ISSUE_LABELS" | grep -q 'status:done'; then
+            echo "Issue already has status:done — closed by merged PR, skipping"
+            exit 0
+          fi
+
+          # Determine label based on state_reason and existing labels
+          LABEL=""
+          case "$STATE_REASON" in
+            not_planned)
+              # Check if already labelled with a specific reason
+              if echo "$ISSUE_LABELS" | grep -q 'duplicate'; then
+                echo "Already labelled as duplicate"
+                LABEL=""
+              elif echo "$ISSUE_LABELS" | grep -q 'wontfix'; then
+                echo "Already labelled as wontfix"
+                LABEL=""
+              else
+                # Check closing comment for hints about the reason
+                LAST_COMMENT=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+                  --jq 'last | .body // ""' 2>/dev/null || echo "")
+
+                if echo "$LAST_COMMENT" | grep -qiE 'duplicate|dupe|already exists'; then
+                  LABEL="duplicate"
+                elif echo "$LAST_COMMENT" | grep -qiE 'already.*(fixed|resolved|done|merged|implemented)'; then
+                  LABEL="already-fixed"
+                elif echo "$LAST_COMMENT" | grep -qiE 'wontfix|won'\''t fix|will not'; then
+                  LABEL="wontfix"
+                else
+                  LABEL="not-planned"
+                fi
+              fi
+              ;;
+            completed)
+              # Completed but no status:done = closed manually without a PR
+              # Check if there's a linked merged PR
+              LINKED_PR=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/timeline" \
+                --jq '[.[] | select(.event == "cross-referenced" and .source.issue.pull_request != null and .source.issue.state == "closed")] | length' 2>/dev/null || echo "0")
+              if [[ "$LINKED_PR" == "0" ]]; then
+                # Check closing comment for already-fixed hints
+                LAST_COMMENT=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" \
+                  --jq 'last | .body // ""' 2>/dev/null || echo "")
+                if echo "$LAST_COMMENT" | grep -qiE 'already.*(fixed|resolved|done|merged|implemented)'; then
+                  LABEL="already-fixed"
+                fi
+                # Otherwise leave unlabelled — could be manually verified as done
+              fi
+              ;;
+          esac
+
+          if [[ -n "$LABEL" ]]; then
+            # Ensure label exists
+            gh label create "$LABEL" --repo "$REPO" --force \
+              --description "$(
+                case "$LABEL" in
+                  duplicate)     echo "This issue or pull request already exists" ;;
+                  not-planned)   echo "Closed without implementation — not planned" ;;
+                  already-fixed) echo "Already fixed by another change" ;;
+                  wontfix)       echo "This will not be worked on" ;;
+                esac
+              )" \
+              --color "$(
+                case "$LABEL" in
+                  duplicate)     echo "cfd3d7" ;;
+                  not-planned)   echo "ffffff" ;;
+                  already-fixed) echo "e4e669" ;;
+                  wontfix)       echo "ffffff" ;;
+                esac
+              )" 2>/dev/null || true
+
+            gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "$LABEL" 2>/dev/null || true
+            echo "Applied label '$LABEL' to issue #$ISSUE_NUMBER"
+          else
+            echo "No closure reason label needed for issue #$ISSUE_NUMBER"
+          fi


### PR DESCRIPTION
## Summary

- Adds `label-closure-reason` job to `issue-sync.yml` that fires on `issues.closed` and applies the appropriate label based on GitHub `state_reason` and closing comment content
- Adds `backfill-closure-labels.sh` for one-time retroactive labelling of existing closed issues
- Backfill already running — labelling ~100 issues that were closed without reason labels

## Labels applied

| Label | When | Color |
|-------|------|-------|
| `duplicate` | `state_reason=not_planned` + comment mentions "duplicate" | grey |
| `already-fixed` | Comment mentions "already fixed/resolved/done" | yellow |
| `wontfix` | Comment mentions "wontfix/won't fix" | white |
| `not-planned` | `state_reason=not_planned` (catch-all) | white |

Issues already labelled `status:done` (closed by merged PR) are skipped — those are handled by the existing `sync-on-pr-merge` job.

## Testing

- Dry-run backfill correctly identifies issues needing labels
- ShellCheck clean on backfill script
- Workflow YAML validates (existing CI checks)

Closes #5074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic closure reason labeling for closed issues with appropriate labels (duplicate, already-fixed, wontfix, not-planned) based on issue state and comments.
  * Backfill capability to apply closure labels to existing closed issues in bulk with dry-run support and rate-limit protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->