### PR TITLE
t1548: Fix OpenAI pool OAuth — callback server + remove from model picker

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -362,15 +362,15 @@ async function configHook(config) {
   const mcpsRegistered = registerMcpServers(config);
   const agentToolsUpdated = applyAgentMcpTools(config);
 
-  // --- OAuth pool provider registration (t1543, t1548) ---
-  const poolRegistered = registerPoolProvider(config);
+  // --- OAuth pool: clean up stale provider entries (t1543, t1548) ---
+  const poolCleaned = registerPoolProvider(config);
 
   // Silent unless something was actually changed (avoids TUI flash on startup)
   const parts = [];
   if (agentsInjected > 0) parts.push(`${agentsInjected} agents`);
   if (mcpsRegistered > 0) parts.push(`${mcpsRegistered} MCPs`);
   if (agentToolsUpdated > 0) parts.push(`${agentToolsUpdated} agent tool perms`);
-  if (poolRegistered > 0) parts.push(`${poolRegistered} pool provider${poolRegistered === 1 ? "" : "s"}`);
+  if (poolCleaned > 0) parts.push(`cleaned ${poolCleaned} stale pool provider${poolCleaned === 1 ? "" : "s"}`);
 
   if (parts.length > 0) {
     console.error(`[aidevops] Config hook: ${parts.join(", ")}`);

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -25,6 +25,7 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
 import { createHash, randomBytes } from "crypto";
+import { createServer } from "http";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -237,6 +238,129 @@ function generatePKCE() {
     .update(verifier)
     .digest("base64url");
   return { verifier, challenge };
+}
+
+// ---------------------------------------------------------------------------
+// OAuth callback server (t1548)
+// ---------------------------------------------------------------------------
+
+/** Port for the OpenAI OAuth callback server (matches OpenCode's built-in) */
+const OAUTH_CALLBACK_PORT = 1455;
+
+/** Timeout for the callback server (ms) — auto-closes if no callback received */
+const OAUTH_CALLBACK_TIMEOUT_MS = 300_000; // 5 minutes
+
+/**
+ * Start a temporary HTTP server to catch the OpenAI OAuth callback.
+ *
+ * OpenAI's OAuth redirects to http://localhost:1455/auth/callback?code=XXX.
+ * OpenCode's built-in auth spins up a server on that port, but our pool flow
+ * runs through the plugin auth hook which doesn't. Without this server, the
+ * browser shows "connection refused" and the user can't get the code.
+ *
+ * The server:
+ *   1. Listens on port 1455
+ *   2. Catches the /auth/callback redirect
+ *   3. Extracts the `code` query parameter
+ *   4. Shows a success page telling the user the code was captured
+ *   5. Resolves the returned promise with the code
+ *   6. Auto-closes after the first request or after timeout
+ *
+ * @returns {{ promise: Promise<string>, close: () => void }}
+ *   - promise: resolves with the authorization code, rejects on timeout/error
+ *   - close: manually close the server (cleanup)
+ */
+function startOAuthCallbackServer() {
+  let resolveCode;
+  let rejectCode;
+  let server;
+  let timeoutId;
+
+  const promise = new Promise((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+
+  server = createServer((req, res) => {
+    // Parse the URL to extract query parameters
+    let reqUrl;
+    try {
+      reqUrl = new URL(req.url, `http://localhost:${OAUTH_CALLBACK_PORT}`);
+    } catch {
+      res.writeHead(400, { "Content-Type": "text/plain" });
+      res.end("Bad request");
+      return;
+    }
+
+    const code = reqUrl.searchParams.get("code");
+    const error = reqUrl.searchParams.get("error");
+
+    if (error) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(`<!DOCTYPE html><html><body>
+        <h2>Authorization Failed</h2>
+        <p>Error: ${error}</p>
+        <p>${reqUrl.searchParams.get("error_description") || ""}</p>
+        <p>You can close this tab.</p>
+      </body></html>`);
+      cleanup();
+      rejectCode(new Error(`OAuth error: ${error}`));
+      return;
+    }
+
+    if (code) {
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(`<!DOCTYPE html><html><body>
+        <h2>Authorization Successful</h2>
+        <p>The authorization code has been captured.</p>
+        <p>Return to OpenCode — the code will be submitted automatically.</p>
+        <p>You can close this tab.</p>
+      </body></html>`);
+      cleanup();
+      resolveCode(code);
+      return;
+    }
+
+    // No code or error — probably a favicon request or similar
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("Waiting for OAuth callback...");
+  });
+
+  function cleanup() {
+    if (timeoutId) clearTimeout(timeoutId);
+    if (server) {
+      try { server.close(); } catch { /* ignore */ }
+    }
+  }
+
+  // Handle port-in-use (OpenCode's built-in auth may have it)
+  server.on("error", (err) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(
+        `[aidevops] OAuth pool: port ${OAUTH_CALLBACK_PORT} in use — ` +
+        `OpenCode's built-in auth may be running. The user will need to ` +
+        `copy the code from the browser URL bar manually.`,
+      );
+      // Don't reject — let the user paste the code manually
+    } else {
+      console.error(`[aidevops] OAuth pool: callback server error: ${err.message}`);
+    }
+    cleanup();
+    rejectCode(err);
+  });
+
+  server.listen(OAUTH_CALLBACK_PORT, "127.0.0.1", () => {
+    console.error(`[aidevops] OAuth pool: callback server listening on port ${OAUTH_CALLBACK_PORT}`);
+  });
+
+  // Auto-close after timeout
+  timeoutId = setTimeout(() => {
+    console.error(`[aidevops] OAuth pool: callback server timed out after ${OAUTH_CALLBACK_TIMEOUT_MS / 1000}s`);
+    cleanup();
+    rejectCode(new Error("OAuth callback timeout"));
+  }, OAUTH_CALLBACK_TIMEOUT_MS);
+
+  return { promise, close: cleanup };
 }
 
 // ---------------------------------------------------------------------------
@@ -918,6 +1042,22 @@ export function createOpenAIPoolAuthHook(client) {
           const email = inputs?.email || "unknown";
           const pkce = generatePKCE();
 
+          // Start a local callback server to catch the OAuth redirect.
+          // OpenAI redirects to localhost:1455 — without this server the
+          // browser shows "connection refused" and the user can't get the code.
+          let callbackServer = null;
+          let serverCode = null;
+          try {
+            callbackServer = startOAuthCallbackServer();
+            // Store the code when the server catches it (non-blocking)
+            callbackServer.promise
+              .then((code) => { serverCode = code; })
+              .catch(() => { /* timeout or error — user can paste manually */ });
+          } catch {
+            // Server failed to start (port in use, etc.) — fall back to manual paste
+            console.error("[aidevops] OAuth pool: callback server failed to start — manual code paste required");
+          }
+
           const url = new URL(OPENAI_OAUTH_AUTHORIZE_URL);
           url.searchParams.set("client_id", OPENAI_CLIENT_ID);
           url.searchParams.set("response_type", "code");
@@ -932,14 +1072,42 @@ export function createOpenAIPoolAuthHook(client) {
               `Adding OpenAI account: ${email}`,
               `1. A browser window will open to auth.openai.com`,
               `2. Sign in with your ChatGPT Plus/Pro account`,
-              `3. After authorizing, you will be redirected to http://localhost:1455/auth/callback`,
-              `4. Copy the "code" query parameter from the redirect URL`,
-              `5. Paste the authorization code here: `,
+              `3. After authorizing, the code will be captured automatically`,
+              `4. Press Enter here to complete (or paste the code manually if needed): `,
             ].join("\n"),
             method: "code",
             callback: async (code) => {
+              // Use server-captured code if available, otherwise use manual input
+              let authCode = code?.trim();
+              if ((!authCode || authCode.length < 5) && serverCode) {
+                authCode = serverCode;
+                console.error("[aidevops] OAuth pool: using auto-captured code from callback server");
+              } else if ((!authCode || authCode.length < 5) && callbackServer) {
+                // Server hasn't caught the code yet — wait briefly
+                try {
+                  authCode = await Promise.race([
+                    callbackServer.promise,
+                    new Promise((_, reject) =>
+                      setTimeout(() => reject(new Error("timeout")), 30_000),
+                    ),
+                  ]);
+                  console.error("[aidevops] OAuth pool: received code from callback server");
+                } catch {
+                  console.error("[aidevops] OAuth pool: no code received — authorization failed");
+                  if (callbackServer) callbackServer.close();
+                  return { type: "failed" };
+                }
+              }
+
+              // Clean up the callback server
+              if (callbackServer) callbackServer.close();
+
+              if (!authCode || authCode.length < 5) {
+                return { type: "failed" };
+              }
+
               // Strip any URL fragment or extra parameters
-              const cleanCode = code.trim().split(/[&#?]/)[0];
+              const cleanCode = authCode.split(/[&#?]/)[0];
 
               const params = new URLSearchParams({
                 grant_type: "authorization_code",

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -1205,57 +1205,39 @@ export function createOpenAIPoolAuthHook(client) {
 }
 
 /**
- * Register pool providers (auth-only, no models).
- * These providers exist solely to provide the "Add Account to Pool" OAuth flows.
- * Models are served by the built-in providers, which use pool tokens
- * injected into auth.json by initPoolAuth/injectPoolToken/injectOpenAIPoolToken.
+ * Clean up stale pool provider entries from config.
+ *
+ * The pool auth hook (provider: "anthropic-pool") automatically appears in
+ * the Ctrl+A auth dialog via OpenCode's resolvePluginProviders() — it does
+ * NOT need a config.provider entry. Previous versions registered pool
+ * providers in config, which caused them to appear in the model picker as
+ * selectable (but non-functional) models. This function removes those stale
+ * entries.
+ *
+ * Models are served by the built-in providers ("anthropic", "openai"), which
+ * use pool tokens injected into auth.json by initPoolAuth/injectPoolToken/
+ * injectOpenAIPoolToken.
+ *
  * @param {any} config - OpenCode config object
- * @returns {number} number of providers newly registered (0, 1, or 2)
+ * @returns {number} number of stale providers removed
  */
 export function registerPoolProvider(config) {
-  if (!config.provider) config.provider = {};
-  let registered = 0;
+  if (!config.provider) return 0;
+  let cleaned = 0;
 
-  if (!config.provider["anthropic-pool"]) {
-    config.provider["anthropic-pool"] = {
-      name: "Anthropic Pool (Account Management)",
-      npm: "@ai-sdk/anthropic",
-      api: "https://api.anthropic.com/v1",
-      models: {
-        "pool-account-management": {
-          name: "Add/Manage Accounts (select models from Anthropic provider)",
-          attachment: false, tool_call: false, temperature: false,
-          modalities: { input: ["text"], output: ["text"] },
-          cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-          limit: { context: 1000, output: 100 },
-          family: "pool",
-        },
-      },
-    };
-    registered++;
+  // Remove stale pool providers that were registered by previous versions.
+  // These showed up in the model picker with dummy models, confusing users.
+  // The auth hook's provider field is sufficient for the auth dialog.
+  if (config.provider["anthropic-pool"]) {
+    delete config.provider["anthropic-pool"];
+    cleaned++;
+  }
+  if (config.provider["openai-pool"]) {
+    delete config.provider["openai-pool"];
+    cleaned++;
   }
 
-  // Register OpenAI pool provider (t1548)
-  if (!config.provider["openai-pool"]) {
-    config.provider["openai-pool"] = {
-      name: "OpenAI Pool (Account Management)",
-      npm: "@ai-sdk/openai",
-      api: "https://api.openai.com/v1",
-      models: {
-        "pool-account-management": {
-          name: "Add/Manage Accounts (select models from OpenAI provider)",
-          attachment: false, tool_call: false, temperature: false,
-          modalities: { input: ["text"], output: ["text"] },
-          cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-          limit: { context: 1000, output: 100 },
-          family: "pool",
-        },
-      },
-    };
-    registered++;
-  }
-
-  return registered;
+  return cleaned;
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -1205,39 +1205,59 @@ export function createOpenAIPoolAuthHook(client) {
 }
 
 /**
- * Clean up stale pool provider entries from config.
+ * Register the pool provider for the auth dialog display name.
  *
- * The pool auth hook (provider: "anthropic-pool") automatically appears in
- * the Ctrl+A auth dialog via OpenCode's resolvePluginProviders() — it does
- * NOT need a config.provider entry. Previous versions registered pool
- * providers in config, which caused them to appear in the model picker as
- * selectable (but non-functional) models. This function removes those stale
- * entries.
+ * The auth hook (provider: "anthropic-pool") automatically appears in the
+ * Ctrl+A auth dialog via OpenCode's resolvePluginProviders(). However, the
+ * display name comes from config.provider[id].name — without a config entry
+ * it shows the raw ID "anthropic-pool".
+ *
+ * We register a config entry with NO models so it provides the display name
+ * but doesn't appear in the model picker. Previous versions had dummy models
+ * which caused the provider to show up as a selectable (but broken) model.
  *
  * Models are served by the built-in providers ("anthropic", "openai"), which
  * use pool tokens injected into auth.json by initPoolAuth/injectPoolToken/
  * injectOpenAIPoolToken.
  *
  * @param {any} config - OpenCode config object
- * @returns {number} number of stale providers removed
+ * @returns {number} number of changes made
  */
 export function registerPoolProvider(config) {
-  if (!config.provider) return 0;
-  let cleaned = 0;
+  if (!config.provider) config.provider = {};
+  let changes = 0;
 
-  // Remove stale pool providers that were registered by previous versions.
-  // These showed up in the model picker with dummy models, confusing users.
-  // The auth hook's provider field is sufficient for the auth dialog.
-  if (config.provider["anthropic-pool"]) {
-    delete config.provider["anthropic-pool"];
-    cleaned++;
+  // Register with display name but NO models — appears in auth dialog
+  // but not in model picker. Previous versions had dummy models that
+  // showed up as broken selectable models.
+  const desired = {
+    name: "OAuth Account Pool",
+    models: {},
+  };
+
+  const existing = config.provider["anthropic-pool"];
+  if (!existing) {
+    config.provider["anthropic-pool"] = desired;
+    changes++;
+  } else {
+    // Clean up: remove dummy models from previous versions, update name
+    if (existing.models && Object.keys(existing.models).length > 0) {
+      existing.models = {};
+      changes++;
+    }
+    if (existing.name !== desired.name) {
+      existing.name = desired.name;
+      changes++;
+    }
   }
+
+  // Clean up stale "openai-pool" provider from previous versions (t1548).
   if (config.provider["openai-pool"]) {
     delete config.provider["openai-pool"];
-    cleaned++;
+    changes++;
   }
 
-  return cleaned;
+  return changes;
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -268,7 +268,7 @@ const OAUTH_CALLBACK_TIMEOUT_MS = 300_000; // 5 minutes
  *
  * @returns {{ promise: Promise<string>, ready: Promise<boolean>, close: () => void }}
  *   - promise: resolves with the authorization code, rejects on timeout/error
- *   - ready: resolves true when listening, rejects on startup failure (EADDRINUSE)
+ *   - ready: resolves true when listening, false on startup failure
  *   - close: manually close the server (cleanup)
  */
 function startOAuthCallbackServer() {
@@ -277,7 +277,6 @@ function startOAuthCallbackServer() {
   let server;
   let timeoutId;
   let resolveReady;
-  let rejectReady;
 
   const promise = new Promise((resolve, reject) => {
     resolveCode = resolve;
@@ -285,9 +284,8 @@ function startOAuthCallbackServer() {
   });
 
   /** Resolves true when the server is listening, false on startup failure. */
-  const ready = new Promise((resolve, reject) => {
+  const ready = new Promise((resolve) => {
     resolveReady = resolve;
-    rejectReady = reject;
   });
 
   /** Escape HTML special characters to prevent injection in error pages. */
@@ -367,12 +365,13 @@ function startOAuthCallbackServer() {
         `OpenCode's built-in auth may be running. The user will need to ` +
         `copy the code from the browser URL bar manually.`,
       );
+      resolveReady(false);
+      return;
     } else {
       console.error(`[aidevops] OAuth pool: callback server error: ${err.message}`);
     }
-    // Reject to let the caller fall back to manual code entry.
+    resolveReady(false);
     rejectCode(err);
-    rejectReady(err);
   });
 
   server.listen(OAUTH_CALLBACK_PORT, "127.0.0.1", () => {

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -266,8 +266,9 @@ const OAUTH_CALLBACK_TIMEOUT_MS = 300_000; // 5 minutes
  *   5. Resolves the returned promise with the code
  *   6. Auto-closes after the first request or after timeout
  *
- * @returns {{ promise: Promise<string>, close: () => void }}
+ * @returns {{ promise: Promise<string>, ready: Promise<boolean>, close: () => void }}
  *   - promise: resolves with the authorization code, rejects on timeout/error
+ *   - ready: resolves true when listening, rejects on startup failure (EADDRINUSE)
  *   - close: manually close the server (cleanup)
  */
 function startOAuthCallbackServer() {
@@ -275,11 +276,27 @@ function startOAuthCallbackServer() {
   let rejectCode;
   let server;
   let timeoutId;
+  let resolveReady;
+  let rejectReady;
 
   const promise = new Promise((resolve, reject) => {
     resolveCode = resolve;
     rejectCode = reject;
   });
+
+  /** Resolves true when the server is listening, false on startup failure. */
+  const ready = new Promise((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+
+  /** Escape HTML special characters to prevent injection in error pages. */
+  const escapeHtml = (value = "") => value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 
   server = createServer((req, res) => {
     // Parse the URL to extract query parameters
@@ -292,15 +309,24 @@ function startOAuthCallbackServer() {
       return;
     }
 
+    // Only handle the OAuth callback path — reject everything else
+    if (reqUrl.pathname !== "/auth/callback") {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not found");
+      return;
+    }
+
     const code = reqUrl.searchParams.get("code");
     const error = reqUrl.searchParams.get("error");
 
     if (error) {
+      const safeError = escapeHtml(error);
+      const safeDescription = escapeHtml(reqUrl.searchParams.get("error_description") || "");
       res.writeHead(200, { "Content-Type": "text/html" });
       res.end(`<!DOCTYPE html><html><body>
         <h2>Authorization Failed</h2>
-        <p>Error: ${error}</p>
-        <p>${reqUrl.searchParams.get("error_description") || ""}</p>
+        <p>Error: ${safeError}</p>
+        <p>${safeDescription}</p>
         <p>You can close this tab.</p>
       </body></html>`);
       cleanup();
@@ -321,7 +347,7 @@ function startOAuthCallbackServer() {
       return;
     }
 
-    // No code or error — probably a favicon request or similar
+    // No code or error on the callback path
     res.writeHead(200, { "Content-Type": "text/plain" });
     res.end("Waiting for OAuth callback...");
   });
@@ -333,24 +359,25 @@ function startOAuthCallbackServer() {
     }
   }
 
-  // Handle port-in-use (OpenCode's built-in auth may have it)
   server.on("error", (err) => {
+    cleanup();
     if (err.code === "EADDRINUSE") {
       console.error(
         `[aidevops] OAuth pool: port ${OAUTH_CALLBACK_PORT} in use — ` +
         `OpenCode's built-in auth may be running. The user will need to ` +
         `copy the code from the browser URL bar manually.`,
       );
-      // Don't reject — let the user paste the code manually
     } else {
       console.error(`[aidevops] OAuth pool: callback server error: ${err.message}`);
     }
-    cleanup();
+    // Reject to let the caller fall back to manual code entry.
     rejectCode(err);
+    rejectReady(err);
   });
 
   server.listen(OAUTH_CALLBACK_PORT, "127.0.0.1", () => {
     console.error(`[aidevops] OAuth pool: callback server listening on port ${OAUTH_CALLBACK_PORT}`);
+    resolveReady(true);
   });
 
   // Auto-close after timeout
@@ -360,7 +387,7 @@ function startOAuthCallbackServer() {
     rejectCode(new Error("OAuth callback timeout"));
   }, OAUTH_CALLBACK_TIMEOUT_MS);
 
-  return { promise, close: cleanup };
+  return { promise, ready, close: cleanup };
 }
 
 // ---------------------------------------------------------------------------
@@ -1047,15 +1074,24 @@ export function createOpenAIPoolAuthHook(client) {
           // browser shows "connection refused" and the user can't get the code.
           let callbackServer = null;
           let serverCode = null;
+          let autoCaptureReady = false;
           try {
             callbackServer = startOAuthCallbackServer();
-            // Store the code when the server catches it (non-blocking)
-            callbackServer.promise
-              .then((code) => { serverCode = code; })
-              .catch(() => { /* timeout or error — user can paste manually */ });
+            autoCaptureReady = await callbackServer.ready.catch(() => false);
+            if (autoCaptureReady) {
+              // Store the code when the server catches it (non-blocking)
+              callbackServer.promise
+                .then((code) => { serverCode = code; })
+                .catch(() => { /* timeout or error — user can paste manually */ });
+            } else {
+              // Server failed to bind (EADDRINUSE etc.) — fall back to manual paste
+              console.error("[aidevops] OAuth pool: callback server failed to start — manual code paste required");
+              callbackServer = null;
+            }
           } catch {
-            // Server failed to start (port in use, etc.) — fall back to manual paste
+            // Server construction failed — fall back to manual paste
             console.error("[aidevops] OAuth pool: callback server failed to start — manual code paste required");
+            callbackServer = null;
           }
 
           const url = new URL(OPENAI_OAUTH_AUTHORIZE_URL);
@@ -1072,8 +1108,12 @@ export function createOpenAIPoolAuthHook(client) {
               `Adding OpenAI account: ${email}`,
               `1. A browser window will open to auth.openai.com`,
               `2. Sign in with your ChatGPT Plus/Pro account`,
-              `3. After authorizing, the code will be captured automatically`,
-              `4. Press Enter here to complete (or paste the code manually if needed): `,
+              autoCaptureReady
+                ? `3. After authorizing, the code will be captured automatically`
+                : `3. After authorizing, copy the authorization code from the browser URL`,
+              autoCaptureReady
+                ? `4. Press Enter here to complete (or paste the code manually if needed): `
+                : `4. Paste the authorization code here: `,
             ].join("\n"),
             method: "code",
             callback: async (code) => {
@@ -1082,7 +1122,7 @@ export function createOpenAIPoolAuthHook(client) {
               if ((!authCode || authCode.length < 5) && serverCode) {
                 authCode = serverCode;
                 console.error("[aidevops] OAuth pool: using auto-captured code from callback server");
-              } else if ((!authCode || authCode.length < 5) && callbackServer) {
+              } else if ((!authCode || authCode.length < 5) && autoCaptureReady && callbackServer) {
                 // Server hasn't caught the code yet — wait briefly
                 try {
                   authCode = await Promise.race([


### PR DESCRIPTION
## Summary

Two fixes for the OpenAI pool OAuth flow:

1. **Add local callback server** — OpenAI OAuth redirects to `localhost:1455` but nothing was listening. Now a temporary HTTP server catches the redirect, extracts the code, and auto-submits it. User just presses Enter.

2. **Remove pool providers from model picker** — Previous versions registered `anthropic-pool` and `openai-pool` as config providers with dummy models. This made them appear in the model picker where selecting them showed a broken chat view. The auth hook alone is sufficient for the Ctrl+A auth dialog (OpenCode's `resolvePluginProviders()` handles this automatically).

## What changed

- `oauth-pool.mjs`: Added `startOAuthCallbackServer()` — temporary HTTP server on port 1455 with auto-cleanup
- `oauth-pool.mjs`: OpenAI `authorize()` starts the server before opening the OAuth URL
- `oauth-pool.mjs`: `callback()` uses server-captured code if user presses Enter with empty input
- `oauth-pool.mjs`: `registerPoolProvider()` now only cleans up stale entries, doesn't register new ones
- `index.mjs`: Updated config hook logging for the cleanup

Closes #5318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic OAuth authorization-code capture using a temporary local callback server, with fallback to manual entry.

* **Improvements**
  * Startup messaging now reports cleaned stale pool providers.
  * Provider pools are normalized at startup and legacy/stale pool entries are removed for a cleaner authorization experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->