### PR TITLE
t1551: Fix Cursor proxy tool calling hang (GH#5454)

### DIFF
--- a/.agents/plugins/opencode-aidevops/cursor/proxy.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy.js
@@ -990,7 +990,13 @@ function handleToolResultResume(active, toolResults, modelId, bridgeKey) {
 async function handleNonStreamingResponse(payload, accessToken, modelId, bridgeKey) {
     const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
     const created = Math.floor(Date.now() / 1000);
-    const fullText = await collectFullResponse(payload, accessToken, bridgeKey);
+    const result = await collectFullResponse(payload, accessToken, bridgeKey);
+    const message = { role: "assistant", content: result.text || "" };
+    let finishReason = "stop";
+    if (result.toolCalls && result.toolCalls.length > 0) {
+        message.tool_calls = result.toolCalls;
+        finishReason = "tool_calls";
+    }
     return new Response(JSON.stringify({
         id: completionId,
         object: "chat.completion",
@@ -999,8 +1005,8 @@ async function handleNonStreamingResponse(payload, accessToken, modelId, bridgeK
         choices: [
             {
                 index: 0,
-                message: { role: "assistant", content: fullText },
-                finish_reason: "stop",
+                message,
+                finish_reason: finishReason,
             },
         ],
         usage: {
@@ -1013,6 +1019,7 @@ async function handleNonStreamingResponse(payload, accessToken, modelId, bridgeK
 async function collectFullResponse(payload, accessToken, bridgeKey) {
     const { promise, resolve } = Promise.withResolvers();
     let fullText = "";
+    let resolved = false;
     const { bridge, heartbeatTimer } = startBridge(accessToken, payload.requestBytes);
     const state = {
         toolCallIndex: 0,
@@ -1027,7 +1034,33 @@ async function collectFullResponse(payload, accessToken, bridgeKey) {
                     return;
                 const { content } = tagFilter.process(text);
                 fullText += content;
-            }, () => { }, (checkpointBytes) => {
+            }, (exec) => {
+                // Tool call received — resolve immediately with tool_calls
+                // and keep the bridge alive for tool result continuation.
+                if (resolved) return;
+                resolved = true;
+                state.pendingExecs.push(exec);
+                const flushed = tagFilter.flush();
+                fullText += flushed.content;
+                const toolCallIndex = state.toolCallIndex++;
+                const toolCalls = [{
+                    id: exec.toolCallId,
+                    type: "function",
+                    function: {
+                        name: exec.toolName,
+                        arguments: exec.decodedArgs,
+                    },
+                }];
+                // Keep the bridge alive for tool result continuation.
+                activeBridges.set(bridgeKey, {
+                    bridge,
+                    heartbeatTimer,
+                    blobStore: payload.blobStore,
+                    mcpTools: payload.mcpTools,
+                    pendingExecs: state.pendingExecs,
+                });
+                resolve({ text: fullText, toolCalls });
+            }, (checkpointBytes) => {
                 const stored = conversationStates.get(bridgeKey);
                 if (stored) {
                     stored.checkpoint = checkpointBytes;
@@ -1047,9 +1080,12 @@ async function collectFullResponse(payload, accessToken, bridgeKey) {
                 stored.blobStore.set(k, v);
             stored.lastAccessMs = Date.now();
         }
-        const flushed = tagFilter.flush();
-        fullText += flushed.content;
-        resolve(fullText);
+        if (!resolved) {
+            resolved = true;
+            const flushed = tagFilter.flush();
+            fullText += flushed.content;
+            resolve({ text: fullText, toolCalls: null });
+        }
     });
     return promise;
 }


### PR DESCRIPTION
## Summary

- Tool-calling requests to the Cursor proxy hung indefinitely
- Root cause: `collectFullResponse()` had `onMcpExec` set to `() => {}` (no-op) — when Cursor returned a tool call, the bridge stayed alive waiting for results that never came
- Fix: resolve immediately with `tool_calls` response and store bridge for continuation

## Before/After

**Before:** `POST /v1/chat/completions` with `tools` → hangs forever
**After:** Returns `finish_reason: "tool_calls"` with proper `tool_calls` array in ~3s

## Test result

```
finish_reason: tool_calls
tool_calls: [{ id: "tool_...", type: "function", function: { name: "calculator", arguments: "{\"expr\":\"2+2\"}" } }]
```

Closes #5454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of tool call execution and response handling to ensure tools are properly invoked and results returned accurately
  * Enhanced response consistency when the AI requests tool execution, with fixes to buffered content handling and response resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->