### PR TITLE
5279: refine AGENTS helper path comment wording

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -143,7 +143,7 @@ Not every task is code. The framework has multiple primary agents, each with dom
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 AGENTS_DIR="${AGENTS_DIR:-"$HOME/.aidevops/agents"}"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
-# Resolves HELPER path dynamically to support custom agents_dir
+# Resolves helper path dynamically when `agents_dir` is customized
 
 # Code task (default — Build+ implied)
 $HELPER run \


### PR DESCRIPTION
## Summary
- refine the inline dispatch-example comment in `.agents/AGENTS.md` to be more concise and direct
- keep the intent explicit while matching review feedback from PR #5235

Closes #5279