### PR TITLE
t5200: deduplicate remote_cmd construction in wp-helper.sh

### DIFF
--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -300,6 +300,18 @@ execute_wp_via_ssh() {
 		ssh_identity_flag=(-i "$expanded_identity")
 	fi
 
+	# Build remote command as a single printf-escaped string.
+	# SSH concatenates multiple args with spaces, destroying bash -c positional
+	# parameter boundaries. Instead, each arg is individually escaped with %q,
+	# preventing both injection and argument-boundary loss. (GH#5197)
+	# Built once here and shared by all SSH-based branches below.
+	local remote_cmd
+	remote_cmd="cd $(printf '%q' "$wp_path") && wp"
+	local arg
+	for arg in "${wp_args[@]}"; do
+		remote_cmd+=" $(printf '%q' "$arg")"
+	done
+
 	case "$site_type" in
 	localwp)
 		# LocalWP - direct local access
@@ -335,28 +347,11 @@ execute_wp_via_ssh() {
 			print_info "Fix with: chmod 600 $expanded_password_file"
 		fi
 
-		# Build remote command as a single printf-escaped string.
-		# SSH concatenates multiple args with spaces, destroying bash -c positional
-		# parameter boundaries. Instead, each arg is individually escaped with %q,
-		# preventing both injection and argument-boundary loss. (GH#5197)
-		local remote_cmd
-		remote_cmd="cd $(printf '%q' "$wp_path") && wp"
-		local arg
-		for arg in "${wp_args[@]}"; do
-			remote_cmd+=" $(printf '%q' "$arg")"
-		done
 		sshpass -f "$expanded_password_file" ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
 		return $?
 		;;
 	hetzner | cloudways | cloudron)
 		# SSH key-based authentication (preferred, -n prevents stdin consumption in loops)
-		# Build remote command as a single printf-escaped string (see sshpass block above)
-		local remote_cmd
-		remote_cmd="cd $(printf '%q' "$wp_path") && wp"
-		local arg
-		for arg in "${wp_args[@]}"; do
-			remote_cmd+=" $(printf '%q' "$arg")"
-		done
 		ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
 		return $?
 		;;

--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -302,15 +302,13 @@ execute_wp_via_ssh() {
 
 	# Build remote command as a single printf-escaped string.
 	# SSH concatenates multiple args with spaces, destroying bash -c positional
-	# parameter boundaries. Instead, each arg is individually escaped with %q,
-	# preventing both injection and argument-boundary loss. (GH#5197)
+	# parameter boundaries. printf %q escapes each arg, preventing both
+	# injection and argument-boundary loss. (GH#5197)
 	# Built once here and shared by all SSH-based branches below.
 	local remote_cmd
 	remote_cmd="cd $(printf '%q' "$wp_path") && wp"
-	local arg
-	for arg in "${wp_args[@]}"; do
-		remote_cmd+=" $(printf '%q' "$arg")"
-	done
+	remote_cmd+=" $(printf '%q ' "${wp_args[@]}")"
+	remote_cmd="${remote_cmd% }"
 
 	case "$site_type" in
 	localwp)


### PR DESCRIPTION
## Summary

- Hoists the `remote_cmd` printf-escaped string construction before the `case` statement in `execute_wp_via_ssh()`, so both SSH branches (sshpass password-based and key-based) share a single copy
- Eliminates 5 net lines of duplicated logic that was flagged by Gemini code review on PR #5199

## Changes

**`.agents/scripts/wp-helper.sh`**: Moved the `remote_cmd` construction block (lines 338-347) from inside the `hostinger|closte` branch to before the `case` statement. Removed the identical duplicate from the `hetzner|cloudways|cloudron` branch. Both SSH branches now reference the shared `remote_cmd` variable. No behavioural change.

## Verification

- ShellCheck: clean (only SC1091 info about external source, pre-existing)
- No functional change — same `remote_cmd` string is built, same SSH invocations execute

Closes #5200