### PR TITLE
t5344: fix: deduplicate OpenCode plugin registration block in mcp-setup.sh

### DIFF
--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -456,26 +456,20 @@ setup_opencode_plugins() {
 	mkdir -p "$plugins_dir"
 
 	# Register plugin if needed; treat broken symlinks as unregistered.
-	if [[ -L "$aidevops_plugin_dst" && -e "$aidevops_plugin_dst" ]]; then
+	if [[ -L "$aidevops_plugin_dst" ]]; then
+		if [[ ! -e "$aidevops_plugin_dst" ]]; then
+			print_warning "Broken aidevops plugin symlink detected; recreating ~/.config/opencode/plugins/opencode-aidevops"
+			ln -sfn "$aidevops_plugin_src" "$aidevops_plugin_dst"
+		fi
 		print_success "aidevops plugin already registered at ~/.config/opencode/plugins/"
-		setup_track_configured "OpenCode plugins"
-		pool_plugin_registered="true"
-	elif [[ -L "$aidevops_plugin_dst" ]]; then
-		print_warning "Broken aidevops plugin symlink detected; recreating ~/.config/opencode/plugins/opencode-aidevops"
-		ln -sfn "$aidevops_plugin_src" "$aidevops_plugin_dst"
-		print_success "aidevops plugin registered at ~/.config/opencode/plugins/"
-		setup_track_configured "OpenCode plugins"
-		pool_plugin_registered="true"
 	elif [[ -d "$aidevops_plugin_dst" && -f "$aidevops_plugin_dst/index.mjs" ]]; then
 		print_success "aidevops plugin already registered at ~/.config/opencode/plugins/"
-		setup_track_configured "OpenCode plugins"
-		pool_plugin_registered="true"
 	else
 		ln -sfn "$aidevops_plugin_src" "$aidevops_plugin_dst"
 		print_success "aidevops plugin registered at ~/.config/opencode/plugins/"
-		setup_track_configured "OpenCode plugins"
-		pool_plugin_registered="true"
 	fi
+	setup_track_configured "OpenCode plugins"
+	pool_plugin_registered="true"
 
 	# Note: opencode-anthropic-auth is built into OpenCode v1.1.36+
 	# Adding it as an external plugin causes TypeError due to double-loading.


### PR DESCRIPTION
## Summary

- Hoists `setup_track_configured "OpenCode plugins"` and `pool_plugin_registered="true"` out of the if/elif/else branches — these two lines were identical across all 4 paths
- Consolidates broken-symlink handling into a nested check within the symlink branch
- Reduces 4 branches to 3 with shared post-block state, eliminating the duplication flagged by Gemini in PR #5329

## Changes

`setup-modules/mcp-setup.sh`: 7 insertions, 13 deletions — net -6 lines

## Verification

- `shellcheck setup-modules/mcp-setup.sh` — zero violations
- Logic equivalence: all original code paths preserved; only the duplicated trailing lines moved outside the conditional

Closes #5344