### PR TITLE
t5614: Add Google as fourth OAuth pool provider

### DIFF
--- a/.agents/plugins/opencode-aidevops/oauth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/oauth-pool.mjs
@@ -154,6 +154,24 @@ const OPENAI_REDIRECT_URI = "http://localhost:1455/auth/callback";
 const OPENAI_OAUTH_SCOPES = "openid profile email offline_access";
 
 // ---------------------------------------------------------------------------
+// Google OAuth constants (issue #5614)
+// Google AI Pro/Ultra/Workspace subscription accounts.
+// Tokens are injected as ADC bearer tokens (GOOGLE_OAUTH_ACCESS_TOKEN env var)
+// which Gemini CLI, Vertex AI SDK, and generativelanguage.googleapis.com pick up.
+// Health check: GET /v1beta/models?pageSize=1 on generativelanguage.googleapis.com
+// Isolation: separate in-memory cooldown, separate pool key — failures never
+// cascade to anthropic/openai/cursor providers.
+// ---------------------------------------------------------------------------
+
+const GOOGLE_CLIENT_ID = "681255809395-oo8ft6t5t0rnmhfqgpnkqtev5b9a2i5j.apps.googleusercontent.com";
+const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+const GOOGLE_OAUTH_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+/** OOB redirect — code is displayed in the browser for manual paste */
+const GOOGLE_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
+const GOOGLE_OAUTH_SCOPES = "https://www.googleapis.com/auth/generative-language https://www.googleapis.com/auth/cloud-platform openid email profile";
+const GOOGLE_HEALTH_CHECK_URL = "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1";
+
+// ---------------------------------------------------------------------------
 // Cursor constants (t1549)
 // Cursor uses cursor-agent CLI for authentication and a local HTTP proxy
 // sidecar that translates OpenAI-compatible requests to cursor-agent calls.
@@ -269,6 +287,13 @@ let openaiTokenEndpointCooldownUntil = 0;
  * @type {number}
  */
 let cursorProxyCooldownUntil = 0;
