### PR TITLE
t5508: default _draft_enabled to true, only disable when explicitly off

### DIFF
--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -717,9 +717,9 @@ cmd_scan() {
 	# Drafts are stored locally and NEVER posted without explicit user approval.
 	local _draft_helper
 	_draft_helper="${SCRIPT_DIR}/draft-response-helper.sh"
-	local _draft_enabled=false
-	if ! type is_feature_enabled &>/dev/null || is_feature_enabled draft_responses 2>/dev/null; then
-		_draft_enabled=true
+	local _draft_enabled=true
+	if type is_feature_enabled &>/dev/null && ! is_feature_enabled draft_responses 2>/dev/null; then
+		_draft_enabled=false
 	fi
 	if [[ "$auto_draft" == "true" && "$_draft_enabled" == "true" && "$needs_attention" -gt 0 && -x "$_draft_helper" ]]; then
 		local _draft_keys


### PR DESCRIPTION
## Summary

- Applies Gemini's follow-up suggestion from PR #5500 review (GH#5508): flips `_draft_enabled` logic from initializing `false` and conditionally setting `true`, to defaulting `true` and only setting `false` when the `draft_responses` feature is explicitly disabled
- Makes the enabling condition the default (feature is on unless turned off), and the disabling condition explicit — improving readability and intent clarity
- Zero new ShellCheck violations

## Change

**Before** (initialize false, set true when enabled):
```bash
local _draft_enabled=false
if ! type is_feature_enabled &>/dev/null || is_feature_enabled draft_responses 2>/dev/null; then
    _draft_enabled=true
fi
```

**After** (default true, set false only when explicitly disabled):
```bash
local _draft_enabled=true
if type is_feature_enabled &>/dev/null && ! is_feature_enabled draft_responses 2>/dev/null; then
    _draft_enabled=false
fi
```

The semantics are identical — `draft_responses` defaults to `true` in `aidevops.defaults.jsonc`, so the feature is enabled unless explicitly turned off. The new form makes this "default on" intent visible in the code.

Closes #5508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-draft feature is now enabled by default with updated gating logic for draft response creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->