### PR TITLE
fix: make profile update self-healing when repos.json entry is missing

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -26,28 +26,74 @@ OPENCODE_DB_FILE="${HOME}/.local/share/opencode/opencode.db"
 # --- Resolve profile repo path from repos.json ---
 _resolve_profile_repo() {
 	local repos_json="${HOME}/.config/aidevops/repos.json"
-	if [[ ! -f "$repos_json" ]]; then
-		echo "Error: repos.json not found at $repos_json" >&2
+
+	# Try repos.json first (primary lookup)
+	if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
+		local profile_path
+		profile_path=$(jq -r '
+			if .initialized_repos then
+				.initialized_repos[] | select(.priority == "profile") | .path
+			else
+				to_entries[] | select(.value.priority == "profile") | .value.path
+			end
+		' "$repos_json" 2>/dev/null | head -1)
+
+		if [[ -n "$profile_path" && "$profile_path" != "null" && -d "$profile_path" ]]; then
+			echo "$profile_path"
+			return 0
+		fi
+	fi
+
+	# Self-healing fallback: find profile repo by convention (~/Git/$username).
+	# This handles the case where cmd_init created the repo but repos.json
+	# registration failed or was lost. The hourly update job would otherwise
+	# silently fail forever.
+	local gh_user=""
+	if command -v gh &>/dev/null; then
+		gh_user=$(gh api user --jq '.login' 2>/dev/null) || true
+	fi
+	if [[ -z "$gh_user" ]]; then
+		echo "Error: no profile repo in repos.json and gh CLI unavailable for fallback" >&2
 		return 1
 	fi
 
-	# Find repo with priority "profile" — supports both flat and nested repos.json formats
-	local profile_path
-	profile_path=$(jq -r '
-		if .initialized_repos then
-			.initialized_repos[] | select(.priority == "profile") | .path
-		else
-			to_entries[] | select(.value.priority == "profile") | .value.path
-		end
-	' "$repos_json" 2>/dev/null | head -1)
-
-	if [[ -z "$profile_path" || "$profile_path" == "null" ]]; then
-		echo "Error: no profile repo found in repos.json (set priority: \"profile\")" >&2
-		return 1
+	local convention_path="${HOME}/Git/${gh_user}"
+	if [[ -d "$convention_path" ]] && [[ -f "${convention_path}/README.md" ]] &&
+		grep -q '<!-- STATS-START -->' "${convention_path}/README.md" 2>/dev/null; then
+		# Found it — auto-register in repos.json so future lookups are fast
+		echo "Auto-registering profile repo at $convention_path" >&2
+		if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
+			local tmp_json
+			tmp_json=$(mktemp)
+			jq --arg path "$convention_path" --arg slug "${gh_user}/${gh_user}" '
+				.initialized_repos += [{
+					"path": $path,
+					"slug": $slug,
+					"priority": "profile",
+					"pulse": false,
+					"maintainer": ($slug | split("/")[0])
+				}]
+			' "$repos_json" >"$tmp_json" && mv "$tmp_json" "$repos_json"
+		fi
+		echo "$convention_path"
+		return 0
 	fi
 
-	echo "$profile_path"
-	return 0
+	# Last resort: try cmd_init to create/clone/register everything
+	if command -v gh &>/dev/null && gh auth status &>/dev/null; then
+		echo "No profile repo found — running init to create one" >&2
+		if cmd_init >&2; then
+			# Re-resolve after init
+			local init_path="${HOME}/Git/${gh_user}"
+			if [[ -d "$init_path" ]]; then
+				echo "$init_path"
+				return 0
+			fi
+		fi
+	fi
+
+	echo "Error: no profile repo found and could not auto-create one" >&2
+	return 1
 }
 
 # --- Format number with commas (bash 3.2 compatible) ---


### PR DESCRIPTION
## Summary

- `_resolve_profile_repo` now has a three-tier fallback instead of failing when repos.json has no profile entry
- Tier 1: repos.json lookup (existing behaviour, fast)
- Tier 2: convention-based discovery at `~/Git/$username` -- checks for STATS markers, auto-registers in repos.json
- Tier 3: last resort -- runs `cmd_init` to create/clone/register everything from scratch

## Context

Observed that `alex-solovyev/alex-solovyev` profile repo was created and seeded by `cmd_init` (commit authored by "Alexey" at 04:00 UTC), but the hourly `cmd_update` has never run -- the UPDATED markers are empty and no update commits exist.

Root cause: `cmd_init` successfully created the GitHub repo and pushed the README, but the repos.json registration step either failed or was lost. The hourly update job calls `_resolve_profile_repo` which only checked repos.json -- no entry meant silent failure every hour, forever.

The self-healing fallback discovers the profile repo by convention (`~/Git/$username` with `<!-- STATS-START -->` markers), auto-registers it in repos.json, and continues. If even that fails, it runs `cmd_init` as a last resort.

## Verification

- `shellcheck` passes (zero violations)
- Boundary test passes (update preserves non-marker sections)