### PR TITLE
t5591: perf: use here-strings in deduplication loops in profile-readme-helper.sh

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -1098,7 +1098,7 @@ _generate_contributions() {
 		while IFS=$'\t' read -r rname rdesc rurl; do
 			[[ -z "$rname" ]] && continue
 			# Deduplicate within forks (xargs -P can return duplicates)
-			if [[ -n "$seen_repos" ]] && printf '%s\n' "$seen_repos" | grep -qxF "$rname" 2>/dev/null; then
+			if [[ -n "$seen_repos" ]] && grep -qxF "$rname" <<<"$seen_repos" 2>/dev/null; then
 				continue
 			fi
 			rname=$(_sanitize_md "$rname")
@@ -1125,7 +1125,7 @@ _generate_contributions() {
 			local repo_name
 			repo_name="${slug##*/}"
 			# Deduplicate against all previously seen repos (forks + earlier entries)
-			if [[ -n "$seen_repos" ]] && printf '%s\n' "$seen_repos" | grep -qxF "$repo_name" 2>/dev/null; then
+			if [[ -n "$seen_repos" ]] && grep -qxF "$repo_name" <<<"$seen_repos" 2>/dev/null; then
 				continue
 			fi
 			# Fetch description from GitHub API (1 call per contributed repo)


### PR DESCRIPTION
## Summary

- Replace `printf '%s\n' "$seen_repos" | grep -qxF` with `grep -qxF "$rname" <<<"$seen_repos"` at two locations in `_generate_contributions()` (lines 1101 and 1128)
- Here-strings avoid spawning a `printf` subprocess and creating a pipe on every loop iteration, reducing process overhead when the seen_repos list is large
- Behaviour is identical; only the mechanism for passing the variable to `grep` changes

## Changes

- `.agents/scripts/profile-readme-helper.sh` — 2 lines changed (both deduplication checks in the forks loop and the contributed-repos loop)

## Verification

- ShellCheck passes with zero violations
- Bash 3.2 compatible (`<<<` here-strings are supported since bash 2.05b)

Closes #5591