### PR TITLE
GH#5210: Fix duplicate dispatch by adding pre-dispatch open PR existence check

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -345,6 +345,84 @@ is_assigned() {
 }
 
 #######################################
+# Check if an issue already has an open PR on GitHub (GH#5210)
+#
+# Queries GitHub for open PRs whose title contains the issue number
+# (as "#NNN") or a task ID extracted from the issue title. This is
+# a deterministic check — "does an open PR exist?" has exactly one
+# correct answer regardless of context.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repo slug (owner/repo)
+#   $3 = (optional) issue title — used for task-id extraction
+# Returns:
+#   exit 0 if open PR found (do NOT dispatch)
+#   exit 1 if no open PR found (safe to dispatch)
+# Outputs: PR info on stdout if found
+#######################################
+has_open_pr() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_title="${3:-}"
+
+	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
+		return 1
+	fi
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+
+	local pr_json pr_count pr_num
+
+	# Strategy 1: Search for open PRs with issue number in title
+	pr_json=$(gh pr list --repo "$repo_slug" --state open \
+		--search "#${issue_number} in:title" \
+		--json number --limit 1 2>/dev/null) || pr_json="[]"
+	pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+	if [[ "$pr_count" -gt 0 ]]; then
+		pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+		printf 'OPEN_PR: issue #%s in %s has open PR #%s (title match)\n' "$issue_number" "$repo_slug" "$pr_num"
+		return 0
+	fi
+
+	# Strategy 2: Search by task ID from issue title
+	local task_id
+	task_id=$(printf '%s' "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
+	if [[ -n "$task_id" ]]; then
+		pr_json=$(gh pr list --repo "$repo_slug" --state open \
+			--search "${task_id} in:title" \
+			--json number --limit 1 2>/dev/null) || pr_json="[]"
+		pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+		if [[ "$pr_count" -gt 0 ]]; then
+			pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+			printf 'OPEN_PR: task %s in %s has open PR #%s (task-id match)\n' "$task_id" "$repo_slug" "$pr_num"
+			return 0
+		fi
+	fi
+
+	# Strategy 3: Search by "Closes/Fixes/Resolves #NNN" in PR body
+	local keyword
+	for keyword in closes fixes resolves; do
+		pr_json=$(gh pr list --repo "$repo_slug" --state open \
+			--search "${keyword} #${issue_number} in:body" \
+			--json number --limit 1 2>/dev/null) || pr_json="[]"
+		pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+		if [[ "$pr_count" -gt 0 ]]; then
+			pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+			printf 'OPEN_PR: issue #%s in %s has open PR #%s (body "%s" match)\n' "$issue_number" "$repo_slug" "$pr_num" "$keyword"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+#######################################
 # Show help
 #######################################
 show_help() {
@@ -356,6 +434,8 @@ Usage:
   dispatch-dedup-helper.sh is-duplicate <title>     Check if already running (exit 0=dup, 1=safe)
   dispatch-dedup-helper.sh is-assigned <issue> <slug> [self-login]
                                                     Check if issue is assigned (exit 0=assigned, 1=free)
+  dispatch-dedup-helper.sh has-open-pr <issue> <slug> [issue-title]
+                                                    Check if open PR exists (exit 0=found, 1=none)
   dispatch-dedup-helper.sh list-running-keys        List keys for all running workers
   dispatch-dedup-helper.sh normalize <title>        Normalize a title for comparison
   dispatch-dedup-helper.sh help                     Show this help
@@ -378,6 +458,13 @@ Examples:
     echo "Assigned to someone else — skip dispatch"
   else
     echo "Unassigned or assigned to self — safe to dispatch"
+  fi
+
+  # Check before dispatching (open PR dedup — GH#5210)
+  if dispatch-dedup-helper.sh has-open-pr 2300 owner/repo "t1337: Fix auth"; then
+    echo "Open PR exists — skip dispatch"
+  else
+    echo "No open PR — safe to dispatch"
   fi
 HELP
 	return 0
@@ -411,6 +498,13 @@ main() {
 			return 1
 		}
 		is_assigned "$1" "$2" "${3:-}"
+		;;
+	has-open-pr)
+		[[ $# -lt 2 ]] && {
+			echo "Error: has-open-pr requires <issue-number> <repo-slug> [issue-title]" >&2
+			return 1
+		}
+		has_open_pr "$1" "$2" "${3:-}"
 		;;
 	list-running-keys)
 		list_running_keys

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -345,6 +345,39 @@ is_assigned() {
 }
 
 #######################################
+# Private helper: run a single open-PR GitHub query.
+#
+# Executes one `gh pr list` search and outputs the first matching PR
+# number on stdout. Centralises the query → parse → validate pattern
+# used by all three strategies in has_open_pr().
+#
+# Args:
+#   $1 = repo slug (owner/repo)
+#   $2 = search query string (passed to --search)
+# Returns:
+#   exit 0 and prints PR number if a match is found
+#   exit 1 if no match or gh/jq error
+#######################################
+_query_open_prs() {
+	local repo_slug="$1"
+	local search_query="$2"
+
+	local pr_json pr_count pr_num
+	pr_json=$(gh pr list --repo "$repo_slug" --state open \
+		--search "$search_query" \
+		--json number --limit 1 2>/dev/null) || pr_json="[]"
+	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+	if [[ "$pr_count" -gt 0 ]]; then
+		pr_num=$(printf '%s' "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+		printf '%s' "$pr_num"
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
 # Check if an issue already has an open PR on GitHub (GH#5210)
 #
 # Queries GitHub for open PRs whose title contains the issue number
@@ -374,16 +407,10 @@ has_open_pr() {
 		return 1
 	fi
 
-	local pr_json pr_count pr_num
+	local pr_num
 
 	# Strategy 1: Search for open PRs with issue number in title
-	pr_json=$(gh pr list --repo "$repo_slug" --state open \
-		--search "#${issue_number} in:title" \
-		--json number --limit 1 2>/dev/null) || pr_json="[]"
-	pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-	if [[ "$pr_count" -gt 0 ]]; then
-		pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+	if pr_num=$(_query_open_prs "$repo_slug" "#${issue_number} in:title"); then
 		printf 'OPEN_PR: issue #%s in %s has open PR #%s (title match)\n' "$issue_number" "$repo_slug" "$pr_num"
 		return 0
 	fi
@@ -392,13 +419,7 @@ has_open_pr() {
 	local task_id
 	task_id=$(printf '%s' "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
 	if [[ -n "$task_id" ]]; then
-		pr_json=$(gh pr list --repo "$repo_slug" --state open \
-			--search "${task_id} in:title" \
-			--json number --limit 1 2>/dev/null) || pr_json="[]"
-		pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-		if [[ "$pr_count" -gt 0 ]]; then
-			pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+		if pr_num=$(_query_open_prs "$repo_slug" "${task_id} in:title"); then
 			printf 'OPEN_PR: task %s in %s has open PR #%s (task-id match)\n' "$task_id" "$repo_slug" "$pr_num"
 			return 0
 		fi
@@ -407,13 +428,7 @@ has_open_pr() {
 	# Strategy 3: Search by "Closes/Fixes/Resolves #NNN" in PR body
 	local keyword
 	for keyword in closes fixes resolves; do
-		pr_json=$(gh pr list --repo "$repo_slug" --state open \
-			--search "${keyword} #${issue_number} in:body" \
-			--json number --limit 1 2>/dev/null) || pr_json="[]"
-		pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-		if [[ "$pr_count" -gt 0 ]]; then
-			pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+		if pr_num=$(_query_open_prs "$repo_slug" "${keyword} #${issue_number} in:body"); then
 			printf 'OPEN_PR: issue #%s in %s has open PR #%s (body "%s" match)\n' "$issue_number" "$repo_slug" "$pr_num" "$keyword"
 			return 0
 		fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2461,12 +2461,97 @@ has_merged_pr_for_issue() {
 }
 
 #######################################
-# Check if dispatching a worker would be a duplicate (GH#4400)
+# Check if an issue already has an open PR (GH#5210)
 #
-# Three-layer dedup:
+# Queries GitHub for open PRs whose title contains the issue number
+# (as "#NNN") or a task ID extracted from the issue title. This is
+# the missing dedup layer: existing checks only look at local processes
+# (Layer 1-2) and merged PRs (Layer 3). A worker that has already
+# created a PR but whose process has exited (or runs on another machine)
+# is invisible to those layers — but the open PR is visible on GitHub.
+#
+# This is a deterministic check (not LLM judgment): "does an open PR
+# exist for this issue?" has exactly one correct answer.
+#
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug (owner/repo)
+#   $3 - issue title (optional; used for task-id extraction)
+# Exit codes:
+#   0 - open PR found (skip dispatch)
+#   1 - no open PR found
+#######################################
+has_open_pr_for_issue() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_title="${3:-}"
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
+		return 1
+	fi
+
+	# Strategy 1: Search for open PRs referencing this issue number in title
+	# Uses "in:title" to avoid false positives from PR bodies that mention
+	# many issue numbers. The "#NNN" pattern matches the standard PR title
+	# format "{task-id}: description (Closes #NNN)".
+	local pr_json pr_count
+	pr_json=$(gh pr list --repo "$repo_slug" --state open \
+		--search "#${issue_number} in:title" \
+		--json number --limit 1 2>/dev/null) || pr_json="[]"
+	pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+	if [[ "$pr_count" -gt 0 ]]; then
+		local pr_num
+		pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+		echo "[pulse-wrapper] Dedup: open PR #${pr_num} found for issue #${issue_number} in ${repo_slug} (title match)" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Strategy 2: Search by task ID extracted from issue title (e.g., "t1337")
+	local task_id
+	task_id=$(echo "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
+	if [[ -n "$task_id" ]]; then
+		pr_json=$(gh pr list --repo "$repo_slug" --state open \
+			--search "${task_id} in:title" \
+			--json number --limit 1 2>/dev/null) || pr_json="[]"
+		pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+		if [[ "$pr_count" -gt 0 ]]; then
+			local pr_num
+			pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+			echo "[pulse-wrapper] Dedup: open PR #${pr_num} found for task ${task_id} in ${repo_slug} (task-id match)" >>"$LOGFILE"
+			return 0
+		fi
+	fi
+
+	# Strategy 3: Search by "Closes #NNN" or "Fixes #NNN" in PR body
+	# Catches PRs that reference the issue in the body but not the title.
+	local keyword
+	for keyword in closes fixes resolves; do
+		pr_json=$(gh pr list --repo "$repo_slug" --state open \
+			--search "${keyword} #${issue_number} in:body" \
+			--json number --limit 1 2>/dev/null) || pr_json="[]"
+		pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+		if [[ "$pr_count" -gt 0 ]]; then
+			local pr_num
+			pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
+			echo "[pulse-wrapper] Dedup: open PR #${pr_num} found for issue #${issue_number} in ${repo_slug} (body '${keyword}' match)" >>"$LOGFILE"
+			return 0
+		fi
+	done
+
+	return 1
+}
+
+#######################################
+# Check if dispatching a worker would be a duplicate (GH#4400, GH#5210)
+#
+# Four-layer dedup:
 #   1. has_worker_for_repo_issue() — exact repo+issue process match
 #   2. dispatch-dedup-helper.sh is-duplicate — normalized title key match
-#   3. has_merged_pr_for_issue() — skip issues already completed by merged PR
+#   3. has_open_pr_for_issue() — open PR on GitHub for this issue/task (GH#5210)
+#   4. has_merged_pr_for_issue() — skip issues already completed by merged PR
 #
 # Arguments:
 #   $1 - issue number
@@ -2498,7 +2583,15 @@ check_dispatch_dedup() {
 		fi
 	fi
 
-	# Layer 3: merged PR evidence for this issue/task
+	# Layer 3: open PR on GitHub for this issue/task (GH#5210)
+	# This catches the case where a worker created a PR but the process
+	# has exited (or runs on another machine). The open PR is visible on
+	# GitHub even when no local process exists.
+	if has_open_pr_for_issue "$issue_number" "$repo_slug" "$issue_title"; then
+		return 0
+	fi
+
+	# Layer 4: merged PR evidence for this issue/task
 	if has_merged_pr_for_issue "$issue_number" "$repo_slug" "$issue_title"; then
 		echo "[pulse-wrapper] Dedup: merged PR already exists for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
 		return 0

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2463,15 +2463,10 @@ has_merged_pr_for_issue() {
 #######################################
 # Check if an issue already has an open PR (GH#5210)
 #
-# Queries GitHub for open PRs whose title contains the issue number
-# (as "#NNN") or a task ID extracted from the issue title. This is
-# the missing dedup layer: existing checks only look at local processes
-# (Layer 1-2) and merged PRs (Layer 3). A worker that has already
-# created a PR but whose process has exited (or runs on another machine)
-# is invisible to those layers — but the open PR is visible on GitHub.
-#
-# This is a deterministic check (not LLM judgment): "does an open PR
-# exist for this issue?" has exactly one correct answer.
+# Delegates to dispatch-dedup-helper.sh has-open-pr, which owns the
+# three-strategy search logic (title match, task-id match, body keyword
+# match). Keeping the logic in one place prevents drift between the two
+# implementations.
 #
 # Arguments:
 #   $1 - issue number
@@ -2479,67 +2474,24 @@ has_merged_pr_for_issue() {
 #   $3 - issue title (optional; used for task-id extraction)
 # Exit codes:
 #   0 - open PR found (skip dispatch)
-#   1 - no open PR found
+#   1 - no open PR found or helper unavailable
 #######################################
 has_open_pr_for_issue() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local issue_title="${3:-}"
 
-	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
+	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
+	if [[ ! -x "$dedup_helper" ]]; then
+		echo "[pulse-wrapper] Dedup: dispatch-dedup-helper.sh not found or not executable — skipping open PR check" >>"$LOGFILE"
 		return 1
 	fi
 
-	# Strategy 1: Search for open PRs referencing this issue number in title
-	# Uses "in:title" to avoid false positives from PR bodies that mention
-	# many issue numbers. The "#NNN" pattern matches the standard PR title
-	# format "{task-id}: description (Closes #NNN)".
-	local pr_json pr_count
-	pr_json=$(gh pr list --repo "$repo_slug" --state open \
-		--search "#${issue_number} in:title" \
-		--json number --limit 1 2>/dev/null) || pr_json="[]"
-	pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-	if [[ "$pr_count" -gt 0 ]]; then
-		local pr_num
-		pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
-		echo "[pulse-wrapper] Dedup: open PR #${pr_num} found for issue #${issue_number} in ${repo_slug} (title match)" >>"$LOGFILE"
+	local output
+	if output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>/dev/null); then
+		echo "[pulse-wrapper] Dedup: ${output}" >>"$LOGFILE"
 		return 0
 	fi
-
-	# Strategy 2: Search by task ID extracted from issue title (e.g., "t1337")
-	local task_id
-	task_id=$(echo "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
-	if [[ -n "$task_id" ]]; then
-		pr_json=$(gh pr list --repo "$repo_slug" --state open \
-			--search "${task_id} in:title" \
-			--json number --limit 1 2>/dev/null) || pr_json="[]"
-		pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-		if [[ "$pr_count" -gt 0 ]]; then
-			local pr_num
-			pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
-			echo "[pulse-wrapper] Dedup: open PR #${pr_num} found for task ${task_id} in ${repo_slug} (task-id match)" >>"$LOGFILE"
-			return 0
-		fi
-	fi
-
-	# Strategy 3: Search by "Closes #NNN" or "Fixes #NNN" in PR body
-	# Catches PRs that reference the issue in the body but not the title.
-	local keyword
-	for keyword in closes fixes resolves; do
-		pr_json=$(gh pr list --repo "$repo_slug" --state open \
-			--search "${keyword} #${issue_number} in:body" \
-			--json number --limit 1 2>/dev/null) || pr_json="[]"
-		pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-		if [[ "$pr_count" -gt 0 ]]; then
-			local pr_num
-			pr_num=$(echo "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
-			echo "[pulse-wrapper] Dedup: open PR #${pr_num} found for issue #${issue_number} in ${repo_slug} (body '${keyword}' match)" >>"$LOGFILE"
-			return 0
-		fi
-	done
 
 	return 1
 }
@@ -2587,8 +2539,12 @@ check_dispatch_dedup() {
 	# This catches the case where a worker created a PR but the process
 	# has exited (or runs on another machine). The open PR is visible on
 	# GitHub even when no local process exists.
-	if has_open_pr_for_issue "$issue_number" "$repo_slug" "$issue_title"; then
-		return 0
+	if [[ -x "$dedup_helper" ]]; then
+		local open_pr_output
+		if open_pr_output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>/dev/null); then
+			echo "[pulse-wrapper] Dedup: ${open_pr_output}" >>"$LOGFILE"
+			return 0
+		fi
 	fi
 
 	# Layer 4: merged PR evidence for this issue/task

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -287,6 +287,83 @@ test_check_dispatch_dedup_treats_merged_pr_as_duplicate() {
 	return 0
 }
 
+test_has_open_pr_for_issue_detects_title_match() {
+	set_gh_search_fixtures "marcusquinn/aidevops|open|#5210 in:title|[{\"number\":1200}]"
+
+	if has_open_pr_for_issue "5210" "marcusquinn/aidevops" "t5210: Fix dispatch dedup"; then
+		print_result "has_open_pr_for_issue detects open PR via issue number in title" 0
+		return 0
+	fi
+
+	print_result "has_open_pr_for_issue detects open PR via issue number in title" 1 "Expected open PR match for issue #5210"
+	return 0
+}
+
+test_has_open_pr_for_issue_detects_task_id_match() {
+	# No match on issue number, but task ID matches
+	set_gh_search_fixtures "marcusquinn/aidevops|open|t1337 in:title|[{\"number\":1201}]"
+
+	if has_open_pr_for_issue "9999" "marcusquinn/aidevops" "t1337: Simplify infra scripts"; then
+		print_result "has_open_pr_for_issue detects open PR via task-id fallback" 0
+		return 0
+	fi
+
+	print_result "has_open_pr_for_issue detects open PR via task-id fallback" 1 "Expected open PR match via task ID"
+	return 0
+}
+
+test_has_open_pr_for_issue_detects_body_closes_match() {
+	# No match on title or task ID, but "closes #NNN" in body matches
+	set_gh_search_fixtures "marcusquinn/aidevops|open|closes #4500 in:body|[{\"number\":1202}]"
+
+	if has_open_pr_for_issue "4500" "marcusquinn/aidevops" ""; then
+		print_result "has_open_pr_for_issue detects open PR via body closes keyword" 0
+		return 0
+	fi
+
+	print_result "has_open_pr_for_issue detects open PR via body closes keyword" 1 "Expected open PR match via body closes"
+	return 0
+}
+
+test_has_open_pr_for_issue_returns_false_when_no_pr() {
+	# No fixtures set — all searches return []
+	set_gh_search_fixtures ""
+
+	if has_open_pr_for_issue "8888" "marcusquinn/aidevops" "t8888: nonexistent task"; then
+		print_result "has_open_pr_for_issue returns false when no open PR exists" 1 "Expected no match but got one"
+		return 0
+	fi
+
+	print_result "has_open_pr_for_issue returns false when no open PR exists" 0
+	return 0
+}
+
+test_check_dispatch_dedup_blocks_on_open_pr() {
+	set_ps_fixture ""
+	set_gh_search_fixtures "marcusquinn/aidevops|open|#5210 in:title|[{\"number\":1200}]"
+
+	if check_dispatch_dedup "5210" "marcusquinn/aidevops" "Issue #5210: Fix dispatch" "t5210: Fix dispatch"; then
+		print_result "check_dispatch_dedup blocks dispatch when open PR exists (GH#5210)" 0
+		return 0
+	fi
+
+	print_result "check_dispatch_dedup blocks dispatch when open PR exists (GH#5210)" 1 "Expected dedup to block on open PR"
+	return 0
+}
+
+test_check_dispatch_dedup_allows_when_no_pr_or_worker() {
+	set_ps_fixture ""
+	set_gh_search_fixtures ""
+
+	if check_dispatch_dedup "7777" "marcusquinn/aidevops" "Issue #7777: New task" "t7777: New task"; then
+		print_result "check_dispatch_dedup allows dispatch when no PR or worker exists" 1 "Expected dispatch to be allowed"
+		return 0
+	fi
+
+	print_result "check_dispatch_dedup allows dispatch when no PR or worker exists" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -300,6 +377,12 @@ main() {
 	test_has_merged_pr_for_issue_detects_closing_keyword
 	test_has_merged_pr_for_issue_detects_task_id_fallback
 	test_check_dispatch_dedup_treats_merged_pr_as_duplicate
+	test_has_open_pr_for_issue_detects_title_match
+	test_has_open_pr_for_issue_detects_task_id_match
+	test_has_open_pr_for_issue_detects_body_closes_match
+	test_has_open_pr_for_issue_returns_false_when_no_pr
+	test_check_dispatch_dedup_blocks_on_open_pr
+	test_check_dispatch_dedup_allows_when_no_pr_or_worker
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -81,6 +81,7 @@ ps() {
 set_gh_search_fixtures() {
 	local fixtures="$1"
 	GH_SEARCH_FIXTURES="$fixtures"
+	export GH_SEARCH_FIXTURES
 	return 0
 }
 
@@ -136,6 +137,7 @@ gh() {
 	command gh "$@"
 	return 0
 }
+export -f gh
 
 test_counts_plain_and_dot_prefixed_opencode_workers() {
 	# Line 125: supervisor /pulse — excluded by standalone /pulse filter


### PR DESCRIPTION
## Summary

- Adds a new dedup layer (`has_open_pr_for_issue()`) that queries GitHub for open PRs matching the task ID or issue number before dispatching a worker
- Integrates as Layer 3 in `check_dispatch_dedup()`, making it a 4-layer dedup system (process match → title key match → **open PR check** → merged PR check)
- Adds standalone `has-open-pr` CLI command to `dispatch-dedup-helper.sh` for external use

## Problem

The pulse-wrapper dispatched new workers for tasks that already had an active worker and open PR. The existing dedup only checked local processes (Layer 1-2) and merged PRs (Layer 3), but never checked for **open** PRs on GitHub. A worker that created a PR but whose process had exited (or ran on another machine) was invisible to those layers.

## Solution

Three-strategy open PR search:
1. Issue number in PR title (`#NNN in:title`)
2. Task ID in PR title (`tNNN in:title`, extracted from issue title)
3. Closing keywords in PR body (`closes #NNN in:body`, `fixes #NNN in:body`, `resolves #NNN in:body`)

This is a deterministic check — "does an open PR exist for this issue?" has exactly one correct answer regardless of context.

## Verification

- ShellCheck: 0 violations on all 3 modified files
- Tests: 15/15 pass (6 new tests added covering all search strategies + integration)
- Pre-existing test failures in `test-pulse-wrapper-worker-count.sh` (5 failures) confirmed on `main` — not caused by this change

Closes #5210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to detect open pull requests related to issues.
  * Deduplication now checks for open PRs before dispatching tasks, reducing redundant work.

* **Tests**
  * Added tests for open-PR detection via title, task ID, and body references.
  * Added tests covering deduplication behavior when open or merged PRs exist.

* **Documentation**
  * Help text and usage examples updated to document the new open-PR check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->