### PR TITLE
t1547: fix: symlink aidevops plugin to ~/.config/opencode/plugins/

### DIFF
--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -82,7 +82,11 @@ The aidevops plugin must be registered in OpenCode. This is done automatically b
 Verify with:
 
 ```bash
-grep -q "opencode-aidevops" ~/.config/opencode/opencode.json && echo "Plugin registered" || echo "Run: aidevops setup"
+if [[ -L ~/.config/opencode/plugins/opencode-aidevops ]] || grep -q "opencode-aidevops" ~/.config/opencode/opencode.json 2>/dev/null; then
+  echo "Plugin registered"
+else
+  echo "Run: aidevops setup"
+fi
 ```
 
 ### Adding Accounts

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -484,28 +484,36 @@ setup_opencode_plugins() {
 		return 0
 	fi
 
-	local opencode_config
-	if ! opencode_config=$(find_opencode_config); then
-		print_skip "OpenCode plugins" "OpenCode config not found" "Run 'opencode' once to create config, then re-run setup"
-		setup_track_deferred "OpenCode plugins" "Run 'opencode' once to create config"
-		return 0
-	fi
-
-	if ! command -v jq &>/dev/null; then
-		print_skip "OpenCode plugins" "jq not installed" "Install jq: brew install jq (macOS) or apt install jq"
-		setup_track_deferred "OpenCode plugins" "Install jq"
-		return 0
-	fi
-
 	# Prerequisites met — proceed with setup
 	print_info "Setting up OpenCode plugins..."
 
-	# Setup aidevops compaction plugin (local file plugin)
-	local aidevops_plugin_path="$HOME/.aidevops/agents/plugins/opencode-aidevops/index.mjs"
+	# Setup aidevops plugin via local plugin directory (not opencode.json plugin array).
+	# OpenCode's plugin array is npm-only. Local plugins must be symlinked to:
+	#   ~/.config/opencode/plugins/  (global)
+	#   .opencode/plugins/           (project-level)
+	# See: https://opencode.ai/docs/plugins/
+	local plugins_dir="$HOME/.config/opencode/plugins"
+	local aidevops_plugin_src="$HOME/.aidevops/agents/plugins/opencode-aidevops"
+	local aidevops_plugin_dst="$plugins_dir/opencode-aidevops"
 	local pool_plugin_registered="false"
-	if [[ -f "$aidevops_plugin_path" ]]; then
-		add_opencode_plugin "file://$HOME/.aidevops" "file://${aidevops_plugin_path}" "$opencode_config"
-		print_success "aidevops compaction plugin registered (preserves context across compaction)"
+
+	if [[ ! -f "$aidevops_plugin_src/index.mjs" ]]; then
+		print_skip "OpenCode plugins" "aidevops plugin not found at $aidevops_plugin_src"
+		setup_track_deferred "OpenCode plugins" "Install/restore aidevops"
+		return 0
+	fi
+
+	# Create plugins directory if needed
+	mkdir -p "$plugins_dir"
+
+	# Symlink if not already registered
+	if [[ -L "$aidevops_plugin_dst" || -d "$aidevops_plugin_dst" ]]; then
+		print_success "aidevops plugin already registered at ~/.config/opencode/plugins/"
+		setup_track_configured "OpenCode plugins"
+		pool_plugin_registered="true"
+	else
+		ln -sf "$aidevops_plugin_src" "$aidevops_plugin_dst"
+		print_success "aidevops plugin registered at ~/.config/opencode/plugins/"
 		setup_track_configured "OpenCode plugins"
 		pool_plugin_registered="true"
 	fi

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -424,58 +424,6 @@ setup_browser_tools() {
 	return 0
 }
 
-add_opencode_plugin() {
-	local plugin_name plugin_spec opencode_config
-	plugin_name="$1"
-	plugin_spec="$2"
-	opencode_config="$3"
-
-	# Check if plugin array exists and if plugin is already configured
-	local has_plugin_array
-	if jq -e '.plugin' "$opencode_config" >/dev/null 2>&1; then
-		has_plugin_array="true"
-	else
-		has_plugin_array="false"
-	fi
-
-	if [[ "$has_plugin_array" == "true" ]]; then
-		# Check if plugin is already in the array
-		local plugin_exists
-		if jq -e --arg p "$plugin_name" '.plugin | map(select(startswith($p))) | length > 0' "$opencode_config" >/dev/null 2>&1; then
-			plugin_exists="true"
-		else
-			plugin_exists="false"
-		fi
-
-		if [[ "$plugin_exists" == "true" ]]; then
-			# Update existing plugin to latest version
-			local temp_file
-			temp_file=$(mktemp)
-			trap 'rm -f "${temp_file:-}"' RETURN
-			jq --arg old "$plugin_name" --arg new "$plugin_spec" \
-				'.plugin = [.plugin[] | if startswith($old) then $new else . end]' \
-				"$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
-			print_success "Updated $plugin_name to latest version"
-		else
-			# Add plugin to existing array
-			local temp_file
-			temp_file=$(mktemp)
-			trap 'rm -f "${temp_file:-}"' RETURN
-			jq --arg p "$plugin_spec" '.plugin += [$p]' "$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
-			print_success "Added $plugin_name plugin to OpenCode config"
-		fi
-	else
-		# Create plugin array with the plugin
-		local temp_file
-		temp_file=$(mktemp)
-		trap 'rm -f "${temp_file:-}"' RETURN
-		jq --arg p "$plugin_spec" '. + {plugin: [$p]}' "$opencode_config" >"$temp_file" && mv "$temp_file" "$opencode_config"
-		print_success "Created plugin array with $plugin_name"
-	fi
-
-	return 0
-}
-
 setup_opencode_plugins() {
 	# Check prerequisites before announcing setup (GH#5240)
 	if ! command -v opencode &>/dev/null; then
@@ -496,23 +444,34 @@ setup_opencode_plugins() {
 	local aidevops_plugin_src="$HOME/.aidevops/agents/plugins/opencode-aidevops"
 	local aidevops_plugin_dst="$plugins_dir/opencode-aidevops"
 	local pool_plugin_registered="false"
+	local aidevops_plugin_entrypoint="$aidevops_plugin_src/index.mjs"
 
-	if [[ ! -f "$aidevops_plugin_src/index.mjs" ]]; then
-		print_skip "OpenCode plugins" "aidevops plugin not found at $aidevops_plugin_src"
-		setup_track_deferred "OpenCode plugins" "Install/restore aidevops"
+	if [[ ! -f "$aidevops_plugin_entrypoint" ]]; then
+		print_skip "OpenCode plugins" "aidevops plugin entry point not found: $aidevops_plugin_entrypoint"
+		setup_track_deferred "OpenCode plugins" "Install/restore aidevops plugin at $aidevops_plugin_entrypoint"
 		return 0
 	fi
 
 	# Create plugins directory if needed
 	mkdir -p "$plugins_dir"
 
-	# Symlink if not already registered
-	if [[ -L "$aidevops_plugin_dst" || -d "$aidevops_plugin_dst" ]]; then
+	# Register plugin if needed; treat broken symlinks as unregistered.
+	if [[ -L "$aidevops_plugin_dst" && -e "$aidevops_plugin_dst" ]]; then
+		print_success "aidevops plugin already registered at ~/.config/opencode/plugins/"
+		setup_track_configured "OpenCode plugins"
+		pool_plugin_registered="true"
+	elif [[ -L "$aidevops_plugin_dst" ]]; then
+		print_warning "Broken aidevops plugin symlink detected; recreating ~/.config/opencode/plugins/opencode-aidevops"
+		ln -sfn "$aidevops_plugin_src" "$aidevops_plugin_dst"
+		print_success "aidevops plugin registered at ~/.config/opencode/plugins/"
+		setup_track_configured "OpenCode plugins"
+		pool_plugin_registered="true"
+	elif [[ -d "$aidevops_plugin_dst" && -f "$aidevops_plugin_dst/index.mjs" ]]; then
 		print_success "aidevops plugin already registered at ~/.config/opencode/plugins/"
 		setup_track_configured "OpenCode plugins"
 		pool_plugin_registered="true"
 	else
-		ln -sf "$aidevops_plugin_src" "$aidevops_plugin_dst"
+		ln -sfn "$aidevops_plugin_src" "$aidevops_plugin_dst"
 		print_success "aidevops plugin registered at ~/.config/opencode/plugins/"
 		setup_track_configured "OpenCode plugins"
 		pool_plugin_registered="true"


### PR DESCRIPTION
## Summary

Fix `setup_opencode_plugins()` in `setup-modules/mcp-setup.sh` to symlink the aidevops plugin to `~/.config/opencode/plugins/` instead of adding a `file://` URL to the `plugin` array in `opencode.json`.

OpenCode's `plugin` array is npm-package-only. Local plugins must be placed in `~/.config/opencode/plugins/` and are auto-loaded from there — `file://` URLs have no effect there.

## Changes

- Removed `jq` dependency check (no longer manipulates `opencode.json` for plugin registration)
- Removed `opencode_config` lookup (no longer needed)
- Replaced `add_opencode_plugin "file://..."` call with `mkdir -p` + `ln -sf` to register the plugin at `~/.config/opencode/plugins/opencode-aidevops`
- Added source file existence check before attempting registration
- `pool_plugin_registered` now reflects whether the symlink exists

## Problem

After running aidevops setup, users had `"plugin": ["file:///Users/.../index.mjs"]` in `opencode.json`. This had no effect — OpenCode ignores `file://` URLs in the plugin array. The plugin was never loaded, so:

- OAuth pool (`Anthropic Pool`) was unavailable in `opencode auth login`
- Users fell back to broken built-in auth and got "Failed to authorize"

## Quality

- ShellCheck: zero violations on `mcp-setup.sh`
- Manual symlink confirmed working: `~/.config/opencode/plugins/opencode-aidevops` exists and OpenCode loads it

## Closes

- Fixes t1547 (GH#5328)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified OpenCode plugin setup to rely on filesystem-based registration, improving robustness and automatic recovery for broken or missing registrations.
  * Setup now accurately detects and tracks whether the plugin is registered.

* **Documentation**
  * Verification instructions updated to recognize registration via either a filesystem link or registry entry, with clearer guidance to run setup when unregistered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #5328