### PR TITLE
feat: add Cursor CLI to setup and tool version checks

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -100,6 +100,13 @@ PIP_TOOLS=(
 	"pip|Outscraper MCP|outscraper-mcp-server|--version|outscraper-mcp-server|uv tool upgrade outscraper-mcp-server"
 )
 
+# Tools installed via curl/custom installers (not in brew/npm/pip registries)
+# Latest version cannot be checked via registry — use "self" category
+# which skips latest-version lookup and just reports installed version
+CUSTOM_TOOLS=(
+	"self|Cursor CLI|agent|--version|cursor-agent|agent update"
+)
+
 # Counters
 OUTDATED_COUNT=0
 INSTALLED_COUNT=0
@@ -277,6 +284,7 @@ check_tool() {
 	npm) latest=$(get_npm_latest "$pkg") ;;
 	brew) latest=$(get_brew_latest "$pkg") ;;
 	pip) latest=$(get_pip_latest "$pkg") ;;
+	self) latest="$installed" ;; # Self-updating tools — no registry to check
 	*) latest="unknown" ;;
 	esac
 
@@ -386,6 +394,9 @@ main() {
 	pip)
 		check_category "Python/Pip" "${PIP_TOOLS[@]}"
 		;;
+	custom)
+		check_category "Custom/Self-Updating" "${CUSTOM_TOOLS[@]}"
+		;;
 	all | *)
 		if [[ ${#NPM_TOOLS[@]} -gt 0 ]]; then
 			check_category "NPM" "${NPM_TOOLS[@]}"
@@ -395,6 +406,9 @@ main() {
 		fi
 		if command -v pip &>/dev/null && [[ ${#PIP_TOOLS[@]} -gt 0 ]]; then
 			check_category "Python/Pip" "${PIP_TOOLS[@]}"
+		fi
+		if [[ ${#CUSTOM_TOOLS[@]} -gt 0 ]]; then
+			check_category "Custom/Self-Updating" "${CUSTOM_TOOLS[@]}"
 		fi
 		;;
 	esac

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -8,7 +8,7 @@
 #   tool-version-check.sh --category npm  # Check only npm tools
 #   tool-version-check.sh --json       # Output as JSON
 #
-# Categories: npm, brew, pip, all (default)
+# Categories: npm, brew, pip, custom, all (default)
 
 # shellcheck disable=SC1091
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
@@ -32,7 +32,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 	--category | -c)
 		if [[ -z "${2:-}" ]]; then
-			echo "Error: --category requires a value (npm, brew, pip, all)"
+			echo "Error: --category requires a value (npm, brew, pip, custom, all)"
 			exit 1
 		fi
 		CATEGORY="$2"
@@ -51,7 +51,7 @@ while [[ $# -gt 0 ]]; do
 		echo ""
 		echo "Options:"
 		echo "  --update, -u       Automatically update outdated tools"
-		echo "  --category, -c     Check only specific category (npm, brew, pip, all)"
+		echo "  --category, -c     Check only specific category (npm, brew, pip, custom, all)"
 		echo "  --json, -j         Output results as JSON"
 		echo "  --quiet, -q        Only show outdated tools"
 		echo "  --help, -h         Show this help"

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -928,7 +928,11 @@ setup_cursor_cli() {
 	echo ""
 
 	local install_cursor
-	read -r -p "Install Cursor CLI? [Y/n]: " install_cursor
+	if [[ "${NON_INTERACTIVE:-}" != "true" ]]; then
+		read -r -p "Install Cursor CLI? [Y/n]: " install_cursor
+	else
+		install_cursor="Y"
+	fi
 
 	if [[ "$install_cursor" =~ ^[Yy]?$ ]]; then
 		print_info "Installing Cursor CLI..."

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -932,7 +932,7 @@ setup_cursor_cli() {
 
 	if [[ "$install_cursor" =~ ^[Yy]?$ ]]; then
 		print_info "Installing Cursor CLI..."
-		if curl https://cursor.com/install -fsS | bash 2>&1; then
+		if verified_install "Cursor CLI" "https://cursor.com/install"; then
 			# Ensure ~/.local/bin is in PATH for this session
 			if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
 				export PATH="$HOME/.local/bin:$PATH"

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -896,6 +896,63 @@ setup_recommended_tools() {
 		print_success "All recommended tools installed!"
 	fi
 
+	# Check for Cursor CLI (agent) — independent of the missing_tools flow
+	# since it uses a curl installer, not brew
+	setup_cursor_cli
+
+	return 0
+}
+
+setup_cursor_cli() {
+	print_info "Checking Cursor CLI (agent)..."
+
+	if command -v agent >/dev/null 2>&1; then
+		local cursor_version
+		cursor_version=$(agent --version 2>/dev/null || echo "unknown")
+		print_success "Cursor CLI found: $cursor_version"
+		return 0
+	fi
+
+	# Check ~/.local/bin specifically (may not be in PATH yet)
+	if [[ -x "$HOME/.local/bin/agent" ]]; then
+		local cursor_version
+		cursor_version=$("$HOME/.local/bin/agent" --version 2>/dev/null || echo "unknown")
+		print_success "Cursor CLI found at ~/.local/bin/agent: $cursor_version"
+		print_info "Ensure ~/.local/bin is in your PATH"
+		return 0
+	fi
+
+	echo "  Cursor CLI provides access to Cursor's AI models (including Composer 2)"
+	echo "  from the terminal. Also usable as an OpenCode provider via the"
+	echo "  opencode-cursor plugin for OAuth-based model access."
+	echo ""
+
+	local install_cursor
+	read -r -p "Install Cursor CLI? [Y/n]: " install_cursor
+
+	if [[ "$install_cursor" =~ ^[Yy]?$ ]]; then
+		print_info "Installing Cursor CLI..."
+		if curl https://cursor.com/install -fsS | bash 2>&1; then
+			# Ensure ~/.local/bin is in PATH for this session
+			if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+				export PATH="$HOME/.local/bin:$PATH"
+				print_info "Added ~/.local/bin to PATH for this session"
+			fi
+			print_success "Cursor CLI installed"
+			echo ""
+			echo "  Next steps:"
+			echo "    agent login     # Authenticate with your Cursor account"
+			echo "    agent models    # List available models"
+			echo "    agent status    # Check auth status"
+		else
+			print_warning "Failed to install Cursor CLI"
+			echo "  Install manually: curl https://cursor.com/install -fsS | bash"
+		fi
+	else
+		print_info "Skipped Cursor CLI installation"
+		echo "  Install later: curl https://cursor.com/install -fsS | bash"
+	fi
+
 	return 0
 }
 


### PR DESCRIPTION
## Summary

- Add Cursor CLI (`agent`) as a recommended tool in `setup.sh` with curl-based installation and auth guidance
- Add `CUSTOM_TOOLS` category in `tool-version-check.sh` with `self` type for tools that self-update outside package registries (Cursor CLI is the first entry)
- Cursor provides exclusive access to Composer 2, a frontier-level proprietary coding model not available through any other provider

## Changes

- `setup-modules/tool-install.sh`: New `setup_cursor_cli()` function called from `setup_recommended_tools()`. Checks `command -v agent` and `~/.local/bin/agent` fallback, offers interactive curl-based install, provides next-steps for `agent login`
- `.agents/scripts/tool-version-check.sh`: New `CUSTOM_TOOLS` array with `self` category that skips registry lookup (sets `latest = installed`). Added `custom` filter to `--category` flag and `all` default

## Next Steps (follow-up tasks)

1. Add Cursor as a third OAuth pool provider in `oauth-pool.mjs` — extract OAuth PKCE flow + gRPC proxy from [opencode-cursor](https://github.com/ephraimduncan/opencode-cursor) plugin
2. Wire pool rotation (LRU, 429 failover, cooldown) for Cursor accounts — same pattern as existing Anthropic/OpenAI providers
3. Add Composer 2 to model routing tiers in `tools/context/model-routing.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a custom tool category in version checks, including self-managed tool handling.
  * Automatic detection of Cursor CLI with additional fallback location checks.
  * Optional interactive setup flow to guide installation of Cursor CLI and update session path when installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->