### PR TITLE
Add Cloudron upstream watches for dependency version tracking

### DIFF
--- a/.agents/configs/upstream-watch.json
+++ b/.agents/configs/upstream-watch.json
@@ -16,7 +16,7 @@
       "source_type": "dockerhub",
       "description": "Cloudron base Docker image (Ubuntu 24.04 + Node/Python/PHP/nginx/gosu)",
       "relevance": "Base image for all Cloudron app packages. Version bumps change the verified inventory table in cloudron-app-packaging.md (Node.js, PHP, Python versions, available tools). Current: 5.0.0 on Cloudron 9.1.3.",
-      "check_command": "curl -s 'https://hub.docker.com/v2/repositories/cloudron/base/tags/?page_size=5&ordering=last_updated' | jq -r '.results[0].name'",
+      "check_command": "curl -s 'https://hub.docker.com/v2/repositories/cloudron/base/tags/?page_size=5&ordering=last_updated' | jq -r '(.results[0].name // \"\")'",
       "affects": [".agents/tools/deployment/cloudron-app-packaging.md", ".agents/tools/deployment/cloudron-app-packaging-skill.md"],
       "added_at": "2026-03-19"
     },
@@ -26,7 +26,7 @@
       "source_type": "gitlab",
       "description": "Official Cloudron packaging/publishing/server-ops skills from git.cloudron.io",
       "relevance": "Source for our 3 imported Cloudron skills. New commits may add addons, manifest fields, CLI commands, or build methods. Last imported: commit b247b124 (2026-03-01).",
-      "check_command": "curl -s 'https://git.cloudron.io/api/v4/projects/docs%2Fskills/repository/commits?per_page=1' | jq -r '.[0].id'",
+      "check_command": "curl -s 'https://git.cloudron.io/api/v4/projects/docs%2Fskills/repository/commits?per_page=1' | jq -r '(.[0].id // \"\")'",
       "affects": [".agents/tools/deployment/cloudron-app-packaging-skill.md", ".agents/tools/deployment/cloudron-app-publishing-skill.md", ".agents/tools/deployment/cloudron-server-ops-skill.md"],
       "last_seen_commit": "b247b124d168730051186aa63afad87c0c1f5a52",
       "added_at": "2026-03-19"
@@ -37,7 +37,7 @@
       "source_type": "forgejo",
       "description": "Community Cloudron packaging assessment toolkit by LoudLemur/OrcVole",
       "relevance": "Source of the two-axis scoring rubric, verified base image inventory, and assessment patterns we adopted. New commits may add assessed apps, refine scoring, or update base image findings.",
-      "check_command": "curl -s 'https://forgejo.wanderingmonster.dev/api/v1/repos/root/cloudron-packaging/commits?limit=1' | jq -r '.[0].sha'",
+      "check_command": "curl -s 'https://forgejo.wanderingmonster.dev/api/v1/repos/root/cloudron-packaging/commits?limit=1' | jq -r '(.[0].sha // \"\")'",
       "affects": [".agents/tools/deployment/cloudron-app-packaging.md"],
       "last_seen_commit": "047e4b07ce362f484a0c5a9854b14a1a5ecf1b48",
       "added_at": "2026-03-19"

