### PR TITLE
t5491: remove redundant SC2001 disable directives in email-signature-parser-helper.sh

### DIFF
--- a/.agents/scripts/email-signature-parser-helper.sh
+++ b/.agents/scripts/email-signature-parser-helper.sh
@@ -430,8 +430,7 @@ merge_toon_contact() {
 		esac
 	done <<<"$existing"
 
-	# Update last_seen (sed required: line-anchored replacement in multiline string)
-	# shellcheck disable=SC2001
+	# Update last_seen (here-string: line-anchored replacement in multiline string)
 	existing=$(sed "s/^  last_seen: .*/  last_seen: ${now}/" <<<"$existing")
 
 	# Detect field changes and build history entries
@@ -455,12 +454,10 @@ merge_toon_contact() {
       new: ${new_val}
       source: ${source}
 "
-			# Update the field in the existing record (sed required: line-anchored multiline replacement)
-			# shellcheck disable=SC2001
+			# Update the field in the existing record (here-string: line-anchored multiline replacement)
 			existing=$(sed "s|^  ${field_name}: .*|  ${field_name}: ${new_val}|" <<<"$existing")
 		elif [[ -z "$old_val" ]]; then
-			# Fill empty field (sed required: line-anchored multiline replacement)
-			# shellcheck disable=SC2001
+			# Fill empty field (here-string: line-anchored multiline replacement)
 			existing=$(sed "s|^  ${field_name}: $|  ${field_name}: ${new_val}|" <<<"$existing")
 		fi
 		return 0
@@ -494,7 +491,6 @@ ${history_entries}"
 	_field_line=$(echo "$existing" | grep -E "^  confidence: " || true)
 	existing_conf="${_field_line#  confidence: }"
 	if [[ "$confidence" == "high" && "$existing_conf" != "high" ]]; then
-		# shellcheck disable=SC2001
 		existing=$(sed "s/^  confidence: .*/  confidence: ${confidence}/" <<<"$existing")
 	fi
 


### PR DESCRIPTION
## Summary

- Removes 4 redundant `# shellcheck disable=SC2001` inline comments from `.agents/scripts/email-signature-parser-helper.sh` (lines ~433, ~458, ~460, ~493)
- Updates comment text from `sed required: ...` to `here-string: ...` to accurately reflect the pattern in use
- These directives were added in PR #5482 but are unnecessary: the sed patterns already use here-strings (`<<<`), and SC2001 is disabled globally in `.shellcheckrc`

## Addresses

Gemini review feedback from PR #5482 — 4 medium-severity findings at lines 435, 460, 464, 498.

## Verification

- `shellcheck` (project config) — zero violations (only expected SC1091 info)
- All 43 email-signature-parser tests pass (0 failures, 1 skipped)

Closes #5491