### PR TITLE
fix: install profile update job whenever gh is available

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1534,9 +1534,10 @@ ST_PLIST
 	fi
 
 	# Profile README auto-update scheduled job.
-	# Only installed if user has a profile repo (priority: "profile") in repos.json.
+	# Installed whenever gh CLI is available — the update script self-heals
+	# (discovers/creates the profile repo on first run via _resolve_profile_repo).
 	# macOS: launchd plist (hourly) | Linux: cron (hourly)
-	if [[ -x "$pr_script" ]] && [[ "$has_profile_repo" == "true" ]]; then
+	if [[ -x "$pr_script" ]] && command -v gh &>/dev/null; then
 		mkdir -p "$HOME/.aidevops/.agent-workspace/logs"
 
 		if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
## Summary

- Changed the profile-readme-update scheduled job gate from `has_profile_repo == true` to `command -v gh` -- the job is now installed whenever gh CLI is available, regardless of whether the profile repo is already set up

## Context

Root cause of alex-solovyev's profile stats never updating: the hourly `profile-readme-helper.sh update` job was only installed by setup.sh if the profile repo was already successfully initialized (`has_profile_repo == true`). If `cmd_init` failed during `setup.sh --non-interactive` (e.g., `gh auth status` unavailable in launchd/cron context), the job was never installed. This meant the self-healing `_resolve_profile_repo` fallback (PR #5372) could never trigger -- nothing was calling `cmd_update` in the first place.

The update script already handles the no-profile-repo case gracefully via `_resolve_profile_repo`'s three-tier fallback (repos.json -> convention path `~/Git/$username` -> `cmd_init`). The gate just needs to ensure `gh` is available for that fallback to work.

## Verification

- `shellcheck` passes (zero violations)