### PR TITLE
GH#5616: Add slash command resolution guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -265,7 +265,7 @@ Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 
 When a user invokes a slash command (`/runners`, `/full-loop`, `/routine`, etc.) or provides input that clearly maps to one, always read the canonical command doc at `scripts/commands/<command>.md` before executing. The on-disk doc is the source of truth — do not improvise from memory or inline text. User-provided workflow descriptions may be stale; use them as context but defer to the command doc for the current procedure.
 
-This also applies when the agent itself needs to perform an action that has a corresponding command (e.g., logging a framework issue → `/log-issue-aidevops`, not raw `framework-issue-helper.sh`). The command doc adds quality steps (diagnostics, duplicate checks, user confirmation) that direct helper invocation skips.
+This also applies when the agent itself needs to perform an action that has a corresponding command (e.g., logging a framework issue → `/log-issue-aidevops`). Prefer the slash command workflow as the operator interface; the command doc enforces quality steps (diagnostics, duplicate checks, user confirmation) that direct helper invocation may skip.
 
 If unsure which command maps to the user's intent, list available commands: `ls ~/.aidevops/agents/scripts/commands/`.
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -261,6 +261,14 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 
+## Slash Command Resolution
+
+When a user invokes a slash command (`/runners`, `/full-loop`, `/routine`, etc.) or provides input that clearly maps to one, always read the canonical command doc at `scripts/commands/<command>.md` before executing. The on-disk doc is the source of truth — do not improvise from memory or inline text. User-provided workflow descriptions may be stale; use them as context but defer to the command doc for the current procedure.
+
+This also applies when the agent itself needs to perform an action that has a corresponding command (e.g., logging a framework issue → `/log-issue-aidevops`, not raw `framework-issue-helper.sh`). The command doc adds quality steps (diagnostics, duplicate checks, user confirmation) that direct helper invocation skips.
+
+If unsure which command maps to the user's intent, list available commands: `ls ~/.aidevops/agents/scripts/commands/`.
+
 ## Domain Index
 
 Read subagents on-demand. Full index: `subagent-index.toon`.

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -78,6 +78,7 @@ Use TodoWrite frequently to track tasks and show progress. Break complex tasks i
 - When multiple independent subtasks exist (for example creating multiple files or running unrelated searches), launch parallel Task tool calls in a single message instead of sequential Task calls.
 - NEVER use bash echo to communicate — output text directly.
 - Use Task tool for codebase exploration.
+- Slash commands: when executing a slash command (`/runners`, `/full-loop`, etc.), always read `scripts/commands/<command>.md` first. See AGENTS.md "Slash Command Resolution".
 
 # File Discovery (MANDATORY - overrides all other guidance)
 - NEVER use mcp_glob or Glob tool when Bash is available


### PR DESCRIPTION
## Summary

- Adds a "Slash Command Resolution" section to `.agents/AGENTS.md` requiring agents to read `scripts/commands/<command>.md` before executing any slash command
- Adds a cross-reference in `.agents/prompts/build.txt` Tool usage policy section
- Includes discoverability fallback for when the agent is unsure which command maps to user intent

## Problem

Agents improvise slash command behavior from memory instead of reading the canonical command doc. This causes:
- Incorrect execution patterns (e.g., using `/full-loop` for non-code tasks)
- Skipped quality steps (duplicate checks, diagnostics, user confirmation)
- Multiple failed attempts before getting it right

## Changes

| File | Change |
|------|--------|
| `.agents/AGENTS.md` | New "Slash Command Resolution" section before Domain Index |
| `.agents/prompts/build.txt` | One-line cross-reference in Tool usage policy |

Closes #5616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added "Slash Command Resolution" guidance requiring agents to consult canonical command documentation before executing slash commands or equivalent internal actions; includes fallback to list available commands when mapping is unclear.
  * Updated tool-usage prompts to enforce reading command docs prior to running commands.

* **Chores**
  * Improved internal agent configuration documentation for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->