### PR TITLE
t1553: Fix stale conversation state and revert MCP tool forwarding

### DIFF
--- a/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
@@ -234,7 +234,7 @@ export function buildCursorProviderModels(models, port) {
     entries[model.id] = {
       name: model.name,
       attachment: false,
-      tool_call: true,
+      tool_call: false,
       temperature: true,
       reasoning: model.reasoning || false,
       modalities: { input: ["text"], output: ["text"] },

--- a/.agents/plugins/opencode-aidevops/cursor/proxy.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy.js
@@ -229,6 +229,11 @@ export async function startProxy(getAccessToken, models = []) {
     }));
     if (proxyServer && proxyPort)
         return proxyPort;
+    // Clear stale conversation states from previous sessions (t1553).
+    // Stale checkpoints reference blobs that Cursor's server has evicted,
+    // causing "Blob not found" errors on the first request.
+    conversationStates.clear();
+    activeBridges.clear();
     proxyServer = Bun.serve({
         port: parseInt(process.env.CURSOR_PROXY_PORT || "32123", 10),
         idleTimeout: 255, // max — Cursor responses can take 30s+
@@ -344,6 +349,8 @@ function handleChatCompletion(body, accessToken) {
     const { systemPrompt, userText, turns, toolResults } = parseMessages(body.messages);
     const modelId = body.model;
     const tools = body.tools ?? [];
+    // Debug logging (t1553) — log what OpenCode sends us
+    console.error(`[proxy] handleChatCompletion: model=${modelId}, tools=${tools.length}, toolNames=[${tools.map(t => t.function?.name || '?').join(',')}], userText=${(userText || '').slice(0, 80)}, toolResults=${toolResults.length}, messages=${body.messages?.length || 0}, stream=${body.stream}`);
     if (!userText && toolResults.length === 0) {
         return new Response(JSON.stringify({
             error: {
@@ -369,7 +376,15 @@ function handleChatCompletion(body, accessToken) {
     if (toolsExhausted) {
         console.error(`[proxy] Tool loop guard: conversation ${bridgeKey} exceeded ${MAX_TOOL_ROUNDS} tool rounds, disabling tools`);
     }
-    const mcpTools = (!toolsExhausted && tools.length > 0) ? buildMcpToolDefinitions(tools) : [];
+    // Do NOT forward OpenAI tools to Cursor as MCP tools (t1553 finding).
+    // Sending MCP tools via RequestContext causes Cursor's gRPC agent to
+    // enter a tool execution loop that hangs indefinitely — the server
+    // sends native tool exec messages (readArgs, shellArgs, etc.), we
+    // reject them, but the server never falls through to text generation.
+    // Tool calling for Cursor models requires a different approach (e.g.,
+    // Nomadcxx-style text prompt flattening with structured text parsing).
+    const mcpTools = [];
+    console.error(`[proxy] tools from OpenCode: ${tools.length}, mcpTools forwarded: ${mcpTools.length} (MCP forwarding disabled — causes gRPC hang)`);
     const effectiveUserText = userText || (toolResults.length > 0
         ? toolResults.map((r) => r.content).join("\n")
         : "");
@@ -715,6 +730,7 @@ function handleKvMessage(kvMsg, blobStore, sendFrame) {
 }
 /** Handle requestContextArgs — provide MCP tools to Cursor. */
 function handleRequestContext(execMsg, mcpTools, sendFrame) {
+    console.error(`[proxy] requestContextArgs: providing ${mcpTools.length} MCP tools to Cursor`);
     const requestContext = create(RequestContextSchema, {
         rules: [],
         repositoryInfo: [],
@@ -847,6 +863,7 @@ function rejectNativeCursorTool(execCase, execMsg, sendFrame) {
 }
 function handleExecMessage(execMsg, mcpTools, sendFrame, onMcpExec) {
     const execCase = execMsg.message.case;
+    console.error(`[proxy] execMessage: case=${execCase}`);
     if (execCase === "requestContextArgs") {
         handleRequestContext(execMsg, mcpTools, sendFrame);
         return;


### PR DESCRIPTION
## Summary

- Fix `Blob not found` error by clearing stale conversation states on proxy startup
- Revert MCP tool forwarding (causes Cursor gRPC to hang indefinitely)
- Add debug logging for future investigation
- Revert `tool_call` back to `false`

## Root cause analysis

**Blob not found**: Stale `conversationStates` from previous sessions reference checkpoints with blob IDs that Cursor's server has evicted. Clearing the map on proxy startup fixes this.

**MCP tool hang**: Sending MCP tools via `RequestContext` causes Cursor's `AgentService/Run` gRPC protocol to enter a tool execution loop. The server sends native tool exec messages (readArgs, shellArgs, etc.), we reject them, but the server never falls through to text generation — it hangs indefinitely. This is a fundamental limitation of using Cursor's agent protocol for tool calling.

**No tool execution**: With `tool_call: false`, OpenCode includes tool descriptions in the system prompt, but Cursor's Composer 2 model narrates what it would do instead of generating structured tool calls. Tool calling for Cursor models needs a fundamentally different approach (e.g., Nomadcxx-style text prompt flattening with structured text parsing at the ai-sdk provider level).

## What's kept for future use

- Tool name alias map (50+ aliases)
- Tool loop guard (MAX_TOOL_ROUNDS = 25)
- `buildMcpToolDefinitions()` function
- Debug logging in handleChatCompletion, requestContext, execMessage

Closes #5457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Proxy now clears stored conversation states and active connections on startup, preventing residual data from previous sessions

## Chores
* Enhanced verbose debug logging for improved troubleshooting of chat operations and tool handling
* Updated model configuration for tool call settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->