### PR TITLE
t5428: fix(mcp-setup): address PR #5408 review feedback — error handling and consistency

### DIFF
--- a/setup-modules/mcp-setup.sh
+++ b/setup-modules/mcp-setup.sh
@@ -502,6 +502,7 @@ setup_opencode_plugins() {
 				print_info "  Filed: https://github.com/ephraimduncan/opencode-cursor/issues/15"
 			else
 				rm -f "$tmp_cursor"
+				print_warning "Failed to remove opencode-cursor-oauth plugin from opencode.json (file: $opencode_config)"
 			fi
 		fi
 	else
@@ -562,7 +563,6 @@ setup_opencode_plugins() {
 			print_info ""
 			print_info "For Cursor Pro accounts:"
 			print_info "  Run: opencode auth login --provider cursor"
-			print_info "  Or from shell: oauth-pool-helper.sh add cursor"
 			print_info ""
 			print_info "  Health check: /models-pool-check"
 			print_info "  Manage accounts: /model-accounts-pool list|status|remove"


### PR DESCRIPTION
## Summary

- Add `print_warning` when `jq` fails to remove the `opencode-cursor-oauth` plugin from `opencode.json` — previously a silent failure, now consistent with the diagnostic pattern used for the plugin registration failure path
- Remove `oauth-pool-helper.sh add cursor` alternative from user-facing guidance; use only `opencode auth login --provider cursor` for consistency (the two commands were presented as equivalent alternatives, causing confusion)

## Findings addressed

Both findings from Gemini review on PR #5408 (`setup-modules/mcp-setup.sh`):

1. **MEDIUM** (line 515 in PR diff): Missing warning on `jq` write failure for cursor provider stub — applied to the equivalent current code path (cursor plugin removal `else` branch)
2. **MEDIUM** (line 576 in PR diff): Inconsistency between `oauth-pool-helper.sh add cursor` and `opencode auth login --provider cursor` — removed the former, keeping only the canonical command

## Verification

- `shellcheck setup-modules/mcp-setup.sh` — zero violations

Closes #5428