### PR TITLE
t5171: fix ambiguous 'last quarter' → '90 days' in ai-search-readiness.md

### DIFF
--- a/.agents/seo/ai-search-readiness.md
+++ b/.agents/seo/ai-search-readiness.md
@@ -82,7 +82,7 @@ Run a complete, high-signal workflow to improve AI search citations and answer q
 - Discovery success: percent of tasks completed by autonomous exploration
 - Citation stability: variance in citation frequency over repeated runs
 - Site-query readiness: percent of priority pages retrievable via `site:yourdomain.com [category]` queries
-- Third-party profile currency: percent of review platform profiles updated within last quarter
+- Third-party profile currency: percent of review platform profiles updated within the last 90 days
 
 ## Prioritization Rules
 


### PR DESCRIPTION
## Summary

- Replaces the ambiguous phrase 'last quarter' with the precise '90 days' in the third-party profile currency metric
- 'Last quarter' can mean either the last calendar quarter or the previous three months; '90 days' is unambiguous
- Addresses the medium-severity finding from gemini-code-assist on PR #5094

## Changes

- `.agents/seo/ai-search-readiness.md:85` — `within last quarter` → `within the last 90 days`

Closes #5171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI Search Readiness Scorecard profile currency metric to assess updates within a 90-day window instead of quarterly intervals for more frequent evaluation criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->