### PR TITLE
t1548: Merge OpenAI pool OAuth into single auth hook

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1057,8 +1057,9 @@ const {
  *    `tool.execute.before`, stored in the `tool_calls` table `intent` column.
  * 8. Compaction context — preserves operational state across context resets
  * 9. OpenAI Pro pool — multi-account rotation for ChatGPT Plus/Pro accounts (t1548)
- *    Same token injection architecture as Anthropic pool. Adds "openai-pool" provider
- *    for account management and injects tokens into the built-in "openai" provider.
+ *    Same token injection architecture as Anthropic pool. Both Anthropic and OpenAI
+ *    pool OAuth methods are merged into a single auth hook (OpenCode 1.2.27 only
+ *    supports one auth hook per plugin). Injects tokens into built-in providers.
  *
  * MCP registration (Phase 2, t008.2):
  * - Registers all known MCP servers from a data-driven registry
@@ -1106,7 +1107,9 @@ export async function AidevopsPlugin({ directory, client }) {
     // Phase 6: LLM observability — capture assistant message metadata (t1308)
     event: async (input) => handleEvent(input),
 
-    // Phase 7: OAuth multi-account pool (t1543)
+    // Phase 7: OAuth multi-account pool — single hook, both providers (t1543, t1548)
+    // OpenCode 1.2.27 only supports one auth hook per plugin (arrays crash).
+    // Both Anthropic and OpenAI pool methods are merged into one hook's methods array.
     auth: createPoolAuthHook(client),
 
     // Compaction context (includes OMOC state when detected)

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -743,9 +743,9 @@ export function createPoolAuthHook(client) {
         get label() {
           const accounts = getAccounts("anthropic");
           if (accounts.length === 0) {
-            return "Add Account to Pool (Claude Pro/Max)";
+            return "Add Anthropic Account (Claude Pro/Max)";
           }
-          return `Add Account to Pool (${accounts.length} account${accounts.length === 1 ? "" : "s"})`;
+          return `Add Anthropic Account (${accounts.length} account${accounts.length === 1 ? "" : "s"})`;
         },
         type: "oauth",
         prompts: [
@@ -880,7 +880,7 @@ export function createPoolAuthHook(client) {
         get label() {
           const accounts = getAccounts("openai");
           if (accounts.length === 0) {
-            return "Add Account to Pool (ChatGPT Plus/Pro)";
+            return "Add OpenAI Account (ChatGPT Plus/Pro)";
           }
           return `Add OpenAI Account (${accounts.length} account${accounts.length === 1 ? "" : "s"})`;
         },

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -715,10 +715,20 @@ export async function injectOpenAIPoolToken(client, skipEmail) {
 }
 
 /**
- * Create the auth hook for the anthropic-pool provider.
- * This provider exists solely for the "Add Account to Pool" OAuth flow.
- * It has no models — users select models from the built-in "anthropic" provider,
- * which uses pool tokens injected into auth.json by initPoolAuth/injectPoolToken.
+ * Create the unified auth hook for the pool provider (t1543, t1548).
+ *
+ * OpenCode 1.2.27 only supports a single auth hook object per plugin — arrays
+ * crash with "Expected string, got undefined". This function returns one auth
+ * hook with both Anthropic and OpenAI OAuth methods in its `methods` array.
+ *
+ * The `provider` field ("anthropic-pool") determines which provider entry the
+ * auth dialog shows under. Both methods appear as selectable options. The actual
+ * token injection targets the correct built-in providers ("anthropic" and
+ * "openai") via client.auth.set() inside each method's callback.
+ *
+ * When OpenCode supports auth arrays (v1.2.30+), this can be split back into
+ * separate hooks per provider if desired — but the merged approach is simpler.
+ *
  * @param {any} client - OpenCode SDK client
  * @returns {import('@opencode-ai/plugin').AuthHook}
  */
@@ -727,6 +737,7 @@ export function createPoolAuthHook(client) {
     provider: "anthropic-pool",
 
     methods: [
+      // --- Anthropic pool method (Claude Pro/Max) ---
       {
         get label() {
           const accounts = getAccounts("anthropic");
@@ -862,35 +873,15 @@ export function createPoolAuthHook(client) {
           };
         },
       },
-    ],
-  };
-}
 
-/**
- * Create the auth hook for the openai-pool provider (t1548).
- * This provider exists solely for the "Add Account to Pool" OAuth flow.
- * It has no models — users select models from the built-in "openai" provider,
- * which uses pool tokens injected into auth.json by injectOpenAIPoolToken.
- *
- * OpenAI OAuth uses form-encoded bodies and a local redirect server (port 1455)
- * for its built-in flow. For the pool's add-account flow we use the same
- * redirect URI with a code-paste UX (same as Anthropic pool).
- *
- * @param {any} client - OpenCode SDK client
- * @returns {import('@opencode-ai/plugin').AuthHook}
- */
-export function createOpenAIPoolAuthHook(client) {
-  return {
-    provider: "openai-pool",
-
-    methods: [
+      // --- OpenAI pool method (ChatGPT Plus/Pro) (t1548) ---
       {
         get label() {
           const accounts = getAccounts("openai");
           if (accounts.length === 0) {
             return "Add Account to Pool (ChatGPT Plus/Pro)";
           }
-          return `Add Account to Pool (${accounts.length} account${accounts.length === 1 ? "" : "s"})`;
+          return `Add OpenAI Account (${accounts.length} account${accounts.length === 1 ? "" : "s"})`;
         },
         type: "oauth",
         prompts: [

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -6,7 +6,8 @@
  * (~/.aidevops/oauth-pool.json) to avoid conflicts with OpenCode's auth.json.
  *
  * Architecture:
- *   - auth hook: registers "anthropic-pool" and "openai-pool" providers with OAuth login flow
+ *   - auth hook: single "anthropic-pool" provider with both Anthropic and OpenAI
+ *     OAuth methods (OpenCode 1.2.27 only supports one auth hook per plugin)
  *   - loader: returns a custom fetch wrapper that rotates credentials on 429
  *   - tool: /model-accounts-pool for listing/removing accounts
  *
@@ -578,13 +579,13 @@ async function seedPoolAuthEntry(client, providerId) {
 
 /**
  * Inject pool tokens into built-in providers on session start.
- * Seeds auth entries for both anthropic-pool and openai-pool providers.
+ * Seeds the anthropic-pool auth entry (which hosts both Anthropic and OpenAI
+ * OAuth methods — OpenCode 1.2.27 only supports one auth hook per plugin).
  * @param {any} client - OpenCode SDK client
  */
 export async function initPoolAuth(client) {
-  // Seed pool provider entries (for "Add Account" OAuth flows)
+  // Seed pool provider entry (hosts both Anthropic + OpenAI OAuth methods)
   await seedPoolAuthEntry(client, "anthropic-pool");
-  await seedPoolAuthEntry(client, "openai-pool");
 
   // Inject pool tokens into built-in providers
   await injectPoolToken(client);
@@ -1028,12 +1029,18 @@ export function createPoolAuthHook(client) {
 }
 
 /**
- * Register pool providers (auth-only, no models).
- * These providers exist solely to provide the "Add Account to Pool" OAuth flows.
- * Models are served by the built-in providers, which use pool tokens
- * injected into auth.json by initPoolAuth/injectPoolToken/injectOpenAIPoolToken.
+ * Register the pool provider (auth-only, no real models).
+ *
+ * A single "anthropic-pool" provider hosts both Anthropic and OpenAI OAuth
+ * methods (OpenCode 1.2.27 only supports one auth hook per plugin). The
+ * provider name is "OAuth Account Pool" to reflect that it handles both.
+ *
+ * Models are served by the built-in providers ("anthropic", "openai"), which
+ * use pool tokens injected into auth.json by initPoolAuth/injectPoolToken/
+ * injectOpenAIPoolToken.
+ *
  * @param {any} config - OpenCode config object
- * @returns {number} number of providers newly registered (0, 1, or 2)
+ * @returns {number} number of providers newly registered (0 or 1)
  */
 export function registerPoolProvider(config) {
   if (!config.provider) config.provider = {};
@@ -1041,12 +1048,12 @@ export function registerPoolProvider(config) {
 
   if (!config.provider["anthropic-pool"]) {
     config.provider["anthropic-pool"] = {
-      name: "Anthropic Pool (Account Management)",
+      name: "OAuth Account Pool (Anthropic + OpenAI)",
       npm: "@ai-sdk/anthropic",
       api: "https://api.anthropic.com/v1",
       models: {
         "pool-account-management": {
-          name: "Add/Manage Accounts (select models from Anthropic provider)",
+          name: "Add/Manage Accounts (select models from Anthropic or OpenAI provider)",
           attachment: false, tool_call: false, temperature: false,
           modalities: { input: ["text"], output: ["text"] },
           cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
@@ -1056,26 +1063,16 @@ export function registerPoolProvider(config) {
       },
     };
     registered++;
+  } else {
+    // Update name from old "Anthropic Pool (Account Management)" to new unified name
+    config.provider["anthropic-pool"].name = "OAuth Account Pool (Anthropic + OpenAI)";
   }
 
-  // Register OpenAI pool provider (t1548)
-  if (!config.provider["openai-pool"]) {
-    config.provider["openai-pool"] = {
-      name: "OpenAI Pool (Account Management)",
-      npm: "@ai-sdk/openai",
-      api: "https://api.openai.com/v1",
-      models: {
-        "pool-account-management": {
-          name: "Add/Manage Accounts (select models from OpenAI provider)",
-          attachment: false, tool_call: false, temperature: false,
-          modalities: { input: ["text"], output: ["text"] },
-          cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-          limit: { context: 1000, output: 100 },
-          family: "pool",
-        },
-      },
-    };
-    registered++;
+  // Clean up stale "openai-pool" provider from previous versions (t1548).
+  // It had no auth hook and showed a confusing API key input. Both OAuth
+  // methods are now in the single "anthropic-pool" auth hook above.
+  if (config.provider["openai-pool"]) {
+    delete config.provider["openai-pool"];
   }
 
   return registered;
@@ -1126,10 +1123,9 @@ export function createPoolTool(client) {
       const provider = args.provider || "anthropic";
       const accounts = getAccounts(provider);
 
-      // Provider-specific add-account instructions
-      const addAccountHint = provider === "openai"
-        ? `To add an account: run \`opencode auth login\` and select "OpenAI Pool".`
-        : `To add an account: run \`opencode auth login\` and select "Anthropic Pool".`;
+      // Add-account instructions (both providers use the same pool auth dialog)
+      const providerLabel = provider === "openai" ? "ChatGPT Plus/Pro" : "Claude Pro/Max";
+      const addAccountHint = `To add an account: run \`opencode auth login\` and select "OAuth Account Pool" → "${providerLabel}".`;
 
       // Provider-specific token endpoint cooldown
       const now = Date.now();
@@ -1240,8 +1236,7 @@ export function createPoolTool(client) {
 
         case "rotate": {
           if (accounts.length < 2) {
-            const poolName = provider === "openai" ? "OpenAI Pool" : "Anthropic Pool";
-            return `Cannot rotate: only ${accounts.length} account(s) in pool. Add more accounts via Ctrl+A → ${poolName}.`;
+            return `Cannot rotate: only ${accounts.length} account(s) in pool. Add more accounts via Ctrl+A → OAuth Account Pool.`;
           }
 
           // Find which account is currently injected (most recently used)


### PR DESCRIPTION
## Summary

- Merges both Anthropic and OpenAI pool OAuth methods into a single `createPoolAuthHook` — one auth hook object with two methods in its `methods` array
- Removes the separate `createOpenAIPoolAuthHook` function that required an auth array (which crashes OpenCode 1.2.27)
- No functional change to the OAuth flows themselves — both Anthropic and OpenAI account addition work identically, just registered under one hook

## Problem

OpenCode 1.2.27 only supports a single auth hook object per plugin. The worker's PR #5319 changed `auth:` to an array of three hooks, which crashed OpenCode on startup with "Expected string, got undefined". The revert (v3.1.22) restored the single Anthropic pool hook but left the OpenAI pool without an auth hook — users couldn't add OpenAI accounts.

## Fix

The auth hook API accepts a `methods` array within a single hook object. Both providers' OAuth methods are now in that array. The `provider` field (`"anthropic-pool"`) determines which provider entry the auth dialog shows under, but the actual token injection targets the correct built-in providers (`"anthropic"` and `"openai"`) via `client.auth.set()` inside each method's callback.

When OpenCode supports auth arrays (v1.2.30+), this can optionally be split back — but the merged approach is simpler.

Closes #5318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated OAuth authentication for Anthropic and OpenAI providers into a unified authentication mechanism, streamlining the login flow across both services.

* **Documentation**
  * Updated authentication plugin documentation to reflect the consolidated OAuth approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->