### PR TITLE
t5334: remove redundant claude availability flag

### DIFF
--- a/.agents/scripts/generate-claude-agents.sh
+++ b/.agents/scripts/generate-claude-agents.sh
@@ -28,11 +28,6 @@ set -euo pipefail
 CLAUDE_COMMANDS_DIR="$HOME/.claude/commands"
 CLAUDE_SETTINGS="$HOME/.claude/settings.json"
 
-has_claude=false
-if command -v claude &>/dev/null; then
-	has_claude=true
-fi
-
 echo -e "${BLUE}Generating Claude Code configuration...${NC}"
 
 # =============================================================================
@@ -481,7 +476,7 @@ echo -e "  ${GREEN}Done${NC} — $command_count slash commands in $CLAUDE_COMMAN
 
 mcp_count=0
 
-if [[ "$has_claude" == "true" ]]; then
+if command -v claude &>/dev/null; then
 	echo -e "${BLUE}Registering MCP servers with Claude Code...${NC}"
 
 	# Get currently registered MCP servers (parse names from `claude mcp list`)


### PR DESCRIPTION
## Summary
- remove the top-level `has_claude` state from `generate-claude-agents.sh`
- perform the `claude` binary availability check directly at MCP registration point of use
- keep script behavior unchanged while reducing duplicated logic and improving locality

Closes #5334