### PR TITLE
t1558: docs: Add Google provider to OAuth pool documentation

### DIFF
--- a/.agents/scripts/commands/models-pool-check.md
+++ b/.agents/scripts/commands/models-pool-check.md
@@ -41,9 +41,10 @@ If Claude CLI is not installed or not logged in, fall back to the standard inter
 >
 > You'll need a paid subscription to one of these:
 >
-> - **Claude Pro or Max** ($20-100/mo from anthropic.com) — for Claude models
+ > - **Claude Pro or Max** ($20-100/mo from anthropic.com) — for Claude models
 > - **ChatGPT Plus or Pro** ($20-200/mo from openai.com) — for GPT/o-series models
 > - **Cursor Pro** ($20/mo from cursor.com) — for models via Cursor's proxy
+> - **Google AI Pro or Ultra** ($25-65/mo from one.google.com) — for Gemini models via Gemini CLI
 >
 > Which provider do you have a subscription with?
 
@@ -55,7 +56,9 @@ For OpenAI: `oauth-pool-helper.sh add openai`
 
 For Cursor: `opencode auth login --provider cursor`
 
-For Anthropic/OpenAI, explain: "This will open your browser to log in. After you authorize, you'll get a code to paste back into the terminal. Once done, restart OpenCode and your account will be active."
+For Google: `oauth-pool-helper.sh add google`
+
+For Anthropic/OpenAI/Google, explain: "This will open your browser to log in. After you authorize, you'll get a code to paste back into the terminal. Once done, restart OpenCode and your account will be active."
 
 For Cursor, explain: "This opens your browser to log into Cursor. After you authorize, tokens are saved automatically. Restart OpenCode and Cursor models will appear when you press Ctrl+T."
 
@@ -96,7 +99,7 @@ After any change (add/remove/re-auth), run `oauth-pool-helper.sh check` again to
 ## Key principles
 
 - **One step at a time.** Don't dump all commands at once. Guide through the immediate next action, wait for confirmation, then proceed.
-- **Separate terminal for add commands.** The `oauth-pool-helper.sh add` command needs a real terminal. For Anthropic/OpenAI it opens a browser; for Cursor it reads from the IDE (instant, no browser). Always say "run this in a separate terminal" — never suggest pasting tokens or codes into this chat.
+- **Separate terminal for add commands.** The `oauth-pool-helper.sh add` command needs a real terminal. For Anthropic/OpenAI/Google it opens a browser; for Cursor it reads from the IDE (instant, no browser). Always say "run this in a separate terminal" — never suggest pasting tokens or codes into this chat.
 - **Explain why, not just what.** "This connects your Claude subscription so you can use Claude models here" is better than "This adds an OAuth token to the pool."
 - **Any model can run this.** The diagnostic uses `oauth-pool-helper.sh` (a shell script). It works even on free OpenCode models with no provider configured. The user doesn't need a working paid provider to check their setup.
 - **Don't mention internals.** Users don't need to know about pool.json, PKCE, token endpoints, auth hooks, or OAuth flows. They need "run this command, then restart."

--- a/README.md
+++ b/README.md
@@ -326,6 +326,27 @@ oauth-pool-helper.sh add cursor
 - **Model discovery** — automatically detects all models available to your account
 - **Pool rotation** — multiple accounts with LRU rotation and 429 failover
 
+### Google AI Pool (Gemini CLI / Vertex AI)
+
+Use your Google AI Pro, AI Ultra, or Workspace subscription for Gemini models. Tokens are injected as ADC bearer tokens that Gemini CLI, Vertex AI SDK, and the Gemini API pick up automatically.
+
+**Setup:**
+
+```bash
+# Add your Google account to the pool (browser OAuth flow)
+aidevops model-accounts-pool add google
+
+# Restart OpenCode — token is injected as GOOGLE_OAUTH_ACCESS_TOKEN
+```
+
+**Supported plans:**
+
+- **Google AI Pro** (~$25/mo) — daily Gemini CLI limits
+- **Google AI Ultra** (~$65/mo) — higher daily limits
+- **Google Workspace** with Gemini add-on — enterprise daily limits
+
+**Isolation guarantee:** Google auth failures never affect Anthropic/OpenAI/Cursor providers. A Google 429 or auth error only puts the Google pool into cooldown.
+
 ### GitHub AI Agent Integration
 
 Enable AI-powered issue resolution directly from GitHub. Comment `/oc fix this` on any issue and the AI creates a branch, implements the fix, and opens a PR.
@@ -394,6 +415,8 @@ aidevops model-accounts-pool check        # live token validity test per account
 | Account shows `auth-error` | `aidevops model-accounts-pool add anthropic` (re-auth) |
 | Pool is empty (no accounts) | `aidevops model-accounts-pool add anthropic` |
 | Recently re-authed, still broken | `aidevops model-accounts-pool assign-pending anthropic` |
+| Google Gemini CLI rate-limited | `aidevops model-accounts-pool rotate google` |
+| Google token expired | `aidevops model-accounts-pool add google` (re-auth) |
 
 **Step 3 — If still broken, re-add the account**
 
@@ -401,6 +424,7 @@ aidevops model-accounts-pool check        # live token validity test per account
 aidevops model-accounts-pool add anthropic     # Claude Pro/Max — opens browser OAuth
 aidevops model-accounts-pool add openai        # ChatGPT Plus/Pro
 aidevops model-accounts-pool add cursor        # Cursor Pro (reads from local IDE)
+aidevops model-accounts-pool add google        # Google AI Pro/Ultra/Workspace — browser OAuth
 aidevops model-accounts-pool import claude-cli # Import from existing Claude CLI auth
 ```
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -3658,6 +3658,7 @@ cmd_help() {
 	echo "  aidevops model-accounts-pool add anthropic     # Add Claude Pro/Max account"
 	echo "  aidevops model-accounts-pool add openai        # Add ChatGPT Plus/Pro account"
 	echo "  aidevops model-accounts-pool add cursor        # Add Cursor Pro account"
+	echo "  aidevops model-accounts-pool add google        # Add Google AI Pro/Ultra/Workspace account"
 	echo "  aidevops model-accounts-pool import claude-cli # Import from Claude CLI auth"
 	echo "  aidevops model-accounts-pool assign-pending <provider># Assign stranded token"
 	echo "  aidevops model-accounts-pool remove <provider> <email># Remove an account"


### PR DESCRIPTION
## Summary

- Add Google AI Pro/Ultra/Workspace as fourth provider across all user-facing documentation
- Follow-up to #5615 which added the implementation but missed several doc surfaces

## Changes

- **README.md**: New "Google AI Pool" section between Cursor and GitHub Agent sections; Google rows in troubleshooting symptom table; `add google` in re-add command block
- **models-pool-check.md**: Google AI Pro/Ultra added to provider interview list; `oauth-pool-helper.sh add google` command and explanation for guided setup
- **aidevops.sh**: `add google` line in CLI help text

## Setup command

Yes — Google OAuth is fully guided via the CLI:

```bash
aidevops model-accounts-pool add google
```

This opens the browser for Google OAuth, the user signs in with their Google AI Pro/Ultra or Workspace account, pastes the authorization code back, and the token is stored and injected automatically.

Closes #5617

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google AI Pro and Ultra models via Gemini CLI integration in the model account pool system.
  * Users can now add Google accounts using browser-based OAuth authentication.

* **Documentation**
  * Added setup and troubleshooting guidance for Google authentication.
  * Documented isolation guarantee ensuring Google rate-limit issues only affect the Google pool.
  * Updated help text to include the new Google provider command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->