### PR TITLE
t5398: clarify pre-v1.1.36 auth instruction with direct section link

### DIFF
--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -338,7 +338,7 @@ OAuth tokens are stored securely by OpenCode in:
 
 > **v1.2.30+**: Use `opencode auth login` and select **Anthropic Pool**.
 > **v1.1.36–v1.2.29**: Use built-in **Anthropic → Claude Pro/Max**.
-> **pre-v1.1.36**: Install `opencode-anthropic-auth` first, then use Anthropic OAuth.
+> **pre-v1.1.36**: See [Legacy Installation](#legacy-installation-pre-v1136-only) for external plugin setup.
 
 ```bash
 # First-time setup


### PR DESCRIPTION
## Summary

- Replaces ambiguous "use Anthropic OAuth" text in the Basic Authentication section with a direct `[Legacy Installation](#legacy-installation-pre-v1136-only)` link, giving pre-v1.1.36 users a clear path to the external plugin setup instructions.

## Review Feedback Addressed

- **Source**: PR #5343 review by Gemini (medium severity)
- **Finding**: The instruction "use Anthropic OAuth" under the "Basic Authentication" heading was ambiguous and could confuse users. A direct link to the relevant section provides a clearer path.

Closes #5398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for older OpenCode versions to reference the dedicated legacy installation section with a direct link for clearer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->