### PR TITLE
fix(t5549): address Gemini review feedback on opencode-sandbox-helper.sh

### DIFF
--- a/.agents/scripts/opencode-sandbox-helper.sh
+++ b/.agents/scripts/opencode-sandbox-helper.sh
@@ -78,8 +78,8 @@ _sandbox_bin() {
 _latest_sandbox() {
 	local latest=""
 	local latest_time=0
+	shopt -s nullglob
 	for dir in "${SANDBOX_ROOT}"/*/; do
-		[[ ! -d "$dir" ]] && continue
 		local ver
 		ver=$(basename "$dir")
 		local mtime
@@ -89,6 +89,7 @@ _latest_sandbox() {
 			latest="$ver"
 		fi
 	done
+	shopt -u nullglob
 	echo "$latest"
 	return 0
 }
@@ -199,8 +200,8 @@ cmd_list() {
 	fi
 
 	local found="false"
+	shopt -s nullglob
 	for dir in "${SANDBOX_ROOT}"/*/; do
-		[[ ! -d "$dir" ]] && continue
 		local ver
 		ver=$(basename "$dir")
 		local bin_path
@@ -216,6 +217,7 @@ cmd_list() {
 		printf '  %-12s  version=%-10s  auth.json=%s\n' "$ver" "$installed_ver" "$has_auth"
 		found="true"
 	done
+	shopt -u nullglob
 
 	if [[ "$found" == "false" ]]; then
 		print_info "No sandbox versions installed"
@@ -298,7 +300,7 @@ cmd_clean() {
 
 main() {
 	local cmd="${1:-help}"
-	shift 2>/dev/null || true
+	if [[ $# -gt 0 ]]; then shift; fi
 
 	case "$cmd" in
 	install) cmd_install "$@" ;;


### PR DESCRIPTION
## Summary

Addresses all 3 findings from the Gemini code review on PR #5548 (`.agents/scripts/opencode-sandbox-helper.sh`).

## Findings Fixed

### HIGH (×2) — `nullglob` for glob loops under `set -e`

**Problem**: With `set -e` active, `for dir in "${SANDBOX_ROOT}"/*/;` exits the script with an error when no sandbox directories exist — the glob literal is passed as a non-existent path.

**Fix**: Wrap both affected loops (`_latest_sandbox` line 81 and `cmd_list` line 202) with `shopt -s nullglob` / `shopt -u nullglob`. This causes the glob to expand to nothing when no directories match, so the loop body is simply skipped. The redundant `[[ ! -d "$dir" ]] && continue` guard is removed as it becomes unnecessary.

### MEDIUM (×1) — Replace `shift 2>/dev/null || true` with explicit guard

**Problem**: `shift 2>/dev/null || true` silences errors to handle the case where `$#` is 0 under `set -e`. This suppresses stderr and can mask real issues.

**Fix**: Replace with the explicit conditional `if [[ $# -gt 0 ]]; then shift; fi` — same semantics, no error suppression.

## Verification

- `shellcheck .agents/scripts/opencode-sandbox-helper.sh` — clean (only pre-existing SC1091 info about external file sourcing)
- Blast radius: 1 file, 5 insertions / 3 deletions

Closes #5549