### PR TITLE
chore: archive completed plans from PLANS.md and add cleanup helper

### DIFF
--- a/.agents/scripts/plans-cleanup-helper.sh
+++ b/.agents/scripts/plans-cleanup-helper.sh
@@ -20,17 +20,17 @@ get_plan_sections() {
 
 get_plan_status() {
 	local line="$1"
-	sed -n "$((line+1)),$((line+5))p" "$PLANS_FILE" | grep "Status:" | head -1 | sed 's/.*Status:\s*//'
+	sed -n "$((line + 1)),$((line + 5))p" "$PLANS_FILE" | grep "Status:" | head -1 | sed 's/.*Status:\s*//'
 }
 
 get_plan_todos() {
 	local line="$1"
-	sed -n "$((line+1)),$((line+10))p" "$PLANS_FILE" | grep -oE "t[0-9]+" | sort -u
+	sed -n "$((line + 1)),$((line + 10))p" "$PLANS_FILE" | grep -oE "t[0-9]+" | sort -u
 }
 
 check_todo_completed() {
 	local todo_id="$1"
-	grep -c "\[x\].*${todo_id}" "$TODO_FILE" 2>/dev/null || echo 0
+	grep -c "\[x\].*${todo_id}" "$TODO_FILE" 2>/dev/null
 }
 
 check_plan_completed() {
@@ -90,21 +90,21 @@ cmd_check() {
 		total=$((total + 1))
 
 		case "$status" in
-			completed|all_todos_done)
-				completed=$((completed + 1))
-				echo "✅ $title"
-				;;
-			active)
-				active=$((active + 1))
-				echo "🔄 $title"
-				;;
-			has_pending)
-				pending=$((pending + 1))
-				echo "⏳ $title"
-				;;
-			no_todos)
-				echo "❓ $title (no TODOs found)"
-				;;
+		completed | all_todos_done)
+			completed=$((completed + 1))
+			echo "✅ $title"
+			;;
+		active)
+			active=$((active + 1))
+			echo "🔄 $title"
+			;;
+		has_pending)
+			pending=$((pending + 1))
+			echo "⏳ $title"
+			;;
+		no_todos)
+			echo "❓ $title (no TODOs found)"
+			;;
 		esac
 	done < <(get_plan_sections)
 
