### PR TITLE
t5364: Add model tier and auto-dispatch default guidance to AGENTS.md Planning section

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -218,7 +218,9 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 **Task briefs are MANDATORY.** Every task must have `todo/tasks/{task_id}-brief.md` capturing: session origin, what, why, how, acceptance criteria, and conversation context. Use `/define` for interactive brief generation with latent criteria probing, or `/new-task` for quick creation from `templates/brief-template.md`. A task without a brief loses the knowledge that created it.
 
-Auto-dispatch: `#auto-dispatch` tag — only if brief has 2+ acceptance criteria, file references in How section, and clear deliverable in What section. Add `assignee:` before pushing if working interactively.
+**Auto-dispatch default**: Always add `#auto-dispatch` unless a specific exclusion applies (needs credentials, needs decomposition, needs user preference). Brief quality gate: 2+ acceptance criteria, file references in How section, clear deliverable in What section. Add `assignee:` before pushing if working interactively. See `workflows/plans.md` "Auto-Dispatch Tagging".
+
+**Model tiers**: Add `tier:thinking` GitHub label for opus-tier tasks, `tier:simple` for haiku-tier. Default (no label) = sonnet. The pulse reads issue labels for tier routing, not `model:` in TODO.md. See `reference/task-taxonomy.md`.
 
 Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-DD`. Use `task-complete-helper.sh`. Every completed task must link to its verification evidence — work without an audit trail is unverifiable and may be reverted.
 


### PR DESCRIPTION
## Summary

- Rewrites the auto-dispatch line to default-to-include (`#auto-dispatch` unless a specific exclusion applies), matching the canonical rule in `workflows/plans.md`
- Adds a new **Model tiers** paragraph explaining `tier:thinking` / `tier:simple` GitHub labels and that the pulse reads issue labels, not `model:` in TODO.md
- Both follow progressive disclosure: summary inline, detail via `See` pointers to `workflows/plans.md` and `reference/task-taxonomy.md`

Closes #5364

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated auto-dispatch tagging behavior to default to enabled unless explicitly excluded.
  * Added tier-based task routing guidance: tasks can be labeled for specific model tiers, with unlabeled tasks defaulting to standard routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->