### PR TITLE
fix: pool injection idle status + headless dispatch timing race

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -1113,12 +1113,8 @@ export async function AidevopsPlugin({ directory, client }) {
   // Phase 6: Initialise LLM observability (t1308)
   initObservability();
 
-  // Phase 7: OAuth pool — seed auth entries so providers appear in connect dialog (t1543, t1548, t1549)
-  await initPoolAuth(client);
-
   // Phase 8: Cursor gRPC proxy (t1551)
-  // Start the gRPC proxy if Cursor accounts exist in the pool.
-  // This runs after initPoolAuth so pool tokens are already seeded.
+  // Started after config hook runs (which calls initPoolAuth), so pool tokens are seeded.
   // The proxy translates OpenAI-compatible requests to Cursor's protobuf/HTTP2 protocol.
   let cursorProxyResult = null;
   const cursorAccounts = getAccounts("cursor");
@@ -1142,8 +1138,14 @@ export async function AidevopsPlugin({ directory, client }) {
   baseTools["model-accounts-pool"] = createPoolTool(client);
 
   return {
-    // Phase 1+2: Lightweight agent index + MCP registration
-    config: async (config) => configHook(config),
+    // Phase 1+2+7: Agent index, MCP registration, and OAuth pool injection.
+    // initPoolAuth runs here (inside OpenCode's config phase) so tokens are
+    // written to auth.json before the first provider call — fixes headless
+    // dispatch race condition where injection arrived after the first API call.
+    config: async (config) => {
+      await initPoolAuth(client);
+      return configHook(config);
+    },
 
     // Phase 1+7: Custom tools (extracted to tools.mjs) + pool management (t1543)
     tool: baseTools,

--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -1304,15 +1304,24 @@ export async function injectPoolToken(client, skipEmail) {
   const accounts = getAccounts("anthropic");
   if (accounts.length === 0) return false;
 
-  // Pick least-recently-used account, optionally skipping one
+  // Pick least-recently-used account, optionally skipping one.
+  // Accept both "active" and "idle" — idle accounts are valid (cooldowns cleared).
+  const now = Date.now();
   let account = null;
   const sorted = [...accounts]
-    .filter((a) => a.status === "active" && a.email !== skipEmail)
+    .filter(
+      (a) =>
+        (a.status === "active" || a.status === "idle") &&
+        a.email !== skipEmail &&
+        (!a.cooldownUntil || a.cooldownUntil <= now),
+    )
     .sort((a, b) => new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0));
 
   if (sorted.length === 0) {
-    // All accounts skipped or inactive — try any active account
-    account = accounts.find((a) => a.status === "active");
+    // All accounts skipped or in cooldown — try any active/idle account as last resort
+    account = accounts.find(
+      (a) => a.status === "active" || a.status === "idle",
+    );
   } else {
     account = sorted[0];
   }


### PR DESCRIPTION
Two bugs identified from user report (Rob S.) — headless /runners failing while interactive sessions work.

## Bug 1 — `injectPoolToken` skips `idle` accounts

`oauth-pool.mjs:1310` filtered `status === "active"` only. After `reset-cooldowns` sets accounts to `"idle"`, injection returned `false` and nothing was written to `auth.json`. `injectOpenAIPoolToken` already accepted `active || idle` correctly — this aligns Anthropic to match.

## Bug 2 — `initPoolAuth` timing race in headless mode

`initPoolAuth` was called in the `AidevopsPlugin()` factory body — before OpenCode finished its own provider initialisation. In headless `opencode run`, the first API call fires before the factory returns, so `client.auth.set()` either hadn't run or its write wasn't picked up by the provider layer yet. Interactive TUI works because human latency absorbs the gap.

Fix: move `initPoolAuth` into the `config` hook, which OpenCode calls as part of its own initialisation sequence before any provider calls.

## Root cause of Rob's symptom
- `anthropic` entry in auth.json: VALID (written by a previous interactive session)
- `anthropic-pool` entry: EXPIRED (stale from pool provider UI flow)
- Headless dispatch was hitting the expired entry because injection hadn't run yet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced OAuth token account selection logic to support both active and idle accounts with improved reliability.
  * Implemented cooldown period filtering to ensure only available accounts are selected for token injection.
  * Optimized OAuth pool initialization timing to occur during plugin configuration phase, improving overall startup sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->