### PR TITLE
t5216: delegate pulse-wrapper open-PR dedup to dispatch-dedup-helper

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -24,6 +24,11 @@
 #     Check if any running worker already covers the same issue/PR/task.
 #     Exit 0 = duplicate found (do NOT dispatch), exit 1 = no duplicate (safe to dispatch).
 #
+#   dispatch-dedup-helper.sh has-open-pr <issue> <slug> [issue-title]
+#     Check whether an issue already has merged PR evidence (closing keyword or
+#     task-id fallback) and should be skipped by pulse dispatch.
+#     Exit 0 = PR evidence exists (do NOT dispatch), exit 1 = no evidence.
+#
 #   dispatch-dedup-helper.sh list-running-keys
 #     List dedup keys for all currently running workers.
 #
@@ -345,95 +350,67 @@ is_assigned() {
 }
 
 #######################################
-# Private helper: run a single open-PR GitHub query.
+# Check whether an issue already has merged PR evidence.
 #
-# Executes one `gh pr list` search and outputs the first matching PR
-# number on stdout. Centralises the query → parse → validate pattern
-# used by all three strategies in has_open_pr().
-#
-# Args:
-#   $1 = repo slug (owner/repo)
-#   $2 = search query string (passed to --search)
-# Returns:
-#   exit 0 and prints PR number if a match is found
-#   exit 1 if no match or gh/jq error
-#######################################
-_query_open_prs() {
-	local repo_slug="$1"
-	local search_query="$2"
-
-	local pr_json pr_count pr_num
-	pr_json=$(gh pr list --repo "$repo_slug" --state open \
-		--search "$search_query" \
-		--json number --limit 1 2>/dev/null) || pr_json="[]"
-	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-	if [[ "$pr_count" -gt 0 ]]; then
-		pr_num=$(printf '%s' "$pr_json" | jq -r '.[0].number' 2>/dev/null) || pr_num="?"
-		printf '%s' "$pr_num"
-		return 0
-	fi
-
-	return 1
-}
-
-#######################################
-# Check if an issue already has an open PR on GitHub (GH#5210)
-#
-# Queries GitHub for open PRs whose title contains the issue number
-# (as "#NNN") or a task ID extracted from the issue title. This is
-# a deterministic check — "does an open PR exist?" has exactly one
-# correct answer regardless of context.
+# Historical note: command name is `has-open-pr` to match pulse-wrapper
+# dispatch dedup call sites from review feedback, but the underlying behavior
+# checks merged PR evidence to avoid redispatching already-completed issues.
 #
 # Args:
 #   $1 = issue number
 #   $2 = repo slug (owner/repo)
-#   $3 = (optional) issue title — used for task-id extraction
+#   $3 = issue title (optional; used for task-id fallback)
 # Returns:
-#   exit 0 if open PR found (do NOT dispatch)
-#   exit 1 if no open PR found (safe to dispatch)
-# Outputs: PR info on stdout if found
+#   exit 0 if merged PR evidence exists (do NOT dispatch)
+#   exit 1 if no merged PR evidence (safe to dispatch)
+# Outputs:
+#   single-line reason when evidence is found
 #######################################
 has_open_pr() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local issue_title="${3:-}"
 
-	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
 		return 1
 	fi
 
