### PR TITLE
fix: correct OAuth setup docs — opencode auth login is API key only

### DIFF
--- a/.agents/tools/credentials/auth-troubleshooting.md
+++ b/.agents/tools/credentials/auth-troubleshooting.md
@@ -4,6 +4,14 @@ Use this when a user reports "Key Missing", auth errors, or the model has stoppe
 
 All recovery commands work from any terminal — no working model session required.
 
+## Important: OAuth only — no API keys
+
+The pool uses **OAuth only** (Claude Pro/Max subscription). API keys are not used and not needed.
+
+- `opencode auth login` prompts for an API key — **do not use this for OAuth**
+- The correct OAuth setup path is `aidevops model-accounts-pool add anthropic` (opens browser)
+- Or via OpenCode TUI: `Ctrl+A` → Anthropic → Login with Claude.ai
+
 ## Recovery flow (run in order)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -273,21 +273,28 @@ See `.agents/tools/task-management/beads.md` for complete documentation and inst
 
 ### OpenCode Anthropic OAuth (Built-in)
 
-OpenCode v1.1.36+ includes Anthropic OAuth authentication natively. No external plugin is needed.
+OpenCode includes Anthropic OAuth authentication natively — no API key needed. OAuth is covered by your Claude Pro/Max subscription at zero additional cost.
 
-**After setup, authenticate:**
+**Authenticate via the pool (recommended):**
 
 ```bash
-opencode auth login
-# Select: Anthropic → Claude Pro/Max
-# Follow OAuth flow in browser
+aidevops model-accounts-pool add anthropic
+# Opens browser OAuth flow — no API key required
+# Restart OpenCode after adding
 ```
+
+**Or via the OpenCode TUI:**
+
+Open OpenCode → `Ctrl+A` → Select **Anthropic** → **Login with Claude.ai** → follow browser OAuth flow.
+
+> **Note:** `opencode auth login` prompts for an API key, not OAuth. Use the commands above for subscription-based OAuth access.
 
 **Benefits:**
 
 - **Zero cost** for Claude Pro/Max subscribers (covered by subscription)
-- **Automatic token refresh** - No manual re-authentication needed
-- **Beta features enabled** - Extended thinking modes and latest features
+- **Automatic token refresh** — no manual re-authentication needed
+- **Multiple accounts** — add more accounts to the pool for automatic rotation when one hits rate limits
+- **Beta features enabled** — extended thinking modes and latest features
 
 ### Cursor Models via Pool Proxy
 


### PR DESCRIPTION
The README documented `opencode auth login` as the OAuth setup path. It isn't — it prompts for an API key. The correct OAuth paths are `aidevops model-accounts-pool add anthropic` (browser flow) or OpenCode TUI `Ctrl+A`. Fixes Justin's confusion and removes the misleading command from docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified that the accounts pool operates exclusively with OAuth authentication, without API key support
  * Added detailed guidance for configuring OAuth authentication through the account pool setup process
  * Clarified the distinction between API key-based login and OAuth-based account authentication
  * Provided setup steps for Anthropic accounts supporting subscription-based access with automatic token refresh
  * Added information about multiple account support for rate-limit handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->