### PR TITLE
GH#5549: fix 3 review findings in opencode-sandbox-helper.sh

### DIFF
--- a/.agents/scripts/opencode-sandbox-helper.sh
+++ b/.agents/scripts/opencode-sandbox-helper.sh
@@ -78,8 +78,8 @@ _sandbox_bin() {
 _latest_sandbox() {
 	local latest=""
 	local latest_time=0
+	shopt -s nullglob
 	for dir in "${SANDBOX_ROOT}"/*/; do
-		[[ ! -d "$dir" ]] && continue
 		local ver
 		ver=$(basename "$dir")
 		local mtime
@@ -89,6 +89,7 @@ _latest_sandbox() {
 			latest="$ver"
 		fi
 	done
+	shopt -u nullglob
 	echo "$latest"
 	return 0
 }
@@ -199,8 +200,8 @@ cmd_list() {
 	fi
 
 	local found="false"
+	shopt -s nullglob
 	for dir in "${SANDBOX_ROOT}"/*/; do
-		[[ ! -d "$dir" ]] && continue
 		local ver
 		ver=$(basename "$dir")
 		local bin_path
@@ -216,6 +217,7 @@ cmd_list() {
 		printf '  %-12s  version=%-10s  auth.json=%s\n' "$ver" "$installed_ver" "$has_auth"
 		found="true"
 	done
+	shopt -u nullglob
 
 	if [[ "$found" == "false" ]]; then
 		print_info "No sandbox versions installed"
@@ -298,7 +300,7 @@ cmd_clean() {
 
 main() {
 	local cmd="${1:-help}"
-	shift 2>/dev/null || true
+	if [[ $# -gt 0 ]]; then shift; fi
 
 	case "$cmd" in
 	install) cmd_install "$@" ;;


### PR DESCRIPTION
## Summary

- Replace `shift 2>/dev/null || true` with `if [[ $# -gt 0 ]]; then shift; fi` for clarity — avoids masking errors under `set -e`
- Add `shopt -s nullglob` / `shopt -u nullglob` around glob loops in `_latest_sandbox` and `cmd_list` to prevent `set -e` exit when no sandbox directories exist
- Remove now-redundant `[[ ! -d "$dir" ]] && continue` guards that were working around the missing nullglob

Closes #5549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal script robustness with refined directory iteration and argument handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->