### PR TITLE
t1550: Add Composer 2 to model routing tiers and bundle presets

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -297,7 +297,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 
 Key capabilities (details in `reference/orchestration.md`, `reference/services.md`, `reference/session.md`):
 
-- **Model routing**: local→haiku→flash→sonnet→pro→opus (cost-aware). See `tools/context/model-routing.md`.
+- **Model routing**: local→haiku→flash→composer→sonnet→pro→opus (cost-aware; composer is Cursor-only). See `tools/context/model-routing.md`.
 - **Bundle presets**: Project-type-aware defaults for model tiers, quality gates, and agent routing. Auto-detected from marker files or explicit in repos.json. See `bundles/` and `scripts/bundle-helper.sh`.
 - **Memory**: cross-session SQLite FTS5 (`/remember`, `/recall`)
 - **Orchestration**: supervisor dispatch, pulse scheduler, auto-pickup, cross-repo issue/PR/TODO visibility

--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -1148,7 +1148,7 @@ aidevops includes autonomous orchestration features that can work in the backgro
 4. Strategic review    - Separate scheduled process (every 4h) — opus-tier review checks
                          queue health, finds stuck chains, identifies root causes, and
                          creates self-improvement tasks (see scripts/commands/runners.md)
-5. Model routing       - Cost-aware dispatch: local > haiku > flash > sonnet > pro > opus
+5. Model routing       - Cost-aware dispatch: local > haiku > flash > composer > sonnet > pro > opus
 6. Budget tracking     - Per-provider spend limits, subscription-aware routing
 7. Session miner       - Daily extraction of learning signals from past sessions
 8. Circuit breaker     - Auto-pauses dispatch if workers fail consecutively

