### PR TITLE
GH#5257: Fix headless-runtime-helper.sh to support opencode/* gateway models

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -7,7 +7,7 @@
 #   - Persists OpenCode session IDs per provider + session key
 #   - Records backoff state per model (rate limits) or per provider (auth errors)
 #   - Clears backoff automatically when auth changes or retry windows expire
-#   - Rejects opencode/* gateway models for headless runs (no Zen fallback)
+#   - Supports opencode/* gateway models when explicitly configured
 
 set -euo pipefail
 
@@ -174,6 +174,13 @@ get_auth_signature() {
 			auth_material="${auth_material}|status=${auth_status}|mtime=${auth_mtime}|env=missing"
 		fi
 		;;
+	opencode)
+		# Gateway models use OpenCode's OAuth session
+		local auth_file auth_mtime
+		auth_file="${HOME}/.local/share/opencode/auth.json"
+		auth_mtime=$(file_mtime "$auth_file")
+		auth_material="${auth_material}|mtime=${auth_mtime}"
+		;;
 	*)
 		auth_material="${auth_material}|unknown=true"
 		;;
@@ -199,9 +206,6 @@ get_configured_models() {
 	for item in "${raw_models[@]}"; do
 		item=$(trim_spaces "$item")
 		[[ -z "$item" ]] && continue
-		if [[ "$item" == opencode/* ]]; then
-			continue
-		fi
 		provider=$(extract_provider "$item" 2>/dev/null || printf '%s' "")
 		[[ -z "$provider" ]] && continue
 		if [[ ${#allowlist[@]} -gt 0 ]]; then
@@ -458,6 +462,14 @@ provider_auth_available() {
 		fi
 		return 1
 		;;
+	opencode)
+		# OpenCode gateway models use OpenCode's OAuth session
+		local auth_file="${HOME}/.local/share/opencode/auth.json"
+		if [[ -f "$auth_file" ]]; then
+			return 0
+		fi
+		return 1
+		;;
 	local)
 		# Local provider is always considered available (no auth needed)
 		return 0
@@ -552,10 +564,6 @@ choose_model() {
 	local provider last_provider start_index i idx current_model current_provider
 
 	if [[ -n "$explicit_model" ]]; then
-		if [[ "$explicit_model" == opencode/* ]]; then
-			print_error "Headless runtime rejects gateway model: $explicit_model"
-			return 1
-		fi
 		provider=$(extract_provider "$explicit_model" 2>/dev/null || printf '%s' "")
 		if [[ -z "$provider" ]]; then
 			print_error "Model must use provider/model format: $explicit_model"
@@ -963,7 +971,7 @@ Backoff granularity:
 Defaults:
   AIDEVOPS_HEADLESS_MODELS defaults to anthropic/claude-sonnet-4-6,openai/gpt-4o
   AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST can restrict selection to providers like: openai
-  Gateway models (opencode/*) are rejected for headless runs.
+  Gateway models (opencode/*) are supported when explicitly configured.
 EOF
 	return 0
 }

--- a/tests/test-headless-runtime-helper.sh
+++ b/tests/test-headless-runtime-helper.sh
@@ -297,6 +297,66 @@ fi
 # Clean up
 bash "$HELPER" backoff clear anthropic >/dev/null 2>&1 || true
 
+section "OpenCode Gateway Models"
+# opencode/* models should be selectable when configured and auth file exists
+# Create a fake auth file so provider_auth_available("opencode") returns true
+FAKE_AUTH_DIR="$TEST_TMP_DIR/fake-opencode-home/.local/share/opencode"
+mkdir -p "$FAKE_AUTH_DIR"
+echo '{"token":"fake"}' >"$FAKE_AUTH_DIR/auth.json"
+
+gateway_model=$(
+	HOME="$TEST_TMP_DIR/fake-opencode-home" \
+		AIDEVOPS_HEADLESS_MODELS="opencode/minimax-m2.5-free" \
+		bash "$HELPER" select --role worker 2>/dev/null || true
+)
+if [[ "$gateway_model" == "opencode/minimax-m2.5-free" ]]; then
+	pass "opencode/* gateway model is selectable when configured"
+else
+	fail "opencode/* gateway model is selectable when configured" "got: $gateway_model"
+fi
+
+# opencode/* models should be skipped when no auth file exists
+# Use ANTHROPIC_API_KEY so Anthropic passes auth check even with fake HOME
+no_auth_gateway=$(
+	HOME="$TEST_TMP_DIR/no-auth-home" \
+		ANTHROPIC_API_KEY="test-key" \
+		AIDEVOPS_HEADLESS_MODELS="opencode/minimax-m2.5-free,anthropic/claude-sonnet-4-6" \
+		bash "$HELPER" select --role worker 2>/dev/null || true
+)
+if [[ "$no_auth_gateway" == "anthropic/claude-sonnet-4-6" ]]; then
+	pass "opencode/* skipped when no auth, falls back to next provider"
+else
+	fail "opencode/* skipped when no auth, falls back to next provider" "got: $no_auth_gateway"
+fi
+
+# opencode/* models should work in cmd_run dispatch
+rm -f "$STUB_LOG_FILE"
+export STUB_SESSION_ID="ses_gateway_one"
+HOME="$TEST_TMP_DIR/fake-opencode-home" \
+	AIDEVOPS_HEADLESS_MODELS="opencode/minimax-m2.5-free" \
+	bash "$HELPER" run \
+	--role worker \
+	--session-key issue-gateway \
+	--dir "$REPO_DIR" \
+	--title "Issue Gateway" \
+	--prompt "Reply with exactly OK" >/dev/null
+if [[ -f "$STUB_LOG_FILE" ]] && grep -q 'opencode/minimax-m2.5-free' "$STUB_LOG_FILE"; then
+	pass "opencode/* gateway model dispatches via cmd_run"
+else
+	fail "opencode/* gateway model dispatches via cmd_run" "stub log: $(cat "$STUB_LOG_FILE" 2>/dev/null || echo 'missing')"
+fi
+
+# Explicit --model with opencode/* should work (no longer rejected)
+explicit_gateway=$(
+	HOME="$TEST_TMP_DIR/fake-opencode-home" \
+		bash "$HELPER" select --role worker --model opencode/minimax-m2.5-free 2>/dev/null || true
+)
+if [[ "$explicit_gateway" == "opencode/minimax-m2.5-free" ]]; then
+	pass "explicit --model opencode/* is accepted"
+else
+	fail "explicit --model opencode/* is accepted" "got: $explicit_gateway"
+fi
+
 echo ""
 printf "Total: %d, Passed: %d, Failed: %d\n" "$TOTAL_COUNT" "$PASS_COUNT" "$FAIL_COUNT"
 


### PR DESCRIPTION
## Summary

- Remove blanket rejection of `opencode/*` gateway models from `get_configured_models()` and `choose_model()`, allowing users to dispatch workers via gateway models when explicitly configured in `AIDEVOPS_HEADLESS_MODELS`
- Add `opencode` provider support to `provider_auth_available()` (checks OAuth session file) and `get_auth_signature()` (enables backoff clearing on re-auth)
- Add 4 new tests covering gateway model selection, auth fallback, dispatch, and explicit `--model` acceptance

## Root Cause

Two rejection points silently dropped `opencode/*` models:
1. `get_configured_models()` line 202-203: `if [[ "$item" == opencode/* ]]; then continue; fi` — filtered out all gateway models before they reached `choose_model()`
2. `choose_model()` line 555-558: rejected explicit `--model opencode/*` with an error

When `AIDEVOPS_HEADLESS_MODELS="opencode/minimax-m2.5-free"`, the model list was empty after filtering, causing `choose_model()` to return error code 1. The `cmd_run` function then exited silently (error went to stderr only).

## Testing

All 20 tests pass (16 existing + 4 new):
- `opencode/* gateway model is selectable when configured`
- `opencode/* skipped when no auth, falls back to next provider`
- `opencode/* gateway model dispatches via cmd_run`
- `explicit --model opencode/* is accepted`

Closes #5257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OpenCode gateway models in headless runs when explicitly configured.
  * Integrated OpenCode OAuth authentication handling for model selection.

* **Tests**
  * Added comprehensive test coverage for OpenCode gateway model selection, authentication scenarios, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->