### PR TITLE
t5399: Remove jq -r flag for clearer null output in cloudron docs

### DIFF
--- a/.agents/services/hosting/cloudron.md
+++ b/.agents/services/hosting/cloudron.md
@@ -251,7 +251,7 @@ last reboot | head -5
 journalctl -b -1 --no-pager | grep -i -E 'cloudron.*update|cloudron-updater'
 
 # Get the current Cloudron version
-jq -r '.version' /home/yellowtent/box/package.json
+jq '.version' /home/yellowtent/box/package.json
 ```
 
 **Step 2: Assess system resources** — Rule out OOM, disk full, or CPU saturation.
@@ -388,7 +388,7 @@ docker exec -it <container_name> /bin/bash
 | App-specific logs | `docker logs <container_name>` | Individual app startup/runtime errors |
 | System journal (previous boot) | `journalctl -b -1 --no-pager -n 50 -p warning` | What happened before the reboot |
 | Cloudron troubleshoot | `cloudron-support --troubleshoot` | Built-in diagnostic checks (DNS, certs, services, migrations) |
-| Cloudron version | `jq -r '.version' /home/yellowtent/box/package.json` | Current Cloudron version |
+| Cloudron version | `jq '.version' /home/yellowtent/box/package.json` | Current Cloudron version |
 
 ### **Database Troubleshooting (MySQL)**
 


### PR DESCRIPTION
## Summary

- Remove `-r` (raw-output) flag from two `jq` version-query commands in `.agents/services/hosting/cloudron.md`
- Without `-r`, a missing `.version` key outputs the string `null` instead of empty output, giving users unambiguous feedback during interactive troubleshooting

## Review Feedback Addressed

Both findings from [PR #5338](https://github.com/marcusquinn/aidevops/pull/5338) (gemini-code-assist):
- **Line 254**: `jq -r '.version'` → `jq '.version'` (code block)
- **Line 391**: `jq -r '.version'` → `jq '.version'` (reference table)

Closes #5399