### PR TITLE
t5294: harden Cloudron version grep patterns in troubleshooting docs

### DIFF
--- a/.agents/services/hosting/cloudron.md
+++ b/.agents/services/hosting/cloudron.md
@@ -251,7 +251,7 @@ last reboot | head -5
 journalctl -b -1 --no-pager | grep -i -E 'cloudron.*update|cloudron-updater'
 
 # Get the current Cloudron version
-grep '"version"' /home/yellowtent/box/package.json
+grep -E '^\s*"version":' /home/yellowtent/box/package.json
 ```
 
 **Step 2: Assess system resources** — Rule out OOM, disk full, or CPU saturation.
@@ -388,7 +388,7 @@ docker exec -it <container_name> /bin/bash
 | App-specific logs | `docker logs <container_name>` | Individual app startup/runtime errors |
 | System journal (previous boot) | `journalctl -b -1 --no-pager -n 50 -p warning` | What happened before the reboot |
 | Cloudron troubleshoot | `cloudron-support --troubleshoot` | Built-in diagnostic checks (DNS, certs, services, migrations) |
-| Cloudron version | `grep '"version"' /home/yellowtent/box/package.json` | Current Cloudron version |
+| Cloudron version | `grep -E '^\s*"version":' /home/yellowtent/box/package.json` | Current Cloudron version |
 
 ### **Database Troubleshooting (MySQL)**
 


### PR DESCRIPTION
## Summary
- Replace two broad `grep '"version"'` examples in the Cloudron troubleshooting guide with an anchored pattern that specifically matches the JSON `\"version\":` key
- Keep scope limited to `.agents/services/hosting/cloudron.md` to resolve PR #5293 review feedback with minimal blast radius

## Verification
- `markdown-formatter check .agents/services/hosting/cloudron.md`

Closes #5294