### PR TITLE
t5592: fix <provider> placeholder consistency in model-accounts-pool help text

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3660,7 +3660,7 @@ cmd_help() {
 	echo "  aidevops model-accounts-pool add cursor        # Add Cursor Pro account"
 	echo "  aidevops model-accounts-pool import claude-cli # Import from Claude CLI auth"
 	echo "  aidevops model-accounts-pool assign-pending <provider># Assign stranded token"
-	echo "  aidevops model-accounts-pool remove <p> <email># Remove an account"
+	echo "  aidevops model-accounts-pool remove <provider> <email># Remove an account"
 	echo ""
 	echo "  Auth recovery (run these in order if model is broken):"
 	echo "    aidevops model-accounts-pool status          # 1. Check pool health"


### PR DESCRIPTION
## Summary

- Fixes inconsistency in `aidevops.sh` help text flagged by Gemini in PR #5569 review
- The `remove` command used abbreviated `<p>` while `assign-pending` used `<provider>`
- Both now consistently use `<provider>` for clear, uniform user-facing help text

## Change

`aidevops.sh:3663`: `remove <p> <email>` → `remove <provider> <email>`

Closes #5592