### PR TITLE
t5553: clarify auth troubleshooting guided help instruction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ aidevops model-accounts-pool remove <p> <email># Remove an account
 
 > **Note:** `reset-cooldowns` clears cooldowns in the pool file. If OpenCode is already running, the in-memory token endpoint cooldown is only cleared when OpenCode restarts or when you use the `/model-accounts-pool reset-cooldowns` slash command inside an active session.
 
-**If you prefer guided help:** Open OpenCode with a free model (OpenCode Zen includes free models that don't require any API key or subscription) and ask it to read the auth troubleshooting agent:
+**If you prefer guided help:** Open OpenCode with a free model (OpenCode Zen includes free models that don't require any API key or subscription) and run the auth troubleshooting agent by typing:
 
 ```
 @auth-troubleshooting


### PR DESCRIPTION
## Summary

- Rephrases "ask it to read the auth troubleshooting agent" → "run the auth troubleshooting agent by typing" at README.md:422
- Makes the instruction more direct and actionable for users troubleshooting auth issues
- Docs-only change, 1 file, 1 line

## Motivation

Addresses Gemini medium review feedback from PR #5539 (inline comment on line 415 of the diff, which maps to line 422 in the current file). The original phrasing was indirect; the new phrasing tells the user exactly what action to take.

Closes #5553