### PR TITLE
t1536: add site-query optimization intelligence to GEO agents

### DIFF
--- a/.agents/seo/ai-agent-discovery.md
+++ b/.agents/seo/ai-agent-discovery.md
@@ -36,6 +36,10 @@ Evaluate machine discoverability, not only human UX, using multi-turn exploratio
 - Capture sequence of search attempts, page hits, and confidence changes
 - Note where agent loops, backtracks, or stalls
 - Separate retrieval failure from comprehension failure
+- Run explicit `site:` retrieval passes against first-party domain pages
+  (`site:yourdomain.com pricing`, `site:yourdomain.com integrations`)
+- Run third-party validation passes (`site:g2.com [brand]`,
+  `site:capterra.com [brand]`) and compare fact consistency
 
 ### 3) Classify findings
 

--- a/.agents/seo/ai-search-readiness.md
+++ b/.agents/seo/ai-search-readiness.md
@@ -32,6 +32,10 @@ Run a complete, high-signal workflow to improve AI search citations and answer q
 - Classify target queries by likelihood of triggering search grounding
 - Prioritize intents where retrieval can be influenced by SEO changes
 - Validate crawler/bot accessibility so eligible queries can actually fetch content
+- Run site-query readiness checks for critical claims:
+  `site:yourdomain.com [product category] features`,
+  `site:yourdomain.com pricing`,
+  `site:yourdomain.com integrations`
 
 ### Phase 1: Query decomposition
 
@@ -63,6 +67,10 @@ Run a complete, high-signal workflow to improve AI search citations and answer q
 - Track citation frequency and confidence by intent cluster
 - Monitor volatility and re-run high-impact intents on schedule
 - Keep a rolling benchmark so wins are distinguished from noise
+- Audit third-party citation readiness quarterly: verify G2/Capterra/
+  TrustRadius profiles are current and fact-aligned with canonical site pages
+- Use UTM-tagged profile links and partner citations so citation-driven
+  sessions and conversion contribution are measurable
 
 ## Readiness Scorecard (Recommended)
 

--- a/.agents/seo/geo-strategy.md
+++ b/.agents/seo/geo-strategy.md
@@ -72,6 +72,15 @@ Design and evaluate AI search optimization strategy with a retrieval-first appro
 - Keep a single canonical value for every critical fact across the site
 - Prefer additive edits to existing pages before creating net-new pages
 - Ensure key pages remain accessible to major AI/search crawlers
+- Build site-searchable content architecture: important product pages should
+  rank for internal domain retrieval patterns like
+  `site:yourdomain.com [category] features [year]`
+- Keep high-intent terms in title, H1, and section headings so domain-scoped
+  retrieval can match quickly without deep crawl depth
+- Maintain review platform parity (G2/Capterra/TrustRadius): keep pricing,
+  feature limits, target segment, and support model aligned with canonical site
+- Track outbound citations from profile links and comparison assets with
+  UTM conventions so third-party mention flow can be attributed
 
 ## Anti-Patterns
 

--- a/.agents/seo/query-fanout-research.md
+++ b/.agents/seo/query-fanout-research.md
@@ -37,6 +37,23 @@ Simulate how AI systems decompose broad prompts into sub-queries and use that ma
 - Tag each sub-query: high, medium, low priority
 - Include common modifiers (location, budget, urgency, compliance, integration)
 
+### 2.5) Model `site:` retrieval stages
+
+- Treat fan-out as a 3-stage retrieval model:
+  broad discovery -> site-specific deep-dive -> third-party validation
+- Stage 1 (broad discovery): open-web category and comparison queries
+  (for example, "best ATS for SMB 2026")
+- Stage 2 (site-specific deep-dive): domain-scoped checks such as
+  `site:brand.com pricing`, `site:brand.com integrations`,
+  `site:brand.com enterprise features`
+- Stage 3 (third-party validation): independent source checks such as
+  `site:g2.com brand review`, `site:capterra.com brand pricing`,
+  `site:trustradius.com brand alternatives`
+- Predict which branch needs each stage before content production;
+  product claims need Stage 2 and trust/risk claims need Stage 3
+- Build branch maps that show where open search is sufficient versus where
+  domain-scoped retrieval and review-platform corroboration are required
+
 ### 3) Map pages to branches
 
 - Link each sub-query to best existing page
