### PR TITLE
fix: remove or invoke never-called test functions (SC2329)

### DIFF
--- a/.agents/scripts/document-creation-helper.sh
+++ b/.agents/scripts/document-creation-helper.sh
@@ -94,18 +94,6 @@ get_ext() {
 	printf '%s' "$ext" | tr '[:upper:]' '[:lower:]'
 }
 
-# Sanitize string for filename (remove/replace unsafe chars)
-sanitize_filename() {
-	local str="$1"
-	# Remove leading/trailing whitespace
-	str=$(printf '%s' "$str" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-	# Replace unsafe chars with dash
-	str=$(printf '%s' "$str" | tr -c '[:alnum:]._-' '-' | tr -s '-')
-	# Limit length to 100 chars
-	str=$(printf '%s' "$str" | cut -c1-100)
-	printf '%s' "$str"
-}
-
 # Activate Python venv if it exists
 activate_venv() {
 	if [[ -f "${VENV_DIR}/bin/activate" ]]; then
@@ -327,95 +315,6 @@ ocr_scanned_pdf() {
 # ============================================================================
 # Tool detection
 # ============================================================================
-
-detect_tools() {
-	local tools_available=()
-	local tools_missing=()
-
-	# Tier 1: Minimal
-	if has_cmd pandoc; then
-		tools_available+=("pandoc")
-	else
-		tools_missing+=("pandoc")
-	fi
-
-	if has_cmd pdftotext; then
-		tools_available+=("poppler")
-	else
-		tools_missing+=("poppler")
-	fi
-
-	# Tier 2: Standard (Python libs)
-	if has_python_pkg odf 2>/dev/null; then
-		tools_available+=("odfpy")
-	else
-		tools_missing+=("odfpy")
-	fi
-
-	if has_python_pkg docx 2>/dev/null; then
-		tools_available+=("python-docx")
-	else
-		tools_missing+=("python-docx")
-	fi
-
-	if has_python_pkg openpyxl 2>/dev/null; then
-		tools_available+=("openpyxl")
-	else
-		tools_missing+=("openpyxl")
-	fi
-
-	# Tier 3: Full
-	if has_cmd soffice || has_cmd libreoffice; then
-		tools_available+=("libreoffice")
-	else
-		tools_missing+=("libreoffice")
-	fi
-
-	# Tier 3: Full
-	# (already checked above)
-
-	# OCR tools
-	if has_cmd tesseract; then
-		tools_available+=("tesseract")
-	else
-		tools_missing+=("tesseract")
-	fi
-
-	if has_python_pkg easyocr 2>/dev/null; then
-		tools_available+=("easyocr")
-	else
-		tools_missing+=("easyocr")
-	fi
-
-	if has_cmd ollama && ollama list 2>/dev/null | grep -q "glm-ocr"; then
-		tools_available+=("glm-ocr")
-	else
-		tools_missing+=("glm-ocr")
-	fi
-
-	# Specialist tools
-	if has_cmd mineru; then
-		tools_available+=("mineru")
-	else
-		tools_missing+=("mineru")
-	fi
-
-	# Advanced conversion providers
-	if has_reader_lm; then
-		tools_available+=("reader-lm")
-	else
-		tools_missing+=("reader-lm")
-	fi
-
-	if has_rolm_ocr; then
-		tools_available+=("rolm-ocr")
-	else
-		tools_missing+=("rolm-ocr")
-	fi
-
-	printf '%s\n' "AVAILABLE:${tools_available[*]:-none}"
-	printf '%s\n' "MISSING:${tools_missing[*]:-none}"
-}
 
 # ============================================================================
 # Status command

--- a/tests/test-migrate-orphaned-supervisor.sh
+++ b/tests/test-migrate-orphaned-supervisor.sh
@@ -50,22 +50,35 @@ AGENTS_DIR="$TEST_HOME/.aidevops/agents"
 SCRIPTS_DIR="$AGENTS_DIR/scripts"
 mkdir -p "$SCRIPTS_DIR"
 
-# Stub functions that migrations.sh expects from setup.sh
+# Stub functions that migrations.sh expects from setup.sh.
+# These are never called directly in this file — they exist so that
+# `source "$MIGRATIONS_SCRIPT"` succeeds. SC2329 is expected.
+# shellcheck disable=SC2329
 print_info() { echo "[INFO] $1"; }
+# shellcheck disable=SC2329
 print_success() { echo "[SUCCESS] $1"; }
+# shellcheck disable=SC2329
 print_warning() { echo "[WARNING] $1"; }
+# shellcheck disable=SC2329
 print_error() { echo "[ERROR] $1"; }
 # _launchd_has_agent is defined in setup.sh; stub it for Linux tests
+# shellcheck disable=SC2329
 _launchd_has_agent() { return 1; }
 # Stubs for other functions referenced by migrations.sh
+# shellcheck disable=SC2329
 find_opencode_config() { return 1; }
+# shellcheck disable=SC2329
 create_backup_with_rotation() { return 0; }
+# shellcheck disable=SC2329
 should_overwrite_user_file() { return 0; }
+# shellcheck disable=SC2329
 resolve_mcp_binary_path() {
 	echo ""
 	return 1
 }
+# shellcheck disable=SC2329
 update_mcp_paths_in_opencode() { return 0; }
+# shellcheck disable=SC2329
 sanitize_plugin_namespace() {
 	echo "$1"
 	return 0

--- a/tests/test-skill-url-update-flow.sh
+++ b/tests/test-skill-url-update-flow.sh
@@ -65,21 +65,6 @@ safe_jq_file() {
 	return 1
 }
 
-safe_jq_json() {
-	local filter="$1"
-	local json="$2"
-	local name="$3"
-	local value=""
-	if value="$(jq -er "$filter" <<<"$json" 2>/dev/null)"; then
-		printf '%s\n' "$value"
-		return 0
-	fi
-
-	fail "$name" "Could not read '$filter' from helper JSON output"
-	printf '\n'
-	return 1
-}
-
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 


### PR DESCRIPTION
## Summary

- Remove dead-code functions (`safe_jq_json`, `sanitize_filename`, `detect_tools`) that trigger ShellCheck SC2329
- Add `# shellcheck disable=SC2329` to stub functions in test-migrate-orphaned-supervisor.sh that are intentionally defined for `source` compatibility but never called directly
- All existing tests pass (20/20 headless-runtime, 16/16 skill-url-update, 10/10 migrate-orphaned-supervisor)

## Changes

| File | Action | Reason |
|------|--------|--------|
| `tests/test-skill-url-update-flow.sh` | Removed `safe_jq_json()` | Dead code — defined but never called |
| `.agents/scripts/document-creation-helper.sh` | Removed `sanitize_filename()` | Dead code — defined but never called |
| `.agents/scripts/document-creation-helper.sh` | Removed `detect_tools()` | Dead code — `cmd_status()` covers the same functionality interactively |
| `tests/test-migrate-orphaned-supervisor.sh` | Added `SC2329` disable | 11 stub functions exist for `source "$MIGRATIONS_SCRIPT"` compatibility — intentionally never called directly |

Closes #5468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated internal helper functions no longer in use to reduce code complexity and improve maintainability
  * Enhanced testing infrastructure by improving compatibility with static code analysis tools through updated configuration
  * Streamlined development utilities and cleaned up unused functions across internal scripts
  * General improvements to code organization and internal tool optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->