### PR TITLE
t1544: fix setup script errors with Unknown MCP integration: context7

### DIFF
--- a/.agents/scripts/setup-mcp-integrations.sh
+++ b/.agents/scripts/setup-mcp-integrations.sh
@@ -38,7 +38,7 @@ get_mcp_command() {
 	"dataforseo") echo "npx dataforseo-mcp-server" ;;
 	# serper - REMOVED: Uses curl subagent (.agents/seo/serper.md), no MCP needed
 	"unstract") echo "docker:unstract/mcp-server" ;;
-	"context7") echo "npx @upstash/context7-mcp@latest" ;;
+	"context7") echo "npx -y @upstash/context7-mcp@latest" ;;
 	*) echo "" ;;
 	esac
 	return 0
@@ -357,7 +357,7 @@ install_mcp() {
 		print_info "  2. Local MCP (via npx):"
 		print_info '     "context7": {'
 		print_info '       "type": "local",'
-		print_info '       "command": ["npx", "@upstash/context7-mcp@latest"],'
+		print_info '       "command": ["npx", "-y", "@upstash/context7-mcp@latest"],'
 		print_info '       "enabled": true'
 		print_info '     }'
 		print_info ""

--- a/.agents/scripts/setup-mcp-integrations.sh
+++ b/.agents/scripts/setup-mcp-integrations.sh
@@ -38,6 +38,7 @@ get_mcp_command() {
 	"dataforseo") echo "npx dataforseo-mcp-server" ;;
 	# serper - REMOVED: Uses curl subagent (.agents/seo/serper.md), no MCP needed
 	"unstract") echo "docker:unstract/mcp-server" ;;
+	"context7") echo "npx @upstash/context7-mcp@latest" ;;
 	*) echo "" ;;
 	esac
 	return 0
@@ -60,6 +61,7 @@ MCP_LIST=(
 	"stagehand-both"
 	"dataforseo"
 	"unstract"
+	"context7"
 )
 
 is_known_mcp() {
@@ -338,6 +340,30 @@ install_mcp() {
 		print_info ""
 		print_info "The MCP connects to your local instance by default."
 		print_info "Config template: configs/mcp-templates/unstract.json"
+		;;
+	"context7")
+		print_info "Setting up Context7 MCP for real-time library documentation..."
+		print_info "Context7 provides up-to-date docs for libraries and frameworks."
+		print_info ""
+		print_info "Two setup options:"
+		print_info ""
+		print_info "  1. Remote MCP (recommended — zero install):"
+		print_info '     "context7": {'
+		print_info '       "type": "remote",'
+		print_info '       "url": "https://mcp.context7.com/mcp",'
+		print_info '       "enabled": true'
+		print_info '     }'
+		print_info ""
+		print_info "  2. Local MCP (via npx):"
+		print_info '     "context7": {'
+		print_info '       "type": "local",'
+		print_info '       "command": ["npx", "@upstash/context7-mcp@latest"],'
+		print_info '       "enabled": true'
+		print_info '     }'
+		print_info ""
+		print_info "Disable telemetry: export CTX7_TELEMETRY_DISABLED=1"
+		print_info "CLI alternative: npx ctx7 setup --opencode --cli"
+		print_info "Docs: ~/.aidevops/agents/tools/context/context7.md"
 		;;
 	*)
 		print_error "Unknown MCP integration: $mcp_name"


### PR DESCRIPTION
## Summary

- Add `context7` to the known MCP integrations list in `setup-mcp-integrations.sh`
- Add `get_mcp_command()` case returning `npx @upstash/context7-mcp@latest`
- Add `install_mcp()` case with setup instructions for both remote MCP (`https://mcp.context7.com/mcp`) and local npx options

## Root Cause

`setup-mcp-integrations.sh` has a hardcoded `MCP_LIST` array and `get_mcp_command()` case statement that didn't include `context7`. Running `setup-mcp-integrations.sh context7` hit the default `*) echo "" ;;` case, returning empty, which triggered the "Unknown MCP integration: context7" error at line 134.

## Verification

- ShellCheck clean (zero violations)
- `MCP_LIST` contains `context7`
- `get_mcp_command("context7")` returns `npx @upstash/context7-mcp@latest`
- `is_known_mcp("context7")` returns 0 (success)

Closes #5248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new MCP integration called Context7. Users can now select Context7 as an installation target and receive tailored setup instructions, including remote and local configuration templates, guidance to disable telemetry, alternate CLI invocation, and links to local documentation for onboarding and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->