### PR TITLE
feat: add Cursor support to oauth-pool-helper.sh and /models-pool-check

### DIFF
--- a/.agents/scripts/commands/models-pool-check.md
+++ b/.agents/scripts/commands/models-pool-check.md
@@ -1,140 +1,86 @@
 ---
-description: Check OAuth pool health, test token validity, and manage provider accounts
+description: Check OAuth pool health, test token validity, and walk users through setup
 agent: Build+
 mode: subagent
 ---
 
-Check the health and status of all OAuth pool accounts across providers.
+This command is the single entry point for users to understand and manage their AI model provider accounts. Assume the user knows nothing about OAuth, pools, tokens, or providers. Your job is to diagnose their situation and guide them through exactly what they need — step by step, one thing at a time.
 
 ## Workflow
 
-1. Call the `model-accounts-pool` tool with `{"action": "check"}` to run a comprehensive health check across all providers
-2. Route based on the check output:
+### Step 1: Diagnose
 
-### Routing rules
+Run `oauth-pool-helper.sh check` via Bash to get the current state. This works on any model, including free OpenCode models — it doesn't require a paid provider to run.
 
-**Path A — No accounts configured:**
-The check output contains "No accounts in any pool." Present the "Adding an account" guide below.
+### Step 2: Interpret and act
 
-**Path B — All accounts healthy:**
-Every account shows `Status: active`, `Token: expires in ...`, and `Validity: OK` (no `EXPIRED`, `INVALID`, `auth-error`, or `Refresh token: MISSING` lines). Report the health summary — no action needed.
+Based on the output, follow the appropriate path:
 
-**Path C — One or more accounts unhealthy:**
-Any account shows one of: `Token: EXPIRED`, `Validity: INVALID`, `Status: auth-error`, or `Refresh token: MISSING`. Present the specific issues and guide the user to the relevant fix:
-- `EXPIRED` / `INVALID` → "Updating/refreshing an account" section
-- `Refresh token: MISSING` → re-add the account with `oauth-pool-helper.sh add <provider>`
-- `Status: auth-error` → "Updating/refreshing an account" section
+**Path A — No accounts exist:**
 
-## Shell Commands
+Tell the user:
 
-Users can also manage accounts directly from the terminal:
+> You don't have any AI provider accounts connected yet. Let's set one up.
+>
+> You'll need a paid subscription to one of these:
+>
+> - **Claude Pro or Max** ($20-100/mo from anthropic.com) — for Claude models
+> - **ChatGPT Plus or Pro** ($20-200/mo from openai.com) — for GPT/o-series models
+> - **Cursor Pro** ($20/mo from cursor.com) — for models via Cursor's proxy
+>
+> Which provider do you have a subscription with?
 
-```bash
-# Add an account (opens browser for OAuth)
-oauth-pool-helper.sh add anthropic       # Claude Pro/Max
-oauth-pool-helper.sh add openai          # ChatGPT Plus/Pro
+Once they answer, give them the exact command to run in a separate terminal (not in this chat):
 
-# Health check (token expiry, validity, status)
-oauth-pool-helper.sh check               # All providers
-oauth-pool-helper.sh check anthropic     # Specific provider
-oauth-pool-helper.sh check openai        # Specific provider
+For Anthropic: `oauth-pool-helper.sh add anthropic`
 
-# List accounts
-oauth-pool-helper.sh list
+For OpenAI: `oauth-pool-helper.sh add openai`
 
-# Remove an account (provider is required)
-oauth-pool-helper.sh remove anthropic user@example.com
-oauth-pool-helper.sh remove openai user@example.com
-```
+For Cursor: `oauth-pool-helper.sh add cursor`
 
-Rotate and reset-cooldowns are MCP-tool-only (no CLI equivalent):
+For Anthropic/OpenAI, explain: "This will open your browser to log in. After you authorize, you'll get a code to paste back into the terminal. Once done, restart OpenCode and your account will be active."
 