--- a/.agents/bundles/schema.json
+++ b/.agents/bundles/schema.json
@@ -36,7 +36,7 @@
     },
     "model_defaults": {
       "type": "object",
-      "description": "Default model tier for each task type. Tiers: local, haiku, flash, sonnet, pro, opus. During composition (multiple bundles), the most-restrictive (highest) tier wins.",
+      "description": "Default model tier for each task type. Tiers: local, haiku, flash, composer, sonnet, pro, opus. During composition (multiple bundles), the most-restrictive (highest) tier wins. The 'composer' tier is Cursor-only.",
       "properties": {
         "implementation": {
           "$ref": "#/$defs/model_tier",
@@ -133,8 +133,8 @@
   "$defs": {
     "model_tier": {
       "type": "string",
-      "enum": ["local", "haiku", "flash", "sonnet", "pro", "opus"],
-      "description": "Model routing tier. See .agents/tools/context/model-routing.md for tier definitions."
+      "enum": ["local", "haiku", "flash", "composer", "sonnet", "pro", "opus"],
+      "description": "Model routing tier. See .agents/tools/context/model-routing.md for tier definitions. The 'composer' tier is Cursor-only; falls back to 'sonnet' outside Cursor."
     },
     "quality_gate": {
       "type": "string",

--- a/.agents/configs/fallback-chain-config.json.txt
+++ b/.agents/configs/fallback-chain-config.json.txt
@@ -11,6 +11,9 @@
     "flash": [
       "anthropic/claude-haiku-4-5"
     ],
+    "composer": [
+      "anthropic/claude-sonnet-4-6"
+    ],
     "sonnet": [
       "anthropic/claude-sonnet-4-6"
     ],

--- a/.agents/scripts/archived/pattern-tracker-helper.sh
+++ b/.agents/scripts/archived/pattern-tracker-helper.sh
@@ -29,11 +29,11 @@ readonly MEMORY_DB="${AIDEVOPS_MEMORY_DIR:-$HOME/.aidevops/.agent-workspace/memo
 # Model tier pricing (USD per 1M tokens) — input/output rates (t1114)
 # Sources: Anthropic, OpenAI, Google official pricing pages (Feb 2026)
 # Format: tier:input_per_1m:output_per_1m
-readonly TIER_PRICING="haiku:0.80:4.00 flash:0.15:0.60 sonnet:3.00:15.00 pro:3.50:10.50 opus:15.00:75.00"
+readonly TIER_PRICING="haiku:0.80:4.00 flash:0.15:0.60 composer:0.50:2.50 sonnet:3.00:15.00 pro:3.50:10.50 opus:15.00:75.00"
 
 #######################################
 # Calculate estimated cost in USD from token counts and model tier (t1114)
-# $1: model_tier (haiku|flash|sonnet|pro|opus)
+# $1: model_tier (haiku|flash|composer|sonnet|pro|opus)
 # $2: tokens_in (integer)
 # $3: tokens_out (integer)
 # Outputs: cost as decimal string (e.g. "0.012345") or empty if unknown
@@ -98,7 +98,7 @@ log_error() {
 readonly VALID_TASK_TYPES="code-review refactor bugfix feature docs testing deployment security architecture planning research content seo"
 
 # Valid model tiers
-readonly VALID_MODELS="haiku flash sonnet pro opus"
+readonly VALID_MODELS="haiku flash composer sonnet pro opus"
 
 #######################################
 # Ensure memory database exists
@@ -1175,7 +1175,7 @@ cmd_label_stats() {
 		return 0
 	fi
 
-	for tier in haiku flash sonnet pro opus; do
+	for tier in haiku flash composer sonnet pro opus; do
 		if [[ -n "$model_filter" && "$tier" != "$model_filter" ]]; then
 			continue
 		fi
@@ -1594,7 +1594,7 @@ ENDJSON
 # evaluate.sh, and dispatch.sh to record A/B comparison data (t1094).
 #
 # Options:
-#   --model <tier>          Model tier (haiku|flash|sonnet|pro|opus)
+#   --model <tier>          Model tier (haiku|flash|composer|sonnet|pro|opus)
 #   --task-type <type>      Task category
 #   --task-id <id>          Task identifier
 #   --correctness <1-5>     Factual accuracy score
@@ -1959,7 +1959,7 @@ COMMANDS:
 RECORD OPTIONS:
     --outcome <success|failure>   Required: was this a success or failure?
     --task-type <type>            Task category (code-review, refactor, bugfix, etc.)
-    --model <tier>                Model used (haiku, flash, sonnet, pro, opus)
+    --model <tier>                Model used (haiku, flash, composer, sonnet, pro, opus)
     --description <text>          What happened (required)
     --task-id <id>                Task identifier (e.g., t102.3)
     --duration <seconds>          How long the task took
@@ -1976,7 +1976,7 @@ RECORD OPTIONS:
     --estimated-cost <usd>        Explicit cost in USD (t1114; auto-calculated from tokens+model if omitted)
 
 SCORE OPTIONS (t1094 — unified backbone):
-    --model <tier>                Model tier (haiku|flash|sonnet|pro|opus)
+    --model <tier>                Model tier (haiku|flash|composer|sonnet|pro|opus)
     --task-type <type>            Task category
     --task-id <id>                Task identifier
     --correctness <1-5>           Factual accuracy score

--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -34,7 +34,7 @@ set -euo pipefail
 # Same DB as pattern-tracker-helper.sh — no duplication of storage.
 
 readonly PATTERN_DB="${AIDEVOPS_MEMORY_DIR:-$HOME/.aidevops/.agent-workspace/memory}/memory.db"
-readonly -a PATTERN_VALID_MODELS=(haiku flash sonnet pro opus)
+readonly -a PATTERN_VALID_MODELS=(haiku flash composer sonnet pro opus)
 
 # Check if pattern data is available
 has_pattern_data() {

--- a/.agents/scripts/fallback-chain-helper.sh
+++ b/.agents/scripts/fallback-chain-helper.sh
@@ -233,7 +233,7 @@ cmd_help() {
 Fallback Chain Helper v2.0 — Simplified model routing
 
 Usage: fallback-chain-helper.sh <command> [options]
-  resolve <tier>  Resolve best available model (tiers: haiku flash sonnet pro opus coding eval health)
+  resolve <tier>  Resolve best available model (tiers: haiku flash composer sonnet pro opus coding eval health)
   table           Print the routing table (JSON)
   help            Show this help
 Options: --config PATH | --quiet | --json

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -117,6 +117,7 @@ get_tier_models() {
 		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
 		haiku) echo "opencode/claude-haiku-4-5|opencode/gemini-3-flash" ;;
 		flash) echo "google/gemini-2.5-flash|opencode/gemini-3-flash" ;;
+		composer) echo "cursor/composer-2|anthropic/claude-sonnet-4-6" ;;
 		sonnet) echo "opencode/claude-sonnet-4-6|anthropic/claude-sonnet-4-6" ;;
 		pro) echo "google/gemini-2.5-pro|opencode/gemini-3-pro" ;;
 		opus) echo "opencode/claude-opus-4-6|anthropic/claude-opus-4-6" ;;
@@ -130,6 +131,7 @@ get_tier_models() {
 		local) echo "local/llama.cpp|anthropic/claude-haiku-4-5" ;;
 		haiku) echo "anthropic/claude-haiku-4-5|google/gemini-2.5-flash" ;;
 		flash) echo "google/gemini-2.5-flash|openai/gpt-4.1-mini" ;;
+		composer) echo "cursor/composer-2|anthropic/claude-sonnet-4-6" ;;
 		sonnet) echo "anthropic/claude-sonnet-4-6|openai/gpt-4.1" ;;
 		pro) echo "google/gemini-2.5-pro|anthropic/claude-sonnet-4-6" ;;
 		opus) echo "anthropic/claude-opus-4-6|openai/o3" ;;