-	if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
-		return 1
-	fi
-
-	local pr_num
-
-	# Strategy 1: Search for open PRs with issue number in title
-	if pr_num=$(_query_open_prs "$repo_slug" "#${issue_number} in:title"); then
-		printf 'OPEN_PR: issue #%s in %s has open PR #%s (title match)\n' "$issue_number" "$repo_slug" "$pr_num"
-		return 0
-	fi
-
-	# Strategy 2: Search by task ID from issue title
-	local task_id
-	task_id=$(printf '%s' "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
-	if [[ -n "$task_id" ]]; then
-		if pr_num=$(_query_open_prs "$repo_slug" "${task_id} in:title"); then
-			printf 'OPEN_PR: task %s in %s has open PR #%s (task-id match)\n' "$task_id" "$repo_slug" "$pr_num"
-			return 0
-		fi
-	fi
-
-	# Strategy 3: Search by "Closes/Fixes/Resolves #NNN" in PR body
-	local keyword
-	for keyword in closes fixes resolves; do
-		if pr_num=$(_query_open_prs "$repo_slug" "${keyword} #${issue_number} in:body"); then
-			printf 'OPEN_PR: issue #%s in %s has open PR #%s (body "%s" match)\n' "$issue_number" "$repo_slug" "$pr_num" "$keyword"
+	local query pr_json pr_count pr_number
+	for keyword in close closes closed fix fixes fixed resolve resolves resolved; do
+		query="${keyword} #${issue_number} in:body"
+		pr_json=$(gh pr list --repo "$repo_slug" --state merged --search "$query" --limit 1 --json number 2>/dev/null) || pr_json="[]"
+		pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+		if [[ "$pr_count" -gt 0 ]]; then
+			pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
+			if [[ -n "$pr_number" ]]; then
+				printf 'merged PR #%s references issue #%s via "%s" keyword\n' "$pr_number" "$issue_number" "$keyword"
+			else
+				printf 'merged PR references issue #%s via "%s" keyword\n' "$issue_number" "$keyword"
+			fi
 			return 0
 		fi
 	done
 
+	local task_id
+	task_id=$(printf '%s' "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || true)
+	if [[ -z "$task_id" ]]; then
+		return 1
+	fi
+
+	query="${task_id} in:title"
+	pr_json=$(gh pr list --repo "$repo_slug" --state merged --search "$query" --limit 1 --json number 2>/dev/null) || pr_json="[]"
+	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+	if [[ "$pr_count" -gt 0 ]]; then
+		pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
+		if [[ -n "$pr_number" ]]; then
+			printf 'merged PR #%s found by task id %s in title\n' "$pr_number" "$task_id"
+		else
+			printf 'merged PR found by task id %s in title\n' "$task_id"
+		fi
+		return 0
+	fi
 	return 1
 }
 
@@ -447,10 +424,10 @@ dispatch-dedup-helper.sh - Normalize and deduplicate worker dispatch titles (t23
 Usage:
   dispatch-dedup-helper.sh extract-keys <title>    Extract dedup keys from a title
   dispatch-dedup-helper.sh is-duplicate <title>     Check if already running (exit 0=dup, 1=safe)
+  dispatch-dedup-helper.sh has-open-pr <issue> <slug> [issue-title]
+                                                    Check merged PR evidence (exit 0=evidence, 1=none)
   dispatch-dedup-helper.sh is-assigned <issue> <slug> [self-login]
                                                     Check if issue is assigned (exit 0=assigned, 1=free)
-  dispatch-dedup-helper.sh has-open-pr <issue> <slug> [issue-title]
-                                                    Check if open PR exists (exit 0=found, 1=none)
   dispatch-dedup-helper.sh list-running-keys        List keys for all running workers
   dispatch-dedup-helper.sh normalize <title>        Normalize a title for comparison
   dispatch-dedup-helper.sh help                     Show this help
@@ -475,11 +452,11 @@ Examples:
     echo "Unassigned or assigned to self — safe to dispatch"
   fi
 
-  # Check before dispatching (open PR dedup — GH#5210)
-  if dispatch-dedup-helper.sh has-open-pr 2300 owner/repo "t1337: Fix auth"; then
-    echo "Open PR exists — skip dispatch"
+  # Check before dispatching (merged PR dedup)
+  if dispatch-dedup-helper.sh has-open-pr 2300 owner/repo "t2300: Fix auth"; then
+    echo "Issue already has merged PR evidence — skip dispatch"
   else
-    echo "No open PR — safe to dispatch"
+    echo "No merged PR evidence — safe to dispatch"
   fi
 HELP
 	return 0

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -2409,101 +2409,12 @@ has_worker_for_repo_issue() {
 }
 
 #######################################
-# Check if an issue already has merged-PR evidence
-#
-# Guards against re-dispatching work that is already completed via an
-# earlier merged PR (including duplicate issue patterns where a second
-# issue exists for the same task ID).
-#
-# Arguments:
-#   $1 - issue number
-#   $2 - repo slug (owner/repo)
-#   $3 - issue title (optional; used for task-id fallback)
-# Exit codes:
-#   0 - merged PR evidence found (skip dispatch)
-#   1 - no merged PR evidence
-#######################################
-has_merged_pr_for_issue() {
-	local issue_number="$1"
-	local repo_slug="$2"
-	local issue_title="${3:-}"
-
-	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
-		return 1
-	fi
-
-	local query pr_json pr_count
-	for keyword in close closes closed fix fixes fixed resolve resolves resolved; do
-		query="${keyword} #${issue_number} in:body"
-		pr_json=$(gh pr list --repo "$repo_slug" --state merged --search "$query" --limit 1 --json number 2>/dev/null) || pr_json="[]"
-		pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-		if [[ "$pr_count" -gt 0 ]]; then
-			return 0
-		fi
-	done
-
-	local task_id
-	task_id=$(echo "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || echo "")
-	if [[ -z "$task_id" ]]; then
-		return 1
-	fi
-
-	query="${task_id} in:title"
-	pr_json=$(gh pr list --repo "$repo_slug" --state merged --search "$query" --limit 1 --json number 2>/dev/null) || pr_json="[]"
-	pr_count=$(echo "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-	if [[ "$pr_count" -gt 0 ]]; then
-		return 0
-	fi
-
-	return 1
-}
-
-#######################################
-# Check if an issue already has an open PR (GH#5210)
-#
-# Delegates to dispatch-dedup-helper.sh has-open-pr, which owns the
-# three-strategy search logic (title match, task-id match, body keyword
-# match). Keeping the logic in one place prevents drift between the two
-# implementations.
-#
-# Arguments:
-#   $1 - issue number
-#   $2 - repo slug (owner/repo)
-#   $3 - issue title (optional; used for task-id extraction)
-# Exit codes:
-#   0 - open PR found (skip dispatch)
-#   1 - no open PR found or helper unavailable
-#######################################
-has_open_pr_for_issue() {
-	local issue_number="$1"
-	local repo_slug="$2"
-	local issue_title="${3:-}"
-
-	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
-	if [[ ! -x "$dedup_helper" ]]; then
-		echo "[pulse-wrapper] Dedup: dispatch-dedup-helper.sh not found or not executable — skipping open PR check" >>"$LOGFILE"
-		return 1
-	fi
-
-	local output
-	if output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>/dev/null); then
-		echo "[pulse-wrapper] Dedup: ${output}" >>"$LOGFILE"
-		return 0
-	fi
-
-	return 1
-}
-
-#######################################
 # Check if dispatching a worker would be a duplicate (GH#4400, GH#5210)
 #
 # Four-layer dedup:
 #   1. has_worker_for_repo_issue() — exact repo+issue process match
 #   2. dispatch-dedup-helper.sh is-duplicate — normalized title key match
-#   3. has_open_pr_for_issue() — open PR on GitHub for this issue/task (GH#5210)
-#   4. has_merged_pr_for_issue() — skip issues already completed by merged PR
+#   3. dispatch-dedup-helper.sh has-open-pr — merged PR evidence for issue/task
 #
 # Arguments:
 #   $1 - issue number
@@ -2535,22 +2446,17 @@ check_dispatch_dedup() {
 		fi
 	fi
 
-	# Layer 3: open PR on GitHub for this issue/task (GH#5210)
-	# This catches the case where a worker created a PR but the process
-	# has exited (or runs on another machine). The open PR is visible on
-	# GitHub even when no local process exists.
+	# Layer 3: merged PR evidence for this issue/task
+	local dedup_helper_output=""
 	if [[ -x "$dedup_helper" ]]; then
-		local open_pr_output
-		if open_pr_output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>/dev/null); then
-			echo "[pulse-wrapper] Dedup: ${open_pr_output}" >>"$LOGFILE"
+		if dedup_helper_output=$("$dedup_helper" has-open-pr "$issue_number" "$repo_slug" "$issue_title" 2>>"$LOGFILE"); then
+			if [[ -n "$dedup_helper_output" ]]; then
+				echo "[pulse-wrapper] Dedup: ${dedup_helper_output}" >>"$LOGFILE"
+			else
+				echo "[pulse-wrapper] Dedup: merged PR evidence already exists for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
+			fi
 			return 0
 		fi
-	fi
-
-	# Layer 4: merged PR evidence for this issue/task
-	if has_merged_pr_for_issue "$issue_number" "$repo_slug" "$issue_title"; then
-		echo "[pulse-wrapper] Dedup: merged PR already exists for #${issue_number} in ${repo_slug}" >>"$LOGFILE"
-		return 0
 	fi
 
 	return 1

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SCRIPT="${SCRIPT_DIR}/../dispatch-dedup-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+TEST_ROOT=""
+GH_FIXTURE_FILE=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	GH_FIXTURE_FILE="${TEST_ROOT}/gh-pr-list-fixtures.txt"
+
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export GH_FIXTURE_FILE
+
+	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+	local_repo=""
+	local_state=""
+	local_search=""
+	shift 2
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo)
+			local_repo="${2:-}"
+			shift 2
+			;;
+		--state)
+			local_state="${2:-}"
+			shift 2
+			;;
+		--search)
+			local_search="${2:-}"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$local_repo" || -z "$local_state" || -z "$local_search" ]]; then
+		printf '[]\n'
+		exit 0
+	fi
+
+	compound_key="${local_repo}|${local_state}|${local_search}"
+	while IFS= read -r line; do
+		[[ -n "$line" ]] || continue
+		fixture_key="${line%|*}"
+		fixture_payload="${line##*|}"
+		if [[ "$fixture_key" == "$compound_key" ]]; then
+			printf '%s\n' "$fixture_payload"
+			exit 0
+		fi
+	done <"${GH_FIXTURE_FILE}"
+
+	printf '[]\n'
+	exit 0
+fi
+
+printf 'unsupported gh invocation in test stub\n' >&2
+exit 1
+EOF
+
+	chmod +x "${TEST_ROOT}/bin/gh"
+	printf '' >"${GH_FIXTURE_FILE}"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+set_gh_fixtures() {
+	local fixtures="$1"
+	printf '%s\n' "$fixtures" >"${GH_FIXTURE_FILE}"
+	return 0
+}
+
+test_has_open_pr_detects_closing_keyword() {
+	set_gh_fixtures 'marcusquinn/aidevops|merged|closes #4527 in:body|[{"number":1145}]'
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" has-open-pr 4527 marcusquinn/aidevops 't4527: prevent duplicate dispatch'); then
+		case "$output" in
+		*'merged PR #1145 references issue #4527 via "closes" keyword'*)
+			print_result "has-open-pr detects merged PR via closing keyword" 0
+			return 0
+			;;
+		esac
+		print_result "has-open-pr detects merged PR via closing keyword" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "has-open-pr detects merged PR via closing keyword" 1 "Expected merged PR evidence for issue #4527"
+	return 0
+}
+
+test_has_open_pr_detects_task_id_fallback() {
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t063.1 in:title|[{"number":1059}]'
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" has-open-pr 9999 marcusquinn/aidevops 't063.1: fix awardsapp duplicate PR dispatch'); then
+		case "$output" in
+		*'merged PR #1059 found by task id t063.1 in title'*)
+			print_result "has-open-pr detects merged PR via task-id fallback" 0
+			return 0
+			;;
+		esac
+		print_result "has-open-pr detects merged PR via task-id fallback" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "has-open-pr detects merged PR via task-id fallback" 1 "Expected merged PR evidence via task-id fallback"
+	return 0
+}
+
+test_has_open_pr_returns_nonzero_without_match() {
+	set_gh_fixtures ''
+
+	if "$HELPER_SCRIPT" has-open-pr 7777 marcusquinn/aidevops 't7777: no merged pr yet'; then
+		print_result "has-open-pr returns nonzero when no evidence exists" 1 "Expected nonzero exit when no merged PR evidence exists"
+		return 0
+	fi
+
+	print_result "has-open-pr returns nonzero when no evidence exists" 0
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	test_has_open_pr_detects_closing_keyword
+	test_has_open_pr_detects_task_id_fallback
+	test_has_open_pr_returns_nonzero_without_match
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -14,7 +14,6 @@ TESTS_FAILED=0
 
 TEST_ROOT=""
 PS_FIXTURE_FILE=""
-GH_SEARCH_FIXTURES=""
 
 print_result() {
 	local test_name="$1"
@@ -78,66 +77,38 @@ ps() {
 	return 0
 }
 
-set_gh_search_fixtures() {
-	local fixtures="$1"
-	GH_SEARCH_FIXTURES="$fixtures"
-	export GH_SEARCH_FIXTURES
-	return 0
-}
+set_dedup_helper_fixture() {
+	local has_open_pr_exit="$1"
+	local has_open_pr_output="${2:-}"
 
-gh() {
-	if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
-		local repo_slug="" state_filter="" search_query=""
-		shift 2
-		while [[ $# -gt 0 ]]; do
-			case "$1" in
-			--repo)
-				repo_slug="${2:-}"
-				shift 2
-				;;
-			--state)
-				state_filter="${2:-}"
-				shift 2
-				;;
-			--search)
-				search_query="${2:-}"
-				shift 2
-				;;
-			*)
-				shift
-				;;
-			esac
-		done
+	cat >"${TEST_ROOT}/dispatch-dedup-helper.sh" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
 
-		# Fail loudly if the function under test omits --repo, --state, or --search
-		if [[ -z "$repo_slug" || -z "$state_filter" || -z "$search_query" ]]; then
-			printf 'unexpected gh pr list args in test stub: repo=%s state=%s search=%s\n' \
-				"$repo_slug" "$state_filter" "$search_query" >&2
-			return 1
+command_name="\${1:-}"
+
+case "\$command_name" in
+is-duplicate)
+	exit 1
+	;;
+has-open-pr)
+	if [[ "${has_open_pr_exit}" -eq 0 ]]; then
+		if [[ -n "${has_open_pr_output}" ]]; then
+			printf '%s\n' "${has_open_pr_output}"
 		fi
