### PR TITLE
t5170: simplify trailing newline check in ensure_trailing_newline()

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -105,7 +105,9 @@ check_file() {
 # Ensure file ends with a trailing newline (prevents malformed appends)
 ensure_trailing_newline() {
 	local file="$1"
-	[[ -s "$file" && $(tail -c1 "$file" | wc -l) -eq 0 ]] && printf '\n' >>"$file"
+	local last
+	last="$(tail -c 1 "$file"; printf x)"
+	[[ -s "$file" ]] && [[ "$last" != $'\n'x ]] && printf '\n' >>"$file"
 }
 
 # Initialize repos.json if it doesn't exist


### PR DESCRIPTION
## Summary

- Replaces `tail -c1 | wc -l` pipe with direct last-character comparison using a `; printf x` sentinel pattern
- More readable and uses one fewer subprocess
- Note: the Gemini reviewer's original suggestion (`$(tail -c 1 "$file") != $'\n'`) has a subtle bug — `$()` strips trailing newlines, so the comparison always sees an empty string. The sentinel pattern (`printf x` appended inside `$()`) preserves the newline for correct comparison.

## Testing

All 4 edge cases verified:
- File with trailing newline: no change (PASS)
- File without trailing newline: newline appended (PASS)
- Empty file: no change (PASS)
- File with only a newline: no change (PASS)

ShellCheck: zero warnings.

Closes #5170

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of file processing to correctly handle trailing newlines, ensuring files are properly formatted regardless of their initial state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->