### PR TITLE
t5589: fix: address quality-debt review feedback on session-checkpoint-helper.sh

### DIFF
--- a/.agents/scripts/session-checkpoint-helper.sh
+++ b/.agents/scripts/session-checkpoint-helper.sh
@@ -116,12 +116,13 @@ sanitize_checkpoint() {
 
 	local redacted=0
 	local pattern
+	local grep_rc
 
 	for pattern in "${CREDENTIAL_PATTERNS[@]}"; do
 		# Check if pattern matches before attempting redaction.
 		# Capture exit code once to avoid running grep twice in debug mode:
 		# 0 = match, 1 = no match, 2 = regex/file error.
-		local grep_rc=0
+		grep_rc=0
 		grep -qE "$pattern" "$target_file" 2>/dev/null || grep_rc=$?
 
 		if [[ "$grep_rc" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

- Moves `local grep_rc` declaration before the `for` loop in `sanitize_checkpoint()` — declaring `local` inside a loop re-declares on every iteration; declaring once before the loop and resetting to `0` inside is cleaner and avoids the bash 3.2 subtlety
- Confirms all critical and nitpick findings from PR #5582 CodeRabbit review are fully addressed in the current codebase

## Context

Issue #5589 was auto-generated by `quality-feedback-helper.sh scan-merged` to track unactioned review feedback from PR #5582. After rebasing onto the latest `main` (which includes PR #5582), all critical findings were already fixed:

- **Critical**: Write-then-sanitize window — fixed by atomic temp file write in `cmd_save` and `cmd_continuation`
- **Critical**: `sed` delimiter conflicts — fixed by switching to `perl -pi -e "s{}{}"` 
- **Critical**: `mv` error handling — fixed with explicit error path and temp file cleanup
- **Nitpick**: Debug logging for pattern failures — already implemented with `[[ -n "${DEBUG:-}" ]]` guards
- **Nitpick**: False-positive documentation for `sk-`/`pk-` patterns — already documented in comment block

This PR adds the one remaining improvement: proper `local` variable scoping for `grep_rc`.

## Verification

- ShellCheck: zero violations (SC1091 info only — sourced file not followed)
- Bash 3.2 syntax check: passes (`/bin/bash -n`)
- All credential patterns tested with perl `s{}{}` substitution: all pass

Closes #5589