### PR TITLE
GH#5240: Clarify setup user flow - reduce confusion from skipped/queued items

### DIFF
--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -7,6 +7,7 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
+GRAY='\033[0;90m'
 NC='\033[0m' # No Color
 
 # Print functions
@@ -14,6 +15,111 @@ print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
 print_warning() { echo -e "${YELLOW}[WARNING]${NC} $1"; }
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+# =============================================================================
+# Setup summary tracker (GH#5240)
+# Tracks what was configured, skipped, and deferred during setup so we can
+# print a clear summary at the end. Uses indexed arrays (bash 3.2 compatible).
+# =============================================================================
+_SETUP_CONFIGURED=()
+_SETUP_SKIPPED=()
+_SETUP_DEFERRED=()
+
+# Record a successfully configured item
+# Usage: setup_track_configured "Google Analytics MCP"
+setup_track_configured() {
+	_SETUP_CONFIGURED+=("$1")
+	return 0
+}
+
+# Record a skipped item with reason
+# Usage: setup_track_skipped "Google Analytics MCP" "OpenCode config not found"
+setup_track_skipped() {
+	local item="$1"
+	local reason="${2:-}"
+	if [[ -n "$reason" ]]; then
+		_SETUP_SKIPPED+=("${item}: ${reason}")
+	else
+		_SETUP_SKIPPED+=("$item")
+	fi
+	return 0
+}
+
+# Record a deferred item with action needed
+# Usage: setup_track_deferred "Google Analytics MCP" "Install pipx, then re-run setup"
+setup_track_deferred() {
+	local item="$1"
+	local action="${2:-}"
+	if [[ -n "$action" ]]; then
+		_SETUP_DEFERRED+=("${item}: ${action}")
+	else
+		_SETUP_DEFERRED+=("$item")
+	fi
+	return 0
+}
+
+# Print a prerequisite-skip message (replaces the confusing "Setting up X... skipping" pattern)
+# Shows what was skipped, why, and what to do about it — without first saying "Setting up..."
+# Usage: print_skip "Google Analytics MCP" "OpenCode not installed" "Install OpenCode first: https://opencode.ai"
+print_skip() {
+	local item="$1"
+	local reason="$2"
+	local action="${3:-}"
+	echo -e "${GRAY}[SKIP]${NC} ${item} -- ${reason}"
+	if [[ -n "$action" ]]; then
+		echo -e "       ${BLUE}>>>${NC} ${action}"
+	fi
+	return 0
+}
+
+# Print the setup summary at the end of the run
+# Shows: configured items, skipped items (with reasons), deferred items (with actions)
+print_setup_summary() {
+	local configured_count=${#_SETUP_CONFIGURED[@]}
+	local skipped_count=${#_SETUP_SKIPPED[@]}
+	local deferred_count=${#_SETUP_DEFERRED[@]}
+
+	# Only print summary if there's something to report
+	if [[ $configured_count -eq 0 && $skipped_count -eq 0 && $deferred_count -eq 0 ]]; then
+		return 0
+	fi
+
+	echo ""
+	echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+	echo -e "${BLUE}  Setup Summary${NC}"
+	echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+
+	if [[ $configured_count -gt 0 ]]; then
+		echo ""
+		echo -e "  ${GREEN}Configured ($configured_count):${NC}"
+		local item
+		for item in "${_SETUP_CONFIGURED[@]}"; do
+			echo -e "    ${GREEN}+${NC} $item"
+		done
+	fi
+
+	if [[ $skipped_count -gt 0 ]]; then
+		echo ""
+		echo -e "  ${GRAY}Skipped ($skipped_count):${NC}"
+		local item
+		for item in "${_SETUP_SKIPPED[@]}"; do
+			echo -e "    ${GRAY}-${NC} $item"
+		done
+	fi
+
+	if [[ $deferred_count -gt 0 ]]; then
+		echo ""
+		echo -e "  ${YELLOW}Deferred ($deferred_count) -- complete these to enable:${NC}"
+		local item
+		for item in "${_SETUP_DEFERRED[@]}"; do
+			echo -e "    ${YELLOW}!${NC} $item"
+		done
+	fi
+
+	echo ""
+	echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+	return 0
+}
 
 # Spinner for long-running operations
 # Usage: run_with_spinner "Installing package..." command arg1 arg2

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -10,6 +10,13 @@ trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
 shopt -s inherit_errexit 2>/dev/null || true
 
 install_mcp_packages() {
+	# Check prerequisites before announcing setup (GH#5240)
+	if ! command -v bun &>/dev/null && ! command -v npm &>/dev/null; then
+		print_skip "MCP packages" "neither bun nor npm found" "Install bun: brew install oven-sh/bun/bun (or npm via Node.js)"
+		setup_track_deferred "MCP packages" "Install bun or npm"
+		return 0
+	fi
+
 	print_info "Installing MCP server packages globally (eliminates npx startup delay)..."
 
 	# Security note: MCP servers run as persistent processes with access to conversation
@@ -26,12 +33,6 @@ install_mcp_packages() {
 		"@steipete/macos-automator-mcp"
 		"@steipete/claude-code-mcp"
 	)
-
-	if ! command -v bun &>/dev/null && ! command -v npm &>/dev/null; then
-		print_warning "Neither bun nor npm found - cannot install MCP packages"
-		print_info "Install bun (recommended): npm install -g bun OR brew install oven-sh/bun/bun"
-		return 0
-	fi
 
 	local installer="npm"
 	command -v bun &>/dev/null && installer="bun"
@@ -205,36 +206,33 @@ update_mcp_paths_in_opencode() {
 }
 
 setup_localwp_mcp() {
-	print_info "Setting up LocalWP MCP server..."
-
-	# Check if LocalWP is installed
+	# Check prerequisites before announcing setup (GH#5240)
 	local localwp_found=false
 	if [[ -d "/Applications/Local.app" ]] || [[ -d "$HOME/Applications/Local.app" ]]; then
 		localwp_found=true
 	fi
 
 	if [[ "$localwp_found" != "true" ]]; then
-		print_info "LocalWP not found - skipping MCP server setup"
-		print_info "Install LocalWP from: https://localwp.com/"
+		print_skip "LocalWP MCP" "LocalWP not installed" "Install from https://localwp.com/ then re-run setup"
+		setup_track_skipped "LocalWP MCP" "LocalWP not installed"
 		return 0
 	fi
 
-	print_success "LocalWP found"
-
-	# Check if npm is available
 	if ! command -v npm &>/dev/null; then
-		print_warning "npm not found - cannot install LocalWP MCP server"
-		print_info "Install Node.js and npm first"
+		print_skip "LocalWP MCP" "npm not found" "Install Node.js and npm first"
+		setup_track_deferred "LocalWP MCP" "Install Node.js/npm, then re-run setup"
 		return 0
 	fi
 
-	# Check if mcp-local-wp is already installed
+	# Prerequisites met — proceed with setup
+	print_info "Setting up LocalWP MCP server..."
+
 	if command -v mcp-local-wp &>/dev/null; then
 		print_success "LocalWP MCP server already installed"
+		setup_track_configured "LocalWP MCP"
 		return 0
 	fi
 
-	# Offer to install mcp-local-wp
 	print_info "LocalWP MCP server enables AI assistants to query WordPress databases"
 	read -r -p "Install LocalWP MCP server (@verygoodplugins/mcp-local-wp)? [Y/n]: " install_mcp
 
@@ -242,6 +240,7 @@ setup_localwp_mcp() {
 		if run_with_spinner "Installing LocalWP MCP server" npm_global_install "@verygoodplugins/mcp-local-wp"; then
 			print_info "Start with: ~/.aidevops/agents/scripts/localhost-helper.sh start-mcp"
 			print_info "Or configure in OpenCode MCP settings for auto-start"
+			setup_track_configured "LocalWP MCP"
 		else
 			print_info "Try manually: sudo npm install -g @verygoodplugins/mcp-local-wp"
 		fi
@@ -254,48 +253,47 @@ setup_localwp_mcp() {
 }
 
 setup_augment_context_engine() {
-	print_info "Setting up Augment Context Engine MCP..."
-
-	# Check Node.js version (requires 22+)
+	# Check prerequisites before announcing setup (GH#5240)
 	if ! command -v node &>/dev/null; then
-		print_warning "Node.js not found - Augment Context Engine setup skipped"
-		print_info "Install Node.js 22+ to enable Augment Context Engine"
-		return
+		print_skip "Augment Context Engine" "Node.js not installed" "Install Node.js 22+: brew install node@22 (macOS) or nvm install 22"
+		setup_track_deferred "Augment Context Engine" "Install Node.js 22+"
+		return 0
 	fi
 
 	local node_version
 	node_version=$(node --version 2>/dev/null | cut -d'v' -f2 | cut -d'.' -f1)
 	if [[ -z "$node_version" ]] || ! [[ "$node_version" =~ ^[0-9]+$ ]]; then
-		print_warning "Could not determine Node.js version - Augment Context Engine setup skipped"
-		return
+		print_skip "Augment Context Engine" "could not determine Node.js version"
+		setup_track_skipped "Augment Context Engine" "Node.js version unknown"
+		return 0
 	fi
 	if [[ "$node_version" -lt 22 ]]; then
-		print_warning "Node.js 22+ required for Augment Context Engine, found v$node_version"
-		print_info "Install: brew install node@22 (macOS) or nvm install 22"
-		return
+		print_skip "Augment Context Engine" "requires Node.js 22+, found v$node_version" "Upgrade: brew install node@22 (macOS) or nvm install 22"
+		setup_track_deferred "Augment Context Engine" "Upgrade Node.js to 22+ (currently v$node_version)"
+		return 0
 	fi
 
-	# Check if auggie is installed
 	if ! command -v auggie &>/dev/null; then
-		print_warning "Auggie CLI not found"
-		print_info "Install with: npm install -g @augmentcode/auggie@prerelease"
-		print_info "Then run: auggie login"
-		return
+		print_skip "Augment Context Engine" "Auggie CLI not installed" "Install: npm install -g @augmentcode/auggie@prerelease && auggie login"
+		setup_track_deferred "Augment Context Engine" "Install Auggie CLI: npm install -g @augmentcode/auggie@prerelease"
+		return 0
 	fi
 
-	# Check if logged in
 	if [[ ! -f "$HOME/.augment/session.json" ]]; then
-		print_warning "Auggie not logged in"
-		print_info "Run: auggie login"
-		return
+		print_skip "Augment Context Engine" "Auggie not logged in" "Run: auggie login"
+		setup_track_deferred "Augment Context Engine" "Run: auggie login"
+		return 0
 	fi
 
+	# Prerequisites met — proceed with setup
+	print_info "Setting up Augment Context Engine MCP..."
 	print_success "Auggie CLI found and authenticated"
 
 	# MCP configuration is handled by generate-opencode-agents.sh for OpenCode
 
 	print_info "Augment Context Engine available as MCP in OpenCode"
 	print_info "Verification: 'What is this project? Please use codebase retrieval tool.'"
+	setup_track_configured "Augment Context Engine"
 
 	return 0
 }
@@ -479,34 +477,35 @@ add_opencode_plugin() {
 }
 
 setup_opencode_plugins() {
-	print_info "Setting up OpenCode plugins..."
-
-	# Check if OpenCode is installed
+	# Check prerequisites before announcing setup (GH#5240)
 	if ! command -v opencode &>/dev/null; then
-		print_warning "OpenCode not found - plugin setup skipped"
-		print_info "Install OpenCode first: https://opencode.ai"
+		print_skip "OpenCode plugins" "OpenCode not installed" "Install from https://opencode.ai"
+		setup_track_skipped "OpenCode plugins" "OpenCode not installed"
 		return 0
 	fi
 
-	# Check if config exists
 	local opencode_config
 	if ! opencode_config=$(find_opencode_config); then
-		print_warning "OpenCode config not found - plugin setup skipped"
+		print_skip "OpenCode plugins" "OpenCode config not found" "Run 'opencode' once to create config, then re-run setup"
+		setup_track_deferred "OpenCode plugins" "Run 'opencode' once to create config"
 		return 0
 	fi
 
-	# Check if jq is available
 	if ! command -v jq &>/dev/null; then
-		print_warning "jq not found - cannot update OpenCode config"
+		print_skip "OpenCode plugins" "jq not installed" "Install jq: brew install jq (macOS) or apt install jq"
+		setup_track_deferred "OpenCode plugins" "Install jq"
 		return 0
 	fi
+
+	# Prerequisites met — proceed with setup
+	print_info "Setting up OpenCode plugins..."
 
 	# Setup aidevops compaction plugin (local file plugin)
 	local aidevops_plugin_path="$HOME/.aidevops/agents/plugins/opencode-aidevops/index.mjs"
 	if [[ -f "$aidevops_plugin_path" ]]; then
-		print_info "Setting up aidevops compaction plugin..."
 		add_opencode_plugin "file://$HOME/.aidevops" "file://${aidevops_plugin_path}" "$opencode_config"
 		print_success "aidevops compaction plugin registered (preserves context across compaction)"
+		setup_track_configured "OpenCode plugins"
 	fi
 
 	# Note: opencode-anthropic-auth is built into OpenCode v1.1.36+
@@ -514,7 +513,7 @@ setup_opencode_plugins() {
 	# Removed in v2.90.0 - see PR #230.
 
 	print_info "After setup, authenticate with: opencode auth login"
-	print_info "  • For Claude OAuth: Select 'Anthropic' → 'Claude Pro/Max' (built-in)"
+	print_info "  - For Claude OAuth: Select 'Anthropic' -> 'Claude Pro/Max' (built-in)"
 
 	return 0
 }
@@ -566,31 +565,30 @@ setup_seo_mcps() {
 }
 
 setup_google_analytics_mcp() {
-	print_info "Setting up Google Analytics MCP..."
-
 	local gsc_creds="$HOME/.config/aidevops/gsc-credentials.json"
 
-	# Check if opencode.json exists
+	# Check prerequisites before announcing setup (GH#5240)
 	local opencode_config
 	if ! opencode_config=$(find_opencode_config); then
-		print_warning "OpenCode config not found - skipping Google Analytics MCP"
+		print_skip "Google Analytics MCP" "OpenCode config not found" "Run 'opencode' once to create config, then re-run setup"
+		setup_track_skipped "Google Analytics MCP" "OpenCode config not found"
 		return 0
 	fi
 
-	# Check if jq is available
 	if ! command -v jq &>/dev/null; then
-		print_warning "jq not found - cannot add Google Analytics MCP to config"
-		print_info "Install jq and re-run setup, or manually add the MCP config"
+		print_skip "Google Analytics MCP" "jq not installed" "Install jq: brew install jq (macOS) or apt install jq"
+		setup_track_deferred "Google Analytics MCP" "Install jq"
 		return 0
 	fi
 
-	# Check if pipx is available
 	if ! command -v pipx &>/dev/null; then
-		print_warning "pipx not found - Google Analytics MCP requires pipx"
-		print_info "Install pipx: brew install pipx (macOS) or pip install pipx"
-		print_info "Then re-run setup to add Google Analytics MCP"
+		print_skip "Google Analytics MCP" "pipx not installed" "Install pipx: brew install pipx (macOS) or pip install pipx"
+		setup_track_deferred "Google Analytics MCP" "Install pipx"
 		return 0
 	fi
+
+	# Prerequisites met — proceed with setup
+	print_info "Setting up Google Analytics MCP..."
 
 	# Auto-detect credentials from shared GSC service account
 	local creds_path=""
@@ -672,18 +670,19 @@ setup_google_analytics_mcp() {
 }
 
 setup_quickfile_mcp() {
-	print_info "Setting up QuickFile MCP server..."
-
 	local quickfile_dir="$HOME/Git/quickfile-mcp"
 	local credentials_dir="$HOME/.config/.quickfile-mcp"
 	local credentials_file="$credentials_dir/credentials.json"
 
-	# Check if Node.js is available
+	# Check prerequisites before announcing setup (GH#5240)
 	if ! command -v node &>/dev/null; then
-		print_warning "Node.js not found - QuickFile MCP setup skipped"
-		print_info "Install Node.js 18+ to enable QuickFile MCP"
+		print_skip "QuickFile MCP" "Node.js not installed" "Install Node.js 18+: brew install node (macOS) or nvm install 18"
+		setup_track_deferred "QuickFile MCP" "Install Node.js 18+"
 		return 0
 	fi
+
+	# Prerequisites met — proceed with setup
+	print_info "Setting up QuickFile MCP server..."
 
 	# Check if already cloned and built
 	if [[ -f "$quickfile_dir/dist/index.js" ]]; then

--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -117,12 +117,13 @@ deploy_plugins() {
 	local target_dir="$1"
 	local plugins_file="$2"
 
-	# Skip if no plugins.json or no jq
+	# Skip if no plugins.json or no jq (GH#5240: clear skip messages)
 	if [[ ! -f "$plugins_file" ]]; then
 		return 0
 	fi
 	if ! command -v jq &>/dev/null; then
-		print_warning "jq not found; skipping plugin deployment"
+		print_skip "Plugin deployment" "jq not installed" "Install jq: brew install jq (macOS) or apt install jq"
+		setup_track_deferred "Plugin deployment" "Install jq"
 		return 0
 	fi
 
@@ -401,14 +402,17 @@ check_skill_updates() {
 }
 
 scan_imported_skills() {
-	print_info "Running security scan on imported skills..."
-
+	# Check prerequisites before announcing setup (GH#5240)
 	local security_helper="$HOME/.aidevops/agents/scripts/security-helper.sh"
 
 	if [[ ! -f "$security_helper" ]]; then
-		print_warning "security-helper.sh not found - skipping skill scan"
+		print_skip "Skill security scan" "security-helper.sh not found" "Deploy agents first (setup.sh), then re-run"
+		setup_track_skipped "Skill security scan" "security-helper.sh not found"
 		return 0
 	fi
+
+	# Prerequisites met — proceed with setup
+	print_info "Running security scan on imported skills..."
 
 	# Install skill-scanner if not present
 	# Pre-check: cisco-ai-skill-scanner requires Python >= 3.10
@@ -484,8 +488,7 @@ scan_imported_skills() {
 }
 
 setup_multi_tenant_credentials() {
-	print_info "Multi-tenant credential storage..."
-
+	# Check prerequisites before announcing setup (GH#5240)
 	local credential_helper="$HOME/.aidevops/agents/scripts/credential-helper.sh"
 
 	if [[ ! -f "$credential_helper" ]]; then
@@ -494,9 +497,13 @@ setup_multi_tenant_credentials() {
 	fi
 
 	if [[ ! -f "$credential_helper" ]]; then
-		print_warning "credential-helper.sh not found - skipping"
+		print_skip "Multi-tenant credentials" "credential-helper.sh not found" "Deploy agents first (setup.sh), then re-run"
+		setup_track_skipped "Multi-tenant credentials" "credential-helper.sh not found"
 		return 0
 	fi
+
+	# Prerequisites met — proceed with setup
+	print_info "Multi-tenant credential storage..."
 
 	# Check if already initialized
 	if [[ -d "$HOME/.config/aidevops/tenants" ]]; then
@@ -547,8 +554,7 @@ setup_multi_tenant_credentials() {
 }
 
 check_tool_updates() {
-	print_info "Checking for tool updates..."
-
+	# Check prerequisites before announcing setup (GH#5240)
 	local tool_check_script="$HOME/.aidevops/agents/scripts/tool-version-check.sh"
 
 	if [[ ! -f "$tool_check_script" ]]; then
@@ -557,9 +563,13 @@ check_tool_updates() {
 	fi
 
 	if [[ ! -f "$tool_check_script" ]]; then
-		print_warning "Tool version check script not found - skipping update check"
+		print_skip "Tool updates" "version check script not found" "Deploy agents first (setup.sh), then re-run"
+		setup_track_skipped "Tool updates" "version check script not found"
 		return 0
 	fi
+
+	# Prerequisites met — proceed with setup
+	print_info "Checking for tool updates..."
 
 	# Run the check in quiet mode first to see if there are updates
 	# Capture both output and exit code

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -94,24 +94,25 @@ get_all_shell_rcs() {
 
 # Offer to install Oh My Zsh if zsh is the default shell and OMZ is not present
 setup_oh_my_zsh() {
-	# Only relevant if zsh is available
+	# Check prerequisites before announcing setup (GH#5240)
 	if ! command -v zsh >/dev/null 2>&1; then
-		print_info "zsh not found - skipping Oh My Zsh setup"
+		print_skip "Oh My Zsh" "zsh not installed" "Install zsh first, then re-run setup"
+		setup_track_skipped "Oh My Zsh" "zsh not installed"
 		return 0
 	fi
 
-	# Check if Oh My Zsh is already installed
 	if [[ -d "$HOME/.oh-my-zsh" ]]; then
 		print_success "Oh My Zsh already installed"
+		setup_track_configured "Oh My Zsh"
 		return 0
 	fi
 
 	local default_shell
 	default_shell=$(detect_default_shell)
 
-	# Only offer if zsh is the default shell (or on macOS where it's the system default)
 	if [[ "$default_shell" != "zsh" && "$(uname)" != "Darwin" ]]; then
-		print_info "Default shell is $default_shell (not zsh) - skipping Oh My Zsh"
+		print_skip "Oh My Zsh" "default shell is $default_shell (not zsh)" "Change default shell to zsh: chsh -s \$(which zsh)"
+		setup_track_skipped "Oh My Zsh" "default shell is $default_shell"
 		return 0
 	fi
 
@@ -822,12 +823,12 @@ ALIASES
 
 # Install terminal title integration that syncs tab titles with git repo/branch
 setup_terminal_title() {
-	print_info "Setting up terminal title integration..."
-
+	# Check prerequisites before announcing setup (GH#5240)
 	local setup_script=".agents/scripts/terminal-title-setup.sh"
 
 	if [[ ! -f "$setup_script" ]]; then
-		print_warning "Terminal title setup script not found - skipping"
+		print_skip "Terminal title" "setup script not found" "Deploy agents first (setup.sh), then re-run"
+		setup_track_skipped "Terminal title" "setup script not found"
 		return 0
 	fi
 
@@ -843,9 +844,13 @@ setup_terminal_title() {
 	done < <(get_all_shell_rcs)
 
 	if [[ "$title_configured" == "true" ]]; then
-		print_info "Terminal title integration already configured - Skipping"
+		print_success "Terminal title integration already configured"
+		setup_track_configured "Terminal title"
 		return 0
 	fi
+
+	# Prerequisites met — proceed with setup
+	print_info "Setting up terminal title integration..."
 
 	# Show current status before asking
 	echo ""

--- a/setup.sh
+++ b/setup.sh
@@ -22,6 +22,7 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
+GRAY='\033[0;90m'
 NC='\033[0m' # No Color
 
 # Global flags
@@ -835,8 +836,11 @@ main() {
 		confirm_step "Disable on-demand MCPs globally" && disable_ondemand_mcps
 	fi
 
+	# Print setup summary before final success message (GH#5240)
+	print_setup_summary
+
 	echo ""
-	print_success "🎉 Setup complete!"
+	print_success "Setup complete!"
 
 	# Enable auto-update if not already enabled
 	# Check both launchd (macOS) and cron (Linux) for existing installation


### PR DESCRIPTION
## Summary

- Replace the confusing "Setting up X..." then "skipping" pattern with prerequisite-first checks that show clear `[SKIP]` messages with reason and actionable next steps
- Add a setup summary tracker that prints configured/skipped/deferred items at the end of the run
- Refactor 12 setup functions across `mcp-setup.sh`, `shell-env.sh`, and `plugins.sh`

## Problem

The setup process showed "Setting up [Service]..." messages followed by "skipping" warnings when prerequisites weren't met. Users saw what looked like a failed setup attempt rather than a clear explanation of what was skipped and why.

## Solution

**Prerequisite-first pattern**: Check requirements before printing "Setting up..." — either show a clear `[SKIP]` with reason and action, or proceed with the actual setup.

**Before:**
```
[INFO] Setting up Google Analytics MCP...
[WARNING] OpenCode config not found - skipping Google Analytics MCP
```

**After:**
```
[SKIP] Google Analytics MCP -- OpenCode config not found
       >>> Run 'opencode' once to create config, then re-run setup
```

**End-of-run summary:**
```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Setup Summary
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  Configured (3):
    + Oh My Zsh
    + Terminal title
    + LocalWP MCP

  Skipped (2):
    - OpenCode plugins: OpenCode not installed
    - Skill security scan: security-helper.sh not found

  Deferred (3) -- complete these to enable:
    ! Google Analytics MCP: Install pipx
    ! Augment Context Engine: Upgrade Node.js to 22+
    ! MCP packages: Install bun or npm

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/setup/_common.sh` | Add `GRAY` color, setup summary tracker, `print_skip()`, `print_setup_summary()` |
| `setup-modules/mcp-setup.sh` | Refactor 6 functions to prerequisite-first pattern |
| `setup-modules/shell-env.sh` | Refactor `setup_oh_my_zsh`, `setup_terminal_title` |
| `setup-modules/plugins.sh` | Refactor 4 functions to prerequisite-first pattern |
| `setup.sh` | Add `GRAY` color, call `print_setup_summary()` before completion |

## Verification

- All 5 modified files pass ShellCheck with zero violations
- Uses indexed arrays only (bash 3.2 compatible, no associative arrays)
- Non-breaking: existing setup behavior preserved, only messaging improved

Closes #5240