### PR TITLE
t5427: profile-readme-helper — simplify jq profile lookup with // operator

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -31,11 +31,9 @@ _resolve_profile_repo() {
 	if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
 		local profile_path
 		profile_path=$(jq -r '
-			if .initialized_repos then
-				.initialized_repos[] | select(.priority == "profile") | .path // empty
-			else
-				to_entries[] | select(.value.priority == "profile") | .value.path // empty
-			end
+			(.initialized_repos // (to_entries | map(.value)))[]
+			| select(.priority == "profile")
+			| .path // empty
 		' "$repos_json" | head -1)
 
 		if [[ -n "$profile_path" && -d "$profile_path" ]]; then


### PR DESCRIPTION
## Summary

- Replaces the `if/else` branch in `_resolve_profile_repo` with a single unified `jq` expression using the alternative operator `//`
- Handles both `.initialized_repos` array format and object-of-objects format in one pipeline, eliminating repetition
- Verified against all three input shapes: array, object-of-objects, and empty input

## Changes

**`.agents/scripts/profile-readme-helper.sh:33-39`** — before:
```jq
if .initialized_repos then
    .initialized_repos[] | select(.priority == "profile") | .path // empty
else
    to_entries[] | select(.value.priority == "profile") | .value.path // empty
end
```

After:
```jq
(.initialized_repos // (to_entries | map(.value)))[]
| select(.priority == "profile")
| .path // empty
```

## Verification

- `shellcheck` passes with zero violations
- `jq` expression tested against all three input shapes (array, object-of-objects, empty) — all produce correct output

Closes #5427