### PR TITLE
t5425: fix(cloudron): use jq fallback operator for version lookup

### DIFF
--- a/.agents/services/hosting/cloudron.md
+++ b/.agents/services/hosting/cloudron.md
@@ -251,7 +251,7 @@ last reboot | head -5
 journalctl -b -1 --no-pager | grep -i -E 'cloudron.*update|cloudron-updater'
 
 # Get the current Cloudron version
-jq '.version' /home/yellowtent/box/package.json
+jq -r '.version // "not found"' /home/yellowtent/box/package.json
 ```
 
 **Step 2: Assess system resources** — Rule out OOM, disk full, or CPU saturation.
@@ -388,7 +388,7 @@ docker exec -it <container_name> /bin/bash
 | App-specific logs | `docker logs <container_name>` | Individual app startup/runtime errors |
 | System journal (previous boot) | `journalctl -b -1 --no-pager -n 50 -p warning` | What happened before the reboot |
 | Cloudron troubleshoot | `cloudron-support --troubleshoot` | Built-in diagnostic checks (DNS, certs, services, migrations) |
-| Cloudron version | `jq '.version' /home/yellowtent/box/package.json` | Current Cloudron version |
+| Cloudron version | `jq -r '.version // "not found"' /home/yellowtent/box/package.json` | Current Cloudron version |
 
 ### **Database Troubleshooting (MySQL)**
 


### PR DESCRIPTION
## Summary

- Apply 2 medium-severity review findings from PR #5413 on `.agents/services/hosting/cloudron.md`
- Replace `jq '.version'` with `jq -r '.version // "not found"'` at lines 254 and 391
- The `//` fallback operator provides a clear human-readable message instead of `null` when the version key is absent; `-r` outputs raw strings (no JSON quotes)

Closes #5425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved Cloudron version lookup documentation with clearer output formatting and added fallback handling for missing version information during troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->