### PR TITLE
t1545: Rename needs-triage to needs-maintainer-review

### DIFF
--- a/.agents/scripts/commands/log-issue-aidevops.md
+++ b/.agents/scripts/commands/log-issue-aidevops.md
@@ -15,7 +15,7 @@ tools:
 
 Log an issue with the aidevops framework to GitHub.
 
-**This is the recommended way to report issues.** All issues from non-collaborators are gated behind maintainer triage (`needs-triage` label) regardless of how they are filed — a maintainer must approve them before the development pipeline picks them up. This command produces higher-quality reports than the web form because the AI assistant gathers diagnostics, checks for duplicates, and validates the report before submission, which helps maintainers approve issues faster.
+**This is the recommended way to report issues.** All issues from non-collaborators are gated behind maintainer review (`needs-maintainer-review` label) regardless of how they are filed — a maintainer must approve them before the development pipeline picks them up. This command produces higher-quality reports than the web form because the AI assistant gathers diagnostics, checks for duplicates, and validates the report before submission, which helps maintainers approve issues faster.
 
 **Arguments**: Optional issue title in quotes, e.g., `/log-issue-aidevops "Update check not working"`
 

--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -57,7 +57,7 @@ Check external contributor gate before ANY merge (see Pre-merge checks below).
 
 ### 4. Dispatch workers for open issues
 
-For each unassigned, non-blocked issue with no open PR, no active worker, and **no `needs-triage` label**:
+For each unassigned, non-blocked issue with no open PR, no active worker, and **no `needs-maintainer-review` label**:
 
 ```bash
 # Dedup guard (MANDATORY — all three checks required)
@@ -236,30 +236,28 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 - **Duplicate issues for same task ID** → keep the one referenced by `ref:GH#` in TODO.md, close others with a comment.
 - **Too large for one worker** → classify with `task-decompose-helper.sh classify`. If composite, decompose into subtask issues, label parent `status:blocked`. Child tasks enter the normal dispatch queue.
 - **`status:queued` or `status:in-progress`** → check `updatedAt`. If updated within 3 hours, skip. If 3+ hours with no PR and no worker, relabel `status:available`, unassign, comment the recovery.
-- **`needs-triage`** → SKIP. External issue awaiting maintainer review. Do NOT dispatch.
-- **`status:available` or no status (without `needs-triage`)** → dispatch a worker.
+- **`needs-maintainer-review`** → SKIP. Awaiting maintainer review. Do NOT dispatch.
+- **`status:available` or no status (without `needs-maintainer-review`)** → dispatch a worker.
 
-### External issues and PRs — triage gate (t1545)
+### External issues and PRs — maintainer review gate (t1545)
 
-**NEVER dispatch a worker for an issue with the `needs-triage` label.** This label is applied automatically by the `issue-triage-gate.yml` workflow to all issues from non-collaborators. It is the hard gate that prevents external issues from entering the pipeline without maintainer review.
+**NEVER dispatch a worker for an issue with the `needs-maintainer-review` label.** This label is applied automatically by the `issue-triage-gate.yml` workflow to all issues from non-collaborators, and manually by the pulse for scope-sensitive items (third-party integrations, architecture changes). It is the hard gate that prevents work from entering the pipeline without maintainer approval.
 
-**Triage flow:**
+**Auto-applied by `issue-triage-gate.yml`:**
 
 1. External user files issue (web form or `/log-issue-aidevops`)
-2. `issue-triage-gate.yml` checks `authorAssociation` — if not OWNER/MEMBER/COLLABORATOR, applies `needs-triage` label and posts a welcome comment
-3. Pulse sees `needs-triage` → **skip, do not dispatch**
+2. Workflow checks `authorAssociation` — if not OWNER/MEMBER/COLLABORATOR, applies `needs-maintainer-review` label and posts a welcome comment
+3. Pulse sees `needs-maintainer-review` → **skip, do not dispatch**
 4. Maintainer reviews the issue and either:
