### PR TITLE
t5387: fix cost spectrum ordering in model-routing.md

### DIFF
--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -22,7 +22,7 @@ model: haiku
 - **Purpose**: Route tasks to the cheapest model that can handle them well
 - **Philosophy**: Use the smallest model that produces acceptable quality
 - **Default**: sonnet (best balance of cost/capability for most tasks)
-- **Cost spectrum**: local (free) -> flash -> haiku -> composer2 -> sonnet -> pro -> opus (highest)
+- **Cost spectrum**: local (free) -> composer2 -> flash -> haiku -> sonnet -> pro -> opus (highest)
 
 ## Model Tiers
 


### PR DESCRIPTION
## Summary

- Corrects the cost spectrum ordering on line 25 of `.agents/tools/context/model-routing.md`
- `composer2` (~0.17x) is cheaper than `flash` (~0.20x) and `haiku` (~0.25x) per the cost table in the same file
- Previous ordering `local -> flash -> haiku -> composer2` was inconsistent with the cost data

## Change

```diff
- **Cost spectrum**: local (free) -> flash -> haiku -> composer2 -> sonnet -> pro -> opus (highest)
+ **Cost spectrum**: local (free) -> composer2 -> flash -> haiku -> sonnet -> pro -> opus (highest)
```

Closes #5387