### PR TITLE
fix: inject OAuth tokens via env vars — works on all OpenCode versions

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -1335,7 +1335,14 @@ export async function injectPoolToken(client, skipEmail) {
     return false;
   }
 
-  // Write to built-in anthropic provider's auth entry
+  // Inject via env var — works on all OpenCode versions including 1.3.0+
+  // where the bundled @ai-sdk/anthropic reads ANTHROPIC_API_KEY directly
+  // and ignores auth.json. OAuth access tokens are accepted in the same
+  // x-api-key header as API keys.
+  process.env.ANTHROPIC_API_KEY = accessToken;
+
+  // Also write to auth.json via client.auth.set — works on OpenCode <=1.2.27
+  // where the provider layer reads auth entries. Harmless on 1.3.0+.
   try {
     await client.auth.set({
       path: { id: "anthropic" },
@@ -1346,19 +1353,18 @@ export async function injectPoolToken(client, skipEmail) {
         expires: account.expires,
       },
     });
-
-    // Mark as used
-    patchAccount("anthropic", account.email, {
-      lastUsed: new Date().toISOString(),
-      status: "active",
-    });
-
-    console.error(`[aidevops] OAuth pool: injected token for ${account.email} into built-in anthropic provider`);
-    return true;
-  } catch (err) {
-    console.error(`[aidevops] OAuth pool: failed to inject token: ${err.message}`);
-    return false;
+  } catch {
+    // Best-effort — env var injection is the primary path
   }
