### PR TITLE
t5346: fix: concise HELPER path comment per gemini review feedback

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -160,7 +160,7 @@ Not every task is code. The framework has multiple primary agents, each with dom
 AGENTS_DIR="$(aidevops config get paths.agents_dir)"
 AGENTS_DIR="${AGENTS_DIR:-"$HOME/.aidevops/agents"}"
 HELPER="${AGENTS_DIR/#\~/$HOME}/scripts/headless-runtime-helper.sh"
-# Resolves helper path dynamically when `agents_dir` is customized
+# Path is determined by 'paths.agents_dir' in config.jsonc
 
 # Code task (default — Build+ implied)
 $HELPER run \


### PR DESCRIPTION
## Summary

- Replace verbose comment `# Resolves helper path dynamically when 'agents_dir' is customized` with concise `# Path is determined by 'paths.agents_dir' in config.jsonc` at `.agents/AGENTS.md:163`
- Addresses gemini-code-assist medium finding from PR #5234 review
- Aligns with tiered documentation principle: core file comments should be direct, not explanatory prose

## Change

**File**: `.agents/AGENTS.md:163`

Before:
```
# Resolves helper path dynamically when `agents_dir` is customized
```

After:
```
# Path is determined by 'paths.agents_dir' in config.jsonc
```

Closes #5346