### PR TITLE
t5467: fix: remove unused variables causing SC2034 ShellCheck warnings

### DIFF
--- a/.agents/scripts/content-scanner-helper.sh
+++ b/.agents/scripts/content-scanner-helper.sh
@@ -392,8 +392,7 @@ scan_content() {
 	fi
 
 	local pg_exit=0
-	local pg_output
-	pg_output=$("$PROMPT_GUARD" check "$normalized" 2>&1) || pg_exit=$?
+	"$PROMPT_GUARD" check "$normalized" >/dev/null 2>&1 || pg_exit=$?
 
 	case "$pg_exit" in
 	0)

--- a/.agents/scripts/mailbox-search-helper.sh
+++ b/.agents/scripts/mailbox-search-helper.sh
@@ -38,8 +38,6 @@ set -euo pipefail
 
 readonly DEFAULT_LIMIT=50
 readonly DEFAULT_MAILDIR="${HOME}/Maildir"
-readonly NOTMUCH_CONFIG_DEFAULT="${HOME}/.notmuch-config"
-readonly MU_MUHOME_DEFAULT="${HOME}/.mu"
 readonly WORKSPACE_DIR="${MAILBOX_SEARCH_WORKSPACE:-${HOME}/.aidevops/.agent-workspace/mailbox-search}"
 readonly RESULTS_DB="${WORKSPACE_DIR}/search-cache.db"
 

--- a/.agents/scripts/worker-token-helper.sh
+++ b/.agents/scripts/worker-token-helper.sh
@@ -252,22 +252,20 @@ create_delegated_token() {
 	fi
 
 	# Check token type and scopes
-	local token_info
-	token_info=$(curl -sf \
+	curl -sf \
 		"https://api.github.com/user" \
 		-H "Authorization: Bearer ${current_token}" \
 		-H "Accept: application/vnd.github+json" \
-		-D /dev/stderr 2>&1 1>/dev/null) || {
+		-D /dev/stderr >/dev/null 2>&1 || {
 		log_token "WARN" "Cannot validate current token"
 		return 1
 	}
 
 	# Check if the token has access to the target repo
-	local repo_check
-	repo_check=$(curl -sf \
+	curl -sf \
 		"https://api.github.com/repos/${repo}" \
 		-H "Authorization: Bearer ${current_token}" \
-		-H "Accept: application/vnd.github+json" 2>/dev/null) || {
+		-H "Accept: application/vnd.github+json" >/dev/null 2>/dev/null || {
 		log_token "WARN" "Current token cannot access repo ${repo}"
 		return 1
 	}

--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,6 @@ GREEN='\033[0;32m'
 BLUE='\033[0;34m'
 YELLOW='\033[1;33m'
 RED='\033[0;31m'
-GRAY='\033[0;90m'
 NC='\033[0m' # No Color
 
 # Global flags
@@ -1614,7 +1613,6 @@ CW_PLIST
 	local pr_script="$HOME/.aidevops/agents/scripts/profile-readme-helper.sh"
 	local pr_label="sh.aidevops.profile-readme-update"
 	local repos_json="$HOME/.config/aidevops/repos.json"
-	local has_profile_repo="false"
 	if [[ -x "$pr_script" ]] && command -v gh &>/dev/null && gh auth status &>/dev/null; then
 		# Initialize profile repo if not already set up.
 		# Verify the entry is valid: local dir exists AND README has stat markers.
@@ -1634,22 +1632,15 @@ CW_PLIST
 				[[ -f "${profile_path}/README.md" ]] &&
 				grep -q '<!-- STATS-START -->' "${profile_path}/README.md" 2>/dev/null; then
 				profile_needs_init="false"
-				has_profile_repo="true"
 			fi
 		fi
 		if [[ "$profile_needs_init" == "true" ]]; then
 			print_info "Setting up GitHub profile README..."
 			if bash "$pr_script" init; then
-				has_profile_repo="true"
 				print_info "Profile README created. Visit your profile repo and click 'Show on profile'."
 			else
 				print_warning "Profile README setup failed (non-fatal, skipping)"
 			fi
-		fi
-	elif [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
-		# No gh CLI but check if profile repo already registered
-		if jq -e '.initialized_repos[]? | select(.priority == "profile")' "$repos_json" >/dev/null 2>&1; then
-			has_profile_repo="true"
 		fi
 	fi
 


### PR DESCRIPTION
## Summary

Removes unused variables that were generating SC2034 (variable assigned but never used) ShellCheck warnings across four scripts.

## Changes

- **setup.sh**: Remove `GRAY` (unused color constant never referenced in output) and `has_profile_repo` (set to `"true"`/`"false"` in three places but never read; the conditional logic and side-effects are preserved)
- **worker-token-helper.sh**: Remove `token_info` and `repo_check` local variables; both `curl` calls are run purely for their exit code (token validation), output was never consumed
- **mailbox-search-helper.sh**: Remove `NOTMUCH_CONFIG_DEFAULT` and `MU_MUHOME_DEFAULT` readonly constants; defined but never referenced anywhere in the file
- **content-scanner-helper.sh**: Remove `pg_output` local variable; `prompt-guard-helper.sh` output is discarded (`>/dev/null 2>&1`), only the exit code drives the `case` statement

## Verification

```
shellcheck setup.sh .agents/scripts/worker-token-helper.sh \
  .agents/scripts/mailbox-search-helper.sh \
  .agents/scripts/content-scanner-helper.sh | grep SC2034
# → No output (zero SC2034 violations)
```

No functional regression — all removed variables were write-only (assigned but never read).

Closes #5467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized output handling in content scanning operations to reduce unnecessary logging.
  * Removed default configuration path constants from mailbox search helper.
  * Simplified GitHub API validation error handling in token delegation processes.
  * Removed unused formatting definitions from initialization scripts.
  * Improved script efficiency through streamlined variable assignments and output capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->