### PR TITLE
t5593: make auth-troubleshooting heading more concise

### DIFF
--- a/.agents/tools/credentials/auth-troubleshooting.md
+++ b/.agents/tools/credentials/auth-troubleshooting.md
@@ -4,7 +4,7 @@ Use this when a user reports "Key Missing", auth errors, or the model has stoppe
 
 All recovery commands work from any terminal — no working model session required.
 
-## Important: Anthropic integration uses OAuth only — no API keys
+## Important: Anthropic Integration (OAuth only)
 
 The pool's Anthropic integration uses **OAuth only** (Claude Pro/Max subscription). API keys are not used and not needed.
 


### PR DESCRIPTION
## Summary

- Shortens the section heading at `.agents/tools/credentials/auth-troubleshooting.md:7` from a full-sentence form to a concise title
- Addresses Gemini code review feedback from PR #5564 (medium severity)
- No functional change — body text below the heading is unchanged and still explains the OAuth-only constraint clearly

Closes #5593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication troubleshooting documentation to clarify that Anthropic integration uses OAuth exclusively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->