### PR TITLE
fix: Homebrew wrapper prefers git repo aidevops.sh over installed snapshot

### DIFF
--- a/homebrew/aidevops.rb
+++ b/homebrew/aidevops.rb
@@ -27,9 +27,15 @@ class Aidevops < Formula
     (share/"aidevops").install ".agents"
     (share/"aidevops").install "VERSION"
     
-    # Create wrapper in bin that calls the libexec script
+    # Create wrapper in bin that prefers the git repo copy (always current
+    # via 'aidevops update') over the Homebrew-installed snapshot.
     (bin/"aidevops").write <<~EOS
       #!/usr/bin/env bash
+      # Prefer git repo copy — always current via 'aidevops update'
+      if [[ -f "$HOME/Git/aidevops/aidevops.sh" ]]; then
+        exec bash "$HOME/Git/aidevops/aidevops.sh" "$@"
+      fi
+      # Fall back to Homebrew-installed copy
       export AIDEVOPS_SHARE="#{share}/aidevops"
       exec "#{libexec}/aidevops.sh" "$@"
     EOS


### PR DESCRIPTION
Same issue as npm wrapper (v3.1.74): brew users run the Homebrew-installed snapshot, not the git repo that `aidevops update` keeps current. After one `brew upgrade`, all future updates work via `aidevops update` alone.