### PR TITLE
t5494: remove legacy key mappings for contribution_watch and draft_responses

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -381,8 +381,7 @@ _legacy_key_to_dotpath() {
 	manage_claude_config) echo "integrations.manage_claude_config" ;;
 	supervisor_pulse) echo "orchestration.supervisor_pulse" ;;
 	repo_sync) echo "orchestration.repo_sync" ;;
-	contribution_watch) echo "orchestration.contribution_watch" ;;
-	draft_responses) echo "orchestration.draft_responses" ;;
+
 	session_greeting) echo "ui.session_greeting" ;;
 	safety_hooks) echo "safety.hooks_enabled" ;;
 	shell_aliases) echo "ui.shell_aliases" ;;

--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -381,7 +381,6 @@ _legacy_key_to_dotpath() {
 	manage_claude_config) echo "integrations.manage_claude_config" ;;
 	supervisor_pulse) echo "orchestration.supervisor_pulse" ;;
 	repo_sync) echo "orchestration.repo_sync" ;;
-
 	session_greeting) echo "ui.session_greeting" ;;
 	safety_hooks) echo "safety.hooks_enabled" ;;
 	shell_aliases) echo "ui.shell_aliases" ;;

--- a/setup.sh
+++ b/setup.sh
@@ -1522,7 +1522,7 @@ ST_PLIST
 	local cw_script="$HOME/.aidevops/agents/scripts/contribution-watch-helper.sh"
 	local cw_label="sh.aidevops.contribution-watch"
 	local cw_state="$HOME/.aidevops/cache/contribution-watch.json"
-	if [[ -x "$cw_script" ]] && is_feature_enabled contribution_watch 2>/dev/null && command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+	if [[ -x "$cw_script" ]] && is_feature_enabled orchestration.contribution_watch 2>/dev/null && command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
 		mkdir -p "$HOME/.aidevops/cache" "$HOME/.aidevops/logs"
 
 		# Auto-seed on first run (populates state file with existing contributions)
@@ -1612,7 +1612,7 @@ CW_PLIST
 	# repo for GitHub notification-driven approval flow.
 	# Respects config: aidevops config set orchestration.draft_responses false
 	local dr_script="$HOME/.aidevops/agents/scripts/draft-response-helper.sh"
-	if [[ -x "$dr_script" ]] && is_feature_enabled draft_responses 2>/dev/null && is_feature_enabled contribution_watch 2>/dev/null && command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+	if [[ -x "$dr_script" ]] && is_feature_enabled orchestration.draft_responses 2>/dev/null && is_feature_enabled orchestration.contribution_watch 2>/dev/null && command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
 		mkdir -p "$HOME/.aidevops/.agent-workspace/draft-responses"
 		if bash "$dr_script" init >/dev/null 2>&1; then
 			print_info "Draft responses ready (private repo + local drafts)"


### PR DESCRIPTION
## Summary

- Remove `contribution_watch` and `draft_responses` from `_legacy_key_to_dotpath` in `config-helper.sh` — these were new features introduced with namespaced keys in PR #5466, not old flat keys needing backward-compat mapping
- Update `setup.sh` to call `is_feature_enabled` with the full dotpath (`orchestration.contribution_watch`, `orchestration.draft_responses`) directly, eliminating the need for the legacy mapping

## Findings addressed

Medium-severity finding from Gemini code review on PR #5466:
- `config-helper.sh:384` — `contribution_watch` added to `_legacy_key_to_dotpath` for a new feature; legacy mappings are for backward compatibility with old flat keys, not new namespaced features. Same pattern applied to `draft_responses` at line 385.

## Verification

- ShellCheck: 0 violations on `config-helper.sh` and `setup.sh`
- `is_feature_enabled orchestration.contribution_watch` resolves correctly via the dotpath lookup path (no legacy mapping needed)

Closes #5494