### PR TITLE
GH#5273: Harden Context7 template JSON validation quoting

### DIFF
--- a/.agents/scripts/validate-mcp-integrations.sh
+++ b/.agents/scripts/validate-mcp-integrations.sh
@@ -205,7 +205,7 @@ test_context7() {
 	# Validate context7-mcp-config.json.txt template if it exists
 	local config_template="configs/context7-mcp-config.json.txt"
 	if [[ -f "$config_template" ]]; then
-		run_test "Context7 config template JSON validation" "python3 -m json.tool '$config_template'"
+		run_test "Context7 config template JSON validation" "jq . >/dev/null < \"$config_template\""
 		print_success "Context7 config template found: $config_template"
 	else
 		print_warning "Context7 config template not found: $config_template"


### PR DESCRIPTION
## Summary
- Replace fragile `python3 -m json.tool '$config_template'` command construction with robust `jq` input redirection and escaped quoting.
- Ensure Context7 config template validation remains safe when paths include special characters.
- Keep behavior aligned with existing script dependencies by using `jq`, which is already required elsewhere in this script.

Closes #5273