### PR TITLE
t5222: audit wiki docs and fix .agents directory references

### DIFF
--- a/.wiki/For-Humans.md
+++ b/.wiki/For-Humans.md
@@ -22,7 +22,7 @@ A non-technical guide to understanding and using the AI DevOps Framework.
 You: "Help me deploy my site to Hostinger"
 
 AI: *reads AGENTS.md*
-    *reads .agent/hostinger.md*
+    *reads .agents/hostinger.md*
     *uses hostinger-helper.sh*
     
 AI: "I'll help you deploy. First, let me verify your account..."
@@ -127,7 +127,7 @@ The framework handles security automatically:
 | File | What It Does |
 |------|--------------|
 | `AGENTS.md` | Main instructions for AI assistants |
-| `.agent/` folder | All documentation and scripts |
+| `.agents/` folder | All documentation and scripts |
 | `~/.aidevops/.agent-workspace/` folder | Your personal working directory |
 
 ## FAQ

--- a/.wiki/Getting-Started.md
+++ b/.wiki/Getting-Started.md
@@ -105,13 +105,13 @@ For services requiring authentication:
 
 ```bash
 # Use the secure key management script
-bash .agent/scripts/setup-local-api-keys.sh
+bash .agents/scripts/setup-local-api-keys.sh
 
 # Example: Add a service key
-bash .agent/scripts/setup-local-api-keys.sh set codacy-api-key YOUR_KEY
+bash .agents/scripts/setup-local-api-keys.sh set codacy-api-key YOUR_KEY
 
 # List configured services
-bash .agent/scripts/setup-local-api-keys.sh list
+bash .agents/scripts/setup-local-api-keys.sh list
 ```
 
 **Keys are stored securely in:** `~/.config/aidevops/mcp-env.sh`
@@ -123,7 +123,7 @@ bash .agent/scripts/setup-local-api-keys.sh list
 ├── AGENTS.md                # AI assistant instructions
 ├── aidevops.sh              # CLI source script
 ├── setup.sh                 # Installer/updater
-├── .agent/                  # All AI-relevant content
+├── .agents/                  # All AI-relevant content
 │   ├── scripts/             # 90+ automation scripts
 │   ├── workflows/           # Development process guides
 │   ├── memory/              # Context persistence templates
@@ -144,10 +144,10 @@ bash .agent/scripts/setup-local-api-keys.sh list
 ### Ask Your AI to Help With:
 
 1. **"Show me what services are available"**
-   - AI reads `.agent/` documentation
+   - AI reads `.agents/` documentation
 
 2. **"Help me set up Hostinger hosting"**
-   - AI uses `.agent/hostinger.md` and scripts
+   - AI uses `.agents/hostinger.md` and scripts
 
 3. **"Check code quality for this project"**
    - AI uses quality CLI helpers
@@ -161,7 +161,7 @@ bash .agent/scripts/setup-local-api-keys.sh list
 >
 > **AI:** I'll help you deploy WordPress on Hostinger. Let me check the framework documentation...
 >
-> *AI reads `.agent/hostinger.md` and uses `hostinger-helper.sh`*
+> *AI reads `.agents/hostinger.md` and uses `hostinger-helper.sh`*
 >
 > **AI:** I found the Hostinger helper. First, let's verify your account is configured...
 
@@ -186,7 +186,7 @@ The framework creates organized working directories:
 
 1. **[CLI Reference](CLI-Reference)** - Master the `aidevops` command
 2. **[Understanding AGENTS.md](Understanding-AGENTS-md)** - Learn how AI guidance works
-3. **[The .agent Directory](The-Agent-Directory)** - Explore the framework structure
+3. **[The .agents Directory](The-Agent-Directory)** - Explore the framework structure
 4. **[Workflows Guide](Workflows-Guide)** - Development processes
 
 ## Troubleshooting
@@ -210,7 +210,7 @@ ls ~/Git/aidevops/AGENTS.md
 ### Scripts Not Executable
 
 ```bash
-chmod +x ~/Git/aidevops/.agent/scripts/*.sh
+chmod +x ~/Git/aidevops/.agents/scripts/*.sh
 ```
 
 ### API Keys Not Working

--- a/.wiki/Home.md
+++ b/.wiki/Home.md
@@ -57,9 +57,9 @@ Your AI assistant now has access to:
 | Concept | Description |
 |---------|-------------|
 | **AGENTS.md** | The authoritative instruction file for AI assistants |
-| **`.agent/`** | All AI-relevant content lives here |
-| **Workflows** | Step-by-step guides in `.agent/workflows/` |
-| **Scripts** | Automation helpers in `.agent/scripts/` |
+| **`.agents/`** | All AI-relevant content lives here |
+| **Workflows** | Step-by-step guides in `.agents/workflows/` |
+| **Scripts** | Automation helpers in `.agents/scripts/` |
 | **MCP Servers** | Real-time integrations for AI assistants |
 
 ## Navigation
@@ -67,7 +67,7 @@ Your AI assistant now has access to:
 - **[Getting Started](Getting-Started)** - Installation and setup
 - **[CLI Reference](CLI-Reference)** - The `aidevops` command
 - **[Understanding AGENTS.md](Understanding-AGENTS-md)** - How AI guidance works
-- **[The .agent Directory](The-Agent-Directory)** - Framework structure
+- **[The .agents Directory](The-Agent-Directory)** - Framework structure
 - **[Workflows Guide](Workflows-Guide)** - Development processes
 - **[For Humans](For-Humans)** - Non-technical overview
 

--- a/.wiki/MCP-Integrations.md
+++ b/.wiki/MCP-Integrations.md
@@ -229,7 +229,7 @@ Website performance auditing and optimization.
 **Installation**:
 
 ```bash
-bash .agent/scripts/setup-mcp-integrations.sh pagespeed
+bash .agents/scripts/setup-mcp-integrations.sh pagespeed
 ```
 
 **Use Cases**:
@@ -294,7 +294,7 @@ Real-time documentation access for thousands of libraries.
 **Installation**:
 
 ```bash
-bash .agent/scripts/setup-mcp-integrations.sh context7
+bash .agents/scripts/setup-mcp-integrations.sh context7
 ```
 
 **Supported Libraries**: React, Vue, Angular, Node.js, Python, and 1000+ more
@@ -316,7 +316,7 @@ Direct WordPress database access for local development.
 **Installation**:
 
 ```bash
-bash .agent/scripts/setup-mcp-integrations.sh localwp
+bash .agents/scripts/setup-mcp-integrations.sh localwp
 ```
 
 **Requirements**: Local by Flywheel or similar WordPress environment
