### PR TITLE
fix: scope /runners to explicit items only, remove embedded /pulse spec

### DIFF
--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -11,6 +11,30 @@ Dispatch one or more workers to handle tasks. Pick the execution mode per task t
 
 Arguments: $ARGUMENTS
 
+## Scope Boundary
+
+**`/runners` is a targeted dispatch tool, not a supervisor.**
+
+When invoked as `/runners GH#267 GH#268` (or any explicit list of items), it does exactly this:
+
+1. Resolve the specified items
+2. Dispatch one worker per item
+3. Show the dispatch table
+4. Stop
+
+It does **NOT**:
+
+- Run supervisor phases
+- Perform auto-pickup of unrelated tasks
+- Run stale claim recovery
+- Run phantom queue reconciliation
+- Run AI lifecycle evaluation
+- Run CodeRabbit pulse
+- Run audit checks
+- Fill worker slots beyond the explicitly specified items
+
+For unattended operation that fills all available slots and runs supervisor phases, use `/pulse`. See `scripts/commands/pulse.md`.
+
 ## How It Works
 
 The runners system is intentionally simple:
@@ -19,134 +43,7 @@ The runners system is intentionally simple:
 2. **It dispatches `opencode run` for each item** — one worker per task
 3. **Code workers** handle branch -> implementation -> PR -> CI -> merge
 4. **Ops workers** execute the requested SOP/command and report outcomes
