### PR TITLE
feat: scheduled and startup token refresh with 1h pre-emptive window

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -304,6 +304,18 @@ main() {
 		[[ -n "$contribution_watch" ]] && echo "$contribution_watch"
 	} >"$cache_dir/session-greeting.txt"
 
+	# Pre-emptive token refresh on session startup (background, non-blocking).
+	# Refreshes any OAuth tokens expiring within 1 hour — catches tokens that
+	# expired while the machine was off. Runs silently; failures are harmless.
+	local agents_dir="${AIDEVOPS_DIR:-$HOME/.aidevops}/agents"
+	local oauth_helper="$agents_dir/scripts/oauth-pool-helper.sh"
+	if [[ -f "$oauth_helper" && -f "$HOME/.aidevops/oauth-pool.json" ]]; then
+		(
+			bash "$oauth_helper" refresh anthropic >/dev/null 2>&1
+			bash "$oauth_helper" refresh openai >/dev/null 2>&1
+		) &
+	fi
+
 	return 0
 }
 

--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -1126,8 +1126,8 @@ try:
         if not refresh_tok:
             continue
 
-        # Only refresh if expired or expiring within 5 minutes
-        if expires and expires > now_ms + 300000:
+        # Only refresh if expired or expiring within 1 hour (3600000ms)
+        if expires and expires > now_ms + 3600000:
             continue
 
         body = json.dumps({

--- a/setup.sh
+++ b/setup.sh
@@ -1753,6 +1753,86 @@ PR_PLIST
 		fi
 	fi
 
+	# OAuth token refresh scheduled job.
+	# Refreshes expired/expiring tokens every 30 min so sessions never hit
+	# "invalid x-api-key". Also runs at load to catch tokens that expired
+	# while the machine was off.
+	local tr_script="$HOME/.aidevops/agents/scripts/oauth-pool-helper.sh"
+	local tr_label="sh.aidevops.token-refresh"
+	if [[ -x "$tr_script" ]] && [[ -f "$HOME/.aidevops/oauth-pool.json" ]]; then
+		mkdir -p "$HOME/.aidevops/.agent-workspace/logs"
+
+		if [[ "$(uname -s)" == "Darwin" ]]; then
+			local tr_plist="$HOME/Library/LaunchAgents/${tr_label}.plist"
+
+			local _xml_tr_script _xml_tr_home
+			_xml_tr_script=$(_xml_escape "$tr_script")
+			_xml_tr_home=$(_xml_escape "$HOME")
+
+			local tr_plist_content
+			tr_plist_content=$(
+				cat <<TR_PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${tr_label}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-c</string>
+		<string>${_xml_tr_script} refresh anthropic; ${_xml_tr_script} refresh openai</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>1800</integer>
+	<key>StandardOutPath</key>
+	<string>${_xml_tr_home}/.aidevops/.agent-workspace/logs/token-refresh.log</string>
+	<key>StandardErrorPath</key>
+	<string>${_xml_tr_home}/.aidevops/.agent-workspace/logs/token-refresh.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<key>HOME</key>
+		<string>${_xml_tr_home}</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityBackgroundIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+</dict>
+</plist>
+TR_PLIST
+			)
+
+			if _launchd_install_if_changed "$tr_label" "$tr_plist" "$tr_plist_content"; then
+				print_info "OAuth token refresh enabled (launchd, every 30 min)"
+			else
+				print_warning "Failed to load token refresh LaunchAgent"
+			fi
+		else
+			# Linux: cron entry (every 30 min)
+			local _cron_tr_script
+			_cron_tr_script=$(_cron_escape "$tr_script")
+			(
+				crontab -l 2>/dev/null | grep -v 'aidevops: token-refresh'
+				echo "*/30 * * * * /bin/bash ${_cron_tr_script} refresh anthropic >> \"\$HOME/.aidevops/.agent-workspace/logs/token-refresh.log\" 2>&1; /bin/bash ${_cron_tr_script} refresh openai >> \"\$HOME/.aidevops/.agent-workspace/logs/token-refresh.log\" 2>&1 # aidevops: token-refresh"
+			) | crontab - 2>/dev/null || true
+			if crontab -l 2>/dev/null | grep -qF "aidevops: token-refresh" 2>/dev/null; then
+				print_info "OAuth token refresh enabled (cron, every 30 min)"
+			else
+				print_warning "Failed to install token refresh cron entry"
+			fi
+		fi
+	fi
+
 	echo ""
 	echo "CLI Command:"
 	echo "  aidevops init         - Initialize aidevops in a project"


### PR DESCRIPTION
## Summary

Prevents `invalid x-api-key` / `Invalid authentication credentials` errors by keeping OAuth tokens fresh before they expire.

## Three refresh layers

| Layer | Trigger | How |
|-------|---------|-----|
| **Scheduled** | Every 30 min (launchd/cron) | `sh.aidevops.token-refresh` plist, RunAtLoad=true |
| **Session startup** | Every new OpenCode/Claude session | Background refresh in `aidevops-update-check.sh` |
| **On rotate** | When switching accounts | Auto-refresh in `cmd_rotate` (from v3.1.84) |

All three use a 1-hour pre-emptive window: tokens are refreshed when they have less than 1 hour remaining, not when they're already expired.

## Changes

- `.agents/scripts/oauth-pool-helper.sh`: threshold 5min -> 1h
- `.agents/scripts/aidevops-update-check.sh`: background refresh on session start
- `.agents/configs/sh.aidevops.token-refresh.plist`: new launchd template
- `setup.sh`: installs/updates the launchd plist (macOS) or cron entry (Linux)

## Root cause of the bug

Tokens expire after ~8 hours. If a session runs longer than that, or the machine sleeps and wakes after expiry, the next API call fails with `invalid x-api-key`. Nothing was refreshing tokens proactively.

Closes #5607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth tokens now automatically refresh in the background on session startup, eliminating manual token management
  * Scheduled token refresh runs every 30 minutes on macOS and Linux platforms
  * Enhanced token refresh timing ensures tokens remain valid longer between refresh cycles
  * All refresh operations occur silently without affecting your workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->