### PR TITLE
t5079: preserve trailing newline before gitignore appends

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1935,6 +1935,9 @@ SOPSEOF
 
 		# Add runtime artifact ignores
 		if ! grep -q "^\.agents/loop-state/" "$gitignore" 2>/dev/null; then
+			if [[ -s "$gitignore" ]] && [[ "$(tail -c 1 "$gitignore" 2>/dev/null || printf '\n')" != $'\n' ]]; then
+				printf '\n' >>"$gitignore"
+			fi
 			{
 				echo ""
 				echo "# aidevops runtime artifacts"
@@ -1955,6 +1958,9 @@ SOPSEOF
 				git -C "$project_root" rm --cached .aidevops.json &>/dev/null || true
 				print_info "Untracked .aidevops.json from git (was committed by older version)"
 			fi
+			if [[ -s "$gitignore" ]] && [[ "$(tail -c 1 "$gitignore" 2>/dev/null || printf '\n')" != $'\n' ]]; then
+				printf '\n' >>"$gitignore"
+			fi
 			echo ".aidevops.json" >>"$gitignore"
 			gitignore_updated=true
 		fi
@@ -1962,6 +1968,9 @@ SOPSEOF
 		# Add .beads if beads is enabled
 		if [[ "$enable_beads" == "true" ]]; then
 			if ! grep -q "^\.beads$" "$gitignore" 2>/dev/null; then
+				if [[ -s "$gitignore" ]] && [[ "$(tail -c 1 "$gitignore" 2>/dev/null || printf '\n')" != $'\n' ]]; then
+					printf '\n' >>"$gitignore"
+				fi
 				echo ".beads" >>"$gitignore"
 				print_success "Added .beads to .gitignore"
 				gitignore_updated=true

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -297,6 +297,9 @@ migrate_agent_to_agents_folder() {
 
 					# Add runtime artifact ignores if not present
 					if ! grep -q "^\.agents/loop-state/" "$gitignore" 2>/dev/null; then
+						if [[ -s "$gitignore" ]] && [[ "$(tail -c 1 "$gitignore" 2>/dev/null || printf '\n')" != $'\n' ]]; then
+							printf '\n' >>"$gitignore"
+						fi
 						{
 							echo ""
 							echo "# aidevops runtime artifacts"
@@ -887,6 +890,9 @@ migrate_loop_state_directories() {
 		local gitignore="$repo_dir/.gitignore"
 		if [[ -f "$gitignore" ]]; then
 			if ! grep -q "^\.agents/loop-state/" "$gitignore" 2>/dev/null; then
+				if [[ -s "$gitignore" ]] && [[ "$(tail -c 1 "$gitignore" 2>/dev/null || printf '\n')" != $'\n' ]]; then
+					printf '\n' >>"$gitignore"
+				fi
 				echo ".agents/loop-state/" >>"$gitignore"
 				print_info "  Added .agents/loop-state/ to .gitignore"
 			fi


### PR DESCRIPTION
## Summary
- prevent malformed `.gitignore` entries by ensuring files end with a newline before appending runtime ignore lines
- apply the newline guard in both migration paths and init-time `.gitignore` updates so all append sites behave consistently

## Verification
- shellcheck setup-modules/migrations.sh
- shellcheck aidevops.sh

Closes #5079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of .gitignore file entries to ensure proper newline handling when new entries are appended, preventing potential file formatting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->