### PR TITLE
t5429: collapse template literal + concatenation to single literals in oauth-pool.mjs

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -608,9 +608,7 @@ function startOAuthCallbackServer() {
     cleanup();
     if (err.code === "EADDRINUSE") {
       console.error(
-        `[aidevops] OAuth pool: port ${OAUTH_CALLBACK_PORT} in use — ` +
-          `OpenCode's built-in auth may be running. The user will need to ` +
-          `copy the code from the browser URL bar manually.`,
+        `[aidevops] OAuth pool: port ${OAUTH_CALLBACK_PORT} in use — OpenCode's built-in auth may be running. The user will need to copy the code from the browser URL bar manually.`,
       );
       resolveReady(false);
       return;
@@ -718,10 +716,7 @@ function upsertAccount(provider, account) {
     if (namedAccounts.length > 0) {
       const emails = namedAccounts.map((a) => a.email).join(", ");
       console.error(
-        `[aidevops] OAuth pool: REFUSED to save account with unknown email. ` +
-          `${namedAccounts.length} named account(s) exist: ${emails}. ` +
-          `Re-auth via "Add Account to Pool" and enter the email when prompted, ` +
-          `or use /model-accounts-pool to manage accounts.`,
+        `[aidevops] OAuth pool: REFUSED to save account with unknown email. ${namedAccounts.length} named account(s) exist: ${emails}. Re-auth via "Add Account to Pool" and enter the email when prompted, or use /model-accounts-pool to manage accounts.`,
       );
       return false;
     }


### PR DESCRIPTION
## Summary

- Collapses two `console.error` calls that used `+` concatenation between template literal fragments into single template literals (no `+`)
- The `createPoolTool` description was already correctly using `[...].join(" ")` — no change needed there
- No behaviour change; string values are identical

## Changes

- `.agents/plugins/opencode-aidevops/oauth-pool.mjs`: lines 611 and 719 — remove `+` concatenation, use single template literal per message

## Context

PR #5402 converted multi-line `+` concatenations to template literals. Gemini then flagged the resulting long lines. The fix in #5402 broke them back into segments with `+`. CodeRabbit then flagged that `+` between template literal fragments is the wrong pattern — the correct form is a single template literal.

This PR applies the correct fix: single template literals, no `+`, no artificial line breaks.

Closes #5429