### PR TITLE
t5197: Fix wp-helper.sh SSH commands silently failing

### DIFF
--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -335,17 +335,29 @@ execute_wp_via_ssh() {
 			print_info "Fix with: chmod 600 $expanded_password_file"
 		fi
 
-		# Pass wp args as positional parameters to avoid shell interpolation issues
-		# Use bash -c (not -lc) to avoid login shell startup files that may redirect/swallow stdout
-		# shellcheck disable=SC2016 # $1/$@ expand on the remote shell, not locally
-		sshpass -f "$expanded_password_file" ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" bash -c 'cd "$1" && shift && wp "$@"' _ "$wp_path" "${wp_args[@]}"
+		# Build remote command as a single printf-escaped string.
+		# SSH concatenates multiple args with spaces, destroying bash -c positional
+		# parameter boundaries. Instead, each arg is individually escaped with %q,
+		# preventing both injection and argument-boundary loss. (GH#5197)
+		local remote_cmd
+		remote_cmd="cd $(printf '%q' "$wp_path") && wp"
+		local arg
+		for arg in "${wp_args[@]}"; do
+			remote_cmd+=" $(printf '%q' "$arg")"
+		done
+		sshpass -f "$expanded_password_file" ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
 		return $?
 		;;
 	hetzner | cloudways | cloudron)
 		# SSH key-based authentication (preferred, -n prevents stdin consumption in loops)
-		# Use bash -c (not -lc) to avoid login shell startup files that may redirect/swallow stdout
-		# shellcheck disable=SC2016 # $1/$@ expand on the remote shell, not locally
-		ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" bash -c 'cd "$1" && shift && wp "$@"' _ "$wp_path" "${wp_args[@]}"
+		# Build remote command as a single printf-escaped string (see sshpass block above)
+		local remote_cmd
+		remote_cmd="cd $(printf '%q' "$wp_path") && wp"
+		local arg
+		for arg in "${wp_args[@]}"; do
+			remote_cmd+=" $(printf '%q' "$arg")"
+		done
+		ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
 		return $?
 		;;
 	*)


### PR DESCRIPTION
## Summary

- Replaces broken `bash -c '...' _ args` SSH pattern with `printf '%q'`-escaped single command string
- Fixes all WP-CLI commands over SSH silently failing with exit code 1 and no output
- Affects cloudways, hetzner, cloudron, hostinger, closte hosting types (localwp unaffected)

## Root Cause

SSH concatenates multiple command arguments with spaces into a single string before passing to the remote shell. The `bash -c '...'` pattern passed wp_args as separate SSH arguments, but the remote shell received a flat string where `bash -c`'s script and its positional parameters were merged — causing `shift` to fail (exit 1) and `wp` to never execute.

## Fix

Build the full remote command as a single `printf '%q'`-escaped string and pass it as one argument to SSH. Each wp arg is individually escaped, preventing both injection and argument-boundary loss. Applied to both the key-based SSH path (hetzner/cloudways/cloudron) and the sshpass path (hostinger/closte).

## Validation

Per issue #5197, tested against live Cloudways sites:
- Basic: `wp core version` → `6.9.4`
- Flags: `plugin list --fields=name,version --status=active --format=table` → full table
- Injection: `core version '; echo INJECTED'` → blocked (exit 1, no injection)
- Multi-site: 4 different sites → all correct

Closes #5197