@@ -337,29 +337,29 @@ bash .agent/scripts/setup-mcp-integrations.sh localwp
 
 ```bash
 # Run comprehensive setup
-bash .agent/scripts/setup-mcp-integrations.sh all
+bash .agents/scripts/setup-mcp-integrations.sh all
 
 # Validate installation
-bash .agent/scripts/validate-mcp-integrations.sh
+bash .agents/scripts/validate-mcp-integrations.sh
 ```
 
 ### Install Specific Server
 
 ```bash
 # Chrome DevTools
-bash .agent/scripts/setup-mcp-integrations.sh chrome-devtools
+bash .agents/scripts/setup-mcp-integrations.sh chrome-devtools
 
 # Playwright
-bash .agent/scripts/setup-mcp-integrations.sh playwright
+bash .agents/scripts/setup-mcp-integrations.sh playwright
 
 # Ahrefs
-bash .agent/scripts/setup-mcp-integrations.sh ahrefs
+bash .agents/scripts/setup-mcp-integrations.sh ahrefs
 
 # Claude Code MCP (fork)
-bash .agent/scripts/setup-mcp-integrations.sh claude-code-mcp
+bash .agents/scripts/setup-mcp-integrations.sh claude-code-mcp
 
 # Context7
-bash .agent/scripts/setup-mcp-integrations.sh context7
+bash .agents/scripts/setup-mcp-integrations.sh context7
 ```
 
 ## Configuration
@@ -377,19 +377,19 @@ Store API keys securely using the helper script:
 
 ```bash
 # Initialize (creates mcp-env.sh, adds shell integration)
-bash ~/git/aidevops/.agent/scripts/setup-local-api-keys.sh setup
+bash ~/git/aidevops/.agents/scripts/setup-local-api-keys.sh setup
 
 # Add keys using service names (converted to UPPER_CASE)
-bash .agent/scripts/setup-local-api-keys.sh set ahrefs-api-key your_key
-bash .agent/scripts/setup-local-api-keys.sh set perplexity-api-key your_key
-bash .agent/scripts/setup-local-api-keys.sh set cloudflare-account-id your_id
-bash .agent/scripts/setup-local-api-keys.sh set cloudflare-api-token your_token
+bash .agents/scripts/setup-local-api-keys.sh set ahrefs-api-key your_key
+bash .agents/scripts/setup-local-api-keys.sh set perplexity-api-key your_key
+bash .agents/scripts/setup-local-api-keys.sh set cloudflare-account-id your_id
+bash .agents/scripts/setup-local-api-keys.sh set cloudflare-api-token your_token
 
 # Or paste export commands from services directly
-bash .agent/scripts/setup-local-api-keys.sh add 'export VERCEL_TOKEN="xxx"'
+bash .agents/scripts/setup-local-api-keys.sh add 'export VERCEL_TOKEN="xxx"'
 
 # List configured keys
-bash .agent/scripts/setup-local-api-keys.sh list
+bash .agents/scripts/setup-local-api-keys.sh list
 ```
 
 ### Environment Variables
@@ -454,7 +454,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 # AI: "Test login flow across Chrome, Firefox, and Safari"
 
 # 3. Audit with PageSpeed
-./.agent/scripts/pagespeed-helper.sh lighthouse https://example.com
+./.agents/scripts/pagespeed-helper.sh lighthouse https://example.com
 
 # 4. Look up Next.js best practices
 # AI: "Show me Next.js SSR optimization techniques"
@@ -480,7 +480,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```bash
 # 1. Create local site
-./.agent/scripts/localhost-helper.sh create-site mysite.local
+./.agents/scripts/localhost-helper.sh create-site mysite.local
 
 # 2. Query database via MCP
 # AI: "Show all published posts from last week"
@@ -489,7 +489,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 # AI: "Find Context7 documentation for wp_enqueue_scripts"
 
 # 4. Test performance
-./.agent/scripts/pagespeed-helper.sh wordpress https://mysite.local
+./.agents/scripts/pagespeed-helper.sh wordpress https://mysite.local
 ```
 
 ## Real-World Use Cases
@@ -584,7 +584,7 @@ AI: "How do I optimize this Next.js page?"
 ### Check Installation Status
 
 ```bash
-bash .agent/scripts/validate-mcp-integrations.sh
+bash .agents/scripts/validate-mcp-integrations.sh
 ```
 
 **Expected Output**:
@@ -776,10 +776,10 @@ export PLAYWRIGHT_BROWSERS_PATH=/custom/path
 
 ### Internal Documentation
 
-- [MCP Integration Setup Script](../.agent/scripts/setup-mcp-integrations.sh)
-- [MCP Validation Script](../.agent/scripts/validate-mcp-integrations.sh)
-- [API Integrations Guide](../.agent/api-integrations.md)
-- [Browser Automation Guide](../.agent/browser-automation.md)
+- [MCP Integration Setup Script](../.agents/scripts/setup-mcp-integrations.sh)
+- [MCP Validation Script](../.agents/scripts/validate-mcp-integrations.sh)
+- [API Integrations Guide](../.agents/api-integrations.md)
+- [Browser Automation Guide](../.agents/browser-automation.md)
 
 ---
 

--- a/.wiki/Providers.md
+++ b/.wiki/Providers.md
@@ -11,7 +11,7 @@ Provider scripts provide standardized interfaces to interact with different serv
 All provider scripts follow this pattern:
 
 ```bash
-./.agent/scripts/[provider]-helper.sh [command] [arguments...]
+./.agents/scripts/[provider]-helper.sh [command] [arguments...]
 ```
 
 Common commands across providers:
@@ -26,7 +26,7 @@ Common commands across providers:
 
 ### Hostinger
 
-**File**: `.agent/scripts/hostinger-helper.sh`
+**File**: `.agents/scripts/hostinger-helper.sh`
 
 Manage Hostinger shared hosting, domains, and email services.
 
@@ -34,16 +34,16 @@ Manage Hostinger shared hosting, domains, and email services.
 
 ```bash
 # List all configured servers
-./.agent/scripts/hostinger-helper.sh list
+./.agents/scripts/hostinger-helper.sh list
 
 # Connect to server via SSH
-./.agent/scripts/hostinger-helper.sh connect example.com
+./.agents/scripts/hostinger-helper.sh connect example.com
 
 # Execute remote command
-./.agent/scripts/hostinger-helper.sh exec example.com "uptime"
+./.agents/scripts/hostinger-helper.sh exec example.com "uptime"
 
 # Show configuration
-./.agent/scripts/hostinger-helper.sh info
+./.agents/scripts/hostinger-helper.sh info
 ```
 
 **Configuration**: `configs/hostinger-config.json`
@@ -59,7 +59,7 @@ Manage Hostinger shared hosting, domains, and email services.
 
 ### Hetzner Cloud
 
