### PR TITLE
t5230: docs: add clarifying comment for dynamic HELPER path in dispatch examples

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -143,6 +143,7 @@ Not every task is code. The framework has multiple primary agents, each with dom
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 AGENTS_DIR="${AGENTS_DIR:-"$HOME/.aidevops/agents"}"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
+# Dynamic path respects user configuration of paths.agents_dir in config.jsonc
 
 # Code task (default — Build+ implied)
 $HELPER run \

--- a/.agents/scripts/commands/runners.md
+++ b/.agents/scripts/commands/runners.md
@@ -95,6 +95,7 @@ For each resolved item, launch a worker using `headless-runtime-helper.sh run`. 
 ```bash
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
+# Dynamic path respects user configuration of paths.agents_dir in config.jsonc
 
 # For code tasks (Build+ is default — omit --agent)
 $HELPER run \

--- a/.agents/tools/ai-assistants/headless-dispatch.md
+++ b/.agents/tools/ai-assistants/headless-dispatch.md
@@ -228,6 +228,7 @@ When dispatching multiple workers manually (outside the pulse supervisor), **sta
 ```bash
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
+# Dynamic path respects user configuration of paths.agents_dir in config.jsonc
 
 # WRONG: Thundering herd — all 4 workers cold-boot simultaneously
 for issue in 42 43 44 45; do
@@ -795,6 +796,7 @@ LINEAGE RULES:
 ```bash
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
+# Dynamic path respects user configuration of paths.agents_dir in config.jsonc
 
 # Standard dispatch (no lineage — top-level task)
 $HELPER run \
@@ -1075,6 +1077,7 @@ NEXT=$(batch-strategy-helper.sh next-batch \
 # Dispatch each task in the batch
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
+# Dynamic path respects user configuration of paths.agents_dir in config.jsonc
 echo "$NEXT" | jq -r '.[]' | while read -r task_id; do
   $HELPER run --role worker --session-key "task-${task_id}" \
     --dir <path> --title "$task_id" \


### PR DESCRIPTION
## Summary

- Add `# Dynamic path respects user configuration of paths.agents_dir in config.jsonc` comment after each `HELPER=` assignment in all 5 dispatch examples
- Files changed: `.agents/scripts/commands/runners.md`, `.agents/AGENTS.md`, `.agents/tools/ai-assistants/headless-dispatch.md` (3 occurrences)

## Context

PR #5124 (merged) updated hardcoded `~/.aidevops/agents/` paths to dynamic `$(aidevops config get paths.agents_dir)` form. Gemini code review flagged all 5 locations as needing a clarifying comment so users understand *why* the path is constructed dynamically rather than hardcoded.

## Verification

All 5 comment lines confirmed present:
```
.agents/scripts/commands/runners.md:98
.agents/AGENTS.md:146
.agents/tools/ai-assistants/headless-dispatch.md:231, 799, 1080
```

Closes #5230