### PR TITLE
t5107: fix secretlint exit-code detection in patch release preflight

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -617,25 +617,20 @@ run_patch_release_preflight() {
 
 	if [[ ${#changed_file_list[@]} -gt 0 ]]; then
 		print_info "Running secretlint on ${#changed_file_list[@]} changed files..."
-		local secretlint_failed=false
+		local sl_exit_code=0
 		local sl_output=""
 		sl_output=$(
 			cd "$REPO_ROOT" || exit 1
 			"${SECRETLINT_CMD[@]}" "${changed_file_list[@]}" --format compact 2>&1
-		) || true
+		) || sl_exit_code=$?
 
-		if [[ -n "$sl_output" ]] && [[ "$sl_output" =~ :\ line\ [0-9]+,\ col\ [0-9]+ ]]; then
+		if [[ $sl_exit_code -eq 1 ]]; then
 			print_error "Secretlint: findings in changed files since $baseline_ref"
 			echo "$sl_output" | head -5
-			secretlint_failed=true
-		fi
-
-		if secretlint_output_has_runtime_error <(echo "$sl_output"); then
-			print_error "Secretlint execution failed due to runtime error"
 			return 1
-		fi
-
-		if [[ "$secretlint_failed" == "true" ]]; then
+		elif [[ $sl_exit_code -ne 0 ]]; then
+			print_error "Secretlint execution failed with exit code $sl_exit_code"
+			echo "$sl_output" | head -5
 			return 1
 		fi
 		print_success "Secretlint: no findings in changed files since $baseline_ref"


### PR DESCRIPTION
## Summary

- Replaces fragile output-regex detection (`: line N, col N` pattern that doesn't match `--format compact` output) with exit-code-based detection in `run_patch_release_preflight`
- Exit 1 = findings → report and fail; exit ≥2 = runtime error → report and fail; exit 0 = clean
- Removes the now-redundant `secretlint_output_has_runtime_error` call at this site (function retained — still used in the full-scan path at line 549)
- ShellCheck passes clean

Closes #5107

**Source review finding**: [PR #5082 comment](https://github.com/marcusquinn/aidevops/pull/5082#discussion_r2941641845) — gemini-code-assist (HIGH)