### PR TITLE
t126: Add Skyvern subagent doc for computer vision browser automation

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -274,7 +274,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Documents/PDF | `tools/document/document-creation.md`, `tools/pdf/overview.md`, `tools/conversion/pandoc.md` |
 | OCR | `tools/ocr/overview.md`, `tools/ocr/paddleocr.md`, `tools/ocr/glm-ocr.md` |
 | Product (shared) | `product/validation.md`, `product/onboarding.md`, `product/monetisation.md`, `product/growth.md`, `product/ui-design.md`, `product/analytics.md` |
-| Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `tools/browser/browser-use.md`, `tools/mobile/app-dev.md`, `tools/mobile/app-store-connect.md`, `tools/browser/extension-dev.md` |
+| Browser/Mobile | `tools/browser/browser-automation.md`, `tools/browser/browser-qa.md`, `tools/browser/browser-use.md`, `tools/browser/skyvern.md`, `tools/mobile/app-dev.md`, `tools/mobile/app-store-connect.md`, `tools/browser/extension-dev.md` |
 | Content/Video/Voice | `content.md`, `tools/video/video-prompt-design.md`, `tools/voice/speech-to-speech.md` |
 | Design | `tools/design/ui-ux-inspiration.md`, `tools/design/ui-ux-catalogue.toon`, `tools/design/brand-identity.md` |
 | SEO | `seo/dataforseo.md`, `seo/google-search-console.md` |

--- a/.agents/subagent-index.toon
+++ b/.agents/subagent-index.toon
@@ -40,7 +40,7 @@ tools/build-mcp/,MCP development - creating MCP servers and plugins,build-mcp|se
 tools/mcp-toolkit/,MCP runtime toolkit - discover call compose and generate CLIs/typed clients for MCP servers,mcporter
 tools/ai-assistants/,AI tool integration - OpenCode headless dispatch model comparison and response scoring,agno|capsolver|claude-code|compare-models|response-scoring|overview|openclaw|opencode-server|headless-dispatch
 tools/ai-orchestration/,AI orchestration - visual builders and multi-agent,overview|langflow|crewai|autogen|openprose
-tools/browser/,Browser automation - scraping testing and QA,agent-browser|browser-automation|browser-qa|browser-use|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy|chrome-webstore-release
+tools/browser/,Browser automation - scraping testing and QA,agent-browser|browser-automation|browser-qa|browser-use|skyvern|stagehand|playwright|playwright-cli|playwright-emulation|playwriter|crawl4ai|watercrawl|pagespeed|peekaboo|curl-copy|chrome-webstore-release
 tools/mobile/,Mobile development - iOS/macOS build test simulator App Store Connect and emulator automation,app-store-connect|agent-device|xcodebuild-mcp|ios-simulator-mcp|maestro|axe-cli|minisim
 tools/pdf/,PDF processing - form filling and digital signatures,overview|libpdf
 tools/accessibility/,Accessibility and contrast testing - WCAG compliance for websites and emails,accessibility

--- a/.agents/tools/browser/skyvern.md
+++ b/.agents/tools/browser/skyvern.md
@@ -15,86 +15,234 @@ tools:
 
 ## Quick Reference
 
-- **Purpose**: Automate browser workflows using computer vision (no selectors needed)
-- **Install**: `pip install skyvern` or Docker
+- **Purpose**: Automate browser workflows using computer vision + LLM (no DOM selectors needed)
+- **Install**: Docker (recommended) or `pip install skyvern`
 - **Repo**: https://github.com/Skyvern-AI/skyvern (20k+ stars, Python, AGPL-3.0)
 - **Docs**: https://docs.skyvern.com/
+- **Cloud**: https://app.skyvern.com/ (managed, no self-hosting required)
+- **Version**: 0.1.x (check repo for latest)
 
-**When to use**: Automating workflows on websites you don't control, where DOM structure changes frequently. Skyvern uses visual understanding to interact with pages, making it resilient to UI changes.
+**When to use**: Automating workflows on websites you don't control, where DOM structure changes frequently, or where pages use visual-only UIs (canvas, iframes, dynamic SPAs). Skyvern uses screenshots + LLM vision to identify and interact with elements — no CSS selectors, no XPath, no brittle DOM queries.
 
 <!-- AI-CONTEXT-END -->
 
 ## Setup
 
-```bash
-# Docker (recommended)
-docker run -p 8000:8000 skyvern/skyvern
+### Docker (recommended for self-hosted)
 
-# Or pip
+```bash
+# Clone and start with Docker Compose
+git clone https://github.com/Skyvern-AI/skyvern.git
+cd skyvern
+docker compose up -d
+
+# API available at http://localhost:8000
+# UI available at http://localhost:8080
+```
+
+### pip (local development)
+
+```bash
 pip install skyvern
+
+# Initialise (downloads browser, sets up DB)
 skyvern init
+
+# Start the server
 skyvern up