-**File**: `.agent/scripts/hetzner-helper.sh`
+**File**: `.agents/scripts/hetzner-helper.sh`
 
 Manage Hetzner VPS servers, networking, and load balancers.
 
@@ -67,22 +67,22 @@ Manage Hetzner VPS servers, networking, and load balancers.
 
 ```bash
 # List servers in project
-./.agent/scripts/hetzner-helper.sh list [project-name]
+./.agents/scripts/hetzner-helper.sh list [project-name]
 
 # Connect to server
-./.agent/scripts/hetzner-helper.sh connect [project-name] [server-name]
+./.agents/scripts/hetzner-helper.sh connect [project-name] [server-name]
 
 # Execute command
-./.agent/scripts/hetzner-helper.sh exec [project-name] [server-name] "command"
+./.agents/scripts/hetzner-helper.sh exec [project-name] [server-name] "command"
 
 # Get server info
-./.agent/scripts/hetzner-helper.sh info [project-name] [server-name]
+./.agents/scripts/hetzner-helper.sh info [project-name] [server-name]
 
 # Manage servers
-./.agent/scripts/hetzner-helper.sh create [project-name] [server-name] [type]
-./.agent/scripts/hetzner-helper.sh delete [project-name] [server-name]
-./.agent/scripts/hetzner-helper.sh start [project-name] [server-name]
-./.agent/scripts/hetzner-helper.sh stop [project-name] [server-name]
+./.agents/scripts/hetzner-helper.sh create [project-name] [server-name] [type]
+./.agents/scripts/hetzner-helper.sh delete [project-name] [server-name]
+./.agents/scripts/hetzner-helper.sh start [project-name] [server-name]
+./.agents/scripts/hetzner-helper.sh stop [project-name] [server-name]
 ```
 
 **Configuration**: `configs/hetzner-config.json`
@@ -98,7 +98,7 @@ Manage Hetzner VPS servers, networking, and load balancers.
 
 ### Coolify
 
-**File**: `.agent/scripts/coolify-helper.sh`
+**File**: `.agents/scripts/coolify-helper.sh`
 
 Manage Coolify self-hosted PaaS and application deployments.
 
@@ -106,16 +106,16 @@ Manage Coolify self-hosted PaaS and application deployments.
 
 ```bash
 # List applications
-./.agent/scripts/coolify-helper.sh list
+./.agents/scripts/coolify-helper.sh list
 
 # Deploy application
-./.agent/scripts/coolify-helper.sh deploy [app-name]
+./.agents/scripts/coolify-helper.sh deploy [app-name]
 
 # Get application status
-./.agent/scripts/coolify-helper.sh status [app-name]
+./.agents/scripts/coolify-helper.sh status [app-name]
 
 # View logs
-./.agent/scripts/coolify-helper.sh logs [app-name]
+./.agents/scripts/coolify-helper.sh logs [app-name]
 ```
 
 **Configuration**: `configs/coolify-config.json`
@@ -131,7 +131,7 @@ Manage Coolify self-hosted PaaS and application deployments.
 
 ### Cloudron
 
-**File**: `.agent/scripts/cloudron-helper.sh`
+**File**: `.agents/scripts/cloudron-helper.sh`
 
 Manage Cloudron server and application platform.
 
@@ -139,18 +139,18 @@ Manage Cloudron server and application platform.
 
 ```bash
 # List installed apps
-./.agent/scripts/cloudron-helper.sh list
+./.agents/scripts/cloudron-helper.sh list
 
 # Install application
-./.agent/scripts/cloudron-helper.sh install [app-name]
+./.agents/scripts/cloudron-helper.sh install [app-name]
 
 # Manage apps
-./.agent/scripts/cloudron-helper.sh start [app-name]
-./.agent/scripts/cloudron-helper.sh stop [app-name]
-./.agent/scripts/cloudron-helper.sh restart [app-name]
+./.agents/scripts/cloudron-helper.sh start [app-name]
+./.agents/scripts/cloudron-helper.sh stop [app-name]
+./.agents/scripts/cloudron-helper.sh restart [app-name]
 
 # Backup management
-./.agent/scripts/cloudron-helper.sh backup [app-name]
+./.agents/scripts/cloudron-helper.sh backup [app-name]
 ```
 
 **Configuration**: `configs/cloudron-config.json`
@@ -166,7 +166,7 @@ Manage Cloudron server and application platform.
 
 ### Closte
 
-**File**: `.agent/scripts/closte-helper.sh`
+**File**: `.agents/scripts/closte-helper.sh`
 
 Manage Closte managed hosting and application deployment.
 
@@ -174,10 +174,10 @@ Manage Closte managed hosting and application deployment.
 
 ```bash
 # List sites
-./.agent/scripts/closte-helper.sh list
+./.agents/scripts/closte-helper.sh list
 
 # Site management
-./.agent/scripts/closte-helper.sh info [site-name]
+./.agents/scripts/closte-helper.sh info [site-name]
 ```
 
 **Configuration**: `configs/closte-config.json`
@@ -188,7 +188,7 @@ Manage Closte managed hosting and application deployment.
 
 ### Cloudflare (DNS Helper)
 
-**File**: `.agent/scripts/dns-helper.sh`
+**File**: `.agents/scripts/dns-helper.sh`
 
 Unified DNS management across multiple providers with focus on Cloudflare.
 
@@ -196,26 +196,26 @@ Unified DNS management across multiple providers with focus on Cloudflare.
 
 ```bash
 # List DNS zones
-./.agent/scripts/dns-helper.sh cloudflare list-zones
+./.agents/scripts/dns-helper.sh cloudflare list-zones
 
 # Add DNS records
-./.agent/scripts/dns-helper.sh cloudflare add-record [domain] A [ip-address]
-./.agent/scripts/dns-helper.sh cloudflare add-record [domain] CNAME [name] [target]
-./.agent/scripts/dns-helper.sh cloudflare add-record [domain] MX [priority] [server]
-./.agent/scripts/dns-helper.sh cloudflare add-record [domain] TXT [name] [value]
+./.agents/scripts/dns-helper.sh cloudflare add-record [domain] A [ip-address]
+./.agents/scripts/dns-helper.sh cloudflare add-record [domain] CNAME [name] [target]
+./.agents/scripts/dns-helper.sh cloudflare add-record [domain] MX [priority] [server]
+./.agents/scripts/dns-helper.sh cloudflare add-record [domain] TXT [name] [value]
 
 # Update record
-./.agent/scripts/dns-helper.sh cloudflare update-record [domain] [record-id] [type] [value]
+./.agents/scripts/dns-helper.sh cloudflare update-record [domain] [record-id] [type] [value]
 
 # Delete record
-./.agent/scripts/dns-helper.sh cloudflare delete-record [domain] [record-id]
+./.agents/scripts/dns-helper.sh cloudflare delete-record [domain] [record-id]
 
 # List records
-./.agent/scripts/dns-helper.sh cloudflare list-records [domain]
+./.agents/scripts/dns-helper.sh cloudflare list-records [domain]
 
 # Manage SSL
-./.agent/scripts/dns-helper.sh cloudflare enable-ssl [domain]
-./.agent/scripts/dns-helper.sh cloudflare set-ssl-mode [domain] [mode]
+./.agents/scripts/dns-helper.sh cloudflare enable-ssl [domain]
+./.agents/scripts/dns-helper.sh cloudflare set-ssl-mode [domain] [mode]
 ```
 
 **Configuration**: `configs/cloudflare-config.json`
