### PR TITLE
t1543: remove redundant empty-string check from is_framework_task()

### DIFF
--- a/.agents/scripts/framework-routing-helper.sh
+++ b/.agents/scripts/framework-routing-helper.sh
@@ -114,11 +114,11 @@ readonly FRAMEWORK_CONCEPT_PATTERNS=(
 # is_framework_task — detect whether a description is framework-level
 # =============================================================================
 # Arguments:
-#   $1 - task title or description text
+#   $1 - task title or description text (must be non-empty; caller validates)
 # Returns:
 #   0 = framework-level (high confidence)
 #   1 = project-level (no framework indicators found)
-#   2 = uncertain or error
+#   2 = uncertain
 # Outputs:
 #   Machine-readable result on stdout: "framework", "project", or "uncertain"
 #   Match details on stderr
@@ -126,11 +126,6 @@ is_framework_task() {
 	local description="$1"
 	local match_count=0
 	local matched_patterns=""
-
-	if [[ -z "$description" ]]; then
-		echo "uncertain"
-		return 2
-	fi
 
 	# Normalise to lowercase for matching
 	local desc_lower


### PR DESCRIPTION
## Summary

- Removes dead code: the empty-string guard in `is_framework_task()` is never reached because `main()` already validates input at line 375 before calling the function
- Updates docstring to clarify that callers are responsible for input validation

## Problem

Gemini code review on PR #5152 identified a medium-severity finding: `is_framework_task()` contains a redundant empty-string check (lines 130-133) that duplicates the validation already performed by `main()` (line 375). This is dead code — the function is never called with an empty string via the script's public `is-framework` command.

## Verification

- All 20 existing tests pass (including the empty-string edge case, which is caught by `main()`)
- ShellCheck: zero violations
- Change scoped to single file: `.agents/scripts/framework-routing-helper.sh`

Closes #5158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal routing helper to refine error handling for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->