### PR TITLE
t1555: Fix draft-response notifications via self-mention and repo watch

### DIFF
--- a/.agents/scripts/draft-response-helper.sh
+++ b/.agents/scripts/draft-response-helper.sh
@@ -147,6 +147,11 @@ _ensure_draft_repo() {
 	gh label create "draft" --repo "$slug" --description "Pending draft response" --color "FBCA04" 2>/dev/null || true
 	gh label create "approved" --repo "$slug" --description "Approved and posted" --color "0E8A16" 2>/dev/null || true
 	gh label create "declined" --repo "$slug" --description "Declined" --color "B60205" 2>/dev/null || true
+
+	# Watch the repo so issue creation triggers GitHub notifications
+	gh api "repos/${slug}/subscription" --method PUT \
+		--input - <<<'{"subscribed":true,"ignored":false}' >/dev/null 2>&1 || true
+
 	_log_info "Created private repo: ${slug}"
 	return 0
 }
@@ -237,6 +242,18 @@ _create_notification_issue() {
 
 	local issue_number
 	issue_number=$(echo "$issue_url" | grep -oE '[0-9]+$') || issue_number=""
+
+	# Post a comment mentioning the user to trigger a GitHub notification.
+	# GitHub does NOT notify you for issues you create yourself — even as assignee.
+	# A self-mention in a comment is the only way to get the notification.
+	if [[ -n "$issue_number" ]]; then
+		local username
+		username=$(_get_username)
+		gh issue comment "$issue_number" --repo "$slug" \
+			--body "@${username} — draft reply ready for review." \
+			>/dev/null 2>&1 || true
+	fi
+
 	echo "$issue_number"
 	return 0
 }


### PR DESCRIPTION
## Summary

GitHub does not notify you for issues you create yourself — even as assignee. Draft-response notification issues were invisible in the user's GitHub notifications.

## Fix

Two mechanisms (belt-and-suspenders):

1. **Repo watch** — `_ensure_draft_repo` now subscribes to the repo via `gh api repos/.../subscription` on creation
2. **Self-mention comment** — after each notification issue is created, a `@username — draft reply ready for review.` comment is posted, which triggers a GitHub notification

Also updated all 8 existing notification issues (#2-9) with:
- Intelligence-led "How to respond" wording (replacing deterministic CLI commands)
- Self-mention comments to trigger retroactive notifications

## Files Changed

| File | Change |
|------|--------|
| `.agents/scripts/draft-response-helper.sh` | +17 lines: repo watch subscription + self-mention comment |