### PR TITLE
t1536: Add site: query optimization intelligence to GEO agents

### DIFF
--- a/.agents/seo/ai-agent-discovery.md
+++ b/.agents/seo/ai-agent-discovery.md
@@ -66,6 +66,9 @@ Evaluate machine discoverability, not only human UX, using multi-turn exploratio
 - Site language uses internal jargon instead of user vocabulary
 - Key answers scattered across weakly-linked pages
 - High-value pages lack explicit sections for common decision questions
+- Page titles use brand-centric language that does not match `site:` query patterns (e.g., "Our Solution" instead of "[Category] Software Features")
+- Review platform profiles are outdated or incomplete, causing third-party validation queries to return stale information
+- Key product pages are consolidated into a single URL, making domain-scoped search return one page for all queries instead of topic-specific matches
 
 ## Related Subagents
 

--- a/.agents/seo/ai-search-readiness.md
+++ b/.agents/seo/ai-search-readiness.md
@@ -81,6 +81,8 @@ Run a complete, high-signal workflow to improve AI search citations and answer q
 - Fact integrity: count of critical contradictions unresolved
 - Discovery success: percent of tasks completed by autonomous exploration
 - Citation stability: variance in citation frequency over repeated runs
+- Site-query readiness: percent of priority pages retrievable via `site:yourdomain.com [category]` queries
+- Third-party profile currency: percent of review platform profiles updated within last quarter
 
 ## Prioritization Rules
 

--- a/.agents/seo/geo-strategy.md
+++ b/.agents/seo/geo-strategy.md
@@ -82,6 +82,27 @@ Design and evaluate AI search optimization strategy with a retrieval-first appro
 - Track outbound citations from profile links and comparison assets with
   UTM conventions so third-party mention flow can be attributed
 
+### Site-searchable content architecture
+
+AI models use `site:yourdomain.com` queries to extract detail from domains they have already identified as relevant. This bypasses traditional SERP ranking — the model is searching your site directly. Content must be structured for domain-scoped retrieval:
+
+- Key product/feature pages must return relevant results for `site:yourdomain.com [category] features [year]` query patterns
+- Each major product, feature, or service should have a dedicated page with a descriptive title containing category terms (not just brand names)
+- Page titles and H1s should include the terms an AI model would use in a `site:` query: product category, feature type, year, and pricing where applicable
+- Avoid consolidating all product information into a single page — domain-scoped search works best when each topic has its own addressable URL
+- Ensure pricing, feature lists, and comparison data are in crawlable HTML, not locked behind JavaScript rendering or gated forms
+
+### Third-party review platform strategy
+
+AI models use `site:g2.com`, `site:capterra.com`, and `site:trustradius.com` queries as a validation stage after extracting claims from brand sites. Third-party citations serve as independent confirmation:
+
+- Maintain complete, current profiles on G2, Capterra, and TrustRadius with the same canonical facts (pricing, features, integrations) as the primary site
+- Ensure review platform profiles use consistent product naming and categorization
+- Respond to reviews to demonstrate active engagement (AI models may extract vendor responses as evidence of support quality)
+- Keep category listings accurate — if the model searches `site:g2.com [your brand] [wrong category]`, it finds nothing
+- Monitor review platform profiles quarterly to ensure feature lists and pricing reflect current offerings
+- Consider TrustRadius, PeerSpot, and vertical-specific review sites for B2B categories where G2/Capterra coverage is thin
+
 ## Anti-Patterns
 
 - Prompt-rank dashboards without content remediation

--- a/.agents/seo/query-fanout-research.md
+++ b/.agents/seo/query-fanout-research.md
@@ -74,12 +74,41 @@ Simulate how AI systems decompose broad prompts into sub-queries and use that ma
 - Include explicit simulation runs for each retrieval stage and record
   citation/source mix shifts after updates
 
