### PR TITLE
GH#5530: fix: kill process group in timeout_sec() macOS fallback

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -214,20 +214,29 @@ timeout_sec() {
 		gtimeout "$secs" "$@"
 		return $?
 	else
-		# macOS fallback: background the command and kill after deadline.
-		# The perl alarm approach (perl -e 'alarm shift; exec @ARGV') is fragile:
-		# SIGALRM may not kill child processes that trap or ignore signals (e.g.,
-		# Node MCP servers). Using background + kill is more reliable.
+		# macOS fallback: background the command in a new process group and kill
+		# the entire group after the deadline. Using set -m puts each background
+		# job in its own process group (PGID == child PID), so kill -- -PGID
+		# terminates the child and all its descendants — not just the direct child.
+		#
+		# GH#5530: the previous implementation used kill "$cmd_pid" which only
+		# killed the direct child. Wrapper processes (e.g., bash sandbox-exec-helper.sh)
+		# survived because they are parents of the killed process, not children.
+		set -m
 		"$@" &
 		local cmd_pid=$!
+		set +m
+		# PGID equals the PID of the process group leader (the background job)
+		local cmd_pgid="$cmd_pid"
 		# Poll every 0.5s; count half-seconds to avoid floating-point math
 		local half_secs_remaining=$((secs * 2))
 		while kill -0 "$cmd_pid" 2>/dev/null; do
 			if ((half_secs_remaining <= 0)); then
-				kill -TERM "$cmd_pid" # SIGTERM (15) — graceful shutdown
+				# Kill the entire process group: SIGTERM first, then SIGKILL
+				kill -TERM -- "-${cmd_pgid}" 2>/dev/null || true # SIGTERM (15) — graceful
 				sleep 0.2
-				if kill -0 "$cmd_pid" 2>/dev/null; then
-					kill -KILL "$cmd_pid" || true # SIGKILL (9) — hard kill
+				if kill -0 -- "-${cmd_pgid}" 2>/dev/null; then
+					kill -KILL -- "-${cmd_pgid}" 2>/dev/null || true # SIGKILL (9) — hard kill
 				fi
 				wait "$cmd_pid" 2>/dev/null || true
 				return 124 # Normalise to GNU timeout convention

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -222,10 +222,15 @@ timeout_sec() {
 		# GH#5530: the previous implementation used kill "$cmd_pid" which only
 		# killed the direct child. Wrapper processes (e.g., bash sandbox-exec-helper.sh)
 		# survived because they are parents of the killed process, not children.
+		#
+		# Save whether monitor mode was already active before enabling it, so we
+		# can restore the original shell state rather than unconditionally disabling it.
+		local monitor_was_enabled=false
+		[[ $- == *m* ]] && monitor_was_enabled=true
 		set -m
 		"$@" &
 		local cmd_pid=$!
-		set +m
+		$monitor_was_enabled || set +m
 		# PGID equals the PID of the process group leader (the background job)
 		local cmd_pgid="$cmd_pid"
 		# Poll every 0.5s; count half-seconds to avoid floating-point math

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -230,7 +230,8 @@ timeout_sec() {
 		set -m
 		"$@" &
 		local cmd_pid=$!
-		$monitor_was_enabled || set +m
+		# Restore monitor mode to its original state (set -m or set +m as appropriate)
+		$monitor_was_enabled && set -m || set +m
 		# PGID equals the PID of the process group leader (the background job)
 		local cmd_pgid="$cmd_pid"
 		# Poll every 0.5s; count half-seconds to avoid floating-point math


### PR DESCRIPTION
## Summary

- Fixes the macOS fallback in `timeout_sec()` (`shared-constants.sh`) to kill the entire process group instead of just the direct child PID
- Completes the fix for GH#5530 — the `sandbox-exec-helper.sh` portion was already merged via PR #5531, this applies the remaining `shared-constants.sh` portion that was in PR #5532 (closed due to merge conflicts)

## Root Cause

The macOS fallback path in `timeout_sec()` used `kill "$cmd_pid"` which only kills the direct child. When the timed-out command spawns its own children (MCP servers, node workers), those grandchildren survive and keep the parent wrapper alive indefinitely — workers ran 7-9h past the 1h timeout.

## Fix

- Use `set -m` to put the background job in its own process group (PGID == child PID)
- Use `kill -- -PGID` to send SIGTERM/SIGKILL to the entire process group
- This matches the approach already applied to `sandbox-exec-helper.sh` in PR #5531

## Verification

- ShellCheck: zero violations on `shared-constants.sh`
- Diff matches exactly what PR #5532 proposed for this file

Closes #5530