@@ -231,7 +231,7 @@ Unified DNS management across multiple providers with focus on Cloudflare.
 
 ### Spaceship
 
-**File**: `.agent/scripts/spaceship-helper.sh`
+**File**: `.agents/scripts/spaceship-helper.sh`
 
 Domain registration and management via Spaceship.
 
@@ -239,22 +239,22 @@ Domain registration and management via Spaceship.
 
 ```bash
 # Check domain availability
-./.agent/scripts/spaceship-helper.sh check-availability [domain]
+./.agents/scripts/spaceship-helper.sh check-availability [domain]
 
 # Purchase domain
-./.agent/scripts/spaceship-helper.sh purchase [domain]
+./.agents/scripts/spaceship-helper.sh purchase [domain]
 
 # List owned domains
-./.agent/scripts/spaceship-helper.sh list
+./.agents/scripts/spaceship-helper.sh list
 
 # Manage nameservers
-./.agent/scripts/spaceship-helper.sh set-nameservers [domain] [ns1] [ns2]
+./.agents/scripts/spaceship-helper.sh set-nameservers [domain] [ns1] [ns2]
 
 # Domain info
-./.agent/scripts/spaceship-helper.sh info [domain]
+./.agents/scripts/spaceship-helper.sh info [domain]
 
 # Renew domain
-./.agent/scripts/spaceship-helper.sh renew [domain]
+./.agents/scripts/spaceship-helper.sh renew [domain]
 ```
 
 **Configuration**: `configs/spaceship-config.json`
@@ -270,7 +270,7 @@ Domain registration and management via Spaceship.
 
 ### 101domains
 
-**File**: `.agent/scripts/101domains-helper.sh`
+**File**: `.agents/scripts/101domains-helper.sh`
 
 Domain purchasing and DNS management via 101domains.
 
@@ -278,20 +278,20 @@ Domain purchasing and DNS management via 101domains.
 
 ```bash
 # Check availability
-./.agent/scripts/101domains-helper.sh check-availability [domain]
+./.agents/scripts/101domains-helper.sh check-availability [domain]
 
 # Search domains
-./.agent/scripts/101domains-helper.sh search [keyword]
+./.agents/scripts/101domains-helper.sh search [keyword]
 
 # Purchase domain
-./.agent/scripts/101domains-helper.sh purchase [domain]
+./.agents/scripts/101domains-helper.sh purchase [domain]
 
 # List domains
-./.agent/scripts/101domains-helper.sh list
+./.agents/scripts/101domains-helper.sh list
 
 # Manage DNS
-./.agent/scripts/101domains-helper.sh add-dns [domain] [type] [value]
-./.agent/scripts/101domains-helper.sh list-dns [domain]
+./.agents/scripts/101domains-helper.sh add-dns [domain] [type] [value]
+./.agents/scripts/101domains-helper.sh list-dns [domain]
 ```
 
 **Configuration**: `configs/101domains-config.json`
@@ -309,7 +309,7 @@ Domain purchasing and DNS management via 101domains.
 
 ### Git Platforms Helper
 
-**File**: `.agent/scripts/git-platforms-helper.sh`
+**File**: `.agents/scripts/git-platforms-helper.sh`
 
 Unified interface for GitHub, GitLab, and Gitea.
 
@@ -317,20 +317,20 @@ Unified interface for GitHub, GitLab, and Gitea.
 
 ```bash
 # GitHub operations
-./.agent/scripts/git-platforms-helper.sh github list-repos
-./.agent/scripts/git-platforms-helper.sh github create-repo [name]
-./.agent/scripts/git-platforms-helper.sh github delete-repo [name]
-./.agent/scripts/git-platforms-helper.sh github clone-repo [name]
+./.agents/scripts/git-platforms-helper.sh github list-repos
+./.agents/scripts/git-platforms-helper.sh github create-repo [name]
+./.agents/scripts/git-platforms-helper.sh github delete-repo [name]
+./.agents/scripts/git-platforms-helper.sh github clone-repo [name]
 
 # GitLab operations
-./.agent/scripts/git-platforms-helper.sh gitlab list-projects
-./.agent/scripts/git-platforms-helper.sh gitlab create-project [name]
-./.agent/scripts/git-platforms-helper.sh gitlab delete-project [id]
+./.agents/scripts/git-platforms-helper.sh gitlab list-projects
+./.agents/scripts/git-platforms-helper.sh gitlab create-project [name]
+./.agents/scripts/git-platforms-helper.sh gitlab delete-project [id]
 
 # Gitea operations
-./.agent/scripts/git-platforms-helper.sh gitea list-repos
-./.agent/scripts/git-platforms-helper.sh gitea create-repo [name]
-./.agent/scripts/git-platforms-helper.sh gitea delete-repo [name]
+./.agents/scripts/git-platforms-helper.sh gitea list-repos
+./.agents/scripts/git-platforms-helper.sh gitea create-repo [name]
+./.agents/scripts/git-platforms-helper.sh gitea delete-repo [name]
 ```
 
 **Configuration**: `configs/git-platforms-config.json`
@@ -346,7 +346,7 @@ Unified interface for GitHub, GitLab, and Gitea.
 
 ### Pandoc Helper
 
-**File**: `.agent/scripts/pandoc-helper.sh`
+**File**: `.agents/scripts/pandoc-helper.sh`
 
 Document format conversion for AI processing.
 
@@ -354,16 +354,16 @@ Document format conversion for AI processing.
 
 ```bash
 # Convert to markdown
-./.agent/scripts/pandoc-helper.sh to-markdown [input-file] [output-file]
+./.agents/scripts/pandoc-helper.sh to-markdown [input-file] [output-file]
 
 # Convert from markdown
-./.agent/scripts/pandoc-helper.sh from-markdown [input-file] [format] [output-file]
+./.agents/scripts/pandoc-helper.sh from-markdown [input-file] [format] [output-file]
 
 # Batch conversion
-./.agent/scripts/pandoc-helper.sh batch [input-dir] [output-dir] [format]
+./.agents/scripts/pandoc-helper.sh batch [input-dir] [output-dir] [format]
 
 # Get info
-./.agent/scripts/pandoc-helper.sh formats
+./.agents/scripts/pandoc-helper.sh formats
 ```
 
 **Supported Formats**:
@@ -386,7 +386,7 @@ Document format conversion for AI processing.
 
 ### Agno Setup
 
-**File**: `.agent/scripts/agno-setup.sh`
+**File**: `.agents/scripts/agno-setup.sh`
 
 Local AI agent operating system for DevOps automation.
 
@@ -394,19 +394,19 @@ Local AI agent operating system for DevOps automation.
 
 ```bash
 # Install Agno
-./.agent/scripts/agno-setup.sh install
+./.agents/scripts/agno-setup.sh install
 
 # Start Agno server
-./.agent/scripts/agno-setup.sh start
+./.agents/scripts/agno-setup.sh start
 
 # Stop Agno server
-./.agent/scripts/agno-setup.sh stop
+./.agents/scripts/agno-setup.sh stop
 
 # Status check
-./.agent/scripts/agno-setup.sh status
+./.agents/scripts/agno-setup.sh status
 
 # Configure
-./.agent/scripts/agno-setup.sh configure
+./.agents/scripts/agno-setup.sh configure
 ```
 
 **Configuration**: `configs/agno-config.json`
@@ -422,7 +422,7 @@ Local AI agent operating system for DevOps automation.
 
 ### LocalWP Helper
 
-**File**: `.agent/scripts/localhost-helper.sh`
+**File**: `.agents/scripts/localhost-helper.sh`
 
 WordPress local development environment management.
 
@@ -430,21 +430,21 @@ WordPress local development environment management.
 
 ```bash
 # Create new site
-./.agent/scripts/localhost-helper.sh create-site [site-name]
+./.agents/scripts/localhost-helper.sh create-site [site-name]
 
 # List sites
-./.agent/scripts/localhost-helper.sh list
+./.agents/scripts/localhost-helper.sh list
 
 # Start/stop site
-./.agent/scripts/localhost-helper.sh start [site-name]
-./.agent/scripts/localhost-helper.sh stop [site-name]
+./.agents/scripts/localhost-helper.sh start [site-name]
+./.agents/scripts/localhost-helper.sh stop [site-name]
 
 # Delete site
-./.agent/scripts/localhost-helper.sh delete [site-name]
+./.agents/scripts/localhost-helper.sh delete [site-name]
 
 # Database operations
-./.agent/scripts/localhost-helper.sh export-db [site-name] [output-file]
-./.agent/scripts/localhost-helper.sh import-db [site-name] [input-file]
+./.agents/scripts/localhost-helper.sh export-db [site-name] [output-file]
+./.agents/scripts/localhost-helper.sh import-db [site-name] [input-file]
 ```
 
 **Features**:
@@ -460,7 +460,7 @@ WordPress local development environment management.
 
 ### MainWP Helper
 
-**File**: `.agent/scripts/mainwp-helper.sh`
+**File**: `.agents/scripts/mainwp-helper.sh`
 
 Centralized WordPress management via MainWP.
 
@@ -468,24 +468,24 @@ Centralized WordPress management via MainWP.
 
 ```bash
 # List all sites
-./.agent/scripts/mainwp-helper.sh list-sites
+./.agents/scripts/mainwp-helper.sh list-sites
 
 # Site management
-./.agent/scripts/mainwp-helper.sh info [site-url]
-./.agent/scripts/mainwp-helper.sh sync [site-url]
+./.agents/scripts/mainwp-helper.sh info [site-url]
+./.agents/scripts/mainwp-helper.sh sync [site-url]
 
 # Backup operations
-./.agent/scripts/mainwp-helper.sh backup [site-url]
-./.agent/scripts/mainwp-helper.sh restore [site-url] [backup-id]
+./.agents/scripts/mainwp-helper.sh backup [site-url]
+./.agents/scripts/mainwp-helper.sh restore [site-url] [backup-id]
 
 # Update management
-./.agent/scripts/mainwp-helper.sh update-core [site-url]
-./.agent/scripts/mainwp-helper.sh update-plugins [site-url]
-./.agent/scripts/mainwp-helper.sh update-themes [site-url]
-./.agent/scripts/mainwp-helper.sh update-all [site-url]
+./.agents/scripts/mainwp-helper.sh update-core [site-url]
+./.agents/scripts/mainwp-helper.sh update-plugins [site-url]
+./.agents/scripts/mainwp-helper.sh update-themes [site-url]
+./.agents/scripts/mainwp-helper.sh update-all [site-url]
 
 # Security scans
-./.agent/scripts/mainwp-helper.sh security-scan [site-url]
+./.agents/scripts/mainwp-helper.sh security-scan [site-url]
 ```
 
 **Configuration**: `configs/mainwp-config.json`
@@ -504,7 +504,7 @@ Centralized WordPress management via MainWP.
 
 ### AWS SES Helper
 
-**File**: `.agent/scripts/ses-helper.sh`
+**File**: `.agents/scripts/ses-helper.sh`
 
 Amazon Simple Email Service management.
 
@@ -512,20 +512,20 @@ Amazon Simple Email Service management.
 
 ```bash
 # Send email
-./.agent/scripts/ses-helper.sh send [to] [subject] [body]
+./.agents/scripts/ses-helper.sh send [to] [subject] [body]
 
 # Verify email address
-./.agent/scripts/ses-helper.sh verify [email]
+./.agents/scripts/ses-helper.sh verify [email]
 
 # List verified emails
-./.agent/scripts/ses-helper.sh list-verified
+./.agents/scripts/ses-helper.sh list-verified
 
 # Get send statistics
-./.agent/scripts/ses-helper.sh stats
+./.agents/scripts/ses-helper.sh stats
 
 # Manage suppression list
-./.agent/scripts/ses-helper.sh list-suppressed
-./.agent/scripts/ses-helper.sh remove-suppressed [email]
+./.agents/scripts/ses-helper.sh list-suppressed
+./.agents/scripts/ses-helper.sh remove-suppressed [email]
 ```
 
 **Configuration**: `configs/ses-config.json`
@@ -543,7 +543,7 @@ Amazon Simple Email Service management.
 
 ### Vaultwarden Helper
 
-**File**: `.agent/scripts/vaultwarden-helper.sh`
+**File**: `.agents/scripts/vaultwarden-helper.sh`
 
 Password and secrets management via Vaultwarden.
 