-```text
-model-accounts-pool {"action": "rotate", "provider": "anthropic"}
-model-accounts-pool {"action": "rotate", "provider": "openai"}
-model-accounts-pool {"action": "reset-cooldowns", "provider": "anthropic"}
-model-accounts-pool {"action": "reset-cooldowns", "provider": "openai"}
-```
+For Cursor, explain: "This reads your credentials from the Cursor IDE — make sure you're logged in there first. No browser step needed, it's instant."
 
-## Account Management Guide
+After they confirm it worked, tell them to restart OpenCode, then use Ctrl+T to select a model from the provider.
 
-When reporting results, include relevant guidance from this section based on what the user needs.
+**Path B — Accounts exist and are healthy:**
 
-### Adding an account
+Show a clean summary:
 
-**Option A — Shell (recommended):**
+| Account | Provider | Status | Token | Validity |
+|---------|----------|--------|-------|----------|
+| user@example.com | anthropic | active | 2h remaining | OK |
 
-Run in your terminal:
+Then: "Everything looks good. Your pool has N account(s) and will auto-rotate between them if one hits rate limits."
 
-```bash
-oauth-pool-helper.sh add anthropic    # Claude Pro/Max
-oauth-pool-helper.sh add openai       # ChatGPT Plus/Pro
-```
+If they only have one account, suggest: "Consider adding a second account for automatic failover when rate limited. Run `oauth-pool-helper.sh add <provider>` in a separate terminal to add another."
 
-This opens your browser for OAuth, then saves the token to the pool. Restart OpenCode after adding.
+**Path C — Accounts exist but have problems:**
 
-**Option B — OpenCode TUI:**
+For each problem, give the specific fix — one at a time:
 
-1. Press Ctrl+A in the TUI
-2. Select the pool provider (Anthropic Pool, OpenAI Pool, Cursor Pool)
-3. Enter your account email when prompted
-4. Complete the OAuth flow in your browser
-5. Paste the authorization code back
-6. After success, switch to the main provider (Anthropic/OpenAI) and select a model — the pool provider is for account management only
+- **EXPIRED token**: "Your token for X expired. It should auto-refresh on next use. If it keeps failing, run `oauth-pool-helper.sh add <provider>` in a separate terminal using the same email to re-authenticate." For Cursor accounts, expired tokens are normal — Cursor tokens are short-lived and the plugin re-reads fresh ones from the Cursor IDE automatically. Only flag it if the status is also `auth-error`.
+- **auth-error status**: "Account X has an authentication error. Run `oauth-pool-helper.sh add <provider>` in a separate terminal with the same email to fix it."
+- **INVALID (401)**: "Token for X is invalid. Run `oauth-pool-helper.sh add <provider>` in a separate terminal with the same email to get a fresh token."
+- **Missing refresh token**: "Account X can't auto-renew. Remove it first with `oauth-pool-helper.sh remove <provider> <email>`, then re-add it with `oauth-pool-helper.sh add <provider>`."
+- **All rate-limited**: "All accounts are currently rate-limited. You can wait for cooldowns to expire, or I can reset them for you now." If they say yes, use the `model-accounts-pool` tool with `{"action": "reset-cooldowns"}`.
 
-Repeat to add multiple accounts. The pool rotates between them automatically when one hits rate limits.
+**Path D — User asks about removing or managing:**
 
-### Updating/refreshing an account
+- To remove: `oauth-pool-helper.sh remove <provider> <email>`
+- To list: `oauth-pool-helper.sh list`
+- To manually rotate: use the `model-accounts-pool` tool with `{"action": "rotate"}`
 
-Tokens refresh automatically. If an account shows `auth-error`:
+### Step 3: Verify
 
-Run `oauth-pool-helper.sh add <provider>` with the same email address — the existing account will be updated with fresh tokens.
+After any change (add/remove/re-auth), run `oauth-pool-helper.sh check` again to confirm the fix worked. Tell the user the result.
 
-### Removing an account
+## Key principles
 
