### PR TITLE
fix: make profile README init resilient to missing repos and stale entries

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -1150,7 +1150,8 @@ cmd_init() {
 	local repo_dir="${HOME}/Git/${gh_user}"
 	local repos_json="${HOME}/.config/aidevops/repos.json"
 
-	# Check if already initialized
+	# Check if already fully initialized: repos.json entry + local dir + README with markers.
+	# If any piece is missing, fall through to recreate what's needed.
 	if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
 		local existing_profile
 		existing_profile=$(jq -r '
@@ -1161,9 +1162,15 @@ cmd_init() {
 			end
 		' "$repos_json" 2>/dev/null | head -1)
 		if [[ -n "$existing_profile" && "$existing_profile" != "null" ]]; then
-			if [[ -d "$existing_profile" ]]; then
+			if [[ -d "$existing_profile" ]] &&
+				[[ -f "${existing_profile}/README.md" ]] &&
+				grep -q '<!-- STATS-START -->' "${existing_profile}/README.md" 2>/dev/null; then
 				echo "Profile repo already initialized at $existing_profile"
 				return 0
+			fi
+			# Use existing path if directory exists (may just need README seeding)
+			if [[ -d "$existing_profile" ]]; then
+				repo_dir="$existing_profile"
 			fi
 		fi
 	fi
@@ -1175,11 +1182,13 @@ cmd_init() {
 			echo "Error: failed to create repo $repo_slug" >&2
 			return 1
 		}
+		# Give GitHub a moment to initialize the repo before cloning
+		sleep 2
 	else
 		echo "GitHub repo $repo_slug already exists"
 	fi
 
-	# Clone if not already local
+	# Clone if not already local, otherwise pull latest
 	if [[ ! -d "$repo_dir" ]]; then
 		echo "Cloning $repo_slug to $repo_dir"
 		git clone "git@github.com:${repo_slug}.git" "$repo_dir" 2>/dev/null ||
@@ -1189,6 +1198,10 @@ cmd_init() {
 		}
 	else
 		echo "Local repo already exists at $repo_dir"
+		# Pull latest to avoid conflicts when seeding README
+		git -C "$repo_dir" pull --ff-only origin main 2>/dev/null ||
+			git -C "$repo_dir" pull --ff-only origin master 2>/dev/null ||
+			true
 	fi
 
 	# Seed README.md if it doesn't have stat markers

--- a/setup.sh
+++ b/setup.sh
@@ -1511,13 +1511,28 @@ ST_PLIST
 	local repos_json="$HOME/.config/aidevops/repos.json"
 	local has_profile_repo="false"
 	if [[ -x "$pr_script" ]] && command -v gh &>/dev/null && gh auth status &>/dev/null; then
-		# Initialize profile repo if not already set up
+		# Initialize profile repo if not already set up.
+		# Verify the entry is valid: local dir exists AND README has stat markers.
+		# If the repo was deleted or local clone removed, re-run init to recreate.
+		local profile_needs_init="true"
 		if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
-			if jq -e '.initialized_repos[]? | select(.priority == "profile")' "$repos_json" >/dev/null 2>&1; then
+			local profile_path
+			profile_path=$(jq -r '
+				if .initialized_repos then
+					.initialized_repos[] | select(.priority == "profile") | .path
+				else
+					to_entries[] | select(.value.priority == "profile") | .value.path
+				end
+			' "$repos_json" 2>/dev/null | head -1)
+			if [[ -n "$profile_path" && "$profile_path" != "null" ]] &&
+				[[ -d "$profile_path" ]] &&
+				[[ -f "${profile_path}/README.md" ]] &&
+				grep -q '<!-- STATS-START -->' "${profile_path}/README.md" 2>/dev/null; then
+				profile_needs_init="false"
 				has_profile_repo="true"
 			fi
 		fi
-		if [[ "$has_profile_repo" == "false" ]]; then
+		if [[ "$profile_needs_init" == "true" ]]; then
 			print_info "Setting up GitHub profile README..."
 			if bash "$pr_script" init; then
 				has_profile_repo="true"
@@ -1525,8 +1540,6 @@ ST_PLIST
 			else
 				print_warning "Profile README setup failed (non-fatal, skipping)"
 			fi
-		else
-			has_profile_repo="true"
 		fi
 	elif [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
 		# No gh CLI but check if profile repo already registered


### PR DESCRIPTION
## Summary

- setup.sh now verifies the profile repo entry is actually valid (local dir exists, README has stat markers) before skipping init -- previously it only checked if repos.json had a profile entry, so deleted repos or missing local clones would never be recreated on setup/update
- profile-readme-helper.sh `cmd_init` now checks all three conditions (dir + README + markers) before returning early, reuses existing repo path from repos.json if dir exists but needs seeding, pulls latest before seeding to avoid push conflicts, and sleeps 2s after `gh repo create` to let GitHub initialize before cloning

## Context

Observed that a colleague's `alex-solovyev/alex-solovyev` profile repo was missing. The existing code in setup.sh would skip profile init if repos.json had *any* profile entry -- even if the local clone was deleted, the GitHub repo was removed, or the README lacked stat markers. This made the auto-creation on setup/update unreliable.

## Verification

- `shellcheck` passes on both modified files (zero violations)
- Existing boundary test (`test-profile-readme-boundary.sh`) passes -- confirms update flow still preserves content outside stat markers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved profile README setup validation to verify complete local configuration
  * Added server synchronization delay after GitHub repository creation

* **Chores**
  * Enhanced initialization detection logic for profile repository setup
  * Improved handling of existing local repositories with automatic synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->