### PR TITLE
t5165: fix tilde expansion in HELPER path from aidevops config

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -125,7 +125,8 @@ Not every task is code. The framework has multiple primary agents, each with dom
 **Dispatch example:**
 
 ```bash
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # Code task (default — Build+ implied)
 $HELPER run \

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -66,7 +66,8 @@ gh issue view 42 --repo user/repo --json number,title,url
 For each resolved item, launch a worker using `headless-runtime-helper.sh run`. This is the **ONLY** correct dispatch path — it constructs the full lifecycle prompt, handles provider rotation, session persistence, and backoff. NEVER use bare `opencode run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (see GH#5096).
 
 ```bash
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # For code tasks (Build+ is default — omit --agent)
 $HELPER run \

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -226,7 +226,8 @@ When dispatching multiple workers manually (outside the pulse supervisor), **sta
 - **MCP cold boot storms**: MCP servers (especially Node-based ones) have expensive startup. Concurrent initialization competes for CPU and I/O.
 
 ```bash
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # WRONG: Thundering herd — all 4 workers cold-boot simultaneously
 for issue in 42 43 44 45; do
@@ -792,7 +793,8 @@ LINEAGE RULES:
 > **IMPORTANT:** Always use `headless-runtime-helper.sh run` for dispatch — never bare `opencode run`. Bare dispatch skips lifecycle reinforcement, causing workers to stop after PR creation (GH#5096).
 
 ```bash
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # Standard dispatch (no lineage — top-level task)
 $HELPER run \
@@ -1071,7 +1073,8 @@ NEXT=$(batch-strategy-helper.sh next-batch \
   --concurrency "$AVAILABLE_SLOTS")
 
 # Dispatch each task in the batch
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 echo "$NEXT" | jq -r '.[]' | while read -r task_id; do
   $HELPER run --role worker --session-key "task-${task_id}" \
     --dir <path> --title "$task_id" \


### PR DESCRIPTION
## Summary

- Fixes tilde not being expanded when `aidevops config get paths.agents_dir` returns a `~`-prefixed path inside double quotes
- Splits the single-line assignment into two variables: `AGENTS_DIR` (raw output) and `HELPER` (with `${AGENTS_DIR/#\~//Users/marcusquinn}` substitution)
- Bash 3.2 compatible — uses standard parameter expansion, no `eval` or `realpath`
- Fixes all 5 occurrences flagged in PR #5125 review across 3 files

## Files Changed

- `.agents/AGENTS.md` — dispatch example (line 128)
- `.agents/scripts/commands/runners.md` — dispatch example (line 69)
- `.agents/tools/ai-assistants/headless-dispatch.md` — 3 occurrences (lines 229, 795, 1074)

## Change Pattern

```bash
# Before (all 5 locations)
HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"

# After (all 5 locations)
AGENTS_DIR="$(aidevops config get paths.agents_dir)"
HELPER="${AGENTS_DIR/#\~//Users/marcusquinn}/scripts/headless-runtime-helper.sh"
```

## References

- Closes #5165
- Addresses all review comments on #5125: https://github.com/marcusquinn/aidevops/pull/5125#discussion_r2942729657