-```bash
-oauth-pool-helper.sh remove anthropic user@example.com
-```
-
-Or use the `model-accounts-pool` tool:
-
-- `{"action": "remove", "provider": "anthropic", "email": "<email>"}`
-- `{"action": "remove", "provider": "openai", "email": "<email>"}`
-
-### Rotating manually
-
-Always specify the provider — omitting it may rotate the wrong pool in multi-provider setups:
-
-- `{"action": "rotate", "provider": "anthropic"}`
-- `{"action": "rotate", "provider": "openai"}`
-
-### Resetting cooldowns
-
-If all accounts are rate-limited and you want to retry immediately — specify the provider:
-
-- `{"action": "reset-cooldowns", "provider": "anthropic"}`
-- `{"action": "reset-cooldowns", "provider": "openai"}`
-
-### Troubleshooting: Pool providers not showing in Ctrl+A
-
-If the pool providers (Anthropic Pool, OpenAI Pool, Cursor Pool) don't appear:
-
-1. **Check plugin is installed**: Run `aidevops setup` — this registers the plugin in opencode.json
-2. **Check opencode.json**: Verify `~/.config/opencode/opencode.json` has the plugin in its `"plugin"` array:
-
-   ```json
-   "plugin": ["file:///Users/<you>/.aidevops/agents/plugins/opencode-aidevops/index.mjs"]
-   ```
-
-3. **Check symlink exists**: `ls -la ~/.config/opencode/plugins/opencode-aidevops`
-4. **Restart OpenCode**: The plugin loads at startup — changes require a restart
-5. **Use shell commands instead**: `oauth-pool-helper.sh add anthropic` works independently of the TUI
-
-## Notes
-
-- Pool file: `~/.aidevops/oauth-pool.json` (600 permissions, never commit)
-- Tokens are provider-specific: Anthropic tokens work with Claude models, OpenAI tokens with GPT/o-series models
-- The pool auto-rotates on rate limiting — manual rotation is rarely needed
-- Token endpoint cooldowns are in-memory (reset on OpenCode restart)
-- Per-account cooldowns persist in the pool file
-- Shell commands work independently of OpenCode — use them when the TUI auth flow is unavailable
+- **One step at a time.** Don't dump all commands at once. Guide through the immediate next action, wait for confirmation, then proceed.
+- **Separate terminal for add commands.** The `oauth-pool-helper.sh add` command needs a real terminal. For Anthropic/OpenAI it opens a browser; for Cursor it reads from the IDE (instant, no browser). Always say "run this in a separate terminal" — never suggest pasting tokens or codes into this chat.
+- **Explain why, not just what.** "This connects your Claude subscription so you can use Claude models here" is better than "This adds an OAuth token to the pool."
+- **Any model can run this.** The diagnostic uses `oauth-pool-helper.sh` (a shell script). It works even on free OpenCode models with no provider configured. The user doesn't need a working paid provider to check their setup.
+- **Don't mention internals.** Users don't need to know about pool.json, PKCE, token endpoints, auth hooks, or OAuth flows. They need "run this command, then restart."
+- **After adding, always remind:** restart OpenCode, then Ctrl+T to pick a model.