+
+  // Mark as used
+  patchAccount("anthropic", account.email, {
+    lastUsed: new Date().toISOString(),
+    status: "active",
+  });
+
+  console.error(`[aidevops] OAuth pool: injected token for ${account.email} into built-in anthropic provider`);
+  return true;
 }
 
 /**
@@ -1397,8 +1403,17 @@ export async function injectOpenAIPoolToken(client, skipEmail) {
 
   if (!account) return false;
 
-  // Write to built-in openai provider's auth entry
-  // OpenAI auth.json structure: { type, access, refresh, expires, accountId }
+  // Ensure we have a valid access token
+  const accessToken = await ensureValidToken("openai", account);
+  if (!accessToken) {
+    console.error(`[aidevops] OAuth pool: failed to get valid OpenAI token for ${account.email}`);
+    return false;
+  }
+
+  // Inject via env var — works on all OpenCode versions including 1.3.0+
+  process.env.OPENAI_API_KEY = accessToken;
+
+  // Also write to auth.json via client.auth.set — works on OpenCode <=1.2.27
   try {
     await client.auth.set({
       path: { id: "openai" },
@@ -1410,19 +1425,18 @@ export async function injectOpenAIPoolToken(client, skipEmail) {
         accountId: account.accountId || "",
       },
     });
-
-    // Mark as used
-    patchAccount("openai", account.email, {
-      lastUsed: new Date().toISOString(),
-      status: "active",
-    });
-
-    console.error(`[aidevops] OAuth pool: injected token for ${account.email} into built-in openai provider`);
-    return true;
-  } catch (err) {
-    console.error(`[aidevops] OAuth pool: failed to inject OpenAI token: ${err.message}`);
-    return false;
+  } catch {
+    // Best-effort — env var injection is the primary path
   }
+
+  // Mark as used
+  patchAccount("openai", account.email, {
+    lastUsed: new Date().toISOString(),
+    status: "active",
+  });
+
+  console.error(`[aidevops] OAuth pool: injected token for ${account.email} into built-in openai provider`);
+  return true;
 }
 
 // ---------------------------------------------------------------------------
@@ -1719,13 +1733,14 @@ export function createPoolAuthHook(client) {
                   added: new Date().toISOString(),
                 });
                 // Also inject into the built-in provider for this session
+                if (tokenData.access) process.env.ANTHROPIC_API_KEY = tokenData.access;
                 try {
                   await client.auth.set({
                     path: { id: "anthropic" },
                     body: { type: "oauth", ...tokenData },
                   });
                 } catch {
-                  // Best-effort session injection
+                  // Best-effort — env var injection is the primary path
                 }
                 return { type: "success", ...tokenData };
               }
@@ -1971,13 +1986,14 @@ export function createOpenAIPoolAuthHook(client) {
                   accountId,
                 });
                 // Also inject into the built-in provider for this session
+                if (tokenData.access) process.env.OPENAI_API_KEY = tokenData.access;
                 try {
                   await client.auth.set({
                     path: { id: "openai" },
                     body: { type: "oauth", ...tokenData, accountId },
                   });
                 } catch {
-                  // Best-effort session injection
+                  // Best-effort — env var injection is the primary path
                 }
                 return { type: "success", ...tokenData };
               }

--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -84,8 +84,7 @@ NPM_TOOLS=(
 )
 
 BREW_TOOLS=(
-	# OpenCode PINNED to 1.2.27 — do NOT auto-upgrade. See tool-install.sh for details.
-	# "brew|OpenCode|opencode|--version|anomalyco/tap/opencode|brew upgrade anomalyco/tap/opencode"
+	"brew|OpenCode|opencode|--version|anomalyco/tap/opencode|brew upgrade anomalyco/tap/opencode"
 	"brew|GitHub CLI|gh|--version|gh|brew upgrade gh"
 	"brew|GitLab CLI|glab|--version|glab|brew upgrade glab"
 	"brew|Worktrunk|wt|--version|max-sixty/worktrunk/wt|brew upgrade max-sixty/worktrunk/wt"

--- a/.agents/tools/credentials/auth-troubleshooting.md
+++ b/.agents/tools/credentials/auth-troubleshooting.md
@@ -52,8 +52,10 @@ aidevops model-accounts-pool remove <p> <email>   # remove an account
 
 ## Key diagnostic facts
 
-- `rotate` writes the new account into `auth.json` immediately — OpenCode must restart to pick it up
+- Token injection uses `process.env.ANTHROPIC_API_KEY` (and `OPENAI_API_KEY`) — works on all OpenCode versions. The env var is set by the plugin at startup and updated on rotation/refresh.
+- `rotate` updates the env var and `auth.json` immediately — takes effect on the next API call without restart
 - `reset-cooldowns` clears the **pool file** cooldowns only; the in-memory token endpoint cooldown in a running OpenCode process requires a restart or `/model-accounts-pool reset-cooldowns` inside an active session
 - Pool file: `~/.aidevops/oauth-pool.json` — if corrupt or missing, `add` recreates it
-- "Key Missing" means the loader returned `{}`: pool is empty, all tokens expired/errored, or OpenCode's auth state was reset
+- "Key Missing" means the plugin didn't load or the pool is empty — check `aidevops model-accounts-pool status`
 - `assign-pending` is needed when OAuth completes but the email lookup fails — the token is saved as `_pending_<provider>` and stranded until assigned
+- If `ANTHROPIC_API_KEY` is set in your shell environment (e.g. `.bashrc`), the pool injection will override it at startup. Remove any manual API key env vars to avoid confusion.

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1418,56 +1418,17 @@ setup_nodejs() {
 setup_opencode_cli() {
 	print_info "Setting up OpenCode CLI..."
 
-	# PINNED VERSION: OpenCode >1.2.27 breaks OAuth token injection.
-	# See install_pkg comment below for details.
-	local pinned_version="1.2.27"
-
 	# Check if OpenCode is already installed
 	if command -v opencode >/dev/null 2>&1; then
 		local oc_version
 		oc_version=$(opencode --version 2>/dev/null | head -1 || echo "unknown")
-
-		# Check if installed version is newer than pinned (needs downgrade)
-		if [[ "$oc_version" != "unknown" ]] && [[ "$oc_version" != "$pinned_version" ]]; then
-			# Compare versions: if installed > pinned, downgrade
-			local installed_major installed_minor installed_patch
-			IFS='.' read -r installed_major installed_minor installed_patch <<<"$oc_version"
-			local pinned_major pinned_minor pinned_patch
-			IFS='.' read -r pinned_major pinned_minor pinned_patch <<<"$pinned_version"
-			installed_patch="${installed_patch%%[^0-9]*}"
-			pinned_patch="${pinned_patch%%[^0-9]*}"
-
-			local needs_downgrade="false"
-			if [[ "${installed_major:-0}" -gt "${pinned_major:-0}" ]]; then
-				needs_downgrade="true"
-			elif [[ "${installed_major:-0}" -eq "${pinned_major:-0}" ]] && [[ "${installed_minor:-0}" -gt "${pinned_minor:-0}" ]]; then
-				needs_downgrade="true"
-			elif [[ "${installed_major:-0}" -eq "${pinned_major:-0}" ]] && [[ "${installed_minor:-0}" -eq "${pinned_minor:-0}" ]] && [[ "${installed_patch:-0}" -gt "${pinned_patch:-0}" ]]; then
-				needs_downgrade="true"
-			fi
-
-			if [[ "$needs_downgrade" == "true" ]]; then
-				print_warning "OpenCode $oc_version has an OAuth regression — downgrading to $pinned_version"
-				if npm_global_install "opencode-ai@${pinned_version}"; then
-					print_success "OpenCode downgraded to $pinned_version (OAuth working)"
-				else
-					print_warning "Downgrade failed — run manually: npm install -g opencode-ai@${pinned_version}"
-				fi
-				return 0
-			fi
-		fi
-
 		print_success "OpenCode already installed: $oc_version"
 		return 0
 	fi
 
 	# Need either bun or npm to install
 	local installer=""
-	# PINNED: OpenCode >1.2.27 has a regression where the built-in anthropic
-	# provider ignores OAuth tokens from auth.json, causing "API key missing"
-	# errors for all OAuth users. Pin to 1.2.27 until the upstream fix lands.
-	# Track: https://github.com/marcusquinn/aidevops/issues/5546
-	local install_pkg="opencode-ai@1.2.27"
+	local install_pkg="opencode-ai@latest"
 
 	if command -v bun >/dev/null 2>&1; then
 		installer="bun"


### PR DESCRIPTION
## Problem

OpenCode 1.3.0+ uses bundled `@ai-sdk/anthropic` which reads `ANTHROPIC_API_KEY` from `process.env`, ignoring `auth.json` entirely. Our `client.auth.set()` injection worked on <=1.2.27 but was invisible to the bundled SDK — causing `AI_LoadAPIKeyError` for all OAuth users on 1.3.0.

## Fix

Set `process.env.ANTHROPIC_API_KEY` (and `OPENAI_API_KEY`) with the OAuth access token at every injection point. The Anthropic API accepts OAuth access tokens in the same `x-api-key` header as API keys.

Injection points updated:
- `injectPoolToken` (startup)
- `injectOpenAIPoolToken` (startup)
- Mid-session account add (both providers)
- 429 rotation (calls inject functions which now update env var)

`client.auth.set()` kept for backward compat with <=1.2.27 but demoted to best-effort.

## Testing

Sandbox headless run on OpenCode 1.3.0:
- Before: `AI_LoadAPIKeyError: Anthropic API key is missing`
- After: Model responds successfully (`hello`)

## Also in this PR

- Lifts the 1.2.27 version pin (no longer needed)
- Restores OpenCode in auto-upgrade list
- Updates auth-troubleshooting.md with env var injection details