### PR TITLE
fix: add cooldown check to oauth-pool fallback account selection

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -1319,8 +1319,11 @@ export async function injectPoolToken(client, skipEmail) {
 
   if (sorted.length === 0) {
     // All accounts skipped or in cooldown — try any active/idle account as last resort
+    // Must still respect cooldown to avoid using accounts that should be resting (GH#5552)
     account = accounts.find(
-      (a) => a.status === "active" || a.status === "idle",
+      (a) =>
+        (a.status === "active" || a.status === "idle") &&
+        (!a.cooldownUntil || a.cooldownUntil <= now),
     );
   } else {
     account = sorted[0];


### PR DESCRIPTION
## Summary

- Fixes the cooldown bypass in `injectPoolToken()` fallback account selection (`.agents/plugins/opencode-aidevops/oauth-pool.mjs:1323`)
- The fallback `find()` now checks `(!a.cooldownUntil || a.cooldownUntil <= now)`, consistent with the primary filter at line 1316
- Without this fix, when all non-skipped accounts are filtered out, the fallback could select an account still in cooldown, causing API errors or rate-limiting

Closes #5552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed account selection logic to properly respect cooldown periods and only select accounts that are available for use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->