-4. **No databases, no state machines, no complex bash pipelines**
-
-The supervisor handles dispatch. The worker command depends on the work type.
-
-> **Note:** The previous bash supervisor implementation (`supervisor-helper.sh` and `supervisor/*.sh`) has been archived to `.agents/scripts/supervisor-archived/` for reference. All active orchestration now uses the AI-driven pulse model described here. Any references to the old paths in setup scripts, tests, or docs should be treated as stale — the archived scripts are not sourced or executed by the current system.
-
-## Automated Mode: `/pulse`
-
-For unattended operation, the `/pulse` command runs every 2 minutes via launchd. Its prime directive is **fill all available worker slots with the highest-value work**. Each pulse cycle:
-
-1. Checks capacity: counts running workers against the configured max (default 6 concurrent)
-2. Reads pre-fetched state: open PRs and issues across all managed repos via `gh`
-3. Merges ready PRs (green CI + review gate passed) — free, no worker slot needed
-4. Dispatches workers to fill all `AVAILABLE` slots (not just one): assigns issues, routes to the right agent, and backgrounds each `opencode run` with `&`
-5. Enters a monitoring loop: sleeps 60s, re-checks capacity, backfills any freed slots immediately
-
-The pulse never dispatches just one worker and stops — it fills every available slot and keeps them filled for the duration of the session (up to 60 minutes). See `scripts/commands/pulse.md` for the full spec.
-
-### Pulse Scheduler Setup
-
-The pulse scheduler runs every 2 minutes and dispatches workers. Setup depends on your OS.
-
-#### macOS (launchd)
-
-If the plist doesn't exist (fresh install, new machine, or after a crash that deleted it), create it:
-
-```bash
-# 1. Get the opencode binary path and user PATH for the plist
-which opencode        # e.g. /opt/homebrew/bin/opencode
-echo "$PATH"          # needed for EnvironmentVariables
-
-# 2. Create the plist
-cat > ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist << 'PLIST'
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>Label</key>
-	<string>com.aidevops.aidevops-supervisor-pulse</string>
-	<key>ProgramArguments</key>
-	<array>
-		<string>/bin/bash</string>
-		<string>-c</string>
-		<string>pgrep -f 'Supervisor Pulse' &gt;/dev/null &amp;&amp; exit 0; OPENCODE_PATH run "/pulse" --dir AIDEVOPS_DIR -m anthropic/claude-sonnet-4-6 --title "Supervisor Pulse"</string>
-	</array>
-	<key>StartInterval</key>
-	<integer>120</integer>
-	<key>StandardOutPath</key>
-	<string>HOME_DIR/.aidevops/logs/pulse.log</string>
-	<key>StandardErrorPath</key>
-	<string>HOME_DIR/.aidevops/logs/pulse.log</string>
-	<key>EnvironmentVariables</key>
-	<dict>
-		<key>PATH</key>
-		<string>USER_PATH</string>
-		<key>HOME</key>
-		<string>HOME_DIR</string>
-	</dict>
-	<key>RunAtLoad</key>
-	<true/>
-	<key>KeepAlive</key>
-	<false/>
-</dict>
-</plist>
-PLIST
-
-# 3. Replace placeholders with actual values
-sed -i '' "s|OPENCODE_PATH|$(which opencode)|g" ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist
-sed -i '' "s|AIDEVOPS_DIR|$HOME/Git/aidevops|g" ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist
-sed -i '' "s|HOME_DIR|$HOME|g" ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist
-sed -i '' "s|USER_PATH|$PATH|g" ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist
-
-# 4. Create log directory and load
-mkdir -p ~/.aidevops/logs
-launchctl load ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist
-```
-
-**Key settings:**
-- `RunAtLoad: true` — fires immediately on login/reboot (no waiting for first timer tick)
-- `KeepAlive: false` — each pulse is a one-shot run, not a long-lived daemon
-- `StartInterval: 120` — fires every 2 minutes
-- The `pgrep` guard prevents overlapping pulses (if a previous pulse is still running, skip)
-
-#### Linux (cron)
-
-One cron entry with a pgrep guard to prevent overlapping pulses:
-
-```bash
-mkdir -p ~/.aidevops/logs
-
-# Add to crontab (every 2 minutes)
-(crontab -l 2>/dev/null; echo "*/2 * * * * pgrep -f 'Supervisor Pulse' >/dev/null || $(which opencode) run \"/pulse\" --dir $HOME/Git/aidevops -m anthropic/claude-sonnet-4-6 --title \"Supervisor Pulse\" >> $HOME/.aidevops/logs/pulse.log 2>&1 # aidevops: supervisor-pulse") | crontab -
-```
-
-**Key settings:**
-- `*/2 * * * *` — fires every 2 minutes
-- `pgrep` guard prevents overlapping pulses (if a previous pulse is still running, skip)
-- Uses full path to `opencode` since cron has a minimal `PATH`
-
-### Enable / Disable / Verify
-
-```bash
-## macOS
-# Enable
-launchctl load ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist
-# Disable
-launchctl unload ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist
-# Check
-launchctl list | grep aidevops-supervisor-pulse
-
-## Linux
-# Check
-crontab -l | grep supervisor-pulse
-# Disable
-crontab -l | grep -v 'supervisor-pulse' | crontab -
-# Re-enable — run the install command above
-
-# Both platforms — check recent output
-tail -50 ~/.aidevops/logs/pulse.log
-```
-
-### After Reboot
-
-**macOS:** The pulse auto-starts on login (`RunAtLoad: true`).
-
-**Linux:** Cron runs automatically after reboot — no extra config needed.
-
-Old workers don't survive reboot on either platform — the first pulse cycle sees 0 workers, 6 empty slots, and dispatches fresh work. No manual intervention needed.
+5. **No databases, no state machines, no complex bash pipelines**
 
 ## Interactive Mode: `/runners`
 
@@ -156,6 +53,7 @@ For manual dispatch of specific work items.
 
 | Pattern | Type | Example |
 |---------|------|---------|
+| `GH#\d+` | GitHub issue/PR numbers | `/runners GH#267 GH#268` |
 | `t\d+` | Task IDs from TODO.md | `/runners t083 t084 t085` |
 | `#\d+` or PR URL | PR numbers | `/runners #382 #383` |
 | Issue URL | GitHub issue | `/runners https://github.com/user/repo/issues/42` |
@@ -166,6 +64,10 @@ For manual dispatch of specific work items.
 For each input item, resolve it to a description:
 
 ```bash
+# GitHub issue/PR numbers (GH#NNN format)
+gh issue view 267 --repo <slug> --json number,title,url
+gh pr view 268 --repo <slug> --json number,title,headRefName,url
+
 # Task IDs — look up in TODO.md
 grep -E "^- \[ \] t083 " TODO.md
 
@@ -206,6 +108,7 @@ opencode run --dir ~/Git/<repo> --title "Issue #42: <title>" \
 ```
 
 **Dispatch rules:**
