### PR TITLE
t5590: fix eval injection risk and unsafe JSON in doctor-helper.sh

### DIFF
--- a/.agents/scripts/doctor-helper.sh
+++ b/.agents/scripts/doctor-helper.sh
@@ -437,6 +437,7 @@ run_fix() {
 		npm) remove_cmd="npm uninstall -g $binary_name" ;;
 		bun) remove_cmd="bun remove -g $binary_name" ;;
 		brew) remove_cmd="brew uninstall $binary_name" ;;
+		cargo) remove_cmd="cargo uninstall $binary_name" ;;
 		*) remove_cmd="rm \"$path\"" ;;
 		esac
 
@@ -447,7 +448,25 @@ run_fix() {
 		read -r confirm
 		if [[ "$confirm" =~ ^[Yy]$ ]]; then
 			echo -e "  ${BLUE}Running:${NC} $remove_cmd"
-			if eval "$remove_cmd" 2>&1; then
+			local success=false
+			case "$method" in
+			npm)
+				if npm uninstall -g "$binary_name" 2>&1; then success=true; fi
+				;;
+			bun)
+				if bun remove -g "$binary_name" 2>&1; then success=true; fi
+				;;
+			brew)
+				if brew uninstall "$binary_name" 2>&1; then success=true; fi
+				;;
+			cargo)
+				if cargo uninstall "$binary_name" 2>&1; then success=true; fi
+				;;
+			*)
+				if rm "$path" 2>&1; then success=true; fi
+				;;
+			esac
+			if $success; then
 				print_success "Removed $binary_name [$method]"
 			else
 				print_error "Failed to remove $binary_name [$method]"
@@ -509,14 +528,16 @@ json_diagnose_binary() {
 			entries="${entries},"
 		fi
 
+		local current_entry
+		current_entry=$(jq -n \
+			--arg path "$loc" \
+			--arg resolved "$resolved" \
+			--arg method "$method" \
+			--arg version "$version" \
+			--argjson active "$is_active" \
+			'{path: $path, resolved: $resolved, method: $method, version: $version, active: $active}')
 		entries="${entries}
-      {
-        \"path\": \"$loc\",
-        \"resolved\": \"$resolved\",
-        \"method\": \"$method\",
-        \"version\": \"$version\",
-        \"active\": $is_active
-      }"
+      ${current_entry}"
 	done <<<"$locations_raw"
 
 	local has_conflicts="false"


### PR DESCRIPTION
## Summary

Addresses all critical and high review findings from PR #5578 (issue #5590).

- **CRITICAL fix**: Replaced `eval "$remove_cmd"` with a direct `case` statement that calls each package manager command with properly quoted arguments. `eval` on a dynamically-constructed string containing a file path is a command injection vector — a binary named `a; rm -rf /` in PATH would execute arbitrary code.
- **Correctness fix**: Added missing `cargo) cargo uninstall "$binary_name"` handler. Previously, cargo-installed binaries fell through to the `rm "$path"` fallback, which is incorrect — `cargo uninstall` is the right removal mechanism and also cleans up metadata.
- **HIGH fix**: Replaced shell-variable string interpolation in JSON construction with `jq -n --arg/--argjson`. Variables like `$version` or `$path` can contain double quotes or backslashes that break JSON syntax; `jq --arg` handles escaping correctly.

ShellCheck: zero violations.

Closes #5590