@@ -146,7 +148,7 @@ get_tier_models() {
 is_known_tier() {
 	local tier="$1"
 	case "$tier" in
-	local | haiku | flash | sonnet | pro | opus | health | eval | coding) return 0 ;;
+	local | haiku | flash | composer | sonnet | pro | opus | health | eval | coding) return 0 ;;
 	*) return 1 ;;
 	esac
 }
@@ -1273,7 +1275,7 @@ cmd_status() {
 	echo ""
 	printf "  %-8s %-35s %-35s\n" "Tier" "Primary" "Fallback"
 	printf "  %-8s %-35s %-35s\n" "----" "-------" "--------"
-	for tier in haiku flash sonnet pro opus health eval coding; do
+	for tier in haiku flash composer sonnet pro opus health eval coding; do
 		local spec
 		spec=$(get_tier_models "$tier" 2>/dev/null) || spec=""
 		local primary="${spec%%|*}"
@@ -1388,7 +1390,7 @@ cmd_resolve() {
 
 	if [[ -z "$tier" ]]; then
 		print_error "Usage: model-availability-helper.sh resolve <tier>"
-		print_info "Available tiers: haiku flash sonnet pro opus health eval coding"
+		print_info "Available tiers: haiku flash composer sonnet pro opus health eval coding"
 		return 1
 	fi
 
@@ -1455,7 +1457,7 @@ cmd_resolve_chain() {
 
 	if [[ -z "$tier" ]]; then
 		print_error "Usage: model-availability-helper.sh resolve-chain <tier> [--agent file]"
-		print_info "Available tiers: haiku flash sonnet pro opus health eval coding"
+		print_info "Available tiers: haiku flash composer sonnet pro opus health eval coding"
 		return 1
 	fi
 

--- a/.agents/scripts/model-label-helper.sh
+++ b/.agents/scripts/model-label-helper.sh
@@ -9,7 +9,7 @@
 #   model-label-helper.sh help
 #
 # Actions: planned, researched, implemented, reviewed, verified, documented, failed, retried
-# Models: haiku, flash, sonnet, pro, opus (or concrete model names)
+# Models: haiku, flash, composer, sonnet, pro, opus (or concrete model names)
 #
 # Labels are append-only (history, not state). Examples:
 #   implemented:sonnet - Task was implemented using sonnet tier
@@ -31,7 +31,7 @@ set -euo pipefail
 readonly VALID_ACTIONS="planned researched implemented reviewed verified documented failed retried"
 
 # Valid model tiers (matches model-routing.md and pattern-tracker)
-readonly VALID_MODELS="local haiku flash sonnet pro opus"
+readonly VALID_MODELS="local haiku flash composer sonnet pro opus"
 
 #######################################
 # Show help
@@ -56,7 +56,7 @@ ACTIONS:
     planned, researched, implemented, reviewed, verified, documented, failed, retried
 
 MODELS:
-    local, haiku, flash, sonnet, pro, opus (or concrete model names like claude-sonnet-4-6)
+    local, haiku, flash, composer, sonnet, pro, opus (or concrete model names like claude-sonnet-4-6)
 
 EXAMPLES:
     # Add label when dispatching a task
@@ -94,7 +94,7 @@ EOF
 # Arguments:
 #   $1 - Model name (e.g., claude-sonnet-4-6, sonnet, gpt-4)
 # Returns:
-#   Normalized tier name (haiku, flash, sonnet, pro, opus)
+#   Normalized tier name (haiku, flash, composer, sonnet, pro, opus)
 #######################################
 normalize_model() {
 	local model="$1"
@@ -114,6 +114,9 @@ normalize_model() {
 	gemini-*-flash*)
 		echo "flash"
 		;;
+	composer-2* | cursor/composer*)
+		echo "composer"
+		;;
 	claude-sonnet-4* | claude-3-sonnet* | claude-3-5-sonnet*)
 		echo "sonnet"
 		;;
@@ -128,6 +131,9 @@ normalize_model() {
 		;;
 	*flash*)
 		echo "flash"
+		;;
+	*composer*)
+		echo "composer"
 		;;
 	*sonnet*)
 		echo "sonnet"

