### PR TITLE
t5392: Fix fragile Status-line lookup in task-complete-helper.sh

### DIFF
--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -381,19 +381,36 @@ sync_plans_status() {
 			continue
 		fi
 
-		# Find the plan's Status line (within 5 lines above the TODO line)
+		# Find the plan's Status line by locating the preceding ### header,
+		# then searching within the header-to-TODO range. This is robust
+		# against additional metadata fields being added between Status and
+		# TODO lines. (GH#5392 — review feedback from PR#5357)
 		local status_line=""
-		local offset=0
-		for offset in 1 2 3 4 5; do
-			local check_line=$((todo_line - offset))
-			if [[ "$check_line" -lt 1 ]]; then break; fi
+		local header_line=""
+		local search_line=$((todo_line - 1))
+		while [[ "$search_line" -ge 1 ]]; do
 			local line_content
-			line_content=$(sed -n "${check_line}p" "$plans_file")
-			if echo "$line_content" | grep -q '^\*\*Status:\*\*'; then
-				status_line="$check_line"
+			line_content=$(sed -n "${search_line}p" "$plans_file")
+			if echo "$line_content" | grep -q '^### \['; then
+				header_line="$search_line"
 				break
 			fi
+			search_line=$((search_line - 1))
 		done
+
+		# Search for Status line between header and TODO line
+		if [[ -n "$header_line" ]]; then
+			local scan_line=$((header_line + 1))
+			while [[ "$scan_line" -lt "$todo_line" ]]; do
+				local line_content
+				line_content=$(sed -n "${scan_line}p" "$plans_file")
+				if echo "$line_content" | grep -q '^\*\*Status:\*\*'; then
+					status_line="$scan_line"
+					break
+				fi
+				scan_line=$((scan_line + 1))
+			done
+		fi
 
 		if [[ -z "$status_line" ]]; then
 			continue


### PR DESCRIPTION
## Summary

- Replaces the fragile fixed-offset search (5 lines upward) in `sync_plans_status()` with a robust header-bounded search: find the preceding `### [` header, then scan forward for `**Status:**` within the header-to-TODO range
- Handles any number of metadata fields between Status and TODO lines in PLANS.md without breaking

## Problem

The previous logic searched a fixed 5-line window above the `**TODO:**` line to find the `**Status:**` line. If the PLANS.md format added more metadata fields between them (e.g., additional timestamps, links, or TOON blocks), the Status line would fall outside the window and the plan status would silently fail to update.

## Fix

Two-phase search:
1. Walk upward from the TODO line to find the plan's `### [` header
2. Walk forward from the header to find `**Status:**` within the bounded range

This is structurally correct regardless of how many lines exist between the header and the TODO line.

## Verification

- ShellCheck: zero violations
- Bash syntax check: passes
- Logic review: the new search is strictly more robust — it finds the same Status line in the current format, and also handles expanded formats

Closes #5392