### PR TITLE
t5276: fix ensure_homebrew() read prompt guard for non-TTY/CI contexts

### DIFF
--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -334,8 +334,8 @@ ensure_homebrew() {
 		return 1
 	fi
 
-	# Non-interactive mode: skip
-	if [[ "$NON_INTERACTIVE" == "true" ]]; then
+	# Non-interactive mode or non-TTY stdin: skip
+	if [[ "${NON_INTERACTIVE:-false}" == "true" ]] || [[ ! -t 0 ]]; then
 		return 1
 	fi
 


### PR DESCRIPTION
## Summary

- Add `[[ ! -t 0 ]]` TTY check to `ensure_homebrew()` alongside the existing `NON_INTERACTIVE` guard, matching the pattern already used in `offer_python_brew_install()`
- Prevents the Homebrew install prompt from blocking in piped/CI runs where `NON_INTERACTIVE` is not explicitly set but stdin is not a terminal
- Also normalises the guard to use `${NON_INTERACTIVE:-false}` (consistent with `offer_python_brew_install()`) instead of bare `$NON_INTERACTIVE`

## Context

Both findings from PR #5239 review were already addressed in the merged code:
- **HIGH (CodeRabbit)**: `offer_python_brew_install()` unconditional `read` — already guarded at line 554-558
- **MEDIUM (Gemini)**: `get_latest_homebrew_python_formula()` manual iteration — already simplified with `sort | head`

The remaining gap was `ensure_homebrew()` at line 338: it had a `NON_INTERACTIVE` guard but lacked the `! -t 0` TTY check. In a piped/CI context where `NON_INTERACTIVE` is unset, the `read` at line 346 would still block.

## Verification

```bash
shellcheck .agents/scripts/setup/_common.sh
bash -n .agents/scripts/setup/_common.sh
```

Both pass with zero violations.

Closes #5276