### PR TITLE
GH#5103: consolidate jq calls in backfill-closure-labels.sh

### DIFF
--- a/.agents/scripts/backfill-closure-labels.sh
+++ b/.agents/scripts/backfill-closure-labels.sh
@@ -74,10 +74,14 @@ while [[ "$_applied" -lt "$_limit" && "$_skipped" -lt 2000 ]]; do
 	# Process each issue (gh --jq '.[]' already outputs one JSON object per line)
 	while IFS= read -r _issue; do
 		[[ -z "$_issue" ]] && continue
-		local_number=$(echo "$_issue" | jq -r '.number')
-		local_reason=$(echo "$_issue" | jq -r '.state_reason // "completed"')
-		local_title=$(echo "$_issue" | jq -r '.title')
-		local_labels=$(echo "$_issue" | jq -r '.labels | join(",")')
+
+		# Single jq call extracts all fields, NUL-delimited for robustness
+		{
+			IFS= read -r -d '' local_number
+			IFS= read -r -d '' local_reason
+			IFS= read -r -d '' local_title
+			IFS= read -r -d '' local_labels
+		} < <(printf '%s' "$_issue" | jq -j '.number, "\u0000", (.state_reason // "completed"), "\u0000", .title, "\u0000", (.labels | join(",")), "\u0000"')
 
 		# Skip if already has a closure reason label
 		if echo "$local_labels" | grep -qE 'duplicate|not-planned|already-fixed|wontfix|status:done'; then


### PR DESCRIPTION
## Summary

- Consolidates 4 separate `jq` forks per issue into a single `jq -j` call with NUL-byte delimiters
- Reduces process forks from 4N to N for N issues processed, improving backfill performance on large repos
- Addresses PR #5097 review feedback (Gemini, medium severity)

## Changes

**`.agents/scripts/backfill-closure-labels.sh`**: Replaced 4 individual `jq -r` calls (lines 77-80) with a single `jq -j` call that outputs all fields (`number`, `state_reason`, `title`, `labels`) separated by NUL bytes (`\u0000`). Fields are read back via `read -r -d ''` in a compound command block.

## Verification

- ShellCheck: zero violations
- Bash 3.2 compatible: `read -d ''` and process substitution both work on bash 3.2
- NUL delimiters handle titles with special characters/newlines safely

Closes #5103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal automation script to improve parsing efficiency and robustness when handling special characters and whitespace in data extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->