### PR TITLE
t1547: deploy primary-agent slash commands with Claude/OpenCode parity

### DIFF
--- a/.agents/scripts/commands/accounts.md
+++ b/.agents/scripts/commands/accounts.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Accounts primary agent
+agent: Accounts
+mode: subagent
+---
+
+Execute this request with the Accounts primary agent.
+
+Request: $ARGUMENTS
+
+Focus on accounting operations, invoicing, reconciliation, and financial workflows.

--- a/.agents/scripts/commands/automate.md
+++ b/.agents/scripts/commands/automate.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Automate primary agent
+agent: Automate
+mode: subagent
+---
+
+Execute this request with the Automate primary agent.
+
+Request: $ARGUMENTS
+
+Focus on orchestration, scheduling, dispatch, monitoring, and automation workflows.

--- a/.agents/scripts/commands/build.md
+++ b/.agents/scripts/commands/build.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Build+ primary agent
+agent: Build+
+mode: subagent
+---
+
+Execute this request with the Build+ primary agent.
+
+Request: $ARGUMENTS
+
+Focus on code implementation, fixes, refactors, CI, and full-loop delivery.

--- a/.agents/scripts/commands/business.md
+++ b/.agents/scripts/commands/business.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Business primary agent
+agent: Business
+mode: subagent
+---
+
+Execute this request with the Business primary agent.
+
+Request: $ARGUMENTS
+
+Focus on company operations, strategy, process design, and operational systems.

--- a/.agents/scripts/commands/content.md
+++ b/.agents/scripts/commands/content.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Content primary agent
+agent: Content
+mode: subagent
+---
+
+Execute this request with the Content primary agent.
+
+Request: $ARGUMENTS
+
+Focus on long-form content, scripts, editorial planning, and publication assets.

--- a/.agents/scripts/commands/health.md
+++ b/.agents/scripts/commands/health.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Health primary agent
+agent: Health
+mode: subagent
+---
+
+Execute this request with the Health primary agent.
+
+Request: $ARGUMENTS
+
+Focus on health domain content and wellness-oriented operational workflows.

--- a/.agents/scripts/commands/legal.md
+++ b/.agents/scripts/commands/legal.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Legal primary agent
+agent: Legal
+mode: subagent
+---
+
+Execute this request with the Legal primary agent.
+
+Request: $ARGUMENTS
+
+Focus on compliance, policy language, contractual terms, and legal documentation.

--- a/.agents/scripts/commands/marketing.md
+++ b/.agents/scripts/commands/marketing.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Marketing primary agent
+agent: Marketing
+mode: subagent
+---
+
+Execute this request with the Marketing primary agent.
+
+Request: $ARGUMENTS
+
+Focus on campaigns, growth experiments, conversion optimization, and messaging.

--- a/.agents/scripts/commands/research.md
+++ b/.agents/scripts/commands/research.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Research primary agent
+agent: Research
+mode: subagent
+---
+
+Execute this request with the Research primary agent.
+
+Request: $ARGUMENTS
+
+Focus on evidence gathering, competitive analysis, and structured synthesis.

--- a/.agents/scripts/commands/sales.md
+++ b/.agents/scripts/commands/sales.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Sales primary agent
+agent: Sales
+mode: subagent
+---
+
+Execute this request with the Sales primary agent.
+
+Request: $ARGUMENTS
+
+Focus on pipeline operations, outreach quality, proposals, and deal enablement.

--- a/.agents/scripts/commands/seo.md
+++ b/.agents/scripts/commands/seo.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the SEO primary agent
+agent: SEO
+mode: subagent
+---
+
+Execute this request with the SEO primary agent.
+
+Request: $ARGUMENTS
+
+Focus on audits, keyword strategy, technical SEO, and search visibility improvements.

--- a/.agents/scripts/commands/social-media.md
+++ b/.agents/scripts/commands/social-media.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Social-Media primary agent
+agent: Social-Media
+mode: subagent
+---
+
+Execute this request with the Social-Media primary agent.
+
+Request: $ARGUMENTS
+
+Focus on social planning, platform-native content, cadence, and engagement workflows.

