### PR TITLE
fix: mcp-setup.sh version parsing and comparison efficiency

### DIFF
--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -488,20 +488,16 @@ setup_opencode_plugins() {
 	oc_raw_version=$(opencode --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "0.0.0")
 
 	local oc_major oc_minor oc_patch
-	oc_major=$(printf '%s' "$oc_raw_version" | cut -d. -f1)
-	oc_minor=$(printf '%s' "$oc_raw_version" | cut -d. -f2)
-	oc_patch=$(printf '%s' "$oc_raw_version" | cut -d. -f3)
+	IFS='.' read -r oc_major oc_minor oc_patch <<<"$oc_raw_version"
 	oc_major="${oc_major:-0}"
 	oc_minor="${oc_minor:-0}"
 	oc_patch="${oc_patch:-0}"
 
 	# Compare against 1.2.30 (where built-in anthropic-auth was removed)
 	local builtin_auth_removed="false"
-	if [[ "$oc_major" -gt 1 ]]; then
-		builtin_auth_removed="true"
-	elif [[ "$oc_major" -eq 1 && "$oc_minor" -gt 2 ]]; then
-		builtin_auth_removed="true"
-	elif [[ "$oc_major" -eq 1 && "$oc_minor" -eq 2 && "$oc_patch" -ge 30 ]]; then
+	if [[ "$oc_major" -gt 1 ]] ||
+		[[ "$oc_major" -eq 1 && "$oc_minor" -gt 2 ]] ||
+		[[ "$oc_major" -eq 1 && "$oc_minor" -eq 2 && "$oc_patch" -ge 30 ]]; then
 		builtin_auth_removed="true"
 	fi
 


### PR DESCRIPTION
## Summary

- Replace 3 `cut` subprocesses with a single `IFS='.' read -r` for version string parsing (avoids spawning 3 subshells)
- Combine 3 separate `if/elif` blocks into one `if` with `||` operators for version comparison (reduces duplication, improves readability)

## Changes

`setup-modules/mcp-setup.sh` lines 490-502:

**Before**: 3 `cut` subprocesses + 3 separate `if/elif` blocks
**After**: Single `IFS='.' read -r` + one `if` with `||` conditions

ShellCheck: zero violations.

Closes #5333