### PR TITLE
refactor: move auth troubleshooting to subagent, pointer in AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -284,6 +284,7 @@ Read subagents on-demand. Full index: `subagent-index.toon`.
 | Email | `tools/ui/react-email.md`, `services/email/email-agent.md`, `services/email/email-mailbox.md`, `services/email/email-actions.md`, `services/email/email-intelligence.md`, `services/email/email-providers.md`, `services/email/email-security.md`, `services/email/email-testing.md`, `services/email/email-composition.md`, `services/email/email-inbound-commands.md`, `services/email/google-workspace.md` |
 | Outreach | `services/outreach/cold-outreach.md`, `services/outreach/smartlead.md`, `services/outreach/instantly.md`, `services/outreach/manyreach.md` |
 | Payments | `services/payments/revenuecat.md`, `services/payments/stripe.md`, `services/payments/procurement.md` |
+| Auth troubleshooting | `tools/credentials/auth-troubleshooting.md` |
 | Security/Encryption | `tools/security/tirith.md`, `tools/security/opsec.md`, `tools/security/prompt-injection-defender.md`, `tools/security/tamper-evident-audit.md`, `tools/credentials/encryption-stack.md` |
 | Database/Local-first | `tools/database/pglite-local-first.md`, `services/database/postgres-drizzle-skill.md` |
 | Vector Search | `tools/database/vector-search.md`, `tools/database/vector-search/zvec.md` |
@@ -316,36 +317,7 @@ Key capabilities (details in `reference/orchestration.md`, `reference/services.m
 - **Browser**: Playwright, dev-browser (persistent login)
 - **Quality**: Write-time per-edit linting → `linters-local.sh` → `/pr review` → `/postflight`. Fix violations at edit time, not commit time. See `prompts/build.txt` "Write-Time Quality Enforcement". Bundle `skip_gates` filter irrelevant checks per project type.
 - **Sessions**: `/session-review`, `/checkpoint`, compaction resilience
-
-## Auth Troubleshooting
-
-If a user reports **"Key Missing"**, **auth errors**, or the model not responding, all recovery commands work from the terminal without a working model session. Direct them to run these in order:
-
-```bash
-aidevops update                                  # ensure latest version first
-aidevops model-accounts-pool status              # 1. pool health at a glance
-aidevops model-accounts-pool check               # 2. live token validity per account
-aidevops model-accounts-pool rotate anthropic    # 3. switch account if rate-limited
-aidevops model-accounts-pool reset-cooldowns     # 4. clear cooldowns if all accounts stuck
-aidevops model-accounts-pool add anthropic       # 5. re-add account if pool empty
-```
-
-**Symptom → command mapping:**
-
-| Symptom | Command |
-|---------|---------|
-| `rate-limited` in status | `rotate anthropic` |
-| All accounts in cooldown | `reset-cooldowns` |
-| `auth-error` in status | `add anthropic` (re-auth via browser) |
-| Pool empty | `add anthropic` or `import claude-cli` |
-| Re-authed but still broken | `assign-pending anthropic` |
-| Error affects all providers | `reset-cooldowns all` then `check` |
-
-**Key facts for diagnosis:**
-- `rotate` switches the active account in `auth.json` immediately — no restart needed for the pool file, but OpenCode must restart to pick up the new token
-- `reset-cooldowns` clears the pool file cooldowns; the in-memory token endpoint cooldown in a running OpenCode process requires a restart or `/model-accounts-pool reset-cooldowns` inside an active session
-- Pool file: `~/.aidevops/oauth-pool.json` — if corrupt or missing, `add` recreates it
-- The error "Key Missing" means the loader returned `{}` — either pool is empty, all tokens expired/errored, or OpenCode's auth state was reset
+- **Auth recovery**: if model is broken or "Key Missing" → read `tools/credentials/auth-troubleshooting.md`
 
 ## Security
 

--- a/.agents/tools/credentials/auth-troubleshooting.md
+++ b/.agents/tools/credentials/auth-troubleshooting.md
@@ -1,0 +1,51 @@
+# Auth Troubleshooting
+
+Use this when a user reports "Key Missing", auth errors, or the model has stopped responding.
+
+All recovery commands work from any terminal — no working model session required.
+
+## Recovery flow (run in order)
+
+```bash
+aidevops update                                   # ensure latest version first
+aidevops model-accounts-pool status               # 1. pool health at a glance
+aidevops model-accounts-pool check                # 2. live token validity per account
+aidevops model-accounts-pool rotate anthropic     # 3. switch account if rate-limited
+aidevops model-accounts-pool reset-cooldowns      # 4. clear cooldowns if all accounts stuck
+aidevops model-accounts-pool add anthropic        # 5. re-add account if pool empty
+```
+
+## Symptom → command
+
+| Symptom | Command |
+|---------|---------|
+| `rate-limited` in status | `rotate anthropic` |
+| All accounts in cooldown | `reset-cooldowns` |
+| `auth-error` in status | `add anthropic` (re-auth via browser) |
+| Pool empty (no accounts) | `add anthropic` or `import claude-cli` |
+| Re-authed but still broken | `assign-pending anthropic` |
+| Error affects all providers | `reset-cooldowns all` then `check` |
+
+## Full command reference
+
+```bash
+aidevops model-accounts-pool status               # aggregate counts per provider
+aidevops model-accounts-pool list                 # per-account detail + expiry
+aidevops model-accounts-pool check                # live API validity test
+aidevops model-accounts-pool rotate [provider]    # switch to next available account NOW
+aidevops model-accounts-pool reset-cooldowns      # clear rate-limit cooldowns (pool file)
+aidevops model-accounts-pool assign-pending <p>   # assign stranded pending token
+aidevops model-accounts-pool add anthropic        # Claude Pro/Max — browser OAuth
+aidevops model-accounts-pool add openai           # ChatGPT Plus/Pro — browser OAuth
+aidevops model-accounts-pool add cursor           # Cursor Pro — reads from local IDE
+aidevops model-accounts-pool import claude-cli    # import from existing Claude CLI auth
+aidevops model-accounts-pool remove <p> <email>   # remove an account
+```
+
+## Key diagnostic facts
+
+- `rotate` writes the new account into `auth.json` immediately — OpenCode must restart to pick it up
+- `reset-cooldowns` clears the **pool file** cooldowns only; the in-memory token endpoint cooldown in a running OpenCode process requires a restart or `/model-accounts-pool reset-cooldowns` inside an active session
+- Pool file: `~/.aidevops/oauth-pool.json` — if corrupt or missing, `add` recreates it
+- "Key Missing" means the loader returned `{}`: pool is empty, all tokens expired/errored, or OpenCode's auth state was reset
+- `assign-pending` is needed when OAuth completes but the email lookup fails — the token is saved as `_pending_<provider>` and stranded until assigned


### PR DESCRIPTION
Inline 30-line troubleshooting block in AGENTS.md only loads when something is broken — wrong place for it. Move to `tools/credentials/auth-troubleshooting.md` and replace with a single pointer line + Domain Index entry, consistent with the progressive disclosure pattern used throughout the framework.