### PR TITLE
t5229: clarify dynamic HELPER path comment in AGENTS dispatch example

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -143,7 +143,7 @@ Not every task is code. The framework has multiple primary agents, each with dom
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 AGENTS_DIR="${AGENTS_DIR:-"$HOME/.aidevops/agents"}"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
-# Dynamic path respects user configuration of paths.agents_dir in config.jsonc
+# Resolves HELPER path dynamically to support custom agents_dir
 
 # Code task (default — Build+ implied)
 $HELPER run \


### PR DESCRIPTION
## Summary
- add an inline comment in the `.agents/AGENTS.md` dispatch example explaining why `HELPER` uses a dynamically resolved path
- improve readability for users new to `paths.agents_dir` while keeping the example behavior unchanged

Closes #5229