--- a/.agents/scripts/commands/video.md
+++ b/.agents/scripts/commands/video.md
@@ -1,0 +1,11 @@
+---
+description: Route work to the Video primary agent
+agent: Video
+mode: subagent
+---
+
+Execute this request with the Video primary agent.
+
+Request: $ARGUMENTS
+
+Focus on video production workflows, prompt design, editing, and delivery planning.

--- a/.agents/scripts/generate-claude-agents.sh
+++ b/.agents/scripts/generate-claude-agents.sh
@@ -11,7 +11,7 @@
 # Architecture mirrors generate-opencode-agents.sh / generate-opencode-commands.sh
 # but targets Claude Code's native configuration system.
 #
-# Prerequisites: `claude` binary must be in PATH
+# Prerequisites: none (if `claude` is missing, MCP registration is skipped)
 # Called by: setup.sh update_claude_config()
 # =============================================================================
 
@@ -28,13 +28,9 @@ set -euo pipefail
 CLAUDE_COMMANDS_DIR="$HOME/.claude/commands"
 CLAUDE_SETTINGS="$HOME/.claude/settings.json"
 
-# =============================================================================
-# GUARD: claude binary must exist
-# =============================================================================
-
-if ! command -v claude &>/dev/null; then
-	echo -e "${YELLOW}[SKIP]${NC} claude binary not found — Claude Code config skipped"
-	exit 0
+has_claude=false
+if command -v claude &>/dev/null; then
+	has_claude=true
 fi
 
 echo -e "${BLUE}Generating Claude Code configuration...${NC}"
@@ -483,64 +479,68 @@ echo -e "  ${GREEN}Done${NC} — $command_count slash commands in $CLAUDE_COMMAN
 # Only adds servers not already registered (idempotent).
 # =============================================================================
 
-echo -e "${BLUE}Registering MCP servers with Claude Code...${NC}"
-
 mcp_count=0
 
-# Get currently registered MCP servers (parse names from `claude mcp list`)
-existing_mcps=""
-if claude mcp list &>/dev/null; then
-	existing_mcps=$(claude mcp list 2>/dev/null | grep -oE '^[a-zA-Z0-9_-]+:' | tr -d ':' || true)
-fi
+if [[ "$has_claude" == "true" ]]; then
+	echo -e "${BLUE}Registering MCP servers with Claude Code...${NC}"
 
-# Helper: register an MCP server if not already present
-# Args: $1=name, $2=json_config
-register_mcp() {
-	local name="$1"
-	local json_config="$2"
+	# Get currently registered MCP servers (parse names from `claude mcp list`)
+	existing_mcps=""
+	if claude mcp list &>/dev/null; then
+		existing_mcps=$(claude mcp list 2>/dev/null | grep -oE '^[a-zA-Z0-9_-]+:' | tr -d ':' || true)
+	fi
 
-	# Check if already registered
-	if echo "$existing_mcps" | grep -qx "$name" 2>/dev/null; then
-		echo -e "  ${BLUE}=${NC} $name (already registered)"
+	# Helper: register an MCP server if not already present
+	# Args: $1=name, $2=json_config
+	register_mcp() {
+		local name="$1"
+		local json_config="$2"
+
+		# Check if already registered
+		if echo "$existing_mcps" | grep -qx "$name" 2>/dev/null; then
+			echo -e "  ${BLUE}=${NC} $name (already registered)"
+			return 0
+		fi
+
+		if claude mcp add-json "$name" "$json_config" -s user 2>/dev/null; then
+			((++mcp_count))
+			echo -e "  ${GREEN}+${NC} $name"
+		else
+			echo -e "  ${YELLOW}!${NC} $name (registration failed)"
+		fi
 		return 0
+	}
+
+	# --- Augment Context Engine ---
+	if command -v auggie &>/dev/null; then
+		local_auggie=$(command -v auggie)
+		register_mcp "auggie-mcp" "{\"type\":\"stdio\",\"command\":\"$local_auggie\",\"args\":[\"--mcp\"]}"
 	fi
 
-	if claude mcp add-json "$name" "$json_config" -s user 2>/dev/null; then
-		((++mcp_count))
-		echo -e "  ${GREEN}+${NC} $name"
-	else
-		echo -e "  ${YELLOW}!${NC} $name (registration failed)"
+	# --- context7 (library docs) ---
+	register_mcp "context7" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@upstash/context7-mcp@latest\"]}"
+
+	# --- Playwright MCP ---
+	register_mcp "playwright" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@anthropic-ai/mcp-server-playwright@latest\"]}"
+
+	# --- shadcn UI ---
+	register_mcp "shadcn" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"shadcn@latest\",\"mcp\"]}"
+
+	# --- OpenAPI Search (remote, zero install) ---
+	register_mcp "openapi-search" "{\"type\":\"sse\",\"url\":\"https://openapi-mcp.openapisearch.com/mcp\"}"
+
+	# --- macOS Automator (macOS only) ---
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		register_mcp "macos-automator" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@steipete/macos-automator-mcp@latest\"]}"
 	fi
-	return 0
-}
 