--- a/.agents/scripts/onboarding-helper.sh
+++ b/.agents/scripts/onboarding-helper.sh
@@ -664,7 +664,7 @@ check_orchestration() {
 	fi
 
 	# Model routing is always available
-	print_service "Model Routing" "ready" "cost-aware: local>haiku>flash>sonnet>pro>opus"
+	print_service "Model Routing" "ready" "cost-aware: local>haiku>flash>composer>sonnet>pro>opus"
 
 	# Budget tracking
 	local budget_script="$HOME/.aidevops/agents/scripts/budget-tracker-helper.sh"

--- a/.agents/scripts/supervisor-archived/ai-actions.sh
+++ b/.agents/scripts/supervisor-archived/ai-actions.sh
@@ -1204,9 +1204,9 @@ validate_action_fields() {
 		fi
 		# Validate model tier
 		case "$recommended_model" in
-		haiku | flash | sonnet | pro | opus) ;;
+		haiku | flash | composer | sonnet | pro | opus) ;;
 		*)
-			echo "invalid recommended_model: $recommended_model (must be haiku|flash|sonnet|pro|opus)"
+			echo "invalid recommended_model: $recommended_model (must be haiku|flash|composer|sonnet|pro|opus)"
 			return 0
 			;;
 		esac

--- a/.agents/scripts/supervisor-archived/evaluate.sh
+++ b/.agents/scripts/supervisor-archived/evaluate.sh
@@ -908,11 +908,11 @@ record_evaluation_metadata() {
 
 	# Record TIER_DOWNGRADE_OK when task succeeded at a cheaper tier (t5148)
 	# Conditions: success outcome, both tiers known, actual tier is cheaper than requested.
-	# Tier rank: haiku=1 < flash=2 < sonnet=3 < pro=4 < opus=5
+	# Tier rank: haiku=1 < flash=2 < composer=3 < sonnet=4 < pro=5 < opus=6
 	# Only record when quality_score >= 2 (complete output) to avoid recording
 	# partial successes that might not represent true tier capability.
 	if [[ "$pt_outcome" == "success" && -n "$requested_tier" && -n "$actual_tier" && "$requested_tier" != "$actual_tier" && "$quality_score" -ge 2 ]]; then
-		local _tier_rank_haiku=1 _tier_rank_flash=2 _tier_rank_sonnet=3 _tier_rank_pro=4 _tier_rank_opus=5
+		local _tier_rank_haiku=1 _tier_rank_flash=2 _tier_rank_composer=3 _tier_rank_sonnet=4 _tier_rank_pro=5 _tier_rank_opus=6
 		local _req_rank_var="_tier_rank_${requested_tier}"
 		local _act_rank_var="_tier_rank_${actual_tier}"
 		local _req_rank="${!_req_rank_var:-0}"

--- a/.agents/scripts/supervisor-archived/issue-sync.sh
+++ b/.agents/scripts/supervisor-archived/issue-sync.sh
@@ -32,7 +32,7 @@ ensure_status_labels() {
 
 #######################################
 # Extract model tier name from a full model string (t1010)
-# Maps provider/model strings to tier names (haiku, flash, sonnet, pro, opus).
+# Maps provider/model strings to tier names (haiku, flash, composer, sonnet, pro, opus).
 # $1: model string (e.g. "anthropic/claude-opus-4-6")
 # Outputs tier name on stdout, empty if unrecognised.
 #######################################
@@ -47,6 +47,7 @@ model_to_tier() {
 	*gpt-4.1*) echo "sonnet" ;;
 	*gemini-2.5-flash*) echo "flash" ;;
 	*gemini-2.5-pro*) echo "pro" ;;
