### PR TITLE
fix: remove escaped $PORT in app-store-connect.md localdev example

### DIFF
--- a/.agents/tools/mobile/app-store-connect.md
+++ b/.agents/tools/mobile/app-store-connect.md
@@ -207,7 +207,7 @@ The `asc` CLI includes an embedded web server with three web apps:
 localdev-helper.sh add asc
 
 # Run the asc web server via localdev
-localdev-helper.sh run --app asc -- asc tui --port \$PORT
+localdev-helper.sh run --app asc -- asc tui --port $PORT
 # → https://asc.local/command-center (dashboard)
 # → https://asc.local/console (CLI reference)
 # → https://asc.local/editor (screenshot studio)


### PR DESCRIPTION
## Summary

- Removes the backslash escape from `\$PORT` on line 210 of `.agents/tools/mobile/app-store-connect.md`
- The escaped form caused the shell to treat `$PORT` as a literal string rather than substituting the environment variable, which would cause `localdev-helper.sh` to pass the literal text `$PORT` as the port argument instead of the actual port number
- Consistent with the same command pattern in `services/hosting/local-hosting.md`

Closes #5430

**Source**: Gemini review finding on PR #5407 (discussion_r2969932979)