### PR TITLE
t1557: Detect default GitHub template README and replace with rich profile

### DIFF
--- a/.agents/scripts/profile-readme-helper.sh
+++ b/.agents/scripts/profile-readme-helper.sh
@@ -1151,6 +1151,31 @@ _generate_contributions() {
 	return 0
 }
 
+# --- Detect if a README is the default GitHub profile template ---
+# Returns 0 (true) if the file matches the default template pattern.
+# The default template contains "## Hi there" and the commented-out suggestions
+# block that GitHub auto-generates for new username/username repos.
+_is_default_github_template() {
+	local readme_path="$1"
+	if [[ ! -f "$readme_path" ]]; then
+		return 1
+	fi
+	# Check for the distinctive GitHub default template markers:
+	# 1. The "Hi there" heading (with or without emoji)
+	# 2. The commented-out "is a special repository" block
+	if grep -q 'Hi there' "$readme_path" 2>/dev/null &&
+		grep -q 'is a.*special.*repository' "$readme_path" 2>/dev/null; then
+		return 0
+	fi
+	# Also match minimal default READMEs that just have "# username" and nothing else
+	local line_count
+	line_count=$(wc -l <"$readme_path" | tr -d ' ')
+	if [[ "$line_count" -le 3 ]] && ! grep -q '<!-- STATS-START -->' "$readme_path" 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
 # --- Inject aidevops markers into an existing README that lacks them ---
 # Preserves all existing content and appends marker blocks at the end.
 # This handles the case where a user has manually written their README
@@ -1209,12 +1234,12 @@ _recover_diverged_profile() {
 		local readme_path="${repo_dir}/README.md"
 		if [[ -f "$readme_path" ]] && grep -q '<!-- STATS-START -->' "$readme_path" 2>/dev/null; then
 			echo "Remote README already has markers — no seeding needed"
+		elif [[ ! -f "$readme_path" ]] || _is_default_github_template "$readme_path"; then
+			echo "Creating rich profile README..."
+			_generate_rich_readme "$gh_user" "$readme_path"
 		elif [[ -f "$readme_path" ]]; then
 			echo "Injecting markers into remote README..."
 			_inject_markers_into_readme "$readme_path"
-		else
-			echo "Creating rich profile README..."
-			_generate_rich_readme "$gh_user" "$readme_path"
 		fi
 
 		# Commit and push the seeded README
@@ -1466,10 +1491,13 @@ cmd_init() {
 
 	# Seed README.md with stat markers.
 	# If the file doesn't exist or is the default GitHub template, generate a full README.
-	# If the file exists with user content but lacks markers, inject markers into it.
+	# If the file exists with real user content but lacks markers, inject markers into it.
 	local readme_path="${repo_dir}/README.md"
 	if [[ ! -f "$readme_path" ]]; then
 		echo "Creating rich profile README..."
+		_generate_rich_readme "$gh_user" "$readme_path"
+	elif _is_default_github_template "$readme_path"; then
+		echo "Default GitHub template detected — replacing with rich profile README..."
 		_generate_rich_readme "$gh_user" "$readme_path"
 	elif ! grep -q '<!-- STATS-START -->' "$readme_path"; then
 		echo "Injecting stat markers into existing README..."
@@ -1590,13 +1618,25 @@ cmd_update() {
 	local source_file
 	source_file="$readme_path"
 
-	# Ensure markers exist in the source content — inject them if missing
+	# Ensure markers exist in the source content — replace default template or inject into custom content
 	if ! grep -q '<!-- STATS-START -->' "$source_file" || ! grep -q '<!-- STATS-END -->' "$source_file"; then
-		echo "Markers missing from README — injecting them..."
-		_inject_markers_into_readme "$source_file"
-		# Commit the marker injection before proceeding with stats update
+		if _is_default_github_template "$source_file"; then
+			echo "Default GitHub template detected — replacing with rich profile README..."
+			local gh_user
+			gh_user=$(_resolve_profile_user "$profile_repo")
+			if [[ -n "$gh_user" ]]; then
+				_generate_rich_readme "$gh_user" "$source_file"
+			else
+				echo "Could not resolve username — injecting markers only..."
+				_inject_markers_into_readme "$source_file"
+			fi
+		else
+			echo "Markers missing from README — injecting them..."
+			_inject_markers_into_readme "$source_file"
+		fi
+		# Commit the marker injection/replacement before proceeding with stats update
 		git -C "$profile_repo" add README.md
-		git -C "$profile_repo" commit -m "feat: inject aidevops stat markers into profile README" --no-verify 2>/dev/null || true
+		git -C "$profile_repo" commit -m "feat: initialize profile README with aidevops stat markers" --no-verify 2>/dev/null || true
 	fi
 
 	# Replace content between markers

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -370,6 +370,99 @@ EOF
 	return 0
 }
 
+test_default_template_replaced_with_rich_readme() {
+	local test_name="default GitHub template replaced with rich profile README"
+
+	TEST_DIR=$(mktemp -d)
+	local fixture_home="${TEST_DIR}/home"
+	local fixture_repo="${TEST_DIR}/profile-repo"
+	local fixture_remote="${TEST_DIR}/profile-remote.git"
+	local helper_dir="${TEST_DIR}/helper"
+	local helper_path="${helper_dir}/profile-readme-helper.sh"
+
+	mkdir -p "${helper_dir}" "${fixture_home}/.config/aidevops"
+	mkdir -p "${fixture_home}/.aidevops/.agent-workspace/observability"
+	mkdir -p "${fixture_home}/.aidevops/cache"
+	cp "${SOURCE_HELPER}" "${helper_path}"
+	chmod +x "${helper_path}"
+	write_stub_dependencies "${helper_dir}"
+
+	# Create a bare remote and local clone with the default GitHub template
+	git init --bare --initial-branch=main "${fixture_remote}" >/dev/null
+	git init -b main "${fixture_repo}" >/dev/null
+	git -C "${fixture_repo}" config user.name "Fixture"
+	git -C "${fixture_repo}" config user.email "fixture@example.com"
+	git -C "${fixture_repo}" remote add origin "${fixture_remote}"
+
+	# Write the exact default GitHub profile template
+	cat >"${fixture_repo}/README.md" <<'EOF'
+## Hi there 👋
+
+<!--
+**fixture/fixture** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+
+Here are some ideas to get you started:
+
+- 🔭 I'm currently working on ...
+- 🌱 I'm currently learning ...
+- 👯 I'm looking to collaborate on ...
+- 🤔 I'm looking for help with ...
+- 💬 Ask me about ...
+- 📫 How to reach me: ...
+- 😄 Pronouns: ...
+- ⚡ Fun fact: ...
+-->
+EOF
+
+	git -C "${fixture_repo}" add README.md
+	git -C "${fixture_repo}" commit -m "Initial commit" >/dev/null
+	git -C "${fixture_repo}" push -u origin main >/dev/null
+
+	# Set up repos.json
+	cat >"${fixture_home}/.config/aidevops/repos.json" <<EOF
+{
+  "initialized_repos": [
+    {
+      "path": "${fixture_repo}",
+      "slug": "fixture/fixture",
+      "priority": "profile",
+      "pulse": false,
+      "maintainer": "fixture"
+    }
+  ]
+}
+EOF
+
+	# Run update — should detect default template and replace with rich README
+	if ! HOME="${fixture_home}" bash "${helper_path}" update >/dev/null 2>&1; then
+		print_result "${test_name}" 1 "helper update command failed"
+		return 0
+	fi
+
+	local readme="${fixture_repo}/README.md"
+
+	# Verify the default template is gone
+	if grep -q 'is a.*special.*repository' "$readme" 2>/dev/null; then
+		print_result "${test_name}" 1 "default GitHub template still present after update"
+		return 0
+	fi
+
+	# Verify markers were added
+	if ! grep -q '<!-- STATS-START -->' "$readme"; then
+		print_result "${test_name}" 1 "STATS-START marker not found after update"
+		return 0
+	fi
+
+	# Verify it's a rich README (has the aidevops tagline)
+	if ! grep -q 'aidevops' "$readme"; then
+		print_result "${test_name}" 1 "aidevops reference not found — not a rich README"
+		return 0
+	fi
+
+	print_result "${test_name}" 0
+	return 0
+}
+
 main() {
 	if [[ ! -x "${SOURCE_HELPER}" ]]; then
 		echo "Helper script not found or not executable: ${SOURCE_HELPER}" >&2
@@ -381,6 +474,8 @@ main() {
 	test_inject_markers_into_existing_readme
 	teardown
 	test_diverged_history_recovery
+	teardown
+	test_default_template_replaced_with_rich_readme
 	teardown
 
 	echo ""


### PR DESCRIPTION
## Summary

- Detect the default GitHub profile template README and replace it with the full rich profile (name, bio, badges, stats) instead of just appending markers
- Follow-up to #5611 which fixed diverged history recovery but left the default template content in place

Closes #5610

## What was done

**Problem:** After the v3.1.87 fix (#5611), the profile-readme-helper correctly injects markers into existing READMEs. But when the README is the default GitHub template ("Hi there" + commented-out suggestions), it only appends markers to the bottom — leaving the useless template content at the top. The profile ends up with stats but no name, bio, or language badges.

**Fix:** Added `_is_default_github_template()` detection and updated all code paths (cmd_init, cmd_update, _recover_diverged_profile) to generate the full rich README when the default template is detected, instead of just injecting markers.

**Detection criteria:**
- "Hi there" heading + "is a special repository" comment block (the distinctive GitHub default)
- Or: README with 3 or fewer lines and no existing markers (minimal default like `# username`)

## Files changed

- `.agents/scripts/profile-readme-helper.sh` — new `_is_default_github_template()` function, updated 3 code paths
- `.agents/scripts/tests/test-profile-readme-boundary.sh` — 1 new test for default template replacement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically detects and replaces default GitHub profile README templates with enriched versions containing project statistics.
  * Profile README initialization now generates richer content instead of keeping the default template.

* **Tests**
  * Added validation tests for profile README template replacement functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->