### PR TITLE
t1551: Fix cursor proxy dependency resolution in deployed plugin

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -186,6 +186,16 @@ deploy_aidevops_agents() {
 
 		print_info "Deployed $agent_count agent files and $script_count scripts"
 
+		# Symlink OpenCode's node_modules into the plugin directory (t1551)
+		# The cursor proxy vendored files import @bufbuild/protobuf and zod,
+		# which are installed in OpenCode's config node_modules but not
+		# resolvable from the deployed plugin path (~/.aidevops/agents/).
+		local oc_node_modules="$HOME/.config/opencode/node_modules"
+		local plugin_dir="$target_dir/plugins/opencode-aidevops"
+		if [[ -d "$oc_node_modules" && -d "$plugin_dir" ]]; then
+			ln -sf "$oc_node_modules" "$plugin_dir/node_modules" 2>/dev/null || true
+		fi
+
 		# Copy VERSION file from repo root to deployed agents
 		if [[ -f "$repo_dir/VERSION" ]]; then
 			if cp "$repo_dir/VERSION" "$target_dir/VERSION"; then


### PR DESCRIPTION
## Summary

- Cursor proxy failed to start inside OpenCode with: `Cannot find module '@bufbuild/protobuf'`
- Root cause: vendored proxy files import `@bufbuild/protobuf` and `zod`, which exist in OpenCode's `~/.config/opencode/node_modules/` but aren't resolvable from the deployed plugin path `~/.aidevops/agents/plugins/`
- Fix: symlink OpenCode's `node_modules` into the plugin directory during `setup.sh` deployment

## What changed

**`setup-modules/agent-deploy.sh`** — Added symlink creation after agent deployment:
```bash
ln -sf ~/.config/opencode/node_modules ~/.aidevops/agents/plugins/opencode-aidevops/node_modules
```

Closes #5446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized node_modules deployment process for plugins to reduce installation footprint and improve deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->