-# --- Augment Context Engine ---
-if command -v auggie &>/dev/null; then
-	local_auggie=$(command -v auggie)
-	register_mcp "auggie-mcp" "{\"type\":\"stdio\",\"command\":\"$local_auggie\",\"args\":[\"--mcp\"]}"
+	# --- Cloudflare API (remote) ---
+	register_mcp "cloudflare-api" "{\"type\":\"sse\",\"url\":\"https://mcp.cloudflare.com/mcp\"}"
+
+	echo -e "  ${GREEN}Done${NC} — $mcp_count new MCP servers registered"
+else
+	echo -e "${YELLOW}[SKIP]${NC} Claude CLI not found — skipping MCP registration"
 fi
-
-# --- context7 (library docs) ---
-register_mcp "context7" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@upstash/context7-mcp@latest\"]}"
-
-# --- Playwright MCP ---
-register_mcp "playwright" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@anthropic-ai/mcp-server-playwright@latest\"]}"
-
-# --- shadcn UI ---
-register_mcp "shadcn" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"shadcn@latest\",\"mcp\"]}"
-
-# --- OpenAPI Search (remote, zero install) ---
-register_mcp "openapi-search" "{\"type\":\"sse\",\"url\":\"https://openapi-mcp.openapisearch.com/mcp\"}"
-
-# --- macOS Automator (macOS only) ---
-if [[ "$(uname -s)" == "Darwin" ]]; then
-	register_mcp "macos-automator" "{\"type\":\"stdio\",\"command\":\"npx\",\"args\":[\"-y\",\"@steipete/macos-automator-mcp@latest\"]}"
-fi
-
-# --- Cloudflare API (remote) ---
-register_mcp "cloudflare-api" "{\"type\":\"sse\",\"url\":\"https://mcp.cloudflare.com/mcp\"}"
-
-echo -e "  ${GREEN}Done${NC} — $mcp_count new MCP servers registered"
 
 # =============================================================================
 # PHASE 3: SETTINGS.JSON

--- a/setup-modules/config.sh
+++ b/setup-modules/config.sh
@@ -139,12 +139,6 @@ update_claude_config() {
 		return 0
 	fi
 
-	# Guard: only run if claude binary exists (t1161)
-	if ! command -v claude &>/dev/null; then
-		print_info "Claude Code not found — skipping Claude config (install: https://claude.ai/download)"
-		return 0
-	fi
-
 	print_info "Updating Claude Code configuration..."
 
 	# Generate Claude Code commands (writes to ~/.claude/commands/)


### PR DESCRIPTION
## Summary
- add primary-agent command source files (`/build`, `/automate`, `/seo`, `/content`, `/marketing`, `/business`, `/accounts`, `/legal`, `/research`, `/sales`, `/social-media`, `/video`, `/health`) so both command generators deploy the same top-level routing commands
- remove the `claude` binary gate in setup config updates so `setup.sh`/`aidevops update` always deploy Claude command/settings artifacts alongside OpenCode
- make `generate-claude-agents.sh` resilient when Claude CLI is absent by skipping MCP registration while still generating slash commands and `~/.claude/settings.json`

Closes #5314