### PR TITLE
t5322: fix OpenCode plugin crash from legacy plugin config

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1114,3 +1114,5 @@ export async function AidevopsPlugin({ directory, client }) {
       compactingHook(input, output, directory),
   };
 }
+
+export default AidevopsPlugin;

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -1037,6 +1037,18 @@ export function createOpenAIPoolAuthHook(client) {
 }
 
 /**
+ * Backward-compatible alias used by older integrations.
+ * @deprecated Use createPoolAuthHook(client)
+ */
+export const poolAuthHook = createPoolAuthHook;
+
+/**
+ * Backward-compatible alias used by older integrations.
+ * @deprecated Use createOpenAIPoolAuthHook(client)
+ */
+export const openaiPoolAuthHook = createOpenAIPoolAuthHook;
+
+/**
  * Register pool providers (auth-only, no models).
  * These providers exist solely to provide the "Add Account to Pool" OAuth flows.
  * Models are served by the built-in providers, which use pool tokens

--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -82,7 +82,9 @@ The aidevops plugin must be registered in OpenCode. This is done automatically b
 Verify with:
 
 ```bash
-grep -q "opencode-aidevops" ~/.config/opencode/opencode.json && echo "Plugin registered" || echo "Run: aidevops setup"
+jq -e '.plugin | arrays | any(.[]; contains("opencode-aidevops"))' ~/.config/opencode/opencode.json >/dev/null \
+  && echo "Plugin registered" \
+  || echo "Run: aidevops setup"
 ```
 
 ### Adding Accounts

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -430,47 +430,57 @@ add_opencode_plugin() {
 	plugin_spec="$2"
 	opencode_config="$3"
 
-	# Check if plugin array exists and if plugin is already configured
-	local has_plugin_array
-	if jq -e '.plugin' "$opencode_config" >/dev/null 2>&1; then
-		has_plugin_array="true"
+	# Normalize OpenCode plugin config (legacy "plugins" object -> "plugin" array).
+	# OpenCode expects .plugin as an array of plugin spec strings.
+	local temp_file
+	temp_file=$(mktemp)
+	trap 'rm -f "${temp_file:-}"' RETURN
+	jq '
+		def as_string_array:
+			if type == "array" then [ .[] | strings ]
+			elif type == "string" then [ . ]
+			else []
+			end;
+
+		.plugin = ((.plugin // []) | as_string_array)
+		| if (.plugins | type) == "object" then
+			.plugin += [
+				.plugins
+				| to_entries[]
+				| select((.value | type) != "object" or (if (.value | has("enabled")) then .value.enabled else true end))
+				| .key
+			]
+		elif (.plugins | type) == "array" then
+			.plugin += ((.plugins) | as_string_array)
+		else
+			.
+		end
+		| del(.plugins)
+		| .plugin |= unique
+	' "$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
+
+	# Check if plugin is already in the array (string entries only)
+	local plugin_exists
+	if jq -e --arg p "$plugin_name" '.plugin | map(select(type == "string" and startswith($p))) | length > 0' "$opencode_config" >/dev/null 2>&1; then
+		plugin_exists="true"
 	else
-		has_plugin_array="false"
+		plugin_exists="false"
 	fi
 
-	if [[ "$has_plugin_array" == "true" ]]; then
-		# Check if plugin is already in the array
-		local plugin_exists
-		if jq -e --arg p "$plugin_name" '.plugin | map(select(startswith($p))) | length > 0' "$opencode_config" >/dev/null 2>&1; then
-			plugin_exists="true"
-		else
-			plugin_exists="false"
-		fi
-
-		if [[ "$plugin_exists" == "true" ]]; then
-			# Update existing plugin to latest version
-			local temp_file
-			temp_file=$(mktemp)
-			trap 'rm -f "${temp_file:-}"' RETURN
-			jq --arg old "$plugin_name" --arg new "$plugin_spec" \
-				'.plugin = [.plugin[] | if startswith($old) then $new else . end]' \
-				"$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
-			print_success "Updated $plugin_name to latest version"
-		else
-			# Add plugin to existing array
-			local temp_file
-			temp_file=$(mktemp)
-			trap 'rm -f "${temp_file:-}"' RETURN
-			jq --arg p "$plugin_spec" '.plugin += [$p]' "$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
-			print_success "Added $plugin_name plugin to OpenCode config"
-		fi
-	else
-		# Create plugin array with the plugin
-		local temp_file
+	if [[ "$plugin_exists" == "true" ]]; then
+		# Update existing plugin to latest version
 		temp_file=$(mktemp)
 		trap 'rm -f "${temp_file:-}"' RETURN
-		jq --arg p "$plugin_spec" '. + {plugin: [$p]}' "$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
-		print_success "Created plugin array with $plugin_name"
+		jq --arg old "$plugin_name" --arg new "$plugin_spec" \
+			'.plugin = [.plugin[] | if type == "string" and startswith($old) then $new else . end]' \
+			"$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
+		print_success "Updated $plugin_name to latest version"
+	else
+		# Add plugin to existing array
+		temp_file=$(mktemp)
+		trap 'rm -f "${temp_file:-}"' RETURN
+		jq --arg p "$plugin_spec" '.plugin += [$p] | .plugin |= unique' "$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
+		print_success "Added $plugin_name plugin to OpenCode config"
 	fi
 
 	return 0


### PR DESCRIPTION
## Summary
- normalize OpenCode config by migrating legacy \\`plugins\\` values into the required \\`plugin\\` string array and removing stale keys before registration
- harden setup registration queries to only process string plugin specs, preventing invalid entries from breaking startup
- add compatibility exports for oauth pool auth-hook aliases and default export for the file-based OpenCode plugin entrypoint

## Verification
- \\`shellcheck setup-modules/mcp-setup.sh\\`
- \\`node --check .agents/plugins/opencode-aidevops/index.mjs\\`
- \\`node --check .agents/plugins/opencode-aidevops/oauth-pool.mjs\\`
- targeted regression script validating legacy \\`plugins\\` object migration excludes disabled entries

Closes #5322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved plugin configuration handling with enhanced validation and deduplication to ensure reliable plugin registration and updates.
  * Added comprehensive backward compatibility support for existing plugin configuration formats and legacy settings.

* **Documentation**
  * Updated plugin registration verification documentation with refined validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->