@@ -54,6 +71,8 @@ Simulate how AI systems decompose broad prompts into sub-queries and use that ma
 - Re-run fan-out prompts and compare page/sentence match quality
 - Confirm top branches are answered by high-confidence sections
 - Record unresolved branches for next sprint
+- Include explicit simulation runs for each retrieval stage and record
+  citation/source mix shifts after updates
 
 ## Guardrails
 

--- a/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
+++ b/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
@@ -227,6 +227,45 @@ Evidence supporting this includes:
 [Concluding statement connecting evidence to actionable insight].
 ```
 
+### Site-Searchable Product Block
+
+Use when AI systems are likely to run domain-scoped retrieval such as
+`site:yourdomain.com [category] features [year]`.
+
+```markdown
+## [Product/Category] Features for [Audience] ([Year])
+
+**Best for**: [ICP or use case]
+**Pricing model**: [starting point / packaging logic]
+**Integrations**: [top integrations users ask about]
+**Compliance**: [SOC 2, GDPR, HIPAA, etc.]
+**Time-to-value**: [implementation timeline]
+
+### Key capabilities
+
+- **[Capability 1]**: [Specific and testable description]
+- **[Capability 2]**: [Specific and testable description]
+- **[Capability 3]**: [Specific and testable description]
+
+### Validation sources
+
+- G2: [profile URL with UTM]
+- Capterra: [profile URL with UTM]
+- TrustRadius: [profile URL with UTM]
+```
+
+**Implementation notes:**
+
+- Mirror the same canonical facts on the product page and third-party profiles
+  (pricing anchor, feature limits, support model)
+- Keep `title`, `H1`, and first section paragraph aligned to likely
+  domain-scoped query modifiers
+- Use consistent UTM parameters across profile and comparison links for
+  citation attribution (for example: `utm_source=g2`,
+  `utm_medium=referral`, `utm_campaign=ai_citation`)
+- Review profile freshness monthly to prevent stale third-party facts from
+  outranking first-party updates
+
 ---
 
 ## Domain-Specific GEO Tactics

--- a/.agents/seo/sro-grounding.md
+++ b/.agents/seo/sro-grounding.md
@@ -29,6 +29,9 @@ Selection Rate Optimization (SRO) focuses on whether a source gets selected into
 - AI retrieval often works with fixed context budgets
 - Top-ranked and higher-relevance sources usually receive larger context share
 - Long pages can suffer low content survival if key facts are buried
+- Retrieval often includes domain-scoped probes (`site:brand.com ...`),
+  so selection depends on whether internal page metadata matches likely
+  category/feature modifiers
 
 ## SRO Workflow
 
@@ -71,6 +74,10 @@ Selection Rate Optimization (SRO) focuses on whether a source gets selected into
 - Use lists/tables only when they preserve factual precision
 - Keep policy, pricing, and capability statements up-to-date
 - Refresh critical sections on a defined cadence to preserve snippet freshness
+- Include category terms in title, H1, and opening paragraph to match
+  `site:` query shapes (for example: "[category] features", "[category] pricing")
+- Keep meta descriptions specific and factual so retrieval systems can
+  disambiguate similar pages during domain-scoped selection
 
 ## Common Failure Modes
 


### PR DESCRIPTION
## Summary
- add a documented 3-stage retrieval model (broad discovery -> site-specific deep-dive -> third-party validation) to fan-out research guidance
- add site-searchable content architecture, domain-scoped retrieval optimization, and review-platform parity strategy across GEO/SRO/readiness docs
- add a reusable Site-Searchable Product Block pattern with UTM attribution conventions and extend discovery workflow with explicit `site:` simulation

Closes #5088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced search validation workflows with explicit site-scoped and third-party retrieval checks
  * New product content pattern templates optimized for domain searchability
  * Updated audit phases including quarterly third-party citation readiness assessments  
  * Expanded geographic strategy implementation guidelines for content architecture and citation attribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->