### PR TITLE
t5296: clarify pulse scope decision heading

### DIFF
--- a/.agents/scripts/commands/pulse.md
+++ b/.agents/scripts/commands/pulse.md
@@ -253,7 +253,7 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
    - Asks for more information → keeps label
    - Closes as duplicate/invalid/out-of-scope
 
-**Manually applied by the pulse for scope decisions:**
+**Scope decision guidelines:**
 
 - **Feature requests for third-party integrations** → label `needs-maintainer-review`, do NOT dispatch
 - **PRs adding dependencies or changing architecture** → label `needs-maintainer-review`, require explicit maintainer approval


### PR DESCRIPTION
## Summary
- Replace a misleading subsection heading in `pulse.md` so the guidance clearly covers both labeling and non-labeling scope outcomes.
- Keep blast radius minimal by changing exactly one line in the existing section.

## Verification
- `markdown-formatter check .agents/scripts/commands/pulse.md`

Closes #5296