### PR TITLE
GH#5202: Replace echo|grep|tail with pure Bash parameter expansion in loop-common.sh

### DIFF
--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -993,8 +993,16 @@ loop_handle_workflow_push_failure() {
 	# Auto-detect issue number from branch name if not provided
 	if [[ -z "$issue_number" ]]; then
 		# Extract last digit sequence from branch name — issue numbers are conventionally
-		# at the end (e.g. bugfix/t5191-fix, feature/update-v2-for-GH-5162)
-		issue_number=$(echo "$branch" | grep -oE '[0-9]+' | tail -1 || echo "")
+		# at the end (e.g. bugfix/t5191-fix, feature/update-v2-for-GH-5162).
+		# Uses pure Bash parameter expansion instead of forking echo|grep|tail.
+		# Compatible with bash 3.2 (avoids negative array index syntax).
+		local nums_only="${branch//[!0-9]/ }"
+		local -a nums_array=()
+		read -ra nums_array <<<"$nums_only"
+		local count=${#nums_array[@]}
+		if [[ $count -gt 0 ]]; then
+			issue_number="${nums_array[$((count - 1))]}"
+		fi
 	fi
 
 	if [[ -z "$repo_slug" || -z "$issue_number" ]]; then


### PR DESCRIPTION
## Summary

- Replaces the `echo "$branch" | grep -oE '[0-9]+' | tail -1` pipeline with pure Bash parameter expansion (`${branch//[!0-9]/ }` + `read -ra`), eliminating 3 forked subprocesses per invocation
- Uses bash 3.2-compatible `${arr[$((count-1))]}` indexing instead of the `${arr[-1]}` negative index syntax from the reviewer's suggestion (which requires bash 4.3+)
- Passes ShellCheck with no new violations

## Changes

**File**: `.agents/scripts/loop-common.sh:993-1006`

**Before** (1 line, 3 external processes):
```bash
issue_number=$(echo "$branch" | grep -oE '[0-9]+' | tail -1 || echo "")
```

**After** (pure Bash, zero forks):
```bash
local nums_only="${branch//[!0-9]/ }"
local -a nums_array=()
read -ra nums_array <<< "$nums_only"
local count=${#nums_array[@]}
if [[ $count -gt 0 ]]; then
    issue_number="${nums_array[$((count - 1))]}"
fi
```

## Verification

Tested with representative branch names — all produce identical results to the original pipeline:

| Branch | Result |
|--------|--------|
| `bugfix/t5191-fix` | `5191` |
| `feature/update-v2-for-GH-5162` | `5162` |
| `fix/quality-debt-5202-loop-common` | `5202` |
| `feature/no-numbers` | *(empty)* |
| `hotfix/42` | `42` |

Closes #5202

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal build script efficiency by optimizing branch name processing with native implementation, improving reliability and reducing external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->