### PR TITLE
t5299: align Claude 3.x pool model capability flags

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -833,6 +833,7 @@ export function registerPoolProvider(config) {
       "claude-3-7-sonnet-20250219": {
         name: "Claude 3.7 Sonnet",
         attachment: true, reasoning: true, tool_call: true, temperature: true,
+        interleaved: true,
         modalities: { input: ["text", "image", "pdf"], output: ["text"] },
         cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
         limit: { context: 200000, output: 16384 },
@@ -840,7 +841,8 @@ export function registerPoolProvider(config) {
       },
       "claude-3-5-haiku-20241022": {
         name: "Claude 3.5 Haiku",
-        attachment: true, tool_call: true, temperature: true,
+        attachment: true, reasoning: true, tool_call: true, temperature: true,
+        interleaved: true,
         modalities: { input: ["text", "image"], output: ["text"] },
         cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
         limit: { context: 200000, output: 8192 },


### PR DESCRIPTION
## Summary
- Add `interleaved: true` to `claude-3-7-sonnet-20250219` in the anthropic pool provider model map
- Add `reasoning: true` and `interleaved: true` to `claude-3-5-haiku-20241022` for capability consistency with the rest of the configured models
- Keep scope limited to `.agents/plugins/opencode-aidevops/oauth-pool.mjs` to address issue #5299 with minimal blast radius

## Verification
- `node --check .agents/plugins/opencode-aidevops/oauth-pool.mjs`

Closes #5299