### PR TITLE
t5191: Fix issue number regex extraction in loop-common.sh

### DIFF
--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -992,8 +992,9 @@ loop_handle_workflow_push_failure() {
 
 	# Auto-detect issue number from branch name if not provided
 	if [[ -z "$issue_number" ]]; then
-		# Extract first digit sequence from branch name (handles issue-42, GH-42, t1234, #42, etc.)
-		issue_number=$(echo "$branch" | grep -oE '[0-9]+' | head -1 || echo "")
+		# Extract last digit sequence from branch name — issue numbers are conventionally
+		# at the end (e.g. bugfix/t5191-fix, feature/update-v2-for-GH-5162)
+		issue_number=$(echo "$branch" | grep -oE '[0-9]+' | tail -1 || echo "")
 	fi
 
 	if [[ -z "$repo_slug" || -z "$issue_number" ]]; then


### PR DESCRIPTION
## Summary

- Fix regex extraction in `handle_workflow_scope_error()` that captured the **first** digit sequence from branch names instead of the **last**
- For branch `feature/update-to-v2.1-for-GH-5162`, the old code extracted `2` instead of `5162`
- Changed `head -1` to `tail -1` — simpler than the `rev` approach suggested in the review, same result, no extra dependency

## Details

**Bug**: `.agents/scripts/loop-common.sh:996` — `grep -oE '[0-9]+' | head -1` grabs the first digit sequence
**Fix**: `grep -oE '[0-9]+' | tail -1` grabs the last digit sequence, where issue numbers conventionally appear

ShellCheck clean (no new findings).

Closes #5191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal automation script for handling workflow events.

---

**Note:** This release contains primarily internal infrastructure improvements with no direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->