### PR TITLE
fix: use dynamic agents_dir path for headless-runtime-helper.sh dispatch examples

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -125,7 +125,7 @@ Not every task is code. The framework has multiple primary agents, each with dom
 **Dispatch example:**
 
 ```bash
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 
 # Code task (default — Build+ implied)
 $HELPER run \

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -181,7 +181,7 @@ gh issue view 42 --repo user/repo --json number,title,url
 For each resolved item, launch a worker using `headless-runtime-helper.sh run`. This is the **ONLY** correct dispatch path — it constructs the full lifecycle prompt, handles provider rotation, session persistence, and backoff. NEVER use bare `opencode run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (see GH#5096).
 
 ```bash
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 
 # For code tasks (Build+ is default — omit --agent)
 $HELPER run \

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -226,7 +226,7 @@ When dispatching multiple workers manually (outside the pulse supervisor), **sta
 - **MCP cold boot storms**: MCP servers (especially Node-based ones) have expensive startup. Concurrent initialization competes for CPU and I/O.
 
 ```bash
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 
 # WRONG: Thundering herd — all 4 workers cold-boot simultaneously
 for issue in 42 43 44 45; do
@@ -792,7 +792,7 @@ LINEAGE RULES:
 > **IMPORTANT:** Always use `headless-runtime-helper.sh run` for dispatch — never bare `opencode run`. Bare dispatch skips lifecycle reinforcement, causing workers to stop after PR creation (GH#5096).
 
 ```bash
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 
 # Standard dispatch (no lineage — top-level task)
 $HELPER run \
@@ -1071,7 +1071,7 @@ NEXT=$(batch-strategy-helper.sh next-batch \
   --concurrency "$AVAILABLE_SLOTS")
 
 # Dispatch each task in the batch
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 echo "$NEXT" | jq -r '.[]' | while read -r task_id; do
   $HELPER run --role worker --session-key "task-${task_id}" \
     --dir <path> --title "$task_id" \


### PR DESCRIPTION
## Summary

- Replace hardcoded `~/.aidevops/agents/scripts/headless-runtime-helper.sh` with `$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh` in all dispatch examples
- Fixes 5 occurrences across 3 files: `.agents/AGENTS.md`, `.agents/scripts/commands/runners.md`, `.agents/tools/ai-assistants/headless-dispatch.md`
- Respects user configuration of `paths.agents_dir` in `config.jsonc` rather than assuming the default install path

## Root Cause

PR #5099 introduced `HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh` as a hardcoded path in dispatch examples. Gemini flagged this as fragile — if a user has configured a custom `paths.agents_dir`, the examples would point to the wrong location.

## Verification

All 5 occurrences replaced; `grep -rn "HELPER=~/.aidevops"` returns no results.

Closes #5100