### PR TITLE
t1551: Fix Cursor proxy port stability across sessions

### DIFF
--- a/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
@@ -23,6 +23,21 @@ import { homedir } from "os";
 import { getAccounts, ensureValidToken, patchAccount } from "./oauth-pool.mjs";
 
 // ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed port for the Cursor proxy. Using a deterministic port ensures the
+ * URL in opencode.json survives across sessions — the proxy always starts
+ * on the same port, so OpenCode can connect immediately without waiting
+ * for the plugin to update the config.
+ *
+ * Override with CURSOR_PROXY_PORT env var if port 32123 conflicts.
+ * (Nomadcxx/opencode-cursor uses 32124, so we use 32123 to avoid collision.)
+ */
+const CURSOR_PROXY_DEFAULT_PORT = parseInt(process.env.CURSOR_PROXY_PORT || "32123", 10);
+
+// ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
 

--- a/.agents/plugins/opencode-aidevops/cursor/proxy.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy.js
@@ -188,7 +188,7 @@ export async function startProxy(getAccessToken, models = []) {
     if (proxyServer && proxyPort)
         return proxyPort;
     proxyServer = Bun.serve({
-        port: 0,
+        port: parseInt(process.env.CURSOR_PROXY_PORT || "32123", 10),
         idleTimeout: 255, // max — Cursor responses can take 30s+
         async fetch(req) {
             const url = new URL(req.url);


### PR DESCRIPTION
## Summary

- Cursor proxy was unreachable on new sessions because it bound to a random port each time
- Root cause: OpenCode reads `opencode.json` at startup before the plugin can update the port
- Fix: use fixed port 32123 (overridable via `CURSOR_PROXY_PORT` env var)

## What changed

- **`cursor/proxy.js`** — Changed `port: 0` to `port: parseInt(process.env.CURSOR_PROXY_PORT || "32123", 10)`
- **`cursor-proxy.mjs`** — Added `CURSOR_PROXY_DEFAULT_PORT` constant with documentation

## Tested

- Proxy starts on port 32123 consistently
- `opencode.json` has stable URL `http://127.0.0.1:32123/v1`
- `GET /v1/models` returns 12 models on the fixed port

Closes #5446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Cursor proxy port configuration to use a deterministic port (default: 32123) with environment variable override support for flexible deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->