### PR TITLE
t5192: add fallback default for paths.agents_dir in dispatch example

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -140,7 +140,8 @@ Not every task is code. The framework has multiple primary agents, each with dom
 **Dispatch example:**
 
 ```bash
-AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+AGENTS_DIR_FROM_CONFIG="$(aidevops config get paths.agents_dir)"
+AGENTS_DIR="${AGENTS_DIR_FROM_CONFIG:-$HOME/.aidevops/agents}"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # Code task (default — Build+ implied)


### PR DESCRIPTION
## Summary

- Add `:-$HOME/.aidevops/agents` fallback default when `aidevops config get paths.agents_dir` returns empty, preventing `HELPER` from resolving to an invalid path like `/scripts/headless-runtime-helper.sh`
- Split the single `AGENTS_DIR` assignment into two lines: capture config value into `AGENTS_DIR_FROM_CONFIG`, then apply default into `AGENTS_DIR` before tilde expansion
- Improves copy-paste robustness for users who haven't configured `paths.agents_dir`

## Change

```bash
# Before
AGENTS_DIR="$(aidevops config get paths.agents_dir)"
HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"

# After
AGENTS_DIR_FROM_CONFIG="$(aidevops config get paths.agents_dir)"
AGENTS_DIR="${AGENTS_DIR_FROM_CONFIG:-$HOME/.aidevops/agents}"
HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
```

## Verification

- `markdownlint-cli2`: 0 errors on `.agents/AGENTS.md`

Closes #5192