### PR TITLE
fix: prevent shellcheck-wrapper infinite recursion on Ubuntu (GH#5526)

### DIFF
--- a/.agents/scripts/shellcheck-wrapper.sh
+++ b/.agents/scripts/shellcheck-wrapper.sh
@@ -29,6 +29,19 @@
 
 set -uo pipefail
 
+# --- Recursion guard ---
+# When setup.sh replaces the real shellcheck binary with this wrapper AND the
+# PATH shim also points to this wrapper, _find_real_shellcheck can mistake one
+# copy for the "real" binary (different realpath, same content). Each copy then
+# invokes the other, creating an infinite fork loop where every process hits the
+# 120s watchdog timeout. The env var breaks the cycle: if we're already inside
+# a wrapper, skip the search and run the real binary directly.
+if [[ "${_SHELLCHECK_WRAPPER_ACTIVE:-}" == "1" ]]; then
+	echo "shellcheck-wrapper: ERROR: recursive invocation detected — cannot find real shellcheck" >&2
+	exit 1
+fi
+export _SHELLCHECK_WRAPPER_ACTIVE=1
+
 # --- Validation ---
 # Validate that a value is a positive integer; coerce invalid/too-small values
 # to a safe default and log a warning. Prevents tight loops or premature aborts
@@ -62,6 +75,28 @@ readonly BACKOFF_FILE="${BACKOFF_DIR}/shellcheck-backoff"
 readonly MAX_BACKOFF=300 # 5 minutes max backoff
 
 # --- Find the real ShellCheck binary ---
+# Check if a candidate is a copy of this wrapper (not the real shellcheck).
+# The real shellcheck is a compiled binary (ELF/Mach-O); this wrapper is a
+# shell script. Checking the first bytes avoids the infinite recursion where
+# two copies of the wrapper each treat the other as the "real" binary.
+_is_wrapper_copy() {
+	local candidate="$1"
+	# Real shellcheck is a compiled binary — first bytes are ELF magic (\x7fELF)
+	# or Mach-O magic. Shell scripts start with "#!" (shebang).
+	# A 2-byte read is sufficient to distinguish.
+	local header
+	header="$(head -c 2 "$candidate" 2>/dev/null)" || return 1
+	if [[ "$header" == "#!" ]]; then
+		# It's a script — check if it's specifically our wrapper
+		if head -5 "$candidate" 2>/dev/null | grep -q "shellcheck-wrapper" 2>/dev/null; then
+			return 0 # yes, it's a wrapper copy
+		fi
+		# Some other shell script named shellcheck — still not the real binary
+		return 0
+	fi
+	return 1 # not a script, likely the real binary
+}
+
 _find_real_shellcheck() {
 	local real_path="${SHELLCHECK_REAL_PATH:-}"
 
@@ -83,14 +118,14 @@ _find_real_shellcheck() {
 
 	# Fast path: check common .real locations before PATH scanning
 	local loc
-	for loc in /opt/homebrew/bin/shellcheck.real /usr/local/bin/shellcheck.real; do
+	for loc in /opt/homebrew/bin/shellcheck.real /usr/local/bin/shellcheck.real /usr/bin/shellcheck.real; do
 		if [[ -x "$loc" ]]; then
 			printf '%s' "$loc"
 			return 0
 		fi
 	done
 
-	# Slow path: search PATH, skipping this wrapper script
+	# Slow path: search PATH, skipping this wrapper script and any copies of it
 	local self
 	self="$(realpath "${BASH_SOURCE[0]}" 2>/dev/null || readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")"
 
@@ -100,7 +135,7 @@ _find_real_shellcheck() {
 		if [[ -x "$candidate" ]]; then
 			local resolved
 			resolved="$(realpath "$candidate" 2>/dev/null || readlink -f "$candidate" 2>/dev/null || echo "$candidate")"
-			if [[ "$resolved" != "$self" ]]; then
+			if [[ "$resolved" != "$self" ]] && ! _is_wrapper_copy "$candidate"; then
 				printf '%s' "$candidate"
 				return 0
 			fi
@@ -112,7 +147,7 @@ _find_real_shellcheck() {
 		if [[ -x "$loc" ]]; then
 			local resolved
 			resolved="$(realpath "$loc" 2>/dev/null || readlink -f "$loc" 2>/dev/null || echo "$loc")"
-			if [[ "$resolved" != "$self" ]]; then
+			if [[ "$resolved" != "$self" ]] && ! _is_wrapper_copy "$loc"; then
 				printf '%s' "$loc"
 				return 0
 			fi


### PR DESCRIPTION
## Summary

Fixes the infinite loop during `setup.sh` on Ubuntu 24.04 where the shellcheck-wrapper spawns processes that get killed by the watchdog after 120s timeout, creating an infinite fork loop.

Closes #5526

## Root Cause

When `setup.sh` runs `setup_shellcheck_wrapper` (from `tool-install.sh`), it replaces the real shellcheck binary (e.g., `/usr/bin/shellcheck`) with a copy of the wrapper script and moves the real binary to `/usr/bin/shellcheck.real`. Simultaneously, the PATH shim at `~/.aidevops/bin/shellcheck` is a symlink to the wrapper source at `~/.aidevops/agents/scripts/shellcheck-wrapper.sh`.

The `_find_real_shellcheck()` function uses `realpath` for self-detection, but the two wrapper copies resolve to different absolute paths:
- Shim symlink resolves to `~/.aidevops/agents/scripts/shellcheck-wrapper.sh`
- Binary replacement resolves to `/usr/bin/shellcheck`

Neither copy recognizes the other as "self", so each returns the other as the "real shellcheck", creating mutual infinite recursion. Each level spawns a background watchdog, and after 120s the watchdog kills the child — producing the flood of `WATCHDOG: killing PID` messages reported in the issue.

## Fix (3 defense layers)

1. **Recursion guard** — Environment variable `_SHELLCHECK_WRAPPER_ACTIVE=1` is set on entry. If already set, the wrapper exits immediately with an error instead of searching for the real binary. This is the primary fix that breaks the infinite loop.

2. **Content-based detection** — New `_is_wrapper_copy()` function checks the first 2 bytes of candidate binaries. The real shellcheck is a compiled Haskell binary (ELF/Mach-O magic bytes); wrapper copies start with `#!` (shebang). Any shell script named `shellcheck` is skipped during PATH scanning.

3. **Added `/usr/bin/shellcheck.real` to fast-path** — The existing fast-path only checked `/opt/homebrew/bin/` and `/usr/local/bin/` locations. Ubuntu installs shellcheck at `/usr/bin/`, so the `.real` file there was never found via fast-path, forcing the slow PATH scan where the recursion bug lives.

## Testing

- Verified wrapper still finds and runs real shellcheck: `shellcheck-wrapper.sh --version` → success
- Verified recursion guard blocks re-entry: `_SHELLCHECK_WRAPPER_ACTIVE=1 shellcheck-wrapper.sh --version` → error + exit 1
- Simulated the Ubuntu scenario (wrapper copy on PATH + symlink shim) → correctly finds `.real` binary, no recursion
- Simulated edge case (no `.real` file, wrapper copies on PATH) → correctly skips copies, finds real binary on system PATH
- ShellCheck clean: zero violations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a recursion issue in the shellcheck wrapper that could cause execution errors. Enhanced wrapper detection to accurately distinguish between wrapper copies and actual shellcheck binaries, preventing infinite loops during script analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->