### PR TITLE
GH#5269: Fix documentation inconsistency in log-issue-aidevops.md regarding triage gate bypass

### DIFF
--- a/.agents/scripts/commands/log-issue-aidevops.md
+++ b/.agents/scripts/commands/log-issue-aidevops.md
@@ -15,7 +15,7 @@ tools:
 
 Log an issue with the aidevops framework to GitHub.
 
-**This is the recommended way to report issues.** It produces higher-quality reports than the web form because the AI assistant gathers diagnostics, checks for duplicates, and validates the report before submission. All issues from external contributors (non-collaborators) are gated behind maintainer triage (`needs-triage` label) regardless of filing method — a maintainer must approve them before the development pipeline picks them up.
+**This is the recommended way to report issues.** All issues from non-collaborators are gated behind maintainer triage (`needs-triage` label) regardless of how they are filed — a maintainer must approve them before the development pipeline picks them up. This command produces higher-quality reports than the web form because the AI assistant gathers diagnostics, checks for duplicates, and validates the report before submission, which helps maintainers approve issues faster.
 
 **Arguments**: Optional issue title in quotes, e.g., `/log-issue-aidevops "Update check not working"`
 


### PR DESCRIPTION
## Summary

- Restructures the introductory paragraph in `log-issue-aidevops.md` to lead with the triage gate fact before explaining the command's benefit
- The previous phrasing was factually correct but could be misread as implying `/log-issue-aidevops` bypasses the triage gate
- New structure makes the causal relationship clear: triage always applies to non-collaborators regardless of filing method, but higher-quality reports from this command help maintainers approve issues faster

## Verification

Cross-referenced against `issue-triage-gate.yml` (the source of truth) and `pulse.md` triage gate section to confirm:
1. **Bots** bypass triage (user.type === 'Bot')
2. **Task ID prefix** issues (`t\d+: ...`) bypass triage
3. **OWNER/MEMBER/COLLABORATOR** bypass triage
4. **All other authors** get `needs-triage` — including issues filed via `/log-issue-aidevops`

The `/log-issue-aidevops` command runs as the external user's GitHub account, so the triage gate correctly applies. No technical bypass exists or should be claimed.

Closes #5269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command usage documentation with clarified guidance on contribution gating and triage rules.
  * Enhanced description of how the command supports faster issue approval processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->