--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -133,9 +133,15 @@ open_browser() {
 cmd_add() {
 	local provider="${1:-anthropic}"
 
-	if [[ "$provider" != "anthropic" && "$provider" != "openai" ]]; then
-		print_error "Unsupported provider: $provider (supported: anthropic, openai)"
+	if [[ "$provider" != "anthropic" && "$provider" != "openai" && "$provider" != "cursor" ]]; then
+		print_error "Unsupported provider: $provider (supported: anthropic, openai, cursor)"
 		return 1
+	fi
+
+	# Cursor uses a different flow — read from local IDE installation
+	if [[ "$provider" == "cursor" ]]; then
+		cmd_add_cursor
+		return $?
 	fi
 
 	# Prompt for email
@@ -339,6 +345,190 @@ json.dump(pool, sys.stdout, indent=2)
 }
 
 # ---------------------------------------------------------------------------
+# Add Cursor account (reads from local Cursor IDE installation)
+# ---------------------------------------------------------------------------
+
+cmd_add_cursor() {
+	# Cursor doesn't use a browser OAuth flow. Instead, credentials are
+	# managed by the Cursor IDE and stored locally. We read them from:
+	#   1. ~/.cursor/auth.json (cursor-agent CLI)
+	#   2. Cursor IDE's SQLite state database (fallback)
+
+	local cursor_auth_json=""
+	local cursor_state_db=""
+
+	# Determine paths based on platform
+	case "$(uname -s)" in
+	Darwin)
+		cursor_auth_json="${HOME}/.cursor/auth.json"
+		cursor_state_db="${HOME}/Library/Application Support/Cursor/User/globalStorage/state.vscdb"
+		;;
+	Linux)
+		local config_dir="${XDG_CONFIG_HOME:-${HOME}/.config}"
+		cursor_auth_json="${config_dir}/cursor/auth.json"
+		cursor_state_db="${HOME}/.config/Cursor/User/globalStorage/state.vscdb"
+		;;
+	MINGW* | MSYS* | CYGWIN*)
+		local app_data="${APPDATA:-${HOME}/AppData/Roaming}"
+		cursor_auth_json="${app_data}/Cursor/auth.json"
+		cursor_state_db="${app_data}/Cursor/User/globalStorage/state.vscdb"
+		;;
+	*)
+		print_error "Unsupported platform for Cursor: $(uname -s)"
+		return 1
+		;;
+	esac
+
+	local access_token=""
+	local refresh_token=""
+	local email=""
+
+	# Source 1: cursor-agent auth.json
+	if [[ -f "$cursor_auth_json" ]]; then
+		print_info "Reading from Cursor auth.json..."
+		access_token=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(d.get('accessToken', ''))
+except: pass
+" "$cursor_auth_json" 2>/dev/null || true)
+		refresh_token=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    print(d.get('refreshToken', ''))
+except: pass
+" "$cursor_auth_json" 2>/dev/null || true)
+	fi
+
+	# Source 2: Cursor IDE state database (fallback or supplement)
+	if [[ -z "$access_token" && -f "$cursor_state_db" ]]; then
+		print_info "Reading from Cursor IDE state database..."
+		if ! command -v sqlite3 &>/dev/null; then
+			print_error "sqlite3 is required to read Cursor credentials but is not installed"
+			return 1
+		fi
+		access_token=$(sqlite3 "$cursor_state_db" "SELECT value FROM ItemTable WHERE key = 'cursorAuth/accessToken'" 2>/dev/null || true)
+		if [[ -z "$refresh_token" ]]; then
+			refresh_token=$(sqlite3 "$cursor_state_db" "SELECT value FROM ItemTable WHERE key = 'cursorAuth/refreshToken'" 2>/dev/null || true)
+		fi
+		if [[ -z "$email" ]]; then
+			email=$(sqlite3 "$cursor_state_db" "SELECT value FROM ItemTable WHERE key = 'cursorAuth/cachedEmail'" 2>/dev/null || true)
+		fi
+	fi
+
+	if [[ -z "$access_token" ]]; then
+		print_error "No Cursor credentials found."
+		echo "" >&2
+		echo "Make sure you:" >&2
+		echo "  1. Have Cursor IDE installed" >&2
+		echo "  2. Are logged into your Cursor account in the IDE" >&2
+		echo "  3. Have an active Cursor Pro subscription" >&2
+		echo "" >&2
+		echo "After logging in, run this command again." >&2
+		return 1
+	fi
+
+	# Decode JWT to get email and expiry (no secrets printed)
+	local jwt_info
+	jwt_info=$(ACCESS="$access_token" python3 -c "
+import os, json, base64
+token = os.environ['ACCESS']
+parts = token.split('.')
+if len(parts) >= 2:
+    # Add padding for base64
+    payload = parts[1] + '=' * (4 - len(parts[1]) % 4)
+    data = json.loads(base64.urlsafe_b64decode(payload))
+    email = data.get('email', '')
+    exp = data.get('exp', 0)
+    print(json.dumps({'email': email, 'exp': exp}))
+else:
+    print(json.dumps({'email': '', 'exp': 0}))
+" 2>/dev/null || echo '{"email":"","exp":0}')
+
+	local jwt_email jwt_exp
+	jwt_email=$(printf '%s' "$jwt_info" | python3 -c "import sys,json; print(json.load(sys.stdin).get('email',''))" 2>/dev/null || true)
+	jwt_exp=$(printf '%s' "$jwt_info" | python3 -c "import sys,json; print(json.load(sys.stdin).get('exp',0))" 2>/dev/null || echo "0")
+
+	# Use JWT email if we didn't get one from the state DB
+	if [[ -z "$email" && -n "$jwt_email" ]]; then
+		email="$jwt_email"
+	fi
+	if [[ -z "$email" ]]; then
+		email="unknown"
+	fi
+
+	# Calculate expiry in milliseconds
+	local expires_ms
+	if [[ "$jwt_exp" != "0" && -n "$jwt_exp" ]]; then
+		expires_ms=$((jwt_exp * 1000))
+	else
+		# Default: 1 hour from now
+		local now_ms
+		now_ms=$(python3 -c "import time; print(int(time.time() * 1000))")
+		expires_ms=$((now_ms + 3600000))
+	fi
+
+	# Upsert into pool file
+	local pool now_iso
+	pool=$(load_pool)
+	now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	pool=$(printf '%s' "$pool" | PROVIDER="cursor" EMAIL="$email" \
+		ACCESS="$access_token" REFRESH="${refresh_token:-}" \
+		EXPIRES="$expires_ms" NOW_ISO="$now_iso" \
+		python3 -c "
+import sys, json, os
+pool = json.load(sys.stdin)
+provider = os.environ['PROVIDER']
+email = os.environ['EMAIL']
+access = os.environ['ACCESS']
+refresh = os.environ['REFRESH']
+expires = int(os.environ['EXPIRES'])
+now_iso = os.environ['NOW_ISO']
+
+if provider not in pool:
+    pool[provider] = []
+
+found = False
+for account in pool[provider]:
+    if account.get('email') == email:
+        account['access'] = access
+        account['refresh'] = refresh
+        account['expires'] = expires
+        account['lastUsed'] = now_iso
+        account['status'] = 'active'
+        account['cooldownUntil'] = None
+        found = True
+        break
+
+if not found:
+    pool[provider].append({
+        'email': email,
+        'access': access,
+        'refresh': refresh,
+        'expires': expires,
+        'added': now_iso,
+        'lastUsed': now_iso,
+        'status': 'active',
+        'cooldownUntil': None,
+    })
+
+json.dump(pool, sys.stdout, indent=2)
+")
+
+	save_pool "$pool"
+
+	local count
+	count=$(printf '%s' "$pool" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('cursor',[])))")
+
+	print_success "Added Cursor account ${email} to pool (${count} account(s) total)"
+	print_info "Restart OpenCode to use the Cursor provider."
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Check accounts
 # ---------------------------------------------------------------------------
 
@@ -460,6 +650,7 @@ for a in pool.get(prov, []):
 		echo "To add an account:"
 		echo "  oauth-pool-helper.sh add anthropic    # Claude Pro/Max"
 		echo "  oauth-pool-helper.sh add openai       # ChatGPT Plus/Pro"
+		echo "  oauth-pool-helper.sh add cursor       # Cursor Pro (reads from IDE)"
 	fi
 	return 0
 }
