### PR TITLE
issue-5299: normalize Claude 3 capability flags in oauth-pool plugin

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -47,6 +47,16 @@ const REQUIRED_BETAS = [
   "interleaved-thinking-2025-05-14",
 ];
 
+const MODEL_CAPABILITY_OVERRIDES = {
+  "claude-3-7-sonnet-20250219": {
+    interleaved: true,
+  },
+  "claude-3-5-haiku-20241022": {
+    reasoning: true,
+    interleaved: true,
+  },
+};
+
 const TOOL_PREFIX = "mcp_";
 
 // ---------------------------------------------------------------------------
@@ -605,6 +615,13 @@ export function createPoolAuthHook(client) {
      */
     async loader(getAuth, provider) {
       const accounts = getAccounts("anthropic");
+
+      for (const [modelId, model] of Object.entries(provider.models || {})) {
+        const overrides = MODEL_CAPABILITY_OVERRIDES[modelId];
+        if (overrides) {
+          Object.assign(model, overrides);
+        }
+      }
 
       // Zero out costs for OAuth (Max plan pricing) regardless of mode
       const auth = await getAuth();


### PR DESCRIPTION
## Summary
- add explicit capability overrides for `claude-3-7-sonnet-20250219` and `claude-3-5-haiku-20241022` in the OAuth pool plugin to restore expected `interleaved`/`reasoning` metadata
- apply overrides in the auth loader before mode selection so model metadata is consistent for pool and single-account OAuth paths

## Validation
- `node --check .agents/plugins/opencode-aidevops/oauth-pool.mjs`
- `bun test` *(not run: `bun` is not installed in this environment)*
- `bun run typecheck` *(not run: `bun` is not installed in this environment)*

Closes #5299

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved model capability configuration for specific AI models to ensure features are properly recognized and applied before cost calculations, enhancing accuracy and consistency in feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->