### PR TITLE
GH#5508: Simplify draft_responses feature flag to default-true pattern

### DIFF
--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -717,9 +717,9 @@ cmd_scan() {
 	# Drafts are stored locally and NEVER posted without explicit user approval.
 	local _draft_helper
 	_draft_helper="${SCRIPT_DIR}/draft-response-helper.sh"
-	local _draft_enabled=false
-	if ! type is_feature_enabled &>/dev/null || is_feature_enabled draft_responses 2>/dev/null; then
-		_draft_enabled=true
+	local _draft_enabled=true
+	if type is_feature_enabled &>/dev/null && ! is_feature_enabled draft_responses 2>/dev/null; then
+		_draft_enabled=false
 	fi
 	if [[ "$auto_draft" == "true" && "$_draft_enabled" == "true" && "$needs_attention" -gt 0 && -x "$_draft_helper" ]]; then
 		local _draft_keys


### PR DESCRIPTION
## Summary

- Flips `_draft_enabled` logic from default-false-then-set-true to default-true-then-set-false per Gemini review suggestion on PR #5500
- Makes the "enabled by default" intent explicit — only disables when the feature flag system exists AND explicitly disables `draft_responses`
- Logically equivalent transformation (De Morgan's law: `!A || B` ≡ `!(A && !B)`)

## Changes

**`.agents/scripts/contribution-watch-helper.sh:720-723`**

Before:
```bash
local _draft_enabled=false
if ! type is_feature_enabled &>/dev/null || is_feature_enabled draft_responses 2>/dev/null; then
    _draft_enabled=true
fi
```

After:
```bash
local _draft_enabled=true
if type is_feature_enabled &>/dev/null && ! is_feature_enabled draft_responses 2>/dev/null; then
    _draft_enabled=false
fi
```

## Verification

- ShellCheck: clean (only SC1091 info about external source, pre-existing)
- Logic equivalence verified via De Morgan's law

Closes #5508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated auto-draft generation to be enabled by default when using the `--auto-draft` flag, with improved handling of feature settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->