### PR TITLE
t5562: fix profile-readme-helper.sh Gemini review feedback

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -1076,6 +1076,9 @@ _normalize_readme_for_compare() {
 _generate_contributions() {
 	local gh_user="$1"
 	local contrib_repos=""
+	# Bash 3.2-compatible seen-set: "|name1|name2|" — O(1) append, O(N) lookup
+	# (associative arrays require bash 4.0+, unavailable on macOS default shell)
+	local seen_repos="|"
 
 	# Source 1: forks — resolve parent URLs
 	local repos_json
@@ -1091,10 +1094,14 @@ _generate_contributions() {
 		' 2>/dev/null || true)
 		while IFS=$'\t' read -r rname rdesc rurl; do
 			[[ -z "$rname" ]] && continue
+			if [[ "$seen_repos" == *"|${rname}|"* ]]; then
+				continue
+			fi
 			rname=$(_sanitize_md "$rname")
 			rdesc=$(_sanitize_md "$rdesc")
 			rurl=$(_sanitize_url "$rurl")
 			[[ -z "$rurl" ]] && continue
+			seen_repos="${seen_repos}${rname}|"
 			contrib_repos="${contrib_repos}- **[${rname}](${rurl})** -- ${rdesc}"$'\n'
 		done <<<"$fork_details"
 	fi
@@ -1113,8 +1120,8 @@ _generate_contributions() {
 			[[ -z "$slug" ]] && continue
 			local repo_name
 			repo_name="${slug##*/}"
-			# Skip if already listed from forks
-			if echo "$contrib_repos" | grep -qF "/${repo_name})" 2>/dev/null; then
+			# Skip if already seen from any source (forks or prior repos.json entries)
+			if [[ "$seen_repos" == *"|${repo_name}|"* ]]; then
 				continue
 			fi
 			# Fetch description from GitHub API (1 call per contributed repo)
@@ -1123,6 +1130,7 @@ _generate_contributions() {
 			desc=$(_sanitize_md "$desc")
 			local url="https://github.com/${slug}"
 			repo_name=$(_sanitize_md "$repo_name")
+			seen_repos="${seen_repos}${repo_name}|"
 			contrib_repos="${contrib_repos}- **[${repo_name}](${url})** -- ${desc}"$'\n'
 		done <<<"$contributed_slugs"
 	fi
@@ -1655,7 +1663,7 @@ cmd_update_contributions() {
 			skip = 0
 			block = ENVIRON["CONTRIBS_BLOCK"]
 			if (block != "") {
-				printf "%s\n", block
+				printf "%s", block
 			}
 			print "<!-- CONTRIBUTIONS-END -->"
 			next


### PR DESCRIPTION
## Summary

Addresses the two medium-severity findings from Gemini's review of PR #5523.

- **Deduplication efficiency** (`_generate_contributions`, line 1094): replaced the O(N×M) `grep` call inside the loop with a bash 3.2-compatible pipe-delimited seen-set (`|name1|name2|`). The seen-set is checked with a glob pattern (`[[ "$seen_repos" == *"|${name}|"* ]]`), giving O(1) append and O(N) lookup — no associative arrays (bash 4.0+ only). The fix also closes the correctness gap: the old `grep` only deduplicated repos.json entries against forks; the new seen-set covers all sources (forks against forks, repos.json entries against forks, and repos.json entries against each other).

- **Extra blank line** (`cmd_update_contributions`, awk block, line 1666): changed `printf "%s\n", block` to `printf "%s", block`. The `CONTRIBS_BLOCK` variable already carries a trailing newline from `_generate_contributions`; the `\n` was adding a second one, producing a spurious blank line in the README.

## Changes

- 1 file changed: `.agents/scripts/profile-readme-helper.sh`
- ShellCheck: zero violations

Closes #5562