### PR TITLE
t5298: make completed-task matcher accept multiple spaces

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -316,7 +316,7 @@ cmd_push() {
 		# even after [x] completion. The pulse reads the stale cache and calls
 		# push <task_id>, which previously matched [x] lines via the [.] pattern.
 		# GH#5280: trailing space made optional — matches [x] at end-of-line too.
-		if [[ "$task_line" =~ ^[[:space:]]*-[[:space:]]\[x\]([[:space:]]|$) ]]; then
+		if [[ "$task_line" =~ ^[[:space:]]*-[[:space:]]+\[x\]([[:space:]]|$) ]]; then
 			print_info "Skipping $task_id — already completed ([x] in TODO.md)"
 			skipped=$((skipped + 1))
 			continue


### PR DESCRIPTION
## Summary
- Make the completed-task detection regex in `issue-sync-helper.sh` accept one or more spaces after the markdown list marker.
- Keep behavior unchanged for normal `- [x]` formatting while adding support for extra-space variants like `-  [x]`.

## Verification
- `shellcheck .agents/scripts/issue-sync-helper.sh` (SC1091 info-only for sourced local files)
- `bash -n .agents/scripts/issue-sync-helper.sh`

Closes #5298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task completion detection logic in the issue sync helper for more accurate task tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->