### PR TITLE
hotfix: disable auth hooks — OpenCode v1.2.27 crashes on plugin auth key

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1112,11 +1112,16 @@ export async function AidevopsPlugin({ directory, client }) {
     event: async (input) => handleEvent(input),
 
     // Phase 7: OAuth multi-account pool (t1543, t1548, t1549)
-    auth: [
-      createPoolAuthHook(client),
-      createOpenAIPoolAuthHook(client),
-      createCursorPoolAuthHook(client),
-    ],
+    // DISABLED: OpenCode v1.2.27 crashes when plugin returns `auth` key
+    // (Expected string, got undefined at worker.js:40673).
+    // Filed: https://github.com/anomalyco/opencode/issues/18536
+    // Pool tokens still work via initPoolAuth() injection above.
+    // Re-enable when OpenCode fixes this regression.
+    // auth: [
+    //   createPoolAuthHook(client),
+    //   createOpenAIPoolAuthHook(client),
+    //   createCursorPoolAuthHook(client),
+    // ],
 
     // Compaction context (includes OMOC state when detected)
     "experimental.session.compacting": async (input, output) =>


### PR DESCRIPTION
## Summary

OpenCode v1.2.27 has a regression where any plugin returning an `auth` key (even `auth: []`) crashes the TUI worker with `Expected string, got undefined`. This prevents OpenCode from starting.

Disables the auth hooks until OpenCode fixes the regression. Pool tokens still work via `initPoolAuth()` injection — existing accounts continue to rotate normally. Only the Ctrl+A "Add Account" flow is affected.

Filed upstream: anomalyco/opencode#18536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Modified OAuth multi-account authentication configuration in the plugin to streamline pool support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->