### PR TITLE
GH#5382: use conventional FIXME tag for disabled auth hook workaround

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1112,11 +1112,9 @@ export async function AidevopsPlugin({ directory, client }) {
     event: async (input) => handleEvent(input),
 
     // Phase 7: OAuth multi-account pool (t1543, t1548, t1549)
-    // DISABLED: OpenCode v1.2.27 crashes when plugin returns `auth` key
-    // (Expected string, got undefined at worker.js:40673).
-    // Filed: https://github.com/anomalyco/opencode/issues/18536
-    // Pool tokens still work via initPoolAuth() injection above.
-    // Re-enable when OpenCode fixes this regression.
+    // FIXME: Re-enable once anomalyco/opencode#18536 is fixed.
+    // The `auth` hook is temporarily disabled due to a regression in OpenCode v1.2.27
+    // that causes a crash. Pool tokens continue to work via `initPoolAuth()`.
     // auth: [
     //   createPoolAuthHook(client),
     //   createOpenAIPoolAuthHook(client),


### PR DESCRIPTION
## Summary

- Replaces verbose comment block with a concise `FIXME:` tag for the temporarily disabled `auth` hook in the OpenCode plugin (`index.mjs:1115`)
- Improves discoverability by IDEs and automated tools (grep for `FIXME`, IDE task lists, etc.)
- Keeps essential context: upstream issue reference (`anomalyco/opencode#18536`), brief reason, workaround status

## Changes

**File**: `.agents/plugins/opencode-aidevops/index.mjs`

Before (5 comment lines + verbose error details):
```js
// DISABLED: OpenCode v1.2.27 crashes when plugin returns `auth` key
// (Expected string, got undefined at worker.js:40673).
// Filed: https://github.com/anomalyco/opencode/issues/18536
// Pool tokens still work via initPoolAuth() injection above.
// Re-enable when OpenCode fixes this regression.
```

After (3 comment lines + conventional FIXME tag):
```js
// FIXME: Re-enable once anomalyco/opencode#18536 is fixed.
// The `auth` hook is temporarily disabled due to a regression in OpenCode v1.2.27
// that causes a crash. Pool tokens continue to work via `initPoolAuth()`.
```

Addresses review feedback from Gemini on PR #5374.

Closes #5382