### PR TITLE
t5202: replace external process pipeline with pure bash issue number extraction

### DIFF
--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -992,9 +992,16 @@ loop_handle_workflow_push_failure() {
 
 	# Auto-detect issue number from branch name if not provided
 	if [[ -z "$issue_number" ]]; then
-		# Extract last digit sequence from branch name — issue numbers are conventionally
-		# at the end (e.g. bugfix/t5191-fix, feature/update-v2-for-GH-5162)
-		issue_number=$(echo "$branch" | grep -oE '[0-9]+' | tail -1 || echo "")
+		# Extract last digit sequence from branch name using pure bash parameter expansion.
+		# Issue numbers are conventionally at the end (e.g. bugfix/t5191-fix, feature/update-v2-for-GH-5162).
+		# Uses ${#array[@]}-1 index instead of array[-1] for bash 3.2 compatibility.
+		local _nums_only="${branch//[!0-9]/ }"
+		# shellcheck disable=SC2206  # intentional word-split to build digit array
+		local _nums_array=($_nums_only)
+		local _nums_count=${#_nums_array[@]}
+		if [[ $_nums_count -gt 0 ]]; then
+			issue_number="${_nums_array[$((_nums_count - 1))]}"
+		fi
 	fi
 
 	if [[ -z "$repo_slug" || -z "$issue_number" ]]; then


### PR DESCRIPTION
## Summary

- Replaces `echo "$branch" | grep -oE '[0-9]+' | tail -1` with pure bash parameter expansion in `loop_handle_workflow_push_failure()`
- Uses `${branch//[!0-9]/ }` to strip non-digits, word-splits into an array, then accesses last element via `${array[$((count-1))]}` — bash 3.2 compatible (no `array[-1]`)
- Adds `# shellcheck disable=SC2206` with explanatory comment since word-splitting is intentional here

## Bash 3.2 Compatibility

The reviewer's suggestion used `${nums_array[-1]}` which is bash 4.0+ only. This implementation uses `${_nums_array[$((_nums_count - 1))]}` which works on bash 3.2.57 (macOS default).

## Test Cases Verified

All pass under `/bin/bash` (3.2):

| Branch | Extracted |
|--------|-----------|
| `bugfix/t5191-fix` | `5191` |
| `feature/update-v2-for-GH-5162` | `5162` |
| `feature/update-to-v2.1-for-GH-5162` | `5162` |
| `issue-42` | `42` |
| `no-numbers-here` | `` (empty) |

Closes #5202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal build script efficiency and portability by refactoring issue number extraction logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->