### PR TITLE
t5489: Log warning when repo subscription fails in _ensure_draft_repo

### DIFF
--- a/.agents/scripts/draft-response-helper.sh
+++ b/.agents/scripts/draft-response-helper.sh
@@ -149,8 +149,10 @@ _ensure_draft_repo() {
 	gh label create "declined" --repo "$slug" --description "Declined" --color "B60205" 2>/dev/null || true
 
 	# Watch the repo so issue creation triggers GitHub notifications
-	gh api "repos/${slug}/subscription" --method PUT \
-		--input - <<<'{"subscribed":true,"ignored":false}' >/dev/null 2>&1 || true
+	if ! gh api "repos/${slug}/subscription" --method PUT \
+		--input - <<<'{"subscribed":true,"ignored":false}' >/dev/null 2>&1; then
+		_log_warn "Failed to subscribe to repository ${slug} — notifications may not be delivered"
+	fi
 
 	_log_info "Created private repo: ${slug}"
 	return 0


### PR DESCRIPTION
## Summary

- Addresses Gemini medium-severity review finding from PR #5485 line 153
- Replaces silent `>/dev/null 2>&1 || true` with an `if !` guard that calls `_log_warn` on failure
- Subscription failure remains non-fatal (the repo creation still succeeds), but the failure is now visible in the log for debugging

## Change

`.agents/scripts/draft-response-helper.sh:152-155` — `_ensure_draft_repo` now logs `WARN: Failed to subscribe to repository ${slug} — notifications may not be delivered` when the `gh api` subscription call exits non-zero, instead of silently discarding the error.

## Verification

- ShellCheck: zero new violations (only pre-existing SC1091 info on sourced file)
- Logic: `if ! cmd; then warn; fi` correctly fires on non-zero exit; `>/dev/null` still suppresses noisy stdout on success

Closes #5489