### PR TITLE
t5159: fix blanket 2>/dev/null suppression in migrate_orphaned_supervisor

### DIFF
--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -1030,10 +1030,10 @@ migrate_orphaned_supervisor() {
 		local new_crontab
 		new_crontab=$(echo "$current_crontab" | grep -v "supervisor-helper.sh")
 		if [[ -n "$new_crontab" ]]; then
-			printf '%s\n' "$new_crontab" | crontab - 2>/dev/null || true
+			printf '%s\n' "$new_crontab" | crontab - || true
 		else
 			# All entries were supervisor-helper.sh — remove crontab entirely
-			crontab -r 2>/dev/null || true
+			crontab -r || true
 		fi
 		print_info "Removed orphaned supervisor-helper.sh cron entries"
 		print_info "  pulse-wrapper.sh will be installed by setup.sh if supervisor pulse is enabled"
@@ -1048,10 +1048,10 @@ migrate_orphaned_supervisor() {
 	if [[ "$(uname -s)" == "Darwin" ]]; then
 		local old_label="com.aidevops.supervisor-pulse"
 		local old_plist="$HOME/Library/LaunchAgents/${old_label}.plist"
-		if [[ -f "$old_plist" ]] || _launchd_has_agent "$old_label" 2>/dev/null; then
+		if _launchd_has_agent "$old_label" || [[ -f "$old_plist" ]]; then
 			# Use launchctl remove by label — works even when the plist file is
 			# missing (orphaned agent loaded without a backing file on disk)
-			launchctl remove "$old_label" 2>/dev/null || true
+			launchctl remove "$old_label" || true
 			rm -f "$old_plist"
 			print_info "Removed orphaned supervisor-pulse LaunchAgent ($old_label)"
 			((++cleaned))


### PR DESCRIPTION
## Summary

- Remove blanket `2>/dev/null` suppression from launchd and crontab cleanup in `migrate_orphaned_supervisor()`, per Gemini Code Assist review on PR #5151
- Reorder launchd condition to check agent registration first (`_launchd_has_agent`), then plist file — correctly prioritises the orphaned-agent case where the plist is missing

## Changes (4 lines in 1 file)

**`setup-modules/migrations.sh`** — `migrate_orphaned_supervisor()`:

| Finding | Severity | Fix |
|---------|----------|-----|
| `_launchd_has_agent "$old_label" 2>/dev/null` | HIGH | Remove redundant `2>/dev/null` (function already handles internally); reorder condition to check agent first |
| `launchctl remove "$old_label" 2>/dev/null \|\| true` | HIGH | Remove `2>/dev/null` so system errors surface; `\|\| true` already prevents abort |
| `crontab - 2>/dev/null \|\| true` | MEDIUM | Remove `2>/dev/null` so permission errors surface |
| `crontab -r 2>/dev/null \|\| true` | MEDIUM | Remove `2>/dev/null` so permission errors surface |

## Verification

- shellcheck: 0 violations
- tests: 10/10 pass (`tests/test-migrate-orphaned-supervisor.sh`)

Closes #5159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error handling in system migration processes for improved reliability.
  * Enhanced macOS system component cleanup with improved conditional checks and logic ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->