### PR TITLE
fix: replace non-portable readlink -f with command -v path check in tool-version-check.sh

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -66,7 +66,11 @@ done
 
 # Detect how OpenCode was installed — build the right upgrade command.
 # update_cmd is executed via `bash -c` so it must be a self-contained string.
-_oc_upgrade_cmd="if r=\$(readlink -f \"\$(command -v opencode)\" 2>/dev/null || readlink \"\$(command -v opencode)\" 2>/dev/null) && [[ \"\$r\" == *bun* ]]; then bun install -g opencode-ai@latest; else npm install -g opencode-ai@latest; fi"
+# Use `command -v` path directly: bun-installed binaries live under ~/.bun/bin/,
+# so the path itself contains "bun". This avoids `readlink -f` which is a GNU
+# extension not available on macOS by default.
+# shellcheck disable=SC2016  # Single quotes intentional: string is a bash -c payload, must not expand at assignment time
+_oc_upgrade_cmd='if r=$(command -v opencode 2>/dev/null); [[ "$r" == *bun* ]]; then bun install -g opencode-ai@latest; else npm install -g opencode-ai@latest; fi'
 
 # Tool definitions
 # Format: category|display_name|cli_command|version_flag|package_name|update_command


### PR DESCRIPTION
## Summary

- Replaces `readlink -f` (GNU extension, unavailable on macOS by default) with a direct `command -v opencode` path check for bun detection
- The `command -v` output already contains the full path (e.g. `~/.bun/bin/opencode`), so checking for `*bun*` in that path is sufficient and portable
- Switches to single-quoted string for the `bash -c` payload, eliminating complex backslash escaping and improving readability
- Adds inline `# shellcheck disable=SC2016` with rationale (single quotes intentional for `bash -c` payload)
- ShellCheck passes with zero violations

## Changes

- `.agents/scripts/tool-version-check.sh` line 69: replace `readlink -f` approach with `command -v` path inspection

Closes #5596
Addresses high-severity review feedback from PR #5570 (gemini-code-assist)