### PR TITLE
t1552: Auto-sync initialized projects on aidevops update

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -106,7 +106,10 @@ check_file() {
 ensure_trailing_newline() {
 	local file="$1"
 	local last
-	last="$(tail -c 1 "$file"; printf x)"
+	last="$(
+		tail -c 1 "$file"
+		printf x
+	)"
 	[[ -s "$file" ]] && [[ "$last" != $'\n'x ]] && printf '\n' >>"$file"
 }
 
@@ -662,6 +665,14 @@ cmd_status() {
 
 # Update/upgrade command
 cmd_update() {
+	local skip_project_sync=false
+	local arg
+	for arg in "$@"; do
+		case "$arg" in
+		--skip-project-sync) skip_project_sync=true ;;
+		esac
+	done
+
 	print_header "Updating AI DevOps Framework"
 	echo ""
 
@@ -811,57 +822,87 @@ cmd_update() {
 		fi
 	fi
 
-	# Check registered repos for updates
+	# Auto-sync registered projects (t1552)
+	# Updates .aidevops.json version stamp and repos.json entry for each
+	# initialized project whose version is older than the current framework.
+	# Skip with --skip-project-sync if needed.
 	echo ""
-	print_header "Checking Initialized Projects"
+	print_header "Syncing Initialized Projects"
 
-	local repos_needing_upgrade=()
-	local current_ver
-	current_ver=$(get_version)
-
-	while IFS= read -r repo_path; do
-		[[ -z "$repo_path" ]] && continue
-
-		if [[ -d "$repo_path" ]]; then
-			if check_repo_needs_upgrade "$repo_path"; then
-				repos_needing_upgrade+=("$repo_path")
-			fi
-		fi
-	done < <(get_registered_repos)
-
-	if [[ ${#repos_needing_upgrade[@]} -eq 0 ]]; then
-		print_success "All registered projects are up to date"
+	if [[ "$skip_project_sync" == "true" ]]; then
+		print_info "Project sync skipped (--skip-project-sync)"
 	else
-		echo ""
-		print_warning "${#repos_needing_upgrade[@]} project(s) may need updates:"
-		for repo in "${repos_needing_upgrade[@]}"; do
-			local repo_name
-			repo_name=$(basename "$repo")
-			echo "  - $repo_name ($repo)"
-		done
-		echo ""
-		read -r -p "Update .aidevops.json version in these projects? [y/N] " response
-		if [[ "$response" =~ ^[Yy]$ ]]; then
+		local repos_needing_upgrade=()
+		local current_ver
+		current_ver=$(get_version)
+
+		while IFS= read -r repo_path; do
+			[[ -z "$repo_path" ]] && continue
+
+			if [[ -d "$repo_path" ]]; then
+				if check_repo_needs_upgrade "$repo_path"; then
+					repos_needing_upgrade+=("$repo_path")
+				fi
+			fi
+		done < <(get_registered_repos)
+
+		if [[ ${#repos_needing_upgrade[@]} -eq 0 ]]; then
+			print_success "All registered projects are up to date"
+		else
+			local synced=0
+			local skipped=0
+			local failed=0
 			for repo in "${repos_needing_upgrade[@]}"; do
-				if [[ -f "$repo/.aidevops.json" ]]; then
-					print_info "Updating $repo..."
-					# Update version in .aidevops.json
-					if command -v jq &>/dev/null; then
-						local temp_file="${repo}/.aidevops.json.tmp"
-						jq --arg version "$current_ver" '.version = $version' "$repo/.aidevops.json" >"$temp_file" &&
-							mv "$temp_file" "$repo/.aidevops.json"
+				if [[ ! -f "$repo/.aidevops.json" ]]; then
+					# Not initialized with aidevops — skip silently
+					skipped=$((skipped + 1))
+					continue
+				fi
+
+				# Try jq first (preserves formatting), fall back to sed
+				# (some .aidevops.json files have minor structural issues
+				# that jq rejects but sed handles fine for version updates)
+				local did_sync=false
+				if command -v jq &>/dev/null; then
+					local temp_file="${repo}/.aidevops.json.tmp"
+					if jq --arg version "$current_ver" '.version = $version' "$repo/.aidevops.json" >"$temp_file" 2>/dev/null &&
+						[[ -s "$temp_file" ]]; then
+						mv "$temp_file" "$repo/.aidevops.json"
 
 						# Update repos.json entry
 						local features
 						features=$(jq -r '[.features | to_entries[] | select(.value == true) | .key] | join(",")' "$repo/.aidevops.json" 2>/dev/null || echo "")
 						register_repo "$repo" "$current_ver" "$features"
 
-						print_success "Updated $(basename "$repo")"
+						did_sync=true
 					else
-						print_warning "jq not installed - manual update needed for $repo"
+						rm -f "$temp_file"
 					fi
 				fi
+
+				# Fallback: sed-based version update (handles malformed JSON)
+				if [[ "$did_sync" != "true" ]]; then
+					if sed -i '' "s/\"version\": *\"[^\"]*\"/\"version\": \"$current_ver\"/" "$repo/.aidevops.json" 2>/dev/null; then
+						did_sync=true
+					fi
+				fi
+
+				if [[ "$did_sync" == "true" ]]; then
+					synced=$((synced + 1))
+				else
+					failed=$((failed + 1))
+				fi
 			done
+
+			if [[ $synced -gt 0 ]]; then
+				print_success "Synced $synced project(s) to v$current_ver"
+			fi
+			if [[ $skipped -gt 0 ]]; then
+				print_info "Skipped $skipped uninitialized project(s) (run 'aidevops init' in each to enable)"
+			fi
+			if [[ $failed -gt 0 ]]; then
+				print_warning "$failed project(s) failed to sync (jq missing or write error)"
+			fi
 		fi
 	fi
 
@@ -3739,7 +3780,8 @@ main() {
 		cmd_status
 		;;
 	update | upgrade | u)
-		cmd_update
+		shift
+		cmd_update "$@"
 		;;
 	auto-update | autoupdate)
 		shift


### PR DESCRIPTION
## Summary

- Replace the interactive `[y/N]` prompt in `aidevops update` with automatic project sync
- After the framework updates, all registered projects with `.aidevops.json` get their version stamp updated automatically
- Add `--skip-project-sync` flag to opt out

## What changed

**`aidevops.sh`** — `cmd_update()`:
- Added flag parsing for `--skip-project-sync`
- Replaced interactive prompt with automatic sync loop
- Added `sed` fallback for `.aidevops.json` files with minor structural issues that `jq` rejects
- Separated "uninitialized" (no `.aidevops.json` — skipped silently) from "failed" (write error — warned)
- Updated dispatch case to pass `$@` to `cmd_update`

## Before/After

**Before:**
```
[WARN] 8 project(s) may need updates:
  - aidevops (/Users/marcusquinn/Git/aidevops)
  - netbird-app (...)
  ...
Update .aidevops.json version in these projects? [y/N]
```

**After:**
```
Syncing Initialized Projects
[OK] Synced 4 project(s) to v3.1.46
[INFO] Skipped 1 uninitialized project(s) (run 'aidevops init' in each to enable)
```

## How it was tested

1. Downgraded a project's version to 3.1.40, ran `aidevops update` — synced back to 3.1.46
2. Tested `--skip-project-sync` flag — correctly skips with info message
3. Verified sed fallback handles malformed JSON (some `.aidevops.json` files have structural issues)
4. ShellCheck: zero violations

Closes #3168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skip-project-sync` flag for the update command to bypass project synchronization.

* **Bug Fixes**
  * Improved version-stamp update mechanism with automatic fallback for handling malformed JSON files.

* **Changes**
  * Modified project initialization sync from interactive prompts to non-interactive auto-sync workflow.
  * Added sync outcome tracking with summary counters and status messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->