### PR TITLE
feat: auto-configure opencode-cursor-oauth plugin in setup

### DIFF
--- a/.agents/scripts/commands/models-pool-check.md
+++ b/.agents/scripts/commands/models-pool-check.md
@@ -36,11 +36,11 @@ For Anthropic: `oauth-pool-helper.sh add anthropic`
 
 For OpenAI: `oauth-pool-helper.sh add openai`
 
-For Cursor: `oauth-pool-helper.sh add cursor`
+For Cursor: `opencode auth login --provider cursor`
 
 For Anthropic/OpenAI, explain: "This will open your browser to log in. After you authorize, you'll get a code to paste back into the terminal. Once done, restart OpenCode and your account will be active."
 
-For Cursor, explain: "This reads your credentials from the Cursor IDE — make sure you're logged in there first. No browser step needed, it's instant."
+For Cursor, explain: "This opens your browser to log into Cursor. After you authorize, tokens are saved automatically. Restart OpenCode and Cursor models will appear when you press Ctrl+T."
 
 After they confirm it worked, tell them to restart OpenCode, then use Ctrl+T to select a model from the provider.
 

--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -478,6 +478,42 @@ setup_opencode_plugins() {
 			print_success "aidevops plugin already registered in opencode.json"
 		fi
 		pool_plugin_registered="true"
+
+		# --- Register opencode-cursor-oauth plugin (npm, auto-installed by OpenCode) ---
+		local cursor_plugin="opencode-cursor-oauth"
+		local cursor_already
+		cursor_already=$(jq --arg p "$cursor_plugin" \
+			'(.plugin // []) | map(select(. == $p)) | length' \
+			"$opencode_config" 2>/dev/null || echo "0")
+
+		if [[ "$cursor_already" -eq 0 ]]; then
+			local tmp_cursor="${opencode_config}.tmp.$$"
+			if jq --arg p "$cursor_plugin" \
+				'.plugin = ((.plugin // []) + [$p] | unique)' \
+				"$opencode_config" >"$tmp_cursor" 2>/dev/null; then
+				mv "$tmp_cursor" "$opencode_config"
+				print_success "Cursor OAuth plugin registered in opencode.json"
+			else
+				rm -f "$tmp_cursor"
+				print_warning "Failed to register Cursor OAuth plugin"
+			fi
+		else
+			print_success "Cursor OAuth plugin already registered"
+		fi
+
+		# --- Ensure cursor provider stub exists (required by opencode-cursor-oauth) ---
+		local has_cursor_provider
+		has_cursor_provider=$(jq '.provider.cursor // empty' "$opencode_config" 2>/dev/null || true)
+		if [[ -z "$has_cursor_provider" ]]; then
+			local tmp_cursor_prov="${opencode_config}.tmp.$$"
+			if jq '.provider.cursor = {"name": "Cursor"}' \
+				"$opencode_config" >"$tmp_cursor_prov" 2>/dev/null; then
+				mv "$tmp_cursor_prov" "$opencode_config"
+				print_success "Cursor provider stub added to opencode.json"
+			else
+				rm -f "$tmp_cursor_prov"
+			fi
+		fi
 	else
 		if [[ -z "${opencode_config:-}" ]]; then
 			print_info "opencode.json not found — run 'opencode' once to create it, then re-run setup"
@@ -534,9 +570,13 @@ setup_opencode_plugins() {
 			print_info "  4. Complete the OAuth flow in your browser"
 			print_info "  5. Repeat to add more accounts for automatic rotation"
 			print_info "  6. Switch to 'Anthropic' provider and select a model to start chatting"
+			print_info ""
+			print_info "For Cursor Pro accounts:"
+			print_info "  Run: opencode auth login --provider cursor"
+			print_info "  Or from shell: oauth-pool-helper.sh add cursor"
+			print_info ""
 			print_info "  Health check: /models-pool-check"
 			print_info "  Manage accounts: /model-accounts-pool list|status|remove"
-			print_info "  Docs: ~/.aidevops/agents/tools/opencode/opencode-anthropic-auth.md"
 		else
 			print_warning "aidevops OpenCode plugin was not registered; 'Anthropic Pool' may be unavailable"
 			print_info "Re-run aidevops setup to register the plugin, then run: opencode auth login"


### PR DESCRIPTION
## Summary

- Auto-register `opencode-cursor-oauth` npm plugin in `opencode.json` during setup (OpenCode installs npm plugins automatically at startup)
- Add required `cursor` provider stub to config
- Add Cursor Pro auth guidance to setup output
- Update `/models-pool-check` to use `opencode auth login --provider cursor` (the proper OAuth flow via `opencode-cursor-oauth` plugin) instead of our homebrew `cursor-agent` proxy

## How Cursor works now

1. `aidevops setup` registers the `opencode-cursor-oauth` plugin + cursor provider stub
2. User runs `opencode auth login --provider cursor` — browser OAuth to Cursor
3. Restart OpenCode — Cursor models appear in Ctrl+T
4. The plugin handles everything: OAuth, model discovery via gRPC, local proxy for API translation, tool calling