### PR TITLE
fix(GH#5511): capture gh api error output in draft-response subscription warning

### DIFF
--- a/.agents/scripts/draft-response-helper.sh
+++ b/.agents/scripts/draft-response-helper.sh
@@ -149,9 +149,10 @@ _ensure_draft_repo() {
 	gh label create "declined" --repo "$slug" --description "Declined" --color "B60205" 2>/dev/null || true
 
 	# Watch the repo so issue creation triggers GitHub notifications
-	if ! gh api "repos/${slug}/subscription" --method PUT \
-		--input - <<<'{"subscribed":true,"ignored":false}' >/dev/null 2>&1; then
-		_log_warn "Failed to subscribe to repository ${slug} for notifications"
+	local gh_output
+	if ! gh_output=$(gh api "repos/${slug}/subscription" --method PUT \
+		--input - <<<'{"subscribed":true,"ignored":false}' 2>&1); then
+		_log_warn "Failed to subscribe to repository ${slug} for notifications: ${gh_output}"
 	fi
 
 	_log_info "Created private repo: ${slug}"


### PR DESCRIPTION
## Summary

- Captures `gh api` error output in `gh_output` variable instead of discarding with `>/dev/null 2>&1`
- Includes the captured error in the `_log_warn` message for easier debugging when the subscription call fails
- No functional behaviour change — subscription failure is still non-fatal (warning only)

## Change

**Before:**
```bash
if ! gh api "repos/${slug}/subscription" --method PUT \
    --input - <<<'{"subscribed":true,"ignored":false}' >/dev/null 2>&1; then
    _log_warn "Failed to subscribe to repository ${slug} for notifications"
fi
```

**After:**
```bash
local gh_output
if ! gh_output=$(gh api "repos/${slug}/subscription" --method PUT \
    --input - <<<'{"subscribed":true,"ignored":false}' 2>&1); then
    _log_warn "Failed to subscribe to repository ${slug} for notifications: ${gh_output}"
fi
```

## Verification

- `shellcheck` passes (only pre-existing SC1091 info, no new issues)
- Implements Gemini review suggestion from PR #5496 discussion

Closes #5511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for repository notification subscription failures by capturing and displaying detailed diagnostic information to aid in troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->