### PR TITLE
5217: Simplify branch number extraction in loop-common.sh using for-loop pattern

### DIFF
--- a/.agents/scripts/loop-common.sh
+++ b/.agents/scripts/loop-common.sh
@@ -994,14 +994,14 @@ loop_handle_workflow_push_failure() {
 	if [[ -z "$issue_number" ]]; then
 		# Extract last digit sequence from branch name using pure bash parameter expansion.
 		# Issue numbers are conventionally at the end (e.g. bugfix/t5191-fix, feature/update-v2-for-GH-5162).
-		# Uses ${#array[@]}-1 index instead of array[-1] for bash 3.2 compatibility.
-		local _nums_only="${branch//[!0-9]/ }"
-		# shellcheck disable=SC2206  # intentional word-split to build digit array
-		local _nums_array=($_nums_only)
-		local _nums_count=${#_nums_array[@]}
-		if [[ $_nums_count -gt 0 ]]; then
-			issue_number="${_nums_array[$((_nums_count - 1))]}"
-		fi
+		# The for loop iterates over all digit sequences and keeps the last one, avoiding an intermediate array.
+		local _nums_only="${branch//[!0-9]/ }" _last_num=""
+		# The unquoted expansion is intentional to iterate over numbers.
+		# shellcheck disable=SC2086
+		for _num in $_nums_only; do
+			_last_num="$_num"
+		done
+		issue_number="$_last_num"
 	fi
 
 	if [[ -z "$repo_slug" || -z "$issue_number" ]]; then


### PR DESCRIPTION
## Summary

- Replaces the intermediate array approach (`_nums_array`, `_nums_count`, conditional index) with a simple `for` loop that iterates over digit sequences and keeps the last one
- Removes the `SC2206` disable comment (array word-split) — the new `SC2086` disable is narrower and matches the reviewer's suggestion exactly
- Functionally equivalent: both approaches extract the last digit sequence from the branch name

## Source

Review feedback from gemini-code-assist on PR #5204, line 1004 of `.agents/scripts/loop-common.sh`.

Closes #5217

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal build script logic for improved maintainability.

**Note:** This release contains no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->