### PR TITLE
feat: add ClaudeBar to setup and upstream watch

### DIFF
--- a/.agents/configs/upstream-watch.json
+++ b/.agents/configs/upstream-watch.json
@@ -28,6 +28,13 @@
       "relevance": "22 higher-level workflow skills complementing the official per-command skills. New skills add orchestration patterns.",
       "default_branch": "main",
       "added_at": "2026-03-21"
+    },
+    {
+      "slug": "tddworks/ClaudeBar",
+      "description": "macOS menu bar app monitoring AI coding assistant usage quotas (Claude, Codex, Gemini, Copilot, Kimi, Kiro, Amp)",
+      "relevance": "Visual quota monitoring complementing our headless model-accounts-pool rotation. New provider support and multi-account features (GH#86) directly relevant. Installed via brew cask in setup.sh.",
+      "default_branch": "main",
+      "added_at": "2026-03-21"
     }
   ],
   "non_github_upstreams": [

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1041,6 +1041,52 @@ setup_minisim() {
 	return 0
 }
 
+setup_claudebar() {
+	# Only available on macOS (native Swift menu bar app)
+	if [[ "$(uname)" != "Darwin" ]]; then
+		return 0
+	fi
+
+	print_info "Setting up ClaudeBar (AI quota monitor)..."
+
+	# Check if ClaudeBar is already installed
+	if [[ -d "/Applications/ClaudeBar.app" ]]; then
+		print_success "ClaudeBar already installed"
+		return 0
+	fi
+
+	# Check if Homebrew is available (required for cask install)
+	if ! command -v brew >/dev/null 2>&1; then
+		print_warning "Homebrew not found - cannot install ClaudeBar automatically"
+		echo "  Download manually: https://github.com/tddworks/ClaudeBar/releases/latest"
+		return 0
+	fi
+
+	print_info "ClaudeBar monitors AI coding assistant usage quotas in your menu bar"
+	echo "  Supports: Claude, Codex, Gemini, Copilot, Antigravity, Kimi, Kiro, Amp"
+	echo "  Features: real-time quota tracking, status notifications, multiple themes"
+	echo "  Requires: macOS 15+, CLI tools for providers you want to monitor"
+	echo ""
+
+	local install_claudebar
+	read -r -p "Install ClaudeBar? [Y/n]: " install_claudebar
+
+	if [[ "$install_claudebar" =~ ^[Yy]?$ ]]; then
+		if run_with_spinner "Installing ClaudeBar" brew install --cask claudebar; then
+			print_success "ClaudeBar installed"
+			print_info "Launch from Applications or Spotlight to start monitoring quotas"
+		else
+			print_warning "Failed to install ClaudeBar via Homebrew"
+			echo "  Download manually: https://github.com/tddworks/ClaudeBar/releases/latest"
+		fi
+	else
+		print_info "Skipped ClaudeBar installation"
+		print_info "Install later: brew install --cask claudebar"
+	fi
+
+	return 0
+}
+
 setup_ssh_key() {
 	print_info "Checking SSH key setup..."
 

--- a/setup.sh
+++ b/setup.sh
@@ -765,6 +765,7 @@ main() {
 		confirm_step "Check Python version (recommend upgrade if outdated)" && check_python_upgrade_available
 		confirm_step "Setup recommended tools (Tabby, Zed, etc.)" && setup_recommended_tools
 		confirm_step "Setup MiniSim (iOS/Android emulator launcher)" && setup_minisim
+		confirm_step "Setup ClaudeBar (AI quota monitor in menu bar)" && setup_claudebar
 		confirm_step "Setup Git CLIs (gh, glab, tea)" && setup_git_clis
 		confirm_step "Setup file discovery tools (fd, ripgrep, ripgrep-all)" && setup_file_discovery_tools
 		confirm_step "Setup rtk (token-optimized CLI output, 60-90% savings)" && setup_rtk


### PR DESCRIPTION
## Summary

Integrates [ClaudeBar](https://github.com/tddworks/ClaudeBar) into the aidevops framework — a macOS menu bar app that monitors AI coding assistant usage quotas.

## Changes

- **`setup-modules/tool-install.sh`** — new `setup_claudebar()` function: checks for `/Applications/ClaudeBar.app`, offers `brew install --cask claudebar` on macOS
- **`setup.sh`** — adds `confirm_step` call after MiniSim (both are macOS-only menu bar apps)
- **`.agents/configs/upstream-watch.json`** — adds `tddworks/ClaudeBar` for release tracking

## Why

ClaudeBar monitors quotas for Claude, Codex, Gemini, Copilot, Antigravity, Kimi, Kiro, and Amp in the menu bar. This complements our headless `model-accounts-pool` rotation with visual monitoring — users can see at a glance which providers are approaching limits.

Also submitted a multi-account domain model PR upstream ([tddworks/ClaudeBar#160](https://github.com/tddworks/ClaudeBar/pull/160)) to address their [#86](https://github.com/tddworks/ClaudeBar/issues/86), drawing on our account pool rotation experience.

## Verification

- ShellCheck: 0 violations on `tool-install.sh`
- JSON: valid `upstream-watch.json`
- Blast radius: 3 files, 54 lines added