### PR TITLE
t1556: Fix self-consumption loop guard in check-approvals

### DIFF
--- a/.agents/scripts/draft-response-helper.sh
+++ b/.agents/scripts/draft-response-helper.sh
@@ -743,18 +743,22 @@ cmd_check_approvals() {
 			echo "    Note: additional action requested — ${action_extra} (queued for interactive session)"
 		fi
 
-		# Persist last_handled_comment timestamp to prevent reprocessing
-		# agent follow-up comments on the next scan cycle.
-		# CRITICAL: This breaks the self-consumption loop — without it, every
-		# hourly scan would re-trigger an LLM call on the same comment.
-		if [[ -n "$latest_user_comment_time" ]]; then
-			local updated_meta
-			updated_meta=$(_read_meta "$draft_id")
-			updated_meta=$(echo "$updated_meta" | jq \
-				--arg ts "$latest_user_comment_time" \
-				'.last_handled_comment = $ts')
-			_write_meta "$draft_id" "$updated_meta"
-		fi
+		# Persist last_handled_comment timestamp to prevent reprocessing.
+		# CRITICAL: Use the current time (after the action), not the user's
+		# comment time. Actions like cmd_approve post follow-up comments
+		# (e.g., "Reply posted.") under the user's auth — those comments
+		# have timestamps AFTER the user's comment. If we only set the
+		# cutoff to the user's comment time, the agent's own follow-up
+		# would be picked up as a "new user comment" on the next scan,
+		# causing an infinite self-consumption loop.
+		local post_action_time
+		post_action_time=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+		local updated_meta
+		updated_meta=$(_read_meta "$draft_id")
+		updated_meta=$(echo "$updated_meta" | jq \
+			--arg ts "$post_action_time" \
+			'.last_handled_comment = $ts')
+		_write_meta "$draft_id" "$updated_meta"
 	done < <(echo "$open_issues" | jq -c '.[]')
 
 	echo "check-approvals complete: ${actions_taken} action(s) taken from ${issue_count} issue(s)."


### PR DESCRIPTION
## Summary

- Fixes the CRITICAL CodeRabbit finding from PR #5517: the `check-approvals` comment matcher could reconsume the agent's own follow-up comments, causing an infinite LLM call loop on every hourly scan

## Root cause

The `last_handled_comment` cutoff was set to the user's comment timestamp (`latest_user_comment_time`). But actions like `cmd_approve` post follow-up comments (e.g., "Reply posted." via `gh issue close --comment`) under the user's auth — those comments have timestamps AFTER the user's comment. On the next scan, the agent's own follow-up would be newer than the cutoff and picked up as a "new user comment", triggering another LLM interpretation call.

## Fix

Set `last_handled_comment` to the current time (`date -u`) after the action completes, ensuring any agent-posted comments are also covered by the cutoff. This is a single-line semantic change (timestamp source) with no behavioral change to the happy path.

## Verification

- ShellCheck: 0 new violations
- The fix is a timestamp source change — no new code paths, no new dependencies
- The `approve`/`reject` paths close the issue (removing it from the open issues list), so the loop guard primarily protects the `redraft` path where the issue stays open

Closes #5516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved approval handling logic to prevent the agent from re-processing its own follow-up comments as new user input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->