### PR TITLE
t5169: refactor email-export-helper CSV quoting — centralize in printf

### DIFF
--- a/.agents/scripts/email-export-helper.sh
+++ b/.agents/scripts/email-export-helper.sh
@@ -172,14 +172,14 @@ append_attachment_manifest() {
 		while IFS= read -r -d '' file_path; do
 			local filename
 			filename=$(basename "$file_path")
-			# RFC 4180: quote all fields; double any embedded double-quotes in filename
-			local csv_filename
-			csv_filename="\"${filename//\"/\"\"}\""
+			# RFC 4180: escape embedded double-quotes in filename; quoting of all fields done in printf
+			local escaped_filename
+			escaped_filename="${filename//\"/\"\"}"
 			local size_bytes
 			size_bytes=$(wc -c <"$file_path" | tr -d ' ')
 			local checksum
 			checksum=$(compute_sha256 "$file_path")
-			printf '%s,"%s","%s"\n' "$csv_filename" "$size_bytes" "$checksum"
+			printf '"%s","%s","%s"\n' "$escaped_filename" "$size_bytes" "$checksum"
 		done < <(find "$attachment_dir" -type f ! -name "$manifest_name" -print0 | sort -z)
 	} >"$temp_manifest"
 


### PR DESCRIPTION
## Summary

- Addresses PR #5122 review feedback from gemini-code-assist
- Separates RFC 4180 double-quote escaping (`escaped_filename`) from field quoting (moved into `printf` format string)
- All three CSV fields now quoted uniformly in the `printf` format, making the quoting logic centralized and consistent

## Change

`email-export-helper.sh:182` — `append_attachment_manifest()`

**Before**: pre-built `csv_filename` with embedded surrounding quotes, passed as `%s` to printf
**After**: `escaped_filename` holds only the escaped value; `printf '"%s","%s","%s"\n'` quotes all three fields uniformly

No behaviour change — output is identical. Pure readability/consistency improvement.

Closes #5169