### PR TITLE
t1542: fix: add 14 orphaned archived scripts to cleanup_deprecated_paths()

### DIFF
--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -37,6 +37,22 @@ cleanup_deprecated_paths() {
 		"$agents_dir/youtube"
 		# osgrep removed — disproportionate CPU/disk cost vs rg + LLM comprehension
 		"$agents_dir/tools/context/osgrep.md"
+		# GH#5155: scripts archived upstream but orphaned in deployed installs
+		# (rsync only adds/overwrites, doesn't delete removed files)
+		"$agents_dir/scripts/pattern-tracker-helper.sh"
+		"$agents_dir/scripts/quality-sweep-helper.sh"
+		"$agents_dir/scripts/quality-loop-helper.sh"
+		"$agents_dir/scripts/review-pulse-helper.sh"
+		"$agents_dir/scripts/self-improve-helper.sh"
+		"$agents_dir/scripts/coderabbit-pulse-helper.sh"
+		"$agents_dir/scripts/coderabbit-task-creator-helper.sh"
+		"$agents_dir/scripts/audit-task-creator-helper.sh"
+		"$agents_dir/scripts/batch-cleanup-helper.sh"
+		"$agents_dir/scripts/coordinator-helper.sh"
+		"$agents_dir/scripts/finding-to-task-helper.sh"
+		"$agents_dir/scripts/objective-runner-helper.sh"
+		"$agents_dir/scripts/ralph-loop-helper.sh"
+		"$agents_dir/scripts/stale-pr-helper.sh"
 	)
 
 	for path in "${deprecated_paths[@]}"; do


### PR DESCRIPTION
## Summary

- Adds 14 orphaned archived scripts to the `deprecated_paths` array in `cleanup_deprecated_paths()` (`setup-modules/migrations.sh`)
- Follow-up to PR #5151 which handled `supervisor-helper.sh` and `supervisor/` directory
- On next `aidevops update`, these orphaned files will be cleaned up from `~/.aidevops/agents/scripts/`

## Problem

After scripts were archived upstream, `aidevops update` (rsync) only adds/overwrites — it doesn't delete files removed from the source. Users who installed before the archival retain 14 orphaned scripts:

`pattern-tracker-helper.sh`, `quality-sweep-helper.sh`, `quality-loop-helper.sh`, `review-pulse-helper.sh`, `self-improve-helper.sh`, `coderabbit-pulse-helper.sh`, `coderabbit-task-creator-helper.sh`, `audit-task-creator-helper.sh`, `batch-cleanup-helper.sh`, `coordinator-helper.sh`, `finding-to-task-helper.sh`, `objective-runner-helper.sh`, `ralph-loop-helper.sh`, `stale-pr-helper.sh`

## Fix

Added all 14 scripts to the existing `deprecated_paths` array in `cleanup_deprecated_paths()`, following the exact same pattern used for other deprecated paths in the function. The existing loop already handles removal and counting.

## Verification

- `shellcheck setup-modules/migrations.sh` — 0 violations
- Pattern matches existing entries in the array (simple path addition)

Closes #5155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the deprecation cleanup procedure to remove additional obsolete scripts and utilities from previous versions. The enhancement targets pattern tracking, quality assurance, code review, audit, batch processing, coordination utilities, and related helper scripts. This ensures comprehensive removal of outdated code during system maintenance cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->