### PR TITLE
t5336: fix(cloudron): use jq for version parsing instead of grep

### DIFF
--- a/.agents/services/hosting/cloudron.md
+++ b/.agents/services/hosting/cloudron.md
@@ -251,7 +251,7 @@ last reboot | head -5
 journalctl -b -1 --no-pager | grep -i -E 'cloudron.*update|cloudron-updater'
 
 # Get the current Cloudron version
-grep -E '^\s*"version":' /home/yellowtent/box/package.json
+jq -r '.version' /home/yellowtent/box/package.json
 ```
 
 **Step 2: Assess system resources** — Rule out OOM, disk full, or CPU saturation.
@@ -388,7 +388,7 @@ docker exec -it <container_name> /bin/bash
 | App-specific logs | `docker logs <container_name>` | Individual app startup/runtime errors |
 | System journal (previous boot) | `journalctl -b -1 --no-pager -n 50 -p warning` | What happened before the reboot |
 | Cloudron troubleshoot | `cloudron-support --troubleshoot` | Built-in diagnostic checks (DNS, certs, services, migrations) |
-| Cloudron version | `grep -E '^\s*"version":' /home/yellowtent/box/package.json` | Current Cloudron version |
+| Cloudron version | `jq -r '.version' /home/yellowtent/box/package.json` | Current Cloudron version |
 
 ### **Database Troubleshooting (MySQL)**
 


### PR DESCRIPTION
## Summary

- Replace `grep -E '^\s*"version":'` with `jq -r '.version'` at line 254 (bash code block) and line 391 (quick-reference table) in `.agents/services/hosting/cloudron.md`
- `jq` is resilient to minified JSON and is already an accepted project tool per the general rules
- Addresses both MEDIUM findings from gemini-code-assist review on PR #5308

Closes #5336

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Cloudron platform diagnostics documentation to improve version information retrieval in post-reboot and update procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->