### PR TITLE
fix(qd-5109): correct WPackagist acquisition year in wp-dev.md

### DIFF
--- a/.agents/tools/wordpress/wp-dev.md
+++ b/.agents/tools/wordpress/wp-dev.md
@@ -118,7 +118,7 @@ brew install node
 
 ## Composer-Based WordPress (Bedrock)
 
-For projects that manage WordPress as a Composer project (e.g., [Bedrock](https://roots.io/bedrock/)), use [WP Composer](https://wp-composer.com/) as the Composer repository for plugins and themes. It is the preferred alternative to WPackagist (which was acquired by WP Engine in March 2026).
+For projects that manage WordPress as a Composer project (e.g., [Bedrock](https://roots.io/bedrock/)), use [WP Composer](https://wp-composer.com/) as the Composer repository for plugins and themes. It is the preferred alternative to WPackagist (which was acquired by WP Engine in March 2024).
 
 **Setup:**
 


### PR DESCRIPTION
## Summary

- Corrects a factual typo in `.agents/tools/wordpress/wp-dev.md` line 121
- WPackagist was acquired by WP Engine in **March 2024**, not 2026
- Addresses the single medium-severity finding from gemini-code-assist review on PR #5078

Closes #5109