### PR TITLE
feat: Add App Store Connect CLI (asc) integration with skills, web apps, and local hosting

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -268,7 +268,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Documents/PDF | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
 | OCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |
 | Product (shared) | `product/validation.md`, `product/onboarding.md`, `product/monetisation.md`, `product/growth.md`, `product/ui-design.md`, `product/analytics.md` |
-| Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `tools/mobile/app-dev.md`, `tools/browser/extension-dev.md` |
+| Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `tools/mobile/app-dev.md`, `tools/mobile/app-store-connect.md`, `tools/browser/extension-dev.md` |
 | Content/Video/Voice | `content.md`, `tools/video/video-prompt-design.md`, `tools/voice/speech-to-speech.md` |
 | Design | `tools/design/ui-ux-inspiration.md`, `tools/design/ui-ux-catalogue.toon`, `tools/design/brand-identity.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |

--- a/.agents/configs/upstream-watch.json
+++ b/.agents/configs/upstream-watch.json
@@ -7,6 +7,27 @@
       "relevance": "Token cost optimization for agent bash operations (git, gh, test runners). Evaluated in t1430.",
       "default_branch": "master",
       "added_at": "2026-03-10"
+    },
+    {
+      "slug": "tddworks/asc-cli",
+      "description": "App Store Connect CLI — Swift CLI for managing iOS/macOS apps, builds, TestFlight, metadata, subscriptions, screenshots",
+      "relevance": "Primary CLI tool for App Store Connect automation. New releases add commands, API coverage, and agent affordances. Documented in tools/mobile/app-store-connect.md.",
+      "default_branch": "main",
+      "added_at": "2026-03-21"
+    },
+    {
+      "slug": "tddworks/asc-cli-skills",
+      "description": "Official agent skills for the asc CLI — per-command-group reference with flags, output schemas, error tables",
+      "relevance": "27 skills covering auth, builds, TestFlight, IAP, subscriptions, code signing, reports, Game Center, Xcode Cloud. New skills extend agent capabilities.",
+      "default_branch": "main",
+      "added_at": "2026-03-21"
+    },
+    {
+      "slug": "rudrankriyam/app-store-connect-cli-skills",
+      "description": "Community workflow skills for asc CLI — release flows, ASO audit, localization, RevenueCat sync, crash triage",
+      "relevance": "22 higher-level workflow skills complementing the official per-command skills. New skills add orchestration patterns.",
+      "default_branch": "main",
+      "added_at": "2026-03-21"
     }
   ],
   "non_github_upstreams": [

--- a/.agents/services/hosting/local-hosting.md
+++ b/.agents/services/hosting/local-hosting.md
@@ -890,6 +890,23 @@ Then run the one-time setup:
 localdev-helper.sh init
 ```
 
+## Tool-Specific Examples
+
+### App Store Connect Web Dashboard (asc-web)
+
+The `asc` CLI (App Store Connect) includes an embedded web server with a dashboard, CLI console, and screenshot studio. See `tools/mobile/app-store-connect.md` for full documentation.
+
+```bash
+# Register with localdev (one-time)
+localdev-helper.sh add asc
+
+# Run the asc web server via localdev
+localdev-helper.sh run --app asc -- asc tui --port $PORT
+# → https://asc.local/command-center (interactive ASC dashboard)
+# → https://asc.local/console (CLI reference + terminal)
+# → https://asc.local/editor (screenshot studio)
+```
+
 ## File Locations
 
 | Path | Purpose |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -41,7 +41,7 @@ tools/mcp-toolkit/,MCP runtime toolkit - discover call compose and generate CLIs
 tools/ai-assistants/,AI tool integration - OpenCode headless dispatch model comparison and response scoring,agno|capsolver|claude-code|compare-models|response-scoring|overview|openclaw|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
 tools/browser/,Browser automation - scraping testing and QA,agent-browser|browser-automation|browser-qa|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy|chrome-webstore-release
