### PR TITLE
t5228: fix(issue-sync): use precise POSIX regex for [x] completion check

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -315,7 +315,7 @@ cmd_push() {
 		# The TOON backlog cache in TODO.md can be stale, showing tasks as pending
 		# even after [x] completion. The pulse reads the stale cache and calls
 		# push <task_id>, which previously matched [x] lines via the [.] pattern.
-		if [[ "$task_line" == *"[x]"* ]]; then
+		if [[ "$task_line" =~ ^[[:space:]]*-\ \[x\]\  ]]; then
 			print_info "Skipping $task_id — already completed ([x] in TODO.md)"
 			skipped=$((skipped + 1))
 			continue


### PR DESCRIPTION
## Summary

- Replaces glob pattern `*"[x]"*` with anchored POSIX regex `^[[:space:]]*-\ \[x\]\ ` at `.agents/scripts/issue-sync-helper.sh:318`
- The glob could match `[x]` appearing anywhere in the task line; the regex anchors to the exact completion marker position at line start
- Uses `[[:space:]]` (POSIX character class) instead of `\s` for portability across regex engines
- Functionally equivalent for well-formed TODO.md lines, but more robust against format drift

Closes #5228

## Review feedback addressed

Gemini code review on PR #5219 (medium severity finding):
> The new pattern `*"[x]"*` is less specific than the original regex. Consider using `[[ ... =~ ... ]]` with the appropriate regex pattern using `[[:space:]]` for whitespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of completed task detection in issue sync, reducing false positives from incidental occurrences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->