### PR TITLE
t5168: Use silent _has_crontab check in cmd_status

### DIFF
--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -112,11 +112,19 @@ _get_scheduler_backend() {
 }
 
 #######################################
-# Require crontab to be available
+# Silent check: is crontab available?
+# Returns: 0 if available, 1 if not
+#######################################
+_has_crontab() {
+	command -v crontab >/dev/null 2>&1
+}
+
+#######################################
+# Require crontab to be available (with error message)
 # Returns: 0 if available, 1 if not
 #######################################
 _require_crontab() {
-	if ! command -v crontab >/dev/null 2>&1; then
+	if ! _has_crontab; then
 		echo "Error: crontab is not available on this system." >&2
 		return 1
 	fi
@@ -887,7 +895,7 @@ cmd_status() {
 		fi
 	elif [[ "$backend" == "cron" ]]; then
 		# Linux: check cron (single crontab -l call)
-		if ! _require_crontab; then
+		if ! _has_crontab; then
 			echo "  Status: crontab unavailable"
 		else
 			local cron_entry


### PR DESCRIPTION
## Summary

- Extract `_has_crontab()` as a silent check for crontab availability (no stderr output)
- Use `_has_crontab` in `cmd_status` instead of `_require_crontab` to prevent a redundant error message on stderr when crontab is not configured — the status function already prints "crontab unavailable"
- Refactor `_require_crontab` to delegate to `_has_crontab`, eliminating duplicated `command -v` logic

Addresses review feedback from Gemini on PR #5123.

Closes #5168