### PR TITLE
t5551: scope OAuth-only statement to Anthropic integration in auth-troubleshooting.md

### DIFF
--- a/.agents/tools/credentials/auth-troubleshooting.md
+++ b/.agents/tools/credentials/auth-troubleshooting.md
@@ -4,9 +4,9 @@ Use this when a user reports "Key Missing", auth errors, or the model has stoppe
 
 All recovery commands work from any terminal — no working model session required.
 
-## Important: OAuth only — no API keys
+## Important: Anthropic integration uses OAuth only — no API keys
 
-The pool uses **OAuth only** (Claude Pro/Max subscription). API keys are not used and not needed.
+The pool's Anthropic integration uses **OAuth only** (Claude Pro/Max subscription). API keys are not used and not needed.
 
 - `opencode auth login` prompts for an API key — **do not use this for OAuth**
 - The correct OAuth setup path is `aidevops model-accounts-pool add anthropic` (opens browser)


### PR DESCRIPTION
## Summary

- Scopes the "OAuth only" statement to the Anthropic integration specifically, avoiding misleading users troubleshooting other provider accounts (e.g., OpenAI which may use API keys)
- Updates both the section heading and body text at lines 7–9
- Docs-only change, 1 file, 2 lines modified

## Change

**Before:**
```
## Important: OAuth only — no API keys
The pool uses **OAuth only** (Claude Pro/Max subscription). API keys are not used and not needed.
```

**After:**
```
## Important: Anthropic integration uses OAuth only — no API keys
The pool's Anthropic integration uses **OAuth only** (Claude Pro/Max subscription). API keys are not used and not needed.
```

## References

Closes #5551
Addresses Gemini medium review feedback from PR #5544 (discussion_r2975991859)