### PR TITLE
fix(issue-sync): make [x] trailing space optional in completion regex

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -315,7 +315,8 @@ cmd_push() {
 		# The TOON backlog cache in TODO.md can be stale, showing tasks as pending
 		# even after [x] completion. The pulse reads the stale cache and calls
 		# push <task_id>, which previously matched [x] lines via the [.] pattern.
-		if [[ "$task_line" =~ ^[[:space:]]*-\ \[x\]\  ]]; then
+		# GH#5280: trailing space made optional — matches [x] at end-of-line too.
+		if [[ "$task_line" =~ ^[[:space:]]*-[[:space:]]\[x\]([[:space:]]|$) ]]; then
 			print_info "Skipping $task_id — already completed ([x] in TODO.md)"
 			skipped=$((skipped + 1))
 			continue


### PR DESCRIPTION
## Summary

- Fixes the `[x]` completion detection regex in `issue-sync-helper.sh` to handle task lines where `[x]` is at end-of-line or followed by a tab
- The previous regex `^[[:space:]]*-\ \[x\]\ ` required a trailing space after `[x]`, which could miss completed tasks in edge-case formatting
- Updated to `^[[:space:]]*-[[:space:]]\[x\]([[:space:]]|$)` — matches either a whitespace character or end-of-line after `[x]`

## Changes

- `.agents/scripts/issue-sync-helper.sh:319` — regex updated, comment added referencing GH#5280

## Testing

ShellCheck passes with zero new violations (only pre-existing SC1091 info notices for sourced files).

The fix is backward-compatible: all previously-matching lines still match. The only change is that lines ending with `[x]` (no trailing space) now also match correctly.

Closes #5280

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completed task detection during synchronization to handle varying formatting styles, ensuring tasks are consistently and reliably tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->