### PR TITLE
t1551: Disable tool_call for Cursor models to prevent hang

### DIFF
--- a/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
@@ -234,7 +234,7 @@ export function buildCursorProviderModels(models, port) {
     entries[model.id] = {
       name: model.name,
       attachment: false,
-      tool_call: true,
+      tool_call: false,
       temperature: true,
       reasoning: model.reasoning || false,
       modalities: { input: ["text"], output: ["text"] },

--- a/.agents/plugins/opencode-aidevops/cursor/proxy.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy.js
@@ -284,7 +284,15 @@ function handleChatCompletion(body, accessToken) {
     evictStaleConversations();
     // Build the request. When tool results are present but the bridge died,
     // we must still include the last user text so Cursor has context.
-    const mcpTools = buildMcpToolDefinitions(tools);
+    // Do NOT forward OpenAI tools to Cursor as MCP tools.
+    // OpenCode handles tool calling at its own layer — it sends tool definitions
+    // to the model, the model returns tool_calls in the response, and OpenCode
+    // executes them. If we forward tools to Cursor as MCP tools, Cursor tries
+    // to execute them via its own MCP protocol (mcpArgs exec messages), which
+    // requires a tool execution loop that OpenCode's ai-sdk provider doesn't
+    // support. Instead, let Cursor see the tools only in the system prompt
+    // (OpenCode includes tool descriptions there) and generate text responses.
+    const mcpTools = [];
     const effectiveUserText = userText || (toolResults.length > 0
         ? toolResults.map((r) => r.content).join("\n")
         : "");


### PR DESCRIPTION
## Summary

- Cursor models hang when OpenCode sends tool definitions — Cursor's native tool system activates and the proxy's rejection loop causes infinite retries
- Fix: set `tool_call: false` in model config and strip tools from proxy requests
- Cursor models now work as text/conversation models in OpenCode (not agentic coding)

## Root cause

Even after stripping MCP tools, Cursor's native tools (read, write, shell, grep) activate when the system prompt mentions tools. The proxy rejects these with error responses, but the model retries indefinitely.

## Trade-off

Cursor models are text-only through the proxy. Full tool support requires implementing a tool execution loop like Nomadcxx/opencode-cursor's ToolRouter chain — filed as future work.

Closes #5454