### PR TITLE
t125: add browser-use to AGENTS.md domain index and subagent-index.toon

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -274,7 +274,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Documents/PDF | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
 | OCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |
 | Product (shared) | `product/validation.md`, `product/onboarding.md`, `product/monetisation.md`, `product/growth.md`, `product/ui-design.md`, `product/analytics.md` |
-| Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `tools/mobile/app-dev.md`, `tools/mobile/app-store-connect.md`, `tools/browser/extension-dev.md` |
+| Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `tools/browser/browser-use.md`, `tools/mobile/app-dev.md`, `tools/mobile/app-store-connect.md`, `tools/browser/extension-dev.md` |
 | Content/Video/Voice | `content.md`, `tools/video/video-prompt-design.md`, `tools/voice/speech-to-speech.md` |
 | Design | `tools/design/ui-ux-inspiration.md`, `tools/design/ui-ux-catalogue.toon`, `tools/design/brand-identity.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -40,7 +40,7 @@ tools/build-mcp/,MCP development - creating MCP servers and plugins,build-mcp|se
 tools/mcp-toolkit/,MCP runtime toolkit - discover call compose and generate CLIs/typed clients for MCP servers,mcporter
 tools/ai-assistants/,AI tool integration - OpenCode headless dispatch model comparison and response scoring,agno|capsolver|claude-code|compare-models|response-scoring|overview|openclaw|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
-tools/browser/,Browser automation - scraping testing and QA,agent-browser|browser-automation|browser-qa|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy|chrome-webstore-release
+tools/browser/,Browser automation - scraping testing and QA,agent-browser|browser-automation|browser-qa|browser-use|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy|chrome-webstore-release
 tools/mobile/,Mobile development - iOS/macOS build test simulator App Store Connect and emulator automation,app-store-connect|agent-device|xcodebuild-mcp|ios-simulator-mcp|maestro|axe-cli|minisim
 tools/pdf/,PDF processing - form filling and digital signatures,overview|libpdf
 tools/accessibility/,Accessibility and contrast testing - WCAG compliance for websites and emails,accessibility


### PR DESCRIPTION
## Summary

- Adds `tools/browser/browser-use.md` to the Browser/Mobile row in the AGENTS.md domain index
- Adds `browser-use` to the `tools/browser/` key_files entry in `subagent-index.toon`

The `browser-use.md` subagent doc already exists (created in #486, updated to v0.12.x API in #5463). This PR completes the index registration that was missing.

## Changes

- `.agents/AGENTS.md` — Browser/Mobile row now includes `tools/browser/browser-use.md`
- `.agents/subagent-index.toon` — `tools/browser/` key_files now includes `browser-use`

Closes #5471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated browser and mobile automation documentation indices to reflect new capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->