-
-		local compound_key="${repo_slug}|${state_filter}|${search_query}"
-		local line fixture_key fixture_payload
-		while IFS= read -r line; do
-			[[ -n "$line" ]] || continue
-			# Fixture format: repo|state|query|payload
-			# Strip last field to get the compound key; last field is the payload
-			fixture_key="${line%|*}"
-			fixture_payload="${line##*|}"
-			if [[ "$fixture_key" == "$compound_key" ]]; then
-				printf '%s\n' "$fixture_payload"
-				return 0
-			fi
-		done <<<"$GH_SEARCH_FIXTURES"
-
-		printf '[]\n'
-		return 0
+		exit 0
 	fi
+	exit 1
+	;;
+*)
+	exit 1
+	;;
+esac
+EOF
 
-	command gh "$@"
+	chmod +x "${TEST_ROOT}/dispatch-dedup-helper.sh"
 	return 0
 }
-export -f gh
 
 test_counts_plain_and_dot_prefixed_opencode_workers() {
 	# Line 125: supervisor /pulse — excluded by standalone /pulse filter
@@ -252,117 +223,21 @@ JSON
 	return 0
 }
 
-test_has_merged_pr_for_issue_detects_closing_keyword() {
-	set_gh_search_fixtures "marcusquinn/aidevops|merged|closes #4527 in:body|[{\"number\":1145}]"
-
-	if has_merged_pr_for_issue "4527" "marcusquinn/aidevops" "t4527: prevent duplicate dispatch"; then
-		print_result "has_merged_pr_for_issue detects merged PR via closes keyword" 0
-		return 0
-	fi
-
-	print_result "has_merged_pr_for_issue detects merged PR via closes keyword" 1 "Expected merged PR match for issue #4527"
-	return 0
-}
-
-test_has_merged_pr_for_issue_detects_task_id_fallback() {
-	set_gh_search_fixtures "marcusquinn/aidevops|merged|t063.1 in:title|[{\"number\":1059}]"
-
-	if has_merged_pr_for_issue "9999" "marcusquinn/aidevops" "t063.1: fix awardsapp duplicate PR dispatch"; then
-		print_result "has_merged_pr_for_issue detects merged PR via task-id fallback" 0
-		return 0
-	fi
-
-	print_result "has_merged_pr_for_issue detects merged PR via task-id fallback" 1 "Expected merged PR match via task ID fallback"
-	return 0
-}
-
 test_check_dispatch_dedup_treats_merged_pr_as_duplicate() {
+	local original_script_dir="$SCRIPT_DIR"
+	SCRIPT_DIR="$TEST_ROOT"
+
 	set_ps_fixture ""
-	set_gh_search_fixtures "marcusquinn/aidevops|merged|closes #4527 in:body|[{\"number\":1145}]"
+	set_dedup_helper_fixture 0 'merged PR #1145 references issue #4527 via "closes" keyword'
 
 	if check_dispatch_dedup "4527" "marcusquinn/aidevops" "Issue #4527: prevent redispatch" "t4527: prevent redispatch"; then
+		SCRIPT_DIR="$original_script_dir"
 		print_result "check_dispatch_dedup skips dispatch when merged PR exists" 0
 		return 0
 	fi
 
+	SCRIPT_DIR="$original_script_dir"
 	print_result "check_dispatch_dedup skips dispatch when merged PR exists" 1 "Expected dedup check to block merged issue"
-	return 0
-}
-
-test_has_open_pr_for_issue_detects_title_match() {
-	set_gh_search_fixtures "marcusquinn/aidevops|open|#5210 in:title|[{\"number\":1200}]"
-
-	if has_open_pr_for_issue "5210" "marcusquinn/aidevops" "t5210: Fix dispatch dedup"; then
-		print_result "has_open_pr_for_issue detects open PR via issue number in title" 0
-		return 0
-	fi
-
-	print_result "has_open_pr_for_issue detects open PR via issue number in title" 1 "Expected open PR match for issue #5210"
-	return 0
-}
-
-test_has_open_pr_for_issue_detects_task_id_match() {
-	# No match on issue number, but task ID matches
-	set_gh_search_fixtures "marcusquinn/aidevops|open|t1337 in:title|[{\"number\":1201}]"
-
-	if has_open_pr_for_issue "9999" "marcusquinn/aidevops" "t1337: Simplify infra scripts"; then
-		print_result "has_open_pr_for_issue detects open PR via task-id fallback" 0
-		return 0
-	fi
-
-	print_result "has_open_pr_for_issue detects open PR via task-id fallback" 1 "Expected open PR match via task ID"
-	return 0
-}
-
-test_has_open_pr_for_issue_detects_body_closes_match() {
-	# No match on title or task ID, but "closes #NNN" in body matches
-	set_gh_search_fixtures "marcusquinn/aidevops|open|closes #4500 in:body|[{\"number\":1202}]"
-
-	if has_open_pr_for_issue "4500" "marcusquinn/aidevops" ""; then
-		print_result "has_open_pr_for_issue detects open PR via body closes keyword" 0
-		return 0
-	fi
-
-	print_result "has_open_pr_for_issue detects open PR via body closes keyword" 1 "Expected open PR match via body closes"
-	return 0
-}
-
-test_has_open_pr_for_issue_returns_false_when_no_pr() {
-	# No fixtures set — all searches return []
-	set_gh_search_fixtures ""
-
-	if has_open_pr_for_issue "8888" "marcusquinn/aidevops" "t8888: nonexistent task"; then
-		print_result "has_open_pr_for_issue returns false when no open PR exists" 1 "Expected no match but got one"
-		return 0
-	fi
-
-	print_result "has_open_pr_for_issue returns false when no open PR exists" 0
-	return 0
-}
-
-test_check_dispatch_dedup_blocks_on_open_pr() {
-	set_ps_fixture ""
-	set_gh_search_fixtures "marcusquinn/aidevops|open|#5210 in:title|[{\"number\":1200}]"
-
-	if check_dispatch_dedup "5210" "marcusquinn/aidevops" "Issue #5210: Fix dispatch" "t5210: Fix dispatch"; then
-		print_result "check_dispatch_dedup blocks dispatch when open PR exists (GH#5210)" 0
-		return 0
-	fi
-
-	print_result "check_dispatch_dedup blocks dispatch when open PR exists (GH#5210)" 1 "Expected dedup to block on open PR"
-	return 0
-}
-
-test_check_dispatch_dedup_allows_when_no_pr_or_worker() {
-	set_ps_fixture ""
-	set_gh_search_fixtures ""
-
-	if check_dispatch_dedup "7777" "marcusquinn/aidevops" "Issue #7777: New task" "t7777: New task"; then
-		print_result "check_dispatch_dedup allows dispatch when no PR or worker exists" 1 "Expected dispatch to be allowed"
-		return 0
-	fi
-
-	print_result "check_dispatch_dedup allows dispatch when no PR or worker exists" 0
 	return 0
 }
 
