### PR TITLE
fix: check all non-bot users in auto-decline safety net, not just owner

### DIFF
--- a/.agents/scripts/draft-response-helper.sh
+++ b/.agents/scripts/draft-response-helper.sh
@@ -832,15 +832,19 @@ cmd_check_approvals() {
 			fi
 		fi
 
-		# Check for user comments on this notification issue
+		# Check for comments from ANY non-bot user on this notification issue.
+		# The safety net should NOT auto-decline if any human has commented —
+		# not just the repo owner ($username). A comment from any non-bot user
+		# indicates human engagement that should block auto-decline.
+		# (GH#5559: was incorrectly filtering to only $username's comments)
 		local sa_comments
 		sa_comments=$(gh api --paginate "repos/${slug}/issues/${sa_issue_number}/comments?per_page=100" \
-			--jq "[.[] | select(.user.login == \"${username}\") | select(.user.login | test(\"\\\\[bot\\\\]\$\"; \"i\") | not)]" \
+			--jq '[.[] | select(.user.login | test("\\[bot\\]$"; "i") | not)]' \
 			2>/dev/null) || sa_comments="[]"
 		local sa_user_comment_count
 		sa_user_comment_count=$(echo "$sa_comments" | jq 'length' 2>/dev/null) || sa_user_comment_count=0
 
-		# Only auto-decline if no user comment exists
+		# Only auto-decline if no non-bot user comment exists
 		if [[ "$sa_user_comment_count" -gt 0 ]]; then
 			continue
 		fi


### PR DESCRIPTION
## Summary

- **Fixes the high-severity Gemini review finding from PR #5522**: the safety-net auto-decline `jq` filter in `draft-response-helper.sh` was restricting the comment search to only `$username` (the authenticated user), but the feature's goal is to block auto-decline when *any* non-bot user has commented
- Removed the `select(.user.login == "${username}")` filter and kept only the bot-exclusion filter (`select(.user.login | test("\\[bot\\]$"; "i") | not)`), so comments from any human user prevent auto-decline
- Without this fix, a comment from a different non-bot user on the notification issue would be missed, leading to incorrect auto-decline of drafts that have active human engagement

Closes #5559