### PR TITLE
fix: tighten awk regex patterns in list_active_worker_processes (t5111)

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1236,8 +1236,8 @@ list_active_worker_processes() {
 		$0 !~ /(^|[[:space:]])\/pulse([[:space:]]|$)/ &&
 		$0 !~ /Supervisor Pulse/ &&
 		$0 ~ /(^|[[:space:]\/])\.?opencode([[:space:]]|$)/ &&
-		$0 !~ /[[:space:]]node[[:space:]].*opencode/ &&
-		$0 !~ /\/\.opencode[[:space:]]/ {
+		$0 !~ /[[:space:]]node[[:space:]].*\/opencode/ &&
+		$0 !~ /\/bin\/\.opencode[[:space:]]/ {
 			print
 		}
 	'


### PR DESCRIPTION
## Summary

- Tightens the two awk exclusion patterns in `list_active_worker_processes` (`pulse-wrapper.sh:1239-1240`) to reduce false positives
- Node child pattern now requires a path separator before `opencode` (`.*\/opencode` instead of `.*opencode`)
- Binary grandchild pattern now requires `/bin/` prefix (`\/bin\/\.opencode` instead of `\/\.opencode`)

## Why

The previous patterns were broad enough to match if an issue title or command argument happened to contain the string `opencode` or a path segment `/.opencode`. This could cause valid worker processes to be incorrectly filtered out of the active-worker list.

The tighter patterns match only the actual command structure of child processes:
- `node /path/to/opencode ...` (node child)
- `/path/to/bin/.opencode ...` (binary grandchild)

## Verification

- ShellCheck: zero violations
- 1 file changed, 2 insertions(+), 2 deletions(-)

Closes #5111