### PR TITLE
t5201: simplify dispatch example variable assignment

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -140,8 +140,8 @@ Not every task is code. The framework has multiple primary agents, each with dom
 **Dispatch example:**
 
 ```bash
-AGENTS_DIR_FROM_CONFIG="$(aidevops config get paths.agents_dir)"
-AGENTS_DIR="${AGENTS_DIR_FROM_CONFIG:-$HOME/.aidevops/agents}"
+AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+AGENTS_DIR="${AGENTS_DIR:-$HOME/.aidevops/agents}"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # Code task (default — Build+ implied)


### PR DESCRIPTION
## Summary

- Removes unnecessary `AGENTS_DIR_FROM_CONFIG` temporary variable in the dispatch example code block
- Reuses `AGENTS_DIR` directly with a fallback default — standard shell idiom, more concise

## Context

Addresses Gemini review feedback from PR #5196 ([discussion](https://github.com/marcusquinn/aidevops/pull/5196#discussion_r2948992659)). The temporary variable was only used once and added no clarity over the self-reassignment pattern.

Closes #5201