### PR TITLE
t5385: fix jq // empty and remove 2>/dev/null on repos.json reads in profile-readme-helper.sh

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -32,13 +32,13 @@ _resolve_profile_repo() {
 		local profile_path
 		profile_path=$(jq -r '
 			if .initialized_repos then
-				.initialized_repos[] | select(.priority == "profile") | .path
+				.initialized_repos[] | select(.priority == "profile") | .path // empty
 			else
-				to_entries[] | select(.value.priority == "profile") | .value.path
+				to_entries[] | select(.value.priority == "profile") | .value.path // empty
 			end
-		' "$repos_json" 2>/dev/null | head -1)
+		' "$repos_json" | head -1)
 
-		if [[ -n "$profile_path" && "$profile_path" != "null" && -d "$profile_path" ]]; then
+		if [[ -n "$profile_path" && -d "$profile_path" ]]; then
 			echo "$profile_path"
 			return 0
 		fi
@@ -1235,12 +1235,12 @@ cmd_init() {
 		local existing_profile
 		existing_profile=$(jq -r '
 			if .initialized_repos then
-				.initialized_repos[] | select(.priority == "profile") | .path
+				.initialized_repos[] | select(.priority == "profile") | .path // empty
 			else
-				to_entries[] | select(.value.priority == "profile") | .value.path
+				to_entries[] | select(.value.priority == "profile") | .value.path // empty
 			end
-		' "$repos_json" 2>/dev/null | head -1)
-		if [[ -n "$existing_profile" && "$existing_profile" != "null" ]]; then
+		' "$repos_json" | head -1)
+		if [[ -n "$existing_profile" ]]; then
 			if [[ -d "$existing_profile" ]] &&
 				[[ -f "${existing_profile}/README.md" ]] &&
 				grep -q '<!-- STATS-START -->' "${existing_profile}/README.md" 2>/dev/null; then


### PR DESCRIPTION
## Summary

Addresses Gemini code review feedback from PR #5372 on `.agents/scripts/profile-readme-helper.sh`.

**Changes** (1 file, 8 lines changed):

- Use `// empty` operator in `jq` filters so a `null` `.path` value produces an empty string rather than the literal string `"null"`. This makes the subsequent `[[ -n "$var" ]]` check sufficient, removing the redundant `&& "$var" != "null"` guard in both `_resolve_profile_repo` and `cmd_init`.
- Remove `2>/dev/null` suppression on the `jq` calls that read `repos.json`. Suppressing stderr on config-file reads hides syntax errors and makes debugging difficult; errors should be visible.

Both occurrences of the pattern were fixed for consistency.

Closes #5385

## Verification

- ShellCheck: zero violations
- Logic unchanged: `// empty` in jq produces no output (not `"null"`) when the field is absent or null, so `head -1` returns empty string — identical runtime behaviour to the previous `2>/dev/null` + `!= "null"` combination, but cleaner and with visible error reporting.