### PR TITLE
t5190: reduce redundant credential storage comment in google-workspace.md

### DIFF
--- a/.agents/services/email/google-workspace.md
+++ b/.agents/services/email/google-workspace.md
@@ -149,8 +149,7 @@ gws gmail +triage   # just works
 # On the machine with a browser:
 gws auth export --unmasked > credentials.json
 # WARNING: credentials.json contains plaintext OAuth tokens.
-# Store the file CONTENT (not the path) as a secret — content is portable
-# across machines and avoids leaving plaintext on disk.
+# Store the file CONTENT as a secret — portable and avoids plaintext on disk.
 # Preferred: store content in gopass (most secure)
 cat credentials.json | aidevops secret set GWS_CREDENTIALS_JSON
 # Then delete the plaintext file immediately


### PR DESCRIPTION
## Summary

- Condenses the inline comment about storing credential content as a secret (line 152), removing the redundant `(not the path)` parenthetical and verbose phrasing — the detailed rationale is already in the Security Note block at lines 171-175.

## Finding Analysis (6 findings from #5190)

| # | Severity | Line | Verdict | Reason |
|---|----------|------|---------|--------|
| 1 | HIGH | 155 | No action | Positive feedback on change already applied in PR #5187 (content vs path storage) |
| 2 | MEDIUM | 152 | **Fixed** | Reduced redundant inline comment — detail already in Security Note block below |
| 3 | MEDIUM | 400 | No action | Positive feedback on `?.` operator already applied in PR #5187 |
| 4 | MEDIUM | 405 | No action | Positive feedback on `?.` operator already applied in PR #5187 |
| 5 | MEDIUM | 410 | No action | Positive feedback on `?.` operator already applied in PR #5187 |
| 6 | MEDIUM | 436 | No action | Positive feedback on `?.` operator already applied in PR #5187 |

5 of 6 findings were positive feedback on changes already merged in PR #5187 — only finding 2 (redundant comment) was actionable.

Closes #5190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified guidance on secret storage practices for improved clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->