+## Site-Scoped Retrieval in Fan-Out
+
+Frontier AI models (observed in GPT-5.4-thinking and similar) use `site:` operator queries extensively during fan-out retrieval. A single user prompt can generate 10+ sub-queries, many of which target specific domains directly rather than searching the open web.
+
+### 3-Stage Retrieval Model
+
+AI fan-out typically follows three stages:
+
+1. **Broad discovery** (queries 1-3): open web searches using category terms, brand names, and comparison phrases to identify relevant domains. Example: `best ATS software 2026`, `[BrandA] vs [BrandB] applicant tracking`.
+2. **Site-specific deep-dive** (queries 4-10): `site:domain.com` queries targeting each discovered brand's own site to extract product details, pricing, features, and differentiators. Example: `site:greenhouse.com enterprise ATS features`, `site:workable.com pricing plans 2026`.
+3. **Third-party validation** (queries 11-13): `site:` queries targeting review platforms (G2, Capterra, TrustRadius) to cross-reference claims with independent evaluations. Example: `site:g2.com greenhouse ATS reviews`, `site:capterra.com workable pricing`.
+
+### Modelling Site-Scoped Sub-Queries
+
+When building a fan-out map, classify each sub-query by retrieval scope:
+
+- **Open-web sub-queries**: discovery-stage queries where the model has not yet committed to a domain. These are influenced by traditional SEO ranking.
+- **Domain-scoped sub-queries**: `site:yourdomain.com` queries where the model is searching your content specifically. These bypass SERP ranking entirely — the model already chose your domain and is extracting detail. Content architecture and on-site searchability determine success.
+- **Third-party validation sub-queries**: `site:g2.com` or `site:capterra.com` queries where the model seeks independent confirmation. Your review platform profiles, not your own site, determine what gets retrieved.
+
+### Implications for Coverage Mapping
+
+- In step 3 (Map pages to branches), tag each branch by its likely retrieval scope: open-web, domain-scoped, or third-party
+- Domain-scoped branches require pages that are individually addressable and contain self-contained answers — the model is searching your site like a database, not reading a narrative
+- Third-party branches require complete, current review platform profiles with the same canonical facts as your primary site
+- A branch marked "complete" on your site but absent from review platforms is only 2/3 covered
+
 ## Guardrails
 
 - Optimize for thematic completeness, not maximal query count
 - Avoid duplicate pages targeting near-identical branches
 - Keep branch language aligned with user phrasing from real queries
 - Re-baseline when SERP intent or product positioning changes
+- Ensure domain-scoped branches have pages that return relevant results for `site:yourdomain.com [category] [feature] [year]` query patterns
+- Verify third-party review profiles contain the same facts as primary site content
 
 ## Related Subagents
 

--- a/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
+++ b/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
@@ -227,7 +227,7 @@ Evidence supporting this includes:
 [Concluding statement connecting evidence to actionable insight].
 ```
 
-### Site-Searchable Product Block
+### GEO Product Block
 
 Use when AI systems are likely to run domain-scoped retrieval such as
 `site:yourdomain.com [category] features [year]`.

--- a/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
+++ b/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
@@ -309,6 +309,75 @@ Different content domains benefit from different authority signals.
 
 ---
 
+## Site-Searchable Content Patterns
+
+These patterns optimize content for domain-scoped AI retrieval — when a model runs `site:yourdomain.com` queries to extract detail from your site specifically.
+
+### Site-Searchable Product Block
+
+Structured content block optimized for domain-scoped AI retrieval. When a model searches `site:yourdomain.com [category] features`, this block ensures the page matches and the key facts are extractable.
+
+```markdown
+## [Product Name]: [Category] [Type] for [Audience]
+
+[Product Name] is a [category term] that [core value proposition in one sentence]. [Key differentiator in one sentence].
+
+### Key Features
+
+- **[Feature category]**: [Specific capability with measurable detail]
+- **[Feature category]**: [Specific capability with measurable detail]
+- **[Feature category]**: [Specific capability with measurable detail]
+- **[Feature category]**: [Specific capability with measurable detail]
+
+### Pricing
+
+[Pricing model] starting at [price point] per [unit/period]. [Brief tier summary]. [Link to detailed pricing page].
+
+### Integrations
+
+Connects with [number] tools including [top 3-5 integration names]. [Link to full integration directory].
+
+*Last updated: [YYYY-MM]*
+```
+
+**Why this works for `site:` retrieval:**
+
+- H2 contains category terms that match `site:` query patterns (not just brand name)
+- Opening sentence is a self-contained definition extractable as a standalone claim
+- Feature list uses category vocabulary, not internal product jargon
+- Pricing and integration sections are individually addressable via heading anchors
+- Last-updated date signals freshness to the retrieval system
+
+### UTM Citation Attribution Tracking
+
+Track which AI-cited pages drive traffic using UTM parameters. AI models that cite sources often include UTM-tagged links, enabling attribution of AI-driven visits.
+
+**Implementation pattern:**
+
+```markdown
+<!-- On pages likely to be cited by AI models -->
+<!-- Canonical URL structure for citation tracking -->
+https://yourdomain.com/product-features/?utm_source=ai&utm_medium=citation&utm_campaign=[model-name]
+```
+
+**Attribution strategy:**
+
+- Monitor `utm_source=ai` or `utm_source=chatgpt` (and similar) traffic in analytics to measure AI citation volume
+- Track which pages receive AI-attributed visits — these are the pages models are actually citing
+- Compare cited pages against your priority page list to identify gaps (high-priority pages not being cited)
+- Use referrer analysis alongside UTM data: AI platforms often send identifiable referrer headers
+- Set up conversion tracking on AI-attributed visits to measure revenue impact, not just traffic
+- Monitor UTM coverage ratio: of all pages cited by AI models, what percentage have proper attribution tracking?
+
+**Key metrics:**
+
+- AI citation traffic volume (visits with AI-attributed UTM or referrer)
+- Citation-to-conversion rate (do AI-referred visitors convert differently?)
+- Page citation distribution (which pages get cited most/least?)
+- UTM coverage (percent of AI-cited pages with attribution tracking)
+
+---
+
 ## Voice Search Optimization
 
 Voice queries are conversational and question-based. Optimize for these patterns:

--- a/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
+++ b/.agents/seo/seo-audit-skill/references/aeo-geo-patterns.md
@@ -355,10 +355,15 @@ Track which AI-cited pages drive traffic using UTM parameters. AI models that ci
 **Implementation pattern:**
 
 ```markdown