-tools/mobile/,Mobile development - iOS/macOS build test simulator and emulator automation,agent-device|xcodebuild-mcp|ios-simulator-mcp|maestro|axe-cli|minisim
+tools/mobile/,Mobile development - iOS/macOS build test simulator App Store Connect and emulator automation,app-store-connect|agent-device|xcodebuild-mcp|ios-simulator-mcp|maestro|axe-cli|minisim
 tools/pdf/,PDF processing - form filling and digital signatures,overview|libpdf
 tools/accessibility/,Accessibility and contrast testing - WCAG compliance for websites and emails,accessibility
 tools/performance/,Web performance - Core Web Vitals and network analysis,performance|webpagetest

--- a/.agents/tools/mobile/app-dev.md
+++ b/.agents/tools/mobile/app-dev.md
@@ -43,6 +43,7 @@
 
 **Related agents**:
 
+- `tools/mobile/app-store-connect.md` - App Store Connect CLI (asc) — builds, TestFlight, metadata, subscriptions, submissions, web dashboard
 - `tools/mobile/agent-device.md` - AI-driven mobile device automation
 - `tools/mobile/xcodebuild-mcp.md` - Xcode build/test/deploy
 - `tools/mobile/maestro.md` - E2E test flows
@@ -65,7 +66,7 @@ Onboarding    -> product/onboarding.md (first-run experience, paywall placement)
 Development   -> tools/mobile/app-dev/expo.md OR tools/mobile/app-dev/swift.md
 Testing       -> agent-device (AI-driven) + maestro (E2E) + xcodebuild-mcp (build)
 Preview       -> ios-simulator-mcp + playwright-emulation (web) + agent-device
-Publishing    -> tools/mobile/app-dev/publishing.md (App Store + Play Store)
+Publishing    -> tools/mobile/app-dev/publishing.md (checklists) + app-store-connect.md (asc CLI)
 Monetisation  -> product/monetisation.md (RevenueCat, ads, freemium)
 Growth        -> product/growth.md (UGC, influencers, content, paid ads)
 Analytics     -> product/analytics.md (retention, engagement, revenue)

--- a/.agents/tools/mobile/app-dev/publishing.md
+++ b/.agents/tools/mobile/app-dev/publishing.md
@@ -32,6 +32,18 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
+## CLI Automation — asc
+
+For programmatic App Store Connect management (builds, TestFlight, metadata, screenshots, subscriptions, submissions), use the `asc` CLI. See `tools/mobile/app-store-connect.md` for full documentation.
+
+```bash
+brew install tddworks/tap/asccli
+asc auth login --key-id KEY --issuer-id ISSUER --private-key-path ~/.asc/AuthKey.p8
+asc apps list
+```
+
+The checklists below cover compliance requirements. The `asc` CLI automates the execution.
+
 ## Apple App Store
 
 ### Pre-Submission Checklist
@@ -169,6 +181,7 @@ tools:
 
 ## Related
 
+- `tools/mobile/app-store-connect.md` - App Store Connect CLI (asc) — programmatic ASC management
 - `tools/mobile/app-dev/testing.md` - Pre-submission testing
 - `product/monetisation.md` - Payment setup
 - `tools/mobile/app-dev/assets.md` - Screenshot and icon generation

