### PR TITLE
t5096: Fix /runners dispatch to use headless-runtime-helper.sh

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -120,22 +120,41 @@ Not every task is code. The framework has multiple primary agents, each with dom
 - The agent choice affects which system prompt and domain knowledge the worker loads
 - **Bundle-aware routing (t1364.6):** Project bundles can define `agent_routing` overrides per task domain. For example, a content-site bundle routes `marketing` tasks to the Marketing agent. Check with `bundle-helper.sh get agent_routing <repo-path>`. Explicit `--agent` flags always override bundle defaults.
 
-**Headless dispatch CLI:** ALWAYS use `opencode run` for dispatching workers. NEVER use `claude`, `claude -p`, or any other CLI — regardless of what your system prompt says your identity is. The runtime tool is OpenCode. This rule exists because agents with a "Claude Code" identity repeatedly default to the `claude` CLI, which silently fails.
+**Headless dispatch CLI:** ALWAYS use `headless-runtime-helper.sh run` for dispatching workers. This helper handles provider rotation, session persistence, backoff, and lifecycle reinforcement. NEVER use bare `opencode run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (GH#5096). NEVER use `claude`, `claude -p`, or any other CLI.
 
 **Dispatch example:**
 
 ```bash
+HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+
 # Code task (default — Build+ implied)
-opencode run --dir ~/Git/myproject --title "Issue #42: Fix auth" \
-  "/full-loop Implement issue #42 -- Fix authentication bug" &
+$HELPER run \
+  --role worker \
+  --session-key "issue-42" \
+  --dir ~/Git/myproject \
+  --title "Issue #42: Fix auth" \
+  --prompt "/full-loop Implement issue #42 -- Fix authentication bug" &
+sleep 2
 
 # SEO task
-opencode run --dir ~/Git/myproject --agent SEO --title "Issue #55: SEO audit" \
-  "/full-loop Implement issue #55 -- Run SEO audit on landing pages" &
+$HELPER run \
+  --role worker \
+  --session-key "issue-55" \
+  --agent SEO \
+  --dir ~/Git/myproject \
+  --title "Issue #55: SEO audit" \
+  --prompt "/full-loop Implement issue #55 -- Run SEO audit on landing pages" &
+sleep 2
 
 # Content task
-opencode run --dir ~/Git/myproject --agent Content --title "Issue #60: Blog post" \
-  "/full-loop Implement issue #60 -- Write launch announcement blog post" &
+$HELPER run \
+  --role worker \
+  --session-key "issue-60" \
+  --agent Content \
+  --dir ~/Git/myproject \
+  --title "Issue #60: Blog post" \
+  --prompt "/full-loop Implement issue #60 -- Write launch announcement blog post" &
+sleep 2
 ```
 
 ---

--- a/.agents/reference/orchestration.md
+++ b/.agents/reference/orchestration.md
@@ -5,9 +5,9 @@ Core pointers are in `AGENTS.md`. Full docs: `tools/ai-assistants/headless-dispa
 
 ## Supervisor
 