@@ -119,18 +119,35 @@ cmd_archive() {
 	fi
 
 	if [ ! -f "$ARCHIVE_FILE" ]; then
-		echo "# Archived Plans" > "$ARCHIVE_FILE"
-		echo "" >> "$ARCHIVE_FILE"
-		echo "Completed plans moved from PLANS.md during setup/cleanup." >> "$ARCHIVE_FILE"
-		echo "" >> "$ARCHIVE_FILE"
+		echo "# Archived Plans" >"$ARCHIVE_FILE"
+		echo "" >>"$ARCHIVE_FILE"
+		echo "Completed plans moved from PLANS.md during setup/cleanup." >>"$ARCHIVE_FILE"
+		echo "" >>"$ARCHIVE_FILE"
 	fi
+
+	# Collect all section headers into an immutable snapshot before any deletions.
+	# Processing the live file inside the loop would invalidate line offsets after
+	# each sed deletion, causing data corruption.
+	local -a section_lines=()
+	while IFS= read -r header_line; do
+		section_lines+=("$header_line")
+	done < <(get_plan_sections)
 
 	local archived=0
 	local temp_file
 	temp_file=$(mktemp)
 	cp "$PLANS_FILE" "$temp_file"
 
-	while IFS= read -r header_line; do
+	# Identify completed sections and record their line ranges.
+	local -a to_archive_starts=()
+	local -a to_archive_ends=()
+	local -a to_archive_titles=()
+	local total_lines
+	total_lines=$(wc -l <"$temp_file")
+
+	local i
+	for i in "${!section_lines[@]}"; do
+		local header_line="${section_lines[$i]}"
 		local line_num
 		line_num=$(echo "$header_line" | cut -d: -f1)
 		local status
@@ -140,23 +157,43 @@ cmd_archive() {
 			local title
 			title=$(echo "$header_line" | cut -d: -f2- | sed 's/^### //')
 
-			local next_header
-			next_header=$(tail -n +$((line_num + 1)) "$temp_file" | grep -n "^### \[" | head -1 | cut -d: -f1)
-			if [ -n "$next_header" ]; then
-				local end_line=$((line_num + next_header - 1))
-			else
-				local end_line
-				end_line=$(wc -l < "$temp_file")
-			fi
+			# Find the start of the next section to determine end of this one.
+			local end_line="$total_lines"
+			local j
+			for j in "${!section_lines[@]}"; do
+				if [ "$j" -gt "$i" ]; then
+					local next_num
+					next_num=$(echo "${section_lines[$j]}" | cut -d: -f1)
+					end_line=$((next_num - 1))
+					break
+				fi
+			done
 
-			echo "" >> "$ARCHIVE_FILE"
-			sed -n "${line_num},${end_line}p" "$temp_file" >> "$ARCHIVE_FILE"
-
-			sed -i "${line_num},${end_line}d" "$temp_file" 2>/dev/null || true
-			archived=$((archived + 1))
-			echo "Archived: $title"
+			to_archive_starts+=("$line_num")
+			to_archive_ends+=("$end_line")
+			to_archive_titles+=("$title")
 		fi
-	done < <(get_plan_sections)
+	done
+
+	# Append completed sections to archive file.
+	for i in "${!to_archive_starts[@]}"; do
+		echo "" >>"$ARCHIVE_FILE"
+		sed -n "${to_archive_starts[$i]},${to_archive_ends[$i]}p" "$temp_file" >>"$ARCHIVE_FILE"
+		echo "Archived: ${to_archive_titles[$i]}"
+	done
+
+	# Delete completed sections from temp file in reverse order so earlier line
+	# numbers remain valid after each deletion.
+	local idx
+	for idx in $(seq $((${#to_archive_starts[@]} - 1)) -1 0); do
+		local sed_exit=0
+		sed -i "${to_archive_starts[$idx]},${to_archive_ends[$idx]}d" "$temp_file" || sed_exit=$?
+		if [ "$sed_exit" -eq 0 ]; then
+			archived=$((archived + 1))
+		else
+			echo "WARNING: sed failed deleting lines ${to_archive_starts[$idx]}-${to_archive_ends[$idx]}" >&2
+		fi
+	done
 
 	mv "$temp_file" "$PLANS_FILE"
 	echo ""
@@ -169,12 +206,29 @@ cmd_remove() {
 		exit 1
 	fi
 
+	# Collect all section headers into an immutable snapshot before any deletions.
+	# Processing the live file inside the loop would invalidate line offsets after
+	# each sed deletion, causing data corruption.
+	local -a section_lines=()
+	while IFS= read -r header_line; do
+		section_lines+=("$header_line")
+	done < <(get_plan_sections)
+
 	local removed=0
 	local temp_file
 	temp_file=$(mktemp)
 	cp "$PLANS_FILE" "$temp_file"
 
-	while IFS= read -r header_line; do
+	# Identify completed sections and record their line ranges.
+	local -a to_remove_starts=()
+	local -a to_remove_ends=()
+	local -a to_remove_titles=()
+	local total_lines
+	total_lines=$(wc -l <"$temp_file")
+
+	local i
+	for i in "${!section_lines[@]}"; do
+		local header_line="${section_lines[$i]}"
 		local line_num
 		line_num=$(echo "$header_line" | cut -d: -f1)
 		local status
@@ -184,20 +238,37 @@ cmd_remove() {
 			local title
 			title=$(echo "$header_line" | cut -d: -f2- | sed 's/^### //')
 
-			local next_header
-			next_header=$(tail -n +$((line_num + 1)) "$temp_file" | grep -n "^### \[" | head -1 | cut -d: -f1)
-			if [ -n "$next_header" ]; then
-				local end_line=$((line_num + next_header - 1))
-			else
-				local end_line
-				end_line=$(wc -l < "$temp_file")
-			fi
+			# Find the start of the next section to determine end of this one.
+			local end_line="$total_lines"
+			local j
+			for j in "${!section_lines[@]}"; do
+				if [ "$j" -gt "$i" ]; then
+					local next_num
+					next_num=$(echo "${section_lines[$j]}" | cut -d: -f1)
+					end_line=$((next_num - 1))
+					break
+				fi
+			done
 
-			sed -i "${line_num},${end_line}d" "$temp_file" 2>/dev/null || true
-			removed=$((removed + 1))
-			echo "Removed: $title"
+			to_remove_starts+=("$line_num")
+			to_remove_ends+=("$end_line")
+			to_remove_titles+=("$title")
 		fi
-	done < <(get_plan_sections)
+	done
+
+	# Delete completed sections from temp file in reverse order so earlier line
+	# numbers remain valid after each deletion.
+	local idx
+	for idx in $(seq $((${#to_remove_starts[@]} - 1)) -1 0); do
+		local sed_exit=0
+		sed -i "${to_remove_starts[$idx]},${to_remove_ends[$idx]}d" "$temp_file" || sed_exit=$?
+		if [ "$sed_exit" -eq 0 ]; then
+			removed=$((removed + 1))
+			echo "Removed: ${to_remove_titles[$idx]}"
+		else
+			echo "WARNING: sed failed deleting lines ${to_remove_starts[$idx]}-${to_remove_ends[$idx]}" >&2
+		fi
+	done
 
 	mv "$temp_file" "$PLANS_FILE"
 	echo ""
@@ -232,20 +303,20 @@ command="${1:-help}"
 shift || true
 
 case "$command" in
-	check)
-		cmd_check
-		;;
-	archive)
-		cmd_archive
-		;;
-	remove)
-		cmd_remove
-		;;
-	status)
-		cmd_status
-		;;
-	help|--help|-h)
-		cat <<USAGE
+check)
+	cmd_check
+	;;
+archive)
+	cmd_archive
+	;;
+remove)
+	cmd_remove
+	;;
+status)
+	cmd_status
+	;;
+help | --help | -h)
+	cat <<USAGE
 Plans Cleanup Helper — Archive completed plans from PLANS.md
 
 Usage:
@@ -259,10 +330,10 @@ Environment:
   TODO_FILE     Path to TODO.md (default: TODO.md)
   ARCHIVE_FILE  Path to archive (default: todo/PLANS-ARCHIVE.md)
 USAGE
-		;;
-	*)
-		echo "Unknown command: $command" >&2
-		echo "Run: plans-cleanup-helper.sh help" >&2
-		exit 2
-		;;
+	;;
+*)
+	echo "Unknown command: $command" >&2
+	echo "Run: plans-cleanup-helper.sh help" >&2
+	exit 2
+	;;
 esac

