### PR TITLE
t5399: fix cloudron.md quality-debt review feedback

### DIFF
--- a/.agents/services/hosting/cloudron.md
+++ b/.agents/services/hosting/cloudron.md
@@ -251,7 +251,7 @@ last reboot | head -5
 journalctl -b -1 --no-pager | grep -i -E 'cloudron.*update|cloudron-updater'
 
 # Get the current Cloudron version
-jq -r '.version' /home/yellowtent/box/package.json
+jq '.version' /home/yellowtent/box/package.json
 ```
 
 **Step 2: Assess system resources** — Rule out OOM, disk full, or CPU saturation.
@@ -388,7 +388,7 @@ docker exec -it <container_name> /bin/bash
 | App-specific logs | `docker logs <container_name>` | Individual app startup/runtime errors |
 | System journal (previous boot) | `journalctl -b -1 --no-pager -n 50 -p warning` | What happened before the reboot |
 | Cloudron troubleshoot | `cloudron-support --troubleshoot` | Built-in diagnostic checks (DNS, certs, services, migrations) |
-| Cloudron version | `jq -r '.version' /home/yellowtent/box/package.json` | Current Cloudron version |
+| Cloudron version | `jq '.version' /home/yellowtent/box/package.json` | Current Cloudron version |
 
 ### **Database Troubleshooting (MySQL)**
 

--- a/.agents/services/hosting/cloudron.md
+++ b/.agents/services/hosting/cloudron.md
@@ -376,7 +376,7 @@ docker exec -it <container_name> /bin/bash
 | `Restarting` | Crash loop | Check logs, likely app/db issue |
 | `Exited (0)` | Clean shutdown | Cloudron hasn't started it yet (normal post-reboot) |
 | `Exited (1)` | Error exit | Check `docker logs <container>` for the error |
-| `Exited (137)` | Killed (SIGKILL/OOM) | Check `dmesg | grep -i oom` and memory limits |
+| `Exited (137)` | Killed (SIGKILL/OOM) | Check `dmesg \| grep -i oom` and memory limits |
 | `Created` | Never started | Waiting in Cloudron's startup queue |
 
 ### Key Log Files and Services


### PR DESCRIPTION
## Summary

Addresses quality-debt review feedback from PR #5338 on \`.agents/services/hosting/cloudron.md\`.

## Changes

- Remove \`-r\` flag from both \`jq -r '.version'\` calls (lines 254 and 391) → \`jq '.version'\`, so a missing \`.version\` key outputs \`null\` instead of empty string, giving clearer feedback during troubleshooting (per Gemini reviewer suggestions)
- Fix pre-existing MD056 lint error: escape \`|\` pipe character inside table cell at line 379 to prevent it being parsed as a column separator

## Testing

- \`markdownlint-cli2 .agents/services/hosting/cloudron.md\` → 0 errors

Closes #5399