### PR TITLE
fix: resolve SonarCloud maintainability violations in stats-functions.sh

### DIFF
--- a/.agents/scripts/stats-functions.sh
+++ b/.agents/scripts/stats-functions.sh
@@ -894,13 +894,11 @@ run_daily_quality_sweep() {
 	# and model demand is lower. Quality sweep findings trigger LLM worker
 	# dispatch via the pulse, so landing findings in this window means the
 	# resulting workers also run at 2x rates. Override: QUALITY_SWEEP_OFFPEAK=0
-	if [[ "${QUALITY_SWEEP_OFFPEAK:-1}" == "1" ]]; then
-		local current_hour
-		current_hour=$(date +%H)
-		if ((10#$current_hour < 18)); then
-			echo "[stats] Quality sweep deferred: hour $current_hour is outside off-peak window (18:00-23:59)" >>"$LOGFILE"
-			return 0
-		fi
+	local current_hour
+	current_hour=$(date +%H)
+	if [[ "${QUALITY_SWEEP_OFFPEAK:-1}" == "1" ]] && ((10#$current_hour < 18)); then
+		echo "[stats] Quality sweep deferred: hour ${current_hour} is outside off-peak window (18:00-23:59)" >>"$LOGFILE"
+		return 0
 	fi
 
 	# Timestamp guard — run at most once per QUALITY_SWEEP_INTERVAL


### PR DESCRIPTION
## Summary

Fixes 10 SonarCloud maintainability violations that caused the 'E Maintainability Rating on New Code' gate failure on PR #5179.

- **Extract repeated string literals to `readonly` constants**: `_ROLE_SUPERVISOR`, `_ROLE_CONTRIBUTOR`, `_LABEL_QUALITY_SWEEP`, `_BADGE_YELLOW`, `_BADGE_UNKNOWN`, `_JQ_LENGTH` — replaces all bash-level usages across the file
- **Merge nested `if` statement**: sys_load_ratio calculation (line 472) — two nested `if` blocks combined into a single condition with `&&`
- **Remove unused local variables**: `findings` (line 1235), `sc_summary` (line 1257), `runner_user` in `_cleanup_stale_pinned_issues` (line 640 — `$2` accepted for API compatibility but not referenced in function body)
- **ShellCheck**: zero violations

Closes #5163

Note: PR #5179 was merged before this fix was pushed. This PR adds the SonarCloud fixes on top of the merged refactor.