### PR TITLE
t5277: refactor Python version-check into shared check_python_version() helper

### DIFF
--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -581,6 +581,51 @@ offer_python_brew_install() {
 	fi
 }
 
+# Check Python version and offer Homebrew install/upgrade if needed.
+# Encapsulates the repeated find_python3 → parse version → compare → offer pattern.
+# Arguments:
+#   $1 - recommended formula (e.g. python@3.13); defaults to get_recommended_python_formula
+#   $2 - context label for messages (e.g. "AI orchestration"); defaults to "skills/tools"
+# Outputs version string to stdout on success (for callers that want to display it).
+# Returns:
+#   0 - Python meets the required version
+#   1 - Python not found or outdated (offer_python_brew_install already called)
+check_python_version() {
+	local recommended_formula="${1:-}"
+	local context_label="${2:-skills/tools}"
+	local python_required_major="${PYTHON_REQUIRED_MAJOR:-3}"
+	local python_required_minor="${PYTHON_REQUIRED_MINOR:-10}"
+
+	if [[ -z "$recommended_formula" ]]; then
+		recommended_formula=$(get_recommended_python_formula)
+	fi
+
+	local python3_bin
+	if python3_bin=$(find_python3); then
+		local python_version
+		python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
+		local python_major python_minor
+		python_major=$(echo "$python_version" | cut -d. -f1)
+		python_minor=$(echo "$python_version" | cut -d. -f2)
+
+		if [[ "$python_major" =~ ^[0-9]+$ ]] && [[ "$python_minor" =~ ^[0-9]+$ ]] &&
+			{ ((python_major > python_required_major)) ||
+				{ ((python_major == python_required_major)) && ((python_minor >= python_required_minor)); }; }; then
+			print_success "Python $python_version found ($python_required_major.$python_required_minor+ required)"
+			echo "$python_version"
+			return 0
+		else
+			print_warning "Python $python_required_major.$python_required_minor+ required for $context_label, found $python_version"
+			offer_python_brew_install "upgrade" "$recommended_formula" || true
+			return 1
+		fi
+	else
+		print_warning "Python 3 not found"
+		offer_python_brew_install "install" "$recommended_formula" || true
+		return 1
+	fi
+}
+
 # Install a package globally via npm or bun, with sudo when needed on Linux.
 # Usage: npm_global_install "package-name" OR npm_global_install "package@version"
 # Uses bun if available (no sudo needed), falls back to npm.

--- a/setup-modules/shell-env.sh
+++ b/setup-modules/shell-env.sh
@@ -387,10 +387,6 @@ check_optional_deps() {
 	print_info "Checking optional dependencies..."
 
 	local missing_optional=()
-	local recommended_python_formula
-	recommended_python_formula=$(get_recommended_python_formula)
-	local python_required_major="${PYTHON_REQUIRED_MAJOR:-3}"
-	local python_required_minor="${PYTHON_REQUIRED_MINOR:-10}"
 
 	if ! command -v sshpass >/dev/null 2>&1; then
 		missing_optional+=("sshpass")
@@ -398,25 +394,7 @@ check_optional_deps() {
 		print_success "sshpass found"
 	fi
 
-	local python3_bin=""
-	if python3_bin=$(find_python3); then
-		local python_version
-		python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
-		local python_major
-		python_major=$(echo "$python_version" | cut -d. -f1)
-		local python_minor
-		python_minor=$(echo "$python_version" | cut -d. -f2)
-
-		if [[ "$python_major" =~ ^[0-9]+$ ]] && [[ "$python_minor" =~ ^[0-9]+$ ]] && { ((python_major > python_required_major)) || { ((python_major == python_required_major)) && ((python_minor >= python_required_minor)); }; }; then
-			print_success "Python $python_version found ($python_required_major.$python_required_minor+ required)"
-		else
-			print_warning "Python $python_version found, but $python_required_major.$python_required_minor+ is recommended for all skills/tools"
-			offer_python_brew_install "upgrade" "$recommended_python_formula" || true
-		fi
-	else
-		print_warning "Python 3 not found"
-		offer_python_brew_install "install" "$recommended_python_formula" || true
-	fi
+	check_python_version "" "skills/tools" >/dev/null || true
 
 	if [[ ${#missing_optional[@]} -gt 0 ]]; then
 		print_warning "Missing optional dependencies: ${missing_optional[*]}"

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1455,37 +1455,9 @@ setup_orbstack_vm() {
 setup_ai_orchestration() {
 	print_info "Setting up AI orchestration frameworks..."
 
-	local has_python=false
-	local python_required_major="${PYTHON_REQUIRED_MAJOR:-3}"
-	local python_required_minor="${PYTHON_REQUIRED_MINOR:-10}"
-	local recommended_python_formula
-	recommended_python_formula=$(get_recommended_python_formula)
-
-	# Check Python (prefer Homebrew/pyenv over system) — uses shared helpers
-	# from _common.sh (get_recommended_python_formula, find_python3,
-	# offer_python_brew_install) to avoid duplicating version-check logic.
-	local python3_bin
-	if python3_bin=$(find_python3); then
-		local python_version
-		python_version=$("$python3_bin" -c 'import sys; print("{}.{}.{}".format(sys.version_info[0], sys.version_info[1], sys.version_info[2]))' 2>/dev/null || true)
-		local major minor
-		major=$(echo "$python_version" | cut -d. -f1)
-		minor=$(echo "$python_version" | cut -d. -f2)
-
-		if [[ "$major" =~ ^[0-9]+$ ]] && [[ "$minor" =~ ^[0-9]+$ ]] && { ((major > python_required_major)) || { ((major == python_required_major)) && ((minor >= python_required_minor)); }; }; then
-			has_python=true
-			print_success "Python $python_version found ($python_required_major.$python_required_minor+ required)"
-		else
-			print_warning "Python $python_required_major.$python_required_minor+ required for AI orchestration, found $python_version"
-			offer_python_brew_install "upgrade" "$recommended_python_formula" || true
-		fi
-	else
-		print_warning "Python 3 not found - AI orchestration frameworks unavailable"
-		offer_python_brew_install "install" "$recommended_python_formula" || true
-		return 0
-	fi
-
-	if [[ "$has_python" == "false" ]]; then
+	# Check Python — uses check_python_version from _common.sh to avoid
+	# duplicating find_python3 → parse → compare → offer_python_brew_install logic.
+	if ! check_python_version "" "AI orchestration" >/dev/null; then
 		return 0
 	fi
 


### PR DESCRIPTION
## Summary

- Add `check_python_version()` to `.agents/scripts/setup/_common.sh` — encapsulates the repeated `find_python3` → parse version → compare → `offer_python_brew_install` pattern
- Replace ~25 lines of duplicated logic in `setup-modules/shell-env.sh:check_optional_deps()` with a single `check_python_version "" "skills/tools" >/dev/null || true` call
- Replace ~25 lines of duplicated logic in `setup-modules/tool-install.sh:setup_ai_orchestration()` with `if ! check_python_version "" "AI orchestration" >/dev/null; then return 0; fi`

## Motivation

Addresses gemini code review feedback from PR #5239: the version-check + brew-install logic was nearly identical in two locations, making future maintenance harder (e.g. changing the version comparison or install prompt would require updating both sites).

## Verification

```bash
shellcheck setup-modules/shell-env.sh setup-modules/tool-install.sh .agents/scripts/setup/_common.sh
bash -n setup-modules/shell-env.sh setup-modules/tool-install.sh .agents/scripts/setup/_common.sh
```

Both pass with zero violations.

Closes #5277