### PR TITLE
5272: harden OAuth API key response handling

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -847,7 +847,17 @@ export function createPoolAuthHook(client) {
                 );
                 return { type: "failed" };
               }
-              const apiKeyResult = await apiKeyResponse.json();
+              let apiKeyResult;
+              try {
+                apiKeyResult = await apiKeyResponse.json();
+              } catch {
+                console.error("[aidevops] OAuth pool: API key creation response was not valid JSON");
+                return { type: "failed" };
+              }
+              if (!apiKeyResult || typeof apiKeyResult.raw_key !== "string") {
+                console.error("[aidevops] OAuth pool: API key creation response missing raw_key");
+                return { type: "failed" };
+              }
               return { type: "success", key: apiKeyResult.raw_key };
             },
           };


### PR DESCRIPTION
## Summary
- Add defensive handling for the OAuth `create_api_key` response in `oauth-pool.mjs`.
- Fail gracefully when the response body is not valid JSON or does not include a string `raw_key`.
- Keep existing non-2xx response handling and logging, now covering malformed success payloads too.

## Verification
- `node --check .agents/plugins/opencode-aidevops/oauth-pool.mjs`
- `.agents/scripts/linters-local.sh` *(runs, but currently reports pre-existing repo-wide baseline violations unrelated to this change)*

Closes #5272