### PR TITLE
t1541: fix runners.md scope — address PR #5129 review feedback

### DIFF
--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -11,6 +11,30 @@ Dispatch one or more workers to handle tasks. Pick the execution mode per task t
 
 Arguments: $ARGUMENTS
 
+## Scope Boundary
+
+**`/runners` is a targeted dispatch tool, not a supervisor.**
+
+When invoked as `/runners GH#267 GH#268` (or any explicit list of items), it does exactly this:
+
+1. Resolve the specified items
+2. Dispatch one worker per item
+3. Show the dispatch table
+4. Stop
+
+It does **NOT**:
+
+- Run supervisor phases
+- Perform auto-pickup of unrelated tasks
+- Run stale claim recovery
+- Run phantom queue reconciliation
+- Run AI lifecycle evaluation
+- Run CodeRabbit pulse
+- Run audit checks
+- Fill worker slots beyond the explicitly specified items
+
+For unattended operation that fills all available slots and runs supervisor phases, use `/pulse`. See `scripts/commands/pulse.md`.
+
 ## How It Works
 
 The runners system is intentionally simple:
@@ -19,9 +43,7 @@ The runners system is intentionally simple:
 2. **It dispatches `opencode run` for each item** — one worker per task
 3. **Code workers** handle branch -> implementation -> PR -> CI -> merge
 4. **Ops workers** execute the requested SOP/command and report outcomes
-4. **No databases, no state machines, no complex bash pipelines**
-
-> **Automated mode:** For unattended operation and full supervisor behaviour (auto-pickup, capacity management, lifecycle evaluation), use `/pulse`. See `.agents/scripts/commands/pulse.md` for the full spec.
+5. **No databases, no state machines, no complex bash pipelines**
 
 ## Interactive Mode: `/runners`
 
@@ -41,6 +63,7 @@ For manual dispatch of specific work items.
 
 | Pattern | Type | Example |
 |---------|------|---------|
+| `GH#\d+` | GitHub issue/PR numbers | `/runners GH#267 GH#268` |
 | `t\d+` | Task IDs from TODO.md | `/runners t083 t084 t085` |
 | `#\d+` or PR URL | PR numbers | `/runners #382 #383` |
 | Issue URL | GitHub issue | `/runners https://github.com/user/repo/issues/42` |
@@ -51,6 +74,10 @@ For manual dispatch of specific work items.
 For each input item, resolve it to a description:
 
 ```bash
+# GitHub issue/PR numbers (GH#NNN format)
+gh issue view 267 --repo <slug> --json number,title,url
+gh pr view 268 --repo <slug> --json number,title,headRefName,url
+
 # Task IDs — look up in TODO.md
 grep -E "^- \[ \] t083 " TODO.md
 
@@ -117,7 +144,7 @@ sleep 2
 ```
 
 **Dispatch rules:**
-- **ALWAYS use `headless-runtime-helper.sh run`** — never bare `opencode run`. The helper provides provider rotation, session persistence, backoff handling, and lifecycle reinforcement that bare dispatch lacks.
+
 - Use `--dir ~/Git/<repo-name>` matching the repo the task belongs to
 - Use `--agent <name>` to route to a specialist (SEO, Content, Marketing, etc.)
 - Omit `--agent` for code tasks — defaults to Build+
@@ -127,7 +154,7 @@ sleep 2
 - **Background each dispatch with `&`** and `sleep 2` between dispatches to avoid thundering herd
 - Code workers handle branch/PR lifecycle; ops workers execute and report outcomes
 
-### Step 3: Monitor
+### Step 3: Show Dispatch Table
 
 After dispatching, show the user what was launched:
 
@@ -136,37 +163,33 @@ After dispatching, show the user what was launched:
 
 | # | Item | Worker |
 |---|------|--------|