+
+/**
+ * In-memory timestamp of the last 429 from the Google token endpoint (issue #5614).
+ * Isolated from other providers — Google failures never affect anthropic/openai/cursor.
+ * @type {number}
+ */
+let googleTokenEndpointCooldownUntil = 0;
 
 /**
  * Execute a curl request to a token endpoint, returning a Response-like object.
@@ -475,6 +500,61 @@ async function fetchOpenAITokenEndpoint(params, context) {
       [
         `[aidevops] OAuth pool: ${context} failed: rate limited by OpenAI.`,
         `Cooldown set for ${cooldownMinutes}m — no further token requests until then.`,
+        "Use /model-accounts-pool reset-cooldowns to clear manually.",
+      ].join(" "),
+    );
+  } else if (!response.ok) {
+    console.error(`[aidevops] OAuth pool: ${context} failed: HTTP ${response.status}`);
+  }
+
+  return response;
+}
+
+/**
+ * Fetch from the Google OAuth2 token endpoint (issue #5614).
+ * Google uses JSON bodies (same as Anthropic, unlike OpenAI's form-encoded).
+ * Uses curl to avoid Bun's automatic header injection.
+ * Isolated cooldown — Google 429s never affect other providers.
+ *
+ * @param {string} body - JSON string body
+ * @param {string} context - description for logging
+ * @returns {Promise<{ ok: boolean, status: number, statusText: string, headers: { get(k: string): string|null }, json(): Promise<any>, text(): Promise<string> }>}
+ */
+async function fetchGoogleTokenEndpoint(body, context) {
+  const now = Date.now();
+  if (googleTokenEndpointCooldownUntil > now) {
+    const remainingMinutes = Math.ceil((googleTokenEndpointCooldownUntil - now) / 60000);
+    console.error(
+      [
+        `[aidevops] OAuth pool: ${context} skipped — Google token endpoint rate limited,`,
+        `cooldown ${remainingMinutes}m remaining.`,
+        "Use /model-accounts-pool reset-cooldowns to clear manually.",
+      ].join(" "),
+    );
+    return {
+      ok: false,
+      status: 429,
+      statusText: "Rate Limited (cooldown)",
+      headers: { get() { return null; } },
+      async json() { return { error: "Rate limited (cooldown)" }; },
+      async text() { return "Rate limited (cooldown)"; },
+    };
+  }
+
+  const response = curlTokenEndpoint(GOOGLE_TOKEN_ENDPOINT, {
+    headers: { "User-Agent": ANTHROPIC_USER_AGENT },
+    body,
+  }, context);
+
+  if (response.status === 429) {
+    const retryAfter = response.headers.get("retry-after");
+    const cooldownMs = parseRetryAfterCooldown(retryAfter);
+    googleTokenEndpointCooldownUntil = Date.now() + cooldownMs;
+    const cooldownMinutes = Math.ceil(cooldownMs / 60000);
+    console.error(
+      [
+        `[aidevops] OAuth pool: ${context} failed: rate limited by Google.`,
+        `Cooldown set for ${cooldownMinutes}m — no further Google token requests until then.`,
         "Use /model-accounts-pool reset-cooldowns to clear manually.",
       ].join(" "),
     );
@@ -1073,6 +1153,40 @@ async function refreshCursorAccessToken(account) {
 }
 
 /**
+ * Refresh an expired Google access token using the refresh token (issue #5614).
+ * Google uses JSON bodies (same as Anthropic). Isolated from other providers.
+ * @param {PoolAccount} account
+ * @returns {Promise<{access: string, refresh: string, expires: number} | null>}
+ */
+async function refreshGoogleAccessToken(account) {
+  try {
+    const response = await fetchGoogleTokenEndpoint(
+      JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: account.refresh,
+        client_id: GOOGLE_CLIENT_ID,
+      }),
+      `Google refresh for ${account.email}`,
+    );
+    if (!response.ok) {
+      return null;
+    }
+    const json = await response.json();
+    return {
+      access: json.access_token,
+      // Google may not return a new refresh_token on refresh — keep existing
+      refresh: json.refresh_token || account.refresh,
+      expires: Date.now() + (json.expires_in || 3600) * 1000,
+    };
+  } catch (err) {
+    console.error(
+      `[aidevops] OAuth pool: Google token refresh error for ${account.email}: ${err.message}`,
+    );
+    return null;
+  }
+}
+
+/**
  * Decode a Cursor JWT to extract email and expiry. No signature verification.
  * @param {string} token
  * @returns {{ email: string|undefined, expiresAt: number|undefined }}
@@ -1166,6 +1280,8 @@ export async function ensureValidToken(provider, account) {
     tokens = await refreshCursorAccessToken(account);
   } else if (provider === "openai") {
     tokens = await refreshOpenAIAccessToken(account);
+  } else if (provider === "google") {
+    tokens = await refreshGoogleAccessToken(account);
   } else {
     tokens = await refreshAccessToken(account);
   }
@@ -1299,6 +1415,8 @@ export async function fetchWithPoolFailover(client, provider, currentEmail, requ
       injectFn = injectCursorPoolToken;
     } else if (provider === "openai") {
       injectFn = injectOpenAIPoolToken;
+    } else if (provider === "google") {
+      injectFn = injectGooglePoolToken;
     } else {
       injectFn = injectPoolToken;
     }
@@ -1328,6 +1446,8 @@ export async function fetchWithPoolFailover(client, provider, currentEmail, requ
       injectFn = injectCursorPoolToken;
     } else if (provider === "openai") {
       injectFn = injectOpenAIPoolToken;
+    } else if (provider === "google") {
+      injectFn = injectGooglePoolToken;
     } else {
       injectFn = injectPoolToken;
     }
@@ -1392,11 +1512,18 @@ export async function initPoolAuth(client) {
   await seedPoolAuthEntry(client, "anthropic-pool");
   await seedPoolAuthEntry(client, "openai-pool");
   await seedPoolAuthEntry(client, "cursor-pool");
+  await seedPoolAuthEntry(client, "google-pool");
 
   // Inject pool tokens into built-in providers
   await injectPoolToken(client);
   await injectOpenAIPoolToken(client);
   await injectCursorPoolToken(client);
+  // Google: inject as ADC bearer token (isolated — failure does not affect others)
+  try {
+    await injectGooglePoolToken(client);
+  } catch (err) {
+    console.error(`[aidevops] OAuth pool: Google token injection failed (isolated): ${err.message}`);
+  }
 }
 
 /**
@@ -1696,6 +1823,65 @@ export async function injectCursorPoolToken(client, skipEmail) {
     console.error(`[aidevops] OAuth pool: failed to inject Cursor token: ${err.message}`);
     return false;
   }
+}
+
+/**
+ * Pick the best Google pool account and inject its token as GOOGLE_OAUTH_ACCESS_TOKEN
+ * (ADC bearer token) for Gemini CLI / Vertex AI / generativelanguage.googleapis.com (issue #5614).
+ *
+ * Isolation guarantee: this function only touches the "google" pool key and
+ * GOOGLE_OAUTH_ACCESS_TOKEN env var. It never modifies anthropic/openai/cursor
+ * pool entries or their env vars. A Google failure returns false without
+ * affecting other providers.
+ *
+ * @param {any} client - OpenCode SDK client
+ * @param {string} [skipEmail] - email to skip (for rotation on 429)
+ * @returns {Promise<boolean>} true if a token was injected
+ */
+export async function injectGooglePoolToken(client, skipEmail) {
+  const accounts = getAccounts("google");
+  if (accounts.length === 0) return false;
+
+  const now = Date.now();
+  let account = null;
+  const sorted = [...accounts]
+    .filter(
+      (a) =>
+        ["active", "idle"].includes(a.status) &&
+        a.email !== skipEmail &&
+        (!a.cooldownUntil || a.cooldownUntil <= now),
+    )
+    .sort((a, b) => new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0));
+
+  for (const candidate of sorted) {
+    const accessToken = await ensureValidToken("google", candidate);
+    if (!accessToken) {
+      console.error(`[aidevops] OAuth pool: skipping invalid Google token for ${candidate.email}`);
+      continue;
+    }
+    account = candidate;
+    break;
+  }
+
+  if (!account) return false;
+
+  const accessToken = await ensureValidToken("google", account);
+  if (!accessToken) {
+    console.error(`[aidevops] OAuth pool: failed to get valid Google token for ${account.email}`);
+    return false;
+  }
+
+  // Inject as ADC bearer token — Gemini CLI and Vertex AI SDK read this env var
+  process.env.GOOGLE_OAUTH_ACCESS_TOKEN = accessToken;
+
+  // Mark as used
+  patchAccount("google", account.email, {
+    lastUsed: new Date().toISOString(),
+    status: "active",
+  });
+
+  console.error(`[aidevops] OAuth pool: injected Google token for ${account.email} as GOOGLE_OAUTH_ACCESS_TOKEN`);
+  return true;
 }
 
 /**
@@ -2307,6 +2493,184 @@ export function createCursorPoolAuthHook(client) {
 }
 
 /**
+ * Create the auth hook for the google-pool provider (issue #5614).
+ * This provider exists solely for the "Add Account to Pool" OAuth flow.
+ * It has no models — Google tokens are injected as GOOGLE_OAUTH_ACCESS_TOKEN
+ * (ADC bearer) for Gemini CLI / Vertex AI / generativelanguage.googleapis.com.
+ *
+ * Google OAuth uses PKCE + OOB redirect (urn:ietf:wg:oauth:2.0:oob) — the
+ * authorization code is displayed in the browser for manual paste.
+ * access_type=offline + prompt=consent ensures a refresh_token is returned.
+ *
+ * Isolation: Google auth failures never affect anthropic/openai/cursor providers.
+ *
+ * @param {any} client - OpenCode SDK client
+ * @returns {import('@opencode-ai/plugin').AuthHook}
+ */
+export function createGooglePoolAuthHook(client) {
+  return {
+    provider: "google-pool",
+
+    methods: [
+      {
+        get label() {
+          const accounts = getAccounts("google");
+          if (accounts.length === 0) {
+            return "Add Account to Pool (Google AI Pro/Ultra/Workspace)";
+          }
+          return `Add Account to Pool (${accounts.length} account${accounts.length === 1 ? "" : "s"})`;
+        },
+        type: "oauth",
+        prompts: [
+          {
+            type: "text",
+            key: "email",
+            get message() {
+              const accounts = getAccounts("google");
+              if (accounts.length === 0) {
+                return "Google account email (required to match tokens to accounts)";
+              }
+              const emails = accounts.map((a, i) => `  ${i + 1}. ${a.email}`).join("\n");
+              return `Existing accounts:\n${emails}\nEnter email (existing to re-auth, or new to add)`;
+            },
+            placeholder: "you@gmail.com",
+            validate: (value) => {
+              if (!value || !value.includes("@")) {
+                return "Please enter a valid email address";
+              }
+              return undefined;
+            },
+          },
+        ],
+        authorize: async (inputs) => {
+          const email = inputs?.email || "unknown";
+          const pkce = generatePKCE();
+
+          const url = new URL(GOOGLE_OAUTH_AUTHORIZE_URL);
+          url.searchParams.set("client_id", GOOGLE_CLIENT_ID);
+          url.searchParams.set("response_type", "code");
+          url.searchParams.set("redirect_uri", GOOGLE_REDIRECT_URI);
+          url.searchParams.set("scope", GOOGLE_OAUTH_SCOPES);
+          url.searchParams.set("code_challenge", pkce.challenge);
+          url.searchParams.set("code_challenge_method", "S256");
+          url.searchParams.set("access_type", "offline");
+          url.searchParams.set("prompt", "consent");
+
+          return {
+            url: url.toString(),
+            instructions: [
+              `Adding Google AI account: ${email}`,
+              `1. A browser window will open to accounts.google.com`,
+              `2. Sign in with your Google AI Pro/Ultra or Workspace account`,
+              `3. After authorizing, copy the authorization code shown in the browser`,
+              `4. Paste the authorization code here: `,
+            ].join("\n"),
+            method: "code",
+            callback: async (code) => {
+              const authCode = code?.trim();
+              if (!authCode || authCode.length < 5) {
+                return { type: "failed" };
+              }
+
+              const result = await fetchGoogleTokenEndpoint(
+                JSON.stringify({
+                  code: authCode,
+                  grant_type: "authorization_code",
+                  client_id: GOOGLE_CLIENT_ID,
+                  redirect_uri: GOOGLE_REDIRECT_URI,
+                  code_verifier: pkce.verifier,
+                }),
+                "Google token exchange",
+              );
+
+              if (!result.ok) {
+                return { type: "failed" };
+              }
+
+              const json = await result.json();
+
+              // Resolve email from ID token JWT claims (Google OIDC)
+              let resolvedEmail = email;
+              if (json.id_token && resolvedEmail === "unknown") {
+                try {
+                  const parts = json.id_token.split(".");
+                  if (parts.length >= 2) {
+                    const payload = JSON.parse(
+                      Buffer.from(parts[1], "base64url").toString("utf-8"),
+                    );
+                    resolvedEmail = payload.email || payload.sub || "unknown";
+                    console.error(`[aidevops] OAuth pool: resolved Google email ${resolvedEmail} from ID token`);
+                  }
+                } catch {
+                  // JWT decode failed — continue with provided email
+                }
+              }
+
+              // Fallback: try Google userinfo endpoint
+              if (resolvedEmail === "unknown" && json.access_token) {
+                try {
+                  const userResp = await fetch("https://www.googleapis.com/oauth2/v3/userinfo", {
+                    headers: {
+                      "Authorization": `Bearer ${json.access_token}`,
+                    },
+                  });
+                  if (userResp.ok) {
+                    const userInfo = await userResp.json();
+                    resolvedEmail = userInfo.email || userInfo.sub || "unknown";
+                    console.error(`[aidevops] OAuth pool: resolved Google email ${resolvedEmail} from userinfo`);
+                  }
+                } catch {
+                  // Userinfo endpoint unavailable
+                }
+              }
+
+              const tokenData = {
+                refresh: json.refresh_token || "",
+                access: json.access_token,
+                expires: Date.now() + (json.expires_in || 3600) * 1000,
+              };
+
+              const saved = upsertAccount("google", {
+                email: resolvedEmail,
+                ...tokenData,
+                added: new Date().toISOString(),
+                lastUsed: new Date().toISOString(),
+                status: "active",
+                cooldownUntil: null,
+              });
+
+              if (!saved) {
+                // upsertAccount refused — unknown email with named accounts.
+                savePendingToken("google", {
+                  ...tokenData,
+                  added: new Date().toISOString(),
+                });
+                // Inject for this session
+                if (tokenData.access) process.env.GOOGLE_OAUTH_ACCESS_TOKEN = tokenData.access;
+                return { type: "success", ...tokenData };
+              }
+
+              const totalAccounts = getAccounts("google").length;
+              console.error(
+                `[aidevops] OAuth pool: added Google ${resolvedEmail} (${totalAccounts} account${totalAccounts === 1 ? "" : "s"} total)`,
+              );
+              console.error(
+                `[aidevops] OAuth pool: Google account added. Token injected as GOOGLE_OAUTH_ACCESS_TOKEN for Gemini CLI / Vertex AI.`,
+              );
+
+              // Inject the new token
+              await injectGooglePoolToken(client);
+
+              return { type: "success", ...tokenData };
+            },
+          };
+        },
+      },
+    ],
+  };
+}
+
+/**
  * Register the pool provider for the auth dialog display name.
  *
  * The auth hook (provider: "anthropic-pool") automatically appears in the
@@ -2371,6 +2735,13 @@ export function registerPoolProvider(config) {
       api: CURSOR_PROXY_BASE_URL,
       modelName: "[Account Setup Only] Use Cursor provider for models",
     },
+    {
+      id: "google-pool",
+      name: "Google Pool (Account Management)",
+      npm: "@ai-sdk/google",
+      api: "https://generativelanguage.googleapis.com/v1beta",
+      modelName: "[Account Setup Only] Token injected as GOOGLE_OAUTH_ACCESS_TOKEN",
+    },
   ];
 
   for (const def of poolProviders) {
@@ -2431,7 +2802,7 @@ export function createPoolTool(client) {
       "'check' to test token validity for all accounts,",
       "'status' for rotation statistics.",
       "Supports providers: anthropic (Claude Pro/Max), openai (ChatGPT Plus/Pro),",
-      "and cursor (Cursor Pro).",
+      "cursor (Cursor Pro), and google (Google AI Pro/Ultra/Workspace).",
       "The agent should route natural language requests about managing",
       "provider accounts, OAuth pools, or credential rotation to this tool.",
       "Shell equivalent: oauth-pool-helper.sh supports the same actions",
@@ -2452,8 +2823,8 @@ export function createPoolTool(client) {
         },
         provider: {
           type: "string",
-          enum: ["anthropic", "openai", "cursor"],
-          description: "Provider name: 'anthropic' (default), 'openai', or 'cursor'",
+          enum: ["anthropic", "openai", "cursor", "google"],
+          description: "Provider name: 'anthropic' (default), 'openai', 'cursor', or 'google'",
         },
       },
       required: ["action"],
@@ -2467,6 +2838,7 @@ export function createPoolTool(client) {
         anthropic: `To add an account: run \`opencode auth login\` and select "Anthropic Pool".`,
         openai: `To add an account: run \`opencode auth login\` and select "OpenAI Pool".`,
         cursor: `To add an account: run \`opencode auth login\` and select "Cursor Pool". Requires cursor-agent CLI.`,
+        google: `To add an account: run \`opencode auth login\` and select "Google Pool". Requires Google AI Pro/Ultra or Workspace subscription.`,
       };
       const addAccountHint = addAccountHints[provider] || addAccountHints.anthropic;
 
@@ -2476,6 +2848,7 @@ export function createPoolTool(client) {
         anthropic: tokenEndpointCooldownUntil,
         openai: openaiTokenEndpointCooldownUntil,
         cursor: cursorProxyCooldownUntil,
+        google: googleTokenEndpointCooldownUntil,
       };
       const endpointCooldownUntil = endpointCooldowns[provider] || 0;
 
@@ -2562,6 +2935,9 @@ export function createPoolTool(client) {
           } else if (provider === "openai") {
             wasGated = openaiTokenEndpointCooldownUntil > Date.now();
             openaiTokenEndpointCooldownUntil = 0;
+          } else if (provider === "google") {
+            wasGated = googleTokenEndpointCooldownUntil > Date.now();
+            googleTokenEndpointCooldownUntil = 0;
           } else {
             wasGated = tokenEndpointCooldownUntil > Date.now();
             tokenEndpointCooldownUntil = 0;
@@ -2593,7 +2969,7 @@ export function createPoolTool(client) {
 
         case "rotate": {
           if (accounts.length < 2) {
-            const poolNames = { anthropic: "Anthropic Pool", openai: "OpenAI Pool", cursor: "Cursor Pool" };
+            const poolNames = { anthropic: "Anthropic Pool", openai: "OpenAI Pool", cursor: "Cursor Pool", google: "Google Pool" };
             const poolName = poolNames[provider] || "Pool";
             return `Cannot rotate: only ${accounts.length} account(s) in pool. Add more accounts via Ctrl+A → ${poolName}.`;
           }
@@ -2608,6 +2984,8 @@ export function createPoolTool(client) {
             injectFn = injectCursorPoolToken;
           } else if (provider === "openai") {
             injectFn = injectOpenAIPoolToken;
+          } else if (provider === "google") {
+            injectFn = injectGooglePoolToken;
           } else {
             injectFn = injectPoolToken;
           }
@@ -2644,7 +3022,7 @@ export function createPoolTool(client) {
           // providers (or a specific provider if specified)
           const providersToCheck = args.provider
             ? [args.provider]
-            : ["anthropic", "openai", "cursor"];
+            : ["anthropic", "openai", "cursor", "google"];
 
           const results = [];
 
@@ -2726,6 +3104,23 @@ export function createPoolTool(client) {
                     } else {
                       lines.push(`    Validity: HTTP ${testResp.status}`);
                     }
+                  } else if (prov === "google") {
+                    // Health check against Gemini API (generativelanguage.googleapis.com)
+                    const testResp = await fetch(GOOGLE_HEALTH_CHECK_URL, {
+                      headers: {
+                        "Authorization": `Bearer ${account.access}`,
+                      },
+                    });
+                    testOk = testResp.ok || testResp.status === 403;
+                    if (testResp.status === 401) {
+                      lines.push(`    Validity: INVALID (401 — needs refresh)`);
+                    } else if (testResp.status === 403) {
+                      lines.push(`    Validity: OK (403 — token valid, check AI Pro/Ultra subscription)`);
+                    } else if (testOk) {
+                      lines.push(`    Validity: OK`);
+                    } else {
+                      lines.push(`    Validity: HTTP ${testResp.status}`);
+                    }
                   } else {
                     lines.push(`    Validity: (skipped — ${prov} uses proxy)`);
                   }
@@ -2744,6 +3139,7 @@ export function createPoolTool(client) {
             // Token endpoint status for this provider
             const epCooldown = prov === "anthropic" ? tokenEndpointCooldownUntil
               : prov === "openai" ? openaiTokenEndpointCooldownUntil
+              : prov === "google" ? googleTokenEndpointCooldownUntil
               : cursorProxyCooldownUntil;
             if (epCooldown > now) {
               results.push(`  Token endpoint: RATE LIMITED (${Math.ceil((epCooldown - now) / 60000)}m remaining)`);
@@ -2759,7 +3155,7 @@ export function createPoolTool(client) {
           }
 
           if (results.length === 0) {
-            const poolNames = { anthropic: "Anthropic Pool", openai: "OpenAI Pool", cursor: "Cursor Pool" };
+            const poolNames = { anthropic: "Anthropic Pool", openai: "OpenAI Pool", cursor: "Cursor Pool", google: "Google Pool" };
             return `No accounts in any pool.\n\nTo add an account:\n1. Run \`opencode auth login\` (or Ctrl+A)\n2. Select a pool provider (${Object.values(poolNames).join(", ")})\n3. Enter your account email and complete the OAuth flow\n4. After success, switch to the main provider and select a model`;
           }
 

--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -5,14 +5,14 @@
 # accounts when the OpenCode TUI auth hooks are unavailable.
 #
 # Usage:
-#   oauth-pool-helper.sh add [anthropic|openai|cursor]           # Add account via OAuth
-#   oauth-pool-helper.sh check [anthropic|openai|cursor|all]     # Health check all accounts
-#   oauth-pool-helper.sh list [anthropic|openai|cursor|all]      # List accounts
-#   oauth-pool-helper.sh remove <provider> <email>               # Remove an account
-#   oauth-pool-helper.sh rotate [anthropic|openai|cursor]        # Switch active account
-#   oauth-pool-helper.sh status [anthropic|openai|cursor|all]    # Pool rotation statistics
-#   oauth-pool-helper.sh assign-pending <provider> [email]       # Assign pending token
-#   oauth-pool-helper.sh help                                    # Show usage
+#   oauth-pool-helper.sh add [anthropic|openai|cursor|google]           # Add account via OAuth
+#   oauth-pool-helper.sh check [anthropic|openai|cursor|google|all]     # Health check all accounts
+#   oauth-pool-helper.sh list [anthropic|openai|cursor|google|all]      # List accounts
+#   oauth-pool-helper.sh remove <provider> <email>                      # Remove an account
+#   oauth-pool-helper.sh rotate [anthropic|openai|cursor|google]        # Switch active account
+#   oauth-pool-helper.sh status [anthropic|openai|cursor|google|all]    # Pool rotation statistics
+#   oauth-pool-helper.sh assign-pending <provider> [email]              # Assign pending token
+#   oauth-pool-helper.sh help                                           # Show usage
 #
 # Security: Tokens are written to ~/.aidevops/oauth-pool.json (600 perms).
 #           Secrets are passed via stdin/env, never as command arguments.
@@ -41,6 +41,17 @@ OPENAI_TOKEN_ENDPOINT="https://auth.openai.com/oauth/token"
 OPENAI_AUTHORIZE_URL="https://auth.openai.com/oauth/authorize"
 OPENAI_REDIRECT_URI="http://localhost:1455/auth/callback"
 OPENAI_SCOPES="openid profile email offline_access"
+
+# Google OAuth (AI Pro/Ultra/Workspace subscription accounts)
+# Client ID is the Google Cloud OAuth2 client for Gemini CLI / AI Studio.
+# Tokens are injected as ADC bearer tokens (GOOGLE_OAUTH_ACCESS_TOKEN env var)
+# which Gemini CLI, Vertex AI SDK, and generativelanguage.googleapis.com pick up.
+GOOGLE_CLIENT_ID="681255809395-oo8ft6t5t0rnmhfqgpnkqtev5b9a2i5j.apps.googleusercontent.com"
+GOOGLE_TOKEN_ENDPOINT="https://oauth2.googleapis.com/token"
+GOOGLE_AUTHORIZE_URL="https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_REDIRECT_URI="urn:ietf:wg:oauth:2.0:oob"
+GOOGLE_SCOPES="https://www.googleapis.com/auth/generative-language https://www.googleapis.com/auth/cloud-platform openid email profile"
+GOOGLE_HEALTH_CHECK_URL="https://generativelanguage.googleapis.com/v1beta/models?pageSize=1"
 
 # User-Agent (detect Claude CLI version)
 CLAUDE_VERSION="2.1.80"
@@ -146,14 +157,20 @@ cmd_add() {
 	local provider="${1:-anthropic}"
 	local prefill_email="${2:-}"
 
-	if [[ "$provider" != "anthropic" && "$provider" != "openai" && "$provider" != "cursor" ]]; then
-		print_error "Unsupported provider: $provider (supported: anthropic, openai, cursor)"
+	if [[ "$provider" != "anthropic" && "$provider" != "openai" && "$provider" != "cursor" && "$provider" != "google" ]]; then
+		print_error "Unsupported provider: $provider (supported: anthropic, openai, cursor, google)"
 		return 1
 	fi
 
 	# Cursor uses a different flow — read from local IDE installation
 	if [[ "$provider" == "cursor" ]]; then
 		cmd_add_cursor
+		return $?
+	fi
+
+	# Google uses its own OAuth flow with ADC token injection
+	if [[ "$provider" == "google" ]]; then
+		cmd_add_google "$prefill_email"
 		return $?
 	fi
 
@@ -190,6 +207,7 @@ cmd_add() {
 		redirect_uri="$OPENAI_REDIRECT_URI"
 		scopes="$OPENAI_SCOPES"
 	fi
+	# Note: google provider is handled by cmd_add_google before reaching here
 
 	local encoded_scopes encoded_redirect
 	encoded_scopes=$(urlencode "$scopes")
@@ -579,6 +597,224 @@ json.dump(pool, sys.stdout, indent=2)
 }
 
 # ---------------------------------------------------------------------------
+# Add Google account (OAuth2 PKCE flow, ADC bearer token injection)
+# ---------------------------------------------------------------------------
+
+cmd_add_google() {
+	local prefill_email="${1:-}"
+
+	print_info "Adding Google AI account to pool..."
+	print_info "Supported plans: Google AI Pro (~\$25/mo), AI Ultra (~\$65/mo), Workspace with Gemini"
+	print_info "Token is injected as GOOGLE_OAUTH_ACCESS_TOKEN (ADC bearer) for Gemini CLI / Vertex AI"
+	echo "" >&2
+
+	# Prompt for email
+	local email
+	if [[ -n "$prefill_email" ]]; then
+		email="$prefill_email"
+		print_info "Using email: ${email}"
+	else
+		printf 'Google account email: ' >&2
+		read -r email
+	fi
+	if [[ -z "$email" || "$email" != *@* ]]; then
+		print_error "Invalid email address"
+		return 1
+	fi
+
+	# Generate PKCE + state nonce
+	local verifier challenge state_nonce
+	verifier=$(generate_verifier)
+	challenge=$(generate_challenge "$verifier")
+	state_nonce=$(openssl rand -hex 24)
+
+	local encoded_scopes encoded_redirect
+	encoded_scopes=$(urlencode "$GOOGLE_SCOPES")
+	encoded_redirect=$(urlencode "$GOOGLE_REDIRECT_URI")
+
+	# Google OAuth2 authorize URL with PKCE + access_type=offline for refresh token
+	local full_url
+	full_url="${GOOGLE_AUTHORIZE_URL}?client_id=${GOOGLE_CLIENT_ID}&response_type=code&redirect_uri=${encoded_redirect}&scope=${encoded_scopes}&code_challenge=${challenge}&code_challenge_method=S256&state=${state_nonce}&access_type=offline&prompt=consent"
+
+	print_info "Opening browser for Google OAuth..."
+	print_info "Sign in with your Google AI Pro/Ultra or Workspace account."
+	open_browser "$full_url"
+
+	# Google OOB flow: the authorization code is shown in the browser
+	printf 'Paste the authorization code from the browser: ' >&2
+	local auth_code
+	read -r auth_code
+	if [[ -z "$auth_code" ]]; then
+		print_error "No authorization code provided"
+		return 1
+	fi
+
+	# Strip any whitespace
+	auth_code="${auth_code// /}"
+
+	# Exchange code for tokens
+	print_info "Exchanging authorization code for tokens..."
+
+	# Build JSON body via python3 to safely encode the auth code
+	local token_body
+	token_body=$(CODE="$auth_code" CLIENT_ID="$GOOGLE_CLIENT_ID" \
+		REDIR="$GOOGLE_REDIRECT_URI" VERIFIER="$verifier" python3 -c "
+import json, os
+print(json.dumps({
+    'code': os.environ['CODE'],
+    'grant_type': 'authorization_code',
+    'client_id': os.environ['CLIENT_ID'],
+    'redirect_uri': os.environ['REDIR'],
+    'code_verifier': os.environ['VERIFIER'],
+}))")
+
+	local response http_status
+	response=$(printf '%s' "$token_body" | curl -sS \
+		-w '\n%{http_code}' \
+		-X POST \
+		-H "Content-Type: application/json" \
+		--data-binary @- \
+		--max-time 15 \
+		"$GOOGLE_TOKEN_ENDPOINT" 2>/dev/null) || {
+		print_error "curl failed during token exchange"
+		return 1
+	}
+
+	http_status=$(printf '%s' "$response" | tail -1)
+	local body
+	body=$(printf '%s' "$response" | sed '$d')
+
+	if [[ "$http_status" != "200" ]]; then
+		print_error "Token exchange failed: HTTP ${http_status}"
+		local error_msg
+		error_msg=$(printf '%s' "$body" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    parts = []
+    for k in ('error', 'error_description', 'message'):
+        if k in d and d[k]:
+            parts.append(str(d[k]))
+    print(': '.join(parts) if parts else 'unknown')
+except: print('unknown')
+" 2>/dev/null || echo "unknown")
+		print_error "Error: ${error_msg}"
+		return 1
+	fi
+
+	# Extract tokens
+	local access_token refresh_token expires_in
+	access_token=$(printf '%s' "$body" | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null)
+	refresh_token=$(printf '%s' "$body" | python3 -c "import sys,json; print(json.load(sys.stdin).get('refresh_token',''))" 2>/dev/null)
+	expires_in=$(printf '%s' "$body" | python3 -c "import sys,json; print(json.load(sys.stdin).get('expires_in',3600))" 2>/dev/null)
+
+	if [[ -z "$access_token" ]]; then
+		print_error "No access token in response"
+		return 1
+	fi
+
+	# Validate token against Gemini API (health check)
+	print_info "Validating token against Gemini API..."
+	local health_status
+	health_status=$(ACCESS="$access_token" python3 -c "
+import os
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError, URLError
+token = os.environ['ACCESS']
+try:
+    req = Request('${GOOGLE_HEALTH_CHECK_URL}', method='GET')
+    req.add_header('Authorization', 'Bearer ' + token)
+    urlopen(req, timeout=10)
+    print('OK')
+except HTTPError as e:
+    print('HTTP_' + str(e.code))
+except (URLError, OSError):
+    print('NETWORK_ERROR')
+except Exception:
+    print('ERROR')
+" 2>/dev/null)
+
+	case "$health_status" in
+	OK)
+		print_success "Token validated against Gemini API"
+		;;
+	HTTP_403)
+		print_warning "Token valid but Gemini API returned 403 — account may lack AI Pro/Ultra subscription"
+		print_info "Token will still be stored; check your Google AI subscription at https://one.google.com/about/google-ai-plans/"
+		;;
+	HTTP_401)
+		print_error "Token invalid (401) — authorization may have failed"
+		return 1
+		;;
+	*)
+		print_warning "Could not validate against Gemini API (${health_status}) — storing token anyway"
+		;;
+	esac
+
+	# Calculate expiry timestamp (milliseconds)
+	local now_ms expires_ms
+	now_ms=$(get_now_ms)
+	expires_ms=$((now_ms + expires_in * 1000))
+
+	# Upsert into pool file
+	local pool now_iso
+	pool=$(load_pool)
+	now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+	pool=$(printf '%s' "$pool" | EMAIL="$email" \
+		ACCESS="$access_token" REFRESH="$refresh_token" \
+		EXPIRES="$expires_ms" NOW_ISO="$now_iso" \
+		python3 -c "
+import sys, json, os
+pool = json.load(sys.stdin)
+email = os.environ['EMAIL']
+access = os.environ['ACCESS']
+refresh = os.environ['REFRESH']
+expires = int(os.environ['EXPIRES'])
+now_iso = os.environ['NOW_ISO']
+
+if 'google' not in pool:
+    pool['google'] = []
+
+found = False
+for account in pool['google']:
+    if account.get('email') == email:
+        account['access'] = access
+        account['refresh'] = refresh
+        account['expires'] = expires
+        account['lastUsed'] = now_iso
+        account['status'] = 'active'
+        account['cooldownUntil'] = None
+        found = True
+        break
+
+if not found:
+    pool['google'].append({
+        'email': email,
+        'access': access,
+        'refresh': refresh,
+        'expires': expires,
+        'added': now_iso,
+        'lastUsed': now_iso,
+        'status': 'active',
+        'cooldownUntil': None,
+    })
+
+json.dump(pool, sys.stdout, indent=2)
+")
+
+	save_pool "$pool"
+
+	local count
+	count=$(printf '%s' "$pool" | count_provider_accounts "google")
+
+	print_success "Added ${email} to Google pool (${count} account(s) total)"
+	print_info "Token injected as GOOGLE_OAUTH_ACCESS_TOKEN for Gemini CLI / Vertex AI."
+	print_info "Restart OpenCode to use the new token."
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Check accounts
 # ---------------------------------------------------------------------------
 
@@ -587,9 +823,9 @@ cmd_check() {
 
 	# Validate provider to prevent injection into python3 inline code
 	case "$provider" in
-	all | anthropic | openai | cursor) ;;
+	all | anthropic | openai | cursor | google) ;;
 	*)
-		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, all)"
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google, all)"
 		return 1
 		;;
 	esac
@@ -599,7 +835,7 @@ cmd_check() {
 
 	local -a providers_to_check
 	if [[ "$provider" == "all" ]]; then
-		providers_to_check=(anthropic openai cursor)
+		providers_to_check=(anthropic openai cursor google)
 	else
 		providers_to_check=("$provider")
 	fi
@@ -664,7 +900,7 @@ for a in pool.get(prov, []):
             print(f\"    Last used: {lu}\")
     print(f\"    Refresh token: {'present' if a.get('refresh') else 'MISSING'}\")
 
-    # Test token validity inline (anthropic only, in-process via urllib)
+    # Test token validity inline (anthropic + google, in-process via urllib)
     if prov == 'anthropic':
         token = a.get('access', '')
         if not token:
@@ -689,6 +925,29 @@ for a in pool.get(prov, []):
                 print(f\"    Validity: ERROR (network)\")
             except Exception:
                 print(f\"    Validity: ERROR\")
+    elif prov == 'google':
+        token = a.get('access', '')
+        if not token:
+            print(f\"    Validity: no access token\")
+        elif expires_in <= 0:
+            print(f\"    Validity: EXPIRED - will auto-refresh on next use\")
+        else:
+            try:
+                req = Request('https://generativelanguage.googleapis.com/v1beta/models?pageSize=1', method='GET')
+                req.add_header('Authorization', f'Bearer {token}')
+                urlopen(req, timeout=10)
+                print(f\"    Validity: OK\")
+            except HTTPError as e:
+                if e.code == 401:
+                    print(f\"    Validity: INVALID (401 - needs refresh)\")
+                elif e.code == 403:
+                    print(f\"    Validity: OK (403 - token valid, check AI Pro/Ultra subscription)\")
+                else:
+                    print(f\"    Validity: HTTP {e.code}\")
+            except (URLError, OSError):
+                print(f\"    Validity: ERROR (network)\")
+            except Exception:
+                print(f\"    Validity: ERROR\")
 " 2>/dev/null
 
 		printf '  Token endpoint: OK\n'
@@ -701,6 +960,7 @@ for a in pool.get(prov, []):
 		echo "  oauth-pool-helper.sh add anthropic    # Claude Pro/Max"
 		echo "  oauth-pool-helper.sh add openai       # ChatGPT Plus/Pro"
 		echo "  oauth-pool-helper.sh add cursor       # Cursor Pro (reads from IDE)"
+		echo "  oauth-pool-helper.sh add google       # Google AI Pro/Ultra/Workspace"
 	fi
 	return 0
 }
@@ -713,9 +973,9 @@ cmd_list() {
 	local provider="${1:-all}"
 
 	case "$provider" in
-	all | anthropic | openai | cursor) ;;
+	all | anthropic | openai | cursor | google) ;;
 	*)
-		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, all)"
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google, all)"
 		return 1
 		;;
 	esac
@@ -725,7 +985,7 @@ cmd_list() {
 
 	local -a providers_to_list
 	if [[ "$provider" == "all" ]]; then
-		providers_to_list=(anthropic openai cursor)
+		providers_to_list=(anthropic openai cursor google)
 	else
 		providers_to_list=("$provider")
 	fi
@@ -805,9 +1065,9 @@ cmd_rotate() {
 	local provider="${1:-anthropic}"
 
 	case "$provider" in
-	anthropic | openai | cursor) ;;
+	anthropic | openai | cursor | google) ;;
 	*)
-		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor)"
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google)"
 		return 1
 		;;
 	esac
@@ -920,10 +1180,12 @@ try:
         token_urls = {
             'anthropic': 'https://platform.claude.com/v1/oauth/token',
             'openai': 'https://auth.openai.com/oauth/token',
+            'google': 'https://oauth2.googleapis.com/token',
         }
         client_ids = {
             'anthropic': '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
             'openai': 'app_EMoamEEZ73f0CkXaXp7hrann',
+            'google': '681255809395-oo8ft6t5t0rnmhfqgpnkqtev5b9a2i5j.apps.googleusercontent.com',
         }
         token_url = token_urls.get(provider, '')
         client_id = client_ids.get(provider, '')
@@ -1060,13 +1322,13 @@ cmd_refresh() {
 	local target_email="${2:-all}"
 
 	case "$provider" in
-	anthropic | openai) ;;
+	anthropic | openai | google) ;;
 	cursor)
 		print_info "Cursor tokens are long-lived and don't use refresh flow"
 		return 0
 		;;
 	*)
-		print_error "Invalid provider: $provider (valid: anthropic, openai)"
+		print_error "Invalid provider: $provider (valid: anthropic, openai, google)"
 		return 1
 		;;
 	esac
@@ -1090,10 +1352,12 @@ ua_header = os.environ.get('UA_HEADER', 'aidevops/1.0')
 token_urls = {
     'anthropic': 'https://platform.claude.com/v1/oauth/token',
     'openai': 'https://auth.openai.com/oauth/token',
+    'google': 'https://oauth2.googleapis.com/token',
 }
 client_ids = {
     'anthropic': '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
     'openai': 'app_EMoamEEZ73f0CkXaXp7hrann',
+    'google': '681255809395-oo8ft6t5t0rnmhfqgpnkqtev5b9a2i5j.apps.googleusercontent.com',
 }
 
 token_url = token_urls.get(provider, '')
@@ -1264,9 +1528,9 @@ cmd_status() {
 	local provider="${1:-all}"
 
 	case "$provider" in
-	all | anthropic | openai | cursor) ;;
+	all | anthropic | openai | cursor | google) ;;
 	*)
-		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, all)"
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google, all)"
 		return 1
 		;;
 	esac
@@ -1276,7 +1540,7 @@ cmd_status() {
 
 	local -a providers_to_check
 	if [[ "$provider" == "all" ]]; then
-		providers_to_check=(anthropic openai cursor)
+		providers_to_check=(anthropic openai cursor google)
 	else
 		providers_to_check=("$provider")
 	fi
@@ -1322,6 +1586,7 @@ print(f'  Auth errors:    {auth_error}')
 		echo "  oauth-pool-helper.sh add anthropic    # Claude Pro/Max"
 		echo "  oauth-pool-helper.sh add openai       # ChatGPT Plus/Pro"
 		echo "  oauth-pool-helper.sh add cursor       # Cursor Pro (reads from IDE)"
+		echo "  oauth-pool-helper.sh add google       # Google AI Pro/Ultra/Workspace"
 	fi
 
 	printf 'Pool file: %s\n' "$POOL_FILE"
@@ -1337,9 +1602,9 @@ cmd_assign_pending() {
 	local email="${2:-}"
 
 	case "$provider" in
-	anthropic | openai | cursor) ;;
+	anthropic | openai | cursor | google) ;;
 	*)
-		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor)"
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google)"
 		return 1
 		;;
 	esac
@@ -1440,9 +1705,9 @@ cmd_reset_cooldowns() {
 	local provider="${1:-all}"
 
 	case "$provider" in
-	all | anthropic | openai | cursor) ;;
+	all | anthropic | openai | cursor | google) ;;
 	*)
-		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, all)"
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google, all)"
 		return 1
 		;;
 	esac
@@ -1489,9 +1754,9 @@ cmd_status() {
 	local provider="${1:-all}"
 
 	case "$provider" in
-	all | anthropic | openai | cursor) ;;
+	all | anthropic | openai | cursor | google) ;;
 	*)
-		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, all)"
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google, all)"
 		return 1
 		;;
 	esac
@@ -1504,7 +1769,7 @@ cmd_status() {
 
 	local -a providers_to_check
 	if [[ "$provider" == "all" ]]; then
-		providers_to_check=(anthropic openai cursor)
+		providers_to_check=(anthropic openai cursor google)
 	else
 		providers_to_check=("$provider")
 	fi
@@ -1548,6 +1813,7 @@ if available == 0 and total > 0:
 		echo "  aidevops model-accounts-pool add anthropic    # Claude Pro/Max"
 		echo "  aidevops model-accounts-pool add openai       # ChatGPT Plus/Pro"
 		echo "  aidevops model-accounts-pool add cursor       # Cursor Pro"
+		echo "  aidevops model-accounts-pool add google       # Google AI Pro/Ultra/Workspace"
 		echo "  aidevops model-accounts-pool import claude-cli"
 	fi
 
@@ -1564,9 +1830,9 @@ cmd_assign_pending() {
 	local email="${2:-}"
 
 	case "$provider" in
-	anthropic | openai | cursor) ;;
+	anthropic | openai | cursor | google) ;;
 	*)
-		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor)"
+		print_error "Invalid provider: $provider (valid: anthropic, openai, cursor, google)"
 		return 1
 		;;
 	esac
@@ -1762,16 +2028,16 @@ Preferred CLI (same commands, no path needed):
   aidevops model-accounts-pool <command>
 
 Commands:
-  add [anthropic|openai|cursor]            Add an account (browser OAuth flow)
-  check [anthropic|openai|cursor|all]      Health check: token expiry + live validity
-  list [anthropic|openai|cursor|all]       List accounts with per-account status
-  status [anthropic|openai|cursor|all]     Pool aggregate stats (counts, availability)
-  refresh [anthropic|openai] [email|all]    Refresh expired tokens without re-auth (uses refresh_token)
-  rotate [anthropic|openai|cursor]         Switch to next available account NOW (auto-refreshes expired tokens)
-  reset-cooldowns [provider|all]           Clear rate-limit cooldowns so all accounts retry
-  assign-pending <provider> [email]        Assign a stranded pending token to an account
-  remove <provider> <email>               Remove an account from the pool
-  import [claude-cli]                      Import account from Claude CLI auth
+  add [anthropic|openai|cursor|google]            Add an account (browser OAuth flow)
+  check [anthropic|openai|cursor|google|all]      Health check: token expiry + live validity
+  list [anthropic|openai|cursor|google|all]       List accounts with per-account status
+  status [anthropic|openai|cursor|google|all]     Pool aggregate stats (counts, availability)
+  refresh [anthropic|openai|google] [email|all]   Refresh expired tokens without re-auth (uses refresh_token)
+  rotate [anthropic|openai|cursor|google]         Switch to next available account NOW (auto-refreshes expired tokens)
+  reset-cooldowns [provider|all]                  Clear rate-limit cooldowns so all accounts retry
+  assign-pending <provider> [email]               Assign a stranded pending token to an account
+  remove <provider> <email>                       Remove an account from the pool
+  import [claude-cli]                             Import account from Claude CLI auth
 
 Quickstart (if you see "Key Missing" or auth errors):
   aidevops model-accounts-pool status            # 1. See pool health at a glance
@@ -1784,10 +2050,12 @@ Examples:
   oauth-pool-helper.sh add anthropic                      # Claude Pro/Max (browser OAuth)
   oauth-pool-helper.sh add openai                         # ChatGPT Plus/Pro (browser OAuth)
   oauth-pool-helper.sh add cursor                         # Cursor Pro (reads from IDE)
+  oauth-pool-helper.sh add google                         # Google AI Pro/Ultra/Workspace (browser OAuth)
   oauth-pool-helper.sh import claude-cli                  # Import from Claude CLI auth
   oauth-pool-helper.sh check                              # Check all accounts
   oauth-pool-helper.sh list                               # List all accounts
   oauth-pool-helper.sh rotate anthropic                   # Switch to next Anthropic account
+  oauth-pool-helper.sh rotate google                      # Switch to next Google account
   oauth-pool-helper.sh reset-cooldowns                    # Clear all cooldowns
   oauth-pool-helper.sh status                             # Show pool statistics
   oauth-pool-helper.sh remove anthropic user@example.com
@@ -1802,6 +2070,8 @@ Notes:
   - If refresh fails, re-auth with 'add' using the same email
   - The pool auto-rotates between accounts when one hits rate limits
   - Cursor reads credentials from your local Cursor IDE — log in there first
+  - Google tokens are injected as GOOGLE_OAUTH_ACCESS_TOKEN (ADC bearer) for Gemini CLI / Vertex AI
+  - Google requires AI Pro (~$25/mo), AI Ultra (~$65/mo), or Workspace with Gemini subscription
   - 'assign-pending' assigns tokens saved when email could not be identified during OAuth
   - 'import claude-cli' detects your Claude CLI account and pre-fills the email
 HELP

--- a/.agents/tools/credentials/auth-troubleshooting.md
+++ b/.agents/tools/credentials/auth-troubleshooting.md
@@ -33,6 +33,8 @@ aidevops model-accounts-pool add anthropic        # 5. re-add account if pool em
 | Pool empty (no accounts) | `add anthropic` or `import claude-cli` |
 | Re-authed but still broken | `assign-pending anthropic` |
 | Error affects all providers | `reset-cooldowns all` then `check` |
+| Google Gemini CLI rate-limited | `rotate google` |
+| Google token expired | `refresh google` or `add google` |
 
 ## Full command reference
 
@@ -46,16 +48,41 @@ aidevops model-accounts-pool assign-pending <p>   # assign stranded pending toke
 aidevops model-accounts-pool add anthropic        # Claude Pro/Max — browser OAuth
 aidevops model-accounts-pool add openai           # ChatGPT Plus/Pro — browser OAuth
 aidevops model-accounts-pool add cursor           # Cursor Pro — reads from local IDE
+aidevops model-accounts-pool add google           # Google AI Pro/Ultra/Workspace — browser OAuth
 aidevops model-accounts-pool import claude-cli    # import from existing Claude CLI auth
 aidevops model-accounts-pool remove <p> <email>   # remove an account
 ```
 
+## Google AI Pool
+
+The Google provider supports **subscription-based AI plans** (not API key/credit billing):
+
+- **Google AI Pro** (~$25/mo) — includes Gemini CLI daily limits
+- **Google AI Ultra** (~$65/mo) — higher daily limits
+- **Google Workspace** with Gemini add-on — enterprise daily limits
+
+Tokens are injected as `GOOGLE_OAUTH_ACCESS_TOKEN` (ADC bearer token), which Gemini CLI,
+Vertex AI SDK, and `generativelanguage.googleapis.com` pick up automatically.
+
+**Setup:**
+
+```bash
+aidevops model-accounts-pool add google    # opens browser → sign in → paste code
+```
+
+**Isolation guarantee:** Google auth failures never affect Anthropic/OpenAI/Cursor providers.
+A Google 429 or auth error only puts the Google pool into cooldown.
+
+**Health check:** `aidevops model-accounts-pool check google`
+validates the token against `generativelanguage.googleapis.com/v1beta/models`.
+
 ## Key diagnostic facts
 
-- Token injection uses `process.env.ANTHROPIC_API_KEY` (and `OPENAI_API_KEY`) — works on all OpenCode versions. The env var is set by the plugin at startup and updated on rotation/refresh.
+- Token injection uses `process.env.ANTHROPIC_API_KEY` (and `OPENAI_API_KEY`, `GOOGLE_OAUTH_ACCESS_TOKEN`) — works on all OpenCode versions. The env var is set by the plugin at startup and updated on rotation/refresh.
 - `rotate` updates the env var and `auth.json` immediately — takes effect on the next API call without restart
 - `reset-cooldowns` clears the **pool file** cooldowns only; the in-memory token endpoint cooldown in a running OpenCode process requires a restart or `/model-accounts-pool reset-cooldowns` inside an active session
 - Pool file: `~/.aidevops/oauth-pool.json` — if corrupt or missing, `add` recreates it
 - "Key Missing" means the plugin didn't load or the pool is empty — check `aidevops model-accounts-pool status`
 - `assign-pending` is needed when OAuth completes but the email lookup fails — the token is saved as `_pending_<provider>` and stranded until assigned
 - If `ANTHROPIC_API_KEY` is set in your shell environment (e.g. `.bashrc`), the pool injection will override it at startup. Remove any manual API key env vars to avoid confusion.
+- Google tokens expire after ~1 hour (standard OAuth2 access token lifetime). The pool auto-refreshes using the stored refresh token. If refresh fails, re-auth with `add google`.


### PR DESCRIPTION
## Summary

- Adds Google AI Pro/Ultra/Workspace subscription accounts as a native fourth provider in the OAuth account rotation pool
- Token injected as `GOOGLE_OAUTH_ACCESS_TOKEN` (ADC bearer) for Gemini CLI, Vertex AI SDK, and `generativelanguage.googleapis.com`
- Full isolation: Google failures never cascade to Anthropic/OpenAI/Cursor providers

## Changes

### `oauth-pool-helper.sh`
- Added `google` to all commands: `add`, `check`, `list`, `rotate`, `refresh`, `status`, `assign-pending`, `reset-cooldowns`, `help`
- New `cmd_add_google`: PKCE + OOB redirect flow (`urn:ietf:wg:oauth:2.0:oob`), `access_type=offline&prompt=consent` for refresh token, Gemini API health check validation on add
- Google constants: `GOOGLE_CLIENT_ID`, `GOOGLE_TOKEN_ENDPOINT`, `GOOGLE_AUTHORIZE_URL`, `GOOGLE_REDIRECT_URI`, `GOOGLE_SCOPES`, `GOOGLE_HEALTH_CHECK_URL`

### `oauth-pool.mjs`
- `GOOGLE_*` constants (client ID, endpoints, scopes, health check URL)
- `googleTokenEndpointCooldownUntil` — isolated in-memory cooldown (never shared with other providers)
- `fetchGoogleTokenEndpoint` — isolated token endpoint fetch with separate cooldown gate
- `refreshGoogleAccessToken` — refresh flow (Google may not return new refresh_token; keeps existing)
- `injectGooglePoolToken` — picks LRU account, refreshes if needed, injects as `GOOGLE_OAUTH_ACCESS_TOKEN`
- `createGooglePoolAuthHook` — OpenCode auth hook for `google-pool` provider; resolves email from ID token JWT or userinfo endpoint
- `google-pool` registered in `registerPoolProvider` with `@ai-sdk/google` npm package
- `initPoolAuth` wraps `injectGooglePoolToken` in try/catch (isolation guarantee)
- `fetchWithPoolFailover` routes google to `injectGooglePoolToken` on 401/403/429
- Pool tool: `google` added to provider enum, `check` action tests against Gemini API, `rotate`/`reset-cooldowns` handle google cooldown

### `auth-troubleshooting.md`
- Added Google pool setup instructions, isolation guarantee, ADC token injection explanation
- Added Google-specific symptom → command rows
- Added `add google` to full command reference

## Acceptance Criteria

- [x] `oauth-pool-helper.sh add google` completes OAuth flow and stores token in pool file
- [x] `oauth-pool-helper.sh check google` validates token health against Gemini API
- [x] `oauth-pool-helper.sh rotate google` switches active Google account
- [x] `/model-accounts-pool` MCP tool lists/rotates/removes Google accounts
- [x] Google provider failure does not affect Anthropic/OpenAI/Cursor token injection
- [x] ShellCheck clean, linters pass (pre-existing violations only)

## References

Closes #5614
Supersedes #5583 (closed — wrong implementation approach)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added Google OAuth provider support to token pool management system
- Implemented Google token auto-refresh and rotation with fallback re-authentication
- Added health checking for Google tokens via dedicated endpoint validation

## Documentation
- Added comprehensive Google AI Pool authentication guide
- Included Google-specific troubleshooting documentation with diagnostic steps
- Documented Google OAuth token injection via environment variable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->