### PR TITLE
t5396: fix jq error visibility and pool_plugin_registered logic in mcp-setup.sh

### DIFF
--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -460,19 +460,19 @@ setup_opencode_plugins() {
 		local already_registered
 		already_registered=$(jq --arg url "$plugin_url" \
 			'(.plugin // []) | map(select(. == $url)) | length' \
-			"$opencode_config" 2>/dev/null || echo "0")
+			"$opencode_config" || echo "0")
 
 		if [[ "$already_registered" -eq 0 ]]; then
 			# Add the plugin URL to the array (create array if absent)
 			local tmp_config="${opencode_config}.tmp.$$"
 			if jq --arg url "$plugin_url" \
 				'.plugin = ((.plugin // []) + [$url] | unique)' \
-				"$opencode_config" >"$tmp_config" 2>/dev/null; then
+				"$opencode_config" >"$tmp_config"; then
 				mv "$tmp_config" "$opencode_config"
 				print_success "aidevops plugin registered in opencode.json"
 			else
 				rm -f "$tmp_config"
-				print_warning "Failed to update opencode.json plugin array"
+				print_warning "Failed to update opencode.json plugin array (file: $opencode_config)"
 			fi
 		else
 			print_success "aidevops plugin already registered in opencode.json"
@@ -498,7 +498,6 @@ setup_opencode_plugins() {
 	fi
 
 	setup_track_configured "OpenCode plugins"
-	pool_plugin_registered="true"
 
 	# Note: opencode-anthropic-auth is built into OpenCode v1.1.36+
 	# Adding it as an external plugin causes TypeError due to double-loading.


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from `jq` read (line 463): malformed `opencode.json` errors are now visible; `|| echo "0"` fallback still handles missing plugin array gracefully
- Remove `2>/dev/null` from `jq` write (line 470): parse/write errors are now visible; error message now includes the config file path for easier debugging
- Remove unconditional `pool_plugin_registered="true"` after mechanism 2: the variable is already set correctly inside the mechanism 1 block; the unconditional assignment caused OAuth pool guidance to be shown even when `jq` was unavailable or `opencode.json` was malformed

## Motivation

Addresses two medium-priority findings from the Gemini review on PR #5356, plus the related logic flaw noted in the same review body. Suppressing `jq` stderr on config file parsing makes debugging silent failures impossible — the `|| echo "0"` fallback already handles the expected "no plugin array" case without needing to hide errors.

Closes #5396