-| 1 | t083: Create Bing Webmaster Tools subagent | dispatched |
-| 2 | t084: Create Rich Results Test subagent | dispatched |
-| 3 | PR #382: Fix auth middleware | dispatched |
+| 1 | GH#267: <title> | dispatched |
+| 2 | GH#268: <title> | dispatched |
 ```
 
-Workers are independent. They succeed or fail on their own. The next `/pulse` cycle
-(or the user) can check on outcomes and dispatch follow-ups.
+Then stop. Workers are independent — they succeed or fail on their own. The next `/pulse` cycle (or the user) can check on outcomes and dispatch follow-ups.
 
-## Dispatcher Philosophy
+## Dispatch Philosophy
 
-The `/pulse` supervisor NEVER does task work itself:
+`/runners` dispatches workers. It does not supervise them.
 
 - **Never** reads source code or implements features
 - **Never** runs tests or linters on behalf of workers
 - **Never** pushes branches or resolves merge conflicts for workers
 - **Always** dispatches workers via `headless-runtime-helper.sh run` (never bare `opencode run`)
 - **Always** routes to the right agent — not every task is code
+- **Always** stops after dispatching the explicitly specified items
 
-`/runners` is a targeted dispatch tool, not a supervisor. It dispatches exactly what you specify and stops.
-
-If a worker fails (whether dispatched by `/pulse` or `/runners`), improve the worker's instructions or command definition, not the dispatcher's role. Each fixed failure improves the next run.
-
----
-
-**Self-improvement** is a universal principle that applies to every agent session — interactive, worker, or supervisor — not just `/runners`. The `/pulse` supervisor observes outcomes from GitHub state (PRs, issues, timelines) and files improvement issues for systemic problems. See `AGENTS.md` "Self-Improvement" for the full principle. The supervisor never maintains separate state — TODO.md, PLANS.md, and GitHub are the database.
+If a worker fails, improve the worker instructions/command definition, not the dispatch logic. Each fixed failure improves the next run.
 
 ## Examples
 
 All items in a single `/runners` invocation are dispatched concurrently — each becomes a separate `opencode run ... &` background process. They do not block each other.
 
 ```bash
+# Dispatch specific GitHub issues (both launch concurrently, then stop)
+/runners GH#267 GH#268
+
 # Dispatch specific tasks (all three launch concurrently)
 /runners t083 t084 t085
 

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -33,7 +33,7 @@ It does **NOT**:
 - Run audit checks
 - Fill worker slots beyond the explicitly specified items
 
-For unattended operation that fills all available slots and runs supervisor phases, use `/pulse`. See `scripts/commands/pulse.md`.
+For unattended operation that fills all available slots and runs supervisor phases, use `/pulse`. See `.agents/scripts/commands/pulse.md`.
 
 ## How It Works
 
@@ -180,7 +180,9 @@ Then stop. Workers are independent — they succeed or fail on their own. The ne
 - **Always** routes to the right agent — not every task is code
 - **Always** stops after dispatching the explicitly specified items
 
-If a worker fails, improve the worker instructions/command definition, not the dispatch logic. Each fixed failure improves the next run.
+`/runners` is a targeted dispatch tool, not a supervisor. It dispatches exactly what you specify and stops.
+
+If a worker fails (whether dispatched by `/pulse` or `/runners`), improve the worker's instructions or command definition, not the dispatcher's role. Each fixed failure improves the next run.
 
 ## Examples
 


### PR DESCRIPTION
## Summary

- Addresses review feedback from PR #5129 on runners.md
- Scopes /runners to explicit items only, removes embedded /pulse spec
- Fixes scope boundary documentation per reviewer suggestions

Closes #5130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the scope and capabilities of the /runners dispatch tool, explicitly defining what it does and doesn't do
  * Reorganized and renamed dispatch workflow steps for improved clarity
  * Added GitHub issue and pull request examples to better illustrate dispatch patterns
  * Enhanced guidance on dispatch constraints and permitted actions in interactive mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->