### PR TITLE
t5237: add Homebrew-aware Python recency checks

### DIFF
--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -320,18 +320,9 @@ get_latest_homebrew_python_formula() {
 		return 1
 	fi
 
-	local latest_formula=""
-	local latest_minor=-1
-	local formula
-	while IFS= read -r formula; do
-		[[ -z "$formula" ]] && continue
-		local minor
-		minor="${formula#python@3.}"
-		if [[ "$minor" =~ ^[0-9]+$ ]] && ((minor > latest_minor)); then
-			latest_minor=$minor
-			latest_formula="$formula"
-		fi
-	done < <(brew search --formula '/^python@3\.[0-9]+$/' 2>/dev/null)
+	local latest_formula
+	latest_formula=$(brew search --formula '/^python@3\.[0-9]+$/' 2>/dev/null |
+		sort -t. -k2 -n -r | head -n 1)
 
 	if [[ -n "$latest_formula" ]]; then
 		echo "$latest_formula"
@@ -405,6 +396,77 @@ find_python3() {
 	fi
 
 	return 1
+}
+
+# Return the recommended Homebrew Python formula name.
+# Uses get_latest_homebrew_python_formula if brew is available, otherwise
+# falls back to a sensible default. Reads PYTHON_REQUIRED_MAJOR/MINOR from
+# the environment (exported by setup.sh).
+# Usage: local formula; formula=$(get_recommended_python_formula)
+get_recommended_python_formula() {
+	local formula="python@3.13"
+	if command -v brew >/dev/null 2>&1; then
+		local detected
+		detected=$(get_latest_homebrew_python_formula 2>/dev/null || true)
+		if [[ -n "$detected" ]]; then
+			formula="$detected"
+		fi
+	fi
+	echo "$formula"
+	return 0
+}
+
+# Offer to install or upgrade Python via Homebrew (interactive prompt).
+# Handles both "Python too old" and "Python not found" cases.
+# Arguments:
+#   $1 - action: "upgrade" or "install"
+#   $2 - recommended formula (e.g. python@3.13)
+# Prints status messages. Returns 0 on success, 1 on skip/failure.
+offer_python_brew_install() {
+	local action="$1"
+	local recommended_formula="$2"
+	local python_required_major="${PYTHON_REQUIRED_MAJOR:-3}"
+	local python_required_minor="${PYTHON_REQUIRED_MINOR:-10}"
+
+	if ! command -v brew >/dev/null 2>&1; then
+		# No Homebrew — print manual instructions
+		if [[ "$action" == "upgrade" ]]; then
+			echo "  Upgrade recommendation (macOS): brew install $recommended_formula"
+		else
+			echo "  Install recommendation: Python $python_required_major.$python_required_minor+"
+			echo "    Ubuntu/Debian: sudo apt install python3"
+			echo "    Fedora:        sudo dnf install python3"
+			echo "    Arch:          sudo pacman -S python"
+		fi
+		return 1
+	fi
+
+	local prompt_verb="Install"
+	[[ "$action" == "upgrade" ]] && prompt_verb="Install/upgrade"
+	echo "  ${prompt_verb} recommendation: brew install $recommended_formula"
+
+	read -r -p "${prompt_verb} Python via Homebrew now? [Y/n]: " install_python
+	if [[ "$install_python" =~ ^[Yy]?$ ]]; then
+		if run_with_spinner "Installing $recommended_formula" brew install "$recommended_formula"; then
+			local python3_bin
+			if python3_bin=$(find_python3); then
+				local python_version
+				python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
+				print_success "Python ${action}d and available: $python_version"
+				return 0
+			else
+				print_warning "Python formula installed, but python3 is not on PATH yet"
+				print_info "Restart your shell or use Homebrew's shellenv instructions"
+				return 1
+			fi
+		else
+			print_warning "Python ${action} failed (non-critical)"
+			return 1
+		fi
+	else
+		print_info "Skipped Python ${action}"
+		return 1
+	fi
 }
 
 # Install a package globally via npm or bun, with sudo when needed on Linux.

--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -445,8 +445,9 @@ offer_python_brew_install() {
 	[[ "$action" == "upgrade" ]] && prompt_verb="Install/upgrade"
 	echo "  ${prompt_verb} recommendation: brew install $recommended_formula"
 
-	# Skip interactive prompt in non-interactive/CI contexts
+	# Skip interactive prompt in CI or non-interactive runs
 	if [[ "${NON_INTERACTIVE:-false}" == "true" ]] || [[ ! -t 0 ]]; then
+		print_info "Skipped Python ${action} (non-interactive)"
 		return 1
 	fi
 

--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -445,6 +445,11 @@ offer_python_brew_install() {
 	[[ "$action" == "upgrade" ]] && prompt_verb="Install/upgrade"
 	echo "  ${prompt_verb} recommendation: brew install $recommended_formula"
 
+	# Skip interactive prompt in non-interactive/CI contexts
+	if [[ "${NON_INTERACTIVE:-false}" == "true" ]] || [[ ! -t 0 ]]; then
+		return 1
+	fi
+
 	read -r -p "${prompt_verb} Python via Homebrew now? [Y/n]: " install_python
 	if [[ "$install_python" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing $recommended_formula" brew install "$recommended_formula"; then

--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -313,6 +313,34 @@ find_opencode_config() {
 	return 1
 }
 
+# Return latest Homebrew python@3.x formula (e.g. python@3.13).
+# Returns 0 and prints formula on success, 1 if unavailable.
+get_latest_homebrew_python_formula() {
+	if ! command -v brew >/dev/null 2>&1; then
+		return 1
+	fi
+
+	local latest_formula=""
+	local latest_minor=-1
+	local formula
+	while IFS= read -r formula; do
+		[[ -z "$formula" ]] && continue
+		local minor
+		minor="${formula#python@3.}"
+		if [[ "$minor" =~ ^[0-9]+$ ]] && ((minor > latest_minor)); then
+			latest_minor=$minor
+			latest_formula="$formula"
+		fi
+	done < <(brew search --formula '/^python@3\.[0-9]+$/' 2>/dev/null)
+
+	if [[ -n "$latest_formula" ]]; then
+		echo "$latest_formula"
+		return 0
+	fi
+
+	return 1
+}
+
 # Find best python3 binary (prefer Homebrew/pyenv over system)
 find_python3() {
 	local candidates=(
@@ -320,17 +348,62 @@ find_python3() {
 		"/usr/local/bin/python3"
 		"$HOME/.pyenv/shims/python3"
 	)
+
+	# Add installed Homebrew versioned Python paths (including keg-only formulae)
+	if command -v brew >/dev/null 2>&1; then
+		local formula
+		while IFS= read -r formula; do
+			[[ -z "$formula" ]] && continue
+			local prefix
+			prefix=$(brew --prefix "$formula" 2>/dev/null || true)
+			[[ -z "$prefix" ]] && continue
+			local minor
+			minor="${formula#python@3.}"
+			candidates+=("$prefix/bin/python3")
+			candidates+=("$prefix/bin/python3.${minor}")
+		done < <(brew list --formula 2>/dev/null | awk '/^python@3\.[0-9]+$/ {print}')
+	fi
+
+	# Fallback to python3 on PATH
+	if command -v python3 >/dev/null 2>&1; then
+		candidates+=("$(command -v python3)")
+	fi
+
+	# Choose newest available Python by major.minor
+	local best_candidate=""
+	local best_major=-1
+	local best_minor=-1
+	local seen_candidates=" "
+	local candidate
 	for candidate in "${candidates[@]}"; do
-		if [[ -x "$candidate" ]]; then
-			echo "$candidate"
-			return 0
+		[[ -x "$candidate" ]] || continue
+		if [[ "$seen_candidates" == *" ${candidate} "* ]]; then
+			continue
+		fi
+		seen_candidates="${seen_candidates}${candidate} "
+
+		local version
+		version=$("$candidate" -c 'import sys; print("{}.{}".format(sys.version_info[0], sys.version_info[1]))' 2>/dev/null || true)
+		local major
+		major=$(echo "$version" | cut -d. -f1)
+		local minor
+		minor=$(echo "$version" | cut -d. -f2)
+		if [[ ! "$major" =~ ^[0-9]+$ ]] || [[ ! "$minor" =~ ^[0-9]+$ ]]; then
+			continue
+		fi
+
+		if ((major > best_major)) || { ((major == best_major)) && ((minor > best_minor)); }; then
+			best_major=$major
+			best_minor=$minor
+			best_candidate="$candidate"
 		fi
 	done
-	# Fallback to PATH
-	if command -v python3 &>/dev/null; then
-		command -v python3
+
+	if [[ -n "$best_candidate" ]]; then
+		echo "$best_candidate"
 		return 0
 	fi
+
 	return 1
 }
 

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -386,17 +386,10 @@ check_optional_deps() {
 	print_info "Checking optional dependencies..."
 
 	local missing_optional=()
-	local recommended_python_formula="python@3.13"
+	local recommended_python_formula
+	recommended_python_formula=$(get_recommended_python_formula)
 	local python_required_major="${PYTHON_REQUIRED_MAJOR:-3}"
 	local python_required_minor="${PYTHON_REQUIRED_MINOR:-10}"
-
-	if command -v brew >/dev/null 2>&1; then
-		local detected_python_formula
-		detected_python_formula=$(get_latest_homebrew_python_formula 2>/dev/null || true)
-		if [[ -n "$detected_python_formula" ]]; then
-			recommended_python_formula="$detected_python_formula"
-		fi
-	fi
 
 	if ! command -v sshpass >/dev/null 2>&1; then
 		missing_optional+=("sshpass")
@@ -417,55 +410,11 @@ check_optional_deps() {
 			print_success "Python $python_version found ($python_required_major.$python_required_minor+ required)"
 		else
 			print_warning "Python $python_version found, but $python_required_major.$python_required_minor+ is recommended for all skills/tools"
-			if command -v brew >/dev/null 2>&1; then
-				echo "  Upgrade recommendation: brew install $recommended_python_formula"
-				read -r -p "Install/upgrade Python via Homebrew now? [Y/n]: " install_python
-				if [[ "$install_python" =~ ^[Yy]?$ ]]; then
-					if run_with_spinner "Installing $recommended_python_formula" brew install "$recommended_python_formula"; then
-						if python3_bin=$(find_python3); then
-							python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
-							print_success "Python upgraded and available: $python_version"
-						else
-							print_warning "Python formula installed, but python3 is not on PATH yet"
-							print_info "Restart your shell or use Homebrew's shellenv instructions"
-						fi
-					else
-						print_warning "Python upgrade failed (non-critical)"
-					fi
-				else
-					print_info "Skipped Python upgrade"
-				fi
-			else
-				echo "  Upgrade recommendation (macOS): brew install $recommended_python_formula"
-			fi
+			offer_python_brew_install "upgrade" "$recommended_python_formula" || true
 		fi
 	else
 		print_warning "Python 3 not found"
-		if command -v brew >/dev/null 2>&1; then
-			echo "  Install recommendation: brew install $recommended_python_formula"
-			read -r -p "Install Python via Homebrew now? [Y/n]: " install_python
-			if [[ "$install_python" =~ ^[Yy]?$ ]]; then
-				if run_with_spinner "Installing $recommended_python_formula" brew install "$recommended_python_formula"; then
-					if python3_bin=$(find_python3); then
-						local installed_python_version
-						installed_python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
-						print_success "Python installed: $installed_python_version"
-					else
-						print_warning "Python formula installed, but python3 is not on PATH yet"
-						print_info "Restart your shell or use Homebrew's shellenv instructions"
-					fi
-				else
-					print_warning "Python installation failed (non-critical)"
-				fi
-			else
-				print_info "Skipped Python installation"
-			fi
-		else
-			echo "  Install recommendation: Python $python_required_major.$python_required_minor+"
-			echo "    Ubuntu/Debian: sudo apt install python3"
-			echo "    Fedora:        sudo dnf install python3"
-			echo "    Arch:          sudo pacman -S python"
-		fi
+		offer_python_brew_install "install" "$recommended_python_formula" || true
 	fi
 
 	if [[ ${#missing_optional[@]} -gt 0 ]]; then

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -386,11 +386,86 @@ check_optional_deps() {
 	print_info "Checking optional dependencies..."
 
 	local missing_optional=()
+	local recommended_python_formula="python@3.13"
+	local python_required_major="${PYTHON_REQUIRED_MAJOR:-3}"
+	local python_required_minor="${PYTHON_REQUIRED_MINOR:-10}"
+
+	if command -v brew >/dev/null 2>&1; then
+		local detected_python_formula
+		detected_python_formula=$(get_latest_homebrew_python_formula 2>/dev/null || true)
+		if [[ -n "$detected_python_formula" ]]; then
+			recommended_python_formula="$detected_python_formula"
+		fi
+	fi
 
 	if ! command -v sshpass >/dev/null 2>&1; then
 		missing_optional+=("sshpass")
 	else
 		print_success "sshpass found"
+	fi
+
+	local python3_bin=""
+	if python3_bin=$(find_python3); then
+		local python_version
+		python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
+		local python_major
+		python_major=$(echo "$python_version" | cut -d. -f1)
+		local python_minor
+		python_minor=$(echo "$python_version" | cut -d. -f2)
+
+		if [[ "$python_major" =~ ^[0-9]+$ ]] && [[ "$python_minor" =~ ^[0-9]+$ ]] && { ((python_major > python_required_major)) || { ((python_major == python_required_major)) && ((python_minor >= python_required_minor)); }; }; then
+			print_success "Python $python_version found ($python_required_major.$python_required_minor+ required)"
+		else
+			print_warning "Python $python_version found, but $python_required_major.$python_required_minor+ is recommended for all skills/tools"
+			if command -v brew >/dev/null 2>&1; then
+				echo "  Upgrade recommendation: brew install $recommended_python_formula"
+				read -r -p "Install/upgrade Python via Homebrew now? [Y/n]: " install_python
+				if [[ "$install_python" =~ ^[Yy]?$ ]]; then
+					if run_with_spinner "Installing $recommended_python_formula" brew install "$recommended_python_formula"; then
+						if python3_bin=$(find_python3); then
+							python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
+							print_success "Python upgraded and available: $python_version"
+						else
+							print_warning "Python formula installed, but python3 is not on PATH yet"
+							print_info "Restart your shell or use Homebrew's shellenv instructions"
+						fi
+					else
+						print_warning "Python upgrade failed (non-critical)"
+					fi
+				else
+					print_info "Skipped Python upgrade"
+				fi
+			else
+				echo "  Upgrade recommendation (macOS): brew install $recommended_python_formula"
+			fi
+		fi
+	else
+		print_warning "Python 3 not found"
+		if command -v brew >/dev/null 2>&1; then
+			echo "  Install recommendation: brew install $recommended_python_formula"
+			read -r -p "Install Python via Homebrew now? [Y/n]: " install_python
+			if [[ "$install_python" =~ ^[Yy]?$ ]]; then
+				if run_with_spinner "Installing $recommended_python_formula" brew install "$recommended_python_formula"; then
+					if python3_bin=$(find_python3); then
+						local installed_python_version
+						installed_python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
+						print_success "Python installed: $installed_python_version"
+					else
+						print_warning "Python formula installed, but python3 is not on PATH yet"
+						print_info "Restart your shell or use Homebrew's shellenv instructions"
+					fi
+				else
+					print_warning "Python installation failed (non-critical)"
+				fi
+			else
+				print_info "Skipped Python installation"
+			fi
+		else
+			echo "  Install recommendation: Python $python_required_major.$python_required_minor+"
+			echo "    Ubuntu/Debian: sudo apt install python3"
+			echo "    Fedora:        sudo dnf install python3"
+			echo "    Arch:          sudo pacman -S python"
+		fi
 	fi
 
 	if [[ ${#missing_optional[@]} -gt 0 ]]; then

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1375,35 +1375,27 @@ setup_ai_orchestration() {
 	local recommended_python_formula
 	recommended_python_formula=$(get_recommended_python_formula)
 
-	# Check Python (prefer Homebrew/pyenv over system)
+	# Check Python (prefer Homebrew/pyenv over system) — uses shared helpers
+	# from _common.sh (get_recommended_python_formula, find_python3,
+	# offer_python_brew_install) to avoid duplicating version-check logic.
 	local python3_bin
 	if python3_bin=$(find_python3); then
 		local python_version
-		python_version=$("$python3_bin" --version 2>&1 | cut -d' ' -f2)
+		python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
 		local major minor
 		major=$(echo "$python_version" | cut -d. -f1)
 		minor=$(echo "$python_version" | cut -d. -f2)
 
-		if ((major > python_required_major)) || { ((major == python_required_major)) && ((minor >= python_required_minor)); }; then
+		if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$minor" =~ ^[0-9]+$ ]] && { ((major > python_required_major)) || { ((major == python_required_major)) && ((minor >= python_required_minor)); }; }; then
 			has_python=true
 			print_success "Python $python_version found ($python_required_major.$python_required_minor+ required)"
 		else
 			print_warning "Python $python_required_major.$python_required_minor+ required for AI orchestration, found $python_version"
-			echo ""
-			echo "  Upgrade options:"
-			echo "    macOS (Homebrew): brew install $recommended_python_formula"
-			echo "    macOS (pyenv):    pyenv install 3.13 && pyenv global 3.13"
-			echo "    Ubuntu/Debian:    sudo apt install python3"
-			echo "    Fedora:           sudo dnf install python3"
-			echo ""
+			offer_python_brew_install "upgrade" "$recommended_python_formula" || true
 		fi
 	else
 		print_warning "Python 3 not found - AI orchestration frameworks unavailable"
-		echo ""
-		echo "  Install options:"
-		echo "    macOS: brew install $recommended_python_formula"
-		echo "    Linux: sudo apt install python3 (or dnf/pacman)"
-		echo ""
+		offer_python_brew_install "install" "$recommended_python_formula" || true
 		return 0
 	fi
 

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1372,14 +1372,8 @@ setup_ai_orchestration() {
 	local has_python=false
 	local python_required_major="${PYTHON_REQUIRED_MAJOR:-3}"
 	local python_required_minor="${PYTHON_REQUIRED_MINOR:-10}"
-	local recommended_python_formula="python@3.13"
-	if command -v brew >/dev/null 2>&1; then
-		local detected_python_formula
-		detected_python_formula=$(get_latest_homebrew_python_formula 2>/dev/null || true)
-		if [[ -n "$detected_python_formula" ]]; then
-			recommended_python_formula="$detected_python_formula"
-		fi
-	fi
+	local recommended_python_formula
+	recommended_python_formula=$(get_recommended_python_formula)
 
 	# Check Python (prefer Homebrew/pyenv over system)
 	local python3_bin

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1370,6 +1370,16 @@ setup_ai_orchestration() {
 	print_info "Setting up AI orchestration frameworks..."
 
 	local has_python=false
+	local python_required_major="${PYTHON_REQUIRED_MAJOR:-3}"
+	local python_required_minor="${PYTHON_REQUIRED_MINOR:-10}"
+	local recommended_python_formula="python@3.13"
+	if command -v brew >/dev/null 2>&1; then
+		local detected_python_formula
+		detected_python_formula=$(get_latest_homebrew_python_formula 2>/dev/null || true)
+		if [[ -n "$detected_python_formula" ]]; then
+			recommended_python_formula="$detected_python_formula"
+		fi
+	fi
 
 	# Check Python (prefer Homebrew/pyenv over system)
 	local python3_bin
@@ -1380,24 +1390,24 @@ setup_ai_orchestration() {
 		major=$(echo "$python_version" | cut -d. -f1)
 		minor=$(echo "$python_version" | cut -d. -f2)
 
-		if [[ $major -ge 3 ]] && [[ $minor -ge 10 ]]; then
+		if ((major > python_required_major)) || { ((major == python_required_major)) && ((minor >= python_required_minor)); }; then
 			has_python=true
-			print_success "Python $python_version found (3.10+ required)"
+			print_success "Python $python_version found ($python_required_major.$python_required_minor+ required)"
 		else
-			print_warning "Python 3.10+ required for AI orchestration, found $python_version"
+			print_warning "Python $python_required_major.$python_required_minor+ required for AI orchestration, found $python_version"
 			echo ""
 			echo "  Upgrade options:"
-			echo "    macOS (Homebrew): brew install python@3.12"
-			echo "    macOS (pyenv):    pyenv install 3.12 && pyenv global 3.12"
-			echo "    Ubuntu/Debian:    sudo apt install python3.12"
-			echo "    Fedora:           sudo dnf install python3.12"
+			echo "    macOS (Homebrew): brew install $recommended_python_formula"
+			echo "    macOS (pyenv):    pyenv install 3.13 && pyenv global 3.13"
+			echo "    Ubuntu/Debian:    sudo apt install python3"
+			echo "    Fedora:           sudo dnf install python3"
 			echo ""
 		fi
 	else
 		print_warning "Python 3 not found - AI orchestration frameworks unavailable"
 		echo ""
 		echo "  Install options:"
-		echo "    macOS: brew install python@3.12"
+		echo "    macOS: brew install $recommended_python_formula"
 		echo "    Linux: sudo apt install python3 (or dnf/pacman)"
 		echo ""
 		return 0

--- a/setup.sh
+++ b/setup.sh
@@ -33,6 +33,7 @@ UPDATE_TOOLS_MODE=false
 # Keep in sync with setup-modules/plugins.sh requirements.
 PYTHON_REQUIRED_MAJOR=3
 PYTHON_REQUIRED_MINOR=10
+export PYTHON_REQUIRED_MAJOR PYTHON_REQUIRED_MINOR
 # Platform constants — exported for sourced setup-modules (shell-env.sh,
 # tool-install.sh) that reference them at runtime.
 PLATFORM_MACOS=$([[ "$(uname -s)" == "Darwin" ]] && echo true || echo false)
@@ -366,99 +367,8 @@ find_opencode_config() {
 	return 1
 }
 
-# Return latest Homebrew python@3.x formula (e.g. python@3.13).
-# Returns 0 and prints formula on success, 1 if unavailable.
-get_latest_homebrew_python_formula() {
-	if ! command -v brew >/dev/null 2>&1; then
-		return 1
-	fi
-
-	local latest_formula=""
-	local latest_minor=-1
-	local formula
-	while IFS= read -r formula; do
-		[[ -z "$formula" ]] && continue
-		local minor
-		minor="${formula#python@3.}"
-		if [[ "$minor" =~ ^[0-9]+$ ]] && ((minor > latest_minor)); then
-			latest_minor=$minor
-			latest_formula="$formula"
-		fi
-	done < <(brew search --formula '/^python@3\.[0-9]+$/' 2>/dev/null)
-
-	if [[ -n "$latest_formula" ]]; then
-		echo "$latest_formula"
-		return 0
-	fi
-
-	return 1
-}
-
-# Find best python3 binary (prefer Homebrew/pyenv over system)
-find_python3() {
-	local candidates=(
-		"/opt/homebrew/bin/python3"
-		"/usr/local/bin/python3"
-		"$HOME/.pyenv/shims/python3"
-	)
-
-	# Add installed Homebrew versioned Python paths (including keg-only formulae)
-	if command -v brew >/dev/null 2>&1; then
-		local formula
-		while IFS= read -r formula; do
-			[[ -z "$formula" ]] && continue
-			local prefix
-			prefix=$(brew --prefix "$formula" 2>/dev/null || true)
-			[[ -z "$prefix" ]] && continue
-			local minor
-			minor="${formula#python@3.}"
-			candidates+=("$prefix/bin/python3")
-			candidates+=("$prefix/bin/python3.${minor}")
-		done < <(brew list --formula 2>/dev/null | awk '/^python@3\.[0-9]+$/ {print}')
-	fi
-
-	# Fallback to python3 on PATH
-	if command -v python3 >/dev/null 2>&1; then
-		candidates+=("$(command -v python3)")
-	fi
-
-	# Choose newest available Python by major.minor
-	local best_candidate=""
-	local best_major=-1
-	local best_minor=-1
-	local seen_candidates=" "
-	local candidate
-	for candidate in "${candidates[@]}"; do
-		[[ -x "$candidate" ]] || continue
-		if [[ "$seen_candidates" == *" ${candidate} "* ]]; then
-			continue
-		fi
-		seen_candidates="${seen_candidates}${candidate} "
-
-		local version
-		version=$("$candidate" -c 'import sys; print("{}.{}".format(sys.version_info[0], sys.version_info[1]))' 2>/dev/null || true)
-		local major
-		major=$(echo "$version" | cut -d. -f1)
-		local minor
-		minor=$(echo "$version" | cut -d. -f2)
-		if [[ ! "$major" =~ ^[0-9]+$ ]] || [[ ! "$minor" =~ ^[0-9]+$ ]]; then
-			continue
-		fi
-
-		if ((major > best_major)) || { ((major == best_major)) && ((minor > best_minor)); }; then
-			best_major=$major
-			best_minor=$minor
-			best_candidate="$candidate"
-		fi
-	done
-
-	if [[ -n "$best_candidate" ]]; then
-		echo "$best_candidate"
-		return 0
-	fi
-
-	return 1
-}
+# get_latest_homebrew_python_formula() and find_python3() are defined in
+# _common.sh (sourced above). Not duplicated here — see GH#5239 review.
 
 # Install a package globally via npm, with sudo when needed on Linux.
 # Usage: npm_global_install "package-name" OR npm_global_install "package@version"

--- a/setup.sh
+++ b/setup.sh
@@ -29,6 +29,10 @@ CLEAN_MODE=false
 INTERACTIVE_MODE=false
 NON_INTERACTIVE="${AIDEVOPS_NON_INTERACTIVE:-false}"
 UPDATE_TOOLS_MODE=false
+# Python compatibility floor used by setup checks and skill/tool gating.
+# Keep in sync with setup-modules/plugins.sh requirements.
+PYTHON_REQUIRED_MAJOR=3
+PYTHON_REQUIRED_MINOR=10
 # Platform constants — exported for sourced setup-modules (shell-env.sh,
 # tool-install.sh) that reference them at runtime.
 PLATFORM_MACOS=$([[ "$(uname -s)" == "Darwin" ]] && echo true || echo false)
@@ -362,6 +366,34 @@ find_opencode_config() {
 	return 1
 }
 
+# Return latest Homebrew python@3.x formula (e.g. python@3.13).
+# Returns 0 and prints formula on success, 1 if unavailable.
+get_latest_homebrew_python_formula() {
+	if ! command -v brew >/dev/null 2>&1; then
+		return 1
+	fi
+
+	local latest_formula=""
+	local latest_minor=-1
+	local formula
+	while IFS= read -r formula; do
+		[[ -z "$formula" ]] && continue
+		local minor
+		minor="${formula#python@3.}"
+		if [[ "$minor" =~ ^[0-9]+$ ]] && ((minor > latest_minor)); then
+			latest_minor=$minor
+			latest_formula="$formula"
+		fi
+	done < <(brew search --formula '/^python@3\.[0-9]+$/' 2>/dev/null)
+
+	if [[ -n "$latest_formula" ]]; then
+		echo "$latest_formula"
+		return 0
+	fi
+
+	return 1
+}
+
 # Find best python3 binary (prefer Homebrew/pyenv over system)
 find_python3() {
 	local candidates=(
@@ -369,17 +401,62 @@ find_python3() {
 		"/usr/local/bin/python3"
 		"$HOME/.pyenv/shims/python3"
 	)
+
+	# Add installed Homebrew versioned Python paths (including keg-only formulae)
+	if command -v brew >/dev/null 2>&1; then
+		local formula
+		while IFS= read -r formula; do
+			[[ -z "$formula" ]] && continue
+			local prefix
+			prefix=$(brew --prefix "$formula" 2>/dev/null || true)
+			[[ -z "$prefix" ]] && continue
+			local minor
+			minor="${formula#python@3.}"
+			candidates+=("$prefix/bin/python3")
+			candidates+=("$prefix/bin/python3.${minor}")
+		done < <(brew list --formula 2>/dev/null | awk '/^python@3\.[0-9]+$/ {print}')
+	fi
+
+	# Fallback to python3 on PATH
+	if command -v python3 >/dev/null 2>&1; then
+		candidates+=("$(command -v python3)")
+	fi
+
+	# Choose newest available Python by major.minor
+	local best_candidate=""
+	local best_major=-1
+	local best_minor=-1
+	local seen_candidates=" "
+	local candidate
 	for candidate in "${candidates[@]}"; do
-		if [[ -x "$candidate" ]]; then
-			echo "$candidate"
-			return 0
+		[[ -x "$candidate" ]] || continue
+		if [[ "$seen_candidates" == *" ${candidate} "* ]]; then
+			continue
+		fi
+		seen_candidates="${seen_candidates}${candidate} "
+
+		local version
+		version=$("$candidate" -c 'import sys; print("{}.{}".format(sys.version_info[0], sys.version_info[1]))' 2>/dev/null || true)
+		local major
+		major=$(echo "$version" | cut -d. -f1)
+		local minor
+		minor=$(echo "$version" | cut -d. -f2)
+		if [[ ! "$major" =~ ^[0-9]+$ ]] || [[ ! "$minor" =~ ^[0-9]+$ ]]; then
+			continue
+		fi
+
+		if ((major > best_major)) || { ((major == best_major)) && ((minor > best_minor)); }; then
+			best_major=$major
+			best_minor=$minor
+			best_candidate="$candidate"
 		fi
 	done
-	# Fallback to PATH
-	if command -v python3 &>/dev/null; then
-		command -v python3
+
+	if [[ -n "$best_candidate" ]]; then
+		echo "$best_candidate"
 		return 0
 	fi
+
 	return 1
 }
 


### PR DESCRIPTION
## Summary
- add shared Python requirement constants and Homebrew formula discovery helper so setup can detect the latest stable `python@3.x` formula dynamically
- upgrade Python binary resolution to prefer the newest installed interpreter (including keg-only Homebrew `python@3.x` installs)
- extend setup dependency checks to validate Python recency, prompt optional Homebrew install/upgrade, and align AI orchestration guidance with dynamic recommendations

## Verification
- `shellcheck setup.sh setup-modules/shell-env.sh setup-modules/tool-install.sh .agents/scripts/setup/_common.sh`
- `bash -n setup.sh setup-modules/shell-env.sh setup-modules/tool-install.sh .agents/scripts/setup/_common.sh`

Closes #5237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Python detection with version-aware requirement checks during setup
  * Automatic identification and recommendation of the latest Homebrew Python formula
  * Interactive Homebrew-based install/upgrade prompts when Python is missing or outdated
  * Centralized, configurable Python compatibility floor used across setup flows
  * Improved messaging, validation, and user feedback for Python installation and version compatibility
<!-- end of auto-generated comment: release notes by coderabbit.ai -->