+```
+
+### Environment
+
+```bash
+# .env
+OPENAI_API_KEY=your-key          # Required for vision LLM
+# ANTHROPIC_API_KEY=your-key     # Alternative LLM provider
+SKYVERN_API_KEY=your-key         # For Skyvern Cloud
 ```
 
 ## API Usage
 
+### Task Creation and Polling
+
 ```python
 import requests
+import time
+
+BASE_URL = "http://localhost:8000"
+HEADERS = {"x-api-key": "your-api-key"}
 
 # Create a task
-response = requests.post("http://localhost:8000/api/v1/tasks", json={
-    "url": "https://example.com/login",
-    "navigation_goal": "Log in with username 'user' and password 'pass', then navigate to settings",
-    "data_extraction_goal": "Extract the account email and plan type",
-})
+response = requests.post(
+    f"{BASE_URL}/api/v1/tasks",
+    headers=HEADERS,
+    json={
+        "url": "https://example.com/login",
+        "navigation_goal": "Log in with username 'user@example.com' and password stored in the PASSWORD env var, then navigate to the account settings page",
+        "data_extraction_goal": "Extract the account email, plan type, and billing cycle",
+        "proxy_location": "RESIDENTIAL",  # Optional: use residential proxy
+        "max_steps_override": 20,          # Optional: cap steps (default 10)
+    },
+)
 
 task_id = response.json()["task_id"]
 
-# Check status
-status = requests.get(f"http://localhost:8000/api/v1/tasks/{task_id}")
-print(status.json())
+# Poll for completion
+while True:
+    status_resp = requests.get(
+        f"{BASE_URL}/api/v1/tasks/{task_id}",
+        headers=HEADERS,
+    )
+    task = status_resp.json()
+    if task["status"] in ("completed", "failed", "terminated"):
+        break
+    time.sleep(2)
+
+print(task["extracted_information"])
+```
+
+### Task Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `created` | Task queued, not yet started |
+| `running` | Browser is executing steps |
+| `completed` | All goals achieved |
+| `failed` | Could not complete the goal |
+| `terminated` | Manually stopped |
+
+### Workflow API (multi-step sequences)
+
+```python
+# Create a reusable workflow
+workflow = requests.post(
+    f"{BASE_URL}/api/v1/workflows",
+    headers=HEADERS,
+    json={
+        "title": "Login and extract data",
+        "description": "Logs in and extracts account info",
+        "workflow_definition": {
+            "blocks": [
+                {
+                    "block_type": "task",
+                    "label": "login",
+                    "url": "https://example.com/login",
+                    "navigation_goal": "Log in with the provided credentials",
+                    "data_extraction_goal": None,
+                    "parameter_keys": ["username", "password"],
+                },
+                {
+                    "block_type": "task",
+                    "label": "extract",
+                    "url": "https://example.com/account",
+                    "navigation_goal": "Navigate to account settings",
+                    "data_extraction_goal": "Extract plan type and billing date",
+                },
+            ]
+        },
+    },
+)
+
+workflow_id = workflow.json()["workflow_id"]
+
+# Run the workflow with parameters
+run = requests.post(
+    f"{BASE_URL}/api/v1/workflows/{workflow_id}/run",
+    headers=HEADERS,
+    json={
+        "data": {
+            "username": "user@example.com",
+            "password": "secret",
+        }
+    },
+)
 ```
 
 ## Key Features
 
-- **Visual element detection**: Identifies buttons, forms, and links by appearance
-- **Workflow chaining**: Multi-step task sequences with conditional logic
-- **Data extraction**: Extract structured data from any page
-- **CAPTCHA handling**: Built-in CAPTCHA solving integration
-- **Proxy support**: Rotate proxies for scraping at scale
-- **Self-hosted**: Full control over data and execution
+- **Visual element detection**: Identifies buttons, forms, links, and inputs by appearance — not by CSS class or ID
+- **CAPTCHA handling**: Built-in integration with CAPTCHA-solving services (2captcha, Anti-Captcha)
+- **Proxy support**: Residential and datacenter proxy rotation for scraping at scale
+- **Workflow chaining**: Multi-step task sequences with parameter passing between steps
+- **Data extraction**: Extract structured JSON from any page using natural language goals
+- **Self-hosted**: Full control over data, execution, and LLM provider
+- **Skyvern Cloud**: Managed option — no infrastructure, pay-per-task
 
-## Workflow Definition
+## Use Cases
 
-```yaml
-# skyvern-workflow.yaml
-steps:
-  - type: navigate
-    url: "https://example.com"
-  - type: click
-    element: "Sign In button"
-  - type: input
-    element: "Email field"
-    value: "user@example.com"
-  - type: click
-    element: "Submit button"
-  - type: extract
-    goal: "Get the dashboard summary data"
+### Forms with CAPTCHAs
+
+Skyvern's primary strength — it handles visual CAPTCHAs that break DOM-based tools:
+
+```python
+requests.post(f"{BASE_URL}/api/v1/tasks", headers=HEADERS, json={
+    "url": "https://example.com/signup",
+    "navigation_goal": "Fill in the signup form with name 'Test User', email 'test@example.com', and solve any CAPTCHA that appears",
+    "data_extraction_goal": "Confirm the account was created successfully",
+})
 ```
 
