### PR TITLE
t5489: Add warning log when gh api subscription call fails in draft-response-helper.sh

### DIFF
--- a/.agents/scripts/draft-response-helper.sh
+++ b/.agents/scripts/draft-response-helper.sh
@@ -149,8 +149,10 @@ _ensure_draft_repo() {
 	gh label create "declined" --repo "$slug" --description "Declined" --color "B60205" 2>/dev/null || true
 
 	# Watch the repo so issue creation triggers GitHub notifications
-	gh api "repos/${slug}/subscription" --method PUT \
-		--input - <<<'{"subscribed":true,"ignored":false}' >/dev/null 2>&1 || true
+	if ! gh api "repos/${slug}/subscription" --method PUT \
+		--input - <<<'{"subscribed":true,"ignored":false}' >/dev/null 2>&1; then
+		_log_warn "Failed to subscribe to repository ${slug} for notifications"
+	fi
 
 	_log_info "Created private repo: ${slug}"
 	return 0


### PR DESCRIPTION
## Summary

- Replaces silent `|| true` error suppression on the `gh api` subscription call in `_ensure_draft_repo()` with an `if ! ...; then _log_warn` pattern
- Subscription failures are now logged as warnings for debugging visibility, instead of being silently swallowed

## Context

Per Gemini code review feedback on PR #5485 (medium severity): the `gh api` call to subscribe to the draft-responses repo suppressed all output and errors. While `|| true` prevented script exit, silently failing to subscribe could lead to missed notifications with no diagnostic trail.

## Changes

**`.agents/scripts/draft-response-helper.sh:152-155`** — Wrap the `gh api repos/${slug}/subscription` call in `if ! ...; then _log_warn` instead of `|| true`.

Closes #5489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for repository operations to provide better visibility when issues occur while maintaining system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->