### PR TITLE
t5346: chore: rephrase HELPER path comment for conciseness

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -160,7 +160,7 @@ Not every task is code. The framework has multiple primary agents, each with dom
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 AGENTS_DIR="${AGENTS_DIR:-"$HOME/.aidevops/agents"}"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
-# Resolves helper path dynamically when `agents_dir` is customized
+# Path is determined by 'paths.agents_dir' in config.jsonc
 
 # Code task (default — Build+ implied)
 $HELPER run \


### PR DESCRIPTION
## Summary

- Rephrase the `HELPER` path comment in `.agents/AGENTS.md` from verbose to concise form per Gemini review feedback on PR #5234
- Change: `# Resolves helper path dynamically when \`agents_dir\` is customized` → `# Path is determined by 'paths.agents_dir' in config.jsonc`
- Aligns with the tiered documentation structure convention (concise core file, details in reference files)

Closes #5346