@@ -376,15 +251,7 @@ main() {
 	test_deduplicates_process_chain_to_one_logical_worker
 	test_deduplicates_multiple_workers_with_process_chains
 	test_repo_issue_detection_uses_filtered_worker_list
-	test_has_merged_pr_for_issue_detects_closing_keyword
-	test_has_merged_pr_for_issue_detects_task_id_fallback
 	test_check_dispatch_dedup_treats_merged_pr_as_duplicate
-	test_has_open_pr_for_issue_detects_title_match
-	test_has_open_pr_for_issue_detects_task_id_match
-	test_has_open_pr_for_issue_detects_body_closes_match
-	test_has_open_pr_for_issue_returns_false_when_no_pr
-	test_check_dispatch_dedup_blocks_on_open_pr
-	test_check_dispatch_dedup_allows_when_no_pr_or_worker
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary
- Remove duplicate merged-PR evidence logic from `pulse-wrapper.sh` and delegate layer-3 dedup checks to `dispatch-dedup-helper.sh has-open-pr`.
- Add a new `has-open-pr` command in `dispatch-dedup-helper.sh` that centralizes merged-PR detection (closing keyword and task-id fallback) and returns a reason string for pulse logging.
- Update pulse-wrapper worker-detection tests for helper delegation and add dedicated helper tests for `has-open-pr` behavior.

## Verification
- `shellcheck .agents/scripts/dispatch-dedup-helper.sh`
- `shellcheck .agents/scripts/pulse-wrapper.sh`
- `shellcheck .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`
- `shellcheck .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh`
- `bash .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh`
- `bash .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh`

Closes #5216