### PR TITLE
t1543: fix: seed auth entry so anthropic-pool appears in connect dialog

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -16,7 +16,7 @@ import { loadAgentIndex, applyAgentMcpTools } from "./agent-loader.mjs";
 import { validateReturnStatements, validatePositionalParams } from "./validators.mjs";
 import { runMarkdownQualityPipeline } from "./quality-pipeline.mjs";
 import { createTtsrHooks } from "./ttsr.mjs";
-import { createPoolAuthHook, registerPoolProvider, createPoolTool } from "./oauth-pool.mjs";
+import { createPoolAuthHook, registerPoolProvider, createPoolTool, initPoolAuth } from "./oauth-pool.mjs";
 
 const HOME = homedir();
 const AGENTS_DIR = join(HOME, ".aidevops", "agents");
@@ -1069,7 +1069,10 @@ export async function AidevopsPlugin({ directory, client }) {
   // Phase 6: Initialise LLM observability (t1308)
   initObservability();
 
-  // Phase 7: OAuth pool tools (t1543)
+  // Phase 7: OAuth pool — seed auth entry so provider appears in connect dialog (t1543)
+  await initPoolAuth(client);
+
+  // Phase 7b: OAuth pool tools (t1543)
   const baseTools = createTools(SCRIPTS_DIR, run, {
     runShellQualityPipeline,
     runMarkdownQualityPipeline,

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -574,6 +574,63 @@ function createPoolFetch(provider) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Seed a placeholder auth entry for the pool provider in OpenCode's auth.json.
+ *
+ * OpenCode only shows providers in the "Connect a provider" dialog if they
+ * have an auth entry (auth.json) OR exist on models.dev. Since anthropic-pool
+ * is a custom provider not on models.dev, we need to seed a placeholder entry
+ * so the provider appears in the dialog for first-time setup.
+ *
+ * If pool accounts already exist, the placeholder is seeded with the first
+ * account's credentials so the loader can immediately use them.
+ *
+ * @param {any} client - OpenCode SDK client
+ */
+export async function initPoolAuth(client) {
+  try {
+    // Check if auth entry already exists
+    const existing = await client.auth.get({ path: { id: "anthropic-pool" } });
+    if (existing?.data) return; // Already seeded
+  } catch {
+    // No entry exists — proceed to seed
+  }
+
+  try {
+    const accounts = getAccounts("anthropic");
+    if (accounts.length > 0) {
+      // Seed with first account's real credentials
+      const first = accounts[0];
+      await client.auth.set({
+        path: { id: "anthropic-pool" },
+        body: {
+          type: "oauth",
+          refresh: first.refresh,
+          access: first.access,
+          expires: first.expires,
+        },
+      });
+    } else {
+      // Seed with a placeholder so the provider appears in the connect dialog.
+      // The placeholder has type "oauth" with empty tokens — the loader will
+      // detect no pool accounts and return empty options, but the provider
+      // will be visible for the user to add their first account.
+      await client.auth.set({
+        path: { id: "anthropic-pool" },
+        body: {
+          type: "oauth",
+          refresh: "",
+          access: "",
+          expires: 0,
+        },
+      });
+    }
+    console.error("[aidevops] OAuth pool: seeded auth entry for anthropic-pool provider");
+  } catch (err) {
+    console.error(`[aidevops] OAuth pool: failed to seed auth entry: ${err.message}`);
+  }
+}
+
+/**
  * Create the auth hook for the pool provider.
  * @param {any} client - OpenCode SDK client
  * @returns {import('@opencode-ai/plugin').AuthHook}


### PR DESCRIPTION
## Summary

- Fix the chicken-and-egg problem where `anthropic-pool` provider didn't appear in the "Connect a provider" dialog (Ctrl+A)
- Add `initPoolAuth()` that seeds a placeholder auth entry in OpenCode's `auth.json` at plugin init time

Closes #5243

## Root cause

OpenCode's "Connect a provider" dialog (`dialog-provider.tsx`) builds its list from `ModelsDev.get()` (external API) merged with `Provider.list()` (authenticated providers). Custom plugin providers like `anthropic-pool` don't exist on models.dev, and without an auth entry they never appear in `Provider.list()` either. The provider was invisible.

## Fix

`initPoolAuth(client)` runs at plugin initialization and:
1. Checks if an auth entry already exists for `anthropic-pool` — if so, skips
2. If pool accounts exist in `oauth-pool.json`: seeds with the first account's real credentials
3. If no accounts yet: seeds with an empty placeholder (`type: "oauth"`, empty tokens)

The placeholder makes the provider appear in the connect dialog. When the user selects it and completes OAuth, the real credentials are stored in the pool file and the auth entry is updated.

## Files changed

- `.agents/plugins/opencode-aidevops/oauth-pool.mjs` — add `initPoolAuth()` export (+55 lines)
- `.agents/plugins/opencode-aidevops/index.mjs` — call `initPoolAuth(client)` at plugin init (+3/-2 lines)