### PR TITLE
GH#5237: Add Python version check to setup flow

### DIFF
--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1001,6 +1001,92 @@ setup_ssh_key() {
 	return 0
 }
 
+# Check installed Python version against latest stable available from package manager.
+# Warns if an upgrade is available but never auto-upgrades (GH#5237).
+# Works on macOS (Homebrew) and Linux (apt/dnf).
+check_python_version() {
+	print_info "Checking Python version..."
+
+	# 1. Check currently installed Python
+	local python3_bin
+	if ! python3_bin=$(find_python3); then
+		print_warning "Python 3 not found"
+		echo ""
+		echo "  Install options:"
+		if [[ "$PLATFORM_MACOS" == "true" ]]; then
+			echo "    brew install python3"
+		elif command -v apt-get >/dev/null 2>&1; then
+			echo "    sudo apt install python3"
+		elif command -v dnf >/dev/null 2>&1; then
+			echo "    sudo dnf install python3"
+		else
+			echo "    Install Python 3 via your system package manager"
+		fi
+		echo ""
+		return 0
+	fi
+
+	local installed_version
+	installed_version=$("$python3_bin" --version 2>&1 | cut -d' ' -f2)
+	local installed_major installed_minor
+	installed_major=$(echo "$installed_version" | cut -d. -f1)
+	installed_minor=$(echo "$installed_version" | cut -d. -f2)
+
+	# 2. Determine latest stable version from package manager
+	local latest_version=""
+
+	if [[ "$PLATFORM_MACOS" == "true" ]] && command -v brew >/dev/null 2>&1; then
+		# Homebrew: `brew info python3` outputs "python@3.X: 3.X.Y" on the first line
+		latest_version=$(brew info --json=v2 python3 2>/dev/null |
+			python3 -c "import sys,json; d=json.load(sys.stdin); print(d['formulae'][0]['versions']['stable'])" 2>/dev/null) || latest_version=""
+	elif command -v apt-cache >/dev/null 2>&1; then
+		# Debian/Ubuntu: get candidate version from apt-cache
+		latest_version=$(apt-cache policy python3 2>/dev/null |
+			awk '/Candidate:/{print $2}' |
+			grep -oE '[0-9]+\.[0-9]+\.[0-9]+') || latest_version=""
+	elif command -v dnf >/dev/null 2>&1; then
+		# Fedora/RHEL: get available version from dnf
+		latest_version=$(dnf info python3 2>/dev/null |
+			awk '/^Version/{print $3}') || latest_version=""
+	fi
+
+	# 3. Compare versions and advise
+	if [[ -z "$latest_version" ]]; then
+		# Could not determine latest — just report installed version
+		print_success "Python $installed_version found"
+		return 0
+	fi
+
+	local latest_major latest_minor
+	latest_major=$(echo "$latest_version" | cut -d. -f1)
+	latest_minor=$(echo "$latest_version" | cut -d. -f2)
+
+	# Compare major.minor (patch differences are not worth warning about)
+	if [[ "$installed_major" -lt "$latest_major" ]] ||
+		{ [[ "$installed_major" -eq "$latest_major" ]] && [[ "$installed_minor" -lt "$latest_minor" ]]; }; then
+		print_warning "Python $installed_version installed, but $latest_version is available"
+		echo ""
+		echo "  Some tools and skills require Python 3.10+."
+		echo "  Upgrade is recommended but not required."
+		echo ""
+		if [[ "$PLATFORM_MACOS" == "true" ]]; then
+			echo "  Upgrade command:"
+			echo "    brew upgrade python3"
+		elif command -v apt-get >/dev/null 2>&1; then
+			echo "  Upgrade command:"
+			echo "    sudo apt update && sudo apt install python3"
+		elif command -v dnf >/dev/null 2>&1; then
+			echo "  Upgrade command:"
+			echo "    sudo dnf upgrade python3"
+		fi
+		echo ""
+	else
+		print_success "Python $installed_version found (latest stable: $latest_version)"
+	fi
+
+	return 0
+}
+
 setup_python_env() {
 	print_info "Setting up Python environment for DSPy..."
 

--- a/setup.sh
+++ b/setup.sh
@@ -709,6 +709,7 @@ main() {
 		print_info "Non-interactive mode: deploying agents and running safe migrations only"
 		verify_location
 		check_requirements
+		check_python_version
 		set_permissions
 		migrate_old_backups
 		migrate_loop_state_directories
@@ -773,6 +774,7 @@ main() {
 
 		# Optional steps with confirmation in interactive mode
 		confirm_step "Check optional dependencies (bun, node, python)" && check_optional_deps
+		confirm_step "Check Python version (recommend upgrade if outdated)" && check_python_version
 		confirm_step "Setup recommended tools (Tabby, Zed, etc.)" && setup_recommended_tools
 		confirm_step "Setup MiniSim (iOS/Android emulator launcher)" && setup_minisim
 		confirm_step "Setup Git CLIs (gh, glab, tea)" && setup_git_clis


### PR DESCRIPTION
## Summary

- Adds `check_python_version()` to `setup-modules/tool-install.sh` that compares the installed Python version against the latest stable available from the system package manager
- Integrates into both interactive (with `confirm_step`) and non-interactive setup paths in `setup.sh`
- Supports macOS (Homebrew `brew info --json=v2`), Debian/Ubuntu (`apt-cache policy`), and Fedora/RHEL (`dnf info`)

## Behavior

- If Python is not installed: warns and suggests install command for the detected platform
- If installed version is older (by major.minor): warns and suggests the upgrade command
- If installed version is current: reports success with version info
- **Never auto-upgrades** — only warns and suggests commands
- Patch-level differences are not flagged (only major.minor comparison)

## Verification

- ShellCheck passes clean on both modified files
- Version comparison logic tested with 3 cases: older, same-minor, identical

Closes #5237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python version checking during setup that verifies your current Python installation against the latest stable version available. If you're running an outdated version, the system recommends upgrades with platform-specific instructions for macOS, Linux (Debian/Ubuntu), and Fedora/RHEL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->