@@ -565,16 +756,17 @@ cmd_help() {
 oauth-pool-helper.sh — Manage OAuth pool accounts from the shell
 
 Commands:
-  add [anthropic|openai]       Add an account via OAuth browser flow
-  check [anthropic|openai|all] Health check accounts (token expiry, validity)
-  list [anthropic|openai|all]  List accounts and their status
-  remove <provider> <email>    Remove an account from the pool
+  add [anthropic|openai|cursor] Add an account
+  check [anthropic|openai|all]  Health check accounts (token expiry, validity)
+  list [anthropic|openai|all]   List accounts and their status
+  remove <provider> <email>     Remove an account from the pool
 
 Examples:
-  oauth-pool-helper.sh add anthropic       # Add a Claude Pro/Max account
-  oauth-pool-helper.sh add openai          # Add a ChatGPT Plus/Pro account
+  oauth-pool-helper.sh add anthropic       # Claude Pro/Max (browser OAuth)
+  oauth-pool-helper.sh add openai          # ChatGPT Plus/Pro (browser OAuth)
+  oauth-pool-helper.sh add cursor          # Cursor Pro (reads from IDE)
   oauth-pool-helper.sh check               # Check all accounts
-  oauth-pool-helper.sh list anthropic      # List Anthropic accounts
+  oauth-pool-helper.sh list                # List all accounts
   oauth-pool-helper.sh remove anthropic user@example.com
 
 Notes:
@@ -582,6 +774,7 @@ Notes:
   - After adding an account, restart OpenCode to use the new token
   - Tokens refresh automatically; use 'add' with the same email to re-auth
   - The pool auto-rotates between accounts when one hits rate limits
+  - Cursor reads credentials from your local Cursor IDE — log in there first
 HELP
 	return 0
 }

