### PR TITLE
chore: remove trailing whitespace from wiki files

### DIFF
--- a/.wiki/For-Humans.md
+++ b/.wiki/For-Humans.md
@@ -24,7 +24,7 @@ You: "Help me deploy my site to Hostinger"
 AI: *reads AGENTS.md*
     *reads .agent/hostinger.md*
     *uses hostinger-helper.sh*
-    
+
 AI: "I'll help you deploy. First, let me verify your account..."
 ```
 

--- a/.wiki/Home.md
+++ b/.wiki/Home.md
@@ -48,7 +48,7 @@ See [CLI Reference](CLI-Reference) for full documentation.
 Your AI assistant now has access to:
 
 - 90+ automation scripts
-- 13 MCP server integrations  
+- 13 MCP server integrations
 - Comprehensive workflow guides
 - Service-specific documentation
 

--- a/.wiki/Understanding-AGENTS-md.md
+++ b/.wiki/Understanding-AGENTS-md.md
@@ -61,7 +61,7 @@ Never expose credentials in logs, output, or error messages
 ```text
 ~/.aidevops/.agent-workspace/
 ├── tmp/      # Temporary files
-├── work/     # Project files  
+├── work/     # Project files
 └── memory/   # Persistent context
 ```
 


### PR DESCRIPTION
## Summary

- Removes trailing whitespace from 3 wiki files (`.wiki/For-Humans.md`, `.wiki/Home.md`, `.wiki/Understanding-AGENTS-md.md`)
- Whitespace-only changes, no content modifications