@@ -551,22 +551,22 @@ Password and secrets management via Vaultwarden.
 
 ```bash
 # List items
-./.agent/scripts/vaultwarden-helper.sh list
+./.agents/scripts/vaultwarden-helper.sh list
 
 # Get item
-./.agent/scripts/vaultwarden-helper.sh get [item-name]
+./.agents/scripts/vaultwarden-helper.sh get [item-name]
 
 # Add item
-./.agent/scripts/vaultwarden-helper.sh add [item-name] [username] [password]
+./.agents/scripts/vaultwarden-helper.sh add [item-name] [username] [password]
 
 # Update item
-./.agent/scripts/vaultwarden-helper.sh update [item-id] [field] [value]
+./.agents/scripts/vaultwarden-helper.sh update [item-id] [field] [value]
 
 # Delete item
-./.agent/scripts/vaultwarden-helper.sh delete [item-id]
+./.agents/scripts/vaultwarden-helper.sh delete [item-id]
 
 # Generate password
-./.agent/scripts/vaultwarden-helper.sh generate [length]
+./.agents/scripts/vaultwarden-helper.sh generate [length]
 ```
 
 **Configuration**: `configs/vaultwarden-config.json`
@@ -584,7 +584,7 @@ Password and secrets management via Vaultwarden.
 
 ### PageSpeed Helper
 
-**File**: `.agent/scripts/pagespeed-helper.sh`
+**File**: `.agents/scripts/pagespeed-helper.sh`
 
 Website performance auditing and optimization.
 
@@ -592,19 +592,19 @@ Website performance auditing and optimization.
 
 ```bash
 # Run PageSpeed audit
-./.agent/scripts/pagespeed-helper.sh audit [url]
+./.agents/scripts/pagespeed-helper.sh audit [url]
 
 # WordPress-specific audit
-./.agent/scripts/pagespeed-helper.sh wordpress [url]
+./.agents/scripts/pagespeed-helper.sh wordpress [url]
 
 # Lighthouse audit
-./.agent/scripts/pagespeed-helper.sh lighthouse [url] [format]
+./.agents/scripts/pagespeed-helper.sh lighthouse [url] [format]
 
 # Compare performance
-./.agent/scripts/pagespeed-helper.sh compare [url1] [url2]
+./.agents/scripts/pagespeed-helper.sh compare [url1] [url2]
 
 # Export report
-./.agent/scripts/pagespeed-helper.sh export [url] [output-file]
+./.agents/scripts/pagespeed-helper.sh export [url] [output-file]
 ```
 
 **Configuration**: `configs/pagespeed-config.json`
@@ -621,7 +621,7 @@ Website performance auditing and optimization.
 
 ### Code Audit Helper
 
-**File**: `.agent/scripts/code-audit-helper.sh`
+**File**: `.agents/scripts/code-audit-helper.sh`
 
 Code quality and security auditing.
 
@@ -629,13 +629,13 @@ Code quality and security auditing.
 
 ```bash
 # Run audit
-./.agent/scripts/code-audit-helper.sh audit [directory]
+./.agents/scripts/code-audit-helper.sh audit [directory]
 
 # Security scan
-./.agent/scripts/code-audit-helper.sh security [directory]
+./.agents/scripts/code-audit-helper.sh security [directory]
 
 # Generate report
-./.agent/scripts/code-audit-helper.sh report [directory] [output-file]
+./.agents/scripts/code-audit-helper.sh report [directory] [output-file]
 ```
 
 **Features**:
@@ -651,7 +651,7 @@ Code quality and security auditing.
 
 ### DSPy Helper
 
-**File**: `.agent/scripts/dspy-helper.sh`
+**File**: `.agents/scripts/dspy-helper.sh`
 
 DSPy framework integration for prompt optimization.
 
@@ -659,16 +659,16 @@ DSPy framework integration for prompt optimization.
 
 ```bash
 # Install DSPy
-./.agent/scripts/dspy-helper.sh install
+./.agents/scripts/dspy-helper.sh install
 
 # Run optimization
-./.agent/scripts/dspy-helper.sh optimize [prompt-file]
+./.agents/scripts/dspy-helper.sh optimize [prompt-file]
 
 # Test prompts
-./.agent/scripts/dspy-helper.sh test [prompt-file]
+./.agents/scripts/dspy-helper.sh test [prompt-file]
 
 # Export optimized prompts
-./.agent/scripts/dspy-helper.sh export [output-file]
+./.agents/scripts/dspy-helper.sh export [output-file]
 ```
 
 **Configuration**: `configs/dspy-config.json`
@@ -684,7 +684,7 @@ DSPy framework integration for prompt optimization.
 
 ### DSPyGround Helper
 
-**File**: `.agent/scripts/dspyground-helper.sh`
+**File**: `.agents/scripts/dspyground-helper.sh`
 
 DSPyGround playground for prompt experimentation.
 
@@ -692,13 +692,13 @@ DSPyGround playground for prompt experimentation.
 
 ```bash
 # Start playground
-./.agent/scripts/dspyground-helper.sh start
+./.agents/scripts/dspyground-helper.sh start
 
 # Stop playground
-./.agent/scripts/dspyground-helper.sh stop
+./.agents/scripts/dspyground-helper.sh stop
 
 # Open in browser
-./.agent/scripts/dspyground-helper.sh open
+./.agents/scripts/dspyground-helper.sh open
 ```
 
 **Configuration**: `configs/dspyground-config.json`
@@ -707,7 +707,7 @@ DSPyGround playground for prompt experimentation.
 
 ### TOON Helper
 
-**File**: `.agent/scripts/toon-helper.sh`
+**File**: `.agents/scripts/toon-helper.sh`
 
 Token-Oriented Object Notation for efficient LLM data exchange.
 
@@ -715,19 +715,19 @@ Token-Oriented Object Notation for efficient LLM data exchange.
 
 ```bash
 # Encode JSON to TOON
-./.agent/scripts/toon-helper.sh encode [input.json] [output.toon]
+./.agents/scripts/toon-helper.sh encode [input.json] [output.toon]
 
 # Decode TOON to JSON
-./.agent/scripts/toon-helper.sh decode [input.toon] [output.json]
+./.agents/scripts/toon-helper.sh decode [input.toon] [output.json]
 
 # Compare token efficiency
-./.agent/scripts/toon-helper.sh compare [file.json]
+./.agents/scripts/toon-helper.sh compare [file.json]
 
 # Batch conversion
-./.agent/scripts/toon-helper.sh batch [input-dir] [output-dir] [mode]
+./.agents/scripts/toon-helper.sh batch [input-dir] [output-dir] [mode]
 
 # Get format info
-./.agent/scripts/toon-helper.sh info
+./.agents/scripts/toon-helper.sh info
 ```
 
 **Features**:
@@ -743,7 +743,7 @@ Token-Oriented Object Notation for efficient LLM data exchange.
 
 ### Setup Wizard Helper
 
-**File**: `.agent/scripts/setup-wizard-helper.sh`
+**File**: `.agents/scripts/setup-wizard-helper.sh`
 
 Interactive setup wizard for initial configuration.
 
