### PR TITLE
quality-debt: add HELPER path comment to dispatch examples

### DIFF
--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -227,6 +227,7 @@ When dispatching multiple workers manually (outside the pulse supervisor), **sta
 
 ```bash
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+# Use dynamic path to respect user configuration of agents_dir
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # WRONG: Thundering herd — all 4 workers cold-boot simultaneously
@@ -794,6 +795,7 @@ LINEAGE RULES:
 
 ```bash
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+# Use dynamic path to respect user configuration of agents_dir
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 
 # Standard dispatch (no lineage — top-level task)
@@ -1074,6 +1076,7 @@ NEXT=$(batch-strategy-helper.sh next-batch \
 
 # Dispatch each task in the batch
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
+# Use dynamic path to respect user configuration of agents_dir
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
 echo "$NEXT" | jq -r '.[]' | while read -r task_id; do
   $HELPER run --role worker --session-key "task-${task_id}" \


### PR DESCRIPTION
## Summary

Addresses PR #5124 review feedback filed as GH#5231.

Adds a one-line comment `# Use dynamic path to respect user configuration of agents_dir` immediately after each `AGENTS_DIR` assignment and before the `HELPER` variable assignment in all three dispatch code examples in `.agents/tools/ai-assistants/headless-dispatch.md`:

- Line 229 — Stagger Protection for Manual Dispatch example
- Line 795 — Dispatch Prompt Template with Lineage example
- Line 1074 — Batch Strategy dispatch example

The comment explains *why* the path is constructed dynamically (to honour the user's `agents_dir` config) rather than hardcoded, improving readability for users copying these examples.

## Changes

- `.agents/tools/ai-assistants/headless-dispatch.md` — 3 comment lines added (one per code block)

Closes #5231

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced code examples in headless dispatch documentation with clarifying comments on dynamic path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->