### PR TITLE
t5167: fix: use --argjson instead of printf pipe in backfill-closure-labels.sh

### DIFF
--- a/.agents/scripts/backfill-closure-labels.sh
+++ b/.agents/scripts/backfill-closure-labels.sh
@@ -81,7 +81,7 @@ while [[ "$_applied" -lt "$_limit" && "$_skipped" -lt 2000 ]]; do
 			IFS= read -r -d '' local_reason
 			IFS= read -r -d '' local_title
 			IFS= read -r -d '' local_labels
-		} < <(printf '%s' "$_issue" | jq -j '.number, "\u0000", (.state_reason // "completed"), "\u0000", .title, "\u0000", (.labels | join(",")), "\u0000"')
+		} < <(jq -j -n --argjson issue "$_issue" '$issue | .number, "\u0000", (.state_reason // "completed"), "\u0000", .title, "\u0000", (.labels | join(",")), "\u0000"')
 
 		# Skip if already has a closure reason label
 		if echo "$local_labels" | grep -qE 'duplicate|not-planned|already-fixed|wontfix|status:done'; then


### PR DESCRIPTION
## Summary

Address Gemini code review feedback from PR #5127 that was not applied before merge.

- Replace `printf '%s' "$_issue" | jq -j ...` with `jq -j -n --argjson issue "$_issue" '$issue | ...'` at line 84
- Eliminates one subprocess fork per loop iteration (no `printf` process)
- More robust: `--argjson` validates the JSON input and avoids any shell quoting edge cases
- ShellCheck: zero violations

## Changes

`.agents/scripts/backfill-closure-labels.sh` — single-line change at line 84.

Closes #5167