### PR TITLE
t5079: Fix gitignore append to ensure trailing newline before new entries

### DIFF
--- a/.agents/scripts/credential-helper.sh
+++ b/.agents/scripts/credential-helper.sh
@@ -727,6 +727,8 @@ cmd_use() {
 
 	# Add to .gitignore if not already there
 	if [[ -f ".gitignore" ]] && ! grep -q "^\.aidevops-tenant$" ".gitignore" 2>/dev/null; then
+		# Ensure trailing newline before appending (prevents malformed entries)
+		[[ -s ".gitignore" && $(tail -c1 ".gitignore" | wc -l) -eq 0 ]] && printf '\n' >>".gitignore"
 		echo ".aidevops-tenant" >>".gitignore"
 		print_info "Added .aidevops-tenant to .gitignore"
 	fi

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1935,6 +1935,8 @@ SOPSEOF
 
 		# Add runtime artifact ignores
 		if ! grep -q "^\.agents/loop-state/" "$gitignore" 2>/dev/null; then
+			# Ensure trailing newline before appending (prevents malformed entries like *.zip.agents/loop-state/)
+			[[ -s "$gitignore" && $(tail -c1 "$gitignore" | wc -l) -eq 0 ]] && printf '\n' >>"$gitignore"
 			{
 				echo ""
 				echo "# aidevops runtime artifacts"
@@ -1955,6 +1957,8 @@ SOPSEOF
 				git -C "$project_root" rm --cached .aidevops.json &>/dev/null || true
 				print_info "Untracked .aidevops.json from git (was committed by older version)"
 			fi
+			# Ensure trailing newline before appending
+			[[ -s "$gitignore" && $(tail -c1 "$gitignore" | wc -l) -eq 0 ]] && printf '\n' >>"$gitignore"
 			echo ".aidevops.json" >>"$gitignore"
 			gitignore_updated=true
 		fi
@@ -1962,6 +1966,8 @@ SOPSEOF
 		# Add .beads if beads is enabled
 		if [[ "$enable_beads" == "true" ]]; then
 			if ! grep -q "^\.beads$" "$gitignore" 2>/dev/null; then
+				# Ensure trailing newline before appending
+				[[ -s "$gitignore" && $(tail -c1 "$gitignore" | wc -l) -eq 0 ]] && printf '\n' >>"$gitignore"
 				echo ".beads" >>"$gitignore"
 				print_success "Added .beads to .gitignore"
 				gitignore_updated=true

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -297,6 +297,8 @@ migrate_agent_to_agents_folder() {
 
 					# Add runtime artifact ignores if not present
 					if ! grep -q "^\.agents/loop-state/" "$gitignore" 2>/dev/null; then
+						# Ensure trailing newline before appending (prevents malformed entries like *.zip.agents/loop-state/)
+						[[ -s "$gitignore" && $(tail -c1 "$gitignore" | wc -l) -eq 0 ]] && printf '\n' >>"$gitignore"
 						{
 							echo ""
 							echo "# aidevops runtime artifacts"
@@ -887,6 +889,8 @@ migrate_loop_state_directories() {
 		local gitignore="$repo_dir/.gitignore"
 		if [[ -f "$gitignore" ]]; then
 			if ! grep -q "^\.agents/loop-state/" "$gitignore" 2>/dev/null; then
+				# Ensure trailing newline before appending (prevents malformed entries)
+				[[ -s "$gitignore" && $(tail -c1 "$gitignore" | wc -l) -eq 0 ]] && printf '\n' >>"$gitignore"
 				echo ".agents/loop-state/" >>"$gitignore"
 				print_info "  Added .agents/loop-state/ to .gitignore"
 			fi


### PR DESCRIPTION
## Summary

- Adds a trailing-newline check before all 6 `.gitignore` append operations across 3 files
- Prevents malformed entries like `*.zip.agents/loop-state/` when the existing file lacks a trailing newline
- Pattern: `[[ -s "$file" && $(tail -c1 "$file" | wc -l) -eq 0 ]] && printf '\n' >> "$file"`

## Files changed

| File | Locations fixed |
|------|----------------|
| `aidevops.sh` | 3 (runtime artifacts, .aidevops.json, .beads) |
| `setup-modules/migrations.sh` | 2 (agent folder migration, loop state migration) |
| `.agents/scripts/credential-helper.sh` | 1 (.aidevops-tenant) |

## Testing

Verified with bash tests covering:
1. File without trailing newline → newline added before append (fixes the bug)
2. File with trailing newline → no extra newline (no double-spacing)
3. Empty file → no newline added, entry appended normally

ShellCheck passes on all 3 modified files.

Closes #5079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced .gitignore file handling across project initialization, migration, and credential setup processes. Configuration entries are now properly separated with newlines, preventing potential malformed entries that could occur when appending settings to existing files. This ensures clean and valid .gitignore formatting throughout project setup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->