### PR TITLE
fix(issue-sync): skip completed [x] tasks in push to prevent duplicate issues

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -310,6 +310,17 @@ cmd_push() {
 			continue
 		}
 
+		# GH#5212: Skip tasks already marked [x] (completed) — prevents duplicate
+		# issues when push is called with a specific task_id that is already done.
+		# The TOON backlog cache in TODO.md can be stale, showing tasks as pending
+		# even after [x] completion. The pulse reads the stale cache and calls
+		# push <task_id>, which previously matched [x] lines via the [.] pattern.
+		if echo "$task_line" | grep -qE "^\s*- \[x\] "; then
+			print_info "Skipping $task_id — already completed ([x] in TODO.md)"
+			skipped=$((skipped + 1))
+			continue
+		fi
+
 		local parsed
 		parsed=$(parse_task_line "$task_line")
 		local description

--- a/.agents/scripts/tests/test-tier3-simplified.sh
+++ b/.agents/scripts/tests/test-tier3-simplified.sh
@@ -439,6 +439,25 @@ test_issue_sync_helper() {
 	# We test those interfaces exist via help output above.
 	# The parse command tests the library functions (parse_task_line, etc.)
 
+	# GH#5212: Test that push skips completed [x] tasks.
+	# Uses DRY_RUN=true and a fake GH_TOKEN to bypass gh auth, then verifies
+	# the skip message appears before any API call is attempted.
+	local tmp_dir
+	tmp_dir=$(mktemp -d)
+	local tmp_todo="$tmp_dir/TODO.md"
+	printf '# Tasks\n\n- [x] t999 Already completed task pr:#1 verified:2026-01-01\n' >"$tmp_todo"
+	# Initialize a minimal git repo so find_project_root and detect_repo_slug work
+	git -C "$tmp_dir" init -q 2>/dev/null || true
+	git -C "$tmp_dir" remote add origin "https://github.com/example/test.git" 2>/dev/null || true
+	local push_output
+	push_output=$(cd "$tmp_dir" && GH_TOKEN=fake-token-for-test DRY_RUN=true "$helper" push t999 2>&1) || true
+	rm -rf "$tmp_dir"
+	if echo "$push_output" | grep -qiE "already completed|skip.*t999|t999.*skip"; then
+		print_result "issue-sync: push skips completed [x] task (GH#5212)" 0
+	else
+		print_result "issue-sync: push skips completed [x] task (GH#5212)" 1 "Expected skip message for completed task. output: $push_output"
+	fi
+
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Fixes duplicate GitHub issues created by the pulse for tasks already marked `[x]` in TODO.md
- Root cause: `cmd_push()` matched task lines with `[.]` (any checkbox state) including `[x]`, so a completed task passed to `push <task_id>` would proceed to create an issue
- Fix: add a completed-task guard in the per-task loop — if the task line is `[x]`, skip with a clear message

## Root Cause

In `issue-sync-helper.sh:cmd_push()`, the task line lookup used `[.]` which matches any checkbox state:

```bash
task_line=$(strip_code_fences <"$todo_file" | grep -E "^\s*- \[.\] ${task_id_ere} " | head -1)
```

The TOON backlog cache in TODO.md can be stale — showing tasks as `pending` even after `[x]` completion. The pulse reads the stale cache and calls `push <task_id>`, which previously matched `[x]` lines and created duplicate issues.

Observed duplicates during pulse cycle 2026-03-18:
- essentials-com/essentials.com #76 (t004 — already done, pr:#10)
- marcusquinn/turbostarter-plus #120 (t004 — already done, pr:#25)
- marcusquinn/quickfile-mcp #45 (t004 — already done, pr:#8)
- <webapp>/<webapp> #1391 (t058 — already done, pr:#399)

## Changes

- `issue-sync-helper.sh`: Added completed-task guard after task line lookup — if `[x]`, skip with message and increment `skipped` counter
- `tests/test-tier3-simplified.sh`: Added GH#5212 regression test using `DRY_RUN=true` + fake `GH_TOKEN` to verify skip behavior without gh auth

## Verification

```
PASS  issue-sync: push skips completed [x] task (GH#5212)
PASS  shellcheck: issue-sync-helper.sh
PASS  shellcheck: tests/test-tier3-simplified.sh
```

Closes #5212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate issues from being created when pushing completed tasks by skipping tasks already marked as finished in the backlog.

* **Tests**
  * Added test coverage to verify that completed tasks are properly skipped during push operations without triggering unnecessary API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->