### PR TITLE
t5365: fix review-bot-gate branch protection check name mismatch

### DIFF
--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -30,7 +30,6 @@ concurrency:
 
 jobs:
   review-bot-gate:
-    name: Wait for AI Review Bots
     runs-on: ubuntu-latest
     # Only run on PRs (issue_comment fires for PR comments too).
     # GH#4002: Skip pull_request_review events from known review bots.


### PR DESCRIPTION
## Summary

- Remove the `name: Wait for AI Review Bots` field from the `review-bot-gate` job in `.github/workflows/review-bot-gate.yml`
- Without a `name:` field, GitHub uses the job ID (`review-bot-gate`) as the check name, matching the branch protection required status check
- This unblocks all PR merges that were permanently `BLOCKED` due to the name mismatch

## Root Cause

When a GitHub Actions job has a `name:` field, GitHub registers the check under that display name — not the job ID. Branch protection was configured to require `review-bot-gate` (the job ID), but the check was registered as `Wait for AI Review Bots` (the display name). Every PR passed the workflow but failed the branch protection check.

## Evidence

- PR #5361: `mergeStateStatus=BLOCKED`, `mergeable=MERGEABLE`
- Workflow run #23371850842: `completed/success` for head `6e42aee1`
- Check registered as: `Wait for AI Review Bots` (not `review-bot-gate`)

## Verification

After merge, the next PR's review-bot-gate workflow will register the check as `review-bot-gate`, matching branch protection. Existing PRs will need a re-push or re-run to pick up the new check name.

Closes #5365