### PR TITLE
fix: expand tilde in HELPER variable assignment to prevent literal ~ in paths

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -140,7 +140,8 @@ Not every task is code. The framework has multiple primary agents, each with dom
 **Dispatch example:**
 
 ```bash
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # Code task (default — Build+ implied)
 $HELPER run \

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -93,7 +93,8 @@ gh issue view 42 --repo user/repo --json number,title,url
 For each resolved item, launch a worker using `headless-runtime-helper.sh run`. This is the **ONLY** correct dispatch path — it constructs the full lifecycle prompt, handles provider rotation, session persistence, and backoff. NEVER use bare `opencode run` for dispatch — workers launched that way miss lifecycle reinforcement and stop after PR creation (see GH#5096).
 
 ```bash
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # For code tasks (Build+ is default — omit --agent)
 $HELPER run \

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -226,7 +226,8 @@ When dispatching multiple workers manually (outside the pulse supervisor), **sta
 - **MCP cold boot storms**: MCP servers (especially Node-based ones) have expensive startup. Concurrent initialization competes for CPU and I/O.
 
 ```bash
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # WRONG: Thundering herd — all 4 workers cold-boot simultaneously
 for issue in 42 43 44 45; do
@@ -792,7 +793,8 @@ LINEAGE RULES:
 > **IMPORTANT:** Always use `headless-runtime-helper.sh run` for dispatch — never bare `opencode run`. Bare dispatch skips lifecycle reinforcement, causing workers to stop after PR creation (GH#5096).
 
 ```bash
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # Standard dispatch (no lineage — top-level task)
 $HELPER run \
@@ -1071,7 +1073,8 @@ NEXT=$(batch-strategy-helper.sh next-batch \
   --concurrency "$AVAILABLE_SLOTS")
 
 # Dispatch each task in the batch
-HELPER="$(aidevops config get paths.agents_dir)/scripts/headless-runtime-helper.sh"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 echo "$NEXT" | jq -r '.[]' | while read -r task_id; do
   $HELPER run --role worker --session-key "task-${task_id}" \
     --dir <path> --title "$task_id" \


### PR DESCRIPTION
## Summary

- Fix tilde expansion bug in `HELPER` variable assignment where `$(aidevops config get paths.agents_dir)` inside double quotes does not expand tildes returned by the config command, causing `$HELPER` to contain a literal `~` and subsequent dispatch commands to fail
- Split each assignment into two lines: first `AGENTS_DIR="$(aidevops config get paths.agents_dir)"`, then `HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"` to replace a leading tilde with `$HOME`
- Fixed 5 occurrences across 3 files (4 from issues + 1 additional find in `runners.md`)

## Files Changed

| File | Locations |
|------|-----------|
| `.agents/tools/ai-assistants/headless-dispatch.md` | Lines 229, 795, 1074 |
| `.agents/AGENTS.md` | Line 143 |
| `.agents/scripts/commands/runners.md` | Line 96 (bonus — same bug, not in original issues) |

## Verification

- `grep` confirms zero remaining instances of the old `HELPER="$(aidevops config get paths.agents_dir)/scripts/..."` pattern
- `markdownlint-cli2`: 0 errors on all 3 changed files

Closes #5166
Closes #5165