### PR TITLE
t5143: Fix screenshot size guardrails missing from non-helper Playwright paths

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -127,6 +127,22 @@ When referencing specific functions or code include the pattern `file_path:line_
 - Never consume >100K tokens on a single operation
 - For remote repos: fetch README first, check size with `gh api`, use `includePatterns`
 
+# Screenshot Size Limits (CRITICAL — session-crashing)
+# Anthropic hard-rejects images >8000px on any dimension. This crashes the session
+# because the oversized image is already in message history — every subsequent
+# API call fails with the same error. There is no recovery except starting a new
+# session and losing all conversation context.
+# GH#4213 added guardrails to browser-qa-helper.sh but agents take screenshots
+# through at least 5 other paths that bypass those guardrails entirely.
+- NEVER use `fullPage: true` for screenshots intended for AI vision review. Use viewport-sized screenshots instead (`fullPage: false` or omit the option).
+- When full-page capture is genuinely needed (human review, visual regression, saving to disk for later), save to file and resize before including in conversation context:
+  `sips --resampleHeightWidthMax 1568 screenshot.png --out screenshot-resized.png` (macOS)
+  `magick screenshot.png -resize "1568x1568>" screenshot-resized.png` (ImageMagick, cross-platform)
+- For AI vision review: target max 1568px on the longest side. Images above this are auto-downscaled by the API, adding latency with no quality benefit.
+- Anthropic hard limit: 8000px on any single dimension. Images at or above this are rejected outright.
+- The Playwright MCP `browser_screenshot` tool returns base64 images directly into conversation context with NO resize hook. There is no way to intercept or resize these images after the tool returns. Prefer `browser-qa-helper.sh screenshot` which has built-in guardrails, or use viewport-sized screenshots via Playwright direct.
+- The `browser-qa-helper.sh screenshot` command is the ONLY screenshot path with automatic size guardrails (post-capture resize to `--max-dim`, default 4000px). All other paths — Playwright MCP, Playwriter MCP, dev-browser scripts, raw Playwright code — have zero size protection.
+
 # Error Prevention (top recurring patterns from session mining)
 #
 # 1. webfetch failures (250 uses, 117 errors = 46.8% failure rate)

--- a/.agents/tools/browser/browser-automation.md
+++ b/.agents/tools/browser/browser-automation.md
@@ -417,6 +417,8 @@ npx chrome-devtools-mcp@latest --proxyServer socks5://127.0.0.1:1080
 
 Best for: Maximum speed, full Playwright API, proxy support, fresh sessions.
 
+> **Screenshot size limit**: Do NOT use `fullPage: true` for screenshots intended for AI vision review. Full-page captures can exceed 8000px, which crashes the session (Anthropic hard-rejects images >8000px). Use viewport-sized screenshots for AI review. Resize full-page captures before including in conversation: `magick screenshot.png -resize "1568x1568>" screenshot-resized.png`. See `prompts/build.txt` "Screenshot Size Limits".
+
 ```javascript
 import { chromium } from 'playwright';
 
