### PR TITLE
t5552: fix cooldown check in fallback account selection

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -1318,9 +1318,9 @@ export async function injectPoolToken(client, skipEmail) {
     .sort((a, b) => new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0));
 
   if (sorted.length === 0) {
-    // All accounts skipped or in cooldown — try any active/idle account as last resort
+    // All accounts skipped or in cooldown — try any active/idle account not in cooldown as last resort
     account = accounts.find(
-      (a) => a.status === "active" || a.status === "idle",
+      (a) => (a.status === "active" || a.status === "idle") && (!a.cooldownUntil || a.cooldownUntil <= now),
     );
   } else {
     account = sorted[0];


### PR DESCRIPTION
## Summary

- Adds `cooldownUntil` check to the fallback `find()` in `injectPoolToken` (`.agents/plugins/opencode-aidevops/oauth-pool.mjs:1323`)
- Without this fix, if all accounts were in cooldown the fallback would select the first `active`/`idle` account regardless of cooldown status, potentially triggering API rate-limit errors
- Applies the exact suggestion from Gemini's high-severity review comment on PR #5541

## Change

```js
// Before
account = accounts.find(
  (a) => a.status === "active" || a.status === "idle",
);

// After
account = accounts.find(
  (a) => (a.status === "active" || a.status === "idle") && (!a.cooldownUntil || a.cooldownUntil <= now),
);
```

Blast radius: 1 line changed in 1 file.

Closes #5552