--- a/.agents/tools/mobile/app-store-connect.md
+++ b/.agents/tools/mobile/app-store-connect.md
@@ -1,0 +1,285 @@
+---
+description: App Store Connect CLI (asc) - manage iOS/macOS apps, builds, TestFlight, metadata, subscriptions, screenshots, and submissions from terminal
+mode: subagent
+tools:
+  read: true
+  write: true
+  edit: true
+  bash: true
+  glob: true
+  grep: true
+  webfetch: false
+  task: false
+---
+
+# App Store Connect CLI — asc
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Purpose**: Programmatic App Store Connect management — builds, releases, TestFlight, metadata, subscriptions, screenshots, code signing, reports
+- **Install**: `brew install tddworks/tap/asccli`
+- **Auth**: `asc auth login --key-id KEY --issuer-id ISSUER --private-key-path ~/.asc/AuthKey.p8`
+- **Project pin**: `asc init --app-id <id>` (saves to `.asc/project.json`, auto-used by all commands)
+- **GitHub**: https://github.com/tddworks/asc-cli (MIT, Swift, 130+ commands, 100+ API endpoints)
+- **Website**: https://asccli.app
+- **Skills (official)**: https://github.com/tddworks/asc-cli-skills (27 skills)
+- **Skills (community)**: https://github.com/rudrankriyam/app-store-connect-cli-skills (22 workflow skills)
+- **Web apps**: Command Center (`/command-center`), Console (`/console`), Screenshot Studio (`/editor`)
+
+**Key design**: CAEOAS (Commands As Engine Of Application State) — every JSON response includes an `affordances` field with ready-to-run next commands. Always follow affordances instead of constructing commands manually.
+
+**Requirements**: macOS 13+, App Store Connect API key
+
+<!-- AI-CONTEXT-END -->
+
+## Install and Auth
+
+```bash
+brew install tddworks/tap/asccli
+
+# Create API key at https://appstoreconnect.apple.com/access/integrations/api
+asc auth login \
+  --key-id YOUR_KEY_ID \
+  --issuer-id YOUR_ISSUER_ID \
+  --private-key-path ~/.asc/AuthKey_XXXXXX.p8 \
+  --name personal        # optional alias; defaults to "default"
+
+asc auth check            # verify active credentials
+asc apps list             # find your app ID
+asc init --app-id <id>    # pin app — skip --app-id on future commands
+```
+
+**Multi-account**: Save multiple accounts with `--name`, switch with `asc auth use <name>`. Credentials stored in `~/.asc/credentials.json`.
+
+**Credential security**: The `asc auth login` command stores the private key PEM in `~/.asc/credentials.json`. Never commit this file. Never pass key content as a command argument — use `--private-key-path` to reference the file.
+
+## Project Context Resolution
+
+`asc init` saves app context to `.asc/project.json`. All commands that need `--app-id` check this file first.
+
+**Resolution order**:
+
+1. User provided `--app-id` explicitly — use it
+2. `.asc/project.json` exists — read `appId` from it
+3. Neither — run `asc apps list`, show results, ask user to pick or run `asc init`
+
+## CAEOAS Affordances
+
+Every JSON response includes an `affordances` field with state-aware next commands:
+
+```json
+{
+  "id": "v1",
+  "versionString": "2.1.0",
+  "state": "PREPARE_FOR_SUBMISSION",
+  "affordances": {
+    "listLocalizations": "asc version-localizations list --version-id v1",
+    "checkReadiness":    "asc versions check-readiness --version-id v1",
+    "submitForReview":   "asc versions submit --version-id v1"
+  }
+}
+```
+
+`submitForReview` only appears when `isEditable == true`. Always follow affordances — they encode business rules the CLI enforces.
+
+## Command Groups
+
+| Group | Key Commands | Purpose |
+|-------|-------------|---------|
+| **apps** | `list` | List all apps |
+| **versions** | `list`, `create`, `set-build`, `check-readiness`, `submit` | App Store versions and submission |
+| **builds** | `list`, `archive`, `upload`, `add-beta-group`, `update-beta-notes` | Build management and upload |
+| **testflight** | `groups list`, `testers add/remove/import/export` | Beta distribution |
+| **version-localizations** | `list`, `create`, `update` | What's New, description, keywords per locale |
+| **app-infos** | `list`, `update` | App name, subtitle, categories, age rating |
+| **app-info-localizations** | `list`, `create`, `update`, `delete` | Per-locale app metadata |
+| **screenshot-sets** | `list`, `create` | Screenshot set management |
+| **screenshots** | `list`, `upload` | Screenshot image upload |
+| **app-preview-sets** | `list`, `create` | Video preview management |
+| **app-previews** | `list`, `upload` | Video preview upload (.mp4, .mov, .m4v) |
+| **app-shots** | `config`, `generate`, `translate` | AI-powered screenshot generation (Gemini) |
+| **iap** | `list`, `create`, `submit`, `price-points`, `prices` | In-app purchases |
+| **subscriptions** | `list`, `create`, `submit` | Auto-renewable subscriptions |
+| **subscription-groups** | `list`, `create` | Subscription groups |
+| **subscription-offers** | `list`, `create` | Introductory and promotional offers |
+| **bundle-ids** | `list`, `create`, `delete` | Bundle ID management |
+| **certificates** | `list`, `create`, `revoke` | Signing certificates |
+| **profiles** | `list`, `create`, `delete` | Provisioning profiles |
+| **devices** | `list`, `register` | Device registration |
+| **reviews** | `list`, `get` | Customer reviews |
+| **review-responses** | `create`, `get`, `delete` | Developer responses to reviews |
+| **game-center** | `detail`, `achievements`, `leaderboards` | Game Center management |
+| **perf-metrics** | `list` | Performance metrics (launch, hang, memory) |
+| **diagnostics** | `list` | Diagnostic signatures and logs |
+| **reports** | `sales-reports`, `finance-reports`, `analytics-reports` | Sales, financial, analytics reports |
+| **users** | `list`, `update`, `remove` | Team member management |
+| **user-invitations** | `list`, `invite`, `cancel` | Team invitations |
+| **xcode-cloud** | `products`, `workflows`, `builds` | Xcode Cloud CI/CD |
+| **iris** | `status`, `apps list`, `apps create` | Private API (browser cookie auth) |
+| **plugins** | `list`, `install`, `run` | Custom event handlers |
+| **tui** | (interactive) | Terminal UI browser |
+
+**Discover commands**: `asc --help`, `asc <command> --help`, `asc <command> <subcommand> --help`
+
+**Output formats**: `--output json` (default), `--output table`, `--output markdown`, `--pretty`
+
+## Key Workflows
+
+### Release Flow (build to App Store review)
+
+```bash
+# 1. Archive and upload (or upload pre-built IPA)
+asc builds archive --scheme MyApp --upload --app-id APP_ID --version 1.2.0 --build-number 55
+# OR: asc builds upload --app-id APP_ID --file MyApp.ipa --version 1.2.0 --build-number 55
+
+# 2. Distribute to TestFlight
+GROUP_ID=$(asc testflight groups list --app-id APP_ID | jq -r '.data[0].id')
+BUILD_ID=$(asc builds list --app-id APP_ID | jq -r '.data[0].id')
+asc builds add-beta-group --build-id "$BUILD_ID" --beta-group-id "$GROUP_ID"
+
+# 3. Link build to version
+VERSION_ID=$(asc versions list --app-id APP_ID | jq -r '.data[0].id')
+asc versions set-build --version-id "$VERSION_ID" --build-id "$BUILD_ID"
+
+# 4. Update What's New
+LOC_ID=$(asc version-localizations list --version-id "$VERSION_ID" | jq -r '.data[0].id')
+asc version-localizations update --localization-id "$LOC_ID" --whats-new "Bug fixes and improvements"
+
+# 5. Pre-flight check and submit
+asc versions check-readiness --version-id "$VERSION_ID"
+asc versions submit --version-id "$VERSION_ID"
+```
+
+### TestFlight Distribution
+
+```bash
+asc testflight groups list --app-id APP_ID
+asc testflight testers add --beta-group-id GROUP_ID --email user@example.com
+asc testflight testers import --beta-group-id GROUP_ID --file testers.csv
+asc builds update-beta-notes --build-id BUILD_ID --locale en-US --notes "What's new in beta"
+```
+
+### Code Signing Setup
+
+```bash
+asc bundle-ids create --name "My App" --identifier com.example.app --platform ios
+asc certificates create --type IOS_DISTRIBUTION --csr-content "$(cat MyApp.certSigningRequest)"
+asc profiles create --name "App Store Profile" --type IOS_APP_STORE \
+  --bundle-id-id BID --certificate-ids CERT_ID
+```
+
+### Metadata and Localisation
+
+```bash
+asc app-info-localizations update --localization-id LOC_ID \
+  --name "My App" --subtitle "Do things faster"
+asc version-localizations update --localization-id LOC_ID \
+  --whats-new "Bug fixes" --description "Full description here"
+```
+
+### AI Screenshot Generation
+
+```bash
+asc app-shots config --gemini-api-key KEY    # one-time setup
+asc app-shots generate                        # iPhone 6.9" at 1320x2868
+asc app-shots generate --device-type APP_IPHONE_67
+asc app-shots translate --to zh --to ja       # localise all screens
+```
+
+## Web Apps (Local Hosting)
+
+The `asc` CLI includes an embedded web server with three web apps:
+
+| App | Path | Purpose |
+|-----|------|---------|
+| **Command Center** | `/command-center` | Interactive ASC dashboard — apps, builds, TestFlight, screenshots, subscriptions, reviews |
+| **Console** | `/console` | CLI reference + embedded terminal, Cmd+K search |
+| **Screenshot Studio** | `/editor` | Visual App Store screenshot builder with device bezels, text layers, gradient backgrounds |
+
+**Live demos**: https://asccli.app/command-center, https://asccli.app/console, https://asccli.app/editor
+
+### Local hosting with localdev
+
+```bash
+# Register with localdev (one-time)
+localdev-helper.sh add asc
+
+# Run the asc web server via localdev
+localdev-helper.sh run --app asc -- asc tui --port \$PORT
+# → https://asc.local/command-center (dashboard)
+# → https://asc.local/console (CLI reference)
+# → https://asc.local/editor (screenshot studio)
+```
+
+The Command Center and Console require the `asc` server backend to execute commands. The Screenshot Studio is fully static and works without any backend — it can also be served standalone.
+
+**Server details**: Node.js HTTP server on port 8420 (configurable via `--port`). Routes: `/api/run` executes `asc` commands, static files served for all three apps. Commands are validated (blocks shell metacharacters).
+
+## Agent Skills
+
+Two complementary skills packs provide agent guidance:
+
+| Pack | Install | Focus |
+|------|---------|-------|
+| **Official** (tddworks) | `asc skills install --all` | Per-command-group reference: exact flags, output schemas, error tables |
+| **Community** (rudrankriyam) | `npx skills add rudrankriyam/app-store-connect-cli-skills` | Workflow orchestration: release flows, ASO audit, localization, RevenueCat sync, crash triage |
+
+Skills are loaded on-demand by the agent when relevant tasks are detected — they are not pre-loaded into context.
+
+## Optional: Blitz MCP Server
+
+[Blitz](https://github.com/blitzdotdev/blitz-mac) is a native macOS app that provides 30+ MCP tools for iOS development (simulator management, App Store Connect, build pipeline). It includes an npm-installable MCP server:
+
+```bash
+# Install MCP server (requires Blitz macOS app running)
+npx @blitzdev/blitz-mcp
+```
+
+**MCP config** (for Claude Code, Cursor, etc.):
+
+```json
+{
+  "mcpServers": {
+    "blitz": {
+      "command": "npx",
+      "args": ["-y", "@blitzdev/blitz-mcp"]
+    }
+  }
+}
+```
+
+Blitz overlaps with our existing XcodeBuildMCP and ios-simulator-mcp but adds ASC submission tools. Use it as an alternative if you prefer a GUI-backed MCP server over the `asc` CLI.
+
+## Integration with aidevops Mobile Stack
+
+| Tool | Role | When to Use |
+|------|------|-------------|
+| **asc CLI** | App Store Connect API | Publishing, metadata, TestFlight, subscriptions, reports |
+| **XcodeBuildMCP** | Build, test, deploy | Xcode project build/test/run (76 tools) |
+| **ios-simulator-mcp** | Simulator interaction | UI testing, screenshots, accessibility |
+| **Maestro** | E2E test flows | Repeatable scripted test flows |
+| **RevenueCat** | Subscription management | Server-side subscription tracking, analytics |
+
+### Typical Full Lifecycle
+
+```text
+1. Build         → xcodebuild-mcp (build_sim, test_sim)
+2. Test          → maestro (E2E flows) + ios-simulator-mcp (ad-hoc QA)
+3. Upload        → asc builds archive --upload (or asc builds upload)
+4. TestFlight    → asc testflight (groups, testers, beta notes)
+5. Metadata      → asc version-localizations, app-info-localizations
+6. Screenshots   → asc app-shots generate + asc screenshots upload
+7. Submit        → asc versions check-readiness + asc versions submit
+8. Monitor       → asc reviews list, asc perf-metrics list
+```
+
+## Related
+
+- `tools/mobile/app-dev.md` — Full mobile development lifecycle
+- `tools/mobile/app-dev/publishing.md` — App Store submission checklists and compliance
+- `tools/mobile/xcodebuild-mcp.md` — Xcode build/test/deploy MCP
+- `tools/mobile/ios-simulator-mcp.md` — Simulator interaction MCP
+- `services/payments/revenuecat.md` — Subscription management
+- `services/hosting/local-hosting.md` — localdev for asc-web hosting


### PR DESCRIPTION
## Summary

- Add comprehensive App Store Connect CLI (`asc`) subagent covering 130+ commands, CAEOAS affordances, web dashboard, and local hosting integration
- Synthesize knowledge from 4 upstream repos (asc-cli, 2 skills packs, Blitz) into our efficiency architecture (one subagent entry point, progressive disclosure)
- Wire into existing mobile stack with cross-references and upstream watch tracking

## What changed

### New file
- **`.agents/tools/mobile/app-store-connect.md`** — Single subagent covering:
  - `asc` CLI install, auth, project context resolution
  - CAEOAS affordance pattern (follow JSON `affordances` fields)
  - All command groups (apps, versions, builds, TestFlight, metadata, screenshots, IAP, subscriptions, code signing, reports, reviews, Game Center, Xcode Cloud, Iris private API)
  - Key workflows: release flow, TestFlight distribution, code signing setup, metadata/localisation, AI screenshot generation
  - Web apps: Command Center (dashboard), Console (CLI reference), Screenshot Studio (visual screenshot builder)
  - Local hosting via `localdev-helper.sh` (`https://asc.local`)
  - Optional Blitz MCP server integration (30+ iOS dev tools)
  - Integration map with existing mobile stack (XcodeBuildMCP, ios-simulator-mcp, Maestro, RevenueCat)

### Updated files
- **`app-dev.md`** — Added app-store-connect.md to related agents list and mobile tool stack
- **`publishing.md`** — Added asc CLI quick-start section and cross-reference
- **`local-hosting.md`** — Added asc-web local hosting example (Tool-Specific Examples section)
- **`upstream-watch.json`** — Added 3 upstream watch entries for tracking releases
- **`subagent-index.toon`** — Added app-store-connect to mobile category
- **`AGENTS.md`** — Added app-store-connect.md to Browser/Mobile domain index

## Design decisions

- **One subagent, not 49 files**: The two skills repos contain 49 skills total. Our efficiency architecture uses progressive disclosure from a single entry point — the subagent synthesizes the best of both repos into one doc. Skills are referenced for on-demand loading, not pre-loaded.
- **CLI-first, GUI-optional**: `asc` CLI is the primary tool (headless-compatible). Blitz MCP is documented as optional for users who prefer a GUI-backed MCP server.
- **Credential security**: Auth section warns against passing key content as arguments, references `--private-key-path` pattern. Credentials file (`~/.asc/credentials.json`) noted as never-commit.
- **Skipped Blitz as primary**: Blitz is a macOS GUI app that overlaps with our existing XcodeBuildMCP + ios-simulator-mcp. Documented as optional MCP alternative, not primary tool.

## Upstream sources

| Repo | Stars | What we used |
|------|-------|-------------|
| [tddworks/asc-cli](https://github.com/tddworks/asc-cli) | 84 | CLI tool, command reference, web app architecture, CAEOAS pattern |
| [tddworks/asc-cli-skills](https://github.com/tddworks/asc-cli-skills) | 0 | 27 official skills (per-command reference, project context resolution) |
| [rudrankriyam/app-store-connect-cli-skills](https://github.com/rudrankriyam/app-store-connect-cli-skills) | 540 | 22 community workflow skills (release flows, ASO, localization) |
| [blitzdotdev/blitz-mac](https://github.com/blitzdotdev/blitz-mac) | 202 | MCP server config (optional integration) |