--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -386,20 +386,16 @@ cmd_add_cursor() {
 	# Source 1: cursor-agent auth.json
 	if [[ -f "$cursor_auth_json" ]]; then
 		print_info "Reading from Cursor auth.json..."
-		access_token=$(python3 -c "
+		local auth_tokens
+		auth_tokens=$(python3 -c "
 import json, sys
 try:
     d = json.load(open(sys.argv[1]))
-    print(d.get('accessToken', ''))
+    print(d.get('accessToken', '') + '\n' + d.get('refreshToken', ''))
 except: pass
 " "$cursor_auth_json" 2>/dev/null || true)
-		refresh_token=$(python3 -c "
-import json, sys
-try:
-    d = json.load(open(sys.argv[1]))
-    print(d.get('refreshToken', ''))
-except: pass
-" "$cursor_auth_json" 2>/dev/null || true)
+		access_token=$(printf '%s' "$auth_tokens" | head -1)
+		refresh_token=$(printf '%s' "$auth_tokens" | tail -1)
 	fi
 
 	# Source 2: Cursor IDE state database (fallback or supplement)
@@ -447,9 +443,15 @@ else:
     print(json.dumps({'email': '', 'exp': 0}))
 " 2>/dev/null || echo '{"email":"","exp":0}')
 
-	local jwt_email jwt_exp
-	jwt_email=$(printf '%s' "$jwt_info" | python3 -c "import sys,json; print(json.load(sys.stdin).get('email',''))" 2>/dev/null || true)
-	jwt_exp=$(printf '%s' "$jwt_info" | python3 -c "import sys,json; print(json.load(sys.stdin).get('exp',0))" 2>/dev/null || echo "0")
+	local jwt_parsed jwt_email jwt_exp
+	jwt_parsed=$(printf '%s' "$jwt_info" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('email', ''))
+print(d.get('exp', 0))
+" 2>/dev/null || printf '\n0')
+	jwt_email=$(printf '%s' "$jwt_parsed" | head -1)
+	jwt_exp=$(printf '%s' "$jwt_parsed" | tail -1)
 
 	# Use JWT email if we didn't get one from the state DB
 	if [[ -z "$email" && -n "$jwt_email" ]]; then


### PR DESCRIPTION
## Summary

- Add `oauth-pool-helper.sh add cursor` — reads credentials from the local Cursor IDE installation (SQLite state DB or auth.json). No browser flow needed — instant, just requires being logged into Cursor IDE.
- Update `/models-pool-check` command doc with Cursor-specific guidance: different setup flow (instant, no browser), expired tokens are normal for Cursor (short-lived, auto-refreshed by plugin)
- Cross-platform support: macOS, Linux, Windows paths for Cursor state DB

## Testing

- `shellcheck` clean
- Tested on macOS: successfully read credentials from Cursor state.vscdb, decoded JWT for email/expiry, saved to pool.json
- `check` command shows Cursor account alongside Anthropic accounts
- `list` and `help` updated with Cursor references