### PR TITLE
t5163: refactor off-peak guard in run_daily_quality_sweep

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -894,9 +894,13 @@ run_daily_quality_sweep() {
 	# and model demand is lower. Quality sweep findings trigger LLM worker
 	# dispatch via the pulse, so landing findings in this window means the
 	# resulting workers also run at 2x rates. Override: QUALITY_SWEEP_OFFPEAK=0
-	if [[ "${QUALITY_SWEEP_OFFPEAK:-1}" == "1" ]] && ((10#$(date +%H) < 18)); then
-		echo "[stats] Quality sweep deferred: hour $(date +%H) is outside off-peak window (18:00-23:59)" >>"$LOGFILE"
-		return 0
+	if [[ "${QUALITY_SWEEP_OFFPEAK:-1}" == "1" ]]; then
+		local current_hour
+		current_hour=$(date +%H)
+		if ((10#$current_hour < 18)); then
+			echo "[stats] Quality sweep deferred: hour $current_hour is outside off-peak window (18:00-23:59)" >>"$LOGFILE"
+			return 0
+		fi
 	fi
 
 	# Timestamp guard — run at most once per QUALITY_SWEEP_INTERVAL

--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -894,14 +894,9 @@ run_daily_quality_sweep() {
 	# and model demand is lower. Quality sweep findings trigger LLM worker
 	# dispatch via the pulse, so landing findings in this window means the
 	# resulting workers also run at 2x rates. Override: QUALITY_SWEEP_OFFPEAK=0
-	if [[ "${QUALITY_SWEEP_OFFPEAK:-1}" == "1" ]]; then
-		local current_hour
-		current_hour=$(date +%H)
-		current_hour=$((10#$current_hour)) # strip leading zero for arithmetic
-		if [[ "$current_hour" -lt 18 ]]; then
-			echo "[stats] Quality sweep deferred: hour ${current_hour} is outside off-peak window (18:00-23:59)" >>"$LOGFILE"
-			return 0
-		fi
+	if [[ "${QUALITY_SWEEP_OFFPEAK:-1}" == "1" ]] && ((10#$(date +%H) < 18)); then
+		echo "[stats] Quality sweep deferred: hour $(date +%H) is outside off-peak window (18:00-23:59)" >>"$LOGFILE"
+		return 0
 	fi
 
 	# Timestamp guard — run at most once per QUALITY_SWEEP_INTERVAL


### PR DESCRIPTION
## Summary

- Combines the env var check and hour comparison into a single `if` statement in `run_daily_quality_sweep()`
- Eliminates the intermediate `current_hour` variable and nested condition (5 lines → 1 line)
- Preserves the log line for observability (uses inline `$(date +%H)` instead of the variable)
- ShellCheck: zero violations

Addresses gemini-code-assist review feedback on PR #5131 (`discussion_r2943501341`).

Closes #5163