### PR TITLE
t5160: Comment out fullPage: true example in playwriter.md

### DIFF
--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -332,7 +332,7 @@ const rows = await page.$$eval('table tr', rows =>
 await page.screenshot({ path: 'viewport.png' })
 
 // Full page screenshot -- save to disk only, resize before sending to AI
-await page.screenshot({ path: 'full.png', fullPage: true })
+// await page.screenshot({ path: 'full.png', fullPage: true })
 
 // Element screenshot (safe -- element-scoped, not full page)
 await page.locator('.chart').screenshot({ path: 'chart.png' })


### PR DESCRIPTION
## Summary

- Comments out the `fullPage: true` screenshot example in `playwriter.md:335` to prevent copy-paste misuse that can produce >8000px screenshots and crash AI sessions
- Addresses critical Gemini review feedback from PR #5144 — the preceding warning comment is retained, but the code itself is now commented out as a stronger guardrail
- Consistent with the approach already taken in `dev-browser.md`

Closes #5160