### PR TITLE
t1546: Setup/update: guide users to configure OAuth pool when built-in anthropic-auth is removed in OpenCode v1.2.30

### DIFF
--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -9,41 +9,133 @@ tools:
 
 # OpenCode Anthropic Auth Plugin
 
-> **DEPRECATED**: As of OpenCode v1.1.36+, Anthropic OAuth is built into OpenCode natively.
-> The external `opencode-anthropic-auth` plugin is no longer needed and must NOT be added
+> **v1.2.30+**: The built-in `anthropic-auth` plugin was removed in OpenCode v1.2.30.
+> Use the **aidevops OAuth pool** instead — run `opencode auth login` and select
+> **"Anthropic Pool"** (provided by the aidevops plugin). See [OAuth Pool Setup](#oauth-pool-setup-v1230) below.
+>
+> **v1.1.36–v1.2.29**: Anthropic OAuth is built into OpenCode natively.
+> The external `opencode-anthropic-auth` npm package is not needed and must NOT be added
 > to `opencode.json` plugins — doing so causes a TypeError due to double-loading.
-> Use `opencode auth login` directly. This document is retained for historical reference.
 
 <!-- AI-CONTEXT-START -->
 
 ## Quick Reference
 
 - **Purpose**: OAuth authentication for Claude Pro/Max accounts in OpenCode
-- **Status**: **DEPRECATED** — built into OpenCode v1.1.36+, do not install as external plugin
-- **Repository**: https://github.com/anomalyco/opencode-anthropic-auth
-- **Installation**: Built-in to OpenCode v1.1.36+ (no installation needed)
+- **Status (v1.2.30+)**: Built-in auth removed — use aidevops OAuth pool (`opencode auth login` → "Anthropic Pool")
+- **Status (v1.1.36–v1.2.29)**: Built-in to OpenCode, no external plugin needed
+- **Repository**: https://github.com/anomalyco/opencode-anthropic-auth (historical reference only)
 
 **Authentication Methods**:
 
-| Method | Use Case | Requirements |
-|--------|----------|--------------|
-| **Claude Pro/Max OAuth** | Free API usage for subscribers | Active Claude Pro/Max subscription |
-| **Create API Key** | Traditional API key via OAuth | Anthropic Console access |
-| **Manual API Key** | Existing API keys | API key from console.anthropic.com |
+| Method | OpenCode Version | Use Case | Requirements |
+|--------|-----------------|----------|--------------|
+| **Anthropic Pool** (aidevops) | v1.2.30+ (required), all versions (recommended) | Multi-account OAuth with rotation | Claude Pro/Max subscription |
+| **Claude Pro/Max OAuth** (built-in) | v1.1.36–v1.2.29 | Single-account OAuth | Claude Pro/Max subscription |
+| **Manual API Key** | All versions | Existing API keys | API key from console.anthropic.com |
 
-**Quick Setup**:
+**Quick Setup (v1.2.30+)**:
 
 ```bash
-# Install plugin (auto-installed by aidevops setup.sh)
-npm install -g opencode-anthropic-auth
+# 1. Ensure aidevops plugin is registered (done by aidevops setup.sh)
+# 2. Add your first account to the pool
+opencode auth login
+# Select: Anthropic Pool
+# Enter your Claude account email
+# Complete OAuth flow in browser
 
-# Authenticate in OpenCode
+# 3. Optionally add more accounts for automatic rotation
+opencode auth login
+# Select: Anthropic Pool → enter second account email
+
+# 4. Manage accounts
+# /model-accounts-pool list
+# /model-accounts-pool status
+# /model-accounts-pool remove user@example.com
+```
+
+**Quick Setup (v1.1.36–v1.2.29)**:
+
+```bash
+# Built-in OAuth (single account)
 opencode auth login
 # Select: Anthropic → Claude Pro/Max (or Create an API Key)
 # Follow OAuth flow in browser
+
+# Or use the aidevops pool for multi-account rotation (recommended)
+opencode auth login
+# Select: Anthropic Pool
 ```
 
 <!-- AI-CONTEXT-END -->
+
+## OAuth Pool Setup (v1.2.30+)
+
+OpenCode v1.2.30 removed the built-in `anthropic-auth` plugin. The aidevops OAuth pool
+(`oauth-pool.mjs`) is the replacement. It provides the same OAuth flow with the addition
+of multi-account rotation — when one account hits a rate limit (429), requests automatically
+switch to the next available account.
+
+### Prerequisites
+
+The aidevops plugin must be registered in OpenCode. This is done automatically by `aidevops setup.sh`.
+Verify with:
+
+```bash
+grep -q "opencode-aidevops" ~/.config/opencode/opencode.json && echo "Plugin registered" || echo "Run: aidevops setup"
+```
+
+### Adding Accounts
+
+```bash
+opencode auth login
+# Select: "Anthropic Pool" (or "Add Account to Pool (Claude Pro/Max)")
+# Enter your Claude account email when prompted
+# A browser window opens to claude.ai/oauth/authorize
+# Sign in and authorize the application
+# Copy the authorization code from the callback URL
+# Paste into the OpenCode prompt
+```
+
+Repeat to add additional accounts. Each account is stored in `~/.aidevops/oauth-pool.json`.
+
+### Managing the Pool
+
+Use the `/model-accounts-pool` tool inside any OpenCode session:
+
+```text
+/model-accounts-pool list              # Show all accounts with status
+/model-accounts-pool status            # Rotation statistics
+/model-accounts-pool remove user@example.com  # Remove an account
+/model-accounts-pool reset-cooldowns   # Clear rate-limit cooldowns
+```
+
+Or use the MCP tool directly:
+
+```bash
+# List accounts (key names only — never expose values)
+cat ~/.aidevops/oauth-pool.json | jq -r '.anthropic[].email'
+```
+
+### Pool File
+
+Credentials are stored in `~/.aidevops/oauth-pool.json` (separate from OpenCode's `auth.json`).
+This file contains OAuth tokens — do not commit to version control.
+
+```bash
+# Check file permissions (should be 600)
+ls -la ~/.aidevops/oauth-pool.json
+```
+
+### Using Pool Models
+
+After adding accounts, pool models appear in the model picker as `anthropic-pool/claude-*`:
+
+- `anthropic-pool/claude-opus-4-6`
+- `anthropic-pool/claude-sonnet-4-6`
+- `anthropic-pool/claude-haiku-4-5`
+
+All models show $0 cost (covered by Claude Pro/Max subscription).
 
 ## Overview
 
@@ -356,13 +448,23 @@ opencode run "Hello, Claude!" --model anthropic/claude-sonnet-4-6
 
 ### Multi-Account Setup
 
-For teams or multi-account scenarios:
+The aidevops OAuth pool supports automatic multi-account rotation. Add multiple accounts:
 
-1. **Different users**: Each user authenticates with their own account
-2. **Account switching**: Use `opencode auth logout && opencode auth login`
-3. **Organization accounts**: Ensure organization members have API access enabled
+```bash
+# Add first account
+opencode auth login
+# Select: Anthropic Pool → enter first account email
 
-**Note**: This plugin does not support automatic multi-account load balancing. Use separate OpenCode profiles or environments for true multi-account rotation.
+# Add second account
+opencode auth login
+# Select: Anthropic Pool → enter second account email
+```
+
+The pool automatically rotates to the next available account when one hits a rate limit (429).
+Accounts are stored in `~/.aidevops/oauth-pool.json` and persist across sessions.
+
+For teams: each user runs their own aidevops setup and manages their own pool. OAuth tokens
+are personal and cannot be shared across users.
 
 ### Beta Feature Customization
 
@@ -398,32 +500,44 @@ cat ~/.config/opencode/auth.json | jq '.anthropic'
 
 ### Automatic Setup
 
-As of aidevops v2.90.0, `setup.sh` no longer installs this plugin (it's built into OpenCode v1.1.36+).
+`setup.sh` registers the aidevops plugin (which includes the OAuth pool) automatically.
+The external `opencode-anthropic-auth` npm package is not installed — it was removed in
+aidevops v2.90.0 when OpenCode v1.1.36 made it redundant.
 
 After setup:
-1. OpenCode's built-in Anthropic OAuth is ready to use
-2. Authenticate with `opencode auth login`
+
+- **OpenCode v1.2.30+**: Run `opencode auth login` → select "Anthropic Pool" to add accounts
+- **OpenCode v1.1.36–v1.2.29**: Run `opencode auth login` → select "Anthropic → Claude Pro/Max"
+  (built-in), or use "Anthropic Pool" for multi-account rotation
 
 ### Recommended Configuration
 
 For aidevops users:
 
-- **Primary agent** (Build+): Use Claude Pro/Max OAuth for zero-cost API usage
+- **Primary agent** (Build+): Use the aidevops OAuth pool for zero-cost API usage with rotation
 - **Specialized agents**: Same authentication applies to all agents
 - **CI/CD workflows**: Use manual API key method for GitHub Actions, etc.
+- **Multiple accounts**: Add 2–3 Claude Pro/Max accounts to the pool for uninterrupted sessions
 
 ### Credential Storage
 
-aidevops follows OpenCode's credential storage:
-
-- OAuth tokens: `~/.config/opencode/auth.json`
-- API keys (if using manual method): Same location
-- Environment variables: Not used by this plugin (OAuth tokens only)
+- **OAuth pool tokens**: `~/.aidevops/oauth-pool.json` (aidevops pool, 0600 permissions)
+- **Built-in OAuth tokens** (v1.1.36–v1.2.29): `~/.config/opencode/auth.json`
+- **API keys** (manual method): `~/.config/opencode/auth.json`
+- **Environment variables**: Not used by OAuth methods
 
 ## Version History
 
+### OpenCode Built-in Auth Timeline
+
+- **OpenCode v1.2.30+**: Built-in `anthropic-auth` removed entirely. Use aidevops OAuth pool.
+- **OpenCode v1.1.36–v1.2.29**: Built-in `anthropic-auth` included natively. External plugin not needed.
+- **OpenCode pre-v1.1.36**: External `opencode-anthropic-auth` npm package required.
+
+### External Plugin (`opencode-anthropic-auth` npm package)
+
 - **0.0.9** (latest): Current version in repository
-  - **DEPRECATED** — functionality now built into OpenCode v1.1.36+
+  - **DEPRECATED** — functionality built into OpenCode v1.1.36+, removed in v1.2.30
   - Maintained by Anomaly (anomalyco)
   - Dependencies: `@opencode-ai/plugin`, `@openauthjs/openauth`
 - **0.0.8**: Updated dependencies and compatibility

--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -152,9 +152,11 @@ The `opencode-anthropic-auth` plugin enables OAuth authentication for Anthropic'
 
 ## Installation
 
-### Built-in (OpenCode v1.1.36+)
+### Built-in (OpenCode v1.1.36–v1.2.29)
 
-Anthropic OAuth is built into OpenCode v1.1.36+. No installation needed — just run:
+> **v1.2.30+**: Built-in auth was removed. Use the [aidevops OAuth pool](#oauth-pool-setup-v1230) instead.
+
+Anthropic OAuth is built into OpenCode v1.1.36–v1.2.29. No installation needed — just run:
 
 ```bash
 opencode auth login
@@ -172,9 +174,11 @@ npm install -g opencode-anthropic-auth
 
 ## Authentication Methods
 
-### 1. Claude Pro/Max OAuth (Recommended for Subscribers)
+### 1. Claude Pro/Max OAuth — Built-in (v1.1.36–v1.2.29 only)
 
-Best for users with active Claude Pro or Max subscriptions who want free API usage.
+> **v1.2.30+**: This built-in option was removed. Use the [aidevops OAuth pool](#oauth-pool-setup-v1230) instead — it provides the same OAuth flow with multi-account rotation.
+
+Best for users on OpenCode v1.1.36–v1.2.29 with active Claude Pro or Max subscriptions who want free API usage.
 
 **Setup**:
 
@@ -381,9 +385,12 @@ opencode run "Hello, Claude!" --model anthropic/claude-sonnet-4-6
 3. Verify refresh_token is present and valid
 4. Check network connectivity to console.anthropic.com
 
-### Plugin Not Detected
+### Plugin Not Detected (pre-v1.1.36 only)
 
-**Symptoms**: Anthropic OAuth options not shown in `opencode auth login`.
+> **v1.2.30+**: The `opencode-anthropic-auth` npm package is not used. If "Anthropic Pool" is missing, the aidevops plugin was not registered — re-run `aidevops setup`.
+> **v1.1.36–v1.2.29**: Built-in auth is native; the npm package is not needed and must NOT be installed.
+
+**Symptoms** (pre-v1.1.36 only): Anthropic OAuth options not shown in `opencode auth login`.
 
 **Solutions**:
 1. Verify installation: `npm list -g opencode-anthropic-auth`
@@ -413,13 +420,14 @@ opencode run "Hello, Claude!" --model anthropic/claude-sonnet-4-6
 
 ## Comparison with Other Auth Methods
 
-| Feature | Anthropic OAuth (built-in) | Manual API Key |
-|---------|---------------------------|----------------|
-| **Claude Pro/Max cost** | $0 (subscription) | Standard rates |
-| **Auto token refresh** | Yes | N/A |
-| **Beta features** | Auto-enabled | Manual |
-| **Setup complexity** | Low (OAuth flow) | Lowest (paste key) |
-| **Best for** | Claude subscribers | API-only users |
+| Feature | Anthropic OAuth built-in (v1.1.36–v1.2.29) | aidevops OAuth Pool (v1.2.30+, all versions) | Manual API Key |
+|---------|---------------------------------------------|----------------------------------------------|----------------|
+| **Claude Pro/Max cost** | $0 (subscription) | $0 (subscription) | Standard rates |
+| **Auto token refresh** | Yes | Yes | N/A |
+| **Beta features** | Auto-enabled | Auto-enabled | Manual |
+| **Multi-account rotation** | No | Yes | No |
+| **Setup complexity** | Low (OAuth flow) | Low (OAuth flow) | Lowest (paste key) |
+| **Best for** | v1.1.36–v1.2.29 subscribers | v1.2.30+ (required); all versions (recommended) | API-only users |
 
 ## Security Considerations
 

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -512,8 +512,45 @@ setup_opencode_plugins() {
 	# Adding it as an external plugin causes TypeError due to double-loading.
 	# Removed in v2.90.0 - see PR #230.
 
-	print_info "After setup, authenticate with: opencode auth login"
-	print_info "  - For Claude OAuth: Select 'Anthropic' -> 'Claude Pro/Max' (built-in)"
+	# Detect OpenCode version to give appropriate auth guidance (t1546, GH#5312)
+	# v1.2.30+ removes the built-in anthropic-auth plugin entirely.
+	# The aidevops OAuth pool (oauth-pool.mjs) is the replacement for all versions.
+	local oc_raw_version
+	oc_raw_version=$(opencode --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
+
+	local oc_major oc_minor oc_patch
+	oc_major=$(printf '%s' "$oc_raw_version" | cut -d. -f1)
+	oc_minor=$(printf '%s' "$oc_raw_version" | cut -d. -f2)
+	oc_patch=$(printf '%s' "$oc_raw_version" | cut -d. -f3)
+	oc_major="${oc_major:-0}"
+	oc_minor="${oc_minor:-0}"
+	oc_patch="${oc_patch:-0}"
+
+	# Compare against 1.2.30 (where built-in anthropic-auth was removed)
+	local builtin_auth_removed="false"
+	if [[ "$oc_major" -gt 1 ]]; then
+		builtin_auth_removed="true"
+	elif [[ "$oc_major" -eq 1 && "$oc_minor" -gt 2 ]]; then
+		builtin_auth_removed="true"
+	elif [[ "$oc_major" -eq 1 && "$oc_minor" -eq 2 && "$oc_patch" -ge 30 ]]; then
+		builtin_auth_removed="true"
+	fi
+
+	if [[ "$builtin_auth_removed" == "true" ]]; then
+		print_info "OpenCode v${oc_raw_version}: built-in Anthropic OAuth removed in v1.2.30"
+		print_info "Use the aidevops OAuth pool (provided by the aidevops plugin above):"
+		print_info "  1. Run: opencode auth login"
+		print_info "  2. Select: 'Anthropic Pool' (added by aidevops plugin)"
+		print_info "  3. Enter your Claude account email"
+		print_info "  4. Complete the OAuth flow in your browser"
+		print_info "  5. Repeat to add more accounts for automatic rotation"
+		print_info "  Manage accounts: /model-accounts-pool list|status|remove"
+		print_info "  Docs: ~/.aidevops/agents/tools/opencode/opencode-anthropic-auth.md"
+	else
+		print_info "After setup, authenticate with: opencode auth login"
+		print_info "  - For Claude OAuth: Select 'Anthropic' -> 'Claude Pro/Max' (built-in)"
+		print_info "  - Or use the aidevops OAuth pool: Select 'Anthropic Pool' for multi-account rotation"
+	fi
 
 	return 0
 }

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -502,10 +502,12 @@ setup_opencode_plugins() {
 
 	# Setup aidevops compaction plugin (local file plugin)
 	local aidevops_plugin_path="$HOME/.aidevops/agents/plugins/opencode-aidevops/index.mjs"
+	local pool_plugin_registered="false"
 	if [[ -f "$aidevops_plugin_path" ]]; then
 		add_opencode_plugin "file://$HOME/.aidevops" "file://${aidevops_plugin_path}" "$opencode_config"
 		print_success "aidevops compaction plugin registered (preserves context across compaction)"
 		setup_track_configured "OpenCode plugins"
+		pool_plugin_registered="true"
 	fi
 
 	# Note: opencode-anthropic-auth is built into OpenCode v1.1.36+
@@ -538,17 +540,22 @@ setup_opencode_plugins() {
 
 	if [[ "$builtin_auth_removed" == "true" ]]; then
 		print_info "OpenCode v${oc_raw_version}: built-in Anthropic OAuth removed in v1.2.30"
-		print_info "Use the aidevops OAuth pool (provided by the aidevops plugin above):"
-		print_info "  1. Run: opencode auth login"
-		print_info "  2. Select: 'Anthropic Pool' (added by aidevops plugin)"
-		print_info "  3. Enter your Claude account email"
-		print_info "  4. Complete the OAuth flow in your browser"
-		print_info "  5. Repeat to add more accounts for automatic rotation"
-		print_info "  Manage accounts: /model-accounts-pool list|status|remove"
-		print_info "  Docs: ~/.aidevops/agents/tools/opencode/opencode-anthropic-auth.md"
+		if [[ "$pool_plugin_registered" == "true" ]]; then
+			print_info "Use the aidevops OAuth pool (provided by the aidevops plugin above):"
+			print_info "  1. Run: opencode auth login"
+			print_info "  2. Select: 'Anthropic Pool' (added by aidevops plugin)"
+			print_info "  3. Enter your Claude account email"
+			print_info "  4. Complete the OAuth flow in your browser"
+			print_info "  5. Repeat to add more accounts for automatic rotation"
+			print_info "  Manage accounts: /model-accounts-pool list|status|remove"
+			print_info "  Docs: ~/.aidevops/agents/tools/opencode/opencode-anthropic-auth.md"
+		else
+			print_warning "aidevops OpenCode plugin was not registered; 'Anthropic Pool' may be unavailable"
+			print_info "Re-run aidevops setup to register the plugin, then run: opencode auth login"
+		fi
 	else
 		print_info "After setup, authenticate with: opencode auth login"
-		print_info "  - For Claude OAuth: Select 'Anthropic' -> 'Claude Pro/Max' (built-in)"
+		print_info "  - For Claude OAuth (v1.1.36-v1.2.29): Select 'Anthropic' -> 'Claude Pro/Max' (built-in)"
 		print_info "  - Or use the aidevops OAuth pool: Select 'Anthropic Pool' for multi-account rotation"
 	fi
 

--- a/todo/tasks/t1546-brief.md
+++ b/todo/tasks/t1546-brief.md
@@ -1,0 +1,67 @@
+# t1546: Setup/update: guide users to configure OAuth pool when built-in anthropic-auth is removed in OpenCode v1.2.30
+
+## Session Origin
+
+Full-loop worker session — issue GH#5312 (ref GH#5311 in TODO.md). OpenCode v1.2.30 removes the
+built-in `anthropic-auth` plugin that previously provided `opencode auth login` → "Anthropic →
+Claude Pro/Max". Users who relied on this flow will lose OAuth access. The aidevops OAuth pool
+(t1543, `oauth-pool.mjs`) is the replacement — it provides the same OAuth flow with multi-account
+rotation. Setup and update flows need to detect this version change and guide users to the pool.
+
+## What
+
+1. Update `setup_opencode_plugins()` in `setup-modules/mcp-setup.sh` to:
+   - Detect OpenCode v1.2.30+ (where built-in anthropic-auth is removed)
+   - Print a clear guidance message directing users to configure the OAuth pool
+   - Explain the `opencode auth login` → "Anthropic Pool" flow as the replacement
+2. Update `opencode-anthropic-auth.md` to document the v1.2.30 removal and the OAuth pool as
+   the canonical replacement for all versions going forward.
+
+## Why
+
+- OpenCode v1.2.30 removes the built-in `anthropic-auth` plugin without a migration guide
+- Users who relied on `opencode auth login` → "Claude Pro/Max" will silently lose OAuth access
+- The aidevops OAuth pool (t1543) already provides the replacement — it just needs to be surfaced
+  during setup/update so users know to configure it
+- Without this guidance, users will hit auth failures and not know why
+
+## How
+
+### `setup-modules/mcp-setup.sh` — `setup_opencode_plugins()`
+
+After the aidevops plugin is registered, add a version check:
+
+```bash
+local oc_version
+oc_version=$(opencode --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
+```
+
+Compare major.minor.patch against 1.2.30. If >= 1.2.30, print guidance:
+- Built-in anthropic-auth removed in v1.2.30
+- Use `opencode auth login` → "Anthropic Pool" (provided by aidevops plugin)
+- Link to `opencode-anthropic-auth.md` for details
+
+### `opencode-anthropic-auth.md`
+
+Add a new section at the top (after the existing DEPRECATED notice) documenting:
+- v1.2.30 removes built-in anthropic-auth entirely
+- The aidevops OAuth pool (`oauth-pool.mjs`) is the replacement
+- How to add accounts: `opencode auth login` → "Anthropic Pool"
+- How to manage accounts: `/model-accounts-pool list|status|remove`
+
+## Acceptance Criteria
+
+1. `setup_opencode_plugins()` detects OpenCode >= v1.2.30 and prints OAuth pool guidance
+2. Guidance message includes the exact `opencode auth login` → "Anthropic Pool" flow
+3. `opencode-anthropic-auth.md` documents v1.2.30 removal and OAuth pool replacement
+4. ShellCheck passes on `mcp-setup.sh`
+5. markdownlint passes on `opencode-anthropic-auth.md`
+
+## Context
+
+- OAuth pool implementation: `.agents/plugins/opencode-aidevops/oauth-pool.mjs` (t1543, GH#5243)
+- Pool login flow: `opencode auth login` → select "Anthropic Pool" → enter email → OAuth browser flow
+- Pool management: `/model-accounts-pool list|status|remove <email>|reset-cooldowns`
+- Pool file: `~/.aidevops/oauth-pool.json` (separate from OpenCode's `auth.json`)
+- Version where built-in auth removed: OpenCode v1.2.30
+- Version where built-in auth was added: OpenCode v1.1.36


### PR DESCRIPTION
## Summary

- `setup_opencode_plugins()` in `setup-modules/mcp-setup.sh` now detects OpenCode >= v1.2.30 and prints step-by-step guidance for the aidevops OAuth pool login flow (`opencode auth login` → "Anthropic Pool")
- For OpenCode v1.1.36–v1.2.29, also surfaces the pool as an option alongside the built-in "Claude Pro/Max" auth
- `opencode-anthropic-auth.md` updated to document the v1.2.30 removal, the OAuth pool as the canonical replacement, multi-account setup, pool management commands, and credential storage locations

## Problem

OpenCode v1.2.30 removes the built-in `anthropic-auth` plugin with no migration guide. Users who relied on `opencode auth login` → "Anthropic → Claude Pro/Max" will silently lose OAuth access. The aidevops OAuth pool (t1543, GH#5243) is the replacement — it just needed to be surfaced during setup/update.

## Changes

### `setup-modules/mcp-setup.sh`

- Version detection: parses `opencode --version` output, compares against 1.2.30 using integer arithmetic (bash 3.2 compatible — no associative arrays, no `mapfile`)
- v1.2.30+: prints 5-step OAuth pool setup guide with pool management command reference
- v1.1.36–v1.2.29: prints existing guidance plus pool as an option

### `.agents/tools/opencode/opencode-anthropic-auth.md`

- Updated header notices to cover both v1.2.30+ (pool required) and v1.1.36–v1.2.29 (built-in)
- New "OAuth Pool Setup (v1.2.30+)" section with prerequisites, account-adding flow, pool management, pool file location, and model names
- Updated Quick Reference table with version column
- Updated "Multi-Account Setup" to document pool-based rotation (replaces outdated "not supported" note)
- Updated "Integration with aidevops" to reflect v1.2.30 change and dual credential storage paths
- Updated Version History with OpenCode built-in auth timeline

## Quality

- ShellCheck: zero violations on `mcp-setup.sh`
- markdownlint: zero violations on `opencode-anthropic-auth.md`

Closes #5312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication guidance to reflect OpenCode version-specific changes
  * Added OAuth pool setup section for newer versions
  * Expanded multi-account management and credential storage documentation

* **Chores**
  * Enhanced setup process to provide version-appropriate authentication instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->