### PR TITLE
t5559: fix auto-decline safety-net to check any non-bot user comment

### DIFF
--- a/.agents/scripts/draft-response-helper.sh
+++ b/.agents/scripts/draft-response-helper.sh
@@ -835,7 +835,7 @@ cmd_check_approvals() {
 		# Check for user comments on this notification issue
 		local sa_comments
 		sa_comments=$(gh api --paginate "repos/${slug}/issues/${sa_issue_number}/comments?per_page=100" \
-			--jq "[.[] | select(.user.login == \"${username}\") | select(.user.login | test(\"\\\\[bot\\\\]\$\"; \"i\") | not)]" \
+			--jq "[.[] | select(.user.login | test(\"\\\\[bot\\\\]\$\"; \"i\") | not)]" \
 			2>/dev/null) || sa_comments="[]"
 		local sa_user_comment_count
 		sa_user_comment_count=$(echo "$sa_comments" | jq 'length' 2>/dev/null) || sa_user_comment_count=0


### PR DESCRIPTION
## Summary

- Removes the `select(.user.login == "${username}")` filter from the safety-net comment check in `cmd_check_approvals` (line 838)
- The filter was incorrectly restricting the "has a user commented?" check to only the authenticated agent account, making comments from any other human user invisible
- Now correctly counts any comment from a non-bot user, preventing false auto-declines when a human other than the agent has engaged on the issue

## Root cause

The `jq` filter combined two conditions: match the agent's own username AND exclude bots. The intent (per the surrounding comment "Only auto-decline if no user comment exists") is to check for *any* non-bot human comment. The username equality filter was logically wrong for this purpose.

## Change

```diff
- --jq "[.[] | select(.user.login == \"${username}\") | select(.user.login | test(\"\\\\[bot\\\\]\$\"; \"i\") | not)]" \
+ --jq "[.[] | select(.user.login | test(\"\\\\[bot\\\\]\$\"; \"i\") | not)]" \
```

## Verification

- ShellCheck: no new violations (only pre-existing SC1091 info on external source)
- 1 file changed, 1 line modified

Closes #5559