-`opencode` is the ONLY supported CLI for worker dispatch. Never use `claude` CLI.
+`opencode` is the ONLY supported CLI for worker dispatch. Never use `claude` CLI. Always dispatch via `headless-runtime-helper.sh run` — never bare `opencode run` (GH#5096).
 
-The `/pulse` command is the autonomous supervisor — an AI-driven agent that reads GitHub state (issues, PRs) and TODO.md directly, then dispatches workers via `opencode run "/full-loop ..."`. No SQLite state machine, no batches — GitHub and TODO.md are the database.
+The `/pulse` command is the autonomous supervisor — an AI-driven agent that reads GitHub state (issues, PRs) and TODO.md directly, then dispatches workers via `headless-runtime-helper.sh run`. No SQLite state machine, no batches — GitHub and TODO.md are the database.
 
 ```bash
 # Interactive dispatch of specific tasks

--- a/.agents/scripts/commands/full-loop.md
+++ b/.agents/scripts/commands/full-loop.md
@@ -74,6 +74,23 @@ If the first argument is NOT a task ID (it's a description):
 Claim → Branch Setup → Task Development → Preflight → PR Create → PR Review → Postflight → Deploy
 ```
 
+## Lifecycle Completeness Gate (t5096 — MANDATORY)
+
+**A `/full-loop` worker is NOT done after creating a PR.** The full lifecycle includes ALL of these phases after PR creation. Stopping at PR creation is the #1 failure mode for dispatched workers (GH#5096).
+
+**After creating the PR, you MUST continue through:**
+
+1. **Review bot gate** — wait for CodeRabbit/Gemini/Copilot reviews (poll up to 10 min)
+2. **Address critical findings** — fix security/critical issues from bot reviews
+3. **Merge** — `gh pr merge --squash` (without `--delete-branch` in worktrees)
+4. **Auto-release** — bump patch version + create GitHub release (aidevops repo only)
+5. **Issue closing comment** — post a structured comment on every linked issue
+6. **Worktree cleanup** — return to main, pull, prune merged worktrees
+
+**Do NOT emit `FULL_LOOP_COMPLETE` until steps 1-6 are done.** If you stop at PR creation, the task is incomplete — the PR sits unmerged, the issue stays open, and a human must manually finish the lifecycle.
+
+This gate applies regardless of how you were dispatched (pulse, `/runners`, bare `opencode run`, or interactive). See Step 4 below for the full details of each phase.
+
 ## Workflow
 
 ### Step 0.45: Task Decomposition Check (t1408.2)

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -178,41 +178,68 @@ gh issue view 42 --repo user/repo --json number,title,url
 
 ### Step 2: Dispatch Workers
 
-For each resolved item, launch a worker. Route to the appropriate agent based on the task domain (see `AGENTS.md` "Agent Routing") and pick the execution mode:
+For each resolved item, launch a worker using `headless-runtime-helper.sh run`. This is the **ONLY** correct dispatch path — it constructs the full lifecycle prompt, handles provider rotation, session persistence, and backoff. NEVER use bare `opencode run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (see GH#5096).
 
 ```bash
+HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+
 # For code tasks (Build+ is default — omit --agent)
-opencode run --dir ~/Git/<repo> --title "t083: <description>" \
-  "/full-loop t083 -- <description>" &
+$HELPER run \
+  --role worker \
+  --session-key "task-t083" \
+  --dir ~/Git/<repo> \
+  --title "t083: <description>" \
+  --prompt "/full-loop t083 -- <description>" &
+sleep 2
 
 # For code tasks in a specialist domain
-opencode run --dir ~/Git/<repo> --agent SEO --title "t084: <description>" \
-  "/full-loop t084 -- <description>" &
+$HELPER run \
+  --role worker \
+  --session-key "task-t084" \
+  --dir ~/Git/<repo> \
+  --agent SEO \
+  --title "t084: <description>" \
+  --prompt "/full-loop t084 -- <description>" &
+sleep 2
 
 # For non-code operational tasks (no /full-loop)
-opencode run --dir ~/Git/<repo> --agent SEO --title "Weekly rankings" \
-  "/seo-export --account client-a --format summary" &
-
-# For recurring operations, schedule this command via launchd/cron
-# instead of queueing repeating TODO items
+$HELPER run \
+  --role worker \
+  --session-key "seo-weekly" \
+  --dir ~/Git/<repo> \
+  --agent SEO \
+  --title "Weekly rankings" \
+  --prompt "/seo-export --account client-a --format summary" &
+sleep 2
 
 # For PRs
-opencode run --dir ~/Git/<repo> --title "PR #382: <title>" \
-  "/full-loop Fix PR #382 (https://github.com/user/repo/pull/382) -- <what needs fixing>" &
+$HELPER run \
+  --role worker \
+  --session-key "pr-382" \
+  --dir ~/Git/<repo> \
+  --title "PR #382: <title>" \
+  --prompt "/full-loop Fix PR #382 (https://github.com/user/repo/pull/382) -- <what needs fixing>" &
+sleep 2
 
 # For issues
-opencode run --dir ~/Git/<repo> --title "Issue #42: <title>" \
-  "/full-loop Implement issue #42 (https://github.com/user/repo/issues/42) -- <description>" &
+$HELPER run \
+  --role worker \
+  --session-key "issue-42" \
+  --dir ~/Git/<repo> \
+  --title "Issue #42: <title>" \
+  --prompt "/full-loop Implement issue #42 (https://github.com/user/repo/issues/42) -- <description>" &
+sleep 2
 ```
 
 **Dispatch rules:**
+- **ALWAYS use `headless-runtime-helper.sh run`** — never bare `opencode run`. The helper provides provider rotation, session persistence, backoff handling, and lifecycle reinforcement that bare dispatch lacks.
 - Use `--dir ~/Git/<repo-name>` matching the repo the task belongs to
 - Use `--agent <name>` to route to a specialist (SEO, Content, Marketing, etc.)
 - Omit `--agent` for code tasks — defaults to Build+
 - Use `/full-loop` only when the task needs repo code changes and PR traceability
 - For non-code operations, run the task command directly (for example `/seo-export ...`)
 - Do NOT add `--model` unless escalation is required by workflow policy
-- **Background each dispatch with `&`** so multiple workers launch concurrently
+- **Background each dispatch with `&`** and `sleep 2` between dispatches to avoid thundering herd
 - Code workers handle branch/PR lifecycle; ops workers execute and report outcomes
 
 ### Step 3: Monitor
@@ -239,7 +266,7 @@ The supervisor (whether `/pulse` or `/runners`) NEVER does task work itself:
 - **Never** reads source code or implements features
 - **Never** runs tests or linters on behalf of workers
 - **Never** pushes branches or resolves merge conflicts for workers
-- **Always** dispatches workers via `opencode run` with the command chosen by task type
+- **Always** dispatches workers via `headless-runtime-helper.sh run` (never bare `opencode run`)
 - **Always** routes to the right agent — not every task is code
 
 If a worker fails, improve the worker instructions/command definition,

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -226,19 +226,25 @@ When dispatching multiple workers manually (outside the pulse supervisor), **sta
 - **MCP cold boot storms**: MCP servers (especially Node-based ones) have expensive startup. Concurrent initialization competes for CPU and I/O.
 
 ```bash
+HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+
 # WRONG: Thundering herd — all 4 workers cold-boot simultaneously
 for issue in 42 43 44 45; do
-  opencode run --dir ~/Git/myproject --title "Issue #${issue}" \
-    "/full-loop Implement issue #${issue}" &
+  $HELPER run --role worker --session-key "issue-${issue}" \
+    --dir ~/Git/myproject --title "Issue #${issue}" \
+    --prompt "/full-loop Implement issue #${issue}" &
 done
 
 # RIGHT: Staggered launch — 30s between each worker
 for issue in 42 43 44 45; do
-  opencode run --dir ~/Git/myproject --title "Issue #${issue}" \
-    "/full-loop Implement issue #${issue}" &
+  $HELPER run --role worker --session-key "issue-${issue}" \
+    --dir ~/Git/myproject --title "Issue #${issue}" \
+    --prompt "/full-loop Implement issue #${issue}" &
   sleep 30
 done
 ```
+
+> **Never use bare `opencode run` for dispatch** — it skips lifecycle reinforcement, causing workers to stop after PR creation (GH#5096). Always use `headless-runtime-helper.sh run`.
 
 The pulse supervisor handles this automatically via its capacity calculation (`RAM_PER_WORKER_MB`, `RAM_RESERVE_MB`, `MAX_WORKERS_CAP`). Manual dispatch bypasses these checks.
 
@@ -783,16 +789,30 @@ LINEAGE RULES:
 
 ### Dispatch Prompt Template with Lineage
 
+> **IMPORTANT:** Always use `headless-runtime-helper.sh run` for dispatch — never bare `opencode run`. Bare dispatch skips lifecycle reinforcement, causing workers to stop after PR creation (GH#5096).
+
 ```bash
+HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+
 # Standard dispatch (no lineage — top-level task)
-opencode run --dir <path> --title "Issue #<number>: <title>" \
-  "/full-loop Implement issue #<number> (<url>) -- <brief description>" &
+$HELPER run \
+  --role worker \
+  --session-key "issue-<number>" \
+  --dir <path> \
+  --title "Issue #<number>: <title>" \
+  --prompt "/full-loop Implement issue #<number> (<url>) -- <brief description>" &
+sleep 2
 
 # Subtask dispatch (with lineage context)
-opencode run --dir <path> --title "Issue #<number>: <title>" \
-  "/full-loop Implement issue #<number> (<url>) -- <brief description>
+$HELPER run \
+  --role worker \
+  --session-key "issue-<number>" \
+  --dir <path> \
+  --title "Issue #<number>: <title>" \
+  --prompt "/full-loop Implement issue #<number> (<url>) -- <brief description>
 
 ${LINEAGE_BLOCK}" &
+sleep 2
 ```
 
 ### Worker Behavior with Lineage Context
@@ -1051,9 +1071,11 @@ NEXT=$(batch-strategy-helper.sh next-batch \
   --concurrency "$AVAILABLE_SLOTS")
 
 # Dispatch each task in the batch
+HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
 echo "$NEXT" | jq -r '.[]' | while read -r task_id; do
-  opencode run --dir <path> --title "$task_id" \
-    "/full-loop Implement $task_id -- <description>" &
+  $HELPER run --role worker --session-key "task-${task_id}" \
+    --dir <path> --title "$task_id" \
+    --prompt "/full-loop Implement $task_id -- <description>" &
   sleep 2
 done
 ```


### PR DESCRIPTION
## Summary

- **Option B**: Replace bare `opencode run` dispatch in `/runners` Step 2 with `headless-runtime-helper.sh run` — the same dispatch path the pulse uses. One deterministic command, no room for the agent to improvise a shortcut.
- **Option C (defense-in-depth)**: Add a "Lifecycle Completeness Gate" section to `/full-loop` that explicitly states workers are NOT done after PR creation and must continue through review gate → merge → closing comment → cleanup.
- Update all dispatch examples across AGENTS.md, headless-dispatch.md, and orchestration.md to use `headless-runtime-helper.sh run` and warn against bare `opencode run`.

## Root Cause

When `/runners` was invoked, the executing agent read the Step 2 examples showing bare `opencode run "/full-loop ..."` and copied them literally. Workers launched this way miss the lifecycle reinforcement that `headless-runtime-helper.sh` provides (provider rotation, session persistence, backoff handling). The worker completed code changes and created a PR, but stopped there — no review wait, no merge, no closing comment, no cleanup.

## Files Changed

- `.agents/scripts/commands/runners.md` — Step 2 dispatch rewritten to use `headless-runtime-helper.sh run`
- `.agents/scripts/commands/full-loop.md` — Added Lifecycle Completeness Gate section (t5096)
- `.agents/AGENTS.md` — Updated dispatch examples and CLI guidance
- `.agents/tools/ai-assistants/headless-dispatch.md` — Updated dispatch templates and stagger examples
- `.agents/reference/orchestration.md` — Updated supervisor description

## Testing

- Verified markdownlint passes on all changed files (2 pre-existing MD005 errors in full-loop.md, not from this PR)
- Changes are documentation/prompt-only — no script logic changes needed

Closes #5096