### PR TITLE
t5161: Fix status:blocked label substring matching in pulse-wrapper

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2609,7 +2609,7 @@ check_terminal_blockers() {
 		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || existing_labels=""
 
 	local already_blocked=false
-	if echo "$existing_labels" | grep -qF 'status:blocked'; then
+	if [[ ",${existing_labels}," == *",status:blocked,"* ]]; then
 		already_blocked=true
 	fi
 


### PR DESCRIPTION
## Summary

- Replace `grep -qF 'status:blocked'` with comma-padded exact pattern matching (`[[ ",${existing_labels}," == *",status:blocked,"* ]]`) to prevent false positives from labels containing `status:blocked` as a substring (e.g., `archive-status:blocked`)
- Uses the standard shell idiom for exact element matching in comma-delimited lists — bash 3.2 compatible, no external process spawned

## Details

**File:** `.agents/scripts/pulse-wrapper.sh:2612`
**Root cause:** `grep -qF 'status:blocked'` performs a fixed-string substring search, so any label containing `status:blocked` as a substring would match (e.g., `archive-status:blocked`, `old-status:blocked-v2`).

**Fix:** Pad the comma-delimited label string with commas on both sides and match against `,status:blocked,`. This ensures the match is exact — the label must be a complete element in the list, not a substring of another label.

**Before:** `echo "$existing_labels" | grep -qF 'status:blocked'`
**After:** `[[ ",${existing_labels}," == *",status:blocked,"* ]]`

## Verification

- ShellCheck passes clean
- All 4 pulse-wrapper test suites pass (23 tests total)

Closes #5161