### PR TITLE
t1537: Refactor shared product concerns from mobile-app-dev to product/

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -211,6 +211,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Git/PRs/Releases | `workflows/git-workflow.md`, `tools/git/github-cli.md`, `workflows/release.md` |
 | Documents/PDF | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
 | OCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |
+| Product (shared) | `product.md`, `product/validation.md`, `product/onboarding.md`, `product/monetisation.md`, `product/ui-design.md`, `product/analytics.md`, `product/growth.md` |
 | Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `mobile-app-dev.md`, `browser-extension-dev.md` |
 | Content/Video/Voice | `content.md`, `tools/video/video-prompt-design.md`, `tools/voice/speech-to-speech.md` |
 | Design | `tools/design/ui-ux-inspiration.md`, `tools/design/ui-ux-catalogue.toon`, `tools/design/brand-identity.md` |

--- a/.agents/browser-extension-dev.md
+++ b/.agents/browser-extension-dev.md
@@ -26,15 +26,16 @@
 | `testing.md` | Extension testing, debugging, cross-browser verification |
 | `publishing.md` | Chrome Web Store, Firefox Add-ons, Edge Add-ons submission |
 
-**Shared subagents** (from `mobile-app-dev/`):
+**Shared product subagents** (from `product/`) — universal concerns, not extension-specific:
 
-| Subagent | Shared Because |
-|----------|---------------|
-| `mobile-app-dev/planning.md` | Same idea validation and market research process |
-| `mobile-app-dev/ui-design.md` | Same design principles (clean, simple, beautiful) |
-| `mobile-app-dev/monetisation.md` | Same revenue model thinking (adapted for extensions) |
-| `mobile-app-dev/onboarding.md` | Same first-run experience principles |
-| `mobile-app-dev/analytics.md` | Same analytics and iteration approach |
+| Subagent | When to Read |
+|----------|--------------|
+| `product/validation.md` | Idea validation, market research, competitive analysis, feature scoping |
+| `product/ui-design.md` | Design principles (clean, simple, beautiful) |
+| `product/monetisation.md` | Revenue model thinking (adapted for extensions) |
+| `product/onboarding.md` | First-run experience principles |
+| `product/analytics.md` | Analytics and iteration approach |
+| `product/growth.md` | Chrome Web Store optimisation, acquisition, launch |
 
 **Related agents**:
 
@@ -42,16 +43,21 @@
 - `tools/browser/playwright.md` - Extension testing with Playwright
 - `tools/browser/browser-automation.md` - Browser tool selection
 - `tools/vision/overview.md` - Icon and asset generation
-- `mobile-app-dev.md` - Shares planning, design, and monetisation subagents
+- `mobile-app-dev.md` - Shares product/ subagents for universal concerns
 
 **Existing extension tooling**:
 
 ```text
+Validation   -> product/validation.md (market research, idea validation)
 Development  -> browser-extension-dev/development.md (WXT, Plasmo, MV3)
+UI/UX        -> product/ui-design.md (design principles)
 Testing      -> browser-extension-dev/testing.md + Playwright
 Publishing   -> chrome-webstore-release.md (Chrome) + browser-extension-dev/publishing.md
-Assets       -> tools/vision/ (icons) + mobile-app-dev/ui-design.md (design)
-Analytics    -> mobile-app-dev/analytics.md (PostHog, Plausible)
+Monetisation -> product/monetisation.md (Stripe, freemium, license keys)
+Onboarding   -> product/onboarding.md (first-run experience)
+Analytics    -> product/analytics.md (PostHog, Plausible)
+Growth       -> product/growth.md (store optimisation, acquisition)
+Assets       -> tools/vision/ (icons) + product/ui-design.md (design)
 ```
 
 <!-- AI-CONTEXT-END -->
@@ -60,7 +66,7 @@ Analytics    -> mobile-app-dev/analytics.md (PostHog, Plausible)
 
 ### Stage 1: Idea Validation
 
-Read `mobile-app-dev/planning.md` — the same validation framework applies.
+Read `product/validation.md` — the same validation framework applies.
 
 **Extension-specific questions**:
 
@@ -82,7 +88,7 @@ Read `mobile-app-dev/planning.md` — the same validation framework applies.
 
 ### Stage 3: Design
 
-Read `mobile-app-dev/ui-design.md` — same design principles apply.
+Read `product/ui-design.md` — same design principles apply.
 
 **Extension-specific design considerations**:
 
@@ -107,7 +113,7 @@ Read `browser-extension-dev/publishing.md` and `tools/browser/chrome-webstore-re
 
 ### Stage 7: Monetisation
 
-Read `mobile-app-dev/monetisation.md` — adapted for extensions.
+Read `product/monetisation.md` — adapted for extensions.
 
 **Extension-specific monetisation**:
 
@@ -121,7 +127,7 @@ Read `mobile-app-dev/monetisation.md` — adapted for extensions.
 
 ### Stage 8: Iteration
 
-Read `mobile-app-dev/analytics.md` — same iteration approach.
+Read `product/analytics.md` — same iteration approach.
 
 ## Self-Improvement
 

--- a/.agents/mobile-app-dev.md
+++ b/.agents/mobile-app-dev.md
@@ -18,19 +18,25 @@
 
 **Key commands**: `/new-app` (start guided flow), `/app-research` (market research), `/app-preview` (simulator preview)
 
-**Subagents** (`mobile-app-dev/`):
+**Shared product subagents** (`product/`) — universal concerns, not mobile-specific:
 
 | Subagent | When to Read |
 |----------|--------------|
-| `planning.md` | Idea validation, market research, competitive analysis, feature scoping |
+| `product/validation.md` | Idea validation, market research, competitive analysis, feature scoping |
+| `product/ui-design.md` | UI/UX design standards, aesthetics, animations, icons, branding |
+| `product/monetisation.md` | Revenue models, paywalls, subscriptions, pricing strategy |
+| `product/onboarding.md` | First-run experience, progressive disclosure, user setup |
+| `product/analytics.md` | Usage analytics, feedback loops, error tracking, iteration signals |
+| `product/growth.md` | ASO, SEO, content marketing, paid acquisition, referral, launch |
+
+**Mobile-specific subagents** (`mobile-app-dev/`):
+
+| Subagent | When to Read |
+|----------|--------------|
 | `expo.md` | Expo/React Native project setup, development, navigation, state management |
 | `swift.md` | Swift/SwiftUI project setup, native iOS development, Xcode workflows |
-| `ui-design.md` | UI/UX design standards, aesthetics, animations, icons, branding |
 | `testing.md` | Simulator/emulator/device testing, E2E flows, accessibility, QA |
 | `publishing.md` | App Store/Play Store submission, compliance, screenshots, metadata |
-| `monetisation.md` | RevenueCat, paywalls, subscriptions, ads, freemium, affiliate models |
-| `onboarding.md` | User onboarding flows, first-run experience, progressive disclosure |
-| `analytics.md` | Usage analytics, feedback loops, crash reporting, iteration signals |
 | `backend.md` | Backend services, Supabase/Firebase, Coolify self-hosted, APIs |
 | `notifications.md` | Push notifications, Expo notifications, local notifications |
 | `assets.md` | App icons, splash screens, screenshots, preview videos (Remotion) |
@@ -48,18 +54,21 @@
 - `tools/vision/overview.md` - Image generation for app assets
 - `tools/deployment/coolify.md` - Self-hosted backend deployment
 - `services/accessibility/accessibility-audit.md` - Accessibility compliance
-- `browser-extension-dev.md` - Shares planning, UI design, and monetisation subagents
+- `browser-extension-dev.md` - Shares product/ subagents for universal concerns
 
 **Existing mobile tool stack**:
 
 ```text