@@ -427,7 +429,7 @@ const browser = await chromium.launch({
 const page = await browser.newPage();
 await page.goto('https://example.com');
 await page.fill('input[name="email"]', 'user@example.com');
-await page.screenshot({ path: '/tmp/screenshot.png' });
+await page.screenshot({ path: '/tmp/screenshot.png' });  // viewport-sized (safe for AI)
 
 // Save state for reuse
 await page.context().storageState({ path: 'state.json' });

--- a/.agents/tools/browser/browser-benchmark.md
+++ b/.agents/tools/browser/browser-benchmark.md
@@ -748,9 +748,11 @@ async function benchVisual() {
     await page.goto(url);
     await page.waitForLoadState('networkidle');
 
-    // Take screenshot
+    // Take viewport-sized screenshot (safe for AI review)
+    // WARNING: Do NOT use fullPage: true for screenshots sent to AI vision.
+    // Full-page captures can exceed 8000px, crashing the session.
     const screenshotPath = `/tmp/bench-visual-${Date.now()}.png`;
-    await page.screenshot({ path: screenshotPath, fullPage: true });
+    await page.screenshot({ path: screenshotPath });
 
     // Get ARIA snapshot (text representation for AI)
     const ariaSnapshot = await page.accessibility.snapshot();
@@ -781,7 +783,7 @@ benchVisual();
 
 **Visual verification workflow** (for AI agents):
 1. Navigate to page
-2. Take screenshot (PNG, full page)
+2. Take viewport-sized screenshot (PNG) -- do NOT use `fullPage: true` for AI review (>8000px crashes session)
 3. Get ARIA accessibility snapshot (structured text)
 4. AI analyses screenshot + ARIA to understand page state
 5. Decide next action based on visual understanding

--- a/.agents/tools/browser/browser-qa.md
+++ b/.agents/tools/browser/browser-qa.md
@@ -119,14 +119,18 @@ browser-qa-helper.sh screenshot --url http://localhost:3000 \
 | tablet | 768 | 1024 | iPad portrait |
 | mobile | 375 | 667 | iPhone SE/8 |
 
-**Image size warning**: Full-page screenshots of long pages can exceed Anthropic's hard reject threshold of `8000×8000 px` (64 megapixels total area). The `1568 px` value refers to an auto-resize trigger on the long edge — images exceeding this are automatically downscaled by the API, incurring latency penalties. For optimal performance, resize screenshots to ≤1568 px on the longest side (≤1.15 megapixels) before sending to a vision API:
+**Image size warning**: Full-page screenshots of long pages can exceed Anthropic's hard reject threshold of `8000px` on any single dimension. The `1568px` value refers to an auto-resize trigger on the long edge -- images exceeding this are automatically downscaled by the API, incurring latency penalties. For optimal performance, resize screenshots to ≤1568px on the longest side before sending to a vision API:
 
 ```bash
 # Resize to max 1568px on longest side (macOS built-in, non-destructive)
 sips --resampleHeightWidthMax 1568 screenshot.png --out screenshot-resized.png
+# Cross-platform (ImageMagick)
+magick screenshot.png -resize "1568x1568>" screenshot-resized.png
 ```
 
-See `tools/vision/image-understanding.md` for per-provider limits. GH#4213 tracks adding auto-resize to `browser-qa-helper.sh`.
+See `tools/vision/image-understanding.md` for per-provider limits.
+
+**`browser-qa-helper.sh` is the ONLY screenshot path with automatic size guardrails** (GH#4213). All other screenshot paths -- Playwright MCP (`browser_screenshot`), Playwriter MCP (`execute` with `page.screenshot()`), dev-browser scripts, raw Playwright code, and the `ui-verification.md` workflow -- have zero automatic size protection. When taking screenshots through any path other than `browser-qa-helper.sh`, you must either: (1) use viewport-sized screenshots (`fullPage: false` or omit the option), or (2) manually resize full-page captures before including them in conversation context.
 
 **What to look for in screenshots**:
 - Layout breaks (overlapping elements, content overflow)

--- a/.agents/tools/browser/dev-browser.md
+++ b/.agents/tools/browser/dev-browser.md
@@ -197,6 +197,8 @@ EOF
 
 ### Navigate and Screenshot
 
+> **Screenshot size limit**: Do NOT use `fullPage: true` for screenshots intended for AI vision review. Full-page captures can exceed 8000px, which crashes the session (Anthropic hard-rejects images >8000px on any dimension). Use viewport-sized screenshots for AI review. If full-page is needed for human review, resize before including in conversation: `magick tmp/full.png -resize "1568x1568>" tmp/full-resized.png`. See `prompts/build.txt` "Screenshot Size Limits".
+
 ```bash
 cd ~/.aidevops/dev-browser/skills/dev-browser && bun x tsx <<'EOF'
 import { connect, waitForPageLoad } from "@/client.js";
@@ -207,8 +209,10 @@ const page = await client.page("main");
 await page.goto("http://localhost:3000/dashboard");
 await waitForPageLoad(page);
 
+// Viewport-sized screenshot (safe for AI review)
 await page.screenshot({ path: "tmp/dashboard.png" });
-await page.screenshot({ path: "tmp/full.png", fullPage: true });
+// Full-page: save to disk only -- resize before sending to AI vision
+// await page.screenshot({ path: "tmp/full.png", fullPage: true });
 
 console.log("Screenshots saved to tmp/");
 await client.disconnect();

--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -325,11 +325,16 @@ const rows = await page.$$eval('table tr', rows =>
 
 ### Screenshot and PDF
 
+> **Screenshot size limit**: Do NOT use `fullPage: true` for screenshots intended for AI vision review. Full-page captures can exceed 8000px, which crashes the session (Anthropic hard-rejects images >8000px). Use viewport-sized screenshots for AI review. If full-page is needed for human review, resize before including in conversation: `magick full.png -resize "1568x1568>" full-resized.png`. See `prompts/build.txt` "Screenshot Size Limits".
+
 ```javascript
-// Full page screenshot
+// Viewport-sized screenshot (safe for AI review)
+await page.screenshot({ path: 'viewport.png' })
+
+// Full page screenshot -- save to disk only, resize before sending to AI
 await page.screenshot({ path: 'full.png', fullPage: true })
 
-// Element screenshot
+// Element screenshot (safe -- element-scoped, not full page)
 await page.locator('.chart').screenshot({ path: 'chart.png' })
 
 // PDF export

--- a/.agents/workflows/ui-verification.md
+++ b/.agents/workflows/ui-verification.md
@@ -40,6 +40,8 @@ tools:
 
 Before making any visual changes, capture the current state for comparison:
 
+> **Screenshot size limit**: NEVER send `fullPage: true` screenshots directly to AI vision review. Full-page captures of modern web pages routinely exceed 8000px tall, which hard-crashes the session (Anthropic rejects images >8000px on any dimension, and the oversized image is already in message history -- every subsequent API call fails). Use viewport-sized screenshots for AI review. If full-page capture is needed for human review, save to disk and resize before including in conversation. See `prompts/build.txt` "Screenshot Size Limits".
+
 ```typescript
 import { chromium, devices } from 'playwright';
 
@@ -56,7 +58,8 @@ for (const { name, config } of standardDevices) {
   const page = await context.newPage();
   await page.goto(targetUrl);
   await page.waitForLoadState('networkidle');
-  await page.screenshot({ path: `/tmp/ui-verify/before-${name}.png`, fullPage: true });
+  // Viewport-sized screenshot (safe for AI review, no resize needed)
+  await page.screenshot({ path: `/tmp/ui-verify/before-${name}.png` });
   await context.close();
 }
 await browser.close();
@@ -72,12 +75,13 @@ After changes, capture the same pages across all standard breakpoints:
 
 ```typescript
 // Same device list as baseline -- capture "after" screenshots
+// Use viewport-sized screenshots (safe for AI review -- no fullPage: true)
 for (const { name, config } of standardDevices) {
   const context = await browser.newContext({ ...config });
   const page = await context.newPage();
   await page.goto(targetUrl);
   await page.waitForLoadState('networkidle');
-  await page.screenshot({ path: `/tmp/ui-verify/after-${name}.png`, fullPage: true });
+  await page.screenshot({ path: `/tmp/ui-verify/after-${name}.png` });
   await context.close();
 }
 ```


### PR DESCRIPTION
## Summary

- Adds "Screenshot Size Limits" section to `prompts/build.txt` — the primary agent instruction file — with rules against `fullPage: true` for AI vision review, resize commands (sips + ImageMagick), and documentation of which paths have guardrails
- Replaces `fullPage: true` with viewport-sized screenshots in all documentation code examples (`ui-verification.md`, `dev-browser.md`, `browser-benchmark.md`)
- Adds size limit warnings to every browser tool doc that shows screenshot examples (`browser-automation.md`, `playwriter.md`, `dev-browser.md`)
- Documents in `browser-qa.md` that `browser-qa-helper.sh` is the ONLY path with automatic size guardrails (GH#4213), and all other paths require manual resize

## Why

Sessions crash when full-page screenshots exceed Anthropic's 8000px hard limit. The oversized image is already in message history, so every subsequent API call fails — there is no recovery. GH#4213 added guardrails to `browser-qa-helper.sh` but agents take screenshots through at least 5 other paths that bypass those guardrails entirely.

## Files Changed (7)

| File | Change |
|------|--------|
| `.agents/prompts/build.txt` | New "Screenshot Size Limits" section with 6 rules |
| `.agents/workflows/ui-verification.md` | Replace `fullPage: true` with viewport screenshots, add warning |
| `.agents/tools/browser/dev-browser.md` | Add size warning, comment out `fullPage` example |
| `.agents/tools/browser/browser-automation.md` | Add size warning to Playwright Direct section |
| `.agents/tools/browser/playwriter.md` | Add size warning, restructure screenshot examples |
| `.agents/tools/browser/browser-qa.md` | Document guardrail coverage gap, add cross-platform resize |
| `.agents/tools/browser/browser-benchmark.md` | Remove `fullPage: true` from visual benchmark |

## Verification

- `markdownlint-cli2`: 0 errors across all 6 modified markdown files
- All changes are documentation/prompt-level — no runtime code modified
- Consistent messaging across all files pointing back to `prompts/build.txt` as the authoritative source

Closes #5143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation with clearer guidance on screenshot size limits and safety practices to prevent session crashes.
  * Enhanced error prevention and URL handling recommendations across developer tools and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->