### PR TITLE
t5200: refactor duplicate remote_cmd into ssh_cmd array in execute_wp_via_ssh

### DIFF
--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -300,6 +300,21 @@ execute_wp_via_ssh() {
 		ssh_identity_flag=(-i "$expanded_identity")
 	fi
 
+	# Build remote command as a single printf-escaped string shared across all
+	# SSH-based hosting types. SSH concatenates multiple args with spaces,
+	# destroying bash -c positional parameter boundaries. Instead, each arg is
+	# individually escaped with %q, preventing both injection and argument-boundary
+	# loss. (GH#5197)
+	local remote_cmd
+	remote_cmd="cd $(printf '%q' "$wp_path") && wp"
+	local arg
+	for arg in "${wp_args[@]}"; do
+		remote_cmd+=" $(printf '%q' "$arg")"
+	done
+
+	# Common SSH flags + remote command shared across all SSH-based hosting types.
+	local ssh_cmd=(-n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd")
+
 	case "$site_type" in
 	localwp)
 		# LocalWP - direct local access
@@ -335,29 +350,12 @@ execute_wp_via_ssh() {
 			print_info "Fix with: chmod 600 $expanded_password_file"
 		fi
 
-		# Build remote command as a single printf-escaped string.
-		# SSH concatenates multiple args with spaces, destroying bash -c positional
-		# parameter boundaries. Instead, each arg is individually escaped with %q,
-		# preventing both injection and argument-boundary loss. (GH#5197)
-		local remote_cmd
-		remote_cmd="cd $(printf '%q' "$wp_path") && wp"
-		local arg
-		for arg in "${wp_args[@]}"; do
-			remote_cmd+=" $(printf '%q' "$arg")"
-		done
-		sshpass -f "$expanded_password_file" ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
+		sshpass -f "$expanded_password_file" ssh "${ssh_cmd[@]}"
 		return $?
 		;;
 	hetzner | cloudways | cloudron)
 		# SSH key-based authentication (preferred, -n prevents stdin consumption in loops)
-		# Build remote command as a single printf-escaped string (see sshpass block above)
-		local remote_cmd
-		remote_cmd="cd $(printf '%q' "$wp_path") && wp"
-		local arg
-		for arg in "${wp_args[@]}"; do
-			remote_cmd+=" $(printf '%q' "$arg")"
-		done
-		ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
+		ssh "${ssh_cmd[@]}"
 		return $?
 		;;
 	*)


### PR DESCRIPTION
## Summary

- Extract duplicated `remote_cmd` building (printf %q pattern) and SSH flags into a shared `ssh_cmd` array before the `case` statement
- Each SSH-based hosting branch now calls `sshpass ... ssh "${ssh_cmd[@]}"` or `ssh "${ssh_cmd[@]}"` — no logic change, no functional difference
- Adapted from original PR #5203 which conflicted after #5199 was merged; rebased and updated to deduplicate the new `printf '%q'` pattern instead of the old `bash -c` pattern

Supersedes #5203 (could not reopen after force-push — GitHub platform limitation).

Closes #5200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability and consistency of remote command execution across hosting platforms (Hostinger, Hetzner, Cloudways, and Cloudron).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->