### PR TITLE
t5346: docs: rephrase HELPER path comment to be more direct

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -160,7 +160,7 @@ Not every task is code. The framework has multiple primary agents, each with dom
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 AGENTS_DIR="${AGENTS_DIR:-"$HOME/.aidevops/agents"}"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
-# Resolves helper path dynamically when `agents_dir` is customized
+# Path is determined by 'paths.agents_dir' in config.jsonc
 
 # Code task (default — Build+ implied)
 $HELPER run \


### PR DESCRIPTION
## Summary

- Rephrase `# Resolves helper path dynamically when 'agents_dir' is customized` to `# Path is determined by 'paths.agents_dir' in config.jsonc` in `.agents/AGENTS.md`
- Applies Gemini reviewer's suggestion from PR #5234: more direct, concise wording aligned with tiered documentation structure

## Changes

Single-line comment update in the dispatch example code block (`.agents/AGENTS.md:163`).

Closes #5346

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how the agent helper path configuration is determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->