### PR TITLE
perf(issue-sync): replace echo|grep with bash string matching for [x] check

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -315,7 +315,7 @@ cmd_push() {
 		# The TOON backlog cache in TODO.md can be stale, showing tasks as pending
 		# even after [x] completion. The pulse reads the stale cache and calls
 		# push <task_id>, which previously matched [x] lines via the [.] pattern.
-		if echo "$task_line" | grep -qE "^\s*- \[x\] "; then
+		if [[ "$task_line" == *"[x]"* ]]; then
 			print_info "Skipping $task_id — already completed ([x] in TODO.md)"
 			skipped=$((skipped + 1))
 			continue


### PR DESCRIPTION
## Summary

- Replaces `echo "$task_line" | grep -qE "^\s*- \[x\] "` with `[[ "$task_line" == *"[x]"* ]]` at `.agents/scripts/issue-sync-helper.sh:318`
- Eliminates two unnecessary process forks (one `echo`, one `grep`) per task iteration in the push loop
- Functionally equivalent: `task_line` is already filtered to the `- [.] task_id` pattern by the preceding `grep`, so `[x]` can only appear in the completion marker position

Closes #5214

## Review feedback source

Gemini code review on PR #5213 (medium severity finding).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task completion detection logic to recognize completed items with more flexible formatting, ensuring better accuracy in issue synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->