--- a/.agents/configs/upstream-watch.json
+++ b/.agents/configs/upstream-watch.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Upstream repos to watch for releases and significant changes. Managed by upstream-watch-helper.sh (t1426). Entry schema: {slug, description, relevance, default_branch, added_at}. State (last_release_seen, last_commit_seen, last_checked, updates_pending) stored in ~/.aidevops/cache/upstream-watch-state.json.",
+  "$comment": "Upstream repos to watch for releases and significant changes. Managed by upstream-watch-helper.sh (t1426). Entry schema: {slug, description, relevance, default_branch, added_at}. State (last_release_seen, last_commit_seen, last_checked, updates_pending) stored in ~/.aidevops/cache/upstream-watch-state.json. Non-GitHub upstreams are tracked in the non_github_upstreams array for manual/scheduled checks.",
   "repos": [
     {
       "slug": "rtk-ai/rtk",
@@ -7,6 +7,40 @@
       "relevance": "Token cost optimization for agent bash operations (git, gh, test runners). Evaluated in t1430.",
       "default_branch": "master",
       "added_at": "2026-03-10"
+    }
+  ],
+  "non_github_upstreams": [
+    {
+      "name": "cloudron-base-image",
+      "url": "https://hub.docker.com/r/cloudron/base/tags",
+      "source_type": "dockerhub",
+      "description": "Cloudron base Docker image (Ubuntu 24.04 + Node/Python/PHP/nginx/gosu)",
+      "relevance": "Base image for all Cloudron app packages. Version bumps change the verified inventory table in cloudron-app-packaging.md (Node.js, PHP, Python versions, available tools). Current: 5.0.0 on Cloudron 9.1.3.",
+      "check_command": "curl -s 'https://hub.docker.com/v2/repositories/cloudron/base/tags/?page_size=5&ordering=last_updated' | jq -r '.results[0].name'",
+      "affects": [".agents/tools/deployment/cloudron-app-packaging.md", ".agents/tools/deployment/cloudron-app-packaging-skill.md"],
+      "added_at": "2026-03-19"
+    },
+    {
+      "name": "cloudron-official-skills",
+      "url": "https://git.cloudron.io/docs/skills",
+      "source_type": "gitlab",
+      "description": "Official Cloudron packaging/publishing/server-ops skills from git.cloudron.io",
+      "relevance": "Source for our 3 imported Cloudron skills. New commits may add addons, manifest fields, CLI commands, or build methods. Last imported: commit b247b124 (2026-03-01).",
+      "check_command": "curl -s 'https://git.cloudron.io/api/v4/projects/docs%2Fskills/repository/commits?per_page=1' | jq -r '.[0].id'",
+      "affects": [".agents/tools/deployment/cloudron-app-packaging-skill.md", ".agents/tools/deployment/cloudron-app-publishing-skill.md", ".agents/tools/deployment/cloudron-server-ops-skill.md"],
+      "last_seen_commit": "b247b124d168730051186aa63afad87c0c1f5a52",
+      "added_at": "2026-03-19"
+    },
+    {
+      "name": "cloudron-packaging-community",
+      "url": "https://forgejo.wanderingmonster.dev/root/cloudron-packaging",
+      "source_type": "forgejo",
+      "description": "Community Cloudron packaging assessment toolkit by LoudLemur/OrcVole",
+      "relevance": "Source of the two-axis scoring rubric, verified base image inventory, and assessment patterns we adopted. New commits may add assessed apps, refine scoring, or update base image findings.",
+      "check_command": "curl -s 'https://forgejo.wanderingmonster.dev/api/v1/repos/root/cloudron-packaging/commits?limit=1' | jq -r '.[0].sha'",
+      "affects": [".agents/tools/deployment/cloudron-app-packaging.md"],
+      "last_seen_commit": "047e4b07ce362f484a0c5a9854b14a1a5ecf1b48",
+      "added_at": "2026-03-19"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `non_github_upstreams` array to `upstream-watch.json` for tracking three Cloudron dependencies that live outside GitHub
- Each entry includes a verified `check_command` (curl + jq), the files it affects, and the last-seen version/commit

## Entries added

| Name | Source | What it tracks | Check works |
|------|--------|---------------|-------------|
| `cloudron-base-image` | Docker Hub | `cloudron/base` tag versions (currently 5.0.0) | `curl` Docker Hub API |
| `cloudron-official-skills` | git.cloudron.io (GitLab) | Official packaging/publishing/server-ops skills | `curl` GitLab API |
| `cloudron-packaging-community` | Forgejo | Community assessment toolkit by LoudLemur | `curl` Forgejo API |

## Why

The previous PR (#5242) added a verified base image inventory and assessment workflow to our Cloudron packaging agents. Those hardcoded version numbers (Node 24.x, PHP 8.3.6, etc.) will go stale when Cloudron releases a new base image. These watch entries provide the trigger for agents to detect the drift and file update issues.

## Discovery

The official skills repo already has newer commits (`fcea3961`) than our last import (`b247b124` from 2026-03-01), meaning there are skill updates we haven't pulled yet.

## Deployment

This config is committed to the repo and deployed to all users via `setup.sh`. Any pulse-enabled aidevops installation will have these watch entries. The `upstream-watch-helper.sh` currently only processes the `repos` array (GitHub), so the `non_github_upstreams` array needs a follow-up to wire into the check loop — but the data and check commands are ready.

## Files changed

- `.agents/configs/upstream-watch.json` — Added `non_github_upstreams` array with 3 entries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced upstream tracking to include non-GitHub sources with manual/scheduled checks.
  * Added monitoring for Docker image tags and additional Git-based upstreams to detect updates.
  * Registered several upstreams that may affect documentation, skills, and packaging materials so changes trigger follow-up checks/notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->