### PR TITLE
t5386: fix model tier enum order by cost in schema.json

### DIFF
--- a/.agents/bundles/schema.json
+++ b/.agents/bundles/schema.json
@@ -133,7 +133,7 @@
   "$defs": {
     "model_tier": {
       "type": "string",
-      "enum": ["local", "haiku", "flash", "sonnet", "composer2", "pro", "opus"],
+      "enum": ["local", "composer2", "flash", "haiku", "sonnet", "pro", "opus"],
       "description": "Model routing tier. See .agents/tools/context/model-routing.md for tier definitions."
     },
     "quality_gate": {

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -22,7 +22,7 @@ model: haiku
 - **Purpose**: Route tasks to the cheapest model that can handle them well
 - **Philosophy**: Use the smallest model that produces acceptable quality
 - **Default**: sonnet (best balance of cost/capability for most tasks)
-- **Cost spectrum**: local (free) -> flash -> haiku -> composer2 -> sonnet -> pro -> opus (highest)
+- **Cost spectrum**: local (free) -> composer2 -> flash -> haiku -> sonnet -> pro -> opus (highest)
 
 ## Model Tiers
 
@@ -124,7 +124,7 @@ tools:
 ---
 ```
 
-Valid values: `local`, `haiku`, `flash`, `sonnet`, `composer2`, `pro`, `opus`
+Valid values: `local`, `composer2`, `flash`, `haiku`, `sonnet`, `pro`, `opus`
 
 > **Note**: The `local` tier requires `local-model-helper.sh` to be set up and a model server running. If no local server is available, `local` in frontmatter falls back to `haiku` (next tier in the routing chain — local has no same-tier fallback). See `tools/local-models/local-models.md` for setup.
 


### PR DESCRIPTION
## Summary

- Reorders `model_tier` enum in `.agents/bundles/schema.json` to reflect correct cost hierarchy: `local → composer2 → flash → haiku → sonnet → pro → opus`
- Fixes the same ordering inconsistency in `.agents/tools/context/model-routing.md` (cost spectrum text on line 25 and valid values list on line 127)

## Root Cause

`composer2` (~0.17x sonnet cost) is cheaper than both `flash` (~0.20x) and `haiku` (~0.25x), but was placed after `sonnet` in the enum. This breaks the "highest tier wins" logic during bundle composition — a bundle specifying `composer2` would incorrectly be treated as a higher tier than `sonnet`.

## Changes

| File | Change |
|------|--------|
| `.agents/bundles/schema.json:136` | Reorder enum: `composer2` moved before `flash` and `haiku` |
| `.agents/tools/context/model-routing.md:25` | Fix cost spectrum text to match cost table |
| `.agents/tools/context/model-routing.md:127` | Fix valid values list to match corrected order |

## Verification

The cost table in `model-routing.md` (lines 142–147) is the authoritative source:
- `composer2`: ~0.17x
- `flash`: ~0.20x
- `haiku`: ~0.25x
- `sonnet`: 1x (baseline)
- `pro`: ~1.5x
- `opus`: ~3x

The new enum order matches this table exactly.

Closes #5386