### PR TITLE
fix: use // empty in jq to eliminate null string check (GH#5385)

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -32,13 +32,13 @@ _resolve_profile_repo() {
 		local profile_path
 		profile_path=$(jq -r '
 			if .initialized_repos then
-				.initialized_repos[] | select(.priority == "profile") | .path
+				.initialized_repos[] | select(.priority == "profile") | .path // empty
 			else
-				to_entries[] | select(.value.priority == "profile") | .value.path
+				to_entries[] | select(.value.priority == "profile") | .value.path // empty
 			end
-		' "$repos_json" 2>/dev/null | head -1)
+		' "$repos_json" | head -1)
 
-		if [[ -n "$profile_path" && "$profile_path" != "null" && -d "$profile_path" ]]; then
+		if [[ -n "$profile_path" && -d "$profile_path" ]]; then
 			echo "$profile_path"
 			return 0
 		fi


### PR DESCRIPTION
Closes #5385

## Change

Single finding from PR #5372 Gemini review, `profile-readme-helper.sh:41`.

- Add `// empty` to both `.path` selectors in the `jq` expression so a `null` value produces no output instead of the string `"null"`
- Remove the now-redundant `&& "$profile_path" != "null"` guard from the conditional
- Remove `2>/dev/null` stderr suppression so `jq` syntax errors in `repos.json` surface during debugging

## Blast radius

1 file, 4 lines changed.