@@ -751,16 +751,16 @@ Interactive setup wizard for initial configuration.
 
 ```bash
 # Run full setup
-./.agent/scripts/setup-wizard-helper.sh
+./.agents/scripts/setup-wizard-helper.sh
 
 # Configure specific provider
-./.agent/scripts/setup-wizard-helper.sh provider [provider-name]
+./.agents/scripts/setup-wizard-helper.sh provider [provider-name]
 
 # Test configuration
-./.agent/scripts/setup-wizard-helper.sh test
+./.agents/scripts/setup-wizard-helper.sh test
 
 # Reset configuration
-./.agent/scripts/setup-wizard-helper.sh reset
+./.agents/scripts/setup-wizard-helper.sh reset
 ```
 
 **Features**:
@@ -774,7 +774,7 @@ Interactive setup wizard for initial configuration.
 
 ### Shared Constants
 
-**File**: `.agent/scripts/shared-constants.sh`
+**File**: `.agents/scripts/shared-constants.sh`
 
 Common variables and functions used across all providers.
 
@@ -806,36 +806,36 @@ echo "$LOG_DIR"
 
 ```bash
 # 1. Purchase domain
-./.agent/scripts/spaceship-helper.sh purchase example.com
+./.agents/scripts/spaceship-helper.sh purchase example.com
 
 # 2. Configure DNS
-./.agent/scripts/dns-helper.sh cloudflare add-record example.com A 192.168.1.1
-./.agent/scripts/dns-helper.sh cloudflare enable-ssl example.com
+./.agents/scripts/dns-helper.sh cloudflare add-record example.com A 192.168.1.1
+./.agents/scripts/dns-helper.sh cloudflare enable-ssl example.com
 
 # 3. Deploy application
-./.agent/scripts/coolify-helper.sh deploy myapp
+./.agents/scripts/coolify-helper.sh deploy myapp
 
 # 4. Audit performance
-./.agent/scripts/pagespeed-helper.sh wordpress https://example.com
+./.agents/scripts/pagespeed-helper.sh wordpress https://example.com
 
 # 5. Backup WordPress
-./.agent/scripts/mainwp-helper.sh backup example.com
+./.agents/scripts/mainwp-helper.sh backup example.com
 ```
 
 ### Server Management Workflow
 
 ```bash
 # 1. Create Hetzner server
-./.agent/scripts/hetzner-helper.sh create main web-server cx11
+./.agents/scripts/hetzner-helper.sh create main web-server cx11
 
 # 2. Connect and configure
-./.agent/scripts/hetzner-helper.sh connect main web-server
+./.agents/scripts/hetzner-helper.sh connect main web-server
 
 # 3. Install Cloudron
-./.agent/scripts/cloudron-helper.sh install
+./.agents/scripts/cloudron-helper.sh install
 
 # 4. Configure SSL
-./.agent/scripts/dns-helper.sh cloudflare enable-ssl example.com
+./.agents/scripts/dns-helper.sh cloudflare enable-ssl example.com
 ```
 
 ## Best Practices
@@ -846,7 +846,7 @@ All scripts implement consistent error handling:
 
 ```bash
 # Scripts exit with non-zero on error
-if ! ./.agent/scripts/hostinger-helper.sh connect example.com; then
+if ! ./.agents/scripts/hostinger-helper.sh connect example.com; then
     echo "Connection failed"
     exit 1
 fi
@@ -868,7 +868,7 @@ Always use configuration files, never hardcode credentials:
 
 ```bash
 # Good
-./.agent/scripts/hostinger-helper.sh list
+./.agents/scripts/hostinger-helper.sh list
 
 # Bad - don't pass credentials as arguments
 ```
@@ -880,7 +880,7 @@ Always use configuration files, never hardcode credentials:
 1. Copy template:
 
 ```bash
-cp .agent/scripts/template-helper.sh .agent/scripts/newprovider-helper.sh
+cp .agents/scripts/template-helper.sh .agents/scripts/newprovider-helper.sh
 ```
 
 1. Implement standard functions:

--- a/.wiki/The-Agent-Directory.md
+++ b/.wiki/The-Agent-Directory.md
@@ -1,11 +1,11 @@
-# The .agent Directory
+# The .agents Directory
 
-Everything AI assistants need lives in `.agent/`. This page explains the structure and how to use it.
+Everything AI assistants need lives in `.agents/`. This page explains the structure and how to use it.
 
 ## Overview
 
 ```text
-.agent/
+.agents/
 ├── scripts/       # 90+ automation & helper scripts
 ├── workflows/     # Development process guides
 ├── memory/        # Context persistence templates
@@ -31,13 +31,13 @@ Everything AI assistants need lives in `.agent/`. This page explains the structu
 
 ```bash
 # List all available scripts
-ls ~/git/aidevops/.agent/scripts/
+ls ~/git/aidevops/.agents/scripts/
 
 # Get help for any script
-bash ~/git/aidevops/.agent/scripts/hostinger-helper.sh help
+bash ~/git/aidevops/.agents/scripts/hostinger-helper.sh help
 
 # Common pattern: service helper with command
-bash ~/git/aidevops/.agent/scripts/[service]-helper.sh [command] [account] [target]
+bash ~/git/aidevops/.agents/scripts/[service]-helper.sh [command] [account] [target]
 ```text
 
 ### Key Scripts
@@ -165,14 +165,14 @@ AI follows workflows for:
 
 ### Adding a New Service
 
-1. Create `service-name.md` in `.agent/`
-2. Create `service-name-helper.sh` in `.agent/scripts/`
+1. Create `service-name.md` in `.agents/`
+2. Create `service-name-helper.sh` in `.agents/scripts/`
 3. Update `AGENTS.md` service categories
 4. Add configuration template in `configs/`
 
 ### Adding a New Workflow
 
-1. Create `workflow-name.md` in `.agent/workflows/`
+1. Create `workflow-name.md` in `.agents/workflows/`
 2. Follow the template in `workflows/README.md`
 3. Update the workflows README index
 

--- a/.wiki/Understanding-AGENTS-md.md
+++ b/.wiki/Understanding-AGENTS-md.md
@@ -8,7 +8,7 @@ It's a comprehensive instruction file that tells AI assistants:
 
 - **What services are available** (30+ integrations)
 - **How to use them securely** (credential management, confirmation requirements)
-- **Where to find documentation** (`.agent/` directory structure)
+- **Where to find documentation** (`.agents/` directory structure)
 - **Quality standards to maintain** (code quality, testing requirements)
 - **Working directory rules** (where to create files)
 
@@ -89,8 +89,8 @@ When you mention DevOps tasks, the AI reads `AGENTS.md` to understand:
 ### 2. Task Execution
 
 For specific tasks, the AI:
