### PR TITLE
t5193: explain why fullPage:true is dangerous in playwriter.md

### DIFF
--- a/.agents/tools/browser/playwriter.md
+++ b/.agents/tools/browser/playwriter.md
@@ -331,7 +331,10 @@ const rows = await page.$$eval('table tr', rows =>
 // Viewport-sized screenshot (safe for AI review)
 await page.screenshot({ path: 'viewport.png' })
 
-// Full page screenshot -- save to disk only, resize before sending to AI
+// DANGER: fullPage:true creates screenshots that can exceed 8000px, which
+// Anthropic hard-rejects -- crashing the AI session with no recovery (the
+// oversized image is stuck in message history). Save to disk only, resize
+// before sending to AI (see "Screenshot Size Limits" in prompts/build.txt).
 // await page.screenshot({ path: 'full.png', fullPage: true })
 
 // Element screenshot (safe -- element-scoped, not full page)


### PR DESCRIPTION
## Summary

- Enhanced the inline comment on the commented-out `fullPage: true` screenshot example in `.agents/tools/browser/playwriter.md` to explicitly state **why** it's dangerous: it creates screenshots that can exceed Anthropic's 8000px hard limit, crashing AI sessions with no recovery (the oversized image is stuck in message history)
- Addresses quality-debt review feedback from PR #5181 (Gemini code review finding, medium severity)

Closes #5193