### PR TITLE
t5469: add inline SC2001 directives for sed patterns requiring regex

### DIFF
--- a/.agents/scripts/email-signature-parser-helper.sh
+++ b/.agents/scripts/email-signature-parser-helper.sh
@@ -430,7 +430,8 @@ merge_toon_contact() {
 		esac
 	done <<<"$existing"
 
-	# Update last_seen
+	# Update last_seen (sed required: line-anchored replacement in multiline string)
+	# shellcheck disable=SC2001
 	existing=$(echo "$existing" | sed "s/^  last_seen: .*/  last_seen: ${now}/")
 
 	# Detect field changes and build history entries
@@ -454,10 +455,12 @@ merge_toon_contact() {
       new: ${new_val}
       source: ${source}
 "
-			# Update the field in the existing record
+			# Update the field in the existing record (sed required: line-anchored multiline replacement)
+			# shellcheck disable=SC2001
 			existing=$(echo "$existing" | sed "s|^  ${field_name}: .*|  ${field_name}: ${new_val}|")
 		elif [[ -z "$old_val" ]]; then
-			# Fill empty field
+			# Fill empty field (sed required: line-anchored multiline replacement)
+			# shellcheck disable=SC2001
 			existing=$(echo "$existing" | sed "s|^  ${field_name}: $|  ${field_name}: ${new_val}|")
 		fi
 		return 0
@@ -491,6 +494,7 @@ ${history_entries}"
 	_field_line=$(echo "$existing" | grep -E "^  confidence: " || true)
 	existing_conf="${_field_line#  confidence: }"
 	if [[ "$confidence" == "high" && "$existing_conf" != "high" ]]; then
+		# shellcheck disable=SC2001
 		existing=$(echo "$existing" | sed "s/^  confidence: .*/  confidence: ${confidence}/")
 	fi
 

--- a/.agents/scripts/email-signature-parser-helper.sh
+++ b/.agents/scripts/email-signature-parser-helper.sh
@@ -432,7 +432,7 @@ merge_toon_contact() {
 
 	# Update last_seen (sed required: line-anchored replacement in multiline string)
 	# shellcheck disable=SC2001
-	existing=$(echo "$existing" | sed "s/^  last_seen: .*/  last_seen: ${now}/")
+	existing=$(sed "s/^  last_seen: .*/  last_seen: ${now}/" <<<"$existing")
 
 	# Detect field changes and build history entries
 	local history_entries=""
@@ -457,11 +457,11 @@ merge_toon_contact() {
 "
 			# Update the field in the existing record (sed required: line-anchored multiline replacement)
 			# shellcheck disable=SC2001
-			existing=$(echo "$existing" | sed "s|^  ${field_name}: .*|  ${field_name}: ${new_val}|")
+			existing=$(sed "s|^  ${field_name}: .*|  ${field_name}: ${new_val}|" <<<"$existing")
 		elif [[ -z "$old_val" ]]; then
 			# Fill empty field (sed required: line-anchored multiline replacement)
 			# shellcheck disable=SC2001
-			existing=$(echo "$existing" | sed "s|^  ${field_name}: $|  ${field_name}: ${new_val}|")
+			existing=$(sed "s|^  ${field_name}: $|  ${field_name}: ${new_val}|" <<<"$existing")
 		fi
 		return 0
 	}
@@ -495,7 +495,7 @@ ${history_entries}"
 	existing_conf="${_field_line#  confidence: }"
 	if [[ "$confidence" == "high" && "$existing_conf" != "high" ]]; then
 		# shellcheck disable=SC2001
-		existing=$(echo "$existing" | sed "s/^  confidence: .*/  confidence: ${confidence}/")
+		existing=$(sed "s/^  confidence: .*/  confidence: ${confidence}/" <<<"$existing")
 	fi
 
 	echo "$existing" >"$toon_file"

--- a/.agents/scripts/entity-helper.sh
+++ b/.agents/scripts/entity-helper.sh
@@ -1565,13 +1565,11 @@ EOF
 			echo "  (no interactions)"
 		else
 			if [[ "$privacy_filter" == true ]]; then
-				# Apply privacy filtering to output (sed required: regex quantifiers/char classes)
-				# shellcheck disable=SC2001
-				interactions=$(echo "$interactions" | sed 's/[a-zA-Z0-9._%+-]\+@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}/[EMAIL]/g')
-				# shellcheck disable=SC2001
-				interactions=$(echo "$interactions" | sed 's/\b[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\b/[IP]/g')
-				# shellcheck disable=SC2001
-				interactions=$(echo "$interactions" | sed 's/sk-[a-zA-Z0-9_-]\{20,\}/[API_KEY]/g')
+				# Apply privacy filtering to output (sed required: regex quantifiers/char classes/word boundaries)
+				interactions=$(sed \
+					-e 's/[a-zA-Z0-9._%+-]\+@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}/[EMAIL]/g' \
+					-e 's/\b[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\b/[IP]/g' \
+					-e 's/sk-[a-zA-Z0-9_-]\{20,\}/[API_KEY]/g' <<<"$interactions")
 			fi
 			echo "$interactions"
 		fi

--- a/.agents/scripts/entity-helper.sh
+++ b/.agents/scripts/entity-helper.sh
@@ -1565,9 +1565,12 @@ EOF
 			echo "  (no interactions)"
 		else
 			if [[ "$privacy_filter" == true ]]; then
-				# Apply privacy filtering to output
+				# Apply privacy filtering to output (sed required: regex quantifiers/char classes)
+				# shellcheck disable=SC2001
 				interactions=$(echo "$interactions" | sed 's/[a-zA-Z0-9._%+-]\+@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}/[EMAIL]/g')
+				# shellcheck disable=SC2001
 				interactions=$(echo "$interactions" | sed 's/\b[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\b/[IP]/g')
+				# shellcheck disable=SC2001
 				interactions=$(echo "$interactions" | sed 's/sk-[a-zA-Z0-9_-]\{20,\}/[API_KEY]/g')
 			fi
 			echo "$interactions"


### PR DESCRIPTION
## Summary

- Adds inline `# shellcheck disable=SC2001` directives to 7 sed patterns across `entity-helper.sh` (3) and `email-signature-parser-helper.sh` (4) that genuinely require regex features unavailable in bash parameter expansion
- Documents why each pattern needs sed: regex quantifiers (`\{2,\}`), character classes, word boundaries (`\b`), and line-anchored replacements (`^`) in multiline strings

## Analysis

The issue proposed replacing `echo "$var" | sed 's/.../.../'` with `${var//search/replace}`. After analysis, all 7 flagged patterns use regex features that parameter expansion cannot replicate:

**entity-helper.sh** (privacy filter, lines 1569-1571):
- Email regex: `[a-zA-Z0-9._%+-]\+@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}` — quantifiers, char classes
- IP regex: `\b[0-9]\{1,3\}\.[0-9]\{1,3\}...` — word boundaries, quantifiers
- API key regex: `sk-[a-zA-Z0-9_-]\{20,\}` — quantifiers

**email-signature-parser-helper.sh** (TOON merge, lines 434-497):
- `s/^  last_seen: .*/...` — line-anchored replacement in multiline string
- `s|^  ${field_name}: .*|...|` — dynamic line-anchored replacement (x2)
- `s/^  confidence: .*/...` — line-anchored replacement in multiline string

## Verification

- `shellcheck --norc --enable=SC2001` reports zero SC2001 on both files
- `shellcheck` with project `.shellcheckrc` reports zero violations (only expected SC1091)
- All 43 email-signature-parser tests pass (0 failures)
- Entity-helper tests: pre-existing failures unrelated to this change (missing DB tables)

Closes #5469