### PR TITLE
fix: document intentional 2>/dev/null in drift check; plans-cleanup finding already resolved (#5393)

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -41,6 +41,8 @@ check_opencode_prompt_drift() {
 	local drift_script=".agents/scripts/opencode-prompt-drift-check.sh"
 	if [[ -f "$drift_script" ]]; then
 		local output exit_code=0
+		# 2>/dev/null is intentional: --quiet mode suppresses expected output; all exit
+		# codes (0=in-sync, 1=drift, other=error) are handled explicitly below.
 		output=$(bash "$drift_script" --quiet 2>/dev/null) || exit_code=$?
 		if [[ "$exit_code" -eq 1 && "$output" == PROMPT_DRIFT* ]]; then
 			local local_hash upstream_hash


### PR DESCRIPTION
## Summary

Closes #5393

The Gemini critical finding from PR #5355 review — `plans-cleanup-helper.sh archive 2>/dev/null` at `setup-modules/agent-deploy.sh:252` — was already resolved by the revert in PR #5357. The plans-cleanup code no longer exists in `agent-deploy.sh`.

## Analysis of remaining `2>/dev/null` usages

All remaining suppressions in the file are legitimate:

| Line | Usage | Justification |
|------|-------|---------------|
| 10 | `shopt -s inherit_errexit 2>/dev/null \|\| true` | Optional bash 4.4+ feature; safe to suppress |
| 44 | `bash "$drift_script" --quiet 2>/dev/null` | `--quiet` mode; all exit codes (0/1/other) handled explicitly |
| 88 | `sanitize_plugin_namespace "$ns" 2>/dev/null` | Validation helper; result checked, failure skips entry |
| 91 | `jq -r ... 2>/dev/null` | jq parse; outer `if` guards the whole block |
| 176–177 | `chmod +x ... 2>/dev/null \|\| true` | Optional permission set; non-fatal by design |
| 183 | `find ... 2>/dev/null` | Count only; non-fatal |
| 230 | `find ... 2>/dev/null` | Existence check; non-fatal |
| 242 | `rmdir ... 2>/dev/null \|\| true` | Optional cleanup; non-fatal by design |
| 362, 380, 386, 393, 446 | curl/tar/find | Errors caught with `if !` + `print_warning`; stderr suppressed to avoid duplicate noise |

None of these match the pattern the Gemini finding warned about (suppressing errors on a script with a known critical bug, with no fallback warning).

## Change

Added a one-line inline comment at line 44 to document the intentional `2>/dev/null` in `check_opencode_prompt_drift`, preventing future false-positive review findings on this pattern.

ShellCheck: zero violations.