### PR TITLE
t5584: fix: address CodeRabbit nitpicks from PR #5582 (session-checkpoint-helper.sh)

### DIFF
--- a/.agents/scripts/session-checkpoint-helper.sh
+++ b/.agents/scripts/session-checkpoint-helper.sh
@@ -93,7 +93,10 @@ readonly -a CREDENTIAL_PATTERNS=(
 	"token${_ASSIGN_SUFFIX}"
 	# Private keys
 	'-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----'
-	# Gopass output (command invocations that may include or precede secret values)
+	# Gopass command invocations — redacts the command itself (e.g., "gopass show path/to/secret").
+	# Limitation: gopass outputs the secret value on a *separate line* after the command.
+	# That subsequent line is not caught here; it relies on the password/token/key patterns
+	# above to match the value. Avoid pasting raw gopass output into checkpoint notes.
 	'gopass show [a-zA-Z0-9/_.-]+'
 )
 


### PR DESCRIPTION
## Summary

Addresses CodeRabbit nitpick comments from PR #5582 review that were deferred as non-blocking.

- Document gopass pattern limitation: the `'gopass show [a-zA-Z0-9/_.-]+'` pattern redacts the command invocation but not the secret value printed on the subsequent line. Added explicit comment explaining this limitation and advising users to avoid pasting raw gopass output into checkpoint notes.
- Verified redundant grep issue (lines 127-133) is already resolved: `grep_rc` is captured once and reused in both the match and debug branches — no second grep call occurs.
- All three items from issue #5584 acceptance criteria verified:
  - `memory-helper.sh` path uses `${SCRIPT_DIR}` consistently ✓ (already in PR #5582)
  - Gopass pattern limitation documented ✓ (this PR)
  - `cmd_continuation()` output sanitized before writing ✓ (already in PR #5582)

## Testing

ShellCheck: zero violations (only SC1091 info for sourced file, expected).

Closes #5584