-## Comparison
+### Dynamic SPAs
 
-| Feature | Skyvern | browser-use | Playwright |
-|---------|---------|-------------|------------|
-| Visual AI | Primary | Hybrid | No |
-| Self-hosted | Yes | Yes | Yes |
-| API-first | Yes | No | No |
-| Workflow YAML | Yes | No | No |
-| License | AGPL-3.0 | MIT | Apache-2.0 |
-| Best for | Resilient automation | AI tasks | Testing |
+Pages that render content via JavaScript after load — Skyvern waits for visual stability before acting:
+
+```python
+requests.post(f"{BASE_URL}/api/v1/tasks", headers=HEADERS, json={
+    "url": "https://app.example.com/dashboard",
+    "navigation_goal": "Click the 'Export' button and wait for the download to complete",
+    "data_extraction_goal": "Extract the export filename shown in the confirmation dialog",
+})
+```
+
+### Visual-Only UIs
+
+Canvas-based apps, embedded iframes, or custom UI components with no accessible DOM:
+
+```python
+requests.post(f"{BASE_URL}/api/v1/tasks", headers=HEADERS, json={
+    "url": "https://example.com/chart-editor",
+    "navigation_goal": "Click the bar chart element in the top-left quadrant and change its colour to blue",
+})
+```
+
+## Self-Hosted vs Skyvern Cloud
+
+| Aspect | Self-Hosted | Skyvern Cloud |
+|--------|-------------|---------------|
+| Setup | Docker Compose, ~10 min | API key only |
+| Cost | LLM API costs only | Per-task pricing |
+| Data privacy | Full control | Data sent to Skyvern |
+| Scaling | Manual (add workers) | Automatic |
+| CAPTCHA solving | Configure own service | Included |
+| Proxy rotation | Configure own proxies | Included |
+| Best for | High volume, sensitive data | Quick start, low volume |
+
+## Comparison with Other Browser Tools
+
+| Feature | Skyvern | browser-use | Playwright | Stagehand |
+|---------|---------|-------------|------------|-----------|
+| Vision AI | Primary (screenshots) | Hybrid (vision + DOM) | No | Yes (DOM-first) |
+| No selectors needed | Yes | Yes | No | Yes |
+| API-first | Yes | No | No | No |
+| Workflow YAML/JSON | Yes | No | No | No |
+| CAPTCHA handling | Built-in | Via Cloud | No | No |
+| Self-hosted | Yes | Yes | Yes | No (Browserbase) |
+| License | AGPL-3.0 | MIT | Apache-2.0 | MIT |
+| Language | Python | Python | Any | TypeScript |
+| Best for | Resilient automation, CAPTCHAs | AI-native tasks | Testing, speed | Natural language on known pages |
+
+## When to Prefer Other Tools
+
+- **Testing your own app**: Use Playwright — faster, deterministic, no LLM cost
+- **AI-native multi-step tasks**: Use browser-use — better Python integration, MIT license
+- **Natural language on known pages**: Use Stagehand — TypeScript-native, Browserbase cloud
+- **Bulk scraping**: Use Crawl4AI — optimised for content extraction at scale
+- **Persistent browser sessions**: Use dev-browser — preserves logins across sessions
 
 ## Related
 
 - `tools/browser/browser-automation.md` - Browser tool decision tree
-- `tools/browser/browser-use.md` - AI-native browser automation
+- `tools/browser/browser-use.md` - AI-native browser automation (MIT, Python)
 - `tools/browser/playwright.md` - Playwright direct automation
+- `tools/browser/stagehand.md` - Stagehand AI browser automation (TypeScript)
+- `tools/browser/crawl4ai.md` - Bulk web scraping and content extraction


### PR DESCRIPTION
## Summary

- Expands `tools/browser/skyvern.md` from 100 to 190+ lines with complete coverage of Skyvern's API, use cases, and decision guidance
- Adds Skyvern to the AGENTS.md Browser/Mobile domain index
- Adds `skyvern` to the `subagent-index.toon` browser/ entry

## Changes

### `tools/browser/skyvern.md`
- Docker Compose and pip setup with environment config
- Task creation, status polling, and Workflow API with working Python examples
- Task status values reference table
- Use cases: forms with CAPTCHAs, dynamic SPAs, visual-only UIs (canvas, iframes)
- Self-hosted vs Skyvern Cloud comparison table
- Full comparison with browser-use, Playwright, and Stagehand
- "When to prefer other tools" guidance

### `AGENTS.md`
- Added `tools/browser/skyvern.md` to Browser/Mobile domain index row

### `subagent-index.toon`
- Added `skyvern` to the `tools/browser/` entry

Closes #5472