### PR TITLE
fix: show clean placeholder when profile stats have no local data

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -603,6 +603,13 @@ _render_model_usage_table() {
 	local model_json="$2"
 	local token_totals="$3"
 
+	# Skip entirely if no model data
+	local model_count
+	model_count=$(echo "$model_json" | jq -r 'if type == "array" then [.[] | select(.cost_total >= 0.05)] | length else 0 end' 2>/dev/null)
+	if [[ "${model_count:-0}" == "0" ]] || [[ "${model_count:-0}" == "null" ]]; then
+		return 0
+	fi
+
 	# Opus rates used as baseline for model routing savings
 	local opus_input_rate="15.0" opus_output_rate="75.0" opus_cache_rate="1.50"
 	local total_requests=0 total_input=0 total_output=0 total_cache=0 total_cost=0
@@ -725,6 +732,35 @@ cmd_generate() {
 	local token_totals_30d token_totals_all
 	token_totals_30d=$(_get_token_totals "30d")
 	token_totals_all=$(_get_token_totals "all")
+
+	# Detect if there's any meaningful data to display.
+	# Check: any session time > 0, any model usage, or any screen time.
+	# If all sources are empty, show a clean "getting started" message instead
+	# of tables full of zeros — which looks broken to new users.
+	local has_data=false
+	local month_total_hours
+	month_total_hours=$(echo "$month_json" | jq -r '(.total_human_hours + .total_machine_hours) // 0' 2>/dev/null)
+	local all_model_count
+	all_model_count=$(echo "$model_json_all" | jq -r 'if type == "array" then length else 0 end' 2>/dev/null)
+	local screen_month_hours
+	screen_month_hours=$(echo "$screen_json" | jq -r '.month_hours // 0' 2>/dev/null)
+
+	if [[ "${month_total_hours:-0}" != "0" ]] && [[ "${month_total_hours:-0}" != "null" ]]; then
+		has_data=true
+	elif [[ "${all_model_count:-0}" != "0" ]] && [[ "${all_model_count:-0}" != "null" ]]; then
+		has_data=true
+	elif [[ "${screen_month_hours:-0}" != "0" ]] && [[ "${screen_month_hours:-0}" != "null" ]]; then
+		has_data=true
+	fi
+
+	if [[ "$has_data" == "false" ]]; then
+		cat <<'EOF'
+## Work with AI
+
+_Stats will appear here automatically once [aidevops](https://aidevops.sh) has been running locally. Includes AI session hours, model usage, token costs, and screen time._
+EOF
+		return 0
+	fi
 
 	# Extract screen time values (round to 1 decimal, strip .0 for large numbers)
 	local screen_today screen_week screen_month screen_year

--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -606,7 +606,7 @@ _render_model_usage_table() {
 	# Skip entirely if no model data
 	local model_count
 	model_count=$(echo "$model_json" | jq -r 'if type == "array" then [.[] | select(.cost_total >= 0.05)] | length else 0 end' 2>/dev/null)
-	if [[ "${model_count:-0}" == "0" ]] || [[ "${model_count:-0}" == "null" ]]; then
+	if [[ "${model_count:-0}" == "0" ]]; then
 		return 0
 	fi
 
@@ -737,19 +737,16 @@ cmd_generate() {
 	# Check: any session time > 0, any model usage, or any screen time.
 	# If all sources are empty, show a clean "getting started" message instead
 	# of tables full of zeros — which looks broken to new users.
+	# Use jq for numeric comparisons to handle floats (e.g., 0.0) correctly.
 	local has_data=false
-	local month_total_hours
-	month_total_hours=$(echo "$month_json" | jq -r '(.total_human_hours + .total_machine_hours) // 0' 2>/dev/null)
-	local all_model_count
-	all_model_count=$(echo "$model_json_all" | jq -r 'if type == "array" then length else 0 end' 2>/dev/null)
-	local screen_month_hours
-	screen_month_hours=$(echo "$screen_json" | jq -r '.month_hours // 0' 2>/dev/null)
+	local has_session_time has_model_usage has_screen_time
+	has_session_time=$(echo "$month_json" | jq -r '((.total_human_hours + .total_machine_hours) // 0) > 0')
+	has_model_usage=$(echo "$model_json_all" | jq -r '((if type == "array" then length else 0 end) // 0) > 0')
+	has_screen_time=$(echo "$screen_json" | jq -r '(.month_hours // 0) > 0')
 
-	if [[ "${month_total_hours:-0}" != "0" ]] && [[ "${month_total_hours:-0}" != "null" ]]; then
-		has_data=true
-	elif [[ "${all_model_count:-0}" != "0" ]] && [[ "${all_model_count:-0}" != "null" ]]; then
-		has_data=true
-	elif [[ "${screen_month_hours:-0}" != "0" ]] && [[ "${screen_month_hours:-0}" != "null" ]]; then
+	if [[ "$has_session_time" == "true" ]] ||
+		[[ "$has_model_usage" == "true" ]] ||
+		[[ "$has_screen_time" == "true" ]]; then
 		has_data=true
 	fi
 


### PR DESCRIPTION
## Summary

- `cmd_generate` now detects when all local data sources (session time, model usage, screen time) are empty and outputs a clean "getting started" placeholder instead of tables full of zeros
- `_render_model_usage_table` skips entirely when there are no model rows above the $0.05 cost threshold, avoiding empty table shells

## Context

When `profile-readme-helper.sh init` creates a profile repo for a new user (e.g., during `setup.sh`), the first `cmd_update` call runs `cmd_generate` which queries local databases for stats. On a fresh install -- or when init runs on a different machine than the user's -- all data sources return zeros. The result was a README with multiple tables full of `0h`, `$0.00`, `0` values, which looks broken rather than "new".

Now new users see:

```markdown
## Work with AI

_Stats will appear here automatically once aidevops has been running locally.
Includes AI session hours, model usage, token costs, and screen time._
```

Once they accumulate real data, the full tables appear on the next hourly update.

## Verification

- `shellcheck` passes (zero violations)
- Boundary test passes (update preserves non-marker sections)
- Manual test: `HOME=/tmp/fake generate` produces clean placeholder
- Manual test: real `generate` still produces full stats tables