### PR TITLE
fix: use aidevops config get paths.agents_dir in HELPER= dispatch examples

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -125,7 +125,7 @@ Not every task is code. The framework has multiple primary agents, each with dom
 **Dispatch example:**
 
 ```bash
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 
 # Code task (default — Build+ implied)
 $HELPER run \

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -181,7 +181,7 @@ gh issue view 42 --repo user/repo --json number,title,url
 For each resolved item, launch a worker using `headless-runtime-helper.sh run`. This is the **ONLY** correct dispatch path — it constructs the full lifecycle prompt, handles provider rotation, session persistence, and backoff. NEVER use bare `opencode run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (see GH#5096).
 
 ```bash
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 
 # For code tasks (Build+ is default — omit --agent)
 $HELPER run \

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -226,7 +226,7 @@ When dispatching multiple workers manually (outside the pulse supervisor), **sta
 - **MCP cold boot storms**: MCP servers (especially Node-based ones) have expensive startup. Concurrent initialization competes for CPU and I/O.
 
 ```bash
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 
 # WRONG: Thundering herd — all 4 workers cold-boot simultaneously
 for issue in 42 43 44 45; do
@@ -792,7 +792,7 @@ LINEAGE RULES:
 > **IMPORTANT:** Always use `headless-runtime-helper.sh run` for dispatch — never bare `opencode run`. Bare dispatch skips lifecycle reinforcement, causing workers to stop after PR creation (GH#5096).
 
 ```bash
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 
 # Standard dispatch (no lineage — top-level task)
 $HELPER run \
@@ -1071,7 +1071,7 @@ NEXT=$(batch-strategy-helper.sh next-batch \
   --concurrency "$AVAILABLE_SLOTS")
 
 # Dispatch each task in the batch
-HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh
+HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
 echo "$NEXT" | jq -r '.[]' | while read -r task_id; do
   $HELPER run --role worker --session-key "task-${task_id}" \
     --dir <path> --title "$task_id" \


### PR DESCRIPTION
## Summary

Addresses PR #5099 review feedback from Gemini (3 findings in headless-dispatch.md + 2 in AGENTS.md and runners.md).

- Replace hardcoded `HELPER=~/.aidevops/agents/scripts/headless-runtime-helper.sh` with `HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"` in all 5 dispatch example code blocks
- Respects user-configured `paths.agents_dir` from `config.jsonc` rather than assuming the default install location
- Functionally identical for default installs; correct for custom `paths.agents_dir` configurations

**Files changed:**
- `.agents/AGENTS.md` (line 128)
- `.agents/scripts/commands/runners.md` (line 184)
- `.agents/tools/ai-assistants/headless-dispatch.md` (lines 229, 795, 1074)

Closes #5102