### PR TITLE
GH#5495: Use config-aware log_dir and namespaced key for contribution-watch

### DIFF
--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -381,7 +381,6 @@ _legacy_key_to_dotpath() {
 	manage_claude_config) echo "integrations.manage_claude_config" ;;
 	supervisor_pulse) echo "orchestration.supervisor_pulse" ;;
 	repo_sync) echo "orchestration.repo_sync" ;;
-	contribution_watch) echo "orchestration.contribution_watch" ;;
 	session_greeting) echo "ui.session_greeting" ;;
 	safety_hooks) echo "safety.hooks_enabled" ;;
 	shell_aliases) echo "ui.shell_aliases" ;;

--- a/setup.sh
+++ b/setup.sh
@@ -1522,8 +1522,16 @@ ST_PLIST
 	local cw_script="$HOME/.aidevops/agents/scripts/contribution-watch-helper.sh"
 	local cw_label="sh.aidevops.contribution-watch"
 	local cw_state="$HOME/.aidevops/cache/contribution-watch.json"
-	if [[ -x "$cw_script" ]] && is_feature_enabled contribution_watch 2>/dev/null && command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
-		mkdir -p "$HOME/.aidevops/cache" "$HOME/.aidevops/logs"
+	if [[ -x "$cw_script" ]] && is_feature_enabled orchestration.contribution_watch 2>/dev/null && command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+		# Resolve log directory from config (respects paths.log_dir customisation)
+		local cw_log_dir
+		if type config_get &>/dev/null; then
+			cw_log_dir=$(config_get "paths.log_dir" "$HOME/.aidevops/logs")
+			cw_log_dir="${cw_log_dir/#\~/$HOME}"
+		else
+			cw_log_dir="$HOME/.aidevops/logs"
+		fi
+		mkdir -p "$HOME/.aidevops/cache" "$cw_log_dir"
 
 		# Auto-seed on first run (populates state file with existing contributions)
 		if [[ ! -f "$cw_state" ]]; then
@@ -1539,9 +1547,10 @@ ST_PLIST
 		if [[ "$(uname -s)" == "Darwin" ]]; then
 			local cw_plist="$HOME/Library/LaunchAgents/${cw_label}.plist"
 
-			local _xml_cw_script _xml_cw_home
+			local _xml_cw_script _xml_cw_home _xml_cw_log_dir
 			_xml_cw_script=$(_xml_escape "$cw_script")
 			_xml_cw_home=$(_xml_escape "$HOME")
+			_xml_cw_log_dir=$(_xml_escape "$cw_log_dir")
 
 			local cw_plist_content
 			cw_plist_content=$(
@@ -1561,9 +1570,9 @@ ST_PLIST
 	<key>StartInterval</key>
 	<integer>3600</integer>
 	<key>StandardOutPath</key>
-	<string>${_xml_cw_home}/.aidevops/logs/contribution-watch.log</string>
+	<string>${_xml_cw_log_dir}/contribution-watch.log</string>
 	<key>StandardErrorPath</key>
-	<string>${_xml_cw_home}/.aidevops/logs/contribution-watch.log</string>
+	<string>${_xml_cw_log_dir}/contribution-watch.log</string>
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
@@ -1593,11 +1602,12 @@ CW_PLIST
 			fi
 		else
 			# Linux: cron entry (hourly)
-			local _cron_cw_script
+			local _cron_cw_script _cron_cw_log_dir
 			_cron_cw_script=$(_cron_escape "$cw_script")
+			_cron_cw_log_dir=$(_cron_escape "$cw_log_dir")
 			(
 				crontab -l 2>/dev/null | grep -v 'aidevops: contribution-watch'
-				echo "0 * * * * /bin/bash ${_cron_cw_script} scan >> \"\$HOME/.aidevops/logs/contribution-watch.log\" 2>&1 # aidevops: contribution-watch"
+				echo "0 * * * * /bin/bash ${_cron_cw_script} scan >> \"${_cron_cw_log_dir}/contribution-watch.log\" 2>&1 # aidevops: contribution-watch"
 			) | crontab - 2>/dev/null || true
 			if crontab -l 2>/dev/null | grep -qF "aidevops: contribution-watch" 2>/dev/null; then
 				print_info "Contribution watch enabled (cron, hourly scan)"


### PR DESCRIPTION
## Summary

- Resolves log directory from `paths.log_dir` config setting instead of hardcoding `~/.aidevops/logs/` in contribution-watch launchd plist and cron job
- Uses namespaced `orchestration.contribution_watch` key directly instead of flat `contribution_watch` legacy key
- Removes unnecessary legacy key mapping from `config-helper.sh`

## Root Cause

PR #5466 introduced contribution-watch auto-install with hardcoded log paths that bypass the `paths.log_dir` configuration setting, and added an unnecessary legacy key mapping for a brand-new feature.

## What Changed

| File | Change |
|------|--------|
| `setup.sh` | Read `paths.log_dir` from config (with fallback), use resolved path in launchd plist and cron entry, use namespaced `orchestration.contribution_watch` key |
| `.agents/scripts/config-helper.sh` | Remove `contribution_watch` legacy key mapping (no legacy users exist for this new feature) |

## Verification

- ShellCheck: 0 violations on both modified files
- `config_get` availability is checked before use (`type config_get &>/dev/null`)
- Tilde expansion handled (`${cw_log_dir/#\~/$HOME}`)
- XML-escaped for plist safety (`_xml_escape`)
- Cron-escaped for cron safety (`_cron_escape`)
- `is_feature_enabled` handles dotpath keys via the `*) echo "$key" ;;` passthrough in `_legacy_key_to_dotpath`

Closes #5495