### PR TITLE
t5200: refactor duplicate remote_cmd into ssh_cmd array in execute_wp_via_ssh

### DIFF
--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -300,6 +300,13 @@ execute_wp_via_ssh() {
 		ssh_identity_flag=(-i "$expanded_identity")
 	fi
 
+	# Common SSH args and remote command shared across all SSH-based hosting types.
+	# Pass wp args as positional parameters to avoid shell interpolation issues.
+	# Use bash -c (not -lc) to avoid login shell startup files that may redirect/swallow stdout.
+	# shellcheck disable=SC2016 # $1/$@ expand on the remote shell, not locally
+	local ssh_cmd=(-n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}"
+		bash -c 'cd "$1" && shift && wp "$@"' _ "$wp_path" "${wp_args[@]}")
+
 	case "$site_type" in
 	localwp)
 		# LocalWP - direct local access
@@ -335,17 +342,12 @@ execute_wp_via_ssh() {
 			print_info "Fix with: chmod 600 $expanded_password_file"
 		fi
 
-		# Pass wp args as positional parameters to avoid shell interpolation issues
-		# Use bash -c (not -lc) to avoid login shell startup files that may redirect/swallow stdout
-		# shellcheck disable=SC2016 # $1/$@ expand on the remote shell, not locally
-		sshpass -f "$expanded_password_file" ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" bash -c 'cd "$1" && shift && wp "$@"' _ "$wp_path" "${wp_args[@]}"
+		sshpass -f "$expanded_password_file" ssh "${ssh_cmd[@]}"
 		return $?
 		;;
 	hetzner | cloudways | cloudron)
 		# SSH key-based authentication (preferred, -n prevents stdin consumption in loops)
-		# Use bash -c (not -lc) to avoid login shell startup files that may redirect/swallow stdout
-		# shellcheck disable=SC2016 # $1/$@ expand on the remote shell, not locally
-		ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" bash -c 'cd "$1" && shift && wp "$@"' _ "$wp_path" "${wp_args[@]}"
+		ssh "${ssh_cmd[@]}"
 		return $?
 		;;
 	*)


### PR DESCRIPTION
## Summary

- Extracts the duplicated SSH connection args and remote `bash -c` command string into a single `ssh_cmd` array, built once before the `case` statement in `execute_wp_via_ssh`
- The `hostinger`/`closte` branch now calls `sshpass -f "$expanded_password_file" ssh "${ssh_cmd[@]}"` and the `hetzner`/`cloudways`/`cloudron` branch calls `ssh "${ssh_cmd[@]}"` — no logic change, no functional difference
- Moves the `shellcheck disable=SC2016` comment to the array construction site (single location) rather than duplicating it in each branch

## Motivation

Addresses the medium-severity finding from gemini-code-assist on PR #5199 (line 347): the remote command construction was duplicated across two case branches, making future changes to the remote command (e.g. adding a new flag or changing the `bash -c` invocation) require two identical edits.

## Verification

- ShellCheck: zero new violations (only pre-existing SC1091 info for external source file)
- Logic: `ssh_cmd` array expands identically to the previous inline args in both branches
- No changes to `localwp` or `*)` branches

Closes #5200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal deployment tooling efficiency by streamlining SSH command execution patterns. Enhanced code maintainability and reduced execution risk while preserving all existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->