### PR TITLE
feat: add Google Workspace CLI (gws) to setup and auto-update

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -79,6 +79,7 @@ NPM_TOOLS=(
 	"npm|Playwriter MCP|playwriter|--version|playwriter|npm install -g playwriter@latest"
 	"npm|macOS Automator MCP|macos-automator-mcp|--version|@steipete/macos-automator-mcp|npm install -g @steipete/macos-automator-mcp@latest"
 	"npm|Claude Code MCP|claude-code-mcp|--version|@steipete/claude-code-mcp|npm install -g @steipete/claude-code-mcp@latest"
+	"npm|Google Workspace CLI|gws|--version|@googleworkspace/cli|npm install -g @googleworkspace/cli@latest"
 )
 
 BREW_TOOLS=(

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1273,6 +1273,60 @@ setup_opencode_cli() {
 	return 0
 }
 
+setup_google_workspace_cli() {
+	print_info "Setting up Google Workspace CLI (gws)..."
+
+	# Check if gws is already installed
+	if command -v gws >/dev/null 2>&1; then
+		local gws_version
+		gws_version=$(gws --version 2>/dev/null | head -1 || echo "unknown")
+		print_success "Google Workspace CLI already installed: $gws_version"
+		return 0
+	fi
+
+	# Need either bun or npm to install
+	local installer=""
+	local install_pkg="@googleworkspace/cli@latest"
+
+	if command -v bun >/dev/null 2>&1; then
+		installer="bun"
+	elif command -v npm >/dev/null 2>&1; then
+		installer="npm"
+	else
+		print_warning "Neither bun nor npm found - cannot install gws"
+		print_info "Install Node.js first, then re-run setup"
+		return 0
+	fi
+
+	print_info "Google Workspace CLI provides Gmail, Calendar, Drive, and all Workspace APIs"
+	echo "  Used by Email, Business, and Accounts agents for Google Workspace integration."
+	echo ""
+
+	local install_gws="Y"
+	if [[ "$NON_INTERACTIVE" != "true" ]]; then
+		read -r -p "Install Google Workspace CLI via $installer? [Y/n]: " install_gws || install_gws="Y"
+	fi
+	if [[ "$install_gws" =~ ^[Yy]?$ ]]; then
+		if run_with_spinner "Installing Google Workspace CLI" npm_global_install "$install_pkg"; then
+			print_success "Google Workspace CLI installed"
+
+			echo ""
+			print_info "Authentication required before use."
+			print_info "Run 'gws auth setup' to authenticate with your Google account."
+			print_info "For headless use: set GOOGLE_WORKSPACE_CLI_CREDENTIALS_FILE"
+			echo ""
+		else
+			print_warning "Google Workspace CLI installation failed"
+			print_info "Try manually: sudo npm install -g $install_pkg"
+		fi
+	else
+		print_info "Skipped Google Workspace CLI installation"
+		print_info "Install later: $installer install -g $install_pkg"
+	fi
+
+	return 0
+}
+
 setup_orbstack_vm() {
 	# Only available on macOS
 	if [[ "$(uname)" != "Darwin" ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -822,6 +822,7 @@ main() {
 		confirm_step "Setup QuickFile MCP (UK accounting)" && setup_quickfile_mcp
 		confirm_step "Setup browser automation tools" && setup_browser_tools
 		confirm_step "Setup AI orchestration frameworks info" && setup_ai_orchestration
+		confirm_step "Setup Google Workspace CLI (Gmail, Calendar, Drive)" && setup_google_workspace_cli
 		confirm_step "Setup OpenCode CLI (AI coding tool)" && setup_opencode_cli
 		confirm_step "Setup OpenCode plugins" && setup_opencode_plugins
 		# Run AFTER OpenCode CLI install so opencode.json may exist for agent config


### PR DESCRIPTION
## Summary

- Adds Google Workspace CLI (`gws`) installation to the setup flow and auto-update cycle
- `gws` is the official Google Workspace CLI (`@googleworkspace/cli`, 20k+ stars) providing Gmail, Calendar, Drive, Sheets, Docs, Contacts, and all Workspace APIs
- The existing subagent doc at `services/email/google-workspace.md` already has full usage instructions -- this PR wires up the install/update infrastructure

## Changes

| File | Change |
|------|--------|
| `setup-modules/tool-install.sh` | New `setup_google_workspace_cli()` function (follows `setup_opencode_cli` pattern) |
| `setup.sh` | Wired into interactive setup flow before OpenCode CLI |
| `.agents/scripts/tool-version-check.sh` | Added to NPM_TOOLS array for auto-update freshness checks |

## Verification

```
$ npm install -g @googleworkspace/cli@latest
added 43 packages in 2s

$ gws --version
gws 0.16.0
```

Tested: install, version check, and schema introspection all working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Workspace CLI support to the setup and tool management system, including automatic version checking and npm-based installation.
  * Google Workspace CLI can now be installed during initial setup with interactive configuration prompts and authentication guidance.

* **Chores**
  * Enhanced setup flow with improved configuration management for development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->