### PR TITLE
t1543: show pool account count and emails in auth dialog

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -689,13 +689,29 @@ export function createPoolAuthHook(client) {
 
     methods: [
       {
-        label: "Add Account to Pool (Claude Pro/Max)",
+        // Dynamic label — shows pool account count each time the dialog opens.
+        // Uses a getter so the label is recomputed on every access.
+        get label() {
+          const accounts = getAccounts("anthropic");
+          if (accounts.length === 0) {
+            return "Add Account to Pool (Claude Pro/Max)";
+          }
+          return `Add Account to Pool (${accounts.length} account${accounts.length === 1 ? "" : "s"})`;
+        },
         type: "oauth",
         prompts: [
           {
             type: "text",
             key: "email",
-            message: "Account email",
+            // Dynamic message — shows existing account emails as context.
+            get message() {
+              const accounts = getAccounts("anthropic");
+              if (accounts.length === 0) {
+                return "Account email";
+              }
+              const emails = accounts.map((a) => a.email).join(", ");
+              return `Current: ${emails}\nNew account email`;
+            },
             placeholder: "you@example.com",
             validate: (value) => {
               if (!value || !value.includes("@")) {


### PR DESCRIPTION
## Summary

- Dynamic label shows account count: `Add Account to Pool (2 accounts)`
- Email prompt shows existing accounts: `Current: marcus@..., work@...\nNew account email`
- Uses JavaScript getter properties so values recompute each time the dialog opens

Closes #5243

## How it works

The auth method object uses `get label()` and `get message()` instead of static string properties. Each time OpenCode's `ProviderAuth.methods()` reads the method, the getter calls `getAccounts("anthropic")` to get the current pool state and builds the string dynamically.

## Testing

Verified with mock pool data:
- 0 accounts: `"Add Account to Pool (Claude Pro/Max)"` / `"Account email"`
- 2 accounts: `"Add Account to Pool (2 accounts)"` / `"Current: marcus@example.com, work@company.com\nNew account email"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced OAuth Anthropic Pool dialog with dynamic account count display in labels and contextual email account information in input prompts for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->