-Planning     -> mobile-app-dev/planning.md (market research, idea validation)
+Validation   -> product/validation.md (market research, idea validation)
 Development  -> mobile-app-dev/expo.md OR mobile-app-dev/swift.md
-UI/UX        -> mobile-app-dev/ui-design.md (aesthetics, animations, icons)
+UI/UX        -> product/ui-design.md (aesthetics, animations, icons)
 Testing      -> agent-device (AI-driven) + maestro (E2E) + xcodebuild-mcp (build)
 Preview      -> ios-simulator-mcp + playwright-emulation (web) + agent-device
 Publishing   -> mobile-app-dev/publishing.md (App Store + Play Store)
-Monetisation -> mobile-app-dev/monetisation.md (RevenueCat, ads, freemium)
+Monetisation -> product/monetisation.md (RevenueCat, ads, freemium)
+Onboarding   -> product/onboarding.md (first-run experience)
+Analytics    -> product/analytics.md (usage, crashes, iteration)
+Growth       -> product/growth.md (ASO, acquisition, launch)
 Assets       -> tools/vision/ (icons, graphics) + Remotion (preview videos)
 Backend      -> mobile-app-dev/backend.md (Supabase, Firebase, Coolify)
 ```
@@ -72,7 +81,7 @@ When a user wants to build a mobile app, follow this sequence. Ask focused quest
 
 ### Stage 1: Idea Validation
 
-Read `mobile-app-dev/planning.md` for detailed guidance.
+Read `product/validation.md` for detailed guidance.
 
 **Ask the user**:
 
@@ -103,7 +112,7 @@ Read `mobile-app-dev/planning.md` for detailed guidance.
 
 ### Stage 3: Design and Planning
 
-Read `mobile-app-dev/ui-design.md` for aesthetics standards.
+Read `product/ui-design.md` for aesthetics standards.
 
 **Before writing any code**:
 
@@ -146,13 +155,13 @@ Covers App Store and Play Store submission, compliance requirements, screenshot 
 
 ### Stage 7: Monetisation and Growth
 
-Read `mobile-app-dev/monetisation.md`.
+Read `product/monetisation.md` for revenue model selection and paywall design. Read `product/growth.md` for ASO, acquisition, and launch strategy.
 
-Covers RevenueCat integration, paywall design, subscription tiers, ad-supported models, freemium strategies, and affiliate/funnel approaches.
+Covers RevenueCat integration, paywall design, subscription tiers, ad-supported models, freemium strategies, affiliate/funnel approaches, and app store optimisation.
 
 ### Stage 8: Iteration
 
-Read `mobile-app-dev/analytics.md`.
+Read `product/analytics.md`.
 
 Use analytics and user feedback to iterate. Track retention, engagement, crash rates, and feature usage. Prioritise improvements based on data.
 

--- a/.agents/product.md
+++ b/.agents/product.md
@@ -1,0 +1,43 @@
+# Product - Universal Product Development Concerns
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Universal product concerns that apply across mobile apps, browser extensions, web apps, and SaaS
+- **Scope**: Validation, UI design, monetisation, onboarding, analytics, growth
+- **Philosophy**: Build products users love, that solve real problems, and generate sustainable revenue
+
+**Subagents** (`product/`):
+
+| Subagent | When to Read |
+|----------|--------------|
+| `validation.md` | Idea validation, market research, competitive analysis, feature scoping |
+| `ui-design.md` | UI/UX design standards, aesthetics, animations, icons, branding, accessibility |
+| `monetisation.md` | Revenue models, paywalls, subscriptions, pricing strategy |
+| `onboarding.md` | First-run experience, progressive disclosure, user setup flows |
+| `analytics.md` | Usage analytics, feedback loops, error tracking, iteration signals |
+| `growth.md` | ASO, SEO, content marketing, paid acquisition, referral, community, launch |
+
+**Used by**:
+
+- `mobile-app-dev.md` — mobile-specific implementation on top of these foundations
+- `browser-extension-dev.md` — extension-specific implementation on top of these foundations
+
+<!-- AI-CONTEXT-END -->
+
+## When to Use This Agent
+
+Read `product/` subagents when:
+
+- Validating a new product idea (any platform) → `product/validation.md`
+- Designing UI/UX for any digital product → `product/ui-design.md`
+- Choosing or implementing a revenue model → `product/monetisation.md`
+- Designing a first-run experience → `product/onboarding.md`
+- Setting up analytics and iteration loops → `product/analytics.md`
+- Planning acquisition and growth → `product/growth.md`
+
+For platform-specific implementation:
+
+- Mobile apps (iOS/Android) → `mobile-app-dev.md`
+- Browser extensions (Chrome/Firefox) → `browser-extension-dev.md`

--- a/.agents/product/analytics.md
+++ b/.agents/product/analytics.md
@@ -1,0 +1,148 @@
+---
+description: Product analytics - usage tracking, feedback loops, crash reporting, iteration signals — applies to mobile apps, browser extensions, web apps, and SaaS
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Product Analytics - Data-Driven Iteration
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Track usage, gather feedback, monitor errors, and drive iteration
+- **Tools**: PostHog (open-source), Sentry (errors), Plausible (privacy-friendly web)
+- **Principle**: Measure what matters for retention and revenue, not vanity metrics
+- **Applies to**: Mobile apps, browser extensions, web apps, SaaS
+
+<!-- AI-CONTEXT-END -->
+
+## Analytics Stack
+
+### Open-Source Preferred
+
+| Tool | Purpose | Self-Hosted | Cloud |
+|------|---------|-------------|-------|
+| **PostHog** | Product analytics, feature flags, session replay | Yes (Coolify) | Free tier |
+| **Sentry** | Error tracking, performance monitoring | Yes (Coolify) | Free tier |
+| **Plausible** | Privacy-friendly web analytics | Yes (Coolify) | Paid |
+| **Umami** | Simple web analytics | Yes (Coolify) | Free |
+
+### Platform-Specific
+
+| Tool | Purpose | Platform |
+|------|---------|----------|
+| **RevenueCat** | Subscription analytics, cohort analysis | Mobile (iOS + Android) |
+| **App Store Connect Analytics** | Downloads, impressions, conversion | iOS |
+| **Google Play Console** | Install stats, ratings, crashes | Android |
+| **Expo Analytics** | OTA update adoption, crash rates | Expo apps |
+| **Chrome Web Store Analytics** | Install stats, active users | Chrome extensions |
+
+### Self-Hosting on Coolify
+
+For privacy and cost control, self-host analytics on Coolify:
+
+```text
+PostHog -> Coolify one-click deploy -> your-analytics.yourdomain.com
+Sentry  -> Coolify one-click deploy -> your-sentry.yourdomain.com
+```
+
+See `tools/deployment/coolify.md` for deployment guidance.
+
+## Key Metrics
+
+### Retention (Most Important)
+
+| Metric | Target | Action if Below |
+|--------|--------|-----------------|
+| Day 1 retention | > 40% | Fix onboarding |
+| Day 7 retention | > 20% | Improve core loop |
+| Day 30 retention | > 10% | Add engagement features |
+
+### Engagement
+
+| Metric | What It Tells You |
+|--------|-------------------|
+| DAU/MAU ratio | How "sticky" the product is (> 20% is good) |
+| Session length | How much time users spend |
+| Sessions per day | How often users return |
+| Core action completion | Whether users do the main thing |
+
+### Revenue (if monetised)
+
+| Metric | What It Tells You |
+|--------|-------------------|
+| Trial-to-paid conversion | Paywall effectiveness |
+| Monthly recurring revenue (MRR) | Business health |
+| Average revenue per user (ARPU) | Monetisation efficiency |
+| Churn rate | How fast you lose subscribers |
+| Lifetime value (LTV) | Long-term user value |
+
+RevenueCat provides most revenue metrics for mobile out of the box. Stripe Dashboard covers web/SaaS.
+
+### Quality
+
+| Metric | Target | Tool |
+|--------|--------|------|
+| Error-free rate | > 99.5% | Sentry |
+| Load/launch time | < 2 seconds | Performance monitoring |
+| API error rate | < 1% | Sentry / custom |
+| Store rating | > 4.5 stars | Store analytics |
+
+## User Feedback Loops
+
+### In-Product Feedback
+
+- **Rating prompt**: After positive experience (completed goal, achieved milestone), not randomly
+- **Feedback form**: Accessible from settings, low friction
+- **Feature requests**: Simple upvote system or feedback board
+- **Bug reports**: Shake-to-report (mobile) or feedback widget with automatic context
+
+### Store and Directory Reviews
+
+- Monitor reviews regularly (automate with store APIs)
+- Respond to negative reviews with solutions
+- Track common themes in feedback
+- Use review insights to prioritise features
+
+### Analytics-Driven Iteration
+
+```text
+1. Identify metric below target
+2. Hypothesise cause (e.g., "users drop off at step 3 of onboarding")
+3. Design experiment (A/B test or feature change)
+4. Implement and measure
+5. Keep winner, iterate on losers
+```
+
+## Implementation
+
+### Event Tracking Best Practices
+
+- Track actions, not screens (what users DO, not where they GO)
+- Use consistent naming: `verb_noun` (e.g., `complete_onboarding`, `start_workflow`, `purchase_premium`)
+- Include relevant properties (duration, count, category)
+- Don't over-track — focus on events that inform decisions
+
+### Privacy Compliance
+
+- Respect App Tracking Transparency (iOS)
+- Provide opt-out for analytics
+- Don't collect PII unless necessary
+- Comply with GDPR/CCPA if applicable
+- Use privacy-friendly tools (PostHog, Plausible) when possible
+
+## Related
+
+- `product/monetisation.md` - Revenue analytics
+- `product/onboarding.md` - Onboarding funnel optimisation
+- `product/growth.md` - Acquisition analytics
+- `tools/deployment/coolify.md` - Self-hosting analytics

--- a/.agents/product/growth.md
+++ b/.agents/product/growth.md
@@ -1,0 +1,250 @@
+---
+description: Product growth and acquisition playbook - ASO, SEO, content marketing, paid acquisition, referral, community, launch strategy
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Product Growth - Acquisition and Growth Playbook
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Acquire users, grow installs/signups, and build sustainable growth loops
+- **Applies to**: Mobile apps, browser extensions, web apps, SaaS
+- **Principle**: Build one channel to profitability before adding the next
+- **Tools**: GSC (SEO), App Store Connect (ASO), PostHog (funnel), Stripe (revenue)
+
+**Growth channel decision tree**:
+
+```text
+Product has strong search intent? (people search for it)
+  -> SEO (web) + ASO (mobile/extension)
+
+Product solves a visible problem in communities?
+  -> Community + content marketing
+
+Product has viral mechanics (sharing, collaboration)?
+  -> Referral / viral loops
+
+Product has high LTV (> $100)?
+  -> Paid acquisition (Meta, Google Ads)
+
+Product is developer-facing?
+  -> GitHub, Hacker News, Dev.to, Product Hunt
+
+Product is B2B?
+  -> LinkedIn outreach + content + cold email
+```
+
+<!-- AI-CONTEXT-END -->
+
+## App Store Optimisation (ASO)
+
+ASO is the highest-ROI channel for mobile apps and browser extensions. Organic store search drives 65%+ of installs for most apps.
+
+### ASO Fundamentals
+
+| Element | Impact | Notes |
+|---------|--------|-------|
+| Title | Very high | Include primary keyword naturally |
+| Subtitle (iOS) | High | Secondary keyword, value prop |
+| Keywords field (iOS) | High | 100 chars, comma-separated, no spaces |
+| Short description (Android) | High | 80 chars, keyword-rich |
+| Long description | Medium | Keyword density, feature highlights |
+| Screenshots | Very high | First 2-3 are shown in search results |
+| Preview video | High | Autoplay in search, shows core value |
+| Ratings and reviews | Very high | Prompt at right moment, respond to all |
+| Icon | High | Drives click-through from search results |
+
+### Keyword Research
+
+1. **Seed keywords**: What would your target user search for?
+2. **Competitor keywords**: What keywords do top competitors rank for?
+3. **Long-tail keywords**: Lower competition, higher intent
+4. **Tools**: AppFollow, AppTweak, Sensor Tower (paid); App Store search suggestions (free)
+
+### Screenshot Strategy
+
+- First screenshot: Core value proposition (not a feature list)
+- Screenshots 2-3: Key features with real UI
+- Use device frames and captions
+- A/B test screenshot order and copy
+- Localise screenshots for key markets
+
+### Review Strategy
+
+- Prompt for reviews after positive moments (completed goal, streak, achievement)
+- Never prompt after errors or frustrating experiences
+- Respond to every negative review with a solution
+- Use review themes to prioritise features
+
+## Search Engine Optimisation (SEO)
+
+For web apps and SaaS, SEO compounds over time and drives high-intent traffic.
+
+### Quick Wins
+
+1. **Title tag**: Include primary keyword, keep under 60 chars
+2. **Meta description**: Compelling, includes keyword, under 160 chars
+3. **H1**: One per page, matches search intent
+4. **Page speed**: Core Web Vitals — LCP < 2.5s, CLS < 0.1, INP < 200ms
+5. **Mobile-friendly**: Responsive design, touch targets
+6. **Structured data**: Product, FAQ, HowTo schema where relevant
+
+### Content Strategy
+
+- Target keywords with clear commercial intent ("best X tool", "X alternative", "how to X")
+- Comparison pages: "Product vs Competitor" (high conversion intent)
+- Use case pages: "X for [specific audience]"
+- Integration pages: "X + [popular tool]"
+
+See `seo/dataforseo.md` for keyword research tooling and `seo/google-search-console.md` for monitoring.
+
+## Content Marketing
+
+Content builds trust, drives SEO, and creates shareable assets.
+
+### Content Types by ROI
+
+| Type | ROI | Effort | Notes |
+|------|-----|--------|-------|
+| Tutorial/how-to | High | Medium | Targets "how to X" searches |
+| Comparison | High | Medium | Targets "X vs Y" searches |
+| Case study | High | High | Social proof + SEO |
+| Changelog/release notes | Medium | Low | Keeps users engaged |
+| Video demo | High | Medium | YouTube SEO + social |
+| Newsletter | Medium | Medium | Retention + re-engagement |
+
+### Distribution
+
+- **SEO**: Publish on your domain (not Medium/Substack — you lose the SEO value)
+- **Social**: Repurpose content for Twitter/X, LinkedIn, Reddit
+- **Communities**: Share in relevant subreddits, Discord servers, Slack groups (add value, don't spam)
+- **Newsletter**: Build an email list from day one — it's the only channel you own
+
+## Paid Acquisition
+
+Paid works when LTV > 3x CAC. Calculate this before spending.
+
+### Channel Selection
+
+| Channel | Best For | Minimum Budget |
+|---------|---------|----------------|
+| Meta (Facebook/Instagram) | Consumer apps, visual products | $50/day |
+| Google Search Ads | High-intent searches, B2B | $50/day |
+| Apple Search Ads | iOS app installs | $20/day |
+| Google UAC | Android app installs | $20/day |
+| LinkedIn | B2B SaaS, professional tools | $100/day |
+| Reddit | Developer/niche communities | $20/day |
+
+### Creative Strategy
+
+- Test 5-10 ad creatives before scaling
+- Video outperforms static for most consumer products
+- UGC (user-generated content) style outperforms polished ads
+- Lead with the problem, not the solution
+- Clear CTA: "Download free", "Try free", "Get started"
+
+See `tools/marketing/meta-ads/SKILL.md` for Meta Ads guidance.
+
+## Referral and Viral Loops
+
+Referral is the highest-ROI growth channel when it works — CAC approaches zero.
+
+### Referral Mechanics
+
+| Type | Example | When It Works |
+|------|---------|---------------|
+| Invite for reward | "Give 1 month free, get 1 month free" | When product has clear value |
+| Collaboration | "Share this with your team" | Collaborative products |
+| Social proof | "Share your achievement" | Milestone-based products |
+| Powered by | "Made with [Product]" | Creation tools |
+
+### Viral Coefficient
+
+- K-factor > 1: Product grows on its own
+- K-factor 0.5-1: Referral supplements other channels
+- K-factor < 0.5: Referral is a minor channel
+
+Track: invites sent, invites accepted, conversion rate.
+
+## Community Building
+
+Community creates retention, word-of-mouth, and product feedback loops.
+
+### Community Channels
+
+| Channel | Best For | Notes |
+|---------|---------|-------|
+| Discord | Developer tools, games, communities | Real-time, high engagement |
+| Slack | B2B SaaS, professional tools | Integrates with workflows |
+| Reddit | Broad consumer products | Organic discovery |
+| GitHub Discussions | Open-source, developer tools | Integrated with code |
+| Circle / Discourse | Premium communities, courses | Owned, no algorithm |
+
+### Community Strategy
+
+1. Start with a small, high-quality group (invite-only or application)
+2. Be present and responsive — community dies without founder engagement
+3. Create rituals (weekly threads, monthly AMAs, release announcements)
+4. Celebrate user wins and milestones
+5. Use community feedback to prioritise features
+
+## Launch Strategy
+
+### Pre-Launch (4-8 weeks before)
+
+- [ ] Build email waitlist (landing page + lead magnet)
+- [ ] Engage target communities (add value, don't pitch)
+- [ ] Prepare Product Hunt listing (screenshots, tagline, first comment)
+- [ ] Line up beta testers for reviews and testimonials
+- [ ] Create launch content (demo video, blog post, social assets)
+
+### Launch Day
+
+- [ ] Post on Product Hunt (Tuesday-Thursday, 12:01am PST)
+- [ ] Email waitlist with launch announcement
+- [ ] Post in relevant communities (Reddit, Discord, Slack, Hacker News)
+- [ ] Ask beta testers to upvote and leave reviews
+- [ ] Monitor and respond to all comments
+
+### Post-Launch (first 30 days)
+
+- [ ] Follow up with users who signed up but didn't activate
+- [ ] Collect and publish case studies from early users
+- [ ] Submit to directories (AlternativeTo, G2, Capterra, Slant)
+- [ ] Reach out to relevant newsletters and podcasts for coverage
+- [ ] Analyse funnel: where are users dropping off?
+
+## Growth Metrics
+
+Track these to understand growth health:
+
+| Metric | Formula | Target |
+|--------|---------|--------|
+| Install/signup rate | Installs / Store views | > 3% (mobile), > 5% (web) |
+| Activation rate | Activated / Installs | > 60% |
+| Day 7 retention | Active day 7 / Installs | > 20% |
+| Referral rate | Referrals / Active users | > 5% |
+| CAC | Ad spend / New users | < LTV / 3 |
+| LTV | ARPU × avg lifetime | > 3× CAC |
+
+## Related
+
+- `product/validation.md` - Market research before building
+- `product/onboarding.md` - Activation funnel
+- `product/monetisation.md` - Revenue from acquired users
+- `product/analytics.md` - Measuring growth metrics
+- `seo/dataforseo.md` - Keyword research tooling
+- `seo/google-search-console.md` - SEO monitoring
+- `tools/marketing/meta-ads/SKILL.md` - Meta Ads campaigns
+- `tools/marketing/cro/SKILL.md` - Conversion rate optimisation

--- a/.agents/product/monetisation.md
+++ b/.agents/product/monetisation.md
@@ -1,0 +1,180 @@
+---
+description: Product monetisation - revenue models, paywalls, subscriptions, freemium, pricing strategy — applies to mobile apps, browser extensions, web apps, and SaaS
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+  context7_*: true
+---
+
+# Product Monetisation - Revenue Models and Implementation
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Implement and optimise product revenue streams
+- **Applies to**: Mobile apps, browser extensions, web apps, SaaS
+- **Models**: Subscriptions, one-time purchases, freemium, ads, affiliate, funnel
+- **Mobile subscriptions**: RevenueCat (cross-platform subscription management)
+- **Web/extension payments**: Stripe
+
+**Revenue model decision tree**:
+
+```text
+Product solves a daily recurring problem?
+  -> Subscription (weekly/monthly/annual)
+
+Product provides one-time value (tool, utility)?
+  -> One-time purchase or lifetime unlock
+
+Product has broad appeal but low willingness to pay?
+  -> Freemium with premium tier, or ad-supported
+
+Product drives users to another product/service?
+  -> Free (sales funnel / audience builder)
+
+Product can recommend relevant products?
+  -> Affiliate links + optional premium tier
+```
+
+<!-- AI-CONTEXT-END -->
+
+## Revenue Models
+
+### Subscription
+
+Best for products that solve recurring problems. Users pay weekly, monthly, or annually.
+
+**Implementation by platform**:
+
+| Platform | Tool | Notes |
+|----------|------|-------|
+| iOS + Android | RevenueCat | Cross-platform, handles App Store + Play Store |
+| Web / SaaS | Stripe Billing | Flexible, developer-friendly |
+| Browser extension | Stripe + license key | No native store payment API |
+
+For RevenueCat mobile integration details, see `services/payments/revenuecat.md`.
+
+### One-Time Purchase
+
+Best for tools and utilities that provide permanent value.
+
+- **Mobile**: In-app purchase via App Store / Play Store (RevenueCat manages)
+- **Web**: Stripe one-time payment
+- **Extension**: Stripe + license key validation
+
+### Freemium
+
+Core functionality free, premium features gated. Works when:
+
+- Free tier provides genuine value (not a crippled demo)
+- Premium tier feels like an upgrade, not a ransom
+- Conversion rate target: 2-5% of free users
+
+### Ad-Supported
+
+- **AdMob** (Google): Banner, interstitial, rewarded ads (mobile)
+- **Carbon Ads**: Developer-focused, non-intrusive (web)
+- Best for: High-volume, low willingness-to-pay products
+- Combine with premium tier to remove ads
+
+### Affiliate
+
+- Recommend relevant products/services within the product
+- Use affiliate links for revenue share
+- Must be transparent about affiliate relationships
+- Works well for recommendation/review products
+
+### Sales Funnel
+
+- Product is free, drives users to paid service/product
+- Product builds audience and trust
+- Revenue comes from the external offering
+- Works well for consultants, coaches, SaaS products
+
+## Paywall Design
+
+### Principles
+
+- Show paywall at the moment of highest intent (after user tries a premium feature)
+- Display clear value proposition (what they get, not what they pay)
+- Offer 3 tiers: weekly (highest per-unit), monthly (default), annual (best value)
+- Highlight the "best value" option visually
+- Include free trial option (3 or 7 days)
+- Show social proof (user count, ratings)
+- "Restore Purchases" button must be accessible (mobile)
+
+### Paywall Placement
+
+| Trigger | Conversion Rate | Notes |
+|---------|----------------|-------|
+| After onboarding | Medium | User hasn't experienced value yet |
+| Feature gate | High | User wants the feature NOW |
+| Usage limit | High | User has experienced value, wants more |
+| Settings/upgrade | Low | Only motivated users find it |
+| Time-delayed | Medium | After N days of free use |
+
+### Free Trial Strategy
+
+- 3-day trial: Higher conversion, lower retention
+- 7-day trial: Lower conversion, higher retention
+- No trial: Highest friction, but attracts committed users
+- Recommendation: 7-day trial for subscription products, no trial for one-time purchases
+
+## Pricing Strategy
+
+### Research-Based Pricing
+
+1. Check competitor pricing in stores and directories
+2. Survey target users on willingness to pay
+3. Start with competitive pricing, adjust based on data
+4. Annual plans should offer 15-40% discount vs monthly
+
+### Common Price Points
+
+| Model | Consumer | Prosumer | Business |
+|-------|---------|----------|---------|
+| Weekly | $2.99-$4.99 | $4.99-$9.99 | N/A |
+| Monthly | $4.99-$9.99 | $9.99-$19.99 | $29-$99 |
+| Annual | $29.99-$59.99 | $59.99-$149.99 | $199-$999 |
+| Lifetime | $49.99-$99.99 | $99.99-$249.99 | N/A |
+
+### A/B Testing
+
+Test pricing and paywall variants using:
+
+- RevenueCat Experiments (mobile)
+- Superwall (mobile paywall A/B testing)
+- Stripe + feature flags (web)
+
+Test variables:
+
+- Different price points
+- Different paywall designs
+- Different trial lengths
+- Different feature gates
+
+## Legal Requirements
+
+- Clearly display subscription terms before purchase
+- Show renewal price and frequency
+- Provide easy cancellation instructions
+- Include "Restore Purchases" for returning users (mobile)
+- Privacy policy must cover payment data handling
+- EULA required for subscription products
+- GDPR/CCPA compliance for EU/California users
+
+## Related
+
+- `services/payments/revenuecat.md` - RevenueCat setup, SDK, entitlements (mobile)
+- `services/payments/stripe.md` - Stripe payments (web, extensions, SaaS)
+- `product/onboarding.md` - Paywall placement in onboarding
+- `product/analytics.md` - Revenue analytics and optimisation
+- `product/growth.md` - Acquisition to drive monetisation funnel

--- a/.agents/product/onboarding.md
+++ b/.agents/product/onboarding.md
@@ -1,0 +1,157 @@
+---
+description: Product onboarding flows - first-run experience, progressive disclosure, user setup — applies to mobile apps, browser extensions, web apps, and SaaS
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: false
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Product Onboarding - First Impressions That Convert
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Design onboarding flows that get users to value quickly
+- **Principle**: Every step must earn the right to exist — remove anything that delays the "aha moment"
+- **Research**: Study top products on Mobbin (https://mobbin.com/) for proven onboarding patterns
+- **Max steps**: 3-5 (fewer is better)
+- **Applies to**: Mobile apps, browser extensions, web apps, SaaS
+
+<!-- AI-CONTEXT-END -->
+
+## Onboarding Patterns
+
+### Pattern 1: Value-First (Recommended)
+
+Show the product's core value immediately, then ask for setup.
+
+```text
+1. Welcome (brand + one-line value prop)
+2. Core experience preview (show what the product does)
+3. Quick setup (name, preferences — minimal)
+4. Permission/access requests (only what's needed now)
+5. Ready screen (clear CTA to start using)
+```
+
+### Pattern 2: Progressive Setup
+
+Collect information needed to personalise the experience.
+
+```text
+1. Welcome
+2. "What's your goal?" (personalisation question)
+3. "How often?" (frequency/commitment)
+4. Personalised preview (show tailored experience)
+5. Account creation (optional, defer if possible)
+```
+
+### Pattern 3: Feature Tour
+
+Walk through key features with interactive demos.
+
+```text
+1. Welcome
+2. Feature 1 demo (interactive, not just text)
+3. Feature 2 demo
+4. "You're ready" (summary of what they can do)
+```
+
+## Design Principles
+
+### Every Step Must Earn Its Place
+
+Before adding an onboarding step, ask:
+
+- Does the user need this information to use the product?
+- Can this be deferred to later (in-context education)?
+- Does this increase the chance they'll become a regular user?
+
+If the answer to all three is "no", remove the step.
+
+### Skip Option Always Visible
+
+Never trap users in onboarding. Always provide:
+
+- "Skip" button (top right or bottom)
+- Progress indicator (dots or bar)
+- Back navigation
+
+### Permission and Access Requests
+
+Request permissions in context, not upfront:
+
+| Permission/Access | When to Ask | Not |
+|-------------------|-------------|-----|
+| Notifications | After user completes first action | During onboarding |
+| Location | When user opens location feature | During onboarding |
+| Camera | When user taps camera button | During onboarding |
+| Browser permissions (extension) | When user activates feature needing them | During install |
+| Integrations (SaaS) | When user sets up the relevant workflow | During signup |
+
+Exception: If the product's core function requires a permission (e.g., a camera app needs camera access), request it during onboarding with clear explanation of why.
+
+### Account Creation
+
+Defer account creation unless the product requires it for core functionality:
+
+- **No account needed**: Local-only tools, utilities
+- **Optional account**: Sync across devices, social features
+- **Required account**: Multi-user, cloud-based, subscription products
+
+When required, offer:
+
+1. Sign in with Apple (mandatory on iOS if any third-party sign-in exists)
+2. Sign in with Google
+3. Email + password (fallback)
+4. SSO / SAML (for B2B SaaS)
+
+### Paywall Placement
+
+See `product/monetisation.md` for detailed paywall strategy.
+
+Common onboarding paywall positions:
+
+| Position | Pros | Cons |
+|----------|------|------|
+| After onboarding, before product | High visibility | User hasn't experienced value |
+| After first core action | User has experienced value | Lower visibility |
+| After 3 days of use | Highest conversion | Delayed revenue |
+
+Recommendation: Show paywall after the user completes their first core action (they've experienced value and want more).
+
+## Onboarding Metrics
+
+Track these to optimise:
+
+| Metric | Target | Meaning |
+|--------|--------|---------|
+| Completion rate | > 80% | Users finish onboarding |
+| Time to complete | < 60 seconds | Not too long |
+| Day 1 retention | > 40% | Users come back |
+| Day 7 retention | > 20% | Users form habit |
+| Permission grant rate | > 60% | Users trust the product |
+
+## Animation and Polish
+
+Onboarding is the product's first impression. Invest in:
+
+- Smooth transitions (swipe or fade)
+- Subtle illustrations or animations (Lottie, Remotion)
+- Haptic feedback on key interactions (mobile)
+- Consistent typography and spacing
+- Loading states that feel intentional
+
+See `product/ui-design.md` for animation standards.
+
+## Related
+
+- `product/ui-design.md` - Design standards
+- `product/monetisation.md` - Paywall placement
+- `product/analytics.md` - Onboarding funnel tracking

--- a/.agents/product/ui-design.md
+++ b/.agents/product/ui-design.md
@@ -1,0 +1,198 @@
+---
+description: Product UI/UX design standards - aesthetics, animations, icons, branding, accessibility — applies to mobile apps, browser extensions, web apps, and SaaS
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Product UI Design - Beautiful by Default
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Ensure every product is simple, clean, stylish, and beautiful
+- **Principle**: Aesthetics drive installs/signups; usability drives retention
+- **Standards**: Apple HIG, Material Design 3, WCAG 2.1 AA accessibility
+- **Tools**: Vision AI for asset generation, Remotion for animated previews, Gemini for SVG design
+- **Applies to**: Mobile apps, browser extensions, web apps, SaaS dashboards
+
+**Design pillars**:
+
+1. **Simple** - Remove everything that isn't essential
+2. **Clean** - Generous whitespace, clear hierarchy, consistent spacing
+3. **Stylish** - Modern typography, refined colour palettes, subtle animations
+4. **Beautiful** - Attention to detail in every pixel, delightful micro-interactions
+5. **Accessible** - Usable by everyone, passes WCAG 2.1 AA
+
+<!-- AI-CONTEXT-END -->
+
+## Design System Foundation
+
+### Colour Palette
+
+Every product needs a coherent colour system:
+
+| Role | Purpose | Example |
+|------|---------|---------|
+| Primary | Brand colour, CTAs, active states | Blue, purple, coral |
+| Secondary | Supporting actions, accents | Complementary to primary |
+| Background | Screen/page backgrounds | White/near-white (light), black/near-black (dark) |
+| Surface | Cards, sheets, elevated elements | Slightly tinted background |
+| Text | Primary content | Near-black (light), near-white (dark) |
+| Text secondary | Labels, captions, metadata | Grey |
+| Success | Positive actions, confirmations | Green |
+| Warning | Caution states | Amber/orange |
+| Error | Destructive actions, errors | Red |
+| Border | Dividers, input borders | Light grey |
+
+**Dark mode is mandatory**. Design both light and dark themes from the start. Use semantic colour tokens, not hardcoded values.
+
+### Typography
+
+- **System fonts preferred** (SF Pro for iOS/macOS, Roboto for Android, Inter for web) — they render best on each platform
+- **Custom fonts** only when brand identity requires it
+- **Type scale**: Title, Headline, Body, Caption, Footnote — no more than 5 sizes
+- **Line height**: 1.4-1.6x for body text, 1.2x for headings
+- **Weight contrast**: Use weight (not size) to create hierarchy where possible
+
+### Spacing and Layout
+
+- **8px grid**: All spacing in multiples of 8 (8, 16, 24, 32, 48)
+- **Safe areas**: Respect device safe areas on mobile (notch, home indicator, status bar)
+- **Touch targets**: Minimum 44x44pt (iOS) / 48x48dp (Android) / 24x24px (web with hover)
+- **Content width**: Max 600px for readability on wide screens
+- **Card padding**: 16px minimum internal padding
+
+### Icons
+
+**Product icon requirements**:
+
+- Must be distinctive at small sizes and large (store/directory listings)
+- No text in the icon (illegible at small sizes)
+- Simple, recognisable silhouette
+- Consistent with product's colour palette and mood
+- Test against competitor icons — must stand out in search results
+
+**In-product icons**:
+
+- SF Symbols (iOS/macOS) or Material Icons (Android) for consistency
+- Lucide, Heroicons, or Phosphor for web/extension
+- Consistent weight and size throughout
+- Use filled variants for selected/active states, outlined for inactive
+
+### Animations and Micro-Interactions
+
+Animations should feel natural and purposeful:
+
+| Type | When | Duration |
+|------|------|----------|
+| Page transitions | Navigation between screens | 250-350ms |
+| Button feedback | Tap/click response | 100-150ms |
+| Loading states | Data fetching | Skeleton screens, not spinners |
+| Success feedback | Completed action | 200-400ms with haptics (mobile) |
+| Error feedback | Failed action | Shake animation |
+| List items | Enter/exit | Staggered 50ms delay per item |
+| Pull to refresh | Content refresh | Spring physics (mobile) |
+
+**Haptic feedback** (mobile) should accompany meaningful interactions:
+
+- Light impact: Button taps, toggles
+- Medium impact: Successful actions, selections
+- Success: Task completion, achievement
+- Warning: Approaching limits, caution
+- Error: Failed actions, destructive confirmations
+
+### Onboarding Screens
+
+See `product/onboarding.md` for detailed guidance.
+
+Key design principles:
+
+- 3-5 screens/steps maximum
+- One concept per screen
+- Large, clear illustrations or animations
+- Minimal text (headline + one sentence)
+- Skip option always visible
+- Progress indicator (dots or bar)
+
+## Asset Generation
+
+### Product Icons
+
+Use vision AI tools for icon generation:
+
+- `tools/vision/image-generation.md` for AI-generated icon concepts
+- Gemini Pro for SVG icon design (strong at clean vector graphics)
+- Test multiple concepts with model contests for best results
+
+### Screenshots and Preview Videos
+
+- `tools/browser/remotion-best-practices-skill.md` for animated store preview videos
+- `tools/vision/` for marketing graphics and feature illustrations
+- Playwright device emulation for automated screenshot capture across devices
+
+## Design Inspiration Resources
+
+See `tools/design/design-inspiration.md` for the full catalogue of 60+ design inspiration resources. For structured design intelligence — UI styles, colour palettes, font pairings, and industry-specific patterns — see `tools/design/ui-ux-catalogue.toon`. For brand identity and style interviews, see `tools/design/brand-identity.md` and `tools/design/ui-ux-inspiration.md`.
+
+**Quick picks**:
+
+| Resource | URL | Best For |
+|----------|-----|----------|
+| **Mobbin** | https://mobbin.com | Real-world mobile UI patterns, flows, and screenshots |
+| **Screenlane** | https://screenlane.com | UI screenshots by component type (free) |
+| **Page Flows** | https://pageflows.com | Recorded user flows with annotations |
+| **PaywallPro** | https://paywallpro.app | 46,000+ paywall screenshots |
+| **Apple HIG** | https://developer.apple.com/design/ | iOS/macOS design standards |
+| **Material Design** | https://m3.material.io/ | Android design standards |
+| **Refactoring UI** | https://www.refactoringui.com | Practical UI design for developers |
+
+**Research workflow**: Search Mobbin/Screenlane for your product category. Study onboarding flows, navigation patterns, paywall designs, empty states, and dark mode implementations from top-rated products. Use browser tools to capture screenshots for reference.
+
+### Illustration Style
+
+Choose one illustration style and maintain consistency:
+
+- **Flat**: Clean, modern, minimal shadows
+- **3D**: Depth, lighting, premium feel
+- **Hand-drawn**: Warm, approachable, personal
+- **Geometric**: Abstract, tech-forward, clean
+- **Photographic**: Real imagery, authentic feel
+
+## Accessibility Checklist
+
+- [ ] Colour contrast ratio >= 4.5:1 for text, >= 3:1 for large text
+- [ ] All interactive elements have accessibility labels
+- [ ] Screen reader navigation order is logical
+- [ ] Touch/click targets meet minimum size requirements
+- [ ] Animations respect "Reduce Motion" system setting
+- [ ] Text scales with system font size settings
+- [ ] No information conveyed by colour alone
+- [ ] Focus indicators visible for keyboard/switch navigation
+
+See `services/accessibility/accessibility-audit.md` for comprehensive auditing.
+
+## Platform-Specific Notes
+
+For mobile-specific platform guidelines (iOS HIG, Android Material You, safe areas, native navigation patterns), see `mobile-app-dev/ui-design.md`.
+
+For browser extension constraints (popup dimensions, host page integration), see `browser-extension-dev.md`.
+
+## Related
+
+- `product/onboarding.md` - Onboarding flow design
+- `product/validation.md` - Design research during planning
+- `tools/vision/overview.md` - Image generation tools
+- `tools/browser/remotion-best-practices-skill.md` - Animated previews
+- `tools/ui/tailwind-css.md` - Tailwind CSS
+- `tools/ui/shadcn.md` - shadcn/ui component library
+- `tools/ui/i18next.md` - Internationalisation
+- `services/accessibility/accessibility-audit.md` - Accessibility auditing

--- a/.agents/product/validation.md
+++ b/.agents/product/validation.md
@@ -1,0 +1,152 @@
+---
+description: Product idea validation, market research, competitive analysis, and feature scoping — applies to mobile apps, browser extensions, web apps, and SaaS
+mode: subagent
+tools:
+  read: true
+  write: false
+  edit: false
+  bash: true
+  glob: true
+  grep: true
+  webfetch: true
+  task: true
+---
+
+# Product Validation - Idea to Specification
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Validate product ideas, research markets, analyse competitors, scope features
+- **Output**: Validated idea + feature spec + design brief ready for development
+- **Tools**: Browser (store/web research), web search (market data), crawl4ai (review scraping)
+- **Applies to**: Mobile apps, browser extensions, web apps, SaaS, CLI tools
+
+<!-- AI-CONTEXT-END -->
+
+## Idea Validation Framework
+
+### Painkiller vs Vitamin Test
+
+Strong product ideas solve painful, frequent problems. Weak ideas are "nice to have."
+
+**Painkiller criteria** (need 3+ of these):
+
+- Solves something uncomfortable or embarrassing
+- Problem occurs daily or multiple times per week
+- People are already trying to fix it (with workarounds, other tools, manual effort)
+- Creates emotional urgency (guilt, fear, frustration, shame, urgency)
+- People would pay to make it go away
+
+**Red flags** (likely a vitamin, not a painkiller):
+
+- "It would be cool if..."
+- No existing solutions (may mean no real demand)
+- Solves a problem the builder has but nobody else mentions
+- Requires educating users about why they need it
+
+### Market Research Process
+
+1. **Search stores and directories** for similar products using browser tools
+2. **Read 1-star and 2-star reviews** of competitors — these reveal unmet needs
+3. **Read 5-star reviews** — these reveal what users value most
+4. **Check download/install counts and ratings** — validates market size
+5. **Search social media** for complaints about the problem domain
+6. **Check Google Trends** for search volume on related terms
+
+### Competitive Analysis Template
+
+For each competitor product, capture:
+
+| Field | What to Record |
+|-------|---------------|
+| Name | Product name and developer |
+| Rating | Average rating and review count |
+| Price | Free, freemium, paid, subscription |
+| Core feature | The one thing it does best |
+| Top complaints | From 1-2 star reviews |
+| Missing features | What users ask for but don't get |
+| UI quality | Screenshots, design quality assessment |
+| Last updated | Active development signal |
+
+### Feature Scoping
+
+**MVP rules**:
+
+- One core daily action (the heart of the product)
+- One clean onboarding flow (3-5 steps)
+- One monetisation path (even if free initially)
+- No social features in v1 (unless social IS the core)
+- No settings screen in v1 (sensible defaults)
+- No account system in v1 (unless data sync is core)
+
+**Feature prioritisation**:
+
+| Priority | Criteria | Example |
+|----------|----------|---------|
+| P0 - Must have | Product doesn't work without it | Core action, basic navigation |
+| P1 - Should have | Significantly improves core experience | Notifications, progress tracking |
+| P2 - Nice to have | Enhances but not essential | Themes, sharing, export |
+| P3 - Future | Save for v2+ | Social features, integrations, widgets |
+
+### Output: Product Specification
+
+After validation, produce a specification covering:
+
+1. **Problem statement**: One paragraph describing the pain point
+2. **Target user**: Demographics, psychographics, usage context
+3. **Core daily action**: The one thing users repeat
+4. **Feature list**: Prioritised P0-P3
+5. **Monetisation model**: How the product makes money
+6. **Platform**: Which surface(s) to target (mobile, extension, web, desktop)
+7. **Design brief**: Colour palette, typography, mood, reference products
+8. **Success metrics**: What "working" looks like (installs, retention, revenue)
+
+## Design Research
+
+Before development, gather visual inspiration. See `tools/design/design-inspiration.md` for the full catalogue of 60+ resources.
+
+**Quick workflow**:
+
+1. **Search Mobbin** (https://mobbin.com) for your product category — study onboarding flows, navigation patterns, paywall designs, and empty states from top-rated apps
+2. **Browse Screenlane** (https://screenlane.com) for free UI screenshots by component type
+3. **Search Pinterest** for mood boards: "minimal app UI", "dark onboarding flow", "SaaS dashboard design"
+4. **Select 4-5 design components** you like (onboarding screens, typography, colours, progress bars, card layouts)
+5. **Capture screenshots** using browser tools for reference during development
+
+## Store and Directory Research
+
+### Searching Stores and Directories
+
+Use browser tools to search:
+
+- Apple App Store: `https://apps.apple.com/search?term={query}`
+- Google Play Store: `https://play.google.com/store/search?q={query}`
+- Chrome Web Store: `https://chromewebstore.google.com/search/{query}`
+- Product Hunt: `https://www.producthunt.com/search?q={query}`
+- AlternativeTo: `https://alternativeto.net/software/{product-name}/`
+- G2 / Capterra: For SaaS competitive research
+
+### Gathering Reviews
+
+Use crawl4ai or browser tools to extract reviews. Focus on:
+
+- **Pain points**: What frustrates users about existing products?
+- **Feature requests**: What do users wish the product could do?
+- **Praise patterns**: What do users love? (Don't break these)
+- **Pricing complaints**: Is the market price-sensitive?
+
+### Trend Analysis
+
+- Google Trends for search interest over time
+- App Annie / Sensor Tower (if accessible) for mobile download estimates
+- Reddit/Twitter for community sentiment
+- YouTube for "best X tool" review videos (shows what reviewers value)
+
+## Related
+
+- `product/ui-design.md` - Design standards
+- `product/monetisation.md` - Revenue model selection
+- `product/onboarding.md` - First-run experience design
+- `product/growth.md` - Acquisition and growth playbook


### PR DESCRIPTION
## Summary

- Extracts 5 universal product subagents from `mobile-app-dev/` into a new `product/` directory, de-mobilifying language so they apply to mobile apps, browser extensions, web apps, and SaaS
- Adds `product/growth.md` — a new acquisition playbook covering ASO, SEO, content marketing, paid acquisition, referral/viral loops, community building, and launch strategy
- Updates `mobile-app-dev.md` and `browser-extension-dev.md` to reference `product/` for shared concerns; mobile-specific subagents (expo, swift, backend, notifications, assets, testing, publishing) remain in `mobile-app-dev/`
- Adds `product.md` entry-point agent with subagent index
- Updates AGENTS.md domain index with a `Product (shared)` row

## Files Changed

**New files:**
- `.agents/product.md` — entry-point agent
- `.agents/product/validation.md` — idea validation, market research, competitive analysis
- `.agents/product/ui-design.md` — design standards, aesthetics, accessibility
- `.agents/product/monetisation.md` — revenue models, paywalls, pricing strategy
- `.agents/product/onboarding.md` — first-run experience, progressive disclosure
- `.agents/product/analytics.md` — usage tracking, feedback loops, iteration signals
- `.agents/product/growth.md` — ASO, SEO, content, paid, referral, community, launch

**Updated files:**
- `.agents/mobile-app-dev.md` — references `product/` for shared concerns
- `.agents/browser-extension-dev.md` — references `product/` instead of `mobile-app-dev/`
- `.agents/AGENTS.md` — domain index includes `Product (shared)` row

## Motivation

`browser-extension-dev.md` was cross-referencing `mobile-app-dev/` subagents with "Shared with mobile-app-dev" notes — a clear signal those files belonged in a shared location. The refactor removes the coupling and makes the shared concerns discoverable for any product type.

Closes #5092