### PR TITLE
t217: enforce parallel Task tool calls for independent subtasks

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -76,6 +76,7 @@ Use TodoWrite frequently to track tasks and show progress. Break complex tasks i
 
 # Tool usage policy
 - Call independent tools in parallel. Use specialized tools for file ops (Read/Edit/Write, not cat/sed/awk).
+- When multiple independent subtasks exist (for example creating multiple files or running unrelated searches), launch parallel Task tool calls in a single message instead of sequential Task calls.
 - NEVER use bash echo to communicate — output text directly.
 - Use Task tool for codebase exploration.
 

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -135,14 +135,20 @@ or when you need to understand a codebase pattern across multiple files.
 the Edit tool to work), or when the answer is a simple grep/rg query.
 
 **5. Parallel sub-work (MANDATORY when applicable)**
-After creating your TodoWrite subtasks, check: do any two subtasks modify DIFFERENT files?
-If yes, you SHOULD parallelise where possible. Use `ai_research` for read-only research
-tasks that do not require file edits.
+After creating your TodoWrite subtasks, check whether multiple subtasks are independent.
+If yes, launch them as parallel **Task tool calls in a single message** instead of sequential
+Task calls across multiple messages.
 
-**Decision heuristic**: If your TodoWrite has 3+ subtasks and any two do not modify the same
-files, the independent ones can run in parallel. Common parallelisable patterns:
-- Use `ai_research` to understand a codebase pattern while you implement in another file
-- Run `ai_research(domain: "code")` to check conventions while writing new code
+**Required pattern**: For independent subtasks (for example, creating unrelated files,
+running separate searches, or collecting read-only context from different modules), issue
+multiple Task tool calls at once so sub-agents run concurrently.
+
+**Decision heuristic**: If your TodoWrite has 3+ subtasks and any two do not touch the same
+files and do not depend on each other's outputs, those subtasks should run in parallel.
+Common parallelisable patterns:
+- Create or update independent files in separate Task sub-agents
+- Run independent searches across different directories/modules
+- Use `ai_research` to understand one area while implementing another
 
 **Do NOT parallelise when**: subtasks modify the same file, or subtask B depends on
 subtask A's output (e.g., B imports a function A creates). When in doubt, run sequentially.

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -137,7 +137,9 @@ the Edit tool to work), or when the answer is a simple grep/rg query.
 **5. Parallel sub-work (MANDATORY when applicable)**
 After creating your TodoWrite subtasks, check whether multiple subtasks are independent.
 If yes, launch them as parallel **Task tool calls in a single message** instead of sequential
-Task calls across multiple messages.
+Task calls across multiple messages. Your TodoWrite still tracks ONE `in_progress` subtask
+at a time (Section 1) — parallel Task calls are how you *delegate* independent work to
+sub-agents concurrently, not how you track your own focus.
 
 **Required pattern**: For independent subtasks (for example, creating unrelated files,
 running separate searches, or collecting read-only context from different modules), issue
@@ -148,7 +150,7 @@ files and do not depend on each other's outputs, those subtasks should run in pa
 Common parallelisable patterns:
 - Create or update independent files in separate Task sub-agents
 - Run independent searches across different directories/modules
-- Use `ai_research` to understand one area while implementing another
+- Delegate `ai_research` calls to gather context while a Task sub-agent implements
 
 **Do NOT parallelise when**: subtasks modify the same file, or subtask B depends on
 subtask A's output (e.g., B imports a function A creates). When in doubt, run sequentially.


### PR DESCRIPTION
## Summary
- add explicit worker system prompt guidance requiring parallel Task tool calls in a single message for independent subtasks
- expand worker efficiency protocol with required pattern, decision heuristic, and examples for when to parallelise vs stay sequential
- keep existing dependency safety rule by retaining sequential guidance when subtasks share files or depend on prior outputs

Closes #5261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated task-processing protocol to allow batching multiple independent tool calls together in a single message for concurrent execution.
* **Documentation**
  * Clarified rules and examples for when and how to parallelize independent subtasks, including a stricter independence requirement for 3+ parallel tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->