+
 - Use `--dir ~/Git/<repo-name>` matching the repo the task belongs to
 - Use `--agent <name>` to route to a specialist (SEO, Content, Marketing, etc.)
 - Omit `--agent` for code tasks — defaults to Build+
@@ -215,7 +118,7 @@ opencode run --dir ~/Git/<repo> --title "Issue #42: <title>" \
 - **Background each dispatch with `&`** so multiple workers launch concurrently
 - Code workers handle branch/PR lifecycle; ops workers execute and report outcomes
 
-### Step 3: Monitor
+### Step 3: Show Dispatch Table
 
 After dispatching, show the user what was launched:
 
@@ -224,34 +127,33 @@ After dispatching, show the user what was launched:
 
 | # | Item | Worker |
 |---|------|--------|
-| 1 | t083: Create Bing Webmaster Tools subagent | dispatched |
-| 2 | t084: Create Rich Results Test subagent | dispatched |
-| 3 | PR #382: Fix auth middleware | dispatched |
+| 1 | GH#267: <title> | dispatched |
+| 2 | GH#268: <title> | dispatched |
 ```
 
-Workers are independent. They succeed or fail on their own. The next `/pulse` cycle
-(or the user) can check on outcomes and dispatch follow-ups.
+Then stop. Workers are independent — they succeed or fail on their own. The next `/pulse` cycle (or the user) can check on outcomes and dispatch follow-ups.
 
-## Supervisor Philosophy
+## Dispatch Philosophy
 
-The supervisor (whether `/pulse` or `/runners`) NEVER does task work itself:
+`/runners` dispatches workers. It does not supervise them.
 
 - **Never** reads source code or implements features
 - **Never** runs tests or linters on behalf of workers
 - **Never** pushes branches or resolves merge conflicts for workers
 - **Always** dispatches workers via `opencode run` with the command chosen by task type
 - **Always** routes to the right agent — not every task is code
+- **Always** stops after dispatching the explicitly specified items
 
-If a worker fails, improve the worker instructions/command definition,
-not the supervisor role. Each fixed failure improves the next run.
-
-**Self-improvement:** The supervisor observes outcomes from GitHub state (PRs, issues, timelines) and files improvement issues for systemic problems. See `AGENTS.md` "Self-Improvement" for the universal principle. The supervisor never maintains separate state — TODO.md, PLANS.md, and GitHub are the database.
+If a worker fails, improve the worker instructions/command definition, not the dispatch logic. Each fixed failure improves the next run.
 
 ## Examples
 
 All items in a single `/runners` invocation are dispatched concurrently — each becomes a separate `opencode run ... &` background process. They do not block each other.
 
 ```bash
+# Dispatch specific GitHub issues (both launch concurrently, then stop)
+/runners GH#267 GH#268
+
 # Dispatch specific tasks (all three launch concurrently)
 /runners t083 t084 t085
 


### PR DESCRIPTION
## Summary

- Adds an explicit **Scope Boundary** section at the top of `runners.md` that enumerates exactly what `/runners` does (resolve specified items → dispatch one worker each → show table → stop) and explicitly lists what it does NOT do (auto-pickup, stale claim recovery, phantom queue reconciliation, AI lifecycle evaluation, CodeRabbit pulse, audit checks).
- Removes the embedded `/pulse` spec (former lines 28–149) that duplicated `pulse.md` and caused agents to treat all supervisor phases as applicable to `/runners`. Replaced with a one-line cross-reference.
- Renames "Supervisor Philosophy" → "Dispatch Philosophy" and removes the line equating `/runners` with the supervisor role (`"The supervisor (whether /pulse or /runners)"`).
- Removes the misleading "archived" note about `supervisor-helper.sh` — the scripts exist at their original paths and agents were calling them.
- Adds `GH#NNN` as a first-class input pattern in the Input Types table (the format used in the bug report).

Closes #5128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated runners documentation with clarified dispatch workflow and four-step process
  * Enhanced behavior details for explicit item dispatch
  * Simplified documentation structure by consolidating legacy references
  * Updated examples and usage patterns for improved user guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->