### PR TITLE
fix: RFC 4180 quote all CSV fields in attachment manifest (GH#5114)

### DIFF
--- a/.agents/scripts/email-export-helper.sh
+++ b/.agents/scripts/email-export-helper.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
 set -euo pipefail
 
 # Email Export Helper for AI DevOps Framework
@@ -12,9 +11,6 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 readonly EMAIL_TO_MD_SCRIPT="${SCRIPT_DIR}/email-to-markdown.py"
 readonly MAILBOX_HELPER_SCRIPT="${SCRIPT_DIR}/email-mailbox-helper.sh"
 readonly DEFAULT_EXPORT_BASE="${HOME}/.aidevops/.agent-workspace/email-case-exports"
-# Newline literal for bash 3.2-safe case pattern matching (RFC 4180 CSV quoting)
-LF=$'\n'
-readonly LF
 
 timestamp_utc() {
 	date -u +"%Y-%m-%dT%H:%M:%SZ"
@@ -176,18 +172,14 @@ append_attachment_manifest() {
 		while IFS= read -r -d '' file_path; do
 			local filename
 			filename=$(basename "$file_path")
-			# RFC 4180: quote fields containing comma, double-quote, or newline
-			local csv_filename="$filename"
-			case "$filename" in
-			*[,\"]* | *"$LF"*)
-				csv_filename="\"${filename//\"/\"\"}\""
-				;;
-			esac
+			# RFC 4180: quote all fields; double any embedded double-quotes in filename
+			local csv_filename
+			csv_filename="\"${filename//\"/\"\"}\""
 			local size_bytes
 			size_bytes=$(wc -c <"$file_path" | tr -d ' ')
 			local checksum
 			checksum=$(compute_sha256 "$file_path")
-			printf '%s,%s,%s\n' "$csv_filename" "$size_bytes" "$checksum"
+			printf '%s,"%s","%s"\n' "$csv_filename" "$size_bytes" "$checksum"
 		done < <(find "$attachment_dir" -type f ! -name "$manifest_name" -print0 | sort -z)
 	} >"$temp_manifest"
 


### PR DESCRIPTION
## Summary

- Apply consistent RFC 4180 quoting to **all three fields** in `attachment-manifest.csv` output: `filename`, `size_bytes`, and `sha256`
- Previously only filenames containing commas/quotes/newlines were conditionally quoted; `size_bytes` and `checksum` fields were always unquoted
- Remove the now-unused `LF` variable and its `# shellcheck disable=SC2034` directive (introduced for the conditional `case`-pattern approach)

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/email-export-helper.sh` | Always quote all CSV fields; remove unused `LF` variable and SC2034 suppress |

## Verification

- `shellcheck .agents/scripts/email-export-helper.sh` — zero violations
- CSV output now: `"filename","size_bytes","sha256"` for all rows (RFC 4180 compliant)

Closes #5114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CSV formatting consistency and reliability in email export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->