### PR TITLE
t5424: store claudebar release URL in variable for maintainability

### DIFF
--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1042,6 +1042,7 @@ setup_minisim() {
 }
 
 setup_claudebar() {
+	local claudebar_release_url="https://github.com/tddworks/ClaudeBar/releases/latest"
 	# Only available on macOS (native Swift menu bar app)
 	if [[ "$(uname)" != "Darwin" ]]; then
 		return 0
@@ -1058,7 +1059,7 @@ setup_claudebar() {
 	# Check if Homebrew is available (required for cask install)
 	if ! command -v brew >/dev/null 2>&1; then
 		print_warning "Homebrew not found - cannot install ClaudeBar automatically"
-		echo "  Download manually: https://github.com/tddworks/ClaudeBar/releases/latest"
+		echo "  Download manually: $claudebar_release_url"
 		return 0
 	fi
 
@@ -1077,7 +1078,7 @@ setup_claudebar() {
 			print_info "Launch from Applications or Spotlight to start monitoring quotas"
 		else
 			print_warning "Failed to install ClaudeBar via Homebrew"
-			echo "  Download manually: https://github.com/tddworks/ClaudeBar/releases/latest"
+			echo "  Download manually: $claudebar_release_url"
 		fi
 	else
 		print_info "Skipped ClaudeBar installation"


### PR DESCRIPTION
## Summary

- Extracts the hardcoded `https://github.com/tddworks/ClaudeBar/releases/latest` URL into a `local claudebar_release_url` variable at the top of `setup_claudebar()` in `setup-modules/tool-install.sh`
- Both downstream `echo` usages now reference `$claudebar_release_url` — single source of truth
- ShellCheck: zero violations

Closes #5424

## Review feedback addressed

Gemini Code Assist finding on PR #5420 (`setup-modules/tool-install.sh:1088`): duplicate URL string should be stored in a variable to avoid update drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code maintenance updates to improve script maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->