### PR TITLE
GH#5380: simplify open_browser() with if/elif/else chain

### DIFF
--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -106,12 +106,12 @@ save_pool() {
 # Open URL in browser (best-effort, never fatal)
 open_browser() {
 	local url="$1"
-	if command -v open &>/dev/null; then
-		open "$url" 2>/dev/null || true
-	elif command -v xdg-open &>/dev/null; then
-		xdg-open "$url" 2>/dev/null || true
-	elif command -v wslview &>/dev/null; then
-		wslview "$url" 2>/dev/null || true
+	if command -v open &>/dev/null && open "$url" 2>/dev/null; then
+		: # opened via macOS open
+	elif command -v xdg-open &>/dev/null && xdg-open "$url" 2>/dev/null; then
+		: # opened via xdg-open
+	elif command -v wslview &>/dev/null && wslview "$url" 2>/dev/null; then
+		: # opened via wslview
 	else
 		print_warning "Cannot open browser automatically."
 	fi


### PR DESCRIPTION
## Summary

- Refactors `open_browser()` in `oauth-pool-helper.sh` to combine the command-existence check and execution into a single `if/elif/else` condition chain
- If a browser opener exists but fails to launch the URL, the function now falls through to try the next alternative instead of silently swallowing the error with `|| true`
- Addresses PR #5377 review feedback from Gemini Code Assist

Closes #5380