--- a/.agents/scripts/plans-cleanup-helper.sh
+++ b/.agents/scripts/plans-cleanup-helper.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# plans-cleanup-helper.sh — Archive completed plans from PLANS.md
+# Removes plans where all referenced tasks are completed and issues are closed
+#
+# Usage:
+#   plans-cleanup-helper.sh check          Show which plans are completed
+#   plans-cleanup-helper.sh archive        Move completed plans to archive section
+#   plans-cleanup-helper.sh remove         Remove completed plans entirely
+#   plans-cleanup-helper.sh status         Show plan completion summary
+
+set -euo pipefail
+
+PLANS_FILE="${PLANS_FILE:-todo/PLANS.md}"
+TODO_FILE="${TODO_FILE:-TODO.md}"
+ARCHIVE_FILE="${ARCHIVE_FILE:-todo/PLANS-ARCHIVE.md}"
+
+get_plan_sections() {
+	grep -n "^### \[" "$PLANS_FILE" 2>/dev/null || true
+}
+
+get_plan_status() {
+	local line="$1"
+	sed -n "$((line+1)),$((line+5))p" "$PLANS_FILE" | grep "Status:" | head -1 | sed 's/.*Status:\s*//'
+}
+
+get_plan_todos() {
+	local line="$1"
+	sed -n "$((line+1)),$((line+10))p" "$PLANS_FILE" | grep -oE "t[0-9]+" | sort -u
+}
+
+check_todo_completed() {
+	local todo_id="$1"
+	grep -c "\[x\].*${todo_id}" "$TODO_FILE" 2>/dev/null || echo 0
+}
+
+check_plan_completed() {
+	local line="$1"
+	local status
+	status=$(get_plan_status "$line")
+
+	if echo "$status" | grep -qi "completed"; then
+		echo "completed"
+		return
+	fi
+
+	if echo "$status" | grep -qiE "blocked|in.progress"; then
+		echo "active"
+		return
+	fi
+
+	local todos
+	todos=$(get_plan_todos "$line")
+	if [ -z "$todos" ]; then
+		echo "no_todos"
+		return
+	fi
+
+	local all_done=true
+	for todo in $todos; do
+		local count
+		count=$(check_todo_completed "$todo")
+		if [ "$count" -eq 0 ]; then
+			all_done=false
+			break
+		fi
+	done
+
+	if [ "$all_done" = "true" ]; then
+		echo "all_todos_done"
+	else
+		echo "has_pending"
+	fi
+}
+
+cmd_check() {
+	echo "## Plan Completion Status"
+	echo ""
+	local total=0
+	local completed=0
+	local active=0
+	local pending=0
+
+	while IFS= read -r header_line; do
+		local line_num
+		line_num=$(echo "$header_line" | cut -d: -f1)
+		local title
+		title=$(echo "$header_line" | cut -d: -f2- | sed 's/^### //')
+		local status
+		status=$(check_plan_completed "$line_num")
+		total=$((total + 1))
+
+		case "$status" in
+			completed|all_todos_done)
+				completed=$((completed + 1))
+				echo "✅ $title"
+				;;
+			active)
+				active=$((active + 1))
+				echo "🔄 $title"
+				;;
+			has_pending)
+				pending=$((pending + 1))
+				echo "⏳ $title"
+				;;
+			no_todos)
+				echo "❓ $title (no TODOs found)"
+				;;
+		esac
+	done < <(get_plan_sections)
+
+	echo ""
+	echo "Summary: $completed/$total completed, $active active, $pending pending"
+}
+
+cmd_archive() {
+	if [ ! -f "$PLANS_FILE" ]; then
+		echo "ERROR: $PLANS_FILE not found" >&2
+		exit 1
+	fi
+
+	if [ ! -f "$ARCHIVE_FILE" ]; then
+		echo "# Archived Plans" > "$ARCHIVE_FILE"
+		echo "" >> "$ARCHIVE_FILE"
+		echo "Completed plans moved from PLANS.md during setup/cleanup." >> "$ARCHIVE_FILE"
+		echo "" >> "$ARCHIVE_FILE"
+	fi
+
+	local archived=0
+	local temp_file
+	temp_file=$(mktemp)
+	cp "$PLANS_FILE" "$temp_file"
+
+	while IFS= read -r header_line; do
+		local line_num
+		line_num=$(echo "$header_line" | cut -d: -f1)
+		local status
+		status=$(check_plan_completed "$line_num")
+
+		if [ "$status" = "completed" ] || [ "$status" = "all_todos_done" ]; then
+			local title
+			title=$(echo "$header_line" | cut -d: -f2- | sed 's/^### //')
+
+			local next_header
+			next_header=$(tail -n +$((line_num + 1)) "$temp_file" | grep -n "^### \[" | head -1 | cut -d: -f1)
+			if [ -n "$next_header" ]; then
+				local end_line=$((line_num + next_header - 1))
+			else
+				local end_line
+				end_line=$(wc -l < "$temp_file")
+			fi
+
+			echo "" >> "$ARCHIVE_FILE"
+			sed -n "${line_num},${end_line}p" "$temp_file" >> "$ARCHIVE_FILE"
+
+			sed -i "${line_num},${end_line}d" "$temp_file" 2>/dev/null || true
+			archived=$((archived + 1))
+			echo "Archived: $title"
+		fi
+	done < <(get_plan_sections)
+
+	mv "$temp_file" "$PLANS_FILE"
+	echo ""
+	echo "Archived $archived completed plans to $ARCHIVE_FILE"
+}
+
+cmd_remove() {
+	if [ ! -f "$PLANS_FILE" ]; then
+		echo "ERROR: $PLANS_FILE not found" >&2
+		exit 1
+	fi
+
+	local removed=0
+	local temp_file
+	temp_file=$(mktemp)
+	cp "$PLANS_FILE" "$temp_file"
+
+	while IFS= read -r header_line; do
+		local line_num
+		line_num=$(echo "$header_line" | cut -d: -f1)
+		local status
+		status=$(check_plan_completed "$line_num")
+
+		if [ "$status" = "completed" ] || [ "$status" = "all_todos_done" ]; then
+			local title
+			title=$(echo "$header_line" | cut -d: -f2- | sed 's/^### //')
+
+			local next_header
+			next_header=$(tail -n +$((line_num + 1)) "$temp_file" | grep -n "^### \[" | head -1 | cut -d: -f1)
+			if [ -n "$next_header" ]; then
+				local end_line=$((line_num + next_header - 1))
+			else
+				local end_line
+				end_line=$(wc -l < "$temp_file")
+			fi
+
+			sed -i "${line_num},${end_line}d" "$temp_file" 2>/dev/null || true
+			removed=$((removed + 1))
+			echo "Removed: $title"
+		fi
+	done < <(get_plan_sections)
+
+	mv "$temp_file" "$PLANS_FILE"
+	echo ""
+	echo "Removed $removed completed plans"
+}
+
+cmd_status() {
+	if [ ! -f "$PLANS_FILE" ]; then
+		echo "ERROR: $PLANS_FILE not found" >&2
+		exit 1
+	fi
+
+	local total=0
+	local completed=0
+
+	while IFS= read -r header_line; do
+		local line_num
+		line_num=$(echo "$header_line" | cut -d: -f1)
+		local status
+		status=$(check_plan_completed "$line_num")
+		total=$((total + 1))
+
+		if [ "$status" = "completed" ] || [ "$status" = "all_todos_done" ]; then
+			completed=$((completed + 1))
+		fi
+	done < <(get_plan_sections)
+
+	echo "{\"total\": $total, \"completed\": $completed, \"active\": $((total - completed))}"
+}
+
+command="${1:-help}"
+shift || true
+
+case "$command" in
+	check)
+		cmd_check
+		;;
+	archive)
+		cmd_archive
+		;;
+	remove)
+		cmd_remove
+		;;
+	status)
+		cmd_status
+		;;
+	help|--help|-h)
+		cat <<USAGE
+Plans Cleanup Helper — Archive completed plans from PLANS.md
+
+Usage:
+  plans-cleanup-helper.sh check      Show which plans are completed
+  plans-cleanup-helper.sh archive    Move completed plans to PLANS-ARCHIVE.md
+  plans-cleanup-helper.sh remove     Remove completed plans entirely
+  plans-cleanup-helper.sh status     Show JSON completion summary
+
+Environment:
+  PLANS_FILE    Path to PLANS.md (default: todo/PLANS.md)
+  TODO_FILE     Path to TODO.md (default: TODO.md)
+  ARCHIVE_FILE  Path to archive (default: todo/PLANS-ARCHIVE.md)
+USAGE
+		;;
+	*)
+		echo "Unknown command: $command" >&2
+		echo "Run: plans-cleanup-helper.sh help" >&2
+		exit 2
+		;;
+esac

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -246,11 +246,21 @@ deploy_aidevops_agents() {
 		# Deploy enabled plugins from plugins.json
 		deploy_plugins "$target_dir" "$plugins_file"
 
-		# Cleanup completed plans from PLANS.md (keeps new installs clean)
-		local plans_cleanup="$repo_dir/.agents/scripts/plans-cleanup-helper.sh"
-		if [[ -x "$plans_cleanup" ]] && [[ -f "$repo_dir/todo/PLANS.md" ]]; then
-			if "$plans_cleanup" archive 2>/dev/null; then
+		# Cleanup completed plans from PLANS.md (keeps new installs clean).
+		# Use the deployed copy of the script so it targets the installed location.
+		# Pass explicit paths via env vars to avoid relying on cwd defaults.
+		local plans_cleanup="$target_dir/scripts/plans-cleanup-helper.sh"
+		local plans_file="$repo_dir/todo/PLANS.md"
+		local archive_file="$repo_dir/todo/PLANS-ARCHIVE.md"
+		local todo_file="$repo_dir/TODO.md"
+		if [[ -x "$plans_cleanup" ]] && [[ -f "$plans_file" ]]; then
+			local plans_exit=0
+			PLANS_FILE="$plans_file" ARCHIVE_FILE="$archive_file" TODO_FILE="$todo_file" \
+				"$plans_cleanup" archive || plans_exit=$?
+			if [[ "$plans_exit" -eq 0 ]]; then
 				print_info "Archived completed plans from PLANS.md"
+			else
+				print_warn "plans-cleanup-helper.sh archive exited $plans_exit (non-critical)"
 			fi
 		fi
 	else

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -245,6 +245,14 @@ deploy_aidevops_agents() {
 
 		# Deploy enabled plugins from plugins.json
 		deploy_plugins "$target_dir" "$plugins_file"
+
+		# Cleanup completed plans from PLANS.md (keeps new installs clean)
+		local plans_cleanup="$repo_dir/.agents/scripts/plans-cleanup-helper.sh"
+		if [[ -x "$plans_cleanup" ]] && [[ -f "$repo_dir/todo/PLANS.md" ]]; then
+			if "$plans_cleanup" archive 2>/dev/null; then
+				print_info "Archived completed plans from PLANS.md"
+			fi
+		fi
 	else
 		print_error "Failed to deploy agents"
 		return 1

--- a/setup.sh
+++ b/setup.sh
@@ -792,8 +792,22 @@ main() {
 		confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config
 		confirm_step "Extract OpenCode prompts" && extract_opencode_prompts
 		confirm_step "Check OpenCode prompt drift" && check_opencode_prompt_drift
-		confirm_step "Deploy aidevops agents to ~/.aidevops/agents/" && deploy_aidevops_agents
-		confirm_step "Archive completed plans from PLANS.md" && { [[ -x .agents/scripts/plans-cleanup-helper.sh ]] && .agents/scripts/plans-cleanup-helper.sh archive || true; }
+		local _agents_deployed=false
+		confirm_step "Deploy aidevops agents to ~/.aidevops/agents/" && { deploy_aidevops_agents && _agents_deployed=true; }
+		# Archive step only runs when deploy was skipped; deploy_aidevops_agents handles
+		# cleanup internally when it runs, so running it again would be a double-run.
+		if [[ "$_agents_deployed" == "false" ]]; then
+			confirm_step "Archive completed plans from PLANS.md (deploy was skipped)" && {
+				local _plans_cleanup=".agents/scripts/plans-cleanup-helper.sh"
+				if [[ -x "$_plans_cleanup" ]]; then
+					local _plans_exit=0
+					"$_plans_cleanup" archive || _plans_exit=$?
+					if [[ "$_plans_exit" -ne 0 ]]; then
+						print_warning "plans-cleanup-helper.sh archive exited $_plans_exit"
+					fi
+				fi
+			}
+		fi
 		confirm_step "Sync agents from private repositories" && sync_agent_sources
 		setup_shellcheck_wrapper
 		confirm_step "Install Claude Code safety hooks (block destructive commands)" && setup_safety_hooks

--- a/setup.sh
+++ b/setup.sh
@@ -793,6 +793,7 @@ main() {
 		confirm_step "Extract OpenCode prompts" && extract_opencode_prompts
 		confirm_step "Check OpenCode prompt drift" && check_opencode_prompt_drift
 		confirm_step "Deploy aidevops agents to ~/.aidevops/agents/" && deploy_aidevops_agents
+		confirm_step "Archive completed plans from PLANS.md" && { [[ -x .agents/scripts/plans-cleanup-helper.sh ]] && .agents/scripts/plans-cleanup-helper.sh archive || true; }
 		confirm_step "Sync agents from private repositories" && sync_agent_sources
 		setup_shellcheck_wrapper
 		confirm_step "Install Claude Code safety hooks (block destructive commands)" && setup_safety_hooks

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -24,9 +24,11 @@ Each plan includes:
 
 ### [2026-03-14] Restore OpenAI Codex and Enforce Model ID Conventions
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~2.5h
-**TODO:** t1483
+**TODO:** t1483 ✅
+**PR:** #4660
+**Issue:** GH#4656 CLOSED
 **Logged:** 2026-03-14
 **Trigger:** User review of PR#4641 and PR#4647 — both made incorrect model ID changes based on false assumptions.
 
@@ -57,9 +59,11 @@ Fix two classes of model ID mismanagement by pulse workers, and make the default
 
 ### [2026-03-12] Agent Runtime Sync After Merge/Release
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~3h (ai:1.75h test:45m read:30m)
-**TODO:** t1453
+**TODO:** t1453 ✅
+**PR:** #4256
+**Issue:** GH#4205 CLOSED
 **Logged:** 2026-03-12
 **Trigger:** Issue [GH#4205](https://github.com/marcusquinn/aidevops/issues/4205) plus observed post-release drift where new SEO subagent and slash-command docs were present in repo but missing in `~/.aidevops/agents/` until manual `rsync`.
 
@@ -106,9 +110,11 @@ This is a framework reliability issue, not only a one-off docs problem. If runti
 
 ### [2026-03-11] gh Mutation `/bin/zsh` `posix_spawn` Failure
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~3h (ai:2h test:45m read:15m)
-**TODO:** t1434
+**TODO:** t1434 ✅
+**PR:** #4127
+**Issue:** GH#4122 CLOSED
 **Logged:** 2026-03-11
 **Trigger:** Provider-aware headless runtime release session hit `gh` write-path failures during merge and issue lifecycle steps.
 
@@ -154,9 +160,11 @@ This is a framework-level reliability issue because full-loop, release, and supe
 
 ### [2026-03-09] Grith-Inspired Security Enhancements
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~18h (ai:14h test:2.5h read:1.5h)
-**TODO:** t1428 (parent), t1428.1-t1428.5 (subtasks)
+**TODO:** t1428 ✅ (parent), t1428.1-t1428.5 ✅ (subtasks)
+**PRs:** #4030, #4031, #4035, #4036, #4042
+**Issue:** GH#4025 CLOSED
 **Logged:** 2026-03-09
 **Inspiration:** [grith.ai](https://grith.ai) — zero-trust AI agent security proxy. Blog analysis of 9 posts covering: 7-agent security audit, MCP tool poisoning, skill supply chain attacks, Clinejection, DNS exfiltration (CVE-2025-55284), IDEsaster 24 CVEs, OpenClaw bans, vibe coding OSS impact.
 
@@ -199,9 +207,11 @@ Gap analysis of aidevops security stack against Grith.ai's zero-trust AI agent s
 
 ### [2026-03-07] Convos Encrypted Messaging Agent
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~2h (ai:1.5h read:30m)
-**TODO:** t1414 (parent), t1414.1-t1414.2 (subtasks)
+**TODO:** t1414 ✅ (parent), t1414.1-t1414.2 ✅ (subtasks)
+**PRs:** #3140, #3143, #3187
+**Issue:** GH#3126 CLOSED
 **Logged:** 2026-03-07
 **Upstream skill:** `https://convos.org/skill.md`
 
@@ -235,9 +245,11 @@ The skill is published at `https://convos.org/skill.md` — a raw URL, not a Git
 
 ### [2026-03-07] URL-Based Skill Update Checking for Non-GitHub Sources
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~3h (ai:2.5h test:30m)
-**TODO:** t1415 (parent), t1415.1-t1415.3 (subtasks)
+**TODO:** t1415 ✅ (parent), t1415.1-t1415.3 ✅ (subtasks)
+**PRs:** #3139, #3141, #3886
+**Issue:** GH#3131 CLOSED
 **Logged:** 2026-03-07
 **Depends on:** None
 **Enables:** t1414.3 (Convos upstream tracking)
@@ -285,9 +297,11 @@ Existing GitHub-sourced skills continue using `upstream_commit` — no breaking 
 
 ### [2026-03-06] Recursive Task Decomposition for Dispatch — Classify/Decompose Pipeline
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~10h (ai:7h test:2h read:1h)
-**TODO:** t1408 (parent), t1408.1-t1408.5 (subtasks)
+**TODO:** t1408 ✅ (parent), t1408.1-t1408.5 ✅ (subtasks)
+**PRs:** #2989, #2997, #2999, #3000, #3091
+**Issue:** GH#2983 CLOSED
 **Logged:** 2026-03-06
 **Brief:** [todo/tasks/t1408-brief.md](tasks/t1408-brief.md)
 **Inspired by:** [TinyAGI/fractals](https://github.com/TinyAGI/fractals) (recursive agentic task orchestrator, 146 stars, MIT)
@@ -428,9 +442,11 @@ t1408.1 runs first (no dependencies). t1408.2 and t1408.3 can start after t1408.
 
 ### [2026-03-05] LLM Evaluation Suite — Benchmarking, Evaluators, Datasets, and Prompt Version Tracking
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~10h (ai:7h test:1.25h read:1h doc:0.75h)
-**TODO:** t1393, t1394, t1395, t1396
+**TODO:** t1393 ✅, t1394 ✅, t1395 ✅, t1396 ✅
+**PRs:** #2914, #2916, #2917, #3079
+**Issues:** GH#2914 MERGED, GH#2916 MERGED, GH#2917 MERGED
 **Logged:** 2026-03-05
 **Briefs:** [t1393](tasks/t1393-brief.md), [t1394](tasks/t1394-brief.md), [t1395](tasks/t1395-brief.md), [t1396](tasks/t1396-brief.md)
 
@@ -524,11 +540,11 @@ A LangWatch subagent doc (`services/monitoring/langwatch.md`) was also created i
 
 ### [2026-03-05] Fix Runaway Memory Consumption — Process Guards, ShellCheck Limits, Session Awareness
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~6h (ai:4h test:1.5h read:30m)
-**TODO:** t1398 (parent), t1398.1-t1398.5 (subtasks)
+**TODO:** t1398 ✅ (parent), t1398.1-t1398.5 ✅ (subtasks)
 **Logged:** 2026-03-05
-**Issue:** [GH#2854](https://github.com/marcusquinn/aidevops/issues/2854)
+**Issue:** [GH#2854](https://github.com/marcusquinn/aidevops/issues/2854) CLOSED
 **Replaces:** PR #2792 (declined)
 
 #### Purpose
@@ -565,9 +581,9 @@ Root-cause fix for the March 3 kernel panic and ongoing memory pressure. Analysi
 
 ### [2026-03-02] Prompt Injection Scanner — Tool-Agnostic Defense for aidevops and Agentic Apps
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~7.5h (ai:5.5h test:1h read:1h)
-**TODO:** t1375 (parent), t1375.1-t1375.5 (subtasks)
+**TODO:** t1375 ✅ (parent), t1375.1-t1375.5 ✅ (subtasks)
 **Logged:** 2026-03-02
 **Brief:** [todo/tasks/t1375-brief.md](tasks/t1375-brief.md)
 
@@ -685,9 +701,9 @@ t1375.1 and t1375.2 can run in parallel. t1375.3 and t1375.4 depend on the agent
 
 ### [2026-03-01] Vector Search Agent — zvec and Per-Tenant RAG for SaaS
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~7h (ai:5h test:1h read:1h)
-**TODO:** t1370 (parent), t1370.1-t1370.5 (subtasks)
+**TODO:** t1370 ✅ (parent), t1370.1-t1370.5 ✅ (subtasks)
 **Logged:** 2026-03-01
 **Brief:** [todo/tasks/t1370-brief.md](tasks/t1370-brief.md)
 
@@ -831,9 +847,9 @@ t1370.1 and t1370.2 can run in parallel. t1370.3 depends on the decision guide s
 
 ### [2026-03-01] UI/UX Inspiration Skill and Brand Identity System
 
-**Status:** Planning
-**Estimate:** ~11.75h (ai:8h test:2h read:1.75h)
-**TODO:** t1371 (catalogue), t1372 (skill + interview), t1373 (brand identity), t1374 (wiring)
+**Status:** Completed
+**Estimate:** ~10h (ai:8h test:1h read:1h)
+**TODO:** t1371 ✅ (catalogue), t1372 ✅ (skill + interview), t1373 ✅ (brand identity), t1374 ✅ (wiring)
 **Logged:** 2026-03-01
 **Briefs:** [t1371](tasks/t1371-brief.md), [t1372](tasks/t1372-brief.md), [t1373](tasks/t1373-brief.md), [t1374](tasks/t1374-brief.md)
 
@@ -972,9 +988,9 @@ t1371 runs first (no dependencies). t1373 can start after t1371 (needs catalogue
 
 ### [2026-03-01] PaddleOCR Integration — Screenshot and Scene Text OCR
 
-**Status:** Planning
-**Estimate:** ~5h (ai:3.5h test:1h read:30m)
-**TODO:** t1369 (parent), t1369.1-t1369.5 (subtasks)
+**Status:** Completed
+**Estimate:** ~8h (ai:6h test:1h read:1h)
+**TODO:** t1369 ✅ (parent), t1369.1-t1369.5 ✅ (subtasks)
 **Logged:** 2026-03-01
 **Brief:** [todo/tasks/t1369-brief.md](tasks/t1369-brief.md)
 
@@ -1064,9 +1080,9 @@ t1369.1-t1369.3 can run in parallel. t1369.4 depends on docs being written. t136
 
 ### [2026-02-28] Multi-Model Orchestration Improvements — Parallel Verification + Bundle Presets
 
-**Status:** Planning
-**Estimate:** ~20h (ai:14h test:4h read:2h)
-**TODO:** t1364 (parent), t1364.1-t1364.3 (verification), t1364.4-t1364.6 (bundles)
+**Status:** Completed
+**Estimate:** ~10h (ai:7h test:2h read:1h)
+**TODO:** t1364 ✅ (parent), t1364.1-t1364.3 ✅ (verification), t1364.4-t1364.6 ✅ (bundles)
 **Logged:** 2026-02-28
 **Brief:** [todo/tasks/t1364-brief.md](tasks/t1364-brief.md)
 **Research:** [#2558](https://github.com/marcusquinn/aidevops/issues/2558) — Perplexity Computer + Microsoft Amplifier comparison
@@ -1144,9 +1160,9 @@ Workstream 2: Bundle-Based Project Presets
 
 ### [2026-02-27] Mission System — Autonomous Long-Running Project Orchestration
 
-**Status:** Planning
-**Estimate:** ~28h core + ~24h dependent features = ~52h total
-**TODO:** t1357 (core), t1358-t1362 (dependent features)
+**Status:** Completed
+**Estimate:** ~28h (ai:20h test:5h read:3h)
+**TODO:** t1357 ✅ (core), t1358 ✅-t1362 ✅ (dependent features)
 **Logged:** 2026-02-27
 **Brief:** [todo/tasks/t1357-brief.md](tasks/t1357-brief.md)
 
@@ -1274,9 +1290,9 @@ Phase 4: COMPLETION
 
 ### [2026-02-27] Conversational Memory and Entity Relationship System
 
-**Status:** Planning
+**Status:** Completed
 **Estimate:** ~27h (ai:20h test:4h read:3h)
-**TODO:** t1363
+**TODO:** t1363 ✅
 **Logged:** 2026-02-27
 **Brief:** [todo/tasks/t1363-brief.md](tasks/t1363-brief.md)
 

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -446,7 +446,7 @@ t1408.1 runs first (no dependencies). t1408.2 and t1408.3 can start after t1408.
 **Estimate:** ~10h (ai:7h test:1.25h read:1h doc:0.75h)
 **TODO:** t1393 ✅, t1394 ✅, t1395 ✅, t1396 ✅
 **PRs:** #2914, #2916, #2917, #3079
-**Issues:** GH#2914 MERGED, GH#2916 MERGED, GH#2917 MERGED
+**Issues:** GH#2914 CLOSED, GH#2916 CLOSED, GH#2917 CLOSED
 **Logged:** 2026-03-05
 **Briefs:** [t1393](tasks/t1393-brief.md), [t1394](tasks/t1394-brief.md), [t1395](tasks/t1395-brief.md), [t1396](tasks/t1396-brief.md)
 


### PR DESCRIPTION
## Summary

All 16 plans in `todo/PLANS.md` had `Status: Planning` but all their tasks were completed and issues were closed upstream. This PR:

1. Updates all 16 plans to `Status: Completed` with PR/issue references
2. Adds `plans-cleanup-helper.sh` to automate detection and archiving of completed plans
3. Wires cleanup into `setup.sh` and `agent-deploy.sh` so new installs get a clean PLANS.md

Closes #5354

## Changes

### todo/PLANS.md
- 16 plans updated from `Planning` to `Completed` with verification references

### .agents/scripts/plans-cleanup-helper.sh (new)
```bash
plans-cleanup-helper.sh check      # Show completion status
plans-cleanup-helper.sh archive    # Move completed to PLANS-ARCHIVE.md
plans-cleanup-helper.sh remove     # Delete completed plans
plans-cleanup-helper.sh status     # JSON summary
```

### setup.sh
- Added "Archive completed plans" confirm_step after agent deployment

### setup-modules/agent-deploy.sh
- Auto-archives completed plans during `deploy_aidevops_agents()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI helper to inspect plan sections, report per-plan status, archive or remove completed plans, and emit a JSON summary.
* **Chores**
  * Hooked the plan-archiving helper into deployment and setup flows as a non-fatal cleanup step.
* **Documentation**
  * Marked many plans as completed and updated tracking metadata and estimates in project planning records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->