-1. Reads relevant `.agent/*.md` documentation
-2. Uses appropriate `.agent/scripts/*.sh` helpers
+1. Reads relevant `.agents/*.md` documentation
+2. Uses appropriate `.agents/scripts/*.sh` helpers
 3. Follows security and quality guidelines
 
 ### 3. File Operations
@@ -124,12 +124,12 @@ When making changes:
 If building AI integrations, you can:
 
 1. **Reference AGENTS.md** in your system prompts
-2. **Use the `.agent/` structure** as context
+2. **Use the `.agents/` structure** as context
 3. **Follow the security contract** for credential handling
 4. **Adopt the working directory conventions** for file operations
 
 ## Related Pages
 
-- **[The .agent Directory](The-Agent-Directory)** - Framework structure details
+- **[The .agents Directory](The-Agent-Directory)** - Framework structure details
 - **[Workflows Guide](Workflows-Guide)** - Development processes
 - **[For Humans](For-Humans)** - Non-technical overview

--- a/.wiki/Workflows-Guide.md
+++ b/.wiki/Workflows-Guide.md
@@ -1,6 +1,6 @@
 # Workflows Guide
 
-The `.agent/workflows/` directory contains process guides for common development tasks. These workflows help AI assistants (and humans) follow consistent, high-quality practices.
+The `.agents/workflows/` directory contains process guides for common development tasks. These workflows help AI assistants (and humans) follow consistent, high-quality practices.
 
 ## Available Workflows
 
@@ -8,41 +8,41 @@ The `.agent/workflows/` directory contains process guides for common development
 
 | Workflow | When to Use |
 |----------|-------------|
-| **[git-workflow.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/git-workflow.md)** | Branching strategies, commit conventions, collaboration |
-| **[release-process.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/release-process.md)** | Version bumps, tagging, GitHub releases |
+| **[git-workflow.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/git-workflow.md)** | Branching strategies, commit conventions, collaboration |
+| **[release-process.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/release-process.md)** | Version bumps, tagging, GitHub releases |
 
 ### Development Lifecycle
 
 | Workflow | When to Use |
 |----------|-------------|
-| **[feature-development.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/feature-development.md)** | Building new features from start to merge |
-| **[bug-fixing.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/bug-fixing.md)** | Fixing bugs, including hotfix procedures |
+| **[feature-development.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/feature-development.md)** | Building new features from start to merge |
+| **[bug-fixing.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/bug-fixing.md)** | Fixing bugs, including hotfix procedures |
 
 ### Code Quality
 
 | Workflow | When to Use |
 |----------|-------------|
-| **[pr.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/pr.md)** | Unified PR workflow (orchestrates all checks) |
-| **[code-audit-remote.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/code-audit-remote.md)** | Remote auditing (CodeRabbit, Codacy, SonarCloud) |
-| **[error-checking-feedback-loops.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/error-checking-feedback-loops.md)** | Monitoring CI/CD, fixing failures |
+| **[pr.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/pr.md)** | Unified PR workflow (orchestrates all checks) |
+| **[code-audit-remote.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/code-audit-remote.md)** | Remote auditing (CodeRabbit, Codacy, SonarCloud) |
+| **[error-checking-feedback-loops.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/error-checking-feedback-loops.md)** | Monitoring CI/CD, fixing failures |
 
 ### Context & Safety
 
 | Workflow | When to Use |
 |----------|-------------|
-| **[multi-repo-workspace.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/multi-repo-workspace.md)** | Working across multiple repositories safely |
+| **[multi-repo-workspace.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/multi-repo-workspace.md)** | Working across multiple repositories safely |
 
 ### Documentation
 
 | Workflow | When to Use |
 |----------|-------------|
-| **[wiki-update.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/wiki-update.md)** | Updating GitHub wiki from codebase changes |
+| **[wiki-update.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/wiki-update.md)** | Updating GitHub wiki from codebase changes |
 
 ### Platform-Specific
 
 | Workflow | When to Use |
 |----------|-------------|
-| **[wordpress-local-testing.md](https://github.com/marcusquinn/aidevops/blob/main/.agent/workflows/wordpress-local-testing.md)** | WordPress Playground, LocalWP, wp-env |
+| **[wordpress-local-testing.md](https://github.com/marcusquinn/aidevops/blob/main/.agents/workflows/wordpress-local-testing.md)** | WordPress Playground, LocalWP, wp-env |
 
 ## Workflow Quick Reference
 
@@ -143,25 +143,25 @@ Following consistent workflows:
 
 ```bash
 # Get all quality feedback for current PR
-bash ~/git/aidevops/.agent/scripts/quality-feedback-helper.sh status --pr NUMBER
+bash ~/git/aidevops/.agents/scripts/quality-feedback-helper.sh status --pr NUMBER
 ```
 
 ### Run Local Linting
 
 ```bash
 # Run local quality checks (fast, offline)
-bash ~/git/aidevops/.agent/scripts/linters-local.sh
+bash ~/git/aidevops/.agents/scripts/linters-local.sh
 ```
 
 ### Monitor CI/CD
 
 ```bash
 # Watch for check completion
-bash ~/git/aidevops/.agent/scripts/quality-feedback-helper.sh watch --pr NUMBER
+bash ~/git/aidevops/.agents/scripts/quality-feedback-helper.sh watch --pr NUMBER
 ```
 
 ## Related Pages
 
-- **[The .agent Directory](The-Agent-Directory)** - Directory structure
+- **[The .agents Directory](The-Agent-Directory)** - Directory structure
 - **[Understanding AGENTS.md](Understanding-AGENTS-md)** - AI instruction file
 - **[Getting Started](Getting-Started)** - Installation and setup

--- a/.wiki/_Sidebar.md
+++ b/.wiki/_Sidebar.md
@@ -8,7 +8,7 @@
 ### Core Concepts
 
 - [Understanding AGENTS.md](Understanding-AGENTS-md)
-- [The .agent Directory](The-Agent-Directory)
+- [The .agents Directory](The-Agent-Directory)
 - [Workflows Guide](Workflows-Guide)
 
 ### Reference


### PR DESCRIPTION
## Summary
- audit all tracked wiki pages under `.wiki/` for incorrect `.agent/` directory references
- update wiki paths and labels to `.agents/` while leaving valid `.agent-workspace` references unchanged
- run markdown formatting validation to confirm no documentation lint/format regressions

Closes #5222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all path references throughout documentation guides to ensure accuracy and consistency.
  * Examples, script references, and configuration instructions across wiki pages have been revised.
  * Navigation labels and internal documentation links updated for clarity.
  * Affected guides include installation, MCP integrations, provider configuration, workflows, and getting started instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->