-   - Removes `needs-triage` and adds `status:available` → dispatchable next cycle
-   - Adds `needs-maintainer-review` for scope decisions → requires explicit approval
+   - Removes `needs-maintainer-review` and adds `status:available` → dispatchable next cycle
+   - Asks for more information → keeps label
    - Closes as duplicate/invalid/out-of-scope
 
-**Scope check for approved external issues:**
+**Manually applied by the pulse for scope decisions:**
 
-Once `needs-triage` is removed, apply the scope check:
-
-- **Destructive behaviour reports** → valid bug, dispatch a fix
 - **Feature requests for third-party integrations** → label `needs-maintainer-review`, do NOT dispatch
 - **PRs adding dependencies or changing architecture** → label `needs-maintainer-review`, require explicit maintainer approval
+- **Destructive behaviour reports** → valid bug, dispatch a fix (no label needed)
 - **Bug fixes and docs PRs** → normal review process
 
 ### Comment-based approval

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug Report
 description: Report a bug — please use /log-issue-aidevops in your AI assistant for best results
 title: "Bug: "
-labels: ["bug", "needs-triage"]
+labels: ["bug", "needs-maintainer-review"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an improvement or new feature
 title: "Feature: "
-labels: ["enhancement", "needs-triage"]
+labels: ["enhancement", "needs-maintainer-review"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/issue-triage-gate.yml
+++ b/.github/workflows/issue-triage-gate.yml
@@ -43,13 +43,13 @@ jobs:
             if (trustedRoles.includes(association)) {
               console.log(`Author ${author} has role ${association} — bypassing triage`);
 
-              // Remove needs-triage if the YAML form template added it
+              // Remove needs-maintainer-review if the YAML form template added it
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issue.number,
-                  name: 'needs-triage'
+                  name: 'needs-maintainer-review'
                 });
               } catch (e) {
                 // Label may not exist yet — that's fine
@@ -59,12 +59,12 @@ jobs:
 
             console.log(`Author ${author} has role ${association} — applying triage gate`);
 
-            // Ensure needs-triage label exists
+            // Ensure needs-maintainer-review label exists
             try {
               await github.rest.issues.createLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                name: 'needs-triage',
+                name: 'needs-maintainer-review',
                 description: 'External issue awaiting maintainer review before pipeline pickup',
                 color: 'FBCA04'
               });
@@ -77,7 +77,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
-              labels: ['needs-triage']
+              labels: ['needs-maintainer-review']
             });
 
             // Remove any auto-dispatch labels that could trigger the pipeline


### PR DESCRIPTION
## Summary

Follow-up to #5265 / PR #5266.

- Rename `needs-triage` label to `needs-maintainer-review` across all files
- Consolidate with the pre-existing `needs-maintainer-review` scope-check concept in pulse.md
- Delete the `needs-triage` GitHub label, update `needs-maintainer-review` description and color

## Why

`needs-triage` is vague — triage by whom? for what? `needs-maintainer-review` says exactly what's needed and who needs to act. It also unifies two previously separate concepts (initial triage gate + scope-check gate) into one label with one meaning: "maintainer must review before the pipeline acts."

## Files Changed

- `.github/ISSUE_TEMPLATE/bug_report.yml` — label reference
- `.github/ISSUE_TEMPLATE/feature_request.yml` — label reference
- `.github/workflows/issue-triage-gate.yml` — all label references (7 occurrences)
- `.agents/scripts/commands/pulse.md` — dispatch skip rule + triage gate section consolidated
- `.agents/scripts/commands/log-issue-aidevops.md` — documentation reference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue submission documentation and AI agent command guides to reflect the revised issue review workflow.

* **Chores**
  * Updated GitHub issue templates for bug reports and feature requests with revised labeling.
  * Updated automated issue triage workflow to implement new classification system for external contributor submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->