### PR TITLE
t5493: remove unused print_error stub from test-migrate-orphaned-supervisor.sh

### DIFF
--- a/tests/test-migrate-orphaned-supervisor.sh
+++ b/tests/test-migrate-orphaned-supervisor.sh
@@ -59,8 +59,6 @@ print_info() { echo "[INFO] $1"; }
 print_success() { echo "[SUCCESS] $1"; }
 # shellcheck disable=SC2329
 print_warning() { echo "[WARNING] $1"; }
-# shellcheck disable=SC2329
-print_error() { echo "[ERROR] $1"; }
 # _launchd_has_agent is defined in setup.sh; stub it for Linux tests
 # shellcheck disable=SC2329
 _launchd_has_agent() { return 1; }
@@ -84,7 +82,7 @@ sanitize_plugin_namespace() {
 	return 0
 }
 # Export stubs so sourced script can find them
-export -f print_info print_success print_warning print_error _launchd_has_agent
+export -f print_info print_success print_warning _launchd_has_agent
 export -f find_opencode_config create_backup_with_rotation should_overwrite_user_file
 export -f resolve_mcp_binary_path update_mcp_paths_in_opencode sanitize_plugin_namespace
 


### PR DESCRIPTION
## Summary

- Remove `print_error` stub function (lines 62-63) — not referenced by `migrations.sh`, confirmed via `grep`
- Remove `print_error` from the `export -f` command (line 87)

## Why

Gemini review on PR #5481 (line 63) flagged that `print_error` is dead code. The PR added a `# shellcheck disable=SC2329` directive, but since the function is genuinely unused by the sourced script, the correct fix is removal — not suppression.

All other stubs (`print_info`, `print_success`, `print_warning`, `_launchd_has_agent`, etc.) are verified as referenced by `migrations.sh` and are retained.

## Verification

- `shellcheck tests/test-migrate-orphaned-supervisor.sh` — zero violations
- All 9 functional tests pass (crontab test skips/hangs on macOS — pre-existing local env issue, unrelated to this change)

Closes #5493