### PR TITLE
t5398: fix ambiguous pre-v1.1.36 auth instruction with direct section link

### DIFF
--- a/.agents/tools/opencode/opencode-anthropic-auth.md
+++ b/.agents/tools/opencode/opencode-anthropic-auth.md
@@ -338,7 +338,7 @@ OAuth tokens are stored securely by OpenCode in:
 
 > **v1.2.30+**: Use `opencode auth login` and select **Anthropic Pool**.
 > **v1.1.36–v1.2.29**: Use built-in **Anthropic → Claude Pro/Max**.
-> **pre-v1.1.36**: Install `opencode-anthropic-auth` first, then use Anthropic OAuth.
+> **pre-v1.1.36**: See [Legacy Installation](#legacy-installation-pre-v1136-only) for external plugin instructions.
 
 ```bash
 # First-time setup


### PR DESCRIPTION
## Summary

- Replaces the vague `use Anthropic OAuth` instruction on line 341 of `.agents/tools/opencode/opencode-anthropic-auth.md` with a direct link to the `### Legacy Installation (pre-v1.1.36 only)` section
- Eliminates the confusion of an OAuth-flavoured instruction appearing under the `### Basic Authentication` heading
- Implements the Gemini reviewer suggestion from PR #5343 (adjusted to use the correct anchor `#legacy-installation-pre-v1136-only` rather than the non-existent `#oauth` anchor)

## Change

```diff
-  > **pre-v1.1.36**: Install `opencode-anthropic-auth` first, then use Anthropic OAuth.
+  > **pre-v1.1.36**: See [Legacy Installation](#legacy-installation-pre-v1136-only) for external plugin instructions.
```

**Blast radius**: 1 file, 1 line.

Closes #5398