-<!-- On pages likely to be cited by AI models -->
-<!-- Canonical URL structure for citation tracking -->
+<!-- Canonical URL (clean, no tracking params) -->
+https://yourdomain.com/product-features/
+
+<!-- Distributed/cited link variant with UTM attribution -->
 https://yourdomain.com/product-features/?utm_source=ai&utm_medium=citation&utm_campaign=[model-name]
 ```
+
+> **Note:** The canonical URL must always be clean — tracking parameters belong
+> only in distributed or cited link variants, never in the canonical itself.
 
 **Attribution strategy:**
 

--- a/.agents/seo/sro-grounding.md
+++ b/.agents/seo/sro-grounding.md
@@ -79,12 +79,24 @@ Selection Rate Optimization (SRO) focuses on whether a source gets selected into
 - Keep meta descriptions specific and factual so retrieval systems can
   disambiguate similar pages during domain-scoped selection
 
+## Optimizing for Domain-Scoped Retrieval
+
+When an AI model runs a `site:yourdomain.com` query, it is searching your site specifically — not competing against the open web. The selection dynamics differ from open-web retrieval:
+
+- **Page titles are query-match surfaces**: the model's `site:` query includes category terms and feature names. Page titles and H1s must contain these terms explicitly. A page titled "Our Platform" will not match `site:yourdomain.com enterprise ATS features` — but "Enterprise ATS Features & Capabilities" will.
+- **Meta descriptions become retrieval previews**: in domain-scoped search, the meta description helps the model decide which of your pages to read. Write meta descriptions as factual summaries containing category terms, not marketing taglines.
+- **Each page competes against your other pages, not competitors**: when the model searches your site, it picks the best-matching page from your domain. Ensure each major topic has a single authoritative page rather than spreading facts across multiple pages that partially match.
+- **Heading hierarchy signals topic structure**: the model uses headings to locate specific sections within a page. Use descriptive headings that match likely query terms (`## Pricing Plans`, `## Enterprise Features`, `## Integration Partners`) rather than creative headings (`## Why We're Different`).
+- **Standalone factual density matters more**: in domain-scoped retrieval, the model is extracting specific claims to compare against other brands. Every key fact should be a self-contained statement that makes sense without surrounding context.
+
 ## Common Failure Modes
 
 - Important claims appear only deep in the page
 - Contradictory facts across pages dilute confidence
 - Overlong narrative sections bury actionable information
 - Snippet candidates rely on pronouns and missing antecedents
+- Page titles use brand-centric language instead of category terms that match `site:` query patterns
+- Key product pages lack meta descriptions with factual summaries
 
 ## Related Subagents
 


### PR DESCRIPTION
## Summary

- Add `site:` operator retrieval intelligence across 6 SEO subagent files, documenting how GPT-5.4 (and similar frontier models) use domain-scoped search queries during fan-out retrieval
- Document the 3-stage retrieval model (broad discovery -> site-specific deep-dive -> third-party validation) in `query-fanout-research.md`
- Add site-searchable content architecture and third-party review platform strategy to `geo-strategy.md`, domain-scoped retrieval optimization to `sro-grounding.md`, site-query readiness checks to `ai-search-readiness.md`, Site-Searchable Product Block pattern and UTM citation attribution to `aeo-geo-patterns.md`, and site-scoped query simulation to `ai-agent-discovery.md`

## Changes

| File | What was added |
|------|---------------|
| `seo/query-fanout-research.md` | 3-stage retrieval model, site-scoped sub-query classification, coverage mapping implications |
| `seo/geo-strategy.md` | Site-searchable content architecture rules, third-party review platform strategy |
| `seo/sro-grounding.md` | Domain-scoped retrieval optimization (titles, meta, headings, factual density) |
| `seo/ai-search-readiness.md` | Phase 0 site-query readiness check, Phase 6 third-party citation readiness, 2 new scorecard metrics |
| `seo/seo-audit-skill/references/aeo-geo-patterns.md` | Site-Searchable Product Block pattern, UTM citation attribution tracking |
| `seo/ai-agent-discovery.md` | Site-scoped query simulation in discovery workflow, new discoverability problems |

## Verification

- All 6 files pass `markdownlint-cli2` with 0 errors
- No new files created — all updates are additive to existing subagents
- 143 lines added across 6 files

Closes #5088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded SEO guidance for domain-scoped (site:) queries: titles, meta descriptions, headings, content architecture, and factual density.
  * Added readiness scorecard metrics (site-query retrievability, third‑party profile currency) and a three-stage site‑scoped retrieval model with validation checks.
  * Added common discoverability issues and remediation checks (brand‑centric titles, stale third‑party profiles, consolidated pages).
  * Introduced site-searchable content patterns/templates and UTM attribution guidance (note: one content block duplicated).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->