### PR TITLE
perf: gate daily quality sweep to off-peak hours (18:00-23:59 local)

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -889,6 +889,20 @@ update_health_issues() {
 # actionable GitHub issues for findings that warrant fixes.
 #######################################
 run_daily_quality_sweep() {
+	# Time-of-day gate — only run during off-peak hours (18:00-23:59 local).
+	# Anthropic doubles token allowance during off-peak (6 PM-12 AM UK time),
+	# and model demand is lower. Quality sweep findings trigger LLM worker
+	# dispatch via the pulse, so landing findings in this window means the
+	# resulting workers also run at 2x rates. Override: QUALITY_SWEEP_OFFPEAK=0
+	if [[ "${QUALITY_SWEEP_OFFPEAK:-1}" == "1" ]]; then
+		local current_hour
+		current_hour=$(date +%H)
+		current_hour=$((10#$current_hour)) # strip leading zero for arithmetic
+		if [[ "$current_hour" -lt 18 ]]; then
+			return 0
+		fi
+	fi
+
 	# Timestamp guard — run at most once per QUALITY_SWEEP_INTERVAL
 	if [[ -f "$QUALITY_SWEEP_LAST_RUN" ]]; then
 		local last_run

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -899,6 +899,7 @@ run_daily_quality_sweep() {
 		current_hour=$(date +%H)
 		current_hour=$((10#$current_hour)) # strip leading zero for arithmetic
 		if [[ "$current_hour" -lt 18 ]]; then
+			echo "[stats] Quality sweep deferred: hour ${current_hour} is outside off-peak window (18:00-23:59)" >>"$LOGFILE"
 			return 0
 		fi
 	fi


### PR DESCRIPTION
## Summary

- Adds a time-of-day gate to `run_daily_quality_sweep()` in `stats-functions.sh` so it only executes during off-peak hours (18:00-23:59 local time)
- Anthropic doubles token allowance during off-peak (6 PM-12 AM UK time), and model demand is lower — quality sweep findings trigger LLM worker dispatch via the pulse, so landing findings in this window means resulting workers also run at 2x rates
- Health issues (every 15 min) and person stats (hourly) continue unaffected on their existing cadence

## Also applied (plist-only, not in this PR)

- `repo-sync` plist changed from floating `StartInterval: 86400` to fixed `StartCalendarInterval` at 19:00 local daily
- `stats-wrapper` plist kept at `StartInterval: 900` (15 min) — the time gate is in the script, not the scheduler

## Override

Set `QUALITY_SWEEP_OFFPEAK=0` to force daytime runs when needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Daily quality sweep now skips execution during off-peak hours (6 PM to 5:59 AM) by default, reducing unnecessary off-hours processing. Override available via configuration flag if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->