+	*composer-2* | cursor/composer*) echo "composer" ;;
 	*haiku*) echo "haiku" ;;
 	*flash*) echo "flash" ;;
 	*sonnet*) echo "sonnet" ;;
@@ -94,7 +95,7 @@ add_model_label() {
 	# Resolve model tier from full model string if needed
 	local tier="$model_input"
 	case "$model_input" in
-	haiku | flash | sonnet | pro | opus) ;; # Already a tier name
+	haiku | flash | composer | sonnet | pro | opus) ;; # Already a tier name
 	*)
 		tier=$(model_to_tier "$model_input")
 		if [[ -z "$tier" ]]; then
@@ -258,7 +259,7 @@ cmd_labels() {
 		local first_entry="true"
 		printf '['
 		for act in $valid_actions; do
-			for tier in haiku flash sonnet pro opus; do
+			for tier in haiku flash composer sonnet pro opus; do
 				local lbl="${act}:${tier}"
 				# Skip if doesn't match filter
 				if [[ -n "$label_pattern" && "$lbl" != *"$label_pattern"* ]]; then
@@ -285,7 +286,7 @@ cmd_labels() {
 		local found=0
 		for act in $valid_actions; do
 			local act_found=0
-			for tier in haiku flash sonnet pro opus; do
+			for tier in haiku flash composer sonnet pro opus; do
 				local lbl="${act}:${tier}"
 				if [[ -n "$label_pattern" && "$lbl" != *"$label_pattern"* ]]; then
 					continue

--- a/.agents/tools/ai-assistants/models/README.md
+++ b/.agents/tools/ai-assistants/models/README.md
@@ -8,6 +8,7 @@ Model-specific subagents enable cross-provider model routing. Instead of passing
 |------|----------|---------------|----------|
 | `haiku` | `models/haiku.md` | claude-haiku-4-5-20251001 | gemini-2.5-flash-preview-05-20 |
 | `flash` | `models/flash.md` | gemini-2.5-flash-preview-05-20 | gpt-4.1-mini |
+| `composer` | `models/composer.md` | cursor/composer-2 | claude-sonnet-4-6 |
 | `sonnet` | `models/sonnet.md` | claude-sonnet-4-6 | gpt-4.1 |
 | `pro` | `models/pro.md` | gemini-2.5-pro | claude-sonnet-4-6 |
 | `opus` | `models/opus.md` | claude-opus-4-6 | o3 |

--- a/.agents/tools/ai-assistants/models/composer.md
+++ b/.agents/tools/ai-assistants/models/composer.md
@@ -1,0 +1,64 @@
+---
+description: Cost-effective frontier coding model (Cursor runtime only)
+mode: subagent
+model: cursor/composer-2
+model-tier: composer
+model-fallback: anthropic/claude-sonnet-4-6
+fallback-chain:
+  - cursor/composer-2
+  - anthropic/claude-sonnet-4-6
+  - openai/gpt-4.1
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: false
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# Composer Tier Model (Cursor Only)
+
+You are a frontier-level coding assistant optimized for cost-effective code implementation. This tier is only available in Cursor via Composer 2.
+
+## Capabilities
+
+- Writing and modifying code (frontier-level quality)
+- Bug fixes and feature additions
+- Test writing and execution
+- Routine refactoring
+- Code generation from specifications
+
+## Constraints
+
+- **Cursor-only**: This model is only available in the Cursor IDE. For headless dispatch, Claude Code, or other runtimes, fall back to `sonnet`.
+- Best suited for code-focused tasks. For architecture decisions, use `opus`. For code review, use `sonnet`.
+- For simple classification/formatting, `haiku` is cheaper.
+- Do not route non-coding tasks (triage, documentation, review) to this tier.
+
+## Model Details
+
+| Field | Value |
+|-------|-------|
+| Provider | Cursor |
+| Model | composer-2 |
+| Context | Large (provider-managed) |
+| Max output | Provider-managed |
+| Input cost | $0.50/1M tokens |
+| Output cost | $2.50/1M tokens |
+| Tier | composer (cost-effective coding) |
+
+## When to Use vs Sonnet
+
+| Criterion | Composer | Sonnet |
+|-----------|----------|--------|
+| Runtime | Cursor only | Any runtime |
+| Cost | ~0.17x sonnet | 1x (baseline) |
+| Code implementation | Frontier-level | Frontier-level |
+| Code review | Not recommended | Strong |
+| Architecture | Not recommended | Adequate |
+| Headless dispatch | Not available | Default tier |
+
+Composer 2 delivers frontier-level coding at ~83% cost savings vs sonnet. Use it for implementation tasks in Cursor; use sonnet for everything else or when Cursor is not the runtime.

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -22,7 +22,7 @@ model: haiku
 - **Purpose**: Route tasks to the cheapest model that can handle them well
 - **Philosophy**: Use the smallest model that produces acceptable quality
 - **Default**: sonnet (best balance of cost/capability for most tasks)
-- **Cost spectrum**: local (free) -> flash -> haiku -> sonnet -> pro -> opus (highest)
+- **Cost spectrum**: local (free) -> flash -> haiku -> composer -> sonnet -> pro -> opus (highest)
 
 ## Model Tiers
 
@@ -31,6 +31,7 @@ model: haiku
 | `local` | llama.cpp (user-selected GGUF) | Free ($0) | Privacy-sensitive tasks, offline work, bulk processing, experimentation |
 | `flash` | gemini-2.5-flash-preview-05-20 | Lowest (~0.20x) | Large context reads, summarization, bulk processing |
 | `haiku` | claude-haiku-4-5-20251001 | Low (~0.25x) | Triage, classification, simple transforms, formatting |
+| `composer` | cursor/composer-2 | Low-Medium (~0.17x) | Cost-effective code implementation (Cursor runtime only) |
 | `sonnet` | claude-sonnet-4-6 | Medium | Code implementation, review, most development tasks |
 | `pro` | gemini-2.5-pro | Medium-High | Large codebase analysis, complex reasoning with big context |
 | `opus` | claude-opus-4-6 | Highest | Architecture decisions, complex multi-step reasoning, novel problems |
@@ -42,6 +43,8 @@ model: haiku
 When referencing models in docs, scripts, or dispatch commands, use the full ID from the subagent frontmatter (e.g., `claude-sonnet-4-6`, not `claude-sonnet-4`). For provider-prefixed contexts (CLI `--model` flags, fallback chains), use `anthropic/claude-sonnet-4-6` or `google/gemini-2.5-pro`.
 
 **Tier names vs model IDs**: Tier names (`haiku`, `sonnet`, `opus`) are abstract routing labels. They are resolved to concrete model IDs at dispatch time by reading the corresponding subagent frontmatter. Never pass a tier name where a model ID is expected.
+
+**Runtime-specific tiers**: The `composer` tier is only available in Cursor. When routing to `composer` outside Cursor, fall back to `sonnet` (the next general-purpose tier). Bundle presets that use `composer` should always have a non-Cursor fallback path.
 
 ## Routing Rules
 
@@ -75,6 +78,15 @@ When referencing models in docs, scripts, or dispatch commands, use the full ID 
 - Generating commit messages from diffs
 - Answering factual questions about code (no reasoning needed)
 - Routing decisions (which subagent to use)
+
+### Use `composer` when:
+
+- Writing or modifying code in Cursor (Composer 2 is Cursor-only)
+- Cost-sensitive code implementation where sonnet is overkill
+- Routine code changes: bug fixes, feature additions, test writing
+- The task is clearly code-focused (not architecture, review, or reasoning-heavy)
+
+> **Runtime constraint**: Composer 2 is only available in Cursor. If the runtime is not Cursor (Claude Code, headless dispatch, etc.), fall back to `sonnet`. Do not route to `composer` in headless dispatch — workers use Claude Code or OpenCode, not Cursor.
 
 ### Use `sonnet` when (default):
 
@@ -112,7 +124,7 @@ tools:
 ---
 ```
 
-Valid values: `local`, `haiku`, `flash`, `sonnet`, `pro`, `opus`
+Valid values: `local`, `haiku`, `flash`, `composer`, `sonnet`, `pro`, `opus`
 
 > **Note**: The `local` tier requires `local-model-helper.sh` to be set up and a model server running. If no local server is available, `local` in frontmatter falls back to `haiku` (next tier in the routing chain — local has no same-tier fallback). See `tools/local-models/local-models.md` for setup.
 
@@ -129,6 +141,7 @@ Approximate relative API costs (sonnet = 1x baseline):
 | local | 0x | 0x | $0 (electricity only) |
 | flash | 0.15x | 0.30x | ~0.20x |
 | haiku | 0.25x | 0.25x | ~0.25x |
+| composer | 0.17x | 0.17x | ~0.17x |
 | sonnet | 1x | 1x | 1x |
 | pro | 1.25x | 2.5x | ~1.5x |
 | opus | 3x | 3x | ~3x |
@@ -142,6 +155,7 @@ Concrete model subagents are defined across these paths (`tools/ai-assistants/mo
 | `local` | `tools/local-models/local-models.md` | llama.cpp (user GGUF) | FAIL (privacy) or haiku (cost) |
 | `flash` | `models/flash.md` | gemini-2.5-flash-preview-05-20 | gpt-4.1-mini |
 | `haiku` | `models/haiku.md` | claude-haiku-4-5-20251001 | gemini-2.5-flash-preview-05-20 |
+| `composer` | `models/composer.md` | cursor/composer-2 | claude-sonnet-4-6 |
 | `sonnet` | `models/sonnet.md` | claude-sonnet-4-6 | gpt-4.1 |
 | `pro` | `models/pro.md` | gemini-2.5-pro | claude-sonnet-4-6 |
 | `opus` | `models/opus.md` | claude-opus-4-6 | o3 |
@@ -201,6 +215,7 @@ Each tier defines a primary model and a fallback from a different provider. When
 | `local` | llama.cpp (localhost) | haiku (cost-only) or FAIL (privacy) | Server not running, no model installed. Fails closed for privacy/on-device tasks; falls back to haiku (next tier in chain) for cost-optimisation use cases. No same-tier fallback exists — local skips directly to cloud. |
 | `flash` | gemini-2.5-flash-preview-05-20 | gpt-4.1-mini | No Google key |
 | `haiku` | claude-haiku-4-5-20251001 | gemini-2.5-flash-preview-05-20 | No Anthropic key |
+| `composer` | cursor/composer-2 | claude-sonnet-4-6 | Not in Cursor runtime |
 | `sonnet` | claude-sonnet-4-6 | gpt-4.1 | No Anthropic key |
 | `pro` | gemini-2.5-pro | claude-sonnet-4-6 | No Google key |
 | `opus` | claude-opus-4-6 | o3 | No Anthropic key |
@@ -296,7 +311,9 @@ Is the task privacy/on-device constrained?
           → NO: flash
         → NO: Is it a novel architecture/design problem?
           → YES: opus
-          → NO: sonnet
+          → NO: Is the runtime Cursor and the task is routine coding?
+            → YES: composer
+            → NO: sonnet
 ```
 
 ## Examples
@@ -309,6 +326,7 @@ Is the task privacy/on-device constrained?
 | "Rename variable X to Y across files" | haiku | Simple text transform |
 | "Summarize this 200-page PDF" | flash | Large context, low reasoning |
 | "Fix this React component bug" | sonnet | Code + reasoning |
+| "Add a new API endpoint" (in Cursor) | composer | Routine coding, Cursor runtime |
 | "Review this 500-file PR" | pro | Large context + reasoning |
 | "Design the auth system architecture" | opus | Novel design, trade-offs |
 | "Generate a commit message" | haiku | Simple text generation |
@@ -375,6 +393,31 @@ bundle-helper.sh resolve ~/Git/my-project
 # List available bundles
 bundle-helper.sh list
 ```
+
+### Runtime-Specific Tiers in Bundles
+
+The `composer` tier can be used in bundle `model_defaults` for projects where Cursor is the primary development environment. Since `composer` is Cursor-only, the resolution flow adds a runtime check:
+
+```text
+Bundle says model_defaults.implementation = "composer"
+  ├── Runtime is Cursor? → Use composer (cursor/composer-2)
+  └── Runtime is NOT Cursor? → Fall back to sonnet (next general-purpose tier)
+```
+
+Example bundle override for a Cursor-primary web-app project:
+
+```json
+{
+  "model_defaults": {
+    "implementation": "composer",
+    "review": "sonnet",
+    "triage": "haiku",
+    "architecture": "opus"
+  }
+}
+```
+
+This saves ~83% on implementation costs vs sonnet when working in Cursor, with automatic fallback to sonnet for headless dispatch and other runtimes.
 
 ### Integration Points
 

--- a/todo/tasks/t1550-brief.md
+++ b/todo/tasks/t1550-brief.md
@@ -1,0 +1,41 @@
+# t1550: Add Composer 2 to model routing tiers and bundle presets
+
+## Session Origin
+
+Interactive session, issue #5363. Blocker t1549 (Cursor as OAuth pool provider) resolved.
+
+## What
+
+Add Cursor Composer 2 as a new `composer` tier in the model routing system, positioned between `haiku` and `sonnet` in the cost spectrum.
+
+## Why
+
+Composer 2 offers frontier-level coding at $0.50/$2.50 per M tokens (~83% cheaper than sonnet at $3/$15). For Cursor users doing routine code implementation, this provides significant cost savings without sacrificing code quality.
+
+## How
+
+1. Update `model-routing.md` with new `composer` tier in all tables (Model Tiers, Cost Estimation, Subagents, Fallback Routing), routing rules, decision flowchart, and examples
+2. Create `models/composer.md` subagent following existing pattern (sonnet.md)
+3. Update `bundles/schema.json` to include `composer` in the `model_tier` enum
+4. Update `models/README.md` tier mapping table
+5. Update `AGENTS.md` cost spectrum reference
+6. Update all helper scripts that enumerate tiers: `model-availability-helper.sh`, `model-label-helper.sh`, `compare-models-helper.sh`, `fallback-chain-helper.sh`, `onboarding-helper.sh`
+7. Update archived scripts: `evaluate.sh`, `issue-sync.sh`, `ai-actions.sh`, `pattern-tracker-helper.sh`
+8. Update `fallback-chain-config.json.txt` with composer chain entry
+9. Add runtime-specific tier documentation (Cursor-only constraint, automatic fallback to sonnet)
+
+## Acceptance Criteria
+
+- [ ] `composer` tier appears in all model routing tables and documentation
+- [ ] `models/composer.md` exists with correct frontmatter and pricing
+- [ ] Bundle schema validates `composer` as a valid tier
+- [ ] All helper scripts accept `composer` as a valid tier name
+- [ ] Runtime constraint (Cursor-only) is clearly documented with fallback behaviour
+- [ ] Linters pass on all modified files
+
+## Context
+
+- Composer 2 is Cursor-specific -- not available via Anthropic/Google/OpenAI APIs
+- Fallback from composer is always sonnet (next general-purpose tier)
+- Bundle defaults are NOT changed -- composer is opt-in via explicit model_defaults override
+- Pricing: $0.50 input / $2.50 output per 1M tokens


### PR DESCRIPTION
## Summary

- Adds Cursor Composer 2 as a new `composer` tier in the model routing system, positioned between `haiku` and `sonnet` ($0.50/$2.50 per M tokens, ~83% cheaper than sonnet for frontier-level coding)
- Creates `models/composer.md` subagent with fallback chain to sonnet for non-Cursor runtimes
- Updates bundle schema, fallback-chain config, and 8 helper scripts to recognize the new tier

## Details

Composer 2 is Cursor-only — it's not available via Anthropic/Google/OpenAI APIs. The implementation documents this constraint clearly:
- Routing rules specify Cursor runtime requirement
- Fallback is always `sonnet` (next general-purpose tier)
- Bundle defaults are NOT changed — `composer` is opt-in via explicit `model_defaults` override
- Decision flowchart adds a runtime check before routing to composer

### Files changed (17)

| Category | Files |
|----------|-------|
| Core docs | `model-routing.md` (all tables, rules, flowchart, examples), `AGENTS.md`, `onboarding.md` |
| New subagent | `models/composer.md` |
| Schema/config | `bundles/schema.json`, `fallback-chain-config.json.txt` |
| Active scripts | `model-availability-helper.sh`, `model-label-helper.sh`, `compare-models-helper.sh`, `fallback-chain-helper.sh`, `onboarding-helper.sh` |
| Archived scripts | `evaluate.sh`, `issue-sync.sh`, `ai-actions.sh`, `pattern-tracker-helper.sh` |
| Task brief | `todo/tasks/t1550-brief.md` |

### Pricing reference

| Tier | Input/1M | Output/1M | Relative to sonnet |
|------|----------|-----------|-------------------|
| haiku | $1.00 | $5.00 | ~0.25x |
| **composer** | **$0.50** | **$2.50** | **~0.17x** |
| sonnet | $3.00 | $15.00 | 1x |

Closes #5363